### PR TITLE
refactor(bayn): make paper authority functional

### DIFF
--- a/services/bayn/src/db/paper-authority-algebra.test.ts
+++ b/services/bayn/src/db/paper-authority-algebra.test.ts
@@ -1,0 +1,549 @@
+import { describe, expect, test } from 'bun:test'
+
+import { Result } from 'effect'
+
+import { config, fixtureLock, fixtureQualification } from '../app-test-support'
+import { canonicalHashV1 } from '../hash'
+import {
+  Authority,
+  KillState,
+  ReconciliationStatus,
+  type AuthorityState,
+  type PaperAuthorityProofBinding,
+} from '../paper'
+import { makeQualificationResult } from '../qualification'
+import {
+  analyzeQualification,
+  defaultQualificationStatisticsPolicy,
+  type QualificationSeries,
+} from '../qualification-statistics'
+import { fixtureProtocol } from '../test-fixtures'
+import {
+  bindPaperGenerationRuntime,
+  decideObserveGeneration,
+  decidePaperActivation,
+  derivePaperAuthorityGeneration,
+  nextAuthorityVersion,
+  paperActivationEffectiveAuthority,
+  paperAuthorityFailureDetails,
+  requireUnusedAuthorityGeneration,
+  validateAuthorityObservation,
+  validateCurrentGenerationHistory,
+  validateDerivedPaperGeneration,
+  validateLatestExactReconciliation,
+  validateMutationCoverage,
+  validateObserveGenerationRequest,
+  validatePaperGenerationEvidence,
+  validatePaperGenerationFreshness,
+  validatePaperGenerationReplay,
+  validatePaperPrepareGeneration,
+  validatePaperSourceAuthority,
+  type ExactReconciliationFacts,
+  type PaperAuthorityAlgebraFailure,
+  type PaperGenerationEvidenceFacts,
+  type PaperGenerationRuntimeBinding,
+} from './paper-authority-algebra'
+
+const successOf = <A>(result: Result.Result<A, PaperAuthorityAlgebraFailure>): A => {
+  expect(Result.isSuccess(result)).toBe(true)
+  if (Result.isFailure(result)) throw new Error(`expected success, received ${result.failure._tag}`)
+  return result.success
+}
+
+const failureOf = <A>(result: Result.Result<A, PaperAuthorityAlgebraFailure>): PaperAuthorityAlgebraFailure => {
+  expect(Result.isFailure(result)).toBe(true)
+  if (Result.isSuccess(result)) throw new Error('expected failure')
+  return result.failure
+}
+
+const hash = (value: string): string => canonicalHashV1({ value })
+const accountId = 'paper-authority-account'
+const observeGenerationHash = hash('observe-generation')
+const updatedAt = new Date('2026-07-25T20:00:00.000Z')
+const observedAt = new Date('2026-07-25T20:00:01.000Z')
+
+const observeAuthority: AuthorityState = {
+  schemaVersion: 'bayn.paper-authority.v1',
+  generationHash: observeGenerationHash,
+  maximum: Authority.Observe,
+  effective: Authority.Observe,
+  kill: KillState.Clear,
+  version: 1,
+  updatedAt: updatedAt.toISOString(),
+}
+
+const observeHistory = {
+  generationHash: observeGenerationHash,
+  maximum: Authority.Observe,
+  authorityVersion: '1',
+  activatedAt: updatedAt,
+}
+
+const prepareBinding: PaperGenerationRuntimeBinding = {
+  accountId,
+  configuredGenerationHash: observeGenerationHash,
+  qualificationRunId: fixtureQualification.runId,
+}
+
+const proof: PaperAuthorityProofBinding = {
+  schemaVersion: 'bayn.paper-authority-proof-binding.v1',
+  riskPolicyHash: hash('risk-policy'),
+  proofPlanHash: hash('proof-plan'),
+}
+
+const reconciliation: ExactReconciliationFacts = {
+  reconciliationId: hash('reconciliation'),
+  accountId,
+  contentHash: hash('reconciliation-content'),
+  status: ReconciliationStatus.Exact,
+  reconciledAt: new Date('2026-07-25T20:00:00.500Z'),
+}
+
+const qualificationSeries = (runId: string): QualificationSeries => {
+  const sessionDate = (index: number): `${number}-${number}-${number}` => {
+    const date = new Date('2000-01-01T00:00:00.000Z')
+    date.setUTCDate(date.getUTCDate() + index)
+    return date.toISOString().slice(0, 10) as `${number}-${number}-${number}`
+  }
+  const blockCount = 90
+  return {
+    schemaVersion: 'bayn.qualification-series.v1',
+    runId,
+    observations: Array.from({ length: blockCount * 21 + 10 }, (_, index) => {
+      const noise = (((index * 17) % 23) - 11) / 100_000
+      return {
+        sessionDate: sessionDate(index),
+        strategyReturn: 0.0005 + noise,
+        cashReturn: 0,
+        buyAndHoldReturn: 0.00015 + noise * 1.1,
+        directVolatilityReturn: 0.0001 + noise * 0.8,
+      }
+    }),
+    rebalanceExecutionDates: Array.from({ length: blockCount + 1 }, (_, index) => sessionDate(index * 21)),
+  }
+}
+
+const qualifiedAnalysis = analyzeQualification(
+  qualificationSeries(fixtureLock.candidateRunId),
+  defaultQualificationStatisticsPolicy,
+  fixtureLock.priorTrialRunIds,
+)
+const qualifiedResult = makeQualificationResult(
+  fixtureLock,
+  {
+    status: 'PASS',
+    gates: [{ name: 'paper_authority_algebra_fixture', passed: true, actual: 1, required: 1 }],
+  },
+  qualifiedAnalysis,
+)
+
+const evidence: PaperGenerationEvidenceFacts = {
+  lock: fixtureLock,
+  result: qualifiedResult,
+  runStatus: 'COMPLETE',
+  expectedArtifactCount: 3,
+  expectedEventCount: 4,
+  expectedGateCount: 5,
+  artifactCount: 3,
+  eventCount: 4,
+  gateCount: 5,
+  statusCount: 2,
+  writingStatusCount: 1,
+  completeStatusCount: 1,
+  writingDetail: { artifactCount: 3, eventCount: 4, gateCount: 5 },
+  completeDetail: { reconciliationExact: true, verdict: 'PASS' },
+  protocolSchemaVersion: 'bayn.risk-balanced-trend.protocol.v3',
+  strategyName: 'risk-balanced-trend',
+  behaviorHash: config.build.strategyBehaviorHash,
+  parameterHash: config.build.strategyParameterHash,
+  parameters: fixtureProtocol,
+}
+
+describe('PAPER authority algebra', () => {
+  test('decides OBSERVE initialization, exact replay, and monotonic rotation', () => {
+    const observeRequest = successOf(
+      validateObserveGenerationRequest({ generationHash: observeGenerationHash, maximum: Authority.Observe }),
+    )
+    expect(observeRequest).toEqual({ generationHash: observeGenerationHash, maximum: Authority.Observe })
+    expect(successOf(decideObserveGeneration(observeRequest, undefined))).toEqual({
+      _tag: 'InitializeObserveGeneration',
+      generationHash: observeGenerationHash,
+      maximum: Authority.Observe,
+    })
+    expect(successOf(decideObserveGeneration(observeRequest, observeAuthority))).toEqual({
+      _tag: 'ReplayObserveGeneration',
+      current: observeAuthority,
+    })
+
+    const rotatedGenerationHash = hash('rotated-observe-generation')
+    const rotationRequest = successOf(
+      validateObserveGenerationRequest({ generationHash: rotatedGenerationHash, maximum: Authority.Observe }),
+    )
+    expect(successOf(decideObserveGeneration(rotationRequest, observeAuthority))).toEqual({
+      _tag: 'RotateObserveGeneration',
+      current: observeAuthority,
+      generationHash: rotatedGenerationHash,
+      maximum: Authority.Observe,
+      authorityVersion: 2,
+    })
+    expect(
+      failureOf(validateObserveGenerationRequest({ generationHash: hash('paper-request'), maximum: Authority.Paper })),
+    ).toEqual({ _tag: 'ObserveMaximumRequired', maximum: Authority.Paper })
+    expect(
+      failureOf(
+        requireUnusedAuthorityGeneration(rotatedGenerationHash, {
+          ...observeHistory,
+          generationHash: rotatedGenerationHash,
+        }),
+      ),
+    ).toEqual({
+      _tag: 'AuthorityGenerationAlreadyUsed',
+      generationHash: rotatedGenerationHash,
+    })
+    expect(
+      failureOf(
+        decideObserveGeneration(observeRequest, {
+          ...observeAuthority,
+          maximum: Authority.Paper,
+        }),
+      ),
+    ).toEqual({
+      _tag: 'AuthorityMaximumConflict',
+      generationHash: observeGenerationHash,
+      requestedMaximum: Authority.Observe,
+      durableMaximum: Authority.Paper,
+    })
+    const exhausted = failureOf(
+      decideObserveGeneration(rotationRequest, {
+        ...observeAuthority,
+        version: Number.MAX_SAFE_INTEGER,
+      }),
+    )
+    expect(exhausted).toEqual({
+      _tag: 'AuthorityVersionExhausted',
+      generationHash: observeGenerationHash,
+      currentAuthorityVersion: Number.MAX_SAFE_INTEGER,
+    })
+    expect(paperAuthorityFailureDetails(exhausted)).toEqual({
+      failure: 'invariant',
+      message: 'durable authority version is not a safe positive integer',
+    })
+  })
+
+  test('validates database observation time and append-only current history', () => {
+    expect(successOf(validateAuthorityObservation(observeAuthority, observedAt))).toBeUndefined()
+    expect(successOf(validateCurrentGenerationHistory(observeAuthority, observeHistory))).toEqual(observeHistory)
+
+    expect(
+      failureOf(validateAuthorityObservation(observeAuthority, new Date('2026-07-25T19:59:59.999Z'))),
+    ).toMatchObject({
+      _tag: 'AuthorityUpdateAfterObservation',
+      generationHash: observeGenerationHash,
+    })
+    expect(failureOf(validateCurrentGenerationHistory(observeAuthority, undefined))).toEqual({
+      _tag: 'CurrentGenerationHistoryMissing',
+      generationHash: observeGenerationHash,
+    })
+    expect(
+      failureOf(validateCurrentGenerationHistory(observeAuthority, { ...observeHistory, authorityVersion: 'NaN' })),
+    ).toEqual({
+      _tag: 'InvalidGenerationHistoryVersion',
+      generationHash: observeGenerationHash,
+      authorityVersion: 'NaN',
+    })
+    const invalidActivatedAt = new Date(Number.NaN)
+    const invalidTimestamp = failureOf(
+      validateCurrentGenerationHistory(observeAuthority, {
+        ...observeHistory,
+        activatedAt: invalidActivatedAt,
+      }),
+    )
+    expect(invalidTimestamp).toMatchObject({
+      _tag: 'InvalidGenerationHistoryActivatedAt',
+      generationHash: observeGenerationHash,
+      activatedAt: invalidActivatedAt,
+      cause: expect.any(RangeError),
+    })
+    if (invalidTimestamp._tag !== 'InvalidGenerationHistoryActivatedAt') {
+      throw new Error('expected invalid generation history timestamp')
+    }
+    expect(paperAuthorityFailureDetails(invalidTimestamp).cause).toBe(invalidTimestamp.cause)
+    expect(
+      failureOf(
+        validateCurrentGenerationHistory(observeAuthority, {
+          ...observeHistory,
+          generationHash: hash('wrong-history'),
+        }),
+      ),
+    ).toMatchObject({
+      _tag: 'CurrentGenerationHistoryMismatch',
+      currentGenerationHash: observeGenerationHash,
+    })
+  })
+
+  test('binds PREPARE runtime facts and rejects authority drift before evidence reads', () => {
+    expect(
+      successOf(
+        bindPaperGenerationRuntime(
+          {
+            maximumAuthority: Authority.Observe,
+            alpaca: { accountId, authorityGenerationHash: observeGenerationHash },
+            qualificationRunId: fixtureQualification.runId,
+          },
+          Authority.Observe,
+          'PREPARE',
+        ),
+      ),
+    ).toEqual(prepareBinding)
+    expect(successOf(validatePaperSourceAuthority(observeAuthority))).toBeUndefined()
+    expect(successOf(validatePaperPrepareGeneration(observeAuthority, prepareBinding))).toBeUndefined()
+
+    const missing = failureOf(
+      bindPaperGenerationRuntime(
+        {
+          maximumAuthority: Authority.Paper,
+          alpaca: undefined,
+          qualificationRunId: undefined,
+        },
+        Authority.Observe,
+        'PREPARE',
+      ),
+    )
+    expect(missing).toEqual({
+      _tag: 'PaperRuntimeBindingUnavailable',
+      operation: 'PREPARE',
+      expectedMaximum: Authority.Observe,
+      configuredMaximum: Authority.Paper,
+      hasAccountBinding: false,
+      hasQualificationBinding: false,
+    })
+    expect(paperAuthorityFailureDetails(missing).message).toBe(
+      'PAPER PREPARE requires the exact configured authority, account, generation, and qualification binding',
+    )
+    expect(
+      failureOf(
+        validatePaperPrepareGeneration(observeAuthority, {
+          ...prepareBinding,
+          configuredGenerationHash: hash('wrong-configured-generation'),
+        }),
+      ),
+    ).toMatchObject({ _tag: 'PaperPrepareGenerationMismatch' })
+    expect(
+      failureOf(
+        validatePaperSourceAuthority({
+          ...observeAuthority,
+          maximum: Authority.Paper,
+          effective: Authority.Paper,
+        }),
+      ),
+    ).toMatchObject({ _tag: 'PaperSourceAuthorityNotObserve' })
+  })
+
+  test('verifies exact terminal evidence and contains canonicalization failures', () => {
+    expect(failureOf(validatePaperGenerationEvidence(undefined, prepareBinding, config.build))).toEqual({
+      _tag: 'QualificationEvidenceUnavailable',
+      qualificationRunId: prepareBinding.qualificationRunId,
+    })
+    expect(qualifiedAnalysis).toMatchObject({ status: 'PASS', reasonCodes: [] })
+    expect(qualifiedResult).toMatchObject({ verdict: 'QUALIFIED', reasonCodes: [] })
+    expect(successOf(validatePaperGenerationEvidence(evidence, prepareBinding, config.build))).toBe(evidence)
+    expect(
+      failureOf(
+        validatePaperGenerationEvidence({ ...evidence, result: fixtureQualification }, prepareBinding, config.build),
+      ),
+    ).toMatchObject({
+      _tag: 'QualificationEvidenceMismatch',
+      qualificationRunId: prepareBinding.qualificationRunId,
+    })
+
+    interface RecursiveMaterial {
+      self?: RecursiveMaterial
+    }
+    const recursive: RecursiveMaterial = {}
+    recursive.self = recursive
+    const failure = failureOf(
+      validatePaperGenerationEvidence({ ...evidence, parameters: recursive }, prepareBinding, config.build),
+    )
+    expect(failure).toMatchObject({
+      _tag: 'QualificationEvidenceVerificationFailed',
+      cause: expect.any(Error),
+    })
+    if (failure._tag !== 'QualificationEvidenceVerificationFailed') {
+      throw new Error('expected qualification evidence verification failure')
+    }
+    const details = paperAuthorityFailureDetails(failure)
+    expect(details).toMatchObject({
+      failure: 'invariant',
+      message: 'PAPER generation differs from terminal qualification evidence or current strategy build',
+    })
+    expect(details.cause).toBe(failure.cause)
+  })
+
+  test('derives stable generation identity from exact covered reconciliation facts', () => {
+    expect(successOf(validateLatestExactReconciliation(reconciliation, accountId))).toBe(reconciliation)
+    expect(
+      successOf(
+        validateMutationCoverage({ unresolvedCount: 0, latestMutationAt: reconciliation.reconciledAt }, reconciliation),
+      ),
+    ).toBeUndefined()
+    const derived = successOf(
+      derivePaperAuthorityGeneration({
+        current: observeAuthority,
+        proof,
+        binding: prepareBinding,
+        evidence,
+        reconciliation,
+        build: config.build,
+      }),
+    )
+    const derivationCause = new Error('injected authority derivation defect')
+    const derivationFailure = failureOf(
+      derivePaperAuthorityGeneration({
+        current: observeAuthority,
+        proof,
+        binding: prepareBinding,
+        evidence,
+        reconciliation,
+        build: {
+          get sourceRevision(): string {
+            throw derivationCause
+          },
+          imageRepository: config.build.imageRepository,
+          imageDigest: config.build.imageDigest,
+          strategyBehaviorHash: config.build.strategyBehaviorHash,
+          strategyParameterHash: config.build.strategyParameterHash,
+        },
+      }),
+    )
+    expect(derivationFailure).toEqual({ _tag: 'PaperGenerationDerivationFailed', cause: derivationCause })
+    expect(paperAuthorityFailureDetails(derivationFailure).cause).toBe(derivationCause)
+    const refreshed = successOf(
+      derivePaperAuthorityGeneration({
+        current: observeAuthority,
+        proof,
+        binding: prepareBinding,
+        evidence,
+        reconciliation: {
+          ...reconciliation,
+          reconciliationId: hash('refreshed-reconciliation'),
+          contentHash: hash('refreshed-reconciliation-content'),
+        },
+        build: config.build,
+      }),
+    )
+
+    expect(derived.generation).toMatchObject({
+      maximum: Authority.Paper,
+      previousGenerationHash: observeGenerationHash,
+      qualificationRunId: fixtureQualification.runId,
+      accountId,
+      riskPolicyHash: proof.riskPolicyHash,
+      proofPlanHash: proof.proofPlanHash,
+      reconciliationId: reconciliation.reconciliationId,
+      reconciliationContentHash: reconciliation.contentHash,
+    })
+    expect(refreshed.generation.generationHash).toBe(derived.generation.generationHash)
+    expect(
+      failureOf(
+        validateLatestExactReconciliation({ ...reconciliation, status: ReconciliationStatus.Discrepancy }, accountId),
+      ),
+    ).toMatchObject({ _tag: 'ExactReconciliationUnavailable' })
+    expect(
+      failureOf(validateMutationCoverage({ unresolvedCount: 1, latestMutationAt: null }, reconciliation)),
+    ).toMatchObject({ _tag: 'MutationCoverageIncomplete', unresolvedCount: 1 })
+    expect(
+      failureOf(
+        validatePaperGenerationFreshness(
+          reconciliation,
+          new Date(reconciliation.reconciledAt.getTime() + config.reconciliationStaleThresholdMs),
+          config.reconciliationStaleThresholdMs,
+        ),
+      ),
+    ).toMatchObject({ _tag: 'ReconciliationNotFresh' })
+  })
+
+  test('decides activation replay byte-stably and preserves an active kill', () => {
+    const derived = successOf(
+      derivePaperAuthorityGeneration({
+        current: observeAuthority,
+        proof,
+        binding: prepareBinding,
+        evidence,
+        reconciliation,
+        build: config.build,
+      }),
+    )
+    const activationBinding = {
+      ...prepareBinding,
+      configuredGenerationHash: derived.generation.generationHash,
+    }
+    const paperAuthority: AuthorityState = {
+      ...observeAuthority,
+      generationHash: derived.generation.generationHash,
+      maximum: Authority.Paper,
+      effective: Authority.Paper,
+      version: 2,
+      updatedAt: observedAt.toISOString(),
+    }
+
+    expect(successOf(nextAuthorityVersion(observeAuthority))).toBe(2)
+    expect(successOf(decidePaperActivation(observeAuthority, activationBinding))).toEqual({
+      _tag: 'ActivatePaperGeneration',
+      current: observeAuthority,
+      authorityVersion: 2,
+    })
+    const exhaustedAuthority = { ...observeAuthority, version: Number.MAX_SAFE_INTEGER }
+    const exhausted = failureOf(decidePaperActivation(exhaustedAuthority, activationBinding))
+    expect(exhausted).toEqual({
+      _tag: 'AuthorityVersionExhausted',
+      generationHash: observeGenerationHash,
+      currentAuthorityVersion: Number.MAX_SAFE_INTEGER,
+    })
+    expect(paperAuthorityFailureDetails(exhausted)).toEqual({
+      failure: 'invariant',
+      message: 'durable authority version is not a safe positive integer',
+    })
+    expect(successOf(validateDerivedPaperGeneration(derived.generation, activationBinding))).toBeUndefined()
+    expect(successOf(decidePaperActivation(paperAuthority, activationBinding))).toEqual({
+      _tag: 'ReplayPaperGeneration',
+      current: paperAuthority,
+    })
+    expect(
+      failureOf(
+        decidePaperActivation(
+          { ...paperAuthority, generationHash: hash('different-durable-paper-generation') },
+          activationBinding,
+        ),
+      ),
+    ).toMatchObject({
+      _tag: 'DurablePaperGenerationMismatch',
+      configuredGenerationHash: activationBinding.configuredGenerationHash,
+    })
+    expect(
+      successOf(validatePaperGenerationReplay(derived.generation, activationBinding, proof, config.build)),
+    ).toBeUndefined()
+    expect(
+      failureOf(
+        validatePaperGenerationReplay(
+          derived.generation,
+          activationBinding,
+          { ...proof, proofPlanHash: hash('changed-proof-plan') },
+          config.build,
+        ),
+      ),
+    ).toMatchObject({ _tag: 'PaperGenerationReplayMismatch' })
+    expect(
+      failureOf(
+        validateDerivedPaperGeneration(derived.generation, {
+          ...activationBinding,
+          configuredGenerationHash: hash('different-derived-paper-generation'),
+        }),
+      ),
+    ).toMatchObject({
+      _tag: 'DerivedPaperGenerationMismatch',
+      derivedGenerationHash: derived.generation.generationHash,
+    })
+    expect(paperActivationEffectiveAuthority(KillState.Clear)).toBe(Authority.Paper)
+    expect(paperActivationEffectiveAuthority(KillState.Active)).toBe(Authority.Observe)
+  })
+})

--- a/services/bayn/src/db/paper-authority-algebra.ts
+++ b/services/bayn/src/db/paper-authority-algebra.ts
@@ -1,0 +1,713 @@
+import { Result } from 'effect'
+
+import type { RuntimeBuildMetadata } from '../config'
+import { makeStrategyProtocolHash } from '../contracts'
+import { canonicalHashV1 } from '../hash'
+import {
+  Authority,
+  KillState,
+  ReconciliationStatus,
+  makePaperAuthorityGeneration,
+  type AuthorityState,
+  type PaperAuthorityGeneration,
+  type PaperAuthorityProofBinding,
+} from '../paper'
+import type { QualificationLock, QualificationResult } from '../qualification'
+
+export interface AuthorityGenerationHistoryFacts {
+  readonly generationHash: string
+  readonly maximum: Authority
+  readonly authorityVersion: string
+  readonly activatedAt: Date
+}
+
+export interface PaperGenerationRuntimeBinding {
+  readonly accountId: string
+  readonly configuredGenerationHash: string
+  readonly qualificationRunId: string
+}
+
+export interface PaperGenerationRuntimeFacts {
+  readonly maximumAuthority: Authority
+  readonly alpaca:
+    | {
+        readonly accountId: string
+        readonly authorityGenerationHash: string
+      }
+    | undefined
+  readonly qualificationRunId: string | undefined
+}
+
+export interface PaperGenerationEvidenceFacts {
+  readonly lock: QualificationLock
+  readonly result: QualificationResult
+  readonly runStatus: 'WRITING' | 'COMPLETE'
+  readonly expectedArtifactCount: number
+  readonly expectedEventCount: number
+  readonly expectedGateCount: number
+  readonly artifactCount: number
+  readonly eventCount: number
+  readonly gateCount: number
+  readonly statusCount: number
+  readonly writingStatusCount: number
+  readonly completeStatusCount: number
+  readonly writingDetail: unknown
+  readonly completeDetail: unknown
+  readonly protocolSchemaVersion: 'bayn.risk-balanced-trend.protocol.v2' | 'bayn.risk-balanced-trend.protocol.v3'
+  readonly strategyName: 'risk-balanced-trend'
+  readonly behaviorHash: string
+  readonly parameterHash: string
+  readonly parameters: unknown
+}
+
+export interface ExactReconciliationFacts {
+  readonly reconciliationId: string
+  readonly accountId: string
+  readonly contentHash: string
+  readonly status: ReconciliationStatus
+  readonly reconciledAt: Date
+}
+
+export interface MutationBaselineFacts {
+  readonly unresolvedCount: number
+  readonly latestMutationAt: Date | null
+}
+
+export interface DerivedPaperGeneration {
+  readonly current: AuthorityState
+  readonly generation: PaperAuthorityGeneration
+  readonly reconciliation: ExactReconciliationFacts
+}
+
+type AuthorityBuildFacts = Pick<
+  RuntimeBuildMetadata,
+  'sourceRevision' | 'imageRepository' | 'imageDigest' | 'strategyBehaviorHash' | 'strategyParameterHash'
+>
+
+export interface ObserveGenerationRequest {
+  readonly generationHash: string
+  readonly maximum: Authority.Observe
+}
+
+export type ObserveGenerationDecision =
+  | {
+      readonly _tag: 'InitializeObserveGeneration'
+      readonly generationHash: string
+      readonly maximum: Authority.Observe
+    }
+  | {
+      readonly _tag: 'ReplayObserveGeneration'
+      readonly current: AuthorityState
+    }
+  | {
+      readonly _tag: 'RotateObserveGeneration'
+      readonly current: AuthorityState
+      readonly generationHash: string
+      readonly maximum: Authority.Observe
+      readonly authorityVersion: number
+    }
+
+export type PaperActivationDecision =
+  | {
+      readonly _tag: 'ActivatePaperGeneration'
+      readonly current: AuthorityState
+      readonly authorityVersion: number
+    }
+  | { readonly _tag: 'ReplayPaperGeneration'; readonly current: AuthorityState }
+
+export type PaperAuthorityAlgebraFailure =
+  | { readonly _tag: 'ObserveMaximumRequired'; readonly maximum: Authority }
+  | { readonly _tag: 'CurrentGenerationHistoryMissing'; readonly generationHash: string }
+  | {
+      readonly _tag: 'InvalidGenerationHistoryVersion'
+      readonly generationHash: string
+      readonly authorityVersion: string
+    }
+  | {
+      readonly _tag: 'InvalidGenerationHistoryActivatedAt'
+      readonly generationHash: string
+      readonly activatedAt: Date
+      readonly cause: unknown
+    }
+  | {
+      readonly _tag: 'CurrentGenerationHistoryMismatch'
+      readonly currentGenerationHash: string
+      readonly historyGenerationHash: string
+      readonly currentMaximum: Authority
+      readonly historyMaximum: Authority
+      readonly currentVersion: number
+      readonly historyVersion: number
+      readonly currentUpdatedAt: string
+      readonly historyActivatedAt: string
+    }
+  | {
+      readonly _tag: 'AuthorityUpdateAfterObservation'
+      readonly generationHash: string
+      readonly updatedAt: Date
+      readonly observedAt: Date
+    }
+  | {
+      readonly _tag: 'AuthorityVersionExhausted'
+      readonly generationHash: string
+      readonly currentAuthorityVersion: number
+    }
+  | { readonly _tag: 'AuthorityGenerationAlreadyUsed'; readonly generationHash: string }
+  | {
+      readonly _tag: 'AuthorityMaximumConflict'
+      readonly generationHash: string
+      readonly requestedMaximum: Authority
+      readonly durableMaximum: Authority
+    }
+  | {
+      readonly _tag: 'PaperRuntimeBindingUnavailable'
+      readonly operation: 'PREPARE' | 'activation'
+      readonly expectedMaximum: Authority
+      readonly configuredMaximum: Authority
+      readonly hasAccountBinding: boolean
+      readonly hasQualificationBinding: boolean
+    }
+  | {
+      readonly _tag: 'PaperSourceAuthorityNotObserve'
+      readonly generationHash: string
+      readonly maximum: Authority
+      readonly effective: Authority
+    }
+  | {
+      readonly _tag: 'PaperPrepareGenerationMismatch'
+      readonly currentGenerationHash: string
+      readonly configuredGenerationHash: string
+    }
+  | { readonly _tag: 'QualificationEvidenceUnavailable'; readonly qualificationRunId: string }
+  | {
+      readonly _tag: 'QualificationEvidenceVerificationFailed'
+      readonly qualificationRunId: string
+      readonly cause: unknown
+    }
+  | {
+      readonly _tag: 'QualificationEvidenceMismatch'
+      readonly qualificationRunId: string
+      readonly evidenceRunId: string
+      readonly evidenceLockId: string
+      readonly behaviorHash: string
+      readonly parameterHash: string
+    }
+  | {
+      readonly _tag: 'ExactReconciliationUnavailable'
+      readonly accountId: string
+      readonly reconciliationId: string | undefined
+      readonly reconciliationAccountId: string | undefined
+      readonly status: ReconciliationStatus | undefined
+    }
+  | {
+      readonly _tag: 'MutationCoverageIncomplete'
+      readonly unresolvedCount: number
+      readonly latestMutationAt: Date | null
+      readonly reconciledAt: Date
+    }
+  | { readonly _tag: 'PaperGenerationDerivationFailed'; readonly cause: unknown }
+  | {
+      readonly _tag: 'ReconciliationNotFresh'
+      readonly reconciledAt: Date
+      readonly observedAt: Date
+      readonly staleThresholdMs: number
+    }
+  | {
+      readonly _tag: 'DurablePaperGenerationMismatch'
+      readonly durableGenerationHash: string
+      readonly configuredGenerationHash: string
+    }
+  | {
+      readonly _tag: 'PaperGenerationReplayMismatch'
+      readonly generationHash: string
+      readonly accountId: string
+      readonly qualificationRunId: string
+    }
+  | {
+      readonly _tag: 'DerivedPaperGenerationMismatch'
+      readonly derivedGenerationHash: string
+      readonly configuredGenerationHash: string
+    }
+
+export interface PaperAuthorityFailureDetails {
+  readonly failure: 'conflict' | 'decode' | 'invariant'
+  readonly message: string
+  readonly cause?: unknown
+}
+
+const fail = <A>(failure: PaperAuthorityAlgebraFailure): Result.Result<A, PaperAuthorityAlgebraFailure> =>
+  Result.fail(failure)
+
+export const validateObserveGenerationRequest = (input: {
+  readonly generationHash: string
+  readonly maximum: Authority
+}): Result.Result<ObserveGenerationRequest, PaperAuthorityAlgebraFailure> =>
+  input.maximum === Authority.Observe
+    ? Result.succeed({ generationHash: input.generationHash, maximum: Authority.Observe })
+    : fail({ _tag: 'ObserveMaximumRequired', maximum: input.maximum })
+
+export const nextAuthorityVersion = (current: {
+  readonly generationHash: string
+  readonly version: number
+}): Result.Result<number, PaperAuthorityAlgebraFailure> => {
+  const authorityVersion = current.version + 1
+  return Number.isSafeInteger(authorityVersion)
+    ? Result.succeed(authorityVersion)
+    : fail({
+        _tag: 'AuthorityVersionExhausted',
+        generationHash: current.generationHash,
+        currentAuthorityVersion: current.version,
+      })
+}
+
+export const decideObserveGeneration = (
+  input: ObserveGenerationRequest,
+  current: AuthorityState | undefined,
+): Result.Result<ObserveGenerationDecision, PaperAuthorityAlgebraFailure> => {
+  if (current === undefined) {
+    return Result.succeed({
+      _tag: 'InitializeObserveGeneration',
+      generationHash: input.generationHash,
+      maximum: input.maximum,
+    })
+  }
+  if (current.generationHash === input.generationHash) {
+    if (current.maximum !== input.maximum) {
+      return fail({
+        _tag: 'AuthorityMaximumConflict',
+        generationHash: input.generationHash,
+        requestedMaximum: input.maximum,
+        durableMaximum: current.maximum,
+      })
+    }
+    return Result.succeed({ _tag: 'ReplayObserveGeneration', current })
+  }
+  return Result.map(
+    nextAuthorityVersion(current),
+    (authorityVersion): ObserveGenerationDecision => ({
+      _tag: 'RotateObserveGeneration',
+      current,
+      generationHash: input.generationHash,
+      maximum: input.maximum,
+      authorityVersion,
+    }),
+  )
+}
+
+export const validateAuthorityObservation = (
+  current: AuthorityState,
+  observedAt: Date,
+): Result.Result<void, PaperAuthorityAlgebraFailure> => {
+  const updatedAt = new Date(current.updatedAt)
+  return updatedAt.getTime() <= observedAt.getTime()
+    ? Result.succeed(undefined)
+    : fail({
+        _tag: 'AuthorityUpdateAfterObservation',
+        generationHash: current.generationHash,
+        updatedAt,
+        observedAt,
+      })
+}
+
+export const validateCurrentGenerationHistory = <History extends AuthorityGenerationHistoryFacts>(
+  current: AuthorityState,
+  history: History | undefined,
+): Result.Result<History, PaperAuthorityAlgebraFailure> => {
+  if (history === undefined) {
+    return fail({ _tag: 'CurrentGenerationHistoryMissing', generationHash: current.generationHash })
+  }
+  const historyVersion = Number(history.authorityVersion)
+  if (!Number.isSafeInteger(historyVersion) || historyVersion <= 0) {
+    return fail({
+      _tag: 'InvalidGenerationHistoryVersion',
+      generationHash: history.generationHash,
+      authorityVersion: history.authorityVersion,
+    })
+  }
+  const historyActivatedAtResult = Result.try({
+    try: () => history.activatedAt.toISOString(),
+    catch: (cause): PaperAuthorityAlgebraFailure => ({
+      _tag: 'InvalidGenerationHistoryActivatedAt',
+      generationHash: history.generationHash,
+      activatedAt: history.activatedAt,
+      cause,
+    }),
+  })
+  if (Result.isFailure(historyActivatedAtResult)) return Result.fail(historyActivatedAtResult.failure)
+  const historyActivatedAt = historyActivatedAtResult.success
+  if (
+    history.generationHash !== current.generationHash ||
+    history.maximum !== current.maximum ||
+    historyVersion > current.version ||
+    historyActivatedAt > current.updatedAt
+  ) {
+    return fail({
+      _tag: 'CurrentGenerationHistoryMismatch',
+      currentGenerationHash: current.generationHash,
+      historyGenerationHash: history.generationHash,
+      currentMaximum: current.maximum,
+      historyMaximum: history.maximum,
+      currentVersion: current.version,
+      historyVersion,
+      currentUpdatedAt: current.updatedAt,
+      historyActivatedAt,
+    })
+  }
+  return Result.succeed(history)
+}
+
+export const requireUnusedAuthorityGeneration = (
+  generationHash: string,
+  existing: AuthorityGenerationHistoryFacts | undefined,
+): Result.Result<void, PaperAuthorityAlgebraFailure> =>
+  existing === undefined ? Result.succeed(undefined) : fail({ _tag: 'AuthorityGenerationAlreadyUsed', generationHash })
+
+export const bindPaperGenerationRuntime = (
+  facts: PaperGenerationRuntimeFacts,
+  expectedMaximum: Authority,
+  operation: 'PREPARE' | 'activation',
+): Result.Result<PaperGenerationRuntimeBinding, PaperAuthorityAlgebraFailure> => {
+  if (
+    facts.maximumAuthority !== expectedMaximum ||
+    facts.alpaca === undefined ||
+    facts.qualificationRunId === undefined
+  ) {
+    return fail({
+      _tag: 'PaperRuntimeBindingUnavailable',
+      operation,
+      expectedMaximum,
+      configuredMaximum: facts.maximumAuthority,
+      hasAccountBinding: facts.alpaca !== undefined,
+      hasQualificationBinding: facts.qualificationRunId !== undefined,
+    })
+  }
+  return Result.succeed({
+    accountId: facts.alpaca.accountId,
+    configuredGenerationHash: facts.alpaca.authorityGenerationHash,
+    qualificationRunId: facts.qualificationRunId,
+  })
+}
+
+export const validatePaperSourceAuthority = (
+  current: AuthorityState,
+): Result.Result<void, PaperAuthorityAlgebraFailure> =>
+  current.maximum === Authority.Observe && current.effective === Authority.Observe
+    ? Result.succeed(undefined)
+    : fail({
+        _tag: 'PaperSourceAuthorityNotObserve',
+        generationHash: current.generationHash,
+        maximum: current.maximum,
+        effective: current.effective,
+      })
+
+export const validatePaperPrepareGeneration = (
+  current: AuthorityState,
+  binding: PaperGenerationRuntimeBinding,
+): Result.Result<void, PaperAuthorityAlgebraFailure> =>
+  current.generationHash === binding.configuredGenerationHash
+    ? Result.succeed(undefined)
+    : fail({
+        _tag: 'PaperPrepareGenerationMismatch',
+        currentGenerationHash: current.generationHash,
+        configuredGenerationHash: binding.configuredGenerationHash,
+      })
+
+export const validatePaperGenerationEvidence = (
+  evidence: PaperGenerationEvidenceFacts | undefined,
+  binding: PaperGenerationRuntimeBinding,
+  build: AuthorityBuildFacts,
+): Result.Result<PaperGenerationEvidenceFacts, PaperAuthorityAlgebraFailure> => {
+  if (evidence === undefined) {
+    return fail({ _tag: 'QualificationEvidenceUnavailable', qualificationRunId: binding.qualificationRunId })
+  }
+  const verified = Result.try({
+    try: () => {
+      const strategyProtocolHash = makeStrategyProtocolHash({
+        name: evidence.strategyName,
+        behaviorHash: evidence.behaviorHash,
+        parameterHash: evidence.parameterHash,
+        parameterSchemaVersion: evidence.protocolSchemaVersion,
+      })
+      return (
+        evidence.result.verdict === 'QUALIFIED' &&
+        evidence.runStatus === 'COMPLETE' &&
+        evidence.expectedArtifactCount === evidence.artifactCount &&
+        evidence.expectedEventCount === evidence.eventCount &&
+        evidence.expectedGateCount === evidence.gateCount &&
+        evidence.statusCount === 2 &&
+        evidence.writingStatusCount === 1 &&
+        evidence.completeStatusCount === 1 &&
+        canonicalHashV1(evidence.writingDetail) ===
+          canonicalHashV1({
+            artifactCount: evidence.expectedArtifactCount,
+            eventCount: evidence.expectedEventCount,
+            gateCount: evidence.expectedGateCount,
+          }) &&
+        canonicalHashV1(evidence.completeDetail) ===
+          canonicalHashV1({
+            reconciliationExact: true,
+            verdict: evidence.result.evaluationVerdict.status,
+          }) &&
+        evidence.result.runId === binding.qualificationRunId &&
+        evidence.result.lockId === evidence.lock.lockId &&
+        evidence.lock.candidateRunId === binding.qualificationRunId &&
+        evidence.protocolSchemaVersion === 'bayn.risk-balanced-trend.protocol.v3' &&
+        evidence.strategyName === 'risk-balanced-trend' &&
+        evidence.behaviorHash === build.strategyBehaviorHash &&
+        evidence.parameterHash === build.strategyParameterHash &&
+        canonicalHashV1(evidence.parameters) === evidence.parameterHash &&
+        strategyProtocolHash === evidence.lock.protocolHash
+      )
+    },
+    catch: (cause): PaperAuthorityAlgebraFailure => ({
+      _tag: 'QualificationEvidenceVerificationFailed',
+      qualificationRunId: binding.qualificationRunId,
+      cause,
+    }),
+  })
+  if (Result.isFailure(verified)) return Result.fail(verified.failure)
+  return verified.success
+    ? Result.succeed(evidence)
+    : fail({
+        _tag: 'QualificationEvidenceMismatch',
+        qualificationRunId: binding.qualificationRunId,
+        evidenceRunId: evidence.result.runId,
+        evidenceLockId: evidence.lock.lockId,
+        behaviorHash: evidence.behaviorHash,
+        parameterHash: evidence.parameterHash,
+      })
+}
+
+export const validateLatestExactReconciliation = (
+  reconciliation: ExactReconciliationFacts | undefined,
+  accountId: string,
+): Result.Result<ExactReconciliationFacts, PaperAuthorityAlgebraFailure> => {
+  if (
+    reconciliation === undefined ||
+    reconciliation.accountId !== accountId ||
+    reconciliation.status !== ReconciliationStatus.Exact
+  ) {
+    return fail({
+      _tag: 'ExactReconciliationUnavailable',
+      accountId,
+      reconciliationId: reconciliation?.reconciliationId,
+      reconciliationAccountId: reconciliation?.accountId,
+      status: reconciliation?.status,
+    })
+  }
+  return Result.succeed(reconciliation)
+}
+
+export const validateMutationCoverage = (
+  baseline: MutationBaselineFacts,
+  reconciliation: ExactReconciliationFacts,
+): Result.Result<void, PaperAuthorityAlgebraFailure> =>
+  baseline.unresolvedCount === 0 &&
+  (baseline.latestMutationAt === null || baseline.latestMutationAt.getTime() <= reconciliation.reconciledAt.getTime())
+    ? Result.succeed(undefined)
+    : fail({
+        _tag: 'MutationCoverageIncomplete',
+        unresolvedCount: baseline.unresolvedCount,
+        latestMutationAt: baseline.latestMutationAt,
+        reconciledAt: reconciliation.reconciledAt,
+      })
+
+export const derivePaperAuthorityGeneration = (input: {
+  readonly current: AuthorityState
+  readonly proof: PaperAuthorityProofBinding
+  readonly binding: PaperGenerationRuntimeBinding
+  readonly evidence: PaperGenerationEvidenceFacts
+  readonly reconciliation: ExactReconciliationFacts
+  readonly build: AuthorityBuildFacts
+}): Result.Result<DerivedPaperGeneration, PaperAuthorityAlgebraFailure> =>
+  Result.try({
+    try: () => ({
+      current: input.current,
+      generation: makePaperAuthorityGeneration({
+        schemaVersion: 'bayn.paper-authority-generation.v2',
+        maximum: Authority.Paper,
+        previousGenerationHash: input.current.generationHash,
+        qualificationRunId: input.evidence.result.runId,
+        qualificationLockId: input.evidence.result.lockId,
+        qualificationResultHash: input.evidence.result.resultHash,
+        protocolHash: input.evidence.lock.protocolHash,
+        qualificationExecutionPolicyHash: input.evidence.lock.policies.execution.contentHash,
+        qualificationSourceRevision: input.evidence.lock.sourceRevision,
+        qualificationImageRepository: input.evidence.lock.image.repository,
+        qualificationImageDigest: input.evidence.lock.image.digest,
+        activationSourceRevision: input.build.sourceRevision,
+        activationImageRepository: input.build.imageRepository,
+        activationImageDigest: input.build.imageDigest,
+        strategyName: input.evidence.strategyName,
+        strategyBehaviorHash: input.evidence.behaviorHash,
+        strategyParameterHash: input.evidence.parameterHash,
+        strategyParameterSchemaVersion: 'bayn.risk-balanced-trend.protocol.v3',
+        accountId: input.binding.accountId,
+        riskPolicyHash: input.proof.riskPolicyHash,
+        proofPlanHash: input.proof.proofPlanHash,
+        reconciliationId: input.reconciliation.reconciliationId,
+        reconciliationContentHash: input.reconciliation.contentHash,
+      }),
+      reconciliation: input.reconciliation,
+    }),
+    catch: (cause): PaperAuthorityAlgebraFailure => ({ _tag: 'PaperGenerationDerivationFailed', cause }),
+  })
+
+export const validatePaperGenerationFreshness = (
+  reconciliation: ExactReconciliationFacts,
+  observedAt: Date,
+  staleThresholdMs: number,
+): Result.Result<Date, PaperAuthorityAlgebraFailure> =>
+  reconciliation.reconciledAt.getTime() <= observedAt.getTime() &&
+  observedAt.getTime() - reconciliation.reconciledAt.getTime() < staleThresholdMs
+    ? Result.succeed(observedAt)
+    : fail({
+        _tag: 'ReconciliationNotFresh',
+        reconciledAt: reconciliation.reconciledAt,
+        observedAt,
+        staleThresholdMs,
+      })
+
+export const decidePaperActivation = (
+  current: AuthorityState,
+  binding: PaperGenerationRuntimeBinding,
+): Result.Result<PaperActivationDecision, PaperAuthorityAlgebraFailure> => {
+  if (current.maximum !== Authority.Paper) {
+    return Result.map(
+      nextAuthorityVersion(current),
+      (authorityVersion): PaperActivationDecision => ({
+        _tag: 'ActivatePaperGeneration',
+        current,
+        authorityVersion,
+      }),
+    )
+  }
+  return current.generationHash === binding.configuredGenerationHash
+    ? Result.succeed({ _tag: 'ReplayPaperGeneration', current })
+    : fail({
+        _tag: 'DurablePaperGenerationMismatch',
+        durableGenerationHash: current.generationHash,
+        configuredGenerationHash: binding.configuredGenerationHash,
+      })
+}
+
+export const validatePaperGenerationReplay = (
+  stored: PaperAuthorityGeneration,
+  binding: PaperGenerationRuntimeBinding,
+  proof: PaperAuthorityProofBinding,
+  build: AuthorityBuildFacts,
+): Result.Result<void, PaperAuthorityAlgebraFailure> =>
+  stored.accountId === binding.accountId &&
+  stored.qualificationRunId === binding.qualificationRunId &&
+  stored.activationSourceRevision === build.sourceRevision &&
+  stored.activationImageRepository === build.imageRepository &&
+  stored.activationImageDigest === build.imageDigest &&
+  stored.strategyBehaviorHash === build.strategyBehaviorHash &&
+  stored.strategyParameterHash === build.strategyParameterHash &&
+  stored.riskPolicyHash === proof.riskPolicyHash &&
+  stored.proofPlanHash === proof.proofPlanHash
+    ? Result.succeed(undefined)
+    : fail({
+        _tag: 'PaperGenerationReplayMismatch',
+        generationHash: stored.generationHash,
+        accountId: binding.accountId,
+        qualificationRunId: binding.qualificationRunId,
+      })
+
+export const validateDerivedPaperGeneration = (
+  generation: PaperAuthorityGeneration,
+  binding: PaperGenerationRuntimeBinding,
+): Result.Result<void, PaperAuthorityAlgebraFailure> =>
+  generation.generationHash === binding.configuredGenerationHash
+    ? Result.succeed(undefined)
+    : fail({
+        _tag: 'DerivedPaperGenerationMismatch',
+        derivedGenerationHash: generation.generationHash,
+        configuredGenerationHash: binding.configuredGenerationHash,
+      })
+
+export const paperActivationEffectiveAuthority = (kill: KillState): Authority =>
+  kill === KillState.Active ? Authority.Observe : Authority.Paper
+
+export const paperAuthorityFailureDetails = (failure: PaperAuthorityAlgebraFailure): PaperAuthorityFailureDetails => {
+  switch (failure._tag) {
+    case 'ObserveMaximumRequired':
+      return { failure: 'invariant', message: 'Phase A authority maximum must be OBSERVE' }
+    case 'CurrentGenerationHistoryMissing':
+      return { failure: 'invariant', message: 'current authority generation lacks immutable history' }
+    case 'InvalidGenerationHistoryVersion':
+      return {
+        failure: 'invariant',
+        message: 'authority generation history version is not a safe positive integer',
+      }
+    case 'InvalidGenerationHistoryActivatedAt':
+      return {
+        failure: 'invariant',
+        message: 'current authority generation history differs from state',
+        cause: failure.cause,
+      }
+    case 'CurrentGenerationHistoryMismatch':
+      return { failure: 'invariant', message: 'current authority generation history differs from state' }
+    case 'AuthorityUpdateAfterObservation':
+      return {
+        failure: 'invariant',
+        message: 'durable authority update follows its database observation time',
+      }
+    case 'AuthorityVersionExhausted':
+      return {
+        failure: 'invariant',
+        message: 'durable authority version is not a safe positive integer',
+      }
+    case 'AuthorityGenerationAlreadyUsed':
+      return { failure: 'conflict', message: 'authority generation hash was already used' }
+    case 'AuthorityMaximumConflict':
+      return { failure: 'conflict', message: 'authority generation maximum conflicts with durable state' }
+    case 'PaperRuntimeBindingUnavailable':
+      return {
+        failure: 'invariant',
+        message: `PAPER ${failure.operation} requires the exact configured authority, account, generation, and qualification binding`,
+      }
+    case 'PaperSourceAuthorityNotObserve':
+      return { failure: 'invariant', message: 'PAPER generation requires current OBSERVE authority' }
+    case 'PaperPrepareGenerationMismatch':
+      return {
+        failure: 'invariant',
+        message: 'PAPER PREPARE current authority differs from the configured OBSERVE generation',
+      }
+    case 'QualificationEvidenceUnavailable':
+      return { failure: 'invariant', message: 'exact terminal qualification evidence is unavailable' }
+    case 'QualificationEvidenceVerificationFailed':
+      return {
+        failure: 'invariant',
+        message: 'PAPER generation differs from terminal qualification evidence or current strategy build',
+        cause: failure.cause,
+      }
+    case 'QualificationEvidenceMismatch':
+      return {
+        failure: 'invariant',
+        message: 'PAPER generation differs from terminal qualification evidence or current strategy build',
+      }
+    case 'ExactReconciliationUnavailable':
+    case 'ReconciliationNotFresh':
+      return {
+        failure: 'invariant',
+        message: 'PAPER generation requires the latest fresh exact account reconciliation',
+      }
+    case 'MutationCoverageIncomplete':
+      return {
+        failure: 'invariant',
+        message: 'PAPER generation requires zero unresolved mutations covered by reconciliation',
+      }
+    case 'PaperGenerationDerivationFailed':
+      return {
+        failure: 'decode',
+        message: 'derived PAPER generation is invalid',
+        cause: failure.cause,
+      }
+    case 'DurablePaperGenerationMismatch':
+      return { failure: 'conflict', message: 'durable PAPER generation differs from the configured generation' }
+    case 'PaperGenerationReplayMismatch':
+      return { failure: 'conflict', message: 'PAPER generation history differs from deterministic replay' }
+    case 'DerivedPaperGenerationMismatch':
+      return { failure: 'invariant', message: 'derived PAPER generation differs from the configured generation' }
+  }
+}

--- a/services/bayn/src/db/paper-store.integration.test.ts
+++ b/services/bayn/src/db/paper-store.integration.test.ts
@@ -2,12 +2,12 @@ import { beforeAll, beforeEach, describe, expect, test } from 'bun:test'
 
 import { NodeServices } from '@effect/platform-node'
 import { PgClient } from '@effect/sql-pg'
-import { Cause, Deferred, Duration, Effect, Exit, Fiber, Layer, ManagedRuntime, Redacted } from 'effect'
+import { Cause, Deferred, Duration, Effect, Exit, Fiber, Layer, ManagedRuntime, Redacted, Result } from 'effect'
 
 import type { RuntimeConfig } from '../config'
 import { makeStrategyProtocolHash } from '../contracts'
 import { operationalError } from '../errors'
-import { WriterFenceLive } from '../execution/writer-fence'
+import { WriterFence, WriterFenceError, WriterFenceLive, type WriterFenceService } from '../execution/writer-fence'
 import { canonicalHashV1 } from '../hash'
 import { hashLedgerPlan } from '../ledger-plan'
 import { Journal, type JournalService } from '../ledger'
@@ -47,7 +47,7 @@ import {
   type ValuationInput,
 } from '../broker/observations'
 import { EvidenceStore, EvidenceStoreLive, PostgresClientLive } from './evidence-store'
-import { PaperStore, PaperStoreLive } from './paper-store'
+import { PaperStore, PaperStoreError, PaperStoreLive } from './paper-store'
 
 const postgresUrl = process.env.BAYN_TEST_POSTGRES_URL
 const testUrl = postgresUrl ?? 'postgresql://bayn:bayn@127.0.0.1:5432/bayn_test'
@@ -247,13 +247,83 @@ const makeStoreRuntime = (control: JournalControl, runtimeConfig: RuntimeConfig 
     ),
   )
 
+type TestTransactionBoundary =
+  | { readonly _tag: 'Return' }
+  | { readonly _tag: 'DieAfterBody'; readonly defect: unknown }
+  | { readonly _tag: 'InterruptAfterBody' }
+
+// Keep a real SQL transaction while bypassing the process-wide writer lease so independent runtimes exercise
+// PaperStore's database authority locks, rollback, and Effect exit channels directly.
+const testTransactionFenceLive = (boundary: TestTransactionBoundary) =>
+  Layer.effect(
+    WriterFence,
+    Effect.gen(function* () {
+      const sql = yield* PgClient.PgClient
+      const [backend] = yield* sql<{ backend_pid: number }>`
+        SELECT pg_backend_pid()::integer AS backend_pid
+      `
+      if (backend === undefined) {
+        return yield* Effect.die(new Error('test transaction fence could not identify its PostgreSQL backend'))
+      }
+      const transaction = <A, E, R>(effect: Effect.Effect<A, E, R>) => {
+        const bounded =
+          boundary._tag === 'Return'
+            ? effect
+            : effect.pipe(
+                Effect.flatMap(() =>
+                  boundary._tag === 'DieAfterBody' ? Effect.die(boundary.defect) : Effect.interrupt,
+                ),
+              )
+        return sql.withTransaction(bounded).pipe(
+          Effect.catchTag('SqlError', (cause) =>
+            Effect.fail(
+              new WriterFenceError({
+                failure: 'unavailable',
+                operation: 'transaction',
+                message: 'test PostgreSQL transaction fence failed',
+                cause,
+              }),
+            ),
+          ),
+        )
+      }
+      return {
+        backendPid: backend.backend_pid,
+        check: Effect.void,
+        transaction,
+      } satisfies WriterFenceService
+    }),
+  )
+
+const makeIndependentStoreRuntime = (
+  control: JournalControl,
+  runtimeConfig: RuntimeConfig,
+  boundary: TestTransactionBoundary = { _tag: 'Return' },
+) =>
+  ManagedRuntime.make(
+    PaperStoreLive(runtimeConfig).pipe(
+      Layer.provideMerge(testTransactionFenceLive(boundary)),
+      Layer.provideMerge(Layer.succeed(Journal, journal(control))),
+      Layer.provideMerge(PostgresClientLive(runtimeConfig)),
+      Layer.provide(NodeServices.layer),
+    ),
+  )
+
 const makeClientRuntime = () => ManagedRuntime.make(PostgresClientLive(config).pipe(Layer.provide(NodeServices.layer)))
 
 const makeEvidenceRuntime = () => ManagedRuntime.make(EvidenceStoreLive(config).pipe(Layer.provide(NodeServices.layer)))
 
+interface AuthorityTupleRow {
+  readonly row: Readonly<Record<string, unknown>>
+  readonly tupleId: string
+}
+
 const readAuthorityTupleEvidence = Effect.gen(function* () {
   const sql = yield* PgClient.PgClient
-  const [evidence] = yield* sql<{ authority: unknown; history: unknown }>`
+  const [evidence] = yield* sql<{
+    authority: readonly AuthorityTupleRow[] | null
+    history: readonly AuthorityTupleRow[] | null
+  }>`
     SELECT
       (
         SELECT jsonb_agg(
@@ -790,6 +860,11 @@ describePostgres('paper accounting persistence', () => {
               version::integer
             FROM authority_state
           `
+          const historyVersions = yield* sql<{ authority_version: number }>`
+            SELECT authority_version::integer
+            FROM authority_generations
+            ORDER BY authority_version
+          `
           return {
             first,
             replay,
@@ -799,6 +874,7 @@ describePostgres('paper accounting persistence', () => {
             beforeReplay,
             afterReplay,
             afterRotation,
+            historyVersions,
           }
         }),
       )
@@ -825,6 +901,8 @@ describePostgres('paper accounting persistence', () => {
       expect(Date.parse(result.rotated.updatedAt)).toBeGreaterThan(Date.parse(result.first.updatedAt))
       expect(result.afterRotation).toMatchObject({ rows: 1, version: 2 })
       expect(result.afterRotation.tuple_id).not.toBe(result.afterReplay.tuple_id)
+      expect(result.historyVersions.map(({ authority_version }) => authority_version)).toEqual([1, 2])
+      expect(result.historyVersions[1]?.authority_version).toBe(result.rotated.version)
     } finally {
       await runtime.dispose()
     }
@@ -1518,23 +1596,7 @@ describePostgres('paper accounting persistence', () => {
             maximum: Authority.Observe,
           })
           const activated = yield* store.activatePaperGeneration(proofBinding(activation))
-          const [beforeReplay] = yield* sql<{
-            authority_tuple: string
-            history_count: number
-            paper_tuple: string
-            reconciliation_content_hash: string
-            reconciliation_id: string
-          }>`
-            SELECT
-              authority.xmin::text AS authority_tuple,
-              paper.xmin::text AS paper_tuple,
-              paper.reconciliation_id,
-              paper.reconciliation_content_hash,
-              (SELECT count(*)::integer FROM authority_generations) AS history_count
-            FROM authority_state AS authority
-            JOIN authority_generations AS paper
-              ON paper.generation_hash = authority.generation_hash
-          `
+          const beforeReplay = yield* readAuthorityTupleEvidence
           yield* seedExactReconciliation(exactReconciliation('paper-replay-later-reconciliation'))
           const replay = yield* store.activatePaperGeneration(proofBinding(activation))
           const changedProof = yield* Effect.flip(
@@ -1543,23 +1605,7 @@ describePostgres('paper accounting persistence', () => {
               proofPlanHash: hash('paper-replay-changed-proof'),
             }),
           )
-          const [afterReplay] = yield* sql<{
-            authority_tuple: string
-            history_count: number
-            paper_tuple: string
-            reconciliation_content_hash: string
-            reconciliation_id: string
-          }>`
-            SELECT
-              authority.xmin::text AS authority_tuple,
-              paper.xmin::text AS paper_tuple,
-              paper.reconciliation_id,
-              paper.reconciliation_content_hash,
-              (SELECT count(*)::integer FROM authority_generations) AS history_count
-            FROM authority_state AS authority
-            JOIN authority_generations AS paper
-              ON paper.generation_hash = authority.generation_hash
-          `
+          const afterReplay = yield* readAuthorityTupleEvidence
           const history = yield* sql<{
             account_id: string | null
             activation_image_digest: string | null
@@ -1622,10 +1668,6 @@ describePostgres('paper accounting persistence', () => {
       expect(result.replay).toEqual(result.activated)
       expect(result.changedProof).toMatchObject({ operation: 'authority', failure: 'conflict' })
       expect(result.afterReplay).toEqual(result.beforeReplay)
-      expect(result.afterReplay).toMatchObject({
-        reconciliation_content_hash: reconciliation.contentHash,
-        reconciliation_id: reconciliation.reconciliationId,
-      })
       expect(Exit.isFailure(result.mutateHistory)).toBe(true)
       expect(Exit.isFailure(result.deleteHistory)).toBe(true)
       expect(Exit.isFailure(result.truncateHistory)).toBe(true)
@@ -1663,11 +1705,159 @@ describePostgres('paper accounting persistence', () => {
           activation_image_digest: config.build.imageDigest,
         },
       ])
+      expect(result.history[1]?.authority_version).toBe(result.activated.version)
       expect(result.activation.qualificationSourceRevision).not.toBe(result.activation.activationSourceRevision)
       expect(result.activation.qualificationImageRepository).not.toBe(result.activation.activationImageRepository)
       expect(result.activation.qualificationImageDigest).not.toBe(result.activation.activationImageDigest)
     } finally {
       await runtime.dispose()
+    }
+  }, 15_000)
+
+  test('rejects PAPER activation version exhaustion without changing authority bytes or xmin', async () => {
+    const initialGenerationHash = hash('paper-version-exhaustion-observe-generation')
+    const reconciliation = exactReconciliation('paper-version-exhaustion')
+    const activation = makeActivation(initialGenerationHash, qualifiedEvidence, reconciliation)
+    const runtime = makeActivationRuntime({ fail: false, planHashes: [] }, activation)
+    try {
+      const result = await runtime.runPromise(
+        Effect.gen(function* () {
+          const store = yield* PaperStore
+          const sql = yield* PgClient.PgClient
+          yield* seedQualificationEvidence(qualifiedEvidence)
+          yield* seedExactReconciliation(reconciliation)
+          yield* store.ensureAuthorityGeneration({
+            generationHash: initialGenerationHash,
+            maximum: Authority.Observe,
+          })
+          yield* sql`ALTER TABLE authority_generations DISABLE TRIGGER authority_generations_append_only`
+          yield* sql`ALTER TABLE authority_state DISABLE TRIGGER authority_transition_only`
+          yield* sql`
+            UPDATE authority_generations
+            SET authority_version = ${Number.MAX_SAFE_INTEGER}
+            WHERE generation_hash = ${initialGenerationHash}
+          `
+          yield* sql`
+            UPDATE authority_state
+            SET version = ${Number.MAX_SAFE_INTEGER}
+            WHERE singleton
+          `
+          yield* sql`ALTER TABLE authority_state ENABLE TRIGGER authority_transition_only`
+          yield* sql`ALTER TABLE authority_generations ENABLE TRIGGER authority_generations_append_only`
+          const before = yield* readAuthorityTupleEvidence
+          const failure = yield* Effect.flip(store.activatePaperGeneration(proofBinding(activation)))
+          const after = yield* readAuthorityTupleEvidence
+          return { after, before, failure }
+        }),
+      )
+
+      expect(result.before.authority?.[0]?.row.version).toBe(Number.MAX_SAFE_INTEGER)
+      expect(result.before.history?.[0]?.row.authority_version).toBe(Number.MAX_SAFE_INTEGER)
+      expect(result.failure).toMatchObject({
+        operation: 'authority',
+        failure: 'invariant',
+        message: 'durable authority version is not a safe positive integer',
+      })
+      expect(result.after).toEqual(result.before)
+    } finally {
+      await runtime.dispose()
+    }
+  }, 15_000)
+
+  test('preserves authority failure causes and rolls back defects and interruptions before commit', async () => {
+    const initialGenerationHash = hash('authority-effect-boundary-observe-generation')
+    const reconciliation = exactReconciliation('authority-effect-boundary')
+    const activation = makeActivation(initialGenerationHash, qualifiedEvidence, reconciliation)
+    const setupRuntime = makeActivationRuntime({ fail: false, planHashes: [] }, activation)
+    try {
+      await setupRuntime.runPromise(
+        Effect.gen(function* () {
+          const store = yield* PaperStore
+          yield* seedQualificationEvidence(qualifiedEvidence)
+          yield* seedExactReconciliation(reconciliation)
+          yield* store.ensureAuthorityGeneration({
+            generationHash: initialGenerationHash,
+            maximum: Authority.Observe,
+          })
+        }),
+      )
+    } finally {
+      await setupRuntime.dispose()
+    }
+
+    const client = makeClientRuntime()
+    const before = await client.runPromise(readAuthorityTupleEvidence)
+    const derivationCause = new Error('injected PAPER generation derivation failure')
+    const validRuntimeConfig = paperRuntimeConfig(activation)
+    const closedFailureRuntime = makeStoreRuntime(
+      { fail: false, planHashes: [] },
+      {
+        ...validRuntimeConfig,
+        build: {
+          get sourceRevision(): string {
+            throw derivationCause
+          },
+          imageRepository: validRuntimeConfig.build.imageRepository,
+          imageDigest: validRuntimeConfig.build.imageDigest,
+          strategyBehaviorHash: validRuntimeConfig.build.strategyBehaviorHash,
+          strategyParameterHash: validRuntimeConfig.build.strategyParameterHash,
+          verification: validRuntimeConfig.build.verification,
+        },
+      },
+    )
+    const defect = new Error('injected post-activation transaction defect')
+    const defectRuntime = makeIndependentStoreRuntime({ fail: false, planHashes: [] }, validRuntimeConfig, {
+      _tag: 'DieAfterBody',
+      defect,
+    })
+    const interruptRuntime = makeIndependentStoreRuntime({ fail: false, planHashes: [] }, validRuntimeConfig, {
+      _tag: 'InterruptAfterBody',
+    })
+    try {
+      const closedExit = await closedFailureRuntime.runPromise(
+        Effect.exit(Effect.flatMap(PaperStore, (store) => store.activatePaperGeneration(proofBinding(activation)))),
+      )
+      expect(Exit.isFailure(closedExit)).toBe(true)
+      if (Exit.isSuccess(closedExit)) throw new Error('expected closed authority failure')
+      const closedError = Cause.findError(closedExit.cause)
+      expect(Result.isSuccess(closedError)).toBe(true)
+      if (Result.isFailure(closedError)) throw new Error('expected typed PaperStoreError')
+      expect(closedError.success).toBeInstanceOf(PaperStoreError)
+      expect(closedError.success).toMatchObject({
+        operation: 'authority',
+        failure: 'decode',
+        message: 'derived PAPER generation is invalid: injected PAPER generation derivation failure',
+      })
+      expect(closedError.success.cause).toBe(derivationCause)
+      expect(Cause.hasDies(closedExit.cause)).toBe(false)
+      expect(await client.runPromise(readAuthorityTupleEvidence)).toEqual(before)
+
+      const defectExit = await defectRuntime.runPromise(
+        Effect.exit(Effect.flatMap(PaperStore, (store) => store.activatePaperGeneration(proofBinding(activation)))),
+      )
+      expect(Exit.isFailure(defectExit)).toBe(true)
+      if (Exit.isSuccess(defectExit)) throw new Error('expected authority transaction defect')
+      const observedDefect = Cause.findDefect(defectExit.cause)
+      expect(Result.isSuccess(observedDefect)).toBe(true)
+      if (Result.isFailure(observedDefect)) throw new Error('expected defect cause')
+      expect(observedDefect.success).toBe(defect)
+      expect(Cause.hasFails(defectExit.cause)).toBe(false)
+      expect(await client.runPromise(readAuthorityTupleEvidence)).toEqual(before)
+
+      const interruptExit = await interruptRuntime.runPromise(
+        Effect.exit(Effect.flatMap(PaperStore, (store) => store.activatePaperGeneration(proofBinding(activation)))),
+      )
+      expect(Exit.isFailure(interruptExit)).toBe(true)
+      if (Exit.isSuccess(interruptExit)) throw new Error('expected authority transaction interruption')
+      expect(Cause.hasInterrupts(interruptExit.cause)).toBe(true)
+      expect(Cause.hasDies(interruptExit.cause)).toBe(false)
+      expect(Cause.hasFails(interruptExit.cause)).toBe(false)
+      expect(await client.runPromise(readAuthorityTupleEvidence)).toEqual(before)
+    } finally {
+      await closedFailureRuntime.dispose()
+      await defectRuntime.dispose()
+      await interruptRuntime.dispose()
+      await client.dispose()
     }
   }, 15_000)
 
@@ -1889,13 +2079,13 @@ describePostgres('paper accounting persistence', () => {
     }
   }, 15_000)
 
-  test('serializes concurrent PAPER activation into one history row and state transition', async () => {
+  test('serializes independent-runtime PAPER activation into one history row and replay-equivalent state', async () => {
     const initialGenerationHash = hash('concurrent-paper-observe-generation')
     const reconciliation = exactReconciliation('concurrent-paper-activation')
     const activation = makeActivation(initialGenerationHash, qualifiedEvidence, reconciliation)
-    const runtime = makeActivationRuntime({ fail: false, planHashes: [] }, activation)
+    const setupRuntime = makeActivationRuntime({ fail: false, planHashes: [] }, activation)
     try {
-      const result = await runtime.runPromise(
+      await setupRuntime.runPromise(
         Effect.gen(function* () {
           const store = yield* PaperStore
           yield* seedQualificationEvidence(qualifiedEvidence)
@@ -1904,12 +2094,33 @@ describePostgres('paper accounting persistence', () => {
             generationHash: initialGenerationHash,
             maximum: Authority.Observe,
           })
-          const states = yield* Effect.all(
-            Array.from({ length: 12 }, () => store.activatePaperGeneration(proofBinding(activation))),
-            { concurrency: 'unbounded' },
-          )
+        }),
+      )
+    } finally {
+      await setupRuntime.dispose()
+    }
+
+    const runtimes = Array.from({ length: 4 }, () =>
+      makeIndependentStoreRuntime({ fail: false, planHashes: [] }, paperRuntimeConfig(activation)),
+    )
+    const client = makeClientRuntime()
+    try {
+      const results = await Promise.all(
+        runtimes.map((runtime) =>
+          runtime.runPromise(
+            Effect.gen(function* () {
+              const fence = yield* WriterFence
+              const store = yield* PaperStore
+              const state = yield* store.activatePaperGeneration(proofBinding(activation))
+              return { backendPid: fence.backendPid, state }
+            }),
+          ),
+        ),
+      )
+      const stored = await client.runPromise(
+        Effect.gen(function* () {
           const sql = yield* PgClient.PgClient
-          const [stored] = yield* sql<{ history_count: number; paper_count: number; version: number }>`
+          const [row] = yield* sql<{ history_count: number; paper_count: number; version: number }>`
             SELECT
               authority.version::integer AS version,
               (SELECT count(*)::integer FROM authority_generations) AS history_count,
@@ -1920,20 +2131,193 @@ describePostgres('paper accounting persistence', () => {
               ) AS paper_count
             FROM authority_state AS authority
           `
-          return { states, stored }
+          const evidence = yield* readAuthorityTupleEvidence
+          return { evidence, row }
         }),
       )
 
-      expect(result.states).toHaveLength(12)
-      expect(new Set(result.states.map((state) => JSON.stringify(state))).size).toBe(1)
-      expect(result.states[0]).toMatchObject({
+      expect(results).toHaveLength(4)
+      expect(new Set(results.map(({ backendPid }) => backendPid)).size).toBe(4)
+      expect(new Set(results.map(({ state }) => JSON.stringify(state))).size).toBe(1)
+      expect(results[0]?.state).toMatchObject({
         maximum: Authority.Paper,
         effective: Authority.Paper,
         version: 2,
       })
-      expect(result.stored).toEqual({ history_count: 2, paper_count: 1, version: 2 })
+      expect(stored.row).toEqual({ history_count: 2, paper_count: 1, version: 2 })
+      expect(stored.evidence.authority).toHaveLength(1)
+      expect(stored.evidence.authority?.[0]).toMatchObject({
+        row: { generation_hash: activation.generationHash, version: 2 },
+        tupleId: expect.any(String),
+      })
+      expect(stored.evidence.history).toHaveLength(2)
+      expect(stored.evidence.history?.[1]).toMatchObject({
+        row: { generation_hash: activation.generationHash, maximum: Authority.Paper },
+        tupleId: expect.any(String),
+      })
     } finally {
-      await runtime.dispose()
+      await Promise.all(runtimes.map((runtime) => runtime.dispose()))
+      await client.dispose()
+    }
+  }, 15_000)
+
+  test('serializes an independent PAPER activation and OBSERVE rotation without mixed history', async () => {
+    const initialGenerationHash = hash('activation-rotation-race-observe-generation')
+    const rotatedGenerationHash = hash('activation-rotation-race-next-observe-generation')
+    const reconciliation = exactReconciliation('activation-rotation-race')
+    const activation = makeActivation(initialGenerationHash, qualifiedEvidence, reconciliation)
+    const setupRuntime = makeActivationRuntime({ fail: false, planHashes: [] }, activation)
+    try {
+      await setupRuntime.runPromise(
+        Effect.gen(function* () {
+          const store = yield* PaperStore
+          yield* seedQualificationEvidence(qualifiedEvidence)
+          yield* seedExactReconciliation(reconciliation)
+          yield* store.ensureAuthorityGeneration({
+            generationHash: initialGenerationHash,
+            maximum: Authority.Observe,
+          })
+        }),
+      )
+    } finally {
+      await setupRuntime.dispose()
+    }
+
+    const activationRuntime = makeIndependentStoreRuntime(
+      { fail: false, planHashes: [] },
+      paperRuntimeConfig(activation),
+    )
+    const rotationRuntime = makeIndependentStoreRuntime({ fail: false, planHashes: [] }, config)
+    const client = makeClientRuntime()
+    let arrivals = 0
+    let releaseRace: () => void = () => undefined
+    const raceGate = new Promise<void>((resolve) => {
+      releaseRace = resolve
+    })
+    const awaitRace = Effect.promise(() => {
+      arrivals += 1
+      if (arrivals === 2) releaseRace()
+      return raceGate
+    })
+    try {
+      const [activationExit, rotationExit] = await Promise.all([
+        activationRuntime.runPromise(
+          Effect.exit(
+            awaitRace.pipe(
+              Effect.andThen(
+                Effect.flatMap(PaperStore, (store) => store.activatePaperGeneration(proofBinding(activation))),
+              ),
+            ),
+          ),
+        ),
+        rotationRuntime.runPromise(
+          Effect.exit(
+            awaitRace.pipe(
+              Effect.andThen(
+                Effect.flatMap(PaperStore, (store) =>
+                  store.ensureAuthorityGeneration({
+                    generationHash: rotatedGenerationHash,
+                    maximum: Authority.Observe,
+                  }),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ])
+      expect(Exit.isSuccess(rotationExit)).toBe(true)
+      if (Exit.isFailure(rotationExit)) {
+        throw new Error(`OBSERVE rotation failed unexpectedly: ${Cause.pretty(rotationExit.cause)}`)
+      }
+
+      if (Exit.isFailure(activationExit)) {
+        const activationFailure = Cause.findError(activationExit.cause)
+        expect(Result.isSuccess(activationFailure)).toBe(true)
+        if (Result.isFailure(activationFailure)) throw new Error('expected closed activation failure')
+        expect(activationFailure.success).toMatchObject({
+          operation: 'authority',
+          failure: 'invariant',
+          message: 'derived PAPER generation differs from the configured generation',
+        })
+      }
+
+      const durable = await client.runPromise(
+        Effect.gen(function* () {
+          const sql = yield* PgClient.PgClient
+          const [state] = yield* sql<{
+            generation_hash: string
+            maximum: Authority
+            effective: Authority
+            version: number
+          }>`
+            SELECT generation_hash, maximum, effective, version::integer
+            FROM authority_state
+          `
+          const history = yield* sql<{
+            authority_version: number
+            generation_hash: string
+            maximum: Authority
+            previous_generation_hash: string | null
+          }>`
+            SELECT
+              authority_version::integer,
+              generation_hash,
+              maximum,
+              previous_generation_hash
+            FROM authority_generations
+            ORDER BY authority_version
+          `
+          return { history, state }
+        }),
+      )
+      const activationSucceeded = Exit.isSuccess(activationExit)
+      expect(durable.state).toEqual({
+        generation_hash: rotatedGenerationHash,
+        maximum: Authority.Observe,
+        effective: Authority.Observe,
+        version: activationSucceeded ? 3 : 2,
+      })
+      expect(durable.history).toEqual(
+        activationSucceeded
+          ? [
+              {
+                authority_version: 1,
+                generation_hash: initialGenerationHash,
+                maximum: Authority.Observe,
+                previous_generation_hash: null,
+              },
+              {
+                authority_version: 2,
+                generation_hash: activation.generationHash,
+                maximum: Authority.Paper,
+                previous_generation_hash: initialGenerationHash,
+              },
+              {
+                authority_version: 3,
+                generation_hash: rotatedGenerationHash,
+                maximum: Authority.Observe,
+                previous_generation_hash: activation.generationHash,
+              },
+            ]
+          : [
+              {
+                authority_version: 1,
+                generation_hash: initialGenerationHash,
+                maximum: Authority.Observe,
+                previous_generation_hash: null,
+              },
+              {
+                authority_version: 2,
+                generation_hash: rotatedGenerationHash,
+                maximum: Authority.Observe,
+                previous_generation_hash: initialGenerationHash,
+              },
+            ],
+      )
+    } finally {
+      await activationRuntime.dispose()
+      await rotationRuntime.dispose()
+      await client.dispose()
     }
   }, 15_000)
 

--- a/services/bayn/src/db/paper-store.ts
+++ b/services/bayn/src/db/paper-store.ts
@@ -1,5 +1,5 @@
 import { PgClient } from '@effect/sql-pg'
-import { Clock, Context, Data, Effect, Layer, Schema } from 'effect'
+import { Clock, Context, Data, Effect, Layer, Result, Schema } from 'effect'
 
 import {
   AccountingTransactionSchema,
@@ -19,7 +19,6 @@ import {
   type ValuationInput,
 } from '../broker/observations'
 import type { RuntimeConfig } from '../config'
-import { makeStrategyProtocolHash } from '../contracts'
 import { WriterFence } from '../execution/writer-fence'
 import { canonicalHashV1 } from '../hash'
 import { Journal } from '../ledger'
@@ -34,7 +33,6 @@ import {
   decodeAuthorityState,
   decodePaperAuthorityProofBinding,
   decodePaperAuthorityGeneration,
-  makePaperAuthorityGeneration,
   type AccountingReceipt,
   type AuthorityState,
   type PaperAuthorityGeneration,
@@ -54,6 +52,35 @@ import {
   accountingReceiptFromRow,
   accountingTransactionFromRow,
 } from './accounting-rows'
+import {
+  bindPaperGenerationRuntime,
+  decideObserveGeneration,
+  decidePaperActivation,
+  derivePaperAuthorityGeneration,
+  paperActivationEffectiveAuthority,
+  paperAuthorityFailureDetails,
+  requireUnusedAuthorityGeneration,
+  validateAuthorityObservation,
+  validateCurrentGenerationHistory,
+  validateDerivedPaperGeneration,
+  validateLatestExactReconciliation,
+  validateMutationCoverage,
+  validateObserveGenerationRequest,
+  validatePaperGenerationEvidence,
+  validatePaperGenerationFreshness,
+  validatePaperGenerationReplay,
+  validatePaperPrepareGeneration,
+  validatePaperSourceAuthority,
+  type AuthorityGenerationHistoryFacts,
+  type DerivedPaperGeneration,
+  type ExactReconciliationFacts,
+  type ObserveGenerationDecision,
+  type ObserveGenerationRequest,
+  type PaperActivationDecision,
+  type PaperAuthorityAlgebraFailure,
+  type PaperGenerationEvidenceFacts,
+  type PaperGenerationRuntimeBinding,
+} from './paper-authority-algebra'
 import {
   makeReconciliation,
   ReconciliationStoreError,
@@ -364,6 +391,16 @@ const fail = (
   message: string,
 ): Effect.Effect<never, PaperStoreError> => Effect.fail(error(operation, failure, message))
 
+const fromAuthorityDecision = <A>(
+  decision: Result.Result<A, PaperAuthorityAlgebraFailure>,
+): Effect.Effect<A, PaperStoreError> =>
+  Effect.fromResult(decision).pipe(
+    Effect.mapError((failure) => {
+      const details = paperAuthorityFailureDetails(failure)
+      return error('authority', details.failure, details.message, details.cause)
+    }),
+  )
+
 const authorityStateFromRow = (
   row: typeof AuthorityStateRow.Type,
 ): Effect.Effect<AuthorityState, PaperStoreError | Schema.SchemaError> => {
@@ -381,13 +418,6 @@ const authorityStateFromRow = (
     version,
     updatedAt: row.updated_at.toISOString(),
   })
-}
-
-const positiveSafeVersion = (value: string, message: string): Effect.Effect<number, PaperStoreError> => {
-  const version = Number(value)
-  return Number.isSafeInteger(version) && version > 0
-    ? Effect.succeed(version)
-    : fail('authority', 'invariant', message)
 }
 
 const paperGenerationFromRow = (
@@ -1165,27 +1195,39 @@ const makeStore = (config: PaperStoreRuntimeConfig) =>
         WHERE generation_hash = ${generationHash}
       `.pipe(Effect.flatMap(decodeAuthorityGenerationRows))
 
+    const generationHistoryFacts = (
+      history: typeof AuthorityGenerationRow.Type,
+    ): AuthorityGenerationHistoryFacts & { readonly row: typeof AuthorityGenerationRow.Type } => ({
+      generationHash: history.generation_hash,
+      maximum: history.maximum,
+      authorityVersion: history.authority_version,
+      activatedAt: history.activated_at,
+      row: history,
+    })
+
     const verifyCurrentGenerationHistory = (
       current: AuthorityState,
       history: typeof AuthorityGenerationRow.Type | undefined,
     ) =>
-      Effect.gen(function* () {
-        if (history === undefined) {
-          return yield* fail('authority', 'invariant', 'current authority generation lacks immutable history')
-        }
-        const historyVersion = yield* positiveSafeVersion(
-          history.authority_version,
-          'authority generation history version is not a safe positive integer',
-        )
-        if (
-          history.generation_hash !== current.generationHash ||
-          history.maximum !== current.maximum ||
-          historyVersion > current.version ||
-          history.activated_at.toISOString() > current.updatedAt
-        ) {
-          return yield* fail('authority', 'invariant', 'current authority generation history differs from state')
-        }
-      })
+      fromAuthorityDecision(
+        validateCurrentGenerationHistory(current, history === undefined ? undefined : generationHistoryFacts(history)),
+      ).pipe(Effect.asVoid)
+
+    const requireCurrentGenerationHistory = (
+      current: AuthorityState,
+      history: typeof AuthorityGenerationRow.Type | undefined,
+    ): Effect.Effect<typeof AuthorityGenerationRow.Type, PaperStoreError> =>
+      fromAuthorityDecision(
+        validateCurrentGenerationHistory(current, history === undefined ? undefined : generationHistoryFacts(history)),
+      ).pipe(Effect.map((validated) => validated.row))
+
+    const requireUnusedGeneration = (generationHash: string, history: typeof AuthorityGenerationRow.Type | undefined) =>
+      fromAuthorityDecision(
+        requireUnusedAuthorityGeneration(
+          generationHash,
+          history === undefined ? undefined : generationHistoryFacts(history),
+        ),
+      )
 
     const nextAuthorityInstant = sql<Record<string, unknown>>`
       SELECT greatest(
@@ -1203,154 +1245,150 @@ const makeStore = (config: PaperStoreRuntimeConfig) =>
       ),
     )
 
+    const initializeObserveGeneration = (
+      decision: Extract<ObserveGenerationDecision, { readonly _tag: 'InitializeObserveGeneration' }>,
+    ) =>
+      Effect.gen(function* () {
+        const [existing] = yield* readGeneration(decision.generationHash)
+        yield* requireUnusedGeneration(decision.generationHash, existing)
+        const [databaseTime] = yield* sql<Record<string, unknown>>`
+          SELECT clock_timestamp() AS activated_at
+        `.pipe(Effect.flatMap(decodeDatabaseInstant))
+        if (databaseTime === undefined) {
+          return yield* fail('authority', 'invariant', 'authority initialization time is unavailable')
+        }
+        yield* sql`
+          INSERT INTO authority_generations (
+            generation_hash, schema_version, previous_generation_hash, maximum,
+            authority_version, activated_at
+          ) VALUES (
+            ${decision.generationHash}, 'bayn.authority-generation-history.v1', NULL,
+            'OBSERVE', 1, ${databaseTime.activated_at}
+          )
+        `
+        const inserted = yield* sql<Record<string, unknown>>`
+          INSERT INTO authority_state (
+            schema_version, generation_hash, maximum, effective, kill_state,
+            reason, version, updated_at
+          ) VALUES (
+            'bayn.paper-authority.v1', ${decision.generationHash}, ${decision.maximum},
+            'OBSERVE', 'CLEAR', NULL, 1, ${databaseTime.activated_at}
+          )
+          RETURNING
+            schema_version, generation_hash, maximum, effective, kill_state, reason,
+            version::text AS version, updated_at
+        `.pipe(Effect.flatMap(decodeAuthorityStateRows))
+        const insertedRow = inserted[0]
+        if (insertedRow === undefined) {
+          return yield* fail('authority', 'invariant', 'authority generation was not initialized')
+        }
+        return yield* authorityStateFromRow(insertedRow)
+      })
+
+    const replayObserveGeneration = (current: AuthorityState) =>
+      readGeneration(current.generationHash).pipe(
+        Effect.flatMap((rows) => verifyCurrentGenerationHistory(current, rows[0])),
+        Effect.as(current),
+      )
+
+    const rotateObserveGeneration = (
+      decision: Extract<ObserveGenerationDecision, { readonly _tag: 'RotateObserveGeneration' }>,
+    ) =>
+      Effect.gen(function* () {
+        const [currentHistory] = yield* readGeneration(decision.current.generationHash)
+        yield* verifyCurrentGenerationHistory(decision.current, currentHistory)
+        const [existing] = yield* readGeneration(decision.generationHash)
+        yield* requireUnusedGeneration(decision.generationHash, existing)
+        const activatedAt = yield* nextAuthorityInstant
+        yield* sql`
+          INSERT INTO authority_generations (
+            generation_hash, schema_version, previous_generation_hash, maximum,
+            authority_version, activated_at
+          ) VALUES (
+            ${decision.generationHash}, 'bayn.authority-generation-history.v1',
+            ${decision.current.generationHash}, 'OBSERVE', ${decision.authorityVersion}, ${activatedAt}
+          )
+        `
+        const rotated = yield* sql<Record<string, unknown>>`
+          UPDATE authority_state
+          SET
+            generation_hash = ${decision.generationHash},
+            maximum = ${decision.maximum},
+            effective = 'OBSERVE',
+            version = ${decision.authorityVersion},
+            updated_at = ${activatedAt}
+          WHERE singleton
+          RETURNING
+            schema_version, generation_hash, maximum, effective, kill_state, reason,
+            version::text AS version, updated_at
+        `.pipe(Effect.flatMap(decodeAuthorityStateRows))
+        const rotatedRow = rotated[0]
+        if (rotatedRow === undefined) {
+          return yield* fail('authority', 'invariant', 'authority generation was not rotated')
+        }
+        return yield* authorityStateFromRow(rotatedRow)
+      })
+
+    const ensureAuthorityGenerationTransaction = (request: ObserveGenerationRequest) =>
+      Effect.gen(function* () {
+        yield* lockAuthorityGenerations
+        const rows = yield* sql<Record<string, unknown>>`
+          SELECT
+            schema_version, generation_hash, maximum, effective, kill_state, reason,
+            version::text AS version, updated_at, clock_timestamp() AS observed_at
+          FROM authority_state
+          WHERE singleton
+          FOR UPDATE
+        `.pipe(Effect.flatMap(decodeAuthorityStateObservationRows))
+        const currentRow = rows[0]
+        const current = currentRow === undefined ? undefined : yield* authorityStateFromRow(currentRow)
+        if (current !== undefined && currentRow !== undefined) {
+          yield* fromAuthorityDecision(validateAuthorityObservation(current, currentRow.observed_at))
+        }
+        const decision = yield* fromAuthorityDecision(decideObserveGeneration(request, current))
+        switch (decision._tag) {
+          case 'InitializeObserveGeneration':
+            return yield* initializeObserveGeneration(decision)
+          case 'ReplayObserveGeneration':
+            return yield* replayObserveGeneration(decision.current)
+          case 'RotateObserveGeneration':
+            return yield* rotateObserveGeneration(decision)
+        }
+      })
+
     const ensureAuthorityGeneration = (candidate: EnsureAuthorityGenerationInput) =>
       run(
         'authority',
         decodeEnsureAuthorityGenerationInput(candidate).pipe(
           Effect.flatMap((input) =>
-            input.maximum !== Authority.Observe
-              ? fail('authority', 'invariant', 'Phase A authority maximum must be OBSERVE')
-              : sql.withTransaction(
-                  Effect.gen(function* () {
-                    yield* lockAuthorityGenerations
-                    const rows = yield* sql<Record<string, unknown>>`
-                      SELECT
-                        schema_version, generation_hash, maximum, effective, kill_state, reason,
-                        version::text AS version, updated_at, clock_timestamp() AS observed_at
-                      FROM authority_state
-                      WHERE singleton
-                      FOR UPDATE
-                    `.pipe(Effect.flatMap(decodeAuthorityStateObservationRows))
-                    const currentRow = rows[0]
-                    if (currentRow === undefined) {
-                      if ((yield* readGeneration(input.generationHash))[0] !== undefined) {
-                        return yield* fail('authority', 'conflict', 'authority generation hash was already used')
-                      }
-                      const [databaseTime] = yield* sql<Record<string, unknown>>`
-                        SELECT clock_timestamp() AS activated_at
-                      `.pipe(Effect.flatMap(decodeDatabaseInstant))
-                      if (databaseTime === undefined) {
-                        return yield* fail('authority', 'invariant', 'authority initialization time is unavailable')
-                      }
-                      yield* sql`
-                        INSERT INTO authority_generations (
-                          generation_hash, schema_version, previous_generation_hash, maximum,
-                          authority_version, activated_at
-                        ) VALUES (
-                          ${input.generationHash}, 'bayn.authority-generation-history.v1', NULL,
-                          'OBSERVE', 1, ${databaseTime.activated_at}
-                        )
-                      `
-                      const inserted = yield* sql<Record<string, unknown>>`
-                        INSERT INTO authority_state (
-                          schema_version, generation_hash, maximum, effective, kill_state,
-                          reason, version, updated_at
-                        ) VALUES (
-                          'bayn.paper-authority.v1', ${input.generationHash}, ${input.maximum},
-                          'OBSERVE', 'CLEAR', NULL, 1, ${databaseTime.activated_at}
-                        )
-                        RETURNING
-                          schema_version, generation_hash, maximum, effective, kill_state, reason,
-                          version::text AS version, updated_at
-                      `.pipe(Effect.flatMap(decodeAuthorityStateRows))
-                      const insertedRow = inserted[0]
-                      if (insertedRow === undefined) {
-                        return yield* fail('authority', 'invariant', 'authority generation was not initialized')
-                      }
-                      return yield* authorityStateFromRow(insertedRow)
-                    }
-
-                    const current = yield* authorityStateFromRow(currentRow)
-                    if (currentRow.updated_at.getTime() > currentRow.observed_at.getTime()) {
-                      return yield* fail(
-                        'authority',
-                        'invariant',
-                        'durable authority update follows its database observation time',
-                      )
-                    }
-                    if (current.generationHash === input.generationHash) {
-                      if (current.maximum !== input.maximum) {
-                        return yield* fail(
-                          'authority',
-                          'conflict',
-                          'authority generation maximum conflicts with durable state',
-                        )
-                      }
-                      yield* verifyCurrentGenerationHistory(current, (yield* readGeneration(current.generationHash))[0])
-                      return current
-                    }
-
-                    yield* verifyCurrentGenerationHistory(current, (yield* readGeneration(current.generationHash))[0])
-                    if ((yield* readGeneration(input.generationHash))[0] !== undefined) {
-                      return yield* fail('authority', 'conflict', 'authority generation hash was already used')
-                    }
-                    const activatedAt = yield* nextAuthorityInstant
-                    yield* sql`
-                      INSERT INTO authority_generations (
-                        generation_hash, schema_version, previous_generation_hash, maximum,
-                        authority_version, activated_at
-                      ) VALUES (
-                        ${input.generationHash}, 'bayn.authority-generation-history.v1',
-                        ${current.generationHash}, 'OBSERVE', ${current.version + 1}, ${activatedAt}
-                      )
-                    `
-                    const rotated = yield* sql<Record<string, unknown>>`
-                      UPDATE authority_state
-                      SET
-                        generation_hash = ${input.generationHash},
-                        maximum = ${input.maximum},
-                        effective = 'OBSERVE',
-                        version = version + 1,
-                        updated_at = ${activatedAt}
-                      WHERE singleton
-                      RETURNING
-                        schema_version, generation_hash, maximum, effective, kill_state, reason,
-                        version::text AS version, updated_at
-                    `.pipe(Effect.flatMap(decodeAuthorityStateRows))
-                    const rotatedRow = rotated[0]
-                    if (rotatedRow === undefined) {
-                      return yield* fail('authority', 'invariant', 'authority generation was not rotated')
-                    }
-                    return yield* authorityStateFromRow(rotatedRow)
-                  }),
-                ),
+            fromAuthorityDecision(validateObserveGenerationRequest(input)).pipe(
+              Effect.flatMap((request) => sql.withTransaction(ensureAuthorityGenerationTransaction(request))),
+            ),
           ),
         ),
       )
 
-    interface PaperGenerationRuntimeBinding {
-      readonly accountId: string
-      readonly configuredGenerationHash: string
-      readonly qualificationRunId: string
-    }
-
-    interface DerivedPaperGeneration {
-      readonly current: AuthorityState
-      readonly generation: PaperAuthorityGeneration
-      readonly reconciliation: typeof ActivationReconciliationRow.Type
-    }
-
     const requirePaperGenerationRuntime = (
       expectedMaximum: Authority,
       operation: 'PREPARE' | 'activation',
-    ): Effect.Effect<PaperGenerationRuntimeBinding, PaperStoreError> => {
-      if (
-        config.maximumAuthority !== expectedMaximum ||
-        config.alpaca === undefined ||
-        config.qualificationRunId === undefined
-      ) {
-        return fail(
-          'authority',
-          'invariant',
-          `PAPER ${operation} requires the exact configured authority, account, generation, and qualification binding`,
-        )
-      }
-      return Effect.succeed({
-        accountId: config.alpaca.accountId,
-        configuredGenerationHash: config.alpaca.authorityGenerationHash,
-        qualificationRunId: config.qualificationRunId,
-      })
-    }
+    ): Effect.Effect<PaperGenerationRuntimeBinding, PaperStoreError> =>
+      fromAuthorityDecision(
+        bindPaperGenerationRuntime(
+          {
+            maximumAuthority: config.maximumAuthority,
+            alpaca:
+              config.alpaca === undefined
+                ? undefined
+                : {
+                    accountId: config.alpaca.accountId,
+                    authorityGenerationHash: config.alpaca.authorityGenerationHash,
+                  },
+            qualificationRunId: config.qualificationRunId,
+          },
+          expectedMaximum,
+          operation,
+        ),
+      )
 
     const lockPaperAuthority = (accountId: string) =>
       Effect.gen(function* () {
@@ -1373,16 +1411,195 @@ const makeStore = (config: PaperStoreRuntimeConfig) =>
           return yield* fail('authority', 'invariant', 'PAPER generation requires initialized authority')
         }
         const current = yield* authorityStateFromRow(currentRow)
-        if (currentRow.updated_at.getTime() > currentRow.observed_at.getTime()) {
-          return yield* fail('authority', 'invariant', 'durable authority update follows its database observation time')
-        }
-        const history = (yield* readGeneration(current.generationHash))[0]
-        yield* verifyCurrentGenerationHistory(current, history)
-        if (history === undefined) {
-          return yield* fail('authority', 'invariant', 'current authority generation lacks immutable history')
-        }
+        yield* fromAuthorityDecision(validateAuthorityObservation(current, currentRow.observed_at))
+        const history = yield* readGeneration(current.generationHash).pipe(
+          Effect.flatMap((rows) => requireCurrentGenerationHistory(current, rows[0])),
+        )
         return { current, history }
       })
+
+    const evidenceFacts = (row: typeof ActivationEvidenceRow.Type): PaperGenerationEvidenceFacts => ({
+      lock: row.lock_payload,
+      result: row.result_payload,
+      runStatus: row.run_status,
+      expectedArtifactCount: row.expected_artifact_count,
+      expectedEventCount: row.expected_event_count,
+      expectedGateCount: row.expected_gate_count,
+      artifactCount: row.artifact_count,
+      eventCount: row.event_count,
+      gateCount: row.gate_count,
+      statusCount: row.status_count,
+      writingStatusCount: row.writing_status_count,
+      completeStatusCount: row.complete_status_count,
+      writingDetail: row.writing_detail,
+      completeDetail: row.complete_detail,
+      protocolSchemaVersion: row.protocol_schema_version,
+      strategyName: row.strategy_name,
+      behaviorHash: row.behavior_hash,
+      parameterHash: row.parameter_hash,
+      parameters: row.parameters,
+    })
+
+    const readPaperGenerationEvidence = (binding: PaperGenerationRuntimeBinding) =>
+      sql`
+        LOCK TABLE
+          evaluation_artifacts,
+          evaluation_events,
+          gate_outcomes,
+          status_history
+        IN SHARE MODE
+      `.pipe(
+        Effect.andThen(
+          sql<Record<string, unknown>>`
+            SELECT
+              lock.payload AS lock_payload,
+              result.payload AS result_payload,
+              run.status AS run_status,
+              run.expected_artifact_count,
+              run.expected_event_count,
+              run.expected_gate_count,
+              (
+                SELECT count(*)::integer
+                FROM evaluation_artifacts
+                WHERE run_id = run.run_id
+              ) AS artifact_count,
+              (
+                SELECT count(*)::integer
+                FROM evaluation_events
+                WHERE run_id = run.run_id
+              ) AS event_count,
+              (
+                SELECT count(*)::integer
+                FROM gate_outcomes
+                WHERE run_id = run.run_id
+              ) AS gate_count,
+              (
+                SELECT count(*)::integer
+                FROM status_history
+                WHERE run_id = run.run_id
+              ) AS status_count,
+              (
+                SELECT count(*)::integer
+                FROM status_history
+                WHERE run_id = run.run_id AND status = 'WRITING'
+              ) AS writing_status_count,
+              (
+                SELECT count(*)::integer
+                FROM status_history
+                WHERE run_id = run.run_id AND status = 'COMPLETE'
+              ) AS complete_status_count,
+              (
+                SELECT detail
+                FROM status_history
+                WHERE run_id = run.run_id AND status = 'WRITING'
+              ) AS writing_detail,
+              (
+                SELECT detail
+                FROM status_history
+                WHERE run_id = run.run_id AND status = 'COMPLETE'
+              ) AS complete_detail,
+              protocol.schema_version AS protocol_schema_version,
+              protocol.strategy_name,
+              protocol.behavior_hash,
+              protocol.parameter_hash,
+              protocol.parameters
+            FROM qualification_results AS result
+            JOIN qualification_locks AS lock
+              ON lock.lock_id = result.lock_id
+              AND lock.candidate_run_id = result.run_id
+            JOIN evaluation_runs AS run
+              ON run.run_id = result.run_id
+              AND run.protocol_hash = lock.protocol_hash
+              AND run.snapshot_id = lock.snapshot_id
+              AND run.source_revision = lock.source_revision
+              AND run.image_repository = lock.image_repository
+              AND run.image_digest = lock.image_digest
+            JOIN protocol_locks AS protocol
+              ON protocol.protocol_hash = run.protocol_hash
+              AND protocol.strategy_name = run.strategy_name
+            WHERE result.run_id = ${binding.qualificationRunId}
+            FOR SHARE OF result, lock, run, protocol
+          `.pipe(Effect.flatMap(decodeActivationEvidenceRows)),
+        ),
+        Effect.map((rows) => (rows[0] === undefined ? undefined : evidenceFacts(rows[0]))),
+        Effect.flatMap((evidence) =>
+          fromAuthorityDecision(validatePaperGenerationEvidence(evidence, binding, config.build)),
+        ),
+      )
+
+    const reconciliationFacts = (row: typeof ActivationReconciliationRow.Type): ExactReconciliationFacts => ({
+      reconciliationId: row.reconciliation_id,
+      accountId: row.account_id,
+      contentHash: row.content_hash,
+      status: row.status,
+      reconciledAt: row.reconciled_at,
+    })
+
+    const readLatestExactReconciliation = (binding: PaperGenerationRuntimeBinding) =>
+      sql<Record<string, unknown>>`
+        SELECT
+          reconciliation_id, account_id, content_hash, status, reconciled_at
+        FROM reconciliations
+        WHERE account_id = ${binding.accountId}
+        ORDER BY reconciled_at DESC, reconciliation_id DESC
+        LIMIT 1
+        FOR SHARE
+      `.pipe(
+        Effect.flatMap(decodeActivationReconciliationRows),
+        Effect.map((rows) => (rows[0] === undefined ? undefined : reconciliationFacts(rows[0]))),
+        Effect.flatMap((reconciliation) =>
+          fromAuthorityDecision(validateLatestExactReconciliation(reconciliation, binding.accountId)),
+        ),
+      )
+
+    const verifyMutationCoverage = (binding: PaperGenerationRuntimeBinding, reconciliation: ExactReconciliationFacts) =>
+      sql<Record<string, unknown>>`
+        WITH latest AS (
+          SELECT DISTINCT ON (event.mutation_id)
+            event.operation,
+            event.event_type,
+            event.occurred_at,
+            intent.state
+          FROM mutation_events AS event
+          JOIN intents AS intent ON intent.intent_id = event.intent_id
+          WHERE intent.account_id = ${binding.accountId}
+          ORDER BY event.mutation_id, event.sequence DESC
+        )
+        SELECT
+          count(*) FILTER (
+            WHERE latest.state <> 'TERMINAL'
+              AND (
+                latest.event_type IN (
+                  'SUBMIT_STARTED',
+                  'SUBMIT_UNKNOWN',
+                  'RECOVERY_NOT_FOUND',
+                  'RECOVERY_UNKNOWN',
+                  'CANCEL_STARTED',
+                  'CANCEL_ACCEPTED',
+                  'CANCEL_UNKNOWN'
+                )
+                OR (
+                  latest.operation = 'CANCEL'
+                  AND latest.event_type = 'RECOVERY_FOUND'
+                )
+              )
+            )::integer AS unresolved_count,
+          max(latest.occurred_at) AS latest_mutation_at
+        FROM latest
+      `.pipe(
+        Effect.flatMap(decodeMutationBaseline),
+        Effect.flatMap(([baseline]) =>
+          fromAuthorityDecision(
+            validateMutationCoverage(
+              {
+                unresolvedCount: baseline.unresolved_count,
+                latestMutationAt: baseline.latest_mutation_at,
+              },
+              reconciliation,
+            ),
+          ),
+        ),
+      )
 
     const derivePaperGeneration = (
       proof: PaperAuthorityProofBinding,
@@ -1390,251 +1607,41 @@ const makeStore = (config: PaperStoreRuntimeConfig) =>
       current: AuthorityState,
     ) =>
       Effect.gen(function* () {
-        if (current.maximum !== Authority.Observe || current.effective !== Authority.Observe) {
-          return yield* fail('authority', 'invariant', 'PAPER generation requires current OBSERVE authority')
-        }
-
-        yield* sql`
-          LOCK TABLE
-            evaluation_artifacts,
-            evaluation_events,
-            gate_outcomes,
-            status_history
-          IN SHARE MODE
-        `
-        const evidenceRows = yield* sql<Record<string, unknown>>`
-          SELECT
-            lock.payload AS lock_payload,
-            result.payload AS result_payload,
-            run.status AS run_status,
-            run.expected_artifact_count,
-            run.expected_event_count,
-            run.expected_gate_count,
-            (
-              SELECT count(*)::integer
-              FROM evaluation_artifacts
-              WHERE run_id = run.run_id
-            ) AS artifact_count,
-            (
-              SELECT count(*)::integer
-              FROM evaluation_events
-              WHERE run_id = run.run_id
-            ) AS event_count,
-            (
-              SELECT count(*)::integer
-              FROM gate_outcomes
-              WHERE run_id = run.run_id
-            ) AS gate_count,
-            (
-              SELECT count(*)::integer
-              FROM status_history
-              WHERE run_id = run.run_id
-            ) AS status_count,
-            (
-              SELECT count(*)::integer
-              FROM status_history
-              WHERE run_id = run.run_id AND status = 'WRITING'
-            ) AS writing_status_count,
-            (
-              SELECT count(*)::integer
-              FROM status_history
-              WHERE run_id = run.run_id AND status = 'COMPLETE'
-            ) AS complete_status_count,
-            (
-              SELECT detail
-              FROM status_history
-              WHERE run_id = run.run_id AND status = 'WRITING'
-            ) AS writing_detail,
-            (
-              SELECT detail
-              FROM status_history
-              WHERE run_id = run.run_id AND status = 'COMPLETE'
-            ) AS complete_detail,
-            protocol.schema_version AS protocol_schema_version,
-            protocol.strategy_name,
-            protocol.behavior_hash,
-            protocol.parameter_hash,
-            protocol.parameters
-          FROM qualification_results AS result
-          JOIN qualification_locks AS lock
-            ON lock.lock_id = result.lock_id
-            AND lock.candidate_run_id = result.run_id
-          JOIN evaluation_runs AS run
-            ON run.run_id = result.run_id
-            AND run.protocol_hash = lock.protocol_hash
-            AND run.snapshot_id = lock.snapshot_id
-            AND run.source_revision = lock.source_revision
-            AND run.image_repository = lock.image_repository
-            AND run.image_digest = lock.image_digest
-          JOIN protocol_locks AS protocol
-            ON protocol.protocol_hash = run.protocol_hash
-            AND protocol.strategy_name = run.strategy_name
-          WHERE result.run_id = ${binding.qualificationRunId}
-          FOR SHARE OF result, lock, run, protocol
-        `.pipe(Effect.flatMap(decodeActivationEvidenceRows))
-        const evidence = evidenceRows[0]
-        if (evidence === undefined) {
-          return yield* fail('authority', 'invariant', 'exact terminal qualification evidence is unavailable')
-        }
-        const lock = evidence.lock_payload
-        const result = evidence.result_payload
-        const strategyProtocolHash = makeStrategyProtocolHash({
-          name: evidence.strategy_name,
-          behaviorHash: evidence.behavior_hash,
-          parameterHash: evidence.parameter_hash,
-          parameterSchemaVersion: evidence.protocol_schema_version,
-        })
-        if (
-          result.verdict !== 'QUALIFIED' ||
-          evidence.run_status !== 'COMPLETE' ||
-          evidence.expected_artifact_count !== evidence.artifact_count ||
-          evidence.expected_event_count !== evidence.event_count ||
-          evidence.expected_gate_count !== evidence.gate_count ||
-          evidence.status_count !== 2 ||
-          evidence.writing_status_count !== 1 ||
-          evidence.complete_status_count !== 1 ||
-          canonicalHashV1(evidence.writing_detail) !==
-            canonicalHashV1({
-              artifactCount: evidence.expected_artifact_count,
-              eventCount: evidence.expected_event_count,
-              gateCount: evidence.expected_gate_count,
-            }) ||
-          canonicalHashV1(evidence.complete_detail) !==
-            canonicalHashV1({
-              reconciliationExact: true,
-              verdict: result.evaluationVerdict.status,
-            }) ||
-          result.runId !== binding.qualificationRunId ||
-          result.lockId !== lock.lockId ||
-          lock.candidateRunId !== binding.qualificationRunId ||
-          evidence.protocol_schema_version !== 'bayn.risk-balanced-trend.protocol.v3' ||
-          evidence.strategy_name !== 'risk-balanced-trend' ||
-          evidence.behavior_hash !== config.build.strategyBehaviorHash ||
-          evidence.parameter_hash !== config.build.strategyParameterHash ||
-          canonicalHashV1(evidence.parameters) !== evidence.parameter_hash ||
-          strategyProtocolHash !== lock.protocolHash
-        ) {
-          return yield* fail(
-            'authority',
-            'invariant',
-            'PAPER generation differs from terminal qualification evidence or current strategy build',
-          )
-        }
-
-        const reconciliationRows = yield* sql<Record<string, unknown>>`
-          SELECT
-            reconciliation_id, account_id, content_hash, status, reconciled_at
-          FROM reconciliations
-          WHERE account_id = ${binding.accountId}
-          ORDER BY reconciled_at DESC, reconciliation_id DESC
-          LIMIT 1
-          FOR SHARE
-        `.pipe(Effect.flatMap(decodeActivationReconciliationRows))
-        const exactReconciliation = reconciliationRows[0]
-        if (
-          exactReconciliation === undefined ||
-          exactReconciliation.account_id !== binding.accountId ||
-          exactReconciliation.status !== ReconciliationStatus.Exact
-        ) {
-          return yield* fail(
-            'authority',
-            'invariant',
-            'PAPER generation requires the latest fresh exact account reconciliation',
-          )
-        }
-
-        const [mutationBaseline] = yield* sql<Record<string, unknown>>`
-          WITH latest AS (
-            SELECT DISTINCT ON (event.mutation_id)
-              event.operation,
-              event.event_type,
-              event.occurred_at,
-              intent.state
-            FROM mutation_events AS event
-            JOIN intents AS intent ON intent.intent_id = event.intent_id
-            WHERE intent.account_id = ${binding.accountId}
-            ORDER BY event.mutation_id, event.sequence DESC
-          )
-          SELECT
-            count(*) FILTER (
-              WHERE latest.state <> 'TERMINAL'
-                AND (
-                  latest.event_type IN (
-                    'SUBMIT_STARTED',
-                    'SUBMIT_UNKNOWN',
-                    'RECOVERY_NOT_FOUND',
-                    'RECOVERY_UNKNOWN',
-                    'CANCEL_STARTED',
-                    'CANCEL_ACCEPTED',
-                    'CANCEL_UNKNOWN'
-                  )
-                  OR (
-                    latest.operation = 'CANCEL'
-                    AND latest.event_type = 'RECOVERY_FOUND'
-                  )
-                )
-              )::integer AS unresolved_count,
-            max(latest.occurred_at) AS latest_mutation_at
-          FROM latest
-        `.pipe(Effect.flatMap(decodeMutationBaseline))
-        if (
-          mutationBaseline.unresolved_count !== 0 ||
-          (mutationBaseline.latest_mutation_at !== null &&
-            mutationBaseline.latest_mutation_at.getTime() > exactReconciliation.reconciled_at.getTime())
-        ) {
-          return yield* fail(
-            'authority',
-            'invariant',
-            'PAPER generation requires zero unresolved mutations covered by reconciliation',
-          )
-        }
-
-        const generation = yield* Effect.try({
-          try: () =>
-            makePaperAuthorityGeneration({
-              schemaVersion: 'bayn.paper-authority-generation.v2',
-              maximum: Authority.Paper,
-              previousGenerationHash: current.generationHash,
-              qualificationRunId: result.runId,
-              qualificationLockId: result.lockId,
-              qualificationResultHash: result.resultHash,
-              protocolHash: lock.protocolHash,
-              qualificationExecutionPolicyHash: lock.policies.execution.contentHash,
-              qualificationSourceRevision: lock.sourceRevision,
-              qualificationImageRepository: lock.image.repository,
-              qualificationImageDigest: lock.image.digest,
-              activationSourceRevision: config.build.sourceRevision,
-              activationImageRepository: config.build.imageRepository,
-              activationImageDigest: config.build.imageDigest,
-              strategyName: evidence.strategy_name,
-              strategyBehaviorHash: evidence.behavior_hash,
-              strategyParameterHash: evidence.parameter_hash,
-              strategyParameterSchemaVersion: 'bayn.risk-balanced-trend.protocol.v3',
-              accountId: binding.accountId,
-              riskPolicyHash: proof.riskPolicyHash,
-              proofPlanHash: proof.proofPlanHash,
-              reconciliationId: exactReconciliation.reconciliation_id,
-              reconciliationContentHash: exactReconciliation.content_hash,
-            }),
-          catch: (cause) => error('authority', 'decode', 'derived PAPER generation is invalid', cause),
-        })
-        return { current, generation, reconciliation: exactReconciliation } satisfies DerivedPaperGeneration
+        yield* fromAuthorityDecision(validatePaperSourceAuthority(current))
+        const evidence = yield* readPaperGenerationEvidence(binding)
+        const reconciliation = yield* readLatestExactReconciliation(binding)
+        yield* verifyMutationCoverage(binding, reconciliation)
+        return yield* fromAuthorityDecision(
+          derivePaperAuthorityGeneration({
+            current,
+            proof,
+            binding,
+            evidence,
+            reconciliation,
+            build: config.build,
+          }),
+        )
       })
 
-    const validatePaperGenerationFreshness = (derived: DerivedPaperGeneration) =>
+    const requireFreshPaperGeneration = (derived: DerivedPaperGeneration) =>
+      nextAuthorityInstant.pipe(
+        Effect.flatMap((observedAt) =>
+          fromAuthorityDecision(
+            validatePaperGenerationFreshness(derived.reconciliation, observedAt, config.reconciliationStaleThresholdMs),
+          ),
+        ),
+      )
+
+    const preparePaperGenerationTransaction = (
+      proof: PaperAuthorityProofBinding,
+      binding: PaperGenerationRuntimeBinding,
+    ) =>
       Effect.gen(function* () {
-        const observedAt = yield* nextAuthorityInstant
-        if (
-          derived.reconciliation.reconciled_at.getTime() > observedAt.getTime() ||
-          observedAt.getTime() - derived.reconciliation.reconciled_at.getTime() >= config.reconciliationStaleThresholdMs
-        ) {
-          return yield* fail(
-            'authority',
-            'invariant',
-            'PAPER generation requires the latest fresh exact account reconciliation',
-          )
-        }
-        return observedAt
+        const locked = yield* lockPaperAuthority(binding.accountId)
+        yield* fromAuthorityDecision(validatePaperPrepareGeneration(locked.current, binding))
+        const derived = yield* derivePaperGeneration(proof, binding, locked.current)
+        yield* requireFreshPaperGeneration(derived)
+        return derived.generation
       })
 
     const preparePaperGeneration = (candidate: PaperAuthorityProofBinding) =>
@@ -1644,23 +1651,96 @@ const makeStore = (config: PaperStoreRuntimeConfig) =>
           const proof = yield* decodePaperAuthorityProofBinding(candidate)
           const binding = yield* requirePaperGenerationRuntime(Authority.Observe, 'PREPARE')
           const fence = yield* WriterFence
-          return yield* fence.transaction(
-            Effect.gen(function* () {
-              const locked = yield* lockPaperAuthority(binding.accountId)
-              if (locked.current.generationHash !== binding.configuredGenerationHash) {
-                return yield* fail(
-                  'authority',
-                  'invariant',
-                  'PAPER PREPARE current authority differs from the configured OBSERVE generation',
-                )
-              }
-              const derived = yield* derivePaperGeneration(proof, binding, locked.current)
-              yield* validatePaperGenerationFreshness(derived)
-              return derived.generation
-            }),
-          )
+          return yield* fence.transaction(preparePaperGenerationTransaction(proof, binding))
         }),
       )
+
+    const replayPaperGeneration = (
+      current: AuthorityState,
+      history: typeof AuthorityGenerationRow.Type,
+      proof: PaperAuthorityProofBinding,
+      binding: PaperGenerationRuntimeBinding,
+    ) =>
+      paperGenerationFromRow(history).pipe(
+        Effect.flatMap((stored) =>
+          fromAuthorityDecision(validatePaperGenerationReplay(stored, binding, proof, config.build)),
+        ),
+        Effect.as(current),
+      )
+
+    const writePaperGenerationActivation = (
+      decision: Extract<PaperActivationDecision, { readonly _tag: 'ActivatePaperGeneration' }>,
+      derived: DerivedPaperGeneration,
+      activatedAt: Date,
+    ) =>
+      Effect.gen(function* () {
+        const input = derived.generation
+        yield* sql`
+          INSERT INTO authority_generations (
+            generation_hash, schema_version, activation_schema_version,
+            previous_generation_hash, maximum, authority_version,
+            qualification_run_id, qualification_lock_id, qualification_result_hash,
+            protocol_hash, qualification_execution_policy_hash,
+            qualification_source_revision, qualification_image_repository,
+            qualification_image_digest, activation_source_revision,
+            activation_image_repository, activation_image_digest,
+            strategy_name, strategy_behavior_hash,
+            strategy_parameter_hash, strategy_parameter_schema_version, account_id,
+            risk_policy_hash, proof_plan_hash, reconciliation_id,
+            reconciliation_content_hash, activated_at
+          ) VALUES (
+            ${input.generationHash}, 'bayn.authority-generation-history.v1',
+            ${input.schemaVersion}, ${input.previousGenerationHash}, 'PAPER', ${decision.authorityVersion},
+            ${input.qualificationRunId}, ${input.qualificationLockId},
+            ${input.qualificationResultHash}, ${input.protocolHash},
+            ${input.qualificationExecutionPolicyHash}, ${input.qualificationSourceRevision},
+            ${input.qualificationImageRepository}, ${input.qualificationImageDigest},
+            ${input.activationSourceRevision}, ${input.activationImageRepository},
+            ${input.activationImageDigest}, ${input.strategyName},
+            ${input.strategyBehaviorHash}, ${input.strategyParameterHash},
+            ${input.strategyParameterSchemaVersion}, ${input.accountId},
+            ${input.riskPolicyHash}, ${input.proofPlanHash}, ${input.reconciliationId},
+            ${input.reconciliationContentHash}, ${activatedAt}
+          )
+        `
+        const effective = paperActivationEffectiveAuthority(derived.current.kill)
+        const activatedRows = yield* sql<Record<string, unknown>>`
+          UPDATE authority_state
+          SET
+            generation_hash = ${input.generationHash},
+            maximum = 'PAPER',
+            effective = ${effective},
+            version = ${decision.authorityVersion},
+            updated_at = ${activatedAt}
+          WHERE singleton
+          RETURNING
+            schema_version, generation_hash, maximum, effective, kill_state, reason,
+            version::text AS version, updated_at
+        `.pipe(Effect.flatMap(decodeAuthorityStateRows))
+        const activatedRow = activatedRows[0]
+        if (activatedRow === undefined) {
+          return yield* fail('authority', 'invariant', 'PAPER authority was not activated')
+        }
+        return yield* authorityStateFromRow(activatedRow)
+      })
+
+    const activatePaperGenerationTransaction = (
+      proof: PaperAuthorityProofBinding,
+      binding: PaperGenerationRuntimeBinding,
+    ) =>
+      Effect.gen(function* () {
+        const locked = yield* lockPaperAuthority(binding.accountId)
+        const decision = yield* fromAuthorityDecision(decidePaperActivation(locked.current, binding))
+        if (decision._tag === 'ReplayPaperGeneration') {
+          return yield* replayPaperGeneration(decision.current, locked.history, proof, binding)
+        }
+        const derived = yield* derivePaperGeneration(proof, binding, decision.current)
+        yield* fromAuthorityDecision(validateDerivedPaperGeneration(derived.generation, binding))
+        const [existing] = yield* readGeneration(derived.generation.generationHash)
+        yield* requireUnusedGeneration(derived.generation.generationHash, existing)
+        const activatedAt = yield* requireFreshPaperGeneration(derived)
+        return yield* writePaperGenerationActivation(decision, derived, activatedAt)
+      })
 
     const activatePaperGeneration = (candidate: PaperAuthorityProofBinding) =>
       run(
@@ -1669,101 +1749,7 @@ const makeStore = (config: PaperStoreRuntimeConfig) =>
           const proof = yield* decodePaperAuthorityProofBinding(candidate)
           const binding = yield* requirePaperGenerationRuntime(Authority.Paper, 'activation')
           const fence = yield* WriterFence
-          return yield* fence.transaction(
-            Effect.gen(function* () {
-              const locked = yield* lockPaperAuthority(binding.accountId)
-              if (locked.current.maximum === Authority.Paper) {
-                if (locked.current.generationHash !== binding.configuredGenerationHash) {
-                  return yield* fail(
-                    'authority',
-                    'conflict',
-                    'durable PAPER generation differs from the configured generation',
-                  )
-                }
-                const stored = yield* paperGenerationFromRow(locked.history)
-                if (
-                  stored.accountId !== binding.accountId ||
-                  stored.qualificationRunId !== binding.qualificationRunId ||
-                  stored.activationSourceRevision !== config.build.sourceRevision ||
-                  stored.activationImageRepository !== config.build.imageRepository ||
-                  stored.activationImageDigest !== config.build.imageDigest ||
-                  stored.strategyBehaviorHash !== config.build.strategyBehaviorHash ||
-                  stored.strategyParameterHash !== config.build.strategyParameterHash ||
-                  stored.riskPolicyHash !== proof.riskPolicyHash ||
-                  stored.proofPlanHash !== proof.proofPlanHash
-                ) {
-                  return yield* fail(
-                    'authority',
-                    'conflict',
-                    'PAPER generation history differs from deterministic replay',
-                  )
-                }
-                return locked.current
-              }
-
-              const derived = yield* derivePaperGeneration(proof, binding, locked.current)
-              if (derived.generation.generationHash !== binding.configuredGenerationHash) {
-                return yield* fail(
-                  'authority',
-                  'invariant',
-                  'derived PAPER generation differs from the configured generation',
-                )
-              }
-              if ((yield* readGeneration(derived.generation.generationHash))[0] !== undefined) {
-                return yield* fail('authority', 'conflict', 'authority generation hash was already used')
-              }
-              const activatedAt = yield* validatePaperGenerationFreshness(derived)
-              const input = derived.generation
-              const nextVersion = derived.current.version + 1
-              yield* sql`
-                INSERT INTO authority_generations (
-                  generation_hash, schema_version, activation_schema_version,
-                  previous_generation_hash, maximum, authority_version,
-                  qualification_run_id, qualification_lock_id, qualification_result_hash,
-                  protocol_hash, qualification_execution_policy_hash,
-                  qualification_source_revision, qualification_image_repository,
-                  qualification_image_digest, activation_source_revision,
-                  activation_image_repository, activation_image_digest,
-                  strategy_name, strategy_behavior_hash,
-                  strategy_parameter_hash, strategy_parameter_schema_version, account_id,
-                  risk_policy_hash, proof_plan_hash, reconciliation_id,
-                  reconciliation_content_hash, activated_at
-                ) VALUES (
-                  ${input.generationHash}, 'bayn.authority-generation-history.v1',
-                  ${input.schemaVersion}, ${input.previousGenerationHash}, 'PAPER', ${nextVersion},
-                  ${input.qualificationRunId}, ${input.qualificationLockId},
-                  ${input.qualificationResultHash}, ${input.protocolHash},
-                  ${input.qualificationExecutionPolicyHash}, ${input.qualificationSourceRevision},
-                  ${input.qualificationImageRepository}, ${input.qualificationImageDigest},
-                  ${input.activationSourceRevision}, ${input.activationImageRepository},
-                  ${input.activationImageDigest}, ${input.strategyName},
-                  ${input.strategyBehaviorHash}, ${input.strategyParameterHash},
-                  ${input.strategyParameterSchemaVersion}, ${input.accountId},
-                  ${input.riskPolicyHash}, ${input.proofPlanHash}, ${input.reconciliationId},
-                  ${input.reconciliationContentHash}, ${activatedAt}
-                )
-              `
-              const effective = derived.current.kill === KillState.Active ? Authority.Observe : Authority.Paper
-              const activatedRows = yield* sql<Record<string, unknown>>`
-                UPDATE authority_state
-                SET
-                  generation_hash = ${input.generationHash},
-                  maximum = 'PAPER',
-                  effective = ${effective},
-                  version = version + 1,
-                  updated_at = ${activatedAt}
-                WHERE singleton
-                RETURNING
-                  schema_version, generation_hash, maximum, effective, kill_state, reason,
-                  version::text AS version, updated_at
-              `.pipe(Effect.flatMap(decodeAuthorityStateRows))
-              const activatedRow = activatedRows[0]
-              if (activatedRow === undefined) {
-                return yield* fail('authority', 'invariant', 'PAPER authority was not activated')
-              }
-              return yield* authorityStateFromRow(activatedRow)
-            }),
-          )
+          return yield* fence.transaction(activatePaperGenerationTransaction(proof, binding))
         }),
       )
 


### PR DESCRIPTION
## Summary

- Extracts closed, total `Result` decisions for OBSERVE generation validation/rotation and PAPER preparation, activation, and replay into a narrow pure authority algebra while retaining bounded Effect/PostgreSQL interpreters.
- Preserves the existing OBSERVE/PAPER advisory-lock order, writer fence, post-lock database time, transaction and SQL ordering, append-only generation history, active-kill behavior, replay immutability, and public `PaperStoreError` cause identity.
- Uses one fail-closed safe-next-authority-version decision for OBSERVE and PAPER; the exact returned version drives both history and state writes, including exhaustion before write SQL.
- Adds synchronous algebra coverage and PostgreSQL 18 causal regressions for byte-plus-`xmin` replay/no-write behavior, independent-runtime activation and rotation races, partial rollback, authority-version exhaustion, and immutable discrepancy history without authority restoration.

No broker, TigerBeetle/ledger, CycleObservability, GitOps, migration, qualification, or execution-coordinator production behavior is changed. The diff is limited to the reviewed four-file PaperStore authority slice.

## Related Issues

- [PROOMPT-428](https://linear.app/proompteng/issue/PROOMPT-428)

## Testing

- `bun test services/bayn/src/db/paper-authority-algebra.test.ts` — 6 passed, 97 assertions.
- `BAYN_TEST_POSTGRES_URL=postgresql://bayn:bayn@127.0.0.1:55432/bayn_test bun test services/bayn/src/db/paper-store.integration.test.ts` against PostgreSQL 18.4 — 30 passed, 187 assertions.
- `env -u BAYN_TEST_POSTGRES_URL bun run --filter @proompteng/bayn test` — 606 passed, 116 skipped, 0 failed, 3,249 assertions.
- `bun test packages/scripts/src/bayn` — 20 passed, 61 assertions.
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint:effect` — 138 files, 0 errors/warnings/messages.
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint` — 0 warnings/errors.
- `bun run --filter @proompteng/bayn lint:oxlint:type` — 0 warnings/errors.
- `bun run --filter @proompteng/bayn build` — 529 modules bundled.
- `git diff --check`

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; breaking changes are documented above.
- [x] Documentation and release-note changes are not required; the follow-up is tracked in PROOMPT-428.