### PR TITLE
perf(bayn): keep reconciliation replay linear

### DIFF
--- a/services/bayn/src/simulation-reconciliation.test.ts
+++ b/services/bayn/src/simulation-reconciliation.test.ts
@@ -112,19 +112,10 @@ const makeEmptyInput = (): MarkedEquityReconciliationInput => {
 }
 
 const makeRoundTripInput = (dayCount: number): MarkedEquityReconciliationInput => {
-  const sessionDates = [
-    '2026-02-01',
-    '2026-02-02',
-    '2026-02-03',
-    '2026-02-04',
-    '2026-02-05',
-    '2026-02-06',
-    '2026-02-07',
-    '2026-02-08',
-    '2026-02-09',
-    '2026-02-10',
-  ] as const
-  assert(dayCount <= sessionDates.length, 'round-trip fixture day count must be bounded')
+  const sessionDates = Array.from(
+    { length: dayCount },
+    (_, index) => new Date(Date.UTC(2026, 1, index + 1)).toISOString().slice(0, 10) as `${number}-${number}-${number}`,
+  )
   const input = makeEmptyInput()
   const markTemplate = input.simulation.dailyMarks[0]
   const events: EvaluationEvent[] = []
@@ -347,21 +338,13 @@ describe('independent marked-equity reconciliation', () => {
   })
 
   test('reconciles a production-length equity history through persistent accumulation', () => {
-    const input = makeEmptyInput()
-    const mark = input.simulation.dailyMarks[0]
-    const dailyMarks = Array.from({ length: 2_266 }, (_, index) => ({
-      ...mark,
-      sessionDate: new Date(Date.UTC(2015, 0, index + 1)).toISOString().slice(0, 10) as `${number}-${number}-${number}`,
-    }))
-    const result = reconcileMarkedEquity({
-      ...input,
-      simulation: { ...input.simulation, dailyMarks },
-    })
+    const input = makeRoundTripInput(2_266)
+    const result = reconcileMarkedEquity(input)
 
     assert(Result.isSuccess(result), 'production-length history must reconcile')
-    expect(result.success.equitySeries).toHaveLength(dailyMarks.length)
-    expect(result.success.equitySeries[0]?.sessionDate).toBe(dailyMarks[0]?.sessionDate)
-    expect(result.success.equitySeries.at(-1)?.sessionDate).toBe(dailyMarks.at(-1)?.sessionDate)
+    expect(result.success.equitySeries).toHaveLength(input.simulation.dailyMarks.length)
+    expect(result.success.equitySeries[0]?.sessionDate).toBe(input.simulation.dailyMarks[0]?.sessionDate)
+    expect(result.success.equitySeries.at(-1)?.sessionDate).toBe(input.simulation.dailyMarks.at(-1)?.sessionDate)
   })
 
   test('returns immutable plain issues and preserves them through Result.match', () => {

--- a/services/bayn/src/simulation-reconciliation/reconstruction.ts
+++ b/services/bayn/src/simulation-reconciliation/reconstruction.ts
@@ -368,27 +368,49 @@ const valueMarkedPositions = (state: ReconstructionState, mark: DailyPositionMar
       })
 }
 
-const eventsDueAtMark = (
+interface DueEventRange {
+  readonly startIndex: number
+  readonly endIndex: number
+}
+
+const selectDueEventRange = (
   prepared: PreparedReconciliation,
   state: ReconstructionState,
   mark: DailyPositionMark,
-): Validation<readonly PreparedMonetaryEvent[]> => {
-  const remaining = prepared.monetaryEvents.slice(state.eventIndex)
-  const firstFutureIndex = remaining.findIndex((event) => event.event.sessionDate > mark.sessionDate)
-  const due = firstFutureIndex === -1 ? remaining : remaining.slice(0, firstFutureIndex)
-  const missed = due.find((event) => event.event.sessionDate !== mark.sessionDate)
-  return missed === undefined
-    ? Result.succeed(due)
-    : fail({
-        _tag: 'IncompleteEvidence',
-        problem: {
-          _tag: 'MissingSessionMark',
-          eventId: missed.event.id,
-          eventSessionDate: missed.event.sessionDate,
-          nextMarkSessionDate: mark.sessionDate,
-        },
-      })
+): Validation<DueEventRange> => {
+  const first = prepared.monetaryEvents[state.eventIndex]
+  if (first === undefined || first.event.sessionDate > mark.sessionDate) {
+    return Result.succeed({ startIndex: state.eventIndex, endIndex: state.eventIndex })
+  }
+  if (first.event.sessionDate < mark.sessionDate) {
+    return fail({
+      _tag: 'IncompleteEvidence',
+      problem: {
+        _tag: 'MissingSessionMark',
+        eventId: first.event.id,
+        eventSessionDate: first.event.sessionDate,
+        nextMarkSessionDate: mark.sessionDate,
+      },
+    })
+  }
+  let endIndex = state.eventIndex + 1
+  while (prepared.monetaryEvents[endIndex]?.event.sessionDate === mark.sessionDate) endIndex += 1
+  return Result.succeed({ startIndex: state.eventIndex, endIndex })
 }
+
+const applyEventRange = (
+  prepared: PreparedReconciliation,
+  state: ReconstructionState,
+  range: DueEventRange,
+): Validation<ReconstructionState> =>
+  prepared.monetaryEvents.slice(range.startIndex, range.endIndex).reduce<Validation<ReconstructionState>>(
+    (reconstructed, event) =>
+      pipe(
+        reconstructed,
+        Result.flatMap((snapshot) => applyEvent(prepared, snapshot, event)),
+      ),
+    Result.succeed(state),
+  )
 
 const applyEventsAtMark = (
   prepared: PreparedReconciliation,
@@ -396,17 +418,8 @@ const applyEventsAtMark = (
   mark: DailyPositionMark,
 ): Validation<ReconstructionState> =>
   pipe(
-    eventsDueAtMark(prepared, state, mark),
-    Result.flatMap((events) =>
-      events.reduce<Validation<ReconstructionState>>(
-        (current, event) =>
-          pipe(
-            current,
-            Result.flatMap((snapshot) => applyEvent(prepared, snapshot, event)),
-          ),
-        Result.succeed(state),
-      ),
-    ),
+    selectDueEventRange(prepared, state, mark),
+    Result.flatMap((range) => applyEventRange(prepared, state, range)),
   )
 
 const reconcileDailyMark = (

--- a/services/bayn/src/simulation-reconciliation/validation.ts
+++ b/services/bayn/src/simulation-reconciliation/validation.ts
@@ -1,4 +1,4 @@
-import { pipe, Result } from 'effect'
+import { Chunk, pipe, Result } from 'effect'
 
 import {
   calculateSessionFees,
@@ -684,7 +684,7 @@ const validateOrdersAndFills = (
   }))
   if (Result.isFailure(orders)) return failIssues(orders.failure)
   const preparedFills = [...orders.success.values()].reduce<
-    Validation<readonly { readonly eventIndex: number; readonly fill: ValidatedFill }[]>
+    Validation<Chunk.Chunk<{ readonly eventIndex: number; readonly fill: ValidatedFill }>>
   >(
     (prepared, order) =>
       pipe(
@@ -696,18 +696,20 @@ const validateOrdersAndFills = (
             Result.map((fill) =>
               fill === undefined || indexedFill === undefined
                 ? items
-                : [...items, { eventIndex: indexedFill.eventIndex, fill }],
+                : Chunk.prepend(items, { eventIndex: indexedFill.eventIndex, fill }),
             ),
           )
         }),
       ),
-    Result.succeed([]),
+    Result.succeed(Chunk.empty()),
   )
   if (Result.isFailure(preparedFills)) return failIssues(preparedFills.failure)
   const orphan = fills.find((fill) => !orders.success.has(fill.orderId))
   return orphan === undefined
     ? Result.succeed(
-        preparedFills.success.toSorted((left, right) => left.eventIndex - right.eventIndex).map(({ fill }) => fill),
+        Chunk.toReadonlyArray(preparedFills.success)
+          .toSorted((left, right) => left.eventIndex - right.eventIndex)
+          .map(({ fill }) => fill),
       )
     : fail({
         _tag: 'MissingReference',
@@ -737,18 +739,21 @@ const validateFeesAndYields = (
   }))
   if (Result.isFailure(indexedCashYields)) return failIssues(indexedCashYields.failure)
   const fillsBySession = groupValuesBy(fills, (fill) => fill.event.sessionDate)
-  return fees.reduce<Validation<readonly ValidatedFee[]>>(
-    (prepared, fee) =>
-      pipe(
-        prepared,
-        Result.flatMap((items) =>
-          pipe(
-            validateFee(runId, fee, fillsBySession.get(fee.sessionDate) ?? [], simulation, costMultiplierMicros),
-            Result.map((valid) => [...items, valid]),
+  return pipe(
+    fees.reduce<Validation<Chunk.Chunk<ValidatedFee>>>(
+      (prepared, fee) =>
+        pipe(
+          prepared,
+          Result.flatMap((items) =>
+            pipe(
+              validateFee(runId, fee, fillsBySession.get(fee.sessionDate) ?? [], simulation, costMultiplierMicros),
+              Result.map((valid) => Chunk.prepend(items, valid)),
+            ),
           ),
         ),
-      ),
-    Result.succeed([]),
+      Result.succeed(Chunk.empty()),
+    ),
+    Result.map((reversed) => Chunk.toReadonlyArray(Chunk.reverse(reversed))),
   )
 }
 
@@ -773,7 +778,7 @@ interface MonetaryEvidence {
 }
 
 interface MonetaryAccumulator {
-  readonly events: readonly PreparedMonetaryEvent[]
+  readonly reversedEvents: Chunk.Chunk<PreparedMonetaryEvent>
   readonly fillIndex: number
   readonly feeIndex: number
 }
@@ -833,25 +838,37 @@ const validateMonetaryEvidence = (
             if (event.kind === 'cash-yield') {
               return Result.succeed({
                 ...accumulator,
-                events: [...accumulator.events, { kind: 'cash-yield', event, cashChange }],
+                reversedEvents: Chunk.prepend(accumulator.reversedEvents, {
+                  kind: 'cash-yield',
+                  event,
+                  cashChange,
+                }),
               })
             }
             return event.kind === 'fill'
               ? Result.succeed({
-                  events: [...accumulator.events, { ...fills[accumulator.fillIndex], cashChange }],
+                  reversedEvents: Chunk.prepend(accumulator.reversedEvents, {
+                    ...fills[accumulator.fillIndex],
+                    cashChange,
+                  }),
                   fillIndex: accumulator.fillIndex + 1,
                   feeIndex: accumulator.feeIndex,
                 })
               : Result.succeed({
-                  events: [...accumulator.events, { ...fees[accumulator.feeIndex], cashChange }],
+                  reversedEvents: Chunk.prepend(accumulator.reversedEvents, {
+                    ...fees[accumulator.feeIndex],
+                    cashChange,
+                  }),
                   fillIndex: accumulator.fillIndex,
                   feeIndex: accumulator.feeIndex + 1,
                 })
           }),
         ),
-      Result.succeed({ events: [], fillIndex: 0, feeIndex: 0 }),
+      Result.succeed({ reversedEvents: Chunk.empty(), fillIndex: 0, feeIndex: 0 }),
     ),
-    Result.map(({ events: monetaryEvents }) => ({ events: monetaryEvents })),
+    Result.map(({ reversedEvents }) => ({
+      events: Chunk.toReadonlyArray(Chunk.reverse(reversedEvents)),
+    })),
   )
 }
 


### PR DESCRIPTION
## Summary

- address both post-merge Codex findings from #13239 by eliminating quadratic monetary-evidence prefix copies and future-tail rescans
- accumulate validated fills, fees, and monetary events with immutable Effect `Chunk`s and materialize ordered arrays once
- advance reconstruction from its monotonic event cursor, copying only the events due for the current mark
- strengthen the regression to reconcile 2,266 sessions and 4,532 monetary events

## Related Issues

None

## Testing

- `bun test services/bayn/src/simulation-reconciliation.test.ts` — 14 pass, 0 fail; production-length case completes in about 165 ms locally
- `bun run --filter @proompteng/bayn test` — 645 pass, 116 environment-gated skip, 0 fail
- `bun run --filter @proompteng/bayn tsc`
- `bunx oxfmt --check services/bayn/src/simulation-reconciliation services/bayn/src/simulation-reconciliation.test.ts`
- `bunx oxlint --deny-warnings services/bayn/src/simulation-reconciliation services/bayn/src/simulation-reconciliation.test.ts`
- `bunx oxlint --type-aware --deny-warnings services/bayn/src/simulation-reconciliation services/bayn/src/simulation-reconciliation.test.ts`
- `bun run --filter @proompteng/bayn build`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is completed.
- [x] Documentation and release notes are not required for this behavior-preserving performance correction.