### PR TITLE
refactor(bayn): totalize broker order encoding

### DIFF
--- a/services/bayn/src/broker/alpaca-mutations.test.ts
+++ b/services/bayn/src/broker/alpaca-mutations.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 
-import { Effect, Fiber, Redacted } from 'effect'
+import { Effect, Fiber, Redacted, Result } from 'effect'
 import { TestClock } from 'effect/testing'
 import { HttpClient, HttpClientResponse } from 'effect/unstable/http'
 
@@ -11,6 +11,8 @@ import {
   MutationFailure,
   MutationOperation,
   makeMutation,
+  orderRequestBody,
+  submitBody,
   type BrokerMutationShape,
   type MutationOptions,
 } from './alpaca-mutations'
@@ -138,7 +140,30 @@ const requestBody = (request: Parameters<Parameters<typeof HttpClient.make>[0]>[
   return JSON.parse(new TextDecoder().decode(request.body.body))
 }
 
+const assertFailure = <A, E>(result: Result.Result<A, E>): E => {
+  if (Result.isSuccess(result)) throw new Error('expected request encoding failure')
+  return result.failure
+}
+
 describe('Alpaca paper mutations', () => {
+  test('returns closed request encoding failures without throwing', () => {
+    expect(assertFailure(submitBody({ ...intent, state: IntentState.Approved }))).toMatchObject({
+      _tag: 'OrderRequestError',
+      failure: 'invalid-intent-state',
+    })
+    expect(assertFailure(orderRequestBody({ ...intent, orderType: OrderType.Limit }))).toMatchObject({
+      _tag: 'OrderRequestError',
+      failure: 'invalid-order',
+    })
+    expect(assertFailure(orderRequestBody({ ...intent, timeInForce: TimeInForce.GoodUntilCanceled }))).toMatchObject({
+      _tag: 'OrderRequestError',
+      failure: 'invalid-order',
+    })
+    const malformedQuantity = assertFailure(orderRequestBody({ ...intent, quantityMicros: 'not-an-integer' }))
+    expect(malformedQuantity).toMatchObject({ _tag: 'OrderRequestError', failure: 'invalid-order' })
+    expect(malformedQuantity.cause).toBeInstanceOf(Error)
+  })
+
   test('refuses to construct mutation capability below explicit PAPER authority', async () => {
     let requests = 0
     const client = HttpClient.make(() => {

--- a/services/bayn/src/broker/alpaca-mutations.ts
+++ b/services/bayn/src/broker/alpaca-mutations.ts
@@ -124,6 +124,22 @@ export interface BrokerMutationShape {
 
 export class BrokerMutation extends Context.Service<BrokerMutation, BrokerMutationShape>()('bayn/BrokerMutation') {}
 
+export interface OrderRequestBody {
+  readonly symbol: string
+  readonly qty: string
+  readonly side: OrderSide
+  readonly type: OrderType.Market
+  readonly time_in_force: TimeInForce
+  readonly client_order_id: string
+  readonly extended_hours: false
+}
+
+export class OrderRequestError extends Data.TaggedError('OrderRequestError')<{
+  readonly failure: 'invalid-intent-state' | 'invalid-order'
+  readonly message: string
+  readonly cause?: unknown
+}> {}
+
 const causeSummary = (cause: unknown): Readonly<Record<string, string>> => {
   if (Schema.isSchemaError(cause)) return { tag: cause._tag, message: cause.message }
   if (typeof cause === 'object' && cause !== null && '_tag' in cause && typeof cause._tag === 'string') {
@@ -223,7 +239,7 @@ const timeInForce = (value: DomainTimeInForce): TimeInForce => {
   }
 }
 
-export const orderRequestBody = (intent: Intent) => {
+const orderRequestBodyUnsafe = (intent: Intent): OrderRequestBody => {
   if (intent.orderType !== DomainOrderType.Market) throw new Error('Bayn broker submission supports market orders only')
   if (intent.timeInForce !== DomainTimeInForce.Day && BigInt(intent.quantityMicros) % 1_000_000n !== 0n) {
     throw new Error('fractional market orders require DAY time in force')
@@ -239,10 +255,26 @@ export const orderRequestBody = (intent: Intent) => {
   } as const
 }
 
-export const submitBody = (intent: Intent) => {
-  if (intent.state !== IntentState.IoStarted) throw new Error('intent must be IO_STARTED before broker submission')
-  return orderRequestBody(intent)
-}
+export const orderRequestBody = (intent: Intent): Result.Result<OrderRequestBody, OrderRequestError> =>
+  Result.try({
+    try: () => orderRequestBodyUnsafe(intent),
+    catch: (cause) =>
+      new OrderRequestError({
+        failure: 'invalid-order',
+        message: 'intent cannot be represented as an Alpaca paper order',
+        cause,
+      }),
+  })
+
+export const submitBody = (intent: Intent): Result.Result<OrderRequestBody, OrderRequestError> =>
+  intent.state !== IntentState.IoStarted
+    ? Result.fail(
+        new OrderRequestError({
+          failure: 'invalid-intent-state',
+          message: 'intent must be IO_STARTED before broker submission',
+        }),
+      )
+    : orderRequestBody(intent)
 
 export const cancelRequestHash = (brokerOrderId: string): string =>
   canonicalHashV1({ operation: MutationOperation.Cancel, brokerOrderId })
@@ -339,10 +371,11 @@ export const makeMutation = (
             ),
           )
         }
-        const body = yield* Effect.try({
-          try: () => submitBody(intent),
-          catch: (cause) => invalidRequest(MutationOperation.Submit, 'order intent cannot be submitted', cause),
-        })
+        const body = yield* Effect.fromResult(submitBody(intent)).pipe(
+          Effect.mapError((cause) =>
+            invalidRequest(MutationOperation.Submit, 'order intent cannot be submitted', cause),
+          ),
+        )
         const requestHash = canonicalHashV1(body)
         const request = yield* HttpClientRequest.bodyJson(
           HttpClientRequest.post(new URL('/v2/orders', paperTradingUrl), {

--- a/services/bayn/src/db/evidence-store.integration.test.ts
+++ b/services/bayn/src/db/evidence-store.integration.test.ts
@@ -1957,7 +1957,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
           yield* Deferred.succeed(submitEntered, undefined)
           yield* Deferred.await(releaseSubmit)
           return {
-            requestHash: canonicalHashV1(orderRequestBody(submitted)),
+            requestHash: canonicalHashV1(Result.getOrThrow(orderRequestBody(submitted))),
             order: {
               accountId: submitted.accountId,
               brokerOrderId: orderId,

--- a/services/bayn/src/execution/coordinator-decisions.test.ts
+++ b/services/bayn/src/execution/coordinator-decisions.test.ts
@@ -37,6 +37,8 @@ import {
   selectRecovery,
   validateRecovery,
 } from './coordinator-decisions'
+
+const encodedRequest = (value: Intent) => Result.getOrThrow(orderRequestBody(value))
 import type { StoredIntent } from './intents'
 import { MutationEventType, mutationIdResult, type MutationEvent } from './mutations'
 
@@ -121,7 +123,7 @@ const mutation = (
 ): MutationEvent => {
   const requestHash =
     operation === MutationOperation.Submit
-      ? canonicalHashV1(orderRequestBody(stateIntent))
+      ? canonicalHashV1(encodedRequest(stateIntent))
       : cancelRequestHash(brokerOrderId)
   return {
     schemaVersion: 'bayn.paper-mutation-event.v1',
@@ -147,8 +149,8 @@ describe('execution coordinator decisions', () => {
       schemaVersion: 'bayn.paper-submit-dry-run.v1',
       intentId,
       clientOrderId: intent.clientOrderId,
-      requestHash: canonicalHashV1(orderRequestBody(intent)),
-      request: orderRequestBody(intent),
+      requestHash: canonicalHashV1(encodedRequest(intent)),
+      request: encodedRequest(intent),
     })
     expect(Option.getOrUndefined(Result.getFailure(expired))).toMatchObject({
       _tag: 'ExpiredRiskDecision',

--- a/services/bayn/src/execution/coordinator-decisions.ts
+++ b/services/bayn/src/execution/coordinator-decisions.ts
@@ -8,6 +8,7 @@ import {
   cancelRequestHash,
   orderRequestBody,
   type MutationEvidence,
+  type OrderRequestBody,
 } from '../broker/alpaca-mutations'
 import {
   type BrokerReadError,
@@ -65,7 +66,7 @@ export type ExecutionDecisionFailure =
     }
 
 export interface EncodedOrder {
-  readonly request: ReturnType<typeof orderRequestBody>
+  readonly request: OrderRequestBody
   readonly requestHash: string
 }
 
@@ -177,18 +178,22 @@ export const encodeOrder = (
   intent: Intent,
   message = 'intent cannot be represented as an Alpaca paper order',
 ): Result.Result<EncodedOrder, ExecutionDecisionFailure> =>
-  Result.try({
-    try: () => {
-      const request = orderRequestBody(intent)
-      return { request, requestHash: canonicalHashV1(request) }
-    },
-    catch: (cause): ExecutionDecisionFailure => ({
-      _tag: 'OrderCanonicalizationFailed',
-      operation,
-      message,
-      cause,
-    }),
-  })
+  orderRequestBody(intent).pipe(
+    Result.mapError(
+      (cause): ExecutionDecisionFailure => ({ _tag: 'OrderCanonicalizationFailed', operation, message, cause }),
+    ),
+    Result.flatMap((request) =>
+      Result.try({
+        try: () => ({ request, requestHash: canonicalHashV1(request) }),
+        catch: (cause): ExecutionDecisionFailure => ({
+          _tag: 'OrderCanonicalizationFailed',
+          operation,
+          message,
+          cause,
+        }),
+      }),
+    ),
+  )
 
 export const validateActiveSubmitRiskDecision = (
   stored: StoredIntent,

--- a/services/bayn/src/execution/coordinator.test.ts
+++ b/services/bayn/src/execution/coordinator.test.ts
@@ -43,6 +43,8 @@ import {
 } from '../paper'
 import { cancel, dryRunSubmit, ExecutionError, ExecutionFailure, recover, submit } from './coordinator'
 import { IntentStore, type IntentStoreService, type StoredIntent } from './intents'
+
+const encodedRequest = (value: Intent) => Result.getOrThrow(orderRequestBody(value))
 import {
   decideMutationAuthority,
   decideMutationOutcome,
@@ -1393,7 +1395,7 @@ const makeHarness = (options: HarnessOptions = {}) => {
       }
       if (options.crashAfterSubmit) return Effect.die(new Error('injected crash after send'))
       if (options.submitError !== undefined) return Effect.fail(options.submitError)
-      const hash = canonicalHashV1(orderRequestBody(submitted))
+      const hash = canonicalHashV1(encodedRequest(submitted))
       if (options.unknownSubmit) {
         return Effect.fail(
           new BrokerMutationError({
@@ -1508,7 +1510,7 @@ const mismatchedSubmissionError = () =>
     failure: MutationFailure.Unknown,
     outcome: MutationOutcome.Unknown,
     message: 'accepted order differs from durable intent',
-    requestHash: canonicalHashV1(orderRequestBody(intent)),
+    requestHash: canonicalHashV1(encodedRequest(intent)),
     evidence: evidence(200, '1970-01-01T00:00:00.100Z'),
     brokerOrderId: orderId,
   })
@@ -1522,8 +1524,8 @@ describe('paper execution coordinator', () => {
       schemaVersion: 'bayn.paper-submit-dry-run.v1',
       intentId,
       clientOrderId: intent.clientOrderId,
-      requestHash: canonicalHashV1(orderRequestBody(intent)),
-      request: orderRequestBody(intent),
+      requestHash: canonicalHashV1(encodedRequest(intent)),
+      request: encodedRequest(intent),
     })
     expect(harness.calls()).toEqual({ submit: 0, cancel: 0, lookup: 0 })
     expect(harness.state()).toBe(IntentState.Approved)


### PR DESCRIPTION
## Summary

- make the exported Alpaca order encoders return a closed `OrderRequestError` Result algebra
- remove duplicate `Effect.try` and `Result.try` wrappers from mutation and coordinator callers
- preserve exact request bodies, request hashes, and pre-I/O rejection behavior

## Related Issues

None

## Testing

- focused broker/coordinator tests — 47 passed, 0 failed
- `bun run --filter @proompteng/bayn test` — 656 passed, 119 skipped, 0 failed
- `bun node_modules/typescript/bin/tsc -p services/bayn/tsconfig.json --noEmit`
- `bun run --cwd services/bayn lint:effect`
- `bun node_modules/oxfmt/bin/oxfmt --check services/bayn`
- `bun node_modules/oxlint/bin/oxlint --config .oxlintrc.json services/bayn`
- `bun node_modules/oxlint/bin/oxlint --config .oxlintrc.json --type-aware --tsconfig services/bayn/tsconfig.json services/bayn`
- `bun run --filter @proompteng/bayn build`
- `bun test packages/scripts/src/bayn` — 20 passed, 0 failed

## Breaking Changes

None

## Checklist

- [x] Invalid intent state, unsupported order shape, and malformed quantity return typed failures without throwing.
- [x] Invalid requests still fail before broker I/O.
- [x] Valid Alpaca JSON bodies and canonical request hashes are unchanged.
- [x] No broker or capital authority is introduced.
