### PR TITLE
refactor(bayn): centralize Effect clock formatting

### DIFF
--- a/services/bayn/src/app.ts
+++ b/services/bayn/src/app.ts
@@ -1,4 +1,4 @@
-import { Clock, Effect, Fiber, Layer, Option, pipe, Ref, Schema, Scope } from 'effect'
+import { Clock, Effect, Fiber, Layer, Option, pipe, Ref, Scope } from 'effect'
 
 import type { LoadedRuntimeConfig, RuntimeConfig } from './config'
 import { CycleObservability } from './db/cycle-observability'
@@ -9,9 +9,9 @@ import { makeHttpLayer } from './http'
 import { Journal } from './ledger'
 import { MarketData } from './market-data'
 import { initialState, type AutonomousCyclePassObservation, type RuntimeState } from './runtime-state'
-import { UtcInstantSchema } from './schemas'
 import { initialize } from './startup'
 import type { Strategy } from './strategy'
+import { utcInstantFromEpochMillis } from './time'
 
 export type RecordAutonomousCyclePass = (observation: AutonomousCyclePassObservation) => Effect.Effect<void>
 
@@ -93,12 +93,18 @@ const initialRuntimeState = <R>(runtime: ApplicationRuntime<R>): RuntimeState =>
     }),
   )
 
-const currentUtcInstant = pipe(
-  Clock.currentTimeMillis,
-  Effect.map((millis) => new Date(millis).toJSON()),
-  Effect.flatMap(Schema.decodeUnknownEffect(UtcInstantSchema)),
-  Effect.mapError((cause) =>
-    operationalError('strategy', 'cycle-loop-clock', 'runtime clock did not produce a canonical UTC instant', cause),
+const currentUtcInstant = Clock.currentTimeMillis.pipe(
+  Effect.flatMap((millis) =>
+    Effect.try({
+      try: () => utcInstantFromEpochMillis(millis),
+      catch: (cause) =>
+        operationalError(
+          'strategy',
+          'cycle-loop-clock',
+          'runtime clock did not produce a canonical UTC instant',
+          cause,
+        ),
+    }),
   ),
 )
 

--- a/services/bayn/src/broker/alpaca-mutations.ts
+++ b/services/bayn/src/broker/alpaca-mutations.ts
@@ -1,4 +1,4 @@
-import { Cause, Clock, Context, Data, Effect, Redacted, Result, Schema } from 'effect'
+import { Cause, Context, Data, Effect, Redacted, Result, Schema } from 'effect'
 import { Headers, HttpClient, HttpClientRequest, HttpClientResponse } from 'effect/unstable/http'
 
 import { canonicalHashV1 } from '../hash'
@@ -13,6 +13,7 @@ import {
   type Intent,
 } from '../paper'
 import { StrictNonEmptyStringSchema as NonEmptyString, UtcInstantSchema as UtcInstant } from '../schemas'
+import { currentUtcInstant } from '../time'
 import {
   OrderResponseSchema,
   OrderSide,
@@ -382,7 +383,7 @@ export const makeMutation = (
                 ),
               ),
             )
-            const observedAt = new Date(yield* Clock.currentTimeMillis).toISOString()
+            const observedAt = yield* currentUtcInstant
             const contentHash = yield* Effect.try({
               try: () => canonicalHashV1(raw),
               catch: (cause) =>
@@ -505,7 +506,7 @@ export const makeMutation = (
                       ),
                     ),
                   )
-            const observedAt = new Date(yield* Clock.currentTimeMillis).toISOString()
+            const observedAt = yield* currentUtcInstant
             const evidence = responseEvidence(headers['x-request-id'], response.status, contentHash, observedAt)
             if (response.status !== 204) {
               return yield* Effect.fail(

--- a/services/bayn/src/broker/alpaca.ts
+++ b/services/bayn/src/broker/alpaca.ts
@@ -1,5 +1,5 @@
 import { NodeHttpClient, Undici } from '@effect/platform-node'
-import { Cause, Clock, Context, Data, DateTime, Effect, Layer, Redacted, Schema, Scope } from 'effect'
+import { Cause, Context, Data, DateTime, Effect, Layer, Redacted, Schema, Scope } from 'effect'
 import { Headers, HttpClient, HttpClientError, HttpClientRequest, HttpClientResponse } from 'effect/unstable/http'
 
 import { canonicalHashV1 } from '../hash'
@@ -8,6 +8,7 @@ import {
   StrictNonEmptyStringSchema as NonEmptyString,
   SymbolSchema as SymbolName,
 } from '../schemas'
+import { addUtcDays, currentUtcDate, currentUtcInstant } from '../time'
 
 export const paperTradingUrl = 'https://paper-api.alpaca.markets'
 const defaultFillActivitiesPageSize = 100
@@ -1255,7 +1256,7 @@ export const make = (options: ReadOptions): Effect.Effect<BrokerReadShape, Broke
               cause,
             ),
         })
-        const observedAt = new Date(yield* Clock.currentTimeMillis).toISOString()
+        const observedAt = yield* currentUtcInstant
         const evidence = yield* Effect.try({
           try: () => responseEvidence(headers, response.status, contentHash, observedAt),
           catch: (cause) =>
@@ -1519,12 +1520,8 @@ const verifyOrderLookup = (
 export const verifyReadAccess = (read: BrokerReadShape): Effect.Effect<ReadPreflight, BrokerReadError> =>
   Effect.gen(function* () {
     const account = yield* read.account
-    const calendarStart = new Date(yield* Clock.currentTimeMillis).toISOString().slice(0, 10)
-    const calendarEnd = new Date(
-      Date.parse(`${calendarStart}T00:00:00.000Z`) + (marketCalendarPreflightRangeDays - 1) * millisecondsPerDay,
-    )
-      .toISOString()
-      .slice(0, 10)
+    const calendarStart = yield* currentUtcDate
+    const calendarEnd = addUtcDays(calendarStart, marketCalendarPreflightRangeDays - 1)
     const responses = yield* Effect.all(
       {
         positions: read.positions,

--- a/services/bayn/src/cycle-readiness.ts
+++ b/services/bayn/src/cycle-readiness.ts
@@ -1,4 +1,4 @@
-import { Clock, Data, Effect, Result } from 'effect'
+import { Data, Effect, Result } from 'effect'
 
 import {
   CycleState,
@@ -10,6 +10,7 @@ import {
 import { CycleStore, type CycleMutationReceipt, type CycleStoreError, type CycleStoreShape } from './db/cycle-store'
 import type { OperationalError } from './errors'
 import { MarketData, type MarketDataInspection, type MarketDataService } from './market-data'
+import { currentUtcInstant } from './time'
 
 export interface PublicationFreshness {
   readonly dataAgeMs: number
@@ -50,7 +51,7 @@ const readinessError = (
   cause?: unknown,
 ): CycleReadinessError => new CycleReadinessError({ operation, failure, message, cause })
 
-const currentTime = Clock.currentTimeMillis.pipe(Effect.map((millis) => new Date(millis).toISOString()))
+const currentTime = currentUtcInstant
 
 export type PublicationFreshnessFailure =
   | {

--- a/services/bayn/src/cycle-runner.ts
+++ b/services/bayn/src/cycle-runner.ts
@@ -1,4 +1,4 @@
-import { Clock, Data, Duration, Effect, HashSet, Option, pipe, Result, Schedule } from 'effect'
+import { Data, Duration, Effect, HashSet, Option, pipe, Result, Schedule } from 'effect'
 
 import {
   BrokerRead,
@@ -34,6 +34,7 @@ import {
   type SignalSessionRow,
 } from './market-data'
 import type { ObserveShadowDecisionDocument } from './shadow-decision-contract'
+import { currentUtcInstant } from './time'
 
 const calendarRangeDays = 31
 // This leaves at least 10 calendar days after the newest candidate inside Alpaca's 31-day observation bound.
@@ -169,7 +170,7 @@ export interface AutonomousCycleLoopOptions<E = never, R = never> {
   readonly pollIntervalMs: number
 }
 
-const currentIsoTime = Clock.currentTimeMillis.pipe(Effect.map((millis) => new Date(millis).toISOString()))
+const currentIsoTime = currentUtcInstant
 
 const runnerError = (
   operation: CycleRunnerError['operation'],

--- a/services/bayn/src/db/paper-store.ts
+++ b/services/bayn/src/db/paper-store.ts
@@ -1,5 +1,5 @@
 import { PgClient } from '@effect/sql-pg'
-import { Clock, Context, Data, Effect, Layer, Result, Schema } from 'effect'
+import { Context, Data, Effect, Layer, Result, Schema } from 'effect'
 
 import { prepareAccounting } from '../accounting/domain'
 import { renderAccountingFailure } from '../accounting/failure'
@@ -19,6 +19,7 @@ import type { RuntimeConfig } from '../config'
 import { WriterFence } from '../execution/writer-fence'
 import { canonicalHashV1 } from '../hash'
 import { Journal } from '../ledger'
+import { currentUtcInstant, utcInstantFromEpochMillis } from '../time'
 import {
   AccountingReceiptSchema,
   Authority,
@@ -867,7 +868,7 @@ const makeStore = (config: PaperStoreRuntimeConfig) =>
               tigerBeetleLedger: stable.tigerBeetleLedger,
             })
             const contentHash = canonicalHashV1(stable)
-            const recordedAt = new Date(yield* Clock.currentTimeMillis).toISOString()
+            const recordedAt = yield* currentUtcInstant
             const candidate = yield* decodeReceipt({ ...stable, receiptId, contentHash, recordedAt })
             yield* sql`
             INSERT INTO accounting_receipts (
@@ -1127,7 +1128,7 @@ const makeStore = (config: PaperStoreRuntimeConfig) =>
                   longMarketValueMicros: longMarketValue.toString(),
                   shortMarketValueMicros: shortMarketValue.toString(),
                   equityMicros: (cash + longMarketValue + shortMarketValue).toString(),
-                  asOf: new Date(Math.max(accountTime, positionTime)).toISOString(),
+                  asOf: utcInstantFromEpochMillis(Math.max(accountTime, positionTime)),
                 })
                 yield* sql`
                   INSERT INTO valuations (

--- a/services/bayn/src/execution/coordinator.ts
+++ b/services/bayn/src/execution/coordinator.ts
@@ -29,6 +29,7 @@ import {
 import { IntentStore, type IntentStoreError, type StoredIntent } from './intents'
 import { MutationStore, type MutationEvent } from './mutations'
 import { WriterFence } from './writer-fence'
+import { currentUtcInstant, utcInstantFromEpochMillis } from '../time'
 
 export enum ExecutionFailure {
   IntentNotFound = 'INTENT_NOT_FOUND',
@@ -57,7 +58,7 @@ interface RecoveryServices {
   readonly broker: BrokerRead['Service']
 }
 
-const currentInstant = Clock.currentTimeMillis.pipe(Effect.map((millis) => new Date(millis).toISOString()))
+const currentInstant = currentUtcInstant
 
 const executionError = (failure: ExecutionDecisionFailure): ExecutionError =>
   Match.value(failure).pipe(
@@ -418,7 +419,7 @@ const continueRecovery = (
     Effect.flatMap((currentMillis) =>
       liftDecision(ensureRecoveryDelay(operation, event, currentMillis)).pipe(
         Effect.flatMap((ready) =>
-          markInterruptedStart(services.mutations, ready, new Date(currentMillis).toISOString()),
+          markInterruptedStart(services.mutations, ready, utcInstantFromEpochMillis(currentMillis)),
         ),
       ),
     ),

--- a/services/bayn/src/health.ts
+++ b/services/bayn/src/health.ts
@@ -26,6 +26,7 @@ import type {
   RuntimeHealth,
   RuntimeState,
 } from './runtime-state'
+import { utcInstantFromEpochMillis } from './time'
 
 type ProbeResult<A> =
   | { readonly _tag: 'Available'; readonly value: A }
@@ -688,7 +689,7 @@ export const probe = (
       broker,
     )
     const checkedAtMs = yield* Clock.currentTimeMillis
-    const checkedAt = new Date(checkedAtMs).toISOString()
+    const checkedAt = utcInstantFromEpochMillis(checkedAtMs)
     const cycleFiber = sampleAutonomousCycleFiber(autonomousCycleFiber)
     const transition = yield* Ref.modify(state, (current) => {
       const decision = deriveHealthTransition(current, {

--- a/services/bayn/src/market-data.ts
+++ b/services/bayn/src/market-data.ts
@@ -1,5 +1,5 @@
 import { ClickhouseClient } from '@effect/sql-clickhouse'
-import { Clock, Context, Effect, Layer, Option, Result, Schema, pipe } from 'effect'
+import { Context, Effect, Layer, Option, Result, Schema, pipe } from 'effect'
 import { isSqlError, type SqlError } from 'effect/unstable/sql/SqlError'
 
 import type { RuntimeConfig } from './config'
@@ -28,6 +28,7 @@ import {
   UniverseIdSchema,
   strictParseOptions as StrictParseOptions,
 } from './schemas'
+import { currentUtcInstant } from './time'
 import {
   DataFeed,
   DataSource,
@@ -572,10 +573,7 @@ const makeMarketData = (
           ),
         )
 
-      const observedAt = pipe(
-        Clock.currentTimeMillis,
-        Effect.map((millis) => new Date(millis).toISOString()),
-      )
+      const observedAt = currentUtcInstant
 
       const decodeManifestRows = (
         rows: readonly unknown[],

--- a/services/bayn/src/observe-composition.ts
+++ b/services/bayn/src/observe-composition.ts
@@ -1,4 +1,4 @@
-import { Clock, Effect, pipe, Result } from 'effect'
+import { Effect, pipe, Result } from 'effect'
 
 import type { AutonomousCycleStartup } from './app'
 import { BrokerRead, type BrokerReadShape, type MarketCalendarQuery } from './broker/alpaca'
@@ -29,6 +29,7 @@ import { reconciledStateHash } from './reconciliation'
 import { BrokerMode, decodePolicy, type Policy, type State } from './risk'
 import { buildObserveShadowDecision, type ShadowDecisionError, type ShadowDeltaRiskInput } from './shadow-decision'
 import type { ObserveShadowDecisionDocument } from './shadow-decision-contract'
+import { currentUtcInstant } from './time'
 import {
   planTargets,
   type SignalSessionReferencePrices,
@@ -265,7 +266,7 @@ const readObserveDecisionFacts = (
       ],
       { concurrency: 3 },
     )
-    const evaluatedAt = new Date(yield* Clock.currentTimeMillis).toISOString()
+    const evaluatedAt = yield* currentUtcInstant
     return { snapshot, calendar, reconciliation, evaluatedAt }
   })
 

--- a/services/bayn/src/reconciler.ts
+++ b/services/bayn/src/reconciler.ts
@@ -1,4 +1,4 @@
-import { Cause, Chunk, Clock, Data, Effect, Exit, HashMap, HashSet, Option, Result, pipe } from 'effect'
+import { Cause, Chunk, Data, Effect, Exit, HashMap, HashSet, Option, Result, pipe } from 'effect'
 
 import {
   BrokerRead,
@@ -33,6 +33,7 @@ import {
   type ReconciliationWriteResult,
 } from './db/reconciliation'
 import { WriterFence, type WriterFenceError, type WriterFenceService } from './execution/writer-fence'
+import { currentUtcInstant } from './time'
 import { canonicalHashV1 } from './hash'
 import type { ReconciledBrokerState, ReconciliationRiskContext } from './reconciliation'
 
@@ -467,9 +468,7 @@ const decideStableHistory = (
     ? Result.succeed(after)
     : Result.fail(snapshotFailure('HistoryChanged', 'broker history changed during reconciliation'))
 
-const currentInstant = Clock.currentTimeMillis.pipe(
-  Effect.map((currentTimeMillis) => new Date(currentTimeMillis).toISOString()),
-)
+const currentInstant = currentUtcInstant
 
 const readStableBrokerSnapshot = (
   read: BrokerReadShape,

--- a/services/bayn/src/time.test.ts
+++ b/services/bayn/src/time.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from 'bun:test'
+
+import { Effect } from 'effect'
+import { TestClock } from 'effect/testing'
+
+import {
+  addUtcDays,
+  currentUtcDate,
+  currentUtcInstant,
+  utcDateFromEpochMillis,
+  utcInstantFromEpochMillis,
+} from './time'
+
+describe('Bayn UTC clock boundary', () => {
+  test('formats epoch milliseconds with the existing canonical UTC wire contract', () => {
+    const epochMillis = Date.parse('2026-07-26T06:23:57.295Z')
+
+    expect(utcInstantFromEpochMillis(epochMillis)).toBe('2026-07-26T06:23:57.295Z')
+    expect(utcDateFromEpochMillis(epochMillis)).toBe('2026-07-26')
+    expect(addUtcDays('2026-12-31', 1)).toBe('2027-01-01')
+  })
+
+  test('samples the injected Effect clock for instant and date projections', async () => {
+    const [instant, date] = await Effect.runPromise(
+      Effect.gen(function* () {
+        yield* TestClock.setTime(Date.parse('2026-07-26T06:23:57.295Z'))
+        return yield* Effect.all([currentUtcInstant, currentUtcDate])
+      }).pipe(Effect.provide(TestClock.layer())),
+    )
+
+    expect(instant).toBe('2026-07-26T06:23:57.295Z')
+    expect(date).toBe('2026-07-26')
+  })
+})

--- a/services/bayn/src/time.ts
+++ b/services/bayn/src/time.ts
@@ -1,0 +1,14 @@
+import { Clock, DateTime, Effect, pipe } from 'effect'
+
+export const utcInstantFromEpochMillis = (epochMillis: number): string =>
+  DateTime.formatIso(DateTime.makeUnsafe(epochMillis))
+
+export const utcDateFromEpochMillis = (epochMillis: number): string =>
+  DateTime.formatIsoDate(DateTime.makeUnsafe(epochMillis))
+
+export const addUtcDays = (date: string, days: number): string =>
+  pipe(DateTime.makeUnsafe(`${date}T00:00:00.000Z`), DateTime.add({ days }), DateTime.formatIsoDate)
+
+export const currentUtcInstant = Clock.currentTimeMillis.pipe(Effect.map(utcInstantFromEpochMillis))
+
+export const currentUtcDate = Clock.currentTimeMillis.pipe(Effect.map(utcDateFromEpochMillis))

--- a/services/bayn/tsconfig.json
+++ b/services/bayn/tsconfig.json
@@ -11,6 +11,7 @@
         "includeSuggestionsInTsc": false,
         "diagnosticSeverity": {
           "anyUnknownInErrorContext": "error",
+          "globalDateInEffect": "error",
           "globalErrorInEffectCatch": "error",
           "globalErrorInEffectFailure": "error",
           "multipleEffectProvide": "error",
@@ -24,6 +25,7 @@
             "options": {
               "diagnosticSeverity": {
                 "anyUnknownInErrorContext": "off",
+                "globalDateInEffect": "off",
                 "globalErrorInEffectCatch": "off",
                 "globalErrorInEffectFailure": "off",
                 "multipleEffectProvide": "off",


### PR DESCRIPTION
## Summary

- centralize Effect clock projections through Effect `DateTime` while preserving the existing UTC wire format
- remove ambient `Date` construction from Effectful runtime, broker, reconciliation, health, cycle, and persistence paths
- enforce `globalDateInEffect` as a blocking Effect diagnostic for production Bayn code

## Related Issues

None

## Testing

- affected runtime tests — 167 passed, 0 failed
- fresh-main `bun run --filter @proompteng/bayn test` after mutation-persistence merge — 653 passed, 119 skipped, 0 failed
- `bun node_modules/typescript/bin/tsc -p services/bayn/tsconfig.json --noEmit`
- `bun run --cwd services/bayn lint:effect`
- custom `globalDateInEffect` diagnostic — 176 files checked, no findings
- `bun node_modules/oxfmt/bin/oxfmt --check services/bayn`
- `bun node_modules/oxlint/bin/oxlint --config .oxlintrc.json services/bayn`
- `bun node_modules/oxlint/bin/oxlint --config .oxlintrc.json --type-aware --tsconfig services/bayn/tsconfig.json services/bayn`
- `bun run --filter @proompteng/bayn build`
- `bun test packages/scripts/src/bayn` — 20 passed, 0 failed

## Breaking Changes

None

## Checklist

- [x] Canonical UTC instant strings remain byte-identical.
- [x] Application startup retains a typed failure if its injected clock cannot be formatted.
- [x] Pure business-date calculations outside Effect clock boundaries are unchanged.
- [x] No broker or capital authority is introduced.
