### PR TITLE
refactor(bayn): totalize canonical hashing

### DIFF
--- a/services/bayn/src/entrypoint.ts
+++ b/services/bayn/src/entrypoint.ts
@@ -7,14 +7,14 @@ import { riskBalancedTrendBehaviorHash } from './behavior'
 import { BrokerRead, live as AlpacaReadLive, scopedReadAdapterLayer, type BrokerReadShape } from './broker/alpaca'
 import { verifyBehaviorHash, verifyParameterHash } from './build'
 import { loadConfig, type LoadedRuntimeConfig } from './config'
-import { makeRuntimeProvenance, makeStrategyProtocolHash } from './contracts'
+import { makeRuntimeProvenance, makeStrategyProtocolHashResult, type ContractConstructionFailure } from './contracts'
 import { CycleObservabilityLive } from './db/cycle-observability'
 import { CycleStoreLive } from './db/cycle-store'
 import { EvidenceStoreFromPostgres, PostgresClientLive } from './db/evidence-store'
 import { PaperStoreLive } from './db/paper-store'
 import { WriterFenceLive } from './execution/writer-fence'
 import { operationalError } from './errors'
-import { canonicalHashV1 } from './hash'
+import { canonicalHashV1Result, type CanonicalJsonFailure } from './hash'
 import { JournalLive } from './ledger'
 import { MarketDataLive } from './market-data'
 import { loadObserveRiskPolicy, makeObserveAutonomousCycleStartup } from './observe-composition'
@@ -24,7 +24,7 @@ import {
   renderPaperCandidateDiscoveryError,
   type PaperCandidateDiscoveryReceipt,
 } from './paper-candidate-discovery'
-import { hashParameters, loadDefaultProtocol, type CausalProtocol } from './protocol'
+import { loadDefaultProtocol, type CausalProtocol } from './protocol'
 import { makeStrategy, type Strategy } from './strategy'
 
 type AlpacaBinding = NonNullable<LoadedRuntimeConfig['alpaca']>
@@ -41,15 +41,15 @@ type RuntimeIdentity<C extends LoadedRuntimeConfig = LoadedRuntimeConfig> = {
 type RuntimeIdentityFailure =
   | {
       readonly _tag: 'RuntimeParameterHashFailed'
-      readonly cause: unknown
+      readonly cause: CanonicalJsonFailure
     }
   | {
       readonly _tag: 'RuntimeProvenanceFailed'
       readonly cause: unknown
     }
   | {
-      readonly _tag: 'RuntimeStrategyFailed'
-      readonly cause: unknown
+      readonly _tag: 'RuntimeStrategyProtocolHashFailed'
+      readonly cause: ContractConstructionFailure
     }
 
 type RuntimePlanFor<M extends RuntimeMode> = RuntimeIdentity<
@@ -72,13 +72,12 @@ type ParameterizedRuntime = RuntimeSeed & { readonly parameterHash: string }
 type ProvenanceRuntime = ParameterizedRuntime & {
   readonly provenance: ReturnType<typeof makeRuntimeProvenance>
 }
+type StrategyRuntime = ProvenanceRuntime & { readonly strategy: Strategy }
 
 const hashRuntimeParameters = (seed: RuntimeSeed): Result.Result<ParameterizedRuntime, RuntimeIdentityFailure> =>
   pipe(
-    Result.try({
-      try: () => hashParameters(seed.protocol),
-      catch: (cause): RuntimeIdentityFailure => ({ _tag: 'RuntimeParameterHashFailed', cause }),
-    }),
+    canonicalHashV1Result(seed.protocol),
+    Result.mapError((cause): RuntimeIdentityFailure => ({ _tag: 'RuntimeParameterHashFailed', cause })),
     Result.map((parameterHash) => ({ ...seed, parameterHash })),
   )
 
@@ -109,28 +108,34 @@ const addRuntimeProvenance = (
     Result.map((provenance) => ({ ...parameterized, provenance })),
   )
 
-const completeRuntimeIdentity = (runtime: ProvenanceRuntime): RuntimeIdentity =>
+const addStrategy = (runtime: ProvenanceRuntime): StrategyRuntime => ({
+  ...runtime,
+  strategy: makeStrategy(runtime.protocol, runtime.provenance),
+})
+
+const addStrategyProtocolHash = (runtime: StrategyRuntime): Result.Result<RuntimeIdentity, RuntimeIdentityFailure> =>
   pipe(
-    makeStrategy(runtime.protocol, runtime.provenance),
-    (strategy): RuntimeIdentity => ({
+    makeStrategyProtocolHashResult(runtime.strategy.provenance.strategy),
+    Result.mapError(
+      (cause): RuntimeIdentityFailure => ({
+        _tag: 'RuntimeStrategyProtocolHashFailed',
+        cause,
+      }),
+    ),
+    Result.map((strategyProtocolHash) => ({
       config: runtime.config,
       protocol: runtime.protocol,
       parameterHash: runtime.parameterHash,
-      strategy,
-      strategyProtocolHash: makeStrategyProtocolHash(strategy.provenance.strategy),
-    }),
+      strategy: runtime.strategy,
+      strategyProtocolHash,
+    })),
   )
-
-const addStrategy = (runtime: ProvenanceRuntime): Result.Result<RuntimeIdentity, RuntimeIdentityFailure> =>
-  Result.try({
-    try: () => completeRuntimeIdentity(runtime),
-    catch: (cause): RuntimeIdentityFailure => ({ _tag: 'RuntimeStrategyFailed', cause }),
-  })
 
 const makeRuntimeIdentity = flow(
   hashRuntimeParameters,
   Result.flatMap(addRuntimeProvenance),
-  Result.flatMap(addStrategy),
+  Result.map(addStrategy),
+  Result.flatMap(addStrategyProtocolHash),
 )
 
 const runtimeIdentityError = (failure: RuntimeIdentityFailure) =>
@@ -152,8 +157,13 @@ const runtimeIdentityError = (failure: RuntimeIdentityFailure) =>
         cause,
       ),
     ),
-    Match.tag('RuntimeStrategyFailed', ({ cause }) =>
-      operationalError('strategy', 'runtime-identity/strategy', 'runtime strategy construction failed', cause),
+    Match.tag('RuntimeStrategyProtocolHashFailed', ({ cause }) =>
+      operationalError(
+        'strategy',
+        'runtime-identity/strategy-protocol-hash',
+        'runtime strategy protocol-hash construction failed',
+        cause,
+      ),
     ),
     Match.exhaustive,
   )
@@ -315,16 +325,15 @@ const writeDiscoveryReceipt = (receipt: PaperCandidateDiscoveryReceipt) =>
 
 const policyHash = (policy: unknown): Effect.Effect<string, ReturnType<typeof operationalError>> =>
   pipe(
-    Result.try({
-      try: () => canonicalHashV1(policy),
-      catch: (cause) =>
-        operationalError(
-          'strategy',
-          'paper-candidate-policy',
-          'source-controlled OBSERVE risk policy canonicalization failed',
-          cause,
-        ),
-    }),
+    canonicalHashV1Result(policy),
+    Result.mapError((cause) =>
+      operationalError(
+        'strategy',
+        'paper-candidate-policy',
+        'source-controlled OBSERVE risk policy canonicalization failed',
+        cause,
+      ),
+    ),
     Effect.fromResult,
   )
 

--- a/services/bayn/src/hash.test.ts
+++ b/services/bayn/src/hash.test.ts
@@ -3,8 +3,10 @@ import { Result } from 'effect'
 
 import {
   canonicalHashV1,
+  canonicalHashV1OrThrow,
   canonicalHashV1Result,
   canonicalJsonV1,
+  canonicalJsonV1OrThrow,
   canonicalJsonV1Result,
   renderCanonicalJsonFailure,
   stableU128,
@@ -18,67 +20,245 @@ const failureOf = <A>(result: Result.Result<A, CanonicalJsonFailure>): Canonical
 }
 
 describe('canonical hashing', () => {
-  test('uses deterministic UTF-16 key order and normalizes negative zero', () => {
-    expect(canonicalJsonV1({ '\u20ac': 1, '\r': 2, a: -0, '\ud83d\ude00': 3 })).toBe('{"\\r":2,"a":0,"€":1,"😀":3}')
-    expect(canonicalJsonV1({ nested: { '2': 2, '10': 1 } })).toBe('{"nested":{"10":1,"2":2}}')
+  test('preserves canonical bytes, UTF-16 key order, negative-zero normalization, and hash identity', () => {
+    const value = {
+      z: [null, true, false, -0, 1.25, 'é', '😀'],
+      a: { '2': 2, '10': 1 },
+    }
+    const canonical = '{"a":{"10":1,"2":2},"z":[null,true,false,0,1.25,"é","😀"]}'
+    const hash = 'eb5c6929cd35d9590df65fb9db0caf13177df754b1d99e17c8d58e30735486c9'
+
+    expect(canonicalJsonV1Result(value)).toEqual(Result.succeed(canonical))
+    expect(canonicalHashV1Result(value)).toEqual(Result.succeed(hash))
+    expect(canonicalJsonV1(value)).toBe(canonical)
+    expect(canonicalHashV1(value)).toBe(hash)
+    expect(canonicalJsonV1OrThrow(value)).toBe(canonical)
+    expect(canonicalHashV1OrThrow(value)).toBe(hash)
     expect(canonicalHashV1({ b: 2, a: 1 })).toBe(canonicalHashV1({ a: 1, b: 2 }))
   })
 
-  test('rejects values that JSON would silently discard or coerce', () => {
-    expect(() => canonicalJsonV1({ missing: undefined })).toThrow('non-JSON undefined')
-    expect(() => canonicalJsonV1({ invalid: Number.NaN })).toThrow('non-finite number')
-    expect(() => canonicalJsonV1({ invalid: Number.POSITIVE_INFINITY })).toThrow('non-finite number')
-    expect(() => canonicalJsonV1({ invalid: 1n })).toThrow('non-JSON bigint')
-    expect(() => canonicalJsonV1(new Date('2026-01-01T00:00:00.000Z'))).toThrow('plain JSON objects')
+  test('preserves valid Unicode exactly and rejects invalid value or key surrogates as data', () => {
+    expect(canonicalJsonV1Result({ emoji: '\ud83d\ude00', composed: 'é', decomposed: 'e\u0301' })).toEqual(
+      Result.succeed('{"composed":"é","decomposed":"é","emoji":"😀"}'),
+    )
+    expect(canonicalHashV1({ value: 'é' })).not.toBe(canonicalHashV1({ value: 'e\u0301' }))
+
+    expect(failureOf(canonicalJsonV1Result({ invalid: '\ud800' }))).toEqual({
+      _tag: 'CanonicalJsonFailure',
+      path: '$.invalid',
+      reason: 'invalid-unicode-surrogate',
+      actualType: 'string',
+    })
+    expect(failureOf(canonicalJsonV1Result({ invalid: '\udc00' }))).toEqual({
+      _tag: 'CanonicalJsonFailure',
+      path: '$.invalid',
+      reason: 'invalid-unicode-surrogate',
+      actualType: 'string',
+    })
+    expect(failureOf(canonicalJsonV1Result({ ['\ud800']: true }))).toEqual({
+      _tag: 'CanonicalJsonFailure',
+      path: '$',
+      reason: 'invalid-unicode-key',
+      actualType: 'string',
+    })
+  })
+
+  test('rejects non-finite numbers and non-JSON values without throwing', () => {
+    const cases = [
+      [{ invalid: Number.NaN }, '$.invalid', 'non-finite-number', 'number'],
+      [{ invalid: Number.POSITIVE_INFINITY }, '$.invalid', 'non-finite-number', 'number'],
+      [{ invalid: Number.NEGATIVE_INFINITY }, '$.invalid', 'non-finite-number', 'number'],
+      [{ missing: undefined }, '$.missing', 'non-json-type', 'undefined'],
+      [{ invalid: 1n }, '$.invalid', 'non-json-type', 'bigint'],
+      [{ invalid: Symbol('value') }, '$.invalid', 'non-json-type', 'symbol'],
+      [{ invalid: () => null }, '$.invalid', 'non-json-type', 'function'],
+    ] as const
+
+    for (const [value, path, reason, actualType] of cases) {
+      const run = () => canonicalJsonV1Result(value)
+      expect(run).not.toThrow()
+      expect(failureOf(run())).toEqual({
+        _tag: 'CanonicalJsonFailure',
+        path,
+        reason,
+        actualType,
+      })
+    }
+
+    expect(renderCanonicalJsonFailure(failureOf(canonicalJsonV1Result({ invalid: Number.NaN })))).toBe(
+      'non-finite-number at $.invalid (number)',
+    )
+  })
+
+  test('rejects cycles while accepting repeated non-cyclic references', () => {
+    const cyclicObject: Record<string, unknown> = {}
+    cyclicObject.self = cyclicObject
+    expect(failureOf(canonicalJsonV1Result(cyclicObject))).toEqual({
+      _tag: 'CanonicalJsonFailure',
+      path: '$.self',
+      reason: 'cycle',
+      actualType: 'object',
+    })
+
+    const cyclicArray: unknown[] = []
+    cyclicArray.push(cyclicArray)
+    expect(failureOf(canonicalJsonV1Result(cyclicArray))).toEqual({
+      _tag: 'CanonicalJsonFailure',
+      path: '$[0]',
+      reason: 'cycle',
+      actualType: 'array',
+    })
+
+    const shared = { value: 1 }
+    expect(canonicalJsonV1Result({ left: shared, right: shared })).toEqual(
+      Result.succeed('{"left":{"value":1},"right":{"value":1}}'),
+    )
+  })
+
+  test('rejects sparse, custom, symbolic, and accessor arrays', () => {
     const sparse: unknown[] = []
     sparse.length = 1
-    expect(() => canonicalJsonV1(sparse)).toThrow('dense array')
 
+    const enumerableCustom = [1]
+    Object.defineProperty(enumerableCustom, 'custom', { enumerable: true, value: 2 })
+
+    const hiddenCustom = [1]
+    Object.defineProperty(hiddenCustom, 'custom', { enumerable: false, value: 2 })
+
+    const symbolic = [1]
+    Object.defineProperty(symbolic, Symbol('custom'), { enumerable: true, value: 2 })
+
+    let getterCalls = 0
     const accessor = [1]
-    Object.defineProperty(accessor, '0', { enumerable: true, get: () => 1 })
-    expect(() => canonicalJsonV1(accessor)).toThrow('enumerable data property')
+    Object.defineProperty(accessor, '0', {
+      enumerable: true,
+      get: () => {
+        getterCalls += 1
+        return 1
+      },
+    })
+
+    for (const value of [sparse, enumerableCustom, hiddenCustom, symbolic]) {
+      expect(failureOf(canonicalJsonV1Result(value))).toEqual({
+        _tag: 'CanonicalJsonFailure',
+        path: '$',
+        reason: 'non-dense-array',
+        actualType: 'array',
+      })
+    }
+    expect(failureOf(canonicalJsonV1Result(accessor))).toEqual({
+      _tag: 'CanonicalJsonFailure',
+      path: '$[0]',
+      reason: 'non-data-property',
+      actualType: 'array-property',
+    })
+    expect(getterCalls).toBe(0)
+  })
+
+  test('accepts plain data descriptors and rejects object accessors, hidden properties, symbols, and prototypes', () => {
+    const data = Object.create(null) as Record<string, unknown>
+    Object.defineProperty(data, 'value', {
+      configurable: false,
+      enumerable: true,
+      writable: false,
+      value: 1,
+    })
+    expect(canonicalJsonV1Result(data)).toEqual(Result.succeed('{"value":1}'))
+
+    let getterCalls = 0
+    const accessor = {}
+    Object.defineProperty(accessor, 'value', {
+      enumerable: true,
+      get: () => {
+        getterCalls += 1
+        return 1
+      },
+    })
+    expect(failureOf(canonicalJsonV1Result(accessor))).toEqual({
+      _tag: 'CanonicalJsonFailure',
+      path: '$.value',
+      reason: 'non-data-property',
+      actualType: 'object-property',
+    })
+    expect(getterCalls).toBe(0)
+
+    const hidden = {}
+    Object.defineProperty(hidden, 'value', { enumerable: false, value: 1 })
+    expect(failureOf(canonicalJsonV1Result(hidden))).toEqual({
+      _tag: 'CanonicalJsonFailure',
+      path: '$.value',
+      reason: 'non-data-property',
+      actualType: 'object-property',
+    })
+
+    const symbolic = { value: 1 }
+    Object.defineProperty(symbolic, Symbol('custom'), { enumerable: false, value: 2 })
+    expect(failureOf(canonicalJsonV1Result(symbolic))).toEqual({
+      _tag: 'CanonicalJsonFailure',
+      path: '$',
+      reason: 'symbol-key',
+      actualType: 'object',
+    })
+
+    expect(failureOf(canonicalJsonV1Result(new Date('2026-01-01T00:00:00.000Z')))).toEqual({
+      _tag: 'CanonicalJsonFailure',
+      path: '$',
+      reason: 'non-plain-object',
+      actualType: 'object',
+    })
+  })
+
+  test('contains throwing reflection traps as fact-bearing Result failures', () => {
+    const revoked = Proxy.revocable({}, {})
+    revoked.revoke()
+    const classify = () => canonicalJsonV1Result(revoked.proxy)
+    expect(classify).not.toThrow()
+    expect(failureOf(classify())).toMatchObject({
+      _tag: 'CanonicalJsonFailure',
+      path: '$',
+      reason: 'introspection-failed',
+      actualType: 'object',
+      operation: 'array-classification',
+      cause: expect.any(TypeError),
+    })
+
+    const ownKeysCause = new Error('own keys unavailable')
+    const hostile = new Proxy(
+      {},
+      {
+        ownKeys: () => {
+          throw ownKeysCause
+        },
+      },
+    )
+    const ownKeysFailure = failureOf(canonicalJsonV1Result(hostile))
+    expect(ownKeysFailure).toMatchObject({
+      _tag: 'CanonicalJsonFailure',
+      path: '$',
+      reason: 'introspection-failed',
+      actualType: 'object',
+      operation: 'own-keys',
+    })
+    expect(ownKeysFailure.reason === 'introspection-failed' && ownKeysFailure.cause).toBe(ownKeysCause)
+    expect(renderCanonicalJsonFailure(ownKeysFailure)).toBe('introspection-failed at $ (object; own-keys)')
+  })
+
+  test('keeps the throwing compatibility aliases behaviorally explicit', () => {
+    expect(() => canonicalJsonV1({ missing: undefined })).toThrow('non-JSON undefined')
+    expect(() => canonicalJsonV1({ invalid: Number.NaN })).toThrow('non-finite number')
+    expect(() => canonicalJsonV1({ invalid: 1n })).toThrow('non-JSON bigint')
+    expect(() => canonicalJsonV1(new Date('2026-01-01T00:00:00.000Z'))).toThrow('plain JSON objects')
 
     const cyclic: Record<string, unknown> = {}
     cyclic.self = cyclic
     expect(() => canonicalJsonV1(cyclic)).toThrow('cycle')
   })
 
-  test('returns canonical output and precise failures as values', () => {
-    const input = { '\u20ac': 1, '\r': 2, a: -0, nested: ['value', true, null] }
-    expect(canonicalJsonV1Result(input)).toEqual(Result.succeed(canonicalJsonV1(input)))
-    expect(canonicalHashV1Result(input)).toEqual(Result.succeed(canonicalHashV1(input)))
-
-    expect(failureOf(canonicalJsonV1Result({ missing: undefined }))).toEqual({
-      _tag: 'CanonicalJsonFailure',
-      path: '$.missing',
-      reason: 'non-json-type',
-      actualType: 'undefined',
-    })
-    expect(failureOf(canonicalJsonV1Result({ invalid: Number.NaN }))).toEqual({
-      _tag: 'CanonicalJsonFailure',
-      path: '$.invalid',
-      reason: 'non-finite-number',
-      actualType: 'number',
-    })
-    expect(renderCanonicalJsonFailure(failureOf(canonicalJsonV1Result({ invalid: Number.NaN })))).toBe(
-      'non-finite-number at $.invalid (number)',
-    )
-
-    const cyclic: Record<string, unknown> = {}
-    cyclic.self = cyclic
-    expect(failureOf(canonicalJsonV1Result(cyclic))).toEqual({
-      _tag: 'CanonicalJsonFailure',
-      path: '$.self',
-      reason: 'cycle',
-      actualType: 'object',
-    })
-  })
-
   test('produces stable non-zero TigerBeetle identifiers', () => {
-    expect(stableU128('run', 'event')).toBe(stableU128('run', 'event'))
+    expect(stableU128('run', 'event')).toBe(54953207663554066615626984220646087740n)
     expect(stableU128('run', 'event')).not.toBe(stableU128('run', 'other'))
     expect(stableU128('run', 'event')).toBeGreaterThan(0n)
-    expect(stableU64('run')).toBeGreaterThan(0n)
+    expect(stableU64('run')).toBe(6267951632907394021n)
     expect(stableU64('run')).toBeLessThan(1n << 64n)
   })
 })

--- a/services/bayn/src/hash.ts
+++ b/services/bayn/src/hash.ts
@@ -6,91 +6,227 @@ export const sha256 = (value: string): string => createHash('sha256').update(val
 
 const compareUtf16 = (left: string, right: string): number => (left < right ? -1 : left > right ? 1 : 0)
 
-export interface CanonicalJsonFailure {
+type CanonicalJsonValidationReason =
+  | 'cycle'
+  | 'invalid-unicode-key'
+  | 'invalid-unicode-surrogate'
+  | 'non-data-property'
+  | 'non-dense-array'
+  | 'non-finite-number'
+  | 'non-json-type'
+  | 'non-plain-object'
+  | 'symbol-key'
+
+type CanonicalJsonIntrospectionOperation =
+  | 'array-classification'
+  | 'array-length'
+  | 'enumerable-own-keys'
+  | 'own-keys'
+  | 'property-descriptor'
+  | 'prototype'
+
+interface CanonicalJsonValidationFailure {
   readonly _tag: 'CanonicalJsonFailure'
   readonly path: string
-  readonly reason:
-    | 'cycle'
-    | 'invalid-unicode-key'
-    | 'invalid-unicode-surrogate'
-    | 'non-data-property'
-    | 'non-dense-array'
-    | 'non-finite-number'
-    | 'non-json-type'
-    | 'non-plain-object'
-    | 'symbol-key'
+  readonly reason: CanonicalJsonValidationReason
   readonly actualType: string
 }
 
-export const renderCanonicalJsonFailure = (failure: CanonicalJsonFailure): string =>
-  `${failure.reason} at ${failure.path} (${failure.actualType})`
+interface CanonicalJsonIntrospectionFailure {
+  readonly _tag: 'CanonicalJsonFailure'
+  readonly path: string
+  readonly reason: 'introspection-failed'
+  readonly actualType: 'array' | 'object'
+  readonly operation: CanonicalJsonIntrospectionOperation
+  readonly cause: unknown
+}
 
-const canonicalFailure = (
+interface CanonicalJsonHashFailure {
+  readonly _tag: 'CanonicalJsonFailure'
+  readonly path: '$'
+  readonly reason: 'sha256-failed'
+  readonly actualType: 'canonical-json'
+  readonly operation: 'sha256'
+  readonly cause: unknown
+}
+
+export type CanonicalJsonFailure =
+  | CanonicalJsonValidationFailure
+  | CanonicalJsonIntrospectionFailure
+  | CanonicalJsonHashFailure
+
+export type CanonicalHashFailure = CanonicalJsonFailure
+
+export const renderCanonicalJsonFailure = (failure: CanonicalJsonFailure): string => {
+  switch (failure.reason) {
+    case 'introspection-failed':
+    case 'sha256-failed':
+      return `${failure.reason} at ${failure.path} (${failure.actualType}; ${failure.operation})`
+    default:
+      return `${failure.reason} at ${failure.path} (${failure.actualType})`
+  }
+}
+
+const validationFailure = (
   path: string,
-  reason: CanonicalJsonFailure['reason'],
+  reason: CanonicalJsonValidationReason,
   actualType: string,
 ): Result.Result<never, CanonicalJsonFailure> => Result.fail({ _tag: 'CanonicalJsonFailure', path, reason, actualType })
+
+const inspect = <A>(
+  path: string,
+  actualType: CanonicalJsonIntrospectionFailure['actualType'],
+  operation: CanonicalJsonIntrospectionOperation,
+  evaluate: () => A,
+): Result.Result<A, CanonicalJsonFailure> =>
+  Result.try({
+    try: evaluate,
+    catch: (cause): CanonicalJsonIntrospectionFailure => ({
+      _tag: 'CanonicalJsonFailure',
+      path,
+      reason: 'introspection-failed',
+      actualType,
+      operation,
+      cause,
+    }),
+  })
+
+const hasInvalidUnicodeSurrogate = (value: string): boolean => {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index)
+    if (code >= 0xd800 && code <= 0xdbff) {
+      const next = value.charCodeAt(index + 1)
+      if (index + 1 >= value.length || next < 0xdc00 || next > 0xdfff) return true
+      index += 1
+    } else if (code >= 0xdc00 && code <= 0xdfff) {
+      return true
+    }
+  }
+  return false
+}
+
+const arrayLength = (value: readonly unknown[], path: string): Result.Result<number, CanonicalJsonFailure> =>
+  inspect(path, 'array', 'array-length', () => value.length)
+
+const enumerableArrayKeys = (
+  value: readonly unknown[],
+  path: string,
+): Result.Result<readonly string[], CanonicalJsonFailure> =>
+  inspect(path, 'array', 'enumerable-own-keys', () => Object.keys(value))
+
+const arrayOwnKeys = (
+  value: readonly unknown[],
+  path: string,
+): Result.Result<readonly PropertyKey[], CanonicalJsonFailure> =>
+  inspect(path, 'array', 'own-keys', () => Reflect.ownKeys(value))
+
+const dataProperty = (
+  value: object,
+  key: PropertyKey,
+  path: string,
+  actualType: CanonicalJsonIntrospectionFailure['actualType'],
+): Result.Result<unknown, CanonicalJsonFailure> =>
+  pipe(
+    inspect(path, actualType, 'property-descriptor', () => Object.getOwnPropertyDescriptor(value, key)),
+    Result.flatMap((descriptor) =>
+      descriptor?.enumerable === true && 'value' in descriptor
+        ? Result.succeed(descriptor.value)
+        : validationFailure(path, 'non-data-property', `${actualType}-property`),
+    ),
+  )
 
 const serializeArrayResult = (
   value: readonly unknown[],
   ancestors: readonly object[],
   path: string,
 ): Result.Result<string, CanonicalJsonFailure> => {
-  if (ancestors.includes(value)) return canonicalFailure(path, 'cycle', 'array')
-  const keys = Object.keys(value)
-  if (
-    keys.length !== value.length ||
-    keys.some((key, index) => key !== String(index)) ||
-    Reflect.ownKeys(value).some(
-      (key) =>
-        key !== 'length' && (typeof key !== 'string' || !/^(?:0|[1-9]\d*)$/.test(key) || Number(key) >= value.length),
-    )
-  ) {
-    return canonicalFailure(path, 'non-dense-array', 'array')
-  }
+  if (ancestors.includes(value)) return validationFailure(path, 'cycle', 'array')
+
   return pipe(
-    Result.all(
-      keys.map((key, index) => {
-        const descriptor = Object.getOwnPropertyDescriptor(value, key)
-        return descriptor?.enumerable === true && 'value' in descriptor
-          ? serializeCanonicalValueResult(descriptor.value, [...ancestors, value], `${path}[${index}]`)
-          : canonicalFailure(`${path}[${key}]`, 'non-data-property', 'array-property')
-      }),
-    ),
-    Result.map((values) => `[${values.join(',')}]`),
+    Result.all({
+      length: arrayLength(value, path),
+      enumerableKeys: enumerableArrayKeys(value, path),
+      ownKeys: arrayOwnKeys(value, path),
+    }),
+    Result.flatMap(({ enumerableKeys, length, ownKeys }) => {
+      const invalidShape =
+        !Number.isSafeInteger(length) ||
+        length < 0 ||
+        enumerableKeys.length !== length ||
+        enumerableKeys.some((key, index) => key !== String(index)) ||
+        ownKeys.some(
+          (key) =>
+            key !== 'length' && (typeof key !== 'string' || !/^(?:0|[1-9]\d*)$/.test(key) || Number(key) >= length),
+        )
+
+      if (invalidShape) return validationFailure(path, 'non-dense-array', 'array')
+
+      const nextAncestors = [...ancestors, value]
+      return pipe(
+        Result.all(
+          enumerableKeys.map((key, index) =>
+            pipe(
+              dataProperty(value, key, `${path}[${key}]`, 'array'),
+              Result.flatMap((nested) => serializeCanonicalValueResult(nested, nextAncestors, `${path}[${index}]`)),
+            ),
+          ),
+        ),
+        Result.map((values) => `[${values.join(',')}]`),
+      )
+    }),
   )
 }
+
+const objectPrototype = (value: object, path: string): Result.Result<object | null, CanonicalJsonFailure> =>
+  inspect(path, 'object', 'prototype', () => Object.getPrototypeOf(value))
+
+const objectOwnKeys = (value: object, path: string): Result.Result<readonly PropertyKey[], CanonicalJsonFailure> =>
+  inspect(path, 'object', 'own-keys', () => Reflect.ownKeys(value))
 
 const serializeObjectResult = (
   value: object,
   ancestors: readonly object[],
   path: string,
 ): Result.Result<string, CanonicalJsonFailure> => {
-  if (ancestors.includes(value)) return canonicalFailure(path, 'cycle', 'object')
-  const prototype = Object.getPrototypeOf(value)
-  if (prototype !== Object.prototype && prototype !== null) {
-    return canonicalFailure(path, 'non-plain-object', prototype?.constructor?.name ?? 'object')
-  }
-  const keys = Reflect.ownKeys(value)
-  if (keys.some((key) => typeof key !== 'string')) {
-    return canonicalFailure(path, 'symbol-key', 'object')
-  }
+  if (ancestors.includes(value)) return validationFailure(path, 'cycle', 'object')
+
   return pipe(
-    Result.all(
-      (keys as string[]).sort(compareUtf16).map((key) => {
-        if (!key.isWellFormed()) return canonicalFailure(path, 'invalid-unicode-key', 'string')
-        const descriptor = Object.getOwnPropertyDescriptor(value, key)
-        return descriptor?.enumerable === true && 'value' in descriptor
-          ? pipe(
-              serializeCanonicalValueResult(descriptor.value, [...ancestors, value], `${path}.${key}`),
-              Result.map((nested) => `${JSON.stringify(key)}:${nested}`),
-            )
-          : canonicalFailure(`${path}.${key}`, 'non-data-property', 'object-property')
-      }),
+    objectPrototype(value, path),
+    Result.flatMap((prototype) =>
+      prototype === Object.prototype || prototype === null
+        ? objectOwnKeys(value, path)
+        : validationFailure(path, 'non-plain-object', 'object'),
     ),
-    Result.map((entries) => `{${entries.join(',')}}`),
+    Result.flatMap((keys) => {
+      if (keys.some((key) => typeof key !== 'string')) {
+        return validationFailure(path, 'symbol-key', 'object')
+      }
+
+      const nextAncestors = [...ancestors, value]
+      return pipe(
+        Result.all(
+          (keys as readonly string[])
+            .slice()
+            .sort(compareUtf16)
+            .map((key) => {
+              if (hasInvalidUnicodeSurrogate(key)) {
+                return validationFailure(path, 'invalid-unicode-key', 'string')
+              }
+              return pipe(
+                dataProperty(value, key, `${path}.${key}`, 'object'),
+                Result.flatMap((nested) => serializeCanonicalValueResult(nested, nextAncestors, `${path}.${key}`)),
+                Result.map((nested) => `${JSON.stringify(key)}:${nested}`),
+              )
+            }),
+        ),
+        Result.map((entries) => `{${entries.join(',')}}`),
+      )
+    }),
   )
 }
+
+const classifyArray = (value: object, path: string): Result.Result<boolean, CanonicalJsonFailure> =>
+  inspect(path, 'object', 'array-classification', () => Array.isArray(value))
 
 const serializeCanonicalValueResult = (
   value: unknown,
@@ -100,101 +236,83 @@ const serializeCanonicalValueResult = (
   if (value === null) return Result.succeed('null')
   if (typeof value === 'boolean') return Result.succeed(value ? 'true' : 'false')
   if (typeof value === 'string') {
-    return value.isWellFormed()
-      ? Result.succeed(JSON.stringify(value))
-      : canonicalFailure(path, 'invalid-unicode-surrogate', 'string')
+    return hasInvalidUnicodeSurrogate(value)
+      ? validationFailure(path, 'invalid-unicode-surrogate', 'string')
+      : Result.succeed(JSON.stringify(value))
   }
   if (typeof value === 'number') {
     return Number.isFinite(value)
       ? Result.succeed(JSON.stringify(Object.is(value, -0) ? 0 : value))
-      : canonicalFailure(path, 'non-finite-number', 'number')
+      : validationFailure(path, 'non-finite-number', 'number')
   }
-  if (Array.isArray(value)) return serializeArrayResult(value, ancestors, path)
-  if (typeof value === 'object') return serializeObjectResult(value, ancestors, path)
-  return canonicalFailure(path, 'non-json-type', typeof value)
+  if (typeof value !== 'object') return validationFailure(path, 'non-json-type', typeof value)
+
+  return pipe(
+    classifyArray(value, path),
+    Result.flatMap((isArray) =>
+      isArray
+        ? serializeArrayResult(value as readonly unknown[], ancestors, path)
+        : serializeObjectResult(value, ancestors, path),
+    ),
+  )
 }
 
 export const canonicalJsonV1Result = (value: unknown): Result.Result<string, CanonicalJsonFailure> =>
   serializeCanonicalValueResult(value, [], '$')
 
-export const canonicalHashV1Result = (value: unknown): Result.Result<string, CanonicalJsonFailure> =>
-  pipe(canonicalJsonV1Result(value), Result.map(sha256))
+const hashCanonicalJsonResult = (canonicalJson: string): Result.Result<string, CanonicalJsonFailure> =>
+  Result.try({
+    try: () => sha256(canonicalJson),
+    catch: (cause): CanonicalJsonHashFailure => ({
+      _tag: 'CanonicalJsonFailure',
+      path: '$',
+      reason: 'sha256-failed',
+      actualType: 'canonical-json',
+      operation: 'sha256',
+      cause,
+    }),
+  })
 
-const serializeCanonicalValue = (value: unknown, ancestors: Set<object>, path: string): string => {
-  if (value === null) return 'null'
-  if (typeof value === 'boolean') return value ? 'true' : 'false'
-  if (typeof value === 'string') {
-    if (!value.isWellFormed()) throw new TypeError(`${path} contains an invalid Unicode surrogate`)
-    return JSON.stringify(value)
+export const canonicalHashV1Result = (value: unknown): Result.Result<string, CanonicalHashFailure> =>
+  pipe(canonicalJsonV1Result(value), Result.flatMap(hashCanonicalJsonResult))
+
+const compatibilityError = (failure: CanonicalJsonFailure): unknown => {
+  switch (failure.reason) {
+    case 'cycle':
+      return new TypeError(`${failure.path} contains a cycle`)
+    case 'invalid-unicode-key':
+      return new TypeError(`${failure.path} contains an invalid Unicode key`)
+    case 'invalid-unicode-surrogate':
+      return new TypeError(`${failure.path} contains an invalid Unicode surrogate`)
+    case 'non-data-property':
+      return new TypeError(`${failure.path} must be an enumerable data property`)
+    case 'non-dense-array':
+      return new TypeError(`${failure.path} must be a dense array without custom properties`)
+    case 'non-finite-number':
+      return new TypeError(`${failure.path} contains a non-finite number`)
+    case 'non-json-type':
+      return new TypeError(`${failure.path} contains a non-JSON ${failure.actualType} value`)
+    case 'non-plain-object':
+      return new TypeError(`${failure.path} must contain only plain JSON objects`)
+    case 'symbol-key':
+      return new TypeError(`${failure.path} contains a symbol key`)
+    case 'introspection-failed':
+    case 'sha256-failed':
+      return failure.cause
   }
-  if (typeof value === 'number') {
-    if (!Number.isFinite(value)) throw new TypeError(`${path} contains a non-finite number`)
-    return JSON.stringify(Object.is(value, -0) ? 0 : value)
-  }
-  if (Array.isArray(value)) {
-    if (ancestors.has(value)) throw new TypeError(`${path} contains a cycle`)
-    const keys = Object.keys(value)
-    if (keys.length !== value.length || keys.some((key, index) => key !== String(index))) {
-      throw new TypeError(`${path} must be a dense array without custom properties`)
-    }
-    if (
-      Reflect.ownKeys(value).some(
-        (key) =>
-          key !== 'length' && (typeof key !== 'string' || !/^(?:0|[1-9]\d*)$/.test(key) || Number(key) >= value.length),
-      )
-    ) {
-      throw new TypeError(`${path} must be a dense array without custom properties`)
-    }
-    const values = keys.map((key) => {
-      const descriptor = Object.getOwnPropertyDescriptor(value, key)
-      if (!descriptor?.enumerable || !('value' in descriptor)) {
-        throw new TypeError(`${path}[${key}] must be an enumerable data property`)
-      }
-      return descriptor.value
-    })
-    ancestors.add(value)
-    try {
-      return `[${values
-        .map((nested, index) => serializeCanonicalValue(nested, ancestors, `${path}[${index}]`))
-        .join(',')}]`
-    } finally {
-      ancestors.delete(value)
-    }
-  }
-  if (typeof value === 'object') {
-    if (ancestors.has(value)) throw new TypeError(`${path} contains a cycle`)
-    const prototype = Object.getPrototypeOf(value)
-    if (prototype !== Object.prototype && prototype !== null) {
-      throw new TypeError(`${path} must contain only plain JSON objects`)
-    }
-    const keys = Reflect.ownKeys(value)
-    if (keys.some((key) => typeof key !== 'string')) throw new TypeError(`${path} contains a symbol key`)
-    const entries = (keys as string[]).map((key) => {
-      if (!key.isWellFormed()) throw new TypeError(`${path} contains an invalid Unicode key`)
-      const descriptor = Object.getOwnPropertyDescriptor(value, key)
-      if (!descriptor?.enumerable || !('value' in descriptor)) {
-        throw new TypeError(`${path}.${key} must be an enumerable data property`)
-      }
-      return [key, descriptor.value] as const
-    })
-    ancestors.add(value)
-    try {
-      return `{${entries
-        .sort(([left], [right]) => compareUtf16(left, right))
-        .map(
-          ([key, nested]) => `${JSON.stringify(key)}:${serializeCanonicalValue(nested, ancestors, `${path}.${key}`)}`,
-        )
-        .join(',')}}`
-    } finally {
-      ancestors.delete(value)
-    }
-  }
-  throw new TypeError(`${path} contains a non-JSON ${typeof value} value`)
 }
 
-export const canonicalJsonV1 = (value: unknown): string => serializeCanonicalValue(value, new Set(), '$')
+export const canonicalJsonV1OrThrow = (value: unknown): string =>
+  pipe(canonicalJsonV1Result(value), Result.getOrThrowWith(compatibilityError))
 
-export const canonicalHashV1 = (value: unknown): string => sha256(canonicalJsonV1(value))
+export const canonicalHashV1OrThrow = (value: unknown): string =>
+  pipe(canonicalHashV1Result(value), Result.getOrThrowWith(compatibilityError))
+
+/** @deprecated Use canonicalJsonV1Result. This alias remains while callers migrate to total canonicalization. */
+export const canonicalJsonV1 = canonicalJsonV1OrThrow
+
+/** @deprecated Use canonicalHashV1Result. This alias remains while callers migrate to total canonicalization. */
+export const canonicalHashV1 = canonicalHashV1OrThrow
 
 export const stableU128 = (...parts: readonly string[]): bigint => {
   const bytes = createHash('sha256').update(parts.join('\u001f')).digest().subarray(0, 16)


### PR DESCRIPTION
## Summary

- make canonical JSON and SHA-256 construction total through a closed, fact-bearing `CanonicalJsonFailure` Result algebra
- contain hostile reflection and proxy failures without invoking accessors, while retaining clearly named deprecated throwing compatibility adapters
- migrate runtime identity and OBSERVE policy hashing to total callers while preserving exact canonical bytes, runtime hashes, and stable TigerBeetle identifiers

## Related Issues

None

## Testing

- `bun test services/bayn/src/hash.test.ts` — 9 passed, 0 failed, 81 assertions
- `node services/bayn/node_modules/typescript/bin/tsc --project services/bayn/tsconfig.json --noEmit --pretty false` — passed
- `bun services/bayn/node_modules/@effect/tsgo/dist/effect-tsgo.js diagnostics --project services/bayn/tsconfig.json --format text --severity error` — 0 errors, 0 warnings
- `node node_modules/oxfmt/bin/oxfmt --check services/bayn/src` — passed
- `node node_modules/oxlint/bin/oxlint --config .oxlintrc.json services/bayn` — 0 errors, 0 warnings
- `node node_modules/oxlint/bin/oxlint --config .oxlintrc.json --type-aware --tsconfig services/bayn/tsconfig.json services/bayn` — 0 errors, 0 warnings
- `bun test` from `services/bayn` — 661 passed, 119 skipped integration cases, 0 failed
- `bun build src/index.ts --target=node --external tigerbeetle-node --outdir=/tmp/bayn-fp-hash-dist` — passed
- `bun test packages/scripts/src/bayn` — 20 passed, 0 failed
- `BAYN_TEST_POSTGRES_URL=postgresql://bayn:bayn@127.0.0.1:55432/bayn_test bun test services/bayn/src/db/evidence-store.integration.test.ts` — 63 passed, 0 failed
- `BAYN_TEST_POSTGRES_URL=postgresql://bayn:bayn@127.0.0.1:55432/bayn_test bun test services/bayn/src/db/paper-store.integration.test.ts` — 30 passed, 0 failed
- `BAYN_TEST_POSTGRES_URL=postgresql://bayn:bayn@127.0.0.1:55432/bayn_test bun test services/bayn/src/db/cycle-store/integration.test.ts` — 13 passed, 0 failed
- deterministic differential against pre-change `hash.ts` — 1,000 generated valid canonical values preserved byte-for-byte and hash-for-hash

## Breaking Changes

None. `canonicalJsonV1` and `canonicalHashV1` remain as deprecated compatibility aliases while callers migrate to the total Result APIs.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; this is a pure TypeScript domain change.
- [x] Documentation and release notes are not required; the compatibility surface remains available and is marked deprecated.
