### PR TITLE
feat(hermes): enable Exa web and MCP tools

### DIFF
--- a/argocd/applications/hermes/README.md
+++ b/argocd/applications/hermes/README.md
@@ -40,7 +40,8 @@ smoke test, manifest change, and normal CI/Codex review.
 - Hermes receives the curated Lab toolchain through a second read-only OCI image volume. Only its `/bin` facade and
   `/nix/store` closure are mounted; the image does not include Nix, a container engine, GitHub credentials, `kubectl`, or
   any additional Kubernetes authority. Bootstrap fails closed unless every tool reports the repository-pinned version.
-- The API key comes from `onepassword-infra` through External Secrets. No secret is committed to Git.
+- The API and Exa keys come from the `infra/hermes-runtime` 1Password item through narrowly mapped External Secrets. No
+  secret is committed to Git.
 - The `tuslagch` GitHub OAuth token is committed only as a namespace-scoped SealedSecret ciphertext. Only the bootstrap init
   container receives `GH_TOKEN`; it creates mode-`0600` GitHub CLI auth files in a per-Pod `emptyDir` shared read-only with
   the gateway. The pinned Hermes runtime intentionally strips `GH_TOKEN` and `GITHUB_TOKEN` from model-authored terminal
@@ -57,8 +58,10 @@ smoke test, manifest change, and normal CI/Codex review.
   resolve consistently from API and Discord terminals.
 - API key rotation requires a bounded Secret refresh, gateway Pod restart, and old-key rejection/new-key acceptance proof.
 - The API is cluster-local and requires bearer authentication for model requests and detailed health.
-- Plugins, MCP servers, delegation, cron, hooks, and speech-to-text remain disabled. Terminal access is explicit for CLI,
-  authenticated API, and Discord sessions; manual approvals and unconditional deny rules remain enabled.
+- Native Exa-backed `web_search` and `web_extract` are enabled for CLI, authenticated API, and Discord sessions. The
+  authenticated Exa MCP server is restricted to its read-only `web_search_exa` and `web_fetch_exa` tools. Plugins,
+  delegation, cron, hooks, and speech-to-text remain disabled; manual approvals and unconditional deny rules remain
+  enabled.
 - Only `/opt/data/workspace/tuslagch`, Hermes-managed memory, and Hermes-managed skills are writable agent surfaces.
 - Bootstrap maintains `proompteng/lab` at `/opt/data/workspace/tuslagch/lab`. Initial clone and clean-main refresh remain
   credential-free and use bounded retries for transient pod-network startup races; interactive runtime Git and GitHub CLI

--- a/argocd/applications/hermes/config.yaml
+++ b/argocd/applications/hermes/config.yaml
@@ -74,9 +74,9 @@ agent:
     - Never claim an external action completed without a fresh readback.
 
 platform_toolsets:
-  cli: [file, memory, terminal, todo]
-  api_server: [file, memory, terminal, todo]
-  discord: [file, memory, terminal, todo]
+  cli: [file, memory, terminal, todo, web, exa]
+  api_server: [file, memory, terminal, todo, web, exa]
+  discord: [file, memory, terminal, todo, web, exa]
 
 platforms:
   discord:
@@ -148,7 +148,21 @@ plugins:
   enabled: []
   disabled: []
 
-mcp_servers: {}
+web:
+  search_backend: exa
+  extract_backend: exa
+
+mcp_servers:
+  exa:
+    url: "https://mcp.exa.ai/mcp?tools=web_search_exa,web_fetch_exa"
+    headers:
+      x-api-key: "${EXA_API_KEY}"
+    connect_timeout: 15
+    timeout: 120
+    tools:
+      include:
+        - web_search_exa
+        - web_fetch_exa
 
 delegation:
   max_iterations: 20

--- a/argocd/applications/hermes/exa-external-secret.yaml
+++ b/argocd/applications/hermes/exa-external-secret.yaml
@@ -1,0 +1,30 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: hermes-exa-auth
+  namespace: hermes
+  labels:
+    app.kubernetes.io/name: hermes
+    app.kubernetes.io/component: gateway
+  annotations:
+    argocd.argoproj.io/sync-wave: "-3"
+spec:
+  refreshPolicy: Periodic
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: onepassword-infra
+  target:
+    name: hermes-exa-auth
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    template:
+      type: Opaque
+  data:
+    - secretKey: EXA_API_KEY
+      remoteRef:
+        conversionStrategy: Default
+        decodingStrategy: None
+        key: hermes-runtime/EXA_API_KEY
+        metadataPolicy: None
+        nullBytePolicy: Ignore

--- a/argocd/applications/hermes/kustomization.yaml
+++ b/argocd/applications/hermes/kustomization.yaml
@@ -33,6 +33,7 @@ resources:
   - serviceaccount.yaml
   - rbac.yaml
   - external-secret.yaml
+  - exa-external-secret.yaml
   - discord-sealed-secret.yaml
   - github-sealed-secret.yaml
   - service.yaml

--- a/argocd/applications/hermes/statefulset.yaml
+++ b/argocd/applications/hermes/statefulset.yaml
@@ -186,6 +186,11 @@ spec:
                 secretKeyRef:
                   name: hermes-api-auth
                   key: API_SERVER_KEY
+            - name: EXA_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: hermes-exa-auth
+                  key: EXA_API_KEY
             - name: DISCORD_BOT_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/docs/runbooks/hermes-production-rollout.md
+++ b/docs/runbooks/hermes-production-rollout.md
@@ -7,7 +7,8 @@ channel without dual writers, and retains a tested rollback path. All `kubectl` 
 
 - Never run OpenClaw and Hermes with the same Discord token at the same time.
 - Never pass `--migrate-secrets` to the OpenClaw migration.
-- Never store or print the API key or Discord token in Git, shell history, logs, Job specs, or evidence artifacts.
+- Never store or print the API key, Exa API key, or Discord token in Git, shell history, logs, Job specs, or evidence
+  artifacts.
 - Never run `hermes claw cleanup`, delete the OpenClaw VM/PVC, or delete Hermes PVCs during the 14-day rollback window.
 - Never start migration or restore until the backup CronJob is suspended and every active backup Job has finished.
 - Never create a migration or restore Job until every earlier Hermes maintenance Job is terminal.
@@ -88,14 +89,15 @@ The expected Hermes toolchain multi-architecture index digest is
    `NetworkPolicy is not enforced` is a hard rollout blocker. Do not sync Hermes or weaken the containment test; install
    and validate a compatible policy engine first.
 
-3. Ensure the `infra` 1Password vault contains exactly one `hermes-runtime` item with a minimum 32-byte API key. The
-   command is safe to rerun: it reuses and validates an existing item, and creates one only when none exists. Do this from
-   a private shell with 1Password unlocked; do not echo the generated value:
+3. Ensure the `infra` 1Password vault contains exactly one `hermes-runtime` item with a minimum 32-byte API server key and
+   a provisioned Exa API key. The command is safe to rerun: it reuses and validates an existing item, and creates one only
+   when none exists. The Exa key must be added through the Exa dashboard before this preflight. Do this from a private
+   shell with 1Password unlocked; do not echo either value:
 
    ```bash
    set -euo pipefail
    cleanup_api_key() {
-     unset hermes_api_key hermes_item_count hermes_item_id api_key_bytes
+     unset hermes_api_key hermes_item_count hermes_item_id api_key_bytes exa_key_bytes
    }
    abort_api_key() { trap - EXIT HUP INT TERM; cleanup_api_key; exit 130; }
    trap cleanup_api_key EXIT
@@ -131,7 +133,14 @@ The expected Hermes toolchain multi-architecture index digest is
        then ($fields[0].value | length)
        else error("exactly one concealed API_SERVER_KEY field is required")
        end')
+   exa_key_bytes=$(op item get --vault infra "$hermes_item_id" --format json | \
+     jq -er '[.fields[] | select(.label == "EXA_API_KEY")] as $fields |
+       if ($fields | length) == 1 and $fields[0].type == "CONCEALED" and ($fields[0].value | type) == "string"
+       then ($fields[0].value | length)
+       else error("exactly one concealed EXA_API_KEY field is required")
+       end')
    test "$api_key_bytes" -ge 32
+   test "$exa_key_bytes" -ge 32
    cleanup_api_key
    trap - EXIT HUP INT TERM
    ```
@@ -148,15 +157,22 @@ The expected Hermes toolchain multi-architecture index digest is
    hermes_deployed_revision=$(kubectl -n argocd get application hermes -o json | jq -r '.status.history[-1].revision // empty')
    test "$hermes_deployed_revision" = "$(git rev-parse HEAD)"
    kubectl -n hermes wait externalsecret/hermes-api-auth --for=condition=Ready --timeout=5m
+   kubectl -n hermes wait externalsecret/hermes-exa-auth --for=condition=Ready --timeout=5m
+   api_secret_keys=$(kubectl -n hermes get secret hermes-api-auth -o json | jq -r '.data | keys | sort | join(",")')
+   exa_secret_keys=$(kubectl -n hermes get secret hermes-exa-auth -o json | jq -r '.data | keys | sort | join(",")')
+   test "$api_secret_keys" = API_SERVER_KEY
+   test "$exa_secret_keys" = EXA_API_KEY
    api_key_bytes=$(kubectl -n hermes get secret hermes-api-auth -o jsonpath='{.data.API_SERVER_KEY}' | base64 -d | wc -c | tr -d '[:space:]')
+   exa_key_bytes=$(kubectl -n hermes get secret hermes-exa-auth -o jsonpath='{.data.EXA_API_KEY}' | base64 -d | wc -c | tr -d '[:space:]')
    test "$api_key_bytes" -ge 32
-   printf '%s\n' "$api_key_bytes"
-   unset api_key_bytes hermes_deployed_revision
+   test "$exa_key_bytes" -ge 32
+   printf 'api_key_bytes=%s exa_key_bytes=%s\n' "$api_key_bytes" "$exa_key_bytes"
+   unset api_secret_keys exa_secret_keys api_key_bytes exa_key_bytes hermes_deployed_revision
    ```
 
    The Argo deployment history is the durable alert-enablement source and must contain a successful deployment. It remains
-   outside the Hermes namespace and is re-exported after monitoring restarts. The reported key length must be at least 32.
-   Do not include the value in rollout evidence.
+   outside the Hermes namespace and is re-exported after monitoring restarts. Both reported key lengths must be at least
+   32. Do not include either value in rollout evidence.
 
 ## Phase 1: API-only canary
 
@@ -297,7 +313,50 @@ The expected Hermes toolchain multi-architecture index digest is
    unset hermes_api_key
    ```
 
-4. Prove state survives a restart. Create a harmless canary file, restart the pod, and read it back:
+4. Prove native Exa search/extract and the allowlisted Exa MCP tools from the production container:
+
+   ```bash
+   set -euo pipefail
+   kubectl -n hermes exec -i hermes-0 -c hermes -- /opt/hermes/.venv/bin/python - <<'PY'
+   import asyncio
+   import json
+
+   from tools.web_tools import web_extract_tool, web_search_tool
+
+   search = json.loads(web_search_tool("Hermes Agent GitHub", limit=2))
+   assert search.get("success") is True, search
+   results = search.get("data", {}).get("web", [])
+   assert len(results) == 2, search
+   assert all(result.get("url", "").startswith("http") for result in results), search
+
+   extract = json.loads(
+       asyncio.run(
+           web_extract_tool(
+               ["https://exa.ai/docs/reference/exa-mcp"],
+               format="markdown",
+               char_limit=4000,
+           )
+       )
+   )
+   pages = extract.get("results", [])
+   assert len(pages) == 1, extract
+   assert not pages[0].get("error"), extract
+   assert "Web Search MCP" in pages[0].get("content", ""), extract
+   print(f"native_web_canary=ok search_results={len(results)} extracted_pages={len(pages)}")
+   PY
+   kubectl -n hermes exec hermes-0 -c hermes -- /bin/sh -lc '
+     set -eu
+     mcp_test=$(hermes mcp test exa 2>&1)
+     printf "%s" "$mcp_test" | grep -F "✓ Connected" >/dev/null
+     printf "%s" "$mcp_test" | grep -F "✓ Tools discovered: 2" >/dev/null
+     printf "%s" "$mcp_test" | grep -F "web_search_exa" >/dev/null
+     printf "%s" "$mcp_test" | grep -F "web_fetch_exa" >/dev/null
+     unset mcp_test
+     printf "exa_mcp_canary=ok tools=2\n"
+   '
+   ```
+
+5. Prove state survives a restart. Create a harmless canary file, restart the pod, and read it back:
 
    ```bash
    set -euo pipefail
@@ -307,7 +366,7 @@ The expected Hermes toolchain multi-architecture index digest is
    kubectl -n hermes exec hermes-0 -c hermes -- test -s /opt/data/workspace/tuslagch/.rollout-canary
    ```
 
-5. Prove direct-egress containment, public HTTPS through Squid, and private-destination denial:
+6. Prove direct-egress containment, public HTTPS through Squid, and private-destination denial:
 
    ```bash
    set -euo pipefail
@@ -336,7 +395,7 @@ The expected Hermes toolchain multi-architecture index digest is
    The direct public request must fail. Discord, GitHub, and an arbitrary public HTTPS destination must work through Squid,
    while the metadata destination must receive Squid's explicit denial.
 
-6. Prove the cluster reader and local lab checkout from inside the gateway:
+7. Prove the cluster reader and local lab checkout from inside the gateway:
 
    ```bash
    set -euo pipefail
@@ -810,8 +869,8 @@ Cutover sequence:
    ```
 
 4. Keep the Lease-owning shell open. Sync Hermes from merged `main` only after the OpenClaw VMI is gone. Wait for the
-   API ExternalSecret, Discord SealedSecret, and rollout; verify backups are enabled, then release the Lease. Prove only one
-   Discord bot session is active. This sync restores the Hermes replicas and backups:
+   API and Exa ExternalSecrets, Discord SealedSecret, and rollout; verify backups are enabled, then release the Lease.
+   Prove only one Discord bot session is active. This sync restores the Hermes replicas and backups:
 
    ```bash
    set -euo pipefail
@@ -819,13 +878,16 @@ Cutover sequence:
    test "$(kubectl -n hermes get lease hermes-maintenance -o jsonpath='{.spec.holderIdentity}')" = "$maintenance_holder"
    argocd app sync hermes --prune=false
    kubectl -n hermes wait externalsecret/hermes-api-auth --for=condition=Ready --timeout=5m
+   kubectl -n hermes wait externalsecret/hermes-exa-auth --for=condition=Ready --timeout=5m
    kubectl -n hermes wait sealedsecret/hermes-discord-auth --for=condition=Synced --timeout=5m
    kubectl -n hermes rollout status statefulset/hermes --timeout=15m
    api_secret_keys=$(kubectl -n hermes get secret hermes-api-auth -o json | jq -r '.data | keys | sort | join(",")')
+   exa_secret_keys=$(kubectl -n hermes get secret hermes-exa-auth -o json | jq -r '.data | keys | sort | join(",")')
    discord_secret_keys=$(kubectl -n hermes get secret hermes-discord-auth -o json | jq -r '.data | keys | sort | join(",")')
    test "$api_secret_keys" = API_SERVER_KEY
+   test "$exa_secret_keys" = EXA_API_KEY
    test "$discord_secret_keys" = DISCORD_ALLOWED_USERS,DISCORD_BOT_TOKEN
-   unset api_secret_keys discord_secret_keys
+   unset api_secret_keys exa_secret_keys discord_secret_keys
    test "$(kubectl -n hermes get cronjob hermes-backup -o jsonpath='{.spec.suspend}')" = false
    test -z "$(kubectl -n openclaw get virtualmachineinstance openclaw --ignore-not-found -o name)"
    test "$(kubectl -n hermes get statefulset hermes -o jsonpath='{.status.readyReplicas}')" = 1
@@ -963,10 +1025,11 @@ The rollout record is complete only when it includes:
 - Hermes toolchain index digest, both platform manifests, OCI version labels, exact login-shell versions, and real lab
   validation with an unchanged checkout status;
 - Argo `Synced/Healthy` readback at those revisions;
-- ExternalSecret Ready conditions and secret field lengths/counts without values;
+- API and Exa ExternalSecret Ready conditions and secret field lengths/counts without values;
 - pod UID, read-only rootfs, scoped service-account token, NetworkPolicy, PVC, and verified backup evidence;
 - gateway service-account identity, allowed cluster-wide reads, rejected Secret reads and writes, and the lab checkout SHA;
-- authenticated API rejection/success, Flamingo model response, and persistence after restart;
+- authenticated API rejection/success, Flamingo model response, native Exa search/extract, the two allowlisted Exa MCP
+  tools, and persistence after restart;
 - migration dry-run/apply Job identities and report counts;
 - single-writer Discord message lifecycle IDs and non-allowlisted-user rejection;
 - retained OpenClaw VM/PVC identities, rollback revision, and rollback-window end timestamp.

--- a/scripts/hermes/validate-production.test.ts
+++ b/scripts/hermes/validate-production.test.ts
@@ -356,24 +356,36 @@ test('rejects a broadly scoped GitHub SealedSecret', async () => {
 test('rejects API sessions without the terminal toolset', async () => {
   const files = await loadProductionFiles()
   files.config = files.config.replace(
-    '  api_server: [file, memory, terminal, todo]',
-    '  api_server: [file, memory, todo]',
+    '  api_server: [file, memory, terminal, todo, web, exa]',
+    '  api_server: [file, memory, todo, web, exa]',
   )
 
   expect(validateProductionContent(files)).toContain(
-    `${productionPaths.config}: missing production invariant "platform_toolsets:\\n  cli: [file, memory, terminal, todo]\\n  api_server: [file, memory, terminal, todo]\\n  discord: [file, memory, terminal, todo]"`,
+    `${productionPaths.config}: missing production invariant "platform_toolsets:\\n  cli: [file, memory, terminal, todo, web, exa]\\n  api_server: [file, memory, terminal, todo, web, exa]\\n  discord: [file, memory, terminal, todo, web, exa]"`,
   )
 })
 
 test('rejects duplicate platform toolset keys', async () => {
   const files = await loadProductionFiles()
   files.config = files.config.replace(
-    '  discord: [file, memory, terminal, todo]\n',
-    '  discord: [file, memory, terminal, todo]\n  discord: [file, memory, terminal, todo]\n',
+    '  discord: [file, memory, terminal, todo, web, exa]\n',
+    '  discord: [file, memory, terminal, todo, web, exa]\n  discord: [file, memory, terminal, todo, web, exa]\n',
   )
 
   expect(validateProductionContent(files)).toContain(
-    `${productionPaths.config}: discord must have exactly one production terminal toolset`,
+    `${productionPaths.config}: discord must have exactly one production web and terminal toolset`,
+  )
+})
+
+test('rejects a gateway without the Exa SecretKeyRef', async () => {
+  const files = await loadProductionFiles()
+  files.statefulSet = files.statefulSet.replace(
+    '                  name: hermes-exa-auth',
+    '                  name: missing-exa-auth',
+  )
+
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.statefulSet}: the gateway must receive exactly one Exa SecretKeyRef`,
   )
 })
 
@@ -407,6 +419,46 @@ test('rejects Discord fields in the API ExternalSecret', async () => {
 
   expect(validateProductionContent(files)).toContain(
     `${productionPaths.externalSecret}: contains forbidden production term "DISCORD_BOT_TOKEN"`,
+  )
+})
+
+test('rejects an Exa ExternalSecret outside the infra vault', async () => {
+  const files = await loadProductionFiles()
+  files.exaExternalSecret = files.exaExternalSecret.replace('name: onepassword-infra', 'name: onepassword-media')
+
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.exaExternalSecret}: missing production invariant "name: onepassword-infra"`,
+  )
+})
+
+test('rejects a duplicate Exa API key mapping', async () => {
+  const files = await loadProductionFiles()
+  files.exaExternalSecret +=
+    '\n    - secretKey: EXA_API_KEY\n      remoteRef:\n        key: hermes-runtime/EXA_API_KEY\n'
+
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.exaExternalSecret}: EXA_API_KEY must have exactly one 1Password mapping`,
+  )
+})
+
+test('rejects Exa MCP tools with mutation or agent authority', async () => {
+  const files = await loadProductionFiles()
+  files.config = files.config.replace('        - web_fetch_exa', '        - web_fetch_exa\n        - agent_run')
+
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.config}: contains forbidden production term "agent_run"`,
+  )
+})
+
+test('rejects an additional MCP server', async () => {
+  const files = await loadProductionFiles()
+  files.config = files.config.replace(
+    '\ndelegation:',
+    '\n  unreviewed:\n    url: "https://example.com/mcp"\n\ndelegation:',
+  )
+
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.config}: Exa must be the only MCP server with exactly two read-only web tools`,
   )
 })
 
@@ -548,12 +600,21 @@ test('rejects a Discord credential transfer without exact-value verification', a
 test('rejects secret bridge verification that does not enforce key length', async () => {
   const files = await loadProductionFiles()
   files.runbook = files.runbook.replace(
-    'test "$api_key_bytes" -ge 32\n   printf \'%s\\n\' "$api_key_bytes"',
-    'echo "$api_key_bytes"',
+    'test "$api_key_bytes" -ge 32\n   test "$exa_key_bytes" -ge 32\n   printf \'api_key_bytes=%s exa_key_bytes=%s\\n\'',
+    'test "$api_key_bytes" -ge 16\n   test "$exa_key_bytes" -ge 32\n   printf \'api_key_bytes=%s exa_key_bytes=%s\\n\'',
   )
 
   expect(validateProductionContent(files)).toContain(
     `${productionPaths.runbook}: 1Password and bridged API keys must both enforce the minimum length`,
+  )
+})
+
+test('rejects Exa secret verification that does not enforce key length', async () => {
+  const files = await loadProductionFiles()
+  files.runbook = files.runbook.replace('test "$exa_key_bytes" -ge 32', 'test "$exa_key_bytes" -ge 16')
+
+  expect(validateProductionContent(files)).toContain(
+    `${productionPaths.runbook}: 1Password and bridged Exa keys must both enforce the minimum length`,
   )
 })
 

--- a/scripts/hermes/validate-production.ts
+++ b/scripts/hermes/validate-production.ts
@@ -19,6 +19,7 @@ export const productionPaths = {
   backupScript: 'argocd/applications/hermes/backup-once.sh',
   config: 'argocd/applications/hermes/config.yaml',
   externalSecret: 'argocd/applications/hermes/external-secret.yaml',
+  exaExternalSecret: 'argocd/applications/hermes/exa-external-secret.yaml',
   discordSealedSecret: 'argocd/applications/hermes/discord-sealed-secret.yaml',
   githubSealedSecret: 'argocd/applications/hermes/github-sealed-secret.yaml',
   networkPolicy: 'argocd/applications/hermes/network-policy.yaml',
@@ -99,6 +100,7 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     '- network-policy.yaml',
     '- rbac.yaml',
     '- external-secret.yaml',
+    '- exa-external-secret.yaml',
     '- discord-sealed-secret.yaml',
     '- github-sealed-secret.yaml',
     '- bootstrap-lab-checkout.sh',
@@ -129,6 +131,7 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     'capabilities:\n              drop:\n                - ALL',
     'seccompProfile:\n              type: RuntimeDefault',
     'API_SERVER_KEY',
+    'EXA_API_KEY',
     'DISCORD_BOT_TOKEN',
     'DISCORD_ALLOWED_USERS',
     'name: data',
@@ -159,6 +162,16 @@ export function validateProductionContent(files: ProductionFiles): string[] {
   ])
   if (count(files.statefulSet, 'mountPath: /etc/profile.d/hermes-tools.sh\n') !== 1) {
     failures.push(`${productionPaths.statefulSet}: the gateway must mount exactly one immutable terminal login profile`)
+  }
+  const exaSecretKeyRef = [
+    '            - name: EXA_API_KEY',
+    '              valueFrom:',
+    '                secretKeyRef:',
+    '                  name: hermes-exa-auth',
+    '                  key: EXA_API_KEY',
+  ].join('\n')
+  if (count(files.statefulSet, exaSecretKeyRef) !== 1) {
+    failures.push(`${productionPaths.statefulSet}: the gateway must receive exactly one Exa SecretKeyRef`)
   }
   forbidTerms(failures, productionPaths.statefulSet, files.statefulSet, [
     ':latest',
@@ -307,13 +320,19 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     'cron_mode: deny',
     'orchestrator_enabled: false',
     'inherit_mcp_toolsets: false',
-    'mcp_servers: {}',
+    'web:\n  search_backend: exa\n  extract_backend: exa',
+    'mcp_servers:\n  exa:',
+    'url: "https://mcp.exa.ai/mcp?tools=web_search_exa,web_fetch_exa"',
+    'x-api-key: "${EXA_API_KEY}"',
+    'connect_timeout: 15',
+    'timeout: 120',
+    'tools:\n      include:\n        - web_search_exa\n        - web_fetch_exa',
     'hooks_auto_accept: false',
     'memory_char_limit: 4400',
     'code_execution:\n  timeout: 120\n  max_tool_calls: 100',
     'Treat /opt/data/workspace/tuslagch/lab as the project root and default working directory',
     'Use the authenticated tuslagch GitHub identity, codex/ branches, and pull requests',
-    'platform_toolsets:\n  cli: [file, memory, terminal, todo]\n  api_server: [file, memory, terminal, todo]\n  discord: [file, memory, terminal, todo]',
+    'platform_toolsets:\n  cli: [file, memory, terminal, todo, web, exa]\n  api_server: [file, memory, terminal, todo, web, exa]\n  discord: [file, memory, terminal, todo, web, exa]',
     'Kubernetes access is cluster-wide read-only',
     '    - "*git push --force*"',
     '  - "kubectl get *"',
@@ -326,12 +345,31 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     'api_key:',
     'token:',
     'allow_all_users: true',
+    'agent_run',
+    'web_search_advanced_exa',
     '    - "*kubectl*"',
   ])
   for (const platform of ['cli', 'api_server', 'discord']) {
-    if (count(files.config, `  ${platform}: [file, memory, terminal, todo]\n`) !== 1) {
-      failures.push(`${productionPaths.config}: ${platform} must have exactly one production terminal toolset`)
+    if (count(files.config, `  ${platform}: [file, memory, terminal, todo, web, exa]\n`) !== 1) {
+      failures.push(`${productionPaths.config}: ${platform} must have exactly one production web and terminal toolset`)
     }
+  }
+  const expectedMcpConfig = [
+    'mcp_servers:',
+    '  exa:',
+    '    url: "https://mcp.exa.ai/mcp?tools=web_search_exa,web_fetch_exa"',
+    '    headers:',
+    '      x-api-key: "${EXA_API_KEY}"',
+    '    connect_timeout: 15',
+    '    timeout: 120',
+    '    tools:',
+    '      include:',
+    '        - web_search_exa',
+    '        - web_fetch_exa',
+  ].join('\n')
+  const mcpConfig = files.config.match(/\nmcp_servers:\n[\s\S]*?\n\ndelegation:/)?.[0] ?? ''
+  if (mcpConfig !== `\n${expectedMcpConfig}\n\ndelegation:`) {
+    failures.push(`${productionPaths.config}: Exa must be the only MCP server with exactly two read-only web tools`)
   }
 
   requireTerms(failures, productionPaths.externalSecret, files.externalSecret, [
@@ -351,6 +389,27 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     count(files.externalSecret, '        key: hermes-runtime/API_SERVER_KEY\n') !== 1
   ) {
     failures.push(`${productionPaths.externalSecret}: API_SERVER_KEY must have exactly one 1Password mapping`)
+  }
+
+  requireTerms(failures, productionPaths.exaExternalSecret, files.exaExternalSecret, [
+    'name: hermes-exa-auth',
+    'name: onepassword-infra',
+    'deletionPolicy: Retain',
+    'secretKey: EXA_API_KEY',
+    'key: hermes-runtime/EXA_API_KEY',
+  ])
+  forbidTerms(failures, productionPaths.exaExternalSecret, files.exaExternalSecret, [
+    'dataFrom:',
+    'kind: Secret',
+    'API_SERVER_KEY',
+    'DISCORD_BOT_TOKEN',
+    'DISCORD_ALLOWED_USERS',
+  ])
+  if (
+    count(files.exaExternalSecret, '    - secretKey: EXA_API_KEY\n') !== 1 ||
+    count(files.exaExternalSecret, '        key: hermes-runtime/EXA_API_KEY\n') !== 1
+  ) {
+    failures.push(`${productionPaths.exaExternalSecret}: EXA_API_KEY must have exactly one 1Password mapping`)
   }
 
   requireTerms(failures, productionPaths.discordSealedSecret, files.discordSealedSecret, [
@@ -947,6 +1006,7 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     'Never create a migration or restore Job until every earlier Hermes maintenance Job is terminal.',
     'Never enable Hermes Discord until a final audited migration is applied after the OpenClaw gateway is inactive.',
     'Never sync Hermes until the disposable NetworkPolicy enforcement probe passes on the live cluster.',
+    'Never store or print the API key, Exa API key, or Discord token',
     'kubectl -n hermes get namespace hermes -o json',
     'Argo CD globally excludes Kubernetes Lease objects',
     "stale_maintenance_holder=$(kubectl -n hermes get lease hermes-maintenance -o jsonpath='{.spec.holderIdentity}')",
@@ -977,6 +1037,8 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     'The CronJob must remain suspended until every prior backup',
     'if kubectl -n hermes exec hermes-0 -c hermes -- /opt/hermes/.venv/bin/python -c',
     'direct public egress unexpectedly succeeded',
+    'native_web_canary=ok search_results={len(results)} extracted_pages={len(pages)}',
+    'exa_mcp_canary=ok tools=2',
     'git ls-remote --exit-code https://github.com/proompteng/lab.git refs/heads/main',
     'opener.open("https://169.254.169.254", timeout=5)',
     '*"403 Forbidden"*)',
@@ -1046,7 +1108,7 @@ export function validateProductionContent(files: ProductionFiles): string[] {
   requireTerms(failures, productionPaths.runbook, phaseZeroSection, [
     'bash scripts/hermes/verify-network-policy-enforcement.sh',
     '`NetworkPolicy is not enforced` is a hard rollout blocker.',
-    'unset hermes_api_key hermes_item_count hermes_item_id api_key_bytes',
+    'unset hermes_api_key hermes_item_count hermes_item_id api_key_bytes exa_key_bytes',
     'trap cleanup_api_key EXIT',
     'hermes_item_count=$(op item list --vault infra --format json',
     '[.[] | select(.title == "hermes-runtime")] | length',
@@ -1058,8 +1120,12 @@ export function validateProductionContent(files: ProductionFiles): string[] {
     'if length == 1 then .[0] else error("exactly one hermes-runtime item is required") end',
     'op item get --vault infra "$hermes_item_id" --format json',
     'else error("exactly one concealed API_SERVER_KEY field is required")',
+    'else error("exactly one concealed EXA_API_KEY field is required")',
     'test "$api_key_bytes" -ge 32',
-    'printf \'%s\\n\' "$api_key_bytes"',
+    'test "$exa_key_bytes" -ge 32',
+    'kubectl -n hermes wait externalsecret/hermes-exa-auth --for=condition=Ready --timeout=5m',
+    'test "$exa_secret_keys" = EXA_API_KEY',
+    'printf \'api_key_bytes=%s exa_key_bytes=%s\\n\' "$api_key_bytes" "$exa_key_bytes"',
     "hermes_deployed_revision=$(kubectl -n argocd get application hermes -o json | jq -r '.status.history[-1].revision // empty')",
     'test "$hermes_deployed_revision" = "$(git rev-parse HEAD)"',
   ])
@@ -1073,6 +1139,9 @@ export function validateProductionContent(files: ProductionFiles): string[] {
   }
   if (count(phaseZeroSection, 'test "$api_key_bytes" -ge 32') !== 2) {
     failures.push(`${productionPaths.runbook}: 1Password and bridged API keys must both enforce the minimum length`)
+  }
+  if (count(phaseZeroSection, 'test "$exa_key_bytes" -ge 32') !== 2) {
+    failures.push(`${productionPaths.runbook}: 1Password and bridged Exa keys must both enforce the minimum length`)
   }
   const rotationSection = files.runbook.match(/## API key rotation[\s\S]*?## Maintenance lock recovery/)?.[0] ?? ''
   requireTerms(failures, productionPaths.runbook, rotationSection, [


### PR DESCRIPTION
## Summary

- bridge `EXA_API_KEY` from `infra/hermes-runtime` through a dedicated ExternalSecret and gateway SecretKeyRef
- enable native Exa-backed `web_search` and `web_extract` for CLI, API, and Discord
- register the authenticated Exa MCP endpoint with only `web_search_exa` and `web_fetch_exa` allowed
- extend production validation, regression coverage, documentation, and rollout canaries

## Related Issues

None

## Testing

- `bun test scripts/hermes/validate-production.test.ts` (117 pass)
- `bun run scripts/hermes/validate-production.ts` (43 production surfaces validated)
- `bunx oxfmt --check scripts/hermes/validate-production.ts scripts/hermes/validate-production.test.ts`
- `kustomize build argocd/applications/hermes > /tmp/hermes-exa-rendered.yaml`
- `scripts/kubeconform.sh argocd/applications/hermes /tmp/hermes-exa-rendered.yaml` (36 valid, 0 invalid, 4 skipped)
- `bun run lint:argocd`
- candidate config passed `hermes config check` in the pinned Hermes 0.18.2 container
- native Exa canaries returned two search results and extracted the Exa MCP documentation
- `hermes mcp test exa` connected through production egress and discovered exactly two tools

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable and Breaking Changes is filled in.
- [x] Documentation, release notes, and follow-ups are updated or tracked.