### PR TITLE
refactor(bayn): make reconciliation functional

### DIFF
--- a/services/bayn/src/db/reconciliation-algebra.test.ts
+++ b/services/bayn/src/db/reconciliation-algebra.test.ts
@@ -322,7 +322,7 @@ describe('PostgreSQL reconciliation algebra', () => {
     })
   })
 
-  test('rejects accounting before the opening snapshot and contains comparison throws', () => {
+  test('rejects accounting before the opening snapshot and preserves typed comparison failures', () => {
     const exact = makeComparison()
     const predates = failureOf(
       compareOpeningCash({
@@ -394,9 +394,21 @@ describe('PostgreSQL reconciliation algebra', () => {
       }),
     )
     expect(duplicateComparison).toMatchObject({
-      _tag: 'AccountingProjectionFailed',
-      operation: 'reconciliation-comparison',
-      cause: expect.any(Error),
+      _tag: 'ReconciliationDecisionFailed',
+      error: {
+        _tag: 'DuplicateIdentity',
+        collection: 'broker-client-order',
+        identity: order.clientOrderId,
+      },
+    })
+    expect(reconciliationAlgebraFailureDetails(duplicateComparison)).toMatchObject({
+      failure: 'invariant',
+      message: `duplicate broker-client-order identity ${order.clientOrderId}`,
+      cause: {
+        _tag: 'DuplicateIdentity',
+        collection: 'broker-client-order',
+        identity: order.clientOrderId,
+      },
     })
     expect(exact.comparison.discrepancies).toEqual([])
   })

--- a/services/bayn/src/db/reconciliation-algebra.ts
+++ b/services/bayn/src/db/reconciliation-algebra.ts
@@ -28,10 +28,12 @@ import {
 import {
   compareReconciliation,
   reconciledStateHash,
+  renderReconciliationDecisionError,
   type DurableFill,
   type IntentExpectation,
   type ProjectedPosition,
   type ReconciliationComparison,
+  type ReconciliationDecisionError,
   type ReconciliationRiskContext,
 } from '../reconciliation'
 import { strictParseOptions, type IsoDate } from '../schemas'
@@ -108,11 +110,7 @@ export interface RiskContextRow {
   readonly peak_equity_micros: string
 }
 
-type AccountingProjectionOperation =
-  | 'accounting-hash'
-  | 'expected-cash'
-  | 'reconciliation-comparison'
-  | 'reconciled-state-hash'
+type AccountingProjectionOperation = 'accounting-hash' | 'expected-cash'
 
 type ReconciliationIdentityOperation = 'content-hash' | 'decode' | 'reconciliation-id'
 
@@ -135,6 +133,10 @@ export type ReconciliationAlgebraFailure =
       readonly _tag: 'AccountingProjectionFailed'
       readonly operation: AccountingProjectionOperation
       readonly cause: unknown
+    }
+  | {
+      readonly _tag: 'ReconciliationDecisionFailed'
+      readonly error: ReconciliationDecisionError
     }
   | {
       readonly _tag: 'DuplicateReconciliationDiscrepancy'
@@ -351,7 +353,7 @@ export const compareOpeningCash = (input: {
         ledgerExact: input.ledgerExact,
       }),
     )
-    const stateHash = yield* accountingProjection('reconciled-state-hash', () =>
+    const stateHash = yield* Result.mapError(
       reconciledStateHash({
         account: input.snapshot.account,
         positions: input.snapshot.positions,
@@ -360,8 +362,9 @@ export const compareOpeningCash = (input: {
         ordersObservedAt: input.snapshot.ordersObservedAt,
         accountingHash,
       }),
+      (error): ReconciliationAlgebraFailure => ({ _tag: 'ReconciliationDecisionFailed', error }),
     )
-    const comparison = yield* accountingProjection('reconciliation-comparison', () =>
+    const comparison = yield* Result.mapError(
       compareReconciliation({
         accountId: input.accountId,
         stateHash,
@@ -378,6 +381,7 @@ export const compareOpeningCash = (input: {
         ledgerExact: input.ledgerExact,
         reconciledAt: input.snapshot.reconciledAt,
       }),
+      (error): ReconciliationAlgebraFailure => ({ _tag: 'ReconciliationDecisionFailed', error }),
     )
     return { accountingHash, comparison }
   })
@@ -638,6 +642,12 @@ export const reconciliationAlgebraFailureDetails = (
         failure: 'invariant',
         message: `paper accounting ${failure.operation} computation failed`,
         cause: failure.cause,
+      }
+    case 'ReconciliationDecisionFailed':
+      return {
+        failure: 'invariant',
+        message: renderReconciliationDecisionError(failure.error),
+        cause: failure.error,
       }
     case 'DuplicateReconciliationDiscrepancy':
       return {

--- a/services/bayn/src/observe-composition.test.ts
+++ b/services/bayn/src/observe-composition.test.ts
@@ -179,14 +179,16 @@ const account: AccountSnapshot = {
 }
 
 const reconciliation = (): Reconciliation => {
-  const stateHash = reconciledStateHash({
-    account,
-    positions: [],
-    positionsObservedAt: reconciledAt,
-    orders: [],
-    ordersObservedAt: reconciledAt,
-    accountingHash,
-  })
+  const stateHash = Result.getOrThrow(
+    reconciledStateHash({
+      account,
+      positions: [],
+      positionsObservedAt: reconciledAt,
+      orders: [],
+      ordersObservedAt: reconciledAt,
+      accountingHash,
+    }),
+  )
   const material = {
     schemaVersion: 'bayn.paper-reconciliation.v1' as const,
     accountId,

--- a/services/bayn/src/observe-composition.ts
+++ b/services/bayn/src/observe-composition.ts
@@ -299,10 +299,8 @@ const prepareExecutionSessionBinding = (
 ): Result.Result<ExecutionSessionBinding, ExecutionSessionBindingFailure | ObserveDecisionCompositionFailure> => {
   const finalizedSnapshot = facts.snapshot.manifest.finalizedSnapshot
   return Result.flatMap(
-    Result.mapError(
-      Result.try(() => reconciledStateHash(facts.reconciliation.brokerState)),
-      (cause) =>
-        compositionFailure('reconciled-state-hash', 'same-pass reconciled broker state is not canonicalizable', cause),
+    Result.mapError(reconciledStateHash(facts.reconciliation.brokerState), (cause) =>
+      compositionFailure('reconciled-state-hash', 'same-pass reconciled broker state is not canonicalizable', cause),
     ),
     (contentHash) =>
       bindCycleExecutionSession({

--- a/services/bayn/src/reconciler.test.ts
+++ b/services/bayn/src/reconciler.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 
-import { Cause, Deferred, Effect, Exit, Fiber } from 'effect'
+import { Cause, Deferred, Effect, Exit, Fiber, Result } from 'effect'
 import { TestClock } from 'effect/testing'
 
 import {
@@ -119,14 +119,16 @@ const receipt: AccountingReceipt = {
 
 const report = (snapshot: BrokerSnapshot): ReconciliationWriteResult => {
   const accountingHash = hash('accounting-state')
-  const stateHash = reconciledStateHash({
-    account: snapshot.account,
-    positions: snapshot.positions,
-    positionsObservedAt: snapshot.positionsObservedAt,
-    orders: snapshot.orders,
-    ordersObservedAt: snapshot.ordersObservedAt,
-    accountingHash,
-  })
+  const stateHash = Result.getOrThrow(
+    reconciledStateHash({
+      account: snapshot.account,
+      positions: snapshot.positions,
+      positionsObservedAt: snapshot.positionsObservedAt,
+      orders: snapshot.orders,
+      ordersObservedAt: snapshot.ordersObservedAt,
+      accountingHash,
+    }),
+  )
   return {
     reconciliation: {
       schemaVersion: 'bayn.paper-reconciliation.v1',
@@ -272,7 +274,7 @@ describe('paper reconciliation loop', () => {
       allOrders.map((candidate) => candidate.brokerOrderId).sort(),
     )
     expect(result.brokerState.unknownOrderCount).toBe(500)
-    const stateHash = reconciledStateHash(result.brokerState)
+    const stateHash = Result.getOrThrow(reconciledStateHash(result.brokerState))
     expect(result.report.reconciliation.expectedHash).toBe(stateHash)
     expect(result.report.reconciliation.observedHash).toBe(stateHash)
     expect(result.brokerState.reconciliation).toEqual(result.report.reconciliation)

--- a/services/bayn/src/reconciliation.test.ts
+++ b/services/bayn/src/reconciliation.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from 'bun:test'
 
+import { Result } from 'effect'
+
 import {
   AccountStatus,
   DiscrepancyKind,
@@ -15,7 +17,19 @@ import {
   type Position,
   type Valuation,
 } from './paper'
-import { compareReconciliation, type ReconciliationSnapshot } from './reconciliation'
+import {
+  compareReconciliation,
+  reconciledStateHash,
+  renderReconciliationDecisionError,
+  type ReconciliationDecisionError,
+  type ReconciliationSnapshot,
+} from './reconciliation'
+
+const successOf = <A>(result: Result.Result<A, ReconciliationDecisionError>): A => Result.getOrThrow(result)
+const failureOf = <A>(result: Result.Result<A, ReconciliationDecisionError>): ReconciliationDecisionError => {
+  if (Result.isFailure(result)) return result.failure
+  return expect.unreachable('expected reconciliation decision failure')
+}
 
 const hash = (value: string): string => value.repeat(64).slice(0, 64)
 const observedAt = '2026-07-22T15:30:00.000Z'
@@ -123,7 +137,7 @@ const snapshot = (overrides: Partial<ReconciliationSnapshot> = {}): Reconciliati
 
 describe('paper reconciliation', () => {
   test('returns one exact hash for a completely reconciled state', () => {
-    const result = compareReconciliation(snapshot())
+    const result = successOf(compareReconciliation(snapshot()))
 
     expect(result.expectedHash).toBe(hash('4'))
     expect(result.observedHash).toBe(result.expectedHash)
@@ -140,7 +154,9 @@ describe('paper reconciliation', () => {
   })
 
   test('treats a restricted broker account as a blocking discrepancy', () => {
-    const result = compareReconciliation(snapshot({ account: { ...account, status: AccountStatus.Restricted } }))
+    const result = successOf(
+      compareReconciliation(snapshot({ account: { ...account, status: AccountStatus.Restricted } })),
+    )
 
     expect(result.discrepancies).toHaveLength(1)
     expect(result.discrepancies[0]).toMatchObject({
@@ -177,8 +193,8 @@ describe('paper reconciliation', () => {
       ledgerExact: false,
     })
 
-    const first = compareReconciliation(input)
-    const second = compareReconciliation(input)
+    const first = successOf(compareReconciliation(input))
+    const second = successOf(compareReconciliation(input))
     const kinds = new Set(first.discrepancies.map((value) => value.kind))
 
     expect(first).toEqual(second)
@@ -204,7 +220,7 @@ describe('paper reconciliation', () => {
   })
 
   test('detects a missing expected broker order', () => {
-    const result = compareReconciliation(snapshot({ orders: [] }))
+    const result = successOf(compareReconciliation(snapshot({ orders: [] })))
 
     expect(result.discrepancies).toHaveLength(1)
     expect(result.discrepancies[0]).toMatchObject({
@@ -216,14 +232,18 @@ describe('paper reconciliation', () => {
 
   test('detects a broker order before the intent expects one', () => {
     const input = snapshot()
-    const result = compareReconciliation({
-      ...input,
-      intents: input.intents.map(({ brokerOrderId: _brokerOrderId, terminalOutcome: _terminalOutcome, ...intent }) => ({
-        ...intent,
-        state: IntentState.IoStarted,
-        expectsBrokerOrder: false,
-      })),
-    })
+    const result = successOf(
+      compareReconciliation({
+        ...input,
+        intents: input.intents.map(
+          ({ brokerOrderId: _brokerOrderId, terminalOutcome: _terminalOutcome, ...intent }) => ({
+            ...intent,
+            state: IntentState.IoStarted,
+            expectsBrokerOrder: false,
+          }),
+        ),
+      }),
+    )
 
     expect(result.discrepancies).toHaveLength(1)
     expect(result.discrepancies[0]).toMatchObject({
@@ -235,8 +255,8 @@ describe('paper reconciliation', () => {
   })
 
   test('detects broker position cost drift independently of quantity', () => {
-    const result = compareReconciliation(
-      snapshot({ positions: [{ ...position, averageEntryPriceMicros: '91000000' }] }),
+    const result = successOf(
+      compareReconciliation(snapshot({ positions: [{ ...position, averageEntryPriceMicros: '91000000' }] })),
     )
 
     expect(result.discrepancies).toHaveLength(1)
@@ -249,11 +269,13 @@ describe('paper reconciliation', () => {
   })
 
   test('preserves exact-half position cost discrepancy identities and hashes', () => {
-    const result = compareReconciliation(
-      snapshot({
-        positions: [{ ...position, quantityMicros: '500000', averageEntryPriceMicros: '1' }],
-        projectedPositions: [{ symbol: position.symbol, quantityMicros: '500000', costBasisMicros: '0' }],
-      }),
+    const result = successOf(
+      compareReconciliation(
+        snapshot({
+          positions: [{ ...position, quantityMicros: '500000', averageEntryPriceMicros: '1' }],
+          projectedPositions: [{ symbol: position.symbol, quantityMicros: '500000', costBasisMicros: '0' }],
+        }),
+      ),
     )
 
     expect(result.observedHash).toBe('eddcbffe34a93edb13621d0f3b4a29b4530550fe0947da942bb11cf46d649c91')
@@ -271,17 +293,19 @@ describe('paper reconciliation', () => {
 
   test('preserves reconciliation output above U128 and its exact evidence hashes', () => {
     const quantityMicros = '170141183460469231731687303715884105727'
-    const result = compareReconciliation(
-      snapshot({
-        positions: [
-          {
-            ...position,
-            quantityMicros,
-            averageEntryPriceMicros: '340282366920938463463374607431768211455',
-          },
-        ],
-        projectedPositions: [{ symbol: position.symbol, quantityMicros, costBasisMicros: '0' }],
-      }),
+    const result = successOf(
+      compareReconciliation(
+        snapshot({
+          positions: [
+            {
+              ...position,
+              quantityMicros,
+              averageEntryPriceMicros: '340282366920938463463374607431768211455',
+            },
+          ],
+          projectedPositions: [{ symbol: position.symbol, quantityMicros, costBasisMicros: '0' }],
+        }),
+      ),
     )
 
     expect(result.observedHash).toBe('7d475d168ec5d130dbc08418eb200deef0775f8ab8339c453e3016a2d3caa7f1')
@@ -298,8 +322,8 @@ describe('paper reconciliation', () => {
   })
 
   test('keeps a ledger discrepancy identity stable while its evidence changes', () => {
-    const first = compareReconciliation(snapshot({ ledgerExact: false, accountingHash: hash('a') }))
-    const second = compareReconciliation(snapshot({ ledgerExact: false, accountingHash: hash('b') }))
+    const first = successOf(compareReconciliation(snapshot({ ledgerExact: false, accountingHash: hash('a') })))
+    const second = successOf(compareReconciliation(snapshot({ ledgerExact: false, accountingHash: hash('b') })))
 
     expect(first.discrepancies).toHaveLength(1)
     expect(second.discrepancies).toHaveLength(1)
@@ -308,18 +332,20 @@ describe('paper reconciliation', () => {
   })
 
   test('compares the complete order contract, lifecycle, and aggregate fill quantity', () => {
-    const result = compareReconciliation(
-      snapshot({
-        orders: [
-          {
-            ...order,
-            orderType: OrderType.Limit,
-            limitPriceMicros: '90000000',
-            status: OrderStatus.PartiallyFilled,
-            filledQuantityMicros: '500000',
-          },
-        ],
-      }),
+    const result = successOf(
+      compareReconciliation(
+        snapshot({
+          orders: [
+            {
+              ...order,
+              orderType: OrderType.Limit,
+              limitPriceMicros: '90000000',
+              status: OrderStatus.PartiallyFilled,
+              filledQuantityMicros: '500000',
+            },
+          ],
+        }),
+      ),
     )
 
     expect(new Set(result.discrepancies.map((value) => value.identity))).toEqual(
@@ -331,9 +357,57 @@ describe('paper reconciliation', () => {
     )
   })
 
+  test('returns fact-bearing failures for account, timestamp, integer, and canonicalization defects', () => {
+    expect(failureOf(compareReconciliation(snapshot({ orders: [{ ...order, accountId: 'other-account' }] })))).toEqual({
+      _tag: 'AccountBindingMismatch',
+      source: 'order',
+      identity: order.brokerOrderId,
+      expectedAccountId: account.accountId,
+      observedAccountId: 'other-account',
+    })
+    expect(failureOf(compareReconciliation(snapshot({ reconciledAt: 'not-an-instant' })))).toEqual({
+      _tag: 'InvalidInstant',
+      field: 'reconciledAt',
+      identity: account.accountId,
+      value: 'not-an-instant',
+    })
+    expect(failureOf(compareReconciliation(snapshot({ expectedCashMicros: 'not-an-integer' })))).toMatchObject({
+      _tag: 'InvalidInteger',
+      source: 'expected-cash',
+      identity: account.accountId,
+      value: 'not-an-integer',
+      cause: expect.any(SyntaxError),
+    })
+    const canonicalization = failureOf(
+      reconciledStateHash({
+        account: { ...account, accountId: '\ud800' },
+        positions: [position],
+        positionsObservedAt: observedAt,
+        orders: [order],
+        ordersObservedAt: observedAt,
+        accountingHash: hash('5'),
+      }),
+    )
+    expect(canonicalization).toMatchObject({
+      _tag: 'CanonicalizationFailed',
+      operation: 'broker-state-hash',
+      cause: expect.any(TypeError),
+    })
+    expect(renderReconciliationDecisionError(canonicalization)).toBe(
+      'reconciliation broker-state-hash canonicalization failed',
+    )
+  })
+
   test('rejects duplicate broker identities before comparing', () => {
-    expect(() => compareReconciliation(snapshot({ orders: [order, { ...order }] }))).toThrow(
-      'duplicate broker client order ID',
+    const error = failureOf(compareReconciliation(snapshot({ orders: [order, { ...order }] })))
+
+    expect(error).toEqual({
+      _tag: 'DuplicateIdentity',
+      collection: 'broker-client-order',
+      identity: order.clientOrderId,
+    })
+    expect(renderReconciliationDecisionError(error)).toBe(
+      `duplicate broker-client-order identity ${order.clientOrderId}`,
     )
   })
 })

--- a/services/bayn/src/reconciliation.ts
+++ b/services/bayn/src/reconciliation.ts
@@ -1,4 +1,4 @@
-import { Result } from 'effect'
+import { HashMap, HashSet, Option, Result, pipe } from 'effect'
 
 import { canonicalHashV1 } from './hash'
 import {
@@ -126,44 +126,223 @@ const absent = '<absent>'
 const expectedResolution = '<resolved>'
 const openOrder = '<open>'
 
+type ReconciliationIdentityCollection =
+  | 'broker-client-order'
+  | 'broker-fill'
+  | 'broker-order'
+  | 'broker-position'
+  | 'discrepancy'
+  | 'durable-fill'
+  | 'intent-client-order'
+  | 'projected-position'
+
+type ReconciliationHashOperation =
+  | 'broker-state-hash'
+  | 'discrepancy-evidence'
+  | 'discrepancy-id'
+  | 'observed-hash'
+  | 'reconciled-state-hash'
+
+type ReconciliationInstantField =
+  | 'account.observedAt'
+  | 'intent.unknownSince'
+  | 'order.observedAt'
+  | 'position.observedAt'
+  | 'reconciledAt'
+  | 'valuation.asOf'
+
+type ReconciliationAccountSource = 'account' | 'fill' | 'order' | 'position' | 'valuation'
+
+type ReconciliationIntegerSource =
+  | 'account-cash'
+  | 'account-equity'
+  | 'expected-cash'
+  | 'fill-quantity'
+  | 'order-filled-quantity'
+  | 'position-average-price'
+  | 'position-quantity'
+  | 'projected-position-cost'
+  | 'projected-position-quantity'
+  | 'valuation-equity'
+
+export type ReconciliationDecisionError =
+  | {
+      readonly _tag: 'CanonicalizationFailed'
+      readonly operation: ReconciliationHashOperation
+      readonly identity?: string
+      readonly cause: unknown
+    }
+  | {
+      readonly _tag: 'FixedPointRoundingFailed'
+      readonly symbol: string
+      readonly quantityMicros: string
+      readonly averageEntryPriceMicros: string
+      readonly cause: unknown
+    }
+  | {
+      readonly _tag: 'InvalidInstant'
+      readonly field: ReconciliationInstantField
+      readonly identity: string
+      readonly value: string
+    }
+  | {
+      readonly _tag: 'InvalidInteger'
+      readonly source: ReconciliationIntegerSource
+      readonly identity: string
+      readonly value: string
+      readonly cause: unknown
+    }
+  | {
+      readonly _tag: 'DuplicateIdentity'
+      readonly collection: ReconciliationIdentityCollection
+      readonly identity: string
+    }
+  | {
+      readonly _tag: 'DiscrepancyWithoutDifference'
+      readonly kind: DiscrepancyKind
+      readonly identity: string
+      readonly value: string
+    }
+  | {
+      readonly _tag: 'IntentTerminalStateMismatch'
+      readonly intentId: string
+      readonly state: IntentState
+      readonly terminalOutcome: TerminalOutcome | null
+    }
+  | {
+      readonly _tag: 'IntentBrokerOrderBindingMismatch'
+      readonly intentId: string
+      readonly expectsBrokerOrder: boolean
+      readonly brokerOrderId: string | null
+    }
+  | {
+      readonly _tag: 'BrokerOrderIdentityMissing'
+      readonly intentId: string
+      readonly clientOrderId: string
+    }
+  | {
+      readonly _tag: 'AccountBindingMismatch'
+      readonly source: ReconciliationAccountSource
+      readonly identity: string
+      readonly expectedAccountId: string
+      readonly observedAccountId: string
+    }
+
+type ReconciliationDecision<A> = Result.Result<A, ReconciliationDecisionError>
+
+const fail = <A>(error: ReconciliationDecisionError): ReconciliationDecision<A> => Result.fail(error)
+
+const canonicalHash = (
+  operation: ReconciliationHashOperation,
+  value: unknown,
+  identity?: string,
+): ReconciliationDecision<string> =>
+  pipe(
+    Result.try(() => canonicalHashV1(value)),
+    Result.mapError(
+      (cause): ReconciliationDecisionError => ({
+        _tag: 'CanonicalizationFailed',
+        operation,
+        ...(identity === undefined ? {} : { identity }),
+        cause,
+      }),
+    ),
+  )
+
 const absolute = (value: bigint): bigint => (value < 0n ? -value : value)
-const roundMicrosProduct = (left: bigint, right: bigint): bigint => {
-  const rounded = roundUnsignedHalfUp(left * right, 1_000_000n)
-  if (Result.isFailure(rounded)) throw new Error('position cost material is outside the unsigned fixed-point range')
-  return rounded.success
-}
 
-export const reconciledStateHash = (state: ReconciledStateMaterial): string => {
-  const brokerStateHash = canonicalHashV1({
-    schemaVersion: 'bayn.paper-risk-broker-state.v1',
-    account: state.account,
-    positions: state.positions,
-    positionsObservedAt: state.positionsObservedAt,
-    orders: state.orders,
-    ordersObservedAt: state.ordersObservedAt,
-  })
-  return canonicalHashV1({
-    schemaVersion: 'bayn.paper-risk-reconciled-state.v1',
-    brokerStateHash,
-    accountingHash: state.accountingHash,
-  })
-}
+const integer = (
+  source: ReconciliationIntegerSource,
+  identity: string,
+  value: string,
+): ReconciliationDecision<bigint> =>
+  pipe(
+    Result.try(() => BigInt(value)),
+    Result.mapError(
+      (cause): ReconciliationDecisionError => ({
+        _tag: 'InvalidInteger',
+        source,
+        identity,
+        value,
+        cause,
+      }),
+    ),
+  )
 
-const instant = (value: string): number => {
+const roundMicrosProduct = (
+  symbol: string,
+  quantityMicros: string,
+  averageEntryPriceMicros: string,
+): ReconciliationDecision<bigint> =>
+  pipe(
+    Result.all({
+      quantity: integer('position-quantity', symbol, quantityMicros),
+      averageEntryPrice: integer('position-average-price', symbol, averageEntryPriceMicros),
+    }),
+    Result.flatMap(({ averageEntryPrice, quantity }) =>
+      pipe(
+        roundUnsignedHalfUp(absolute(quantity) * averageEntryPrice, 1_000_000n),
+        Result.mapError(
+          (cause): ReconciliationDecisionError => ({
+            _tag: 'FixedPointRoundingFailed',
+            symbol,
+            quantityMicros,
+            averageEntryPriceMicros,
+            cause,
+          }),
+        ),
+      ),
+    ),
+  )
+
+export const reconciledStateHash = (state: ReconciledStateMaterial): ReconciliationDecision<string> =>
+  pipe(
+    canonicalHash('broker-state-hash', {
+      schemaVersion: 'bayn.paper-risk-broker-state.v1',
+      account: state.account,
+      positions: state.positions,
+      positionsObservedAt: state.positionsObservedAt,
+      orders: state.orders,
+      ordersObservedAt: state.ordersObservedAt,
+    }),
+    Result.flatMap((brokerStateHash) =>
+      canonicalHash('reconciled-state-hash', {
+        schemaVersion: 'bayn.paper-risk-reconciled-state.v1',
+        brokerStateHash,
+        accountingHash: state.accountingHash,
+      }),
+    ),
+  )
+
+const instant = (
+  field: ReconciliationInstantField,
+  identity: string,
+  value: string,
+): ReconciliationDecision<number> => {
   const milliseconds = Date.parse(value)
-  if (!Number.isFinite(milliseconds)) throw new Error(`invalid reconciliation instant ${value}`)
-  return milliseconds
+  return Number.isFinite(milliseconds)
+    ? Result.succeed(milliseconds)
+    : fail({ _tag: 'InvalidInstant', field, identity, value })
 }
 
-const indexUnique = <A>(values: readonly A[], identity: (value: A) => string, label: string): Map<string, A> => {
-  const indexed = new Map<string, A>()
-  for (const value of values) {
-    const key = identity(value)
-    if (indexed.has(key)) throw new Error(`duplicate ${label} ${key}`)
-    indexed.set(key, value)
-  }
-  return indexed
-}
+const indexUnique = <A>(
+  values: readonly A[],
+  identity: (value: A) => string,
+  collection: ReconciliationIdentityCollection,
+): ReconciliationDecision<HashMap.HashMap<string, A>> =>
+  values.reduce<ReconciliationDecision<HashMap.HashMap<string, A>>>(
+    (indexed, value) =>
+      pipe(
+        indexed,
+        Result.flatMap((current) => {
+          const key = identity(value)
+          return HashMap.has(current, key)
+            ? fail({ _tag: 'DuplicateIdentity', collection, identity: key })
+            : Result.succeed(HashMap.set(current, key, value))
+        }),
+      ),
+    Result.succeed(HashMap.empty()),
+  )
 
 const discrepancy = (
   accountId: string,
@@ -171,28 +350,57 @@ const discrepancy = (
   identity: string,
   expected: string,
   observed: string,
-): DiscrepancyInput => {
-  if (expected === observed) throw new Error(`discrepancy ${kind}:${identity} does not differ`)
-  const discrepancyId = canonicalHashV1({
-    schemaVersion: 'bayn.paper-discrepancy-id.v1',
-    accountId,
-    kind,
-    identity,
-  })
-  return {
-    discrepancyId,
-    kind,
-    identity,
-    expected,
-    observed,
-    evidenceHash: canonicalHashV1({
-      schemaVersion: 'bayn.paper-discrepancy-evidence.v1',
-      discrepancyId,
-      expected,
-      observed,
-    }),
-  }
-}
+): ReconciliationDecision<DiscrepancyInput> =>
+  expected === observed
+    ? fail({ _tag: 'DiscrepancyWithoutDifference', kind, identity, value: expected })
+    : pipe(
+        canonicalHash(
+          'discrepancy-id',
+          {
+            schemaVersion: 'bayn.paper-discrepancy-id.v1',
+            accountId,
+            kind,
+            identity,
+          },
+          identity,
+        ),
+        Result.flatMap((discrepancyId) =>
+          pipe(
+            canonicalHash(
+              'discrepancy-evidence',
+              {
+                schemaVersion: 'bayn.paper-discrepancy-evidence.v1',
+                discrepancyId,
+                expected,
+                observed,
+              },
+              identity,
+            ),
+            Result.map((evidenceHash) => ({
+              discrepancyId,
+              kind,
+              identity,
+              expected,
+              observed,
+              evidenceHash,
+            })),
+          ),
+        ),
+      )
+
+const compareValue = (
+  accountId: string,
+  kind: DiscrepancyKind,
+  identity: string,
+  expected: string,
+  observed: string,
+): ReconciliationDecision<readonly DiscrepancyInput[]> =>
+  expected === observed
+    ? Result.succeed([])
+    : pipe(
+        discrepancy(accountId, kind, identity, expected, observed),
+        Result.map((value) => [value]),
+      )
 
 const terminalOutcome = (status: OrderStatus): TerminalOutcome | undefined => {
   switch (status) {
@@ -209,298 +417,518 @@ const terminalOutcome = (status: OrderStatus): TerminalOutcome | undefined => {
   }
 }
 
-const compareOrders = (snapshot: ReconciliationSnapshot, discrepancies: DiscrepancyInput[]): void => {
-  const intents = indexUnique(snapshot.intents, (intent) => intent.clientOrderId, 'intent client order ID')
-  const ordersByClient = indexUnique(snapshot.orders, (order) => order.clientOrderId, 'broker client order ID')
-  indexUnique(snapshot.orders, (order) => order.brokerOrderId, 'broker order ID')
-
-  for (const intent of snapshot.intents) {
-    if ((intent.state === IntentState.Terminal) !== (intent.terminalOutcome !== undefined)) {
-      throw new Error(`intent ${intent.intentId} terminal state and outcome disagree`)
-    }
-    if (intent.expectsBrokerOrder !== (intent.brokerOrderId !== undefined)) {
-      throw new Error(`intent ${intent.intentId} broker order expectation and identity disagree`)
-    }
+const validateIntent = (intent: IntentExpectation): ReconciliationDecision<void> => {
+  if ((intent.state === IntentState.Terminal) !== (intent.terminalOutcome !== undefined)) {
+    return fail({
+      _tag: 'IntentTerminalStateMismatch',
+      intentId: intent.intentId,
+      state: intent.state,
+      terminalOutcome: intent.terminalOutcome ?? null,
+    })
   }
+  return intent.expectsBrokerOrder === (intent.brokerOrderId !== undefined)
+    ? Result.succeed(undefined)
+    : fail({
+        _tag: 'IntentBrokerOrderBindingMismatch',
+        intentId: intent.intentId,
+        expectsBrokerOrder: intent.expectsBrokerOrder,
+        brokerOrderId: intent.brokerOrderId ?? null,
+      })
+}
 
-  for (const order of snapshot.orders) {
-    const intent = intents.get(order.clientOrderId)
-    if (intent === undefined) {
-      discrepancies.push(
-        discrepancy(
-          snapshot.accountId,
-          DiscrepancyKind.Order,
-          `${order.clientOrderId}:presence`,
-          absent,
-          order.brokerOrderId,
-        ),
-      )
-      continue
-    }
-    if (!intent.expectsBrokerOrder) {
-      discrepancies.push(
-        discrepancy(
-          snapshot.accountId,
-          DiscrepancyKind.Order,
-          `${intent.clientOrderId}:presence`,
-          absent,
-          order.brokerOrderId,
-        ),
-      )
-      continue
-    }
-    const expectedBrokerOrderId = intent.brokerOrderId
-    if (expectedBrokerOrderId === undefined) throw new Error(`intent ${intent.intentId} has no broker order identity`)
-    const expectedOrder = [
-      expectedBrokerOrderId,
-      intent.symbol,
-      intent.side,
-      intent.orderType,
-      intent.timeInForce,
-      intent.quantityMicros,
-    ].join(':')
-    const observedOrder = [
+const brokerOrderIdentity = (intent: IntentExpectation): ReconciliationDecision<string> =>
+  intent.brokerOrderId === undefined
+    ? fail({
+        _tag: 'BrokerOrderIdentityMissing',
+        intentId: intent.intentId,
+        clientOrderId: intent.clientOrderId,
+      })
+    : Result.succeed(intent.brokerOrderId)
+
+const compareObservedOrder = (
+  snapshot: ReconciliationSnapshot,
+  intents: HashMap.HashMap<string, IntentExpectation>,
+  order: Order,
+): ReconciliationDecision<readonly DiscrepancyInput[]> => {
+  const intent = Option.getOrUndefined(HashMap.get(intents, order.clientOrderId))
+  if (intent === undefined || !intent.expectsBrokerOrder) {
+    return compareValue(
+      snapshot.accountId,
+      DiscrepancyKind.Order,
+      `${order.clientOrderId}:presence`,
+      absent,
       order.brokerOrderId,
-      order.symbol,
-      order.side,
-      order.orderType,
-      order.timeInForce,
-      order.quantityMicros,
-    ].join(':')
-    if (expectedOrder !== observedOrder) {
-      discrepancies.push(
-        discrepancy(
-          snapshot.accountId,
-          DiscrepancyKind.Order,
-          `${intent.clientOrderId}:content`,
-          expectedOrder,
-          observedOrder,
-        ),
-      )
-    }
-    const expectedOutcome = intent.terminalOutcome ?? openOrder
-    const observedOutcome = terminalOutcome(order.status) ?? openOrder
-    if (expectedOutcome !== observedOutcome) {
-      discrepancies.push(
-        discrepancy(
-          snapshot.accountId,
-          DiscrepancyKind.Order,
-          `${intent.clientOrderId}:lifecycle`,
-          expectedOutcome,
-          observedOutcome,
-        ),
-      )
-    }
+    )
   }
+  return pipe(
+    brokerOrderIdentity(intent),
+    Result.flatMap((expectedBrokerOrderId) => {
+      const expectedOrder = [
+        expectedBrokerOrderId,
+        intent.symbol,
+        intent.side,
+        intent.orderType,
+        intent.timeInForce,
+        intent.quantityMicros,
+      ].join(':')
+      const observedOrder = [
+        order.brokerOrderId,
+        order.symbol,
+        order.side,
+        order.orderType,
+        order.timeInForce,
+        order.quantityMicros,
+      ].join(':')
+      return pipe(
+        Result.all({
+          content: compareValue(
+            snapshot.accountId,
+            DiscrepancyKind.Order,
+            `${intent.clientOrderId}:content`,
+            expectedOrder,
+            observedOrder,
+          ),
+          lifecycle: compareValue(
+            snapshot.accountId,
+            DiscrepancyKind.Order,
+            `${intent.clientOrderId}:lifecycle`,
+            intent.terminalOutcome ?? openOrder,
+            terminalOutcome(order.status) ?? openOrder,
+          ),
+        }),
+        Result.map(({ content, lifecycle }) => [...content, ...lifecycle]),
+      )
+    }),
+  )
+}
 
-  for (const intent of snapshot.intents) {
-    if (intent.expectsBrokerOrder && !ordersByClient.has(intent.clientOrderId)) {
-      const expectedBrokerOrderId = intent.brokerOrderId
-      if (expectedBrokerOrderId === undefined) throw new Error(`intent ${intent.intentId} has no broker order identity`)
-      discrepancies.push(
-        discrepancy(
-          snapshot.accountId,
-          DiscrepancyKind.Order,
-          `${intent.clientOrderId}:presence`,
-          expectedBrokerOrderId,
-          absent,
+const compareExpectedIntent = (
+  snapshot: ReconciliationSnapshot,
+  ordersByClient: HashMap.HashMap<string, Order>,
+  intent: IntentExpectation,
+): ReconciliationDecision<readonly DiscrepancyInput[]> => {
+  const missingOrder = intent.expectsBrokerOrder && !HashMap.has(ordersByClient, intent.clientOrderId)
+  const presence = missingOrder
+    ? pipe(
+        brokerOrderIdentity(intent),
+        Result.flatMap((brokerOrderId) =>
+          compareValue(
+            snapshot.accountId,
+            DiscrepancyKind.Order,
+            `${intent.clientOrderId}:presence`,
+            brokerOrderId,
+            absent,
+          ),
         ),
       )
-    }
-    if (intent.unknownSince !== undefined) {
-      discrepancies.push(
-        discrepancy(
+    : Result.succeed<readonly DiscrepancyInput[]>([])
+  const mutation =
+    intent.unknownSince === undefined
+      ? Result.succeed<readonly DiscrepancyInput[]>([])
+      : compareValue(
           snapshot.accountId,
           DiscrepancyKind.Mutation,
           intent.intentId,
           expectedResolution,
           `UNKNOWN:${intent.unknownSince}`,
+        )
+  return pipe(
+    Result.all({ mutation, presence }),
+    Result.map(({ mutation, presence }) => [...presence, ...mutation]),
+  )
+}
+
+const compareOrders = (snapshot: ReconciliationSnapshot): ReconciliationDecision<readonly DiscrepancyInput[]> =>
+  pipe(
+    Result.all({
+      intents: indexUnique(snapshot.intents, (intent) => intent.clientOrderId, 'intent-client-order'),
+      ordersByClient: indexUnique(snapshot.orders, (order) => order.clientOrderId, 'broker-client-order'),
+      brokerOrders: indexUnique(snapshot.orders, (order) => order.brokerOrderId, 'broker-order'),
+      validIntents: Result.all(snapshot.intents.map(validateIntent)),
+    }),
+    Result.flatMap(({ intents, ordersByClient }) =>
+      pipe(
+        Result.all({
+          observed: Result.all(snapshot.orders.map((order) => compareObservedOrder(snapshot, intents, order))),
+          expected: Result.all(
+            snapshot.intents.map((intent) => compareExpectedIntent(snapshot, ordersByClient, intent)),
+          ),
+        }),
+        Result.map(({ expected, observed }) => [...observed.flat(), ...expected.flat()]),
+      ),
+    ),
+  )
+
+const fillQuantities = (fills: readonly Fill[]): ReconciliationDecision<HashMap.HashMap<string, bigint>> =>
+  fills.reduce<ReconciliationDecision<HashMap.HashMap<string, bigint>>>(
+    (totals, fill) =>
+      pipe(
+        Result.all({
+          totals,
+          quantity: integer('fill-quantity', fill.fillId, fill.quantityMicros),
+        }),
+        Result.map(({ quantity, totals }) =>
+          HashMap.set(
+            totals,
+            fill.brokerOrderId,
+            Option.getOrElse(HashMap.get(totals, fill.brokerOrderId), () => 0n) + quantity,
+          ),
         ),
-      )
-    }
+      ),
+    Result.succeed(HashMap.empty()),
+  )
+
+const compareObservedFill = (
+  snapshot: ReconciliationSnapshot,
+  durable: HashMap.HashMap<string, DurableFill>,
+  fill: Fill,
+): ReconciliationDecision<readonly DiscrepancyInput[]> => {
+  const stored = Option.getOrUndefined(HashMap.get(durable, fill.fillId))
+  if (stored === undefined) {
+    return compareValue(snapshot.accountId, DiscrepancyKind.Fill, fill.fillId, 'durable', absent)
   }
+  return pipe(
+    Result.all({
+      order: compareValue(
+        snapshot.accountId,
+        DiscrepancyKind.Fill,
+        fill.fillId,
+        stored.brokerOrderId,
+        fill.brokerOrderId,
+      ),
+      accounting: stored.accounted
+        ? Result.succeed<readonly DiscrepancyInput[]>([])
+        : compareValue(snapshot.accountId, DiscrepancyKind.Accounting, fill.fillId, 'POSTED', 'MISSING'),
+    }),
+    Result.map(({ accounting, order }) => [...order, ...accounting]),
+  )
 }
 
-const compareFills = (snapshot: ReconciliationSnapshot, discrepancies: DiscrepancyInput[]): void => {
-  const observed = indexUnique(snapshot.fills, (fill) => fill.fillId, 'broker fill ID')
-  const durable = indexUnique(snapshot.durableFills, (fill) => fill.fillId, 'durable fill ID')
-  const filledByOrder = new Map<string, bigint>()
-  for (const fill of snapshot.fills) {
-    filledByOrder.set(fill.brokerOrderId, (filledByOrder.get(fill.brokerOrderId) ?? 0n) + BigInt(fill.quantityMicros))
-    const stored = durable.get(fill.fillId)
-    if (stored === undefined) {
-      discrepancies.push(discrepancy(snapshot.accountId, DiscrepancyKind.Fill, fill.fillId, 'durable', absent))
-      continue
-    }
-    if (stored.brokerOrderId !== fill.brokerOrderId) {
-      discrepancies.push(
-        discrepancy(snapshot.accountId, DiscrepancyKind.Fill, fill.fillId, stored.brokerOrderId, fill.brokerOrderId),
-      )
-    }
-    if (!stored.accounted) {
-      discrepancies.push(discrepancy(snapshot.accountId, DiscrepancyKind.Accounting, fill.fillId, 'POSTED', 'MISSING'))
-    }
-  }
-  for (const fill of snapshot.durableFills) {
-    if (!observed.has(fill.fillId)) {
-      discrepancies.push(discrepancy(snapshot.accountId, DiscrepancyKind.Fill, fill.fillId, 'broker', absent))
-    }
-  }
-  for (const order of snapshot.orders) {
-    const expected = order.filledQuantityMicros
-    const actual = (filledByOrder.get(order.brokerOrderId) ?? 0n).toString()
-    if (expected !== actual) {
-      discrepancies.push(
-        discrepancy(snapshot.accountId, DiscrepancyKind.Fill, `${order.brokerOrderId}:quantity`, expected, actual),
-      )
-    }
-  }
+const compareDurableFill = (
+  snapshot: ReconciliationSnapshot,
+  observed: HashMap.HashMap<string, Fill>,
+  fill: DurableFill,
+): ReconciliationDecision<readonly DiscrepancyInput[]> =>
+  HashMap.has(observed, fill.fillId)
+    ? Result.succeed([])
+    : compareValue(snapshot.accountId, DiscrepancyKind.Fill, fill.fillId, 'broker', absent)
+
+const compareOrderFillQuantity = (
+  snapshot: ReconciliationSnapshot,
+  filledByOrder: HashMap.HashMap<string, bigint>,
+  order: Order,
+): ReconciliationDecision<readonly DiscrepancyInput[]> =>
+  pipe(
+    integer('order-filled-quantity', order.brokerOrderId, order.filledQuantityMicros),
+    Result.flatMap((expected) =>
+      compareValue(
+        snapshot.accountId,
+        DiscrepancyKind.Fill,
+        `${order.brokerOrderId}:quantity`,
+        expected.toString(),
+        Option.getOrElse(HashMap.get(filledByOrder, order.brokerOrderId), () => 0n).toString(),
+      ),
+    ),
+  )
+
+const compareFills = (snapshot: ReconciliationSnapshot): ReconciliationDecision<readonly DiscrepancyInput[]> =>
+  pipe(
+    Result.all({
+      observed: indexUnique(snapshot.fills, (fill) => fill.fillId, 'broker-fill'),
+      durable: indexUnique(snapshot.durableFills, (fill) => fill.fillId, 'durable-fill'),
+      filledByOrder: fillQuantities(snapshot.fills),
+    }),
+    Result.flatMap(({ durable, filledByOrder, observed }) =>
+      pipe(
+        Result.all({
+          observedFills: Result.all(snapshot.fills.map((fill) => compareObservedFill(snapshot, durable, fill))),
+          durableFills: Result.all(snapshot.durableFills.map((fill) => compareDurableFill(snapshot, observed, fill))),
+          orders: Result.all(snapshot.orders.map((order) => compareOrderFillQuantity(snapshot, filledByOrder, order))),
+        }),
+        Result.map(({ durableFills, observedFills, orders }) => [
+          ...observedFills.flat(),
+          ...durableFills.flat(),
+          ...orders.flat(),
+        ]),
+      ),
+    ),
+  )
+
+interface PositionComparison {
+  readonly difference: bigint
+  readonly discrepancies: readonly DiscrepancyInput[]
 }
 
-const comparePositions = (snapshot: ReconciliationSnapshot, discrepancies: DiscrepancyInput[]): bigint => {
-  const observed = indexUnique(snapshot.positions, (position) => position.symbol, 'broker position symbol')
-  const projected = indexUnique(snapshot.projectedPositions, (position) => position.symbol, 'projected position symbol')
-  let difference = 0n
-  for (const symbol of [...new Set([...observed.keys(), ...projected.keys()])].sort()) {
-    const expectedPosition = projected.get(symbol)
-    const observedPosition = observed.get(symbol)
-    const expectedQuantity = expectedPosition?.quantityMicros ?? '0'
-    const observedQuantity = observedPosition?.quantityMicros ?? '0'
-    difference += absolute(BigInt(expectedQuantity) - BigInt(observedQuantity))
-    if (expectedQuantity !== observedQuantity) {
-      discrepancies.push(
-        discrepancy(
+const comparePosition = (
+  snapshot: ReconciliationSnapshot,
+  observed: HashMap.HashMap<string, Position>,
+  projected: HashMap.HashMap<string, ProjectedPosition>,
+  symbol: string,
+): ReconciliationDecision<PositionComparison> => {
+  const expectedPosition = Option.getOrUndefined(HashMap.get(projected, symbol))
+  const observedPosition = Option.getOrUndefined(HashMap.get(observed, symbol))
+  const expectedQuantityText = expectedPosition?.quantityMicros ?? '0'
+  const observedQuantityText = observedPosition?.quantityMicros ?? '0'
+  const expectedCostText = expectedPosition?.costBasisMicros ?? '0'
+  return pipe(
+    Result.all({
+      expectedQuantity: integer('projected-position-quantity', symbol, expectedQuantityText),
+      observedQuantity: integer('position-quantity', symbol, observedQuantityText),
+      expectedCost: integer('projected-position-cost', symbol, expectedCostText),
+      observedCost:
+        observedPosition === undefined
+          ? Result.succeed(0n)
+          : roundMicrosProduct(symbol, observedPosition.quantityMicros, observedPosition.averageEntryPriceMicros),
+    }),
+    Result.flatMap(({ expectedCost, expectedQuantity, observedCost, observedQuantity }) =>
+      pipe(
+        Result.all({
+          quantity: compareValue(
+            snapshot.accountId,
+            DiscrepancyKind.Position,
+            `${symbol}:quantity`,
+            expectedQuantity.toString(),
+            observedQuantity.toString(),
+          ),
+          cost: compareValue(
+            snapshot.accountId,
+            DiscrepancyKind.Position,
+            `${symbol}:cost`,
+            expectedCost.toString(),
+            observedCost.toString(),
+          ),
+        }),
+        Result.map(({ cost, quantity }) => ({
+          difference: absolute(expectedQuantity - observedQuantity),
+          discrepancies: [...quantity, ...cost],
+        })),
+      ),
+    ),
+  )
+}
+
+const comparePositions = (snapshot: ReconciliationSnapshot): ReconciliationDecision<PositionComparison> =>
+  pipe(
+    Result.all({
+      observed: indexUnique(snapshot.positions, (position) => position.symbol, 'broker-position'),
+      projected: indexUnique(snapshot.projectedPositions, (position) => position.symbol, 'projected-position'),
+    }),
+    Result.flatMap(({ observed, projected }) => {
+      const symbols = [
+        ...HashSet.union(HashSet.fromIterable(HashMap.keys(observed)), HashSet.fromIterable(HashMap.keys(projected))),
+      ].sort()
+      return pipe(
+        Result.all(symbols.map((symbol) => comparePosition(snapshot, observed, projected, symbol))),
+        Result.map((comparisons) => ({
+          difference: comparisons.reduce((total, comparison) => total + comparison.difference, 0n),
+          discrepancies: comparisons.flatMap((comparison) => comparison.discrepancies),
+        })),
+      )
+    }),
+  )
+
+const accountBinding = (
+  source: ReconciliationAccountSource,
+  identity: string,
+  expectedAccountId: string,
+  observedAccountId: string,
+): ReconciliationDecision<void> =>
+  observedAccountId === expectedAccountId
+    ? Result.succeed(undefined)
+    : fail({
+        _tag: 'AccountBindingMismatch',
+        source,
+        identity,
+        expectedAccountId,
+        observedAccountId,
+      })
+
+const validateAccountBindings = (snapshot: ReconciliationSnapshot): ReconciliationDecision<void> =>
+  pipe(
+    Result.all([
+      accountBinding('account', snapshot.account.accountId, snapshot.accountId, snapshot.account.accountId),
+      accountBinding('valuation', snapshot.valuation.valuationId, snapshot.accountId, snapshot.valuation.accountId),
+      ...snapshot.positions.map((position) =>
+        accountBinding('position', position.symbol, snapshot.accountId, position.accountId),
+      ),
+      ...snapshot.orders.map((order) =>
+        accountBinding('order', order.brokerOrderId, snapshot.accountId, order.accountId),
+      ),
+      ...snapshot.fills.map((fill) => accountBinding('fill', fill.fillId, snapshot.accountId, fill.accountId)),
+    ]),
+    Result.map(() => undefined),
+  )
+
+interface ScalarComparison {
+  readonly difference: bigint
+  readonly discrepancies: readonly DiscrepancyInput[]
+}
+
+const compareCash = (snapshot: ReconciliationSnapshot): ReconciliationDecision<ScalarComparison> =>
+  pipe(
+    Result.all({
+      expected: integer('expected-cash', snapshot.accountId, snapshot.expectedCashMicros),
+      observed: integer('account-cash', snapshot.accountId, snapshot.account.cashMicros),
+    }),
+    Result.flatMap(({ expected, observed }) =>
+      pipe(
+        compareValue(
           snapshot.accountId,
-          DiscrepancyKind.Position,
-          `${symbol}:quantity`,
-          expectedQuantity,
-          observedQuantity,
+          DiscrepancyKind.Cash,
+          snapshot.accountId,
+          expected.toString(),
+          observed.toString(),
         ),
-      )
-    }
-    const expectedCost = expectedPosition?.costBasisMicros ?? '0'
-    const observedCost =
-      observedPosition === undefined
-        ? '0'
-        : roundMicrosProduct(
-            absolute(BigInt(observedPosition.quantityMicros)),
-            BigInt(observedPosition.averageEntryPriceMicros),
-          ).toString()
-    if (expectedCost !== observedCost) {
-      discrepancies.push(
-        discrepancy(snapshot.accountId, DiscrepancyKind.Position, `${symbol}:cost`, expectedCost, observedCost),
-      )
-    }
-  }
-  return difference
-}
-
-export const compareReconciliation = (snapshot: ReconciliationSnapshot): ReconciliationComparison => {
-  if (snapshot.account.accountId !== snapshot.accountId || snapshot.valuation.accountId !== snapshot.accountId) {
-    throw new Error('reconciliation snapshot contains another account')
-  }
-  if (snapshot.positions.some((position) => position.accountId !== snapshot.accountId)) {
-    throw new Error('reconciliation positions contain another account')
-  }
-  if (snapshot.orders.some((order) => order.accountId !== snapshot.accountId)) {
-    throw new Error('reconciliation orders contain another account')
-  }
-  if (snapshot.fills.some((fill) => fill.accountId !== snapshot.accountId)) {
-    throw new Error('reconciliation fills contain another account')
-  }
-
-  const discrepancies: DiscrepancyInput[] = []
-  if (snapshot.account.status !== AccountStatus.Active) {
-    discrepancies.push(
-      discrepancy(
-        snapshot.accountId,
-        DiscrepancyKind.Account,
-        snapshot.accountId,
-        AccountStatus.Active,
-        snapshot.account.status,
+        Result.map((discrepancies) => ({ difference: observed - expected, discrepancies })),
       ),
-    )
-  }
-  compareOrders(snapshot, discrepancies)
-  compareFills(snapshot, discrepancies)
-  const positionDifference = comparePositions(snapshot, discrepancies)
+    ),
+  )
 
-  const cashDifference = BigInt(snapshot.account.cashMicros) - BigInt(snapshot.expectedCashMicros)
-  if (cashDifference !== 0n) {
-    discrepancies.push(
-      discrepancy(
-        snapshot.accountId,
-        DiscrepancyKind.Cash,
-        snapshot.accountId,
-        snapshot.expectedCashMicros,
-        snapshot.account.cashMicros,
+const compareEquity = (snapshot: ReconciliationSnapshot): ReconciliationDecision<ScalarComparison> =>
+  pipe(
+    Result.all({
+      expected: integer('valuation-equity', snapshot.accountId, snapshot.valuation.equityMicros),
+      observed: integer('account-equity', snapshot.accountId, snapshot.account.equityMicros),
+    }),
+    Result.flatMap(({ expected, observed }) =>
+      pipe(
+        compareValue(
+          snapshot.accountId,
+          DiscrepancyKind.Valuation,
+          snapshot.accountId,
+          expected.toString(),
+          observed.toString(),
+        ),
+        Result.map((discrepancies) => ({ difference: observed - expected, discrepancies })),
       ),
-    )
-  }
+    ),
+  )
 
-  const equityDifference = BigInt(snapshot.account.equityMicros) - BigInt(snapshot.valuation.equityMicros)
-  if (equityDifference !== 0n) {
-    discrepancies.push(
-      discrepancy(
-        snapshot.accountId,
-        DiscrepancyKind.Valuation,
-        snapshot.accountId,
-        snapshot.valuation.equityMicros,
-        snapshot.account.equityMicros,
-      ),
-    )
-  }
-  if (!snapshot.ledgerExact) {
-    discrepancies.push(
-      discrepancy(
+const compareAccountStatus = (snapshot: ReconciliationSnapshot): ReconciliationDecision<readonly DiscrepancyInput[]> =>
+  compareValue(
+    snapshot.accountId,
+    DiscrepancyKind.Account,
+    snapshot.accountId,
+    AccountStatus.Active,
+    snapshot.account.status,
+  )
+
+const compareLedger = (snapshot: ReconciliationSnapshot): ReconciliationDecision<readonly DiscrepancyInput[]> =>
+  snapshot.ledgerExact
+    ? Result.succeed([])
+    : compareValue(
         snapshot.accountId,
         DiscrepancyKind.Accounting,
         `${snapshot.accountId}:ledger`,
         'EXACT',
         `MISMATCH:${snapshot.accountingHash}`,
+      )
+
+interface TemporalMetrics {
+  readonly brokerPollAgeMs: number
+  readonly oldestUnknownMutationAgeMs: number
+}
+
+const temporalMetrics = (snapshot: ReconciliationSnapshot): ReconciliationDecision<TemporalMetrics> =>
+  pipe(
+    Result.all({
+      reconciledAt: instant('reconciledAt', snapshot.accountId, snapshot.reconciledAt),
+      brokerTimes: Result.all([
+        instant('account.observedAt', snapshot.account.accountId, snapshot.account.observedAt),
+        instant('valuation.asOf', snapshot.valuation.valuationId, snapshot.valuation.asOf),
+        ...snapshot.positions.map((position) => instant('position.observedAt', position.symbol, position.observedAt)),
+        ...snapshot.orders.map((order) => instant('order.observedAt', order.brokerOrderId, order.observedAt)),
+      ]),
+      unknownTimes: Result.all(
+        snapshot.intents.flatMap((intent) =>
+          intent.unknownSince === undefined
+            ? []
+            : [instant('intent.unknownSince', intent.intentId, intent.unknownSince)],
+        ),
       ),
-    )
-  }
-
-  const ordered = [...discrepancies].sort((left, right) =>
-    left.discrepancyId < right.discrepancyId ? -1 : left.discrepancyId > right.discrepancyId ? 1 : 0,
-  )
-  if (new Set(ordered.map((value) => value.discrepancyId)).size !== ordered.length) {
-    throw new Error('reconciliation produced duplicate discrepancy identities')
-  }
-  const observedHash =
-    ordered.length === 0
-      ? snapshot.stateHash
-      : canonicalHashV1({
-          schemaVersion: 'bayn.paper-reconciliation-observed.v1',
-          stateHash: snapshot.stateHash,
-          discrepancies: ordered.map((value) => value.evidenceHash),
-        })
-
-  const reconciledAt = instant(snapshot.reconciledAt)
-  const brokerTimes = [
-    snapshot.account.observedAt,
-    snapshot.valuation.asOf,
-    ...snapshot.positions.map((position) => position.observedAt),
-    ...snapshot.orders.map((order) => order.observedAt),
-  ].map(instant)
-  const oldestBrokerTime = brokerTimes.length === 0 ? reconciledAt : Math.min(...brokerTimes)
-  const unknownTimes = snapshot.intents.flatMap((intent) =>
-    intent.unknownSince === undefined ? [] : [instant(intent.unknownSince)],
-  )
-
-  return {
-    expectedHash: snapshot.stateHash,
-    observedHash,
-    discrepancies: ordered,
-    metrics: {
-      brokerPollAgeMs: Math.max(0, reconciledAt - oldestBrokerTime),
+    }),
+    Result.map(({ brokerTimes, reconciledAt, unknownTimes }) => ({
+      brokerPollAgeMs: Math.max(0, reconciledAt - (brokerTimes.length === 0 ? reconciledAt : Math.min(...brokerTimes))),
       oldestUnknownMutationAgeMs: unknownTimes.length === 0 ? 0 : Math.max(0, reconciledAt - Math.min(...unknownTimes)),
-      cashDifferenceMicros: cashDifference.toString(),
-      positionDifferenceMicros: positionDifference.toString(),
-      equityDifferenceMicros: equityDifference.toString(),
-      accountingExact: snapshot.ledgerExact,
-      discrepancyCount: ordered.length,
-    },
+    })),
+  )
+
+export const compareReconciliation = (
+  snapshot: ReconciliationSnapshot,
+): ReconciliationDecision<ReconciliationComparison> =>
+  pipe(
+    Result.all({
+      bindings: validateAccountBindings(snapshot),
+      account: compareAccountStatus(snapshot),
+      orders: compareOrders(snapshot),
+      fills: compareFills(snapshot),
+      positions: comparePositions(snapshot),
+      cash: compareCash(snapshot),
+      equity: compareEquity(snapshot),
+      ledger: compareLedger(snapshot),
+      temporal: temporalMetrics(snapshot),
+    }),
+    Result.flatMap(({ account, cash, equity, fills, ledger, orders, positions, temporal }) => {
+      const ordered = [
+        ...account,
+        ...orders,
+        ...fills,
+        ...positions.discrepancies,
+        ...cash.discrepancies,
+        ...equity.discrepancies,
+        ...ledger,
+      ].sort((left, right) =>
+        left.discrepancyId < right.discrepancyId ? -1 : left.discrepancyId > right.discrepancyId ? 1 : 0,
+      )
+      return pipe(
+        indexUnique(ordered, (value) => value.discrepancyId, 'discrepancy'),
+        Result.flatMap(() =>
+          ordered.length === 0
+            ? Result.succeed(snapshot.stateHash)
+            : canonicalHash('observed-hash', {
+                schemaVersion: 'bayn.paper-reconciliation-observed.v1',
+                stateHash: snapshot.stateHash,
+                discrepancies: ordered.map((value) => value.evidenceHash),
+              }),
+        ),
+        Result.map((observedHash) => ({
+          expectedHash: snapshot.stateHash,
+          observedHash,
+          discrepancies: ordered,
+          metrics: {
+            ...temporal,
+            cashDifferenceMicros: cash.difference.toString(),
+            positionDifferenceMicros: positions.difference.toString(),
+            equityDifferenceMicros: equity.difference.toString(),
+            accountingExact: snapshot.ledgerExact,
+            discrepancyCount: ordered.length,
+          },
+        })),
+      )
+    }),
+  )
+
+export const renderReconciliationDecisionError = (error: ReconciliationDecisionError): string => {
+  switch (error._tag) {
+    case 'CanonicalizationFailed':
+      return `reconciliation ${error.operation} canonicalization failed${error.identity === undefined ? '' : ` for ${error.identity}`}`
+    case 'FixedPointRoundingFailed':
+      return `position ${error.symbol} cost could not be rounded from quantity ${error.quantityMicros} and price ${error.averageEntryPriceMicros}`
+    case 'InvalidInstant':
+      return `reconciliation ${error.field} for ${error.identity} is invalid: ${error.value}`
+    case 'InvalidInteger':
+      return `reconciliation ${error.source} for ${error.identity} is invalid: ${error.value}`
+    case 'DuplicateIdentity':
+      return `duplicate ${error.collection} identity ${error.identity}`
+    case 'DiscrepancyWithoutDifference':
+      return `reconciliation discrepancy ${error.kind}:${error.identity} has equal value ${error.value}`
+    case 'IntentTerminalStateMismatch':
+      return `intent ${error.intentId} terminal state ${error.state} and outcome ${error.terminalOutcome ?? '<absent>'} disagree`
+    case 'IntentBrokerOrderBindingMismatch':
+      return `intent ${error.intentId} broker-order expectation ${error.expectsBrokerOrder} and identity ${error.brokerOrderId ?? '<absent>'} disagree`
+    case 'BrokerOrderIdentityMissing':
+      return `intent ${error.intentId} for client order ${error.clientOrderId} has no broker order identity`
+    case 'AccountBindingMismatch':
+      return `${error.source} ${error.identity} account ${error.observedAccountId} does not match ${error.expectedAccountId}`
   }
 }

--- a/services/bayn/src/risk.test.ts
+++ b/services/bayn/src/risk.test.ts
@@ -187,14 +187,16 @@ const baseState = (): State => {
   ]
   const orders: readonly ReturnType<typeof openOrder>[] = []
   const accountingHash = hash('a')
-  const reconciledStateHashValue = reconciledStateHash({
-    account,
-    positions,
-    positionsObservedAt: observedAt,
-    orders,
-    ordersObservedAt: observedAt,
-    accountingHash,
-  })
+  const reconciledStateHashValue = Result.getOrThrow(
+    reconciledStateHash({
+      account,
+      positions,
+      positionsObservedAt: observedAt,
+      orders,
+      ordersObservedAt: observedAt,
+      accountingHash,
+    }),
+  )
   const calendar = {
     schemaVersion: 'bayn.alpaca-market-calendar-observation.v1' as const,
     source: 'alpaca-v2-calendar' as const,
@@ -272,14 +274,16 @@ const baseState = (): State => {
 
 const makeState = (overrides: Partial<State> = {}): State => {
   const merged = { ...baseState(), ...overrides }
-  const reconciledStateHashValue = reconciledStateHash({
-    account: merged.account,
-    positions: merged.positions,
-    positionsObservedAt: merged.positionsObservedAt,
-    orders: merged.orders,
-    ordersObservedAt: merged.ordersObservedAt,
-    accountingHash: merged.accountingHash,
-  })
+  const reconciledStateHashValue = Result.getOrThrow(
+    reconciledStateHash({
+      account: merged.account,
+      positions: merged.positions,
+      positionsObservedAt: merged.positionsObservedAt,
+      orders: merged.orders,
+      ordersObservedAt: merged.ordersObservedAt,
+      accountingHash: merged.accountingHash,
+    }),
+  )
   const reconciliation =
     overrides.reconciliation ??
     ({

--- a/services/bayn/src/risk.ts
+++ b/services/bayn/src/risk.ts
@@ -1,4 +1,4 @@
-import { Data, Result, Schema } from 'effect'
+import { Data, Result, Schema, pipe } from 'effect'
 
 import { canonicalHashV1 } from './hash'
 import { ExecutionSessionBindingSchema } from './execution-session'
@@ -694,24 +694,24 @@ const deriveRiskMetrics = (facts: RiskFacts): DerivedRiskMetrics => {
 }
 
 const deriveReconciledHash = (facts: RiskFacts): Result.Result<string, RiskEvaluationFailure> =>
-  Result.try({
-    try: () =>
-      reconciledStateHash({
-        account: facts.state.account,
-        positions: facts.state.positions,
-        positionsObservedAt: facts.state.positionsObservedAt,
-        orders: facts.state.orders,
-        ordersObservedAt: facts.state.ordersObservedAt,
-        accountingHash: facts.state.accountingHash,
-      }),
-    catch: (cause) =>
+  pipe(
+    reconciledStateHash({
+      account: facts.state.account,
+      positions: facts.state.positions,
+      positionsObservedAt: facts.state.positionsObservedAt,
+      orders: facts.state.orders,
+      ordersObservedAt: facts.state.ordersObservedAt,
+      accountingHash: facts.state.accountingHash,
+    }),
+    Result.mapError((cause) =>
       canonicalizeRiskInputFailure(
         'reconciliation',
         'validated reconciled broker state is not canonicalizable',
         { intentId: facts.intent.intentId },
         cause,
       ),
-  })
+    ),
+  )
 
 const buildIntentContractGates = (facts: RiskFacts): readonly GateResult[] => {
   const { intent, policy, state } = facts

--- a/services/bayn/src/shadow-decision.test.ts
+++ b/services/bayn/src/shadow-decision.test.ts
@@ -172,14 +172,16 @@ const makeBrokerState = () => {
   }
   const positions = [position('AMD'), position('NVDA')]
   const orders = [] as const
-  const stateHash = reconciledStateHash({
-    account,
-    positions,
-    positionsObservedAt: brokerObservedAt,
-    orders,
-    ordersObservedAt: brokerObservedAt,
-    accountingHash,
-  })
+  const stateHash = Result.getOrThrow(
+    reconciledStateHash({
+      account,
+      positions,
+      positionsObservedAt: brokerObservedAt,
+      orders,
+      ordersObservedAt: brokerObservedAt,
+      accountingHash,
+    }),
+  )
   const reconciliationMaterial = {
     schemaVersion: 'bayn.paper-reconciliation.v1' as const,
     accountId,

--- a/services/bayn/src/shadow-decision.ts
+++ b/services/bayn/src/shadow-decision.ts
@@ -547,10 +547,10 @@ const assembleShadowDecisionDocument = (
   reduction: ShadowReduction,
 ): Result.Result<ObserveShadowDecisionDocument, ShadowDecisionError> => {
   const { input, policyHash, strategyDecisionHash } = context
-  const planningBrokerStateHash = Result.try({
-    try: () => reconciledStateHash(plannerBrokerStateMaterial(input.plannerInput)),
-    catch: (cause) => error('contract', 'planning broker state hash could not be derived', cause),
-  })
+  const planningBrokerStateHash = Result.mapError(
+    reconciledStateHash(plannerBrokerStateMaterial(input.plannerInput)),
+    (cause) => error('contract', 'planning broker state hash could not be derived', cause),
+  )
   if (Result.isFailure(planningBrokerStateHash)) return Result.fail(planningBrokerStateHash.failure)
   const document = Result.mapError(
     makeObserveShadowDecisionDocument({

--- a/services/bayn/src/target-planner.test.ts
+++ b/services/bayn/src/target-planner.test.ts
@@ -118,14 +118,16 @@ const reconciliation = (
   orders: readonly Order[],
   ordersObservedAt: string,
 ): Reconciliation => {
-  const stateHash = reconciledStateHash({
-    account,
-    positions,
-    positionsObservedAt,
-    orders,
-    ordersObservedAt,
-    accountingHash,
-  })
+  const stateHash = Result.getOrThrow(
+    reconciledStateHash({
+      account,
+      positions,
+      positionsObservedAt,
+      orders,
+      ordersObservedAt,
+      accountingHash,
+    }),
+  )
   const material = {
     schemaVersion: 'bayn.paper-reconciliation.v1' as const,
     accountId: account.accountId,

--- a/services/bayn/src/target-planner.ts
+++ b/services/bayn/src/target-planner.ts
@@ -1,4 +1,4 @@
-import { Data, Result, Schema } from 'effect'
+import { Data, Result, Schema, pipe } from 'effect'
 
 import { IntentPlanSchema, type IntentPlan } from './execution/intents'
 import { desiredQuantityMicros, MICROS } from './execution-model'
@@ -589,22 +589,40 @@ const deriveTargetsFailure = (
 const decodeTargetPlannerInputResult = Schema.decodeUnknownResult(TargetPlannerInputSchema, strictParseOptions)
 const decodeTargetPlanSemanticResult = Schema.decodeUnknownResult(TargetPlanResultSemanticSchema, strictParseOptions)
 
-const deriveTargetPlannerHashes = (
+const plannerInputHash = (
   input: TargetPlannerInput,
-): Result.Result<TargetPlannerHashes, TargetPlannerFailure> =>
-  Result.try({
-    try: () => ({
-      inputHash: canonicalHashV1(input),
-      referencePriceHash: canonicalHashV1(referencePriceMaterial(input.referencePrices)),
-      reconciledBrokerStateHash: reconciledStateHash(input.brokerState),
-    }),
-    catch: (cause) =>
+  operation: 'input' | 'reference-price',
+  value: unknown,
+): Result.Result<string, TargetPlannerFailure> =>
+  pipe(
+    Result.try(() => canonicalHashV1(value)),
+    Result.mapError((cause) =>
       canonicalizePlannerInputFailure(
         'hash',
-        'validated target-planner evidence is not canonicalizable',
+        `validated target-planner ${operation} evidence is not canonicalizable`,
         { cycleId: input.cycleId },
         cause,
       ),
+    ),
+  )
+
+const deriveTargetPlannerHashes = (
+  input: TargetPlannerInput,
+): Result.Result<TargetPlannerHashes, TargetPlannerFailure> =>
+  Result.all({
+    inputHash: plannerInputHash(input, 'input', input),
+    referencePriceHash: plannerInputHash(input, 'reference-price', referencePriceMaterial(input.referencePrices)),
+    reconciledBrokerStateHash: pipe(
+      reconciledStateHash(input.brokerState),
+      Result.mapError((cause) =>
+        canonicalizePlannerInputFailure(
+          'hash',
+          'validated target-planner reconciled broker state is not canonicalizable',
+          { cycleId: input.cycleId },
+          cause,
+        ),
+      ),
+    ),
   })
 
 const parseTargetPlannerFacts = (input: TargetPlannerInput, hashes: TargetPlannerHashes): TargetPlannerFacts => {


### PR DESCRIPTION
## Summary

- replace throwing and mutable broker/accounting reconciliation with immutable `HashMap`/`HashSet` decisions and a closed `ReconciliationDecisionError` algebra
- return typed `Result` values for reconciliation comparison and reconciled-state hashing, preserving exact causes and fact-bearing renderers
- remove the DB layer generic reconciliation `Result.try` wrapper and compose typed failures directly through planner, risk, shadow, and OBSERVE boundaries

## Related Issues

None

## Testing

- `bun run --filter @proompteng/bayn tsc`
- `bun test services/bayn/src/reconciliation.test.ts services/bayn/src/db/reconciliation-algebra.test.ts services/bayn/src/target-planner.test.ts services/bayn/src/risk.test.ts services/bayn/src/shadow-decision.test.ts services/bayn/src/observe-composition.test.ts services/bayn/src/reconciler.test.ts` (86 pass, 0 fail)
- `bun run --filter @proompteng/bayn test` (612 pass, 116 PostgreSQL-gated skips, 0 fail)
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:effect`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn build`
- `git diff --check`

## Breaking Changes

None. Internal reconciliation functions now expose their typed `Result` contract and all repository call sites are migrated.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.