### PR TITLE
refactor(bayn): consolidate unsigned round-half-up

### DIFF
--- a/services/bayn/src/accounting.test.ts
+++ b/services/bayn/src/accounting.test.ts
@@ -53,6 +53,33 @@ describe('paper accounting', () => {
     expect(prepared.transaction.notionalMicros).toBe('50000001')
   })
 
+  test('preserves the exact half-up transaction and ledger identity golden', () => {
+    const prepared = prepareAccounting(
+      eventId,
+      fill({ quantityMicros: '500000', priceMicros: '100000001', feeMicros: '2500' }),
+      emptyPosition,
+      7001,
+    )
+
+    expect(prepared.transaction).toMatchObject({
+      transactionId: '5c30c458a20098f8a787b1a9e098c0756bf710f06683a740aba539b20c1a39f8',
+      notionalMicros: '50000001',
+      costBasisMicros: '50000001',
+      cashDeltaMicros: '-50002501',
+      ledgerPlanHash: 'ed64d5c2d5e9dbb34eaf42b9f86d6afb7323478e2550e2921dbd22a3edef3657',
+      contentHash: '7d91dd98ee38ce4a6bb1c0a8e6ad032f6c3da9106847ddcf80c3f2fbf0042222',
+    })
+    expect(prepared.ledger.accounts.map((account) => account.id)).toEqual([
+      11_018_531_402_962_299_880_943_285_336_145_171_022n,
+      162_492_250_068_507_024_268_897_767_784_019_191_926n,
+      256_393_807_197_113_497_662_451_249_474_476_167_056n,
+    ])
+    expect(prepared.ledger.transfers.map((transfer) => [transfer.id, transfer.amount])).toEqual([
+      [67_063_131_099_678_162_361_447_000_629_170_124_156n, 2_500n],
+      [230_986_136_044_309_168_085_596_967_250_981_161_443n, 50_000_001n],
+    ])
+  })
+
   test('uses average cost for a partial sale and records a gain', () => {
     const prepared = prepareAccounting(
       eventId,

--- a/services/bayn/src/accounting.ts
+++ b/services/bayn/src/accounting.ts
@@ -1,5 +1,5 @@
 import { AccountFlags, type Account, type Transfer } from 'tigerbeetle-node'
-import { Schema } from 'effect'
+import { Result, Schema } from 'effect'
 
 import { canonicalHashV1, stableU128, stableU64 } from './hash'
 import { AccountCode, hashLedgerPlan, LEDGER_SCHEMA_VERSION, TransferCode, type LedgerPlan } from './ledger-plan'
@@ -17,6 +17,7 @@ import {
   UtcInstantSchema as UtcInstant,
   strictParseOptions,
 } from './schemas'
+import { roundUnsignedHalfUp } from './unsigned-round-half-up'
 
 const MICROS = 1_000_000n
 type AccountCodeValue = (typeof AccountCode)[keyof typeof AccountCode]
@@ -58,10 +59,11 @@ export interface PreparedAccounting {
 const decodeTransaction = Schema.decodeUnknownSync(AccountingTransactionSchema, strictParseOptions)
 
 const roundDiv = (numerator: bigint, denominator: bigint): bigint => {
-  if (numerator < 0n || denominator <= 0n) {
+  const rounded = roundUnsignedHalfUp(numerator, denominator)
+  if (Result.isFailure(rounded)) {
     throw new Error('fixed-point division requires a non-negative numerator and positive denominator')
   }
-  return (numerator + denominator / 2n) / denominator
+  return rounded.success
 }
 
 const makeAccount = (brokerAccountId: string, ledger: number, name: string, code: AccountCodeValue): Account => {

--- a/services/bayn/src/execution-model.test.ts
+++ b/services/bayn/src/execution-model.test.ts
@@ -8,7 +8,9 @@ import {
   desiredQuantityMicros,
   makeFillTerms,
   makeOrderOutcome,
+  notionalMicros,
   referencePriceMicros,
+  saleCostBasisMicros,
 } from './execution-model'
 
 describe('explicit paper execution model', () => {
@@ -30,6 +32,16 @@ describe('explicit paper execution model', () => {
       slippageCostMicros: 25_000n,
     })
     expect(referencePriceMicros(100.123456, defaultExecutionModel)).toBe(100_123_500n)
+  })
+
+  test('preserves half-up arithmetic and its public error contract', () => {
+    const u128Maximum = (1n << 128n) - 1n
+
+    expect(referencePriceMicros(100.12345, defaultExecutionModel)).toBe(100_123_500n)
+    expect(notionalMicros(500_000n, 100_000_001n)).toBe(50_000_001n)
+    expect(saleCostBasisMicros(1n, 1n, 2n)).toBe(1n)
+    expect(notionalMicros(u128Maximum, 1_000_001n)).toBe(340_282_707_203_305_384_401_838_070_806_375_643_223n)
+    expect(() => notionalMicros(-1n, 1n)).toThrow('roundDiv requires non-negative numerator and denominator')
   })
 
   test('makes full, partial, and rejected outcomes deterministic', () => {

--- a/services/bayn/src/execution-model.ts
+++ b/services/bayn/src/execution-model.ts
@@ -1,5 +1,8 @@
+import { Result } from 'effect'
+
 import { canonicalHashV1 } from './hash'
 import type { ExecutionModel, IsoDate, OrderRejectionReason, OrderStatus } from './types'
+import { roundUnsignedHalfUp } from './unsigned-round-half-up'
 
 export const MICROS = 1_000_000n
 const PPM = 1_000_000n
@@ -78,8 +81,9 @@ const ceilDiv = (numerator: bigint, denominator: bigint): bigint => {
 }
 
 const roundDiv = (numerator: bigint, denominator: bigint): bigint => {
-  if (numerator < 0n || denominator <= 0n) throw new Error('roundDiv requires non-negative numerator and denominator')
-  return (numerator + denominator / 2n) / denominator
+  const rounded = roundUnsignedHalfUp(numerator, denominator)
+  if (Result.isFailure(rounded)) throw new Error('roundDiv requires non-negative numerator and denominator')
+  return rounded.success
 }
 
 const quantizeDown = (value: bigint, increment: bigint): bigint => {

--- a/services/bayn/src/reconciliation.test.ts
+++ b/services/bayn/src/reconciliation.test.ts
@@ -248,6 +248,55 @@ describe('paper reconciliation', () => {
     })
   })
 
+  test('preserves exact-half position cost discrepancy identities and hashes', () => {
+    const result = compareReconciliation(
+      snapshot({
+        positions: [{ ...position, quantityMicros: '500000', averageEntryPriceMicros: '1' }],
+        projectedPositions: [{ symbol: position.symbol, quantityMicros: '500000', costBasisMicros: '0' }],
+      }),
+    )
+
+    expect(result.observedHash).toBe('eddcbffe34a93edb13621d0f3b4a29b4530550fe0947da942bb11cf46d649c91')
+    expect(result.discrepancies).toEqual([
+      {
+        discrepancyId: '82d8cf06a2c0300ed87632447e51b5fc7b03ac37eeb87df44e46edea3a0af96b',
+        kind: DiscrepancyKind.Position,
+        identity: `${position.symbol}:cost`,
+        expected: '0',
+        observed: '1',
+        evidenceHash: 'bc9bfb97cb8744667e423365862a52d76046a352ee1398ee82274f0c2a07783d',
+      },
+    ])
+  })
+
+  test('preserves reconciliation output above U128 and its exact evidence hashes', () => {
+    const quantityMicros = '170141183460469231731687303715884105727'
+    const result = compareReconciliation(
+      snapshot({
+        positions: [
+          {
+            ...position,
+            quantityMicros,
+            averageEntryPriceMicros: '340282366920938463463374607431768211455',
+          },
+        ],
+        projectedPositions: [{ symbol: position.symbol, quantityMicros, costBasisMicros: '0' }],
+      }),
+    )
+
+    expect(result.observedHash).toBe('7d475d168ec5d130dbc08418eb200deef0775f8ab8339c453e3016a2d3caa7f1')
+    expect(result.discrepancies).toEqual([
+      {
+        discrepancyId: '82d8cf06a2c0300ed87632447e51b5fc7b03ac37eeb87df44e46edea3a0af96b',
+        kind: DiscrepancyKind.Position,
+        identity: `${position.symbol}:cost`,
+        expected: '0',
+        observed: '57896044618658097711785492504343953926124568782438874324533730092808913',
+        evidenceHash: '937546e66a02272e1b3bbc238fdf84721746ebd04d30f6de5deae0627ad0bafd',
+      },
+    ])
+  })
+
   test('keeps a ledger discrepancy identity stable while its evidence changes', () => {
     const first = compareReconciliation(snapshot({ ledgerExact: false, accountingHash: hash('a') }))
     const second = compareReconciliation(snapshot({ ledgerExact: false, accountingHash: hash('b') }))

--- a/services/bayn/src/reconciliation.ts
+++ b/services/bayn/src/reconciliation.ts
@@ -1,3 +1,5 @@
+import { Result } from 'effect'
+
 import { canonicalHashV1 } from './hash'
 import {
   AccountStatus,
@@ -14,6 +16,7 @@ import {
   type Valuation,
 } from './paper'
 import type { IsoDate } from './schemas'
+import { roundUnsignedHalfUp } from './unsigned-round-half-up'
 
 export interface IntentExpectation {
   readonly intentId: string
@@ -124,7 +127,11 @@ const expectedResolution = '<resolved>'
 const openOrder = '<open>'
 
 const absolute = (value: bigint): bigint => (value < 0n ? -value : value)
-const roundMicrosProduct = (left: bigint, right: bigint): bigint => (left * right + 500_000n) / 1_000_000n
+const roundMicrosProduct = (left: bigint, right: bigint): bigint => {
+  const rounded = roundUnsignedHalfUp(left * right, 1_000_000n)
+  if (Result.isFailure(rounded)) throw new Error('position cost material is outside the unsigned fixed-point range')
+  return rounded.success
+}
 
 export const reconciledStateHash = (state: ReconciledStateMaterial): string => {
   const brokerStateHash = canonicalHashV1({

--- a/services/bayn/src/unsigned-round-half-up.test.ts
+++ b/services/bayn/src/unsigned-round-half-up.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from 'bun:test'
+import { Result } from 'effect'
+
+import { roundUnsignedHalfUp, type UnsignedRoundHalfUpFailure } from './unsigned-round-half-up'
+
+const success = (result: Result.Result<bigint, UnsignedRoundHalfUpFailure>): bigint => {
+  expect(Result.isSuccess(result)).toBe(true)
+  if (Result.isFailure(result)) throw new Error(result.failure._tag)
+  return result.success
+}
+
+const failure = (result: Result.Result<bigint, UnsignedRoundHalfUpFailure>): UnsignedRoundHalfUpFailure => {
+  expect(Result.isFailure(result)).toBe(true)
+  if (Result.isSuccess(result)) throw new Error(`unexpected rounded value ${result.success}`)
+  return result.failure
+}
+
+const legacyRoundHalfUp = (numerator: bigint, denominator: bigint): bigint =>
+  (numerator + denominator / 2n) / denominator
+
+describe('unsigned round-half-up', () => {
+  test('matches the prior formula and exact golden vectors', () => {
+    const vectors: ReadonlyArray<readonly [bigint, bigint, bigint]> = [
+      [0n, 1n, 0n],
+      [4n, 10n, 0n],
+      [5n, 10n, 1n],
+      [6n, 10n, 1n],
+      [14n, 10n, 1n],
+      [15n, 10n, 2n],
+      [1n, 3n, 0n],
+      [2n, 3n, 1n],
+    ]
+
+    for (const [numerator, denominator, expected] of vectors) {
+      expect(success(roundUnsignedHalfUp(numerator, denominator))).toBe(expected)
+      expect(expected).toBe(legacyRoundHalfUp(numerator, denominator))
+    }
+  })
+
+  test('preserves unbounded BigInt inputs and outputs', () => {
+    const u128Maximum = (1n << 128n) - 1n
+    const formerNumeratorBoundary = u128Maximum * u128Maximum
+    const quotient = (1n << 512n) + 123n
+    const evenDenominator = (1n << 320n) + 2n
+    const oddDenominator = (1n << 320n) + 1n
+    const vectors: ReadonlyArray<readonly [bigint, bigint, bigint]> = [
+      [quotient * evenDenominator + evenDenominator / 2n, evenDenominator, quotient + 1n],
+      [quotient * oddDenominator + oddDenominator / 2n, oddDenominator, quotient],
+      [quotient * oddDenominator + oddDenominator / 2n + 1n, oddDenominator, quotient + 1n],
+    ]
+
+    for (const [numerator, denominator, expected] of vectors) {
+      expect(numerator > formerNumeratorBoundary).toBe(true)
+      expect(denominator > u128Maximum).toBe(true)
+      expect(expected > u128Maximum).toBe(true)
+      expect(success(roundUnsignedHalfUp(numerator, denominator))).toBe(expected)
+      expect(expected).toBe(legacyRoundHalfUp(numerator, denominator))
+    }
+  })
+
+  test('retains exact invalid numerator and denominator material', () => {
+    expect(failure(roundUnsignedHalfUp(-1n, 7n))).toEqual({
+      _tag: 'NegativeUnsignedRoundHalfUpNumerator',
+      numerator: -1n,
+      denominator: 7n,
+      minimumNumerator: 0n,
+    })
+    expect(failure(roundUnsignedHalfUp(7n, 0n))).toEqual({
+      _tag: 'NonPositiveUnsignedRoundHalfUpDenominator',
+      numerator: 7n,
+      denominator: 0n,
+      minimumDenominator: 1n,
+    })
+    expect(failure(roundUnsignedHalfUp(7n, -1n))).toEqual({
+      _tag: 'NonPositiveUnsignedRoundHalfUpDenominator',
+      numerator: 7n,
+      denominator: -1n,
+      minimumDenominator: 1n,
+    })
+  })
+})

--- a/services/bayn/src/unsigned-round-half-up.ts
+++ b/services/bayn/src/unsigned-round-half-up.ts
@@ -1,0 +1,38 @@
+import { Result } from 'effect'
+
+export type UnsignedRoundHalfUpFailure =
+  | {
+      readonly _tag: 'NegativeUnsignedRoundHalfUpNumerator'
+      readonly numerator: bigint
+      readonly denominator: bigint
+      readonly minimumNumerator: 0n
+    }
+  | {
+      readonly _tag: 'NonPositiveUnsignedRoundHalfUpDenominator'
+      readonly numerator: bigint
+      readonly denominator: bigint
+      readonly minimumDenominator: 1n
+    }
+
+export const roundUnsignedHalfUp = (
+  numerator: bigint,
+  denominator: bigint,
+): Result.Result<bigint, UnsignedRoundHalfUpFailure> => {
+  if (numerator < 0n) {
+    return Result.fail({
+      _tag: 'NegativeUnsignedRoundHalfUpNumerator',
+      numerator,
+      denominator,
+      minimumNumerator: 0n,
+    })
+  }
+  if (denominator <= 0n) {
+    return Result.fail({
+      _tag: 'NonPositiveUnsignedRoundHalfUpDenominator',
+      numerator,
+      denominator,
+      minimumDenominator: 1n,
+    })
+  }
+  return Result.succeed((numerator + denominator / 2n) / denominator)
+}


### PR DESCRIPTION
## Summary

- introduce one total pure `Result` helper for unsigned round-half-up arithmetic with unbounded `bigint` inputs
- route the existing accounting, execution-model, and reconciliation half-up calculations through that helper without changing valid outputs or public error contracts
- add exact golden, invalid-input, and above-U128 regressions covering durable hashes, ledger identities, and reconciliation evidence

## Related Issues

Related to PROOMPT-418.

## Testing

- `bun test services/bayn/src/unsigned-round-half-up.test.ts services/bayn/src/accounting.test.ts services/bayn/src/execution-model.test.ts services/bayn/src/reconciliation.test.ts` (30 passed, 121 assertions)
- `bun run --filter @proompteng/bayn tsc`
- `bunx oxfmt --check services/bayn/src/unsigned-round-half-up.ts services/bayn/src/unsigned-round-half-up.test.ts services/bayn/src/accounting.ts services/bayn/src/accounting.test.ts services/bayn/src/execution-model.ts services/bayn/src/execution-model.test.ts services/bayn/src/reconciliation.ts services/bayn/src/reconciliation.test.ts`
- `bunx oxlint --deny-warnings services/bayn/src/unsigned-round-half-up.ts services/bayn/src/accounting.ts services/bayn/src/execution-model.ts services/bayn/src/reconciliation.ts`
- `git diff --check origin/main...HEAD`
- two independent exact-tree reviews approved unbounded-BigInt compatibility and preservation of hashes, IDs, ordering, and failure behavior

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots section removed because this source-only refactor has no UI.
- [x] Breaking Changes section is filled in.
- [x] Documentation, release notes, and follow-ups are updated or tracked in PROOMPT-418.
