### PR TITLE
refactor(bayn): totalize coordinator instants

### DIFF
--- a/services/bayn/src/execution/coordinator-decisions.test.ts
+++ b/services/bayn/src/execution/coordinator-decisions.test.ts
@@ -251,6 +251,11 @@ describe('execution coordinator decisions', () => {
       field: 'current-time',
       value: Number.NaN,
     })
+    expectInvalidInstant(validateActiveSubmitRiskDecision(stored(), 0.5), {
+      operation: MutationOperation.Submit,
+      field: 'current-time',
+      value: 0.5,
+    })
     expectInvalidInstant(validateActiveSubmitRiskDecision(stored(), Number.MAX_VALUE), {
       operation: MutationOperation.Submit,
       field: 'current-time',
@@ -268,6 +273,14 @@ describe('execution coordinator decisions', () => {
         Number.NaN,
       ),
       { operation: MutationOperation.Submit, field: 'current-time', value: Number.NaN },
+    )
+    expectInvalidInstant(
+      ensureRecoveryDelay(
+        MutationOperation.Submit,
+        mutation(MutationOperation.Submit, MutationEventType.SubmitUnknown),
+        0.5,
+      ),
+      { operation: MutationOperation.Submit, field: 'current-time', value: 0.5 },
     )
     expectInvalidInstant(
       ensureRecoveryDelay(

--- a/services/bayn/src/execution/coordinator-decisions.ts
+++ b/services/bayn/src/execution/coordinator-decisions.ts
@@ -21,6 +21,7 @@ import {
 import { canonicalHashV1Result } from '../hash'
 import { IntentState, RiskOutcome, TerminalOutcome, type Intent } from '../paper'
 import { UtcInstantSchema } from '../schemas'
+import { utcInstantFromEpochMillisResult } from '../time'
 import type { StoredIntent } from './intents/domain'
 import { MutationEventType, type MutationEvent } from './mutations'
 
@@ -166,6 +167,7 @@ interface CancelReceipt {
 }
 
 const completeMutationEvidence = Schema.is(MutationEvidenceSchema)
+const isUtcInstant = Schema.is(UtcInstantSchema)
 
 export const selectStoredIntent = (
   operation: MutationOperation,
@@ -188,18 +190,16 @@ const parseInstant = (
     : Result.fail({ _tag: 'InvalidInstant', operation, field, value })
 }
 
-const isUtcInstant = Schema.is(UtcInstantSchema)
-
 const formatInstant = (
   operation: MutationOperation,
   field: Extract<ExecutionDecisionFailure, { readonly _tag: 'InvalidInstant' }>['field'],
   epochMillis: number,
 ): Result.Result<string, ExecutionDecisionFailure> =>
   Result.flatMap(
-    Result.try({
-      try: () => new Date(epochMillis).toISOString(),
-      catch: (): ExecutionDecisionFailure => ({ _tag: 'InvalidInstant', operation, field, value: epochMillis }),
-    }),
+    Result.mapError(
+      utcInstantFromEpochMillisResult(epochMillis),
+      (): ExecutionDecisionFailure => ({ _tag: 'InvalidInstant', operation, field, value: epochMillis }),
+    ),
     (instant) =>
       isUtcInstant(instant)
         ? Result.succeed(instant)


### PR DESCRIPTION
## Summary

- replace exception-backed coordinator epoch formatting with the shared total UTC epoch-millisecond Result boundary
- reject fractional and other non-safe-integer clock samples before risk-expiry or recovery-delay comparisons can observe a different unrounded value
- preserve the existing `InvalidInstant` public failure algebra and the four-digit durable UTC instant contract
- preserve all successful submit/cancel recovery ordering, consistency delays, mutation transitions, and PostgreSQL transaction behavior

## Related Issues

None

## Testing

- focused time and execution coordinator coverage: 37 passed, 0 failed
- `bun run --filter @proompteng/bayn test` — 750 passed, 121 PostgreSQL-only skipped, 0 failed
- `bun test packages/scripts/src/bayn` — 20 passed, 0 failed
- PostgreSQL 18: EvidenceStore 65 passed; PaperStore 30 passed; CycleStore 13 passed
- TypeScript direct compiler — 0 errors
- Effect diagnostics — 256 files, 0 errors, warnings, or messages
- Oxfmt and Oxlint standard/type-aware modes
- production build and `git diff --check`

## Breaking Changes

None. Successful coordinator timestamps and the existing `InvalidInstant` contract are unchanged; fractional epochs now fail closed instead of being truncated.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
