### PR TITLE
refactor(bayn): make intent persistence functional

### DIFF
--- a/services/bayn/src/db/evidence-store.integration.test.ts
+++ b/services/bayn/src/db/evidence-store.integration.test.ts
@@ -256,6 +256,39 @@ const paperIntentEvidence = Effect.gen(function* () {
   return evidence
 })
 
+const seedPlannedIntent = (intent: Intent) =>
+  Effect.gen(function* () {
+    const sql = yield* PgClient.PgClient
+    yield* sql`
+      INSERT INTO intents (
+        intent_id, schema_version, authority_generation_hash, strategy_name, cycle_id,
+        decision_hash, policy_hash, account_id, client_order_id, symbol, side, order_type,
+        time_in_force, quantity_micros, notional_limit_micros, state, created_at, updated_at
+      ) VALUES (
+        ${intent.intentId}, ${intent.schemaVersion}, ${intent.authorityGenerationHash},
+        ${intent.strategyName}, ${intent.cycleId}, ${intent.decisionHash}, ${intent.policyHash},
+        ${intent.accountId}, ${intent.clientOrderId}, ${intent.symbol}, ${intent.side},
+        ${intent.orderType}, ${intent.timeInForce}, ${intent.quantityMicros},
+        ${intent.notionalLimitMicros}, ${intent.state}, ${intent.createdAt}, ${intent.createdAt}
+      )
+    `
+  })
+
+const restrictIntentCommitAuthority = (killState: KillState) =>
+  Effect.gen(function* () {
+    const sql = yield* PgClient.PgClient
+    yield* sql`
+      UPDATE authority_state
+      SET
+        effective = 'OBSERVE',
+        kill_state = ${killState},
+        reason = ${killState === KillState.Active ? 'IntentStore commit rejection fixture' : null},
+        version = version + 1,
+        updated_at = greatest(clock_timestamp(), updated_at + interval '1 millisecond')
+      WHERE singleton
+    `
+  })
+
 const seedApprovedIntent = (intent: Intent, decision: RiskDecision) =>
   Effect.gen(function* () {
     const sql = yield* PgClient.PgClient
@@ -1058,21 +1091,6 @@ describePostgres('PostgreSQL evaluation evidence', () => {
         const secondOwnerExit = yield* Effect.promise(() =>
           secondOwner.runPromiseExit(Effect.flatMap(WriterFence, (fence) => fence.check)),
         )
-        const transitionTime = new Date(Date.now() + 1_000).toISOString()
-        const transitions = yield* Effect.promise(() =>
-          execution.runPromise(
-            Effect.gen(function* () {
-              const store = yield* IntentStore
-              return yield* Effect.all(
-                [
-                  store.markIoStarted(intent.intentId, transitionTime),
-                  store.markIoStarted(intent.intentId, transitionTime),
-                ],
-                { concurrency: 'unbounded' },
-              )
-            }),
-          ),
-        )
         const retryAfterTransition = yield* Effect.promise(() =>
           execution.runPromise(Effect.flatMap(IntentStore, (store) => store.commit(intent, decision))),
         )
@@ -1100,7 +1118,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
             }),
           ),
         )
-        return { commits, retryAfterTransition, secondOwnerExit, stored, transitions }
+        return { commits, retryAfterTransition, secondOwnerExit, stored }
       }).pipe(
         Effect.ensuring(
           Effect.all([Effect.promise(() => secondOwner.dispose()), Effect.promise(() => execution.dispose())], {
@@ -1116,17 +1134,14 @@ describePostgres('PostgreSQL evaluation evidence', () => {
     expect(observed.commits[0].record.intent.intentId).toBe(intent.intentId)
     expect(observed.commits[1].record.intent.clientOrderId).toBe(intent.clientOrderId)
     expect(Exit.isFailure(observed.secondOwnerExit)).toBe(true)
-    expect(
-      observed.transitions.map((receipt) => receipt.deduplicated).sort((left, right) => Number(left) - Number(right)),
-    ).toEqual([false, true])
     expect(observed.retryAfterTransition).toMatchObject({
       deduplicated: true,
-      record: { intent: { state: 'IO_STARTED' }, stateVersion: 3 },
+      record: { intent: { state: 'APPROVED' }, stateVersion: 2 },
     })
     expect(observed.stored).toEqual({
       client_order_id: intent.clientOrderId,
-      state: 'IO_STARTED',
-      state_version: 3,
+      state: 'APPROVED',
+      state_version: 2,
       intents: 1,
       decisions: 1,
     })
@@ -1144,15 +1159,19 @@ describePostgres('PostgreSQL evaluation evidence', () => {
     const observed = await Effect.runPromise(
       Effect.gen(function* () {
         const forgedDecision = yield* Effect.promise(() =>
-          execution.runPromiseExit(
-            Effect.flatMap(IntentStore, (store) => store.commit(intent, { ...decision, decisionId: '0'.repeat(64) })),
+          execution.runPromise(
+            Effect.flatMap(IntentStore, (store) =>
+              store.commit(intent, { ...decision, decisionId: '0'.repeat(64) }),
+            ).pipe(Effect.flip),
           ),
         )
         const receipt = yield* Effect.promise(() =>
           execution.runPromise(Effect.flatMap(IntentStore, (store) => store.commit(intent, decision))),
         )
         const conflict = yield* Effect.promise(() =>
-          execution.runPromiseExit(Effect.flatMap(IntentStore, (store) => store.commit(divergent, divergentDecision))),
+          execution.runPromise(
+            Effect.flatMap(IntentStore, (store) => store.commit(divergent, divergentDecision)).pipe(Effect.flip),
+          ),
         )
         const counts = yield* Effect.promise(() =>
           runtime.runPromise(
@@ -1176,18 +1195,24 @@ describePostgres('PostgreSQL evaluation evidence', () => {
       intent: { state: 'TERMINAL', terminalOutcome: 'BLOCKED' },
       stateVersion: 2,
     })
-    expect(Exit.isFailure(observed.conflict)).toBe(true)
-    expect(Exit.isFailure(observed.forgedDecision)).toBe(true)
-    if (Exit.isFailure(observed.forgedDecision)) {
-      expect(Cause.pretty(observed.forgedDecision.cause)).toContain(
-        'risk decision does not match its deterministic identity',
-      )
-    }
-    if (Exit.isFailure(observed.conflict)) {
-      expect(Cause.pretty(observed.conflict.cause)).toContain(
-        'deterministic intent identity was reused with different content',
-      )
-    }
+    expect(observed.forgedDecision).toMatchObject({
+      _tag: 'IntentStoreError',
+      failure: 'invariant',
+      operation: 'commit',
+      message: `risk decision ${'0'.repeat(64)} does not match deterministic identity ${decision.decisionId}`,
+      cause: {
+        _tag: 'RiskDecisionIdentityMismatch',
+        decisionId: '0'.repeat(64),
+        expectedDecisionId: decision.decisionId,
+      },
+    })
+    expect(observed.conflict).toMatchObject({
+      _tag: 'IntentStoreError',
+      failure: 'conflict',
+      operation: 'commit',
+      message: `deterministic intent identity ${intent.intentId} was reused with different content`,
+      cause: { _tag: 'ImmutableIntentMismatch', intentId: intent.intentId },
+    })
     expect(observed.counts).toEqual({ decisions: 1, intents: 1 })
   })
 
@@ -1205,7 +1230,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
       const observed = await execution.runPromise(
         Effect.gen(function* () {
           const before = yield* paperIntentEvidence
-          const staleCommit = yield* Effect.exit(
+          const staleCommit = yield* Effect.flip(
             Effect.flatMap(IntentStore, (store) => store.commit(staleIntent, staleDecision)),
           )
           const afterFailure = yield* paperIntentEvidence
@@ -1226,12 +1251,17 @@ describePostgres('PostgreSQL evaluation evidence', () => {
         decisionHash: staleIntent.decisionHash,
         symbol: staleIntent.symbol,
       })
-      expect(Exit.isFailure(observed.staleCommit)).toBe(true)
-      if (Exit.isFailure(observed.staleCommit)) {
-        expect(Cause.pretty(observed.staleCommit.cause)).toContain(
-          'PAPER intent does not match the current immutable authority-generation bindings',
-        )
-      }
+      expect(observed.staleCommit).toMatchObject({
+        _tag: 'IntentStoreError',
+        failure: 'invariant',
+        operation: 'commit',
+        message: 'intent does not bind the active PAPER generation',
+        cause: {
+          _tag: 'AuthorityGenerationMismatch',
+          observed: rotated.generationHash,
+          expected: originalGeneration.generationHash,
+        },
+      })
       expect(observed.afterFailure).toEqual(observed.before)
       expect(observed.currentCommit).toMatchObject({
         deduplicated: false,
@@ -1291,6 +1321,80 @@ describePostgres('PostgreSQL evaluation evidence', () => {
     }
   })
 
+  test('rejects first and incomplete commits under effective OBSERVE or an ACTIVE kill without content or xmin writes', async () => {
+    const generation = await activateAuditedPaperAuthority()
+    const commits = await Effect.runPromise(
+      Effect.forEach(
+        [
+          { cycleId: fixtureHash('effective-observe-first-commit'), state: 'first' },
+          { cycleId: fixtureHash('effective-observe-incomplete-commit'), state: 'incomplete' },
+          { cycleId: fixtureHash('active-kill-first-commit'), state: 'first' },
+          { cycleId: fixtureHash('active-kill-incomplete-commit'), state: 'incomplete' },
+        ] as const,
+        (fixture) =>
+          planForGeneration(intentPlan({ cycleId: fixture.cycleId }), generation.generationHash).pipe(
+            Effect.flatMap((intent) =>
+              riskDecision(intent, RiskOutcome.Approved).pipe(
+                Effect.map((decision) => ({ ...fixture, decision, intent })),
+              ),
+            ),
+          ),
+      ),
+    )
+    const authorityCases = [
+      {
+        killState: KillState.Clear,
+        expected: {
+          message: 'effective authority is not PAPER',
+          cause: { _tag: 'EffectiveAuthorityNotPaper', observed: Authority.Observe },
+        },
+        commits: commits.slice(0, 2),
+      },
+      {
+        killState: KillState.Active,
+        expected: {
+          message: 'PAPER authority kill is not CLEAR',
+          cause: { _tag: 'AuthorityKillNotClear', observed: KillState.Active },
+        },
+        commits: commits.slice(2),
+      },
+    ] as const
+    const execution = makeExecutionRuntime()
+    try {
+      const observed = await execution.runPromise(
+        Effect.forEach(authorityCases, (authorityCase) =>
+          Effect.gen(function* () {
+            yield* restrictIntentCommitAuthority(authorityCase.killState)
+            return yield* Effect.forEach(authorityCase.commits, (commitCase) =>
+              Effect.gen(function* () {
+                if (commitCase.state === 'incomplete') yield* seedPlannedIntent(commitCase.intent)
+                const before = yield* paperIntentEvidence
+                const error = yield* Effect.flip(
+                  Effect.flatMap(IntentStore, (store) => store.commit(commitCase.intent, commitCase.decision)),
+                )
+                const after = yield* paperIntentEvidence
+                return { after, before, error, expected: authorityCase.expected, state: commitCase.state }
+              }),
+            )
+          }),
+        ).pipe(Effect.map((results) => results.flat())),
+      )
+
+      expect(observed.map(({ state }) => state)).toEqual(['first', 'incomplete', 'first', 'incomplete'])
+      for (const result of observed) {
+        expect(result.error).toMatchObject({
+          _tag: 'IntentStoreError',
+          failure: 'invariant',
+          operation: 'commit',
+          ...result.expected,
+        })
+        expect(result.after).toEqual(result.before)
+      }
+    } finally {
+      await execution.dispose()
+    }
+  })
+
   test('rejects first-commit policy or strategy drift from the current authority generation without writes', async () => {
     const generation = await activateAuditedPaperAuthority()
     const variants = await Effect.runPromise(
@@ -1319,7 +1423,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
         const observed = await execution.runPromise(
           Effect.gen(function* () {
             const before = yield* paperIntentEvidence
-            const commit = yield* Effect.exit(
+            const commit = yield* Effect.flip(
               Effect.flatMap(IntentStore, (store) => store.commit(variant.intent, variant.decision)),
             )
             const after = yield* paperIntentEvidence
@@ -1327,12 +1431,29 @@ describePostgres('PostgreSQL evaluation evidence', () => {
           }),
         )
 
-        expect(Exit.isFailure(observed.commit)).toBe(true)
-        if (Exit.isFailure(observed.commit)) {
-          expect(Cause.pretty(observed.commit.cause)).toContain(
-            'PAPER intent does not match the current immutable authority-generation bindings',
-          )
-        }
+        const mismatch =
+          variant.intent.policyHash !== generation.riskPolicyHash
+            ? {
+                field: 'riskPolicyHash',
+                observed: generation.riskPolicyHash,
+                expected: variant.intent.policyHash,
+              }
+            : {
+                field: 'strategyName',
+                observed: generation.strategyName,
+                expected: variant.intent.strategyName,
+              }
+        expect(observed.commit).toMatchObject({
+          _tag: 'IntentStoreError',
+          failure: 'invariant',
+          operation: 'commit',
+          message: `active PAPER generation ${generation.generationHash} has mismatched ${mismatch.field}`,
+          cause: {
+            _tag: 'AuthorityGenerationHistoryMismatch',
+            generationHash: generation.generationHash,
+            ...mismatch,
+          },
+        })
         expect(observed.after).toEqual(observed.before)
       }
     } finally {
@@ -1341,7 +1462,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
   })
 
   test('rejects an intent whose generation history binds a different account without writing', async () => {
-    await activateAuditedPaperAuthority()
+    const generation = await activateAuditedPaperAuthority()
     const intent = await Effect.runPromise(
       plan(intentPlan({ accountId: 'paper-account-2', cycleId: fixtureHash('wrong-generation-account-cycle') })),
     )
@@ -1356,7 +1477,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
               (SELECT count(*)::integer FROM intents) AS intents,
               (SELECT count(*)::integer FROM risk_decisions) AS decisions
           `
-          const commit = yield* Effect.exit(Effect.flatMap(IntentStore, (store) => store.commit(intent, decision)))
+          const commit = yield* Effect.flip(Effect.flatMap(IntentStore, (store) => store.commit(intent, decision)))
           const after = yield* sql<{ decisions: number; intents: number }>`
             SELECT
               (SELECT count(*)::integer FROM intents) AS intents,
@@ -1366,12 +1487,19 @@ describePostgres('PostgreSQL evaluation evidence', () => {
         }),
       )
 
-      expect(Exit.isFailure(observed.commit)).toBe(true)
-      if (Exit.isFailure(observed.commit)) {
-        expect(Cause.pretty(observed.commit.cause)).toContain(
-          'PAPER intent does not match the current immutable authority-generation bindings',
-        )
-      }
+      expect(observed.commit).toMatchObject({
+        _tag: 'IntentStoreError',
+        failure: 'invariant',
+        operation: 'commit',
+        message: `active PAPER generation ${generation.generationHash} has mismatched accountId`,
+        cause: {
+          _tag: 'AuthorityGenerationHistoryMismatch',
+          generationHash: generation.generationHash,
+          field: 'accountId',
+          observed: generation.accountId,
+          expected: intent.accountId,
+        },
+      })
       expect(observed.after).toEqual(observed.before)
       expect(observed.after).toEqual({ decisions: 0, intents: 0 })
     } finally {

--- a/services/bayn/src/execution/coordinator.test.ts
+++ b/services/bayn/src/execution/coordinator.test.ts
@@ -191,7 +191,6 @@ const makeHarness = (options: HarnessOptions = {}) => {
 
   const intentStore: IntentStoreService = {
     commit: () => Effect.die(new Error('unexpected commit')),
-    markIoStarted: () => Effect.die(new Error('unexpected markIoStarted')),
     read: (id) => Effect.succeed(id === intentId ? Option.some(stored) : Option.none()),
   }
 

--- a/services/bayn/src/execution/intents.test.ts
+++ b/services/bayn/src/execution/intents.test.ts
@@ -1,9 +1,39 @@
+import assert from 'node:assert/strict'
+
 import { describe, expect, test } from 'bun:test'
 
-import { Effect, Exit } from 'effect'
+import { Effect, Exit, Result } from 'effect'
 
-import { Authority, IntentState, KillState, OrderSide, OrderType, TimeInForce } from '../paper'
-import { paperIntentIdForPlan, plan, planPaperIntent, type IntentPlan } from './intents'
+import {
+  Authority,
+  IntentState,
+  KillState,
+  OrderSide,
+  OrderType,
+  RiskOutcome,
+  TerminalOutcome,
+  TimeInForce,
+  type Intent,
+  type RiskDecision,
+} from '../paper'
+import {
+  classifyExistingCommit,
+  decodeAuthorityBindingRows,
+  decodeStoredIntentRows,
+  decideIntentInsert,
+  decideIntentTransition,
+  decideRiskCommit,
+  intentIdForPlan,
+  paperIntentIdForPlan,
+  plan,
+  planPaperIntent,
+  validateCommitIdentity,
+  validateCurrentAuthority,
+  type AuthorityBindingRow,
+  type IntentPlan,
+  type PreparedCommit,
+  type StoredIntent,
+} from './intents'
 
 const hash = (digit: string): string => digit.repeat(64)
 
@@ -34,6 +64,103 @@ const riskState = (generationHash = hash('a'), maximum = Authority.Paper) => ({
     updatedAt: '2026-07-22T09:59:00.000Z',
   },
 })
+
+const paperIntent: Intent = {
+  schemaVersion: 'bayn.paper-intent.v3',
+  authorityGenerationHash: hash('a'),
+  intentId: '6f3b7a528607ed8804f55c5fe23a0c47a4d6f72abf2bb9a41a69d93368d9c8ac',
+  strategyName: input.strategyName,
+  cycleId: input.cycleId,
+  decisionHash: input.decisionHash,
+  policyHash: input.policyHash,
+  accountId: input.accountId,
+  clientOrderId: 'b1_bzt6UoYH7YgE9Vxf4joMR6TW9yq_K7mkGmnZM2jZyKw',
+  symbol: input.symbol,
+  side: input.side,
+  orderType: input.orderType,
+  timeInForce: input.timeInForce,
+  quantityMicros: input.quantityMicros,
+  notionalLimitMicros: input.notionalLimitMicros,
+  state: IntentState.Planned,
+  createdAt: input.createdAt,
+}
+
+const approvedDecision: RiskDecision = {
+  schemaVersion: 'bayn.paper-risk-decision.v1',
+  decisionId: 'dfb3ec0a5fda18eb05a9869870039f694c18d3639907963ef26e5a9cafcd50cd',
+  inputHash: hash('d'),
+  intentId: paperIntent.intentId,
+  policyHash: paperIntent.policyHash,
+  outcome: RiskOutcome.Approved,
+  reasonCodes: [],
+  decidedAt: '2026-07-22T10:00:01.000Z',
+  expiresAt: '2026-07-22T10:05:01.000Z',
+}
+
+const preparedCommit = (): PreparedCommit => {
+  const prepared = validateCommitIdentity(paperIntent, approvedDecision)
+  assert(Result.isSuccess(prepared))
+  return prepared.success
+}
+
+const storedIntent = (
+  state: IntentState,
+  decision: RiskDecision | undefined,
+  terminalOutcome?: TerminalOutcome,
+): StoredIntent => ({
+  intent: {
+    ...paperIntent,
+    ...(decision === undefined ? {} : { riskDecisionId: decision.decisionId }),
+    state,
+    ...(terminalOutcome === undefined ? {} : { terminalOutcome }),
+  },
+  ...(decision === undefined ? {} : { decision }),
+  stateVersion: decision === undefined ? 1 : 2,
+  updatedAt: decision?.decidedAt ?? paperIntent.createdAt,
+})
+
+const authorityRow = (overrides: Partial<AuthorityBindingRow> = {}): AuthorityBindingRow => ({
+  maximum: Authority.Paper,
+  effective: Authority.Paper,
+  kill_state: KillState.Clear,
+  generation_hash: paperIntent.authorityGenerationHash,
+  generation_maximum: Authority.Paper,
+  generation_account_id: paperIntent.accountId,
+  generation_risk_policy_hash: paperIntent.policyHash,
+  generation_strategy_name: paperIntent.strategyName,
+  ...overrides,
+})
+
+const storedRow = {
+  schema_version: paperIntent.schemaVersion,
+  intent_id: paperIntent.intentId,
+  risk_decision_id: approvedDecision.decisionId,
+  authority_generation_hash: paperIntent.authorityGenerationHash,
+  strategy_name: paperIntent.strategyName,
+  cycle_id: paperIntent.cycleId,
+  decision_hash: paperIntent.decisionHash,
+  policy_hash: paperIntent.policyHash,
+  account_id: paperIntent.accountId,
+  client_order_id: paperIntent.clientOrderId,
+  symbol: paperIntent.symbol,
+  side: paperIntent.side,
+  order_type: paperIntent.orderType,
+  time_in_force: paperIntent.timeInForce,
+  quantity_micros: paperIntent.quantityMicros,
+  notional_limit_micros: paperIntent.notionalLimitMicros,
+  state: IntentState.Approved,
+  terminal_outcome: null,
+  state_version: 2,
+  created_at: paperIntent.createdAt,
+  updated_at: approvedDecision.decidedAt,
+  decision_id: approvedDecision.decisionId,
+  input_hash: approvedDecision.inputHash,
+  decision_policy_hash: approvedDecision.policyHash,
+  outcome: approvedDecision.outcome,
+  reason_codes: approvedDecision.reasonCodes,
+  decided_at: approvedDecision.decidedAt,
+  expires_at: approvedDecision.expiresAt,
+}
 
 describe('deterministic paper intents', () => {
   test('derives one stable full intent identity and Alpaca-bounded client order ID', async () => {
@@ -135,5 +262,147 @@ describe('deterministic paper intents', () => {
     const result = await Effect.runPromiseExit(planPaperIntent(input, riskState(hash('c'), Authority.Observe)))
 
     expect(Exit.isFailure(result)).toBe(true)
+  })
+})
+
+describe('pure intent commit decisions', () => {
+  test('validates exact golden intent and risk identities synchronously', () => {
+    const result = validateCommitIdentity(paperIntent, approvedDecision)
+
+    expect(Result.isSuccess(result)).toBe(true)
+    if (Result.isSuccess(result)) {
+      expect(result.success).toEqual({ _tag: 'PreparedCommit', intent: paperIntent, decision: approvedDecision })
+      expect(result.success.intent.intentId).toBe('6f3b7a528607ed8804f55c5fe23a0c47a4d6f72abf2bb9a41a69d93368d9c8ac')
+      expect(result.success.intent.clientOrderId).toBe('b1_bzt6UoYH7YgE9Vxf4joMR6TW9yq_K7mkGmnZM2jZyKw')
+      expect(result.success.decision.decisionId).toBe(
+        'dfb3ec0a5fda18eb05a9869870039f694c18d3639907963ef26e5a9cafcd50cd',
+      )
+    }
+  })
+
+  test('rejects malformed intent input through the exact decode failure without defecting', () => {
+    const result = validateCommitIdentity({ ...paperIntent, strategyName: 'invalid\ud800strategy' }, approvedDecision)
+
+    expect(Result.isFailure(result)).toBe(true)
+    if (Result.isFailure(result)) {
+      expect(result.failure._tag).toBe('IntentDecodeFailed')
+      if (result.failure._tag === 'IntentDecodeFailed') {
+        expect(String(result.failure.cause)).toContain('["strategyName"]')
+        expect(String(result.failure.cause)).toContain('well-formed Unicode')
+      }
+    }
+  })
+
+  test('totalizes the exported reference identity helper without changing its golden ID', () => {
+    const golden = intentIdForPlan(input)
+    const invalid = intentIdForPlan({ ...input, strategyName: 'invalid\ud800strategy' })
+
+    expect(golden).toMatchObject({
+      _tag: 'Success',
+      success: 'bbfe217b000266231ce1c29b8e3d447ad0e60903d287ee3e40a33aa964394fac',
+    })
+    expect(Result.isFailure(invalid)).toBe(true)
+    if (Result.isFailure(invalid)) {
+      expect(invalid.failure).toMatchObject({
+        _tag: 'CanonicalizationFailed',
+        material: { _tag: 'ReferenceIntentIdentity', strategyName: 'invalid\ud800strategy' },
+      })
+      expect(invalid.failure.cause).toBeInstanceOf(TypeError)
+    }
+  })
+
+  test('classifies insert, incomplete completion, and exact replay without mutation', () => {
+    const prepared = preparedCommit()
+    const insert = classifyExistingCommit([], prepared)
+    const incomplete = classifyExistingCommit([storedIntent(IntentState.Planned, undefined)], prepared)
+    const replay = classifyExistingCommit([storedIntent(IntentState.Approved, approvedDecision)], prepared)
+
+    expect(Result.isSuccess(insert) && insert.success._tag).toBe('InsertIntent')
+    expect(Result.isSuccess(incomplete) && incomplete.success._tag).toBe('CompleteIntent')
+    expect(Result.isSuccess(replay) && replay.success._tag).toBe('ExactReplay')
+    if (Result.isSuccess(replay) && replay.success._tag === 'ExactReplay') {
+      expect(replay.success.receipt.deduplicated).toBe(true)
+      expect(replay.success.receipt.record.intent.state).toBe(IntentState.Approved)
+    }
+  })
+
+  test('gives immutable conflict precedence over incomplete-state validation', () => {
+    const prepared = preparedCommit()
+    const result = classifyExistingCommit(
+      [
+        {
+          ...storedIntent(IntentState.Acknowledged, undefined),
+          intent: { ...paperIntent, accountId: 'paper-account-2', state: IntentState.Acknowledged },
+        },
+      ],
+      prepared,
+    )
+
+    expect(Result.isFailure(result) && result.failure._tag).toBe('ImmutableIntentMismatch')
+  })
+
+  test('requires PAPER maximum, PAPER effective authority, a clear kill, and exact generation history', () => {
+    const variants = [
+      authorityRow({ maximum: Authority.Observe }),
+      authorityRow({ effective: Authority.Observe }),
+      authorityRow({ kill_state: KillState.Active }),
+      authorityRow({ generation_hash: hash('b') }),
+      authorityRow({ generation_account_id: 'paper-account-2' }),
+      authorityRow({ generation_risk_policy_hash: hash('4') }),
+      authorityRow({ generation_strategy_name: 'another-strategy' }),
+    ]
+    const tags = variants.map((authority) => {
+      const result = validateCurrentAuthority([authority], paperIntent)
+      return Result.isFailure(result) ? result.failure._tag : 'Success'
+    })
+
+    expect(Result.isSuccess(validateCurrentAuthority([authorityRow()], paperIntent))).toBe(true)
+    expect(tags).toEqual([
+      'MaximumAuthorityNotPaper',
+      'EffectiveAuthorityNotPaper',
+      'AuthorityKillNotClear',
+      'AuthorityGenerationMismatch',
+      'AuthorityGenerationHistoryMismatch',
+      'AuthorityGenerationHistoryMismatch',
+      'AuthorityGenerationHistoryMismatch',
+    ])
+  })
+
+  test('strictly decodes database rows and rejects excess or malformed fields', () => {
+    const stored = decodeStoredIntentRows([storedRow])
+    const extraStored = decodeStoredIntentRows([{ ...storedRow, unexpected: true }])
+    const malformedStored = decodeStoredIntentRows([{ ...storedRow, state_version: 0 }])
+    const authority = decodeAuthorityBindingRows([authorityRow()])
+    const extraAuthority = decodeAuthorityBindingRows([{ ...authorityRow(), unexpected: true }])
+
+    expect(Result.isSuccess(stored)).toBe(true)
+    expect(Result.isFailure(extraStored)).toBe(true)
+    expect(Result.isFailure(malformedStored)).toBe(true)
+    expect(Result.isSuccess(authority)).toBe(true)
+    expect(Result.isFailure(extraAuthority)).toBe(true)
+  })
+
+  test('totalizes insert, decision, and transition RETURNING dispositions', () => {
+    expect(decideIntentInsert([], paperIntent.intentId)).toMatchObject({
+      _tag: 'Success',
+      success: { _tag: 'IntentInsertConflict', intentId: paperIntent.intentId },
+    })
+    expect(decideIntentInsert([{ intent_id: paperIntent.intentId }], paperIntent.intentId)).toMatchObject({
+      _tag: 'Success',
+      success: { _tag: 'IntentInserted', intentId: paperIntent.intentId },
+    })
+    expect(decideRiskCommit([{ decision_id: approvedDecision.decisionId }], approvedDecision.decisionId)).toMatchObject(
+      {
+        _tag: 'Success',
+        success: { _tag: 'RiskDecisionInserted', decisionId: approvedDecision.decisionId },
+      },
+    )
+    expect(decideIntentTransition([{ intent_id: paperIntent.intentId }], paperIntent.intentId)).toMatchObject({
+      _tag: 'Success',
+      success: { _tag: 'IntentTransitioned', intentId: paperIntent.intentId },
+    })
+    expect(Result.isFailure(decideRiskCommit([], approvedDecision.decisionId))).toBe(true)
+    expect(Result.isFailure(decideIntentTransition([{ intent_id: hash('f') }], paperIntent.intentId))).toBe(true)
+    expect(Result.isFailure(decideIntentInsert([{ intent_id: 'invalid' }], paperIntent.intentId))).toBe(true)
   })
 })

--- a/services/bayn/src/execution/intents.ts
+++ b/services/bayn/src/execution/intents.ts
@@ -1,20 +1,20 @@
 import { Buffer } from 'node:buffer'
 
 import { PgClient } from '@effect/sql-pg'
-import { Context, Data, Effect, Layer, Option, Schema } from 'effect'
+import { Context, Data, Effect, Layer, Option, Result, Schema } from 'effect'
+import { isSqlError } from 'effect/unstable/sql/SqlError'
 import type { Fragment } from 'effect/unstable/sql/Statement'
 
 import { canonicalHashV1 } from '../hash'
 import {
   Authority,
-  decodeIntent,
-  decodeReferenceIntent,
-  decodeRiskDecision,
   IntentSchema,
   IntentState,
+  KillState,
   OrderSide,
   OrderType,
   PositiveMicrosSchema,
+  ReferenceIntentSchema,
   RiskDecisionSchema,
   RiskOutcome,
   TerminalOutcome,
@@ -50,10 +50,49 @@ export const IntentPlanSchema = Schema.Struct({
 })
 export type IntentPlan = typeof IntentPlanSchema.Type
 
-const decodePlan = Schema.decodeUnknownEffect(IntentPlanSchema, strictParseOptions)
-const decodeAuthorityGenerationHash = Schema.decodeUnknownEffect(Sha256, strictParseOptions)
+const decodePlanResult = Schema.decodeUnknownResult(IntentPlanSchema, strictParseOptions)
+const decodeAuthorityGenerationHashResult = Schema.decodeUnknownResult(Sha256, strictParseOptions)
+const decodeIntentResult = Schema.decodeUnknownResult(IntentSchema, strictParseOptions)
+const decodeRiskDecisionResult = Schema.decodeUnknownResult(RiskDecisionSchema, strictParseOptions)
+const decodeIntentIdResult = Schema.decodeUnknownResult(Sha256, strictParseOptions)
 const intentEquivalent = Schema.toEquivalence(IntentSchema)
 const decisionEquivalent = Schema.toEquivalence(RiskDecisionSchema)
+
+export type IntentCanonicalMaterial =
+  | {
+      readonly _tag: 'ReferenceIntentIdentity'
+      readonly strategyName: string
+      readonly cycleId: string
+      readonly decisionHash: string
+      readonly accountId: string
+      readonly symbol: string
+    }
+  | {
+      readonly _tag: 'PaperIntentIdentity'
+      readonly authorityGenerationHash: string
+      readonly strategyName: string
+      readonly cycleId: string
+      readonly decisionHash: string
+      readonly accountId: string
+      readonly symbol: string
+    }
+  | { readonly _tag: 'ImmutableIntentContent'; readonly intentId: string }
+  | { readonly _tag: 'RiskDecisionIdentity'; readonly decisionId: string; readonly intentId: string }
+
+export interface IntentCanonicalizationFailure {
+  readonly _tag: 'CanonicalizationFailed'
+  readonly material: IntentCanonicalMaterial
+  readonly cause: unknown
+}
+
+const canonicalHashResult = (
+  material: IntentCanonicalMaterial,
+  value: unknown,
+): Result.Result<string, IntentCanonicalizationFailure> =>
+  Result.try({
+    try: () => canonicalHashV1(value),
+    catch: (cause): IntentCanonicalizationFailure => ({ _tag: 'CanonicalizationFailed', material, cause }),
+  })
 
 const referenceIdentityMaterial = (input: IntentPlan) => ({
   schemaVersion: 'bayn.paper-intent-identity.v1',
@@ -84,88 +123,164 @@ const paperIdentityMaterial = (input: IntentPlan, authorityGenerationHash: strin
   notionalLimitMicros: input.notionalLimitMicros,
 })
 
-const paperIntentId = (input: IntentPlan, authorityGenerationHash: string): string =>
-  canonicalHashV1(paperIdentityMaterial(input, authorityGenerationHash))
-
-export const intentIdForPlan = (input: IntentPlan): string => canonicalHashV1(referenceIdentityMaterial(input))
-
-export const paperIntentIdForPlan = (input: unknown, authorityGenerationHash: string) =>
-  Effect.all([decodePlan(input), decodeAuthorityGenerationHash(authorityGenerationHash)]).pipe(
-    Effect.map(([decoded, generationHash]) => paperIntentId(decoded, generationHash)),
+const referenceIntentIdResult = (input: IntentPlan): Result.Result<string, IntentCanonicalizationFailure> =>
+  canonicalHashResult(
+    {
+      _tag: 'ReferenceIntentIdentity',
+      strategyName: input.strategyName,
+      cycleId: input.cycleId,
+      decisionHash: input.decisionHash,
+      accountId: input.accountId,
+      symbol: input.symbol,
+    },
+    referenceIdentityMaterial(input),
   )
+
+const paperIntentIdResult = (
+  input: IntentPlan,
+  authorityGenerationHash: string,
+): Result.Result<string, IntentCanonicalizationFailure> =>
+  canonicalHashResult(
+    {
+      _tag: 'PaperIntentIdentity',
+      authorityGenerationHash,
+      strategyName: input.strategyName,
+      cycleId: input.cycleId,
+      decisionHash: input.decisionHash,
+      accountId: input.accountId,
+      symbol: input.symbol,
+    },
+    paperIdentityMaterial(input, authorityGenerationHash),
+  )
+
+export const intentIdForPlan = referenceIntentIdResult
 
 const clientOrderId = (intentId: string): string => `b1_${Buffer.from(intentId, 'hex').toString('base64url')}`
 
-const makeReferenceIntent = (decoded: IntentPlan): Effect.Effect<ReferenceIntent, Schema.SchemaError> => {
-  const intentId = intentIdForPlan(decoded)
-  return decodeReferenceIntent({
-    schemaVersion: 'bayn.paper-intent.v2',
-    intentId,
-    strategyName: decoded.strategyName,
-    cycleId: decoded.cycleId,
-    decisionHash: decoded.decisionHash,
-    policyHash: decoded.policyHash,
-    accountId: decoded.accountId,
-    clientOrderId: clientOrderId(intentId),
-    symbol: decoded.symbol,
-    side: decoded.side,
-    orderType: decoded.orderType,
-    timeInForce: decoded.timeInForce,
-    quantityMicros: decoded.quantityMicros,
-    notionalLimitMicros: decoded.notionalLimitMicros,
-    state: IntentState.Planned,
-    createdAt: decoded.createdAt,
-  })
+type IntentConstructionFailure =
+  | IntentCanonicalizationFailure
+  | {
+      readonly _tag: 'ConstructedIntentDecodeFailed'
+      readonly intentKind: 'reference' | 'paper'
+      readonly cause: unknown
+    }
+
+const makeReferenceIntentResult = (decoded: IntentPlan): Result.Result<ReferenceIntent, IntentConstructionFailure> => {
+  const intentId = referenceIntentIdResult(decoded)
+  if (Result.isFailure(intentId)) return Result.fail(intentId.failure)
+  return Result.mapError(
+    Schema.decodeUnknownResult(
+      ReferenceIntentSchema,
+      strictParseOptions,
+    )({
+      schemaVersion: 'bayn.paper-intent.v2',
+      intentId: intentId.success,
+      strategyName: decoded.strategyName,
+      cycleId: decoded.cycleId,
+      decisionHash: decoded.decisionHash,
+      policyHash: decoded.policyHash,
+      accountId: decoded.accountId,
+      clientOrderId: clientOrderId(intentId.success),
+      symbol: decoded.symbol,
+      side: decoded.side,
+      orderType: decoded.orderType,
+      timeInForce: decoded.timeInForce,
+      quantityMicros: decoded.quantityMicros,
+      notionalLimitMicros: decoded.notionalLimitMicros,
+      state: IntentState.Planned,
+      createdAt: decoded.createdAt,
+    }),
+    (cause): IntentConstructionFailure => ({ _tag: 'ConstructedIntentDecodeFailed', intentKind: 'reference', cause }),
+  )
 }
 
-const makePaperIntent = (
+const makePaperIntentResult = (
   decoded: IntentPlan,
   authorityGenerationHash: string,
-): Effect.Effect<Intent, Schema.SchemaError> => {
-  const intentId = paperIntentId(decoded, authorityGenerationHash)
-  return decodeIntent({
-    schemaVersion: 'bayn.paper-intent.v3',
-    authorityGenerationHash,
-    intentId,
-    strategyName: decoded.strategyName,
-    cycleId: decoded.cycleId,
-    decisionHash: decoded.decisionHash,
-    policyHash: decoded.policyHash,
-    accountId: decoded.accountId,
-    clientOrderId: clientOrderId(intentId),
-    symbol: decoded.symbol,
-    side: decoded.side,
-    orderType: decoded.orderType,
-    timeInForce: decoded.timeInForce,
-    quantityMicros: decoded.quantityMicros,
-    notionalLimitMicros: decoded.notionalLimitMicros,
-    state: IntentState.Planned,
-    createdAt: decoded.createdAt,
-  })
+): Result.Result<Intent, IntentConstructionFailure> => {
+  const intentId = paperIntentIdResult(decoded, authorityGenerationHash)
+  if (Result.isFailure(intentId)) return Result.fail(intentId.failure)
+  return Result.mapError(
+    decodeIntentResult({
+      schemaVersion: 'bayn.paper-intent.v3',
+      authorityGenerationHash,
+      intentId: intentId.success,
+      strategyName: decoded.strategyName,
+      cycleId: decoded.cycleId,
+      decisionHash: decoded.decisionHash,
+      policyHash: decoded.policyHash,
+      accountId: decoded.accountId,
+      clientOrderId: clientOrderId(intentId.success),
+      symbol: decoded.symbol,
+      side: decoded.side,
+      orderType: decoded.orderType,
+      timeInForce: decoded.timeInForce,
+      quantityMicros: decoded.quantityMicros,
+      notionalLimitMicros: decoded.notionalLimitMicros,
+      state: IntentState.Planned,
+      createdAt: decoded.createdAt,
+    }),
+    (cause): IntentConstructionFailure => ({ _tag: 'ConstructedIntentDecodeFailed', intentKind: 'paper', cause }),
+  )
 }
 
-export const plan = (input: unknown) => decodePlan(input).pipe(Effect.flatMap(makeReferenceIntent))
+export type IntentPlanningFailure =
+  | { readonly _tag: 'IntentPlanDecodeFailed'; readonly cause: unknown }
+  | { readonly _tag: 'AuthorityGenerationHashDecodeFailed'; readonly cause: unknown }
+  | IntentConstructionFailure
+
+const decodePlanForPlanning = (input: unknown): Result.Result<IntentPlan, IntentPlanningFailure> =>
+  Result.mapError(
+    decodePlanResult(input),
+    (cause): IntentPlanningFailure => ({ _tag: 'IntentPlanDecodeFailed', cause }),
+  )
+
+export const plan = (input: unknown): Effect.Effect<ReferenceIntent, IntentPlanningFailure> => {
+  const decoded = decodePlanForPlanning(input)
+  return Effect.fromResult(Result.flatMap(decoded, makeReferenceIntentResult))
+}
+
+export const paperIntentIdForPlan = (
+  input: unknown,
+  authorityGenerationHash: string,
+): Effect.Effect<string, IntentPlanningFailure> => {
+  const decoded = decodePlanForPlanning(input)
+  const generation = Result.mapError(
+    decodeAuthorityGenerationHashResult(authorityGenerationHash),
+    (cause): IntentPlanningFailure => ({ _tag: 'AuthorityGenerationHashDecodeFailed', cause }),
+  )
+  return Effect.fromResult(
+    Result.flatMap(decoded, (intentPlan) =>
+      Result.flatMap(generation, (generationHash) => paperIntentIdResult(intentPlan, generationHash)),
+    ),
+  )
+}
 
 export class PaperIntentBindingError extends Data.TaggedError('PaperIntentBindingError')<{
   readonly message: string
 }> {}
 
-export const planPaperIntent = (input: unknown, state: Pick<State, 'authority'>) =>
-  Effect.gen(function* () {
-    const decoded = yield* decodePlan(input)
-    if (state.authority.maximum !== Authority.Paper) {
-      return yield* Effect.fail(
-        new PaperIntentBindingError({
-          message: 'a durable PAPER intent requires a PAPER authority generation from risk state',
-        }),
-      )
-    }
-    return yield* makePaperIntent(decoded, state.authority.generationHash)
-  })
+export const planPaperIntent = (
+  input: unknown,
+  state: Pick<State, 'authority'>,
+): Effect.Effect<Intent, IntentPlanningFailure | PaperIntentBindingError> => {
+  if (state.authority.maximum !== Authority.Paper) {
+    return Effect.fail(
+      new PaperIntentBindingError({
+        message: 'a durable PAPER intent requires a PAPER authority generation from risk state',
+      }),
+    )
+  }
+  return Effect.fromResult(
+    Result.flatMap(decodePlanForPlanning(input), (decoded) =>
+      makePaperIntentResult(decoded, state.authority.generationHash),
+    ),
+  )
+}
 
 export class IntentStoreError extends Data.TaggedError('IntentStoreError')<{
   readonly failure: 'conflict' | 'decode' | 'invariant' | 'query'
-  readonly operation: 'commit' | 'mark-io-started' | 'read'
+  readonly operation: 'commit' | 'read'
   readonly message: string
   readonly cause?: unknown
 }> {}
@@ -186,10 +301,6 @@ export interface IntentStoreService {
   readonly commit: (
     intent: Intent,
     decision: RiskDecision,
-  ) => Effect.Effect<IntentReceipt, IntentStoreError | WriterFenceError>
-  readonly markIoStarted: (
-    intentId: string,
-    updatedAt: string,
   ) => Effect.Effect<IntentReceipt, IntentStoreError | WriterFenceError>
   readonly read: (intentId: string) => Effect.Effect<Option.Option<StoredIntent>, IntentStoreError>
 }
@@ -242,9 +353,410 @@ const WithDecisionRow = Schema.Struct({
 })
 const StoredRow = Schema.Union([WithoutDecisionRow, WithDecisionRow])
 type StoredRow = typeof StoredRow.Type
-const decodeRows = Schema.decodeUnknownEffect(Schema.Array(StoredRow), strictParseOptions)
-const decodeIntentId = Schema.decodeUnknownEffect(Sha256)
-const decodeUpdatedAt = Schema.decodeUnknownEffect(UtcInstant)
+const decodeStoredRowsResult = Schema.decodeUnknownResult(Schema.Array(StoredRow), strictParseOptions)
+
+const AuthorityBindingRow = Schema.Struct({
+  maximum: Schema.Enum(Authority),
+  effective: Schema.Enum(Authority),
+  kill_state: Schema.Enum(KillState),
+  generation_hash: Sha256,
+  generation_maximum: Schema.NullOr(Schema.Enum(Authority)),
+  generation_account_id: Schema.NullOr(NonEmptyString),
+  generation_risk_policy_hash: Schema.NullOr(Sha256),
+  generation_strategy_name: Schema.NullOr(NonEmptyString),
+})
+export type AuthorityBindingRow = typeof AuthorityBindingRow.Type
+const decodeAuthorityBindingRowsResult = Schema.decodeUnknownResult(
+  Schema.Array(AuthorityBindingRow),
+  strictParseOptions,
+)
+
+const IntentReturningRow = Schema.Struct({ intent_id: Sha256 })
+const DecisionReturningRow = Schema.Struct({ decision_id: Sha256 })
+const decodeIntentReturningRowsResult = Schema.decodeUnknownResult(Schema.Array(IntentReturningRow), strictParseOptions)
+const decodeDecisionReturningRowsResult = Schema.decodeUnknownResult(
+  Schema.Array(DecisionReturningRow),
+  strictParseOptions,
+)
+
+export type StoredRowsFailure =
+  | { readonly _tag: 'StoredRowsDecodeFailed'; readonly cause: unknown }
+  | { readonly _tag: 'StoredIntentDecodeFailed'; readonly intentId: string; readonly cause: unknown }
+  | { readonly _tag: 'StoredRiskDecisionDecodeFailed'; readonly intentId: string; readonly cause: unknown }
+
+const storedRowToRecord = (row: StoredRow): Result.Result<StoredIntent, StoredRowsFailure> => {
+  const intent = decodeIntentResult({
+    schemaVersion: row.schema_version,
+    intentId: row.intent_id,
+    ...(row.risk_decision_id === null ? {} : { riskDecisionId: row.risk_decision_id }),
+    authorityGenerationHash: row.authority_generation_hash,
+    strategyName: row.strategy_name,
+    cycleId: row.cycle_id,
+    decisionHash: row.decision_hash,
+    policyHash: row.policy_hash,
+    accountId: row.account_id,
+    clientOrderId: row.client_order_id,
+    symbol: row.symbol,
+    side: row.side,
+    orderType: row.order_type,
+    timeInForce: row.time_in_force,
+    quantityMicros: row.quantity_micros,
+    notionalLimitMicros: row.notional_limit_micros,
+    state: row.state,
+    ...(row.terminal_outcome === null ? {} : { terminalOutcome: row.terminal_outcome }),
+    createdAt: row.created_at,
+  })
+  if (Result.isFailure(intent)) {
+    return Result.fail({ _tag: 'StoredIntentDecodeFailed', intentId: row.intent_id, cause: intent.failure })
+  }
+  if (row.decision_id === null) {
+    return Result.succeed({
+      intent: intent.success,
+      stateVersion: row.state_version,
+      updatedAt: row.updated_at,
+    })
+  }
+  const decision = decodeRiskDecisionResult({
+    schemaVersion: 'bayn.paper-risk-decision.v1',
+    decisionId: row.decision_id,
+    inputHash: row.input_hash,
+    intentId: row.intent_id,
+    policyHash: row.decision_policy_hash,
+    outcome: row.outcome,
+    reasonCodes: row.reason_codes,
+    decidedAt: row.decided_at,
+    expiresAt: row.expires_at,
+  })
+  if (Result.isFailure(decision)) {
+    return Result.fail({ _tag: 'StoredRiskDecisionDecodeFailed', intentId: row.intent_id, cause: decision.failure })
+  }
+  return Result.succeed({
+    intent: intent.success,
+    decision: decision.success,
+    stateVersion: row.state_version,
+    updatedAt: row.updated_at,
+  })
+}
+
+export const decodeStoredIntentRows = (rows: unknown): Result.Result<readonly StoredIntent[], StoredRowsFailure> => {
+  const decoded = decodeStoredRowsResult(rows)
+  if (Result.isFailure(decoded)) return Result.fail({ _tag: 'StoredRowsDecodeFailed', cause: decoded.failure })
+  return Result.all(decoded.success.map(storedRowToRecord))
+}
+
+export type CommitMaterialFailure =
+  | { readonly _tag: 'IntentDecodeFailed'; readonly cause: unknown }
+  | { readonly _tag: 'RiskDecisionDecodeFailed'; readonly cause: unknown }
+  | IntentConstructionFailure
+  | { readonly _tag: 'IntentIdentityMismatch'; readonly intentId: string }
+  | IntentCanonicalizationFailure
+  | { readonly _tag: 'RiskDecisionIdentityMismatch'; readonly decisionId: string; readonly expectedDecisionId: string }
+  | {
+      readonly _tag: 'RiskDecisionBindingMismatch'
+      readonly intentId: string
+      readonly decisionIntentId: string
+      readonly policyHash: string
+      readonly decisionPolicyHash: string
+    }
+
+export interface PreparedCommit {
+  readonly _tag: 'PreparedCommit'
+  readonly intent: Intent
+  readonly decision: RiskDecision
+}
+
+const planFromIntent = (intent: Intent): IntentPlan => ({
+  schemaVersion: 'bayn.paper-intent-plan.v1',
+  strategyName: intent.strategyName,
+  cycleId: intent.cycleId,
+  decisionHash: intent.decisionHash,
+  policyHash: intent.policyHash,
+  accountId: intent.accountId,
+  symbol: intent.symbol,
+  side: intent.side,
+  orderType: intent.orderType,
+  timeInForce: intent.timeInForce,
+  quantityMicros: intent.quantityMicros,
+  notionalLimitMicros: intent.notionalLimitMicros,
+  createdAt: intent.createdAt,
+})
+
+export const validateCommitIdentity = (
+  inputIntent: unknown,
+  inputDecision: unknown,
+): Result.Result<PreparedCommit, CommitMaterialFailure> => {
+  const intent = decodeIntentResult(inputIntent)
+  if (Result.isFailure(intent)) return Result.fail({ _tag: 'IntentDecodeFailed', cause: intent.failure })
+  const expectedIntent = makePaperIntentResult(planFromIntent(intent.success), intent.success.authorityGenerationHash)
+  if (Result.isFailure(expectedIntent)) return Result.fail(expectedIntent.failure)
+  if (!intentEquivalent(intent.success, expectedIntent.success)) {
+    return Result.fail({ _tag: 'IntentIdentityMismatch', intentId: intent.success.intentId })
+  }
+
+  const decision = decodeRiskDecisionResult(inputDecision)
+  if (Result.isFailure(decision)) return Result.fail({ _tag: 'RiskDecisionDecodeFailed', cause: decision.failure })
+  const { decisionId, ...decisionMaterial } = decision.success
+  const expectedDecisionId = canonicalHashResult(
+    { _tag: 'RiskDecisionIdentity', decisionId, intentId: decision.success.intentId },
+    decisionMaterial,
+  )
+  if (Result.isFailure(expectedDecisionId)) return Result.fail(expectedDecisionId.failure)
+  if (decisionId !== expectedDecisionId.success) {
+    return Result.fail({
+      _tag: 'RiskDecisionIdentityMismatch',
+      decisionId,
+      expectedDecisionId: expectedDecisionId.success,
+    })
+  }
+  if (
+    decision.success.intentId !== intent.success.intentId ||
+    decision.success.policyHash !== intent.success.policyHash
+  ) {
+    return Result.fail({
+      _tag: 'RiskDecisionBindingMismatch',
+      intentId: intent.success.intentId,
+      decisionIntentId: decision.success.intentId,
+      policyHash: intent.success.policyHash,
+      decisionPolicyHash: decision.success.policyHash,
+    })
+  }
+  return Result.succeed({ _tag: 'PreparedCommit', intent: intent.success, decision: decision.success })
+}
+
+const immutableIntentMaterial = (intent: Intent) => ({
+  schemaVersion: intent.schemaVersion,
+  intentId: intent.intentId,
+  authorityGenerationHash: intent.authorityGenerationHash,
+  strategyName: intent.strategyName,
+  cycleId: intent.cycleId,
+  decisionHash: intent.decisionHash,
+  policyHash: intent.policyHash,
+  accountId: intent.accountId,
+  clientOrderId: intent.clientOrderId,
+  symbol: intent.symbol,
+  side: intent.side,
+  orderType: intent.orderType,
+  timeInForce: intent.timeInForce,
+  quantityMicros: intent.quantityMicros,
+  notionalLimitMicros: intent.notionalLimitMicros,
+  createdAt: intent.createdAt,
+})
+
+const immutableIntentHashResult = (intent: Intent): Result.Result<string, IntentCanonicalizationFailure> =>
+  canonicalHashResult({ _tag: 'ImmutableIntentContent', intentId: intent.intentId }, immutableIntentMaterial(intent))
+
+export type ExistingCommitFailure =
+  | IntentCanonicalizationFailure
+  | { readonly _tag: 'MultipleIntentConflicts'; readonly count: number }
+  | { readonly _tag: 'ImmutableIntentMismatch'; readonly intentId: string }
+  | { readonly _tag: 'StoredDecisionMismatch'; readonly intentId: string; readonly decisionId: string }
+  | {
+      readonly _tag: 'IncompleteIntentState'
+      readonly intentId: string
+      readonly state: IntentState
+      readonly riskDecisionId?: string
+    }
+
+export type ExistingCommitDisposition =
+  | { readonly _tag: 'InsertIntent' }
+  | { readonly _tag: 'CompleteIntent'; readonly record: StoredIntent }
+  | { readonly _tag: 'ExactReplay'; readonly receipt: IntentReceipt }
+
+const decisionStateMatches = (record: StoredIntent, decision: RiskDecision): boolean =>
+  decision.outcome === RiskOutcome.Approved
+    ? record.intent.state !== IntentState.Planned
+    : record.intent.state === IntentState.Terminal && record.intent.terminalOutcome === TerminalOutcome.Blocked
+
+export const classifyExistingCommit = (
+  records: readonly StoredIntent[],
+  prepared: PreparedCommit,
+): Result.Result<ExistingCommitDisposition, ExistingCommitFailure> => {
+  if (records.length === 0) return Result.succeed({ _tag: 'InsertIntent' })
+  if (records.length > 1) return Result.fail({ _tag: 'MultipleIntentConflicts', count: records.length })
+  const record = records[0]
+  const storedHash = immutableIntentHashResult(record.intent)
+  if (Result.isFailure(storedHash)) return Result.fail(storedHash.failure)
+  const requestedHash = immutableIntentHashResult(prepared.intent)
+  if (Result.isFailure(requestedHash)) return Result.fail(requestedHash.failure)
+  if (storedHash.success !== requestedHash.success) {
+    return Result.fail({ _tag: 'ImmutableIntentMismatch', intentId: prepared.intent.intentId })
+  }
+  if (record.decision !== undefined) {
+    if (
+      !decisionEquivalent(record.decision, prepared.decision) ||
+      record.intent.riskDecisionId !== prepared.decision.decisionId ||
+      !decisionStateMatches(record, prepared.decision)
+    ) {
+      return Result.fail({
+        _tag: 'StoredDecisionMismatch',
+        intentId: prepared.intent.intentId,
+        decisionId: prepared.decision.decisionId,
+      })
+    }
+    return Result.succeed({
+      _tag: 'ExactReplay',
+      receipt: { record, deduplicated: true },
+    })
+  }
+  if (record.intent.state !== IntentState.Planned || record.intent.riskDecisionId !== undefined) {
+    return Result.fail({
+      _tag: 'IncompleteIntentState',
+      intentId: prepared.intent.intentId,
+      state: record.intent.state,
+      ...(record.intent.riskDecisionId === undefined ? {} : { riskDecisionId: record.intent.riskDecisionId }),
+    })
+  }
+  return Result.succeed({ _tag: 'CompleteIntent', record })
+}
+
+export type AuthorityBindingFailure =
+  | { readonly _tag: 'AuthorityMissing' }
+  | { readonly _tag: 'MultipleAuthorityRows'; readonly count: number }
+  | { readonly _tag: 'MaximumAuthorityNotPaper'; readonly observed: Authority }
+  | { readonly _tag: 'EffectiveAuthorityNotPaper'; readonly observed: Authority }
+  | { readonly _tag: 'AuthorityKillNotClear'; readonly observed: KillState }
+  | { readonly _tag: 'AuthorityGenerationMismatch'; readonly observed: string; readonly expected: string }
+  | {
+      readonly _tag: 'AuthorityGenerationHistoryMismatch'
+      readonly generationHash: string
+      readonly field: 'maximum' | 'accountId' | 'riskPolicyHash' | 'strategyName'
+      readonly observed: string | null
+      readonly expected: string
+    }
+
+export const decodeAuthorityBindingRows = (
+  rows: unknown,
+): Result.Result<
+  readonly AuthorityBindingRow[],
+  { readonly _tag: 'AuthorityRowsDecodeFailed'; readonly cause: unknown }
+> =>
+  Result.mapError(decodeAuthorityBindingRowsResult(rows), (cause) => ({
+    _tag: 'AuthorityRowsDecodeFailed' as const,
+    cause,
+  }))
+
+export const validateCurrentAuthority = (
+  rows: readonly AuthorityBindingRow[],
+  intent: Intent,
+): Result.Result<
+  { readonly _tag: 'CurrentPaperAuthority'; readonly binding: AuthorityBindingRow },
+  AuthorityBindingFailure
+> => {
+  if (rows.length === 0) return Result.fail({ _tag: 'AuthorityMissing' })
+  if (rows.length > 1) return Result.fail({ _tag: 'MultipleAuthorityRows', count: rows.length })
+  const authority = rows[0]
+  if (authority.maximum !== Authority.Paper) {
+    return Result.fail({ _tag: 'MaximumAuthorityNotPaper', observed: authority.maximum })
+  }
+  if (authority.kill_state !== KillState.Clear) {
+    return Result.fail({ _tag: 'AuthorityKillNotClear', observed: authority.kill_state })
+  }
+  if (authority.effective !== Authority.Paper) {
+    return Result.fail({ _tag: 'EffectiveAuthorityNotPaper', observed: authority.effective })
+  }
+  if (authority.generation_hash !== intent.authorityGenerationHash) {
+    return Result.fail({
+      _tag: 'AuthorityGenerationMismatch',
+      observed: authority.generation_hash,
+      expected: intent.authorityGenerationHash,
+    })
+  }
+  const generationFields = [
+    ['maximum', authority.generation_maximum, Authority.Paper],
+    ['accountId', authority.generation_account_id, intent.accountId],
+    ['riskPolicyHash', authority.generation_risk_policy_hash, intent.policyHash],
+    ['strategyName', authority.generation_strategy_name, intent.strategyName],
+  ] as const
+  const mismatch = generationFields.find(([, observed, expected]) => observed !== expected)
+  if (mismatch !== undefined) {
+    const [field, observed, expected] = mismatch
+    return Result.fail({
+      _tag: 'AuthorityGenerationHistoryMismatch',
+      generationHash: authority.generation_hash,
+      field,
+      observed,
+      expected,
+    })
+  }
+  return Result.succeed({ _tag: 'CurrentPaperAuthority', binding: authority })
+}
+
+export type WriteDispositionFailure =
+  | {
+      readonly _tag: 'ReturningRowsDecodeFailed'
+      readonly write: 'intent' | 'decision' | 'transition'
+      readonly cause: unknown
+    }
+  | {
+      readonly _tag: 'UnexpectedReturningRows'
+      readonly write: 'intent' | 'decision' | 'transition'
+      readonly expectedId: string
+      readonly observedIds: readonly string[]
+    }
+
+export type IntentInsertDisposition =
+  | { readonly _tag: 'IntentInserted'; readonly intentId: string }
+  | { readonly _tag: 'IntentInsertConflict'; readonly intentId: string }
+
+export const decideIntentInsert = (
+  rows: unknown,
+  expectedIntentId: string,
+): Result.Result<IntentInsertDisposition, WriteDispositionFailure> => {
+  const decoded = decodeIntentReturningRowsResult(rows)
+  if (Result.isFailure(decoded)) {
+    return Result.fail({ _tag: 'ReturningRowsDecodeFailed', write: 'intent', cause: decoded.failure })
+  }
+  if (decoded.success.length === 0) {
+    return Result.succeed({ _tag: 'IntentInsertConflict', intentId: expectedIntentId })
+  }
+  if (decoded.success.length === 1 && decoded.success[0].intent_id === expectedIntentId) {
+    return Result.succeed({ _tag: 'IntentInserted', intentId: expectedIntentId })
+  }
+  return Result.fail({
+    _tag: 'UnexpectedReturningRows',
+    write: 'intent',
+    expectedId: expectedIntentId,
+    observedIds: decoded.success.map((row) => row.intent_id),
+  })
+}
+
+export const decideRiskCommit = (
+  rows: unknown,
+  expectedDecisionId: string,
+): Result.Result<{ readonly _tag: 'RiskDecisionInserted'; readonly decisionId: string }, WriteDispositionFailure> => {
+  const decoded = decodeDecisionReturningRowsResult(rows)
+  if (Result.isFailure(decoded)) {
+    return Result.fail({ _tag: 'ReturningRowsDecodeFailed', write: 'decision', cause: decoded.failure })
+  }
+  if (decoded.success.length === 1 && decoded.success[0].decision_id === expectedDecisionId) {
+    return Result.succeed({ _tag: 'RiskDecisionInserted', decisionId: expectedDecisionId })
+  }
+  return Result.fail({
+    _tag: 'UnexpectedReturningRows',
+    write: 'decision',
+    expectedId: expectedDecisionId,
+    observedIds: decoded.success.map((row) => row.decision_id),
+  })
+}
+
+export const decideIntentTransition = (
+  rows: unknown,
+  expectedIntentId: string,
+): Result.Result<{ readonly _tag: 'IntentTransitioned'; readonly intentId: string }, WriteDispositionFailure> => {
+  const decoded = decodeIntentReturningRowsResult(rows)
+  if (Result.isFailure(decoded)) {
+    return Result.fail({ _tag: 'ReturningRowsDecodeFailed', write: 'transition', cause: decoded.failure })
+  }
+  if (decoded.success.length === 1 && decoded.success[0].intent_id === expectedIntentId) {
+    return Result.succeed({ _tag: 'IntentTransitioned', intentId: expectedIntentId })
+  }
+  return Result.fail({
+    _tag: 'UnexpectedReturningRows',
+    write: 'transition',
+    expectedId: expectedIntentId,
+    observedIds: decoded.success.map((row) => row.intent_id),
+  })
+}
 
 const selectRows = (sql: PgClient.PgClient, predicate: Fragment) => sql`
   SELECT
@@ -281,66 +793,6 @@ const selectRows = (sql: PgClient.PgClient, predicate: Fragment) => sql`
   WHERE ${predicate}
 `
 
-const toRecord = (row: StoredRow) =>
-  Effect.gen(function* () {
-    const intent = yield* decodeIntent({
-      schemaVersion: row.schema_version,
-      intentId: row.intent_id,
-      ...(row.risk_decision_id === null ? {} : { riskDecisionId: row.risk_decision_id }),
-      authorityGenerationHash: row.authority_generation_hash,
-      strategyName: row.strategy_name,
-      cycleId: row.cycle_id,
-      decisionHash: row.decision_hash,
-      policyHash: row.policy_hash,
-      accountId: row.account_id,
-      clientOrderId: row.client_order_id,
-      symbol: row.symbol,
-      side: row.side,
-      orderType: row.order_type,
-      timeInForce: row.time_in_force,
-      quantityMicros: row.quantity_micros,
-      notionalLimitMicros: row.notional_limit_micros,
-      state: row.state,
-      ...(row.terminal_outcome === null ? {} : { terminalOutcome: row.terminal_outcome }),
-      createdAt: row.created_at,
-    })
-    const decision =
-      row.decision_id === null
-        ? undefined
-        : yield* decodeRiskDecision({
-            schemaVersion: 'bayn.paper-risk-decision.v1',
-            decisionId: row.decision_id,
-            inputHash: row.input_hash,
-            intentId: row.intent_id,
-            policyHash: row.decision_policy_hash,
-            outcome: row.outcome,
-            reasonCodes: row.reason_codes,
-            decidedAt: row.decided_at,
-            expiresAt: row.expires_at,
-          })
-    return { intent, decision, stateVersion: row.state_version, updatedAt: row.updated_at } satisfies StoredIntent
-  })
-
-const immutableIntentHash = (intent: Intent): string =>
-  canonicalHashV1({
-    schemaVersion: intent.schemaVersion,
-    intentId: intent.intentId,
-    authorityGenerationHash: intent.authorityGenerationHash,
-    strategyName: intent.strategyName,
-    cycleId: intent.cycleId,
-    decisionHash: intent.decisionHash,
-    policyHash: intent.policyHash,
-    accountId: intent.accountId,
-    clientOrderId: intent.clientOrderId,
-    symbol: intent.symbol,
-    side: intent.side,
-    orderType: intent.orderType,
-    timeInForce: intent.timeInForce,
-    quantityMicros: intent.quantityMicros,
-    notionalLimitMicros: intent.notionalLimitMicros,
-    createdAt: intent.createdAt,
-  })
-
 const storeError = (
   failure: IntentStoreError['failure'],
   operation: IntentStoreError['operation'],
@@ -348,379 +800,404 @@ const storeError = (
   cause?: unknown,
 ) => new IntentStoreError({ failure, operation, message, cause })
 
+const renderCommitMaterialFailure = (failure: CommitMaterialFailure): string => {
+  switch (failure._tag) {
+    case 'IntentDecodeFailed':
+      return 'planned intent failed schema decoding'
+    case 'RiskDecisionDecodeFailed':
+      return 'risk decision failed schema decoding'
+    case 'ConstructedIntentDecodeFailed':
+      return `constructed ${failure.intentKind} intent failed schema decoding`
+    case 'CanonicalizationFailed':
+      return `canonical ${failure.material._tag} hashing failed`
+    case 'IntentIdentityMismatch':
+      return `planned intent ${failure.intentId} does not match its deterministic identity`
+    case 'RiskDecisionIdentityMismatch':
+      return `risk decision ${failure.decisionId} does not match deterministic identity ${failure.expectedDecisionId}`
+    case 'RiskDecisionBindingMismatch':
+      return `risk decision is not bound to intent ${failure.intentId} and policy ${failure.policyHash}`
+  }
+}
+
+const commitMaterialError = (failure: CommitMaterialFailure): IntentStoreError => {
+  const kind =
+    failure._tag === 'IntentDecodeFailed' ||
+    failure._tag === 'RiskDecisionDecodeFailed' ||
+    failure._tag === 'ConstructedIntentDecodeFailed'
+      ? 'decode'
+      : 'invariant'
+  return storeError(kind, 'commit', renderCommitMaterialFailure(failure), failure)
+}
+
+const existingCommitError = (failure: ExistingCommitFailure): IntentStoreError => {
+  switch (failure._tag) {
+    case 'CanonicalizationFailed':
+      return storeError('invariant', 'commit', `canonical ${failure.material._tag} hashing failed`, failure)
+    case 'MultipleIntentConflicts':
+      return storeError(
+        'conflict',
+        'commit',
+        `intent uniqueness boundary resolved to ${failure.count} records`,
+        failure,
+      )
+    case 'ImmutableIntentMismatch':
+      return storeError(
+        'conflict',
+        'commit',
+        `deterministic intent identity ${failure.intentId} was reused with different content`,
+        failure,
+      )
+    case 'StoredDecisionMismatch':
+      return storeError(
+        'conflict',
+        'commit',
+        `stored intent ${failure.intentId} diverges from decision ${failure.decisionId}`,
+        failure,
+      )
+    case 'IncompleteIntentState':
+      return storeError('invariant', 'commit', `intent ${failure.intentId} without a decision is not PLANNED`, failure)
+  }
+}
+
+const authorityError = (failure: AuthorityBindingFailure): IntentStoreError => {
+  switch (failure._tag) {
+    case 'AuthorityMissing':
+      return storeError('invariant', 'commit', 'PAPER authority is not initialized', failure)
+    case 'MultipleAuthorityRows':
+      return storeError('invariant', 'commit', 'PAPER authority singleton returned multiple rows', failure)
+    case 'MaximumAuthorityNotPaper':
+      return storeError('invariant', 'commit', 'GitOps maximum authority is not PAPER', failure)
+    case 'EffectiveAuthorityNotPaper':
+      return storeError('invariant', 'commit', 'effective authority is not PAPER', failure)
+    case 'AuthorityKillNotClear':
+      return storeError('invariant', 'commit', 'PAPER authority kill is not CLEAR', failure)
+    case 'AuthorityGenerationMismatch':
+      return storeError('invariant', 'commit', 'intent does not bind the active PAPER generation', failure)
+    case 'AuthorityGenerationHistoryMismatch':
+      return storeError(
+        'invariant',
+        'commit',
+        `active PAPER generation ${failure.generationHash} has mismatched ${failure.field}`,
+        failure,
+      )
+  }
+}
+
+const writeDispositionError = (failure: WriteDispositionFailure): IntentStoreError =>
+  failure._tag === 'ReturningRowsDecodeFailed'
+    ? storeError('decode', 'commit', `${failure.write} RETURNING rows failed schema decoding`, failure)
+    : storeError(
+        'conflict',
+        'commit',
+        `${failure.write} did not return the exact expected identity ${failure.expectedId}`,
+        failure,
+      )
+
+const storedRowsError = (operation: IntentStoreError['operation'], failure: StoredRowsFailure): IntentStoreError => {
+  switch (failure._tag) {
+    case 'StoredRowsDecodeFailed':
+      return storeError('decode', operation, 'stored intent rows failed schema decoding', failure)
+    case 'StoredIntentDecodeFailed':
+      return storeError('decode', operation, `stored intent ${failure.intentId} failed schema decoding`, failure)
+    case 'StoredRiskDecisionDecodeFailed':
+      return storeError('decode', operation, `stored decision for ${failure.intentId} failed schema decoding`, failure)
+  }
+}
+
+const classifyIntentCause = (operation: IntentStoreError['operation'], cause: unknown): IntentStoreError => {
+  if (cause instanceof IntentStoreError) return cause
+  if (isSqlError(cause)) {
+    if (cause.reason._tag === 'UniqueViolation') {
+      return storeError('conflict', operation, `intent ${operation} violated a uniqueness boundary`, cause)
+    }
+    if (cause.reason._tag === 'ConstraintError') {
+      return storeError('invariant', operation, `intent ${operation} violated a durable semantic constraint`, cause)
+    }
+  }
+  return storeError('query', operation, `intent ${operation} failed`, cause)
+}
+
+const classifyCommitCause = (cause: unknown): IntentStoreError | WriterFenceError =>
+  cause instanceof WriterFenceError ? cause : classifyIntentCause('commit', cause)
+
+const runRead = <A, E, R>(effect: Effect.Effect<A, E, R>): Effect.Effect<A, IntentStoreError, R> =>
+  effect.pipe(Effect.mapError((cause) => classifyIntentCause('read', cause)))
+
+const runCommit = <A, E, R>(effect: Effect.Effect<A, E, R>): Effect.Effect<A, IntentStoreError | WriterFenceError, R> =>
+  effect.pipe(Effect.mapError(classifyCommitCause))
+
+const decodeStoredEffect = (
+  operation: IntentStoreError['operation'],
+  rows: unknown,
+): Effect.Effect<readonly StoredIntent[], IntentStoreError> =>
+  Effect.fromResult(decodeStoredIntentRows(rows)).pipe(
+    Effect.mapError((failure) => storedRowsError(operation, failure)),
+  )
+
+const readById = (
+  sql: PgClient.PgClient,
+  operation: IntentStoreError['operation'],
+  intentId: string,
+): Effect.Effect<Option.Option<StoredIntent>, IntentStoreError, never> => {
+  const decodedId = Result.mapError(decodeIntentIdResult(intentId), (cause) =>
+    storeError('decode', operation, 'invalid intent ID', cause),
+  )
+  return Effect.fromResult(decodedId).pipe(
+    Effect.flatMap((id) =>
+      selectRows(sql, sql`intent.intent_id = ${id}`).pipe(
+        Effect.mapError((cause) => classifyIntentCause(operation, cause)),
+      ),
+    ),
+    Effect.flatMap((rows) => decodeStoredEffect(operation, rows)),
+    Effect.flatMap((records) =>
+      records.length <= 1
+        ? Effect.succeed(Option.fromNullishOr(records[0]))
+        : Effect.fail(storeError('invariant', operation, 'intent ID returned multiple records')),
+    ),
+  )
+}
+
+const readConflicts = (
+  sql: PgClient.PgClient,
+  intent: Intent,
+): Effect.Effect<readonly StoredIntent[], IntentStoreError> =>
+  selectRows(
+    sql,
+    sql`
+      intent.intent_id = ${intent.intentId}
+      OR (intent.account_id = ${intent.accountId} AND intent.client_order_id = ${intent.clientOrderId})
+      OR (
+        intent.account_id = ${intent.accountId}
+        AND intent.strategy_name = ${intent.strategyName}
+        AND intent.cycle_id = ${intent.cycleId}
+        AND intent.decision_hash = ${intent.decisionHash}
+        AND intent.symbol = ${intent.symbol}
+      )
+    `,
+  ).pipe(
+    Effect.mapError((cause) => classifyIntentCause('commit', cause)),
+    Effect.flatMap((rows) => decodeStoredEffect('commit', rows)),
+  )
+
+const readCurrentAuthority = (
+  sql: PgClient.PgClient,
+): Effect.Effect<readonly AuthorityBindingRow[], IntentStoreError> =>
+  sql`
+    SELECT
+      authority.maximum,
+      authority.effective,
+      authority.kill_state,
+      authority.generation_hash,
+      generation.maximum AS generation_maximum,
+      generation.account_id AS generation_account_id,
+      generation.risk_policy_hash AS generation_risk_policy_hash,
+      generation.strategy_name AS generation_strategy_name
+    FROM authority_state AS authority
+    LEFT JOIN authority_generations AS generation
+      ON generation.generation_hash = authority.generation_hash
+    WHERE authority.singleton
+    FOR UPDATE OF authority
+  `.pipe(
+    Effect.mapError((cause) => classifyIntentCause('commit', cause)),
+    Effect.flatMap((rows) =>
+      Effect.fromResult(decodeAuthorityBindingRows(rows)).pipe(
+        Effect.mapError((failure) =>
+          storeError('decode', 'commit', 'authority binding rows failed schema decoding', failure),
+        ),
+      ),
+    ),
+  )
+
+const insertIntent = (sql: PgClient.PgClient, intent: Intent) =>
+  sql`
+    INSERT INTO intents (
+      intent_id,
+      schema_version,
+      authority_generation_hash,
+      strategy_name,
+      cycle_id,
+      decision_hash,
+      policy_hash,
+      account_id,
+      client_order_id,
+      symbol,
+      side,
+      order_type,
+      time_in_force,
+      quantity_micros,
+      notional_limit_micros,
+      state,
+      created_at,
+      updated_at
+    ) VALUES (
+      ${intent.intentId},
+      ${intent.schemaVersion},
+      ${intent.authorityGenerationHash},
+      ${intent.strategyName},
+      ${intent.cycleId},
+      ${intent.decisionHash},
+      ${intent.policyHash},
+      ${intent.accountId},
+      ${intent.clientOrderId},
+      ${intent.symbol},
+      ${intent.side},
+      ${intent.orderType},
+      ${intent.timeInForce},
+      ${intent.quantityMicros},
+      ${intent.notionalLimitMicros},
+      ${intent.state},
+      ${intent.createdAt},
+      ${intent.createdAt}
+    )
+    ON CONFLICT DO NOTHING
+    RETURNING intent_id
+  `.pipe(Effect.mapError((cause) => classifyIntentCause('commit', cause)))
+
+const insertRiskDecision = (sql: PgClient.PgClient, decision: RiskDecision) =>
+  sql`
+    INSERT INTO risk_decisions (
+      decision_id,
+      schema_version,
+      input_hash,
+      intent_id,
+      policy_hash,
+      outcome,
+      reason_codes,
+      decided_at,
+      expires_at
+    ) VALUES (
+      ${decision.decisionId},
+      ${decision.schemaVersion},
+      ${decision.inputHash},
+      ${decision.intentId},
+      ${decision.policyHash},
+      ${decision.outcome},
+      ${decision.reasonCodes},
+      ${decision.decidedAt},
+      ${decision.expiresAt}
+    )
+    ON CONFLICT DO NOTHING
+    RETURNING decision_id
+  `.pipe(Effect.mapError((cause) => classifyIntentCause('commit', cause)))
+
+const transitionIntent = (sql: PgClient.PgClient, intent: Intent, decision: RiskDecision) => {
+  const approved = decision.outcome === RiskOutcome.Approved
+  return sql`
+    UPDATE intents
+    SET
+      risk_decision_id = ${decision.decisionId},
+      state = ${approved ? IntentState.Approved : IntentState.Terminal},
+      terminal_outcome = ${approved ? null : TerminalOutcome.Blocked},
+      state_version = state_version + 1,
+      updated_at = ${decision.decidedAt}
+    WHERE intent_id = ${intent.intentId} AND state = ${IntentState.Planned}
+    RETURNING intent_id
+  `.pipe(Effect.mapError((cause) => classifyIntentCause('commit', cause)))
+}
+
+type ResolvedIntent =
+  | { readonly _tag: 'Replay'; readonly receipt: IntentReceipt }
+  | { readonly _tag: 'Pending'; readonly record: StoredIntent }
+
+const resolveDisposition = (
+  disposition: ExistingCommitDisposition,
+): Effect.Effect<ResolvedIntent, IntentStoreError> => {
+  if (disposition._tag === 'ExactReplay') {
+    return Effect.succeed({ _tag: 'Replay', receipt: disposition.receipt })
+  }
+  if (disposition._tag === 'CompleteIntent') {
+    return Effect.succeed({ _tag: 'Pending', record: disposition.record })
+  }
+  return Effect.fail(storeError('conflict', 'commit', 'inserted intent cannot be read back'))
+}
+
+const reclassifyAfterInsert = (
+  sql: PgClient.PgClient,
+  prepared: PreparedCommit,
+): Effect.Effect<ResolvedIntent, IntentStoreError> =>
+  readConflicts(sql, prepared.intent).pipe(
+    Effect.flatMap((records) =>
+      Effect.fromResult(classifyExistingCommit(records, prepared)).pipe(Effect.mapError(existingCommitError)),
+    ),
+    Effect.flatMap(resolveDisposition),
+  )
+
+const resolveIntent = (
+  sql: PgClient.PgClient,
+  prepared: PreparedCommit,
+): Effect.Effect<ResolvedIntent, IntentStoreError> =>
+  Effect.gen(function* () {
+    const records = yield* readConflicts(sql, prepared.intent)
+    const disposition = yield* Effect.fromResult(classifyExistingCommit(records, prepared)).pipe(
+      Effect.mapError(existingCommitError),
+    )
+    if (disposition._tag === 'ExactReplay') {
+      return { _tag: 'Replay', receipt: disposition.receipt } satisfies ResolvedIntent
+    }
+
+    const authorityRows = yield* readCurrentAuthority(sql)
+    yield* Effect.fromResult(validateCurrentAuthority(authorityRows, prepared.intent)).pipe(
+      Effect.mapError(authorityError),
+    )
+    if (disposition._tag === 'CompleteIntent') {
+      return { _tag: 'Pending', record: disposition.record } satisfies ResolvedIntent
+    }
+
+    const insertedRows = yield* insertIntent(sql, prepared.intent)
+    yield* Effect.fromResult(decideIntentInsert(insertedRows, prepared.intent.intentId)).pipe(
+      Effect.mapError(writeDispositionError),
+    )
+    return yield* reclassifyAfterInsert(sql, prepared)
+  })
+
+const persistDecision = (
+  sql: PgClient.PgClient,
+  prepared: PreparedCommit,
+): Effect.Effect<IntentReceipt, IntentStoreError> =>
+  Effect.gen(function* () {
+    const decisionRows = yield* insertRiskDecision(sql, prepared.decision)
+    yield* Effect.fromResult(decideRiskCommit(decisionRows, prepared.decision.decisionId)).pipe(
+      Effect.mapError(writeDispositionError),
+    )
+    const transitionRows = yield* transitionIntent(sql, prepared.intent, prepared.decision)
+    yield* Effect.fromResult(decideIntentTransition(transitionRows, prepared.intent.intentId)).pipe(
+      Effect.mapError(writeDispositionError),
+    )
+    const stored = yield* readById(sql, 'commit', prepared.intent.intentId)
+    if (Option.isNone(stored)) {
+      return yield* Effect.fail(storeError('invariant', 'commit', 'committed intent cannot be read back'))
+    }
+    const verified = yield* Effect.fromResult(classifyExistingCommit([stored.value], prepared)).pipe(
+      Effect.mapError(existingCommitError),
+    )
+    if (verified._tag !== 'ExactReplay') {
+      return yield* Effect.fail(storeError('invariant', 'commit', 'committed intent readback is incomplete'))
+    }
+    return { record: verified.receipt.record, deduplicated: false }
+  })
+
+const commitTransaction = (
+  sql: PgClient.PgClient,
+  prepared: PreparedCommit,
+): Effect.Effect<IntentReceipt, IntentStoreError> =>
+  resolveIntent(sql, prepared).pipe(
+    Effect.flatMap((resolved) =>
+      resolved._tag === 'Replay' ? Effect.succeed(resolved.receipt) : persistDecision(sql, prepared),
+    ),
+  )
+
 const makeStore = Effect.gen(function* () {
   const sql = yield* PgClient.PgClient
   const fence = yield* WriterFence
-
-  const run = <A, E, R>(
-    operation: IntentStoreError['operation'],
-    effect: Effect.Effect<A, E, R>,
-  ): Effect.Effect<A, IntentStoreError | WriterFenceError, R> =>
-    effect.pipe(
-      Effect.mapError((cause) =>
-        cause instanceof WriterFenceError || cause instanceof IntentStoreError
-          ? cause
-          : storeError('query', operation, `intent ${operation} failed`, cause),
-      ),
-    )
-
-  const decodeStored = (operation: IntentStoreError['operation'], rows: unknown) =>
-    decodeRows(rows).pipe(
-      Effect.mapError((cause) => storeError('decode', operation, 'stored intent rows failed schema decoding', cause)),
-      Effect.flatMap((decoded) =>
-        Effect.forEach(decoded, (row) =>
-          toRecord(row).pipe(
-            Effect.mapError((cause) =>
-              storeError('decode', operation, 'stored intent payload failed schema decoding', cause),
-            ),
-          ),
-        ),
-      ),
-    )
-
-  const readById = (operation: IntentStoreError['operation'], intentId: string) =>
-    Effect.gen(function* () {
-      const decodedId = yield* decodeIntentId(intentId).pipe(
-        Effect.mapError((cause) => storeError('decode', operation, 'invalid intent ID', cause)),
-      )
-      const rows = yield* selectRows(sql, sql`intent.intent_id = ${decodedId}`)
-      const records = yield* decodeStored(operation, rows)
-      if (records.length > 1) {
-        return yield* Effect.fail(storeError('invariant', operation, 'intent ID returned multiple records'))
-      }
-      return Option.fromNullishOr(records[0])
-    })
-
-  const withFence = fence.transaction
-
-  const commit = (inputIntent: Intent, inputDecision: RiskDecision) =>
-    run(
-      'commit',
-      Effect.gen(function* () {
-        const expectedIntent = yield* makePaperIntent(
-          {
-            schemaVersion: 'bayn.paper-intent-plan.v1',
-            strategyName: inputIntent.strategyName,
-            cycleId: inputIntent.cycleId,
-            decisionHash: inputIntent.decisionHash,
-            policyHash: inputIntent.policyHash,
-            accountId: inputIntent.accountId,
-            symbol: inputIntent.symbol,
-            side: inputIntent.side,
-            orderType: inputIntent.orderType,
-            timeInForce: inputIntent.timeInForce,
-            quantityMicros: inputIntent.quantityMicros,
-            notionalLimitMicros: inputIntent.notionalLimitMicros,
-            createdAt: inputIntent.createdAt,
-          },
-          inputIntent.authorityGenerationHash,
-        ).pipe(Effect.mapError((cause) => storeError('decode', 'commit', 'invalid planned intent', cause)))
-        if (!intentEquivalent(inputIntent, expectedIntent)) {
-          return yield* Effect.fail(
-            storeError('invariant', 'commit', 'planned intent does not match its deterministic identity'),
-          )
-        }
-        const decision = yield* decodeRiskDecision(inputDecision).pipe(
-          Effect.mapError((cause) => storeError('decode', 'commit', 'invalid risk decision', cause)),
-        )
-        const { decisionId, ...decisionMaterial } = decision
-        if (decisionId !== canonicalHashV1(decisionMaterial)) {
-          return yield* Effect.fail(
-            storeError('invariant', 'commit', 'risk decision does not match its deterministic identity'),
-          )
-        }
-        if (decision.intentId !== inputIntent.intentId || decision.policyHash !== inputIntent.policyHash) {
-          return yield* Effect.fail(
-            storeError('invariant', 'commit', 'risk decision does not match the intent and policy'),
-          )
-        }
-
-        return yield* withFence(
-          Effect.gen(function* () {
-            const readConflicts = () =>
-              selectRows(
-                sql,
-                sql`
-                intent.intent_id = ${inputIntent.intentId}
-                OR (intent.account_id = ${inputIntent.accountId} AND intent.client_order_id = ${inputIntent.clientOrderId})
-                OR (
-                  intent.account_id = ${inputIntent.accountId}
-                  AND intent.strategy_name = ${inputIntent.strategyName}
-                  AND intent.cycle_id = ${inputIntent.cycleId}
-                  AND intent.decision_hash = ${inputIntent.decisionHash}
-                  AND intent.symbol = ${inputIntent.symbol}
-                )
-              `,
-              ).pipe(Effect.flatMap((rows) => decodeStored('commit', rows)))
-
-            let conflictRows = yield* readConflicts()
-            if (conflictRows.length > 1) {
-              return yield* Effect.fail(
-                storeError('conflict', 'commit', 'intent uniqueness boundary resolved to multiple records'),
-              )
-            }
-            const preexisting = conflictRows[0]
-            if (preexisting !== undefined) {
-              if (immutableIntentHash(preexisting.intent) !== immutableIntentHash(inputIntent)) {
-                return yield* Effect.fail(
-                  storeError('conflict', 'commit', 'deterministic intent identity was reused with different content'),
-                )
-              }
-              if (preexisting.decision !== undefined) {
-                const stateMatchesDecision =
-                  decision.outcome === RiskOutcome.Approved
-                    ? preexisting.intent.state !== IntentState.Planned
-                    : preexisting.intent.state === IntentState.Terminal &&
-                      preexisting.intent.terminalOutcome === TerminalOutcome.Blocked
-                if (
-                  !decisionEquivalent(preexisting.decision, decision) ||
-                  preexisting.intent.riskDecisionId !== decision.decisionId ||
-                  !stateMatchesDecision
-                ) {
-                  return yield* Effect.fail(
-                    storeError('conflict', 'commit', 'stored intent decision diverges from the requested decision'),
-                  )
-                }
-                return { record: preexisting, deduplicated: true } satisfies IntentReceipt
-              }
-              if (preexisting.intent.state !== IntentState.Planned || preexisting.intent.riskDecisionId !== undefined) {
-                return yield* Effect.fail(storeError('invariant', 'commit', 'intent without a decision is not PLANNED'))
-              }
-            }
-
-            const authorityRows = yield* sql<{
-              generation_account_id: string | null
-              generation_hash: string
-              generation_maximum: string | null
-              generation_risk_policy_hash: string | null
-              generation_strategy_name: string | null
-              maximum: string
-            }>`
-              SELECT
-                authority.maximum,
-                authority.generation_hash,
-                generation.maximum AS generation_maximum,
-                generation.account_id AS generation_account_id,
-                generation.risk_policy_hash AS generation_risk_policy_hash,
-                generation.strategy_name AS generation_strategy_name
-              FROM authority_state AS authority
-              LEFT JOIN authority_generations AS generation
-                ON generation.generation_hash = authority.generation_hash
-              WHERE authority.singleton
-              FOR UPDATE OF authority
-            `
-            const authority = authorityRows[0]
-            if (
-              authority === undefined ||
-              authority.maximum !== Authority.Paper ||
-              authority.generation_hash !== inputIntent.authorityGenerationHash ||
-              authority.generation_maximum !== Authority.Paper ||
-              authority.generation_account_id !== inputIntent.accountId ||
-              authority.generation_risk_policy_hash !== inputIntent.policyHash ||
-              authority.generation_strategy_name !== inputIntent.strategyName
-            ) {
-              return yield* Effect.fail(
-                storeError(
-                  'invariant',
-                  'commit',
-                  'PAPER intent does not match the current immutable authority-generation bindings',
-                ),
-              )
-            }
-
-            if (preexisting === undefined) {
-              yield* sql`
-                INSERT INTO intents (
-                  intent_id,
-                  schema_version,
-                  authority_generation_hash,
-                  strategy_name,
-                  cycle_id,
-                  decision_hash,
-                  policy_hash,
-                  account_id,
-                  client_order_id,
-                  symbol,
-                  side,
-                  order_type,
-                  time_in_force,
-                  quantity_micros,
-                  notional_limit_micros,
-                  state,
-                  created_at,
-                  updated_at
-                ) VALUES (
-                  ${inputIntent.intentId},
-                  ${inputIntent.schemaVersion},
-                  ${inputIntent.authorityGenerationHash},
-                  ${inputIntent.strategyName},
-                  ${inputIntent.cycleId},
-                  ${inputIntent.decisionHash},
-                  ${inputIntent.policyHash},
-                  ${inputIntent.accountId},
-                  ${inputIntent.clientOrderId},
-                  ${inputIntent.symbol},
-                  ${inputIntent.side},
-                  ${inputIntent.orderType},
-                  ${inputIntent.timeInForce},
-                  ${inputIntent.quantityMicros},
-                  ${inputIntent.notionalLimitMicros},
-                  ${inputIntent.state},
-                  ${inputIntent.createdAt},
-                  ${inputIntent.createdAt}
-                )
-                ON CONFLICT DO NOTHING
-              `
-              conflictRows = yield* readConflicts()
-            }
-            if (conflictRows.length !== 1) {
-              return yield* Effect.fail(
-                storeError('conflict', 'commit', 'intent uniqueness boundary did not resolve to one record'),
-              )
-            }
-            const existing = conflictRows[0]
-            if (immutableIntentHash(existing.intent) !== immutableIntentHash(inputIntent)) {
-              return yield* Effect.fail(
-                storeError('conflict', 'commit', 'deterministic intent identity was reused with different content'),
-              )
-            }
-            if (existing.decision !== undefined) {
-              const stateMatchesDecision =
-                decision.outcome === RiskOutcome.Approved
-                  ? existing.intent.state !== IntentState.Planned
-                  : existing.intent.state === IntentState.Terminal &&
-                    existing.intent.terminalOutcome === TerminalOutcome.Blocked
-              if (
-                !decisionEquivalent(existing.decision, decision) ||
-                existing.intent.riskDecisionId !== decision.decisionId ||
-                !stateMatchesDecision
-              ) {
-                return yield* Effect.fail(
-                  storeError('conflict', 'commit', 'stored intent decision diverges from the requested decision'),
-                )
-              }
-              return { record: existing, deduplicated: true } satisfies IntentReceipt
-            }
-            if (existing.intent.state !== IntentState.Planned || existing.intent.riskDecisionId !== undefined) {
-              return yield* Effect.fail(storeError('invariant', 'commit', 'intent without a decision is not PLANNED'))
-            }
-
-            const insertedDecision = yield* sql<{ decision_id: string }>`
-              INSERT INTO risk_decisions (
-                decision_id,
-                schema_version,
-                input_hash,
-                intent_id,
-                policy_hash,
-                outcome,
-                reason_codes,
-                decided_at,
-                expires_at
-              ) VALUES (
-                ${decision.decisionId},
-                ${decision.schemaVersion},
-                ${decision.inputHash},
-                ${decision.intentId},
-                ${decision.policyHash},
-                ${decision.outcome},
-                ${decision.reasonCodes},
-                ${decision.decidedAt},
-                ${decision.expiresAt}
-              )
-              ON CONFLICT DO NOTHING
-              RETURNING decision_id
-            `
-            if (insertedDecision.length !== 1) {
-              return yield* Effect.fail(
-                storeError('conflict', 'commit', 'risk decision identity was already used by different content'),
-              )
-            }
-
-            const approved = decision.outcome === RiskOutcome.Approved
-            const transitioned = yield* sql<{ intent_id: string }>`
-              UPDATE intents
-              SET
-                risk_decision_id = ${decision.decisionId},
-                state = ${approved ? IntentState.Approved : IntentState.Terminal},
-                terminal_outcome = ${approved ? null : TerminalOutcome.Blocked},
-                state_version = state_version + 1,
-                updated_at = ${decision.decidedAt}
-              WHERE intent_id = ${inputIntent.intentId} AND state = ${IntentState.Planned}
-              RETURNING intent_id
-            `
-            if (transitioned.length !== 1) {
-              return yield* Effect.fail(storeError('conflict', 'commit', 'planned intent transition lost its race'))
-            }
-
-            const stored = yield* readById('commit', inputIntent.intentId)
-            if (Option.isNone(stored)) {
-              return yield* Effect.fail(storeError('invariant', 'commit', 'committed intent cannot be read back'))
-            }
-            return { record: stored.value, deduplicated: false } satisfies IntentReceipt
-          }),
-        )
-      }),
-    )
-
-  const markIoStarted = (intentId: string, updatedAt: string) =>
-    run(
-      'mark-io-started',
-      Effect.gen(function* () {
-        const decodedId = yield* decodeIntentId(intentId).pipe(
-          Effect.mapError((cause) => storeError('decode', 'mark-io-started', 'invalid intent ID', cause)),
-        )
-        const decodedTime = yield* decodeUpdatedAt(updatedAt).pipe(
-          Effect.mapError((cause) => storeError('decode', 'mark-io-started', 'invalid transition time', cause)),
-        )
-        return yield* withFence(
-          Effect.gen(function* () {
-            const current = yield* readById('mark-io-started', decodedId)
-            if (Option.isNone(current)) {
-              return yield* Effect.fail(storeError('invariant', 'mark-io-started', 'intent does not exist'))
-            }
-            if (current.value.intent.state === IntentState.IoStarted) {
-              return { record: current.value, deduplicated: true } satisfies IntentReceipt
-            }
-            if (
-              current.value.intent.state !== IntentState.Approved ||
-              current.value.decision?.outcome !== RiskOutcome.Approved
-            ) {
-              return yield* Effect.fail(
-                storeError('invariant', 'mark-io-started', 'only an approved intent may enter IO_STARTED'),
-              )
-            }
-            const transitioned = yield* sql<{ intent_id: string }>`
-              UPDATE intents
-              SET state = ${IntentState.IoStarted}, state_version = state_version + 1, updated_at = ${decodedTime}
-              WHERE intent_id = ${decodedId} AND state = ${IntentState.Approved}
-              RETURNING intent_id
-            `
-            if (transitioned.length !== 1) {
-              return yield* Effect.fail(
-                storeError('conflict', 'mark-io-started', 'approved intent transition lost its race'),
-              )
-            }
-            const stored = yield* readById('mark-io-started', decodedId)
-            if (Option.isNone(stored)) {
-              return yield* Effect.fail(
-                storeError('invariant', 'mark-io-started', 'IO_STARTED intent cannot be read back'),
-              )
-            }
-            return { record: stored.value, deduplicated: false } satisfies IntentReceipt
-          }),
-        )
-      }),
-    )
-
   return {
-    commit,
-    markIoStarted,
-    read: (intentId) =>
-      readById('read', intentId).pipe(
-        Effect.mapError((cause) =>
-          cause instanceof IntentStoreError ? cause : storeError('query', 'read', 'intent read failed', cause),
+    commit: (intent, decision) =>
+      runCommit(
+        Effect.fromResult(validateCommitIdentity(intent, decision)).pipe(
+          Effect.mapError(commitMaterialError),
+          Effect.flatMap((prepared) => fence.transaction(commitTransaction(sql, prepared))),
         ),
       ),
+    read: (intentId) => runRead(readById(sql, 'read', intentId)),
   } satisfies IntentStoreService
 })
 

--- a/services/bayn/src/shadow-decision-contract.ts
+++ b/services/bayn/src/shadow-decision-contract.ts
@@ -71,19 +71,23 @@ const materialIssues = (document: ObserveShadowDecisionMaterial): readonly Schem
   for (const [index, risk] of document.deltaRisk.entries()) {
     const evaluation = risk.evaluation
     const target = targets[index]
-    if (
-      target !== undefined &&
-      evaluation.input.intentId !==
-        intentIdForPlan({
-          schemaVersion: 'bayn.paper-intent-plan.v1',
-          ...target,
-          notionalLimitMicros: risk.notionalLimitMicros,
-        })
-    ) {
-      issues.push({
-        path: ['deltaRisk', index, 'evaluation', 'input', 'intentId'],
-        issue: 'must bind the corresponding ordered target delta',
+    if (target !== undefined) {
+      const identity = intentIdForPlan({
+        schemaVersion: 'bayn.paper-intent-plan.v1',
+        ...target,
+        notionalLimitMicros: risk.notionalLimitMicros,
       })
+      if (Result.isFailure(identity)) {
+        issues.push({
+          path: ['deltaRisk', index, 'evaluation', 'input', 'intentId'],
+          issue: 'corresponding ordered target delta must have a canonical identity',
+        })
+      } else if (evaluation.input.intentId !== identity.success) {
+        issues.push({
+          path: ['deltaRisk', index, 'evaluation', 'input', 'intentId'],
+          issue: 'must bind the corresponding ordered target delta',
+        })
+      }
     }
     if (evaluation.policyHash !== document.bindings.policyHash) {
       issues.push({ path: ['deltaRisk', index, 'evaluation', 'policyHash'], issue: 'must match the bound policy' })

--- a/services/bayn/src/shadow-decision.ts
+++ b/services/bayn/src/shadow-decision.ts
@@ -299,16 +299,13 @@ const makeReferenceIntent = (input: IntentPlan): Result.Result<ReferenceIntent, 
     error('contract', 'shadow target delta could not form a valid risk intent', cause),
   )
   if (Result.isFailure(decodedPlan)) return Result.fail(decodedPlan.failure)
-  const identity = Result.try({
-    try: () => {
-      const intentId = intentIdForPlan(decodedPlan.success)
-      return {
-        intentId,
-        clientOrderId: `b1_${Buffer.from(intentId, 'hex').toString('base64url')}`,
-      }
-    },
-    catch: (cause) => error('contract', 'shadow target delta identity is not canonicalizable', cause),
-  })
+  const identity = Result.mapError(
+    Result.map(intentIdForPlan(decodedPlan.success), (intentId) => ({
+      intentId,
+      clientOrderId: `b1_${Buffer.from(intentId, 'hex').toString('base64url')}`,
+    })),
+    (cause) => error('contract', 'shadow target delta identity is not canonicalizable', cause),
+  )
   if (Result.isFailure(identity)) return Result.fail(identity.failure)
   const decoded = decodedPlan.success
   return Result.mapError(


### PR DESCRIPTION
## Summary

- split deterministic intent identity, strict row decoding, authority validation, replay classification, and write dispositions into total pure `Result` algebras
- reduce the persistence boundary to small Effect interpreters that retain typed SQL and canonicalization causes instead of throwing or flattening failures
- require replay-first, exact PAPER generation/account/policy/strategy authorization before new or incomplete commits, with no-write PostgreSQL proof under OBSERVE and active kill
- remove the duplicate `IntentStore.markIoStarted` path so `MutationStore` remains the sole atomic owner of broker I/O transition state

## Related Issues

PROOMPT-425

## Testing

- `bun test src/execution/intents.test.ts src/shadow-decision.test.ts src/observe-composition.test.ts src/cycle-runner.test.ts` — 57 passed
- `bun run --filter @proompteng/bayn test` — 568 passed, 113 PostgreSQL-gated skips, 0 failed
- `BAYN_TEST_POSTGRES_URL=postgresql://gregkonush@127.0.0.1:5432/bayn_test bun test src/db/evidence-store.integration.test.ts src/db/paper-store.integration.test.ts src/db/cycle-store.integration.test.ts src/db/cycle-observability.integration.test.ts` — 105 passed
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn build`
- independent exact-patch review: approved with no findings

## Breaking Changes

Internal Bayn capability change: `IntentStore.markIoStarted` is removed. `MutationStore` is now the only writer of broker I/O transition state. There is no configuration, database-schema, GitOps, or deployed-runtime change.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; this is a service-internal refactor.
- [x] Breaking Changes is filled in.
- [x] Documentation and follow-up work remain tracked in the Bayn functional-refactor roadmap.
