### PR TITLE
refactor(bayn): enforce typed Effect boundaries

### DIFF
--- a/.github/workflows/bayn-ci.yml
+++ b/.github/workflows/bayn-ci.yml
@@ -29,7 +29,7 @@ jobs:
       lint-command: bunx oxfmt --check services/bayn argocd/applications/bayn argocd/applications/torghut/clickhouse/bayn-sealed-secret.yaml argocd/applications/torghut/clickhouse/clickhouse-cluster.yaml
       oxlint-command: bun run --cwd services/bayn lint:oxlint
       oxlint-type-command: bun run --cwd services/bayn lint:oxlint:type
-      test-command: bun run --cwd services/bayn tsc && bun run --cwd services/bayn test && bun test packages/scripts/src/bayn
+      test-command: bun run --cwd services/bayn tsc && bun run --cwd services/bayn lint:effect && bun run --cwd services/bayn test && bun test packages/scripts/src/bayn
       build-command: bun run --cwd services/bayn build
     secrets: inherit
 

--- a/bun.lock
+++ b/bun.lock
@@ -725,6 +725,7 @@
         "tigerbeetle-node": "0.17.9",
       },
       "devDependencies": {
+        "@effect/tsgo": "0.24.3",
         "@types/bun": "1.3.14",
         "@types/node": "^25.6.0",
         "typescript": "^7.0.2",
@@ -1408,6 +1409,22 @@
     "@effect/sql-clickhouse": ["@effect/sql-clickhouse@4.0.0-beta.100", "", { "dependencies": { "@clickhouse/client": "^1.23.1" }, "peerDependencies": { "@effect/platform-node": "^4.0.0-beta.100", "effect": "^4.0.0-beta.100" } }, "sha512-Ezypiv/jySrTHQ4GReAikQHwnHP1NB1Ae/uV/FyVHVfsOJSrdSzzN9rzOvihuga+OnyJUmNfWuPhhNrenWLqIw=="],
 
     "@effect/sql-pg": ["@effect/sql-pg@4.0.0-beta.100", "", { "dependencies": { "pg": "^8.22.0", "pg-connection-string": "2.14.0", "pg-cursor": "^2.21.0", "pg-pool": "^3.14.0", "pg-types": "^4.1.0" }, "peerDependencies": { "effect": "^4.0.0-beta.100" } }, "sha512-KU8P7FMeYw/0bbTrqpRIvmRaUetY/r5JAkX8ydsxtryBJu4JL7v8lm6ijOtoDHHS9kdcNGYGpiZZnn5AaQQJMQ=="],
+
+    "@effect/tsgo": ["@effect/tsgo@0.24.3", "", { "optionalDependencies": { "@effect/tsgo-darwin-arm64": "0.24.3", "@effect/tsgo-darwin-x64": "0.24.3", "@effect/tsgo-linux-arm": "0.24.3", "@effect/tsgo-linux-arm64": "0.24.3", "@effect/tsgo-linux-x64": "0.24.3", "@effect/tsgo-win32-arm64": "0.24.3", "@effect/tsgo-win32-x64": "0.24.3" }, "bin": { "effect-tsgo": "dist/effect-tsgo.js" } }, "sha512-WQxKU3MFzWzI38GbE9cf0POkVX4y0xahD8QqDjLfixW1AEValuHNfOQvyKM2MDWOLdGff4hP8VnIOeduwQt66A=="],
+
+    "@effect/tsgo-darwin-arm64": ["@effect/tsgo-darwin-arm64@0.24.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-eO83D7ZmpAsocA5WJQ8SSAPnAOZ+dEduFIozg9c2SmH36PCHG1Eb++I0UiQml+2LAr4o/QE2wKdWj7LExebjZA=="],
+
+    "@effect/tsgo-darwin-x64": ["@effect/tsgo-darwin-x64@0.24.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-ksX9BdCM8289RRuN0lWhtzuvstH1frxwdxhoW08rrGW3ryER3udEFqEtgtveP0cYvK9gTlV5lXbQPNGktQ2sTw=="],
+
+    "@effect/tsgo-linux-arm": ["@effect/tsgo-linux-arm@0.24.3", "", { "os": "linux", "cpu": "arm" }, "sha512-0TzebGLMNZkHOGSK0w1B4zuvHGlA+Od4LdElWeHHP6iMPEiEWPq17If787+oc+Y67yITPJ9DZcibu69eI9mZhg=="],
+
+    "@effect/tsgo-linux-arm64": ["@effect/tsgo-linux-arm64@0.24.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-CMiThuURi14rT5Ikag5pVnUC3tx4IcmPpRR4WBQkHxAbOf5a1Lo1NUF82zY0azhLW2WszBamTSZP5Tcv4uks2A=="],
+
+    "@effect/tsgo-linux-x64": ["@effect/tsgo-linux-x64@0.24.3", "", { "os": "linux", "cpu": "x64" }, "sha512-R4jl1JWoYEldUU1rtCG1fXWW2ywj/rgY1xaCzK8HSb8fQhQ71WRLLAyAe8ewROuseWQ9Ip+IbbfAeXQOpmpdDA=="],
+
+    "@effect/tsgo-win32-arm64": ["@effect/tsgo-win32-arm64@0.24.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-DOJ4oa8pk8qxEQwKHpJOqtjOfB9iOMuc6Cnb2ZbTG32PBfhqeRYv6YFGhFtgAojXyxfuRP2gCJVpFfjzHJh7nQ=="],
+
+    "@effect/tsgo-win32-x64": ["@effect/tsgo-win32-x64@0.24.3", "", { "os": "win32", "cpu": "x64" }, "sha512-6GpENpPn3mXldmJoM+Z7qi+8fe39xJYB2bLD5jqCFWl14vFp1AeJvYwHYQak8HRm1FiPz72Ninslv8DjHYtZgA=="],
 
     "@effect/typeclass": ["@effect/typeclass@0.38.0", "", { "peerDependencies": { "effect": "^3.19.0" } }, "sha512-lMUcJTRtG8KXhXoczapZDxbLK5os7M6rn0zkvOgncJW++A0UyelZfMVMKdT5R+fgpZcsAU/1diaqw3uqLJwGxA=="],
 

--- a/nix/images/bayn.nix
+++ b/nix/images/bayn.nix
@@ -20,8 +20,8 @@ import ./bun-workspace-service.nix {
   serviceName = "bayn";
   packageName = "@proompteng/bayn";
   depsHash = {
-    x86_64-linux = "sha256-rHuG2j4rs9YZ1FIz6QCNnF8Nj0/10oUeMUZdqMeKi7I=";
-    aarch64-linux = "sha256-pn7Lh1Y8RLuKGy5erc/da0DbWgUvoipnaMMWGgzM9+Q=";
+    x86_64-linux = "sha256-9T3slexnTOAJNAfQtDCo786fTMlbo+bnOzxgQ3NVwrQ=";
+    aarch64-linux = "sha256-JsRAu1zGBRkVGhkoWmc9Po1SNJaAtWWWmn5LIY6etl4=";
   };
   installFilters = [
     "@proompteng/bayn"

--- a/nix/images/signal-publisher.nix
+++ b/nix/images/signal-publisher.nix
@@ -16,8 +16,8 @@ import ./bun-workspace-service.nix {
   serviceName = "signal-publisher";
   packageName = "@proompteng/signal-publisher";
   depsHash = {
-    x86_64-linux = "sha256-sE1/XDxd0wxRPs3KWJMSaBwaz6sK1iyZ0+54//hDfe0=";
-    aarch64-linux = "sha256-4PxjLPmmO+aKtvYrlmd0TTpyNA83VEINgX6R/rh645c=";
+    x86_64-linux = "sha256-mNpd0O8anbQwConzOo62V7zvh38ucqN0JJ9mV4KBS+M=";
+    aarch64-linux = "sha256-Hfow1Chee6xSsHH41a6U4SqwJvXmwNKYB+P3VNDhLjs=";
   };
   installFilters = [
     "@proompteng/signal-publisher"

--- a/services/bayn/package.json
+++ b/services/bayn/package.json
@@ -10,6 +10,7 @@
     "dev": "BAYN_PROVENANCE_MODE=development bun --watch src/index.ts",
     "start": "BAYN_PROVENANCE_MODE=development node dist/index.js",
     "lint": "bunx oxfmt --check src",
+    "lint:effect": "bun node_modules/@effect/tsgo/dist/effect-tsgo.js diagnostics --project tsconfig.json --format text --severity error",
     "lint:oxlint": "oxlint --config ../../.oxlintrc.json .",
     "lint:oxlint:type": "oxlint --config ../../.oxlintrc.json --type-aware --tsconfig ./tsconfig.json .",
     "test": "bun test",
@@ -24,6 +25,7 @@
     "tigerbeetle-node": "0.17.9"
   },
   "devDependencies": {
+    "@effect/tsgo": "0.24.3",
     "@types/bun": "1.3.14",
     "@types/node": "^25.6.0",
     "typescript": "^7.0.2"

--- a/services/bayn/package.json
+++ b/services/bayn/package.json
@@ -10,7 +10,7 @@
     "dev": "BAYN_PROVENANCE_MODE=development bun --watch src/index.ts",
     "start": "BAYN_PROVENANCE_MODE=development node dist/index.js",
     "lint": "bunx oxfmt --check src",
-    "lint:effect": "bun node_modules/@effect/tsgo/dist/effect-tsgo.js diagnostics --project tsconfig.json --format text --severity error",
+    "lint:effect": "find ../../node_modules/.bun -path '*/@effect/tsgo-*/lib/tsc*' -type f ! -name '*.json' -exec chmod +x {} + 2>/dev/null || true; bun node_modules/@effect/tsgo/dist/effect-tsgo.js diagnostics --project tsconfig.json --format text --severity error",
     "lint:oxlint": "oxlint --config ../../.oxlintrc.json .",
     "lint:oxlint:type": "oxlint --config ../../.oxlintrc.json --type-aware --tsconfig ./tsconfig.json .",
     "test": "bun test",

--- a/services/bayn/src/app.test.ts
+++ b/services/bayn/src/app.test.ts
@@ -61,12 +61,7 @@ describe('Bayn application composition', () => {
           observedAt: new Date(yield* Clock.currentTimeMillis).toISOString(),
           outcome: 'NO_PUBLICATION',
         })
-        const fiber = yield* Effect.never.pipe(
-          Effect.onInterrupt(() => Effect.sync(() => void (backgroundInterrupted = true))),
-          Effect.forkScoped({ startImmediately: true }),
-        )
-        yield* Effect.yieldNow
-        return fiber
+        return Effect.never.pipe(Effect.onInterrupt(() => Effect.sync(() => void (backgroundInterrupted = true))))
       })
     const reconciliation = Effect.sync(() => {
       calls.push('reconciliation')
@@ -105,10 +100,10 @@ describe('Bayn application composition', () => {
     let startupQualificationRunId: string | undefined
     let startupStrategyProtocolHash: string | undefined
     const autonomousCycleStartup = ({ qualificationRunId, strategyProtocolHash }: AutonomousCycleStartupInput) =>
-      Effect.gen(function* () {
+      Effect.sync(() => {
         startupQualificationRunId = qualificationRunId
         startupStrategyProtocolHash = strategyProtocolHash
-        return yield* Effect.never.pipe(Effect.forkScoped({ startImmediately: true }))
+        return Effect.never
       })
     const reconciliation = Effect.sync(() => {
       throw new Error('stop after pinned composition proof')

--- a/services/bayn/src/app.ts
+++ b/services/bayn/src/app.ts
@@ -1,4 +1,4 @@
-import { Clock, Effect, Fiber, Layer, Ref, Scope } from 'effect'
+import { Clock, Effect, Fiber, Layer, Ref } from 'effect'
 
 import type { RuntimeConfig } from './config'
 import { makeStrategyProtocolHash } from './contracts'
@@ -21,9 +21,11 @@ export interface AutonomousCycleStartupInput {
   readonly recordPass: RecordAutonomousCyclePass
 }
 
-export type AutonomousCycleStartup = (
+export type AutonomousCycleLoop = Effect.Effect<void>
+
+export type AutonomousCycleStartup<R = never> = (
   input: AutonomousCycleStartupInput,
-) => Effect.Effect<Fiber.Fiber<void, never>, OperationalError, Scope.Scope>
+) => Effect.Effect<AutonomousCycleLoop, OperationalError, R>
 
 const cyclePassError = (observation: Extract<AutonomousCyclePassObservation, { readonly result: 'FAILURE' }>): string =>
   `cycleRunner: ${observation.operation}/${observation.failure}: ${observation.message}`
@@ -64,13 +66,13 @@ const recordAutonomousCyclePass = (
     }
   })
 
-export const run = (
+export const run = <R = never>(
   config: RuntimeConfig,
   strategy: Strategy,
   reconciliation: Effect.Effect<void> = Effect.void,
   broker?: BrokerProbe,
-  autonomousCycleStartup?: AutonomousCycleStartup,
-): Effect.Effect<never, OperationalError, MarketData | Journal | EvidenceStore | CycleObservability> =>
+  autonomousCycleStartup?: AutonomousCycleStartup<R>,
+): Effect.Effect<never, OperationalError, MarketData | Journal | EvidenceStore | CycleObservability | R> =>
   Effect.scoped(
     Effect.gen(function* () {
       const evidenceStore = yield* EvidenceStore
@@ -88,11 +90,12 @@ export const run = (
             ...current,
             autonomousCycleLoop: { ...current.autonomousCycleLoop, startedAt },
           }))
-          autonomousCycleFiber = yield* autonomousCycleStartup({
+          const autonomousCycleLoop = yield* autonomousCycleStartup({
             qualificationRunId: initialized.evidence.evaluation.runId,
             strategyProtocolHash: makeStrategyProtocolHash(strategy.provenance.strategy),
             recordPass: (observation) => recordAutonomousCyclePass(state, observation),
           })
+          autonomousCycleFiber = yield* autonomousCycleLoop.pipe(Effect.forkScoped({ startImmediately: true }))
         }
       }
       yield* monitor(config, state, broker, autonomousCycleFiber).pipe(Effect.forkScoped({ startImmediately: true }))

--- a/services/bayn/src/broker/alpaca-mutations.ts
+++ b/services/bayn/src/broker/alpaca-mutations.ts
@@ -257,11 +257,11 @@ const responseEvidence = (
   observedAt: string,
 ): MutationEvidence => ({ requestId, status, contentHash, observedAt })
 
-const withDeadline = <A>(
+const withDeadline = <A, E>(
   operation: MutationOperation,
   requestHash: string,
   timeoutMs: number,
-  effect: Effect.Effect<A, unknown>,
+  effect: Effect.Effect<A, E>,
 ): Effect.Effect<A, BrokerMutationError> =>
   effect.pipe(
     Effect.timeout(`${timeoutMs} millis`),
@@ -316,8 +316,10 @@ export const makeMutation = (
       Effect.mapError((cause) => configurationError('Alpaca mutation account verification failed', cause)),
     )
 
-    const submit = (input: Intent) =>
-      Effect.gen(function* () {
+    const submit = Effect.fn('BrokerMutation.submit', {
+      attributes: { 'broker.system': 'alpaca', 'broker.operation': MutationOperation.Submit },
+    })(
+      function* (input: Intent) {
         const intent = yield* decodeIntent(input).pipe(
           Effect.mapError((cause) => invalidRequest(MutationOperation.Submit, 'invalid order intent', cause)),
         )
@@ -448,15 +450,14 @@ export const makeMutation = (
             return { requestHash, order, evidence } satisfies SubmitReceipt
           }),
         )
-      }).pipe(
-        Effect.provideService(Headers.CurrentRedactedNames, redactedHeaders),
-        Effect.withSpan('broker.mutation', {
-          attributes: { 'broker.system': 'alpaca', 'broker.operation': MutationOperation.Submit },
-        }),
-      )
+      },
+      (effect) => effect.pipe(Effect.provideService(Headers.CurrentRedactedNames, redactedHeaders)),
+    )
 
-    const cancel = (brokerOrderId: string) =>
-      Effect.gen(function* () {
+    const cancel = Effect.fn('BrokerMutation.cancel', {
+      attributes: { 'broker.system': 'alpaca', 'broker.operation': MutationOperation.Cancel },
+    })(
+      function* (brokerOrderId: string) {
         const orderId = yield* Schema.decodeUnknownEffect(Uuid)(brokerOrderId).pipe(
           Effect.mapError((cause) => invalidRequest(MutationOperation.Cancel, 'invalid Alpaca order ID', cause)),
         )
@@ -517,12 +518,9 @@ export const makeMutation = (
             return { requestHash, brokerOrderId: orderId, evidence } satisfies CancelReceipt
           }),
         )
-      }).pipe(
-        Effect.provideService(Headers.CurrentRedactedNames, redactedHeaders),
-        Effect.withSpan('broker.mutation', {
-          attributes: { 'broker.system': 'alpaca', 'broker.operation': MutationOperation.Cancel },
-        }),
-      )
+      },
+      (effect) => effect.pipe(Effect.provideService(Headers.CurrentRedactedNames, redactedHeaders)),
+    )
 
     return { submit, cancel }
   })

--- a/services/bayn/src/broker/alpaca.ts
+++ b/services/bayn/src/broker/alpaca.ts
@@ -635,7 +635,7 @@ const RuntimeOptionsSchema = Schema.Struct({
   retryAttempts: Schema.Int.check(Schema.isBetween({ minimum: 0, maximum: 3 })),
 })
 
-type Decoder<A> = (input: unknown) => Effect.Effect<A, unknown>
+type Decoder<A> = (input: unknown) => Effect.Effect<A, Schema.SchemaError>
 
 const decodeAccount = Schema.decodeUnknownEffect(AccountResponseSchema, responseParseOptions)
 const decodeAccountConfiguration = Schema.decodeUnknownEffect(AccountConfigurationResponseSchema, responseParseOptions)

--- a/services/bayn/src/cycle-runner.test.ts
+++ b/services/bayn/src/cycle-runner.test.ts
@@ -1272,16 +1272,17 @@ describe('autonomous cycle runner', () => {
     const program = Effect.scoped(
       Effect.gen(function* () {
         yield* TestClock.setTime(Date.parse('2026-01-30T21:20:00.000Z'))
+        const loop = yield* startAutonomousCycleLoop({
+          context: Effect.succeed(context()),
+          observePass: (observation) => Effect.sync(() => observations.push(observation)),
+          pollIntervalMs: 100,
+        })
         const fiber = yield* provide(
-          startAutonomousCycleLoop({
-            context: Effect.succeed(context()),
-            observePass: (observation) => Effect.sync(() => observations.push(observation)),
-            pollIntervalMs: 100,
-          }),
+          loop.pipe(Effect.forkScoped({ startImmediately: true })),
           brokerRead(() => Effect.die(new Error('missing publication must not read the broker'))),
           cycleStore(control),
           marketDataService(Effect.succeed({ outcome: 'MISSING', observedAt: '2026-01-30T21:20:00.000Z' })),
-        )
+        ).pipe(Effect.forkScoped({ startImmediately: true }))
         yield* Effect.yieldNow
         yield* Fiber.interrupt(fiber)
       }),
@@ -1781,16 +1782,17 @@ describe('autonomous cycle runner', () => {
     const program = Effect.scoped(
       Effect.gen(function* () {
         yield* TestClock.setTime(Date.parse('2026-01-30T21:20:00.000Z'))
+        const loop = yield* startAutonomousCycleLoop({
+          context: Effect.succeed(context()),
+          observePass: (observation) => Effect.sync(() => observations.push(observation)),
+          pollIntervalMs: 100,
+        })
         const fiber = yield* provide(
-          startAutonomousCycleLoop({
-            context: Effect.succeed(context()),
-            observePass: (observation) => Effect.sync(() => observations.push(observation)),
-            pollIntervalMs: 100,
-          }),
+          loop.pipe(Effect.forkScoped({ startImmediately: true })),
           read,
           store,
           marketDataService(Effect.succeed(finalizedPublication()), finalizedPublicationInspection()),
-        )
+        ).pipe(Effect.forkScoped({ startImmediately: true }))
         yield* Effect.yieldNow
         expect(control.acquisitions).toHaveLength(1)
         yield* TestClock.adjust(99)
@@ -1840,16 +1842,17 @@ describe('autonomous cycle runner', () => {
     await Effect.runPromise(
       Effect.scoped(
         Effect.gen(function* () {
+          const loop = yield* startAutonomousCycleLoop({
+            context: Effect.succeed(context()),
+            observePass: ignorePass,
+            pollIntervalMs: 100,
+          })
           yield* provide(
-            startAutonomousCycleLoop({
-              context: Effect.succeed(context()),
-              observePass: ignorePass,
-              pollIntervalMs: 100,
-            }),
+            loop,
             brokerRead(() => Effect.die(new Error('in-flight publication read must not reach the broker'))),
             cycleStore(control),
             marketDataService(latest),
-          )
+          ).pipe(Effect.forkScoped({ startImmediately: true }))
           yield* Deferred.await(started)
         }),
       ),
@@ -1871,12 +1874,13 @@ describe('autonomous cycle runner', () => {
     const program = Effect.scoped(
       Effect.gen(function* () {
         yield* TestClock.setTime(Date.parse('2026-01-30T21:20:00.000Z'))
+        const loop = yield* startAutonomousCycleLoop({
+          context: Effect.succeed(context()),
+          observePass: (observation) => Effect.sync(() => observations.push(observation)),
+          pollIntervalMs: 100,
+        })
         const fiber = yield* provide(
-          startAutonomousCycleLoop({
-            context: Effect.succeed(context()),
-            observePass: (observation) => Effect.sync(() => observations.push(observation)),
-            pollIntervalMs: 100,
-          }),
+          loop.pipe(Effect.forkScoped({ startImmediately: true })),
           brokerRead(() => Effect.die(new Error('empty FINALIZED discovery must not read the broker'))),
           cycleStore(control),
           marketDataService(discovery),
@@ -1943,12 +1947,13 @@ describe('autonomous cycle runner', () => {
     const program = Effect.scoped(
       Effect.gen(function* () {
         yield* TestClock.setTime(Date.parse('2026-01-30T21:20:00.000Z'))
+        const loop = yield* startAutonomousCycleLoop({
+          context: Effect.succeed(context()),
+          observePass: (observation) => Effect.sync(() => observations.push(observation)),
+          pollIntervalMs: 100,
+        })
         const fiber = yield* provide(
-          startAutonomousCycleLoop({
-            context: Effect.succeed(context()),
-            observePass: (observation) => Effect.sync(() => observations.push(observation)),
-            pollIntervalMs: 100,
-          }),
+          loop.pipe(Effect.forkScoped({ startImmediately: true })),
           read,
           store,
           marketDataService(discovery),
@@ -2023,12 +2028,13 @@ describe('autonomous cycle runner', () => {
     const program = Effect.scoped(
       Effect.gen(function* () {
         yield* TestClock.setTime(Date.parse(active.window.submissionOpenAt))
+        const loop = yield* startAutonomousCycleLoop({
+          context: Effect.succeed(context(undefined, buildDecision)),
+          observePass: (observation) => Effect.sync(() => observations.push(observation)),
+          pollIntervalMs: 100,
+        })
         const fiber = yield* provide(
-          startAutonomousCycleLoop({
-            context: Effect.succeed(context(undefined, buildDecision)),
-            observePass: (observation) => Effect.sync(() => observations.push(observation)),
-            pollIntervalMs: 100,
-          }),
+          loop.pipe(Effect.forkScoped({ startImmediately: true })),
           brokerRead(() => Effect.die({ _tag: 'UnexpectedDecisionBuildBrokerRead' })),
           store,
           marketDataService(Effect.die({ _tag: 'UnexpectedDecisionBuildMarketDataRead' })),
@@ -2074,19 +2080,20 @@ describe('autonomous cycle runner', () => {
     const program = Effect.scoped(
       Effect.gen(function* () {
         yield* TestClock.setTime(Date.parse('2026-01-30T21:20:00.000Z'))
-        const fiber = yield* provide(
-          startAutonomousCycleLoop({
-            context: Effect.suspend(() => {
-              contextLoads += 1
-              return contextLoads === 1 ? Effect.fail(contextFailure) : Effect.succeed(context())
-            }),
-            observePass: (observation) => Effect.sync(() => observations.push(observation)),
-            pollIntervalMs: 100,
+        const loop = yield* startAutonomousCycleLoop({
+          context: Effect.suspend(() => {
+            contextLoads += 1
+            return contextLoads === 1 ? Effect.fail(contextFailure) : Effect.succeed(context())
           }),
+          observePass: (observation) => Effect.sync(() => observations.push(observation)),
+          pollIntervalMs: 100,
+        })
+        const fiber = yield* provide(
+          loop,
           brokerRead(() => Effect.succeed({ value: monthEndCalendar, evidence })),
           cycleStore(control),
           marketDataService(Effect.succeed(finalizedPublication())),
-        )
+        ).pipe(Effect.forkScoped({ startImmediately: true }))
         yield* Effect.yieldNow
         expect(contextLoads).toBe(1)
         expect(control.acquisitions).toEqual([])
@@ -2133,16 +2140,17 @@ describe('autonomous cycle runner', () => {
     const exit = await Effect.runPromise(
       Effect.scoped(
         Effect.gen(function* () {
+          const loop = yield* startAutonomousCycleLoop({
+            context: Effect.die(defect),
+            observePass: (observation) => Effect.sync(() => observations.push(observation)),
+            pollIntervalMs: 100,
+          })
           const fiber = yield* provide(
-            startAutonomousCycleLoop({
-              context: Effect.die(defect),
-              observePass: (observation) => Effect.sync(() => observations.push(observation)),
-              pollIntervalMs: 100,
-            }),
+            loop,
             brokerRead(() => Effect.die(new Error('defective context must not read the broker'))),
             cycleStore(control),
             marketDataService(Effect.die(new Error('defective context must not inspect publications'))),
-          )
+          ).pipe(Effect.forkScoped({ startImmediately: true }))
           return yield* Fiber.await(fiber)
         }),
       ),
@@ -2160,16 +2168,17 @@ describe('autonomous cycle runner', () => {
     await Effect.runPromise(
       Effect.scoped(
         Effect.gen(function* () {
+          const loop = yield* startAutonomousCycleLoop({
+            context: Effect.fail(contextFailure),
+            observePass: ignorePass,
+            pollIntervalMs: 100,
+          })
           const fiber = yield* provide(
-            startAutonomousCycleLoop({
-              context: Effect.fail(contextFailure),
-              observePass: ignorePass,
-              pollIntervalMs: 100,
-            }),
+            loop,
             brokerRead(() => Effect.die(new Error('failed context must not read the broker'))),
             cycleStore(control),
             marketDataService(Effect.die(new Error('failed context must not inspect finalized publications'))),
-          )
+          ).pipe(Effect.forkScoped({ startImmediately: true }))
           yield* Effect.yieldNow
           return yield* Fiber.interrupt(fiber)
         }),
@@ -2184,16 +2193,11 @@ describe('autonomous cycle runner', () => {
       const failure = await Effect.runPromise(
         Effect.flip(
           Effect.scoped(
-            provide(
-              startAutonomousCycleLoop({
-                context: Effect.succeed(context()),
-                observePass: ignorePass,
-                pollIntervalMs,
-              }),
-              brokerRead(() => Effect.die(new Error('invalid config must not read the broker'))),
-              cycleStore(control),
-              marketDataService(Effect.die(new Error('invalid config must not inspect publications'))),
-            ),
+            startAutonomousCycleLoop({
+              context: Effect.succeed(context()),
+              observePass: ignorePass,
+              pollIntervalMs,
+            }),
           ),
         ),
       )

--- a/services/bayn/src/cycle-runner.ts
+++ b/services/bayn/src/cycle-runner.ts
@@ -1,4 +1,4 @@
-import { Clock, Data, Duration, Effect, Fiber, Option, Result, Schedule, Scope } from 'effect'
+import { Clock, Data, Duration, Effect, Option, Result, Schedule } from 'effect'
 
 import {
   BrokerRead,
@@ -1157,35 +1157,32 @@ const observationTime = Clock.currentTimeMillis.pipe(Effect.map((millis) => new 
 
 export const startAutonomousCycleLoop = <E, R>(
   options: AutonomousCycleLoopOptions<E, R>,
-): Effect.Effect<
-  Fiber.Fiber<void, never>,
-  CycleRunnerError,
-  BrokerRead | CycleStore | MarketData | R | Scope.Scope
-> => {
+): Effect.Effect<Effect.Effect<void, never, BrokerRead | CycleStore | MarketData | R>, CycleRunnerError> => {
   if (!Number.isSafeInteger(options.pollIntervalMs) || options.pollIntervalMs <= 0) {
     return Effect.fail(
       runnerError('configure', 'invalid-config', 'cycle loop interval must be a positive safe integer'),
     )
   }
-  return runLoopPass(options.context).pipe(
-    Effect.flatMap((result) =>
-      observationTime.pipe(
-        Effect.flatMap((observedAt) => {
-          const observation: CyclePassObservation = { outcome: 'SUCCEEDED', observedAt, result }
-          return options.observePass(observation).pipe(Effect.andThen(logCyclePass(observation)))
-        }),
+  return Effect.succeed(
+    runLoopPass(options.context).pipe(
+      Effect.flatMap((result) =>
+        observationTime.pipe(
+          Effect.flatMap((observedAt) => {
+            const observation: CyclePassObservation = { outcome: 'SUCCEEDED', observedAt, result }
+            return options.observePass(observation).pipe(Effect.andThen(logCyclePass(observation)))
+          }),
+        ),
       ),
-    ),
-    Effect.catch((error) =>
-      observationTime.pipe(
-        Effect.flatMap((observedAt) => {
-          const observation: CyclePassObservation = { outcome: 'FAILED', observedAt, error }
-          return options.observePass(observation).pipe(Effect.andThen(logCyclePass(observation)))
-        }),
+      Effect.catch((error) =>
+        observationTime.pipe(
+          Effect.flatMap((observedAt) => {
+            const observation: CyclePassObservation = { outcome: 'FAILED', observedAt, error }
+            return options.observePass(observation).pipe(Effect.andThen(logCyclePass(observation)))
+          }),
+        ),
       ),
+      Effect.repeat(Schedule.spaced(Duration.millis(options.pollIntervalMs))),
+      Effect.asVoid,
     ),
-    Effect.repeat(Schedule.spaced(Duration.millis(options.pollIntervalMs))),
-    Effect.asVoid,
-    Effect.forkScoped({ startImmediately: true }),
   )
 }

--- a/services/bayn/src/db/cycle-store.ts
+++ b/services/bayn/src/db/cycle-store.ts
@@ -1,6 +1,6 @@
 import { PgClient } from '@effect/sql-pg'
 import { Context, Data, Effect, Layer, Option, Schema } from 'effect'
-import { isSqlError } from 'effect/unstable/sql/SqlError'
+import { isSqlError, type SqlError } from 'effect/unstable/sql/SqlError'
 
 import {
   CycleDraftSchema,
@@ -28,6 +28,8 @@ import { ObserveShadowDecisionDocumentSchema, type ObserveShadowDecisionDocument
 import { TargetPlanStatus } from '../target-planner'
 import type { InputManifest, IsoDate } from '../types'
 import { ensureSnapshotReference } from './snapshot-reference'
+
+type CycleStoreInternalError = CycleStoreError | Schema.SchemaError | SqlError
 
 export interface CycleAcquireReceipt {
   readonly cycle: AutonomousCycle
@@ -289,7 +291,7 @@ const selectCycle = (
   sql: PgClient.PgClient,
   cycleId: string,
   locked: boolean,
-): Effect.Effect<readonly AutonomousCycle[], unknown> => {
+): Effect.Effect<readonly AutonomousCycle[], SqlError | Schema.SchemaError> => {
   const rows = locked
     ? sql<Record<string, unknown>>`
         SELECT
@@ -330,7 +332,7 @@ const selectCycle = (
 const selectCycleByAuthoritySlot = (
   sql: PgClient.PgClient,
   slot: CycleAuthoritySlot,
-): Effect.Effect<readonly AutonomousCycle[], unknown> =>
+): Effect.Effect<readonly AutonomousCycle[], SqlError | Schema.SchemaError> =>
   sql<Record<string, unknown>>`
     SELECT
       cycle_id, schema_version, identity_schema_version, strategy_name,
@@ -353,7 +355,7 @@ const selectCycleByAuthoritySlot = (
 const selectDecisionDocument = (
   sql: PgClient.PgClient,
   cycleId: string,
-): Effect.Effect<readonly { readonly document: ObserveShadowDecisionDocument }[], unknown> =>
+): Effect.Effect<readonly { readonly document: ObserveShadowDecisionDocument }[], SqlError | Schema.SchemaError> =>
   sql<Record<string, unknown>>`
     SELECT document
     FROM autonomous_cycle_shadow_decisions
@@ -363,7 +365,7 @@ const selectDecisionDocument = (
 const selectOldestUnfinishedCycle = (
   sql: PgClient.PgClient,
   scope: CycleRecoveryScope,
-): Effect.Effect<readonly AutonomousCycle[], unknown> =>
+): Effect.Effect<readonly AutonomousCycle[], SqlError | Schema.SchemaError> =>
   sql<Record<string, unknown>>`
     SELECT
       cycle_id, schema_version, identity_schema_version, strategy_name,
@@ -427,7 +429,9 @@ const makeCycleStore = Effect.gen(function* () {
       ),
     )
 
-  const decisionEvidenceMatches = (document: ObserveShadowDecisionDocument): Effect.Effect<boolean, unknown> =>
+  const decisionEvidenceMatches = (
+    document: ObserveShadowDecisionDocument,
+  ): Effect.Effect<boolean, SqlError | Schema.SchemaError> =>
     sql<Record<string, unknown>>`
       SELECT EXISTS (
         SELECT 1
@@ -452,7 +456,7 @@ const makeCycleStore = Effect.gen(function* () {
   const verifyDecisionBoundBlock = (
     cycle: AutonomousCycle,
     reason: CycleTerminalReason,
-  ): Effect.Effect<void, unknown> =>
+  ): Effect.Effect<void, CycleStoreInternalError> =>
     Effect.gen(function* () {
       const storedRows = yield* selectDecisionDocument(sql, cycle.identity.cycleId)
       const storedDocument = storedRows[0]?.document
@@ -479,7 +483,7 @@ const makeCycleStore = Effect.gen(function* () {
     cycle: AutonomousCycle,
     reason: CycleTerminalReason,
     observedAt: string,
-  ): Effect.Effect<CycleMutationReceipt, unknown> => {
+  ): Effect.Effect<CycleMutationReceipt, CycleStoreInternalError> => {
     if (cycle.state === CycleState.Blocked && cycle.terminalReason === reason) {
       return Effect.succeed({ cycle, changed: false })
     }
@@ -660,7 +664,7 @@ const makeCycleStore = Effect.gen(function* () {
       ),
     )
 
-  const persistSnapshotReference = (inputManifest: InputManifest): Effect.Effect<void, unknown> =>
+  const persistSnapshotReference = (inputManifest: InputManifest): Effect.Effect<void, CycleStoreInternalError> =>
     ensureSnapshotReference(sql, inputManifest).pipe(
       Effect.flatMap((matches) =>
         matches

--- a/services/bayn/src/db/evidence-store.ts
+++ b/services/bayn/src/db/evidence-store.ts
@@ -1801,5 +1801,8 @@ export const makeEvidenceStoreLayer = <RMigration, RStore>(
     }),
   )
 
+export const EvidenceStoreFromPostgres = (config: Pick<RuntimeConfig, 'operationTimeoutMs'>) =>
+  makeEvidenceStoreLayer(config, migrations, makeEvidenceStore)
+
 export const EvidenceStoreLive = (config: RuntimeConfig) =>
-  makeEvidenceStoreLayer(config, migrations, makeEvidenceStore).pipe(Layer.provideMerge(PostgresClientLive(config)))
+  EvidenceStoreFromPostgres(config).pipe(Layer.provideMerge(PostgresClientLive(config)))

--- a/services/bayn/src/db/paper-store.ts
+++ b/services/bayn/src/db/paper-store.ts
@@ -56,6 +56,7 @@ import {
 } from './accounting-rows'
 import {
   makeReconciliation,
+  ReconciliationStoreError,
   restrictAuthority,
   type BrokerSnapshot,
   type IntentBinding,
@@ -332,11 +333,29 @@ const run = <A, E, R>(
   effect: Effect.Effect<A, E, R>,
 ): Effect.Effect<A, PaperStoreError, R> =>
   effect.pipe(
-    Effect.mapError((cause) =>
-      cause instanceof PaperStoreError
-        ? cause
-        : error(operation, Schema.isSchemaError(cause) ? 'decode' : 'query', 'paper evidence operation failed', cause),
-    ),
+    Effect.mapError((cause) => {
+      if (cause instanceof PaperStoreError) return cause
+      if (cause instanceof ReconciliationStoreError) {
+        return error(
+          operation,
+          cause.failure === 'ledger'
+            ? 'ledger'
+            : cause.failure === 'decode'
+              ? 'decode'
+              : cause.failure === 'invariant'
+                ? 'invariant'
+                : 'query',
+          'paper reconciliation operation failed',
+          cause,
+        )
+      }
+      return error(
+        operation,
+        Schema.isSchemaError(cause) ? 'decode' : 'query',
+        'paper evidence operation failed',
+        cause,
+      )
+    }),
   )
 
 const fail = (

--- a/services/bayn/src/db/reconciliation.ts
+++ b/services/bayn/src/db/reconciliation.ts
@@ -1,5 +1,5 @@
 import { PgClient } from '@effect/sql-pg'
-import { Effect, Schema } from 'effect'
+import { Data, Effect, Schema } from 'effect'
 
 import { rebuildAccountingLedger, type AccountingTransaction } from '../accounting'
 import { MutationOperation } from '../broker/alpaca-mutations'
@@ -78,6 +78,13 @@ export interface ReconciliationWriteResult extends ReconciliationReport {
   readonly riskContext: ReconciliationRiskContext
 }
 
+export class ReconciliationStoreError extends Data.TaggedError('ReconciliationStoreError')<{
+  readonly operation: 'bindings' | 'reconcile' | 'restrict-authority' | 'risk-context'
+  readonly failure: 'decode' | 'invariant' | 'ledger' | 'query'
+  readonly message: string
+  readonly cause?: unknown
+}> {}
+
 const IntentBindingRow = Schema.Struct({ intent_id: Sha256, client_order_id: NonEmptyString })
 const IntentRow = Schema.Struct({
   intent_id: Sha256,
@@ -141,13 +148,42 @@ const decodeContent = Schema.decodeUnknownEffect(ReconciliationContentRow, stric
 const decodeRiskContext = Schema.decodeUnknownEffect(ReconciliationRiskContextRow, strictParseOptions)
 const encodeDiscrepancies = Schema.encodeSync(Schema.fromJsonString(Schema.Array(DiscrepancySchema)))
 
-const attempt = <A>(evaluate: () => A): Effect.Effect<A, unknown> =>
-  Effect.try({ try: evaluate, catch: (cause) => cause })
+const storeError = (
+  operation: ReconciliationStoreError['operation'],
+  failure: ReconciliationStoreError['failure'],
+  message: string,
+  cause?: unknown,
+): ReconciliationStoreError => new ReconciliationStoreError({ operation, failure, message, cause })
+
+const runStore = <A, E, R>(
+  operation: ReconciliationStoreError['operation'],
+  effect: Effect.Effect<A, E, R>,
+): Effect.Effect<A, ReconciliationStoreError, R> =>
+  effect.pipe(
+    Effect.mapError((cause) => {
+      if (cause instanceof ReconciliationStoreError) return cause
+      return storeError(
+        operation,
+        Schema.isSchemaError(cause) ? 'decode' : 'query',
+        `paper reconciliation ${operation} failed`,
+        cause,
+      )
+    }),
+  )
+
+const attempt = <A>(
+  operation: ReconciliationStoreError['operation'],
+  evaluate: () => A,
+): Effect.Effect<A, ReconciliationStoreError> =>
+  Effect.try({
+    try: evaluate,
+    catch: (cause) => storeError(operation, 'invariant', `paper reconciliation ${operation} invariant failed`, cause),
+  })
 
 const riskContextFromRow = (
   row: (typeof ReconciliationRiskContextRow.Type)[0],
   unknownMutationCount: number,
-): Effect.Effect<ReconciliationRiskContext, unknown> =>
+): Effect.Effect<ReconciliationRiskContext, ReconciliationStoreError> =>
   Effect.gen(function* () {
     const requiredAuthority = [
       row.authority_schema_version,
@@ -160,13 +196,15 @@ const riskContextFromRow = (
     ]
     const authorityMissing = requiredAuthority.every((value) => value === null)
     if (authorityMissing && (row.authority_reason !== null || row.authority_observed_at !== null)) {
-      return yield* Effect.fail(new Error('authority evidence exists without durable authority state'))
+      return yield* Effect.fail(
+        storeError('risk-context', 'invariant', 'authority evidence exists without durable authority state'),
+      )
     }
     if (
       !authorityMissing &&
       (requiredAuthority.some((value) => value === null) || row.authority_observed_at === null)
     ) {
-      return yield* Effect.fail(new Error('durable authority state is incomplete'))
+      return yield* Effect.fail(storeError('risk-context', 'invariant', 'durable authority state is incomplete'))
     }
 
     const authority = authorityMissing
@@ -174,7 +212,9 @@ const riskContextFromRow = (
       : yield* Effect.gen(function* () {
           const version = Number(row.authority_version)
           if (!Number.isSafeInteger(version) || version <= 0) {
-            return yield* Effect.fail(new Error('durable authority version is not a safe positive integer'))
+            return yield* Effect.fail(
+              storeError('risk-context', 'invariant', 'durable authority version is not a safe positive integer'),
+            )
           }
           return yield* decodeAuthorityState({
             schemaVersion: row.authority_schema_version,
@@ -185,7 +225,11 @@ const riskContextFromRow = (
             ...(row.authority_reason === null ? {} : { reason: row.authority_reason }),
             version,
             updatedAt: row.authority_updated_at?.toISOString(),
-          })
+          }).pipe(
+            Effect.mapError((cause) =>
+              storeError('risk-context', 'decode', 'durable authority state failed decoding', cause),
+            ),
+          )
         })
 
     const material = {
@@ -198,11 +242,15 @@ const riskContextFromRow = (
     if (authority === null) return { ...material, authority: null, authorityObservedAt: null }
     const authorityObservedAt = row.authority_observed_at
     if (authorityObservedAt === null) {
-      return yield* Effect.fail(new Error('durable authority observation time is missing'))
+      return yield* Effect.fail(
+        storeError('risk-context', 'invariant', 'durable authority observation time is missing'),
+      )
     }
     const authorityObservedAtIso = authorityObservedAt.toISOString()
     if (authority.updatedAt > authorityObservedAtIso) {
-      return yield* Effect.fail(new Error('durable authority update follows its observation time'))
+      return yield* Effect.fail(
+        storeError('risk-context', 'invariant', 'durable authority update follows its observation time'),
+      )
     }
     return { ...material, authority, authorityObservedAt: authorityObservedAtIso }
   })
@@ -258,42 +306,50 @@ export const restrictAuthority = (
   sql: PgClient.PgClient,
   reason: string,
   updatedAt: string,
-): Effect.Effect<void, unknown> =>
-  sql`
-    UPDATE authority_state
-    SET
-      effective = 'OBSERVE',
-      kill_state = 'ACTIVE',
-      reason = ${reason},
-      version = version + 1,
-      updated_at = ${updatedAt}
-    WHERE singleton
-      AND (effective <> 'OBSERVE' OR kill_state <> 'ACTIVE')
-  `.pipe(Effect.asVoid)
+): Effect.Effect<void, ReconciliationStoreError> =>
+  runStore(
+    'restrict-authority',
+    sql`
+      UPDATE authority_state
+      SET
+        effective = 'OBSERVE',
+        kill_state = 'ACTIVE',
+        reason = ${reason},
+        version = version + 1,
+        updated_at = ${updatedAt}
+      WHERE singleton
+        AND (effective <> 'OBSERVE' OR kill_state <> 'ACTIVE')
+    `.pipe(Effect.asVoid),
+  )
 
 export const makeReconciliation = (
   sql: PgClient.PgClient,
   journal: JournalService,
   config: Pick<RuntimeConfig, 'tigerBeetle'>,
 ) => {
-  const bindings = (accountId: string): Effect.Effect<readonly IntentBinding[], unknown> =>
-    sql<Record<string, unknown>>`
-      SELECT intent_id, client_order_id
-      FROM intents
-      WHERE account_id = ${accountId}
-      ORDER BY client_order_id
-    `.pipe(
-      Effect.flatMap(decodeBindings),
-      Effect.map((rows) => rows.map((row) => ({ intentId: row.intent_id, clientOrderId: row.client_order_id }))),
+  const bindings = (accountId: string): Effect.Effect<readonly IntentBinding[], ReconciliationStoreError> =>
+    runStore(
+      'bindings',
+      sql<Record<string, unknown>>`
+        SELECT intent_id, client_order_id
+        FROM intents
+        WHERE account_id = ${accountId}
+        ORDER BY client_order_id
+      `.pipe(
+        Effect.flatMap(decodeBindings),
+        Effect.map((rows) => rows.map((row) => ({ intentId: row.intent_id, clientOrderId: row.client_order_id }))),
+      ),
     )
 
-  const reconcile = (snapshot: BrokerSnapshot): Effect.Effect<ReconciliationWriteResult, unknown> =>
-    sql.withTransaction(
-      Effect.gen(function* () {
-        const accountId = snapshot.account.accountId
-        yield* sql`SELECT pg_advisory_xact_lock(hashtextextended(${`ALPACA:${accountId}`}, 0))`
+  const reconcile = (snapshot: BrokerSnapshot): Effect.Effect<ReconciliationWriteResult, ReconciliationStoreError> =>
+    runStore(
+      'reconcile',
+      sql.withTransaction(
+        Effect.gen(function* () {
+          const accountId = snapshot.account.accountId
+          yield* sql`SELECT pg_advisory_xact_lock(hashtextextended(${`ALPACA:${accountId}`}, 0))`
 
-        const intentRows = yield* sql<Record<string, unknown>>`
+          const intentRows = yield* sql<Record<string, unknown>>`
           SELECT
             intent.intent_id,
             intent.client_order_id,
@@ -330,30 +386,30 @@ export const makeReconciliation = (
           WHERE intent.account_id = ${accountId}
           ORDER BY intent.client_order_id
         `.pipe(Effect.flatMap(decodeIntents))
-        const intents: IntentExpectation[] = intentRows.map((row) => ({
-          intentId: row.intent_id,
-          clientOrderId: row.client_order_id,
-          symbol: row.symbol,
-          side: row.side,
-          orderType: row.order_type,
-          timeInForce: row.time_in_force,
-          quantityMicros: row.quantity_micros,
-          state: row.state,
-          ...(row.terminal_outcome === null ? {} : { terminalOutcome: row.terminal_outcome }),
-          expectsBrokerOrder: row.broker_order_id !== null,
-          ...(row.broker_order_id === null ? {} : { brokerOrderId: row.broker_order_id }),
-          ...(row.mutation_event_type !== null &&
-          (unresolvedEvents.has(row.mutation_event_type) ||
-            (row.mutation_operation === MutationOperation.Cancel &&
-              row.mutation_event_type === MutationEventType.RecoveryFound &&
-              row.state !== IntentState.Terminal)) &&
-          row.mutation_occurred_at !== null
-            ? { unknownSince: row.mutation_occurred_at }
-            : {}),
-        }))
-        const unknownMutationCount = intents.filter((intent) => intent.unknownSince !== undefined).length
+          const intents: IntentExpectation[] = intentRows.map((row) => ({
+            intentId: row.intent_id,
+            clientOrderId: row.client_order_id,
+            symbol: row.symbol,
+            side: row.side,
+            orderType: row.order_type,
+            timeInForce: row.time_in_force,
+            quantityMicros: row.quantity_micros,
+            state: row.state,
+            ...(row.terminal_outcome === null ? {} : { terminalOutcome: row.terminal_outcome }),
+            expectsBrokerOrder: row.broker_order_id !== null,
+            ...(row.broker_order_id === null ? {} : { brokerOrderId: row.broker_order_id }),
+            ...(row.mutation_event_type !== null &&
+            (unresolvedEvents.has(row.mutation_event_type) ||
+              (row.mutation_operation === MutationOperation.Cancel &&
+                row.mutation_event_type === MutationEventType.RecoveryFound &&
+                row.state !== IntentState.Terminal)) &&
+            row.mutation_occurred_at !== null
+              ? { unknownSince: row.mutation_occurred_at }
+              : {}),
+          }))
+          const unknownMutationCount = intents.filter((intent) => intent.unknownSince !== undefined).length
 
-        const transactionRows = yield* sql<Record<string, unknown>>`
+          const transactionRows = yield* sql<Record<string, unknown>>`
           SELECT
             schema_version, transaction_id, broker_event_id, intent_id, account_id, symbol, side,
             quantity_micros::text AS quantity_micros, price_micros::text AS price_micros,
@@ -366,8 +422,8 @@ export const makeReconciliation = (
           WHERE account_id = ${accountId}
           ORDER BY occurred_at, transaction_id
         `.pipe(Effect.flatMap(decodeTransactions))
-        const transactions = transactionRows.map(accountingTransactionFromRow)
-        const receiptRows = yield* sql<Record<string, unknown>>`
+          const transactions = yield* attempt('reconcile', () => transactionRows.map(accountingTransactionFromRow))
+          const receiptRows = yield* sql<Record<string, unknown>>`
           SELECT
             schema_version, receipt_id, intent_id, broker_event_id,
             tigerbeetle_cluster_id::text AS tigerbeetle_cluster_id,
@@ -384,26 +440,37 @@ export const makeReconciliation = (
           WHERE broker_event_id IN (SELECT broker_event_id FROM accounting_transactions WHERE account_id = ${accountId})
           ORDER BY broker_event_id
         `.pipe(Effect.flatMap(decodeReceipts))
-        const receipts = yield* Effect.forEach(receiptRows, (row) =>
-          decodeAccountingReceipt(accountingReceiptFromRow(row)),
-        )
-        const { exactReceipts, plans } = yield* attempt(() => {
-          const receiptsByEvent = new Map(receipts.map((receipt) => [receipt.brokerEventId, receipt]))
-          if (receiptsByEvent.size !== receipts.length) throw new Error('duplicate accounting receipt broker event')
-          const plans = transactions.map((transaction) =>
-            rebuildAccountingLedger(transaction, config.tigerBeetle.ledger),
+          const receipts = yield* Effect.forEach(receiptRows, (row) =>
+            decodeAccountingReceipt(accountingReceiptFromRow(row)),
           )
-          const exactReceipts = new Map(
-            transactions.map((transaction, index) => [
-              transaction.brokerEventId,
-              receiptIsExact(transaction, receiptsByEvent.get(transaction.brokerEventId), plans[index], config),
-            ]),
-          )
-          return { exactReceipts, plans }
-        })
-        const ledgerExact = yield* journal.verifyAccount(accountId, plans)
+          const { exactReceipts, plans } = yield* attempt('reconcile', () => {
+            const receiptsByEvent = new Map(receipts.map((receipt) => [receipt.brokerEventId, receipt]))
+            if (receiptsByEvent.size !== receipts.length) throw new Error('duplicate accounting receipt broker event')
+            const plans = transactions.map((transaction) =>
+              rebuildAccountingLedger(transaction, config.tigerBeetle.ledger),
+            )
+            const exactReceipts = new Map(
+              transactions.map((transaction, index) => [
+                transaction.brokerEventId,
+                receiptIsExact(transaction, receiptsByEvent.get(transaction.brokerEventId), plans[index], config),
+              ]),
+            )
+            return { exactReceipts, plans }
+          })
+          const ledgerExact = yield* journal
+            .verifyAccount(accountId, plans)
+            .pipe(
+              Effect.mapError((cause) =>
+                storeError(
+                  'reconcile',
+                  'ledger',
+                  'TigerBeetle account verification failed during reconciliation',
+                  cause,
+                ),
+              ),
+            )
 
-        const durableFillRows = yield* sql<Record<string, unknown>>`
+          const durableFillRows = yield* sql<Record<string, unknown>>`
           SELECT
             fill.fill_id,
             fill.broker_order_id,
@@ -416,14 +483,14 @@ export const makeReconciliation = (
           WHERE fill.account_id = ${accountId}
           ORDER BY fill.fill_id
         `.pipe(Effect.flatMap(decodeDurableFills))
-        const durableFills = durableFillRows.map((row) => ({
-          fillId: row.fill_id,
-          brokerOrderId: row.broker_order_id,
-          accounted:
-            row.transaction_id !== null && row.receipt_id !== null && exactReceipts.get(row.broker_event_id) === true,
-        }))
+          const durableFills = durableFillRows.map((row) => ({
+            fillId: row.fill_id,
+            brokerOrderId: row.broker_order_id,
+            accounted:
+              row.transaction_id !== null && row.receipt_id !== null && exactReceipts.get(row.broker_event_id) === true,
+          }))
 
-        const projectedPositionRows = yield* sql<Record<string, unknown>>`
+          const projectedPositionRows = yield* sql<Record<string, unknown>>`
           SELECT
             symbol,
             sum(quantity_delta_micros)::text AS quantity_micros,
@@ -434,13 +501,13 @@ export const makeReconciliation = (
           HAVING sum(quantity_delta_micros) <> 0
           ORDER BY symbol
         `.pipe(Effect.flatMap(decodeProjectedPositions))
-        const projectedPositions = projectedPositionRows.map((row) => ({
-          symbol: row.symbol,
-          quantityMicros: row.quantity_micros,
-          costBasisMicros: row.cost_basis_micros,
-        }))
+          const projectedPositions = projectedPositionRows.map((row) => ({
+            symbol: row.symbol,
+            quantityMicros: row.quantity_micros,
+            costBasisMicros: row.cost_basis_micros,
+          }))
 
-        const [openingCash] = yield* sql<Record<string, unknown>>`
+          const [openingCash] = yield* sql<Record<string, unknown>>`
           SELECT
             snapshot.cash_micros::text AS cash_micros,
             to_char(event.observed_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') AS observed_at
@@ -450,117 +517,128 @@ export const makeReconciliation = (
           ORDER BY event.source_sequence
           LIMIT 1
         `.pipe(Effect.flatMap(decodeOpeningCash))
-        const { accountingHash, comparison } = yield* attempt(() => {
-          if (transactions.some((transaction) => transaction.occurredAt < openingCash.observed_at)) {
-            throw new Error('paper accounting predates the opening cash snapshot')
-          }
-          const expectedCashMicros = transactions
-            .reduce((cash, transaction) => cash + BigInt(transaction.cashDeltaMicros), BigInt(openingCash.cash_micros))
-            .toString()
-          const accountingHash = canonicalHashV1({
-            schemaVersion: 'bayn.paper-accounting-state.v1',
-            accountId,
-            openingCash,
-            transactions,
-            receipts,
-            ledgerExact,
-          })
-          const stateHash = reconciledStateHash({
-            account: snapshot.account,
-            positions: snapshot.positions,
-            positionsObservedAt: snapshot.positionsObservedAt,
-            orders: snapshot.orders,
-            ordersObservedAt: snapshot.ordersObservedAt,
-            accountingHash,
-          })
-          return {
-            accountingHash,
-            comparison: compareReconciliation({
+          const { accountingHash, comparison } = yield* attempt('reconcile', () => {
+            if (transactions.some((transaction) => transaction.occurredAt < openingCash.observed_at)) {
+              throw new Error('paper accounting predates the opening cash snapshot')
+            }
+            const expectedCashMicros = transactions
+              .reduce(
+                (cash, transaction) => cash + BigInt(transaction.cashDeltaMicros),
+                BigInt(openingCash.cash_micros),
+              )
+              .toString()
+            const accountingHash = canonicalHashV1({
+              schemaVersion: 'bayn.paper-accounting-state.v1',
               accountId,
-              stateHash,
+              openingCash,
+              transactions,
+              receipts,
+              ledgerExact,
+            })
+            const stateHash = reconciledStateHash({
               account: snapshot.account,
               positions: snapshot.positions,
+              positionsObservedAt: snapshot.positionsObservedAt,
               orders: snapshot.orders,
-              fills: snapshot.fills,
-              intents,
-              durableFills,
-              projectedPositions,
-              expectedCashMicros,
-              valuation: snapshot.valuation,
+              ordersObservedAt: snapshot.ordersObservedAt,
               accountingHash,
-              ledgerExact,
-              reconciledAt: snapshot.reconciledAt,
-            }),
-          }
-        })
+            })
+            return {
+              accountingHash,
+              comparison: compareReconciliation({
+                accountId,
+                stateHash,
+                account: snapshot.account,
+                positions: snapshot.positions,
+                orders: snapshot.orders,
+                fills: snapshot.fills,
+                intents,
+                durableFills,
+                projectedPositions,
+                expectedCashMicros,
+                valuation: snapshot.valuation,
+                accountingHash,
+                ledgerExact,
+                reconciledAt: snapshot.reconciledAt,
+              }),
+            }
+          })
 
-        const [previous] = yield* sql<Record<string, unknown>>`
+          const [previous] = yield* sql<Record<string, unknown>>`
           SELECT discrepancies
           FROM reconciliations
           WHERE account_id = ${accountId}
           ORDER BY reconciled_at DESC, reconciliation_id DESC
           LIMIT 1
         `.pipe(Effect.flatMap(decodePreviousReconciliation))
-        const { contentHash, discrepancies, reconciliationId, reconciliationMaterial, status } = yield* attempt(() => {
-          const prior = new Map((previous?.discrepancies ?? []).map((value) => [value.discrepancyId, value]))
-          const status =
-            comparison.discrepancies.length === 0 ? ReconciliationStatus.Exact : ReconciliationStatus.Discrepancy
-          const discrepancies: Discrepancy[] = comparison.discrepancies.map((value) => ({
-            ...value,
-            firstObservedAt: prior.get(value.discrepancyId)?.firstObservedAt ?? snapshot.reconciledAt,
-            lastObservedAt: snapshot.reconciledAt,
-          }))
-          const reconciliationMaterial = {
-            schemaVersion: 'bayn.paper-reconciliation.v1' as const,
+          const { contentHash, discrepancies, reconciliationId, reconciliationMaterial, status } = yield* attempt(
+            'reconcile',
+            () => {
+              const prior = new Map((previous?.discrepancies ?? []).map((value) => [value.discrepancyId, value]))
+              const status =
+                comparison.discrepancies.length === 0 ? ReconciliationStatus.Exact : ReconciliationStatus.Discrepancy
+              const discrepancies: Discrepancy[] = comparison.discrepancies.map((value) => ({
+                ...value,
+                firstObservedAt: prior.get(value.discrepancyId)?.firstObservedAt ?? snapshot.reconciledAt,
+                lastObservedAt: snapshot.reconciledAt,
+              }))
+              const reconciliationMaterial = {
+                schemaVersion: 'bayn.paper-reconciliation.v1' as const,
+                accountId,
+                expectedHash: comparison.expectedHash,
+                observedHash: comparison.observedHash,
+                status,
+                discrepancies,
+                reconciledAt: snapshot.reconciledAt,
+              }
+              const reconciliationId = canonicalHashV1({
+                schemaVersion: 'bayn.paper-reconciliation-id.v1',
+                material: reconciliationMaterial,
+              })
+              const contentHash = canonicalHashV1({ ...reconciliationMaterial, reconciliationId })
+              return { contentHash, discrepancies, reconciliationId, reconciliationMaterial, status }
+            },
+          )
+          const reconciliation = yield* decodeReconciliation({
+            schemaVersion: reconciliationMaterial.schemaVersion,
+            reconciliationId,
             accountId,
             expectedHash: comparison.expectedHash,
             observedHash: comparison.observedHash,
+            contentHash,
             status,
             discrepancies,
             reconciledAt: snapshot.reconciledAt,
-          }
-          const reconciliationId = canonicalHashV1({
-            schemaVersion: 'bayn.paper-reconciliation-id.v1',
-            material: reconciliationMaterial,
           })
-          const contentHash = canonicalHashV1({ ...reconciliationMaterial, reconciliationId })
-          return { contentHash, discrepancies, reconciliationId, reconciliationMaterial, status }
-        })
-        const reconciliation = yield* decodeReconciliation({
-          schemaVersion: reconciliationMaterial.schemaVersion,
-          reconciliationId,
-          accountId,
-          expectedHash: comparison.expectedHash,
-          observedHash: comparison.observedHash,
-          contentHash,
-          status,
-          discrepancies,
-          reconciledAt: snapshot.reconciledAt,
-        })
-        yield* sql`
+          const encodedDiscrepancies = yield* attempt('reconcile', () =>
+            encodeDiscrepancies(reconciliation.discrepancies),
+          )
+          yield* sql`
           INSERT INTO reconciliations (
             reconciliation_id, schema_version, account_id, expected_hash, observed_hash,
             content_hash, status, discrepancies, reconciled_at
           ) VALUES (
             ${reconciliation.reconciliationId}, ${reconciliation.schemaVersion}, ${reconciliation.accountId},
             ${reconciliation.expectedHash}, ${reconciliation.observedHash}, ${reconciliation.contentHash},
-            ${reconciliation.status}, ${sql.json(encodeDiscrepancies(reconciliation.discrepancies))},
+            ${reconciliation.status}, ${sql.json(encodedDiscrepancies)},
             ${reconciliation.reconciledAt}
           )
           ON CONFLICT (reconciliation_id) DO NOTHING
         `
-        const [stored] = yield* sql<Record<string, unknown>>`
+          const [stored] = yield* sql<Record<string, unknown>>`
           SELECT content_hash FROM reconciliations WHERE reconciliation_id = ${reconciliationId}
         `.pipe(Effect.flatMap(decodeContent))
-        if (stored.content_hash !== contentHash) {
-          return yield* Effect.fail(new Error('stored reconciliation differs from deterministic replay'))
-        }
+          if (stored.content_hash !== contentHash) {
+            return yield* Effect.fail(
+              storeError('reconcile', 'invariant', 'stored reconciliation differs from deterministic replay'),
+            )
+          }
 
-        if (comparison.discrepancies.length > 0) {
-          yield* restrictAuthority(sql, `reconciliation discrepancy ${reconciliationId}`, snapshot.reconciledAt)
-        }
+          if (comparison.discrepancies.length > 0) {
+            yield* restrictAuthority(sql, `reconciliation discrepancy ${reconciliationId}`, snapshot.reconciledAt)
+          }
 
-        const [riskContextRow] = yield* sql<Record<string, unknown>>`
+          const [riskContextRow] = yield* sql<Record<string, unknown>>`
           WITH boundary AS (
             SELECT (${snapshot.reconciledAt}::timestamptz AT TIME ZONE 'America/New_York')::date AS trading_date
           )
@@ -600,10 +678,11 @@ export const makeReconciliation = (
           FROM boundary
           LEFT JOIN authority_state AS authority ON authority.singleton
         `.pipe(Effect.flatMap(decodeRiskContext))
-        const riskContext = yield* riskContextFromRow(riskContextRow, unknownMutationCount)
+          const riskContext = yield* riskContextFromRow(riskContextRow, unknownMutationCount)
 
-        return { reconciliation, metrics: comparison.metrics, accountingHash, riskContext }
-      }),
+          return { reconciliation, metrics: comparison.metrics, accountingHash, riskContext }
+        }),
+      ),
     )
 
   return { bindings, reconcile }

--- a/services/bayn/src/db/snapshot-reference.ts
+++ b/services/bayn/src/db/snapshot-reference.ts
@@ -1,5 +1,6 @@
 import { PgClient } from '@effect/sql-pg'
 import { Effect, Schema } from 'effect'
+import type { SqlError } from 'effect/unstable/sql/SqlError'
 
 import { strictParseOptions } from '../schemas'
 import type { InputManifest } from '../types'
@@ -15,7 +16,7 @@ const decodeSnapshotReferenceMatch = Schema.decodeUnknownEffect(SnapshotReferenc
 export const ensureSnapshotReference = (
   sql: PgClient.PgClient,
   inputManifest: InputManifest,
-): Effect.Effect<boolean, unknown> =>
+): Effect.Effect<boolean, SqlError | Schema.SchemaError> =>
   Effect.gen(function* () {
     const snapshot = inputManifest.finalizedSnapshot
     yield* sql`

--- a/services/bayn/src/index.ts
+++ b/services/bayn/src/index.ts
@@ -1,7 +1,6 @@
 import { NodeHttpClient, NodeRuntime, NodeServices } from '@effect/platform-node'
 import { ClickhouseClient } from '@effect/sql-clickhouse'
-import { PgClient } from '@effect/sql-pg'
-import { Context, Effect, Layer, Logger, Redacted, Schema, Stdio, Stream } from 'effect'
+import { Effect, Layer, Logger, Redacted, Schema, Stdio, Stream } from 'effect'
 
 import { run } from './app'
 import { riskBalancedTrendBehaviorHash } from './behavior'
@@ -9,23 +8,25 @@ import { BrokerRead, live as AlpacaReadLive, scopedReadAdapterLayer } from './br
 import { verifyBehaviorHash, verifyParameterHash } from './build'
 import { loadConfig, type LoadedRuntimeConfig } from './config'
 import { makeRuntimeProvenance, makeStrategyProtocolHash } from './contracts'
-import { CycleObservability, CycleObservabilityLive } from './db/cycle-observability'
-import { CycleStore, CycleStoreLive } from './db/cycle-store'
-import { EvidenceStoreLive, PostgresClientLive } from './db/evidence-store'
-import { PaperStore, PaperStoreLive } from './db/paper-store'
-import { WriterFence, WriterFenceLive } from './execution/writer-fence'
+import { CycleObservabilityLive } from './db/cycle-observability'
+import { CycleStoreLive } from './db/cycle-store'
+import { EvidenceStoreFromPostgres, PostgresClientLive } from './db/evidence-store'
+import { PaperStoreLive } from './db/paper-store'
+import { WriterFenceLive } from './execution/writer-fence'
 import { operationalError } from './errors'
 import { canonicalHashV1 } from './hash'
 import type { BrokerProbe } from './health'
 import { JournalLive } from './ledger'
-import { MarketData, MarketDataLive } from './market-data'
+import { MarketDataLive } from './market-data'
 import { loadObserveRiskPolicy, makeObserveAutonomousCycleStartup } from './observe-composition'
-import { acquireSqlLayer } from './operations'
+import { retrySqlLayer } from './operations'
 import { Authority } from './paper'
 import { discoverPaperProofCandidates } from './paper-proof-discovery'
 import { hashParameters, loadDefaultProtocol } from './protocol'
-import { runOnce } from './reconciler'
 import { makeStrategy, type Strategy } from './strategy'
+
+const mapLayerError = <A, E, R, E2>(layer: Layer.Layer<A, E, R>, map: (error: E) => E2): Layer.Layer<A, E2, R> =>
+  Layer.unwrap(Layer.build(layer).pipe(Effect.mapError(map), Effect.map(Layer.succeedContext)))
 
 const main = Effect.gen(function* () {
   const config = yield* loadConfig()
@@ -52,7 +53,7 @@ const main = Effect.gen(function* () {
   if (config.paperProofCommand !== undefined) {
     return yield* runPaperProofDiscovery(config, strategy)
   }
-  const clickhouse = yield* acquireSqlLayer(
+  const clickhouse = retrySqlLayer(
     ClickhouseClient.layer({
       url: config.clickhouse.url,
       username: config.clickhouse.username,
@@ -62,87 +63,57 @@ const main = Effect.gen(function* () {
       request_timeout: config.operationTimeoutMs,
     }).pipe(Layer.provide(NodeHttpClient.layerNodeHttp)),
   )
-  const marketData = MarketDataLive(config, protocol).pipe(
-    Layer.provide(Layer.succeedContext(clickhouse)),
-    Layer.provide(NodeHttpClient.layerNodeHttp),
+  const marketData = MarketDataLive(config, protocol).pipe(Layer.provide(clickhouse))
+  const database = retrySqlLayer(
+    EvidenceStoreFromPostgres(config).pipe(
+      Layer.provideMerge(PostgresClientLive(config).pipe(Layer.provide(NodeServices.layer))),
+    ),
   )
-  const marketDataContext = yield* Layer.build(marketData)
-  const marketDataService = Context.get(marketDataContext, MarketData)
-  const evidenceStore = yield* acquireSqlLayer(EvidenceStoreLive(config).pipe(Layer.provide(NodeServices.layer)))
-  const cycleObservability = CycleObservabilityLive.pipe(Layer.provide(Layer.succeedContext(evidenceStore)))
-  const journal = yield* acquireSqlLayer(JournalLive(config))
-  let broker: BrokerProbe | undefined
-  let autonomousCycleStartup: Parameters<typeof run>[4]
-  if (config.alpaca !== undefined) {
-    const brokerReadContext = yield* Layer.build(
-      AlpacaReadLive({
-        expectedAccountId: config.alpaca.accountId,
-        key: config.alpaca.key,
-        secret: config.alpaca.secret,
-        proxyUrl: config.alpaca.proxyUrl,
-        operationTimeoutMs: config.operationTimeoutMs,
-        retryAttempts: config.alpaca.retryAttempts,
-      }),
-    ).pipe(
-      Effect.mapError((cause) => operationalError('config', 'alpaca', 'Alpaca paper account binding failed', cause)),
-    )
-    const brokerRead = Context.get(brokerReadContext, BrokerRead)
-    broker = {
-      read: brokerRead,
-      expectedAccountId: config.alpaca.accountId,
+  const journal = JournalLive(config)
+  const cycleObservability = CycleObservabilityLive.pipe(Layer.provide(database))
+  const core = Layer.mergeAll(marketData, database, journal, cycleObservability)
+  if (config.alpaca === undefined) {
+    return yield* run(config, strategy).pipe(Effect.provide(core))
+  }
+
+  const alpaca = config.alpaca
+  const brokerRead = mapLayerError(
+    AlpacaReadLive({
+      expectedAccountId: alpaca.accountId,
+      key: alpaca.key,
+      secret: alpaca.secret,
+      proxyUrl: alpaca.proxyUrl,
+      operationTimeoutMs: config.operationTimeoutMs,
+      retryAttempts: alpaca.retryAttempts,
+    }),
+    (cause) => operationalError('config', 'alpaca', 'Alpaca paper account binding failed', cause),
+  )
+  const storage = Layer.merge(database, journal)
+  const paperStore = PaperStoreLive(config).pipe(Layer.provide(storage))
+  const writerFence = WriterFenceLive.pipe(Layer.provide(database))
+  const cycleStore = CycleStoreLive.pipe(Layer.provide(database))
+  const live = Layer.mergeAll(core, brokerRead, paperStore, writerFence, cycleStore)
+  const application = Effect.gen(function* () {
+    const read = yield* BrokerRead
+    const broker: BrokerProbe = {
+      read,
+      expectedAccountId: alpaca.accountId,
       executionEligible: false,
       executionDisabledReason:
         config.maximumAuthority === Authority.Observe
           ? 'MAXIMUM_AUTHORITY_OBSERVE'
           : 'PAPER_DISPATCH_REQUIRES_CYCLE_GATES',
     }
-    const storage = Layer.mergeAll(Layer.succeedContext(evidenceStore), Layer.succeedContext(journal))
-    const paperStoreContext = yield* Layer.build(PaperStoreLive(config).pipe(Layer.provide(storage))).pipe(
-      Effect.mapError((cause) =>
-        operationalError('database', 'paper-store', 'paper persistence composition failed', cause),
-      ),
-    )
-    const paperStore = Context.get(paperStoreContext, PaperStore)
-    const writerFenceContext = yield* Layer.build(
-      WriterFenceLive.pipe(Layer.provide(Layer.succeedContext(evidenceStore))),
-    ).pipe(
-      Effect.mapError((cause) =>
-        operationalError('database', 'writer-fence', 'paper writer fence acquisition failed', cause),
-      ),
-    )
-    const writerFence = Context.get(writerFenceContext, WriterFence)
-    const cycleStoreContext = yield* Layer.build(
-      CycleStoreLive.pipe(Layer.provide(Layer.succeedContext(evidenceStore))),
-    ).pipe(
-      Effect.mapError((cause) =>
-        operationalError('database', 'cycle-store', 'cycle persistence composition failed', cause),
-      ),
-    )
-    const reconcile = runOnce.pipe(
-      Effect.provideService(BrokerRead, brokerRead),
-      Effect.provideService(PaperStore, paperStore),
-      Effect.provideService(WriterFence, writerFence),
-    )
-    autonomousCycleStartup = makeObserveAutonomousCycleStartup({
-      accountId: config.alpaca.accountId,
-      authorityGenerationHash: config.alpaca.authorityGenerationHash,
-      brokerRead,
-      cycleStore: Context.get(cycleStoreContext, CycleStore),
-      marketData: marketDataService,
+    const autonomousCycleStartup = makeObserveAutonomousCycleStartup({
+      accountId: alpaca.accountId,
+      authorityGenerationHash: alpaca.authorityGenerationHash,
       maximumAuthority: config.maximumAuthority,
-      paperStore,
       pollIntervalMs: config.cyclePollIntervalMs,
-      reconcile,
       strategy,
     })
-  }
-  const dependencies = Layer.mergeAll(
-    Layer.succeedContext(marketDataContext),
-    cycleObservability,
-    Layer.succeedContext(journal),
-    Layer.succeedContext(evidenceStore),
-  )
-  return yield* run(config, strategy, Effect.void, broker, autonomousCycleStartup).pipe(Effect.provide(dependencies))
+    return yield* run(config, strategy, Effect.void, broker, autonomousCycleStartup)
+  })
+  return yield* application.pipe(Effect.provide(live))
 }).pipe(Effect.scoped)
 
 const encodeJson = Schema.encodeUnknownEffect(Schema.fromJsonString(Schema.Json))
@@ -165,11 +136,10 @@ const runPaperProofDiscovery = (config: LoadedRuntimeConfig, strategy: Strategy)
         operationalError('config', 'paper-command', 'source-controlled OBSERVE risk policy is invalid', cause),
       ),
     )
-    const postgres = yield* acquireSqlLayer(PostgresClientLive(config).pipe(Layer.provide(NodeServices.layer)))
-    const postgresLayer = Layer.succeedContext(postgres)
-    const observabilityContext = yield* Layer.build(CycleObservabilityLive.pipe(Layer.provide(postgresLayer)))
-    const cycleStoreContext = yield* Layer.build(CycleStoreLive.pipe(Layer.provide(postgresLayer)))
-    const brokerReadContext = yield* Layer.build(
+    const postgres = retrySqlLayer(PostgresClientLive(config).pipe(Layer.provide(NodeServices.layer)))
+    const observability = CycleObservabilityLive.pipe(Layer.provide(postgres))
+    const cycleStore = CycleStoreLive.pipe(Layer.provide(postgres))
+    const brokerRead = mapLayerError(
       scopedReadAdapterLayer({
         expectedAccountId: alpaca.accountId,
         key: alpaca.key,
@@ -178,35 +148,31 @@ const runPaperProofDiscovery = (config: LoadedRuntimeConfig, strategy: Strategy)
         operationTimeoutMs: config.operationTimeoutMs,
         retryAttempts: alpaca.retryAttempts,
       }),
-    ).pipe(
-      Effect.mapError((cause) =>
-        operationalError('config', 'alpaca', 'Alpaca scoped read adapter construction failed', cause),
-      ),
+      (cause) => operationalError('config', 'alpaca', 'Alpaca scoped read adapter construction failed', cause),
     )
-    const brokerRead = Context.get(brokerReadContext, BrokerRead)
-    const receipt = yield* discoverPaperProofCandidates({
-      sourceRevision: config.build.sourceRevision,
-      image: {
-        repository: config.build.imageRepository,
-        digest: config.build.imageDigest,
-      },
-      strategy: strategy.provenance.strategy,
-      strategyProtocolHash: makeStrategyProtocolHash(strategy.provenance.strategy),
-      qualificationRunId,
-      accountId: alpaca.accountId,
-      authorityGenerationHash: alpaca.authorityGenerationHash,
-      policyHash: canonicalHashV1(policy),
-    }).pipe(
-      Effect.provideService(PgClient.PgClient, Context.get(postgres, PgClient.PgClient)),
-      Effect.provideService(CycleObservability, Context.get(observabilityContext, CycleObservability)),
-      Effect.provideService(CycleStore, Context.get(cycleStoreContext, CycleStore)),
-      Effect.provideService(BrokerRead, brokerRead),
-    )
-    const output = yield* encodeJson(receipt)
-    const stdio = yield* Stdio.Stdio
-    yield* Stream.run(Stream.make(`${output}\n`), stdio.stdout())
-  }).pipe(Effect.provide(NodeServices.layer))
+    const dependencies = Layer.mergeAll(postgres, observability, cycleStore, brokerRead)
+    const runtime = Layer.merge(dependencies, NodeServices.layer)
+    return yield* Effect.gen(function* () {
+      const receipt = yield* discoverPaperProofCandidates({
+        sourceRevision: config.build.sourceRevision,
+        image: {
+          repository: config.build.imageRepository,
+          digest: config.build.imageDigest,
+        },
+        strategy: strategy.provenance.strategy,
+        strategyProtocolHash: makeStrategyProtocolHash(strategy.provenance.strategy),
+        qualificationRunId,
+        accountId: alpaca.accountId,
+        authorityGenerationHash: alpaca.authorityGenerationHash,
+        policyHash: canonicalHashV1(policy),
+      })
+      const output = yield* encodeJson(receipt)
+      const stdio = yield* Stdio.Stdio
+      yield* Stream.run(Stream.make(`${output}\n`), stdio.stdout())
+    }).pipe(Effect.provide(runtime))
+  })
 
-const program = main.pipe(Effect.annotateLogs({ service: 'bayn' }), Effect.provide(Logger.layer([Logger.consoleJson])))
+const runtime = Layer.merge(Logger.layer([Logger.consoleJson]), NodeServices.layer)
+const program = main.pipe(Effect.annotateLogs({ service: 'bayn' }), Effect.provide(runtime))
 
 NodeRuntime.runMain(program)

--- a/services/bayn/src/market-data.test.ts
+++ b/services/bayn/src/market-data.test.ts
@@ -388,6 +388,53 @@ describe('finalized Signal snapshot reader', () => {
     }
   })
 
+  test('returns malformed inspection rows through the typed operational channel', async () => {
+    const fixture = makeFixture()
+    const malformedSessions = [
+      { ...fixture.rows.sessions[0], close_time: 'not-a-market-time' },
+      ...fixture.rows.sessions.slice(1),
+    ] as unknown as readonly SignalSessionRow[]
+    const client = makeClickhouseFixture(fixture.rows.manifests, malformedSessions, [])
+    const layer = MarketDataLive(
+      {
+        operationTimeoutMs: 5_000,
+        clickhouse: {
+          url: 'http://clickhouse.test:8123',
+          username: 'bayn',
+          password: Redacted.make('secret'),
+          snapshotId,
+          publicationAsOf: fixture.request.publicationAsOf,
+          calendarVersion: fixture.request.calendarVersion,
+          bounds: fixture.request.bounds,
+        },
+      },
+      {
+        universeId: fixture.request.universeId,
+        universeSymbolHash: fixture.request.universeSymbolHash,
+        universe: fixture.request.universe,
+        historyStart: fixture.request.historyStart,
+        evaluationStart: fixture.request.evaluationStart,
+      },
+    ).pipe(Layer.provide(Layer.succeed(ClickhouseClient.ClickhouseClient, client)))
+
+    const failure = await Effect.runPromise(
+      Effect.flip(
+        Effect.gen(function* () {
+          const marketData = yield* MarketData
+          return yield* marketData.inspect
+        }).pipe(Effect.provide(layer)),
+      ),
+    )
+
+    expect(failure).toMatchObject({
+      _tag: 'OperationalError',
+      component: 'market-data',
+      operation: 'inspect',
+      retryable: false,
+    })
+    expect(failure.message).toContain('Signal snapshot verification failed')
+  })
+
   test('reproduces the publisher contract before exposing bounded numeric bars', () => {
     const fixture = makeFixture()
     const snapshot = verifyFinalizedSnapshot(fixture.rows, fixture.request)

--- a/services/bayn/src/market-data.ts
+++ b/services/bayn/src/market-data.ts
@@ -981,8 +981,9 @@ const makeMarketData = (
       inspect: Effect.gen(function* () {
         const observedAt = new Date(yield* Clock.currentTimeMillis).toISOString()
         const [manifests, sessions] = yield* Effect.all([loadManifests, loadSessions], { concurrency: 2 })
-        const rows = decodeSnapshotRows([], sessions, manifests)
-        return yield* verify('inspect', () => verifyFinalizedCalendar(rows, request(observedAt)))
+        return yield* verify('inspect', () =>
+          verifyFinalizedCalendar(decodeSnapshotRows([], sessions, manifests), request(observedAt)),
+        )
       }).pipe(
         Effect.mapError((cause) =>
           marketDataOperationError('inspect', 'failed to inspect finalized Signal calendar', cause),

--- a/services/bayn/src/observe-composition.test.ts
+++ b/services/bayn/src/observe-composition.test.ts
@@ -4,6 +4,7 @@ import { Effect, Result } from 'effect'
 import { TestClock } from 'effect/testing'
 
 import {
+  BrokerRead,
   BrokerReadError,
   BrokerReadErrorKind,
   type BrokerReadShape,
@@ -20,12 +21,12 @@ import {
   makeCycleWindow,
   makeExecutionCalendarObservation,
 } from './cycle'
-import type { CycleStoreShape } from './db/cycle-store'
-import { PaperStoreError, type PaperStoreShape } from './db/paper-store'
+import { CycleStore, type CycleStoreShape } from './db/cycle-store'
+import { PaperStore, PaperStoreError, type PaperStoreShape } from './db/paper-store'
 import { operationalError } from './errors'
-import { WriterFenceError } from './execution/writer-fence'
+import { WriterFence, WriterFenceError, type WriterFenceService } from './execution/writer-fence'
 import { canonicalHashV1 } from './hash'
-import type { MarketDataService, MarketDataSnapshot } from './market-data'
+import { MarketData, type MarketDataService, type MarketDataSnapshot } from './market-data'
 import {
   buildObserveCycleDecision,
   loadObserveRiskPolicy,
@@ -578,16 +579,16 @@ describe('OBSERVE runtime composition', () => {
       fillActivities: () => unused,
       marketCalendar: () => unused,
     }
+    const writerFence: WriterFenceService = {
+      backendPid: 1,
+      check: unused,
+      transaction: (effect) => effect,
+    }
     const startup = makeObserveAutonomousCycleStartup({
       accountId,
       authorityGenerationHash: generationHash,
-      brokerRead,
-      cycleStore,
-      marketData: marketData([]),
       maximumAuthority: Authority.Paper,
-      paperStore,
       pollIntervalMs: 30_000,
-      reconcile: unused,
       strategy: {
         currentDecision: () => {
           throw new Error('PAPER startup must not compile a shadow decision')
@@ -602,7 +603,13 @@ describe('OBSERVE runtime composition', () => {
           qualificationRunId: 'c'.repeat(64),
           strategyProtocolHash: 'd'.repeat(64),
           recordPass: () => unused,
-        }),
+        }).pipe(
+          Effect.provideService(BrokerRead, brokerRead),
+          Effect.provideService(CycleStore, cycleStore),
+          Effect.provideService(MarketData, marketData([])),
+          Effect.provideService(PaperStore, paperStore),
+          Effect.provideService(WriterFence, writerFence),
+        ),
       ),
     )
 

--- a/services/bayn/src/observe-composition.ts
+++ b/services/bayn/src/observe-composition.ts
@@ -10,7 +10,8 @@ import {
   type CyclePassObservation,
 } from './cycle-runner'
 import { CycleStore, type CycleStoreShape } from './db/cycle-store'
-import type { PaperStoreShape } from './db/paper-store'
+import { PaperStore, type PaperStoreShape } from './db/paper-store'
+import { WriterFence, type WriterFenceService } from './execution/writer-fence'
 import {
   bindCycleExecutionSession,
   type ExecutionSessionBinding,
@@ -22,7 +23,7 @@ import { canonicalHashV1 } from './hash'
 import { MarketData, type MarketDataService } from './market-data'
 import { Authority, OrderSide, OrderType, TimeInForce, type AuthorityState } from './paper'
 import type { CausalProtocol } from './protocol'
-import type { ReconciliationPassResult, runOnce } from './reconciler'
+import { runOnce, type ReconciliationPassResult } from './reconciler'
 import { reconciledStateHash } from './reconciliation'
 import { BrokerMode, decodePolicy, type Policy, type State } from './risk'
 import { buildObserveShadowDecision, type ShadowDecisionError, type ShadowDeltaRiskInput } from './shadow-decision'
@@ -485,14 +486,19 @@ const observePass = (
 export interface ObserveAutonomousCycleInput {
   readonly accountId: string
   readonly authorityGenerationHash: string
+  readonly maximumAuthority: Authority
+  readonly pollIntervalMs: number
+  readonly strategy: Pick<Strategy, 'currentDecision' | 'parameters'>
+}
+
+type ObserveRuntime = BrokerRead | CycleStore | MarketData | PaperStore | WriterFence
+
+interface ObserveRuntimeServices {
   readonly brokerRead: BrokerReadShape
   readonly cycleStore: CycleStoreShape
   readonly marketData: MarketDataService
-  readonly maximumAuthority: Authority
   readonly paperStore: PaperStoreShape
-  readonly pollIntervalMs: number
-  readonly reconcile: Effect.Effect<ReconciliationPassResult, ReconciliationPassError>
-  readonly strategy: Pick<Strategy, 'currentDecision' | 'parameters'>
+  readonly writerFence: WriterFenceService
 }
 
 interface ObserveStartupPreparation {
@@ -540,8 +546,9 @@ const validateObserveAuthorityInitialization = (
 
 const initializeObserveAuthority = (
   input: ObserveAutonomousCycleInput,
+  paperStore: PaperStoreShape,
 ): Effect.Effect<AuthorityState, OperationalError> =>
-  input.paperStore
+  paperStore
     .ensureAuthorityGeneration({
       generationHash: input.authorityGenerationHash,
       maximum: Authority.Observe,
@@ -555,11 +562,17 @@ const initializeObserveAuthority = (
 
 const startObserveAutonomousLoop = (
   input: ObserveAutonomousCycleInput,
+  services: ObserveRuntimeServices,
   startup: Parameters<AutonomousCycleStartup>[0],
   preparation: ObserveStartupPreparation,
   policy: Policy,
-) =>
-  startAutonomousCycleLoop({
+) => {
+  const reconcile = runOnce.pipe(
+    Effect.provideService(BrokerRead, services.brokerRead),
+    Effect.provideService(PaperStore, services.paperStore),
+    Effect.provideService(WriterFence, services.writerFence),
+  )
+  return startAutonomousCycleLoop({
     context: Effect.succeed({
       qualificationRunId: startup.qualificationRunId,
       strategyProtocolHash: startup.strategyProtocolHash,
@@ -570,26 +583,31 @@ const startObserveAutonomousLoop = (
           authorityGenerationHash: input.authorityGenerationHash,
           cycle,
           executionModel: preparation.executionModel,
-          marketCalendar: input.brokerRead.marketCalendar,
-          marketData: input.marketData,
+          marketCalendar: services.brokerRead.marketCalendar,
+          marketData: services.marketData,
           policy,
-          reconcile: input.reconcile,
+          reconcile,
           strategy: input.strategy,
         }).pipe(Effect.mapError(decisionBuildError)),
     }),
     observePass: (observation) => observePass(startup.recordPass, observation),
     pollIntervalMs: input.pollIntervalMs,
   }).pipe(
-    Effect.provideService(BrokerRead, input.brokerRead),
-    Effect.provideService(CycleStore, input.cycleStore),
-    Effect.provideService(MarketData, input.marketData),
     Effect.mapError((cause) =>
       operationalError('strategy', 'cycle-loop', 'autonomous cycle loop failed to start', cause),
     ),
+    Effect.map((loop) =>
+      loop.pipe(
+        Effect.provideService(BrokerRead, services.brokerRead),
+        Effect.provideService(CycleStore, services.cycleStore),
+        Effect.provideService(MarketData, services.marketData),
+      ),
+    ),
   )
+}
 
 export const makeObserveAutonomousCycleStartup =
-  (input: ObserveAutonomousCycleInput): AutonomousCycleStartup =>
+  (input: ObserveAutonomousCycleInput): AutonomousCycleStartup<ObserveRuntime> =>
   (startup) =>
     Effect.gen(function* () {
       const preparation = yield* Effect.fromResult(prepareObserveStartup(input))
@@ -598,6 +616,13 @@ export const makeObserveAutonomousCycleStartup =
           operationalError('strategy', 'risk-policy', 'source-controlled paper risk policy is invalid', cause),
         ),
       )
-      yield* initializeObserveAuthority(input)
-      return yield* startObserveAutonomousLoop(input, startup, preparation, policy)
+      const services: ObserveRuntimeServices = {
+        brokerRead: yield* BrokerRead,
+        cycleStore: yield* CycleStore,
+        marketData: yield* MarketData,
+        paperStore: yield* PaperStore,
+        writerFence: yield* WriterFence,
+      }
+      yield* initializeObserveAuthority(input, services.paperStore)
+      return yield* startObserveAutonomousLoop(input, services, startup, preparation, policy)
     })

--- a/services/bayn/src/operations.ts
+++ b/services/bayn/src/operations.ts
@@ -19,13 +19,18 @@ const isRetryableSqlAcquisition = (error: unknown): boolean => {
   )
 }
 
-export const acquireSqlLayer = <A, E, R>(layer: Layer.Layer<A, E, R>) =>
-  Layer.build(layer).pipe(
-    Effect.retry({
-      times: 2,
-      schedule: Schedule.spaced(Duration.seconds(1)),
-      while: isRetryableSqlAcquisition,
-    }),
+export const acquireSqlLayer = <A, E, R>(layer: Layer.Layer<A, E, R>) => Layer.build(retrySqlLayer(layer))
+
+export const retrySqlLayer = <A, E, R>(layer: Layer.Layer<A, E, R>): Layer.Layer<A, E, R> =>
+  Layer.unwrap(
+    Layer.build(layer).pipe(
+      Effect.retry({
+        times: 2,
+        schedule: Schedule.spaced(Duration.seconds(1)),
+        while: isRetryableSqlAcquisition,
+      }),
+      Effect.map(Layer.succeedContext),
+    ),
   )
 
 export const withinDeadline = <A, R>(

--- a/services/bayn/src/qualification-audit-command.ts
+++ b/services/bayn/src/qualification-audit-command.ts
@@ -1,7 +1,7 @@
 import { NodeHttpClient, NodeRuntime, NodeServices } from '@effect/platform-node'
 import { ClickhouseClient } from '@effect/sql-clickhouse'
 import { PgClient } from '@effect/sql-pg'
-import { Config, Effect, FileSystem, Layer, Logger, Redacted, Schema, Stdio, Stream } from 'effect'
+import { Config, Data, Effect, FileSystem, Layer, Logger, Redacted, Schema, Stdio, Stream } from 'effect'
 import { ChildProcess, ChildProcessSpawner } from 'effect/unstable/process'
 
 import { EvaluationEventSchema, decodeInputManifestArtifact } from './evidence-contracts'
@@ -142,14 +142,32 @@ const config = Config.all({
 
 type AuditConfig = Config.Success<typeof config>
 
+class QualificationAuditCommandError extends Data.TaggedError('QualificationAuditCommandError')<{
+  readonly operation: 'audit' | 'configuration' | 'repository' | 'signal-access'
+  readonly message: string
+  readonly cause?: unknown
+}> {}
+
+const commandError = (
+  operation: QualificationAuditCommandError['operation'],
+  message: string,
+  cause?: unknown,
+): QualificationAuditCommandError => new QualificationAuditCommandError({ operation, message, cause })
+
 const postgresLayer = (input: AuditConfig) => {
   const readCertificate = Effect.gen(function* () {
     if (!input.postgresTls) return undefined
     if (input.postgresCaPath.length === 0) {
-      return yield* Effect.fail(new Error('BAYN_AUDIT_POSTGRES_CA_PATH is required with TLS'))
+      return yield* Effect.fail(commandError('configuration', 'BAYN_AUDIT_POSTGRES_CA_PATH is required with TLS'))
     }
     const fileSystem = yield* FileSystem.FileSystem
-    return yield* fileSystem.readFileString(input.postgresCaPath)
+    return yield* fileSystem
+      .readFileString(input.postgresCaPath)
+      .pipe(
+        Effect.mapError((cause) =>
+          commandError('configuration', 'failed to read the qualification-audit PostgreSQL CA certificate', cause),
+        ),
+      )
   })
   return Layer.unwrap(
     readCertificate.pipe(
@@ -381,7 +399,7 @@ const readSignalReplicaAccess = (
   database: AuditDatabaseSnapshot,
   finalizedAt: string,
   signalTables: InputManifest['tables'],
-): Effect.Effect<SignalReplicaAccess, unknown> => {
+): Effect.Effect<SignalReplicaAccess, QualificationAuditCommandError> => {
   const barsTable = `signal.${signalTables.bars}`
   const sessionsTable = `signal.${signalTables.sessions}`
   const manifestTable = `signal.${signalTables.manifests}`
@@ -437,18 +455,17 @@ const readSignalReplicaAccess = (
       })),
     }
   })
+  const clickhouse = ClickhouseClient.layer({
+    url: url.href,
+    username: input.auditClickhouseUsername,
+    password: Redacted.value(input.auditClickhousePassword),
+    database: 'system',
+    application: 'bayn-qualification-audit',
+    request_timeout: input.operationTimeoutMs,
+  }).pipe(Layer.provide(NodeHttpClient.layerNodeHttp))
   return program.pipe(
-    Effect.provide(
-      ClickhouseClient.layer({
-        url: url.href,
-        username: input.auditClickhouseUsername,
-        password: Redacted.value(input.auditClickhousePassword),
-        database: 'system',
-        application: 'bayn-qualification-audit',
-        request_timeout: input.operationTimeoutMs,
-      }),
-    ),
-    Effect.provide(NodeHttpClient.layerNodeHttp),
+    Effect.provide(clickhouse),
+    Effect.mapError((cause) => commandError('signal-access', 'ClickHouse replica audit read failed', cause)),
   )
 }
 
@@ -457,7 +474,10 @@ const readSignalAccess = (
   database: AuditDatabaseSnapshot,
   finalizedAt: string,
   signalTables: InputManifest['tables'],
-): Effect.Effect<{ readonly replicas: readonly string[]; readonly access: readonly SignalAccessRecord[] }, unknown> =>
+): Effect.Effect<
+  { readonly replicas: readonly string[]; readonly access: readonly SignalAccessRecord[] },
+  QualificationAuditCommandError
+> =>
   Effect.all(
     input.auditClickhouseUrls.map((url) => readSignalReplicaAccess(input, url, database, finalizedAt, signalTables)),
     { concurrency: 'unbounded' },
@@ -484,7 +504,7 @@ const readSignalAccess = (
           }
           return { replicas: observed, access: sources.flatMap((source) => source.access) }
         },
-        catch: (cause) => cause,
+        catch: (cause) => commandError('signal-access', 'ClickHouse replica audit topology is invalid', cause),
       }),
     ),
   )
@@ -494,7 +514,7 @@ const repositoryAudit = (
   sourceRevision: string,
   lockCreatedAt: string,
   resultIdentity: readonly string[],
-): Effect.Effect<RepositoryAudit, unknown, ChildProcessSpawner.ChildProcessSpawner> =>
+): Effect.Effect<RepositoryAudit, QualificationAuditCommandError, ChildProcessSpawner.ChildProcessSpawner> =>
   Effect.gen(function* () {
     const processes = yield* ChildProcessSpawner.ChildProcessSpawner
     const exists = yield* processes.exitCode(
@@ -521,14 +541,14 @@ const repositoryAudit = (
       sourceCommitAncestorOfMain: Number(ancestor) === 0,
       preLockResultReferences: [...references].sort(),
     }
-  })
+  }).pipe(Effect.mapError((cause) => commandError('repository', 'repository provenance audit failed', cause)))
 
 const main = Effect.gen(function* () {
   const input = yield* config
   const database = yield* readDatabase(input.runId).pipe(Effect.provide(postgresLayer(input)))
   const inputManifestArtifact = database.artifacts.find((artifact) => artifact.name === 'input-manifest')
   if (inputManifestArtifact === undefined) {
-    return yield* Effect.fail(new Error('input-manifest artifact is missing'))
+    return yield* Effect.fail(commandError('audit', 'input-manifest artifact is missing'))
   }
   const manifest = yield* decodeInputManifestArtifact(inputManifestArtifact.payload)
   const protocol = database.protocol.parameters
@@ -553,20 +573,17 @@ const main = Effect.gen(function* () {
   }
   const report = yield* Effect.try({
     try: () => (input.output === 'dossier' ? makeQualificationDossier(auditInput) : auditQualification(auditInput)),
-    catch: (cause) => cause,
+    catch: (cause) => commandError('audit', 'qualification audit evaluation failed', cause),
   })
   const output = yield* encodeJson(report)
   const stdio = yield* Stdio.Stdio
   yield* Stream.run(Stream.make(`${output}\n`), stdio.stdout())
   if (input.output === 'audit' && 'status' in report && report.status !== 'PASS') {
-    return yield* Effect.fail(new Error('qualification audit failed'))
+    return yield* Effect.fail(commandError('audit', 'qualification audit failed'))
   }
 })
 
-const program = main.pipe(
-  Effect.annotateLogs({ service: 'bayn-qualification-audit' }),
-  Effect.provide(Logger.layer([Logger.consoleJson])),
-  Effect.provide(NodeServices.layer),
-)
+const runtime = Layer.merge(Logger.layer([Logger.consoleJson]), NodeServices.layer)
+const program = main.pipe(Effect.annotateLogs({ service: 'bayn-qualification-audit' }), Effect.provide(runtime))
 
 NodeRuntime.runMain(program)

--- a/services/bayn/src/reconciler.ts
+++ b/services/bayn/src/reconciler.ts
@@ -50,6 +50,8 @@ export interface ReconciliationPassResult {
   readonly riskContext: ReconciliationRiskContext
 }
 
+export type ReconciliationPassError = BrokerReadError | PaperStoreError | ReconciliationError | WriterFenceError
+
 export class ReconciliationError extends Data.TaggedError('ReconciliationError')<{
   readonly operation: 'pagination' | 'normalization' | 'snapshot'
   readonly message: string
@@ -333,7 +335,7 @@ const run = (
 
 export const runOnce: Effect.Effect<
   ReconciliationPassResult,
-  BrokerReadError | PaperStoreError | ReconciliationError | WriterFenceError,
+  ReconciliationPassError,
   BrokerRead | PaperStore | WriterFence
 > = Effect.gen(function* () {
   const read = yield* BrokerRead

--- a/services/bayn/tsconfig.json
+++ b/services/bayn/tsconfig.json
@@ -3,7 +3,37 @@
   "compilerOptions": {
     "noEmit": true,
     "strict": true,
-    "types": ["bun", "node"]
+    "types": ["bun", "node"],
+    "plugins": [
+      {
+        "name": "@effect/language-service",
+        "diagnostics": true,
+        "includeSuggestionsInTsc": false,
+        "diagnosticSeverity": {
+          "anyUnknownInErrorContext": "error",
+          "globalErrorInEffectCatch": "error",
+          "globalErrorInEffectFailure": "error",
+          "multipleEffectProvide": "error",
+          "scopeInLayerEffect": "error",
+          "unknownInEffectCatch": "error"
+        },
+        "overrides": [
+          {
+            "include": ["src/**/*.test.ts", "src/**/*test-support.ts"],
+            "options": {
+              "diagnosticSeverity": {
+                "anyUnknownInErrorContext": "off",
+                "globalErrorInEffectCatch": "off",
+                "globalErrorInEffectFailure": "off",
+                "multipleEffectProvide": "off",
+                "scopeInLayerEffect": "off",
+                "unknownInEffectCatch": "off"
+              }
+            }
+          }
+        ]
+      }
+    ]
   },
   "include": ["src", "migrations"]
 }


### PR DESCRIPTION
## Summary

- preserve typed Effect failures across autonomous decision, reconciliation, database, broker, and audit boundaries
- make the application own the autonomous cycle fiber and compose runtime dependencies as one shared Layer graph
- close the malformed market-data inspection defect path and add a regression test
- add named broker mutation spans and enforce critical Effect language-service diagnostics in Bayn CI

## Related Issues

None

## Testing

- `bun run --filter @proompteng/bayn test` — 560 passed, 112 skipped, 0 failed
- `bun node_modules/typescript/bin/tsc -p services/bayn/tsconfig.json --noEmit`
- `bun run --cwd services/bayn lint:effect`
- `bun node_modules/oxfmt/bin/oxfmt --check services/bayn .github/workflows/bayn-ci.yml`
- `bun node_modules/oxlint/bin/oxlint --config .oxlintrc.json services/bayn`
- `bun node_modules/oxlint/bin/oxlint --config .oxlintrc.json --type-aware --tsconfig services/bayn/tsconfig.json services/bayn`
- `bun build services/bayn/src/index.ts --target=node --external tigerbeetle-node --outdir=/tmp/bayn-remediation-dist`
- `bun test packages/scripts/src/bayn` — 20 passed, 0 failed

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
