### PR TITLE
refactor(bayn): totalize ledger plan construction

### DIFF
--- a/services/bayn/src/db/evidence-recovery.test.ts
+++ b/services/bayn/src/db/evidence-recovery.test.ts
@@ -7,7 +7,7 @@ import { Result } from 'effect'
 import { fixtureEvaluation, provenance } from '../app-test-support'
 import { makeEquitySeriesArtifact, QualificationArtifactManifestSchema } from '../evidence-contracts'
 import { canonicalHashV1 } from '../hash'
-import { buildLedgerPlan } from '../ledger-plan'
+import { buildLedgerPlan, LedgerValidationError } from '../ledger-plan'
 import { summarizeEvaluation } from '../risk-balanced-trend'
 import { fixtureProtocol } from '../test-fixtures'
 import type { EvaluationEvent } from '../types'
@@ -40,7 +40,9 @@ const artifact = (name: string, schemaVersion: string, payload: unknown, itemCou
 
 const makeRecoveryFixture = (): RecoveryFixture => {
   const evaluation = fixtureEvaluation
-  const ledger = buildLedgerPlan(evaluation, 1)
+  const ledgerResult = buildLedgerPlan(evaluation, 1)
+  assert(Result.isSuccess(ledgerResult), 'ledger recovery fixture must succeed')
+  const ledger = ledgerResult.success
   const reconciliation = {
     runId: evaluation.runId,
     accountCount: ledger.accounts.length,
@@ -709,7 +711,10 @@ describe('evidence recovery verifier', () => {
       _tag: 'ComputationFailure',
       operation: 'build-ledger-plan',
     })
-    if (issue._tag === 'ComputationFailure') expect(issue.cause).toBeInstanceOf(TypeError)
+    if (issue._tag === 'ComputationFailure') {
+      expect(issue.cause).toBeInstanceOf(LedgerValidationError)
+      if (issue.cause instanceof LedgerValidationError) expect(issue.cause.cause).toBeInstanceOf(TypeError)
+    }
   })
 
   test('retains typed reconciliation issues and reports final component and status drift', () => {

--- a/services/bayn/src/db/evidence-recovery.ts
+++ b/services/bayn/src/db/evidence-recovery.ts
@@ -1070,23 +1070,23 @@ const validateReconciliationShape = (prepared: PreparedEvidenceRecovery): Result
     if (reconciliation.runId !== prepared.runId) {
       return yield* mismatch('reconciliation', ['runId'], reconciliation.runId, prepared.runId)
     }
-    const ledgerPlan = yield* Result.try({
-      try: () =>
-        buildLedgerPlan(
-          {
-            runId: prepared.runId,
-            initialCapitalMicros: prepared.decoded.evaluation.initialCapitalMicros,
-            inputManifest: prepared.decoded.inputManifest,
-            events: prepared.decoded.events,
-          },
-          cardinalityOnlyLedger,
-        ),
-      catch: (cause): EvidenceRecoveryIssue => ({
-        _tag: 'ComputationFailure',
-        operation: 'build-ledger-plan',
-        cause,
-      }),
-    })
+    const ledgerPlan = yield* buildLedgerPlan(
+      {
+        runId: prepared.runId,
+        initialCapitalMicros: prepared.decoded.evaluation.initialCapitalMicros,
+        inputManifest: prepared.decoded.inputManifest,
+        events: prepared.decoded.events,
+      },
+      cardinalityOnlyLedger,
+    ).pipe(
+      Result.mapError(
+        (cause): EvidenceRecoveryIssue => ({
+          _tag: 'ComputationFailure',
+          operation: 'build-ledger-plan',
+          cause,
+        }),
+      ),
+    )
     if (reconciliation.accountCount !== ledgerPlan.accounts.length) {
       return yield* mismatch(
         'reconciliation',

--- a/services/bayn/src/db/evidence-store.integration.test.ts
+++ b/services/bayn/src/db/evidence-store.integration.test.ts
@@ -438,7 +438,9 @@ const makeInput = (
   )
   assert(Result.isSuccess(evaluationResult), 'strategy evaluation fixture must succeed')
   const evaluation = evaluationResult.success
-  const ledger = buildLedgerPlan(evaluation, 7_001)
+  const ledgerResult = buildLedgerPlan(evaluation, 7_001)
+  assert(Result.isSuccess(ledgerResult), 'ledger plan fixture must succeed')
+  const ledger = ledgerResult.success
   return {
     provenance,
     parameters: protocol,

--- a/services/bayn/src/ledger-plan.test.ts
+++ b/services/bayn/src/ledger-plan.test.ts
@@ -76,6 +76,31 @@ describe('ledger plan Result algebra', () => {
     expect(String(failure.cause)).toContain('no fill events')
   })
 
+  test('contains hostile cause rendering inside the closed build failure', () => {
+    const { result } = evaluationPlan()
+    const hostileCause = new Proxy(new Error('hidden cause'), {
+      get: (target, property, receiver) => {
+        if (property === 'message') throw new Error('cause message is unavailable')
+        return Reflect.get(target, property, receiver)
+      },
+    })
+    const inputManifest = new Proxy(result.inputManifest, {
+      get: (target, property, receiver) => {
+        if (property === 'symbols') throw hostileCause
+        return Reflect.get(target, property, receiver)
+      },
+    })
+
+    const failure = assertFailure(buildLedgerPlan({ ...result, inputManifest }, ledger))
+
+    expect(failure).toMatchObject({
+      operation: 'build-plan',
+      reason: 'ledger-plan-failure',
+      message: 'TigerBeetle build-plan failed: unrenderable cause',
+    })
+    expect(failure.cause).toBe(hostileCause)
+  })
+
   test('partitions exact existing transfers and preserves missing request order', () => {
     const { plan } = evaluationPlan()
     const existing = [plan.transfers[1], plan.transfers.at(-1)].filter(

--- a/services/bayn/src/ledger-plan.test.ts
+++ b/services/bayn/src/ledger-plan.test.ts
@@ -34,7 +34,7 @@ const evaluationPlan = () => {
   const result = assertSuccess(
     evaluateRiskBalancedTrend(snapshot.bars, snapshot.manifest, fixtureProtocol, makeTestProvenance()),
   )
-  return { result, plan: buildLedgerPlan(result, ledger) }
+  return { result, plan: assertSuccess(buildLedgerPlan(result, ledger)) }
 }
 
 const materialize = (plan: LedgerPlan): { readonly accounts: Account[]; readonly transfers: Transfer[] } => {
@@ -63,6 +63,19 @@ const materialize = (plan: LedgerPlan): { readonly accounts: Account[]; readonly
 }
 
 describe('ledger plan Result algebra', () => {
+  test('returns a closed build failure without throwing', () => {
+    const { result } = evaluationPlan()
+    const failure = assertFailure(buildLedgerPlan({ ...result, events: [] }, ledger))
+
+    expect(failure).toMatchObject({
+      operation: 'build-plan',
+      reason: 'ledger-plan-failure',
+      material: { ledger },
+    })
+    expect(failure.cause).toBeInstanceOf(Error)
+    expect(String(failure.cause)).toContain('no fill events')
+  })
+
   test('partitions exact existing transfers and preserves missing request order', () => {
     const { plan } = evaluationPlan()
     const existing = [plan.transfers[1], plan.transfers.at(-1)].filter(

--- a/services/bayn/src/ledger-plan.ts
+++ b/services/bayn/src/ledger-plan.ts
@@ -156,7 +156,7 @@ const positiveAmount = (value: string, name: string): bigint => {
   return parsed
 }
 
-export const buildLedgerPlan = (result: LedgerInput, ledger: number): LedgerPlan => {
+const buildLedgerPlanUnsafe = (result: LedgerInput, ledger: number): LedgerPlan => {
   const runKey = stableU128('bayn-run-v1', result.runId)
   const runTag = stableU64('bayn-run-v1', result.runId)
   const accountsByName = new Map<string, Account>()
@@ -310,6 +310,24 @@ export const buildLedgerPlan = (result: LedgerInput, ledger: number): LedgerPlan
     transfers: transfers.sort((left, right) => (left.id < right.id ? -1 : 1)),
   }
 }
+
+const causeMessage = (cause: unknown): string => (cause instanceof Error ? cause.message : String(cause))
+
+export const buildLedgerPlan = (
+  result: LedgerInput,
+  ledger: number,
+): Result.Result<LedgerPlan, LedgerValidationError> =>
+  Result.try({
+    try: () => buildLedgerPlanUnsafe(result, ledger),
+    catch: (cause) =>
+      ledgerValidationError(
+        'build-plan',
+        'ledger-plan-failure',
+        `TigerBeetle build-plan failed: ${causeMessage(cause)}`,
+        { ledger },
+        cause,
+      ),
+  })
 
 const serializeRecord = (record: Account | Transfer): Record<string, number | string> =>
   Object.fromEntries(

--- a/services/bayn/src/ledger-plan.ts
+++ b/services/bayn/src/ledger-plan.ts
@@ -311,7 +311,13 @@ const buildLedgerPlanUnsafe = (result: LedgerInput, ledger: number): LedgerPlan 
   }
 }
 
-const causeMessage = (cause: unknown): string => (cause instanceof Error ? cause.message : String(cause))
+const causeMessage = (cause: unknown): string => {
+  const rendered = Result.try({
+    try: () => String(cause instanceof Error ? cause.message : cause),
+    catch: () => undefined,
+  })
+  return Result.isSuccess(rendered) ? rendered.success : 'unrenderable cause'
+}
 
 export const buildLedgerPlan = (
   result: LedgerInput,

--- a/services/bayn/src/ledger.test.ts
+++ b/services/bayn/src/ledger.test.ts
@@ -21,6 +21,7 @@ import {
   transactionTransferQuery,
   validatePersistedRunEvidence,
   type JournalService,
+  type LedgerPlan,
   type TigerBeetleClient,
 } from './ledger'
 import { LEDGER_BATCH_MAX } from './ledger-plan'
@@ -37,7 +38,7 @@ const assertFailure = <A, E>(result: Result.Result<A, E>): E => {
   return result.failure
 }
 
-const materializeAccounts = (plan: ReturnType<typeof buildLedgerPlan>): Account[] => {
+const materializeAccounts = (plan: LedgerPlan): Account[] => {
   const balances = new Map(plan.accounts.map((account) => [account.id, { debits: 0n, credits: 0n }]))
   const balance = (accountId: bigint) => {
     const value = balances.get(accountId)
@@ -56,7 +57,7 @@ const materializeAccounts = (plan: ReturnType<typeof buildLedgerPlan>): Account[
   }))
 }
 
-const materializeTransfers = (plan: ReturnType<typeof buildLedgerPlan>): Transfer[] =>
+const materializeTransfers = (plan: LedgerPlan): Transfer[] =>
   plan.transfers.map((transfer) => ({ ...transfer, timestamp: 1n }))
 
 const journalConfig = {
@@ -93,7 +94,7 @@ const evaluationPlan = () => {
   const result = assertSuccess(
     evaluateRiskBalancedTrend(snapshot.bars, snapshot.manifest, fixtureProtocol, makeTestProvenance()),
   )
-  return { result, plan: buildLedgerPlan(result, journalConfig.tigerBeetle.ledger) }
+  return { result, plan: assertSuccess(buildLedgerPlan(result, journalConfig.tigerBeetle.ledger)) }
 }
 
 const makeTigerBeetleClient = (overrides: Partial<TigerBeetleClient> = {}): TigerBeetleClient => ({
@@ -348,12 +349,12 @@ describe('TigerBeetle simulation journal', () => {
     const result = assertSuccess(
       evaluateRiskBalancedTrend(snapshot.bars, snapshot.manifest, fixtureProtocol, makeTestProvenance()),
     )
-    const first = buildLedgerPlan(result, 7001)
-    const second = buildLedgerPlan(result, 7001)
+    const first = assertSuccess(buildLedgerPlan(result, 7001))
+    const second = assertSuccess(buildLedgerPlan(result, 7001))
     expect(first).toEqual(second)
     expect(hashLedgerPlan(first)).toMatch(/^[a-f0-9]{64}$/)
     expect(hashLedgerPlan(first)).toBe(hashLedgerPlan(second))
-    expect(hashLedgerPlan(first)).not.toBe(hashLedgerPlan(buildLedgerPlan(result, 7002)))
+    expect(hashLedgerPlan(first)).not.toBe(hashLedgerPlan(assertSuccess(buildLedgerPlan(result, 7002))))
     expect(first.accounts).toHaveLength(fixtureProtocol.universe.length + 6)
     expect(first.transfers.length).toBeGreaterThan(1)
     expect(
@@ -366,7 +367,7 @@ describe('TigerBeetle simulation journal', () => {
     const result = assertSuccess(
       evaluateRiskBalancedTrend(snapshot.bars, snapshot.manifest, fixtureProtocol, makeTestProvenance()),
     )
-    const plan = buildLedgerPlan(result, 7001)
+    const plan = assertSuccess(buildLedgerPlan(result, 7001))
     const accounts = materializeAccounts(plan)
     const transfers = materializeTransfers(plan)
     expect(
@@ -388,7 +389,7 @@ describe('TigerBeetle simulation journal', () => {
     const result = assertSuccess(
       evaluateRiskBalancedTrend(snapshot.bars, snapshot.manifest, fixtureProtocol, makeTestProvenance()),
     )
-    const plan = buildLedgerPlan(result, journalConfig.tigerBeetle.ledger)
+    const plan = assertSuccess(buildLedgerPlan(result, journalConfig.tigerBeetle.ledger))
     const target = makeLedgerClient()
 
     const reconciliations = await Effect.runPromise(
@@ -451,7 +452,7 @@ describe('TigerBeetle simulation journal', () => {
     expect(transferCreates).toBe(0)
   })
 
-  test('retains the exact throwing ledger-plan cause without starting TigerBeetle writes', async () => {
+  test('retains the exact typed ledger-plan failure without starting TigerBeetle writes', async () => {
     const { result } = evaluationPlan()
     let writes = 0
     const client = makeTigerBeetleClient({
@@ -733,7 +734,7 @@ describe('TigerBeetle simulation journal', () => {
     const result = assertSuccess(
       evaluateRiskBalancedTrend(snapshot.bars, snapshot.manifest, fixtureProtocol, makeTestProvenance()),
     )
-    const plan = buildLedgerPlan(result, journalConfig.tigerBeetle.ledger)
+    const plan = assertSuccess(buildLedgerPlan(result, journalConfig.tigerBeetle.ledger))
     const target = makeLedgerClient()
     target.accounts.set(plan.accounts[0].id, { ...plan.accounts[0], code: plan.accounts[0].code + 1, timestamp: 1n })
 
@@ -751,7 +752,7 @@ describe('TigerBeetle simulation journal', () => {
     const result = assertSuccess(
       evaluateRiskBalancedTrend(snapshot.bars, snapshot.manifest, fixtureProtocol, provenance),
     )
-    const plan = buildLedgerPlan(result, 7001)
+    const plan = assertSuccess(buildLedgerPlan(result, 7001))
     let accounts = materializeAccounts(plan)
     const transfers = materializeTransfers(plan)
     let writes = 0

--- a/services/bayn/src/ledger.ts
+++ b/services/bayn/src/ledger.ts
@@ -45,8 +45,6 @@ export interface JournalService {
 
 export class Journal extends Context.Service<Journal, JournalService>()('bayn/Journal') {}
 
-const causeMessage = (cause: unknown): string => (cause instanceof Error ? cause.message : String(cause))
-
 const validationBoundary = <A>(decision: Result.Result<A, LedgerValidationError>): Effect.Effect<A, OperationalError> =>
   Effect.fromResult(decision).pipe(
     Effect.mapError(
@@ -304,26 +302,13 @@ const checkRun = (
     yield* validationBoundary(validatePersistedRunEvidence(result, ledger, accounts, transfers))
   })
 
-const buildJournalPlan = (result: LedgerInput, ledger: number): Result.Result<LedgerPlan, LedgerValidationError> =>
-  Result.try({
-    try: () => buildLedgerPlan(result, ledger),
-    catch: (cause) =>
-      validationError(
-        'build-plan',
-        'ledger-plan-failure',
-        `TigerBeetle build-plan failed: ${causeMessage(cause)}`,
-        { ledger },
-        cause,
-      ),
-  })
-
 const journalAndReconcile = (
   client: TigerBeetleRequestClient,
   ledger: number,
   result: LedgerInput,
 ): Effect.Effect<ReconciliationResult, OperationalError> =>
   Effect.gen(function* () {
-    const plan = yield* validationBoundary(buildJournalPlan(result, ledger))
+    const plan = yield* validationBoundary(buildLedgerPlan(result, ledger))
     yield* createAndVerifyAccounts(client, plan.accounts)
     yield* createAndVerifyTransfers(client, plan.transfers)
     const accountQuery = { ...queryFilter(ledger), user_data_128: plan.runKey, limit: plan.accounts.length + 1 }


### PR DESCRIPTION
## Summary

- make the exported ledger-plan builder return the existing closed `LedgerValidationError` Result algebra
- remove duplicate `Result.try` wrappers from the journal and evidence-recovery callers
- preserve deterministic ledger math, plan hashes, journal behavior, and the original failure cause

## Related Issues

None

## Testing

- focused ledger and evidence-recovery tests — 35 passed, 0 failed
- `bun run --filter @proompteng/bayn test` — 654 passed, 119 skipped, 0 failed
- `bun node_modules/typescript/bin/tsc -p services/bayn/tsconfig.json --noEmit`
- `bun run --cwd services/bayn lint:effect`
- `bun node_modules/oxfmt/bin/oxfmt --check services/bayn`
- `bun node_modules/oxlint/bin/oxlint --config .oxlintrc.json services/bayn`
- `bun node_modules/oxlint/bin/oxlint --config .oxlintrc.json --type-aware --tsconfig services/bayn/tsconfig.json services/bayn`
- `bun run --filter @proompteng/bayn build`
- `bun test packages/scripts/src/bayn` — 20 passed, 0 failed

## Breaking Changes

None

## Checklist

- [x] The exported pure API no longer throws for invalid evaluation material or batch limits.
- [x] Existing `build-plan` failure classification and nested original cause are preserved.
- [x] Ledger identities, account/transfer ordering, and hashes are unchanged.
- [x] No broker or capital authority is introduced.
