### PR TITLE
refactor(bayn): totalize cycle planning and risk

### DIFF
--- a/services/bayn/src/cycle-recovery.test.ts
+++ b/services/bayn/src/cycle-recovery.test.ts
@@ -1,0 +1,730 @@
+import { describe, expect, test } from 'bun:test'
+
+import { Result } from 'effect'
+
+import {
+  CycleState,
+  CycleTerminalReason,
+  makeCycleDraft,
+  makeCycleExecutionPolicy,
+  makeCycleIdentity,
+  makeCycleWindow,
+  makeExecutionCalendarObservation,
+  type AutonomousCycle,
+  type CycleDraft,
+} from './cycle'
+import {
+  cycleCompletionStateForTargetPlan,
+  cycleTerminalReasonForBlockedTargetPlan,
+  selectCycleRecovery,
+  type CycleRecoverySelection,
+  type CycleRecoveryState,
+} from './cycle-recovery'
+import { canonicalHashV1 } from './hash'
+import { makeObserveShadowDecisionDocument, type ObserveShadowDecisionDocument } from './shadow-decision-contract'
+import { TargetPlanReason, TargetPlanStatus, type BlockedTargetPlanReason } from './target-planner'
+
+const hash = (character: string): string => character.repeat(64)
+const qualificationRunId = hash('1')
+const strategyProtocolHash = hash('2')
+const accountId = 'paper-account-1'
+const snapshotId = hash('3')
+
+const value = <A, E>(result: Result.Result<A, E>): A => {
+  if (Result.isFailure(result)) throw result.failure
+  return result.success
+}
+
+const draft = (signalCalendarVersion = 'XNYS-v1'): CycleDraft => {
+  const calendar = value(
+    makeExecutionCalendarObservation({
+      schemaVersion: 'bayn.alpaca-market-calendar-observation.v1',
+      source: 'alpaca-v2-calendar',
+      date: '2026-02-02',
+      openAt: '2026-02-02T14:30:00.000Z',
+      closeAt: '2026-02-02T21:00:00.000Z',
+    }),
+  )
+  const policy = value(
+    makeCycleExecutionPolicy({
+      schemaVersion: 'bayn.autonomous-cycle-execution-policy.v1',
+      strategyExecutionModelHash: hash('4'),
+      submissionWindowMs: 30 * 60_000,
+      submissionCutoffBeforeOpenMs: 2 * 60_000,
+    }),
+  )
+  const identity = value(
+    makeCycleIdentity({
+      schemaVersion: 'bayn.autonomous-cycle-identity.v1',
+      strategyName: 'risk-balanced-trend',
+      qualificationRunId,
+      strategyProtocolHash,
+      accountId,
+      signalSessionDate: '2026-01-30',
+      signalCalendarVersion,
+      executionSessionDate: calendar.executionSessionDate,
+      executionCalendarSchemaVersion: calendar.executionCalendarSchemaVersion,
+      executionCalendarSource: calendar.executionCalendarSource,
+      executionCalendarHash: calendar.executionCalendarHash,
+      executionPolicy: policy,
+    }),
+  )
+  const window = value(
+    makeCycleWindow(
+      {
+        calendar_version: signalCalendarVersion,
+        session_date: '2026-01-30',
+        close_time: '16:00',
+        timezone: 'America/New_York',
+      },
+      calendar,
+      policy,
+    ),
+  )
+  return value(makeCycleDraft(identity, window))
+}
+
+const pendingCycle = (signalCalendarVersion = 'XNYS-v1'): AutonomousCycle => ({
+  ...draft(signalCalendarVersion),
+  state: CycleState.Pending,
+  bindings: {},
+  stateVersion: 1,
+  createdAt: '2026-01-30T21:15:00.000Z',
+  updatedAt: '2026-01-30T21:15:00.000Z',
+})
+
+const boundPendingCycle = (): AutonomousCycle => ({
+  ...pendingCycle(),
+  bindings: { snapshotId },
+  stateVersion: 2,
+  updatedAt: '2026-01-30T21:16:00.000Z',
+})
+
+const activeCycle = (): AutonomousCycle => ({
+  ...boundPendingCycle(),
+  state: CycleState.Active,
+  stateVersion: 3,
+  updatedAt: '2026-02-02T13:56:00.000Z',
+})
+
+const targetPlan = (
+  status: TargetPlanStatus.NoTrade | TargetPlanStatus.Blocked,
+  reason: TargetPlanReason.TargetsSatisfied | BlockedTargetPlanReason,
+) => {
+  const targets =
+    status === TargetPlanStatus.NoTrade
+      ? [
+          {
+            symbol: 'AMD',
+            targetWeight: 0.5,
+            referencePriceMicros: '100000000',
+            currentQuantityMicros: '1000000',
+            targetQuantityMicros: '1000000',
+          },
+        ]
+      : []
+  const material = {
+    schemaVersion: 'bayn.paper-reference-target-plan.v1' as const,
+    inputHash: hash('5'),
+    status,
+    reason,
+    targets,
+    intentTargets: [],
+    requiredReferenceBuyNotionalMicros: '0',
+    availableBuyingPowerMicros: '0',
+    residualBuyingPowerMicros: '0',
+  }
+  return { ...material, outputHash: canonicalHashV1(material) }
+}
+
+const decisionDocument = (
+  cycle: AutonomousCycle,
+  status: TargetPlanStatus.NoTrade | TargetPlanStatus.Blocked = TargetPlanStatus.NoTrade,
+  reason: TargetPlanReason.TargetsSatisfied | BlockedTargetPlanReason = TargetPlanReason.TargetsSatisfied,
+  createdAt = '2026-02-02T13:59:00.000Z',
+): ObserveShadowDecisionDocument =>
+  value(
+    makeObserveShadowDecisionDocument({
+      schemaVersion: 'bayn.observe-shadow-decision.v1',
+      mode: 'OBSERVE',
+      dispatchable: false,
+      bindings: {
+        strategyName: cycle.identity.strategyName,
+        cycleId: cycle.identity.cycleId,
+        strategyProtocolHash: cycle.identity.strategyProtocolHash,
+        snapshotId,
+        snapshotContentHash: hash('6'),
+        snapshotFinalizedAt: cycle.window.signalCloseAt,
+        strategyDecisionHash: hash('7'),
+        policyHash: hash('8'),
+        accountId,
+        planningBrokerStateHash: hash('9'),
+        reconciliationId: hash('a'),
+        reconciliationHash: hash('b'),
+      },
+      targetPlan: targetPlan(status, reason),
+      deltaRisk: [],
+      createdAt,
+      submissionCutoffAt: cycle.window.submissionCutoffAt,
+      expiresAt: cycle.window.submissionCutoffAt,
+    }),
+  )
+
+const recoveryState = (
+  cycle: AutonomousCycle | undefined,
+  overrides: Partial<Omit<CycleRecoveryState, 'cycle'>> = {},
+): CycleRecoveryState => ({
+  qualificationRunId,
+  accountId,
+  strategyProtocolHash,
+  observedAt: '2026-02-02T13:57:00.000Z',
+  cycle,
+  ...overrides,
+})
+
+const select = (state: CycleRecoveryState): CycleRecoverySelection => value(selectCycleRecovery(state))
+
+describe('cycle recovery algebra', () => {
+  test('selects every discovery, readiness, activation, waiting, and decision-building action', () => {
+    const pending = pendingCycle()
+    const bound = boundPendingCycle()
+    const active = activeCycle()
+    const blockedReadinessCycle: AutonomousCycle = {
+      ...pending,
+      state: CycleState.Blocked,
+      terminalReason: CycleTerminalReason.MissedPublication,
+      terminalAt: pending.window.publicationDeadlineAt,
+      updatedAt: pending.window.publicationDeadlineAt,
+      stateVersion: 2,
+    }
+
+    expect(select(recoveryState(undefined))).toEqual({ action: 'DISCOVER' })
+    expect(select(recoveryState(pending))).toEqual({ action: 'READ_PUBLICATION', cycle: pending })
+    expect(
+      select(
+        recoveryState(pending, {
+          observedAt: pending.updatedAt,
+          readiness: {
+            outcome: 'WAITING',
+            reason: 'PUBLICATION_MISSING',
+            observedAt: pending.updatedAt,
+            cycle: pending,
+          },
+        }),
+      ),
+    ).toMatchObject({ action: 'RETURN_READINESS', recoveryAction: 'WAITING' })
+    expect(
+      select(
+        recoveryState(pending, {
+          readiness: {
+            outcome: 'BLOCKED',
+            observedAt: blockedReadinessCycle.updatedAt,
+            cycle: blockedReadinessCycle,
+          },
+        }),
+      ),
+    ).toMatchObject({ action: 'RETURN_READINESS', recoveryAction: 'BLOCKED' })
+    expect(
+      select(
+        recoveryState(pending, {
+          observedAt: pending.updatedAt,
+          readiness: {
+            outcome: 'BOUND',
+            observedAt: bound.updatedAt,
+            cycle: bound,
+            snapshotId,
+          },
+        }),
+      ),
+    ).toMatchObject({ action: 'RETURN_READINESS', recoveryAction: 'BOUND_SNAPSHOT' })
+    expect(
+      select(
+        recoveryState(bound, {
+          observedAt: bound.updatedAt,
+          readiness: {
+            outcome: 'ALREADY_BOUND',
+            observedAt: bound.updatedAt,
+            cycle: bound,
+            snapshotId,
+          },
+        }),
+      ),
+    ).toEqual({ action: 'ACTIVATE', cycleId: bound.identity.cycleId, observedAt: bound.updatedAt })
+    expect(select(recoveryState(active))).toEqual({
+      action: 'WAIT',
+      cycle: active,
+      observedAt: '2026-02-02T13:57:00.000Z',
+    })
+    expect(
+      select(
+        recoveryState(active, {
+          observedAt: active.window.submissionOpenAt,
+        }),
+      ),
+    ).toEqual({ action: 'BUILD_DECISION', cycle: active })
+  })
+
+  test('preserves deadline, protocol, and decision-bound precedence and both completion states', () => {
+    const pending = pendingCycle()
+    const active = activeCycle()
+    expect(
+      select(
+        recoveryState(pending, {
+          observedAt: pending.window.publicationDeadlineAt,
+          strategyProtocolHash: hash('f'),
+        }),
+      ),
+    ).toMatchObject({ action: 'BLOCK', reason: CycleTerminalReason.MissedPublication })
+    expect(
+      select(
+        recoveryState(active, {
+          observedAt: active.window.submissionCutoffAt,
+          strategyProtocolHash: hash('f'),
+        }),
+      ),
+    ).toMatchObject({ action: 'BLOCK', reason: CycleTerminalReason.MissedSubmission })
+    expect(select(recoveryState(active, { strategyProtocolHash: hash('f') }))).toMatchObject({
+      action: 'BLOCK',
+      reason: CycleTerminalReason.ProvenanceMismatch,
+    })
+
+    const noTrade = decisionDocument(active)
+    const decisionBound: AutonomousCycle = {
+      ...active,
+      bindings: { snapshotId, decisionHash: noTrade.contentHash },
+      updatedAt: '2026-02-02T14:01:00.000Z',
+      stateVersion: 4,
+    }
+    const afterCutoff = '2026-02-02T14:29:00.000Z'
+    expect(
+      select(
+        recoveryState(decisionBound, {
+          observedAt: afterCutoff,
+          strategyProtocolHash: hash('f'),
+        }),
+      ),
+    ).toEqual({ action: 'READ_DECISION', cycle: decisionBound })
+    expect(
+      select(
+        recoveryState(decisionBound, {
+          observedAt: afterCutoff,
+          strategyProtocolHash: hash('f'),
+          decisionDocument: noTrade,
+        }),
+      ),
+    ).toMatchObject({ action: 'FINISH', state: CycleState.NoTrade })
+    expect(cycleCompletionStateForTargetPlan(TargetPlanStatus.Planned)).toBe(CycleState.Completed)
+    expect(cycleCompletionStateForTargetPlan(TargetPlanStatus.NoTrade)).toBe(CycleState.NoTrade)
+
+    const blocked = decisionDocument(active, TargetPlanStatus.Blocked, TargetPlanReason.InputStale)
+    const blockedBound: AutonomousCycle = {
+      ...decisionBound,
+      bindings: { snapshotId, decisionHash: blocked.contentHash },
+    }
+    expect(
+      select(
+        recoveryState(blockedBound, {
+          observedAt: afterCutoff,
+          strategyProtocolHash: hash('f'),
+          decisionDocument: blocked,
+        }),
+      ),
+    ).toMatchObject({ action: 'BLOCK', reason: CycleTerminalReason.DataStale })
+  })
+
+  test('uses the freshest correlated readiness observation for activation and submission cutoff precedence', () => {
+    const bound = boundPendingCycle()
+    expect(bound.window.publicationDeadlineAt).toBe('2026-02-02T13:58:00.000Z')
+    expect(bound.window.submissionCutoffAt).toBe('2026-02-02T14:28:00.000Z')
+
+    const at = (readinessObservedAt: string): CycleRecoverySelection =>
+      select(
+        recoveryState(bound, {
+          observedAt: '2026-02-02T13:57:00.000Z',
+          readiness: {
+            outcome: 'ALREADY_BOUND',
+            observedAt: readinessObservedAt,
+            cycle: bound,
+            snapshotId,
+          },
+        }),
+      )
+
+    expect(at('2026-02-02T14:27:59.999Z')).toEqual({
+      action: 'ACTIVATE',
+      cycleId: bound.identity.cycleId,
+      observedAt: '2026-02-02T14:27:59.999Z',
+    })
+    expect(at(bound.window.submissionCutoffAt)).toEqual({
+      action: 'BLOCK',
+      cycleId: bound.identity.cycleId,
+      observedAt: bound.window.submissionCutoffAt,
+      reason: CycleTerminalReason.MissedSubmission,
+    })
+    expect(at('2026-02-02T14:29:00.000Z')).toEqual({
+      action: 'BLOCK',
+      cycleId: bound.identity.cycleId,
+      observedAt: '2026-02-02T14:29:00.000Z',
+      reason: CycleTerminalReason.MissedSubmission,
+    })
+  })
+
+  test('rejects a concurrent snapshot binding that became effective at or after the publication deadline', () => {
+    const pending = pendingCycle()
+    const selectConcurrentBinding = (bindingEffectiveAt: string, observedAt: string): CycleRecoverySelection => {
+      const concurrentlyBound: AutonomousCycle = {
+        ...pending,
+        bindings: { snapshotId },
+        stateVersion: pending.stateVersion + 1,
+        updatedAt: bindingEffectiveAt,
+      }
+      return select(
+        recoveryState(pending, {
+          observedAt: '2026-02-02T13:57:00.000Z',
+          readiness: {
+            outcome: 'ALREADY_BOUND',
+            observedAt,
+            cycle: concurrentlyBound,
+            snapshotId,
+          },
+        }),
+      )
+    }
+
+    expect(selectConcurrentBinding('2026-02-02T13:57:59.999Z', '2026-02-02T14:00:00.000Z')).toMatchObject({
+      action: 'ACTIVATE',
+    })
+    for (const bindingEffectiveAt of ['2026-02-02T13:58:00.000Z', '2026-02-02T13:58:00.001Z']) {
+      expect(selectConcurrentBinding(bindingEffectiveAt, '2026-02-02T14:00:00.000Z')).toEqual({
+        action: 'BLOCK',
+        cycleId: pending.identity.cycleId,
+        observedAt: '2026-02-02T14:00:00.000Z',
+        reason: CycleTerminalReason.MissedPublication,
+      })
+    }
+  })
+
+  test('rejects stale recovery and readiness observations before the selected cycle update', () => {
+    const active = activeCycle()
+    const staleState = selectCycleRecovery(
+      recoveryState(active, {
+        observedAt: '2026-02-02T13:55:59.999Z',
+      }),
+    )
+    expect(Result.isFailure(staleState)).toBe(true)
+    if (Result.isFailure(staleState)) {
+      expect(staleState.failure).toMatchObject({
+        operation: 'select',
+        reason: 'chronology',
+        facts: {
+          actualObservedAt: '2026-02-02T13:55:59.999Z',
+          expectedMinimumObservedAt: active.updatedAt,
+        },
+      })
+    }
+
+    const pending = pendingCycle()
+    const staleReadiness = selectCycleRecovery(
+      recoveryState(pending, {
+        readiness: {
+          outcome: 'WAITING',
+          reason: 'PUBLICATION_MISSING',
+          observedAt: '2026-01-30T21:14:59.999Z',
+          cycle: pending,
+        },
+      }),
+    )
+    expect(Result.isFailure(staleReadiness)).toBe(true)
+    if (Result.isFailure(staleReadiness)) {
+      expect(staleReadiness.failure).toMatchObject({
+        operation: 'select',
+        reason: 'readiness-binding',
+        facts: {
+          selectedUpdatedAt: pending.updatedAt,
+          readinessObservedAt: '2026-01-30T21:14:59.999Z',
+        },
+      })
+    }
+
+    const readinessBeforeRecovery = selectCycleRecovery(
+      recoveryState(pending, {
+        observedAt: '2026-01-30T21:16:00.000Z',
+        readiness: {
+          outcome: 'WAITING',
+          reason: 'PUBLICATION_MISSING',
+          observedAt: pending.updatedAt,
+          cycle: pending,
+        },
+      }),
+    )
+    expect(Result.isFailure(readinessBeforeRecovery)).toBe(true)
+    if (Result.isFailure(readinessBeforeRecovery)) {
+      expect(readinessBeforeRecovery.failure).toMatchObject({
+        operation: 'select',
+        reason: 'readiness-binding',
+        facts: {
+          expectedMinimumReadinessObservedAt: '2026-01-30T21:16:00.000Z',
+          actualReadinessObservedAt: pending.updatedAt,
+        },
+      })
+    }
+  })
+
+  test('rejects adversarial readiness snapshots, drafts, states, and version transitions', () => {
+    const pending = pendingCycle()
+    const bound = boundPendingCycle()
+    const blocked: AutonomousCycle = {
+      ...pending,
+      state: CycleState.Blocked,
+      terminalReason: CycleTerminalReason.MissedPublication,
+      terminalAt: pending.window.publicationDeadlineAt,
+      updatedAt: pending.window.publicationDeadlineAt,
+      stateVersion: pending.stateVersion + 1,
+    }
+    const differentDraftBound: AutonomousCycle = {
+      ...bound,
+      window: {
+        ...bound.window,
+        signalCloseAt: '2026-01-30T20:59:00.000Z',
+      },
+    }
+    const wrongSnapshotBound: AutonomousCycle = {
+      ...bound,
+      bindings: { snapshotId: hash('c') },
+    }
+    const cases = [
+      {
+        selected: pending,
+        readiness: {
+          outcome: 'BOUND',
+          observedAt: bound.updatedAt,
+          cycle: differentDraftBound,
+          snapshotId,
+        } as const,
+      },
+      {
+        selected: pending,
+        readiness: {
+          outcome: 'BOUND',
+          observedAt: bound.updatedAt,
+          cycle: { ...bound, stateVersion: bound.stateVersion + 1 },
+          snapshotId,
+        } as const,
+      },
+      {
+        selected: bound,
+        readiness: {
+          outcome: 'ALREADY_BOUND',
+          observedAt: bound.updatedAt,
+          cycle: wrongSnapshotBound,
+          snapshotId: hash('c'),
+        } as const,
+      },
+      {
+        selected: pending,
+        readiness: {
+          outcome: 'BLOCKED',
+          observedAt: blocked.updatedAt,
+          cycle: pending,
+        } as const,
+      },
+    ]
+
+    for (const { readiness, selected } of cases) {
+      const result = selectCycleRecovery(recoveryState(selected, { observedAt: selected.updatedAt, readiness }))
+      expect(Result.isFailure(result)).toBe(true)
+      if (Result.isFailure(result)) {
+        expect(result.failure).toMatchObject({
+          operation: 'select',
+          reason: 'readiness-binding',
+        })
+        expect(result.failure.facts).toMatchObject({
+          expectedAccountId: selected.identity.accountId,
+          actualAccountId: readiness.cycle.identity.accountId,
+          expectedCycleId: selected.identity.cycleId,
+          actualCycleId: readiness.cycle.identity.cycleId,
+          expectedSubmissionCutoffAt: selected.window.submissionCutoffAt,
+          actualSubmissionCutoffAt: readiness.cycle.window.submissionCutoffAt,
+          selectedStateVersion: selected.stateVersion,
+          actualStateVersion: readiness.cycle.stateVersion,
+        })
+      }
+    }
+  })
+
+  test('rejects decision documents created before cycle creation or the submission window', () => {
+    const active = activeCycle()
+    const beforeCycleCreation = decisionDocument(
+      active,
+      TargetPlanStatus.NoTrade,
+      TargetPlanReason.TargetsSatisfied,
+      '2026-01-30T21:14:59.999Z',
+    )
+    const beforeSubmissionOpen = decisionDocument(
+      active,
+      TargetPlanStatus.Blocked,
+      TargetPlanReason.InputStale,
+      '2026-02-02T13:57:59.999Z',
+    )
+    const cases = [beforeCycleCreation, beforeSubmissionOpen]
+
+    for (const document of cases) {
+      const decisionBound: AutonomousCycle = {
+        ...active,
+        bindings: { snapshotId, decisionHash: document.contentHash },
+        updatedAt: '2026-02-02T14:01:00.000Z',
+        stateVersion: active.stateVersion + 1,
+      }
+      const result = selectCycleRecovery(
+        recoveryState(decisionBound, {
+          observedAt: decisionBound.updatedAt,
+          decisionDocument: document,
+        }),
+      )
+      expect(Result.isFailure(result)).toBe(true)
+      if (Result.isFailure(result)) {
+        expect(result.failure).toMatchObject({
+          operation: 'validate-decision',
+          reason: 'decision-binding',
+          facts: {
+            expectedAccountId: active.identity.accountId,
+            actualAccountId: document.bindings.accountId,
+            expectedCycleId: active.identity.cycleId,
+            actualCycleId: document.bindings.cycleId,
+            expectedSubmissionCutoffAt: active.window.submissionCutoffAt,
+            actualSubmissionCutoffAt: document.submissionCutoffAt,
+            actualDocumentCreatedAt: document.createdAt,
+            minimumCycleCreatedAt: active.createdAt,
+            minimumSubmissionOpenAt: active.window.submissionOpenAt,
+          },
+        })
+      }
+    }
+  })
+
+  test('maps the closed blocked-reason algebra exhaustively', () => {
+    const cases: ReadonlyArray<readonly [BlockedTargetPlanReason, CycleTerminalReason]> = [
+      [TargetPlanReason.SubmissionCutoffReached, CycleTerminalReason.MissedSubmission],
+      [TargetPlanReason.IdentityMismatch, CycleTerminalReason.ProvenanceMismatch],
+      [TargetPlanReason.InputMismatch, CycleTerminalReason.DataInvalid],
+      [TargetPlanReason.InputStale, CycleTerminalReason.DataStale],
+      [TargetPlanReason.ReconciliationNotExact, CycleTerminalReason.Reconciliation],
+      [TargetPlanReason.AccountNotActive, CycleTerminalReason.BrokerDisabled],
+      [TargetPlanReason.UnknownOrder, CycleTerminalReason.UnresolvedMutation],
+      [TargetPlanReason.UnresolvedOrder, CycleTerminalReason.UnresolvedMutation],
+      [TargetPlanReason.BelowMinimumBuyNotional, CycleTerminalReason.Risk],
+      [TargetPlanReason.InsufficientBuyingPower, CycleTerminalReason.Risk],
+      [TargetPlanReason.NonPositiveEquity, CycleTerminalReason.Risk],
+      [TargetPlanReason.ShortPositionNotAllowed, CycleTerminalReason.Risk],
+    ]
+    expect(cases.map(([reason]) => cycleTerminalReasonForBlockedTargetPlan(reason))).toEqual(
+      cases.map(([_, terminalReason]) => terminalReason),
+    )
+  })
+
+  test('returns tagged failures for every reachable recovery-state contradiction', () => {
+    const pending = pendingCycle()
+    const otherPending = pendingCycle('XNYS-v2')
+    const otherBound: AutonomousCycle = {
+      ...pending,
+      bindings: { snapshotId: hash('c') },
+      stateVersion: 2,
+      updatedAt: '2026-01-30T21:16:00.000Z',
+    }
+    const active = activeCycle()
+    const document = decisionDocument(active)
+    const otherDocument = decisionDocument(active, TargetPlanStatus.Blocked, TargetPlanReason.InputStale)
+    const decisionBound: AutonomousCycle = {
+      ...active,
+      bindings: { snapshotId, decisionHash: document.contentHash },
+      updatedAt: '2026-02-02T14:01:00.000Z',
+      stateVersion: 4,
+    }
+    const cases: ReadonlyArray<readonly [unknown, string, string]> = [
+      [{}, 'decode-state', 'decode'],
+      [{ ...recoveryState(undefined), readiness: { outcome: 'WAITING' } }, 'decode-state', 'decode'],
+      [
+        recoveryState(undefined, {
+          readiness: {
+            outcome: 'WAITING',
+            reason: 'PUBLICATION_MISSING',
+            observedAt: pending.updatedAt,
+            cycle: pending,
+          },
+        }),
+        'select',
+        'evidence-without-cycle',
+      ],
+      [recoveryState(pending, { accountId: 'another-account' }), 'select', 'scope'],
+      [
+        recoveryState({
+          ...pending,
+          state: CycleState.Blocked,
+          terminalReason: CycleTerminalReason.MissedPublication,
+          terminalAt: pending.updatedAt,
+        }),
+        'select',
+        'terminal-cycle',
+      ],
+      [
+        recoveryState(active, {
+          readiness: {
+            outcome: 'WAITING',
+            reason: 'PUBLICATION_MISSING',
+            observedAt: pending.updatedAt,
+            cycle: pending,
+          },
+        }),
+        'select',
+        'state-evidence',
+      ],
+      [recoveryState(active, { decisionDocument: document }), 'select', 'state-evidence'],
+      [recoveryState(pending, { decisionDocument: document }), 'select', 'state-evidence'],
+      [
+        recoveryState(decisionBound, { observedAt: decisionBound.updatedAt, decisionDocument: null }),
+        'select',
+        'decision-missing',
+      ],
+      [
+        recoveryState(decisionBound, {
+          observedAt: decisionBound.updatedAt,
+          decisionDocument: otherDocument,
+        }),
+        'validate-decision',
+        'decision-binding',
+      ],
+      [
+        recoveryState(pending, {
+          readiness: {
+            outcome: 'WAITING',
+            reason: 'PUBLICATION_MISSING',
+            observedAt: otherPending.updatedAt,
+            cycle: otherPending,
+          },
+        }),
+        'select',
+        'readiness-binding',
+      ],
+      [
+        recoveryState(pending, {
+          readiness: {
+            outcome: 'BOUND',
+            observedAt: otherBound.updatedAt,
+            cycle: otherBound,
+            snapshotId,
+          },
+        }),
+        'select',
+        'readiness-binding',
+      ],
+    ]
+
+    for (const [state, operation, reason] of cases) {
+      const result = selectCycleRecovery(state)
+      expect(Result.isFailure(result)).toBe(true)
+      if (Result.isFailure(result)) {
+        expect(result.failure).toMatchObject({ _tag: 'CycleRecoveryFailure', operation, reason })
+      }
+    }
+  })
+})

--- a/services/bayn/src/cycle-recovery.ts
+++ b/services/bayn/src/cycle-recovery.ts
@@ -1,14 +1,37 @@
+import { Data, Result, Schema } from 'effect'
+
 import {
+  AutonomousCycleSchema,
   CycleState,
   CycleTerminalReason,
-  cycleTerminalReasonForTargetPlanBlock,
+  cycleDraftMatches,
+  cycleDraftOf,
   isTerminalCycleState,
+  type ActiveDecisionBoundCycle,
+  type ActiveUnboundCycle,
   type AutonomousCycle,
   type CycleCompletionState,
+  type PendingCycle,
 } from './cycle'
 import type { CyclePublicationReadiness } from './cycle-readiness'
-import type { ObserveShadowDecisionDocument } from './shadow-decision-contract'
-import { TargetPlanStatus } from './target-planner'
+import { ObserveShadowDecisionDocumentSchema, type ObserveShadowDecisionDocument } from './shadow-decision-contract'
+import {
+  NonNegativeFiniteSchema,
+  Sha256Schema,
+  StrictNonEmptyStringSchema,
+  UtcInstantSchema,
+  strictParseOptions,
+} from './schemas'
+import { TargetPlanReason, TargetPlanStatus, type BlockedTargetPlanReason } from './target-planner'
+
+type WaitingReadiness = Extract<CyclePublicationReadiness, { readonly outcome: 'WAITING' }>
+type BlockedReadiness = Extract<CyclePublicationReadiness, { readonly outcome: 'BLOCKED' }>
+type BoundOrAlreadyReadiness = Extract<CyclePublicationReadiness, { readonly outcome: 'BOUND' | 'ALREADY_BOUND' }>
+type BoundReadiness = Omit<BoundOrAlreadyReadiness, 'outcome'> & { readonly outcome: 'BOUND' }
+type AlreadyBoundReadiness = Omit<BoundOrAlreadyReadiness, 'outcome'> & { readonly outcome: 'ALREADY_BOUND' }
+
+const isAlreadyBoundReadiness = (readiness: CyclePublicationReadiness): readiness is AlreadyBoundReadiness =>
+  readiness.outcome === 'ALREADY_BOUND'
 
 export type CycleRecoverySelection =
   | { readonly action: 'DISCOVER' }
@@ -21,8 +44,18 @@ export type CycleRecoverySelection =
   | { readonly action: 'READ_PUBLICATION'; readonly cycle: AutonomousCycle }
   | {
       readonly action: 'RETURN_READINESS'
-      readonly result: CyclePublicationReadiness
-      readonly recoveryAction: 'BLOCKED' | 'BOUND_SNAPSHOT' | 'WAITING'
+      readonly result: WaitingReadiness
+      readonly recoveryAction: 'WAITING'
+    }
+  | {
+      readonly action: 'RETURN_READINESS'
+      readonly result: BlockedReadiness
+      readonly recoveryAction: 'BLOCKED'
+    }
+  | {
+      readonly action: 'RETURN_READINESS'
+      readonly result: BoundReadiness
+      readonly recoveryAction: 'BOUND_SNAPSHOT'
     }
   | {
       readonly action: 'ACTIVATE'
@@ -53,18 +86,216 @@ export interface CycleRecoveryState {
   readonly decisionDocument?: ObserveShadowDecisionDocument | null
 }
 
-const validateDecisionBinding = (cycle: AutonomousCycle, document: ObserveShadowDecisionDocument): void => {
-  if (
-    cycle.bindings.decisionHash !== document.contentHash ||
+type RecoveryScope = Pick<
+  CycleRecoveryState,
+  'accountId' | 'observedAt' | 'qualificationRunId' | 'strategyProtocolHash'
+>
+
+export type CorrelatedCycleRecoveryState =
+  | (RecoveryScope & {
+      readonly cycle?: undefined
+      readonly readiness?: undefined
+      readonly decisionDocument?: undefined
+    })
+  | (RecoveryScope & {
+      readonly cycle: PendingCycle
+      readonly readiness?: CyclePublicationReadiness
+      readonly decisionDocument?: undefined
+    })
+  | (RecoveryScope & {
+      readonly cycle: ActiveUnboundCycle
+      readonly readiness?: undefined
+      readonly decisionDocument?: undefined
+    })
+  | (RecoveryScope & {
+      readonly cycle: ActiveDecisionBoundCycle
+      readonly readiness?: undefined
+      readonly decisionDocument?: ObserveShadowDecisionDocument | null
+    })
+
+interface DecodeRecoveryStateIssue {
+  readonly operation: 'decode-state'
+  readonly reason: 'decode'
+}
+
+interface SelectRecoveryIssue {
+  readonly operation: 'select'
+  readonly reason:
+    | 'chronology'
+    | 'decision-missing'
+    | 'evidence-without-cycle'
+    | 'readiness-binding'
+    | 'scope'
+    | 'state-evidence'
+    | 'terminal-cycle'
+}
+
+interface ValidateRecoveryDecisionIssue {
+  readonly operation: 'validate-decision'
+  readonly reason: 'decision-binding'
+}
+
+type CycleRecoveryIssue = DecodeRecoveryStateIssue | SelectRecoveryIssue | ValidateRecoveryDecisionIssue
+
+interface CycleRecoveryFailureDetails {
+  readonly message: string
+  readonly facts: Readonly<Record<string, unknown>>
+  readonly cause?: unknown
+}
+
+const CycleRecoveryFailure = Data.TaggedError('CycleRecoveryFailure')<CycleRecoveryIssue & CycleRecoveryFailureDetails>
+export type CycleRecoveryFailure = InstanceType<typeof CycleRecoveryFailure>
+
+type CycleRecoveryReason<Operation extends CycleRecoveryIssue['operation']> = Extract<
+  CycleRecoveryIssue,
+  { readonly operation: Operation }
+>['reason']
+
+const decodeRecoveryStateFailure = (
+  reason: CycleRecoveryReason<'decode-state'>,
+  message: string,
+  facts: Readonly<Record<string, unknown>> = {},
+  cause?: unknown,
+): CycleRecoveryFailure => new CycleRecoveryFailure({ operation: 'decode-state', reason, message, facts, cause })
+
+const selectRecoveryFailure = (
+  reason: CycleRecoveryReason<'select'>,
+  message: string,
+  facts: Readonly<Record<string, unknown>> = {},
+  cause?: unknown,
+): CycleRecoveryFailure => new CycleRecoveryFailure({ operation: 'select', reason, message, facts, cause })
+
+const validateDecisionFailure = (
+  reason: CycleRecoveryReason<'validate-decision'>,
+  message: string,
+  facts: Readonly<Record<string, unknown>> = {},
+  cause?: unknown,
+): CycleRecoveryFailure => new CycleRecoveryFailure({ operation: 'validate-decision', reason, message, facts, cause })
+
+const PublicationFreshnessSchema = Schema.Struct({
+  dataAgeMs: NonNegativeFiniteSchema,
+  publicationDelayMs: NonNegativeFiniteSchema,
+})
+
+const WaitingReadinessSchema = Schema.Struct({
+  outcome: Schema.Literal('WAITING'),
+  reason: Schema.Literals(['SIGNAL_SESSION_OPEN', 'PUBLICATION_MISSING']),
+  observedAt: UtcInstantSchema,
+  cycle: AutonomousCycleSchema,
+})
+
+const BoundReadinessSchema = Schema.Struct({
+  outcome: Schema.Literals(['BOUND', 'ALREADY_BOUND']),
+  observedAt: UtcInstantSchema,
+  cycle: AutonomousCycleSchema,
+  snapshotId: Sha256Schema,
+  freshness: Schema.optionalKey(PublicationFreshnessSchema),
+})
+
+const BlockedReadinessSchema = Schema.Struct({
+  outcome: Schema.Literal('BLOCKED'),
+  observedAt: UtcInstantSchema,
+  cycle: AutonomousCycleSchema,
+})
+
+const CyclePublicationReadinessSchema = Schema.Union([
+  WaitingReadinessSchema,
+  BoundReadinessSchema,
+  BlockedReadinessSchema,
+])
+
+const CycleRecoveryStateSchema = Schema.Struct({
+  qualificationRunId: Sha256Schema,
+  accountId: StrictNonEmptyStringSchema,
+  strategyProtocolHash: Sha256Schema,
+  observedAt: UtcInstantSchema,
+  cycle: Schema.UndefinedOr(AutonomousCycleSchema),
+  readiness: Schema.optionalKey(CyclePublicationReadinessSchema),
+  decisionDocument: Schema.optionalKey(Schema.NullOr(ObserveShadowDecisionDocumentSchema)),
+})
+
+type DecodedCycleRecoveryState = typeof CycleRecoveryStateSchema.Type
+
+const decodeCycleRecoveryStateResult = Schema.decodeUnknownResult(CycleRecoveryStateSchema, strictParseOptions)
+
+const validateDecisionBinding = (
+  cycle: AutonomousCycle,
+  document: ObserveShadowDecisionDocument,
+): Result.Result<void, CycleRecoveryFailure> => {
+  const facts = {
+    expectedAccountId: cycle.identity.accountId,
+    actualAccountId: document.bindings.accountId,
+    expectedCycleId: cycle.identity.cycleId,
+    actualCycleId: document.bindings.cycleId,
+    expectedCycleStateVersion: cycle.stateVersion,
+    actualDocumentCreatedAt: document.createdAt,
+    expectedDecisionHash: cycle.bindings.decisionHash,
+    actualDecisionHash: document.contentHash,
+    expectedSnapshotId: cycle.bindings.snapshotId,
+    actualSnapshotId: document.bindings.snapshotId,
+    expectedStrategyName: cycle.identity.strategyName,
+    actualStrategyName: document.bindings.strategyName,
+    expectedStrategyProtocolHash: cycle.identity.strategyProtocolHash,
+    actualStrategyProtocolHash: document.bindings.strategyProtocolHash,
+    expectedSubmissionCutoffAt: cycle.window.submissionCutoffAt,
+    actualSubmissionCutoffAt: document.submissionCutoffAt,
+    minimumCycleCreatedAt: cycle.createdAt,
+    minimumSubmissionOpenAt: cycle.window.submissionOpenAt,
+    maximumCycleUpdatedAt: cycle.updatedAt,
+  }
+  return cycle.bindings.decisionHash !== document.contentHash ||
     cycle.bindings.snapshotId !== document.bindings.snapshotId ||
     cycle.identity.cycleId !== document.bindings.cycleId ||
     cycle.identity.strategyName !== document.bindings.strategyName ||
     cycle.identity.strategyProtocolHash !== document.bindings.strategyProtocolHash ||
     cycle.identity.accountId !== document.bindings.accountId ||
     cycle.window.submissionCutoffAt !== document.submissionCutoffAt ||
+    document.createdAt < cycle.createdAt ||
+    document.createdAt < cycle.window.submissionOpenAt ||
     document.createdAt > cycle.updatedAt
-  ) {
-    throw new TypeError('durable shadow decision does not match the active cycle binding')
+    ? Result.fail(
+        validateDecisionFailure(
+          'decision-binding',
+          'durable shadow decision does not match the active cycle binding',
+          facts,
+        ),
+      )
+    : Result.succeed(undefined)
+}
+
+export const cycleTerminalReasonForBlockedTargetPlan = (reason: BlockedTargetPlanReason): CycleTerminalReason => {
+  switch (reason) {
+    case TargetPlanReason.SubmissionCutoffReached:
+      return CycleTerminalReason.MissedSubmission
+    case TargetPlanReason.IdentityMismatch:
+      return CycleTerminalReason.ProvenanceMismatch
+    case TargetPlanReason.InputMismatch:
+      return CycleTerminalReason.DataInvalid
+    case TargetPlanReason.InputStale:
+      return CycleTerminalReason.DataStale
+    case TargetPlanReason.ReconciliationNotExact:
+      return CycleTerminalReason.Reconciliation
+    case TargetPlanReason.AccountNotActive:
+      return CycleTerminalReason.BrokerDisabled
+    case TargetPlanReason.UnknownOrder:
+    case TargetPlanReason.UnresolvedOrder:
+      return CycleTerminalReason.UnresolvedMutation
+    case TargetPlanReason.BelowMinimumBuyNotional:
+    case TargetPlanReason.InsufficientBuyingPower:
+    case TargetPlanReason.NonPositiveEquity:
+    case TargetPlanReason.ShortPositionNotAllowed:
+      return CycleTerminalReason.Risk
+  }
+}
+
+export const cycleCompletionStateForTargetPlan = (
+  status: TargetPlanStatus.Planned | TargetPlanStatus.NoTrade,
+): CycleCompletionState => {
+  switch (status) {
+    case TargetPlanStatus.Planned:
+      return CycleState.Completed
+    case TargetPlanStatus.NoTrade:
+      return CycleState.NoTrade
   }
 }
 
@@ -72,76 +303,296 @@ const selectBoundDecision = (
   cycle: AutonomousCycle,
   document: ObserveShadowDecisionDocument | null | undefined,
   observedAt: string,
-): CycleRecoverySelection => {
-  if (document === undefined) return { action: 'READ_DECISION', cycle }
-  if (document === null) throw new TypeError('decision-bound cycle is missing its durable document')
-  validateDecisionBinding(cycle, document)
-  switch (document.targetPlan.status) {
-    case TargetPlanStatus.Planned:
-      return {
-        action: 'FINISH',
+): Result.Result<CycleRecoverySelection, CycleRecoveryFailure> => {
+  if (document === undefined) return Result.succeed({ action: 'READ_DECISION', cycle })
+  if (document === null) {
+    return Result.fail(
+      selectRecoveryFailure('decision-missing', 'decision-bound cycle is missing its durable document', {
         cycleId: cycle.identity.cycleId,
-        observedAt,
-        state: CycleState.Completed,
+      }),
+    )
+  }
+  return Result.flatMap(
+    validateDecisionBinding(cycle, document),
+    (): Result.Result<CycleRecoverySelection, CycleRecoveryFailure> => {
+      switch (document.targetPlan.status) {
+        case TargetPlanStatus.Planned:
+        case TargetPlanStatus.NoTrade:
+          return Result.succeed({
+            action: 'FINISH',
+            cycleId: cycle.identity.cycleId,
+            observedAt,
+            state: cycleCompletionStateForTargetPlan(document.targetPlan.status),
+          })
+        case TargetPlanStatus.Blocked:
+          return Result.succeed({
+            action: 'BLOCK',
+            cycleId: cycle.identity.cycleId,
+            observedAt,
+            reason: cycleTerminalReasonForBlockedTargetPlan(document.targetPlan.reason),
+          })
       }
-    case TargetPlanStatus.NoTrade:
-      return {
-        action: 'FINISH',
-        cycleId: cycle.identity.cycleId,
-        observedAt,
-        state: CycleState.NoTrade,
-      }
-    case TargetPlanStatus.Blocked: {
-      const reason = document.targetPlan.reason
-      if (reason === null) throw new TypeError('blocked target plan requires its durable reason')
-      return {
-        action: 'BLOCK',
-        cycleId: cycle.identity.cycleId,
-        observedAt,
-        reason: cycleTerminalReasonForTargetPlanBlock(reason),
-      }
-    }
+    },
+  )
+}
+
+const readinessBindingFacts = (
+  cycle: AutonomousCycle,
+  recoveryObservedAt: string,
+  readiness: CyclePublicationReadiness,
+): Readonly<Record<string, unknown>> => {
+  const selectedSnapshotId = cycle.bindings.snapshotId
+  const readinessSnapshotId = readiness.cycle.bindings.snapshotId
+  const declaredSnapshotId =
+    readiness.outcome === 'BOUND' || readiness.outcome === 'ALREADY_BOUND' ? readiness.snapshotId : undefined
+  const expectedStateVersion =
+    readiness.outcome === 'WAITING' || (readiness.outcome === 'ALREADY_BOUND' && selectedSnapshotId !== undefined)
+      ? cycle.stateVersion
+      : cycle.stateVersion + 1
+  return {
+    outcome: readiness.outcome,
+    expectedAccountId: cycle.identity.accountId,
+    actualAccountId: readiness.cycle.identity.accountId,
+    expectedCycleId: cycle.identity.cycleId,
+    actualCycleId: readiness.cycle.identity.cycleId,
+    expectedQualificationRunId: cycle.identity.qualificationRunId,
+    actualQualificationRunId: readiness.cycle.identity.qualificationRunId,
+    expectedStrategyProtocolHash: cycle.identity.strategyProtocolHash,
+    actualStrategyProtocolHash: readiness.cycle.identity.strategyProtocolHash,
+    expectedSignalSessionDate: cycle.identity.signalSessionDate,
+    actualSignalSessionDate: readiness.cycle.identity.signalSessionDate,
+    expectedSignalCalendarVersion: cycle.identity.signalCalendarVersion,
+    actualSignalCalendarVersion: readiness.cycle.identity.signalCalendarVersion,
+    expectedSubmissionCutoffAt: cycle.window.submissionCutoffAt,
+    actualSubmissionCutoffAt: readiness.cycle.window.submissionCutoffAt,
+    expectedSelectedSnapshotId: selectedSnapshotId,
+    actualSelectedSnapshotId: readinessSnapshotId,
+    declaredSnapshotId,
+    expectedState: readiness.outcome === 'BLOCKED' ? CycleState.Blocked : CycleState.Pending,
+    actualState: readiness.cycle.state,
+    selectedStateVersion: cycle.stateVersion,
+    expectedStateVersion,
+    actualStateVersion: readiness.cycle.stateVersion,
+    selectedUpdatedAt: cycle.updatedAt,
+    expectedMinimumReadinessObservedAt: recoveryObservedAt,
+    actualReadinessObservedAt: readiness.observedAt,
+    readinessObservedAt: readiness.observedAt,
+    readinessCycleUpdatedAt: readiness.cycle.updatedAt,
   }
 }
 
-export const selectCycleRecovery = (state: CycleRecoveryState): CycleRecoverySelection => {
-  const { cycle, decisionDocument, readiness } = state
-  if (cycle === undefined) {
-    if (readiness !== undefined || decisionDocument !== undefined) {
-      throw new TypeError('recovery evidence requires an unfinished cycle')
-    }
-    return { action: 'DISCOVER' }
+const readinessCommonMatches = (cycle: AutonomousCycle, readiness: CyclePublicationReadiness): boolean =>
+  cycleDraftMatches(cycleDraftOf(cycle), cycleDraftOf(readiness.cycle)) &&
+  readiness.cycle.identity.cycleId === cycle.identity.cycleId &&
+  readiness.cycle.identity.accountId === cycle.identity.accountId &&
+  readiness.cycle.identity.qualificationRunId === cycle.identity.qualificationRunId &&
+  readiness.cycle.identity.strategyProtocolHash === cycle.identity.strategyProtocolHash &&
+  readiness.cycle.window.submissionCutoffAt === cycle.window.submissionCutoffAt &&
+  readiness.cycle.createdAt === cycle.createdAt &&
+  readiness.observedAt >= cycle.updatedAt
+
+const waitingReadinessMatches = (cycle: AutonomousCycle, readiness: WaitingReadiness): boolean =>
+  cycle.bindings.snapshotId === undefined &&
+  readiness.cycle.state === CycleState.Pending &&
+  readiness.cycle.bindings.snapshotId === undefined &&
+  readiness.cycle.bindings.decisionHash === undefined &&
+  readiness.cycle.stateVersion === cycle.stateVersion &&
+  readiness.cycle.updatedAt === cycle.updatedAt &&
+  ((readiness.reason === 'SIGNAL_SESSION_OPEN' && readiness.observedAt < cycle.window.signalCloseAt) ||
+    (readiness.reason === 'PUBLICATION_MISSING' &&
+      readiness.observedAt >= cycle.window.signalCloseAt &&
+      readiness.observedAt < cycle.window.publicationDeadlineAt))
+
+const boundReadinessMatches = (cycle: AutonomousCycle, readiness: BoundOrAlreadyReadiness): boolean =>
+  readiness.outcome === 'BOUND' &&
+  cycle.bindings.snapshotId === undefined &&
+  readiness.cycle.state === CycleState.Pending &&
+  readiness.cycle.bindings.snapshotId === readiness.snapshotId &&
+  readiness.cycle.bindings.decisionHash === undefined &&
+  readiness.cycle.stateVersion === cycle.stateVersion + 1 &&
+  readiness.cycle.updatedAt === readiness.observedAt &&
+  readiness.observedAt >= cycle.window.signalCloseAt &&
+  readiness.observedAt < cycle.window.publicationDeadlineAt
+
+const alreadyBoundReadinessMatches = (cycle: AutonomousCycle, readiness: BoundOrAlreadyReadiness): boolean => {
+  if (readiness.outcome !== 'ALREADY_BOUND') return false
+  const unchangedBoundCycle =
+    cycle.bindings.snapshotId === readiness.snapshotId &&
+    readiness.cycle.stateVersion === cycle.stateVersion &&
+    readiness.cycle.updatedAt === cycle.updatedAt
+  const concurrentBinding =
+    cycle.bindings.snapshotId === undefined &&
+    readiness.cycle.stateVersion === cycle.stateVersion + 1 &&
+    readiness.cycle.updatedAt > cycle.updatedAt &&
+    readiness.cycle.updatedAt <= readiness.observedAt
+  return (
+    readiness.cycle.state === CycleState.Pending &&
+    readiness.cycle.bindings.snapshotId === readiness.snapshotId &&
+    readiness.cycle.bindings.decisionHash === undefined &&
+    (unchangedBoundCycle || concurrentBinding)
+  )
+}
+
+const blockedReadinessMatches = (cycle: AutonomousCycle, readiness: BlockedReadiness): boolean =>
+  cycle.bindings.snapshotId === undefined &&
+  readiness.cycle.state === CycleState.Blocked &&
+  readiness.cycle.bindings.snapshotId === undefined &&
+  readiness.cycle.bindings.decisionHash === undefined &&
+  readiness.cycle.terminalReason === CycleTerminalReason.MissedPublication &&
+  readiness.cycle.terminalAt === readiness.observedAt &&
+  readiness.cycle.updatedAt === readiness.observedAt &&
+  readiness.cycle.stateVersion === cycle.stateVersion + 1 &&
+  readiness.observedAt >= cycle.window.publicationDeadlineAt
+
+const readinessOutcomeMatches = (cycle: AutonomousCycle, readiness: CyclePublicationReadiness): boolean => {
+  switch (readiness.outcome) {
+    case 'WAITING':
+      return waitingReadinessMatches(cycle, readiness)
+    case 'BOUND':
+      return boundReadinessMatches(cycle, readiness)
+    case 'ALREADY_BOUND':
+      return alreadyBoundReadinessMatches(cycle, readiness)
+    case 'BLOCKED':
+      return blockedReadinessMatches(cycle, readiness)
   }
+}
+
+const readinessIsCorrelated = (
+  cycle: AutonomousCycle,
+  recoveryObservedAt: string,
+  readiness: CyclePublicationReadiness,
+): boolean =>
+  readiness.observedAt >= recoveryObservedAt &&
+  readinessCommonMatches(cycle, readiness) &&
+  readinessOutcomeMatches(cycle, readiness)
+
+const validateReadiness = (
+  cycle: AutonomousCycle,
+  recoveryObservedAt: string,
+  readiness: CyclePublicationReadiness,
+): Result.Result<void, CycleRecoveryFailure> => {
+  if (!readinessIsCorrelated(cycle, recoveryObservedAt, readiness)) {
+    return Result.fail(
+      selectRecoveryFailure(
+        'readiness-binding',
+        'publication readiness must be the permitted transition of the exact selected cycle draft and snapshot',
+        readinessBindingFacts(cycle, recoveryObservedAt, readiness),
+      ),
+    )
+  }
+  return Result.succeed(undefined)
+}
+
+const validateRecoveryCycleContext = (
+  state: DecodedCycleRecoveryState,
+  cycle: AutonomousCycle,
+): Result.Result<void, CycleRecoveryFailure> => {
   if (cycle.identity.qualificationRunId !== state.qualificationRunId || cycle.identity.accountId !== state.accountId) {
-    throw new TypeError('unfinished cycle does not match the configured recovery scope')
+    return Result.fail(
+      selectRecoveryFailure('scope', 'unfinished cycle does not match the configured recovery scope', {
+        cycleId: cycle.identity.cycleId,
+        expectedQualificationRunId: state.qualificationRunId,
+        actualQualificationRunId: cycle.identity.qualificationRunId,
+        expectedAccountId: state.accountId,
+        actualAccountId: cycle.identity.accountId,
+        cycleState: cycle.state,
+        cycleStateVersion: cycle.stateVersion,
+        submissionCutoffAt: cycle.window.submissionCutoffAt,
+      }),
+    )
   }
   if (isTerminalCycleState(cycle.state)) {
-    throw new TypeError('terminal cycles must not enter autonomous recovery')
+    return Result.fail(
+      selectRecoveryFailure('terminal-cycle', 'terminal cycles must not enter autonomous recovery', {
+        cycleId: cycle.identity.cycleId,
+        state: cycle.state,
+      }),
+    )
   }
-  if (cycle.state === CycleState.Active && cycle.bindings.decisionHash !== undefined) {
-    if (readiness !== undefined) throw new TypeError('active cycle recovery does not accept publication readiness')
-    return selectBoundDecision(cycle, decisionDocument, state.observedAt)
+  if (state.observedAt < cycle.updatedAt) {
+    return Result.fail(
+      selectRecoveryFailure('chronology', 'recovery observation cannot precede the selected cycle update', {
+        actualObservedAt: state.observedAt,
+        expectedMinimumObservedAt: cycle.updatedAt,
+        cycleId: cycle.identity.cycleId,
+        cycleState: cycle.state,
+        cycleStateVersion: cycle.stateVersion,
+      }),
+    )
   }
+  return Result.succeed(undefined)
+}
+
+const selectDecisionBoundRecovery = (
+  state: DecodedCycleRecoveryState,
+  cycle: AutonomousCycle,
+): Result.Result<CycleRecoverySelection, CycleRecoveryFailure> => {
+  if (state.readiness !== undefined) {
+    return Result.fail(
+      selectRecoveryFailure('state-evidence', 'active cycle recovery does not accept publication readiness', {
+        cycleId: cycle.identity.cycleId,
+      }),
+    )
+  }
+  return selectBoundDecision(cycle, state.decisionDocument, state.observedAt)
+}
+
+const correlatedReadinessOf = (
+  state: DecodedCycleRecoveryState,
+  cycle: AutonomousCycle,
+): AlreadyBoundReadiness | undefined => {
+  const { readiness } = state
+  return readiness !== undefined &&
+    isAlreadyBoundReadiness(readiness) &&
+    readinessIsCorrelated(cycle, state.observedAt, readiness)
+    ? readiness
+    : undefined
+}
+
+const freshestRecoveryObservationAt = (
+  state: DecodedCycleRecoveryState,
+  readiness: AlreadyBoundReadiness | undefined,
+): string =>
+  readiness !== undefined && readiness.observedAt > state.observedAt ? readiness.observedAt : state.observedAt
+
+const pendingSnapshotBindingAt = (
+  cycle: AutonomousCycle,
+  readiness: AlreadyBoundReadiness | undefined,
+): string | undefined => {
+  if (cycle.state !== CycleState.Pending) return undefined
+  if (cycle.bindings.snapshotId !== undefined) return cycle.updatedAt
+  return readiness?.cycle.updatedAt
+}
+
+const selectDeadlineOrProvenance = (
+  state: DecodedCycleRecoveryState,
+  cycle: AutonomousCycle,
+): CycleRecoverySelection | undefined => {
+  const correlatedReadiness = correlatedReadinessOf(state, cycle)
+  const observedAt = freshestRecoveryObservationAt(state, correlatedReadiness)
+  const pendingBindingEffectiveAt = pendingSnapshotBindingAt(cycle, correlatedReadiness)
+
   if (
     cycle.state === CycleState.Pending &&
-    cycle.bindings.snapshotId === undefined &&
-    state.observedAt >= cycle.window.publicationDeadlineAt
+    (pendingBindingEffectiveAt === undefined
+      ? observedAt >= cycle.window.publicationDeadlineAt
+      : pendingBindingEffectiveAt >= cycle.window.publicationDeadlineAt)
   ) {
     return {
       action: 'BLOCK',
       cycleId: cycle.identity.cycleId,
-      observedAt: state.observedAt,
+      observedAt,
       reason: CycleTerminalReason.MissedPublication,
     }
   }
   if (
-    (cycle.state === CycleState.Active || cycle.bindings.snapshotId !== undefined) &&
-    state.observedAt >= cycle.window.submissionCutoffAt
+    (cycle.state === CycleState.Active || pendingBindingEffectiveAt !== undefined) &&
+    observedAt >= cycle.window.submissionCutoffAt
   ) {
     return {
       action: 'BLOCK',
       cycleId: cycle.identity.cycleId,
-      observedAt: state.observedAt,
+      observedAt,
       reason: CycleTerminalReason.MissedSubmission,
     }
   }
@@ -153,39 +604,112 @@ export const selectCycleRecovery = (state: CycleRecoveryState): CycleRecoverySel
       reason: CycleTerminalReason.ProvenanceMismatch,
     }
   }
-  if (cycle.state === CycleState.Active) {
-    if (readiness !== undefined) throw new TypeError('active cycle recovery does not accept publication readiness')
-    if (decisionDocument !== undefined) {
-      throw new TypeError('unbound active cycle cannot have durable decision evidence')
-    }
-    if (state.observedAt < cycle.window.submissionOpenAt) {
-      return { action: 'WAIT', cycle, observedAt: state.observedAt }
-    }
-    return { action: 'BUILD_DECISION', cycle }
-  }
-  if (cycle.state !== CycleState.Pending) {
-    throw new TypeError(`unsupported unfinished cycle state ${cycle.state}`)
-  }
-  if (decisionDocument !== undefined) {
-    throw new TypeError('pending cycle recovery does not accept decision evidence')
-  }
-  if (readiness === undefined) return { action: 'READ_PUBLICATION', cycle }
-  if (readiness.cycle.identity.cycleId !== cycle.identity.cycleId) {
-    throw new TypeError('publication readiness must describe the selected unfinished cycle')
-  }
+  return undefined
+}
 
-  switch (readiness.outcome) {
-    case 'WAITING':
-      return { action: 'RETURN_READINESS', recoveryAction: 'WAITING', result: readiness }
-    case 'BLOCKED':
-      return { action: 'RETURN_READINESS', recoveryAction: 'BLOCKED', result: readiness }
-    case 'BOUND':
-      return { action: 'RETURN_READINESS', recoveryAction: 'BOUND_SNAPSHOT', result: readiness }
-    case 'ALREADY_BOUND':
-      return {
-        action: 'ACTIVATE',
-        cycleId: readiness.cycle.identity.cycleId,
-        observedAt: readiness.observedAt,
-      }
+const selectActiveRecovery = (
+  state: DecodedCycleRecoveryState,
+  cycle: AutonomousCycle,
+): Result.Result<CycleRecoverySelection, CycleRecoveryFailure> => {
+  if (state.readiness !== undefined) {
+    return Result.fail(
+      selectRecoveryFailure('state-evidence', 'active cycle recovery does not accept publication readiness', {
+        cycleId: cycle.identity.cycleId,
+      }),
+    )
+  }
+  if (state.decisionDocument !== undefined) {
+    return Result.fail(
+      selectRecoveryFailure('state-evidence', 'unbound active cycle cannot have durable decision evidence', {
+        cycleId: cycle.identity.cycleId,
+      }),
+    )
+  }
+  return state.observedAt < cycle.window.submissionOpenAt
+    ? Result.succeed({ action: 'WAIT', cycle, observedAt: state.observedAt })
+    : Result.succeed({ action: 'BUILD_DECISION', cycle })
+}
+
+const selectPendingReadiness = (
+  cycle: AutonomousCycle,
+  recoveryObservedAt: string,
+  readiness: CyclePublicationReadiness,
+): Result.Result<CycleRecoverySelection, CycleRecoveryFailure> =>
+  Result.map(validateReadiness(cycle, recoveryObservedAt, readiness), () => {
+    switch (readiness.outcome) {
+      case 'WAITING':
+        return { action: 'RETURN_READINESS', recoveryAction: 'WAITING', result: readiness }
+      case 'BLOCKED':
+        return { action: 'RETURN_READINESS', recoveryAction: 'BLOCKED', result: readiness }
+      case 'BOUND':
+        return {
+          action: 'RETURN_READINESS',
+          recoveryAction: 'BOUND_SNAPSHOT',
+          result: { ...readiness, outcome: 'BOUND' },
+        }
+      case 'ALREADY_BOUND':
+        return {
+          action: 'ACTIVATE',
+          cycleId: readiness.cycle.identity.cycleId,
+          observedAt: readiness.observedAt,
+        }
+    }
+  })
+
+const selectPendingRecovery = (
+  state: DecodedCycleRecoveryState,
+  cycle: AutonomousCycle,
+): Result.Result<CycleRecoverySelection, CycleRecoveryFailure> => {
+  if (state.decisionDocument !== undefined) {
+    return Result.fail(
+      selectRecoveryFailure('state-evidence', 'pending cycle recovery does not accept decision evidence', {
+        cycleId: cycle.identity.cycleId,
+      }),
+    )
+  }
+  return state.readiness === undefined
+    ? Result.succeed({ action: 'READ_PUBLICATION', cycle })
+    : selectPendingReadiness(cycle, state.observedAt, state.readiness)
+}
+
+const selectDecodedCycleRecovery = (
+  state: DecodedCycleRecoveryState,
+): Result.Result<CycleRecoverySelection, CycleRecoveryFailure> => {
+  const { cycle } = state
+  if (cycle === undefined) {
+    if (state.readiness !== undefined || state.decisionDocument !== undefined) {
+      return Result.fail(
+        selectRecoveryFailure('evidence-without-cycle', 'recovery evidence requires an unfinished cycle'),
+      )
+    }
+    return Result.succeed({ action: 'DISCOVER' })
+  }
+  const cycleContext = validateRecoveryCycleContext(state, cycle)
+  if (Result.isFailure(cycleContext)) return Result.fail(cycleContext.failure)
+  if (cycle.state === CycleState.Active && cycle.bindings.decisionHash !== undefined) {
+    return selectDecisionBoundRecovery(state, cycle)
+  }
+  const deadlineOrProvenance = selectDeadlineOrProvenance(state, cycle)
+  if (deadlineOrProvenance !== undefined) return Result.succeed(deadlineOrProvenance)
+  switch (cycle.state) {
+    case CycleState.Active:
+      return selectActiveRecovery(state, cycle)
+    case CycleState.Pending:
+      return selectPendingRecovery(state, cycle)
+    default:
+      return Result.fail(
+        selectRecoveryFailure('state-evidence', `unsupported unfinished cycle state ${cycle.state}`, {
+          cycleId: cycle.identity.cycleId,
+          state: cycle.state,
+        }),
+      )
   }
 }
+
+export const selectCycleRecovery = (state: unknown): Result.Result<CycleRecoverySelection, CycleRecoveryFailure> =>
+  Result.flatMap(
+    Result.mapError(decodeCycleRecoveryStateResult(state), (cause) =>
+      decodeRecoveryStateFailure('decode', 'autonomous cycle recovery state is invalid', {}, cause),
+    ),
+    selectDecodedCycleRecovery,
+  )

--- a/services/bayn/src/cycle.test.ts
+++ b/services/bayn/src/cycle.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, test } from 'bun:test'
 
-import { Effect, Exit } from 'effect'
+import { Effect, Exit, Result, Schema } from 'effect'
 
 import type { MarketCalendarObservation, MarketCalendarSession } from './broker/alpaca'
 import {
   CycleState,
-  CycleTerminalReason,
-  cycleTerminalReasonForTargetPlanBlock,
+  CycleIdentitySchema,
+  cycleDraftMatches,
   decodeCycleDraft,
   decodeCycleIdentity,
   decodeCycleWindow,
@@ -18,6 +18,8 @@ import {
   makeCycleIdentity,
   makeCycleWindow,
   makeExecutionCalendarObservation,
+  signalSessionCloseAt,
+  type CycleConstructionFailure,
   type CycleExecutionPolicy,
   type CycleIdentityMaterial,
   type ExecutionCalendarObservation,
@@ -25,7 +27,7 @@ import {
 import { defaultExecutionModel } from './execution-model'
 import { canonicalHashV1 } from './hash'
 import type { SignalSessionRow } from './market-data'
-import { TargetPlanReason } from './target-planner'
+import { strictParseOptions } from './schemas'
 import type { IsoDate } from './types'
 
 const signalCalendarVersion = 'signal-XNYS-2026-v1'
@@ -40,6 +42,21 @@ const springDstSession: MarketCalendarSession = {
   closeAt: '2026-03-09T20:00:00.000Z',
 }
 
+const resultValue = <A, E>(result: Result.Result<A, E>): A => {
+  if (Result.isFailure(result)) throw result.failure
+  return result.success
+}
+const makeCycleDraftSuccess = (...args: Parameters<typeof makeCycleDraft>) => resultValue(makeCycleDraft(...args))
+const makeCycleExecutionPolicySuccess = (...args: Parameters<typeof makeCycleExecutionPolicy>) =>
+  resultValue(makeCycleExecutionPolicy(...args))
+const makeCycleExecutionPolicyFromModelSuccess = (...args: Parameters<typeof makeCycleExecutionPolicyFromModel>) =>
+  resultValue(makeCycleExecutionPolicyFromModel(...args))
+const makeCycleIdentitySuccess = (...args: Parameters<typeof makeCycleIdentity>) =>
+  resultValue(makeCycleIdentity(...args))
+const makeCycleWindowSuccess = (...args: Parameters<typeof makeCycleWindow>) => resultValue(makeCycleWindow(...args))
+const makeExecutionCalendarObservationSuccess = (...args: Parameters<typeof makeExecutionCalendarObservation>) =>
+  resultValue(makeExecutionCalendarObservation(...args))
+
 const signalSession = (
   sessionDate: IsoDate,
   closeTime = '16:00',
@@ -52,7 +69,7 @@ const signalSession = (
 })
 
 const executionCalendar = (session: MarketCalendarSession = springDstSession): ExecutionCalendarObservation =>
-  makeExecutionCalendarObservation({
+  makeExecutionCalendarObservationSuccess({
     schemaVersion: 'bayn.alpaca-market-calendar-observation.v1',
     source: 'alpaca-v2-calendar',
     ...session,
@@ -76,7 +93,7 @@ const makeExecutionPolicy = (
   submissionCutoffBeforeOpenMs = defaultSubmissionCutoffBeforeOpenMs,
   modelHash = strategyExecutionModelHash,
 ): CycleExecutionPolicy =>
-  makeCycleExecutionPolicy({
+  makeCycleExecutionPolicySuccess({
     schemaVersion: 'bayn.autonomous-cycle-execution-policy.v1',
     strategyExecutionModelHash: modelHash,
     submissionWindowMs,
@@ -107,7 +124,7 @@ describe('autonomous cycle identity and calendar', () => {
     if (defaultExecutionModel.schemaVersion !== 'bayn.execution-model.v2') {
       throw new Error('default execution model must be the causal v2 contract')
     }
-    const policy = makeCycleExecutionPolicyFromModel(defaultExecutionModel)
+    const policy = makeCycleExecutionPolicyFromModelSuccess(defaultExecutionModel)
 
     expect(policy).toMatchObject({
       schemaVersion: 'bayn.autonomous-cycle-execution-policy.v1',
@@ -125,45 +142,12 @@ describe('autonomous cycle identity and calendar', () => {
     )
   })
 
-  test('maps every blocked target-plan reason to its exact cycle terminal reason', () => {
-    expect([
-      cycleTerminalReasonForTargetPlanBlock(TargetPlanReason.SubmissionCutoffReached),
-      cycleTerminalReasonForTargetPlanBlock(TargetPlanReason.IdentityMismatch),
-      cycleTerminalReasonForTargetPlanBlock(TargetPlanReason.InputMismatch),
-      cycleTerminalReasonForTargetPlanBlock(TargetPlanReason.InputStale),
-      cycleTerminalReasonForTargetPlanBlock(TargetPlanReason.ReconciliationNotExact),
-      cycleTerminalReasonForTargetPlanBlock(TargetPlanReason.AccountNotActive),
-      cycleTerminalReasonForTargetPlanBlock(TargetPlanReason.UnknownOrder),
-      cycleTerminalReasonForTargetPlanBlock(TargetPlanReason.UnresolvedOrder),
-      cycleTerminalReasonForTargetPlanBlock(TargetPlanReason.BelowMinimumBuyNotional),
-      cycleTerminalReasonForTargetPlanBlock(TargetPlanReason.InsufficientBuyingPower),
-      cycleTerminalReasonForTargetPlanBlock(TargetPlanReason.NonPositiveEquity),
-      cycleTerminalReasonForTargetPlanBlock(TargetPlanReason.ShortPositionNotAllowed),
-    ]).toEqual([
-      CycleTerminalReason.MissedSubmission,
-      CycleTerminalReason.ProvenanceMismatch,
-      CycleTerminalReason.DataInvalid,
-      CycleTerminalReason.DataStale,
-      CycleTerminalReason.Reconciliation,
-      CycleTerminalReason.BrokerDisabled,
-      CycleTerminalReason.UnresolvedMutation,
-      CycleTerminalReason.UnresolvedMutation,
-      CycleTerminalReason.Risk,
-      CycleTerminalReason.Risk,
-      CycleTerminalReason.Risk,
-      CycleTerminalReason.Risk,
-    ])
-    expect(() => cycleTerminalReasonForTargetPlanBlock(TargetPlanReason.TargetsSatisfied)).toThrow(
-      'blocked target plan cannot use the no-trade reason',
-    )
-  })
-
   test('derives stable identities from all Signal, execution-calendar, account, and policy inputs', () => {
     const material = makeIdentityMaterial('2026-03-06')
-    const first = makeCycleIdentity(material)
-    const replay = makeCycleIdentity(structuredClone(material))
-    const otherAccount = makeCycleIdentity({ ...material, accountId: 'paper-account-2' })
-    const otherModel = makeCycleIdentity({
+    const first = makeCycleIdentitySuccess(material)
+    const replay = makeCycleIdentitySuccess(structuredClone(material))
+    const otherAccount = makeCycleIdentitySuccess({ ...material, accountId: 'paper-account-2' })
+    const otherModel = makeCycleIdentitySuccess({
       ...material,
       executionPolicy: makeExecutionPolicy(
         defaultSubmissionWindowMs,
@@ -175,13 +159,45 @@ describe('autonomous cycle identity and calendar', () => {
       ...springDstSession,
       closeAt: '2026-03-09T17:00:00.000Z',
     })
-    const otherExecutionCalendar = makeCycleIdentity(makeIdentityMaterial('2026-03-06', changedExecutionCalendar))
+    const otherExecutionCalendar = makeCycleIdentitySuccess(
+      makeIdentityMaterial('2026-03-06', changedExecutionCalendar),
+    )
 
     expect(replay).toEqual(first)
+    expect(first.cycleId).toBe('0abeb0fa91334072af88e44f66e88974c33c3b5261adb327c26719bd9110e0d9')
     expect(otherAccount.cycleId).not.toBe(first.cycleId)
     expect(otherModel.cycleId).not.toBe(first.cycleId)
     expect(otherModel.executionPolicy.executionPolicyHash).not.toBe(first.executionPolicy.executionPolicyHash)
     expect(otherExecutionCalendar.cycleId).not.toBe(first.cycleId)
+  })
+
+  test('rejects ill-formed Unicode at the cycle identity field before canonical hashing', () => {
+    const material = makeIdentityMaterial('2026-03-06')
+    const constructed = makeCycleIdentity({ ...material, accountId: '\ud800' })
+    expect(Result.isFailure(constructed)).toBe(true)
+    if (Result.isFailure(constructed)) {
+      expect(constructed.failure).toMatchObject({
+        _tag: 'CycleConstructionFailure',
+        operation: 'cycle-identity',
+        reason: 'decode',
+      })
+      expect(String(constructed.failure.cause)).toContain('["accountId"]')
+      expect(String(constructed.failure.cause)).toContain('well-formed Unicode')
+    }
+
+    const identity = makeCycleIdentitySuccess(material)
+    const decoded = Schema.decodeUnknownResult(
+      CycleIdentitySchema,
+      strictParseOptions,
+    )({
+      ...identity,
+      accountId: '\ud800',
+    })
+    expect(Result.isFailure(decoded)).toBe(true)
+    if (Result.isFailure(decoded)) {
+      expect(String(decoded.failure)).toContain('["accountId"]')
+      expect(String(decoded.failure)).toContain('well-formed Unicode')
+    }
   })
 
   test('binds only the selected #13136 session across different response ranges and evidence hashes', () => {
@@ -207,12 +223,12 @@ describe('autonomous cycle identity and calendar', () => {
       ],
       '2'.repeat(64),
     )
-    const narrowSelected = makeExecutionCalendarObservation({
+    const narrowSelected = makeExecutionCalendarObservationSuccess({
       schemaVersion: narrowResponse.schemaVersion,
       source: narrowResponse.source,
       ...narrowResponse.sessions[0]!,
     })
-    const broadSelected = makeExecutionCalendarObservation({
+    const broadSelected = makeExecutionCalendarObservationSuccess({
       schemaVersion: broadResponse.schemaVersion,
       source: broadResponse.source,
       ...broadResponse.sessions.find((session) => session.date === springDstSession.date)!,
@@ -220,14 +236,14 @@ describe('autonomous cycle identity and calendar', () => {
 
     expect(narrowResponse.normalizedResponseHash).not.toBe(broadResponse.normalizedResponseHash)
     expect(narrowSelected).toEqual(broadSelected)
-    expect(makeCycleIdentity(makeIdentityMaterial('2026-03-06', narrowSelected)).cycleId).toBe(
-      makeCycleIdentity(makeIdentityMaterial('2026-03-06', broadSelected)).cycleId,
+    expect(makeCycleIdentitySuccess(makeIdentityMaterial('2026-03-06', narrowSelected)).cycleId).toBe(
+      makeCycleIdentitySuccess(makeIdentityMaterial('2026-03-06', broadSelected)).cycleId,
     )
   })
 
   test('binds a decoded future broker-calendar observation across the spring DST boundary', () => {
     const observedExecutionCalendar = executionCalendar()
-    const window = makeCycleWindow(signalSession('2026-03-06'), observedExecutionCalendar, makeExecutionPolicy())
+    const window = makeCycleWindowSuccess(signalSession('2026-03-06'), observedExecutionCalendar, makeExecutionPolicy())
 
     expect(window).toEqual({
       schemaVersion: 'bayn.autonomous-cycle-window.v1',
@@ -244,7 +260,7 @@ describe('autonomous cycle identity and calendar', () => {
   })
 
   test('accepts observed holiday gaps and early closes without deriving the next session from Signal rows', () => {
-    const holidayWindow = makeCycleWindow(
+    const holidayWindow = makeCycleWindowSuccess(
       signalSession('2026-07-02'),
       executionCalendar({
         date: '2026-07-06',
@@ -256,7 +272,7 @@ describe('autonomous cycle identity and calendar', () => {
     expect(holidayWindow.executionSessionDate).toBe('2026-07-06')
     expect(holidayWindow.executionOpenAt).toBe('2026-07-06T13:30:00.000Z')
 
-    const earlyCloseWindow = makeCycleWindow(
+    const earlyCloseWindow = makeCycleWindowSuccess(
       signalSession('2026-11-25'),
       executionCalendar({
         date: '2026-11-27',
@@ -273,7 +289,7 @@ describe('autonomous cycle identity and calendar', () => {
     })
 
     expect(() =>
-      makeCycleWindow(
+      makeCycleWindowSuccess(
         signalSession('2026-03-09'),
         executionCalendar({
           date: '2026-03-10',
@@ -286,24 +302,36 @@ describe('autonomous cycle identity and calendar', () => {
   })
 
   test('enforces the one-day duration cap in the pure window factory', () => {
-    expect(() =>
-      makeCycleWindow(signalSession('2026-03-06'), executionCalendar(), makeExecutionPolicy(86_400_001)),
-    ).toThrow('submission window must be between one millisecond and one day')
-    expect(() =>
-      makeCycleWindow(
-        signalSession('2026-03-06'),
-        executionCalendar(),
-        makeExecutionPolicy(defaultSubmissionWindowMs, 86_400_001),
-      ),
-    ).toThrow('broker cutoff lead must be between one millisecond and one day')
+    const excessiveWindow = makeCycleWindow(signalSession('2026-03-06'), executionCalendar(), {
+      submissionWindowMs: 86_400_001,
+      submissionCutoffBeforeOpenMs: defaultSubmissionCutoffBeforeOpenMs,
+    })
+    const excessiveLead = makeCycleWindow(signalSession('2026-03-06'), executionCalendar(), {
+      submissionWindowMs: defaultSubmissionWindowMs,
+      submissionCutoffBeforeOpenMs: 86_400_001,
+    })
+    expect(Result.isFailure(excessiveWindow)).toBe(true)
+    expect(Result.isFailure(excessiveWindow) ? excessiveWindow.failure : null).toMatchObject({
+      _tag: 'CycleConstructionFailure',
+      operation: 'cycle-window',
+      reason: 'duration',
+      message: 'submission window must be between one millisecond and one day',
+    })
+    expect(Result.isFailure(excessiveLead)).toBe(true)
+    expect(Result.isFailure(excessiveLead) ? excessiveLead.failure : null).toMatchObject({
+      _tag: 'CycleConstructionFailure',
+      operation: 'cycle-window',
+      reason: 'duration',
+      message: 'broker cutoff lead must be between one millisecond and one day',
+    })
   })
 
   test('rejects forged execution observations, UTC drift, and identity provenance mismatches', async () => {
     const observedExecutionCalendar = executionCalendar()
     const executionPolicy = makeExecutionPolicy()
     const material = makeIdentityMaterial('2026-03-06', observedExecutionCalendar, executionPolicy)
-    const identity = makeCycleIdentity(material)
-    const window = makeCycleWindow(signalSession('2026-03-06'), observedExecutionCalendar, executionPolicy)
+    const identity = makeCycleIdentitySuccess(material)
+    const window = makeCycleWindowSuccess(signalSession('2026-03-06'), observedExecutionCalendar, executionPolicy)
 
     const forgedObservation = await Effect.runPromiseExit(
       decodeExecutionCalendarObservation({
@@ -322,7 +350,7 @@ describe('autonomous cycle identity and calendar', () => {
     const forgedDraft = await Effect.runPromiseExit(
       decodeCycleDraft({
         schemaVersion: 'bayn.autonomous-cycle.v1',
-        identity: makeCycleIdentity({ ...material, executionCalendarHash: forgedHash }),
+        identity: makeCycleIdentitySuccess({ ...material, executionCalendarHash: forgedHash }),
         window: { ...window, executionCalendarHash: forgedHash },
       }),
     )
@@ -331,16 +359,16 @@ describe('autonomous cycle identity and calendar', () => {
     const forgedIdentity = await Effect.runPromiseExit(decodeCycleIdentity({ ...identity, cycleId: 'f'.repeat(64) }))
     expect(Exit.isFailure(forgedIdentity)).toBe(true)
 
-    const otherSignalCalendarWindow = makeCycleWindow(
+    const otherSignalCalendarWindow = makeCycleWindowSuccess(
       signalSession('2026-03-06', '16:00', 'signal-XNYS-2026-other'),
       observedExecutionCalendar,
       executionPolicy,
     )
-    expect(() => makeCycleDraft(identity, otherSignalCalendarWindow)).toThrow(
-      'cycle identity and window must bind the same Signal calendar',
+    expect(() => makeCycleDraftSuccess(identity, otherSignalCalendarWindow)).toThrow(
+      'cycle identity and window bindings are incoherent',
     )
 
-    const otherExecutionCalendarWindow = makeCycleWindow(
+    const otherExecutionCalendarWindow = makeCycleWindowSuccess(
       signalSession('2026-03-06'),
       executionCalendar({
         ...springDstSession,
@@ -348,21 +376,21 @@ describe('autonomous cycle identity and calendar', () => {
       }),
       executionPolicy,
     )
-    expect(() => makeCycleDraft(identity, otherExecutionCalendarWindow)).toThrow(
-      'cycle identity and window must bind the same execution calendar observation',
+    expect(() => makeCycleDraftSuccess(identity, otherExecutionCalendarWindow)).toThrow(
+      'cycle identity and window bindings are incoherent',
     )
 
     expect(() =>
-      makeCycleDraft(
-        makeCycleIdentity(
+      makeCycleDraftSuccess(
+        makeCycleIdentitySuccess(
           makeIdentityMaterial('2026-03-06', observedExecutionCalendar, makeExecutionPolicy(15 * 60 * 1_000)),
         ),
         window,
       ),
-    ).toThrow('cycle window must match the bound execution policy')
+    ).toThrow('cycle identity and window bindings are incoherent')
     expect(() =>
-      makeCycleDraft(
-        makeCycleIdentity(
+      makeCycleDraftSuccess(
+        makeCycleIdentitySuccess(
           makeIdentityMaterial(
             '2026-03-06',
             observedExecutionCalendar,
@@ -371,12 +399,96 @@ describe('autonomous cycle identity and calendar', () => {
         ),
         window,
       ),
-    ).toThrow('cycle broker cutoff must match the bound execution policy')
+    ).toThrow('cycle identity and window bindings are incoherent')
 
     expect(isCycleStateTransitionAllowed(CycleState.Pending, CycleState.Active)).toBe(true)
     expect(isCycleStateTransitionAllowed(CycleState.Active, CycleState.Blocked)).toBe(true)
     expect(isCycleStateTransitionAllowed(CycleState.Active, CycleState.NoTrade)).toBe(true)
     expect(isCycleStateTransitionAllowed(CycleState.Active, CycleState.Completed)).toBe(true)
     expect(isCycleStateTransitionAllowed(CycleState.Blocked, CycleState.Blocked)).toBe(false)
+  })
+
+  test('treats non-canonicalizable typed draft material as a non-match without throwing', () => {
+    const observedExecutionCalendar = executionCalendar()
+    const executionPolicy = makeExecutionPolicy()
+    const identity = makeCycleIdentitySuccess(
+      makeIdentityMaterial('2026-03-06', observedExecutionCalendar, executionPolicy),
+    )
+    const window = makeCycleWindowSuccess(signalSession('2026-03-06'), observedExecutionCalendar, executionPolicy)
+    const valid = makeCycleDraftSuccess(identity, window)
+    const cyclic = Object.assign({ ...valid }, { self: undefined as unknown })
+    cyclic.self = cyclic
+
+    expect(cycleDraftMatches(valid, cyclic)).toBe(false)
+  })
+
+  test('returns closed tagged failures for every reachable constructor invariant', () => {
+    const observedExecutionCalendar = executionCalendar()
+    const executionPolicy = makeExecutionPolicy()
+    const identity = makeCycleIdentitySuccess(
+      makeIdentityMaterial('2026-03-06', observedExecutionCalendar, executionPolicy),
+    )
+    const window = makeCycleWindowSuccess(signalSession('2026-03-06'), observedExecutionCalendar, executionPolicy)
+    const otherSignalWindow = makeCycleWindowSuccess(
+      signalSession('2026-03-06', '16:00', 'signal-calendar-other'),
+      observedExecutionCalendar,
+      executionPolicy,
+    )
+    const sameDayCalendar = executionCalendar({
+      date: '2026-03-06',
+      openAt: '2026-03-06T14:30:00.000Z',
+      closeAt: '2026-03-06T21:00:00.000Z',
+    })
+    const cases: ReadonlyArray<readonly [string, string, Result.Result<unknown, CycleConstructionFailure>]> = [
+      ['signal-close', 'decode', signalSessionCloseAt({})],
+      ['signal-close', 'market-time', signalSessionCloseAt(signalSession('2026-03-08', '02:30'))],
+      ['execution-policy', 'decode', makeCycleExecutionPolicy({})],
+      ['execution-policy', 'decode', makeCycleExecutionPolicyFromModel({})],
+      ['execution-calendar', 'decode', makeExecutionCalendarObservation({})],
+      ['cycle-identity', 'decode', makeCycleIdentity({})],
+      [
+        'cycle-identity',
+        'session-order',
+        makeCycleIdentity(makeIdentityMaterial('2026-03-06', sameDayCalendar, executionPolicy)),
+      ],
+      ['cycle-window', 'decode', makeCycleWindow({}, observedExecutionCalendar, executionPolicy)],
+      [
+        'cycle-window',
+        'session-order',
+        makeCycleWindow(signalSession('2026-03-09'), observedExecutionCalendar, executionPolicy),
+      ],
+      [
+        'cycle-window',
+        'market-time',
+        makeCycleWindow(signalSession('2026-03-08', '02:30'), observedExecutionCalendar, executionPolicy),
+      ],
+      [
+        'cycle-window',
+        'submission-window',
+        makeCycleWindow(
+          signalSession('2026-03-09'),
+          executionCalendar({
+            date: '2026-03-10',
+            openAt: '2026-03-10T13:30:00.000Z',
+            closeAt: '2026-03-10T20:00:00.000Z',
+          }),
+          makeExecutionPolicy(18 * 60 * 60 * 1_000),
+        ),
+      ],
+      ['cycle-draft', 'decode', makeCycleDraft({}, window)],
+      ['cycle-draft', 'decode', makeCycleDraft(identity, {})],
+      ['cycle-draft', 'binding', makeCycleDraft(identity, otherSignalWindow)],
+    ] as const
+
+    for (const [operation, reason, result] of cases) {
+      expect(Result.isFailure(result)).toBe(true)
+      if (Result.isFailure(result)) {
+        expect(result.failure).toMatchObject({
+          _tag: 'CycleConstructionFailure',
+          operation,
+          reason,
+        })
+      }
+    }
   })
 })

--- a/services/bayn/src/cycle.ts
+++ b/services/bayn/src/cycle.ts
@@ -1,9 +1,8 @@
-import { DateTime, Schema } from 'effect'
+import { Data, DateTime, Result, Schema } from 'effect'
 
 import type { MarketCalendarObservation, MarketCalendarSession } from './broker/alpaca'
 import { canonicalHashV1 } from './hash'
-import type { SignalSessionRow } from './market-data'
-import type { CausalProtocol } from './protocol'
+import { ExecutionModelV2Schema } from './protocol'
 import {
   IsoDateSchema,
   PositiveIntegerSchema,
@@ -12,12 +11,17 @@ import {
   UtcInstantSchema,
   strictParseOptions,
 } from './schemas'
-import { TargetPlanReason } from './target-planner'
-
 const cycleTimeZone = 'America/New_York' as const
 const autonomousCycleSubmissionWindowMs = 30 * 60_000
 const SubmissionWindowMsSchema = PositiveIntegerSchema.check(Schema.isLessThanOrEqualTo(86_400_000))
 const maximumSubmissionDurationMs = 86_400_000
+
+const canonicalHashResult = (value: unknown): Result.Result<string, unknown> => Result.try(() => canonicalHashV1(value))
+
+const canonicalHashMatches = (value: unknown, expectedHash: string): boolean => {
+  const hash = canonicalHashResult(value)
+  return Result.isSuccess(hash) && hash.success === expectedHash
+}
 
 const localMarketTimeToUtcOption = (sessionDate: string, marketTime: string): string | undefined => {
   const match = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})$/.exec(`${sessionDate}T${marketTime}`)
@@ -39,14 +43,6 @@ const localMarketTimeToUtcOption = (sessionDate: string, marketTime: string): st
   return zoned._tag === 'None' ? undefined : DateTime.toDateUtc(zoned.value).toISOString()
 }
 
-const localMarketTimeToUtc = (sessionDate: string, marketTime: string): string => {
-  const instant = localMarketTimeToUtcOption(sessionDate, marketTime)
-  if (instant === undefined) {
-    throw new TypeError(`${sessionDate} ${marketTime} is not a valid ${cycleTimeZone} market time`)
-  }
-  return instant
-}
-
 export enum CycleState {
   Pending = 'PENDING',
   Active = 'ACTIVE',
@@ -55,6 +51,107 @@ export enum CycleState {
   Blocked = 'BLOCKED',
 }
 export type CycleCompletionState = CycleState.Completed | CycleState.NoTrade
+
+interface CycleDraftConstructionIssue {
+  readonly operation: 'cycle-draft'
+  readonly reason: 'binding' | 'decode'
+}
+
+interface CycleIdentityConstructionIssue {
+  readonly operation: 'cycle-identity'
+  readonly reason: 'decode' | 'hash' | 'session-order'
+}
+
+interface CycleWindowConstructionIssue {
+  readonly operation: 'cycle-window'
+  readonly reason: 'decode' | 'duration' | 'market-time' | 'session-order' | 'submission-window'
+}
+
+interface ExecutionCalendarConstructionIssue {
+  readonly operation: 'execution-calendar'
+  readonly reason: 'decode' | 'hash'
+}
+
+interface ExecutionPolicyConstructionIssue {
+  readonly operation: 'execution-policy'
+  readonly reason: 'decode' | 'hash'
+}
+
+interface SignalCloseConstructionIssue {
+  readonly operation: 'signal-close'
+  readonly reason: 'decode' | 'market-time'
+}
+
+type CycleConstructionIssue =
+  | CycleDraftConstructionIssue
+  | CycleIdentityConstructionIssue
+  | CycleWindowConstructionIssue
+  | ExecutionCalendarConstructionIssue
+  | ExecutionPolicyConstructionIssue
+  | SignalCloseConstructionIssue
+
+interface CycleConstructionFailureDetails {
+  readonly message: string
+  readonly facts: Readonly<Record<string, unknown>>
+  readonly cause?: unknown
+}
+
+const CycleConstructionFailure = Data.TaggedError('CycleConstructionFailure')<
+  CycleConstructionIssue & CycleConstructionFailureDetails
+>
+export type CycleConstructionFailure = InstanceType<typeof CycleConstructionFailure>
+
+type CycleConstructionReason<Operation extends CycleConstructionIssue['operation']> = Extract<
+  CycleConstructionIssue,
+  { readonly operation: Operation }
+>['reason']
+
+const cycleDraftFailure = (
+  reason: CycleConstructionReason<'cycle-draft'>,
+  message: string,
+  facts: Readonly<Record<string, unknown>> = {},
+  cause?: unknown,
+): CycleConstructionFailure => new CycleConstructionFailure({ operation: 'cycle-draft', reason, message, facts, cause })
+
+const cycleIdentityFailure = (
+  reason: CycleConstructionReason<'cycle-identity'>,
+  message: string,
+  facts: Readonly<Record<string, unknown>> = {},
+  cause?: unknown,
+): CycleConstructionFailure =>
+  new CycleConstructionFailure({ operation: 'cycle-identity', reason, message, facts, cause })
+
+const cycleWindowFailure = (
+  reason: CycleConstructionReason<'cycle-window'>,
+  message: string,
+  facts: Readonly<Record<string, unknown>> = {},
+  cause?: unknown,
+): CycleConstructionFailure =>
+  new CycleConstructionFailure({ operation: 'cycle-window', reason, message, facts, cause })
+
+const executionCalendarFailure = (
+  reason: CycleConstructionReason<'execution-calendar'>,
+  message: string,
+  facts: Readonly<Record<string, unknown>> = {},
+  cause?: unknown,
+): CycleConstructionFailure =>
+  new CycleConstructionFailure({ operation: 'execution-calendar', reason, message, facts, cause })
+
+const executionPolicyFailure = (
+  reason: CycleConstructionReason<'execution-policy'>,
+  message: string,
+  facts: Readonly<Record<string, unknown>> = {},
+  cause?: unknown,
+): CycleConstructionFailure =>
+  new CycleConstructionFailure({ operation: 'execution-policy', reason, message, facts, cause })
+
+const signalCloseFailure = (
+  reason: CycleConstructionReason<'signal-close'>,
+  message: string,
+  facts: Readonly<Record<string, unknown>> = {},
+  cause?: unknown,
+): CycleConstructionFailure =>
+  new CycleConstructionFailure({ operation: 'signal-close', reason, message, facts, cause })
 
 export enum CycleTerminalReason {
   MissedPublication = 'BLOCKED_MISSED_PUBLICATION_DEADLINE',
@@ -70,33 +167,6 @@ export enum CycleTerminalReason {
   UnresolvedMutation = 'BLOCKED_UNRESOLVED_MUTATION',
   Reconciliation = 'BLOCKED_RECONCILIATION',
   Risk = 'BLOCKED_RISK',
-}
-
-export const cycleTerminalReasonForTargetPlanBlock = (reason: TargetPlanReason): CycleTerminalReason => {
-  switch (reason) {
-    case TargetPlanReason.SubmissionCutoffReached:
-      return CycleTerminalReason.MissedSubmission
-    case TargetPlanReason.IdentityMismatch:
-      return CycleTerminalReason.ProvenanceMismatch
-    case TargetPlanReason.InputMismatch:
-      return CycleTerminalReason.DataInvalid
-    case TargetPlanReason.InputStale:
-      return CycleTerminalReason.DataStale
-    case TargetPlanReason.ReconciliationNotExact:
-      return CycleTerminalReason.Reconciliation
-    case TargetPlanReason.AccountNotActive:
-      return CycleTerminalReason.BrokerDisabled
-    case TargetPlanReason.UnknownOrder:
-    case TargetPlanReason.UnresolvedOrder:
-      return CycleTerminalReason.UnresolvedMutation
-    case TargetPlanReason.BelowMinimumBuyNotional:
-    case TargetPlanReason.InsufficientBuyingPower:
-    case TargetPlanReason.NonPositiveEquity:
-    case TargetPlanReason.ShortPositionNotAllowed:
-      return CycleTerminalReason.Risk
-    case TargetPlanReason.TargetsSatisfied:
-      throw new TypeError('blocked target plan cannot use the no-trade reason')
-  }
 }
 
 const ExecutionCalendarObservationMaterialBase = Schema.Struct({
@@ -147,7 +217,7 @@ const executionCalendarObservationIssues = (
   observation: typeof ExecutionCalendarObservationBase.Type,
 ): Schema.FilterIssue[] => {
   const issues = executionCalendarMaterialIssues(observation)
-  if (observation.executionCalendarHash !== canonicalHashV1(executionCalendarMaterialOf(observation))) {
+  if (!canonicalHashMatches(executionCalendarMaterialOf(observation), observation.executionCalendarHash)) {
     issues.push({
       path: ['executionCalendarHash'],
       issue: 'must match the selected broker-calendar session',
@@ -163,11 +233,11 @@ export type ExecutionCalendarObservation = typeof ExecutionCalendarObservationSc
 export type SelectedExecutionCalendarSession = Pick<MarketCalendarObservation, 'schemaVersion' | 'source'> &
   MarketCalendarSession
 
-const decodeExecutionCalendarMaterialSync = Schema.decodeUnknownSync(
+const decodeExecutionCalendarMaterialResult = Schema.decodeUnknownResult(
   ExecutionCalendarObservationMaterialSchema,
   strictParseOptions,
 )
-const decodeExecutionCalendarObservationSync = Schema.decodeUnknownSync(
+const decodeExecutionCalendarObservationResult = Schema.decodeUnknownResult(
   ExecutionCalendarObservationSchema,
   strictParseOptions,
 )
@@ -185,14 +255,14 @@ const CycleExecutionPolicyBase = Schema.Struct({
   executionPolicyHash: Sha256Schema,
 })
 
-export const CycleExecutionPolicySchema = CycleExecutionPolicyBase.check(
-  Schema.makeFilter((policy) => {
-    const { executionPolicyHash, ...material } = policy
-    return executionPolicyHash === canonicalHashV1(material)
-      ? []
-      : [{ path: ['executionPolicyHash'], issue: 'must match the canonical execution policy material' }]
-  }),
-)
+const cycleExecutionPolicyIssues = (policy: typeof CycleExecutionPolicyBase.Type): readonly Schema.FilterIssue[] => {
+  const { executionPolicyHash, ...material } = policy
+  return canonicalHashMatches(material, executionPolicyHash)
+    ? []
+    : [{ path: ['executionPolicyHash'], issue: 'must match the canonical execution policy material' }]
+}
+
+export const CycleExecutionPolicySchema = CycleExecutionPolicyBase.check(Schema.makeFilter(cycleExecutionPolicyIssues))
 export type CycleExecutionPolicy = typeof CycleExecutionPolicySchema.Type
 
 const CycleIdentityMaterialSchema = Schema.Struct({
@@ -216,19 +286,19 @@ const CycleIdentityBase = Schema.Struct({
   cycleId: Sha256Schema,
 })
 
-export const CycleIdentitySchema = CycleIdentityBase.check(
-  Schema.makeFilter((identity) => {
-    const issues: Schema.FilterIssue[] = []
-    const { cycleId, ...material } = identity
-    if (identity.signalSessionDate >= identity.executionSessionDate) {
-      issues.push({ path: ['executionSessionDate'], issue: 'must follow the Signal session' })
-    }
-    if (cycleId !== canonicalHashV1(material)) {
-      issues.push({ path: ['cycleId'], issue: 'must match the canonical cycle identity material' })
-    }
-    return issues
-  }),
-)
+const cycleIdentityIssues = (identity: typeof CycleIdentityBase.Type): readonly Schema.FilterIssue[] => {
+  const issues: Schema.FilterIssue[] = []
+  const { cycleId, ...material } = identity
+  if (identity.signalSessionDate >= identity.executionSessionDate) {
+    issues.push({ path: ['executionSessionDate'], issue: 'must follow the Signal session' })
+  }
+  if (!canonicalHashMatches(material, cycleId)) {
+    issues.push({ path: ['cycleId'], issue: 'must match the canonical cycle identity material' })
+  }
+  return issues
+}
+
+export const CycleIdentitySchema = CycleIdentityBase.check(Schema.makeFilter(cycleIdentityIssues))
 export type CycleIdentity = typeof CycleIdentitySchema.Type
 
 const CycleWindowBase = Schema.Struct({
@@ -242,30 +312,30 @@ const CycleWindowBase = Schema.Struct({
   submissionCutoffAt: UtcInstantSchema,
 })
 
-export const CycleWindowSchema = CycleWindowBase.check(
-  Schema.makeFilter((window) => {
-    const issues = executionCalendarObservationIssues(window)
-    if (window.signalSessionDate >= window.executionSessionDate) {
-      issues.push({ path: ['executionSessionDate'], issue: 'must follow the Signal session' })
-    }
-    if (window.signalCloseAt >= window.submissionOpenAt) {
-      issues.push({ path: ['submissionOpenAt'], issue: 'must follow the Signal session close' })
-    }
-    if (window.publicationDeadlineAt !== window.submissionOpenAt) {
-      issues.push({ path: ['publicationDeadlineAt'], issue: 'must equal the pre-open submission window' })
-    }
-    if (window.submissionOpenAt >= window.submissionCutoffAt) {
-      issues.push({ path: ['submissionCutoffAt'], issue: 'must follow the submission window open' })
-    }
-    if (window.submissionCutoffAt >= window.executionOpenAt) {
-      issues.push({ path: ['executionOpenAt'], issue: 'must follow the broker submission cutoff' })
-    }
-    if (window.executionOpenAt >= window.executionCloseAt) {
-      issues.push({ path: ['executionCloseAt'], issue: 'must follow the execution session open' })
-    }
-    return issues
-  }),
-)
+const cycleWindowIssues = (window: typeof CycleWindowBase.Type): readonly Schema.FilterIssue[] => {
+  const issues = executionCalendarObservationIssues(window)
+  if (window.signalSessionDate >= window.executionSessionDate) {
+    issues.push({ path: ['executionSessionDate'], issue: 'must follow the Signal session' })
+  }
+  if (window.signalCloseAt >= window.submissionOpenAt) {
+    issues.push({ path: ['submissionOpenAt'], issue: 'must follow the Signal session close' })
+  }
+  if (window.publicationDeadlineAt !== window.submissionOpenAt) {
+    issues.push({ path: ['publicationDeadlineAt'], issue: 'must equal the pre-open submission window' })
+  }
+  if (window.submissionOpenAt >= window.submissionCutoffAt) {
+    issues.push({ path: ['submissionCutoffAt'], issue: 'must follow the submission window open' })
+  }
+  if (window.submissionCutoffAt >= window.executionOpenAt) {
+    issues.push({ path: ['executionOpenAt'], issue: 'must follow the broker submission cutoff' })
+  }
+  if (window.executionOpenAt >= window.executionCloseAt) {
+    issues.push({ path: ['executionCloseAt'], issue: 'must follow the execution session open' })
+  }
+  return issues
+}
+
+export const CycleWindowSchema = CycleWindowBase.check(Schema.makeFilter(cycleWindowIssues))
 export type CycleWindow = typeof CycleWindowSchema.Type
 
 const CycleDraftBase = Schema.Struct({
@@ -394,125 +464,398 @@ export const AutonomousCycleSchema = AutonomousCycleBase.check(
 )
 export type AutonomousCycle = typeof AutonomousCycleSchema.Type
 
-type SignalCycleSessionRow = Pick<SignalSessionRow, 'calendar_version' | 'session_date' | 'close_time' | 'timezone'>
+type AutonomousCycleVariantBase = Omit<AutonomousCycle, 'bindings' | 'state' | 'terminalAt' | 'terminalReason'>
+type PendingCycleBindings =
+  | { readonly snapshotId?: undefined; readonly decisionHash?: undefined }
+  | { readonly snapshotId: string; readonly decisionHash?: undefined }
+type TerminalCycleBindings = PendingCycleBindings | { readonly snapshotId: string; readonly decisionHash: string }
+export type PendingCycle = AutonomousCycleVariantBase & {
+  readonly state: CycleState.Pending
+  readonly bindings: PendingCycleBindings
+  readonly terminalReason?: undefined
+  readonly terminalAt?: undefined
+}
+export type ActiveUnboundCycle = AutonomousCycleVariantBase & {
+  readonly state: CycleState.Active
+  readonly bindings: { readonly snapshotId: string; readonly decisionHash?: undefined }
+  readonly terminalReason?: undefined
+  readonly terminalAt?: undefined
+}
+export type ActiveDecisionBoundCycle = AutonomousCycleVariantBase & {
+  readonly state: CycleState.Active
+  readonly bindings: { readonly snapshotId: string; readonly decisionHash: string }
+  readonly terminalReason?: undefined
+  readonly terminalAt?: undefined
+}
+export type CompletedCycle = AutonomousCycleVariantBase & {
+  readonly state: CycleCompletionState
+  readonly bindings: { readonly snapshotId: string; readonly decisionHash: string }
+  readonly terminalReason?: undefined
+  readonly terminalAt: string
+}
+export type BlockedCycle = AutonomousCycleVariantBase & {
+  readonly state: CycleState.Blocked
+  readonly bindings: TerminalCycleBindings
+  readonly terminalReason: CycleTerminalReason
+  readonly terminalAt: string
+}
+export type CorrelatedAutonomousCycle =
+  | PendingCycle
+  | ActiveUnboundCycle
+  | ActiveDecisionBoundCycle
+  | CompletedCycle
+  | BlockedCycle
 
-export const signalSessionCloseAt = (signalSession: SignalCycleSessionRow): string => {
-  if (signalSession.timezone !== cycleTimeZone) {
-    throw new TypeError('Signal session timezone must be America/New_York')
-  }
-  return localMarketTimeToUtc(signalSession.session_date, signalSession.close_time)
+const SignalCycleSessionSchema = Schema.Struct({
+  calendar_version: StrictNonEmptyStringSchema,
+  session_date: IsoDateSchema,
+  close_time: Schema.String.check(Schema.isPattern(/^(?:[01]\d|2[0-3]):[0-5]\d$/)),
+  timezone: Schema.Literal(cycleTimeZone),
+})
+
+const SelectedExecutionCalendarSessionSchema = Schema.Struct({
+  schemaVersion: Schema.Literal('bayn.alpaca-market-calendar-observation.v1'),
+  source: Schema.Literal('alpaca-v2-calendar'),
+  date: IsoDateSchema,
+  openAt: UtcInstantSchema,
+  closeAt: UtcInstantSchema,
+})
+
+const CycleWindowPolicyInputSchema = Schema.Union([
+  CycleExecutionPolicySchema,
+  Schema.Struct({
+    submissionWindowMs: Schema.Number,
+    submissionCutoffBeforeOpenMs: Schema.Number,
+  }),
+])
+
+const decodeSignalCycleSessionResult = Schema.decodeUnknownResult(SignalCycleSessionSchema, strictParseOptions)
+const decodeSelectedExecutionCalendarSessionResult = Schema.decodeUnknownResult(
+  SelectedExecutionCalendarSessionSchema,
+  strictParseOptions,
+)
+const decodeCycleWindowPolicyInputResult = Schema.decodeUnknownResult(CycleWindowPolicyInputSchema, strictParseOptions)
+const decodeCycleExecutionPolicyMaterialResult = Schema.decodeUnknownResult(
+  CycleExecutionPolicyMaterialSchema,
+  strictParseOptions,
+)
+const decodeExecutionModelV2Result = Schema.decodeUnknownResult(ExecutionModelV2Schema, strictParseOptions)
+const decodeCycleExecutionPolicyResult = Schema.decodeUnknownResult(CycleExecutionPolicySchema, strictParseOptions)
+const decodeCycleIdentityMaterialResult = Schema.decodeUnknownResult(CycleIdentityMaterialSchema, strictParseOptions)
+const decodeCycleIdentityResult = Schema.decodeUnknownResult(CycleIdentitySchema, strictParseOptions)
+const decodeCycleWindowResult = Schema.decodeUnknownResult(CycleWindowSchema, strictParseOptions)
+const decodeCycleDraftResult = Schema.decodeUnknownResult(CycleDraftSchema, strictParseOptions)
+
+type SignalCycleSession = typeof SignalCycleSessionSchema.Type
+type CycleWindowPolicyInput = typeof CycleWindowPolicyInputSchema.Type
+
+interface DecodedCycleWindowInput {
+  readonly signal: SignalCycleSession
+  readonly calendar: ExecutionCalendarObservation
+  readonly policy: CycleWindowPolicyInput
 }
 
-export const makeCycleExecutionPolicy = (material: CycleExecutionPolicyMaterial): CycleExecutionPolicy => ({
-  ...material,
-  executionPolicyHash: canonicalHashV1(material),
-})
+interface DerivedCycleWindowTimes {
+  readonly signalCloseAt: string
+  readonly submissionOpenAt: string
+  readonly submissionCutoffAt: string
+}
+
+export const signalSessionCloseAt = (signalSession: unknown): Result.Result<string, CycleConstructionFailure> =>
+  Result.flatMap(
+    Result.mapError(decodeSignalCycleSessionResult(signalSession), (cause) =>
+      signalCloseFailure('decode', 'Signal session must contain a canonical America/New_York close', {}, cause),
+    ),
+    (decoded) => {
+      const instant = localMarketTimeToUtcOption(decoded.session_date, decoded.close_time)
+      return instant === undefined
+        ? Result.fail(
+            signalCloseFailure(
+              'market-time',
+              `${decoded.session_date} ${decoded.close_time} is not a valid ${cycleTimeZone} market time`,
+              { sessionDate: decoded.session_date, marketTime: decoded.close_time, timeZone: cycleTimeZone },
+            ),
+          )
+        : Result.succeed(instant)
+    },
+  )
+
+export const makeCycleExecutionPolicy = (
+  material: unknown,
+): Result.Result<CycleExecutionPolicy, CycleConstructionFailure> =>
+  Result.flatMap(
+    Result.mapError(decodeCycleExecutionPolicyMaterialResult(material), (cause) =>
+      executionPolicyFailure('decode', 'cycle execution policy material is invalid', {}, cause),
+    ),
+    (decoded) =>
+      Result.flatMap(
+        Result.try({
+          try: () => ({ ...decoded, executionPolicyHash: canonicalHashV1(decoded) }),
+          catch: (cause) =>
+            executionPolicyFailure('hash', 'cycle execution policy material is not canonicalizable', {}, cause),
+        }),
+        (policy) =>
+          Result.mapError(decodeCycleExecutionPolicyResult(policy), (cause) =>
+            executionPolicyFailure('decode', 'cycle execution policy is invalid', {}, cause),
+          ),
+      ),
+  )
 
 export const makeCycleExecutionPolicyFromModel = (
-  executionModel: CausalProtocol['executionModel'],
-): CycleExecutionPolicy =>
-  makeCycleExecutionPolicy({
-    schemaVersion: 'bayn.autonomous-cycle-execution-policy.v1',
-    strategyExecutionModelHash: canonicalHashV1(executionModel),
-    submissionWindowMs: autonomousCycleSubmissionWindowMs,
-    submissionCutoffBeforeOpenMs: executionModel.order.submissionCutoffLeadMinutes * 60_000,
-  })
+  executionModel: unknown,
+): Result.Result<CycleExecutionPolicy, CycleConstructionFailure> =>
+  Result.flatMap(
+    Result.mapError(decodeExecutionModelV2Result(executionModel), (cause) =>
+      executionPolicyFailure('decode', 'strategy execution model is invalid', {}, cause),
+    ),
+    (decodedModel) =>
+      Result.flatMap(
+        Result.try({
+          try: () => canonicalHashV1(decodedModel),
+          catch: (cause) =>
+            executionPolicyFailure('hash', 'strategy execution model is not canonicalizable', {}, cause),
+        }),
+        (strategyExecutionModelHash) =>
+          makeCycleExecutionPolicy({
+            schemaVersion: 'bayn.autonomous-cycle-execution-policy.v1',
+            strategyExecutionModelHash,
+            submissionWindowMs: autonomousCycleSubmissionWindowMs,
+            submissionCutoffBeforeOpenMs: decodedModel.order.submissionCutoffLeadMinutes * 60_000,
+          }),
+      ),
+  )
 
 export const makeExecutionCalendarObservation = (
-  session: SelectedExecutionCalendarSession,
-): ExecutionCalendarObservation => {
-  let material: ExecutionCalendarObservationMaterial
-  try {
-    material = decodeExecutionCalendarMaterialSync({
-      executionCalendarSchemaVersion: session.schemaVersion,
-      executionCalendarSource: session.source,
-      executionSessionDate: session.date,
-      executionOpenAt: session.openAt,
-      executionCloseAt: session.closeAt,
-    })
-  } catch {
-    throw new TypeError('broker calendar session must contain ordered UTC instants for its session date')
-  }
-  return { ...material, executionCalendarHash: canonicalHashV1(material) }
+  session: unknown,
+): Result.Result<ExecutionCalendarObservation, CycleConstructionFailure> =>
+  Result.flatMap(
+    Result.mapError(decodeSelectedExecutionCalendarSessionResult(session), (cause) =>
+      executionCalendarFailure(
+        'decode',
+        'broker calendar session must contain ordered UTC instants for its session date',
+        {},
+        cause,
+      ),
+    ),
+    (decoded) => {
+      const materialResult = decodeExecutionCalendarMaterialResult({
+        executionCalendarSchemaVersion: decoded.schemaVersion,
+        executionCalendarSource: decoded.source,
+        executionSessionDate: decoded.date,
+        executionOpenAt: decoded.openAt,
+        executionCloseAt: decoded.closeAt,
+      })
+      return Result.flatMap(
+        Result.mapError(materialResult, (cause) =>
+          executionCalendarFailure(
+            'decode',
+            'broker calendar session must contain ordered UTC instants for its session date',
+            { sessionDate: decoded.date },
+            cause,
+          ),
+        ),
+        (material) =>
+          Result.flatMap(
+            Result.try({
+              try: () => ({ ...material, executionCalendarHash: canonicalHashV1(material) }),
+              catch: (cause) =>
+                executionCalendarFailure(
+                  'hash',
+                  'broker calendar session is not canonicalizable',
+                  { sessionDate: decoded.date },
+                  cause,
+                ),
+            }),
+            (observation) =>
+              Result.mapError(decodeExecutionCalendarObservationResult(observation), (cause) =>
+                executionCalendarFailure(
+                  'decode',
+                  'selected broker calendar session is invalid',
+                  { sessionDate: decoded.date },
+                  cause,
+                ),
+              ),
+          ),
+      )
+    },
+  )
+
+export const makeCycleIdentity = (material: unknown): Result.Result<CycleIdentity, CycleConstructionFailure> =>
+  Result.flatMap(
+    Result.mapError(decodeCycleIdentityMaterialResult(material), (cause) =>
+      cycleIdentityFailure('decode', 'cycle identity material is invalid', {}, cause),
+    ),
+    (decoded) =>
+      Result.flatMap(
+        Result.try({
+          try: () => ({ ...decoded, cycleId: canonicalHashV1(decoded) }),
+          catch: (cause) => cycleIdentityFailure('hash', 'cycle identity material is not canonicalizable', {}, cause),
+        }),
+        (identity) =>
+          Result.mapError(decodeCycleIdentityResult(identity), (cause) =>
+            cycleIdentityFailure(
+              'session-order',
+              'execution session must follow the Signal session',
+              {
+                signalSessionDate: decoded.signalSessionDate,
+                executionSessionDate: decoded.executionSessionDate,
+              },
+              cause,
+            ),
+          ),
+      ),
+  )
+
+const decodeCycleWindowInputs = (
+  signalSession: unknown,
+  executionCalendar: unknown,
+  executionPolicy: unknown,
+): Result.Result<DecodedCycleWindowInput, CycleConstructionFailure> => {
+  const decodedSignal = Result.mapError(decodeSignalCycleSessionResult(signalSession), (cause) =>
+    cycleWindowFailure('decode', 'Signal session material is invalid', {}, cause),
+  )
+  const decodedCalendar = Result.mapError(decodeExecutionCalendarObservationResult(executionCalendar), (cause) =>
+    cycleWindowFailure('decode', 'selected broker calendar session is invalid', {}, cause),
+  )
+  const decodedPolicy = Result.mapError(decodeCycleWindowPolicyInputResult(executionPolicy), (cause) =>
+    cycleWindowFailure('decode', 'cycle window policy is invalid', {}, cause),
+  )
+  return Result.flatMap(decodedSignal, (signal) =>
+    Result.flatMap(decodedCalendar, (calendar) =>
+      Result.map(decodedPolicy, (policy) => ({ signal, calendar, policy })),
+    ),
+  )
 }
 
-export const makeCycleIdentity = (material: CycleIdentityMaterial): CycleIdentity => ({
-  ...material,
-  cycleId: canonicalHashV1(material),
-})
-
-export const makeCycleWindow = (
-  signalSession: SignalCycleSessionRow,
-  executionCalendar: ExecutionCalendarObservation,
-  executionPolicy: Pick<CycleExecutionPolicy, 'submissionWindowMs' | 'submissionCutoffBeforeOpenMs'>,
-): CycleWindow => {
-  const { submissionCutoffBeforeOpenMs, submissionWindowMs } = executionPolicy
+const validateCycleWindowDurations = (
+  policy: CycleWindowPolicyInput,
+): Result.Result<void, CycleConstructionFailure> => {
+  const { submissionCutoffBeforeOpenMs, submissionWindowMs } = policy
   if (
     !Number.isSafeInteger(submissionWindowMs) ||
     submissionWindowMs <= 0 ||
     submissionWindowMs > maximumSubmissionDurationMs
   ) {
-    throw new TypeError('submission window must be between one millisecond and one day')
+    return Result.fail(
+      cycleWindowFailure('duration', 'submission window must be between one millisecond and one day', {
+        submissionWindowMs,
+      }),
+    )
   }
   if (
     !Number.isSafeInteger(submissionCutoffBeforeOpenMs) ||
     submissionCutoffBeforeOpenMs <= 0 ||
     submissionCutoffBeforeOpenMs > maximumSubmissionDurationMs
   ) {
-    throw new TypeError('broker cutoff lead must be between one millisecond and one day')
+    return Result.fail(
+      cycleWindowFailure('duration', 'broker cutoff lead must be between one millisecond and one day', {
+        submissionCutoffBeforeOpenMs,
+      }),
+    )
   }
-  if (signalSession.session_date >= executionCalendar.executionSessionDate) {
-    throw new TypeError('execution session must follow the Signal session')
-  }
-  try {
-    decodeExecutionCalendarObservationSync(executionCalendar)
-  } catch {
-    throw new TypeError('selected broker calendar session is invalid')
-  }
-  const signalCloseAt = signalSessionCloseAt(signalSession)
-  const executionOpenAt = executionCalendar.executionOpenAt
-  const submissionCutoffAt = new Date(Date.parse(executionOpenAt) - submissionCutoffBeforeOpenMs).toISOString()
-  const submissionOpenAt = new Date(Date.parse(submissionCutoffAt) - submissionWindowMs).toISOString()
-  if (submissionOpenAt <= signalCloseAt) {
-    throw new TypeError('submission window must begin after the Signal session close')
-  }
-  return {
-    schemaVersion: 'bayn.autonomous-cycle-window.v1',
-    signalCalendarVersion: signalSession.calendar_version,
-    signalSessionDate: signalSession.session_date,
-    ...executionCalendar,
-    signalCloseAt,
-    publicationDeadlineAt: submissionOpenAt,
-    submissionOpenAt,
-    submissionCutoffAt,
-  }
+  return Result.succeed(undefined)
 }
 
-export const makeCycleDraft = (identity: CycleIdentity, window: CycleWindow): CycleDraft => {
-  if (identity.signalSessionDate !== window.signalSessionDate) {
-    throw new TypeError('cycle identity and window must bind the same Signal session')
+const deriveCycleWindowTimes = (
+  input: DecodedCycleWindowInput,
+): Result.Result<DerivedCycleWindowTimes, CycleConstructionFailure> => {
+  const { calendar, policy, signal } = input
+  if (signal.session_date >= calendar.executionSessionDate) {
+    return Result.fail(
+      cycleWindowFailure('session-order', 'execution session must follow the Signal session', {
+        signalSessionDate: signal.session_date,
+        executionSessionDate: calendar.executionSessionDate,
+      }),
+    )
   }
-  if (identity.signalCalendarVersion !== window.signalCalendarVersion) {
-    throw new TypeError('cycle identity and window must bind the same Signal calendar')
+  const signalCloseAt = localMarketTimeToUtcOption(signal.session_date, signal.close_time)
+  if (signalCloseAt === undefined) {
+    return Result.fail(
+      cycleWindowFailure(
+        'market-time',
+        `${signal.session_date} ${signal.close_time} is not a valid ${cycleTimeZone} market time`,
+        { sessionDate: signal.session_date, marketTime: signal.close_time, timeZone: cycleTimeZone },
+      ),
+    )
   }
-  if (
-    identity.executionSessionDate !== window.executionSessionDate ||
-    identity.executionCalendarSchemaVersion !== window.executionCalendarSchemaVersion ||
-    identity.executionCalendarSource !== window.executionCalendarSource ||
-    identity.executionCalendarHash !== window.executionCalendarHash
-  ) {
-    throw new TypeError('cycle identity and window must bind the same execution calendar observation')
+  const submissionCutoffAt = new Date(
+    Date.parse(calendar.executionOpenAt) - policy.submissionCutoffBeforeOpenMs,
+  ).toISOString()
+  const submissionOpenAt = new Date(Date.parse(submissionCutoffAt) - policy.submissionWindowMs).toISOString()
+  if (submissionOpenAt <= signalCloseAt) {
+    return Result.fail(
+      cycleWindowFailure('submission-window', 'submission window must begin after the Signal session close', {
+        signalCloseAt,
+        submissionOpenAt,
+      }),
+    )
   }
-  const submissionWindowMs = Date.parse(window.submissionCutoffAt) - Date.parse(window.submissionOpenAt)
-  if (submissionWindowMs !== identity.executionPolicy.submissionWindowMs) {
-    throw new TypeError('cycle window must match the bound execution policy')
-  }
-  const submissionCutoffBeforeOpenMs = Date.parse(window.executionOpenAt) - Date.parse(window.submissionCutoffAt)
-  if (submissionCutoffBeforeOpenMs !== identity.executionPolicy.submissionCutoffBeforeOpenMs) {
-    throw new TypeError('cycle broker cutoff must match the bound execution policy')
-  }
-  return { schemaVersion: 'bayn.autonomous-cycle.v1', identity, window }
+  return Result.succeed({ signalCloseAt, submissionOpenAt, submissionCutoffAt })
 }
+
+const assembleCycleWindow = (
+  input: DecodedCycleWindowInput,
+  times: DerivedCycleWindowTimes,
+): Result.Result<CycleWindow, CycleConstructionFailure> =>
+  Result.mapError(
+    decodeCycleWindowResult({
+      schemaVersion: 'bayn.autonomous-cycle-window.v1',
+      signalCalendarVersion: input.signal.calendar_version,
+      signalSessionDate: input.signal.session_date,
+      ...input.calendar,
+      signalCloseAt: times.signalCloseAt,
+      publicationDeadlineAt: times.submissionOpenAt,
+      submissionOpenAt: times.submissionOpenAt,
+      submissionCutoffAt: times.submissionCutoffAt,
+    }),
+    (cause) => cycleWindowFailure('decode', 'derived cycle window is invalid', {}, cause),
+  )
+
+export const makeCycleWindow = (
+  signalSession: unknown,
+  executionCalendar: unknown,
+  executionPolicy: unknown,
+): Result.Result<CycleWindow, CycleConstructionFailure> =>
+  Result.flatMap(decodeCycleWindowInputs(signalSession, executionCalendar, executionPolicy), (input) =>
+    Result.flatMap(validateCycleWindowDurations(input.policy), () =>
+      Result.flatMap(deriveCycleWindowTimes(input), (times) => assembleCycleWindow(input, times)),
+    ),
+  )
+
+export const makeCycleDraft = (
+  identity: unknown,
+  window: unknown,
+): Result.Result<CycleDraft, CycleConstructionFailure> =>
+  Result.flatMap(
+    Result.mapError(decodeCycleIdentityResult(identity), (cause) =>
+      cycleDraftFailure('decode', 'cycle identity is invalid', {}, cause),
+    ),
+    (decodedIdentity) =>
+      Result.flatMap(
+        Result.mapError(decodeCycleWindowResult(window), (cause) =>
+          cycleDraftFailure('decode', 'cycle window is invalid', {}, cause),
+        ),
+        (decodedWindow) =>
+          Result.mapError(
+            decodeCycleDraftResult({
+              schemaVersion: 'bayn.autonomous-cycle.v1',
+              identity: decodedIdentity,
+              window: decodedWindow,
+            }),
+            (cause) =>
+              cycleDraftFailure(
+                'binding',
+                'cycle identity and window bindings are incoherent',
+                {
+                  cycleId: decodedIdentity.cycleId,
+                  signalSessionDate: decodedWindow.signalSessionDate,
+                  executionSessionDate: decodedWindow.executionSessionDate,
+                },
+                cause,
+              ),
+          ),
+      ),
+  )
 
 export const isTerminalCycleState = (state: CycleState): boolean =>
   state === CycleState.Completed || state === CycleState.NoTrade || state === CycleState.Blocked
@@ -531,8 +874,12 @@ export const cycleDraftOf = (cycle: AutonomousCycle): CycleDraft => ({
   window: cycle.window,
 })
 
-export const cycleDraftMatches = (left: CycleDraft, right: CycleDraft): boolean =>
-  canonicalHashV1(left) === canonicalHashV1(right)
+export const cycleDraftMatches = (left: CycleDraft, right: CycleDraft): boolean => {
+  const leftHash = canonicalHashResult(left)
+  if (Result.isFailure(leftHash)) return false
+  const rightHash = canonicalHashResult(right)
+  return Result.isSuccess(rightHash) && leftHash.success === rightHash.success
+}
 
 export const decodeExecutionCalendarObservation = Schema.decodeUnknownEffect(
   ExecutionCalendarObservationSchema,

--- a/services/bayn/src/evidence-contracts.ts
+++ b/services/bayn/src/evidence-contracts.ts
@@ -297,45 +297,57 @@ export const DailyPositionMarksArtifactSchema = Schema.Struct({
   ).check(Schema.isMinLength(1)),
 })
 
+const DecisionCovarianceWindowSchema = Schema.Struct({
+  returnCount: PositiveInteger,
+  firstSession: IsoDateSchema,
+  lastSession: IsoDateSchema,
+  sessionsHash: Sha256Schema,
+})
+
+const DecisionHorizonSignalSchema = Schema.Struct({
+  horizonSessions: PositiveInteger,
+  return: Schema.Finite,
+  normalizedTrend: Schema.Finite,
+})
+
+const DecisionSymbolSignalSchema = Schema.Struct({
+  symbol: Symbol,
+  horizons: Schema.Array(DecisionHorizonSignalSchema).check(Schema.isMinLength(1)),
+  dailyVolatility: NonNegativeFinite,
+  annualizedVolatility: NonNegativeFinite,
+  compositeScore: Schema.Finite,
+  positiveScore: NonNegativeFinite,
+  eligible: Schema.Boolean,
+  uncappedWeight: UnitIntervalFinite,
+  cappedWeight: UnitIntervalFinite,
+  targetWeight: UnitIntervalFinite,
+})
+
+export const DecisionPlanSchema = Schema.Struct({
+  schemaVersion: Schema.Literal('bayn.risk-balanced-trend-decision-plan.v1'),
+  signalDate: IsoDateSchema,
+  covarianceWindow: DecisionCovarianceWindowSchema,
+  estimatedAnnualizedPortfolioVolatility: NonNegativeFinite,
+  exposureScale: UnitIntervalFinite,
+  targetWeights: Schema.Record(Symbol, UnitIntervalFinite),
+  signals: Schema.Array(DecisionSymbolSignalSchema).check(Schema.isMinLength(1)),
+})
+
+const SignalDecisionSchema = Schema.Struct({
+  schemaVersion: DecisionPlanSchema.fields.schemaVersion,
+  decisionId: Sha256Schema,
+  signalDate: DecisionPlanSchema.fields.signalDate,
+  executionDate: IsoDateSchema,
+  covarianceWindow: DecisionPlanSchema.fields.covarianceWindow,
+  estimatedAnnualizedPortfolioVolatility: DecisionPlanSchema.fields.estimatedAnnualizedPortfolioVolatility,
+  exposureScale: DecisionPlanSchema.fields.exposureScale,
+  targetWeights: DecisionPlanSchema.fields.targetWeights,
+  signals: DecisionPlanSchema.fields.signals,
+})
+
 export const RiskBalancedTrendSignalDecisionsArtifactSchema = Schema.Struct({
   schemaVersion: Schema.Literal('bayn.risk-balanced-trend-decisions.v1'),
-  items: Schema.Array(
-    Schema.Struct({
-      schemaVersion: Schema.Literal('bayn.risk-balanced-trend-decision-plan.v1'),
-      decisionId: Sha256Schema,
-      signalDate: IsoDateSchema,
-      executionDate: IsoDateSchema,
-      covarianceWindow: Schema.Struct({
-        returnCount: PositiveInteger,
-        firstSession: IsoDateSchema,
-        lastSession: IsoDateSchema,
-        sessionsHash: Sha256Schema,
-      }),
-      estimatedAnnualizedPortfolioVolatility: NonNegativeFinite,
-      exposureScale: UnitIntervalFinite,
-      targetWeights: Schema.Record(Symbol, UnitIntervalFinite),
-      signals: Schema.Array(
-        Schema.Struct({
-          symbol: Symbol,
-          horizons: Schema.Array(
-            Schema.Struct({
-              horizonSessions: PositiveInteger,
-              return: Schema.Finite,
-              normalizedTrend: Schema.Finite,
-            }),
-          ).check(Schema.isMinLength(1)),
-          dailyVolatility: NonNegativeFinite,
-          annualizedVolatility: NonNegativeFinite,
-          compositeScore: Schema.Finite,
-          positiveScore: NonNegativeFinite,
-          eligible: Schema.Boolean,
-          uncappedWeight: UnitIntervalFinite,
-          cappedWeight: UnitIntervalFinite,
-          targetWeight: UnitIntervalFinite,
-        }),
-      ).check(Schema.isMinLength(1)),
-    }),
-  ).check(Schema.isMinLength(1)),
+  items: Schema.Array(SignalDecisionSchema).check(Schema.isMinLength(1)),
 })
 
 export const DailyPerformanceSeriesArtifactSchema = Schema.Struct({
@@ -445,7 +457,7 @@ export type CashChange = (typeof CashChangesArtifactSchema.Type)['items'][number
 export type DailyPositionMark = (typeof DailyPositionMarksArtifactSchema.Type)['items'][number]
 export type PositionMark = DailyPositionMark['positions'][number]
 export type SignalDecision = (typeof RiskBalancedTrendSignalDecisionsArtifactSchema.Type)['items'][number]
-export type DecisionPlan = Omit<SignalDecision, 'decisionId' | 'executionDate'>
+export type DecisionPlan = typeof DecisionPlanSchema.Type
 export type SymbolSignal = SignalDecision['signals'][number]
 export type HorizonSignal = SymbolSignal['horizons'][number]
 export type DailyPerformancePoint = (typeof DailyPerformanceSeriesArtifactSchema.Type)['items'][number]

--- a/services/bayn/src/execution-session.test.ts
+++ b/services/bayn/src/execution-session.test.ts
@@ -1,23 +1,41 @@
 import { describe, expect, test } from 'bun:test'
 
-import { Schema } from 'effect'
+import { Result, Schema } from 'effect'
 
 import type { MarketCalendarObservation } from './broker/alpaca'
 import {
   CycleState,
   makeCycleDraft,
+  makeCycleExecutionPolicy,
   makeCycleExecutionPolicyFromModel,
   makeCycleIdentity,
   makeCycleWindow,
   makeExecutionCalendarObservation,
   type AutonomousCycle,
+  type CycleExecutionPolicy,
 } from './cycle'
 import { defaultExecutionModel } from './execution-model'
-import { bindCycleExecutionSession, bindExecutionSession, ExecutionSessionBindingSchema } from './execution-session'
+import {
+  bindCycleExecutionSession,
+  bindExecutionSession,
+  ExecutionSessionBindingSchema,
+  type BindCycleExecutionSessionInput,
+  type BindExecutionSessionInput,
+  type ExecutionSessionBinding,
+} from './execution-session'
 import { canonicalHashV1 } from './hash'
 import { strictParseOptions } from './schemas'
 
 const hash = (character: string): string => character.repeat(64)
+const resultValue = <A, E>(result: Result.Result<A, E>): A => {
+  if (Result.isFailure(result)) throw result.failure
+  return result.success
+}
+const bindExecutionSessionSuccess = (input: BindExecutionSessionInput): ExecutionSessionBinding =>
+  resultValue(bindExecutionSession(input))
+const bindCycleExecutionSessionSuccess = (input: BindCycleExecutionSessionInput): ExecutionSessionBinding =>
+  resultValue(bindCycleExecutionSession(input))
+
 const causalExecutionModel = (() => {
   if (defaultExecutionModel.schemaVersion !== 'bayn.execution-model.v2') {
     throw new Error('execution-session cycle fixtures require the causal v2 execution model')
@@ -39,20 +57,21 @@ const calendar = (
   return { ...material, normalizedResponseHash: canonicalHashV1(material) }
 }
 
-const bind = (observation: MarketCalendarObservation) =>
-  bindExecutionSession({
-    signal: {
-      sessionDate: '2026-07-02',
-      finalizedAt: '2026-07-02T22:00:00.000Z',
-      contentHash: hash('a'),
-    },
-    planningBrokerState: {
-      observedAt: '2026-07-02T22:01:00.000Z',
-      contentHash: hash('b'),
-    },
-    calendar: observation,
-    executionModel: defaultExecutionModel,
-  })
+const bindingInput = (observation: MarketCalendarObservation): BindExecutionSessionInput => ({
+  signal: {
+    sessionDate: '2026-07-02',
+    finalizedAt: '2026-07-02T22:00:00.000Z',
+    contentHash: hash('a'),
+  },
+  planningBrokerState: {
+    observedAt: '2026-07-02T22:01:00.000Z',
+    contentHash: hash('b'),
+  },
+  calendar: observation,
+  executionModel: defaultExecutionModel,
+})
+
+const bind = (observation: MarketCalendarObservation) => bindExecutionSessionSuccess(bindingInput(observation))
 
 const decodeBinding = Schema.decodeUnknownSync(ExecutionSessionBindingSchema, strictParseOptions)
 
@@ -77,41 +96,47 @@ const monthEndCalendar = calendar(
   { start: '2026-01-30', end: '2026-02-03' },
 )
 
-const makeActiveCycle = (): AutonomousCycle => {
+const makeActiveCycle = (policyOverride?: CycleExecutionPolicy): AutonomousCycle => {
   const executionSession = monthEndCalendar.sessions[1]
   if (executionSession === undefined) throw new Error('cycle fixture requires the first post-signal session')
-  const executionCalendar = makeExecutionCalendarObservation({
-    schemaVersion: monthEndCalendar.schemaVersion,
-    source: monthEndCalendar.source,
-    ...executionSession,
-  })
-  const executionPolicy = makeCycleExecutionPolicyFromModel(causalExecutionModel)
-  const identity = makeCycleIdentity({
-    schemaVersion: 'bayn.autonomous-cycle-identity.v1',
-    strategyName: 'risk-balanced-trend',
-    qualificationRunId: hash('1'),
-    strategyProtocolHash: hash('2'),
-    accountId: 'paper-account-1',
-    signalSessionDate: '2026-01-30',
-    signalCalendarVersion: 'signal-calendar-v1',
-    executionSessionDate: executionCalendar.executionSessionDate,
-    executionCalendarSchemaVersion: executionCalendar.executionCalendarSchemaVersion,
-    executionCalendarSource: executionCalendar.executionCalendarSource,
-    executionCalendarHash: executionCalendar.executionCalendarHash,
-    executionPolicy,
-  })
-  const window = makeCycleWindow(
-    {
-      calendar_version: 'signal-calendar-v1',
-      session_date: '2026-01-30',
-      close_time: '16:00',
-      timezone: 'America/New_York',
-    },
-    executionCalendar,
-    executionPolicy,
+  const executionCalendar = resultValue(
+    makeExecutionCalendarObservation({
+      schemaVersion: monthEndCalendar.schemaVersion,
+      source: monthEndCalendar.source,
+      ...executionSession,
+    }),
+  )
+  const executionPolicy = policyOverride ?? resultValue(makeCycleExecutionPolicyFromModel(causalExecutionModel))
+  const identity = resultValue(
+    makeCycleIdentity({
+      schemaVersion: 'bayn.autonomous-cycle-identity.v1',
+      strategyName: 'risk-balanced-trend',
+      qualificationRunId: hash('1'),
+      strategyProtocolHash: hash('2'),
+      accountId: 'paper-account-1',
+      signalSessionDate: '2026-01-30',
+      signalCalendarVersion: 'signal-calendar-v1',
+      executionSessionDate: executionCalendar.executionSessionDate,
+      executionCalendarSchemaVersion: executionCalendar.executionCalendarSchemaVersion,
+      executionCalendarSource: executionCalendar.executionCalendarSource,
+      executionCalendarHash: executionCalendar.executionCalendarHash,
+      executionPolicy,
+    }),
+  )
+  const window = resultValue(
+    makeCycleWindow(
+      {
+        calendar_version: 'signal-calendar-v1',
+        session_date: '2026-01-30',
+        close_time: '16:00',
+        timezone: 'America/New_York',
+      },
+      executionCalendar,
+      executionPolicy,
+    ),
   )
   return {
-    ...makeCycleDraft(identity, window),
+    ...resultValue(makeCycleDraft(identity, window)),
     state: CycleState.Active,
     bindings: { snapshotId: hash('3') },
     stateVersion: 3,
@@ -120,9 +145,9 @@ const makeActiveCycle = (): AutonomousCycle => {
   }
 }
 
-const bindCycle = (overrides: Partial<Parameters<typeof bindCycleExecutionSession>[0]> = {}) => {
+const cycleBindingInput = (overrides: Partial<BindCycleExecutionSessionInput> = {}): BindCycleExecutionSessionInput => {
   const cycle = makeActiveCycle()
-  return bindCycleExecutionSession({
+  return {
     cycle,
     signal: {
       sessionDate: cycle.identity.signalSessionDate,
@@ -136,8 +161,11 @@ const bindCycle = (overrides: Partial<Parameters<typeof bindCycleExecutionSessio
     calendar: monthEndCalendar,
     executionModel: causalExecutionModel,
     ...overrides,
-  })
+  }
 }
+
+const bindCycle = (overrides: Partial<BindCycleExecutionSessionInput> = {}) =>
+  bindCycleExecutionSessionSuccess(cycleBindingInput(overrides))
 
 describe('causal execution-session binding', () => {
   test('binds a holiday gap, fixed pre-open cutoff, and early close without assuming session hours', () => {
@@ -167,11 +195,11 @@ describe('causal execution-session binding', () => {
       submissionCutoffAt: '2026-07-06T13:15:00.000Z',
       submissionCutoffLeadMinutes: 15,
     })
-    expect(result.bindingHash).toMatch(/^[a-f0-9]{64}$/)
+    expect(result.bindingHash).toBe('045ffeda9fa49a32f5552e648d954438572dcd1405539f132e7f77dc2b58ce21')
   })
 
   test('preserves the DST-normalized open supplied by the bounded broker observation', () => {
-    const result = bindExecutionSession({
+    const result = bindExecutionSessionSuccess({
       signal: {
         sessionDate: '2026-03-06',
         finalizedAt: '2026-03-06T22:00:00.000Z',
@@ -203,7 +231,7 @@ describe('causal execution-session binding', () => {
     ).toThrow('normalized response hash')
 
     expect(() =>
-      bindExecutionSession({
+      bindExecutionSessionSuccess({
         signal: {
           sessionDate: '2026-07-02',
           finalizedAt: '2026-07-06T13:15:00.000Z',
@@ -217,6 +245,37 @@ describe('causal execution-session binding', () => {
         executionModel: defaultExecutionModel,
       }),
     ).toThrow('submissionOpenAt < submissionCutoffAt < executionSession.openAt')
+  })
+
+  test('requires signal finalization no earlier than the declared signal session date', () => {
+    const observation = calendar([
+      { date: '2026-07-06', openAt: '2026-07-06T13:30:00.000Z', closeAt: '2026-07-06T20:00:00.000Z' },
+    ])
+    const atBoundary = bindingInput(observation)
+    const accepted = bindExecutionSession({
+      ...atBoundary,
+      signal: { ...atBoundary.signal, finalizedAt: '2026-07-02T00:00:00.000Z' },
+      planningBrokerState: { ...atBoundary.planningBrokerState, observedAt: '2026-07-02T00:00:00.000Z' },
+    })
+    expect(Result.isSuccess(accepted)).toBe(true)
+
+    const beforeBoundary = bindExecutionSession({
+      ...atBoundary,
+      signal: { ...atBoundary.signal, finalizedAt: '2026-07-01T23:59:59.999Z' },
+      planningBrokerState: { ...atBoundary.planningBrokerState, observedAt: '2026-07-01T23:59:59.999Z' },
+    })
+    expect(Result.isFailure(beforeBoundary)).toBe(true)
+    if (Result.isFailure(beforeBoundary)) {
+      expect(beforeBoundary.failure).toMatchObject({
+        _tag: 'ExecutionSessionBindingFailure',
+        operation: 'derive-window',
+        reason: 'signal-finalization',
+        facts: {
+          finalizedAt: '2026-07-01T23:59:59.999Z',
+          signalSessionDate: '2026-07-02',
+        },
+      })
+    }
   })
 
   test('rejects a rehashed binding whose cutoff does not match the declared lead', () => {
@@ -258,7 +317,7 @@ describe('causal execution-session binding', () => {
         ...tamperedMaterial,
         bindingHash: canonicalHashV1(tamperedMaterial),
       }),
-    ).toThrow('must be the first post-signal session in the normalized calendar observation')
+    ).toThrow('must be the first post-signal session in the supplied normalized calendar observation')
   })
 
   test('rejects a rehashed calendar whose UTC instants do not belong to the declared session date', () => {
@@ -292,7 +351,7 @@ describe('causal execution-session binding', () => {
         ...tamperedMaterial,
         bindingHash: canonicalHashV1(tamperedMaterial),
       }),
-    ).toThrow('must have valid hours on its declared UTC session date within the requested range')
+    ).toThrow('must have ordered UTC hours on their declared date within the request')
   })
 
   test('rejects a truncated calendar range that can skip the actual next exchange session', () => {
@@ -323,36 +382,102 @@ describe('causal execution-session binding', () => {
     })
   })
 
-  test('allows later evidence to narrow but never widen the durable cycle submission window', () => {
-    expect(
-      bindCycle({
-        planningBrokerState: {
-          observedAt: '2026-02-02T14:00:00.000Z',
-          contentHash: hash('c'),
-        },
-      }).submissionOpenAt,
-    ).toBe('2026-02-02T14:00:00.000Z')
+  test('binds cycle signal finalization only at or after the durable signal close boundary', () => {
+    const cycle = makeActiveCycle()
+    const atClose = bindCycle({
+      signal: {
+        sessionDate: cycle.identity.signalSessionDate,
+        finalizedAt: cycle.window.signalCloseAt,
+        contentHash: hash('c'),
+      },
+    })
+    const afterClose = bindCycle({
+      signal: {
+        sessionDate: cycle.identity.signalSessionDate,
+        finalizedAt: '2026-01-30T21:00:00.001Z',
+        contentHash: hash('d'),
+      },
+    })
+    expect(atClose.signal.finalizedAt).toBe(cycle.window.signalCloseAt)
+    expect(afterClose.signal.finalizedAt).toBe('2026-01-30T21:00:00.001Z')
 
-    expect(() =>
-      bindCycle({
+    const beforeClose = bindCycleExecutionSession(
+      cycleBindingInput({
+        signal: {
+          sessionDate: cycle.identity.signalSessionDate,
+          finalizedAt: '2026-01-30T20:59:59.999Z',
+          contentHash: hash('e'),
+        },
+      }),
+    )
+    expect(Result.isFailure(beforeClose)).toBe(true)
+    if (Result.isFailure(beforeClose)) {
+      expect(beforeClose.failure).toMatchObject({
+        operation: 'bind-cycle',
+        reason: 'cycle-window',
+        facts: {
+          cycleId: cycle.identity.cycleId,
+          expectedMinimumSignalFinalizedAt: cycle.window.signalCloseAt,
+          observedSignalFinalizedAt: '2026-01-30T20:59:59.999Z',
+        },
+      })
+    }
+  })
+
+  test('allows later evidence to narrow but never widen the durable cycle submission window', () => {
+    const baseline = bindCycle()
+    const narrowed = bindCycle({
+      planningBrokerState: {
+        observedAt: '2026-02-02T14:00:00.000Z',
+        contentHash: hash('c'),
+      },
+    })
+    expect(narrowed.submissionOpenAt).toBe('2026-02-02T14:00:00.000Z')
+    expect(narrowed.bindingHash).not.toBe(baseline.bindingHash)
+    const { bindingHash: _, ...narrowedMaterial } = narrowed
+    expect(narrowed.bindingHash).toBe(canonicalHashV1(narrowedMaterial))
+
+    const widened = bindCycleExecutionSession(
+      cycleBindingInput({
         planningBrokerState: {
           observedAt: '2026-02-02T13:44:59.999Z',
           contentHash: hash('d'),
         },
       }),
-    ).toThrow('cannot widen the durable cycle submission window')
+    )
+    expect(Result.isFailure(widened)).toBe(true)
+    if (Result.isFailure(widened)) {
+      expect(widened.failure).toMatchObject({
+        operation: 'bind-cycle',
+        reason: 'cycle-window',
+        facts: {
+          expectedMinimumSubmissionOpenAt: makeActiveCycle().window.submissionOpenAt,
+          observedSubmissionOpenAt: '2026-02-02T13:44:59.999Z',
+        },
+      })
+    }
   })
 
   test('fails closed when the complete calendar no longer selects the cycle session', () => {
-    expect(() =>
-      bindCycle({
+    const cycle = makeActiveCycle()
+    const signalMismatch = bindCycleExecutionSession(
+      cycleBindingInput({
         signal: {
           sessionDate: '2026-01-31',
-          finalizedAt: '2026-01-30T21:15:00.000Z',
+          finalizedAt: '2026-01-31T21:15:00.000Z',
           contentHash: hash('e'),
         },
       }),
-    ).toThrow('does not match the durable cycle calendar')
+    )
+    expect(Result.isFailure(signalMismatch)).toBe(true)
+    if (Result.isFailure(signalMismatch)) {
+      expect(signalMismatch.failure.facts).toEqual({
+        cycleId: cycle.identity.cycleId,
+        field: 'signalSessionDate',
+        expected: '2026-01-30',
+        observed: '2026-01-31',
+      })
+    }
 
     const changedHours = calendar(
       monthEndCalendar.sessions.map((session) =>
@@ -360,13 +485,31 @@ describe('causal execution-session binding', () => {
       ),
       monthEndCalendar.requestedRange,
     )
-    expect(() => bindCycle({ calendar: changedHours })).toThrow('does not match the durable cycle calendar')
+    const hoursMismatch = bindCycleExecutionSession(cycleBindingInput({ calendar: changedHours }))
+    expect(Result.isFailure(hoursMismatch)).toBe(true)
+    if (Result.isFailure(hoursMismatch)) {
+      expect(hoursMismatch.failure.facts).toEqual({
+        cycleId: cycle.identity.cycleId,
+        field: 'executionCloseAt',
+        expected: '2026-02-02T21:00:00.000Z',
+        observed: '2026-02-02T18:00:00.000Z',
+      })
+    }
 
     const skippedSession = calendar(
       monthEndCalendar.sessions.filter((session) => session.date !== '2026-02-02'),
       monthEndCalendar.requestedRange,
     )
-    expect(() => bindCycle({ calendar: skippedSession })).toThrow('does not match the durable cycle calendar')
+    const dateMismatch = bindCycleExecutionSession(cycleBindingInput({ calendar: skippedSession }))
+    expect(Result.isFailure(dateMismatch)).toBe(true)
+    if (Result.isFailure(dateMismatch)) {
+      expect(dateMismatch.failure.facts).toEqual({
+        cycleId: cycle.identity.cycleId,
+        field: 'executionSessionDate',
+        expected: '2026-02-02',
+        observed: '2026-02-03',
+      })
+    }
   })
 
   test('fails closed when the current execution model differs from the cycle policy', () => {
@@ -378,8 +521,155 @@ describe('causal execution-session binding', () => {
       },
     }
 
-    expect(() => bindCycle({ executionModel: changedModel })).toThrow(
-      'does not match the durable cycle execution policy',
+    const mismatch = bindCycleExecutionSession(cycleBindingInput({ executionModel: changedModel }))
+    expect(Result.isFailure(mismatch)).toBe(true)
+    if (Result.isFailure(mismatch)) {
+      expect(mismatch.failure).toMatchObject({
+        operation: 'bind-cycle',
+        reason: 'cycle-policy',
+        facts: {
+          cycleId: makeActiveCycle().identity.cycleId,
+          field: 'strategyExecutionModelHash',
+          expected: makeActiveCycle().identity.executionPolicy.strategyExecutionModelHash,
+          observed: canonicalHashV1(changedModel),
+        },
+      })
+    }
+
+    const shorterLeadPolicy = resultValue(
+      makeCycleExecutionPolicy({
+        schemaVersion: 'bayn.autonomous-cycle-execution-policy.v1',
+        strategyExecutionModelHash: canonicalHashV1(causalExecutionModel),
+        submissionWindowMs: 30 * 60_000,
+        submissionCutoffBeforeOpenMs: 14 * 60_000,
+      }),
     )
+    const shorterLeadCycle = makeActiveCycle(shorterLeadPolicy)
+    const leadMismatch = bindCycleExecutionSession(cycleBindingInput({ cycle: shorterLeadCycle }))
+    expect(Result.isFailure(leadMismatch)).toBe(true)
+    if (Result.isFailure(leadMismatch)) {
+      expect(leadMismatch.failure).toMatchObject({
+        operation: 'bind-cycle',
+        reason: 'cycle-policy',
+        facts: {
+          cycleId: shorterLeadCycle.identity.cycleId,
+          field: 'submissionCutoffBeforeOpenMs',
+          expected: 14 * 60_000,
+          observed: 15 * 60_000,
+        },
+      })
+    }
+  })
+
+  test('returns each reachable closed failure reason from the exported binders', () => {
+    const futureSession = {
+      date: '2026-07-06',
+      openAt: '2026-07-06T13:30:00.000Z',
+      closeAt: '2026-07-06T20:00:00.000Z',
+    } as const
+    const validCalendar = calendar([futureSession])
+    const invalidHashCalendar = {
+      ...validCalendar,
+      sessions: [{ ...futureSession, closeAt: '2026-07-06T19:00:00.000Z' }],
+    }
+    const reversedRangeCalendar = calendar([futureSession], {
+      start: '2026-07-10',
+      end: '2026-07-02',
+    })
+    const wrongDateCalendar = calendar([
+      {
+        ...futureSession,
+        openAt: '2026-07-07T13:30:00.000Z',
+        closeAt: '2026-07-07T20:00:00.000Z',
+      },
+    ])
+    const unorderedCalendar = calendar([
+      {
+        date: '2026-07-07',
+        openAt: '2026-07-07T13:30:00.000Z',
+        closeAt: '2026-07-07T20:00:00.000Z',
+      },
+      futureSession,
+    ])
+    const noFutureSessionCalendar = calendar([
+      {
+        date: '2026-07-02',
+        openAt: '2026-07-02T13:30:00.000Z',
+        closeAt: '2026-07-02T20:00:00.000Z',
+      },
+    ])
+    const atCutoffInput = {
+      ...bindingInput(validCalendar),
+      signal: {
+        ...bindingInput(validCalendar).signal,
+        finalizedAt: '2026-07-06T13:15:00.000Z',
+      },
+    }
+    const prematureFinalizationInput = {
+      ...bindingInput(validCalendar),
+      signal: {
+        ...bindingInput(validCalendar).signal,
+        finalizedAt: '2026-07-01T23:59:59.999Z',
+      },
+      planningBrokerState: {
+        ...bindingInput(validCalendar).planningBrokerState,
+        observedAt: '2026-07-01T23:59:59.999Z',
+      },
+    }
+    const changedModel = {
+      ...causalExecutionModel,
+      order: {
+        ...causalExecutionModel.order,
+        submissionCutoffLeadMinutes: causalExecutionModel.order.submissionCutoffLeadMinutes - 1,
+      },
+    }
+    const cases = [
+      ['bind', 'decode', bindExecutionSession({})],
+      ['derive-window', 'calendar-hash', bindExecutionSession(bindingInput(invalidHashCalendar))],
+      ['derive-window', 'range', bindExecutionSession(bindingInput(reversedRangeCalendar))],
+      ['derive-window', 'calendar-session', bindExecutionSession(bindingInput(wrongDateCalendar))],
+      ['derive-window', 'calendar-order', bindExecutionSession(bindingInput(unorderedCalendar))],
+      ['derive-window', 'future-session', bindExecutionSession(bindingInput(noFutureSessionCalendar))],
+      ['derive-window', 'signal-finalization', bindExecutionSession(prematureFinalizationInput)],
+      ['derive-window', 'submission-window', bindExecutionSession(atCutoffInput)],
+      ['bind-cycle', 'decode', bindCycleExecutionSession({})],
+      [
+        'bind-cycle',
+        'cycle-calendar',
+        bindCycleExecutionSession(
+          cycleBindingInput({
+            signal: {
+              sessionDate: '2026-01-31',
+              finalizedAt: '2026-01-31T21:15:00.000Z',
+              contentHash: hash('e'),
+            },
+          }),
+        ),
+      ],
+      ['bind-cycle', 'cycle-policy', bindCycleExecutionSession(cycleBindingInput({ executionModel: changedModel }))],
+      [
+        'bind-cycle',
+        'cycle-window',
+        bindCycleExecutionSession(
+          cycleBindingInput({
+            planningBrokerState: {
+              observedAt: '2026-02-02T13:44:59.999Z',
+              contentHash: hash('d'),
+            },
+          }),
+        ),
+      ],
+    ] as const
+
+    for (const [operation, reason, result] of cases) {
+      expect(Result.isFailure(result)).toBe(true)
+      if (Result.isFailure(result)) {
+        expect(result.failure).toMatchObject({
+          _tag: 'ExecutionSessionBindingFailure',
+          operation,
+          reason,
+        })
+      }
+    }
   })
 })

--- a/services/bayn/src/execution-session.ts
+++ b/services/bayn/src/execution-session.ts
@@ -1,10 +1,15 @@
-import { Schema } from 'effect'
+import { Data, Result, Schema } from 'effect'
 
 import type { MarketCalendarObservation } from './broker/alpaca'
-import { makeExecutionCalendarObservation, type AutonomousCycle } from './cycle'
+import {
+  AutonomousCycleSchema,
+  makeExecutionCalendarObservation,
+  type AutonomousCycle,
+  type ExecutionCalendarObservation,
+} from './cycle'
 import { canonicalHashV1 } from './hash'
-import type { ExecutionModel } from './protocol'
-import { IsoDateSchema, Sha256Schema, UtcInstantSchema, strictParseOptions as StrictParseOptions } from './schemas'
+import { ExecutionModelV2Schema, type ExecutionModel } from './protocol'
+import { IsoDateSchema, Sha256Schema, UtcInstantSchema, strictParseOptions } from './schemas'
 
 const CalendarIdentitySchema = Schema.Struct({
   schemaVersion: Schema.Literal('bayn.alpaca-market-calendar-observation.v1'),
@@ -24,122 +29,328 @@ const CalendarIdentitySchema = Schema.Struct({
   normalizedResponseHash: Sha256Schema,
 })
 
+const SignalBindingSchema = Schema.Struct({
+  sessionDate: IsoDateSchema,
+  finalizedAt: UtcInstantSchema,
+  contentHash: Sha256Schema,
+})
+
+const PlanningBrokerStateBindingSchema = Schema.Struct({
+  observedAt: UtcInstantSchema,
+  contentHash: Sha256Schema,
+})
+
+const ExecutionSessionSchema = Schema.Struct({
+  date: IsoDateSchema,
+  openAt: UtcInstantSchema,
+  closeAt: UtcInstantSchema,
+})
+
+const SubmissionCutoffLeadMinutesSchema = Schema.Int.check(Schema.isBetween({ minimum: 1, maximum: 120 }))
+
 const ExecutionSessionBindingBase = Schema.Struct({
   schemaVersion: Schema.Literal('bayn.execution-session-binding.v1'),
-  signal: Schema.Struct({
-    sessionDate: IsoDateSchema,
-    finalizedAt: UtcInstantSchema,
-    contentHash: Sha256Schema,
-  }),
-  planningBrokerState: Schema.Struct({
-    observedAt: UtcInstantSchema,
-    contentHash: Sha256Schema,
-  }),
+  signal: SignalBindingSchema,
+  planningBrokerState: PlanningBrokerStateBindingSchema,
   calendar: CalendarIdentitySchema,
-  executionSession: Schema.Struct({
-    date: IsoDateSchema,
-    openAt: UtcInstantSchema,
-    closeAt: UtcInstantSchema,
-  }),
+  executionSession: ExecutionSessionSchema,
   submissionOpenAt: UtcInstantSchema,
   submissionCutoffAt: UtcInstantSchema,
-  submissionCutoffLeadMinutes: Schema.Int.check(Schema.isBetween({ minimum: 1, maximum: 120 })),
+  submissionCutoffLeadMinutes: SubmissionCutoffLeadMinutesSchema,
   bindingHash: Sha256Schema,
 })
 
-export const ExecutionSessionBindingSchema = ExecutionSessionBindingBase.check(
-  Schema.makeFilter((binding: typeof ExecutionSessionBindingBase.Type) => {
-    const issues: Schema.FilterIssue[] = []
-    if (binding.signal.sessionDate >= binding.executionSession.date) {
-      issues.push({ path: ['executionSession', 'date'], issue: 'must follow the finalized signal session' })
-    }
-    if (binding.calendar.requestedRange.start > binding.signal.sessionDate) {
-      issues.push({
-        path: ['calendar', 'requestedRange', 'start'],
-        issue: 'must be on or before the signal session',
-      })
-    }
-    for (let index = 0; index < binding.calendar.sessions.length; index += 1) {
-      const session = binding.calendar.sessions[index]
-      if (
-        session.date < binding.calendar.requestedRange.start ||
-        session.date > binding.calendar.requestedRange.end ||
-        session.openAt.slice(0, 10) !== session.date ||
-        session.closeAt.slice(0, 10) !== session.date ||
-        session.openAt >= session.closeAt
-      ) {
-        issues.push({
-          path: ['calendar', 'sessions', index],
-          issue: 'must have valid hours on its declared UTC session date within the requested range',
-        })
-      }
-      if (index > 0 && binding.calendar.sessions[index - 1].date >= session.date) {
-        issues.push({
-          path: ['calendar', 'sessions', index],
-          issue: 'must be unique and strictly ordered',
-        })
-      }
-    }
-    const calendarMaterial = {
-      schemaVersion: binding.calendar.schemaVersion,
-      source: binding.calendar.source,
-      requestedRange: binding.calendar.requestedRange,
-      timeZone: binding.calendar.timeZone,
-      sessions: binding.calendar.sessions,
-    }
-    if (binding.calendar.normalizedResponseHash !== canonicalHashV1(calendarMaterial)) {
-      issues.push({
-        path: ['calendar', 'normalizedResponseHash'],
-        issue: 'must match the complete normalized calendar observation',
-      })
-    }
-    const selectedSession = binding.calendar.sessions.find((session) => session.date > binding.signal.sessionDate)
+interface BindExecutionSessionIssue {
+  readonly operation: 'bind'
+  readonly reason: 'decode' | 'hash'
+}
+
+interface BindCycleExecutionSessionIssue {
+  readonly operation: 'bind-cycle'
+  readonly reason: 'cycle-calendar' | 'cycle-policy' | 'cycle-window' | 'decode' | 'hash'
+}
+
+interface DeriveExecutionSessionWindowIssue {
+  readonly operation: 'derive-window'
+  readonly reason:
+    | 'calendar-hash'
+    | 'calendar-order'
+    | 'calendar-session'
+    | 'future-session'
+    | 'hash'
+    | 'range'
+    | 'signal-finalization'
+    | 'submission-window'
+}
+
+type ExecutionSessionBindingIssue =
+  | BindExecutionSessionIssue
+  | BindCycleExecutionSessionIssue
+  | DeriveExecutionSessionWindowIssue
+
+interface ExecutionSessionBindingFailureDetails {
+  readonly message: string
+  readonly facts: Readonly<Record<string, unknown>>
+  readonly cause?: unknown
+}
+
+const ExecutionSessionBindingFailure = Data.TaggedError('ExecutionSessionBindingFailure')<
+  ExecutionSessionBindingIssue & ExecutionSessionBindingFailureDetails
+>
+export type ExecutionSessionBindingFailure = InstanceType<typeof ExecutionSessionBindingFailure>
+
+type ExecutionSessionBindingReason<Operation extends ExecutionSessionBindingIssue['operation']> = Extract<
+  ExecutionSessionBindingIssue,
+  { readonly operation: Operation }
+>['reason']
+
+const bindFailure = (
+  reason: ExecutionSessionBindingReason<'bind'>,
+  message: string,
+  facts: Readonly<Record<string, unknown>> = {},
+  cause?: unknown,
+): ExecutionSessionBindingFailure =>
+  new ExecutionSessionBindingFailure({ operation: 'bind', reason, message, facts, cause })
+
+const bindCycleFailure = (
+  reason: ExecutionSessionBindingReason<'bind-cycle'>,
+  message: string,
+  facts: Readonly<Record<string, unknown>> = {},
+  cause?: unknown,
+): ExecutionSessionBindingFailure =>
+  new ExecutionSessionBindingFailure({ operation: 'bind-cycle', reason, message, facts, cause })
+
+const deriveWindowFailure = (
+  reason: ExecutionSessionBindingReason<'derive-window'>,
+  message: string,
+  facts: Readonly<Record<string, unknown>> = {},
+  cause?: unknown,
+): ExecutionSessionBindingFailure =>
+  new ExecutionSessionBindingFailure({ operation: 'derive-window', reason, message, facts, cause })
+
+type CalendarIdentity = typeof CalendarIdentitySchema.Type
+type SignalBinding = typeof SignalBindingSchema.Type
+type PlanningBrokerStateBinding = typeof PlanningBrokerStateBindingSchema.Type
+type ExecutionSession = typeof ExecutionSessionSchema.Type
+
+interface ExecutionSessionWindowInput {
+  readonly signal: SignalBinding
+  readonly planningBrokerState: PlanningBrokerStateBinding
+  readonly calendar: CalendarIdentity
+  readonly submissionCutoffLeadMinutes: number
+}
+
+interface ExecutionSessionWindow {
+  readonly executionSession: ExecutionSession
+  readonly submissionOpenAt: string
+  readonly submissionCutoffAt: string
+}
+
+const calendarObservationMaterial = (observation: CalendarIdentity) => ({
+  schemaVersion: observation.schemaVersion,
+  source: observation.source,
+  requestedRange: observation.requestedRange,
+  timeZone: observation.timeZone,
+  sessions: observation.sessions,
+})
+
+const validateCalendarHash = (calendar: CalendarIdentity): Result.Result<void, ExecutionSessionBindingFailure> => {
+  const observedCalendarHash = Result.try({
+    try: () => canonicalHashV1(calendarObservationMaterial(calendar)),
+    catch: (cause) => deriveWindowFailure('hash', 'Alpaca market calendar content is not canonicalizable', {}, cause),
+  })
+  if (Result.isFailure(observedCalendarHash)) return Result.fail(observedCalendarHash.failure)
+  if (observedCalendarHash.success !== calendar.normalizedResponseHash) {
+    return Result.fail(
+      deriveWindowFailure(
+        'calendar-hash',
+        'Alpaca market calendar normalized response hash does not match its content',
+        {
+          expectedHash: observedCalendarHash.success,
+          observedHash: calendar.normalizedResponseHash,
+        },
+      ),
+    )
+  }
+  return Result.succeed(undefined)
+}
+
+const validateCalendarRangeAndSignal = (
+  calendar: CalendarIdentity,
+  signal: SignalBinding,
+): Result.Result<void, ExecutionSessionBindingFailure> => {
+  if (calendar.requestedRange.start > calendar.requestedRange.end) {
+    return Result.fail(
+      deriveWindowFailure('range', 'Alpaca market calendar request range must be ordered', {
+        requestedRange: calendar.requestedRange,
+      }),
+    )
+  }
+  if (calendar.requestedRange.start > signal.sessionDate) {
+    return Result.fail(
+      deriveWindowFailure('range', 'Alpaca market calendar request must start on or before the signal session', {
+        requestedRange: calendar.requestedRange,
+        signalSessionDate: signal.sessionDate,
+      }),
+    )
+  }
+  if (signal.finalizedAt.slice(0, 10) < signal.sessionDate) {
+    return Result.fail(
+      deriveWindowFailure(
+        'signal-finalization',
+        'signal publication cannot be finalized before its declared signal session date exists',
+        {
+          finalizedAt: signal.finalizedAt,
+          signalSessionDate: signal.sessionDate,
+        },
+      ),
+    )
+  }
+  return Result.succeed(undefined)
+}
+
+const validateCalendarSessions = (calendar: CalendarIdentity): Result.Result<void, ExecutionSessionBindingFailure> => {
+  for (let index = 0; index < calendar.sessions.length; index += 1) {
+    const session = calendar.sessions[index]
     if (
-      selectedSession === undefined ||
-      canonicalHashV1(selectedSession) !== canonicalHashV1(binding.executionSession)
+      session.date < calendar.requestedRange.start ||
+      session.date > calendar.requestedRange.end ||
+      session.openAt.slice(0, 10) !== session.date ||
+      session.closeAt.slice(0, 10) !== session.date ||
+      session.openAt >= session.closeAt
+    ) {
+      return Result.fail(
+        deriveWindowFailure(
+          'calendar-session',
+          'Alpaca market calendar sessions must have ordered UTC hours on their declared date within the request',
+          { index, session, requestedRange: calendar.requestedRange },
+        ),
+      )
+    }
+    if (index > 0 && calendar.sessions[index - 1].date >= session.date) {
+      return Result.fail(
+        deriveWindowFailure('calendar-order', 'Alpaca market calendar sessions must be unique and strictly ordered', {
+          index,
+          previousDate: calendar.sessions[index - 1].date,
+          date: session.date,
+        }),
+      )
+    }
+  }
+  return Result.succeed(undefined)
+}
+
+const selectExecutionSession = (
+  calendar: CalendarIdentity,
+  signal: SignalBinding,
+): Result.Result<ExecutionSession, ExecutionSessionBindingFailure> => {
+  const executionSession = calendar.sessions.find((session) => session.date > signal.sessionDate)
+  if (executionSession === undefined) {
+    return Result.fail(
+      deriveWindowFailure(
+        'future-session',
+        'Alpaca market calendar response does not contain a future execution session',
+        { signalSessionDate: signal.sessionDate },
+      ),
+    )
+  }
+  return Result.succeed(executionSession)
+}
+
+const deriveSubmissionWindow = (
+  executionSession: ExecutionSession,
+  signal: SignalBinding,
+  planningBrokerState: PlanningBrokerStateBinding,
+  submissionCutoffLeadMinutes: number,
+): Result.Result<Omit<ExecutionSessionWindow, 'executionSession'>, ExecutionSessionBindingFailure> => {
+  const submissionOpenAt =
+    signal.finalizedAt >= planningBrokerState.observedAt ? signal.finalizedAt : planningBrokerState.observedAt
+  const submissionCutoffAt = new Date(
+    Date.parse(executionSession.openAt) - submissionCutoffLeadMinutes * 60_000,
+  ).toISOString()
+  if (submissionOpenAt >= submissionCutoffAt || submissionCutoffAt >= executionSession.openAt) {
+    return Result.fail(
+      deriveWindowFailure(
+        'submission-window',
+        'execution-session binding must produce submissionOpenAt < submissionCutoffAt < executionSession.openAt',
+        {
+          executionOpenAt: executionSession.openAt,
+          submissionCutoffAt,
+          submissionOpenAt,
+        },
+      ),
+    )
+  }
+  return Result.succeed({ submissionOpenAt, submissionCutoffAt })
+}
+
+const deriveExecutionSessionWindow = (
+  input: ExecutionSessionWindowInput,
+): Result.Result<ExecutionSessionWindow, ExecutionSessionBindingFailure> =>
+  Result.flatMap(validateCalendarHash(input.calendar), () =>
+    Result.flatMap(validateCalendarRangeAndSignal(input.calendar, input.signal), () =>
+      Result.flatMap(validateCalendarSessions(input.calendar), () =>
+        Result.flatMap(selectExecutionSession(input.calendar, input.signal), (executionSession) =>
+          Result.map(
+            deriveSubmissionWindow(
+              executionSession,
+              input.signal,
+              input.planningBrokerState,
+              input.submissionCutoffLeadMinutes,
+            ),
+            (submissionWindow) => ({ executionSession, ...submissionWindow }),
+          ),
+        ),
+      ),
+    ),
+  )
+
+const bindingIssues = (binding: typeof ExecutionSessionBindingBase.Type): readonly Schema.FilterIssue[] => {
+  const issues: Schema.FilterIssue[] = []
+  const derived = deriveExecutionSessionWindow({
+    signal: binding.signal,
+    planningBrokerState: binding.planningBrokerState,
+    calendar: binding.calendar,
+    submissionCutoffLeadMinutes: binding.submissionCutoffLeadMinutes,
+  })
+  if (Result.isFailure(derived)) {
+    issues.push({ path: ['calendar'], issue: derived.failure.message })
+  } else {
+    const expected = derived.success
+    if (
+      expected.executionSession.date !== binding.executionSession.date ||
+      expected.executionSession.openAt !== binding.executionSession.openAt ||
+      expected.executionSession.closeAt !== binding.executionSession.closeAt
     ) {
       issues.push({
         path: ['executionSession'],
-        issue: 'must be the first post-signal session in the normalized calendar observation',
+        issue: 'must be the first post-signal session in the supplied normalized calendar observation',
       })
     }
-    if (binding.executionSession.openAt >= binding.executionSession.closeAt) {
-      issues.push({ path: ['executionSession', 'closeAt'], issue: 'must follow the execution open' })
-    }
-    if (
-      binding.signal.finalizedAt > binding.submissionOpenAt ||
-      binding.planningBrokerState.observedAt > binding.submissionOpenAt
-    ) {
+    if (binding.submissionOpenAt !== expected.submissionOpenAt) {
       issues.push({
         path: ['submissionOpenAt'],
-        issue: 'must not precede finalized signal data or reconciled planning broker state',
+        issue: 'must equal the later of finalized signal data and reconciled planning broker state',
       })
     }
-    if (
-      binding.submissionOpenAt >= binding.submissionCutoffAt ||
-      binding.submissionCutoffAt >= binding.executionSession.openAt
-    ) {
-      issues.push({
-        path: ['submissionCutoffAt'],
-        issue: 'must produce submissionOpenAt < submissionCutoffAt < executionSession.openAt',
-      })
-    }
-    const expectedSubmissionCutoffAt = new Date(
-      Date.parse(binding.executionSession.openAt) - binding.submissionCutoffLeadMinutes * 60_000,
-    ).toISOString()
-    if (binding.submissionCutoffAt !== expectedSubmissionCutoffAt) {
+    if (binding.submissionCutoffAt !== expected.submissionCutoffAt) {
       issues.push({
         path: ['submissionCutoffAt'],
         issue: 'must equal execution open minus the declared fixed cutoff lead',
       })
     }
-    const { bindingHash, ...material } = binding
-    if (bindingHash !== canonicalHashV1(material)) {
-      issues.push({ path: ['bindingHash'], issue: 'must match the causal execution-session material' })
-    }
-    return issues
-  }),
-)
+  }
+  const { bindingHash, ...material } = binding
+  const expectedBindingHash = Result.try(() => canonicalHashV1(material))
+  if (Result.isFailure(expectedBindingHash)) {
+    issues.push({ path: ['bindingHash'], issue: 'execution-session material must be canonicalizable' })
+  } else if (bindingHash !== expectedBindingHash.success) {
+    issues.push({ path: ['bindingHash'], issue: 'must match the causal execution-session material' })
+  }
+  return issues
+}
+
+export const ExecutionSessionBindingSchema = ExecutionSessionBindingBase.check(Schema.makeFilter(bindingIssues))
 export type ExecutionSessionBinding = typeof ExecutionSessionBindingSchema.Type
 
 export interface BindExecutionSessionInput {
@@ -160,99 +371,253 @@ export interface BindCycleExecutionSessionInput extends BindExecutionSessionInpu
   readonly cycle: AutonomousCycle
 }
 
-const decodeBinding = Schema.decodeUnknownSync(ExecutionSessionBindingSchema, StrictParseOptions)
-
-const observationMaterial = (observation: MarketCalendarObservation) => ({
-  schemaVersion: observation.schemaVersion,
-  source: observation.source,
-  requestedRange: observation.requestedRange,
-  timeZone: observation.timeZone,
-  sessions: observation.sessions,
+const BindExecutionSessionInputSchema = Schema.Struct({
+  signal: SignalBindingSchema,
+  planningBrokerState: PlanningBrokerStateBindingSchema,
+  calendar: CalendarIdentitySchema,
+  executionModel: ExecutionModelV2Schema,
 })
 
-export const bindExecutionSession = (input: BindExecutionSessionInput): ExecutionSessionBinding => {
-  if (input.executionModel.schemaVersion !== 'bayn.execution-model.v2') {
-    throw new Error('causal execution-session binding requires bayn.execution-model.v2')
-  }
-  if (canonicalHashV1(observationMaterial(input.calendar)) !== input.calendar.normalizedResponseHash) {
-    throw new Error('Alpaca market calendar normalized response hash does not match its content')
-  }
-  for (let index = 1; index < input.calendar.sessions.length; index += 1) {
-    if (input.calendar.sessions[index - 1].date >= input.calendar.sessions[index].date) {
-      throw new Error('Alpaca market calendar sessions must be unique and strictly ordered')
-    }
-  }
-  if (input.calendar.requestedRange.start > input.signal.sessionDate) {
-    throw new Error('Alpaca market calendar request must start on or before the signal session')
-  }
-  const executionSession = input.calendar.sessions.find((session) => session.date > input.signal.sessionDate)
-  if (executionSession === undefined) {
-    throw new Error('Alpaca market calendar response does not contain a future execution session')
-  }
-  if (
-    executionSession.date < input.calendar.requestedRange.start ||
-    executionSession.date > input.calendar.requestedRange.end
-  ) {
-    throw new Error('execution session is outside the bound Alpaca market calendar request')
-  }
-  const submissionOpenAt =
-    input.signal.finalizedAt >= input.planningBrokerState.observedAt
-      ? input.signal.finalizedAt
-      : input.planningBrokerState.observedAt
-  const cutoffLeadMinutes = input.executionModel.order.submissionCutoffLeadMinutes
-  const submissionCutoffAt = new Date(Date.parse(executionSession.openAt) - cutoffLeadMinutes * 60_000).toISOString()
-  const material = {
-    schemaVersion: 'bayn.execution-session-binding.v1',
-    signal: input.signal,
-    planningBrokerState: input.planningBrokerState,
-    calendar: {
-      schemaVersion: input.calendar.schemaVersion,
-      source: input.calendar.source,
-      requestedRange: input.calendar.requestedRange,
-      timeZone: input.calendar.timeZone,
-      sessions: input.calendar.sessions,
-      normalizedResponseHash: input.calendar.normalizedResponseHash,
+const BindCycleExecutionSessionInputSchema = Schema.Struct({
+  ...BindExecutionSessionInputSchema.fields,
+  cycle: AutonomousCycleSchema,
+})
+
+type DecodedBindExecutionSessionInput = typeof BindExecutionSessionInputSchema.Type
+type DecodedBindCycleExecutionSessionInput = typeof BindCycleExecutionSessionInputSchema.Type
+
+const decodeBindExecutionSessionInputResult = Schema.decodeUnknownResult(
+  BindExecutionSessionInputSchema,
+  strictParseOptions,
+)
+const decodeBindCycleExecutionSessionInputResult = Schema.decodeUnknownResult(
+  BindCycleExecutionSessionInputSchema,
+  strictParseOptions,
+)
+const decodeExecutionSessionBindingResult = Schema.decodeUnknownResult(
+  ExecutionSessionBindingSchema,
+  strictParseOptions,
+)
+
+const bindDecodedExecutionSession = (
+  input: DecodedBindExecutionSessionInput,
+): Result.Result<ExecutionSessionBinding, ExecutionSessionBindingFailure> =>
+  Result.flatMap(
+    deriveExecutionSessionWindow({
+      signal: input.signal,
+      planningBrokerState: input.planningBrokerState,
+      calendar: input.calendar,
+      submissionCutoffLeadMinutes: input.executionModel.order.submissionCutoffLeadMinutes,
+    }),
+    (derived) => {
+      const material = {
+        schemaVersion: 'bayn.execution-session-binding.v1',
+        signal: input.signal,
+        planningBrokerState: input.planningBrokerState,
+        calendar: input.calendar,
+        ...derived,
+        submissionCutoffLeadMinutes: input.executionModel.order.submissionCutoffLeadMinutes,
+      } as const
+      return Result.flatMap(
+        Result.try({
+          try: () => ({ ...material, bindingHash: canonicalHashV1(material) }),
+          catch: (cause) => bindFailure('hash', 'execution-session binding material is not canonicalizable', {}, cause),
+        }),
+        (binding) =>
+          Result.mapError(decodeExecutionSessionBindingResult(binding), (cause) =>
+            bindFailure('decode', 'derived execution-session binding is invalid', {}, cause),
+          ),
+      )
     },
-    executionSession,
-    submissionOpenAt,
-    submissionCutoffAt,
-    submissionCutoffLeadMinutes: cutoffLeadMinutes,
-  } as const
-  return decodeBinding({ ...material, bindingHash: canonicalHashV1(material) })
+  )
+
+export const bindExecutionSession = (
+  input: unknown,
+): Result.Result<ExecutionSessionBinding, ExecutionSessionBindingFailure> =>
+  Result.flatMap(
+    Result.mapError(decodeBindExecutionSessionInputResult(input), (cause) =>
+      bindFailure('decode', 'execution-session binding input is invalid', {}, cause),
+    ),
+    bindDecodedExecutionSession,
+  )
+
+const makeSelectedCycleCalendar = (
+  binding: ExecutionSessionBinding,
+): Result.Result<ExecutionCalendarObservation, ExecutionSessionBindingFailure> =>
+  Result.mapError(
+    makeExecutionCalendarObservation({
+      schemaVersion: binding.calendar.schemaVersion,
+      source: binding.calendar.source,
+      ...binding.executionSession,
+    }),
+    (cause) =>
+      bindCycleFailure(
+        'cycle-calendar',
+        'execution-session binding selected an invalid durable cycle calendar',
+        {},
+        cause,
+      ),
+  )
+
+const validateCycleCalendar = (
+  binding: ExecutionSessionBinding,
+  cycle: AutonomousCycle,
+  selected: ExecutionCalendarObservation,
+): Result.Result<void, ExecutionSessionBindingFailure> => {
+  const mismatch = [
+    {
+      field: 'signalSessionDate',
+      expected: cycle.identity.signalSessionDate,
+      observed: binding.signal.sessionDate,
+    },
+    {
+      field: 'executionSessionDate',
+      expected: cycle.window.executionSessionDate,
+      observed: binding.executionSession.date,
+    },
+    {
+      field: 'executionOpenAt',
+      expected: cycle.window.executionOpenAt,
+      observed: binding.executionSession.openAt,
+    },
+    {
+      field: 'executionCloseAt',
+      expected: cycle.window.executionCloseAt,
+      observed: binding.executionSession.closeAt,
+    },
+    {
+      field: 'executionCalendarSchemaVersion',
+      expected: cycle.window.executionCalendarSchemaVersion,
+      observed: selected.executionCalendarSchemaVersion,
+    },
+    {
+      field: 'executionCalendarSource',
+      expected: cycle.window.executionCalendarSource,
+      observed: selected.executionCalendarSource,
+    },
+    {
+      field: 'executionCalendarHash',
+      expected: cycle.window.executionCalendarHash,
+      observed: selected.executionCalendarHash,
+    },
+  ].find(({ expected, observed }) => expected !== observed)
+  if (mismatch !== undefined) {
+    return Result.fail(
+      bindCycleFailure('cycle-calendar', 'execution-session binding does not match the durable cycle calendar', {
+        cycleId: cycle.identity.cycleId,
+        ...mismatch,
+      }),
+    )
+  }
+  return Result.succeed(undefined)
 }
 
-export const bindCycleExecutionSession = (input: BindCycleExecutionSessionInput): ExecutionSessionBinding => {
-  const binding = bindExecutionSession(input)
-  const cycle = input.cycle
-  const selectedObservation = makeExecutionCalendarObservation({
-    schemaVersion: binding.calendar.schemaVersion,
-    source: binding.calendar.source,
-    ...binding.executionSession,
-  })
-  if (
-    binding.signal.sessionDate !== cycle.identity.signalSessionDate ||
-    binding.executionSession.date !== cycle.identity.executionSessionDate ||
-    binding.executionSession.date !== cycle.window.executionSessionDate ||
-    binding.executionSession.openAt !== cycle.window.executionOpenAt ||
-    binding.executionSession.closeAt !== cycle.window.executionCloseAt ||
-    selectedObservation.executionCalendarSchemaVersion !== cycle.identity.executionCalendarSchemaVersion ||
-    selectedObservation.executionCalendarSchemaVersion !== cycle.window.executionCalendarSchemaVersion ||
-    selectedObservation.executionCalendarSource !== cycle.identity.executionCalendarSource ||
-    selectedObservation.executionCalendarSource !== cycle.window.executionCalendarSource ||
-    selectedObservation.executionCalendarHash !== cycle.identity.executionCalendarHash ||
-    selectedObservation.executionCalendarHash !== cycle.window.executionCalendarHash
-  ) {
-    throw new TypeError('execution-session binding does not match the durable cycle calendar')
+const validateCycleSignalFinalization = (
+  binding: ExecutionSessionBinding,
+  cycle: AutonomousCycle,
+): Result.Result<void, ExecutionSessionBindingFailure> => {
+  if (binding.signal.finalizedAt < cycle.window.signalCloseAt) {
+    return Result.fail(
+      bindCycleFailure(
+        'cycle-window',
+        'cycle execution-session signal finalization cannot precede the durable signal close',
+        {
+          cycleId: cycle.identity.cycleId,
+          expectedMinimumSignalFinalizedAt: cycle.window.signalCloseAt,
+          observedSignalFinalizedAt: binding.signal.finalizedAt,
+        },
+      ),
+    )
   }
-  if (
-    canonicalHashV1(input.executionModel) !== cycle.identity.executionPolicy.strategyExecutionModelHash ||
-    binding.submissionCutoffLeadMinutes * 60_000 !== cycle.identity.executionPolicy.submissionCutoffBeforeOpenMs ||
-    binding.submissionCutoffAt !== cycle.window.submissionCutoffAt
-  ) {
-    throw new TypeError('execution-session binding does not match the durable cycle execution policy')
-  }
-  if (binding.submissionOpenAt < cycle.window.submissionOpenAt) {
-    throw new TypeError('execution-session binding cannot widen the durable cycle submission window')
-  }
-  return binding
+  return Result.succeed(undefined)
 }
+
+const validateCycleExecutionPolicy = (
+  input: DecodedBindCycleExecutionSessionInput,
+  binding: ExecutionSessionBinding,
+): Result.Result<void, ExecutionSessionBindingFailure> => {
+  const executionModelHash = Result.try({
+    try: () => canonicalHashV1(input.executionModel),
+    catch: (cause) =>
+      bindCycleFailure(
+        'hash',
+        'execution model is not canonicalizable',
+        { cycleId: input.cycle.identity.cycleId },
+        cause,
+      ),
+  })
+  if (Result.isFailure(executionModelHash)) return Result.fail(executionModelHash.failure)
+  if (executionModelHash.success !== input.cycle.identity.executionPolicy.strategyExecutionModelHash) {
+    return Result.fail(
+      bindCycleFailure('cycle-policy', 'execution-session binding does not match the durable cycle execution policy', {
+        cycleId: input.cycle.identity.cycleId,
+        field: 'strategyExecutionModelHash',
+        expected: input.cycle.identity.executionPolicy.strategyExecutionModelHash,
+        observed: executionModelHash.success,
+      }),
+    )
+  }
+  const observedCutoffLeadMs = binding.submissionCutoffLeadMinutes * 60_000
+  if (observedCutoffLeadMs !== input.cycle.identity.executionPolicy.submissionCutoffBeforeOpenMs) {
+    return Result.fail(
+      bindCycleFailure('cycle-policy', 'execution-session binding does not match the durable cycle execution policy', {
+        cycleId: input.cycle.identity.cycleId,
+        field: 'submissionCutoffBeforeOpenMs',
+        expected: input.cycle.identity.executionPolicy.submissionCutoffBeforeOpenMs,
+        observed: observedCutoffLeadMs,
+      }),
+    )
+  }
+  if (binding.submissionCutoffAt !== input.cycle.window.submissionCutoffAt) {
+    return Result.fail(
+      bindCycleFailure('cycle-policy', 'execution-session binding does not match the durable cycle execution policy', {
+        cycleId: input.cycle.identity.cycleId,
+        field: 'submissionCutoffAt',
+        expected: input.cycle.window.submissionCutoffAt,
+        observed: binding.submissionCutoffAt,
+      }),
+    )
+  }
+  return Result.succeed(undefined)
+}
+
+const validateCycleSubmissionWindow = (
+  cycle: AutonomousCycle,
+  binding: ExecutionSessionBinding,
+): Result.Result<void, ExecutionSessionBindingFailure> => {
+  if (binding.submissionOpenAt < cycle.window.submissionOpenAt) {
+    return Result.fail(
+      bindCycleFailure('cycle-window', 'execution-session binding cannot widen the durable cycle submission window', {
+        cycleId: cycle.identity.cycleId,
+        expectedMinimumSubmissionOpenAt: cycle.window.submissionOpenAt,
+        observedSubmissionOpenAt: binding.submissionOpenAt,
+      }),
+    )
+  }
+  return Result.succeed(undefined)
+}
+
+const bindDecodedCycleExecutionSession = (
+  input: DecodedBindCycleExecutionSessionInput,
+): Result.Result<ExecutionSessionBinding, ExecutionSessionBindingFailure> =>
+  Result.flatMap(bindDecodedExecutionSession(input), (binding) =>
+    Result.flatMap(makeSelectedCycleCalendar(binding), (selected) =>
+      Result.flatMap(validateCycleCalendar(binding, input.cycle, selected), () =>
+        Result.flatMap(validateCycleSignalFinalization(binding, input.cycle), () =>
+          Result.flatMap(validateCycleExecutionPolicy(input, binding), () =>
+            Result.map(validateCycleSubmissionWindow(input.cycle, binding), () => binding),
+          ),
+        ),
+      ),
+    ),
+  )
+
+export const bindCycleExecutionSession = (
+  input: unknown,
+): Result.Result<ExecutionSessionBinding, ExecutionSessionBindingFailure> =>
+  Result.flatMap(
+    Result.mapError(decodeBindCycleExecutionSessionInputResult(input), (cause) =>
+      bindCycleFailure('decode', 'cycle execution-session binding input is invalid', {}, cause),
+    ),
+    bindDecodedCycleExecutionSession,
+  )

--- a/services/bayn/src/risk.test.ts
+++ b/services/bayn/src/risk.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 
-import { Schema } from 'effect'
+import { Result, Schema } from 'effect'
 
 import { canonicalHashV1 } from './hash'
 import {
@@ -22,7 +22,20 @@ import {
   type ReferenceIntent,
 } from './paper'
 import { reconciledStateHash } from './reconciliation'
-import { BrokerMode, PolicySchema, Reason, StateSchema, evaluate, type Policy, type State } from './risk'
+import {
+  BrokerMode,
+  EvaluationSchema,
+  Gate,
+  orderedRiskGateDefinitions,
+  PolicySchema,
+  Reason,
+  RiskEvaluationFailure,
+  StateSchema,
+  evaluate,
+  type Evaluation,
+  type Policy,
+  type State,
+} from './risk'
 import { strictParseOptions } from './schemas'
 
 const evaluatedAt = '2026-07-21T21:00:00.000Z'
@@ -33,6 +46,33 @@ const decodePolicy = Schema.decodeUnknownSync(PolicySchema, strictParseOptions)
 const decodeState = Schema.decodeUnknownSync(StateSchema, strictParseOptions)
 const decodeIntent = Schema.decodeUnknownSync(IntentSchema, strictParseOptions)
 const decodeReferenceIntent = Schema.decodeUnknownSync(ReferenceIntentSchema, strictParseOptions)
+const decodeEvaluationResult = Schema.decodeUnknownResult(EvaluationSchema, strictParseOptions)
+
+type OperationReason<Input> = Input extends {
+  readonly operation: infer Operation
+  readonly reason: infer FailureReason
+}
+  ? { readonly operation: Operation; readonly reason: FailureReason }
+  : never
+type RiskFailurePair = OperationReason<ConstructorParameters<typeof RiskEvaluationFailure>[0]>
+const riskFailurePairs = [
+  { operation: 'bind-authority', reason: 'authority-contract' },
+  { operation: 'bind-authority', reason: 'authority-generation' },
+  { operation: 'bind-authority', reason: 'authority-maximum' },
+  { operation: 'canonicalize-input', reason: 'evidence' },
+  { operation: 'canonicalize-input', reason: 'reconciliation' },
+  { operation: 'decode-input', reason: 'intent' },
+  { operation: 'decode-input', reason: 'policy' },
+  { operation: 'decode-input', reason: 'positions' },
+  { operation: 'decode-input', reason: 'state' },
+  { operation: 'decode-output', reason: 'decision' },
+  { operation: 'decode-output', reason: 'evaluation' },
+  { operation: 'decode-output', reason: 'input' },
+] as const satisfies readonly RiskFailurePair[]
+type MissingRiskFailurePair = Exclude<RiskFailurePair, (typeof riskFailurePairs)[number]>
+type InvalidRiskFailurePair = Exclude<(typeof riskFailurePairs)[number], RiskFailurePair>
+const riskFailurePairCoverage: [MissingRiskFailurePair, InvalidRiskFailurePair] extends [never, never] ? true : never =
+  true
 
 const rehashExecutionSession = (
   binding: Omit<State['executionSession'], 'bindingHash'>,
@@ -47,7 +87,13 @@ const changeExecutionWindow = (
 ): State['executionSession'] => {
   const { bindingHash: _, ...material } = binding
   if (overrides.submissionCutoffAt === undefined) {
-    return rehashExecutionSession({ ...material, ...overrides })
+    return rehashExecutionSession({
+      ...material,
+      ...overrides,
+      ...(overrides.submissionOpenAt === undefined
+        ? {}
+        : { signal: { ...material.signal, finalizedAt: overrides.submissionOpenAt } }),
+    })
   }
   const executionOpenAt = new Date(
     Date.parse(overrides.submissionCutoffAt) + material.submissionCutoffLeadMinutes * 60_000,
@@ -285,13 +331,24 @@ const makeReferenceIntent = (): ReferenceIntent => {
   return decodeReferenceIntent({ ...intent, schemaVersion: 'bayn.paper-intent.v2' })
 }
 
+const evaluateSuccess = (
+  intent: Intent | ReferenceIntent,
+  state: State,
+  policy: Policy,
+  proposedPositions?: State['positions'],
+): Evaluation => {
+  const result = evaluate(intent, state, policy, proposedPositions)
+  if (Result.isFailure(result)) throw result.failure
+  return result.success
+}
+
 const expectBlocked = (
   reason: Reason,
   intent: Intent | ReferenceIntent = makeIntent(),
   state = makeState(),
   policy = makePolicy(),
 ): void => {
-  const result = evaluate(intent, state, policy)
+  const result = evaluateSuccess(intent, state, policy)
   expect(result.decision.outcome).toBe(RiskOutcome.Blocked)
   expect(result.decision.reasonCodes).toContain(reason)
 }
@@ -373,13 +430,23 @@ describe('bounded paper risk', () => {
   })
 
   test('approves the exact limit boundary and binds a deterministic decision', () => {
-    const first = evaluate(makeIntent(), makeState(), makePolicy())
-    const second = evaluate(makeIntent(), makeState(), makePolicy())
+    const first = evaluateSuccess(makeIntent(), makeState(), makePolicy())
+    const second = evaluateSuccess(makeIntent(), makeState(), makePolicy())
 
     expect(first).toEqual(second)
     expect(first.decision.outcome).toBe(RiskOutcome.Approved)
     expect(first.decision.reasonCodes).toEqual([])
     expect(first.gates.every((gate) => gate.passed)).toBe(true)
+    expect(first.gates.map(({ name, reason }) => ({ name, reason }))).toEqual(
+      orderedRiskGateDefinitions.map(({ name, reason }) => ({ name, reason })),
+    )
+    expect({
+      inputHash: first.input.inputHash,
+      decisionId: first.decision.decisionId,
+    }).toEqual({
+      inputHash: 'e5579076394f86be2dbd61b7a4e6d65133f52568c2af1642a7a04e9726fe0c61',
+      decisionId: 'c7b20a3346071c31182bc7799709676e6e33d4418a51bde1f880465d0d09e8d0',
+    })
     expect(first.input.freshUntil).toBe('2026-07-21T21:00:30.000Z')
     expect(first.metrics).toEqual({
       orderNotionalMicros: '100000000',
@@ -414,12 +481,12 @@ describe('bounded paper risk', () => {
       executionSession: changeExecutionWindow(state.executionSession, { submissionCutoffAt: nearCutoffAt }),
     })
 
-    expect(evaluate(makeIntent({ createdAt: evaluatedAt }), atOpen, makePolicy()).decision.outcome).toBe(
+    expect(evaluateSuccess(makeIntent({ createdAt: evaluatedAt }), atOpen, makePolicy()).decision.outcome).toBe(
       RiskOutcome.Approved,
     )
     expectBlocked(Reason.OutsideSession, makeIntent(), beforeOpen, makePolicy())
     expectBlocked(Reason.OutsideSession, makeIntent(), atCutoff, makePolicy())
-    const nearCutoff = evaluate(makeIntent(), observeNearCutoff, makePolicy())
+    const nearCutoff = evaluateSuccess(makeIntent(), observeNearCutoff, makePolicy())
     expect(nearCutoff.decision.reasonCodes).toContain(Reason.AuthorityNotPaper)
     expect(nearCutoff.decision.expiresAt).toBe(nearCutoffAt)
     expect(nearCutoff.input.freshUntil).toBe(nearCutoffAt)
@@ -466,7 +533,7 @@ describe('bounded paper risk', () => {
       maxDailyTradedNotionalMicros: '201000000',
       maxAdverseSlippageBps: 100,
     })
-    expect(evaluate(slippageIntent, slippageState, slippagePolicy).decision.outcome).toBe(RiskOutcome.Approved)
+    expect(evaluateSuccess(slippageIntent, slippageState, slippagePolicy).decision.outcome).toBe(RiskOutcome.Approved)
     expectBlocked(
       Reason.AdverseSlippageExceeded,
       slippageIntent,
@@ -479,7 +546,7 @@ describe('bounded paper risk', () => {
   })
 
   test('does not require buying power for a position-reducing sell', () => {
-    const result = evaluate(
+    const result = evaluateSuccess(
       makeIntent({ side: OrderSide.Sell }),
       makeState({ account: { ...baseState().account, buyingPowerMicros: '0' } }),
       makePolicy(),
@@ -512,7 +579,7 @@ describe('bounded paper risk', () => {
       maxNetExposureMicros: '500000000',
       maxDailyTradedNotionalMicros: '300000000',
     })
-    const result = evaluate(intent, state, policy)
+    const result = evaluateSuccess(intent, state, policy)
 
     expect(result.decision.outcome).toBe(RiskOutcome.Approved)
     expect(result.metrics.postTradeSymbolExposureMicros).toBe('400000000')
@@ -552,7 +619,7 @@ describe('bounded paper risk', () => {
       maxNetExposureMicros: '300000000',
       maxDailyTradedNotionalMicros: '298000000',
     })
-    const result = evaluate(intent, state, policy)
+    const result = evaluateSuccess(intent, state, policy)
 
     expect(result.decision.outcome).toBe(RiskOutcome.Blocked)
     expect(result.decision.reasonCodes).toContain(Reason.ShortPositionNotAllowed)
@@ -591,7 +658,7 @@ describe('bounded paper risk', () => {
       expectedExecutionPriceMicros: '49100000',
     })
     const intent = makeIntent({ side: OrderSide.Sell, quantityMicros: '1', notionalLimitMicros: '50' })
-    const result = evaluate(intent, state, makePolicy())
+    const result = evaluateSuccess(intent, state, makePolicy())
 
     expect(result.metrics.postTradeSymbolExposureMicros).toBe('-99')
     expect(result.metrics.postTradeNetExposureMicros).toBe('2')
@@ -707,11 +774,15 @@ describe('bounded paper risk', () => {
   })
 
   test('binds every intent, policy, and evidence change and caps approval lifetime', () => {
-    const baseline = evaluate(makeIntent(), makeState(), makePolicy())
-    const changedIntent = evaluate(makeIntent({ clientOrderId: 'risk-test-order-2' }), makeState(), makePolicy())
-    const changedPolicy = evaluate(makeIntent(), makeState(), makePolicy({ allowedSymbols: ['AMD', 'NVDA', 'WDC'] }))
-    const changedState = evaluate(makeIntent(), makeState({ marketDataHash: hash('9') }), makePolicy())
-    const changedAccounting = evaluate(makeIntent(), makeState({ accountingHash: hash('b') }), makePolicy())
+    const baseline = evaluateSuccess(makeIntent(), makeState(), makePolicy())
+    const changedIntent = evaluateSuccess(makeIntent({ clientOrderId: 'risk-test-order-2' }), makeState(), makePolicy())
+    const changedPolicy = evaluateSuccess(
+      makeIntent(),
+      makeState(),
+      makePolicy({ allowedSymbols: ['AMD', 'NVDA', 'WDC'] }),
+    )
+    const changedState = evaluateSuccess(makeIntent(), makeState({ marketDataHash: hash('9') }), makePolicy())
+    const changedAccounting = evaluateSuccess(makeIntent(), makeState({ accountingHash: hash('b') }), makePolicy())
 
     expect(changedIntent.input.intentId).toBe(baseline.input.intentId)
     expect(changedIntent.input.inputHash).not.toBe(baseline.input.inputHash)
@@ -721,13 +792,13 @@ describe('bounded paper risk', () => {
     expect(changedState.input.inputHash).not.toBe(baseline.input.inputHash)
     expect(changedAccounting.input.inputHash).not.toBe(baseline.input.inputHash)
 
-    const ttlCapped = evaluate(makeIntent(), makeState(), makePolicy({ decisionTtlMs: 1_000 }))
-    const freshnessCapped = evaluate(
+    const ttlCapped = evaluateSuccess(makeIntent(), makeState(), makePolicy({ decisionTtlMs: 1_000 }))
+    const freshnessCapped = evaluateSuccess(
       makeIntent(),
       makeState(),
       makePolicy({ decisionTtlMs: 60_000, maxBrokerStateAgeMs: 30_001, maxMarketDataAgeMs: 30_001 }),
     )
-    const cutoffCapped = evaluate(
+    const cutoffCapped = evaluateSuccess(
       makeIntent(),
       makeState({
         executionSession: changeExecutionWindow(makeState().executionSession, {
@@ -736,7 +807,7 @@ describe('bounded paper risk', () => {
       }),
       makePolicy({ decisionTtlMs: 60_000 }),
     )
-    const intentCapped = evaluate(
+    const intentCapped = evaluateSuccess(
       makeIntent(),
       makeState(),
       makePolicy({ decisionTtlMs: 60_000, maxIntentAgeMs: 15_001 }),
@@ -749,20 +820,16 @@ describe('bounded paper risk', () => {
 
   test('requires the exact authority generation for PAPER evaluation and hashes that binding', () => {
     const baselineState = makeState()
-    const baseline = evaluate(makeIntent(), baselineState, makePolicy())
+    const baseline = evaluateSuccess(makeIntent(), baselineState, makePolicy())
     const rotatedAuthority = { ...baselineState.authority, generationHash: hash('9') }
     const rotatedState = makeState({ authority: rotatedAuthority })
-    const rotated = evaluate(makeIntent({ authorityGenerationHash: hash('9') }), rotatedState, makePolicy())
+    const rotated = evaluateSuccess(makeIntent({ authorityGenerationHash: hash('9') }), rotatedState, makePolicy())
 
     expect(rotated.input.inputHash).not.toBe(baseline.input.inputHash)
     expect(rotated.gates.find((gate) => gate.name === 'reconciliation')?.passed).toBe(true)
-    expect(() => evaluate(makeIntent(), rotatedState, makePolicy())).toThrow(
-      'PAPER risk intent must bind the exact PAPER authority generation from risk state',
-    )
-    expect(() => evaluate(makeReferenceIntent(), baselineState, makePolicy())).toThrow(
-      'PAPER risk evaluation requires an authority-generation-bound intent',
-    )
-    expect(() =>
+    const failures = [
+      evaluate(makeIntent(), rotatedState, makePolicy()),
+      evaluate(makeReferenceIntent(), baselineState, makePolicy()),
       evaluate(
         makeReferenceIntent(),
         makeState({
@@ -775,8 +842,6 @@ describe('bounded paper risk', () => {
         }),
         makePolicy(),
       ),
-    ).toThrow('PAPER risk evaluation requires an authority-generation-bound intent')
-    expect(() =>
       evaluate(
         makeIntent(),
         makeState({
@@ -788,6 +853,117 @@ describe('bounded paper risk', () => {
         }),
         makePolicy(),
       ),
-    ).toThrow('authority-generation-bound risk intent requires PAPER maximum authority')
+    ] as const
+    expect(failures.map((result) => (Result.isFailure(result) ? result.failure.reason : null))).toEqual([
+      'authority-generation',
+      'authority-contract',
+      'authority-contract',
+      'authority-maximum',
+    ])
+    for (const result of failures) {
+      expect(Result.isFailure(result)).toBe(true)
+      if (Result.isFailure(result)) {
+        expect(result.failure).toMatchObject({
+          _tag: 'RiskEvaluationFailure',
+          operation: 'bind-authority',
+        })
+      }
+    }
+  })
+
+  test('returns closed tagged failures for malformed exported inputs', () => {
+    const cases = [
+      ['intent', evaluate({}, makeState(), makePolicy())],
+      ['state', evaluate(makeIntent(), {}, makePolicy())],
+      ['policy', evaluate(makeIntent(), makeState(), {})],
+      ['positions', evaluate(makeIntent(), makeState(), makePolicy(), [{}])],
+    ] as const
+
+    for (const [reason, result] of cases) {
+      expect(Result.isFailure(result)).toBe(true)
+      if (Result.isFailure(result)) {
+        expect(result.failure).toMatchObject({
+          _tag: 'RiskEvaluationFailure',
+          operation: 'decode-input',
+          reason,
+        })
+        expect(result.failure.cause).toBeDefined()
+      }
+    }
+  })
+
+  test('exposes exactly the correlated risk failure operation and reason table', () => {
+    const failures = riskFailurePairs.map(
+      (pair) => new RiskEvaluationFailure({ ...pair, message: 'failure-pair coverage', facts: {} }),
+    )
+    expect(riskFailurePairCoverage).toBe(true)
+    expect(failures.map(({ operation, reason }) => ({ operation, reason }))).toEqual([...riskFailurePairs])
+    expect(failures.every((failure) => failure._tag === 'RiskEvaluationFailure')).toBe(true)
+  })
+
+  test('rejects projected position books that diverge from the authoritative account snapshot context', () => {
+    const state = makeState()
+    const first = state.positions[0]
+    const second = state.positions[1]
+    if (first === undefined || second === undefined) throw new Error('risk fixture requires two positions')
+    const cases: readonly State['positions'][] = [
+      [second, first],
+      [first, { ...second, symbol: first.symbol }],
+      [{ ...first, accountId: 'another-account' }, second],
+      [{ ...first, observedAt: '2026-07-21T20:59:29.999Z' }, second],
+      [{ ...first, marketValueMicros: '0' }, second],
+    ]
+
+    for (const proposedPositions of cases) {
+      const result = evaluate(makeIntent(), state, makePolicy(), proposedPositions)
+      expect(Result.isFailure(result)).toBe(true)
+      if (Result.isFailure(result)) {
+        expect(result.failure).toMatchObject({
+          _tag: 'RiskEvaluationFailure',
+          operation: 'decode-input',
+          reason: 'positions',
+        })
+        expect(result.failure.facts.issues).toBeArray()
+      }
+    }
+  })
+
+  test('fails before gates when malformed projected positions could undercount exact-state gross exposure', () => {
+    const state = makeState()
+    expect(state.reconciliation.status).toBe(ReconciliationStatus.Exact)
+    expect(state.reconciliation.expectedHash).toBe(state.reconciliation.observedHash)
+    const proposedPositions = state.positions.map((position) =>
+      position.symbol === 'AMD' ? { ...position, marketValueMicros: '0' } : position,
+    )
+    const result = evaluate(makeIntent(), state, makePolicy({ maxGrossExposureMicros: '250000000' }), proposedPositions)
+
+    expect(Result.isFailure(result)).toBe(true)
+    if (Result.isFailure(result)) {
+      expect(result.failure).toMatchObject({
+        _tag: 'RiskEvaluationFailure',
+        operation: 'decode-input',
+        reason: 'positions',
+      })
+      expect(result.failure.facts.issues).toContainEqual({
+        path: ['positions', 0, 'marketValueMicros'],
+        issue: 'must have the quantity sign',
+      })
+    }
+  })
+
+  test('rejects a rehashed evaluation with a gate assigned another gate reason', () => {
+    const valid = evaluateSuccess(makeIntent(), makeState(), makePolicy())
+    const gates = valid.gates.map((gate) => ({ ...gate }))
+    const firstReason = gates[0]?.reason
+    const secondReason = gates[1]?.reason
+    if (firstReason === undefined || secondReason === undefined) {
+      throw new Error('risk fixture requires the first two authoritative gates')
+    }
+    gates[0] = { ...gates[0]!, reason: secondReason }
+    gates[1] = { ...gates[1]!, reason: firstReason }
+
+    const decoded = decodeEvaluationResult({ ...valid, gates })
+    expect(Result.isFailure(decoded)).toBe(true)
+    expect(gates[0]?.name).toBe(Gate.IntentState)
   })
 })

--- a/services/bayn/src/risk.ts
+++ b/services/bayn/src/risk.ts
@@ -1,4 +1,4 @@
-import { Schema } from 'effect'
+import { Data, Result, Schema } from 'effect'
 
 import { canonicalHashV1 } from './hash'
 import { ExecutionSessionBindingSchema } from './execution-session'
@@ -7,6 +7,7 @@ import {
   AccountStatus,
   Authority,
   AuthorityStateSchema,
+  IntentSchema,
   IntentState,
   KillState,
   OrderSchema,
@@ -17,6 +18,7 @@ import {
   PositiveMicrosSchema,
   ReconciliationSchema,
   ReconciliationStatus,
+  ReferenceIntentSchema,
   RiskDecisionSchema,
   RiskInputSchema,
   RiskOutcome,
@@ -24,6 +26,7 @@ import {
   TimeInForce,
   UnsignedMicrosSchema,
   type Intent,
+  type Position,
   type ReferenceIntent,
 } from './paper'
 import { reconciledStateHash } from './reconciliation'
@@ -129,6 +132,55 @@ export enum Reason {
   DrawdownExceeded = 'DRAWDOWN_EXCEEDED',
 }
 
+export interface RiskGateDefinition {
+  readonly name: Gate
+  readonly reason: Reason
+}
+
+type RiskGateDefinitionByName = {
+  readonly [Name in Gate]: {
+    readonly name: Name
+    readonly reason: Reason
+  }
+}
+
+const riskGateDefinitionByName: RiskGateDefinitionByName = {
+  [Gate.IntentState]: { name: Gate.IntentState, reason: Reason.IntentNotPlanned },
+  [Gate.IntentTime]: { name: Gate.IntentTime, reason: Reason.IntentTimeInvalid },
+  [Gate.IntentFreshness]: { name: Gate.IntentFreshness, reason: Reason.IntentStale },
+  [Gate.Account]: { name: Gate.Account, reason: Reason.AccountMismatch },
+  [Gate.AccountStatus]: { name: Gate.AccountStatus, reason: Reason.AccountNotActive },
+  [Gate.Equity]: { name: Gate.Equity, reason: Reason.EquityNotPositive },
+  [Gate.Symbol]: { name: Gate.Symbol, reason: Reason.SymbolNotAllowed },
+  [Gate.MarketDataSymbol]: { name: Gate.MarketDataSymbol, reason: Reason.MarketDataSymbolMismatch },
+  [Gate.OrderType]: { name: Gate.OrderType, reason: Reason.OrderTypeNotAllowed },
+  [Gate.TimeInForce]: { name: Gate.TimeInForce, reason: Reason.TimeInForceNotAllowed },
+  [Gate.Authority]: { name: Gate.Authority, reason: Reason.AuthorityNotPaper },
+  [Gate.Kill]: { name: Gate.Kill, reason: Reason.KillActive },
+  [Gate.Reconciliation]: { name: Gate.Reconciliation, reason: Reason.ReconciliationNotExact },
+  [Gate.BrokerStateFreshness]: { name: Gate.BrokerStateFreshness, reason: Reason.BrokerStateStale },
+  [Gate.MarketDataFreshness]: { name: Gate.MarketDataFreshness, reason: Reason.MarketDataStale },
+  [Gate.Session]: { name: Gate.Session, reason: Reason.OutsideSession },
+  [Gate.UnknownMutations]: { name: Gate.UnknownMutations, reason: Reason.UnknownMutation },
+  [Gate.UnresolvedOrders]: { name: Gate.UnresolvedOrders, reason: Reason.UnresolvedOrdersExceeded },
+  [Gate.IntentNotional]: { name: Gate.IntentNotional, reason: Reason.IntentNotionalExceeded },
+  [Gate.OrderNotional]: { name: Gate.OrderNotional, reason: Reason.OrderNotionalExceeded },
+  [Gate.BuyingPower]: { name: Gate.BuyingPower, reason: Reason.BuyingPowerExceeded },
+  [Gate.AdverseSlippage]: { name: Gate.AdverseSlippage, reason: Reason.AdverseSlippageExceeded },
+  [Gate.LongOnly]: { name: Gate.LongOnly, reason: Reason.ShortPositionNotAllowed },
+  [Gate.SymbolExposure]: { name: Gate.SymbolExposure, reason: Reason.SymbolExposureExceeded },
+  [Gate.GrossExposure]: { name: Gate.GrossExposure, reason: Reason.GrossExposureExceeded },
+  [Gate.NetExposure]: { name: Gate.NetExposure, reason: Reason.NetExposureExceeded },
+  [Gate.DailyTradedNotional]: {
+    name: Gate.DailyTradedNotional,
+    reason: Reason.DailyTradedNotionalExceeded,
+  },
+  [Gate.DailyLoss]: { name: Gate.DailyLoss, reason: Reason.DailyLossExceeded },
+  [Gate.Drawdown]: { name: Gate.Drawdown, reason: Reason.DrawdownExceeded },
+}
+
+export const orderedRiskGateDefinitions: ReadonlyArray<RiskGateDefinition> = Object.values(riskGateDefinitionByName)
+
 export const PolicySchema = Schema.Struct({
   schemaVersion: Schema.Literal('bayn.paper-risk-policy.v1'),
   accountId: NonEmptyString,
@@ -184,6 +236,38 @@ const StateBase = Schema.Struct({
 
 const timeDoesNotFollow = (candidate: string, boundary: string): boolean => candidate > boundary
 
+interface PositionBook {
+  readonly positions: readonly Position[]
+  readonly accountId: string
+  readonly observedAt: string
+}
+
+const positionBookIssues = (book: PositionBook): readonly Schema.FilterIssue[] => {
+  const issues: Schema.FilterIssue[] = []
+  const symbols = book.positions.map((position) => position.symbol)
+  if (new Set(symbols).size !== symbols.length || !isSorted(symbols)) {
+    issues.push({ path: ['positions'], issue: 'must be unique and sorted by symbol' })
+  }
+  for (const [index, position] of book.positions.entries()) {
+    if (position.accountId !== book.accountId) {
+      issues.push({ path: ['positions', index, 'accountId'], issue: 'must match the account snapshot' })
+    }
+    if (position.observedAt !== book.observedAt) {
+      issues.push({ path: ['positions', index, 'observedAt'], issue: 'must match positionsObservedAt' })
+    }
+    const quantity = BigInt(position.quantityMicros)
+    const marketValue = BigInt(position.marketValueMicros)
+    if (
+      (quantity === 0n) !== (marketValue === 0n) ||
+      (quantity > 0n && marketValue <= 0n) ||
+      (quantity < 0n && marketValue >= 0n)
+    ) {
+      issues.push({ path: ['positions', index, 'marketValueMicros'], issue: 'must have the quantity sign' })
+    }
+  }
+  return issues
+}
+
 export const StateSchema = StateBase.check(
   Schema.makeFilter((state: typeof StateBase.Type): readonly Schema.FilterIssue[] => {
     const issues: Schema.FilterIssue[] = []
@@ -227,27 +311,13 @@ export const StateSchema = StateBase.check(
     ) {
       issues.push({ path: ['reconciliation', 'reconciledAt'], issue: 'must cover every broker snapshot' })
     }
-    const positionSymbols = state.positions.map((position) => position.symbol)
-    if (new Set(positionSymbols).size !== positionSymbols.length || !isSorted(positionSymbols)) {
-      issues.push({ path: ['positions'], issue: 'must be unique and sorted by symbol' })
-    }
-    for (const [index, position] of state.positions.entries()) {
-      if (position.accountId !== accountId) {
-        issues.push({ path: ['positions', index, 'accountId'], issue: 'must match the account snapshot' })
-      }
-      if (position.observedAt !== state.positionsObservedAt) {
-        issues.push({ path: ['positions', index, 'observedAt'], issue: 'must match positionsObservedAt' })
-      }
-      const quantity = BigInt(position.quantityMicros)
-      const marketValue = BigInt(position.marketValueMicros)
-      if (
-        (quantity === 0n) !== (marketValue === 0n) ||
-        (quantity > 0n && marketValue < 0n) ||
-        (quantity < 0n && marketValue > 0n)
-      ) {
-        issues.push({ path: ['positions', index, 'marketValueMicros'], issue: 'must have the quantity sign' })
-      }
-    }
+    issues.push(
+      ...positionBookIssues({
+        positions: state.positions,
+        accountId,
+        observedAt: state.positionsObservedAt,
+      }),
+    )
     const brokerOrderIds = state.orders.map((order) => order.brokerOrderId)
     if (new Set(brokerOrderIds).size !== brokerOrderIds.length || !isSorted(brokerOrderIds)) {
       issues.push({ path: ['orders'], issue: 'must be unique and sorted by brokerOrderId' })
@@ -327,15 +397,20 @@ export const EvaluationSchema = EvaluationBase.check(
       issues.push({ path: ['decision'], issue: 'must retain the risk input evaluation and expiry times' })
     }
     const { decisionId, ...decisionMaterial } = evaluation.decision
-    if (decisionId !== canonicalHashV1(decisionMaterial)) {
+    const expectedDecisionId = Result.try(() => canonicalHashV1(decisionMaterial))
+    if (Result.isFailure(expectedDecisionId)) {
+      issues.push({ path: ['decision', 'decisionId'], issue: 'risk decision material must be canonicalizable' })
+    } else if (decisionId !== expectedDecisionId.success) {
       issues.push({ path: ['decision', 'decisionId'], issue: 'must match the canonical risk decision material' })
     }
-    const gateNames = Object.values(Gate)
     if (
-      evaluation.gates.length !== gateNames.length ||
-      evaluation.gates.some((gate, index) => gate.name !== gateNames[index])
+      evaluation.gates.length !== orderedRiskGateDefinitions.length ||
+      evaluation.gates.some((gate, index) => {
+        const definition = orderedRiskGateDefinitions[index]
+        return definition === undefined || gate.name !== definition.name || gate.reason !== definition.reason
+      })
     ) {
-      issues.push({ path: ['gates'], issue: 'must contain every risk gate in canonical order' })
+      issues.push({ path: ['gates'], issue: 'must contain every risk gate/reason pair in canonical order' })
     }
     const failedReasons = evaluation.gates.filter((gate) => !gate.passed).map((gate) => gate.reason)
     if (
@@ -354,8 +429,86 @@ export const EvaluationSchema = EvaluationBase.check(
 export type Evaluation = typeof EvaluationSchema.Type
 export type RiskIntent = Intent | ReferenceIntent
 
-const decodeInput = Schema.decodeUnknownSync(RiskInputSchema, StrictParseOptions)
-const decodeDecision = Schema.decodeUnknownSync(RiskDecisionSchema, StrictParseOptions)
+interface BindRiskAuthorityIssue {
+  readonly operation: 'bind-authority'
+  readonly reason: 'authority-contract' | 'authority-generation' | 'authority-maximum'
+}
+
+interface CanonicalizeRiskInputIssue {
+  readonly operation: 'canonicalize-input'
+  readonly reason: 'evidence' | 'reconciliation'
+}
+
+interface DecodeRiskInputIssue {
+  readonly operation: 'decode-input'
+  readonly reason: 'intent' | 'policy' | 'positions' | 'state'
+}
+
+interface DecodeRiskOutputIssue {
+  readonly operation: 'decode-output'
+  readonly reason: 'decision' | 'evaluation' | 'input'
+}
+
+type RiskEvaluationIssue =
+  | BindRiskAuthorityIssue
+  | CanonicalizeRiskInputIssue
+  | DecodeRiskInputIssue
+  | DecodeRiskOutputIssue
+
+interface RiskEvaluationFailureDetails {
+  readonly message: string
+  readonly facts: Readonly<Record<string, unknown>>
+  readonly cause?: unknown
+}
+
+export const RiskEvaluationFailure = Data.TaggedError('RiskEvaluationFailure')<
+  RiskEvaluationIssue & RiskEvaluationFailureDetails
+>
+export type RiskEvaluationFailure = InstanceType<typeof RiskEvaluationFailure>
+
+type RiskEvaluationReason<Operation extends RiskEvaluationIssue['operation']> = Extract<
+  RiskEvaluationIssue,
+  { readonly operation: Operation }
+>['reason']
+
+const bindRiskAuthorityFailure = (
+  reason: RiskEvaluationReason<'bind-authority'>,
+  message: string,
+  facts: Readonly<Record<string, unknown>> = {},
+  cause?: unknown,
+): RiskEvaluationFailure => new RiskEvaluationFailure({ operation: 'bind-authority', reason, message, facts, cause })
+
+const canonicalizeRiskInputFailure = (
+  reason: RiskEvaluationReason<'canonicalize-input'>,
+  message: string,
+  facts: Readonly<Record<string, unknown>> = {},
+  cause?: unknown,
+): RiskEvaluationFailure =>
+  new RiskEvaluationFailure({ operation: 'canonicalize-input', reason, message, facts, cause })
+
+const decodeRiskInputFailure = (
+  reason: RiskEvaluationReason<'decode-input'>,
+  message: string,
+  facts: Readonly<Record<string, unknown>> = {},
+  cause?: unknown,
+): RiskEvaluationFailure => new RiskEvaluationFailure({ operation: 'decode-input', reason, message, facts, cause })
+
+const decodeRiskOutputFailure = (
+  reason: RiskEvaluationReason<'decode-output'>,
+  message: string,
+  facts: Readonly<Record<string, unknown>> = {},
+  cause?: unknown,
+): RiskEvaluationFailure => new RiskEvaluationFailure({ operation: 'decode-output', reason, message, facts, cause })
+
+const RiskIntentSchema = Schema.Union([IntentSchema, ReferenceIntentSchema])
+const ProposedPositionsSchema = Schema.Array(PositionSchema)
+const decodeRiskIntentResult = Schema.decodeUnknownResult(RiskIntentSchema, StrictParseOptions)
+const decodeRiskStateResult = Schema.decodeUnknownResult(StateSchema, StrictParseOptions)
+const decodeRiskPolicyResult = Schema.decodeUnknownResult(PolicySchema, StrictParseOptions)
+const decodeProposedPositionsResult = Schema.decodeUnknownResult(ProposedPositionsSchema, StrictParseOptions)
+const decodeRiskInputResult = Schema.decodeUnknownResult(RiskInputSchema, StrictParseOptions)
+const decodeRiskDecisionResult = Schema.decodeUnknownResult(RiskDecisionSchema, StrictParseOptions)
+const decodeRiskEvaluationResult = Schema.decodeUnknownResult(EvaluationSchema, StrictParseOptions)
 
 const absolute = (value: bigint): bigint => (value < 0n ? -value : value)
 const positiveDifference = (left: bigint, right: bigint): bigint => (left > right ? left - right : 0n)
@@ -368,162 +521,265 @@ const utc = (value: number): string => new Date(value).toISOString()
 
 const makeGate = (
   name: Gate,
-  reason: Reason,
   passed: boolean,
   actual: string | number | bigint,
   required: string | number | bigint,
-): GateResult => ({ name, reason, passed, actual: String(actual), required: String(required) })
+): GateResult => ({
+  name,
+  reason: riskGateDefinitionByName[name].reason,
+  passed,
+  actual: String(actual),
+  required: String(required),
+})
 
 const isUnresolved = (status: OrderStatus): boolean =>
   status === OrderStatus.New || status === OrderStatus.PartiallyFilled || status === OrderStatus.Pending
 
-export const evaluate = (
+interface ParsedPositionFacts {
+  readonly symbol: string
+  readonly quantityMicros: bigint
+  readonly marketValueMicros: bigint
+}
+
+interface RiskFacts {
+  readonly intent: RiskIntent
+  readonly state: State
+  readonly policy: Policy
+  readonly proposedPositions: State['positions']
+  readonly positions: ReadonlyArray<ParsedPositionFacts>
+  readonly evaluatedAt: number
+  readonly intentCreatedAt: number
+  readonly marketDataObservedAt: number
+  readonly submissionOpenAt: number
+  readonly submissionCutoffAt: number
+  readonly referencePriceMicros: bigint
+  readonly expectedExecutionPriceMicros: bigint
+  readonly intentQuantityMicros: bigint
+  readonly intentNotionalLimitMicros: bigint
+  readonly accountEquityMicros: bigint
+  readonly accountBuyingPowerMicros: bigint
+  readonly reservedBuyingPowerMicros: bigint
+  readonly priorDailyTradedNotionalMicros: bigint
+  readonly dayStartEquityMicros: bigint
+  readonly peakEquityMicros: bigint
+  readonly maxOrderNotionalMicros: bigint
+  readonly maxSymbolExposureMicros: bigint
+  readonly maxGrossExposureMicros: bigint
+  readonly maxNetExposureMicros: bigint
+  readonly maxDailyTradedNotionalMicros: bigint
+  readonly maxDailyLossMicros: bigint
+  readonly maxDrawdownMicros: bigint
+  readonly maxAdverseSlippageBps: bigint
+}
+
+interface DerivedRiskMetrics {
+  readonly orderNotionalMicros: bigint
+  readonly currentSymbolQuantityMicros: bigint
+  readonly postTradeSymbolQuantityMicros: bigint
+  readonly postTradeSymbolExposureMicros: bigint
+  readonly postTradeSymbolExposureMagnitudeMicros: bigint
+  readonly postTradeGrossExposureMicros: bigint
+  readonly postTradeNetExposureMicros: bigint
+  readonly postTradeNetExposureMagnitudeMicros: bigint
+  readonly aggregateBuyingPowerMicros: bigint
+  readonly dailyTradedNotionalMicros: bigint
+  readonly dailyLossMicros: bigint
+  readonly drawdownMicros: bigint
+  readonly adverseSlippageBps: bigint
+  readonly unresolvedOrderCount: number
+  readonly oldestBrokerStateAt: number
+  readonly brokerFreshUntil: number
+  readonly marketFreshUntil: number
+}
+
+const parseRiskFacts = (
   intent: RiskIntent,
   state: State,
   policy: Policy,
-  proposedPositions: State['positions'] = state.positions,
-): Evaluation => {
-  if (intent.schemaVersion === 'bayn.paper-intent.v3') {
-    if (state.authority.maximum !== Authority.Paper) {
-      throw new Error('authority-generation-bound risk intent requires PAPER maximum authority')
-    }
-    if (intent.authorityGenerationHash !== state.authority.generationHash) {
-      throw new Error('PAPER risk intent must bind the exact PAPER authority generation from risk state')
-    }
-  } else if (state.authority.maximum === Authority.Paper) {
-    throw new Error('PAPER risk evaluation requires an authority-generation-bound intent')
-  }
-  const evaluatedAt = instant(state.evaluatedAt)
-  const policyHash = canonicalHashV1(policy)
-  const referencePrice = BigInt(state.referencePriceMicros)
-  const expectedPrice = BigInt(state.expectedExecutionPriceMicros)
-  const orderNotional = divideUp(BigInt(intent.quantityMicros) * expectedPrice, QUANTITY_SCALE)
-  const direction = intent.side === OrderSide.Buy ? 1n : -1n
-  const currentSymbolQuantity = proposedPositions
-    .filter((position) => position.symbol === intent.symbol)
-    .reduce((total, position) => total + BigInt(position.quantityMicros), 0n)
-  const postTradeSymbolQuantity = currentSymbolQuantity + direction * BigInt(intent.quantityMicros)
-  const postTradeSymbolExposureNumerator = postTradeSymbolQuantity * referencePrice
-  const postTradeSymbolExposure = divideAwayFromZero(postTradeSymbolExposureNumerator, QUANTITY_SCALE)
-  const postTradeSymbolExposureMagnitude = divideUp(absolute(postTradeSymbolExposureNumerator), QUANTITY_SCALE)
-  const otherGrossExposure = proposedPositions
-    .filter((position) => position.symbol !== intent.symbol)
-    .reduce((total, position) => total + absolute(BigInt(position.marketValueMicros)), 0n)
-  const otherNetExposure = proposedPositions
-    .filter((position) => position.symbol !== intent.symbol)
-    .reduce((total, position) => total + BigInt(position.marketValueMicros), 0n)
-  const postTradeGrossExposure = otherGrossExposure + postTradeSymbolExposureMagnitude
-  const postTradeNetExposureNumerator = otherNetExposure * QUANTITY_SCALE + postTradeSymbolExposureNumerator
-  const postTradeNetExposure = divideAwayFromZero(postTradeNetExposureNumerator, QUANTITY_SCALE)
-  const postTradeNetExposureMagnitude = divideUp(absolute(postTradeNetExposureNumerator), QUANTITY_SCALE)
-  const aggregateBuyingPower =
-    BigInt(state.reservedBuyingPowerMicros) + (intent.side === OrderSide.Buy ? orderNotional : 0n)
-  const dailyTradedNotional = BigInt(state.dailyTradedNotionalMicros) + orderNotional
-  const dailyLoss = positiveDifference(BigInt(state.dayStartEquityMicros), BigInt(state.account.equityMicros))
-  const drawdown = positiveDifference(BigInt(state.peakEquityMicros), BigInt(state.account.equityMicros))
-  const adversePriceDifference =
-    intent.side === OrderSide.Buy
-      ? positiveDifference(expectedPrice, referencePrice)
-      : positiveDifference(referencePrice, expectedPrice)
-  const adverseSlippageBps = divideUp(adversePriceDifference * BASIS_POINTS, referencePrice)
-  const unresolvedOrderCount = state.orders.filter((order) => isUnresolved(order.status)).length
-  const reconciledHash = reconciledStateHash({
-    account: state.account,
-    positions: state.positions,
-    positionsObservedAt: state.positionsObservedAt,
-    orders: state.orders,
-    ordersObservedAt: state.ordersObservedAt,
-    accountingHash: state.accountingHash,
-  })
-  const oldestBrokerState = Math.min(
-    instant(state.account.observedAt),
-    instant(state.positionsObservedAt),
-    instant(state.ordersObservedAt),
-    ...state.orders.map((order) => instant(order.observedAt)),
-    instant(state.reconciliation.reconciledAt),
-    instant(state.authorityObservedAt),
-  )
-  const brokerFreshUntil = oldestBrokerState + policy.maxBrokerStateAgeMs
-  const marketFreshUntil = instant(state.marketDataObservedAt) + policy.maxMarketDataAgeMs
-  const submissionOpen = instant(state.executionSession.submissionOpenAt)
-  const submissionCutoff = instant(state.executionSession.submissionCutoffAt)
+  proposedPositions: State['positions'],
+): RiskFacts => ({
+  intent,
+  state,
+  policy,
+  proposedPositions,
+  positions: proposedPositions.map((position) => ({
+    symbol: position.symbol,
+    quantityMicros: BigInt(position.quantityMicros),
+    marketValueMicros: BigInt(position.marketValueMicros),
+  })),
+  evaluatedAt: instant(state.evaluatedAt),
+  intentCreatedAt: instant(intent.createdAt),
+  marketDataObservedAt: instant(state.marketDataObservedAt),
+  submissionOpenAt: instant(state.executionSession.submissionOpenAt),
+  submissionCutoffAt: instant(state.executionSession.submissionCutoffAt),
+  referencePriceMicros: BigInt(state.referencePriceMicros),
+  expectedExecutionPriceMicros: BigInt(state.expectedExecutionPriceMicros),
+  intentQuantityMicros: BigInt(intent.quantityMicros),
+  intentNotionalLimitMicros: BigInt(intent.notionalLimitMicros),
+  accountEquityMicros: BigInt(state.account.equityMicros),
+  accountBuyingPowerMicros: BigInt(state.account.buyingPowerMicros),
+  reservedBuyingPowerMicros: BigInt(state.reservedBuyingPowerMicros),
+  priorDailyTradedNotionalMicros: BigInt(state.dailyTradedNotionalMicros),
+  dayStartEquityMicros: BigInt(state.dayStartEquityMicros),
+  peakEquityMicros: BigInt(state.peakEquityMicros),
+  maxOrderNotionalMicros: BigInt(policy.maxOrderNotionalMicros),
+  maxSymbolExposureMicros: BigInt(policy.maxSymbolExposureMicros),
+  maxGrossExposureMicros: BigInt(policy.maxGrossExposureMicros),
+  maxNetExposureMicros: BigInt(policy.maxNetExposureMicros),
+  maxDailyTradedNotionalMicros: BigInt(policy.maxDailyTradedNotionalMicros),
+  maxDailyLossMicros: BigInt(policy.maxDailyLossMicros),
+  maxDrawdownMicros: BigInt(policy.maxDrawdownMicros),
+  maxAdverseSlippageBps: BigInt(policy.maxAdverseSlippageBps),
+})
 
-  const gates = [
-    makeGate(Gate.IntentState, Reason.IntentNotPlanned, intent.state === IntentState.Planned, intent.state, 'PLANNED'),
+const deriveRiskMetrics = (facts: RiskFacts): DerivedRiskMetrics => {
+  const orderNotionalMicros = divideUp(facts.intentQuantityMicros * facts.expectedExecutionPriceMicros, QUANTITY_SCALE)
+  const direction = facts.intent.side === OrderSide.Buy ? 1n : -1n
+  const currentSymbolQuantityMicros = facts.positions
+    .filter((position) => position.symbol === facts.intent.symbol)
+    .reduce((total, position) => total + position.quantityMicros, 0n)
+  const postTradeSymbolQuantityMicros = currentSymbolQuantityMicros + direction * facts.intentQuantityMicros
+  const postTradeSymbolExposureNumerator = postTradeSymbolQuantityMicros * facts.referencePriceMicros
+  const postTradeSymbolExposureMicros = divideAwayFromZero(postTradeSymbolExposureNumerator, QUANTITY_SCALE)
+  const postTradeSymbolExposureMagnitudeMicros = divideUp(absolute(postTradeSymbolExposureNumerator), QUANTITY_SCALE)
+  const otherGrossExposureMicros = facts.positions
+    .filter((position) => position.symbol !== facts.intent.symbol)
+    .reduce((total, position) => total + absolute(position.marketValueMicros), 0n)
+  const otherNetExposureMicros = facts.positions
+    .filter((position) => position.symbol !== facts.intent.symbol)
+    .reduce((total, position) => total + position.marketValueMicros, 0n)
+  const postTradeGrossExposureMicros = otherGrossExposureMicros + postTradeSymbolExposureMagnitudeMicros
+  const postTradeNetExposureNumerator = otherNetExposureMicros * QUANTITY_SCALE + postTradeSymbolExposureNumerator
+  const postTradeNetExposureMicros = divideAwayFromZero(postTradeNetExposureNumerator, QUANTITY_SCALE)
+  const postTradeNetExposureMagnitudeMicros = divideUp(absolute(postTradeNetExposureNumerator), QUANTITY_SCALE)
+  const aggregateBuyingPowerMicros =
+    facts.reservedBuyingPowerMicros + (facts.intent.side === OrderSide.Buy ? orderNotionalMicros : 0n)
+  const dailyTradedNotionalMicros = facts.priorDailyTradedNotionalMicros + orderNotionalMicros
+  const dailyLossMicros = positiveDifference(facts.dayStartEquityMicros, facts.accountEquityMicros)
+  const drawdownMicros = positiveDifference(facts.peakEquityMicros, facts.accountEquityMicros)
+  const adversePriceDifference =
+    facts.intent.side === OrderSide.Buy
+      ? positiveDifference(facts.expectedExecutionPriceMicros, facts.referencePriceMicros)
+      : positiveDifference(facts.referencePriceMicros, facts.expectedExecutionPriceMicros)
+  const adverseSlippageBps = divideUp(adversePriceDifference * BASIS_POINTS, facts.referencePriceMicros)
+  const unresolvedOrderCount = facts.state.orders.filter((order) => isUnresolved(order.status)).length
+  const oldestBrokerStateAt = Math.min(
+    instant(facts.state.account.observedAt),
+    instant(facts.state.positionsObservedAt),
+    instant(facts.state.ordersObservedAt),
+    ...facts.state.orders.map((order) => instant(order.observedAt)),
+    instant(facts.state.reconciliation.reconciledAt),
+    instant(facts.state.authorityObservedAt),
+  )
+
+  return {
+    orderNotionalMicros,
+    currentSymbolQuantityMicros,
+    postTradeSymbolQuantityMicros,
+    postTradeSymbolExposureMicros,
+    postTradeSymbolExposureMagnitudeMicros,
+    postTradeGrossExposureMicros,
+    postTradeNetExposureMicros,
+    postTradeNetExposureMagnitudeMicros,
+    aggregateBuyingPowerMicros,
+    dailyTradedNotionalMicros,
+    dailyLossMicros,
+    drawdownMicros,
+    adverseSlippageBps,
+    unresolvedOrderCount,
+    oldestBrokerStateAt,
+    brokerFreshUntil: oldestBrokerStateAt + facts.policy.maxBrokerStateAgeMs,
+    marketFreshUntil: facts.marketDataObservedAt + facts.policy.maxMarketDataAgeMs,
+  }
+}
+
+const deriveReconciledHash = (facts: RiskFacts): Result.Result<string, RiskEvaluationFailure> =>
+  Result.try({
+    try: () =>
+      reconciledStateHash({
+        account: facts.state.account,
+        positions: facts.state.positions,
+        positionsObservedAt: facts.state.positionsObservedAt,
+        orders: facts.state.orders,
+        ordersObservedAt: facts.state.ordersObservedAt,
+        accountingHash: facts.state.accountingHash,
+      }),
+    catch: (cause) =>
+      canonicalizeRiskInputFailure(
+        'reconciliation',
+        'validated reconciled broker state is not canonicalizable',
+        { intentId: facts.intent.intentId },
+        cause,
+      ),
+  })
+
+const buildIntentContractGates = (facts: RiskFacts): readonly GateResult[] => {
+  const { intent, policy, state } = facts
+  return [
+    makeGate(Gate.IntentState, intent.state === IntentState.Planned, intent.state, 'PLANNED'),
     makeGate(
       Gate.IntentTime,
-      Reason.IntentTimeInvalid,
-      instant(intent.createdAt) >= submissionOpen && instant(intent.createdAt) <= evaluatedAt,
+      facts.intentCreatedAt >= facts.submissionOpenAt && facts.intentCreatedAt <= facts.evaluatedAt,
       intent.createdAt,
       `[${state.executionSession.submissionOpenAt},${state.evaluatedAt}]`,
     ),
     makeGate(
       Gate.IntentFreshness,
-      Reason.IntentStale,
-      evaluatedAt < instant(intent.createdAt) + policy.maxIntentAgeMs,
-      evaluatedAt - instant(intent.createdAt),
+      facts.evaluatedAt < facts.intentCreatedAt + policy.maxIntentAgeMs,
+      facts.evaluatedAt - facts.intentCreatedAt,
       `<${policy.maxIntentAgeMs}`,
     ),
     makeGate(
       Gate.Account,
-      Reason.AccountMismatch,
       intent.accountId === policy.accountId && state.account.accountId === policy.accountId,
       `${intent.accountId}:${state.account.accountId}`,
       policy.accountId,
     ),
     makeGate(
       Gate.AccountStatus,
-      Reason.AccountNotActive,
       state.account.status === AccountStatus.Active,
       state.account.status,
       AccountStatus.Active,
     ),
-    makeGate(
-      Gate.Equity,
-      Reason.EquityNotPositive,
-      BigInt(state.account.equityMicros) > 0n,
-      state.account.equityMicros,
-      '>0',
-    ),
+    makeGate(Gate.Equity, facts.accountEquityMicros > 0n, state.account.equityMicros, '>0'),
     makeGate(
       Gate.Symbol,
-      Reason.SymbolNotAllowed,
       policy.allowedSymbols.includes(intent.symbol),
       intent.symbol,
       policy.allowedSymbols.join(','),
     ),
-    makeGate(
-      Gate.MarketDataSymbol,
-      Reason.MarketDataSymbolMismatch,
-      state.marketDataSymbol === intent.symbol,
-      state.marketDataSymbol,
-      intent.symbol,
-    ),
+    makeGate(Gate.MarketDataSymbol, state.marketDataSymbol === intent.symbol, state.marketDataSymbol, intent.symbol),
     makeGate(
       Gate.OrderType,
-      Reason.OrderTypeNotAllowed,
       intent.orderType === OrderType.Market,
       intent.orderType,
       policy.allowedOrderTypes.join(','),
     ),
     makeGate(
       Gate.TimeInForce,
-      Reason.TimeInForceNotAllowed,
       policy.allowedTimeInForce.includes(intent.timeInForce),
       intent.timeInForce,
       policy.allowedTimeInForce.join(','),
     ),
+  ]
+}
+
+const buildAuthorityAndStateGates = (
+  facts: RiskFacts,
+  metrics: DerivedRiskMetrics,
+  reconciledHash: string,
+): readonly GateResult[] => {
+  const { policy, state } = facts
+  return [
     makeGate(
       Gate.Authority,
-      Reason.AuthorityNotPaper,
       state.authority.maximum === Authority.Paper && state.authority.effective === Authority.Paper,
       `${state.authority.maximum}:${state.authority.effective}`,
       'PAPER:PAPER',
     ),
-    makeGate(Gate.Kill, Reason.KillActive, state.authority.kill === KillState.Clear, state.authority.kill, 'CLEAR'),
+    makeGate(Gate.Kill, state.authority.kill === KillState.Clear, state.authority.kill, 'CLEAR'),
     makeGate(
       Gate.Reconciliation,
-      Reason.ReconciliationNotExact,
       state.reconciliation.status === ReconciliationStatus.Exact &&
         state.reconciliation.expectedHash === reconciledHash &&
         state.reconciliation.observedHash === reconciledHash,
@@ -532,210 +788,397 @@ export const evaluate = (
     ),
     makeGate(
       Gate.BrokerStateFreshness,
-      Reason.BrokerStateStale,
-      evaluatedAt < brokerFreshUntil,
-      evaluatedAt - oldestBrokerState,
+      facts.evaluatedAt < metrics.brokerFreshUntil,
+      facts.evaluatedAt - metrics.oldestBrokerStateAt,
       `<${policy.maxBrokerStateAgeMs}`,
     ),
     makeGate(
       Gate.MarketDataFreshness,
-      Reason.MarketDataStale,
-      evaluatedAt < marketFreshUntil,
-      evaluatedAt - instant(state.marketDataObservedAt),
+      facts.evaluatedAt < metrics.marketFreshUntil,
+      facts.evaluatedAt - facts.marketDataObservedAt,
       `<${policy.maxMarketDataAgeMs}`,
     ),
     makeGate(
       Gate.Session,
-      Reason.OutsideSession,
-      evaluatedAt >= submissionOpen && evaluatedAt < submissionCutoff,
+      facts.evaluatedAt >= facts.submissionOpenAt && facts.evaluatedAt < facts.submissionCutoffAt,
       state.evaluatedAt,
       `[${state.executionSession.submissionOpenAt},${state.executionSession.submissionCutoffAt})`,
     ),
-    makeGate(
-      Gate.UnknownMutations,
-      Reason.UnknownMutation,
-      state.unknownMutationCount === 0,
-      state.unknownMutationCount,
-      0,
-    ),
+    makeGate(Gate.UnknownMutations, state.unknownMutationCount === 0, state.unknownMutationCount, 0),
     makeGate(
       Gate.UnresolvedOrders,
-      Reason.UnresolvedOrdersExceeded,
-      unresolvedOrderCount <= policy.maxUnresolvedOrders,
-      unresolvedOrderCount,
+      metrics.unresolvedOrderCount <= policy.maxUnresolvedOrders,
+      metrics.unresolvedOrderCount,
       `<=${policy.maxUnresolvedOrders}`,
     ),
+  ]
+}
+
+const buildOrderLimitGates = (facts: RiskFacts, metrics: DerivedRiskMetrics): readonly GateResult[] => {
+  const { intent, policy, state } = facts
+  return [
     makeGate(
       Gate.IntentNotional,
-      Reason.IntentNotionalExceeded,
-      orderNotional <= BigInt(intent.notionalLimitMicros),
-      orderNotional,
+      metrics.orderNotionalMicros <= facts.intentNotionalLimitMicros,
+      metrics.orderNotionalMicros,
       `<=${intent.notionalLimitMicros}`,
     ),
     makeGate(
       Gate.OrderNotional,
-      Reason.OrderNotionalExceeded,
-      orderNotional <= BigInt(policy.maxOrderNotionalMicros),
-      orderNotional,
+      metrics.orderNotionalMicros <= facts.maxOrderNotionalMicros,
+      metrics.orderNotionalMicros,
       `<=${policy.maxOrderNotionalMicros}`,
     ),
     makeGate(
       Gate.BuyingPower,
-      Reason.BuyingPowerExceeded,
-      aggregateBuyingPower <= BigInt(state.account.buyingPowerMicros),
-      aggregateBuyingPower,
+      metrics.aggregateBuyingPowerMicros <= facts.accountBuyingPowerMicros,
+      metrics.aggregateBuyingPowerMicros,
       `<=${state.account.buyingPowerMicros}`,
     ),
     makeGate(
       Gate.AdverseSlippage,
-      Reason.AdverseSlippageExceeded,
-      adverseSlippageBps <= BigInt(policy.maxAdverseSlippageBps),
-      adverseSlippageBps,
+      metrics.adverseSlippageBps <= facts.maxAdverseSlippageBps,
+      metrics.adverseSlippageBps,
       `<=${policy.maxAdverseSlippageBps}`,
     ),
+  ]
+}
+
+const buildExposureGates = (facts: RiskFacts, metrics: DerivedRiskMetrics): readonly GateResult[] => {
+  const { policy } = facts
+  return [
     makeGate(
       Gate.LongOnly,
-      Reason.ShortPositionNotAllowed,
-      currentSymbolQuantity >= 0n && postTradeSymbolQuantity >= 0n,
-      `${currentSymbolQuantity}:${postTradeSymbolQuantity}`,
+      metrics.currentSymbolQuantityMicros >= 0n && metrics.postTradeSymbolQuantityMicros >= 0n,
+      `${metrics.currentSymbolQuantityMicros}:${metrics.postTradeSymbolQuantityMicros}`,
       '>=0:>=0',
     ),
     makeGate(
       Gate.SymbolExposure,
-      Reason.SymbolExposureExceeded,
-      postTradeSymbolExposureMagnitude <= BigInt(policy.maxSymbolExposureMicros),
-      postTradeSymbolExposureMagnitude,
+      metrics.postTradeSymbolExposureMagnitudeMicros <= facts.maxSymbolExposureMicros,
+      metrics.postTradeSymbolExposureMagnitudeMicros,
       `<=${policy.maxSymbolExposureMicros}`,
     ),
     makeGate(
       Gate.GrossExposure,
-      Reason.GrossExposureExceeded,
-      postTradeGrossExposure <= BigInt(policy.maxGrossExposureMicros),
-      postTradeGrossExposure,
+      metrics.postTradeGrossExposureMicros <= facts.maxGrossExposureMicros,
+      metrics.postTradeGrossExposureMicros,
       `<=${policy.maxGrossExposureMicros}`,
     ),
     makeGate(
       Gate.NetExposure,
-      Reason.NetExposureExceeded,
-      postTradeNetExposureMagnitude <= BigInt(policy.maxNetExposureMicros),
-      postTradeNetExposureMagnitude,
+      metrics.postTradeNetExposureMagnitudeMicros <= facts.maxNetExposureMicros,
+      metrics.postTradeNetExposureMagnitudeMicros,
       `<=${policy.maxNetExposureMicros}`,
     ),
+  ]
+}
+
+const buildCumulativeRiskGates = (facts: RiskFacts, metrics: DerivedRiskMetrics): readonly GateResult[] => {
+  const { policy } = facts
+  return [
     makeGate(
       Gate.DailyTradedNotional,
-      Reason.DailyTradedNotionalExceeded,
-      dailyTradedNotional <= BigInt(policy.maxDailyTradedNotionalMicros),
-      dailyTradedNotional,
+      metrics.dailyTradedNotionalMicros <= facts.maxDailyTradedNotionalMicros,
+      metrics.dailyTradedNotionalMicros,
       `<=${policy.maxDailyTradedNotionalMicros}`,
     ),
     makeGate(
       Gate.DailyLoss,
-      Reason.DailyLossExceeded,
-      dailyLoss <= BigInt(policy.maxDailyLossMicros),
-      dailyLoss,
+      metrics.dailyLossMicros <= facts.maxDailyLossMicros,
+      metrics.dailyLossMicros,
       `<=${policy.maxDailyLossMicros}`,
     ),
     makeGate(
       Gate.Drawdown,
-      Reason.DrawdownExceeded,
-      drawdown <= BigInt(policy.maxDrawdownMicros),
-      drawdown,
+      metrics.drawdownMicros <= facts.maxDrawdownMicros,
+      metrics.drawdownMicros,
       `<=${policy.maxDrawdownMicros}`,
     ),
-  ] as const
+  ]
+}
 
-  const reasonCodes = gates.filter((gate) => !gate.passed).map((gate) => gate.reason)
-  const outcome = reasonCodes.length === 0 ? RiskOutcome.Approved : RiskOutcome.Blocked
+const buildRiskGates = (
+  facts: RiskFacts,
+  metrics: DerivedRiskMetrics,
+  reconciledHash: string,
+): ReadonlyArray<GateResult> => [
+  ...buildIntentContractGates(facts),
+  ...buildAuthorityAndStateGates(facts, metrics, reconciledHash),
+  ...buildOrderLimitGates(facts, metrics),
+  ...buildExposureGates(facts, metrics),
+  ...buildCumulativeRiskGates(facts, metrics),
+]
+
+const deriveRiskExpiry = (facts: RiskFacts, metrics: DerivedRiskMetrics, outcome: RiskOutcome): string => {
   const approvalExpiry = Math.min(
-    evaluatedAt + policy.decisionTtlMs,
-    instant(intent.createdAt) + policy.maxIntentAgeMs,
-    brokerFreshUntil,
-    marketFreshUntil,
-    submissionCutoff,
+    facts.evaluatedAt + facts.policy.decisionTtlMs,
+    facts.intentCreatedAt + facts.policy.maxIntentAgeMs,
+    metrics.brokerFreshUntil,
+    metrics.marketFreshUntil,
+    facts.submissionCutoffAt,
   )
-  const ordinaryBlockedExpiry = evaluatedAt + Math.min(1_000, policy.decisionTtlMs)
+  const ordinaryBlockedExpiry = facts.evaluatedAt + Math.min(1_000, facts.policy.decisionTtlMs)
   const blockedExpiry =
-    evaluatedAt < submissionCutoff ? Math.min(ordinaryBlockedExpiry, submissionCutoff) : ordinaryBlockedExpiry
-  const expiresAt = utc(outcome === RiskOutcome.Approved ? approvalExpiry : blockedExpiry)
-  const accountSnapshotHash = canonicalHashV1({
-    account: state.account,
-    authority: state.authority,
-    authorityObservedAt: state.authorityObservedAt,
-    accountingHash: state.accountingHash,
-    brokerMode: state.brokerMode,
-    reconciliation: state.reconciliation,
-    dailyTradedNotionalMicros: state.dailyTradedNotionalMicros,
-    dayStartEquityMicros: state.dayStartEquityMicros,
-    peakEquityMicros: state.peakEquityMicros,
+    facts.evaluatedAt < facts.submissionCutoffAt
+      ? Math.min(ordinaryBlockedExpiry, facts.submissionCutoffAt)
+      : ordinaryBlockedExpiry
+  return utc(outcome === RiskOutcome.Approved ? approvalExpiry : blockedExpiry)
+}
+
+interface RiskBindingHashes {
+  readonly policyHash: string
+  readonly accountSnapshotHash: string
+  readonly positionsHash: string
+  readonly ordersHash: string
+  readonly marketDataHash: string
+  readonly inputHash: string
+}
+
+const deriveRiskBindingHashes = (facts: RiskFacts): Result.Result<RiskBindingHashes, RiskEvaluationFailure> =>
+  Result.try({
+    try: () => {
+      const { intent, policy, proposedPositions, state } = facts
+      const policyHash = canonicalHashV1(policy)
+      const accountSnapshotHash = canonicalHashV1({
+        account: state.account,
+        authority: state.authority,
+        authorityObservedAt: state.authorityObservedAt,
+        accountingHash: state.accountingHash,
+        brokerMode: state.brokerMode,
+        reconciliation: state.reconciliation,
+        dailyTradedNotionalMicros: state.dailyTradedNotionalMicros,
+        dayStartEquityMicros: state.dayStartEquityMicros,
+        peakEquityMicros: state.peakEquityMicros,
+      })
+      const positionsHash = canonicalHashV1({
+        items: proposedPositions,
+        observedAt: state.positionsObservedAt,
+      })
+      const ordersHash = canonicalHashV1({
+        items: state.orders,
+        observedAt: state.ordersObservedAt,
+        unknownMutationCount: state.unknownMutationCount,
+      })
+      const marketDataHash = canonicalHashV1({
+        symbol: state.marketDataSymbol,
+        sourceHash: state.marketDataHash,
+        observedAt: state.marketDataObservedAt,
+        referencePriceMicros: state.referencePriceMicros,
+        expectedExecutionPriceMicros: state.expectedExecutionPriceMicros,
+        executionSession: state.executionSession,
+      })
+      const inputHash = canonicalHashV1({
+        schemaVersion:
+          intent.schemaVersion === 'bayn.paper-intent.v3'
+            ? 'bayn.paper-risk-evaluation-input.v3'
+            : 'bayn.paper-risk-evaluation-input.v2',
+        intent,
+        policy,
+        state,
+        proposedPositions,
+        componentHashes: {
+          accountSnapshotHash,
+          positionsHash,
+          ordersHash,
+          marketDataHash,
+        },
+      })
+      return {
+        policyHash,
+        accountSnapshotHash,
+        positionsHash,
+        ordersHash,
+        marketDataHash,
+        inputHash,
+      }
+    },
+    catch: (cause) =>
+      canonicalizeRiskInputFailure(
+        'evidence',
+        'validated risk input evidence is not canonicalizable',
+        { intentId: facts.intent.intentId },
+        cause,
+      ),
   })
-  const positionsHash = canonicalHashV1({ items: proposedPositions, observedAt: state.positionsObservedAt })
-  const ordersHash = canonicalHashV1({
-    items: state.orders,
-    observedAt: state.ordersObservedAt,
-    unknownMutationCount: state.unknownMutationCount,
-  })
-  const marketDataHash = canonicalHashV1({
-    symbol: state.marketDataSymbol,
-    sourceHash: state.marketDataHash,
-    observedAt: state.marketDataObservedAt,
-    referencePriceMicros: state.referencePriceMicros,
-    expectedExecutionPriceMicros: state.expectedExecutionPriceMicros,
-    executionSession: state.executionSession,
-  })
-  const inputMaterial = {
-    schemaVersion:
-      intent.schemaVersion === 'bayn.paper-intent.v3'
-        ? 'bayn.paper-risk-evaluation-input.v3'
-        : 'bayn.paper-risk-evaluation-input.v2',
-    intent,
-    policy,
-    state,
-    proposedPositions,
-    componentHashes: { accountSnapshotHash, positionsHash, ordersHash, marketDataHash },
-  } as const
-  const inputHash = canonicalHashV1(inputMaterial)
-  const input = decodeInput({
-    schemaVersion: 'bayn.paper-risk-input.v1',
-    inputHash,
-    intentId: intent.intentId,
-    policyHash,
-    accountSnapshotHash,
-    positionsHash,
-    ordersHash,
-    marketDataHash,
-    evaluatedAt: state.evaluatedAt,
-    freshUntil: expiresAt,
-  })
-  const decisionMaterial = {
+
+type DecodedRiskInput = typeof RiskInputSchema.Type
+type DecodedRiskDecision = typeof RiskDecisionSchema.Type
+
+const makeRiskInput = (
+  facts: RiskFacts,
+  hashes: RiskBindingHashes,
+  expiresAt: string,
+): Result.Result<DecodedRiskInput, RiskEvaluationFailure> =>
+  Result.mapError(
+    decodeRiskInputResult({
+      schemaVersion: 'bayn.paper-risk-input.v1',
+      inputHash: hashes.inputHash,
+      intentId: facts.intent.intentId,
+      policyHash: hashes.policyHash,
+      accountSnapshotHash: hashes.accountSnapshotHash,
+      positionsHash: hashes.positionsHash,
+      ordersHash: hashes.ordersHash,
+      marketDataHash: hashes.marketDataHash,
+      evaluatedAt: facts.state.evaluatedAt,
+      freshUntil: expiresAt,
+    }),
+    (cause) =>
+      decodeRiskOutputFailure('input', 'derived risk input is invalid', { intentId: facts.intent.intentId }, cause),
+  )
+
+const makeRiskDecision = (
+  facts: RiskFacts,
+  hashes: RiskBindingHashes,
+  input: DecodedRiskInput,
+  outcome: RiskOutcome,
+  reasonCodes: ReadonlyArray<Reason>,
+  expiresAt: string,
+): Result.Result<DecodedRiskDecision, RiskEvaluationFailure> => {
+  const material = {
     schemaVersion: 'bayn.paper-risk-decision.v1',
-    inputHash,
-    intentId: intent.intentId,
-    policyHash,
+    inputHash: input.inputHash,
+    intentId: facts.intent.intentId,
+    policyHash: hashes.policyHash,
     outcome,
     reasonCodes,
-    decidedAt: state.evaluatedAt,
+    decidedAt: facts.state.evaluatedAt,
     expiresAt,
   } as const
-  const decision = decodeDecision({ ...decisionMaterial, decisionId: canonicalHashV1(decisionMaterial) })
+  const decision = { ...material, decisionId: canonicalHashV1(material) }
+  return Result.mapError(decodeRiskDecisionResult(decision), (cause) =>
+    decodeRiskOutputFailure('decision', 'derived risk decision is invalid', { intentId: facts.intent.intentId }, cause),
+  )
+}
 
-  return {
-    policyHash,
-    input,
-    decision,
-    gates,
-    metrics: {
-      orderNotionalMicros: orderNotional.toString(),
-      postTradeSymbolExposureMicros: postTradeSymbolExposure.toString(),
-      postTradeGrossExposureMicros: postTradeGrossExposure.toString(),
-      postTradeNetExposureMicros: postTradeNetExposure.toString(),
-      dailyTradedNotionalMicros: dailyTradedNotional.toString(),
-      dailyLossMicros: dailyLoss.toString(),
-      drawdownMicros: drawdown.toString(),
-      adverseSlippageBps: adverseSlippageBps.toString(),
-      aggregateBuyingPowerMicros: aggregateBuyingPower.toString(),
-      unresolvedOrderCount,
-    },
+const makeRiskEvaluation = (
+  hashes: RiskBindingHashes,
+  input: DecodedRiskInput,
+  decision: DecodedRiskDecision,
+  gates: ReadonlyArray<GateResult>,
+  metrics: DerivedRiskMetrics,
+): Result.Result<Evaluation, RiskEvaluationFailure> =>
+  Result.mapError(
+    decodeRiskEvaluationResult({
+      policyHash: hashes.policyHash,
+      input,
+      decision,
+      gates,
+      metrics: {
+        orderNotionalMicros: metrics.orderNotionalMicros.toString(),
+        postTradeSymbolExposureMicros: metrics.postTradeSymbolExposureMicros.toString(),
+        postTradeGrossExposureMicros: metrics.postTradeGrossExposureMicros.toString(),
+        postTradeNetExposureMicros: metrics.postTradeNetExposureMicros.toString(),
+        dailyTradedNotionalMicros: metrics.dailyTradedNotionalMicros.toString(),
+        dailyLossMicros: metrics.dailyLossMicros.toString(),
+        drawdownMicros: metrics.drawdownMicros.toString(),
+        adverseSlippageBps: metrics.adverseSlippageBps.toString(),
+        aggregateBuyingPowerMicros: metrics.aggregateBuyingPowerMicros.toString(),
+        unresolvedOrderCount: metrics.unresolvedOrderCount,
+      },
+    }),
+    (cause) =>
+      decodeRiskOutputFailure('evaluation', 'derived risk evaluation is invalid', { intentId: input.intentId }, cause),
+  )
+
+const validateAuthorityBinding = (intent: RiskIntent, state: State): Result.Result<void, RiskEvaluationFailure> => {
+  if (intent.schemaVersion === 'bayn.paper-intent.v3') {
+    if (state.authority.maximum !== Authority.Paper) {
+      return Result.fail(
+        bindRiskAuthorityFailure(
+          'authority-maximum',
+          'authority-generation-bound risk intent requires PAPER maximum authority',
+          { intentId: intent.intentId, maximum: state.authority.maximum },
+        ),
+      )
+    }
+    if (intent.authorityGenerationHash !== state.authority.generationHash) {
+      return Result.fail(
+        bindRiskAuthorityFailure(
+          'authority-generation',
+          'PAPER risk intent must bind the exact PAPER authority generation from risk state',
+          {
+            intentId: intent.intentId,
+            expectedGenerationHash: state.authority.generationHash,
+            observedGenerationHash: intent.authorityGenerationHash,
+          },
+        ),
+      )
+    }
+  } else if (state.authority.maximum === Authority.Paper) {
+    return Result.fail(
+      bindRiskAuthorityFailure(
+        'authority-contract',
+        'PAPER risk evaluation requires an authority-generation-bound intent',
+        { intentId: intent.intentId },
+      ),
+    )
   }
+  return Result.succeed(undefined)
+}
+
+const evaluateDecoded = (
+  intent: RiskIntent,
+  state: State,
+  policy: Policy,
+  proposedPositions: State['positions'],
+): Result.Result<Evaluation, RiskEvaluationFailure> =>
+  Result.flatMap(validateAuthorityBinding(intent, state), () => {
+    const facts = parseRiskFacts(intent, state, policy, proposedPositions)
+    return Result.flatMap(deriveReconciledHash(facts), (reconciledHash) => {
+      const metrics = deriveRiskMetrics(facts)
+      const gates = buildRiskGates(facts, metrics, reconciledHash)
+      const reasonCodes = gates.filter((gate) => !gate.passed).map((gate) => gate.reason)
+      const outcome = reasonCodes.length === 0 ? RiskOutcome.Approved : RiskOutcome.Blocked
+      const expiresAt = deriveRiskExpiry(facts, metrics, outcome)
+      return Result.flatMap(deriveRiskBindingHashes(facts), (hashes) =>
+        Result.flatMap(makeRiskInput(facts, hashes, expiresAt), (input) =>
+          Result.flatMap(makeRiskDecision(facts, hashes, input, outcome, reasonCodes, expiresAt), (decision) =>
+            makeRiskEvaluation(hashes, input, decision, gates, metrics),
+          ),
+        ),
+      )
+    })
+  })
+
+export const evaluate = (
+  intentInput: unknown,
+  stateInput: unknown,
+  policyInput: unknown,
+  proposedPositionsInput?: unknown,
+): Result.Result<Evaluation, RiskEvaluationFailure> => {
+  const intent = Result.mapError(decodeRiskIntentResult(intentInput), (cause) =>
+    decodeRiskInputFailure('intent', 'risk intent is invalid', {}, cause),
+  )
+  if (Result.isFailure(intent)) return Result.fail(intent.failure)
+  const state = Result.mapError(decodeRiskStateResult(stateInput), (cause) =>
+    decodeRiskInputFailure('state', 'risk state is invalid', {}, cause),
+  )
+  if (Result.isFailure(state)) return Result.fail(state.failure)
+  const policy = Result.mapError(decodeRiskPolicyResult(policyInput), (cause) =>
+    decodeRiskInputFailure('policy', 'risk policy is invalid', {}, cause),
+  )
+  if (Result.isFailure(policy)) return Result.fail(policy.failure)
+  const proposedPositions = Result.mapError(
+    decodeProposedPositionsResult(proposedPositionsInput ?? state.success.positions),
+    (cause) => decodeRiskInputFailure('positions', 'proposed risk positions are invalid', {}, cause),
+  )
+  if (Result.isFailure(proposedPositions)) return Result.fail(proposedPositions.failure)
+  const proposedPositionIssues = positionBookIssues({
+    positions: proposedPositions.success,
+    accountId: state.success.account.accountId,
+    observedAt: state.success.positionsObservedAt,
+  })
+  if (proposedPositionIssues.length > 0) {
+    return Result.fail(
+      decodeRiskInputFailure(
+        'positions',
+        'proposed risk positions do not match the authoritative position-book context',
+        { issues: proposedPositionIssues },
+      ),
+    )
+  }
+  return evaluateDecoded(intent.success, state.success, policy.success, proposedPositions.success)
 }
 
 export const decodePolicy = Schema.decodeUnknownEffect(PolicySchema, StrictParseOptions)

--- a/services/bayn/src/schemas.ts
+++ b/services/bayn/src/schemas.ts
@@ -25,6 +25,9 @@ export const StrictNonEmptyStringSchema = Schema.String.check(
   Schema.makeFilter((value: string) => value.length > 0 && value.trim() === value, {
     expected: 'a non-empty string without surrounding whitespace',
   }),
+  Schema.makeFilter((value: string) => value.isWellFormed(), {
+    expected: 'a well-formed Unicode string',
+  }),
 )
 export const TrimmedNonEmptyStringSchema = Schema.Trim.check(Schema.isMinLength(1))
 export const IsoDateSchema = Schema.String.pipe(Schema.refine(isIsoDate, { expected: 'a valid ISO date (YYYY-MM-DD)' }))

--- a/services/bayn/src/shadow-decision-contract.ts
+++ b/services/bayn/src/shadow-decision-contract.ts
@@ -1,4 +1,4 @@
-import { Schema } from 'effect'
+import { Data, Result, Schema } from 'effect'
 
 import { intentIdForPlan } from './execution/intents'
 import { canonicalHashV1 } from './hash'
@@ -115,25 +115,87 @@ const ObserveShadowDecisionDocumentBase = Schema.Struct({
   contentHash: Sha256Schema,
 })
 
-export const ObserveShadowDecisionDocumentSchema = ObserveShadowDecisionDocumentBase.check(
-  Schema.makeFilter((document: typeof ObserveShadowDecisionDocumentBase.Type): readonly Schema.FilterIssue[] => {
-    const { contentHash, ...material } = document
-    const issues = [...materialIssues(material)]
-    if (contentHash !== canonicalHashV1(material)) {
-      issues.push({ path: ['contentHash'], issue: 'must match the canonical shadow decision material' })
-    }
-    return issues
-  }),
+const ObserveShadowDecisionDocumentSemanticSchema = ObserveShadowDecisionDocumentBase.check(
+  Schema.makeFilter((document) => materialIssues(document)),
+)
+
+const documentHashIssues = (
+  document: typeof ObserveShadowDecisionDocumentSemanticSchema.Type,
+): readonly Schema.FilterIssue[] => {
+  const { contentHash, ...material } = document
+  return contentHash === canonicalHashV1(material)
+    ? []
+    : [{ path: ['contentHash'], issue: 'must match the canonical shadow decision material' }]
+}
+
+export const ObserveShadowDecisionDocumentSchema = ObserveShadowDecisionDocumentSemanticSchema.check(
+  Schema.makeFilter(documentHashIssues),
 )
 export type ObserveShadowDecisionDocument = typeof ObserveShadowDecisionDocumentSchema.Type
 
-const decodeDocumentSync = Schema.decodeUnknownSync(ObserveShadowDecisionDocumentSchema, strictParseOptions)
+interface MakeShadowDecisionDocumentIssue {
+  readonly operation: 'make'
+  readonly reason: 'canonicalization' | 'contract'
+}
+
+interface DecodeShadowDecisionDocumentIssue {
+  readonly operation: 'decode'
+  readonly reason: 'contract'
+}
+
+type ShadowDecisionContractIssue = MakeShadowDecisionDocumentIssue | DecodeShadowDecisionDocumentIssue
+
+interface ShadowDecisionContractFailureDetails {
+  readonly message: string
+  readonly cause?: unknown
+}
+
+export const ShadowDecisionContractFailure = Data.TaggedError('ShadowDecisionContractFailure')<
+  ShadowDecisionContractIssue & ShadowDecisionContractFailureDetails
+>
+export type ShadowDecisionContractFailure = InstanceType<typeof ShadowDecisionContractFailure>
+
+type ShadowDecisionContractReason<Operation extends ShadowDecisionContractIssue['operation']> = Extract<
+  ShadowDecisionContractIssue,
+  { readonly operation: Operation }
+>['reason']
+
+const makeDocumentFailure = (
+  reason: ShadowDecisionContractReason<'make'>,
+  message: string,
+  cause?: unknown,
+): ShadowDecisionContractFailure => new ShadowDecisionContractFailure({ operation: 'make', reason, message, cause })
+
+const decodeDocumentFailure = (
+  reason: ShadowDecisionContractReason<'decode'>,
+  message: string,
+  cause?: unknown,
+): ShadowDecisionContractFailure => new ShadowDecisionContractFailure({ operation: 'decode', reason, message, cause })
+
+const decodeDocumentResult = Schema.decodeUnknownResult(ObserveShadowDecisionDocumentSchema, strictParseOptions)
 
 export const makeObserveShadowDecisionDocument = (
-  material: ObserveShadowDecisionMaterial,
-): ObserveShadowDecisionDocument => decodeDocumentSync({ ...material, contentHash: canonicalHashV1(material) })
+  material: unknown,
+): Result.Result<ObserveShadowDecisionDocument, ShadowDecisionContractFailure> => {
+  if (typeof material !== 'object' || material === null || Array.isArray(material)) {
+    return Result.fail(makeDocumentFailure('contract', 'shadow decision material must be an object'))
+  }
+  return Result.flatMap(
+    Result.try({
+      try: () => ({ ...material, contentHash: canonicalHashV1(material) }),
+      catch: (cause) =>
+        makeDocumentFailure('canonicalization', 'shadow decision material is not canonicalizable', cause),
+    }),
+    (candidate) =>
+      Result.mapError(decodeDocumentResult(candidate), (cause) =>
+        makeDocumentFailure('contract', 'shadow decision material failed its durable contract', cause),
+      ),
+  )
+}
 
-export const decodeObserveShadowDecisionDocument = Schema.decodeUnknownEffect(
-  ObserveShadowDecisionDocumentSchema,
-  strictParseOptions,
-)
+export const decodeObserveShadowDecisionDocument = (
+  input: unknown,
+): Result.Result<ObserveShadowDecisionDocument, ShadowDecisionContractFailure> =>
+  Result.mapError(decodeDocumentResult(input), (cause) =>
+    decodeDocumentFailure('contract', 'shadow decision document failed its durable contract', cause),
+  )

--- a/services/bayn/src/shadow-decision.test.ts
+++ b/services/bayn/src/shadow-decision.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 
-import { Effect, Exit, Schema } from 'effect'
+import { Effect, Exit, Result, Schema } from 'effect'
 
 import {
   AutonomousCycleSchema,
@@ -13,7 +13,7 @@ import {
   type AutonomousCycle,
 } from './cycle'
 import { defaultExecutionModel } from './execution-model'
-import { bindExecutionSession } from './execution-session'
+import { bindExecutionSession, type BindExecutionSessionInput } from './execution-session'
 import { canonicalHashV1 } from './hash'
 import {
   AccountStatus,
@@ -31,7 +31,12 @@ import {
 import { reconciledStateHash } from './reconciliation'
 import { BrokerMode, Gate, PolicySchema, Reason, StateSchema, type Policy, type State } from './risk'
 import { strictParseOptions } from './schemas'
-import { decodeObserveShadowDecisionDocument, type ObserveShadowDecisionDocument } from './shadow-decision-contract'
+import {
+  decodeObserveShadowDecisionDocument,
+  makeObserveShadowDecisionDocument,
+  ShadowDecisionContractFailure,
+  type ObserveShadowDecisionDocument,
+} from './shadow-decision-contract'
 import {
   buildObserveShadowDecision,
   type ObserveShadowDecisionInput,
@@ -51,25 +56,63 @@ const snapshotId = hash('2')
 const snapshotContentHash = hash('3')
 const accountingHash = hash('a')
 
+type ShadowContractOperationReason<Input> = Input extends {
+  readonly operation: infer Operation
+  readonly reason: infer FailureReason
+}
+  ? { readonly operation: Operation; readonly reason: FailureReason }
+  : never
+type ShadowContractFailurePair = ShadowContractOperationReason<
+  ConstructorParameters<typeof ShadowDecisionContractFailure>[0]
+>
+const shadowContractFailurePairs = [
+  { operation: 'make', reason: 'canonicalization' },
+  { operation: 'make', reason: 'contract' },
+  { operation: 'decode', reason: 'contract' },
+] as const satisfies readonly ShadowContractFailurePair[]
+type MissingShadowContractFailurePair = Exclude<ShadowContractFailurePair, (typeof shadowContractFailurePairs)[number]>
+type InvalidShadowContractFailurePair = Exclude<(typeof shadowContractFailurePairs)[number], ShadowContractFailurePair>
+const shadowContractFailurePairCoverage: [MissingShadowContractFailurePair, InvalidShadowContractFailurePair] extends [
+  never,
+  never,
+]
+  ? true
+  : never = true
+
+const resultValue = <A, E>(result: Result.Result<A, E>): A => {
+  if (Result.isFailure(result)) throw result.failure
+  return result.success
+}
+const makeCycleDraftSuccess = (...args: Parameters<typeof makeCycleDraft>) => resultValue(makeCycleDraft(...args))
+const makeCycleExecutionPolicySuccess = (...args: Parameters<typeof makeCycleExecutionPolicy>) =>
+  resultValue(makeCycleExecutionPolicy(...args))
+const makeCycleIdentitySuccess = (...args: Parameters<typeof makeCycleIdentity>) =>
+  resultValue(makeCycleIdentity(...args))
+const makeCycleWindowSuccess = (...args: Parameters<typeof makeCycleWindow>) => resultValue(makeCycleWindow(...args))
+const makeExecutionCalendarObservationSuccess = (...args: Parameters<typeof makeExecutionCalendarObservation>) =>
+  resultValue(makeExecutionCalendarObservation(...args))
+const bindExecutionSessionSuccess = (input: BindExecutionSessionInput) => resultValue(bindExecutionSession(input))
+const planTargetsSuccess = (input: TargetPlannerInput) => resultValue(planTargets(input))
+
 const decodeCycle = Schema.decodeUnknownSync(AutonomousCycleSchema, strictParseOptions)
 const decodePolicy = Schema.decodeUnknownSync(PolicySchema, strictParseOptions)
 const decodeState = Schema.decodeUnknownSync(StateSchema, strictParseOptions)
 
 const makeCycle = (): AutonomousCycle => {
-  const executionPolicy = makeCycleExecutionPolicy({
+  const executionPolicy = makeCycleExecutionPolicySuccess({
     schemaVersion: 'bayn.autonomous-cycle-execution-policy.v1',
     strategyExecutionModelHash: canonicalHashV1(defaultExecutionModel),
     submissionWindowMs: 3_600_000,
     submissionCutoffBeforeOpenMs: 900_000,
   })
-  const executionCalendar = makeExecutionCalendarObservation({
+  const executionCalendar = makeExecutionCalendarObservationSuccess({
     schemaVersion: 'bayn.alpaca-market-calendar-observation.v1',
     source: 'alpaca-v2-calendar',
     date: executionDate,
     openAt: '2026-07-22T13:30:00.000Z',
     closeAt: '2026-07-22T20:00:00.000Z',
   })
-  const identity = makeCycleIdentity({
+  const identity = makeCycleIdentitySuccess({
     schemaVersion: 'bayn.autonomous-cycle-identity.v1',
     strategyName: 'risk-balanced-trend',
     qualificationRunId: hash('1'),
@@ -83,7 +126,7 @@ const makeCycle = (): AutonomousCycle => {
     executionCalendarHash: executionCalendar.executionCalendarHash,
     executionPolicy,
   })
-  const window = makeCycleWindow(
+  const window = makeCycleWindowSuccess(
     {
       calendar_version: 'XNYS-v1',
       session_date: signalDate,
@@ -93,7 +136,7 @@ const makeCycle = (): AutonomousCycle => {
     executionCalendar,
     executionPolicy,
   )
-  const draft = makeCycleDraft(identity, window)
+  const draft = makeCycleDraftSuccess(identity, window)
   return decodeCycle({
     ...draft,
     state: CycleState.Active,
@@ -266,7 +309,7 @@ const makeRiskState = (cycle: AutonomousCycle, symbol: string): State => {
       },
     ],
   }
-  const executionSession = bindExecutionSession({
+  const executionSession = bindExecutionSessionSuccess({
     signal: {
       sessionDate: signalDate,
       finalizedAt: snapshotFinalizedAt,
@@ -348,7 +391,7 @@ const makeInput = (
     },
     compiledDecision,
     plannerInput,
-    targetPlan: planTargets(plannerInput),
+    targetPlan: planTargetsSuccess(plannerInput),
     policy,
     riskInputs,
   }
@@ -364,6 +407,7 @@ describe('OBSERVE shadow decision', () => {
     const replay = await build(makeInput())
 
     expect(replay).toEqual(first)
+    expect(first.contentHash).toBe('9690389d06537db6d479ef7c1c690d6f5edb21dcd8b4e483baba1e9d372998b3')
     expect(first).toMatchObject({
       schemaVersion: 'bayn.observe-shadow-decision.v1',
       mode: 'OBSERVE',
@@ -478,7 +522,7 @@ describe('OBSERVE shadow decision', () => {
     const stale = await build({
       ...staleInput,
       plannerInput: stalePlannerInput,
-      targetPlan: planTargets(stalePlannerInput),
+      targetPlan: planTargetsSuccess(stalePlannerInput),
       riskInputs: [],
     })
 
@@ -503,7 +547,7 @@ describe('OBSERVE shadow decision', () => {
     const document = await build({
       ...input,
       plannerInput,
-      targetPlan: planTargets(plannerInput),
+      targetPlan: planTargetsSuccess(plannerInput),
       riskInputs: input.riskInputs.map((riskInput) => ({
         ...riskInput,
         state: { ...riskInput.state, evaluatedAt: createdAt },
@@ -526,7 +570,7 @@ describe('OBSERVE shadow decision', () => {
       },
       {
         ...input,
-        targetPlan: planTargets({
+        targetPlan: planTargetsSuccess({
           ...input.plannerInput,
           maximumInputAgeMs: input.plannerInput.maximumInputAgeMs + 1,
         }),
@@ -569,6 +613,39 @@ describe('OBSERVE shadow decision', () => {
       const exit = await Effect.runPromiseExit(buildObserveShadowDecision(variant))
       expect(Exit.isFailure(exit)).toBe(true)
     }
+  })
+
+  test('rejects incomplete, malformed covariance and signal evidence, and excess compiled-decision fields', async () => {
+    const input = makeInput()
+    const { estimatedAnnualizedPortfolioVolatility: _missingVolatility, ...missingField } = input.compiledDecision
+    const malformedDecisions = [
+      missingField,
+      {
+        ...input.compiledDecision,
+        covarianceWindow: {
+          ...input.compiledDecision.covarianceWindow,
+          returnCount: 0,
+        },
+      },
+      {
+        ...input.compiledDecision,
+        signals: input.compiledDecision.signals.map((signal, index) =>
+          index === 0 ? { ...signal, horizons: [] } : signal,
+        ),
+      },
+      {
+        ...input.compiledDecision,
+        unexpectedFutureEvidence: true,
+      },
+    ]
+
+    const failures = await Promise.all(
+      malformedDecisions.map((compiledDecision) =>
+        Effect.runPromise(Effect.flip(buildObserveShadowDecision({ ...input, compiledDecision }))),
+      ),
+    )
+    expect(failures.map(({ failure }) => failure)).toEqual(['contract', 'contract', 'contract', 'contract'])
+    expect(failures.every(({ cause }) => cause !== undefined)).toBe(true)
   })
 
   test('durable schema rejects approval, coordinator fields, and content-hash rewrites', async () => {
@@ -616,8 +693,81 @@ describe('OBSERVE shadow decision', () => {
     const swappedRisk = { ...swappedWithoutHash, contentHash: canonicalHashV1(swappedWithoutHash) }
 
     for (const candidate of [approved, coordinatorMaterial, rewritten, exactCutoff, swappedRisk]) {
-      const exit = await Effect.runPromiseExit(decodeObserveShadowDecisionDocument(candidate))
-      expect(Exit.isFailure(exit)).toBe(true)
+      expect(Result.isFailure(decodeObserveShadowDecisionDocument(candidate))).toBe(true)
     }
+  })
+
+  test('rejects ill-formed Unicode at the exact shadow binding path without a hash defect', async () => {
+    const document = await build(makeInput({ AMD: 0.1, NVDA: 0.1 }))
+    const result = decodeObserveShadowDecisionDocument({
+      ...document,
+      bindings: { ...document.bindings, strategyName: '\ud800' },
+    })
+
+    expect(Result.isFailure(result)).toBe(true)
+    if (Result.isFailure(result)) {
+      expect(result.failure).toMatchObject({
+        _tag: 'ShadowDecisionContractFailure',
+        operation: 'decode',
+        reason: 'contract',
+      })
+      expect(String(result.failure.cause)).toContain('["bindings"]["strategyName"]')
+      expect(String(result.failure.cause)).toContain('well-formed Unicode')
+    }
+  })
+
+  test('returns each closed shadow failure category and contract-constructor failure', async () => {
+    const input = makeInput()
+    const bindingFailure = {
+      ...input,
+      snapshot: { ...input.snapshot, snapshotId: hash('f') },
+    }
+    const riskFailure = {
+      ...input,
+      riskInputs: input.riskInputs.map((riskInput) => ({
+        ...riskInput,
+        state: {
+          ...riskInput.state,
+          authority: {
+            ...riskInput.state.authority,
+            maximum: Authority.Paper,
+          },
+        },
+      })),
+    }
+    const failures = await Promise.all(
+      [{}, bindingFailure, riskFailure].map((candidate) =>
+        Effect.runPromise(Effect.flip(buildObserveShadowDecision(candidate))),
+      ),
+    )
+    expect(failures.map((failure) => failure.failure)).toEqual(['contract', 'binding', 'risk'])
+    expect(failures.every((failure) => failure._tag === 'ShadowDecisionError')).toBe(true)
+
+    const cyclic: Record<string, unknown> = {}
+    cyclic.self = cyclic
+    const constructorFailures = [
+      makeObserveShadowDecisionDocument(null),
+      makeObserveShadowDecisionDocument({}),
+      makeObserveShadowDecisionDocument(cyclic),
+      decodeObserveShadowDecisionDocument({}),
+    ]
+    expect(
+      constructorFailures.map((result) =>
+        Result.isFailure(result) ? [result.failure.operation, result.failure.reason] : null,
+      ),
+    ).toEqual([
+      ['make', 'contract'],
+      ['make', 'contract'],
+      ['make', 'canonicalization'],
+      ['decode', 'contract'],
+    ])
+
+    const contractFailures = shadowContractFailurePairs.map(
+      (pair) => new ShadowDecisionContractFailure({ ...pair, message: 'failure-pair coverage' }),
+    )
+    expect(shadowContractFailurePairCoverage).toBe(true)
+    expect(contractFailures.map(({ operation, reason }) => ({ operation, reason }))).toEqual([
+      ...shadowContractFailurePairs,
+    ])
   })
 })

--- a/services/bayn/src/shadow-decision.ts
+++ b/services/bayn/src/shadow-decision.ts
@@ -1,24 +1,42 @@
-import { Data, Effect } from 'effect'
+import { Buffer } from 'node:buffer'
 
-import type { AutonomousCycle } from './cycle'
-import { CycleState } from './cycle'
-import { plan, type IntentPlan } from './execution/intents'
+import { Data, Effect, Result, Schema } from 'effect'
+
+import { AutonomousCycleSchema, CycleState, type AutonomousCycle } from './cycle'
+import { DecisionPlanSchema, type DecisionPlan } from './evidence-contracts'
+import { intentIdForPlan, IntentPlanSchema, type IntentPlan } from './execution/intents'
 import { canonicalHashV1 } from './hash'
-import { Authority, OrderSide, RiskOutcome, type Position } from './paper'
+import {
+  Authority,
+  IntentState,
+  OrderSide,
+  ReferenceIntentSchema,
+  RiskOutcome,
+  type Position,
+  type ReferenceIntent,
+} from './paper'
 import { reconciledStateHash } from './reconciliation'
-import { decodeState, evaluate, Reason, type Policy, type State } from './risk'
+import { evaluate, PolicySchema, Reason, StateSchema, type Policy, type State } from './risk'
 import {
   makeObserveShadowDecisionDocument,
   type DeltaRiskEvaluation,
   type ObserveShadowDecisionDocument,
 } from './shadow-decision-contract'
 import {
+  TargetPlannerInputSchema,
+  TargetPlanResultSchema,
   TargetPlanStatus,
   type PlannedTargetQuantity,
   type TargetPlannerInput,
   type TargetPlanResult,
 } from './target-planner'
-import type { DecisionPlan } from './types'
+import {
+  PositiveMicrosSchema,
+  Sha256Schema,
+  StrictNonEmptyStringSchema,
+  UtcInstantSchema,
+  strictParseOptions,
+} from './schemas'
 
 export interface ShadowSnapshotBinding {
   readonly snapshotId: string
@@ -51,30 +69,39 @@ export class ShadowDecisionError extends Data.TaggedError('ShadowDecisionError')
 const error = (failure: ShadowDecisionError['failure'], message: string, cause?: unknown): ShadowDecisionError =>
   new ShadowDecisionError({ failure, message, cause })
 
-const fail = (failure: ShadowDecisionError['failure'], message: string): Effect.Effect<never, ShadowDecisionError> =>
-  Effect.fail(error(failure, message))
-
-const sameHash = (left: unknown, right: unknown): boolean => canonicalHashV1(left) === canonicalHashV1(right)
-
-const plannerBrokerStateMaterial = (input: TargetPlannerInput) => ({
-  account: input.brokerState.account,
-  positions: input.brokerState.positions,
-  positionsObservedAt: input.brokerState.positionsObservedAt,
-  orders: input.brokerState.orders,
-  ordersObservedAt: input.brokerState.ordersObservedAt,
-  accountingHash: input.brokerState.accountingHash,
+const ShadowSnapshotBindingSchema = Schema.Struct({
+  snapshotId: Sha256Schema,
+  contentHash: Sha256Schema,
+  finalizedAt: UtcInstantSchema,
 })
 
-const riskBrokerStateMaterial = (state: State) => ({
-  account: state.account,
-  positions: state.positions,
-  positionsObservedAt: state.positionsObservedAt,
-  orders: state.orders,
-  ordersObservedAt: state.ordersObservedAt,
-  accountingHash: state.accountingHash,
+const ShadowDeltaRiskInputSchema = Schema.Struct({
+  symbol: StrictNonEmptyStringSchema,
+  notionalLimitMicros: PositiveMicrosSchema,
+  state: StateSchema,
 })
+
+const ObserveShadowDecisionInputSchema = Schema.Struct({
+  cycle: AutonomousCycleSchema,
+  snapshot: ShadowSnapshotBindingSchema,
+  compiledDecision: Schema.Unknown,
+  plannerInput: TargetPlannerInputSchema,
+  targetPlan: TargetPlanResultSchema,
+  policy: PolicySchema,
+  riskInputs: Schema.Array(ShadowDeltaRiskInputSchema),
+})
+
+const decodeObserveShadowDecisionInputResult = Schema.decodeUnknownResult(
+  ObserveShadowDecisionInputSchema,
+  strictParseOptions,
+)
+const decodeDecisionPlanResult = Schema.decodeUnknownResult(DecisionPlanSchema, strictParseOptions)
+const decodeIntentPlanResult = Schema.decodeUnknownResult(IntentPlanSchema, strictParseOptions)
+const decodeReferenceIntentResult = Schema.decodeUnknownResult(ReferenceIntentSchema, strictParseOptions)
+const decodeCumulativeStateResult = Schema.decodeUnknownResult(StateSchema, strictParseOptions)
 
 const QUANTITY_SCALE = 1_000_000n
+// Every micros value consumed by the pure reducer is schema-decoded before reaching these arithmetic helpers.
 const absolute = (value: bigint): bigint => (value < 0n ? -value : value)
 const divideAwayFromZero = (numerator: bigint): bigint => {
   const magnitude = absolute(numerator)
@@ -114,15 +141,49 @@ const projectTargetPosition = (
   return [...retained, projected].sort(compareSymbols)
 }
 
+const plannerBrokerStateMaterial = (input: TargetPlannerInput) => ({
+  account: input.brokerState.account,
+  positions: input.brokerState.positions,
+  positionsObservedAt: input.brokerState.positionsObservedAt,
+  orders: input.brokerState.orders,
+  ordersObservedAt: input.brokerState.ordersObservedAt,
+  accountingHash: input.brokerState.accountingHash,
+})
+
+const riskBrokerStateMaterial = (state: State) => ({
+  account: state.account,
+  positions: state.positions,
+  positionsObservedAt: state.positionsObservedAt,
+  orders: state.orders,
+  ordersObservedAt: state.ordersObservedAt,
+  accountingHash: state.accountingHash,
+})
+
+const hashValue = (
+  value: unknown,
+  failure: ShadowDecisionError['failure'],
+  message: string,
+): Result.Result<string, ShadowDecisionError> =>
+  Result.mapError(Result.try({ try: () => canonicalHashV1(value), catch: (cause) => cause }), (cause) =>
+    error(failure, message, cause),
+  )
+
+const compiledDecisionOf = (input: unknown): Result.Result<DecisionPlan, ShadowDecisionError> =>
+  Result.mapError(decodeDecisionPlanResult(input), (cause) =>
+    error('contract', 'compiled strategy decision is invalid', cause),
+  )
+
 const validateBindings = (
   input: ObserveShadowDecisionInput,
   strategyDecisionHash: string,
   policyHash: string,
-): string | null => {
+): Result.Result<void, ShadowDecisionError> => {
   const { cycle, plannerInput, snapshot } = input
-  if (cycle.state !== CycleState.Active) return 'shadow planning requires an active autonomous cycle'
+  if (cycle.state !== CycleState.Active) {
+    return Result.fail(error('binding', 'shadow planning requires an active autonomous cycle'))
+  }
   if (cycle.bindings.snapshotId !== snapshot.snapshotId) {
-    return 'shadow snapshot must match the immutable cycle snapshot binding'
+    return Result.fail(error('binding', 'shadow snapshot must match the immutable cycle snapshot binding'))
   }
   if (
     plannerInput.cycleId !== cycle.identity.cycleId ||
@@ -131,44 +192,70 @@ const validateBindings = (
     plannerInput.signalDate !== cycle.identity.signalSessionDate ||
     plannerInput.submissionCutoffAt !== cycle.window.submissionCutoffAt
   ) {
-    return 'target planner identity must match the active autonomous cycle'
+    return Result.fail(error('binding', 'target planner identity must match the active autonomous cycle'))
   }
   if (
     plannerInput.decisionHash !== strategyDecisionHash ||
     plannerInput.policyHash !== policyHash ||
     input.policy.accountId !== cycle.identity.accountId
   ) {
-    return 'target planner decision and policy must match the compiled shadow inputs'
+    return Result.fail(error('binding', 'target planner decision and policy must match the compiled shadow inputs'))
   }
-  if (
-    input.compiledDecision.signalDate !== plannerInput.signalDate ||
-    !sameHash(input.compiledDecision.targetWeights, plannerInput.targetWeights)
-  ) {
-    return 'compiled strategy decision must match the target planner weights and signal session'
+  if (input.compiledDecision.signalDate !== plannerInput.signalDate) {
+    return Result.fail(
+      error('binding', 'compiled strategy decision must match the target planner weights and signal session'),
+    )
+  }
+  const compiledWeightsHash = hashValue(
+    input.compiledDecision.targetWeights,
+    'contract',
+    'compiled target weights are not canonicalizable',
+  )
+  if (Result.isFailure(compiledWeightsHash)) return Result.fail(compiledWeightsHash.failure)
+  const plannedWeightsHash = hashValue(
+    plannerInput.targetWeights,
+    'contract',
+    'planned target weights are not canonicalizable',
+  )
+  if (Result.isFailure(plannedWeightsHash)) return Result.fail(plannedWeightsHash.failure)
+  if (compiledWeightsHash.success !== plannedWeightsHash.success) {
+    return Result.fail(
+      error('binding', 'compiled strategy decision must match the target planner weights and signal session'),
+    )
   }
   if (plannerInput.observedAt < cycle.updatedAt) {
-    return 'shadow decision creation cannot precede the durable cycle state'
+    return Result.fail(error('binding', 'shadow decision creation cannot precede the durable cycle state'))
   }
-  return null
+  return Result.succeed(undefined)
 }
 
 const validateRiskState = (
   input: ObserveShadowDecisionInput,
   riskInput: ShadowDeltaRiskInput,
   commonExecutionSessionHash: string,
-): string | null => {
+  plannerBrokerStateHash: string,
+  plannerReconciliationHash: string,
+): Result.Result<void, ShadowDecisionError> => {
   const { cycle, plannerInput, snapshot } = input
   const state = riskInput.state
-  if (state.authority.effective !== Authority.Observe) return 'shadow risk requires effective OBSERVE authority'
-  if (state.evaluatedAt !== plannerInput.observedAt) return 'shadow risk time must match target planning time'
-  if (state.marketDataSymbol !== riskInput.symbol) return 'shadow risk market symbol must match its target delta'
-  if (state.marketDataHash !== snapshot.contentHash) return 'shadow risk data must match the finalized snapshot content'
+  if (state.authority.effective !== Authority.Observe) {
+    return Result.fail(error('binding', 'shadow risk requires effective OBSERVE authority'))
+  }
+  if (state.evaluatedAt !== plannerInput.observedAt) {
+    return Result.fail(error('binding', 'shadow risk time must match target planning time'))
+  }
+  if (state.marketDataSymbol !== riskInput.symbol) {
+    return Result.fail(error('binding', 'shadow risk market symbol must match its target delta'))
+  }
+  if (state.marketDataHash !== snapshot.contentHash) {
+    return Result.fail(error('binding', 'shadow risk data must match the finalized snapshot content'))
+  }
   if (
     state.executionSession.signal.sessionDate !== cycle.identity.signalSessionDate ||
     state.executionSession.signal.finalizedAt !== snapshot.finalizedAt ||
     state.executionSession.signal.contentHash !== snapshot.contentHash
   ) {
-    return 'shadow risk signal binding must match the finalized cycle snapshot'
+    return Result.fail(error('binding', 'shadow risk signal binding must match the finalized cycle snapshot'))
   }
   if (
     state.executionSession.executionSession.date !== cycle.identity.executionSessionDate ||
@@ -177,144 +264,346 @@ const validateRiskState = (
     state.executionSession.submissionCutoffAt !== cycle.window.submissionCutoffAt ||
     state.executionSession.submissionOpenAt < cycle.window.submissionOpenAt
   ) {
-    return 'shadow risk execution session must remain inside the immutable cycle window'
+    return Result.fail(error('binding', 'shadow risk execution session must remain inside the immutable cycle window'))
   }
   if (state.executionSession.bindingHash !== commonExecutionSessionHash) {
-    return 'every target delta must use one execution-session binding'
+    return Result.fail(error('binding', 'every target delta must use one execution-session binding'))
   }
-  if (
-    state.referencePriceMicros !== plannerInput.referencePrices.priceMicros[riskInput.symbol] ||
-    !sameHash(riskBrokerStateMaterial(state), plannerBrokerStateMaterial(plannerInput)) ||
-    !sameHash(state.reconciliation, plannerInput.brokerState.reconciliation)
-  ) {
-    return 'shadow risk must use the exact target-planning price, account, and reconciliation state'
+  if (state.referencePriceMicros !== plannerInput.referencePrices.priceMicros[riskInput.symbol]) {
+    return Result.fail(
+      error('binding', 'shadow risk must use the exact target-planning price, account, and reconciliation state'),
+    )
   }
-  return null
+  const riskStateHash = hashValue(
+    riskBrokerStateMaterial(state),
+    'contract',
+    'shadow risk broker state is not canonicalizable',
+  )
+  if (Result.isFailure(riskStateHash)) return Result.fail(riskStateHash.failure)
+  const riskReconciliationHash = hashValue(
+    state.reconciliation,
+    'contract',
+    'shadow risk reconciliation is not canonicalizable',
+  )
+  if (Result.isFailure(riskReconciliationHash)) return Result.fail(riskReconciliationHash.failure)
+  return riskStateHash.success === plannerBrokerStateHash &&
+    riskReconciliationHash.success === plannerReconciliationHash
+    ? Result.succeed(undefined)
+    : Result.fail(
+        error('binding', 'shadow risk must use the exact target-planning price, account, and reconciliation state'),
+      )
 }
 
-export const buildObserveShadowDecision = (
-  input: ObserveShadowDecisionInput,
-): Effect.Effect<ObserveShadowDecisionDocument, ShadowDecisionError> =>
-  Effect.gen(function* () {
-    const strategyDecisionHash = canonicalHashV1(input.compiledDecision)
-    const policyHash = canonicalHashV1(input.policy)
-    const bindingFailure = validateBindings(input, strategyDecisionHash, policyHash)
-    if (bindingFailure !== null) return yield* fail('binding', bindingFailure)
-
-    const planner = input.targetPlan
-    if (planner.inputHash !== canonicalHashV1(input.plannerInput)) {
-      return yield* fail('binding', 'target plan must match the exact planner input')
-    }
-    if (planner.status !== TargetPlanStatus.Planned && input.riskInputs.length !== 0) {
-      return yield* fail('binding', 'NO_TRADE and BLOCKED target plans cannot retain ignored risk inputs')
-    }
-    if (planner.status === TargetPlanStatus.Planned && planner.intentTargets.length !== input.riskInputs.length) {
-      return yield* fail('binding', 'planned target deltas require exactly one risk input per symbol')
-    }
-
-    const riskInputs = new Map(input.riskInputs.map((riskInput) => [riskInput.symbol, riskInput]))
-    if (riskInputs.size !== input.riskInputs.length) {
-      return yield* fail('binding', 'shadow risk inputs must contain unique symbols')
-    }
-    const firstRiskInput = input.riskInputs[0]
-    const commonExecutionSessionHash = firstRiskInput?.state.executionSession.bindingHash ?? ''
-    const baseReservedBuyingPower = firstRiskInput?.state.reservedBuyingPowerMicros ?? '0'
-    const baseDailyTradedNotional = firstRiskInput?.state.dailyTradedNotionalMicros ?? '0'
-    for (const candidate of input.riskInputs) {
-      if (
-        candidate.state.reservedBuyingPowerMicros !== baseReservedBuyingPower ||
-        candidate.state.dailyTradedNotionalMicros !== baseDailyTradedNotional
-      ) {
-        return yield* fail(
-          'binding',
-          'every shadow risk input must start from one reservation and daily-notional state',
-        )
+const makeReferenceIntent = (input: IntentPlan): Result.Result<ReferenceIntent, ShadowDecisionError> => {
+  const decodedPlan = Result.mapError(decodeIntentPlanResult(input), (cause) =>
+    error('contract', 'shadow target delta could not form a valid risk intent', cause),
+  )
+  if (Result.isFailure(decodedPlan)) return Result.fail(decodedPlan.failure)
+  const identity = Result.try({
+    try: () => {
+      const intentId = intentIdForPlan(decodedPlan.success)
+      return {
+        intentId,
+        clientOrderId: `b1_${Buffer.from(intentId, 'hex').toString('base64url')}`,
       }
-      const stateFailure = validateRiskState(input, candidate, commonExecutionSessionHash)
-      if (stateFailure !== null) return yield* fail('binding', stateFailure)
-    }
-
-    let reservedBuyingPower = BigInt(baseReservedBuyingPower)
-    let dailyTradedNotional = BigInt(baseDailyTradedNotional)
-    let projectedPositions = firstRiskInput?.state.positions ?? []
-    const targetsBySymbol = new Map(planner.targets.map((target) => [target.symbol, target]))
-    const deltaRisk: DeltaRiskEvaluation[] = []
-
-    for (const targetIntent of planner.intentTargets) {
-      const provided = riskInputs.get(targetIntent.symbol)
-      if (provided === undefined) return yield* fail('binding', 'planned target delta is missing its risk input')
-      const intentPlan: IntentPlan = {
-        schemaVersion: 'bayn.paper-intent-plan.v1',
-        ...targetIntent,
-        notionalLimitMicros: provided.notionalLimitMicros,
-      }
-      const intent = yield* plan(intentPlan).pipe(
-        Effect.mapError((cause) => error('contract', 'shadow target delta could not form a valid risk intent', cause)),
-      )
-      const state = yield* decodeState({
-        ...provided.state,
-        reservedBuyingPowerMicros: reservedBuyingPower.toString(),
-        dailyTradedNotionalMicros: dailyTradedNotional.toString(),
-      }).pipe(Effect.mapError((cause) => error('contract', 'cumulative shadow risk state is invalid', cause)))
-      const evaluation = yield* Effect.try({
-        try: () => evaluate(intent, state, input.policy, projectedPositions),
-        catch: (cause) => error('risk', 'shadow target risk evaluation failed', cause),
-      })
-      if (
-        evaluation.policyHash !== policyHash ||
-        evaluation.decision.outcome !== RiskOutcome.Blocked ||
-        !evaluation.decision.reasonCodes.includes(Reason.AuthorityNotPaper)
-      ) {
-        return yield* fail('risk', 'OBSERVE shadow risk must remain blocked by non-paper authority')
-      }
-
-      const orderNotional = BigInt(evaluation.metrics.orderNotionalMicros)
-      dailyTradedNotional += orderNotional
-      if (targetIntent.side === OrderSide.Buy) reservedBuyingPower += orderNotional
-      const target = targetsBySymbol.get(targetIntent.symbol)
-      if (target === undefined) return yield* fail('contract', 'planned target delta is missing its final quantity')
-      projectedPositions = projectTargetPosition(
-        projectedPositions,
-        target,
-        input.plannerInput.accountId,
-        provided.state.positionsObservedAt,
-      )
-      deltaRisk.push({
-        notionalLimitMicros: provided.notionalLimitMicros,
-        evaluation,
-      })
-    }
-
-    const document = yield* Effect.try({
-      try: () =>
-        makeObserveShadowDecisionDocument({
-          schemaVersion: 'bayn.observe-shadow-decision.v1',
-          mode: 'OBSERVE',
-          dispatchable: false,
-          bindings: {
-            strategyName: input.plannerInput.strategyName,
-            cycleId: input.cycle.identity.cycleId,
-            strategyProtocolHash: input.cycle.identity.strategyProtocolHash,
-            snapshotId: input.snapshot.snapshotId,
-            snapshotContentHash: input.snapshot.contentHash,
-            snapshotFinalizedAt: input.snapshot.finalizedAt,
-            strategyDecisionHash,
-            policyHash,
-            accountId: input.plannerInput.accountId,
-            planningBrokerStateHash: reconciledStateHash(plannerBrokerStateMaterial(input.plannerInput)),
-            reconciliationId: input.plannerInput.brokerState.reconciliation.reconciliationId,
-            reconciliationHash: input.plannerInput.brokerState.reconciliation.contentHash,
-          },
-          targetPlan: planner,
-          deltaRisk,
-          submissionCutoffAt: input.cycle.window.submissionCutoffAt,
-          expiresAt: input.cycle.window.submissionCutoffAt,
-          createdAt: input.plannerInput.observedAt,
-        }),
-      catch: (cause) => error('contract', 'shadow decision document failed durable contract validation', cause),
-    })
-    if (input.cycle.bindings.decisionHash !== undefined && input.cycle.bindings.decisionHash !== document.contentHash) {
-      return yield* fail('binding', 'shadow document must match the immutable cycle decision binding')
-    }
-    return document
+    },
+    catch: (cause) => error('contract', 'shadow target delta identity is not canonicalizable', cause),
   })
+  if (Result.isFailure(identity)) return Result.fail(identity.failure)
+  const decoded = decodedPlan.success
+  return Result.mapError(
+    decodeReferenceIntentResult({
+      schemaVersion: 'bayn.paper-intent.v2',
+      intentId: identity.success.intentId,
+      strategyName: decoded.strategyName,
+      cycleId: decoded.cycleId,
+      decisionHash: decoded.decisionHash,
+      policyHash: decoded.policyHash,
+      accountId: decoded.accountId,
+      clientOrderId: identity.success.clientOrderId,
+      symbol: decoded.symbol,
+      side: decoded.side,
+      orderType: decoded.orderType,
+      timeInForce: decoded.timeInForce,
+      quantityMicros: decoded.quantityMicros,
+      notionalLimitMicros: decoded.notionalLimitMicros,
+      state: IntentState.Planned,
+      createdAt: decoded.createdAt,
+    }),
+    (cause) => error('contract', 'shadow target delta could not form a valid risk intent', cause),
+  )
+}
+
+interface ShadowReduction {
+  readonly reservedBuyingPower: bigint
+  readonly dailyTradedNotional: bigint
+  readonly projectedPositions: readonly Position[]
+  readonly deltaRisk: readonly DeltaRiskEvaluation[]
+}
+
+interface ShadowReductionContext {
+  readonly input: ObserveShadowDecisionInput
+  readonly policyHash: string
+  readonly riskInputs: ReadonlyMap<string, ShadowDeltaRiskInput>
+  readonly targetsBySymbol: ReadonlyMap<string, PlannedTargetQuantity>
+}
+
+const reduceShadowDelta = (
+  accumulator: ShadowReduction,
+  targetIntent: TargetPlanResult['intentTargets'][number],
+  context: ShadowReductionContext,
+): Result.Result<ShadowReduction, ShadowDecisionError> => {
+  const provided = context.riskInputs.get(targetIntent.symbol)
+  if (provided === undefined) {
+    return Result.fail(error('binding', 'planned target delta is missing its risk input'))
+  }
+  const intent = makeReferenceIntent({
+    schemaVersion: 'bayn.paper-intent-plan.v1',
+    ...targetIntent,
+    notionalLimitMicros: provided.notionalLimitMicros,
+  })
+  if (Result.isFailure(intent)) return Result.fail(intent.failure)
+  const state = Result.mapError(
+    decodeCumulativeStateResult({
+      ...provided.state,
+      reservedBuyingPowerMicros: accumulator.reservedBuyingPower.toString(),
+      dailyTradedNotionalMicros: accumulator.dailyTradedNotional.toString(),
+    }),
+    (cause) => error('contract', 'cumulative shadow risk state is invalid', cause),
+  )
+  if (Result.isFailure(state)) return Result.fail(state.failure)
+  const evaluation = evaluate(intent.success, state.success, context.input.policy, accumulator.projectedPositions)
+  if (Result.isFailure(evaluation)) {
+    return Result.fail(error('risk', 'shadow target risk evaluation failed', evaluation.failure))
+  }
+  if (
+    evaluation.success.policyHash !== context.policyHash ||
+    evaluation.success.decision.outcome !== RiskOutcome.Blocked ||
+    !evaluation.success.decision.reasonCodes.includes(Reason.AuthorityNotPaper)
+  ) {
+    return Result.fail(error('risk', 'OBSERVE shadow risk must remain blocked by non-paper authority'))
+  }
+  const target = context.targetsBySymbol.get(targetIntent.symbol)
+  if (target === undefined) {
+    return Result.fail(error('contract', 'planned target delta is missing its final quantity'))
+  }
+  const orderNotional = BigInt(evaluation.success.metrics.orderNotionalMicros)
+  return Result.succeed({
+    reservedBuyingPower: accumulator.reservedBuyingPower + (targetIntent.side === OrderSide.Buy ? orderNotional : 0n),
+    dailyTradedNotional: accumulator.dailyTradedNotional + orderNotional,
+    projectedPositions: projectTargetPosition(
+      accumulator.projectedPositions,
+      target,
+      context.input.plannerInput.accountId,
+      provided.state.positionsObservedAt,
+    ),
+    deltaRisk: [
+      ...accumulator.deltaRisk,
+      {
+        notionalLimitMicros: provided.notionalLimitMicros,
+        evaluation: evaluation.success,
+      },
+    ],
+  })
+}
+
+interface ShadowDecisionContext {
+  readonly input: ObserveShadowDecisionInput
+  readonly strategyDecisionHash: string
+  readonly policyHash: string
+}
+
+interface PreparedShadowRisk {
+  readonly input: ObserveShadowDecisionInput
+  readonly policyHash: string
+  readonly riskInputs: ReadonlyMap<string, ShadowDeltaRiskInput>
+  readonly targetsBySymbol: ReadonlyMap<string, PlannedTargetQuantity>
+  readonly baseReservedBuyingPower: string
+  readonly baseDailyTradedNotional: string
+  readonly initialPositions: readonly Position[]
+}
+
+const decodeShadowDecisionContext = (
+  inputValue: unknown,
+): Result.Result<ShadowDecisionContext, ShadowDecisionError> => {
+  const decoded = Result.mapError(decodeObserveShadowDecisionInputResult(inputValue), (cause) =>
+    error('contract', 'shadow decision input failed its domain contract', cause),
+  )
+  if (Result.isFailure(decoded)) return Result.fail(decoded.failure)
+  const compiledDecision = compiledDecisionOf(decoded.success.compiledDecision)
+  if (Result.isFailure(compiledDecision)) return Result.fail(compiledDecision.failure)
+  const input: ObserveShadowDecisionInput = {
+    ...decoded.success,
+    compiledDecision: compiledDecision.success,
+  }
+  const strategyDecisionHash = hashValue(
+    input.compiledDecision,
+    'contract',
+    'compiled strategy decision is not canonicalizable',
+  )
+  if (Result.isFailure(strategyDecisionHash)) return Result.fail(strategyDecisionHash.failure)
+  const policyHash = hashValue(input.policy, 'contract', 'shadow risk policy is not canonicalizable')
+  if (Result.isFailure(policyHash)) return Result.fail(policyHash.failure)
+  return Result.succeed({
+    input,
+    strategyDecisionHash: strategyDecisionHash.success,
+    policyHash: policyHash.success,
+  })
+}
+
+const validateShadowPlanningBindings = (context: ShadowDecisionContext): Result.Result<void, ShadowDecisionError> => {
+  const { input, policyHash, strategyDecisionHash } = context
+  const binding = validateBindings(input, strategyDecisionHash, policyHash)
+  if (Result.isFailure(binding)) return Result.fail(binding.failure)
+  const plannerInputHash = hashValue(input.plannerInput, 'contract', 'target planner input is not canonicalizable')
+  if (Result.isFailure(plannerInputHash)) return Result.fail(plannerInputHash.failure)
+  if (input.targetPlan.inputHash !== plannerInputHash.success) {
+    return Result.fail(error('binding', 'target plan must match the exact planner input'))
+  }
+  if (input.targetPlan.status !== TargetPlanStatus.Planned && input.riskInputs.length !== 0) {
+    return Result.fail(error('binding', 'NO_TRADE and BLOCKED target plans cannot retain ignored risk inputs'))
+  }
+  if (
+    input.targetPlan.status === TargetPlanStatus.Planned &&
+    input.targetPlan.intentTargets.length !== input.riskInputs.length
+  ) {
+    return Result.fail(error('binding', 'planned target deltas require exactly one risk input per symbol'))
+  }
+  return Result.succeed(undefined)
+}
+
+const prepareShadowRisk = (context: ShadowDecisionContext): Result.Result<PreparedShadowRisk, ShadowDecisionError> => {
+  const { input } = context
+  const riskInputs = new Map(input.riskInputs.map((riskInput) => [riskInput.symbol, riskInput]))
+  if (riskInputs.size !== input.riskInputs.length) {
+    return Result.fail(error('binding', 'shadow risk inputs must contain unique symbols'))
+  }
+  const firstRiskInput = input.riskInputs[0]
+  const baseReservedBuyingPower = firstRiskInput?.state.reservedBuyingPowerMicros ?? '0'
+  const baseDailyTradedNotional = firstRiskInput?.state.dailyTradedNotionalMicros ?? '0'
+  const commonExecutionSessionHash = firstRiskInput?.state.executionSession.bindingHash ?? ''
+  const plannerBrokerStateHash = hashValue(
+    plannerBrokerStateMaterial(input.plannerInput),
+    'contract',
+    'target-planning broker state is not canonicalizable',
+  )
+  if (Result.isFailure(plannerBrokerStateHash)) return Result.fail(plannerBrokerStateHash.failure)
+  const plannerReconciliationHash = hashValue(
+    input.plannerInput.brokerState.reconciliation,
+    'contract',
+    'target-planning reconciliation is not canonicalizable',
+  )
+  if (Result.isFailure(plannerReconciliationHash)) return Result.fail(plannerReconciliationHash.failure)
+
+  for (const candidate of input.riskInputs) {
+    if (
+      candidate.state.reservedBuyingPowerMicros !== baseReservedBuyingPower ||
+      candidate.state.dailyTradedNotionalMicros !== baseDailyTradedNotional
+    ) {
+      return Result.fail(
+        error('binding', 'every shadow risk input must start from one reservation and daily-notional state'),
+      )
+    }
+    const stateValidation = validateRiskState(
+      input,
+      candidate,
+      commonExecutionSessionHash,
+      plannerBrokerStateHash.success,
+      plannerReconciliationHash.success,
+    )
+    if (Result.isFailure(stateValidation)) return Result.fail(stateValidation.failure)
+  }
+
+  const targetsBySymbol = new Map(input.targetPlan.targets.map((target) => [target.symbol, target]))
+  return Result.succeed({
+    input,
+    policyHash: context.policyHash,
+    riskInputs,
+    targetsBySymbol,
+    baseReservedBuyingPower,
+    baseDailyTradedNotional,
+    initialPositions: firstRiskInput?.state.positions ?? [],
+  })
+}
+
+const reduceShadowRisk = (prepared: PreparedShadowRisk): Result.Result<ShadowReduction, ShadowDecisionError> =>
+  prepared.input.targetPlan.intentTargets.reduce<Result.Result<ShadowReduction, ShadowDecisionError>>(
+    (accumulator, targetIntent) =>
+      Result.flatMap(accumulator, (state) =>
+        reduceShadowDelta(state, targetIntent, {
+          input: prepared.input,
+          policyHash: prepared.policyHash,
+          riskInputs: prepared.riskInputs,
+          targetsBySymbol: prepared.targetsBySymbol,
+        }),
+      ),
+    Result.succeed({
+      reservedBuyingPower: BigInt(prepared.baseReservedBuyingPower),
+      dailyTradedNotional: BigInt(prepared.baseDailyTradedNotional),
+      projectedPositions: prepared.initialPositions,
+      deltaRisk: [],
+    }),
+  )
+
+const assembleShadowDecisionDocument = (
+  context: ShadowDecisionContext,
+  reduction: ShadowReduction,
+): Result.Result<ObserveShadowDecisionDocument, ShadowDecisionError> => {
+  const { input, policyHash, strategyDecisionHash } = context
+  const planningBrokerStateHash = Result.try({
+    try: () => reconciledStateHash(plannerBrokerStateMaterial(input.plannerInput)),
+    catch: (cause) => error('contract', 'planning broker state hash could not be derived', cause),
+  })
+  if (Result.isFailure(planningBrokerStateHash)) return Result.fail(planningBrokerStateHash.failure)
+  const document = Result.mapError(
+    makeObserveShadowDecisionDocument({
+      schemaVersion: 'bayn.observe-shadow-decision.v1',
+      mode: 'OBSERVE',
+      dispatchable: false,
+      bindings: {
+        strategyName: input.plannerInput.strategyName,
+        cycleId: input.cycle.identity.cycleId,
+        strategyProtocolHash: input.cycle.identity.strategyProtocolHash,
+        snapshotId: input.snapshot.snapshotId,
+        snapshotContentHash: input.snapshot.contentHash,
+        snapshotFinalizedAt: input.snapshot.finalizedAt,
+        strategyDecisionHash,
+        policyHash,
+        accountId: input.plannerInput.accountId,
+        planningBrokerStateHash: planningBrokerStateHash.success,
+        reconciliationId: input.plannerInput.brokerState.reconciliation.reconciliationId,
+        reconciliationHash: input.plannerInput.brokerState.reconciliation.contentHash,
+      },
+      targetPlan: input.targetPlan,
+      deltaRisk: reduction.deltaRisk,
+      submissionCutoffAt: input.cycle.window.submissionCutoffAt,
+      expiresAt: input.cycle.window.submissionCutoffAt,
+      createdAt: input.plannerInput.observedAt,
+    }),
+    (cause) => error('contract', 'shadow decision document failed durable contract validation', cause),
+  )
+  if (Result.isFailure(document)) return Result.fail(document.failure)
+  if (
+    input.cycle.bindings.decisionHash !== undefined &&
+    input.cycle.bindings.decisionHash !== document.success.contentHash
+  ) {
+    return Result.fail(error('binding', 'shadow document must match the immutable cycle decision binding'))
+  }
+  return document
+}
+
+const reduceObserveShadowDecision = (
+  inputValue: unknown,
+): Result.Result<ObserveShadowDecisionDocument, ShadowDecisionError> =>
+  Result.flatMap(decodeShadowDecisionContext(inputValue), (context) =>
+    Result.flatMap(validateShadowPlanningBindings(context), () =>
+      Result.flatMap(prepareShadowRisk(context), (prepared) =>
+        Result.flatMap(reduceShadowRisk(prepared), (reduction) => assembleShadowDecisionDocument(context, reduction)),
+      ),
+    ),
+  )
+
+export const buildObserveShadowDecision = (
+  input: unknown,
+): Effect.Effect<ObserveShadowDecisionDocument, ShadowDecisionError> =>
+  Effect.fromResult(reduceObserveShadowDecision(input))

--- a/services/bayn/src/target-planner.test.ts
+++ b/services/bayn/src/target-planner.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from 'bun:test'
 
+import { Result } from 'effect'
+
 import { canonicalHashV1 } from './hash'
 import {
   AccountStatus,
@@ -18,8 +20,10 @@ import { reconciledStateHash } from './reconciliation'
 import {
   TargetPlanReason,
   TargetPlanStatus,
+  decodeTargetPlanResult,
   planTargets,
   type SignalSessionReferencePrices,
+  type TargetPlanResult,
   type TargetPlannerInput,
 } from './target-planner'
 
@@ -76,11 +80,13 @@ const order = (
   symbol = 'AMD',
   orderObservedAt = brokerObservedAt,
   orderAccountId = accountId,
+  known = true,
 ): Order => ({
   schemaVersion: 'bayn.paper-order.v1',
   accountId: orderAccountId,
   brokerOrderId: `broker-${status}`,
   clientOrderId: `client-${status}`,
+  ...(known ? { intentId: hash('9') } : {}),
   symbol,
   side: OrderSide.Buy,
   orderType: OrderType.Market,
@@ -198,9 +204,15 @@ const fixture = (options: FixtureOptions = {}): TargetPlannerInput => {
   }
 }
 
+const planSuccess = (input: TargetPlannerInput): TargetPlanResult => {
+  const result = planTargets(input)
+  if (Result.isFailure(result)) throw result.failure
+  return result.success
+}
+
 describe('causal target planner', () => {
   test('produces exact target deltas in stable sell-then-buy order without crediting the sell', () => {
-    const result = planTargets(fixture())
+    const result = planSuccess(fixture())
 
     expect(result.status).toBe(TargetPlanStatus.Planned)
     expect(result.reason).toBeNull()
@@ -240,15 +252,15 @@ describe('causal target planner', () => {
   })
 
   test('replays byte-for-byte with golden hashes and binds decision drift', () => {
-    const first = planTargets(fixture())
-    const replay = planTargets(fixture())
-    const reordered = planTargets(
+    const first = planSuccess(fixture())
+    const replay = planSuccess(fixture())
+    const reordered = planSuccess(
       fixture({
         priceMicros: { NVDA: '100000000', AMD: '50000000' },
         targetWeights: { NVDA: 0.5, AMD: 0.5 },
       }),
     )
-    const changedDecision = planTargets(fixture({ decisionHash: hash('4') }))
+    const changedDecision = planSuccess(fixture({ decisionHash: hash('4') }))
 
     expect(replay).toEqual(first)
     expect(reordered).toEqual(first)
@@ -264,14 +276,14 @@ describe('causal target planner', () => {
       { open: '900000000', high: '999000000', low: '1', close: '777000000' },
       { open: '1', high: '2', low: '1', close: '3' },
     ]
-    const plans = futureSessions.map(() => planTargets(fixture()))
+    const plans = futureSessions.map(() => planSuccess(fixture()))
 
     expect(futureSessions[0]).not.toEqual(futureSessions[1])
     expect(plans[1]).toEqual(plans[0])
   })
 
   test('returns no-trade when the rounded targets already match the all-cash account', () => {
-    const result = planTargets(
+    const result = planSuccess(
       fixture({
         positions: [],
         targetWeights: { AMD: 0, NVDA: 0 },
@@ -288,14 +300,14 @@ describe('causal target planner', () => {
   })
 
   test('liquidates only the existing long quantity and rejects an existing short', () => {
-    const liquidation = planTargets(
+    const liquidation = planSuccess(
       fixture({
         buyingPowerMicros: '-1000000',
         positions: [position('AMD', '1000000'), position('NVDA', '2000000')],
         targetWeights: { AMD: 0, NVDA: 0 },
       }),
     )
-    const short = planTargets(
+    const short = planSuccess(
       fixture({
         positions: [position('AMD', '-1'), position('NVDA', '2000000')],
       }),
@@ -314,13 +326,13 @@ describe('causal target planner', () => {
   })
 
   test('reserves aggregate buys against current buying power without unfilled sell proceeds', () => {
-    const aggregate = planTargets(
+    const aggregate = planSuccess(
       fixture({
         buyingPowerMicros: '6000000000',
         positions: [],
       }),
     )
-    const sellDoesNotFund = planTargets(
+    const sellDoesNotFund = planSuccess(
       fixture({
         buyingPowerMicros: '1500000000',
         positions: [position('AMD', '0'), position('NVDA', '100000000')],
@@ -348,9 +360,9 @@ describe('causal target planner', () => {
   })
 
   test('treats the submission cutoff as an exclusive boundary', () => {
-    const before = planTargets(fixture({ observedAt: '2026-07-23T13:29:59.999Z' }))
-    const exact = planTargets(fixture({ observedAt: submissionCutoffAt }))
-    const after = planTargets(fixture({ observedAt: '2026-07-23T13:30:00.001Z' }))
+    const before = planSuccess(fixture({ observedAt: '2026-07-23T13:29:59.999Z' }))
+    const exact = planSuccess(fixture({ observedAt: submissionCutoffAt }))
+    const after = planSuccess(fixture({ observedAt: '2026-07-23T13:30:00.001Z' }))
 
     expect(before.status).toBe(TargetPlanStatus.Planned)
     expect(exact.reason).toBe(TargetPlanReason.SubmissionCutoffReached)
@@ -358,7 +370,7 @@ describe('causal target planner', () => {
   })
 
   test('blocks input at the exact freshness boundary and observations from the future', () => {
-    const stale = planTargets(
+    const stale = planSuccess(
       fixture({
         accountObservedAt: '2026-07-23T13:27:00.000Z',
         maximumInputAgeMs: 120_000,
@@ -367,7 +379,7 @@ describe('causal target planner', () => {
     const future = fixture({ pricesObservedAt: '2026-07-23T13:29:00.001Z' })
 
     expect(stale.reason).toBe(TargetPlanReason.InputStale)
-    expect(planTargets(future).reason).toBe(TargetPlanReason.InputMismatch)
+    expect(planSuccess(future).reason).toBe(TargetPlanReason.InputMismatch)
   })
 
   test('rejects a reference vector labeled as a signal session that has not happened', () => {
@@ -384,14 +396,14 @@ describe('causal target planner', () => {
       referencePrices: { ...material, contentHash: canonicalHashV1(material) },
     }
 
-    expect(planTargets(futureSignal).reason).toBe(TargetPlanReason.IdentityMismatch)
+    expect(planSuccess(futureSignal).reason).toBe(TargetPlanReason.IdentityMismatch)
   })
 
   test('blocks identity, reference-vector, and reconciliation mismatches', () => {
-    const identity = planTargets(fixture({ referenceSignalDate: '2026-07-21' }))
+    const identity = planSuccess(fixture({ referenceSignalDate: '2026-07-21' }))
     const referenceInput = fixture()
     const reconciliationInput = fixture()
-    const leveraged = planTargets(fixture({ targetWeights: { AMD: 0.75, NVDA: 0.75 } }))
+    const leveraged = planSuccess(fixture({ targetWeights: { AMD: 0.75, NVDA: 0.75 } }))
     const badReference = {
       ...referenceInput,
       referencePrices: { ...referenceInput.referencePrices, contentHash: hash('f') },
@@ -409,16 +421,17 @@ describe('causal target planner', () => {
 
     expect(identity.reason).toBe(TargetPlanReason.IdentityMismatch)
     expect(leveraged.reason).toBe(TargetPlanReason.InputMismatch)
-    expect(planTargets(badReference).reason).toBe(TargetPlanReason.InputMismatch)
-    expect(planTargets(badReconciliation).reason).toBe(TargetPlanReason.ReconciliationNotExact)
+    expect(planSuccess(badReference).reason).toBe(TargetPlanReason.InputMismatch)
+    expect(planSuccess(badReconciliation).reason).toBe(TargetPlanReason.ReconciliationNotExact)
   })
 
   test('blocks unknown and unresolved orders but accepts terminal order history', () => {
-    const unknown = planTargets(fixture({ unknownOrderCount: 1 }))
+    const unknownOrder = order(OrderStatus.Filled, 'AMD', brokerObservedAt, accountId, false)
+    const unknown = planSuccess(fixture({ orders: [unknownOrder], unknownOrderCount: 1 }))
     const unresolvedOrder = order(OrderStatus.New)
-    const unresolved = planTargets(fixture({ orders: [unresolvedOrder] }))
+    const unresolved = planSuccess(fixture({ orders: [unresolvedOrder] }))
     const terminalOrder = order(OrderStatus.Filled)
-    const terminal = planTargets(fixture({ orders: [terminalOrder] }))
+    const terminal = planSuccess(fixture({ orders: [terminalOrder] }))
 
     expect(unknown.reason).toBe(TargetPlanReason.UnknownOrder)
     expect(unresolved.reason).toBe(TargetPlanReason.UnresolvedOrder)
@@ -436,7 +449,7 @@ describe('causal target planner', () => {
       ...preciseInput,
       precision: { ...preciseInput.precision, quantityIncrementMicros: '1000000' },
     }
-    const rounded = planTargets(precise)
+    const rounded = planSuccess(precise)
 
     const dust = fixture({
       buyingPowerMicros: '10000000000',
@@ -448,7 +461,9 @@ describe('causal target planner', () => {
 
     expect(rounded.targets[0]?.targetQuantityMicros).toBe('333000000')
     expect(rounded.intentTargets[0]?.quantityMicros).toBe('333000000')
-    expect(planTargets(dust).reason).toBe(TargetPlanReason.BelowMinimumBuyNotional)
+    const belowMinimum = planSuccess(dust)
+    expect(belowMinimum.reason).toBe(TargetPlanReason.BelowMinimumBuyNotional)
+    expect(belowMinimum.requiredReferenceBuyNotionalMicros).toBe('100000')
   })
 
   test('blocks a durable reconciliation discrepancy even when its top-level hashes agree', () => {
@@ -488,6 +503,213 @@ describe('causal target planner', () => {
       },
     }
 
-    expect(planTargets(discrepantInput).reason).toBe(TargetPlanReason.ReconciliationNotExact)
+    expect(planSuccess(discrepantInput).reason).toBe(TargetPlanReason.ReconciliationNotExact)
+  })
+
+  test('covers every terminal planner action with its exact closed reason', () => {
+    const reconciliationMismatch = fixture()
+    const belowMinimum = fixture({
+      buyingPowerMicros: '10000000000',
+      equityMicros: '1000000',
+      positions: [],
+      priceMicros: { AMD: '100000000' },
+      targetWeights: { AMD: 0.1 },
+    })
+    const externalOrder = order(OrderStatus.Filled, 'AMD', brokerObservedAt, accountId, false)
+    const cases: readonly [TargetPlanReason, TargetPlannerInput][] = [
+      [TargetPlanReason.SubmissionCutoffReached, fixture({ observedAt: submissionCutoffAt })],
+      [TargetPlanReason.IdentityMismatch, fixture({ referenceSignalDate: '2026-07-21' })],
+      [TargetPlanReason.InputMismatch, fixture({ targetWeights: { AMD: 0.75, NVDA: 0.75 } })],
+      [
+        TargetPlanReason.InputStale,
+        fixture({ accountObservedAt: '2026-07-23T13:27:00.000Z', maximumInputAgeMs: 120_000 }),
+      ],
+      [
+        TargetPlanReason.ReconciliationNotExact,
+        {
+          ...reconciliationMismatch,
+          brokerState: {
+            ...reconciliationMismatch.brokerState,
+            reconciliation: {
+              ...reconciliationMismatch.brokerState.reconciliation,
+              observedHash: hash('e'),
+            },
+          },
+        },
+      ],
+      [TargetPlanReason.AccountNotActive, fixture({ accountStatus: AccountStatus.Restricted })],
+      [TargetPlanReason.UnknownOrder, fixture({ orders: [externalOrder], unknownOrderCount: 1 })],
+      [TargetPlanReason.UnresolvedOrder, fixture({ orders: [order(OrderStatus.New)] })],
+      [
+        TargetPlanReason.ShortPositionNotAllowed,
+        fixture({ positions: [position('AMD', '-1'), position('NVDA', '2000000')] }),
+      ],
+      [TargetPlanReason.NonPositiveEquity, fixture({ equityMicros: '0' })],
+      [TargetPlanReason.BelowMinimumBuyNotional, belowMinimum],
+      [TargetPlanReason.InsufficientBuyingPower, fixture({ buyingPowerMicros: '1', positions: [] })],
+      [TargetPlanReason.TargetsSatisfied, fixture({ positions: [], targetWeights: { AMD: 0, NVDA: 0 } })],
+    ]
+
+    expect(cases.map(([_, input]) => planSuccess(input).reason)).toEqual(cases.map(([reason]) => reason))
+  })
+
+  test('returns tagged failures for malformed domain input without BigInt, date, or canonicalization defects', () => {
+    const malformed: readonly unknown[] = [
+      { ...fixture(), observedAt: 'not-an-instant' },
+      { ...fixture(), precision: { ...fixture().precision, quantityIncrementMicros: '0' } },
+      {
+        ...fixture(),
+        referencePrices: {
+          ...fixture().referencePrices,
+          priceMicros: { AMD: 'not-micros', NVDA: '100000000' },
+        },
+      },
+      { ...fixture(), targetWeights: { AMD: Number.NaN, NVDA: 0.5 } },
+    ]
+
+    for (const input of malformed) {
+      const result = planTargets(input)
+      expect(Result.isFailure(result)).toBe(true)
+      if (Result.isFailure(result)) {
+        expect(result.failure._tag).toBe('TargetPlannerFailure')
+        expect(result.failure.operation).toBe('decode-input')
+        expect(result.failure.cause).toBeDefined()
+      }
+    }
+  })
+
+  test('returns a tagged precision failure for a decoded weight beyond the execution fixed-point', () => {
+    const result = planTargets(
+      fixture({
+        targetWeights: {
+          AMD: 0.12345678901234,
+          NVDA: 0.5,
+        },
+      }),
+    )
+
+    expect(Result.isFailure(result)).toBe(true)
+    if (Result.isFailure(result)) {
+      expect(result.failure).toMatchObject({
+        _tag: 'TargetPlannerFailure',
+        operation: 'derive-targets',
+        reason: 'precision',
+        facts: {
+          symbol: 'AMD',
+          targetWeight: 0.12345678901234,
+        },
+      })
+      expect(result.failure.cause).toBeDefined()
+    }
+  })
+
+  test('rejects noncanonical, sign-incoherent, duplicate, and temporally incoherent broker state before planning', () => {
+    const filled = order(OrderStatus.Filled)
+    const canceled = order(OrderStatus.Canceled)
+    const cases = [
+      fixture({ positions: [position('AMD', '1'), position('AMD', '2')] }),
+      fixture({ positions: [position('NVDA', '2'), position('AMD', '1')] }),
+      fixture({ orders: [filled, canceled] }),
+      fixture({ positions: [{ ...position('AMD', '1'), marketValueMicros: '-1' }, position('NVDA', '2')] }),
+      fixture({ positions: [{ ...position('AMD', '0'), marketValueMicros: '1' }, position('NVDA', '2')] }),
+      fixture({ positions: [{ ...position('AMD', '-1'), marketValueMicros: '1' }, position('NVDA', '2')] }),
+      fixture({ positions: [position('AMD', '1', '2026-07-23T13:27:00.000Z'), position('NVDA', '2')] }),
+      fixture({ positions: [position('AMD', '1', '2026-07-23T13:29:00.001Z'), position('NVDA', '2')] }),
+      fixture({ unknownOrderCount: 1 }),
+    ]
+
+    expect(cases.map((input) => planSuccess(input).reason)).toEqual(cases.map(() => TargetPlanReason.InputMismatch))
+  })
+
+  test('rejects rehashed status, sign, delta, ordering, reason-fact, and buying-power impossibilities', () => {
+    const valid = planSuccess(fixture())
+    const rehash = (candidate: Omit<typeof valid, 'outputHash'>) => ({
+      ...candidate,
+      outputHash: canonicalHashV1(candidate),
+    })
+    const { outputHash: _, ...material } = valid
+    const candidates: readonly unknown[] = [
+      rehash({ ...material, intentTargets: [...material.intentTargets].reverse() }),
+      rehash({
+        ...material,
+        intentTargets: material.intentTargets.map((intent, index) =>
+          index === 0 ? { ...intent, quantityMicros: (BigInt(intent.quantityMicros) + 1n).toString() } : intent,
+        ),
+      }),
+      rehash({ ...material, requiredReferenceBuyNotionalMicros: '1' }),
+      rehash({ ...material, residualBuyingPowerMicros: '1' }),
+      rehash({
+        ...material,
+        targets: material.targets.map((target, index) =>
+          index === 0 ? { ...target, targetQuantityMicros: target.currentQuantityMicros } : target,
+        ),
+      }),
+      rehash({
+        ...material,
+        targets: material.targets.map((target, index) =>
+          index === 0 ? { ...target, targetQuantityMicros: '-1' } : target,
+        ),
+      }),
+      rehash({
+        ...material,
+        targets: material.targets.map((target, index) =>
+          index === 0 ? { ...target, currentQuantityMicros: '-1' } : target,
+        ),
+      }),
+      rehash({
+        ...material,
+        targets: material.targets.map((target, index) => (index === 0 ? { ...target, targetWeight: 0 } : target)),
+      }),
+      rehash({
+        ...material,
+        availableBuyingPowerMicros: '0',
+        residualBuyingPowerMicros: `-${material.requiredReferenceBuyNotionalMicros}`,
+      }),
+      (() => {
+        const noTrade = planSuccess(fixture({ positions: [], targetWeights: { AMD: 0, NVDA: 0 } }))
+        const { outputHash: _, ...noTradeMaterial } = noTrade
+        const impossible = { ...noTradeMaterial, targets: [] }
+        return { ...impossible, outputHash: canonicalHashV1(impossible) }
+      })(),
+      (() => {
+        const impossible = {
+          schemaVersion: 'bayn.paper-reference-target-plan.v1' as const,
+          inputHash: valid.inputHash,
+          status: TargetPlanStatus.Blocked,
+          reason: TargetPlanReason.InsufficientBuyingPower,
+          targets: [],
+          intentTargets: [],
+          requiredReferenceBuyNotionalMicros: '0',
+          availableBuyingPowerMicros: '-1',
+          residualBuyingPowerMicros: '-1',
+        }
+        return { ...impossible, outputHash: canonicalHashV1(impossible) }
+      })(),
+    ]
+
+    for (const candidate of candidates) {
+      expect(Result.isFailure(decodeTargetPlanResult(candidate))).toBe(true)
+    }
+  })
+
+  test('rejects ill-formed Unicode at the exact intent identity path before output hashing', () => {
+    const valid = planSuccess(fixture())
+    const candidate = {
+      ...valid,
+      intentTargets: valid.intentTargets.map((intent) => ({ ...intent, strategyName: '\ud800' })),
+    }
+    const result = decodeTargetPlanResult(candidate)
+
+    expect(Result.isFailure(result)).toBe(true)
+    if (Result.isFailure(result)) {
+      expect(result.failure).toMatchObject({
+        _tag: 'TargetPlannerFailure',
+        operation: 'decode-output',
+        reason: 'contract',
+      })
+      expect(result.failure.cause).toBeDefined()
+      expect(String(result.failure.cause)).toContain('["intentTargets"][0]["strategyName"]')
+      expect(String(result.failure.cause)).toContain('well-formed Unicode')
+    }
   })
 })

--- a/services/bayn/src/target-planner.ts
+++ b/services/bayn/src/target-planner.ts
@@ -1,50 +1,91 @@
-import { Schema } from 'effect'
+import { Data, Result, Schema } from 'effect'
 
 import { IntentPlanSchema, type IntentPlan } from './execution/intents'
 import { desiredQuantityMicros, MICROS } from './execution-model'
 import { canonicalHashV1 } from './hash'
-import { AccountStatus, OrderSide, OrderStatus, OrderType, ReconciliationStatus, TimeInForce } from './paper'
-import type { ExecutionModel } from './protocol'
-import { reconciledStateHash, type ReconciledBrokerState } from './reconciliation'
 import {
+  AccountSnapshotSchema,
+  AccountStatus,
+  DiscrepancySchema,
+  OrderSchema,
+  OrderSide,
+  OrderStatus,
+  OrderType,
+  PositionSchema,
+  ReconciliationStatus,
+  TimeInForce,
+} from './paper'
+import { reconciledStateHash } from './reconciliation'
+import {
+  NonNegativeIntegerSchema,
+  IsoDateSchema,
   PositiveMicrosSchema,
+  PositiveIntegerSchema,
   Sha256Schema,
   SignedMicrosSchema,
+  StrictNonEmptyStringSchema,
   SymbolSchema,
   UnitIntervalSchema,
   UnsignedMicrosSchema,
-  type IsoDate,
+  UtcInstantSchema,
+  strictParseOptions,
 } from './schemas'
-import type { SignalDecision } from './types'
 
 const WEIGHT_SUM_TOLERANCE = 1e-12
 
-export interface SignalSessionReferencePrices {
-  readonly schemaVersion: 'bayn.signal-session-reference-prices.v1'
-  readonly signalDate: IsoDate
-  readonly observedAt: string
-  readonly contentHash: string
-  readonly priceMicros: Readonly<Record<string, string>>
-}
+const SignalSessionReferencePricesSchema = Schema.Struct({
+  schemaVersion: Schema.Literal('bayn.signal-session-reference-prices.v1'),
+  signalDate: IsoDateSchema,
+  observedAt: UtcInstantSchema,
+  contentHash: Sha256Schema,
+  priceMicros: Schema.Record(SymbolSchema, PositiveMicrosSchema),
+})
 
-export type TargetPlannerBrokerState = ReconciledBrokerState
+const TargetPlannerBrokerStateSchema = Schema.Struct({
+  account: AccountSnapshotSchema,
+  positions: Schema.Array(PositionSchema),
+  positionsObservedAt: UtcInstantSchema,
+  orders: Schema.Array(OrderSchema),
+  ordersObservedAt: UtcInstantSchema,
+  accountingHash: Sha256Schema,
+  reconciliation: Schema.Struct({
+    schemaVersion: Schema.Literal('bayn.paper-reconciliation.v1'),
+    reconciliationId: Sha256Schema,
+    accountId: StrictNonEmptyStringSchema,
+    expectedHash: Sha256Schema,
+    observedHash: Sha256Schema,
+    contentHash: Sha256Schema,
+    status: Schema.Enum(ReconciliationStatus),
+    discrepancies: Schema.Array(DiscrepancySchema),
+    reconciledAt: UtcInstantSchema,
+  }),
+  unknownOrderCount: NonNegativeIntegerSchema,
+})
 
-export interface TargetPlannerInput {
-  readonly schemaVersion: 'bayn.paper-target-planner-input.v1'
-  readonly strategyName: IntentPlan['strategyName']
-  readonly cycleId: IntentPlan['cycleId']
-  readonly decisionHash: IntentPlan['decisionHash']
-  readonly policyHash: IntentPlan['policyHash']
-  readonly accountId: IntentPlan['accountId']
-  readonly signalDate: IsoDate
-  readonly targetWeights: SignalDecision['targetWeights']
-  readonly referencePrices: SignalSessionReferencePrices
-  readonly brokerState: TargetPlannerBrokerState
-  readonly precision: ExecutionModel['precision']
-  readonly maximumInputAgeMs: number
-  readonly submissionCutoffAt: string
-  readonly observedAt: string
-}
+export const TargetPlannerInputSchema = Schema.Struct({
+  schemaVersion: Schema.Literal('bayn.paper-target-planner-input.v1'),
+  strategyName: StrictNonEmptyStringSchema,
+  cycleId: Sha256Schema,
+  decisionHash: Sha256Schema,
+  policyHash: Sha256Schema,
+  accountId: StrictNonEmptyStringSchema,
+  signalDate: SignalSessionReferencePricesSchema.fields.signalDate,
+  targetWeights: Schema.Record(SymbolSchema, UnitIntervalSchema),
+  referencePrices: SignalSessionReferencePricesSchema,
+  brokerState: TargetPlannerBrokerStateSchema,
+  precision: Schema.Struct({
+    quantityIncrementMicros: PositiveMicrosSchema,
+    priceIncrementMicros: PositiveMicrosSchema,
+    minimumBuyNotionalMicros: PositiveMicrosSchema,
+  }),
+  maximumInputAgeMs: PositiveIntegerSchema,
+  submissionCutoffAt: UtcInstantSchema,
+  observedAt: UtcInstantSchema,
+})
+
+export type SignalSessionReferencePrices = typeof SignalSessionReferencePricesSchema.Type
+export type TargetPlannerBrokerState = typeof TargetPlannerBrokerStateSchema.Type
+export type TargetPlannerInput = typeof TargetPlannerInputSchema.Type
 
 export interface PlannedTargetQuantity {
   readonly symbol: string
@@ -78,27 +119,69 @@ export enum TargetPlanReason {
   UnresolvedOrder = 'UNRESOLVED_ORDER',
 }
 
-export interface TargetPlanResult {
-  readonly schemaVersion: 'bayn.paper-reference-target-plan.v1'
-  readonly inputHash: string
-  readonly outputHash: string
-  readonly status: TargetPlanStatus
-  readonly reason: TargetPlanReason | null
-  readonly targets: readonly PlannedTargetQuantity[]
-  readonly intentTargets: readonly ReferenceTargetIntent[]
-  readonly requiredReferenceBuyNotionalMicros: string
-  readonly availableBuyingPowerMicros: string
-  readonly residualBuyingPowerMicros: string
+export const blockedTargetPlanReasons = [
+  TargetPlanReason.AccountNotActive,
+  TargetPlanReason.BelowMinimumBuyNotional,
+  TargetPlanReason.IdentityMismatch,
+  TargetPlanReason.InputMismatch,
+  TargetPlanReason.InputStale,
+  TargetPlanReason.InsufficientBuyingPower,
+  TargetPlanReason.NonPositiveEquity,
+  TargetPlanReason.ReconciliationNotExact,
+  TargetPlanReason.ShortPositionNotAllowed,
+  TargetPlanReason.SubmissionCutoffReached,
+  TargetPlanReason.UnknownOrder,
+  TargetPlanReason.UnresolvedOrder,
+] as const
+export type BlockedTargetPlanReason = (typeof blockedTargetPlanReasons)[number]
+
+interface CanonicalizeTargetPlannerInputIssue {
+  readonly operation: 'canonicalize-input'
+  readonly reason: 'hash'
 }
 
-type OutputMaterial = Omit<TargetPlanResult, 'outputHash'>
+interface CanonicalizeTargetPlannerOutputIssue {
+  readonly operation: 'canonicalize-output'
+  readonly reason: 'hash'
+}
+
+interface DecodeTargetPlannerInputIssue {
+  readonly operation: 'decode-input'
+  readonly reason: 'contract'
+}
+
+interface DecodeTargetPlannerOutputIssue {
+  readonly operation: 'decode-output'
+  readonly reason: 'contract' | 'hash'
+}
+
+interface DeriveTargetPlannerTargetsIssue {
+  readonly operation: 'derive-targets'
+  readonly reason: 'precision'
+}
+
+type TargetPlannerIssue =
+  | CanonicalizeTargetPlannerInputIssue
+  | CanonicalizeTargetPlannerOutputIssue
+  | DecodeTargetPlannerInputIssue
+  | DecodeTargetPlannerOutputIssue
+  | DeriveTargetPlannerTargetsIssue
+
+interface TargetPlannerFailureDetails {
+  readonly message: string
+  readonly facts: Readonly<Record<string, unknown>>
+  readonly cause?: unknown
+}
+
+const TargetPlannerFailure = Data.TaggedError('TargetPlannerFailure')<TargetPlannerIssue & TargetPlannerFailureDetails>
+export type TargetPlannerFailure = InstanceType<typeof TargetPlannerFailure>
 
 const PlannedTargetQuantitySchema = Schema.Struct({
   symbol: SymbolSchema,
   targetWeight: UnitIntervalSchema,
   referencePriceMicros: PositiveMicrosSchema,
-  currentQuantityMicros: SignedMicrosSchema,
-  targetQuantityMicros: SignedMicrosSchema,
+  currentQuantityMicros: UnsignedMicrosSchema,
+  targetQuantityMicros: UnsignedMicrosSchema,
 })
 
 const ReferenceTargetIntentSchema = Schema.Struct({
@@ -115,78 +198,307 @@ const ReferenceTargetIntentSchema = Schema.Struct({
   createdAt: IntentPlanSchema.fields.createdAt,
 })
 
-const TargetPlanResultBase = Schema.Struct({
+const TargetPlanResultFields = {
   schemaVersion: Schema.Literal('bayn.paper-reference-target-plan.v1'),
   inputHash: Sha256Schema,
   outputHash: Sha256Schema,
-  status: Schema.Enum(TargetPlanStatus),
-  reason: Schema.NullOr(Schema.Enum(TargetPlanReason)),
   targets: Schema.Array(PlannedTargetQuantitySchema),
-  intentTargets: Schema.Array(ReferenceTargetIntentSchema),
   requiredReferenceBuyNotionalMicros: UnsignedMicrosSchema,
   availableBuyingPowerMicros: SignedMicrosSchema,
   residualBuyingPowerMicros: SignedMicrosSchema,
+} as const
+
+const PlannedTargetPlanResultSchema = Schema.Struct({
+  ...TargetPlanResultFields,
+  status: Schema.Literal(TargetPlanStatus.Planned),
+  reason: Schema.Null,
+  intentTargets: Schema.Array(ReferenceTargetIntentSchema).check(Schema.isMinLength(1)),
 })
 
-export const TargetPlanResultSchema = TargetPlanResultBase.check(
-  Schema.makeFilter((result: typeof TargetPlanResultBase.Type): readonly Schema.FilterIssue[] => {
-    const issues: Schema.FilterIssue[] = []
-    const { outputHash, ...material } = result
-    if (outputHash !== canonicalHashV1(material)) {
-      issues.push({ path: ['outputHash'], issue: 'must match the canonical target-plan output material' })
-    }
-    if (result.status === TargetPlanStatus.Planned && (result.reason !== null || result.intentTargets.length === 0)) {
-      issues.push({ path: ['status'], issue: 'PLANNED requires target deltas and no reason' })
-    }
-    if (
-      result.status === TargetPlanStatus.NoTrade &&
-      (result.reason !== TargetPlanReason.TargetsSatisfied || result.intentTargets.length !== 0)
-    ) {
-      issues.push({ path: ['status'], issue: 'NO_TRADE requires TARGETS_SATISFIED and no target deltas' })
-    }
-    if (result.status === TargetPlanStatus.Blocked && (result.reason === null || result.intentTargets.length !== 0)) {
-      issues.push({ path: ['status'], issue: 'BLOCKED requires one reason and no target deltas' })
-    }
-    const targetSymbols = result.targets.map((target) => target.symbol)
-    if (new Set(targetSymbols).size !== targetSymbols.length) {
-      issues.push({ path: ['targets'], issue: 'must contain one target per symbol' })
-    }
-    const intentSymbols = result.intentTargets.map((intent) => intent.symbol)
-    if (
-      new Set(intentSymbols).size !== intentSymbols.length ||
-      intentSymbols.some((symbol) => !targetSymbols.includes(symbol))
-    ) {
-      issues.push({ path: ['intentTargets'], issue: 'must contain at most one delta for each persisted target' })
-    }
-    return issues
-  }),
-)
+const NoTradeTargetPlanResultSchema = Schema.Struct({
+  ...TargetPlanResultFields,
+  status: Schema.Literal(TargetPlanStatus.NoTrade),
+  reason: Schema.Literal(TargetPlanReason.TargetsSatisfied),
+  targets: Schema.Array(PlannedTargetQuantitySchema).check(Schema.isMinLength(1)),
+  intentTargets: Schema.Tuple([]),
+})
+
+const BlockedTargetPlanResultSchema = Schema.Struct({
+  ...TargetPlanResultFields,
+  status: Schema.Literal(TargetPlanStatus.Blocked),
+  reason: Schema.Literals(blockedTargetPlanReasons),
+  intentTargets: Schema.Tuple([]),
+})
+
+const TargetPlanResultBase = Schema.Union([
+  PlannedTargetPlanResultSchema,
+  NoTradeTargetPlanResultSchema,
+  BlockedTargetPlanResultSchema,
+])
 
 const compareText = (left: string, right: string): number => (left < right ? -1 : left > right ? 1 : 0)
+const isStrictlySorted = (values: readonly string[]): boolean =>
+  values.every((value, index) => index === 0 || values[index - 1] < value)
 
-const finish = (material: OutputMaterial): TargetPlanResult => ({
-  ...material,
-  outputHash: canonicalHashV1(material),
-})
+interface TargetPlanDeltaFact {
+  readonly index: number
+  readonly target: PlannedTargetQuantity
+  readonly currentQuantity: bigint
+  readonly targetQuantity: bigint
+  readonly delta: bigint
+  readonly intent: ReferenceTargetIntent | undefined
+}
+
+interface TargetPlanSemanticFacts {
+  readonly targetSymbols: readonly string[]
+  readonly intentsBySymbol: ReadonlyMap<string, ReferenceTargetIntent>
+  readonly deltas: readonly TargetPlanDeltaFact[]
+  readonly requiredReferenceBuyNotional: bigint
+  readonly nonzeroDeltaCount: number
+  readonly positiveDeltaCount: number
+}
+
+const deriveTargetPlanSemanticFacts = (result: typeof TargetPlanResultBase.Type): TargetPlanSemanticFacts => {
+  const targetSymbols = result.targets.map((target) => target.symbol)
+  const intentsBySymbol = new Map(result.intentTargets.map((intent) => [intent.symbol, intent]))
+  let requiredReferenceBuyNotional = 0n
+  let nonzeroDeltaCount = 0
+  let positiveDeltaCount = 0
+  const deltas = result.targets.map((target, index): TargetPlanDeltaFact => {
+    const currentQuantity = BigInt(target.currentQuantityMicros)
+    const targetQuantity = BigInt(target.targetQuantityMicros)
+    const delta = targetQuantity - currentQuantity
+    if (delta !== 0n) nonzeroDeltaCount += 1
+    if (delta > 0n) {
+      positiveDeltaCount += 1
+      requiredReferenceBuyNotional += (delta * BigInt(target.referencePriceMicros) + MICROS - 1n) / MICROS
+    }
+    return {
+      index,
+      target,
+      currentQuantity,
+      targetQuantity,
+      delta,
+      intent: intentsBySymbol.get(target.symbol),
+    }
+  })
+  return {
+    targetSymbols,
+    intentsBySymbol,
+    deltas,
+    requiredReferenceBuyNotional,
+    nonzeroDeltaCount,
+    positiveDeltaCount,
+  }
+}
+
+const targetPlanOrderingIssues = (
+  result: typeof TargetPlanResultBase.Type,
+  facts: TargetPlanSemanticFacts,
+): readonly Schema.FilterIssue[] => {
+  const issues: Schema.FilterIssue[] = []
+  if (new Set(facts.targetSymbols).size !== facts.targetSymbols.length || !isStrictlySorted(facts.targetSymbols)) {
+    issues.push({ path: ['targets'], issue: 'must contain one target per symbol in canonical order' })
+  }
+  const intentSymbols = result.intentTargets.map((intent) => intent.symbol)
+  if (
+    facts.intentsBySymbol.size !== result.intentTargets.length ||
+    intentSymbols.some((symbol) => !facts.targetSymbols.includes(symbol))
+  ) {
+    issues.push({ path: ['intentTargets'], issue: 'must contain at most one delta for each persisted target' })
+  }
+  for (let index = 1; index < result.intentTargets.length; index += 1) {
+    const previous = result.intentTargets[index - 1]
+    const current = result.intentTargets[index]
+    if (
+      (previous.side === OrderSide.Buy && current.side === OrderSide.Sell) ||
+      (previous.side === current.side && previous.symbol >= current.symbol)
+    ) {
+      issues.push({ path: ['intentTargets'], issue: 'must be ordered sells first and then by symbol' })
+      break
+    }
+  }
+  return issues
+}
+
+const targetQuantityIssues = (facts: TargetPlanSemanticFacts): readonly Schema.FilterIssue[] => {
+  const issues: Schema.FilterIssue[] = []
+  for (const { index, target, targetQuantity } of facts.deltas) {
+    if (target.targetWeight === 0 && targetQuantity !== 0n) {
+      issues.push({
+        path: ['targets', index, 'targetQuantityMicros'],
+        issue: 'must be zero when the target weight is zero',
+      })
+    }
+  }
+  return issues
+}
+
+const plannedIntentIssues = (
+  result: typeof TargetPlanResultBase.Type,
+  facts: TargetPlanSemanticFacts,
+): readonly Schema.FilterIssue[] => {
+  if (result.status !== TargetPlanStatus.Planned) return []
+  const issues: Schema.FilterIssue[] = []
+  const firstIntent = result.intentTargets[0]
+  for (const { delta, index, intent, target } of facts.deltas) {
+    if (delta === 0n && intent !== undefined) {
+      issues.push({ path: ['intentTargets'], issue: `must not retain a zero delta for ${target.symbol}` })
+      continue
+    }
+    if (delta !== 0n && intent === undefined) {
+      issues.push({ path: ['intentTargets'], issue: `must retain the nonzero delta for ${target.symbol}` })
+      continue
+    }
+    if (
+      intent !== undefined &&
+      (intent.side !== (delta > 0n ? OrderSide.Buy : OrderSide.Sell) ||
+        BigInt(intent.quantityMicros) !== (delta < 0n ? -delta : delta) ||
+        intent.orderType !== OrderType.Market ||
+        intent.timeInForce !== TimeInForce.Day)
+    ) {
+      issues.push({ path: ['intentTargets', index], issue: 'must exactly encode the target quantity delta' })
+    }
+    if (
+      firstIntent !== undefined &&
+      intent !== undefined &&
+      (intent.strategyName !== firstIntent.strategyName ||
+        intent.cycleId !== firstIntent.cycleId ||
+        intent.decisionHash !== firstIntent.decisionHash ||
+        intent.policyHash !== firstIntent.policyHash ||
+        intent.accountId !== firstIntent.accountId ||
+        intent.createdAt !== firstIntent.createdAt)
+    ) {
+      issues.push({ path: ['intentTargets', index], issue: 'must share one target-plan identity and creation time' })
+    }
+  }
+  if (facts.nonzeroDeltaCount !== result.intentTargets.length) {
+    issues.push({ path: ['intentTargets'], issue: 'must contain every and only nonzero target delta' })
+  }
+  return issues
+}
+
+const targetPlanStatusIssues = (
+  result: typeof TargetPlanResultBase.Type,
+  facts: TargetPlanSemanticFacts,
+): readonly Schema.FilterIssue[] => {
+  const issues: Schema.FilterIssue[] = []
+  if (result.status === TargetPlanStatus.NoTrade && facts.nonzeroDeltaCount !== 0) {
+    issues.push({ path: ['status'], issue: 'NO_TRADE requires every target quantity to be satisfied' })
+  }
+  if (
+    result.status === TargetPlanStatus.Blocked &&
+    result.targets.length > 0 &&
+    result.reason !== TargetPlanReason.BelowMinimumBuyNotional &&
+    result.reason !== TargetPlanReason.InsufficientBuyingPower
+  ) {
+    issues.push({ path: ['targets'], issue: 'blocked target evidence is valid only for notional failures' })
+  }
+  return issues
+}
+
+const targetPlanBuyingPowerIssues = (
+  result: typeof TargetPlanResultBase.Type,
+  facts: TargetPlanSemanticFacts,
+): readonly Schema.FilterIssue[] => {
+  const issues: Schema.FilterIssue[] = []
+  const required = BigInt(result.requiredReferenceBuyNotionalMicros)
+  const available = BigInt(result.availableBuyingPowerMicros)
+  const residual = BigInt(result.residualBuyingPowerMicros)
+  if (required !== facts.requiredReferenceBuyNotional) {
+    issues.push({
+      path: ['requiredReferenceBuyNotionalMicros'],
+      issue: 'must equal the exact aggregate reference notional of positive target deltas',
+    })
+  }
+  const expectedResidual = result.status === TargetPlanStatus.Blocked ? available : available - required
+  if (residual !== expectedResidual) {
+    issues.push({ path: ['residualBuyingPowerMicros'], issue: 'must agree with target-plan buying-power arithmetic' })
+  }
+  if (result.status === TargetPlanStatus.Planned && required > 0n && required > available) {
+    issues.push({ path: ['status'], issue: 'PLANNED requires sufficient current buying power' })
+  }
+  if (
+    result.status === TargetPlanStatus.Blocked &&
+    result.reason === TargetPlanReason.InsufficientBuyingPower &&
+    (facts.positiveDeltaCount === 0 || required === 0n || required <= available)
+  ) {
+    issues.push({
+      path: ['reason'],
+      issue: 'INSUFFICIENT_BUYING_POWER requires a positive target buy and a reference shortfall',
+    })
+  }
+  if (
+    result.status === TargetPlanStatus.Blocked &&
+    result.reason === TargetPlanReason.BelowMinimumBuyNotional &&
+    (facts.positiveDeltaCount === 0 || required === 0n)
+  ) {
+    issues.push({
+      path: ['requiredReferenceBuyNotionalMicros'],
+      issue: 'BELOW_MINIMUM_BUY_NOTIONAL requires a positive target buy and its nonzero reference notional',
+    })
+  }
+  return issues
+}
+
+// The base union decodes every micros string and plain-data field before these pure semantic phases run.
+const targetPlanSemanticIssues = (result: typeof TargetPlanResultBase.Type): readonly Schema.FilterIssue[] => {
+  const facts = deriveTargetPlanSemanticFacts(result)
+  return [
+    ...targetPlanOrderingIssues(result, facts),
+    ...targetQuantityIssues(facts),
+    ...plannedIntentIssues(result, facts),
+    ...targetPlanStatusIssues(result, facts),
+    ...targetPlanBuyingPowerIssues(result, facts),
+  ]
+}
+
+const TargetPlanResultSemanticSchema = TargetPlanResultBase.check(Schema.makeFilter(targetPlanSemanticIssues))
+
+const targetPlanHashIssues = (result: typeof TargetPlanResultSemanticSchema.Type): readonly Schema.FilterIssue[] => {
+  const { outputHash, ...material } = result
+  const expectedHash = Result.try({
+    try: () => canonicalHashV1(material),
+    catch: (cause) => cause,
+  })
+  if (Result.isFailure(expectedHash)) {
+    return [{ path: ['outputHash'], issue: 'target-plan output material must be canonicalizable' }]
+  }
+  return outputHash === expectedHash.success
+    ? []
+    : [{ path: ['outputHash'], issue: 'must match the canonical target-plan output material' }]
+}
+
+export const TargetPlanResultSchema = TargetPlanResultSemanticSchema.check(Schema.makeFilter(targetPlanHashIssues))
+export type TargetPlanResult = typeof TargetPlanResultSchema.Type
+export type PlannedTargetPlanResult = Extract<TargetPlanResult, { readonly status: TargetPlanStatus.Planned }>
+export type NoTradeTargetPlanResult = Extract<TargetPlanResult, { readonly status: TargetPlanStatus.NoTrade }>
+export type BlockedTargetPlanResult = Extract<TargetPlanResult, { readonly status: TargetPlanStatus.Blocked }>
+
+type OutputMaterial = TargetPlanResult extends infer Plan
+  ? Plan extends TargetPlanResult
+    ? Omit<Plan, 'outputHash'>
+    : never
+  : never
+type BlockedOutputMaterial = Extract<OutputMaterial, { readonly status: TargetPlanStatus.Blocked }>
 
 const blocked = (
   inputHash: string,
-  reason: Exclude<TargetPlanReason, TargetPlanReason.TargetsSatisfied>,
+  reason: BlockedTargetPlanReason,
   availableBuyingPowerMicros: string,
   targets: readonly PlannedTargetQuantity[] = [],
   requiredReferenceBuyNotionalMicros = '0',
-): TargetPlanResult =>
-  finish({
-    schemaVersion: 'bayn.paper-reference-target-plan.v1',
-    inputHash,
-    status: TargetPlanStatus.Blocked,
-    reason,
-    targets,
-    intentTargets: [],
-    requiredReferenceBuyNotionalMicros,
-    availableBuyingPowerMicros,
-    residualBuyingPowerMicros: availableBuyingPowerMicros,
-  })
+): BlockedOutputMaterial => ({
+  schemaVersion: 'bayn.paper-reference-target-plan.v1',
+  inputHash,
+  status: TargetPlanStatus.Blocked,
+  reason,
+  targets,
+  intentTargets: [],
+  requiredReferenceBuyNotionalMicros,
+  availableBuyingPowerMicros,
+  residualBuyingPowerMicros: availableBuyingPowerMicros,
+})
 
 const sameStrings = (left: readonly string[], right: readonly string[]): boolean =>
   left.length === right.length && left.every((value, index) => value === right[index])
@@ -194,17 +506,148 @@ const sameStrings = (left: readonly string[], right: readonly string[]): boolean
 const isUnresolved = (status: OrderStatus): boolean =>
   status === OrderStatus.New || status === OrderStatus.PartiallyFilled || status === OrderStatus.Pending
 
-const referencePriceHash = (referencePrices: SignalSessionReferencePrices): string =>
-  canonicalHashV1({
-    schemaVersion: referencePrices.schemaVersion,
-    signalDate: referencePrices.signalDate,
-    observedAt: referencePrices.observedAt,
-    priceMicros: referencePrices.priceMicros,
+const referencePriceMaterial = (referencePrices: SignalSessionReferencePrices) => ({
+  schemaVersion: referencePrices.schemaVersion,
+  signalDate: referencePrices.signalDate,
+  observedAt: referencePrices.observedAt,
+  priceMicros: referencePrices.priceMicros,
+})
+
+interface TargetPlannerHashes {
+  readonly inputHash: string
+  readonly referencePriceHash: string
+  readonly reconciledBrokerStateHash: string
+}
+
+interface TargetPlannerFacts {
+  readonly input: TargetPlannerInput
+  readonly inputHash: string
+  readonly referencePriceHash: string
+  readonly reconciledBrokerStateHash: string
+  readonly targetSymbols: readonly string[]
+  readonly priceSymbols: readonly string[]
+  readonly prices: ReadonlyMap<string, bigint>
+  readonly positions: ReadonlyMap<string, bigint>
+  readonly positionQuantities: readonly bigint[]
+  readonly positionMarketValues: readonly bigint[]
+  readonly observedAt: number
+  readonly submissionCutoffAt: number
+  readonly sourceTimes: readonly number[]
+  readonly priceIncrement: bigint
+  readonly quantityIncrement: bigint
+  readonly minimumBuyNotional: bigint
+  readonly equity: bigint
+  readonly availableBuyingPower: bigint
+}
+
+interface PlannedTargetFact {
+  readonly target: PlannedTargetQuantity
+  readonly referencePrice: bigint
+  readonly delta: bigint
+}
+
+type TargetPlannerReason<Operation extends TargetPlannerIssue['operation']> = Extract<
+  TargetPlannerIssue,
+  { readonly operation: Operation }
+>['reason']
+
+const canonicalizePlannerInputFailure = (
+  reason: TargetPlannerReason<'canonicalize-input'>,
+  message: string,
+  facts: Readonly<Record<string, unknown>> = {},
+  cause?: unknown,
+): TargetPlannerFailure => new TargetPlannerFailure({ operation: 'canonicalize-input', reason, message, facts, cause })
+
+const canonicalizePlannerOutputFailure = (
+  reason: TargetPlannerReason<'canonicalize-output'>,
+  message: string,
+  facts: Readonly<Record<string, unknown>> = {},
+  cause?: unknown,
+): TargetPlannerFailure => new TargetPlannerFailure({ operation: 'canonicalize-output', reason, message, facts, cause })
+
+const decodePlannerInputFailure = (
+  reason: TargetPlannerReason<'decode-input'>,
+  message: string,
+  facts: Readonly<Record<string, unknown>> = {},
+  cause?: unknown,
+): TargetPlannerFailure => new TargetPlannerFailure({ operation: 'decode-input', reason, message, facts, cause })
+
+const decodePlannerOutputFailure = (
+  reason: TargetPlannerReason<'decode-output'>,
+  message: string,
+  facts: Readonly<Record<string, unknown>> = {},
+  cause?: unknown,
+): TargetPlannerFailure => new TargetPlannerFailure({ operation: 'decode-output', reason, message, facts, cause })
+
+const deriveTargetsFailure = (
+  reason: TargetPlannerReason<'derive-targets'>,
+  message: string,
+  facts: Readonly<Record<string, unknown>> = {},
+  cause?: unknown,
+): TargetPlannerFailure => new TargetPlannerFailure({ operation: 'derive-targets', reason, message, facts, cause })
+
+const decodeTargetPlannerInputResult = Schema.decodeUnknownResult(TargetPlannerInputSchema, strictParseOptions)
+const decodeTargetPlanSemanticResult = Schema.decodeUnknownResult(TargetPlanResultSemanticSchema, strictParseOptions)
+
+const deriveTargetPlannerHashes = (
+  input: TargetPlannerInput,
+): Result.Result<TargetPlannerHashes, TargetPlannerFailure> =>
+  Result.try({
+    try: () => ({
+      inputHash: canonicalHashV1(input),
+      referencePriceHash: canonicalHashV1(referencePriceMaterial(input.referencePrices)),
+      reconciledBrokerStateHash: reconciledStateHash(input.brokerState),
+    }),
+    catch: (cause) =>
+      canonicalizePlannerInputFailure(
+        'hash',
+        'validated target-planner evidence is not canonicalizable',
+        { cycleId: input.cycleId },
+        cause,
+      ),
   })
 
-const identityAndSessionMatch = (input: TargetPlannerInput): boolean => {
+const parseTargetPlannerFacts = (input: TargetPlannerInput, hashes: TargetPlannerHashes): TargetPlannerFacts => {
   const targetSymbols = Object.keys(input.targetWeights).sort(compareText)
   const priceSymbols = Object.keys(input.referencePrices.priceMicros).sort(compareText)
+  const prices = new Map(
+    Object.entries(input.referencePrices.priceMicros).map(([symbol, price]) => [symbol, BigInt(price)]),
+  )
+  const positionQuantities = input.brokerState.positions.map((position) => BigInt(position.quantityMicros))
+  const positionMarketValues = input.brokerState.positions.map((position) => BigInt(position.marketValueMicros))
+  const positions = new Map(
+    input.brokerState.positions.map((position, index) => [position.symbol, positionQuantities[index]]),
+  )
+  return {
+    input,
+    ...hashes,
+    targetSymbols,
+    priceSymbols,
+    prices,
+    positions,
+    positionQuantities,
+    positionMarketValues,
+    observedAt: Date.parse(input.observedAt),
+    submissionCutoffAt: Date.parse(input.submissionCutoffAt),
+    sourceTimes: [
+      input.referencePrices.observedAt,
+      input.brokerState.account.observedAt,
+      input.brokerState.positionsObservedAt,
+      input.brokerState.ordersObservedAt,
+      input.brokerState.reconciliation.reconciledAt,
+      ...input.brokerState.positions.map((position) => position.observedAt),
+      ...input.brokerState.orders.map((order) => order.observedAt),
+    ].map(Date.parse),
+    priceIncrement: BigInt(input.precision.priceIncrementMicros),
+    quantityIncrement: BigInt(input.precision.quantityIncrementMicros),
+    minimumBuyNotional: BigInt(input.precision.minimumBuyNotionalMicros),
+    equity: BigInt(input.brokerState.account.equityMicros),
+    availableBuyingPower: BigInt(input.brokerState.account.buyingPowerMicros),
+  }
+}
+
+const identityAndSessionMatch = (facts: TargetPlannerFacts): boolean => {
+  const { input, priceSymbols, targetSymbols } = facts
   const accountId = input.accountId
   return (
     targetSymbols.length > 0 &&
@@ -220,10 +663,48 @@ const identityAndSessionMatch = (input: TargetPlannerInput): boolean => {
   )
 }
 
-const brokerStateIsCurrent = (input: TargetPlannerInput): boolean => {
+const brokerStateIsCoherent = (facts: TargetPlannerFacts): boolean => {
+  const { input, positionMarketValues, positionQuantities, priceIncrement, prices, quantityIncrement } = facts
+  const state = input.brokerState
+  const positionSymbols = state.positions.map((position) => position.symbol)
+  const brokerOrderIds = state.orders.map((order) => order.brokerOrderId)
+  const clientOrderIds = state.orders.map((order) => order.clientOrderId)
+  const latestOrderObservation = state.orders.reduce(
+    (latest, order) => (order.observedAt > latest ? order.observedAt : latest),
+    '',
+  )
+  const unknownOrderCount = state.orders.filter((order) => order.intentId === undefined).length
+  return (
+    new Set(positionSymbols).size === positionSymbols.length &&
+    isStrictlySorted(positionSymbols) &&
+    state.positions.every((position) => position.observedAt === state.positionsObservedAt) &&
+    positionQuantities.every((quantity, index) => {
+      const marketValue = positionMarketValues[index]
+      return (
+        marketValue !== undefined &&
+        (quantity === 0n) === (marketValue === 0n) &&
+        (quantity <= 0n || marketValue > 0n) &&
+        (quantity >= 0n || marketValue < 0n)
+      )
+    }) &&
+    new Set(brokerOrderIds).size === brokerOrderIds.length &&
+    isStrictlySorted(brokerOrderIds) &&
+    new Set(clientOrderIds).size === clientOrderIds.length &&
+    state.orders.every((order) => order.observedAt <= state.ordersObservedAt) &&
+    (state.orders.length === 0 || latestOrderObservation === state.ordersObservedAt) &&
+    state.unknownOrderCount === unknownOrderCount &&
+    input.referencePrices.contentHash === facts.referencePriceHash &&
+    Object.values(input.targetWeights).reduce((total, weight) => total + weight, 0) <= 1 + WEIGHT_SUM_TOLERANCE &&
+    [...prices.values()].every((price) => price % priceIncrement === 0n) &&
+    positionQuantities.every((quantity) => quantity % quantityIncrement === 0n)
+  )
+}
+
+const brokerStateIsCurrent = (facts: TargetPlannerFacts): boolean => {
+  const { input } = facts
   const state = input.brokerState
   const reconciliation = state.reconciliation
-  const stateHash = reconciledStateHash(state)
+  const stateHash = facts.reconciledBrokerStateHash
   return (
     reconciliation.status === ReconciliationStatus.Exact &&
     reconciliation.discrepancies.length === 0 &&
@@ -235,55 +716,74 @@ const brokerStateIsCurrent = (input: TargetPlannerInput): boolean => {
   )
 }
 
-const sourceTimes = (input: TargetPlannerInput): readonly number[] =>
-  [
-    input.referencePrices.observedAt,
-    input.brokerState.account.observedAt,
-    input.brokerState.positionsObservedAt,
-    input.brokerState.ordersObservedAt,
-    input.brokerState.reconciliation.reconciledAt,
-    ...input.brokerState.orders.map((order) => order.observedAt),
-  ].map((value) => Date.parse(value))
-
-const referenceInputsMatch = (input: TargetPlannerInput): boolean => {
-  const priceIncrement = BigInt(input.precision.priceIncrementMicros)
-  const quantityIncrement = BigInt(input.precision.quantityIncrementMicros)
-  const totalWeight = Object.values(input.targetWeights).reduce((total, weight) => total + weight, 0)
-  return (
-    input.referencePrices.contentHash === referencePriceHash(input.referencePrices) &&
-    totalWeight <= 1 + WEIGHT_SUM_TOLERANCE &&
-    Object.values(input.referencePrices.priceMicros).every(
-      (price) => BigInt(price) > 0n && BigInt(price) % priceIncrement === 0n,
-    ) &&
-    input.brokerState.positions.every((position) => BigInt(position.quantityMicros) % quantityIncrement === 0n)
-  )
-}
-
 const referenceNotional = (quantityMicros: bigint, priceMicros: bigint): bigint =>
   (quantityMicros * priceMicros + MICROS - 1n) / MICROS
 
-export const planTargets = (input: TargetPlannerInput): TargetPlanResult => {
-  const inputHash = canonicalHashV1(input)
+const derivePlannedTargetFacts = (
+  facts: TargetPlannerFacts,
+): Result.Result<ReadonlyArray<PlannedTargetFact>, TargetPlannerFailure> =>
+  [...facts.prices.entries()]
+    .sort(([left], [right]) => compareText(left, right))
+    .reduce<Result.Result<ReadonlyArray<PlannedTargetFact>, TargetPlannerFailure>>(
+      (result, [symbol, referencePrice]) =>
+        Result.flatMap(result, (targetFacts) => {
+          const currentQuantity = facts.positions.get(symbol) ?? 0n
+          return Result.map(
+            Result.try({
+              try: () =>
+                desiredQuantityMicros(facts.equity, facts.input.targetWeights[symbol], referencePrice, {
+                  precision: facts.input.precision,
+                }),
+              catch: (cause) =>
+                deriveTargetsFailure(
+                  'precision',
+                  'target quantity could not be represented at the declared precision',
+                  {
+                    cycleId: facts.input.cycleId,
+                    symbol,
+                    targetWeight: facts.input.targetWeights[symbol],
+                  },
+                  cause,
+                ),
+            }),
+            (targetQuantity) => [
+              ...targetFacts,
+              {
+                referencePrice,
+                delta: targetQuantity - currentQuantity,
+                target: {
+                  symbol,
+                  targetWeight: facts.input.targetWeights[symbol],
+                  referencePriceMicros: referencePrice.toString(),
+                  currentQuantityMicros: currentQuantity.toString(),
+                  targetQuantityMicros: targetQuantity.toString(),
+                },
+              },
+            ],
+          )
+        }),
+      Result.succeed([]),
+    )
+
+const selectTargetPlannerPreflightBlock = (facts: TargetPlannerFacts): BlockedOutputMaterial | undefined => {
+  const { input, inputHash } = facts
   const availableBuyingPowerMicros = input.brokerState.account.buyingPowerMicros
-  const observedAt = Date.parse(input.observedAt)
-  if (observedAt >= Date.parse(input.submissionCutoffAt)) {
+  if (facts.observedAt >= facts.submissionCutoffAt) {
     return blocked(inputHash, TargetPlanReason.SubmissionCutoffReached, availableBuyingPowerMicros)
   }
-  if (!identityAndSessionMatch(input)) {
+  if (!identityAndSessionMatch(facts)) {
     return blocked(inputHash, TargetPlanReason.IdentityMismatch, availableBuyingPowerMicros)
   }
-  if (!referenceInputsMatch(input)) {
+  if (!brokerStateIsCoherent(facts)) {
     return blocked(inputHash, TargetPlanReason.InputMismatch, availableBuyingPowerMicros)
   }
-
-  const observations = sourceTimes(input)
-  if (observations.some((source) => source > observedAt)) {
+  if (facts.sourceTimes.some((source) => source > facts.observedAt)) {
     return blocked(inputHash, TargetPlanReason.InputMismatch, availableBuyingPowerMicros)
   }
-  if (observations.some((source) => observedAt - source >= input.maximumInputAgeMs)) {
+  if (facts.sourceTimes.some((source) => facts.observedAt - source >= input.maximumInputAgeMs)) {
     return blocked(inputHash, TargetPlanReason.InputStale, availableBuyingPowerMicros)
   }
-  if (!brokerStateIsCurrent(input)) {
+  if (!brokerStateIsCurrent(facts)) {
     return blocked(inputHash, TargetPlanReason.ReconciliationNotExact, availableBuyingPowerMicros)
   }
   if (input.brokerState.account.status !== AccountStatus.Active) {
@@ -295,89 +795,169 @@ export const planTargets = (input: TargetPlannerInput): TargetPlanResult => {
   if (input.brokerState.orders.some((order) => isUnresolved(order.status))) {
     return blocked(inputHash, TargetPlanReason.UnresolvedOrder, availableBuyingPowerMicros)
   }
-  if (input.brokerState.positions.some((position) => BigInt(position.quantityMicros) < 0n)) {
+  if (facts.positionQuantities.some((quantity) => quantity < 0n)) {
     return blocked(inputHash, TargetPlanReason.ShortPositionNotAllowed, availableBuyingPowerMicros)
   }
-
-  const equityMicros = BigInt(input.brokerState.account.equityMicros)
-  if (equityMicros <= 0n) {
+  if (facts.equity <= 0n) {
     return blocked(inputHash, TargetPlanReason.NonPositiveEquity, availableBuyingPowerMicros)
   }
+  return undefined
+}
 
-  const minimumBuyNotionalMicros = BigInt(input.precision.minimumBuyNotionalMicros)
-  const positions = new Map(
-    input.brokerState.positions.map((position) => [position.symbol, BigInt(position.quantityMicros)]),
-  )
-  const targets = Object.keys(input.targetWeights)
-    .sort(compareText)
-    .map((symbol): PlannedTargetQuantity => {
-      const referencePriceMicros = BigInt(input.referencePrices.priceMicros[symbol])
-      return {
-        symbol,
-        targetWeight: input.targetWeights[symbol],
-        referencePriceMicros: referencePriceMicros.toString(),
-        currentQuantityMicros: (positions.get(symbol) ?? 0n).toString(),
-        targetQuantityMicros: desiredQuantityMicros(equityMicros, input.targetWeights[symbol], referencePriceMicros, {
-          precision: input.precision,
-        }).toString(),
-      }
-    })
-
-  const intents = targets
-    .flatMap((target): readonly ReferenceTargetIntent[] => {
-      const delta = BigInt(target.targetQuantityMicros) - BigInt(target.currentQuantityMicros)
-      if (delta === 0n) return []
-      return [
-        {
-          strategyName: input.strategyName,
-          cycleId: input.cycleId,
-          decisionHash: input.decisionHash,
-          policyHash: input.policyHash,
-          accountId: input.accountId,
-          symbol: target.symbol,
-          side: delta > 0n ? OrderSide.Buy : OrderSide.Sell,
-          orderType: OrderType.Market,
-          timeInForce: TimeInForce.Day,
-          quantityMicros: (delta < 0n ? -delta : delta).toString(),
-          createdAt: input.observedAt,
-        },
-      ]
-    })
+const makeReferenceTargetIntents = (
+  input: TargetPlannerInput,
+  targetFacts: readonly PlannedTargetFact[],
+): readonly ReferenceTargetIntent[] =>
+  targetFacts
+    .flatMap(({ target, delta }): readonly ReferenceTargetIntent[] =>
+      delta === 0n
+        ? []
+        : [
+            {
+              strategyName: input.strategyName,
+              cycleId: input.cycleId,
+              decisionHash: input.decisionHash,
+              policyHash: input.policyHash,
+              accountId: input.accountId,
+              symbol: target.symbol,
+              side: delta > 0n ? OrderSide.Buy : OrderSide.Sell,
+              orderType: OrderType.Market,
+              timeInForce: TimeInForce.Day,
+              quantityMicros: (delta < 0n ? -delta : delta).toString(),
+              createdAt: input.observedAt,
+            },
+          ],
+    )
     .sort((left, right) => {
       if (left.side !== right.side) return left.side === OrderSide.Sell ? -1 : 1
       return compareText(left.symbol, right.symbol)
     })
 
-  const requiredReferenceBuyNotional = intents
-    .filter((intent) => intent.side === OrderSide.Buy)
-    .map((intent) =>
-      referenceNotional(BigInt(intent.quantityMicros), BigInt(input.referencePrices.priceMicros[intent.symbol])),
-    )
-  if (requiredReferenceBuyNotional.some((notional) => notional < minimumBuyNotionalMicros)) {
-    return blocked(inputHash, TargetPlanReason.BelowMinimumBuyNotional, availableBuyingPowerMicros, targets)
-  }
-
-  const requiredBuyingPower = requiredReferenceBuyNotional.reduce((total, value) => total + value, 0n)
-  const availableBuyingPower = BigInt(availableBuyingPowerMicros)
-  if (requiredBuyingPower > 0n && requiredBuyingPower > availableBuyingPower) {
+const selectTargetNotionalBlock = (
+  facts: TargetPlannerFacts,
+  targets: readonly PlannedTargetQuantity[],
+  requiredReferenceBuyNotionals: readonly bigint[],
+): BlockedOutputMaterial | undefined => {
+  const requiredBuyingPower = requiredReferenceBuyNotionals.reduce((total, value) => total + value, 0n)
+  const availableBuyingPowerMicros = facts.input.brokerState.account.buyingPowerMicros
+  if (requiredReferenceBuyNotionals.some((notional) => notional < facts.minimumBuyNotional)) {
     return blocked(
-      inputHash,
-      TargetPlanReason.InsufficientBuyingPower,
+      facts.inputHash,
+      TargetPlanReason.BelowMinimumBuyNotional,
       availableBuyingPowerMicros,
       targets,
       requiredBuyingPower.toString(),
     )
   }
+  return requiredBuyingPower > 0n && requiredBuyingPower > facts.availableBuyingPower
+    ? blocked(
+        facts.inputHash,
+        TargetPlanReason.InsufficientBuyingPower,
+        availableBuyingPowerMicros,
+        targets,
+        requiredBuyingPower.toString(),
+      )
+    : undefined
+}
 
-  return finish({
+const assembleExecutableTargetPlan = (
+  facts: TargetPlannerFacts,
+  targetFacts: readonly PlannedTargetFact[],
+): OutputMaterial => {
+  const targets = targetFacts.map((fact) => fact.target)
+  const intents = makeReferenceTargetIntents(facts.input, targetFacts)
+  const requiredReferenceBuyNotionals = targetFacts
+    .filter((fact) => fact.delta > 0n)
+    .map((fact) => referenceNotional(fact.delta, fact.referencePrice))
+  const requiredBuyingPower = requiredReferenceBuyNotionals.reduce((total, value) => total + value, 0n)
+  const notionalBlock = selectTargetNotionalBlock(facts, targets, requiredReferenceBuyNotionals)
+  if (notionalBlock !== undefined) return notionalBlock
+  const common = {
     schemaVersion: 'bayn.paper-reference-target-plan.v1',
-    inputHash,
-    status: intents.length === 0 ? TargetPlanStatus.NoTrade : TargetPlanStatus.Planned,
-    reason: intents.length === 0 ? TargetPlanReason.TargetsSatisfied : null,
+    inputHash: facts.inputHash,
     targets,
-    intentTargets: intents,
     requiredReferenceBuyNotionalMicros: requiredBuyingPower.toString(),
-    availableBuyingPowerMicros,
-    residualBuyingPowerMicros: (availableBuyingPower - requiredBuyingPower).toString(),
-  })
+    availableBuyingPowerMicros: facts.input.brokerState.account.buyingPowerMicros,
+    residualBuyingPowerMicros: (facts.availableBuyingPower - requiredBuyingPower).toString(),
+  } as const
+  return intents.length === 0
+    ? {
+        ...common,
+        status: TargetPlanStatus.NoTrade,
+        reason: TargetPlanReason.TargetsSatisfied,
+        intentTargets: [],
+      }
+    : {
+        ...common,
+        status: TargetPlanStatus.Planned,
+        reason: null,
+        intentTargets: intents,
+      }
+}
+
+const computeTargetPlan = (facts: TargetPlannerFacts): Result.Result<OutputMaterial, TargetPlannerFailure> => {
+  const preflightBlock = selectTargetPlannerPreflightBlock(facts)
+  return preflightBlock === undefined
+    ? Result.map(derivePlannedTargetFacts(facts), (targetFacts) => assembleExecutableTargetPlan(facts, targetFacts))
+    : Result.succeed(preflightBlock)
+}
+
+const finalizeTargetPlan = (material: OutputMaterial): Result.Result<TargetPlanResult, TargetPlannerFailure> =>
+  Result.flatMap(
+    Result.try({
+      try: () => ({ ...material, outputHash: canonicalHashV1(material) }),
+      catch: (cause) =>
+        canonicalizePlannerOutputFailure(
+          'hash',
+          'target-plan output material is not canonicalizable',
+          { inputHash: material.inputHash, status: material.status },
+          cause,
+        ),
+    }),
+    decodeTargetPlanResult,
+  )
+
+export const decodeTargetPlanResult = (input: unknown): Result.Result<TargetPlanResult, TargetPlannerFailure> =>
+  Result.flatMap(
+    Result.mapError(decodeTargetPlanSemanticResult(input), (cause) =>
+      decodePlannerOutputFailure('contract', 'target-plan output failed its durable contract', {}, cause),
+    ),
+    (decoded) => {
+      const { outputHash, ...material } = decoded
+      return Result.flatMap(
+        Result.try({
+          try: () => canonicalHashV1(material),
+          catch: (cause) =>
+            canonicalizePlannerOutputFailure(
+              'hash',
+              'target-plan output material is not canonicalizable',
+              { inputHash: decoded.inputHash, path: ['outputHash'], status: decoded.status },
+              cause,
+            ),
+        }),
+        (expectedHash) =>
+          expectedHash === outputHash
+            ? Result.succeed(decoded)
+            : Result.fail(
+                decodePlannerOutputFailure('hash', 'target-plan output hash does not match its canonical material', {
+                  expectedHash,
+                  inputHash: decoded.inputHash,
+                  observedHash: outputHash,
+                  path: ['outputHash'],
+                  status: decoded.status,
+                }),
+              ),
+      )
+    },
+  )
+
+export const planTargets = (input: unknown): Result.Result<TargetPlanResult, TargetPlannerFailure> => {
+  const decoded = Result.mapError(decodeTargetPlannerInputResult(input), (cause) =>
+    decodePlannerInputFailure('contract', 'target-planner input failed its durable contract', {}, cause),
+  )
+  return Result.flatMap(decoded, (value) =>
+    Result.flatMap(deriveTargetPlannerHashes(value), (hashes) =>
+      Result.flatMap(computeTargetPlan(parseTargetPlannerFacts(value, hashes)), finalizeTargetPlan),
+    ),
+  )
 }


### PR DESCRIPTION
## Summary

- Totalize Bayn cycle construction/recovery, execution-session, target-planning, risk, and shadow-decision domain boundaries with decoded readonly `Result` failures and status-discriminated target plans.
- Strengthen canonical identity/hash, chronology, readiness, projected-position, and reason-specific invariant validation while preserving valid decision IDs and golden hashes.
- Replace no-I/O Effect internals with cohesive pure phases and add exhaustive table, golden, and property-style regressions for reachable domain outcomes.

Reviewed bundle: `37d151768610c162af7103295d2f59dc892504d2652c8f4c4c6837af16be19d2`.

## Related Issues

PROOMPT-420

## Testing

- `bun test services/bayn/src/cycle.test.ts services/bayn/src/cycle-recovery.test.ts services/bayn/src/execution-session.test.ts services/bayn/src/target-planner.test.ts services/bayn/src/risk.test.ts services/bayn/src/shadow-decision.test.ts` — 78 passed, 0 failed.
- `bunx oxfmt --check <15 owned files>` — all 15 files correctly formatted.
- `bunx oxlint --config .oxlintrc.json <15 owned files>` — 0 warnings, 0 errors.
- `bunx oxlint --config .oxlintrc.json --type-aware --tsconfig services/bayn/tsconfig.json <15 owned files>` — 0 warnings, 0 errors.
- `git diff --check HEAD^ HEAD` — clean.
- `bun run --filter @proompteng/bayn tsc` — expected 75 caller-only diagnostics in the separately owned runner/readiness/observe/cycle-store/test integration surfaces; zero diagnostics in owned files.
- `bun run --filter @proompteng/bayn build` — expected stale `cycleTerminalReasonForTargetPlanBlock` import in `src/db/cycle-store.ts`, pending the caller-integration pass.

## Breaking Changes

This domain integration base changes formerly partial constructors and selectors to return closed `Result` values. Existing runner, readiness, observe-composition, cycle-store, and corresponding test callers require the separately scoped integration migration before the combined PR becomes type/build clean. No trading or authority behavior is changed.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable for this domain-only refactor.
- [x] Required caller migrations and follow-up are tracked by PROOMPT-420 and documented above.