### PR TITLE
refactor(bayn): make TigerBeetle resources functional

### DIFF
--- a/services/bayn/src/resources.test.ts
+++ b/services/bayn/src/resources.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 
-import { Cause, Effect, Exit, Option, Redacted, Ref } from 'effect'
+import { Cause, Effect, Exit, Option, Redacted, Ref, Result } from 'effect'
 import { AuthorizationError, SqlError } from 'effect/unstable/sql/SqlError'
 
 import { initialize } from './app'
@@ -13,6 +13,13 @@ import { Authority } from './paper'
 import { initialState } from './runtime-state'
 import { makeStrategy } from './strategy'
 import { fixtureProtocol, makeSnapshot, makeTestProvenance } from './test-fixtures'
+import {
+  parseReplicaEndpoints,
+  resolveReplicaAddresses,
+  validateResolvedReplicaAddresses,
+  validateResolvedReplicaEndpoint,
+  type ReplicaAddressValidationError,
+} from './tigerbeetle-client'
 
 const provenance = makeTestProvenance()
 const fixtureStrategy = makeStrategy(fixtureProtocol, provenance)
@@ -119,6 +126,88 @@ const makeTigerBeetleClient = (overrides: Partial<TigerBeetleClient> = {}): Tige
   ...overrides,
 })
 
+const resultSuccess = <A>(decision: Result.Result<A, ReplicaAddressValidationError>): A => {
+  expect(Result.isSuccess(decision)).toBeTrue()
+  if (Result.isFailure(decision)) throw decision.failure
+  return decision.success
+}
+
+const resultFailure = <A>(decision: Result.Result<A, ReplicaAddressValidationError>): ReplicaAddressValidationError => {
+  expect(Result.isFailure(decision)).toBeTrue()
+  if (Result.isSuccess(decision)) throw new Error('replica address decision unexpectedly succeeded')
+  return decision.failure
+}
+
+describe('TigerBeetle replica address decisions', () => {
+  test('parses configured endpoints synchronously while preserving request order', () => {
+    expect(
+      resultSuccess(parseReplicaEndpoints([' 3000 ', '127.0.0.1', '127.0.0.2:3001', 'replica-0.test:3002'])),
+    ).toEqual([
+      { _tag: 'DirectReplicaAddress', configuredAddress: ' 3000 ', address: '3000' },
+      { _tag: 'DirectReplicaAddress', configuredAddress: '127.0.0.1', address: '127.0.0.1' },
+      { _tag: 'DirectReplicaAddress', configuredAddress: '127.0.0.2:3001', address: '127.0.0.2:3001' },
+      {
+        _tag: 'ReplicaHostname',
+        configuredAddress: 'replica-0.test:3002',
+        hostname: 'replica-0.test',
+        port: 3002,
+      },
+    ])
+
+    for (const [configuredAddresses, reason] of [
+      [[], 'empty-addresses'],
+      [['missing-port'], 'invalid-address'],
+      [['replica.test:not-a-port'], 'invalid-address'],
+      [['replica.test:70000'], 'invalid-port'],
+      [['::1'], 'ipv6-unsupported'],
+    ] as const) {
+      expect(resultFailure(parseReplicaEndpoints(configuredAddresses))).toMatchObject({ reason })
+    }
+  })
+
+  test('validates DNS answers and the final exact address set synchronously', () => {
+    const [endpoint] = resultSuccess(parseReplicaEndpoints(['replica-0.test:3000']))
+    expect(resultSuccess(validateResolvedReplicaEndpoint(endpoint, ['::1', '10.0.0.1', 'not-an-address']))).toBe(
+      '10.0.0.1:3000',
+    )
+    expect(resultFailure(validateResolvedReplicaEndpoint(endpoint, ['::1']))).toMatchObject({
+      reason: 'no-ipv4-address',
+    })
+    expect(resultFailure(validateResolvedReplicaEndpoint(endpoint, ['10.0.0.1', '10.0.0.2']))).toMatchObject({
+      reason: 'multiple-ipv4-addresses',
+    })
+    expect(resultSuccess(validateResolvedReplicaAddresses(['10.0.0.1:3000', '10.0.0.2:3000']))).toEqual([
+      '10.0.0.1:3000',
+      '10.0.0.2:3000',
+    ])
+    expect(resultFailure(validateResolvedReplicaAddresses(['10.0.0.1:3000', '10.0.0.1:3000']))).toMatchObject({
+      reason: 'duplicate-address',
+      material: { duplicateAddress: '10.0.0.1:3000' },
+    })
+  })
+
+  test('preflights every endpoint before DNS and interrupts an in-flight lookup', async () => {
+    let lookups = 0
+    const invalidExit = await Effect.runPromiseExit(
+      resolveReplicaAddresses(['replica-0.test:3000', 'missing-port'], () => {
+        lookups += 1
+        return Effect.succeed(['10.0.0.1'])
+      }),
+    )
+    expect(Exit.isFailure(invalidExit)).toBeTrue()
+    expect(lookups).toBe(0)
+
+    let interrupted = false
+    const interruptedExit = await Effect.runPromiseExit(
+      resolveReplicaAddresses(['replica-0.test:3000'], () =>
+        Effect.never.pipe(Effect.onInterrupt(() => Effect.sync(() => void (interrupted = true)))),
+      ).pipe(Effect.timeout(5)),
+    )
+    expect(Exit.isFailure(interruptedExit)).toBeTrue()
+    expect(interrupted).toBeTrue()
+  })
+})
+
 describe('Bayn resource lifecycle', () => {
   test('closes the TigerBeetle client exactly once when its scope exits', async () => {
     let tigerBeetleCloseCount = 0
@@ -146,15 +235,20 @@ describe('Bayn resource lifecycle', () => {
 
   test('replaces a failed TigerBeetle client so the next probe recovers', async () => {
     const closeCounts = [0, 0]
+    const lookupCounts = [0, 0]
     const clients = [
       makeTigerBeetleClient({
         lookupAccounts: async () => {
+          lookupCounts[0] += 1
           throw new Error('Client was closed.')
         },
         destroy: () => void (closeCounts[0] += 1),
       }),
       makeTigerBeetleClient({
-        lookupAccounts: async () => [],
+        lookupAccounts: async () => {
+          lookupCounts[1] += 1
+          return []
+        },
         destroy: () => void (closeCounts[1] += 1),
       }),
     ]
@@ -186,6 +280,7 @@ describe('Bayn resource lifecycle', () => {
 
     expect(firstError.message).toContain('Client was closed')
     expect(clientIndex).toBe(2)
+    expect(lookupCounts).toEqual([1, 1])
     expect(closeCounts).toEqual([1, 1])
   })
 
@@ -257,6 +352,7 @@ describe('Bayn resource lifecycle', () => {
       throw new Error('unexpected TigerBeetle client acquisition')
     }
     let acquisitionsAfterInterrupt = 0
+    let acquisitionsAfterReplacementFailure = 0
 
     const replacementError = await Effect.runPromise(
       Effect.scoped(
@@ -265,6 +361,7 @@ describe('Bayn resource lifecycle', () => {
           yield* journal.check.pipe(Effect.timeout(5), Effect.ignore)
           acquisitionsAfterInterrupt = clientAcquisitions
           const error = yield* Effect.flip(journal.check)
+          acquisitionsAfterReplacementFailure = clientAcquisitions
           yield* journal.check
           return error
         }).pipe(
@@ -279,6 +376,7 @@ describe('Bayn resource lifecycle', () => {
     )
 
     expect(acquisitionsAfterInterrupt).toBe(1)
+    expect(acquisitionsAfterReplacementFailure).toBe(2)
     expect(clientAcquisitions).toBe(3)
     expect(closeCounts).toEqual([1, 1])
     expect(replacementError.message).toContain('replacement unavailable')

--- a/services/bayn/src/tigerbeetle-client.ts
+++ b/services/bayn/src/tigerbeetle-client.ts
@@ -2,12 +2,63 @@ import { Resolver } from 'node:dns/promises'
 import { isIP } from 'node:net'
 
 import { type Client, type ClientInitArgs, createClient } from 'tigerbeetle-node'
-import { Effect, Option, ScopedRef, Semaphore } from 'effect'
+import { Data, Effect, Option, Result, Scope, ScopedRef, Semaphore } from 'effect'
 
 import type { RuntimeConfig } from './config'
-import { operationalError, retryableOperationalError, type OperationalError } from './errors'
+import { OperationalError, operationalError, retryableOperationalError } from './errors'
 
 type ResolveHostname = (hostname: string) => Effect.Effect<readonly string[], OperationalError>
+
+export type ReplicaAddressValidationReason =
+  | 'duplicate-address'
+  | 'empty-addresses'
+  | 'invalid-address'
+  | 'invalid-port'
+  | 'ipv6-unsupported'
+  | 'multiple-ipv4-addresses'
+  | 'no-ipv4-address'
+
+export class ReplicaAddressValidationError extends Data.TaggedError('ReplicaAddressValidationError')<{
+  readonly reason: ReplicaAddressValidationReason
+  readonly message: string
+  readonly material: Readonly<Record<string, unknown>>
+}> {}
+
+export type ReplicaEndpoint =
+  | {
+      readonly _tag: 'DirectReplicaAddress'
+      readonly configuredAddress: string
+      readonly address: string
+    }
+  | {
+      readonly _tag: 'ReplicaHostname'
+      readonly configuredAddress: string
+      readonly hostname: string
+      readonly port: number
+    }
+
+const failReplicaAddressValidation = (
+  reason: ReplicaAddressValidationReason,
+  message: string,
+  material: Readonly<Record<string, unknown>>,
+): Result.Result<never, ReplicaAddressValidationError> =>
+  Result.fail(new ReplicaAddressValidationError({ reason, message, material }))
+
+const replicaAddressBoundary = <A>(
+  decision: Result.Result<A, ReplicaAddressValidationError>,
+): Effect.Effect<A, OperationalError> =>
+  Effect.fromResult(decision).pipe(
+    Effect.mapError(
+      (cause) =>
+        new OperationalError({
+          component: 'journal',
+          operation: 'resolve-replica-addresses',
+          message: cause.message,
+          retryable: false,
+          cause,
+        }),
+    ),
+  )
 
 const lookupIpv4: ResolveHostname = (hostname) =>
   Effect.suspend(() => {
@@ -24,118 +75,149 @@ const lookupIpv4: ResolveHostname = (hostname) =>
     }).pipe(Effect.onInterrupt(() => Effect.sync(() => resolver.cancel())))
   })
 
-const parsePort = (value: string, address: string): Effect.Effect<number, OperationalError> => {
+const parsePort = (value: string, address: string): Result.Result<number, ReplicaAddressValidationError> => {
   if (!/^\d+$/.test(value)) {
-    return Effect.fail(
-      operationalError('journal', 'resolve-replica-addresses', `invalid TigerBeetle replica address: ${address}`),
-    )
+    return failReplicaAddressValidation('invalid-address', `invalid TigerBeetle replica address: ${address}`, {
+      address,
+      port: value,
+    })
   }
   const port = Number(value)
   if (!Number.isInteger(port) || port < 1 || port > 65_535) {
-    return Effect.fail(
-      operationalError('journal', 'resolve-replica-addresses', `invalid TigerBeetle replica port: ${address}`),
-    )
+    return failReplicaAddressValidation('invalid-port', `invalid TigerBeetle replica port: ${address}`, {
+      address,
+      port: value,
+    })
   }
-  return Effect.succeed(port)
+  return Result.succeed(port)
 }
 
-const resolveReplicaAddress = (
+const parseReplicaEndpoint = (
   configuredAddress: string,
-  resolveHostname: ResolveHostname,
-): Effect.Effect<readonly string[], OperationalError> =>
-  Effect.gen(function* () {
-    const address = configuredAddress.trim()
-    const addressFamily = isIP(address)
-    if (addressFamily === 4) return [address]
-    if (addressFamily === 6) {
-      return yield* Effect.fail(
-        operationalError(
-          'journal',
-          'resolve-replica-addresses',
-          `IPv6 TigerBeetle replica addresses are not supported: ${address}`,
-        ),
-      )
-    }
-    if (/^\d+$/.test(address)) {
-      yield* parsePort(address, address)
-      return [address]
-    }
+): Result.Result<ReplicaEndpoint, ReplicaAddressValidationError> => {
+  const address = configuredAddress.trim()
+  const addressFamily = isIP(address)
+  if (addressFamily === 4) {
+    return Result.succeed({ _tag: 'DirectReplicaAddress', configuredAddress, address })
+  }
+  if (addressFamily === 6) {
+    return failReplicaAddressValidation(
+      'ipv6-unsupported',
+      `IPv6 TigerBeetle replica addresses are not supported: ${address}`,
+      { configuredAddress, address },
+    )
+  }
+  if (/^\d+$/.test(address)) {
+    return Result.map(parsePort(address, address), () => ({
+      _tag: 'DirectReplicaAddress' as const,
+      configuredAddress,
+      address,
+    }))
+  }
 
-    const separator = address.lastIndexOf(':')
-    if (separator <= 0 || separator !== address.indexOf(':')) {
-      return yield* Effect.fail(
-        operationalError(
-          'journal',
-          'resolve-replica-addresses',
-          `invalid TigerBeetle replica address: ${configuredAddress}`,
-        ),
-      )
+  const separator = address.lastIndexOf(':')
+  if (separator <= 0 || separator !== address.indexOf(':')) {
+    return failReplicaAddressValidation(
+      'invalid-address',
+      `invalid TigerBeetle replica address: ${configuredAddress}`,
+      { configuredAddress, address },
+    )
+  }
+  const hostname = address.slice(0, separator)
+  const hostnameFamily = isIP(hostname)
+  if (hostnameFamily === 6) {
+    return failReplicaAddressValidation(
+      'ipv6-unsupported',
+      `IPv6 TigerBeetle replica addresses are not supported: ${address}`,
+      { configuredAddress, address, hostname },
+    )
+  }
+  return Result.map(parsePort(address.slice(separator + 1), address), (port): ReplicaEndpoint => {
+    if (hostnameFamily === 4) {
+      return {
+        _tag: 'DirectReplicaAddress',
+        configuredAddress,
+        address: `${hostname}:${port}`,
+      }
     }
-    const hostname = address.slice(0, separator)
-    const port = yield* parsePort(address.slice(separator + 1), address)
-    const hostnameFamily = isIP(hostname)
-    if (hostnameFamily === 4) return [`${hostname}:${port}`]
-    if (hostnameFamily === 6) {
-      return yield* Effect.fail(
-        operationalError(
-          'journal',
-          'resolve-replica-addresses',
-          `IPv6 TigerBeetle replica addresses are not supported: ${address}`,
-        ),
-      )
-    }
-
-    const ipv4Addresses = (yield* resolveHostname(hostname)).filter((value) => isIP(value) === 4)
-    if (ipv4Addresses.length === 0) {
-      return yield* Effect.fail(
-        operationalError(
-          'journal',
-          'resolve-replica-addresses',
-          `TigerBeetle replica hostname has no IPv4 address: ${hostname}`,
-        ),
-      )
-    }
-    if (ipv4Addresses.length !== 1) {
-      return yield* Effect.fail(
-        operationalError(
-          'journal',
-          'resolve-replica-addresses',
-          `TigerBeetle replica hostname must resolve to exactly one IPv4 address: ${hostname}`,
-        ),
-      )
-    }
-    return [`${ipv4Addresses[0]}:${port}`]
+    return { _tag: 'ReplicaHostname', configuredAddress, hostname, port }
   })
+}
+
+export const parseReplicaEndpoints = (
+  configuredAddresses: readonly string[],
+): Result.Result<readonly ReplicaEndpoint[], ReplicaAddressValidationError> =>
+  configuredAddresses.length === 0
+    ? failReplicaAddressValidation('empty-addresses', 'at least one TigerBeetle replica address is required', {
+        configuredAddresses,
+      })
+    : Result.all(configuredAddresses.map(parseReplicaEndpoint))
+
+export const validateResolvedReplicaEndpoint = (
+  endpoint: ReplicaEndpoint,
+  resolvedAddresses: readonly string[],
+): Result.Result<string, ReplicaAddressValidationError> => {
+  if (endpoint._tag === 'DirectReplicaAddress') return Result.succeed(endpoint.address)
+
+  const ipv4Addresses = resolvedAddresses.filter((value) => isIP(value) === 4)
+  if (ipv4Addresses.length === 0) {
+    return failReplicaAddressValidation(
+      'no-ipv4-address',
+      `TigerBeetle replica hostname has no IPv4 address: ${endpoint.hostname}`,
+      { endpoint, resolvedAddresses },
+    )
+  }
+  if (ipv4Addresses.length !== 1) {
+    return failReplicaAddressValidation(
+      'multiple-ipv4-addresses',
+      `TigerBeetle replica hostname must resolve to exactly one IPv4 address: ${endpoint.hostname}`,
+      { endpoint, resolvedAddresses, ipv4Addresses },
+    )
+  }
+  return Result.succeed(`${ipv4Addresses[0]}:${endpoint.port}`)
+}
+
+export const validateResolvedReplicaAddresses = (
+  addresses: readonly string[],
+): Result.Result<string[], ReplicaAddressValidationError> => {
+  if (addresses.length === 0) {
+    return failReplicaAddressValidation('empty-addresses', 'at least one TigerBeetle replica address is required', {
+      addresses,
+    })
+  }
+  const duplicateAddress = addresses.find((address, index) => addresses.indexOf(address) !== index)
+  if (duplicateAddress !== undefined) {
+    return failReplicaAddressValidation(
+      'duplicate-address',
+      'TigerBeetle replica hostnames resolved to duplicate IPv4 addresses',
+      { addresses, duplicateAddress },
+    )
+  }
+  return Result.succeed([...addresses])
+}
+
+const resolveReplicaEndpoint = (
+  endpoint: ReplicaEndpoint,
+  resolveHostname: ResolveHostname,
+): Effect.Effect<string, OperationalError> =>
+  endpoint._tag === 'DirectReplicaAddress'
+    ? replicaAddressBoundary(validateResolvedReplicaEndpoint(endpoint, []))
+    : resolveHostname(endpoint.hostname).pipe(
+        Effect.flatMap((addresses) => replicaAddressBoundary(validateResolvedReplicaEndpoint(endpoint, addresses))),
+      )
 
 export const resolveReplicaAddresses = (
   configuredAddresses: readonly string[],
   resolveHostname: ResolveHostname = lookupIpv4,
 ): Effect.Effect<string[], OperationalError> =>
-  configuredAddresses.length === 0
-    ? Effect.fail(
-        operationalError(
-          'journal',
-          'resolve-replica-addresses',
-          'at least one TigerBeetle replica address is required',
-        ),
-      )
-    : Effect.forEach(configuredAddresses, (address) => resolveReplicaAddress(address, resolveHostname), {
+  replicaAddressBoundary(parseReplicaEndpoints(configuredAddresses)).pipe(
+    Effect.flatMap((endpoints) =>
+      Effect.forEach(endpoints, (endpoint) => resolveReplicaEndpoint(endpoint, resolveHostname), {
         concurrency: 'unbounded',
-      }).pipe(
-        Effect.flatMap((resolved) => {
-          const addresses = resolved.flat()
-          if (new Set(addresses).size !== addresses.length) {
-            return Effect.fail(
-              operationalError(
-                'journal',
-                'resolve-replica-addresses',
-                'TigerBeetle replica hostnames resolved to duplicate IPv4 addresses',
-              ),
-            )
-          }
-          return Effect.succeed(addresses)
-        }),
-      )
+      }),
+    ),
+    Effect.flatMap((addresses) => replicaAddressBoundary(validateResolvedReplicaAddresses(addresses))),
+  )
 
 export interface JournalDependencies {
   readonly createClient: (options: ClientInitArgs) => TigerBeetleClient
@@ -164,110 +246,151 @@ export interface TigerBeetleRequestClient {
   ) => Effect.Effect<A, OperationalError>
 }
 
+type AcquireTigerBeetleClient = Effect.Effect<TigerBeetleClient, OperationalError, Scope.Scope>
+type TigerBeetleClientRef = ScopedRef.ScopedRef<Option.Option<TigerBeetleClient>>
+
+const closeTigerBeetleClient = (client: TigerBeetleClient): Effect.Effect<void> =>
+  Effect.try({
+    try: () => client.destroy(),
+    catch: (cause) => operationalError('journal', 'close', 'failed to close TigerBeetle client', cause),
+  }).pipe(
+    Effect.catch((error) =>
+      Effect.logWarning('TigerBeetle client close failed').pipe(
+        Effect.annotateLogs({ component: error.component, operation: error.operation, error: error.message }),
+      ),
+    ),
+  )
+
+const connectTigerBeetleClient = (
+  config: Pick<RuntimeConfig, 'operationTimeoutMs' | 'tigerBeetle'>,
+  dependencies: JournalDependencies,
+): Effect.Effect<TigerBeetleClient, OperationalError> =>
+  dependencies.resolveReplicaAddresses(config.tigerBeetle.replicaAddresses).pipe(
+    Effect.flatMap((replicaAddresses) =>
+      Effect.try({
+        try: () =>
+          dependencies.createClient({
+            cluster_id: config.tigerBeetle.clusterId,
+            replica_addresses: replicaAddresses,
+          }),
+        catch: (cause) => retryableOperationalError('journal', 'connect', 'failed to create TigerBeetle client', cause),
+      }),
+    ),
+    Effect.timeoutOrElse({
+      duration: config.operationTimeoutMs,
+      orElse: () =>
+        Effect.fail(
+          retryableOperationalError(
+            'journal',
+            'connect',
+            `TigerBeetle client creation timed out after ${config.operationTimeoutMs}ms`,
+          ),
+        ),
+    }),
+  )
+
+const acquireTigerBeetleClient = (
+  config: Pick<RuntimeConfig, 'operationTimeoutMs' | 'tigerBeetle'>,
+  dependencies: JournalDependencies,
+): AcquireTigerBeetleClient =>
+  Effect.acquireRelease(connectTigerBeetleClient(config, dependencies), closeTigerBeetleClient)
+
+const requireInstalledTigerBeetleClient = (
+  clients: TigerBeetleClientRef,
+): Effect.Effect<TigerBeetleClient, OperationalError> =>
+  ScopedRef.get(clients).pipe(
+    Effect.flatMap(
+      Option.match({
+        onSome: (client) => Effect.succeed(client),
+        onNone: () => Effect.fail(retryableOperationalError('journal', 'connect', 'TigerBeetle client is unavailable')),
+      }),
+    ),
+  )
+
+const installMissingTigerBeetleClient = (
+  clients: TigerBeetleClientRef,
+  acquireClient: AcquireTigerBeetleClient,
+): Effect.Effect<TigerBeetleClient, OperationalError> =>
+  ScopedRef.get(clients).pipe(
+    Effect.flatMap(
+      Option.match({
+        onSome: (client) => Effect.succeed(client),
+        onNone: () =>
+          ScopedRef.set(clients, acquireClient.pipe(Effect.map(Option.some))).pipe(
+            Effect.andThen(requireInstalledTigerBeetleClient(clients)),
+          ),
+      }),
+    ),
+  )
+
+const getTigerBeetleClient = (
+  clients: TigerBeetleClientRef,
+  clientState: Semaphore.Semaphore,
+  acquireClient: AcquireTigerBeetleClient,
+): Effect.Effect<TigerBeetleClient, OperationalError> =>
+  ScopedRef.get(clients).pipe(
+    Effect.flatMap(
+      Option.match({
+        onSome: (client) => Effect.succeed(client),
+        onNone: () => clientState.withPermit(installMissingTigerBeetleClient(clients, acquireClient)),
+      }),
+    ),
+  )
+
+const invalidateTigerBeetleClient = (
+  clients: TigerBeetleClientRef,
+  clientState: Semaphore.Semaphore,
+  active: TigerBeetleClient,
+  trigger: string,
+): Effect.Effect<void> =>
+  clientState
+    .withPermitsIfAvailable(1)(
+      ScopedRef.get(clients).pipe(
+        Effect.flatMap((current) =>
+          Option.isSome(current) && current.value === active
+            ? ScopedRef.set(clients, Effect.succeed(Option.none<TigerBeetleClient>())).pipe(
+                Effect.andThen(
+                  Effect.logWarning('TigerBeetle client invalidated').pipe(Effect.annotateLogs({ trigger })),
+                ),
+              )
+            : Effect.void,
+        ),
+      ),
+    )
+    .pipe(Effect.asVoid)
+
+const tigerBeetleRequest = <A>(
+  getClient: Effect.Effect<TigerBeetleClient, OperationalError>,
+  invalidateClient: (active: TigerBeetleClient, trigger: string) => Effect.Effect<void>,
+  operation: string,
+  execute: (active: TigerBeetleClient) => Promise<A>,
+): Effect.Effect<A, OperationalError> =>
+  getClient.pipe(
+    Effect.flatMap((active) =>
+      Effect.tryPromise({
+        try: () => execute(active),
+        catch: (cause) => retryableOperationalError('journal', operation, `TigerBeetle ${operation} failed`, cause),
+      }).pipe(
+        Effect.onInterrupt(() => invalidateClient(active, `interrupted:${operation}`)),
+        Effect.tapError(() => invalidateClient(active, `failed:${operation}`)),
+      ),
+    ),
+  )
+
 export const makeTigerBeetleRequestClient = (
   config: Pick<RuntimeConfig, 'operationTimeoutMs' | 'tigerBeetle'>,
   dependencies: JournalDependencies = defaultDependencies,
 ) =>
   Effect.gen(function* () {
-    const acquireClient = Effect.acquireRelease(
-      dependencies.resolveReplicaAddresses(config.tigerBeetle.replicaAddresses).pipe(
-        Effect.flatMap((replicaAddresses) =>
-          Effect.try({
-            try: () =>
-              dependencies.createClient({
-                cluster_id: config.tigerBeetle.clusterId,
-                replica_addresses: replicaAddresses,
-              }),
-            catch: (cause) =>
-              retryableOperationalError('journal', 'connect', 'failed to create TigerBeetle client', cause),
-          }),
-        ),
-        Effect.timeoutOrElse({
-          duration: config.operationTimeoutMs,
-          orElse: () =>
-            Effect.fail(
-              retryableOperationalError(
-                'journal',
-                'connect',
-                `TigerBeetle client creation timed out after ${config.operationTimeoutMs}ms`,
-              ),
-            ),
-        }),
-      ),
-      (client) =>
-        Effect.try({
-          try: () => client.destroy(),
-          catch: (cause) => operationalError('journal', 'close', 'failed to close TigerBeetle client', cause),
-        }).pipe(
-          Effect.catch((error) =>
-            Effect.logWarning('TigerBeetle client close failed').pipe(
-              Effect.annotateLogs({ component: error.component, operation: error.operation, error: error.message }),
-            ),
-          ),
-        ),
-    )
+    const acquireClient = acquireTigerBeetleClient(config, dependencies)
     const clients = yield* ScopedRef.fromAcquire(acquireClient.pipe(Effect.map(Option.some)))
     const clientState = yield* Semaphore.make(1)
-    const installClient = ScopedRef.set(clients, acquireClient.pipe(Effect.map(Option.some)))
-    const getInstalledClient = ScopedRef.get(clients).pipe(
-      Effect.flatMap(
-        Option.match({
-          onSome: Effect.succeed,
-          onNone: () =>
-            Effect.fail(retryableOperationalError('journal', 'connect', 'TigerBeetle client is unavailable')),
-        }),
-      ),
-    )
-    const getClient = ScopedRef.get(clients).pipe(
-      Effect.flatMap(
-        Option.match({
-          onSome: Effect.succeed,
-          onNone: () =>
-            clientState.withPermit(
-              ScopedRef.get(clients).pipe(
-                Effect.flatMap(
-                  Option.match({
-                    onSome: Effect.succeed,
-                    onNone: () => installClient.pipe(Effect.andThen(getInstalledClient)),
-                  }),
-                ),
-              ),
-            ),
-        }),
-      ),
-    )
-    const invalidateClient = (active: TigerBeetleClient, trigger: string): Effect.Effect<void> =>
-      clientState
-        .withPermitsIfAvailable(1)(
-          ScopedRef.get(clients).pipe(
-            Effect.flatMap((current) =>
-              Option.isSome(current) && current.value === active
-                ? ScopedRef.set(clients, Effect.succeed(Option.none<TigerBeetleClient>())).pipe(
-                    Effect.andThen(
-                      Effect.logWarning('TigerBeetle client invalidated').pipe(Effect.annotateLogs({ trigger })),
-                    ),
-                  )
-                : Effect.void,
-            ),
-          ),
-        )
-        .pipe(Effect.asVoid)
+    const getClient = getTigerBeetleClient(clients, clientState, acquireClient)
+    const invalidateClient = (active: TigerBeetleClient, trigger: string) =>
+      invalidateTigerBeetleClient(clients, clientState, active, trigger)
     const client: TigerBeetleRequestClient = {
       request: <A>(operation: string, execute: (active: TigerBeetleClient) => Promise<A>) =>
-        getClient.pipe(
-          Effect.flatMap((active) =>
-            Effect.tryPromise({
-              try: () => execute(active),
-              catch: (cause) =>
-                retryableOperationalError('journal', operation, `TigerBeetle ${operation} failed`, cause),
-            }).pipe(
-              Effect.onInterrupt(() => invalidateClient(active, `interrupted:${operation}`)),
-              Effect.catch((error) =>
-                invalidateClient(active, `failed:${operation}`).pipe(Effect.andThen(Effect.fail(error))),
-              ),
-            ),
-          ),
-        ),
+        tigerBeetleRequest(getClient, invalidateClient, operation, execute),
     }
     return client
   })


### PR DESCRIPTION
## Summary

- Parse configured TigerBeetle replica endpoints and validate DNS-resolved IPv4 addresses through total, synchronous `Result` decisions with a closed validation error that retains exact material and becomes the public operational error only at the resource boundary.
- Keep DNS cancellation, client creation, `acquireRelease`, `ScopedRef` replacement, semaphore coordination, interruption invalidation, and finalization in small Effect interpreters while preserving configured replica order and zero automatic request replay.
- Add focused regressions proving deterministic preflight occurs before DNS, in-flight DNS is interrupted, each failed request executes once, replacement is deferred to the next explicit request, and every acquired client is closed exactly once.
- Limit production and test scope to the TigerBeetle resource boundary; no broker, PostgreSQL/reconciler, financial arithmetic, GitOps, qualification, or deployment contract changes.

## Related Issues

PROOMPT-433

## Testing

- `bun test services/bayn/src/resources.test.ts services/bayn/src/ledger.test.ts` — 30 passed, 0 failed, 136 assertions.
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn build`
- `git diff --check origin/main..HEAD`

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (screenshots are not applicable to this service-only change).
- [x] Documentation, release notes, and follow-ups are updated or tracked (PROOMPT-433 tracks this refactor; no user-facing documentation change is required).