### PR TITLE
refactor(bayn): totalize canonicalization boundaries

### DIFF
--- a/services/bayn/src/db/paper-store/accounting.ts
+++ b/services/bayn/src/db/paper-store/accounting.ts
@@ -6,7 +6,6 @@ import { renderAccountingFailure } from '../../accounting/failure'
 import type { PositionCost, PreparedAccounting } from '../../accounting/model'
 import type { AccountingTransaction } from '../../accounting/schema'
 import type { FillEventInput } from '../../broker/observations'
-import { canonicalHashV1 } from '../../hash'
 import type { JournalService } from '../../ledger'
 import { currentUtcInstant } from '../../time'
 import type { AccountingReceipt } from '../../paper'
@@ -20,6 +19,7 @@ import {
   decidePreparedAccountingReplay,
   decidePreparedTransaction,
   decideSuccessorAbsence,
+  planAccountingReceipt,
 } from './decisions'
 import { liftPaperDecision, paperStoreError, runPaperOperation } from './errors'
 import {
@@ -228,46 +228,32 @@ export const makeAccountingInterpreter = (
   const recordReceipt = (prepared: PreparedAccounting): Effect.Effect<AccountingReceipt, PaperStoreError> =>
     runPaperOperation(
       'receipt',
-      sql.withTransaction(
-        Effect.gen(function* () {
-          const accountIds = prepared.ledger.accounts.map((account) => account.id.toString())
-          const transferIds = prepared.ledger.transfers.map((transfer) => transfer.id.toString())
-          const postedMicros = prepared.ledger.transfers.reduce((sum, transfer) => sum + transfer.amount, 0n).toString()
-          const stable = {
-            schemaVersion: 'bayn.paper-accounting-receipt.v1' as const,
-            ...(prepared.transaction.intentId === undefined ? {} : { intentId: prepared.transaction.intentId }),
-            brokerEventId: prepared.transaction.brokerEventId,
-            tigerBeetleClusterId: config.tigerBeetle.clusterId.toString(),
-            tigerBeetleLedger: config.tigerBeetle.ledger,
-            accountIds,
-            transferIds,
-            debitMicros: postedMicros,
-            creditMicros: postedMicros,
-          }
-          const receiptId = canonicalHashV1({
-            schemaVersion: 'bayn.paper-accounting-receipt-id.v1',
-            brokerEventId: prepared.transaction.brokerEventId,
-            tigerBeetleClusterId: stable.tigerBeetleClusterId,
-            tigerBeetleLedger: stable.tigerBeetleLedger,
-          })
-          const contentHash = canonicalHashV1(stable)
-          const recordedAt = yield* currentUtcInstant
-          const candidate = yield* decodeReceipt({ ...stable, receiptId, contentHash, recordedAt })
-          yield* sql`
-            INSERT INTO accounting_receipts (
-              receipt_id, schema_version, intent_id, broker_event_id, tigerbeetle_cluster_id, tigerbeetle_ledger,
-              account_ids, transfer_ids, debit_micros, credit_micros, content_hash, recorded_at
-            ) VALUES (
-              ${candidate.receiptId}, ${candidate.schemaVersion}, ${candidate.intentId ?? null},
-              ${candidate.brokerEventId}, ${candidate.tigerBeetleClusterId}, ${candidate.tigerBeetleLedger},
-              ${candidate.accountIds}, ${candidate.transferIds}, ${candidate.debitMicros}, ${candidate.creditMicros},
-              ${candidate.contentHash}, ${candidate.recordedAt}
-            )
-            ON CONFLICT (broker_event_id) DO NOTHING
-          `
-          const stored = yield* readReceipt(candidate.brokerEventId)
-          return yield* liftPaperDecision('receipt', decideAccountingReceiptReplay(stored, candidate))
-        }),
+      liftPaperDecision(
+        'receipt',
+        planAccountingReceipt(prepared, config.tigerBeetle.clusterId.toString(), config.tigerBeetle.ledger),
+      ).pipe(
+        Effect.flatMap((planned) =>
+          sql.withTransaction(
+            Effect.gen(function* () {
+              const recordedAt = yield* currentUtcInstant
+              const candidate = yield* decodeReceipt({ ...planned, recordedAt })
+              yield* sql`
+                INSERT INTO accounting_receipts (
+                  receipt_id, schema_version, intent_id, broker_event_id, tigerbeetle_cluster_id, tigerbeetle_ledger,
+                  account_ids, transfer_ids, debit_micros, credit_micros, content_hash, recorded_at
+                ) VALUES (
+                  ${candidate.receiptId}, ${candidate.schemaVersion}, ${candidate.intentId ?? null},
+                  ${candidate.brokerEventId}, ${candidate.tigerBeetleClusterId}, ${candidate.tigerBeetleLedger},
+                  ${candidate.accountIds}, ${candidate.transferIds}, ${candidate.debitMicros}, ${candidate.creditMicros},
+                  ${candidate.contentHash}, ${candidate.recordedAt}
+                )
+                ON CONFLICT (broker_event_id) DO NOTHING
+              `
+              const stored = yield* readReceipt(candidate.brokerEventId)
+              return yield* liftPaperDecision('receipt', decideAccountingReceiptReplay(stored, candidate))
+            }),
+          ),
+        ),
       ),
     )
 

--- a/services/bayn/src/db/paper-store/decisions.test.ts
+++ b/services/bayn/src/db/paper-store/decisions.test.ts
@@ -16,6 +16,7 @@ import {
   decidePreparedAccountingReplay,
   decideStoredValuation,
   finishPositionSnapshot,
+  planAccountingReceipt,
   planPositionSnapshot,
   planValuation,
   requireValuationPositionSnapshot,
@@ -117,21 +118,9 @@ const accountingFill: Fill = {
 const preparedResult = prepareAccounting('a'.repeat(64), accountingFill, { quantityMicros: '0', costMicros: '0' }, 7001)
 if (Result.isFailure(preparedResult)) throw new Error(`accounting fixture failed: ${preparedResult.failure._tag}`)
 const prepared = preparedResult.success
-const postedMicros = prepared.ledger.transfers.reduce((sum, transfer) => sum + transfer.amount, 0n).toString()
-const receiptMaterial = {
-  schemaVersion: 'bayn.paper-accounting-receipt.v1' as const,
-  brokerEventId: prepared.transaction.brokerEventId,
-  tigerBeetleClusterId: '1',
-  tigerBeetleLedger: 7001,
-  accountIds: prepared.ledger.accounts.map((account) => account.id.toString()),
-  transferIds: prepared.ledger.transfers.map((transfer) => transfer.id.toString()),
-  debitMicros: postedMicros,
-  creditMicros: postedMicros,
-}
+const receiptPlan = value(planAccountingReceipt(prepared, '1', 7001))
 const accountingReceipt: AccountingReceipt = {
-  ...receiptMaterial,
-  receiptId: hash('receipt-1'),
-  contentHash: canonicalHashV1(receiptMaterial),
+  ...receiptPlan,
   recordedAt: observedAt,
 }
 
@@ -234,6 +223,30 @@ describe('PaperStore decisions', () => {
         _tag: 'PaperStoreHashFailure',
         operation: 'accounting-receipt-candidate',
         cause: { reason: 'invalid-unicode-surrogate', path: '$.accountIds[0]' },
+      },
+    })
+
+    expect(failure(planAccountingReceipt(prepared, '1', Number.NaN))).toMatchObject({
+      failure: 'invariant',
+      message: 'accounting receipt identity is not canonicalizable',
+      cause: {
+        _tag: 'PaperStoreHashFailure',
+        operation: 'accounting-receipt-id',
+        cause: { reason: 'non-finite-number', path: '$.tigerBeetleLedger' },
+      },
+    })
+
+    expect(
+      failure(
+        planAccountingReceipt({ ...prepared, transaction: { ...prepared.transaction, intentId: '\ud800' } }, '1', 7001),
+      ),
+    ).toMatchObject({
+      failure: 'invariant',
+      message: 'accounting receipt content is not canonicalizable',
+      cause: {
+        _tag: 'PaperStoreHashFailure',
+        operation: 'accounting-receipt-content',
+        cause: { reason: 'invalid-unicode-surrogate', path: '$.intentId' },
       },
     })
   })

--- a/services/bayn/src/db/paper-store/decisions.ts
+++ b/services/bayn/src/db/paper-store/decisions.ts
@@ -21,6 +21,8 @@ type PaperStoreHashOperation =
   | 'position-snapshot-content'
   | 'accounting-transaction-stored'
   | 'accounting-transaction-candidate'
+  | 'accounting-receipt-id'
+  | 'accounting-receipt-content'
   | 'accounting-receipt-stored'
   | 'accounting-receipt-candidate'
   | 'valuation-source'
@@ -332,6 +334,46 @@ export const decideAccountingReceipt = (
   if (receipts.length > 1) return fail('invariant', 'fill has multiple accounting receipts')
   return Result.succeed(receipts[0])
 }
+
+export type AccountingReceiptPlan = Omit<AccountingReceipt, 'recordedAt'>
+
+export const planAccountingReceipt = (
+  prepared: PreparedAccounting,
+  tigerBeetleClusterId: string,
+  tigerBeetleLedger: number,
+): Result.Result<AccountingReceiptPlan, PaperStoreDecisionFailure> =>
+  Result.gen(function* () {
+    const accountIds = prepared.ledger.accounts.map((account) => account.id.toString())
+    const transferIds = prepared.ledger.transfers.map((transfer) => transfer.id.toString())
+    const postedMicros = prepared.ledger.transfers.reduce((sum, transfer) => sum + transfer.amount, 0n).toString()
+    const stable = {
+      schemaVersion: 'bayn.paper-accounting-receipt.v1' as const,
+      ...(prepared.transaction.intentId === undefined ? {} : { intentId: prepared.transaction.intentId }),
+      brokerEventId: prepared.transaction.brokerEventId,
+      tigerBeetleClusterId,
+      tigerBeetleLedger,
+      accountIds,
+      transferIds,
+      debitMicros: postedMicros,
+      creditMicros: postedMicros,
+    }
+    const receiptId = yield* hashDecision(
+      'accounting-receipt-id',
+      {
+        schemaVersion: 'bayn.paper-accounting-receipt-id.v1',
+        brokerEventId: prepared.transaction.brokerEventId,
+        tigerBeetleClusterId,
+        tigerBeetleLedger,
+      },
+      'accounting receipt identity is not canonicalizable',
+    )
+    const contentHash = yield* hashDecision(
+      'accounting-receipt-content',
+      stable,
+      'accounting receipt content is not canonicalizable',
+    )
+    return { ...stable, receiptId, contentHash }
+  })
 
 export const stableAccountingReceipt = (receipt: AccountingReceipt) => ({
   schemaVersion: receipt.schemaVersion,

--- a/services/bayn/src/execution/coordinator.test.ts
+++ b/services/bayn/src/execution/coordinator.test.ts
@@ -221,8 +221,13 @@ describe('MutationStore decision algebra', () => {
         intentId: '\ud800',
         operation: MutationOperation.Submit,
       },
+      cause: {
+        _tag: 'CanonicalJsonFailure',
+        path: '$.intentId',
+        reason: 'invalid-unicode-surrogate',
+        actualType: 'string',
+      },
     })
-    expect(identity.failure.cause).toBeInstanceOf(TypeError)
   })
 
   test('makes every authority outcome explicit', () => {
@@ -326,9 +331,14 @@ describe('MutationStore decision algebra', () => {
       operation: 'begin-submit',
       failure: 'invariant',
       message: 'mutation identity canonicalization failed',
+      cause: {
+        _tag: 'CanonicalJsonFailure',
+        path: '$.intentId',
+        reason: 'invalid-unicode-surrogate',
+        actualType: 'string',
+      },
     })
-    expect(malformedReplay.cause).toBeInstanceOf(TypeError)
-    expect(malformedReplay.canonicalizationFailure?.cause).toBe(malformedReplay.cause)
+    expect(malformedReplay.cause).toBe(malformedReplay.canonicalizationFailure?.cause)
 
     const authority = resultSuccess(decideMutationAuthority(MutationOperation.Submit, decisionAuthority))
     const submit = resultSuccess(
@@ -473,9 +483,14 @@ describe('MutationStore decision algebra', () => {
       operation: 'begin-cancel',
       failure: 'invariant',
       message: 'mutation event canonicalization failed',
+      cause: {
+        _tag: 'CanonicalJsonFailure',
+        path: '$.brokerOrderId',
+        reason: 'invalid-unicode-surrogate',
+        actualType: 'string',
+      },
     })
-    expect(malformedEvent.cause).toBeInstanceOf(TypeError)
-    expect(malformedEvent.canonicalizationFailure?.cause).toBe(malformedEvent.cause)
+    expect(malformedEvent.cause).toBe(malformedEvent.canonicalizationFailure?.cause)
   })
 
   test('maps every public outcome to one closed transition decision', () => {
@@ -781,9 +796,14 @@ describe('MutationStore decision algebra', () => {
       operation: 'record-submit',
       failure: 'invariant',
       message: 'mutation event canonicalization failed',
+      cause: {
+        _tag: 'CanonicalJsonFailure',
+        path: '$.brokerOrderId',
+        reason: 'invalid-unicode-surrogate',
+        actualType: 'string',
+      },
     })
-    expect(canonicalizationFailure.cause).toBeInstanceOf(TypeError)
-    expect(canonicalizationFailure.canonicalizationFailure?.cause).toBe(canonicalizationFailure.cause)
+    expect(canonicalizationFailure.cause).toBe(canonicalizationFailure.canonicalizationFailure?.cause)
 
     const outcomeFailures: readonly [
       MutationOutcomeInput,

--- a/services/bayn/src/execution/mutations/decisions.ts
+++ b/services/bayn/src/execution/mutations/decisions.ts
@@ -1,7 +1,7 @@
 import { Result, Schema } from 'effect'
 
 import { MutationOperation, type MutationEvidence } from '../../broker/alpaca-mutations'
-import { canonicalHashV1 } from '../../hash'
+import { canonicalHashV1Result } from '../../hash'
 import { Authority, IntentState, KillState, TerminalOutcome } from '../../paper'
 import { strictParseOptions } from '../../schemas'
 import {
@@ -69,14 +69,14 @@ const canonicalHashResult = (
   fact: MutationCanonicalizationFact,
   value: unknown,
 ): Result.Result<string, MutationCanonicalizationFailure> =>
-  Result.try({
-    try: () => canonicalHashV1(value),
-    catch: (cause): MutationCanonicalizationFailure => ({
+  Result.mapError(
+    canonicalHashV1Result(value),
+    (cause): MutationCanonicalizationFailure => ({
       _tag: 'MutationCanonicalizationFailure',
       fact,
       cause,
     }),
-  })
+  )
 
 export const mutationIdResult = (
   intentId: string,

--- a/services/bayn/src/execution/mutations/model.ts
+++ b/services/bayn/src/execution/mutations/model.ts
@@ -1,6 +1,7 @@
 import { Context, Data, Effect, Schema } from 'effect'
 
 import { MutationEvidenceSchema, MutationOperation, type MutationEvidence } from '../../broker/alpaca-mutations'
+import type { CanonicalHashFailure } from '../../hash'
 import { Authority, IntentState, KillState, TerminalOutcome } from '../../paper'
 import {
   Sha256Schema as Sha256,
@@ -76,7 +77,7 @@ export type MutationCanonicalizationFact =
 export interface MutationCanonicalizationFailure {
   readonly _tag: 'MutationCanonicalizationFailure'
   readonly fact: MutationCanonicalizationFact
-  readonly cause: unknown
+  readonly cause: CanonicalHashFailure
 }
 
 export class MutationStoreError extends Data.TaggedError('MutationStoreError')<{

--- a/services/bayn/src/qualification-candidate/domain.test.ts
+++ b/services/bayn/src/qualification-candidate/domain.test.ts
@@ -154,7 +154,16 @@ describe('qualification candidate decisions', () => {
           candidateObservations([{ snapshot: malformed }, { snapshot: malformed }]),
         ),
       ),
-    ).toMatchObject({ _tag: 'CanonicalizationFailed', subject: 'snapshot' })
+    ).toEqual({
+      _tag: 'CanonicalizationFailed',
+      subject: 'snapshot',
+      cause: {
+        _tag: 'CanonicalJsonFailure',
+        path: '$.manifest.finalizedSnapshot.calendarVersion',
+        reason: 'invalid-unicode-surrogate',
+        actualType: 'string',
+      },
+    })
   })
 
   test('accepts only an unused snapshot observed through a read-only transaction', () => {

--- a/services/bayn/src/qualification-candidate/domain.ts
+++ b/services/bayn/src/qualification-candidate/domain.ts
@@ -2,7 +2,7 @@ import { isIP } from 'node:net'
 
 import { Option, pipe, Redacted, Result } from 'effect'
 
-import { canonicalJsonV1, sha256 } from '../hash'
+import { canonicalJsonV1Result, sha256 } from '../hash'
 import type { MarketDataSnapshot } from '../market-data'
 import type { QualificationCandidateFailure } from './failure'
 import type {
@@ -214,10 +214,14 @@ const canonicalSnapshot = (
   snapshot: MarketDataSnapshot,
 ): Result.Result<CanonicalSnapshot, QualificationCandidateFailure> =>
   pipe(
-    Result.try({
-      try: () => canonicalJsonV1(snapshot),
-      catch: (cause) => ({ _tag: 'CanonicalizationFailed' as const, subject: 'snapshot' as const, cause }),
-    }),
+    canonicalJsonV1Result(snapshot),
+    Result.mapError(
+      (cause): QualificationCandidateFailure => ({
+        _tag: 'CanonicalizationFailed',
+        subject: 'snapshot',
+        cause,
+      }),
+    ),
     Result.map((json) => ({ json, hash: sha256(json) })),
   )
 

--- a/services/bayn/src/qualification-candidate/failure.ts
+++ b/services/bayn/src/qualification-candidate/failure.ts
@@ -1,5 +1,7 @@
 import { Data } from 'effect'
 
+import type { CanonicalJsonFailure } from '../hash'
+
 export type QualificationCandidateFailure =
   | { readonly _tag: 'ConfigurationLoadFailed'; readonly cause: unknown }
   | { readonly _tag: 'PostgresUrlMalformed' }
@@ -52,7 +54,7 @@ export type QualificationCandidateFailure =
   | {
       readonly _tag: 'CanonicalizationFailed'
       readonly subject: 'snapshot' | 'report'
-      readonly cause: unknown
+      readonly cause: CanonicalJsonFailure
     }
   | {
       readonly _tag: 'ReplicaSnapshotsDiverged'

--- a/services/bayn/src/qualification-candidate/program.ts
+++ b/services/bayn/src/qualification-candidate/program.ts
@@ -1,7 +1,7 @@
 import { Config, Effect, FileSystem, Result, Stdio, Stream } from 'effect'
 import * as Reactivity from 'effect/unstable/reactivity/Reactivity'
 
-import { canonicalJsonV1 } from '../hash'
+import { canonicalJsonV1Result } from '../hash'
 import { loadDefaultProtocol } from '../protocol'
 import { IsoDateSchema, PositiveIntegerSchema, TrimmedNonEmptyStringSchema } from '../schemas'
 import type { CausalProtocol } from '../types'
@@ -113,11 +113,16 @@ const writeReport = (
   report: QualificationCandidateReport,
 ): Effect.Effect<void, QualificationCandidateFailure, Stdio.Stdio> =>
   Effect.fromResult(
-    Result.try({
-      try: () => `${canonicalJsonV1(report)}\n`,
-      catch: (cause): QualificationCandidateFailure => ({ _tag: 'CanonicalizationFailed', subject: 'report', cause }),
-    }),
+    Result.mapError(
+      canonicalJsonV1Result(report),
+      (cause): QualificationCandidateFailure => ({
+        _tag: 'CanonicalizationFailed',
+        subject: 'report',
+        cause,
+      }),
+    ),
   ).pipe(
+    Effect.map((encoded) => `${encoded}\n`),
     Effect.flatMap((encoded) =>
       Effect.flatMap(Stdio.Stdio, (stdio) =>
         Stream.run(Stream.make(encoded), stdio.stdout()).pipe(


### PR DESCRIPTION
## Summary

- Preserve exact canonical JSON/hash failures in mutation identity and qualification candidate Result algebras instead of catching deprecated throwing aliases.
- Plan deterministic accounting receipt identity and content as a pure Result before opening the PostgreSQL transaction.
- Keep existing receipt material, replay behavior, transaction ordering, and wire hashes unchanged while adding precise failure-path coverage.

## Related Issues

None.

## Testing

- `bun run --cwd services/bayn test` — 751 passed, 121 PostgreSQL-gated skipped, 0 failed.
- `bun node_modules/typescript/bin/tsc --noEmit --pretty false -p services/bayn/tsconfig.json`
- `node node_modules/oxfmt/dist/cli.js --check services/bayn`
- `bun run --cwd services/bayn lint:oxlint`
- `bun run --cwd services/bayn lint:oxlint:type`
- `bun run --cwd services/bayn lint:effect`
- `bun run --cwd services/bayn build`
- `bun test packages/scripts/src/bayn` — 20 passed, 0 failed.
- `BAYN_TEST_POSTGRES_URL=postgresql://bayn@127.0.0.1:55439/bayn_test bun test services/bayn/src/db/paper-store.integration.test.ts` against PostgreSQL 18 — 30 passed, 0 failed.
- Focused coordinator, qualification-candidate, and paper-store decision suites — 78 passed, 0 failed.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] Documentation, release notes, and follow-ups are not required for this internal refactor.
