### PR TITLE
refactor(bayn): model total ledger planning

### DIFF
--- a/services/bayn/src/ledger-plan.test.ts
+++ b/services/bayn/src/ledger-plan.test.ts
@@ -366,6 +366,67 @@ describe('ledger plan Result algebra', () => {
     })
   })
 
+  test('rejects hostile scalar identities before hashing or rendering can coerce them', () => {
+    const result = evaluationResult()
+    const fill = firstFill(result, 'buy')
+    let runIdCoercions = 0
+    const hostileRunId = {
+      [Symbol.toPrimitive]: () => {
+        runIdCoercions += 1
+        throw new TypeError('ledger-plan run identity coercion is unavailable')
+      },
+    }
+
+    expect(
+      assertLedgerPlanFailure(buildLedgerPlan({ ...result, runId: hostileRunId as unknown as string }, ledger)),
+    ).toEqual({
+      kind: 'input-value-invalid',
+      field: 'runId',
+      expected: 'string',
+      actualType: 'object',
+    })
+    expect(runIdCoercions).toBe(0)
+
+    expect(
+      assertLedgerPlanFailure(
+        buildLedgerPlan({ ...result, events: [{ ...fill, id: Symbol('fill-id') as unknown as string }] }, ledger),
+      ),
+    ).toEqual({
+      kind: 'input-value-invalid',
+      field: 'fill.id',
+      expected: 'string',
+      actualType: 'symbol',
+      index: 0,
+      eventKind: 'fill',
+    })
+
+    expect(
+      assertLedgerPlanFailure(
+        buildLedgerPlan(
+          {
+            ...result,
+            inputManifest: {
+              ...result.inputManifest,
+              symbols: [
+                {
+                  ...result.inputManifest.symbols[0],
+                  symbol: Symbol('inventory-symbol') as unknown as string,
+                },
+              ],
+            },
+          },
+          ledger,
+        ),
+      ),
+    ).toEqual({
+      kind: 'input-value-invalid',
+      field: 'inputManifest.symbol',
+      expected: 'string',
+      actualType: 'symbol',
+      index: 0,
+    })
+  })
+
   test('preserves exact TigerBeetle identity, ordering, amounts, flags, and replay hash', () => {
     const result = evaluationResult()
     const first = assertSuccess(buildLedgerPlan(result, ledger))

--- a/services/bayn/src/ledger-plan.test.ts
+++ b/services/bayn/src/ledger-plan.test.ts
@@ -2,20 +2,25 @@ import assert from 'node:assert/strict'
 
 import { describe, expect, test } from 'bun:test'
 import { Result } from 'effect'
-import { type Account, type Transfer } from 'tigerbeetle-node'
+import { AccountFlags, type Account, type Transfer } from 'tigerbeetle-node'
 
 import {
   AccountCode,
   buildLedgerPlan,
+  hashLedgerPlan,
+  LEDGER_BATCH_MAX,
   preflightTransfers,
   reconcileLedgerPlan,
   TransferCode,
   validatePersistedRunEvidence,
+  type LedgerInput,
   type LedgerPlan,
-  type LedgerValidationError,
+  type LedgerPlanFailureDetail,
+  LedgerValidationError,
 } from './ledger-plan'
 import { evaluateRiskBalancedTrend } from './risk-balanced-trend'
 import { fixtureProtocol, makeSnapshot, makeTestProvenance } from './test-fixtures'
+import type { CashYieldEvent, FeeEvent, FillEvent } from './types'
 
 const ledger = 7_001
 
@@ -24,17 +29,36 @@ const assertSuccess = <A, E>(result: Result.Result<A, E>): A => {
   return result.success
 }
 
-const assertFailure = <A>(result: Result.Result<A, LedgerValidationError>): LedgerValidationError => {
+const assertFailure = <A, E>(result: Result.Result<A, E>): E => {
   assert(Result.isFailure(result), 'ledger plan decision must fail')
   return result.failure
 }
 
-const evaluationPlan = () => {
+const assertLedgerPlanFailure = <A>(result: Result.Result<A, LedgerValidationError>): LedgerPlanFailureDetail => {
+  const failure = assertFailure(result)
+  expect(failure).toBeInstanceOf(LedgerValidationError)
+  assert('detail' in failure, 'ledger plan failure must retain its closed detail')
+  return failure.detail as LedgerPlanFailureDetail
+}
+
+const evaluationResult = (): LedgerInput => {
   const snapshot = makeSnapshot()
-  const result = assertSuccess(
+  return assertSuccess(
     evaluateRiskBalancedTrend(snapshot.bars, snapshot.manifest, fixtureProtocol, makeTestProvenance()),
   )
+}
+
+const evaluationPlan = () => {
+  const result = evaluationResult()
   return { result, plan: assertSuccess(buildLedgerPlan(result, ledger)) }
+}
+
+const firstFill = (result: LedgerInput, side?: FillEvent['side']): FillEvent => {
+  const fill = result.events.find(
+    (event): event is FillEvent => event.kind === 'fill' && (side === undefined || event.side === side),
+  )
+  assert(fill, `evaluation fixture must contain a${side === undefined ? '' : ` ${side}`} fill`)
+  return fill
 }
 
 const materialize = (plan: LedgerPlan): { readonly accounts: Account[]; readonly transfers: Transfer[] } => {
@@ -63,42 +87,299 @@ const materialize = (plan: LedgerPlan): { readonly accounts: Account[]; readonly
 }
 
 describe('ledger plan Result algebra', () => {
-  test('returns a closed build failure without throwing', () => {
-    const { result } = evaluationPlan()
-    const failure = assertFailure(buildLedgerPlan({ ...result, events: [] }, ledger))
+  test('returns a fact-bearing no-fill failure', () => {
+    const result = evaluationResult()
+    const failure = assertLedgerPlanFailure(buildLedgerPlan({ ...result, events: [] }, ledger))
 
-    expect(failure).toMatchObject({
-      operation: 'build-plan',
-      reason: 'ledger-plan-failure',
-      material: { ledger },
+    expect(failure).toEqual({
+      kind: 'no-fill-events',
+      runId: result.runId,
+      eventCount: 0,
     })
-    expect(failure.cause).toBeInstanceOf(Error)
-    expect(String(failure.cause)).toContain('no fill events')
   })
 
-  test('contains hostile cause rendering inside the closed build failure', () => {
-    const { result } = evaluationPlan()
-    const hostileCause = new Proxy(new Error('hidden cause'), {
-      get: (target, property, receiver) => {
-        if (property === 'message') throw new Error('cause message is unavailable')
-        return Reflect.get(target, property, receiver)
+  test('returns exact parsing and sign failures for every planned amount', () => {
+    const result = evaluationResult()
+    const fill = firstFill(result, 'buy')
+    const fee = {
+      kind: 'fee',
+      id: 'e'.repeat(64),
+      sessionDate: fill.sessionDate,
+      commissionMicros: '0',
+      secMicros: '0',
+      tafMicros: '0',
+      catMicros: '0',
+      totalMicros: '1',
+    } satisfies FeeEvent
+    const cashYield = {
+      kind: 'cash-yield',
+      id: 'd'.repeat(64),
+      sessionDate: fill.sessionDate,
+      elapsedDays: 1,
+      annualYieldBps: 100,
+      amountMicros: '1',
+    } satisfies CashYieldEvent
+
+    const cases: readonly {
+      readonly input: LedgerInput
+      readonly expected: Partial<LedgerPlanFailureDetail>
+    }[] = [
+      {
+        input: { ...result, initialCapitalMicros: 'invalid', events: [fill] },
+        expected: {
+          kind: 'amount-parse-failed',
+          field: 'initialCapitalMicros',
+          value: 'invalid',
+        },
+      },
+      {
+        input: { ...result, initialCapitalMicros: '0', events: [fill] },
+        expected: { kind: 'initial-capital-not-positive', value: 0n },
+      },
+      {
+        input: { ...result, initialCapitalMicros: '-1', events: [fill] },
+        expected: { kind: 'initial-capital-not-positive', value: -1n },
+      },
+      {
+        input: { ...result, events: [{ ...fill, notionalMicros: 'invalid' }] },
+        expected: {
+          kind: 'amount-parse-failed',
+          field: 'fill.notionalMicros',
+          value: 'invalid',
+          eventId: fill.id,
+        },
+      },
+      {
+        input: { ...result, events: [{ ...fill, notionalMicros: '-1' }] },
+        expected: {
+          kind: 'negative-amount',
+          field: 'fill.notionalMicros',
+          value: -1n,
+          eventId: fill.id,
+        },
+      },
+      {
+        input: { ...result, events: [{ ...fill, costBasisMicros: 'invalid' }] },
+        expected: {
+          kind: 'amount-parse-failed',
+          field: 'fill.costBasisMicros',
+          value: 'invalid',
+          eventId: fill.id,
+        },
+      },
+      {
+        input: { ...result, events: [{ ...fill, costBasisMicros: '-1' }] },
+        expected: {
+          kind: 'negative-amount',
+          field: 'fill.costBasisMicros',
+          value: -1n,
+          eventId: fill.id,
+        },
+      },
+      {
+        input: { ...result, events: [fill, { ...fee, totalMicros: 'invalid' }] },
+        expected: {
+          kind: 'amount-parse-failed',
+          field: 'fee.totalMicros',
+          value: 'invalid',
+          eventId: fee.id,
+        },
+      },
+      {
+        input: { ...result, events: [fill, { ...fee, totalMicros: '-1' }] },
+        expected: {
+          kind: 'negative-amount',
+          field: 'fee.totalMicros',
+          value: -1n,
+          eventId: fee.id,
+        },
+      },
+      {
+        input: { ...result, events: [fill, { ...cashYield, amountMicros: 'invalid' }] },
+        expected: {
+          kind: 'amount-parse-failed',
+          field: 'cashYield.amountMicros',
+          value: 'invalid',
+          eventId: cashYield.id,
+        },
+      },
+      {
+        input: { ...result, events: [fill, { ...cashYield, amountMicros: '-1' }] },
+        expected: {
+          kind: 'negative-amount',
+          field: 'cashYield.amountMicros',
+          value: -1n,
+          eventId: cashYield.id,
+        },
+      },
+    ]
+
+    for (const { input, expected } of cases) {
+      expect(assertLedgerPlanFailure(buildLedgerPlan(input, ledger))).toMatchObject(expected)
+    }
+  })
+
+  test('returns exact inventory and event canonicalization failures', () => {
+    const result = evaluationResult()
+    const fill = firstFill(result, 'buy')
+    const missingSymbol = 'MISSING-INVENTORY'
+
+    expect(
+      assertLedgerPlanFailure(buildLedgerPlan({ ...result, events: [{ ...fill, symbol: missingSymbol }] }, ledger)),
+    ).toEqual({
+      kind: 'inventory-account-missing',
+      runId: result.runId,
+      eventId: fill.id,
+      symbol: missingSymbol,
+    })
+
+    const nonCanonicalFill = { ...fill, unsupported: undefined } as FillEvent
+    expect(assertLedgerPlanFailure(buildLedgerPlan({ ...result, events: [nonCanonicalFill] }, ledger))).toEqual({
+      kind: 'canonicalization-failed',
+      operation: 'event-transfer',
+      eventId: fill.id,
+      leg: 'buy',
+      cause: {
+        _tag: 'CanonicalJsonFailure',
+        path: '$.unsupported',
+        reason: 'non-json-type',
+        actualType: 'undefined',
       },
     })
+  })
+
+  test('retains hostile manifest access as a closed failure with the original cause', () => {
+    const result = evaluationResult()
+    const cause = new TypeError('ledger-plan symbols are unavailable')
     const inputManifest = new Proxy(result.inputManifest, {
       get: (target, property, receiver) => {
-        if (property === 'symbols') throw hostileCause
+        if (property === 'symbols') throw cause
         return Reflect.get(target, property, receiver)
       },
     })
 
     const failure = assertFailure(buildLedgerPlan({ ...result, inputManifest }, ledger))
 
+    expect(failure).toBeInstanceOf(LedgerValidationError)
     expect(failure).toMatchObject({
-      operation: 'build-plan',
-      reason: 'ledger-plan-failure',
-      message: 'TigerBeetle build-plan failed: unrenderable cause',
+      kind: 'input-access-failed',
+      detail: { kind: 'input-access-failed', field: 'inputManifest.symbols', cause },
+      material: {
+        ledger,
+        failure: { kind: 'input-access-failed', field: 'inputManifest.symbols', cause },
+      },
+      cause,
     })
-    expect(failure.cause).toBe(hostileCause)
+  })
+
+  test('preserves exact TigerBeetle identity, ordering, amounts, flags, and replay hash', () => {
+    const result = evaluationResult()
+    const first = assertSuccess(buildLedgerPlan(result, ledger))
+    const replay = assertSuccess(buildLedgerPlan(result, ledger))
+
+    expect(replay).toEqual(first)
+    expect(first.runKey).toBe(79_792_431_000_025_543_657_647_989_592_544_810_778n)
+    expect(first.runTag).toBe(18_307_385_734_514_644_762n)
+    expect(first.accounts).toHaveLength(11)
+    expect(first.transfers).toHaveLength(269)
+    expect(first.accounts[0].id).toBe(28_174_988_367_779_630_772_009_788_722_886_677_084n)
+    expect(first.accounts.at(-1)?.id).toBe(328_386_117_789_076_263_753_212_874_624_739_142_962n)
+    expect(first.transfers[0].id).toBe(532_337_791_250_265_855_850_739_987_090_731_240n)
+    expect(first.transfers.at(-1)?.id).toBe(340_248_724_424_856_676_616_453_965_797_055_502_080n)
+    expect(first.transfers.find((transfer) => transfer.code === TransferCode.funding)?.id).toBe(
+      109_353_885_019_586_710_761_486_091_928_106_698_321n,
+    )
+    expect(first.accounts.every((account) => account.flags === AccountFlags.history)).toBeTrue()
+    expect(first.transfers.every((transfer) => transfer.flags === 0 && transfer.amount > 0n)).toBeTrue()
+    expect(hashLedgerPlan(first)).toBe('9c6888ca700beb1c5fb698d28c6d42a5e0b913d4340b08554b475fe96da92074')
+  })
+
+  test('accepts the last exact single-query size and rejects both next records', () => {
+    const result = evaluationResult()
+    const fill = firstFill(result, 'buy')
+    const coverage = result.inputManifest.symbols.find((candidate) => candidate.symbol === fill.symbol)
+    assert(coverage, `evaluation manifest must cover ${fill.symbol}`)
+
+    const manifestWithSymbols = (count: number): LedgerInput['inputManifest'] => ({
+      ...result.inputManifest,
+      symbols: Array.from({ length: count }, (_, index) => ({
+        ...coverage,
+        symbol: index === 0 ? fill.symbol : `LIMIT${index.toString().padStart(5, '0')}`,
+      })),
+    })
+    const allowedAccounts = assertSuccess(
+      buildLedgerPlan(
+        {
+          ...result,
+          inputManifest: manifestWithSymbols(LEDGER_BATCH_MAX - 7),
+          events: [fill],
+        },
+        ledger,
+      ),
+    )
+    expect(allowedAccounts.accounts).toHaveLength(LEDGER_BATCH_MAX - 1)
+    expect(
+      assertLedgerPlanFailure(
+        buildLedgerPlan(
+          {
+            ...result,
+            inputManifest: manifestWithSymbols(LEDGER_BATCH_MAX - 6),
+            events: [fill],
+          },
+          ledger,
+        ),
+      ),
+    ).toEqual({
+      kind: 'single-query-limit-exceeded',
+      runId: result.runId,
+      accountCount: LEDGER_BATCH_MAX,
+      transferCount: 2,
+      limit: LEDGER_BATCH_MAX,
+    })
+
+    const feeEvents = Array.from(
+      { length: LEDGER_BATCH_MAX - 2 },
+      (_, index): FeeEvent => ({
+        kind: 'fee',
+        id: `f${(index + 1).toString(16).padStart(63, '0')}`,
+        sessionDate: fill.sessionDate,
+        commissionMicros: '1',
+        secMicros: '0',
+        tafMicros: '0',
+        catMicros: '0',
+        totalMicros: '1',
+      }),
+    )
+    const minimalManifest = manifestWithSymbols(1)
+    const allowedTransfers = assertSuccess(
+      buildLedgerPlan(
+        {
+          ...result,
+          inputManifest: minimalManifest,
+          events: [fill, ...feeEvents.slice(0, -1)],
+        },
+        ledger,
+      ),
+    )
+    expect(allowedTransfers.transfers).toHaveLength(LEDGER_BATCH_MAX - 1)
+    expect(
+      assertLedgerPlanFailure(
+        buildLedgerPlan(
+          {
+            ...result,
+            inputManifest: minimalManifest,
+            events: [fill, ...feeEvents],
+          },
+          ledger,
+        ),
+      ),
+    ).toEqual({
+      kind: 'single-query-limit-exceeded',
+      runId: result.runId,
+      accountCount: 7,
+      transferCount: LEDGER_BATCH_MAX,
+      limit: LEDGER_BATCH_MAX,
+    })
   })
 
   test('partitions exact existing transfers and preserves missing request order', () => {

--- a/services/bayn/src/ledger-plan.test.ts
+++ b/services/bayn/src/ledger-plan.test.ts
@@ -272,6 +272,37 @@ describe('ledger plan Result algebra', () => {
     })
   })
 
+  test('retains hostile event collection and discriminator access as closed failures', () => {
+    const result = evaluationResult()
+    const fill = firstFill(result, 'buy')
+    const eventsCause = new TypeError('ledger-plan events are unavailable')
+    const kindCause = new TypeError('ledger-plan event kind is unavailable')
+    const hostileInput = new Proxy(result, {
+      get: (target, property, receiver) => {
+        if (property === 'events') throw eventsCause
+        return Reflect.get(target, property, receiver)
+      },
+    })
+    const hostileFill = new Proxy(fill, {
+      get: (target, property, receiver) => {
+        if (property === 'kind') throw kindCause
+        return Reflect.get(target, property, receiver)
+      },
+    })
+
+    expect(assertLedgerPlanFailure(buildLedgerPlan(hostileInput, ledger))).toEqual({
+      kind: 'input-access-failed',
+      field: 'events',
+      cause: eventsCause,
+    })
+    expect(assertLedgerPlanFailure(buildLedgerPlan({ ...result, events: [hostileFill] }, ledger))).toEqual({
+      kind: 'input-access-failed',
+      field: 'event.kind',
+      eventIndex: 0,
+      cause: kindCause,
+    })
+  })
+
   test('preserves exact TigerBeetle identity, ordering, amounts, flags, and replay hash', () => {
     const result = evaluationResult()
     const first = assertSuccess(buildLedgerPlan(result, ledger))

--- a/services/bayn/src/ledger-plan.test.ts
+++ b/services/bayn/src/ledger-plan.test.ts
@@ -234,18 +234,25 @@ describe('ledger plan Result algebra', () => {
     })
 
     const nonCanonicalFill = { ...fill, unsupported: undefined } as FillEvent
-    expect(assertLedgerPlanFailure(buildLedgerPlan({ ...result, events: [nonCanonicalFill] }, ledger))).toEqual({
+    const canonicalizationFailure = assertFailure(buildLedgerPlan({ ...result, events: [nonCanonicalFill] }, ledger))
+    expect(canonicalizationFailure).toMatchObject({
+      operation: 'build-plan',
+      reason: 'ledger-plan-failure',
       kind: 'canonicalization-failed',
-      operation: 'event-transfer',
-      eventId: fill.id,
-      leg: 'buy',
-      cause: {
-        _tag: 'CanonicalJsonFailure',
-        path: '$.unsupported',
-        reason: 'non-json-type',
-        actualType: 'undefined',
+      detail: {
+        kind: 'canonicalization-failed',
+        canonicalizationOperation: 'event-transfer',
+        eventId: fill.id,
+        leg: 'buy',
+        cause: {
+          _tag: 'CanonicalJsonFailure',
+          path: '$.unsupported',
+          reason: 'non-json-type',
+          actualType: 'undefined',
+        },
       },
     })
+    expect(canonicalizationFailure.operation).toBe('build-plan')
   })
 
   test('retains hostile manifest access as a closed failure with the original cause', () => {

--- a/services/bayn/src/ledger-plan.test.ts
+++ b/services/bayn/src/ledger-plan.test.ts
@@ -129,6 +129,7 @@ describe('ledger plan Result algebra', () => {
         expected: {
           kind: 'amount-parse-failed',
           field: 'initialCapitalMicros',
+          actualType: 'string',
           value: 'invalid',
         },
       },
@@ -145,6 +146,7 @@ describe('ledger plan Result algebra', () => {
         expected: {
           kind: 'amount-parse-failed',
           field: 'fill.notionalMicros',
+          actualType: 'string',
           value: 'invalid',
           eventId: fill.id,
         },
@@ -163,6 +165,7 @@ describe('ledger plan Result algebra', () => {
         expected: {
           kind: 'amount-parse-failed',
           field: 'fill.costBasisMicros',
+          actualType: 'string',
           value: 'invalid',
           eventId: fill.id,
         },
@@ -181,6 +184,7 @@ describe('ledger plan Result algebra', () => {
         expected: {
           kind: 'amount-parse-failed',
           field: 'fee.totalMicros',
+          actualType: 'string',
           value: 'invalid',
           eventId: fee.id,
         },
@@ -199,6 +203,7 @@ describe('ledger plan Result algebra', () => {
         expected: {
           kind: 'amount-parse-failed',
           field: 'cashYield.amountMicros',
+          actualType: 'string',
           value: 'invalid',
           eventId: cashYield.id,
         },
@@ -217,6 +222,57 @@ describe('ledger plan Result algebra', () => {
     for (const { input, expected } of cases) {
       expect(assertLedgerPlanFailure(buildLedgerPlan(input, ledger))).toMatchObject(expected)
     }
+  })
+
+  test('never re-coerces rejected amount values while constructing failures', () => {
+    const result = evaluationResult()
+    const fill = firstFill(result, 'buy')
+    const coercionCause = new TypeError('amount coercion is unavailable')
+    const hostileAmount = {
+      [Symbol.toPrimitive]: () => {
+        throw coercionCause
+      },
+    }
+
+    const symbolFailure = assertFailure(
+      buildLedgerPlan(
+        { ...result, initialCapitalMicros: Symbol('invalid') as unknown as string, events: [fill] },
+        ledger,
+      ),
+    )
+    expect(symbolFailure).toMatchObject({
+      operation: 'build-plan',
+      message: 'TigerBeetle build-plan failed: initialCapitalMicros is not an integer micros value (symbol)',
+      detail: {
+        kind: 'amount-parse-failed',
+        field: 'initialCapitalMicros',
+        actualType: 'symbol',
+      },
+    })
+    expect(symbolFailure.detail).not.toHaveProperty('value')
+
+    const hostileFailure = assertFailure(
+      buildLedgerPlan(
+        {
+          ...result,
+          events: [{ ...fill, notionalMicros: hostileAmount as unknown as string }],
+        },
+        ledger,
+      ),
+    )
+    expect(hostileFailure).toMatchObject({
+      operation: 'build-plan',
+      message: 'TigerBeetle build-plan failed: fill.notionalMicros is not an integer micros value (object)',
+      detail: {
+        kind: 'amount-parse-failed',
+        field: 'fill.notionalMicros',
+        actualType: 'object',
+        eventId: fill.id,
+        cause: coercionCause,
+      },
+      cause: coercionCause,
+    })
+    expect(hostileFailure.detail).not.toHaveProperty('value')
   })
 
   test('returns exact inventory and event canonicalization failures', () => {

--- a/services/bayn/src/ledger-plan.ts
+++ b/services/bayn/src/ledger-plan.ts
@@ -100,6 +100,10 @@ export interface LedgerPlan {
   readonly transfers: readonly Transfer[]
 }
 
+export interface EvaluationLedgerPlan extends LedgerPlan {
+  readonly runId: string
+}
+
 export interface LedgerInput {
   readonly runId: string
   readonly initialCapitalMicros: string
@@ -496,7 +500,7 @@ const planEvents = (result: LedgerInput): Result.Result<PlannedEvents, LedgerPla
 const buildLedgerPlanDecision = (
   result: LedgerInput,
   ledger: number,
-): Result.Result<LedgerPlan, LedgerPlanFailureDetail> =>
+): Result.Result<EvaluationLedgerPlan, LedgerPlanFailureDetail> =>
   Result.gen(function* () {
     const rawRunId = yield* Result.mapError(
       Result.try(() => result.runId),
@@ -695,6 +699,7 @@ const buildLedgerPlanDecision = (
       })
     }
     return {
+      runId,
       runKey,
       runTag,
       accounts: [...accountsByName.values()].sort((left, right) => (left.id < right.id ? -1 : 1)),
@@ -702,7 +707,10 @@ const buildLedgerPlanDecision = (
     }
   })
 
-export const buildLedgerPlan = (result: LedgerInput, ledger: number): Result.Result<LedgerPlan, LedgerPlanFailure> =>
+export const buildLedgerPlan = (
+  result: LedgerInput,
+  ledger: number,
+): Result.Result<EvaluationLedgerPlan, LedgerPlanFailure> =>
   Result.mapError(buildLedgerPlanDecision(result, ledger), (failure) => makeLedgerPlanFailure(ledger, failure))
 
 const serializeRecord = (record: Account | Transfer): Record<string, number | string> =>

--- a/services/bayn/src/ledger-plan.ts
+++ b/services/bayn/src/ledger-plan.ts
@@ -127,8 +127,11 @@ export type LedgerPlanInputField =
   | 'fill.side'
   | 'fill.symbol'
   | 'initialCapitalMicros'
+  | 'inputManifest.symbol'
   | 'inputManifest.symbols'
   | 'runId'
+
+type LedgerPlanInputExpectation = 'evaluation-event-kind' | 'fill-side' | 'string'
 
 export type LedgerPlanFailureDetail =
   | {
@@ -175,6 +178,15 @@ export type LedgerPlanFailureDetail =
       readonly cause: unknown
     }
   | {
+      readonly kind: 'input-value-invalid'
+      readonly field: LedgerPlanInputField
+      readonly expected: LedgerPlanInputExpectation
+      readonly actualType: string
+      readonly value?: string
+      readonly index?: number
+      readonly eventKind?: EvaluationEvent['kind']
+    }
+  | {
       readonly kind: 'single-query-limit-exceeded'
       readonly runId: string
       readonly accountCount: number
@@ -205,6 +217,8 @@ export const renderLedgerPlanFailure = (failure: LedgerPlanFailureDetail): strin
       return `event ${failure.eventId} ${failure.leg} material is not canonicalizable: ${renderCanonicalJsonFailure(failure.cause)}`
     case 'input-access-failed':
       return `${failure.field} is unavailable`
+    case 'input-value-invalid':
+      return `${failure.field} is not a valid ${failure.expected}`
     case 'single-query-limit-exceeded':
       return 'Bayn ledger run exceeds the exact single-query reconciliation limit'
   }
@@ -365,6 +379,48 @@ const inputAccessFailure = (
   cause,
 })
 
+const invalidInputValue = (
+  field: LedgerPlanInputField,
+  expected: LedgerPlanInputExpectation,
+  value: unknown,
+  index?: number,
+  eventKind?: EvaluationEvent['kind'],
+): LedgerPlanFailureDetail => ({
+  kind: 'input-value-invalid',
+  field,
+  expected,
+  actualType: value === null ? 'null' : typeof value,
+  ...(typeof value === 'string' ? { value } : {}),
+  ...(index === undefined ? {} : { index }),
+  ...(eventKind === undefined ? {} : { eventKind }),
+})
+
+const requireStringInput = (
+  field: LedgerPlanInputField,
+  value: unknown,
+  index?: number,
+  eventKind?: EvaluationEvent['kind'],
+): Result.Result<string, LedgerPlanFailureDetail> =>
+  typeof value === 'string'
+    ? Result.succeed(value)
+    : failLedgerPlan(invalidInputValue(field, 'string', value, index, eventKind))
+
+const requireEventKind = (
+  value: unknown,
+  eventIndex: number,
+): Result.Result<EvaluationEvent['kind'], LedgerPlanFailureDetail> =>
+  value === 'decision' || value === 'fill' || value === 'fee' || value === 'cash-yield'
+    ? Result.succeed(value)
+    : failLedgerPlan(invalidInputValue('event.kind', 'evaluation-event-kind', value, eventIndex))
+
+const requireFillSide = (
+  value: unknown,
+  eventIndex: number,
+): Result.Result<FillEvent['side'], LedgerPlanFailureDetail> =>
+  value === 'buy' || value === 'sell'
+    ? Result.succeed(value)
+    : failLedgerPlan(invalidInputValue('fill.side', 'fill-side', value, eventIndex, 'fill'))
+
 const planEvents = (result: LedgerInput): Result.Result<PlannedEvents, LedgerPlanFailureDetail> =>
   Result.gen(function* () {
     const events = yield* Result.mapError(
@@ -376,24 +432,28 @@ const planEvents = (result: LedgerInput): Result.Result<PlannedEvents, LedgerPla
     const cashYields: PlannedCashYieldEvent[] = []
 
     for (const [eventIndex, event] of events.entries()) {
-      const kind = yield* Result.mapError(
+      const rawKind = yield* Result.mapError(
         Result.try(() => event.kind),
         (cause) => inputAccessFailure('event.kind', cause, eventIndex),
       )
+      const kind = yield* requireEventKind(rawKind, eventIndex)
       if (kind === 'fill') {
         const fill = event as FillEvent
-        const id = yield* Result.mapError(
+        const rawId = yield* Result.mapError(
           Result.try(() => fill.id),
           (cause) => inputAccessFailure('fill.id', cause, eventIndex, kind),
         )
-        const symbol = yield* Result.mapError(
+        const id = yield* requireStringInput('fill.id', rawId, eventIndex, kind)
+        const rawSymbol = yield* Result.mapError(
           Result.try(() => fill.symbol),
           (cause) => inputAccessFailure('fill.symbol', cause, eventIndex, kind),
         )
-        const side = yield* Result.mapError(
+        const symbol = yield* requireStringInput('fill.symbol', rawSymbol, eventIndex, kind)
+        const rawSide = yield* Result.mapError(
           Result.try(() => fill.side),
           (cause) => inputAccessFailure('fill.side', cause, eventIndex, kind),
         )
+        const side = yield* requireFillSide(rawSide, eventIndex)
         const notionalMicros = yield* Result.mapError(
           Result.try(() => fill.notionalMicros),
           (cause) => inputAccessFailure('fill.notionalMicros', cause, eventIndex, kind),
@@ -405,10 +465,11 @@ const planEvents = (result: LedgerInput): Result.Result<PlannedEvents, LedgerPla
         fills.push({ event: fill, id, symbol, side, notionalMicros, costBasisMicros })
       } else if (kind === 'fee') {
         const fee = event as FeeEvent
-        const id = yield* Result.mapError(
+        const rawId = yield* Result.mapError(
           Result.try(() => fee.id),
           (cause) => inputAccessFailure('fee.id', cause, eventIndex, kind),
         )
+        const id = yield* requireStringInput('fee.id', rawId, eventIndex, kind)
         const totalMicros = yield* Result.mapError(
           Result.try(() => fee.totalMicros),
           (cause) => inputAccessFailure('fee.totalMicros', cause, eventIndex, kind),
@@ -416,10 +477,11 @@ const planEvents = (result: LedgerInput): Result.Result<PlannedEvents, LedgerPla
         fees.push({ event: fee, id, totalMicros })
       } else if (kind === 'cash-yield') {
         const cashYield = event as CashYieldEvent
-        const id = yield* Result.mapError(
+        const rawId = yield* Result.mapError(
           Result.try(() => cashYield.id),
           (cause) => inputAccessFailure('cashYield.id', cause, eventIndex, kind),
         )
+        const id = yield* requireStringInput('cashYield.id', rawId, eventIndex, kind)
         const amountMicros = yield* Result.mapError(
           Result.try(() => cashYield.amountMicros),
           (cause) => inputAccessFailure('cashYield.amountMicros', cause, eventIndex, kind),
@@ -436,10 +498,11 @@ const buildLedgerPlanDecision = (
   ledger: number,
 ): Result.Result<LedgerPlan, LedgerPlanFailureDetail> =>
   Result.gen(function* () {
-    const runId = yield* Result.mapError(
+    const rawRunId = yield* Result.mapError(
       Result.try(() => result.runId),
       (cause) => inputAccessFailure('runId', cause),
     )
+    const runId = yield* requireStringInput('runId', rawRunId)
     const initialCapitalMicros = yield* Result.mapError(
       Result.try(() => result.initialCapitalMicros),
       (cause) => inputAccessFailure('initialCapitalMicros', cause),
@@ -458,15 +521,18 @@ const buildLedgerPlanDecision = (
     const cashYieldIncome = addAccount('cash-yield-income', AccountCode.cashYieldIncome)
     const realizedGain = addAccount('realized-gain', AccountCode.realizedGain)
     const realizedLoss = addAccount('realized-loss', AccountCode.realizedLoss)
-    const inventorySymbols = yield* Result.mapError(
-      Result.try(() => result.inputManifest.symbols.map((coverage) => coverage.symbol).sort()),
+    const rawInventorySymbols = yield* Result.mapError(
+      Result.try(() => result.inputManifest.symbols.map((coverage) => coverage.symbol as unknown)),
       (cause): LedgerPlanFailureDetail => ({
         kind: 'input-access-failed',
         field: 'inputManifest.symbols',
         cause,
       }),
     )
-    for (const symbol of inventorySymbols) {
+    const inventorySymbols = yield* Result.all(
+      rawInventorySymbols.map((symbol, index) => requireStringInput('inputManifest.symbol', symbol, index)),
+    )
+    for (const symbol of inventorySymbols.toSorted()) {
       addAccount(`inventory:${symbol}`, AccountCode.inventory)
     }
 

--- a/services/bayn/src/ledger-plan.ts
+++ b/services/bayn/src/ledger-plan.ts
@@ -139,7 +139,8 @@ export type LedgerPlanFailureDetail =
   | {
       readonly kind: 'amount-parse-failed'
       readonly field: LedgerPlanAmountField
-      readonly value: string
+      readonly actualType: string
+      readonly value?: string
       readonly eventId?: string
       readonly cause: unknown
     }
@@ -191,7 +192,9 @@ export const renderLedgerPlanFailure = (failure: LedgerPlanFailureDetail): strin
     case 'no-fill-events':
       return 'evaluation produced no fill events to journal'
     case 'amount-parse-failed':
-      return `${failure.field} is not an integer micros value: ${failure.value}`
+      return failure.value === undefined
+        ? `${failure.field} is not an integer micros value (${failure.actualType})`
+        : `${failure.field} is not an integer micros value: ${failure.value}`
     case 'negative-amount':
       return `${failure.field} must not be negative`
     case 'initial-capital-not-positive':
@@ -297,15 +300,16 @@ const transfer = (
 
 const parseAmount = (
   field: LedgerPlanAmountField,
-  value: string,
+  value: unknown,
   eventId?: string,
 ): Result.Result<bigint, LedgerPlanFailureDetail> =>
   Result.mapError(
-    Result.try(() => BigInt(value)),
+    Result.try(() => BigInt(value as string)),
     (cause): LedgerPlanFailureDetail => ({
       kind: 'amount-parse-failed',
       field,
-      value,
+      actualType: value === null ? 'null' : typeof value,
+      ...(typeof value === 'string' ? { value } : {}),
       ...(eventId === undefined ? {} : { eventId }),
       cause,
     }),
@@ -313,7 +317,7 @@ const parseAmount = (
 
 const nonNegativeAmount = (
   field: Exclude<LedgerPlanAmountField, 'initialCapitalMicros'>,
-  value: string,
+  value: unknown,
   eventId: string,
 ): Result.Result<bigint, LedgerPlanFailureDetail> =>
   Result.flatMap(parseAmount(field, value, eventId), (parsed) =>
@@ -325,20 +329,20 @@ interface PlannedFillEvent {
   readonly id: string
   readonly symbol: string
   readonly side: FillEvent['side']
-  readonly notionalMicros: string
-  readonly costBasisMicros: string
+  readonly notionalMicros: unknown
+  readonly costBasisMicros: unknown
 }
 
 interface PlannedFeeEvent {
   readonly event: FeeEvent
   readonly id: string
-  readonly totalMicros: string
+  readonly totalMicros: unknown
 }
 
 interface PlannedCashYieldEvent {
   readonly event: CashYieldEvent
   readonly id: string
-  readonly amountMicros: string
+  readonly amountMicros: unknown
 }
 
 interface PlannedEvents {

--- a/services/bayn/src/ledger-plan.ts
+++ b/services/bayn/src/ledger-plan.ts
@@ -161,7 +161,7 @@ export type LedgerPlanFailureDetail =
     }
   | {
       readonly kind: 'canonicalization-failed'
-      readonly operation: 'event-transfer'
+      readonly canonicalizationOperation: 'event-transfer'
       readonly eventId: string
       readonly leg: string
       readonly cause: CanonicalJsonFailure
@@ -181,10 +181,10 @@ export type LedgerPlanFailureDetail =
       readonly limit: number
     }
 
-export type LedgerPlanFailure = LedgerValidationError &
-  LedgerPlanFailureDetail & {
-    readonly detail: LedgerPlanFailureDetail
-  }
+export type LedgerPlanFailure = LedgerValidationError & {
+  readonly kind: LedgerPlanFailureDetail['kind']
+  readonly detail: LedgerPlanFailureDetail
+}
 
 export const renderLedgerPlanFailure = (failure: LedgerPlanFailureDetail): string => {
   switch (failure.kind) {
@@ -227,8 +227,7 @@ const makeLedgerPlanFailure = (ledger: number, detail: LedgerPlanFailureDetail):
       { ledger, failure: detail },
       ledgerPlanCause(detail),
     ),
-    detail,
-    { detail },
+    { kind: detail.kind, detail },
   ) as LedgerPlanFailure
 
 const failLedgerPlan = (failure: LedgerPlanFailureDetail): Result.Result<never, LedgerPlanFailureDetail> =>
@@ -273,7 +272,7 @@ const transfer = (
   if (Result.isFailure(eventHash)) {
     return failLedgerPlan({
       kind: 'canonicalization-failed',
-      operation: 'event-transfer',
+      canonicalizationOperation: 'event-transfer',
       eventId,
       leg,
       cause: eventHash.failure,

--- a/services/bayn/src/ledger-plan.ts
+++ b/services/bayn/src/ledger-plan.ts
@@ -114,6 +114,22 @@ export type LedgerPlanAmountField =
   | 'fill.notionalMicros'
   | 'initialCapitalMicros'
 
+export type LedgerPlanInputField =
+  | 'cashYield.amountMicros'
+  | 'cashYield.id'
+  | 'event.kind'
+  | 'events'
+  | 'fee.id'
+  | 'fee.totalMicros'
+  | 'fill.costBasisMicros'
+  | 'fill.id'
+  | 'fill.notionalMicros'
+  | 'fill.side'
+  | 'fill.symbol'
+  | 'initialCapitalMicros'
+  | 'inputManifest.symbols'
+  | 'runId'
+
 export type LedgerPlanFailureDetail =
   | {
       readonly kind: 'no-fill-events'
@@ -152,7 +168,9 @@ export type LedgerPlanFailureDetail =
     }
   | {
       readonly kind: 'input-access-failed'
-      readonly field: 'inputManifest.symbols'
+      readonly field: LedgerPlanInputField
+      readonly eventIndex?: number
+      readonly eventKind?: EvaluationEvent['kind']
       readonly cause: unknown
     }
   | {
@@ -303,16 +321,131 @@ const nonNegativeAmount = (
     parsed < 0n ? failLedgerPlan({ kind: 'negative-amount', field, value: parsed, eventId }) : Result.succeed(parsed),
   )
 
+interface PlannedFillEvent {
+  readonly event: FillEvent
+  readonly id: string
+  readonly symbol: string
+  readonly side: FillEvent['side']
+  readonly notionalMicros: string
+  readonly costBasisMicros: string
+}
+
+interface PlannedFeeEvent {
+  readonly event: FeeEvent
+  readonly id: string
+  readonly totalMicros: string
+}
+
+interface PlannedCashYieldEvent {
+  readonly event: CashYieldEvent
+  readonly id: string
+  readonly amountMicros: string
+}
+
+interface PlannedEvents {
+  readonly eventCount: number
+  readonly fills: readonly PlannedFillEvent[]
+  readonly fees: readonly PlannedFeeEvent[]
+  readonly cashYields: readonly PlannedCashYieldEvent[]
+}
+
+const inputAccessFailure = (
+  field: LedgerPlanInputField,
+  cause: unknown,
+  eventIndex?: number,
+  eventKind?: EvaluationEvent['kind'],
+): LedgerPlanFailureDetail => ({
+  kind: 'input-access-failed',
+  field,
+  ...(eventIndex === undefined ? {} : { eventIndex }),
+  ...(eventKind === undefined ? {} : { eventKind }),
+  cause,
+})
+
+const planEvents = (result: LedgerInput): Result.Result<PlannedEvents, LedgerPlanFailureDetail> =>
+  Result.gen(function* () {
+    const events = yield* Result.mapError(
+      Result.try(() => [...result.events]),
+      (cause) => inputAccessFailure('events', cause),
+    )
+    const fills: PlannedFillEvent[] = []
+    const fees: PlannedFeeEvent[] = []
+    const cashYields: PlannedCashYieldEvent[] = []
+
+    for (const [eventIndex, event] of events.entries()) {
+      const kind = yield* Result.mapError(
+        Result.try(() => event.kind),
+        (cause) => inputAccessFailure('event.kind', cause, eventIndex),
+      )
+      if (kind === 'fill') {
+        const fill = event as FillEvent
+        const id = yield* Result.mapError(
+          Result.try(() => fill.id),
+          (cause) => inputAccessFailure('fill.id', cause, eventIndex, kind),
+        )
+        const symbol = yield* Result.mapError(
+          Result.try(() => fill.symbol),
+          (cause) => inputAccessFailure('fill.symbol', cause, eventIndex, kind),
+        )
+        const side = yield* Result.mapError(
+          Result.try(() => fill.side),
+          (cause) => inputAccessFailure('fill.side', cause, eventIndex, kind),
+        )
+        const notionalMicros = yield* Result.mapError(
+          Result.try(() => fill.notionalMicros),
+          (cause) => inputAccessFailure('fill.notionalMicros', cause, eventIndex, kind),
+        )
+        const costBasisMicros = yield* Result.mapError(
+          Result.try(() => fill.costBasisMicros),
+          (cause) => inputAccessFailure('fill.costBasisMicros', cause, eventIndex, kind),
+        )
+        fills.push({ event: fill, id, symbol, side, notionalMicros, costBasisMicros })
+      } else if (kind === 'fee') {
+        const fee = event as FeeEvent
+        const id = yield* Result.mapError(
+          Result.try(() => fee.id),
+          (cause) => inputAccessFailure('fee.id', cause, eventIndex, kind),
+        )
+        const totalMicros = yield* Result.mapError(
+          Result.try(() => fee.totalMicros),
+          (cause) => inputAccessFailure('fee.totalMicros', cause, eventIndex, kind),
+        )
+        fees.push({ event: fee, id, totalMicros })
+      } else if (kind === 'cash-yield') {
+        const cashYield = event as CashYieldEvent
+        const id = yield* Result.mapError(
+          Result.try(() => cashYield.id),
+          (cause) => inputAccessFailure('cashYield.id', cause, eventIndex, kind),
+        )
+        const amountMicros = yield* Result.mapError(
+          Result.try(() => cashYield.amountMicros),
+          (cause) => inputAccessFailure('cashYield.amountMicros', cause, eventIndex, kind),
+        )
+        cashYields.push({ event: cashYield, id, amountMicros })
+      }
+    }
+
+    return { eventCount: events.length, fills, fees, cashYields }
+  })
+
 const buildLedgerPlanDecision = (
   result: LedgerInput,
   ledger: number,
 ): Result.Result<LedgerPlan, LedgerPlanFailureDetail> =>
   Result.gen(function* () {
-    const runKey = stableU128('bayn-run-v1', result.runId)
-    const runTag = stableU64('bayn-run-v1', result.runId)
+    const runId = yield* Result.mapError(
+      Result.try(() => result.runId),
+      (cause) => inputAccessFailure('runId', cause),
+    )
+    const initialCapitalMicros = yield* Result.mapError(
+      Result.try(() => result.initialCapitalMicros),
+      (cause) => inputAccessFailure('initialCapitalMicros', cause),
+    )
+    const runKey = stableU128('bayn-run-v1', runId)
+    const runTag = stableU64('bayn-run-v1', runId)
     const accountsByName = new Map<string, Account>()
     const addAccount = (name: string, code: number): Account => {
-      const created = account(result.runId, runKey, runTag, ledger, name, code)
+      const created = account(runId, runKey, runTag, ledger, name, code)
       accountsByName.set(name, created)
       return created
     }
@@ -335,21 +468,21 @@ const buildLedgerPlanDecision = (
     }
 
     const transfers: Transfer[] = []
-    const fillEvents = result.events.filter((event): event is FillEvent => event.kind === 'fill')
-    if (fillEvents.length === 0) {
+    const events = yield* planEvents(result)
+    if (events.fills.length === 0) {
       return yield* failLedgerPlan({
         kind: 'no-fill-events',
-        runId: result.runId,
-        eventCount: result.events.length,
+        runId,
+        eventCount: events.eventCount,
       })
     }
-    const startingCapital = yield* parseAmount('initialCapitalMicros', result.initialCapitalMicros)
+    const startingCapital = yield* parseAmount('initialCapitalMicros', initialCapitalMicros)
     if (startingCapital <= 0n) {
       return yield* failLedgerPlan({ kind: 'initial-capital-not-positive', value: startingCapital })
     }
     transfers.push(
       yield* transfer(
-        result.runId,
+        runId,
         runTag,
         ledger,
         'funding',
@@ -358,16 +491,16 @@ const buildLedgerPlanDecision = (
         equity.id,
         startingCapital,
         TransferCode.funding,
-        { kind: 'funding', runId: result.runId, amountMicros: startingCapital.toString() },
+        { kind: 'funding', runId, amountMicros: startingCapital.toString() },
       ),
     )
 
-    for (const fill of fillEvents) {
+    for (const fill of events.fills) {
       const inventory = accountsByName.get(`inventory:${fill.symbol}`)
       if (inventory === undefined) {
         return yield* failLedgerPlan({
           kind: 'inventory-account-missing',
-          runId: result.runId,
+          runId,
           eventId: fill.id,
           symbol: fill.symbol,
         })
@@ -379,7 +512,7 @@ const buildLedgerPlanDecision = (
       if (fill.side === 'buy') {
         transfers.push(
           yield* transfer(
-            result.runId,
+            runId,
             runTag,
             ledger,
             fill.id,
@@ -388,14 +521,14 @@ const buildLedgerPlanDecision = (
             cash.id,
             notional,
             TransferCode.buy,
-            fill,
+            fill.event,
           ),
         )
       } else if (notional >= costBasis) {
         if (costBasis > 0n) {
           transfers.push(
             yield* transfer(
-              result.runId,
+              runId,
               runTag,
               ledger,
               fill.id,
@@ -404,14 +537,14 @@ const buildLedgerPlanDecision = (
               inventory.id,
               costBasis,
               TransferCode.sellBasis,
-              fill,
+              fill.event,
             ),
           )
         }
         if (notional > costBasis) {
           transfers.push(
             yield* transfer(
-              result.runId,
+              runId,
               runTag,
               ledger,
               fill.id,
@@ -420,14 +553,14 @@ const buildLedgerPlanDecision = (
               realizedGain.id,
               notional - costBasis,
               TransferCode.realizedGain,
-              fill,
+              fill.event,
             ),
           )
         }
       } else {
         transfers.push(
           yield* transfer(
-            result.runId,
+            runId,
             runTag,
             ledger,
             fill.id,
@@ -436,12 +569,12 @@ const buildLedgerPlanDecision = (
             inventory.id,
             notional,
             TransferCode.sellBasis,
-            fill,
+            fill.event,
           ),
         )
         transfers.push(
           yield* transfer(
-            result.runId,
+            runId,
             runTag,
             ledger,
             fill.id,
@@ -450,27 +583,25 @@ const buildLedgerPlanDecision = (
             inventory.id,
             costBasis - notional,
             TransferCode.realizedLoss,
-            fill,
+            fill.event,
           ),
         )
       }
     }
-    const feeEvents = result.events.filter((event): event is FeeEvent => event.kind === 'fee')
-    for (const fee of feeEvents) {
+    for (const fee of events.fees) {
       const amount = yield* nonNegativeAmount('fee.totalMicros', fee.totalMicros, fee.id)
       if (amount > 0n) {
         transfers.push(
-          yield* transfer(result.runId, runTag, ledger, fee.id, 'fee', fees.id, cash.id, amount, TransferCode.fee, fee),
+          yield* transfer(runId, runTag, ledger, fee.id, 'fee', fees.id, cash.id, amount, TransferCode.fee, fee.event),
         )
       }
     }
-    const cashYieldEvents = result.events.filter((event): event is CashYieldEvent => event.kind === 'cash-yield')
-    for (const cashYield of cashYieldEvents) {
+    for (const cashYield of events.cashYields) {
       const amount = yield* nonNegativeAmount('cashYield.amountMicros', cashYield.amountMicros, cashYield.id)
       if (amount > 0n) {
         transfers.push(
           yield* transfer(
-            result.runId,
+            runId,
             runTag,
             ledger,
             cashYield.id,
@@ -479,7 +610,7 @@ const buildLedgerPlanDecision = (
             cashYieldIncome.id,
             amount,
             TransferCode.cashYield,
-            cashYield,
+            cashYield.event,
           ),
         )
       }
@@ -488,7 +619,7 @@ const buildLedgerPlanDecision = (
     if (accountsByName.size >= LEDGER_BATCH_MAX || transfers.length >= LEDGER_BATCH_MAX) {
       return yield* failLedgerPlan({
         kind: 'single-query-limit-exceeded',
-        runId: result.runId,
+        runId,
         accountCount: accountsByName.size,
         transferCount: transfers.length,
         limit: LEDGER_BATCH_MAX,

--- a/services/bayn/src/ledger-plan.ts
+++ b/services/bayn/src/ledger-plan.ts
@@ -1,7 +1,14 @@
 import { Data, Result } from 'effect'
 import { AccountFlags, type Account, type Transfer } from 'tigerbeetle-node'
 
-import { canonicalHashV1, stableU128, stableU64 } from './hash'
+import {
+  canonicalHashV1,
+  canonicalHashV1Result,
+  renderCanonicalJsonFailure,
+  stableU128,
+  stableU64,
+  type CanonicalJsonFailure,
+} from './hash'
 import type { CashYieldEvent, EvaluationEvent, FeeEvent, FillEvent, InputManifest, ReconciliationResult } from './types'
 
 export const LEDGER_SCHEMA_VERSION = 2
@@ -100,6 +107,115 @@ export interface LedgerInput {
   readonly events: readonly EvaluationEvent[]
 }
 
+export type LedgerPlanAmountField =
+  | 'cashYield.amountMicros'
+  | 'fee.totalMicros'
+  | 'fill.costBasisMicros'
+  | 'fill.notionalMicros'
+  | 'initialCapitalMicros'
+
+export type LedgerPlanFailureDetail =
+  | {
+      readonly kind: 'no-fill-events'
+      readonly runId: string
+      readonly eventCount: number
+    }
+  | {
+      readonly kind: 'amount-parse-failed'
+      readonly field: LedgerPlanAmountField
+      readonly value: string
+      readonly eventId?: string
+      readonly cause: unknown
+    }
+  | {
+      readonly kind: 'negative-amount'
+      readonly field: Exclude<LedgerPlanAmountField, 'initialCapitalMicros'>
+      readonly value: bigint
+      readonly eventId: string
+    }
+  | {
+      readonly kind: 'initial-capital-not-positive'
+      readonly value: bigint
+    }
+  | {
+      readonly kind: 'inventory-account-missing'
+      readonly runId: string
+      readonly eventId: string
+      readonly symbol: string
+    }
+  | {
+      readonly kind: 'canonicalization-failed'
+      readonly operation: 'event-transfer'
+      readonly eventId: string
+      readonly leg: string
+      readonly cause: CanonicalJsonFailure
+    }
+  | {
+      readonly kind: 'input-access-failed'
+      readonly field: 'inputManifest.symbols'
+      readonly cause: unknown
+    }
+  | {
+      readonly kind: 'single-query-limit-exceeded'
+      readonly runId: string
+      readonly accountCount: number
+      readonly transferCount: number
+      readonly limit: number
+    }
+
+export type LedgerPlanFailure = LedgerValidationError &
+  LedgerPlanFailureDetail & {
+    readonly detail: LedgerPlanFailureDetail
+  }
+
+export const renderLedgerPlanFailure = (failure: LedgerPlanFailureDetail): string => {
+  switch (failure.kind) {
+    case 'no-fill-events':
+      return 'evaluation produced no fill events to journal'
+    case 'amount-parse-failed':
+      return `${failure.field} is not an integer micros value: ${failure.value}`
+    case 'negative-amount':
+      return `${failure.field} must not be negative`
+    case 'initial-capital-not-positive':
+      return 'initial capital must be positive'
+    case 'inventory-account-missing':
+      return `missing inventory account for ${failure.symbol}`
+    case 'canonicalization-failed':
+      return `event ${failure.eventId} ${failure.leg} material is not canonicalizable: ${renderCanonicalJsonFailure(failure.cause)}`
+    case 'input-access-failed':
+      return `${failure.field} is unavailable`
+    case 'single-query-limit-exceeded':
+      return 'Bayn ledger run exceeds the exact single-query reconciliation limit'
+  }
+}
+
+const ledgerPlanCause = (failure: LedgerPlanFailureDetail): unknown => {
+  switch (failure.kind) {
+    case 'amount-parse-failed':
+    case 'canonicalization-failed':
+    case 'input-access-failed':
+      return failure.cause
+    default:
+      return failure
+  }
+}
+
+const makeLedgerPlanFailure = (ledger: number, detail: LedgerPlanFailureDetail): LedgerPlanFailure =>
+  Object.assign(
+    ledgerValidationError(
+      'build-plan',
+      'ledger-plan-failure',
+      `TigerBeetle build-plan failed: ${renderLedgerPlanFailure(detail)}`,
+      { ledger, failure: detail },
+      ledgerPlanCause(detail),
+    ),
+    detail,
+    { detail },
+  ) as LedgerPlanFailure
+
+const failLedgerPlan = (failure: LedgerPlanFailureDetail): Result.Result<never, LedgerPlanFailureDetail> =>
+  Result.fail(failure)
+
 const account = (
   runId: string,
   runKey: bigint,
@@ -134,206 +250,260 @@ const transfer = (
   amount: bigint,
   code: number,
   event: unknown,
-): Transfer => ({
-  id: stableU128('bayn-transfer-v1', runId, eventId, leg),
-  debit_account_id: debitAccountId,
-  credit_account_id: creditAccountId,
-  amount,
-  pending_id: 0n,
-  user_data_128: stableU128('bayn-event-v1', canonicalHashV1(event)),
-  user_data_64: runTag,
-  user_data_32: LEDGER_SCHEMA_VERSION,
-  timeout: 0,
-  ledger,
-  code,
-  flags: 0,
-  timestamp: 0n,
-})
-
-const positiveAmount = (value: string, name: string): bigint => {
-  const parsed = BigInt(value)
-  if (parsed < 0n) throw new Error(`${name} must not be negative`)
-  return parsed
+): Result.Result<Transfer, LedgerPlanFailureDetail> => {
+  const eventHash = canonicalHashV1Result(event)
+  if (Result.isFailure(eventHash)) {
+    return failLedgerPlan({
+      kind: 'canonicalization-failed',
+      operation: 'event-transfer',
+      eventId,
+      leg,
+      cause: eventHash.failure,
+    })
+  }
+  return Result.succeed({
+    id: stableU128('bayn-transfer-v1', runId, eventId, leg),
+    debit_account_id: debitAccountId,
+    credit_account_id: creditAccountId,
+    amount,
+    pending_id: 0n,
+    user_data_128: stableU128('bayn-event-v1', eventHash.success),
+    user_data_64: runTag,
+    user_data_32: LEDGER_SCHEMA_VERSION,
+    timeout: 0,
+    ledger,
+    code,
+    flags: 0,
+    timestamp: 0n,
+  })
 }
 
-const buildLedgerPlanUnsafe = (result: LedgerInput, ledger: number): LedgerPlan => {
-  const runKey = stableU128('bayn-run-v1', result.runId)
-  const runTag = stableU64('bayn-run-v1', result.runId)
-  const accountsByName = new Map<string, Account>()
-  const addAccount = (name: string, code: number): Account => {
-    const created = account(result.runId, runKey, runTag, ledger, name, code)
-    accountsByName.set(name, created)
-    return created
-  }
-  const cash = addAccount('cash', AccountCode.cash)
-  const equity = addAccount('equity', AccountCode.equity)
-  const fees = addAccount('fee-expense', AccountCode.feeExpense)
-  const cashYieldIncome = addAccount('cash-yield-income', AccountCode.cashYieldIncome)
-  const realizedGain = addAccount('realized-gain', AccountCode.realizedGain)
-  const realizedLoss = addAccount('realized-loss', AccountCode.realizedLoss)
-  for (const symbol of result.inputManifest.symbols.map((coverage) => coverage.symbol).sort()) {
-    addAccount(`inventory:${symbol}`, AccountCode.inventory)
-  }
-
-  const transfers: Transfer[] = []
-  const fillEvents = result.events.filter((event): event is FillEvent => event.kind === 'fill')
-  if (fillEvents.length === 0) throw new Error('evaluation produced no fill events to journal')
-  const startingCapital = BigInt(result.initialCapitalMicros)
-  if (startingCapital <= 0n) throw new Error('initial capital must be positive')
-  transfers.push(
-    transfer(
-      result.runId,
-      runTag,
-      ledger,
-      'funding',
-      'principal',
-      cash.id,
-      equity.id,
-      startingCapital,
-      TransferCode.funding,
-      { kind: 'funding', runId: result.runId, amountMicros: startingCapital.toString() },
-    ),
+const parseAmount = (
+  field: LedgerPlanAmountField,
+  value: string,
+  eventId?: string,
+): Result.Result<bigint, LedgerPlanFailureDetail> =>
+  Result.mapError(
+    Result.try(() => BigInt(value)),
+    (cause): LedgerPlanFailureDetail => ({
+      kind: 'amount-parse-failed',
+      field,
+      value,
+      ...(eventId === undefined ? {} : { eventId }),
+      cause,
+    }),
   )
 
-  for (const fill of fillEvents) {
-    const inventory = accountsByName.get(`inventory:${fill.symbol}`)
-    if (!inventory) throw new Error(`missing inventory account for ${fill.symbol}`)
-    const notional = positiveAmount(fill.notionalMicros, 'fill notional')
-    const costBasis = positiveAmount(fill.costBasisMicros, 'fill cost basis')
-    if (notional === 0n) continue
+const nonNegativeAmount = (
+  field: Exclude<LedgerPlanAmountField, 'initialCapitalMicros'>,
+  value: string,
+  eventId: string,
+): Result.Result<bigint, LedgerPlanFailureDetail> =>
+  Result.flatMap(parseAmount(field, value, eventId), (parsed) =>
+    parsed < 0n ? failLedgerPlan({ kind: 'negative-amount', field, value: parsed, eventId }) : Result.succeed(parsed),
+  )
 
-    if (fill.side === 'buy') {
-      transfers.push(
-        transfer(result.runId, runTag, ledger, fill.id, 'buy', inventory.id, cash.id, notional, TransferCode.buy, fill),
-      )
-    } else if (notional >= costBasis) {
-      if (costBasis > 0n) {
+const buildLedgerPlanDecision = (
+  result: LedgerInput,
+  ledger: number,
+): Result.Result<LedgerPlan, LedgerPlanFailureDetail> =>
+  Result.gen(function* () {
+    const runKey = stableU128('bayn-run-v1', result.runId)
+    const runTag = stableU64('bayn-run-v1', result.runId)
+    const accountsByName = new Map<string, Account>()
+    const addAccount = (name: string, code: number): Account => {
+      const created = account(result.runId, runKey, runTag, ledger, name, code)
+      accountsByName.set(name, created)
+      return created
+    }
+    const cash = addAccount('cash', AccountCode.cash)
+    const equity = addAccount('equity', AccountCode.equity)
+    const fees = addAccount('fee-expense', AccountCode.feeExpense)
+    const cashYieldIncome = addAccount('cash-yield-income', AccountCode.cashYieldIncome)
+    const realizedGain = addAccount('realized-gain', AccountCode.realizedGain)
+    const realizedLoss = addAccount('realized-loss', AccountCode.realizedLoss)
+    const inventorySymbols = yield* Result.mapError(
+      Result.try(() => result.inputManifest.symbols.map((coverage) => coverage.symbol).sort()),
+      (cause): LedgerPlanFailureDetail => ({
+        kind: 'input-access-failed',
+        field: 'inputManifest.symbols',
+        cause,
+      }),
+    )
+    for (const symbol of inventorySymbols) {
+      addAccount(`inventory:${symbol}`, AccountCode.inventory)
+    }
+
+    const transfers: Transfer[] = []
+    const fillEvents = result.events.filter((event): event is FillEvent => event.kind === 'fill')
+    if (fillEvents.length === 0) {
+      return yield* failLedgerPlan({
+        kind: 'no-fill-events',
+        runId: result.runId,
+        eventCount: result.events.length,
+      })
+    }
+    const startingCapital = yield* parseAmount('initialCapitalMicros', result.initialCapitalMicros)
+    if (startingCapital <= 0n) {
+      return yield* failLedgerPlan({ kind: 'initial-capital-not-positive', value: startingCapital })
+    }
+    transfers.push(
+      yield* transfer(
+        result.runId,
+        runTag,
+        ledger,
+        'funding',
+        'principal',
+        cash.id,
+        equity.id,
+        startingCapital,
+        TransferCode.funding,
+        { kind: 'funding', runId: result.runId, amountMicros: startingCapital.toString() },
+      ),
+    )
+
+    for (const fill of fillEvents) {
+      const inventory = accountsByName.get(`inventory:${fill.symbol}`)
+      if (inventory === undefined) {
+        return yield* failLedgerPlan({
+          kind: 'inventory-account-missing',
+          runId: result.runId,
+          eventId: fill.id,
+          symbol: fill.symbol,
+        })
+      }
+      const notional = yield* nonNegativeAmount('fill.notionalMicros', fill.notionalMicros, fill.id)
+      const costBasis = yield* nonNegativeAmount('fill.costBasisMicros', fill.costBasisMicros, fill.id)
+      if (notional === 0n) continue
+
+      if (fill.side === 'buy') {
         transfers.push(
-          transfer(
+          yield* transfer(
             result.runId,
             runTag,
             ledger,
             fill.id,
-            'sell-basis',
+            'buy',
+            inventory.id,
+            cash.id,
+            notional,
+            TransferCode.buy,
+            fill,
+          ),
+        )
+      } else if (notional >= costBasis) {
+        if (costBasis > 0n) {
+          transfers.push(
+            yield* transfer(
+              result.runId,
+              runTag,
+              ledger,
+              fill.id,
+              'sell-basis',
+              cash.id,
+              inventory.id,
+              costBasis,
+              TransferCode.sellBasis,
+              fill,
+            ),
+          )
+        }
+        if (notional > costBasis) {
+          transfers.push(
+            yield* transfer(
+              result.runId,
+              runTag,
+              ledger,
+              fill.id,
+              'realized-gain',
+              cash.id,
+              realizedGain.id,
+              notional - costBasis,
+              TransferCode.realizedGain,
+              fill,
+            ),
+          )
+        }
+      } else {
+        transfers.push(
+          yield* transfer(
+            result.runId,
+            runTag,
+            ledger,
+            fill.id,
+            'sell-proceeds',
             cash.id,
             inventory.id,
-            costBasis,
+            notional,
             TransferCode.sellBasis,
             fill,
           ),
         )
-      }
-      if (notional > costBasis) {
         transfers.push(
-          transfer(
+          yield* transfer(
             result.runId,
             runTag,
             ledger,
             fill.id,
-            'realized-gain',
-            cash.id,
-            realizedGain.id,
-            notional - costBasis,
-            TransferCode.realizedGain,
+            'realized-loss',
+            realizedLoss.id,
+            inventory.id,
+            costBasis - notional,
+            TransferCode.realizedLoss,
             fill,
           ),
         )
       }
-    } else {
-      transfers.push(
-        transfer(
-          result.runId,
-          runTag,
-          ledger,
-          fill.id,
-          'sell-proceeds',
-          cash.id,
-          inventory.id,
-          notional,
-          TransferCode.sellBasis,
-          fill,
-        ),
-      )
-      transfers.push(
-        transfer(
-          result.runId,
-          runTag,
-          ledger,
-          fill.id,
-          'realized-loss',
-          realizedLoss.id,
-          inventory.id,
-          costBasis - notional,
-          TransferCode.realizedLoss,
-          fill,
-        ),
-      )
     }
-  }
-  const feeEvents = result.events.filter((event): event is FeeEvent => event.kind === 'fee')
-  for (const fee of feeEvents) {
-    const amount = positiveAmount(fee.totalMicros, 'fee total')
-    if (amount > 0n) {
-      transfers.push(
-        transfer(result.runId, runTag, ledger, fee.id, 'fee', fees.id, cash.id, amount, TransferCode.fee, fee),
-      )
+    const feeEvents = result.events.filter((event): event is FeeEvent => event.kind === 'fee')
+    for (const fee of feeEvents) {
+      const amount = yield* nonNegativeAmount('fee.totalMicros', fee.totalMicros, fee.id)
+      if (amount > 0n) {
+        transfers.push(
+          yield* transfer(result.runId, runTag, ledger, fee.id, 'fee', fees.id, cash.id, amount, TransferCode.fee, fee),
+        )
+      }
     }
-  }
-  const cashYieldEvents = result.events.filter((event): event is CashYieldEvent => event.kind === 'cash-yield')
-  for (const cashYield of cashYieldEvents) {
-    const amount = positiveAmount(cashYield.amountMicros, 'cash yield')
-    if (amount > 0n) {
-      transfers.push(
-        transfer(
-          result.runId,
-          runTag,
-          ledger,
-          cashYield.id,
-          'cash-yield',
-          cash.id,
-          cashYieldIncome.id,
-          amount,
-          TransferCode.cashYield,
-          cashYield,
-        ),
-      )
+    const cashYieldEvents = result.events.filter((event): event is CashYieldEvent => event.kind === 'cash-yield')
+    for (const cashYield of cashYieldEvents) {
+      const amount = yield* nonNegativeAmount('cashYield.amountMicros', cashYield.amountMicros, cashYield.id)
+      if (amount > 0n) {
+        transfers.push(
+          yield* transfer(
+            result.runId,
+            runTag,
+            ledger,
+            cashYield.id,
+            'cash-yield',
+            cash.id,
+            cashYieldIncome.id,
+            amount,
+            TransferCode.cashYield,
+            cashYield,
+          ),
+        )
+      }
     }
-  }
 
-  if (accountsByName.size >= LEDGER_BATCH_MAX || transfers.length >= LEDGER_BATCH_MAX) {
-    throw new Error('Bayn ledger run exceeds the exact single-query reconciliation limit')
-  }
-  return {
-    runKey,
-    runTag,
-    accounts: [...accountsByName.values()].sort((left, right) => (left.id < right.id ? -1 : 1)),
-    transfers: transfers.sort((left, right) => (left.id < right.id ? -1 : 1)),
-  }
-}
-
-const causeMessage = (cause: unknown): string => {
-  const rendered = Result.try({
-    try: () => String(cause instanceof Error ? cause.message : cause),
-    catch: () => undefined,
+    if (accountsByName.size >= LEDGER_BATCH_MAX || transfers.length >= LEDGER_BATCH_MAX) {
+      return yield* failLedgerPlan({
+        kind: 'single-query-limit-exceeded',
+        runId: result.runId,
+        accountCount: accountsByName.size,
+        transferCount: transfers.length,
+        limit: LEDGER_BATCH_MAX,
+      })
+    }
+    return {
+      runKey,
+      runTag,
+      accounts: [...accountsByName.values()].sort((left, right) => (left.id < right.id ? -1 : 1)),
+      transfers: transfers.sort((left, right) => (left.id < right.id ? -1 : 1)),
+    }
   })
-  return Result.isSuccess(rendered) ? rendered.success : 'unrenderable cause'
-}
 
-export const buildLedgerPlan = (
-  result: LedgerInput,
-  ledger: number,
-): Result.Result<LedgerPlan, LedgerValidationError> =>
-  Result.try({
-    try: () => buildLedgerPlanUnsafe(result, ledger),
-    catch: (cause) =>
-      ledgerValidationError(
-        'build-plan',
-        'ledger-plan-failure',
-        `TigerBeetle build-plan failed: ${causeMessage(cause)}`,
-        { ledger },
-        cause,
-      ),
-  })
+export const buildLedgerPlan = (result: LedgerInput, ledger: number): Result.Result<LedgerPlan, LedgerPlanFailure> =>
+  Result.mapError(buildLedgerPlanDecision(result, ledger), (failure) => makeLedgerPlanFailure(ledger, failure))
 
 const serializeRecord = (record: Account | Transfer): Record<string, number | string> =>
   Object.fromEntries(

--- a/services/bayn/src/ledger.test.ts
+++ b/services/bayn/src/ledger.test.ts
@@ -541,6 +541,57 @@ describe('TigerBeetle simulation journal', () => {
     expect(writes).toBe(0)
   })
 
+  test('rejects hostile event identity before TigerBeetle writes or failure rendering', async () => {
+    const { result } = evaluationPlan()
+    const fill = result.events.find((event): event is FillEvent => event.kind === 'fill')
+    assert(fill, 'evaluation fixture must contain a fill event')
+    let writes = 0
+    const client = makeTigerBeetleClient({
+      createAccounts: async () => {
+        writes += 1
+        return []
+      },
+      createTransfers: async () => {
+        writes += 1
+        return []
+      },
+    })
+
+    const error = await Effect.runPromise(
+      Effect.flip(
+        withJournal(client, (journal) =>
+          journal.journalAndReconcile({
+            ...result,
+            events: [{ ...fill, id: Symbol('fill-id') as unknown as string }],
+          }),
+        ),
+      ),
+    )
+
+    expect(error.retryable).toBeFalse()
+    expect(error.operation).toBe('build-plan')
+    expect(error.cause).toBeInstanceOf(LedgerValidationError)
+    if (error.cause instanceof LedgerValidationError) {
+      expect(error.cause).toMatchObject({
+        operation: 'build-plan',
+        reason: 'ledger-plan-failure',
+        message: 'TigerBeetle build-plan failed: fill.id is not a valid string',
+        material: {
+          ledger: journalConfig.tigerBeetle.ledger,
+          failure: {
+            kind: 'input-value-invalid',
+            field: 'fill.id',
+            expected: 'string',
+            actualType: 'symbol',
+            index: 0,
+            eventKind: 'fill',
+          },
+        },
+      })
+    }
+    expect(writes).toBe(0)
+  })
+
   test('retains hostile amount coercion inside the non-retryable journal boundary', async () => {
     const { result } = evaluationPlan()
     const fill = result.events.find((event): event is FillEvent => event.kind === 'fill')

--- a/services/bayn/src/ledger.test.ts
+++ b/services/bayn/src/ledger.test.ts
@@ -541,6 +541,47 @@ describe('TigerBeetle simulation journal', () => {
     expect(writes).toBe(0)
   })
 
+  test('keeps event canonicalization failures under the build-plan journal operation', async () => {
+    const { result } = evaluationPlan()
+    const fill = result.events.find((event): event is FillEvent => event.kind === 'fill')
+    assert(fill, 'evaluation fixture must contain a fill event')
+    const nonCanonicalFill = { ...fill, unsupported: undefined } as FillEvent
+    let writes = 0
+    const client = makeTigerBeetleClient({
+      createAccounts: async () => {
+        writes += 1
+        return []
+      },
+      createTransfers: async () => {
+        writes += 1
+        return []
+      },
+    })
+
+    const error = await Effect.runPromise(
+      Effect.flip(
+        withJournal(client, (journal) => journal.journalAndReconcile({ ...result, events: [nonCanonicalFill] })),
+      ),
+    )
+
+    expect(error.retryable).toBeFalse()
+    expect(error.operation).toBe('build-plan')
+    expect(error.cause).toBeInstanceOf(LedgerValidationError)
+    if (error.cause instanceof LedgerValidationError) {
+      expect(error.cause.operation).toBe('build-plan')
+      expect(error.cause.material).toMatchObject({
+        ledger: journalConfig.tigerBeetle.ledger,
+        failure: {
+          kind: 'canonicalization-failed',
+          canonicalizationOperation: 'event-transfer',
+          eventId: fill.id,
+          leg: 'buy',
+        },
+      })
+    }
+    expect(writes).toBe(0)
+  })
+
   test('does not turn an unexpected account-reconciliation defect into a false verification result', async () => {
     const plan = paperPlan('e')
     const accounts = materializeAccounts(plan)

--- a/services/bayn/src/ledger.test.ts
+++ b/services/bayn/src/ledger.test.ts
@@ -592,6 +592,35 @@ describe('TigerBeetle simulation journal', () => {
     expect(writes).toBe(0)
   })
 
+  test('reuses the validated run identity after writes without reading mutable input again', async () => {
+    const { result, plan } = evaluationPlan()
+    const target = makeLedgerClient()
+    let runIdReads = 0
+    const secondReadCause = new TypeError('ledger run identity was read after the plan committed')
+    const input = {
+      initialCapitalMicros: result.initialCapitalMicros,
+      inputManifest: result.inputManifest,
+      events: result.events,
+      get runId(): string {
+        runIdReads += 1
+        if (runIdReads > 1) throw secondReadCause
+        return result.runId
+      },
+    }
+
+    const reconciled = await Effect.runPromise(
+      withJournal(target.client, (journal) => journal.journalAndReconcile(input)),
+    )
+
+    expect(reconciled).toEqual({
+      runId: result.runId,
+      accountCount: plan.accounts.length,
+      transferCount: plan.transfers.length,
+      exact: true,
+    })
+    expect(runIdReads).toBe(1)
+  })
+
   test('retains hostile amount coercion inside the non-retryable journal boundary', async () => {
     const { result } = evaluationPlan()
     const fill = result.events.find((event): event is FillEvent => event.kind === 'fill')

--- a/services/bayn/src/ledger.test.ts
+++ b/services/bayn/src/ledger.test.ts
@@ -541,6 +541,62 @@ describe('TigerBeetle simulation journal', () => {
     expect(writes).toBe(0)
   })
 
+  test('retains hostile amount coercion inside the non-retryable journal boundary', async () => {
+    const { result } = evaluationPlan()
+    const fill = result.events.find((event): event is FillEvent => event.kind === 'fill')
+    assert(fill, 'evaluation fixture must contain a fill event')
+    const cause = new TypeError('ledger-plan amount coercion is unavailable')
+    const hostileAmount = {
+      [Symbol.toPrimitive]: () => {
+        throw cause
+      },
+    }
+    let writes = 0
+    const client = makeTigerBeetleClient({
+      createAccounts: async () => {
+        writes += 1
+        return []
+      },
+      createTransfers: async () => {
+        writes += 1
+        return []
+      },
+    })
+
+    const error = await Effect.runPromise(
+      Effect.flip(
+        withJournal(client, (journal) =>
+          journal.journalAndReconcile({
+            ...result,
+            events: [{ ...fill, notionalMicros: hostileAmount as unknown as string }],
+          }),
+        ),
+      ),
+    )
+
+    expect(error.retryable).toBeFalse()
+    expect(error.operation).toBe('build-plan')
+    expect(error.cause).toBeInstanceOf(LedgerValidationError)
+    if (error.cause instanceof LedgerValidationError) {
+      expect(error.cause).toMatchObject({
+        operation: 'build-plan',
+        message: 'TigerBeetle build-plan failed: fill.notionalMicros is not an integer micros value (object)',
+        material: {
+          ledger: journalConfig.tigerBeetle.ledger,
+          failure: {
+            kind: 'amount-parse-failed',
+            field: 'fill.notionalMicros',
+            actualType: 'object',
+            eventId: fill.id,
+            cause,
+          },
+        },
+        cause,
+      })
+    }
+    expect(writes).toBe(0)
+  })
+
   test('keeps event canonicalization failures under the build-plan journal operation', async () => {
     const { result } = evaluationPlan()
     const fill = result.events.find((event): event is FillEvent => event.kind === 'fill')

--- a/services/bayn/src/ledger.test.ts
+++ b/services/bayn/src/ledger.test.ts
@@ -483,10 +483,16 @@ describe('TigerBeetle simulation journal', () => {
       expect(error.cause).toMatchObject({
         operation: 'build-plan',
         reason: 'ledger-plan-failure',
-        material: { ledger: journalConfig.tigerBeetle.ledger },
+        material: {
+          ledger: journalConfig.tigerBeetle.ledger,
+          failure: { kind: 'no-fill-events', runId: result.runId, eventCount: 0 },
+        },
       })
-      expect(error.cause.cause).toBeInstanceOf(Error)
-      expect(String(error.cause.cause)).toContain('no fill events')
+      expect(error.cause.cause).toEqual({
+        kind: 'no-fill-events',
+        runId: result.runId,
+        eventCount: 0,
+      })
     }
     expect(writes).toBe(0)
   })

--- a/services/bayn/src/ledger.test.ts
+++ b/services/bayn/src/ledger.test.ts
@@ -27,6 +27,7 @@ import {
 import { LEDGER_BATCH_MAX } from './ledger-plan'
 import { evaluateRiskBalancedTrend } from './risk-balanced-trend'
 import { fixtureProtocol, makeSnapshot, makeTestProvenance } from './test-fixtures'
+import type { FillEvent } from './types'
 
 const assertSuccess = <A, E>(result: Result.Result<A, E>): A => {
   assert(Result.isSuccess(result), 'strategy evaluation fixture must succeed')
@@ -492,6 +493,49 @@ describe('TigerBeetle simulation journal', () => {
         kind: 'no-fill-events',
         runId: result.runId,
         eventCount: 0,
+      })
+    }
+    expect(writes).toBe(0)
+  })
+
+  test('retains hostile event access inside the non-retryable journal boundary', async () => {
+    const { result } = evaluationPlan()
+    const fill = result.events.find((event): event is FillEvent => event.kind === 'fill')
+    assert(fill, 'evaluation fixture must contain a fill event')
+    const cause = new TypeError('ledger-plan event kind is unavailable')
+    const hostileFill = new Proxy(fill, {
+      get: (target, property, receiver) => {
+        if (property === 'kind') throw cause
+        return Reflect.get(target, property, receiver)
+      },
+    })
+    let writes = 0
+    const client = makeTigerBeetleClient({
+      createAccounts: async () => {
+        writes += 1
+        return []
+      },
+      createTransfers: async () => {
+        writes += 1
+        return []
+      },
+    })
+
+    const error = await Effect.runPromise(
+      Effect.flip(withJournal(client, (journal) => journal.journalAndReconcile({ ...result, events: [hostileFill] }))),
+    )
+
+    expect(error.retryable).toBeFalse()
+    expect(error.cause).toBeInstanceOf(LedgerValidationError)
+    if (error.cause instanceof LedgerValidationError) {
+      expect(error.cause).toMatchObject({
+        operation: 'build-plan',
+        reason: 'ledger-plan-failure',
+        material: {
+          ledger: journalConfig.tigerBeetle.ledger,
+          failure: { kind: 'input-access-failed', field: 'event.kind', eventIndex: 0, cause },
+        },
+        cause,
       })
     }
     expect(writes).toBe(0)

--- a/services/bayn/src/ledger.ts
+++ b/services/bayn/src/ledger.ts
@@ -439,6 +439,7 @@ export {
   validatePersistedRunEvidence,
   type LedgerInput,
   type LedgerPlan,
+  type LedgerPlanFailure,
   type LedgerValidationOperation,
   type LedgerValidationReason,
 } from './ledger-plan'

--- a/services/bayn/src/ledger.ts
+++ b/services/bayn/src/ledger.ts
@@ -321,7 +321,7 @@ const journalAndReconcile = (
       { concurrency: 'unbounded' },
     )
     yield* validationBoundary(reconcileLedgerPlan(plan, accounts, transfers))
-    return { runId: result.runId, accountCount: accounts.length, transferCount: transfers.length, exact: true }
+    return { runId: plan.runId, accountCount: accounts.length, transferCount: transfers.length, exact: true }
   })
 
 const post = (client: TigerBeetleRequestClient, plan: LedgerPlan): Effect.Effect<void, OperationalError> =>
@@ -437,6 +437,7 @@ export {
   LedgerValidationError,
   reconcileLedgerPlan,
   validatePersistedRunEvidence,
+  type EvaluationLedgerPlan,
   type LedgerInput,
   type LedgerPlan,
   type LedgerPlanFailure,


### PR DESCRIPTION
## Summary

- replace ledger-plan throw/catch construction with closed fact-bearing `Result` failures for parsing, capital, inventory, transfer hashing, hostile input access, and query limits
- preserve the existing `LedgerValidationError` and `OperationalError` boundary while exposing exact planner failure material
- retain exact TigerBeetle identity, ordering, amounts, flags, limits, and replay hashes with focused regressions

## Related Issues

None

## Testing

- `bun test services/bayn/src/ledger-plan.test.ts services/bayn/src/ledger.test.ts services/bayn/src/db/evidence-recovery.test.ts --timeout 30000`
- `bun run --filter @proompteng/bayn test`
- `bun services/bayn/node_modules/typescript/bin/tsc --noEmit -p services/bayn/tsconfig.json`
- `bun services/bayn/node_modules/@effect/tsgo/dist/effect-tsgo.js diagnostics --project services/bayn/tsconfig.json --format text --severity error`
- `bun node_modules/oxfmt/bin/oxfmt --check services/bayn/src`
- `node_modules/.bin/oxlint --config .oxlintrc.json services/bayn`
- `node_modules/.bin/oxlint --config .oxlintrc.json --type-aware --tsconfig services/bayn/tsconfig.json services/bayn`
- `bun build services/bayn/src/index.ts --target=node --external tigerbeetle-node --outdir=services/bayn/dist`
- `bun test packages/scripts/src/bayn`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots section removed because it is not applicable; Breaking Changes is handled.
- [x] No documentation, release-note, or follow-up changes are required.
