### PR TITLE
refactor(bayn): totalize core decision hashing

### DIFF
--- a/services/bayn/src/cycle.ts
+++ b/services/bayn/src/cycle.ts
@@ -1,7 +1,7 @@
 import { Data, DateTime, Result, Schema } from 'effect'
 
 import type { MarketCalendarObservation, MarketCalendarSession } from './broker/alpaca'
-import { canonicalHashV1 } from './hash'
+import { canonicalHashV1Result } from './hash'
 import { ExecutionModelV2Schema } from './protocol'
 import {
   IsoDateSchema,
@@ -16,10 +16,8 @@ const autonomousCycleSubmissionWindowMs = 30 * 60_000
 const SubmissionWindowMsSchema = PositiveIntegerSchema.check(Schema.isLessThanOrEqualTo(86_400_000))
 const maximumSubmissionDurationMs = 86_400_000
 
-const canonicalHashResult = (value: unknown): Result.Result<string, unknown> => Result.try(() => canonicalHashV1(value))
-
 const canonicalHashMatches = (value: unknown, expectedHash: string): boolean => {
-  const hash = canonicalHashResult(value)
+  const hash = canonicalHashV1Result(value)
   return Result.isSuccess(hash) && hash.success === expectedHash
 }
 
@@ -589,13 +587,11 @@ export const makeCycleExecutionPolicy = (
     ),
     (decoded) =>
       Result.flatMap(
-        Result.try({
-          try: () => ({ ...decoded, executionPolicyHash: canonicalHashV1(decoded) }),
-          catch: (cause) =>
-            executionPolicyFailure('hash', 'cycle execution policy material is not canonicalizable', {}, cause),
-        }),
-        (policy) =>
-          Result.mapError(decodeCycleExecutionPolicyResult(policy), (cause) =>
+        Result.mapError(canonicalHashV1Result(decoded), (cause) =>
+          executionPolicyFailure('hash', 'cycle execution policy material is not canonicalizable', {}, cause),
+        ),
+        (executionPolicyHash) =>
+          Result.mapError(decodeCycleExecutionPolicyResult({ ...decoded, executionPolicyHash }), (cause) =>
             executionPolicyFailure('decode', 'cycle execution policy is invalid', {}, cause),
           ),
       ),
@@ -610,11 +606,9 @@ export const makeCycleExecutionPolicyFromModel = (
     ),
     (decodedModel) =>
       Result.flatMap(
-        Result.try({
-          try: () => canonicalHashV1(decodedModel),
-          catch: (cause) =>
-            executionPolicyFailure('hash', 'strategy execution model is not canonicalizable', {}, cause),
-        }),
+        Result.mapError(canonicalHashV1Result(decodedModel), (cause) =>
+          executionPolicyFailure('hash', 'strategy execution model is not canonicalizable', {}, cause),
+        ),
         (strategyExecutionModelHash) =>
           makeCycleExecutionPolicy({
             schemaVersion: 'bayn.autonomous-cycle-execution-policy.v1',
@@ -656,24 +650,24 @@ export const makeExecutionCalendarObservation = (
         ),
         (material) =>
           Result.flatMap(
-            Result.try({
-              try: () => ({ ...material, executionCalendarHash: canonicalHashV1(material) }),
-              catch: (cause) =>
-                executionCalendarFailure(
-                  'hash',
-                  'broker calendar session is not canonicalizable',
-                  { sessionDate: decoded.date },
-                  cause,
-                ),
-            }),
-            (observation) =>
-              Result.mapError(decodeExecutionCalendarObservationResult(observation), (cause) =>
-                executionCalendarFailure(
-                  'decode',
-                  'selected broker calendar session is invalid',
-                  { sessionDate: decoded.date },
-                  cause,
-                ),
+            Result.mapError(canonicalHashV1Result(material), (cause) =>
+              executionCalendarFailure(
+                'hash',
+                'broker calendar session is not canonicalizable',
+                { sessionDate: decoded.date },
+                cause,
+              ),
+            ),
+            (executionCalendarHash) =>
+              Result.mapError(
+                decodeExecutionCalendarObservationResult({ ...material, executionCalendarHash }),
+                (cause) =>
+                  executionCalendarFailure(
+                    'decode',
+                    'selected broker calendar session is invalid',
+                    { sessionDate: decoded.date },
+                    cause,
+                  ),
               ),
           ),
       )
@@ -687,12 +681,11 @@ export const makeCycleIdentity = (material: unknown): Result.Result<CycleIdentit
     ),
     (decoded) =>
       Result.flatMap(
-        Result.try({
-          try: () => ({ ...decoded, cycleId: canonicalHashV1(decoded) }),
-          catch: (cause) => cycleIdentityFailure('hash', 'cycle identity material is not canonicalizable', {}, cause),
-        }),
-        (identity) =>
-          Result.mapError(decodeCycleIdentityResult(identity), (cause) =>
+        Result.mapError(canonicalHashV1Result(decoded), (cause) =>
+          cycleIdentityFailure('hash', 'cycle identity material is not canonicalizable', {}, cause),
+        ),
+        (cycleId) =>
+          Result.mapError(decodeCycleIdentityResult({ ...decoded, cycleId }), (cause) =>
             cycleIdentityFailure(
               'session-order',
               'execution session must follow the Signal session',
@@ -875,9 +868,9 @@ export const cycleDraftOf = (cycle: AutonomousCycle): CycleDraft => ({
 })
 
 export const cycleDraftMatches = (left: CycleDraft, right: CycleDraft): boolean => {
-  const leftHash = canonicalHashResult(left)
+  const leftHash = canonicalHashV1Result(left)
   if (Result.isFailure(leftHash)) return false
-  const rightHash = canonicalHashResult(right)
+  const rightHash = canonicalHashV1Result(right)
   return Result.isSuccess(rightHash) && leftHash.success === rightHash.success
 }
 

--- a/services/bayn/src/execution-session.ts
+++ b/services/bayn/src/execution-session.ts
@@ -7,7 +7,7 @@ import {
   type AutonomousCycle,
   type ExecutionCalendarObservation,
 } from './cycle'
-import { canonicalHashV1 } from './hash'
+import { canonicalHashV1Result } from './hash'
 import { ExecutionModelV2Schema, type ExecutionModel } from './protocol'
 import { IsoDateSchema, Sha256Schema, UtcInstantSchema, strictParseOptions } from './schemas'
 
@@ -155,10 +155,9 @@ const calendarObservationMaterial = (observation: CalendarIdentity) => ({
 })
 
 const validateCalendarHash = (calendar: CalendarIdentity): Result.Result<void, ExecutionSessionBindingFailure> => {
-  const observedCalendarHash = Result.try({
-    try: () => canonicalHashV1(calendarObservationMaterial(calendar)),
-    catch: (cause) => deriveWindowFailure('hash', 'Alpaca market calendar content is not canonicalizable', {}, cause),
-  })
+  const observedCalendarHash = Result.mapError(canonicalHashV1Result(calendarObservationMaterial(calendar)), (cause) =>
+    deriveWindowFailure('hash', 'Alpaca market calendar content is not canonicalizable', {}, cause),
+  )
   if (Result.isFailure(observedCalendarHash)) return Result.fail(observedCalendarHash.failure)
   if (observedCalendarHash.success !== calendar.normalizedResponseHash) {
     return Result.fail(
@@ -341,7 +340,7 @@ const bindingIssues = (binding: typeof ExecutionSessionBindingBase.Type): readon
     }
   }
   const { bindingHash, ...material } = binding
-  const expectedBindingHash = Result.try(() => canonicalHashV1(material))
+  const expectedBindingHash = canonicalHashV1Result(material)
   if (Result.isFailure(expectedBindingHash)) {
     issues.push({ path: ['bindingHash'], issue: 'execution-session material must be canonicalizable' })
   } else if (bindingHash !== expectedBindingHash.success) {
@@ -419,12 +418,11 @@ const bindDecodedExecutionSession = (
         submissionCutoffLeadMinutes: input.executionModel.order.submissionCutoffLeadMinutes,
       } as const
       return Result.flatMap(
-        Result.try({
-          try: () => ({ ...material, bindingHash: canonicalHashV1(material) }),
-          catch: (cause) => bindFailure('hash', 'execution-session binding material is not canonicalizable', {}, cause),
-        }),
-        (binding) =>
-          Result.mapError(decodeExecutionSessionBindingResult(binding), (cause) =>
+        Result.mapError(canonicalHashV1Result(material), (cause) =>
+          bindFailure('hash', 'execution-session binding material is not canonicalizable', {}, cause),
+        ),
+        (bindingHash) =>
+          Result.mapError(decodeExecutionSessionBindingResult({ ...material, bindingHash }), (cause) =>
             bindFailure('decode', 'derived execution-session binding is invalid', {}, cause),
           ),
       )
@@ -536,16 +534,14 @@ const validateCycleExecutionPolicy = (
   input: DecodedBindCycleExecutionSessionInput,
   binding: ExecutionSessionBinding,
 ): Result.Result<void, ExecutionSessionBindingFailure> => {
-  const executionModelHash = Result.try({
-    try: () => canonicalHashV1(input.executionModel),
-    catch: (cause) =>
-      bindCycleFailure(
-        'hash',
-        'execution model is not canonicalizable',
-        { cycleId: input.cycle.identity.cycleId },
-        cause,
-      ),
-  })
+  const executionModelHash = Result.mapError(canonicalHashV1Result(input.executionModel), (cause) =>
+    bindCycleFailure(
+      'hash',
+      'execution model is not canonicalizable',
+      { cycleId: input.cycle.identity.cycleId },
+      cause,
+    ),
+  )
   if (Result.isFailure(executionModelHash)) return Result.fail(executionModelHash.failure)
   if (executionModelHash.success !== input.cycle.identity.executionPolicy.strategyExecutionModelHash) {
     return Result.fail(

--- a/services/bayn/src/risk.ts
+++ b/services/bayn/src/risk.ts
@@ -1,6 +1,6 @@
 import { Data, Result, Schema, pipe } from 'effect'
 
-import { canonicalHashV1 } from './hash'
+import { canonicalHashV1Result } from './hash'
 import { ExecutionSessionBindingSchema } from './execution-session'
 import {
   AccountSnapshotSchema,
@@ -397,7 +397,7 @@ export const EvaluationSchema = EvaluationBase.check(
       issues.push({ path: ['decision'], issue: 'must retain the risk input evaluation and expiry times' })
     }
     const { decisionId, ...decisionMaterial } = evaluation.decision
-    const expectedDecisionId = Result.try(() => canonicalHashV1(decisionMaterial))
+    const expectedDecisionId = canonicalHashV1Result(decisionMaterial)
     if (Result.isFailure(expectedDecisionId)) {
       issues.push({ path: ['decision', 'decisionId'], issue: 'risk decision material must be canonicalizable' })
     } else if (decisionId !== expectedDecisionId.success) {
@@ -935,72 +935,73 @@ interface RiskBindingHashes {
   readonly inputHash: string
 }
 
-const deriveRiskBindingHashes = (facts: RiskFacts): Result.Result<RiskBindingHashes, RiskEvaluationFailure> =>
-  Result.try({
-    try: () => {
-      const { intent, policy, proposedPositions, state } = facts
-      const policyHash = canonicalHashV1(policy)
-      const accountSnapshotHash = canonicalHashV1({
-        account: state.account,
-        authority: state.authority,
-        authorityObservedAt: state.authorityObservedAt,
-        accountingHash: state.accountingHash,
-        brokerMode: state.brokerMode,
-        reconciliation: state.reconciliation,
-        dailyTradedNotionalMicros: state.dailyTradedNotionalMicros,
-        dayStartEquityMicros: state.dayStartEquityMicros,
-        peakEquityMicros: state.peakEquityMicros,
-      })
-      const positionsHash = canonicalHashV1({
-        items: proposedPositions,
-        observedAt: state.positionsObservedAt,
-      })
-      const ordersHash = canonicalHashV1({
-        items: state.orders,
-        observedAt: state.ordersObservedAt,
-        unknownMutationCount: state.unknownMutationCount,
-      })
-      const marketDataHash = canonicalHashV1({
-        symbol: state.marketDataSymbol,
-        sourceHash: state.marketDataHash,
-        observedAt: state.marketDataObservedAt,
-        referencePriceMicros: state.referencePriceMicros,
-        expectedExecutionPriceMicros: state.expectedExecutionPriceMicros,
-        executionSession: state.executionSession,
-      })
-      const inputHash = canonicalHashV1({
-        schemaVersion:
-          intent.schemaVersion === 'bayn.paper-intent.v3'
-            ? 'bayn.paper-risk-evaluation-input.v3'
-            : 'bayn.paper-risk-evaluation-input.v2',
-        intent,
-        policy,
-        state,
-        proposedPositions,
-        componentHashes: {
-          accountSnapshotHash,
-          positionsHash,
-          ordersHash,
-          marketDataHash,
-        },
-      })
-      return {
-        policyHash,
-        accountSnapshotHash,
-        positionsHash,
-        ordersHash,
-        marketDataHash,
-        inputHash,
-      }
-    },
-    catch: (cause) =>
+const riskEvidenceHash = (facts: RiskFacts, value: unknown): Result.Result<string, RiskEvaluationFailure> =>
+  pipe(
+    canonicalHashV1Result(value),
+    Result.mapError((cause) =>
       canonicalizeRiskInputFailure(
         'evidence',
         'validated risk input evidence is not canonicalizable',
         { intentId: facts.intent.intentId },
         cause,
       ),
+    ),
+  )
+
+const deriveRiskBindingHashes = (facts: RiskFacts): Result.Result<RiskBindingHashes, RiskEvaluationFailure> => {
+  const componentHashes = Result.all({
+    policyHash: riskEvidenceHash(facts, facts.policy),
+    accountSnapshotHash: riskEvidenceHash(facts, {
+      account: facts.state.account,
+      authority: facts.state.authority,
+      authorityObservedAt: facts.state.authorityObservedAt,
+      accountingHash: facts.state.accountingHash,
+      brokerMode: facts.state.brokerMode,
+      reconciliation: facts.state.reconciliation,
+      dailyTradedNotionalMicros: facts.state.dailyTradedNotionalMicros,
+      dayStartEquityMicros: facts.state.dayStartEquityMicros,
+      peakEquityMicros: facts.state.peakEquityMicros,
+    }),
+    positionsHash: riskEvidenceHash(facts, {
+      items: facts.proposedPositions,
+      observedAt: facts.state.positionsObservedAt,
+    }),
+    ordersHash: riskEvidenceHash(facts, {
+      items: facts.state.orders,
+      observedAt: facts.state.ordersObservedAt,
+      unknownMutationCount: facts.state.unknownMutationCount,
+    }),
+    marketDataHash: riskEvidenceHash(facts, {
+      symbol: facts.state.marketDataSymbol,
+      sourceHash: facts.state.marketDataHash,
+      observedAt: facts.state.marketDataObservedAt,
+      referencePriceMicros: facts.state.referencePriceMicros,
+      expectedExecutionPriceMicros: facts.state.expectedExecutionPriceMicros,
+      executionSession: facts.state.executionSession,
+    }),
   })
+  return Result.flatMap(componentHashes, (hashes) =>
+    Result.map(
+      riskEvidenceHash(facts, {
+        schemaVersion:
+          facts.intent.schemaVersion === 'bayn.paper-intent.v3'
+            ? 'bayn.paper-risk-evaluation-input.v3'
+            : 'bayn.paper-risk-evaluation-input.v2',
+        intent: facts.intent,
+        policy: facts.policy,
+        state: facts.state,
+        proposedPositions: facts.proposedPositions,
+        componentHashes: {
+          accountSnapshotHash: hashes.accountSnapshotHash,
+          positionsHash: hashes.positionsHash,
+          ordersHash: hashes.ordersHash,
+          marketDataHash: hashes.marketDataHash,
+        },
+      }),
+      (inputHash) => ({ ...hashes, inputHash }),
+    ),
+  )
+}
 
 type DecodedRiskInput = typeof RiskInputSchema.Type
 type DecodedRiskDecision = typeof RiskDecisionSchema.Type
@@ -1045,9 +1046,15 @@ const makeRiskDecision = (
     decidedAt: facts.state.evaluatedAt,
     expiresAt,
   } as const
-  const decision = { ...material, decisionId: canonicalHashV1(material) }
-  return Result.mapError(decodeRiskDecisionResult(decision), (cause) =>
-    decodeRiskOutputFailure('decision', 'derived risk decision is invalid', { intentId: facts.intent.intentId }, cause),
+  return Result.flatMap(riskEvidenceHash(facts, material), (decisionId) =>
+    Result.mapError(decodeRiskDecisionResult({ ...material, decisionId }), (cause) =>
+      decodeRiskOutputFailure(
+        'decision',
+        'derived risk decision is invalid',
+        { intentId: facts.intent.intentId },
+        cause,
+      ),
+    ),
   )
 }
 

--- a/services/bayn/src/target-planner.ts
+++ b/services/bayn/src/target-planner.ts
@@ -2,7 +2,7 @@ import { Data, Result, Schema, pipe } from 'effect'
 
 import { IntentPlanSchema, type IntentPlan } from './execution/intents'
 import { desiredQuantityMicros, MICROS } from './execution-model'
-import { canonicalHashV1 } from './hash'
+import { canonicalHashV1Result } from './hash'
 import {
   AccountSnapshotSchema,
   AccountStatus,
@@ -457,10 +457,7 @@ const TargetPlanResultSemanticSchema = TargetPlanResultBase.check(Schema.makeFil
 
 const targetPlanHashIssues = (result: typeof TargetPlanResultSemanticSchema.Type): readonly Schema.FilterIssue[] => {
   const { outputHash, ...material } = result
-  const expectedHash = Result.try({
-    try: () => canonicalHashV1(material),
-    catch: (cause) => cause,
-  })
+  const expectedHash = canonicalHashV1Result(material)
   if (Result.isFailure(expectedHash)) {
     return [{ path: ['outputHash'], issue: 'target-plan output material must be canonicalizable' }]
   }
@@ -595,7 +592,7 @@ const plannerInputHash = (
   value: unknown,
 ): Result.Result<string, TargetPlannerFailure> =>
   pipe(
-    Result.try(() => canonicalHashV1(value)),
+    canonicalHashV1Result(value),
     Result.mapError((cause) =>
       canonicalizePlannerInputFailure(
         'hash',
@@ -921,17 +918,18 @@ const computeTargetPlan = (facts: TargetPlannerFacts): Result.Result<OutputMater
 
 const finalizeTargetPlan = (material: OutputMaterial): Result.Result<TargetPlanResult, TargetPlannerFailure> =>
   Result.flatMap(
-    Result.try({
-      try: () => ({ ...material, outputHash: canonicalHashV1(material) }),
-      catch: (cause) =>
+    pipe(
+      canonicalHashV1Result(material),
+      Result.mapError((cause) =>
         canonicalizePlannerOutputFailure(
           'hash',
           'target-plan output material is not canonicalizable',
           { inputHash: material.inputHash, status: material.status },
           cause,
         ),
-    }),
-    decodeTargetPlanResult,
+      ),
+    ),
+    (outputHash) => decodeTargetPlanResult({ ...material, outputHash }),
   )
 
 export const decodeTargetPlanResult = (input: unknown): Result.Result<TargetPlanResult, TargetPlannerFailure> =>
@@ -942,16 +940,17 @@ export const decodeTargetPlanResult = (input: unknown): Result.Result<TargetPlan
     (decoded) => {
       const { outputHash, ...material } = decoded
       return Result.flatMap(
-        Result.try({
-          try: () => canonicalHashV1(material),
-          catch: (cause) =>
+        pipe(
+          canonicalHashV1Result(material),
+          Result.mapError((cause) =>
             canonicalizePlannerOutputFailure(
               'hash',
               'target-plan output material is not canonicalizable',
               { inputHash: decoded.inputHash, path: ['outputHash'], status: decoded.status },
               cause,
             ),
-        }),
+          ),
+        ),
         (expectedHash) =>
           expectedHash === outputHash
             ? Result.succeed(decoded)


### PR DESCRIPTION
## Summary

- totalize risk evidence, aggregate input, and decision hashing by composing the canonical `Result` API instead of catching deprecated throwing adapters
- totalize target-planner input and output identity construction while preserving exact input/output hashes and durable failure vocabulary
- totalize cycle policy, calendar, identity, and execution-session binding hashes, including schema semantic checks and pure equality decisions
- preserve every existing hash byte, gate result, planner action, cycle identity, execution window, and runtime contract

## Related Issues

None

## Testing

- `bun test services/bayn/src/risk.test.ts services/bayn/src/target-planner.test.ts services/bayn/src/cycle.test.ts services/bayn/src/execution-session.test.ts` — 62 passed, 0 failed
- `node services/bayn/node_modules/typescript/bin/tsc --project services/bayn/tsconfig.json --noEmit --pretty false` — passed before and after rebase
- `bun services/bayn/node_modules/@effect/tsgo/dist/effect-tsgo.js diagnostics --project services/bayn/tsconfig.json --format text --severity error` — 185 files, 0 errors, 0 warnings
- `node node_modules/oxfmt/bin/oxfmt --check services/bayn/src` — passed
- `node node_modules/oxlint/bin/oxlint --config .oxlintrc.json services/bayn` — 0 errors, 0 warnings
- `node node_modules/oxlint/bin/oxlint --config .oxlintrc.json --type-aware --tsconfig services/bayn/tsconfig.json services/bayn` — 0 errors, 0 warnings
- `bun test services/bayn/src` — 668 passed, 119 PostgreSQL-gated skips, 0 failed
- `bun build services/bayn/src/index.ts --target=node --external tigerbeetle-node --outdir=/tmp/bayn-fp-top3-dist` — passed
- `bun test packages/scripts/src/bayn` — 20 passed, 0 failed
- verified no `canonicalHashV1(...)` or `Result.try` remains in the four changed production modules

## Breaking Changes

None. Durable identities, schemas, public failures, and compatibility adapters remain unchanged.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; this is a pure TypeScript domain refactor.
- [x] Documentation and release notes are not required because public and durable contracts are unchanged.
