### PR TITLE
feat(bayn): precommit robust trend qualification

### DIFF
--- a/docs/bayn/architecture.md
+++ b/docs/bayn/architecture.md
@@ -142,9 +142,10 @@ audit therefore fails candidate-bar chronology and principal checks. GitOps may 
 database recovery under `OBSERVE`; the pin clears no qualification or mutation gate.
 
 At each month-end close, the strategy computes volatility-normalized returns over 21, 63, 126, and 252 sessions,
-averages them into a composite score, and assigns weight only to positive scores. Weights are redistributed under a 35%
-per-symbol cap, quantized deterministically, and scaled down when estimated portfolio volatility exceeds 10%. Residual
-exposure remains cash. The strategy parameters and thresholds are unchanged from the rejected v2 run.
+clips each score to `[-2, 2]`, and uses the median as the composite. A sleeve is eligible only when at least three of
+four horizons are positive and the median is positive. Eligible sleeves are weighted by positive conviction per unit
+annualized volatility, redistributed under a 35% per-symbol cap, quantized deterministically, and scaled down when
+estimated portfolio volatility exceeds 10%. Residual exposure remains cash.
 
 The v3 execution model is live-causal. Once the signal session is finalized, planning uses that session's close-price
 vector and a content-hashed reconciled broker state observed before planning. The bounded Alpaca calendar response
@@ -156,10 +157,11 @@ Ordinary non-extended `DAY` market orders may be submitted only after the plan i
 aggregate pre-submit buying power and cannot spend planned sell proceeds. The selected session open is a fill outcome:
 changing it may alter fills, gaps, slippage, shortfall, and performance, but cannot alter planned quantities.
 
-The source-controlled precommit identities are behavior
-`dc614c54bbf43842d83cd88497e835f7bb25c413eb6e8bd7cbab0a925ec9b2dd` and parameters
-`e5e4cc5d22b84c4dc8fc65c306d097fda063b0058253da5b900fe1d462d437b3`. They do not relabel
-the terminal v2 rejection and do not constitute a new qualification.
+The source-controlled v4 precommit identities are behavior
+`9e87fe0f66048c48da2191ef1fae36ef3ee0eb4ddcd036ef40881f0fe0f6eb42` and parameters
+`19bc51c7361b181aa48845d178cb63373b3f2e017bcbea1cf3b70ab16647f8a9`. They do not relabel the terminal v3
+rejection and do not constitute a new qualification. GitOps must hold this changed identity until a finalized snapshot
+newer than the observed 2026-07-24 snapshot is available.
 
 The evaluator compares the candidate with buy-and-hold, direct-volatility timing, and doubled-cost results over aligned
 dates. Qualification also applies the committed statistical and walk-forward policy. Every decision, benchmark,

--- a/docs/bayn/authoritative-universe.md
+++ b/docs/bayn/authoritative-universe.md
@@ -120,7 +120,7 @@ that pre-lock Bayn/operator reads of the bars table returned only bounded public
 independent audits therefore fail both candidate-bar chronology and principal checks rather than exempting those reads.
 PROOMPT-406 owns the causal contract and corrected precommit; this record clears no M2.2 or paper-mutation gate.
 
-## Corrected causal precommit
+## Corrected causal baseline
 
 `bayn.risk-balanced-trend.protocol.v3` plans quantities from the finalized signal-session close and reconciled
 pre-plan broker state, then treats the selected next-session open only as a fill outcome. The bounded Alpaca calendar
@@ -128,14 +128,30 @@ identity fixes the future session open, close, and a 15-minute pre-open cutoff. 
 cash and cannot spend planned sell proceeds. The strategy horizons, weight cap, volatility target, universe, and
 qualification gates remain unchanged.
 
-The source-controlled identities are:
+Its released source-controlled identities are:
 
 - behavior `dc614c54bbf43842d83cd88497e835f7bb25c413eb6e8bd7cbab0a925ec9b2dd`;
-- parameters `e5e4cc5d22b84c4dc8fc65c306d097fda063b0058253da5b900fe1d462d437b3`; and
-- deterministic fixture evaluation `8be4f2f76c69bd7eeb2984bc08cd1d49013d2b349c8c574683851d4052a4901f`.
+- parameters `e5e4cc5d22b84c4dc8fc65c306d097fda063b0058253da5b900fe1d462d437b3`.
 
-These hashes are a corrected precommit, not a qualification result. The pinned v2 run remains terminal `REJECTED`;
-no qualification rerun is part of PROOMPT-406.
+The terminal v3 qualification run remains `REJECTED` because its Sharpe-difference lower confidence bound is not
+positive. It remains pinned and non-authorizing under `OBSERVE`.
+
+## Robust trend qualification precommit
+
+`bayn.risk-balanced-trend.protocol.v4` preserves the causal v3 execution model, five-sleeve universe, monthly
+rebalance, 35% per-symbol cap, 10% portfolio-volatility ceiling, benchmarks, costs, and qualification policy. It clips
+each normalized horizon score to `[-2, 2]`, uses the median score, requires at least three of four horizons to be
+positive, and allocates eligible sleeves by positive conviction per unit annualized volatility before the existing
+cap and covariance-aware portfolio scaling.
+
+The v4 source-controlled identities are:
+
+- behavior `9e87fe0f66048c48da2191ef1fae36ef3ee0eb4ddcd036ef40881f0fe0f6eb42`;
+- parameters `19bc51c7361b181aa48845d178cb63373b3f2e017bcbea1cf3b70ab16647f8a9`; and
+- deterministic fixture evaluation `81002ac221b557498e06cbcd9307d986ed21ff2c2ce883adcc489fef7f468416`.
+
+These hashes are a precommit, not a qualification result. The changed strategy identity cannot consume the already
+observed 2026-07-24 snapshot; release remains held until a fresher finalized snapshot exists.
 
 Publication rollback remains fail-closed: stop new publication through GitOps and preserve finalized or partially
 staged rows for diagnosis. Never delete M2.1 evidence or Signal publication tables.

--- a/nix/images/bayn.nix
+++ b/nix/images/bayn.nix
@@ -9,10 +9,10 @@
 
 let
   imageRepository = "registry.ide-newton.ts.net/lab/bayn";
-  # SHA-256 identity for bayn.risk-balanced-trend.behavior.v2, verified by the production executable.
-  strategyBehaviorHash = "dc614c54bbf43842d83cd88497e835f7bb25c413eb6e8bd7cbab0a925ec9b2dd";
-  # Canonical hash of the compiled bayn.risk-balanced-trend.protocol.v3 document.
-  strategyParameterHash = "e5e4cc5d22b84c4dc8fc65c306d097fda063b0058253da5b900fe1d462d437b3";
+  # SHA-256 identity for bayn.risk-balanced-trend.behavior.v3, verified by the production executable.
+  strategyBehaviorHash = "9e87fe0f66048c48da2191ef1fae36ef3ee0eb4ddcd036ef40881f0fe0f6eb42";
+  # Canonical hash of the compiled bayn.risk-balanced-trend.protocol.v4 document.
+  strategyParameterHash = "19bc51c7361b181aa48845d178cb63373b3f2e017bcbea1cf3b70ab16647f8a9";
   buildDefine = name: value: "--define ${name}=${lib.escapeShellArg (builtins.toJSON value)}";
 in
 import ./bun-workspace-service.nix {

--- a/services/bayn/README.md
+++ b/services/bayn/README.md
@@ -2,9 +2,12 @@
 
 Bayn is a single-writer, paper-only quantitative qualification runtime. The released cross-asset one-shot is terminal
 `REJECTED`, pinned by `BAYN_QUALIFICATION_RUN_ID`, and non-authorizing. The next source-controlled precommit is
-`bayn.risk-balanced-trend.protocol.v3`: the same strategy parameters and thresholds with a corrected live-causal
-execution contract. It is not qualified and this change does not rerun qualification. GitOps remains `OBSERVE`; the
-paper mutation capability, execution entry point, and capital-promotion path remain dormant.
+`bayn.risk-balanced-trend.protocol.v4`: normalized horizon trends are clipped before a median aggregate, at least three
+of four horizons must be positive, and eligible sleeves are risk-budgeted by conviction per unit annualized
+volatility. The universe, monthly rebalance, 35% sleeve cap, 10% portfolio-volatility ceiling, execution costs,
+benchmarks, uncertainty policy, and economic gates remain unchanged. It is not qualified and this change does not
+rerun qualification. GitOps remains `OBSERVE`; the paper mutation capability, execution entry point, and
+capital-promotion path remain dormant.
 
 ## Runtime contract
 
@@ -27,16 +30,17 @@ paper mutation capability, execution entry point, and capital-promotion path rem
   I/O. Fill accounting persists Alpaca's full source timestamp and orders equal timestamps by fill ID, rejects late
   predecessors, and records a receipt only after the complete TigerBeetle transaction-tag transfer set matches.
 - The composition root builds one pure strategy value and passes it explicitly to the lifecycle. Effect services and
-  layers are reserved for I/O resources. The compiled `bayn.risk-balanced-trend.protocol.v3` owns its authoritative
+  layers are reserved for I/O resources. The compiled `bayn.risk-balanced-trend.protocol.v4` owns its authoritative
   universe and causal execution contract; the HTTP and startup lifecycle remain strategy-independent. Protocol v2
   remains decodable only so immutable historical evidence can be recovered.
 - The typed protocol is compiled into the image and runtime-decoded with Effect Schema. Strategies remain reviewed
-  TypeScript rather than JSON.
+  TypeScript rather than JSON. Protocol v4 is the current candidate; v2 and v3 remain decodable only for immutable
+  historical evidence.
 - The executable embeds source, repository, and strategy-behavior identity. Startup verifies the compiled behavior and
   parameter hashes against those embedded facts, and status exposes the promoted image digest, parameter hash, and
-  contract versions. The v3 precommit uses behavior hash
-  `dc614c54bbf43842d83cd88497e835f7bb25c413eb6e8bd7cbab0a925ec9b2dd` and parameter hash
-  `e5e4cc5d22b84c4dc8fc65c306d097fda063b0058253da5b900fe1d462d437b3`.
+  contract versions. The v4 precommit uses behavior hash
+  `9e87fe0f66048c48da2191ef1fae36ef3ee0eb4ddcd036ef40881f0fe0f6eb42` and parameter hash
+  `19bc51c7361b181aa48845d178cb63373b3f2e017bcbea1cf3b70ab16647f8a9`.
 - The package `dev` and `start` scripts use explicit `development-configured` provenance because their artifacts are
   not OCI production builds. That mode is visible in status and cannot override an executable with embedded metadata;
   it does not change lifecycle or authority. The Nix image starts in the default production mode and fails closed if
@@ -142,8 +146,10 @@ credentials and writes no dossier. Later PREPARE/SUBMIT/CANCEL/RECOVER work rema
 
 - `GET /livez`: process liveness.
 - `GET /readyz`: current dependency, evidence, and accounting readiness.
-- `GET /v1/status`: operational dependencies, data and evidence identity, terminal qualification, economic verdict,
-  accounting, current build provenance, qualification-execution provenance, and the configured authority ceiling.
+- `GET /v1/status`: operational dependencies, data and evidence identity, terminal qualification, deterministic
+  qualification diagnosis, economic verdict, accounting, current build provenance, qualification-execution
+  provenance, and the configured authority ceiling. Diagnosis includes the selected benchmark, point Sharpe gap,
+  bootstrap distribution and positive fraction, lower bounds, power, walk-forward stability, and transaction costs.
 - `GET /v1/evaluations/:runId`: complete content-hashed evidence for one exact run ID. The service is ClusterIP-only
   and the Bayn network policy limits HTTP ingress to the namespace.
 
@@ -164,9 +170,10 @@ chronology on every physical ClickHouse replica with a separately supplied audit
 text. It emits one `bayn.qualification-audit.v2` JSON report and exits nonzero on any failed check. Run it twice and
 require identical `auditHash` values.
 
-The current auditor independently replays only causal protocol v3 evidence. Protocol v2 remains recoverable by run ID,
-but its rejected qualification must be replayed with the source revision and immutable image recorded on that run; a
-current-source audit fails explicitly instead of applying v3 semantics to historical evidence.
+The current auditor independently replays causal protocol v3 and v4 evidence with version-matched semantics. Protocol
+v2 remains recoverable by run ID, but its rejected qualification must be replayed with the source revision and
+immutable image recorded on that run; a current-source audit fails explicitly instead of applying newer semantics to
+historical evidence.
 
 ```sh
 BAYN_AUDIT_RUN_ID=<run-id> \

--- a/services/bayn/migrations/0018_robust_trend_protocol.ts
+++ b/services/bayn/migrations/0018_robust_trend_protocol.ts
@@ -1,0 +1,29 @@
+import { Effect } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient
+
+  yield* sql`
+    ALTER TABLE protocol_locks
+      DROP CONSTRAINT protocol_locks_schema_version_check,
+      ADD CONSTRAINT protocol_locks_schema_version_check CHECK (
+        schema_version IN (
+          'bayn.risk-balanced-trend.protocol.v2',
+          'bayn.risk-balanced-trend.protocol.v3',
+          'bayn.risk-balanced-trend.protocol.v4'
+        )
+      )
+  `
+
+  yield* sql`
+    ALTER TABLE authority_generations
+      DROP CONSTRAINT authority_generations_strategy_parameter_schema_version_check,
+      ADD CONSTRAINT authority_generations_strategy_parameter_schema_version_check CHECK (
+        strategy_parameter_schema_version IN (
+          'bayn.risk-balanced-trend.protocol.v3',
+          'bayn.risk-balanced-trend.protocol.v4'
+        )
+      )
+  `
+})

--- a/services/bayn/src/audit/audit.ts
+++ b/services/bayn/src/audit/audit.ts
@@ -243,7 +243,10 @@ export type QualificationAuditFailure =
       readonly _tag: 'UnsupportedAuditProtocolVersion'
       readonly storedSchemaVersion: string
       readonly suppliedSchemaVersion: string
-      readonly requiredSchemaVersion: 'bayn.risk-balanced-trend.protocol.v3'
+      readonly supportedSchemaVersions: readonly [
+        'bayn.risk-balanced-trend.protocol.v3',
+        'bayn.risk-balanced-trend.protocol.v4',
+      ]
     }
   | {
       readonly _tag: 'ReferenceCandidateTraceMissing'
@@ -430,15 +433,19 @@ const makeAuditFacts = (
       requiredStrategyName: contract.name,
     })
   }
+  const supportedSchemaVersions = [
+    'bayn.risk-balanced-trend.protocol.v3',
+    'bayn.risk-balanced-trend.protocol.v4',
+  ] as const
   if (
-    database.protocol.schemaVersion !== 'bayn.risk-balanced-trend.protocol.v3' ||
-    input.protocol.schemaVersion !== 'bayn.risk-balanced-trend.protocol.v3'
+    database.protocol.schemaVersion !== input.protocol.schemaVersion ||
+    !supportedSchemaVersions.some((schemaVersion) => schemaVersion === database.protocol.schemaVersion)
   ) {
     return Result.fail({
       _tag: 'UnsupportedAuditProtocolVersion',
       storedSchemaVersion: database.protocol.schemaVersion,
       suppliedSchemaVersion: input.protocol.schemaVersion,
-      requiredSchemaVersion: 'bayn.risk-balanced-trend.protocol.v3',
+      supportedSchemaVersions,
     })
   }
   const provenanceResult = makeRuntimeProvenanceResult({

--- a/services/bayn/src/audit/reference/decisions.ts
+++ b/services/bayn/src/audit/reference/decisions.ts
@@ -11,6 +11,15 @@ export const roundWeight = (value: number): number => Number.parseFloat(value.to
 export const average = (values: readonly number[]): number =>
   values.reduce((sum, value) => sum + value, 0) / values.length
 
+const median = (values: readonly number[]): number => {
+  const sorted = [...values].sort((left, right) => left - right)
+  const midpoint = Math.floor(sorted.length / 2)
+  const upper = sorted.at(midpoint) ?? 0
+  if (sorted.length % 2 === 1) return upper
+  const lower = sorted.at(midpoint - 1) ?? upper
+  return (lower + upper) / 2
+}
+
 export const sampleDeviation = (values: readonly number[]): number => {
   if (values.length < 2) return 0
   const center = average(values)
@@ -288,8 +297,29 @@ export const riskBalancedDecisionPlan = (
       }
       horizons.push({ horizonSessions, return: value, normalizedTrend })
     }
-    const compositeScore = dailyVolatility === 0 ? 0 : average(horizons.map((horizon) => horizon.normalizedTrend))
-    if (![annualizedVolatility, compositeScore].every(Number.isFinite)) {
+    if (horizons.length === 0) {
+      return Result.fail({
+        _tag: 'ReferenceInvalidScore',
+        symbol,
+        annualizedVolatility,
+        compositeScore: Number.NaN,
+      })
+    }
+    let compositeScore = 0
+    let positiveScore = 0
+    let eligible = false
+    if (dailyVolatility > 0 && protocol.schemaVersion === 'bayn.risk-balanced-trend.protocol.v4') {
+      const cap = protocol.signal.normalizedTrendCap
+      compositeScore = median(horizons.map(({ normalizedTrend }) => Math.max(-cap, Math.min(cap, normalizedTrend))))
+      const positiveHorizons = horizons.filter(({ normalizedTrend }) => normalizedTrend > 0).length
+      eligible = positiveHorizons >= protocol.signal.minimumPositiveHorizons && compositeScore > 0
+      positiveScore = eligible ? compositeScore / annualizedVolatility : 0
+    } else if (dailyVolatility > 0) {
+      compositeScore = average(horizons.map((horizon) => horizon.normalizedTrend))
+      positiveScore = Math.max(0, compositeScore)
+      eligible = true
+    }
+    if (![annualizedVolatility, compositeScore, positiveScore].every(Number.isFinite)) {
       return Result.fail({
         _tag: 'ReferenceInvalidScore',
         symbol,
@@ -303,8 +333,8 @@ export const riskBalancedDecisionPlan = (
       dailyVolatility,
       annualizedVolatility,
       compositeScore,
-      positiveScore: Math.max(0, compositeScore),
-      eligible: dailyVolatility > 0,
+      positiveScore,
+      eligible,
       uncappedWeight: 0,
       cappedWeight: 0,
       targetWeight: 0,

--- a/services/bayn/src/behavior.ts
+++ b/services/bayn/src/behavior.ts
@@ -1,4 +1,4 @@
 import { sha256 } from './hash'
 
-export const riskBalancedTrendBehaviorVersion = 'bayn.risk-balanced-trend.behavior.v2' as const
+export const riskBalancedTrendBehaviorVersion = 'bayn.risk-balanced-trend.behavior.v3' as const
 export const riskBalancedTrendBehaviorHash = sha256(riskBalancedTrendBehaviorVersion)

--- a/services/bayn/src/contracts.test.ts
+++ b/services/bayn/src/contracts.test.ts
@@ -88,7 +88,7 @@ describe('current contracts', () => {
       schemaVersion: 'bayn.runtime-provenance.v2',
       strategy: {
         name: 'risk-balanced-trend',
-        parameterSchemaVersion: 'bayn.risk-balanced-trend.protocol.v3',
+        parameterSchemaVersion: 'bayn.risk-balanced-trend.protocol.v4',
       },
       contractVersions: {
         inputManifest: 'bayn.input-manifest.v3',

--- a/services/bayn/src/contracts.ts
+++ b/services/bayn/src/contracts.ts
@@ -174,6 +174,7 @@ const RuntimeProvenanceBase = Schema.Struct({
     parameterSchemaVersion: Schema.Literals([
       'bayn.risk-balanced-trend.protocol.v2',
       'bayn.risk-balanced-trend.protocol.v3',
+      'bayn.risk-balanced-trend.protocol.v4',
     ]),
   }),
   contractVersions: Schema.Struct({

--- a/services/bayn/src/db/evidence-store.integration.test.ts
+++ b/services/bayn/src/db/evidence-store.integration.test.ts
@@ -655,7 +655,7 @@ const makeMutationPaperAuthorityGeneration = (
   }
   const strategy = mutationQualificationProvenance.strategy
   const strategyParameterSchemaVersion = strategy.parameterSchemaVersion
-  if (strategyParameterSchemaVersion !== 'bayn.risk-balanced-trend.protocol.v3') {
+  if (strategyParameterSchemaVersion !== 'bayn.risk-balanced-trend.protocol.v4') {
     throw new Error('audited mutation fixture requires the current strategy parameter contract')
   }
 
@@ -1037,6 +1037,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
       { migration_id: 15, name: 'acknowledged_submit_recovery' },
       { migration_id: 16, name: 'authority_bound_intents' },
       { migration_id: 17, name: 'stable_paper_authority_generation' },
+      { migration_id: 18, name: 'robust_trend_protocol' },
     ])
   })
 
@@ -4289,7 +4290,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
             '{}'::jsonb
           )
         `)
-        const current = yield* Effect.exit(sql`
+        const causalHistorical = yield* Effect.exit(sql`
           INSERT INTO protocol_locks (
             protocol_hash, schema_version, strategy_name, behavior_hash, parameter_hash, parameters
           ) VALUES (
@@ -4301,12 +4302,25 @@ describePostgres('PostgreSQL evaluation evidence', () => {
             '{}'::jsonb
           )
         `)
-        return { current, historical, unsupported }
+        const current = yield* Effect.exit(sql`
+          INSERT INTO protocol_locks (
+            protocol_hash, schema_version, strategy_name, behavior_hash, parameter_hash, parameters
+          ) VALUES (
+            ${'9'.repeat(64)},
+            'bayn.risk-balanced-trend.protocol.v4',
+            'risk-balanced-trend',
+            ${'a'.repeat(64)},
+            ${'b'.repeat(64)},
+            '{}'::jsonb
+          )
+        `)
+        return { causalHistorical, current, historical, unsupported }
       }),
     )
 
     expect(Exit.isFailure(exits.unsupported)).toBe(true)
     expect(Exit.isSuccess(exits.historical)).toBe(true)
+    expect(Exit.isSuccess(exits.causalHistorical)).toBe(true)
     expect(Exit.isSuccess(exits.current)).toBe(true)
   })
 
@@ -5269,7 +5283,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
     if (Option.isSome(result.stored)) {
       expect(result.stored.value.protocol).toMatchObject({
         strategyName: 'risk-balanced-trend',
-        schemaVersion: 'bayn.risk-balanced-trend.protocol.v3',
+        schemaVersion: 'bayn.risk-balanced-trend.protocol.v4',
         parameters: fixtureProtocol,
       })
       expect(result.stored.value.run).toMatchObject({

--- a/services/bayn/src/db/migrations.ts
+++ b/services/bayn/src/db/migrations.ts
@@ -17,6 +17,7 @@ import authorityGenerationHistory from '../../migrations/0014_authority_generati
 import acknowledgedSubmitRecovery from '../../migrations/0015_acknowledged_submit_recovery'
 import authorityBoundIntents from '../../migrations/0016_authority_bound_intents'
 import stablePaperAuthorityGeneration from '../../migrations/0017_stable_paper_authority_generation'
+import robustTrendProtocol from '../../migrations/0018_robust_trend_protocol'
 
 export const migrationLoader = PgMigrator.fromRecord({
   '1_initial_schema': initialSchema,
@@ -36,4 +37,5 @@ export const migrationLoader = PgMigrator.fromRecord({
   '15_acknowledged_submit_recovery': acknowledgedSubmitRecovery,
   '16_authority_bound_intents': authorityBoundIntents,
   '17_stable_paper_authority_generation': stablePaperAuthorityGeneration,
+  '18_robust_trend_protocol': robustTrendProtocol,
 })

--- a/services/bayn/src/db/paper-authority-algebra.test.ts
+++ b/services/bayn/src/db/paper-authority-algebra.test.ts
@@ -156,7 +156,7 @@ const evidence: PaperGenerationEvidenceFacts = {
   completeStatusCount: 1,
   writingDetail: { artifactCount: 3, eventCount: 4, gateCount: 5 },
   completeDetail: { reconciliationExact: true, verdict: 'PASS' },
-  protocolSchemaVersion: 'bayn.risk-balanced-trend.protocol.v3',
+  protocolSchemaVersion: 'bayn.risk-balanced-trend.protocol.v4',
   strategyName: 'risk-balanced-trend',
   behaviorHash: config.build.strategyBehaviorHash,
   parameterHash: config.build.strategyParameterHash,

--- a/services/bayn/src/db/paper-authority-algebra.ts
+++ b/services/bayn/src/db/paper-authority-algebra.ts
@@ -55,7 +55,10 @@ export interface PaperGenerationEvidenceFacts {
   readonly completeStatusCount: number
   readonly writingDetail: unknown
   readonly completeDetail: unknown
-  readonly protocolSchemaVersion: 'bayn.risk-balanced-trend.protocol.v2' | 'bayn.risk-balanced-trend.protocol.v3'
+  readonly protocolSchemaVersion:
+    | 'bayn.risk-balanced-trend.protocol.v2'
+    | 'bayn.risk-balanced-trend.protocol.v3'
+    | 'bayn.risk-balanced-trend.protocol.v4'
   readonly strategyName: 'risk-balanced-trend'
   readonly behaviorHash: string
   readonly parameterHash: string
@@ -568,7 +571,7 @@ export const validatePaperGenerationEvidence = (
       facts.resultRunId === binding.qualificationRunId &&
       facts.resultLockId === facts.lockId &&
       facts.candidateRunId === binding.qualificationRunId &&
-      facts.protocolSchemaVersion === 'bayn.risk-balanced-trend.protocol.v3' &&
+      facts.protocolSchemaVersion === 'bayn.risk-balanced-trend.protocol.v4' &&
       facts.strategyName === 'risk-balanced-trend' &&
       facts.behaviorHash === facts.strategyBehaviorHash &&
       facts.parameterHash === facts.strategyParameterHash &&
@@ -648,7 +651,7 @@ const readPaperAuthorityGenerationMaterial = (input: {
       strategyName: input.evidence.strategyName,
       strategyBehaviorHash: input.evidence.behaviorHash,
       strategyParameterHash: input.evidence.parameterHash,
-      strategyParameterSchemaVersion: 'bayn.risk-balanced-trend.protocol.v3',
+      strategyParameterSchemaVersion: 'bayn.risk-balanced-trend.protocol.v4',
       accountId: input.binding.accountId,
       riskPolicyHash: input.proof.riskPolicyHash,
       proofPlanHash: input.proof.proofPlanHash,

--- a/services/bayn/src/db/paper-store/rows.ts
+++ b/services/bayn/src/db/paper-store/rows.ts
@@ -131,7 +131,9 @@ export const AuthorityGenerationRow = Schema.Struct({
   strategy_name: Schema.NullOr(Schema.Literal('risk-balanced-trend')),
   strategy_behavior_hash: Schema.NullOr(Sha256),
   strategy_parameter_hash: Schema.NullOr(Sha256),
-  strategy_parameter_schema_version: Schema.NullOr(Schema.Literal('bayn.risk-balanced-trend.protocol.v3')),
+  strategy_parameter_schema_version: Schema.NullOr(
+    Schema.Literals(['bayn.risk-balanced-trend.protocol.v3', 'bayn.risk-balanced-trend.protocol.v4']),
+  ),
   account_id: Schema.NullOr(NonEmptyString),
   risk_policy_hash: Schema.NullOr(Sha256),
   proof_plan_hash: Schema.NullOr(Sha256),
@@ -160,6 +162,7 @@ export const ActivationEvidenceRow = Schema.Struct({
   protocol_schema_version: Schema.Literals([
     'bayn.risk-balanced-trend.protocol.v2',
     'bayn.risk-balanced-trend.protocol.v3',
+    'bayn.risk-balanced-trend.protocol.v4',
   ]),
   strategy_name: Schema.Literal('risk-balanced-trend'),
   behavior_hash: Sha256,

--- a/services/bayn/src/http.ts
+++ b/services/bayn/src/http.ts
@@ -12,6 +12,7 @@ import type { DatabaseError, EvidenceStoreService } from './db/evidence-store'
 import type { OperationalError } from './errors'
 import { databaseOperation, withinDeadline } from './operations'
 import { Authority } from './paper'
+import { makeQualificationDiagnosis } from './qualification-diagnosis'
 import { isReady, type DependencyHealth, type RuntimeState } from './runtime-state'
 
 type ReadEvidence = EvidenceStoreService['read']
@@ -129,6 +130,10 @@ export const statusFacts = (
       analysisHash: state.evidence?.qualification.analysis.analysisHash ?? null,
       candidateOrdinal: state.evidence?.qualification.analysis.candidateOrdinal ?? null,
       reasonCodes: state.evidence?.qualification.reasonCodes ?? [],
+      diagnosis:
+        state.evidence === null
+          ? null
+          : makeQualificationDiagnosis(state.evidence.evaluation, state.evidence.qualification),
       executionProvenance: state.evidence?.provenance ?? null,
     },
     accounting: {

--- a/services/bayn/src/ledger-plan.test.ts
+++ b/services/bayn/src/ledger-plan.test.ts
@@ -435,20 +435,20 @@ describe('ledger plan Result algebra', () => {
     const replay = assertSuccess(buildLedgerPlan(result, ledger))
 
     expect(replay).toEqual(first)
-    expect(first.runKey).toBe(79_792_431_000_025_543_657_647_989_592_544_810_778n)
-    expect(first.runTag).toBe(18_307_385_734_514_644_762n)
+    expect(first.runKey).toBe(69_942_771_251_131_843_050_516_581_237_517_927_397n)
+    expect(first.runTag).toBe(2_699_395_039_088_034_789n)
     expect(first.accounts).toHaveLength(11)
-    expect(first.transfers).toHaveLength(269)
-    expect(first.accounts[0].id).toBe(28_174_988_367_779_630_772_009_788_722_886_677_084n)
-    expect(first.accounts.at(-1)?.id).toBe(328_386_117_789_076_263_753_212_874_624_739_142_962n)
-    expect(first.transfers[0].id).toBe(532_337_791_250_265_855_850_739_987_090_731_240n)
-    expect(first.transfers.at(-1)?.id).toBe(340_248_724_424_856_676_616_453_965_797_055_502_080n)
+    expect(first.transfers).toHaveLength(249)
+    expect(first.accounts[0].id).toBe(43_249_501_142_936_952_057_395_946_051_265_147_876n)
+    expect(first.accounts.at(-1)?.id).toBe(187_166_520_106_165_147_592_061_639_881_212_135_452n)
+    expect(first.transfers[0].id).toBe(843_588_107_247_104_286_364_813_362_505_705_787n)
+    expect(first.transfers.at(-1)?.id).toBe(339_931_206_364_908_967_505_523_512_953_605_189_254n)
     expect(first.transfers.find((transfer) => transfer.code === TransferCode.funding)?.id).toBe(
-      109_353_885_019_586_710_761_486_091_928_106_698_321n,
+      91_698_455_022_344_017_785_425_376_077_893_533_948n,
     )
     expect(first.accounts.every((account) => account.flags === AccountFlags.history)).toBeTrue()
     expect(first.transfers.every((transfer) => transfer.flags === 0 && transfer.amount > 0n)).toBeTrue()
-    expect(hashPlan(first)).toBe('9c6888ca700beb1c5fb698d28c6d42a5e0b913d4340b08554b475fe96da92074')
+    expect(hashPlan(first)).toBe('92365839d645ebb14e6cefcefe92f6459aadde44b101926952767962112c8762')
   })
 
   test('returns exact ledger-plan hash access, serialization, and canonicalization failures', () => {

--- a/services/bayn/src/paper.ts
+++ b/services/bayn/src/paper.ts
@@ -618,7 +618,10 @@ const PaperAuthorityGenerationIdentityMaterialSchema = Schema.Struct({
   strategyName: Schema.Literal('risk-balanced-trend'),
   strategyBehaviorHash: Sha256,
   strategyParameterHash: Sha256,
-  strategyParameterSchemaVersion: Schema.Literal('bayn.risk-balanced-trend.protocol.v3'),
+  strategyParameterSchemaVersion: Schema.Literals([
+    'bayn.risk-balanced-trend.protocol.v3',
+    'bayn.risk-balanced-trend.protocol.v4',
+  ]),
   accountId: NonEmptyString,
   riskPolicyHash: Sha256,
   proofPlanHash: Sha256,

--- a/services/bayn/src/protocol.test.ts
+++ b/services/bayn/src/protocol.test.ts
@@ -11,7 +11,7 @@ describe('strategy protocol', () => {
     const protocol = await Effect.runPromise(loadDefaultProtocol)
 
     expect(protocol).toMatchObject({
-      schemaVersion: 'bayn.risk-balanced-trend.protocol.v3',
+      schemaVersion: 'bayn.risk-balanced-trend.protocol.v4',
       universeId: 'cross-asset-taa-v1',
       universeSymbolHash: 'c15a52d125073a20c3addee154974ef32b4ef009c40a46b05b54743f075c0fe8',
       universe: ['DBC', 'EFA', 'IEF', 'SPY', 'VNQ'],
@@ -21,6 +21,12 @@ describe('strategy protocol', () => {
       volatilityWindow: 63,
       maximumSymbolWeight: 0.35,
       maximumPortfolioVolatility: 0.1,
+      signal: {
+        aggregation: 'clipped-median-consensus',
+        normalizedTrendCap: 2,
+        minimumPositiveHorizons: 3,
+        allocation: 'conviction-inverse-volatility',
+      },
       executionModel: {
         schemaVersion: 'bayn.execution-model.v2',
         order: {
@@ -69,6 +75,10 @@ describe('strategy protocol', () => {
       { ...defaultProtocolDocument, horizons: [1, 2], volatilityWindow: 2 },
       { ...defaultProtocolDocument, maximumSymbolWeight: 0 },
       { ...defaultProtocolDocument, maximumPortfolioVolatility: 1.1 },
+      {
+        ...defaultProtocolDocument,
+        signal: { ...defaultProtocolDocument.signal, minimumPositiveHorizons: 5 },
+      },
       { ...defaultProtocolDocument, universeSymbolHash: '0'.repeat(64) },
       { ...defaultProtocolDocument, universeId: 'equity-infrastructure-v1' },
       { ...defaultProtocolDocument, evaluationStart: defaultProtocolDocument.historyStart },
@@ -83,8 +93,9 @@ describe('strategy protocol', () => {
   })
 
   test('decodes the frozen v2 protocol only for immutable historical evidence', async () => {
+    const { signal: _signal, ...historicalBase } = defaultProtocolDocument
     const historical = {
-      ...defaultProtocolDocument,
+      ...historicalBase,
       schemaVersion: 'bayn.risk-balanced-trend.protocol.v2',
       executionModel: {
         ...defaultProtocolDocument.executionModel,
@@ -104,6 +115,16 @@ describe('strategy protocol', () => {
 
     expect(protocol.schemaVersion).toBe('bayn.risk-balanced-trend.protocol.v2')
     expect(protocol.executionModel.schemaVersion).toBe('bayn.execution-model.v1')
+  })
+
+  test('decodes the frozen v3 protocol only for immutable historical evidence', async () => {
+    const { signal: _signal, ...historicalBase } = defaultProtocolDocument
+    const protocol = await Effect.runPromise(
+      loadProtocol({ ...historicalBase, schemaVersion: 'bayn.risk-balanced-trend.protocol.v3' }),
+    )
+
+    expect(protocol.schemaVersion).toBe('bayn.risk-balanced-trend.protocol.v3')
+    expect('signal' in protocol).toBe(false)
   })
 
   test('requires every execution fact', async () => {

--- a/services/bayn/src/protocol.ts
+++ b/services/bayn/src/protocol.ts
@@ -167,8 +167,20 @@ const ProtocolV3Base = Schema.Struct({
   executionModel: ExecutionModelV2Schema,
 })
 
+const ProtocolV4Base = Schema.Struct({
+  schemaVersion: Schema.Literal('bayn.risk-balanced-trend.protocol.v4'),
+  ...ProtocolCommon,
+  signal: Schema.Struct({
+    aggregation: Schema.Literal('clipped-median-consensus'),
+    normalizedTrendCap: PositiveFinite,
+    minimumPositiveHorizons: PositiveInteger,
+    allocation: Schema.Literal('conviction-inverse-volatility'),
+  }),
+  executionModel: ExecutionModelV2Schema,
+})
+
 const protocolIssues = (
-  parameters: typeof ProtocolV2Base.Type | typeof ProtocolV3Base.Type,
+  parameters: typeof ProtocolV2Base.Type | typeof ProtocolV3Base.Type | typeof ProtocolV4Base.Type,
 ): readonly Schema.FilterIssue[] => {
   const issues: Schema.FilterIssue[] = []
   const sortedUniverse = [...new Set(parameters.universe)].sort()
@@ -206,17 +218,27 @@ const protocolIssues = (
       issue: `must provide at least ${DIRECT_VOLATILITY_WINDOW} sessions for the direct-volatility benchmark`,
     })
   }
+  if (
+    parameters.schemaVersion === 'bayn.risk-balanced-trend.protocol.v4' &&
+    parameters.signal.minimumPositiveHorizons > parameters.horizons.length
+  ) {
+    issues.push({
+      path: ['signal', 'minimumPositiveHorizons'],
+      issue: 'must not exceed the configured horizon count',
+    })
+  }
   return issues
 }
 
 export const ProtocolV2Schema = ProtocolV2Base.check(Schema.makeFilter(protocolIssues))
 export const ProtocolV3Schema = ProtocolV3Base.check(Schema.makeFilter(protocolIssues))
-export const ProtocolSchema = Schema.Union([ProtocolV2Schema, ProtocolV3Schema])
+export const ProtocolV4Schema = ProtocolV4Base.check(Schema.makeFilter(protocolIssues))
+export const ProtocolSchema = Schema.Union([ProtocolV2Schema, ProtocolV3Schema, ProtocolV4Schema])
 export type Protocol = typeof ProtocolSchema.Type
-export type CausalProtocol = typeof ProtocolV3Schema.Type
+export type CausalProtocol = typeof ProtocolV4Schema.Type
 
 export const defaultProtocolDocument = {
-  schemaVersion: 'bayn.risk-balanced-trend.protocol.v3',
+  schemaVersion: 'bayn.risk-balanced-trend.protocol.v4',
   universeId: universeContract.id,
   universeSymbolHash: universeContract.symbolHash,
   universe: universeContract.symbols,
@@ -229,6 +251,12 @@ export const defaultProtocolDocument = {
   maximumSymbolWeight: 0.35,
   maximumPortfolioVolatility: 0.1,
   directVolatilityTarget: 0.1,
+  signal: {
+    aggregation: 'clipped-median-consensus',
+    normalizedTrendCap: 2,
+    minimumPositiveHorizons: 3,
+    allocation: 'conviction-inverse-volatility',
+  },
   initialCapitalMicros: '1000000000000',
   executionModel: defaultExecutionModel,
   thresholds: defaultEconomicThresholds,
@@ -245,7 +273,7 @@ export const loadProtocol = (input: unknown): Effect.Effect<Protocol, Operationa
   )
 
 export const loadDefaultProtocol: Effect.Effect<CausalProtocol, OperationalError> = Schema.decodeUnknownEffect(
-  ProtocolV3Schema,
+  ProtocolV4Schema,
   StrictParseOptions,
 )(defaultProtocolDocument).pipe(
   Effect.mapError((cause) =>

--- a/services/bayn/src/qualification-audit.test.ts
+++ b/services/bayn/src/qualification-audit.test.ts
@@ -353,7 +353,7 @@ describe('qualification audit', () => {
     ])
     expect(first.policies.policySetHash).toBe(canonicalHashV1(first.policies.documents))
     expect(second.auditHash).toBe(first.auditHash)
-    expect(first.auditHash).toBe('b3a9ee416e1a97794acebb9ad071da4a01b1513f1ba6c87cc5f206c76b168043')
+    expect(first.auditHash).toBe('864443531b3431094e3750f21436e79b1d6447043608e88192b4749a976268b3')
   })
 
   test('passes for a later candidate when prior terminal result lineage is complete', () => {
@@ -432,7 +432,7 @@ describe('qualification audit', () => {
       _tag: 'UnsupportedAuditProtocolVersion',
       storedSchemaVersion: 'bayn.risk-balanced-trend.protocol.v2',
       suppliedSchemaVersion: fixtureProtocol.schemaVersion,
-      requiredSchemaVersion: 'bayn.risk-balanced-trend.protocol.v3',
+      supportedSchemaVersions: ['bayn.risk-balanced-trend.protocol.v3', 'bayn.risk-balanced-trend.protocol.v4'],
     })
   })
 

--- a/services/bayn/src/qualification-diagnosis.test.ts
+++ b/services/bayn/src/qualification-diagnosis.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from 'bun:test'
+
+import { canonicalHashV1 } from './hash'
+import { pinnedEvaluation, pinnedQualification } from './app-test-support'
+import { makeQualificationDiagnosis } from './qualification-diagnosis'
+import { summarizeEvaluation } from './risk-balanced-trend'
+
+describe('qualification diagnosis', () => {
+  test('summarizes statistical distance and economic costs deterministically', () => {
+    const evaluation = summarizeEvaluation(pinnedEvaluation)
+    const first = makeQualificationDiagnosis(evaluation, pinnedQualification)
+    const second = makeQualificationDiagnosis(evaluation, pinnedQualification)
+    const { diagnosisHash, ...material } = first
+
+    expect(second).toEqual(first)
+    expect(diagnosisHash).toBe(canonicalHashV1(material))
+    expect(first.runId).toBe(pinnedQualification.runId)
+    expect(first.candidateOrdinal).toBe(pinnedQualification.analysis.candidateOrdinal)
+    expect(first.benchmark.name).toBe(pinnedQualification.analysis.bootstrap.selectedBenchmark)
+    expect(first.bootstrap.sharpeDifference.sampleCount).toBe(pinnedQualification.analysis.bootstrap.producedSamples)
+    expect(first.bootstrap.sharpeDifference.lowerBound).toBe(
+      pinnedQualification.analysis.bootstrap.sharpeDifferenceLowerBound,
+    )
+    expect(first.bootstrap.sharpeDifference.positiveFraction).toBeGreaterThanOrEqual(0)
+    expect(first.bootstrap.sharpeDifference.positiveFraction).toBeLessThanOrEqual(1)
+    expect(first.candidate.totalTransactionCostMicros).toMatch(/^[0-9]+$/)
+  })
+})

--- a/services/bayn/src/qualification-diagnosis.ts
+++ b/services/bayn/src/qualification-diagnosis.ts
@@ -1,0 +1,97 @@
+import { canonicalHashV1 } from './hash'
+import type { QualificationResult } from './qualification'
+import type { EvaluationSummary, PerformanceMetrics } from './types'
+
+const round = (value: number): number => Number.parseFloat(value.toFixed(12))
+
+const nearestRank = (sorted: readonly number[], probability: number): number => {
+  if (sorted.length === 0) return 0
+  const rank = Math.max(1, Math.ceil(probability * sorted.length))
+  return sorted.at(rank - 1) ?? 0
+}
+
+const distribution = (values: readonly number[], lowerBound: number) => {
+  const sorted = [...values].sort((left, right) => left - right)
+  const mean = values.length === 0 ? 0 : values.reduce((total, value) => total + value, 0) / values.length
+  const positive = values.filter((value) => value > 0).length
+  return {
+    method: 'nearest-rank' as const,
+    sampleCount: values.length,
+    minimum: sorted.at(0) ?? 0,
+    lowerBound,
+    p05: nearestRank(sorted, 0.05),
+    median: nearestRank(sorted, 0.5),
+    p95: nearestRank(sorted, 0.95),
+    maximum: sorted.at(-1) ?? 0,
+    mean: round(mean),
+    positiveFraction: round(values.length === 0 ? 0 : positive / values.length),
+  }
+}
+
+const totalTransactionCostMicros = (metrics: PerformanceMetrics): string =>
+  (
+    BigInt(metrics.totalFeesMicros) +
+    BigInt(metrics.totalSpreadCostMicros) +
+    BigInt(metrics.totalSlippageCostMicros)
+  ).toString()
+
+const metricFacts = (metrics: PerformanceMetrics) => ({
+  observations: metrics.observations,
+  annualizedReturn: metrics.annualizedReturn,
+  annualizedVolatility: metrics.annualizedVolatility,
+  sharpe: metrics.sharpe,
+  maximumDrawdown: metrics.maximumDrawdown,
+  annualTurnover: metrics.annualTurnover,
+  totalTransactionCostMicros: totalTransactionCostMicros(metrics),
+  totalCashYieldMicros: metrics.totalCashYieldMicros,
+})
+
+export const makeQualificationDiagnosis = (evaluation: EvaluationSummary, result: QualificationResult) => {
+  const bootstrap = result.analysis.bootstrap
+  const benchmarkMetrics =
+    bootstrap.selectedBenchmark === 'buy-and-hold' ? evaluation.buyAndHold : evaluation.directVolTiming
+  const material = {
+    schemaVersion: 'bayn.qualification-diagnosis.v1' as const,
+    runId: result.runId,
+    candidateOrdinal: result.analysis.candidateOrdinal,
+    verdict: result.verdict,
+    reasonCodes: result.reasonCodes,
+    candidate: metricFacts(evaluation.strategy),
+    benchmark: {
+      name: bootstrap.selectedBenchmark,
+      ...metricFacts(benchmarkMetrics),
+      qualificationSharpe: bootstrap.selectedBenchmarkSharpe,
+    },
+    economicPointSharpeDifference: round(evaluation.strategy.sharpe - benchmarkMetrics.sharpe),
+    bootstrap: {
+      adjustedOneSidedAlpha: bootstrap.adjustedOneSidedAlpha,
+      tailSampleCount: bootstrap.tailSampleCount,
+      minimumTailSamples: bootstrap.minimumTailSamples,
+      tailResolutionSufficient: bootstrap.tailResolutionSufficient,
+      sharpeDifference: distribution(bootstrap.sharpeDifferenceSamples, bootstrap.sharpeDifferenceLowerBound),
+      annualizedExcessReturn: distribution(
+        bootstrap.annualizedExcessReturnSamples,
+        bootstrap.annualizedExcessReturnLowerBound,
+      ),
+    },
+    power: {
+      sufficient: result.analysis.power.sufficient,
+      availableCompleteRebalanceBlocks: result.analysis.power.availableCompleteRebalanceBlocks,
+      requiredCompleteRebalanceBlocks: result.analysis.power.requiredCompleteRebalanceBlocks,
+      availableCompleteSessions: result.analysis.power.availableCompleteSessions,
+      requiredSessions: result.analysis.power.requiredSessions,
+    },
+    walkForward: {
+      sufficient: result.analysis.walkForward.sufficient,
+      folds: result.analysis.walkForward.folds.length,
+      requiredFolds: result.analysis.walkForward.requiredFolds,
+      positiveFoldFraction: result.analysis.walkForward.positiveFoldFraction,
+      requiredPositiveFoldFraction: result.analysis.walkForward.requiredPositiveFoldFraction,
+      maximumFoldDrawdown: result.analysis.walkForward.maximumFoldDrawdown,
+      maximumAllowedFoldDrawdown: result.analysis.policy.walkForward.maximumFoldDrawdown,
+    },
+  }
+  return { ...material, diagnosisHash: canonicalHashV1(material) }
+}
+
+export type QualificationDiagnosis = ReturnType<typeof makeQualificationDiagnosis>

--- a/services/bayn/src/risk-balanced-trend.test.ts
+++ b/services/bayn/src/risk-balanced-trend.test.ts
@@ -15,20 +15,38 @@ import {
 } from './risk-balanced-trend'
 import { makeStrategy } from './strategy'
 import { makeSnapshot, makeTestProvenance, fixtureProtocol } from './test-fixtures'
-import type { CausalProtocol, IsoDate } from './types'
+import type { CausalProtocol, IsoDate, Protocol } from './types'
 
 const assertSuccess = <A, E>(result: Result.Result<A, E>): A => {
   assert(Result.isSuccess(result), 'strategy evaluation fixture must succeed')
   return result.success
 }
 
-const shortProtocol = (overrides: Partial<CausalProtocol> = {}): CausalProtocol => ({
-  ...fixtureProtocol,
+type HistoricalProtocol = Extract<Protocol, { readonly schemaVersion: 'bayn.risk-balanced-trend.protocol.v3' }>
+
+const { signal: _candidateSignal, ...historicalProtocolBase } = fixtureProtocol
+const historicalProtocol: HistoricalProtocol = {
+  ...historicalProtocolBase,
+  schemaVersion: 'bayn.risk-balanced-trend.protocol.v3',
+}
+
+const shortProtocol = (overrides: Partial<HistoricalProtocol> = {}): HistoricalProtocol => ({
+  ...historicalProtocol,
   universe: ['DBC', 'EEM', 'EFA'],
   horizons: [1, 2],
   volatilityWindow: 2,
   maximumSymbolWeight: 0.35,
   maximumPortfolioVolatility: 0.1,
+  ...overrides,
+})
+
+const shortCandidateProtocol = (overrides: Partial<CausalProtocol> = {}): CausalProtocol => ({
+  ...fixtureProtocol,
+  universe: ['DBC', 'EEM', 'EFA'],
+  horizons: [1, 2, 3, 4],
+  volatilityWindow: 4,
+  maximumSymbolWeight: 0.35,
+  maximumPortfolioVolatility: 1,
   ...overrides,
 })
 
@@ -120,6 +138,38 @@ describe('risk-balanced trend candidate', () => {
     expect(efa.compositeScore).toBeCloseTo(-Math.sqrt(8), 12)
     expect(efa.positiveScore).toBe(0)
     expect(decision.targetWeights).toEqual({ DBC: 0.666666666667, EEM: 0.333333333333, EFA: 0 })
+  })
+
+  test('requires three positive horizons and allocates by conviction per unit volatility in protocol v4', () => {
+    const protocol = shortCandidateProtocol()
+    const dates = [
+      '2026-07-13',
+      '2026-07-14',
+      '2026-07-15',
+      '2026-07-16',
+      '2026-07-17',
+    ] as const satisfies readonly IsoDate[]
+    const decision = assertSuccess(
+      makeRiskBalancedTrendDecision(
+        dates[4],
+        dates,
+        {
+          DBC: [100, 99, 101, 98, 100],
+          EEM: [100, 99, 98, 99, 101],
+          EFA: [100, 101, 102, 101, 99],
+        },
+        protocol,
+      ),
+    )
+    const dbc = decision.signals.find((signal) => signal.symbol === 'DBC')
+    const eem = decision.signals.find((signal) => signal.symbol === 'EEM')
+    const efa = decision.signals.find((signal) => signal.symbol === 'EFA')
+
+    expect(dbc).toMatchObject({ eligible: false, positiveScore: 0, targetWeight: 0 })
+    expect(eem?.eligible).toBe(true)
+    expect(eem?.targetWeight).toBeGreaterThan(0)
+    expect(eem?.positiveScore).toBeCloseTo((eem?.compositeScore ?? 0) / (eem?.annualizedVolatility ?? 1), 12)
+    expect(efa).toMatchObject({ eligible: false, positiveScore: 0, targetWeight: 0 })
   })
 
   test('normalizes continuous trend, retains cash under cap capacity, and scales portfolio volatility', () => {
@@ -538,9 +588,9 @@ describe('risk-balanced trend candidate', () => {
     )
     expect(analysis.priorTrialRunIds).toEqual(priorTrialRunIds)
     expect(analysis.candidateOrdinal).toBe(9)
-    expect(canonicalHashV1(first)).toBe('8be4f2f76c69bd7eeb2984bc08cd1d49013d2b349c8c574683851d4052a4901f')
+    expect(canonicalHashV1(first)).toBe('81002ac221b557498e06cbcd9307d986ed21ff2c2ce883adcc489fef7f468416')
     expect(canonicalHashV1(first.signalDecisions)).toBe(
-      'e0803e7a3d0258f508b054262f6ba5a1760b4a35d78816c1c701c7d783061568',
+      'a7ee602d168b076e56759e852ac3a207d7f74774ee0f2650c0922ad1e1f4e272',
     )
   })
 })

--- a/services/bayn/src/risk-balanced-trend/decisions.ts
+++ b/services/bayn/src/risk-balanced-trend/decisions.ts
@@ -299,6 +299,63 @@ interface PreparedSignal {
   readonly returns: readonly number[]
 }
 
+const median = (values: readonly number[]): number => {
+  const sorted = [...values].sort((left, right) => left - right)
+  const midpoint = Math.floor(sorted.length / 2)
+  const upper = sorted.at(midpoint) ?? 0
+  if (sorted.length % 2 === 1) return upper
+  const lower = sorted.at(midpoint - 1) ?? upper
+  return (lower + upper) / 2
+}
+
+const scoreSignal = (
+  protocol: Protocol,
+  horizons: readonly SymbolSignal['horizons'][number][],
+  dailyVolatility: number,
+  annualizedVolatility: number,
+  symbol: string,
+): Result.Result<Pick<SymbolSignal, 'compositeScore' | 'positiveScore' | 'eligible'>, RiskBalancedTrendFailure> => {
+  if (horizons.length === 0) {
+    return fail({
+      _tag: 'InvalidRiskBalancedTrendNumber',
+      operation: 'composite-score',
+      value: Number.NaN,
+      symbol,
+      reason: 'not-finite',
+    })
+  }
+  if (dailyVolatility === 0) {
+    return Result.succeed({ compositeScore: 0, positiveScore: 0, eligible: false })
+  }
+  if (protocol.schemaVersion !== 'bayn.risk-balanced-trend.protocol.v4') {
+    return pipe(
+      mean(horizons.map((value) => value.normalizedTrend)),
+      Result.flatMap((value) => finite(value, 'composite-score', symbol)),
+      Result.map((compositeScore) => ({
+        compositeScore,
+        positiveScore: Math.max(0, compositeScore),
+        eligible: true,
+      })),
+    )
+  }
+  const cap = protocol.signal.normalizedTrendCap
+  const clipped = horizons.map(({ normalizedTrend }) => Math.max(-cap, Math.min(cap, normalizedTrend)))
+  const compositeScore = median(clipped)
+  const positiveHorizons = horizons.filter(({ normalizedTrend }) => normalizedTrend > 0).length
+  const eligible = positiveHorizons >= protocol.signal.minimumPositiveHorizons && compositeScore > 0
+  return pipe(
+    Result.all({
+      compositeScore: finite(compositeScore, 'composite-score', symbol),
+      positiveScore: finite(eligible ? compositeScore / annualizedVolatility : 0, 'weight-allocation', symbol),
+    }),
+    Result.map(({ compositeScore: score, positiveScore }) => ({
+      compositeScore: score,
+      positiveScore,
+      eligible,
+    })),
+  )
+}
+
 const prepareSignal = (
   symbol: string,
   closes: Readonly<Record<string, readonly number[]>>,
@@ -370,21 +427,14 @@ const prepareSignal = (
                 ),
                 Result.flatMap((horizons) =>
                   pipe(
-                    dailyVolatility === 0
-                      ? Result.succeed(0)
-                      : pipe(
-                          mean(horizons.map((value) => value.normalizedTrend)),
-                          Result.flatMap((value) => finite(value, 'composite-score', symbol)),
-                        ),
-                    Result.map((compositeScore) => ({
+                    scoreSignal(protocol, horizons, dailyVolatility, annualizedVolatility, symbol),
+                    Result.map((score) => ({
                       signal: {
                         symbol,
                         horizons,
                         dailyVolatility,
                         annualizedVolatility,
-                        compositeScore,
-                        positiveScore: Math.max(0, compositeScore),
-                        eligible: dailyVolatility > 0,
+                        ...score,
                       },
                       returns: recentReturns,
                     })),

--- a/services/bayn/src/startup.test.ts
+++ b/services/bayn/src/startup.test.ts
@@ -749,10 +749,11 @@ describe('Bayn startup lifecycle', () => {
     })
   })
 
-  test('recovers immutable protocol v2 evidence independently of the compiled v3 strategy', async () => {
+  test('recovers immutable protocol v2 evidence independently of the compiled v4 strategy', async () => {
+    const { signal: _signal, ...historicalBase } = defaultProtocolDocument
     const historicalProtocol = Effect.runSync(
       loadProtocol({
-        ...defaultProtocolDocument,
+        ...historicalBase,
         schemaVersion: 'bayn.risk-balanced-trend.protocol.v2',
         executionModel: {
           ...defaultProtocolDocument.executionModel,
@@ -847,7 +848,7 @@ describe('Bayn startup lifecycle', () => {
       ),
     )
 
-    expect(fixtureStrategy.provenance.strategy.parameterSchemaVersion).toBe('bayn.risk-balanced-trend.protocol.v3')
+    expect(fixtureStrategy.provenance.strategy.parameterSchemaVersion).toBe('bayn.risk-balanced-trend.protocol.v4')
     expect(await Effect.runPromise(Ref.get(state))).toMatchObject({
       status: 'STARTING',
       evidence: {

--- a/services/bayn/src/startup/decisions.ts
+++ b/services/bayn/src/startup/decisions.ts
@@ -62,7 +62,8 @@ const provenanceFromStored = (
   if (
     stored.protocol.strategyName !== 'risk-balanced-trend' ||
     (stored.protocol.schemaVersion !== 'bayn.risk-balanced-trend.protocol.v2' &&
-      stored.protocol.schemaVersion !== 'bayn.risk-balanced-trend.protocol.v3')
+      stored.protocol.schemaVersion !== 'bayn.risk-balanced-trend.protocol.v3' &&
+      stored.protocol.schemaVersion !== 'bayn.risk-balanced-trend.protocol.v4')
   ) {
     return Result.fail({
       _tag: 'StoredProvenanceInvalid',
@@ -70,10 +71,7 @@ const provenanceFromStored = (
       issue: { reason: 'unsupported-contract' },
     })
   }
-  const parameterSchemaVersion =
-    stored.protocol.schemaVersion === 'bayn.risk-balanced-trend.protocol.v2'
-      ? 'bayn.risk-balanced-trend.protocol.v2'
-      : 'bayn.risk-balanced-trend.protocol.v3'
+  const parameterSchemaVersion = stored.protocol.schemaVersion
   const provenanceResult = pipe(
     makeRuntimeProvenanceResult({
       sourceRevision: stored.run.sourceRevision,


### PR DESCRIPTION
## Summary

- precommit `bayn.risk-balanced-trend.protocol.v4` with clipped median horizon consensus, a 3-of-4 positive-horizon gate, and conviction-per-volatility risk budgeting
- preserve exact v2/v3 historical evaluation and independent replay semantics while adding durable v4 protocol, startup, audit, PAPER, and PostgreSQL contracts
- expose deterministic qualification diagnosis in `/v1/status`, including point Sharpe gap, bootstrap distribution/positive fraction, lower bounds, power, walk-forward stability, and transaction costs
- add migration 18 for v4 protocol locks and authority-generation history

## Why

Candidate ordinal 4 is sufficiently powered and passes excess-return and walk-forward gates, but its Sharpe-difference bootstrap is centered at zero: point improvement `+0.002343`, median `+0.000239`, 50.04% positive samples, and LCB `-0.576023`. Immutable attribution also found 76 of 570 symbol decisions allocating with only one or two positive horizons. Protocol v4 addresses that observed structural weakness without weakening the benchmark, confidence level, multiplicity adjustment, lineage, or promotion gates.

## Safety

- authority remains `OBSERVE`; no broker-order or capital-promotion capability is enabled
- this PR does not rerun or replace the pinned qualification
- the currently observed Signal snapshot is still 2026-07-24, so GitOps must hold the changed strategy identity until a fresher finalized snapshot exists
- no manual Codex review was requested

## Validation

- Oxfmt: 268 files
- TypeScript: pass
- Effect diagnostics: 264 files, 0 findings
- Oxlint: 264 files, 0 findings
- type-aware Oxlint: 264 files, 0 findings
- Bayn unit suite: 754 pass, 121 PostgreSQL-gated skip, 0 fail, 4,374 assertions
- PostgreSQL 18 exact-head integration: evidence 65, PAPER 30, cycles 13; 108 pass, 0 fail
- build: 623 modules, 4.48 MB
- GitOps promotion tests: 20 pass, 0 fail
