### PR TITLE
chore(bayn): pin audited qualification run

### DIFF
--- a/argocd/applications/bayn/deployment.yaml
+++ b/argocd/applications/bayn/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         app.kubernetes.io/name: bayn
         app.kubernetes.io/part-of: bayn
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-07-25T21:05:27Z"
+        kubectl.kubernetes.io/restartedAt: "2026-07-25T21:25:42Z"
     spec:
       serviceAccountName: bayn
       automountServiceAccountToken: false
@@ -56,6 +56,8 @@ spec:
               value: "dc614c54bbf43842d83cd88497e835f7bb25c413eb6e8bd7cbab0a925ec9b2dd"
             - name: BAYN_STRATEGY_PARAMETER_HASH
               value: "e5e4cc5d22b84c4dc8fc65c306d097fda063b0058253da5b900fe1d462d437b3"
+            - name: BAYN_QUALIFICATION_RUN_ID
+              value: "440f5d079247f42c52f31111345c18bfa694263cef052dfb9a32b2b1c8f20861"
             - name: BAYN_MAXIMUM_AUTHORITY
               value: OBSERVE
             - name: BAYN_HEALTH_INTERVAL_MS


### PR DESCRIPTION
## Summary

- pin the exact terminal Bayn qualification run `440f5d079247f42c52f31111345c18bfa694263cef052dfb9a32b2b1c8f20861`
- retain the immutable `cbd908019` image, strategy hashes, fresh 2026-07-24 Signal snapshot, TigerBeetle identity, and `OBSERVE` authority unchanged
- restart Bayn so startup recovers the pinned durable proof instead of evaluating again

## Qualification evidence

The unpinned candidate completed one terminal run:

- economic verdict: `PASS`
- qualification verdict: `REJECTED`
- marked equity difference: `0`
- evidence: 17 artifacts, 697 events, 7 gates
- accounting: 11 accounts and 785 transfers reconciled exactly
- runtime remained `READY`, `OBSERVE`, and zero-mutation

The rejection is terminal qualification evidence; this pin does not claim approval or capital authority.

## Independent audit

The source-pinned read-only auditor was run twice against the exact `cbd908019` source, both physical ClickHouse replicas, PostgreSQL `REPEATABLE READ, READ ONLY`, and authoritative `origin/main` history.

Both reports passed all 45 checks and produced the identical audit hash:

`4bacfa6bf202dd408c8e9e5cd4fa964d92f96e99f58e26f8f5c701cec12f888a`

## Testing

- `bun test packages/scripts/src/bayn` — 20 passed, 0 failed
- `kubectl kustomize argocd/applications/bayn` — rendered successfully
- rendered deployment contains the exact run pin, source, image digest, and snapshot
- release writer returned `promotionAction=promote`, `qualificationMode=install`, and `snapshotChanged=false`
- `git diff --check`

## Breaking Changes

None. Maximum authority remains `OBSERVE`; the terminal qualification verdict remains `REJECTED`.

## Checklist

- [x] The run was produced by the exact immutable deployed candidate.
- [x] Two independent audits produced the same passing audit hash.
- [x] No image, strategy, snapshot, ledger, or authority binding is changed by the pin.
- [x] No audit report or credential material is committed.
