### PR TITLE
refactor(bayn): centralize broker response hashing

### DIFF
--- a/services/bayn/src/broker/alpaca-mutations.test.ts
+++ b/services/bayn/src/broker/alpaca-mutations.test.ts
@@ -483,4 +483,26 @@ describe('Alpaca paper mutations', () => {
       },
     })
   })
+
+  test('hashes a non-JSON cancel response as exact raw text', async () => {
+    const body = 'upstream unavailable\n'
+    const client = HttpClient.make((request) =>
+      Effect.succeed(
+        HttpClientResponse.fromWeb(request, new Response(body, { status: 502, headers: responseHeaders })),
+      ),
+    )
+
+    const failure = await Effect.runPromise(Effect.flip(withMutation(client, (mutation) => mutation.cancel(orderId))))
+
+    expect(failure).toMatchObject({
+      operation: MutationOperation.Cancel,
+      failure: MutationFailure.Unknown,
+      outcome: MutationOutcome.Unknown,
+      evidence: {
+        contentHash: canonicalHashV1(body),
+        requestId: 'req-123',
+        status: 502,
+      },
+    })
+  })
 })

--- a/services/bayn/src/broker/alpaca-mutations.ts
+++ b/services/bayn/src/broker/alpaca-mutations.ts
@@ -1,4 +1,4 @@
-import { Cause, Clock, Context, Data, Effect, Redacted, Schema } from 'effect'
+import { Cause, Clock, Context, Data, Effect, Redacted, Result, Schema } from 'effect'
 import { Headers, HttpClient, HttpClientRequest, HttpClientResponse } from 'effect/unstable/http'
 
 import { canonicalHashV1 } from '../hash'
@@ -61,6 +61,7 @@ const decodeErrorResponse = Schema.decodeUnknownEffect(ErrorResponseSchema, resp
 const decodeOrderResponse = Schema.decodeUnknownEffect(OrderResponseSchema, responseParseOptions)
 const decodeIntent = Schema.decodeUnknownEffect(IntentSchema, inputParseOptions)
 const decodeOptions = Schema.decodeUnknownEffect(OptionsSchema, inputParseOptions)
+const decodeJsonResponseBody = Schema.decodeUnknownResult(Schema.UnknownFromJsonString)
 
 export enum MutationOperation {
   Submit = 'SUBMIT',
@@ -256,6 +257,12 @@ const responseEvidence = (
   contentHash: string,
   observedAt: string,
 ): MutationEvidence => ({ requestId, status, contentHash, observedAt })
+
+const canonicalResponseBodyHash = (body: string): string =>
+  Result.match(decodeJsonResponseBody(body), {
+    onFailure: () => canonicalHashV1(body),
+    onSuccess: canonicalHashV1,
+  })
 
 const withDeadline = <A, E>(
   operation: MutationOperation,
@@ -487,12 +494,7 @@ export const makeMutation = (
               response.status === 204
                 ? canonicalHashV1(null)
                 : yield* response.text.pipe(
-                    Effect.flatMap((body) =>
-                      Effect.try({
-                        try: () => canonicalHashV1(JSON.parse(body)),
-                        catch: () => undefined,
-                      }).pipe(Effect.orElseSucceed(() => canonicalHashV1(body))),
-                    ),
+                    Effect.map(canonicalResponseBodyHash),
                     Effect.mapError((cause) =>
                       unknownOutcome(
                         MutationOperation.Cancel,


### PR DESCRIPTION
## Summary

- centralize ambiguous Alpaca cancel response hashing in one pure helper
- decode JSON response text through Effect Schema before canonical hashing
- preserve exact raw-text hashing when a response body is not valid JSON

## Related Issues

None

## Testing

- `bun test services/bayn/src/broker/alpaca-mutations.test.ts` — 13 passed, 0 failed
- `bun run --filter @proompteng/bayn test` — 636 passed, 116 skipped, 0 failed
- `bun node_modules/typescript/bin/tsc -p services/bayn/tsconfig.json --noEmit`
- `bun run --cwd services/bayn lint:effect`
- `bun node_modules/oxfmt/bin/oxfmt --check services/bayn`
- `bun node_modules/oxlint/bin/oxlint --config .oxlintrc.json services/bayn`
- `bun node_modules/oxlint/bin/oxlint --config .oxlintrc.json --type-aware --tsconfig services/bayn/tsconfig.json services/bayn`
- `bun run --filter @proompteng/bayn build`
- `bun test packages/scripts/src/bayn` — 20 passed, 0 failed

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable and Breaking Changes is filled in.
- [x] No documentation or release-note update is required for this internal boundary refactor.
