### PR TITLE
refactor(bayn): totalize candidate capture time

### DIFF
--- a/services/bayn/src/paper-candidate-discovery.test.ts
+++ b/services/bayn/src/paper-candidate-discovery.test.ts
@@ -534,11 +534,31 @@ describe('paper candidate discovery', () => {
         _tag: 'ObservationCaptureTimeInvalid',
         failure: 'broker',
         observedAtMs: -8_640_000_000_000_001,
+        cause: {
+          _tag: 'ObservationCaptureEpochOutOfRange',
+          observedAtMs: -8_640_000_000_000_001,
+        },
       })
       expect(renderPaperCandidateDiscoveryError(invalidCapture.failure)).toBe(
         'paper candidate observation capture time is invalid: observedMs=-8640000000000001',
       )
     }
+
+    const fractionalCapture = validatePaperCandidateDiscoveryObservations(validatedSnapshot.success, {
+      ...observations,
+      capturedAtMs: Date.parse(observedAt) + 0.5,
+    })
+    expect(fractionalCapture).toEqual(
+      Result.fail({
+        _tag: 'ObservationCaptureTimeInvalid',
+        failure: 'broker',
+        observedAtMs: Date.parse(observedAt) + 0.5,
+        cause: {
+          _tag: 'ObservationCaptureEpochNotSafeInteger',
+          observedAtMs: Date.parse(observedAt) + 0.5,
+        },
+      }),
+    )
 
     const futureAssetObservedAt = '2099-07-24T12:00:01.000Z'
     const capturedAt = '2099-07-24T12:00:00.500Z'

--- a/services/bayn/src/paper-candidate-discovery/broker-observation-validation.ts
+++ b/services/bayn/src/paper-candidate-discovery/broker-observation-validation.ts
@@ -193,17 +193,27 @@ export const assembleValidatedObservations = (
   accountConfiguration: ValidatedAccountConfiguration,
   assets: ValidatedAssets,
   capturedAtMs: number,
-): Result.Result<ValidatedPaperCandidateObservations, PaperCandidateDiscoveryError> =>
-  pipe(
-    Result.try({
-      try: () => new Date(capturedAtMs).toISOString(),
-      catch: (cause): PaperCandidateDiscoveryError => ({
-        _tag: 'ObservationCaptureTimeInvalid',
-        failure: 'broker',
-        observedAtMs: capturedAtMs,
-        cause,
-      }),
-    }),
+): Result.Result<ValidatedPaperCandidateObservations, PaperCandidateDiscoveryError> => {
+  if (!Number.isSafeInteger(capturedAtMs)) {
+    return Result.fail({
+      _tag: 'ObservationCaptureTimeInvalid',
+      failure: 'broker',
+      observedAtMs: capturedAtMs,
+      cause: { _tag: 'ObservationCaptureEpochNotSafeInteger', observedAtMs: capturedAtMs },
+    })
+  }
+  const capturedAtDate = new Date(capturedAtMs)
+  if (!Number.isFinite(capturedAtDate.getTime())) {
+    return Result.fail({
+      _tag: 'ObservationCaptureTimeInvalid',
+      failure: 'broker',
+      observedAtMs: capturedAtMs,
+      cause: { _tag: 'ObservationCaptureEpochOutOfRange', observedAtMs: capturedAtMs },
+    })
+  }
+  const capturedAt = capturedAtDate.toISOString()
+  return pipe(
+    Result.succeed(capturedAt),
     Result.flatMap((capturedAt) =>
       pipe(
         Result.all([
@@ -238,6 +248,7 @@ export const assembleValidatedObservations = (
       ),
     ),
   )
+}
 
 export const validatePaperCandidateDiscoveryObservations = (
   validatedSnapshot: ValidatedPaperCandidateSnapshot,

--- a/services/bayn/src/paper-candidate-discovery/failure.ts
+++ b/services/bayn/src/paper-candidate-discovery/failure.ts
@@ -269,7 +269,15 @@ export type PaperCandidateDiscoveryError =
       readonly _tag: 'ObservationCaptureTimeInvalid'
       readonly failure: 'broker'
       readonly observedAtMs: number
-      readonly cause: unknown
+      readonly cause:
+        | {
+            readonly _tag: 'ObservationCaptureEpochNotSafeInteger'
+            readonly observedAtMs: number
+          }
+        | {
+            readonly _tag: 'ObservationCaptureEpochOutOfRange'
+            readonly observedAtMs: number
+          }
     }
   | {
       readonly _tag: 'AssetMissing'


### PR DESCRIPTION
## Summary

- replace exception-backed paper-candidate capture-time conversion with a closed Result algebra
- distinguish non-safe-integer clock samples from valid integer epochs outside the JavaScript UTC range
- preserve document-expiry and observation-chronology ordering, receipt hashing, and the read-only repeatable-read discovery transaction
- add exact regressions for fractional capture times and out-of-range epochs

## Related Issues

None

## Testing

- focused paper-candidate discovery and failure coverage: 15 passed, 1 PostgreSQL-only skipped, 0 failed
- `bun test services/bayn/src` — 728 passed, 120 PostgreSQL-only skipped, 0 failed
- `bun test packages/scripts/src/bayn` — 20 passed, 0 failed
- PostgreSQL 18: candidate discovery 15 passed; EvidenceStore 64 passed; PaperStore 30 passed; CycleStore 13 passed
- TypeScript and Effect diagnostics — 218 files, 0 errors, warnings, or messages
- Oxfmt exact Bayn CI scope
- Oxlint standard and type-aware modes
- production build and `git diff --check`

## Breaking Changes

None. `ObservationCaptureTimeInvalid` retains its existing tag, failure class, and raw epoch; its cause is now closed fact data rather than an engine exception.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
