### PR TITLE
refactor(bayn): make reconciliation transaction functional

### DIFF
--- a/services/bayn/src/db/paper-store.integration.test.ts
+++ b/services/bayn/src/db/paper-store.integration.test.ts
@@ -2877,10 +2877,29 @@ describePostgres('paper accounting persistence', () => {
             reconciledAt: resolvedObservedAt,
           })
 
-          const rows = yield* sql<{ discrepancy_count: number; status: string }>`
-            SELECT status, jsonb_array_length(discrepancies)::integer AS discrepancy_count
+          const rows = yield* sql<{
+            reconciliation_id: string
+            content_hash: string
+            discrepancy_count: number
+            status: string
+          }>`
+            SELECT
+              reconciliation_id,
+              content_hash,
+              status,
+              jsonb_array_length(discrepancies)::integer AS discrepancy_count
             FROM reconciliations
-            ORDER BY reconciled_at
+            ORDER BY reconciled_at, reconciliation_id COLLATE "C"
+          `
+          const [latest] = yield* sql<{
+            reconciliation_id: string
+            content_hash: string
+            status: string
+          }>`
+            SELECT reconciliation_id, content_hash, status
+            FROM reconciliations
+            ORDER BY reconciled_at DESC, reconciliation_id COLLATE "C" DESC
+            LIMIT 1
           `
           const [authority] = yield* sql<{
             effective: string
@@ -2903,6 +2922,7 @@ describePostgres('paper accounting persistence', () => {
             ongoing,
             resolved,
             rows,
+            latest,
             authority,
             mutateReconciliation,
             mismatchObservedAt,
@@ -2936,12 +2956,33 @@ describePostgres('paper accounting persistence', () => {
       })
       expect(result.resolved.reconciliation.status).toBe(ReconciliationStatus.Exact)
       expect(result.resolved.reconciliation.discrepancies).toEqual([])
-      expect(result.rows).toEqual([
+      expect(
+        result.rows.map(({ status, discrepancy_count: discrepancyCount }) => ({
+          status,
+          discrepancy_count: discrepancyCount,
+        })),
+      ).toEqual([
         { status: ReconciliationStatus.Exact, discrepancy_count: 0 },
         { status: ReconciliationStatus.Discrepancy, discrepancy_count: 1 },
         { status: ReconciliationStatus.Discrepancy, discrepancy_count: 1 },
         { status: ReconciliationStatus.Exact, discrepancy_count: 0 },
       ])
+      expect(
+        result.rows.map(({ reconciliation_id: reconciliationId, content_hash: contentHash }) => ({
+          reconciliationId,
+          contentHash,
+        })),
+      ).toEqual(
+        [result.exact, result.mismatch, result.ongoing, result.resolved].map(({ reconciliation }) => ({
+          reconciliationId: reconciliation.reconciliationId,
+          contentHash: reconciliation.contentHash,
+        })),
+      )
+      expect(result.latest).toEqual({
+        reconciliation_id: result.resolved.reconciliation.reconciliationId,
+        content_hash: result.resolved.reconciliation.contentHash,
+        status: ReconciliationStatus.Exact,
+      })
       expect(result.authority).toEqual({
         effective: 'OBSERVE',
         kill_state: 'ACTIVE',

--- a/services/bayn/src/db/reconciliation-algebra.test.ts
+++ b/services/bayn/src/db/reconciliation-algebra.test.ts
@@ -1,0 +1,599 @@
+import { describe, expect, test } from 'bun:test'
+
+import { Result } from 'effect'
+
+import { prepareAccounting } from '../accounting'
+import { MutationOperation } from '../broker/alpaca-mutations'
+import { MutationEventType } from '../execution/mutations'
+import { canonicalHashV1 } from '../hash'
+import {
+  AccountStatus,
+  Authority,
+  IntentState,
+  KillState,
+  OrderSide,
+  OrderStatus,
+  OrderType,
+  ReconciliationStatus,
+  TerminalOutcome,
+  TimeInForce,
+  type AccountSnapshot,
+  type AccountingReceipt,
+  type Fill,
+  type Order,
+  type Position,
+} from '../paper'
+import {
+  canonicalAccountingReceiptMaterial,
+  compareOpeningCash,
+  decideReconciliation,
+  projectIntentExpectations,
+  reconciliationAlgebraFailureDetails,
+  riskContextFromRow,
+  validateReconciliationReadback,
+  verifyAccountingReceipts,
+  type ReconciliationAlgebraFailure,
+  type RiskContextRow,
+} from './reconciliation-algebra'
+
+const successOf = <A>(result: Result.Result<A, ReconciliationAlgebraFailure>): A => {
+  expect(Result.isSuccess(result)).toBe(true)
+  if (Result.isFailure(result)) throw new Error(`expected success, received ${result.failure._tag}`)
+  return result.success
+}
+
+const failureOf = <A>(result: Result.Result<A, ReconciliationAlgebraFailure>): ReconciliationAlgebraFailure => {
+  expect(Result.isFailure(result)).toBe(true)
+  if (Result.isSuccess(result)) throw new Error('expected failure')
+  return result.failure
+}
+
+const hash = (value: string): string => canonicalHashV1({ value })
+const accountId = 'paper-account'
+const openingObservedAt = '2026-07-22T15:29:59.000Z'
+const observedAt = '2026-07-22T15:30:00.000Z'
+const reconciledAt = '2026-07-22T15:30:01.000Z'
+const tigerBeetle = { clusterId: 1n, ledger: 1 }
+
+const fill: Fill = {
+  schemaVersion: 'bayn.paper-fill.v1',
+  accountId,
+  fillId: 'fill-1',
+  brokerOrderId: 'broker-order-1',
+  clientOrderId: 'bayn-order-1',
+  intentId: hash('intent-1'),
+  symbol: 'NVDA',
+  side: OrderSide.Buy,
+  quantityMicros: '1000000',
+  priceMicros: '100000000',
+  feeMicros: '0',
+  occurredAt: observedAt,
+}
+
+const prepared = prepareAccounting(hash('broker-event-1'), fill, { quantityMicros: '0', costMicros: '0' }, 1)
+const postedMicros = prepared.ledger.transfers.reduce((sum, transfer) => sum + transfer.amount, 0n).toString()
+const receiptMaterial = {
+  schemaVersion: 'bayn.paper-accounting-receipt.v1' as const,
+  intentId: fill.intentId,
+  brokerEventId: prepared.transaction.brokerEventId,
+  tigerBeetleClusterId: tigerBeetle.clusterId.toString(),
+  tigerBeetleLedger: tigerBeetle.ledger,
+  accountIds: prepared.ledger.accounts.map((account) => account.id.toString()),
+  transferIds: prepared.ledger.transfers.map((transfer) => transfer.id.toString()),
+  debitMicros: postedMicros,
+  creditMicros: postedMicros,
+}
+const receipt: AccountingReceipt = {
+  ...receiptMaterial,
+  receiptId: hash('receipt-1'),
+  contentHash: canonicalHashV1(receiptMaterial),
+  recordedAt: observedAt,
+}
+
+const account: AccountSnapshot = {
+  schemaVersion: 'bayn.paper-account-snapshot.v1',
+  accountId,
+  status: AccountStatus.Active,
+  currency: 'USD',
+  cashMicros: '900000000',
+  equityMicros: '1000000000',
+  buyingPowerMicros: '900000000',
+  observedAt,
+}
+
+const position: Position = {
+  schemaVersion: 'bayn.paper-position.v1',
+  accountId,
+  symbol: fill.symbol,
+  quantityMicros: fill.quantityMicros,
+  averageEntryPriceMicros: fill.priceMicros,
+  marketPriceMicros: fill.priceMicros,
+  marketValueMicros: fill.priceMicros,
+  unrealizedPnlMicros: '0',
+  observedAt,
+}
+
+const order: Order = {
+  schemaVersion: 'bayn.paper-order.v1',
+  accountId,
+  brokerOrderId: fill.brokerOrderId,
+  clientOrderId: fill.clientOrderId,
+  intentId: fill.intentId,
+  symbol: fill.symbol,
+  side: fill.side,
+  orderType: OrderType.Market,
+  timeInForce: TimeInForce.Day,
+  quantityMicros: fill.quantityMicros,
+  filledQuantityMicros: fill.quantityMicros,
+  status: OrderStatus.Filled,
+  observedAt,
+}
+
+const intentRow = {
+  intent_id: fill.intentId ?? hash('missing-intent'),
+  client_order_id: fill.clientOrderId,
+  symbol: fill.symbol,
+  side: fill.side,
+  order_type: order.orderType,
+  time_in_force: order.timeInForce,
+  quantity_micros: fill.quantityMicros,
+  state: IntentState.Terminal,
+  terminal_outcome: TerminalOutcome.Filled,
+  broker_order_id: fill.brokerOrderId,
+  mutation_operation: MutationOperation.Submit,
+  mutation_event_type: MutationEventType.SubmitAccepted,
+  mutation_occurred_at: observedAt,
+} as const
+
+const makeComparison = (status: AccountStatus = AccountStatus.Active) => {
+  const intentProjection = successOf(projectIntentExpectations([intentRow]))
+  const accounting = successOf(verifyAccountingReceipts([prepared.transaction], [receipt], { tigerBeetle }))
+  const durableFills = [
+    {
+      fillId: fill.fillId,
+      brokerOrderId: fill.brokerOrderId,
+      accounted: accounting.exactReceipts.get(prepared.transaction.brokerEventId) === true,
+    },
+  ]
+  const projectedPositions = [
+    {
+      symbol: position.symbol,
+      quantityMicros: position.quantityMicros,
+      costBasisMicros: prepared.transaction.costBasisMicros,
+    },
+  ]
+  return successOf(
+    compareOpeningCash({
+      accountId,
+      openingCash: { cash_micros: '1000000000', observed_at: openingObservedAt },
+      transactions: [prepared.transaction],
+      receipts: [receipt],
+      ledgerExact: true,
+      snapshot: {
+        account: { ...account, status },
+        positions: [position],
+        positionsObservedAt: observedAt,
+        orders: [order],
+        ordersObservedAt: observedAt,
+        fills: [fill],
+        valuation: {
+          schemaVersion: 'bayn.paper-valuation.v1',
+          valuationId: hash('valuation-1'),
+          accountId,
+          sourceHash: hash('valuation-source'),
+          cashMicros: account.cashMicros,
+          longMarketValueMicros: position.marketValueMicros,
+          shortMarketValueMicros: '0',
+          equityMicros: account.equityMicros,
+          asOf: observedAt,
+        },
+        reconciledAt,
+      },
+      intents: intentProjection.intents,
+      durableFills,
+      projectedPositions,
+    }),
+  )
+}
+
+const emptyRiskRow = (): RiskContextRow => ({
+  trading_date: '2026-07-22',
+  authority_schema_version: null,
+  authority_generation_hash: null,
+  authority_maximum: null,
+  authority_effective: null,
+  authority_kill: null,
+  authority_reason: null,
+  authority_version: null,
+  authority_updated_at: null,
+  authority_observed_at: null,
+  daily_traded_notional_micros: '0',
+  day_start_equity_micros: '1000000000',
+  peak_equity_micros: '1000000000',
+})
+
+describe('PostgreSQL reconciliation algebra', () => {
+  test('projects intent uncertainty without Effects', () => {
+    const projection = successOf(
+      projectIntentExpectations([
+        {
+          ...intentRow,
+          state: IntentState.Acknowledged,
+          terminal_outcome: null,
+          mutation_operation: MutationOperation.Cancel,
+          mutation_event_type: MutationEventType.RecoveryFound,
+        },
+        intentRow,
+      ]),
+    )
+
+    expect(projection.unknownMutationCount).toBe(1)
+    expect(projection.intents[0]).toMatchObject({ intentId: fill.intentId, unknownSince: observedAt })
+    expect(projection.intents[1]?.unknownSince).toBeUndefined()
+  })
+
+  test('verifies ledger plans, receipt material, and exact accounting bindings', () => {
+    const verification = successOf(verifyAccountingReceipts([prepared.transaction], [receipt], { tigerBeetle }))
+
+    expect(verification.plans).toEqual([prepared.ledger])
+    expect(verification.exactReceipts.get(prepared.transaction.brokerEventId)).toBe(true)
+    expect(canonicalAccountingReceiptMaterial(receipt)).toEqual(receiptMaterial)
+    expect(canonicalHashV1(canonicalAccountingReceiptMaterial(receipt))).toBe(receipt.contentHash)
+
+    const inexact = successOf(
+      verifyAccountingReceipts([prepared.transaction], [{ ...receipt, contentHash: hash('wrong-receipt-content') }], {
+        tigerBeetle,
+      }),
+    )
+    expect(inexact.exactReceipts.get(prepared.transaction.brokerEventId)).toBe(false)
+  })
+
+  test('rejects duplicate receipt broker events before ledger planning', () => {
+    const conflictingReceipt: AccountingReceipt = {
+      ...receipt,
+      receiptId: hash('duplicate-receipt'),
+      contentHash: hash('conflicting-receipt-content'),
+    }
+    const duplicateReceipts = [conflictingReceipt, receipt]
+    const failure = failureOf(verifyAccountingReceipts([prepared.transaction], duplicateReceipts, { tigerBeetle }))
+
+    expect(failure).toEqual({
+      _tag: 'DuplicateReceiptBrokerEvent',
+      brokerEventId: prepared.transaction.brokerEventId,
+    })
+    expect(
+      failureOf(
+        verifyAccountingReceipts(
+          [{ ...prepared.transaction, contentHash: hash('invalid-transaction-content') }],
+          duplicateReceipts,
+          { tigerBeetle },
+        ),
+      ),
+    ).toEqual(failure)
+    expect(reconciliationAlgebraFailureDetails(failure)).toEqual({
+      failure: 'invariant',
+      message: `duplicate accounting receipt broker event ${prepared.transaction.brokerEventId}`,
+      cause: failure,
+    })
+  })
+
+  test('returns closed ledger-plan failures with their causes', () => {
+    const failure = failureOf(
+      verifyAccountingReceipts(
+        [{ ...prepared.transaction, contentHash: hash('invalid-transaction-content') }],
+        [receipt],
+        { tigerBeetle },
+      ),
+    )
+    expect(failure).toMatchObject({
+      _tag: 'AccountingPlanFailed',
+      transactionId: prepared.transaction.transactionId,
+      brokerEventId: prepared.transaction.brokerEventId,
+      cause: expect.any(Error),
+    })
+    if (failure._tag !== 'AccountingPlanFailed') throw new Error('expected accounting plan failure')
+    const details = reconciliationAlgebraFailureDetails(failure)
+    expect(details).toMatchObject({
+      failure: 'invariant',
+      message: `accounting ledger plan verification failed for transaction ${prepared.transaction.transactionId}`,
+    })
+    expect(details.cause).toBe(failure.cause)
+  })
+
+  test('compares opening cash and produces the unchanged exact accounting identity', () => {
+    const result = makeComparison()
+
+    expect(result.accountingHash).toBe(
+      canonicalHashV1({
+        schemaVersion: 'bayn.paper-accounting-state.v1',
+        accountId,
+        openingCash: { cash_micros: '1000000000', observed_at: openingObservedAt },
+        transactions: [prepared.transaction],
+        receipts: [receipt],
+        ledgerExact: true,
+      }),
+    )
+    expect(result.comparison.discrepancies).toEqual([])
+    expect(result.comparison.metrics).toMatchObject({
+      accountingExact: true,
+      cashDifferenceMicros: '0',
+      positionDifferenceMicros: '0',
+      equityDifferenceMicros: '0',
+    })
+  })
+
+  test('rejects accounting before the opening snapshot and contains comparison throws', () => {
+    const exact = makeComparison()
+    const predates = failureOf(
+      compareOpeningCash({
+        accountId,
+        openingCash: { cash_micros: '1000000000', observed_at: '2026-07-22T15:30:00.001Z' },
+        transactions: [prepared.transaction],
+        receipts: [receipt],
+        ledgerExact: true,
+        snapshot: {
+          account,
+          positions: [position],
+          positionsObservedAt: observedAt,
+          orders: [order],
+          ordersObservedAt: observedAt,
+          fills: [fill],
+          valuation: {
+            schemaVersion: 'bayn.paper-valuation.v1',
+            valuationId: hash('valuation-2'),
+            accountId,
+            sourceHash: hash('valuation-source-2'),
+            cashMicros: account.cashMicros,
+            longMarketValueMicros: position.marketValueMicros,
+            shortMarketValueMicros: '0',
+            equityMicros: account.equityMicros,
+            asOf: observedAt,
+          },
+          reconciledAt,
+        },
+        intents: [],
+        durableFills: [],
+        projectedPositions: [],
+      }),
+    )
+    expect(predates).toMatchObject({
+      _tag: 'AccountingPredatesOpeningCash',
+      transactionId: prepared.transaction.transactionId,
+    })
+
+    const duplicateComparison = failureOf(
+      compareOpeningCash({
+        accountId,
+        openingCash: { cash_micros: '1000000000', observed_at: openingObservedAt },
+        transactions: [],
+        receipts: [],
+        ledgerExact: true,
+        snapshot: {
+          account,
+          positions: [],
+          positionsObservedAt: observedAt,
+          orders: [order, order],
+          ordersObservedAt: observedAt,
+          fills: [],
+          valuation: {
+            schemaVersion: 'bayn.paper-valuation.v1',
+            valuationId: hash('valuation-3'),
+            accountId,
+            sourceHash: hash('valuation-source-3'),
+            cashMicros: account.cashMicros,
+            longMarketValueMicros: '0',
+            shortMarketValueMicros: '0',
+            equityMicros: account.cashMicros,
+            asOf: observedAt,
+          },
+          reconciledAt,
+        },
+        intents: [],
+        durableFills: [],
+        projectedPositions: [],
+      }),
+    )
+    expect(duplicateComparison).toMatchObject({
+      _tag: 'AccountingProjectionFailed',
+      operation: 'reconciliation-comparison',
+      cause: expect.any(Error),
+    })
+    expect(exact.comparison.discrepancies).toEqual([])
+  })
+
+  test('ages discrepancies, builds deterministic identities, and validates readback', () => {
+    const mismatch = makeComparison(AccountStatus.Restricted)
+    const first = successOf(
+      decideReconciliation({
+        accountId,
+        comparison: mismatch.comparison,
+        previous: [],
+        reconciledAt,
+      }),
+    )
+    const nextObservedAt = '2026-07-22T15:30:02.000Z'
+    const ongoing = successOf(
+      decideReconciliation({
+        accountId,
+        comparison: mismatch.comparison,
+        previous: first.discrepancies,
+        reconciledAt: nextObservedAt,
+      }),
+    )
+    const firstDiscrepancy = first.discrepancies[0]
+    if (firstDiscrepancy === undefined) throw new Error('expected one reconciliation discrepancy')
+
+    expect(first.status).toBe(ReconciliationStatus.Discrepancy)
+    expect(first.discrepancies[0]).toMatchObject({
+      firstObservedAt: reconciledAt,
+      lastObservedAt: reconciledAt,
+    })
+    expect(ongoing.discrepancies[0]).toMatchObject({
+      discrepancyId: firstDiscrepancy.discrepancyId,
+      firstObservedAt: reconciledAt,
+      lastObservedAt: nextObservedAt,
+    })
+    expect(successOf(validateReconciliationReadback(first, first.contentHash))).toBeUndefined()
+    expect(failureOf(validateReconciliationReadback(first, hash('wrong-readback')))).toMatchObject({
+      _tag: 'StoredReconciliationMismatch',
+      reconciliationId: first.reconciliationId,
+      expectedContentHash: first.contentHash,
+    })
+    expect(
+      failureOf(
+        decideReconciliation({
+          accountId,
+          comparison: mismatch.comparison,
+          previous: [firstDiscrepancy, firstDiscrepancy],
+          reconciledAt: nextObservedAt,
+        }),
+      ),
+    ).toMatchObject({
+      _tag: 'DuplicateReconciliationDiscrepancy',
+      source: 'previous',
+      discrepancyId: firstDiscrepancy.discrepancyId,
+    })
+    expect(
+      failureOf(
+        decideReconciliation({
+          accountId,
+          comparison: {
+            ...mismatch.comparison,
+            discrepancies: [firstDiscrepancy, firstDiscrepancy],
+          },
+          previous: [],
+          reconciledAt: nextObservedAt,
+        }),
+      ),
+    ).toMatchObject({
+      _tag: 'DuplicateReconciliationDiscrepancy',
+      source: 'current',
+      discrepancyId: firstDiscrepancy.discrepancyId,
+    })
+  })
+
+  test('validates absent and complete authority risk context without Effects', () => {
+    expect(successOf(riskContextFromRow(emptyRiskRow(), 2))).toEqual({
+      tradingDate: '2026-07-22',
+      authority: null,
+      authorityObservedAt: null,
+      unknownMutationCount: 2,
+      dailyTradedNotionalMicros: '0',
+      dayStartEquityMicros: '1000000000',
+      peakEquityMicros: '1000000000',
+    })
+
+    const updatedAt = new Date('2026-07-22T15:30:01.000Z')
+    const observedAuthorityAt = new Date('2026-07-22T15:30:02.000Z')
+    const authority = successOf(
+      riskContextFromRow(
+        {
+          ...emptyRiskRow(),
+          authority_schema_version: 'bayn.paper-authority.v1',
+          authority_generation_hash: hash('authority-generation'),
+          authority_maximum: Authority.Observe,
+          authority_effective: Authority.Observe,
+          authority_kill: KillState.Clear,
+          authority_version: '1',
+          authority_updated_at: updatedAt,
+          authority_observed_at: observedAuthorityAt,
+        },
+        0,
+      ),
+    )
+    expect(authority).toMatchObject({
+      authority: {
+        generationHash: hash('authority-generation'),
+        maximum: Authority.Observe,
+        effective: Authority.Observe,
+        kill: KillState.Clear,
+        version: 1,
+        updatedAt: updatedAt.toISOString(),
+      },
+      authorityObservedAt: observedAuthorityAt.toISOString(),
+    })
+  })
+
+  test('returns closed risk-row, authority-decode, and timestamp failures', () => {
+    expect(
+      failureOf(
+        riskContextFromRow(
+          {
+            ...emptyRiskRow(),
+            authority_reason: 'orphaned reason',
+          },
+          0,
+        ),
+      ),
+    ).toMatchObject({
+      _tag: 'InvalidRiskContext',
+      reason: 'authority-evidence-without-state',
+    })
+    expect(
+      failureOf(
+        riskContextFromRow(
+          {
+            ...emptyRiskRow(),
+            authority_schema_version: 'bayn.paper-authority.v1',
+          },
+          0,
+        ),
+      ),
+    ).toMatchObject({
+      _tag: 'InvalidRiskContext',
+      reason: 'authority-state-incomplete',
+      details: {
+        missingFields: expect.arrayContaining(['authority_generation_hash', 'authority_observed_at']),
+      },
+    })
+
+    const invalidAuthority = failureOf(
+      riskContextFromRow(
+        {
+          ...emptyRiskRow(),
+          authority_schema_version: 'bayn.paper-authority.v1',
+          authority_generation_hash: hash('invalid-authority-generation'),
+          authority_maximum: Authority.Observe,
+          authority_effective: Authority.Paper,
+          authority_kill: KillState.Clear,
+          authority_version: '1',
+          authority_updated_at: new Date('2026-07-22T15:30:01.000Z'),
+          authority_observed_at: new Date('2026-07-22T15:30:02.000Z'),
+        },
+        0,
+      ),
+    )
+    expect(invalidAuthority).toMatchObject({
+      _tag: 'AuthorityStateDecodeFailed',
+      cause: expect.anything(),
+    })
+    if (invalidAuthority._tag !== 'AuthorityStateDecodeFailed') {
+      throw new Error('expected authority-state decode failure')
+    }
+    const decodeDetails = reconciliationAlgebraFailureDetails(invalidAuthority)
+    expect(decodeDetails.failure).toBe('decode')
+    expect(decodeDetails.cause).toBe(invalidAuthority.cause)
+
+    const invalidTimestamp = failureOf(
+      riskContextFromRow(
+        {
+          ...emptyRiskRow(),
+          authority_schema_version: 'bayn.paper-authority.v1',
+          authority_generation_hash: hash('invalid-date-authority-generation'),
+          authority_maximum: Authority.Observe,
+          authority_effective: Authority.Observe,
+          authority_kill: KillState.Clear,
+          authority_version: '1',
+          authority_updated_at: new Date(Number.NaN),
+          authority_observed_at: new Date('2026-07-22T15:30:02.000Z'),
+        },
+        0,
+      ),
+    )
+    expect(invalidTimestamp).toMatchObject({
+      _tag: 'RiskContextTimestampFailed',
+      field: 'authority_updated_at',
+      cause: expect.any(RangeError),
+    })
+  })
+})

--- a/services/bayn/src/db/reconciliation-algebra.ts
+++ b/services/bayn/src/db/reconciliation-algebra.ts
@@ -1,0 +1,679 @@
+import { Result, Schema } from 'effect'
+
+import { rebuildAccountingLedger, type AccountingTransaction } from '../accounting'
+import { MutationOperation } from '../broker/alpaca-mutations'
+import type { RuntimeConfig } from '../config'
+import { MutationEventType } from '../execution/mutations'
+import { canonicalHashV1 } from '../hash'
+import {
+  Authority,
+  AuthorityStateSchema,
+  IntentState,
+  KillState,
+  OrderSide,
+  OrderType,
+  ReconciliationSchema,
+  ReconciliationStatus,
+  TerminalOutcome,
+  TimeInForce,
+  type AccountSnapshot,
+  type AccountingReceipt,
+  type Discrepancy,
+  type Fill,
+  type Order,
+  type Position,
+  type Reconciliation,
+  type Valuation,
+} from '../paper'
+import {
+  compareReconciliation,
+  reconciledStateHash,
+  type DurableFill,
+  type IntentExpectation,
+  type ProjectedPosition,
+  type ReconciliationComparison,
+  type ReconciliationRiskContext,
+} from '../reconciliation'
+import { strictParseOptions, type IsoDate } from '../schemas'
+
+export interface IntentProjectionRow {
+  readonly intent_id: string
+  readonly client_order_id: string
+  readonly symbol: string
+  readonly side: OrderSide
+  readonly order_type: OrderType
+  readonly time_in_force: TimeInForce
+  readonly quantity_micros: string
+  readonly state: IntentState
+  readonly terminal_outcome: TerminalOutcome | null
+  readonly broker_order_id: string | null
+  readonly mutation_operation: MutationOperation | null
+  readonly mutation_event_type: MutationEventType | null
+  readonly mutation_occurred_at: string | null
+}
+
+export interface IntentProjection {
+  readonly intents: readonly IntentExpectation[]
+  readonly unknownMutationCount: number
+}
+
+export interface OpeningCashRow {
+  readonly cash_micros: string
+  readonly observed_at: string
+}
+
+export interface ReconciliationSnapshotMaterial {
+  readonly account: AccountSnapshot
+  readonly positions: readonly Position[]
+  readonly positionsObservedAt: string
+  readonly orders: readonly Order[]
+  readonly ordersObservedAt: string
+  readonly fills: readonly Fill[]
+  readonly valuation: Valuation
+  readonly reconciledAt: string
+}
+
+export interface AccountingVerification {
+  readonly exactReceipts: ReadonlyMap<string, boolean>
+  readonly plans: readonly ReturnType<typeof rebuildAccountingLedger>[]
+}
+
+type AccountingLedgerIdentity = {
+  readonly tigerBeetle: Pick<RuntimeConfig['tigerBeetle'], 'clusterId' | 'ledger'>
+}
+
+export interface AccountingComparison {
+  readonly accountingHash: string
+  readonly comparison: ReconciliationComparison
+}
+
+export interface AgedDiscrepancies {
+  readonly discrepancies: readonly Discrepancy[]
+  readonly status: ReconciliationStatus
+}
+
+export interface RiskContextRow {
+  readonly trading_date: IsoDate
+  readonly authority_schema_version: 'bayn.paper-authority.v1' | null
+  readonly authority_generation_hash: string | null
+  readonly authority_maximum: Authority | null
+  readonly authority_effective: Authority | null
+  readonly authority_kill: KillState | null
+  readonly authority_reason: string | null
+  readonly authority_version: string | null
+  readonly authority_updated_at: Date | null
+  readonly authority_observed_at: Date | null
+  readonly daily_traded_notional_micros: string
+  readonly day_start_equity_micros: string
+  readonly peak_equity_micros: string
+}
+
+type AccountingProjectionOperation =
+  | 'accounting-hash'
+  | 'expected-cash'
+  | 'reconciliation-comparison'
+  | 'reconciled-state-hash'
+
+type ReconciliationIdentityOperation = 'content-hash' | 'decode' | 'reconciliation-id'
+
+export type ReconciliationAlgebraFailure =
+  | {
+      readonly _tag: 'AccountingPlanFailed'
+      readonly transactionId: string
+      readonly brokerEventId: string
+      readonly cause: unknown
+    }
+  | { readonly _tag: 'DuplicateReceiptBrokerEvent'; readonly brokerEventId: string }
+  | { readonly _tag: 'ReceiptVerificationFailed'; readonly brokerEventId: string; readonly cause: unknown }
+  | {
+      readonly _tag: 'AccountingPredatesOpeningCash'
+      readonly transactionId: string
+      readonly transactionOccurredAt: string
+      readonly openingObservedAt: string
+    }
+  | {
+      readonly _tag: 'AccountingProjectionFailed'
+      readonly operation: AccountingProjectionOperation
+      readonly cause: unknown
+    }
+  | {
+      readonly _tag: 'DuplicateReconciliationDiscrepancy'
+      readonly source: 'current' | 'previous'
+      readonly discrepancyId: string
+    }
+  | {
+      readonly _tag: 'ReconciliationIdentityFailed'
+      readonly operation: ReconciliationIdentityOperation
+      readonly cause: unknown
+    }
+  | {
+      readonly _tag: 'StoredReconciliationMismatch'
+      readonly reconciliationId: string
+      readonly expectedContentHash: string
+      readonly storedContentHash: string
+    }
+  | {
+      readonly _tag: 'InvalidRiskContext'
+      readonly reason:
+        | 'authority-evidence-without-state'
+        | 'authority-state-incomplete'
+        | 'authority-update-after-observation'
+        | 'authority-version-invalid'
+      readonly details: Readonly<Record<string, unknown>>
+    }
+  | { readonly _tag: 'AuthorityStateDecodeFailed'; readonly cause: unknown }
+  | {
+      readonly _tag: 'RiskContextTimestampFailed'
+      readonly field: 'authority_observed_at' | 'authority_updated_at'
+      readonly cause: unknown
+    }
+
+const unresolvedEvents = new Set<MutationEventType>([
+  MutationEventType.SubmitStarted,
+  MutationEventType.SubmitUnknown,
+  MutationEventType.RecoveryNotFound,
+  MutationEventType.RecoveryUnknown,
+  MutationEventType.CancelStarted,
+  MutationEventType.CancelAccepted,
+  MutationEventType.CancelUnknown,
+])
+
+const decodeAuthorityState = Schema.decodeUnknownResult(AuthorityStateSchema, strictParseOptions)
+const decodeReconciliation = Schema.decodeUnknownResult(ReconciliationSchema, strictParseOptions)
+
+const fail = (failure: ReconciliationAlgebraFailure): Result.Result<never, ReconciliationAlgebraFailure> =>
+  Result.fail(failure)
+
+export const projectIntentExpectations = (
+  rows: readonly IntentProjectionRow[],
+): Result.Result<IntentProjection, ReconciliationAlgebraFailure> => {
+  const intents: readonly IntentExpectation[] = rows.map((row) => ({
+    intentId: row.intent_id,
+    clientOrderId: row.client_order_id,
+    symbol: row.symbol,
+    side: row.side,
+    orderType: row.order_type,
+    timeInForce: row.time_in_force,
+    quantityMicros: row.quantity_micros,
+    state: row.state,
+    ...(row.terminal_outcome === null ? {} : { terminalOutcome: row.terminal_outcome }),
+    expectsBrokerOrder: row.broker_order_id !== null,
+    ...(row.broker_order_id === null ? {} : { brokerOrderId: row.broker_order_id }),
+    ...(row.mutation_event_type !== null &&
+    (unresolvedEvents.has(row.mutation_event_type) ||
+      (row.mutation_operation === MutationOperation.Cancel &&
+        row.mutation_event_type === MutationEventType.RecoveryFound &&
+        row.state !== IntentState.Terminal)) &&
+    row.mutation_occurred_at !== null
+      ? { unknownSince: row.mutation_occurred_at }
+      : {}),
+  }))
+  return Result.succeed({
+    intents,
+    unknownMutationCount: intents.filter((intent) => intent.unknownSince !== undefined).length,
+  })
+}
+
+export const canonicalAccountingReceiptMaterial = (receipt: AccountingReceipt) => ({
+  schemaVersion: receipt.schemaVersion,
+  ...(receipt.intentId === undefined ? {} : { intentId: receipt.intentId }),
+  brokerEventId: receipt.brokerEventId,
+  tigerBeetleClusterId: receipt.tigerBeetleClusterId,
+  tigerBeetleLedger: receipt.tigerBeetleLedger,
+  accountIds: receipt.accountIds,
+  transferIds: receipt.transferIds,
+  debitMicros: receipt.debitMicros,
+  creditMicros: receipt.creditMicros,
+})
+
+const receiptMatches = (
+  transaction: AccountingTransaction,
+  receipt: AccountingReceipt | undefined,
+  plan: ReturnType<typeof rebuildAccountingLedger>,
+  config: AccountingLedgerIdentity,
+): Result.Result<boolean, ReconciliationAlgebraFailure> => {
+  if (receipt === undefined) return Result.succeed(false)
+  return Result.try({
+    try: () => {
+      const accountIds = plan.accounts.map((account) => account.id.toString())
+      const transferIds = plan.transfers.map((transfer) => transfer.id.toString())
+      const posted = plan.transfers.reduce((sum, transfer) => sum + transfer.amount, 0n).toString()
+      return (
+        receipt.brokerEventId === transaction.brokerEventId &&
+        receipt.intentId === transaction.intentId &&
+        receipt.tigerBeetleClusterId === config.tigerBeetle.clusterId.toString() &&
+        receipt.tigerBeetleLedger === config.tigerBeetle.ledger &&
+        receipt.debitMicros === posted &&
+        receipt.creditMicros === posted &&
+        receipt.accountIds.length === accountIds.length &&
+        receipt.accountIds.every((value, index) => value === accountIds[index]) &&
+        receipt.transferIds.length === transferIds.length &&
+        receipt.transferIds.every((value, index) => value === transferIds[index]) &&
+        canonicalHashV1(canonicalAccountingReceiptMaterial(receipt)) === receipt.contentHash
+      )
+    },
+    catch: (cause): ReconciliationAlgebraFailure => ({
+      _tag: 'ReceiptVerificationFailed',
+      brokerEventId: transaction.brokerEventId,
+      cause,
+    }),
+  })
+}
+
+export const verifyAccountingReceipts = (
+  transactions: readonly AccountingTransaction[],
+  receipts: readonly AccountingReceipt[],
+  config: AccountingLedgerIdentity,
+): Result.Result<AccountingVerification, ReconciliationAlgebraFailure> =>
+  Result.gen(function* () {
+    const receiptBrokerEvents = new Set<string>()
+    for (const receipt of receipts) {
+      if (receiptBrokerEvents.has(receipt.brokerEventId)) {
+        return yield* fail({ _tag: 'DuplicateReceiptBrokerEvent', brokerEventId: receipt.brokerEventId })
+      }
+      receiptBrokerEvents.add(receipt.brokerEventId)
+    }
+    const receiptsByEvent = new Map(receipts.map((receipt) => [receipt.brokerEventId, receipt]))
+    const planned: {
+      readonly transaction: AccountingTransaction
+      readonly plan: ReturnType<typeof rebuildAccountingLedger>
+    }[] = []
+    for (const transaction of transactions) {
+      planned.push({
+        transaction,
+        plan: yield* Result.try({
+          try: () => rebuildAccountingLedger(transaction, config.tigerBeetle.ledger),
+          catch: (cause): ReconciliationAlgebraFailure => ({
+            _tag: 'AccountingPlanFailed',
+            transactionId: transaction.transactionId,
+            brokerEventId: transaction.brokerEventId,
+            cause,
+          }),
+        }),
+      })
+    }
+
+    const exactReceipts = new Map<string, boolean>()
+    for (const { transaction, plan } of planned) {
+      exactReceipts.set(
+        transaction.brokerEventId,
+        yield* receiptMatches(transaction, receiptsByEvent.get(transaction.brokerEventId), plan, config),
+      )
+    }
+    return { exactReceipts, plans: planned.map(({ plan }) => plan) }
+  })
+
+const accountingProjection = <A>(
+  operation: AccountingProjectionOperation,
+  evaluate: () => A,
+): Result.Result<A, ReconciliationAlgebraFailure> =>
+  Result.try({
+    try: evaluate,
+    catch: (cause): ReconciliationAlgebraFailure => ({ _tag: 'AccountingProjectionFailed', operation, cause }),
+  })
+
+export const compareOpeningCash = (input: {
+  readonly accountId: string
+  readonly openingCash: OpeningCashRow
+  readonly transactions: readonly AccountingTransaction[]
+  readonly receipts: readonly AccountingReceipt[]
+  readonly ledgerExact: boolean
+  readonly snapshot: ReconciliationSnapshotMaterial
+  readonly intents: readonly IntentExpectation[]
+  readonly durableFills: readonly DurableFill[]
+  readonly projectedPositions: readonly ProjectedPosition[]
+}): Result.Result<AccountingComparison, ReconciliationAlgebraFailure> =>
+  Result.gen(function* () {
+    const predecessor = input.transactions.find((transaction) => transaction.occurredAt < input.openingCash.observed_at)
+    if (predecessor !== undefined) {
+      return yield* fail({
+        _tag: 'AccountingPredatesOpeningCash',
+        transactionId: predecessor.transactionId,
+        transactionOccurredAt: predecessor.occurredAt,
+        openingObservedAt: input.openingCash.observed_at,
+      })
+    }
+    const expectedCashMicros = yield* accountingProjection('expected-cash', () =>
+      input.transactions
+        .reduce(
+          (cash, transaction) => cash + BigInt(transaction.cashDeltaMicros),
+          BigInt(input.openingCash.cash_micros),
+        )
+        .toString(),
+    )
+    const accountingHash = yield* accountingProjection('accounting-hash', () =>
+      canonicalHashV1({
+        schemaVersion: 'bayn.paper-accounting-state.v1',
+        accountId: input.accountId,
+        openingCash: input.openingCash,
+        transactions: input.transactions,
+        receipts: input.receipts,
+        ledgerExact: input.ledgerExact,
+      }),
+    )
+    const stateHash = yield* accountingProjection('reconciled-state-hash', () =>
+      reconciledStateHash({
+        account: input.snapshot.account,
+        positions: input.snapshot.positions,
+        positionsObservedAt: input.snapshot.positionsObservedAt,
+        orders: input.snapshot.orders,
+        ordersObservedAt: input.snapshot.ordersObservedAt,
+        accountingHash,
+      }),
+    )
+    const comparison = yield* accountingProjection('reconciliation-comparison', () =>
+      compareReconciliation({
+        accountId: input.accountId,
+        stateHash,
+        account: input.snapshot.account,
+        positions: input.snapshot.positions,
+        orders: input.snapshot.orders,
+        fills: input.snapshot.fills,
+        intents: input.intents,
+        durableFills: input.durableFills,
+        projectedPositions: input.projectedPositions,
+        expectedCashMicros,
+        valuation: input.snapshot.valuation,
+        accountingHash,
+        ledgerExact: input.ledgerExact,
+        reconciledAt: input.snapshot.reconciledAt,
+      }),
+    )
+    return { accountingHash, comparison }
+  })
+
+export const ageDiscrepancies = (
+  comparison: ReconciliationComparison,
+  previous: readonly Discrepancy[],
+  reconciledAt: string,
+): Result.Result<AgedDiscrepancies, ReconciliationAlgebraFailure> => {
+  const prior = new Map<string, Discrepancy>()
+  for (const discrepancy of previous) {
+    if (prior.has(discrepancy.discrepancyId)) {
+      return fail({
+        _tag: 'DuplicateReconciliationDiscrepancy',
+        source: 'previous',
+        discrepancyId: discrepancy.discrepancyId,
+      })
+    }
+    prior.set(discrepancy.discrepancyId, discrepancy)
+  }
+
+  const current = new Set<string>()
+  const discrepancies: Discrepancy[] = []
+  for (const discrepancy of comparison.discrepancies) {
+    if (current.has(discrepancy.discrepancyId)) {
+      return fail({
+        _tag: 'DuplicateReconciliationDiscrepancy',
+        source: 'current',
+        discrepancyId: discrepancy.discrepancyId,
+      })
+    }
+    current.add(discrepancy.discrepancyId)
+    discrepancies.push({
+      ...discrepancy,
+      firstObservedAt: prior.get(discrepancy.discrepancyId)?.firstObservedAt ?? reconciledAt,
+      lastObservedAt: reconciledAt,
+    })
+  }
+  return Result.succeed({
+    discrepancies,
+    status: discrepancies.length === 0 ? ReconciliationStatus.Exact : ReconciliationStatus.Discrepancy,
+  })
+}
+
+const reconciliationIdentity = <A>(
+  operation: ReconciliationIdentityOperation,
+  evaluate: () => A,
+): Result.Result<A, ReconciliationAlgebraFailure> =>
+  Result.try({
+    try: evaluate,
+    catch: (cause): ReconciliationAlgebraFailure => ({ _tag: 'ReconciliationIdentityFailed', operation, cause }),
+  })
+
+export const makeReconciliationIdentity = (input: {
+  readonly accountId: string
+  readonly comparison: ReconciliationComparison
+  readonly aged: AgedDiscrepancies
+  readonly reconciledAt: string
+}): Result.Result<Reconciliation, ReconciliationAlgebraFailure> =>
+  Result.gen(function* () {
+    const material = {
+      schemaVersion: 'bayn.paper-reconciliation.v1' as const,
+      accountId: input.accountId,
+      expectedHash: input.comparison.expectedHash,
+      observedHash: input.comparison.observedHash,
+      status: input.aged.status,
+      discrepancies: input.aged.discrepancies,
+      reconciledAt: input.reconciledAt,
+    }
+    const reconciliationId = yield* reconciliationIdentity('reconciliation-id', () =>
+      canonicalHashV1({
+        schemaVersion: 'bayn.paper-reconciliation-id.v1',
+        material,
+      }),
+    )
+    const contentHash = yield* reconciliationIdentity('content-hash', () =>
+      canonicalHashV1({ ...material, reconciliationId }),
+    )
+    const decoded = decodeReconciliation({ ...material, reconciliationId, contentHash })
+    if (Result.isFailure(decoded)) {
+      return yield* fail({
+        _tag: 'ReconciliationIdentityFailed',
+        operation: 'decode',
+        cause: decoded.failure,
+      })
+    }
+    return decoded.success
+  })
+
+export const decideReconciliation = (input: {
+  readonly accountId: string
+  readonly comparison: ReconciliationComparison
+  readonly previous: readonly Discrepancy[]
+  readonly reconciledAt: string
+}): Result.Result<Reconciliation, ReconciliationAlgebraFailure> =>
+  Result.gen(function* () {
+    const aged = yield* ageDiscrepancies(input.comparison, input.previous, input.reconciledAt)
+    return yield* makeReconciliationIdentity({ ...input, aged })
+  })
+
+export const validateReconciliationReadback = (
+  reconciliation: Reconciliation,
+  storedContentHash: string,
+): Result.Result<void, ReconciliationAlgebraFailure> =>
+  storedContentHash === reconciliation.contentHash
+    ? Result.succeed(undefined)
+    : fail({
+        _tag: 'StoredReconciliationMismatch',
+        reconciliationId: reconciliation.reconciliationId,
+        expectedContentHash: reconciliation.contentHash,
+        storedContentHash,
+      })
+
+const timestamp = (
+  field: 'authority_observed_at' | 'authority_updated_at',
+  value: Date,
+): Result.Result<string, ReconciliationAlgebraFailure> =>
+  Result.try({
+    try: () => value.toISOString(),
+    catch: (cause): ReconciliationAlgebraFailure => ({ _tag: 'RiskContextTimestampFailed', field, cause }),
+  })
+
+const riskMaterial = (row: RiskContextRow, unknownMutationCount: number) => ({
+  tradingDate: row.trading_date,
+  unknownMutationCount,
+  dailyTradedNotionalMicros: row.daily_traded_notional_micros,
+  dayStartEquityMicros: row.day_start_equity_micros,
+  peakEquityMicros: row.peak_equity_micros,
+})
+
+export const riskContextFromRow = (
+  row: RiskContextRow,
+  unknownMutationCount: number,
+): Result.Result<ReconciliationRiskContext, ReconciliationAlgebraFailure> =>
+  Result.gen(function* () {
+    const authorityMissing =
+      row.authority_schema_version === null &&
+      row.authority_generation_hash === null &&
+      row.authority_maximum === null &&
+      row.authority_effective === null &&
+      row.authority_kill === null &&
+      row.authority_version === null &&
+      row.authority_updated_at === null
+    if (authorityMissing) {
+      if (row.authority_reason !== null || row.authority_observed_at !== null) {
+        return yield* fail({
+          _tag: 'InvalidRiskContext',
+          reason: 'authority-evidence-without-state',
+          details: {
+            authorityReasonPresent: row.authority_reason !== null,
+            authorityObservedAtPresent: row.authority_observed_at !== null,
+          },
+        })
+      }
+      return { ...riskMaterial(row, unknownMutationCount), authority: null, authorityObservedAt: null }
+    }
+
+    const missingFields: string[] = []
+    if (row.authority_schema_version === null) missingFields.push('authority_schema_version')
+    if (row.authority_generation_hash === null) missingFields.push('authority_generation_hash')
+    if (row.authority_maximum === null) missingFields.push('authority_maximum')
+    if (row.authority_effective === null) missingFields.push('authority_effective')
+    if (row.authority_kill === null) missingFields.push('authority_kill')
+    if (row.authority_version === null) missingFields.push('authority_version')
+    if (row.authority_updated_at === null) missingFields.push('authority_updated_at')
+    if (row.authority_observed_at === null) missingFields.push('authority_observed_at')
+    if (
+      row.authority_schema_version === null ||
+      row.authority_generation_hash === null ||
+      row.authority_maximum === null ||
+      row.authority_effective === null ||
+      row.authority_kill === null ||
+      row.authority_version === null ||
+      row.authority_updated_at === null ||
+      row.authority_observed_at === null
+    ) {
+      return yield* fail({
+        _tag: 'InvalidRiskContext',
+        reason: 'authority-state-incomplete',
+        details: { missingFields },
+      })
+    }
+
+    const version = Number(row.authority_version)
+    if (!Number.isSafeInteger(version) || version <= 0) {
+      return yield* fail({
+        _tag: 'InvalidRiskContext',
+        reason: 'authority-version-invalid',
+        details: { authorityVersion: row.authority_version },
+      })
+    }
+
+    const authorityUpdatedAt = yield* timestamp('authority_updated_at', row.authority_updated_at)
+    const decodedAuthority = decodeAuthorityState({
+      schemaVersion: row.authority_schema_version,
+      generationHash: row.authority_generation_hash,
+      maximum: row.authority_maximum,
+      effective: row.authority_effective,
+      kill: row.authority_kill,
+      ...(row.authority_reason === null ? {} : { reason: row.authority_reason }),
+      version,
+      updatedAt: authorityUpdatedAt,
+    })
+    if (Result.isFailure(decodedAuthority)) {
+      return yield* fail({ _tag: 'AuthorityStateDecodeFailed', cause: decodedAuthority.failure })
+    }
+    const authorityObservedAt = yield* timestamp('authority_observed_at', row.authority_observed_at)
+    if (decodedAuthority.success.updatedAt > authorityObservedAt) {
+      return yield* fail({
+        _tag: 'InvalidRiskContext',
+        reason: 'authority-update-after-observation',
+        details: { authorityUpdatedAt: decodedAuthority.success.updatedAt, authorityObservedAt },
+      })
+    }
+    return {
+      ...riskMaterial(row, unknownMutationCount),
+      authority: decodedAuthority.success,
+      authorityObservedAt,
+    }
+  })
+
+interface ReconciliationAlgebraFailureDetails {
+  readonly failure: 'decode' | 'invariant'
+  readonly message: string
+  readonly cause: unknown
+}
+
+export const reconciliationAlgebraFailureDetails = (
+  failure: ReconciliationAlgebraFailure,
+): ReconciliationAlgebraFailureDetails => {
+  switch (failure._tag) {
+    case 'AccountingPlanFailed':
+      return {
+        failure: 'invariant',
+        message: `accounting ledger plan verification failed for transaction ${failure.transactionId}`,
+        cause: failure.cause,
+      }
+    case 'DuplicateReceiptBrokerEvent':
+      return {
+        failure: 'invariant',
+        message: `duplicate accounting receipt broker event ${failure.brokerEventId}`,
+        cause: failure,
+      }
+    case 'ReceiptVerificationFailed':
+      return {
+        failure: 'invariant',
+        message: `accounting receipt verification failed for broker event ${failure.brokerEventId}`,
+        cause: failure.cause,
+      }
+    case 'AccountingPredatesOpeningCash':
+      return {
+        failure: 'invariant',
+        message: `accounting transaction ${failure.transactionId} predates the opening cash snapshot`,
+        cause: failure,
+      }
+    case 'AccountingProjectionFailed':
+      return {
+        failure: 'invariant',
+        message: `paper accounting ${failure.operation} computation failed`,
+        cause: failure.cause,
+      }
+    case 'DuplicateReconciliationDiscrepancy':
+      return {
+        failure: 'invariant',
+        message: `duplicate ${failure.source} reconciliation discrepancy ${failure.discrepancyId}`,
+        cause: failure,
+      }
+    case 'ReconciliationIdentityFailed':
+      return {
+        failure: failure.operation === 'decode' ? 'decode' : 'invariant',
+        message: `reconciliation ${failure.operation} computation failed`,
+        cause: failure.cause,
+      }
+    case 'StoredReconciliationMismatch':
+      return {
+        failure: 'invariant',
+        message: `stored reconciliation ${failure.reconciliationId} differs from deterministic replay`,
+        cause: failure,
+      }
+    case 'InvalidRiskContext':
+      return {
+        failure: 'invariant',
+        message: `reconciliation risk context is invalid: ${failure.reason}`,
+        cause: failure,
+      }
+    case 'AuthorityStateDecodeFailed':
+      return {
+        failure: 'decode',
+        message: 'durable reconciliation authority state is invalid',
+        cause: failure.cause,
+      }
+    case 'RiskContextTimestampFailed':
+      return {
+        failure: 'invariant',
+        message: `reconciliation risk context timestamp ${failure.field} is invalid`,
+        cause: failure.cause,
+      }
+  }
+}

--- a/services/bayn/src/db/reconciliation.ts
+++ b/services/bayn/src/db/reconciliation.ts
@@ -1,10 +1,9 @@
 import { PgClient } from '@effect/sql-pg'
-import { Data, Effect, Schema } from 'effect'
+import { Data, Effect, Result, Schema } from 'effect'
 
-import { rebuildAccountingLedger, type AccountingTransaction } from '../accounting'
+import type { AccountingTransaction } from '../accounting'
 import { MutationOperation } from '../broker/alpaca-mutations'
 import type { RuntimeConfig } from '../config'
-import { canonicalHashV1 } from '../hash'
 import type { JournalService } from '../ledger'
 import {
   Authority,
@@ -13,17 +12,13 @@ import {
   KillState,
   OrderSide,
   OrderType,
-  ReconciliationStatus,
   SignedMicrosSchema,
   TerminalOutcome,
   TimeInForce,
   UnsignedMicrosSchema,
   decodeAccountingReceipt,
-  decodeAuthorityState,
-  decodeReconciliation,
   type AccountSnapshot,
   type AccountingReceipt,
-  type Discrepancy,
   type Fill,
   type Order,
   type Position,
@@ -31,9 +26,8 @@ import {
   type Valuation,
 } from '../paper'
 import {
-  compareReconciliation,
-  reconciledStateHash,
   type IntentExpectation,
+  type ReconciliationComparison,
   type ReconciliationMetrics,
   type ReconciliationRiskContext,
 } from '../reconciliation'
@@ -51,6 +45,16 @@ import {
   accountingReceiptFromRow,
   accountingTransactionFromRow,
 } from './accounting-rows'
+import {
+  compareOpeningCash,
+  decideReconciliation,
+  projectIntentExpectations,
+  reconciliationAlgebraFailureDetails,
+  riskContextFromRow,
+  validateReconciliationReadback,
+  verifyAccountingReceipts,
+  type ReconciliationAlgebraFailure,
+} from './reconciliation-algebra'
 
 export interface IntentBinding {
   readonly intentId: string
@@ -76,6 +80,20 @@ export interface ReconciliationReport {
 export interface ReconciliationWriteResult extends ReconciliationReport {
   readonly accountingHash: string
   readonly riskContext: ReconciliationRiskContext
+}
+
+interface AccountingReadPhase {
+  readonly intents: readonly IntentExpectation[]
+  readonly unknownMutationCount: number
+  readonly transactions: readonly AccountingTransaction[]
+  readonly receipts: readonly AccountingReceipt[]
+  readonly exactReceipts: ReadonlyMap<string, boolean>
+  readonly ledgerExact: boolean
+}
+
+interface ComparisonReadPhase {
+  readonly accountingHash: string
+  readonly comparison: ReconciliationComparison
 }
 
 export class ReconciliationStoreError extends Data.TaggedError('ReconciliationStoreError')<{
@@ -180,127 +198,16 @@ const attempt = <A>(
     catch: (cause) => storeError(operation, 'invariant', `paper reconciliation ${operation} invariant failed`, cause),
   })
 
-const riskContextFromRow = (
-  row: (typeof ReconciliationRiskContextRow.Type)[0],
-  unknownMutationCount: number,
-): Effect.Effect<ReconciliationRiskContext, ReconciliationStoreError> =>
-  Effect.gen(function* () {
-    const requiredAuthority = [
-      row.authority_schema_version,
-      row.authority_generation_hash,
-      row.authority_maximum,
-      row.authority_effective,
-      row.authority_kill,
-      row.authority_version,
-      row.authority_updated_at,
-    ]
-    const authorityMissing = requiredAuthority.every((value) => value === null)
-    if (authorityMissing && (row.authority_reason !== null || row.authority_observed_at !== null)) {
-      return yield* Effect.fail(
-        storeError('risk-context', 'invariant', 'authority evidence exists without durable authority state'),
-      )
-    }
-    if (
-      !authorityMissing &&
-      (requiredAuthority.some((value) => value === null) || row.authority_observed_at === null)
-    ) {
-      return yield* Effect.fail(storeError('risk-context', 'invariant', 'durable authority state is incomplete'))
-    }
-
-    const authority = authorityMissing
-      ? null
-      : yield* Effect.gen(function* () {
-          const version = Number(row.authority_version)
-          if (!Number.isSafeInteger(version) || version <= 0) {
-            return yield* Effect.fail(
-              storeError('risk-context', 'invariant', 'durable authority version is not a safe positive integer'),
-            )
-          }
-          return yield* decodeAuthorityState({
-            schemaVersion: row.authority_schema_version,
-            generationHash: row.authority_generation_hash,
-            maximum: row.authority_maximum,
-            effective: row.authority_effective,
-            kill: row.authority_kill,
-            ...(row.authority_reason === null ? {} : { reason: row.authority_reason }),
-            version,
-            updatedAt: row.authority_updated_at?.toISOString(),
-          }).pipe(
-            Effect.mapError((cause) =>
-              storeError('risk-context', 'decode', 'durable authority state failed decoding', cause),
-            ),
-          )
-        })
-
-    const material = {
-      tradingDate: row.trading_date,
-      unknownMutationCount,
-      dailyTradedNotionalMicros: row.daily_traded_notional_micros,
-      dayStartEquityMicros: row.day_start_equity_micros,
-      peakEquityMicros: row.peak_equity_micros,
-    }
-    if (authority === null) return { ...material, authority: null, authorityObservedAt: null }
-    const authorityObservedAt = row.authority_observed_at
-    if (authorityObservedAt === null) {
-      return yield* Effect.fail(
-        storeError('risk-context', 'invariant', 'durable authority observation time is missing'),
-      )
-    }
-    const authorityObservedAtIso = authorityObservedAt.toISOString()
-    if (authority.updatedAt > authorityObservedAtIso) {
-      return yield* Effect.fail(
-        storeError('risk-context', 'invariant', 'durable authority update follows its observation time'),
-      )
-    }
-    return { ...material, authority, authorityObservedAt: authorityObservedAtIso }
-  })
-
-const unresolvedEvents = new Set<MutationEventType>([
-  MutationEventType.SubmitStarted,
-  MutationEventType.SubmitUnknown,
-  MutationEventType.RecoveryNotFound,
-  MutationEventType.RecoveryUnknown,
-  MutationEventType.CancelStarted,
-  MutationEventType.CancelAccepted,
-  MutationEventType.CancelUnknown,
-])
-
-const receiptMaterial = (receipt: AccountingReceipt) => ({
-  schemaVersion: receipt.schemaVersion,
-  ...(receipt.intentId === undefined ? {} : { intentId: receipt.intentId }),
-  brokerEventId: receipt.brokerEventId,
-  tigerBeetleClusterId: receipt.tigerBeetleClusterId,
-  tigerBeetleLedger: receipt.tigerBeetleLedger,
-  accountIds: receipt.accountIds,
-  transferIds: receipt.transferIds,
-  debitMicros: receipt.debitMicros,
-  creditMicros: receipt.creditMicros,
-})
-
-const receiptIsExact = (
-  transaction: AccountingTransaction,
-  receipt: AccountingReceipt | undefined,
-  plan: ReturnType<typeof rebuildAccountingLedger>,
-  config: Pick<RuntimeConfig, 'tigerBeetle'>,
-): boolean => {
-  if (receipt === undefined) return false
-  const accountIds = plan.accounts.map((account) => account.id.toString())
-  const transferIds = plan.transfers.map((transfer) => transfer.id.toString())
-  const posted = plan.transfers.reduce((sum, transfer) => sum + transfer.amount, 0n).toString()
-  return (
-    receipt.brokerEventId === transaction.brokerEventId &&
-    receipt.intentId === transaction.intentId &&
-    receipt.tigerBeetleClusterId === config.tigerBeetle.clusterId.toString() &&
-    receipt.tigerBeetleLedger === config.tigerBeetle.ledger &&
-    receipt.debitMicros === posted &&
-    receipt.creditMicros === posted &&
-    receipt.accountIds.length === accountIds.length &&
-    receipt.accountIds.every((value, index) => value === accountIds[index]) &&
-    receipt.transferIds.length === transferIds.length &&
-    receipt.transferIds.every((value, index) => value === transferIds[index]) &&
-    canonicalHashV1(receiptMaterial(receipt)) === receipt.contentHash
+const fromDecision = <A>(
+  operation: ReconciliationStoreError['operation'],
+  decision: Result.Result<A, ReconciliationAlgebraFailure>,
+): Effect.Effect<A, ReconciliationStoreError> =>
+  Effect.fromResult(decision).pipe(
+    Effect.mapError((failure) => {
+      const details = reconciliationAlgebraFailureDetails(failure)
+      return storeError(operation, details.failure, details.message, details.cause)
+    }),
   )
-}
 
 export const restrictAuthority = (
   sql: PgClient.PgClient,
@@ -334,22 +241,18 @@ export const makeReconciliation = (
         SELECT intent_id, client_order_id
         FROM intents
         WHERE account_id = ${accountId}
-        ORDER BY client_order_id
+        ORDER BY client_order_id COLLATE "C"
       `.pipe(
         Effect.flatMap(decodeBindings),
         Effect.map((rows) => rows.map((row) => ({ intentId: row.intent_id, clientOrderId: row.client_order_id }))),
       ),
     )
 
-  const reconcile = (snapshot: BrokerSnapshot): Effect.Effect<ReconciliationWriteResult, ReconciliationStoreError> =>
+  const readAccountingPhase = (accountId: string): Effect.Effect<AccountingReadPhase, ReconciliationStoreError> =>
     runStore(
       'reconcile',
-      sql.withTransaction(
-        Effect.gen(function* () {
-          const accountId = snapshot.account.accountId
-          yield* sql`SELECT pg_advisory_xact_lock(hashtextextended(${`ALPACA:${accountId}`}, 0))`
-
-          const intentRows = yield* sql<Record<string, unknown>>`
+      Effect.gen(function* () {
+        const intentRows = yield* sql<Record<string, unknown>>`
           SELECT
             intent.intent_id,
             intent.client_order_id,
@@ -384,32 +287,14 @@ export const makeReconciliation = (
             LIMIT 1
           ) AS accepted ON true
           WHERE intent.account_id = ${accountId}
-          ORDER BY intent.client_order_id
+          ORDER BY intent.client_order_id COLLATE "C"
         `.pipe(Effect.flatMap(decodeIntents))
-          const intents: IntentExpectation[] = intentRows.map((row) => ({
-            intentId: row.intent_id,
-            clientOrderId: row.client_order_id,
-            symbol: row.symbol,
-            side: row.side,
-            orderType: row.order_type,
-            timeInForce: row.time_in_force,
-            quantityMicros: row.quantity_micros,
-            state: row.state,
-            ...(row.terminal_outcome === null ? {} : { terminalOutcome: row.terminal_outcome }),
-            expectsBrokerOrder: row.broker_order_id !== null,
-            ...(row.broker_order_id === null ? {} : { brokerOrderId: row.broker_order_id }),
-            ...(row.mutation_event_type !== null &&
-            (unresolvedEvents.has(row.mutation_event_type) ||
-              (row.mutation_operation === MutationOperation.Cancel &&
-                row.mutation_event_type === MutationEventType.RecoveryFound &&
-                row.state !== IntentState.Terminal)) &&
-            row.mutation_occurred_at !== null
-              ? { unknownSince: row.mutation_occurred_at }
-              : {}),
-          }))
-          const unknownMutationCount = intents.filter((intent) => intent.unknownSince !== undefined).length
+        const { intents, unknownMutationCount } = yield* fromDecision(
+          'reconcile',
+          projectIntentExpectations(intentRows),
+        )
 
-          const transactionRows = yield* sql<Record<string, unknown>>`
+        const transactionRows = yield* sql<Record<string, unknown>>`
           SELECT
             schema_version, transaction_id, broker_event_id, intent_id, account_id, symbol, side,
             quantity_micros::text AS quantity_micros, price_micros::text AS price_micros,
@@ -420,10 +305,10 @@ export const makeReconciliation = (
             cash_delta_micros::text AS cash_delta_micros, ledger_plan_hash, content_hash, occurred_at
           FROM accounting_transactions
           WHERE account_id = ${accountId}
-          ORDER BY occurred_at, transaction_id
+          ORDER BY occurred_at, transaction_id COLLATE "C"
         `.pipe(Effect.flatMap(decodeTransactions))
-          const transactions = yield* attempt('reconcile', () => transactionRows.map(accountingTransactionFromRow))
-          const receiptRows = yield* sql<Record<string, unknown>>`
+        const transactions = yield* attempt('reconcile', () => transactionRows.map(accountingTransactionFromRow))
+        const receiptRows = yield* sql<Record<string, unknown>>`
           SELECT
             schema_version, receipt_id, intent_id, broker_event_id,
             tigerbeetle_cluster_id::text AS tigerbeetle_cluster_id,
@@ -438,39 +323,36 @@ export const makeReconciliation = (
             content_hash, recorded_at
           FROM accounting_receipts
           WHERE broker_event_id IN (SELECT broker_event_id FROM accounting_transactions WHERE account_id = ${accountId})
-          ORDER BY broker_event_id
+          ORDER BY broker_event_id COLLATE "C"
         `.pipe(Effect.flatMap(decodeReceipts))
-          const receipts = yield* Effect.forEach(receiptRows, (row) =>
-            decodeAccountingReceipt(accountingReceiptFromRow(row)),
+        const receipts = yield* Effect.forEach(receiptRows, (row) =>
+          decodeAccountingReceipt(accountingReceiptFromRow(row)),
+        )
+        const { exactReceipts, plans } = yield* fromDecision(
+          'reconcile',
+          verifyAccountingReceipts(transactions, receipts, config),
+        )
+        const ledgerExact = yield* journal
+          .verifyAccount(accountId, plans)
+          .pipe(
+            Effect.mapError((cause) =>
+              storeError('reconcile', 'ledger', 'TigerBeetle account verification failed during reconciliation', cause),
+            ),
           )
-          const { exactReceipts, plans } = yield* attempt('reconcile', () => {
-            const receiptsByEvent = new Map(receipts.map((receipt) => [receipt.brokerEventId, receipt]))
-            if (receiptsByEvent.size !== receipts.length) throw new Error('duplicate accounting receipt broker event')
-            const plans = transactions.map((transaction) =>
-              rebuildAccountingLedger(transaction, config.tigerBeetle.ledger),
-            )
-            const exactReceipts = new Map(
-              transactions.map((transaction, index) => [
-                transaction.brokerEventId,
-                receiptIsExact(transaction, receiptsByEvent.get(transaction.brokerEventId), plans[index], config),
-              ]),
-            )
-            return { exactReceipts, plans }
-          })
-          const ledgerExact = yield* journal
-            .verifyAccount(accountId, plans)
-            .pipe(
-              Effect.mapError((cause) =>
-                storeError(
-                  'reconcile',
-                  'ledger',
-                  'TigerBeetle account verification failed during reconciliation',
-                  cause,
-                ),
-              ),
-            )
 
-          const durableFillRows = yield* sql<Record<string, unknown>>`
+        return { intents, unknownMutationCount, transactions, receipts, exactReceipts, ledgerExact }
+      }),
+    )
+
+  const readComparisonPhase = (
+    accountId: string,
+    snapshot: BrokerSnapshot,
+    accounting: AccountingReadPhase,
+  ): Effect.Effect<ComparisonReadPhase, ReconciliationStoreError> =>
+    runStore(
+      'reconcile',
+      Effect.gen(function* () {
+        const durableFillRows = yield* sql<Record<string, unknown>>`
           SELECT
             fill.fill_id,
             fill.broker_order_id,
@@ -481,16 +363,18 @@ export const makeReconciliation = (
           LEFT JOIN accounting_transactions AS transaction ON transaction.broker_event_id = fill.event_id
           LEFT JOIN accounting_receipts AS receipt ON receipt.broker_event_id = fill.event_id
           WHERE fill.account_id = ${accountId}
-          ORDER BY fill.fill_id
+          ORDER BY fill.fill_id COLLATE "C"
         `.pipe(Effect.flatMap(decodeDurableFills))
-          const durableFills = durableFillRows.map((row) => ({
-            fillId: row.fill_id,
-            brokerOrderId: row.broker_order_id,
-            accounted:
-              row.transaction_id !== null && row.receipt_id !== null && exactReceipts.get(row.broker_event_id) === true,
-          }))
+        const durableFills = durableFillRows.map((row) => ({
+          fillId: row.fill_id,
+          brokerOrderId: row.broker_order_id,
+          accounted:
+            row.transaction_id !== null &&
+            row.receipt_id !== null &&
+            accounting.exactReceipts.get(row.broker_event_id) === true,
+        }))
 
-          const projectedPositionRows = yield* sql<Record<string, unknown>>`
+        const projectedPositionRows = yield* sql<Record<string, unknown>>`
           SELECT
             symbol,
             sum(quantity_delta_micros)::text AS quantity_micros,
@@ -499,15 +383,15 @@ export const makeReconciliation = (
           WHERE account_id = ${accountId}
           GROUP BY symbol
           HAVING sum(quantity_delta_micros) <> 0
-          ORDER BY symbol
+          ORDER BY symbol COLLATE "C"
         `.pipe(Effect.flatMap(decodeProjectedPositions))
-          const projectedPositions = projectedPositionRows.map((row) => ({
-            symbol: row.symbol,
-            quantityMicros: row.quantity_micros,
-            costBasisMicros: row.cost_basis_micros,
-          }))
+        const projectedPositions = projectedPositionRows.map((row) => ({
+          symbol: row.symbol,
+          quantityMicros: row.quantity_micros,
+          costBasisMicros: row.cost_basis_micros,
+        }))
 
-          const [openingCash] = yield* sql<Record<string, unknown>>`
+        const [openingCash] = yield* sql<Record<string, unknown>>`
           SELECT
             snapshot.cash_micros::text AS cash_micros,
             to_char(event.observed_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') AS observed_at
@@ -517,103 +401,51 @@ export const makeReconciliation = (
           ORDER BY event.source_sequence
           LIMIT 1
         `.pipe(Effect.flatMap(decodeOpeningCash))
-          const { accountingHash, comparison } = yield* attempt('reconcile', () => {
-            if (transactions.some((transaction) => transaction.occurredAt < openingCash.observed_at)) {
-              throw new Error('paper accounting predates the opening cash snapshot')
-            }
-            const expectedCashMicros = transactions
-              .reduce(
-                (cash, transaction) => cash + BigInt(transaction.cashDeltaMicros),
-                BigInt(openingCash.cash_micros),
-              )
-              .toString()
-            const accountingHash = canonicalHashV1({
-              schemaVersion: 'bayn.paper-accounting-state.v1',
-              accountId,
-              openingCash,
-              transactions,
-              receipts,
-              ledgerExact,
-            })
-            const stateHash = reconciledStateHash({
-              account: snapshot.account,
-              positions: snapshot.positions,
-              positionsObservedAt: snapshot.positionsObservedAt,
-              orders: snapshot.orders,
-              ordersObservedAt: snapshot.ordersObservedAt,
-              accountingHash,
-            })
-            return {
-              accountingHash,
-              comparison: compareReconciliation({
-                accountId,
-                stateHash,
-                account: snapshot.account,
-                positions: snapshot.positions,
-                orders: snapshot.orders,
-                fills: snapshot.fills,
-                intents,
-                durableFills,
-                projectedPositions,
-                expectedCashMicros,
-                valuation: snapshot.valuation,
-                accountingHash,
-                ledgerExact,
-                reconciledAt: snapshot.reconciledAt,
-              }),
-            }
-          })
+        return yield* fromDecision(
+          'reconcile',
+          compareOpeningCash({
+            accountId,
+            openingCash,
+            transactions: accounting.transactions,
+            receipts: accounting.receipts,
+            ledgerExact: accounting.ledgerExact,
+            snapshot,
+            intents: accounting.intents,
+            durableFills,
+            projectedPositions,
+          }),
+        )
+      }),
+    )
 
-          const [previous] = yield* sql<Record<string, unknown>>`
+  const writeReconciliationPhase = (
+    accountId: string,
+    comparison: ReconciliationComparison,
+    reconciledAt: string,
+  ): Effect.Effect<Reconciliation, ReconciliationStoreError> =>
+    runStore(
+      'reconcile',
+      Effect.gen(function* () {
+        const [previous] = yield* sql<Record<string, unknown>>`
           SELECT discrepancies
           FROM reconciliations
           WHERE account_id = ${accountId}
-          ORDER BY reconciled_at DESC, reconciliation_id DESC
+          ORDER BY reconciled_at DESC, reconciliation_id COLLATE "C" DESC
           LIMIT 1
         `.pipe(Effect.flatMap(decodePreviousReconciliation))
-          const { contentHash, discrepancies, reconciliationId, reconciliationMaterial, status } = yield* attempt(
-            'reconcile',
-            () => {
-              const prior = new Map((previous?.discrepancies ?? []).map((value) => [value.discrepancyId, value]))
-              const status =
-                comparison.discrepancies.length === 0 ? ReconciliationStatus.Exact : ReconciliationStatus.Discrepancy
-              const discrepancies: Discrepancy[] = comparison.discrepancies.map((value) => ({
-                ...value,
-                firstObservedAt: prior.get(value.discrepancyId)?.firstObservedAt ?? snapshot.reconciledAt,
-                lastObservedAt: snapshot.reconciledAt,
-              }))
-              const reconciliationMaterial = {
-                schemaVersion: 'bayn.paper-reconciliation.v1' as const,
-                accountId,
-                expectedHash: comparison.expectedHash,
-                observedHash: comparison.observedHash,
-                status,
-                discrepancies,
-                reconciledAt: snapshot.reconciledAt,
-              }
-              const reconciliationId = canonicalHashV1({
-                schemaVersion: 'bayn.paper-reconciliation-id.v1',
-                material: reconciliationMaterial,
-              })
-              const contentHash = canonicalHashV1({ ...reconciliationMaterial, reconciliationId })
-              return { contentHash, discrepancies, reconciliationId, reconciliationMaterial, status }
-            },
-          )
-          const reconciliation = yield* decodeReconciliation({
-            schemaVersion: reconciliationMaterial.schemaVersion,
-            reconciliationId,
+        const reconciliation = yield* fromDecision(
+          'reconcile',
+          decideReconciliation({
             accountId,
-            expectedHash: comparison.expectedHash,
-            observedHash: comparison.observedHash,
-            contentHash,
-            status,
-            discrepancies,
-            reconciledAt: snapshot.reconciledAt,
-          })
-          const encodedDiscrepancies = yield* attempt('reconcile', () =>
-            encodeDiscrepancies(reconciliation.discrepancies),
-          )
-          yield* sql`
+            comparison,
+            previous: previous?.discrepancies ?? [],
+            reconciledAt,
+          }),
+        )
+        const encodedDiscrepancies = yield* attempt('reconcile', () =>
+          encodeDiscrepancies(reconciliation.discrepancies),
+        )
+        yield* sql`
           INSERT INTO reconciliations (
             reconciliation_id, schema_version, account_id, expected_hash, observed_hash,
             content_hash, status, discrepancies, reconciled_at
@@ -624,23 +456,30 @@ export const makeReconciliation = (
             ${reconciliation.reconciledAt}
           )
           ON CONFLICT (reconciliation_id) DO NOTHING
-        `
-          const [stored] = yield* sql<Record<string, unknown>>`
-          SELECT content_hash FROM reconciliations WHERE reconciliation_id = ${reconciliationId}
+          `
+        const [stored] = yield* sql<Record<string, unknown>>`
+          SELECT content_hash FROM reconciliations WHERE reconciliation_id = ${reconciliation.reconciliationId}
         `.pipe(Effect.flatMap(decodeContent))
-          if (stored.content_hash !== contentHash) {
-            return yield* Effect.fail(
-              storeError('reconcile', 'invariant', 'stored reconciliation differs from deterministic replay'),
-            )
-          }
+        yield* fromDecision('reconcile', validateReconciliationReadback(reconciliation, stored.content_hash))
 
-          if (comparison.discrepancies.length > 0) {
-            yield* restrictAuthority(sql, `reconciliation discrepancy ${reconciliationId}`, snapshot.reconciledAt)
-          }
+        if (reconciliation.discrepancies.length > 0) {
+          yield* restrictAuthority(sql, `reconciliation discrepancy ${reconciliation.reconciliationId}`, reconciledAt)
+        }
+        return reconciliation
+      }),
+    )
 
-          const [riskContextRow] = yield* sql<Record<string, unknown>>`
+  const readRiskContextPhase = (
+    accountId: string,
+    reconciledAt: string,
+    unknownMutationCount: number,
+  ): Effect.Effect<ReconciliationRiskContext, ReconciliationStoreError> =>
+    runStore(
+      'reconcile',
+      Effect.gen(function* () {
+        const [riskContextRow] = yield* sql<Record<string, unknown>>`
           WITH boundary AS (
-            SELECT (${snapshot.reconciledAt}::timestamptz AT TIME ZONE 'America/New_York')::date AS trading_date
+            SELECT (${reconciledAt}::timestamptz AT TIME ZONE 'America/New_York')::date AS trading_date
           )
           SELECT
             boundary.trading_date::text AS trading_date,
@@ -657,33 +496,53 @@ export const makeReconciliation = (
               SELECT sum(transaction.notional_micros)::text
               FROM accounting_transactions AS transaction
               WHERE transaction.account_id = ${accountId}
-                AND transaction.occurred_at <= ${snapshot.reconciledAt}
+                AND transaction.occurred_at <= ${reconciledAt}
                 AND (transaction.occurred_at AT TIME ZONE 'America/New_York')::date = boundary.trading_date
             ), '0') AS daily_traded_notional_micros,
             (
               SELECT valuation.equity_micros::text
               FROM valuations AS valuation
               WHERE valuation.account_id = ${accountId}
-                AND valuation.as_of <= ${snapshot.reconciledAt}
+                AND valuation.as_of <= ${reconciledAt}
                 AND (valuation.as_of AT TIME ZONE 'America/New_York')::date = boundary.trading_date
-              ORDER BY valuation.as_of, valuation.valuation_id
+              ORDER BY valuation.as_of, valuation.valuation_id COLLATE "C"
               LIMIT 1
             ) AS day_start_equity_micros,
             (
               SELECT max(valuation.equity_micros)::text
               FROM valuations AS valuation
               WHERE valuation.account_id = ${accountId}
-                AND valuation.as_of <= ${snapshot.reconciledAt}
+                AND valuation.as_of <= ${reconciledAt}
             ) AS peak_equity_micros
           FROM boundary
           LEFT JOIN authority_state AS authority ON authority.singleton
         `.pipe(Effect.flatMap(decodeRiskContext))
-          const riskContext = yield* riskContextFromRow(riskContextRow, unknownMutationCount)
-
-          return { reconciliation, metrics: comparison.metrics, accountingHash, riskContext }
-        }),
-      ),
+        return yield* fromDecision('risk-context', riskContextFromRow(riskContextRow, unknownMutationCount))
+      }),
     )
+
+  const reconcileTransaction = (
+    snapshot: BrokerSnapshot,
+  ): Effect.Effect<ReconciliationWriteResult, ReconciliationStoreError> =>
+    runStore(
+      'reconcile',
+      Effect.gen(function* () {
+        const accountId = snapshot.account.accountId
+        yield* sql`SELECT pg_advisory_xact_lock(hashtextextended(${`ALPACA:${accountId}`}, 0))`
+        const accounting = yield* readAccountingPhase(accountId)
+        const { accountingHash, comparison } = yield* readComparisonPhase(accountId, snapshot, accounting)
+        const reconciliation = yield* writeReconciliationPhase(accountId, comparison, snapshot.reconciledAt)
+        const riskContext = yield* readRiskContextPhase(
+          accountId,
+          snapshot.reconciledAt,
+          accounting.unknownMutationCount,
+        )
+        return { reconciliation, metrics: comparison.metrics, accountingHash, riskContext }
+      }),
+    )
+
+  const reconcile = (snapshot: BrokerSnapshot): Effect.Effect<ReconciliationWriteResult, ReconciliationStoreError> =>
+    runStore('reconcile', sql.withTransaction(reconcileTransaction(snapshot)))
 
   return { bindings, reconcile }
 }


### PR DESCRIPTION
## Summary

- Extract pure, total `Result` decisions for intent projection, canonical receipt and ledger verification, opening-cash comparison, discrepancy aging, reconciliation identity/readback, and risk-context validation; map closed failures once into the existing `ReconciliationStoreError` boundary.
- Run PostgreSQL reads, TigerBeetle verification, deterministic reconciliation insertion/readback, downward authority restriction, and risk-context readback as bounded named phases inside exactly one transaction while preserving the advisory lock and query order.
- Fail closed on duplicate accounting receipts for one `brokerEventId` before receipt projection or ledger planning, with synchronous regression coverage and PostgreSQL assertions for latest immutable evidence and no authority restoration.
- Scope is limited to reconciliation production code, its pure algebra/tests, and the existing PostgreSQL integration fixture. There are no PaperStore production, GitOps, qualification, migration, broker-client, or capital-authority changes.

## Related Issues

None

## Testing

- `bun test services/bayn/src/db/reconciliation-algebra.test.ts services/bayn/src/reconciliation.test.ts` — 18 passed.
- `bun run --filter @proompteng/bayn test` — 577 passed, 113 skipped, 0 failed.
- PostgreSQL 18.4: `evidence-store.integration.test.ts` — 60 passed; `paper-store.integration.test.ts` — 27 passed; `cycle-store.integration.test.ts` — 13 passed; focused immutable-history/no-authority-restoration regression — 1 passed.
- `bun test packages/scripts/src/bayn` — 20 passed.
- `bun run --filter @proompteng/bayn tsc`
- `bun run --cwd services/bayn lint:effect`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn build`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (screenshots section removed; no visual change).
- [x] Documentation, release notes, and follow-ups are updated or tracked (no documentation or release-note change is required for this internal refactor).