### PR TITLE
refactor(bayn): expose cycle service requirements

### DIFF
--- a/services/bayn/src/app.ts
+++ b/services/bayn/src/app.ts
@@ -20,11 +20,11 @@ export type AutonomousCycleStartupInput = {
   readonly recordPass: RecordAutonomousCyclePass
 }
 
-export type AutonomousCycleLoop = Effect.Effect<void>
+export type AutonomousCycleLoop<R = never> = Effect.Effect<void, never, R>
 
-export type AutonomousCycleStartup<R = never> = (
+export type AutonomousCycleStartup<StartupR = never, LoopR = StartupR> = (
   input: AutonomousCycleStartupInput,
-) => Effect.Effect<AutonomousCycleLoop, OperationalError, R>
+) => Effect.Effect<AutonomousCycleLoop<LoopR>, OperationalError, StartupR>
 
 export type BrokerlessApplicationConfig = Extract<LoadedRuntimeConfig, { readonly runtimeMode: 'BrokerlessService' }>
 
@@ -33,12 +33,12 @@ export type AutonomousObserveApplicationConfig = Extract<
   { readonly runtimeMode: 'AutonomousObserveService' }
 >
 
-type AutonomousObserveRuntime<R> = {
+type AutonomousObserveRuntime<StartupR, LoopR> = {
   readonly broker: BrokerProbe
-  readonly startCycle: AutonomousCycleStartup<R>
+  readonly startCycle: AutonomousCycleStartup<StartupR, LoopR>
 }
 
-type ApplicationRuntime<R> = Option.Option<AutonomousObserveRuntime<R>>
+type ApplicationRuntime<StartupR, LoopR> = Option.Option<AutonomousObserveRuntime<StartupR, LoopR>>
 
 const cyclePassError = (observation: Extract<AutonomousCyclePassObservation, { readonly result: 'FAILURE' }>): string =>
   `cycleRunner: ${observation.operation}/${observation.failure}: ${observation.message}`
@@ -77,14 +77,14 @@ const applyAutonomousCyclePass = (current: RuntimeState, observation: Autonomous
     : next
 }
 
-const brokerProbe = <R>(runtime: ApplicationRuntime<R>): BrokerProbe | undefined =>
+const brokerProbe = <StartupR, LoopR>(runtime: ApplicationRuntime<StartupR, LoopR>): BrokerProbe | undefined =>
   pipe(
     runtime,
     Option.map(({ broker }) => broker),
     Option.getOrUndefined,
   )
 
-const initialRuntimeState = <R>(runtime: ApplicationRuntime<R>): RuntimeState =>
+const initialRuntimeState = <StartupR, LoopR>(runtime: ApplicationRuntime<StartupR, LoopR>): RuntimeState =>
   pipe(
     runtime,
     Option.match({
@@ -114,11 +114,11 @@ const markAutonomousCycleStarted = (state: Ref.Ref<RuntimeState>, startedAt: str
     autonomousCycleLoop: { ...current.autonomousCycleLoop, startedAt },
   }))
 
-const forkAutonomousCycle = <R>(
-  runtime: AutonomousObserveRuntime<R>,
+const forkAutonomousCycle = <StartupR, LoopR>(
+  runtime: AutonomousObserveRuntime<StartupR, LoopR>,
   state: Ref.Ref<RuntimeState>,
   qualificationRunId: string,
-): Effect.Effect<Fiber.Fiber<void, never>, OperationalError, R | Scope.Scope> =>
+): Effect.Effect<Fiber.Fiber<void, never>, OperationalError, StartupR | LoopR | Scope.Scope> =>
   pipe(
     currentUtcInstant,
     Effect.tap((startedAt) => markAutonomousCycleStarted(state, startedAt)),
@@ -131,10 +131,10 @@ const forkAutonomousCycle = <R>(
     Effect.flatMap(Effect.forkScoped({ startImmediately: true })),
   )
 
-const startAutonomousCycle = <R>(
-  runtime: ApplicationRuntime<R>,
+const startAutonomousCycle = <StartupR, LoopR>(
+  runtime: ApplicationRuntime<StartupR, LoopR>,
   state: Ref.Ref<RuntimeState>,
-): Effect.Effect<Fiber.Fiber<void, never> | undefined, OperationalError, R | Scope.Scope> =>
+): Effect.Effect<Fiber.Fiber<void, never> | undefined, OperationalError, StartupR | LoopR | Scope.Scope> =>
   pipe(
     runtime,
     Option.match({
@@ -162,11 +162,15 @@ const startHttpServer = (
     Effect.mapError((cause) => operationalError('http', 'listen', 'HTTP server failed to listen', cause)),
   )
 
-const runApplication = <R>(
+const runApplication = <StartupR, LoopR>(
   config: RuntimeConfig,
   strategy: Strategy,
-  runtime: ApplicationRuntime<R>,
-): Effect.Effect<never, OperationalError, MarketData | Journal | EvidenceStore | CycleObservability | R> =>
+  runtime: ApplicationRuntime<StartupR, LoopR>,
+): Effect.Effect<
+  never,
+  OperationalError,
+  MarketData | Journal | EvidenceStore | CycleObservability | StartupR | LoopR
+> =>
   pipe(
     Effect.Do,
     Effect.bind('evidenceStore', () => EvidenceStore),
@@ -190,13 +194,16 @@ export const brokerlessApplication = (
 ): Effect.Effect<never, OperationalError, MarketData | Journal | EvidenceStore | CycleObservability> =>
   runApplication(config, strategy, Option.none())
 
-export const autonomousObserveApplication = <R>(
+export const autonomousObserveApplication = <StartupR, LoopR>(
   config: AutonomousObserveApplicationConfig,
   strategy: Strategy,
   broker: BrokerProbe,
-  startCycle: AutonomousCycleStartup<R>,
-): Effect.Effect<never, OperationalError, MarketData | Journal | EvidenceStore | CycleObservability | R> =>
-  runApplication(config, strategy, Option.some({ broker, startCycle }))
+  startCycle: AutonomousCycleStartup<StartupR, LoopR>,
+): Effect.Effect<
+  never,
+  OperationalError,
+  MarketData | Journal | EvidenceStore | CycleObservability | StartupR | LoopR
+> => runApplication(config, strategy, Option.some({ broker, startCycle }))
 
 export { monitor, probe } from './health'
 export { initialize } from './startup'

--- a/services/bayn/src/cycle-runner/decisions.ts
+++ b/services/bayn/src/cycle-runner/decisions.ts
@@ -442,8 +442,8 @@ type CycleCalendarCandidateFailure =
       readonly cause: CycleConstructionFailure
     }
 
-const selectCycleCalendarPublication = (
-  context: CycleRunContext,
+const selectCycleCalendarPublication = <R>(
+  context: CycleRunContext<R>,
   publication: MarketDataInspection,
   observation: MarketCalendarObservation,
   calendarReadContentHash: string,
@@ -483,8 +483,8 @@ const selectCycleCalendarPublication = (
   )
 }
 
-export const selectCycleCalendarCandidate = (
-  context: CycleRunContext,
+export const selectCycleCalendarCandidate = <R>(
+  context: CycleRunContext<R>,
   publications: NonEmptyPublications,
   observation: MarketCalendarObservation,
   calendarReadContentHash: string,

--- a/services/bayn/src/cycle-runner/model.ts
+++ b/services/bayn/src/cycle-runner/model.ts
@@ -14,14 +14,14 @@ export class CycleDecisionBuildError extends Data.TaggedError('CycleDecisionBuil
   readonly cause?: unknown
 }> {}
 
-export interface CycleRunContext {
+export interface CycleRunContext<R = never> {
   readonly qualificationRunId: string
   readonly strategyProtocolHash: string
   readonly accountId: string
   readonly executionPolicy: CycleExecutionPolicy
   readonly buildDecision: (
     cycle: AutonomousCycle,
-  ) => Effect.Effect<ObserveShadowDecisionDocument, CycleDecisionBuildError>
+  ) => Effect.Effect<ObserveShadowDecisionDocument, CycleDecisionBuildError, R>
 }
 
 export interface CycleCandidate {
@@ -129,8 +129,8 @@ export type CyclePassObservation =
       readonly error: CycleRunnerError
     }
 
-export interface AutonomousCycleLoopOptions<E = never, R = never> {
-  readonly context: Effect.Effect<CycleRunContext, E, R>
+export interface AutonomousCycleLoopOptions<E = never, ContextR = never, DecisionR = never> {
+  readonly context: Effect.Effect<CycleRunContext<DecisionR>, E, ContextR>
   readonly observePass: (observation: CyclePassObservation) => Effect.Effect<void>
   readonly pollIntervalMs: number
 }

--- a/services/bayn/src/cycle-runner/program.ts
+++ b/services/bayn/src/cycle-runner/program.ts
@@ -70,9 +70,9 @@ const bindDiscoveredPublication = (
     ),
   )
 
-const readCycleAuthoritySlot = (
+const readCycleAuthoritySlot = <R>(
   store: CycleStoreShape,
-  context: CycleRunContext,
+  context: CycleRunContext<R>,
   publication: MarketDataInspection,
 ): Effect.Effect<CycleAuthoritySlot, CycleRunnerError> => {
   const signalSessionDate = publication.signalSession.session_date
@@ -89,9 +89,9 @@ const readCycleAuthoritySlot = (
   )
 }
 
-const continueCycleAuthorityReads = (
+const continueCycleAuthorityReads = <R>(
   store: CycleStoreShape,
-  context: CycleRunContext,
+  context: CycleRunContext<R>,
   state: CycleAuthoritySelectionState,
   publications: readonly MarketDataInspection[],
 ): Effect.Effect<CycleAuthoritySelection, CycleRunnerError> => {
@@ -110,8 +110,8 @@ const continueCycleAuthorityReads = (
   )
 }
 
-const readCycleAuthoritySlots = (
-  context: CycleRunContext,
+const readCycleAuthoritySlots = <R>(
+  context: CycleRunContext<R>,
   publications: NonEmptyPublications,
 ): Effect.Effect<CycleAuthoritySelection, CycleRunnerError, CycleStore> =>
   pipe(
@@ -192,8 +192,8 @@ const acquireCycleCandidate = (
     ),
   )
 
-const interpretCycleCalendar = (
-  context: CycleRunContext,
+const interpretCycleCalendar = <R>(
+  context: CycleRunContext<R>,
   publications: NonEmptyPublications,
   observation: MarketCalendarObservation,
   calendarReadContentHash: string,
@@ -208,8 +208,8 @@ const interpretCycleCalendar = (
     ),
   )
 
-const readCycleCalendar = (
-  context: CycleRunContext,
+const readCycleCalendar = <R>(
+  context: CycleRunContext<R>,
   publications: NonEmptyPublications,
 ): Effect.Effect<CycleRunResult, CycleRunnerError, BrokerRead | CycleStore> =>
   pipe(
@@ -235,8 +235,8 @@ const readCycleCalendar = (
     ),
   )
 
-const interpretCycleAuthoritySelection = (
-  context: CycleRunContext,
+const interpretCycleAuthoritySelection = <R>(
+  context: CycleRunContext<R>,
   selection: CycleAuthoritySelection,
   discoveryObservedAt: string,
 ): Effect.Effect<CycleRunResult, CycleRunnerError, BrokerRead | CycleStore> => {
@@ -262,8 +262,8 @@ const interpretCycleAuthoritySelection = (
   }
 }
 
-export const discoverAutonomousCyclePass = (
-  context: CycleRunContext,
+export const discoverAutonomousCyclePass = <R>(
+  context: CycleRunContext<R>,
 ): Effect.Effect<CycleRunResult, CycleRunnerError, BrokerRead | CycleStore | MarketData> =>
   pipe(
     MarketData,
@@ -296,11 +296,11 @@ const chooseRecovery = (state: CycleRecoveryState): Effect.Effect<CycleRecoveryS
     ),
   )
 
-const recoverCycle = (
+const recoverCycle = <R>(
   selection: CycleRecoverySelection,
-  context: CycleRunContext,
+  context: CycleRunContext<R>,
   observedAt: string,
-): Effect.Effect<CycleRunResult, CycleRunnerError, BrokerRead | CycleStore | MarketData> => {
+): Effect.Effect<CycleRunResult, CycleRunnerError, BrokerRead | CycleStore | MarketData | R> => {
   switch (selection.action) {
     case 'DISCOVER':
       return discoverAutonomousCyclePass(context)
@@ -431,9 +431,9 @@ const recoverCycle = (
   }
 }
 
-export const runAutonomousCyclePass = (
-  context: CycleRunContext,
-): Effect.Effect<CycleRunResult, CycleRunnerError, BrokerRead | CycleStore | MarketData> =>
+export const runAutonomousCyclePass = <R>(
+  context: CycleRunContext<R>,
+): Effect.Effect<CycleRunResult, CycleRunnerError, BrokerRead | CycleStore | MarketData | R> =>
   pipe(
     CycleStore,
     Effect.flatMap((store) =>
@@ -470,9 +470,9 @@ const logCyclePass = (observation: CyclePassObservation): Effect.Effect<void> =>
   return log.pipe(Effect.annotateLogs(facts.annotations))
 }
 
-const runLoopPass = <E, R>(
-  context: Effect.Effect<CycleRunContext, E, R>,
-): Effect.Effect<CycleRunResult, CycleRunnerError, BrokerRead | CycleStore | MarketData | R> =>
+const runLoopPass = <E, ContextR, DecisionR>(
+  context: Effect.Effect<CycleRunContext<DecisionR>, E, ContextR>,
+): Effect.Effect<CycleRunResult, CycleRunnerError, BrokerRead | CycleStore | MarketData | ContextR | DecisionR> =>
   context.pipe(
     Effect.mapError((cause) =>
       runnerError('load-context', 'context', 'autonomous cycle context loading failed', cause),
@@ -481,8 +481,8 @@ const runLoopPass = <E, R>(
     Effect.withLogSpan('autonomous-cycle'),
   )
 
-const observeSuccessfulPass = <E, R>(
-  options: AutonomousCycleLoopOptions<E, R>,
+const observeSuccessfulPass = <E, ContextR, DecisionR>(
+  options: AutonomousCycleLoopOptions<E, ContextR, DecisionR>,
   result: CycleRunResult,
 ): Effect.Effect<void> =>
   pipe(
@@ -493,8 +493,8 @@ const observeSuccessfulPass = <E, R>(
     }),
   )
 
-const observeFailedPass = <E, R>(
-  options: AutonomousCycleLoopOptions<E, R>,
+const observeFailedPass = <E, ContextR, DecisionR>(
+  options: AutonomousCycleLoopOptions<E, ContextR, DecisionR>,
   error: CycleRunnerError,
 ): Effect.Effect<void> =>
   pipe(
@@ -505,9 +505,9 @@ const observeFailedPass = <E, R>(
     }),
   )
 
-const cycleLoopProgram = <E, R>(
-  options: AutonomousCycleLoopOptions<E, R>,
-): Effect.Effect<void, never, BrokerRead | CycleStore | MarketData | R> =>
+const cycleLoopProgram = <E, ContextR, DecisionR>(
+  options: AutonomousCycleLoopOptions<E, ContextR, DecisionR>,
+): Effect.Effect<void, never, BrokerRead | CycleStore | MarketData | ContextR | DecisionR> =>
   pipe(
     runLoopPass(options.context),
     Effect.flatMap((result) => observeSuccessfulPass(options, result)),
@@ -516,9 +516,12 @@ const cycleLoopProgram = <E, R>(
     Effect.asVoid,
   )
 
-export const makeAutonomousCycleLoop = <E, R>(
-  options: AutonomousCycleLoopOptions<E, R>,
-): Result.Result<Effect.Effect<void, never, BrokerRead | CycleStore | MarketData | R>, CycleRunnerError> =>
+export const makeAutonomousCycleLoop = <E, ContextR, DecisionR>(
+  options: AutonomousCycleLoopOptions<E, ContextR, DecisionR>,
+): Result.Result<
+  Effect.Effect<void, never, BrokerRead | CycleStore | MarketData | ContextR | DecisionR>,
+  CycleRunnerError
+> =>
   pipe(
     validateCycleLoopInterval(options.pollIntervalMs),
     Result.map(() => cycleLoopProgram(options)),

--- a/services/bayn/src/observe-composition.test.ts
+++ b/services/bayn/src/observe-composition.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, test } from 'bun:test'
 
-import { Cause, Effect, Exit, Result } from 'effect'
+import { Cause, Deferred, Effect, Exit, Fiber, Option, Result } from 'effect'
 import { TestClock } from 'effect/testing'
 
+import type { AutonomousCycleLoop } from './app'
 import { fixtureStrategy } from './app-test-support'
 import {
   BrokerRead,
@@ -25,7 +26,7 @@ import {
 import { makeStrategyProtocolHash } from './contracts'
 import { CycleStore, type CycleStoreShape } from './db/cycle-store'
 import { PaperStore, PaperStoreError, type PaperStoreShape } from './db/paper-store'
-import { operationalError } from './errors'
+import { operationalError, type OperationalError } from './errors'
 import { WriterFence, WriterFenceError, type WriterFenceService } from './execution/writer-fence'
 import { canonicalHashV1 } from './hash'
 import { MarketData, type MarketDataService, type MarketDataSnapshot } from './market-data'
@@ -646,6 +647,98 @@ describe('OBSERVE runtime composition', () => {
       expect(failure.operation).toBe(testCase.expectedOperation)
       expect(failure.cause).toBe(testCase.cause)
     }
+  })
+
+  test('keeps startup and long-lived loop requirements explicit at separate composition boundaries', async () => {
+    const unused = Effect.die(new Error('missing-publication loop must not use this capability'))
+    const authority = reconciliationResult().riskContext.authority
+    if (authority === null) return expect.unreachable('fixture authority is required')
+    const paperStore: PaperStoreShape = {
+      ingest: () => unused,
+      ingestPositions: () => unused,
+      account: () => unused,
+      value: () => unused,
+      hasAccountBaseline: () => unused,
+      bindings: () => unused,
+      reconcile: () => unused,
+      ensureAuthorityGeneration: () => Effect.succeed(authority),
+      preparePaperGeneration: () => unused,
+      activatePaperGeneration: () => unused,
+      restrictAuthority: () => unused,
+    }
+    const cycleStore: CycleStoreShape = {
+      acquire: () => unused,
+      read: () => unused,
+      readAuthoritySlot: () => unused,
+      readDecisionDocument: () => unused,
+      readOldestUnfinished: () => Effect.succeed(Option.none()),
+      bindSnapshot: () => unused,
+      activate: () => unused,
+      bindDecision: () => unused,
+      finish: () => unused,
+      block: () => unused,
+    }
+    const brokerRead: BrokerReadShape = {
+      account: unused,
+      accountConfiguration: unused,
+      assetBySymbol: unusedAssetBySymbol,
+      positions: unused,
+      orders: () => unused,
+      orderById: () => unused,
+      orderByClientId: () => unused,
+      fillActivities: () => unused,
+      marketCalendar: () => unused,
+    }
+    const marketDataService: MarketDataService = {
+      ...marketData([]),
+      inspectCyclePublications: Effect.succeed({
+        outcome: 'MISSING',
+        observedAt: '2026-01-30T21:20:00.000Z',
+      }),
+    }
+    const writerFence: WriterFenceService = {
+      backendPid: 1,
+      check: unused,
+      transaction: (effect) => effect,
+    }
+    const startup = makeObserveAutonomousCycleStartup({
+      accountId,
+      authorityGenerationHash: generationHash,
+      maximumAuthority: Authority.Observe,
+      pollIntervalMs: 30_000,
+      strategy: fixtureStrategy,
+    })
+
+    await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const pass = yield* Deferred.make<Parameters<Parameters<typeof startup>[0]['recordPass']>[0]>()
+          const acquireLoop: Effect.Effect<
+            AutonomousCycleLoop<BrokerRead | CycleStore | MarketData | PaperStore | WriterFence>,
+            OperationalError,
+            PaperStore
+          > = startup({
+            qualificationRunId: 'c'.repeat(64),
+            recordPass: (observation) => Deferred.succeed(pass, observation).pipe(Effect.asVoid),
+          })
+          const loop = yield* acquireLoop.pipe(Effect.provideService(PaperStore, paperStore))
+          const fiber = yield* loop.pipe(
+            Effect.provideService(BrokerRead, brokerRead),
+            Effect.provideService(CycleStore, cycleStore),
+            Effect.provideService(MarketData, marketDataService),
+            Effect.provideService(PaperStore, paperStore),
+            Effect.provideService(WriterFence, writerFence),
+            Effect.forkScoped,
+          )
+          const observation = yield* Deferred.await(pass).pipe(Effect.timeout('1 second'))
+          expect(observation).toMatchObject({
+            result: 'SUCCESS',
+            outcome: 'NO_PUBLICATION',
+          })
+          yield* Fiber.interrupt(fiber)
+        }),
+      ),
+    )
   })
 
   test('fails PAPER startup before authority initialization or autonomous work can begin', async () => {

--- a/services/bayn/src/observe-composition.ts
+++ b/services/bayn/src/observe-composition.ts
@@ -1,12 +1,13 @@
-import { Context, Effect, pipe, Result } from 'effect'
+import { Effect, pipe, Result } from 'effect'
 
-import type { AutonomousCycleStartup } from './app'
+import type { AutonomousCycleLoop, AutonomousCycleStartup } from './app'
 import { BrokerRead, type BrokerReadShape, type MarketCalendarQuery } from './broker/alpaca'
 import { makeCycleExecutionPolicyFromModel, type AutonomousCycle, type CycleExecutionPolicy } from './cycle'
 import {
   CycleDecisionBuildError,
   makeAutonomousCycleLoop,
   marketCalendarQueryForSignal,
+  type CycleRunContext,
   type CyclePassObservation,
 } from './cycle-runner'
 import { CycleStore } from './db/cycle-store'
@@ -494,7 +495,8 @@ export type ObserveAutonomousCycleInput = {
   readonly strategy: Pick<Strategy, 'currentDecision' | 'parameters' | 'provenance'>
 }
 
-type ObserveRuntime = BrokerRead | CycleStore | MarketData | PaperStore | WriterFence
+type ObserveDecisionRuntime = BrokerRead | MarketData | PaperStore | WriterFence
+type ObserveRuntime = CycleStore | ObserveDecisionRuntime
 
 export type ObserveStartupPreparation = {
   readonly executionModel: CausalProtocol['executionModel']
@@ -562,41 +564,39 @@ const initializeObserveAuthority = (
 
 const makeObserveAutonomousLoop = (
   input: ObserveAutonomousCycleInput,
-  runtime: Context.Context<ObserveRuntime>,
   startup: Parameters<AutonomousCycleStartup>[0],
   preparation: ObserveStartupPreparation,
   policy: Policy,
-) => {
-  const reconcile = runOnce.pipe(Effect.provideContext(runtime))
+): Result.Result<AutonomousCycleLoop<ObserveRuntime>, OperationalError> => {
+  const context: CycleRunContext<ObserveDecisionRuntime> = {
+    qualificationRunId: startup.qualificationRunId,
+    strategyProtocolHash: preparation.strategyProtocolHash,
+    accountId: input.accountId,
+    executionPolicy: preparation.executionPolicy,
+    buildDecision: (cycle) =>
+      buildObserveCycleDecision({
+        authorityGenerationHash: input.authorityGenerationHash,
+        cycle,
+        executionModel: preparation.executionModel,
+        policy,
+        reconcile: runOnce,
+        strategy: input.strategy,
+      }).pipe(Effect.mapError(decisionBuildError)),
+  }
   return pipe(
     makeAutonomousCycleLoop({
-      context: Effect.succeed({
-        qualificationRunId: startup.qualificationRunId,
-        strategyProtocolHash: preparation.strategyProtocolHash,
-        accountId: input.accountId,
-        executionPolicy: preparation.executionPolicy,
-        buildDecision: (cycle) =>
-          buildObserveCycleDecision({
-            authorityGenerationHash: input.authorityGenerationHash,
-            cycle,
-            executionModel: preparation.executionModel,
-            policy,
-            reconcile,
-            strategy: input.strategy,
-          }).pipe(Effect.mapError(decisionBuildError), Effect.provideContext(runtime)),
-      }),
+      context: Effect.succeed(context),
       observePass: (observation) => observePass(startup.recordPass, observation),
       pollIntervalMs: input.pollIntervalMs,
     }),
     Result.mapError((cause) =>
       operationalError('strategy', 'cycle-loop', 'autonomous cycle loop failed to start', cause),
     ),
-    Result.map((loop) => loop.pipe(Effect.provideContext(runtime))),
   )
 }
 
 export const makeObserveAutonomousCycleStartup =
-  (input: ObserveAutonomousCycleInput): AutonomousCycleStartup<ObserveRuntime> =>
+  (input: ObserveAutonomousCycleInput): AutonomousCycleStartup<PaperStore, ObserveRuntime> =>
   (startup) =>
     Effect.gen(function* () {
       const preparation = yield* Effect.fromResult(prepareObserveStartup(input))
@@ -605,7 +605,6 @@ export const makeObserveAutonomousCycleStartup =
           operationalError('strategy', 'risk-policy', 'source-controlled paper risk policy is invalid', cause),
         ),
       )
-      const runtime = yield* Effect.context<ObserveRuntime>()
       yield* initializeObserveAuthority(input)
-      return yield* Effect.fromResult(makeObserveAutonomousLoop(input, runtime, startup, preparation, policy))
+      return yield* Effect.fromResult(makeObserveAutonomousLoop(input, startup, preparation, policy))
     })


### PR DESCRIPTION
## Summary

- expose autonomous-cycle startup and long-lived loop requirements as separate Effect environment parameters
- propagate decision-building service requirements through `CycleRunContext` and the modular cycle-runner program
- remove captured runtime `Context` and repeated `Effect.provideContext` from OBSERVE composition
- add a regression that acquires startup with only `PaperStore` and provides loop services at the later execution boundary

## Related Issues

None

## Testing

- `bun run --cwd services/bayn test` — 729 passed, 120 PostgreSQL-gated skips, 0 failed
- `bun test services/bayn/src/app.test.ts services/bayn/src/cycle-runner.test.ts services/bayn/src/observe-composition.test.ts` — 41 passed, 0 failed on merged `main`
- `bun node_modules/typescript/bin/tsc --noEmit -p services/bayn/tsconfig.json`
- `bun services/bayn/node_modules/@effect/tsgo/dist/effect-tsgo.js diagnostics --project services/bayn/tsconfig.json --format text --severity error`
- `bun node_modules/oxfmt/bin/oxfmt --check services/bayn/src`
- `bun node_modules/oxlint/bin/oxlint --config .oxlintrc.json services/bayn`
- `bun node_modules/oxlint/bin/oxlint --config .oxlintrc.json --type-aware --tsconfig services/bayn/tsconfig.json services/bayn`
- `bun build services/bayn/src/index.ts --target=node --external tigerbeetle-node --outdir=services/bayn/dist`
- `bun test packages/scripts/src/bayn` — 20 passed, 0 failed
- `git diff --check`

## Breaking Changes

None. The exported generic defaults preserve existing callers while making non-empty requirements visible when present.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] Documentation and release notes are not required for this internal type-level composition correction.
