### PR TITLE
refactor(bayn): close trading decision failures

### DIFF
--- a/services/bayn/src/broker/observations.test.ts
+++ b/services/bayn/src/broker/observations.test.ts
@@ -233,5 +233,22 @@ describe('paper broker observations', () => {
     const unsupported = failure(orderObservation({ ...order, orderType: AlpacaOrderType.Stop }, evidence))
     expect(unsupported).toEqual({ _tag: 'UnsupportedOrderType', value: AlpacaOrderType.Stop })
     expect(renderBrokerObservationError(unsupported)).toBe('unsupported paper order type stop')
+
+    expect(failure(orderObservation({ ...order, filledQuantityMicros: '+1' }, evidence))).toEqual({
+      _tag: 'FilledQuantityInvalid',
+      filledQuantityMicros: '+1',
+      quantityMicros: '2000000',
+    })
+
+    expect(failure(accountObservation({ value: { ...account, id: '\ud800' }, evidence }))).toMatchObject({
+      _tag: 'CanonicalizationFailed',
+      target: 'account',
+      cause: {
+        _tag: 'CanonicalJsonFailure',
+        path: '$.account.accountId',
+        reason: 'invalid-unicode-surrogate',
+        actualType: 'string',
+      },
+    })
   })
 })

--- a/services/bayn/src/broker/observations.ts
+++ b/services/bayn/src/broker/observations.ts
@@ -1,6 +1,6 @@
 import { Result, Schema, pipe } from 'effect'
 
-import { canonicalHashV1 } from '../hash'
+import { canonicalHashV1Result, type CanonicalHashFailure } from '../hash'
 import {
   AccountSnapshotSchema,
   AccountStatus,
@@ -84,7 +84,11 @@ type ObservationTarget = 'account' | 'fill' | 'order' | 'position' | 'position-s
 
 export type BrokerObservationError =
   | { readonly _tag: 'DecodeFailed'; readonly target: ObservationTarget; readonly cause: unknown }
-  | { readonly _tag: 'CanonicalizationFailed'; readonly target: ObservationTarget; readonly cause: unknown }
+  | {
+      readonly _tag: 'CanonicalizationFailed'
+      readonly target: ObservationTarget
+      readonly cause: CanonicalHashFailure
+    }
   | { readonly _tag: 'TimestampInvalid'; readonly value: string }
   | {
       readonly _tag: 'ObservationTimeMismatch'
@@ -134,10 +138,12 @@ const decodePosition = decode('position', PositionEventInputSchema)
 const decodePositionSnapshot = decode('position-snapshot', PositionSnapshotInputSchema)
 
 const canonicalHash = (target: ObservationTarget, value: unknown): Result.Result<string, BrokerObservationError> =>
-  pipe(
-    Result.try(() => canonicalHashV1(value)),
-    Result.mapError((cause): BrokerObservationError => ({ _tag: 'CanonicalizationFailed', target, cause })),
+  Result.mapError(
+    canonicalHashV1Result(value),
+    (cause): BrokerObservationError => ({ _tag: 'CanonicalizationFailed', target, cause }),
   )
+
+const canonicalUnsignedIntegerPattern = /^(?:0|[1-9][0-9]*)$/
 
 export const sourceTimestamp = (value: string): Result.Result<string, BrokerObservationError> => {
   const match = /^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})(?:\.(\d{1,9}))?Z$/.exec(value)
@@ -223,26 +229,21 @@ const timeInForce = (value: AlpacaTimeInForce): Result.Result<TimeInForce, Broke
 const nonterminalStatus = (
   filledQuantityMicros: string,
   quantityMicros: string,
-): Result.Result<OrderStatus, BrokerObservationError> =>
-  pipe(
-    Result.try(() => ({ filled: BigInt(filledQuantityMicros), quantity: BigInt(quantityMicros) })),
-    Result.mapError(
-      (): BrokerObservationError => ({
-        _tag: 'FilledQuantityInvalid',
-        filledQuantityMicros,
-        quantityMicros,
-      }),
-    ),
-    Result.flatMap(({ filled, quantity }) =>
-      filled === 0n
-        ? Result.succeed(OrderStatus.Pending)
-        : filled < quantity
-          ? Result.succeed(OrderStatus.PartiallyFilled)
-          : filled === quantity
-            ? Result.succeed(OrderStatus.Filled)
-            : fail({ _tag: 'FilledQuantityInvalid', filledQuantityMicros, quantityMicros }),
-    ),
-  )
+): Result.Result<OrderStatus, BrokerObservationError> => {
+  if (
+    !canonicalUnsignedIntegerPattern.test(filledQuantityMicros) ||
+    !canonicalUnsignedIntegerPattern.test(quantityMicros)
+  ) {
+    return fail({ _tag: 'FilledQuantityInvalid', filledQuantityMicros, quantityMicros })
+  }
+  const filled = BigInt(filledQuantityMicros)
+  const quantity = BigInt(quantityMicros)
+  if (filled === 0n) return Result.succeed(OrderStatus.Pending)
+  if (filled < quantity) return Result.succeed(OrderStatus.PartiallyFilled)
+  return filled === quantity
+    ? Result.succeed(OrderStatus.Filled)
+    : fail({ _tag: 'FilledQuantityInvalid', filledQuantityMicros, quantityMicros })
+}
 
 const orderStatus = (
   value: AlpacaOrderStatus,

--- a/services/bayn/src/execution/intents.test.ts
+++ b/services/bayn/src/execution/intents.test.ts
@@ -306,8 +306,13 @@ describe('pure intent commit decisions', () => {
       expect(invalid.failure).toMatchObject({
         _tag: 'CanonicalizationFailed',
         material: { _tag: 'ReferenceIntentIdentity', strategyName: 'invalid\ud800strategy' },
+        cause: {
+          _tag: 'CanonicalJsonFailure',
+          path: '$.strategyName',
+          reason: 'invalid-unicode-surrogate',
+          actualType: 'string',
+        },
       })
-      expect(invalid.failure.cause).toBeInstanceOf(TypeError)
     }
   })
 

--- a/services/bayn/src/execution/intents.ts
+++ b/services/bayn/src/execution/intents.ts
@@ -5,7 +5,7 @@ import { Context, Data, Effect, Layer, Option, Result, Schema } from 'effect'
 import { isSqlError } from 'effect/unstable/sql/SqlError'
 import type { Fragment } from 'effect/unstable/sql/Statement'
 
-import { canonicalHashV1 } from '../hash'
+import { canonicalHashV1Result, type CanonicalHashFailure } from '../hash'
 import {
   Authority,
   IntentSchema,
@@ -82,17 +82,17 @@ export type IntentCanonicalMaterial =
 export interface IntentCanonicalizationFailure {
   readonly _tag: 'CanonicalizationFailed'
   readonly material: IntentCanonicalMaterial
-  readonly cause: unknown
+  readonly cause: CanonicalHashFailure
 }
 
 const canonicalHashResult = (
   material: IntentCanonicalMaterial,
   value: unknown,
 ): Result.Result<string, IntentCanonicalizationFailure> =>
-  Result.try({
-    try: () => canonicalHashV1(value),
-    catch: (cause): IntentCanonicalizationFailure => ({ _tag: 'CanonicalizationFailed', material, cause }),
-  })
+  Result.mapError(
+    canonicalHashV1Result(value),
+    (cause): IntentCanonicalizationFailure => ({ _tag: 'CanonicalizationFailed', material, cause }),
+  )
 
 const referenceIdentityMaterial = (input: IntentPlan) => ({
   schemaVersion: 'bayn.paper-intent-identity.v1',

--- a/services/bayn/src/reconciliation.test.ts
+++ b/services/bayn/src/reconciliation.test.ts
@@ -371,12 +371,17 @@ describe('paper reconciliation', () => {
       identity: account.accountId,
       value: 'not-an-instant',
     })
-    expect(failureOf(compareReconciliation(snapshot({ expectedCashMicros: 'not-an-integer' })))).toMatchObject({
+    expect(failureOf(compareReconciliation(snapshot({ expectedCashMicros: 'not-an-integer' })))).toEqual({
       _tag: 'InvalidInteger',
       source: 'expected-cash',
       identity: account.accountId,
       value: 'not-an-integer',
-      cause: expect.any(SyntaxError),
+    })
+    expect(failureOf(compareReconciliation(snapshot({ expectedCashMicros: '+1' })))).toEqual({
+      _tag: 'InvalidInteger',
+      source: 'expected-cash',
+      identity: account.accountId,
+      value: '+1',
     })
     const canonicalization = failureOf(
       reconciledStateHash({
@@ -391,7 +396,12 @@ describe('paper reconciliation', () => {
     expect(canonicalization).toMatchObject({
       _tag: 'CanonicalizationFailed',
       operation: 'broker-state-hash',
-      cause: expect.any(TypeError),
+      cause: {
+        _tag: 'CanonicalJsonFailure',
+        path: '$.account.accountId',
+        reason: 'invalid-unicode-surrogate',
+        actualType: 'string',
+      },
     })
     expect(renderReconciliationDecisionError(canonicalization)).toBe(
       'reconciliation broker-state-hash canonicalization failed',

--- a/services/bayn/src/reconciliation.ts
+++ b/services/bayn/src/reconciliation.ts
@@ -1,6 +1,6 @@
 import { HashMap, HashSet, Option, Result, pipe } from 'effect'
 
-import { canonicalHashV1 } from './hash'
+import { canonicalHashV1Result, type CanonicalHashFailure } from './hash'
 import {
   AccountStatus,
   DiscrepancyKind,
@@ -170,7 +170,7 @@ export type ReconciliationDecisionError =
       readonly _tag: 'CanonicalizationFailed'
       readonly operation: ReconciliationHashOperation
       readonly identity?: string
-      readonly cause: unknown
+      readonly cause: CanonicalHashFailure
     }
   | {
       readonly _tag: 'FixedPointRoundingFailed'
@@ -190,7 +190,6 @@ export type ReconciliationDecisionError =
       readonly source: ReconciliationIntegerSource
       readonly identity: string
       readonly value: string
-      readonly cause: unknown
     }
   | {
       readonly _tag: 'DuplicateIdentity'
@@ -237,37 +236,33 @@ const canonicalHash = (
   value: unknown,
   identity?: string,
 ): ReconciliationDecision<string> =>
-  pipe(
-    Result.try(() => canonicalHashV1(value)),
-    Result.mapError(
-      (cause): ReconciliationDecisionError => ({
-        _tag: 'CanonicalizationFailed',
-        operation,
-        ...(identity === undefined ? {} : { identity }),
-        cause,
-      }),
-    ),
+  Result.mapError(
+    canonicalHashV1Result(value),
+    (cause): ReconciliationDecisionError => ({
+      _tag: 'CanonicalizationFailed',
+      operation,
+      ...(identity === undefined ? {} : { identity }),
+      cause,
+    }),
   )
 
 const absolute = (value: bigint): bigint => (value < 0n ? -value : value)
+
+const canonicalIntegerPattern = /^(?:0|-?[1-9][0-9]*)$/
 
 const integer = (
   source: ReconciliationIntegerSource,
   identity: string,
   value: string,
 ): ReconciliationDecision<bigint> =>
-  pipe(
-    Result.try(() => BigInt(value)),
-    Result.mapError(
-      (cause): ReconciliationDecisionError => ({
+  canonicalIntegerPattern.test(value)
+    ? Result.succeed(BigInt(value))
+    : fail({
         _tag: 'InvalidInteger',
         source,
         identity,
         value,
-        cause,
-      }),
-    ),
-  )
+      })
 
 const roundMicrosProduct = (
   symbol: string,


### PR DESCRIPTION
## Summary

- totalize deterministic intent identity hashing with `canonicalHashV1Result` and retain closed `CanonicalHashFailure` facts in planning and commit validation
- totalize broker observation hashing and recognize canonical unsigned quantity strings before `BigInt` conversion instead of deriving expected failures from exceptions
- totalize reconciliation hashing and canonical signed integer parsing while preserving every valid hash, discrepancy identity, metric, and failure precedence
- keep Effect at the PostgreSQL and runtime boundaries; these changed decisions remain synchronous immutable `Result` algebra

## Related Issues

None

## Testing

- `bun test services/bayn/src/execution/intents.test.ts services/bayn/src/broker/observations.test.ts services/bayn/src/reconciliation.test.ts` — 32 passed, 0 failed before and after rebases
- `node services/bayn/node_modules/typescript/bin/tsc --project services/bayn/tsconfig.json --noEmit --pretty false` — passed
- `bun services/bayn/node_modules/@effect/tsgo/dist/effect-tsgo.js diagnostics --project services/bayn/tsconfig.json --format text --severity error` — 215 files, 0 errors, 0 warnings
- `node node_modules/oxfmt/bin/oxfmt --check services/bayn/src` — passed
- `node node_modules/oxlint/bin/oxlint --config .oxlintrc.json services/bayn` — 0 errors, 0 warnings
- `node node_modules/oxlint/bin/oxlint --config .oxlintrc.json --type-aware --tsconfig services/bayn/tsconfig.json services/bayn` — 0 errors, 0 warnings
- `bun test services/bayn/src` — 694 passed, 120 PostgreSQL-gated skips, 0 failed
- `bun build services/bayn/src/index.ts --target=node --external tigerbeetle-node --outdir=/tmp/bayn-fp-next3-dist` — passed
- `bun test packages/scripts/src/bayn` — 20 passed, 0 failed
- verified the three changed production modules contain neither deprecated `canonicalHashV1(...)` calls nor `Result.try`

## Breaking Changes

None. Valid deterministic IDs, hashes, broker events, reconciliation outputs, and public renderings are unchanged. Canonicalization causes are narrowed from `unknown` to the existing closed `CanonicalHashFailure` contract.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; this is a pure TypeScript domain refactor.
- [x] Documentation and release notes are not required because durable and runtime behavior is unchanged.
