### PR TITLE
refactor(bayn): close evidence boundary failures

### DIFF
--- a/services/bayn/src/accounting/domain.test.ts
+++ b/services/bayn/src/accounting/domain.test.ts
@@ -207,25 +207,28 @@ describe('paper accounting', () => {
   })
 
   test('returns parse and canonicalization defects as concrete failure data', () => {
-    const malformed = Result.try(() =>
-      prepareAccounting(eventId, fill(), { quantityMicros: 'invalid', costMicros: '0' }, 7001),
+    expect(failureOf(prepareAccounting(eventId, fill(), { quantityMicros: 'invalid', costMicros: '0' }, 7001))).toEqual(
+      {
+        _tag: 'AccountingMicrosParseFailed',
+        field: 'position.quantityMicros',
+        value: 'invalid',
+      },
     )
-    assert(Result.isSuccess(malformed), 'accounting must not throw for malformed micros')
-    expect(failureOf(malformed.success)).toMatchObject({
+    expect(failureOf(prepareAccounting(eventId, fill(), { quantityMicros: '+1', costMicros: '0' }, 7001))).toEqual({
       _tag: 'AccountingMicrosParseFailed',
       field: 'position.quantityMicros',
-      value: 'invalid',
-      cause: expect.any(SyntaxError),
+      value: '+1',
     })
 
-    const invalidUnicode = Result.try(() =>
-      prepareAccounting(eventId, fill({ accountId: '\ud800' }), emptyPosition, 7001),
-    )
-    assert(Result.isSuccess(invalidUnicode), 'accounting must not throw for invalid canonical material')
-    expect(failureOf(invalidUnicode.success)).toMatchObject({
+    expect(failureOf(prepareAccounting(eventId, fill({ accountId: '\ud800' }), emptyPosition, 7001))).toMatchObject({
       _tag: 'AccountingCanonicalizationFailed',
       operation: 'transaction-content',
-      cause: expect.any(TypeError),
+      cause: {
+        _tag: 'CanonicalJsonFailure',
+        path: '$.accountId',
+        reason: 'invalid-unicode-surrogate',
+        actualType: 'string',
+      },
     })
   })
 

--- a/services/bayn/src/accounting/domain.ts
+++ b/services/bayn/src/accounting/domain.ts
@@ -2,7 +2,7 @@ import type { Account, Transfer } from 'tigerbeetle-node'
 import { AccountFlags } from 'tigerbeetle-node'
 import { pipe, Result } from 'effect'
 
-import { canonicalHashV1, stableU128, stableU64 } from '../hash'
+import { canonicalHashV1Result, stableU128, stableU64 } from '../hash'
 import { AccountCode, hashLedgerPlan, LEDGER_SCHEMA_VERSION, TransferCode, type LedgerPlan } from '../ledger-plan'
 import { OrderSide, type Fill } from '../paper'
 import { roundUnsignedHalfUp } from '../unsigned-round-half-up'
@@ -51,11 +51,12 @@ type AccountSpec = {
 
 const failAccounting = (failure: AccountingFailure): Result.Result<never, AccountingFailure> => Result.fail(failure)
 
+const canonicalIntegerPattern = /^(?:0|-?[1-9][0-9]*)$/
+
 const parseMicros = (field: AccountingMicrosField, value: string): Result.Result<bigint, AccountingFailure> =>
-  Result.mapError(
-    Result.try(() => BigInt(value)),
-    (cause) => ({ _tag: 'AccountingMicrosParseFailed', field, value, cause }),
-  )
+  canonicalIntegerPattern.test(value)
+    ? Result.succeed(BigInt(value))
+    : failAccounting({ _tag: 'AccountingMicrosParseFailed', field, value })
 
 const parseAccountingInput = (
   fill: Fill,
@@ -309,10 +310,11 @@ const hashAccountingMaterial = (
   operation: AccountingHashOperation,
   material: unknown,
 ): Result.Result<string, AccountingFailure> =>
-  Result.mapError(
-    Result.try(() => canonicalHashV1(material)),
-    (cause) => ({ _tag: 'AccountingCanonicalizationFailed', operation, cause }),
-  )
+  Result.mapError(canonicalHashV1Result(material), (cause) => ({
+    _tag: 'AccountingCanonicalizationFailed',
+    operation,
+    cause,
+  }))
 
 const hashAccountingLedgerPlan = (plan: LedgerPlan): Result.Result<string, AccountingFailure> =>
   Result.mapError(

--- a/services/bayn/src/accounting/failure.ts
+++ b/services/bayn/src/accounting/failure.ts
@@ -1,5 +1,6 @@
 import type { Schema } from 'effect'
 
+import type { CanonicalHashFailure } from '../hash'
 import type { UnsignedRoundHalfUpFailure } from '../unsigned-round-half-up'
 
 export type AccountingMicrosField =
@@ -16,7 +17,6 @@ export type AccountingFailure =
       readonly _tag: 'AccountingMicrosParseFailed'
       readonly field: AccountingMicrosField
       readonly value: string
-      readonly cause: unknown
     }
   | {
       readonly _tag: 'AccountingUnsignedDivisionFailed'
@@ -45,7 +45,12 @@ export type AccountingFailure =
     }
   | {
       readonly _tag: 'AccountingCanonicalizationFailed'
-      readonly operation: AccountingHashOperation
+      readonly operation: Exclude<AccountingHashOperation, 'ledger-plan'>
+      readonly cause: CanonicalHashFailure
+    }
+  | {
+      readonly _tag: 'AccountingCanonicalizationFailed'
+      readonly operation: 'ledger-plan'
       readonly cause: unknown
     }
   | {

--- a/services/bayn/src/market-data-verification.ts
+++ b/services/bayn/src/market-data-verification.ts
@@ -1,7 +1,7 @@
 import { Result, Schema, pipe } from 'effect'
 
 import { type EvaluationBounds, type FinalizedSnapshotProvenance, FinalizedSnapshotProvenanceSchema } from './contracts'
-import { canonicalHashV1, sha256 } from './hash'
+import { canonicalHashV1Result, sha256, type CanonicalHashFailure } from './hash'
 import { strictParseOptions } from './schemas'
 import {
   type FinalizedPublicationRequest,
@@ -122,7 +122,7 @@ export type MarketDataVerificationError =
       readonly _tag: 'CanonicalizationFailed'
       readonly target: 'bars' | 'input-manifest' | 'manifest' | 'sessions' | 'snapshot-identity'
       readonly snapshotId: string
-      readonly cause: unknown
+      readonly cause: CanonicalHashFailure
     }
   | {
       readonly _tag: 'SessionFieldMismatch'
@@ -237,15 +237,15 @@ const canonicalHashResult = (
   snapshotId: string,
   value: unknown,
 ): Result.Result<string, MarketDataVerificationError> =>
-  Result.try({
-    try: () => canonicalHashV1(value),
-    catch: (cause): MarketDataVerificationError => ({
+  Result.mapError(
+    canonicalHashV1Result(value),
+    (cause): MarketDataVerificationError => ({
       _tag: 'CanonicalizationFailed',
       target,
       snapshotId,
       cause,
     }),
-  })
+  )
 
 export const decodeSignalCount = (
   value: string | number,

--- a/services/bayn/src/paper-candidate-discovery/failure.test.ts
+++ b/services/bayn/src/paper-candidate-discovery/failure.test.ts
@@ -1,0 +1,34 @@
+import { expect, test } from 'bun:test'
+
+import { Result } from 'effect'
+
+import { canonicalHashResult, type PaperCandidateDiscoveryError } from './failure'
+
+test('paper candidate hashing retains closed canonical failure facts', () => {
+  const result = canonicalHashResult(
+    { cycleId: '\ud800' },
+    (cause): PaperCandidateDiscoveryError => ({
+      _tag: 'BindingHashFailed',
+      failure: 'output',
+      cycleId: 'cycle-1',
+      documentContentHash: 'a'.repeat(64),
+      cause,
+    }),
+  )
+
+  expect(Result.isFailure(result)).toBe(true)
+  if (Result.isFailure(result)) {
+    expect(result.failure).toEqual({
+      _tag: 'BindingHashFailed',
+      failure: 'output',
+      cycleId: 'cycle-1',
+      documentContentHash: 'a'.repeat(64),
+      cause: {
+        _tag: 'CanonicalJsonFailure',
+        path: '$.cycleId',
+        reason: 'invalid-unicode-surrogate',
+        actualType: 'string',
+      },
+    })
+  }
+})

--- a/services/bayn/src/paper-candidate-discovery/failure.ts
+++ b/services/bayn/src/paper-candidate-discovery/failure.ts
@@ -1,6 +1,6 @@
 import { Result } from 'effect'
 
-import { canonicalHashV1 } from '../hash'
+import { canonicalHashV1Result, type CanonicalHashFailure } from '../hash'
 import { Authority, RiskOutcome } from '../paper'
 
 export type PaperCandidateDiscoveryError =
@@ -310,7 +310,7 @@ export type PaperCandidateDiscoveryError =
       readonly failure: 'output'
       readonly cycleId: string
       readonly documentContentHash: string
-      readonly cause: unknown
+      readonly cause: CanonicalHashFailure
     }
   | {
       readonly _tag: 'CandidateFactsDecodeFailed'
@@ -324,14 +324,14 @@ export type PaperCandidateDiscoveryError =
       readonly failure: 'output'
       readonly immutableBindingHash: string
       readonly candidateCount: number
-      readonly cause: unknown
+      readonly cause: CanonicalHashFailure
     }
   | {
       readonly _tag: 'ReceiptHashFailed'
       readonly failure: 'output'
       readonly schemaVersion: string
       readonly candidateFactsHash: string
-      readonly cause: unknown
+      readonly cause: CanonicalHashFailure
     }
   | {
       readonly _tag: 'ReceiptDecodeFailed'
@@ -494,9 +494,5 @@ export const requireValue = <A>(
 
 export const canonicalHashResult = (
   value: unknown,
-  onFailure: (cause: unknown) => PaperCandidateDiscoveryError,
-): Result.Result<string, PaperCandidateDiscoveryError> =>
-  Result.try({
-    try: () => canonicalHashV1(value),
-    catch: onFailure,
-  })
+  onFailure: (cause: CanonicalHashFailure) => PaperCandidateDiscoveryError,
+): Result.Result<string, PaperCandidateDiscoveryError> => Result.mapError(canonicalHashV1Result(value), onFailure)


### PR DESCRIPTION
## Summary

- totalize finalized Signal snapshot canonicalization and retain closed `CanonicalHashFailure` evidence for manifest, calendar, bars, and input-manifest identities
- totalize paper-candidate binding, candidate-facts, and receipt hashes without exception-derived expected failures
- recognize canonical signed accounting micros before `BigInt` conversion and totalize transaction identity/content hashing
- retain the existing guarded ledger-plan compatibility adapter until that public hash API becomes total; no ledger implementation files are changed

## Related Issues

None

## Testing

- `bun test services/bayn/src/market-data.test.ts services/bayn/src/paper-candidate-discovery/failure.test.ts services/bayn/src/accounting/domain.test.ts` — 33 passed, 0 failed before and after rebase
- publisher compatibility, accounting transaction identity goldens, and deterministic replay remain unchanged
- new candidate-discovery regression verifies exact closed canonical failure facts
- new accounting regression rejects non-canonical `+1` integer spelling before conversion
- TypeScript — passed
- Effect diagnostics — 217 files, 0 errors, 0 warnings
- Oxfmt — 200 files passed
- Oxlint syntax and type-aware modes — 217 files, 0 errors, 0 warnings
- full Bayn suite — 710 passed, 120 PostgreSQL-gated skips, 0 failed
- production build — 587 modules bundled successfully
- Bayn manifest tests — 20 passed, 0 failed

## Breaking Changes

None for valid durable data. Existing valid hashes, accounting transactions, ledger plans, and market-data identities are unchanged. Malformed accounting micros using non-canonical signs or leading forms now fail through `AccountingMicrosParseFailed` instead of being accepted by JavaScript `BigInt` coercion.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable.
- [x] Breaking Changes is filled in.
- [x] Documentation and release notes are not required because valid durable behavior is unchanged.
