### PR TITLE
refactor(bayn): totalize ledger plan hashing

### DIFF
--- a/services/bayn/src/accounting/domain.test.ts
+++ b/services/bayn/src/accounting/domain.test.ts
@@ -230,6 +230,19 @@ describe('paper accounting', () => {
         actualType: 'string',
       },
     })
+    expect(failureOf(prepareAccounting(eventId, fill(), emptyPosition, Number.NaN))).toEqual({
+      _tag: 'AccountingCanonicalizationFailed',
+      operation: 'ledger-plan',
+      cause: {
+        _tag: 'LedgerPlanHashCanonicalizationFailed',
+        cause: {
+          _tag: 'CanonicalJsonFailure',
+          path: '$.accounts[0].ledger',
+          reason: 'non-finite-number',
+          actualType: 'number',
+        },
+      },
+    })
   })
 
   test('validates decoded transaction content and ledger identity as separate failures', () => {

--- a/services/bayn/src/accounting/domain.ts
+++ b/services/bayn/src/accounting/domain.ts
@@ -3,7 +3,7 @@ import { AccountFlags } from 'tigerbeetle-node'
 import { pipe, Result } from 'effect'
 
 import { canonicalHashV1Result, stableU128, stableU64 } from '../hash'
-import { AccountCode, hashLedgerPlan, LEDGER_SCHEMA_VERSION, TransferCode, type LedgerPlan } from '../ledger-plan'
+import { AccountCode, hashLedgerPlanResult, LEDGER_SCHEMA_VERSION, TransferCode, type LedgerPlan } from '../ledger-plan'
 import { OrderSide, type Fill } from '../paper'
 import { roundUnsignedHalfUp } from '../unsigned-round-half-up'
 import { type AccountingFailure, type AccountingHashOperation, type AccountingMicrosField } from './failure'
@@ -317,10 +317,11 @@ const hashAccountingMaterial = (
   }))
 
 const hashAccountingLedgerPlan = (plan: LedgerPlan): Result.Result<string, AccountingFailure> =>
-  Result.mapError(
-    Result.try(() => hashLedgerPlan(plan)),
-    (cause) => ({ _tag: 'AccountingCanonicalizationFailed', operation: 'ledger-plan', cause }),
-  )
+  Result.mapError(hashLedgerPlanResult(plan), (cause) => ({
+    _tag: 'AccountingCanonicalizationFailed',
+    operation: 'ledger-plan',
+    cause,
+  }))
 
 const requireContentHash = (
   transaction: AccountingTransaction,

--- a/services/bayn/src/db/paper-store.integration.test.ts
+++ b/services/bayn/src/db/paper-store.integration.test.ts
@@ -11,7 +11,7 @@ import { makeStrategyProtocolHash } from '../contracts'
 import { operationalError } from '../errors'
 import { WriterFence, WriterFenceError, WriterFenceLive, type WriterFenceService } from '../execution/writer-fence'
 import { canonicalHashV1 } from '../hash'
-import { hashLedgerPlan } from '../ledger-plan'
+import { hashLedgerPlanResult } from '../ledger-plan'
 import { Journal, type JournalService } from '../ledger'
 import {
   AccountStatus,
@@ -241,7 +241,7 @@ interface JournalControl {
 const journal = (control: JournalControl): JournalService => ({
   post: (plan) =>
     Effect.suspend(() => {
-      control.planHashes.push(hashLedgerPlan(plan))
+      control.planHashes.push(successOfResult(hashLedgerPlanResult(plan)))
       return control.fail
         ? Effect.fail(operationalError('journal', 'post', 'injected TigerBeetle failure'))
         : Effect.void

--- a/services/bayn/src/ledger-plan.test.ts
+++ b/services/bayn/src/ledger-plan.test.ts
@@ -7,7 +7,7 @@ import { AccountFlags, type Account, type Transfer } from 'tigerbeetle-node'
 import {
   AccountCode,
   buildLedgerPlan,
-  hashLedgerPlan,
+  hashLedgerPlanResult,
   LEDGER_BATCH_MAX,
   preflightTransfers,
   reconcileLedgerPlan,
@@ -33,6 +33,8 @@ const assertFailure = <A, E>(result: Result.Result<A, E>): E => {
   assert(Result.isFailure(result), 'ledger plan decision must fail')
   return result.failure
 }
+
+const hashPlan = (plan: LedgerPlan): string => assertSuccess(hashLedgerPlanResult(plan))
 
 const assertLedgerPlanFailure = <A>(result: Result.Result<A, LedgerValidationError>): LedgerPlanFailureDetail => {
   const failure = assertFailure(result)
@@ -446,7 +448,56 @@ describe('ledger plan Result algebra', () => {
     )
     expect(first.accounts.every((account) => account.flags === AccountFlags.history)).toBeTrue()
     expect(first.transfers.every((transfer) => transfer.flags === 0 && transfer.amount > 0n)).toBeTrue()
-    expect(hashLedgerPlan(first)).toBe('9c6888ca700beb1c5fb698d28c6d42a5e0b913d4340b08554b475fe96da92074')
+    expect(hashPlan(first)).toBe('9c6888ca700beb1c5fb698d28c6d42a5e0b913d4340b08554b475fe96da92074')
+  })
+
+  test('returns exact ledger-plan hash access, serialization, and canonicalization failures', () => {
+    const plan = assertSuccess(buildLedgerPlan(evaluationResult(), ledger))
+    const accessCause = new Error('accounts unavailable')
+    const inaccessible = Object.defineProperty({ ...plan }, 'accounts', {
+      enumerable: true,
+      get: () => {
+        throw accessCause
+      },
+    }) as LedgerPlan
+    expect(assertFailure(hashLedgerPlanResult(inaccessible))).toEqual({
+      _tag: 'LedgerPlanHashAccessFailed',
+      source: 'accounts',
+      cause: accessCause,
+    })
+
+    const serializationCause = new Error('account field unavailable')
+    const hostileAccount = Object.defineProperty({ ...plan.accounts[0] }, 'ledger', {
+      enumerable: true,
+      get: () => {
+        throw serializationCause
+      },
+    }) as Account
+    expect(
+      assertFailure(hashLedgerPlanResult({ ...plan, accounts: [hostileAccount, ...plan.accounts.slice(1)] })),
+    ).toEqual({
+      _tag: 'LedgerPlanRecordSerializationFailed',
+      record: 'account',
+      ordinal: 0,
+      cause: serializationCause,
+    })
+
+    expect(
+      assertFailure(
+        hashLedgerPlanResult({
+          ...plan,
+          accounts: [{ ...plan.accounts[0], ledger: Number.NaN }, ...plan.accounts.slice(1)],
+        }),
+      ),
+    ).toEqual({
+      _tag: 'LedgerPlanHashCanonicalizationFailed',
+      cause: {
+        _tag: 'CanonicalJsonFailure',
+        path: '$.accounts[0].ledger',
+        reason: 'non-finite-number',
+        actualType: 'number',
+      },
+    })
   })
 
   test('accepts the last exact single-query size and rejects both next records', () => {

--- a/services/bayn/src/ledger-plan.ts
+++ b/services/bayn/src/ledger-plan.ts
@@ -100,6 +100,25 @@ export interface LedgerPlan {
   readonly transfers: readonly Transfer[]
 }
 
+export type LedgerPlanHashAccessSource = 'accounts' | 'run-key' | 'run-tag' | 'transfers'
+
+export type LedgerPlanHashFailure =
+  | {
+      readonly _tag: 'LedgerPlanHashAccessFailed'
+      readonly source: LedgerPlanHashAccessSource
+      readonly cause: unknown
+    }
+  | {
+      readonly _tag: 'LedgerPlanRecordSerializationFailed'
+      readonly record: 'account' | 'transfer'
+      readonly ordinal: number
+      readonly cause: unknown
+    }
+  | {
+      readonly _tag: 'LedgerPlanHashCanonicalizationFailed'
+      readonly cause: CanonicalJsonFailure
+    }
+
 export interface EvaluationLedgerPlan extends LedgerPlan {
   readonly runId: string
 }
@@ -713,18 +732,55 @@ export const buildLedgerPlan = (
 ): Result.Result<EvaluationLedgerPlan, LedgerPlanFailure> =>
   Result.mapError(buildLedgerPlanDecision(result, ledger), (failure) => makeLedgerPlanFailure(ledger, failure))
 
-const serializeRecord = (record: Account | Transfer): Record<string, number | string> =>
-  Object.fromEntries(
-    Object.entries(record).map(([key, value]) => [key, typeof value === 'bigint' ? value.toString() : value]),
-  )
+const accessLedgerPlan = <A>(
+  source: LedgerPlanHashAccessSource,
+  evaluate: () => A,
+): Result.Result<A, LedgerPlanHashFailure> =>
+  Result.try({
+    try: evaluate,
+    catch: (cause): LedgerPlanHashFailure => ({ _tag: 'LedgerPlanHashAccessFailed', source, cause }),
+  })
 
-export const hashLedgerPlan = (plan: LedgerPlan): string =>
-  canonicalHashV1({
-    schemaVersion: 'bayn.ledger-plan.v1',
-    runKey: plan.runKey.toString(),
-    runTag: plan.runTag.toString(),
-    accounts: plan.accounts.map(serializeRecord),
-    transfers: plan.transfers.map(serializeRecord),
+const serializeRecordResult = (
+  record: Account | Transfer,
+  kind: 'account' | 'transfer',
+  ordinal: number,
+): Result.Result<Record<string, number | string>, LedgerPlanHashFailure> =>
+  Result.try({
+    try: () =>
+      Object.fromEntries(
+        Object.entries(record).map(([key, value]) => [key, typeof value === 'bigint' ? value.toString() : value]),
+      ),
+    catch: (cause): LedgerPlanHashFailure => ({
+      _tag: 'LedgerPlanRecordSerializationFailed',
+      record: kind,
+      ordinal,
+      cause,
+    }),
+  })
+
+export const hashLedgerPlanResult = (plan: LedgerPlan): Result.Result<string, LedgerPlanHashFailure> =>
+  Result.gen(function* () {
+    const runKey = yield* accessLedgerPlan('run-key', () => plan.runKey.toString())
+    const runTag = yield* accessLedgerPlan('run-tag', () => plan.runTag.toString())
+    const accountRecords = yield* accessLedgerPlan('accounts', () => [...plan.accounts])
+    const transferRecords = yield* accessLedgerPlan('transfers', () => [...plan.transfers])
+    const accounts = yield* Result.all(
+      accountRecords.map((record, ordinal) => serializeRecordResult(record, 'account', ordinal)),
+    )
+    const transfers = yield* Result.all(
+      transferRecords.map((record, ordinal) => serializeRecordResult(record, 'transfer', ordinal)),
+    )
+    return yield* Result.mapError(
+      canonicalHashV1Result({
+        schemaVersion: 'bayn.ledger-plan.v1',
+        runKey,
+        runTag,
+        accounts,
+        transfers,
+      }),
+      (cause): LedgerPlanHashFailure => ({ _tag: 'LedgerPlanHashCanonicalizationFailed', cause }),
+    )
   })
 
 export const accountMetadataMatches = (actual: Account, expected: Account): boolean =>

--- a/services/bayn/src/ledger.test.ts
+++ b/services/bayn/src/ledger.test.ts
@@ -12,7 +12,7 @@ import {
   buildLedgerPlan,
   classifyAccountCreateBatch,
   classifyTransferCreateBatch,
-  hashLedgerPlan,
+  hashLedgerPlanResult,
   Journal,
   JournalLive,
   LedgerValidationError,
@@ -38,6 +38,8 @@ const assertFailure = <A, E>(result: Result.Result<A, E>): E => {
   assert(Result.isFailure(result), 'ledger decision fixture must fail')
   return result.failure
 }
+
+const hashPlan = (plan: LedgerPlan): string => assertSuccess(hashLedgerPlanResult(plan))
 
 const materializeAccounts = (plan: LedgerPlan): Account[] => {
   const balances = new Map(plan.accounts.map((account) => [account.id, { debits: 0n, credits: 0n }]))
@@ -353,9 +355,9 @@ describe('TigerBeetle simulation journal', () => {
     const first = assertSuccess(buildLedgerPlan(result, 7001))
     const second = assertSuccess(buildLedgerPlan(result, 7001))
     expect(first).toEqual(second)
-    expect(hashLedgerPlan(first)).toMatch(/^[a-f0-9]{64}$/)
-    expect(hashLedgerPlan(first)).toBe(hashLedgerPlan(second))
-    expect(hashLedgerPlan(first)).not.toBe(hashLedgerPlan(assertSuccess(buildLedgerPlan(result, 7002))))
+    expect(hashPlan(first)).toMatch(/^[a-f0-9]{64}$/)
+    expect(hashPlan(first)).toBe(hashPlan(second))
+    expect(hashPlan(first)).not.toBe(hashPlan(assertSuccess(buildLedgerPlan(result, 7002))))
     expect(first.accounts).toHaveLength(fixtureProtocol.universe.length + 6)
     expect(first.transfers.length).toBeGreaterThan(1)
     expect(

--- a/services/bayn/src/ledger.ts
+++ b/services/bayn/src/ledger.ts
@@ -433,7 +433,7 @@ export const JournalLive = (
   )
 export {
   buildLedgerPlan,
-  hashLedgerPlan,
+  hashLedgerPlanResult,
   LedgerValidationError,
   reconcileLedgerPlan,
   validatePersistedRunEvidence,


### PR DESCRIPTION
## Summary

- replace the throwing ledger-plan hash boundary with `hashLedgerPlanResult`
- preserve exact plan-access, record-serialization, and canonical-JSON failure facts
- propagate ledger hash failures through the existing accounting `Result` algebra
- remove the exported throwing `hashLedgerPlan` compatibility path
- add hostile record, inaccessible plan, and non-finite ledger regressions

## Related Issues

None

## Testing

- focused accounting/ledger tests: 51 passed, 0 failed
- full Bayn suite: 751 passed, 121 PostgreSQL-gated skips, 0 failed
- PostgreSQL 18 paper-store integration: 30 passed, 0 failed
- PostgreSQL 18 evidence-store integration: 65 passed, 0 failed
- TypeScript 7.0.2: passed
- Effect diagnostics: 256/256 files, 0 findings
- Oxfmt: passed
- standard and type-aware Oxlint: passed
- production build: 617 modules, 4.48 MB
- Bayn manifest tests: 20 passed, 0 failed
- pre-commit lint-staged and commit-message hooks: passed

## Breaking Changes

The internal throwing `hashLedgerPlan` export is removed. All repository callers now use the typed `hashLedgerPlanResult` boundary.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; breaking changes are documented.
- [x] No release note is required for this internal fail-closed boundary correction.
