### PR TITLE
chore(bayn): promote image sha-859d0e78f1c27c3949293f9b9a955bd2bf33132c

### DIFF
--- a/argocd/applications/bayn/deployment.yaml
+++ b/argocd/applications/bayn/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         app.kubernetes.io/name: bayn
         app.kubernetes.io/part-of: bayn
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-07-27T00:18:25Z"
+        kubectl.kubernetes.io/restartedAt: "2026-07-27T00:32:18Z"
     spec:
       serviceAccountName: bayn
       automountServiceAccountToken: false
@@ -47,11 +47,11 @@ spec:
               protocol: TCP
           env:
             - name: BAYN_CODE_REVISION
-              value: 1231cf551abcd24fe6c8ca929e0de25af2648146
+              value: 859d0e78f1c27c3949293f9b9a955bd2bf33132c
             - name: BAYN_IMAGE_REPOSITORY
               value: registry.ide-newton.ts.net/lab/bayn
             - name: BAYN_IMAGE_DIGEST
-              value: sha256:4dcb2d483496f733169d0cbac821aae81bf04e0437483db4b44b137e69e058a6
+              value: sha256:cd35337fe8345c02160826134083e3127eba89f286e326f562843ab6de289a04
             - name: BAYN_STRATEGY_BEHAVIOR_HASH
               value: "dc614c54bbf43842d83cd88497e835f7bb25c413eb6e8bd7cbab0a925ec9b2dd"
             - name: BAYN_STRATEGY_PARAMETER_HASH

--- a/argocd/applications/bayn/kustomization.yaml
+++ b/argocd/applications/bayn/kustomization.yaml
@@ -22,5 +22,5 @@ configMapGenerator:
 images:
   - name: registry.ide-newton.ts.net/lab/bayn
     newName: registry.ide-newton.ts.net/lab/bayn
-    newTag: "sha-1231cf551abcd24fe6c8ca929e0de25af2648146"
-    digest: sha256:4dcb2d483496f733169d0cbac821aae81bf04e0437483db4b44b137e69e058a6
+    newTag: "sha-859d0e78f1c27c3949293f9b9a955bd2bf33132c"
+    digest: sha256:cd35337fe8345c02160826134083e3127eba89f286e326f562843ab6de289a04


### PR DESCRIPTION
## Summary

Promote the immutable Bayn image against the current Signal snapshot and dedicated Bayn TigerBeetle
ledger. Qualification-pin handling is selected from the verified compiled behavior identity.

- Source commit: `859d0e78f1c27c3949293f9b9a955bd2bf33132c`
- Image tag: `sha-859d0e78f1c27c3949293f9b9a955bd2bf33132c`
- Image digest: `sha256:cd35337fe8345c02160826134083e3127eba89f286e326f562843ab6de289a04`
- Qualification mode: `preserve`
- Existing pin: `true`
- Qualification identity bindings match: `true`
- Snapshot changed: `false`
- Deployed snapshot: `1b963bb9550d07e1c7239ebe1a021e82c0f112b8f21fce0ab4e922c47b272a27`
- Candidate snapshot: `1b963bb9550d07e1c7239ebe1a021e82c0f112b8f21fce0ab4e922c47b272a27`
- Deployed behavior hash: `dc614c54bbf43842d83cd88497e835f7bb25c413eb6e8bd7cbab0a925ec9b2dd`
- Candidate behavior hash: `dc614c54bbf43842d83cd88497e835f7bb25c413eb6e8bd7cbab0a925ec9b2dd`
- Deployed parameter hash: `e5e4cc5d22b84c4dc8fc65c306d097fda063b0058253da5b900fe1d462d437b3`
- Candidate parameter hash: `e5e4cc5d22b84c4dc8fc65c306d097fda063b0058253da5b900fe1d462d437b3`

## Related Issues

PROOMPT-400

## Testing

- OCI index contains `linux/amd64` and `linux/arm64`.

## Screenshots (if applicable)

N/A

## Breaking Changes

This is a one-way current-contract runtime release. Databases with the old migration tracker are rejected;
there is no schema fallback or automatic rename. `preserve` keeps the terminal run only when compiled
behavior, protocol parameters, Signal inputs, TigerBeetle cluster ID, and TigerBeetle ledger all match.
Replica addresses are transport and an explicit candidate may change them without relabeling qualification
evidence. `replace` removes an existing incompatible pin only for a fresh Signal snapshot. `install` is
available only to a controlled invocation that supplies the complete reviewed candidate runtime and exact
independently accepted terminal run ID; automatic image promotion supplies neither and therefore never
creates a pin. Installation can pin only the exact source, image digest, compiled strategy, and runtime
already deployed without a pin. It cannot replace an old pin and advance to a fresh candidate in the same
change.

## Checklist

- [x] Testing section documents exact validation.
- [x] Runtime source revision and image digest are immutable.
- [x] No broker or capital-promotion authority is introduced.