### PR TITLE
refactor(bayn): make mutation persistence functional

### DIFF
--- a/services/bayn/src/db/evidence-store.integration.test.ts
+++ b/services/bayn/src/db/evidence-store.integration.test.ts
@@ -11,15 +11,30 @@ import stablePaperAuthorityGeneration from '../../migrations/0017_stable_paper_a
 import type { RuntimeConfig } from '../config'
 import { makeStrategyProtocolHash, type RuntimeProvenance } from '../contracts'
 import { IntentStore, IntentStoreLive, planPaperIntent, type IntentPlan } from '../execution/intents'
-import { MutationEventType, MutationStore, MutationStoreLive, mutationId } from '../execution/mutations'
+import {
+  MutationEventType,
+  MutationStore,
+  MutationStoreError,
+  MutationStoreLive,
+  mutationIdResult,
+} from '../execution/mutations'
 import {
   BrokerMutation,
   MutationOperation,
   cancelRequestHash,
+  orderRequestBody,
   type BrokerMutationShape,
 } from '../broker/alpaca-mutations'
+import {
+  AssetClass,
+  OrderClass,
+  OrderSide as BrokerOrderSide,
+  OrderStatus,
+  OrderType as BrokerOrderType,
+  TimeInForce as BrokerTimeInForce,
+} from '../broker/alpaca'
 import { cancel, submit } from '../execution/coordinator'
-import { WriterFence, WriterFenceLive } from '../execution/writer-fence'
+import { WriterFence, WriterFenceLive, type WriterFenceService } from '../execution/writer-fence'
 import { canonicalHashV1 } from '../hash'
 import { buildLedgerPlan, Journal, type JournalService } from '../ledger'
 import {
@@ -126,6 +141,31 @@ const makeMutationRuntime = (config = makeConfig()) =>
       Layer.provide(NodeServices.layer),
     ),
   )
+
+const makeMutationRuntimeWithFenceFailure = (
+  failure: Effect.Effect<never>,
+  onTransaction: () => void,
+  config = makeConfig(),
+) => {
+  const postgres = PostgresClientLive(config).pipe(Layer.provide(NodeServices.layer))
+  const liveFence = WriterFenceLive.pipe(Layer.provide(postgres))
+  const failingFence = Layer.effect(
+    WriterFence,
+    Effect.map(
+      WriterFence,
+      (fence) =>
+        ({
+          backendPid: fence.backendPid,
+          check: fence.check,
+          transaction: <A, E, R>(effect: Effect.Effect<A, E, R>) => {
+            onTransaction()
+            return fence.transaction(effect.pipe(Effect.andThen(failure)))
+          },
+        }) satisfies WriterFenceService,
+    ),
+  ).pipe(Layer.provide(liveFence))
+  return ManagedRuntime.make(MutationStoreLive.pipe(Layer.provideMerge(failingFence), Layer.provideMerge(postgres)))
+}
 
 const makeCoordinatorRuntime = (broker: BrokerMutationShape, config = makeConfig()) =>
   ManagedRuntime.make(
@@ -339,6 +379,7 @@ const seedAcceptedSubmit = (intent: Intent, decision: RiskDecision, fixture: str
   Effect.gen(function* () {
     const sql = yield* PgClient.PgClient
     const requestHash = fixtureHash(`${fixture}-request`)
+    const submitMutationId = yield* Effect.fromResult(mutationIdResult(intent.intentId, MutationOperation.Submit))
     const startedAt = new Date(Date.parse(decision.decidedAt) + 1).toISOString()
     const acceptedAt = new Date(Date.parse(decision.decidedAt) + 2).toISOString()
     yield* sql.withTransaction(
@@ -350,7 +391,7 @@ const seedAcceptedSubmit = (intent: Intent, decision: RiskDecision, fixture: str
             request_id, response_status, response_content_hash, occurred_at
           ) VALUES (
             ${fixtureHash(`${fixture}-started`)}, 'bayn.paper-mutation-event.v1',
-            ${mutationId(intent.intentId, MutationOperation.Submit)}, ${intent.intentId},
+            ${submitMutationId}, ${intent.intentId},
             1, 'SUBMIT', 'SUBMIT_STARTED', ${requestHash}, 1000, NULL,
             NULL, NULL, NULL, ${startedAt}
           )
@@ -367,7 +408,7 @@ const seedAcceptedSubmit = (intent: Intent, decision: RiskDecision, fixture: str
             request_id, response_status, response_content_hash, occurred_at
           ) VALUES (
             ${fixtureHash(`${fixture}-accepted`)}, 'bayn.paper-mutation-event.v1',
-            ${mutationId(intent.intentId, MutationOperation.Submit)}, ${intent.intentId},
+            ${submitMutationId}, ${intent.intentId},
             2, 'SUBMIT', 'SUBMIT_ACCEPTED', ${requestHash}, 1000, ${orderId},
             ${`${fixture}-request-id`}, 200, ${fixtureHash(`${fixture}-response`)}, ${acceptedAt}
           )
@@ -1689,6 +1730,94 @@ describePostgres('PostgreSQL evaluation evidence', () => {
     expect(observed.count).toBe(1)
   })
 
+  test('retains typed causes and rolls back executed WriterFence transactions on defects and interruption', async () => {
+    const typedRuntime = makeMutationRuntime()
+    const typedExit = await typedRuntime.runPromise(
+      Effect.exit(
+        Effect.flatMap(MutationStore, (store) =>
+          store.beginSubmit('invalid-intent-id', '1'.repeat(64), 1_000, new Date().toISOString()),
+        ),
+      ),
+    )
+    await typedRuntime.dispose()
+    expect(Exit.isFailure(typedExit)).toBe(true)
+    if (Exit.isFailure(typedExit)) {
+      const failure = Cause.findFail(typedExit.cause)
+      expect(Result.isSuccess(failure)).toBe(true)
+      if (Result.isSuccess(failure)) {
+        const error = failure.success.error
+        expect(error).toBeInstanceOf(MutationStoreError)
+        if (!(error instanceof MutationStoreError)) throw new Error('expected MutationStoreError')
+        expect(error).toMatchObject({
+          operation: 'begin-submit',
+          failure: 'decode',
+          message: 'invalid mutation start',
+        })
+        expect(error.cause).toBeDefined()
+      }
+    }
+
+    await activateAuditedPaperAuthority()
+    const intent = await Effect.runPromise(
+      plan(intentPlan({ cycleId: fixtureHash('mutation-writer-fence-failure-cycle') })),
+    )
+    const decision = await Effect.runPromise(riskDecision(intent, RiskOutcome.Approved))
+    const execution = makeExecutionRuntime()
+    await execution.runPromise(Effect.flatMap(IntentStore, (store) => store.commit(intent, decision)))
+    await execution.dispose()
+    const before = await runtime.runPromise(paperIntentEvidence)
+    const startedAt = new Date(Date.now() + 100).toISOString()
+
+    const defect = new Error('injected WriterFence transaction defect')
+    let defectTransactions = 0
+    let defectAfterMutation = 0
+    const defectRuntime = makeMutationRuntimeWithFenceFailure(
+      Effect.sync(() => {
+        defectAfterMutation += 1
+      }).pipe(Effect.andThen(Effect.die(defect))),
+      () => {
+        defectTransactions += 1
+      },
+    )
+    const defectExit = await defectRuntime.runPromise(
+      Effect.exit(
+        Effect.flatMap(MutationStore, (store) => store.beginSubmit(intent.intentId, 'b'.repeat(64), 1_000, startedAt)),
+      ),
+    )
+    await defectRuntime.dispose()
+    expect(defectTransactions).toBe(1)
+    expect(defectAfterMutation).toBe(1)
+    expect(Exit.isFailure(defectExit)).toBe(true)
+    if (Exit.isFailure(defectExit)) {
+      const found = Cause.findDefect(defectExit.cause)
+      expect(Result.isSuccess(found)).toBe(true)
+      if (Result.isSuccess(found)) expect(found.success).toBe(defect)
+    }
+    expect(await runtime.runPromise(paperIntentEvidence)).toEqual(before)
+
+    let interruptedTransactions = 0
+    let interruptAfterMutation = 0
+    const interruptedRuntime = makeMutationRuntimeWithFenceFailure(
+      Effect.sync(() => {
+        interruptAfterMutation += 1
+      }).pipe(Effect.andThen(Effect.interrupt)),
+      () => {
+        interruptedTransactions += 1
+      },
+    )
+    const interruptedExit = await interruptedRuntime.runPromise(
+      Effect.exit(
+        Effect.flatMap(MutationStore, (store) => store.beginSubmit(intent.intentId, 'd'.repeat(64), 1_000, startedAt)),
+      ),
+    )
+    await interruptedRuntime.dispose()
+    expect(interruptedTransactions).toBe(1)
+    expect(interruptAfterMutation).toBe(1)
+    expect(Exit.isFailure(interruptedExit)).toBe(true)
+    if (Exit.isFailure(interruptedExit)) expect(Cause.hasInterrupts(interruptedExit.cause)).toBe(true)
+    expect(await runtime.runPromise(paperIntentEvidence)).toEqual(before)
+  })
+
   test('linearizes one submit and records its exact acknowledged outcome', async () => {
     await activateAuditedPaperAuthority()
     const execution = makeExecutionRuntime()
@@ -1722,6 +1851,9 @@ describePostgres('PostgreSQL evaluation evidence', () => {
         const changedDelay = yield* Effect.exit(store.beginSubmit(intent.intentId, requestHash, 2_000, startedAt))
         const accepted = yield* store.submitAccepted(intent.intentId, requestHash, orderId, evidence)
         const replay = yield* store.submitAccepted(intent.intentId, requestHash, orderId, evidence)
+        const terminalReplay = yield* Effect.exit(
+          store.submitAccepted(intent.intentId, requestHash, orderId, evidence, TerminalOutcome.Filled),
+        )
         const sql = yield* PgClient.PgClient
         const state = yield* sql<{ events: number; state: string; state_version: number }>`
           SELECT
@@ -1731,7 +1863,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
           FROM intents
           WHERE intent_id = ${intent.intentId}
         `
-        return { accepted, changedDelay, replay, starts, state: state[0] }
+        return { accepted, changedDelay, replay, starts, state: state[0], terminalReplay }
       }),
     )
     await mutation.dispose()
@@ -1742,8 +1874,191 @@ describePostgres('PostgreSQL evaluation evidence', () => {
     expect(observed.accepted.eventType).toBe(MutationEventType.SubmitAccepted)
     expect(observed.accepted.consistencyDelayMs).toBe(1_000)
     expect(observed.replay.eventId).toBe(observed.accepted.eventId)
+    expect(Exit.isFailure(observed.terminalReplay)).toBe(true)
+    if (Exit.isFailure(observed.terminalReplay)) {
+      expect(Cause.pretty(observed.terminalReplay.cause)).toContain(
+        'mutation outcome replay conflicts with durable intent state',
+      )
+    }
     expect(observed.state).toEqual({ state: 'ACKNOWLEDGED', state_version: 4, events: 2 })
   })
+
+  test('omits explicitly undefined partial evidence before decoding a durable unknown outcome', async () => {
+    await activateAuditedPaperAuthority()
+    const execution = makeExecutionRuntime()
+    const intent = await Effect.runPromise(
+      plan(intentPlan({ cycleId: fixtureHash('mutation-explicit-undefined-evidence-cycle') })),
+    )
+    const decision = await Effect.runPromise(riskDecision(intent, RiskOutcome.Approved))
+    await execution.runPromise(Effect.flatMap(IntentStore, (store) => store.commit(intent, decision)))
+    await execution.dispose()
+
+    const mutation = makeMutationRuntime()
+    const requestHash = fixtureHash('mutation-explicit-undefined-evidence-request')
+    const base = Date.now() + 100
+    const observed = await mutation.runPromise(
+      Effect.gen(function* () {
+        const store = yield* MutationStore
+        yield* store.beginSubmit(intent.intentId, requestHash, 1_000, new Date(base).toISOString())
+        const event = yield* store.submitUnknown(intent.intentId, requestHash, new Date(base + 1).toISOString(), {
+          requestId: undefined,
+          status: undefined,
+          contentHash: undefined,
+          observedAt: undefined,
+        })
+        const sql = yield* PgClient.PgClient
+        const [stored] = yield* sql<{
+          request_id: string | null
+          response_content_hash: string | null
+          response_status: number | null
+        }>`
+          SELECT request_id, response_status::integer, response_content_hash
+          FROM mutation_events
+          WHERE event_id = ${event.eventId}
+        `
+        return { event, stored }
+      }),
+    )
+    await mutation.dispose()
+
+    expect(observed.event).toMatchObject({ eventType: MutationEventType.SubmitUnknown })
+    expect(observed.event.requestId).toBeUndefined()
+    expect(observed.event.responseStatus).toBeUndefined()
+    expect(observed.event.responseContentHash).toBeUndefined()
+    expect(observed.stored).toEqual({
+      request_id: null,
+      response_status: null,
+      response_content_hash: null,
+    })
+  })
+
+  test('causally serializes concurrent coordinator submit and cancel calls around one POST and DELETE', async () => {
+    await activateAuditedPaperAuthority()
+    const intent = await Effect.runPromise(
+      plan(intentPlan({ cycleId: fixtureHash('mutation-concurrent-submit-cancel-cycle') })),
+    )
+    const decision = await Effect.runPromise(riskDecision(intent, RiskOutcome.Approved))
+    const execution = makeExecutionRuntime()
+    await execution.runPromise(Effect.flatMap(IntentStore, (store) => store.commit(intent, decision)))
+    await execution.dispose()
+
+    const submitEntered = await Effect.runPromise(Deferred.make<void>())
+    const releaseSubmit = await Effect.runPromise(Deferred.make<void>())
+    const brokerCalls = { cancel: 0, submit: 0 }
+    const base = Date.now() + 1_000
+    const submitObservedAt = new Date(base).toISOString()
+    const cancelObservedAt = new Date(base + 1_000).toISOString()
+    const broker: BrokerMutationShape = {
+      submit: (submitted) =>
+        Effect.gen(function* () {
+          brokerCalls.submit += 1
+          yield* Deferred.succeed(submitEntered, undefined)
+          yield* Deferred.await(releaseSubmit)
+          return {
+            requestHash: canonicalHashV1(orderRequestBody(submitted)),
+            order: {
+              accountId: submitted.accountId,
+              brokerOrderId: orderId,
+              clientOrderId: submitted.clientOrderId,
+              createdAt: submitObservedAt,
+              updatedAt: submitObservedAt,
+              submittedAt: submitObservedAt,
+              assetId: fixtureHash('mutation-concurrent-broker-asset').slice(0, 36),
+              symbol: submitted.symbol,
+              assetClass: AssetClass.UsEquity,
+              quantityMicros: submitted.quantityMicros,
+              filledQuantityMicros: '0',
+              orderClass: OrderClass.Simple,
+              orderType: BrokerOrderType.Market,
+              side: BrokerOrderSide.Buy,
+              timeInForce: BrokerTimeInForce.Day,
+              status: OrderStatus.Accepted,
+              extendedHours: false,
+              observedAt: submitObservedAt,
+            },
+            evidence: {
+              requestId: 'concurrent-submit-request',
+              status: 200,
+              contentHash: fixtureHash('mutation-concurrent-submit-response'),
+              observedAt: submitObservedAt,
+            },
+          }
+        }),
+      cancel: (brokerOrderId) => {
+        brokerCalls.cancel += 1
+        return Effect.succeed({
+          requestHash: cancelRequestHash(brokerOrderId),
+          brokerOrderId,
+          evidence: {
+            requestId: 'concurrent-cancel-request',
+            status: 204,
+            contentHash: fixtureHash('mutation-concurrent-cancel-response'),
+            observedAt: cancelObservedAt,
+          },
+        })
+      },
+    }
+    const coordinator = makeCoordinatorRuntime(broker)
+    const observed = await coordinator
+      .runPromise(
+        Effect.gen(function* () {
+          const firstSubmit = yield* Effect.forkChild(submit(intent.intentId, 1_000))
+          const secondSubmit = yield* Effect.forkChild(submit(intent.intentId, 1_000))
+          yield* Deferred.await(submitEntered)
+          const earlyCancels = yield* Effect.all(
+            [Effect.exit(cancel(intent.intentId, 1_000)), Effect.exit(cancel(intent.intentId, 1_000))],
+            { concurrency: 'unbounded' },
+          )
+          yield* Deferred.succeed(releaseSubmit, undefined)
+          const submissions = yield* Effect.all([Fiber.join(firstSubmit), Fiber.join(secondSubmit)], {
+            concurrency: 'unbounded',
+          })
+          const cancellations = yield* Effect.all([cancel(intent.intentId, 1_000), cancel(intent.intentId, 1_000)], {
+            concurrency: 'unbounded',
+          })
+          const sql = yield* PgClient.PgClient
+          const events = yield* sql<{
+            event_type: string
+            occurred_at: string
+            operation: string
+            sequence: number
+          }>`
+          SELECT
+            operation,
+            event_type,
+            sequence::integer,
+            to_char(occurred_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"') AS occurred_at
+          FROM mutation_events
+          WHERE intent_id = ${intent.intentId}
+          ORDER BY occurred_at, operation, sequence
+        `
+          return { cancellations, earlyCancels, events, submissions }
+        }).pipe(Effect.ensuring(Deferred.succeed(releaseSubmit, undefined).pipe(Effect.ignore))),
+      )
+      .finally(() => coordinator.dispose())
+
+    expect(observed.earlyCancels).toHaveLength(2)
+    for (const cancellation of observed.earlyCancels) {
+      expect(Exit.isFailure(cancellation)).toBe(true)
+      if (Exit.isFailure(cancellation)) {
+        expect(Cause.pretty(cancellation.cause)).toContain('positively identified broker order')
+      }
+    }
+    expect(observed.submissions).toHaveLength(2)
+    expect(observed.cancellations).toHaveLength(2)
+    expect(brokerCalls).toEqual({ submit: 1, cancel: 1 })
+    expect(observed.events.map(({ event_type, operation, sequence }) => ({ event_type, operation, sequence }))).toEqual(
+      [
+        { operation: MutationOperation.Submit, event_type: MutationEventType.SubmitStarted, sequence: 1 },
+        { operation: MutationOperation.Submit, event_type: MutationEventType.SubmitAccepted, sequence: 2 },
+        { operation: MutationOperation.Cancel, event_type: MutationEventType.CancelStarted, sequence: 1 },
+        { operation: MutationOperation.Cancel, event_type: MutationEventType.CancelAccepted, sequence: 2 },
+      ],
+    )
+    expect(observed.events.map((event) => event.occurred_at)).toEqual(
+      observed.events.map((event) => event.occurred_at).sort(),
+    )
+  }, 20_000)
 
   test('linearizes accepted submit terminal recovery and replays without another durable write', async () => {
     await activateAuditedPaperAuthority()
@@ -1797,6 +2112,27 @@ describePostgres('PostgreSQL evaluation evidence', () => {
           ],
           { concurrency: 'unbounded' },
         )
+        const beforeConflictingReplay = yield* paperIntentEvidence
+        const conflictingReplay = yield* Effect.exit(
+          store.recoveryFound(
+            intent.intentId,
+            MutationOperation.Submit,
+            requestHash,
+            orderId,
+            terminalEvidence,
+            TerminalOutcome.Canceled,
+          ),
+        )
+        const afterConflictingReplay = yield* paperIntentEvidence
+        const exactReplay = yield* store.recoveryFound(
+          intent.intentId,
+          MutationOperation.Submit,
+          requestHash,
+          orderId,
+          terminalEvidence,
+          TerminalOutcome.Filled,
+        )
+        const afterExactReplay = yield* paperIntentEvidence
         const sql = yield* PgClient.PgClient
         const [state] = yield* sql<{
           events: number
@@ -1812,12 +2148,30 @@ describePostgres('PostgreSQL evaluation evidence', () => {
           FROM intents
           WHERE intent_id = ${intent.intentId}
         `
-        return { recovered, state }
+        return {
+          afterConflictingReplay,
+          afterExactReplay,
+          beforeConflictingReplay,
+          conflictingReplay,
+          exactReplay,
+          recovered,
+          state,
+        }
       }),
     )
     await mutation.dispose()
 
     expect(observed.recovered[0].eventId).toBe(observed.recovered[1].eventId)
+    expect(observed.exactReplay.eventId).toBe(observed.recovered[0].eventId)
+    expect(Exit.isFailure(observed.conflictingReplay)).toBe(true)
+    if (Exit.isFailure(observed.conflictingReplay)) {
+      expect(Cause.pretty(observed.conflictingReplay.cause)).toContain(
+        'mutation outcome replay conflicts with durable intent state',
+      )
+    }
+    expect(observed.afterConflictingReplay).toEqual(observed.beforeConflictingReplay)
+    expect(JSON.stringify(observed.afterConflictingReplay)).toBe(JSON.stringify(observed.beforeConflictingReplay))
+    expect(observed.afterExactReplay).toEqual(observed.beforeConflictingReplay)
     expect(observed.recovered[0]).toMatchObject({
       sequence: 3,
       eventType: MutationEventType.RecoveryFound,
@@ -1930,6 +2284,12 @@ describePostgres('PostgreSQL evaluation evidence', () => {
     const submitHash = '7'.repeat(64)
     const cancelHash = cancelRequestHash(orderId)
     const base = Date.now() + 100
+    const cancelTerminalEvidence = {
+      requestId: 'terminal-cancel-recovery',
+      status: 200,
+      contentHash: '3'.repeat(64),
+      observedAt: new Date(base + 5).toISOString(),
+    }
     const observed = await mutation.runPromise(
       Effect.gen(function* () {
         const store = yield* MutationStore
@@ -1968,14 +2328,25 @@ describePostgres('PostgreSQL evaluation evidence', () => {
           MutationOperation.Cancel,
           cancelHash,
           orderId,
-          {
-            requestId: 'terminal-cancel-recovery',
-            status: 200,
-            contentHash: '3'.repeat(64),
-            observedAt: new Date(base + 5).toISOString(),
-          },
+          cancelTerminalEvidence,
           TerminalOutcome.Canceled,
         )
+        const beforeReplayConflicts = yield* paperIntentEvidence
+        const differentTerminalReplay = yield* Effect.exit(
+          store.recoveryFound(
+            intent.intentId,
+            MutationOperation.Cancel,
+            cancelHash,
+            orderId,
+            cancelTerminalEvidence,
+            TerminalOutcome.Expired,
+          ),
+        )
+        const afterDifferentTerminalReplay = yield* paperIntentEvidence
+        const omittedTerminalReplay = yield* Effect.exit(
+          store.recoveryFound(intent.intentId, MutationOperation.Cancel, cancelHash, orderId, cancelTerminalEvidence),
+        )
+        const afterOmittedTerminalReplay = yield* paperIntentEvidence
         const sql = yield* PgClient.PgClient
         const [state] = yield* sql<{
           events: number
@@ -1991,7 +2362,17 @@ describePostgres('PostgreSQL evaluation evidence', () => {
           FROM intents
           WHERE intent_id = ${intent.intentId}
         `
-        return { afterSubmitRecovery, canceled, state, submitRecovery }
+        return {
+          afterDifferentTerminalReplay,
+          afterOmittedTerminalReplay,
+          afterSubmitRecovery,
+          beforeReplayConflicts,
+          canceled,
+          differentTerminalReplay,
+          omittedTerminalReplay,
+          state,
+          submitRecovery,
+        }
       }),
     )
     await mutation.dispose()
@@ -2008,6 +2389,15 @@ describePostgres('PostgreSQL evaluation evidence', () => {
       eventType: MutationEventType.RecoveryFound,
       brokerOrderId: orderId,
     })
+    for (const replay of [observed.differentTerminalReplay, observed.omittedTerminalReplay]) {
+      expect(Exit.isFailure(replay)).toBe(true)
+      if (Exit.isFailure(replay)) {
+        expect(Cause.pretty(replay.cause)).toContain('mutation outcome replay conflicts with durable intent state')
+      }
+    }
+    expect(observed.afterDifferentTerminalReplay).toEqual(observed.beforeReplayConflicts)
+    expect(JSON.stringify(observed.afterDifferentTerminalReplay)).toBe(JSON.stringify(observed.beforeReplayConflicts))
+    expect(observed.afterOmittedTerminalReplay).toEqual(observed.beforeReplayConflicts)
     expect(observed.state).toEqual({
       state: 'TERMINAL',
       state_version: 5,

--- a/services/bayn/src/execution/coordinator-decisions.test.ts
+++ b/services/bayn/src/execution/coordinator-decisions.test.ts
@@ -38,7 +38,7 @@ import {
   validateRecovery,
 } from './coordinator-decisions'
 import type { StoredIntent } from './intents'
-import { MutationEventType, mutationId, type MutationEvent } from './mutations'
+import { MutationEventType, mutationIdResult, type MutationEvent } from './mutations'
 
 const intentId = 'a'.repeat(64)
 const accountId = 'e6fe16f3-64a4-4921-8928-cadf02f92f98'
@@ -126,7 +126,7 @@ const mutation = (
   return {
     schemaVersion: 'bayn.paper-mutation-event.v1',
     eventId: '3'.repeat(64),
-    mutationId: mutationId(intentId, operation),
+    mutationId: Result.getOrThrow(mutationIdResult(intentId, operation)),
     intentId,
     sequence: 1,
     operation,

--- a/services/bayn/src/execution/coordinator.test.ts
+++ b/services/bayn/src/execution/coordinator.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 
-import { Cause, Clock, Duration, Effect, Exit, Fiber, Option } from 'effect'
+import { Cause, Clock, Duration, Effect, Exit, Fiber, Option, Result } from 'effect'
 import { TestClock } from 'effect/testing'
 
 import {
@@ -29,7 +29,9 @@ import {
 import { unusedAssetBySymbol, unusedMarketCalendar } from '../broker/alpaca-test-support'
 import { canonicalHashV1 } from '../hash'
 import {
+  Authority,
   IntentState,
+  KillState,
   MutationOutcome,
   OrderSide,
   OrderType,
@@ -41,7 +43,25 @@ import {
 } from '../paper'
 import { cancel, dryRunSubmit, ExecutionError, ExecutionFailure, recover, submit } from './coordinator'
 import { IntentStore, type IntentStoreService, type StoredIntent } from './intents'
-import { MutationEventType, MutationStore, mutationId, type MutationEvent, type MutationStoreShape } from './mutations'
+import {
+  decideMutationAuthority,
+  decideMutationOutcome,
+  decideMutationStart,
+  decideMutationStartReplay,
+  MutationEventType,
+  MutationStore,
+  MutationStoreError,
+  mutationIdResult,
+  type MutationAuthoritySnapshot,
+  type MutationEvent,
+  type MutationIntentTransition,
+  type MutationIntentSnapshot,
+  type MutationOutcomeDefinition,
+  type MutationOutcomeInput,
+  type MutationReplayIntentSnapshot,
+  type MutationStartInput,
+  type MutationStoreShape,
+} from './mutations'
 import { WriterFence, WriterFenceError } from './writer-fence'
 
 const intentId = 'a'.repeat(64)
@@ -110,6 +130,1023 @@ const evidence = (status: number, observedAt: string): MutationEvidence => ({
   observedAt,
 })
 
+const resultSuccess = <A, E>(result: Result.Result<A, E>): A => {
+  expect(Result.isSuccess(result)).toBe(true)
+  if (Result.isFailure(result)) throw result.failure
+  return result.success
+}
+
+const resultFailure = <A>(result: Result.Result<A, MutationStoreError>): MutationStoreError => {
+  expect(Result.isFailure(result)).toBe(true)
+  if (Result.isSuccess(result)) throw new Error('expected a mutation decision failure')
+  return result.failure
+}
+
+const decisionRequestHash = '1'.repeat(64)
+const decisionStartedAt = '1970-01-01T00:00:01.000Z'
+const decisionOutcomeAt = '1970-01-01T00:00:02.000Z'
+
+const decisionStartInput = (operation: MutationOperation, brokerOrderId?: string): MutationStartInput => ({
+  intentId,
+  requestHash: decisionRequestHash,
+  consistencyDelayMs: 1_000,
+  occurredAt: decisionStartedAt,
+  ...(operation === MutationOperation.Cancel && brokerOrderId !== undefined ? { brokerOrderId } : {}),
+})
+
+const decisionAuthority: MutationAuthoritySnapshot = {
+  maximum: Authority.Paper,
+  effective: Authority.Paper,
+  killState: KillState.Clear,
+  generationHash: intent.authorityGenerationHash,
+  generationMaximum: Authority.Paper,
+  generationAccountId: accountId,
+}
+
+const decisionIntent = (state: IntentState = IntentState.Approved): MutationIntentSnapshot => ({
+  accountId,
+  authorityGenerationHash: intent.authorityGenerationHash,
+  policyHash: intent.policyHash,
+  state,
+  strategyName: intent.strategyName,
+  updatedAt: initialTime,
+  generationAccountId: accountId,
+  generationMaximum: Authority.Paper,
+  generationRiskPolicyHash: intent.policyHash,
+  generationStrategyName: intent.strategyName,
+})
+
+const decisionEvent = (
+  operation: MutationOperation,
+  eventType: MutationEventType,
+  overrides: Partial<MutationEvent> = {},
+): MutationEvent => ({
+  schemaVersion: 'bayn.paper-mutation-event.v1',
+  eventId: canonicalHashV1({ operation, eventType, overrides }),
+  mutationId: resultSuccess(mutationIdResult(intentId, operation)),
+  intentId,
+  sequence: 1,
+  operation,
+  eventType,
+  requestHash: decisionRequestHash,
+  consistencyDelayMs: 1_000,
+  occurredAt: decisionStartedAt,
+  ...overrides,
+})
+
+const decisionOutcomeInput = (overrides: Partial<MutationOutcomeInput> = {}): MutationOutcomeInput => ({
+  intentId,
+  requestHash: decisionRequestHash,
+  occurredAt: decisionOutcomeAt,
+  ...overrides,
+})
+
+const decisionReplayIntent = (
+  state: IntentState,
+  terminalOutcome: TerminalOutcome | null = null,
+): MutationReplayIntentSnapshot => ({ state, terminalOutcome })
+
+describe('MutationStore decision algebra', () => {
+  test('returns a closed canonicalization failure for a malformed mutation identity', () => {
+    const identity = mutationIdResult('\ud800', MutationOperation.Submit)
+
+    expect(Result.isFailure(identity)).toBe(true)
+    if (Result.isSuccess(identity)) throw new Error('expected malformed mutation identity to fail')
+    expect(identity.failure).toMatchObject({
+      _tag: 'MutationCanonicalizationFailure',
+      fact: {
+        _tag: 'MutationIdentity',
+        intentId: '\ud800',
+        operation: MutationOperation.Submit,
+      },
+    })
+    expect(identity.failure.cause).toBeInstanceOf(TypeError)
+  })
+
+  test('makes every authority outcome explicit', () => {
+    const submitBinding = resultSuccess(decideMutationAuthority(MutationOperation.Submit, decisionAuthority))
+    expect(submitBinding).toEqual({
+      accountId,
+      generationHash: intent.authorityGenerationHash,
+    })
+    expect(
+      resultSuccess(
+        decideMutationAuthority(MutationOperation.Cancel, {
+          ...decisionAuthority,
+          effective: Authority.Observe,
+          killState: KillState.Active,
+        }),
+      ),
+    ).toEqual(submitBinding)
+
+    const failures: readonly [MutationOperation, MutationAuthoritySnapshot | undefined, string][] = [
+      [MutationOperation.Submit, undefined, 'paper authority is not initialized'],
+      [
+        MutationOperation.Submit,
+        { ...decisionAuthority, maximum: Authority.Observe },
+        'GitOps maximum authority is not PAPER',
+      ],
+      [
+        MutationOperation.Submit,
+        { ...decisionAuthority, effective: Authority.Observe },
+        'effective authority is not PAPER and clear',
+      ],
+      [
+        MutationOperation.Submit,
+        { ...decisionAuthority, killState: KillState.Active },
+        'effective authority is not PAPER and clear',
+      ],
+      [
+        MutationOperation.Cancel,
+        { ...decisionAuthority, effective: Authority.Observe },
+        'cancellation requires PAPER authority or an active kill',
+      ],
+      [
+        MutationOperation.Submit,
+        { ...decisionAuthority, generationMaximum: Authority.Observe },
+        'active PAPER authority lacks its immutable account binding',
+      ],
+      [
+        MutationOperation.Submit,
+        { ...decisionAuthority, generationAccountId: null },
+        'active PAPER authority lacks its immutable account binding',
+      ],
+    ]
+    for (const [operation, authority, message] of failures) {
+      expect(resultFailure(decideMutationAuthority(operation, authority))).toMatchObject({
+        _tag: 'MutationStoreError',
+        failure: 'authority',
+        message,
+      })
+    }
+  })
+
+  test('decides start replay, immutable binding, stale time, and retained cancel identity', () => {
+    const submitInput = decisionStartInput(MutationOperation.Submit)
+    const submitStarted = decisionEvent(MutationOperation.Submit, MutationEventType.SubmitStarted)
+    expect(resultSuccess(decideMutationStartReplay(MutationOperation.Submit, submitInput, undefined))).toEqual({
+      _tag: 'BeginMutation',
+    })
+    const replay = resultSuccess(decideMutationStartReplay(MutationOperation.Submit, submitInput, submitStarted))
+    expect(replay).toEqual({
+      _tag: 'ReplayMutation',
+      receipt: { event: submitStarted, started: false },
+    })
+    if (replay._tag === 'ReplayMutation') expect(replay.receipt.event).toBe(submitStarted)
+
+    for (const changed of [
+      { ...submitStarted, requestHash: '2'.repeat(64) },
+      { ...submitStarted, consistencyDelayMs: 2_000 },
+      { ...submitStarted, mutationId: '3'.repeat(64) },
+    ]) {
+      expect(resultFailure(decideMutationStartReplay(MutationOperation.Submit, submitInput, changed))).toMatchObject({
+        operation: 'begin-submit',
+        failure: 'conflict',
+        message: 'mutation identity was reused with different request content',
+      })
+    }
+    const cancelInput = decisionStartInput(MutationOperation.Cancel, orderId)
+    expect(
+      resultFailure(
+        decideMutationStartReplay(
+          MutationOperation.Cancel,
+          cancelInput,
+          decisionEvent(MutationOperation.Cancel, MutationEventType.CancelStarted, {
+            brokerOrderId: 'another-order',
+          }),
+        ),
+      ),
+    ).toMatchObject({ operation: 'begin-cancel', failure: 'conflict' })
+    const malformedReplay = resultFailure(
+      decideMutationStartReplay(MutationOperation.Submit, { ...submitInput, intentId: '\ud800' }, submitStarted),
+    )
+    expect(malformedReplay).toMatchObject({
+      operation: 'begin-submit',
+      failure: 'invariant',
+      message: 'mutation identity canonicalization failed',
+    })
+    expect(malformedReplay.cause).toBeInstanceOf(TypeError)
+    expect(malformedReplay.canonicalizationFailure?.cause).toBe(malformedReplay.cause)
+
+    const authority = resultSuccess(decideMutationAuthority(MutationOperation.Submit, decisionAuthority))
+    const submit = resultSuccess(
+      decideMutationStart(MutationOperation.Submit, submitInput, authority, decisionIntent(), undefined),
+    )
+    expect(submit).toMatchObject({
+      event: {
+        operation: MutationOperation.Submit,
+        eventType: MutationEventType.SubmitStarted,
+        sequence: 1,
+      },
+      intentTransition: 'ApprovedToIoStarted',
+    })
+
+    const bindingFailures: readonly [MutationIntentSnapshot, string][] = [
+      [
+        { ...decisionIntent(), generationMaximum: Authority.Observe },
+        'intent does not match its immutable PAPER authority-generation bindings',
+      ],
+      [
+        { ...decisionIntent(), generationAccountId: null },
+        'intent does not match its immutable PAPER authority-generation bindings',
+      ],
+      [
+        { ...decisionIntent(), generationAccountId: 'another-account' },
+        'intent does not match its immutable PAPER authority-generation bindings',
+      ],
+      [
+        { ...decisionIntent(), generationRiskPolicyHash: '4'.repeat(64) },
+        'intent does not match its immutable PAPER authority-generation bindings',
+      ],
+      [
+        { ...decisionIntent(), generationStrategyName: 'another-strategy' },
+        'intent does not match its immutable PAPER authority-generation bindings',
+      ],
+    ]
+    for (const [snapshot, message] of bindingFailures) {
+      expect(
+        resultFailure(decideMutationStart(MutationOperation.Submit, submitInput, authority, snapshot, undefined)),
+      ).toMatchObject({ operation: 'begin-submit', failure: 'authority', message })
+    }
+    expect(
+      resultFailure(
+        decideMutationStart(
+          MutationOperation.Submit,
+          submitInput,
+          { ...authority, accountId: 'another-account' },
+          decisionIntent(),
+          undefined,
+        ),
+      ),
+    ).toMatchObject({
+      message: 'intent account does not match the active PAPER authority generation',
+    })
+    expect(
+      resultFailure(
+        decideMutationStart(
+          MutationOperation.Submit,
+          submitInput,
+          authority,
+          { ...decisionIntent(), authorityGenerationHash: '5'.repeat(64) },
+          undefined,
+        ),
+      ),
+    ).toMatchObject({
+      message: 'intent authority generation is not the active PAPER generation',
+    })
+    expect(
+      resultFailure(
+        decideMutationStart(
+          MutationOperation.Submit,
+          { ...submitInput, occurredAt: initialTime },
+          authority,
+          decisionIntent(),
+          undefined,
+        ),
+      ),
+    ).toMatchObject({ message: 'mutation time must follow the intent state' })
+
+    const retainedStates: readonly [MutationEventType, IntentState][] = [
+      [MutationEventType.SubmitAccepted, IntentState.Acknowledged],
+      [MutationEventType.RecoveryFound, IntentState.Acknowledged],
+      [MutationEventType.SubmitUnknown, IntentState.Unknown],
+      [MutationEventType.RecoveryNotFound, IntentState.Unknown],
+      [MutationEventType.RecoveryUnknown, IntentState.Unknown],
+    ]
+    for (const [eventType, state] of retainedStates) {
+      const cancel = resultSuccess(
+        decideMutationStart(
+          MutationOperation.Cancel,
+          cancelInput,
+          authority,
+          decisionIntent(state),
+          decisionEvent(MutationOperation.Submit, eventType, { brokerOrderId: orderId }),
+        ),
+      )
+      expect(cancel).toMatchObject({
+        event: { operation: MutationOperation.Cancel, eventType: MutationEventType.CancelStarted },
+        intentTransition: 'KeepIntentState',
+      })
+    }
+    for (const submitted of [
+      undefined,
+      decisionEvent(MutationOperation.Submit, MutationEventType.SubmitRejected, { brokerOrderId: orderId }),
+      decisionEvent(MutationOperation.Submit, MutationEventType.SubmitAccepted, {
+        brokerOrderId: 'another-order',
+      }),
+    ]) {
+      expect(
+        resultFailure(
+          decideMutationStart(
+            MutationOperation.Cancel,
+            cancelInput,
+            authority,
+            decisionIntent(IntentState.Acknowledged),
+            submitted,
+          ),
+        ),
+      ).toMatchObject({
+        operation: 'begin-cancel',
+        failure: 'invariant',
+        message: 'cancel requires the exact durable submitted order identity',
+      })
+    }
+
+    const malformedBrokerOrderId = '\ud800'
+    const malformedEvent = resultFailure(
+      decideMutationStart(
+        MutationOperation.Cancel,
+        decisionStartInput(MutationOperation.Cancel, malformedBrokerOrderId),
+        authority,
+        decisionIntent(IntentState.Acknowledged),
+        {
+          ...decisionEvent(MutationOperation.Submit, MutationEventType.SubmitAccepted, {
+            brokerOrderId: orderId,
+          }),
+          brokerOrderId: malformedBrokerOrderId,
+        },
+      ),
+    )
+    expect(malformedEvent).toMatchObject({
+      operation: 'begin-cancel',
+      failure: 'invariant',
+      message: 'mutation event canonicalization failed',
+    })
+    expect(malformedEvent.cause).toBeInstanceOf(TypeError)
+    expect(malformedEvent.canonicalizationFailure?.cause).toBe(malformedEvent.cause)
+  })
+
+  test('maps every public outcome to one closed transition decision', () => {
+    const cases: readonly [
+      MutationOutcomeDefinition,
+      MutationOperation,
+      MutationEventType,
+      MutationIntentTransition['_tag'],
+      IntentState | undefined,
+      TerminalOutcome | undefined,
+    ][] = [
+      [
+        { _tag: 'SubmitAccepted' },
+        MutationOperation.Submit,
+        MutationEventType.SubmitAccepted,
+        'TransitionFromIoStarted',
+        IntentState.Acknowledged,
+        undefined,
+      ],
+      [
+        { _tag: 'SubmitAccepted', terminalOutcome: TerminalOutcome.Filled },
+        MutationOperation.Submit,
+        MutationEventType.SubmitAccepted,
+        'TransitionFromIoStarted',
+        IntentState.Terminal,
+        TerminalOutcome.Filled,
+      ],
+      [
+        { _tag: 'SubmitRejected' },
+        MutationOperation.Submit,
+        MutationEventType.SubmitRejected,
+        'TransitionFromIoStarted',
+        IntentState.Terminal,
+        TerminalOutcome.Rejected,
+      ],
+      [
+        { _tag: 'SubmitUnknown' },
+        MutationOperation.Submit,
+        MutationEventType.SubmitUnknown,
+        'TransitionFromIoStarted',
+        IntentState.Unknown,
+        undefined,
+      ],
+      [
+        { _tag: 'CancelAccepted' },
+        MutationOperation.Cancel,
+        MutationEventType.CancelAccepted,
+        'KeepIntentState',
+        undefined,
+        undefined,
+      ],
+      [
+        { _tag: 'CancelUnknown' },
+        MutationOperation.Cancel,
+        MutationEventType.CancelUnknown,
+        'KeepIntentState',
+        undefined,
+        undefined,
+      ],
+      [
+        { _tag: 'RecoveryFound', operation: MutationOperation.Submit },
+        MutationOperation.Submit,
+        MutationEventType.RecoveryFound,
+        'RecoverSubmit',
+        IntentState.Acknowledged,
+        undefined,
+      ],
+      [
+        {
+          _tag: 'RecoveryFound',
+          operation: MutationOperation.Submit,
+          terminalOutcome: TerminalOutcome.Expired,
+        },
+        MutationOperation.Submit,
+        MutationEventType.RecoveryFound,
+        'RecoverSubmit',
+        IntentState.Terminal,
+        TerminalOutcome.Expired,
+      ],
+      [
+        { _tag: 'RecoveryFound', operation: MutationOperation.Cancel },
+        MutationOperation.Cancel,
+        MutationEventType.RecoveryFound,
+        'KeepIntentState',
+        undefined,
+        undefined,
+      ],
+      [
+        {
+          _tag: 'RecoveryFound',
+          operation: MutationOperation.Cancel,
+          terminalOutcome: TerminalOutcome.Canceled,
+        },
+        MutationOperation.Cancel,
+        MutationEventType.RecoveryFound,
+        'RecoverCancelTerminal',
+        IntentState.Terminal,
+        TerminalOutcome.Canceled,
+      ],
+      [
+        { _tag: 'RecoveryNotFound', operation: MutationOperation.Submit },
+        MutationOperation.Submit,
+        MutationEventType.RecoveryNotFound,
+        'KeepIntentState',
+        undefined,
+        undefined,
+      ],
+      [
+        { _tag: 'RecoveryUnknown', operation: MutationOperation.Cancel },
+        MutationOperation.Cancel,
+        MutationEventType.RecoveryUnknown,
+        'KeepIntentState',
+        undefined,
+        undefined,
+      ],
+    ]
+
+    for (const [definition, operation, eventType, tag, state, terminalOutcome] of cases) {
+      const previousType =
+        definition._tag === 'SubmitAccepted' ||
+        definition._tag === 'SubmitRejected' ||
+        definition._tag === 'SubmitUnknown'
+          ? MutationEventType.SubmitStarted
+          : definition._tag === 'CancelAccepted' || definition._tag === 'CancelUnknown'
+            ? MutationEventType.CancelStarted
+            : operation === MutationOperation.Submit
+              ? MutationEventType.SubmitUnknown
+              : MutationEventType.CancelUnknown
+      const brokerOrderId =
+        eventType === MutationEventType.SubmitRejected || eventType === MutationEventType.SubmitUnknown
+          ? undefined
+          : orderId
+      const status =
+        eventType === MutationEventType.CancelAccepted
+          ? 204
+          : eventType === MutationEventType.RecoveryNotFound
+            ? 404
+            : eventType === MutationEventType.SubmitRejected
+              ? 422
+              : 200
+      const previous = decisionEvent(
+        operation,
+        previousType,
+        operation === MutationOperation.Cancel ? { brokerOrderId: orderId } : {},
+      )
+      const decision = resultSuccess(
+        decideMutationOutcome(
+          decisionOutcomeInput({
+            ...(brokerOrderId === undefined ? {} : { brokerOrderId }),
+            evidence: evidence(status, decisionOutcomeAt),
+          }),
+          definition,
+          previous,
+          decisionReplayIntent(
+            previousType === MutationEventType.SubmitStarted || previousType === MutationEventType.CancelStarted
+              ? IntentState.IoStarted
+              : IntentState.Unknown,
+          ),
+        ),
+      )
+      expect(decision).toMatchObject({
+        _tag: 'AppendMutation',
+        event: { operation, eventType },
+        transition: { _tag: tag },
+      })
+      if (decision._tag !== 'AppendMutation') throw new Error('expected append decision')
+      if ('nextState' in decision.transition) {
+        if (state === undefined) throw new Error('expected a transition state')
+        expect(decision.transition.nextState).toBe(state)
+      } else {
+        expect(state).toBeUndefined()
+      }
+      if ('terminalOutcome' in decision.transition) {
+        expect(decision.transition.terminalOutcome).toBe(terminalOutcome)
+      } else {
+        expect(terminalOutcome).toBeUndefined()
+      }
+    }
+  })
+
+  test('decides every durable event transition, exact replay, retained ID, and cancel-first containment', () => {
+    const allowed: readonly [MutationOperation, MutationEventType, MutationEventType][] = [
+      [MutationOperation.Submit, MutationEventType.SubmitStarted, MutationEventType.SubmitAccepted],
+      [MutationOperation.Submit, MutationEventType.SubmitStarted, MutationEventType.SubmitRejected],
+      [MutationOperation.Submit, MutationEventType.SubmitStarted, MutationEventType.SubmitUnknown],
+      [MutationOperation.Cancel, MutationEventType.CancelStarted, MutationEventType.CancelAccepted],
+      [MutationOperation.Cancel, MutationEventType.CancelStarted, MutationEventType.CancelUnknown],
+      [MutationOperation.Submit, MutationEventType.SubmitAccepted, MutationEventType.RecoveryFound],
+      [MutationOperation.Submit, MutationEventType.SubmitUnknown, MutationEventType.RecoveryNotFound],
+      [MutationOperation.Cancel, MutationEventType.CancelAccepted, MutationEventType.RecoveryUnknown],
+      [MutationOperation.Cancel, MutationEventType.CancelUnknown, MutationEventType.RecoveryFound],
+      [MutationOperation.Submit, MutationEventType.RecoveryFound, MutationEventType.RecoveryNotFound],
+      [MutationOperation.Submit, MutationEventType.RecoveryNotFound, MutationEventType.RecoveryUnknown],
+      [MutationOperation.Cancel, MutationEventType.RecoveryUnknown, MutationEventType.RecoveryFound],
+    ]
+    for (const [operation, previousType, nextType] of allowed) {
+      const previous =
+        previousType === MutationEventType.SubmitStarted
+          ? decisionEvent(operation, previousType)
+          : decisionEvent(operation, previousType, { brokerOrderId: orderId })
+      const brokerOrderId =
+        nextType === MutationEventType.SubmitRejected || nextType === MutationEventType.SubmitUnknown
+          ? undefined
+          : orderId
+      const status =
+        nextType === MutationEventType.CancelAccepted
+          ? 204
+          : nextType === MutationEventType.RecoveryNotFound
+            ? 404
+            : nextType === MutationEventType.SubmitRejected
+              ? 422
+              : 200
+      const definition: MutationOutcomeDefinition = (() => {
+        switch (nextType) {
+          case MutationEventType.SubmitAccepted:
+            return { _tag: 'SubmitAccepted' }
+          case MutationEventType.SubmitRejected:
+            return { _tag: 'SubmitRejected' }
+          case MutationEventType.SubmitUnknown:
+            return { _tag: 'SubmitUnknown' }
+          case MutationEventType.CancelAccepted:
+            return { _tag: 'CancelAccepted' }
+          case MutationEventType.CancelUnknown:
+            return { _tag: 'CancelUnknown' }
+          case MutationEventType.RecoveryFound:
+            return { _tag: 'RecoveryFound', operation }
+          case MutationEventType.RecoveryNotFound:
+            return { _tag: 'RecoveryNotFound', operation }
+          case MutationEventType.RecoveryUnknown:
+            return { _tag: 'RecoveryUnknown', operation }
+          case MutationEventType.SubmitStarted:
+          case MutationEventType.CancelStarted:
+            throw new Error('STARTED is not an outcome definition')
+        }
+      })()
+      const result = resultSuccess(
+        decideMutationOutcome(
+          decisionOutcomeInput({
+            ...(brokerOrderId === undefined ? {} : { brokerOrderId }),
+            evidence: evidence(status, decisionOutcomeAt),
+          }),
+          definition,
+          previous,
+          decisionReplayIntent(
+            previousType === MutationEventType.SubmitStarted || previousType === MutationEventType.CancelStarted
+              ? IntentState.IoStarted
+              : IntentState.Unknown,
+          ),
+        ),
+      )
+      expect(result).toMatchObject({
+        _tag: 'AppendMutation',
+        event: {
+          eventType: nextType,
+          ...(brokerOrderId === undefined ? {} : { brokerOrderId: orderId }),
+        },
+      })
+    }
+
+    const replayEvidence = evidence(404, decisionOutcomeAt)
+    const replayed = decisionEvent(MutationOperation.Submit, MutationEventType.RecoveryNotFound, {
+      sequence: 2,
+      brokerOrderId: orderId,
+      requestId: replayEvidence.requestId,
+      responseStatus: replayEvidence.status,
+      responseContentHash: replayEvidence.contentHash,
+    })
+    const replay = resultSuccess(
+      decideMutationOutcome(
+        decisionOutcomeInput({
+          occurredAt: '1970-01-01T00:00:03.000Z',
+          evidence: replayEvidence,
+        }),
+        { _tag: 'RecoveryNotFound', operation: MutationOperation.Submit },
+        replayed,
+        decisionReplayIntent(IntentState.Unknown),
+      ),
+    )
+    expect(replay).toEqual({ _tag: 'ReplayMutation', event: replayed })
+    if (replay._tag === 'ReplayMutation') expect(replay.event).toBe(replayed)
+
+    const retained = resultSuccess(
+      decideMutationOutcome(
+        decisionOutcomeInput({ evidence: evidence(200, decisionOutcomeAt) }),
+        { _tag: 'RecoveryFound', operation: MutationOperation.Submit },
+        decisionEvent(MutationOperation.Submit, MutationEventType.SubmitAccepted, {
+          brokerOrderId: orderId,
+        }),
+        decisionReplayIntent(IntentState.Acknowledged),
+      ),
+    )
+    expect(retained).toMatchObject({ _tag: 'AppendMutation', event: { brokerOrderId: orderId } })
+
+    const canonicalizationFailure = resultFailure(
+      decideMutationOutcome(
+        decisionOutcomeInput({ brokerOrderId: '\ud800' }),
+        { _tag: 'SubmitUnknown' },
+        decisionEvent(MutationOperation.Submit, MutationEventType.SubmitStarted),
+        decisionReplayIntent(IntentState.IoStarted),
+      ),
+    )
+    expect(canonicalizationFailure).toMatchObject({
+      operation: 'record-submit',
+      failure: 'invariant',
+      message: 'mutation event canonicalization failed',
+    })
+    expect(canonicalizationFailure.cause).toBeInstanceOf(TypeError)
+    expect(canonicalizationFailure.canonicalizationFailure?.cause).toBe(canonicalizationFailure.cause)
+
+    const outcomeFailures: readonly [
+      MutationOutcomeInput,
+      MutationOutcomeDefinition,
+      MutationEvent | undefined,
+      string,
+    ][] = [
+      [decisionOutcomeInput(), { _tag: 'SubmitAccepted' }, undefined, 'mutation STARTED event does not exist'],
+      [
+        decisionOutcomeInput({ requestHash: '2'.repeat(64) }),
+        { _tag: 'SubmitAccepted' },
+        decisionEvent(MutationOperation.Submit, MutationEventType.SubmitStarted),
+        'mutation request hash changed',
+      ],
+      [
+        decisionOutcomeInput({ brokerOrderId: 'another-order' }),
+        { _tag: 'RecoveryFound', operation: MutationOperation.Submit },
+        decisionEvent(MutationOperation.Submit, MutationEventType.SubmitAccepted, {
+          brokerOrderId: orderId,
+        }),
+        'mutation broker order identity cannot change',
+      ],
+      [
+        decisionOutcomeInput({ occurredAt: '1969-12-31T23:59:58.000Z' }),
+        { _tag: 'SubmitAccepted' },
+        decisionEvent(MutationOperation.Submit, MutationEventType.SubmitStarted),
+        'mutation identity and sequence must remain exact',
+      ],
+      [
+        decisionOutcomeInput(),
+        { _tag: 'CancelAccepted' },
+        decisionEvent(MutationOperation.Submit, MutationEventType.SubmitStarted),
+        'mutation identity and sequence must remain exact',
+      ],
+      [
+        decisionOutcomeInput(),
+        { _tag: 'RecoveryFound', operation: MutationOperation.Submit },
+        decisionEvent(MutationOperation.Submit, MutationEventType.SubmitRejected),
+        'invalid mutation transition from SUBMIT_REJECTED to RECOVERY_FOUND',
+      ],
+      [
+        decisionOutcomeInput(),
+        { _tag: 'RecoveryFound', operation: MutationOperation.Submit },
+        decisionEvent(MutationOperation.Submit, MutationEventType.SubmitStarted),
+        'invalid mutation transition from SUBMIT_STARTED to RECOVERY_FOUND',
+      ],
+      [
+        decisionOutcomeInput({ brokerOrderId: orderId }),
+        { _tag: 'RecoveryUnknown', operation: MutationOperation.Cancel },
+        decisionEvent(MutationOperation.Cancel, MutationEventType.CancelStarted, { brokerOrderId: orderId }),
+        'invalid mutation transition from CANCEL_STARTED to RECOVERY_UNKNOWN',
+      ],
+    ]
+    for (const [input, definition, previous, message] of outcomeFailures) {
+      expect(
+        resultFailure(decideMutationOutcome(input, definition, previous, decisionReplayIntent(IntentState.IoStarted))),
+      ).toMatchObject({
+        failure: message.includes('does not exist') ? 'invariant' : 'conflict',
+        message,
+      })
+    }
+
+    const invalidContracts: readonly [MutationOutcomeInput, MutationOutcomeDefinition, MutationEvent, IntentState][] = [
+      [
+        decisionOutcomeInput({ evidence: evidence(200, decisionOutcomeAt) }),
+        { _tag: 'SubmitAccepted' },
+        decisionEvent(MutationOperation.Submit, MutationEventType.SubmitStarted),
+        IntentState.IoStarted,
+      ],
+      [
+        decisionOutcomeInput({ evidence: evidence(500, decisionOutcomeAt) }),
+        { _tag: 'SubmitRejected' },
+        decisionEvent(MutationOperation.Submit, MutationEventType.SubmitStarted),
+        IntentState.IoStarted,
+      ],
+      [
+        decisionOutcomeInput({ evidence: evidence(200, decisionOutcomeAt) }),
+        { _tag: 'RecoveryFound', operation: MutationOperation.Submit },
+        decisionEvent(MutationOperation.Submit, MutationEventType.SubmitUnknown),
+        IntentState.Unknown,
+      ],
+      [
+        decisionOutcomeInput({ evidence: evidence(200, decisionOutcomeAt) }),
+        { _tag: 'RecoveryNotFound', operation: MutationOperation.Submit },
+        decisionEvent(MutationOperation.Submit, MutationEventType.SubmitUnknown),
+        IntentState.Unknown,
+      ],
+      [
+        decisionOutcomeInput({ brokerOrderId: orderId, evidence: evidence(200, decisionOutcomeAt) }),
+        { _tag: 'CancelAccepted' },
+        decisionEvent(MutationOperation.Cancel, MutationEventType.CancelStarted, { brokerOrderId: orderId }),
+        IntentState.Acknowledged,
+      ],
+      [
+        decisionOutcomeInput(),
+        { _tag: 'CancelUnknown' },
+        decisionEvent(MutationOperation.Cancel, MutationEventType.CancelStarted),
+        IntentState.Acknowledged,
+      ],
+    ]
+    for (const [input, definition, previous, state] of invalidContracts) {
+      expect(
+        resultFailure(decideMutationOutcome(input, definition, previous, decisionReplayIntent(state))),
+      ).toMatchObject({
+        failure: 'invariant',
+        message: 'mutation event does not match its operation and evidence contract',
+      })
+    }
+
+    const recoveryInput = decisionOutcomeInput({
+      brokerOrderId: orderId,
+      evidence: evidence(200, decisionOutcomeAt),
+    })
+    const unknownSubmit = decisionEvent(MutationOperation.Submit, MutationEventType.SubmitUnknown)
+    const terminalSubmit = resultSuccess(
+      decideMutationOutcome(
+        recoveryInput,
+        {
+          _tag: 'RecoveryFound',
+          operation: MutationOperation.Submit,
+          terminalOutcome: TerminalOutcome.Filled,
+        },
+        unknownSubmit,
+        decisionReplayIntent(IntentState.Unknown),
+      ),
+    )
+    expect(terminalSubmit).toMatchObject({
+      _tag: 'AppendMutation',
+      cancelFirst: { _tag: 'RequireNoDurableCancellation' },
+    })
+    const openSubmit = resultSuccess(
+      decideMutationOutcome(
+        recoveryInput,
+        { _tag: 'RecoveryFound', operation: MutationOperation.Submit },
+        unknownSubmit,
+        decisionReplayIntent(IntentState.Unknown),
+      ),
+    )
+    expect(openSubmit).toMatchObject({
+      _tag: 'AppendMutation',
+      cancelFirst: { _tag: 'SkipCancelFirstRead' },
+    })
+
+    const acceptedEvidence = evidence(200, decisionOutcomeAt)
+    const accepted = decisionEvent(MutationOperation.Submit, MutationEventType.SubmitAccepted, {
+      sequence: 2,
+      brokerOrderId: orderId,
+      requestId: acceptedEvidence.requestId,
+      responseStatus: acceptedEvidence.status,
+      responseContentHash: acceptedEvidence.contentHash,
+    })
+    const acceptedInput = decisionOutcomeInput({
+      brokerOrderId: orderId,
+      evidence: acceptedEvidence,
+      occurredAt: '1970-01-01T00:00:03.000Z',
+    })
+    expect(
+      resultSuccess(
+        decideMutationOutcome(
+          acceptedInput,
+          { _tag: 'SubmitAccepted' },
+          accepted,
+          decisionReplayIntent(IntentState.Acknowledged),
+        ),
+      ),
+    ).toEqual({ _tag: 'ReplayMutation', event: accepted })
+    expect(
+      resultFailure(
+        decideMutationOutcome(
+          acceptedInput,
+          { _tag: 'SubmitAccepted', terminalOutcome: TerminalOutcome.Filled },
+          accepted,
+          decisionReplayIntent(IntentState.Acknowledged),
+        ),
+      ),
+    ).toMatchObject({
+      operation: 'record-submit',
+      failure: 'conflict',
+      message: 'mutation outcome replay conflicts with durable intent state',
+    })
+    expect(
+      resultSuccess(
+        decideMutationOutcome(
+          acceptedInput,
+          { _tag: 'SubmitAccepted', terminalOutcome: TerminalOutcome.Filled },
+          accepted,
+          decisionReplayIntent(IntentState.Terminal, TerminalOutcome.Filled),
+        ),
+      ),
+    ).toEqual({ _tag: 'ReplayMutation', event: accepted })
+
+    const identicalEvidenceWrongIntent = resultFailure(
+      decideMutationOutcome(
+        { ...acceptedInput, intentId: '2'.repeat(64) },
+        { _tag: 'SubmitAccepted' },
+        accepted,
+        decisionReplayIntent(IntentState.Acknowledged),
+      ),
+    )
+    expect(identicalEvidenceWrongIntent).toMatchObject({
+      operation: 'record-submit',
+      failure: 'conflict',
+      message: 'mutation identity and sequence must remain exact',
+    })
+    const identicalEvidenceWrongOperation = resultFailure(
+      decideMutationOutcome(
+        acceptedInput,
+        { _tag: 'CancelAccepted' },
+        accepted,
+        decisionReplayIntent(IntentState.Acknowledged),
+      ),
+    )
+    expect(identicalEvidenceWrongOperation).toMatchObject({
+      operation: 'record-cancel',
+      failure: 'conflict',
+      message: 'mutation identity and sequence must remain exact',
+    })
+  })
+
+  test('binds same-evidence replay to the exact terminal outcome while retaining open and unknown replay', () => {
+    const submitEvidence = evidence(200, decisionOutcomeAt)
+    const submitInput = decisionOutcomeInput({
+      brokerOrderId: orderId,
+      evidence: submitEvidence,
+      occurredAt: '1970-01-01T00:00:03.000Z',
+    })
+    const submitAccepted = decisionEvent(MutationOperation.Submit, MutationEventType.SubmitAccepted, {
+      sequence: 2,
+      brokerOrderId: orderId,
+      requestId: submitEvidence.requestId,
+      responseStatus: submitEvidence.status,
+      responseContentHash: submitEvidence.contentHash,
+    })
+    const submitRecovery = { ...submitAccepted, eventType: MutationEventType.RecoveryFound, sequence: 3 }
+    const cancelRecovery = decisionEvent(MutationOperation.Cancel, MutationEventType.RecoveryFound, {
+      sequence: 3,
+      brokerOrderId: orderId,
+      requestId: submitEvidence.requestId,
+      responseStatus: submitEvidence.status,
+      responseContentHash: submitEvidence.contentHash,
+    })
+
+    const terminalCases: readonly {
+      readonly durable: MutationReplayIntentSnapshot
+      readonly exact: MutationOutcomeDefinition
+      readonly conflicting: MutationOutcomeDefinition
+      readonly input: MutationOutcomeInput
+      readonly operation: MutationStoreError['operation']
+      readonly previous: MutationEvent
+    }[] = [
+      {
+        durable: decisionReplayIntent(IntentState.Terminal, TerminalOutcome.Filled),
+        exact: { _tag: 'SubmitAccepted', terminalOutcome: TerminalOutcome.Filled },
+        conflicting: { _tag: 'SubmitAccepted', terminalOutcome: TerminalOutcome.Canceled },
+        input: submitInput,
+        operation: 'record-submit',
+        previous: submitAccepted,
+      },
+      {
+        durable: decisionReplayIntent(IntentState.Terminal, TerminalOutcome.Filled),
+        exact: {
+          _tag: 'RecoveryFound',
+          operation: MutationOperation.Submit,
+          terminalOutcome: TerminalOutcome.Filled,
+        },
+        conflicting: {
+          _tag: 'RecoveryFound',
+          operation: MutationOperation.Submit,
+          terminalOutcome: TerminalOutcome.Expired,
+        },
+        input: submitInput,
+        operation: 'record-recovery',
+        previous: submitRecovery,
+      },
+      {
+        durable: decisionReplayIntent(IntentState.Terminal, TerminalOutcome.Canceled),
+        exact: {
+          _tag: 'RecoveryFound',
+          operation: MutationOperation.Cancel,
+          terminalOutcome: TerminalOutcome.Canceled,
+        },
+        conflicting: {
+          _tag: 'RecoveryFound',
+          operation: MutationOperation.Cancel,
+          terminalOutcome: TerminalOutcome.Expired,
+        },
+        input: submitInput,
+        operation: 'record-recovery',
+        previous: cancelRecovery,
+      },
+    ]
+
+    for (const replay of terminalCases) {
+      expect(resultSuccess(decideMutationOutcome(replay.input, replay.exact, replay.previous, replay.durable))).toEqual(
+        {
+          _tag: 'ReplayMutation',
+          event: replay.previous,
+        },
+      )
+      expect(
+        resultFailure(decideMutationOutcome(replay.input, replay.conflicting, replay.previous, replay.durable)),
+      ).toMatchObject({
+        operation: replay.operation,
+        failure: 'conflict',
+        message: 'mutation outcome replay conflicts with durable intent state',
+      })
+    }
+
+    const openCancelRecovery = {
+      _tag: 'RecoveryFound',
+      operation: MutationOperation.Cancel,
+    } as const
+    for (const state of [IntentState.Acknowledged, IntentState.Unknown, IntentState.Recovered]) {
+      expect(
+        resultSuccess(
+          decideMutationOutcome(submitInput, openCancelRecovery, cancelRecovery, decisionReplayIntent(state)),
+        ),
+      ).toEqual({ _tag: 'ReplayMutation', event: cancelRecovery })
+    }
+    expect(
+      resultFailure(
+        decideMutationOutcome(
+          submitInput,
+          openCancelRecovery,
+          cancelRecovery,
+          decisionReplayIntent(IntentState.Terminal, TerminalOutcome.Canceled),
+        ),
+      ),
+    ).toMatchObject({
+      operation: 'record-recovery',
+      failure: 'conflict',
+      message: 'mutation outcome replay conflicts with durable intent state',
+    })
+
+    expect(
+      resultSuccess(
+        decideMutationOutcome(
+          submitInput,
+          { _tag: 'RecoveryFound', operation: MutationOperation.Submit },
+          submitRecovery,
+          decisionReplayIntent(IntentState.Acknowledged),
+        ),
+      ),
+    ).toEqual({ _tag: 'ReplayMutation', event: submitRecovery })
+
+    const unknownEvidence = evidence(503, decisionOutcomeAt)
+    const unknown = decisionEvent(MutationOperation.Submit, MutationEventType.SubmitUnknown, {
+      sequence: 2,
+      requestId: unknownEvidence.requestId,
+      responseStatus: unknownEvidence.status,
+      responseContentHash: unknownEvidence.contentHash,
+    })
+    expect(
+      resultSuccess(
+        decideMutationOutcome(
+          decisionOutcomeInput({ evidence: unknownEvidence }),
+          { _tag: 'SubmitUnknown' },
+          unknown,
+          decisionReplayIntent(IntentState.Unknown),
+        ),
+      ),
+    ).toEqual({ _tag: 'ReplayMutation', event: unknown })
+  })
+})
+
 const completeEvidence = (response: Partial<MutationEvidence> | undefined): MutationEvidence | undefined =>
   response?.requestId !== undefined &&
   response.status !== undefined &&
@@ -157,7 +1194,7 @@ const makeHarness = (options: HarnessOptions = {}) => {
     const value: MutationEvent = {
       schemaVersion: 'bayn.paper-mutation-event.v1',
       eventId: canonicalHashV1({ operation, sequence, eventType, occurredAt }),
-      mutationId: mutationId(intentId, operation),
+      mutationId: resultSuccess(mutationIdResult(intentId, operation)),
       intentId,
       sequence,
       operation,

--- a/services/bayn/src/execution/mutations.ts
+++ b/services/bayn/src/execution/mutations.ts
@@ -1,5 +1,5 @@
 import { PgClient } from '@effect/sql-pg'
-import { Context, Data, Effect, Layer, Schema } from 'effect'
+import { Context, Data, Effect, Layer, Result, Schema } from 'effect'
 
 import { canonicalHashV1 } from '../hash'
 import { Authority, IntentState, KillState, TerminalOutcome } from '../paper'
@@ -63,8 +63,8 @@ const StoredEventRow = Schema.Struct({
   response_content_hash: Schema.NullOr(Sha256),
   occurred_at: UtcInstant,
 })
-const decodeRows = Schema.decodeUnknownEffect(Schema.Array(StoredEventRow), strictParseOptions)
-const decodeIntentId = Schema.decodeUnknownEffect(Sha256)
+const decodeRowsResult = Schema.decodeUnknownResult(Schema.Array(StoredEventRow), strictParseOptions)
+const decodeIntentIdResult = Schema.decodeUnknownResult(Sha256)
 const StartInputSchema = Schema.Struct({
   intentId: Sha256,
   requestHash: Sha256,
@@ -79,18 +79,22 @@ const OutcomeInputSchema = Schema.Struct({
   brokerOrderId: Schema.optionalKey(BrokerOrderId),
   evidence: Schema.optionalKey(MutationEvidenceSchema),
 })
-const decodeStartInput = Schema.decodeUnknownEffect(StartInputSchema, strictParseOptions)
-const decodeOutcomeInput = Schema.decodeUnknownEffect(OutcomeInputSchema, strictParseOptions)
-const CompleteEvidenceInput = Schema.Struct({
-  requestId: Schema.Unknown,
-  status: Schema.Unknown,
-  contentHash: Schema.Unknown,
-  observedAt: Schema.Unknown,
-})
-const hasCompleteEvidence = Schema.is(CompleteEvidenceInput)
+const decodeStartInputResult = Schema.decodeUnknownResult(StartInputSchema, strictParseOptions)
+const decodeOutcomeInputResult = Schema.decodeUnknownResult(OutcomeInputSchema, strictParseOptions)
+const hasCompleteEvidence = (evidence: Partial<MutationEvidence>): evidence is MutationEvidence =>
+  evidence.requestId !== undefined &&
+  evidence.status !== undefined &&
+  evidence.contentHash !== undefined &&
+  evidence.observedAt !== undefined
 
-const completeEvidence = (evidence: Partial<MutationEvidence> | undefined): Partial<MutationEvidence> | undefined =>
-  evidence !== undefined && hasCompleteEvidence(evidence) ? evidence : undefined
+type MutationEvidenceDecision =
+  | { readonly _tag: 'OmitIncompleteEvidence' }
+  | { readonly _tag: 'RetainCompleteEvidence'; readonly evidence: Partial<MutationEvidence> }
+
+const decideMutationEvidence = (evidence: Partial<MutationEvidence> | undefined): MutationEvidenceDecision =>
+  evidence !== undefined && hasCompleteEvidence(evidence)
+    ? { _tag: 'RetainCompleteEvidence', evidence }
+    : { _tag: 'OmitIncompleteEvidence' }
 
 const eventIdentity = (event: Omit<MutationEvent, 'eventId'>) => ({
   schemaVersion: event.schemaVersion,
@@ -108,12 +112,65 @@ const eventIdentity = (event: Omit<MutationEvent, 'eventId'>) => ({
   occurredAt: event.occurredAt,
 })
 
-export const mutationId = (intentId: string, operation: MutationOperation): string =>
-  canonicalHashV1({ schemaVersion: 'bayn.paper-mutation.v1', intentId, operation })
+type MutationCanonicalizationFact =
+  | {
+      readonly _tag: 'MutationIdentity'
+      readonly intentId: string
+      readonly operation: MutationOperation
+    }
+  | {
+      readonly _tag: 'MutationEventIdentity'
+      readonly intentId: string
+      readonly operation: MutationOperation
+      readonly sequence: number
+      readonly eventType: MutationEventType
+    }
 
-const makeEvent = (event: Omit<MutationEvent, 'eventId' | 'schemaVersion'>): MutationEvent => {
+interface MutationCanonicalizationFailure {
+  readonly _tag: 'MutationCanonicalizationFailure'
+  readonly fact: MutationCanonicalizationFact
+  readonly cause: unknown
+}
+
+const canonicalHashResult = (
+  fact: MutationCanonicalizationFact,
+  value: unknown,
+): Result.Result<string, MutationCanonicalizationFailure> =>
+  Result.try({
+    try: () => canonicalHashV1(value),
+    catch: (cause): MutationCanonicalizationFailure => ({
+      _tag: 'MutationCanonicalizationFailure',
+      fact,
+      cause,
+    }),
+  })
+
+export const mutationIdResult = (
+  intentId: string,
+  operation: MutationOperation,
+): Result.Result<string, MutationCanonicalizationFailure> =>
+  canonicalHashResult(
+    { _tag: 'MutationIdentity', intentId, operation },
+    { schemaVersion: 'bayn.paper-mutation.v1', intentId, operation },
+  )
+
+const mutationEventResult = (
+  event: Omit<MutationEvent, 'eventId' | 'schemaVersion'>,
+): Result.Result<MutationEvent, MutationCanonicalizationFailure> => {
   const content = { schemaVersion: 'bayn.paper-mutation-event.v1' as const, ...event }
-  return { ...content, eventId: canonicalHashV1(eventIdentity(content)) }
+  return Result.map(
+    canonicalHashResult(
+      {
+        _tag: 'MutationEventIdentity',
+        intentId: event.intentId,
+        operation: event.operation,
+        sequence: event.sequence,
+        eventType: event.eventType,
+      },
+      eventIdentity(content),
+    ),
+    (eventId) => ({ ...content, eventId }),
+  )
 }
 
 const toEvent = (row: typeof StoredEventRow.Type): MutationEvent => ({
@@ -133,14 +190,64 @@ const toEvent = (row: typeof StoredEventRow.Type): MutationEvent => ({
   occurredAt: row.occurred_at,
 })
 
-class MutationStoreError extends Data.TaggedError('MutationStoreError')<{
+const AuthorityRows = Schema.Array(
+  Schema.Struct({
+    effective: Schema.Enum(Authority),
+    generation_hash: Sha256,
+    generation_account_id: Schema.NullOr(NonEmptyString),
+    generation_maximum: Schema.NullOr(Schema.Enum(Authority)),
+    kill_state: Schema.Enum(KillState),
+    maximum: Schema.Enum(Authority),
+  }),
+)
+const IntentRows = Schema.Array(
+  Schema.Struct({
+    account_id: NonEmptyString,
+    authority_generation_hash: Sha256,
+    generation_account_id: Schema.NullOr(NonEmptyString),
+    generation_maximum: Schema.NullOr(Schema.Enum(Authority)),
+    generation_risk_policy_hash: Schema.NullOr(Sha256),
+    generation_strategy_name: Schema.NullOr(NonEmptyString),
+    policy_hash: Sha256,
+    state: Schema.Enum(IntentState),
+    strategy_name: NonEmptyString,
+    updated_at: UtcInstant,
+  }),
+)
+const UnresolvedRows = Schema.Array(Schema.Struct({ unresolved: Schema.Boolean }))
+const EventIdRows = Schema.Array(Schema.Struct({ event_id: Sha256 }))
+const IntentIdRows = Schema.Array(Schema.Struct({ intent_id: Sha256 }))
+const OutcomeIntentRows = Schema.Array(
+  Schema.Struct({
+    state: Schema.Enum(IntentState),
+    terminal_outcome: Schema.NullOr(Schema.Enum(TerminalOutcome)),
+  }),
+)
+const AcknowledgedRows = Schema.Array(Schema.Struct({ acknowledged: Schema.Boolean }))
+
+const decodeAuthorityRowsResult = Schema.decodeUnknownResult(AuthorityRows, strictParseOptions)
+const decodeIntentRowsResult = Schema.decodeUnknownResult(IntentRows, strictParseOptions)
+const decodeUnresolvedRowsResult = Schema.decodeUnknownResult(UnresolvedRows, strictParseOptions)
+const decodeEventIdRowsResult = Schema.decodeUnknownResult(EventIdRows, strictParseOptions)
+const decodeIntentIdRowsResult = Schema.decodeUnknownResult(IntentIdRows, strictParseOptions)
+const decodeOutcomeIntentRowsResult = Schema.decodeUnknownResult(OutcomeIntentRows, strictParseOptions)
+const decodeAcknowledgedRowsResult = Schema.decodeUnknownResult(AcknowledgedRows, strictParseOptions)
+
+export class MutationStoreError extends Data.TaggedError('MutationStoreError')<{
   readonly operation: 'begin-submit' | 'record-submit' | 'begin-cancel' | 'record-cancel' | 'record-recovery' | 'read'
   readonly failure: 'authority' | 'conflict' | 'decode' | 'invariant' | 'query'
   readonly message: string
   readonly cause?: unknown
+  readonly canonicalizationFailure?: MutationCanonicalizationFailure
 }> {}
 
-interface StartReceipt {
+type StartStoreOperation = Extract<MutationStoreError['operation'], 'begin-submit' | 'begin-cancel'>
+type OutcomeStoreOperation = Extract<
+  MutationStoreError['operation'],
+  'record-submit' | 'record-cancel' | 'record-recovery'
+>
+
+export interface StartReceipt {
   readonly event: MutationEvent
   readonly started: boolean
 }
@@ -220,15 +327,125 @@ export interface MutationStoreShape {
 
 export class MutationStore extends Context.Service<MutationStore, MutationStoreShape>()('bayn/MutationStore') {}
 
+export type MutationStartInput = typeof StartInputSchema.Type
+export type MutationOutcomeInput = typeof OutcomeInputSchema.Type
+
+export interface MutationAuthoritySnapshot {
+  readonly maximum: Authority
+  readonly effective: Authority
+  readonly killState: KillState
+  readonly generationHash: string
+  readonly generationMaximum: Authority | null
+  readonly generationAccountId: string | null
+}
+
+export interface MutationAuthorityBinding {
+  readonly accountId: string
+  readonly generationHash: string
+}
+
+export interface MutationIntentSnapshot {
+  readonly accountId: string
+  readonly authorityGenerationHash: string
+  readonly policyHash: string
+  readonly state: IntentState
+  readonly strategyName: string
+  readonly updatedAt: string
+  readonly generationAccountId: string | null
+  readonly generationMaximum: Authority | null
+  readonly generationRiskPolicyHash: string | null
+  readonly generationStrategyName: string | null
+}
+
+export type MutationStartReplayDecision =
+  | { readonly _tag: 'BeginMutation' }
+  | { readonly _tag: 'ReplayMutation'; readonly receipt: StartReceipt }
+
+export type MutationStartDecision = {
+  readonly event: MutationEvent
+  readonly intentTransition: 'KeepIntentState' | 'ApprovedToIoStarted'
+}
+
+export type MutationIntentTransition =
+  | { readonly _tag: 'KeepIntentState' }
+  | {
+      readonly _tag: 'TransitionFromIoStarted'
+      readonly nextState: IntentState
+      readonly terminalOutcome?: TerminalOutcome
+    }
+  | {
+      readonly _tag: 'RecoverSubmit'
+      readonly nextState: IntentState.Acknowledged | IntentState.Terminal
+      readonly terminalOutcome?: TerminalOutcome
+    }
+  | {
+      readonly _tag: 'RecoverCancelTerminal'
+      readonly nextState: IntentState.Terminal
+      readonly terminalOutcome: TerminalOutcome
+    }
+
+type MutationCancelFirstDecision =
+  | { readonly _tag: 'SkipCancelFirstRead' }
+  | { readonly _tag: 'RequireNoDurableCancellation' }
+
+export type MutationOutcomeDefinition =
+  | { readonly _tag: 'SubmitAccepted'; readonly terminalOutcome?: TerminalOutcome }
+  | { readonly _tag: 'SubmitRejected' }
+  | { readonly _tag: 'SubmitUnknown' }
+  | { readonly _tag: 'CancelAccepted' }
+  | { readonly _tag: 'CancelUnknown' }
+  | {
+      readonly _tag: 'RecoveryFound'
+      readonly operation: MutationOperation
+      readonly terminalOutcome?: TerminalOutcome
+    }
+  | { readonly _tag: 'RecoveryNotFound'; readonly operation: MutationOperation }
+  | { readonly _tag: 'RecoveryUnknown'; readonly operation: MutationOperation }
+
+interface MutationOutcomeFacts {
+  readonly operation: MutationOperation
+  readonly eventType: MutationEventType
+  readonly transition: MutationIntentTransition
+  readonly replayIntent?: MutationReplayIntentExpectation
+  readonly cancelFirst: MutationCancelFirstDecision
+}
+
+export interface MutationReplayIntentSnapshot {
+  readonly state: IntentState
+  readonly terminalOutcome: TerminalOutcome | null
+}
+
+type MutationReplayIntentExpectation =
+  | {
+      readonly _tag: 'ExactReplayIntent'
+      readonly snapshot: MutationReplayIntentSnapshot
+    }
+  | { readonly _tag: 'NonTerminalReplayIntent' }
+
+export type MutationOutcomeDecision =
+  | { readonly _tag: 'ReplayMutation'; readonly event: MutationEvent }
+  | {
+      readonly _tag: 'AppendMutation'
+      readonly event: MutationEvent
+      readonly transition: MutationIntentTransition
+      readonly cancelFirst: MutationCancelFirstDecision
+    }
+
+type SubmitRecoveryWriteDecision =
+  | { readonly _tag: 'TransitionRecoveredIntent' }
+  | { readonly _tag: 'TransitionAcknowledgedTerminalIntent' }
+  | { readonly _tag: 'VerifyAcknowledgedIntent' }
+
 const intentStateForIdentifiedSubmit = (
   event: MutationEvent | undefined,
   intentId: string,
+  expectedMutationId: string,
   brokerOrderId: string,
 ): IntentState | undefined => {
   if (
     event?.operation !== MutationOperation.Submit ||
     event.intentId !== intentId ||
-    event.mutationId !== mutationId(intentId, MutationOperation.Submit) ||
+    event.mutationId !== expectedMutationId ||
     event.brokerOrderId !== brokerOrderId
   ) {
     return undefined
@@ -253,6 +470,609 @@ const storeError = (
   cause?: unknown,
 ) => new MutationStoreError({ operation, failure, message, cause })
 
+const startStoreOperationFor = (operation: MutationOperation): StartStoreOperation =>
+  operation === MutationOperation.Submit ? 'begin-submit' : 'begin-cancel'
+
+const canonicalizationStoreError = (
+  operation: MutationStoreError['operation'],
+  failure: MutationCanonicalizationFailure,
+): MutationStoreError =>
+  new MutationStoreError({
+    operation,
+    failure: 'invariant',
+    message:
+      failure.fact._tag === 'MutationIdentity'
+        ? 'mutation identity canonicalization failed'
+        : 'mutation event canonicalization failed',
+    cause: failure.cause,
+    canonicalizationFailure: failure,
+  })
+
+const canonicalMutationId = (
+  storeOperation: MutationStoreError['operation'],
+  intentId: string,
+  operation: MutationOperation,
+): Result.Result<string, MutationStoreError> =>
+  Result.mapError(mutationIdResult(intentId, operation), (failure) =>
+    canonicalizationStoreError(storeOperation, failure),
+  )
+
+const makeEventResult = (
+  storeOperation: MutationStoreError['operation'],
+  event: Omit<MutationEvent, 'eventId' | 'schemaVersion'>,
+): Result.Result<MutationEvent, MutationStoreError> =>
+  Result.mapError(mutationEventResult(event), (failure) => canonicalizationStoreError(storeOperation, failure))
+
+export const decideMutationStartReplay = (
+  operation: MutationOperation,
+  input: MutationStartInput,
+  existing: MutationEvent | undefined,
+): Result.Result<MutationStartReplayDecision, MutationStoreError> => {
+  if (existing === undefined) return Result.succeed({ _tag: 'BeginMutation' })
+  const storeOperation = startStoreOperationFor(operation)
+  const expectedMutationId = canonicalMutationId(storeOperation, input.intentId, operation)
+  if (Result.isFailure(expectedMutationId)) return Result.fail(expectedMutationId.failure)
+  if (
+    existing.requestHash !== input.requestHash ||
+    existing.consistencyDelayMs !== input.consistencyDelayMs ||
+    (operation === MutationOperation.Cancel && existing.brokerOrderId !== input.brokerOrderId) ||
+    existing.mutationId !== expectedMutationId.success
+  ) {
+    return Result.fail(
+      storeError(storeOperation, 'conflict', 'mutation identity was reused with different request content'),
+    )
+  }
+  return Result.succeed({
+    _tag: 'ReplayMutation',
+    receipt: { event: existing, started: false },
+  })
+}
+
+export const decideMutationAuthority = (
+  operation: MutationOperation,
+  authority: MutationAuthoritySnapshot | undefined,
+): Result.Result<MutationAuthorityBinding, MutationStoreError> => {
+  const storeOperation = startStoreOperationFor(operation)
+  if (authority === undefined) {
+    return Result.fail(storeError(storeOperation, 'authority', 'paper authority is not initialized'))
+  }
+  if (authority.maximum !== Authority.Paper) {
+    return Result.fail(storeError(storeOperation, 'authority', 'GitOps maximum authority is not PAPER'))
+  }
+  if (
+    operation === MutationOperation.Submit &&
+    (authority.effective !== Authority.Paper || authority.killState !== KillState.Clear)
+  ) {
+    return Result.fail(storeError('begin-submit', 'authority', 'effective authority is not PAPER and clear'))
+  }
+  if (
+    operation === MutationOperation.Cancel &&
+    authority.killState === KillState.Clear &&
+    authority.effective !== Authority.Paper
+  ) {
+    return Result.fail(
+      storeError('begin-cancel', 'authority', 'cancellation requires PAPER authority or an active kill'),
+    )
+  }
+  if (authority.generationMaximum !== Authority.Paper || authority.generationAccountId === null) {
+    return Result.fail(
+      storeError(storeOperation, 'authority', 'active PAPER authority lacks its immutable account binding'),
+    )
+  }
+  return Result.succeed({
+    accountId: authority.generationAccountId,
+    generationHash: authority.generationHash,
+  })
+}
+
+const decideMutationContainment = (unresolved: boolean | undefined): Result.Result<void, MutationStoreError> =>
+  unresolved === false
+    ? Result.succeed(undefined)
+    : Result.fail(storeError('begin-submit', 'invariant', 'another broker mutation has an unresolved outcome'))
+
+export const decideMutationStart = (
+  operation: MutationOperation,
+  input: MutationStartInput,
+  authority: MutationAuthorityBinding,
+  intent: MutationIntentSnapshot | undefined,
+  submitted: MutationEvent | undefined,
+): Result.Result<MutationStartDecision, MutationStoreError> => {
+  const storeOperation = startStoreOperationFor(operation)
+  if (intent === undefined) {
+    return Result.fail(storeError(storeOperation, 'invariant', 'intent does not exist'))
+  }
+  if (
+    intent.generationMaximum !== Authority.Paper ||
+    intent.generationAccountId === null ||
+    intent.generationAccountId !== intent.accountId ||
+    intent.generationRiskPolicyHash !== intent.policyHash ||
+    intent.generationStrategyName !== intent.strategyName
+  ) {
+    return Result.fail(
+      storeError(
+        storeOperation,
+        'authority',
+        'intent does not match its immutable PAPER authority-generation bindings',
+      ),
+    )
+  }
+  if (intent.accountId !== authority.accountId) {
+    return Result.fail(
+      storeError(storeOperation, 'authority', 'intent account does not match the active PAPER authority generation'),
+    )
+  }
+  if (operation === MutationOperation.Submit && intent.authorityGenerationHash !== authority.generationHash) {
+    return Result.fail(
+      storeError('begin-submit', 'authority', 'intent authority generation is not the active PAPER generation'),
+    )
+  }
+
+  const expectedMutationId = canonicalMutationId(storeOperation, input.intentId, operation)
+  if (Result.isFailure(expectedMutationId)) return Result.fail(expectedMutationId.failure)
+  const expectedSubmittedMutationId =
+    operation === MutationOperation.Cancel
+      ? canonicalMutationId(storeOperation, input.intentId, MutationOperation.Submit)
+      : undefined
+  if (expectedSubmittedMutationId !== undefined && Result.isFailure(expectedSubmittedMutationId)) {
+    return Result.fail(expectedSubmittedMutationId.failure)
+  }
+  const requiredState =
+    operation === MutationOperation.Submit
+      ? IntentState.Approved
+      : input.brokerOrderId === undefined || expectedSubmittedMutationId === undefined
+        ? undefined
+        : intentStateForIdentifiedSubmit(
+            submitted,
+            input.intentId,
+            expectedSubmittedMutationId.success,
+            input.brokerOrderId,
+          )
+  if (requiredState === undefined) {
+    return Result.fail(
+      storeError('begin-cancel', 'invariant', 'cancel requires the exact durable submitted order identity'),
+    )
+  }
+  if (intent.state !== requiredState) {
+    return Result.fail(
+      storeError(storeOperation, 'invariant', `${operation.toLowerCase()} requires an ${requiredState} intent`),
+    )
+  }
+  if (input.occurredAt <= intent.updatedAt) {
+    return Result.fail(storeError(storeOperation, 'invariant', 'mutation time must follow the intent state'))
+  }
+
+  return Result.map(
+    makeEventResult(storeOperation, {
+      mutationId: expectedMutationId.success,
+      intentId: input.intentId,
+      sequence: 1,
+      operation,
+      eventType:
+        operation === MutationOperation.Submit ? MutationEventType.SubmitStarted : MutationEventType.CancelStarted,
+      requestHash: input.requestHash,
+      consistencyDelayMs: input.consistencyDelayMs,
+      ...(input.brokerOrderId === undefined ? {} : { brokerOrderId: input.brokerOrderId }),
+      occurredAt: input.occurredAt,
+    }),
+    (event): MutationStartDecision => ({
+      event,
+      intentTransition: operation === MutationOperation.Submit ? 'ApprovedToIoStarted' : 'KeepIntentState',
+    }),
+  )
+}
+
+const decideMutationOutcomeDefinition = (definition: MutationOutcomeDefinition): MutationOutcomeFacts => {
+  switch (definition._tag) {
+    case 'SubmitAccepted':
+      return {
+        operation: MutationOperation.Submit,
+        eventType: MutationEventType.SubmitAccepted,
+        transition: {
+          _tag: 'TransitionFromIoStarted',
+          nextState: definition.terminalOutcome === undefined ? IntentState.Acknowledged : IntentState.Terminal,
+          ...(definition.terminalOutcome === undefined ? {} : { terminalOutcome: definition.terminalOutcome }),
+        },
+        replayIntent: {
+          _tag: 'ExactReplayIntent',
+          snapshot: {
+            state: definition.terminalOutcome === undefined ? IntentState.Acknowledged : IntentState.Terminal,
+            terminalOutcome: definition.terminalOutcome ?? null,
+          },
+        },
+        cancelFirst: { _tag: 'SkipCancelFirstRead' },
+      }
+    case 'SubmitRejected':
+      return {
+        operation: MutationOperation.Submit,
+        eventType: MutationEventType.SubmitRejected,
+        transition: {
+          _tag: 'TransitionFromIoStarted',
+          nextState: IntentState.Terminal,
+          terminalOutcome: TerminalOutcome.Rejected,
+        },
+        replayIntent: {
+          _tag: 'ExactReplayIntent',
+          snapshot: {
+            state: IntentState.Terminal,
+            terminalOutcome: TerminalOutcome.Rejected,
+          },
+        },
+        cancelFirst: { _tag: 'SkipCancelFirstRead' },
+      }
+    case 'SubmitUnknown':
+      return {
+        operation: MutationOperation.Submit,
+        eventType: MutationEventType.SubmitUnknown,
+        transition: { _tag: 'TransitionFromIoStarted', nextState: IntentState.Unknown },
+        replayIntent: {
+          _tag: 'ExactReplayIntent',
+          snapshot: {
+            state: IntentState.Unknown,
+            terminalOutcome: null,
+          },
+        },
+        cancelFirst: { _tag: 'SkipCancelFirstRead' },
+      }
+    case 'CancelAccepted':
+      return {
+        operation: MutationOperation.Cancel,
+        eventType: MutationEventType.CancelAccepted,
+        transition: { _tag: 'KeepIntentState' },
+        cancelFirst: { _tag: 'SkipCancelFirstRead' },
+      }
+    case 'CancelUnknown':
+      return {
+        operation: MutationOperation.Cancel,
+        eventType: MutationEventType.CancelUnknown,
+        transition: { _tag: 'KeepIntentState' },
+        cancelFirst: { _tag: 'SkipCancelFirstRead' },
+      }
+    case 'RecoveryFound':
+      return {
+        operation: definition.operation,
+        eventType: MutationEventType.RecoveryFound,
+        transition:
+          definition.operation === MutationOperation.Submit
+            ? {
+                _tag: 'RecoverSubmit',
+                nextState: definition.terminalOutcome === undefined ? IntentState.Acknowledged : IntentState.Terminal,
+                ...(definition.terminalOutcome === undefined ? {} : { terminalOutcome: definition.terminalOutcome }),
+              }
+            : definition.terminalOutcome === undefined
+              ? { _tag: 'KeepIntentState' }
+              : {
+                  _tag: 'RecoverCancelTerminal',
+                  nextState: IntentState.Terminal,
+                  terminalOutcome: definition.terminalOutcome,
+                },
+        ...(definition.operation === MutationOperation.Submit
+          ? {
+              replayIntent: {
+                _tag: 'ExactReplayIntent',
+                snapshot: {
+                  state: definition.terminalOutcome === undefined ? IntentState.Acknowledged : IntentState.Terminal,
+                  terminalOutcome: definition.terminalOutcome ?? null,
+                },
+              },
+            }
+          : definition.terminalOutcome === undefined
+            ? { replayIntent: { _tag: 'NonTerminalReplayIntent' } }
+            : {
+                replayIntent: {
+                  _tag: 'ExactReplayIntent',
+                  snapshot: {
+                    state: IntentState.Terminal,
+                    terminalOutcome: definition.terminalOutcome,
+                  },
+                },
+              }),
+        cancelFirst:
+          definition.operation === MutationOperation.Submit && definition.terminalOutcome !== undefined
+            ? { _tag: 'RequireNoDurableCancellation' }
+            : { _tag: 'SkipCancelFirstRead' },
+      }
+    case 'RecoveryNotFound':
+      return {
+        operation: definition.operation,
+        eventType: MutationEventType.RecoveryNotFound,
+        transition: { _tag: 'KeepIntentState' },
+        cancelFirst: { _tag: 'SkipCancelFirstRead' },
+      }
+    case 'RecoveryUnknown':
+      return {
+        operation: definition.operation,
+        eventType: MutationEventType.RecoveryUnknown,
+        transition: { _tag: 'KeepIntentState' },
+        cancelFirst: { _tag: 'SkipCancelFirstRead' },
+      }
+  }
+}
+
+const outcomeStoreOperation = (definition: MutationOutcomeDefinition): OutcomeStoreOperation => {
+  switch (definition._tag) {
+    case 'SubmitAccepted':
+    case 'SubmitRejected':
+    case 'SubmitUnknown':
+      return 'record-submit'
+    case 'CancelAccepted':
+    case 'CancelUnknown':
+      return 'record-cancel'
+    case 'RecoveryFound':
+    case 'RecoveryNotFound':
+    case 'RecoveryUnknown':
+      return 'record-recovery'
+  }
+}
+
+const isRecoveryEventType = (eventType: MutationEventType): boolean =>
+  eventType === MutationEventType.RecoveryFound ||
+  eventType === MutationEventType.RecoveryNotFound ||
+  eventType === MutationEventType.RecoveryUnknown
+
+const allowsOutcomeEvent = (previous: MutationEventType, next: MutationEventType): boolean => {
+  switch (previous) {
+    case MutationEventType.SubmitStarted:
+      return (
+        next === MutationEventType.SubmitAccepted ||
+        next === MutationEventType.SubmitRejected ||
+        next === MutationEventType.SubmitUnknown
+      )
+    case MutationEventType.CancelStarted:
+      return next === MutationEventType.CancelAccepted || next === MutationEventType.CancelUnknown
+    case MutationEventType.SubmitAccepted:
+    case MutationEventType.SubmitUnknown:
+    case MutationEventType.CancelAccepted:
+    case MutationEventType.CancelUnknown:
+    case MutationEventType.RecoveryFound:
+    case MutationEventType.RecoveryNotFound:
+    case MutationEventType.RecoveryUnknown:
+      return isRecoveryEventType(next)
+    case MutationEventType.SubmitRejected:
+      return false
+  }
+}
+
+const sameOutcome = (previous: MutationEvent, event: MutationEvent): boolean =>
+  previous.eventType === event.eventType &&
+  previous.requestId === event.requestId &&
+  previous.responseStatus === event.responseStatus &&
+  previous.responseContentHash === event.responseContentHash &&
+  previous.brokerOrderId === event.brokerOrderId
+
+const matchesReplayIntent = (
+  expected: MutationReplayIntentExpectation,
+  current: MutationReplayIntentSnapshot | undefined,
+): boolean => {
+  if (current === undefined) return false
+  switch (expected._tag) {
+    case 'ExactReplayIntent':
+      return current.state === expected.snapshot.state && current.terminalOutcome === expected.snapshot.terminalOutcome
+    case 'NonTerminalReplayIntent':
+      return current.state !== IntentState.Terminal && current.terminalOutcome === null
+  }
+}
+
+const decideMutationEventContract = (
+  storeOperation: OutcomeStoreOperation,
+  event: MutationEvent,
+): Result.Result<void, MutationStoreError> => {
+  const valid = (() => {
+    switch (event.eventType) {
+      case MutationEventType.SubmitAccepted:
+        return (
+          event.operation === MutationOperation.Submit &&
+          event.brokerOrderId !== undefined &&
+          event.responseStatus === 200
+        )
+      case MutationEventType.SubmitRejected:
+        return (
+          event.operation === MutationOperation.Submit &&
+          event.brokerOrderId === undefined &&
+          (event.responseStatus === 400 ||
+            event.responseStatus === 401 ||
+            event.responseStatus === 403 ||
+            event.responseStatus === 404 ||
+            event.responseStatus === 422)
+        )
+      case MutationEventType.SubmitUnknown:
+        return event.operation === MutationOperation.Submit
+      case MutationEventType.RecoveryFound:
+        return event.brokerOrderId !== undefined && event.responseStatus === 200
+      case MutationEventType.RecoveryNotFound:
+        return (
+          event.responseStatus === 404 &&
+          (event.operation === MutationOperation.Submit || event.brokerOrderId !== undefined)
+        )
+      case MutationEventType.RecoveryUnknown:
+        return true
+      case MutationEventType.CancelAccepted:
+        return (
+          event.operation === MutationOperation.Cancel &&
+          event.brokerOrderId !== undefined &&
+          event.responseStatus === 204
+        )
+      case MutationEventType.CancelUnknown:
+        return event.operation === MutationOperation.Cancel && event.brokerOrderId !== undefined
+      case MutationEventType.SubmitStarted:
+      case MutationEventType.CancelStarted:
+        return false
+    }
+  })()
+  return valid
+    ? Result.succeed(undefined)
+    : Result.fail(
+        storeError(storeOperation, 'invariant', 'mutation event does not match its operation and evidence contract'),
+      )
+}
+
+export const decideMutationOutcome = (
+  input: MutationOutcomeInput,
+  definition: MutationOutcomeDefinition,
+  previous: MutationEvent | undefined,
+  currentIntent: MutationReplayIntentSnapshot | undefined,
+): Result.Result<MutationOutcomeDecision, MutationStoreError> => {
+  const storeOperation = outcomeStoreOperation(definition)
+  const facts = decideMutationOutcomeDefinition(definition)
+  if (previous === undefined) {
+    return Result.fail(storeError(storeOperation, 'invariant', 'mutation STARTED event does not exist'))
+  }
+  const expectedMutationId = canonicalMutationId(storeOperation, input.intentId, facts.operation)
+  if (Result.isFailure(expectedMutationId)) return Result.fail(expectedMutationId.failure)
+  if (
+    previous.intentId !== input.intentId ||
+    previous.operation !== facts.operation ||
+    previous.mutationId !== expectedMutationId.success
+  ) {
+    return Result.fail(storeError(storeOperation, 'conflict', 'mutation identity and sequence must remain exact'))
+  }
+  if (previous.requestHash !== input.requestHash) {
+    return Result.fail(storeError(storeOperation, 'conflict', 'mutation request hash changed'))
+  }
+  if (
+    previous.brokerOrderId !== undefined &&
+    input.brokerOrderId !== undefined &&
+    previous.brokerOrderId !== input.brokerOrderId
+  ) {
+    return Result.fail(storeError(storeOperation, 'conflict', 'mutation broker order identity cannot change'))
+  }
+
+  const brokerOrderId = previous.brokerOrderId ?? input.brokerOrderId
+  const eventResult = makeEventResult(storeOperation, {
+    mutationId: previous.mutationId,
+    intentId: input.intentId,
+    sequence: previous.sequence + 1,
+    operation: facts.operation,
+    eventType: facts.eventType,
+    requestHash: input.requestHash,
+    consistencyDelayMs: previous.consistencyDelayMs,
+    ...(brokerOrderId === undefined ? {} : { brokerOrderId }),
+    ...(input.evidence?.requestId === undefined ? {} : { requestId: input.evidence.requestId }),
+    ...(input.evidence?.status === undefined ? {} : { responseStatus: input.evidence.status }),
+    ...(input.evidence?.contentHash === undefined ? {} : { responseContentHash: input.evidence.contentHash }),
+    occurredAt: input.occurredAt,
+  })
+  if (Result.isFailure(eventResult)) return Result.fail(eventResult.failure)
+  const event = eventResult.success
+  if (sameOutcome(previous, event)) {
+    if (facts.replayIntent !== undefined && !matchesReplayIntent(facts.replayIntent, currentIntent)) {
+      return Result.fail(
+        storeError(storeOperation, 'conflict', 'mutation outcome replay conflicts with durable intent state'),
+      )
+    }
+    return Result.succeed({ _tag: 'ReplayMutation', event: previous })
+  }
+  if (input.occurredAt < previous.occurredAt) {
+    return Result.fail(storeError(storeOperation, 'conflict', 'mutation identity and sequence must remain exact'))
+  }
+  if (!allowsOutcomeEvent(previous.eventType, facts.eventType)) {
+    return Result.fail(
+      storeError(
+        storeOperation,
+        'conflict',
+        `invalid mutation transition from ${previous.eventType} to ${facts.eventType}`,
+      ),
+    )
+  }
+  const eventContract = decideMutationEventContract(storeOperation, event)
+  if (Result.isFailure(eventContract)) return Result.fail(eventContract.failure)
+  return Result.succeed({
+    _tag: 'AppendMutation',
+    event,
+    transition: facts.transition,
+    cancelFirst: facts.cancelFirst,
+  })
+}
+
+const decideCancelFirst = (
+  decision: MutationCancelFirstDecision,
+  cancellation: MutationEvent | undefined,
+): Result.Result<void, MutationStoreError> =>
+  decision._tag === 'RequireNoDurableCancellation' && cancellation !== undefined
+    ? Result.fail(
+        storeError('record-recovery', 'conflict', 'terminal submit recovery cannot overtake a durable cancellation'),
+      )
+    : Result.succeed(undefined)
+
+const decideMutationAppend = (
+  storeOperation: MutationStoreError['operation'],
+  event: MutationEvent,
+  appendedEventIds: readonly string[],
+  requireCurrentRisk: boolean,
+): Result.Result<MutationEvent, MutationStoreError> =>
+  appendedEventIds.length === 1
+    ? Result.succeed(event)
+    : Result.fail(
+        storeError(
+          storeOperation,
+          requireCurrentRisk ? 'invariant' : 'conflict',
+          requireCurrentRisk
+            ? 'mutation start requires a current approved risk decision'
+            : 'mutation event append lost its race',
+        ),
+      )
+
+const decideSubmitStartWrite = (transitionedIntentIds: readonly string[]): Result.Result<void, MutationStoreError> =>
+  transitionedIntentIds.length === 1
+    ? Result.succeed(undefined)
+    : Result.fail(storeError('begin-submit', 'conflict', 'approved intent transition lost its race'))
+
+const decideMutationOutcomeWrite = (
+  storeOperation: OutcomeStoreOperation,
+  transitionedIntentIds: readonly string[],
+): Result.Result<void, MutationStoreError> =>
+  transitionedIntentIds.length === 1
+    ? Result.succeed(undefined)
+    : Result.fail(storeError(storeOperation, 'conflict', 'intent mutation outcome lost its race'))
+
+const decideSubmitRecoveryWrite = (
+  storeOperation: OutcomeStoreOperation,
+  recoveredIntentIds: readonly string[],
+  transition: Extract<MutationIntentTransition, { readonly _tag: 'RecoverSubmit' }>,
+): Result.Result<SubmitRecoveryWriteDecision, MutationStoreError> => {
+  if (recoveredIntentIds.length === 1) return Result.succeed({ _tag: 'TransitionRecoveredIntent' })
+  if (recoveredIntentIds.length === 0 && transition.nextState === IntentState.Terminal) {
+    return Result.succeed({ _tag: 'TransitionAcknowledgedTerminalIntent' })
+  }
+  if (recoveredIntentIds.length === 0 && transition.nextState === IntentState.Acknowledged) {
+    return Result.succeed({ _tag: 'VerifyAcknowledgedIntent' })
+  }
+  return Result.fail(storeError(storeOperation, 'conflict', 'unknown intent recovery lost its race'))
+}
+
+const decideAcknowledgedRecovery = (
+  storeOperation: OutcomeStoreOperation,
+  acknowledged: boolean | undefined,
+): Result.Result<void, MutationStoreError> =>
+  acknowledged === true
+    ? Result.succeed(undefined)
+    : Result.fail(storeError(storeOperation, 'conflict', 'submit recovery requires an unresolved durable intent'))
+
+const decideRecoveredOutcomeWrite = (
+  storeOperation: OutcomeStoreOperation,
+  transitionedIntentIds: readonly string[],
+  acknowledgedTerminal: boolean,
+): Result.Result<void, MutationStoreError> =>
+  transitionedIntentIds.length === 1
+    ? Result.succeed(undefined)
+    : Result.fail(
+        storeError(
+          storeOperation,
+          'conflict',
+          acknowledgedTerminal
+            ? 'acknowledged intent terminal recovery lost its race'
+            : 'recovered intent outcome lost its race',
+        ),
+      )
+
+const decideCancelRecoveryState = (
+  storeOperation: OutcomeStoreOperation,
+  recoveredIntentIds: readonly string[],
+): Result.Result<IntentState.Acknowledged | IntentState.Recovered, MutationStoreError> => {
+  if (recoveredIntentIds.length === 0) return Result.succeed(IntentState.Acknowledged)
+  if (recoveredIntentIds.length === 1) return Result.succeed(IntentState.Recovered)
+  return Result.fail(storeError(storeOperation, 'conflict', 'intent mutation outcome lost its race'))
+}
+
 const selectLatest = (sql: PgClient.PgClient, intentId: string, operation: MutationOperation) => sql`
   SELECT
     schema_version,
@@ -275,6 +1095,98 @@ const selectLatest = (sql: PgClient.PgClient, intentId: string, operation: Mutat
   LIMIT 1
 `
 
+const decodeStartInput = (
+  operation: MutationOperation,
+  input: unknown,
+): Result.Result<MutationStartInput, MutationStoreError> =>
+  Result.mapError(decodeStartInputResult(input), (cause) =>
+    storeError(startStoreOperationFor(operation), 'decode', 'invalid mutation start', cause),
+  )
+
+const decodeOutcomeInput = (
+  storeOperation: OutcomeStoreOperation,
+  input: {
+    readonly intentId: string
+    readonly requestHash: string
+    readonly occurredAt: string
+    readonly brokerOrderId?: string
+    readonly evidence?: Partial<MutationEvidence>
+  },
+): Result.Result<MutationOutcomeInput, MutationStoreError> => {
+  const evidence = decideMutationEvidence(input.evidence)
+  return Result.mapError(
+    decodeOutcomeInputResult({
+      intentId: input.intentId,
+      requestHash: input.requestHash,
+      occurredAt: input.occurredAt,
+      ...(input.brokerOrderId === undefined ? {} : { brokerOrderId: input.brokerOrderId }),
+      ...(evidence._tag === 'RetainCompleteEvidence' ? { evidence: evidence.evidence } : {}),
+    }),
+    (cause) => storeError(storeOperation, 'decode', 'invalid mutation outcome', cause),
+  )
+}
+
+const decodeStoredEvents = (rows: unknown): Result.Result<readonly MutationEvent[], MutationStoreError> =>
+  Result.map(
+    Result.mapError(decodeRowsResult(rows), (cause) =>
+      storeError('read', 'decode', 'stored mutation event failed decoding', cause),
+    ),
+    (decoded) => decoded.map(toEvent),
+  )
+
+const decodeAuthoritySnapshot = (
+  operation: MutationOperation,
+  rows: unknown,
+): Result.Result<MutationAuthoritySnapshot | undefined, MutationStoreError> =>
+  Result.map(
+    Result.mapError(decodeAuthorityRowsResult(rows), (cause) =>
+      storeError(startStoreOperationFor(operation), 'decode', 'stored mutation authority failed decoding', cause),
+    ),
+    (decoded) => {
+      const authority = decoded[0]
+      return authority === undefined
+        ? undefined
+        : {
+            maximum: authority.maximum,
+            effective: authority.effective,
+            killState: authority.kill_state,
+            generationHash: authority.generation_hash,
+            generationMaximum: authority.generation_maximum,
+            generationAccountId: authority.generation_account_id,
+          }
+    },
+  )
+
+const decodeIntentSnapshot = (
+  operation: MutationOperation,
+  rows: unknown,
+): Result.Result<MutationIntentSnapshot | undefined, MutationStoreError> =>
+  Result.map(
+    Result.mapError(decodeIntentRowsResult(rows), (cause) =>
+      storeError(startStoreOperationFor(operation), 'decode', 'stored mutation intent failed decoding', cause),
+    ),
+    (decoded) => {
+      const intent = decoded[0]
+      return intent === undefined
+        ? undefined
+        : {
+            accountId: intent.account_id,
+            authorityGenerationHash: intent.authority_generation_hash,
+            policyHash: intent.policy_hash,
+            state: intent.state,
+            strategyName: intent.strategy_name,
+            updatedAt: intent.updated_at,
+            generationAccountId: intent.generation_account_id,
+            generationMaximum: intent.generation_maximum,
+            generationRiskPolicyHash: intent.generation_risk_policy_hash,
+            generationStrategyName: intent.generation_strategy_name,
+          }
+    },
+  )
+
+const fromDecision = <A, E>(evaluate: () => Result.Result<A, E>): Effect.Effect<A, E> =>
+  Effect.suspend(() => Effect.fromResult(evaluate()))
+
 const makeStore = Effect.gen(function* () {
   const sql = yield* PgClient.PgClient
   const fence = yield* WriterFence
@@ -291,178 +1203,233 @@ const makeStore = Effect.gen(function* () {
       ),
     )
 
-  const withFence = fence.transaction
-
   const readLatest = (intentId: string, operation: MutationOperation) =>
-    Effect.gen(function* () {
-      const rows = yield* decodeRows(yield* selectLatest(sql, intentId, operation)).pipe(
-        Effect.mapError((cause) => storeError('read', 'decode', 'stored mutation event failed decoding', cause)),
-      )
-      return rows[0] === undefined ? undefined : toEvent(rows[0])
-    })
+    selectLatest(sql, intentId, operation).pipe(
+      Effect.flatMap((rows) => fromDecision(() => Result.map(decodeStoredEvents(rows), (events) => events[0]))),
+    )
 
   const latest = (intentId: string, operation: MutationOperation) =>
-    decodeIntentId(intentId).pipe(
-      Effect.mapError((cause) => storeError('read', 'decode', 'invalid intent ID', cause)),
+    fromDecision(() =>
+      Result.mapError(decodeIntentIdResult(intentId), (cause) =>
+        storeError('read', 'decode', 'invalid intent ID', cause),
+      ),
+    ).pipe(
       Effect.flatMap((decodedIntentId) => readLatest(decodedIntentId, operation)),
       Effect.mapError((cause) =>
         cause instanceof MutationStoreError ? cause : storeError('read', 'query', 'mutation read failed', cause),
       ),
     )
 
-  const append = (event: MutationEvent, requireCurrentRisk = false) =>
-    Effect.gen(function* () {
-      const rows = yield* sql<{ event_id: string }>`
-        INSERT INTO mutation_events (
-          event_id,
-          schema_version,
-          mutation_id,
-          intent_id,
-          sequence,
-          operation,
-          event_type,
-          request_hash,
-          consistency_delay_ms,
-          broker_order_id,
-          request_id,
-          response_status,
-          response_content_hash,
-          occurred_at
-        )
-        SELECT
-          ${event.eventId},
-          ${event.schemaVersion},
-          ${event.mutationId},
-          ${event.intentId},
-          ${event.sequence},
-          ${event.operation},
-          ${event.eventType},
-          ${event.requestHash},
-          ${event.consistencyDelayMs},
-          ${event.brokerOrderId ?? null},
-          ${event.requestId ?? null},
-          ${event.responseStatus ?? null},
-          ${event.responseContentHash ?? null},
-          ${event.occurredAt}
-        WHERE ${!requireCurrentRisk}
-          OR EXISTS (
-            SELECT 1
-            FROM intents AS intent
-            JOIN risk_decisions AS decision
-              ON decision.decision_id = intent.risk_decision_id
-              AND decision.intent_id = intent.intent_id
-            WHERE intent.intent_id = ${event.intentId}
-              AND decision.outcome = 'APPROVED'
-              AND decision.decided_at <= clock_timestamp()
-              AND decision.expires_at > clock_timestamp()
-          )
-        RETURNING event_id
-      `
-      if (rows.length !== 1) {
-        const operation = event.operation === MutationOperation.Submit ? 'begin-submit' : 'begin-cancel'
-        return yield* Effect.fail(
-          storeError(operation, 'invariant', 'mutation start requires a current approved risk decision'),
-        )
-      }
-      return event
-    })
-
-  const assertAuthority = (operation: MutationOperation) =>
-    Effect.gen(function* () {
-      const storeOperation = operation === MutationOperation.Submit ? 'begin-submit' : 'begin-cancel'
-      const rows = yield* sql<{
-        effective: string
-        generation_hash: string
-        generation_account_id: string | null
-        generation_maximum: string | null
-        kill_state: string
-        maximum: string
-      }>`
-        SELECT
-          authority.maximum,
-          authority.effective,
-          authority.kill_state,
-          authority.generation_hash,
-          generation.maximum AS generation_maximum,
-          generation.account_id AS generation_account_id
-        FROM authority_state AS authority
-        LEFT JOIN authority_generations AS generation
-          ON generation.generation_hash = authority.generation_hash
-        WHERE authority.singleton
-        FOR UPDATE OF authority
-      `
-      const authority = rows[0]
-      if (authority === undefined) {
-        return yield* Effect.fail(storeError(storeOperation, 'authority', 'paper authority is not initialized'))
-      }
-      if (authority.maximum !== Authority.Paper) {
-        return yield* Effect.fail(storeError(storeOperation, 'authority', 'GitOps maximum authority is not PAPER'))
-      }
-      if (
-        operation === MutationOperation.Submit &&
-        (authority.effective !== Authority.Paper || authority.kill_state !== KillState.Clear)
-      ) {
-        return yield* Effect.fail(storeError('begin-submit', 'authority', 'effective authority is not PAPER and clear'))
-      }
-      if (
-        operation === MutationOperation.Cancel &&
-        authority.kill_state === KillState.Clear &&
-        authority.effective !== Authority.Paper
-      ) {
-        return yield* Effect.fail(
-          storeError('begin-cancel', 'authority', 'cancellation requires PAPER authority or an active kill'),
-        )
-      }
-      if (authority.generation_maximum !== Authority.Paper || authority.generation_account_id === null) {
-        return yield* Effect.fail(
-          storeError(storeOperation, 'authority', 'active PAPER authority lacks its immutable account binding'),
-        )
-      }
-      return {
-        accountId: authority.generation_account_id,
-        generationHash: authority.generation_hash,
-      } as const
-    })
-
-  const assertNoOtherUnresolved = (intentId: string) =>
-    Effect.gen(function* () {
-      const rows = yield* sql<{ unresolved: boolean }>`
-        SELECT EXISTS (
+  const appendEvent = (
+    storeOperation: MutationStoreError['operation'],
+    event: MutationEvent,
+    requireCurrentRisk = false,
+  ) =>
+    sql<{ event_id: string }>`
+      INSERT INTO mutation_events (
+        event_id,
+        schema_version,
+        mutation_id,
+        intent_id,
+        sequence,
+        operation,
+        event_type,
+        request_hash,
+        consistency_delay_ms,
+        broker_order_id,
+        request_id,
+        response_status,
+        response_content_hash,
+        occurred_at
+      )
+      SELECT
+        ${event.eventId},
+        ${event.schemaVersion},
+        ${event.mutationId},
+        ${event.intentId},
+        ${event.sequence},
+        ${event.operation},
+        ${event.eventType},
+        ${event.requestHash},
+        ${event.consistencyDelayMs},
+        ${event.brokerOrderId ?? null},
+        ${event.requestId ?? null},
+        ${event.responseStatus ?? null},
+        ${event.responseContentHash ?? null},
+        ${event.occurredAt}
+      WHERE ${!requireCurrentRisk}
+        OR EXISTS (
           SELECT 1
-          FROM (
-            SELECT DISTINCT ON (events.mutation_id)
-              events.intent_id,
-              events.operation,
-              events.event_type,
-              intents.state
-            FROM mutation_events AS events
-            JOIN intents ON intents.intent_id = events.intent_id
-            ORDER BY events.mutation_id, events.sequence DESC
-          ) AS latest
-          WHERE latest.intent_id <> ${intentId}
-            AND latest.state <> 'TERMINAL'
-            AND (
-              latest.event_type IN (
-                'SUBMIT_STARTED',
-                'SUBMIT_UNKNOWN',
-                'RECOVERY_NOT_FOUND',
-                'RECOVERY_UNKNOWN',
-                'CANCEL_STARTED',
-                'CANCEL_ACCEPTED',
-                'CANCEL_UNKNOWN'
-              )
-              OR (
-                latest.operation = 'CANCEL'
-                AND latest.event_type = 'RECOVERY_FOUND'
-              )
-            )
-        ) AS unresolved
-      `
-      if (rows[0]?.unresolved !== false) {
-        return yield* Effect.fail(
-          storeError('begin-submit', 'invariant', 'another broker mutation has an unresolved outcome'),
+          FROM intents AS intent
+          JOIN risk_decisions AS decision
+            ON decision.decision_id = intent.risk_decision_id
+            AND decision.intent_id = intent.intent_id
+          WHERE intent.intent_id = ${event.intentId}
+            AND decision.outcome = 'APPROVED'
+            AND decision.decided_at <= clock_timestamp()
+            AND decision.expires_at > clock_timestamp()
         )
-      }
+      RETURNING event_id
+    `.pipe(
+      Effect.flatMap((rows) =>
+        fromDecision(() =>
+          Result.flatMap(
+            Result.mapError(decodeEventIdRowsResult(rows), (cause) =>
+              storeError(storeOperation, 'decode', 'mutation event append result failed decoding', cause),
+            ),
+            (decoded) =>
+              decideMutationAppend(
+                storeOperation,
+                event,
+                decoded.map((row) => row.event_id),
+                requireCurrentRisk,
+              ),
+          ),
+        ),
+      ),
+    )
+
+  const readAuthorityBinding = (operation: MutationOperation) =>
+    sql<{
+      effective: string
+      generation_hash: string
+      generation_account_id: string | null
+      generation_maximum: string | null
+      kill_state: string
+      maximum: string
+    }>`
+      SELECT
+        authority.maximum,
+        authority.effective,
+        authority.kill_state,
+        authority.generation_hash,
+        generation.maximum AS generation_maximum,
+        generation.account_id AS generation_account_id
+      FROM authority_state AS authority
+      LEFT JOIN authority_generations AS generation
+        ON generation.generation_hash = authority.generation_hash
+      WHERE authority.singleton
+      FOR UPDATE OF authority
+    `.pipe(
+      Effect.flatMap((rows) =>
+        fromDecision(() =>
+          Result.flatMap(decodeAuthoritySnapshot(operation, rows), (authority) =>
+            decideMutationAuthority(operation, authority),
+          ),
+        ),
+      ),
+    )
+
+  const requireNoOtherUnresolved = (intentId: string) =>
+    sql<{ unresolved: boolean }>`
+      SELECT EXISTS (
+        SELECT 1
+        FROM (
+          SELECT DISTINCT ON (events.mutation_id)
+            events.intent_id,
+            events.operation,
+            events.event_type,
+            intents.state
+          FROM mutation_events AS events
+          JOIN intents ON intents.intent_id = events.intent_id
+          ORDER BY events.mutation_id, events.sequence DESC
+        ) AS latest
+        WHERE latest.intent_id <> ${intentId}
+          AND latest.state <> 'TERMINAL'
+          AND (
+            latest.event_type IN (
+              'SUBMIT_STARTED',
+              'SUBMIT_UNKNOWN',
+              'RECOVERY_NOT_FOUND',
+              'RECOVERY_UNKNOWN',
+              'CANCEL_STARTED',
+              'CANCEL_ACCEPTED',
+              'CANCEL_UNKNOWN'
+            )
+            OR (
+              latest.operation = 'CANCEL'
+              AND latest.event_type = 'RECOVERY_FOUND'
+            )
+          )
+      ) AS unresolved
+    `.pipe(
+      Effect.flatMap((rows) =>
+        fromDecision(() =>
+          Result.flatMap(
+            Result.mapError(decodeUnresolvedRowsResult(rows), (cause) =>
+              storeError('begin-submit', 'decode', 'unresolved mutation result failed decoding', cause),
+            ),
+            (decoded) => decideMutationContainment(decoded[0]?.unresolved),
+          ),
+        ),
+      ),
+    )
+
+  const readIntent = (operation: MutationOperation, intentId: string) =>
+    sql<{
+      account_id: string
+      authority_generation_hash: string
+      generation_account_id: string | null
+      generation_maximum: string | null
+      generation_risk_policy_hash: string | null
+      generation_strategy_name: string | null
+      policy_hash: string
+      state: string
+      strategy_name: string
+      updated_at: string
+    }>`
+      SELECT
+        intent.account_id,
+        intent.authority_generation_hash,
+        intent.policy_hash,
+        intent.state,
+        intent.strategy_name,
+        generation.account_id AS generation_account_id,
+        generation.maximum AS generation_maximum,
+        generation.risk_policy_hash AS generation_risk_policy_hash,
+        generation.strategy_name AS generation_strategy_name,
+        to_char(intent.updated_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') AS updated_at
+      FROM intents AS intent
+      LEFT JOIN authority_generations AS generation
+        ON generation.generation_hash = intent.authority_generation_hash
+      WHERE intent.intent_id = ${intentId}
+      FOR UPDATE OF intent
+    `.pipe(Effect.flatMap((rows) => fromDecision(() => decodeIntentSnapshot(operation, rows))))
+
+  const transitionSubmitStart = (input: MutationStartInput) =>
+    sql<{ intent_id: string }>`
+      UPDATE intents
+      SET state = ${IntentState.IoStarted}, state_version = state_version + 1, updated_at = ${input.occurredAt}
+      WHERE intent_id = ${input.intentId} AND state = ${IntentState.Approved}
+      RETURNING intent_id
+    `.pipe(
+      Effect.flatMap((rows) =>
+        fromDecision(() =>
+          Result.flatMap(
+            Result.mapError(decodeIntentIdRowsResult(rows), (cause) =>
+              storeError('begin-submit', 'decode', 'submit transition result failed decoding', cause),
+            ),
+            (decoded) => decideSubmitStartWrite(decoded.map((row) => row.intent_id)),
+          ),
+        ),
+      ),
+    )
+
+  const beginTransaction = (operation: MutationOperation, input: MutationStartInput) =>
+    Effect.gen(function* () {
+      const existing = yield* readLatest(input.intentId, operation)
+      const replay = yield* fromDecision(() => decideMutationStartReplay(operation, input, existing))
+      if (replay._tag === 'ReplayMutation') return replay.receipt
+
+      const authority = yield* readAuthorityBinding(operation)
+      if (operation === MutationOperation.Submit) yield* requireNoOtherUnresolved(input.intentId)
+      const intent = yield* readIntent(operation, input.intentId)
+      const submitted =
+        operation === MutationOperation.Cancel ? yield* readLatest(input.intentId, MutationOperation.Submit) : undefined
+      const decision = yield* fromDecision(() => decideMutationStart(operation, input, authority, intent, submitted))
+      yield* appendEvent(startStoreOperationFor(operation), decision.event, operation === MutationOperation.Submit)
+      if (decision.intentTransition === 'ApprovedToIoStarted') yield* transitionSubmitStart(input)
+      return { event: decision.event, started: true } satisfies StartReceipt
     })
 
   const begin = (
@@ -472,464 +1439,340 @@ const makeStore = Effect.gen(function* () {
     consistencyDelayMs: number,
     occurredAt: string,
     brokerOrderId?: string,
-  ) => {
-    const storeOperation = operation === MutationOperation.Submit ? 'begin-submit' : 'begin-cancel'
-    return run(
-      storeOperation,
-      Effect.gen(function* () {
-        const input = yield* decodeStartInput({
+  ) =>
+    run(
+      startStoreOperationFor(operation),
+      fromDecision(() =>
+        decodeStartInput(operation, {
           intentId,
           requestHash,
           consistencyDelayMs,
           occurredAt,
           ...(brokerOrderId === undefined ? {} : { brokerOrderId }),
-        }).pipe(Effect.mapError((cause) => storeError(storeOperation, 'decode', 'invalid mutation start', cause)))
-        return yield* withFence(
-          Effect.gen(function* () {
-            const existing = yield* readLatest(input.intentId, operation)
-            if (existing !== undefined) {
-              if (
-                existing.requestHash !== input.requestHash ||
-                existing.consistencyDelayMs !== input.consistencyDelayMs ||
-                (operation === MutationOperation.Cancel && existing.brokerOrderId !== input.brokerOrderId) ||
-                existing.mutationId !== mutationId(input.intentId, operation)
-              ) {
-                return yield* Effect.fail(
-                  storeError(storeOperation, 'conflict', 'mutation identity was reused with different request content'),
-                )
-              }
-              return { event: existing, started: false } satisfies StartReceipt
-            }
-
-            const authority = yield* assertAuthority(operation)
-            if (operation === MutationOperation.Submit) yield* assertNoOtherUnresolved(input.intentId)
-            const intents = yield* sql<{
-              account_id: string
-              authority_generation_hash: string
-              generation_account_id: string | null
-              generation_maximum: string | null
-              generation_risk_policy_hash: string | null
-              generation_strategy_name: string | null
-              policy_hash: string
-              state: string
-              strategy_name: string
-              updated_at: string
-            }>`
-              SELECT
-                intent.account_id,
-                intent.authority_generation_hash,
-                intent.policy_hash,
-                intent.state,
-                intent.strategy_name,
-                generation.account_id AS generation_account_id,
-                generation.maximum AS generation_maximum,
-                generation.risk_policy_hash AS generation_risk_policy_hash,
-                generation.strategy_name AS generation_strategy_name,
-                to_char(intent.updated_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') AS updated_at
-              FROM intents AS intent
-              LEFT JOIN authority_generations AS generation
-                ON generation.generation_hash = intent.authority_generation_hash
-              WHERE intent.intent_id = ${input.intentId}
-              FOR UPDATE OF intent
-            `
-            const intent = intents[0]
-            if (intent === undefined) {
-              return yield* Effect.fail(storeError(storeOperation, 'invariant', 'intent does not exist'))
-            }
-            if (
-              intent.generation_maximum !== Authority.Paper ||
-              intent.generation_account_id === null ||
-              intent.generation_account_id !== intent.account_id ||
-              intent.generation_risk_policy_hash !== intent.policy_hash ||
-              intent.generation_strategy_name !== intent.strategy_name
-            ) {
-              return yield* Effect.fail(
-                storeError(
-                  storeOperation,
-                  'authority',
-                  'intent does not match its immutable PAPER authority-generation bindings',
-                ),
-              )
-            }
-            if (intent.account_id !== authority.accountId) {
-              return yield* Effect.fail(
-                storeError(
-                  storeOperation,
-                  'authority',
-                  'intent account does not match the active PAPER authority generation',
-                ),
-              )
-            }
-            if (
-              operation === MutationOperation.Submit &&
-              intent.authority_generation_hash !== authority.generationHash
-            ) {
-              return yield* Effect.fail(
-                storeError(
-                  'begin-submit',
-                  'authority',
-                  'intent authority generation is not the active PAPER generation',
-                ),
-              )
-            }
-            const requiredState =
-              operation === MutationOperation.Submit
-                ? IntentState.Approved
-                : input.brokerOrderId === undefined
-                  ? undefined
-                  : intentStateForIdentifiedSubmit(
-                      yield* readLatest(input.intentId, MutationOperation.Submit),
-                      input.intentId,
-                      input.brokerOrderId,
-                    )
-            if (requiredState === undefined) {
-              return yield* Effect.fail(
-                storeError('begin-cancel', 'invariant', 'cancel requires the exact durable submitted order identity'),
-              )
-            }
-            if (intent.state !== requiredState) {
-              return yield* Effect.fail(
-                storeError(
-                  storeOperation,
-                  'invariant',
-                  `${operation.toLowerCase()} requires an ${requiredState} intent`,
-                ),
-              )
-            }
-            if (input.occurredAt <= intent.updated_at) {
-              return yield* Effect.fail(
-                storeError(storeOperation, 'invariant', 'mutation time must follow the intent state'),
-              )
-            }
-
-            const event = makeEvent({
-              mutationId: mutationId(input.intentId, operation),
-              intentId: input.intentId,
-              sequence: 1,
-              operation,
-              eventType:
-                operation === MutationOperation.Submit
-                  ? MutationEventType.SubmitStarted
-                  : MutationEventType.CancelStarted,
-              requestHash: input.requestHash,
-              consistencyDelayMs: input.consistencyDelayMs,
-              ...(input.brokerOrderId === undefined ? {} : { brokerOrderId: input.brokerOrderId }),
-              occurredAt: input.occurredAt,
-            })
-            yield* append(event, operation === MutationOperation.Submit)
-            if (operation === MutationOperation.Submit) {
-              const transitioned = yield* sql<{ intent_id: string }>`
-                UPDATE intents
-                SET state = ${IntentState.IoStarted}, state_version = state_version + 1, updated_at = ${input.occurredAt}
-                WHERE intent_id = ${input.intentId} AND state = ${IntentState.Approved}
-                RETURNING intent_id
-              `
-              if (transitioned.length !== 1) {
-                return yield* Effect.fail(
-                  storeError('begin-submit', 'conflict', 'approved intent transition lost its race'),
-                )
-              }
-            }
-            return { event, started: true } satisfies StartReceipt
-          }),
-        )
-      }),
+        }),
+      ).pipe(Effect.flatMap((input) => fence.transaction(beginTransaction(operation, input)))),
     )
+
+  const decodeIntentWriteRows = (
+    storeOperation: OutcomeStoreOperation,
+    message: string,
+    rows: unknown,
+  ): Result.Result<readonly string[], MutationStoreError> =>
+    Result.map(
+      Result.mapError(decodeIntentIdRowsResult(rows), (cause) => storeError(storeOperation, 'decode', message, cause)),
+      (decoded) => decoded.map((row) => row.intent_id),
+    )
+
+  const readOutcomeIntentSnapshot = (storeOperation: OutcomeStoreOperation, intentId: string) =>
+    sql<{ state: string; terminal_outcome: string | null }>`
+      SELECT state, terminal_outcome
+      FROM intents
+      WHERE intent_id = ${intentId}
+      FOR UPDATE
+    `.pipe(
+      Effect.flatMap((rows) =>
+        fromDecision(() =>
+          Result.map(
+            Result.mapError(decodeOutcomeIntentRowsResult(rows), (cause) =>
+              storeError(storeOperation, 'decode', 'stored mutation intent state failed decoding', cause),
+            ),
+            (decoded): MutationReplayIntentSnapshot | undefined => {
+              const intent = decoded[0]
+              return intent === undefined
+                ? undefined
+                : {
+                    state: intent.state,
+                    terminalOutcome: intent.terminal_outcome,
+                  }
+            },
+          ),
+        ),
+      ),
+    )
+
+  const transitionFromIoStarted = (
+    storeOperation: OutcomeStoreOperation,
+    input: MutationOutcomeInput,
+    transition: Extract<MutationIntentTransition, { readonly _tag: 'TransitionFromIoStarted' }>,
+  ) =>
+    sql<{ intent_id: string }>`
+      UPDATE intents
+      SET
+        state = ${transition.nextState},
+        terminal_outcome = ${transition.terminalOutcome ?? null},
+        state_version = state_version + 1,
+        updated_at = GREATEST(${input.occurredAt}::timestamptz, updated_at + interval '1 microsecond')
+      WHERE intent_id = ${input.intentId} AND state = ${IntentState.IoStarted}
+      RETURNING intent_id
+    `.pipe(
+      Effect.flatMap((rows) =>
+        fromDecision(() =>
+          Result.flatMap(
+            decodeIntentWriteRows(storeOperation, 'mutation outcome transition result failed decoding', rows),
+            (decoded) => decideMutationOutcomeWrite(storeOperation, decoded),
+          ),
+        ),
+      ),
+    )
+
+  const recoverUnknownSubmit = (storeOperation: OutcomeStoreOperation, input: MutationOutcomeInput) =>
+    sql<{ intent_id: string }>`
+      UPDATE intents
+      SET state = ${IntentState.Recovered}, state_version = state_version + 1, updated_at = ${input.occurredAt}
+      WHERE intent_id = ${input.intentId} AND state = ${IntentState.Unknown}
+      RETURNING intent_id
+    `.pipe(
+      Effect.flatMap((rows) =>
+        fromDecision(() => decodeIntentWriteRows(storeOperation, 'submit recovery result failed decoding', rows)),
+      ),
+    )
+
+  const transitionRecoveredSubmit = (
+    storeOperation: OutcomeStoreOperation,
+    input: MutationOutcomeInput,
+    transition: Extract<MutationIntentTransition, { readonly _tag: 'RecoverSubmit' }>,
+  ) =>
+    sql<{ intent_id: string }>`
+      UPDATE intents
+      SET
+        state = ${transition.nextState},
+        terminal_outcome = ${transition.terminalOutcome ?? null},
+        state_version = state_version + 1,
+        updated_at = GREATEST(
+          ${input.occurredAt}::timestamptz + interval '1 microsecond',
+          updated_at + interval '1 microsecond'
+      )
+      WHERE intent_id = ${input.intentId} AND state = ${IntentState.Recovered}
+      RETURNING intent_id
+    `.pipe(
+      Effect.flatMap((rows) =>
+        fromDecision(() =>
+          Result.flatMap(
+            decodeIntentWriteRows(storeOperation, 'recovered submit transition result failed decoding', rows),
+            (decoded) => decideRecoveredOutcomeWrite(storeOperation, decoded, false),
+          ),
+        ),
+      ),
+    )
+
+  const transitionAcknowledgedSubmit = (
+    storeOperation: OutcomeStoreOperation,
+    input: MutationOutcomeInput,
+    transition: Extract<MutationIntentTransition, { readonly _tag: 'RecoverSubmit' }>,
+  ) =>
+    sql<{ intent_id: string }>`
+      UPDATE intents
+      SET
+        state = ${IntentState.Terminal},
+        terminal_outcome = ${transition.terminalOutcome ?? null},
+        state_version = state_version + 1,
+        updated_at = GREATEST(
+          ${input.occurredAt}::timestamptz,
+          updated_at + interval '1 microsecond'
+        )
+      WHERE intent_id = ${input.intentId} AND state = ${IntentState.Acknowledged}
+      RETURNING intent_id
+    `.pipe(
+      Effect.flatMap((rows) =>
+        fromDecision(() =>
+          Result.flatMap(
+            decodeIntentWriteRows(storeOperation, 'acknowledged submit transition result failed decoding', rows),
+            (decoded) => decideRecoveredOutcomeWrite(storeOperation, decoded, true),
+          ),
+        ),
+      ),
+    )
+
+  const verifyAcknowledgedSubmit = (storeOperation: OutcomeStoreOperation, intentId: string) =>
+    sql<{ acknowledged: boolean }>`
+      SELECT EXISTS (
+        SELECT 1
+        FROM intents
+        WHERE intent_id = ${intentId} AND state = ${IntentState.Acknowledged}
+      ) AS acknowledged
+    `.pipe(
+      Effect.flatMap((rows) =>
+        fromDecision(() =>
+          Result.flatMap(
+            Result.mapError(decodeAcknowledgedRowsResult(rows), (cause) =>
+              storeError(storeOperation, 'decode', 'acknowledged submit recovery result failed decoding', cause),
+            ),
+            (decoded) => decideAcknowledgedRecovery(storeOperation, decoded[0]?.acknowledged),
+          ),
+        ),
+      ),
+    )
+
+  const applySubmitRecovery = (
+    storeOperation: OutcomeStoreOperation,
+    input: MutationOutcomeInput,
+    transition: Extract<MutationIntentTransition, { readonly _tag: 'RecoverSubmit' }>,
+  ) =>
+    Effect.gen(function* () {
+      const recovered = yield* recoverUnknownSubmit(storeOperation, input)
+      const decision = yield* fromDecision(() => decideSubmitRecoveryWrite(storeOperation, recovered, transition))
+      switch (decision._tag) {
+        case 'TransitionRecoveredIntent':
+          return yield* transitionRecoveredSubmit(storeOperation, input, transition)
+        case 'TransitionAcknowledgedTerminalIntent':
+          return yield* transitionAcknowledgedSubmit(storeOperation, input, transition)
+        case 'VerifyAcknowledgedIntent':
+          return yield* verifyAcknowledgedSubmit(storeOperation, input.intentId)
+      }
+    })
+
+  const recoverUnknownCancel = (storeOperation: OutcomeStoreOperation, input: MutationOutcomeInput) =>
+    sql<{ intent_id: string }>`
+      UPDATE intents
+      SET
+        state = ${IntentState.Recovered},
+        state_version = state_version + 1,
+        updated_at = GREATEST(${input.occurredAt}::timestamptz, updated_at + interval '1 microsecond')
+      WHERE intent_id = ${input.intentId} AND state = ${IntentState.Unknown}
+      RETURNING intent_id
+    `.pipe(
+      Effect.flatMap((rows) =>
+        fromDecision(() => decodeIntentWriteRows(storeOperation, 'cancel recovery result failed decoding', rows)),
+      ),
+    )
+
+  const applyCancelRecovery = (
+    storeOperation: OutcomeStoreOperation,
+    input: MutationOutcomeInput,
+    transition: Extract<MutationIntentTransition, { readonly _tag: 'RecoverCancelTerminal' }>,
+  ) =>
+    Effect.gen(function* () {
+      const recovered = yield* recoverUnknownCancel(storeOperation, input)
+      const fromState = yield* fromDecision(() => decideCancelRecoveryState(storeOperation, recovered))
+      const transitioned = yield* sql<{ intent_id: string }>`
+        UPDATE intents
+        SET
+          state = ${IntentState.Terminal},
+          terminal_outcome = ${transition.terminalOutcome},
+          state_version = state_version + 1,
+          updated_at = GREATEST(${input.occurredAt}::timestamptz, updated_at + interval '1 microsecond')
+        WHERE intent_id = ${input.intentId} AND state = ${fromState}
+        RETURNING intent_id
+      `
+      return yield* fromDecision(() =>
+        Result.flatMap(
+          decodeIntentWriteRows(storeOperation, 'cancel terminal transition result failed decoding', transitioned),
+          (decoded) => decideMutationOutcomeWrite(storeOperation, decoded),
+        ),
+      )
+    })
+
+  const applyOutcomeTransition = (
+    storeOperation: OutcomeStoreOperation,
+    input: MutationOutcomeInput,
+    transition: MutationIntentTransition,
+  ) => {
+    switch (transition._tag) {
+      case 'KeepIntentState':
+        return Effect.void
+      case 'TransitionFromIoStarted':
+        return transitionFromIoStarted(storeOperation, input, transition)
+      case 'RecoverSubmit':
+        return applySubmitRecovery(storeOperation, input, transition)
+      case 'RecoverCancelTerminal':
+        return applyCancelRecovery(storeOperation, input, transition)
+    }
+  }
+
+  const outcomeTransaction = (
+    storeOperation: OutcomeStoreOperation,
+    input: MutationOutcomeInput,
+    definition: MutationOutcomeDefinition,
+  ) => {
+    const facts = decideMutationOutcomeDefinition(definition)
+    return Effect.gen(function* () {
+      const previous = yield* readLatest(input.intentId, facts.operation)
+      const currentIntent = yield* readOutcomeIntentSnapshot(storeOperation, input.intentId)
+      const decision = yield* fromDecision(() => decideMutationOutcome(input, definition, previous, currentIntent))
+      if (decision._tag === 'ReplayMutation') return decision.event
+
+      if (decision.cancelFirst._tag === 'RequireNoDurableCancellation') {
+        const cancellation = yield* readLatest(input.intentId, MutationOperation.Cancel)
+        yield* fromDecision(() => decideCancelFirst(decision.cancelFirst, cancellation))
+      }
+      yield* appendEvent(storeOperation, decision.event)
+      yield* applyOutcomeTransition(storeOperation, input, decision.transition)
+      return decision.event
+    })
   }
 
   const appendOutcome = (
-    storeOperation: MutationStoreError['operation'],
+    definition: MutationOutcomeDefinition,
     intentId: string,
-    operation: MutationOperation,
     requestHash: string,
-    eventType: MutationEventType,
     occurredAt: string,
-    fields: {
-      readonly brokerOrderId?: string
-      readonly evidence?: Partial<MutationEvidence>
-      readonly nextState?: IntentState
-      readonly fromState?: IntentState
-      readonly terminalOutcome?: TerminalOutcome
-      readonly recover?: boolean
-      readonly recoverUnknown?: boolean
-    },
-  ) =>
-    run(
+    evidence?: Partial<MutationEvidence>,
+    brokerOrderId?: string,
+  ) => {
+    const storeOperation = outcomeStoreOperation(definition)
+    return run(
       storeOperation,
-      Effect.gen(function* () {
-        const evidence = completeEvidence(fields.evidence)
-        const input = yield* decodeOutcomeInput({
-          intentId,
-          requestHash,
-          occurredAt,
-          ...(fields.brokerOrderId === undefined ? {} : { brokerOrderId: fields.brokerOrderId }),
-          ...(evidence === undefined ? {} : { evidence }),
-        }).pipe(Effect.mapError((cause) => storeError(storeOperation, 'decode', 'invalid mutation outcome', cause)))
-        return yield* withFence(
-          Effect.gen(function* () {
-            const previous = yield* readLatest(input.intentId, operation)
-            if (previous === undefined) {
-              return yield* Effect.fail(
-                storeError(storeOperation, 'invariant', 'mutation STARTED event does not exist'),
-              )
-            }
-            if (previous.requestHash !== input.requestHash) {
-              return yield* Effect.fail(storeError(storeOperation, 'conflict', 'mutation request hash changed'))
-            }
-            const eventBrokerOrderId = input.brokerOrderId ?? previous.brokerOrderId
-            const event = makeEvent({
-              mutationId: previous.mutationId,
-              intentId: input.intentId,
-              sequence: previous.sequence + 1,
-              operation,
-              eventType,
-              requestHash: input.requestHash,
-              consistencyDelayMs: previous.consistencyDelayMs,
-              ...(eventBrokerOrderId === undefined ? {} : { brokerOrderId: eventBrokerOrderId }),
-              ...(input.evidence?.requestId === undefined ? {} : { requestId: input.evidence.requestId }),
-              ...(input.evidence?.status === undefined ? {} : { responseStatus: input.evidence.status }),
-              ...(input.evidence?.contentHash === undefined ? {} : { responseContentHash: input.evidence.contentHash }),
-              occurredAt: input.occurredAt,
-            })
-            if (
-              previous.eventType === event.eventType &&
-              previous.requestId === event.requestId &&
-              previous.responseStatus === event.responseStatus &&
-              previous.responseContentHash === event.responseContentHash &&
-              previous.brokerOrderId === event.brokerOrderId
-            ) {
-              return previous
-            }
-            if (
-              operation === MutationOperation.Submit &&
-              eventType === MutationEventType.RecoveryFound &&
-              fields.nextState === IntentState.Terminal &&
-              (yield* readLatest(input.intentId, MutationOperation.Cancel)) !== undefined
-            ) {
-              return yield* Effect.fail(
-                storeError(
-                  storeOperation,
-                  'conflict',
-                  'terminal submit recovery cannot overtake a durable cancellation',
-                ),
-              )
-            }
-            yield* append(event)
-
-            if (fields.recover === true) {
-              const recovered = yield* sql<{ intent_id: string }>`
-                UPDATE intents
-                SET state = ${IntentState.Recovered}, state_version = state_version + 1, updated_at = ${input.occurredAt}
-                WHERE intent_id = ${input.intentId} AND state = ${IntentState.Unknown}
-                RETURNING intent_id
-              `
-              if (recovered.length === 1 && fields.nextState !== undefined) {
-                const transitioned = yield* sql<{ intent_id: string }>`
-                  UPDATE intents
-                  SET
-                    state = ${fields.nextState},
-                    terminal_outcome = ${fields.terminalOutcome ?? null},
-                    state_version = state_version + 1,
-                    updated_at = GREATEST(
-                      ${input.occurredAt}::timestamptz + interval '1 microsecond',
-                      updated_at + interval '1 microsecond'
-                  )
-                  WHERE intent_id = ${input.intentId} AND state = ${IntentState.Recovered}
-                  RETURNING intent_id
-                `
-                if (transitioned.length !== 1) {
-                  return yield* Effect.fail(
-                    storeError(storeOperation, 'conflict', 'recovered intent outcome lost its race'),
-                  )
-                }
-              } else if (recovered.length === 0 && fields.nextState === IntentState.Terminal) {
-                const transitioned = yield* sql<{ intent_id: string }>`
-                  UPDATE intents
-                  SET
-                    state = ${IntentState.Terminal},
-                    terminal_outcome = ${fields.terminalOutcome ?? null},
-                    state_version = state_version + 1,
-                    updated_at = GREATEST(
-                      ${input.occurredAt}::timestamptz,
-                      updated_at + interval '1 microsecond'
-                    )
-                  WHERE intent_id = ${input.intentId} AND state = ${IntentState.Acknowledged}
-                  RETURNING intent_id
-                `
-                if (transitioned.length !== 1) {
-                  return yield* Effect.fail(
-                    storeError(storeOperation, 'conflict', 'acknowledged intent terminal recovery lost its race'),
-                  )
-                }
-              } else if (recovered.length === 0 && fields.nextState === IntentState.Acknowledged) {
-                const acknowledged = yield* sql<{ acknowledged: boolean }>`
-                  SELECT EXISTS (
-                    SELECT 1
-                    FROM intents
-                    WHERE intent_id = ${input.intentId} AND state = ${IntentState.Acknowledged}
-                  ) AS acknowledged
-                `
-                if (acknowledged[0]?.acknowledged !== true) {
-                  return yield* Effect.fail(
-                    storeError(storeOperation, 'conflict', 'submit recovery requires an unresolved durable intent'),
-                  )
-                }
-              } else if (recovered.length !== 1) {
-                return yield* Effect.fail(
-                  storeError(storeOperation, 'conflict', 'unknown intent recovery lost its race'),
-                )
-              }
-            } else if (fields.nextState !== undefined) {
-              let fromState = fields.fromState ?? IntentState.IoStarted
-              if (fields.recoverUnknown === true) {
-                const recovered = yield* sql<{ intent_id: string }>`
-                  UPDATE intents
-                  SET
-                    state = ${IntentState.Recovered},
-                    state_version = state_version + 1,
-                    updated_at = GREATEST(${input.occurredAt}::timestamptz, updated_at + interval '1 microsecond')
-                  WHERE intent_id = ${input.intentId} AND state = ${IntentState.Unknown}
-                  RETURNING intent_id
-                `
-                if (recovered.length === 1) fromState = IntentState.Recovered
-              }
-              const transitioned = yield* sql<{ intent_id: string }>`
-                UPDATE intents
-                SET
-                  state = ${fields.nextState},
-                  terminal_outcome = ${fields.terminalOutcome ?? null},
-                  state_version = state_version + 1,
-                  updated_at = GREATEST(${input.occurredAt}::timestamptz, updated_at + interval '1 microsecond')
-                WHERE intent_id = ${input.intentId} AND state = ${fromState}
-                RETURNING intent_id
-              `
-              if (transitioned.length !== 1) {
-                return yield* Effect.fail(
-                  storeError(storeOperation, 'conflict', 'intent mutation outcome lost its race'),
-                )
-              }
-            }
-            return event
+      fromDecision(() =>
+        Result.map(
+          decodeOutcomeInput(storeOperation, {
+            intentId,
+            requestHash,
+            occurredAt,
+            ...(evidence === undefined ? {} : { evidence }),
+            ...(brokerOrderId === undefined ? {} : { brokerOrderId }),
           }),
-        )
-      }),
+          (input) => ({ definition, input }),
+        ),
+      ).pipe(
+        Effect.flatMap(({ definition, input }) =>
+          fence.transaction(outcomeTransaction(storeOperation, input, definition)),
+        ),
+      ),
     )
+  }
 
   return {
     beginSubmit: (intentId, requestHash, consistencyDelayMs, occurredAt) =>
       begin(MutationOperation.Submit, intentId, requestHash, consistencyDelayMs, occurredAt),
-    submitAccepted: (intentId, requestHash, brokerOrderId, evidence, terminalOutcome) => {
-      const terminal = terminalOutcome !== undefined
-      return appendOutcome(
-        'record-submit',
-        intentId,
-        MutationOperation.Submit,
-        requestHash,
-        MutationEventType.SubmitAccepted,
-        evidence.observedAt,
+    submitAccepted: (intentId, requestHash, brokerOrderId, evidence, terminalOutcome) =>
+      appendOutcome(
         {
-          brokerOrderId,
-          evidence,
-          nextState: terminal ? IntentState.Terminal : IntentState.Acknowledged,
+          _tag: 'SubmitAccepted',
           ...(terminalOutcome === undefined ? {} : { terminalOutcome }),
         },
-      )
-    },
-    submitRejected: (intentId, requestHash, evidence) =>
-      appendOutcome(
-        'record-submit',
         intentId,
-        MutationOperation.Submit,
         requestHash,
-        MutationEventType.SubmitRejected,
         evidence.observedAt,
-        {
-          evidence,
-          nextState: IntentState.Terminal,
-          terminalOutcome: TerminalOutcome.Rejected,
-        },
+        evidence,
+        brokerOrderId,
       ),
+    submitRejected: (intentId, requestHash, evidence) =>
+      appendOutcome({ _tag: 'SubmitRejected' }, intentId, requestHash, evidence.observedAt, evidence),
     submitUnknown: (intentId, requestHash, occurredAt, evidence, brokerOrderId) =>
-      appendOutcome(
-        'record-submit',
-        intentId,
-        MutationOperation.Submit,
-        requestHash,
-        MutationEventType.SubmitUnknown,
-        occurredAt,
-        {
-          ...(brokerOrderId === undefined ? {} : { brokerOrderId }),
-          evidence: completeEvidence(evidence),
-          nextState: IntentState.Unknown,
-        },
-      ),
+      appendOutcome({ _tag: 'SubmitUnknown' }, intentId, requestHash, occurredAt, evidence, brokerOrderId),
     beginCancel: (intentId, requestHash, brokerOrderId, consistencyDelayMs, occurredAt) =>
       begin(MutationOperation.Cancel, intentId, requestHash, consistencyDelayMs, occurredAt, brokerOrderId),
     cancelAccepted: (intentId, requestHash, brokerOrderId, evidence) =>
-      appendOutcome(
-        'record-cancel',
-        intentId,
-        MutationOperation.Cancel,
-        requestHash,
-        MutationEventType.CancelAccepted,
-        evidence.observedAt,
-        { brokerOrderId, evidence },
-      ),
+      appendOutcome({ _tag: 'CancelAccepted' }, intentId, requestHash, evidence.observedAt, evidence, brokerOrderId),
     cancelUnknown: (intentId, requestHash, brokerOrderId, occurredAt, evidence) =>
+      appendOutcome({ _tag: 'CancelUnknown' }, intentId, requestHash, occurredAt, evidence, brokerOrderId),
+    recoveryFound: (intentId, operation, requestHash, brokerOrderId, evidence, terminalOutcome) =>
       appendOutcome(
-        'record-cancel',
-        intentId,
-        MutationOperation.Cancel,
-        requestHash,
-        MutationEventType.CancelUnknown,
-        occurredAt,
-        { brokerOrderId, evidence: completeEvidence(evidence) },
-      ),
-    recoveryFound: (intentId, operation, requestHash, brokerOrderId, evidence, terminalOutcome) => {
-      const terminal = terminalOutcome !== undefined
-      return appendOutcome(
-        'record-recovery',
-        intentId,
-        operation,
-        requestHash,
-        MutationEventType.RecoveryFound,
-        evidence.observedAt,
         {
-          brokerOrderId,
-          evidence,
-          recover: operation === MutationOperation.Submit,
-          ...(operation === MutationOperation.Submit || terminal
-            ? {
-                nextState: terminal ? IntentState.Terminal : IntentState.Acknowledged,
-                ...(operation === MutationOperation.Cancel
-                  ? { fromState: IntentState.Acknowledged, recoverUnknown: true }
-                  : {}),
-                ...(terminalOutcome === undefined ? {} : { terminalOutcome }),
-              }
-            : {}),
+          _tag: 'RecoveryFound',
+          operation,
+          ...(terminalOutcome === undefined ? {} : { terminalOutcome }),
         },
-      )
-    },
-    recoveryNotFound: (intentId, operation, requestHash, evidence) =>
-      appendOutcome(
-        'record-recovery',
         intentId,
-        operation,
         requestHash,
-        MutationEventType.RecoveryNotFound,
         evidence.observedAt,
-        { evidence },
+        evidence,
+        brokerOrderId,
       ),
+    recoveryNotFound: (intentId, operation, requestHash, evidence) =>
+      appendOutcome({ _tag: 'RecoveryNotFound', operation }, intentId, requestHash, evidence.observedAt, evidence),
     recoveryUnknown: (intentId, operation, requestHash, occurredAt, evidence) =>
-      appendOutcome(
-        'record-recovery',
-        intentId,
-        operation,
-        requestHash,
-        MutationEventType.RecoveryUnknown,
-        occurredAt,
-        { evidence: completeEvidence(evidence) },
-      ),
+      appendOutcome({ _tag: 'RecoveryUnknown', operation }, intentId, requestHash, occurredAt, evidence),
     latest,
   } satisfies MutationStoreShape
 })


### PR DESCRIPTION
## Summary

- Refactors Bayn mutation persistence around decoded immutable inputs and closed pure decisions for submit, cancel, recovery, replay, authority, account, stale approval, retained broker identity, cancel-first ordering, and terminal outcomes.
- Keeps PostgreSQL, row locks, Clock, journal writes, and the single WriterFence transaction in bounded Effect interpreters without adding broker POST/DELETE retry or another state machine.
- Makes mutation identity canonicalization total through `mutationIdResult`, retains contextual typed causes, and verifies exact `{ state, terminal_outcome }` replay classification, including symmetric cancel terminal-to-open conflicts.
- Adds focused pure, coordinator concurrency, defect/interruption rollback, and PostgreSQL content/`xmin` no-write regressions while preserving the trigger-aligned STARTED → UNKNOWN → RECOVERY graph.
- Changes no migrations, GitOps, qualification production logic, PaperStore, broker HTTP clients, or database schema.

## Related Issues

- PROOMPT-425

## Testing

- `bun test services/bayn/src/execution/coordinator-decisions.test.ts services/bayn/src/execution/coordinator.test.ts` — 33 passed
- `BAYN_TEST_POSTGRES_URL=postgresql://bayn:bayn@127.0.0.1:5432/bayn_test bun test services/bayn/src/db/evidence-store.integration.test.ts` — 63 passed
- `bun run --filter @proompteng/bayn test` — 651 passed, 119 skipped
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:effect` — 0 errors, warnings, or messages
- `bun run --filter @proompteng/bayn lint:oxlint` — 0 errors or warnings
- `bun run --filter @proompteng/bayn lint:oxlint:type` — 0 errors or warnings
- `bun run --filter @proompteng/bayn build` — 552 modules bundled

## Breaking Changes

None for runtime or durable contracts. The partial test-facing `mutationId` export is replaced by the total `mutationIdResult` boundary.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable to this backend refactor.
- [x] Documentation, release notes, and follow-ups are not required; PROOMPT-425 tracks the remaining coordinator slice.