### PR TITLE
refactor(bayn): make cycle loop construction pure

### DIFF
--- a/services/bayn/src/cycle-runner.test.ts
+++ b/services/bayn/src/cycle-runner.test.ts
@@ -2256,7 +2256,7 @@ describe('autonomous cycle runner', () => {
     expect(control).toEqual({ acquisitions: [], binds: 0 })
   })
 
-  test('rejects invalid loop intervals before starting discovery', async () => {
+  test('rejects invalid loop intervals before starting discovery', () => {
     const control: StoreControl = { acquisitions: [], binds: 0 }
     for (const pollIntervalMs of [0, -1, 0.5, Number.MAX_SAFE_INTEGER + 1]) {
       const result = makeAutonomousCycleLoop({

--- a/services/bayn/src/cycle-runner.test.ts
+++ b/services/bayn/src/cycle-runner.test.ts
@@ -27,6 +27,7 @@ import {
   CycleRunnerError,
   cyclePassLogFacts,
   isMonthEndCycleDue,
+  makeAutonomousCycleLoop,
   makeDueCycleDraft,
   marketCalendarQueryForPublications,
   marketCalendarQueryForSignal,
@@ -35,7 +36,7 @@ import {
   selectCycleCalendarCandidate,
   selectDiscoveredPublications,
   selectNextExecutionSession,
-  startAutonomousCycleLoop,
+  type AutonomousCycleLoopOptions,
   type CycleCandidate,
   type CyclePassObservation,
   type CycleRunContext,
@@ -53,6 +54,9 @@ import {
 import { makeObserveShadowDecisionDocument, type ObserveShadowDecisionDocument } from './shadow-decision-contract'
 import { TargetPlanReason, TargetPlanStatus } from './target-planner'
 import { DataFeed, DataSource, PriceAdjustment, PublicationSchema, type InputManifest, type IsoDate } from './types'
+
+const cycleLoop = <E, R>(options: AutonomousCycleLoopOptions<E, R>) =>
+  Effect.fromResult(makeAutonomousCycleLoop(options))
 
 const signalCalendarVersion = 'signal-XNYS-2026-v1'
 const snapshotId = 'd'.repeat(64)
@@ -1337,7 +1341,7 @@ describe('autonomous cycle runner', () => {
     const program = Effect.scoped(
       Effect.gen(function* () {
         yield* TestClock.setTime(Date.parse('2026-01-30T21:20:00.000Z'))
-        const loop = yield* startAutonomousCycleLoop({
+        const loop = yield* cycleLoop({
           context: Effect.succeed(context()),
           observePass: (observation) => Effect.sync(() => observations.push(observation)),
           pollIntervalMs: 100,
@@ -1847,7 +1851,7 @@ describe('autonomous cycle runner', () => {
     const program = Effect.scoped(
       Effect.gen(function* () {
         yield* TestClock.setTime(Date.parse('2026-01-30T21:20:00.000Z'))
-        const loop = yield* startAutonomousCycleLoop({
+        const loop = yield* cycleLoop({
           context: Effect.succeed(context()),
           observePass: (observation) => Effect.sync(() => observations.push(observation)),
           pollIntervalMs: 100,
@@ -1907,7 +1911,7 @@ describe('autonomous cycle runner', () => {
     await Effect.runPromise(
       Effect.scoped(
         Effect.gen(function* () {
-          const loop = yield* startAutonomousCycleLoop({
+          const loop = yield* cycleLoop({
             context: Effect.succeed(context()),
             observePass: ignorePass,
             pollIntervalMs: 100,
@@ -1939,7 +1943,7 @@ describe('autonomous cycle runner', () => {
     const program = Effect.scoped(
       Effect.gen(function* () {
         yield* TestClock.setTime(Date.parse('2026-01-30T21:20:00.000Z'))
-        const loop = yield* startAutonomousCycleLoop({
+        const loop = yield* cycleLoop({
           context: Effect.succeed(context()),
           observePass: (observation) => Effect.sync(() => observations.push(observation)),
           pollIntervalMs: 100,
@@ -2012,7 +2016,7 @@ describe('autonomous cycle runner', () => {
     const program = Effect.scoped(
       Effect.gen(function* () {
         yield* TestClock.setTime(Date.parse('2026-01-30T21:20:00.000Z'))
-        const loop = yield* startAutonomousCycleLoop({
+        const loop = yield* cycleLoop({
           context: Effect.succeed(context()),
           observePass: (observation) => Effect.sync(() => observations.push(observation)),
           pollIntervalMs: 100,
@@ -2093,7 +2097,7 @@ describe('autonomous cycle runner', () => {
     const program = Effect.scoped(
       Effect.gen(function* () {
         yield* TestClock.setTime(Date.parse(active.window.submissionOpenAt))
-        const loop = yield* startAutonomousCycleLoop({
+        const loop = yield* cycleLoop({
           context: Effect.succeed(context(undefined, buildDecision)),
           observePass: (observation) => Effect.sync(() => observations.push(observation)),
           pollIntervalMs: 100,
@@ -2145,7 +2149,7 @@ describe('autonomous cycle runner', () => {
     const program = Effect.scoped(
       Effect.gen(function* () {
         yield* TestClock.setTime(Date.parse('2026-01-30T21:20:00.000Z'))
-        const loop = yield* startAutonomousCycleLoop({
+        const loop = yield* cycleLoop({
           context: Effect.suspend(() => {
             contextLoads += 1
             return contextLoads === 1 ? Effect.fail(contextFailure) : Effect.succeed(context())
@@ -2205,7 +2209,7 @@ describe('autonomous cycle runner', () => {
     const exit = await Effect.runPromise(
       Effect.scoped(
         Effect.gen(function* () {
-          const loop = yield* startAutonomousCycleLoop({
+          const loop = yield* cycleLoop({
             context: Effect.die(defect),
             observePass: (observation) => Effect.sync(() => observations.push(observation)),
             pollIntervalMs: 100,
@@ -2233,7 +2237,7 @@ describe('autonomous cycle runner', () => {
     await Effect.runPromise(
       Effect.scoped(
         Effect.gen(function* () {
-          const loop = yield* startAutonomousCycleLoop({
+          const loop = yield* cycleLoop({
             context: Effect.fail(contextFailure),
             observePass: ignorePass,
             pollIntervalMs: 100,
@@ -2255,18 +2259,13 @@ describe('autonomous cycle runner', () => {
   test('rejects invalid loop intervals before starting discovery', async () => {
     const control: StoreControl = { acquisitions: [], binds: 0 }
     for (const pollIntervalMs of [0, -1, 0.5, Number.MAX_SAFE_INTEGER + 1]) {
-      const failure = await Effect.runPromise(
-        Effect.flip(
-          Effect.scoped(
-            startAutonomousCycleLoop({
-              context: Effect.succeed(context()),
-              observePass: ignorePass,
-              pollIntervalMs,
-            }),
-          ),
-        ),
-      )
-      expect(failure).toMatchObject({
+      const result = makeAutonomousCycleLoop({
+        context: Effect.succeed(context()),
+        observePass: ignorePass,
+        pollIntervalMs,
+      })
+      expect(Result.isFailure(result)).toBe(true)
+      expect(Result.isFailure(result) ? result.failure : undefined).toMatchObject({
         _tag: 'CycleRunnerError',
         operation: 'configure',
         failure: 'invalid-config',

--- a/services/bayn/src/cycle-runner.ts
+++ b/services/bayn/src/cycle-runner.ts
@@ -1298,11 +1298,10 @@ const validateCycleLoopInterval = (pollIntervalMs: number): Result.Result<number
     ? Result.succeed(pollIntervalMs)
     : Result.fail(runnerError('configure', 'invalid-config', 'cycle loop interval must be a positive safe integer'))
 
-export const startAutonomousCycleLoop = <E, R>(
+export const makeAutonomousCycleLoop = <E, R>(
   options: AutonomousCycleLoopOptions<E, R>,
-): Effect.Effect<Effect.Effect<void, never, BrokerRead | CycleStore | MarketData | R>, CycleRunnerError> =>
+): Result.Result<Effect.Effect<void, never, BrokerRead | CycleStore | MarketData | R>, CycleRunnerError> =>
   pipe(
     validateCycleLoopInterval(options.pollIntervalMs),
     Result.map(() => cycleLoopProgram(options)),
-    Effect.fromResult,
   )

--- a/services/bayn/src/observe-composition.ts
+++ b/services/bayn/src/observe-composition.ts
@@ -1,12 +1,12 @@
-import { Clock, Effect, Result } from 'effect'
+import { Clock, Effect, pipe, Result } from 'effect'
 
 import type { AutonomousCycleStartup } from './app'
 import { BrokerRead, type BrokerReadShape, type MarketCalendarQuery } from './broker/alpaca'
 import { makeCycleExecutionPolicyFromModel, type AutonomousCycle, type CycleExecutionPolicy } from './cycle'
 import {
   CycleDecisionBuildError,
+  makeAutonomousCycleLoop,
   marketCalendarQueryForSignal,
-  startAutonomousCycleLoop,
   type CyclePassObservation,
 } from './cycle-runner'
 import { CycleStore, type CycleStoreShape } from './db/cycle-store'
@@ -575,7 +575,7 @@ const initializeObserveAuthority = (
       Effect.flatMap((authority) => Effect.fromResult(validateObserveAuthorityInitialization(authority, input))),
     )
 
-const startObserveAutonomousLoop = (
+const makeObserveAutonomousLoop = (
   input: ObserveAutonomousCycleInput,
   services: ObserveRuntimeServices,
   startup: Parameters<AutonomousCycleStartup>[0],
@@ -587,31 +587,32 @@ const startObserveAutonomousLoop = (
     Effect.provideService(PaperStore, services.paperStore),
     Effect.provideService(WriterFence, services.writerFence),
   )
-  return startAutonomousCycleLoop({
-    context: Effect.succeed({
-      qualificationRunId: startup.qualificationRunId,
-      strategyProtocolHash: preparation.strategyProtocolHash,
-      accountId: input.accountId,
-      executionPolicy: preparation.executionPolicy,
-      buildDecision: (cycle) =>
-        buildObserveCycleDecision({
-          authorityGenerationHash: input.authorityGenerationHash,
-          cycle,
-          executionModel: preparation.executionModel,
-          marketCalendar: services.brokerRead.marketCalendar,
-          marketData: services.marketData,
-          policy,
-          reconcile,
-          strategy: input.strategy,
-        }).pipe(Effect.mapError(decisionBuildError)),
+  return pipe(
+    makeAutonomousCycleLoop({
+      context: Effect.succeed({
+        qualificationRunId: startup.qualificationRunId,
+        strategyProtocolHash: preparation.strategyProtocolHash,
+        accountId: input.accountId,
+        executionPolicy: preparation.executionPolicy,
+        buildDecision: (cycle) =>
+          buildObserveCycleDecision({
+            authorityGenerationHash: input.authorityGenerationHash,
+            cycle,
+            executionModel: preparation.executionModel,
+            marketCalendar: services.brokerRead.marketCalendar,
+            marketData: services.marketData,
+            policy,
+            reconcile,
+            strategy: input.strategy,
+          }).pipe(Effect.mapError(decisionBuildError)),
+      }),
+      observePass: (observation) => observePass(startup.recordPass, observation),
+      pollIntervalMs: input.pollIntervalMs,
     }),
-    observePass: (observation) => observePass(startup.recordPass, observation),
-    pollIntervalMs: input.pollIntervalMs,
-  }).pipe(
-    Effect.mapError((cause) =>
+    Result.mapError((cause) =>
       operationalError('strategy', 'cycle-loop', 'autonomous cycle loop failed to start', cause),
     ),
-    Effect.map((loop) =>
+    Result.map((loop) =>
       loop.pipe(
         Effect.provideService(BrokerRead, services.brokerRead),
         Effect.provideService(CycleStore, services.cycleStore),
@@ -639,5 +640,5 @@ export const makeObserveAutonomousCycleStartup =
         writerFence: yield* WriterFence,
       }
       yield* initializeObserveAuthority(input, services.paperStore)
-      return yield* startObserveAutonomousLoop(input, services, startup, preparation, policy)
+      return yield* Effect.fromResult(makeObserveAutonomousLoop(input, services, startup, preparation, policy))
     })


### PR DESCRIPTION
## Summary

- replace the nested `Effect<Effect<...>>` autonomous loop constructor with a pure `Result`
- convert the validated loop to Effect only at OBSERVE application composition
- keep scoped forking, interruption, loop scheduling, and pass observation behavior unchanged

## Related Issues

None

## Testing

- `bun test services/bayn/src/cycle-runner.test.ts services/bayn/src/observe-composition.test.ts services/bayn/src/app.test.ts` — 38 passed, 0 failed
- custom Effect diagnostics with `effectInFailure` and `returnEffectInGen` enabled — no findings
- `bun run --filter @proompteng/bayn test` — 643 passed, 116 skipped, 0 failed
- `bun node_modules/typescript/bin/tsc -p services/bayn/tsconfig.json --noEmit`
- `bun run --cwd services/bayn lint:effect`
- `bun node_modules/oxfmt/bin/oxfmt --check services/bayn`
- `bun node_modules/oxlint/bin/oxlint --config .oxlintrc.json services/bayn`
- `bun node_modules/oxlint/bin/oxlint --config .oxlintrc.json --type-aware --tsconfig services/bayn/tsconfig.json services/bayn`
- `bun run --filter @proompteng/bayn build`
- `bun test packages/scripts/src/bayn` — 20 passed, 0 failed

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable and Breaking Changes is filled in.
- [x] No documentation or release-note update is required for this internal composition refactor.
