### PR TITLE
refactor(bayn): totalize reconciliation history hashing

### DIFF
--- a/services/bayn/src/reconciler.test.ts
+++ b/services/bayn/src/reconciler.test.ts
@@ -560,6 +560,74 @@ describe('paper reconciliation loop', () => {
     expect(control.restrictions).toEqual(['reconciliation pass incomplete'])
   })
 
+  test('returns exact history materialization and canonicalization failures without defecting', async () => {
+    const materializationDefect = new Error('hostile broker order asset access')
+    const hostileOrder = Object.defineProperty({ ...order(0) }, 'assetId', {
+      enumerable: true,
+      get: () => {
+        throw materializationDefect
+      },
+    }) as BrokerOrder
+    const malformedOrder = { ...order(1), clientOrderId: '\ud800' }
+
+    const cases = [
+      {
+        input: hostileOrder,
+        expected: {
+          message: 'broker before history materialization failed',
+          cause: materializationDefect,
+          error: { _tag: 'HistoryMaterializationFailed', cause: materializationDefect },
+        },
+      },
+      {
+        input: malformedOrder,
+        expected: {
+          message: 'broker before history canonicalization failed',
+          cause: {
+            _tag: 'CanonicalJsonFailure',
+            path: '$.orders[0].clientOrderId',
+            reason: 'invalid-unicode-surrogate',
+            actualType: 'string',
+          },
+          error: {
+            _tag: 'HistoryCanonicalizationFailed',
+            cause: {
+              _tag: 'CanonicalJsonFailure',
+              path: '$.orders[0].clientOrderId',
+              reason: 'invalid-unicode-surrogate',
+              actualType: 'string',
+            },
+          },
+        },
+      },
+    ] as const
+
+    for (const testCase of cases) {
+      const read: BrokerReadShape = {
+        ...emptyRead(),
+        orders: () => Effect.succeed({ value: [testCase.input], evidence: evidence('hostile-order') }),
+      }
+      const control: StoreControl = { writes: 0, reconciliations: [], restrictions: [] }
+
+      const failure = await Effect.runPromise(provide(read, makeStore(control)).pipe(Effect.flip))
+
+      expect(failure).toMatchObject({
+        _tag: 'ReconciliationError',
+        operation: 'snapshot',
+        message: testCase.expected.message,
+        cause: testCase.expected.cause,
+        failure: {
+          _tag: 'HistoryHash',
+          side: 'before',
+          error: testCase.expected.error,
+        },
+      })
+      expect(control.writes).toBe(0)
+      expect(control.reconciliations).toEqual([])
+      expect(control.restrictions).toEqual(['reconciliation pass incomplete'])
+    }
+  })
+
   test('rejects broker history beyond the hard row limit before persisting', async () => {
     let offset = 0
     const read: BrokerReadShape = {

--- a/services/bayn/src/reconciler.ts
+++ b/services/bayn/src/reconciler.ts
@@ -34,7 +34,7 @@ import {
 } from './db/reconciliation'
 import { WriterFence, type WriterFenceError, type WriterFenceService } from './execution/writer-fence'
 import { currentUtcInstant } from './time'
-import { canonicalHashV1 } from './hash'
+import { canonicalHashV1Result, type CanonicalHashFailure } from './hash'
 import type { ReconciledBrokerState, ReconciliationRiskContext } from './reconciliation'
 
 const maximumRows = 10_000
@@ -101,6 +101,12 @@ type PaginationFailureReason =
 
 type SnapshotFailureReason = 'HistoryChanged' | 'AccountBaselineMissing'
 
+type HistorySnapshotSide = 'before' | 'after'
+
+type HistoryHashFailure =
+  | { readonly _tag: 'HistoryMaterializationFailed'; readonly cause: unknown }
+  | { readonly _tag: 'HistoryCanonicalizationFailed'; readonly cause: CanonicalHashFailure }
+
 type ValidationFailureReason =
   | 'DuplicateIntentClientOrderId'
   | 'DuplicateBrokerClientOrderId'
@@ -113,6 +119,11 @@ type NormalizationStage = 'order-timestamp' | 'order' | 'fill-ordering' | 'fill'
 type ReconciliationFailure =
   | { readonly _tag: 'Pagination'; readonly reason: PaginationFailureReason }
   | { readonly _tag: 'Snapshot'; readonly reason: SnapshotFailureReason }
+  | {
+      readonly _tag: 'HistoryHash'
+      readonly side: HistorySnapshotSide
+      readonly error: HistoryHashFailure
+    }
   | { readonly _tag: 'Validation'; readonly reason: ValidationFailureReason; readonly detail: string }
   | {
       readonly _tag: 'Normalization'
@@ -149,6 +160,17 @@ const snapshotFailure = (reason: SnapshotFailureReason, message: string): Reconc
     operation: 'snapshot',
     message,
     failure: { _tag: 'Snapshot', reason },
+  })
+
+const historyHashFailure = (side: HistorySnapshotSide, error: HistoryHashFailure): ReconciliationError =>
+  new ReconciliationError({
+    operation: 'snapshot',
+    message:
+      error._tag === 'HistoryMaterializationFailed'
+        ? `broker ${side} history materialization failed`
+        : `broker ${side} history canonicalization failed`,
+    cause: error.cause,
+    failure: { _tag: 'HistoryHash', side, error },
   })
 
 const validationFailure = (reason: ValidationFailureReason, detail: string): ReconciliationError =>
@@ -446,27 +468,48 @@ const readHistory = (
     { concurrency: 2 },
   )
 
-const historyHash = (history: BrokerHistory): string =>
-  canonicalHashV1({
-    schemaVersion: 'bayn.paper-broker-history.v1',
-    orders: history.orders.rows
-      .map(({ value }) => {
-        const { observedAt: _observedAt, ...material } = value
-        return material
-      })
-      .sort((left, right) => left.brokerOrderId.localeCompare(right.brokerOrderId)),
-    fills: history.fills
-      .map(({ value }) => value)
-      .sort((left, right) => left.activityId.localeCompare(right.activityId)),
-  })
+const historyHashResult = (history: BrokerHistory): Result.Result<string, HistoryHashFailure> =>
+  pipe(
+    Result.try({
+      try: () => ({
+        schemaVersion: 'bayn.paper-broker-history.v1',
+        orders: history.orders.rows
+          .map(({ value }) => {
+            const { observedAt: _observedAt, ...material } = value
+            return material
+          })
+          .sort((left, right) => left.brokerOrderId.localeCompare(right.brokerOrderId)),
+        fills: history.fills
+          .map(({ value }) => value)
+          .sort((left, right) => left.activityId.localeCompare(right.activityId)),
+      }),
+      catch: (cause): HistoryHashFailure => ({ _tag: 'HistoryMaterializationFailed', cause }),
+    }),
+    Result.flatMap((material) =>
+      pipe(
+        canonicalHashV1Result(material),
+        Result.mapError((cause): HistoryHashFailure => ({ _tag: 'HistoryCanonicalizationFailed', cause })),
+      ),
+    ),
+  )
 
 const decideStableHistory = (
   before: BrokerHistory,
   after: BrokerHistory,
 ): Result.Result<BrokerHistory, ReconciliationError> =>
-  historyHash(before) === historyHash(after)
-    ? Result.succeed(after)
-    : Result.fail(snapshotFailure('HistoryChanged', 'broker history changed during reconciliation'))
+  Result.gen(function* () {
+    const beforeHash = yield* pipe(
+      historyHashResult(before),
+      Result.mapError((error) => historyHashFailure('before', error)),
+    )
+    const afterHash = yield* pipe(
+      historyHashResult(after),
+      Result.mapError((error) => historyHashFailure('after', error)),
+    )
+    return beforeHash === afterHash
+      ? after
+      : yield* Result.fail(snapshotFailure('HistoryChanged', 'broker history changed during reconciliation'))
+  })
 
 const currentInstant = currentUtcInstant
 


### PR DESCRIPTION
## Summary

- Replace the throwing broker-history hash comparison with a pure Result decision.
- Distinguish hostile history materialization from canonical JSON failure and retain the exact pre/post snapshot side and original cause.
- Preserve existing broker-history hash material, stable-snapshot race detection, containment, and zero-write failure behavior.

## Related Issues

None.

## Testing

- `bun test services/bayn/src/reconciler.test.ts` — 15 passed, 0 failed.
- `bun run --cwd services/bayn test` — 752 passed, 121 PostgreSQL-gated skipped, 0 failed.
- `bun node_modules/typescript/bin/tsc --noEmit --pretty false -p services/bayn/tsconfig.json`
- `node node_modules/oxfmt/dist/cli.js --check services/bayn`
- `bun run --cwd services/bayn lint:oxlint`
- `bun run --cwd services/bayn lint:oxlint:type`
- `bun run --cwd services/bayn lint:effect`
- `bun run --cwd services/bayn build`
- `bun test packages/scripts/src/bayn` — 20 passed, 0 failed.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] Documentation, release notes, and follow-ups are not required for this internal refactor.
