### PR TITLE
refactor(bayn): totalize cycle observability projection

### DIFF
--- a/services/bayn/src/db/cycle-observability.test.ts
+++ b/services/bayn/src/db/cycle-observability.test.ts
@@ -1,0 +1,245 @@
+import { describe, expect, test } from 'bun:test'
+
+import { Result } from 'effect'
+
+import { CycleState, CycleTerminalReason } from '../cycle'
+import { Authority, KillState, ReconciliationStatus } from '../paper'
+import { projectCycleObservabilityRow, type CycleObservabilityProjectionRow } from './cycle-observability'
+
+const emptyRow = (): CycleObservabilityProjectionRow => ({
+  current_cycle_id: null,
+  current_account_id: null,
+  current_signal_session_date: null,
+  current_execution_session_date: null,
+  current_state: null,
+  current_snapshot_id: null,
+  current_decision_hash: null,
+  current_terminal_reason: null,
+  current_submission_open_at: null,
+  current_submission_cutoff_at: null,
+  current_execution_open_at: null,
+  current_execution_close_at: null,
+  current_created_at: null,
+  current_updated_at: null,
+  current_terminal_at: null,
+  last_cycle_id: null,
+  last_account_id: null,
+  last_signal_session_date: null,
+  last_execution_session_date: null,
+  last_state: null,
+  last_snapshot_id: null,
+  last_decision_hash: null,
+  last_terminal_reason: null,
+  last_submission_open_at: null,
+  last_submission_cutoff_at: null,
+  last_execution_open_at: null,
+  last_execution_close_at: null,
+  last_created_at: null,
+  last_updated_at: null,
+  last_terminal_at: null,
+  selected_account_id: null,
+  account_mismatch: false,
+  unfinished_cycle_count: 0,
+  authority_generation_hash: null,
+  authority_maximum: null,
+  authority_effective: null,
+  authority_kill: null,
+  authority_reason: null,
+  authority_updated_at: null,
+  reconciliation_id: null,
+  reconciliation_account_id: null,
+  reconciliation_status: null,
+  reconciliation_discrepancy_count: null,
+  reconciled_at: null,
+  reconciliation_covers_latest_mutation: null,
+  mutation_event_count: 0,
+  unresolved_mutation_count: 0,
+  oldest_unresolved_mutation_at: null,
+  latest_mutation_at: null,
+})
+
+const currentCycleRow = (): CycleObservabilityProjectionRow => ({
+  ...emptyRow(),
+  current_cycle_id: '1'.repeat(64),
+  current_account_id: 'paper-account-1',
+  current_signal_session_date: '2026-07-24',
+  current_execution_session_date: '2026-07-27',
+  current_state: CycleState.Pending,
+  current_snapshot_id: '2'.repeat(64),
+  current_decision_hash: null,
+  current_terminal_reason: null,
+  current_submission_open_at: new Date('2026-07-27T13:00:00.000Z'),
+  current_submission_cutoff_at: new Date('2026-07-27T13:28:00.000Z'),
+  current_execution_open_at: new Date('2026-07-27T13:30:00.000Z'),
+  current_execution_close_at: new Date('2026-07-27T20:00:00.000Z'),
+  current_created_at: new Date('2026-07-24T21:00:00.000Z'),
+  current_updated_at: new Date('2026-07-24T21:01:00.000Z'),
+})
+
+describe('cycle observability projection', () => {
+  test('projects the empty durable state without effects', () => {
+    expect(projectCycleObservabilityRow(emptyRow())).toEqual(
+      Result.succeed({
+        current: null,
+        last: null,
+        unfinishedCycleCount: 0,
+        authority: null,
+        reconciliation: null,
+        mutations: {
+          eventCount: 0,
+          unresolvedCount: 0,
+          oldestUnresolvedAt: null,
+          latestOccurredAt: null,
+        },
+      }),
+    )
+  })
+
+  test('projects complete cycle, authority, reconciliation, and mutation facts', () => {
+    const row: CycleObservabilityProjectionRow = {
+      ...currentCycleRow(),
+      unfinished_cycle_count: 1,
+      authority_generation_hash: '3'.repeat(64),
+      authority_maximum: Authority.Observe,
+      authority_effective: Authority.Observe,
+      authority_kill: KillState.Clear,
+      authority_reason: null,
+      authority_updated_at: new Date('2026-07-24T21:02:00.000Z'),
+      reconciliation_id: '4'.repeat(64),
+      reconciliation_account_id: 'paper-account-1',
+      reconciliation_status: ReconciliationStatus.Exact,
+      reconciliation_discrepancy_count: 0,
+      reconciled_at: new Date('2026-07-24T21:03:00.000Z'),
+      reconciliation_covers_latest_mutation: true,
+      mutation_event_count: 2,
+      unresolved_mutation_count: 1,
+      oldest_unresolved_mutation_at: new Date('2026-07-24T21:04:00.000Z'),
+      latest_mutation_at: new Date('2026-07-24T21:05:00.000Z'),
+    }
+
+    const projected = projectCycleObservabilityRow(row)
+    expect(Result.isSuccess(projected)).toBe(true)
+    if (Result.isFailure(projected)) return expect.unreachable(projected.failure.message)
+    expect(projected.success).toMatchObject({
+      current: {
+        cycleId: '1'.repeat(64),
+        accountId: 'paper-account-1',
+        phase: CycleState.Pending,
+        submissionOpenAt: '2026-07-27T13:00:00.000Z',
+      },
+      unfinishedCycleCount: 1,
+      authority: {
+        generationHash: '3'.repeat(64),
+        maximum: Authority.Observe,
+        effective: Authority.Observe,
+        kill: KillState.Clear,
+      },
+      reconciliation: {
+        reconciliationId: '4'.repeat(64),
+        status: ReconciliationStatus.Exact,
+        discrepancyCount: 0,
+        coversLatestMutation: true,
+      },
+      mutations: {
+        eventCount: 2,
+        unresolvedCount: 1,
+        oldestUnresolvedAt: '2026-07-24T21:04:00.000Z',
+        latestOccurredAt: '2026-07-24T21:05:00.000Z',
+      },
+    })
+  })
+
+  test('returns every incomplete projection as typed failure data without throwing', () => {
+    const cases = [
+      {
+        row: { ...emptyRow(), current_cycle_id: '1'.repeat(64) },
+        message: 'current cycle projection is incomplete',
+      },
+      {
+        row: { ...emptyRow(), last_cycle_id: '2'.repeat(64) },
+        message: 'last cycle projection is incomplete',
+      },
+      {
+        row: { ...emptyRow(), authority_maximum: Authority.Observe },
+        message: 'durable authority projection is incomplete',
+      },
+      {
+        row: { ...emptyRow(), reconciliation_id: '3'.repeat(64) },
+        message: 'reconciliation projection is incomplete',
+      },
+    ] as const
+
+    for (const testCase of cases) {
+      expect(() => projectCycleObservabilityRow(testCase.row)).not.toThrow()
+      const projected = projectCycleObservabilityRow(testCase.row)
+      expect(Result.isFailure(projected)).toBe(true)
+      if (Result.isSuccess(projected)) return expect.unreachable('incomplete projection unexpectedly succeeded')
+      expect(projected.failure).toMatchObject({
+        _tag: 'CycleObservabilityError',
+        operation: 'read',
+        failure: 'invariant',
+        message: testCase.message,
+      })
+    }
+  })
+
+  test('keeps explicit account mismatch ahead of other incomplete row failures', () => {
+    const row: CycleObservabilityProjectionRow = {
+      ...emptyRow(),
+      current_cycle_id: '1'.repeat(64),
+      selected_account_id: 'paper-account-expected',
+      account_mismatch: true,
+    }
+
+    const projected = projectCycleObservabilityRow(row)
+    expect(Result.isFailure(projected)).toBe(true)
+    if (Result.isSuccess(projected)) return expect.unreachable('account mismatch unexpectedly succeeded')
+    expect(projected.failure).toMatchObject({
+      failure: 'invariant',
+      message: 'configured account paper-account-expected differs from the projected current or last cycle',
+    })
+  })
+
+  test('preserves terminal cycle fields without deriving missing values', () => {
+    const row: CycleObservabilityProjectionRow = {
+      ...currentCycleRow(),
+      current_cycle_id: null,
+      current_account_id: null,
+      current_signal_session_date: null,
+      current_execution_session_date: null,
+      current_state: null,
+      current_snapshot_id: null,
+      current_submission_open_at: null,
+      current_submission_cutoff_at: null,
+      current_execution_open_at: null,
+      current_execution_close_at: null,
+      current_created_at: null,
+      current_updated_at: null,
+      last_cycle_id: '5'.repeat(64),
+      last_account_id: 'paper-account-1',
+      last_signal_session_date: '2026-07-24',
+      last_execution_session_date: '2026-07-27',
+      last_state: CycleState.Blocked,
+      last_snapshot_id: '6'.repeat(64),
+      last_decision_hash: null,
+      last_terminal_reason: CycleTerminalReason.MissedPublication,
+      last_submission_open_at: new Date('2026-07-27T13:00:00.000Z'),
+      last_submission_cutoff_at: new Date('2026-07-27T13:28:00.000Z'),
+      last_execution_open_at: new Date('2026-07-27T13:30:00.000Z'),
+      last_execution_close_at: new Date('2026-07-27T20:00:00.000Z'),
+      last_created_at: new Date('2026-07-24T21:00:00.000Z'),
+      last_updated_at: new Date('2026-07-24T21:10:00.000Z'),
+      last_terminal_at: new Date('2026-07-24T21:10:00.000Z'),
+    }
+
+    const projected = projectCycleObservabilityRow(row)
+    expect(Result.isSuccess(projected)).toBe(true)
+    if (Result.isFailure(projected)) return expect.unreachable(projected.failure.message)
+    expect(projected.success.last).toMatchObject({
+      cycleId: '5'.repeat(64),
+      phase: CycleState.Blocked,
+      terminalReason: CycleTerminalReason.MissedPublication,
+      terminalAt: '2026-07-24T21:10:00.000Z',
+    })
+  })
+})

--- a/services/bayn/src/db/cycle-observability.ts
+++ b/services/bayn/src/db/cycle-observability.ts
@@ -1,5 +1,5 @@
 import { PgClient } from '@effect/sql-pg'
-import { Context, Data, Effect, Layer, Schema } from 'effect'
+import { Context, Data, Effect, Layer, pipe, Result, Schema } from 'effect'
 import { isSqlError } from 'effect/unstable/sql/SqlError'
 
 import {
@@ -95,13 +95,18 @@ const ProjectionRowSchema = Schema.Struct({
   latest_mutation_at: NullableDate,
 })
 type ProjectionRow = typeof ProjectionRowSchema.Type
+export type CycleObservabilityProjectionRow = ProjectionRow
 
 const ProjectionRowsSchema = Schema.Tuple([ProjectionRowSchema])
 const decodeRunId = Schema.decodeUnknownEffect(Sha256Schema, strictParseOptions)
 const decodeAccountId = Schema.decodeUnknownEffect(StrictNonEmptyStringSchema, strictParseOptions)
 const decodeProjectionRows = Schema.decodeUnknownEffect(ProjectionRowsSchema, strictParseOptions)
 
-const messageOf = (cause: unknown): string => (cause instanceof Error ? cause.message : String(cause))
+const messageOf = (cause: unknown): string =>
+  pipe(
+    Result.try(() => (cause instanceof Error ? cause.message : String(cause))),
+    Result.getOrElse(() => '<unrenderable cause>'),
+  )
 
 const readError = (
   failure: CycleObservabilityError['failure'],
@@ -115,9 +120,12 @@ const readError = (
     cause,
   })
 
-const snapshotFromRow = (row: ProjectionRow, prefix: 'current' | 'last'): CycleOperationsSnapshot | null => {
+const snapshotFromRow = (
+  row: ProjectionRow,
+  prefix: 'current' | 'last',
+): Result.Result<CycleOperationsSnapshot | null, CycleObservabilityError> => {
   const cycleId = row[`${prefix}_cycle_id`]
-  if (cycleId === null) return null
+  if (cycleId === null) return Result.succeed(null)
   const accountId = row[`${prefix}_account_id`]
   const signalSessionDate = row[`${prefix}_signal_session_date`]
   const executionSessionDate = row[`${prefix}_execution_session_date`]
@@ -140,9 +148,9 @@ const snapshotFromRow = (row: ProjectionRow, prefix: 'current' | 'last'): CycleO
     createdAt === null ||
     updatedAt === null
   ) {
-    throw readError('invariant', `${prefix} cycle projection is incomplete`)
+    return Result.fail(readError('invariant', `${prefix} cycle projection is incomplete`))
   }
-  return {
+  return Result.succeed({
     cycleId,
     accountId,
     signalSessionDate,
@@ -158,31 +166,35 @@ const snapshotFromRow = (row: ProjectionRow, prefix: 'current' | 'last'): CycleO
     createdAt: createdAt.toISOString(),
     updatedAt: updatedAt.toISOString(),
     terminalAt: row[`${prefix}_terminal_at`]?.toISOString() ?? null,
-  }
+  })
 }
 
-const authorityFromRow = (row: ProjectionRow): DurableAuthorityObservation | null => {
-  if (row.authority_maximum === null) return null
+const authorityFromRow = (
+  row: ProjectionRow,
+): Result.Result<DurableAuthorityObservation | null, CycleObservabilityError> => {
+  if (row.authority_maximum === null) return Result.succeed(null)
   if (
     row.authority_generation_hash === null ||
     row.authority_effective === null ||
     row.authority_kill === null ||
     row.authority_updated_at === null
   ) {
-    throw readError('invariant', 'durable authority projection is incomplete')
+    return Result.fail(readError('invariant', 'durable authority projection is incomplete'))
   }
-  return {
+  return Result.succeed({
     generationHash: row.authority_generation_hash,
     maximum: row.authority_maximum,
     effective: row.authority_effective,
     kill: row.authority_kill,
     reason: row.authority_reason,
     updatedAt: row.authority_updated_at.toISOString(),
-  }
+  })
 }
 
-const reconciliationFromRow = (row: ProjectionRow): ReconciliationObservation | null => {
-  if (row.reconciliation_id === null) return null
+const reconciliationFromRow = (
+  row: ProjectionRow,
+): Result.Result<ReconciliationObservation | null, CycleObservabilityError> => {
+  if (row.reconciliation_id === null) return Result.succeed(null)
   if (
     row.reconciliation_account_id === null ||
     row.reconciliation_status === null ||
@@ -190,38 +202,50 @@ const reconciliationFromRow = (row: ProjectionRow): ReconciliationObservation | 
     row.reconciled_at === null ||
     row.reconciliation_covers_latest_mutation === null
   ) {
-    throw readError('invariant', 'reconciliation projection is incomplete')
+    return Result.fail(readError('invariant', 'reconciliation projection is incomplete'))
   }
-  return {
+  return Result.succeed({
     reconciliationId: row.reconciliation_id,
     accountId: row.reconciliation_account_id,
     status: row.reconciliation_status,
     discrepancyCount: row.reconciliation_discrepancy_count,
     reconciledAt: row.reconciled_at.toISOString(),
     coversLatestMutation: row.reconciliation_covers_latest_mutation,
-  }
+  })
 }
 
-const projectionFromRow = (row: ProjectionRow): CycleOperationsProjection => {
+export const projectCycleObservabilityRow = (
+  row: CycleObservabilityProjectionRow,
+): Result.Result<CycleOperationsProjection, CycleObservabilityError> => {
   if (row.account_mismatch) {
-    throw readError(
-      'invariant',
-      `configured account ${row.selected_account_id ?? 'unknown'} differs from the projected current or last cycle`,
+    return Result.fail(
+      readError(
+        'invariant',
+        `configured account ${row.selected_account_id ?? 'unknown'} differs from the projected current or last cycle`,
+      ),
     )
   }
-  return {
-    current: snapshotFromRow(row, 'current'),
-    last: snapshotFromRow(row, 'last'),
-    unfinishedCycleCount: row.unfinished_cycle_count,
-    authority: authorityFromRow(row),
-    reconciliation: reconciliationFromRow(row),
-    mutations: {
-      eventCount: row.mutation_event_count,
-      unresolvedCount: row.unresolved_mutation_count,
-      oldestUnresolvedAt: row.oldest_unresolved_mutation_at?.toISOString() ?? null,
-      latestOccurredAt: row.latest_mutation_at?.toISOString() ?? null,
-    },
-  }
+  return pipe(
+    Result.all({
+      current: snapshotFromRow(row, 'current'),
+      last: snapshotFromRow(row, 'last'),
+      authority: authorityFromRow(row),
+      reconciliation: reconciliationFromRow(row),
+    }),
+    Result.map(({ current, last, authority, reconciliation }) => ({
+      current,
+      last,
+      unfinishedCycleCount: row.unfinished_cycle_count,
+      authority,
+      reconciliation,
+      mutations: {
+        eventCount: row.mutation_event_count,
+        unresolvedCount: row.unresolved_mutation_count,
+        oldestUnresolvedAt: row.oldest_unresolved_mutation_at?.toISOString() ?? null,
+        latestOccurredAt: row.latest_mutation_at?.toISOString() ?? null,
+      },
+    })),
+  )
 }
 
 const makeCycleObservability = Effect.gen(function* () {
@@ -405,15 +429,7 @@ const makeCycleObservability = Effect.gen(function* () {
           Effect.mapError((cause) => readError('decode', 'autonomous cycle observability decoding failed', cause)),
         ),
       ),
-      Effect.flatMap(([row]) =>
-        Effect.try({
-          try: () => projectionFromRow(row),
-          catch: (cause) =>
-            cause instanceof CycleObservabilityError
-              ? cause
-              : readError('invariant', 'autonomous cycle observability projection failed', cause),
-        }),
-      ),
+      Effect.flatMap(([row]) => Effect.fromResult(projectCycleObservabilityRow(row))),
     )
 
   return { read } satisfies CycleObservabilityShape


### PR DESCRIPTION
## Summary

Refactor the PostgreSQL cycle-observability projection boundary from hidden JavaScript exceptions to explicit functional error algebra.

- convert current-cycle, last-cycle, durable-authority, and reconciliation projection helpers to `Result`
- compose the full projection with `Result.all`
- replace the outer `Effect.try` exception adapter with `Effect.fromResult`
- preserve account-mismatch and incomplete-row failure precedence
- make cause rendering total when a foreign error value cannot be stringified
- add synchronous behavioral tests for empty, complete, terminal, mismatched, and every incomplete projection shape

The SQL query, durable schemas, health semantics, broker authority, mutation accounting, and public status contracts are unchanged.

## Research rationale

Current Effect guidance treats expected failures as typed values and recommends progressively moving pure decision logic below Effectful I/O boundaries. This projection is deterministic row-to-domain interpretation, so it now returns `Result` directly rather than using exceptions as an internal control protocol.

## Testing

Exact head: `595b969e2b1ca99b9f740165f6ce0ae73c14885e`

- focused projector, health, and database-operation tests: 27 passed, 0 failed
- complete Bayn suite: 694 passed, 120 integration-gated skips, 0 failed, 4,067 assertions
- TypeScript compilation passed
- Effect diagnostics: 215 files, 0 errors, 0 warnings, 0 messages
- Oxfmt passed
- Oxlint passed
- type-aware Oxlint passed
- production bundle passed: 587 modules, 4.48 MB
- `git diff --check` passed
- exact-head PostgreSQL integration and native amd64/arm64 image checks remain required in CI

## Rollout and impact

This is a behavior-preserving internal refactor with no schema or manifest changes. After merge, require the immutable multi-architecture Bayn image build, generated digest promotion, Argo `Synced/Healthy`, a Ready pod with zero restarts, and successful `/livez`, `/readyz`, and `/v1/status` verification.

Rollback is a source/image revert. No data or authority migration is required.

## Breaking Changes

None.

## Checklist

- [x] Expected projection failures are typed values, not exceptions.
- [x] Query and durable contract semantics are unchanged.
- [x] Failure precedence is covered behaviorally.
- [x] No overlap with existing Bayn qualification-audit or ledger PRs.
- [x] OBSERVE authority and zero broker/capital dispatch remain unchanged.
