### PR TITLE
fix(bayn): preserve strategy decision defects

### DIFF
--- a/services/bayn/src/observe-composition.test.ts
+++ b/services/bayn/src/observe-composition.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 
-import { Effect, Result } from 'effect'
+import { Cause, Effect, Exit, Result } from 'effect'
 import { TestClock } from 'effect/testing'
 
 import { fixtureStrategy } from './app-test-support'
@@ -48,7 +48,7 @@ import { ReconciliationError, type ReconciliationPassResult } from './reconciler
 import { reconciledStateHash } from './reconciliation'
 import { Reason } from './risk'
 import { fixtureProtocol, makeSnapshot } from './test-fixtures'
-import type { DecisionPlan } from './types'
+import type { DecisionPlan, IsoDate } from './types'
 
 const signalDate = '2020-04-30'
 const executionDate = '2020-05-01'
@@ -472,6 +472,73 @@ describe('OBSERVE runtime composition', () => {
       cause: undefined,
     })
     expect(strategyCalls).toBe(0)
+  })
+
+  test('maps an expected strategy decision failure into the typed operational channel', async () => {
+    const policy = await Effect.runPromise(loadObserveRiskPolicy(accountId, fixtureProtocol.universe))
+    const strategyFailure = {
+      _tag: 'CurrentDecisionCoverageMismatch' as const,
+      signalDate: signalDate as IsoDate,
+      expectedSymbols: fixtureProtocol.universe,
+      observedSymbols: [],
+    }
+    const failure = await Effect.runPromise(
+      Effect.flip(
+        Effect.gen(function* () {
+          yield* TestClock.setTime(Date.parse(evaluatedAt))
+          return yield* buildObserveCycleDecision({
+            authorityGenerationHash: generationHash,
+            cycle,
+            executionModel: fixtureProtocol.executionModel,
+            policy,
+            reconcile: Effect.succeed(reconciliationResult()),
+            strategy: { currentDecision: () => Result.fail(strategyFailure) },
+          })
+        }).pipe(
+          (program) => provideDecisionServices(program, marketData([]), calendarRead([])),
+          Effect.provide(TestClock.layer()),
+        ),
+      ),
+    )
+
+    expect(failure._tag).toBe('OperationalError')
+    if (failure._tag === 'OperationalError') {
+      expect(failure.component).toBe('strategy')
+      expect(failure.operation).toBe('current-decision')
+      expect(failure.message).toStartWith('current strategy decision compilation failed')
+      expect(failure.cause).toBe(strategyFailure)
+    }
+  })
+
+  test('preserves a thrown strategy decision bug as the identical Effect defect', async () => {
+    const policy = await Effect.runPromise(loadObserveRiskPolicy(accountId, fixtureProtocol.universe))
+    const defect = new Error('unexpected current-decision defect')
+    const exit = await Effect.runPromiseExit(
+      Effect.gen(function* () {
+        yield* TestClock.setTime(Date.parse(evaluatedAt))
+        return yield* buildObserveCycleDecision({
+          authorityGenerationHash: generationHash,
+          cycle,
+          executionModel: fixtureProtocol.executionModel,
+          policy,
+          reconcile: Effect.succeed(reconciliationResult()),
+          strategy: {
+            currentDecision: () => {
+              throw defect
+            },
+          },
+        })
+      }).pipe(
+        (program) => provideDecisionServices(program, marketData([]), calendarRead([])),
+        Effect.provide(TestClock.layer()),
+      ),
+    )
+
+    expect(Exit.isFailure(exit)).toBe(true)
+    if (Exit.isFailure(exit)) {
+      const defects = exit.cause.reasons.flatMap((reason) => (Cause.isDieReason(reason) ? [reason.defect] : []))
+      expect(defects).toContain(defect)
+    }
   })
 
   test('closes read and reconciliation failures with their operational classifications and exact causes', async () => {

--- a/services/bayn/src/observe-composition.ts
+++ b/services/bayn/src/observe-composition.ts
@@ -323,16 +323,11 @@ const compileObserveStrategyDecision = <R>(
   facts: ObserveDecisionFacts,
   executionSession: ExecutionSessionBinding,
 ): Effect.Effect<CurrentStrategyDecision, OperationalError> =>
-  Effect.try({
-    try: () => input.strategy.currentDecision(facts.snapshot.bars, facts.snapshot.manifest, executionSession),
-    catch: (cause) =>
-      operationalError('strategy', 'current-decision', 'current strategy decision compilation failed', cause),
-  }).pipe(
-    Effect.flatMap(Effect.fromResult),
+  Effect.fromResult(
+    input.strategy.currentDecision(facts.snapshot.bars, facts.snapshot.manifest, executionSession),
+  ).pipe(
     Effect.mapError((cause) =>
-      cause._tag === 'OperationalError'
-        ? cause
-        : operationalError('strategy', 'current-decision', 'current strategy decision compilation failed', cause),
+      operationalError('strategy', 'current-decision', 'current strategy decision compilation failed', cause),
     ),
   )
 


### PR DESCRIPTION
## Summary

- lift the pure strategy `Result` directly into Effect instead of wrapping it in a broad `Effect.try`
- keep expected current-decision failures in the typed `OperationalError` channel with the exact domain cause
- preserve thrown strategy bugs as Effect defects so they cannot be misclassified as recoverable runtime failures
- add regressions for both typed-failure and defect behavior

## Related Issues

None

## Testing

- `bun test services/bayn/src/observe-composition.test.ts`
- `bun run --cwd services/bayn test` — 706 passed, 120 PostgreSQL-gated skips, 0 failed
- `bun node_modules/typescript/bin/tsc --noEmit -p services/bayn/tsconfig.json`
- `bun services/bayn/node_modules/@effect/tsgo/dist/effect-tsgo.js diagnostics --project services/bayn/tsconfig.json --format text --severity error`
- `bun node_modules/oxfmt/bin/oxfmt --check services/bayn/src`
- `bun node_modules/oxlint/bin/oxlint --config .oxlintrc.json services/bayn`
- `bun node_modules/oxlint/bin/oxlint --config .oxlintrc.json --type-aware --tsconfig services/bayn/tsconfig.json services/bayn`
- `bun build services/bayn/src/index.ts --target=node --external tigerbeetle-node --outdir=services/bayn/dist`
- `bun test packages/scripts/src/bayn` — 20 passed, 0 failed
- `git diff --check origin/main...HEAD`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] Documentation, release notes, and follow-ups are not required for this internal error-boundary correction.
