### PR TITLE
refactor(bayn): make ledger verification functional

### DIFF
--- a/services/bayn/src/ledger-plan.test.ts
+++ b/services/bayn/src/ledger-plan.test.ts
@@ -196,6 +196,39 @@ describe('ledger plan Result algebra', () => {
     }
   })
 
+  test('rejects a transferless fixed account with the generic inventory code', () => {
+    const { result, plan } = evaluationPlan()
+    const persisted = materialize(plan)
+    const fixedAccountIndex = persisted.accounts.findIndex((account) => account.code === AccountCode.cashYieldIncome)
+    assert.notEqual(fixedAccountIndex, -1, 'ledger plan must contain the deterministic cash-yield-income account')
+    const fixedAccount = persisted.accounts[fixedAccountIndex]
+    expect(
+      persisted.transfers.some(
+        (transfer) => transfer.debit_account_id === fixedAccount.id || transfer.credit_account_id === fixedAccount.id,
+      ),
+    ).toBeFalse()
+    const invalidAccounts = persisted.accounts.map((account, index) =>
+      index === fixedAccountIndex ? { ...account, code: AccountCode.inventory } : account,
+    )
+    const receipt = {
+      runId: result.runId,
+      accountCount: persisted.accounts.length,
+      transferCount: persisted.transfers.length,
+      exact: true,
+    } as const
+
+    expect(
+      assertFailure(validatePersistedRunEvidence(receipt, ledger, invalidAccounts, persisted.transfers)),
+    ).toMatchObject({
+      operation: 'check-run',
+      reason: 'invalid-account-metadata',
+      material: {
+        account: { id: fixedAccount.id, code: AccountCode.inventory },
+        expected: { deterministicId: fixedAccount.id, code: AccountCode.cashYieldIncome },
+      },
+    })
+  })
+
   test('does not claim event-derived identity without the expected plan', () => {
     const { result, plan } = evaluationPlan()
     const persisted = materialize(plan)

--- a/services/bayn/src/ledger-plan.test.ts
+++ b/services/bayn/src/ledger-plan.test.ts
@@ -1,0 +1,226 @@
+import assert from 'node:assert/strict'
+
+import { describe, expect, test } from 'bun:test'
+import { Result } from 'effect'
+import { type Account, type Transfer } from 'tigerbeetle-node'
+
+import {
+  AccountCode,
+  buildLedgerPlan,
+  preflightTransfers,
+  reconcileLedgerPlan,
+  TransferCode,
+  validatePersistedRunEvidence,
+  type LedgerPlan,
+  type LedgerValidationError,
+} from './ledger-plan'
+import { evaluateRiskBalancedTrend } from './risk-balanced-trend'
+import { fixtureProtocol, makeSnapshot, makeTestProvenance } from './test-fixtures'
+
+const ledger = 7_001
+
+const assertSuccess = <A, E>(result: Result.Result<A, E>): A => {
+  assert(Result.isSuccess(result), 'ledger plan decision must succeed')
+  return result.success
+}
+
+const assertFailure = <A>(result: Result.Result<A, LedgerValidationError>): LedgerValidationError => {
+  assert(Result.isFailure(result), 'ledger plan decision must fail')
+  return result.failure
+}
+
+const evaluationPlan = () => {
+  const snapshot = makeSnapshot()
+  const result = assertSuccess(
+    evaluateRiskBalancedTrend(snapshot.bars, snapshot.manifest, fixtureProtocol, makeTestProvenance()),
+  )
+  return { result, plan: buildLedgerPlan(result, ledger) }
+}
+
+const materialize = (plan: LedgerPlan): { readonly accounts: Account[]; readonly transfers: Transfer[] } => {
+  const balances = new Map(plan.accounts.map((account) => [account.id, { debits: 0n, credits: 0n }]))
+  for (const transfer of plan.transfers) {
+    const debit = balances.get(transfer.debit_account_id)
+    const credit = balances.get(transfer.credit_account_id)
+    assert(debit, `missing debit account ${transfer.debit_account_id}`)
+    assert(credit, `missing credit account ${transfer.credit_account_id}`)
+    debit.debits += transfer.amount
+    credit.credits += transfer.amount
+  }
+  return {
+    accounts: plan.accounts.map((account) => {
+      const balance = balances.get(account.id)
+      assert(balance, `missing account balance ${account.id}`)
+      return {
+        ...account,
+        debits_posted: balance.debits,
+        credits_posted: balance.credits,
+        timestamp: 1n,
+      }
+    }),
+    transfers: plan.transfers.map((transfer) => ({ ...transfer, timestamp: 1n })),
+  }
+}
+
+describe('ledger plan Result algebra', () => {
+  test('partitions exact existing transfers and preserves missing request order', () => {
+    const { plan } = evaluationPlan()
+    const existing = [plan.transfers[1], plan.transfers.at(-1)].filter(
+      (transfer): transfer is Transfer => transfer !== undefined,
+    )
+    const missing = assertSuccess(preflightTransfers(plan.transfers, existing))
+
+    expect(missing.map((transfer) => transfer.id)).toEqual(
+      plan.transfers
+        .filter((transfer) => !existing.some((present) => present.id === transfer.id))
+        .map((transfer) => transfer.id),
+    )
+
+    const mismatch = assertFailure(
+      preflightTransfers(plan.transfers, [{ ...plan.transfers[0], amount: plan.transfers[0].amount + 1n }]),
+    )
+    expect(mismatch).toMatchObject({
+      operation: 'preflight-transfers',
+      reason: 'record-mismatch',
+      material: { id: plan.transfers[0].id },
+    })
+  })
+
+  test('reconciles exact sets and posted balances without throwing assertions', () => {
+    const { plan } = evaluationPlan()
+    const persisted = materialize(plan)
+
+    expect(Result.isSuccess(reconcileLedgerPlan(plan, persisted.accounts, persisted.transfers))).toBeTrue()
+    expect(
+      assertFailure(
+        reconcileLedgerPlan(plan, persisted.accounts, [
+          ...persisted.transfers,
+          { ...persisted.transfers[0], id: persisted.transfers[0].id + 1n },
+        ]),
+      ),
+    ).toMatchObject({ operation: 'reconcile', reason: 'record-set-mismatch' })
+    expect(
+      assertFailure(
+        reconcileLedgerPlan(
+          plan,
+          [
+            { ...persisted.accounts[0], credits_posted: persisted.accounts[0].credits_posted + 1n },
+            ...persisted.accounts.slice(1),
+          ],
+          persisted.transfers,
+        ),
+      ),
+    ).toMatchObject({ operation: 'reconcile', reason: 'invalid-balance' })
+  })
+
+  test('validates all locally reconstructible persisted-run metadata', () => {
+    const { result, plan } = evaluationPlan()
+    const persisted = materialize(plan)
+    const receipt = {
+      runId: result.runId,
+      accountCount: persisted.accounts.length,
+      transferCount: persisted.transfers.length,
+      exact: true,
+    } as const
+
+    expect(
+      Result.isSuccess(validatePersistedRunEvidence(receipt, ledger, persisted.accounts, persisted.transfers)),
+    ).toBeTrue()
+
+    for (const invalidAccount of [
+      { ...persisted.accounts[0], code: 999 },
+      { ...persisted.accounts[0], flags: 0 },
+      { ...persisted.accounts[0], reserved: 1 },
+      { ...persisted.accounts[0], timestamp: 0n },
+    ]) {
+      expect(
+        assertFailure(
+          validatePersistedRunEvidence(
+            receipt,
+            ledger,
+            [invalidAccount, ...persisted.accounts.slice(1)],
+            persisted.transfers,
+          ),
+        ),
+      ).toMatchObject({ operation: 'check-run', reason: 'invalid-account-metadata' })
+    }
+
+    for (const invalidTransfer of [
+      { ...persisted.transfers[0], code: 999 },
+      { ...persisted.transfers[0], flags: 1 },
+      { ...persisted.transfers[0], pending_id: 1n },
+      { ...persisted.transfers[0], timeout: 1 },
+      { ...persisted.transfers[0], timestamp: 0n },
+    ]) {
+      expect(
+        assertFailure(
+          validatePersistedRunEvidence(receipt, ledger, persisted.accounts, [
+            invalidTransfer,
+            ...persisted.transfers.slice(1),
+          ]),
+        ),
+      ).toMatchObject({ operation: 'check-run', reason: 'invalid-transfer-metadata' })
+    }
+
+    const cashIndex = persisted.accounts.findIndex((account) => account.code === AccountCode.cash)
+    assert.notEqual(cashIndex, -1, 'ledger plan must contain deterministic cash account')
+    const cash = persisted.accounts[cashIndex]
+    const changedCashId = cash.id ^ (1n << 127n)
+    const invalidIdentityAccounts = persisted.accounts.map((account, index) =>
+      index === cashIndex ? { ...account, id: changedCashId } : account,
+    )
+    const invalidIdentityTransfers = persisted.transfers.map((transfer) => ({
+      ...transfer,
+      debit_account_id: transfer.debit_account_id === cash.id ? changedCashId : transfer.debit_account_id,
+      credit_account_id: transfer.credit_account_id === cash.id ? changedCashId : transfer.credit_account_id,
+    }))
+    expect(
+      assertFailure(validatePersistedRunEvidence(receipt, ledger, invalidIdentityAccounts, invalidIdentityTransfers)),
+    ).toMatchObject({ operation: 'check-run', reason: 'invalid-account-metadata' })
+
+    const fundingIndex = persisted.transfers.findIndex((transfer) => transfer.code === TransferCode.funding)
+    assert.notEqual(fundingIndex, -1, 'ledger plan must contain deterministic funding')
+    for (const replacement of [
+      { ...persisted.transfers[fundingIndex], id: persisted.transfers[fundingIndex].id ^ (1n << 127n) },
+      {
+        ...persisted.transfers[fundingIndex],
+        user_data_128: persisted.transfers[fundingIndex].user_data_128 ^ (1n << 127n),
+      },
+    ]) {
+      const invalidFunding = persisted.transfers.map((transfer, index) =>
+        index === fundingIndex ? replacement : transfer,
+      )
+      expect(
+        assertFailure(validatePersistedRunEvidence(receipt, ledger, persisted.accounts, invalidFunding)),
+      ).toMatchObject({ operation: 'check-run', reason: 'invalid-transfer-metadata' })
+    }
+  })
+
+  test('does not claim event-derived identity without the expected plan', () => {
+    const { result, plan } = evaluationPlan()
+    const persisted = materialize(plan)
+    const eventTransferIndex = persisted.transfers.findIndex((transfer) => transfer.code !== TransferCode.funding)
+    assert.notEqual(eventTransferIndex, -1, 'ledger plan must contain an event-derived transfer')
+    const original = persisted.transfers[eventTransferIndex]
+    const locallyConsistent = persisted.transfers.map((transfer, index) =>
+      index === eventTransferIndex
+        ? {
+            ...transfer,
+            id: original.id ^ (1n << 127n),
+            user_data_128: original.user_data_128 ^ (1n << 127n),
+          }
+        : transfer,
+    )
+    const receipt = {
+      runId: result.runId,
+      accountCount: persisted.accounts.length,
+      transferCount: persisted.transfers.length,
+      exact: true,
+    } as const
+
+    expect(
+      Result.isSuccess(validatePersistedRunEvidence(receipt, ledger, persisted.accounts, locallyConsistent)),
+    ).toBeTrue()
+    expect(Result.isFailure(reconcileLedgerPlan(plan, persisted.accounts, locallyConsistent))).toBeTrue()
+  })
+})

--- a/services/bayn/src/ledger-plan.ts
+++ b/services/bayn/src/ledger-plan.ts
@@ -1,7 +1,8 @@
+import { Data, Result } from 'effect'
 import { AccountFlags, type Account, type Transfer } from 'tigerbeetle-node'
 
 import { canonicalHashV1, stableU128, stableU64 } from './hash'
-import type { CashYieldEvent, EvaluationEvent, FeeEvent, FillEvent, InputManifest } from './types'
+import type { CashYieldEvent, EvaluationEvent, FeeEvent, FillEvent, InputManifest, ReconciliationResult } from './types'
 
 export const LEDGER_SCHEMA_VERSION = 2
 export const LEDGER_BATCH_MAX = 8_189
@@ -25,6 +26,65 @@ export const TransferCode = {
   fee: 6,
   cashYield: 7,
 } as const
+
+export type LedgerValidationOperation =
+  | 'build-account-reconciliation'
+  | 'build-plan'
+  | 'build-transaction-transfer-query'
+  | 'check-run'
+  | 'post'
+  | 'preflight-transfers'
+  | 'reconcile'
+  | 'verify-account'
+  | 'verify-account-results'
+  | 'verify-existing-accounts'
+  | 'verify-existing-transfers'
+  | 'verify-posted-plan'
+  | 'verify-transfer-results'
+
+export type LedgerValidationReason =
+  | 'batch-limit'
+  | 'batch-result-count'
+  | 'create-rejected'
+  | 'duplicate-account'
+  | 'duplicate-transfer'
+  | 'empty-plan'
+  | 'invalid-account-metadata'
+  | 'invalid-balance'
+  | 'invalid-transaction'
+  | 'invalid-transfer-metadata'
+  | 'ledger-plan-failure'
+  | 'missing-balance'
+  | 'record-mismatch'
+  | 'record-set-mismatch'
+  | 'run-count-mismatch'
+  | 'unknown-account-reference'
+  | 'wrong-account'
+
+export class LedgerValidationError extends Data.TaggedError('LedgerValidationError')<{
+  readonly operation: LedgerValidationOperation
+  readonly reason: LedgerValidationReason
+  readonly message: string
+  readonly material: Readonly<Record<string, unknown>>
+  readonly cause?: unknown
+}> {}
+
+export const ledgerValidationError = (
+  operation: LedgerValidationOperation,
+  reason: LedgerValidationReason,
+  message: string,
+  material: Readonly<Record<string, unknown>>,
+  cause?: unknown,
+): LedgerValidationError => new LedgerValidationError({ operation, reason, message, material, cause })
+
+export const failLedgerValidation = (
+  operation: LedgerValidationOperation,
+  reason: LedgerValidationReason,
+  detail: string,
+  material: Readonly<Record<string, unknown>>,
+  cause?: unknown,
+): Result.Result<never, LedgerValidationError> =>
+  Result.fail(ledgerValidationError(operation, reason, `TigerBeetle ${operation} failed: ${detail}`, material, cause))
 
 export interface LedgerPlan {
   readonly runKey: bigint
@@ -265,16 +325,17 @@ export const hashLedgerPlan = (plan: LedgerPlan): string =>
     transfers: plan.transfers.map(serializeRecord),
   })
 
-const accountMetadataMatches = (actual: Account, expected: Account): boolean =>
+export const accountMetadataMatches = (actual: Account, expected: Account): boolean =>
   actual.id === expected.id &&
   actual.user_data_128 === expected.user_data_128 &&
   actual.user_data_64 === expected.user_data_64 &&
   actual.user_data_32 === expected.user_data_32 &&
+  actual.reserved === expected.reserved &&
   actual.ledger === expected.ledger &&
   actual.code === expected.code &&
   actual.flags === expected.flags
 
-const transferMatches = (actual: Transfer, expected: Transfer): boolean =>
+export const transferMetadataMatches = (actual: Transfer, expected: Transfer): boolean =>
   actual.id === expected.id &&
   actual.debit_account_id === expected.debit_account_id &&
   actual.credit_account_id === expected.credit_account_id &&
@@ -288,56 +349,435 @@ const transferMatches = (actual: Transfer, expected: Transfer): boolean =>
   actual.code === expected.code &&
   actual.flags === expected.flags
 
-const assertUniqueExact = <T extends { readonly id: bigint }>(
-  kind: string,
-  actual: readonly T[],
-  expected: readonly T[],
-  matches: (actualValue: T, expectedValue: T) => boolean,
-): void => {
-  const expectedById = new Map(expected.map((value) => [value.id, value]))
-  if (actual.length !== expected.length || new Set(actual.map((value) => value.id)).size !== actual.length) {
-    throw new Error(`${kind} set mismatch: expected ${expected.length}, received ${actual.length}`)
+const duplicateRecordId = <Record extends { readonly id: bigint }>(records: readonly Record[]): bigint | undefined => {
+  const ids = new Set<bigint>()
+  for (const record of records) {
+    if (ids.has(record.id)) return record.id
+    ids.add(record.id)
   }
-  for (const value of actual) {
-    const expectedValue = expectedById.get(value.id)
-    if (!expectedValue || !matches(value, expectedValue)) throw new Error(`${kind} ${value.id} does not match its plan`)
-  }
+  return undefined
 }
 
-export const assertAccountsMatch = (kind: string, actual: readonly Account[], expected: readonly Account[]): void =>
-  assertUniqueExact(kind, actual, expected, accountMetadataMatches)
+const verifyUniqueExact = <Record extends { readonly id: bigint }>(
+  operation: LedgerValidationOperation,
+  kind: string,
+  actual: readonly Record[],
+  expected: readonly Record[],
+  matches: (actualValue: Record, expectedValue: Record) => boolean,
+): Result.Result<void, LedgerValidationError> => {
+  const actualDuplicateId = duplicateRecordId(actual)
+  const expectedDuplicateId = duplicateRecordId(expected)
+  if (actual.length !== expected.length || actualDuplicateId !== undefined || expectedDuplicateId !== undefined) {
+    return failLedgerValidation(
+      operation,
+      'record-set-mismatch',
+      `${kind} set mismatch: expected ${expected.length}, received ${actual.length}`,
+      {
+        kind,
+        expectedCount: expected.length,
+        actualCount: actual.length,
+        ...(actualDuplicateId === undefined ? {} : { duplicateId: actualDuplicateId }),
+        ...(expectedDuplicateId === undefined ? {} : { duplicateExpectedId: expectedDuplicateId }),
+      },
+    )
+  }
 
-export const assertTransfersMatch = (kind: string, actual: readonly Transfer[], expected: readonly Transfer[]): void =>
-  assertUniqueExact(kind, actual, expected, transferMatches)
+  const expectedById = new Map(expected.map((value) => [value.id, value]))
+  for (const value of actual) {
+    const expectedValue = expectedById.get(value.id)
+    if (expectedValue === undefined || !matches(value, expectedValue)) {
+      return failLedgerValidation(operation, 'record-mismatch', `${kind} ${value.id} does not match its plan`, {
+        kind,
+        id: value.id,
+        actual: value,
+        expected: expectedValue,
+      })
+    }
+  }
+  return Result.succeed(undefined)
+}
 
-export const assertReconciled = (
+export const verifyExactAccounts = (
+  operation: LedgerValidationOperation,
+  kind: string,
+  actual: readonly Account[],
+  expected: readonly Account[],
+): Result.Result<void, LedgerValidationError> =>
+  verifyUniqueExact(operation, kind, actual, expected, accountMetadataMatches)
+
+export const verifyExactTransfers = (
+  operation: LedgerValidationOperation,
+  kind: string,
+  actual: readonly Transfer[],
+  expected: readonly Transfer[],
+): Result.Result<void, LedgerValidationError> =>
+  verifyUniqueExact(operation, kind, actual, expected, transferMetadataMatches)
+
+export const verifyLedgerPlanRecords = (
+  operation: LedgerValidationOperation,
+  accountKind: string,
+  transferKind: string,
   plan: LedgerPlan,
   actualAccounts: readonly Account[],
   actualTransfers: readonly Transfer[],
-): void => {
-  assertAccountsMatch('account', actualAccounts, plan.accounts)
-  assertTransfersMatch('transfer', actualTransfers, plan.transfers)
+): Result.Result<void, LedgerValidationError> =>
+  Result.gen(function* () {
+    yield* verifyExactAccounts(operation, accountKind, actualAccounts, plan.accounts)
+    yield* verifyExactTransfers(operation, transferKind, actualTransfers, plan.transfers)
+  })
 
-  const expectedBalances = new Map(plan.accounts.map((value) => [value.id, { debits: 0n, credits: 0n }]))
-  for (const value of plan.transfers) {
-    const debit = expectedBalances.get(value.debit_account_id)
-    const credit = expectedBalances.get(value.credit_account_id)
-    if (debit === undefined || credit === undefined) {
-      throw new Error(`transfer ${value.id} references an unknown account`)
-    }
-    debit.debits += value.amount
-    credit.credits += value.amount
+export const preflightTransfers = (
+  expected: readonly Transfer[],
+  existing: readonly Transfer[],
+): Result.Result<readonly Transfer[], LedgerValidationError> => {
+  const expectedDuplicateId = duplicateRecordId(expected)
+  const existingDuplicateId = duplicateRecordId(existing)
+  if (expectedDuplicateId !== undefined || existingDuplicateId !== undefined) {
+    return failLedgerValidation(
+      'preflight-transfers',
+      'record-set-mismatch',
+      'transfer preflight contains duplicate deterministic IDs',
+      {
+        expectedCount: expected.length,
+        actualCount: existing.length,
+        ...(expectedDuplicateId === undefined ? {} : { duplicateExpectedId: expectedDuplicateId }),
+        ...(existingDuplicateId === undefined ? {} : { duplicateId: existingDuplicateId }),
+      },
+    )
   }
-  for (const value of actualAccounts) {
-    const balance = expectedBalances.get(value.id)
-    if (balance === undefined) throw new Error(`unexpected account ${value.id}`)
-    if (
-      value.debits_pending !== 0n ||
-      value.credits_pending !== 0n ||
-      value.debits_posted !== balance.debits ||
-      value.credits_posted !== balance.credits
-    ) {
-      throw new Error(`account ${value.id} balance does not reconcile exactly`)
+
+  const expectedById = new Map(expected.map((transfer) => [transfer.id, transfer]))
+  const existingIds = new Set<bigint>()
+  for (const transfer of existing) {
+    const expectedTransfer = expectedById.get(transfer.id)
+    if (expectedTransfer === undefined || !transferMetadataMatches(transfer, expectedTransfer)) {
+      return failLedgerValidation(
+        'preflight-transfers',
+        'record-mismatch',
+        `existing transfer ${transfer.id} does not match its plan`,
+        {
+          kind: 'existing transfer',
+          id: transfer.id,
+          actual: transfer,
+          expected: expectedTransfer,
+        },
+      )
     }
+    existingIds.add(transfer.id)
   }
+
+  return Result.succeed(expected.filter((transfer) => !existingIds.has(transfer.id)))
 }
+
+interface LedgerBalances {
+  readonly accountsById: ReadonlyMap<bigint, Account>
+  readonly transfersById: ReadonlyMap<bigint, Transfer>
+}
+
+const reconcileBalances = (
+  operation: 'check-run' | 'reconcile' | 'verify-account',
+  accounts: readonly Account[],
+  transfers: readonly Transfer[],
+  runId?: string,
+): Result.Result<LedgerBalances, LedgerValidationError> => {
+  const accountDuplicateId = duplicateRecordId(accounts)
+  if (accountDuplicateId !== undefined) {
+    return failLedgerValidation(
+      operation,
+      'duplicate-account',
+      runId === undefined
+        ? `ledger contains duplicate account ${accountDuplicateId}`
+        : `run ${runId} contains duplicate account ${accountDuplicateId}`,
+      { ...(runId === undefined ? {} : { runId }), accountId: accountDuplicateId },
+    )
+  }
+  const transferDuplicateId = duplicateRecordId(transfers)
+  if (transferDuplicateId !== undefined) {
+    return failLedgerValidation(
+      operation,
+      'duplicate-transfer',
+      runId === undefined
+        ? `ledger contains duplicate transfer ${transferDuplicateId}`
+        : `run ${runId} contains duplicate transfer ${transferDuplicateId}`,
+      { ...(runId === undefined ? {} : { runId }), transferId: transferDuplicateId },
+    )
+  }
+
+  const accountsById = new Map(accounts.map((account) => [account.id, account]))
+  const transfersById = new Map(transfers.map((transfer) => [transfer.id, transfer]))
+  const balances = new Map(accounts.map((account) => [account.id, { debits: 0n, credits: 0n }]))
+  for (const transfer of transfers) {
+    const debit = balances.get(transfer.debit_account_id)
+    const credit = balances.get(transfer.credit_account_id)
+    if (debit === undefined || credit === undefined) {
+      return failLedgerValidation(
+        operation,
+        'unknown-account-reference',
+        runId === undefined
+          ? `transfer ${transfer.id} references an unknown account`
+          : `run ${runId} transfer ${transfer.id} references an account outside the run`,
+        {
+          ...(runId === undefined ? {} : { runId }),
+          transferId: transfer.id,
+          debitAccountId: transfer.debit_account_id,
+          creditAccountId: transfer.credit_account_id,
+        },
+      )
+    }
+    if (transfer.debit_account_id === transfer.credit_account_id) {
+      balances.set(transfer.debit_account_id, {
+        debits: debit.debits + transfer.amount,
+        credits: debit.credits + transfer.amount,
+      })
+    } else {
+      balances.set(transfer.debit_account_id, {
+        debits: debit.debits + transfer.amount,
+        credits: debit.credits,
+      })
+      balances.set(transfer.credit_account_id, {
+        debits: credit.debits,
+        credits: credit.credits + transfer.amount,
+      })
+    }
+  }
+
+  for (const account of accounts) {
+    const balance = balances.get(account.id)
+    if (balance === undefined) {
+      return failLedgerValidation(
+        operation,
+        'missing-balance',
+        runId === undefined
+          ? `unexpected account ${account.id}`
+          : `run ${runId} has no balance for account ${account.id}`,
+        { ...(runId === undefined ? {} : { runId }), accountId: account.id },
+      )
+    }
+    if (
+      account.debits_pending !== 0n ||
+      account.credits_pending !== 0n ||
+      account.debits_posted !== balance.debits ||
+      account.credits_posted !== balance.credits
+    ) {
+      return failLedgerValidation(
+        operation,
+        'invalid-balance',
+        runId === undefined
+          ? `account ${account.id} balance does not reconcile exactly`
+          : `run ${runId} account ${account.id} balance does not reconcile locally`,
+        { ...(runId === undefined ? {} : { runId }), account, expected: balance },
+      )
+    }
+  }
+  return Result.succeed({ accountsById, transfersById })
+}
+
+export const reconcileLedgerPlan = (
+  plan: LedgerPlan,
+  actualAccounts: readonly Account[],
+  actualTransfers: readonly Transfer[],
+  operation: 'reconcile' | 'verify-account' = 'reconcile',
+): Result.Result<void, LedgerValidationError> =>
+  Result.gen(function* () {
+    yield* verifyLedgerPlanRecords(operation, 'account', 'transfer', plan, actualAccounts, actualTransfers)
+    yield* reconcileBalances(operation, actualAccounts, actualTransfers)
+  })
+
+const fixedAccountNames = new Map<number, string>([
+  [AccountCode.cash, 'cash'],
+  [AccountCode.equity, 'equity'],
+  [AccountCode.realizedGain, 'realized-gain'],
+  [AccountCode.cashYieldIncome, 'cash-yield-income'],
+  [AccountCode.feeExpense, 'fee-expense'],
+  [AccountCode.realizedLoss, 'realized-loss'],
+])
+const accountCodes = new Set<number>(Object.values(AccountCode))
+const transferCodes = new Set<number>(Object.values(TransferCode))
+const transferAccountCodes = new Map<number, readonly [number, number]>([
+  [TransferCode.funding, [AccountCode.cash, AccountCode.equity]],
+  [TransferCode.buy, [AccountCode.inventory, AccountCode.cash]],
+  [TransferCode.sellBasis, [AccountCode.cash, AccountCode.inventory]],
+  [TransferCode.realizedGain, [AccountCode.cash, AccountCode.realizedGain]],
+  [TransferCode.realizedLoss, [AccountCode.realizedLoss, AccountCode.inventory]],
+  [TransferCode.fee, [AccountCode.feeExpense, AccountCode.cash]],
+  [TransferCode.cashYield, [AccountCode.cash, AccountCode.cashYieldIncome]],
+])
+
+const verifyPersistedAccount = (
+  result: ReconciliationResult,
+  ledger: number,
+  runKey: bigint,
+  runTag: bigint,
+  value: Account,
+): Result.Result<void, LedgerValidationError> => {
+  const fixedName = fixedAccountNames.get(value.code)
+  const expectedId = fixedName === undefined ? undefined : stableU128('bayn-account-v1', result.runId, fixedName)
+  if (
+    value.id === 0n ||
+    value.user_data_128 !== runKey ||
+    value.user_data_64 !== runTag ||
+    value.user_data_32 !== LEDGER_SCHEMA_VERSION ||
+    value.reserved !== 0 ||
+    value.ledger !== ledger ||
+    !accountCodes.has(value.code) ||
+    value.flags !== AccountFlags.history ||
+    value.timestamp <= 0n ||
+    (expectedId !== undefined && value.id !== expectedId)
+  ) {
+    return failLedgerValidation(
+      'check-run',
+      'invalid-account-metadata',
+      `run ${result.runId} account ${value.id} has invalid locally verifiable metadata`,
+      {
+        runId: result.runId,
+        account: value,
+        expected: {
+          runKey,
+          runTag,
+          schemaVersion: LEDGER_SCHEMA_VERSION,
+          reserved: 0,
+          ledger,
+          accountCodes: [...accountCodes],
+          flags: AccountFlags.history,
+          positiveTimestamp: true,
+          ...(expectedId === undefined ? {} : { deterministicId: expectedId }),
+        },
+      },
+    )
+  }
+  return Result.succeed(undefined)
+}
+
+const verifyPersistedTransfer = (
+  result: ReconciliationResult,
+  ledger: number,
+  runTag: bigint,
+  accountsById: ReadonlyMap<bigint, Account>,
+  value: Transfer,
+): Result.Result<void, LedgerValidationError> => {
+  const debit = accountsById.get(value.debit_account_id)
+  const credit = accountsById.get(value.credit_account_id)
+  const accountCodePair = transferAccountCodes.get(value.code)
+  const fundingId = stableU128('bayn-transfer-v1', result.runId, 'funding', 'principal')
+  const fundingEventId = stableU128(
+    'bayn-event-v1',
+    canonicalHashV1({ kind: 'funding', runId: result.runId, amountMicros: value.amount.toString() }),
+  )
+  if (
+    value.id === 0n ||
+    value.debit_account_id === value.credit_account_id ||
+    value.amount <= 0n ||
+    value.pending_id !== 0n ||
+    value.user_data_128 === 0n ||
+    value.user_data_64 !== runTag ||
+    value.user_data_32 !== LEDGER_SCHEMA_VERSION ||
+    value.timeout !== 0 ||
+    value.ledger !== ledger ||
+    !transferCodes.has(value.code) ||
+    value.flags !== 0 ||
+    value.timestamp <= 0n ||
+    debit === undefined ||
+    credit === undefined ||
+    accountCodePair === undefined ||
+    debit.code !== accountCodePair[0] ||
+    credit.code !== accountCodePair[1] ||
+    (value.code === TransferCode.funding && (value.id !== fundingId || value.user_data_128 !== fundingEventId))
+  ) {
+    return failLedgerValidation(
+      'check-run',
+      'invalid-transfer-metadata',
+      `run ${result.runId} transfer ${value.id} has invalid locally verifiable metadata`,
+      {
+        runId: result.runId,
+        transfer: value,
+        expected: {
+          runTag,
+          schemaVersion: LEDGER_SCHEMA_VERSION,
+          pendingId: 0n,
+          timeout: 0,
+          ledger,
+          transferCodes: [...transferCodes],
+          flags: 0,
+          positiveTimestamp: true,
+          accountCodePair,
+          ...(value.code === TransferCode.funding
+            ? { deterministicId: fundingId, deterministicEventId: fundingEventId }
+            : {}),
+        },
+      },
+    )
+  }
+  return Result.succeed(undefined)
+}
+
+/**
+ * Validates only invariants recoverable from a persisted reconciliation receipt and TigerBeetle records.
+ * Inventory symbols and event-derived IDs and hashes other than funding are not persisted in those inputs; they require
+ * the original expected plan and are checked by reconcileLedgerPlan instead.
+ */
+export const validatePersistedRunEvidence = (
+  result: ReconciliationResult,
+  ledger: number,
+  accounts: readonly Account[],
+  transfers: readonly Transfer[],
+): Result.Result<void, LedgerValidationError> =>
+  Result.gen(function* () {
+    if (accounts.length !== result.accountCount) {
+      return yield* failLedgerValidation(
+        'check-run',
+        'run-count-mismatch',
+        `run ${result.runId} has ${accounts.length} accounts; expected ${result.accountCount}`,
+        {
+          runId: result.runId,
+          kind: 'account',
+          actualCount: accounts.length,
+          expectedCount: result.accountCount,
+        },
+      )
+    }
+    if (transfers.length !== result.transferCount) {
+      return yield* failLedgerValidation(
+        'check-run',
+        'run-count-mismatch',
+        `run ${result.runId} has ${transfers.length} transfers; expected ${result.transferCount}`,
+        {
+          runId: result.runId,
+          kind: 'transfer',
+          actualCount: transfers.length,
+          expectedCount: result.transferCount,
+        },
+      )
+    }
+
+    const runKey = stableU128('bayn-run-v1', result.runId)
+    const runTag = stableU64('bayn-run-v1', result.runId)
+    const reconciled = yield* reconcileBalances('check-run', accounts, transfers, result.runId)
+    for (const account of accounts) {
+      yield* verifyPersistedAccount(result, ledger, runKey, runTag, account)
+    }
+    if (accounts.length > 0) {
+      for (const [code, name] of fixedAccountNames) {
+        const expectedId = stableU128('bayn-account-v1', result.runId, name)
+        if (!reconciled.accountsById.has(expectedId)) {
+          return yield* failLedgerValidation(
+            'check-run',
+            'record-set-mismatch',
+            `run ${result.runId} is missing required ${name} account`,
+            { runId: result.runId, kind: 'account', code, expectedId },
+          )
+        }
+      }
+    }
+    for (const transfer of transfers) {
+      yield* verifyPersistedTransfer(result, ledger, runTag, reconciled.accountsById, transfer)
+    }
+    const fundingId = stableU128('bayn-transfer-v1', result.runId, 'funding', 'principal')
+    if (transfers.length > 0 && !reconciled.transfersById.has(fundingId)) {
+      return yield* failLedgerValidation(
+        'check-run',
+        'record-set-mismatch',
+        `run ${result.runId} is missing its deterministic funding transfer`,
+        { runId: result.runId, kind: 'transfer', code: TransferCode.funding, expectedId: fundingId },
+      )
+    }
+  })

--- a/services/bayn/src/ledger-plan.ts
+++ b/services/bayn/src/ledger-plan.ts
@@ -758,12 +758,25 @@ export const validatePersistedRunEvidence = (
     if (accounts.length > 0) {
       for (const [code, name] of fixedAccountNames) {
         const expectedId = stableU128('bayn-account-v1', result.runId, name)
-        if (!reconciled.accountsById.has(expectedId)) {
+        const persistedAccount = reconciled.accountsById.get(expectedId)
+        if (persistedAccount === undefined) {
           return yield* failLedgerValidation(
             'check-run',
             'record-set-mismatch',
             `run ${result.runId} is missing required ${name} account`,
             { runId: result.runId, kind: 'account', code, expectedId },
+          )
+        }
+        if (persistedAccount.code !== code) {
+          return yield* failLedgerValidation(
+            'check-run',
+            'invalid-account-metadata',
+            `run ${result.runId} required ${name} account has code ${persistedAccount.code}; expected ${code}`,
+            {
+              runId: result.runId,
+              account: persistedAccount,
+              expected: { deterministicId: expectedId, code },
+            },
           )
         }
       }

--- a/services/bayn/src/ledger.test.ts
+++ b/services/bayn/src/ledger.test.ts
@@ -1,28 +1,40 @@
 import assert from 'node:assert/strict'
 
 import { describe, expect, test } from 'bun:test'
-import { Effect, Redacted, Result } from 'effect'
+import { Cause, Effect, Exit, Redacted, Result } from 'effect'
 import { CreateAccountStatus, CreateTransferStatus, type Account, type Transfer } from 'tigerbeetle-node'
 
 import { prepareAccounting, rebuildAccountingLedger } from './accounting'
 import type { RuntimeConfig } from './config'
 import { Authority, OrderSide, type Fill } from './paper'
 import {
-  assertReconciled,
+  assembleAccountPlan,
   buildLedgerPlan,
+  classifyAccountCreateBatch,
+  classifyTransferCreateBatch,
   hashLedgerPlan,
   Journal,
   JournalLive,
+  LedgerValidationError,
+  reconcileLedgerPlan,
   resolveReplicaAddresses,
+  transactionTransferQuery,
+  validatePersistedRunEvidence,
   type JournalService,
   type TigerBeetleClient,
 } from './ledger'
+import { LEDGER_BATCH_MAX } from './ledger-plan'
 import { evaluateRiskBalancedTrend } from './risk-balanced-trend'
 import { fixtureProtocol, makeSnapshot, makeTestProvenance } from './test-fixtures'
 
 const assertSuccess = <A, E>(result: Result.Result<A, E>): A => {
   assert(Result.isSuccess(result), 'strategy evaluation fixture must succeed')
   return result.success
+}
+
+const assertFailure = <A, E>(result: Result.Result<A, E>): E => {
+  assert(Result.isFailure(result), 'ledger decision fixture must fail')
+  return result.failure
 }
 
 const materializeAccounts = (plan: ReturnType<typeof buildLedgerPlan>): Account[] => {
@@ -51,6 +63,36 @@ const journalConfig = {
   operationTimeoutMs: 1_000,
   tigerBeetle: { clusterId: 222397790944575595450310052784555675227n, replicaAddresses: ['3000'], ledger: 7_001 },
 } satisfies Pick<RuntimeConfig, 'operationTimeoutMs' | 'tigerBeetle'>
+
+const paperFill = (fillId: string, accountId = 'paper-account'): Fill => ({
+  schemaVersion: 'bayn.paper-fill.v1',
+  accountId,
+  fillId,
+  brokerOrderId: `broker-${fillId}`,
+  clientOrderId: `client-${fillId}`,
+  symbol: 'NVDA',
+  side: OrderSide.Buy,
+  quantityMicros: '1000000',
+  priceMicros: '100000000',
+  feeMicros: '100',
+  occurredAt: '2026-07-22T15:30:00.000Z',
+})
+
+const paperPlan = (fillId: string, accountId = 'paper-account') =>
+  prepareAccounting(
+    fillId.padEnd(64, fillId[0] ?? 'a').slice(0, 64),
+    paperFill(fillId, accountId),
+    { quantityMicros: '0', costMicros: '0' },
+    journalConfig.tigerBeetle.ledger,
+  ).ledger
+
+const evaluationPlan = () => {
+  const snapshot = makeSnapshot()
+  const result = assertSuccess(
+    evaluateRiskBalancedTrend(snapshot.bars, snapshot.manifest, fixtureProtocol, makeTestProvenance()),
+  )
+  return { result, plan: buildLedgerPlan(result, journalConfig.tigerBeetle.ledger) }
+}
 
 const makeTigerBeetleClient = (overrides: Partial<TigerBeetleClient> = {}): TigerBeetleClient => ({
   createAccounts: async () => [],
@@ -130,6 +172,174 @@ const withJournal = <A, E>(client: TigerBeetleClient, use: (journal: JournalServ
     ),
   )
 
+describe('TigerBeetle ledger decisions', () => {
+  test('classifies account and transfer create batches without losing request order or rejection material', () => {
+    const plan = paperPlan('a')
+    const accounts = plan.accounts.slice(0, 2)
+    const accountDecision = classifyAccountCreateBatch(accounts, [
+      { timestamp: 1n, status: CreateAccountStatus.exists },
+      { timestamp: 2n, status: CreateAccountStatus.created },
+    ])
+    expect(assertSuccess(accountDecision)).toEqual([accounts[0]])
+
+    const rejectedAccount = assertFailure(
+      classifyAccountCreateBatch(accounts, [
+        { timestamp: 1n, status: CreateAccountStatus.created },
+        { timestamp: 2n, status: CreateAccountStatus.exists_with_different_code },
+      ]),
+    )
+    expect(rejectedAccount).toBeInstanceOf(LedgerValidationError)
+    expect(rejectedAccount).toMatchObject({
+      operation: 'verify-account-results',
+      reason: 'create-rejected',
+      material: {
+        kind: 'account',
+        id: accounts[1].id,
+        status: CreateAccountStatus.exists_with_different_code,
+      },
+    })
+
+    const transfers = plan.transfers.slice(0, 2)
+    expect(
+      assertSuccess(
+        classifyTransferCreateBatch(transfers, [
+          { timestamp: 1n, status: CreateTransferStatus.created },
+          { timestamp: 2n, status: CreateTransferStatus.exists },
+        ]),
+      ),
+    ).toEqual([transfers[1]])
+
+    const incomplete = assertFailure(classifyTransferCreateBatch(transfers, []))
+    expect(incomplete).toMatchObject({
+      operation: 'verify-transfer-results',
+      reason: 'batch-result-count',
+      material: { kind: 'transfer', expectedCount: transfers.length, actualCount: 0 },
+    })
+  })
+
+  test('builds one exact transaction query and rejects empty or mixed transaction plans', () => {
+    const plan = paperPlan('a')
+    const query = assertSuccess(transactionTransferQuery(plan))
+    expect(query).toEqual({
+      user_data_128: plan.transfers[0].user_data_128,
+      user_data_64: 0n,
+      user_data_32: 0,
+      ledger: journalConfig.tigerBeetle.ledger,
+      code: 0,
+      timestamp_min: 0n,
+      timestamp_max: 0n,
+      limit: plan.transfers.length + 1,
+      flags: 0,
+    })
+
+    const empty = assertFailure(transactionTransferQuery({ ...plan, accounts: [], transfers: [] }))
+    expect(empty).toMatchObject({ operation: 'post', reason: 'empty-plan' })
+
+    const atLimit = assertFailure(
+      transactionTransferQuery({
+        ...plan,
+        accounts: Array.from({ length: LEDGER_BATCH_MAX }, () => plan.accounts[0]),
+      }),
+    )
+    expect(atLimit).toMatchObject({
+      operation: 'post',
+      reason: 'batch-limit',
+      material: { accountCount: LEDGER_BATCH_MAX, limit: LEDGER_BATCH_MAX },
+    })
+
+    const mixed = assertFailure(
+      transactionTransferQuery({
+        ...plan,
+        transfers: [plan.transfers[0], { ...plan.transfers[1], user_data_128: plan.transfers[0].user_data_128 + 1n }],
+      }),
+    )
+    expect(mixed).toMatchObject({
+      operation: 'build-transaction-transfer-query',
+      reason: 'invalid-transaction',
+    })
+  })
+
+  test('assembles paper account plans with exact deduplication and duplicate-transfer rejection', () => {
+    const first = paperPlan('a')
+    const second = paperPlan('b')
+    const assembled = assertSuccess(assembleAccountPlan('paper-account', [first, second]))
+
+    expect(assembled.runKey).toBe(first.runKey)
+    expect(assembled.runTag).toBe(first.runTag)
+    expect(assembled.accounts).toEqual(first.accounts)
+    expect(assembled.transfers.map((transfer) => transfer.id)).toEqual(
+      [...first.transfers, ...second.transfers]
+        .map((transfer) => transfer.id)
+        .sort((left, right) => (left < right ? -1 : 1)),
+    )
+
+    const duplicate = assertFailure(assembleAccountPlan('paper-account', [first, first]))
+    expect(duplicate).toMatchObject({
+      operation: 'build-account-reconciliation',
+      reason: 'duplicate-transfer',
+      material: { accountId: 'paper-account', transferId: first.transfers[0].id },
+    })
+
+    const wrongAccount = assertFailure(assembleAccountPlan('paper-account', [paperPlan('c', 'other-account')]))
+    expect(wrongAccount).toMatchObject({
+      operation: 'build-account-reconciliation',
+      reason: 'wrong-account',
+      material: { accountId: 'paper-account' },
+    })
+  })
+
+  test('folds exact plan and locally verifiable persisted-run balances into Result failures', () => {
+    const { result, plan } = evaluationPlan()
+    const accounts = materializeAccounts(plan)
+    const transfers = materializeTransfers(plan)
+
+    expect(Result.isSuccess(reconcileLedgerPlan(plan, accounts, transfers))).toBeTrue()
+    expect(
+      Result.isSuccess(
+        validatePersistedRunEvidence(
+          {
+            runId: result.runId,
+            accountCount: accounts.length,
+            transferCount: transfers.length,
+            exact: true,
+          },
+          journalConfig.tigerBeetle.ledger,
+          accounts,
+          transfers,
+        ),
+      ),
+    ).toBeTrue()
+
+    const drifted = [{ ...accounts[0], debits_posted: accounts[0].debits_posted + 1n }, ...accounts.slice(1)]
+    const reconciliationFailure = assertFailure(reconcileLedgerPlan(plan, drifted, transfers))
+    expect(reconciliationFailure).toMatchObject({
+      operation: 'reconcile',
+      reason: 'invalid-balance',
+      material: { account: drifted[0] },
+    })
+
+    const duplicateAccounts = [...accounts.slice(0, -1), accounts[0]]
+    const persistedFailure = assertFailure(
+      validatePersistedRunEvidence(
+        {
+          runId: result.runId,
+          accountCount: accounts.length,
+          transferCount: transfers.length,
+          exact: true,
+        },
+        journalConfig.tigerBeetle.ledger,
+        duplicateAccounts,
+        transfers,
+      ),
+    )
+    expect(persistedFailure).toMatchObject({
+      operation: 'check-run',
+      reason: 'duplicate-account',
+      material: { runId: result.runId, accountId: accounts[0].id },
+    })
+  })
+})
+
 describe('TigerBeetle simulation journal', () => {
   test('plans deterministic double-entry transfers and reconciles exact sets and balances', () => {
     const snapshot = makeSnapshot()
@@ -144,7 +354,9 @@ describe('TigerBeetle simulation journal', () => {
     expect(hashLedgerPlan(first)).not.toBe(hashLedgerPlan(buildLedgerPlan(result, 7002)))
     expect(first.accounts).toHaveLength(fixtureProtocol.universe.length + 6)
     expect(first.transfers.length).toBeGreaterThan(1)
-    expect(() => assertReconciled(first, materializeAccounts(first), materializeTransfers(first))).not.toThrow()
+    expect(
+      Result.isSuccess(reconcileLedgerPlan(first, materializeAccounts(first), materializeTransfers(first))),
+    ).toBeTrue()
   })
 
   test('fails closed on extra transfers or mismatched balances', () => {
@@ -155,16 +367,18 @@ describe('TigerBeetle simulation journal', () => {
     const plan = buildLedgerPlan(result, 7001)
     const accounts = materializeAccounts(plan)
     const transfers = materializeTransfers(plan)
-    expect(() =>
-      assertReconciled(plan, accounts, [...transfers, { ...transfers[0], id: transfers[0].id + 1n }]),
-    ).toThrow('transfer set mismatch')
-    expect(() =>
-      assertReconciled(
-        plan,
-        [{ ...accounts[0], debits_posted: accounts[0].debits_posted + 1n }, ...accounts.slice(1)],
-        transfers,
+    expect(
+      assertFailure(reconcileLedgerPlan(plan, accounts, [...transfers, { ...transfers[0], id: transfers[0].id + 1n }])),
+    ).toMatchObject({ reason: 'record-set-mismatch' })
+    expect(
+      assertFailure(
+        reconcileLedgerPlan(
+          plan,
+          [{ ...accounts[0], debits_posted: accounts[0].debits_posted + 1n }, ...accounts.slice(1)],
+          transfers,
+        ),
       ),
-    ).toThrow('balance does not reconcile exactly')
+    ).toMatchObject({ reason: 'invalid-balance' })
   })
 
   test('creates an empty target exactly once and verifies an idempotent replay', async () => {
@@ -190,6 +404,209 @@ describe('TigerBeetle simulation journal', () => {
     })
     expect(target.accounts.size).toBe(plan.accounts.length)
     expect(target.transfers.size).toBe(plan.transfers.length)
+  })
+
+  test('keeps pure validation failures separate from retryable TigerBeetle I/O failures', async () => {
+    const plan = paperPlan('d')
+    let transferCreates = 0
+    const rejectedClient = makeTigerBeetleClient({
+      createAccounts: async (accounts) =>
+        accounts.map((_, index) => ({
+          timestamp: 1n,
+          status: index === 0 ? CreateAccountStatus.exists_with_different_code : CreateAccountStatus.created,
+        })),
+      createTransfers: async () => {
+        transferCreates += 1
+        return []
+      },
+    })
+
+    const rejected = await Effect.runPromise(Effect.flip(withJournal(rejectedClient, (journal) => journal.post(plan))))
+    expect(rejected.retryable).toBeFalse()
+    expect(rejected.cause).toBeInstanceOf(LedgerValidationError)
+    expect(rejected.cause).toMatchObject({
+      operation: 'verify-account-results',
+      reason: 'create-rejected',
+      material: { kind: 'account', id: plan.accounts[0].id },
+    })
+    expect(transferCreates).toBe(0)
+
+    const ioCause = new Error('TigerBeetle transport unavailable')
+    const unavailableClient = makeTigerBeetleClient({
+      createAccounts: async () => {
+        throw ioCause
+      },
+      createTransfers: async () => {
+        transferCreates += 1
+        return []
+      },
+    })
+    const unavailable = await Effect.runPromise(
+      Effect.flip(withJournal(unavailableClient, (journal) => journal.post(plan))),
+    )
+    expect(unavailable.retryable).toBeTrue()
+    expect(unavailable.cause).toBe(ioCause)
+    expect(transferCreates).toBe(0)
+  })
+
+  test('retains the exact throwing ledger-plan cause without starting TigerBeetle writes', async () => {
+    const { result } = evaluationPlan()
+    let writes = 0
+    const client = makeTigerBeetleClient({
+      createAccounts: async () => {
+        writes += 1
+        return []
+      },
+      createTransfers: async () => {
+        writes += 1
+        return []
+      },
+    })
+
+    const error = await Effect.runPromise(
+      Effect.flip(
+        withJournal(client, (journal) =>
+          journal.journalAndReconcile({
+            ...result,
+            events: [],
+          }),
+        ),
+      ),
+    )
+
+    expect(error.retryable).toBeFalse()
+    expect(error.cause).toBeInstanceOf(LedgerValidationError)
+    if (error.cause instanceof LedgerValidationError) {
+      expect(error.cause).toMatchObject({
+        operation: 'build-plan',
+        reason: 'ledger-plan-failure',
+        material: { ledger: journalConfig.tigerBeetle.ledger },
+      })
+      expect(error.cause.cause).toBeInstanceOf(Error)
+      expect(String(error.cause.cause)).toContain('no fill events')
+    }
+    expect(writes).toBe(0)
+  })
+
+  test('does not turn an unexpected account-reconciliation defect into a false verification result', async () => {
+    const plan = paperPlan('e')
+    const accounts = materializeAccounts(plan)
+    const defect = new Error('account reconciliation accessor defect')
+    const defectiveAccount = new Proxy(accounts[0], {
+      get: (target, property, receiver) => {
+        if (property === 'code') throw defect
+        return Reflect.get(target, property, receiver)
+      },
+    })
+    const client = makeTigerBeetleClient({
+      queryAccounts: async () => [defectiveAccount, ...accounts.slice(1)],
+      queryTransfers: async () => materializeTransfers(plan),
+    })
+
+    const exit = await Effect.runPromiseExit(
+      withJournal(client, (journal) => journal.verifyAccount('paper-account', [plan])),
+    )
+    expect(Exit.isFailure(exit)).toBeTrue()
+    if (Exit.isFailure(exit)) expect(Cause.squash(exit.cause)).toBe(defect)
+  })
+
+  test('replays a committed transfer batch after an unknown result without another transfer mutation', async () => {
+    const plan = paperPlan('f')
+    const target = makeLedgerClient()
+    const unknownCause = new Error('connection rejected after TigerBeetle committed the transfer batch')
+    let transferMutationCalls = 0
+    const committedThenUnknownClient: TigerBeetleClient = {
+      ...target.client,
+      createTransfers: async (batch) => {
+        transferMutationCalls += 1
+        await target.client.createTransfers(batch)
+        throw unknownCause
+      },
+    }
+
+    const unknown = await Effect.runPromise(
+      Effect.flip(withJournal(committedThenUnknownClient, (journal) => journal.post(plan))),
+    )
+    expect(unknown.retryable).toBeTrue()
+    expect(unknown.cause).toBe(unknownCause)
+    expect(transferMutationCalls).toBe(1)
+    expect(target.transfers.size).toBe(plan.transfers.length)
+
+    let replayTransferMutationCalls = 0
+    const replayClient: TigerBeetleClient = {
+      ...target.client,
+      createTransfers: async (batch) => {
+        replayTransferMutationCalls += 1
+        return target.client.createTransfers(batch)
+      },
+    }
+    const reconciled = await Effect.runPromise(
+      withJournal(replayClient, (journal) =>
+        journal.post(plan).pipe(Effect.andThen(journal.verifyAccount('paper-account', [plan]))),
+      ),
+    )
+
+    expect(reconciled).toBeTrue()
+    expect(replayTransferMutationCalls).toBe(0)
+    expect(transferMutationCalls).toBe(1)
+    expect(target.transfers.size).toBe(plan.transfers.length)
+  })
+
+  test('preflights every deterministic transfer and creates only missing records in request order', async () => {
+    const plan = paperPlan('1')
+    const target = makeLedgerClient()
+    const existing = plan.transfers.at(-1)
+    assert(existing, 'paper ledger fixture must contain a transfer')
+    for (const account of plan.accounts) target.accounts.set(account.id, { ...account, timestamp: 1n })
+    await target.client.createTransfers([existing])
+
+    const lookupBatches: bigint[][] = []
+    const createBatches: bigint[][] = []
+    const client: TigerBeetleClient = {
+      ...target.client,
+      lookupTransfers: async (ids) => {
+        lookupBatches.push([...ids])
+        return target.client.lookupTransfers(ids)
+      },
+      createTransfers: async (batch) => {
+        createBatches.push(batch.map((transfer) => transfer.id))
+        return target.client.createTransfers(batch)
+      },
+    }
+
+    await Effect.runPromise(withJournal(client, (journal) => journal.post(plan)))
+
+    expect(lookupBatches[0]).toEqual(plan.transfers.map((transfer) => transfer.id))
+    expect(createBatches).toEqual([
+      plan.transfers.filter((transfer) => transfer.id !== existing.id).map((transfer) => transfer.id),
+    ])
+
+    const conflict = makeLedgerClient()
+    conflict.transfers.set(plan.transfers[0].id, {
+      ...plan.transfers[0],
+      amount: plan.transfers[0].amount + 1n,
+      timestamp: 1n,
+    })
+    let conflictingCreates = 0
+    let conflictingLookup: readonly bigint[] = []
+    const conflictingClient: TigerBeetleClient = {
+      ...conflict.client,
+      lookupTransfers: async (ids) => {
+        conflictingLookup = [...ids]
+        return conflict.client.lookupTransfers(ids)
+      },
+      createTransfers: async (batch) => {
+        conflictingCreates += 1
+        return conflict.client.createTransfers(batch)
+      },
+    }
+    const mismatch = await Effect.runPromise(
+      Effect.flip(withJournal(conflictingClient, (journal) => journal.post(plan))),
+    )
+
+    expect(mismatch.message).toContain('does not match its plan')
+    expect(conflictingLookup).toEqual(plan.transfers.map((transfer) => transfer.id))
+    expect(conflictingCreates).toBe(0)
   })
 
   test('posts one paper fill idempotently and rejects a conflicting transfer', async () => {
@@ -392,8 +809,59 @@ describe('TigerBeetle simulation journal', () => {
 
     accounts = [{ ...accounts[0], debits_posted: accounts[0].debits_posted + 1n }, ...accounts.slice(1)]
     const error = await Effect.runPromise(Effect.flip(useJournal(check)))
-    expect(error.message).toContain('balance does not reconcile exactly')
+    expect(error.message).toContain('balance does not reconcile locally')
     expect(writes).toBe(0)
+  })
+
+  test('rejects exact query-limit ceilings before issuing TigerBeetle reads', async () => {
+    const plan = paperPlan('0')
+    const atLimit = {
+      ...plan,
+      accounts: Array.from({ length: LEDGER_BATCH_MAX }, (_, index) => ({
+        ...plan.accounts[0],
+        id: BigInt(index + 1),
+      })),
+      transfers: [],
+    }
+    let reads = 0
+    const client = makeTigerBeetleClient({
+      queryAccounts: async () => {
+        reads += 1
+        return []
+      },
+      queryTransfers: async () => {
+        reads += 1
+        return []
+      },
+    })
+
+    const [runError, accountError] = await Effect.runPromise(
+      withJournal(client, (journal) =>
+        Effect.all([
+          Effect.flip(
+            journal.checkRun({
+              runId: 'a'.repeat(64),
+              accountCount: LEDGER_BATCH_MAX,
+              transferCount: 0,
+              exact: true,
+            }),
+          ),
+          Effect.flip(journal.verifyAccount('paper-account', [atLimit])),
+        ]),
+      ),
+    )
+
+    expect(runError).toMatchObject({
+      operation: 'check-run',
+      retryable: false,
+      cause: { _tag: 'LedgerValidationError', reason: 'batch-limit' },
+    })
+    expect(accountError).toMatchObject({
+      operation: 'verify-account',
+      retryable: false,
+      cause: { _tag: 'LedgerValidationError', reason: 'batch-limit' },
+    })
+    expect(reads).toBe(0)
   })
 })
 

--- a/services/bayn/src/ledger.ts
+++ b/services/bayn/src/ledger.ts
@@ -1,22 +1,30 @@
 import {
   type Account,
+  type CreateAccountResult,
   CreateAccountStatus,
+  type CreateTransferResult,
   CreateTransferStatus,
   type QueryFilter,
   type Transfer,
 } from 'tigerbeetle-node'
-import { Context, Effect, Layer } from 'effect'
+import { Context, Effect, Layer, Result } from 'effect'
 
 import type { RuntimeConfig } from './config'
-import { operationalError, type OperationalError } from './errors'
+import { OperationalError } from './errors'
 import { stableU128, stableU64 } from './hash'
 import {
-  assertAccountsMatch,
-  assertReconciled,
-  assertTransfersMatch,
+  accountMetadataMatches,
   buildLedgerPlan,
+  failLedgerValidation as failedValidation,
   LEDGER_BATCH_MAX as BATCH_MAX,
-  LEDGER_SCHEMA_VERSION as SCHEMA_VERSION,
+  ledgerValidationError as validationError,
+  LedgerValidationError,
+  preflightTransfers,
+  reconcileLedgerPlan,
+  validatePersistedRunEvidence,
+  verifyExactAccounts,
+  verifyExactTransfers,
+  verifyLedgerPlanRecords,
   type LedgerInput,
   type LedgerPlan,
 } from './ledger-plan'
@@ -37,11 +45,89 @@ export interface JournalService {
 
 export class Journal extends Context.Service<Journal, JournalService>()('bayn/Journal') {}
 
-const validate = <A>(operation: string, evaluate: () => A): Effect.Effect<A, OperationalError> =>
-  Effect.try({
-    try: evaluate,
-    catch: (cause) => operationalError('journal', operation, `TigerBeetle ${operation} failed`, cause),
-  })
+const causeMessage = (cause: unknown): string => (cause instanceof Error ? cause.message : String(cause))
+
+const validationBoundary = <A>(decision: Result.Result<A, LedgerValidationError>): Effect.Effect<A, OperationalError> =>
+  Effect.fromResult(decision).pipe(
+    Effect.mapError(
+      (error) =>
+        new OperationalError({
+          component: 'journal',
+          operation: error.operation,
+          message: error.message,
+          retryable: false,
+          cause: error,
+        }),
+    ),
+  )
+
+type CreateResult = CreateAccountResult | CreateTransferResult
+
+const classifyCreateBatch = <Record extends { readonly id: bigint }>(
+  kind: 'account' | 'transfer',
+  operation: 'verify-account-results' | 'verify-transfer-results',
+  records: readonly Record[],
+  results: readonly CreateResult[],
+  created: number,
+  exists: number,
+): Result.Result<readonly Record[], LedgerValidationError> => {
+  if (results.length !== records.length) {
+    return failedValidation(
+      operation,
+      'batch-result-count',
+      `TigerBeetle returned an incomplete ${kind} result batch`,
+      { kind, expectedCount: records.length, actualCount: results.length },
+    )
+  }
+
+  const existing: Record[] = []
+  for (let index = 0; index < results.length; index += 1) {
+    const result = results[index]
+    const record = records[index]
+    if (result.status === created) continue
+    if (result.status === exists) {
+      existing.push(record)
+      continue
+    }
+    return failedValidation(
+      operation,
+      'create-rejected',
+      `TigerBeetle rejected ${kind} ${record.id} with status ${result.status}`,
+      {
+        kind,
+        id: record.id,
+        status: result.status,
+      },
+    )
+  }
+  return Result.succeed(existing)
+}
+
+export const classifyAccountCreateBatch = (
+  accounts: readonly Account[],
+  results: readonly CreateAccountResult[],
+): Result.Result<readonly Account[], LedgerValidationError> =>
+  classifyCreateBatch(
+    'account',
+    'verify-account-results',
+    accounts,
+    results,
+    CreateAccountStatus.created,
+    CreateAccountStatus.exists,
+  )
+
+export const classifyTransferCreateBatch = (
+  transfers: readonly Transfer[],
+  results: readonly CreateTransferResult[],
+): Result.Result<readonly Transfer[], LedgerValidationError> =>
+  classifyCreateBatch(
+    'transfer',
+    'verify-transfer-results',
+    transfers,
+    results,
+    CreateTransferStatus.created,
+    CreateTransferStatus.exists,
+  )
 
 const createAndVerifyAccounts = (
   client: TigerBeetleRequestClient,
@@ -49,27 +135,15 @@ const createAndVerifyAccounts = (
 ): Effect.Effect<void, OperationalError> =>
   Effect.gen(function* () {
     const results = yield* client.request('create-accounts', (active) => active.createAccounts([...accounts]))
-    const existingIds = yield* validate('verify-account-results', () => {
-      if (results.length !== accounts.length) {
-        throw new Error('TigerBeetle returned an incomplete account result batch')
-      }
-      const ids: bigint[] = []
-      for (let index = 0; index < results.length; index += 1) {
-        const status = results[index].status
-        if (status === CreateAccountStatus.created) continue
-        if (status === CreateAccountStatus.exists) {
-          ids.push(accounts[index].id)
-          continue
-        }
-        throw new Error(`TigerBeetle rejected account ${accounts[index].id} with status ${status}`)
-      }
-      return ids
-    })
-    if (existingIds.length === 0) return
+    const existingExpected = yield* validationBoundary(classifyAccountCreateBatch(accounts, results))
+    if (existingExpected.length === 0) return
 
-    const existing = yield* client.request('lookup-existing-accounts', (active) => active.lookupAccounts(existingIds))
-    const expected = accounts.filter((value) => existingIds.includes(value.id))
-    yield* validate('verify-existing-accounts', () => assertAccountsMatch('existing account', existing, expected))
+    const existing = yield* client.request('lookup-existing-accounts', (active) =>
+      active.lookupAccounts(existingExpected.map((account) => account.id)),
+    )
+    yield* validationBoundary(
+      verifyExactAccounts('verify-existing-accounts', 'existing account', existing, existingExpected),
+    )
   })
 
 const createAndVerifyTransfers = (
@@ -77,28 +151,22 @@ const createAndVerifyTransfers = (
   transfers: readonly Transfer[],
 ): Effect.Effect<void, OperationalError> =>
   Effect.gen(function* () {
-    const results = yield* client.request('create-transfers', (active) => active.createTransfers([...transfers]))
-    const existingIds = yield* validate('verify-transfer-results', () => {
-      if (results.length !== transfers.length) {
-        throw new Error('TigerBeetle returned an incomplete transfer result batch')
-      }
-      const ids: bigint[] = []
-      for (let index = 0; index < results.length; index += 1) {
-        const status = results[index].status
-        if (status === CreateTransferStatus.created) continue
-        if (status === CreateTransferStatus.exists) {
-          ids.push(transfers[index].id)
-          continue
-        }
-        throw new Error(`TigerBeetle rejected transfer ${transfers[index].id} with status ${status}`)
-      }
-      return ids
-    })
-    if (existingIds.length === 0) return
+    const existing = yield* client.request('lookup-preflight-transfers', (active) =>
+      active.lookupTransfers(transfers.map((transfer) => transfer.id)),
+    )
+    const missing = yield* validationBoundary(preflightTransfers(transfers, existing))
+    if (missing.length === 0) return
 
-    const existing = yield* client.request('lookup-existing-transfers', (active) => active.lookupTransfers(existingIds))
-    const expected = transfers.filter((value) => existingIds.includes(value.id))
-    yield* validate('verify-existing-transfers', () => assertTransfersMatch('existing transfer', existing, expected))
+    const results = yield* client.request('create-transfers', (active) => active.createTransfers([...missing]))
+    const existingExpected = yield* validationBoundary(classifyTransferCreateBatch(missing, results))
+    if (existingExpected.length === 0) return
+
+    const racedExisting = yield* client.request('lookup-existing-transfers', (active) =>
+      active.lookupTransfers(existingExpected.map((transfer) => transfer.id)),
+    )
+    yield* validationBoundary(
+      verifyExactTransfers('verify-existing-transfers', 'existing transfer', racedExisting, existingExpected),
+    )
   })
 
 const queryFilter = (ledger: number): QueryFilter => ({
@@ -113,88 +181,110 @@ const queryFilter = (ledger: number): QueryFilter => ({
   flags: 0,
 })
 
-const transactionTransferQuery = (plan: LedgerPlan): QueryFilter => {
+export const transactionTransferQuery = (plan: LedgerPlan): Result.Result<QueryFilter, LedgerValidationError> => {
+  if (plan.accounts.length === 0 || plan.transfers.length === 0) {
+    return Result.fail(
+      validationError('post', 'empty-plan', 'TigerBeetle posting plan must contain accounts and transfers', {
+        accountCount: plan.accounts.length,
+        transferCount: plan.transfers.length,
+      }),
+    )
+  }
+  if (plan.accounts.length >= BATCH_MAX || plan.transfers.length >= BATCH_MAX) {
+    return Result.fail(
+      validationError('post', 'batch-limit', 'TigerBeetle posting plan exceeds batch limits', {
+        accountCount: plan.accounts.length,
+        transferCount: plan.transfers.length,
+        limit: BATCH_MAX,
+      }),
+    )
+  }
+
   const first = plan.transfers[0]
-  if (first === undefined) throw new Error('accounting plan contains no transfers')
   if (
+    first === undefined ||
     first.user_data_128 === 0n ||
     plan.transfers.some(
       (transfer) => transfer.ledger !== first.ledger || transfer.user_data_128 !== first.user_data_128,
     )
   ) {
-    throw new Error('accounting transfers do not share one nonzero transaction tag and ledger')
+    return failedValidation(
+      'build-transaction-transfer-query',
+      'invalid-transaction',
+      first === undefined
+        ? 'accounting plan contains no transfers'
+        : 'accounting transfers do not share one nonzero transaction tag and ledger',
+      {
+        transferCount: plan.transfers.length,
+        transactionTag: first?.user_data_128,
+        ledger: first?.ledger,
+      },
+    )
   }
-  return {
+  return Result.succeed({
     ...queryFilter(first.ledger),
     user_data_128: first.user_data_128,
     limit: plan.transfers.length + 1,
-  }
+  })
 }
 
-const assertPersistedRun = (
+interface LedgerQueries {
+  readonly accounts: QueryFilter
+  readonly transfers: QueryFilter
+}
+
+const persistedRunQueries = (
   result: ReconciliationResult,
   ledger: number,
-  accounts: readonly Account[],
-  transfers: readonly Transfer[],
-): void => {
-  if (accounts.length !== result.accountCount) {
-    throw new Error(`run ${result.runId} has ${accounts.length} accounts; expected ${result.accountCount}`)
+): Result.Result<LedgerQueries, LedgerValidationError> => {
+  if (result.accountCount >= BATCH_MAX || result.transferCount >= BATCH_MAX) {
+    return Result.fail(
+      validationError('check-run', 'batch-limit', 'persisted TigerBeetle counts exceed the exact query limit', {
+        accountCount: result.accountCount,
+        transferCount: result.transferCount,
+        limit: BATCH_MAX,
+      }),
+    )
   }
-  if (transfers.length !== result.transferCount) {
-    throw new Error(`run ${result.runId} has ${transfers.length} transfers; expected ${result.transferCount}`)
-  }
+  return Result.succeed({
+    accounts: {
+      ...queryFilter(ledger),
+      user_data_128: stableU128('bayn-run-v1', result.runId),
+      limit: result.accountCount + 1,
+    },
+    transfers: {
+      ...queryFilter(ledger),
+      user_data_64: stableU64('bayn-run-v1', result.runId),
+      limit: result.transferCount + 1,
+    },
+  })
+}
 
-  const runKey = stableU128('bayn-run-v1', result.runId)
-  const runTag = stableU64('bayn-run-v1', result.runId)
-  const accountIds = new Set<bigint>()
-  const balances = new Map<bigint, { debits: bigint; credits: bigint }>()
-  for (const value of accounts) {
-    if (accountIds.has(value.id)) throw new Error(`run ${result.runId} contains duplicate account ${value.id}`)
-    if (
-      value.user_data_128 !== runKey ||
-      value.user_data_64 !== runTag ||
-      value.user_data_32 !== SCHEMA_VERSION ||
-      value.ledger !== ledger
-    ) {
-      throw new Error(`run ${result.runId} account ${value.id} has invalid metadata`)
-    }
-    accountIds.add(value.id)
-    balances.set(value.id, { debits: 0n, credits: 0n })
+const accountReconciliationQueries = (
+  plan: LedgerPlan,
+  ledger: number,
+): Result.Result<LedgerQueries, LedgerValidationError> => {
+  if (plan.accounts.length >= BATCH_MAX || plan.transfers.length >= BATCH_MAX) {
+    return Result.fail(
+      validationError('verify-account', 'batch-limit', 'paper account exceeds the exact reconciliation limit', {
+        accountCount: plan.accounts.length,
+        transferCount: plan.transfers.length,
+        limit: BATCH_MAX,
+      }),
+    )
   }
-
-  const transferIds = new Set<bigint>()
-  for (const value of transfers) {
-    if (transferIds.has(value.id)) throw new Error(`run ${result.runId} contains duplicate transfer ${value.id}`)
-    if (
-      value.user_data_64 !== runTag ||
-      value.user_data_32 !== SCHEMA_VERSION ||
-      value.ledger !== ledger ||
-      value.amount <= 0n
-    ) {
-      throw new Error(`run ${result.runId} transfer ${value.id} has invalid metadata`)
-    }
-    const debit = balances.get(value.debit_account_id)
-    const credit = balances.get(value.credit_account_id)
-    if (debit === undefined || credit === undefined) {
-      throw new Error(`run ${result.runId} transfer ${value.id} references an account outside the run`)
-    }
-    transferIds.add(value.id)
-    debit.debits += value.amount
-    credit.credits += value.amount
-  }
-
-  for (const value of accounts) {
-    const balance = balances.get(value.id)
-    if (balance === undefined) throw new Error(`run ${result.runId} has no balance for account ${value.id}`)
-    if (
-      value.debits_pending !== 0n ||
-      value.credits_pending !== 0n ||
-      value.debits_posted !== balance.debits ||
-      value.credits_posted !== balance.credits
-    ) {
-      throw new Error(`run ${result.runId} account ${value.id} balance does not reconcile exactly`)
-    }
-  }
+  return Result.succeed({
+    accounts: {
+      ...queryFilter(ledger),
+      user_data_128: plan.runKey,
+      limit: plan.accounts.length + 1,
+    },
+    transfers: {
+      ...queryFilter(ledger),
+      user_data_64: plan.runTag,
+      limit: plan.transfers.length + 1,
+    },
+  })
 }
 
 const checkRun = (
@@ -203,25 +293,28 @@ const checkRun = (
   result: ReconciliationResult,
 ): Effect.Effect<void, OperationalError> =>
   Effect.gen(function* () {
-    if (result.accountCount >= BATCH_MAX || result.transferCount >= BATCH_MAX) {
-      return yield* Effect.fail(
-        operationalError('journal', 'check-run', 'persisted TigerBeetle counts exceed the exact query limit'),
-      )
-    }
-    const runKey = stableU128('bayn-run-v1', result.runId)
-    const runTag = stableU64('bayn-run-v1', result.runId)
+    const queries = yield* validationBoundary(persistedRunQueries(result, ledger))
     const [accounts, transfers] = yield* Effect.all(
       [
-        client.request('check-run-accounts', (active) =>
-          active.queryAccounts({ ...queryFilter(ledger), user_data_128: runKey, limit: result.accountCount + 1 }),
-        ),
-        client.request('check-run-transfers', (active) =>
-          active.queryTransfers({ ...queryFilter(ledger), user_data_64: runTag, limit: result.transferCount + 1 }),
-        ),
+        client.request('check-run-accounts', (active) => active.queryAccounts(queries.accounts)),
+        client.request('check-run-transfers', (active) => active.queryTransfers(queries.transfers)),
       ],
       { concurrency: 'unbounded' },
     )
-    yield* validate('check-run', () => assertPersistedRun(result, ledger, accounts, transfers))
+    yield* validationBoundary(validatePersistedRunEvidence(result, ledger, accounts, transfers))
+  })
+
+const buildJournalPlan = (result: LedgerInput, ledger: number): Result.Result<LedgerPlan, LedgerValidationError> =>
+  Result.try({
+    try: () => buildLedgerPlan(result, ledger),
+    catch: (cause) =>
+      validationError(
+        'build-plan',
+        'ledger-plan-failure',
+        `TigerBeetle build-plan failed: ${causeMessage(cause)}`,
+        { ledger },
+        cause,
+      ),
   })
 
 const journalAndReconcile = (
@@ -230,7 +323,7 @@ const journalAndReconcile = (
   result: LedgerInput,
 ): Effect.Effect<ReconciliationResult, OperationalError> =>
   Effect.gen(function* () {
-    const plan = yield* validate('build-plan', () => buildLedgerPlan(result, ledger))
+    const plan = yield* validationBoundary(buildJournalPlan(result, ledger))
     yield* createAndVerifyAccounts(client, plan.accounts)
     yield* createAndVerifyTransfers(client, plan.transfers)
     const accountQuery = { ...queryFilter(ledger), user_data_128: plan.runKey, limit: plan.accounts.length + 1 }
@@ -242,21 +335,13 @@ const journalAndReconcile = (
       ],
       { concurrency: 'unbounded' },
     )
-    yield* validate('reconcile', () => assertReconciled(plan, accounts, transfers))
+    yield* validationBoundary(reconcileLedgerPlan(plan, accounts, transfers))
     return { runId: result.runId, accountCount: accounts.length, transferCount: transfers.length, exact: true }
   })
 
 const post = (client: TigerBeetleRequestClient, plan: LedgerPlan): Effect.Effect<void, OperationalError> =>
   Effect.gen(function* () {
-    if (plan.accounts.length === 0 || plan.transfers.length === 0) {
-      return yield* Effect.fail(
-        operationalError('journal', 'post', 'TigerBeetle posting plan must contain accounts and transfers'),
-      )
-    }
-    if (plan.accounts.length >= BATCH_MAX || plan.transfers.length >= BATCH_MAX) {
-      return yield* Effect.fail(operationalError('journal', 'post', 'TigerBeetle posting plan exceeds batch limits'))
-    }
-    const transferQuery = yield* validate('build-transaction-transfer-query', () => transactionTransferQuery(plan))
+    const transferQuery = yield* validationBoundary(transactionTransferQuery(plan))
     yield* createAndVerifyAccounts(client, plan.accounts)
     yield* createAndVerifyTransfers(client, plan.transfers)
     const [accounts, transfers] = yield* Effect.all(
@@ -268,37 +353,58 @@ const post = (client: TigerBeetleRequestClient, plan: LedgerPlan): Effect.Effect
       ],
       { concurrency: 'unbounded' },
     )
-    yield* validate('verify-posted-plan', () => {
-      assertAccountsMatch('posted account', accounts, plan.accounts)
-      assertTransfersMatch('posted transfer', transfers, plan.transfers)
-    })
+    yield* validationBoundary(
+      verifyLedgerPlanRecords('verify-posted-plan', 'posted account', 'posted transfer', plan, accounts, transfers),
+    )
   })
 
-const accountPlan = (accountId: string, plans: readonly LedgerPlan[]): LedgerPlan => {
+export const assembleAccountPlan = (
+  accountId: string,
+  plans: readonly LedgerPlan[],
+): Result.Result<LedgerPlan, LedgerValidationError> => {
   const runKey = stableU128('bayn-paper-account-v1', accountId)
   const runTag = stableU64('bayn-paper-account-v1', accountId)
   const accounts = new Map<bigint, Account>()
   const transfers = new Map<bigint, Transfer>()
   for (const plan of plans) {
     if (plan.runKey !== runKey || plan.runTag !== runTag) {
-      throw new Error(`accounting plan does not belong to paper account ${accountId}`)
+      return failedValidation(
+        'build-account-reconciliation',
+        'wrong-account',
+        `accounting plan does not belong to paper account ${accountId}`,
+        { accountId, planRunKey: plan.runKey, planRunTag: plan.runTag, expectedRunKey: runKey, expectedRunTag: runTag },
+      )
     }
     for (const account of plan.accounts) {
       const existing = accounts.get(account.id)
-      if (existing !== undefined) assertAccountsMatch('accounting account', [account], [existing])
-      else accounts.set(account.id, account)
+      if (existing !== undefined && !accountMetadataMatches(account, existing)) {
+        return failedValidation(
+          'build-account-reconciliation',
+          'record-mismatch',
+          `accounting account ${account.id} does not match its plan`,
+          { kind: 'accounting account', id: account.id, actual: account, expected: existing },
+        )
+      }
+      if (existing === undefined) accounts.set(account.id, account)
     }
     for (const transfer of plan.transfers) {
-      if (transfers.has(transfer.id)) throw new Error(`duplicate accounting transfer ${transfer.id}`)
+      if (transfers.has(transfer.id)) {
+        return failedValidation(
+          'build-account-reconciliation',
+          'duplicate-transfer',
+          `duplicate accounting transfer ${transfer.id}`,
+          { accountId, transferId: transfer.id },
+        )
+      }
       transfers.set(transfer.id, transfer)
     }
   }
-  return {
+  return Result.succeed({
     runKey,
     runTag,
     accounts: [...accounts.values()].sort((left, right) => (left.id < right.id ? -1 : 1)),
     transfers: [...transfers.values()].sort((left, right) => (left.id < right.id ? -1 : 1)),
-  }
+  })
 }
 
 const verifyAccount = (
@@ -308,39 +414,16 @@ const verifyAccount = (
   plans: readonly LedgerPlan[],
 ): Effect.Effect<boolean, OperationalError> =>
   Effect.gen(function* () {
-    const expected = yield* validate('build-account-reconciliation', () => accountPlan(accountId, plans))
-    if (expected.accounts.length >= BATCH_MAX || expected.transfers.length >= BATCH_MAX) {
-      return yield* Effect.fail(
-        operationalError('journal', 'verify-account', 'paper account exceeds the exact reconciliation limit'),
-      )
-    }
+    const expected = yield* validationBoundary(assembleAccountPlan(accountId, plans))
+    const queries = yield* validationBoundary(accountReconciliationQueries(expected, ledger))
     const [accounts, transfers] = yield* Effect.all(
       [
-        client.request('verify-account-accounts', (active) =>
-          active.queryAccounts({
-            ...queryFilter(ledger),
-            user_data_128: expected.runKey,
-            limit: expected.accounts.length + 1,
-          }),
-        ),
-        client.request('verify-account-transfers', (active) =>
-          active.queryTransfers({
-            ...queryFilter(ledger),
-            user_data_64: expected.runTag,
-            limit: expected.transfers.length + 1,
-          }),
-        ),
+        client.request('verify-account-accounts', (active) => active.queryAccounts(queries.accounts)),
+        client.request('verify-account-transfers', (active) => active.queryTransfers(queries.transfers)),
       ],
       { concurrency: 'unbounded' },
     )
-    return yield* Effect.sync(() => {
-      try {
-        assertReconciled(expected, accounts, transfers)
-        return true
-      } catch {
-        return false
-      }
-    })
+    return Result.isSuccess(reconcileLedgerPlan(expected, accounts, transfers, 'verify-account'))
   })
 
 export const JournalLive = (
@@ -349,18 +432,29 @@ export const JournalLive = (
 ): Layer.Layer<Journal, OperationalError> =>
   Layer.effect(
     Journal,
-    Effect.gen(function* () {
-      const client = yield* makeTigerBeetleRequestClient(config, dependencies)
-      return {
-        post: (plan) => post(client, plan),
-        verifyAccount: (accountId, plans) => verifyAccount(client, config.tigerBeetle.ledger, accountId, plans),
-        check: client
-          .request('connectivity-check', (active) => active.lookupAccounts([stableU128('bayn-connectivity-probe')]))
-          .pipe(Effect.asVoid),
-        checkRun: (result) => checkRun(client, config.tigerBeetle.ledger, result),
-        journalAndReconcile: (result) => journalAndReconcile(client, config.tigerBeetle.ledger, result),
-      }
-    }),
+    makeTigerBeetleRequestClient(config, dependencies).pipe(
+      Effect.map(
+        (client): JournalService => ({
+          post: (plan) => post(client, plan),
+          verifyAccount: (accountId, plans) => verifyAccount(client, config.tigerBeetle.ledger, accountId, plans),
+          check: client
+            .request('connectivity-check', (active) => active.lookupAccounts([stableU128('bayn-connectivity-probe')]))
+            .pipe(Effect.asVoid),
+          checkRun: (result) => checkRun(client, config.tigerBeetle.ledger, result),
+          journalAndReconcile: (result) => journalAndReconcile(client, config.tigerBeetle.ledger, result),
+        }),
+      ),
+    ),
   )
-export { assertReconciled, buildLedgerPlan, hashLedgerPlan, type LedgerInput, type LedgerPlan } from './ledger-plan'
+export {
+  buildLedgerPlan,
+  hashLedgerPlan,
+  LedgerValidationError,
+  reconcileLedgerPlan,
+  validatePersistedRunEvidence,
+  type LedgerInput,
+  type LedgerPlan,
+  type LedgerValidationOperation,
+  type LedgerValidationReason,
+} from './ledger-plan'
 export { resolveReplicaAddresses, type JournalDependencies, type TigerBeetleClient } from './tigerbeetle-client'


### PR DESCRIPTION
## Summary

- Moves ledger create-batch classification, query validation, persisted-evidence checks, account-plan assembly, and reconciliation folds into total `Result` decisions with one closed `LedgerValidationError`; thin TigerBeetle interpreters convert the result once at the I/O boundary while preserving `JournalService`'s public error type.
- Preflights every deterministic transfer ID read-only, rejects any existing-record metadata mismatch before `createTransfers`, creates only missing transfers in request order, and verifies idempotent replay after a committed-then-unknown create result without an additional mutation.
- Consolidates exact-set and balance reconciliation in `ledger-plan.ts`, removes the throwing `assertReconciled` dependency, and validates every locally derivable persisted-run invariant, including codes, flags, `pending_id`, timeout, balances, and fixed identities. Each fixed deterministic account ID is bound to its exact required code, including accounts with no transfers; evidence that requires an expected plan is deliberately not fabricated.
- Adds synchronous pure decision coverage plus focused TigerBeetle I/O, defect, interruption, duplicate/missing-record, existing-record, committed-then-unknown replay, and transferless fixed-account regressions. This change does not claim linked-batch atomicity; replay safety comes from deterministic IDs, read-only preflight, exact existing-record verification, and creation of only missing transfers.

No broker client, GitOps, qualification, migration, configuration, resource production, or capital-authority behavior changes are included.

### Reviewed receipt

- Approved base: `103bf8da57cf8b5c714cd2426cd2e56db01ebc6b`
- Independent-review patch SHA-256: `884b3ffff86b0ea0255479419c0d2fdc092881284d8568bd98fc0a09f28afd5a`
- Independently reviewed result tree: `b57fb52341adefd90aff0f4a677aa58f8af831dc`
- Initial reviewed commit: `6d78c6bec9dc4faa5578787e5f8c547fb6d02980`
- Automatic-review correction: `293c1e84df95da83ab721d622cdb7c9b449858db`
- Current head tree: `3ee732feddc50ce5e178e4e602c4c4c57e8f1897`
- Current base-to-head patch SHA-256: `f2931aee09eaddeff718a0deb1169c9c3122b9570b18bc0c4f2de4c50e3cd4ef`
- Exact scope: `services/bayn/src/ledger-plan.ts`, `services/bayn/src/ledger-plan.test.ts`, `services/bayn/src/ledger.ts`, and `services/bayn/src/ledger.test.ts`
- Current diff: 4 files, 1,516 insertions, 242 deletions

## Related Issues

None.

## Testing

- `bun test services/bayn/src/ledger-plan.test.ts services/bayn/src/ledger.test.ts services/bayn/src/resources.test.ts` — 32 passed, 0 failed, 129 assertions.
- `bun run --filter @proompteng/bayn test` — 583 passed, 113 skipped, 0 failed, 3,005 expectations across 696 tests / 48 files.
- `BAYN_TEST_POSTGRES_URL=<verified local *_test database> bun test services/bayn/src/db/paper-store.integration.test.ts` — 27 passed, 0 failed.
- `BAYN_TEST_POSTGRES_URL=<verified local *_test database> bun test services/bayn/src/db/evidence-store.integration.test.ts` — 60 passed, 0 failed.
- `bun run --filter @proompteng/bayn lint:effect` — 134 files, 0 errors, warnings, or messages.
- `bun run --filter @proompteng/bayn tsc` — passed.
- `bun run --filter @proompteng/bayn lint` — Oxfmt checked 117 files, passed.
- `bun run --filter @proompteng/bayn lint:oxlint` — 0 warnings or errors.
- `bun run --filter @proompteng/bayn lint:oxlint:type` — 0 warnings or errors.
- `bun run --filter @proompteng/bayn build` — 527 modules bundled, 4.23 MB output, passed.
- Exact-head GitHub validation on `293c1e84df95da83ab721d622cdb7c9b449858db` — 9 successful checks and 2 expected skips; Bayn PR checks, PostgreSQL integration, and both amd64/arm64 image builds passed.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] Documentation, release notes, and follow-ups are not required for this behavior-preserving internal refactor.