### PR TITLE
refactor(bayn): totalize execution model decisions

### DIFF
--- a/services/bayn/src/audit/audit.ts
+++ b/services/bayn/src/audit/audit.ts
@@ -19,7 +19,7 @@ import {
   type Protocol,
   type SimulationTrace,
 } from '../types'
-import { evaluateReference, type ReferenceEvaluation } from './reference'
+import { evaluateReference, type ReferenceEvaluation, type ReferenceEvaluationFailure } from './reference'
 
 const decodeReconciliation = Schema.decodeUnknownSync(ReconciliationResultSchema, StrictParseOptions)
 type GateScalar = EconomicVerdict['gates'][number]['actual']
@@ -298,7 +298,9 @@ const makeMarkedEquityAuditMaterial = (
       }
 }
 
-const makeAuditFacts = (input: QualificationAuditInput): QualificationAuditFacts => {
+const makeAuditFacts = (
+  input: QualificationAuditInput,
+): Result.Result<QualificationAuditFacts, ReferenceEvaluationFailure> => {
   const database = input.database
   if (database.protocol.strategyName !== contract.name || database.run.strategyName !== contract.name) {
     throw new Error('stored qualification uses an unsupported strategy contract')
@@ -321,7 +323,9 @@ const makeAuditFacts = (input: QualificationAuditInput): QualificationAuditFacts
       parameterSchemaVersion: database.protocol.schemaVersion,
     },
   })
-  const reference = evaluateReference(input.bars, input.manifest, input.protocol, provenance)
+  const referenceResult = evaluateReference(input.bars, input.manifest, input.protocol, provenance)
+  if (Result.isFailure(referenceResult)) return Result.fail(referenceResult.failure)
+  const reference = referenceResult.success
   const trace = reference.strategy.trace
   if (trace === null) throw new Error('reference evaluation omitted its candidate trace')
   const sortedReplicas = [...input.signalReplicas].sort()
@@ -330,7 +334,7 @@ const makeAuditFacts = (input: QualificationAuditInput): QualificationAuditFacts
     if (left.replica !== right.replica) return left.replica < right.replica ? -1 : 1
     return left.queryId < right.queryId ? -1 : left.queryId > right.queryId ? 1 : 0
   })
-  return {
+  return Result.succeed({
     input,
     database,
     artifact: new Map(database.artifacts.map((value) => [value.name, value])),
@@ -345,7 +349,7 @@ const makeAuditFacts = (input: QualificationAuditInput): QualificationAuditFacts
     sortedAccess,
     publisherSet: new Set(input.signalPrincipals.publishers),
     markedEquity: makeMarkedEquityAuditMaterial(input, reference, trace),
-  }
+  })
 }
 
 const auditStoredEvidence = (facts: QualificationAuditFacts): readonly AuditCheck[] => {
@@ -836,8 +840,12 @@ const makeAuditReport = (facts: QualificationAuditFacts, checks: readonly AuditC
   return { ...material, auditHash: canonicalHashV1(material) }
 }
 
-export const auditQualification = (input: QualificationAuditInput): QualificationAuditReport => {
-  const facts = makeAuditFacts(input)
+export const auditQualification = (
+  input: QualificationAuditInput,
+): Result.Result<QualificationAuditReport, ReferenceEvaluationFailure> => {
+  const factsResult = makeAuditFacts(input)
+  if (Result.isFailure(factsResult)) return Result.fail(factsResult.failure)
+  const facts = factsResult.success
   const checks = [
     ...auditStoredEvidence(facts),
     ...auditReferenceArtifacts(facts),
@@ -845,5 +853,5 @@ export const auditQualification = (input: QualificationAuditInput): Qualificatio
     ...auditQualificationBindings(facts),
     ...auditSignalAndRepository(facts),
   ]
-  return makeAuditReport(facts, checks)
+  return Result.succeed(makeAuditReport(facts, checks))
 }

--- a/services/bayn/src/audit/dossier.ts
+++ b/services/bayn/src/audit/dossier.ts
@@ -1,4 +1,4 @@
-import { Schema } from 'effect'
+import { Result, Schema } from 'effect'
 
 import { canonicalHashV1 } from '../hash'
 import { QualificationLockSchema, QualificationResultSchema } from '../qualification'
@@ -10,6 +10,7 @@ import {
   type QualificationAuditInput,
   type QualificationAuditReport,
 } from './audit'
+import type { ReferenceEvaluationFailure } from './reference'
 
 const decodeLock = Schema.decodeUnknownSync(QualificationLockSchema, StrictParseOptions)
 const decodeResult = Schema.decodeUnknownSync(QualificationResultSchema, StrictParseOptions)
@@ -98,8 +99,12 @@ export interface QualificationDossier {
   readonly dossierHash: string
 }
 
-export const makeQualificationDossier = (input: QualificationAuditInput): QualificationDossier => {
-  const audit = auditQualification(input)
+export const makeQualificationDossier = (
+  input: QualificationAuditInput,
+): Result.Result<QualificationDossier, ReferenceEvaluationFailure> => {
+  const auditResult = auditQualification(input)
+  if (Result.isFailure(auditResult)) return Result.fail(auditResult.failure)
+  const audit = auditResult.success
   const database = input.database
   validateSubject(database, input.manifest, audit)
   const lock = decodeLock(database.qualification.lock)
@@ -144,5 +149,5 @@ export const makeQualificationDossier = (input: QualificationAuditInput): Qualif
       capitalPromotion: false as const,
     },
   }
-  return { ...material, dossierHash: canonicalHashV1(material) }
+  return Result.succeed({ ...material, dossierHash: canonicalHashV1(material) })
 }

--- a/services/bayn/src/audit/reference.ts
+++ b/services/bayn/src/audit/reference.ts
@@ -1,3 +1,5 @@
+import { pipe, Result } from 'effect'
+
 import { makeRunIdentity, makeStrategyProtocolHash, type RuntimeProvenance } from '../contracts'
 import {
   MICROS,
@@ -13,6 +15,7 @@ import {
   referencePriceMicros,
   saleCostBasisMicros,
   scaleQuantityMicros,
+  type ExecutionModelFailure,
   type FeeInput,
   type FillTerms,
 } from '../execution-model'
@@ -73,6 +76,16 @@ export interface ReferenceEvaluation {
   readonly doubleCostStrategy: Replay
   readonly verdict: EconomicVerdict
 }
+
+export type ReferenceEvaluationFailure =
+  | ExecutionModelFailure
+  | {
+      readonly _tag: 'UnsupportedReferenceExecutionModel'
+      readonly actual: string
+      readonly required: 'bayn.execution-model.v2'
+    }
+
+type ReferenceComputation<A> = Result.Result<A, ReferenceEvaluationFailure>
 
 const tradingDays = 252
 
@@ -411,33 +424,36 @@ const order = (
   requestedQuantityMicros: bigint,
   referencePrice: bigint,
   protocol: SimulationProtocol,
-): SimulatedOrder => {
-  const outcome = makeOrderOutcome({
-    identity: {
-      schemaVersion: 'bayn.partial-fill-seed.v1',
-      signalDate: decision.signalDate,
-      executionDate: decision.executionDate,
-      symbol,
+): ReferenceComputation<SimulatedOrder> =>
+  pipe(
+    makeOrderOutcome({
+      identity: {
+        schemaVersion: 'bayn.partial-fill-seed.v1',
+        signalDate: decision.signalDate,
+        executionDate: decision.executionDate,
+        symbol,
+        side,
+      },
       side,
-    },
-    side,
-    requestedQuantityMicros,
-    referencePriceMicros: referencePrice,
-    model: protocol.executionModel,
-  })
-  const material = {
-    decisionId: decision.id,
-    sessionDate,
-    symbol,
-    side,
-    requestedQuantityMicros: outcome.requestedQuantityMicros.toString(),
-    filledQuantityMicros: outcome.filledQuantityMicros.toString(),
-    status: outcome.status,
-    rejectionReason: outcome.rejectionReason,
-    unfilledRemainder: outcome.unfilledRemainder,
-  }
-  return { id: canonicalHashV1({ runId, kind: 'order', ...material }), ...material }
-}
+      requestedQuantityMicros,
+      referencePriceMicros: referencePrice,
+      model: protocol.executionModel,
+    }),
+    Result.map((outcome) => {
+      const material = {
+        decisionId: decision.id,
+        sessionDate,
+        symbol,
+        side,
+        requestedQuantityMicros: outcome.requestedQuantityMicros.toString(),
+        filledQuantityMicros: outcome.filledQuantityMicros.toString(),
+        status: outcome.status,
+        rejectionReason: outcome.rejectionReason,
+        unfilledRemainder: outcome.unfilledRemainder,
+      }
+      return { id: canonicalHashV1({ runId, kind: 'order', ...material }), ...material }
+    }),
+  )
 
 const restrictReferenceBuyFill = (
   runId: string,
@@ -505,6 +521,133 @@ const cashChange = (
   return { id: canonicalHashV1({ runId, kind: 'cash-change', ...material }), ...material }
 }
 
+const replayPrices = (
+  session: Session,
+  protocol: SimulationProtocol,
+  price: (bar: DailyBar) => number,
+): ReferenceComputation<Readonly<Record<string, bigint>>> =>
+  pipe(
+    Result.all(
+      protocol.universe.map((symbol) =>
+        pipe(
+          referencePriceMicros(price(session.bars[symbol]), protocol.executionModel),
+          Result.map((priceMicros) => [symbol, priceMicros] as const),
+        ),
+      ),
+    ),
+    Result.map((entries) => Object.fromEntries(entries)),
+  )
+
+const replayPositionValue = (
+  prices: Readonly<Record<string, bigint>>,
+  positions: ReadonlyMap<string, Position>,
+  protocol: SimulationProtocol,
+): ReferenceComputation<bigint> =>
+  protocol.universe.reduce<ReferenceComputation<bigint>>(
+    (total, symbol) =>
+      pipe(
+        total,
+        Result.flatMap((value) =>
+          pipe(
+            notionalMicros(positions.get(symbol)?.quantityMicros ?? 0n, prices[symbol]),
+            Result.map((notional) => value + notional),
+          ),
+        ),
+      ),
+    Result.succeed(0n),
+  )
+
+const replayDesiredQuantities = (
+  equityMicros: bigint,
+  weights: Readonly<Record<string, number>>,
+  prices: Readonly<Record<string, bigint>>,
+  protocol: SimulationProtocol,
+): ReferenceComputation<Readonly<Record<string, bigint>>> =>
+  pipe(
+    Result.all(
+      protocol.universe.map((symbol) =>
+        pipe(
+          desiredQuantityMicros(equityMicros, weights[symbol], prices[symbol], protocol.executionModel),
+          Result.map((quantityMicros) => [symbol, quantityMicros] as const),
+        ),
+      ),
+    ),
+    Result.map((entries) => Object.fromEntries(entries)),
+  )
+
+interface ReferenceBuyCandidate {
+  readonly symbol: string
+  readonly quantityMicros: bigint
+}
+
+const replayBuyFeeInputs = (
+  buys: readonly ReferenceBuyCandidate[],
+  scalePpm: bigint,
+  prices: Readonly<Record<string, bigint>>,
+  protocol: SimulationProtocol,
+  costMultiplierMicros: bigint,
+  minimumNotionalMicros?: bigint,
+): ReferenceComputation<readonly FeeInput[]> =>
+  buys.reduce<ReferenceComputation<readonly FeeInput[]>>(
+    (result, buy) =>
+      pipe(
+        result,
+        Result.flatMap((inputs) =>
+          pipe(
+            scaleQuantityMicros(buy.quantityMicros, scalePpm, protocol.executionModel),
+            Result.flatMap((quantityMicros) => {
+              if (quantityMicros === 0n) return Result.succeed(inputs)
+              return pipe(
+                notionalMicros(quantityMicros, prices[buy.symbol]),
+                Result.flatMap((referenceNotionalMicros) => {
+                  if (minimumNotionalMicros !== undefined && referenceNotionalMicros < minimumNotionalMicros) {
+                    return Result.succeed(inputs)
+                  }
+                  return pipe(
+                    makeFillTerms(
+                      'buy',
+                      quantityMicros,
+                      prices[buy.symbol],
+                      protocol.executionModel,
+                      costMultiplierMicros,
+                    ),
+                    Result.map((terms) => [
+                      ...inputs,
+                      { side: 'buy' as const, quantityMicros, notionalMicros: terms.notionalMicros },
+                    ]),
+                  )
+                }),
+              )
+            }),
+          ),
+        ),
+      ),
+    Result.succeed([]),
+  )
+
+const replayBuysFitCash = (
+  buys: readonly ReferenceBuyCandidate[],
+  scalePpm: bigint,
+  prices: Readonly<Record<string, bigint>>,
+  protocol: SimulationProtocol,
+  costMultiplierMicros: bigint,
+  availableCashMicros: bigint,
+  minimumNotionalMicros?: bigint,
+): ReferenceComputation<boolean> =>
+  pipe(
+    replayBuyFeeInputs(buys, scalePpm, prices, protocol, costMultiplierMicros, minimumNotionalMicros),
+    Result.flatMap((inputs) =>
+      pipe(
+        calculateSessionFees(inputs, protocol.executionModel, costMultiplierMicros),
+        Result.map(
+          (fees) =>
+            inputs.reduce((total, candidate) => total + candidate.notionalMicros, 0n) + fees.totalMicros <=
+            availableCashMicros,
+        ),
+      ),
+    ),
+  )
+
 const replay = (
   sessions: readonly Session[],
   targets: readonly Target[],
@@ -513,9 +656,13 @@ const replay = (
   costMultiplierMicros: bigint,
   runId: string,
   retainTrace: boolean,
-): Replay => {
+): ReferenceComputation<Replay> => {
   if (protocol.executionModel.schemaVersion !== 'bayn.execution-model.v2') {
-    throw new Error('reference replay requires the causal bayn.execution-model.v2 contract')
+    return Result.fail({
+      _tag: 'UnsupportedReferenceExecutionModel',
+      actual: protocol.executionModel.schemaVersion,
+      required: 'bayn.execution-model.v2',
+    })
   }
   const targetBySession = new Map(targets.map((target) => [target.executionIndex, target]))
   const positions = new Map<string, Position>()
@@ -548,8 +695,12 @@ const replay = (
     const planningCashSnapshot = cash
 
     if (previousDate !== undefined) {
-      const elapsedDays = elapsedCalendarDays(previousDate, session.date)
-      const accrued = accrueCashYield(cash, elapsedDays, protocol.executionModel)
+      const elapsedDaysResult = elapsedCalendarDays(previousDate, session.date)
+      if (Result.isFailure(elapsedDaysResult)) return Result.fail(elapsedDaysResult.failure)
+      const elapsedDays = elapsedDaysResult.success
+      const accruedResult = accrueCashYield(cash, elapsedDays, protocol.executionModel)
+      if (Result.isFailure(accruedResult)) return Result.fail(accruedResult.failure)
+      const accrued = accruedResult.success
       if (accrued > 0n) {
         cash += accrued
         cashYield += accrued
@@ -589,31 +740,19 @@ const replay = (
         decisions.push({ ...target.plan, decisionId: decision.id, executionDate: decision.executionDate })
       }
 
-      const planPrices = Object.fromEntries(
-        protocol.universe.map((symbol) => [
-          symbol,
-          referencePriceMicros(sessions[target.signalIndex].bars[symbol].close, protocol.executionModel),
-        ]),
-      ) as Readonly<Record<string, bigint>>
-      const fillPrices = Object.fromEntries(
-        protocol.universe.map((symbol) => [
-          symbol,
-          referencePriceMicros(session.bars[symbol].open, protocol.executionModel),
-        ]),
-      ) as Readonly<Record<string, bigint>>
+      const planPricesResult = replayPrices(sessions[target.signalIndex], protocol, (bar) => bar.close)
+      if (Result.isFailure(planPricesResult)) return Result.fail(planPricesResult.failure)
+      const planPrices = planPricesResult.success
+      const fillPricesResult = replayPrices(session, protocol, (bar) => bar.open)
+      if (Result.isFailure(fillPricesResult)) return Result.fail(fillPricesResult.failure)
+      const fillPrices = fillPricesResult.success
       const cashAvailableWhenPlanned = planningCashSnapshot
-      const planEquity =
-        planningCashSnapshot +
-        protocol.universe.reduce(
-          (sum, symbol) => sum + notionalMicros(positions.get(symbol)?.quantityMicros ?? 0n, planPrices[symbol]),
-          0n,
-        )
-      const desired = Object.fromEntries(
-        protocol.universe.map((symbol) => [
-          symbol,
-          desiredQuantityMicros(planEquity, target.weights[symbol], planPrices[symbol], protocol.executionModel),
-        ]),
-      ) as Readonly<Record<string, bigint>>
+      const plannedPositionValue = replayPositionValue(planPrices, positions, protocol)
+      if (Result.isFailure(plannedPositionValue)) return Result.fail(plannedPositionValue.failure)
+      const planEquity = planningCashSnapshot + plannedPositionValue.success
+      const desiredResult = replayDesiredQuantities(planEquity, target.weights, planPrices, protocol)
+      if (Result.isFailure(desiredResult)) return Result.fail(desiredResult.failure)
+      const desired = desiredResult.success
       const sessionFills: FillEvent[] = []
 
       const sellPlans = [...protocol.universe]
@@ -630,118 +769,109 @@ const replay = (
           return { symbol, quantityMicros: desired[symbol] > held ? desired[symbol] - held : 0n }
         })
         .filter((candidate) => candidate.quantityMicros > 0n)
-      const planFitsCash = (scale: bigint): boolean => {
-        const candidates: FeeInput[] = []
-        for (const candidate of buyPlans) {
-          const quantity = scaleQuantityMicros(candidate.quantityMicros, scale, protocol.executionModel)
-          if (
-            quantity === 0n ||
-            notionalMicros(quantity, planPrices[candidate.symbol]) <
-              BigInt(protocol.executionModel.precision.minimumBuyNotionalMicros)
-          ) {
-            continue
-          }
-          const terms = makeFillTerms(
-            'buy',
-            quantity,
-            planPrices[candidate.symbol],
-            protocol.executionModel,
-            costMultiplierMicros,
-          )
-          candidates.push({ side: 'buy', quantityMicros: quantity, notionalMicros: terms.notionalMicros })
-        }
-        const candidateFees = calculateSessionFees(candidates, protocol.executionModel, costMultiplierMicros)
-        return (
-          candidates.reduce((total, candidate) => total + candidate.notionalMicros, 0n) + candidateFees.totalMicros <=
-          cashAvailableWhenPlanned
-        )
-      }
+      const minimumBuyNotionalMicros = BigInt(protocol.executionModel.precision.minimumBuyNotionalMicros)
       let acceptedPlanScale = 0n
       let upperPlanScale = ppm
       while (acceptedPlanScale < upperPlanScale) {
         const midpoint = (acceptedPlanScale + upperPlanScale + 1n) / 2n
-        if (planFitsCash(midpoint)) acceptedPlanScale = midpoint
+        const fitsCash = replayBuysFitCash(
+          buyPlans,
+          midpoint,
+          planPrices,
+          protocol,
+          costMultiplierMicros,
+          cashAvailableWhenPlanned,
+          minimumBuyNotionalMicros,
+        )
+        if (Result.isFailure(fitsCash)) return Result.fail(fitsCash.failure)
+        if (fitsCash.success) acceptedPlanScale = midpoint
         else upperPlanScale = midpoint - 1n
       }
-      const sellOrders = sellPlans.map((candidate) =>
-        order(
+      const sellOrdersResult = Result.all(
+        sellPlans.map((candidate) =>
+          order(
+            runId,
+            decision,
+            session.date,
+            candidate.symbol,
+            'sell',
+            candidate.quantityMicros,
+            fillPrices[candidate.symbol],
+            protocol,
+          ),
+        ),
+      )
+      if (Result.isFailure(sellOrdersResult)) return Result.fail(sellOrdersResult.failure)
+      const sellOrders = sellOrdersResult.success
+      const unboundedBuyOrders: SimulatedOrder[] = []
+      for (const candidate of buyPlans) {
+        const requested = scaleQuantityMicros(candidate.quantityMicros, acceptedPlanScale, protocol.executionModel)
+        if (Result.isFailure(requested)) return Result.fail(requested.failure)
+        if (requested.success === 0n) continue
+        const requestedNotional = notionalMicros(requested.success, planPrices[candidate.symbol])
+        if (Result.isFailure(requestedNotional)) return Result.fail(requestedNotional.failure)
+        if (requestedNotional.success < minimumBuyNotionalMicros) continue
+        const simulatedOrder = order(
           runId,
           decision,
           session.date,
           candidate.symbol,
-          'sell',
-          candidate.quantityMicros,
+          'buy',
+          requested.success,
           fillPrices[candidate.symbol],
           protocol,
-        ),
-      )
-      const unboundedBuyOrders = buyPlans.flatMap((candidate): SimulatedOrder[] => {
-        const requested = scaleQuantityMicros(candidate.quantityMicros, acceptedPlanScale, protocol.executionModel)
-        return requested === 0n ||
-          notionalMicros(requested, planPrices[candidate.symbol]) <
-            BigInt(protocol.executionModel.precision.minimumBuyNotionalMicros)
-          ? []
-          : [
-              order(
-                runId,
-                decision,
-                session.date,
-                candidate.symbol,
-                'buy',
-                requested,
-                fillPrices[candidate.symbol],
-                protocol,
-              ),
-            ]
-      })
-      const fillsFitPlannedCash = (scale: bigint): boolean => {
-        const candidates: FeeInput[] = []
-        for (const candidate of unboundedBuyOrders) {
-          const quantity = scaleQuantityMicros(BigInt(candidate.filledQuantityMicros), scale, protocol.executionModel)
-          if (quantity === 0n) continue
-          const terms = makeFillTerms(
-            'buy',
-            quantity,
-            fillPrices[candidate.symbol],
-            protocol.executionModel,
-            costMultiplierMicros,
-          )
-          candidates.push({ side: 'buy', quantityMicros: quantity, notionalMicros: terms.notionalMicros })
-        }
-        const candidateFees = calculateSessionFees(candidates, protocol.executionModel, costMultiplierMicros)
-        return (
-          candidates.reduce((total, candidate) => total + candidate.notionalMicros, 0n) + candidateFees.totalMicros <=
-          cashAvailableWhenPlanned
         )
+        if (Result.isFailure(simulatedOrder)) return Result.fail(simulatedOrder.failure)
+        unboundedBuyOrders.push(simulatedOrder.success)
       }
+      const unboundedFillCandidates = unboundedBuyOrders.map((candidate) => ({
+        symbol: candidate.symbol,
+        quantityMicros: BigInt(candidate.filledQuantityMicros),
+      }))
       let acceptedFillScale = 0n
       let upperFillScale = ppm
       while (acceptedFillScale < upperFillScale) {
         const midpoint = (acceptedFillScale + upperFillScale + 1n) / 2n
-        if (fillsFitPlannedCash(midpoint)) acceptedFillScale = midpoint
+        const fitsCash = replayBuysFitCash(
+          unboundedFillCandidates,
+          midpoint,
+          fillPrices,
+          protocol,
+          costMultiplierMicros,
+          cashAvailableWhenPlanned,
+        )
+        if (Result.isFailure(fitsCash)) return Result.fail(fitsCash.failure)
+        if (fitsCash.success) acceptedFillScale = midpoint
         else upperFillScale = midpoint - 1n
       }
-      const buyOrders = unboundedBuyOrders.map((candidate) =>
-        restrictReferenceBuyFill(
-          runId,
-          candidate,
-          scaleQuantityMicros(BigInt(candidate.filledQuantityMicros), acceptedFillScale, protocol.executionModel),
-        ),
-      )
+      const buyOrders: SimulatedOrder[] = []
+      for (const candidate of unboundedBuyOrders) {
+        const permittedQuantity = scaleQuantityMicros(
+          BigInt(candidate.filledQuantityMicros),
+          acceptedFillScale,
+          protocol.executionModel,
+        )
+        if (Result.isFailure(permittedQuantity)) return Result.fail(permittedQuantity.failure)
+        buyOrders.push(restrictReferenceBuyFill(runId, candidate, permittedQuantity.success))
+      }
 
       for (const simulatedOrder of sellOrders) {
         if (retainTrace) orders.push(simulatedOrder)
         const position = positions.get(simulatedOrder.symbol) ?? { quantityMicros: 0n, costBasisMicros: 0n }
         const quantity = BigInt(simulatedOrder.filledQuantityMicros)
         if (quantity === 0n) continue
-        const terms = makeFillTerms(
+        const termsResult = makeFillTerms(
           'sell',
           quantity,
           fillPrices[simulatedOrder.symbol],
           protocol.executionModel,
           costMultiplierMicros,
         )
-        const costBasis = saleCostBasisMicros(position.costBasisMicros, quantity, position.quantityMicros)
+        if (Result.isFailure(termsResult)) return Result.fail(termsResult.failure)
+        const terms = termsResult.success
+        const costBasisResult = saleCostBasisMicros(position.costBasisMicros, quantity, position.quantityMicros)
+        if (Result.isFailure(costBasisResult)) return Result.fail(costBasisResult.failure)
+        const costBasis = costBasisResult.success
         const event = fill(runId, decision, simulatedOrder, terms, costBasis)
         cash += terms.notionalMicros
         turnover += terms.notionalMicros
@@ -761,13 +891,15 @@ const replay = (
         if (retainTrace) orders.push(simulatedOrder)
         const quantity = BigInt(simulatedOrder.filledQuantityMicros)
         if (quantity === 0n) continue
-        const terms = makeFillTerms(
+        const termsResult = makeFillTerms(
           'buy',
           quantity,
           fillPrices[simulatedOrder.symbol],
           protocol.executionModel,
           costMultiplierMicros,
         )
+        if (Result.isFailure(termsResult)) return Result.fail(termsResult.failure)
+        const terms = termsResult.success
         const event = fill(runId, decision, simulatedOrder, terms, terms.notionalMicros)
         cash -= terms.notionalMicros
         turnover += terms.notionalMicros
@@ -784,7 +916,7 @@ const replay = (
         }
       }
 
-      const fee = calculateSessionFees(
+      const feeResult = calculateSessionFees(
         sessionFills.map((event) => ({
           side: event.side,
           quantityMicros: BigInt(event.quantityMicros),
@@ -793,6 +925,8 @@ const replay = (
         protocol.executionModel,
         costMultiplierMicros,
       )
+      if (Result.isFailure(feeResult)) return Result.fail(feeResult.failure)
+      const fee = feeResult.success
       if (fee.totalMicros > 0n) {
         cash -= fee.totalMicros
         fees += fee.totalMicros
@@ -817,18 +951,12 @@ const replay = (
       if (cash < 0n) throw new Error('reference replay spent unavailable cash')
     }
 
-    const closes = Object.fromEntries(
-      protocol.universe.map((symbol) => [
-        symbol,
-        referencePriceMicros(session.bars[symbol].close, protocol.executionModel),
-      ]),
-    ) as Readonly<Record<string, bigint>>
-    const closingEquity =
-      cash +
-      protocol.universe.reduce(
-        (sum, symbol) => sum + notionalMicros(positions.get(symbol)?.quantityMicros ?? 0n, closes[symbol]),
-        0n,
-      )
+    const closesResult = replayPrices(session, protocol, (bar) => bar.close)
+    if (Result.isFailure(closesResult)) return Result.fail(closesResult.failure)
+    const closes = closesResult.success
+    const closingPositionValue = replayPositionValue(closes, positions, protocol)
+    if (Result.isFailure(closingPositionValue)) return Result.fail(closingPositionValue.failure)
+    const closingEquity = cash + closingPositionValue.success
     equity.push(closingEquity)
     peakEquity = peakEquity > closingEquity ? peakEquity : closingEquity
     const point: DailyPerformancePoint = {
@@ -850,25 +978,29 @@ const replay = (
     }
     daily.push(point)
     if (retainTrace) {
+      const markedPositions: DailyPositionMark['positions'][number][] = []
+      for (const symbol of [...protocol.universe].sort()) {
+        const position = positions.get(symbol) ?? { quantityMicros: 0n, costBasisMicros: 0n }
+        const marketValue = notionalMicros(position.quantityMicros, closes[symbol])
+        if (Result.isFailure(marketValue)) return Result.fail(marketValue.failure)
+        markedPositions.push({
+          symbol,
+          quantityMicros: position.quantityMicros.toString(),
+          costBasisMicros: position.costBasisMicros.toString(),
+          priceMicros: closes[symbol].toString(),
+          marketValueMicros: marketValue.success.toString(),
+        })
+      }
       marks.push({
         ...point,
         cashMicros: cash.toString(),
-        positions: [...protocol.universe].sort().map((symbol) => {
-          const position = positions.get(symbol) ?? { quantityMicros: 0n, costBasisMicros: 0n }
-          return {
-            symbol,
-            quantityMicros: position.quantityMicros.toString(),
-            costBasisMicros: position.costBasisMicros.toString(),
-            priceMicros: closes[symbol].toString(),
-            marketValueMicros: notionalMicros(position.quantityMicros, closes[symbol]).toString(),
-          }
-        }),
+        positions: markedPositions,
       })
     }
     previousEquity = closingEquity
   }
 
-  return {
+  return Result.succeed({
     metrics: metrics(equity, turnover, fees, spread, slippage, cashYield, initial),
     events,
     decisions,
@@ -883,7 +1015,7 @@ const replay = (
           dailyMarks: marks,
         }
       : null,
-  }
+  })
 }
 
 const verdict = (
@@ -949,7 +1081,7 @@ export const evaluateReference = (
   manifest: InputManifest,
   protocol: Protocol,
   provenance: RuntimeProvenance,
-): ReferenceEvaluation => {
+): ReferenceComputation<ReferenceEvaluation> => {
   const sessions = align(bars, manifest, protocol.universe)
   const dates = sessions.map((session) => session.date)
   const requiredHistory = riskBalancedHistoryLength(protocol)
@@ -1025,19 +1157,24 @@ export const evaluateReference = (
     runId,
     false,
   )
-  return {
-    runId,
-    protocolHash,
-    strategy,
-    buyAndHold,
-    directVolTiming,
-    doubleCostStrategy,
-    verdict: verdict(
-      strategy.metrics,
-      buyAndHold.metrics,
-      directVolTiming.metrics,
-      doubleCostStrategy.metrics,
-      protocol,
+  return pipe(
+    Result.all({ strategy, buyAndHold, directVolTiming, doubleCostStrategy }),
+    Result.map(
+      ({ strategy, buyAndHold, directVolTiming, doubleCostStrategy }): ReferenceEvaluation => ({
+        runId,
+        protocolHash,
+        strategy,
+        buyAndHold,
+        directVolTiming,
+        doubleCostStrategy,
+        verdict: verdict(
+          strategy.metrics,
+          buyAndHold.metrics,
+          directVolTiming.metrics,
+          doubleCostStrategy.metrics,
+          protocol,
+        ),
+      }),
     ),
-  }
+  )
 }

--- a/services/bayn/src/execution-model.test.ts
+++ b/services/bayn/src/execution-model.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'bun:test'
+import { Result } from 'effect'
 
 import {
   MICROS,
@@ -6,18 +7,33 @@ import {
   calculateSessionFees,
   defaultExecutionModel,
   desiredQuantityMicros,
+  elapsedCalendarDays,
   makeFillTerms,
   makeOrderOutcome,
   notionalMicros,
   referencePriceMicros,
   saleCostBasisMicros,
+  scaleQuantityMicros,
+  type ExecutionModelFailure,
 } from './execution-model'
+
+const success = <A>(result: Result.Result<A, ExecutionModelFailure>): A => {
+  expect(Result.isSuccess(result)).toBe(true)
+  if (Result.isFailure(result)) throw new Error(result.failure._tag)
+  return result.success
+}
+
+const failure = <A>(result: Result.Result<A, ExecutionModelFailure>): ExecutionModelFailure => {
+  expect(Result.isFailure(result)).toBe(true)
+  if (Result.isSuccess(result)) throw new Error('expected execution-model failure')
+  return result.failure
+}
 
 describe('explicit paper execution model', () => {
   test('rounds price adversely and separates spread from slippage', () => {
-    const reference = referencePriceMicros(100, defaultExecutionModel)
-    const buy = makeFillTerms('buy', MICROS, reference, defaultExecutionModel, MICROS)
-    const sell = makeFillTerms('sell', MICROS, reference, defaultExecutionModel, MICROS)
+    const reference = success(referencePriceMicros(100, defaultExecutionModel))
+    const buy = success(makeFillTerms('buy', MICROS, reference, defaultExecutionModel, MICROS))
+    const sell = success(makeFillTerms('sell', MICROS, reference, defaultExecutionModel, MICROS))
 
     expect(buy).toMatchObject({
       referencePriceMicros: 100_000_000n,
@@ -31,17 +47,22 @@ describe('explicit paper execution model', () => {
       spreadCostMicros: 25_000n,
       slippageCostMicros: 25_000n,
     })
-    expect(referencePriceMicros(100.123456, defaultExecutionModel)).toBe(100_123_500n)
+    expect(success(referencePriceMicros(100.123456, defaultExecutionModel))).toBe(100_123_500n)
   })
 
-  test('preserves half-up arithmetic and its public error contract', () => {
+  test('preserves half-up arithmetic and its exact failure data', () => {
     const u128Maximum = (1n << 128n) - 1n
 
-    expect(referencePriceMicros(100.12345, defaultExecutionModel)).toBe(100_123_500n)
-    expect(notionalMicros(500_000n, 100_000_001n)).toBe(50_000_001n)
-    expect(saleCostBasisMicros(1n, 1n, 2n)).toBe(1n)
-    expect(notionalMicros(u128Maximum, 1_000_001n)).toBe(340_282_707_203_305_384_401_838_070_806_375_643_223n)
-    expect(() => notionalMicros(-1n, 1n)).toThrow('roundDiv requires non-negative numerator and denominator')
+    expect(success(referencePriceMicros(100.12345, defaultExecutionModel))).toBe(100_123_500n)
+    expect(success(notionalMicros(500_000n, 100_000_001n))).toBe(50_000_001n)
+    expect(success(saleCostBasisMicros(1n, 1n, 2n))).toBe(1n)
+    expect(success(notionalMicros(u128Maximum, 1_000_001n))).toBe(340_282_707_203_305_384_401_838_070_806_375_643_223n)
+    expect(failure(notionalMicros(-1n, 1n))).toEqual({
+      _tag: 'NegativeUnsignedRoundHalfUpNumerator',
+      numerator: -1n,
+      denominator: MICROS,
+      minimumNumerator: 0n,
+    })
   })
 
   test('makes full, partial, and rejected outcomes deterministic', () => {
@@ -60,36 +81,40 @@ describe('explicit paper execution model', () => {
       referencePriceMicros: 100_000_000n,
     }
 
-    expect(makeOrderOutcome({ ...input, model: fullModel })).toMatchObject({
+    expect(success(makeOrderOutcome({ ...input, model: fullModel }))).toMatchObject({
       filledQuantityMicros: 2_000_000n,
       status: 'filled',
       unfilledRemainder: 'none',
     })
-    const partial = makeOrderOutcome({ ...input, model: partialModel })
-    expect(partial).toEqual(makeOrderOutcome({ ...input, model: partialModel }))
+    const partial = success(makeOrderOutcome({ ...input, model: partialModel }))
+    expect(partial).toEqual(success(makeOrderOutcome({ ...input, model: partialModel })))
     expect(partial).toMatchObject({
       filledQuantityMicros: 1_000_000n,
       status: 'partially-filled',
       unfilledRemainder: 'canceled',
     })
     expect(
-      makeOrderOutcome({
-        ...input,
-        requestedQuantityMicros: 5_000n,
-        referencePriceMicros: 100_000_000n,
-        model: fullModel,
-      }),
+      success(
+        makeOrderOutcome({
+          ...input,
+          requestedQuantityMicros: 5_000n,
+          referencePriceMicros: 100_000_000n,
+          model: fullModel,
+        }),
+      ),
     ).toMatchObject({ status: 'rejected', rejectionReason: 'below-minimum-buy-notional' })
   })
 
   test('aggregates regulatory fees by session, applies caps, and rounds each type upward to a cent', () => {
-    const fees = calculateSessionFees(
-      [
-        { side: 'buy', quantityMicros: 1_000_000n, notionalMicros: 100_000_000n },
-        { side: 'sell', quantityMicros: 10_000_000n, notionalMicros: 1_000_000_000n },
-      ],
-      defaultExecutionModel,
-      MICROS,
+    const fees = success(
+      calculateSessionFees(
+        [
+          { side: 'buy', quantityMicros: 1_000_000n, notionalMicros: 100_000_000n },
+          { side: 'sell', quantityMicros: 10_000_000n, notionalMicros: 1_000_000_000n },
+        ],
+        defaultExecutionModel,
+        MICROS,
+      ),
     )
     expect(fees).toEqual({
       commissionMicros: 0n,
@@ -99,53 +124,41 @@ describe('explicit paper execution model', () => {
       totalMicros: 50_000n,
     })
 
-    const capped = calculateSessionFees(
-      [{ side: 'sell', quantityMicros: 100_000_000n * MICROS, notionalMicros: 100_000_000n * MICROS }],
-      defaultExecutionModel,
-      MICROS,
+    const capped = success(
+      calculateSessionFees(
+        [{ side: 'sell', quantityMicros: 100_000_000n * MICROS, notionalMicros: 100_000_000n * MICROS }],
+        defaultExecutionModel,
+        MICROS,
+      ),
     )
     expect(capped.tafMicros).toBe(9_790_000n)
   })
 
   test('keeps cash yield explicit for both zero and nonzero rates', () => {
-    expect(accrueCashYield(1_000n * MICROS, 3, defaultExecutionModel)).toBe(0n)
+    expect(success(accrueCashYield(1_000n * MICROS, 3, defaultExecutionModel))).toBe(0n)
     const yielding = {
       ...defaultExecutionModel,
       cash: { ...defaultExecutionModel.cash, annualYieldBps: 500 },
     }
-    expect(accrueCashYield(1_000n * MICROS, 3, yielding)).toBe(410_958n)
+    expect(success(accrueCashYield(1_000n * MICROS, 3, yielding))).toBe(410_958n)
   })
 
   test('accepts exact twelve-decimal weights despite binary floating-point representation', () => {
-    expect(desiredQuantityMicros(1_000n * MICROS, 0.123_456_789_012, 100n * MICROS, defaultExecutionModel)).toBe(
-      1_234_567n,
-    )
-    expect(() =>
-      desiredQuantityMicros(1_000n * MICROS, 0.123_456_789_012_3, 100n * MICROS, defaultExecutionModel),
-    ).toThrow('target weight exceeds fixed-point precision')
+    expect(
+      success(desiredQuantityMicros(1_000n * MICROS, 0.123_456_789_012, 100n * MICROS, defaultExecutionModel)),
+    ).toBe(1_234_567n)
+    expect(
+      failure(desiredQuantityMicros(1_000n * MICROS, 0.123_456_789_012_3, 100n * MICROS, defaultExecutionModel)),
+    ).toMatchObject({
+      _tag: 'InvalidFixedPointNumber',
+      field: 'target weight',
+      reason: 'precision-exceeded',
+    })
   })
 
   test('doubles declared execution costs without changing fill selection', () => {
     const identity = { decisionId: 'a'.repeat(64), symbol: 'SPY', side: 'sell' }
-    const outcome = makeOrderOutcome({
-      identity,
-      side: 'sell',
-      requestedQuantityMicros: 2_000_000n,
-      referencePriceMicros: 100_000_000n,
-      model: defaultExecutionModel,
-    })
-    const base = makeFillTerms('sell', outcome.filledQuantityMicros, 100_000_000n, defaultExecutionModel, MICROS)
-    const doubled = makeFillTerms(
-      'sell',
-      outcome.filledQuantityMicros,
-      100_000_000n,
-      defaultExecutionModel,
-      2n * MICROS,
-    )
-
-    expect(doubled.spreadCostMicros).toBe(2n * base.spreadCostMicros)
-    expect(doubled.slippageCostMicros).toBe(2n * base.slippageCostMicros)
-    expect(
+    const outcome = success(
       makeOrderOutcome({
         identity,
         side: 'sell',
@@ -153,6 +166,75 @@ describe('explicit paper execution model', () => {
         referencePriceMicros: 100_000_000n,
         model: defaultExecutionModel,
       }),
+    )
+    const base = success(
+      makeFillTerms('sell', outcome.filledQuantityMicros, 100_000_000n, defaultExecutionModel, MICROS),
+    )
+    const doubled = success(
+      makeFillTerms('sell', outcome.filledQuantityMicros, 100_000_000n, defaultExecutionModel, 2n * MICROS),
+    )
+
+    expect(doubled.spreadCostMicros).toBe(2n * base.spreadCostMicros)
+    expect(doubled.slippageCostMicros).toBe(2n * base.slippageCostMicros)
+    expect(
+      success(
+        makeOrderOutcome({
+          identity,
+          side: 'sell',
+          requestedQuantityMicros: 2_000_000n,
+          referencePriceMicros: 100_000_000n,
+          model: defaultExecutionModel,
+        }),
+      ),
     ).toEqual(outcome)
+  })
+
+  test('returns discriminated failures for every invalid public decision family', () => {
+    expect(failure(referencePriceMicros(Number.NaN, defaultExecutionModel))).toMatchObject({
+      _tag: 'InvalidReferencePrice',
+      reason: 'not-positive',
+    })
+    expect(failure(makeFillTerms('buy', 0n, MICROS, defaultExecutionModel, MICROS))).toMatchObject({
+      _tag: 'InvalidFillTerms',
+      reason: 'invalid-quantity-or-price',
+    })
+    expect(failure(calculateSessionFees([], defaultExecutionModel, 0n))).toMatchObject({
+      _tag: 'InvalidFeeCostMultiplier',
+    })
+    expect(failure(accrueCashYield(-1n, 1, defaultExecutionModel))).toMatchObject({
+      _tag: 'InvalidCashYield',
+      reason: 'negative-cash',
+    })
+    expect(failure(elapsedCalendarDays('2026-01-02', '2026-01-01'))).toEqual({
+      _tag: 'InvalidCashAccrualPeriod',
+      from: '2026-01-02',
+      to: '2026-01-01',
+    })
+    expect(failure(saleCostBasisMicros(100n, 2n, 1n))).toMatchObject({
+      _tag: 'InvalidSaleCostBasis',
+      reason: 'quantity-exceeds-position',
+    })
+    expect(failure(scaleQuantityMicros(1n, 1_000_001n, defaultExecutionModel))).toMatchObject({
+      _tag: 'InvalidQuantityScale',
+    })
+  })
+
+  test('retains canonicalization failure evidence without throwing', () => {
+    const partialModel = {
+      ...defaultExecutionModel,
+      partialFills: { ...defaultExecutionModel.partialFills, probabilityPpm: 1_000_000 },
+    }
+    const result = makeOrderOutcome({
+      identity: { invalid: 1n },
+      side: 'sell',
+      requestedQuantityMicros: MICROS,
+      referencePriceMicros: 100n * MICROS,
+      model: partialModel,
+    })
+
+    expect(failure(result)).toMatchObject({
+      _tag: 'OrderOutcomeCanonicalizationFailed',
+      identity: { invalid: 1n },
+    })
   })
 })

--- a/services/bayn/src/execution-model.ts
+++ b/services/bayn/src/execution-model.ts
@@ -1,8 +1,8 @@
-import { Result } from 'effect'
+import { pipe, Result } from 'effect'
 
 import { canonicalHashV1 } from './hash'
 import type { ExecutionModel, IsoDate, OrderRejectionReason, OrderStatus } from './types'
-import { roundUnsignedHalfUp } from './unsigned-round-half-up'
+import { roundUnsignedHalfUp, type UnsignedRoundHalfUpFailure } from './unsigned-round-half-up'
 
 export const MICROS = 1_000_000n
 const PPM = 1_000_000n
@@ -59,61 +59,208 @@ export const defaultExecutionModel: ExecutionModel = {
   doubleCostMultiplier: 2,
 }
 
-const ensureUnsigned = (value: string, name: string): bigint => {
-  if (!/^[0-9]+$/.test(value)) throw new Error(`${name} must be an unsigned integer string`)
-  return BigInt(value)
+type FixedPointFailureReason = 'negative' | 'not-finite' | 'precision-exceeded'
+
+export type ExecutionModelFailure =
+  | {
+      readonly _tag: 'InvalidUnsignedInteger'
+      readonly field: string
+      readonly value: string
+      readonly minimum: bigint
+    }
+  | {
+      readonly _tag: 'InvalidFixedPointNumber'
+      readonly field: string
+      readonly value: number
+      readonly scale: number
+      readonly reason: FixedPointFailureReason
+    }
+  | {
+      readonly _tag: 'InvalidIntegerNumber'
+      readonly field: string
+      readonly value: number
+      readonly minimum: number
+      readonly maximum: number
+    }
+  | {
+      readonly _tag: 'InvalidCeilingDivision'
+      readonly numerator: bigint
+      readonly denominator: bigint
+      readonly minimumNumerator: 0n
+      readonly minimumDenominator: 1n
+    }
+  | UnsignedRoundHalfUpFailure
+  | {
+      readonly _tag: 'InvalidQuantization'
+      readonly operation: 'down'
+      readonly value: bigint
+      readonly increment: bigint
+      readonly minimumValue: 0n
+      readonly minimumIncrement: 1n
+    }
+  | {
+      readonly _tag: 'InvalidReferencePrice'
+      readonly price: number
+      readonly reason: 'not-positive' | 'rounded-to-zero'
+    }
+  | {
+      readonly _tag: 'InvalidDesiredQuantity'
+      readonly equityMicros: bigint
+      readonly weight: number
+      readonly priceMicros: bigint
+      readonly reason: 'invalid-equity-or-price' | 'weight-exceeds-one'
+    }
+  | {
+      readonly _tag: 'InvalidFillTerms'
+      readonly side: 'buy' | 'sell'
+      readonly quantityMicros: bigint
+      readonly referencePriceMicros: bigint
+      readonly costMultiplierMicros: bigint
+      readonly reason: 'invalid-quantity-or-price' | 'invalid-cost-multiplier' | 'costs-consume-reference-price'
+    }
+  | {
+      readonly _tag: 'OrderOutcomeCanonicalizationFailed'
+      readonly identity: unknown
+      readonly cause: unknown
+    }
+  | {
+      readonly _tag: 'InvalidFeeCostMultiplier'
+      readonly costMultiplierMicros: bigint
+      readonly minimum: 1n
+    }
+  | {
+      readonly _tag: 'InvalidCashYield'
+      readonly cashMicros: bigint
+      readonly elapsedDays: number
+      readonly reason: 'negative-cash' | 'invalid-elapsed-days'
+    }
+  | {
+      readonly _tag: 'InvalidCashAccrualPeriod'
+      readonly from: IsoDate
+      readonly to: IsoDate
+    }
+  | {
+      readonly _tag: 'InvalidSaleCostBasis'
+      readonly positionCostBasisMicros: bigint
+      readonly soldQuantityMicros: bigint
+      readonly positionQuantityMicros: bigint
+      readonly reason: 'invalid-position' | 'quantity-exceeds-position'
+    }
+  | {
+      readonly _tag: 'InvalidQuantityScale'
+      readonly quantityMicros: bigint
+      readonly scalePpm: bigint
+      readonly minimumScalePpm: 0n
+      readonly maximumScalePpm: 1_000_000n
+    }
+
+type ExecutionResult<A> = Result.Result<A, ExecutionModelFailure>
+
+const fail = <A>(failure: ExecutionModelFailure): ExecutionResult<A> => Result.fail(failure)
+
+const ensureUnsigned = (value: string, field: string, minimum = 0n): ExecutionResult<bigint> => {
+  if (!/^[0-9]+$/.test(value)) {
+    return fail({ _tag: 'InvalidUnsignedInteger', field, value, minimum })
+  }
+  const parsed = BigInt(value)
+  return parsed < minimum ? fail({ _tag: 'InvalidUnsignedInteger', field, value, minimum }) : Result.succeed(parsed)
 }
 
-const scaledNumber = (value: number, name: string, scale = Number(MICROS)): bigint => {
-  if (!Number.isFinite(value) || value < 0) throw new Error(`${name} must be finite and non-negative`)
+const scaledNumber = (value: number, field: string, scale = Number(MICROS)): ExecutionResult<bigint> => {
+  if (!Number.isFinite(value)) {
+    return fail({ _tag: 'InvalidFixedPointNumber', field, value, scale, reason: 'not-finite' })
+  }
+  if (value < 0) {
+    return fail({ _tag: 'InvalidFixedPointNumber', field, value, scale, reason: 'negative' })
+  }
   const scaled = value * scale
   const rounded = Math.round(scaled)
   const floatingPointTolerance = Math.max(1e-9, Number.EPSILON * Math.abs(scaled) * 4)
-  if (!Number.isSafeInteger(rounded) || Math.abs(scaled - rounded) > floatingPointTolerance) {
-    throw new Error(`${name} exceeds fixed-point precision`)
+  return !Number.isSafeInteger(rounded) || Math.abs(scaled - rounded) > floatingPointTolerance
+    ? fail({ _tag: 'InvalidFixedPointNumber', field, value, scale, reason: 'precision-exceeded' })
+    : Result.succeed(BigInt(rounded))
+}
+
+const integerNumber = (value: number, field: string, minimum: number, maximum: number): ExecutionResult<bigint> =>
+  Number.isSafeInteger(value) && value >= minimum && value <= maximum
+    ? Result.succeed(BigInt(value))
+    : fail({ _tag: 'InvalidIntegerNumber', field, value, minimum, maximum })
+
+const ceilDiv = (numerator: bigint, denominator: bigint): ExecutionResult<bigint> => {
+  if (numerator < 0n || denominator <= 0n) {
+    return fail({
+      _tag: 'InvalidCeilingDivision',
+      numerator,
+      denominator,
+      minimumNumerator: 0n,
+      minimumDenominator: 1n,
+    })
   }
-  return BigInt(rounded)
+  return Result.succeed(numerator === 0n ? 0n : (numerator - 1n) / denominator + 1n)
 }
 
-const ceilDiv = (numerator: bigint, denominator: bigint): bigint => {
-  if (numerator < 0n || denominator <= 0n) throw new Error('ceilDiv requires non-negative numerator and denominator')
-  return numerator === 0n ? 0n : (numerator - 1n) / denominator + 1n
-}
+const roundDiv = (numerator: bigint, denominator: bigint): ExecutionResult<bigint> =>
+  roundUnsignedHalfUp(numerator, denominator)
 
-const roundDiv = (numerator: bigint, denominator: bigint): bigint => {
-  const rounded = roundUnsignedHalfUp(numerator, denominator)
-  if (Result.isFailure(rounded)) throw new Error('roundDiv requires non-negative numerator and denominator')
-  return rounded.success
-}
+const quantizeDown = (value: bigint, increment: bigint): ExecutionResult<bigint> =>
+  value < 0n || increment <= 0n
+    ? fail({
+        _tag: 'InvalidQuantization',
+        operation: 'down',
+        value,
+        increment,
+        minimumValue: 0n,
+        minimumIncrement: 1n,
+      })
+    : Result.succeed((value / increment) * increment)
 
-const quantizeDown = (value: bigint, increment: bigint): bigint => {
-  if (value < 0n || increment <= 0n) throw new Error('quantization requires non-negative value and positive increment')
-  return (value / increment) * increment
-}
+const quantizeUp = (value: bigint, increment: bigint): ExecutionResult<bigint> =>
+  pipe(
+    ceilDiv(value, increment),
+    Result.map((quotient) => quotient * increment),
+  )
 
-const quantizeUp = (value: bigint, increment: bigint): bigint => ceilDiv(value, increment) * increment
+const quantizeNearest = (value: bigint, increment: bigint): ExecutionResult<bigint> =>
+  pipe(
+    roundDiv(value, increment),
+    Result.map((quotient) => quotient * increment),
+  )
 
-const quantizeNearest = (value: bigint, increment: bigint): bigint => roundDiv(value, increment) * increment
-
-export const numberToMicros = (value: number, name = 'value'): bigint => {
-  if (!Number.isFinite(value) || value < 0) throw new Error(`${name} must be finite and non-negative`)
-  const scaled = Math.round(value * Number(MICROS))
-  if (!Number.isSafeInteger(scaled)) throw new Error(`${name} exceeds monetary precision`)
-  return BigInt(scaled)
+export const numberToMicros = (value: number, field = 'value'): ExecutionResult<bigint> => {
+  const scale = Number(MICROS)
+  if (!Number.isFinite(value)) {
+    return fail({ _tag: 'InvalidFixedPointNumber', field, value, scale, reason: 'not-finite' })
+  }
+  if (value < 0) {
+    return fail({ _tag: 'InvalidFixedPointNumber', field, value, scale, reason: 'negative' })
+  }
+  const scaled = Math.round(value * scale)
+  return Number.isSafeInteger(scaled)
+    ? Result.succeed(BigInt(scaled))
+    : fail({ _tag: 'InvalidFixedPointNumber', field, value, scale, reason: 'precision-exceeded' })
 }
 
 export const microsToNumber = (value: bigint): number => Number(value) / Number(MICROS)
 
-export const referencePriceMicros = (price: number, model: ExecutionModel): bigint => {
-  if (!Number.isFinite(price) || price <= 0) throw new Error('reference price must be finite and positive')
-  const increment = ensureUnsigned(model.precision.priceIncrementMicros, 'price increment')
-  if (increment === 0n) throw new Error('price increment must be positive')
-  const quantized = quantizeNearest(numberToMicros(price, 'reference price'), increment)
-  if (quantized === 0n) throw new Error('reference price rounds to zero')
-  return quantized
+export const referencePriceMicros = (price: number, model: ExecutionModel): ExecutionResult<bigint> => {
+  if (!Number.isFinite(price) || price <= 0) {
+    return fail({ _tag: 'InvalidReferencePrice', price, reason: 'not-positive' })
+  }
+  return pipe(
+    Result.all({
+      increment: ensureUnsigned(model.precision.priceIncrementMicros, 'price increment', 1n),
+      priceMicros: numberToMicros(price, 'reference price'),
+    }),
+    Result.flatMap(({ increment, priceMicros }) => quantizeNearest(priceMicros, increment)),
+    Result.flatMap((quantized) =>
+      quantized === 0n
+        ? fail({ _tag: 'InvalidReferencePrice', price, reason: 'rounded-to-zero' })
+        : Result.succeed(quantized),
+    ),
+  )
 }
 
-export const notionalMicros = (quantityMicros: bigint, priceMicros: bigint): bigint =>
+export const notionalMicros = (quantityMicros: bigint, priceMicros: bigint): ExecutionResult<bigint> =>
   roundDiv(quantityMicros * priceMicros, MICROS)
 
 export const desiredQuantityMicros = (
@@ -121,20 +268,50 @@ export const desiredQuantityMicros = (
   weight: number,
   priceMicros: bigint,
   model: Pick<ExecutionModel, 'precision'>,
-): bigint => {
-  if (equityMicros < 0n || priceMicros <= 0n) throw new Error('desired quantity requires valid equity and price')
-  const weightUnits = scaledNumber(weight, 'target weight', Number(WEIGHT_SCALE))
-  if (weightUnits > WEIGHT_SCALE) throw new Error('target weight exceeds one')
-  const increment = ensureUnsigned(model.precision.quantityIncrementMicros, 'quantity increment')
-  if (increment === 0n) throw new Error('quantity increment must be positive')
-  const raw = (equityMicros * weightUnits * MICROS) / (WEIGHT_SCALE * priceMicros)
-  return quantizeDown(raw, increment)
+): ExecutionResult<bigint> => {
+  if (equityMicros < 0n || priceMicros <= 0n) {
+    return fail({
+      _tag: 'InvalidDesiredQuantity',
+      equityMicros,
+      weight,
+      priceMicros,
+      reason: 'invalid-equity-or-price',
+    })
+  }
+  return pipe(
+    scaledNumber(weight, 'target weight', Number(WEIGHT_SCALE)),
+    Result.flatMap((weightUnits) => {
+      if (weightUnits > WEIGHT_SCALE) {
+        return fail({
+          _tag: 'InvalidDesiredQuantity',
+          equityMicros,
+          weight,
+          priceMicros,
+          reason: 'weight-exceeds-one',
+        })
+      }
+      return pipe(
+        ensureUnsigned(model.precision.quantityIncrementMicros, 'quantity increment', 1n),
+        Result.flatMap((increment) => {
+          const raw = (equityMicros * weightUnits * MICROS) / (WEIGHT_SCALE * priceMicros)
+          return quantizeDown(raw, increment)
+        }),
+      )
+    }),
+  )
 }
 
-const impactedDelta = (reference: bigint, bps: number, costMultiplierMicros: bigint): bigint => {
-  const bpsMicros = scaledNumber(bps, 'execution cost basis points')
-  return ceilDiv(reference * bpsMicros * costMultiplierMicros, BPS * MICROS * MICROS)
-}
+const impactedDelta = (
+  referencePriceMicros: bigint,
+  basisPoints: number,
+  costMultiplierMicros: bigint,
+): ExecutionResult<bigint> =>
+  pipe(
+    scaledNumber(basisPoints, 'execution cost basis points'),
+    Result.flatMap((basisPointMicros) =>
+      ceilDiv(referencePriceMicros * basisPointMicros * costMultiplierMicros, BPS * MICROS * MICROS),
+    ),
+  )
 
 export interface FillTerms {
   readonly referencePriceMicros: bigint
@@ -150,38 +327,81 @@ export const makeFillTerms = (
   referencePrice: bigint,
   model: ExecutionModel,
   costMultiplierMicros: bigint,
-): FillTerms => {
-  if (quantityMicros <= 0n || referencePrice <= 0n) throw new Error('fill terms require positive quantity and price')
-  if (costMultiplierMicros <= 0n) throw new Error('cost multiplier must be positive')
-  const increment = ensureUnsigned(model.precision.priceIncrementMicros, 'price increment')
-  if (increment === 0n) throw new Error('price increment must be positive')
-  const spreadDelta = impactedDelta(referencePrice, model.priceImpact.halfSpreadBps, costMultiplierMicros)
-  const slippageDelta = impactedDelta(referencePrice, model.priceImpact.slippageBps, costMultiplierMicros)
-  const spreadPrice =
-    side === 'buy'
-      ? quantizeUp(referencePrice + spreadDelta, increment)
-      : quantizeDown(referencePrice > spreadDelta ? referencePrice - spreadDelta : 0n, increment)
-  const fillPrice =
-    side === 'buy'
-      ? quantizeUp(referencePrice + spreadDelta + slippageDelta, increment)
-      : quantizeDown(
-          referencePrice > spreadDelta + slippageDelta ? referencePrice - spreadDelta - slippageDelta : 0n,
-          increment,
-        )
-  if (spreadPrice <= 0n || fillPrice <= 0n) throw new Error('execution costs consume the reference price')
-  return {
-    referencePriceMicros: referencePrice,
-    fillPriceMicros: fillPrice,
-    notionalMicros: notionalMicros(quantityMicros, fillPrice),
-    spreadCostMicros: notionalMicros(
+): ExecutionResult<FillTerms> => {
+  const invalid = <A>(
+    reason: Extract<ExecutionModelFailure, { readonly _tag: 'InvalidFillTerms' }>['reason'],
+  ): ExecutionResult<A> =>
+    fail({
+      _tag: 'InvalidFillTerms',
+      side,
       quantityMicros,
-      spreadPrice > referencePrice ? spreadPrice - referencePrice : referencePrice - spreadPrice,
-    ),
-    slippageCostMicros: notionalMicros(
-      quantityMicros,
-      fillPrice > spreadPrice ? fillPrice - spreadPrice : spreadPrice - fillPrice,
-    ),
-  }
+      referencePriceMicros: referencePrice,
+      costMultiplierMicros,
+      reason,
+    })
+  if (quantityMicros <= 0n || referencePrice <= 0n) return invalid('invalid-quantity-or-price')
+  if (costMultiplierMicros <= 0n) return invalid('invalid-cost-multiplier')
+
+  return pipe(
+    Result.all({
+      increment: ensureUnsigned(model.precision.priceIncrementMicros, 'price increment', 1n),
+      spreadDelta: impactedDelta(referencePrice, model.priceImpact.halfSpreadBps, costMultiplierMicros),
+      slippageDelta: impactedDelta(referencePrice, model.priceImpact.slippageBps, costMultiplierMicros),
+    }),
+    Result.flatMap(({ increment, spreadDelta, slippageDelta }) => {
+      const spreadPrice = pipe(
+        side === 'buy'
+          ? quantizeUp(referencePrice + spreadDelta, increment)
+          : quantizeDown(referencePrice > spreadDelta ? referencePrice - spreadDelta : 0n, increment),
+        Result.flatMap((price) => {
+          if (price <= 0n) return invalid<bigint>('costs-consume-reference-price')
+          return Result.succeed(price)
+        }),
+      )
+      return pipe(
+        spreadPrice,
+        Result.flatMap((quantizedSpreadPrice) =>
+          pipe(
+            side === 'buy'
+              ? quantizeUp(referencePrice + spreadDelta + slippageDelta, increment)
+              : quantizeDown(
+                  referencePrice > spreadDelta + slippageDelta ? referencePrice - spreadDelta - slippageDelta : 0n,
+                  increment,
+                ),
+            Result.flatMap((fillPrice) => {
+              if (fillPrice <= 0n) return invalid<FillTerms>('costs-consume-reference-price')
+              return pipe(
+                Result.all({
+                  notional: notionalMicros(quantityMicros, fillPrice),
+                  spreadCost: notionalMicros(
+                    quantityMicros,
+                    quantizedSpreadPrice > referencePrice
+                      ? quantizedSpreadPrice - referencePrice
+                      : referencePrice - quantizedSpreadPrice,
+                  ),
+                  slippageCost: notionalMicros(
+                    quantityMicros,
+                    fillPrice > quantizedSpreadPrice
+                      ? fillPrice - quantizedSpreadPrice
+                      : quantizedSpreadPrice - fillPrice,
+                  ),
+                }),
+                Result.map(
+                  ({ notional, spreadCost, slippageCost }): FillTerms => ({
+                    referencePriceMicros: referencePrice,
+                    fillPriceMicros: fillPrice,
+                    notionalMicros: notional,
+                    spreadCostMicros: spreadCost,
+                    slippageCostMicros: slippageCost,
+                  }),
+                ),
+              )
+            }),
+          ),
+        ),
+      )
+    }),
+  )
 }
 
 export interface OrderOutcome {
@@ -192,53 +412,100 @@ export interface OrderOutcome {
   readonly unfilledRemainder: 'none' | 'canceled'
 }
 
-export const makeOrderOutcome = (input: {
+export interface OrderOutcomeInput {
   readonly identity: unknown
   readonly side: 'buy' | 'sell'
   readonly requestedQuantityMicros: bigint
   readonly referencePriceMicros: bigint
   readonly model: ExecutionModel
-}): OrderOutcome => {
-  const quantityIncrement = ensureUnsigned(input.model.precision.quantityIncrementMicros, 'quantity increment')
-  if (quantityIncrement === 0n) throw new Error('quantity increment must be positive')
-  const requested = quantizeDown(input.requestedQuantityMicros, quantityIncrement)
-  const reject = (reason: OrderRejectionReason): OrderOutcome => ({
-    requestedQuantityMicros: requested,
-    filledQuantityMicros: 0n,
-    status: 'rejected',
-    rejectionReason: reason,
-    unfilledRemainder: 'canceled',
-  })
-  if (requested === 0n) return reject('zero-after-rounding')
-  if (
-    input.side === 'buy' &&
-    notionalMicros(requested, input.referencePriceMicros) <
-      ensureUnsigned(input.model.precision.minimumBuyNotionalMicros, 'minimum buy notional')
-  ) {
-    return reject('below-minimum-buy-notional')
-  }
-
-  const probability = BigInt(input.model.partialFills.probabilityPpm)
-  const bucket = BigInt(`0x${canonicalHashV1(input.identity).slice(0, 16)}`) % PPM
-  if (bucket >= probability) {
-    return {
-      requestedQuantityMicros: requested,
-      filledQuantityMicros: requested,
-      status: 'filled',
-      rejectionReason: null,
-      unfilledRemainder: 'none',
-    }
-  }
-  const filled = quantizeDown((requested * BigInt(input.model.partialFills.filledFractionPpm)) / PPM, quantityIncrement)
-  if (filled === 0n) return reject('zero-after-rounding')
-  return {
-    requestedQuantityMicros: requested,
-    filledQuantityMicros: filled,
-    status: 'partially-filled',
-    rejectionReason: null,
-    unfilledRemainder: 'canceled',
-  }
 }
+
+export const makeOrderOutcome = (input: OrderOutcomeInput): ExecutionResult<OrderOutcome> =>
+  pipe(
+    ensureUnsigned(input.model.precision.quantityIncrementMicros, 'quantity increment', 1n),
+    Result.flatMap((quantityIncrement) =>
+      pipe(
+        quantizeDown(input.requestedQuantityMicros, quantityIncrement),
+        Result.map((requested) => ({ quantityIncrement, requested })),
+      ),
+    ),
+    Result.flatMap(({ quantityIncrement, requested }) => {
+      const reject = (reason: OrderRejectionReason): OrderOutcome => ({
+        requestedQuantityMicros: requested,
+        filledQuantityMicros: 0n,
+        status: 'rejected',
+        rejectionReason: reason,
+        unfilledRemainder: 'canceled',
+      })
+      if (requested === 0n) return Result.succeed(reject('zero-after-rounding'))
+
+      const belowMinimumBuyNotional =
+        input.side === 'sell'
+          ? Result.succeed(false)
+          : pipe(
+              notionalMicros(requested, input.referencePriceMicros),
+              Result.flatMap((requestedNotional) =>
+                pipe(
+                  ensureUnsigned(input.model.precision.minimumBuyNotionalMicros, 'minimum buy notional'),
+                  Result.map((minimumBuyNotional) => requestedNotional < minimumBuyNotional),
+                ),
+              ),
+            )
+      return pipe(
+        belowMinimumBuyNotional,
+        Result.flatMap((belowMinimum) => {
+          if (belowMinimum) {
+            return Result.succeed(reject('below-minimum-buy-notional'))
+          }
+          return pipe(
+            integerNumber(input.model.partialFills.probabilityPpm, 'partial fill probability', 0, Number(PPM)),
+            Result.flatMap((probability) =>
+              pipe(
+                Result.try({
+                  try: () => canonicalHashV1(input.identity),
+                  catch: (cause): ExecutionModelFailure => ({
+                    _tag: 'OrderOutcomeCanonicalizationFailed',
+                    identity: input.identity,
+                    cause,
+                  }),
+                }),
+                Result.flatMap((identityHash) => {
+                  const bucket = BigInt(`0x${identityHash.slice(0, 16)}`) % PPM
+                  if (bucket >= probability) {
+                    return Result.succeed({
+                      requestedQuantityMicros: requested,
+                      filledQuantityMicros: requested,
+                      status: 'filled',
+                      rejectionReason: null,
+                      unfilledRemainder: 'none',
+                    })
+                  }
+                  return pipe(
+                    integerNumber(input.model.partialFills.filledFractionPpm, 'partial fill fraction', 0, Number(PPM)),
+                    Result.flatMap((filledFraction) =>
+                      quantizeDown((requested * filledFraction) / PPM, quantityIncrement),
+                    ),
+                    Result.map(
+                      (filled): OrderOutcome =>
+                        filled === 0n
+                          ? reject('zero-after-rounding')
+                          : {
+                              requestedQuantityMicros: requested,
+                              filledQuantityMicros: filled,
+                              status: 'partially-filled',
+                              rejectionReason: null,
+                              unfilledRemainder: 'canceled',
+                            },
+                    ),
+                  )
+                }),
+              ),
+            ),
+          )
+        }),
+      )
+    }),
+  )
 
 export interface FeeInput {
   readonly side: 'buy' | 'sell'
@@ -254,84 +521,137 @@ export interface FeeBreakdown {
   readonly totalMicros: bigint
 }
 
-const roundedFee = (numerator: bigint, denominator: bigint, increment: bigint): bigint =>
-  numerator === 0n ? 0n : ceilDiv(numerator, denominator * increment) * increment
+const roundedFee = (numerator: bigint, denominator: bigint, increment: bigint): ExecutionResult<bigint> =>
+  numerator === 0n
+    ? Result.succeed(0n)
+    : pipe(
+        ceilDiv(numerator, denominator * increment),
+        Result.map((quotient) => quotient * increment),
+      )
 
 export const calculateSessionFees = (
   fills: readonly FeeInput[],
   model: ExecutionModel,
   costMultiplierMicros: bigint,
-): FeeBreakdown => {
-  if (costMultiplierMicros <= 0n) throw new Error('cost multiplier must be positive')
-  const rounding = ensureUnsigned(model.fees.roundingIncrementMicros, 'fee rounding increment')
-  if (rounding === 0n) throw new Error('fee rounding increment must be positive')
+): ExecutionResult<FeeBreakdown> => {
+  if (costMultiplierMicros <= 0n) {
+    return fail({ _tag: 'InvalidFeeCostMultiplier', costMultiplierMicros, minimum: 1n })
+  }
   const totalNotional = fills.reduce((sum, fill) => sum + fill.notionalMicros, 0n)
   const sellNotional = fills.reduce((sum, fill) => sum + (fill.side === 'sell' ? fill.notionalMicros : 0n), 0n)
   const totalQuantity = fills.reduce((sum, fill) => sum + fill.quantityMicros, 0n)
-  const commission = roundedFee(
-    totalNotional * scaledNumber(model.fees.commissionBps, 'commission basis points') * costMultiplierMicros,
-    BPS * MICROS * MICROS,
-    rounding,
+
+  return pipe(
+    Result.all({
+      rounding: ensureUnsigned(model.fees.roundingIncrementMicros, 'fee rounding increment', 1n),
+      commissionRate: scaledNumber(model.fees.commissionBps, 'commission basis points'),
+      secRate: scaledNumber(model.fees.secSellBps, 'SEC basis points'),
+      tafRate: ensureUnsigned(model.fees.tafSellPerShareMicros, 'TAF share rate'),
+      tafCap: ensureUnsigned(model.fees.tafMaximumPerOrderMicros, 'TAF order cap'),
+      catRate: ensureUnsigned(model.fees.catPerShareMicros, 'CAT share rate'),
+    }),
+    Result.flatMap(({ rounding, commissionRate, secRate, tafRate, tafCap, catRate }) => {
+      const tafNumerator = fills.reduce(
+        (sum, fill) =>
+          fill.side === 'sell'
+            ? sum + (fill.quantityMicros * tafRate < tafCap * MICROS ? fill.quantityMicros * tafRate : tafCap * MICROS)
+            : sum,
+        0n,
+      )
+      return pipe(
+        Result.all({
+          commission: roundedFee(
+            totalNotional * commissionRate * costMultiplierMicros,
+            BPS * MICROS * MICROS,
+            rounding,
+          ),
+          sec: roundedFee(sellNotional * secRate * costMultiplierMicros, BPS * MICROS * MICROS, rounding),
+          taf: roundedFee(tafNumerator * costMultiplierMicros, MICROS * MICROS, rounding),
+          cat: roundedFee(totalQuantity * catRate * costMultiplierMicros, MICROS * MICROS, rounding),
+        }),
+        Result.map(
+          ({ commission, sec, taf, cat }): FeeBreakdown => ({
+            commissionMicros: commission,
+            secMicros: sec,
+            tafMicros: taf,
+            catMicros: cat,
+            totalMicros: commission + sec + taf + cat,
+          }),
+        ),
+      )
+    }),
   )
-  const sec = roundedFee(
-    sellNotional * scaledNumber(model.fees.secSellBps, 'SEC basis points') * costMultiplierMicros,
-    BPS * MICROS * MICROS,
-    rounding,
-  )
-  const tafRate = ensureUnsigned(model.fees.tafSellPerShareMicros, 'TAF share rate')
-  const tafCap = ensureUnsigned(model.fees.tafMaximumPerOrderMicros, 'TAF order cap')
-  const tafNumerator = fills.reduce(
-    (sum, fill) =>
-      fill.side === 'sell'
-        ? sum + (fill.quantityMicros * tafRate < tafCap * MICROS ? fill.quantityMicros * tafRate : tafCap * MICROS)
-        : sum,
-    0n,
-  )
-  const taf = roundedFee(tafNumerator * costMultiplierMicros, MICROS * MICROS, rounding)
-  const catRate = ensureUnsigned(model.fees.catPerShareMicros, 'CAT share rate')
-  const cat = roundedFee(totalQuantity * catRate * costMultiplierMicros, MICROS * MICROS, rounding)
-  const total = commission + sec + taf + cat
-  return {
-    commissionMicros: commission,
-    secMicros: sec,
-    tafMicros: taf,
-    catMicros: cat,
-    totalMicros: total,
+}
+
+export const accrueCashYield = (
+  cashMicros: bigint,
+  elapsedDays: number,
+  model: ExecutionModel,
+): ExecutionResult<bigint> => {
+  if (cashMicros < 0n) {
+    return fail({ _tag: 'InvalidCashYield', cashMicros, elapsedDays, reason: 'negative-cash' })
   }
+  if (!Number.isInteger(elapsedDays) || elapsedDays < 0) {
+    return fail({ _tag: 'InvalidCashYield', cashMicros, elapsedDays, reason: 'invalid-elapsed-days' })
+  }
+  return pipe(
+    scaledNumber(model.cash.annualYieldBps, 'annual cash yield basis points'),
+    Result.map((annualYieldBps) => (cashMicros * annualYieldBps * BigInt(elapsedDays)) / (BPS * MICROS * 365n)),
+  )
 }
 
-export const accrueCashYield = (cashMicros: bigint, elapsedDays: number, model: ExecutionModel): bigint => {
-  if (cashMicros < 0n) throw new Error('cash yield cannot accrue on negative cash')
-  if (!Number.isInteger(elapsedDays) || elapsedDays < 0) throw new Error('elapsed days must be a non-negative integer')
-  const annualYieldBps = scaledNumber(model.cash.annualYieldBps, 'annual cash yield basis points')
-  return (cashMicros * annualYieldBps * BigInt(elapsedDays)) / (BPS * MICROS * 365n)
-}
-
-export const elapsedCalendarDays = (from: IsoDate, to: IsoDate): number => {
+export const elapsedCalendarDays = (from: IsoDate, to: IsoDate): ExecutionResult<number> => {
   const fromTime = Date.parse(`${from}T00:00:00Z`)
   const toTime = Date.parse(`${to}T00:00:00Z`)
-  if (!Number.isFinite(fromTime) || !Number.isFinite(toTime) || toTime < fromTime) {
-    throw new Error('cash accrual dates are invalid or unordered')
-  }
-  return (toTime - fromTime) / 86_400_000
+  return !Number.isFinite(fromTime) || !Number.isFinite(toTime) || toTime < fromTime
+    ? fail({ _tag: 'InvalidCashAccrualPeriod', from, to })
+    : Result.succeed((toTime - fromTime) / 86_400_000)
 }
 
 export const saleCostBasisMicros = (
   positionCostBasisMicros: bigint,
   soldQuantityMicros: bigint,
   positionQuantityMicros: bigint,
-): bigint => {
+): ExecutionResult<bigint> => {
   if (positionCostBasisMicros < 0n || soldQuantityMicros < 0n || positionQuantityMicros <= 0n) {
-    throw new Error('sale cost basis requires a positive position and non-negative values')
+    return fail({
+      _tag: 'InvalidSaleCostBasis',
+      positionCostBasisMicros,
+      soldQuantityMicros,
+      positionQuantityMicros,
+      reason: 'invalid-position',
+    })
   }
-  if (soldQuantityMicros > positionQuantityMicros) throw new Error('sale quantity exceeds the position')
+  if (soldQuantityMicros > positionQuantityMicros) {
+    return fail({
+      _tag: 'InvalidSaleCostBasis',
+      positionCostBasisMicros,
+      soldQuantityMicros,
+      positionQuantityMicros,
+      reason: 'quantity-exceeds-position',
+    })
+  }
   return roundDiv(positionCostBasisMicros * soldQuantityMicros, positionQuantityMicros)
 }
 
-export const scaleQuantityMicros = (quantityMicros: bigint, scalePpm: bigint, model: ExecutionModel): bigint => {
-  if (scalePpm < 0n || scalePpm > PPM) throw new Error('quantity scale must be between zero and one million')
-  const increment = ensureUnsigned(model.precision.quantityIncrementMicros, 'quantity increment')
-  return quantizeDown((quantityMicros * scalePpm) / PPM, increment)
+export const scaleQuantityMicros = (
+  quantityMicros: bigint,
+  scalePpm: bigint,
+  model: ExecutionModel,
+): ExecutionResult<bigint> => {
+  if (scalePpm < 0n || scalePpm > PPM) {
+    return fail({
+      _tag: 'InvalidQuantityScale',
+      quantityMicros,
+      scalePpm,
+      minimumScalePpm: 0n,
+      maximumScalePpm: PPM,
+    })
+  }
+  return pipe(
+    ensureUnsigned(model.precision.quantityIncrementMicros, 'quantity increment'),
+    Result.flatMap((increment) => quantizeDown((quantityMicros * scalePpm) / PPM, increment)),
+  )
 }
 
 export const ppm = PPM

--- a/services/bayn/src/observe-composition.test.ts
+++ b/services/bayn/src/observe-composition.test.ts
@@ -368,7 +368,7 @@ describe('OBSERVE runtime composition', () => {
             expect(binding.signal.sessionDate).toBe(signalDate)
             expect(binding.executionSession.date).toBe(executionDate)
             expect(binding.submissionOpenAt).toBe(reconciledAt)
-            return { decision, priceMicros }
+            return Result.succeed({ decision, priceMicros })
           },
         },
       })
@@ -430,7 +430,7 @@ describe('OBSERVE runtime composition', () => {
             strategy: {
               currentDecision: () => {
                 strategyCalls += 1
-                return { decision, priceMicros }
+                return Result.succeed({ decision, priceMicros })
               },
             },
           })
@@ -543,7 +543,7 @@ describe('OBSERVE runtime composition', () => {
             marketData: testCase.marketData,
             policy,
             reconcile: testCase.reconcile,
-            strategy: { currentDecision: () => ({ decision, priceMicros }) },
+            strategy: { currentDecision: () => Result.succeed({ decision, priceMicros }) },
           }),
         ),
       )

--- a/services/bayn/src/observe-composition.ts
+++ b/services/bayn/src/observe-composition.ts
@@ -329,7 +329,14 @@ const compileObserveStrategyDecision = (
     try: () => input.strategy.currentDecision(facts.snapshot.bars, facts.snapshot.manifest, executionSession),
     catch: (cause) =>
       operationalError('strategy', 'current-decision', 'current strategy decision compilation failed', cause),
-  })
+  }).pipe(
+    Effect.flatMap(Effect.fromResult),
+    Effect.mapError((cause) =>
+      cause._tag === 'OperationalError'
+        ? cause
+        : operationalError('strategy', 'current-decision', 'current strategy decision compilation failed', cause),
+    ),
+  )
 
 const prepareObservePlanner = (
   input: ObserveDecisionInput,
@@ -378,48 +385,52 @@ const reduceObserveRiskInputs = (
   prices: SignalSessionReferencePrices,
 ): Result.Result<readonly ShadowDeltaRiskInput[], ObserveDecisionCompositionFailure> =>
   Result.mapError(
-    Result.try((): readonly ShadowDeltaRiskInput[] =>
-      targetPlan.intentTargets.map((target): ShadowDeltaRiskInput => {
+    Result.all(
+      targetPlan.intentTargets.map((target) => {
         const referencePrice = BigInt(prices.priceMicros[target.symbol])
-        const fillTerms = makeFillTerms(
-          target.side === OrderSide.Buy ? 'buy' : 'sell',
-          BigInt(target.quantityMicros),
-          referencePrice,
-          input.executionModel,
-          MICROS,
+        return Result.map(
+          makeFillTerms(
+            target.side === OrderSide.Buy ? 'buy' : 'sell',
+            BigInt(target.quantityMicros),
+            referencePrice,
+            input.executionModel,
+            MICROS,
+          ),
+          (fillTerms): ShadowDeltaRiskInput => {
+            const reconciliation = facts.reconciliation
+            const finalizedSnapshot = facts.snapshot.manifest.finalizedSnapshot
+            const state: State = {
+              schemaVersion: 'bayn.paper-risk-state.v2',
+              brokerMode: BrokerMode.Paper,
+              account: reconciliation.brokerState.account,
+              positions: reconciliation.brokerState.positions,
+              positionsObservedAt: reconciliation.brokerState.positionsObservedAt,
+              orders: reconciliation.brokerState.orders,
+              ordersObservedAt: reconciliation.brokerState.ordersObservedAt,
+              reconciliation: reconciliation.brokerState.reconciliation,
+              authority: authorityObservation.authority,
+              authorityObservedAt: authorityObservation.observedAt,
+              unknownMutationCount: reconciliation.riskContext.unknownMutationCount,
+              dailyTradedNotionalMicros: reconciliation.riskContext.dailyTradedNotionalMicros,
+              dayStartEquityMicros: reconciliation.riskContext.dayStartEquityMicros,
+              peakEquityMicros: reconciliation.riskContext.peakEquityMicros,
+              accountingHash: reconciliation.brokerState.accountingHash,
+              marketDataSymbol: target.symbol,
+              marketDataHash: finalizedSnapshot.contentHash,
+              referencePriceMicros: referencePrice.toString(),
+              expectedExecutionPriceMicros: fillTerms.fillPriceMicros.toString(),
+              marketDataObservedAt: facts.evaluatedAt,
+              executionSession,
+              reservedBuyingPowerMicros: '0',
+              evaluatedAt: facts.evaluatedAt,
+            }
+            return {
+              symbol: target.symbol,
+              notionalLimitMicros: fillTerms.notionalMicros.toString(),
+              state,
+            }
+          },
         )
-        const reconciliation = facts.reconciliation
-        const finalizedSnapshot = facts.snapshot.manifest.finalizedSnapshot
-        const state: State = {
-          schemaVersion: 'bayn.paper-risk-state.v2',
-          brokerMode: BrokerMode.Paper,
-          account: reconciliation.brokerState.account,
-          positions: reconciliation.brokerState.positions,
-          positionsObservedAt: reconciliation.brokerState.positionsObservedAt,
-          orders: reconciliation.brokerState.orders,
-          ordersObservedAt: reconciliation.brokerState.ordersObservedAt,
-          reconciliation: reconciliation.brokerState.reconciliation,
-          authority: authorityObservation.authority,
-          authorityObservedAt: authorityObservation.observedAt,
-          unknownMutationCount: reconciliation.riskContext.unknownMutationCount,
-          dailyTradedNotionalMicros: reconciliation.riskContext.dailyTradedNotionalMicros,
-          dayStartEquityMicros: reconciliation.riskContext.dayStartEquityMicros,
-          peakEquityMicros: reconciliation.riskContext.peakEquityMicros,
-          accountingHash: reconciliation.brokerState.accountingHash,
-          marketDataSymbol: target.symbol,
-          marketDataHash: finalizedSnapshot.contentHash,
-          referencePriceMicros: referencePrice.toString(),
-          expectedExecutionPriceMicros: fillTerms.fillPriceMicros.toString(),
-          marketDataObservedAt: facts.evaluatedAt,
-          executionSession,
-          reservedBuyingPowerMicros: '0',
-          evaluatedAt: facts.evaluatedAt,
-        }
-        return {
-          symbol: target.symbol,
-          notionalLimitMicros: fillTerms.notionalMicros.toString(),
-          state,
-        }
       }),
     ),
     (cause) => compositionFailure('shadow-risk-inputs', 'shadow risk input construction failed', cause),

--- a/services/bayn/src/qualification-audit-command.ts
+++ b/services/bayn/src/qualification-audit-command.ts
@@ -1,7 +1,7 @@
 import { NodeHttpClient, NodeRuntime, NodeServices } from '@effect/platform-node'
 import { ClickhouseClient } from '@effect/sql-clickhouse'
 import { PgClient } from '@effect/sql-pg'
-import { Config, Data, Effect, FileSystem, Layer, Logger, Redacted, Schema, Stdio, Stream } from 'effect'
+import { Config, Data, Effect, FileSystem, Layer, Logger, Redacted, Result, Schema, Stdio, Stream } from 'effect'
 import { ChildProcess, ChildProcessSpawner } from 'effect/unstable/process'
 
 import { EvaluationEventSchema, decodeInputManifestArtifact } from './evidence-contracts'
@@ -12,10 +12,12 @@ import {
   auditQualification,
   classifySignalTableAccess,
   type AuditDatabaseSnapshot,
+  type QualificationAuditReport,
   type RepositoryAudit,
   type SignalAccessRecord,
 } from './audit/audit'
-import { makeQualificationDossier } from './audit/dossier'
+import { makeQualificationDossier, type QualificationDossier } from './audit/dossier'
+import type { ReferenceEvaluationFailure } from './audit/reference'
 import {
   NonNegativeIntegerSchema as NonNegativeInteger,
   PositiveIntegerSchema as PositiveInteger,
@@ -571,10 +573,14 @@ const main = Effect.gen(function* () {
     signalPrincipals: { candidate: input.signalUsername, publishers: [input.signalPublisherUsername] },
     repository,
   }
-  const report = yield* Effect.try({
-    try: () => (input.output === 'dossier' ? makeQualificationDossier(auditInput) : auditQualification(auditInput)),
+  const reportDecision = yield* Effect.try({
+    try: (): Result.Result<QualificationAuditReport | QualificationDossier, ReferenceEvaluationFailure> =>
+      input.output === 'dossier' ? makeQualificationDossier(auditInput) : auditQualification(auditInput),
     catch: (cause) => commandError('audit', 'qualification audit evaluation failed', cause),
   })
+  const report = yield* Effect.fromResult(reportDecision).pipe(
+    Effect.mapError((cause) => commandError('audit', 'qualification audit execution model failed', cause)),
+  )
   const output = yield* encodeJson(report)
   const stdio = yield* Stdio.Stdio
   yield* Stream.run(Stream.make(`${output}\n`), stdio.stdout())

--- a/services/bayn/src/qualification-audit.test.ts
+++ b/services/bayn/src/qualification-audit.test.ts
@@ -8,15 +8,28 @@ import { makeStrategyProtocolHash } from './contracts'
 import { canonicalHashV1 } from './hash'
 import { makeQualificationResult } from './qualification'
 import {
-  auditQualification,
+  auditQualification as auditQualificationResult,
   classifySignalTableAccess,
   type AuditDatabaseSnapshot,
   type QualificationAuditInput,
+  type QualificationAuditReport,
 } from './audit/audit'
-import { makeQualificationDossier } from './audit/dossier'
+import { makeQualificationDossier as makeQualificationDossierResult, type QualificationDossier } from './audit/dossier'
 import { makeStrategy } from './strategy'
 import { summarizeEvaluation } from './risk-balanced-trend'
 import { fixtureProtocol, makeSnapshot, makeTestProvenance } from './test-fixtures'
+
+const auditQualification = (input: QualificationAuditInput): QualificationAuditReport => {
+  const result = auditQualificationResult(input)
+  assert(Result.isSuccess(result), 'qualification audit fixture must produce a report')
+  return result.success
+}
+
+const makeQualificationDossier = (input: QualificationAuditInput): QualificationDossier => {
+  const result = makeQualificationDossierResult(input)
+  assert(Result.isSuccess(result), 'qualification dossier fixture must produce a dossier')
+  return result.success
+}
 
 const fixture = (priorTrialRunIds: readonly string[] = []): QualificationAuditInput => {
   const snapshot = makeSnapshot(900)

--- a/services/bayn/src/qualification-reference.test.ts
+++ b/services/bayn/src/qualification-reference.test.ts
@@ -20,7 +20,7 @@ describe('independent qualification reference', () => {
     const actual = assertSuccess(
       evaluateRiskBalancedTrend(snapshot.bars, snapshot.manifest, fixtureProtocol, provenance),
     )
-    const reference = evaluateReference(snapshot.bars, snapshot.manifest, fixtureProtocol, provenance)
+    const reference = assertSuccess(evaluateReference(snapshot.bars, snapshot.manifest, fixtureProtocol, provenance))
 
     expect(reference.runId).toBe(actual.runId)
     expect(reference.protocolHash).toBe(actual.protocolHash)
@@ -40,9 +40,9 @@ describe('independent qualification reference', () => {
   test('binds the result to raw market data', () => {
     const snapshot = makeSnapshot(900)
     const provenance = makeTestProvenance()
-    const original = evaluateReference(snapshot.bars, snapshot.manifest, fixtureProtocol, provenance)
+    const original = assertSuccess(evaluateReference(snapshot.bars, snapshot.manifest, fixtureProtocol, provenance))
     const bars = snapshot.bars.map((bar, index) => (index === 4_000 ? { ...bar, close: bar.close * 1.5 } : bar))
-    const changed = evaluateReference(bars, snapshot.manifest, fixtureProtocol, provenance)
+    const changed = assertSuccess(evaluateReference(bars, snapshot.manifest, fixtureProtocol, provenance))
 
     expect(canonicalHashV1(changed.strategy.decisions)).not.toBe(canonicalHashV1(original.strategy.decisions))
   })
@@ -69,7 +69,9 @@ describe('independent qualification reference', () => {
     const changedActual = assertSuccess(
       evaluateRiskBalancedTrend(changedBars, snapshot.manifest, fixtureProtocol, provenance),
     )
-    const changedReference = evaluateReference(changedBars, snapshot.manifest, fixtureProtocol, provenance)
+    const changedReference = assertSuccess(
+      evaluateReference(changedBars, snapshot.manifest, fixtureProtocol, provenance),
+    )
     const requests = (orders: typeof actual.simulation.orders) =>
       orders
         .filter((order) => order.sessionDate === executionDate)

--- a/services/bayn/src/risk-balanced-trend.test.ts
+++ b/services/bayn/src/risk-balanced-trend.test.ts
@@ -280,10 +280,12 @@ describe('risk-balanced trend candidate', () => {
         ? { ...bar, close: 100.123456 }
         : bar,
     )
-    const current = strategy.currentDecision(
-      bars,
-      snapshot.manifest,
-      currentDecisionBinding(snapshot.manifest.lastSession, ['2020-04-30', '2020-05-01', '2020-05-04']),
+    const current = assertSuccess(
+      strategy.currentDecision(
+        bars,
+        snapshot.manifest,
+        currentDecisionBinding(snapshot.manifest.lastSession, ['2020-04-30', '2020-05-01', '2020-05-04']),
+      ),
     )
     const sessionDates = [...new Set(snapshot.bars.map((bar) => bar.sessionDate))].sort()
     const historyLength = Math.max(fixtureProtocol.volatilityWindow, ...fixtureProtocol.horizons) + 1
@@ -295,7 +297,7 @@ describe('risk-balanced trend candidate', () => {
       fixtureProtocol.universe.map((symbol) => {
         const close = closesBySymbolAndDate.get(`${symbol}\u001f${snapshot.manifest.finalizedSnapshot.lastSession}`)
         if (close === undefined) throw new Error(`fixture is missing terminal close for ${symbol}`)
-        return [symbol, referencePriceMicros(close, fixtureProtocol.executionModel).toString()]
+        return [symbol, assertSuccess(referencePriceMicros(close, fixtureProtocol.executionModel)).toString()]
       }),
     )
     const expectedDecision = makeRiskBalancedTrendDecision(
@@ -319,6 +321,32 @@ describe('risk-balanced trend candidate', () => {
     expect(current.priceMicros[fixtureProtocol.universe[0]]).toBe('100123500')
     expect(Object.keys(current.priceMicros)).toEqual([...fixtureProtocol.universe])
     expect(Object.values(current.priceMicros).every((price) => /^[1-9][0-9]*$/.test(price))).toBe(true)
+  })
+
+  test('returns terminal-price quantization failures through the current-decision Result', () => {
+    const snapshot = makeSnapshot(1_129)
+    const protocol = {
+      ...fixtureProtocol,
+      executionModel: {
+        ...fixtureProtocol.executionModel,
+        precision: {
+          ...fixtureProtocol.executionModel.precision,
+          priceIncrementMicros: '1000000000000',
+        },
+      },
+    }
+    const strategy = makeStrategy(protocol, makeTestProvenance(protocol))
+    const current = strategy.currentDecision(
+      snapshot.bars,
+      snapshot.manifest,
+      currentDecisionBinding(snapshot.manifest.lastSession, ['2020-04-30', '2020-05-01', '2020-05-04']),
+    )
+
+    assert(Result.isFailure(current), 'current decision must preserve execution-model price failure data')
+    expect(current.failure).toMatchObject({
+      _tag: 'InvalidReferencePrice',
+      reason: 'rounded-to-zero',
+    })
   })
 
   test('rejects a current decision outside the bound month-end cycle', () => {

--- a/services/bayn/src/risk-balanced-trend.ts
+++ b/services/bayn/src/risk-balanced-trend.ts
@@ -1,7 +1,7 @@
-import { Result, Schema } from 'effect'
+import { pipe, Result, Schema } from 'effect'
 
 import type { RuntimeProvenance } from './contracts'
-import { MICROS, referencePriceMicros } from './execution-model'
+import { MICROS, referencePriceMicros, type ExecutionModelFailure } from './execution-model'
 import { ExecutionSessionBindingSchema, type ExecutionSessionBinding } from './execution-session'
 import { canonicalHashV1 } from './hash'
 import { strictParseOptions } from './schemas'
@@ -22,6 +22,8 @@ import {
   simulate,
   TRADING_DAYS,
   type AlignedSession,
+  type SimulationFailure,
+  type SimulationResult,
   type SimulationTarget,
 } from './simulation'
 import {
@@ -305,7 +307,7 @@ export const compileCurrentRiskBalancedTrendDecision = (
   inputManifest: InputManifest,
   protocol: Protocol,
   cycleBinding: CurrentDecisionCycleBinding,
-): CurrentRiskBalancedTrendDecision => {
+): Result.Result<CurrentRiskBalancedTrendDecision, ExecutionModelFailure> => {
   const binding = decodeCurrentDecisionCycleBinding(cycleBinding)
   const sessions = alignBars(bars, protocol.universe, inputManifest)
   const signalIndex = sessions.length - 1
@@ -325,12 +327,17 @@ export const compileCurrentRiskBalancedTrendDecision = (
     throw new Error('current strategy decision requires a month-end due cycle')
   }
   const decision = decisionFromAlignedSessions(sessions, signalIndex, protocol)
-  const priceMicros = Object.fromEntries(
-    protocol.universe.map((symbol) => [
-      symbol,
-      referencePriceMicros(terminalSession.bars[symbol].close, protocol.executionModel).toString(),
-    ]),
+  const prices = pipe(
+    protocol.universe.map((symbol) =>
+      Result.map(
+        referencePriceMicros(terminalSession.bars[symbol].close, protocol.executionModel),
+        (price) => [symbol, price.toString()] as const,
+      ),
+    ),
+    Result.all,
   )
+  if (Result.isFailure(prices)) return Result.fail(prices.failure)
+  const priceMicros = Object.fromEntries(prices.success)
   const priceSymbols = Object.keys(priceMicros)
   if (
     decision.signalDate !== terminalSession.date ||
@@ -341,7 +348,7 @@ export const compileCurrentRiskBalancedTrendDecision = (
   ) {
     throw new Error('current strategy decision and terminal closes do not cover one compiled universe session')
   }
-  return { decision, priceMicros }
+  return Result.succeed({ decision, priceMicros })
 }
 
 export interface QualificationPrecommit {
@@ -382,16 +389,24 @@ export interface RiskBalancedTrendCompatibilityFailure {
   readonly cause: unknown
 }
 
-export type RiskBalancedTrendEvaluationIssue = SimulationReconciliationIssue | RiskBalancedTrendCompatibilityFailure
+export interface RiskBalancedTrendSimulationFailure {
+  readonly _tag: 'RiskBalancedTrendSimulationFailure'
+  readonly cause: SimulationFailure
+}
+
+export type RiskBalancedTrendEvaluationIssue =
+  | SimulationReconciliationIssue
+  | RiskBalancedTrendCompatibilityFailure
+  | RiskBalancedTrendSimulationFailure
 
 interface PreparedEvaluation {
   readonly runId: string
   readonly protocolHash: string
-  readonly strategy: ReturnType<typeof simulate>
-  readonly buyAndHold: ReturnType<typeof simulate>
-  readonly directVolTiming: ReturnType<typeof simulate>
-  readonly doubleCost: ReturnType<typeof simulate>
-  readonly simulation: NonNullable<ReturnType<typeof simulate>['simulation']>
+  readonly strategy: SimulationResult
+  readonly buyAndHold: SimulationResult
+  readonly directVolTiming: SimulationResult
+  readonly doubleCost: SimulationResult
+  readonly simulation: NonNullable<SimulationResult['simulation']>
   readonly signalDecisions: readonly SignalDecision[]
 }
 
@@ -401,7 +416,7 @@ const prepareEvaluation = (
   inputManifest: InputManifest,
   protocol: Protocol,
   provenance: RuntimeProvenance,
-): PreparedEvaluation => {
+): Result.Result<PreparedEvaluation, readonly RiskBalancedTrendEvaluationIssue[]> => {
   const { runId, protocolHash } = makeEvaluationIdentity(inputManifest, protocol, provenance)
   const sessions = alignBars(bars, protocol.universe, inputManifest)
   const sessionDates = sessions.map((session) => session.date)
@@ -449,23 +464,33 @@ const prepareEvaluation = (
     runId,
     false,
   )
-  if (strategy.simulation === null) throw new Error('candidate simulation did not retain its evidence trace')
-  const signalDecisions = strategy.signalDecisions.map((decision) => {
+  const simulations = Result.all({ strategy, buyAndHold, directVolTiming, doubleCost })
+  if (Result.isFailure(simulations)) {
+    return Result.fail(
+      Object.freeze([
+        Object.freeze({
+          _tag: 'RiskBalancedTrendSimulationFailure' as const,
+          cause: simulations.failure,
+        }),
+      ]),
+    )
+  }
+  if (simulations.success.strategy.simulation === null) {
+    return Result.fail(riskBalancedTrendCompatibilityFailure('prepare', 'candidate simulation omitted its trace'))
+  }
+  const signalDecisions = simulations.success.strategy.signalDecisions.map((decision) => {
     if (decision.schemaVersion !== ContractVersion.DecisionPlan) {
       throw new Error('risk-balanced trend simulation retained a decision from another strategy')
     }
     return decision
   })
-  return {
+  return Result.succeed({
     runId,
     protocolHash,
-    strategy,
-    buyAndHold,
-    directVolTiming,
-    doubleCost,
-    simulation: strategy.simulation,
+    ...simulations.success,
+    simulation: simulations.success.strategy.simulation,
     signalDecisions,
-  }
+  })
 }
 
 export const riskBalancedTrendCompatibilityFailure = (
@@ -486,6 +511,7 @@ export const renderRiskBalancedTrendEvaluationIssues = (issues: readonly RiskBal
   issues
     .map((issue) => {
       if (issue._tag === 'RiskBalancedTrendCompatibilityFailure') return renderCompatibilityCause(issue.cause)
+      if (issue._tag === 'RiskBalancedTrendSimulationFailure') return renderCompatibilityCause(issue.cause)
       return renderSimulationReconciliationIssue(issue)
     })
     .join('; ')
@@ -496,10 +522,13 @@ export const evaluateRiskBalancedTrend = (
   protocol: Protocol,
   provenance: RuntimeProvenance,
 ): Result.Result<EvaluationResult, readonly RiskBalancedTrendEvaluationIssue[]> => {
-  const prepared = Result.try({
-    try: () => prepareEvaluation(bars, inputManifest, protocol, provenance),
-    catch: (cause) => riskBalancedTrendCompatibilityFailure('prepare', cause),
-  })
+  const prepared = pipe(
+    Result.try({
+      try: () => prepareEvaluation(bars, inputManifest, protocol, provenance),
+      catch: (cause) => riskBalancedTrendCompatibilityFailure('prepare', cause),
+    }),
+    Result.flatMap((decision) => decision),
+  )
   if (Result.isFailure(prepared)) return Result.fail(prepared.failure)
   const markedEquity = reconcileMarkedEquity({
     runId: prepared.success.runId,

--- a/services/bayn/src/simulation-causality.test.ts
+++ b/services/bayn/src/simulation-causality.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'bun:test'
+import { Result } from 'effect'
 
 import { defaultExecutionModel, MICROS } from './execution-model'
 import { canonicalHashV1 } from './hash'
@@ -105,7 +106,11 @@ const targets: readonly SimulationTarget[] = [
   },
 ]
 
-const run = (input: readonly AlignedSession[]) => simulate(input, targets, 1, protocol, MICROS, 'a'.repeat(64), true)
+const run = (input: readonly AlignedSession[]) => {
+  const result = simulate(input, targets, 1, protocol, MICROS, 'a'.repeat(64), true)
+  if (Result.isFailure(result)) throw new Error(result.failure._tag)
+  return result.success
+}
 
 const requests = (result: ReturnType<typeof run>, sessionDate: IsoDate) =>
   result.simulation?.orders

--- a/services/bayn/src/simulation-reconciliation.test.ts
+++ b/services/bayn/src/simulation-reconciliation.test.ts
@@ -164,13 +164,15 @@ const makeRoundTripInput = (dayCount: number): MarkedEquityReconciliationInput =
       }
       const orderId = canonicalHashV1({ runId: input.runId, kind: 'order', ...orderPayload })
       orders.push({ id: orderId, ...orderPayload })
-      const terms = makeFillTerms(
+      const termsResult = makeFillTerms(
         side,
         quantityMicros,
         referencePriceMicros,
         input.simulation.executionModel,
         costMultiplierMicros,
       )
+      assert(Result.isSuccess(termsResult), 'reconciliation fixture fill terms must succeed')
+      const terms = termsResult.success
       const fillPayload = {
         orderId,
         decisionId,
@@ -275,6 +277,7 @@ type IssueLeaf =
   | 'ComputationFailed/FillTerms'
   | 'ComputationFailed/FeeSchedule'
   | 'ComputationFailed/CashYield'
+  | 'ComputationFailed/PositionNotional'
 
 const issueLeaf = (issue: SimulationReconciliationIssue): IssueLeaf => {
   switch (issue._tag) {
@@ -505,7 +508,12 @@ describe('independent marked-equity reconciliation', () => {
     assert(fillIssue._tag === 'ComputationFailed', 'fill calculation must retain its failure')
     expect(Object.isFrozen(fillIssue.computation)).toBe(true)
     expect(Reflect.set(fillIssue.computation, 'costMultiplierMicros', '0')).toBe(false)
-    expect(fillIssue.cause).toEqual(expect.objectContaining({ message: 'price increment must be positive' }))
+    expect(fillIssue.cause).toEqual({
+      _tag: 'InvalidUnsignedInteger',
+      field: 'price increment',
+      value: '0',
+      minimum: 1n,
+    })
     expect(Object.isFrozen(fillIssue.cause as object)).toBe(false)
 
     const zeroFeeIncrement: SimulationTrace = {

--- a/services/bayn/src/simulation-reconciliation.ts
+++ b/services/bayn/src/simulation-reconciliation.ts
@@ -1,6 +1,14 @@
 import { Result } from 'effect'
 
-import { accrueCashYield, calculateSessionFees, makeFillTerms, notionalMicros, type FeeInput } from './execution-model'
+import {
+  accrueCashYield,
+  calculateSessionFees,
+  makeFillTerms,
+  notionalMicros,
+  type FeeBreakdown,
+  type FeeInput,
+  type FillTerms,
+} from './execution-model'
 import { canonicalHashV1 } from './hash'
 import type {
   CashChange,
@@ -323,6 +331,13 @@ type FailedComputation =
       readonly elapsedDays: number
       readonly annualYieldBps: number
     }
+  | {
+      readonly _tag: 'PositionNotional'
+      readonly sessionDate: string
+      readonly symbol: string
+      readonly quantityMicros: string
+      readonly priceMicros: string
+    }
 
 type InvalidIntegerIssue =
   | {
@@ -487,6 +502,7 @@ const freezePublicIssue = (issue: SimulationReconciliationIssue): SimulationReco
         case 'FillTerms':
         case 'FeeSchedule':
         case 'CashYield':
+        case 'PositionNotional':
           return Object.freeze(Object.assign({}, issue, { computation: Object.freeze({ ...issue.computation }) }))
       }
     }
@@ -663,7 +679,7 @@ const computeFillTerms = (
   referencePriceMicros: bigint,
   simulation: SimulationTrace,
   costMultiplierMicros: bigint,
-): Validation<ReturnType<typeof makeFillTerms>> => {
+): Validation<FillTerms> => {
   const computation: FailedComputation = {
     _tag: 'FillTerms',
     fillId: fill.id,
@@ -672,11 +688,10 @@ const computeFillTerms = (
     referencePriceMicros: referencePriceMicros.toString(),
     costMultiplierMicros: costMultiplierMicros.toString(),
   }
-  return Result.try({
-    try: () =>
-      makeFillTerms(fill.side, quantityMicros, referencePriceMicros, simulation.executionModel, costMultiplierMicros),
-    catch: (cause): readonly SimulationReconciliationIssue[] => [{ _tag: 'ComputationFailed', computation, cause }],
-  })
+  return Result.mapError(
+    makeFillTerms(fill.side, quantityMicros, referencePriceMicros, simulation.executionModel, costMultiplierMicros),
+    (cause): readonly SimulationReconciliationIssue[] => [{ _tag: 'ComputationFailed', computation, cause }],
+  )
 }
 
 const validateFill = (
@@ -871,17 +886,17 @@ const feeSchedule = (
   inputs: readonly FeeInput[],
   simulation: SimulationTrace,
   costMultiplierMicros: bigint,
-): Validation<ReturnType<typeof calculateSessionFees>> => {
+): Validation<FeeBreakdown> => {
   const computation: FailedComputation = {
     _tag: 'FeeSchedule',
     feeId: fee.id,
     fillCount: inputs.length,
     costMultiplierMicros: costMultiplierMicros.toString(),
   }
-  return Result.try({
-    try: () => calculateSessionFees(inputs, simulation.executionModel, costMultiplierMicros),
-    catch: (cause): readonly SimulationReconciliationIssue[] => [{ _tag: 'ComputationFailed', computation, cause }],
-  })
+  return Result.mapError(
+    calculateSessionFees(inputs, simulation.executionModel, costMultiplierMicros),
+    (cause): readonly SimulationReconciliationIssue[] => [{ _tag: 'ComputationFailed', computation, cause }],
+  )
 }
 
 const validateFee = (
@@ -1400,10 +1415,10 @@ const cashYieldTransition = (
     elapsedDays: event.elapsedDays,
     annualYieldBps: simulation.executionModel.cash.annualYieldBps,
   }
-  const expected = Result.try({
-    try: () => accrueCashYield(cashMicros, event.elapsedDays, simulation.executionModel),
-    catch: (cause): readonly SimulationReconciliationIssue[] => [{ _tag: 'ComputationFailed', computation, cause }],
-  })
+  const expected = Result.mapError(
+    accrueCashYield(cashMicros, event.elapsedDays, simulation.executionModel),
+    (cause): readonly SimulationReconciliationIssue[] => [{ _tag: 'ComputationFailed', computation, cause }],
+  )
   if (Result.isFailure(expected)) return failIssues(expected.failure)
   const amount = unsigned({
     kind: 'cash-yield',
@@ -1576,14 +1591,26 @@ const valueMarkedPositions = (state: MutableReconstructionState, mark: DailyPosi
     if (Result.isFailure(costBasis)) {
       return positionIssues.length > 0 ? failIssues(positionIssues) : Result.fail(costBasis.failure)
     }
-    // Both operands are parsed unsigned integers and notionalMicros divides by the fixed non-zero MICROS constant.
     const reconstructedValue = notionalMicros(quantity, price.success)
-    reconstructedPositionValueMicros += reconstructedValue
+    if (Result.isFailure(reconstructedValue)) {
+      return fail({
+        _tag: 'ComputationFailed',
+        computation: {
+          _tag: 'PositionNotional',
+          sessionDate: mark.sessionDate,
+          symbol: position.symbol,
+          quantityMicros: quantity.toString(),
+          priceMicros: price.success.toString(),
+        },
+        cause: reconstructedValue.failure,
+      })
+    }
+    reconstructedPositionValueMicros += reconstructedValue.success
     const marketValue = positionUnsigned(mark, position, 'marketValueMicros')
     if (Result.isFailure(marketValue)) {
       return positionIssues.length > 0 ? failIssues(positionIssues) : Result.fail(marketValue.failure)
     }
-    if (marketValue.success !== reconstructedValue) {
+    if (marketValue.success !== reconstructedValue.success) {
       positionIssues.push({
         _tag: 'EvidenceMismatch',
         problem: {
@@ -1592,7 +1619,7 @@ const valueMarkedPositions = (state: MutableReconstructionState, mark: DailyPosi
           symbol: position.symbol,
           field: 'marketValueMicros',
           actualMicros: marketValue.success.toString(),
-          expectedMicros: reconstructedValue.toString(),
+          expectedMicros: reconstructedValue.success.toString(),
         },
       })
     }

--- a/services/bayn/src/simulation.ts
+++ b/services/bayn/src/simulation.ts
@@ -1,3 +1,5 @@
+import { pipe, Result } from 'effect'
+
 import { makeRunIdentity, makeStrategyProtocolHash, type RuntimeProvenance } from './contracts'
 import {
   MICROS,
@@ -13,6 +15,8 @@ import {
   referencePriceMicros,
   saleCostBasisMicros,
   scaleQuantityMicros,
+  type ExecutionModelFailure,
+  type FeeBreakdown,
   type FeeInput,
   type FillTerms,
 } from './execution-model'
@@ -65,6 +69,18 @@ export interface SimulationResult {
   readonly dailyPerformance: readonly DailyPerformancePoint[]
   readonly simulation: SimulationTrace | null
 }
+
+export type SimulationFailure =
+  | ExecutionModelFailure
+  | {
+      readonly _tag: 'UnsupportedSimulationExecutionModel'
+      readonly actual: string
+      readonly required: 'bayn.execution-model.v2'
+    }
+
+export type SimulationDecision = Result.Result<SimulationResult, SimulationFailure>
+
+type SimulationComputation<A> = Result.Result<A, SimulationFailure>
 
 export const TRADING_DAYS = 252
 
@@ -226,33 +242,36 @@ const makeOrder = (
   requestedQuantityMicros: bigint,
   referencePrice: bigint,
   protocol: SimulationProtocol,
-): SimulatedOrder => {
-  const outcome = makeOrderOutcome({
-    identity: {
-      schemaVersion: ContractVersion.PartialFillSeed,
-      signalDate: decision.signalDate,
-      executionDate: decision.executionDate,
-      symbol,
+): SimulationComputation<SimulatedOrder> =>
+  pipe(
+    makeOrderOutcome({
+      identity: {
+        schemaVersion: ContractVersion.PartialFillSeed,
+        signalDate: decision.signalDate,
+        executionDate: decision.executionDate,
+        symbol,
+        side,
+      },
       side,
-    },
-    side,
-    requestedQuantityMicros,
-    referencePriceMicros: referencePrice,
-    model: protocol.executionModel,
-  })
-  const payload = {
-    decisionId: decision.id,
-    sessionDate,
-    symbol,
-    side,
-    requestedQuantityMicros: outcome.requestedQuantityMicros.toString(),
-    filledQuantityMicros: outcome.filledQuantityMicros.toString(),
-    status: outcome.status,
-    rejectionReason: outcome.rejectionReason,
-    unfilledRemainder: outcome.unfilledRemainder,
-  }
-  return { id: canonicalHashV1({ runId, kind: 'order', ...payload }), ...payload }
-}
+      requestedQuantityMicros,
+      referencePriceMicros: referencePrice,
+      model: protocol.executionModel,
+    }),
+    Result.map((outcome) => {
+      const payload = {
+        decisionId: decision.id,
+        sessionDate,
+        symbol,
+        side,
+        requestedQuantityMicros: outcome.requestedQuantityMicros.toString(),
+        filledQuantityMicros: outcome.filledQuantityMicros.toString(),
+        status: outcome.status,
+        rejectionReason: outcome.rejectionReason,
+        unfilledRemainder: outcome.unfilledRemainder,
+      }
+      return { id: canonicalHashV1({ runId, kind: 'order', ...payload }), ...payload }
+    }),
+  )
 
 const limitOrderFillToBuyingPower = (
   runId: string,
@@ -320,7 +339,7 @@ const makeCashChange = (
   return { id: canonicalHashV1({ runId, kind: 'cash-change', ...payload }), ...payload }
 }
 
-const makeFeeEvent = (runId: string, sessionDate: IsoDate, fees: ReturnType<typeof calculateSessionFees>): FeeEvent => {
+const makeFeeEvent = (runId: string, sessionDate: IsoDate, fees: FeeBreakdown): FeeEvent => {
   const payload = {
     sessionDate,
     commissionMicros: fees.commissionMicros.toString(),
@@ -343,6 +362,131 @@ const makeCashYieldEvent = (
   return { kind: 'cash-yield' as const, id: canonicalHashV1({ runId, kind: 'cash-yield', ...payload }), ...payload }
 }
 
+const referencePricesFor = (
+  bars: Readonly<Record<string, DailyBar>>,
+  protocol: SimulationProtocol,
+  price: (bar: DailyBar) => number,
+): SimulationComputation<Readonly<Record<string, bigint>>> =>
+  pipe(
+    Result.all(
+      Object.entries(bars).map(([symbol, bar]) =>
+        pipe(
+          referencePriceMicros(price(bar), protocol.executionModel),
+          Result.map((priceMicros) => [symbol, priceMicros] as const),
+        ),
+      ),
+    ),
+    Result.map((entries) => Object.fromEntries(entries)),
+  )
+
+const positionValueMicros = (
+  prices: Readonly<Record<string, bigint>>,
+  positions: ReadonlyMap<string, Position>,
+): SimulationComputation<bigint> =>
+  Object.entries(prices).reduce<SimulationComputation<bigint>>(
+    (total, [symbol, price]) =>
+      pipe(
+        total,
+        Result.flatMap((value) =>
+          pipe(
+            notionalMicros(positions.get(symbol)?.quantityMicros ?? 0n, price),
+            Result.map((notional) => value + notional),
+          ),
+        ),
+      ),
+    Result.succeed(0n),
+  )
+
+const desiredQuantitiesFor = (
+  planningEquityMicros: bigint,
+  weights: Readonly<Record<string, number>>,
+  prices: Readonly<Record<string, bigint>>,
+  protocol: SimulationProtocol,
+): SimulationComputation<Readonly<Record<string, bigint>>> =>
+  pipe(
+    Result.all(
+      Object.entries(weights).map(([symbol, weight]) =>
+        pipe(
+          desiredQuantityMicros(planningEquityMicros, weight, prices[symbol], protocol.executionModel),
+          Result.map((quantityMicros) => [symbol, quantityMicros] as const),
+        ),
+      ),
+    ),
+    Result.map((entries) => Object.fromEntries(entries)),
+  )
+
+interface BuyCandidate {
+  readonly symbol: string
+  readonly quantityMicros: bigint
+}
+
+const scaledBuyFeeInputs = (
+  buys: readonly BuyCandidate[],
+  scalePpm: bigint,
+  prices: Readonly<Record<string, bigint>>,
+  protocol: SimulationProtocol,
+  costMultiplierMicros: bigint,
+  minimumNotionalMicros?: bigint,
+): SimulationComputation<readonly FeeInput[]> =>
+  buys.reduce<SimulationComputation<readonly FeeInput[]>>(
+    (result, buy) =>
+      pipe(
+        result,
+        Result.flatMap((inputs) =>
+          pipe(
+            scaleQuantityMicros(buy.quantityMicros, scalePpm, protocol.executionModel),
+            Result.flatMap((quantityMicros) => {
+              if (quantityMicros === 0n) return Result.succeed(inputs)
+              return pipe(
+                notionalMicros(quantityMicros, prices[buy.symbol]),
+                Result.flatMap((referenceNotionalMicros) => {
+                  if (minimumNotionalMicros !== undefined && referenceNotionalMicros < minimumNotionalMicros) {
+                    return Result.succeed(inputs)
+                  }
+                  return pipe(
+                    makeFillTerms(
+                      'buy',
+                      quantityMicros,
+                      prices[buy.symbol],
+                      protocol.executionModel,
+                      costMultiplierMicros,
+                    ),
+                    Result.map((terms) => [
+                      ...inputs,
+                      { side: 'buy' as const, quantityMicros, notionalMicros: terms.notionalMicros },
+                    ]),
+                  )
+                }),
+              )
+            }),
+          ),
+        ),
+      ),
+    Result.succeed([]),
+  )
+
+const buysAffordable = (
+  buys: readonly BuyCandidate[],
+  scalePpm: bigint,
+  prices: Readonly<Record<string, bigint>>,
+  protocol: SimulationProtocol,
+  costMultiplierMicros: bigint,
+  availableCashMicros: bigint,
+  minimumNotionalMicros?: bigint,
+): SimulationComputation<boolean> =>
+  pipe(
+    scaledBuyFeeInputs(buys, scalePpm, prices, protocol, costMultiplierMicros, minimumNotionalMicros),
+    Result.flatMap((inputs) =>
+      pipe(
+        calculateSessionFees(inputs, protocol.executionModel, costMultiplierMicros),
+        Result.map(
+          (fees) =>
+            inputs.reduce((sum, fill) => sum + fill.notionalMicros, 0n) + fees.totalMicros <= availableCashMicros,
+        ),
+      ),
+    ),
+  )
+
 export const simulate = (
   sessions: readonly AlignedSession[],
   targets: readonly SimulationTarget[],
@@ -351,9 +495,13 @@ export const simulate = (
   costMultiplierMicros: bigint,
   runId: string,
   recordEvents: boolean,
-): SimulationResult => {
+): SimulationDecision => {
   if (protocol.executionModel.schemaVersion !== 'bayn.execution-model.v2') {
-    throw new Error('simulation requires the causal bayn.execution-model.v2 contract')
+    return Result.fail({
+      _tag: 'UnsupportedSimulationExecutionModel',
+      actual: protocol.executionModel.schemaVersion,
+      required: 'bayn.execution-model.v2',
+    })
   }
   const targetsByExecution = new Map(targets.map((target) => [target.executionIndex, target]))
   const positions = new Map<string, Position>()
@@ -386,8 +534,12 @@ export const simulate = (
     const planningCashSnapshotMicros = cashMicros
 
     if (previousSessionDate !== undefined) {
-      const elapsedDays = elapsedCalendarDays(previousSessionDate, session.date)
-      const cashYield = accrueCashYield(cashMicros, elapsedDays, protocol.executionModel)
+      const elapsedDaysResult = elapsedCalendarDays(previousSessionDate, session.date)
+      if (Result.isFailure(elapsedDaysResult)) return Result.fail(elapsedDaysResult.failure)
+      const elapsedDays = elapsedDaysResult.success
+      const cashYieldResult = accrueCashYield(cashMicros, elapsedDays, protocol.executionModel)
+      if (Result.isFailure(cashYieldResult)) return Result.fail(cashYieldResult.failure)
+      const cashYield = cashYieldResult.success
       if (cashYield > 0n) {
         cashMicros += cashYield
         totalCashYieldMicros += cashYield
@@ -429,31 +581,24 @@ export const simulate = (
         signalDecisions.push({ ...target.decision, decisionId: decision.id, executionDate: decision.executionDate })
       }
 
-      const planningPrices = Object.fromEntries(
-        Object.entries(sessions[target.signalIndex].bars).map(([symbol, bar]) => [
-          symbol,
-          referencePriceMicros(bar.close, protocol.executionModel),
-        ]),
-      ) as Readonly<Record<string, bigint>>
-      const executionOpenPrices = Object.fromEntries(
-        Object.entries(session.bars).map(([symbol, bar]) => [
-          symbol,
-          referencePriceMicros(bar.open, protocol.executionModel),
-        ]),
-      ) as Readonly<Record<string, bigint>>
+      const planningPricesResult = referencePricesFor(sessions[target.signalIndex].bars, protocol, (bar) => bar.close)
+      if (Result.isFailure(planningPricesResult)) return Result.fail(planningPricesResult.failure)
+      const planningPrices = planningPricesResult.success
+      const executionOpenPricesResult = referencePricesFor(session.bars, protocol, (bar) => bar.open)
+      if (Result.isFailure(executionOpenPricesResult)) return Result.fail(executionOpenPricesResult.failure)
+      const executionOpenPrices = executionOpenPricesResult.success
       const planningCashMicros = planningCashSnapshotMicros
-      const planningEquityMicros =
-        planningCashSnapshotMicros +
-        Object.entries(planningPrices).reduce(
-          (value, [symbol, price]) => value + notionalMicros(positions.get(symbol)?.quantityMicros ?? 0n, price),
-          0n,
-        )
-      const desiredQuantities = Object.fromEntries(
-        Object.entries(target.weights).map(([symbol, weight]) => [
-          symbol,
-          desiredQuantityMicros(planningEquityMicros, weight, planningPrices[symbol], protocol.executionModel),
-        ]),
-      ) as Readonly<Record<string, bigint>>
+      const planningPositionValue = positionValueMicros(planningPrices, positions)
+      if (Result.isFailure(planningPositionValue)) return Result.fail(planningPositionValue.failure)
+      const planningEquityMicros = planningCashSnapshotMicros + planningPositionValue.success
+      const desiredQuantitiesResult = desiredQuantitiesFor(
+        planningEquityMicros,
+        target.weights,
+        planningPrices,
+        protocol,
+      )
+      if (Result.isFailure(desiredQuantitiesResult)) return Result.fail(desiredQuantitiesResult.failure)
+      const desiredQuantities = desiredQuantitiesResult.success
       const sessionFills: FillEvent[] = []
 
       const plannedSells = Object.keys(target.weights)
@@ -482,110 +627,109 @@ export const simulate = (
           }
         })
         .filter((buy) => buy.quantityMicros > 0n)
-      const plannedBuysAffordable = (scalePpm: bigint): boolean => {
-        const buyInputs = proposedBuys.flatMap((buy): FeeInput[] => {
-          const quantity = scaleQuantityMicros(buy.quantityMicros, scalePpm, protocol.executionModel)
-          if (
-            quantity === 0n ||
-            notionalMicros(quantity, planningPrices[buy.symbol]) <
-              BigInt(protocol.executionModel.precision.minimumBuyNotionalMicros)
-          ) {
-            return []
-          }
-          const terms = makeFillTerms(
-            'buy',
-            quantity,
-            planningPrices[buy.symbol],
-            protocol.executionModel,
-            costMultiplierMicros,
-          )
-          return [{ side: 'buy', quantityMicros: quantity, notionalMicros: terms.notionalMicros }]
-        })
-        const fees = calculateSessionFees(buyInputs, protocol.executionModel, costMultiplierMicros)
-        return buyInputs.reduce((sum, fill) => sum + fill.notionalMicros, 0n) + fees.totalMicros <= planningCashMicros
-      }
+      const minimumBuyNotionalMicros = BigInt(protocol.executionModel.precision.minimumBuyNotionalMicros)
       let plannedBuyScale = 0n
       let maximumPlannedBuyScale = ppm
       while (plannedBuyScale < maximumPlannedBuyScale) {
         const candidate = (plannedBuyScale + maximumPlannedBuyScale + 1n) / 2n
-        if (plannedBuysAffordable(candidate)) plannedBuyScale = candidate
+        const affordable = buysAffordable(
+          proposedBuys,
+          candidate,
+          planningPrices,
+          protocol,
+          costMultiplierMicros,
+          planningCashMicros,
+          minimumBuyNotionalMicros,
+        )
+        if (Result.isFailure(affordable)) return Result.fail(affordable.failure)
+        if (affordable.success) plannedBuyScale = candidate
         else maximumPlannedBuyScale = candidate - 1n
       }
-      const sellOrders = plannedSells.map((sell) =>
-        makeOrder(
+      const sellOrdersResult = Result.all(
+        plannedSells.map((sell) =>
+          makeOrder(
+            runId,
+            decision,
+            session.date,
+            sell.symbol,
+            'sell',
+            sell.quantityMicros,
+            executionOpenPrices[sell.symbol],
+            protocol,
+          ),
+        ),
+      )
+      if (Result.isFailure(sellOrdersResult)) return Result.fail(sellOrdersResult.failure)
+      const sellOrders = sellOrdersResult.success
+      const plannedBuyOrders: SimulatedOrder[] = []
+      for (const buy of proposedBuys) {
+        const requestedQuantity = scaleQuantityMicros(buy.quantityMicros, plannedBuyScale, protocol.executionModel)
+        if (Result.isFailure(requestedQuantity)) return Result.fail(requestedQuantity.failure)
+        if (requestedQuantity.success === 0n) continue
+        const requestedNotional = notionalMicros(requestedQuantity.success, planningPrices[buy.symbol])
+        if (Result.isFailure(requestedNotional)) return Result.fail(requestedNotional.failure)
+        if (requestedNotional.success < minimumBuyNotionalMicros) continue
+        const order = makeOrder(
           runId,
           decision,
           session.date,
-          sell.symbol,
-          'sell',
-          sell.quantityMicros,
-          executionOpenPrices[sell.symbol],
+          buy.symbol,
+          'buy',
+          requestedQuantity.success,
+          executionOpenPrices[buy.symbol],
           protocol,
-        ),
-      )
-      const plannedBuyOrders = proposedBuys.flatMap((buy): SimulatedOrder[] => {
-        const requestedQuantity = scaleQuantityMicros(buy.quantityMicros, plannedBuyScale, protocol.executionModel)
-        return requestedQuantity === 0n ||
-          notionalMicros(requestedQuantity, planningPrices[buy.symbol]) <
-            BigInt(protocol.executionModel.precision.minimumBuyNotionalMicros)
-          ? []
-          : [
-              makeOrder(
-                runId,
-                decision,
-                session.date,
-                buy.symbol,
-                'buy',
-                requestedQuantity,
-                executionOpenPrices[buy.symbol],
-                protocol,
-              ),
-            ]
-      })
-      const executionBuysAffordable = (scalePpm: bigint): boolean => {
-        const buyInputs = plannedBuyOrders.flatMap((order): FeeInput[] => {
-          const quantity = scaleQuantityMicros(BigInt(order.filledQuantityMicros), scalePpm, protocol.executionModel)
-          if (quantity === 0n) return []
-          const terms = makeFillTerms(
-            'buy',
-            quantity,
-            executionOpenPrices[order.symbol],
-            protocol.executionModel,
-            costMultiplierMicros,
-          )
-          return [{ side: 'buy', quantityMicros: quantity, notionalMicros: terms.notionalMicros }]
-        })
-        const fees = calculateSessionFees(buyInputs, protocol.executionModel, costMultiplierMicros)
-        return buyInputs.reduce((sum, fill) => sum + fill.notionalMicros, 0n) + fees.totalMicros <= planningCashMicros
+        )
+        if (Result.isFailure(order)) return Result.fail(order.failure)
+        plannedBuyOrders.push(order.success)
       }
+      const plannedFillCandidates = plannedBuyOrders.map((order) => ({
+        symbol: order.symbol,
+        quantityMicros: BigInt(order.filledQuantityMicros),
+      }))
       let executionBuyScale = 0n
       let maximumExecutionBuyScale = ppm
       while (executionBuyScale < maximumExecutionBuyScale) {
         const candidate = (executionBuyScale + maximumExecutionBuyScale + 1n) / 2n
-        if (executionBuysAffordable(candidate)) executionBuyScale = candidate
+        const affordable = buysAffordable(
+          plannedFillCandidates,
+          candidate,
+          executionOpenPrices,
+          protocol,
+          costMultiplierMicros,
+          planningCashMicros,
+        )
+        if (Result.isFailure(affordable)) return Result.fail(affordable.failure)
+        if (affordable.success) executionBuyScale = candidate
         else maximumExecutionBuyScale = candidate - 1n
       }
-      const buyOrders = plannedBuyOrders.map((order) =>
-        limitOrderFillToBuyingPower(
-          runId,
-          order,
-          scaleQuantityMicros(BigInt(order.filledQuantityMicros), executionBuyScale, protocol.executionModel),
-        ),
-      )
+      const buyOrders: SimulatedOrder[] = []
+      for (const order of plannedBuyOrders) {
+        const filledQuantity = scaleQuantityMicros(
+          BigInt(order.filledQuantityMicros),
+          executionBuyScale,
+          protocol.executionModel,
+        )
+        if (Result.isFailure(filledQuantity)) return Result.fail(filledQuantity.failure)
+        buyOrders.push(limitOrderFillToBuyingPower(runId, order, filledQuantity.success))
+      }
 
       for (const order of sellOrders) {
         if (recordEvents) orders.push(order)
         const position = positions.get(order.symbol) ?? { quantityMicros: 0n, costBasisMicros: 0n }
         const filledQuantity = BigInt(order.filledQuantityMicros)
         if (filledQuantity > 0n) {
-          const terms = makeFillTerms(
+          const termsResult = makeFillTerms(
             'sell',
             filledQuantity,
             executionOpenPrices[order.symbol],
             protocol.executionModel,
             costMultiplierMicros,
           )
-          const costBasis = saleCostBasisMicros(position.costBasisMicros, filledQuantity, position.quantityMicros)
+          if (Result.isFailure(termsResult)) return Result.fail(termsResult.failure)
+          const terms = termsResult.success
+          const costBasisResult = saleCostBasisMicros(position.costBasisMicros, filledQuantity, position.quantityMicros)
+          if (Result.isFailure(costBasisResult)) return Result.fail(costBasisResult.failure)
+          const costBasis = costBasisResult.success
           const fill = makeFill(runId, decision, order, terms, costBasis)
           cashMicros += terms.notionalMicros
           turnoverMicros += terms.notionalMicros
@@ -606,13 +750,15 @@ export const simulate = (
         if (recordEvents) orders.push(order)
         const filledQuantity = BigInt(order.filledQuantityMicros)
         if (filledQuantity > 0n) {
-          const terms = makeFillTerms(
+          const termsResult = makeFillTerms(
             'buy',
             filledQuantity,
             executionOpenPrices[order.symbol],
             protocol.executionModel,
             costMultiplierMicros,
           )
+          if (Result.isFailure(termsResult)) return Result.fail(termsResult.failure)
+          const terms = termsResult.success
           const fill = makeFill(runId, decision, order, terms, terms.notionalMicros)
           cashMicros -= terms.notionalMicros
           turnoverMicros += terms.notionalMicros
@@ -635,7 +781,9 @@ export const simulate = (
         quantityMicros: BigInt(fill.quantityMicros),
         notionalMicros: BigInt(fill.notionalMicros),
       }))
-      const fees = calculateSessionFees(feeInputs, protocol.executionModel, costMultiplierMicros)
+      const feesResult = calculateSessionFees(feeInputs, protocol.executionModel, costMultiplierMicros)
+      if (Result.isFailure(feesResult)) return Result.fail(feesResult.failure)
+      const fees = feesResult.success
       if (fees.totalMicros > 0n) {
         cashMicros -= fees.totalMicros
         totalFeesMicros += fees.totalMicros
@@ -648,18 +796,12 @@ export const simulate = (
       if (cashMicros < 0n) throw new Error(`simulation spent unavailable cash: ${cashMicros}`)
     }
 
-    const closingPrices = Object.fromEntries(
-      Object.entries(session.bars).map(([symbol, bar]) => [
-        symbol,
-        referencePriceMicros(bar.close, protocol.executionModel),
-      ]),
-    ) as Readonly<Record<string, bigint>>
-    const closingEquityMicros =
-      cashMicros +
-      Object.entries(closingPrices).reduce(
-        (value, [symbol, price]) => value + notionalMicros(positions.get(symbol)?.quantityMicros ?? 0n, price),
-        0n,
-      )
+    const closingPricesResult = referencePricesFor(session.bars, protocol, (bar) => bar.close)
+    if (Result.isFailure(closingPricesResult)) return Result.fail(closingPricesResult.failure)
+    const closingPrices = closingPricesResult.success
+    const closingPositionValue = positionValueMicros(closingPrices, positions)
+    if (Result.isFailure(closingPositionValue)) return Result.fail(closingPositionValue.failure)
+    const closingEquityMicros = cashMicros + closingPositionValue.success
     equityMicros.push(closingEquityMicros)
     const netReturn = Number(closingEquityMicros) / Number(previousEquityMicros) - 1
     peakEquityMicros = peakEquityMicros > closingEquityMicros ? peakEquityMicros : closingEquityMicros
@@ -682,28 +824,32 @@ export const simulate = (
     } satisfies DailyPerformancePoint
     dailyPerformance.push(performance)
     if (recordEvents) {
+      const markedPositions: DailyPositionMark['positions'][number][] = []
+      for (const [symbol] of Object.entries(session.bars).sort(([left], [right]) =>
+        left < right ? -1 : left > right ? 1 : 0,
+      )) {
+        const position = positions.get(symbol) ?? { quantityMicros: 0n, costBasisMicros: 0n }
+        const priceMicros = closingPrices[symbol]
+        const marketValue = notionalMicros(position.quantityMicros, priceMicros)
+        if (Result.isFailure(marketValue)) return Result.fail(marketValue.failure)
+        markedPositions.push({
+          symbol,
+          quantityMicros: position.quantityMicros.toString(),
+          costBasisMicros: position.costBasisMicros.toString(),
+          priceMicros: priceMicros.toString(),
+          marketValueMicros: marketValue.success.toString(),
+        })
+      }
       dailyMarks.push({
         ...performance,
         cashMicros: cashMicros.toString(),
-        positions: Object.entries(session.bars)
-          .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
-          .map(([symbol]) => {
-            const position = positions.get(symbol) ?? { quantityMicros: 0n, costBasisMicros: 0n }
-            const priceMicros = closingPrices[symbol]
-            return {
-              symbol,
-              quantityMicros: position.quantityMicros.toString(),
-              costBasisMicros: position.costBasisMicros.toString(),
-              priceMicros: priceMicros.toString(),
-              marketValueMicros: notionalMicros(position.quantityMicros, priceMicros).toString(),
-            }
-          }),
+        positions: markedPositions,
       })
     }
     previousEquityMicros = closingEquityMicros
   }
 
-  return {
+  return Result.succeed({
     metrics: calculateExactPerformanceMetrics(
       equityMicros,
       turnoverMicros,
@@ -726,7 +872,7 @@ export const simulate = (
           dailyMarks,
         }
       : null,
-  }
+  })
 }
 
 export const buildVerdict = (

--- a/services/bayn/src/strategy.ts
+++ b/services/bayn/src/strategy.ts
@@ -1,6 +1,7 @@
 import { Result, Schema } from 'effect'
 
 import type { RuntimeProvenance } from './contracts'
+import type { ExecutionModelFailure } from './execution-model'
 import { InputManifestArtifactSchema } from './evidence-contracts'
 import {
   defaultQualificationStatisticsPolicyDocument,
@@ -28,6 +29,7 @@ import type { DailyBar, EvaluationResult, InputManifest, IsoDate, Protocol } fro
 
 export type CurrentStrategyDecision = CurrentRiskBalancedTrendDecision
 export type CurrentStrategyDecisionCycleBinding = CurrentDecisionCycleBinding
+export type CurrentStrategyDecisionFailure = ExecutionModelFailure
 
 export interface Strategy {
   readonly name: string
@@ -41,7 +43,7 @@ export interface Strategy {
     bars: readonly DailyBar[],
     manifest: InputManifest,
     cycleBinding: CurrentStrategyDecisionCycleBinding,
-  ) => CurrentStrategyDecision
+  ) => Result.Result<CurrentStrategyDecision, CurrentStrategyDecisionFailure>
   readonly prepareLock: (
     manifest: InputManifest,
     sessionDates: readonly IsoDate[],

--- a/services/bayn/src/target-planner.ts
+++ b/services/bayn/src/target-planner.ts
@@ -747,12 +747,11 @@ const derivePlannedTargetFacts = (
         Result.flatMap(result, (targetFacts) => {
           const currentQuantity = facts.positions.get(symbol) ?? 0n
           return Result.map(
-            Result.try({
-              try: () =>
-                desiredQuantityMicros(facts.equity, facts.input.targetWeights[symbol], referencePrice, {
-                  precision: facts.input.precision,
-                }),
-              catch: (cause) =>
+            Result.mapError(
+              desiredQuantityMicros(facts.equity, facts.input.targetWeights[symbol], referencePrice, {
+                precision: facts.input.precision,
+              }),
+              (cause) =>
                 deriveTargetsFailure(
                   'precision',
                   'target quantity could not be represented at the declared precision',
@@ -763,7 +762,7 @@ const derivePlannedTargetFacts = (
                   },
                   cause,
                 ),
-            }),
+            ),
             (targetQuantity) => [
               ...targetFacts,
               {


### PR DESCRIPTION
## Summary

- Replaces throw-based execution-model arithmetic and order decisions with pure `Result` values and readonly discriminated failure data.
- Propagates the honest interface through simulation, strategy planning, OBSERVE composition, reconciliation, and the independent qualification audit without compatibility wrappers.
- Preserves execution hashes, deterministic partial fills, fee and cash-yield arithmetic, no-sell-proceeds buying power, audit independence, and existing safety boundaries through golden and causality regressions.
- Keeps broader throw-based strategy and manifest validation outside this execution-model slice.

## Related Issues

None

## Testing

- `bun test src/execution-model.test.ts src/simulation-causality.test.ts src/simulation-reconciliation.test.ts src/risk-balanced-trend.test.ts src/observe-composition.test.ts src/qualification-reference.test.ts src/qualification-audit.test.ts src/target-planner.test.ts`
- `bun run --filter @proompteng/bayn test` (638 passed, 116 environment-gated integration tests skipped, 0 failed)
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn build`

## Breaking Changes

None. All in-repository direct callers were migrated atomically.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are handled: no documentation or release-note change is required for this internal refactor; broader strategy validation totalization remains a separate application-wide slice.