### PR TITLE
fix(bayn): validate candidate capture chronology

### DIFF
--- a/services/bayn/src/paper-candidate-discovery.test.ts
+++ b/services/bayn/src/paper-candidate-discovery.test.ts
@@ -509,6 +509,59 @@ describe('paper candidate discovery', () => {
     }
   })
 
+  test('keeps capture-time conversion and broker chronology inside the typed Result channel', () => {
+    const validSnapshot = {
+      projection: projection(),
+      cycle: cycle(),
+      document: document(),
+    }
+    const validatedSnapshot = validatePaperCandidateDiscoverySnapshot(identity, validSnapshot, Date.parse(observedAt))
+    expect(Result.isSuccess(validatedSnapshot)).toBe(true)
+    if (Result.isFailure(validatedSnapshot)) return
+
+    const observations = {
+      account: Effect.runSync(account()),
+      accountConfiguration: accountConfiguration(),
+      assets: symbols.map((symbol) => asset(symbol)),
+    }
+    const invalidCapture = validatePaperCandidateDiscoveryObservations(validatedSnapshot.success, {
+      ...observations,
+      capturedAtMs: -8_640_000_000_000_001,
+    })
+    expect(Result.isFailure(invalidCapture)).toBe(true)
+    if (Result.isFailure(invalidCapture)) {
+      expect(invalidCapture.failure).toMatchObject({
+        _tag: 'ObservationCaptureTimeInvalid',
+        failure: 'broker',
+        observedAtMs: -8_640_000_000_000_001,
+      })
+      expect(renderPaperCandidateDiscoveryError(invalidCapture.failure)).toBe(
+        'paper candidate observation capture time is invalid: observedMs=-8640000000000001',
+      )
+    }
+
+    const futureAssetObservedAt = '2099-07-24T12:00:01.000Z'
+    const capturedAt = '2099-07-24T12:00:00.500Z'
+    const noncausalCapture = validatePaperCandidateDiscoveryObservations(validatedSnapshot.success, {
+      account: observations.account,
+      accountConfiguration: observations.accountConfiguration,
+      assets: symbols.map((symbol) => asset(symbol, symbol.toLowerCase(), futureAssetObservedAt)),
+      capturedAtMs: Date.parse(capturedAt),
+    })
+    expect(Result.isFailure(noncausalCapture)).toBe(true)
+    if (Result.isFailure(noncausalCapture)) {
+      expect(noncausalCapture.failure).toEqual({
+        _tag: 'ObservationChronologyMismatch',
+        failure: 'broker',
+        earlier: 'asset',
+        later: 'capture',
+        symbol: 'VNQ',
+        earlierObservedAt: futureAssetObservedAt,
+        laterObservedAt: capturedAt,
+      })
+    }
+  })
+
   test('reads one immutable snapshot and emits every ordered candidate without mutation capabilities', async () => {
     const state = control()
     const receipt = await Effect.runPromise(program(state))

--- a/services/bayn/src/paper-candidate-discovery/broker-observation-validation.ts
+++ b/services/bayn/src/paper-candidate-discovery/broker-observation-validation.ts
@@ -195,19 +195,48 @@ export const assembleValidatedObservations = (
   capturedAtMs: number,
 ): Result.Result<ValidatedPaperCandidateObservations, PaperCandidateDiscoveryError> =>
   pipe(
-    requireCondition(capturedAtMs < Date.parse(validatedSnapshot.snapshot.document.expiresAt), {
-      _tag: 'DocumentStale',
-      failure: 'document-stale',
-      observedAtMs: capturedAtMs,
-      expiresAt: validatedSnapshot.snapshot.document.expiresAt,
+    Result.try({
+      try: () => new Date(capturedAtMs).toISOString(),
+      catch: (cause): PaperCandidateDiscoveryError => ({
+        _tag: 'ObservationCaptureTimeInvalid',
+        failure: 'broker',
+        observedAtMs: capturedAtMs,
+        cause,
+      }),
     }),
-    Result.map(() => ({
-      [ValidatedObservationsTypeId]: true as const,
-      account,
-      accountConfiguration,
-      assets,
-      capturedAt: new Date(capturedAtMs).toISOString(),
-    })),
+    Result.flatMap((capturedAt) =>
+      pipe(
+        Result.all([
+          requireCondition(capturedAtMs < Date.parse(validatedSnapshot.snapshot.document.expiresAt), {
+            _tag: 'DocumentStale',
+            failure: 'document-stale',
+            observedAtMs: capturedAtMs,
+            expiresAt: validatedSnapshot.snapshot.document.expiresAt,
+          }),
+          pipe(
+            assets.reads.map((asset) =>
+              requireCondition(Date.parse(asset.value.observedAt) <= capturedAtMs, {
+                _tag: 'ObservationChronologyMismatch',
+                failure: 'broker',
+                earlier: 'asset',
+                later: 'capture',
+                symbol: asset.value.symbol,
+                earlierObservedAt: asset.value.observedAt,
+                laterObservedAt: capturedAt,
+              }),
+            ),
+            Result.all,
+          ),
+        ]),
+        Result.map(() => ({
+          [ValidatedObservationsTypeId]: true as const,
+          account,
+          accountConfiguration,
+          assets,
+          capturedAt,
+        })),
+      ),
+    ),
   )
 
 export const validatePaperCandidateDiscoveryObservations = (

--- a/services/bayn/src/paper-candidate-discovery/failure.ts
+++ b/services/bayn/src/paper-candidate-discovery/failure.ts
@@ -257,6 +257,21 @@ export type PaperCandidateDiscoveryError =
       readonly laterObservedAt: string
     }
   | {
+      readonly _tag: 'ObservationChronologyMismatch'
+      readonly failure: 'broker'
+      readonly earlier: 'asset'
+      readonly later: 'capture'
+      readonly symbol: string
+      readonly earlierObservedAt: string
+      readonly laterObservedAt: string
+    }
+  | {
+      readonly _tag: 'ObservationCaptureTimeInvalid'
+      readonly failure: 'broker'
+      readonly observedAtMs: number
+      readonly cause: unknown
+    }
+  | {
       readonly _tag: 'AssetMissing'
       readonly failure: 'broker'
       readonly ordinal: number
@@ -358,6 +373,7 @@ const paperCandidateDiscoveryErrorTags: ReadonlySet<string> = new Set([
   'AccountMismatch',
   'ObservationTimeMismatch',
   'ObservationChronologyMismatch',
+  'ObservationCaptureTimeInvalid',
   'AssetMissing',
   'AssetSymbolMismatch',
   'AssetCountMismatch',
@@ -442,6 +458,8 @@ export const renderPaperCandidateDiscoveryError = (error: PaperCandidateDiscover
       return `paper candidate ${error.observation} evidence time mismatch: symbol=${error.symbol ?? 'none'} value=${error.valueObservedAt} evidence=${error.evidenceObservedAt}`
     case 'ObservationChronologyMismatch':
       return `paper candidate observation chronology mismatch: earlier=${error.earlier}:${error.earlierObservedAt} later=${error.later}:${error.laterObservedAt} symbol=${error.symbol ?? 'none'}`
+    case 'ObservationCaptureTimeInvalid':
+      return `paper candidate observation capture time is invalid: observedMs=${error.observedAtMs}`
     case 'AssetMissing':
       return `paper candidate asset observation is missing: ordinal=${error.ordinal} symbol=${error.symbol}`
     case 'AssetSymbolMismatch':


### PR DESCRIPTION
## Summary

- keep candidate observation capture-time conversion inside the closed `PaperCandidateDiscoveryError` Result algebra
- reject capture timestamps that precede completed asset observations, preserving account → configuration → asset → capture causal ordering
- preserve the public facade, receipt schema and hashes, broker read sequence, read-only transaction, OBSERVE authority, and cutoff behavior

## Related Issues

None

## Testing

- `bun test services/bayn/src/paper-candidate-discovery.test.ts` — 14 passed, 1 PostgreSQL-gated skip, 0 failed
- `BAYN_TEST_POSTGRES_URL=postgresql://... bun test services/bayn/src/paper-candidate-discovery.test.ts` against PostgreSQL 18 — 15 passed, 0 failed
- `bun test services/bayn/src` — 669 passed, 119 PostgreSQL-gated skips, 0 failed
- `bun node_modules/typescript/bin/tsc --noEmit -p services/bayn/tsconfig.json`
- Effect diagnostics — 185 files checked, 0 errors or warnings
- `bun node_modules/oxfmt/bin/oxfmt --check services/bayn/src`
- `bun node_modules/oxlint/bin/oxlint --config .oxlintrc.json services/bayn`
- `bun node_modules/oxlint/bin/oxlint --config .oxlintrc.json --type-aware --tsconfig services/bayn/tsconfig.json services/bayn`
- `bun build services/bayn/src/index.ts --target=node --external tigerbeetle-node --outdir=services/bayn/dist`
- `bun test packages/scripts/src/bayn` — 20 passed, 0 failed

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is handled above.
- [x] Documentation, release notes, and follow-ups are not required for this internal fix.
- [x] Public exports, receipt wire material, and contract hashes are unchanged.
- [x] Invalid epoch conversion and non-causal capture evidence return fact-bearing typed failures rather than defects.
- [x] No broker mutation, persistence, authority, configuration, entrypoint, or rollout behavior is changed.
