### PR TITLE
refactor(bayn): totalize Alpaca proxy configuration

### DIFF
--- a/services/bayn/src/broker/alpaca.test.ts
+++ b/services/bayn/src/broker/alpaca.test.ts
@@ -29,6 +29,7 @@ import {
   type BrokerReadShape,
   type ReadOptions,
 } from './alpaca'
+import { parseProxyUrl } from './alpaca/http'
 import { decodeOrder } from './alpaca/model'
 import { decimalToMicrosResult, normalizeOrderResult } from './alpaca/normalizers'
 import { responseEvidenceResult } from './alpaca/requests'
@@ -1428,6 +1429,32 @@ describe('Alpaca paper reads', () => {
 })
 
 describe('Alpaca proxy lifecycle', () => {
+  test('parses only credential-free HTTP origins as a pure Result decision', () => {
+    const valid = parseProxyUrl('https://proxy.test:3128')
+    expect(Result.isSuccess(valid)).toBe(true)
+    if (Result.isSuccess(valid)) expect(valid.success.origin).toBe('https://proxy.test:3128')
+
+    for (const [proxyUrl, message] of [
+      ['not a URL', 'invalid Alpaca proxy configuration'],
+      ['socks5://proxy.test:1080', 'Alpaca proxy URL must use HTTP or HTTPS'],
+      ['http://user:secret@proxy.test:3128', 'Alpaca proxy credentials must not be embedded in the URL'],
+      ['http://proxy.test:3128/path', 'Alpaca proxy URL must contain only an origin'],
+      ['http://proxy.test:3128?route=paper', 'Alpaca proxy URL must contain only an origin'],
+      ['http://proxy.test:3128#paper', 'Alpaca proxy URL must contain only an origin'],
+    ] as const) {
+      const result = parseProxyUrl(proxyUrl)
+      expect(Result.isFailure(result)).toBe(true)
+      if (Result.isFailure(result)) {
+        expect(result.failure).toMatchObject({
+          kind: BrokerReadErrorKind.Configuration,
+          operation: 'proxy',
+          retryable: false,
+          message,
+        })
+      }
+    }
+  })
+
   test('keeps its Undici proxy dispatcher alive until the owning scope exits and releases it exactly once', async () => {
     let releases = 0
     await Effect.runPromise(
@@ -1458,5 +1485,32 @@ describe('Alpaca proxy lifecycle', () => {
       operation: 'proxy',
       retryable: false,
     })
+  })
+
+  test('contains dispatcher construction failures in the typed acquisition channel', async () => {
+    let releases = 0
+    const failure = await Effect.runPromise(
+      Effect.flip(
+        Effect.scoped(
+          makeProxyDispatcher('http://proxy.test:3128', {
+            create: () => {
+              throw new Error('dispatcher construction failed')
+            },
+            destroy: () => {
+              releases += 1
+              return Promise.resolve()
+            },
+          }),
+        ),
+      ),
+    )
+
+    expect(failure).toMatchObject({
+      kind: BrokerReadErrorKind.Configuration,
+      operation: 'proxy',
+      retryable: false,
+      message: 'Alpaca proxy dispatcher acquisition failed',
+    })
+    expect(releases).toBe(0)
   })
 })

--- a/services/bayn/src/broker/alpaca/http.ts
+++ b/services/bayn/src/broker/alpaca/http.ts
@@ -1,5 +1,5 @@
 import { NodeHttpClient, Undici } from '@effect/platform-node'
-import { Cause, Effect, Layer, Redacted, Result, Scope } from 'effect'
+import { Cause, Effect, Layer, pipe, Redacted, Result, Scope } from 'effect'
 import { Headers, HttpClient, HttpClientRequest, HttpClientResponse } from 'effect/unstable/http'
 
 import { canonicalHashV1Result, renderCanonicalJsonFailure } from '../../hash'
@@ -100,21 +100,36 @@ export const makeProxyDispatcher = (
   },
 ): Effect.Effect<Undici.Dispatcher, BrokerReadError, Scope.Scope> =>
   Effect.acquireRelease(
-    Effect.try({
-      try: () => {
-        const url = new URL(proxyUrl)
-        if (url.protocol !== 'http:' && url.protocol !== 'https:') throw new Error('proxy URL must use HTTP or HTTPS')
-        if (url.username !== '' || url.password !== '') {
-          throw new Error('proxy credentials must not be embedded in the URL')
-        }
-        if (url.pathname !== '/' || url.search !== '' || url.hash !== '') {
-          throw new Error('proxy URL must contain only an origin')
-        }
-        return dependencies.create(url)
-      },
+    pipe(
+      Effect.fromResult(parseProxyUrl(proxyUrl)),
+      Effect.flatMap((url) =>
+        Effect.try({
+          try: () => dependencies.create(url),
+          catch: (cause) => configurationError('proxy', 'Alpaca proxy dispatcher acquisition failed', cause),
+        }),
+      ),
+    ),
+    (dispatcher) => Effect.promise(() => dependencies.destroy(dispatcher)),
+  )
+
+export const parseProxyUrl = (proxyUrl: string): Result.Result<URL, BrokerReadError> =>
+  pipe(
+    Result.try({
+      try: () => new URL(proxyUrl),
       catch: (cause) => configurationError('proxy', 'invalid Alpaca proxy configuration', cause),
     }),
-    (dispatcher) => Effect.promise(() => dependencies.destroy(dispatcher)),
+    Result.flatMap((url) => {
+      if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+        return Result.fail(configurationError('proxy', 'Alpaca proxy URL must use HTTP or HTTPS'))
+      }
+      if (url.username !== '' || url.password !== '') {
+        return Result.fail(configurationError('proxy', 'Alpaca proxy credentials must not be embedded in the URL'))
+      }
+      if (url.pathname !== '/' || url.search !== '' || url.hash !== '') {
+        return Result.fail(configurationError('proxy', 'Alpaca proxy URL must contain only an origin'))
+      }
+      return Result.succeed(url)
+    }),
   )
 
 const proxyLayer = (proxyUrl: string): Layer.Layer<NodeHttpClient.Dispatcher, BrokerReadError> =>


### PR DESCRIPTION
## Summary

- parse and validate Alpaca proxy URLs as a pure `Result` decision before resource acquisition
- remove the three proxy-policy throws while retaining `Effect.try` only around the external Undici dispatcher constructor
- preserve scoped acquire/release behavior and return typed configuration failures for parse, protocol, credential, origin, and constructor errors
- add direct pure and lifecycle regressions for every proxy boundary branch

## Related Issues

None.

## Testing

- `bun test services/bayn/src/broker/alpaca.test.ts` — 39 passed, 0 failed
- `bun run --filter @proompteng/bayn test` — 691 passed, 120 integration-gated skipped, 0 failed
- `bun node_modules/typescript/bin/tsc --noEmit -p services/bayn/tsconfig.json` — passed
- Effect diagnostics — 215 files, 0 errors, warnings, or messages
- Oxfmt check for `services/bayn/src` — passed
- Oxlint syntax and type-aware modes for `services/bayn` — passed
- production build — passed
- `bun test packages/scripts/src/bayn` — 20 passed, 0 failed

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable.
- [x] Breaking Changes is filled in.
- [x] Documentation, release notes, and follow-ups are not required for this internal refactor.
- [x] Proxy allow-list semantics, credential rejection, scoped finalization, and broker-read behavior are unchanged.
- [x] Production proxy policy validation contains no manual throws.
