### PR TITLE
refactor(bayn): scope qualification candidate clients

### DIFF
--- a/services/bayn/src/qualification-candidate-command.ts
+++ b/services/bayn/src/qualification-candidate-command.ts
@@ -1,8 +1,11 @@
 import { NodeRuntime, NodeServices } from '@effect/platform-node'
-import { Effect } from 'effect'
+import { Effect, Layer } from 'effect'
+import * as Reactivity from 'effect/unstable/reactivity/Reactivity'
 
 import { qualificationCandidateMain } from './qualification-candidate/program'
 
 if (import.meta.main) {
-  NodeRuntime.runMain(qualificationCandidateMain.pipe(Effect.provide(NodeServices.layer)))
+  NodeRuntime.runMain(
+    qualificationCandidateMain.pipe(Effect.provide(Layer.merge(NodeServices.layer, Reactivity.layer))),
+  )
 }

--- a/services/bayn/src/qualification-candidate/live.test.ts
+++ b/services/bayn/src/qualification-candidate/live.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, test } from 'bun:test'
+import { Deferred, Effect, Fiber, Redacted, Ref } from 'effect'
+
+import { readCandidateReplica, readQualificationLocks } from './live'
+import type { CandidateConfig } from './model'
+import {
+  candidateInput,
+  candidateObservations,
+  candidatePublicationDate,
+  candidatePublisherPrincipal,
+  candidateReplicaEndpoints,
+} from './test-fixtures'
+
+const candidateConfig = (): CandidateConfig => ({
+  publicationDate: candidatePublicationDate,
+  clickhouseUrls: candidateInput().clickhouseUrls,
+  publisherUsername: candidatePublisherPrincipal,
+  publisherPassword: Redacted.make('publisher-password'),
+  postgresUrl: Redacted.make('postgresql://bayn:password@127.0.0.1:5432/bayn'),
+  postgresTls: undefined,
+  tigerBeetleClusterId: candidateInput().tigerBeetleClusterId,
+  tigerBeetleAddresses: candidateInput().tigerBeetleAddresses,
+  tigerBeetleLedger: candidateInput().tigerBeetleLedger,
+  operationTimeoutMs: 5_000,
+})
+
+describe('qualification candidate live client lifecycle', () => {
+  test('acquires and releases the ClickHouse client exactly once after a successful replica read', async () => {
+    let acquisitions = 0
+    let releases = 0
+    const observation = candidateObservations()[0]
+
+    const result = await Effect.runPromise(
+      readCandidateReplica(
+        candidateInput(),
+        candidateReplicaEndpoints[0],
+        Redacted.make('publisher-password'),
+        5_000,
+        () =>
+          Effect.acquireRelease(
+            Effect.sync(() => {
+              acquisitions += 1
+              return { read: Effect.succeed(observation) }
+            }),
+            () =>
+              Effect.sync(() => {
+                releases += 1
+              }),
+          ),
+      ),
+    )
+
+    expect(result).toEqual(observation)
+    expect(acquisitions).toBe(1)
+    expect(releases).toBe(1)
+  })
+
+  test('interrupts an in-flight ClickHouse read and releases the client exactly once', async () => {
+    const counts = await Effect.runPromise(
+      Effect.gen(function* () {
+        const started = yield* Deferred.make<void>()
+        const acquisitions = yield* Ref.make(0)
+        const releases = yield* Ref.make(0)
+        const fiber = yield* readCandidateReplica(
+          candidateInput(),
+          candidateReplicaEndpoints[0],
+          Redacted.make('publisher-password'),
+          5_000,
+          () =>
+            Effect.acquireRelease(
+              Ref.update(acquisitions, (count) => count + 1).pipe(
+                Effect.as({
+                  read: Deferred.succeed(started, undefined).pipe(Effect.andThen(Effect.never)),
+                }),
+              ),
+              () => Ref.update(releases, (count) => count + 1),
+            ),
+        ).pipe(Effect.forkChild({ startImmediately: true }))
+
+        yield* Deferred.await(started)
+        yield* Fiber.interrupt(fiber)
+        return yield* Effect.all({
+          acquisitions: Ref.get(acquisitions),
+          releases: Ref.get(releases),
+        })
+      }),
+    )
+
+    expect(counts).toEqual({ acquisitions: 1, releases: 1 })
+  })
+
+  test('acquires and releases the PostgreSQL client exactly once after a successful lock read', async () => {
+    let acquisitions = 0
+    let releases = 0
+    const observation = { transactionReadOnly: true, count: 0 }
+
+    const result = await Effect.runPromise(
+      readQualificationLocks(candidateConfig(), 'a'.repeat(64), () =>
+        Effect.acquireRelease(
+          Effect.sync(() => {
+            acquisitions += 1
+            return { read: () => Effect.succeed(observation) }
+          }),
+          () =>
+            Effect.sync(() => {
+              releases += 1
+            }),
+        ),
+      ),
+    )
+
+    expect(result).toEqual(observation)
+    expect(acquisitions).toBe(1)
+    expect(releases).toBe(1)
+  })
+
+  test('interrupts an in-flight PostgreSQL read and releases the client exactly once', async () => {
+    const counts = await Effect.runPromise(
+      Effect.gen(function* () {
+        const started = yield* Deferred.make<void>()
+        const acquisitions = yield* Ref.make(0)
+        const releases = yield* Ref.make(0)
+        const fiber = yield* readQualificationLocks(candidateConfig(), 'a'.repeat(64), () =>
+          Effect.acquireRelease(
+            Ref.update(acquisitions, (count) => count + 1).pipe(
+              Effect.as({
+                read: () => Deferred.succeed(started, undefined).pipe(Effect.andThen(Effect.never)),
+              }),
+            ),
+            () => Ref.update(releases, (count) => count + 1),
+          ),
+        ).pipe(Effect.forkChild({ startImmediately: true }))
+
+        yield* Deferred.await(started)
+        yield* Fiber.interrupt(fiber)
+        return yield* Effect.all({
+          acquisitions: Ref.get(acquisitions),
+          releases: Ref.get(releases),
+        })
+      }),
+    )
+
+    expect(counts).toEqual({ acquisitions: 1, releases: 1 })
+  })
+})

--- a/services/bayn/src/qualification-candidate/live.ts
+++ b/services/bayn/src/qualification-candidate/live.ts
@@ -1,9 +1,9 @@
 import type { ConnectionOptions } from 'node:tls'
 
-import { NodeHttpClient } from '@effect/platform-node'
 import { ClickhouseClient } from '@effect/sql-clickhouse'
 import { PgClient } from '@effect/sql-pg'
-import { Effect, FileSystem, Layer, PlatformError, Redacted } from 'effect'
+import { Context, Effect, FileSystem, Layer, PlatformError, Redacted, Scope } from 'effect'
+import * as Reactivity from 'effect/unstable/reactivity/Reactivity'
 
 import { MarketData, MarketDataLive } from '../market-data'
 import type { IsoDate } from '../schemas'
@@ -33,13 +33,13 @@ const candidateBounds = (protocol: CausalProtocol, publicationDate: IsoDate) => 
   evaluationEnd: publicationDate,
 })
 
-const clickhouseLayer = (
+const makeCandidateClickhouse = (
   input: QualificationCandidateInput,
   endpoint: CandidateReplicaEndpoint,
   password: Redacted.Redacted<string>,
   operationTimeoutMs: number,
 ) =>
-  ClickhouseClient.layer({
+  ClickhouseClient.make({
     url: endpoint.href,
     username: input.publisherPrincipal,
     password: Redacted.value(password),
@@ -47,73 +47,95 @@ const clickhouseLayer = (
     application: 'bayn-qualification-candidate',
     request_timeout: operationTimeoutMs,
     clickhouse_settings: { readonly: '1' },
-  }).pipe(Layer.provide(NodeHttpClient.layerNodeHttp))
+  })
 
-export const readCandidateReplica = (
+export interface CandidateReplicaClient<R, E> {
+  readonly read: Effect.Effect<CandidateReplicaObservation, E, Scope.Scope | R>
+}
+
+export type AcquireCandidateReplicaClient<R, AcquireError, ReadError> = (
   input: QualificationCandidateInput,
   endpoint: CandidateReplicaEndpoint,
   password: Redacted.Redacted<string>,
   operationTimeoutMs: number,
-): Effect.Effect<CandidateReplicaObservation, QualificationCandidateFailure> =>
-  Effect.flatMap(ClickhouseClient.ClickhouseClient, (sql) =>
-    Effect.all(
-      {
-        identityRows: sql`
-          SELECT hostName() AS replica, currentUser() AS principal
-        `.pipe(sql.withQueryId('bayn-candidate-replica-identity'), Effect.flatMap(decodeReplicaIdentityRows)),
-        candidateRows: sql`
-          SELECT snapshot_id, calendar_version
-          FROM signal.snapshot_manifests_v2
-          WHERE universe_id = ${sql.param('String', input.protocol.universeId)}
-            AND universe_symbol_hash = ${sql.param('String', input.protocol.universeSymbolHash)}
-            AND requested_start = toDate(${sql.param('String', input.protocol.historyStart)})
-            AND publication_asof = toDate(${sql.param('String', input.publicationDate)})
-          ORDER BY finalized_at DESC, snapshot_id DESC
-          LIMIT 1
-        `.pipe(sql.withQueryId(`bayn-candidate-select-${input.publicationDate}`), Effect.flatMap(decodeCandidateRows)),
-      },
-      { concurrency: 1 },
-    ).pipe(
-      Effect.flatMap(({ identityRows: [identity], candidateRows: [candidate] }) =>
-        MarketData.pipe(
-          Effect.provide(
-            MarketDataLive(
-              {
-                operationTimeoutMs,
-                clickhouse: {
-                  url: endpoint.href,
-                  username: input.publisherPrincipal,
-                  password,
-                  snapshotId: candidate.snapshot_id,
-                  publicationAsOf: input.publicationDate,
-                  calendarVersion: candidate.calendar_version,
-                  bounds: candidateBounds(input.protocol, input.publicationDate),
-                },
-              },
-              input.protocol,
+) => Effect.Effect<CandidateReplicaClient<R, ReadError>, AcquireError, Scope.Scope | R>
+
+const acquireCandidateReplicaClient = (
+  input: QualificationCandidateInput,
+  endpoint: CandidateReplicaEndpoint,
+  password: Redacted.Redacted<string>,
+  operationTimeoutMs: number,
+) =>
+  makeCandidateClickhouse(input, endpoint, password, operationTimeoutMs).pipe(
+    Effect.map((sql) => ({
+      read: Effect.gen(function* () {
+        const {
+          identityRows: [identity],
+          candidateRows: [candidate],
+        } = yield* Effect.all(
+          {
+            identityRows: sql`
+              SELECT hostName() AS replica, currentUser() AS principal
+            `.pipe(sql.withQueryId('bayn-candidate-replica-identity'), Effect.flatMap(decodeReplicaIdentityRows)),
+            candidateRows: sql`
+              SELECT snapshot_id, calendar_version
+              FROM signal.snapshot_manifests_v2
+              WHERE universe_id = ${sql.param('String', input.protocol.universeId)}
+                AND universe_symbol_hash = ${sql.param('String', input.protocol.universeSymbolHash)}
+                AND requested_start = toDate(${sql.param('String', input.protocol.historyStart)})
+                AND publication_asof = toDate(${sql.param('String', input.publicationDate)})
+              ORDER BY finalized_at DESC, snapshot_id DESC
+              LIMIT 1
+            `.pipe(
+              sql.withQueryId(`bayn-candidate-select-${input.publicationDate}`),
+              Effect.flatMap(decodeCandidateRows),
             ),
-          ),
-          Effect.flatMap((marketData) =>
-            marketData
-              .loadSnapshotPublication({
+          },
+          { concurrency: 1 },
+        )
+        const marketDataContext = yield* Layer.build(
+          MarketDataLive(
+            {
+              operationTimeoutMs,
+              clickhouse: {
+                url: endpoint.href,
+                username: input.publisherPrincipal,
+                password,
                 snapshotId: candidate.snapshot_id,
-                signalSessionDate: input.publicationDate,
-                signalCalendarVersion: candidate.calendar_version,
-              })
-              .pipe(
-                Effect.map((snapshot) => ({
-                  endpointHost: endpoint.hostname,
-                  replica: identity.replica,
-                  principal: identity.principal,
-                  snapshot,
-                })),
-              ),
-          ),
-        ),
-      ),
-    ),
+                publicationAsOf: input.publicationDate,
+                calendarVersion: candidate.calendar_version,
+                bounds: candidateBounds(input.protocol, input.publicationDate),
+              },
+            },
+            input.protocol,
+          ).pipe(Layer.provide(Layer.succeed(ClickhouseClient.ClickhouseClient, sql))),
+        )
+        const marketData = Context.get(marketDataContext, MarketData)
+        const snapshot = yield* marketData.loadSnapshotPublication({
+          snapshotId: candidate.snapshot_id,
+          signalSessionDate: input.publicationDate,
+          signalCalendarVersion: candidate.calendar_version,
+        })
+        return {
+          endpointHost: endpoint.hostname,
+          replica: identity.replica,
+          principal: identity.principal,
+          snapshot,
+        }
+      }),
+    })),
+  )
+
+const readCandidateReplicaWith = <R, AcquireError, ReadError>(
+  input: QualificationCandidateInput,
+  endpoint: CandidateReplicaEndpoint,
+  password: Redacted.Redacted<string>,
+  operationTimeoutMs: number,
+  acquireClient: AcquireCandidateReplicaClient<R, AcquireError, ReadError>,
+): Effect.Effect<CandidateReplicaObservation, QualificationCandidateFailure, R> =>
+  Effect.scoped(
+    acquireClient(input, endpoint, password, operationTimeoutMs).pipe(Effect.flatMap((client) => client.read)),
   ).pipe(
-    Effect.provide(clickhouseLayer(input, endpoint, password, operationTimeoutMs)),
     Effect.mapError(
       (cause): QualificationCandidateFailure => ({
         _tag: 'ReplicaReadFailed',
@@ -123,65 +145,127 @@ export const readCandidateReplica = (
     ),
   )
 
+export function readCandidateReplica(
+  input: QualificationCandidateInput,
+  endpoint: CandidateReplicaEndpoint,
+  password: Redacted.Redacted<string>,
+  operationTimeoutMs: number,
+): Effect.Effect<CandidateReplicaObservation, QualificationCandidateFailure, Reactivity.Reactivity>
+export function readCandidateReplica<R, AcquireError, ReadError>(
+  input: QualificationCandidateInput,
+  endpoint: CandidateReplicaEndpoint,
+  password: Redacted.Redacted<string>,
+  operationTimeoutMs: number,
+  acquireClient: AcquireCandidateReplicaClient<R, AcquireError, ReadError>,
+): Effect.Effect<CandidateReplicaObservation, QualificationCandidateFailure, R>
+export function readCandidateReplica<R, AcquireError, ReadError>(
+  input: QualificationCandidateInput,
+  endpoint: CandidateReplicaEndpoint,
+  password: Redacted.Redacted<string>,
+  operationTimeoutMs: number,
+  acquireClient?: AcquireCandidateReplicaClient<R, AcquireError, ReadError>,
+): Effect.Effect<CandidateReplicaObservation, QualificationCandidateFailure, R | Reactivity.Reactivity> {
+  return acquireClient === undefined
+    ? readCandidateReplicaWith(input, endpoint, password, operationTimeoutMs, acquireCandidateReplicaClient)
+    : readCandidateReplicaWith(input, endpoint, password, operationTimeoutMs, acquireClient)
+}
+
 const postgresSsl = (
   input: CandidateConfig,
 ): Effect.Effect<ConnectionOptions | undefined, PlatformError.PlatformError, FileSystem.FileSystem> => {
   const tls = input.postgresTls
-  if (tls === undefined) return Effect.succeed(undefined)
+  if (tls === undefined) return Effect.void.pipe(Effect.as(undefined))
   return Effect.flatMap(FileSystem.FileSystem, (fileSystem) =>
     fileSystem.readFileString(tls.caPath).pipe(Effect.map((ca) => makeCandidatePostgresSslOptions(tls.serverName, ca))),
   )
 }
 
-const postgresLayer = (input: CandidateConfig) =>
-  Layer.unwrap(
-    postgresSsl(input).pipe(
-      Effect.map((ssl) =>
-        PgClient.layerFrom(
-          PgClient.make({
-            url: input.postgresUrl,
-            ssl,
-            applicationName: 'bayn-qualification-candidate',
-            connectTimeout: input.operationTimeoutMs,
-            idleTimeout: '30 seconds',
-            maxConnections: 1,
-            minConnections: 0,
-            transformJson: false,
-          }),
-        ),
-      ),
+const makeCandidatePostgres = (input: CandidateConfig) =>
+  postgresSsl(input).pipe(
+    Effect.flatMap((ssl) =>
+      PgClient.make({
+        url: input.postgresUrl,
+        ssl,
+        applicationName: 'bayn-qualification-candidate',
+        connectTimeout: input.operationTimeoutMs,
+        idleTimeout: '30 seconds',
+        maxConnections: 1,
+        minConnections: 0,
+        transformJson: false,
+      }),
     ),
   )
 
-export const readQualificationLocks = (
+export interface QualificationLockClient<R, E> {
+  readonly read: (snapshotId: string) => Effect.Effect<QualificationLockObservation, E, Scope.Scope | R>
+}
+
+export type AcquireQualificationLockClient<R, AcquireError, ReadError> = (
   input: CandidateConfig,
-  snapshotId: string,
-): Effect.Effect<QualificationLockObservation, QualificationCandidateFailure, FileSystem.FileSystem> =>
-  Effect.flatMap(PgClient.PgClient, (sql) =>
-    sql.withTransaction(
-      sql`SET TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY`.pipe(
-        Effect.flatMap(() =>
-          Effect.all(
-            {
-              readOnlyRows: sql`SELECT current_setting('transaction_read_only') = 'on' AS read_only`.pipe(
-                Effect.flatMap(decodeReadOnlyRows),
+) => Effect.Effect<QualificationLockClient<R, ReadError>, AcquireError, Scope.Scope | R>
+
+const acquireQualificationLockClient = (input: CandidateConfig) =>
+  makeCandidatePostgres(input).pipe(
+    Effect.map((sql) => ({
+      read: (snapshotId: string) =>
+        sql.withTransaction(
+          sql`SET TRANSACTION ISOLATION LEVEL REPEATABLE READ READ ONLY`.pipe(
+            Effect.flatMap(() =>
+              Effect.all(
+                {
+                  readOnlyRows: sql`SELECT current_setting('transaction_read_only') = 'on' AS read_only`.pipe(
+                    Effect.flatMap(decodeReadOnlyRows),
+                  ),
+                  countRows: sql`
+                    SELECT count(*)::integer AS lock_count
+                    FROM qualification_locks
+                    WHERE snapshot_id = ${snapshotId}
+                  `.pipe(Effect.flatMap(decodeLockCountRows)),
+                },
+                { concurrency: 1 },
               ),
-              countRows: sql`
-                SELECT count(*)::integer AS lock_count
-                FROM qualification_locks
-                WHERE snapshot_id = ${snapshotId}
-              `.pipe(Effect.flatMap(decodeLockCountRows)),
-            },
-            { concurrency: 1 },
+            ),
+            Effect.map(({ readOnlyRows: [readOnly], countRows: [count] }) => ({
+              transactionReadOnly: readOnly.read_only,
+              count: count.lock_count,
+            })),
           ),
         ),
-        Effect.map(({ readOnlyRows: [readOnly], countRows: [count] }) => ({
-          transactionReadOnly: readOnly.read_only,
-          count: count.lock_count,
-        })),
-      ),
-    ),
-  ).pipe(
-    Effect.provide(postgresLayer(input)),
+    })),
+  )
+
+const readQualificationLocksWith = <R, AcquireError, ReadError>(
+  input: CandidateConfig,
+  snapshotId: string,
+  acquireClient: AcquireQualificationLockClient<R, AcquireError, ReadError>,
+): Effect.Effect<QualificationLockObservation, QualificationCandidateFailure, R> =>
+  Effect.scoped(acquireClient(input).pipe(Effect.flatMap((client) => client.read(snapshotId)))).pipe(
     Effect.mapError((cause): QualificationCandidateFailure => ({ _tag: 'PostgresReadFailed', cause })),
   )
+
+export function readQualificationLocks(
+  input: CandidateConfig,
+  snapshotId: string,
+): Effect.Effect<
+  QualificationLockObservation,
+  QualificationCandidateFailure,
+  FileSystem.FileSystem | Reactivity.Reactivity
+>
+export function readQualificationLocks<R, AcquireError, ReadError>(
+  input: CandidateConfig,
+  snapshotId: string,
+  acquireClient: AcquireQualificationLockClient<R, AcquireError, ReadError>,
+): Effect.Effect<QualificationLockObservation, QualificationCandidateFailure, R>
+export function readQualificationLocks<R, AcquireError, ReadError>(
+  input: CandidateConfig,
+  snapshotId: string,
+  acquireClient?: AcquireQualificationLockClient<R, AcquireError, ReadError>,
+): Effect.Effect<
+  QualificationLockObservation,
+  QualificationCandidateFailure,
+  R | FileSystem.FileSystem | Reactivity.Reactivity
+> {
+  return acquireClient === undefined
+    ? readQualificationLocksWith(input, snapshotId, acquireQualificationLockClient)
+    : readQualificationLocksWith(input, snapshotId, acquireClient)
+}

--- a/services/bayn/src/qualification-candidate/model.ts
+++ b/services/bayn/src/qualification-candidate/model.ts
@@ -61,13 +61,13 @@ export interface QualificationCandidateInput {
   readonly tigerBeetleLedger: string
 }
 
-export interface QualificationCandidateReaders {
+export interface QualificationCandidateReaders<R = never> {
   readonly readReplica: (
     endpoint: CandidateReplicaEndpoint,
-  ) => Effect.Effect<CandidateReplicaObservation, QualificationCandidateFailure>
+  ) => Effect.Effect<CandidateReplicaObservation, QualificationCandidateFailure, R>
   readonly readQualificationLocks: (
     snapshotId: string,
-  ) => Effect.Effect<QualificationLockObservation, QualificationCandidateFailure>
+  ) => Effect.Effect<QualificationLockObservation, QualificationCandidateFailure, R>
 }
 
 export interface QualificationCandidateReport {

--- a/services/bayn/src/qualification-candidate/program.test.ts
+++ b/services/bayn/src/qualification-candidate/program.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test'
-import { ConfigProvider, Effect } from 'effect'
+import { ConfigProvider, Context, Effect } from 'effect'
 
 import {
   QualificationCandidateError,
@@ -33,6 +33,10 @@ const failure = async (
   candidateReaders: QualificationCandidateReaders,
 ): Promise<QualificationCandidateFailure> =>
   Effect.runPromise(Effect.flip(verifyQualificationCandidate(candidateInput, candidateReaders)))
+
+class ReaderRequirement extends Context.Service<ReaderRequirement, { readonly enabled: true }>()(
+  'bayn/test/QualificationCandidateReaderRequirement',
+) {}
 
 describe('qualification candidate command', () => {
   test('converts pure failure data to one cause-preserving runtime error', () => {
@@ -265,6 +269,34 @@ describe('qualification candidate command', () => {
       'chi-torghut-clickhouse-default-0-1-0',
     ])
     expect(new Set(report.replicas.map((replica) => replica.snapshotCanonicalHash)).size).toBe(1)
+  })
+
+  test('keeps reader requirements visible until the composition boundary', async () => {
+    const readers = candidateReaders()
+    const report = await Effect.runPromise(
+      verifyQualificationCandidate(candidateInput(), {
+        readReplica: (endpoint) =>
+          ReaderRequirement.pipe(
+            Effect.flatMap((requirement) =>
+              requirement.enabled
+                ? readers.readReplica(endpoint)
+                : Effect.die(new Error('reader requirement must be enabled')),
+            ),
+          ),
+        readQualificationLocks: (snapshotId) =>
+          ReaderRequirement.pipe(
+            Effect.flatMap((requirement) =>
+              requirement.enabled
+                ? readers.readQualificationLocks(snapshotId)
+                : Effect.die(new Error('reader requirement must be enabled')),
+            ),
+          ),
+      }).pipe(Effect.provideService(ReaderRequirement, { enabled: true })),
+    )
+
+    expect(report.candidateRuntime.BAYN_SIGNAL_SNAPSHOT_ID).toBe(
+      candidateSnapshot.manifest.finalizedSnapshot.snapshotId,
+    )
   })
 
   test.each([

--- a/services/bayn/src/qualification-candidate/program.ts
+++ b/services/bayn/src/qualification-candidate/program.ts
@@ -1,4 +1,5 @@
 import { Config, Effect, FileSystem, Result, Stdio, Stream } from 'effect'
+import * as Reactivity from 'effect/unstable/reactivity/Reactivity'
 
 import { canonicalJsonV1 } from '../hash'
 import { loadDefaultProtocol } from '../protocol'
@@ -46,10 +47,14 @@ export const loadQualificationCandidateConfig = rawConfig.pipe(
   Effect.flatMap((input) => Effect.fromResult(resolveCandidateConfig(input))),
 )
 
-const readReplicaPair = (
+const readReplicaPair = <R>(
   endpoints: readonly [CandidateReplicaEndpoint, CandidateReplicaEndpoint],
-  readers: QualificationCandidateReaders,
-): Effect.Effect<readonly [CandidateReplicaObservation, CandidateReplicaObservation], QualificationCandidateFailure> =>
+  readers: QualificationCandidateReaders<R>,
+): Effect.Effect<
+  readonly [CandidateReplicaObservation, CandidateReplicaObservation],
+  QualificationCandidateFailure,
+  R
+> =>
   readers
     .readReplica(endpoints[0])
     .pipe(
@@ -58,10 +63,10 @@ const readReplicaPair = (
       ),
     )
 
-export const verifyQualificationCandidate = (
+export const verifyQualificationCandidate = <R>(
   input: QualificationCandidateInput,
-  readers: QualificationCandidateReaders,
-): Effect.Effect<QualificationCandidateReport, QualificationCandidateFailure> =>
+  readers: QualificationCandidateReaders<R>,
+): Effect.Effect<QualificationCandidateReport, QualificationCandidateFailure, R> =>
   Effect.fromResult(validateCandidateEndpoints(input.clickhouseUrls)).pipe(
     Effect.flatMap((endpoints) =>
       readReplicaPair(endpoints, readers).pipe(
@@ -87,19 +92,20 @@ const candidateInput = (input: CandidateConfig, protocol: CausalProtocol): Quali
 
 const verifyConfiguredCandidate = (
   input: CandidateConfig,
-): Effect.Effect<QualificationCandidateReport, QualificationCandidateFailure, FileSystem.FileSystem> =>
+): Effect.Effect<
+  QualificationCandidateReport,
+  QualificationCandidateFailure,
+  FileSystem.FileSystem | Reactivity.Reactivity
+> =>
   loadDefaultProtocol.pipe(
     Effect.mapError((cause): QualificationCandidateFailure => ({ _tag: 'ProtocolLoadFailed', cause })),
     Effect.flatMap((protocol) => {
       const candidate = candidateInput(input, protocol)
-      return Effect.flatMap(FileSystem.FileSystem, (fileSystem) =>
-        verifyQualificationCandidate(candidate, {
-          readReplica: (endpoint) =>
-            readCandidateReplica(candidate, endpoint, input.publisherPassword, input.operationTimeoutMs),
-          readQualificationLocks: (snapshotId) =>
-            readQualificationLocks(input, snapshotId).pipe(Effect.provideService(FileSystem.FileSystem, fileSystem)),
-        }),
-      )
+      return verifyQualificationCandidate(candidate, {
+        readReplica: (endpoint) =>
+          readCandidateReplica(candidate, endpoint, input.publisherPassword, input.operationTimeoutMs),
+        readQualificationLocks: (snapshotId) => readQualificationLocks(input, snapshotId),
+      })
     }),
   )
 


### PR DESCRIPTION
## Summary

- replace nested internal ClickHouse and PostgreSQL layer provisioning with scoped client acquisition
- propagate qualification-candidate reader requirements through the Effect environment and provide shared runtime services once at the command boundary
- preserve the exact five SQL statements, ClickHouse query IDs, sequential replica reads, repeatable-read/read-only PostgreSQL transaction, failure mapping, and report output
- add public-API lifecycle regression coverage for successful completion and interruption of both clients, including exactly-once release

## Related Issues

None

## Testing

- `bun services/bayn/node_modules/typescript/bin/tsc --noEmit -p services/bayn/tsconfig.json` — passed
- Effect TSGo diagnostics — 218 files checked, 0 errors, warnings, or messages
- Oxfmt — 222 files checked, passed
- standard Oxlint — 0 warnings or errors
- type-aware Oxlint — 0 warnings or errors
- focused qualification-candidate lifecycle and command tests — 31 passed, 0 failed
- `bun test` from `services/bayn` — 727 passed, 120 PostgreSQL-gated skipped, 0 failed
- production build — 587 modules bundled successfully
- `bun test packages/scripts/src/bayn` — 20 passed, 0 failed
- PostgreSQL 18 scoped-reader check — repeatable-read/read-only evidence was true, expected qualification lock count was 1, and 0 `bayn-qualification-candidate` connections remained after scope closure
- normalized SQL equivalence audit — 5 original statements, 5 refactored statements, no missing or extra statements; query IDs unchanged

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is handled above.
- [x] Documentation, release notes, and follow-ups are not required for this internal refactor.
- [x] Resource finalization is owned by `Effect.scoped` and runtime requirements remain visible in the Effect environment.
- [x] Completion and interruption each release both scoped client types exactly once.
- [x] SQL, query ordering, transaction semantics, failure classification, and public report output remain unchanged.
