### PR TITLE
refactor(bayn): close functional boundaries

### DIFF
--- a/services/bayn/src/observe-composition.test.ts
+++ b/services/bayn/src/observe-composition.test.ts
@@ -319,6 +319,31 @@ const calendarRead =
       }
     })
 
+const decisionBrokerRead = (marketCalendar: BrokerReadShape['marketCalendar']): BrokerReadShape => {
+  const unused = Effect.die(new Error('decision building must not use unrelated broker reads'))
+  return {
+    account: unused,
+    accountConfiguration: unused,
+    assetBySymbol: unusedAssetBySymbol,
+    positions: unused,
+    orders: () => unused,
+    orderById: () => unused,
+    orderByClientId: () => unused,
+    fillActivities: () => unused,
+    marketCalendar,
+  }
+}
+
+const provideDecisionServices = <A, E>(
+  program: Effect.Effect<A, E, BrokerRead | MarketData>,
+  marketDataService: MarketDataService,
+  marketCalendar: BrokerReadShape['marketCalendar'],
+): Effect.Effect<A, E> =>
+  program.pipe(
+    Effect.provideService(BrokerRead, decisionBrokerRead(marketCalendar)),
+    Effect.provideService(MarketData, marketDataService),
+  )
+
 describe('OBSERVE runtime composition', () => {
   test('derives the autonomous cycle protocol identity from the current strategy provenance', () => {
     const prepared = prepareObserveStartup({
@@ -358,8 +383,6 @@ describe('OBSERVE runtime composition', () => {
         authorityGenerationHash: generationHash,
         cycle,
         executionModel: fixtureProtocol.executionModel,
-        marketCalendar: calendarRead(calendarQueries),
-        marketData: marketData(snapshotRequests),
         policy,
         reconcile: Effect.succeed(reconciliationResult()),
         strategy: {
@@ -372,7 +395,10 @@ describe('OBSERVE runtime composition', () => {
           },
         },
       })
-    }).pipe(Effect.provide(TestClock.layer()))
+    }).pipe(
+      (program) => provideDecisionServices(program, marketData(snapshotRequests), calendarRead(calendarQueries)),
+      Effect.provide(TestClock.layer()),
+    )
 
     const document = await Effect.runPromise(program)
 
@@ -423,8 +449,6 @@ describe('OBSERVE runtime composition', () => {
             authorityGenerationHash: generationHash,
             cycle,
             executionModel: fixtureProtocol.executionModel,
-            marketCalendar: calendarRead([]),
-            marketData: marketData([]),
             policy,
             reconcile: Effect.succeed(reconciliationResult('9'.repeat(64))),
             strategy: {
@@ -434,7 +458,10 @@ describe('OBSERVE runtime composition', () => {
               },
             },
           })
-        }).pipe(Effect.provide(TestClock.layer())),
+        }).pipe(
+          (program) => provideDecisionServices(program, marketData([]), calendarRead([])),
+          Effect.provide(TestClock.layer()),
+        ),
       ),
     )
 
@@ -539,12 +566,10 @@ describe('OBSERVE runtime composition', () => {
             authorityGenerationHash: generationHash,
             cycle,
             executionModel: fixtureProtocol.executionModel,
-            marketCalendar: testCase.marketCalendar,
-            marketData: testCase.marketData,
             policy,
             reconcile: testCase.reconcile,
             strategy: { currentDecision: () => Result.succeed({ decision, priceMicros }) },
-          }),
+          }).pipe((program) => provideDecisionServices(program, testCase.marketData, testCase.marketCalendar)),
         ),
       )
 

--- a/services/bayn/src/observe-composition.ts
+++ b/services/bayn/src/observe-composition.ts
@@ -1,4 +1,4 @@
-import { Effect, pipe, Result } from 'effect'
+import { Context, Effect, pipe, Result } from 'effect'
 
 import type { AutonomousCycleStartup } from './app'
 import { BrokerRead, type BrokerReadShape, type MarketCalendarQuery } from './broker/alpaca'
@@ -9,9 +9,9 @@ import {
   marketCalendarQueryForSignal,
   type CyclePassObservation,
 } from './cycle-runner'
-import { CycleStore, type CycleStoreShape } from './db/cycle-store'
-import { PaperStore, type PaperStoreShape } from './db/paper-store'
-import { WriterFence, type WriterFenceService } from './execution/writer-fence'
+import { CycleStore } from './db/cycle-store'
+import { PaperStore } from './db/paper-store'
+import { WriterFence } from './execution/writer-fence'
 import {
   bindCycleExecutionSession,
   type ExecutionSessionBinding,
@@ -20,7 +20,7 @@ import {
 import { makeFillTerms, MICROS } from './execution-model'
 import { makeStrategyProtocolHash } from './contracts'
 import { operationalError, type OperationalError } from './errors'
-import { canonicalHashV1 } from './hash'
+import { canonicalHashV1Result } from './hash'
 import { MarketData, type MarketDataService } from './market-data'
 import { Authority, OrderSide, OrderType, TimeInForce, type AuthorityState } from './paper'
 import type { CausalProtocol } from './protocol'
@@ -70,14 +70,12 @@ type ObserveStrategy = Pick<Strategy, 'currentDecision'>
 
 type ReconciliationPassError = Effect.Error<typeof runOnce>
 
-export type ObserveDecisionInput = {
+export type ObserveDecisionInput<R = never> = {
   readonly authorityGenerationHash: string
   readonly cycle: AutonomousCycle
   readonly executionModel: CausalProtocol['executionModel']
-  readonly marketCalendar: BrokerReadShape['marketCalendar']
-  readonly marketData: MarketDataService
   readonly policy: Policy
-  readonly reconcile: Effect.Effect<ReconciliationPassResult, ReconciliationPassError>
+  readonly reconcile: Effect.Effect<ReconciliationPassResult, ReconciliationPassError, R>
   readonly strategy: ObserveStrategy
 }
 
@@ -197,10 +195,7 @@ const hashObserveMaterial = (
   message: string,
   value: unknown,
 ): Result.Result<string, ObserveDecisionCompositionFailure> =>
-  Result.mapError(
-    Result.try(() => canonicalHashV1(value)),
-    (cause) => compositionFailure(operation, message, cause),
-  )
+  Result.mapError(canonicalHashV1Result(value), (cause) => compositionFailure(operation, message, cause))
 
 const referencePrices = (
   signalDate: SignalSessionReferencePrices['signalDate'],
@@ -219,8 +214,8 @@ const referencePrices = (
   )
 }
 
-const prepareObserveDecisionReads = (
-  input: ObserveDecisionInput,
+const prepareObserveDecisionReads = <R>(
+  input: ObserveDecisionInput<R>,
 ): Result.Result<ObserveDecisionReadPreparation, CycleCalendarQueryFailure | ObserveDecisionCompositionFailure> => {
   const snapshotId = input.cycle.bindings.snapshotId
   if (snapshotId === undefined) {
@@ -232,14 +227,16 @@ const prepareObserveDecisionReads = (
   }))
 }
 
-const readObserveDecisionFacts = (
-  input: ObserveDecisionInput,
+const readObserveDecisionFacts = <R>(
+  input: ObserveDecisionInput<R>,
   preparation: ObserveDecisionReadPreparation,
-): Effect.Effect<ObserveDecisionFacts, OperationalError> =>
+): Effect.Effect<ObserveDecisionFacts, OperationalError, BrokerRead | MarketData | R> =>
   Effect.gen(function* () {
+    const brokerRead = yield* BrokerRead
+    const marketData = yield* MarketData
     const [snapshot, calendar, reconciliation] = yield* Effect.all(
       [
-        input.marketData
+        marketData
           .loadSnapshotPublication({
             snapshotId: preparation.snapshotId,
             signalSessionDate: input.cycle.identity.signalSessionDate,
@@ -255,7 +252,7 @@ const readObserveDecisionFacts = (
               ),
             ),
           ),
-        input
+        brokerRead
           .marketCalendar(preparation.marketCalendarQuery)
           .pipe(
             Effect.mapError((cause) =>
@@ -294,8 +291,8 @@ const requireObserveAuthority = (
   return Result.succeed({ authority, observedAt: result.riskContext.authorityObservedAt })
 }
 
-const prepareExecutionSessionBinding = (
-  input: ObserveDecisionInput,
+const prepareExecutionSessionBinding = <R>(
+  input: ObserveDecisionInput<R>,
   facts: ObserveDecisionFacts,
 ): Result.Result<ExecutionSessionBinding, ExecutionSessionBindingFailure | ObserveDecisionCompositionFailure> => {
   const finalizedSnapshot = facts.snapshot.manifest.finalizedSnapshot
@@ -321,8 +318,8 @@ const prepareExecutionSessionBinding = (
   )
 }
 
-const compileObserveStrategyDecision = (
-  input: ObserveDecisionInput,
+const compileObserveStrategyDecision = <R>(
+  input: ObserveDecisionInput<R>,
   facts: ObserveDecisionFacts,
   executionSession: ExecutionSessionBinding,
 ): Effect.Effect<CurrentStrategyDecision, OperationalError> =>
@@ -339,8 +336,8 @@ const compileObserveStrategyDecision = (
     ),
   )
 
-const prepareObservePlanner = (
-  input: ObserveDecisionInput,
+const prepareObservePlanner = <R>(
+  input: ObserveDecisionInput<R>,
   facts: ObserveDecisionFacts,
   compiled: CurrentStrategyDecision,
 ): Result.Result<ObservePlannerPreparation, ObserveDecisionCompositionFailure> =>
@@ -377,8 +374,8 @@ const prepareObservePlanner = (
     ),
   )
 
-const reduceObserveRiskInputs = (
-  input: ObserveDecisionInput,
+const reduceObserveRiskInputs = <R>(
+  input: ObserveDecisionInput<R>,
   facts: ObserveDecisionFacts,
   authorityObservation: ObserveAuthorityObservation,
   executionSession: ExecutionSessionBinding,
@@ -437,9 +434,9 @@ const reduceObserveRiskInputs = (
     (cause) => compositionFailure('shadow-risk-inputs', 'shadow risk input construction failed', cause),
   )
 
-export const buildObserveCycleDecision = (
-  input: ObserveDecisionInput,
-): Effect.Effect<ObserveShadowDecisionDocument, ObserveDecisionFailure> =>
+export const buildObserveCycleDecision = <R>(
+  input: ObserveDecisionInput<R>,
+): Effect.Effect<ObserveShadowDecisionDocument, ObserveDecisionFailure, BrokerRead | MarketData | R> =>
   Effect.gen(function* () {
     const readPreparation = yield* Effect.fromResult(prepareObserveDecisionReads(input))
     const facts = yield* readObserveDecisionFacts(input, readPreparation)
@@ -504,14 +501,6 @@ export type ObserveAutonomousCycleInput = {
 
 type ObserveRuntime = BrokerRead | CycleStore | MarketData | PaperStore | WriterFence
 
-type ObserveRuntimeServices = {
-  readonly brokerRead: BrokerReadShape
-  readonly cycleStore: CycleStoreShape
-  readonly marketData: MarketDataService
-  readonly paperStore: PaperStoreShape
-  readonly writerFence: WriterFenceService
-}
-
 export type ObserveStartupPreparation = {
   readonly executionModel: CausalProtocol['executionModel']
   readonly executionPolicy: CycleExecutionPolicy
@@ -562,32 +551,28 @@ const validateObserveAuthorityInitialization = (
 
 const initializeObserveAuthority = (
   input: ObserveAutonomousCycleInput,
-  paperStore: PaperStoreShape,
-): Effect.Effect<AuthorityState, OperationalError> =>
-  paperStore
-    .ensureAuthorityGeneration({
-      generationHash: input.authorityGenerationHash,
-      maximum: Authority.Observe,
-    })
-    .pipe(
-      Effect.mapError((cause) =>
-        operationalError('database', 'authority', 'OBSERVE authority initialization failed', cause),
-      ),
-      Effect.flatMap((authority) => Effect.fromResult(validateObserveAuthorityInitialization(authority, input))),
-    )
+): Effect.Effect<AuthorityState, OperationalError, PaperStore> =>
+  PaperStore.pipe(
+    Effect.flatMap((paperStore) =>
+      paperStore.ensureAuthorityGeneration({
+        generationHash: input.authorityGenerationHash,
+        maximum: Authority.Observe,
+      }),
+    ),
+    Effect.mapError((cause) =>
+      operationalError('database', 'authority', 'OBSERVE authority initialization failed', cause),
+    ),
+    Effect.flatMap((authority) => Effect.fromResult(validateObserveAuthorityInitialization(authority, input))),
+  )
 
 const makeObserveAutonomousLoop = (
   input: ObserveAutonomousCycleInput,
-  services: ObserveRuntimeServices,
+  runtime: Context.Context<ObserveRuntime>,
   startup: Parameters<AutonomousCycleStartup>[0],
   preparation: ObserveStartupPreparation,
   policy: Policy,
 ) => {
-  const reconcile = runOnce.pipe(
-    Effect.provideService(BrokerRead, services.brokerRead),
-    Effect.provideService(PaperStore, services.paperStore),
-    Effect.provideService(WriterFence, services.writerFence),
-  )
+  const reconcile = runOnce.pipe(Effect.provideContext(runtime))
   return pipe(
     makeAutonomousCycleLoop({
       context: Effect.succeed({
@@ -600,12 +585,10 @@ const makeObserveAutonomousLoop = (
             authorityGenerationHash: input.authorityGenerationHash,
             cycle,
             executionModel: preparation.executionModel,
-            marketCalendar: services.brokerRead.marketCalendar,
-            marketData: services.marketData,
             policy,
             reconcile,
             strategy: input.strategy,
-          }).pipe(Effect.mapError(decisionBuildError)),
+          }).pipe(Effect.mapError(decisionBuildError), Effect.provideContext(runtime)),
       }),
       observePass: (observation) => observePass(startup.recordPass, observation),
       pollIntervalMs: input.pollIntervalMs,
@@ -613,13 +596,7 @@ const makeObserveAutonomousLoop = (
     Result.mapError((cause) =>
       operationalError('strategy', 'cycle-loop', 'autonomous cycle loop failed to start', cause),
     ),
-    Result.map((loop) =>
-      loop.pipe(
-        Effect.provideService(BrokerRead, services.brokerRead),
-        Effect.provideService(CycleStore, services.cycleStore),
-        Effect.provideService(MarketData, services.marketData),
-      ),
-    ),
+    Result.map((loop) => loop.pipe(Effect.provideContext(runtime))),
   )
 }
 
@@ -633,13 +610,7 @@ export const makeObserveAutonomousCycleStartup =
           operationalError('strategy', 'risk-policy', 'source-controlled paper risk policy is invalid', cause),
         ),
       )
-      const services: ObserveRuntimeServices = {
-        brokerRead: yield* BrokerRead,
-        cycleStore: yield* CycleStore,
-        marketData: yield* MarketData,
-        paperStore: yield* PaperStore,
-        writerFence: yield* WriterFence,
-      }
-      yield* initializeObserveAuthority(input, services.paperStore)
-      return yield* Effect.fromResult(makeObserveAutonomousLoop(input, services, startup, preparation, policy))
+      const runtime = yield* Effect.context<ObserveRuntime>()
+      yield* initializeObserveAuthority(input)
+      return yield* Effect.fromResult(makeObserveAutonomousLoop(input, runtime, startup, preparation, policy))
     })

--- a/services/bayn/src/simulation-reconciliation.test.ts
+++ b/services/bayn/src/simulation-reconciliation.test.ts
@@ -493,6 +493,33 @@ describe('independent marked-equity reconciliation', () => {
     expect(renderSimulationReconciliationIssue(issue)).toEndWith('invalid-unicode-key at $.targetWeights (string)')
   })
 
+  test('renders hostile failure evidence without invoking accessors or defecting', () => {
+    let getterCalls = 0
+    const evidence = {
+      kind: 'input' as const,
+      field: 'initialCapitalMicros' as const,
+      value: 'not-an-integer',
+    }
+    Object.defineProperty(evidence, 'value', {
+      enumerable: true,
+      get: () => {
+        getterCalls += 1
+        throw new Error('failure rendering must not invoke evidence accessors')
+      },
+    })
+    const issue: SimulationReconciliationIssue = {
+      _tag: 'InvalidInteger',
+      expected: 'unsigned-integer',
+      evidence,
+    }
+
+    expect(() => renderSimulationReconciliationIssue(issue)).not.toThrow()
+    expect(renderSimulationReconciliationIssue(issue)).toBe(
+      'invalid integer (unsigned-integer): <unrenderable: non-data-property at $.value (object-property)>',
+    )
+    expect(getterCalls).toBe(0)
+  })
+
   test('captures canonical calculation failures without duplicating execution-model validation', () => {
     const zeroPriceIncrement: SimulationTrace = {
       ...evaluation.simulation,

--- a/services/bayn/src/simulation-reconciliation/model.ts
+++ b/services/bayn/src/simulation-reconciliation/model.ts
@@ -1,7 +1,7 @@
-import type { Result } from 'effect'
+import { pipe, Result } from 'effect'
 
 import type { ExecutionModelFailure } from '../execution-model'
-import { renderCanonicalJsonFailure, type CanonicalJsonFailure } from '../hash'
+import { canonicalJsonV1Result, renderCanonicalJsonFailure, type CanonicalJsonFailure } from '../hash'
 import type {
   CashYieldEvent,
   EquityPoint,
@@ -358,31 +358,49 @@ export type SimulationReconciliationIssue =
       readonly cause: ExecutionModelFailure
     }
 
-export const renderSimulationReconciliationIssue = (issue: SimulationReconciliationIssue): string => {
+const renderEvidence = (value: unknown): string =>
+  pipe(
+    canonicalJsonV1Result(value),
+    Result.match({
+      onSuccess: (json) => json,
+      onFailure: (failure) => `<unrenderable: ${renderCanonicalJsonFailure(failure)}>`,
+    }),
+  )
+
+const renderSimulationReconciliationIssueUnsafe = (issue: SimulationReconciliationIssue): string => {
   switch (issue._tag) {
     case 'InvalidInteger':
-      return `invalid integer (${issue.expected}): ${JSON.stringify(issue.evidence)}`
+      return `invalid integer (${issue.expected}): ${renderEvidence(issue.evidence)}`
     case 'InvalidIdentity': {
       if (issue.problem._tag !== 'CanonicalizationFailed') {
-        return `invalid identity: ${JSON.stringify({ evidence: issue.evidence, problem: issue.problem }, null, 0)}`
+        return `invalid identity: ${renderEvidence({ evidence: issue.evidence, problem: issue.problem })}`
       }
-      return `identity canonicalization failed for ${JSON.stringify(issue.evidence)}: ${renderCanonicalJsonFailure(issue.problem.cause)}`
+      return `identity canonicalization failed for ${renderEvidence(issue.evidence)}: ${renderCanonicalJsonFailure(issue.problem.cause)}`
     }
     case 'MissingReference':
-      return `missing reference: ${JSON.stringify(issue.problem)}`
+      return `missing reference: ${renderEvidence(issue.problem)}`
     case 'EvidenceMismatch':
-      return `evidence mismatch: ${JSON.stringify(issue.problem)}`
+      return `evidence mismatch: ${renderEvidence(issue.problem)}`
     case 'InvalidEvidenceState':
-      return `invalid evidence state: ${JSON.stringify(issue.problem)}`
+      return `invalid evidence state: ${renderEvidence(issue.problem)}`
     case 'IncompleteEvidence':
-      return `incomplete evidence: ${JSON.stringify(issue.problem)}`
+      return `incomplete evidence: ${renderEvidence(issue.problem)}`
     case 'ComputationFailed':
-      return `${issue.computation._tag} calculation failed for ${JSON.stringify(issue.computation)}: ${issue.cause._tag}`
+      return `${issue.computation._tag} calculation failed for ${renderEvidence(issue.computation)}: ${issue.cause._tag}`
   }
 }
 
+export const renderSimulationReconciliationIssue = (issue: SimulationReconciliationIssue): string =>
+  pipe(
+    Result.try(() => renderSimulationReconciliationIssueUnsafe(issue)),
+    Result.getOrElse(() => 'unrenderable simulation reconciliation issue'),
+  )
+
 export const renderSimulationReconciliationIssues = (issues: readonly SimulationReconciliationIssue[]): string =>
-  issues.map(renderSimulationReconciliationIssue).join('; ')
+  pipe(
+    Result.try(() => issues.map(renderSimulationReconciliationIssue).join('; ')),
+    Result.getOrElse(() => 'unrenderable simulation reconciliation issues'),
+  )
 
 export interface MarkedEquityReconciliationInput {
   readonly runId: string

--- a/services/bayn/src/simulation/inputs.ts
+++ b/services/bayn/src/simulation/inputs.ts
@@ -1,9 +1,10 @@
-import { Chunk, pipe, Result } from 'effect'
+import { Chunk, Option, pipe, Result } from 'effect'
 
 import { makeRunIdentityResult, makeStrategyProtocolHashResult, type RuntimeProvenance } from '../contracts'
 import { canonicalHashV1Result } from '../hash'
 import { ContractVersion, type DailyBar, type InputManifest, type IsoDate, type Protocol } from '../types'
 import type { AlignedSession, EvaluationIdentity, EvaluationWindow, SimulationFailure } from './model'
+import { optionalRecordValue } from './record'
 
 const fail = <A = never>(failure: SimulationFailure): Result.Result<A, SimulationFailure> => Result.fail(failure)
 
@@ -78,8 +79,15 @@ export const requiredRecordValue = <A>(
   operation: RecordOperation,
   context: string,
 ): Result.Result<A, SimulationFailure> => {
-  const value = Reflect.get(values, key) as A | undefined
-  return value === undefined ? fail({ _tag: 'MissingRecordValue', operation, key, context }) : Result.succeed(value)
+  return pipe(
+    optionalRecordValue(values, key, operation, context),
+    Result.flatMap(
+      Option.match({
+        onNone: () => fail({ _tag: 'MissingRecordValue', operation, key, context }),
+        onSome: Result.succeed,
+      }),
+    ),
+  )
 }
 
 const buildAlignedSession = (

--- a/services/bayn/src/simulation/model.ts
+++ b/services/bayn/src/simulation/model.ts
@@ -74,6 +74,14 @@ export type SimulationDomainFailure =
       readonly context: string
     }
   | {
+      readonly _tag: 'RecordAccessFailed'
+      readonly operation: 'bar' | 'position' | 'price' | 'target-weight'
+      readonly key: string
+      readonly context: string
+      readonly reason: 'introspection-failed' | 'non-data-property'
+      readonly cause?: unknown
+    }
+  | {
       readonly _tag: 'InvalidStatisticInput'
       readonly statistic: 'mean' | 'sample-standard-deviation'
       readonly reason: 'empty' | 'not-finite'
@@ -214,6 +222,8 @@ export const renderSimulationFailure = (failure: SimulationFailure): string => {
       return `${failure.operation} requires session index ${failure.index} within ${failure.sessionCount} sessions`
     case 'MissingRecordValue':
       return `${failure.operation} ${failure.key} is missing from ${failure.context}`
+    case 'RecordAccessFailed':
+      return `${failure.operation} ${failure.key} cannot be read from ${failure.context}: ${failure.reason}`
     case 'InvalidStatisticInput':
       return `${failure.statistic} received ${failure.reason} input`
     case 'InvalidWeight':

--- a/services/bayn/src/simulation/rebalance.ts
+++ b/services/bayn/src/simulation/rebalance.ts
@@ -155,14 +155,19 @@ const proposedTrades = (
         .map((symbol) =>
           pipe(
             requiredRecordValue(desiredQuantities, symbol, 'target-weight', 'desired quantities'),
-            Result.map((desired) => {
-              const current = positionFor(positions, symbol).quantityMicros
-              return {
-                symbol,
-                sellQuantityMicros: desired < current ? current - desired : 0n,
-                buyQuantityMicros: desired > current ? desired - current : 0n,
-              }
-            }),
+            Result.flatMap((desired) =>
+              pipe(
+                positionFor(positions, symbol),
+                Result.map((position) => {
+                  const current = position.quantityMicros
+                  return {
+                    symbol,
+                    sellQuantityMicros: desired < current ? current - desired : 0n,
+                    buyQuantityMicros: desired > current ? desired - current : 0n,
+                  }
+                }),
+              ),
+            ),
           ),
         ),
     ),
@@ -263,10 +268,12 @@ const applySellOrder = (
 ): Result.Result<RebalanceState, SimulationFailure> => {
   const state = appendOrder(rebalance.simulation, order, input.recordEvents)
   if (order.filledQuantityMicros === 0n) return Result.succeed({ ...rebalance, simulation: state })
-  const position = positionFor(state.positions, order.event.symbol)
   return pipe(
-    requiredRecordValue(executionPrices, order.event.symbol, 'price', 'execution prices'),
-    Result.flatMap((price) =>
+    Result.all({
+      position: positionFor(state.positions, order.event.symbol),
+      price: requiredRecordValue(executionPrices, order.event.symbol, 'price', 'execution prices'),
+    }),
+    Result.flatMap(({ position, price }) =>
       pipe(
         Result.all({
           costBasis: saleCostBasisMicros(position.costBasisMicros, order.filledQuantityMicros, position.quantityMicros),
@@ -332,24 +339,28 @@ const applyBuyOrder = (
           pipe(
             makeFill(input.runId, decision, order, terms, terms.notionalMicros),
             Result.flatMap((fill) => {
-              const position = positionFor(state.positions, order.event.symbol)
-              const updated = {
-                ...state,
-                cashMicros: state.cashMicros - terms.notionalMicros,
-                turnoverMicros: state.turnoverMicros + terms.notionalMicros,
-                totalSpreadCostMicros: state.totalSpreadCostMicros + terms.spreadCostMicros,
-                totalSlippageCostMicros: state.totalSlippageCostMicros + terms.slippageCostMicros,
-                positions: updatePosition(state.positions, order.event.symbol, {
-                  quantityMicros: position.quantityMicros + order.filledQuantityMicros,
-                  costBasisMicros: position.costBasisMicros + terms.notionalMicros,
-                }),
-              }
               return pipe(
-                appendFillEvidence(updated, fill, -terms.notionalMicros, input.runId, input.recordEvents),
-                Result.map((simulation) => ({
-                  simulation,
-                  fills: Chunk.append(rebalance.fills, fill),
-                })),
+                positionFor(state.positions, order.event.symbol),
+                Result.flatMap((position) => {
+                  const updated = {
+                    ...state,
+                    cashMicros: state.cashMicros - terms.notionalMicros,
+                    turnoverMicros: state.turnoverMicros + terms.notionalMicros,
+                    totalSpreadCostMicros: state.totalSpreadCostMicros + terms.spreadCostMicros,
+                    totalSlippageCostMicros: state.totalSlippageCostMicros + terms.slippageCostMicros,
+                    positions: updatePosition(state.positions, order.event.symbol, {
+                      quantityMicros: position.quantityMicros + order.filledQuantityMicros,
+                      costBasisMicros: position.costBasisMicros + terms.notionalMicros,
+                    }),
+                  }
+                  return pipe(
+                    appendFillEvidence(updated, fill, -terms.notionalMicros, input.runId, input.recordEvents),
+                    Result.map((simulation) => ({
+                      simulation,
+                      fills: Chunk.append(rebalance.fills, fill),
+                    })),
+                  )
+                }),
               )
             }),
           ),

--- a/services/bayn/src/simulation/record.test.ts
+++ b/services/bayn/src/simulation/record.test.ts
@@ -1,0 +1,72 @@
+import assert from 'node:assert/strict'
+
+import { describe, expect, test } from 'bun:test'
+import { Result } from 'effect'
+
+import { requiredRecordValue } from './inputs'
+import { positionFor, type Position } from './state'
+
+describe('simulation record access', () => {
+  test('reads enumerable data properties and distinguishes absence', () => {
+    expect(requiredRecordValue({ AAPL: 100n }, 'AAPL', 'price', 'prices')).toEqual(Result.succeed(100n))
+    expect(requiredRecordValue({ AAPL: 100n }, 'MSFT', 'price', 'prices')).toEqual(
+      Result.fail({
+        _tag: 'MissingRecordValue',
+        operation: 'price',
+        key: 'MSFT',
+        context: 'prices',
+      }),
+    )
+
+    const missingPosition = positionFor({}, 'AAPL')
+    assert(Result.isSuccess(missingPosition), 'an absent position must resolve to the immutable zero position')
+    expect(missingPosition.success).toEqual({ quantityMicros: 0n, costBasisMicros: 0n })
+  })
+
+  test('rejects accessors without invoking them', () => {
+    let getterCalls = 0
+    const prices: Record<string, bigint> = {}
+    Object.defineProperty(prices, 'AAPL', {
+      enumerable: true,
+      get: () => {
+        getterCalls += 1
+        throw new Error('simulation lookup must not invoke accessors')
+      },
+    })
+
+    expect(requiredRecordValue(prices, 'AAPL', 'price', 'prices')).toEqual(
+      Result.fail({
+        _tag: 'RecordAccessFailed',
+        operation: 'price',
+        key: 'AAPL',
+        context: 'prices',
+        reason: 'non-data-property',
+        cause: undefined,
+      }),
+    )
+    expect(getterCalls).toBe(0)
+  })
+
+  test('retains hostile record introspection as a typed failure', () => {
+    const cause = new Error('descriptor trap failed')
+    const positions = new Proxy<Record<string, Position>>(
+      {},
+      {
+        getOwnPropertyDescriptor: () => {
+          throw cause
+        },
+      },
+    )
+
+    expect(positionFor(positions, 'AAPL')).toEqual(
+      Result.fail({
+        _tag: 'RecordAccessFailed',
+        operation: 'position',
+        key: 'AAPL',
+        context: 'simulation positions',
+        reason: 'introspection-failed',
+        cause,
+      }),
+    )
+  })
+})

--- a/services/bayn/src/simulation/record.ts
+++ b/services/bayn/src/simulation/record.ts
@@ -1,0 +1,40 @@
+import { Option, pipe, Result } from 'effect'
+
+import type { SimulationFailure } from './model'
+
+type RecordAccessOperation = Extract<SimulationFailure, { readonly _tag: 'RecordAccessFailed' }>['operation']
+
+const accessFailure = (
+  operation: RecordAccessOperation,
+  key: string,
+  context: string,
+  reason: Extract<SimulationFailure, { readonly _tag: 'RecordAccessFailed' }>['reason'],
+  cause?: unknown,
+): SimulationFailure => ({
+  _tag: 'RecordAccessFailed',
+  operation,
+  key,
+  context,
+  reason,
+  cause,
+})
+
+export const optionalRecordValue = <A>(
+  values: Readonly<Record<string, A>>,
+  key: string,
+  operation: RecordAccessOperation,
+  context: string,
+): Result.Result<Option.Option<A>, SimulationFailure> =>
+  pipe(
+    Result.try({
+      try: () => Object.getOwnPropertyDescriptor(values, key),
+      catch: (cause) => accessFailure(operation, key, context, 'introspection-failed', cause),
+    }),
+    Result.flatMap((descriptor) => {
+      if (descriptor === undefined) return Result.succeed(Option.none())
+      if (descriptor.enumerable !== true || !('value' in descriptor)) {
+        return Result.fail(accessFailure(operation, key, context, 'non-data-property'))
+      }
+      return Result.succeed(Option.some(descriptor.value as A))
+    }),
+  )

--- a/services/bayn/src/simulation/state.ts
+++ b/services/bayn/src/simulation/state.ts
@@ -1,4 +1,4 @@
-import { Chunk } from 'effect'
+import { Chunk, Option, pipe, Result } from 'effect'
 
 import type {
   CashChange,
@@ -10,6 +10,8 @@ import type {
   SignalDecision,
   SimulatedOrder,
 } from '../types'
+import type { SimulationFailure } from './model'
+import { optionalRecordValue } from './record'
 
 export interface Position {
   readonly quantityMicros: bigint
@@ -64,8 +66,14 @@ export interface TradeCandidate {
 
 const zeroPosition: Position = { quantityMicros: 0n, costBasisMicros: 0n }
 
-export const positionFor = (positions: Readonly<Record<string, Position>>, symbol: string): Position =>
-  (Reflect.get(positions, symbol) as Position | undefined) ?? zeroPosition
+export const positionFor = (
+  positions: Readonly<Record<string, Position>>,
+  symbol: string,
+): Result.Result<Position, SimulationFailure> =>
+  pipe(
+    optionalRecordValue(positions, symbol, 'position', 'simulation positions'),
+    Result.map(Option.getOrElse(() => zeroPosition)),
+  )
 
 export const updatePosition = (
   positions: Readonly<Record<string, Position>>,

--- a/services/bayn/src/simulation/valuation.ts
+++ b/services/bayn/src/simulation/valuation.ts
@@ -35,8 +35,13 @@ export const positionValueMicros = (
         total,
         Result.flatMap((value) =>
           pipe(
-            notionalMicros(positionFor(positions, symbol).quantityMicros, price),
-            Result.map((notional) => value + notional),
+            positionFor(positions, symbol),
+            Result.flatMap((position) =>
+              pipe(
+                notionalMicros(position.quantityMicros, price),
+                Result.map((notional) => value + notional),
+              ),
+            ),
           ),
         ),
       ),
@@ -52,10 +57,12 @@ const markedPositions = (
     Object.keys(session.bars)
       .sort()
       .map((symbol) => {
-        const position = positionFor(positions, symbol)
         return pipe(
-          requiredRecordValue(closingPrices, symbol, 'price', 'closing prices'),
-          Result.flatMap((priceMicros) =>
+          Result.all({
+            position: positionFor(positions, symbol),
+            priceMicros: requiredRecordValue(closingPrices, symbol, 'price', 'closing prices'),
+          }),
+          Result.flatMap(({ position, priceMicros }) =>
             pipe(
               notionalMicros(position.quantityMicros, priceMicros),
               Result.map((marketValueMicros) => ({


### PR DESCRIPTION
## Summary

This applies the three highest-impact functional-programming refactors found by auditing fresh `origin/main` against current Effect guidance:

1. **Total failure rendering**
   - replace partial `JSON.stringify` calls in simulation reconciliation rendering with canonical `Result`-based rendering
   - keep hostile accessors and reflection defects inside stable fallback text

2. **Total simulation record access**
   - replace `Reflect.get` and implicit missing-position defaults with an explicit `Result<Option<A>, SimulationFailure>` record boundary
   - reject accessors and proxy descriptor failures without invoking them
   - propagate typed record failures through rebalance and valuation

3. **Effect-native OBSERVE composition**
   - keep `BrokerRead`, `MarketData`, `PaperStore`, `CycleStore`, and `WriterFence` as Effect environment requirements
   - capture and provide the runtime context once at the composition edge instead of manually extracting service records and repeatedly chaining `provideService`
   - replace a throwing hash compatibility call with the existing total `canonicalHashV1Result`

The changes preserve deterministic simulation bytes, OBSERVE-only authority, zero dispatch capability, retry/deadline behavior, and existing public contracts.

## Related Issues

None.

## Testing

Exact rebased head: `7039c1028b4f7b1854397056698087c97c5713fb`

- TypeScript compilation passed
- Effect diagnostics: 205 files, 0 errors, 0 warnings, 0 messages
- Oxfmt over `services/bayn/src`: passed
- Oxlint: 0 warnings, 0 errors
- type-aware Oxlint: 0 warnings, 0 errors
- complete Bayn unit suite: 683 passed, 119 PostgreSQL-gated skips, 0 failed, 4,033 assertions
- focused post-rebase suite: 24 passed, 0 failed
- production bundle: 580 modules, 4.46 MB
- `git diff --check`: passed
- required exact-head PostgreSQL integration, shared compatibility, and native amd64/arm64 image checks remain blocking in CI

## Rollout and impact

This is a behavior-preserving internal refactor. It does not alter GitOps configuration, database schema, broker authority, capital authority, strategy parameters, or image ownership.

After merge:

- require the immutable Bayn multi-architecture image build and release contract
- merge the generated digest-pinning promotion only after all checks and automatic review are clear
- verify Argo CD reaches `Synced/Healthy`
- verify the Bayn Deployment is Ready on the promoted digest with zero restarts
- verify startup, OBSERVE cycle, `/livez`, `/readyz`, and status behavior

Rollback is a source/image revert. No data migration or authority rollback is required.

## Screenshots (if applicable)

N/A

## Breaking Changes

None.

## Checklist

- [x] Three priorities are based on fresh-main inspection and current Effect guidance.
- [x] Existing open Bayn PR ownership is not overlapped.
- [x] Pure failures remain typed and fact-bearing.
- [x] Effect services remain explicit environment requirements until composition.
- [x] OBSERVE remains non-dispatchable and capital authority is unchanged.
- [x] Testing, rollout monitoring, and rollback are documented.
