### PR TITLE
refactor(bayn): make broker observations functional

### DIFF
--- a/services/bayn/src/broker/observations.test.ts
+++ b/services/bayn/src/broker/observations.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'bun:test'
+import { Result } from 'effect'
 
 import {
   AccountStatus as AlpacaAccountStatus,
@@ -18,7 +19,21 @@ import {
   type ReadEvidence,
 } from './alpaca'
 import { AccountStatus, OrderSide, OrderStatus } from '../paper'
-import { accountObservation, fillObservation, orderObservation, positionSnapshot } from './observations'
+import {
+  accountObservation,
+  fillObservation,
+  orderObservation,
+  positionSnapshot,
+  renderBrokerObservationError,
+  sourceTimestamp,
+  type BrokerObservationError,
+} from './observations'
+
+const success = <A>(result: Result.Result<A, BrokerObservationError>): A => Result.getOrThrow(result)
+const failure = <A>(result: Result.Result<A, BrokerObservationError>): BrokerObservationError => {
+  if (Result.isFailure(result)) return result.failure
+  return expect.unreachable('expected broker observation failure')
+}
 
 const observedAt = '2026-07-22T15:30:01.000Z'
 const evidence: ReadEvidence = {
@@ -80,8 +95,8 @@ const activity: FillActivity = {
 
 describe('paper broker observations', () => {
   test('normalizes account status and preserves observation freshness', () => {
-    const first = accountObservation({ value: account, evidence })
-    const replay = accountObservation({ value: account, evidence: { ...evidence, requestId: 'request-2' } })
+    const first = success(accountObservation({ value: account, evidence }))
+    const replay = success(accountObservation({ value: account, evidence: { ...evidence, requestId: 'request-2' } }))
 
     expect(first._tag).toBe('Account')
     if (first._tag !== 'Account') throw new Error('expected account observation')
@@ -89,13 +104,15 @@ describe('paper broker observations', () => {
     expect(first.sourceEventId).toBe(`account:${evidence.contentHash}:${observedAt}`)
     expect(replay).toEqual(first)
     const laterObservedAt = '2026-07-22T15:31:01.000Z'
-    const later = accountObservation({
-      value: { ...account, observedAt: laterObservedAt },
-      evidence: { ...evidence, observedAt: laterObservedAt },
-    })
+    const later = success(
+      accountObservation({
+        value: { ...account, observedAt: laterObservedAt },
+        evidence: { ...evidence, observedAt: laterObservedAt },
+      }),
+    )
     expect(later.sourceEventId).not.toBe(first.sourceEventId)
     expect(later.contentHash).toBe(first.contentHash)
-    const restricted = accountObservation({ value: { ...account, tradingBlocked: true }, evidence })
+    const restricted = success(accountObservation({ value: { ...account, tradingBlocked: true }, evidence }))
     expect(restricted._tag === 'Account' && restricted.account.status).toBe(AccountStatus.Restricted)
   })
 
@@ -130,27 +147,29 @@ describe('paper broker observations', () => {
         observedAt,
       },
     ]
-    const snapshot = positionSnapshot(account.id, { value: positions, evidence })
+    const snapshot = success(positionSnapshot(account.id, { value: positions, evidence }))
     const events = snapshot.positions
 
     expect(events).toHaveLength(2)
     expect(events.map((event) => (event._tag === 'Position' ? event.position.symbol : ''))).toEqual(['AMD', 'NVDA'])
     expect(new Set(events.map((event) => event.sourceEventId)).size).toBe(2)
     const laterObservedAt = '2026-07-22T15:31:01.000Z'
-    const later = positionSnapshot(account.id, {
-      value: positions.map((position) => ({ ...position, observedAt: laterObservedAt })),
-      evidence: { ...evidence, observedAt: laterObservedAt },
-    }).positions
+    const later = success(
+      positionSnapshot(account.id, {
+        value: positions.map((position) => ({ ...position, observedAt: laterObservedAt })),
+        evidence: { ...evidence, observedAt: laterObservedAt },
+      }),
+    ).positions
     expect(later.map((event) => event.sourceEventId)).not.toEqual(events.map((event) => event.sourceEventId))
     expect(later.map((event) => event.contentHash)).toEqual(events.map((event) => event.contentHash))
-    expect(() =>
-      positionSnapshot(account.id, { value: [positions[0], { ...positions[1], symbol: 'NVDA' }], evidence }),
-    ).toThrow('duplicate Alpaca position symbol')
-    expect(positionSnapshot(account.id, { value: [], evidence }).positions).toEqual([])
+    expect(
+      failure(positionSnapshot(account.id, { value: [positions[0], { ...positions[1], symbol: 'NVDA' }], evidence })),
+    ).toEqual({ _tag: 'DuplicatePositionSymbol', symbol: 'NVDA' })
+    expect(success(positionSnapshot(account.id, { value: [], evidence })).positions).toEqual([])
   })
 
   test('maps a partially filled pending order without discarding fill state', () => {
-    const event = orderObservation(order, evidence, 'b'.repeat(64))
+    const event = success(orderObservation(order, evidence, 'b'.repeat(64)))
 
     expect(event._tag).toBe('Order')
     if (event._tag !== 'Order') throw new Error('expected order observation')
@@ -162,16 +181,18 @@ describe('paper broker observations', () => {
     })
     expect(event.occurredAt).toBe('2026-07-22T15:30:00.500Z')
     expect(event.sourceEventId).toBe(`order:${order.brokerOrderId}:${order.updatedAt}`)
-    expect(() => orderObservation({ ...order, extendedHours: true }, evidence)).toThrow(
-      'paper execution requires extended hours to be disabled',
-    )
-    expect(() => orderObservation({ ...order, updatedAt: undefined }, evidence)).toThrow(
-      'paper order event requires Alpaca updated_at',
-    )
+    expect(failure(orderObservation({ ...order, extendedHours: true }, evidence))).toEqual({
+      _tag: 'ExtendedHoursUnsupported',
+      brokerOrderId: order.brokerOrderId,
+    })
+    expect(failure(orderObservation({ ...order, updatedAt: undefined }, evidence))).toEqual({
+      _tag: 'OrderUpdatedAtMissing',
+      brokerOrderId: order.brokerOrderId,
+    })
   })
 
   test('binds a fill to its order and defaults paper fees to zero', () => {
-    const event = fillObservation(activity, order, evidence, { intentId: 'b'.repeat(64) })
+    const event = success(fillObservation(activity, order, evidence, { intentId: 'b'.repeat(64) }))
 
     expect(event.fill).toMatchObject({
       fillId: activity.activityId,
@@ -181,8 +202,36 @@ describe('paper broker observations', () => {
       occurredAt: '2026-07-22T15:30:00.000Z',
     })
     expect(event.sourceTimestamp).toBe('2026-07-22T15:30:00.000987000Z')
-    expect(() => fillObservation({ ...activity, symbol: 'AMD' }, order, evidence)).toThrow(
-      'Alpaca fill activity does not match its order',
-    )
+    expect(failure(fillObservation({ ...activity, symbol: 'AMD' }, order, evidence))).toEqual({
+      _tag: 'FillOrderMismatch',
+      activityId: activity.activityId,
+      brokerOrderId: order.brokerOrderId,
+    })
+  })
+
+  test('returns closed fact-bearing failures for malformed broker observations', () => {
+    expect(failure(sourceTimestamp('not-a-timestamp'))).toEqual({
+      _tag: 'TimestampInvalid',
+      value: 'not-a-timestamp',
+    })
+    expect(failure(sourceTimestamp('2026-99-99T15:30:00Z'))).toEqual({
+      _tag: 'TimestampInvalid',
+      value: '2026-99-99T15:30:00Z',
+    })
+    expect(
+      failure(
+        accountObservation({
+          value: account,
+          evidence: { ...evidence, observedAt: '2026-07-22T15:30:02.000Z' },
+        }),
+      ),
+    ).toEqual({
+      _tag: 'ObservationTimeMismatch',
+      valueObservedAt: observedAt,
+      evidenceObservedAt: '2026-07-22T15:30:02.000Z',
+    })
+    const unsupported = failure(orderObservation({ ...order, orderType: AlpacaOrderType.Stop }, evidence))
+    expect(unsupported).toEqual({ _tag: 'UnsupportedOrderType', value: AlpacaOrderType.Stop })
+    expect(renderBrokerObservationError(unsupported)).toBe('unsupported paper order type stop')
   })
 })

--- a/services/bayn/src/broker/observations.ts
+++ b/services/bayn/src/broker/observations.ts
@@ -1,4 +1,4 @@
-import { Schema } from 'effect'
+import { Result, Schema, pipe } from 'effect'
 
 import { canonicalHashV1 } from '../hash'
 import {
@@ -80,22 +80,99 @@ export const ValuationInputSchema = Schema.Struct({
 })
 export type ValuationInput = typeof ValuationInputSchema.Type
 
-const decodeEvent = Schema.decodeUnknownSync(BrokerEventInputSchema, strictParseOptions)
-const decodeFill = Schema.decodeUnknownSync(FillEventInputSchema, strictParseOptions)
-const decodePosition = Schema.decodeUnknownSync(PositionEventInputSchema, strictParseOptions)
-const decodePositionSnapshot = Schema.decodeUnknownSync(PositionSnapshotInputSchema, strictParseOptions)
+type ObservationTarget = 'account' | 'fill' | 'order' | 'position' | 'position-snapshot'
 
-const canonicalInstant = (value: string): string => new Date(value).toISOString()
+export type BrokerObservationError =
+  | { readonly _tag: 'DecodeFailed'; readonly target: ObservationTarget; readonly cause: unknown }
+  | { readonly _tag: 'CanonicalizationFailed'; readonly target: ObservationTarget; readonly cause: unknown }
+  | { readonly _tag: 'TimestampInvalid'; readonly value: string }
+  | {
+      readonly _tag: 'ObservationTimeMismatch'
+      readonly valueObservedAt: string
+      readonly evidenceObservedAt: string
+    }
+  | { readonly _tag: 'UnsupportedOrderType'; readonly value: AlpacaOrderType }
+  | { readonly _tag: 'UnsupportedTimeInForce'; readonly value: AlpacaTimeInForce }
+  | {
+      readonly _tag: 'FilledQuantityInvalid'
+      readonly filledQuantityMicros: string
+      readonly quantityMicros: string
+    }
+  | { readonly _tag: 'UnsupportedOrderStatus'; readonly value: AlpacaOrderStatus }
+  | { readonly _tag: 'DuplicatePositionAsset'; readonly assetId: string }
+  | { readonly _tag: 'DuplicatePositionSymbol'; readonly symbol: string }
+  | {
+      readonly _tag: 'PositionAccountMismatch'
+      readonly expectedAccountId: string
+      readonly accountIds: readonly string[]
+    }
+  | { readonly _tag: 'QuantityOrderRequired'; readonly brokerOrderId: string }
+  | { readonly _tag: 'ExtendedHoursUnsupported'; readonly brokerOrderId: string }
+  | { readonly _tag: 'OrderUpdatedAtMissing'; readonly brokerOrderId: string }
+  | {
+      readonly _tag: 'FillOrderMismatch'
+      readonly activityId: string
+      readonly brokerOrderId: string
+    }
 
-export const sourceTimestamp = (value: string): string => {
+const fail = <A>(error: BrokerObservationError): Result.Result<A, BrokerObservationError> => Result.fail(error)
+
+const decode =
+  <A>(target: ObservationTarget, schema: Schema.Codec<A>) =>
+  (value: unknown): Result.Result<A, BrokerObservationError> =>
+    pipe(
+      Schema.decodeUnknownResult(schema, strictParseOptions)(value),
+      Result.mapError((cause): BrokerObservationError => ({ _tag: 'DecodeFailed', target, cause })),
+    )
+
+const decodeEvent = (
+  target: Extract<ObservationTarget, 'account' | 'order'>,
+  value: unknown,
+): Result.Result<BrokerEventInput, BrokerObservationError> => decode(target, BrokerEventInputSchema)(value)
+const decodeFill = decode('fill', FillEventInputSchema)
+const decodePosition = decode('position', PositionEventInputSchema)
+const decodePositionSnapshot = decode('position-snapshot', PositionSnapshotInputSchema)
+
+const canonicalHash = (target: ObservationTarget, value: unknown): Result.Result<string, BrokerObservationError> =>
+  pipe(
+    Result.try(() => canonicalHashV1(value)),
+    Result.mapError((cause): BrokerObservationError => ({ _tag: 'CanonicalizationFailed', target, cause })),
+  )
+
+export const sourceTimestamp = (value: string): Result.Result<string, BrokerObservationError> => {
   const match = /^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})(?:\.(\d{1,9}))?Z$/.exec(value)
-  if (match === null) throw new Error('broker timestamp is not a UTC RFC 3339 instant')
-  return `${match[1]}.${(match[2] ?? '').padEnd(9, '0')}Z`
+  if (match === null) return fail({ _tag: 'TimestampInvalid', value })
+  return pipe(
+    Schema.decodeUnknownResult(
+      UtcOrderTimestamp,
+      strictParseOptions,
+    )(`${match[1]}.${(match[2] ?? '').padEnd(9, '0')}Z`),
+    Result.mapError((): BrokerObservationError => ({ _tag: 'TimestampInvalid', value })),
+  )
 }
 
-const assertObservationTime = (observedAt: string, evidence: ReadEvidence): void => {
-  if (observedAt !== evidence.observedAt) throw new Error('normalized broker payload and response evidence disagree')
-}
+const canonicalInstant = (value: string): Result.Result<string, BrokerObservationError> =>
+  pipe(
+    sourceTimestamp(value),
+    Result.flatMap((timestamp) =>
+      pipe(
+        Schema.decodeUnknownResult(UtcInstant, strictParseOptions)(`${timestamp.slice(0, 23)}Z`),
+        Result.mapError((): BrokerObservationError => ({ _tag: 'TimestampInvalid', value })),
+      ),
+    ),
+  )
+
+const validateObservationTime = (
+  observedAt: string,
+  evidence: ReadEvidence,
+): Result.Result<void, BrokerObservationError> =>
+  observedAt === evidence.observedAt
+    ? Result.succeed(undefined)
+    : fail({
+        _tag: 'ObservationTimeMismatch',
+        valueObservedAt: observedAt,
+        evidenceObservedAt: evidence.observedAt,
+      })
 
 const withoutObservedAt = <A extends { readonly observedAt: string }>(value: A): Omit<A, 'observedAt'> => {
   const { observedAt: _observedAt, ...content } = value
@@ -117,55 +194,76 @@ const accountStatus = (account: AlpacaAccount): AccountStatus => {
 
 const side = (value: AlpacaOrderSide): OrderSide => (value === AlpacaOrderSide.Buy ? OrderSide.Buy : OrderSide.Sell)
 
-const orderType = (value: AlpacaOrderType): OrderType => {
+const orderType = (value: AlpacaOrderType): Result.Result<OrderType, BrokerObservationError> => {
   switch (value) {
     case AlpacaOrderType.Market:
-      return OrderType.Market
+      return Result.succeed(OrderType.Market)
     case AlpacaOrderType.Limit:
-      return OrderType.Limit
+      return Result.succeed(OrderType.Limit)
     default:
-      throw new Error(`unsupported paper order type ${value}`)
+      return fail({ _tag: 'UnsupportedOrderType', value })
   }
 }
 
-const timeInForce = (value: AlpacaTimeInForce): TimeInForce => {
+const timeInForce = (value: AlpacaTimeInForce): Result.Result<TimeInForce, BrokerObservationError> => {
   switch (value) {
     case AlpacaTimeInForce.Day:
-      return TimeInForce.Day
+      return Result.succeed(TimeInForce.Day)
     case AlpacaTimeInForce.GoodUntilCanceled:
-      return TimeInForce.GoodUntilCanceled
+      return Result.succeed(TimeInForce.GoodUntilCanceled)
     case AlpacaTimeInForce.ImmediateOrCancel:
-      return TimeInForce.ImmediateOrCancel
+      return Result.succeed(TimeInForce.ImmediateOrCancel)
     case AlpacaTimeInForce.FillOrKill:
-      return TimeInForce.FillOrKill
+      return Result.succeed(TimeInForce.FillOrKill)
     default:
-      throw new Error(`unsupported paper time in force ${value}`)
+      return fail({ _tag: 'UnsupportedTimeInForce', value })
   }
 }
 
-const nonterminalStatus = (filledQuantityMicros: string, quantityMicros: string): OrderStatus => {
-  const filled = BigInt(filledQuantityMicros)
-  const quantity = BigInt(quantityMicros)
-  if (filled === 0n) return OrderStatus.Pending
-  if (filled < quantity) return OrderStatus.PartiallyFilled
-  if (filled === quantity) return OrderStatus.Filled
-  throw new Error('Alpaca filled quantity exceeds order quantity')
-}
+const nonterminalStatus = (
+  filledQuantityMicros: string,
+  quantityMicros: string,
+): Result.Result<OrderStatus, BrokerObservationError> =>
+  pipe(
+    Result.try(() => ({ filled: BigInt(filledQuantityMicros), quantity: BigInt(quantityMicros) })),
+    Result.mapError(
+      (): BrokerObservationError => ({
+        _tag: 'FilledQuantityInvalid',
+        filledQuantityMicros,
+        quantityMicros,
+      }),
+    ),
+    Result.flatMap(({ filled, quantity }) =>
+      filled === 0n
+        ? Result.succeed(OrderStatus.Pending)
+        : filled < quantity
+          ? Result.succeed(OrderStatus.PartiallyFilled)
+          : filled === quantity
+            ? Result.succeed(OrderStatus.Filled)
+            : fail({ _tag: 'FilledQuantityInvalid', filledQuantityMicros, quantityMicros }),
+    ),
+  )
 
-const orderStatus = (value: AlpacaOrderStatus, filledQuantityMicros: string, quantityMicros: string): OrderStatus => {
+const orderStatus = (
+  value: AlpacaOrderStatus,
+  filledQuantityMicros: string,
+  quantityMicros: string,
+): Result.Result<OrderStatus, BrokerObservationError> => {
   switch (value) {
     case AlpacaOrderStatus.New:
-      return filledQuantityMicros === '0' ? OrderStatus.New : nonterminalStatus(filledQuantityMicros, quantityMicros)
+      return filledQuantityMicros === '0'
+        ? Result.succeed(OrderStatus.New)
+        : nonterminalStatus(filledQuantityMicros, quantityMicros)
     case AlpacaOrderStatus.PartiallyFilled:
-      return OrderStatus.PartiallyFilled
+      return Result.succeed(OrderStatus.PartiallyFilled)
     case AlpacaOrderStatus.Filled:
-      return OrderStatus.Filled
+      return Result.succeed(OrderStatus.Filled)
     case AlpacaOrderStatus.Canceled:
-      return OrderStatus.Canceled
+      return Result.succeed(OrderStatus.Canceled)
     case AlpacaOrderStatus.Expired:
-      return OrderStatus.Expired
+      return Result.succeed(OrderStatus.Expired)
     case AlpacaOrderStatus.Rejected:
-      return OrderStatus.Rejected
+      return Result.succeed(OrderStatus.Rejected)
     case AlpacaOrderStatus.Accepted:
     case AlpacaOrderStatus.AcceptedForBidding:
     case AlpacaOrderStatus.PendingCancel:
@@ -179,12 +277,13 @@ const orderStatus = (value: AlpacaOrderStatus, filledQuantityMicros: string, qua
     case AlpacaOrderStatus.Suspended:
       return nonterminalStatus(filledQuantityMicros, quantityMicros)
     default:
-      throw new Error(`unsupported paper order status ${value}`)
+      return fail({ _tag: 'UnsupportedOrderStatus', value })
   }
 }
 
-export const accountObservation = (result: ReadResult<AlpacaAccount>): BrokerEventInput => {
-  assertObservationTime(result.value.observedAt, result.evidence)
+export const accountObservation = (
+  result: ReadResult<AlpacaAccount>,
+): Result.Result<BrokerEventInput, BrokerObservationError> => {
   const account = {
     schemaVersion: 'bayn.paper-account-snapshot.v1' as const,
     accountId: result.value.id,
@@ -195,159 +294,285 @@ export const accountObservation = (result: ReadResult<AlpacaAccount>): BrokerEve
     buyingPowerMicros: result.value.buyingPowerMicros,
     observedAt: result.value.observedAt,
   }
-  return decodeEvent({
-    _tag: 'Account',
-    broker: Broker.Alpaca,
-    accountId: account.accountId,
-    sourceEventId: `account:${result.evidence.contentHash}:${result.evidence.observedAt}`,
-    contentHash: canonicalHashV1({
-      schemaVersion: 'bayn.paper-account-source.v1',
-      responseContentHash: result.evidence.contentHash,
-      account: withoutObservedAt(account),
+  return pipe(
+    Result.all({
+      observationTime: validateObservationTime(result.value.observedAt, result.evidence),
+      contentHash: canonicalHash('account', {
+        schemaVersion: 'bayn.paper-account-source.v1',
+        responseContentHash: result.evidence.contentHash,
+        account: withoutObservedAt(account),
+      }),
     }),
-    occurredAt: account.observedAt,
-    observedAt: account.observedAt,
-    account,
-  })
+    Result.flatMap(({ contentHash }) =>
+      decodeEvent('account', {
+        _tag: 'Account',
+        broker: Broker.Alpaca,
+        accountId: account.accountId,
+        sourceEventId: `account:${result.evidence.contentHash}:${result.evidence.observedAt}`,
+        contentHash,
+        occurredAt: account.observedAt,
+        observedAt: account.observedAt,
+        account,
+      }),
+    ),
+  )
 }
 
-const positionObservations = (result: ReadResult<readonly AlpacaPosition[]>): readonly PositionEventInput[] => {
-  const identities = new Set<string>()
-  const symbols = new Set<string>()
-  return [...result.value]
-    .sort((left, right) => (left.symbol < right.symbol ? -1 : left.symbol > right.symbol ? 1 : 0))
-    .map((value) => {
-      assertObservationTime(value.observedAt, result.evidence)
-      if (identities.has(value.assetId)) throw new Error(`duplicate Alpaca position asset ${value.assetId}`)
-      if (symbols.has(value.symbol)) throw new Error(`duplicate Alpaca position symbol ${value.symbol}`)
-      identities.add(value.assetId)
-      symbols.add(value.symbol)
-      const position = {
-        schemaVersion: 'bayn.paper-position.v1' as const,
-        accountId: value.accountId,
-        symbol: value.symbol,
-        quantityMicros: value.quantityMicros,
-        averageEntryPriceMicros: value.averageEntryPriceMicros,
-        marketPriceMicros: value.marketPriceMicros,
-        marketValueMicros: value.marketValueMicros,
-        unrealizedPnlMicros: value.unrealizedPnlMicros,
-        observedAt: value.observedAt,
-      }
-      return decodePosition({
+const positionObservation = (
+  value: AlpacaPosition,
+  evidence: ReadEvidence,
+): Result.Result<PositionEventInput, BrokerObservationError> => {
+  const position = {
+    schemaVersion: 'bayn.paper-position.v1' as const,
+    accountId: value.accountId,
+    symbol: value.symbol,
+    quantityMicros: value.quantityMicros,
+    averageEntryPriceMicros: value.averageEntryPriceMicros,
+    marketPriceMicros: value.marketPriceMicros,
+    marketValueMicros: value.marketValueMicros,
+    unrealizedPnlMicros: value.unrealizedPnlMicros,
+    observedAt: value.observedAt,
+  }
+  return pipe(
+    Result.all({
+      observationTime: validateObservationTime(value.observedAt, evidence),
+      contentHash: canonicalHash('position', {
+        schemaVersion: 'bayn.paper-position-source.v1',
+        responseContentHash: evidence.contentHash,
+        position: withoutObservedAt(position),
+      }),
+    }),
+    Result.flatMap(({ contentHash }) =>
+      decodePosition({
         _tag: 'Position',
         broker: Broker.Alpaca,
         accountId: position.accountId,
-        sourceEventId: `position:${result.evidence.contentHash}:${result.evidence.observedAt}:${value.assetId}`,
-        contentHash: canonicalHashV1({
-          schemaVersion: 'bayn.paper-position-source.v1',
-          responseContentHash: result.evidence.contentHash,
-          position: withoutObservedAt(position),
-        }),
+        sourceEventId: `position:${evidence.contentHash}:${evidence.observedAt}:${value.assetId}`,
+        contentHash,
         occurredAt: position.observedAt,
         observedAt: position.observedAt,
         position,
-      })
-    })
+      }),
+    ),
+  )
+}
+
+const duplicatePosition = (positions: readonly AlpacaPosition[]): BrokerObservationError | undefined => {
+  const duplicateAsset = positions.find(
+    (position, index) => positions.findIndex((candidate) => candidate.assetId === position.assetId) !== index,
+  )
+  if (duplicateAsset !== undefined) return { _tag: 'DuplicatePositionAsset', assetId: duplicateAsset.assetId }
+  const duplicateSymbol = positions.find(
+    (position, index) => positions.findIndex((candidate) => candidate.symbol === position.symbol) !== index,
+  )
+  return duplicateSymbol === undefined ? undefined : { _tag: 'DuplicatePositionSymbol', symbol: duplicateSymbol.symbol }
 }
 
 export const positionSnapshot = (
   accountId: string,
   result: ReadResult<readonly AlpacaPosition[]>,
-): PositionSnapshotInput => {
-  if (result.value.some((position) => position.accountId !== accountId)) {
-    throw new Error('Alpaca position response contains another account')
-  }
-  return decodePositionSnapshot({
-    accountId,
-    sourceHash: result.evidence.contentHash,
-    observedAt: result.evidence.observedAt,
-    positions: positionObservations(result),
-  })
+): Result.Result<PositionSnapshotInput, BrokerObservationError> => {
+  const accountIds = [...new Set(result.value.map((position) => position.accountId))].sort()
+  const accountMismatch = accountIds.some((observedAccountId) => observedAccountId !== accountId)
+  const ordered = [...result.value].sort((left, right) => left.symbol.localeCompare(right.symbol))
+  const duplicate = duplicatePosition(ordered)
+  return accountMismatch
+    ? fail({ _tag: 'PositionAccountMismatch', expectedAccountId: accountId, accountIds })
+    : duplicate !== undefined
+      ? fail(duplicate)
+      : pipe(
+          Result.all(ordered.map((position) => positionObservation(position, result.evidence))),
+          Result.flatMap((positions) =>
+            decodePositionSnapshot({
+              accountId,
+              sourceHash: result.evidence.contentHash,
+              observedAt: result.evidence.observedAt,
+              positions,
+            }),
+          ),
+        )
 }
 
-export const orderObservation = (value: AlpacaOrder, evidence: ReadEvidence, intentId?: string): BrokerEventInput => {
-  assertObservationTime(value.observedAt, evidence)
-  if (value.quantityMicros === undefined || value.notionalMicros !== undefined) {
-    throw new Error('paper accounting requires a quantity order')
-  }
-  if (value.extendedHours) throw new Error('paper execution requires extended hours to be disabled')
-  if (value.updatedAt === undefined) throw new Error('paper order event requires Alpaca updated_at')
-  const updatedAt = value.updatedAt
-  const order = {
-    schemaVersion: 'bayn.paper-order.v1' as const,
-    accountId: value.accountId,
-    brokerOrderId: value.brokerOrderId,
-    clientOrderId: value.clientOrderId,
-    ...(intentId === undefined ? {} : { intentId }),
-    symbol: value.symbol,
-    side: side(value.side),
-    orderType: orderType(value.orderType),
-    timeInForce: timeInForce(value.timeInForce),
-    quantityMicros: value.quantityMicros,
-    filledQuantityMicros: value.filledQuantityMicros,
-    ...(value.limitPriceMicros === undefined ? {} : { limitPriceMicros: value.limitPriceMicros }),
-    status: orderStatus(value.status, value.filledQuantityMicros, value.quantityMicros),
-    observedAt: value.observedAt,
-  }
-  const occurredAt = canonicalInstant(updatedAt)
-  return decodeEvent({
-    _tag: 'Order',
-    broker: Broker.Alpaca,
-    accountId: order.accountId,
-    sourceEventId: `order:${order.brokerOrderId}:${updatedAt}`,
-    contentHash: canonicalHashV1({
-      schemaVersion: 'bayn.paper-order-source.v1',
-      order: withoutObservedAt(order),
-      brokerUpdatedAt: updatedAt,
-    }),
-    occurredAt,
-    observedAt: order.observedAt,
-    order,
-  })
+type QuantityOrder = AlpacaOrder & {
+  readonly quantityMicros: string
+  readonly notionalMicros?: undefined
+  readonly updatedAt: string
 }
+
+const validateOrderShape = (
+  value: AlpacaOrder,
+  evidence: ReadEvidence,
+): Result.Result<QuantityOrder, BrokerObservationError> => {
+  const quantityMicros = value.quantityMicros
+  if (quantityMicros === undefined || value.notionalMicros !== undefined) {
+    return fail({ _tag: 'QuantityOrderRequired', brokerOrderId: value.brokerOrderId })
+  }
+  if (value.extendedHours) {
+    return fail({ _tag: 'ExtendedHoursUnsupported', brokerOrderId: value.brokerOrderId })
+  }
+  const updatedAt = value.updatedAt
+  if (updatedAt === undefined) {
+    return fail({ _tag: 'OrderUpdatedAtMissing', brokerOrderId: value.brokerOrderId })
+  }
+  return pipe(
+    validateObservationTime(value.observedAt, evidence),
+    Result.map(() => ({
+      ...value,
+      quantityMicros,
+      notionalMicros: undefined,
+      updatedAt,
+    })),
+  )
+}
+
+export const orderObservation = (
+  value: AlpacaOrder,
+  evidence: ReadEvidence,
+  intentId?: string,
+): Result.Result<BrokerEventInput, BrokerObservationError> =>
+  pipe(
+    validateOrderShape(value, evidence),
+    Result.flatMap((validated) =>
+      pipe(
+        Result.all({
+          orderType: orderType(validated.orderType),
+          timeInForce: timeInForce(validated.timeInForce),
+          status: orderStatus(validated.status, validated.filledQuantityMicros, validated.quantityMicros),
+          occurredAt: canonicalInstant(validated.updatedAt),
+        }),
+        Result.flatMap(({ occurredAt, orderType: normalizedOrderType, status, timeInForce: normalizedTimeInForce }) => {
+          const order = {
+            schemaVersion: 'bayn.paper-order.v1' as const,
+            accountId: validated.accountId,
+            brokerOrderId: validated.brokerOrderId,
+            clientOrderId: validated.clientOrderId,
+            ...(intentId === undefined ? {} : { intentId }),
+            symbol: validated.symbol,
+            side: side(validated.side),
+            orderType: normalizedOrderType,
+            timeInForce: normalizedTimeInForce,
+            quantityMicros: validated.quantityMicros,
+            filledQuantityMicros: validated.filledQuantityMicros,
+            ...(validated.limitPriceMicros === undefined ? {} : { limitPriceMicros: validated.limitPriceMicros }),
+            status,
+            observedAt: validated.observedAt,
+          }
+          return pipe(
+            canonicalHash('order', {
+              schemaVersion: 'bayn.paper-order-source.v1',
+              order: withoutObservedAt(order),
+              brokerUpdatedAt: validated.updatedAt,
+            }),
+            Result.flatMap((contentHash) =>
+              decodeEvent('order', {
+                _tag: 'Order',
+                broker: Broker.Alpaca,
+                accountId: order.accountId,
+                sourceEventId: `order:${order.brokerOrderId}:${validated.updatedAt}`,
+                contentHash,
+                occurredAt,
+                observedAt: order.observedAt,
+                order,
+              }),
+            ),
+          )
+        }),
+      ),
+    ),
+  )
 
 export const fillObservation = (
   activity: FillActivity,
   order: AlpacaOrder,
   evidence: ReadEvidence,
   options: { readonly intentId?: string; readonly feeMicros?: string } = {},
-): FillEventInput => {
-  if (
-    activity.accountId !== order.accountId ||
-    activity.brokerOrderId !== order.brokerOrderId ||
-    activity.symbol !== order.symbol ||
-    activity.side !== order.side
-  ) {
-    throw new Error('Alpaca fill activity does not match its order')
+): Result.Result<FillEventInput, BrokerObservationError> => {
+  const matchesOrder =
+    activity.accountId === order.accountId &&
+    activity.brokerOrderId === order.brokerOrderId &&
+    activity.symbol === order.symbol &&
+    activity.side === order.side
+  return matchesOrder
+    ? pipe(
+        Result.all({
+          occurredAt: canonicalInstant(activity.transactionTime),
+          sourceTimestamp: sourceTimestamp(activity.transactionTime),
+        }),
+        Result.flatMap(({ occurredAt, sourceTimestamp: normalizedSourceTimestamp }) => {
+          const fill = {
+            schemaVersion: 'bayn.paper-fill.v1' as const,
+            accountId: activity.accountId,
+            fillId: activity.activityId,
+            brokerOrderId: activity.brokerOrderId,
+            clientOrderId: order.clientOrderId,
+            ...(options.intentId === undefined ? {} : { intentId: options.intentId }),
+            symbol: activity.symbol,
+            side: side(activity.side),
+            quantityMicros: activity.quantityMicros,
+            priceMicros: activity.priceMicros,
+            feeMicros: options.feeMicros ?? '0',
+            occurredAt,
+          }
+          return pipe(
+            canonicalHash('fill', {
+              schemaVersion: 'bayn.paper-fill-source.v1',
+              fill,
+              brokerTransactionTime: activity.transactionTime,
+            }),
+            Result.flatMap((contentHash) =>
+              decodeFill({
+                _tag: 'Fill',
+                broker: Broker.Alpaca,
+                accountId: fill.accountId,
+                sourceEventId: fill.fillId,
+                sourceTimestamp: normalizedSourceTimestamp,
+                contentHash,
+                occurredAt: fill.occurredAt,
+                observedAt: evidence.observedAt,
+                fill,
+              }),
+            ),
+          )
+        }),
+      )
+    : fail({
+        _tag: 'FillOrderMismatch',
+        activityId: activity.activityId,
+        brokerOrderId: order.brokerOrderId,
+      })
+}
+
+export const renderBrokerObservationError = (error: BrokerObservationError): string => {
+  switch (error._tag) {
+    case 'DecodeFailed':
+      return `${error.target} observation failed strict decoding`
+    case 'CanonicalizationFailed':
+      return `${error.target} observation failed canonical hashing`
+    case 'TimestampInvalid':
+      return `broker timestamp is not a UTC RFC 3339 instant: ${error.value}`
+    case 'ObservationTimeMismatch':
+      return `broker payload observation ${error.valueObservedAt} does not match response evidence ${error.evidenceObservedAt}`
+    case 'UnsupportedOrderType':
+      return `unsupported paper order type ${error.value}`
+    case 'UnsupportedTimeInForce':
+      return `unsupported paper time in force ${error.value}`
+    case 'FilledQuantityInvalid':
+      return `filled quantity ${error.filledQuantityMicros} exceeds or is invalid for order quantity ${error.quantityMicros}`
+    case 'UnsupportedOrderStatus':
+      return `unsupported paper order status ${error.value}`
+    case 'DuplicatePositionAsset':
+      return `duplicate Alpaca position asset ${error.assetId}`
+    case 'DuplicatePositionSymbol':
+      return `duplicate Alpaca position symbol ${error.symbol}`
+    case 'PositionAccountMismatch':
+      return `Alpaca position accounts ${error.accountIds.join(',')} do not match ${error.expectedAccountId}`
+    case 'QuantityOrderRequired':
+      return `paper accounting requires quantity order ${error.brokerOrderId}`
+    case 'ExtendedHoursUnsupported':
+      return `paper execution requires extended hours disabled for ${error.brokerOrderId}`
+    case 'OrderUpdatedAtMissing':
+      return `paper order ${error.brokerOrderId} requires Alpaca updated_at`
+    case 'FillOrderMismatch':
+      return `Alpaca fill ${error.activityId} does not match order ${error.brokerOrderId}`
   }
-  const occurredAt = canonicalInstant(activity.transactionTime)
-  const fill = {
-    schemaVersion: 'bayn.paper-fill.v1' as const,
-    accountId: activity.accountId,
-    fillId: activity.activityId,
-    brokerOrderId: activity.brokerOrderId,
-    clientOrderId: order.clientOrderId,
-    ...(options.intentId === undefined ? {} : { intentId: options.intentId }),
-    symbol: activity.symbol,
-    side: side(activity.side),
-    quantityMicros: activity.quantityMicros,
-    priceMicros: activity.priceMicros,
-    feeMicros: options.feeMicros ?? '0',
-    occurredAt,
-  }
-  return decodeFill({
-    _tag: 'Fill',
-    broker: Broker.Alpaca,
-    accountId: fill.accountId,
-    sourceEventId: fill.fillId,
-    sourceTimestamp: sourceTimestamp(activity.transactionTime),
-    contentHash: canonicalHashV1({
-      schemaVersion: 'bayn.paper-fill-source.v1',
-      fill,
-      brokerTransactionTime: activity.transactionTime,
-    }),
-    occurredAt: fill.occurredAt,
-    observedAt: evidence.observedAt,
-    fill,
-  })
 }

--- a/services/bayn/src/db/paper-store.integration.test.ts
+++ b/services/bayn/src/db/paper-store.integration.test.ts
@@ -723,7 +723,7 @@ const fillEvent = (
   quantityMicros: string,
   priceMicros: string,
   eventOccurredAt = occurredAt,
-  brokerTimestamp = sourceTimestamp(eventOccurredAt),
+  brokerTimestamp = Result.getOrThrow(sourceTimestamp(eventOccurredAt)),
   eventAccountId = accountId,
   eventObservedAt = observedAt,
 ): FillEventInput => {
@@ -2699,7 +2699,7 @@ describePostgres('paper accounting persistence', () => {
       '1000000',
       '70000000',
       '2026-07-21T19:58:00.000Z',
-      sourceTimestamp('2026-07-21T19:58:00.000Z'),
+      Result.getOrThrow(sourceTimestamp('2026-07-21T19:58:00.000Z')),
       accountId,
       '2026-07-21T19:58:01.000Z',
     )
@@ -2709,7 +2709,7 @@ describePostgres('paper accounting persistence', () => {
       '1000000',
       '70000000',
       '2026-07-21T19:59:00.000Z',
-      sourceTimestamp('2026-07-21T19:59:00.000Z'),
+      Result.getOrThrow(sourceTimestamp('2026-07-21T19:59:00.000Z')),
       accountId,
       '2026-07-21T19:59:01.000Z',
     )
@@ -2720,7 +2720,7 @@ describePostgres('paper accounting persistence', () => {
       '1000000',
       '70000000',
       occurredAt,
-      sourceTimestamp(occurredAt),
+      Result.getOrThrow(sourceTimestamp(occurredAt)),
       otherAccountId,
     )
     try {

--- a/services/bayn/src/reconciler.test.ts
+++ b/services/bayn/src/reconciler.test.ts
@@ -395,18 +395,8 @@ describe('paper reconciliation loop', () => {
     expect(control.restrictions).toEqual(['reconciliation pass incomplete'])
   })
 
-  test('retains the exact Error cause of a normalization failure', async () => {
-    const normalizationCause = new Error('injected normalization failure')
-    let extendedHoursReads = 0
-    const malformedOrder = new Proxy(order(0), {
-      get: (target, property, receiver) => {
-        if (property === 'extendedHours') {
-          extendedHoursReads += 1
-          if (extendedHoursReads === 3) throw normalizationCause
-        }
-        return Reflect.get(target, property, receiver)
-      },
-    })
+  test('retains the exact typed cause of a normalization failure', async () => {
+    const malformedOrder = { ...order(0), extendedHours: true }
     const read: BrokerReadShape = {
       ...emptyRead(),
       orders: () => Effect.succeed({ value: [malformedOrder], evidence: evidence('orders') }),
@@ -422,47 +412,21 @@ describe('paper reconciliation loop', () => {
     expect(failure).toMatchObject({
       _tag: 'ReconciliationError',
       operation: 'normalization',
-      message: 'broker snapshot normalization failed',
+      message: `paper execution requires extended hours disabled for ${malformedOrder.brokerOrderId}`,
       failure: {
         _tag: 'Normalization',
         stage: 'order',
         identity: malformedOrder.brokerOrderId,
+        error: {
+          _tag: 'ExtendedHoursUnsupported',
+          brokerOrderId: malformedOrder.brokerOrderId,
+        },
       },
     })
-    expect(failure.cause).toBe(normalizationCause)
-    expect(failure.failure.cause).toBe(normalizationCause)
-    expect(extendedHoursReads).toBe(3)
-    expect(control.writes).toBe(0)
-    expect(control.reconciliations).toEqual([])
-    expect(control.restrictions).toEqual(['reconciliation pass incomplete'])
-  })
-
-  test('propagates a non-Error normalization throw as a defect after restricting authority', async () => {
-    const defect = { _tag: 'InjectedNormalizationDefect' }
-    let extendedHoursReads = 0
-    const throwingOrder = new Proxy(order(0), {
-      get: (target, property, receiver) => {
-        if (property === 'extendedHours') {
-          extendedHoursReads += 1
-          if (extendedHoursReads === 3) throw defect
-        }
-        return Reflect.get(target, property, receiver)
-      },
+    expect(failure.cause).toEqual({
+      _tag: 'ExtendedHoursUnsupported',
+      brokerOrderId: malformedOrder.brokerOrderId,
     })
-    const read: BrokerReadShape = {
-      ...emptyRead(),
-      orders: () => Effect.succeed({ value: [throwingOrder], evidence: evidence('orders') }),
-    }
-    const control: StoreControl = { writes: 0, reconciliations: [], restrictions: [] }
-
-    const exit = await Effect.runPromiseExit(provide(read, makeStore(control)))
-
-    expect(Exit.isFailure(exit)).toBe(true)
-    if (Exit.isFailure(exit)) {
-      const defects = exit.cause.reasons.flatMap((reason) => (Cause.isDieReason(reason) ? [reason.defect] : []))
-      expect(defects).toContain(defect)
-    }
-    expect(extendedHoursReads).toBe(3)
     expect(control.writes).toBe(0)
     expect(control.reconciliations).toEqual([])
     expect(control.restrictions).toEqual(['reconciliation pass incomplete'])
@@ -486,7 +450,7 @@ describe('paper reconciliation loop', () => {
     expect(failure).toMatchObject({
       _tag: 'ReconciliationError',
       operation: 'normalization',
-      message: 'broker snapshot normalization failed',
+      message: `duplicate broker client order ID ${first.clientOrderId}`,
       failure: {
         _tag: 'Validation',
         reason: 'DuplicateBrokerClientOrderId',

--- a/services/bayn/src/reconciler.ts
+++ b/services/bayn/src/reconciler.ts
@@ -1,4 +1,4 @@
-import { Cause, Chunk, Clock, Data, Effect, Exit, HashMap, HashSet, Option, Result } from 'effect'
+import { Cause, Chunk, Clock, Data, Effect, Exit, HashMap, HashSet, Option, Result, pipe } from 'effect'
 
 import {
   BrokerRead,
@@ -18,8 +18,10 @@ import {
   fillObservation,
   orderObservation,
   positionSnapshot,
+  renderBrokerObservationError,
   sourceTimestamp,
   type BrokerEventInput,
+  type BrokerObservationError,
   type FillEventInput,
   type PositionSnapshotInput,
 } from './broker/observations'
@@ -38,7 +40,6 @@ const maximumRows = 10_000
 const ordersPageSize = 500
 const fillsPageSize = 100
 const incompletePassReason = 'reconciliation pass incomplete'
-const normalizationMessage = 'broker snapshot normalization failed'
 
 interface Observed<A> {
   readonly value: A
@@ -106,11 +107,7 @@ type ValidationFailureReason =
   | 'FillOrderMissing'
   | 'UnexpectedAccountEvent'
 
-type NormalizationStage = 'order' | 'fill-ordering' | 'fill' | 'account' | 'positions'
-
-type NormalizationDecisionFailure =
-  | ReconciliationError
-  | { readonly _tag: 'Defect'; readonly cause: Cause.Cause<never> }
+type NormalizationStage = 'order-timestamp' | 'order' | 'fill-ordering' | 'fill' | 'account' | 'positions'
 
 type ReconciliationFailure =
   | { readonly _tag: 'Pagination'; readonly reason: PaginationFailureReason }
@@ -120,7 +117,7 @@ type ReconciliationFailure =
       readonly _tag: 'Normalization'
       readonly stage: NormalizationStage
       readonly identity?: string
-      readonly cause: Error
+      readonly error: BrokerObservationError
     }
   | {
       readonly _tag: 'AuthorityRestrictionFailed'
@@ -156,38 +153,42 @@ const snapshotFailure = (reason: SnapshotFailureReason, message: string): Reconc
 const validationFailure = (reason: ValidationFailureReason, detail: string): ReconciliationError =>
   new ReconciliationError({
     operation: 'normalization',
-    message: normalizationMessage,
+    message: detail,
     failure: { _tag: 'Validation', reason, detail },
   })
 
-const decideNormalizationFailure = (
+const normalizationFailure = (
   stage: NormalizationStage,
   identity: string | undefined,
-  cause: unknown,
-): NormalizationDecisionFailure => {
-  if (!(cause instanceof Error)) return { _tag: 'Defect', cause: Cause.die(cause) }
-  return new ReconciliationError({
+  error: BrokerObservationError,
+): ReconciliationError =>
+  new ReconciliationError({
     operation: 'normalization',
-    message: normalizationMessage,
-    cause,
+    message: renderBrokerObservationError(error),
+    cause: error,
     failure: {
       _tag: 'Normalization',
       stage,
       ...(identity === undefined ? {} : { identity }),
-      cause,
+      error,
     },
   })
-}
 
-const normalizationAttempt = <A>(
+const mapObservationFailure = <A>(
   stage: NormalizationStage,
   identity: string | undefined,
-  evaluate: () => A,
-): Result.Result<A, NormalizationDecisionFailure> =>
-  Result.try({
-    try: evaluate,
-    catch: (cause) => decideNormalizationFailure(stage, identity, cause),
-  })
+  result: Result.Result<A, BrokerObservationError>,
+): Result.Result<A, ReconciliationError> =>
+  pipe(
+    result,
+    Result.mapError((error) => normalizationFailure(stage, identity, error)),
+  )
+
+const normalizeTimestamp = (
+  stage: Extract<NormalizationStage, 'order-timestamp' | 'fill-ordering'>,
+  identity: string,
+  value: string,
+): Result.Result<string, ReconciliationError> => mapObservationFailure(stage, identity, sourceTimestamp(value))
 
 const compareText = (left: string, right: string): number => (left < right ? -1 : left > right ? 1 : 0)
 
@@ -265,10 +266,34 @@ const decideOrderPage = (
       }
 
       const previousSubmittedAt = result.success.previousSubmittedAt
-      if (previousSubmittedAt !== undefined && sourceTimestamp(submittedAt) < sourceTimestamp(previousSubmittedAt)) {
+      const normalizedSubmittedAt = normalizeTimestamp('order-timestamp', order.brokerOrderId, submittedAt)
+      if (Result.isFailure(normalizedSubmittedAt)) return Result.fail(normalizedSubmittedAt.failure)
+      const normalizedPrevious =
+        previousSubmittedAt === undefined
+          ? undefined
+          : normalizeTimestamp('order-timestamp', order.brokerOrderId, previousSubmittedAt)
+      if (normalizedPrevious !== undefined && Result.isFailure(normalizedPrevious)) {
+        return Result.fail(normalizedPrevious.failure)
+      }
+      const normalizedCursor =
+        state.cursor === undefined
+          ? undefined
+          : normalizeTimestamp('order-timestamp', order.brokerOrderId, state.cursor)
+      if (normalizedCursor !== undefined && Result.isFailure(normalizedCursor)) {
+        return Result.fail(normalizedCursor.failure)
+      }
+      if (
+        normalizedPrevious !== undefined &&
+        Result.isSuccess(normalizedPrevious) &&
+        normalizedSubmittedAt.success < normalizedPrevious.success
+      ) {
         return Result.fail(paginationFailure('OrderHistoryNotAscending', 'Alpaca order history is not ascending'))
       }
-      if (state.cursor !== undefined && sourceTimestamp(submittedAt) <= sourceTimestamp(state.cursor)) {
+      if (
+        normalizedCursor !== undefined &&
+        Result.isSuccess(normalizedCursor) &&
+        normalizedSubmittedAt.success <= normalizedCursor.success
+      ) {
         return Result.fail(
           paginationFailure('OrderTimestampCursorDidNotAdvance', 'Alpaca order timestamp cursor did not advance'),
         )
@@ -461,8 +486,8 @@ const readStableBrokerSnapshot = (
 
 const indexBindings = (
   bindings: readonly IntentBinding[],
-): Result.Result<HashMap.HashMap<string, string>, NormalizationDecisionFailure> =>
-  bindings.reduce<Result.Result<HashMap.HashMap<string, string>, NormalizationDecisionFailure>>((result, binding) => {
+): Result.Result<HashMap.HashMap<string, string>, ReconciliationError> =>
+  bindings.reduce<Result.Result<HashMap.HashMap<string, string>, ReconciliationError>>((result, binding) => {
     if (Result.isFailure(result)) return result
     if (HashMap.has(result.success, binding.clientOrderId)) {
       return Result.fail(
@@ -481,8 +506,8 @@ interface OrderNormalizationState {
 const normalizeOrders = (
   rows: readonly Observed<BrokerOrder>[],
   intentByClient: HashMap.HashMap<string, string>,
-): Result.Result<OrderNormalizationState, NormalizationDecisionFailure> =>
-  rows.reduce<Result.Result<OrderNormalizationState, NormalizationDecisionFailure>>(
+): Result.Result<OrderNormalizationState, ReconciliationError> =>
+  rows.reduce<Result.Result<OrderNormalizationState, ReconciliationError>>(
     (result, observed) => {
       if (Result.isFailure(result)) return result
       if (HashSet.has(result.success.clientOrderIds, observed.value.clientOrderId)) {
@@ -494,7 +519,9 @@ const normalizeOrders = (
         )
       }
 
-      const normalized = normalizationAttempt('order', observed.value.brokerOrderId, () =>
+      const normalized = mapObservationFailure(
+        'order',
+        observed.value.brokerOrderId,
         orderObservation(
           observed.value,
           observed.evidence,
@@ -522,27 +549,32 @@ const normalizeFills = (
   fills: readonly Observed<FillActivity>[],
   orders: OrderNormalizationState,
   intentByClient: HashMap.HashMap<string, string>,
-): Result.Result<readonly FillEventInput[], NormalizationDecisionFailure> => {
-  const ordered = normalizationAttempt('fill-ordering', undefined, () =>
-    [...fills].sort((left, right) => {
-      const byTime = compareText(
-        sourceTimestamp(left.value.transactionTime),
-        sourceTimestamp(right.value.transactionTime),
-      )
-      return byTime === 0 ? compareText(left.value.activityId, right.value.activityId) : byTime
-    }),
+): Result.Result<readonly FillEventInput[], ReconciliationError> => {
+  const timestamped = Result.all(
+    fills.map((observed) =>
+      pipe(
+        normalizeTimestamp('fill-ordering', observed.value.activityId, observed.value.transactionTime),
+        Result.map((timestamp) => ({ observed, timestamp })),
+      ),
+    ),
   )
-  if (Result.isFailure(ordered)) return Result.fail(ordered.failure)
+  if (Result.isFailure(timestamped)) return Result.fail(timestamped.failure)
+  const ordered = [...timestamped.success].sort((left, right) => {
+    const byTime = compareText(left.timestamp, right.timestamp)
+    return byTime === 0 ? compareText(left.observed.value.activityId, right.observed.value.activityId) : byTime
+  })
 
   return Result.all(
-    ordered.success.map((observed) => {
+    ordered.map(({ observed }) => {
       const order = Option.getOrUndefined(HashMap.get(orders.orderById, observed.value.brokerOrderId))
       if (order === undefined) {
         return Result.fail(
           validationFailure('FillOrderMissing', `Alpaca fill ${observed.value.activityId} references a missing order`),
         )
       }
-      return normalizationAttempt('fill', observed.value.activityId, () =>
+      return mapObservationFailure(
+        'fill',
+        observed.value.activityId,
         fillObservation(observed.value, order, observed.evidence, {
           intentId: Option.getOrUndefined(HashMap.get(intentByClient, order.clientOrderId)),
         }),
@@ -553,8 +585,8 @@ const normalizeFills = (
 
 const normalizeAccount = (
   account: ReadResult<BrokerAccount>,
-): Result.Result<AccountEventInput, NormalizationDecisionFailure> => {
-  const normalized = normalizationAttempt('account', account.value.id, () => accountObservation(account))
+): Result.Result<AccountEventInput, ReconciliationError> => {
+  const normalized = mapObservationFailure('account', account.value.id, accountObservation(account))
   if (Result.isFailure(normalized)) return Result.fail(normalized.failure)
   return normalized.success._tag === 'Account'
     ? Result.succeed(normalized.success)
@@ -564,13 +596,13 @@ const normalizeAccount = (
 const normalizePositions = (
   accountId: string,
   positions: ReadResult<readonly BrokerPosition[]>,
-): Result.Result<PositionSnapshotInput, NormalizationDecisionFailure> =>
-  normalizationAttempt('positions', accountId, () => positionSnapshot(accountId, positions))
+): Result.Result<PositionSnapshotInput, ReconciliationError> =>
+  mapObservationFailure('positions', accountId, positionSnapshot(accountId, positions))
 
 const normalizeSnapshot = (
   snapshot: StableBrokerSnapshot,
   bindings: readonly IntentBinding[],
-): Result.Result<NormalizedBrokerSnapshot, NormalizationDecisionFailure> =>
+): Result.Result<NormalizedBrokerSnapshot, ReconciliationError> =>
   Result.gen(function* () {
     const intentByClient = yield* indexBindings(bindings)
     const orders = yield* normalizeOrders(snapshot.history.orders.rows, intentByClient)
@@ -586,16 +618,8 @@ const normalizeSnapshot = (
   })
 
 const interpretNormalizationDecision = <A>(
-  decision: Result.Result<A, NormalizationDecisionFailure>,
-): Effect.Effect<A, ReconciliationError> => {
-  if (Result.isSuccess(decision)) return Effect.succeed(decision.success)
-  switch (decision.failure._tag) {
-    case 'ReconciliationError':
-      return Effect.fail(decision.failure)
-    case 'Defect':
-      return Effect.failCause(decision.failure.cause)
-  }
-}
+  decision: Result.Result<A, ReconciliationError>,
+): Effect.Effect<A, ReconciliationError> => Effect.fromResult(decision)
 
 const decideAccountBaseline = (hasAccountBaseline: boolean): Result.Result<void, ReconciliationError> =>
   hasAccountBaseline


### PR DESCRIPTION
## Summary

- replace throwing broker observation normalization with a closed, fact-bearing `Result` error algebra
- decode, validate, timestamp, and hash account, position, order, and fill observations through pure pipelines
- make reconciliation consume typed observation failures directly while preserving fail-closed authority containment

## Related Issues

None

## Testing

- `bun run --filter @proompteng/bayn tsc`
- `bun test services/bayn/src/broker/observations.test.ts services/bayn/src/reconciler.test.ts` (19 pass, 0 fail)
- `bun run --filter @proompteng/bayn test` (611 pass, 116 PostgreSQL-gated skips, 0 fail)
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:effect`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn build`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.