### PR TITLE
refactor(bayn): flatten snapshot reference failures

### DIFF
--- a/services/bayn/src/db/cycle-store/integration.test.ts
+++ b/services/bayn/src/db/cycle-store/integration.test.ts
@@ -907,9 +907,9 @@ describePostgres('PostgreSQL autonomous cycle store', () => {
     expect(result.atClose.changed).toBe(true)
     expect(Exit.isFailure(result.missingReference)).toBe(true)
     if (Exit.isFailure(result.missingReference)) {
-      expect(Cause.pretty(result.missingReference.cause)).toContain(
-        'stored snapshot reference diverged from the finalized Signal publication',
-      )
+      const cause = Cause.pretty(result.missingReference.cause)
+      expect(cause).toContain('stored snapshot reference diverged from the finalized Signal publication')
+      expect(cause).toContain('snapshot reference mismatch at manifestHash')
     }
     expect(Exit.isFailure(result.staleReference)).toBe(true)
     if (Exit.isFailure(result.staleReference)) {

--- a/services/bayn/src/db/cycle-store/postgres.ts
+++ b/services/bayn/src/db/cycle-store/postgres.ts
@@ -22,7 +22,11 @@ import {
 } from '../../schemas'
 import { ObserveShadowDecisionDocumentSchema, type ObserveShadowDecisionDocument } from '../../shadow-decision-contract'
 import type { InputManifest, IsoDate } from '../../types'
-import { ensureSnapshotReference } from '../snapshot-reference'
+import {
+  ensureSnapshotReference,
+  renderSnapshotReferenceIssue,
+  snapshotReferenceIssueTags,
+} from '../snapshot-reference'
 import {
   decideAcquire,
   decideActivation,
@@ -460,14 +464,15 @@ const makeCycleStore = Effect.map(PgClient.PgClient, (sql) => {
 
   const persistSnapshotReference = (inputManifest: InputManifest): Effect.Effect<void, CycleStoreInternalError> =>
     ensureSnapshotReference(sql, inputManifest).pipe(
-      Effect.flatMap((matches) =>
-        matches
-          ? Effect.void
-          : fail(
-              'bind-snapshot',
-              'conflict',
-              'stored snapshot reference diverged from the finalized Signal publication',
-            ),
+      Effect.catchTag(snapshotReferenceIssueTags, (cause) =>
+        Effect.fail(
+          storeError(
+            'bind-snapshot',
+            'conflict',
+            `stored snapshot reference diverged from the finalized Signal publication: ${renderSnapshotReferenceIssue(cause)}`,
+            cause,
+          ),
+        ),
       ),
     )
 

--- a/services/bayn/src/db/evidence-store/postgres.ts
+++ b/services/bayn/src/db/evidence-store/postgres.ts
@@ -18,8 +18,9 @@ import {
   type StoredEvaluationEvidence,
 } from '../evidence-recovery'
 import {
-  ensureSnapshotReferenceResult as ensureSnapshotReferenceRow,
+  ensureSnapshotReference as ensureSnapshotReferenceRow,
   renderSnapshotReferenceIssue,
+  snapshotReferenceIssueTags,
 } from '../snapshot-reference'
 import { databaseError, ensure, runDatabase, type DatabaseError } from './errors'
 import type { ArtifactItemPage, EvidenceStoreService, PersistEvaluationInput, QualificationRecord } from './model'
@@ -560,14 +561,11 @@ export const makeEvidenceStore = Effect.gen(function* () {
     })
 
   const ensureSnapshotReference = (inputManifest: InputManifest) =>
-    Effect.gen(function* () {
-      const validated = yield* ensureSnapshotReferenceRow(sql, inputManifest)
-      yield* Effect.fromResult(validated).pipe(
-        Effect.mapError((cause) =>
-          databaseError('invariant', 'snapshot-reference', renderSnapshotReferenceIssue(cause), cause),
-        ),
-      )
-    })
+    ensureSnapshotReferenceRow(sql, inputManifest).pipe(
+      Effect.catchTag(snapshotReferenceIssueTags, (cause) =>
+        Effect.fail(databaseError('invariant', 'snapshot-reference', renderSnapshotReferenceIssue(cause), cause)),
+      ),
+    )
 
   const readReceipt = (plan: PersistencePlan, deduplicated: boolean) =>
     Effect.gen(function* () {

--- a/services/bayn/src/db/snapshot-reference.ts
+++ b/services/bayn/src/db/snapshot-reference.ts
@@ -46,6 +46,12 @@ export type SnapshotReferenceIssue =
       readonly cause: CanonicalJsonFailure
     }
 
+export const snapshotReferenceIssueTags = [
+  'SnapshotReferenceCardinalityMismatch',
+  'SnapshotReferenceMismatch',
+  'SnapshotReferenceCanonicalizationFailed',
+] as const
+
 const decodeSnapshotReferenceRows = Schema.decodeUnknownEffect(
   Schema.Array(SnapshotReferenceRowSchema),
   strictParseOptions,
@@ -149,10 +155,10 @@ export const renderSnapshotReferenceIssue = (issue: SnapshotReferenceIssue): str
   }
 }
 
-export const ensureSnapshotReferenceResult = (
+export const ensureSnapshotReference = (
   sql: PgClient.PgClient,
   inputManifest: InputManifest,
-): Effect.Effect<Result.Result<void, SnapshotReferenceIssue>, SqlError | Schema.SchemaError> =>
+): Effect.Effect<void, SnapshotReferenceIssue | SqlError | Schema.SchemaError> =>
   Effect.gen(function* () {
     const snapshot = inputManifest.finalizedSnapshot
     yield* sql`
@@ -205,11 +211,5 @@ export const ensureSnapshotReferenceResult = (
       FROM snapshot_references
       WHERE snapshot_id = ${snapshot.snapshotId}
     `.pipe(Effect.flatMap(decodeSnapshotReferenceRows))
-    return validateSnapshotReference(inputManifest, rows)
+    yield* Effect.fromResult(validateSnapshotReference(inputManifest, rows))
   })
-
-export const ensureSnapshotReference = (
-  sql: PgClient.PgClient,
-  inputManifest: InputManifest,
-): Effect.Effect<boolean, SqlError | Schema.SchemaError> =>
-  ensureSnapshotReferenceResult(sql, inputManifest).pipe(Effect.map(Result.isSuccess))


### PR DESCRIPTION
## Summary

- Replace the nested `Effect<Result<void, SnapshotReferenceIssue>, ...>` snapshot persistence boundary with one typed `Effect` error channel.
- Lift the pure snapshot-reference `Result` exactly once at the PostgreSQL interpreter boundary.
- Preserve exact snapshot mismatch evidence when mapping domain failures into EvidenceStore and CycleStore errors.

## Related Issues

None

## Testing

- Clean-tree full Bayn suite: 729 passed, 120 PostgreSQL-gated skips, 0 failed.
- PostgreSQL 18 CI suites: evidence store 64 passed, paper store 30 passed, cycle store 13 passed.
- `snapshot-reference.test.ts`: 2 passed.
- TypeScript: passed with the pinned TypeScript 7.0.2 compiler.
- Effect diagnostics: 231/231 files, 0 errors, warnings, or messages.
- Oxfmt and standard/type-aware Oxlint: passed with 0 findings.
- Production build: 599 modules bundled, 4.50 MB output.
- `bun test packages/scripts/src/bayn`: 20 passed.
- Pre-commit lint-staged and commit-message hooks: passed.

## Breaking Changes

None. The internal persistence helper now exposes snapshot-reference failures in the Effect error channel instead of returning a nested `Result` value.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; breaking changes are documented.
- [x] Existing Bayn functional-boundary guidance applies; no additional release note is required.
