### PR TITLE
refactor(bayn): totalize execution coordinator time

### DIFF
--- a/services/bayn/src/execution/coordinator-decisions.test.ts
+++ b/services/bayn/src/execution/coordinator-decisions.test.ts
@@ -251,6 +251,11 @@ describe('execution coordinator decisions', () => {
       field: 'current-time',
       value: Number.NaN,
     })
+    expectInvalidInstant(validateActiveSubmitRiskDecision(stored(), Number.MAX_VALUE), {
+      operation: MutationOperation.Submit,
+      field: 'current-time',
+      value: Number.MAX_VALUE,
+    })
     expectInvalidInstant(
       ensureRecoveryDelay(
         MutationOperation.Submit,
@@ -258,6 +263,14 @@ describe('execution coordinator decisions', () => {
         Number.NaN,
       ),
       { operation: MutationOperation.Submit, field: 'current-time', value: Number.NaN },
+    )
+    expectInvalidInstant(
+      ensureRecoveryDelay(
+        MutationOperation.Submit,
+        mutation(MutationOperation.Submit, MutationEventType.SubmitUnknown),
+        Number.MAX_VALUE,
+      ),
+      { operation: MutationOperation.Submit, field: 'current-time', value: Number.MAX_VALUE },
     )
     expectInvalidInstant(
       ensureRecoveryDelay(

--- a/services/bayn/src/execution/coordinator-decisions.test.ts
+++ b/services/bayn/src/execution/coordinator-decisions.test.ts
@@ -34,8 +34,11 @@ import {
   encodeOrder,
   ensureRecoveryDelay,
   makeDryRunSubmit,
+  nextInstant,
   selectRecovery,
+  validateActiveSubmitRiskDecision,
   validateRecovery,
+  type ExecutionDecisionFailure,
 } from './coordinator-decisions'
 
 const encodedRequest = (value: Intent) => Result.getOrThrow(orderRequestBody(value))
@@ -208,6 +211,65 @@ describe('execution coordinator decisions', () => {
     expect(
       Result.getOrThrow(ensureRecoveryDelay(MutationOperation.Submit, submit, Date.parse(submit.occurredAt) + 1_000)),
     ).toEqual(submit)
+  })
+
+  test('returns malformed and overflowing coordinator instants through the closed failure algebra', () => {
+    const expectInvalidInstant = <A>(
+      result: Result.Result<A, ExecutionDecisionFailure>,
+      expected: {
+        readonly operation: MutationOperation
+        readonly field: Extract<ExecutionDecisionFailure, { readonly _tag: 'InvalidInstant' }>['field']
+        readonly value: string | number
+      },
+    ) => {
+      expect(Result.isFailure(result)).toBe(true)
+      if (Result.isFailure(result)) {
+        expect(result.failure).toMatchObject({ _tag: 'InvalidInstant', ...expected })
+      }
+    }
+
+    expect(
+      Result.getOrThrow(nextInstant(MutationOperation.Submit, '2026-07-25T00:00:00.000Z', '2026-07-25T00:00:00.000Z')),
+    ).toBe('2026-07-25T00:00:00.001Z')
+
+    expectInvalidInstant(nextInstant(MutationOperation.Submit, 'not-an-instant', '2026-07-25T00:00:00.000Z'), {
+      operation: MutationOperation.Submit,
+      field: 'stored-updated-at',
+      value: 'not-an-instant',
+    })
+    expectInvalidInstant(nextInstant(MutationOperation.Cancel, '2026-07-25T00:00:00.000Z', 'not-an-instant'), {
+      operation: MutationOperation.Cancel,
+      field: 'occurred-at',
+      value: 'not-an-instant',
+    })
+    expectInvalidInstant(
+      nextInstant(MutationOperation.Submit, '+275760-09-13T00:00:00.000Z', '2026-07-25T00:00:00.000Z'),
+      { operation: MutationOperation.Submit, field: 'stored-updated-at', value: 8_640_000_000_000_001 },
+    )
+    expectInvalidInstant(validateActiveSubmitRiskDecision(stored(), Number.NaN), {
+      operation: MutationOperation.Submit,
+      field: 'current-time',
+      value: Number.NaN,
+    })
+    expectInvalidInstant(
+      ensureRecoveryDelay(
+        MutationOperation.Submit,
+        mutation(MutationOperation.Submit, MutationEventType.SubmitUnknown),
+        Number.NaN,
+      ),
+      { operation: MutationOperation.Submit, field: 'current-time', value: Number.NaN },
+    )
+    expectInvalidInstant(
+      ensureRecoveryDelay(
+        MutationOperation.Cancel,
+        {
+          ...mutation(MutationOperation.Cancel, MutationEventType.CancelUnknown),
+          occurredAt: 'not-an-instant',
+        } as MutationEvent,
+        Date.parse('2026-07-25T00:00:00.000Z'),
+      ),
+      { operation: MutationOperation.Cancel, field: 'occurred-at', value: 'not-an-instant' },
+    )
   })
 
   test('neutralizes the exact zero-fill canceled broker order but not a different order', () => {

--- a/services/bayn/src/execution/coordinator-decisions.test.ts
+++ b/services/bayn/src/execution/coordinator-decisions.test.ts
@@ -256,6 +256,11 @@ describe('execution coordinator decisions', () => {
       field: 'current-time',
       value: Number.MAX_VALUE,
     })
+    expectInvalidInstant(validateActiveSubmitRiskDecision(stored(), 253_402_300_800_000), {
+      operation: MutationOperation.Submit,
+      field: 'current-time',
+      value: 253_402_300_800_000,
+    })
     expectInvalidInstant(
       ensureRecoveryDelay(
         MutationOperation.Submit,
@@ -271,6 +276,14 @@ describe('execution coordinator decisions', () => {
         Number.MAX_VALUE,
       ),
       { operation: MutationOperation.Submit, field: 'current-time', value: Number.MAX_VALUE },
+    )
+    expectInvalidInstant(
+      ensureRecoveryDelay(
+        MutationOperation.Submit,
+        mutation(MutationOperation.Submit, MutationEventType.SubmitUnknown),
+        253_402_300_800_000,
+      ),
+      { operation: MutationOperation.Submit, field: 'current-time', value: 253_402_300_800_000 },
     )
     expectInvalidInstant(
       ensureRecoveryDelay(

--- a/services/bayn/src/execution/coordinator-decisions.ts
+++ b/services/bayn/src/execution/coordinator-decisions.ts
@@ -191,7 +191,7 @@ const validateCurrentTime = (
   operation: MutationOperation,
   currentTimeMillis: number,
 ): Result.Result<number, ExecutionDecisionFailure> =>
-  Number.isFinite(currentTimeMillis)
+  Number.isFinite(currentTimeMillis) && Number.isFinite(new Date(currentTimeMillis).getTime())
     ? Result.succeed(currentTimeMillis)
     : Result.fail({ _tag: 'InvalidInstant', operation, field: 'current-time', value: currentTimeMillis })
 

--- a/services/bayn/src/execution/coordinator-decisions.ts
+++ b/services/bayn/src/execution/coordinator-decisions.ts
@@ -18,7 +18,7 @@ import {
   type ReadEvidence,
   type ReadResult,
 } from '../broker/alpaca'
-import { canonicalHashV1 } from '../hash'
+import { canonicalHashV1Result } from '../hash'
 import { IntentState, RiskOutcome, TerminalOutcome, type Intent } from '../paper'
 import type { StoredIntent } from './intents'
 import { MutationEventType, type MutationEvent } from './mutations'
@@ -63,6 +63,12 @@ export type ExecutionDecisionFailure =
       readonly _tag: 'RecoveryTooEarly'
       readonly operation: MutationOperation
       readonly eligibleAt: string
+    }
+  | {
+      readonly _tag: 'InvalidInstant'
+      readonly operation: MutationOperation
+      readonly field: 'stored-updated-at' | 'occurred-at' | 'risk-expires-at' | 'current-time'
+      readonly value: string | number
     }
 
 export interface EncodedOrder {
@@ -170,8 +176,47 @@ export const selectStoredIntent = (
     onSome: Result.succeed,
   })
 
-export const nextInstant = (instant: string, current: string): string =>
-  new Date(Math.max(Date.parse(current), Date.parse(instant) + 1)).toISOString()
+const parseInstant = (
+  operation: MutationOperation,
+  field: Extract<ExecutionDecisionFailure, { readonly _tag: 'InvalidInstant' }>['field'],
+  value: string,
+): Result.Result<number, ExecutionDecisionFailure> => {
+  const epochMillis = Date.parse(value)
+  return Number.isFinite(epochMillis)
+    ? Result.succeed(epochMillis)
+    : Result.fail({ _tag: 'InvalidInstant', operation, field, value })
+}
+
+const validateCurrentTime = (
+  operation: MutationOperation,
+  currentTimeMillis: number,
+): Result.Result<number, ExecutionDecisionFailure> =>
+  Number.isFinite(currentTimeMillis)
+    ? Result.succeed(currentTimeMillis)
+    : Result.fail({ _tag: 'InvalidInstant', operation, field: 'current-time', value: currentTimeMillis })
+
+const formatInstant = (
+  operation: MutationOperation,
+  field: Extract<ExecutionDecisionFailure, { readonly _tag: 'InvalidInstant' }>['field'],
+  epochMillis: number,
+): Result.Result<string, ExecutionDecisionFailure> =>
+  Result.try({
+    try: () => new Date(epochMillis).toISOString(),
+    catch: (): ExecutionDecisionFailure => ({ _tag: 'InvalidInstant', operation, field, value: epochMillis }),
+  })
+
+export const nextInstant = (
+  operation: MutationOperation,
+  instant: string,
+  current: string,
+): Result.Result<string, ExecutionDecisionFailure> =>
+  Result.flatMap(parseInstant(operation, 'stored-updated-at', instant), (instantMillis) =>
+    Result.flatMap(parseInstant(operation, 'occurred-at', current), (currentMillis) =>
+      currentMillis >= instantMillis + 1
+        ? formatInstant(operation, 'occurred-at', currentMillis)
+        : formatInstant(operation, 'stored-updated-at', instantMillis + 1),
+    ),
+  )
 
 export const encodeOrder = (
   operation: MutationOperation,
@@ -183,15 +228,17 @@ export const encodeOrder = (
       (cause): ExecutionDecisionFailure => ({ _tag: 'OrderCanonicalizationFailed', operation, message, cause }),
     ),
     Result.flatMap((request) =>
-      Result.try({
-        try: () => ({ request, requestHash: canonicalHashV1(request) }),
-        catch: (cause): ExecutionDecisionFailure => ({
-          _tag: 'OrderCanonicalizationFailed',
-          operation,
-          message,
-          cause,
-        }),
-      }),
+      canonicalHashV1Result(request).pipe(
+        Result.map((requestHash) => ({ request, requestHash })),
+        Result.mapError(
+          (cause): ExecutionDecisionFailure => ({
+            _tag: 'OrderCanonicalizationFailed',
+            operation,
+            message,
+            cause,
+          }),
+        ),
+      ),
     ),
   )
 
@@ -208,9 +255,13 @@ export const validateActiveSubmitRiskDecision = (
   ) {
     return Result.fail({ _tag: 'InvalidRiskDecision', operationLabel })
   }
-  return currentTimeMillis >= Date.parse(decision.expiresAt)
-    ? Result.fail({ _tag: 'ExpiredRiskDecision', operationLabel, expiresAt: decision.expiresAt })
-    : Result.succeed(stored)
+  return Result.flatMap(validateCurrentTime(MutationOperation.Submit, currentTimeMillis), (currentMillis) =>
+    Result.flatMap(parseInstant(MutationOperation.Submit, 'risk-expires-at', decision.expiresAt), (expiresAt) =>
+      currentMillis >= expiresAt
+        ? Result.fail({ _tag: 'ExpiredRiskDecision', operationLabel, expiresAt: decision.expiresAt })
+        : Result.succeed(stored),
+    ),
+  )
 }
 
 export const makeDryRunSubmit = (
@@ -400,14 +451,20 @@ export const ensureRecoveryDelay = (
   event: MutationEvent,
   currentMillis: number,
 ): Result.Result<MutationEvent, ExecutionDecisionFailure> => {
-  const eligibleMillis = Date.parse(event.occurredAt) + event.consistencyDelayMs
-  return currentMillis >= eligibleMillis
-    ? Result.succeed(event)
-    : Result.fail({
-        _tag: 'RecoveryTooEarly',
-        operation,
-        eligibleAt: new Date(eligibleMillis).toISOString(),
-      })
+  return Result.flatMap(parseInstant(operation, 'occurred-at', event.occurredAt), (occurredAt) =>
+    Result.flatMap(validateCurrentTime(operation, currentMillis), (now) => {
+      const eligibleMillis = occurredAt + event.consistencyDelayMs
+      return now >= eligibleMillis
+        ? Result.succeed(event)
+        : Result.flatMap(formatInstant(operation, 'occurred-at', eligibleMillis), (eligibleAt) =>
+            Result.fail({
+              _tag: 'RecoveryTooEarly',
+              operation,
+              eligibleAt,
+            }),
+          )
+    }),
+  )
 }
 
 export const decideInterruptedStart = (event: MutationEvent, occurredAt: string): InterruptedStartDecision => {

--- a/services/bayn/src/execution/coordinator-decisions.ts
+++ b/services/bayn/src/execution/coordinator-decisions.ts
@@ -20,6 +20,7 @@ import {
 } from '../broker/alpaca'
 import { canonicalHashV1Result } from '../hash'
 import { IntentState, RiskOutcome, TerminalOutcome, type Intent } from '../paper'
+import { UtcInstantSchema } from '../schemas'
 import type { StoredIntent } from './intents'
 import { MutationEventType, type MutationEvent } from './mutations'
 
@@ -187,23 +188,29 @@ const parseInstant = (
     : Result.fail({ _tag: 'InvalidInstant', operation, field, value })
 }
 
-const validateCurrentTime = (
-  operation: MutationOperation,
-  currentTimeMillis: number,
-): Result.Result<number, ExecutionDecisionFailure> =>
-  Number.isFinite(currentTimeMillis) && Number.isFinite(new Date(currentTimeMillis).getTime())
-    ? Result.succeed(currentTimeMillis)
-    : Result.fail({ _tag: 'InvalidInstant', operation, field: 'current-time', value: currentTimeMillis })
+const isUtcInstant = Schema.is(UtcInstantSchema)
 
 const formatInstant = (
   operation: MutationOperation,
   field: Extract<ExecutionDecisionFailure, { readonly _tag: 'InvalidInstant' }>['field'],
   epochMillis: number,
 ): Result.Result<string, ExecutionDecisionFailure> =>
-  Result.try({
-    try: () => new Date(epochMillis).toISOString(),
-    catch: (): ExecutionDecisionFailure => ({ _tag: 'InvalidInstant', operation, field, value: epochMillis }),
-  })
+  Result.flatMap(
+    Result.try({
+      try: () => new Date(epochMillis).toISOString(),
+      catch: (): ExecutionDecisionFailure => ({ _tag: 'InvalidInstant', operation, field, value: epochMillis }),
+    }),
+    (instant) =>
+      isUtcInstant(instant)
+        ? Result.succeed(instant)
+        : Result.fail({ _tag: 'InvalidInstant', operation, field, value: epochMillis }),
+  )
+
+const validateCurrentTime = (
+  operation: MutationOperation,
+  currentTimeMillis: number,
+): Result.Result<number, ExecutionDecisionFailure> =>
+  Result.map(formatInstant(operation, 'current-time', currentTimeMillis), () => currentTimeMillis)
 
 export const nextInstant = (
   operation: MutationOperation,

--- a/services/bayn/src/execution/coordinator.ts
+++ b/services/bayn/src/execution/coordinator.ts
@@ -119,6 +119,12 @@ const executionError = (failure: ExecutionDecisionFailure): ExecutionError =>
           message: `broker lookup is not allowed before ${eligibleAt}`,
           eligibleAt,
         }),
+      InvalidInstant: ({ operation, field, value }) =>
+        new ExecutionError({
+          operation,
+          failure: ExecutionFailure.InvalidState,
+          message: `execution coordinator ${field} instant is invalid: ${value}`,
+        }),
     }),
   )
 
@@ -209,11 +215,10 @@ const startSubmit = (
     Effect.andThen(requireActiveSubmitRiskDecision(stored)),
     Effect.andThen(currentInstant),
     Effect.flatMap((occurredAt) =>
-      services.mutations.beginSubmit(
-        stored.intent.intentId,
-        requestHash,
-        consistencyDelayMs,
-        nextInstant(stored.updatedAt, occurredAt),
+      liftDecision(nextInstant(MutationOperation.Submit, stored.updatedAt, occurredAt)).pipe(
+        Effect.flatMap((nextOccurredAt) =>
+          services.mutations.beginSubmit(stored.intent.intentId, requestHash, consistencyDelayMs, nextOccurredAt),
+        ),
       ),
     ),
     Effect.flatMap((started) =>
@@ -295,12 +300,16 @@ const startCancel = (
   services.fence.check.pipe(
     Effect.andThen(currentInstant),
     Effect.flatMap((occurredAt) =>
-      services.mutations.beginCancel(
-        stored.intent.intentId,
-        requestHash,
-        brokerOrderId,
-        consistencyDelayMs,
-        nextInstant(stored.updatedAt, occurredAt),
+      liftDecision(nextInstant(MutationOperation.Cancel, stored.updatedAt, occurredAt)).pipe(
+        Effect.flatMap((nextOccurredAt) =>
+          services.mutations.beginCancel(
+            stored.intent.intentId,
+            requestHash,
+            brokerOrderId,
+            consistencyDelayMs,
+            nextOccurredAt,
+          ),
+        ),
       ),
     ),
     Effect.flatMap((started) =>


### PR DESCRIPTION
## Summary

- replace execution-coordinator date defects with a closed `InvalidInstant` decision algebra
- validate durable update times, sampled clock values, risk expiry, recovery timestamps, and date-range overflow before persistence or broker work
- lift `nextInstant` decisions at submit/cancel interpreter boundaries while preserving writer-fence and mutation ordering
- use `canonicalHashV1Result` directly for order request identity
- add pure regressions for malformed, non-finite, and overflowing instants

## Related Issues

None.

## Testing

- `bun test services/bayn/src/execution/coordinator-decisions.test.ts services/bayn/src/execution/coordinator.test.ts` — 34 passed, 0 failed
- `bun run --filter @proompteng/bayn test` — 695 passed, 120 integration-gated skipped, 0 failed
- `bun node_modules/typescript/bin/tsc --noEmit -p services/bayn/tsconfig.json` — passed
- Effect diagnostics — 215 files, 0 errors, warnings, or messages
- Oxfmt check for `services/bayn/src` — passed
- Oxlint syntax and type-aware modes for `services/bayn` — passed
- production build — passed
- `bun test packages/scripts/src/bayn` — 20 passed, 0 failed

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable.
- [x] Breaking Changes is filled in.
- [x] Documentation, release notes, and follow-ups are not required for this internal refactor.
- [x] Writer-fence checks, durable mutation ordering, recovery delays, request hashes, and broker calls are unchanged.
- [x] Expected time and canonicalization failures remain in typed `Result` / `Effect` channels.
