### PR TITLE
refactor(bayn): make reconciliation orchestration functional

### DIFF
--- a/services/bayn/src/reconciler.test.ts
+++ b/services/bayn/src/reconciler.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 
-import { Deferred, Effect, Fiber } from 'effect'
+import { Cause, Deferred, Effect, Exit, Fiber } from 'effect'
 import { TestClock } from 'effect/testing'
 
 import {
@@ -24,10 +24,10 @@ import {
 import { unusedAssetBySymbol, unusedMarketCalendar } from './broker/alpaca-test-support'
 import { canonicalHashV1 } from './hash'
 import { ReconciliationStatus, type AccountingReceipt, type Valuation } from './paper'
-import { PaperStore, type PaperStoreShape } from './db/paper-store'
+import { PaperStore, PaperStoreError, type PaperStoreShape } from './db/paper-store'
 import type { BrokerSnapshot, ReconciliationWriteResult } from './db/reconciliation'
 import { WriterFence, type WriterFenceService } from './execution/writer-fence'
-import { ReconciliationError, runContinuously, runOnce } from './reconciler'
+import { ReconciliationError, runOnce } from './reconciler'
 import { reconciledStateHash } from './reconciliation'
 
 const accountId = '61e69015-8549-4bfd-b9c3-01e75843f47d'
@@ -223,11 +223,11 @@ const fence: WriterFenceService = {
   transaction: (effect) => effect,
 }
 
-const provide = (read: BrokerReadShape, store: PaperStoreShape) =>
+const provide = (read: BrokerReadShape, store: PaperStoreShape, writerFence = fence) =>
   runOnce.pipe(
     Effect.provideService(BrokerRead, read),
     Effect.provideService(PaperStore, store),
-    Effect.provideService(WriterFence, fence),
+    Effect.provideService(WriterFence, writerFence),
   )
 
 describe('paper reconciliation loop', () => {
@@ -284,6 +284,66 @@ describe('paper reconciliation loop', () => {
     expect(control.restrictions).toEqual([])
   })
 
+  test('preserves causal broker read order and clock cutoffs', async () => {
+    let accountReads = 0
+    let positionReads = 0
+    let orderReads = 0
+    let fillReads = 0
+    const orderCutoffs: Array<string | undefined> = []
+    const fillCutoffs: Array<string | undefined> = []
+    const read: BrokerReadShape = {
+      ...emptyRead(),
+      account: Effect.gen(function* () {
+        expect(orderReads).toBe(1)
+        expect(fillReads).toBe(1)
+        accountReads += 1
+        yield* TestClock.adjust(100)
+        return { value: account, evidence: evidence('account') }
+      }),
+      positions: Effect.sync(() => {
+        expect(orderReads).toBe(1)
+        expect(fillReads).toBe(1)
+        positionReads += 1
+        return { value: [], evidence: evidence('positions') }
+      }),
+      orders: (query = {}) =>
+        Effect.sync(() => {
+          orderReads += 1
+          orderCutoffs.push(query.until)
+          if (orderReads === 1) {
+            expect(accountReads).toBe(0)
+            expect(positionReads).toBe(0)
+          } else {
+            expect(accountReads).toBe(1)
+            expect(positionReads).toBe(1)
+          }
+          return { value: [], evidence: evidence(`orders-${orderReads}`) }
+        }),
+      fillActivities: (query = {}) =>
+        Effect.sync(() => {
+          fillReads += 1
+          fillCutoffs.push(query.until)
+          if (fillReads === 1) {
+            expect(accountReads).toBe(0)
+            expect(positionReads).toBe(0)
+          } else {
+            expect(accountReads).toBe(1)
+            expect(positionReads).toBe(1)
+          }
+          return { value: { items: [] }, evidence: evidence(`fills-${fillReads}`) }
+        }),
+    }
+    const control: StoreControl = { writes: 0, reconciliations: [], restrictions: [] }
+
+    const result = await Effect.runPromise(provide(read, makeStore(control)).pipe(Effect.provide(TestClock.layer())))
+
+    expect(orderCutoffs).toEqual(['1970-01-01T00:00:00.000Z', '1970-01-01T00:00:00.100Z'])
+    expect(fillCutoffs).toEqual(orderCutoffs)
+    expect(control.reconciliations).toHaveLength(1)
+    expect(control.reconciliations[0].reconciledAt).toBe('1970-01-01T00:00:00.100Z')
+    expect(result.report.reconciliation.reconciledAt).toBe('1970-01-01T00:00:00.100Z')
+  })
+
   test('rejects historical fills on an uninitialized account before ingesting broker state', async () => {
     const existingOrder = order(0)
     const existingFill = fill(0, existingOrder)
@@ -296,10 +356,15 @@ describe('paper reconciliation loop', () => {
 
     const failure = await Effect.runPromise(provide(read, makeStore(control, false)).pipe(Effect.flip))
 
+    expect(failure).toBeInstanceOf(ReconciliationError)
     expect(failure).toMatchObject({
       _tag: 'ReconciliationError',
       operation: 'snapshot',
       message: 'paper account has fill history before Bayn established an opening cash baseline',
+      failure: {
+        _tag: 'Snapshot',
+        reason: 'AccountBaselineMissing',
+      },
     })
     expect(control.writes).toBe(0)
     expect(control.reconciliations).toEqual([])
@@ -320,6 +385,113 @@ describe('paper reconciliation loop', () => {
       _tag: 'ReconciliationError',
       operation: 'pagination',
       message: `Alpaca order ${pendingOrder.brokerOrderId} is missing submitted_at`,
+      failure: {
+        _tag: 'Pagination',
+        reason: 'OrderSubmittedAtMissing',
+      },
+    })
+    expect(control.writes).toBe(0)
+    expect(control.reconciliations).toEqual([])
+    expect(control.restrictions).toEqual(['reconciliation pass incomplete'])
+  })
+
+  test('retains the exact Error cause of a normalization failure', async () => {
+    const normalizationCause = new Error('injected normalization failure')
+    let extendedHoursReads = 0
+    const malformedOrder = new Proxy(order(0), {
+      get: (target, property, receiver) => {
+        if (property === 'extendedHours') {
+          extendedHoursReads += 1
+          if (extendedHoursReads === 3) throw normalizationCause
+        }
+        return Reflect.get(target, property, receiver)
+      },
+    })
+    const read: BrokerReadShape = {
+      ...emptyRead(),
+      orders: () => Effect.succeed({ value: [malformedOrder], evidence: evidence('orders') }),
+    }
+    const control: StoreControl = { writes: 0, reconciliations: [], restrictions: [] }
+
+    const failure = await Effect.runPromise(provide(read, makeStore(control)).pipe(Effect.flip))
+
+    expect(failure).toBeInstanceOf(ReconciliationError)
+    if (!(failure instanceof ReconciliationError) || failure.failure?._tag !== 'Normalization') {
+      throw new Error('expected a reconciliation normalization failure')
+    }
+    expect(failure).toMatchObject({
+      _tag: 'ReconciliationError',
+      operation: 'normalization',
+      message: 'broker snapshot normalization failed',
+      failure: {
+        _tag: 'Normalization',
+        stage: 'order',
+        identity: malformedOrder.brokerOrderId,
+      },
+    })
+    expect(failure.cause).toBe(normalizationCause)
+    expect(failure.failure.cause).toBe(normalizationCause)
+    expect(extendedHoursReads).toBe(3)
+    expect(control.writes).toBe(0)
+    expect(control.reconciliations).toEqual([])
+    expect(control.restrictions).toEqual(['reconciliation pass incomplete'])
+  })
+
+  test('propagates a non-Error normalization throw as a defect after restricting authority', async () => {
+    const defect = { _tag: 'InjectedNormalizationDefect' }
+    let extendedHoursReads = 0
+    const throwingOrder = new Proxy(order(0), {
+      get: (target, property, receiver) => {
+        if (property === 'extendedHours') {
+          extendedHoursReads += 1
+          if (extendedHoursReads === 3) throw defect
+        }
+        return Reflect.get(target, property, receiver)
+      },
+    })
+    const read: BrokerReadShape = {
+      ...emptyRead(),
+      orders: () => Effect.succeed({ value: [throwingOrder], evidence: evidence('orders') }),
+    }
+    const control: StoreControl = { writes: 0, reconciliations: [], restrictions: [] }
+
+    const exit = await Effect.runPromiseExit(provide(read, makeStore(control)))
+
+    expect(Exit.isFailure(exit)).toBe(true)
+    if (Exit.isFailure(exit)) {
+      const defects = exit.cause.reasons.flatMap((reason) => (Cause.isDieReason(reason) ? [reason.defect] : []))
+      expect(defects).toContain(defect)
+    }
+    expect(extendedHoursReads).toBe(3)
+    expect(control.writes).toBe(0)
+    expect(control.reconciliations).toEqual([])
+    expect(control.restrictions).toEqual(['reconciliation pass incomplete'])
+  })
+
+  test('returns a closed duplicate-client validation reason', async () => {
+    const first = order(0)
+    const duplicateClient = { ...order(1), clientOrderId: first.clientOrderId }
+    const read: BrokerReadShape = {
+      ...emptyRead(),
+      orders: () => Effect.succeed({ value: [first, duplicateClient], evidence: evidence('orders') }),
+    }
+    const control: StoreControl = { writes: 0, reconciliations: [], restrictions: [] }
+
+    const failure = await Effect.runPromise(provide(read, makeStore(control)).pipe(Effect.flip))
+
+    expect(failure).toBeInstanceOf(ReconciliationError)
+    if (!(failure instanceof ReconciliationError) || failure.failure?._tag !== 'Validation') {
+      throw new Error('expected a reconciliation validation failure')
+    }
+    expect(failure).toMatchObject({
+      _tag: 'ReconciliationError',
+      operation: 'normalization',
+      message: 'broker snapshot normalization failed',
+      failure: {
+        _tag: 'Validation',
+        reason: 'DuplicateBrokerClientOrderId',
+        detail: `duplicate broker client order ID ${first.clientOrderId}`,
+      },
     })
     expect(control.writes).toBe(0)
     expect(control.reconciliations).toEqual([])
@@ -369,6 +541,12 @@ describe('paper reconciliation loop', () => {
 
     const failure = await Effect.runPromise(provide(read, makeStore(control)).pipe(Effect.flip))
     expect(failure).toBeInstanceOf(ReconciliationError)
+    expect(failure).toMatchObject({
+      failure: {
+        _tag: 'Pagination',
+        reason: 'DuplicateFill',
+      },
+    })
     expect(control.writes).toBe(0)
     expect(control.reconciliations).toEqual([])
     expect(control.restrictions).toEqual(['reconciliation pass incomplete'])
@@ -404,6 +582,10 @@ describe('paper reconciliation loop', () => {
       _tag: 'ReconciliationError',
       operation: 'snapshot',
       message: 'broker history changed during reconciliation',
+      failure: {
+        _tag: 'Snapshot',
+        reason: 'HistoryChanged',
+      },
     })
     expect(orderReads).toBe(2)
     expect(fillReads).toBe(2)
@@ -433,72 +615,151 @@ describe('paper reconciliation loop', () => {
       _tag: 'ReconciliationError',
       operation: 'pagination',
       message: 'Alpaca fill history exceeds 10000 rows',
+      failure: {
+        _tag: 'Pagination',
+        reason: 'FillHistoryTooLarge',
+      },
     })
     expect(offset).toBe(10_001)
     expect(control.writes).toBe(0)
     expect(control.restrictions).toEqual(['reconciliation pass incomplete'])
   })
 
-  test('runs immediately and repeats on the Effect schedule', async () => {
+  test('keeps persistence and containment in distinct writer-fence transactions', async () => {
     const control: StoreControl = { writes: 0, reconciliations: [], restrictions: [] }
-    const program = Effect.scoped(
-      Effect.gen(function* () {
-        const fiber = yield* runContinuously(100).pipe(
-          Effect.provideService(BrokerRead, emptyRead()),
-          Effect.provideService(PaperStore, makeStore(control)),
-          Effect.provideService(WriterFence, fence),
-          Effect.forkScoped({ startImmediately: true }),
-        )
-        yield* Effect.yieldNow
-        expect(control.reconciliations).toHaveLength(1)
-        yield* TestClock.adjust(99)
-        expect(control.reconciliations).toHaveLength(1)
-        yield* TestClock.adjust(1)
-        expect(control.reconciliations).toHaveLength(2)
-        yield* Fiber.interrupt(fiber)
-      }),
-    ).pipe(Effect.provide(TestClock.layer()))
+    const transactionEvents: string[] = []
+    let transactionDepth = 0
+    const writerFence: WriterFenceService = {
+      backendPid: 2,
+      check: Effect.void,
+      transaction: (effect) =>
+        Effect.sync(() => {
+          transactionDepth += 1
+          transactionEvents.push('begin')
+        }).pipe(
+          Effect.andThen(effect),
+          Effect.ensuring(
+            Effect.sync(() => {
+              transactionEvents.push('end')
+              transactionDepth -= 1
+            }),
+          ),
+        ),
+    }
+    const insideTransaction = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+      Effect.sync(() => {
+        expect(transactionDepth).toBe(1)
+      }).pipe(Effect.andThen(effect))
+    const baseStore = makeStore(control)
+    const persistenceFailure = new PaperStoreError({
+      operation: 'reconciliation',
+      failure: 'query',
+      message: 'injected reconciliation write failure',
+    })
+    const store: PaperStoreShape = {
+      ...baseStore,
+      ingest: (input) => insideTransaction(baseStore.ingest(input)),
+      ingestPositions: (input) => insideTransaction(baseStore.ingestPositions(input)),
+      account: (input) => insideTransaction(baseStore.account(input)),
+      value: (input) => insideTransaction(baseStore.value(input)),
+      hasAccountBaseline: (id) => insideTransaction(baseStore.hasAccountBaseline(id)),
+      bindings: (id) => insideTransaction(baseStore.bindings(id)),
+      reconcile: () => insideTransaction(Effect.fail(persistenceFailure)),
+      restrictAuthority: (reason, updatedAt) => insideTransaction(baseStore.restrictAuthority(reason, updatedAt)),
+    }
 
-    await Effect.runPromise(program)
+    const exit = await Effect.runPromiseExit(provide(emptyRead(), store, writerFence))
+
+    expect(Exit.isFailure(exit)).toBe(true)
+    if (Exit.isFailure(exit)) {
+      const failures = exit.cause.reasons.flatMap((reason) => (Cause.isFailReason(reason) ? [reason.error] : []))
+      expect(failures).toEqual([persistenceFailure])
+    }
+    expect(transactionEvents).toEqual(['begin', 'end', 'begin', 'end'])
+    expect(transactionDepth).toBe(0)
+    expect(control.restrictions).toEqual(['reconciliation pass incomplete'])
   })
 
-  test('restricts authority after a failed pass and retries on the same scoped loop', async () => {
-    const control: StoreControl = { writes: 0, reconciliations: [], restrictions: [] }
-    let attempts = 0
+  test('retains both causes when authority restriction fails', async () => {
+    const primaryFailure = new BrokerReadError({
+      operation: 'account',
+      kind: BrokerReadErrorKind.Transport,
+      message: 'injected primary read failure',
+      retryable: true,
+    })
+    const containmentFailure = new PaperStoreError({
+      operation: 'authority',
+      failure: 'query',
+      message: 'injected authority restriction failure',
+    })
     const read: BrokerReadShape = {
       ...emptyRead(),
-      account: Effect.suspend(() => {
-        attempts += 1
-        return attempts === 1
-          ? Effect.fail(
-              new BrokerReadError({
-                operation: 'account',
-                kind: BrokerReadErrorKind.Transport,
-                message: 'injected read failure',
-                retryable: true,
-              }),
-            )
-          : Effect.succeed({ value: account, evidence: evidence('account') })
-      }),
+      account: Effect.fail(primaryFailure),
     }
-    const program = Effect.scoped(
-      Effect.gen(function* () {
-        const fiber = yield* runContinuously(100).pipe(
-          Effect.provideService(BrokerRead, read),
-          Effect.provideService(PaperStore, makeStore(control)),
-          Effect.provideService(WriterFence, fence),
-          Effect.forkScoped({ startImmediately: true }),
-        )
-        yield* Effect.yieldNow
-        expect(control.restrictions).toEqual(['reconciliation pass incomplete'])
-        expect(control.reconciliations).toEqual([])
-        yield* TestClock.adjust(100)
-        expect(control.reconciliations).toHaveLength(1)
-        yield* Fiber.interrupt(fiber)
-      }),
-    ).pipe(Effect.provide(TestClock.layer()))
+    const control: StoreControl = { writes: 0, reconciliations: [], restrictions: [] }
+    let restrictionAttempts = 0
+    const store: PaperStoreShape = {
+      ...makeStore(control),
+      restrictAuthority: () =>
+        Effect.sync(() => {
+          restrictionAttempts += 1
+        }).pipe(Effect.andThen(Effect.fail(containmentFailure))),
+    }
+    let transactions = 0
+    const writerFence: WriterFenceService = {
+      backendPid: 4,
+      check: Effect.void,
+      transaction: (effect) =>
+        Effect.sync(() => {
+          transactions += 1
+        }).pipe(Effect.andThen(effect)),
+    }
 
-    await Effect.runPromise(program)
+    const exit = await Effect.runPromiseExit(provide(read, store, writerFence))
+
+    expect(Exit.isFailure(exit)).toBe(true)
+    if (Exit.isFailure(exit)) {
+      const failures = exit.cause.reasons.flatMap((reason) => (Cause.isFailReason(reason) ? [reason.error] : []))
+      const containmentErrors = failures.filter(
+        (failure): failure is ReconciliationError =>
+          failure instanceof ReconciliationError && failure.failure?._tag === 'AuthorityRestrictionFailed',
+      )
+      expect(containmentErrors).toHaveLength(1)
+      const containmentError = containmentErrors[0]
+      if (containmentError?.failure?._tag !== 'AuthorityRestrictionFailed') {
+        throw new Error('expected an authority restriction failure')
+      }
+      const reconciliationFailures = containmentError.failure.reconciliationCause.reasons.flatMap((reason) =>
+        Cause.isFailReason(reason) ? [reason.error] : [],
+      )
+      const restrictionFailures = containmentError.failure.restrictionCause.reasons.flatMap((reason) =>
+        Cause.isFailReason(reason) ? [reason.error] : [],
+      )
+      expect(reconciliationFailures).toContain(primaryFailure)
+      expect(restrictionFailures).toContain(containmentFailure)
+    }
+    expect(restrictionAttempts).toBe(1)
+    expect(transactions).toBe(1)
+    expect(control.reconciliations).toEqual([])
+  })
+
+  test('propagates a defect after successful authority restriction', async () => {
+    const defect = new Error('unexpected reconciliation defect')
+    const read: BrokerReadShape = {
+      ...emptyRead(),
+      account: Effect.die(defect),
+    }
+    const control: StoreControl = { writes: 0, reconciliations: [], restrictions: [] }
+
+    const exit = await Effect.runPromiseExit(provide(read, makeStore(control)))
+
+    expect(Exit.isFailure(exit)).toBe(true)
+    if (Exit.isFailure(exit)) {
+      const defects = exit.cause.reasons.flatMap((reason) => (Cause.isDieReason(reason) ? [reason.defect] : []))
+      expect(defects).toContain(defect)
+    }
+    expect(control.restrictions).toEqual(['reconciliation pass incomplete'])
+    expect(control.reconciliations).toEqual([])
   })
 
   test('interrupts an in-flight read on shutdown without treating shutdown as a failed pass', async () => {

--- a/services/bayn/src/reconciler.ts
+++ b/services/bayn/src/reconciler.ts
@@ -1,14 +1,17 @@
-import { Cause, Clock, Data, Duration, Effect, Schedule } from 'effect'
+import { Cause, Chunk, Clock, Data, Effect, Exit, HashMap, HashSet, Option, Result } from 'effect'
 
 import {
   BrokerRead,
   OrderCollection,
   SortDirection,
+  type Account as BrokerAccount,
   type BrokerReadError,
   type BrokerReadShape,
   type FillActivity,
   type Order as BrokerOrder,
+  type Position as BrokerPosition,
   type ReadEvidence,
+  type ReadResult,
 } from './broker/alpaca'
 import {
   accountObservation,
@@ -18,9 +21,15 @@ import {
   sourceTimestamp,
   type BrokerEventInput,
   type FillEventInput,
+  type PositionSnapshotInput,
 } from './broker/observations'
 import { PaperStore, type PaperStoreError, type PaperStoreShape } from './db/paper-store'
-import type { BrokerSnapshot, ReconciliationReport } from './db/reconciliation'
+import {
+  type BrokerSnapshot,
+  type IntentBinding,
+  type ReconciliationReport,
+  type ReconciliationWriteResult,
+} from './db/reconciliation'
 import { WriterFence, type WriterFenceError, type WriterFenceService } from './execution/writer-fence'
 import { canonicalHashV1 } from './hash'
 import type { ReconciledBrokerState, ReconciliationRiskContext } from './reconciliation'
@@ -28,6 +37,8 @@ import type { ReconciledBrokerState, ReconciliationRiskContext } from './reconci
 const maximumRows = 10_000
 const ordersPageSize = 500
 const fillsPageSize = 100
+const incompletePassReason = 'reconciliation pass incomplete'
+const normalizationMessage = 'broker snapshot normalization failed'
 
 interface Observed<A> {
   readonly value: A
@@ -44,135 +55,370 @@ interface BrokerHistory {
   readonly fills: readonly Observed<FillActivity>[]
 }
 
+interface StableBrokerSnapshot {
+  readonly account: ReadResult<BrokerAccount>
+  readonly positions: ReadResult<readonly BrokerPosition[]>
+  readonly history: BrokerHistory
+}
+
+type AccountEventInput = Extract<BrokerEventInput, { readonly _tag: 'Account' }>
+type OrderEventInput = Extract<BrokerEventInput, { readonly _tag: 'Order' }>
+
+interface NormalizedBrokerSnapshot {
+  readonly account: AccountEventInput
+  readonly positions: PositionSnapshotInput
+  readonly orderEvents: readonly OrderEventInput[]
+  readonly fillEvents: readonly FillEventInput[]
+}
+
+interface ReconciliationDecision {
+  readonly snapshot: BrokerSnapshot
+  readonly unknownOrderCount: number
+  readonly orderCount: number
+  readonly fillCount: number
+}
+
 export interface ReconciliationPassResult {
   readonly report: ReconciliationReport
   readonly brokerState: ReconciledBrokerState
   readonly riskContext: ReconciliationRiskContext
 }
 
-export type ReconciliationPassError = BrokerReadError | PaperStoreError | ReconciliationError | WriterFenceError
+type PaginationFailureReason =
+  | 'OrderPageTooLarge'
+  | 'OrderSubmittedAtMissing'
+  | 'OrderHistoryNotAscending'
+  | 'OrderTimestampCursorDidNotAdvance'
+  | 'DuplicateOrder'
+  | 'OrderHistoryTooLarge'
+  | 'OrderCursorDidNotAdvance'
+  | 'FillPageTooLarge'
+  | 'DuplicateFill'
+  | 'FillHistoryTooLarge'
+  | 'FillCursorDidNotAdvance'
+
+type SnapshotFailureReason = 'HistoryChanged' | 'AccountBaselineMissing'
+
+type ValidationFailureReason =
+  | 'DuplicateIntentClientOrderId'
+  | 'DuplicateBrokerClientOrderId'
+  | 'UnexpectedOrderEvent'
+  | 'FillOrderMissing'
+  | 'UnexpectedAccountEvent'
+
+type NormalizationStage = 'order' | 'fill-ordering' | 'fill' | 'account' | 'positions'
+
+type NormalizationDecisionFailure =
+  | ReconciliationError
+  | { readonly _tag: 'Defect'; readonly cause: Cause.Cause<never> }
+
+type ReconciliationFailure =
+  | { readonly _tag: 'Pagination'; readonly reason: PaginationFailureReason }
+  | { readonly _tag: 'Snapshot'; readonly reason: SnapshotFailureReason }
+  | { readonly _tag: 'Validation'; readonly reason: ValidationFailureReason; readonly detail: string }
+  | {
+      readonly _tag: 'Normalization'
+      readonly stage: NormalizationStage
+      readonly identity?: string
+      readonly cause: Error
+    }
+  | {
+      readonly _tag: 'AuthorityRestrictionFailed'
+      readonly reconciliationCause: Cause.Cause<
+        BrokerReadError | PaperStoreError | ReconciliationError | WriterFenceError
+      >
+      readonly restrictionCause: Cause.Cause<PaperStoreError | WriterFenceError>
+    }
 
 export class ReconciliationError extends Data.TaggedError('ReconciliationError')<{
-  readonly operation: 'pagination' | 'normalization' | 'snapshot'
+  readonly operation: 'containment' | 'normalization' | 'pagination' | 'snapshot'
   readonly message: string
+  readonly failure?: ReconciliationFailure
   readonly cause?: unknown
 }> {}
 
-const failure = (operation: ReconciliationError['operation'], message: string, cause?: unknown): ReconciliationError =>
-  new ReconciliationError({ operation, message, cause })
+export type ReconciliationPassError = BrokerReadError | PaperStoreError | ReconciliationError | WriterFenceError
 
-const attempt = <A>(operation: ReconciliationError['operation'], message: string, evaluate: () => A) =>
-  Effect.try({ try: evaluate, catch: (cause) => failure(operation, message, cause) })
+const paginationFailure = (reason: PaginationFailureReason, message: string): ReconciliationError =>
+  new ReconciliationError({
+    operation: 'pagination',
+    message,
+    failure: { _tag: 'Pagination', reason },
+  })
+
+const snapshotFailure = (reason: SnapshotFailureReason, message: string): ReconciliationError =>
+  new ReconciliationError({
+    operation: 'snapshot',
+    message,
+    failure: { _tag: 'Snapshot', reason },
+  })
+
+const validationFailure = (reason: ValidationFailureReason, detail: string): ReconciliationError =>
+  new ReconciliationError({
+    operation: 'normalization',
+    message: normalizationMessage,
+    failure: { _tag: 'Validation', reason, detail },
+  })
+
+const decideNormalizationFailure = (
+  stage: NormalizationStage,
+  identity: string | undefined,
+  cause: unknown,
+): NormalizationDecisionFailure => {
+  if (!(cause instanceof Error)) return { _tag: 'Defect', cause: Cause.die(cause) }
+  return new ReconciliationError({
+    operation: 'normalization',
+    message: normalizationMessage,
+    cause,
+    failure: {
+      _tag: 'Normalization',
+      stage,
+      ...(identity === undefined ? {} : { identity }),
+      cause,
+    },
+  })
+}
+
+const normalizationAttempt = <A>(
+  stage: NormalizationStage,
+  identity: string | undefined,
+  evaluate: () => A,
+): Result.Result<A, NormalizationDecisionFailure> =>
+  Result.try({
+    try: evaluate,
+    catch: (cause) => decideNormalizationFailure(stage, identity, cause),
+  })
 
 const compareText = (left: string, right: string): number => (left < right ? -1 : left > right ? 1 : 0)
 
-const readOrders = (
+interface OrderPaginationState {
+  readonly rows: readonly Observed<BrokerOrder>[]
+  readonly ids: HashSet.HashSet<string>
+  readonly cursor: string | undefined
+  readonly previousSubmittedAt: string | undefined
+  readonly observedAt: string | undefined
+}
+
+interface FillPaginationState {
+  readonly rows: readonly Observed<FillActivity>[]
+  readonly ids: HashSet.HashSet<string>
+  readonly cursor: string | undefined
+}
+
+type OrderPageDecision =
+  | { readonly _tag: 'Continue'; readonly state: OrderPaginationState }
+  | { readonly _tag: 'Complete'; readonly read: OrderRead }
+
+type FillPageDecision =
+  | { readonly _tag: 'Continue'; readonly state: FillPaginationState }
+  | { readonly _tag: 'Complete'; readonly rows: readonly Observed<FillActivity>[] }
+
+interface OrderPageAccumulator {
+  readonly rows: Chunk.Chunk<Observed<BrokerOrder>>
+  readonly ids: HashSet.HashSet<string>
+  readonly previousSubmittedAt: string | undefined
+}
+
+interface FillPageAccumulator {
+  readonly rows: Chunk.Chunk<Observed<FillActivity>>
+  readonly ids: HashSet.HashSet<string>
+}
+
+const initialOrderPaginationState = (): OrderPaginationState => ({
+  rows: [],
+  ids: HashSet.empty(),
+  cursor: undefined,
+  previousSubmittedAt: undefined,
+  observedAt: undefined,
+})
+
+const initialFillPaginationState = (): FillPaginationState => ({
+  rows: [],
+  ids: HashSet.empty(),
+  cursor: undefined,
+})
+
+const decideOrderPage = (
+  state: OrderPaginationState,
+  limit: number,
+  page: ReadResult<readonly BrokerOrder[]>,
+): Result.Result<OrderPageDecision, ReconciliationError> => {
+  const observedAt =
+    state.observedAt === undefined || page.evidence.observedAt > state.observedAt
+      ? page.evidence.observedAt
+      : state.observedAt
+  if (page.value.length > limit) {
+    return Result.fail(paginationFailure('OrderPageTooLarge', 'Alpaca returned more orders than requested'))
+  }
+  if (page.value.length === 0) {
+    return Result.succeed({ _tag: 'Complete', read: { rows: state.rows, observedAt } })
+  }
+
+  const pageResult = page.value.reduce<Result.Result<OrderPageAccumulator, ReconciliationError>>(
+    (result, order) => {
+      if (Result.isFailure(result)) return result
+      const submittedAt = order.submittedAt
+      if (submittedAt === undefined) {
+        return Result.fail(
+          paginationFailure('OrderSubmittedAtMissing', `Alpaca order ${order.brokerOrderId} is missing submitted_at`),
+        )
+      }
+
+      const previousSubmittedAt = result.success.previousSubmittedAt
+      if (previousSubmittedAt !== undefined && sourceTimestamp(submittedAt) < sourceTimestamp(previousSubmittedAt)) {
+        return Result.fail(paginationFailure('OrderHistoryNotAscending', 'Alpaca order history is not ascending'))
+      }
+      if (state.cursor !== undefined && sourceTimestamp(submittedAt) <= sourceTimestamp(state.cursor)) {
+        return Result.fail(
+          paginationFailure('OrderTimestampCursorDidNotAdvance', 'Alpaca order timestamp cursor did not advance'),
+        )
+      }
+      if (HashSet.has(result.success.ids, order.brokerOrderId)) {
+        return Result.fail(paginationFailure('DuplicateOrder', `duplicate Alpaca order ${order.brokerOrderId}`))
+      }
+
+      const rows = Chunk.append(result.success.rows, { value: order, evidence: page.evidence })
+      if (state.rows.length + Chunk.size(rows) > maximumRows) {
+        return Result.fail(
+          paginationFailure('OrderHistoryTooLarge', `Alpaca order history exceeds ${maximumRows} rows`),
+        )
+      }
+      return Result.succeed({
+        rows,
+        ids: HashSet.add(result.success.ids, order.brokerOrderId),
+        previousSubmittedAt: submittedAt,
+      })
+    },
+    Result.succeed({
+      rows: Chunk.empty(),
+      ids: state.ids,
+      previousSubmittedAt: state.previousSubmittedAt,
+    }),
+  )
+  if (Result.isFailure(pageResult)) return Result.fail(pageResult.failure)
+
+  const rows = [...state.rows, ...Chunk.toReadonlyArray(pageResult.success.rows)]
+  if (page.value.length < limit) {
+    return Result.succeed({ _tag: 'Complete', read: { rows, observedAt } })
+  }
+
+  const next = page.value[page.value.length - 1]?.submittedAt
+  if (next === undefined || next === state.cursor) {
+    return Result.fail(paginationFailure('OrderCursorDidNotAdvance', 'Alpaca order cursor did not advance'))
+  }
+  return Result.succeed({
+    _tag: 'Continue',
+    state: {
+      rows,
+      ids: pageResult.success.ids,
+      cursor: next,
+      previousSubmittedAt: pageResult.success.previousSubmittedAt,
+      observedAt,
+    },
+  })
+}
+
+const decideFillPage = (
+  state: FillPaginationState,
+  pageSize: number,
+  page: ReadResult<{ readonly items: readonly FillActivity[]; readonly nextPageToken?: string }>,
+): Result.Result<FillPageDecision, ReconciliationError> => {
+  if (page.value.items.length > pageSize) {
+    return Result.fail(paginationFailure('FillPageTooLarge', 'Alpaca returned more fills than requested'))
+  }
+
+  const pageResult = page.value.items.reduce<Result.Result<FillPageAccumulator, ReconciliationError>>(
+    (result, fill) => {
+      if (Result.isFailure(result)) return result
+      if (HashSet.has(result.success.ids, fill.activityId)) {
+        return Result.fail(paginationFailure('DuplicateFill', `duplicate Alpaca fill ${fill.activityId}`))
+      }
+
+      const rows = Chunk.append(result.success.rows, { value: fill, evidence: page.evidence })
+      if (state.rows.length + Chunk.size(rows) > maximumRows) {
+        return Result.fail(paginationFailure('FillHistoryTooLarge', `Alpaca fill history exceeds ${maximumRows} rows`))
+      }
+      return Result.succeed({
+        rows,
+        ids: HashSet.add(result.success.ids, fill.activityId),
+      })
+    },
+    Result.succeed({ rows: Chunk.empty(), ids: state.ids }),
+  )
+  if (Result.isFailure(pageResult)) return Result.fail(pageResult.failure)
+
+  const rows = [...state.rows, ...Chunk.toReadonlyArray(pageResult.success.rows)]
+  const next = page.value.nextPageToken
+  if (next === undefined) return Result.succeed({ _tag: 'Complete', rows })
+
+  const last = page.value.items[page.value.items.length - 1]?.activityId
+  if (page.value.items.length === 0 || next === state.cursor || next !== last) {
+    return Result.fail(paginationFailure('FillCursorDidNotAdvance', 'Alpaca fill cursor did not advance'))
+  }
+  return Result.succeed({
+    _tag: 'Continue',
+    state: {
+      rows,
+      ids: pageResult.success.ids,
+      cursor: next,
+    },
+  })
+}
+
+const readOrderPages = (
   read: BrokerReadShape,
   until: string,
-): Effect.Effect<OrderRead, BrokerReadError | ReconciliationError> =>
-  Effect.gen(function* () {
-    const rows: Observed<BrokerOrder>[] = []
-    const ids = new Set<string>()
-    let cursor: string | undefined
-    let previousSubmittedAt: string | undefined
-    let observedAt: string | undefined
+  state: OrderPaginationState,
+): Effect.Effect<OrderRead, BrokerReadError | ReconciliationError> => {
+  const limit = Math.min(ordersPageSize, maximumRows + 1 - state.rows.length)
+  return Effect.suspend(() =>
+    read.orders({
+      status: OrderCollection.All,
+      direction: SortDirection.Ascending,
+      limit,
+      until,
+      ...(state.cursor === undefined ? {} : { after: state.cursor }),
+    }),
+  ).pipe(
+    Effect.flatMap((page) => Effect.fromResult(decideOrderPage(state, limit, page))),
+    Effect.flatMap((decision) =>
+      decision._tag === 'Complete' ? Effect.succeed(decision.read) : readOrderPages(read, until, decision.state),
+    ),
+  )
+}
 
-    while (true) {
-      const limit = Math.min(ordersPageSize, maximumRows + 1 - rows.length)
-      const page = yield* read.orders({
-        status: OrderCollection.All,
-        direction: SortDirection.Ascending,
-        limit,
-        until,
-        ...(cursor === undefined ? {} : { after: cursor }),
-      })
-      observedAt =
-        observedAt === undefined || page.evidence.observedAt > observedAt ? page.evidence.observedAt : observedAt
-      if (page.value.length > limit) {
-        return yield* Effect.fail(failure('pagination', 'Alpaca returned more orders than requested'))
-      }
-      if (page.value.length === 0) return { rows, observedAt }
-
-      for (const order of page.value) {
-        const submittedAt = order.submittedAt
-        if (submittedAt === undefined) {
-          return yield* Effect.fail(
-            failure('pagination', `Alpaca order ${order.brokerOrderId} is missing submitted_at`),
-          )
-        }
-        if (previousSubmittedAt !== undefined && sourceTimestamp(submittedAt) < sourceTimestamp(previousSubmittedAt)) {
-          return yield* Effect.fail(failure('pagination', 'Alpaca order history is not ascending'))
-        }
-        if (cursor !== undefined && sourceTimestamp(submittedAt) <= sourceTimestamp(cursor)) {
-          return yield* Effect.fail(failure('pagination', 'Alpaca order timestamp cursor did not advance'))
-        }
-        if (ids.has(order.brokerOrderId)) {
-          return yield* Effect.fail(failure('pagination', `duplicate Alpaca order ${order.brokerOrderId}`))
-        }
-        ids.add(order.brokerOrderId)
-        rows.push({ value: order, evidence: page.evidence })
-        previousSubmittedAt = submittedAt
-        if (rows.length > maximumRows) {
-          return yield* Effect.fail(failure('pagination', `Alpaca order history exceeds ${maximumRows} rows`))
-        }
-      }
-
-      if (page.value.length < limit) return { rows, observedAt }
-      const next = page.value[page.value.length - 1]?.submittedAt
-      if (next === undefined || next === cursor) {
-        return yield* Effect.fail(failure('pagination', 'Alpaca order cursor did not advance'))
-      }
-      cursor = next
-    }
-  })
-
-const readFills = (
+const readFillPages = (
   read: BrokerReadShape,
   until: string,
-): Effect.Effect<readonly Observed<FillActivity>[], BrokerReadError | ReconciliationError> =>
-  Effect.gen(function* () {
-    const rows: Observed<FillActivity>[] = []
-    const ids = new Set<string>()
-    let cursor: string | undefined
-
-    while (true) {
-      const pageSize = Math.min(fillsPageSize, maximumRows + 1 - rows.length)
-      const page = yield* read.fillActivities({
-        direction: SortDirection.Ascending,
-        pageSize,
-        until,
-        ...(cursor === undefined ? {} : { pageToken: cursor }),
-      })
-      if (page.value.items.length > pageSize) {
-        return yield* Effect.fail(failure('pagination', 'Alpaca returned more fills than requested'))
-      }
-
-      for (const fill of page.value.items) {
-        if (ids.has(fill.activityId)) {
-          return yield* Effect.fail(failure('pagination', `duplicate Alpaca fill ${fill.activityId}`))
-        }
-        ids.add(fill.activityId)
-        rows.push({ value: fill, evidence: page.evidence })
-        if (rows.length > maximumRows) {
-          return yield* Effect.fail(failure('pagination', `Alpaca fill history exceeds ${maximumRows} rows`))
-        }
-      }
-
-      const next = page.value.nextPageToken
-      if (next === undefined) return rows
-      const last = page.value.items[page.value.items.length - 1]?.activityId
-      if (page.value.items.length === 0 || next === cursor || next !== last) {
-        return yield* Effect.fail(failure('pagination', 'Alpaca fill cursor did not advance'))
-      }
-      cursor = next
-    }
-  })
+  state: FillPaginationState,
+): Effect.Effect<readonly Observed<FillActivity>[], BrokerReadError | ReconciliationError> => {
+  const pageSize = Math.min(fillsPageSize, maximumRows + 1 - state.rows.length)
+  return Effect.suspend(() =>
+    read.fillActivities({
+      direction: SortDirection.Ascending,
+      pageSize,
+      until,
+      ...(state.cursor === undefined ? {} : { pageToken: state.cursor }),
+    }),
+  ).pipe(
+    Effect.flatMap((page) => Effect.fromResult(decideFillPage(state, pageSize, page))),
+    Effect.flatMap((decision) =>
+      decision._tag === 'Complete' ? Effect.succeed(decision.rows) : readFillPages(read, until, decision.state),
+    ),
+  )
+}
 
 const readHistory = (
   read: BrokerReadShape,
   until: string,
 ): Effect.Effect<BrokerHistory, BrokerReadError | ReconciliationError> =>
-  Effect.all({ orders: readOrders(read, until), fills: readFills(read, until) }, { concurrency: 2 })
+  Effect.all(
+    {
+      orders: readOrderPages(read, until, initialOrderPaginationState()),
+      fills: readFillPages(read, until, initialFillPaginationState()),
+    },
+    { concurrency: 2 },
+  )
 
 const historyHash = (history: BrokerHistory): string =>
   canonicalHashV1({
@@ -188,150 +434,373 @@ const historyHash = (history: BrokerHistory): string =>
       .sort((left, right) => left.activityId.localeCompare(right.activityId)),
   })
 
+const decideStableHistory = (
+  before: BrokerHistory,
+  after: BrokerHistory,
+): Result.Result<BrokerHistory, ReconciliationError> =>
+  historyHash(before) === historyHash(after)
+    ? Result.succeed(after)
+    : Result.fail(snapshotFailure('HistoryChanged', 'broker history changed during reconciliation'))
+
+const currentInstant = Clock.currentTimeMillis.pipe(
+  Effect.map((currentTimeMillis) => new Date(currentTimeMillis).toISOString()),
+)
+
+const readStableBrokerSnapshot = (
+  read: BrokerReadShape,
+): Effect.Effect<StableBrokerSnapshot, BrokerReadError | ReconciliationError> =>
+  Effect.gen(function* () {
+    const beforeUntil = yield* currentInstant
+    const before = yield* readHistory(read, beforeUntil)
+    const [account, positions] = yield* Effect.all([read.account, read.positions], { concurrency: 2 })
+    const afterUntil = yield* currentInstant
+    const after = yield* readHistory(read, afterUntil)
+    const history = yield* Effect.fromResult(decideStableHistory(before, after))
+    return { account, positions, history }
+  })
+
+const indexBindings = (
+  bindings: readonly IntentBinding[],
+): Result.Result<HashMap.HashMap<string, string>, NormalizationDecisionFailure> =>
+  bindings.reduce<Result.Result<HashMap.HashMap<string, string>, NormalizationDecisionFailure>>((result, binding) => {
+    if (Result.isFailure(result)) return result
+    if (HashMap.has(result.success, binding.clientOrderId)) {
+      return Result.fail(
+        validationFailure('DuplicateIntentClientOrderId', `duplicate intent client order ID ${binding.clientOrderId}`),
+      )
+    }
+    return Result.succeed(HashMap.set(result.success, binding.clientOrderId, binding.intentId))
+  }, Result.succeed(HashMap.empty()))
+
+interface OrderNormalizationState {
+  readonly orderById: HashMap.HashMap<string, BrokerOrder>
+  readonly clientOrderIds: HashSet.HashSet<string>
+  readonly events: Chunk.Chunk<OrderEventInput>
+}
+
+const normalizeOrders = (
+  rows: readonly Observed<BrokerOrder>[],
+  intentByClient: HashMap.HashMap<string, string>,
+): Result.Result<OrderNormalizationState, NormalizationDecisionFailure> =>
+  rows.reduce<Result.Result<OrderNormalizationState, NormalizationDecisionFailure>>(
+    (result, observed) => {
+      if (Result.isFailure(result)) return result
+      if (HashSet.has(result.success.clientOrderIds, observed.value.clientOrderId)) {
+        return Result.fail(
+          validationFailure(
+            'DuplicateBrokerClientOrderId',
+            `duplicate broker client order ID ${observed.value.clientOrderId}`,
+          ),
+        )
+      }
+
+      const normalized = normalizationAttempt('order', observed.value.brokerOrderId, () =>
+        orderObservation(
+          observed.value,
+          observed.evidence,
+          Option.getOrUndefined(HashMap.get(intentByClient, observed.value.clientOrderId)),
+        ),
+      )
+      if (Result.isFailure(normalized)) return Result.fail(normalized.failure)
+      if (normalized.success._tag !== 'Order') {
+        return Result.fail(validationFailure('UnexpectedOrderEvent', 'normalized order event is not an order'))
+      }
+      return Result.succeed({
+        orderById: HashMap.set(result.success.orderById, observed.value.brokerOrderId, observed.value),
+        clientOrderIds: HashSet.add(result.success.clientOrderIds, observed.value.clientOrderId),
+        events: Chunk.append(result.success.events, normalized.success),
+      })
+    },
+    Result.succeed({
+      orderById: HashMap.empty(),
+      clientOrderIds: HashSet.empty(),
+      events: Chunk.empty(),
+    }),
+  )
+
+const normalizeFills = (
+  fills: readonly Observed<FillActivity>[],
+  orders: OrderNormalizationState,
+  intentByClient: HashMap.HashMap<string, string>,
+): Result.Result<readonly FillEventInput[], NormalizationDecisionFailure> => {
+  const ordered = normalizationAttempt('fill-ordering', undefined, () =>
+    [...fills].sort((left, right) => {
+      const byTime = compareText(
+        sourceTimestamp(left.value.transactionTime),
+        sourceTimestamp(right.value.transactionTime),
+      )
+      return byTime === 0 ? compareText(left.value.activityId, right.value.activityId) : byTime
+    }),
+  )
+  if (Result.isFailure(ordered)) return Result.fail(ordered.failure)
+
+  return Result.all(
+    ordered.success.map((observed) => {
+      const order = Option.getOrUndefined(HashMap.get(orders.orderById, observed.value.brokerOrderId))
+      if (order === undefined) {
+        return Result.fail(
+          validationFailure('FillOrderMissing', `Alpaca fill ${observed.value.activityId} references a missing order`),
+        )
+      }
+      return normalizationAttempt('fill', observed.value.activityId, () =>
+        fillObservation(observed.value, order, observed.evidence, {
+          intentId: Option.getOrUndefined(HashMap.get(intentByClient, order.clientOrderId)),
+        }),
+      )
+    }),
+  )
+}
+
+const normalizeAccount = (
+  account: ReadResult<BrokerAccount>,
+): Result.Result<AccountEventInput, NormalizationDecisionFailure> => {
+  const normalized = normalizationAttempt('account', account.value.id, () => accountObservation(account))
+  if (Result.isFailure(normalized)) return Result.fail(normalized.failure)
+  return normalized.success._tag === 'Account'
+    ? Result.succeed(normalized.success)
+    : Result.fail(validationFailure('UnexpectedAccountEvent', 'normalized account event is not an account'))
+}
+
+const normalizePositions = (
+  accountId: string,
+  positions: ReadResult<readonly BrokerPosition[]>,
+): Result.Result<PositionSnapshotInput, NormalizationDecisionFailure> =>
+  normalizationAttempt('positions', accountId, () => positionSnapshot(accountId, positions))
+
+const normalizeSnapshot = (
+  snapshot: StableBrokerSnapshot,
+  bindings: readonly IntentBinding[],
+): Result.Result<NormalizedBrokerSnapshot, NormalizationDecisionFailure> =>
+  Result.gen(function* () {
+    const intentByClient = yield* indexBindings(bindings)
+    const orders = yield* normalizeOrders(snapshot.history.orders.rows, intentByClient)
+    const fillEvents = yield* normalizeFills(snapshot.history.fills, orders, intentByClient)
+    const account = yield* normalizeAccount(snapshot.account)
+    const positions = yield* normalizePositions(snapshot.account.value.id, snapshot.positions)
+    return {
+      account,
+      positions,
+      orderEvents: Chunk.toReadonlyArray(orders.events),
+      fillEvents,
+    }
+  })
+
+const interpretNormalizationDecision = <A>(
+  decision: Result.Result<A, NormalizationDecisionFailure>,
+): Effect.Effect<A, ReconciliationError> => {
+  if (Result.isSuccess(decision)) return Effect.succeed(decision.success)
+  switch (decision.failure._tag) {
+    case 'ReconciliationError':
+      return Effect.fail(decision.failure)
+    case 'Defect':
+      return Effect.failCause(decision.failure.cause)
+  }
+}
+
+const decideAccountBaseline = (hasAccountBaseline: boolean): Result.Result<void, ReconciliationError> =>
+  hasAccountBaseline
+    ? Result.succeed(undefined)
+    : Result.fail(
+        snapshotFailure(
+          'AccountBaselineMissing',
+          'paper account has fill history before Bayn established an opening cash baseline',
+        ),
+      )
+
+const prepareNormalizedSnapshot = (
+  store: PaperStoreShape,
+  snapshot: StableBrokerSnapshot,
+): Effect.Effect<NormalizedBrokerSnapshot, PaperStoreError | ReconciliationError> =>
+  Effect.gen(function* () {
+    const bindings = yield* store.bindings(snapshot.account.value.id)
+    if (snapshot.history.fills.length > 0) {
+      const hasAccountBaseline = yield* store.hasAccountBaseline(snapshot.account.value.id)
+      yield* Effect.fromResult(decideAccountBaseline(hasAccountBaseline))
+    }
+    return yield* interpretNormalizationDecision(normalizeSnapshot(snapshot, bindings))
+  })
+
+const ingestBrokerEvents = (store: PaperStoreShape, normalized: NormalizedBrokerSnapshot) =>
+  Effect.gen(function* () {
+    const accountReceipt = yield* store.ingest(normalized.account)
+    const positionsReceipt = yield* store.ingestPositions(normalized.positions)
+    yield* Effect.forEach(normalized.orderEvents, store.ingest, { discard: true })
+    yield* Effect.forEach(normalized.fillEvents, store.account, { discard: true })
+    const valuation = yield* store.value({
+      accountEventId: accountReceipt.eventId,
+      positionSnapshotId: positionsReceipt.snapshotId,
+    })
+    return valuation
+  })
+
+const makeReconciliationDecision = (
+  normalized: NormalizedBrokerSnapshot,
+  ordersObservedAt: string,
+  valuation: BrokerSnapshot['valuation'],
+  reconciledAt: string,
+): ReconciliationDecision => {
+  const positions = normalized.positions.positions
+    .map((event) => event.position)
+    .sort((left, right) => compareText(left.symbol, right.symbol))
+  const orders = normalized.orderEvents
+    .map((event) => event.order)
+    .sort((left, right) => compareText(left.brokerOrderId, right.brokerOrderId))
+  return {
+    snapshot: {
+      account: normalized.account.account,
+      positions,
+      positionsObservedAt: normalized.positions.observedAt,
+      orders,
+      ordersObservedAt,
+      fills: normalized.fillEvents.map((event) => event.fill),
+      valuation,
+      reconciledAt,
+    },
+    unknownOrderCount: orders.filter((order) => order.intentId === undefined).length,
+    orderCount: normalized.orderEvents.length,
+    fillCount: normalized.fillEvents.length,
+  }
+}
+
+const makePassResult = (
+  decision: ReconciliationDecision,
+  persisted: ReconciliationWriteResult,
+): ReconciliationPassResult => {
+  const report: ReconciliationReport = {
+    reconciliation: persisted.reconciliation,
+    metrics: persisted.metrics,
+  }
+  return {
+    report,
+    brokerState: {
+      account: decision.snapshot.account,
+      positions: decision.snapshot.positions,
+      positionsObservedAt: decision.snapshot.positionsObservedAt,
+      orders: decision.snapshot.orders,
+      ordersObservedAt: decision.snapshot.ordersObservedAt,
+      accountingHash: persisted.accountingHash,
+      reconciliation: persisted.reconciliation,
+      unknownOrderCount: decision.unknownOrderCount,
+    },
+    riskContext: persisted.riskContext,
+  }
+}
+
+const logCompletedPass = (result: ReconciliationPassResult, decision: ReconciliationDecision): Effect.Effect<void> =>
+  Effect.logInfo('Paper account reconciliation completed').pipe(
+    Effect.annotateLogs({
+      accountId: result.report.reconciliation.accountId,
+      status: result.report.reconciliation.status,
+      reconciliationId: result.report.reconciliation.reconciliationId,
+      orderCount: decision.orderCount,
+      fillCount: decision.fillCount,
+      discrepancyCount: result.report.metrics.discrepancyCount,
+      brokerPollAgeMs: result.report.metrics.brokerPollAgeMs,
+      oldestUnknownMutationAgeMs: result.report.metrics.oldestUnknownMutationAgeMs,
+      accountingExact: result.report.metrics.accountingExact,
+    }),
+  )
+
+const writeReconciliation = (
+  store: PaperStoreShape,
+  normalized: NormalizedBrokerSnapshot,
+  ordersObservedAt: string,
+): Effect.Effect<ReconciliationPassResult, PaperStoreError> =>
+  Effect.gen(function* () {
+    const valuation = yield* ingestBrokerEvents(store, normalized)
+    const reconciledAt = yield* currentInstant
+    const decision = makeReconciliationDecision(normalized, ordersObservedAt, valuation, reconciledAt)
+    const persisted = yield* store.reconcile(decision.snapshot)
+    const result = makePassResult(decision, persisted)
+    yield* logCompletedPass(result, decision)
+    return result
+  })
+
+const persistStableSnapshot = (
+  store: PaperStoreShape,
+  fence: WriterFenceService,
+  snapshot: StableBrokerSnapshot,
+): Effect.Effect<ReconciliationPassResult, PaperStoreError | ReconciliationError | WriterFenceError> =>
+  fence.transaction(
+    prepareNormalizedSnapshot(store, snapshot).pipe(
+      Effect.flatMap((normalized) => writeReconciliation(store, normalized, snapshot.history.orders.observedAt)),
+    ),
+  )
+
 const run = (
   read: BrokerReadShape,
   store: PaperStoreShape,
   fence: WriterFenceService,
-): Effect.Effect<
-  ReconciliationPassResult,
-  BrokerReadError | PaperStoreError | ReconciliationError | WriterFenceError
-> =>
-  Effect.gen(function* () {
-    const beforeUntil = new Date(yield* Clock.currentTimeMillis).toISOString()
-    const before = yield* readHistory(read, beforeUntil)
-    const [accountResult, positionsResult] = yield* Effect.all([read.account, read.positions], { concurrency: 2 })
-    const afterUntil = new Date(yield* Clock.currentTimeMillis).toISOString()
-    const history = yield* readHistory(read, afterUntil)
-    if (historyHash(before) !== historyHash(history)) {
-      return yield* Effect.fail(failure('snapshot', 'broker history changed during reconciliation'))
-    }
-    const { orders, fills } = history
+): Effect.Effect<ReconciliationPassResult, ReconciliationPassError> =>
+  readStableBrokerSnapshot(read).pipe(
+    Effect.flatMap((snapshot) => persistStableSnapshot(store, fence, snapshot)),
+    Effect.withLogSpan('reconciliation'),
+  )
 
-    return yield* fence.transaction(
-      Effect.gen(function* () {
-        const bindings = yield* store.bindings(accountResult.value.id)
-        if (fills.length > 0 && !(yield* store.hasAccountBaseline(accountResult.value.id))) {
-          return yield* Effect.fail(
-            failure('snapshot', 'paper account has fill history before Bayn established an opening cash baseline'),
-          )
-        }
+type ContainmentDecision =
+  | { readonly _tag: 'PreserveInterruption' }
+  | { readonly _tag: 'RestrictAuthority'; readonly reason: typeof incompletePassReason }
 
-        const normalized = yield* attempt('normalization', 'broker snapshot normalization failed', () => {
-          const intentByClient = new Map<string, string>()
-          for (const binding of bindings) {
-            if (intentByClient.has(binding.clientOrderId)) {
-              throw new Error(`duplicate intent client order ID ${binding.clientOrderId}`)
-            }
-            intentByClient.set(binding.clientOrderId, binding.intentId)
-          }
+const decideContainment = <E>(cause: Cause.Cause<E>): ContainmentDecision =>
+  Cause.hasInterruptsOnly(cause)
+    ? { _tag: 'PreserveInterruption' }
+    : { _tag: 'RestrictAuthority', reason: incompletePassReason }
 
-          const orderById = new Map<string, BrokerOrder>()
-          const clientOrderIds = new Set<string>()
-          const orderEvents: Extract<BrokerEventInput, { readonly _tag: 'Order' }>[] = []
-          for (const observed of orders.rows) {
-            if (orderById.has(observed.value.brokerOrderId)) {
-              throw new Error(`duplicate broker order ID ${observed.value.brokerOrderId}`)
-            }
-            if (clientOrderIds.has(observed.value.clientOrderId)) {
-              throw new Error(`duplicate broker client order ID ${observed.value.clientOrderId}`)
-            }
-            orderById.set(observed.value.brokerOrderId, observed.value)
-            clientOrderIds.add(observed.value.clientOrderId)
-            const event = orderObservation(
-              observed.value,
-              observed.evidence,
-              intentByClient.get(observed.value.clientOrderId),
-            )
-            if (event._tag !== 'Order') throw new Error('normalized order event is not an order')
-            orderEvents.push(event)
-          }
+const restrictAuthority = (
+  store: PaperStoreShape,
+  fence: WriterFenceService,
+  decision: Extract<ContainmentDecision, { readonly _tag: 'RestrictAuthority' }>,
+): Effect.Effect<void, PaperStoreError | WriterFenceError> =>
+  currentInstant.pipe(
+    Effect.flatMap((failedAt) => fence.transaction(store.restrictAuthority(decision.reason, failedAt))),
+  )
 
-          const fillEvents = [...fills]
-            .sort((left, right) => {
-              const byTime = compareText(
-                sourceTimestamp(left.value.transactionTime),
-                sourceTimestamp(right.value.transactionTime),
-              )
-              return byTime === 0 ? compareText(left.value.activityId, right.value.activityId) : byTime
-            })
-            .map((observed): FillEventInput => {
-              const order = orderById.get(observed.value.brokerOrderId)
-              if (order === undefined) {
-                throw new Error(`Alpaca fill ${observed.value.activityId} references a missing order`)
-              }
-              return fillObservation(observed.value, order, observed.evidence, {
-                intentId: intentByClient.get(order.clientOrderId),
-              })
-            })
+const hasDefectOrInterruption = <E>(cause: Cause.Cause<E>): boolean =>
+  cause.reasons.some((reason) => Cause.isDieReason(reason) || Cause.isInterruptReason(reason))
 
-          const accountEvent = accountObservation(accountResult)
-          if (accountEvent._tag !== 'Account') throw new Error('normalized account event is not an account')
-          return {
-            account: accountEvent,
-            positions: positionSnapshot(accountResult.value.id, positionsResult),
-            orderEvents,
-            fillEvents,
-          }
-        })
+const authorityRestrictionFailure = (
+  reconciliationCause: Cause.Cause<ReconciliationPassError>,
+  restrictionCause: Cause.Cause<PaperStoreError | WriterFenceError>,
+): ReconciliationError =>
+  new ReconciliationError({
+    operation: 'containment',
+    message: 'authority restriction failed after reconciliation failure',
+    failure: {
+      _tag: 'AuthorityRestrictionFailed',
+      reconciliationCause,
+      restrictionCause,
+    },
+  })
 
-        const accountReceipt = yield* store.ingest(normalized.account)
-        const positionsReceipt = yield* store.ingestPositions(normalized.positions)
-        yield* Effect.forEach(normalized.orderEvents, store.ingest, { discard: true })
-        yield* Effect.forEach(normalized.fillEvents, store.account, { discard: true })
-        const valuation = yield* store.value({
-          accountEventId: accountReceipt.eventId,
-          positionSnapshotId: positionsReceipt.snapshotId,
-        })
-        const reconciledAt = new Date(yield* Clock.currentTimeMillis).toISOString()
-        const positions = normalized.positions.positions
-          .map((event) => event.position)
-          .sort((left, right) => compareText(left.symbol, right.symbol))
-        const reconciledOrders = normalized.orderEvents
-          .map((event) => event.order)
-          .sort((left, right) => compareText(left.brokerOrderId, right.brokerOrderId))
-        const unknownOrderCount = reconciledOrders.filter((order) => order.intentId === undefined).length
-        const persisted = yield* store.reconcile({
-          account: normalized.account.account,
-          positions,
-          positionsObservedAt: normalized.positions.observedAt,
-          orders: reconciledOrders,
-          ordersObservedAt: orders.observedAt,
-          fills: normalized.fillEvents.map((event) => event.fill),
-          valuation,
-          reconciledAt,
-        } satisfies BrokerSnapshot)
-        const report: ReconciliationReport = {
-          reconciliation: persisted.reconciliation,
-          metrics: persisted.metrics,
-        }
-        const brokerState: ReconciledBrokerState = {
-          account: normalized.account.account,
-          positions,
-          positionsObservedAt: normalized.positions.observedAt,
-          orders: reconciledOrders,
-          ordersObservedAt: orders.observedAt,
-          accountingHash: persisted.accountingHash,
-          reconciliation: persisted.reconciliation,
-          unknownOrderCount,
-        }
+const preserveFailureAfterContainment = (
+  cause: Cause.Cause<ReconciliationPassError>,
+  containmentExit: Exit.Exit<void, PaperStoreError | WriterFenceError>,
+): Effect.Effect<never, ReconciliationPassError> => {
+  if (Exit.isSuccess(containmentExit)) return Effect.failCause(cause)
+  if (hasDefectOrInterruption(containmentExit.cause)) {
+    return Effect.failCause(Cause.combine(cause, containmentExit.cause))
+  }
+  const containmentError = authorityRestrictionFailure(cause, containmentExit.cause)
+  return hasDefectOrInterruption(cause)
+    ? Effect.failCause(Cause.combine(cause, Cause.fail(containmentError)))
+    : Effect.fail(containmentError)
+}
 
-        yield* Effect.logInfo('Paper account reconciliation completed').pipe(
-          Effect.annotateLogs({
-            accountId: report.reconciliation.accountId,
-            status: report.reconciliation.status,
-            reconciliationId: report.reconciliation.reconciliationId,
-            orderCount: normalized.orderEvents.length,
-            fillCount: normalized.fillEvents.length,
-            discrepancyCount: report.metrics.discrepancyCount,
-            brokerPollAgeMs: report.metrics.brokerPollAgeMs,
-            oldestUnknownMutationAgeMs: report.metrics.oldestUnknownMutationAgeMs,
-            accountingExact: report.metrics.accountingExact,
-          }),
-        )
-        return { report, brokerState, riskContext: persisted.riskContext }
-      }),
-    )
-  }).pipe(Effect.withLogSpan('reconciliation'))
+const containRuntimeFailure = <A, R>(
+  effect: Effect.Effect<A, ReconciliationPassError, R>,
+  store: PaperStoreShape,
+  fence: WriterFenceService,
+): Effect.Effect<A, ReconciliationPassError, R> =>
+  Effect.matchCauseEffect(effect, {
+    onFailure: (cause) => {
+      const decision = decideContainment(cause)
+      if (decision._tag === 'PreserveInterruption') return Effect.failCause(cause)
+      return Effect.exit(restrictAuthority(store, fence, decision)).pipe(
+        Effect.flatMap((containmentExit) => preserveFailureAfterContainment(cause, containmentExit)),
+      )
+    },
+    onSuccess: (value) => Effect.succeed(value),
+  })
 
 export const runOnce: Effect.Effect<
   ReconciliationPassResult,
@@ -341,23 +810,5 @@ export const runOnce: Effect.Effect<
   const read = yield* BrokerRead
   const store = yield* PaperStore
   const fence = yield* WriterFence
-  const restrict = Effect.gen(function* () {
-    const failedAt = new Date(yield* Clock.currentTimeMillis).toISOString()
-    yield* fence.transaction(store.restrictAuthority('reconciliation pass incomplete', failedAt))
-  })
-  return yield* run(read, store, fence).pipe(
-    Effect.tapCause((cause) => (Cause.hasInterruptsOnly(cause) ? Effect.void : restrict)),
-  )
+  return yield* containRuntimeFailure(run(read, store, fence), store, fence)
 })
-
-export const runContinuously = (interval: Duration.Input) =>
-  runOnce.pipe(
-    Effect.tapError((error) =>
-      Effect.logError('Paper account reconciliation failed; authority is restricted to OBSERVE').pipe(
-        Effect.annotateLogs({ errorTag: error._tag, operation: error.operation }),
-      ),
-    ),
-    Effect.catch(() => Effect.void),
-    Effect.repeat(Schedule.spaced(interval)),
-    Effect.asVoid,
-  )


### PR DESCRIPTION
## Summary

- Refactors Bayn reconciliation into immutable pagination, stable-snapshot, normalization, persistence, and containment decisions with small Effect interpreters.
- Preserves broker read ordering and timestamps, WriterFence transaction boundaries, public reconciliation error tags, exact normalization causes, and defect/interruption propagation.
- Retains both reconciliation and authority-restriction causes when fail-closed containment cannot complete.
- Removes the dead `runContinuously` surface; `observe-composition.ts` remains the sole scoped autonomous scheduler and consumes only `runOnce`.
- Changes only the reconciler and its focused tests; there are no database, migration, GitOps, qualification, broker-client, or broker-mutation changes.

## Related Issues

None

## Testing

- `bun test src/reconciler.test.ts` — 15 passed
- `bun test src/observe-composition.test.ts` — 5 passed
- `bun test` — 573 passed, 113 skipped, 0 failed
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint:effect` — 133 files, 0 errors
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn build`
- `BAYN_TEST_POSTGRES_URL=postgresql://gregkonush@127.0.0.1:5432/bayn_test bun test src/db/paper-store.integration.test.ts` — 27 passed
- `BAYN_TEST_POSTGRES_URL=postgresql://gregkonush@127.0.0.1:5432/bayn_test bun test src/db/evidence-store.integration.test.ts` — 60 passed

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] Documentation and release notes are not required for this internal refactor; no follow-up is required.