### PR TITLE
fix(hermes): raise code tool-call limit

### DIFF
--- a/argocd/applications/hermes/config.yaml
+++ b/argocd/applications/hermes/config.yaml
@@ -160,7 +160,7 @@ delegation:
 
 code_execution:
   timeout: 120
-  max_tool_calls: 10
+  max_tool_calls: 100
 
 stt:
   enabled: false

--- a/scripts/hermes/validate-production.test.ts
+++ b/scripts/hermes/validate-production.test.ts
@@ -114,6 +114,18 @@ test('rejects a gateway working directory above the lab checkout', async () => {
   )
 })
 
+test('rejects a reduced code-execution tool-call budget', async () => {
+  const files = await loadProductionFiles()
+  files.config = files.config.replace(
+    'code_execution:\n  timeout: 120\n  max_tool_calls: 100',
+    'code_execution:\n  timeout: 120\n  max_tool_calls: 10',
+  )
+
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.config}: missing production invariant \"code_execution:\\n  timeout: 120\\n  max_tool_calls: 100\"`,
+  )
+})
+
 test('rejects a gateway container started outside the lab checkout', async () => {
   const files = await loadProductionFiles()
   files.statefulSet = files.statefulSet.replace(

--- a/scripts/hermes/validate-production.ts
+++ b/scripts/hermes/validate-production.ts
@@ -310,6 +310,7 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     'mcp_servers: {}',
     'hooks_auto_accept: false',
     'memory_char_limit: 4400',
+    'code_execution:\n  timeout: 120\n  max_tool_calls: 100',
     'Treat /opt/data/workspace/tuslagch/lab as the project root and default working directory',
     'Use the authenticated tuslagch GitHub identity, codex/ branches, and pull requests',
     'platform_toolsets:\n  cli: [file, memory, terminal, todo]\n  api_server: [file, memory, terminal, todo]\n  discord: [file, memory, terminal, todo]',


### PR DESCRIPTION
## Summary

- Raise Hermes programmatic code-execution tool calls from 10 to 100 per execution.
- Enforce the production value in the Hermes validator and add regression coverage against a reduced budget.
- Preserve the existing safety, approval, RBAC, network, and tool-loop guardrails.

## Related Issues

None

## Testing

- `bun test scripts/hermes/*.test.ts` — 124 passed, 0 failed.
- `bun run scripts/hermes/validate-production.ts` — validated 42 Hermes production surfaces.
- `bun run lint:argocd` — all kubeconform batches completed with 0 invalid resources and 0 errors.
- `bunx oxfmt --check argocd/applications/hermes/config.yaml scripts/hermes/validate-production.ts scripts/hermes/validate-production.test.ts` — passed.
- `kustomize build argocd/applications/hermes` plus pinned kubeconform 0.7.0 — 36 valid, 0 invalid, 0 errors, 2 skipped.

## Rollout and Impact

- Merge through normal CI, then manually sync the `hermes` Argo CD application with pruning disabled.
- The hash-named `hermes-config` ConfigMap changes from `hermes-config-bhkbf24hdc` to `hermes-config-t468mfmh7d`, which updates the StatefulSet pod template and performs a controlled single-replica restart.
- Expect a brief Hermes API and Discord interruption while `hermes-0` restarts. No data, secret, RBAC, network-policy, model, or image changes are included.
- Verify the new ConfigMap, StatefulSet revision, mounted runtime config, config check, detailed health endpoint, and restart count after reconciliation.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.