### PR TITLE
refactor(bayn): totalize qualification audit

### DIFF
--- a/services/bayn/src/audit/audit.ts
+++ b/services/bayn/src/audit/audit.ts
@@ -21,7 +21,7 @@ import {
 } from '../types'
 import { evaluateReference, type ReferenceEvaluation, type ReferenceEvaluationFailure } from './reference'
 
-const decodeReconciliation = Schema.decodeUnknownSync(ReconciliationResultSchema, StrictParseOptions)
+const decodeReconciliation = Schema.decodeUnknownResult(ReconciliationResultSchema, StrictParseOptions)
 type GateScalar = EconomicVerdict['gates'][number]['actual']
 
 export interface StoredArtifact {
@@ -112,15 +112,29 @@ export interface SignalPrincipals {
   readonly publishers: readonly string[]
 }
 
+export type SignalTableClassificationFailure = {
+  readonly _tag: 'SignalEvidenceTableNotAccessed'
+  readonly observedTables: readonly string[]
+  readonly expectedTables: readonly string[]
+}
+
 export const classifySignalTableAccess = (
   observedTables: readonly string[],
   signalTables: InputManifest['tables'],
-): SignalAccessRecord['kind'] => {
+): Result.Result<SignalAccessRecord['kind'], SignalTableClassificationFailure> => {
   const tables = new Set(observedTables)
-  if (tables.has(`signal.${signalTables.bars}`)) return 'bars'
-  if (tables.has(`signal.${signalTables.sessions}`)) return 'sessions'
-  if (tables.has(`signal.${signalTables.manifests}`)) return 'manifest'
-  throw new Error('query log record does not access a Signal evidence table')
+  if (tables.has(`signal.${signalTables.bars}`)) return Result.succeed('bars')
+  if (tables.has(`signal.${signalTables.sessions}`)) return Result.succeed('sessions')
+  if (tables.has(`signal.${signalTables.manifests}`)) return Result.succeed('manifest')
+  return Result.fail({
+    _tag: 'SignalEvidenceTableNotAccessed',
+    observedTables: [...observedTables].sort(),
+    expectedTables: [
+      `signal.${signalTables.bars}`,
+      `signal.${signalTables.sessions}`,
+      `signal.${signalTables.manifests}`,
+    ].sort(),
+  })
 }
 
 export interface RepositoryAudit {
@@ -139,6 +153,111 @@ export interface QualificationAuditInput {
   readonly signalPrincipals: SignalPrincipals
   readonly repository: RepositoryAudit
 }
+
+export interface SignalReplicaAuditSource {
+  readonly replica: string
+  readonly topology: readonly string[]
+  readonly access: readonly SignalAccessRecord[]
+}
+
+export type SignalReplicaTopologyFailure =
+  | {
+      readonly _tag: 'DuplicateSignalReplicaEndpoint'
+      readonly observedReplicas: readonly string[]
+    }
+  | {
+      readonly _tag: 'InvalidSignalReplicaTopology'
+      readonly topology: readonly string[]
+      readonly minimumReplicaCount: 2
+    }
+  | {
+      readonly _tag: 'DivergentSignalReplicaTopology'
+      readonly replica: string
+      readonly expectedTopology: readonly string[]
+      readonly actualTopology: readonly string[]
+    }
+  | {
+      readonly _tag: 'IncompleteSignalReplicaCoverage'
+      readonly observedReplicas: readonly string[]
+      readonly expectedTopology: readonly string[]
+    }
+  | {
+      readonly _tag: 'SignalReplicaRecordMismatch'
+      readonly endpointReplica: string
+      readonly recordReplica: string
+      readonly queryId: string
+    }
+
+export const validateSignalReplicaTopology = (
+  sources: readonly SignalReplicaAuditSource[],
+): Result.Result<
+  { readonly replicas: readonly string[]; readonly access: readonly SignalAccessRecord[] },
+  SignalReplicaTopologyFailure
+> => {
+  const observedReplicas = sources.map((source) => source.replica).sort()
+  if (new Set(observedReplicas).size !== observedReplicas.length) {
+    return Result.fail({ _tag: 'DuplicateSignalReplicaEndpoint', observedReplicas })
+  }
+  const expectedTopology = [...(sources[0]?.topology ?? [])].sort()
+  if (expectedTopology.length < 2 || new Set(expectedTopology).size !== expectedTopology.length) {
+    return Result.fail({ _tag: 'InvalidSignalReplicaTopology', topology: expectedTopology, minimumReplicaCount: 2 })
+  }
+  for (const source of sources) {
+    const actualTopology = [...source.topology].sort()
+    if (actualTopology.join('\0') !== expectedTopology.join('\0')) {
+      return Result.fail({
+        _tag: 'DivergentSignalReplicaTopology',
+        replica: source.replica,
+        expectedTopology,
+        actualTopology,
+      })
+    }
+  }
+  if (observedReplicas.join('\0') !== expectedTopology.join('\0')) {
+    return Result.fail({ _tag: 'IncompleteSignalReplicaCoverage', observedReplicas, expectedTopology })
+  }
+  for (const source of sources) {
+    const mismatched = source.access.find((record) => record.replica !== source.replica)
+    if (mismatched !== undefined) {
+      return Result.fail({
+        _tag: 'SignalReplicaRecordMismatch',
+        endpointReplica: source.replica,
+        recordReplica: mismatched.replica,
+        queryId: mismatched.queryId,
+      })
+    }
+  }
+  return Result.succeed({ replicas: observedReplicas, access: sources.flatMap((source) => source.access) })
+}
+
+export type QualificationAuditFailure =
+  | ReferenceEvaluationFailure
+  | {
+      readonly _tag: 'UnsupportedAuditStrategyContract'
+      readonly protocolStrategyName: string
+      readonly runStrategyName: string
+      readonly requiredStrategyName: typeof contract.name
+    }
+  | {
+      readonly _tag: 'UnsupportedAuditProtocolVersion'
+      readonly storedSchemaVersion: string
+      readonly suppliedSchemaVersion: string
+      readonly requiredSchemaVersion: 'bayn.risk-balanced-trend.protocol.v3'
+    }
+  | {
+      readonly _tag: 'ReferenceCandidateTraceMissing'
+      readonly runId: string
+    }
+  | {
+      readonly _tag: 'ReconciliationArtifactInvalid'
+      readonly artifactName: 'reconciliation'
+      readonly cause: Schema.SchemaError
+    }
+  | {
+      readonly _tag: 'UnsupportedQualificationArtifact'
+      readonly artifactName: string
+      readonly supportedArtifactNames: readonly string[]
+    }
 
 export interface AuditCheck {
   readonly name: string
@@ -300,18 +419,26 @@ const makeMarkedEquityAuditMaterial = (
 
 const makeAuditFacts = (
   input: QualificationAuditInput,
-): Result.Result<QualificationAuditFacts, ReferenceEvaluationFailure> => {
+): Result.Result<QualificationAuditFacts, QualificationAuditFailure> => {
   const database = input.database
   if (database.protocol.strategyName !== contract.name || database.run.strategyName !== contract.name) {
-    throw new Error('stored qualification uses an unsupported strategy contract')
+    return Result.fail({
+      _tag: 'UnsupportedAuditStrategyContract',
+      protocolStrategyName: database.protocol.strategyName,
+      runStrategyName: database.run.strategyName,
+      requiredStrategyName: contract.name,
+    })
   }
   if (
     database.protocol.schemaVersion !== 'bayn.risk-balanced-trend.protocol.v3' ||
     input.protocol.schemaVersion !== 'bayn.risk-balanced-trend.protocol.v3'
   ) {
-    throw new Error(
-      'current auditor requires causal protocol v3; audit immutable v2 evidence with its source-pinned image',
-    )
+    return Result.fail({
+      _tag: 'UnsupportedAuditProtocolVersion',
+      storedSchemaVersion: database.protocol.schemaVersion,
+      suppliedSchemaVersion: input.protocol.schemaVersion,
+      requiredSchemaVersion: 'bayn.risk-balanced-trend.protocol.v3',
+    })
   }
   const provenance = makeRuntimeProvenance({
     sourceRevision: database.run.sourceRevision,
@@ -327,7 +454,7 @@ const makeAuditFacts = (
   if (Result.isFailure(referenceResult)) return Result.fail(referenceResult.failure)
   const reference = referenceResult.success
   const trace = reference.strategy.trace
-  if (trace === null) throw new Error('reference evaluation omitted its candidate trace')
+  if (trace === null) return Result.fail({ _tag: 'ReferenceCandidateTraceMissing', runId: reference.runId })
   const sortedReplicas = [...input.signalReplicas].sort()
   const sortedAccess = [...input.signalAccess].sort((left, right) => {
     if (left.queryStartTime !== right.queryStartTime) return left.queryStartTime < right.queryStartTime ? -1 : 1
@@ -551,9 +678,19 @@ const auditReferenceArtifacts = (facts: QualificationAuditFacts): readonly Audit
   return checks
 }
 
-const auditArtifactManifest = (facts: QualificationAuditFacts): readonly AuditCheck[] => {
+const auditArtifactManifest = (
+  facts: QualificationAuditFacts,
+): Result.Result<readonly AuditCheck[], QualificationAuditFailure> => {
   const { artifact, database, input, markedEquity, reference, trace } = facts
-  const reconciliation = decodeReconciliation(artifact.get('reconciliation')?.payload)
+  const reconciliationResult = decodeReconciliation(artifact.get('reconciliation')?.payload)
+  if (Result.isFailure(reconciliationResult)) {
+    return Result.fail({
+      _tag: 'ReconciliationArtifactInvalid',
+      artifactName: 'reconciliation',
+      cause: reconciliationResult.failure,
+    })
+  }
+  const reconciliation = reconciliationResult.success
   const checks = [
     makeAuditCheck(
       'accounting-reconciliation-identity',
@@ -563,7 +700,7 @@ const auditArtifactManifest = (facts: QualificationAuditFacts): readonly AuditCh
   ]
   if (markedEquity._tag === 'Unavailable') {
     checks.push(makeAuditCheck('qualification-artifact-manifest', false, markedEquity.evidence))
-    return checks
+    return Result.succeed(checks)
   }
   const artifactItemCounts = new Map<string, number>([
     ['evaluation-summary', 0],
@@ -583,12 +720,32 @@ const auditArtifactManifest = (facts: QualificationAuditFacts): readonly AuditCh
     ['marked-equity-reconciliation', 0],
     ['reconciliation', 0],
   ])
-  const artifactItemCount = (name: string): number => {
-    const count = artifactItemCounts.get(name)
-    if (count === undefined) throw new Error(`unsupported qualification artifact: ${name}`)
-    return count
-  }
   const baseArtifacts = database.artifacts.filter((value) => value.name !== 'qualification-artifact-manifest')
+  const supportedArtifactNames = [...artifactItemCounts.keys()].sort()
+  const manifestArtifacts: {
+    readonly name: string
+    readonly schemaVersion: string
+    readonly itemCount: number
+    readonly contentHash: string
+  }[] = []
+  for (const value of [...baseArtifacts].sort((left, right) =>
+    left.name < right.name ? -1 : left.name > right.name ? 1 : 0,
+  )) {
+    const itemCount = artifactItemCounts.get(value.name)
+    if (itemCount === undefined) {
+      return Result.fail({
+        _tag: 'UnsupportedQualificationArtifact',
+        artifactName: value.name,
+        supportedArtifactNames,
+      })
+    }
+    manifestArtifacts.push({
+      name: value.name,
+      schemaVersion: value.schemaVersion,
+      itemCount,
+      contentHash: value.contentHash,
+    })
+  }
   const qualificationManifest = {
     schemaVersion: 'bayn.qualification-artifact-manifest.v1',
     identity: {
@@ -610,14 +767,7 @@ const auditArtifactManifest = (facts: QualificationAuditFacts): readonly AuditCh
       executionModel: input.protocol.executionModel,
       costMultiplierMicros: MICROS_STRING,
     },
-    artifacts: [...baseArtifacts]
-      .sort((left, right) => (left.name < right.name ? -1 : left.name > right.name ? 1 : 0))
-      .map((value) => ({
-        name: value.name,
-        schemaVersion: value.schemaVersion,
-        itemCount: artifactItemCount(value.name),
-        contentHash: value.contentHash,
-      })),
+    artifacts: manifestArtifacts,
     events: {
       count: database.events.length,
       contentHash: canonicalHashV1(
@@ -638,7 +788,7 @@ const auditArtifactManifest = (facts: QualificationAuditFacts): readonly AuditCh
       `contentHash=${canonicalHashV1(qualificationManifest)}`,
     ),
   )
-  return checks
+  return Result.succeed(checks)
 }
 
 const auditQualificationBindings = (facts: QualificationAuditFacts): readonly AuditCheck[] => {
@@ -842,14 +992,16 @@ const makeAuditReport = (facts: QualificationAuditFacts, checks: readonly AuditC
 
 export const auditQualification = (
   input: QualificationAuditInput,
-): Result.Result<QualificationAuditReport, ReferenceEvaluationFailure> => {
+): Result.Result<QualificationAuditReport, QualificationAuditFailure> => {
   const factsResult = makeAuditFacts(input)
   if (Result.isFailure(factsResult)) return Result.fail(factsResult.failure)
   const facts = factsResult.success
+  const artifactManifestChecks = auditArtifactManifest(facts)
+  if (Result.isFailure(artifactManifestChecks)) return Result.fail(artifactManifestChecks.failure)
   const checks = [
     ...auditStoredEvidence(facts),
     ...auditReferenceArtifacts(facts),
-    ...auditArtifactManifest(facts),
+    ...artifactManifestChecks.success,
     ...auditQualificationBindings(facts),
     ...auditSignalAndRepository(facts),
   ]

--- a/services/bayn/src/audit/dossier.ts
+++ b/services/bayn/src/audit/dossier.ts
@@ -1,27 +1,28 @@
 import { Result, Schema } from 'effect'
 
 import { canonicalHashV1 } from '../hash'
-import { QualificationLockSchema, QualificationResultSchema } from '../qualification'
+import {
+  QualificationLockSchema,
+  QualificationResultSchema,
+  type QualificationLock,
+  type QualificationResult,
+} from '../qualification'
 import { strictParseOptions as StrictParseOptions } from '../schemas'
 import type { InputManifest } from '../types'
 import {
   auditQualification,
   type AuditDatabaseSnapshot,
+  type QualificationAuditFailure,
   type QualificationAuditInput,
   type QualificationAuditReport,
 } from './audit'
-import type { ReferenceEvaluationFailure } from './reference'
 
-const decodeLock = Schema.decodeUnknownSync(QualificationLockSchema, StrictParseOptions)
-const decodeResult = Schema.decodeUnknownSync(QualificationResultSchema, StrictParseOptions)
+const decodeLock = Schema.decodeUnknownResult(QualificationLockSchema, StrictParseOptions)
+const decodeResult = Schema.decodeUnknownResult(QualificationResultSchema, StrictParseOptions)
 
 const itemCount = (payload: unknown): number => {
   if (typeof payload !== 'object' || payload === null || !('items' in payload)) return 0
   return Array.isArray(payload.items) ? payload.items.length : 0
-}
-
-const assert = (condition: boolean, message: string): void => {
-  if (!condition) throw new Error(message)
 }
 
 const evidenceSummary = (database: AuditDatabaseSnapshot) => ({
@@ -51,25 +52,82 @@ const evidenceSummary = (database: AuditDatabaseSnapshot) => ({
   },
 })
 
+export type QualificationDossierFailure =
+  | QualificationAuditFailure
+  | {
+      readonly _tag: 'QualificationDossierSubjectMismatch'
+      readonly check: QualificationDossierSubjectCheck
+      readonly actual: unknown
+      readonly expected: unknown
+    }
+  | {
+      readonly _tag: 'QualificationDossierDocumentInvalid'
+      readonly document: 'lock' | 'result'
+      readonly cause: Schema.SchemaError
+    }
+
+type QualificationDossierSubjectCheck =
+  | 'audit-passed'
+  | 'audit-hash'
+  | 'database-read-only'
+  | 'evaluation-complete'
+  | 'audit-run-id'
+  | 'protocol-hash'
+  | 'snapshot-id'
+  | 'stored-artifact-count'
+  | 'stored-event-count'
+  | 'stored-gate-count'
+  | 'audit-artifact-count'
+  | 'audit-event-count'
+  | 'audit-gate-count'
+  | 'lock-run-id'
+  | 'result-run-id'
+  | 'stored-lock-id'
+  | 'result-lock-id'
+  | 'stored-analysis-hash'
+  | 'stored-result-hash'
+  | 'stored-verdict'
+  | 'trial-lineage'
+
+const mismatch = (
+  check: QualificationDossierSubjectCheck,
+  actual: unknown,
+  expected: unknown,
+): Result.Result<never, QualificationDossierFailure> =>
+  Result.fail({ _tag: 'QualificationDossierSubjectMismatch', check, actual, expected })
+
+const requireEqual = (
+  check: QualificationDossierSubjectCheck,
+  actual: unknown,
+  expected: unknown,
+): Result.Result<void, QualificationDossierFailure> =>
+  Object.is(actual, expected) ? Result.succeed(undefined) : mismatch(check, actual, expected)
+
 const validateSubject = (
   database: AuditDatabaseSnapshot,
   manifest: InputManifest,
   audit: QualificationAuditReport,
-): void => {
+): Result.Result<void, QualificationDossierFailure> => {
   const auditMaterial = Object.fromEntries(Object.entries(audit).filter(([name]) => name !== 'auditHash'))
-  assert(audit.status === 'PASS' && audit.checks.every((check) => check.passed), 'qualification audit did not pass')
-  assert(audit.auditHash === canonicalHashV1(auditMaterial), 'qualification audit hash is invalid')
-  assert(database.transactionReadOnly, 'qualification database snapshot was not read-only')
-  assert(database.run.status === 'COMPLETE', 'qualification evaluation is not complete')
-  assert(database.run.runId === audit.runId, 'qualification audit and evaluation run IDs differ')
-  assert(database.run.protocolHash === database.protocol.protocolHash, 'run and protocol hashes differ')
-  assert(database.run.snapshotId === manifest.finalizedSnapshot.snapshotId, 'run and Signal snapshot IDs differ')
-  assert(database.run.artifactCount === database.artifacts.length, 'artifact count differs from the stored run')
-  assert(database.run.eventCount === database.events.length, 'event count differs from the stored run')
-  assert(database.run.gateCount === database.gates.length, 'gate count differs from the stored run')
-  assert(audit.evidence.artifactCount === database.artifacts.length, 'audit artifact count differs')
-  assert(audit.evidence.eventCount === database.events.length, 'audit event count differs')
-  assert(audit.evidence.gateCount === database.gates.length, 'audit gate count differs')
+  const checks = [
+    requireEqual('audit-passed', audit.status === 'PASS' && audit.checks.every((check) => check.passed), true),
+    requireEqual('audit-hash', audit.auditHash, canonicalHashV1(auditMaterial)),
+    requireEqual('database-read-only', database.transactionReadOnly, true),
+    requireEqual('evaluation-complete', database.run.status, 'COMPLETE'),
+    requireEqual('audit-run-id', audit.runId, database.run.runId),
+    requireEqual('protocol-hash', database.run.protocolHash, database.protocol.protocolHash),
+    requireEqual('snapshot-id', database.run.snapshotId, manifest.finalizedSnapshot.snapshotId),
+    requireEqual('stored-artifact-count', database.run.artifactCount, database.artifacts.length),
+    requireEqual('stored-event-count', database.run.eventCount, database.events.length),
+    requireEqual('stored-gate-count', database.run.gateCount, database.gates.length),
+    requireEqual('audit-artifact-count', audit.evidence.artifactCount, database.artifacts.length),
+    requireEqual('audit-event-count', audit.evidence.eventCount, database.events.length),
+    requireEqual('audit-gate-count', audit.evidence.gateCount, database.gates.length),
+  ]
+  for (const check of checks) {
+    if (Result.isFailure(check)) return Result.fail(check.failure)
+  }
+  return Result.succeed(undefined)
 }
 
 export interface QualificationDossier {
@@ -85,8 +143,8 @@ export interface QualificationDossier {
     readonly resultCommittedAt: string
     readonly priorTrialRunIds: readonly string[]
     readonly priorTrialSetHash: string
-    readonly lock: ReturnType<typeof decodeLock>
-    readonly result: ReturnType<typeof decodeResult>
+    readonly lock: QualificationLock
+    readonly result: QualificationResult
   }
   readonly audit: QualificationAuditReport
   readonly authority: {
@@ -101,25 +159,36 @@ export interface QualificationDossier {
 
 export const makeQualificationDossier = (
   input: QualificationAuditInput,
-): Result.Result<QualificationDossier, ReferenceEvaluationFailure> => {
+): Result.Result<QualificationDossier, QualificationDossierFailure> => {
   const auditResult = auditQualification(input)
   if (Result.isFailure(auditResult)) return Result.fail(auditResult.failure)
   const audit = auditResult.success
   const database = input.database
-  validateSubject(database, input.manifest, audit)
-  const lock = decodeLock(database.qualification.lock)
-  const result = decodeResult(database.qualification.result)
-  assert(lock.candidateRunId === database.run.runId, 'qualification lock and evaluation run IDs differ')
-  assert(result.runId === database.run.runId, 'qualification result and evaluation run IDs differ')
-  assert(lock.lockId === database.qualification.storedLockId, 'qualification lock ID differs from its row')
-  assert(result.lockId === lock.lockId, 'qualification result and lock IDs differ')
-  assert(
-    result.analysis.analysisHash === database.qualification.storedAnalysisHash,
-    'analysis hash differs from its row',
-  )
-  assert(result.resultHash === database.qualification.storedResultHash, 'result hash differs from its row')
-  assert(result.verdict === database.qualification.storedVerdict, 'qualification verdict differs from its row')
-  assert(canonicalHashV1(lock.priorTrialRunIds) === canonicalHashV1(database.priorTrialRunIds), 'trial lineage differs')
+  const subjectResult = validateSubject(database, input.manifest, audit)
+  if (Result.isFailure(subjectResult)) return Result.fail(subjectResult.failure)
+  const lockResult = decodeLock(database.qualification.lock)
+  if (Result.isFailure(lockResult)) {
+    return Result.fail({ _tag: 'QualificationDossierDocumentInvalid', document: 'lock', cause: lockResult.failure })
+  }
+  const resultResult = decodeResult(database.qualification.result)
+  if (Result.isFailure(resultResult)) {
+    return Result.fail({ _tag: 'QualificationDossierDocumentInvalid', document: 'result', cause: resultResult.failure })
+  }
+  const lock = lockResult.success
+  const result = resultResult.success
+  const bindingChecks = [
+    requireEqual('lock-run-id', lock.candidateRunId, database.run.runId),
+    requireEqual('result-run-id', result.runId, database.run.runId),
+    requireEqual('stored-lock-id', lock.lockId, database.qualification.storedLockId),
+    requireEqual('result-lock-id', result.lockId, lock.lockId),
+    requireEqual('stored-analysis-hash', result.analysis.analysisHash, database.qualification.storedAnalysisHash),
+    requireEqual('stored-result-hash', result.resultHash, database.qualification.storedResultHash),
+    requireEqual('stored-verdict', result.verdict, database.qualification.storedVerdict),
+    requireEqual('trial-lineage', canonicalHashV1(lock.priorTrialRunIds), canonicalHashV1(database.priorTrialRunIds)),
+  ]
+  for (const check of bindingChecks) {
+    if (Result.isFailure(check)) return Result.fail(check.failure)
+  }
 
   const material = {
     schemaVersion: 'bayn.qualification-dossier.v2' as const,

--- a/services/bayn/src/audit/reference.ts
+++ b/services/bayn/src/audit/reference.ts
@@ -55,8 +55,14 @@ interface Target {
 }
 
 interface Position {
-  quantityMicros: bigint
-  costBasisMicros: bigint
+  readonly quantityMicros: bigint
+  readonly costBasisMicros: bigint
+}
+
+export interface ReferenceReplayWork {
+  readonly sessionsProcessed: number
+  readonly positionStateCopies: number
+  readonly positionWrites: number
 }
 
 interface Replay {
@@ -65,6 +71,10 @@ interface Replay {
   readonly decisions: readonly SignalDecision[]
   readonly daily: readonly DailyPerformancePoint[]
   readonly trace: SimulationTrace | null
+}
+
+interface ReplayWithWork extends Replay {
+  readonly work: ReferenceReplayWork
 }
 
 export interface ReferenceEvaluation {
@@ -77,12 +87,197 @@ export interface ReferenceEvaluation {
   readonly verdict: EconomicVerdict
 }
 
+export interface ReferenceEvaluationWork {
+  readonly strategy: ReferenceReplayWork
+  readonly buyAndHold: ReferenceReplayWork
+  readonly directVolTiming: ReferenceReplayWork
+  readonly doubleCostStrategy: ReferenceReplayWork
+}
+
+interface ReferenceEvaluationWithWork {
+  readonly runId: string
+  readonly protocolHash: string
+  readonly strategy: ReplayWithWork
+  readonly buyAndHold: ReplayWithWork
+  readonly directVolTiming: ReplayWithWork
+  readonly doubleCostStrategy: ReplayWithWork
+  readonly verdict: EconomicVerdict
+}
+
 export type ReferenceEvaluationFailure =
   | ExecutionModelFailure
   | {
       readonly _tag: 'UnsupportedReferenceExecutionModel'
       readonly actual: string
       readonly required: 'bayn.execution-model.v2'
+    }
+  | {
+      readonly _tag: 'ReferenceInputRowCountMismatch'
+      readonly expected: number
+      readonly actual: number
+    }
+  | {
+      readonly _tag: 'ReferenceUnexpectedSymbol'
+      readonly symbol: string
+      readonly sessionDate: IsoDate
+      readonly universe: readonly string[]
+    }
+  | {
+      readonly _tag: 'ReferenceDuplicateBar'
+      readonly symbol: string
+      readonly sessionDate: IsoDate
+    }
+  | {
+      readonly _tag: 'ReferenceIncompleteSession'
+      readonly sessionDate: IsoDate
+      readonly missingSymbols: readonly string[]
+      readonly actualSymbolCount: number
+      readonly expectedSymbolCount: number
+    }
+  | {
+      readonly _tag: 'ReferenceManifestSessionMismatch'
+      readonly expectedSessionCount: number
+      readonly actualSessionCount: number
+      readonly expectedFirstSession: IsoDate
+      readonly actualFirstSession: IsoDate | null
+      readonly expectedLastSession: IsoDate
+      readonly actualLastSession: IsoDate | null
+    }
+  | {
+      readonly _tag: 'ReferenceInvalidWeight'
+      readonly symbol: string
+      readonly weight: number
+      readonly maximumWeight: number
+    }
+  | {
+      readonly _tag: 'ReferenceWeightBoundingFailed'
+      readonly totalUnits: number
+      readonly excessUnits: number
+      readonly weightScale: number
+    }
+  | {
+      readonly _tag: 'ReferenceCovarianceInputMismatch'
+      readonly leftLength: number
+      readonly rightLength: number
+    }
+  | {
+      readonly _tag: 'ReferenceCovarianceNotFinite'
+      readonly leftLength: number
+      readonly rightLength: number
+      readonly covariance: number
+    }
+  | {
+      readonly _tag: 'ReferencePortfolioVarianceInvalid'
+      readonly dailyVariance: number
+    }
+  | {
+      readonly _tag: 'ReferencePortfolioVolatilityInvalid'
+      readonly dailyVariance: number
+      readonly annualizedVolatility: number
+    }
+  | {
+      readonly _tag: 'ReferenceInsufficientHistory'
+      readonly signalIndex: number
+      readonly requiredHistory: number
+      readonly sessionCount: number
+    }
+  | {
+      readonly _tag: 'ReferenceInvalidClose'
+      readonly symbol: string
+      readonly sessionDate: IsoDate
+      readonly close: number
+    }
+  | {
+      readonly _tag: 'ReferenceMissingCurrentClose'
+      readonly symbol: string
+      readonly signalIndex: number
+    }
+  | {
+      readonly _tag: 'ReferenceInvalidReturn'
+      readonly symbol: string
+      readonly sessionDate: IsoDate
+      readonly value: number
+    }
+  | {
+      readonly _tag: 'ReferenceMissingPriorClose'
+      readonly symbol: string
+      readonly signalIndex: number
+      readonly horizonSessions: number
+    }
+  | {
+      readonly _tag: 'ReferenceInvalidHorizonSignal'
+      readonly symbol: string
+      readonly horizonSessions: number
+      readonly return: number
+      readonly normalizedTrend: number
+    }
+  | {
+      readonly _tag: 'ReferenceInvalidScore'
+      readonly symbol: string
+      readonly annualizedVolatility: number
+      readonly compositeScore: number
+    }
+  | {
+      readonly _tag: 'ReferenceWeightsOutsideLimits'
+      readonly totalWeight: number
+      readonly maximumSymbolWeight: number
+      readonly portfolioVolatility: number
+      readonly maximumPortfolioVolatility: number
+    }
+  | {
+      readonly _tag: 'ReferenceDirectVolatilityWindowInvalid'
+      readonly signalIndex: number
+      readonly requiredPriorIndex: number
+      readonly sessionCount: number
+    }
+  | {
+      readonly _tag: 'ReferenceInvalidEquityCurve'
+      readonly observationCount: number
+      readonly firstNonPositiveIndex: number | null
+      readonly firstNonPositiveValueMicros: string | null
+    }
+  | {
+      readonly _tag: 'ReferenceBuyFillRestrictionInvalid'
+      readonly orderId: string
+      readonly modeledQuantityMicros: string
+      readonly permittedQuantityMicros: string
+    }
+  | {
+      readonly _tag: 'ReferenceMissingDecisionPlan'
+      readonly signalIndex: number
+      readonly executionIndex: number
+    }
+  | {
+      readonly _tag: 'ReferenceTargetSignalMissing'
+      readonly signalIndex: number
+      readonly executionIndex: number
+      readonly sessionCount: number
+    }
+  | {
+      readonly _tag: 'ReferenceNegativeCash'
+      readonly sessionDate: IsoDate
+      readonly cashMicros: string
+    }
+  | {
+      readonly _tag: 'ReferenceNoEligibleSignal'
+      readonly sessionCount: number
+      readonly lookbackStart: IsoDate
+      readonly evaluationStart: IsoDate
+      readonly evaluationEnd: IsoDate
+    }
+  | {
+      readonly _tag: 'ReferenceInsufficientObservations'
+      readonly actual: number
+      readonly required: number
+      readonly startIndex: number
+      readonly endExclusive: number
+    }
+  | {
+      readonly _tag: 'ReferenceProvenanceMismatch'
+      readonly requiredStrategyName: 'risk-balanced-trend'
+      readonly actualStrategyName: string
+      readonly expectedParameterHash: string
+      readonly actualParameterHash: string
     }
 
 type ReferenceComputation<A> = Result.Result<A, ReferenceEvaluationFailure>
@@ -100,40 +295,82 @@ const sampleDeviation = (values: readonly number[]): number => {
   return Math.sqrt(variance)
 }
 
-const align = (bars: readonly DailyBar[], manifest: InputManifest, universe: readonly string[]): readonly Session[] => {
-  if (bars.length !== manifest.rowCount) throw new Error('reference input row count differs from the manifest')
+const align = (
+  bars: readonly DailyBar[],
+  manifest: InputManifest,
+  universe: readonly string[],
+): ReferenceComputation<readonly Session[]> => {
+  if (bars.length !== manifest.rowCount) {
+    return Result.fail({
+      _tag: 'ReferenceInputRowCountMismatch',
+      expected: manifest.rowCount,
+      actual: bars.length,
+    })
+  }
   const expected = new Set(universe)
   const grouped = new Map<IsoDate, Map<string, DailyBar>>()
   for (const bar of bars) {
-    if (!expected.has(bar.symbol)) throw new Error(`reference input has unexpected symbol ${bar.symbol}`)
+    if (!expected.has(bar.symbol)) {
+      return Result.fail({
+        _tag: 'ReferenceUnexpectedSymbol',
+        symbol: bar.symbol,
+        sessionDate: bar.sessionDate,
+        universe,
+      })
+    }
     const day = grouped.get(bar.sessionDate) ?? new Map<string, DailyBar>()
-    if (day.has(bar.symbol)) throw new Error(`reference input duplicates ${bar.symbol} ${bar.sessionDate}`)
+    if (day.has(bar.symbol)) {
+      return Result.fail({ _tag: 'ReferenceDuplicateBar', symbol: bar.symbol, sessionDate: bar.sessionDate })
+    }
     day.set(bar.symbol, bar)
     grouped.set(bar.sessionDate, day)
   }
-  const sessions = [...grouped.entries()]
-    .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
-    .map(([date, day]): Session => {
-      if (day.size !== universe.length || universe.some((symbol) => !day.has(symbol))) {
-        throw new Error(`reference input session ${date} is incomplete`)
+  const sessions: Session[] = []
+  for (const [date, day] of [...grouped.entries()].sort(([left], [right]) =>
+    left < right ? -1 : left > right ? 1 : 0,
+  )) {
+    const missingSymbols = universe.filter((symbol) => !day.has(symbol))
+    if (day.size !== universe.length || missingSymbols.length > 0) {
+      return Result.fail({
+        _tag: 'ReferenceIncompleteSession',
+        sessionDate: date,
+        missingSymbols,
+        actualSymbolCount: day.size,
+        expectedSymbolCount: universe.length,
+      })
+    }
+    const sessionBars: Record<string, DailyBar> = {}
+    for (const symbol of universe) {
+      const bar = day.get(symbol)
+      if (bar === undefined) {
+        return Result.fail({
+          _tag: 'ReferenceIncompleteSession',
+          sessionDate: date,
+          missingSymbols: [symbol],
+          actualSymbolCount: day.size,
+          expectedSymbolCount: universe.length,
+        })
       }
-      const sessionBars = Object.fromEntries(
-        universe.map((symbol) => {
-          const bar = day.get(symbol)
-          if (bar === undefined) throw new Error(`reference input session ${date} is missing ${symbol}`)
-          return [symbol, bar]
-        }),
-      )
-      return { date, bars: sessionBars }
-    })
+      sessionBars[symbol] = bar
+    }
+    sessions.push({ date, bars: sessionBars })
+  }
   if (
     sessions.length !== manifest.sessionCount ||
     sessions[0]?.date !== manifest.firstSession ||
     sessions.at(-1)?.date !== manifest.lastSession
   ) {
-    throw new Error('reference input sessions differ from the manifest')
+    return Result.fail({
+      _tag: 'ReferenceManifestSessionMismatch',
+      expectedSessionCount: manifest.sessionCount,
+      actualSessionCount: sessions.length,
+      expectedFirstSession: manifest.firstSession,
+      actualFirstSession: sessions[0]?.date ?? null,
+      expectedLastSession: manifest.lastSession,
+      actualLastSession: sessions.at(-1)?.date ?? null,
+    })
   }
-  return sessions
+  return Result.succeed(sessions)
 }
 
 const monthEnds = (dates: readonly IsoDate[]): readonly number[] => {
@@ -144,7 +381,7 @@ const monthEnds = (dates: readonly IsoDate[]): readonly number[] => {
   return result
 }
 
-const riskBalancedHistoryLength = (protocol: Protocol): number =>
+const riskBalancedHistoryLength = (protocol: Pick<Protocol, 'volatilityWindow' | 'horizons'>): number =>
   Math.max(protocol.volatilityWindow, ...protocol.horizons)
 
 const allocateCapped = (
@@ -185,17 +422,16 @@ const weightScale = 1_000_000_000_000
 const quantizeCappedWeights = (
   weights: Readonly<Record<string, number>>,
   maximumWeight: number,
-): Readonly<Record<string, number>> => {
+): ReferenceComputation<Readonly<Record<string, number>>> => {
   const maximumUnits = Math.floor(maximumWeight * weightScale + Number.EPSILON)
-  const units: Record<string, number> = Object.fromEntries(
-    Object.keys(weights)
-      .sort()
-      .map((symbol) => {
-        const weight = weights[symbol]
-        if (!Number.isFinite(weight) || weight < 0) throw new Error(`reference target weight is invalid for ${symbol}`)
-        return [symbol, Math.min(maximumUnits, Math.max(0, Math.round(weight * weightScale)))]
-      }),
-  )
+  const units: Record<string, number> = {}
+  for (const symbol of Object.keys(weights).sort()) {
+    const weight = weights[symbol]
+    if (!Number.isFinite(weight) || weight < 0) {
+      return Result.fail({ _tag: 'ReferenceInvalidWeight', symbol, weight, maximumWeight })
+    }
+    units[symbol] = Math.min(maximumUnits, Math.max(0, Math.round(weight * weightScale)))
+  }
   let total = Object.values(units).reduce((sum, value) => sum + value, 0)
   let excess = Math.max(0, total - weightScale)
   for (const symbol of Object.keys(units).sort().reverse()) {
@@ -205,83 +441,140 @@ const quantizeCappedWeights = (
     excess -= reduction
     total -= reduction
   }
-  if (total > weightScale || excess > 0) throw new Error('reference weights cannot be bounded at full exposure')
-  return Object.fromEntries(Object.entries(units).map(([symbol, value]) => [symbol, value / weightScale]))
+  if (total > weightScale || excess > 0) {
+    return Result.fail({ _tag: 'ReferenceWeightBoundingFailed', totalUnits: total, excessUnits: excess, weightScale })
+  }
+  return Result.succeed(
+    Object.fromEntries(Object.entries(units).map(([symbol, value]) => [symbol, value / weightScale])),
+  )
 }
 
-const sampleCovariance = (left: readonly number[], right: readonly number[]): number => {
-  if (left.length !== right.length || left.length < 2) throw new Error('reference covariance inputs are not aligned')
+const sampleCovariance = (left: readonly number[], right: readonly number[]): ReferenceComputation<number> => {
+  if (left.length !== right.length || left.length < 2) {
+    return Result.fail({ _tag: 'ReferenceCovarianceInputMismatch', leftLength: left.length, rightLength: right.length })
+  }
   const leftAverage = average(left)
   const rightAverage = average(right)
   const value =
     left.reduce((total, observation, index) => total + (observation - leftAverage) * (right[index] - rightAverage), 0) /
     (left.length - 1)
-  if (!Number.isFinite(value)) throw new Error('reference covariance is not finite')
-  return value
+  if (!Number.isFinite(value)) {
+    return Result.fail({
+      _tag: 'ReferenceCovarianceNotFinite',
+      leftLength: left.length,
+      rightLength: right.length,
+      covariance: value,
+    })
+  }
+  return Result.succeed(value)
 }
 
 const portfolioVolatility = (
   weights: Readonly<Record<string, number>>,
   returns: Readonly<Record<string, readonly number[]>>,
-): number => {
+): ReferenceComputation<number> => {
   const symbols = Object.keys(weights).sort()
-  const dailyVariance = symbols.reduce(
-    (outer, left) =>
-      outer +
-      symbols.reduce(
-        (inner, right) => inner + weights[left] * weights[right] * sampleCovariance(returns[left], returns[right]),
-        0,
-      ),
-    0,
-  )
+  let dailyVariance = 0
+  for (const left of symbols) {
+    let innerVariance = 0
+    for (const right of symbols) {
+      const covariance = sampleCovariance(returns[left], returns[right])
+      if (Result.isFailure(covariance)) return covariance
+      innerVariance += weights[left] * weights[right] * covariance.success
+    }
+    dailyVariance += innerVariance
+  }
   if (!Number.isFinite(dailyVariance) || dailyVariance < -1e-12) {
-    throw new Error('reference covariance produced an invalid portfolio variance')
+    return Result.fail({ _tag: 'ReferencePortfolioVarianceInvalid', dailyVariance })
   }
   const annualized = Math.sqrt(Math.max(0, dailyVariance) * tradingDays)
-  if (!Number.isFinite(annualized)) throw new Error('reference portfolio volatility is not finite')
-  return annualized
+  if (!Number.isFinite(annualized)) {
+    return Result.fail({
+      _tag: 'ReferencePortfolioVolatilityInvalid',
+      dailyVariance,
+      annualizedVolatility: annualized,
+    })
+  }
+  return Result.succeed(annualized)
 }
 
 const riskBalancedDecisionPlan = (
   signalIndex: number,
   sessions: readonly Session[],
   protocol: Protocol,
-): DecisionPlan => {
+): ReferenceComputation<DecisionPlan> => {
   const requiredHistory = riskBalancedHistoryLength(protocol)
-  if (signalIndex < requiredHistory) throw new Error('reference risk-balanced trend has insufficient history')
+  if (signalIndex < requiredHistory || signalIndex >= sessions.length) {
+    return Result.fail({
+      _tag: 'ReferenceInsufficientHistory',
+      signalIndex,
+      requiredHistory,
+      sessionCount: sessions.length,
+    })
+  }
   const history = sessions.slice(signalIndex - requiredHistory, signalIndex + 1)
   const sessionDates = history.map((session) => session.date)
   const returnsBySymbol: Record<string, readonly number[]> = {}
-  const baseSignals = protocol.universe.map((symbol) => {
+  const baseSignals: DecisionPlan['signals'][number][] = []
+  for (const symbol of protocol.universe) {
     const closes = history.map((session) => session.bars[symbol].close)
-    if (closes.some((close) => !Number.isFinite(close) || close <= 0)) {
-      throw new Error(`reference risk-balanced trend has an invalid close for ${symbol}`)
+    const invalidCloseIndex = closes.findIndex((close) => !Number.isFinite(close) || close <= 0)
+    if (invalidCloseIndex !== -1) {
+      return Result.fail({
+        _tag: 'ReferenceInvalidClose',
+        symbol,
+        sessionDate: history[invalidCloseIndex].date,
+        close: closes[invalidCloseIndex],
+      })
     }
     const current = closes.at(-1)
-    if (current === undefined) throw new Error(`reference risk-balanced trend has no current close for ${symbol}`)
+    if (current === undefined) {
+      return Result.fail({ _tag: 'ReferenceMissingCurrentClose', symbol, signalIndex })
+    }
     const volatilityCloses = closes.slice(-(protocol.volatilityWindow + 1))
     const recentReturns = volatilityCloses.slice(1).map((close, index) => close / volatilityCloses[index] - 1)
-    if (recentReturns.some((value) => !Number.isFinite(value))) {
-      throw new Error(`reference risk-balanced trend has an invalid return for ${symbol}`)
+    const invalidReturnIndex = recentReturns.findIndex((value) => !Number.isFinite(value))
+    if (invalidReturnIndex !== -1) {
+      const firstVolatilitySessionIndex = history.length - volatilityCloses.length
+      return Result.fail({
+        _tag: 'ReferenceInvalidReturn',
+        symbol,
+        sessionDate: history[firstVolatilitySessionIndex + invalidReturnIndex + 1].date,
+        value: recentReturns[invalidReturnIndex],
+      })
     }
     returnsBySymbol[symbol] = recentReturns
     const dailyVolatility = sampleDeviation(recentReturns)
     const annualizedVolatility = dailyVolatility * Math.sqrt(tradingDays)
-    const horizons = protocol.horizons.map((horizonSessions) => {
+    const horizons: DecisionPlan['signals'][number]['horizons'][number][] = []
+    for (const horizonSessions of protocol.horizons) {
       const prior = closes[closes.length - 1 - horizonSessions]
-      if (prior === undefined) throw new Error(`reference risk-balanced trend has no prior close for ${symbol}`)
+      if (prior === undefined) {
+        return Result.fail({ _tag: 'ReferenceMissingPriorClose', symbol, signalIndex, horizonSessions })
+      }
       const value = current / prior - 1
       const normalizedTrend = dailyVolatility === 0 ? 0 : value / (dailyVolatility * Math.sqrt(horizonSessions))
       if (![value, normalizedTrend].every(Number.isFinite)) {
-        throw new Error(`reference risk-balanced trend has an invalid horizon signal for ${symbol}`)
+        return Result.fail({
+          _tag: 'ReferenceInvalidHorizonSignal',
+          symbol,
+          horizonSessions,
+          return: value,
+          normalizedTrend,
+        })
       }
-      return { horizonSessions, return: value, normalizedTrend }
-    })
+      horizons.push({ horizonSessions, return: value, normalizedTrend })
+    }
     const compositeScore = dailyVolatility === 0 ? 0 : average(horizons.map((horizon) => horizon.normalizedTrend))
     if (![annualizedVolatility, compositeScore].every(Number.isFinite)) {
-      throw new Error(`reference risk-balanced trend has an invalid score for ${symbol}`)
+      return Result.fail({
+        _tag: 'ReferenceInvalidScore',
+        symbol,
+        annualizedVolatility,
+        compositeScore,
+      })
     }
-    return {
+    baseSignals.push({
       symbol,
       horizons,
       dailyVolatility,
@@ -289,28 +582,39 @@ const riskBalancedDecisionPlan = (
       compositeScore,
       positiveScore: Math.max(0, compositeScore),
       eligible: dailyVolatility > 0,
-    }
-  })
+      uncappedWeight: 0,
+      cappedWeight: 0,
+      targetWeight: 0,
+    })
+  }
 
   const scores = Object.fromEntries(baseSignals.map((signal) => [signal.symbol, signal.positiveScore]))
   const scoreTotal = Object.values(scores).reduce((total, score) => total + score, 0)
   const uncappedWeights = Object.fromEntries(
     protocol.universe.map((symbol) => [symbol, scoreTotal === 0 ? 0 : scores[symbol] / scoreTotal]),
   )
-  const cappedWeights = quantizeCappedWeights(
+  const cappedWeightsResult = quantizeCappedWeights(
     allocateCapped(scores, protocol.maximumSymbolWeight),
     protocol.maximumSymbolWeight,
   )
-  const estimatedAnnualizedPortfolioVolatility = portfolioVolatility(cappedWeights, returnsBySymbol)
+  if (Result.isFailure(cappedWeightsResult)) return Result.fail(cappedWeightsResult.failure)
+  const cappedWeights = cappedWeightsResult.success
+  const estimatedVolatilityResult = portfolioVolatility(cappedWeights, returnsBySymbol)
+  if (Result.isFailure(estimatedVolatilityResult)) return Result.fail(estimatedVolatilityResult.failure)
+  const estimatedAnnualizedPortfolioVolatility = estimatedVolatilityResult.success
   const exposureScale =
     estimatedAnnualizedPortfolioVolatility === 0
       ? 1
       : Math.min(1, protocol.maximumPortfolioVolatility / estimatedAnnualizedPortfolioVolatility)
-  let targetWeights = quantizeCappedWeights(
+  const targetWeightsResult = quantizeCappedWeights(
     Object.fromEntries(protocol.universe.map((symbol) => [symbol, cappedWeights[symbol] * exposureScale])),
     protocol.maximumSymbolWeight,
   )
-  const scaledVolatility = portfolioVolatility(targetWeights, returnsBySymbol)
+  if (Result.isFailure(targetWeightsResult)) return Result.fail(targetWeightsResult.failure)
+  let targetWeights = targetWeightsResult.success
+  const scaledVolatilityResult = portfolioVolatility(targetWeights, returnsBySymbol)
+  if (Result.isFailure(scaledVolatilityResult)) return Result.fail(scaledVolatilityResult.failure)
+  const scaledVolatility = scaledVolatilityResult.success
   if (scaledVolatility > protocol.maximumPortfolioVolatility) {
     const correction = protocol.maximumPortfolioVolatility / scaledVolatility
     targetWeights = Object.fromEntries(
@@ -321,24 +625,43 @@ const riskBalancedDecisionPlan = (
     )
   }
   const totalWeight = Object.values(targetWeights).reduce((total, weight) => total + weight, 0)
+  const finalVolatilityResult = portfolioVolatility(targetWeights, returnsBySymbol)
+  if (Result.isFailure(finalVolatilityResult)) return Result.fail(finalVolatilityResult.failure)
+  const finalVolatility = finalVolatilityResult.success
   if (
     totalWeight > 1 + 1e-12 ||
     Object.values(targetWeights).some(
       (weight) => !Number.isFinite(weight) || weight < 0 || weight > protocol.maximumSymbolWeight + 1e-12,
     ) ||
-    portfolioVolatility(targetWeights, returnsBySymbol) > protocol.maximumPortfolioVolatility + 1e-12
+    finalVolatility > protocol.maximumPortfolioVolatility + 1e-12
   ) {
-    throw new Error('reference risk-balanced trend produced weights outside the protocol limits')
+    return Result.fail({
+      _tag: 'ReferenceWeightsOutsideLimits',
+      totalWeight,
+      maximumSymbolWeight: protocol.maximumSymbolWeight,
+      portfolioVolatility: finalVolatility,
+      maximumPortfolioVolatility: protocol.maximumPortfolioVolatility,
+    })
   }
 
   const covarianceDates = sessionDates.slice(-protocol.volatilityWindow)
-  return {
+  const signalSession = sessions[signalIndex]
+  const firstCovarianceSession = covarianceDates[0]
+  if (signalSession === undefined || firstCovarianceSession === undefined) {
+    return Result.fail({
+      _tag: 'ReferenceInsufficientHistory',
+      signalIndex,
+      requiredHistory,
+      sessionCount: sessions.length,
+    })
+  }
+  return Result.succeed({
     schemaVersion: 'bayn.risk-balanced-trend-decision-plan.v1',
-    signalDate: sessions[signalIndex].date,
+    signalDate: signalSession.date,
     covarianceWindow: {
       returnCount: protocol.volatilityWindow,
-      firstSession: covarianceDates[0],
-      lastSession: covarianceDates.at(-1) ?? sessions[signalIndex].date,
+      firstSession: firstCovarianceSession,
+      lastSession: covarianceDates.at(-1) ?? signalSession.date,
       sessionsHash: canonicalHashV1(covarianceDates),
     },
     estimatedAnnualizedPortfolioVolatility,
@@ -350,25 +673,50 @@ const riskBalancedDecisionPlan = (
       cappedWeight: cappedWeights[signal.symbol],
       targetWeight: targetWeights[signal.symbol],
     })),
-  }
+  })
 }
 
 const directVolatilityTarget = (
   sessions: readonly Session[],
   signalIndex: number,
   protocol: SimulationProtocol,
-): Readonly<Record<string, number>> => {
+): ReferenceComputation<Readonly<Record<string, number>>> => {
+  if (signalIndex < 63 || signalIndex >= sessions.length) {
+    return Result.fail({
+      _tag: 'ReferenceDirectVolatilityWindowInvalid',
+      signalIndex,
+      requiredPriorIndex: signalIndex - 63,
+      sessionCount: sessions.length,
+    })
+  }
   const portfolioReturns: number[] = []
   for (let index = signalIndex - 62; index <= signalIndex; index += 1) {
-    const returns = protocol.universe.map(
-      (symbol) => sessions[index].bars[symbol].close / sessions[index - 1].bars[symbol].close - 1,
-    )
+    const session = sessions[index]
+    const priorSession = sessions[index - 1]
+    if (session === undefined || priorSession === undefined) {
+      return Result.fail({
+        _tag: 'ReferenceDirectVolatilityWindowInvalid',
+        signalIndex,
+        requiredPriorIndex: index - 1,
+        sessionCount: sessions.length,
+      })
+    }
+    const returns = protocol.universe.map((symbol) => session.bars[symbol].close / priorSession.bars[symbol].close - 1)
+    const invalidReturnIndex = returns.findIndex((value) => !Number.isFinite(value))
+    if (invalidReturnIndex !== -1) {
+      return Result.fail({
+        _tag: 'ReferenceInvalidReturn',
+        symbol: protocol.universe[invalidReturnIndex],
+        sessionDate: session.date,
+        value: returns[invalidReturnIndex],
+      })
+    }
     portfolioReturns.push(average(returns))
   }
   const volatility = sampleDeviation(portfolioReturns) * Math.sqrt(tradingDays)
   const exposure = volatility <= 0 ? 0 : Math.min(1, protocol.directVolatilityTarget / volatility)
   const weight = roundWeight(exposure / protocol.universe.length)
-  return Object.fromEntries(protocol.universe.map((symbol) => [symbol, weight]))
+  return Result.succeed(Object.fromEntries(protocol.universe.map((symbol) => [symbol, weight])))
 }
 
 const metrics = (
@@ -379,12 +727,26 @@ const metrics = (
   slippageMicros: bigint,
   yieldMicros: bigint,
   initialMicros: bigint,
-): PerformanceMetrics => {
-  if (equityMicros.length < 2 || equityMicros.some((value) => value <= 0n)) {
-    throw new Error('reference replay produced an invalid equity curve')
+): ReferenceComputation<PerformanceMetrics> => {
+  const firstNonPositiveIndex = equityMicros.findIndex((value) => value <= 0n)
+  if (equityMicros.length < 2 || firstNonPositiveIndex !== -1) {
+    return Result.fail({
+      _tag: 'ReferenceInvalidEquityCurve',
+      observationCount: equityMicros.length,
+      firstNonPositiveIndex: firstNonPositiveIndex === -1 ? null : firstNonPositiveIndex,
+      firstNonPositiveValueMicros:
+        firstNonPositiveIndex === -1 ? null : (equityMicros[firstNonPositiveIndex]?.toString() ?? null),
+    })
   }
   const endingEquityMicros = equityMicros.at(-1)
-  if (endingEquityMicros === undefined) throw new Error('reference replay produced an empty equity curve')
+  if (endingEquityMicros === undefined) {
+    return Result.fail({
+      _tag: 'ReferenceInvalidEquityCurve',
+      observationCount: equityMicros.length,
+      firstNonPositiveIndex: null,
+      firstNonPositiveValueMicros: null,
+    })
+  }
   const equity = equityMicros.map(microsToNumber)
   const initial = microsToNumber(initialMicros)
   const endingEquity = microsToNumber(endingEquityMicros)
@@ -399,7 +761,7 @@ const metrics = (
     peak = Math.max(peak, value)
     maximumDrawdown = Math.max(maximumDrawdown, 1 - value / peak)
   }
-  return {
+  return Result.succeed({
     observations: equity.length,
     totalReturn,
     annualizedReturn,
@@ -412,7 +774,7 @@ const metrics = (
     totalSlippageCostMicros: slippageMicros.toString(),
     totalCashYieldMicros: yieldMicros.toString(),
     endingEquityMicros: endingEquityMicros.toString(),
-  }
+  })
 }
 
 const order = (
@@ -455,15 +817,20 @@ const order = (
     }),
   )
 
-const restrictReferenceBuyFill = (
+export const restrictReferenceBuyFill = (
   runId: string,
   simulatedOrder: SimulatedOrder,
   permittedQuantity: bigint,
-): SimulatedOrder => {
+): ReferenceComputation<SimulatedOrder> => {
   const modeledQuantity = BigInt(simulatedOrder.filledQuantityMicros)
-  if (modeledQuantity === 0n || modeledQuantity === permittedQuantity) return simulatedOrder
+  if (modeledQuantity === 0n || modeledQuantity === permittedQuantity) return Result.succeed(simulatedOrder)
   if (permittedQuantity < 0n || permittedQuantity > modeledQuantity) {
-    throw new Error('reference buying-power adjustment must only reduce a modeled buy fill')
+    return Result.fail({
+      _tag: 'ReferenceBuyFillRestrictionInvalid',
+      orderId: simulatedOrder.id,
+      modeledQuantityMicros: modeledQuantity.toString(),
+      permittedQuantityMicros: permittedQuantity.toString(),
+    })
   }
   const material = {
     decisionId: simulatedOrder.decisionId,
@@ -476,7 +843,7 @@ const restrictReferenceBuyFill = (
     rejectionReason: permittedQuantity === 0n ? ('insufficient-buying-power' as const) : null,
     unfilledRemainder: 'canceled' as const,
   }
-  return { id: canonicalHashV1({ runId, kind: 'order', ...material }), ...material }
+  return Result.succeed({ id: canonicalHashV1({ runId, kind: 'order', ...material }), ...material })
 }
 
 const fill = (
@@ -648,6 +1015,19 @@ const replayBuysFitCash = (
     ),
   )
 
+interface ReplayState {
+  readonly positions: ReadonlyMap<string, Position>
+  readonly cashMicros: bigint
+  readonly turnoverMicros: bigint
+  readonly feeMicros: bigint
+  readonly spreadMicros: bigint
+  readonly slippageMicros: bigint
+  readonly cashYieldMicros: bigint
+  readonly previousEquityMicros: bigint
+  readonly peakEquityMicros: bigint
+  readonly previousDate?: IsoDate
+}
+
 const replay = (
   sessions: readonly Session[],
   targets: readonly Target[],
@@ -656,7 +1036,7 @@ const replay = (
   costMultiplierMicros: bigint,
   runId: string,
   retainTrace: boolean,
-): ReferenceComputation<Replay> => {
+): ReferenceComputation<ReplayWithWork> => {
   if (protocol.executionModel.schemaVersion !== 'bayn.execution-model.v2') {
     return Result.fail({
       _tag: 'UnsupportedReferenceExecutionModel',
@@ -665,17 +1045,20 @@ const replay = (
     })
   }
   const targetBySession = new Map(targets.map((target) => [target.executionIndex, target]))
-  const positions = new Map<string, Position>()
   const initial = BigInt(protocol.initialCapitalMicros)
-  let cash = initial
-  let turnover = 0n
-  let fees = 0n
-  let spread = 0n
-  let slippage = 0n
-  let cashYield = 0n
-  let previousEquity = initial
-  let peakEquity = initial
-  let previousDate: IsoDate | undefined
+  let state: ReplayState = {
+    positions: new Map(),
+    cashMicros: initial,
+    turnoverMicros: 0n,
+    feeMicros: 0n,
+    spreadMicros: 0n,
+    slippageMicros: 0n,
+    cashYieldMicros: 0n,
+    previousEquityMicros: initial,
+    peakEquityMicros: initial,
+  }
+  let positionStateCopies = 0
+  let positionWrites = 0
   const equity: bigint[] = []
   const events: EvaluationEvent[] = []
   const decisions: SignalDecision[] = []
@@ -687,15 +1070,32 @@ const replay = (
   for (let index = startIndex; index < sessions.length; index += 1) {
     const session = sessions[index]
     const target = targetBySession.get(index)
-    const beforeTurnover = turnover
-    const beforeFees = fees
-    const beforeSpread = spread
-    const beforeSlippage = slippage
-    const beforeYield = cashYield
-    const planningCashSnapshot = cash
+    const beforeTurnover = state.turnoverMicros
+    const beforeFees = state.feeMicros
+    const beforeSpread = state.spreadMicros
+    const beforeSlippage = state.slippageMicros
+    const beforeYield = state.cashYieldMicros
+    const planningCashSnapshot = state.cashMicros
+    let cash = state.cashMicros
+    let turnover = state.turnoverMicros
+    let fees = state.feeMicros
+    let spread = state.spreadMicros
+    let slippage = state.slippageMicros
+    let cashYield = state.cashYieldMicros
+    let positions = state.positions
+    let writablePositions: Map<string, Position> | undefined
+    const writePosition = (symbol: string, position: Position): void => {
+      if (writablePositions === undefined) {
+        writablePositions = new Map(positions)
+        positionStateCopies += 1
+      }
+      writablePositions.set(symbol, position)
+      positions = writablePositions
+      positionWrites += 1
+    }
 
-    if (previousDate !== undefined) {
-      const elapsedDaysResult = elapsedCalendarDays(previousDate, session.date)
+    if (state.previousDate !== undefined) {
+      const elapsedDaysResult = elapsedCalendarDays(state.previousDate, session.date)
       if (Result.isFailure(elapsedDaysResult)) return Result.fail(elapsedDaysResult.failure)
       const elapsedDays = elapsedDaysResult.success
       const accruedResult = accrueCashYield(cash, elapsedDays, protocol.executionModel)
@@ -721,11 +1121,19 @@ const replay = (
         }
       }
     }
-    previousDate = session.date
 
     if (target !== undefined) {
+      const signalSession = sessions[target.signalIndex]
+      if (signalSession === undefined) {
+        return Result.fail({
+          _tag: 'ReferenceTargetSignalMissing',
+          signalIndex: target.signalIndex,
+          executionIndex: target.executionIndex,
+          sessionCount: sessions.length,
+        })
+      }
       const decisionMaterial = {
-        signalDate: sessions[target.signalIndex].date,
+        signalDate: signalSession.date,
         executionDate: session.date,
         targetWeights: target.weights,
       }
@@ -735,12 +1143,18 @@ const replay = (
         ...decisionMaterial,
       }
       if (retainTrace) {
-        if (target.plan === undefined) throw new Error('reference candidate target lacks a signal plan')
+        if (target.plan === undefined) {
+          return Result.fail({
+            _tag: 'ReferenceMissingDecisionPlan',
+            signalIndex: target.signalIndex,
+            executionIndex: target.executionIndex,
+          })
+        }
         events.push(decision)
         decisions.push({ ...target.plan, decisionId: decision.id, executionDate: decision.executionDate })
       }
 
-      const planPricesResult = replayPrices(sessions[target.signalIndex], protocol, (bar) => bar.close)
+      const planPricesResult = replayPrices(signalSession, protocol, (bar) => bar.close)
       if (Result.isFailure(planPricesResult)) return Result.fail(planPricesResult.failure)
       const planPrices = planPricesResult.success
       const fillPricesResult = replayPrices(session, protocol, (bar) => bar.open)
@@ -852,7 +1266,9 @@ const replay = (
           protocol.executionModel,
         )
         if (Result.isFailure(permittedQuantity)) return Result.fail(permittedQuantity.failure)
-        buyOrders.push(restrictReferenceBuyFill(runId, candidate, permittedQuantity.success))
+        const restricted = restrictReferenceBuyFill(runId, candidate, permittedQuantity.success)
+        if (Result.isFailure(restricted)) return Result.fail(restricted.failure)
+        buyOrders.push(restricted.success)
       }
 
       for (const simulatedOrder of sellOrders) {
@@ -877,9 +1293,10 @@ const replay = (
         turnover += terms.notionalMicros
         spread += terms.spreadCostMicros
         slippage += terms.slippageCostMicros
-        position.quantityMicros -= quantity
-        position.costBasisMicros -= costBasis
-        positions.set(simulatedOrder.symbol, position)
+        writePosition(simulatedOrder.symbol, {
+          quantityMicros: position.quantityMicros - quantity,
+          costBasisMicros: position.costBasisMicros - costBasis,
+        })
         sessionFills.push(event)
         if (retainTrace) {
           events.push(event)
@@ -906,9 +1323,10 @@ const replay = (
         spread += terms.spreadCostMicros
         slippage += terms.slippageCostMicros
         const position = positions.get(simulatedOrder.symbol) ?? { quantityMicros: 0n, costBasisMicros: 0n }
-        position.quantityMicros += quantity
-        position.costBasisMicros += terms.notionalMicros
-        positions.set(simulatedOrder.symbol, position)
+        writePosition(simulatedOrder.symbol, {
+          quantityMicros: position.quantityMicros + quantity,
+          costBasisMicros: position.costBasisMicros + terms.notionalMicros,
+        })
         sessionFills.push(event)
         if (retainTrace) {
           events.push(event)
@@ -948,7 +1366,9 @@ const replay = (
           changes.push(cashChange(runId, event, -fee.totalMicros, cash))
         }
       }
-      if (cash < 0n) throw new Error('reference replay spent unavailable cash')
+      if (cash < 0n) {
+        return Result.fail({ _tag: 'ReferenceNegativeCash', sessionDate: session.date, cashMicros: cash.toString() })
+      }
     }
 
     const closesResult = replayPrices(session, protocol, (bar) => bar.close)
@@ -958,11 +1378,11 @@ const replay = (
     if (Result.isFailure(closingPositionValue)) return Result.fail(closingPositionValue.failure)
     const closingEquity = cash + closingPositionValue.success
     equity.push(closingEquity)
-    peakEquity = peakEquity > closingEquity ? peakEquity : closingEquity
+    const peakEquity = state.peakEquityMicros > closingEquity ? state.peakEquityMicros : closingEquity
     const point: DailyPerformancePoint = {
       sessionDate: session.date,
       equityMicros: closingEquity.toString(),
-      netReturn: Number(closingEquity) / Number(previousEquity) - 1,
+      netReturn: Number(closingEquity) / Number(state.previousEquityMicros) - 1,
       turnoverMicros: (turnover - beforeTurnover).toString(),
       cumulativeTurnoverMicros: turnover.toString(),
       feeMicros: (fees - beforeFees).toString(),
@@ -997,11 +1417,32 @@ const replay = (
         positions: markedPositions,
       })
     }
-    previousEquity = closingEquity
+    state = {
+      positions,
+      cashMicros: cash,
+      turnoverMicros: turnover,
+      feeMicros: fees,
+      spreadMicros: spread,
+      slippageMicros: slippage,
+      cashYieldMicros: cashYield,
+      previousEquityMicros: closingEquity,
+      peakEquityMicros: peakEquity,
+      previousDate: session.date,
+    }
   }
 
+  const metricsResult = metrics(
+    equity,
+    state.turnoverMicros,
+    state.feeMicros,
+    state.spreadMicros,
+    state.slippageMicros,
+    state.cashYieldMicros,
+    initial,
+  )
+  if (Result.isFailure(metricsResult)) return Result.fail(metricsResult.failure)
   return Result.succeed({
-    metrics: metrics(equity, turnover, fees, spread, slippage, cashYield, initial),
+    metrics: metricsResult.success,
     events,
     decisions,
     daily,
@@ -1015,6 +1456,11 @@ const replay = (
           dailyMarks: marks,
         }
       : null,
+    work: {
+      sessionsProcessed: daily.length,
+      positionStateCopies,
+      positionWrites,
+    },
   })
 }
 
@@ -1076,13 +1522,15 @@ const verdict = (
   return { status: gates.every((gate) => gate.passed) ? 'PASS' : 'FAIL_CLOSED', gates }
 }
 
-export const evaluateReference = (
+const evaluateReferenceWithWork = (
   bars: readonly DailyBar[],
   manifest: InputManifest,
   protocol: Protocol,
   provenance: RuntimeProvenance,
-): ReferenceComputation<ReferenceEvaluation> => {
-  const sessions = align(bars, manifest, protocol.universe)
+): ReferenceComputation<ReferenceEvaluationWithWork> => {
+  const sessionsResult = align(bars, manifest, protocol.universe)
+  if (Result.isFailure(sessionsResult)) return Result.fail(sessionsResult.failure)
+  const sessions = sessionsResult.success
   const dates = sessions.map((session) => session.date)
   const requiredHistory = riskBalancedHistoryLength(protocol)
   const eligibleSignals = monthEnds(dates).filter(
@@ -1093,13 +1541,28 @@ export const evaluateReference = (
       dates[index + 1] >= manifest.bounds.evaluationStart &&
       dates[index + 1] <= manifest.bounds.evaluationEnd,
   )
-  if (eligibleSignals.length === 0) throw new Error('reference dataset has no eligible signal session')
-  const startIndex = eligibleSignals[0] + 1
+  const firstEligibleSignal = eligibleSignals[0]
+  if (firstEligibleSignal === undefined) {
+    return Result.fail({
+      _tag: 'ReferenceNoEligibleSignal',
+      sessionCount: sessions.length,
+      lookbackStart: manifest.bounds.lookbackStart,
+      evaluationStart: manifest.bounds.evaluationStart,
+      evaluationEnd: manifest.bounds.evaluationEnd,
+    })
+  }
+  const startIndex = firstEligibleSignal + 1
   const firstAfterEnd = dates.findIndex((date) => date > manifest.bounds.evaluationEnd)
   const endExclusive = firstAfterEnd === -1 ? dates.length : firstAfterEnd
   const boundedSessions = sessions.slice(0, endExclusive)
   if (endExclusive - startIndex < protocol.thresholds.minimumObservations) {
-    throw new Error('reference dataset has too few evaluation observations')
+    return Result.fail({
+      _tag: 'ReferenceInsufficientObservations',
+      actual: endExclusive - startIndex,
+      required: protocol.thresholds.minimumObservations,
+      startIndex,
+      endExclusive,
+    })
   }
 
   const parameterHash = canonicalHashV1(protocol)
@@ -1110,7 +1573,13 @@ export const evaluateReference = (
     parameterSchemaVersion: protocol.schemaVersion,
   }
   if (parameterHash !== provenance.strategy.parameterHash || provenance.strategy.name !== 'risk-balanced-trend') {
-    throw new Error('reference protocol does not match runtime provenance')
+    return Result.fail({
+      _tag: 'ReferenceProvenanceMismatch',
+      requiredStrategyName: 'risk-balanced-trend',
+      actualStrategyName: provenance.strategy.name,
+      expectedParameterHash: parameterHash,
+      actualParameterHash: provenance.strategy.parameterHash,
+    })
   }
   const runId = makeRunIdentity({
     schemaVersion: 'bayn.run-identity.v1',
@@ -1126,10 +1595,18 @@ export const evaluateReference = (
     bounds: manifest.bounds,
   }).runId
   const protocolHash = makeStrategyProtocolHash(strategyIdentity)
-  const candidateTargets = eligibleSignals.map((signalIndex): Target => {
-    const plan = riskBalancedDecisionPlan(signalIndex, sessions, protocol)
-    return { signalIndex, executionIndex: signalIndex + 1, weights: plan.targetWeights, plan }
-  })
+  const candidateTargetsResult = Result.all(
+    eligibleSignals.map((signalIndex) =>
+      pipe(
+        riskBalancedDecisionPlan(signalIndex, sessions, protocol),
+        Result.map(
+          (plan): Target => ({ signalIndex, executionIndex: signalIndex + 1, weights: plan.targetWeights, plan }),
+        ),
+      ),
+    ),
+  )
+  if (Result.isFailure(candidateTargetsResult)) return Result.fail(candidateTargetsResult.failure)
+  const candidateTargets = candidateTargetsResult.success
   const equalWeight = roundWeight(1 / protocol.universe.length)
   const buyAndHoldTargets: readonly Target[] = [
     {
@@ -1138,13 +1615,22 @@ export const evaluateReference = (
       weights: Object.fromEntries(protocol.universe.map((symbol) => [symbol, equalWeight])),
     },
   ]
-  const directVolTargets = eligibleSignals.map(
-    (signalIndex): Target => ({
-      signalIndex,
-      executionIndex: signalIndex + 1,
-      weights: directVolatilityTarget(sessions, signalIndex, protocol),
-    }),
+  const directVolTargetsResult = Result.all(
+    eligibleSignals.map((signalIndex) =>
+      pipe(
+        directVolatilityTarget(sessions, signalIndex, protocol),
+        Result.map(
+          (weights): Target => ({
+            signalIndex,
+            executionIndex: signalIndex + 1,
+            weights,
+          }),
+        ),
+      ),
+    ),
   )
+  if (Result.isFailure(directVolTargetsResult)) return Result.fail(directVolTargetsResult.failure)
+  const directVolTargets = directVolTargetsResult.success
   const strategy = replay(boundedSessions, candidateTargets, startIndex, protocol, MICROS, runId, true)
   const buyAndHold = replay(boundedSessions, buyAndHoldTargets, startIndex, protocol, MICROS, runId, false)
   const directVolTiming = replay(boundedSessions, directVolTargets, startIndex, protocol, MICROS, runId, false)
@@ -1160,7 +1646,7 @@ export const evaluateReference = (
   return pipe(
     Result.all({ strategy, buyAndHold, directVolTiming, doubleCostStrategy }),
     Result.map(
-      ({ strategy, buyAndHold, directVolTiming, doubleCostStrategy }): ReferenceEvaluation => ({
+      ({ strategy, buyAndHold, directVolTiming, doubleCostStrategy }): ReferenceEvaluationWithWork => ({
         runId,
         protocolHash,
         strategy,
@@ -1178,3 +1664,46 @@ export const evaluateReference = (
     ),
   )
 }
+
+const stripReplayWork = (replay: ReplayWithWork): Replay => ({
+  metrics: replay.metrics,
+  events: replay.events,
+  decisions: replay.decisions,
+  daily: replay.daily,
+  trace: replay.trace,
+})
+
+export const evaluateReference = (
+  bars: readonly DailyBar[],
+  manifest: InputManifest,
+  protocol: Protocol,
+  provenance: RuntimeProvenance,
+): ReferenceComputation<ReferenceEvaluation> =>
+  pipe(
+    evaluateReferenceWithWork(bars, manifest, protocol, provenance),
+    Result.map((reference) => ({
+      runId: reference.runId,
+      protocolHash: reference.protocolHash,
+      strategy: stripReplayWork(reference.strategy),
+      buyAndHold: stripReplayWork(reference.buyAndHold),
+      directVolTiming: stripReplayWork(reference.directVolTiming),
+      doubleCostStrategy: stripReplayWork(reference.doubleCostStrategy),
+      verdict: reference.verdict,
+    })),
+  )
+
+export const measureReferenceEvaluationWork = (
+  bars: readonly DailyBar[],
+  manifest: InputManifest,
+  protocol: Protocol,
+  provenance: RuntimeProvenance,
+): ReferenceComputation<ReferenceEvaluationWork> =>
+  pipe(
+    evaluateReferenceWithWork(bars, manifest, protocol, provenance),
+    Result.map((reference) => ({
+      strategy: reference.strategy.work,
+      buyAndHold: reference.buyAndHold.work,
+      directVolTiming: reference.directVolTiming.work,
+      doubleCostStrategy: reference.doubleCostStrategy.work,
+    })),
+  )

--- a/services/bayn/src/qualification-audit-command.test.ts
+++ b/services/bayn/src/qualification-audit-command.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from 'bun:test'
+
+const commandPath = new URL('./qualification-audit-command.ts', import.meta.url).pathname
+const secretMarkers = ['postgres-secret-marker', 'signal-secret-marker', 'audit-secret-marker'] as const
+
+const runCommand = async (output: 'audit' | 'dossier') => {
+  const child = Bun.spawn({
+    cmd: [process.execPath, commandPath],
+    cwd: import.meta.dir,
+    env: {
+      ...process.env,
+      NODE_ENV: 'test',
+      BAYN_AUDIT_OUTPUT: output,
+      BAYN_AUDIT_RUN_ID: '0'.repeat(64),
+      BAYN_AUDIT_POSTGRES_URL: `postgresql://audit:${secretMarkers[0]}@127.0.0.1:1/bayn_audit_test`,
+      BAYN_AUDIT_POSTGRES_TLS: 'false',
+      BAYN_AUDIT_SIGNAL_URL: 'http://127.0.0.1:1',
+      BAYN_AUDIT_SIGNAL_USERNAME: 'bayn-audit-candidate',
+      BAYN_AUDIT_SIGNAL_PUBLISHER_USERNAME: 'bayn-audit-publisher',
+      BAYN_AUDIT_SIGNAL_PASSWORD: secretMarkers[1],
+      BAYN_AUDIT_CLICKHOUSE_URLS: 'http://127.0.0.1:1,http://127.0.0.1:2',
+      BAYN_AUDIT_CLICKHOUSE_USERNAME: 'bayn-audit-query-log',
+      BAYN_AUDIT_CLICKHOUSE_PASSWORD: secretMarkers[2],
+      BAYN_AUDIT_REPOSITORY_PATH: import.meta.dir,
+      BAYN_AUDIT_OPERATION_TIMEOUT_MS: '100',
+    },
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+  const [exitCode, stdout, stderr] = await Promise.all([
+    child.exited,
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+  ])
+  return { exitCode, stdout, stderr }
+}
+
+describe('qualification audit command', () => {
+  for (const output of ['audit', 'dossier'] as const) {
+    test(`fails closed without exposing credentials in ${output} test mode`, async () => {
+      const result = await runCommand(output)
+      const outputText = `${result.stdout}\n${result.stderr}`
+
+      expect(result.exitCode).not.toBe(0)
+      expect(outputText).toContain('PostgreSQL read-only qualification audit failed')
+      for (const secret of secretMarkers) {
+        expect(outputText).not.toContain(secret)
+      }
+    })
+  }
+})

--- a/services/bayn/src/qualification-audit-command.ts
+++ b/services/bayn/src/qualification-audit-command.ts
@@ -11,13 +11,12 @@ import { QualificationLockSchema, QualificationResultSchema } from './qualificat
 import {
   auditQualification,
   classifySignalTableAccess,
+  validateSignalReplicaTopology,
   type AuditDatabaseSnapshot,
-  type QualificationAuditReport,
   type RepositoryAudit,
   type SignalAccessRecord,
 } from './audit/audit'
-import { makeQualificationDossier, type QualificationDossier } from './audit/dossier'
-import type { ReferenceEvaluationFailure } from './audit/reference'
+import { makeQualificationDossier } from './audit/dossier'
 import {
   NonNegativeIntegerSchema as NonNegativeInteger,
   PositiveIntegerSchema as PositiveInteger,
@@ -445,17 +444,27 @@ const readSignalReplicaAccess = (
         )
       ORDER BY query_start_time_microseconds, query_id
     `.pipe(sql.withQueryId(`bayn-audit-access-${database.run.runId.slice(-24)}`))
-    return {
-      replica,
-      topology,
-      access: (yield* decodeAccessRows(rows)).map((row) => ({
+    const access: SignalAccessRecord[] = []
+    for (const row of yield* decodeAccessRows(rows)) {
+      const classification = classifySignalTableAccess(row.tables, signalTables)
+      if (Result.isFailure(classification)) {
+        return yield* Effect.fail(
+          commandError(
+            'signal-access',
+            'ClickHouse query-log row has no Signal evidence table',
+            classification.failure,
+          ),
+        )
+      }
+      access.push({
         replica: row.replica,
         queryId: row.query_id,
         queryStartTime: row.query_start_time,
         user: row.user,
-        kind: classifySignalTableAccess(row.tables, signalTables),
-      })),
+        kind: classification.success,
+      })
     }
+    return { replica, topology, access }
   })
   const clickhouse = ClickhouseClient.layer({
     url: url.href,
@@ -485,29 +494,11 @@ const readSignalAccess = (
     { concurrency: 'unbounded' },
   ).pipe(
     Effect.flatMap((sources) =>
-      Effect.try({
-        try: () => {
-          const observed = sources.map((source) => source.replica).sort()
-          if (new Set(observed).size !== observed.length) {
-            throw new Error('ClickHouse audit endpoints resolved to duplicate replicas')
-          }
-          const topology = [...(sources[0]?.topology ?? [])].sort()
-          if (topology.length < 2 || new Set(topology).size !== topology.length) {
-            throw new Error('ClickHouse audit topology must contain at least two unique replicas')
-          }
-          if (sources.some((source) => [...source.topology].sort().join('\0') !== topology.join('\0'))) {
-            throw new Error('ClickHouse audit endpoints report divergent replica topology')
-          }
-          if (observed.join('\0') !== topology.join('\0')) {
-            throw new Error('ClickHouse audit endpoints do not cover every configured cluster replica')
-          }
-          if (sources.some((source) => source.access.some((record) => record.replica !== source.replica))) {
-            throw new Error('ClickHouse query-log rows do not match their audited replica')
-          }
-          return { replicas: observed, access: sources.flatMap((source) => source.access) }
-        },
-        catch: (cause) => commandError('signal-access', 'ClickHouse replica audit topology is invalid', cause),
-      }),
+      Effect.fromResult(validateSignalReplicaTopology(sources)).pipe(
+        Effect.mapError((cause) =>
+          commandError('signal-access', 'ClickHouse replica audit topology is invalid', cause),
+        ),
+      ),
     ),
   )
 
@@ -545,24 +536,105 @@ const repositoryAudit = (
     }
   }).pipe(Effect.mapError((cause) => commandError('repository', 'repository provenance audit failed', cause)))
 
+type LoadedSignal = Effect.Success<ReturnType<typeof loadSignal>>
+type SignalAccessAudit = Effect.Success<ReturnType<typeof readSignalAccess>>
+
+interface ReadDatabaseCommand {
+  readonly _tag: 'ReadDatabase'
+  readonly runId: string
+}
+
+interface LoadSignalCommand {
+  readonly _tag: 'LoadSignal'
+  readonly manifest: InputManifest
+  readonly protocol: Protocol
+}
+
+interface ReadSignalAccessCommand {
+  readonly _tag: 'ReadSignalAccess'
+  readonly database: AuditDatabaseSnapshot
+  readonly finalizedAt: string
+  readonly signalTables: InputManifest['tables']
+}
+
+interface AuditRepositoryCommand {
+  readonly _tag: 'AuditRepository'
+  readonly sourceRevision: string
+  readonly lockCreatedAt: string
+  readonly resultIdentity: readonly string[]
+}
+
+type ReadOnlyAuditCommand = ReadDatabaseCommand | LoadSignalCommand | ReadSignalAccessCommand | AuditRepositoryCommand
+
+function interpretReadOnlyAuditCommand(
+  input: AuditConfig,
+  command: ReadDatabaseCommand,
+): Effect.Effect<AuditDatabaseSnapshot, QualificationAuditCommandError, FileSystem.FileSystem>
+function interpretReadOnlyAuditCommand(
+  input: AuditConfig,
+  command: LoadSignalCommand,
+): Effect.Effect<LoadedSignal, QualificationAuditCommandError>
+function interpretReadOnlyAuditCommand(
+  input: AuditConfig,
+  command: ReadSignalAccessCommand,
+): Effect.Effect<SignalAccessAudit, QualificationAuditCommandError>
+function interpretReadOnlyAuditCommand(
+  input: AuditConfig,
+  command: AuditRepositoryCommand,
+): Effect.Effect<RepositoryAudit, QualificationAuditCommandError, ChildProcessSpawner.ChildProcessSpawner>
+function interpretReadOnlyAuditCommand(
+  input: AuditConfig,
+  command: ReadOnlyAuditCommand,
+): Effect.Effect<
+  AuditDatabaseSnapshot | LoadedSignal | SignalAccessAudit | RepositoryAudit,
+  QualificationAuditCommandError,
+  FileSystem.FileSystem | ChildProcessSpawner.ChildProcessSpawner
+> {
+  switch (command._tag) {
+    case 'ReadDatabase':
+      return readDatabase(command.runId).pipe(
+        Effect.provide(postgresLayer(input)),
+        Effect.mapError((cause) => commandError('audit', 'PostgreSQL read-only qualification audit failed', cause)),
+      )
+    case 'LoadSignal':
+      return loadSignal(input, command.manifest, command.protocol).pipe(
+        Effect.mapError((cause) => commandError('signal-access', 'Signal snapshot audit read failed', cause)),
+      )
+    case 'ReadSignalAccess':
+      return readSignalAccess(input, command.database, command.finalizedAt, command.signalTables)
+    case 'AuditRepository':
+      return repositoryAudit(
+        input.repositoryPath,
+        command.sourceRevision,
+        command.lockCreatedAt,
+        command.resultIdentity,
+      )
+  }
+}
+
 const main = Effect.gen(function* () {
   const input = yield* config
-  const database = yield* readDatabase(input.runId).pipe(Effect.provide(postgresLayer(input)))
+  const database = yield* interpretReadOnlyAuditCommand(input, { _tag: 'ReadDatabase', runId: input.runId })
   const inputManifestArtifact = database.artifacts.find((artifact) => artifact.name === 'input-manifest')
   if (inputManifestArtifact === undefined) {
     return yield* Effect.fail(commandError('audit', 'input-manifest artifact is missing'))
   }
   const manifest = yield* decodeInputManifestArtifact(inputManifestArtifact.payload)
   const protocol = database.protocol.parameters
-  const signal = yield* loadSignal(input, manifest, protocol)
-  const signalAccess = yield* readSignalAccess(input, database, manifest.finalizedSnapshot.finalizedAt, manifest.tables)
+  const signal = yield* interpretReadOnlyAuditCommand(input, { _tag: 'LoadSignal', manifest, protocol })
+  const signalAccess = yield* interpretReadOnlyAuditCommand(input, {
+    _tag: 'ReadSignalAccess',
+    database,
+    finalizedAt: manifest.finalizedSnapshot.finalizedAt,
+    signalTables: manifest.tables,
+  })
   const result = database.qualification.result
-  const repository = yield* repositoryAudit(
-    input.repositoryPath,
-    database.run.sourceRevision,
-    database.qualification.lockCreatedAt,
-    [database.run.runId, result.resultHash, result.analysis.analysisHash],
-  )
+  const repository = yield* interpretReadOnlyAuditCommand(input, {
+    _tag: 'AuditRepository',
+    sourceRevision: database.run.sourceRevision,
+    lockCreatedAt: database.qualification.lockCreatedAt,
+    resultIdentity: [database.run.runId, result.resultHash, result.analysis.analysisHash],
+  })
   const auditInput = {
     bars: signal.bars,
     manifest: signal.manifest,
@@ -573,14 +645,14 @@ const main = Effect.gen(function* () {
     signalPrincipals: { candidate: input.signalUsername, publishers: [input.signalPublisherUsername] },
     repository,
   }
-  const reportDecision = yield* Effect.try({
-    try: (): Result.Result<QualificationAuditReport | QualificationDossier, ReferenceEvaluationFailure> =>
-      input.output === 'dossier' ? makeQualificationDossier(auditInput) : auditQualification(auditInput),
-    catch: (cause) => commandError('audit', 'qualification audit evaluation failed', cause),
-  })
-  const report = yield* Effect.fromResult(reportDecision).pipe(
-    Effect.mapError((cause) => commandError('audit', 'qualification audit execution model failed', cause)),
-  )
+  const report =
+    input.output === 'dossier'
+      ? yield* Effect.fromResult(makeQualificationDossier(auditInput)).pipe(
+          Effect.mapError((cause) => commandError('audit', 'qualification dossier construction failed', cause)),
+        )
+      : yield* Effect.fromResult(auditQualification(auditInput)).pipe(
+          Effect.mapError((cause) => commandError('audit', 'qualification audit evaluation failed', cause)),
+        )
   const output = yield* encodeJson(report)
   const stdio = yield* Stdio.Stdio
   yield* Stream.run(Stream.make(`${output}\n`), stdio.stdout())

--- a/services/bayn/src/qualification-audit.test.ts
+++ b/services/bayn/src/qualification-audit.test.ts
@@ -10,6 +10,7 @@ import { makeQualificationResult } from './qualification'
 import {
   auditQualification as auditQualificationResult,
   classifySignalTableAccess,
+  validateSignalReplicaTopology,
   type AuditDatabaseSnapshot,
   type QualificationAuditInput,
   type QualificationAuditReport,
@@ -23,6 +24,11 @@ const auditQualification = (input: QualificationAuditInput): QualificationAuditR
   const result = auditQualificationResult(input)
   assert(Result.isSuccess(result), 'qualification audit fixture must produce a report')
   return result.success
+}
+
+const assertFailure = <A, E>(result: Result.Result<A, E>): E => {
+  assert(Result.isFailure(result), 'fixture decision must fail')
+  return result.failure
 }
 
 const makeQualificationDossier = (input: QualificationAuditInput): QualificationDossier => {
@@ -422,9 +428,12 @@ describe('qualification audit', () => {
       },
     }
 
-    expect(() => auditQualification({ ...input, database })).toThrow(
-      'current auditor requires causal protocol v3; audit immutable v2 evidence with its source-pinned image',
-    )
+    expect(assertFailure(auditQualificationResult({ ...input, database }))).toEqual({
+      _tag: 'UnsupportedAuditProtocolVersion',
+      storedSchemaVersion: 'bayn.risk-balanced-trend.protocol.v2',
+      suppliedSchemaVersion: fixtureProtocol.schemaVersion,
+      requiredSchemaVersion: 'bayn.risk-balanced-trend.protocol.v3',
+    })
   })
 
   test('fails closed when candidate bars were read before the lock', () => {
@@ -443,13 +452,111 @@ describe('qualification audit', () => {
   test('classifies Signal access from table metadata with bars taking fail-closed precedence', () => {
     const tables = fixture().manifest.tables
 
-    expect(classifySignalTableAccess([`signal.${tables.bars}`], tables)).toBe('bars')
-    expect(classifySignalTableAccess([`signal.${tables.manifests}`, `signal.${tables.bars}`], tables)).toBe('bars')
-    expect(classifySignalTableAccess([`signal.${tables.sessions}`], tables)).toBe('sessions')
-    expect(classifySignalTableAccess([`signal.${tables.manifests}`], tables)).toBe('manifest')
-    expect(() => classifySignalTableAccess(['system.query_log'], tables)).toThrow(
-      'query log record does not access a Signal evidence table',
+    expect(Result.getOrThrow(classifySignalTableAccess([`signal.${tables.bars}`], tables))).toBe('bars')
+    expect(
+      Result.getOrThrow(classifySignalTableAccess([`signal.${tables.manifests}`, `signal.${tables.bars}`], tables)),
+    ).toBe('bars')
+    expect(Result.getOrThrow(classifySignalTableAccess([`signal.${tables.sessions}`], tables))).toBe('sessions')
+    expect(Result.getOrThrow(classifySignalTableAccess([`signal.${tables.manifests}`], tables))).toBe('manifest')
+    expect(assertFailure(classifySignalTableAccess(['system.query_log'], tables))).toEqual({
+      _tag: 'SignalEvidenceTableNotAccessed',
+      observedTables: ['system.query_log'],
+      expectedTables: [`signal.${tables.bars}`, `signal.${tables.manifests}`, `signal.${tables.sessions}`].sort(),
+    })
+  })
+
+  test('validates complete and internally consistent Signal replica topology', () => {
+    const access = {
+      replica: 'replica-0',
+      queryId: 'query-0',
+      queryStartTime: '2026-07-20T12:00:00.000000Z',
+      user: 'bayn',
+      kind: 'bars' as const,
+    }
+    const success = validateSignalReplicaTopology([
+      { replica: 'replica-1', topology: ['replica-0', 'replica-1'], access: [] },
+      { replica: 'replica-0', topology: ['replica-1', 'replica-0'], access: [access] },
+    ])
+    assert(Result.isSuccess(success))
+    expect(success.success).toEqual({ replicas: ['replica-0', 'replica-1'], access: [access] })
+
+    expect(
+      assertFailure(
+        validateSignalReplicaTopology([
+          { replica: 'replica-0', topology: ['replica-0', 'replica-1'], access: [] },
+          { replica: 'replica-0', topology: ['replica-0', 'replica-1'], access: [] },
+        ]),
+      )._tag,
+    ).toBe('DuplicateSignalReplicaEndpoint')
+    expect(
+      assertFailure(validateSignalReplicaTopology([{ replica: 'replica-0', topology: ['replica-0'], access: [] }]))
+        ._tag,
+    ).toBe('InvalidSignalReplicaTopology')
+    expect(
+      assertFailure(
+        validateSignalReplicaTopology([
+          { replica: 'replica-0', topology: ['replica-0', 'replica-1'], access: [] },
+          { replica: 'replica-1', topology: ['replica-0', 'replica-2'], access: [] },
+        ]),
+      )._tag,
+    ).toBe('DivergentSignalReplicaTopology')
+    expect(
+      assertFailure(
+        validateSignalReplicaTopology([{ replica: 'replica-0', topology: ['replica-0', 'replica-1'], access: [] }]),
+      )._tag,
+    ).toBe('IncompleteSignalReplicaCoverage')
+    expect(
+      assertFailure(
+        validateSignalReplicaTopology([
+          { replica: 'replica-0', topology: ['replica-0', 'replica-1'], access: [{ ...access, replica: 'replica-1' }] },
+          { replica: 'replica-1', topology: ['replica-0', 'replica-1'], access: [] },
+        ]),
+      ),
+    ).toEqual({
+      _tag: 'SignalReplicaRecordMismatch',
+      endpointReplica: 'replica-0',
+      recordReplica: 'replica-1',
+      queryId: 'query-0',
+    })
+  })
+
+  test('returns closed failures for malformed reconciliation and unsupported artifacts', () => {
+    const malformed = fixture()
+    const malformedArtifacts = malformed.database.artifacts.map((artifact) =>
+      artifact.name === 'reconciliation' ? { ...artifact, payload: null } : artifact,
     )
+    expect(
+      assertFailure(
+        auditQualificationResult({
+          ...malformed,
+          database: { ...malformed.database, artifacts: malformedArtifacts },
+        }),
+      )._tag,
+    ).toBe('ReconciliationArtifactInvalid')
+
+    const unsupported = fixture()
+    const unsupportedArtifact = {
+      name: 'unsupported-artifact',
+      schemaVersion: 'bayn.unsupported.v1',
+      contentHash: canonicalHashV1({}),
+      payload: {},
+    }
+    expect(
+      assertFailure(
+        auditQualificationResult({
+          ...unsupported,
+          database: {
+            ...unsupported.database,
+            run: { ...unsupported.database.run, artifactCount: unsupported.database.run.artifactCount + 1 },
+            artifacts: [...unsupported.database.artifacts, unsupportedArtifact],
+          },
+        }),
+      ),
+    ).toEqual({
+      _tag: 'UnsupportedQualificationArtifact',
+      artifactName: 'unsupported-artifact',
+      supportedArtifactNames: expect.arrayContaining(['reconciliation', 'strategy']),
+    })
   })
 
   test.each([
@@ -597,22 +704,36 @@ describe('qualification dossier', () => {
 
   test('refuses to publish a failed or mismatched audit', () => {
     const failed = fixture()
-    expect(() =>
-      makeQualificationDossier({
-        ...failed,
-        repository: { ...failed.repository, sourceCommitAncestorOfMain: false },
-      }),
-    ).toThrow('qualification audit did not pass')
+    expect(
+      assertFailure(
+        makeQualificationDossierResult({
+          ...failed,
+          repository: { ...failed.repository, sourceCommitAncestorOfMain: false },
+        }),
+      ),
+    ).toEqual({
+      _tag: 'QualificationDossierSubjectMismatch',
+      check: 'audit-passed',
+      actual: false,
+      expected: true,
+    })
 
     const mismatched = fixture()
-    expect(() =>
-      makeQualificationDossier({
-        ...mismatched,
-        database: {
-          ...mismatched.database,
-          run: { ...mismatched.database.run, artifactCount: mismatched.database.run.artifactCount + 1 },
-        },
-      }),
-    ).toThrow('qualification audit did not pass')
+    expect(
+      assertFailure(
+        makeQualificationDossierResult({
+          ...mismatched,
+          database: {
+            ...mismatched.database,
+            run: { ...mismatched.database.run, artifactCount: mismatched.database.run.artifactCount + 1 },
+          },
+        }),
+      ),
+    ).toEqual({
+      _tag: 'QualificationDossierSubjectMismatch',
+      check: 'audit-passed',
+      actual: false,
+      expected: true,
+    })
   })
 })

--- a/services/bayn/src/qualification-reference.test.ts
+++ b/services/bayn/src/qualification-reference.test.ts
@@ -4,13 +4,18 @@ import { describe, expect, test } from 'bun:test'
 import { Result } from 'effect'
 
 import { canonicalHashV1 } from './hash'
-import { evaluateReference } from './audit/reference'
+import { evaluateReference, measureReferenceEvaluationWork, restrictReferenceBuyFill } from './audit/reference'
 import { evaluateRiskBalancedTrend } from './risk-balanced-trend'
 import { fixtureProtocol, makeSnapshot, makeTestProvenance } from './test-fixtures'
 
 const assertSuccess = <A, E>(result: Result.Result<A, E>): A => {
   assert(Result.isSuccess(result), 'strategy evaluation fixture must succeed')
   return result.success
+}
+
+const assertFailure = <A, E>(result: Result.Result<A, E>): E => {
+  assert(Result.isFailure(result), 'reference evaluation fixture must fail')
+  return result.failure
 }
 
 describe('independent qualification reference', () => {
@@ -32,6 +37,7 @@ describe('independent qualification reference', () => {
     expect(reference.strategy.events).toEqual(actual.events)
     expect(reference.strategy.decisions).toEqual(actual.signalDecisions)
     expect(reference.strategy.trace).toEqual(actual.simulation)
+    expect('work' in reference.strategy).toBe(false)
     expect(reference.buyAndHold.daily).toEqual(actual.benchmarkSeries.buyAndHold)
     expect(reference.directVolTiming.daily).toEqual(actual.benchmarkSeries.directVolTiming)
     expect(reference.doubleCostStrategy.daily).toEqual(actual.benchmarkSeries.doubleCostStrategy)
@@ -45,6 +51,14 @@ describe('independent qualification reference', () => {
     const changed = assertSuccess(evaluateReference(bars, snapshot.manifest, fixtureProtocol, provenance))
 
     expect(canonicalHashV1(changed.strategy.decisions)).not.toBe(canonicalHashV1(original.strategy.decisions))
+  })
+
+  test('does not import the production strategy evaluator', async () => {
+    const source = await Bun.file(new URL('./audit/reference.ts', import.meta.url)).text()
+
+    expect(source).not.toContain("from '../risk-balanced-trend'")
+    expect(source).not.toContain("from '../risk-balanced-trend/index'")
+    expect(source).not.toContain('evaluateRiskBalancedTrend')
   })
 
   test('independently keeps planned quantities invariant to future execution OHLC', () => {
@@ -87,5 +101,186 @@ describe('independent qualification reference', () => {
     expect(requests(changedReference.strategy.trace?.orders ?? [])).toEqual(requests(actual.simulation.orders))
     expect(changedActual.strategy.endingEquityMicros).not.toBe(actual.strategy.endingEquityMicros)
     expect(changedReference.strategy.trace).toEqual(changedActual.simulation)
+  })
+
+  test('uses immutable replay transitions with linear state-copy work at realistic history size', () => {
+    const snapshot = makeSnapshot(900)
+    const provenance = makeTestProvenance()
+    const before = canonicalHashV1({ bars: snapshot.bars, manifest: snapshot.manifest, protocol: fixtureProtocol })
+    const first = assertSuccess(
+      measureReferenceEvaluationWork(snapshot.bars, snapshot.manifest, fixtureProtocol, provenance),
+    )
+    const second = assertSuccess(
+      measureReferenceEvaluationWork(snapshot.bars, snapshot.manifest, fixtureProtocol, provenance),
+    )
+
+    expect(snapshot.bars).toHaveLength(900 * fixtureProtocol.universe.length)
+    for (const replay of [first.strategy, first.buyAndHold, first.directVolTiming, first.doubleCostStrategy]) {
+      expect(replay.positionStateCopies).toBeLessThanOrEqual(replay.sessionsProcessed)
+      expect(replay.positionWrites).toBeLessThanOrEqual(replay.sessionsProcessed * fixtureProtocol.universe.length * 2)
+    }
+    expect(second).toEqual(first)
+    expect(canonicalHashV1({ bars: snapshot.bars, manifest: snapshot.manifest, protocol: fixtureProtocol })).toBe(
+      before,
+    )
+  })
+
+  test('returns fact-bearing failures for malformed reference inputs', () => {
+    const snapshot = makeSnapshot(900)
+    const provenance = makeTestProvenance()
+
+    expect(
+      assertFailure(evaluateReference(snapshot.bars.slice(1), snapshot.manifest, fixtureProtocol, provenance)),
+    ).toEqual({
+      _tag: 'ReferenceInputRowCountMismatch',
+      expected: snapshot.manifest.rowCount,
+      actual: snapshot.bars.length - 1,
+    })
+
+    const unexpectedBars = snapshot.bars.map((bar, index) => (index === 0 ? { ...bar, symbol: 'UNEXPECTED' } : bar))
+    expect(assertFailure(evaluateReference(unexpectedBars, snapshot.manifest, fixtureProtocol, provenance))._tag).toBe(
+      'ReferenceUnexpectedSymbol',
+    )
+
+    const duplicateBars = snapshot.bars.map((bar, index) =>
+      index === 1 ? { ...bar, symbol: snapshot.bars[0].symbol } : bar,
+    )
+    expect(assertFailure(evaluateReference(duplicateBars, snapshot.manifest, fixtureProtocol, provenance))._tag).toBe(
+      'ReferenceDuplicateBar',
+    )
+
+    const incompleteBars = snapshot.bars.map((bar, index) =>
+      index === 0 ? { ...bar, sessionDate: '1990-01-01' as typeof bar.sessionDate } : bar,
+    )
+    expect(assertFailure(evaluateReference(incompleteBars, snapshot.manifest, fixtureProtocol, provenance))._tag).toBe(
+      'ReferenceIncompleteSession',
+    )
+
+    expect(
+      assertFailure(
+        evaluateReference(
+          snapshot.bars,
+          { ...snapshot.manifest, sessionCount: snapshot.manifest.sessionCount + 1 },
+          fixtureProtocol,
+          provenance,
+        ),
+      )._tag,
+    ).toBe('ReferenceManifestSessionMismatch')
+  })
+
+  test('returns fact-bearing failures for invalid reference protocol decisions', () => {
+    const snapshot = makeSnapshot(900)
+
+    const covarianceProtocol = { ...fixtureProtocol, volatilityWindow: 1 }
+    expect(
+      assertFailure(
+        evaluateReference(snapshot.bars, snapshot.manifest, covarianceProtocol, makeTestProvenance(covarianceProtocol)),
+      )._tag,
+    ).toBe('ReferenceCovarianceInputMismatch')
+
+    const horizonProtocol = { ...fixtureProtocol, horizons: [0] }
+    expect(
+      assertFailure(
+        evaluateReference(snapshot.bars, snapshot.manifest, horizonProtocol, makeTestProvenance(horizonProtocol)),
+      )._tag,
+    ).toBe('ReferenceInvalidHorizonSignal')
+
+    const scoreProtocol = { ...fixtureProtocol, horizons: [] }
+    expect(
+      assertFailure(
+        evaluateReference(snapshot.bars, snapshot.manifest, scoreProtocol, makeTestProvenance(scoreProtocol)),
+      )._tag,
+    ).toBe('ReferenceInvalidScore')
+
+    const weightProtocol = { ...fixtureProtocol, maximumSymbolWeight: -0.1 }
+    expect(
+      assertFailure(
+        evaluateReference(snapshot.bars, snapshot.manifest, weightProtocol, makeTestProvenance(weightProtocol)),
+      )._tag,
+    ).toBe('ReferenceInvalidWeight')
+
+    const insufficientProtocol = {
+      ...fixtureProtocol,
+      thresholds: { ...fixtureProtocol.thresholds, minimumObservations: 100_000 },
+    }
+    expect(
+      assertFailure(
+        evaluateReference(
+          snapshot.bars,
+          snapshot.manifest,
+          insufficientProtocol,
+          makeTestProvenance(insufficientProtocol),
+        ),
+      )._tag,
+    ).toBe('ReferenceInsufficientObservations')
+  })
+
+  test('fails closed on invalid market values, provenance, and execution-model versions', () => {
+    const snapshot = makeSnapshot(900)
+    const invalidCloseBars = snapshot.bars.map((bar, index) => (index === 4_000 ? { ...bar, close: 0 } : bar))
+    expect(
+      assertFailure(evaluateReference(invalidCloseBars, snapshot.manifest, fixtureProtocol, makeTestProvenance()))._tag,
+    ).toBe('ReferenceInvalidClose')
+
+    const changedProvenance = {
+      ...makeTestProvenance(),
+      strategy: { ...makeTestProvenance().strategy, parameterHash: '0'.repeat(64) },
+    }
+    expect(
+      assertFailure(evaluateReference(snapshot.bars, snapshot.manifest, fixtureProtocol, changedProvenance))._tag,
+    ).toBe('ReferenceProvenanceMismatch')
+
+    const noSignalManifest = {
+      ...snapshot.manifest,
+      bounds: {
+        ...snapshot.manifest.bounds,
+        evaluationStart: snapshot.manifest.firstSession,
+        evaluationEnd: snapshot.manifest.firstSession,
+      },
+    }
+    expect(
+      assertFailure(evaluateReference(snapshot.bars, noSignalManifest, fixtureProtocol, makeTestProvenance()))._tag,
+    ).toBe('ReferenceNoEligibleSignal')
+
+    const unsupportedProtocol = {
+      ...fixtureProtocol,
+      executionModel: { ...fixtureProtocol.executionModel, schemaVersion: 'bayn.execution-model.v1' },
+    } as unknown as typeof fixtureProtocol
+    expect(
+      assertFailure(
+        evaluateReference(
+          snapshot.bars,
+          snapshot.manifest,
+          unsupportedProtocol,
+          makeTestProvenance(unsupportedProtocol),
+        ),
+      ),
+    ).toEqual({
+      _tag: 'UnsupportedReferenceExecutionModel',
+      actual: 'bayn.execution-model.v1',
+      required: 'bayn.execution-model.v2',
+    })
+  })
+
+  test('rejects a buying-power adjustment that increases a modeled fill', () => {
+    const order = {
+      id: '1'.repeat(64),
+      decisionId: '2'.repeat(64),
+      sessionDate: '2026-07-21' as const,
+      symbol: fixtureProtocol.universe[0],
+      side: 'buy' as const,
+      requestedQuantityMicros: '100',
+      filledQuantityMicros: '80',
+      status: 'partially-filled' as const,
+      rejectionReason: null,
+      unfilledRemainder: 'canceled' as const,
+    }
+
+    expect(assertFailure(restrictReferenceBuyFill('3'.repeat(64), order, 81n))).toEqual({
+      _tag: 'ReferenceBuyFillRestrictionInvalid',
+      orderId: order.id,
+      modeledQuantityMicros: '80',
+      permittedQuantityMicros: '81',
+    })
   })
 })

--- a/services/bayn/src/qualification-reference.test.ts
+++ b/services/bayn/src/qualification-reference.test.ts
@@ -71,7 +71,7 @@ describe('independent qualification reference', () => {
         assert(build.metafile !== undefined, 'dependency-boundary build omitted its metafile')
         return Object.keys(build.metafile.inputs).map((path) => path.replaceAll('\\', '/'))
       }
-      const productionEvaluator = /(?:^|\/)services\/bayn\/src\/risk-balanced-trend(?:\.ts|\/)/
+      const productionEvaluator = /(?:^|\/)risk-balanced-trend(?:\.ts|\/)/
       const productionInputs = await buildInputs(new URL('./risk-balanced-trend/index.ts', import.meta.url))
       const referenceInputs = await buildInputs(new URL('./audit/reference.ts', import.meta.url))
 

--- a/services/bayn/src/qualification-reference.test.ts
+++ b/services/bayn/src/qualification-reference.test.ts
@@ -1,4 +1,7 @@
 import assert from 'node:assert/strict'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 
 import { describe, expect, test } from 'bun:test'
 import { Result } from 'effect'
@@ -53,12 +56,30 @@ describe('independent qualification reference', () => {
     expect(canonicalHashV1(changed.strategy.decisions)).not.toBe(canonicalHashV1(original.strategy.decisions))
   })
 
-  test('does not import the production strategy evaluator', async () => {
-    const source = await Bun.file(new URL('./audit/reference.ts', import.meta.url)).text()
+  test('keeps the reference dependency graph outside the production strategy evaluator', async () => {
+    const outputDirectory = await mkdtemp(join(tmpdir(), 'bayn-reference-dependency-'))
+    try {
+      const buildInputs = async (entrypoint: URL): Promise<readonly string[]> => {
+        const build = await Bun.build({
+          entrypoints: [entrypoint.pathname],
+          outdir: outputDirectory,
+          target: 'bun',
+          metafile: true,
+          packages: 'external',
+        })
+        assert(build.success, build.logs.map(String).join('\n'))
+        assert(build.metafile !== undefined, 'dependency-boundary build omitted its metafile')
+        return Object.keys(build.metafile.inputs).map((path) => path.replaceAll('\\', '/'))
+      }
+      const productionEvaluator = /(?:^|\/)services\/bayn\/src\/risk-balanced-trend(?:\.ts|\/)/
+      const productionInputs = await buildInputs(new URL('./risk-balanced-trend/index.ts', import.meta.url))
+      const referenceInputs = await buildInputs(new URL('./audit/reference.ts', import.meta.url))
 
-    expect(source).not.toContain("from '../risk-balanced-trend'")
-    expect(source).not.toContain("from '../risk-balanced-trend/index'")
-    expect(source).not.toContain('evaluateRiskBalancedTrend')
+      expect(productionInputs.some((path) => productionEvaluator.test(path))).toBe(true)
+      expect(referenceInputs.filter((path) => productionEvaluator.test(path))).toEqual([])
+    } finally {
+      await rm(outputDirectory, { recursive: true, force: true })
+    }
   })
 
   test('independently keeps planned quantities invariant to future execution OHLC', () => {


### PR DESCRIPTION
## Summary

- replace qualification-reference partial paths with closed fact-bearing `Result` failures while preserving the independent audit oracle and its public success shape
- make replay state transitions immutable, with at most one local position-map draft per writing session
- totalize audit classification, replica topology, artifact decoding, and dossier publication without changing check ordering or canonical material
- adapt the qualification-audit boundary to a small read-only Effect command interpreter
- add command credential-redaction regressions, source-level evaluator-independence coverage, and realistic 900-session bounded-copy evidence

## Related Issues

None.

## Preserved Invariants

- every existing qualification/audit check, chronology/topology rule, lineage rule, and fail-closed decision
- canonical inputs, hashes, artifact ordering, and two-run deterministic `auditHash`
- repeatable-read read-only PostgreSQL audit transaction
- deterministic artifact/dossier rendering and credential-safe command output
- exact successful strategy, benchmark, event, decision, trace, and metric outputs

The golden audit hash remains `b3a9ee416e1a97794acebb9ad071da4a01b1513f1ba6c87cc5f206c76b168043`.

## Performance Evidence

A 900-session fixture containing 5,400 bars for the six-symbol protocol universe verifies deterministic work counts and unchanged caller inputs. Replay position state is copied no more than once per processed session, and writes are bounded by sessions × universe × two sides. The regression uses operation counts rather than a flaky wall-clock gate.

## Testing

- `bun test services/bayn/src/qualification-audit-command.test.ts services/bayn/src/qualification-reference.test.ts services/bayn/src/qualification-audit.test.ts` — 34 passed
- `bun test services/bayn/src` — 694 passed, 119 integration-only skipped, 0 failed
- `bun test services/bayn/src/db/evidence-store.integration.test.ts` against PostgreSQL 18 — 63 passed
- `bun test services/bayn/src/db/paper-store.integration.test.ts` against PostgreSQL 18 — 30 passed
- `bun test services/bayn/src/db/cycle-store/integration.test.ts` against PostgreSQL 18 — 13 passed
- `bun test packages/scripts/src/bayn` — 20 passed
- audit and dossier command subprocesses under `NODE_ENV=test` — both failed closed and exposed no supplied credential marker
- Effect diagnostics — 206 files, 0 errors, warnings, or messages
- `tsc --noEmit -p services/bayn/tsconfig.json` — passed
- Oxfmt check for `services/bayn/src` — passed
- Oxlint syntax mode for `services/bayn` — passed
- Oxlint type-aware mode for `services/bayn` — passed
- `bun build services/bayn/src/index.ts --target=node --external tigerbeetle-node --outdir=services/bayn/dist` — passed
- required PR checks: PostgreSQL integration, linux/amd64 OCI build, and linux/arm64 OCI build — passed on head `9c3fde916bada41714780ffbeed39fb128b0965e`

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots section removed because this change has no UI.
- [x] Breaking Changes section is filled in.
- [x] Documentation, release notes, and follow-ups are not required for this internal refactor.




