### PR TITLE
refactor(bayn): expose replica read requirements

### DIFF
--- a/services/bayn/src/market-data/index.ts
+++ b/services/bayn/src/market-data/index.ts
@@ -13,7 +13,7 @@ export type {
 } from './model'
 export type { SignalBarRow, SignalManifestRow, SignalSessionRow, SnapshotRows } from './rows'
 export { marketDataOperationError } from './errors'
-export { MarketDataLive } from './program'
+export { makeMarketData, MarketDataLive } from './program'
 export {
   renderMarketDataVerificationError,
   selectCyclePublicationManifests,

--- a/services/bayn/src/market-data/program.ts
+++ b/services/bayn/src/market-data/program.ts
@@ -33,7 +33,7 @@ import { decodeSnapshotRows, type SignalManifestRow } from './rows'
 // MarketData seam complete while the runner clamps by calendar date before its single broker-calendar read.
 const cyclePublicationCandidateLimit = 16
 
-const makeMarketData = (
+export const makeMarketData = (
   config: Pick<RuntimeConfig, 'clickhouse' | 'operationTimeoutMs'>,
   contract: MarketDataContract,
 ): Effect.Effect<MarketDataService, never, ClickhouseClient.ClickhouseClient> =>

--- a/services/bayn/src/qualification-candidate/live.test.ts
+++ b/services/bayn/src/qualification-candidate/live.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test'
-import { Deferred, Effect, Fiber, Redacted, Ref } from 'effect'
+import { Context, Deferred, Effect, Fiber, Redacted, Ref } from 'effect'
 
 import { readCandidateReplica, readQualificationLocks } from './live'
 import type { CandidateConfig } from './model'
@@ -23,6 +23,14 @@ const candidateConfig = (): CandidateConfig => ({
   tigerBeetleLedger: candidateInput().tigerBeetleLedger,
   operationTimeoutMs: 5_000,
 })
+
+class ReplicaAcquireRequirement extends Context.Service<ReplicaAcquireRequirement, { readonly enabled: true }>()(
+  'bayn/test/ReplicaAcquireRequirement',
+) {}
+
+class ReplicaReadRequirement extends Context.Service<ReplicaReadRequirement, { readonly enabled: true }>()(
+  'bayn/test/ReplicaReadRequirement',
+) {}
 
 describe('qualification candidate live client lifecycle', () => {
   test('acquires and releases the ClickHouse client exactly once after a successful replica read', async () => {
@@ -87,6 +95,52 @@ describe('qualification candidate live client lifecycle', () => {
     )
 
     expect(counts).toEqual({ acquisitions: 1, releases: 1 })
+  })
+
+  test('keeps ClickHouse acquisition and replica-read requirements visible at separate boundaries', async () => {
+    let acquireRequirements = 0
+    let readRequirements = 0
+    let releases = 0
+    const observation = candidateObservations()[0]
+
+    const program: Effect.Effect<
+      ReturnType<typeof candidateObservations>[number],
+      unknown,
+      ReplicaAcquireRequirement | ReplicaReadRequirement
+    > = readCandidateReplica(
+      candidateInput(),
+      candidateReplicaEndpoints[0],
+      Redacted.make('publisher-password'),
+      5_000,
+      () =>
+        ReplicaAcquireRequirement.pipe(
+          Effect.tap(() => Effect.sync(() => void (acquireRequirements += 1))),
+          Effect.flatMap(() =>
+            Effect.acquireRelease(
+              Effect.succeed({
+                read: ReplicaReadRequirement.pipe(
+                  Effect.tap(() => Effect.sync(() => void (readRequirements += 1))),
+                  Effect.as(observation),
+                ),
+              }),
+              () => Effect.sync(() => void (releases += 1)),
+            ),
+          ),
+        ),
+    )
+    const result = await Effect.runPromise(
+      program.pipe(
+        Effect.provideService(ReplicaAcquireRequirement, { enabled: true }),
+        Effect.provideService(ReplicaReadRequirement, { enabled: true }),
+      ),
+    )
+
+    expect(result).toEqual(observation)
+    expect({ acquireRequirements, readRequirements, releases }).toEqual({
+      acquireRequirements: 1,
+      readRequirements: 1,
+      releases: 1,
+    })
   })
 
   test('acquires and releases the PostgreSQL client exactly once after a successful lock read', async () => {

--- a/services/bayn/src/qualification-candidate/live.ts
+++ b/services/bayn/src/qualification-candidate/live.ts
@@ -2,10 +2,10 @@ import type { ConnectionOptions } from 'node:tls'
 
 import { ClickhouseClient } from '@effect/sql-clickhouse'
 import { PgClient } from '@effect/sql-pg'
-import { Context, Effect, FileSystem, Layer, PlatformError, Redacted, Scope } from 'effect'
+import { Effect, FileSystem, PlatformError, Redacted, Scope } from 'effect'
 import * as Reactivity from 'effect/unstable/reactivity/Reactivity'
 
-import { MarketData, MarketDataLive } from '../market-data'
+import { makeMarketData } from '../market-data'
 import type { IsoDate } from '../schemas'
 import type { CausalProtocol } from '../types'
 import type { QualificationCandidateFailure } from './failure'
@@ -50,15 +50,15 @@ const makeCandidateClickhouse = (
   })
 
 export interface CandidateReplicaClient<R, E> {
-  readonly read: Effect.Effect<CandidateReplicaObservation, E, Scope.Scope | R>
+  readonly read: Effect.Effect<CandidateReplicaObservation, E, R>
 }
 
-export type AcquireCandidateReplicaClient<R, AcquireError, ReadError> = (
+export type AcquireCandidateReplicaClient<AcquireR, ReadR, AcquireError, ReadError> = (
   input: QualificationCandidateInput,
   endpoint: CandidateReplicaEndpoint,
   password: Redacted.Redacted<string>,
   operationTimeoutMs: number,
-) => Effect.Effect<CandidateReplicaClient<R, ReadError>, AcquireError, Scope.Scope | R>
+) => Effect.Effect<CandidateReplicaClient<ReadR, ReadError>, AcquireError, Scope.Scope | AcquireR>
 
 const acquireCandidateReplicaClient = (
   input: QualificationCandidateInput,
@@ -75,42 +75,39 @@ const acquireCandidateReplicaClient = (
         } = yield* Effect.all(
           {
             identityRows: sql`
-              SELECT hostName() AS replica, currentUser() AS principal
-            `.pipe(sql.withQueryId('bayn-candidate-replica-identity'), Effect.flatMap(decodeReplicaIdentityRows)),
+                SELECT hostName() AS replica, currentUser() AS principal
+              `.pipe(sql.withQueryId('bayn-candidate-replica-identity'), Effect.flatMap(decodeReplicaIdentityRows)),
             candidateRows: sql`
-              SELECT snapshot_id, calendar_version
-              FROM signal.snapshot_manifests_v2
-              WHERE universe_id = ${sql.param('String', input.protocol.universeId)}
-                AND universe_symbol_hash = ${sql.param('String', input.protocol.universeSymbolHash)}
-                AND requested_start = toDate(${sql.param('String', input.protocol.historyStart)})
-                AND publication_asof = toDate(${sql.param('String', input.publicationDate)})
-              ORDER BY finalized_at DESC, snapshot_id DESC
-              LIMIT 1
-            `.pipe(
+                SELECT snapshot_id, calendar_version
+                FROM signal.snapshot_manifests_v2
+                WHERE universe_id = ${sql.param('String', input.protocol.universeId)}
+                  AND universe_symbol_hash = ${sql.param('String', input.protocol.universeSymbolHash)}
+                  AND requested_start = toDate(${sql.param('String', input.protocol.historyStart)})
+                  AND publication_asof = toDate(${sql.param('String', input.publicationDate)})
+                ORDER BY finalized_at DESC, snapshot_id DESC
+                LIMIT 1
+              `.pipe(
               sql.withQueryId(`bayn-candidate-select-${input.publicationDate}`),
               Effect.flatMap(decodeCandidateRows),
             ),
           },
           { concurrency: 1 },
         )
-        const marketDataContext = yield* Layer.build(
-          MarketDataLive(
-            {
-              operationTimeoutMs,
-              clickhouse: {
-                url: endpoint.href,
-                username: input.publisherPrincipal,
-                password,
-                snapshotId: candidate.snapshot_id,
-                publicationAsOf: input.publicationDate,
-                calendarVersion: candidate.calendar_version,
-                bounds: candidateBounds(input.protocol, input.publicationDate),
-              },
+        const marketData = yield* makeMarketData(
+          {
+            operationTimeoutMs,
+            clickhouse: {
+              url: endpoint.href,
+              username: input.publisherPrincipal,
+              password,
+              snapshotId: candidate.snapshot_id,
+              publicationAsOf: input.publicationDate,
+              calendarVersion: candidate.calendar_version,
+              bounds: candidateBounds(input.protocol, input.publicationDate),
             },
-            input.protocol,
-          ).pipe(Layer.provide(Layer.succeed(ClickhouseClient.ClickhouseClient, sql))),
-        )
-        const marketData = Context.get(marketDataContext, MarketData)
+          },
+          input.protocol,
+        ).pipe(Effect.provideService(ClickhouseClient.ClickhouseClient, sql))
         const snapshot = yield* marketData.loadSnapshotPublication({
           snapshotId: candidate.snapshot_id,
           signalSessionDate: input.publicationDate,
@@ -126,13 +123,13 @@ const acquireCandidateReplicaClient = (
     })),
   )
 
-const readCandidateReplicaWith = <R, AcquireError, ReadError>(
+const readCandidateReplicaWith = <AcquireR, ReadR, AcquireError, ReadError>(
   input: QualificationCandidateInput,
   endpoint: CandidateReplicaEndpoint,
   password: Redacted.Redacted<string>,
   operationTimeoutMs: number,
-  acquireClient: AcquireCandidateReplicaClient<R, AcquireError, ReadError>,
-): Effect.Effect<CandidateReplicaObservation, QualificationCandidateFailure, R> =>
+  acquireClient: AcquireCandidateReplicaClient<AcquireR, ReadR, AcquireError, ReadError>,
+): Effect.Effect<CandidateReplicaObservation, QualificationCandidateFailure, Exclude<AcquireR | ReadR, Scope.Scope>> =>
   Effect.scoped(
     acquireClient(input, endpoint, password, operationTimeoutMs).pipe(Effect.flatMap((client) => client.read)),
   ).pipe(
@@ -151,20 +148,24 @@ export function readCandidateReplica(
   password: Redacted.Redacted<string>,
   operationTimeoutMs: number,
 ): Effect.Effect<CandidateReplicaObservation, QualificationCandidateFailure, Reactivity.Reactivity>
-export function readCandidateReplica<R, AcquireError, ReadError>(
+export function readCandidateReplica<AcquireR, ReadR, AcquireError, ReadError>(
   input: QualificationCandidateInput,
   endpoint: CandidateReplicaEndpoint,
   password: Redacted.Redacted<string>,
   operationTimeoutMs: number,
-  acquireClient: AcquireCandidateReplicaClient<R, AcquireError, ReadError>,
-): Effect.Effect<CandidateReplicaObservation, QualificationCandidateFailure, R>
-export function readCandidateReplica<R, AcquireError, ReadError>(
+  acquireClient: AcquireCandidateReplicaClient<AcquireR, ReadR, AcquireError, ReadError>,
+): Effect.Effect<CandidateReplicaObservation, QualificationCandidateFailure, Exclude<AcquireR | ReadR, Scope.Scope>>
+export function readCandidateReplica<AcquireR, ReadR, AcquireError, ReadError>(
   input: QualificationCandidateInput,
   endpoint: CandidateReplicaEndpoint,
   password: Redacted.Redacted<string>,
   operationTimeoutMs: number,
-  acquireClient?: AcquireCandidateReplicaClient<R, AcquireError, ReadError>,
-): Effect.Effect<CandidateReplicaObservation, QualificationCandidateFailure, R | Reactivity.Reactivity> {
+  acquireClient?: AcquireCandidateReplicaClient<AcquireR, ReadR, AcquireError, ReadError>,
+): Effect.Effect<
+  CandidateReplicaObservation,
+  QualificationCandidateFailure,
+  Exclude<AcquireR | ReadR, Scope.Scope> | Reactivity.Reactivity
+> {
   return acquireClient === undefined
     ? readCandidateReplicaWith(input, endpoint, password, operationTimeoutMs, acquireCandidateReplicaClient)
     : readCandidateReplicaWith(input, endpoint, password, operationTimeoutMs, acquireClient)


### PR DESCRIPTION
## Summary

- remove nested `Layer.build` and `Context.get` from the qualification ClickHouse replica read
- construct the MarketData capability directly from the already-scoped ClickHouse client through the stable MarketData facade
- separate replica-client acquisition requirements from read-operation requirements in the public test seam
- discharge `Scope` at `readCandidateReplica` while preserving interruption and exactly-once release
- add a regression proving acquisition and read requirements remain separately visible in the Effect environment

## Related Issues

None

## Testing

- `bun test services/bayn/src/qualification-candidate/live.test.ts services/bayn/src/market-data.test.ts` — 25 passed, 0 failed
- `bun run --cwd services/bayn test` — 731 passed, 120 PostgreSQL-gated skips, 0 failed
- `bun node_modules/typescript/bin/tsc --noEmit -p services/bayn/tsconfig.json`
- `bun services/bayn/node_modules/@effect/tsgo/dist/effect-tsgo.js diagnostics --project services/bayn/tsconfig.json --format text --severity error`
- `bun node_modules/oxfmt/bin/oxfmt --check services/bayn/src`
- `bun node_modules/oxlint/bin/oxlint --config .oxlintrc.json services/bayn`
- `bun node_modules/oxlint/bin/oxlint --config .oxlintrc.json --type-aware --tsconfig services/bayn/tsconfig.json services/bayn`
- `bun build services/bayn/src/index.ts --target=node --external tigerbeetle-node --outdir=services/bayn/dist`
- `bun test packages/scripts/src/bayn` — 20 passed, 0 failed
- `git diff --check`

## Breaking Changes

None. Existing callers continue to infer their requirements; the generic test seam now distinguishes acquisition and read environments.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] Documentation and release notes are not required for this internal capability-boundary correction.
