### PR TITLE
refactor(bayn): make execution coordinator functional

### DIFF
--- a/services/bayn/src/execution/coordinator-decisions.test.ts
+++ b/services/bayn/src/execution/coordinator-decisions.test.ts
@@ -1,0 +1,241 @@
+import { describe, expect, test } from 'bun:test'
+
+import { Option, Result } from 'effect'
+
+import {
+  MutationOperation,
+  cancelRequestHash,
+  orderRequestBody,
+  type MutationEvidence,
+} from '../broker/alpaca-mutations'
+import {
+  AssetClass,
+  OrderClass,
+  OrderSide as BrokerSide,
+  OrderStatus,
+  OrderType as BrokerOrderType,
+  TimeInForce as BrokerTimeInForce,
+  type Order,
+} from '../broker/alpaca'
+import { canonicalHashV1 } from '../hash'
+import {
+  IntentState,
+  OrderSide,
+  OrderType,
+  RiskOutcome,
+  TerminalOutcome,
+  TimeInForce,
+  type Intent,
+  type RiskDecision,
+} from '../paper'
+import {
+  decideRecoverySuccess,
+  decideSubmitSuccess,
+  encodeOrder,
+  ensureRecoveryDelay,
+  makeDryRunSubmit,
+  selectRecovery,
+  validateRecovery,
+} from './coordinator-decisions'
+import type { StoredIntent } from './intents'
+import { MutationEventType, mutationId, type MutationEvent } from './mutations'
+
+const intentId = 'a'.repeat(64)
+const accountId = 'e6fe16f3-64a4-4921-8928-cadf02f92f98'
+const brokerOrderId = '61e69015-8549-4bfd-b9c3-01e75843f47d'
+const decisionId = 'b'.repeat(64)
+
+const intent: Intent = {
+  schemaVersion: 'bayn.paper-intent.v3',
+  intentId,
+  authorityGenerationHash: 'f'.repeat(64),
+  riskDecisionId: decisionId,
+  strategyName: 'risk-balanced-trend',
+  cycleId: 'c'.repeat(64),
+  decisionHash: 'd'.repeat(64),
+  policyHash: 'e'.repeat(64),
+  accountId,
+  clientOrderId: `b1_${'A'.repeat(43)}`,
+  symbol: 'AMD',
+  side: OrderSide.Buy,
+  orderType: OrderType.Market,
+  timeInForce: TimeInForce.Day,
+  quantityMicros: '1250000',
+  notionalLimitMicros: '200000000',
+  state: IntentState.Approved,
+  createdAt: '2026-07-25T00:00:00.000Z',
+}
+
+const riskDecision: RiskDecision = {
+  schemaVersion: 'bayn.paper-risk-decision.v1',
+  decisionId,
+  inputHash: '1'.repeat(64),
+  intentId,
+  policyHash: intent.policyHash,
+  outcome: RiskOutcome.Approved,
+  reasonCodes: [],
+  decidedAt: '2026-07-25T00:00:00.000Z',
+  expiresAt: '2026-07-25T00:05:00.000Z',
+}
+
+const stored = (state: IntentState = IntentState.Approved): StoredIntent => ({
+  intent: { ...intent, state },
+  decision: riskDecision,
+  stateVersion: 1,
+  updatedAt: intent.createdAt,
+})
+
+const evidence: MutationEvidence = {
+  requestId: 'request-1',
+  status: 200,
+  contentHash: '2'.repeat(64),
+  observedAt: '2026-07-25T00:01:00.000Z',
+}
+
+const order = (overrides: Partial<Order> = {}): Order => ({
+  accountId,
+  brokerOrderId,
+  clientOrderId: intent.clientOrderId,
+  createdAt: evidence.observedAt,
+  updatedAt: evidence.observedAt,
+  submittedAt: evidence.observedAt,
+  assetId: 'b0b6dd9d-8b9b-48a9-ba46-b9d54906e415',
+  symbol: intent.symbol,
+  assetClass: AssetClass.UsEquity,
+  quantityMicros: intent.quantityMicros,
+  filledQuantityMicros: '0',
+  orderClass: OrderClass.Simple,
+  orderType: BrokerOrderType.Market,
+  side: BrokerSide.Buy,
+  timeInForce: BrokerTimeInForce.Day,
+  status: OrderStatus.Accepted,
+  extendedHours: false,
+  observedAt: evidence.observedAt,
+  ...overrides,
+})
+
+const mutation = (
+  operation: MutationOperation,
+  eventType: MutationEventType,
+  stateIntent: Intent = intent,
+): MutationEvent => {
+  const requestHash =
+    operation === MutationOperation.Submit
+      ? canonicalHashV1(orderRequestBody(stateIntent))
+      : cancelRequestHash(brokerOrderId)
+  return {
+    schemaVersion: 'bayn.paper-mutation-event.v1',
+    eventId: '3'.repeat(64),
+    mutationId: mutationId(intentId, operation),
+    intentId,
+    sequence: 1,
+    operation,
+    eventType,
+    requestHash,
+    consistencyDelayMs: 1_000,
+    brokerOrderId,
+    occurredAt: '2026-07-25T00:01:00.000Z',
+  }
+}
+
+describe('execution coordinator decisions', () => {
+  test('builds the dry-run request only from a currently approved durable decision', () => {
+    const active = makeDryRunSubmit(stored(), Date.parse('2026-07-25T00:04:59.999Z'))
+    const expired = makeDryRunSubmit(stored(), Date.parse(riskDecision.expiresAt))
+
+    expect(Result.getOrThrow(active)).toEqual({
+      schemaVersion: 'bayn.paper-submit-dry-run.v1',
+      intentId,
+      clientOrderId: intent.clientOrderId,
+      requestHash: canonicalHashV1(orderRequestBody(intent)),
+      request: orderRequestBody(intent),
+    })
+    expect(Option.getOrUndefined(Result.getFailure(expired))).toMatchObject({
+      _tag: 'ExpiredRiskDecision',
+      expiresAt: riskDecision.expiresAt,
+    })
+  })
+
+  test('classifies exact and mismatched broker submissions without performing effects', () => {
+    const encoded = Result.getOrThrow(encodeOrder(MutationOperation.Submit, intent))
+    const exact = decideSubmitSuccess(intent, encoded, {
+      requestHash: encoded.requestHash,
+      order: order({ status: OrderStatus.Filled, filledQuantityMicros: intent.quantityMicros }),
+      evidence,
+    })
+    const mismatched = decideSubmitSuccess(intent, encoded, {
+      requestHash: encoded.requestHash,
+      order: order({ accountId: 'd4aa6c51-2f30-4f1c-8dbc-462067dd569c' }),
+      evidence,
+    })
+
+    expect(exact).toEqual({
+      _tag: 'SubmitAccepted',
+      brokerOrderId,
+      evidence,
+      terminalOutcome: TerminalOutcome.Filled,
+    })
+    expect(mismatched).toEqual({
+      _tag: 'SubmitUnknown',
+      brokerOrderId,
+      evidence,
+    })
+  })
+
+  test('keeps recovery selection, cancellation ordering, and delay boundaries pure', () => {
+    const unknownIntent = { ...intent, state: IntentState.Unknown }
+    const submit = mutation(MutationOperation.Submit, MutationEventType.SubmitUnknown, unknownIntent)
+    const cancel = mutation(MutationOperation.Cancel, MutationEventType.CancelStarted, unknownIntent)
+
+    expect(Result.getOrThrow(selectRecovery(MutationOperation.Submit, unknownIntent, submit))).toEqual({
+      _tag: 'RecoveryRequired',
+      event: submit,
+    })
+    expect(Option.getOrUndefined(Result.getFailure(validateRecovery(unknownIntent, submit, cancel)))).toEqual({
+      _tag: 'SubmitRecoveryBlockedByCancellation',
+    })
+    expect(
+      Option.getOrUndefined(
+        Result.getFailure(ensureRecoveryDelay(MutationOperation.Submit, submit, Date.parse(submit.occurredAt) + 999)),
+      ),
+    ).toEqual({
+      _tag: 'RecoveryTooEarly',
+      operation: MutationOperation.Submit,
+      eligibleAt: '2026-07-25T00:01:01.000Z',
+    })
+    expect(
+      Result.getOrThrow(ensureRecoveryDelay(MutationOperation.Submit, submit, Date.parse(submit.occurredAt) + 1_000)),
+    ).toEqual(submit)
+  })
+
+  test('neutralizes the exact zero-fill canceled broker order but not a different order', () => {
+    const acknowledged = { ...intent, state: IntentState.Acknowledged }
+    const cancel = mutation(MutationOperation.Cancel, MutationEventType.CancelUnknown, acknowledged)
+    const canceled = order({
+      status: OrderStatus.Canceled,
+      filledQuantityMicros: '0',
+      accountId: 'd4aa6c51-2f30-4f1c-8dbc-462067dd569c',
+    })
+
+    expect(
+      decideRecoverySuccess(acknowledged, MutationOperation.Cancel, cancel, {
+        value: canceled,
+        evidence,
+      }),
+    ).toEqual({
+      _tag: 'RecoveryFound',
+      brokerOrderId,
+      evidence,
+      terminalOutcome: TerminalOutcome.Canceled,
+    })
+    expect(
+      decideRecoverySuccess(acknowledged, MutationOperation.Cancel, cancel, {
+        value: { ...canceled, brokerOrderId: '9bcf0f36-19d5-488c-97ac-ad16ce9ca97a' },
+        evidence,
+      }),
+    ).toEqual({
+      _tag: 'RecoveryUnknown',
+      evidence,
+    })
+  })
+})

--- a/services/bayn/src/execution/coordinator-decisions.ts
+++ b/services/bayn/src/execution/coordinator-decisions.ts
@@ -1,0 +1,454 @@
+import { Option, Result, Schema } from 'effect'
+
+import {
+  type BrokerMutationError,
+  MutationEvidenceSchema,
+  MutationFailure,
+  MutationOperation,
+  cancelRequestHash,
+  orderRequestBody,
+  type MutationEvidence,
+} from '../broker/alpaca-mutations'
+import {
+  type BrokerReadError,
+  BrokerReadErrorKind,
+  OrderStatus,
+  type Order,
+  type ReadEvidence,
+  type ReadResult,
+} from '../broker/alpaca'
+import { canonicalHashV1 } from '../hash'
+import { IntentState, RiskOutcome, TerminalOutcome, type Intent } from '../paper'
+import type { StoredIntent } from './intents'
+import { MutationEventType, type MutationEvent } from './mutations'
+
+// Pure decisions for the effectful coordinator interpreter.
+export type ExecutionDecisionFailure =
+  | {
+      readonly _tag: 'IntentMissing'
+      readonly operation: MutationOperation
+      readonly intentId: string
+    }
+  | {
+      readonly _tag: 'InvalidRiskDecision'
+      readonly operationLabel: string
+    }
+  | {
+      readonly _tag: 'ExpiredRiskDecision'
+      readonly operationLabel: string
+      readonly expiresAt: string
+    }
+  | {
+      readonly _tag: 'OrderCanonicalizationFailed'
+      readonly operation: MutationOperation
+      readonly message: string
+      readonly cause: unknown
+    }
+  | {
+      readonly _tag: 'CancellationOrderMissing'
+    }
+  | {
+      readonly _tag: 'MutationMissing'
+      readonly operation: MutationOperation
+    }
+  | {
+      readonly _tag: 'SubmitRecoveryBlockedByCancellation'
+    }
+  | {
+      readonly _tag: 'InvalidRecovery'
+      readonly operation: MutationOperation
+    }
+  | {
+      readonly _tag: 'RecoveryTooEarly'
+      readonly operation: MutationOperation
+      readonly eligibleAt: string
+    }
+
+export interface EncodedOrder {
+  readonly request: ReturnType<typeof orderRequestBody>
+  readonly requestHash: string
+}
+
+export interface DryRunSubmitDecision extends EncodedOrder {
+  readonly schemaVersion: 'bayn.paper-submit-dry-run.v1'
+  readonly intentId: string
+  readonly clientOrderId: string
+}
+
+export type SubmitPersistenceDecision =
+  | {
+      readonly _tag: 'SubmitAccepted'
+      readonly brokerOrderId: string
+      readonly evidence: MutationEvidence
+      readonly terminalOutcome?: TerminalOutcome
+    }
+  | {
+      readonly _tag: 'SubmitRejected'
+      readonly evidence: MutationEvidence
+    }
+  | {
+      readonly _tag: 'SubmitUnknown'
+      readonly brokerOrderId?: string
+      readonly evidence?: MutationEvidence
+    }
+
+export type CancelPersistenceDecision =
+  | {
+      readonly _tag: 'CancelAccepted'
+      readonly evidence: MutationEvidence
+    }
+  | {
+      readonly _tag: 'CancelUnknown'
+      readonly evidence?: MutationEvidence
+    }
+
+export type RecoverySelection =
+  | {
+      readonly _tag: 'RecoveryComplete'
+      readonly event: MutationEvent
+    }
+  | {
+      readonly _tag: 'RecoveryRequired'
+      readonly event: MutationEvent
+    }
+
+export type InterruptedStartDecision =
+  | {
+      readonly _tag: 'MarkSubmitUnknown'
+      readonly event: MutationEvent
+      readonly occurredAt: string
+    }
+  | {
+      readonly _tag: 'MarkCancelUnknown'
+      readonly event: MutationEvent
+      readonly brokerOrderId: string
+      readonly occurredAt: string
+    }
+  | {
+      readonly _tag: 'KeepMutation'
+      readonly event: MutationEvent
+    }
+
+export type RecoveryPersistenceDecision =
+  | {
+      readonly _tag: 'RecoveryFound'
+      readonly brokerOrderId: string
+      readonly evidence: MutationEvidence
+      readonly terminalOutcome?: TerminalOutcome
+    }
+  | {
+      readonly _tag: 'RecoveryNotFound'
+      readonly evidence: MutationEvidence
+    }
+  | {
+      readonly _tag: 'RecoveryUnknown'
+      readonly evidence?: MutationEvidence
+    }
+
+interface SubmitReceipt {
+  readonly requestHash: string
+  readonly order: Order
+  readonly evidence: MutationEvidence
+}
+
+interface CancelReceipt {
+  readonly requestHash: string
+  readonly brokerOrderId: string
+  readonly evidence: MutationEvidence
+}
+
+const completeMutationEvidence = Schema.is(MutationEvidenceSchema)
+
+export const selectStoredIntent = (
+  operation: MutationOperation,
+  intentId: string,
+  stored: Option.Option<StoredIntent>,
+): Result.Result<StoredIntent, ExecutionDecisionFailure> =>
+  Option.match(stored, {
+    onNone: () => Result.fail({ _tag: 'IntentMissing', operation, intentId }),
+    onSome: Result.succeed,
+  })
+
+export const nextInstant = (instant: string, current: string): string =>
+  new Date(Math.max(Date.parse(current), Date.parse(instant) + 1)).toISOString()
+
+export const encodeOrder = (
+  operation: MutationOperation,
+  intent: Intent,
+  message = 'intent cannot be represented as an Alpaca paper order',
+): Result.Result<EncodedOrder, ExecutionDecisionFailure> =>
+  Result.try({
+    try: () => {
+      const request = orderRequestBody(intent)
+      return { request, requestHash: canonicalHashV1(request) }
+    },
+    catch: (cause): ExecutionDecisionFailure => ({
+      _tag: 'OrderCanonicalizationFailed',
+      operation,
+      message,
+      cause,
+    }),
+  })
+
+export const validateActiveSubmitRiskDecision = (
+  stored: StoredIntent,
+  currentTimeMillis: number,
+  operationLabel = 'submission',
+): Result.Result<StoredIntent, ExecutionDecisionFailure> => {
+  const decision = stored.decision
+  if (
+    stored.intent.state !== IntentState.Approved ||
+    decision?.outcome !== RiskOutcome.Approved ||
+    stored.intent.riskDecisionId !== decision.decisionId
+  ) {
+    return Result.fail({ _tag: 'InvalidRiskDecision', operationLabel })
+  }
+  return currentTimeMillis >= Date.parse(decision.expiresAt)
+    ? Result.fail({ _tag: 'ExpiredRiskDecision', operationLabel, expiresAt: decision.expiresAt })
+    : Result.succeed(stored)
+}
+
+export const makeDryRunSubmit = (
+  stored: StoredIntent,
+  currentTimeMillis: number,
+): Result.Result<DryRunSubmitDecision, ExecutionDecisionFailure> =>
+  validateActiveSubmitRiskDecision(stored, currentTimeMillis, 'dry-run submission').pipe(
+    Result.flatMap(({ intent }) =>
+      encodeOrder(
+        MutationOperation.Submit,
+        intent,
+        'approved intent cannot be represented as an Alpaca paper order',
+      ).pipe(
+        Result.map(({ request, requestHash }) => ({
+          schemaVersion: 'bayn.paper-submit-dry-run.v1' as const,
+          intentId: intent.intentId,
+          clientOrderId: intent.clientOrderId,
+          requestHash,
+          request,
+        })),
+      ),
+    ),
+  )
+
+export const terminalOutcome = (status: OrderStatus): TerminalOutcome | undefined => {
+  switch (status) {
+    case OrderStatus.Filled:
+      return TerminalOutcome.Filled
+    case OrderStatus.Canceled:
+      return TerminalOutcome.Canceled
+    case OrderStatus.Expired:
+      return TerminalOutcome.Expired
+    case OrderStatus.Rejected:
+      return TerminalOutcome.Rejected
+    default:
+      return undefined
+  }
+}
+
+export const exactOrder = (intent: Intent, request: EncodedOrder['request'], order: Order): boolean =>
+  order.accountId === intent.accountId &&
+  order.clientOrderId === intent.clientOrderId &&
+  order.symbol === intent.symbol &&
+  order.side === request.side &&
+  order.orderType === request.type &&
+  order.timeInForce === request.time_in_force &&
+  order.quantityMicros === intent.quantityMicros &&
+  (order.status !== OrderStatus.Filled || order.filledQuantityMicros === intent.quantityMicros) &&
+  order.extendedHours === false
+
+export const completeEvidence = (value: unknown): MutationEvidence | undefined =>
+  completeMutationEvidence(value) ? value : undefined
+
+export const mutationEvidence = (evidence: ReadEvidence): MutationEvidence => ({
+  requestId: evidence.requestId,
+  status: evidence.status,
+  contentHash: evidence.contentHash,
+  observedAt: evidence.observedAt,
+})
+
+export const readErrorEvidence = (error: BrokerReadError): MutationEvidence | undefined =>
+  completeEvidence({
+    requestId: error.requestId,
+    status: error.status,
+    contentHash: error.contentHash,
+    observedAt: error.observedAt,
+  })
+
+export const decideSubmitFailure = (
+  expectedRequestHash: string,
+  error: BrokerMutationError,
+): SubmitPersistenceDecision => {
+  const evidence = completeEvidence(error.evidence)
+  return error.failure === MutationFailure.Rejected &&
+    error.requestHash === expectedRequestHash &&
+    evidence !== undefined
+    ? { _tag: 'SubmitRejected', evidence }
+    : {
+        _tag: 'SubmitUnknown',
+        ...(error.brokerOrderId === undefined ? {} : { brokerOrderId: error.brokerOrderId }),
+        ...(evidence === undefined ? {} : { evidence }),
+      }
+}
+
+export const decideSubmitSuccess = (
+  intent: Intent,
+  encoded: EncodedOrder,
+  receipt: SubmitReceipt,
+): SubmitPersistenceDecision => {
+  if (receipt.requestHash !== encoded.requestHash || !exactOrder(intent, encoded.request, receipt.order)) {
+    return {
+      _tag: 'SubmitUnknown',
+      brokerOrderId: receipt.order.brokerOrderId,
+      evidence: receipt.evidence,
+    }
+  }
+  const outcome = terminalOutcome(receipt.order.status)
+  return {
+    _tag: 'SubmitAccepted',
+    brokerOrderId: receipt.order.brokerOrderId,
+    evidence: receipt.evidence,
+    ...(outcome === undefined ? {} : { terminalOutcome: outcome }),
+  }
+}
+
+export const cancellationIdentity = (
+  submitEvent: MutationEvent | undefined,
+): Result.Result<{ readonly brokerOrderId: string; readonly requestHash: string }, ExecutionDecisionFailure> =>
+  submitEvent?.brokerOrderId === undefined
+    ? Result.fail({ _tag: 'CancellationOrderMissing' })
+    : Result.succeed({
+        brokerOrderId: submitEvent.brokerOrderId,
+        requestHash: cancelRequestHash(submitEvent.brokerOrderId),
+      })
+
+export const decideCancelFailure = (error: BrokerMutationError): CancelPersistenceDecision => {
+  const evidence = completeEvidence(error.evidence)
+  return {
+    _tag: 'CancelUnknown',
+    ...(evidence === undefined ? {} : { evidence }),
+  }
+}
+
+export const decideCancelSuccess = (
+  brokerOrderId: string,
+  requestHash: string,
+  receipt: CancelReceipt,
+): CancelPersistenceDecision =>
+  receipt.requestHash === requestHash && receipt.brokerOrderId === brokerOrderId
+    ? { _tag: 'CancelAccepted', evidence: receipt.evidence }
+    : { _tag: 'CancelUnknown', evidence: receipt.evidence }
+
+const submitResolved = (intent: Intent, event: MutationEvent): boolean =>
+  intent.state === IntentState.Terminal &&
+  (event.eventType === MutationEventType.SubmitAccepted ||
+    event.eventType === MutationEventType.SubmitRejected ||
+    event.eventType === MutationEventType.RecoveryFound)
+
+export const selectRecovery = (
+  operation: MutationOperation,
+  intent: Intent,
+  event: MutationEvent | undefined,
+): Result.Result<RecoverySelection, ExecutionDecisionFailure> => {
+  if (event === undefined) return Result.fail({ _tag: 'MutationMissing', operation })
+  const complete =
+    (operation === MutationOperation.Submit && submitResolved(intent, event)) ||
+    (operation === MutationOperation.Cancel &&
+      intent.state === IntentState.Terminal &&
+      event.eventType === MutationEventType.RecoveryFound)
+  return Result.succeed(complete ? { _tag: 'RecoveryComplete', event } : { _tag: 'RecoveryRequired', event })
+}
+
+const recoveryRequestHash = (
+  intent: Intent,
+  event: MutationEvent,
+): Result.Result<string | undefined, ExecutionDecisionFailure> =>
+  event.operation === MutationOperation.Submit
+    ? encodeOrder(event.operation, intent).pipe(Result.map(({ requestHash }) => requestHash))
+    : Result.succeed(event.brokerOrderId === undefined ? undefined : cancelRequestHash(event.brokerOrderId))
+
+export const validateRecovery = (
+  intent: Intent,
+  event: MutationEvent,
+  cancellation: MutationEvent | undefined,
+): Result.Result<MutationEvent, ExecutionDecisionFailure> => {
+  if (event.operation === MutationOperation.Submit && cancellation !== undefined) {
+    return Result.fail({ _tag: 'SubmitRecoveryBlockedByCancellation' })
+  }
+  return recoveryRequestHash(intent, event).pipe(
+    Result.flatMap((expectedHash) => {
+      const validState =
+        event.operation === MutationOperation.Submit
+          ? intent.state === IntentState.IoStarted ||
+            intent.state === IntentState.Unknown ||
+            intent.state === IntentState.Acknowledged
+          : intent.state === IntentState.Acknowledged ||
+            (intent.state === IntentState.Unknown && event.brokerOrderId !== undefined)
+      if (expectedHash === event.requestHash && validState) return Result.succeed(event)
+      const failure: ExecutionDecisionFailure = { _tag: 'InvalidRecovery', operation: event.operation }
+      return Result.fail(failure)
+    }),
+  )
+}
+
+export const ensureRecoveryDelay = (
+  operation: MutationOperation,
+  event: MutationEvent,
+  currentMillis: number,
+): Result.Result<MutationEvent, ExecutionDecisionFailure> => {
+  const eligibleMillis = Date.parse(event.occurredAt) + event.consistencyDelayMs
+  return currentMillis >= eligibleMillis
+    ? Result.succeed(event)
+    : Result.fail({
+        _tag: 'RecoveryTooEarly',
+        operation,
+        eligibleAt: new Date(eligibleMillis).toISOString(),
+      })
+}
+
+export const decideInterruptedStart = (event: MutationEvent, occurredAt: string): InterruptedStartDecision => {
+  if (event.eventType === MutationEventType.SubmitStarted) {
+    return { _tag: 'MarkSubmitUnknown', event, occurredAt }
+  }
+  return event.eventType === MutationEventType.CancelStarted && event.brokerOrderId !== undefined
+    ? { _tag: 'MarkCancelUnknown', event, brokerOrderId: event.brokerOrderId, occurredAt }
+    : { _tag: 'KeepMutation', event }
+}
+
+export const decideRecoveryFailure = (error: BrokerReadError): RecoveryPersistenceDecision => {
+  const evidence = readErrorEvidence(error)
+  return error.kind === BrokerReadErrorKind.NotFound && evidence !== undefined
+    ? { _tag: 'RecoveryNotFound', evidence }
+    : {
+        _tag: 'RecoveryUnknown',
+        ...(evidence === undefined ? {} : { evidence }),
+      }
+}
+
+export const decideRecoverySuccess = (
+  intent: Intent,
+  operation: MutationOperation,
+  interrupted: MutationEvent,
+  result: ReadResult<Order>,
+): RecoveryPersistenceDecision => {
+  const evidence = mutationEvidence(result.evidence)
+  const outcome = terminalOutcome(result.value.status)
+  const neutralizedMismatchedOrder =
+    operation === MutationOperation.Cancel &&
+    interrupted.brokerOrderId === result.value.brokerOrderId &&
+    result.value.filledQuantityMicros === '0' &&
+    outcome !== undefined &&
+    outcome !== TerminalOutcome.Filled
+  const exactBrokerOrderId =
+    interrupted.brokerOrderId === undefined || interrupted.brokerOrderId === result.value.brokerOrderId
+  const request = encodeOrder(operation, intent)
+  const matchesIntent = Result.isSuccess(request) && exactOrder(intent, request.success.request, result.value)
+
+  return (!exactBrokerOrderId || !matchesIntent) && !neutralizedMismatchedOrder
+    ? { _tag: 'RecoveryUnknown', evidence }
+    : {
+        _tag: 'RecoveryFound',
+        brokerOrderId: result.value.brokerOrderId,
+        evidence,
+        ...(outcome === undefined ? {} : { terminalOutcome: outcome }),
+      }
+}

--- a/services/bayn/src/execution/coordinator.ts
+++ b/services/bayn/src/execution/coordinator.ts
@@ -1,26 +1,33 @@
-import { Clock, Data, Effect, Option, Schema } from 'effect'
+import { Clock, Data, Effect, Match, Result } from 'effect'
 
+import { BrokerMutation, MutationOperation } from '../broker/alpaca-mutations'
+import { BrokerRead } from '../broker/alpaca'
+import { IntentState, type Intent } from '../paper'
 import {
-  BrokerMutation,
-  MutationEvidenceSchema,
-  MutationFailure,
-  MutationOperation,
-  cancelRequestHash,
-  orderRequestBody,
-  type MutationEvidence,
-} from '../broker/alpaca-mutations'
-import {
-  BrokerRead,
-  BrokerReadError,
-  BrokerReadErrorKind,
-  OrderStatus,
-  type Order,
-  type ReadEvidence,
-} from '../broker/alpaca'
-import { canonicalHashV1 } from '../hash'
-import { IntentState, RiskOutcome, TerminalOutcome, type Intent } from '../paper'
+  cancellationIdentity,
+  decideCancelFailure,
+  decideCancelSuccess,
+  decideInterruptedStart,
+  decideRecoveryFailure,
+  decideRecoverySuccess,
+  decideSubmitFailure,
+  decideSubmitSuccess,
+  encodeOrder,
+  ensureRecoveryDelay,
+  makeDryRunSubmit,
+  nextInstant,
+  selectRecovery,
+  selectStoredIntent,
+  validateActiveSubmitRiskDecision,
+  validateRecovery,
+  type CancelPersistenceDecision,
+  type DryRunSubmitDecision,
+  type ExecutionDecisionFailure,
+  type RecoveryPersistenceDecision,
+  type SubmitPersistenceDecision,
+} from './coordinator-decisions'
 import { IntentStore, type IntentStoreError, type StoredIntent } from './intents'
-import { MutationEventType, MutationStore, type MutationEvent } from './mutations'
+import { MutationStore, type MutationEvent } from './mutations'
 import { WriterFence } from './writer-fence'
 
 export enum ExecutionFailure {
@@ -37,411 +44,406 @@ export class ExecutionError extends Data.TaggedError('ExecutionError')<{
   readonly cause?: unknown
 }> {}
 
-export interface DryRunSubmit {
-  readonly schemaVersion: 'bayn.paper-submit-dry-run.v1'
-  readonly intentId: string
-  readonly clientOrderId: string
-  readonly requestHash: string
-  readonly request: ReturnType<typeof orderRequestBody>
+export interface DryRunSubmit extends DryRunSubmitDecision {}
+
+interface MutationServices {
+  readonly mutations: MutationStore['Service']
+  readonly broker: BrokerMutation['Service']
+  readonly fence: WriterFence['Service']
 }
 
-const now = Clock.currentTimeMillis.pipe(Effect.map((millis) => new Date(millis).toISOString()))
+interface RecoveryServices {
+  readonly mutations: MutationStore['Service']
+  readonly broker: BrokerRead['Service']
+}
 
-const readIntent = (operation: MutationOperation, intentId: string) =>
-  Effect.gen(function* () {
-    const store = yield* IntentStore
-    const stored = yield* store.read(intentId)
-    if (Option.isNone(stored)) {
-      return yield* Effect.fail(
+const currentInstant = Clock.currentTimeMillis.pipe(Effect.map((millis) => new Date(millis).toISOString()))
+
+const executionError = (failure: ExecutionDecisionFailure): ExecutionError =>
+  Match.value(failure).pipe(
+    Match.tagsExhaustive({
+      IntentMissing: ({ operation, intentId }) =>
         new ExecutionError({
           operation,
           failure: ExecutionFailure.IntentNotFound,
           message: `intent ${intentId} does not exist`,
         }),
-      )
-    }
-    return stored.value
-  })
-
-const nextInstant = (instant: string, current: string): string =>
-  new Date(Math.max(Date.parse(current), Date.parse(instant) + 1)).toISOString()
-
-const requestHash = (operation: MutationOperation, intent: Intent) =>
-  Effect.try({
-    try: () => canonicalHashV1(orderRequestBody(intent)),
-    catch: (cause) =>
-      new ExecutionError({
-        operation,
-        failure: ExecutionFailure.InvalidState,
-        message: 'intent cannot be represented as an Alpaca paper order',
-        cause,
-      }),
-  })
-
-const terminalOutcome = (status: OrderStatus): TerminalOutcome | undefined => {
-  switch (status) {
-    case OrderStatus.Filled:
-      return TerminalOutcome.Filled
-    case OrderStatus.Canceled:
-      return TerminalOutcome.Canceled
-    case OrderStatus.Expired:
-      return TerminalOutcome.Expired
-    case OrderStatus.Rejected:
-      return TerminalOutcome.Rejected
-    default:
-      return undefined
-  }
-}
-
-const exactOrder = (intent: Intent, order: Order): boolean => {
-  const body = orderRequestBody(intent)
-  return (
-    order.accountId === intent.accountId &&
-    order.clientOrderId === intent.clientOrderId &&
-    order.symbol === intent.symbol &&
-    order.side === body.side &&
-    order.orderType === body.type &&
-    order.timeInForce === body.time_in_force &&
-    order.quantityMicros === intent.quantityMicros &&
-    (order.status !== OrderStatus.Filled || order.filledQuantityMicros === intent.quantityMicros) &&
-    order.extendedHours === false
-  )
-}
-
-const isCompleteEvidence = (value: unknown): value is MutationEvidence => Schema.is(MutationEvidenceSchema)(value)
-
-const mutationEvidence = (evidence: ReadEvidence): MutationEvidence => ({
-  requestId: evidence.requestId,
-  status: evidence.status,
-  contentHash: evidence.contentHash,
-  observedAt: evidence.observedAt,
-})
-
-const readErrorEvidence = (error: BrokerReadError): MutationEvidence | undefined => {
-  const candidate = {
-    requestId: error.requestId,
-    status: error.status,
-    contentHash: error.contentHash,
-    observedAt: error.observedAt,
-  }
-  return isCompleteEvidence(candidate) ? candidate : undefined
-}
-
-const isSubmitResolved = (intent: Intent, event: MutationEvent): boolean =>
-  intent.state === IntentState.Terminal &&
-  (event.eventType === MutationEventType.SubmitAccepted ||
-    event.eventType === MutationEventType.SubmitRejected ||
-    event.eventType === MutationEventType.RecoveryFound)
-
-const requireActiveSubmitRiskDecision = (stored: StoredIntent, operationLabel = 'submission') =>
-  Effect.gen(function* () {
-    const decision = stored.decision
-    if (
-      stored.intent.state !== IntentState.Approved ||
-      decision?.outcome !== RiskOutcome.Approved ||
-      stored.intent.riskDecisionId !== decision.decisionId
-    ) {
-      return yield* Effect.fail(
+      InvalidRiskDecision: ({ operationLabel }) =>
         new ExecutionError({
           operation: MutationOperation.Submit,
           failure: ExecutionFailure.InvalidState,
           message: `${operationLabel} requires one committed approved intent and matching risk decision`,
         }),
-      )
-    }
-    const currentTime = yield* Clock.currentTimeMillis
-    if (currentTime >= Date.parse(decision.expiresAt)) {
-      return yield* Effect.fail(
+      ExpiredRiskDecision: ({ operationLabel, expiresAt }) =>
         new ExecutionError({
           operation: MutationOperation.Submit,
           failure: ExecutionFailure.InvalidState,
-          message: `${operationLabel} risk decision expired at ${decision.expiresAt}`,
+          message: `${operationLabel} risk decision expired at ${expiresAt}`,
         }),
-      )
-    }
-    return stored
-  })
+      OrderCanonicalizationFailed: ({ operation, message, cause }) =>
+        new ExecutionError({
+          operation,
+          failure: ExecutionFailure.InvalidState,
+          message,
+          cause,
+        }),
+      CancellationOrderMissing: () =>
+        new ExecutionError({
+          operation: MutationOperation.Cancel,
+          failure: ExecutionFailure.InvalidState,
+          message: 'cancellation requires a positively identified broker order',
+        }),
+      MutationMissing: ({ operation }) =>
+        new ExecutionError({
+          operation,
+          failure: ExecutionFailure.InvalidState,
+          message: 'mutation does not exist',
+        }),
+      SubmitRecoveryBlockedByCancellation: () =>
+        new ExecutionError({
+          operation: MutationOperation.Submit,
+          failure: ExecutionFailure.InvalidState,
+          message: 'submit recovery requires the durable cancellation to recover first',
+        }),
+      InvalidRecovery: ({ operation }) =>
+        new ExecutionError({
+          operation,
+          failure: ExecutionFailure.InvalidState,
+          message: 'durable mutation identity or intent state does not permit broker recovery',
+        }),
+      RecoveryTooEarly: ({ operation, eligibleAt }) =>
+        new ExecutionError({
+          operation,
+          failure: ExecutionFailure.RecoveryTooEarly,
+          message: `broker lookup is not allowed before ${eligibleAt}`,
+          eligibleAt,
+        }),
+    }),
+  )
+
+const liftDecision = <A>(decision: Result.Result<A, ExecutionDecisionFailure>): Effect.Effect<A, ExecutionError> =>
+  Effect.fromResult(decision).pipe(Effect.mapError(executionError))
+
+const readIntent = (
+  operation: MutationOperation,
+  intentId: string,
+): Effect.Effect<StoredIntent, ExecutionError | IntentStoreError, IntentStore> =>
+  Effect.flatMap(IntentStore, (store) =>
+    store
+      .read(intentId)
+      .pipe(Effect.flatMap((stored) => liftDecision(selectStoredIntent(operation, intentId, stored)))),
+  )
+
+const requireActiveSubmitRiskDecision = (
+  stored: StoredIntent,
+  operationLabel = 'submission',
+): Effect.Effect<StoredIntent, ExecutionError> =>
+  Clock.currentTimeMillis.pipe(
+    Effect.flatMap((currentTimeMillis) =>
+      liftDecision(validateActiveSubmitRiskDecision(stored, currentTimeMillis, operationLabel)),
+    ),
+  )
 
 export const dryRunSubmit = (
   intentId: string,
 ): Effect.Effect<DryRunSubmit, ExecutionError | IntentStoreError, IntentStore> =>
   readIntent(MutationOperation.Submit, intentId).pipe(
     Effect.flatMap((stored) =>
-      Effect.gen(function* () {
-        yield* requireActiveSubmitRiskDecision(stored, 'dry-run submission')
-        return yield* Effect.try({
-          try: (): DryRunSubmit => {
-            const request = orderRequestBody(stored.intent)
-            return {
-              schemaVersion: 'bayn.paper-submit-dry-run.v1',
-              intentId: stored.intent.intentId,
-              clientOrderId: stored.intent.clientOrderId,
-              requestHash: canonicalHashV1(request),
-              request,
-            }
-          },
-          catch: (cause) =>
-            new ExecutionError({
-              operation: MutationOperation.Submit,
-              failure: ExecutionFailure.InvalidState,
-              message: 'approved intent cannot be represented as an Alpaca paper order',
-              cause,
-            }),
-        })
-      }),
+      Clock.currentTimeMillis.pipe(
+        Effect.flatMap((currentTimeMillis) => liftDecision(makeDryRunSubmit(stored, currentTimeMillis))),
+      ),
     ),
   )
 
-const validateRecovery = (stored: Intent, event: MutationEvent) =>
-  Effect.gen(function* () {
-    const expectedHash =
-      event.operation === MutationOperation.Submit
-        ? yield* requestHash(event.operation, stored)
-        : event.brokerOrderId === undefined
-          ? undefined
-          : cancelRequestHash(event.brokerOrderId)
-    const validState =
-      event.operation === MutationOperation.Submit
-        ? stored.state === IntentState.IoStarted ||
-          stored.state === IntentState.Unknown ||
-          stored.state === IntentState.Acknowledged
-        : stored.state === IntentState.Acknowledged ||
-          (stored.state === IntentState.Unknown && event.brokerOrderId !== undefined)
-    if (expectedHash === event.requestHash && validState) return
-    return yield* Effect.fail(
-      new ExecutionError({
-        operation: event.operation,
-        failure: ExecutionFailure.InvalidState,
-        message: 'durable mutation identity or intent state does not permit broker recovery',
-      }),
-    )
-  })
+const persistSubmitDecision = (
+  services: MutationServices,
+  intentId: string,
+  requestHash: string,
+  decision: SubmitPersistenceDecision,
+) =>
+  Match.value(decision).pipe(
+    Match.tagsExhaustive({
+      SubmitAccepted: ({ brokerOrderId, evidence, terminalOutcome }) =>
+        services.mutations.submitAccepted(intentId, requestHash, brokerOrderId, evidence, terminalOutcome),
+      SubmitRejected: ({ evidence }) => services.mutations.submitRejected(intentId, requestHash, evidence),
+      SubmitUnknown: ({ brokerOrderId, evidence }) =>
+        (evidence === undefined ? currentInstant : Effect.succeed(evidence.observedAt)).pipe(
+          Effect.flatMap((occurredAt) =>
+            services.mutations.submitUnknown(intentId, requestHash, occurredAt, evidence, brokerOrderId),
+          ),
+        ),
+    }),
+  )
 
-export const submit = (intentId: string, consistencyDelayMs: number) =>
-  Effect.gen(function* () {
-    const mutations = yield* MutationStore
-    const broker = yield* BrokerMutation
-    const fence = yield* WriterFence
-    const existing = yield* mutations.latest(intentId, MutationOperation.Submit)
-    const before = yield* readIntent(MutationOperation.Submit, intentId)
-    const hash = yield* requestHash(MutationOperation.Submit, before.intent)
-    if (existing !== undefined) {
-      const replay = yield* mutations.beginSubmit(intentId, hash, consistencyDelayMs, existing.occurredAt)
-      return replay.event
-    }
-    yield* fence.check
-    yield* requireActiveSubmitRiskDecision(before)
-    const current = yield* now
-    const started = yield* mutations.beginSubmit(
-      intentId,
-      hash,
-      consistencyDelayMs,
-      nextInstant(before.updatedAt, current),
-    )
-    if (!started.started) return started.event
-
-    const submittedIntent: Intent = { ...before.intent, state: IntentState.IoStarted }
-
-    return yield* broker.submit(submittedIntent).pipe(
-      Effect.matchEffect({
-        onFailure: (error) => {
-          if (
-            error.failure === MutationFailure.Rejected &&
-            error.requestHash === hash &&
-            isCompleteEvidence(error.evidence)
-          ) {
-            return mutations.submitRejected(intentId, hash, error.evidence)
-          }
-          return isCompleteEvidence(error.evidence)
-            ? mutations.submitUnknown(intentId, hash, error.evidence.observedAt, error.evidence, error.brokerOrderId)
-            : now.pipe(
-                Effect.flatMap((occurredAt) =>
-                  mutations.submitUnknown(intentId, hash, occurredAt, undefined, error.brokerOrderId),
-                ),
-              )
-        },
-        onSuccess: (receipt) => {
-          if (receipt.requestHash !== hash || !exactOrder(submittedIntent, receipt.order)) {
-            return mutations.submitUnknown(
-              intentId,
-              hash,
-              receipt.evidence.observedAt,
-              receipt.evidence,
-              receipt.order.brokerOrderId,
-            )
-          }
-          return mutations.submitAccepted(
-            intentId,
-            hash,
-            receipt.order.brokerOrderId,
-            receipt.evidence,
-            terminalOutcome(receipt.order.status),
-          )
-        },
-      }),
-    )
-  })
-
-export const cancel = (intentId: string, consistencyDelayMs: number) =>
-  Effect.gen(function* () {
-    const mutations = yield* MutationStore
-    const broker = yield* BrokerMutation
-    const fence = yield* WriterFence
-    const existing = yield* mutations.latest(intentId, MutationOperation.Cancel)
-    const submitEvent = yield* mutations.latest(intentId, MutationOperation.Submit)
-    const orderId = submitEvent?.brokerOrderId
-    if (orderId === undefined) {
-      return yield* Effect.fail(
-        new ExecutionError({
-          operation: MutationOperation.Cancel,
-          failure: ExecutionFailure.InvalidState,
-          message: 'cancellation requires a positively identified broker order',
-        }),
-      )
-    }
-    const hash = cancelRequestHash(orderId)
-    if (existing !== undefined) {
-      const replay = yield* mutations.beginCancel(intentId, hash, orderId, consistencyDelayMs, existing.occurredAt)
-      return replay.event
-    }
-    const intent = yield* readIntent(MutationOperation.Cancel, intentId)
-    yield* fence.check
-    const current = yield* now
-    const started = yield* mutations.beginCancel(
-      intentId,
-      hash,
-      orderId,
-      consistencyDelayMs,
-      nextInstant(intent.updatedAt, current),
-    )
-    if (!started.started) return started.event
-
-    return yield* broker.cancel(orderId).pipe(
-      Effect.matchEffect({
-        onFailure: (error) =>
-          isCompleteEvidence(error.evidence)
-            ? mutations.cancelUnknown(intentId, hash, orderId, error.evidence.observedAt, error.evidence)
-            : now.pipe(Effect.flatMap((occurredAt) => mutations.cancelUnknown(intentId, hash, orderId, occurredAt))),
-        onSuccess: (receipt) => {
-          if (receipt.requestHash !== hash || receipt.brokerOrderId !== orderId) {
-            return mutations.cancelUnknown(intentId, hash, orderId, receipt.evidence.observedAt, receipt.evidence)
-          }
-          return mutations.cancelAccepted(intentId, hash, orderId, receipt.evidence)
-        },
-      }),
-    )
-  })
-
-const ensureRecoveryDelay = (operation: MutationOperation, event: MutationEvent, currentMillis: number) => {
-  const eligibleMillis = Date.parse(event.occurredAt) + event.consistencyDelayMs
-  if (currentMillis >= eligibleMillis) return Effect.void
-  const eligibleAt = new Date(eligibleMillis).toISOString()
-  return Effect.fail(
-    new ExecutionError({
-      operation,
-      failure: ExecutionFailure.RecoveryTooEarly,
-      message: `broker lookup is not allowed before ${eligibleAt}`,
-      eligibleAt,
+const submitToBroker = (
+  services: MutationServices,
+  stored: StoredIntent,
+  requestHash: string,
+  request: DryRunSubmitDecision['request'],
+) => {
+  const submittedIntent: Intent = { ...stored.intent, state: IntentState.IoStarted }
+  return services.broker.submit(submittedIntent).pipe(
+    Effect.matchEffect({
+      onFailure: (error) =>
+        persistSubmitDecision(services, stored.intent.intentId, requestHash, decideSubmitFailure(requestHash, error)),
+      onSuccess: (receipt) =>
+        persistSubmitDecision(
+          services,
+          stored.intent.intentId,
+          requestHash,
+          decideSubmitSuccess(submittedIntent, { requestHash, request }, receipt),
+        ),
     }),
   )
 }
 
-const markInterruptedStart = (event: MutationEvent, occurredAt: string) =>
-  Effect.flatMap(MutationStore, (store) => {
-    if (event.eventType === MutationEventType.SubmitStarted) {
-      return store.submitUnknown(event.intentId, event.requestHash, occurredAt)
-    }
-    if (event.eventType === MutationEventType.CancelStarted && event.brokerOrderId !== undefined) {
-      return store.cancelUnknown(event.intentId, event.requestHash, event.brokerOrderId, occurredAt)
-    }
-    return Effect.succeed(event)
-  })
+const startSubmit = (
+  services: MutationServices,
+  stored: StoredIntent,
+  requestHash: string,
+  request: DryRunSubmitDecision['request'],
+  consistencyDelayMs: number,
+) =>
+  services.fence.check.pipe(
+    Effect.andThen(requireActiveSubmitRiskDecision(stored)),
+    Effect.andThen(currentInstant),
+    Effect.flatMap((occurredAt) =>
+      services.mutations.beginSubmit(
+        stored.intent.intentId,
+        requestHash,
+        consistencyDelayMs,
+        nextInstant(stored.updatedAt, occurredAt),
+      ),
+    ),
+    Effect.flatMap((started) =>
+      started.started ? submitToBroker(services, stored, requestHash, request) : Effect.succeed(started.event),
+    ),
+  )
+
+const runSubmit = (services: MutationServices, intentId: string, consistencyDelayMs: number) =>
+  services.mutations
+    .latest(intentId, MutationOperation.Submit)
+    .pipe(
+      Effect.flatMap((existing) =>
+        readIntent(MutationOperation.Submit, intentId).pipe(
+          Effect.flatMap((stored) =>
+            liftDecision(encodeOrder(MutationOperation.Submit, stored.intent)).pipe(
+              Effect.flatMap(({ request, requestHash }) =>
+                existing === undefined
+                  ? startSubmit(services, stored, requestHash, request, consistencyDelayMs)
+                  : services.mutations
+                      .beginSubmit(intentId, requestHash, consistencyDelayMs, existing.occurredAt)
+                      .pipe(Effect.map(({ event }) => event)),
+              ),
+            ),
+          ),
+        ),
+      ),
+    )
+
+export const submit = (intentId: string, consistencyDelayMs: number) =>
+  Effect.all({
+    mutations: MutationStore,
+    broker: BrokerMutation,
+    fence: WriterFence,
+  }).pipe(Effect.flatMap((services) => runSubmit(services, intentId, consistencyDelayMs)))
+
+const persistCancelDecision = (
+  services: MutationServices,
+  intentId: string,
+  requestHash: string,
+  brokerOrderId: string,
+  decision: CancelPersistenceDecision,
+) =>
+  Match.value(decision).pipe(
+    Match.tagsExhaustive({
+      CancelAccepted: ({ evidence }) =>
+        services.mutations.cancelAccepted(intentId, requestHash, brokerOrderId, evidence),
+      CancelUnknown: ({ evidence }) =>
+        (evidence === undefined ? currentInstant : Effect.succeed(evidence.observedAt)).pipe(
+          Effect.flatMap((occurredAt) =>
+            services.mutations.cancelUnknown(intentId, requestHash, brokerOrderId, occurredAt, evidence),
+          ),
+        ),
+    }),
+  )
+
+const cancelAtBroker = (services: MutationServices, intentId: string, requestHash: string, brokerOrderId: string) =>
+  services.broker.cancel(brokerOrderId).pipe(
+    Effect.matchEffect({
+      onFailure: (error) =>
+        persistCancelDecision(services, intentId, requestHash, brokerOrderId, decideCancelFailure(error)),
+      onSuccess: (receipt) =>
+        persistCancelDecision(
+          services,
+          intentId,
+          requestHash,
+          brokerOrderId,
+          decideCancelSuccess(brokerOrderId, requestHash, receipt),
+        ),
+    }),
+  )
+
+const startCancel = (
+  services: MutationServices,
+  stored: StoredIntent,
+  requestHash: string,
+  brokerOrderId: string,
+  consistencyDelayMs: number,
+) =>
+  services.fence.check.pipe(
+    Effect.andThen(currentInstant),
+    Effect.flatMap((occurredAt) =>
+      services.mutations.beginCancel(
+        stored.intent.intentId,
+        requestHash,
+        brokerOrderId,
+        consistencyDelayMs,
+        nextInstant(stored.updatedAt, occurredAt),
+      ),
+    ),
+    Effect.flatMap((started) =>
+      started.started
+        ? cancelAtBroker(services, stored.intent.intentId, requestHash, brokerOrderId)
+        : Effect.succeed(started.event),
+    ),
+  )
+
+const runCancel = (services: MutationServices, intentId: string, consistencyDelayMs: number) =>
+  services.mutations
+    .latest(intentId, MutationOperation.Cancel)
+    .pipe(
+      Effect.flatMap((existing) =>
+        services.mutations
+          .latest(intentId, MutationOperation.Submit)
+          .pipe(
+            Effect.flatMap((submitted) =>
+              liftDecision(cancellationIdentity(submitted)).pipe(
+                Effect.flatMap(({ brokerOrderId, requestHash }) =>
+                  existing === undefined
+                    ? readIntent(MutationOperation.Cancel, intentId).pipe(
+                        Effect.flatMap((stored) =>
+                          startCancel(services, stored, requestHash, brokerOrderId, consistencyDelayMs),
+                        ),
+                      )
+                    : services.mutations
+                        .beginCancel(intentId, requestHash, brokerOrderId, consistencyDelayMs, existing.occurredAt)
+                        .pipe(Effect.map(({ event }) => event)),
+                ),
+              ),
+            ),
+          ),
+      ),
+    )
+
+export const cancel = (intentId: string, consistencyDelayMs: number) =>
+  Effect.all({
+    mutations: MutationStore,
+    broker: BrokerMutation,
+    fence: WriterFence,
+  }).pipe(Effect.flatMap((services) => runCancel(services, intentId, consistencyDelayMs)))
+
+const markInterruptedStart = (mutations: MutationStore['Service'], event: MutationEvent, occurredAt: string) =>
+  Match.value(decideInterruptedStart(event, occurredAt)).pipe(
+    Match.tagsExhaustive({
+      MarkSubmitUnknown: ({ event: started, occurredAt: interruptedAt }) =>
+        mutations.submitUnknown(started.intentId, started.requestHash, interruptedAt),
+      MarkCancelUnknown: ({ event: started, brokerOrderId, occurredAt: interruptedAt }) =>
+        mutations.cancelUnknown(started.intentId, started.requestHash, brokerOrderId, interruptedAt),
+      KeepMutation: ({ event: current }) => Effect.succeed(current),
+    }),
+  )
+
+const persistRecoveryDecision = (
+  services: RecoveryServices,
+  intentId: string,
+  operation: MutationOperation,
+  requestHash: string,
+  decision: RecoveryPersistenceDecision,
+) =>
+  Match.value(decision).pipe(
+    Match.tagsExhaustive({
+      RecoveryFound: ({ brokerOrderId, evidence, terminalOutcome }) =>
+        services.mutations.recoveryFound(intentId, operation, requestHash, brokerOrderId, evidence, terminalOutcome),
+      RecoveryNotFound: ({ evidence }) =>
+        services.mutations.recoveryNotFound(intentId, operation, requestHash, evidence),
+      RecoveryUnknown: ({ evidence }) =>
+        (evidence === undefined ? currentInstant : Effect.succeed(evidence.observedAt)).pipe(
+          Effect.flatMap((occurredAt) =>
+            services.mutations.recoveryUnknown(intentId, operation, requestHash, occurredAt, evidence),
+          ),
+        ),
+    }),
+  )
+
+const recoverAtBroker = (
+  services: RecoveryServices,
+  stored: StoredIntent,
+  operation: MutationOperation,
+  interrupted: MutationEvent,
+) =>
+  services.broker.orderByClientId(stored.intent.clientOrderId).pipe(
+    Effect.matchEffect({
+      onFailure: (error) =>
+        persistRecoveryDecision(
+          services,
+          stored.intent.intentId,
+          operation,
+          interrupted.requestHash,
+          decideRecoveryFailure(error),
+        ),
+      onSuccess: (result) =>
+        persistRecoveryDecision(
+          services,
+          stored.intent.intentId,
+          operation,
+          interrupted.requestHash,
+          decideRecoverySuccess(stored.intent, operation, interrupted, result),
+        ),
+    }),
+  )
+
+const continueRecovery = (
+  services: RecoveryServices,
+  stored: StoredIntent,
+  operation: MutationOperation,
+  event: MutationEvent,
+) =>
+  (operation === MutationOperation.Submit
+    ? services.mutations.latest(stored.intent.intentId, MutationOperation.Cancel)
+    : Effect.succeed(undefined)
+  ).pipe(
+    Effect.flatMap((cancellation) => liftDecision(validateRecovery(stored.intent, event, cancellation))),
+    Effect.andThen(Clock.currentTimeMillis),
+    Effect.flatMap((currentMillis) =>
+      liftDecision(ensureRecoveryDelay(operation, event, currentMillis)).pipe(
+        Effect.flatMap((ready) =>
+          markInterruptedStart(services.mutations, ready, new Date(currentMillis).toISOString()),
+        ),
+      ),
+    ),
+    Effect.flatMap((interrupted) => recoverAtBroker(services, stored, operation, interrupted)),
+  )
+
+const runRecovery = (services: RecoveryServices, intentId: string, operation: MutationOperation) =>
+  readIntent(operation, intentId).pipe(
+    Effect.flatMap((stored) =>
+      services.mutations.latest(intentId, operation).pipe(
+        Effect.flatMap((latest) => liftDecision(selectRecovery(operation, stored.intent, latest))),
+        Effect.flatMap((selection) =>
+          Match.value(selection).pipe(
+            Match.tagsExhaustive({
+              RecoveryComplete: ({ event }) => Effect.succeed(event),
+              RecoveryRequired: ({ event }) => continueRecovery(services, stored, operation, event),
+            }),
+          ),
+        ),
+      ),
+    ),
+  )
 
 export const recover = (intentId: string, operation: MutationOperation) =>
-  Effect.gen(function* () {
-    const mutations = yield* MutationStore
-    const broker = yield* BrokerRead
-    const stored = yield* readIntent(operation, intentId)
-    const latest = yield* mutations.latest(intentId, operation)
-    if (latest === undefined) {
-      return yield* Effect.fail(
-        new ExecutionError({
-          operation,
-          failure: ExecutionFailure.InvalidState,
-          message: 'mutation does not exist',
-        }),
-      )
-    }
-    if (operation === MutationOperation.Submit && isSubmitResolved(stored.intent, latest)) return latest
-    if (
-      operation === MutationOperation.Cancel &&
-      stored.intent.state === IntentState.Terminal &&
-      latest.eventType === MutationEventType.RecoveryFound
-    ) {
-      return latest
-    }
-    if (
-      operation === MutationOperation.Submit &&
-      (yield* mutations.latest(intentId, MutationOperation.Cancel)) !== undefined
-    ) {
-      return yield* Effect.fail(
-        new ExecutionError({
-          operation,
-          failure: ExecutionFailure.InvalidState,
-          message: 'submit recovery requires the durable cancellation to recover first',
-        }),
-      )
-    }
-    yield* validateRecovery(stored.intent, latest)
-
-    const currentMillis = yield* Clock.currentTimeMillis
-    yield* ensureRecoveryDelay(operation, latest, currentMillis)
-    const interrupted = yield* markInterruptedStart(latest, new Date(currentMillis).toISOString())
-
-    return yield* broker.orderByClientId(stored.intent.clientOrderId).pipe(
-      Effect.matchEffect({
-        onFailure: (error) => {
-          const evidence = readErrorEvidence(error)
-          if (error.kind === BrokerReadErrorKind.NotFound && evidence !== undefined) {
-            return mutations.recoveryNotFound(intentId, operation, interrupted.requestHash, evidence)
-          }
-          return evidence === undefined
-            ? now.pipe(
-                Effect.flatMap((occurredAt) =>
-                  mutations.recoveryUnknown(intentId, operation, interrupted.requestHash, occurredAt),
-                ),
-              )
-            : mutations.recoveryUnknown(intentId, operation, interrupted.requestHash, evidence.observedAt, evidence)
-        },
-        onSuccess: (result) => {
-          const evidence = mutationEvidence(result.evidence)
-          const outcome = terminalOutcome(result.value.status)
-          const neutralizedMismatchedOrder =
-            operation === MutationOperation.Cancel &&
-            interrupted.brokerOrderId === result.value.brokerOrderId &&
-            result.value.filledQuantityMicros === '0' &&
-            outcome !== undefined &&
-            outcome !== TerminalOutcome.Filled
-          const exactBrokerOrderId =
-            interrupted.brokerOrderId === undefined || interrupted.brokerOrderId === result.value.brokerOrderId
-          if ((!exactBrokerOrderId || !exactOrder(stored.intent, result.value)) && !neutralizedMismatchedOrder) {
-            return mutations.recoveryUnknown(
-              intentId,
-              operation,
-              interrupted.requestHash,
-              evidence.observedAt,
-              evidence,
-            )
-          }
-          return mutations.recoveryFound(
-            intentId,
-            operation,
-            interrupted.requestHash,
-            result.value.brokerOrderId,
-            evidence,
-            outcome,
-          )
-        },
-      }),
-    )
-  })
+  Effect.all({
+    mutations: MutationStore,
+    broker: BrokerRead,
+  }).pipe(Effect.flatMap((services) => runRecovery(services, intentId, operation)))


### PR DESCRIPTION
## Summary

- Separate submit, cancel, and recovery logic into pure immutable `Result` decisions with explicit tagged failures and persistence actions.
- Replace generator-based coordinator control flow with small composable Effect pipelines that only interpret broker, store, writer-fence, and clock effects.
- Preserve request identity, risk-expiry, durable replay, cancellation ordering, broker evidence, and recovery-delay semantics; add direct pure decision coverage.

## Related Issues

None

## Testing

- bun test services/bayn/src/execution/coordinator-decisions.test.ts services/bayn/src/execution/coordinator.test.ts (27 passed)
- bun run --filter @proompteng/bayn test (617 passed, 116 PostgreSQL-gated skipped, 0 failed)
- bun run --filter @proompteng/bayn tsc
- bun run --filter @proompteng/bayn lint
- bun run --filter @proompteng/bayn lint:oxlint
- bun run --filter @proompteng/bayn lint:oxlint:type
- bun run --filter @proompteng/bayn build
- bunx oxfmt --check services/bayn/src/execution/coordinator.ts services/bayn/src/execution/coordinator-decisions.ts services/bayn/src/execution/coordinator-decisions.test.ts
- git diff --check

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] Documentation and release notes are not required because the runtime contract and public behavior are unchanged.