### PR TITLE
refactor(bayn): make cycle persistence functional

### DIFF
--- a/.github/workflows/bayn-ci.yml
+++ b/.github/workflows/bayn-ci.yml
@@ -67,4 +67,4 @@ jobs:
         run: |
           bun test services/bayn/src/db/evidence-store.integration.test.ts
           bun test services/bayn/src/db/paper-store.integration.test.ts
-          bun test services/bayn/src/db/cycle-store.integration.test.ts
+          bun test services/bayn/src/db/cycle-store/integration.test.ts

--- a/nix/images/bayn.nix
+++ b/nix/images/bayn.nix
@@ -20,8 +20,8 @@ import ./bun-workspace-service.nix {
   serviceName = "bayn";
   packageName = "@proompteng/bayn";
   depsHash = {
-    x86_64-linux = "sha256-9T3slexnTOAJNAfQtDCo786fTMlbo+bnOzxgQ3NVwrQ=";
-    aarch64-linux = "sha256-JsRAu1zGBRkVGhkoWmc9Po1SNJaAtWWWmn5LIY6etl4=";
+    x86_64-linux = "sha256-SEYHsmsuooEqOsFNS/lYTXCGRM3He9UvrGz7k6RHpnE=";
+    aarch64-linux = "sha256-hHXy0xti6FFixXlGDMM9wVoKMuNRbixhExyeo16hn2I=";
   };
   installFilters = [
     "@proompteng/bayn"

--- a/services/bayn/src/db/cycle-store/decisions.test.ts
+++ b/services/bayn/src/db/cycle-store/decisions.test.ts
@@ -1,0 +1,345 @@
+import { describe, expect, test } from 'bun:test'
+
+import { Result } from 'effect'
+
+import {
+  CycleState,
+  CycleTerminalReason,
+  makeCycleDraft,
+  makeCycleExecutionPolicy,
+  makeCycleIdentity,
+  makeCycleWindow,
+  makeExecutionCalendarObservation,
+  type AutonomousCycle,
+  type CycleDraft,
+} from '../../cycle'
+import { canonicalHashV1 } from '../../hash'
+import { makeObserveShadowDecisionDocument, type ObserveShadowDecisionDocument } from '../../shadow-decision-contract'
+import { TargetPlanReason, TargetPlanStatus, type BlockedTargetPlanReason } from '../../target-planner'
+import { DataFeed, DataSource, PriceAdjustment, PublicationSchema, type InputManifest } from '../../types'
+import {
+  decideAcquire,
+  decideActivation,
+  decideBlock,
+  decideCompletion,
+  decideDecisionBinding,
+  decideSnapshotBinding,
+  makeInitialCycle,
+  validateBlockedDecision,
+  validateCompletionDocument,
+  type CycleStoreDecisionFailure,
+} from './decisions'
+
+const hash = (character: string): string => character.repeat(64)
+const accountId = 'paper-account-1'
+const snapshotId = hash('3')
+
+const value = <A, E>(result: Result.Result<A, E>): A => {
+  expect(Result.isSuccess(result)).toBe(true)
+  if (Result.isFailure(result)) return expect.unreachable('expected a successful cycle-store decision')
+  return result.success
+}
+
+const failure = <A>(result: Result.Result<A, CycleStoreDecisionFailure>): CycleStoreDecisionFailure => {
+  expect(Result.isFailure(result)).toBe(true)
+  if (Result.isSuccess(result)) return expect.unreachable('expected a failed cycle-store decision')
+  return result.failure
+}
+
+const draft = (): CycleDraft => {
+  const calendar = value(
+    makeExecutionCalendarObservation({
+      schemaVersion: 'bayn.alpaca-market-calendar-observation.v1',
+      source: 'alpaca-v2-calendar',
+      date: '2026-02-02',
+      openAt: '2026-02-02T14:30:00.000Z',
+      closeAt: '2026-02-02T21:00:00.000Z',
+    }),
+  )
+  const policy = value(
+    makeCycleExecutionPolicy({
+      schemaVersion: 'bayn.autonomous-cycle-execution-policy.v1',
+      strategyExecutionModelHash: hash('4'),
+      submissionWindowMs: 30 * 60_000,
+      submissionCutoffBeforeOpenMs: 2 * 60_000,
+    }),
+  )
+  const identity = value(
+    makeCycleIdentity({
+      schemaVersion: 'bayn.autonomous-cycle-identity.v1',
+      strategyName: 'risk-balanced-trend',
+      qualificationRunId: hash('1'),
+      strategyProtocolHash: hash('2'),
+      accountId,
+      signalSessionDate: '2026-01-30',
+      signalCalendarVersion: 'XNYS-v1',
+      executionSessionDate: calendar.executionSessionDate,
+      executionCalendarSchemaVersion: calendar.executionCalendarSchemaVersion,
+      executionCalendarSource: calendar.executionCalendarSource,
+      executionCalendarHash: calendar.executionCalendarHash,
+      executionPolicy: policy,
+    }),
+  )
+  return value(
+    makeCycleDraft(
+      identity,
+      value(
+        makeCycleWindow(
+          {
+            calendar_version: 'XNYS-v1',
+            session_date: '2026-01-30',
+            close_time: '16:00',
+            timezone: 'America/New_York',
+          },
+          calendar,
+          policy,
+        ),
+      ),
+    ),
+  )
+}
+
+const pendingCycle = (): AutonomousCycle => ({
+  ...draft(),
+  state: CycleState.Pending,
+  bindings: {},
+  stateVersion: 1,
+  createdAt: '2026-01-30T21:15:00.000Z',
+  updatedAt: '2026-01-30T21:15:00.000Z',
+})
+
+const boundPendingCycle = (): AutonomousCycle => ({
+  ...pendingCycle(),
+  bindings: { snapshotId },
+  stateVersion: 2,
+  updatedAt: '2026-01-30T21:16:00.000Z',
+})
+
+const activeCycle = (): AutonomousCycle => ({
+  ...boundPendingCycle(),
+  state: CycleState.Active,
+  stateVersion: 3,
+  updatedAt: '2026-02-02T13:56:00.000Z',
+})
+
+const snapshot: InputManifest['finalizedSnapshot'] = {
+  schemaVersion: 'bayn.finalized-snapshot.v3',
+  snapshotId,
+  publicationId: hash('4'),
+  publicationSchemaVersion: PublicationSchema.AdjustedDailySnapshotV2,
+  universeId: 'cross-asset-taa-v1',
+  universeSymbolHash: hash('5'),
+  source: DataSource.Alpaca,
+  sourceFeed: DataFeed.Sip,
+  adjustment: PriceAdjustment.All,
+  calendarVersion: 'XNYS-v1',
+  publisherSourceRevision: 'a'.repeat(40),
+  publisherImage: {
+    repository: 'registry.ide-newton.ts.net/lab/signal-publisher',
+    digest: `sha256:${hash('6')}`,
+  },
+  finalizedAt: '2026-01-30T21:01:00.000Z',
+  requestedStart: '2016-01-04',
+  firstSession: '2016-01-04',
+  lastSession: '2026-01-30',
+  asOfSession: '2026-01-30',
+  symbols: ['AMD'],
+  rowCount: 1,
+  sessionCount: 1,
+  contentHash: hash('7'),
+  sessionsContentHash: hash('8'),
+}
+
+const targetPlan = (
+  status: TargetPlanStatus.NoTrade | TargetPlanStatus.Blocked,
+  reason: TargetPlanReason.TargetsSatisfied | BlockedTargetPlanReason,
+) => {
+  const material = {
+    schemaVersion: 'bayn.paper-reference-target-plan.v1' as const,
+    inputHash: hash('9'),
+    status,
+    reason,
+    targets:
+      status === TargetPlanStatus.NoTrade
+        ? [
+            {
+              symbol: 'AMD',
+              targetWeight: 0.5,
+              referencePriceMicros: '100000000',
+              currentQuantityMicros: '1000000',
+              targetQuantityMicros: '1000000',
+            },
+          ]
+        : [],
+    intentTargets: [],
+    requiredReferenceBuyNotionalMicros: '0',
+    availableBuyingPowerMicros: '0',
+    residualBuyingPowerMicros: '0',
+  }
+  return { ...material, outputHash: canonicalHashV1(material) }
+}
+
+const document = (
+  cycle: AutonomousCycle,
+  status: TargetPlanStatus.NoTrade | TargetPlanStatus.Blocked = TargetPlanStatus.NoTrade,
+  reason: TargetPlanReason.TargetsSatisfied | BlockedTargetPlanReason = TargetPlanReason.TargetsSatisfied,
+): ObserveShadowDecisionDocument =>
+  value(
+    makeObserveShadowDecisionDocument({
+      schemaVersion: 'bayn.observe-shadow-decision.v1',
+      mode: 'OBSERVE',
+      dispatchable: false,
+      bindings: {
+        strategyName: cycle.identity.strategyName,
+        cycleId: cycle.identity.cycleId,
+        strategyProtocolHash: cycle.identity.strategyProtocolHash,
+        snapshotId,
+        snapshotContentHash: hash('a'),
+        snapshotFinalizedAt: cycle.window.signalCloseAt,
+        strategyDecisionHash: hash('b'),
+        policyHash: hash('c'),
+        accountId,
+        planningBrokerStateHash: hash('d'),
+        reconciliationId: hash('e'),
+        reconciliationHash: hash('f'),
+      },
+      targetPlan: targetPlan(status, reason),
+      deltaRisk: [],
+      createdAt: '2026-02-02T13:57:00.000Z',
+      submissionCutoffAt: cycle.window.submissionCutoffAt,
+      expiresAt: cycle.window.submissionCutoffAt,
+    }),
+  )
+
+describe('cycle store decisions', () => {
+  test('constructs and acquires the deterministic cycle without mutable state', () => {
+    const input = draft()
+    const initial = makeInitialCycle(input, '2026-01-30T21:15:00.000Z')
+    expect(initial).toMatchObject({ state: CycleState.Pending, stateVersion: 1, bindings: {} })
+    expect(value(decideAcquire(initial, input, initial.updatedAt, true))).toEqual({
+      _tag: 'Return',
+      cycle: initial,
+      created: true,
+    })
+
+    const deadlineCycle = makeInitialCycle(input, input.window.publicationDeadlineAt)
+    expect(deadlineCycle).toMatchObject({
+      state: CycleState.Blocked,
+      terminalReason: CycleTerminalReason.MissedPublication,
+      terminalAt: input.window.publicationDeadlineAt,
+    })
+    expect(
+      failure(
+        decideAcquire(
+          initial,
+          { ...input, identity: { ...input.identity, strategyProtocolHash: hash('0') } },
+          initial.updatedAt,
+          false,
+        ),
+      ),
+    ).toMatchObject({ failure: 'conflict' })
+  })
+
+  test('selects snapshot replay, persistence, deadline blocking, and conflicts', () => {
+    const pending = pendingCycle()
+    expect(value(decideSnapshotBinding(pending, snapshot, '2026-01-30T21:16:00.000Z'))).toMatchObject({
+      _tag: 'Persist',
+      snapshotId,
+    })
+    expect(value(decideSnapshotBinding(boundPendingCycle(), snapshot, '2026-01-30T21:17:00.000Z'))).toMatchObject({
+      _tag: 'Replay',
+    })
+    expect(value(decideSnapshotBinding(pending, snapshot, pending.window.publicationDeadlineAt))).toMatchObject({
+      _tag: 'Block',
+      reason: CycleTerminalReason.MissedPublication,
+    })
+    expect(
+      failure(
+        decideSnapshotBinding(boundPendingCycle(), { ...snapshot, snapshotId: hash('0') }, '2026-01-30T21:17:00.000Z'),
+      ),
+    ).toMatchObject({ failure: 'conflict', message: 'cycle snapshot binding cannot be replaced' })
+  })
+
+  test('selects activation replay, persistence, deadline blocking, and invalid states', () => {
+    const bound = boundPendingCycle()
+    expect(value(decideActivation(bound, '2026-02-02T13:57:00.000Z'))).toMatchObject({ _tag: 'Persist' })
+    expect(value(decideActivation(activeCycle(), '2026-02-02T13:57:00.000Z'))).toMatchObject({
+      _tag: 'Replay',
+    })
+    expect(value(decideActivation(bound, bound.window.submissionCutoffAt))).toMatchObject({
+      _tag: 'Block',
+      reason: CycleTerminalReason.MissedSubmission,
+    })
+    expect(failure(decideActivation(pendingCycle(), '2026-02-02T13:57:00.000Z'))).toMatchObject({
+      failure: 'invariant',
+      message: 'cycle activation requires a bound snapshot',
+    })
+  })
+
+  test('validates decision binding before any durable evidence query or write', () => {
+    const active = activeCycle()
+    const input = document(active)
+    expect(value(decideDecisionBinding(active, input, '2026-02-02T13:58:00.000Z', []))).toMatchObject({
+      _tag: 'Persist',
+      document: input,
+    })
+
+    const bound: AutonomousCycle = {
+      ...active,
+      bindings: { snapshotId, decisionHash: input.contentHash },
+      stateVersion: 4,
+      updatedAt: '2026-02-02T13:58:00.000Z',
+    }
+    expect(value(decideDecisionBinding(bound, input, bound.updatedAt, [input]))).toMatchObject({
+      _tag: 'Replay',
+    })
+    expect(failure(decideDecisionBinding(bound, input, bound.updatedAt, []))).toMatchObject({
+      failure: 'conflict',
+      message: 'cycle decision binding cannot be replaced',
+    })
+    expect(value(decideDecisionBinding(active, input, active.window.submissionCutoffAt, []))).toMatchObject({
+      _tag: 'Block',
+      reason: CycleTerminalReason.MissedSubmission,
+    })
+  })
+
+  test('requires completion to match the exact bound durable decision', () => {
+    const active = activeCycle()
+    const noTrade = document(active)
+    const bound: AutonomousCycle = {
+      ...active,
+      bindings: { snapshotId, decisionHash: noTrade.contentHash },
+      stateVersion: 4,
+      updatedAt: '2026-02-02T13:58:00.000Z',
+    }
+    const selected = value(decideCompletion(bound, CycleState.NoTrade, '2026-02-02T13:59:00.000Z'))
+    expect(selected).toMatchObject({ _tag: 'VerifyDecision', decisionHash: noTrade.contentHash })
+    if (selected._tag !== 'VerifyDecision') return expect.unreachable('expected decision verification')
+    expect(value(validateCompletionDocument(selected, [noTrade]))).toBeUndefined()
+    expect(failure(validateCompletionDocument(selected, []))).toMatchObject({
+      failure: 'invariant',
+      message: 'cycle terminal state must match its exact durable shadow decision',
+    })
+  })
+
+  test('requires a decision-bound block to match the exact target-plan reason', () => {
+    const active = activeCycle()
+    const blocked = document(active, TargetPlanStatus.Blocked, TargetPlanReason.InputStale)
+    const bound: AutonomousCycle = {
+      ...active,
+      bindings: { snapshotId, decisionHash: blocked.contentHash },
+      stateVersion: 4,
+      updatedAt: '2026-02-02T13:58:00.000Z',
+    }
+    const selected = value(decideBlock(bound, CycleTerminalReason.DataStale, '2026-02-02T13:59:00.000Z'))
+    expect(selected).toMatchObject({ _tag: 'VerifyDecision', reason: CycleTerminalReason.DataStale })
+    if (selected._tag !== 'VerifyDecision') return expect.unreachable('expected decision verification')
+    expect(value(validateBlockedDecision(selected, [blocked]))).toBeUndefined()
+    expect(
+      failure(validateBlockedDecision({ ...selected, reason: CycleTerminalReason.DataInvalid }, [blocked])),
+    ).toMatchObject({
+      failure: 'invariant',
+      message: 'cycle blocked reason must match its exact durable shadow decision',
+    })
+  })
+})

--- a/services/bayn/src/db/cycle-store/decisions.ts
+++ b/services/bayn/src/db/cycle-store/decisions.ts
@@ -1,0 +1,336 @@
+import { Result, Schema } from 'effect'
+
+import {
+  CycleState,
+  CycleTerminalReason,
+  cycleDraftMatches,
+  cycleDraftOf,
+  isCycleStateTransitionAllowed,
+  type AutonomousCycle,
+  type CycleCompletionState,
+  type CycleDraft,
+} from '../../cycle'
+import { cycleTerminalReasonForBlockedTargetPlan } from '../../cycle-recovery'
+import { ObserveShadowDecisionDocumentSchema, type ObserveShadowDecisionDocument } from '../../shadow-decision-contract'
+import { TargetPlanStatus } from '../../target-planner'
+import type { InputManifest } from '../../types'
+
+export interface CycleStoreDecisionFailure {
+  readonly failure: 'conflict' | 'invariant' | 'not-found'
+  readonly message: string
+}
+
+export type AcquireDecision =
+  | {
+      readonly _tag: 'Return'
+      readonly cycle: AutonomousCycle
+      readonly created: boolean
+    }
+  | {
+      readonly _tag: 'Block'
+      readonly cycle: AutonomousCycle
+      readonly created: boolean
+      readonly reason: CycleTerminalReason.MissedPublication
+    }
+
+export type SnapshotDecision =
+  | {
+      readonly _tag: 'Replay'
+      readonly cycle: AutonomousCycle
+    }
+  | {
+      readonly _tag: 'Persist'
+      readonly cycle: AutonomousCycle
+      readonly snapshotId: string
+    }
+  | {
+      readonly _tag: 'Block'
+      readonly cycle: AutonomousCycle
+      readonly reason: CycleTerminalReason.MissedPublication
+    }
+
+export type ActivationDecision =
+  | {
+      readonly _tag: 'Replay'
+      readonly cycle: AutonomousCycle
+    }
+  | {
+      readonly _tag: 'Persist'
+      readonly cycle: AutonomousCycle
+    }
+  | {
+      readonly _tag: 'Block'
+      readonly cycle: AutonomousCycle
+      readonly reason: CycleTerminalReason.MissedSubmission
+    }
+
+export type DecisionBindingDecision =
+  | {
+      readonly _tag: 'Replay'
+      readonly cycle: AutonomousCycle
+    }
+  | {
+      readonly _tag: 'Persist'
+      readonly cycle: AutonomousCycle
+      readonly document: ObserveShadowDecisionDocument
+    }
+  | {
+      readonly _tag: 'Block'
+      readonly cycle: AutonomousCycle
+      readonly reason: CycleTerminalReason.MissedSubmission
+    }
+
+export type CompletionDecision =
+  | {
+      readonly _tag: 'Replay'
+      readonly cycle: AutonomousCycle
+    }
+  | {
+      readonly _tag: 'VerifyDecision'
+      readonly cycle: AutonomousCycle
+      readonly decisionHash: string
+      readonly state: CycleCompletionState
+    }
+
+export type BlockDecision =
+  | {
+      readonly _tag: 'Replay'
+      readonly cycle: AutonomousCycle
+    }
+  | {
+      readonly _tag: 'Persist'
+      readonly cycle: AutonomousCycle
+      readonly reason: CycleTerminalReason
+    }
+  | {
+      readonly _tag: 'VerifyDecision'
+      readonly cycle: AutonomousCycle
+      readonly reason: CycleTerminalReason
+      readonly decisionHash: string
+    }
+
+const fail = (
+  failure: CycleStoreDecisionFailure['failure'],
+  message: string,
+): Result.Result<never, CycleStoreDecisionFailure> => Result.fail({ failure, message })
+
+const shadowDecisionEquivalent = Schema.toEquivalence(ObserveShadowDecisionDocumentSchema)
+
+export const makeInitialCycle = (draft: CycleDraft, observedAt: string): AutonomousCycle => {
+  const missedPublication = observedAt >= draft.window.publicationDeadlineAt
+  return {
+    ...draft,
+    state: missedPublication ? CycleState.Blocked : CycleState.Pending,
+    bindings: {},
+    ...(missedPublication
+      ? {
+          terminalReason: CycleTerminalReason.MissedPublication,
+          terminalAt: observedAt,
+        }
+      : {}),
+    stateVersion: 1,
+    createdAt: observedAt,
+    updatedAt: observedAt,
+  }
+}
+
+export const decideAcquire = (
+  stored: AutonomousCycle,
+  draft: CycleDraft,
+  observedAt: string,
+  created: boolean,
+): Result.Result<AcquireDecision, CycleStoreDecisionFailure> => {
+  if (!cycleDraftMatches(cycleDraftOf(stored), draft)) {
+    return fail('conflict', 'stored cycle differs from deterministic acquisition input')
+  }
+  return Result.succeed(
+    stored.state === CycleState.Pending && observedAt >= stored.window.publicationDeadlineAt
+      ? {
+          _tag: 'Block',
+          cycle: stored,
+          created,
+          reason: CycleTerminalReason.MissedPublication,
+        }
+      : { _tag: 'Return', cycle: stored, created },
+  )
+}
+
+export const decideSnapshotBinding = (
+  cycle: AutonomousCycle,
+  snapshot: InputManifest['finalizedSnapshot'],
+  observedAt: string,
+): Result.Result<SnapshotDecision, CycleStoreDecisionFailure> => {
+  if (observedAt < cycle.window.signalCloseAt) {
+    return fail('invariant', 'snapshot binding cannot precede the Signal session close')
+  }
+  if (
+    snapshot.asOfSession !== cycle.identity.signalSessionDate ||
+    snapshot.lastSession !== cycle.identity.signalSessionDate ||
+    snapshot.calendarVersion !== cycle.identity.signalCalendarVersion
+  ) {
+    return fail('invariant', 'finalized Signal publication does not match the cycle signal session and calendar')
+  }
+  if (cycle.bindings.snapshotId !== undefined) {
+    return cycle.bindings.snapshotId === snapshot.snapshotId
+      ? Result.succeed({ _tag: 'Replay', cycle })
+      : fail('conflict', 'cycle snapshot binding cannot be replaced')
+  }
+  if (cycle.state !== CycleState.Pending) {
+    return fail('conflict', 'snapshot may bind only while a cycle is pending')
+  }
+  if (observedAt >= cycle.window.publicationDeadlineAt) {
+    return Result.succeed({
+      _tag: 'Block',
+      cycle,
+      reason: CycleTerminalReason.MissedPublication,
+    })
+  }
+  return observedAt < cycle.updatedAt
+    ? fail('conflict', 'cycle update time cannot move backward')
+    : Result.succeed({ _tag: 'Persist', cycle, snapshotId: snapshot.snapshotId })
+}
+
+export const decideActivation = (
+  cycle: AutonomousCycle,
+  observedAt: string,
+): Result.Result<ActivationDecision, CycleStoreDecisionFailure> => {
+  if (cycle.state === CycleState.Active) return Result.succeed({ _tag: 'Replay', cycle })
+  if (!isCycleStateTransitionAllowed(cycle.state, CycleState.Active)) {
+    return fail('conflict', 'only a pending cycle may become active')
+  }
+  if (cycle.bindings.snapshotId === undefined) {
+    return fail('invariant', 'cycle activation requires a bound snapshot')
+  }
+  if (observedAt >= cycle.window.submissionCutoffAt) {
+    return Result.succeed({
+      _tag: 'Block',
+      cycle,
+      reason: CycleTerminalReason.MissedSubmission,
+    })
+  }
+  return observedAt < cycle.updatedAt
+    ? fail('conflict', 'cycle update time cannot move backward')
+    : Result.succeed({ _tag: 'Persist', cycle })
+}
+
+export const decideDecisionBinding = (
+  cycle: AutonomousCycle,
+  document: ObserveShadowDecisionDocument,
+  observedAt: string,
+  storedDocuments: readonly ObserveShadowDecisionDocument[],
+): Result.Result<DecisionBindingDecision, CycleStoreDecisionFailure> => {
+  if (cycle.bindings.decisionHash !== undefined) {
+    const storedDocument = storedDocuments[0]
+    return cycle.bindings.decisionHash === document.contentHash &&
+      storedDocuments.length === 1 &&
+      storedDocument !== undefined &&
+      shadowDecisionEquivalent(storedDocument, document)
+      ? Result.succeed({ _tag: 'Replay', cycle })
+      : fail('conflict', 'cycle decision binding cannot be replaced')
+  }
+  if (cycle.state !== CycleState.Active) {
+    return fail('conflict', 'decision may bind only while a cycle is active')
+  }
+  if (observedAt >= cycle.window.submissionCutoffAt) {
+    return Result.succeed({
+      _tag: 'Block',
+      cycle,
+      reason: CycleTerminalReason.MissedSubmission,
+    })
+  }
+  if (
+    document.bindings.cycleId !== cycle.identity.cycleId ||
+    document.bindings.strategyName !== cycle.identity.strategyName ||
+    document.bindings.strategyProtocolHash !== cycle.identity.strategyProtocolHash ||
+    document.bindings.snapshotId !== cycle.bindings.snapshotId ||
+    document.bindings.accountId !== cycle.identity.accountId ||
+    document.submissionCutoffAt !== cycle.window.submissionCutoffAt ||
+    document.createdAt > observedAt ||
+    document.createdAt < cycle.updatedAt
+  ) {
+    return fail('invariant', 'shadow decision does not match the active autonomous cycle')
+  }
+  return observedAt < cycle.updatedAt
+    ? fail('conflict', 'cycle update time cannot move backward')
+    : Result.succeed({ _tag: 'Persist', cycle, document })
+}
+
+export const decideCompletion = (
+  cycle: AutonomousCycle,
+  state: CycleCompletionState,
+  observedAt: string,
+): Result.Result<CompletionDecision, CycleStoreDecisionFailure> => {
+  if (cycle.state === state) return Result.succeed({ _tag: 'Replay', cycle })
+  if (!isCycleStateTransitionAllowed(cycle.state, state)) {
+    return fail('conflict', 'only an active cycle may finish from its bound decision')
+  }
+  if (observedAt < cycle.updatedAt) return fail('conflict', 'cycle update time cannot move backward')
+  const decisionHash = cycle.bindings.decisionHash
+  return decisionHash === undefined
+    ? fail('invariant', 'cycle completion requires a bound shadow decision')
+    : Result.succeed({ _tag: 'VerifyDecision', cycle, decisionHash, state })
+}
+
+export const validateCompletionDocument = (
+  decision: Extract<CompletionDecision, { readonly _tag: 'VerifyDecision' }>,
+  storedDocuments: readonly ObserveShadowDecisionDocument[],
+): Result.Result<void, CycleStoreDecisionFailure> => {
+  const storedDocument = storedDocuments[0]
+  const expectedStatus = decision.state === CycleState.Completed ? TargetPlanStatus.Planned : TargetPlanStatus.NoTrade
+  return storedDocuments.length === 1 &&
+    storedDocument !== undefined &&
+    storedDocument.contentHash === decision.decisionHash &&
+    storedDocument.targetPlan.status === expectedStatus
+    ? Result.succeed(undefined)
+    : fail('invariant', 'cycle terminal state must match its exact durable shadow decision')
+}
+
+export const decideBlock = (
+  cycle: AutonomousCycle,
+  reason: CycleTerminalReason,
+  observedAt: string,
+): Result.Result<BlockDecision, CycleStoreDecisionFailure> => {
+  if (cycle.state === CycleState.Blocked && cycle.terminalReason === reason) {
+    return Result.succeed({ _tag: 'Replay', cycle })
+  }
+  if (!isCycleStateTransitionAllowed(cycle.state, CycleState.Blocked)) {
+    return fail('conflict', `terminal cycle ${cycle.identity.cycleId} cannot be blocked again`)
+  }
+  if (
+    reason === CycleTerminalReason.MissedPublication &&
+    (cycle.state !== CycleState.Pending ||
+      cycle.bindings.snapshotId !== undefined ||
+      observedAt < cycle.window.publicationDeadlineAt)
+  ) {
+    return fail(
+      'invariant',
+      'missed-publication transition requires an unbound pending cycle at or after its publication deadline',
+    )
+  }
+  if (reason === CycleTerminalReason.MissedSubmission && observedAt < cycle.window.submissionCutoffAt) {
+    return fail('invariant', 'missed-submission transition cannot precede the broker submission cutoff')
+  }
+  if (observedAt < cycle.updatedAt) return fail('conflict', 'cycle update time cannot move backward')
+  const decisionHash = cycle.bindings.decisionHash
+  return cycle.state === CycleState.Active && decisionHash !== undefined
+    ? Result.succeed({ _tag: 'VerifyDecision', cycle, reason, decisionHash })
+    : Result.succeed({ _tag: 'Persist', cycle, reason })
+}
+
+export const validateBlockedDecision = (
+  decision: Extract<BlockDecision, { readonly _tag: 'VerifyDecision' }>,
+  storedDocuments: readonly ObserveShadowDecisionDocument[],
+): Result.Result<void, CycleStoreDecisionFailure> => {
+  const storedDocument = storedDocuments[0]
+  if (
+    storedDocuments.length !== 1 ||
+    storedDocument === undefined ||
+    storedDocument.contentHash !== decision.decisionHash ||
+    storedDocument.targetPlan.status !== TargetPlanStatus.Blocked
+  ) {
+    return fail('invariant', 'decision-bound cycle may block only from its exact blocked shadow decision')
+  }
+  return decision.reason === cycleTerminalReasonForBlockedTargetPlan(storedDocument.targetPlan.reason)
+    ? Result.succeed(undefined)
+    : fail('invariant', 'cycle blocked reason must match its exact durable shadow decision')
+}

--- a/services/bayn/src/db/cycle-store/index.ts
+++ b/services/bayn/src/db/cycle-store/index.ts
@@ -1,0 +1,10 @@
+export {
+  CycleStore,
+  CycleStoreError,
+  CycleStoreLive,
+  type CycleAcquireReceipt,
+  type CycleAuthoritySlot,
+  type CycleMutationReceipt,
+  type CycleRecoveryScope,
+  type CycleStoreShape,
+} from './postgres'

--- a/services/bayn/src/db/cycle-store/integration.test.ts
+++ b/services/bayn/src/db/cycle-store/integration.test.ts
@@ -5,8 +5,8 @@ import { PgClient, PgMigrator } from '@effect/sql-pg'
 import { Cause, Effect, Exit, Layer, ManagedRuntime, Option, Redacted, Result } from 'effect'
 import { TestClock } from 'effect/testing'
 
-import { BrokerRead, type BrokerReadShape, type MarketCalendarObservation } from '../broker/alpaca'
-import { unusedAssetBySymbol } from '../broker/alpaca-test-support'
+import { BrokerRead, type BrokerReadShape, type MarketCalendarObservation } from '../../broker/alpaca'
+import { unusedAssetBySymbol } from '../../broker/alpaca-test-support'
 import {
   CycleState,
   CycleTerminalReason,
@@ -16,28 +16,28 @@ import {
   makeCycleWindow,
   makeExecutionCalendarObservation,
   type CycleDraft,
-} from '../cycle'
+} from '../../cycle'
 import {
   makeDueCycleDraft,
   runAutonomousCyclePass,
   selectNextExecutionSession,
   type CycleRunContext,
   type CycleRunResult,
-} from '../cycle-runner'
-import { canonicalHashV1, sha256 } from '../hash'
+} from '../../cycle-runner'
+import { canonicalHashV1, sha256 } from '../../hash'
 import {
   MarketData,
   type FinalizedPublicationInspection,
   type MarketDataService,
   type SignalSessionRow,
-} from '../market-data'
-import { ReconciliationStatus } from '../paper'
-import { makeObserveShadowDecisionDocument } from '../shadow-decision-contract'
-import { TargetPlanReason, TargetPlanStatus } from '../target-planner'
-import { DataFeed, DataSource, PriceAdjustment, PublicationSchema, type InputManifest, type IsoDate } from '../types'
-import { CycleStore, CycleStoreLive, type CycleStoreShape } from './cycle-store'
-import { PostgresClientLive } from './evidence-store'
-import { migrationLoader } from './migrations'
+} from '../../market-data'
+import { ReconciliationStatus } from '../../paper'
+import { makeObserveShadowDecisionDocument } from '../../shadow-decision-contract'
+import { TargetPlanReason, TargetPlanStatus } from '../../target-planner'
+import { DataFeed, DataSource, PriceAdjustment, PublicationSchema, type InputManifest, type IsoDate } from '../../types'
+import { PostgresClientLive } from '../evidence-store'
+import { migrationLoader } from '../migrations'
+import { CycleStore, CycleStoreLive, type CycleStoreShape } from '.'
 
 const postgresUrl = process.env.BAYN_TEST_POSTGRES_URL
 const testUrl = postgresUrl ?? 'postgresql://bayn:bayn@127.0.0.1:5432/bayn_test'

--- a/services/bayn/src/db/cycle-store/postgres.ts
+++ b/services/bayn/src/db/cycle-store/postgres.ts
@@ -1,21 +1,17 @@
 import { PgClient } from '@effect/sql-pg'
-import { Context, Data, Effect, Layer, Option, Schema } from 'effect'
+import { Context, Data, Effect, Layer, Match, Option, Result, Schema } from 'effect'
 import { isSqlError, type SqlError } from 'effect/unstable/sql/SqlError'
 
 import {
   CycleDraftSchema,
   CycleState,
   CycleTerminalReason,
-  cycleDraftMatches,
-  cycleDraftOf,
   decodeAutonomousCycle,
-  isCycleStateTransitionAllowed,
   type AutonomousCycle,
   type CycleCompletionState,
   type CycleDraft,
-} from '../cycle'
-import { cycleTerminalReasonForBlockedTargetPlan } from '../cycle-recovery'
-import { decodeInputManifestArtifact } from '../evidence-contracts'
+} from '../../cycle'
+import { decodeInputManifestArtifact } from '../../evidence-contracts'
 import {
   IsoDateSchema,
   PositiveIntegerSchema,
@@ -23,11 +19,28 @@ import {
   StrictNonEmptyStringSchema,
   UtcInstantSchema,
   strictParseOptions,
-} from '../schemas'
-import { ObserveShadowDecisionDocumentSchema, type ObserveShadowDecisionDocument } from '../shadow-decision-contract'
-import { TargetPlanStatus } from '../target-planner'
-import type { InputManifest, IsoDate } from '../types'
-import { ensureSnapshotReference } from './snapshot-reference'
+} from '../../schemas'
+import { ObserveShadowDecisionDocumentSchema, type ObserveShadowDecisionDocument } from '../../shadow-decision-contract'
+import type { InputManifest, IsoDate } from '../../types'
+import { ensureSnapshotReference } from '../snapshot-reference'
+import {
+  decideAcquire,
+  decideActivation,
+  decideBlock,
+  decideCompletion,
+  decideDecisionBinding,
+  decideSnapshotBinding,
+  makeInitialCycle,
+  validateBlockedDecision,
+  validateCompletionDocument,
+  type AcquireDecision,
+  type ActivationDecision,
+  type BlockDecision,
+  type CompletionDecision,
+  type CycleStoreDecisionFailure,
+  type DecisionBindingDecision,
+  type SnapshotDecision,
+} from './decisions'
 
 type CycleStoreInternalError = CycleStoreError | Schema.SchemaError | SqlError
 
@@ -191,8 +204,6 @@ const decodeStoredDecisionDocumentRows = Schema.decodeUnknownEffect(
   StoredDecisionDocumentRowsSchema,
   strictParseOptions,
 )
-const shadowDecisionEquivalent = Schema.toEquivalence(ObserveShadowDecisionDocumentSchema)
-
 const messageOf = (cause: unknown): string => (cause instanceof Error ? cause.message : String(cause))
 
 const storeError = (
@@ -232,6 +243,12 @@ const fail = (
   failure: CycleStoreError['failure'],
   message: string,
 ): Effect.Effect<never, CycleStoreError> => Effect.fail(storeError(operation, failure, message))
+
+const liftDecision = <A>(
+  operation: CycleStoreError['operation'],
+  decision: Result.Result<A, CycleStoreDecisionFailure>,
+): Effect.Effect<A, CycleStoreError> =>
+  Effect.fromResult(decision).pipe(Effect.mapError(({ failure, message }) => storeError(operation, failure, message)))
 
 const rowToCycle = (row: StoredCycleRow): Effect.Effect<AutonomousCycle, Schema.SchemaError> =>
   decodeAutonomousCycle({
@@ -398,24 +415,12 @@ const exactlyOne = (
   return Effect.succeed(cycle)
 }
 
-const initialCycle = (draft: CycleDraft, observedAt: string): Effect.Effect<AutonomousCycle, Schema.SchemaError> => {
-  const missed = observedAt >= draft.window.publicationDeadlineAt
-  return decodeAutonomousCycle({
-    ...draft,
-    state: missed ? CycleState.Blocked : CycleState.Pending,
-    bindings: {},
-    ...(missed ? { terminalReason: CycleTerminalReason.MissedPublication, terminalAt: observedAt } : {}),
-    stateVersion: 1,
-    createdAt: observedAt,
-    updatedAt: observedAt,
-  })
-}
-
-const makeCycleStore = Effect.gen(function* () {
-  const sql = yield* PgClient.PgClient
-
+const makeCycleStore = Effect.map(PgClient.PgClient, (sql) => {
   const readLocked = (operation: CycleStoreError['operation'], cycleId: string) =>
     selectCycle(sql, cycleId, true).pipe(Effect.flatMap((rows) => exactlyOne(operation, rows)))
+
+  const readDocuments = (cycleId: string) =>
+    selectDecisionDocument(sql, cycleId).pipe(Effect.map((rows) => rows.map(({ document }) => document)))
 
   const requireApplied = (
     operation: CycleStoreError['operation'],
@@ -453,154 +458,166 @@ const makeCycleStore = Effect.gen(function* () {
       Effect.map(([match]) => match.matches),
     )
 
-  const verifyDecisionBoundBlock = (
+  const persistSnapshotReference = (inputManifest: InputManifest): Effect.Effect<void, CycleStoreInternalError> =>
+    ensureSnapshotReference(sql, inputManifest).pipe(
+      Effect.flatMap((matches) =>
+        matches
+          ? Effect.void
+          : fail(
+              'bind-snapshot',
+              'conflict',
+              'stored snapshot reference diverged from the finalized Signal publication',
+            ),
+      ),
+    )
+
+  const persistBlockedCycle = (
+    operation: CycleStoreError['operation'],
     cycle: AutonomousCycle,
     reason: CycleTerminalReason,
-  ): Effect.Effect<void, CycleStoreInternalError> =>
-    Effect.gen(function* () {
-      const storedRows = yield* selectDecisionDocument(sql, cycle.identity.cycleId)
-      const storedDocument = storedRows[0]?.document
-      if (
-        storedRows.length !== 1 ||
-        storedDocument === undefined ||
-        storedDocument.contentHash !== cycle.bindings.decisionHash ||
-        storedDocument.targetPlan.status !== TargetPlanStatus.Blocked
-      ) {
-        return yield* fail(
-          'block',
-          'invariant',
-          'decision-bound cycle may block only from its exact blocked shadow decision',
-        )
-      }
-      const expectedReason = cycleTerminalReasonForBlockedTargetPlan(storedDocument.targetPlan.reason)
-      if (reason !== expectedReason) {
-        return yield* fail('block', 'invariant', 'cycle blocked reason must match its exact durable shadow decision')
-      }
-    })
+    observedAt: string,
+  ): Effect.Effect<CycleMutationReceipt, CycleStoreInternalError> =>
+    sql<Record<string, unknown>>`
+      UPDATE autonomous_cycles
+      SET
+        state = ${CycleState.Blocked},
+        terminal_reason = ${reason},
+        state_version = ${cycle.stateVersion + 1},
+        updated_at = ${observedAt},
+        terminal_at = ${observedAt}
+      WHERE cycle_id = ${cycle.identity.cycleId}
+        AND state = ${cycle.state}
+        AND state_version = ${cycle.stateVersion}
+      RETURNING cycle_id
+    `.pipe(
+      Effect.flatMap((rows) => requireApplied(operation, rows)),
+      Effect.flatMap(() => readLocked(operation, cycle.identity.cycleId)),
+      Effect.map((updated) => ({ cycle: updated, changed: true })),
+    )
+
+  const interpretBlockDecision = (
+    operation: CycleStoreError['operation'],
+    observedAt: string,
+    decision: BlockDecision,
+  ): Effect.Effect<CycleMutationReceipt, CycleStoreInternalError> =>
+    Match.value(decision).pipe(
+      Match.tagsExhaustive({
+        Replay: ({ cycle }) => Effect.succeed({ cycle, changed: false }),
+        Persist: ({ cycle, reason }) => persistBlockedCycle(operation, cycle, reason, observedAt),
+        VerifyDecision: (verification) =>
+          readDocuments(verification.cycle.identity.cycleId).pipe(
+            Effect.flatMap((documents) => liftDecision(operation, validateBlockedDecision(verification, documents))),
+            Effect.andThen(persistBlockedCycle(operation, verification.cycle, verification.reason, observedAt)),
+          ),
+      }),
+    )
 
   const blockCycle = (
     operation: CycleStoreError['operation'],
     cycle: AutonomousCycle,
     reason: CycleTerminalReason,
     observedAt: string,
-  ): Effect.Effect<CycleMutationReceipt, CycleStoreInternalError> => {
-    if (cycle.state === CycleState.Blocked && cycle.terminalReason === reason) {
-      return Effect.succeed({ cycle, changed: false })
-    }
-    if (!isCycleStateTransitionAllowed(cycle.state, CycleState.Blocked)) {
-      return fail(operation, 'conflict', `terminal cycle ${cycle.identity.cycleId} cannot be blocked again`)
-    }
-    if (
-      reason === CycleTerminalReason.MissedPublication &&
-      (cycle.state !== CycleState.Pending ||
-        cycle.bindings.snapshotId !== undefined ||
-        observedAt < cycle.window.publicationDeadlineAt)
-    ) {
-      return fail(
-        operation,
-        'invariant',
-        'missed-publication transition requires an unbound pending cycle at or after its publication deadline',
-      )
-    }
-    if (reason === CycleTerminalReason.MissedSubmission && observedAt < cycle.window.submissionCutoffAt) {
-      return fail(operation, 'invariant', 'missed-submission transition cannot precede the broker submission cutoff')
-    }
-    if (observedAt < cycle.updatedAt) {
-      return fail(operation, 'conflict', 'cycle update time cannot move backward')
-    }
-    const verifyDecision =
-      cycle.state === CycleState.Active && cycle.bindings.decisionHash !== undefined
-        ? verifyDecisionBoundBlock(cycle, reason)
-        : Effect.void
-    return verifyDecision.pipe(
-      Effect.andThen(sql<Record<string, unknown>>`
-        UPDATE autonomous_cycles
-        SET
-          state = ${CycleState.Blocked},
-          terminal_reason = ${reason},
-          state_version = ${cycle.stateVersion + 1},
-          updated_at = ${observedAt},
-          terminal_at = ${observedAt}
-        WHERE cycle_id = ${cycle.identity.cycleId}
-          AND state = ${cycle.state}
-          AND state_version = ${cycle.stateVersion}
-        RETURNING cycle_id
-      `),
-      Effect.flatMap((rows) => requireApplied(operation, rows)),
-      Effect.flatMap(() => readLocked(operation, cycle.identity.cycleId)),
-      Effect.map((updated) => ({ cycle: updated, changed: true })),
+  ): Effect.Effect<CycleMutationReceipt, CycleStoreInternalError> =>
+    liftDecision(operation, decideBlock(cycle, reason, observedAt)).pipe(
+      Effect.flatMap((decision) => interpretBlockDecision(operation, observedAt, decision)),
     )
-  }
+
+  const insertCycle = (candidate: AutonomousCycle) =>
+    sql<Record<string, unknown>>`
+      INSERT INTO autonomous_cycles (
+        cycle_id, schema_version, identity_schema_version, strategy_name,
+        qualification_run_id, strategy_protocol_hash, account_id,
+        signal_session_date, signal_calendar_version,
+        execution_policy_schema_version, execution_policy_hash,
+        strategy_execution_model_hash, submission_window_ms, submission_cutoff_before_open_ms,
+        window_schema_version, execution_calendar_schema_version,
+        execution_calendar_source, execution_calendar_hash, execution_session_date,
+        signal_close_at, publication_deadline_at, submission_open_at,
+        execution_open_at, execution_close_at, submission_cutoff_at, state, snapshot_id,
+        decision_hash, terminal_reason, state_version,
+        created_at, updated_at, terminal_at
+      ) VALUES (
+        ${candidate.identity.cycleId}, ${candidate.schemaVersion},
+        ${candidate.identity.schemaVersion}, ${candidate.identity.strategyName},
+        ${candidate.identity.qualificationRunId}, ${candidate.identity.strategyProtocolHash},
+        ${candidate.identity.accountId}, ${candidate.identity.signalSessionDate},
+        ${candidate.identity.signalCalendarVersion},
+        ${candidate.identity.executionPolicy.schemaVersion},
+        ${candidate.identity.executionPolicy.executionPolicyHash},
+        ${candidate.identity.executionPolicy.strategyExecutionModelHash},
+        ${candidate.identity.executionPolicy.submissionWindowMs},
+        ${candidate.identity.executionPolicy.submissionCutoffBeforeOpenMs},
+        ${candidate.window.schemaVersion}, ${candidate.window.executionCalendarSchemaVersion},
+        ${candidate.window.executionCalendarSource}, ${candidate.window.executionCalendarHash},
+        ${candidate.window.executionSessionDate},
+        ${candidate.window.signalCloseAt}, ${candidate.window.publicationDeadlineAt},
+        ${candidate.window.submissionOpenAt}, ${candidate.window.executionOpenAt},
+        ${candidate.window.executionCloseAt},
+        ${candidate.window.submissionCutoffAt}, ${candidate.state}, NULL, NULL,
+        ${candidate.terminalReason ?? null}, ${candidate.stateVersion},
+        ${candidate.createdAt}, ${candidate.updatedAt}, ${candidate.terminalAt ?? null}
+      )
+      ON CONFLICT DO NOTHING
+      RETURNING cycle_id
+    `.pipe(Effect.flatMap(decodeMutationRows))
+
+  const lockAuthoritySlot = (candidate: AutonomousCycle): Effect.Effect<string, CycleStoreInternalError> =>
+    sql<Record<string, unknown>>`
+      SELECT cycle_id
+      FROM autonomous_cycles
+      WHERE qualification_run_id = ${candidate.identity.qualificationRunId}
+        AND account_id = ${candidate.identity.accountId}
+        AND signal_session_date = ${candidate.identity.signalSessionDate}
+      FOR UPDATE
+    `.pipe(
+      Effect.flatMap(decodeMutationRows),
+      Effect.flatMap((rows) => {
+        const cycleId = rows[0]?.cycle_id
+        return rows.length === 1 && cycleId !== undefined
+          ? Effect.succeed(cycleId)
+          : fail('acquire', 'invariant', 'autonomous cycle authority slot was not found exactly once')
+      }),
+    )
+
+  const interpretAcquireDecision = (
+    observedAt: string,
+    decision: AcquireDecision,
+  ): Effect.Effect<CycleAcquireReceipt, CycleStoreInternalError> =>
+    Match.value(decision).pipe(
+      Match.tagsExhaustive({
+        Return: ({ cycle, created }) => Effect.succeed({ cycle, created }),
+        Block: ({ cycle, created, reason }) =>
+          blockCycle('acquire', cycle, reason, observedAt).pipe(
+            Effect.map((receipt) => ({ cycle: receipt.cycle, created })),
+          ),
+      }),
+    )
 
   const acquire = (draft: CycleDraft, observedAt: string): Effect.Effect<CycleAcquireReceipt, CycleStoreError> =>
     run(
       'acquire',
-      Effect.gen(function* () {
-        const decodedDraft = yield* decodeCycleDraft(draft)
-        const decodedTime = yield* Schema.decodeUnknownEffect(UtcInstantSchema, strictParseOptions)(observedAt)
-        const candidate = yield* initialCycle(decodedDraft, decodedTime)
-        return yield* sql.withTransaction(
-          Effect.gen(function* () {
-            const inserted = yield* sql<Record<string, unknown>>`
-              INSERT INTO autonomous_cycles (
-                cycle_id, schema_version, identity_schema_version, strategy_name,
-                qualification_run_id, strategy_protocol_hash, account_id,
-                signal_session_date, signal_calendar_version,
-                execution_policy_schema_version, execution_policy_hash,
-                strategy_execution_model_hash, submission_window_ms, submission_cutoff_before_open_ms,
-                window_schema_version, execution_calendar_schema_version,
-                execution_calendar_source, execution_calendar_hash, execution_session_date,
-                signal_close_at, publication_deadline_at, submission_open_at,
-                execution_open_at, execution_close_at, submission_cutoff_at, state, snapshot_id,
-                decision_hash, terminal_reason, state_version,
-                created_at, updated_at, terminal_at
-              ) VALUES (
-                ${candidate.identity.cycleId}, ${candidate.schemaVersion},
-                ${candidate.identity.schemaVersion}, ${candidate.identity.strategyName},
-                ${candidate.identity.qualificationRunId}, ${candidate.identity.strategyProtocolHash},
-                ${candidate.identity.accountId}, ${candidate.identity.signalSessionDate},
-                ${candidate.identity.signalCalendarVersion},
-                ${candidate.identity.executionPolicy.schemaVersion},
-                ${candidate.identity.executionPolicy.executionPolicyHash},
-                ${candidate.identity.executionPolicy.strategyExecutionModelHash},
-                ${candidate.identity.executionPolicy.submissionWindowMs},
-                ${candidate.identity.executionPolicy.submissionCutoffBeforeOpenMs},
-                ${candidate.window.schemaVersion}, ${candidate.window.executionCalendarSchemaVersion},
-                ${candidate.window.executionCalendarSource}, ${candidate.window.executionCalendarHash},
-                ${candidate.window.executionSessionDate},
-                ${candidate.window.signalCloseAt}, ${candidate.window.publicationDeadlineAt},
-                ${candidate.window.submissionOpenAt}, ${candidate.window.executionOpenAt},
-                ${candidate.window.executionCloseAt},
-                ${candidate.window.submissionCutoffAt}, ${candidate.state}, NULL, NULL,
-                ${candidate.terminalReason ?? null}, ${candidate.stateVersion},
-                ${candidate.createdAt}, ${candidate.updatedAt}, ${candidate.terminalAt ?? null}
-              )
-              ON CONFLICT DO NOTHING
-              RETURNING cycle_id
-            `.pipe(Effect.flatMap(decodeMutationRows))
-            const slot = yield* sql<Record<string, unknown>>`
-              SELECT cycle_id
-              FROM autonomous_cycles
-              WHERE qualification_run_id = ${candidate.identity.qualificationRunId}
-                AND account_id = ${candidate.identity.accountId}
-                AND signal_session_date = ${candidate.identity.signalSessionDate}
-              FOR UPDATE
-            `.pipe(Effect.flatMap(decodeMutationRows))
-            const storedCycleId = slot[0]?.cycle_id
-            if (slot.length !== 1 || storedCycleId === undefined) {
-              return yield* fail('acquire', 'invariant', 'autonomous cycle authority slot was not found exactly once')
-            }
-            let stored = yield* readLocked('acquire', storedCycleId)
-            if (!cycleDraftMatches(cycleDraftOf(stored), decodedDraft)) {
-              return yield* fail('acquire', 'conflict', 'stored cycle differs from deterministic acquisition input')
-            }
-            if (stored.state === CycleState.Pending && decodedTime >= stored.window.publicationDeadlineAt) {
-              stored = (yield* blockCycle('acquire', stored, CycleTerminalReason.MissedPublication, decodedTime)).cycle
-            }
-            return { cycle: stored, created: inserted.length === 1 }
-          }),
-        )
-      }),
+      decodeCycleDraft(draft).pipe(
+        Effect.bindTo('draft'),
+        Effect.bind('observedAt', () => Schema.decodeUnknownEffect(UtcInstantSchema, strictParseOptions)(observedAt)),
+        Effect.map(({ draft: decodedDraft, observedAt: decodedTime }) => ({
+          draft: decodedDraft,
+          observedAt: decodedTime,
+          candidate: makeInitialCycle(decodedDraft, decodedTime),
+        })),
+        Effect.flatMap(({ draft: decodedDraft, observedAt: decodedTime, candidate }) =>
+          sql.withTransaction(
+            insertCycle(candidate).pipe(
+              Effect.bindTo('inserted'),
+              Effect.bind('storedCycleId', () => lockAuthoritySlot(candidate)),
+              Effect.bind('stored', ({ storedCycleId }) => readLocked('acquire', storedCycleId)),
+              Effect.flatMap(({ inserted, stored }) =>
+                liftDecision('acquire', decideAcquire(stored, decodedDraft, decodedTime, inserted.length === 1)),
+              ),
+              Effect.flatMap((decision) => interpretAcquireDecision(decodedTime, decision)),
+            ),
+          ),
+        ),
+      ),
     )
 
   const read = (cycleId: string): Effect.Effect<Option.Option<AutonomousCycle>, CycleStoreError> =>
@@ -643,12 +660,12 @@ const makeCycleStore = Effect.gen(function* () {
         Sha256Schema,
         strictParseOptions,
       )(cycleId).pipe(
-        Effect.flatMap((decodedId) => selectDecisionDocument(sql, decodedId)),
-        Effect.flatMap((rows) => {
-          if (rows.length > 1) {
+        Effect.flatMap(readDocuments),
+        Effect.flatMap((documents) => {
+          if (documents.length > 1) {
             return fail('read-decision-document', 'invariant', 'cycle decision document returned multiple rows')
           }
-          return Effect.succeed(rows[0] === undefined ? Option.none() : Option.some(rows[0].document))
+          return Effect.succeed(documents[0] === undefined ? Option.none() : Option.some(documents[0]))
         }),
       ),
     )
@@ -664,17 +681,40 @@ const makeCycleStore = Effect.gen(function* () {
       ),
     )
 
-  const persistSnapshotReference = (inputManifest: InputManifest): Effect.Effect<void, CycleStoreInternalError> =>
-    ensureSnapshotReference(sql, inputManifest).pipe(
-      Effect.flatMap((matches) =>
-        matches
-          ? Effect.void
-          : fail(
-              'bind-snapshot',
-              'conflict',
-              'stored snapshot reference diverged from the finalized Signal publication',
-            ),
-      ),
+  const persistSnapshot = (
+    manifest: InputManifest,
+    observedAt: string,
+    decision: Extract<SnapshotDecision, { readonly _tag: 'Persist' }>,
+  ): Effect.Effect<CycleMutationReceipt, CycleStoreInternalError> =>
+    persistSnapshotReference(manifest).pipe(
+      Effect.andThen(sql<Record<string, unknown>>`
+        UPDATE autonomous_cycles
+        SET
+          snapshot_id = ${decision.snapshotId},
+          state_version = ${decision.cycle.stateVersion + 1},
+          updated_at = ${observedAt}
+        WHERE cycle_id = ${decision.cycle.identity.cycleId}
+          AND state = ${CycleState.Pending}
+          AND state_version = ${decision.cycle.stateVersion}
+          AND snapshot_id IS NULL
+        RETURNING cycle_id
+      `),
+      Effect.flatMap((rows) => requireApplied('bind-snapshot', rows)),
+      Effect.flatMap(() => readLocked('bind-snapshot', decision.cycle.identity.cycleId)),
+      Effect.map((cycle) => ({ cycle, changed: true })),
+    )
+
+  const interpretSnapshotDecision = (
+    manifest: InputManifest,
+    observedAt: string,
+    decision: SnapshotDecision,
+  ): Effect.Effect<CycleMutationReceipt, CycleStoreInternalError> =>
+    Match.value(decision).pipe(
+      Match.tagsExhaustive({
+        Replay: ({ cycle }) => persistSnapshotReference(manifest).pipe(Effect.as({ cycle, changed: false })),
+        Persist: (persist) => persistSnapshot(manifest, observedAt, persist),
+        Block: ({ cycle, reason }) => blockCycle('bind-snapshot', cycle, reason, observedAt),
+      }),
     )
 
   const bindSnapshot = (
@@ -685,71 +725,55 @@ const makeCycleStore = Effect.gen(function* () {
     run(
       'bind-snapshot',
       decodeSnapshotInput({ cycleId, observedAt }).pipe(
-        Effect.flatMap((input) =>
+        Effect.bindTo('input'),
+        Effect.bind('manifest', () => decodeInputManifestArtifact(inputManifest)),
+        Effect.flatMap(({ input, manifest }) =>
           sql.withTransaction(
-            Effect.gen(function* () {
-              const decodedManifest = yield* decodeInputManifestArtifact(inputManifest)
-              const cycle = yield* readLocked('bind-snapshot', input.cycleId)
-              const snapshot = decodedManifest.finalizedSnapshot
-              if (input.observedAt < cycle.window.signalCloseAt) {
-                return yield* fail(
+            readLocked('bind-snapshot', input.cycleId).pipe(
+              Effect.flatMap((cycle) =>
+                liftDecision(
                   'bind-snapshot',
-                  'invariant',
-                  'snapshot binding cannot precede the Signal session close',
-                )
-              }
-              if (
-                snapshot.asOfSession !== cycle.identity.signalSessionDate ||
-                snapshot.lastSession !== cycle.identity.signalSessionDate ||
-                snapshot.calendarVersion !== cycle.identity.signalCalendarVersion
-              ) {
-                return yield* fail(
-                  'bind-snapshot',
-                  'invariant',
-                  'finalized Signal publication does not match the cycle signal session and calendar',
-                )
-              }
-              if (cycle.bindings.snapshotId !== undefined) {
-                if (cycle.bindings.snapshotId !== snapshot.snapshotId) {
-                  return yield* fail('bind-snapshot', 'conflict', 'cycle snapshot binding cannot be replaced')
-                }
-                yield* persistSnapshotReference(decodedManifest)
-                return { cycle, changed: false }
-              }
-              if (cycle.state !== CycleState.Pending) {
-                return yield* fail('bind-snapshot', 'conflict', 'snapshot may bind only while a cycle is pending')
-              }
-              if (input.observedAt >= cycle.window.publicationDeadlineAt) {
-                return yield* blockCycle(
-                  'bind-snapshot',
-                  cycle,
-                  CycleTerminalReason.MissedPublication,
-                  input.observedAt,
-                )
-              }
-              if (input.observedAt < cycle.updatedAt) {
-                return yield* fail('bind-snapshot', 'conflict', 'cycle update time cannot move backward')
-              }
-              yield* persistSnapshotReference(decodedManifest)
-              const updatedRows = yield* sql<Record<string, unknown>>`
-                UPDATE autonomous_cycles
-                SET
-                  snapshot_id = ${snapshot.snapshotId},
-                  state_version = ${cycle.stateVersion + 1},
-                  updated_at = ${input.observedAt}
-                WHERE cycle_id = ${input.cycleId}
-                  AND state = ${CycleState.Pending}
-                  AND state_version = ${cycle.stateVersion}
-                  AND snapshot_id IS NULL
-                RETURNING cycle_id
-              `
-              yield* requireApplied('bind-snapshot', updatedRows)
-              const updated = yield* readLocked('bind-snapshot', input.cycleId)
-              return { cycle: updated, changed: true }
-            }),
+                  decideSnapshotBinding(cycle, manifest.finalizedSnapshot, input.observedAt),
+                ),
+              ),
+              Effect.flatMap((decision) => interpretSnapshotDecision(manifest, input.observedAt, decision)),
+            ),
           ),
         ),
       ),
+    )
+
+  const persistActivation = (
+    observedAt: string,
+    decision: Extract<ActivationDecision, { readonly _tag: 'Persist' }>,
+  ): Effect.Effect<CycleMutationReceipt, CycleStoreInternalError> =>
+    sql<Record<string, unknown>>`
+      UPDATE autonomous_cycles
+      SET
+        state = ${CycleState.Active},
+        state_version = ${decision.cycle.stateVersion + 1},
+        updated_at = ${observedAt}
+      WHERE cycle_id = ${decision.cycle.identity.cycleId}
+        AND state = ${CycleState.Pending}
+        AND state_version = ${decision.cycle.stateVersion}
+        AND snapshot_id IS NOT NULL
+      RETURNING cycle_id
+    `.pipe(
+      Effect.flatMap((rows) => requireApplied('activate', rows)),
+      Effect.flatMap(() => readLocked('activate', decision.cycle.identity.cycleId)),
+      Effect.map((cycle) => ({ cycle, changed: true })),
+    )
+
+  const interpretActivationDecision = (
+    observedAt: string,
+    decision: ActivationDecision,
+  ): Effect.Effect<CycleMutationReceipt, CycleStoreInternalError> =>
+    Match.value(decision).pipe(
+      Match.tagsExhaustive({
+        Replay: ({ cycle }) => Effect.succeed({ cycle, changed: false }),
+        Persist: (persist) => persistActivation(observedAt, persist),
+        Block: ({ cycle, reason }) => blockCycle('activate', cycle, reason, observedAt),
+      }),
     )
 
   const activate = (cycleId: string, observedAt: string): Effect.Effect<CycleMutationReceipt, CycleStoreError> =>
@@ -758,40 +782,69 @@ const makeCycleStore = Effect.gen(function* () {
       decodeCycleIdInput({ cycleId, observedAt }).pipe(
         Effect.flatMap((input) =>
           sql.withTransaction(
-            Effect.gen(function* () {
-              const cycle = yield* readLocked('activate', input.cycleId)
-              if (cycle.state === CycleState.Active) return { cycle, changed: false }
-              if (!isCycleStateTransitionAllowed(cycle.state, CycleState.Active)) {
-                return yield* fail('activate', 'conflict', 'only a pending cycle may become active')
-              }
-              if (cycle.bindings.snapshotId === undefined) {
-                return yield* fail('activate', 'invariant', 'cycle activation requires a bound snapshot')
-              }
-              if (input.observedAt >= cycle.window.submissionCutoffAt) {
-                return yield* blockCycle('activate', cycle, CycleTerminalReason.MissedSubmission, input.observedAt)
-              }
-              if (input.observedAt < cycle.updatedAt) {
-                return yield* fail('activate', 'conflict', 'cycle update time cannot move backward')
-              }
-              const updatedRows = yield* sql<Record<string, unknown>>`
-                UPDATE autonomous_cycles
-                SET
-                  state = ${CycleState.Active},
-                  state_version = ${cycle.stateVersion + 1},
-                  updated_at = ${input.observedAt}
-                WHERE cycle_id = ${input.cycleId}
-                  AND state = ${CycleState.Pending}
-                  AND state_version = ${cycle.stateVersion}
-                  AND snapshot_id IS NOT NULL
-                RETURNING cycle_id
-              `
-              yield* requireApplied('activate', updatedRows)
-              const updated = yield* readLocked('activate', input.cycleId)
-              return { cycle: updated, changed: true }
-            }),
+            readLocked('activate', input.cycleId).pipe(
+              Effect.flatMap((cycle) => liftDecision('activate', decideActivation(cycle, input.observedAt))),
+              Effect.flatMap((decision) => interpretActivationDecision(input.observedAt, decision)),
+            ),
           ),
         ),
       ),
+    )
+
+  const persistDecisionBinding = (
+    observedAt: string,
+    decision: Extract<DecisionBindingDecision, { readonly _tag: 'Persist' }>,
+  ): Effect.Effect<CycleMutationReceipt, CycleStoreInternalError> =>
+    decisionEvidenceMatches(decision.document).pipe(
+      Effect.flatMap((matches) =>
+        matches
+          ? Effect.void
+          : fail(
+              'bind-decision',
+              'invariant',
+              'shadow decision does not match the durable snapshot and exact reconciliation evidence',
+            ),
+      ),
+      Effect.andThen(sql`
+        INSERT INTO autonomous_cycle_shadow_decisions (
+          cycle_id,
+          schema_version,
+          document,
+          created_at
+        ) VALUES (
+          ${decision.cycle.identity.cycleId},
+          ${decision.document.schemaVersion},
+          ${sql.json(decision.document)},
+          ${decision.document.createdAt}
+        )
+      `),
+      Effect.andThen(sql<Record<string, unknown>>`
+        UPDATE autonomous_cycles
+        SET
+          decision_hash = ${decision.document.contentHash},
+          state_version = ${decision.cycle.stateVersion + 1},
+          updated_at = ${observedAt}
+        WHERE cycle_id = ${decision.cycle.identity.cycleId}
+          AND state = ${CycleState.Active}
+          AND state_version = ${decision.cycle.stateVersion}
+          AND decision_hash IS NULL
+        RETURNING cycle_id
+      `),
+      Effect.flatMap((rows) => requireApplied('bind-decision', rows)),
+      Effect.flatMap(() => readLocked('bind-decision', decision.cycle.identity.cycleId)),
+      Effect.map((cycle) => ({ cycle, changed: true })),
+    )
+
+  const interpretDecisionBinding = (
+    observedAt: string,
+    decision: DecisionBindingDecision,
+  ): Effect.Effect<CycleMutationReceipt, CycleStoreInternalError> =>
+    Match.value(decision).pipe(
+      Match.tagsExhaustive({
+        Replay: ({ cycle }) => Effect.succeed({ cycle, changed: false }),
+        Persist: (persist) => persistDecisionBinding(observedAt, persist),
+        Block: ({ cycle, reason }) => blockCycle('bind-decision', cycle, reason, observedAt),
+      }),
     )
 
   const bindDecision = (
@@ -804,85 +857,59 @@ const makeCycleStore = Effect.gen(function* () {
       decodeDecisionInput({ cycleId, document, observedAt }).pipe(
         Effect.flatMap((input) =>
           sql.withTransaction(
-            Effect.gen(function* () {
-              const cycle = yield* readLocked('bind-decision', input.cycleId)
-              if (cycle.bindings.decisionHash !== undefined) {
-                const storedRows = yield* selectDecisionDocument(sql, input.cycleId)
-                const storedDocument = storedRows[0]?.document
-                if (
-                  cycle.bindings.decisionHash !== input.document.contentHash ||
-                  storedRows.length !== 1 ||
-                  storedDocument === undefined ||
-                  !shadowDecisionEquivalent(storedDocument, input.document)
-                ) {
-                  return yield* fail('bind-decision', 'conflict', 'cycle decision binding cannot be replaced')
-                }
-                return { cycle, changed: false }
-              }
-              if (cycle.state !== CycleState.Active) {
-                return yield* fail('bind-decision', 'conflict', 'decision may bind only while a cycle is active')
-              }
-              if (input.observedAt >= cycle.window.submissionCutoffAt) {
-                return yield* blockCycle('bind-decision', cycle, CycleTerminalReason.MissedSubmission, input.observedAt)
-              }
-              if (
-                input.document.bindings.cycleId !== cycle.identity.cycleId ||
-                input.document.bindings.strategyName !== cycle.identity.strategyName ||
-                input.document.bindings.strategyProtocolHash !== cycle.identity.strategyProtocolHash ||
-                input.document.bindings.snapshotId !== cycle.bindings.snapshotId ||
-                input.document.bindings.accountId !== cycle.identity.accountId ||
-                input.document.submissionCutoffAt !== cycle.window.submissionCutoffAt ||
-                input.document.createdAt > input.observedAt ||
-                input.document.createdAt < cycle.updatedAt
-              ) {
-                return yield* fail(
+            readLocked('bind-decision', input.cycleId).pipe(
+              Effect.bindTo('cycle'),
+              Effect.bind('documents', ({ cycle }) =>
+                cycle.bindings.decisionHash === undefined ? Effect.succeed([]) : readDocuments(input.cycleId),
+              ),
+              Effect.flatMap(({ cycle, documents }) =>
+                liftDecision(
                   'bind-decision',
-                  'invariant',
-                  'shadow decision does not match the active autonomous cycle',
-                )
-              }
-              if (input.observedAt < cycle.updatedAt) {
-                return yield* fail('bind-decision', 'conflict', 'cycle update time cannot move backward')
-              }
-              if (!(yield* decisionEvidenceMatches(input.document))) {
-                return yield* fail(
-                  'bind-decision',
-                  'invariant',
-                  'shadow decision does not match the durable snapshot and exact reconciliation evidence',
-                )
-              }
-              yield* sql`
-                INSERT INTO autonomous_cycle_shadow_decisions (
-                  cycle_id,
-                  schema_version,
-                  document,
-                  created_at
-                ) VALUES (
-                  ${input.cycleId},
-                  ${input.document.schemaVersion},
-                  ${sql.json(input.document)},
-                  ${input.document.createdAt}
-                )
-              `
-              const updatedRows = yield* sql<Record<string, unknown>>`
-                UPDATE autonomous_cycles
-                SET
-                  decision_hash = ${input.document.contentHash},
-                  state_version = ${cycle.stateVersion + 1},
-                  updated_at = ${input.observedAt}
-                WHERE cycle_id = ${input.cycleId}
-                  AND state = ${CycleState.Active}
-                  AND state_version = ${cycle.stateVersion}
-                  AND decision_hash IS NULL
-                RETURNING cycle_id
-              `
-              yield* requireApplied('bind-decision', updatedRows)
-              const updated = yield* readLocked('bind-decision', input.cycleId)
-              return { cycle: updated, changed: true }
-            }),
+                  decideDecisionBinding(cycle, input.document, input.observedAt, documents),
+                ),
+              ),
+              Effect.flatMap((decision) => interpretDecisionBinding(input.observedAt, decision)),
+            ),
           ),
         ),
       ),
+    )
+
+  const persistCompletion = (
+    observedAt: string,
+    decision: Extract<CompletionDecision, { readonly _tag: 'VerifyDecision' }>,
+  ): Effect.Effect<CycleMutationReceipt, CycleStoreInternalError> =>
+    sql<Record<string, unknown>>`
+      UPDATE autonomous_cycles
+      SET
+        state = ${decision.state},
+        state_version = ${decision.cycle.stateVersion + 1},
+        updated_at = ${observedAt},
+        terminal_at = ${observedAt}
+      WHERE cycle_id = ${decision.cycle.identity.cycleId}
+        AND state = ${CycleState.Active}
+        AND state_version = ${decision.cycle.stateVersion}
+        AND decision_hash = ${decision.decisionHash}
+      RETURNING cycle_id
+    `.pipe(
+      Effect.flatMap((rows) => requireApplied('finish', rows)),
+      Effect.flatMap(() => readLocked('finish', decision.cycle.identity.cycleId)),
+      Effect.map((cycle) => ({ cycle, changed: true })),
+    )
+
+  const interpretCompletionDecision = (
+    observedAt: string,
+    decision: CompletionDecision,
+  ): Effect.Effect<CycleMutationReceipt, CycleStoreInternalError> =>
+    Match.value(decision).pipe(
+      Match.tagsExhaustive({
+        Replay: ({ cycle }) => Effect.succeed({ cycle, changed: false }),
+        VerifyDecision: (verification) =>
+          readDocuments(verification.cycle.identity.cycleId).pipe(
+            Effect.flatMap((documents) => liftDecision('finish', validateCompletionDocument(verification, documents))),
+            Effect.andThen(persistCompletion(observedAt, verification)),
+          ),
+      }),
     )
 
   const finish = (
@@ -895,52 +922,10 @@ const makeCycleStore = Effect.gen(function* () {
       decodeFinishInput({ cycleId, state, observedAt }).pipe(
         Effect.flatMap((input) =>
           sql.withTransaction(
-            Effect.gen(function* () {
-              const cycle = yield* readLocked('finish', input.cycleId)
-              if (cycle.state === input.state) return { cycle, changed: false }
-              if (!isCycleStateTransitionAllowed(cycle.state, input.state)) {
-                return yield* fail('finish', 'conflict', 'only an active cycle may finish from its bound decision')
-              }
-              if (input.observedAt < cycle.updatedAt) {
-                return yield* fail('finish', 'conflict', 'cycle update time cannot move backward')
-              }
-              const decisionHash = cycle.bindings.decisionHash
-              if (decisionHash === undefined) {
-                return yield* fail('finish', 'invariant', 'cycle completion requires a bound shadow decision')
-              }
-              const storedRows = yield* selectDecisionDocument(sql, input.cycleId)
-              const storedDocument = storedRows[0]?.document
-              const expectedStatus =
-                input.state === CycleState.Completed ? TargetPlanStatus.Planned : TargetPlanStatus.NoTrade
-              if (
-                storedRows.length !== 1 ||
-                storedDocument === undefined ||
-                storedDocument.contentHash !== decisionHash ||
-                storedDocument.targetPlan.status !== expectedStatus
-              ) {
-                return yield* fail(
-                  'finish',
-                  'invariant',
-                  'cycle terminal state must match its exact durable shadow decision',
-                )
-              }
-              const updatedRows = yield* sql<Record<string, unknown>>`
-                UPDATE autonomous_cycles
-                SET
-                  state = ${input.state},
-                  state_version = ${cycle.stateVersion + 1},
-                  updated_at = ${input.observedAt},
-                  terminal_at = ${input.observedAt}
-                WHERE cycle_id = ${input.cycleId}
-                  AND state = ${CycleState.Active}
-                  AND state_version = ${cycle.stateVersion}
-                  AND decision_hash = ${decisionHash}
-                RETURNING cycle_id
-              `
-              yield* requireApplied('finish', updatedRows)
-              const updated = yield* readLocked('finish', input.cycleId)
-              return { cycle: updated, changed: true }
-            }),
+            readLocked('finish', input.cycleId).pipe(
+              Effect.flatMap((cycle) => liftDecision('finish', decideCompletion(cycle, input.state, input.observedAt))),
+              Effect.flatMap((decision) => interpretCompletionDecision(input.observedAt, decision)),
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
## Summary

- Group cycle persistence into one cohesive `db/cycle-store/` module with a stable public boundary, a PostgreSQL interpreter, pure lifecycle decisions, and colocated tests.
- Move acquisition, snapshot binding, activation, decision binding, completion, and blocking branches into immutable `Result` functions over decoded domain values.
- Replace nested transaction generators and mutable acquisition state with small Effect pipelines that only decode, transact, query, persist, and map typed failures.
- Preserve authority-slot locking, conditional state-version writes, snapshot-reference validation, exact decision evidence, deadline behavior, replay, and terminal-state semantics.
- Refresh the two architecture-specific Bayn Bun dependency hashes after the source-module layout changed the fixed-output workspace closure.

## Related Issues

None

## Testing

- `bun test services/bayn/src/db/cycle-store/decisions.test.ts services/bayn/src/cycle-readiness.test.ts services/bayn/src/cycle-runner.test.ts` (41 passed, 0 failed)
- `bun run --filter @proompteng/bayn test` (623 passed, 116 PostgreSQL-gated skipped, 0 failed)
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn build`
- `nix-instantiate --parse nix/images/bayn.nix`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] Documentation and release notes are not required because the public CycleStore and runtime behavior are unchanged.