### PR TITLE
refactor(bayn): totalize reference identities

### DIFF
--- a/services/bayn/src/audit/reference.ts
+++ b/services/bayn/src/audit/reference.ts
@@ -1,6 +1,11 @@
 import { pipe, Result } from 'effect'
 
-import { makeRunIdentity, makeStrategyProtocolHash, type RuntimeProvenance } from '../contracts'
+import {
+  makeRunIdentityResult,
+  makeStrategyProtocolHashResult,
+  type ContractConstructionFailure,
+  type RuntimeProvenance,
+} from '../contracts'
 import {
   MICROS,
   accrueCashYield,
@@ -19,7 +24,7 @@ import {
   type FeeInput,
   type FillTerms,
 } from '../execution-model'
-import { canonicalHashV1 } from '../hash'
+import { canonicalHashV1, canonicalHashV1Result, type CanonicalHashFailure } from '../hash'
 import type {
   CashChange,
   DailyBar,
@@ -106,6 +111,8 @@ interface ReferenceEvaluationWithWork {
 
 export type ReferenceEvaluationFailure =
   | ExecutionModelFailure
+  | ContractConstructionFailure
+  | CanonicalHashFailure
   | {
       readonly _tag: 'UnsupportedReferenceExecutionModel'
       readonly actual: string
@@ -1565,7 +1572,9 @@ const evaluateReferenceWithWork = (
     })
   }
 
-  const parameterHash = canonicalHashV1(protocol)
+  const parameterHashResult = canonicalHashV1Result(protocol)
+  if (Result.isFailure(parameterHashResult)) return Result.fail(parameterHashResult.failure)
+  const parameterHash = parameterHashResult.success
   const strategyIdentity = {
     name: provenance.strategy.name,
     behaviorHash: provenance.strategy.behaviorHash,
@@ -1581,7 +1590,7 @@ const evaluateReferenceWithWork = (
       actualParameterHash: provenance.strategy.parameterHash,
     })
   }
-  const runId = makeRunIdentity({
+  const runIdentityResult = makeRunIdentityResult({
     schemaVersion: 'bayn.run-identity.v1',
     sourceRevision: provenance.sourceRevision,
     image: provenance.image,
@@ -1593,8 +1602,12 @@ const evaluateReferenceWithWork = (
     finalizedSnapshot: manifest.finalizedSnapshot,
     calendarVersion: manifest.finalizedSnapshot.calendarVersion,
     bounds: manifest.bounds,
-  }).runId
-  const protocolHash = makeStrategyProtocolHash(strategyIdentity)
+  })
+  if (Result.isFailure(runIdentityResult)) return Result.fail(runIdentityResult.failure)
+  const protocolHashResult = makeStrategyProtocolHashResult(strategyIdentity)
+  if (Result.isFailure(protocolHashResult)) return Result.fail(protocolHashResult.failure)
+  const runId = runIdentityResult.success.runId
+  const protocolHash = protocolHashResult.success
   const candidateTargetsResult = Result.all(
     eligibleSignals.map((signalIndex) =>
       pipe(

--- a/services/bayn/src/qualification-reference.test.ts
+++ b/services/bayn/src/qualification-reference.test.ts
@@ -251,6 +251,19 @@ describe('independent qualification reference', () => {
       assertFailure(evaluateReference(snapshot.bars, snapshot.manifest, fixtureProtocol, changedProvenance))._tag,
     ).toBe('ReferenceProvenanceMismatch')
 
+    const malformedIdentityProvenance = {
+      ...makeTestProvenance(),
+      sourceRevision: 'not-a-source-revision',
+    }
+    expect(
+      assertFailure(
+        evaluateReference(snapshot.bars, snapshot.manifest, fixtureProtocol, malformedIdentityProvenance as never),
+      ),
+    ).toMatchObject({
+      _tag: 'ContractSchemaInvalid',
+      operation: 'run-identity-material',
+    })
+
     const noSignalManifest = {
       ...snapshot.manifest,
       bounds: {


### PR DESCRIPTION
## Summary

- route independent reference parameter hashing through `canonicalHashV1Result`
- derive reference run identity and strategy protocol hash through the closed contract constructors
- propagate canonicalization and schema facts through `ReferenceEvaluationFailure` instead of invoking throwing compatibility aliases
- preserve every valid run ID, protocol hash, replay artifact, and audit verdict
- add malformed reconstructed provenance coverage

## Related Issues

None.

## Testing

- `bun test services/bayn/src/qualification-reference.test.ts services/bayn/src/qualification-audit.test.ts` — 32 passed, 0 failed
- `bun run --filter @proompteng/bayn test` — 709 passed, 120 integration-gated skipped, 0 failed
- `bun node_modules/typescript/bin/tsc --noEmit -p services/bayn/tsconfig.json` — passed
- Effect diagnostics — 216 files, 0 errors, warnings, or messages
- Oxfmt check for `services/bayn/src` — passed
- Oxlint syntax and type-aware modes for `services/bayn` — passed
- production build — 587 modules bundled successfully
- `bun test packages/scripts/src/bayn` — 20 passed, 0 failed
- verified `audit/reference.ts` no longer calls `makeRunIdentity` or `makeStrategyProtocolHash`

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable.
- [x] Breaking Changes is filled in.
- [x] Documentation, release notes, and follow-ups are not required for this internal refactor.
- [x] Golden run identity, protocol identity, replay output, audit ordering, and audit verdicts are unchanged.
- [x] Reconstructed identity failures remain in the closed `Result` algebra.
