### PR TITLE
refactor(bayn): totalize runtime provenance

### DIFF
--- a/services/bayn/src/audit/audit.ts
+++ b/services/bayn/src/audit/audit.ts
@@ -1,6 +1,6 @@
 import { Result, Schema } from 'effect'
 
-import { makeRuntimeProvenance } from '../contracts'
+import { makeRuntimeProvenanceResult, type ContractConstructionFailure, type RuntimeProvenance } from '../contracts'
 import { ReconciliationResultSchema } from '../evidence-contracts'
 import { canonicalHashV1 } from '../hash'
 import type { QualificationLock, QualificationResult } from '../qualification'
@@ -232,6 +232,7 @@ export const validateSignalReplicaTopology = (
 
 export type QualificationAuditFailure =
   | ReferenceEvaluationFailure
+  | ContractConstructionFailure
   | {
       readonly _tag: 'UnsupportedAuditStrategyContract'
       readonly protocolStrategyName: string
@@ -387,7 +388,7 @@ interface QualificationAuditFacts {
   readonly result: QualificationResult
   readonly reference: ReferenceEvaluation
   readonly trace: SimulationTrace
-  readonly provenance: ReturnType<typeof makeRuntimeProvenance>
+  readonly provenance: RuntimeProvenance
   readonly policyDocuments: ReturnType<typeof makePolicyDocuments>
   readonly sortedReplicas: readonly string[]
   readonly replicaSet: ReadonlySet<string>
@@ -440,7 +441,7 @@ const makeAuditFacts = (
       requiredSchemaVersion: 'bayn.risk-balanced-trend.protocol.v3',
     })
   }
-  const provenance = makeRuntimeProvenance({
+  const provenanceResult = makeRuntimeProvenanceResult({
     sourceRevision: database.run.sourceRevision,
     image: { repository: database.run.imageRepository, digest: database.run.imageDigest },
     strategy: {
@@ -450,6 +451,8 @@ const makeAuditFacts = (
       parameterSchemaVersion: database.protocol.schemaVersion,
     },
   })
+  if (Result.isFailure(provenanceResult)) return Result.fail(provenanceResult.failure)
+  const provenance = provenanceResult.success
   const referenceResult = evaluateReference(input.bars, input.manifest, input.protocol, provenance)
   if (Result.isFailure(referenceResult)) return Result.fail(referenceResult.failure)
   const reference = referenceResult.success

--- a/services/bayn/src/contracts.test.ts
+++ b/services/bayn/src/contracts.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 
-import { Effect, Exit, Schema } from 'effect'
+import { Effect, Exit, Result, Schema } from 'effect'
 
 import {
   FinalizedSnapshotProvenanceSchema,
@@ -10,6 +10,7 @@ import {
   decodeRunIdentity,
   decodeRuntimeProvenance,
   makeRunIdentity,
+  makeRuntimeProvenanceResult,
 } from './contracts'
 import { fixtureProtocol, makeSnapshot, makeTestProvenance } from './test-fixtures'
 
@@ -73,6 +74,15 @@ describe('current contracts', () => {
 
   test('accepts current and immutable historical runtime provenance', async () => {
     const provenance = makeTestProvenance()
+    expect(
+      Result.getOrThrow(
+        makeRuntimeProvenanceResult({
+          sourceRevision: provenance.sourceRevision,
+          image: provenance.image,
+          strategy: provenance.strategy,
+        }),
+      ),
+    ).toEqual(provenance)
     expect(await Effect.runPromise(decodeRuntimeProvenance(provenance))).toEqual(provenance)
     expect(provenance).toMatchObject({
       schemaVersion: 'bayn.runtime-provenance.v2',
@@ -105,5 +115,22 @@ describe('current contracts', () => {
         strategy: { ...provenance.strategy, name: 'tsmom', parameterSchemaVersion: 'bayn.tsmom.protocol.v2' },
       }),
     )
+  })
+
+  test('returns malformed runtime provenance as a typed construction failure', () => {
+    const provenance = makeTestProvenance()
+    const result = makeRuntimeProvenanceResult({
+      sourceRevision: 'not-a-revision',
+      image: provenance.image,
+      strategy: provenance.strategy,
+    } as never)
+
+    expect(Result.isFailure(result)).toBe(true)
+    if (Result.isFailure(result)) {
+      expect(result.failure).toMatchObject({
+        _tag: 'ContractSchemaInvalid',
+        operation: 'runtime-provenance',
+      })
+    }
   })
 })

--- a/services/bayn/src/contracts.ts
+++ b/services/bayn/src/contracts.ts
@@ -204,7 +204,7 @@ export type ContractConstructionFailure =
     }
   | {
       readonly _tag: 'ContractSchemaInvalid'
-      readonly operation: 'run-identity' | 'run-identity-material'
+      readonly operation: 'run-identity' | 'run-identity-material' | 'runtime-provenance'
       readonly cause: Schema.SchemaError
     }
 
@@ -235,9 +235,9 @@ export const decodeRuntimeProvenance = Schema.decodeUnknownEffect(RuntimeProvena
 
 const decodeRunIdentityMaterialSync = Schema.decodeUnknownSync(RunIdentityMaterialSchema, StrictParseOptions)
 const decodeRunIdentitySync = Schema.decodeUnknownSync(RunIdentitySchema, StrictParseOptions)
-const decodeRuntimeProvenanceSync = Schema.decodeUnknownSync(RuntimeProvenanceSchema, StrictParseOptions)
 const decodeRunIdentityMaterialResult = Schema.decodeUnknownResult(RunIdentityMaterialSchema, StrictParseOptions)
 const decodeRunIdentityResult = Schema.decodeUnknownResult(RunIdentitySchema, StrictParseOptions)
+const decodeRuntimeProvenanceResult = Schema.decodeUnknownResult(RuntimeProvenanceSchema, StrictParseOptions)
 
 export const makeRunIdentity = (input: RunIdentityMaterial): RunIdentity => {
   const material = decodeRunIdentityMaterialSync(input)
@@ -282,16 +282,29 @@ export const makeRunIdentityResult = (
     ),
   )
 
-export const makeRuntimeProvenance = (input: RuntimeProvenanceInput): RuntimeProvenance => {
-  return decodeRuntimeProvenanceSync({
-    schemaVersion: 'bayn.runtime-provenance.v2',
-    ...input,
-    contractVersions: {
-      runtimeProvenance: 'bayn.runtime-provenance.v2',
-      inputManifest: 'bayn.input-manifest.v3',
-      evaluation: ContractVersion.Evaluation,
-    },
-  })
-}
+export const makeRuntimeProvenanceResult = (
+  input: RuntimeProvenanceInput,
+): Result.Result<RuntimeProvenance, ContractConstructionFailure> =>
+  pipe(
+    decodeRuntimeProvenanceResult({
+      schemaVersion: 'bayn.runtime-provenance.v2',
+      ...input,
+      contractVersions: {
+        runtimeProvenance: 'bayn.runtime-provenance.v2',
+        inputManifest: 'bayn.input-manifest.v3',
+        evaluation: ContractVersion.Evaluation,
+      },
+    }),
+    Result.mapError(
+      (cause): ContractConstructionFailure => ({
+        _tag: 'ContractSchemaInvalid',
+        operation: 'runtime-provenance',
+        cause,
+      }),
+    ),
+  )
+
+export const makeRuntimeProvenance = (input: RuntimeProvenanceInput): RuntimeProvenance =>
+  Result.getOrThrow(makeRuntimeProvenanceResult(input))
 
 export { IsoDateSchema, Sha256Schema } from './schemas'

--- a/services/bayn/src/entrypoint.ts
+++ b/services/bayn/src/entrypoint.ts
@@ -7,7 +7,12 @@ import { riskBalancedTrendBehaviorHash } from './behavior'
 import { BrokerRead, live as AlpacaReadLive, scopedReadAdapterLayer, type BrokerReadShape } from './broker/alpaca'
 import { verifyBehaviorHash, verifyParameterHash } from './build'
 import { loadConfig, type LoadedRuntimeConfig } from './config'
-import { makeRuntimeProvenance, makeStrategyProtocolHashResult, type ContractConstructionFailure } from './contracts'
+import {
+  makeRuntimeProvenanceResult,
+  makeStrategyProtocolHashResult,
+  type ContractConstructionFailure,
+  type RuntimeProvenance,
+} from './contracts'
 import { CycleObservabilityLive } from './db/cycle-observability'
 import { CycleStoreLive } from './db/cycle-store'
 import { EvidenceStoreFromPostgres, PostgresClientLive } from './db/evidence-store'
@@ -70,7 +75,7 @@ type RuntimeSeed = {
 
 type ParameterizedRuntime = RuntimeSeed & { readonly parameterHash: string }
 type ProvenanceRuntime = ParameterizedRuntime & {
-  readonly provenance: ReturnType<typeof makeRuntimeProvenance>
+  readonly provenance: RuntimeProvenance
 }
 type StrategyRuntime = ProvenanceRuntime & { readonly strategy: Strategy }
 
@@ -85,26 +90,25 @@ const addRuntimeProvenance = (
   parameterized: ParameterizedRuntime,
 ): Result.Result<ProvenanceRuntime, RuntimeIdentityFailure> =>
   pipe(
-    Result.try({
-      try: () =>
-        makeRuntimeProvenance({
-          sourceRevision: parameterized.config.build.sourceRevision,
-          image: {
-            repository: parameterized.config.build.imageRepository,
-            digest: parameterized.config.build.imageDigest,
-          },
-          strategy: {
-            name: 'risk-balanced-trend',
-            behaviorHash: riskBalancedTrendBehaviorHash,
-            parameterHash: parameterized.parameterHash,
-            parameterSchemaVersion: parameterized.protocol.schemaVersion,
-          },
-        }),
-      catch: (cause): RuntimeIdentityFailure => ({
+    makeRuntimeProvenanceResult({
+      sourceRevision: parameterized.config.build.sourceRevision,
+      image: {
+        repository: parameterized.config.build.imageRepository,
+        digest: parameterized.config.build.imageDigest,
+      },
+      strategy: {
+        name: 'risk-balanced-trend',
+        behaviorHash: riskBalancedTrendBehaviorHash,
+        parameterHash: parameterized.parameterHash,
+        parameterSchemaVersion: parameterized.protocol.schemaVersion,
+      },
+    }),
+    Result.mapError(
+      (cause): RuntimeIdentityFailure => ({
         _tag: 'RuntimeProvenanceFailed',
         cause,
       }),
-    }),
+    ),
     Result.map((provenance) => ({ ...parameterized, provenance })),
   )
 

--- a/services/bayn/src/startup.test.ts
+++ b/services/bayn/src/startup.test.ts
@@ -184,6 +184,11 @@ describe('Bayn startup pure decisions', () => {
             ? 'stored qualification provenance is invalid: stored evaluation uses an unsupported strategy contract'
             : expect.stringContaining('stored qualification provenance is invalid:'),
       })
+      if (reason === 'malformed') {
+        const rendered = renderStartupDecisionFailure(failure).message
+        expect(rendered).not.toContain('[object Object]')
+        expect(rendered).toContain('sourceRevision')
+      }
     }
   })
 

--- a/services/bayn/src/startup.ts
+++ b/services/bayn/src/startup.ts
@@ -1,7 +1,7 @@
 import { Effect, Option, pipe, Ref, Result } from 'effect'
 
 import type { RuntimeConfig } from './config'
-import { makeRuntimeProvenance, makeStrategyProtocolHash, type RuntimeProvenance } from './contracts'
+import { makeRuntimeProvenanceResult, makeStrategyProtocolHash, type RuntimeProvenance } from './contracts'
 import {
   EvidenceStore,
   type EvidenceStoreService,
@@ -519,24 +519,25 @@ const provenanceFromStored = (
     stored.protocol.schemaVersion === 'bayn.risk-balanced-trend.protocol.v2'
       ? 'bayn.risk-balanced-trend.protocol.v2'
       : 'bayn.risk-balanced-trend.protocol.v3'
-  const provenanceResult = Result.try({
-    try: () =>
-      makeRuntimeProvenance({
-        sourceRevision: stored.run.sourceRevision,
-        image: { repository: stored.run.imageRepository, digest: stored.run.imageDigest },
-        strategy: {
-          name: 'risk-balanced-trend',
-          behaviorHash: stored.protocol.behaviorHash,
-          parameterHash: stored.protocol.parameterHash,
-          parameterSchemaVersion,
-        },
-      }),
-    catch: (cause): StartupDecisionFailure => ({
-      _tag: 'StoredProvenanceInvalid',
-      identity,
-      issue: { reason: 'malformed', cause },
+  const provenanceResult = pipe(
+    makeRuntimeProvenanceResult({
+      sourceRevision: stored.run.sourceRevision,
+      image: { repository: stored.run.imageRepository, digest: stored.run.imageDigest },
+      strategy: {
+        name: 'risk-balanced-trend',
+        behaviorHash: stored.protocol.behaviorHash,
+        parameterHash: stored.protocol.parameterHash,
+        parameterSchemaVersion,
+      },
     }),
-  })
+    Result.mapError(
+      (cause): StartupDecisionFailure => ({
+        _tag: 'StoredProvenanceInvalid',
+        identity,
+        issue: { reason: 'malformed', cause },
+      }),
+    ),
+  )
   if (Result.isFailure(provenanceResult)) return provenanceResult
   const provenance = provenanceResult.success
   const parameterHashResult = canonicalStartupHash(

--- a/services/bayn/src/startup.ts
+++ b/services/bayn/src/startup.ts
@@ -534,7 +534,7 @@ const provenanceFromStored = (
       (cause): StartupDecisionFailure => ({
         _tag: 'StoredProvenanceInvalid',
         identity,
-        issue: { reason: 'malformed', cause },
+        issue: { reason: 'malformed', cause: cause.cause },
       }),
     ),
   )


### PR DESCRIPTION
## Summary

- add a total `makeRuntimeProvenanceResult` contract constructor
- remove the synchronous runtime-provenance decoder from production construction
- route startup recovery, runtime composition, and qualification audit through the typed constructor
- preserve the throwing helper only as a compatibility alias used by test fixtures
- retain exact provenance bytes, contract versions, hashes, and existing failure classifications

## Related Issues

None.

## Testing

- focused contracts/startup/audit/app/config tests — 128 passed, 0 failed
- `bun run --filter @proompteng/bayn test` — 710 passed, 120 integration-gated skipped, 0 failed
- `bun node_modules/typescript/bin/tsc --noEmit -p services/bayn/tsconfig.json` — passed
- Effect diagnostics — 216 files, 0 errors, warnings, or messages
- Oxfmt check for `services/bayn/src` — passed
- Oxlint syntax and type-aware modes for `services/bayn` — passed
- production build — 587 modules bundled successfully
- `bun test packages/scripts/src/bayn` — 20 passed, 0 failed
- verified `decodeRuntimeProvenanceSync` is absent and no production caller uses the compatibility constructor

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable.
- [x] Breaking Changes is filled in.
- [x] Documentation, release notes, and follow-ups are not required for this internal refactor.
- [x] Runtime provenance bytes, contract versions, failure presentation, and audit output remain unchanged.
- [x] Production provenance construction remains in the closed `Result` / `Effect` failure channels.
