### PR TITLE
refactor(bayn): totalize cycle observability clock

### DIFF
--- a/services/bayn/src/cycle-observability.test.ts
+++ b/services/bayn/src/cycle-observability.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, test } from 'bun:test'
 
+import { Result } from 'effect'
+
 import {
   CycleOperationsCondition,
   CycleOperationsReason,
   deriveCycleOperationsStatus,
+  deriveCycleOperationsStatusResult,
+  renderCycleOperationsStatusFailure,
   type CycleOperationsProjection,
   type CycleOperationsSnapshot,
 } from './cycle-observability'
@@ -50,6 +54,41 @@ const projection = (overrides: Partial<CycleOperationsProjection> = {}): CycleOp
 })
 
 describe('autonomous cycle operations classification', () => {
+  test('returns exact clock failures without defecting', () => {
+    const notInteger = deriveCycleOperationsStatusResult(projection(), 0.5, Authority.Observe, thresholds)
+    expect(notInteger).toEqual(
+      Result.fail({
+        _tag: 'CycleOperationsClockInvalid',
+        nowMs: 0.5,
+        cause: { _tag: 'UtcEpochMillisNotSafeInteger', epochMillis: 0.5 },
+      }),
+    )
+    if (Result.isFailure(notInteger)) {
+      expect(renderCycleOperationsStatusFailure(notInteger.failure)).toBe(
+        'cycle operations clock must be a safe integer epoch millisecond: observed=0.5',
+      )
+    }
+
+    const outOfRange = deriveCycleOperationsStatusResult(
+      projection(),
+      8_640_000_000_000_001,
+      Authority.Observe,
+      thresholds,
+    )
+    expect(outOfRange).toEqual(
+      Result.fail({
+        _tag: 'CycleOperationsClockInvalid',
+        nowMs: 8_640_000_000_000_001,
+        cause: { _tag: 'UtcEpochMillisOutOfRange', epochMillis: 8_640_000_000_000_001 },
+      }),
+    )
+    if (Result.isFailure(outOfRange)) {
+      expect(renderCycleOperationsStatusFailure(outOfRange.failure)).toBe(
+        'cycle operations clock is outside the supported UTC range: observed=8640000000000001',
+      )
+    }
+  })
+
   test('distinguishes expected publication waiting from exact deadline and attempt stalls', () => {
     const pending = snapshot(CycleState.Pending, {
       submissionOpenAt: '2026-07-20T12:00:00.000Z',

--- a/services/bayn/src/cycle-observability.ts
+++ b/services/bayn/src/cycle-observability.ts
@@ -1,5 +1,8 @@
+import { Result } from 'effect'
+
 import { Authority, KillState, ReconciliationStatus } from './paper'
 import { CycleState, type CycleTerminalReason } from './cycle'
+import { utcInstantFromEpochMillisResult, type UtcEpochMillisFailure } from './time'
 
 export interface CycleOperationsThresholds {
   readonly cycleStallThresholdMs: number
@@ -115,6 +118,23 @@ export interface CycleOperationsStatus extends CycleOperationsProjection {
   readonly error: string | null
 }
 
+export type CycleOperationsStatusFailure = {
+  readonly _tag: 'CycleOperationsClockInvalid'
+  readonly nowMs: number
+  readonly cause: UtcEpochMillisFailure
+}
+
+export const renderCycleOperationsStatusFailure = (failure: CycleOperationsStatusFailure): string => {
+  switch (failure.cause._tag) {
+    case 'UtcEpochMillisNotSafeInteger':
+      return `cycle operations clock must be a safe integer epoch millisecond: observed=${failure.nowMs}`
+    case 'UtcEpochMillisOutOfRange':
+      return `cycle operations clock is outside the supported UTC range: observed=${failure.nowMs}`
+  }
+  const exhaustive: never = failure.cause
+  return exhaustive
+}
+
 const ageAt = (instant: string | null, nowMs: number): number | null =>
   instant === null ? null : Math.max(0, nowMs - Date.parse(instant))
 
@@ -203,13 +223,13 @@ const lifecycleCondition = (
   return [CycleOperationsCondition.Failed, CycleOperationsReason.MultipleUnfinishedCycles]
 }
 
-export const deriveCycleOperationsStatus = (
+const deriveCycleOperationsStatusWithCheckedAt = (
   projection: CycleOperationsProjection,
   nowMs: number,
   maximumAuthority: Authority,
   thresholds: CycleOperationsThresholds,
+  checkedAt: string,
 ): CycleOperationsStatus => {
-  const checkedAt = new Date(nowMs).toISOString()
   const attemptAgeMs = ageAt(projection.current?.updatedAt ?? null, nowMs)
   const oldestUnresolvedMutationAgeMs = ageAt(projection.mutations.oldestUnresolvedAt, nowMs)
   const reconciliationAgeMs = ageAt(projection.reconciliation?.reconciledAt ?? null, nowMs)
@@ -288,3 +308,25 @@ export const deriveCycleOperationsStatus = (
     error: null,
   }
 }
+
+export const deriveCycleOperationsStatusResult = (
+  projection: CycleOperationsProjection,
+  nowMs: number,
+  maximumAuthority: Authority,
+  thresholds: CycleOperationsThresholds,
+): Result.Result<CycleOperationsStatus, CycleOperationsStatusFailure> =>
+  Result.map(
+    Result.mapError(
+      utcInstantFromEpochMillisResult(nowMs),
+      (cause): CycleOperationsStatusFailure => ({ _tag: 'CycleOperationsClockInvalid', nowMs, cause }),
+    ),
+    (checkedAt) => deriveCycleOperationsStatusWithCheckedAt(projection, nowMs, maximumAuthority, thresholds, checkedAt),
+  )
+
+export const deriveCycleOperationsStatus = (
+  projection: CycleOperationsProjection,
+  nowMs: number,
+  maximumAuthority: Authority,
+  thresholds: CycleOperationsThresholds,
+): CycleOperationsStatus =>
+  Result.getOrThrow(deriveCycleOperationsStatusResult(projection, nowMs, maximumAuthority, thresholds))

--- a/services/bayn/src/health.test.ts
+++ b/services/bayn/src/health.test.ts
@@ -28,6 +28,16 @@ import { initialState, type RuntimeState } from './runtime-state'
 import { makeSnapshot } from './test-fixtures'
 
 const brokerAccountId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const availableClock = (checkedAt: string) =>
+  ({ _tag: 'Available', checkedAt, checkedAtMs: Date.parse(checkedAt) }) as const
+const unsafeClock = (observedAtMs: number) =>
+  ({
+    _tag: 'Unavailable',
+    observedAtMs,
+    failure: Number.isSafeInteger(observedAtMs)
+      ? ({ _tag: 'UtcEpochMillisOutOfRange', epochMillis: observedAtMs } as const)
+      : ({ _tag: 'UtcEpochMillisNotSafeInteger', epochMillis: observedAtMs } as const),
+  }) as const
 const accountResult = (id = brokerAccountId): ReadResult<Account> => ({
   value: {
     id,
@@ -364,7 +374,6 @@ describe('Bayn continuous health', () => {
     const current = readyState()
     const original = structuredClone(current)
     const checkedAt = '2026-07-20T00:04:00.000Z'
-    const checkedAtMs = Date.parse(checkedAt)
     const pending = pendingCycle('2026-07-20T00:03:30.000Z')
     const transition = deriveHealthTransition(current, {
       config,
@@ -386,8 +395,7 @@ describe('Bayn continuous health', () => {
       },
       broker: undefined,
       cycleFiber: { _tag: 'NotProvided' },
-      checkedAt,
-      checkedAtMs,
+      clock: availableClock(checkedAt),
     })
 
     expect(current).toEqual(original)
@@ -405,6 +413,7 @@ describe('Bayn continuous health', () => {
       },
       failedDependencies: ['signal'],
       checkedAt,
+      clockFailure: null,
     })
     expect(deriveHealthLogDecisions(transition)).toEqual([
       {
@@ -438,6 +447,374 @@ describe('Bayn continuous health', () => {
         },
       },
     ])
+  })
+
+  test('does not manufacture a cycle-runner stall from a rejected finite clock', () => {
+    const progressAt = '2026-07-20T00:00:00.000Z'
+    const current: RuntimeState = {
+      ...readyState(),
+      autonomousCycleLoop: {
+        configured: true,
+        startedAt: progressAt,
+        lastPass: { result: 'SUCCESS', observedAt: progressAt, outcome: 'NO_PUBLICATION' },
+      },
+    }
+    const transition = deriveHealthTransition(current, {
+      config,
+      evidenceAvailable: true,
+      results: {
+        postgresql: { _tag: 'Available', value: undefined },
+        signal: { _tag: 'Available', value: undefined },
+        tigerBeetle: { _tag: 'Available', value: undefined },
+        durableEvidence: { _tag: 'Available', value: undefined },
+        cycle: { _tag: 'Available', value: emptyCycleProjection() },
+        broker: null,
+      },
+      broker: undefined,
+      cycleFiber: { _tag: 'Running' },
+      clock: unsafeClock(8_640_000_000_000_001),
+    })
+
+    expect(transition).toMatchObject({
+      next: {
+        status: 'DEGRADED',
+        error: 'cycle clock: cycle operations clock is outside the supported UTC range: observed=8640000000000001',
+        health: {
+          checkedAt: null,
+          dependencies: {
+            cycleRunner: {
+              status: 'AVAILABLE',
+              checkedAt: '2026-07-20T00:00:00.000Z',
+              error: null,
+            },
+          },
+        },
+        cycle: {
+          condition: CycleOperationsCondition.Unknown,
+          reason: CycleOperationsReason.ObservationUnavailable,
+          checkedAt: null,
+          error: 'cycle operations clock is outside the supported UTC range: observed=8640000000000001',
+        },
+      },
+      failedDependencies: ['cycle'],
+      checkedAt: null,
+      clockFailure: {
+        _tag: 'UtcEpochMillisOutOfRange',
+        epochMillis: 8_640_000_000_000_001,
+      },
+    })
+  })
+
+  test('preserves the prior validated cycle-runner failure when the clock is unavailable', () => {
+    const progressAt = '2026-07-20T00:00:00.000Z'
+    const previousRunner = {
+      status: 'UNAVAILABLE' as const,
+      checkedAt: '2026-07-20T00:06:00.000Z',
+      error: 'autonomous cycle loop has not completed a successful pass for 360000ms',
+    }
+    const ready = readyState()
+    const current: RuntimeState = {
+      ...ready,
+      health: {
+        ...ready.health,
+        dependencies: { ...ready.health.dependencies, cycleRunner: previousRunner },
+      },
+      autonomousCycleLoop: {
+        configured: true,
+        startedAt: progressAt,
+        lastPass: { result: 'SUCCESS', observedAt: progressAt, outcome: 'NO_PUBLICATION' },
+      },
+    }
+    const transition = deriveHealthTransition(current, {
+      config,
+      evidenceAvailable: true,
+      results: {
+        postgresql: { _tag: 'Available', value: undefined },
+        signal: { _tag: 'Available', value: undefined },
+        tigerBeetle: { _tag: 'Available', value: undefined },
+        durableEvidence: { _tag: 'Available', value: undefined },
+        cycle: { _tag: 'Available', value: emptyCycleProjection() },
+        broker: null,
+      },
+      broker: undefined,
+      cycleFiber: { _tag: 'Running' },
+      clock: unsafeClock(8_640_000_000_000_001),
+    })
+
+    expect(transition).toMatchObject({
+      next: {
+        status: 'DEGRADED',
+        error: `${`cycleRunner: ${previousRunner.error}`}; cycle clock: cycle operations clock is outside the supported UTC range: observed=8640000000000001`,
+        health: { dependencies: { cycleRunner: previousRunner } },
+      },
+      failedDependencies: ['cycleRunner', 'cycle'],
+      clockFailure: {
+        _tag: 'UtcEpochMillisOutOfRange',
+        epochMillis: 8_640_000_000_000_001,
+      },
+    })
+  })
+
+  test('degrades with a closed cycle-classification failure instead of defecting', () => {
+    const current = readyState()
+    const transition = deriveHealthTransition(current, {
+      config,
+      evidenceAvailable: true,
+      results: {
+        postgresql: { _tag: 'Available', value: undefined },
+        signal: { _tag: 'Available', value: undefined },
+        tigerBeetle: { _tag: 'Available', value: undefined },
+        durableEvidence: { _tag: 'Available', value: undefined },
+        cycle: { _tag: 'Available', value: emptyCycleProjection() },
+        broker: null,
+      },
+      broker: undefined,
+      cycleFiber: { _tag: 'NotProvided' },
+      clock: unsafeClock(Number.NaN),
+    })
+
+    expect(transition).toMatchObject({
+      next: {
+        status: 'DEGRADED',
+        error: 'cycle clock: cycle operations clock must be a safe integer epoch millisecond: observed=NaN',
+        cycle: {
+          condition: CycleOperationsCondition.Unknown,
+          reason: CycleOperationsReason.ObservationUnavailable,
+          checkedAt: null,
+          error: 'cycle operations clock must be a safe integer epoch millisecond: observed=NaN',
+        },
+        health: { checkedAt: null },
+      },
+      failedDependencies: ['cycle'],
+      checkedAt: null,
+      clockFailure: { _tag: 'UtcEpochMillisNotSafeInteger', epochMillis: Number.NaN },
+    })
+    const logDecisions = deriveHealthLogDecisions(transition)
+    expect(logDecisions).toMatchObject([
+      {
+        _tag: 'RuntimeStatusChanged',
+        level: 'WARNING',
+        message: 'Bayn health changed to DEGRADED',
+        annotations: {
+          service: 'bayn',
+          probeSequence: 2,
+          failedDependencies: 'cycle',
+        },
+      },
+      {
+        _tag: 'CycleOperationsChanged',
+        level: 'INFO',
+        message: 'Bayn cycle operations changed to UNKNOWN',
+        annotations: {
+          service: 'bayn',
+          cycleCondition: CycleOperationsCondition.Unknown,
+          cycleReason: CycleOperationsReason.ObservationUnavailable,
+        },
+      },
+    ])
+    expect(logDecisions.every((decision) => !('checkedAt' in decision.annotations))).toBe(true)
+  })
+
+  test('reports an unavailable cycle dependency once', () => {
+    const current = readyState()
+    const checkedAt = '2026-07-20T00:04:00.000Z'
+    const transition = deriveHealthTransition(current, {
+      config,
+      evidenceAvailable: true,
+      results: {
+        postgresql: { _tag: 'Available', value: undefined },
+        signal: { _tag: 'Available', value: undefined },
+        tigerBeetle: { _tag: 'Available', value: undefined },
+        durableEvidence: { _tag: 'Available', value: undefined },
+        cycle: { _tag: 'Unavailable', error: 'cycle projection timed out' },
+        broker: null,
+      },
+      broker: undefined,
+      cycleFiber: { _tag: 'NotProvided' },
+      clock: availableClock(checkedAt),
+    })
+
+    expect(transition).toMatchObject({
+      next: {
+        status: 'DEGRADED',
+        error: 'cycle: cycle projection timed out',
+        cycle: {
+          condition: CycleOperationsCondition.Unknown,
+          reason: CycleOperationsReason.ObservationUnavailable,
+          checkedAt,
+          error: 'cycle projection timed out',
+        },
+      },
+      failedDependencies: ['cycle'],
+    })
+  })
+
+  test('retains clock failure alongside an unavailable cycle projection and logs clock recovery', () => {
+    const projectionError = 'cycle projection timed out'
+    const clockError = 'cycle operations clock must be a safe integer epoch millisecond: observed=NaN'
+    const failed = deriveHealthTransition(readyState(), {
+      config,
+      evidenceAvailable: true,
+      results: {
+        postgresql: { _tag: 'Available', value: undefined },
+        signal: { _tag: 'Available', value: undefined },
+        tigerBeetle: { _tag: 'Available', value: undefined },
+        durableEvidence: { _tag: 'Available', value: undefined },
+        cycle: { _tag: 'Unavailable', error: projectionError },
+        broker: null,
+      },
+      broker: undefined,
+      cycleFiber: { _tag: 'NotProvided' },
+      clock: unsafeClock(Number.NaN),
+    })
+
+    expect(failed).toMatchObject({
+      next: {
+        status: 'DEGRADED',
+        error: `cycle: ${projectionError}; cycle clock: ${clockError}`,
+        cycle: {
+          condition: CycleOperationsCondition.Unknown,
+          reason: CycleOperationsReason.ObservationUnavailable,
+          checkedAt: null,
+          error: `${projectionError}; ${clockError}`,
+        },
+      },
+      failedDependencies: ['cycle'],
+      checkedAt: null,
+      clockFailure: { _tag: 'UtcEpochMillisNotSafeInteger', epochMillis: Number.NaN },
+    })
+
+    const checkedAt = '2026-07-20T00:04:00.000Z'
+    const recoveredClock = deriveHealthTransition(failed.next, {
+      config,
+      evidenceAvailable: true,
+      results: {
+        postgresql: { _tag: 'Available', value: undefined },
+        signal: { _tag: 'Available', value: undefined },
+        tigerBeetle: { _tag: 'Available', value: undefined },
+        durableEvidence: { _tag: 'Available', value: undefined },
+        cycle: { _tag: 'Unavailable', error: projectionError },
+        broker: null,
+      },
+      broker: undefined,
+      cycleFiber: { _tag: 'NotProvided' },
+      clock: availableClock(checkedAt),
+    })
+
+    expect(recoveredClock).toMatchObject({
+      next: {
+        status: 'DEGRADED',
+        error: `cycle: ${projectionError}`,
+        cycle: {
+          condition: CycleOperationsCondition.Unknown,
+          reason: CycleOperationsReason.ObservationUnavailable,
+          checkedAt,
+          error: projectionError,
+        },
+      },
+      failedDependencies: ['cycle'],
+      checkedAt,
+      clockFailure: null,
+    })
+    expect(deriveHealthLogDecisions(recoveredClock)).toMatchObject([
+      {
+        _tag: 'CycleOperationsChanged',
+        level: 'INFO',
+        message: 'Bayn cycle operations changed to UNKNOWN',
+        annotations: {
+          service: 'bayn',
+          checkedAt,
+          cycleCondition: CycleOperationsCondition.Unknown,
+          cycleReason: CycleOperationsReason.ObservationUnavailable,
+          cycleError: projectionError,
+        },
+      },
+    ])
+  })
+
+  test('logs a changed UNKNOWN cycle failure without fabricating its time', () => {
+    const checkedAt = '2026-07-20T00:04:00.000Z'
+    const unavailable = deriveHealthTransition(readyState(), {
+      config,
+      evidenceAvailable: true,
+      results: {
+        postgresql: { _tag: 'Available', value: undefined },
+        signal: { _tag: 'Available', value: undefined },
+        tigerBeetle: { _tag: 'Available', value: undefined },
+        durableEvidence: { _tag: 'Available', value: undefined },
+        cycle: { _tag: 'Unavailable', error: 'cycle projection timed out' },
+        broker: null,
+      },
+      broker: undefined,
+      cycleFiber: { _tag: 'NotProvided' },
+      clock: availableClock(checkedAt),
+    }).next
+    const invalidClock = deriveHealthTransition(unavailable, {
+      config,
+      evidenceAvailable: true,
+      results: {
+        postgresql: { _tag: 'Available', value: undefined },
+        signal: { _tag: 'Available', value: undefined },
+        tigerBeetle: { _tag: 'Available', value: undefined },
+        durableEvidence: { _tag: 'Available', value: undefined },
+        cycle: { _tag: 'Available', value: emptyCycleProjection() },
+        broker: null,
+      },
+      broker: undefined,
+      cycleFiber: { _tag: 'NotProvided' },
+      clock: unsafeClock(Number.NaN),
+    })
+
+    expect(deriveHealthLogDecisions(invalidClock)).toMatchObject([
+      {
+        _tag: 'CycleOperationsChanged',
+        level: 'INFO',
+        message: 'Bayn cycle operations changed to UNKNOWN',
+        annotations: {
+          service: 'bayn',
+          cycleCondition: CycleOperationsCondition.Unknown,
+          cycleReason: CycleOperationsReason.ObservationUnavailable,
+          cycleError: 'cycle operations clock must be a safe integer epoch millisecond: observed=NaN',
+        },
+      },
+    ])
+    expect(deriveHealthLogDecisions(invalidClock).every((decision) => !('checkedAt' in decision.annotations))).toBe(
+      true,
+    )
+  })
+
+  test('keeps the repeating probe alive when the injected clock is invalid', async () => {
+    const initial = readyState()
+    const state = await Effect.runPromise(Ref.make(initial))
+    const program = Effect.scoped(
+      Effect.gen(function* () {
+        yield* TestClock.setTime(Number.NaN)
+        yield* provideHealthyDependencies(initial, probe(config, state))
+        expect(yield* Ref.get(state)).toMatchObject({
+          status: 'DEGRADED',
+          error: 'cycle clock: cycle operations clock must be a safe integer epoch millisecond: observed=NaN',
+          health: {
+            checkedAt: null,
+            dependencies: {
+              postgresql: { checkedAt: null },
+              signal: { checkedAt: null },
+              tigerBeetle: { checkedAt: null },
+              evidence: { checkedAt: null },
+              cycle: { checkedAt: null },
+              cycleRunner: { checkedAt: null },
+            },
+          },
+          cycle: {
+            condition: CycleOperationsCondition.Unknown,
+            reason: CycleOperationsReason.ObservationUnavailable,
+            checkedAt: null,
+            error: 'cycle operations clock must be a safe integer epoch millisecond: observed=NaN',
+          },
+        })
+      }),
+    ).pipe(Effect.provide(TestClock.layer()))
+
+    await Effect.runPromise(program)
   })
 
   test('requires the configured broker account GET while keeping execution disabled under OBSERVE', async () => {

--- a/services/bayn/src/health/decisions.ts
+++ b/services/bayn/src/health/decisions.ts
@@ -4,7 +4,8 @@ import type { RuntimeConfig } from '../config'
 import type { FinalizedSnapshotProvenance } from '../contracts'
 import {
   CycleOperationsCondition,
-  deriveCycleOperationsStatus,
+  deriveCycleOperationsStatusResult,
+  renderCycleOperationsStatusFailure,
   type CycleOperationsProjection,
   type CycleOperationsStatus,
   unknownCycleOperationsStatus,
@@ -26,6 +27,7 @@ import type {
   HealthDependencyName,
   HealthFailureSummary,
   HealthLogDecision,
+  HealthProbeClock,
   HealthProbeResults,
   HealthTransition,
   HealthTransitionInput,
@@ -168,20 +170,21 @@ export const renderDurableEvidenceFailure = (failure: DurableEvidenceFailure): s
   return exhaustive
 }
 
-const dependencyHealth = <A>(result: ProbeResult<A>, checkedAt: string): DependencyHealth => ({
+const dependencyHealth = <A>(result: ProbeResult<A>, checkedAt: string | null): DependencyHealth => ({
   status: result._tag === 'Available' ? 'AVAILABLE' : 'UNAVAILABLE',
   checkedAt,
   error: result._tag === 'Available' ? null : result.error,
 })
 
 const cycleLoopHealth = (
+  previous: DependencyHealth,
   loop: AutonomousCycleLoopStatus,
   fiber: AutonomousCycleFiberObservation,
-  checkedAt: string,
-  checkedAtMs: number,
+  clock: HealthProbeClock,
   stallThresholdMs: number,
   required: boolean,
 ): DependencyHealth => {
+  const checkedAt = clock._tag === 'Available' ? clock.checkedAt : null
   const available = (): DependencyHealth => ({ status: 'AVAILABLE', checkedAt, error: null })
   const unavailable = (error: string): DependencyHealth => ({ status: 'UNAVAILABLE', checkedAt, error })
   if (!loop.configured) {
@@ -195,7 +198,8 @@ const cycleLoopHealth = (
   }
   const progressAt = loop.lastPass?.observedAt ?? loop.startedAt
   if (progressAt === null) return unavailable('autonomous cycle loop start time is unavailable')
-  const ageMs = checkedAtMs - Date.parse(progressAt)
+  if (clock._tag === 'Unavailable') return previous
+  const ageMs = clock.checkedAtMs - Date.parse(progressAt)
   if (!Number.isFinite(ageMs) || ageMs < 0) {
     return unavailable('autonomous cycle loop progress time is invalid or in the future')
   }
@@ -209,7 +213,7 @@ const deriveBrokerStatus = (
   current: BrokerStatus | null,
   broker: BrokerConfiguration | undefined,
   result: ProbeResult<string> | null,
-  checkedAt: string,
+  checkedAt: string | null,
 ): BrokerStatus | null => {
   if (broker === undefined) return current
   const observed = result ?? { _tag: 'Unavailable', error: 'broker probe did not run' }
@@ -237,20 +241,40 @@ const deriveBrokerStatus = (
 const deriveCycleStatus = (
   result: ProbeResult<CycleOperationsProjection>,
   config: RuntimeConfig,
-  checkedAt: string,
-  checkedAtMs: number,
+  clock: HealthProbeClock,
 ): CycleOperationsStatus => {
+  const clockError =
+    clock._tag === 'Unavailable'
+      ? renderCycleOperationsStatusFailure({
+          _tag: 'CycleOperationsClockInvalid',
+          nowMs: clock.observedAtMs,
+          cause: clock.failure,
+        })
+      : null
   if (result._tag === 'Available') {
-    return deriveCycleOperationsStatus(result.value, checkedAtMs, config.maximumAuthority, config)
+    if (clock._tag === 'Unavailable') return unknownCycleOperationsStatus(clockError)
+    return Result.match(
+      deriveCycleOperationsStatusResult(result.value, clock.checkedAtMs, config.maximumAuthority, config),
+      {
+        onFailure: (failure) => ({
+          ...unknownCycleOperationsStatus(renderCycleOperationsStatusFailure(failure)),
+          checkedAt: null,
+        }),
+        onSuccess: (status) => status,
+      },
+    )
   }
-  return { ...unknownCycleOperationsStatus(result.error), checkedAt }
+  return {
+    ...unknownCycleOperationsStatus(clockError === null ? result.error : `${result.error}; ${clockError}`),
+    checkedAt: clock._tag === 'Available' ? clock.checkedAt : null,
+  }
 }
 
 const deriveRuntimeHealth = (
   current: RuntimeState,
   results: HealthProbeResults,
   cycleRunner: DependencyHealth,
-  checkedAt: string,
+  checkedAt: string | null,
 ): RuntimeHealth => ({
   sequence: current.health.sequence + 1,
   checkedAt,
@@ -268,6 +292,7 @@ const summarizeHealthFailures = (
   health: RuntimeHealth,
   broker: BrokerStatus | null,
   cycle: CycleOperationsStatus,
+  clockError: string | null,
 ): HealthFailureSummary => {
   const dependencyFailures = (
     Object.entries(health.dependencies) as readonly [keyof RuntimeHealth['dependencies'], DependencyHealth][]
@@ -278,18 +303,25 @@ const summarizeHealthFailures = (
       ? `broker: ${broker.error ?? 'account binding unavailable'}`
       : null
   const cycleFailure =
-    cycle.condition === CycleOperationsCondition.Stalled || cycle.condition === CycleOperationsCondition.Failed
-      ? `cycle: ${cycle.reason}`
-      : null
+    dependencyNames.includes('cycle') || (clockError !== null && cycle.error === clockError)
+      ? null
+      : cycle.error !== null
+        ? `cycle: ${cycle.error}`
+        : cycle.condition === CycleOperationsCondition.Stalled || cycle.condition === CycleOperationsCondition.Failed
+          ? `cycle: ${cycle.reason}`
+          : null
   const brokerDependencies: readonly HealthDependencyName[] = brokerFailure === null ? [] : ['broker']
-  const cycleDependencies: readonly HealthDependencyName[] =
-    cycleFailure === null || dependencyNames.includes('cycle') ? [] : ['cycle']
+  const cycleDependencies: readonly HealthDependencyName[] = cycleFailure === null ? [] : ['cycle']
+  const clockDependencies: readonly HealthDependencyName[] = clockError === null ? [] : ['cycle']
   return {
-    failedDependencies: [...dependencyNames, ...brokerDependencies, ...cycleDependencies],
+    failedDependencies: [
+      ...new Set([...dependencyNames, ...brokerDependencies, ...cycleDependencies, ...clockDependencies]),
+    ],
     messages: [
       ...dependencyFailures.map(([name, dependency]) => `${name}: ${dependency.error}`),
       ...(brokerFailure === null ? [] : [brokerFailure]),
       ...(cycleFailure === null ? [] : [cycleFailure]),
+      ...(clockError === null ? [] : [`cycle clock: ${clockError}`]),
     ],
   }
 }
@@ -310,25 +342,36 @@ const deriveNextRuntimeState = (
 }
 
 export const deriveHealthTransition = (current: RuntimeState, input: HealthTransitionInput): HealthTransition => {
+  const checkedAt = input.clock._tag === 'Available' ? input.clock.checkedAt : null
+  const clockFailure = input.clock._tag === 'Unavailable' ? input.clock.failure : null
+  const clockError =
+    input.clock._tag === 'Unavailable'
+      ? renderCycleOperationsStatusFailure({
+          _tag: 'CycleOperationsClockInvalid',
+          nowMs: input.clock.observedAtMs,
+          cause: input.clock.failure,
+        })
+      : null
   const cycleRunner = cycleLoopHealth(
+    current.health.dependencies.cycleRunner,
     current.autonomousCycleLoop,
     input.cycleFiber,
-    input.checkedAt,
-    input.checkedAtMs,
+    input.clock,
     input.config.cycleStallThresholdMs,
     input.broker !== undefined,
   )
-  const cycle = deriveCycleStatus(input.results.cycle, input.config, input.checkedAt, input.checkedAtMs)
-  const broker = deriveBrokerStatus(current.broker, input.broker, input.results.broker, input.checkedAt)
-  const health = deriveRuntimeHealth(current, input.results, cycleRunner, input.checkedAt)
-  const failures = summarizeHealthFailures(health, broker, cycle)
+  const cycle = deriveCycleStatus(input.results.cycle, input.config, input.clock)
+  const broker = deriveBrokerStatus(current.broker, input.broker, input.results.broker, checkedAt)
+  const health = deriveRuntimeHealth(current, input.results, cycleRunner, checkedAt)
+  const failures = summarizeHealthFailures(health, broker, cycle, clockError)
   const next = deriveNextRuntimeState(current, input.evidenceAvailable, health, cycle, broker, failures)
   return {
     current,
     next,
     health,
     failedDependencies: failures.failedDependencies,
-    checkedAt: input.checkedAt,
+    checkedAt,
+    clockFailure,
   }
 }
 
@@ -340,7 +383,7 @@ const runtimeStatusLogDecision = (transition: HealthTransition): HealthLogDecisi
     message: `Bayn health changed to ${transition.next.status}`,
     annotations: {
       service: 'bayn',
-      checkedAt: transition.checkedAt,
+      ...(transition.checkedAt === null ? {} : { checkedAt: transition.checkedAt }),
       probeSequence: transition.health.sequence,
       failedDependencies: transition.failedDependencies.join(','),
     },
@@ -350,7 +393,8 @@ const runtimeStatusLogDecision = (transition: HealthTransition): HealthLogDecisi
 const cycleOperationsLogDecision = (transition: HealthTransition): HealthLogDecision | null => {
   if (
     transition.next.cycle.condition === transition.current.cycle.condition &&
-    transition.next.cycle.reason === transition.current.cycle.reason
+    transition.next.cycle.reason === transition.current.cycle.reason &&
+    transition.next.cycle.error === transition.current.cycle.error
   ) {
     return null
   }
@@ -365,9 +409,10 @@ const cycleOperationsLogDecision = (transition: HealthTransition): HealthLogDeci
     message: `Bayn cycle operations changed to ${cycle.condition}`,
     annotations: {
       service: 'bayn',
-      checkedAt: transition.checkedAt,
+      ...(transition.checkedAt === null ? {} : { checkedAt: transition.checkedAt }),
       cycleCondition: cycle.condition,
       cycleReason: cycle.reason,
+      ...(cycle.error === null ? {} : { cycleError: cycle.error }),
       currentCycleId: cycle.current?.cycleId ?? '',
       currentPhase: cycle.current?.phase ?? '',
       signalSessionDate: cycle.current?.signalSessionDate ?? '',

--- a/services/bayn/src/health/model.ts
+++ b/services/bayn/src/health/model.ts
@@ -4,6 +4,7 @@ import type { CycleOperationsProjection } from '../cycle-observability'
 import type { QualificationRecord } from '../db/evidence-store'
 import type { CanonicalHashFailure } from '../hash'
 import type { BrokerConfiguration, RuntimeHealth, RuntimeState } from '../runtime-state'
+import type { UtcEpochMillisFailure } from '../time'
 
 export type ProbeResult<A> =
   | { readonly _tag: 'Available'; readonly value: A }
@@ -70,14 +71,25 @@ export type AutonomousCycleFiberObservation =
   | { readonly _tag: 'ExitedSuccessfully' }
   | { readonly _tag: 'ExitedWithFailure'; readonly error: string }
 
+export type HealthProbeClock =
+  | {
+      readonly _tag: 'Available'
+      readonly checkedAt: string
+      readonly checkedAtMs: number
+    }
+  | {
+      readonly _tag: 'Unavailable'
+      readonly observedAtMs: number
+      readonly failure: UtcEpochMillisFailure
+    }
+
 export interface HealthTransitionInput {
   readonly config: RuntimeConfig
   readonly evidenceAvailable: boolean
   readonly results: HealthProbeResults
   readonly broker: BrokerConfiguration | undefined
   readonly cycleFiber: AutonomousCycleFiberObservation
-  readonly checkedAt: string
-  readonly checkedAtMs: number
+  readonly clock: HealthProbeClock
 }
 
 export interface HealthFailureSummary {
@@ -90,7 +102,8 @@ export interface HealthTransition {
   readonly next: RuntimeState
   readonly health: RuntimeHealth
   readonly failedDependencies: readonly HealthDependencyName[]
-  readonly checkedAt: string
+  readonly checkedAt: string | null
+  readonly clockFailure: UtcEpochMillisFailure | null
 }
 
 export type LogAnnotation = string | number | boolean

--- a/services/bayn/src/health/program.ts
+++ b/services/bayn/src/health/program.ts
@@ -1,4 +1,4 @@
-import { Cause, Clock, Duration, Effect, Exit, Fiber, Option, Ref, Schedule } from 'effect'
+import { Cause, Clock, Duration, Effect, Exit, Fiber, Option, Ref, Result, Schedule } from 'effect'
 
 import type { BrokerReadShape } from '../broker/alpaca'
 import type { RuntimeConfig } from '../config'
@@ -10,7 +10,7 @@ import { Journal } from '../ledger'
 import { MarketData } from '../market-data'
 import { databaseOperation, withinDeadline } from '../operations'
 import type { BrokerConfiguration, RuntimeEvidence, RuntimeState } from '../runtime-state'
-import { utcInstantFromEpochMillis } from '../time'
+import { utcInstantFromEpochMillisResult } from '../time'
 import {
   deriveHealthLogDecisions,
   deriveHealthTransition,
@@ -234,7 +234,11 @@ export const probe = (
       broker,
     )
     const checkedAtMs = yield* Clock.currentTimeMillis
-    const checkedAt = utcInstantFromEpochMillis(checkedAtMs)
+    const checkedAtResult = utcInstantFromEpochMillisResult(checkedAtMs)
+    const clock = Result.match(checkedAtResult, {
+      onFailure: (failure) => ({ _tag: 'Unavailable' as const, observedAtMs: checkedAtMs, failure }),
+      onSuccess: (checkedAt) => ({ _tag: 'Available' as const, checkedAt, checkedAtMs }),
+    })
     const cycleFiber = sampleAutonomousCycleFiber(autonomousCycleFiber)
     const transition = yield* Ref.modify(state, (current) => {
       const decision = deriveHealthTransition(current, {
@@ -243,8 +247,7 @@ export const probe = (
         results,
         broker: brokerConfiguration(broker),
         cycleFiber,
-        checkedAt,
-        checkedAtMs,
+        clock,
       })
       return [decision, decision.next] as const
     })

--- a/services/bayn/src/time.test.ts
+++ b/services/bayn/src/time.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 
-import { Effect } from 'effect'
+import { Effect, Result } from 'effect'
 import { TestClock } from 'effect/testing'
 
 import {
@@ -9,6 +9,7 @@ import {
   currentUtcInstant,
   utcDateFromEpochMillis,
   utcInstantFromEpochMillis,
+  utcInstantFromEpochMillisResult,
 } from './time'
 
 describe('Bayn UTC clock boundary', () => {
@@ -18,6 +19,18 @@ describe('Bayn UTC clock boundary', () => {
     expect(utcInstantFromEpochMillis(epochMillis)).toBe('2026-07-26T06:23:57.295Z')
     expect(utcDateFromEpochMillis(epochMillis)).toBe('2026-07-26')
     expect(addUtcDays('2026-12-31', 1)).toBe('2027-01-01')
+  })
+
+  test('returns closed failures for invalid epoch milliseconds', () => {
+    expect(utcInstantFromEpochMillisResult(0.5)).toEqual(
+      Result.fail({ _tag: 'UtcEpochMillisNotSafeInteger', epochMillis: 0.5 }),
+    )
+    expect(utcInstantFromEpochMillisResult(Number.NaN)).toEqual(
+      Result.fail({ _tag: 'UtcEpochMillisNotSafeInteger', epochMillis: Number.NaN }),
+    )
+    expect(utcInstantFromEpochMillisResult(8_640_000_000_000_001)).toEqual(
+      Result.fail({ _tag: 'UtcEpochMillisOutOfRange', epochMillis: 8_640_000_000_000_001 }),
+    )
   })
 
   test('samples the injected Effect clock for instant and date projections', async () => {

--- a/services/bayn/src/time.ts
+++ b/services/bayn/src/time.ts
@@ -1,4 +1,24 @@
-import { Clock, DateTime, Effect, pipe } from 'effect'
+import { Clock, DateTime, Effect, Option, pipe, Result } from 'effect'
+
+export type UtcEpochMillisFailure =
+  | {
+      readonly _tag: 'UtcEpochMillisNotSafeInteger'
+      readonly epochMillis: number
+    }
+  | {
+      readonly _tag: 'UtcEpochMillisOutOfRange'
+      readonly epochMillis: number
+    }
+
+export const utcInstantFromEpochMillisResult = (epochMillis: number): Result.Result<string, UtcEpochMillisFailure> => {
+  if (!Number.isSafeInteger(epochMillis)) {
+    return Result.fail({ _tag: 'UtcEpochMillisNotSafeInteger', epochMillis })
+  }
+  return Option.match(DateTime.make(epochMillis), {
+    onNone: () => Result.fail({ _tag: 'UtcEpochMillisOutOfRange', epochMillis }),
+    onSome: (dateTime) => Result.succeed(DateTime.formatIso(dateTime)),
+  })
+}
 
 export const utcInstantFromEpochMillis = (epochMillis: number): string =>
   DateTime.formatIso(DateTime.makeUnsafe(epochMillis))


### PR DESCRIPTION
## Summary

- add a total UTC epoch-millisecond conversion using Effect `DateTime.make` and a closed `Result` failure algebra
- expose a Result-returning cycle-operations classifier while retaining the existing compatibility facade
- make health classification degrade to an explicit unavailable cycle status when its sampled clock is invalid instead of defecting
- preserve all valid clock output, cycle lifecycle precedence, authority/reconciliation safety checks, database projections, and durable store behavior

## Related Issues

None

## Testing

- focused time, cycle observability, health, and coordinator compatibility coverage: 63 passed, 0 failed
- `bun run --filter @proompteng/bayn test` — 732 passed, 120 PostgreSQL-only skipped, 0 failed
- `bun test packages/scripts/src/bayn` — 20 passed, 0 failed
- PostgreSQL 18: cycle observability 5 passed; EvidenceStore 64 passed; PaperStore 30 passed; CycleStore 13 passed
- TypeScript direct compiler — 0 errors (`bun node_modules/typescript/bin/tsc --noEmit --pretty false -p services/bayn/tsconfig.json`)
- Effect diagnostics — 231 files, 0 errors, warnings, or messages
- Oxfmt and Oxlint standard/type-aware modes
- production build and `git diff --check`

The workspace `bunx tsc` launcher exits without diagnostics in this container; the exact direct TypeScript compiler invocation above passed before and after rebasing onto current main.

## Breaking Changes

None. Valid cycle status output and the existing `deriveCycleOperationsStatus` API remain unchanged; health uses the new total Result path.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
