### PR TITLE
fix(bayn): reject non-finite boundary numbers

### DIFF
--- a/services/bayn/src/cycle.test.ts
+++ b/services/bayn/src/cycle.test.ts
@@ -326,6 +326,28 @@ describe('autonomous cycle identity and calendar', () => {
     })
   })
 
+  test('rejects non-finite cycle durations before date arithmetic', () => {
+    for (const policy of [
+      {
+        submissionWindowMs: Number.POSITIVE_INFINITY,
+        submissionCutoffBeforeOpenMs: defaultSubmissionCutoffBeforeOpenMs,
+      },
+      {
+        submissionWindowMs: defaultSubmissionWindowMs,
+        submissionCutoffBeforeOpenMs: Number.NaN,
+      },
+    ]) {
+      const result = makeCycleWindow(signalSession('2026-03-06'), executionCalendar(), policy)
+      expect(Result.isFailure(result)).toBe(true)
+      expect(Result.isFailure(result) ? result.failure : null).toMatchObject({
+        _tag: 'CycleConstructionFailure',
+        operation: 'cycle-window',
+        reason: 'decode',
+        message: 'cycle window policy is invalid',
+      })
+    }
+  })
+
   test('rejects forged execution observations, UTC drift, and identity provenance mismatches', async () => {
     const observedExecutionCalendar = executionCalendar()
     const executionPolicy = makeExecutionPolicy()

--- a/services/bayn/src/cycle.ts
+++ b/services/bayn/src/cycle.ts
@@ -524,8 +524,8 @@ const SelectedExecutionCalendarSessionSchema = Schema.Struct({
 const CycleWindowPolicyInputSchema = Schema.Union([
   CycleExecutionPolicySchema,
   Schema.Struct({
-    submissionWindowMs: Schema.Number,
-    submissionCutoffBeforeOpenMs: Schema.Number,
+    submissionWindowMs: Schema.Finite,
+    submissionCutoffBeforeOpenMs: Schema.Finite,
   }),
 ])
 

--- a/services/bayn/src/market-data.test.ts
+++ b/services/bayn/src/market-data.test.ts
@@ -447,6 +447,58 @@ describe('finalized Signal snapshot reader', () => {
     expect(failure.message).toBe('failed to decode Signal sessions')
   })
 
+  test('rejects non-finite manifest counts at the row boundary', async () => {
+    for (const barCount of [Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY]) {
+      const fixture = makeFixture()
+      const malformedManifests = [
+        { ...fixture.rows.manifests[0], bar_count: barCount },
+      ] as unknown as readonly SignalManifestRow[]
+      const client = makeClickhouseFixture(malformedManifests, fixture.rows.sessions, [])
+      const layer = MarketDataLive(
+        {
+          operationTimeoutMs: 5_000,
+          clickhouse: {
+            url: 'http://clickhouse.test:8123',
+            username: 'bayn',
+            password: Redacted.make('secret'),
+            snapshotId,
+            publicationAsOf: fixture.request.publicationAsOf,
+            calendarVersion: fixture.request.calendarVersion,
+            bounds: fixture.request.bounds,
+          },
+        },
+        {
+          universeId: fixture.request.universeId,
+          universeSymbolHash: fixture.request.universeSymbolHash,
+          universe: fixture.request.universe,
+          historyStart: fixture.request.historyStart,
+          evaluationStart: fixture.request.evaluationStart,
+        },
+      ).pipe(Layer.provide(Layer.succeed(ClickhouseClient.ClickhouseClient, client)))
+
+      const failure = await Effect.runPromise(
+        Effect.flip(
+          Effect.gen(function* () {
+            const marketData = yield* MarketData
+            return yield* marketData.inspect
+          }).pipe(Effect.provide(layer)),
+        ),
+      )
+
+      expect(failure).toMatchObject({
+        _tag: 'OperationalError',
+        component: 'market-data',
+        operation: 'inspect',
+        retryable: false,
+        cause: {
+          _tag: 'RowDecodeFailed',
+          rows: 'manifests',
+        },
+      })
+      expect(failure.message).toBe('failed to decode Signal manifests')
+    }
+  })
+
   test('reproduces the publisher contract before exposing bounded numeric bars', () => {
     const fixture = makeFixture()
     const snapshot = verificationSuccess(verifyFinalizedSnapshot(fixture.rows, fixture.request))

--- a/services/bayn/src/market-data.ts
+++ b/services/bayn/src/market-data.ts
@@ -59,7 +59,7 @@ const cyclePublicationCandidateLimit = 16
 const SnapshotIdSchema = HashSchema
 const FixedDecimalSchema = Schema.String.check(Schema.isPattern(/^(?:0|[1-9]\d*)\.\d{8}$/))
 const MarketTimeSchema = Schema.String.check(Schema.isPattern(/^(?:0\d|1\d|2[0-3]):[0-5]\d$/))
-const CountSchema = Schema.Union([Schema.Number, DigitsSchema])
+const CountSchema = Schema.Union([Schema.Finite, DigitsSchema])
 const FinalizedAtSchema = Schema.String.check(
   Schema.isPattern(/^\d{4}-\d{2}-\d{2} (?:[01]\d|2[0-3]):[0-5]\d:[0-5]\d\.\d{3}$/),
 )

--- a/services/bayn/tsconfig.json
+++ b/services/bayn/tsconfig.json
@@ -14,6 +14,7 @@
           "globalErrorInEffectCatch": "error",
           "globalErrorInEffectFailure": "error",
           "multipleEffectProvide": "error",
+          "schemaNumber": "error",
           "scopeInLayerEffect": "error",
           "unknownInEffectCatch": "error"
         },
@@ -26,6 +27,7 @@
                 "globalErrorInEffectCatch": "off",
                 "globalErrorInEffectFailure": "off",
                 "multipleEffectProvide": "off",
+                "schemaNumber": "off",
                 "scopeInLayerEffect": "off",
                 "unknownInEffectCatch": "off"
               }


### PR DESCRIPTION
## Summary

- reject non-finite cycle-window durations during schema decoding before date arithmetic
- reject non-finite Signal manifest counts during row decoding before count conversion
- make Effect's `schemaNumber` diagnostic blocking for Bayn production code

## Related Issues

None

## Testing

- `bun test services/bayn/src/cycle.test.ts services/bayn/src/market-data.test.ts` — 31 passed, 0 failed
- `bun run --filter @proompteng/bayn test` — 625 passed, 116 skipped, 0 failed
- `bun node_modules/typescript/bin/tsc -p services/bayn/tsconfig.json --noEmit`
- `bun run --cwd services/bayn lint:effect`
- `bun node_modules/oxfmt/bin/oxfmt --check services/bayn`
- `bun node_modules/oxlint/bin/oxlint --config .oxlintrc.json services/bayn`
- `bun node_modules/oxlint/bin/oxlint --config .oxlintrc.json --type-aware --tsconfig services/bayn/tsconfig.json services/bayn`
- `bun run --filter @proompteng/bayn build`
- `bun test packages/scripts/src/bayn` — 20 passed, 0 failed

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable and Breaking Changes is filled in.
- [x] No documentation or release-note update is required for this boundary validation change.
