### PR TITLE
fix(bayn): preserve observability retryability

### DIFF
--- a/services/bayn/src/http.ts
+++ b/services/bayn/src/http.ts
@@ -8,12 +8,13 @@ import type { RuntimeBuildMetadata, RuntimeConfig } from './config'
 import type { RuntimeProvenance } from './contracts'
 import { CycleOperationsCondition, CycleOperationsReason } from './cycle-observability'
 import { CycleState, CycleTerminalReason } from './cycle'
+import type { DatabaseError, EvidenceStoreService } from './db/evidence-store'
 import type { OperationalError } from './errors'
 import { databaseOperation, withinDeadline } from './operations'
 import { Authority } from './paper'
 import { isReady, type DependencyHealth, type RuntimeState } from './runtime-state'
 
-type ReadEvidence = (runId: string) => Effect.Effect<Option.Option<unknown>, { readonly message: string }>
+type ReadEvidence = EvidenceStoreService['read']
 
 export type HttpResponseDecision =
   | {
@@ -248,7 +249,7 @@ export const historicalReadFailureDecision = (runId: string, error: OperationalE
   }) as const
 
 export const readHistoricalEvidence = <A, R>(
-  read: Effect.Effect<Option.Option<A>, { readonly message: string }, R>,
+  read: Effect.Effect<Option.Option<A>, DatabaseError, R>,
   timeoutMs: number,
 ): Effect.Effect<Option.Option<A>, OperationalError, R> =>
   withinDeadline(databaseOperation(read, 'read-evidence'), timeoutMs, 'database', 'read-evidence')

--- a/services/bayn/src/operations.test.ts
+++ b/services/bayn/src/operations.test.ts
@@ -10,6 +10,7 @@ import {
   UnknownError,
 } from 'effect/unstable/sql/SqlError'
 
+import { CycleObservabilityError } from './db/cycle-observability'
 import { DatabaseError } from './db/evidence-store'
 import { acquireSqlLayer, databaseOperation } from './operations'
 
@@ -256,5 +257,45 @@ describe('Bayn database operation failures', () => {
     expect(authentication.retryable).toBe(false)
     expect(authorization.retryable).toBe(false)
     expect(connection.retryable).toBe(true)
+  })
+
+  test('preserves transient cycle-observability query retryability without widening the error boundary', async () => {
+    const classify = (cause: SqlError) =>
+      Effect.runPromise(
+        Effect.flip(
+          databaseOperation(
+            Effect.fail(
+              new CycleObservabilityError({
+                operation: 'read',
+                failure: 'query',
+                message: cause.message,
+                cause,
+              }),
+            ),
+            'cycle-observability',
+          ),
+        ),
+      )
+
+    const [connection, authorization] = await Promise.all([
+      classify(
+        new SqlError({
+          reason: new ConnectionError({ cause: new Error('connection reset'), operation: 'query' }),
+        }),
+      ),
+      classify(
+        new SqlError({
+          reason: new AuthorizationError({ cause: new Error('permission denied'), operation: 'query' }),
+        }),
+      ),
+    ])
+
+    expect(connection).toMatchObject({
+      component: 'database',
+      operation: 'cycle-observability',
+      retryable: true,
+    })
+    expect(connection.cause).toBeInstanceOf(CycleObservabilityError)
+    expect(authorization.retryable).toBe(false)
   })
 })

--- a/services/bayn/src/operations.ts
+++ b/services/bayn/src/operations.ts
@@ -1,8 +1,11 @@
 import { Duration, Effect, Layer, Schedule } from 'effect'
 import { isSqlError } from 'effect/unstable/sql/SqlError'
 
+import { CycleObservabilityError } from './db/cycle-observability'
 import { DatabaseError } from './db/evidence-store'
 import { operationalError, retryableOperationalError, type Component, type OperationalError } from './errors'
+
+type DatabaseOperationFailure = DatabaseError | CycleObservabilityError
 
 const isRetryableSqlAcquisition = (error: unknown): boolean => {
   if (isSqlError(error)) return error.isRetryable
@@ -48,15 +51,15 @@ export const withinDeadline = <A, R>(
   )
 
 export const databaseOperation = <A, R>(
-  effect: Effect.Effect<A, { readonly message: string }, R>,
+  effect: Effect.Effect<A, DatabaseOperationFailure, R>,
   operation: string,
 ): Effect.Effect<A, OperationalError, R> =>
   effect.pipe(
     Effect.mapError((cause) => {
       const retryable =
-        cause instanceof DatabaseError &&
-        cause.failure === 'unavailable' &&
-        (!isSqlError(cause.cause) || cause.cause.isRetryable)
+        cause instanceof DatabaseError
+          ? cause.failure === 'unavailable' && (!isSqlError(cause.cause) || cause.cause.isRetryable)
+          : cause.failure === 'query' && isSqlError(cause.cause) && cause.cause.isRetryable
       const makeError = retryable ? retryableOperationalError : operationalError
       return makeError('database', operation, `PostgreSQL ${operation} failed`, cause)
     }),


### PR DESCRIPTION
## Summary

- narrow the shared PostgreSQL operation boundary to the two actual store failure types
- preserve retryability for transient cycle-observability SQL query failures
- type historical evidence reads directly to `DatabaseError` instead of a structural message shape

## Related Issues

None

## Testing

- `bun test services/bayn/src/operations.test.ts services/bayn/src/http.test.ts services/bayn/src/health.test.ts` — 44 passed, 0 failed
- `bun run --filter @proompteng/bayn test` — 643 passed, 116 skipped, 0 failed
- `bun node_modules/typescript/bin/tsc -p services/bayn/tsconfig.json --noEmit`
- `bun run --cwd services/bayn lint:effect`
- `bun node_modules/oxfmt/bin/oxfmt --check services/bayn`
- `bun node_modules/oxlint/bin/oxlint --config .oxlintrc.json services/bayn`
- `bun node_modules/oxlint/bin/oxlint --config .oxlintrc.json --type-aware --tsconfig services/bayn/tsconfig.json services/bayn`
- `bun run --filter @proompteng/bayn build`
- `bun test packages/scripts/src/bayn` — 20 passed, 0 failed

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable and Breaking Changes is filled in.
- [x] No documentation or release-note update is required for this error-boundary correction.
