### PR TITLE
refactor(bayn): totalize cycle date ranges

### DIFF
--- a/services/bayn/src/cycle-runner.test.ts
+++ b/services/bayn/src/cycle-runner.test.ts
@@ -826,19 +826,31 @@ describe('autonomous cycle runner', () => {
     if (malformedNonLatest.failure._tag !== 'CyclePublicationDateInvalid') {
       throw new Error('malformed publication fixture must retain its date failure')
     }
-    expect(malformedNonLatest.failure.cause).toBeInstanceOf(RangeError)
-    if (!(malformedNonLatest.failure.cause instanceof RangeError)) {
-      throw new Error('malformed publication cause must remain a RangeError')
-    }
-    expect(malformedNonLatest.failure.cause.message).toBe('Invalid Date')
+    expect(malformedNonLatest.failure.cause).toEqual({
+      _tag: 'IsoDateInputInvalid',
+      date: '0000-00-00',
+      epochMillis: Number.NaN,
+    })
 
     const malformedQuery = marketCalendarQueryForSignal('0000-00-00')
     if (Result.isSuccess(malformedQuery)) throw new Error('malformed query fixture must fail')
-    expect(malformedQuery.failure.cause).toBeInstanceOf(RangeError)
-    if (!(malformedQuery.failure.cause instanceof RangeError)) {
-      throw new Error('malformed query cause must remain a RangeError')
-    }
-    expect(malformedQuery.failure.cause.message).toBe('Invalid Date')
+    expect(malformedQuery.failure.cause).toEqual({
+      _tag: 'IsoDateInputInvalid',
+      date: '0000-00-00',
+      epochMillis: Number.NaN,
+    })
+    expect(marketCalendarQueryForSignal('2026-02-30')).toEqual(
+      Result.fail({
+        _tag: 'CycleCalendarQueryRangeOutOfRange',
+        signalSessionDate: '2026-02-30',
+        offsetDays: 30,
+        cause: {
+          _tag: 'IsoDateInputNotCanonical',
+          date: '2026-02-30',
+          normalized: '2026-03-02T00:00:00.000Z',
+        },
+      }),
+    )
   })
 
   test('classifies publication discovery as a pure typed decision before dependency reads', () => {

--- a/services/bayn/src/cycle-runner.ts
+++ b/services/bayn/src/cycle-runner.ts
@@ -215,18 +215,47 @@ interface CyclePublicationDateInput {
   }
 }
 
+type IsoDateShiftCause =
+  | {
+      readonly _tag: 'IsoDateInputInvalid'
+      readonly date: string
+      readonly epochMillis: number
+    }
+  | {
+      readonly _tag: 'IsoDateInputNotCanonical'
+      readonly date: string
+      readonly normalized: string
+    }
+  | {
+      readonly _tag: 'IsoDateOffsetInvalid'
+      readonly date: string
+      readonly days: number
+    }
+  | {
+      readonly _tag: 'IsoDateShiftEpochOutOfRange'
+      readonly date: string
+      readonly days: number
+      readonly epochMillis: number
+    }
+  | {
+      readonly _tag: 'IsoDateShiftResultOutOfRange'
+      readonly date: string
+      readonly days: number
+      readonly shifted: string
+    }
+
 type IsoDateShiftFailure = {
   readonly _tag: 'IsoDateShiftOutOfRange'
   readonly date: string
   readonly days: number
-  readonly cause: unknown
+  readonly cause: IsoDateShiftCause
 }
 
 type CyclePublicationFailure =
   | {
       readonly _tag: 'CyclePublicationDateInvalid'
       readonly signalSessionDate: string
-      readonly cause: unknown
+      readonly cause: IsoDateShiftCause
     }
   | {
       readonly _tag: 'CyclePublicationDuplicate'
@@ -236,46 +265,49 @@ type CyclePublicationFailure =
       readonly _tag: 'CyclePublicationRangeOutOfRange'
       readonly signalSessionDate: string
       readonly offsetDays: number
-      readonly cause: unknown
+      readonly cause: IsoDateShiftCause
     }
 
 type CycleCalendarQueryFailure = {
   readonly _tag: 'CycleCalendarQueryRangeOutOfRange'
   readonly signalSessionDate: string
   readonly offsetDays: number
-  readonly cause: unknown
+  readonly cause: IsoDateShiftCause
 }
 
 const shiftIsoDate = (date: string, days: number): Result.Result<string, IsoDateShiftFailure> => {
-  const failure = (cause: unknown): IsoDateShiftFailure => ({
-    _tag: 'IsoDateShiftOutOfRange',
-    date,
-    days,
-    cause,
-  })
-  return Result.flatMap(
-    Result.try({
-      try: () => {
-        const input = new Date(`${date}T00:00:00.000Z`).toISOString()
-        if (input !== `${date}T00:00:00.000Z`) {
-          return {
-            _tag: 'INVALID' as const,
-            cause: { _tag: 'IsoDateInputNotCanonical', date, normalized: input } as const,
-          }
-        }
-        const shifted = new Date(Date.parse(input) + days * millisecondsPerDay).toISOString()
-        const shiftedDate = shifted.slice(0, 10)
-        return /^\d{4}-\d{2}-\d{2}$/.test(shiftedDate) && shifted === `${shiftedDate}T00:00:00.000Z`
-          ? { _tag: 'VALID' as const, shiftedDate }
-          : {
-              _tag: 'INVALID' as const,
-              cause: { _tag: 'IsoDateShiftResultOutOfRange', date, days, shifted } as const,
-            }
-      },
-      catch: failure,
-    }),
-    (outcome) => (outcome._tag === 'VALID' ? Result.succeed(outcome.shiftedDate) : Result.fail(failure(outcome.cause))),
-  )
+  const failure = (cause: IsoDateShiftCause): Result.Result<never, IsoDateShiftFailure> =>
+    Result.fail({
+      _tag: 'IsoDateShiftOutOfRange',
+      date,
+      days,
+      cause,
+    })
+
+  if (!Number.isSafeInteger(days)) return failure({ _tag: 'IsoDateOffsetInvalid', date, days })
+
+  const inputDate = new Date(`${date}T00:00:00.000Z`)
+  const inputEpochMillis = inputDate.getTime()
+  if (!Number.isFinite(inputEpochMillis)) {
+    return failure({ _tag: 'IsoDateInputInvalid', date, epochMillis: inputEpochMillis })
+  }
+
+  const input = inputDate.toISOString()
+  if (input !== `${date}T00:00:00.000Z`) {
+    return failure({ _tag: 'IsoDateInputNotCanonical', date, normalized: input })
+  }
+
+  const shiftedEpochMillis = inputEpochMillis + days * millisecondsPerDay
+  const shiftedDateValue = new Date(shiftedEpochMillis)
+  if (!Number.isFinite(shiftedDateValue.getTime())) {
+    return failure({ _tag: 'IsoDateShiftEpochOutOfRange', date, days, epochMillis: shiftedEpochMillis })
+  }
+
+  const shifted = shiftedDateValue.toISOString()
+  const shiftedDate = shifted.slice(0, 10)
+  return /^\d{4}-\d{2}-\d{2}$/.test(shiftedDate) && shifted === `${shiftedDate}T00:00:00.000Z`
+    ? Result.succeed(shiftedDate)
+    : failure({ _tag: 'IsoDateShiftResultOutOfRange', date, days, shifted })
 }
 
 export const marketCalendarQueryForSignal = (


### PR DESCRIPTION
## Summary

- replace generic exception-backed ISO date shifting with an explicit closed Result algebra for invalid input, noncanonical dates, invalid offsets, shifted epoch overflow, and out-of-contract shifted dates
- preserve exact valid publication and market-calendar query boundaries while removing JavaScript `RangeError` objects from the public cycle-runner failure contract
- add regressions for malformed `0000-00-00` and normalized invalid calendar dates such as `2026-02-30`
- keep cycle selection, broker reads, store operations, timing cutoffs, and persistence behavior unchanged

## Related Issues

None

## Testing

- focused cycle-runner/readiness/recovery/session coverage: 69 passed, 0 failed
- `bun test services/bayn/src` — 728 passed, 120 PostgreSQL-only skipped, 0 failed
- `bun test packages/scripts/src/bayn` — 20 passed, 0 failed
- PostgreSQL 18: EvidenceStore 64 passed; PaperStore 30 passed; CycleStore 13 passed
- TypeScript and Effect diagnostics — 218 files, 0 errors, warnings, or messages
- Oxfmt exact Bayn CI scope
- Oxlint standard and type-aware modes
- production build and `git diff --check`

## Breaking Changes

None. Successful date calculations and outer cycle-runner failure tags are unchanged; their `cause` now contains closed date facts rather than engine exceptions.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
