### PR TITLE
refactor(bayn): totalize cycle observability projection

### DIFF
--- a/services/bayn/src/db/cycle-observability.test.ts
+++ b/services/bayn/src/db/cycle-observability.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, test } from 'bun:test'
+
+import { Result } from 'effect'
+
+import { Authority, KillState, ReconciliationStatus } from '../paper'
+import { decodeCycleOperationsProjection } from './cycle-observability'
+
+const sha = (value: string): string => value.repeat(64)
+const instant = (value: string): Date => new Date(value)
+
+const emptyRow = () => ({
+  current_cycle_id: null,
+  current_account_id: null,
+  current_signal_session_date: null,
+  current_execution_session_date: null,
+  current_state: null,
+  current_snapshot_id: null,
+  current_decision_hash: null,
+  current_terminal_reason: null,
+  current_submission_open_at: null,
+  current_submission_cutoff_at: null,
+  current_execution_open_at: null,
+  current_execution_close_at: null,
+  current_created_at: null,
+  current_updated_at: null,
+  current_terminal_at: null,
+  last_cycle_id: null,
+  last_account_id: null,
+  last_signal_session_date: null,
+  last_execution_session_date: null,
+  last_state: null,
+  last_snapshot_id: null,
+  last_decision_hash: null,
+  last_terminal_reason: null,
+  last_submission_open_at: null,
+  last_submission_cutoff_at: null,
+  last_execution_open_at: null,
+  last_execution_close_at: null,
+  last_created_at: null,
+  last_updated_at: null,
+  last_terminal_at: null,
+  selected_account_id: null,
+  account_mismatch: false,
+  unfinished_cycle_count: 0,
+  authority_generation_hash: null,
+  authority_maximum: null,
+  authority_effective: null,
+  authority_kill: null,
+  authority_reason: null,
+  authority_updated_at: null,
+  reconciliation_id: null,
+  reconciliation_account_id: null,
+  reconciliation_status: null,
+  reconciliation_discrepancy_count: null,
+  reconciled_at: null,
+  reconciliation_covers_latest_mutation: null,
+  mutation_event_count: 0,
+  unresolved_mutation_count: 0,
+  oldest_unresolved_mutation_at: null,
+  latest_mutation_at: null,
+})
+
+describe('cycle observability projection decisions', () => {
+  test('decodes an empty projection without throwing or inventing state', () => {
+    const result = decodeCycleOperationsProjection([emptyRow()])
+
+    expect(result).toEqual(
+      Result.succeed({
+        current: null,
+        last: null,
+        unfinishedCycleCount: 0,
+        authority: null,
+        reconciliation: null,
+        mutations: {
+          eventCount: 0,
+          unresolvedCount: 0,
+          oldestUnresolvedAt: null,
+          latestOccurredAt: null,
+        },
+      }),
+    )
+  })
+
+  test('returns closed invariant failures for every incomplete projection family', () => {
+    const current = decodeCycleOperationsProjection([{ ...emptyRow(), current_cycle_id: sha('a') }])
+    const authority = decodeCycleOperationsProjection([{ ...emptyRow(), authority_maximum: Authority.Observe }])
+    const reconciliation = decodeCycleOperationsProjection([{ ...emptyRow(), reconciliation_id: sha('b') }])
+
+    for (const [result, message] of [
+      [current, 'current cycle projection is incomplete'],
+      [authority, 'durable authority projection is incomplete'],
+      [reconciliation, 'reconciliation projection is incomplete'],
+    ] as const) {
+      expect(Result.isFailure(result)).toBe(true)
+      if (Result.isFailure(result)) {
+        expect(result.failure).toMatchObject({
+          _tag: 'CycleObservabilityError',
+          operation: 'read',
+          failure: 'invariant',
+          message,
+        })
+      }
+    }
+  })
+
+  test('returns the configured-account mismatch as data', () => {
+    const result = decodeCycleOperationsProjection([
+      { ...emptyRow(), selected_account_id: 'paper-account', account_mismatch: true },
+    ])
+
+    expect(Result.isFailure(result)).toBe(true)
+    if (Result.isFailure(result)) {
+      expect(result.failure).toMatchObject({
+        _tag: 'CycleObservabilityError',
+        operation: 'read',
+        failure: 'invariant',
+        message: 'configured account paper-account differs from the projected current or last cycle',
+      })
+    }
+  })
+
+  test('decodes complete cycle, authority, reconciliation, and mutation observations', () => {
+    const row = {
+      ...emptyRow(),
+      current_cycle_id: sha('a'),
+      current_account_id: 'paper-account',
+      current_signal_session_date: '2026-07-24',
+      current_execution_session_date: '2026-07-27',
+      current_state: 'ACTIVE',
+      current_snapshot_id: sha('b'),
+      current_decision_hash: sha('c'),
+      current_terminal_reason: null,
+      current_submission_open_at: instant('2026-07-27T12:00:00.000Z'),
+      current_submission_cutoff_at: instant('2026-07-27T13:00:00.000Z'),
+      current_execution_open_at: instant('2026-07-27T13:30:00.000Z'),
+      current_execution_close_at: instant('2026-07-27T20:00:00.000Z'),
+      current_created_at: instant('2026-07-24T21:00:00.000Z'),
+      current_updated_at: instant('2026-07-24T21:01:00.000Z'),
+      authority_generation_hash: sha('d'),
+      authority_maximum: Authority.Observe,
+      authority_effective: Authority.Observe,
+      authority_kill: KillState.Clear,
+      authority_updated_at: instant('2026-07-24T21:02:00.000Z'),
+      reconciliation_id: sha('e'),
+      reconciliation_account_id: 'paper-account',
+      reconciliation_status: ReconciliationStatus.Exact,
+      reconciliation_discrepancy_count: 0,
+      reconciled_at: instant('2026-07-24T21:03:00.000Z'),
+      reconciliation_covers_latest_mutation: true,
+      mutation_event_count: 2,
+      unresolved_mutation_count: 1,
+      oldest_unresolved_mutation_at: instant('2026-07-24T21:04:00.000Z'),
+      latest_mutation_at: instant('2026-07-24T21:05:00.000Z'),
+    }
+    const result = decodeCycleOperationsProjection([row])
+
+    expect(Result.isSuccess(result)).toBe(true)
+    if (Result.isSuccess(result)) {
+      expect(result.success).toMatchObject({
+        current: {
+          cycleId: sha('a'),
+          accountId: 'paper-account',
+          phase: 'ACTIVE',
+          submissionOpenAt: '2026-07-27T12:00:00.000Z',
+        },
+        authority: {
+          generationHash: sha('d'),
+          maximum: Authority.Observe,
+          effective: Authority.Observe,
+          kill: KillState.Clear,
+        },
+        reconciliation: {
+          reconciliationId: sha('e'),
+          status: ReconciliationStatus.Exact,
+          discrepancyCount: 0,
+          coversLatestMutation: true,
+        },
+        mutations: {
+          eventCount: 2,
+          unresolvedCount: 1,
+          oldestUnresolvedAt: '2026-07-24T21:04:00.000Z',
+          latestOccurredAt: '2026-07-24T21:05:00.000Z',
+        },
+      })
+    }
+  })
+
+  test('keeps malformed SQL rows in the decode failure channel', () => {
+    const result = decodeCycleOperationsProjection([{ ...emptyRow(), mutation_event_count: -1 }])
+
+    expect(Result.isFailure(result)).toBe(true)
+    if (Result.isFailure(result)) {
+      expect(result.failure).toMatchObject({
+        _tag: 'CycleObservabilityError',
+        operation: 'read',
+        failure: 'decode',
+      })
+    }
+  })
+})

--- a/services/bayn/src/db/cycle-observability.ts
+++ b/services/bayn/src/db/cycle-observability.ts
@@ -1,5 +1,5 @@
 import { PgClient } from '@effect/sql-pg'
-import { Context, Data, Effect, Layer, Schema } from 'effect'
+import { Context, Data, Effect, Layer, pipe, Result, Schema } from 'effect'
 import { isSqlError } from 'effect/unstable/sql/SqlError'
 
 import {
@@ -99,7 +99,7 @@ type ProjectionRow = typeof ProjectionRowSchema.Type
 const ProjectionRowsSchema = Schema.Tuple([ProjectionRowSchema])
 const decodeRunId = Schema.decodeUnknownEffect(Sha256Schema, strictParseOptions)
 const decodeAccountId = Schema.decodeUnknownEffect(StrictNonEmptyStringSchema, strictParseOptions)
-const decodeProjectionRows = Schema.decodeUnknownEffect(ProjectionRowsSchema, strictParseOptions)
+const decodeProjectionRowsResult = Schema.decodeUnknownResult(ProjectionRowsSchema, strictParseOptions)
 
 const messageOf = (cause: unknown): string => (cause instanceof Error ? cause.message : String(cause))
 
@@ -115,9 +115,12 @@ const readError = (
     cause,
   })
 
-const snapshotFromRow = (row: ProjectionRow, prefix: 'current' | 'last'): CycleOperationsSnapshot | null => {
+const snapshotFromRow = (
+  row: ProjectionRow,
+  prefix: 'current' | 'last',
+): Result.Result<CycleOperationsSnapshot | null, CycleObservabilityError> => {
   const cycleId = row[`${prefix}_cycle_id`]
-  if (cycleId === null) return null
+  if (cycleId === null) return Result.succeed(null)
   const accountId = row[`${prefix}_account_id`]
   const signalSessionDate = row[`${prefix}_signal_session_date`]
   const executionSessionDate = row[`${prefix}_execution_session_date`]
@@ -140,9 +143,9 @@ const snapshotFromRow = (row: ProjectionRow, prefix: 'current' | 'last'): CycleO
     createdAt === null ||
     updatedAt === null
   ) {
-    throw readError('invariant', `${prefix} cycle projection is incomplete`)
+    return Result.fail(readError('invariant', `${prefix} cycle projection is incomplete`))
   }
-  return {
+  return Result.succeed({
     cycleId,
     accountId,
     signalSessionDate,
@@ -158,31 +161,35 @@ const snapshotFromRow = (row: ProjectionRow, prefix: 'current' | 'last'): CycleO
     createdAt: createdAt.toISOString(),
     updatedAt: updatedAt.toISOString(),
     terminalAt: row[`${prefix}_terminal_at`]?.toISOString() ?? null,
-  }
+  })
 }
 
-const authorityFromRow = (row: ProjectionRow): DurableAuthorityObservation | null => {
-  if (row.authority_maximum === null) return null
+const authorityFromRow = (
+  row: ProjectionRow,
+): Result.Result<DurableAuthorityObservation | null, CycleObservabilityError> => {
+  if (row.authority_maximum === null) return Result.succeed(null)
   if (
     row.authority_generation_hash === null ||
     row.authority_effective === null ||
     row.authority_kill === null ||
     row.authority_updated_at === null
   ) {
-    throw readError('invariant', 'durable authority projection is incomplete')
+    return Result.fail(readError('invariant', 'durable authority projection is incomplete'))
   }
-  return {
+  return Result.succeed({
     generationHash: row.authority_generation_hash,
     maximum: row.authority_maximum,
     effective: row.authority_effective,
     kill: row.authority_kill,
     reason: row.authority_reason,
     updatedAt: row.authority_updated_at.toISOString(),
-  }
+  })
 }
 
-const reconciliationFromRow = (row: ProjectionRow): ReconciliationObservation | null => {
-  if (row.reconciliation_id === null) return null
+const reconciliationFromRow = (
+  row: ProjectionRow,
+): Result.Result<ReconciliationObservation | null, CycleObservabilityError> => {
+  if (row.reconciliation_id === null) return Result.succeed(null)
   if (
     row.reconciliation_account_id === null ||
     row.reconciliation_status === null ||
@@ -190,39 +197,58 @@ const reconciliationFromRow = (row: ProjectionRow): ReconciliationObservation | 
     row.reconciled_at === null ||
     row.reconciliation_covers_latest_mutation === null
   ) {
-    throw readError('invariant', 'reconciliation projection is incomplete')
+    return Result.fail(readError('invariant', 'reconciliation projection is incomplete'))
   }
-  return {
+  return Result.succeed({
     reconciliationId: row.reconciliation_id,
     accountId: row.reconciliation_account_id,
     status: row.reconciliation_status,
     discrepancyCount: row.reconciliation_discrepancy_count,
     reconciledAt: row.reconciled_at.toISOString(),
     coversLatestMutation: row.reconciliation_covers_latest_mutation,
-  }
+  })
 }
 
-const projectionFromRow = (row: ProjectionRow): CycleOperationsProjection => {
+const projectionFromRow = (row: ProjectionRow): Result.Result<CycleOperationsProjection, CycleObservabilityError> => {
   if (row.account_mismatch) {
-    throw readError(
-      'invariant',
-      `configured account ${row.selected_account_id ?? 'unknown'} differs from the projected current or last cycle`,
+    return Result.fail(
+      readError(
+        'invariant',
+        `configured account ${row.selected_account_id ?? 'unknown'} differs from the projected current or last cycle`,
+      ),
     )
   }
-  return {
-    current: snapshotFromRow(row, 'current'),
-    last: snapshotFromRow(row, 'last'),
-    unfinishedCycleCount: row.unfinished_cycle_count,
-    authority: authorityFromRow(row),
-    reconciliation: reconciliationFromRow(row),
-    mutations: {
-      eventCount: row.mutation_event_count,
-      unresolvedCount: row.unresolved_mutation_count,
-      oldestUnresolvedAt: row.oldest_unresolved_mutation_at?.toISOString() ?? null,
-      latestOccurredAt: row.latest_mutation_at?.toISOString() ?? null,
-    },
-  }
+  return pipe(
+    Result.all({
+      current: snapshotFromRow(row, 'current'),
+      last: snapshotFromRow(row, 'last'),
+      authority: authorityFromRow(row),
+      reconciliation: reconciliationFromRow(row),
+    }),
+    Result.map(({ current, last, authority, reconciliation }) => ({
+      current,
+      last,
+      unfinishedCycleCount: row.unfinished_cycle_count,
+      authority,
+      reconciliation,
+      mutations: {
+        eventCount: row.mutation_event_count,
+        unresolvedCount: row.unresolved_mutation_count,
+        oldestUnresolvedAt: row.oldest_unresolved_mutation_at?.toISOString() ?? null,
+        latestOccurredAt: row.latest_mutation_at?.toISOString() ?? null,
+      },
+    })),
+  )
 }
+
+export const decodeCycleOperationsProjection = (
+  rows: unknown,
+): Result.Result<CycleOperationsProjection, CycleObservabilityError> =>
+  pipe(
+    decodeProjectionRowsResult(rows),
+    Result.mapError((cause) => readError('decode', 'autonomous cycle observability decoding failed', cause)),
+    Result.flatMap(([row]) => projectionFromRow(row)),
+  )
 
 const makeCycleObservability = Effect.gen(function* () {
   const sql = yield* PgClient.PgClient
@@ -400,20 +426,7 @@ const makeCycleObservability = Effect.gen(function* () {
           ),
         ),
       ),
-      Effect.flatMap((rows) =>
-        decodeProjectionRows(rows).pipe(
-          Effect.mapError((cause) => readError('decode', 'autonomous cycle observability decoding failed', cause)),
-        ),
-      ),
-      Effect.flatMap(([row]) =>
-        Effect.try({
-          try: () => projectionFromRow(row),
-          catch: (cause) =>
-            cause instanceof CycleObservabilityError
-              ? cause
-              : readError('invariant', 'autonomous cycle observability projection failed', cause),
-        }),
-      ),
+      Effect.flatMap((rows) => Effect.fromResult(decodeCycleOperationsProjection(rows))),
     )
 
   return { read } satisfies CycleObservabilityShape


### PR DESCRIPTION
## Summary

- replace cycle-observability projection throws with a pure `Result` decision algebra
- decode SQL projection rows synchronously before lifting the result into the Effect service boundary
- return exact typed invariant failures for incomplete cycle, authority, reconciliation, and account-mismatch projections
- add direct pure coverage for empty, complete, malformed, and every former throwing projection family

## Related Issues

None.

## Testing

- `bun test services/bayn/src/db/cycle-observability.test.ts` — 5 passed, 0 failed
- `BAYN_TEST_POSTGRES_URL=postgresql://... bun test services/bayn/src/db/cycle-observability.integration.test.ts` against PostgreSQL 18 — 5 passed, 0 failed
- `bun run --filter @proompteng/bayn test` — 694 passed, 120 integration-gated skipped, 0 failed
- `bun node_modules/typescript/bin/tsc --noEmit -p services/bayn/tsconfig.json` — passed
- Effect diagnostics — 215 files, 0 errors, warnings, or messages
- Oxfmt check for `services/bayn/src` — passed
- Oxlint syntax and type-aware modes for `services/bayn` — passed
- production build — passed
- `bun test packages/scripts/src/bayn` — 20 passed, 0 failed

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable.
- [x] Breaking Changes is filled in.
- [x] Documentation, release notes, and follow-ups are not required for this internal refactor.
- [x] SQL, account isolation, reconciliation ordering, and public projection contracts are unchanged.
- [x] Production projection code contains no `throw` or `Effect.try` compatibility boundary.
