### PR TITLE
chore(bayn): deploy fresh qualification candidate

### DIFF
--- a/argocd/applications/bayn/deployment.yaml
+++ b/argocd/applications/bayn/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         app.kubernetes.io/name: bayn
         app.kubernetes.io/part-of: bayn
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-07-23T03:44:29Z"
+        kubectl.kubernetes.io/restartedAt: "2026-07-25T21:05:27Z"
     spec:
       serviceAccountName: bayn
       automountServiceAccountToken: false
@@ -47,17 +47,15 @@ spec:
               protocol: TCP
           env:
             - name: BAYN_CODE_REVISION
-              value: 6e36949f82d8fbab510b01b7499923b535f110cc
+              value: cbd908019b7681f3251f7760a961d1dbabcc8c67
             - name: BAYN_IMAGE_REPOSITORY
               value: registry.ide-newton.ts.net/lab/bayn
             - name: BAYN_IMAGE_DIGEST
-              value: sha256:b0fb63e90e0e9b5b8b1a0883b8b0a498f5d05d194d669efe024aaec8162529ec
+              value: sha256:b08adf9ca42d768ea38d7d23a6aa8bf112f6dd9c2334d397a226a6903dfc27a2
             - name: BAYN_STRATEGY_BEHAVIOR_HASH
-              value: "43cece33d3db232ffb02ba78826727e50b5795319d09d27e1baa0c04709eb056"
+              value: "dc614c54bbf43842d83cd88497e835f7bb25c413eb6e8bd7cbab0a925ec9b2dd"
             - name: BAYN_STRATEGY_PARAMETER_HASH
-              value: "649148eeaaf1f3aa1f1dd6d129a93aeef6b07f63e1aa60b6ed79f91a9cf7bbf8"
-            - name: BAYN_QUALIFICATION_RUN_ID
-              value: "7a521052ff039376267eb16f222023edf5d72f308af380c71f2d50da6e6a1b32"
+              value: "e5e4cc5d22b84c4dc8fc65c306d097fda063b0058253da5b900fe1d462d437b3"
             - name: BAYN_MAXIMUM_AUTHORITY
               value: OBSERVE
             - name: BAYN_HEALTH_INTERVAL_MS
@@ -77,21 +75,21 @@ spec:
                   name: bayn-clickhouse-auth
                   key: password
             - name: BAYN_SIGNAL_SNAPSHOT_ID
-              value: "840c75885270b349d4a992e003918ce7e6fe39730f981a20b2e88ae2db45a2e2"
+              value: "1b963bb9550d07e1c7239ebe1a021e82c0f112b8f21fce0ab4e922c47b272a27"
             - name: BAYN_SIGNAL_PUBLICATION_ASOF
-              value: "2026-07-22"
+              value: "2026-07-24"
             - name: BAYN_SIGNAL_CALENDAR_VERSION
               value: "alpaca-us-equity-calendar-v1"
             - name: BAYN_SIGNAL_DATA_START
               value: "2016-01-04"
             - name: BAYN_SIGNAL_DATA_END
-              value: "2026-07-22"
+              value: "2026-07-24"
             - name: BAYN_SIGNAL_LOOKBACK_START
               value: "2016-01-04"
             - name: BAYN_SIGNAL_EVALUATION_START
               value: "2017-01-03"
             - name: BAYN_SIGNAL_EVALUATION_END
-              value: "2026-07-22"
+              value: "2026-07-24"
             - name: BAYN_POSTGRES_URL
               valueFrom:
                 secretKeyRef:

--- a/argocd/applications/bayn/kustomization.yaml
+++ b/argocd/applications/bayn/kustomization.yaml
@@ -22,5 +22,5 @@ configMapGenerator:
 images:
   - name: registry.ide-newton.ts.net/lab/bayn
     newName: registry.ide-newton.ts.net/lab/bayn
-    newTag: "sha-6e36949f82d8fbab510b01b7499923b535f110cc"
-    digest: sha256:b0fb63e90e0e9b5b8b1a0883b8b0a498f5d05d194d669efe024aaec8162529ec
+    newTag: "sha-cbd908019b7681f3251f7760a961d1dbabcc8c67"
+    digest: sha256:b08adf9ca42d768ea38d7d23a6aa8bf112f6dd9c2334d397a226a6903dfc27a2


### PR DESCRIPTION
## Summary

- deploy the immutable Bayn image built from `cbd908019b7681f3251f7760a961d1dbabcc8c67`
- advance to the natural finalized Signal publication for 2026-07-24 (`1b963bb9550d07e1c7239ebe1a021e82c0f112b8f21fce0ab4e922c47b272a27`)
- install the image's compiled strategy identity and remove the previous qualification pin
- keep maximum authority at `OBSERVE`; this is the required one-shot unpinned qualification candidate, not qualification acceptance or capital authorization

## Candidate verification

- both physical ClickHouse replicas returned byte-identical, fully verified snapshot material
- replica identities covered `chi-torghut-clickhouse-default-0-0-0` and `chi-torghut-clickhouse-default-0-1-0`
- PostgreSQL qualification-lock inspection ran in `REPEATABLE READ, READ ONLY`
- qualification lock count for the fresh snapshot was zero
- the release writer returned `promotionAction=promote`, `qualificationMode=replace`, and `snapshotChanged=true`

## Testing

- `bun test packages/scripts/src/bayn` — 20 passed, 0 failed
- `kubectl kustomize argocd/applications/bayn` — rendered successfully
- rendered candidate contains the exact source, digest, and fresh snapshot and contains no `BAYN_QUALIFICATION_RUN_ID`
- `git diff --check`

## Breaking Changes

None. The deployment remains observe-only. The next controlled change must pin the exact terminal qualification run produced by this immutable candidate.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] The old qualification pin is not rebound to a changed strategy or snapshot.
- [x] The candidate was independently verified before GitOps mutation.
- [x] No candidate receipt or credential material was committed.
