### PR TITLE
refactor(bayn): totalize decision evidence hashes

### DIFF
--- a/services/bayn/src/execution-model.test.ts
+++ b/services/bayn/src/execution-model.test.ts
@@ -235,6 +235,12 @@ describe('explicit paper execution model', () => {
     expect(failure(result)).toMatchObject({
       _tag: 'OrderOutcomeCanonicalizationFailed',
       identity: { invalid: 1n },
+      cause: {
+        _tag: 'CanonicalJsonFailure',
+        path: '$.invalid',
+        reason: 'non-json-type',
+        actualType: 'bigint',
+      },
     })
   })
 })

--- a/services/bayn/src/execution-model.ts
+++ b/services/bayn/src/execution-model.ts
@@ -1,6 +1,6 @@
 import { pipe, Result } from 'effect'
 
-import { canonicalHashV1 } from './hash'
+import { canonicalHashV1Result, type CanonicalHashFailure } from './hash'
 import type { ExecutionModel, IsoDate, OrderRejectionReason, OrderStatus } from './types'
 import { roundUnsignedHalfUp, type UnsignedRoundHalfUpFailure } from './unsigned-round-half-up'
 
@@ -121,7 +121,7 @@ export type ExecutionModelFailure =
   | {
       readonly _tag: 'OrderOutcomeCanonicalizationFailed'
       readonly identity: unknown
-      readonly cause: unknown
+      readonly cause: CanonicalHashFailure
     }
   | {
       readonly _tag: 'InvalidFeeCostMultiplier'
@@ -461,14 +461,14 @@ export const makeOrderOutcome = (input: OrderOutcomeInput): ExecutionResult<Orde
             integerNumber(input.model.partialFills.probabilityPpm, 'partial fill probability', 0, Number(PPM)),
             Result.flatMap((probability) =>
               pipe(
-                Result.try({
-                  try: () => canonicalHashV1(input.identity),
-                  catch: (cause): ExecutionModelFailure => ({
+                Result.mapError(
+                  canonicalHashV1Result(input.identity),
+                  (cause): ExecutionModelFailure => ({
                     _tag: 'OrderOutcomeCanonicalizationFailed',
                     identity: input.identity,
                     cause,
                   }),
-                }),
+                ),
                 Result.flatMap((identityHash) => {
                   const bucket = BigInt(`0x${identityHash.slice(0, 16)}`) % PPM
                   if (bucket >= probability) {

--- a/services/bayn/src/health.test.ts
+++ b/services/bayn/src/health.test.ts
@@ -275,12 +275,14 @@ describe('Bayn continuous health', () => {
       if (Result.isFailure(canonicalization) && canonicalization.failure._tag === 'CanonicalizationFailed') {
         expect(canonicalization.failure.runId).toBe(evidence.evaluation.runId)
         expect(canonicalization.failure.material).toBe('EXPECTED_DURABLE_EVIDENCE')
-        expect(canonicalization.failure.cause).toBeInstanceOf(TypeError)
-        expect(String(canonicalization.failure.cause)).toBe(
-          'TypeError: $.persistence.runId contains an invalid Unicode surrogate',
-        )
+        expect(canonicalization.failure.cause).toEqual({
+          _tag: 'CanonicalJsonFailure',
+          path: '$.persistence.runId',
+          reason: 'invalid-unicode-surrogate',
+          actualType: 'string',
+        })
         expect(renderDurableEvidenceFailure(canonicalization.failure)).toBe(
-          `canonicalization of EXPECTED_DURABLE_EVIDENCE for run ${evidence.evaluation.runId} failed: TypeError: $.persistence.runId contains an invalid Unicode surrogate`,
+          `canonicalization of EXPECTED_DURABLE_EVIDENCE for run ${evidence.evaluation.runId} failed: invalid-unicode-surrogate at $.persistence.runId (string)`,
         )
       }
     }
@@ -346,10 +348,15 @@ describe('Bayn continuous health', () => {
       durableCause._tag === 'CanonicalizationFailed' &&
       'cause' in durableCause
     ) {
-      expect(durableCause.cause).toBeInstanceOf(TypeError)
+      expect(durableCause.cause).toEqual({
+        _tag: 'CanonicalJsonFailure',
+        path: '$.persistence.runId',
+        reason: 'invalid-unicode-surrogate',
+        actualType: 'string',
+      })
     }
     expect(durableError.message).toBe(
-      `durable evidence verification failed: canonicalization of EXPECTED_DURABLE_EVIDENCE for run ${evidence.evaluation.runId} failed: TypeError: $.persistence.runId contains an invalid Unicode surrogate`,
+      `durable evidence verification failed: canonicalization of EXPECTED_DURABLE_EVIDENCE for run ${evidence.evaluation.runId} failed: invalid-unicode-surrogate at $.persistence.runId (string)`,
     )
   })
 

--- a/services/bayn/src/health.ts
+++ b/services/bayn/src/health.ts
@@ -13,7 +13,7 @@ import {
 import { CycleObservability } from './db/cycle-observability'
 import { EvidenceStore, type QualificationRecord, type RecoveredEvaluationEvidence } from './db/evidence-store'
 import { OperationalError, operationalError } from './errors'
-import { canonicalHashV1 } from './hash'
+import { canonicalHashV1Result, renderCanonicalJsonFailure, type CanonicalHashFailure } from './hash'
 import { Journal } from './ledger'
 import { MarketData } from './market-data'
 import { databaseOperation, withinDeadline } from './operations'
@@ -82,7 +82,7 @@ export type DurableEvidenceFailure =
         | 'OBSERVED_DURABLE_EVIDENCE'
         | 'EXPECTED_QUALIFICATION'
         | 'OBSERVED_QUALIFICATION'
-      readonly cause: unknown
+      readonly cause: CanonicalHashFailure
     }
 
 export type HealthDependencyName = keyof RuntimeHealth['dependencies'] | 'broker'
@@ -237,10 +237,10 @@ const canonicalHashResult = (
   material: Extract<DurableEvidenceFailure, { readonly _tag: 'CanonicalizationFailed' }>['material'],
   value: unknown,
 ): Result.Result<string, DurableEvidenceFailure> =>
-  Result.try({
-    try: () => canonicalHashV1(value),
-    catch: (cause): DurableEvidenceFailure => ({ _tag: 'CanonicalizationFailed', runId, material, cause }),
-  })
+  Result.mapError(
+    canonicalHashV1Result(value),
+    (cause): DurableEvidenceFailure => ({ _tag: 'CanonicalizationFailed', runId, material, cause }),
+  )
 
 export const validateDurableEvidence = (
   recovered: RecoveredEvaluationEvidence | null,
@@ -313,7 +313,7 @@ export const renderDurableEvidenceFailure = (failure: DurableEvidenceFailure): s
     case 'TerminalQualificationMismatch':
       return `terminal qualification ${failure.runId} hash ${failure.observedQualificationHash} differs from active proof hash ${failure.expectedQualificationHash}`
     case 'CanonicalizationFailed':
-      return `canonicalization of ${failure.material} for run ${failure.runId} failed: ${String(failure.cause)}`
+      return `canonicalization of ${failure.material} for run ${failure.runId} failed: ${renderCanonicalJsonFailure(failure.cause)}`
   }
   const exhaustive: never = failure
   return exhaustive

--- a/services/bayn/src/shadow-decision-contract.ts
+++ b/services/bayn/src/shadow-decision-contract.ts
@@ -193,8 +193,16 @@ export const makeObserveShadowDecisionDocument = (
       makeDocumentFailure('canonicalization', 'shadow decision material is not canonicalizable', cause),
     ),
     (contentHash) =>
-      Result.mapError(decodeDocumentResult({ ...material, contentHash }), (cause) =>
-        makeDocumentFailure('contract', 'shadow decision material failed its durable contract', cause),
+      Result.flatMap(
+        Result.try({
+          try: () => ({ ...material, contentHash }),
+          catch: (cause) =>
+            makeDocumentFailure('canonicalization', 'shadow decision material is not canonicalizable', cause),
+        }),
+        (candidate) =>
+          Result.mapError(decodeDocumentResult(candidate), (cause) =>
+            makeDocumentFailure('contract', 'shadow decision material failed its durable contract', cause),
+          ),
       ),
   )
 }

--- a/services/bayn/src/shadow-decision-contract.ts
+++ b/services/bayn/src/shadow-decision-contract.ts
@@ -1,7 +1,7 @@
 import { Data, Result, Schema } from 'effect'
 
 import { intentIdForPlan } from './execution/intents'
-import { canonicalHashV1 } from './hash'
+import { canonicalHashV1Result } from './hash'
 import { PositiveMicrosSchema, RiskOutcome } from './paper'
 import { EvaluationSchema, Reason } from './risk'
 import { Sha256Schema, StrictNonEmptyStringSchema, UtcInstantSchema, strictParseOptions } from './schemas'
@@ -127,7 +127,11 @@ const documentHashIssues = (
   document: typeof ObserveShadowDecisionDocumentSemanticSchema.Type,
 ): readonly Schema.FilterIssue[] => {
   const { contentHash, ...material } = document
-  return contentHash === canonicalHashV1(material)
+  const expectedHash = canonicalHashV1Result(material)
+  if (Result.isFailure(expectedHash)) {
+    return [{ path: ['contentHash'], issue: 'shadow decision material must be canonicalizable' }]
+  }
+  return contentHash === expectedHash.success
     ? []
     : [{ path: ['contentHash'], issue: 'must match the canonical shadow decision material' }]
 }
@@ -185,13 +189,11 @@ export const makeObserveShadowDecisionDocument = (
     return Result.fail(makeDocumentFailure('contract', 'shadow decision material must be an object'))
   }
   return Result.flatMap(
-    Result.try({
-      try: () => ({ ...material, contentHash: canonicalHashV1(material) }),
-      catch: (cause) =>
-        makeDocumentFailure('canonicalization', 'shadow decision material is not canonicalizable', cause),
-    }),
-    (candidate) =>
-      Result.mapError(decodeDocumentResult(candidate), (cause) =>
+    Result.mapError(canonicalHashV1Result(material), (cause) =>
+      makeDocumentFailure('canonicalization', 'shadow decision material is not canonicalizable', cause),
+    ),
+    (contentHash) =>
+      Result.mapError(decodeDocumentResult({ ...material, contentHash }), (cause) =>
         makeDocumentFailure('contract', 'shadow decision material failed its durable contract', cause),
       ),
   )

--- a/services/bayn/src/shadow-decision.test.ts
+++ b/services/bayn/src/shadow-decision.test.ts
@@ -763,6 +763,15 @@ describe('OBSERVE shadow decision', () => {
       ['make', 'canonicalization'],
       ['decode', 'contract'],
     ])
+    const cyclicFailure = constructorFailures[2]
+    if (Result.isFailure(cyclicFailure)) {
+      expect(cyclicFailure.failure.cause).toEqual({
+        _tag: 'CanonicalJsonFailure',
+        path: '$.self',
+        reason: 'cycle',
+        actualType: 'object',
+      })
+    }
 
     const contractFailures = shadowContractFailurePairs.map(
       (pair) => new ShadowDecisionContractFailure({ ...pair, message: 'failure-pair coverage' }),

--- a/services/bayn/src/shadow-decision.test.ts
+++ b/services/bayn/src/shadow-decision.test.ts
@@ -720,6 +720,7 @@ describe('OBSERVE shadow decision', () => {
 
   test('returns each closed shadow failure category and contract-constructor failure', async () => {
     const input = makeInput()
+    const validDocument = await build(input)
     const bindingFailure = {
       ...input,
       snapshot: { ...input.snapshot, snapshotId: hash('f') },
@@ -771,6 +772,27 @@ describe('OBSERVE shadow decision', () => {
         reason: 'cycle',
         actualType: 'object',
       })
+    }
+
+    const { contentHash: _, ...validMaterial } = validDocument
+    const reflectionCause = new Error('second ownKeys failed')
+    let ownKeysCalls = 0
+    const statefulMaterial = new Proxy(validMaterial, {
+      ownKeys: (target) => {
+        ownKeysCalls += 1
+        if (ownKeysCalls === 2) throw reflectionCause
+        return Reflect.ownKeys(target)
+      },
+    })
+    const statefulFailure = makeObserveShadowDecisionDocument(statefulMaterial)
+    expect(Result.isFailure(statefulFailure)).toBe(true)
+    if (Result.isFailure(statefulFailure)) {
+      expect(statefulFailure.failure).toMatchObject({
+        _tag: 'ShadowDecisionContractFailure',
+        operation: 'make',
+        reason: 'canonicalization',
+      })
+      expect(statefulFailure.failure.cause).toBe(reflectionCause)
     }
 
     const contractFailures = shadowContractFailurePairs.map(

--- a/services/bayn/src/shadow-decision.ts
+++ b/services/bayn/src/shadow-decision.ts
@@ -5,7 +5,7 @@ import { Data, Effect, Result, Schema } from 'effect'
 import { AutonomousCycleSchema, CycleState, type AutonomousCycle } from './cycle'
 import { DecisionPlanSchema, type DecisionPlan } from './evidence-contracts'
 import { intentIdForPlan, IntentPlanSchema, type IntentPlan } from './execution/intents'
-import { canonicalHashV1 } from './hash'
+import { canonicalHashV1Result } from './hash'
 import {
   Authority,
   IntentState,
@@ -164,9 +164,7 @@ const hashValue = (
   failure: ShadowDecisionError['failure'],
   message: string,
 ): Result.Result<string, ShadowDecisionError> =>
-  Result.mapError(Result.try({ try: () => canonicalHashV1(value), catch: (cause) => cause }), (cause) =>
-    error(failure, message, cause),
-  )
+  Result.mapError(canonicalHashV1Result(value), (cause) => error(failure, message, cause))
 
 const compiledDecisionOf = (input: unknown): Result.Result<DecisionPlan, ShadowDecisionError> =>
   Result.mapError(decodeDecisionPlanResult(input), (cause) =>


### PR DESCRIPTION
## Summary

- totalize OBSERVE shadow-decision and durable document hashing with the closed canonical `Result` API
- retain structured canonical hash failures through continuous durable-evidence health verification and render them without exception stringification
- totalize execution-model order-outcome identity hashing while preserving deterministic fill selection and every valid output
- retain a narrow `Result.try` only around spreading caller-owned unknown material, a genuinely throwing reflection boundary, so hostile stateful proxies remain typed

## Related Issues

None

## Testing

- `bun test services/bayn/src/shadow-decision.test.ts services/bayn/src/health.test.ts services/bayn/src/execution-model.test.ts` — 31 passed, 0 failed after the review fix; 183 assertions
- hostile stateful-proxy regression proves hashing may succeed while a later `ownKeys` spread failure still returns `ShadowDecisionContractFailure`
- `node services/bayn/node_modules/typescript/bin/tsc --project services/bayn/tsconfig.json --noEmit --pretty false` — passed
- Effect diagnostics — 216 files, 0 errors, 0 warnings
- Oxfmt check for `services/bayn/src` — passed across 199 files
- Oxlint syntax and type-aware modes — passed across 216 files; focused review-fix lint also passed
- `bun test services/bayn/src` — 704 passed, 120 PostgreSQL-gated skips, 0 failed before the review-only boundary fix
- production build — 587 modules bundled successfully
- `bun test packages/scripts/src/bayn` — 20 passed, 0 failed
- verified deprecated `canonicalHashV1(...)` calls are absent from all four changed production modules

## Breaking Changes

None. Shadow document hashes, health decisions, fill selection, schemas, and operational error categories are unchanged. Canonicalization causes are narrowed to the existing closed failure contract where the total hash API applies.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable.
- [x] Breaking Changes is filled in.
- [x] Documentation and release notes are not required because durable behavior is unchanged.
