### PR TITLE
feat(bayn): model orthogonal execution authority

### DIFF
--- a/services/bayn/src/execution/authority.test.ts
+++ b/services/bayn/src/execution/authority.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, test } from 'bun:test'
+
+import { Result } from 'effect'
+
+import { Authority } from '../paper'
+import { BrokerMode } from '../risk'
+import {
+  BrokerEnvironment,
+  CapitalAccessState,
+  ExecutionAccess,
+  LegacyBrokerMode,
+  LegacyMaximumAuthority,
+  decodeExecutionAuthority,
+  decodeLegacyPaperAuthority,
+  disabledCapitalAccess,
+  enabledCapitalAccess,
+  encodeLegacyPaperAuthority,
+  makeExecutionAuthority,
+} from './authority'
+
+const failureOf = <A, E>(result: Result.Result<A, E>): E => {
+  if (Result.isFailure(result)) return result.failure
+  throw new Error('expected failure')
+}
+
+const policyIdentity = '9a36746eaf154b9ba18cd046c42c1f44f4e93c68d54921fc9ac874fc19f5f13a'
+
+describe('execution authority model', () => {
+  test('keeps broker environment, execution access, and capital access orthogonal', () => {
+    const environments = [BrokerEnvironment.Sandbox, BrokerEnvironment.Live] as const
+    const executionAccesses = [ExecutionAccess.ReadOnly, ExecutionAccess.SubmitOrders] as const
+    const capitalAccesses = [disabledCapitalAccess, enabledCapitalAccess(policyIdentity)] as const
+
+    const authorities = environments.flatMap((brokerEnvironment) =>
+      executionAccesses.flatMap((executionAccess) =>
+        capitalAccesses.map((capitalAccess) =>
+          Result.getOrThrow(
+            decodeExecutionAuthority(makeExecutionAuthority(brokerEnvironment, executionAccess, capitalAccess)),
+          ),
+        ),
+      ),
+    )
+
+    expect(authorities).toHaveLength(8)
+    expect(authorities).toContainEqual(
+      makeExecutionAuthority(BrokerEnvironment.Live, ExecutionAccess.ReadOnly, disabledCapitalAccess),
+    )
+    expect(authorities).toContainEqual(
+      makeExecutionAuthority(
+        BrokerEnvironment.Sandbox,
+        ExecutionAccess.SubmitOrders,
+        enabledCapitalAccess(policyIdentity),
+      ),
+    )
+  })
+
+  test('requires policy identity only for enabled capital access', () => {
+    expect(
+      failureOf(
+        decodeExecutionAuthority({
+          brokerEnvironment: BrokerEnvironment.Live,
+          executionAccess: ExecutionAccess.ReadOnly,
+          capitalAccess: { _tag: CapitalAccessState.Enabled },
+        }),
+      ).message,
+    ).toContain('policyIdentity')
+
+    expect(
+      failureOf(
+        decodeExecutionAuthority({
+          brokerEnvironment: BrokerEnvironment.Sandbox,
+          executionAccess: ExecutionAccess.SubmitOrders,
+          capitalAccess: {
+            _tag: CapitalAccessState.Disabled,
+            policyIdentity,
+          },
+        }),
+      ).message,
+    ).toContain('Unexpected key')
+  })
+
+  test('preserves existing PAPER and OBSERVE durable identifiers through the legacy adapter', () => {
+    expect(String(LegacyBrokerMode.Paper)).toBe('PAPER')
+    expect(String(LegacyMaximumAuthority.Observe)).toBe('OBSERVE')
+    expect(String(LegacyMaximumAuthority.Paper)).toBe('PAPER')
+    expect(String(BrokerMode.Paper)).toBe('PAPER')
+    expect(String(Authority.Observe)).toBe('OBSERVE')
+    expect(String(Authority.Paper)).toBe('PAPER')
+
+    const observe = Result.getOrThrow(
+      decodeLegacyPaperAuthority({
+        brokerMode: BrokerMode.Paper,
+        maximum: Authority.Observe,
+        effective: Authority.Observe,
+      }),
+    )
+    const contained = Result.getOrThrow(
+      decodeLegacyPaperAuthority({
+        brokerMode: BrokerMode.Paper,
+        maximum: Authority.Paper,
+        effective: Authority.Observe,
+        riskPolicyHash: policyIdentity,
+      }),
+    )
+    const submit = Result.getOrThrow(
+      decodeLegacyPaperAuthority({
+        brokerMode: BrokerMode.Paper,
+        maximum: Authority.Paper,
+        effective: Authority.Paper,
+        riskPolicyHash: policyIdentity,
+      }),
+    )
+
+    expect(observe).toEqual(
+      makeExecutionAuthority(BrokerEnvironment.Sandbox, ExecutionAccess.ReadOnly, disabledCapitalAccess),
+    )
+    expect(contained).toEqual(
+      makeExecutionAuthority(BrokerEnvironment.Sandbox, ExecutionAccess.ReadOnly, enabledCapitalAccess(policyIdentity)),
+    )
+    expect(submit).toEqual(
+      makeExecutionAuthority(
+        BrokerEnvironment.Sandbox,
+        ExecutionAccess.SubmitOrders,
+        enabledCapitalAccess(policyIdentity),
+      ),
+    )
+    expect(Result.getOrThrow(encodeLegacyPaperAuthority(observe))).toEqual({
+      brokerMode: LegacyBrokerMode.Paper,
+      maximum: LegacyMaximumAuthority.Observe,
+      effective: LegacyMaximumAuthority.Observe,
+    })
+    expect(Result.getOrThrow(encodeLegacyPaperAuthority(contained))).toEqual({
+      brokerMode: LegacyBrokerMode.Paper,
+      maximum: LegacyMaximumAuthority.Paper,
+      effective: LegacyMaximumAuthority.Observe,
+      riskPolicyHash: policyIdentity,
+    })
+    expect(Result.getOrThrow(encodeLegacyPaperAuthority(submit))).toEqual({
+      brokerMode: LegacyBrokerMode.Paper,
+      maximum: LegacyMaximumAuthority.Paper,
+      effective: LegacyMaximumAuthority.Paper,
+      riskPolicyHash: policyIdentity,
+    })
+  })
+
+  test('fails closed when legacy authority material is incomplete or contradictory', () => {
+    expect(
+      failureOf(
+        decodeLegacyPaperAuthority({
+          brokerMode: BrokerMode.Paper,
+          maximum: Authority.Paper,
+          effective: Authority.Observe,
+        }),
+      ),
+    ).toEqual({
+      _tag: 'MissingLegacyRiskPolicyHash',
+      maximum: LegacyMaximumAuthority.Paper,
+    })
+
+    expect(
+      failureOf(
+        decodeLegacyPaperAuthority({
+          brokerMode: BrokerMode.Paper,
+          maximum: Authority.Observe,
+          effective: Authority.Observe,
+          riskPolicyHash: policyIdentity,
+        }),
+      ),
+    ).toEqual({
+      _tag: 'UnexpectedLegacyRiskPolicyHash',
+      maximum: LegacyMaximumAuthority.Observe,
+      riskPolicyHash: policyIdentity,
+    })
+
+    expect(
+      failureOf(
+        decodeLegacyPaperAuthority({
+          brokerMode: BrokerMode.Paper,
+          maximum: Authority.Observe,
+          effective: Authority.Paper,
+        }),
+      ),
+    ).toEqual({
+      _tag: 'LegacyEffectiveAuthorityExceedsMaximum',
+      maximum: LegacyMaximumAuthority.Observe,
+      effective: LegacyMaximumAuthority.Paper,
+    })
+
+    expect(
+      failureOf(
+        decodeLegacyPaperAuthority({
+          brokerMode: 'LIVE',
+          maximum: Authority.Observe,
+          effective: Authority.Observe,
+        }),
+      )._tag,
+    ).toBe('InvalidLegacyPaperAuthorityMaterial')
+  })
+
+  test('rejects new combinations that the legacy paper-only contract cannot represent', () => {
+    expect(
+      failureOf(
+        encodeLegacyPaperAuthority(
+          makeExecutionAuthority(BrokerEnvironment.Live, ExecutionAccess.ReadOnly, disabledCapitalAccess),
+        ),
+      ),
+    ).toEqual({
+      _tag: 'LegacyBrokerEnvironmentUnsupported',
+      brokerEnvironment: BrokerEnvironment.Live,
+    })
+
+    expect(
+      failureOf(
+        encodeLegacyPaperAuthority(
+          makeExecutionAuthority(BrokerEnvironment.Sandbox, ExecutionAccess.SubmitOrders, disabledCapitalAccess),
+        ),
+      ),
+    ).toEqual({
+      _tag: 'LegacyAuthorityCombinationUnsupported',
+      executionAccess: ExecutionAccess.SubmitOrders,
+      capitalAccess: CapitalAccessState.Disabled,
+    })
+  })
+})

--- a/services/bayn/src/execution/authority.ts
+++ b/services/bayn/src/execution/authority.ts
@@ -1,0 +1,231 @@
+import { Result, Schema } from 'effect'
+
+import { Sha256Schema as Sha256, strictParseOptions as StrictParseOptions } from '../schemas'
+
+export enum BrokerEnvironment {
+  Sandbox = 'sandbox',
+  Live = 'live',
+}
+
+export enum ExecutionAccess {
+  ReadOnly = 'read-only',
+  SubmitOrders = 'submit-orders',
+}
+
+export const BrokerEnvironmentSchema = Schema.Enum(BrokerEnvironment)
+export const ExecutionAccessSchema = Schema.Enum(ExecutionAccess)
+export const CapitalPolicyIdentitySchema = Sha256
+export type CapitalPolicyIdentity = typeof CapitalPolicyIdentitySchema.Type
+
+export enum CapitalAccessState {
+  Disabled = 'Disabled',
+  Enabled = 'Enabled',
+}
+
+export interface DisabledCapitalAccess {
+  readonly _tag: CapitalAccessState.Disabled
+}
+
+export interface EnabledCapitalAccess {
+  readonly _tag: CapitalAccessState.Enabled
+  readonly policyIdentity: CapitalPolicyIdentity
+}
+
+export type CapitalAccess = DisabledCapitalAccess | EnabledCapitalAccess
+
+export interface ExecutionAuthority {
+  readonly brokerEnvironment: BrokerEnvironment
+  readonly executionAccess: ExecutionAccess
+  readonly capitalAccess: CapitalAccess
+}
+
+export const disabledCapitalAccess: DisabledCapitalAccess = {
+  _tag: CapitalAccessState.Disabled,
+}
+
+export const enabledCapitalAccess = (policyIdentity: CapitalPolicyIdentity): EnabledCapitalAccess => ({
+  _tag: CapitalAccessState.Enabled,
+  policyIdentity,
+})
+
+export const makeExecutionAuthority = (
+  brokerEnvironment: BrokerEnvironment,
+  executionAccess: ExecutionAccess,
+  capitalAccess: CapitalAccess,
+): ExecutionAuthority => ({
+  brokerEnvironment,
+  executionAccess,
+  capitalAccess,
+})
+
+export const CapitalAccessSchema = Schema.Union([
+  Schema.Struct({
+    _tag: Schema.Literal(CapitalAccessState.Disabled),
+  }),
+  Schema.Struct({
+    _tag: Schema.Literal(CapitalAccessState.Enabled),
+    policyIdentity: CapitalPolicyIdentitySchema,
+  }),
+])
+
+export const ExecutionAuthoritySchema = Schema.Struct({
+  brokerEnvironment: BrokerEnvironmentSchema,
+  executionAccess: ExecutionAccessSchema,
+  capitalAccess: CapitalAccessSchema,
+})
+
+const decodeExecutionAuthorityResult = Schema.decodeUnknownResult(ExecutionAuthoritySchema, StrictParseOptions)
+
+export const decodeExecutionAuthority = (input: unknown): Result.Result<ExecutionAuthority, Schema.SchemaError> =>
+  decodeExecutionAuthorityResult(input)
+
+/**
+ * Durable identifiers used by the existing paper-only schemas and PostgreSQL rows.
+ * Keep these exact values until a separate data migration changes the stored contracts.
+ */
+export enum LegacyBrokerMode {
+  Paper = 'PAPER',
+}
+
+export enum LegacyMaximumAuthority {
+  Observe = 'OBSERVE',
+  Paper = 'PAPER',
+}
+
+export interface LegacyPaperAuthorityMaterial {
+  readonly brokerMode: LegacyBrokerMode.Paper
+  readonly maximum: LegacyMaximumAuthority
+  readonly effective: LegacyMaximumAuthority
+  readonly riskPolicyHash?: CapitalPolicyIdentity
+}
+
+export const LegacyPaperAuthorityMaterialSchema = Schema.Struct({
+  brokerMode: Schema.Literal(LegacyBrokerMode.Paper),
+  maximum: Schema.Enum(LegacyMaximumAuthority),
+  effective: Schema.Enum(LegacyMaximumAuthority),
+  riskPolicyHash: Schema.optionalKey(CapitalPolicyIdentitySchema),
+})
+
+const decodeLegacyPaperAuthorityMaterialResult = Schema.decodeUnknownResult(
+  LegacyPaperAuthorityMaterialSchema,
+  StrictParseOptions,
+)
+
+export type LegacyPaperAuthorityDecodeFailure =
+  | {
+      readonly _tag: 'InvalidLegacyPaperAuthorityMaterial'
+      readonly cause: Schema.SchemaError
+    }
+  | {
+      readonly _tag: 'MissingLegacyRiskPolicyHash'
+      readonly maximum: LegacyMaximumAuthority.Paper
+    }
+  | {
+      readonly _tag: 'UnexpectedLegacyRiskPolicyHash'
+      readonly maximum: LegacyMaximumAuthority.Observe
+      readonly riskPolicyHash: CapitalPolicyIdentity
+    }
+  | {
+      readonly _tag: 'LegacyEffectiveAuthorityExceedsMaximum'
+      readonly maximum: LegacyMaximumAuthority.Observe
+      readonly effective: LegacyMaximumAuthority.Paper
+    }
+
+export const decodeLegacyPaperAuthority = (
+  input: unknown,
+): Result.Result<ExecutionAuthority, LegacyPaperAuthorityDecodeFailure> => {
+  const decoded = decodeLegacyPaperAuthorityMaterialResult(input)
+  if (Result.isFailure(decoded)) {
+    return Result.fail({
+      _tag: 'InvalidLegacyPaperAuthorityMaterial',
+      cause: decoded.failure,
+    })
+  }
+
+  const material: LegacyPaperAuthorityMaterial = decoded.success
+  if (material.maximum === LegacyMaximumAuthority.Observe && material.effective === LegacyMaximumAuthority.Paper) {
+    return Result.fail({
+      _tag: 'LegacyEffectiveAuthorityExceedsMaximum',
+      maximum: LegacyMaximumAuthority.Observe,
+      effective: LegacyMaximumAuthority.Paper,
+    })
+  }
+
+  if (material.maximum === LegacyMaximumAuthority.Observe) {
+    if (material.riskPolicyHash !== undefined) {
+      return Result.fail({
+        _tag: 'UnexpectedLegacyRiskPolicyHash',
+        maximum: LegacyMaximumAuthority.Observe,
+        riskPolicyHash: material.riskPolicyHash,
+      })
+    }
+    return Result.succeed(
+      makeExecutionAuthority(BrokerEnvironment.Sandbox, ExecutionAccess.ReadOnly, disabledCapitalAccess),
+    )
+  }
+
+  if (material.riskPolicyHash === undefined) {
+    return Result.fail({
+      _tag: 'MissingLegacyRiskPolicyHash',
+      maximum: LegacyMaximumAuthority.Paper,
+    })
+  }
+  return Result.succeed(
+    makeExecutionAuthority(
+      BrokerEnvironment.Sandbox,
+      material.effective === LegacyMaximumAuthority.Paper ? ExecutionAccess.SubmitOrders : ExecutionAccess.ReadOnly,
+      enabledCapitalAccess(material.riskPolicyHash),
+    ),
+  )
+}
+
+export type LegacyPaperAuthorityEncodeFailure =
+  | {
+      readonly _tag: 'LegacyBrokerEnvironmentUnsupported'
+      readonly brokerEnvironment: BrokerEnvironment.Live
+    }
+  | {
+      readonly _tag: 'LegacyAuthorityCombinationUnsupported'
+      readonly executionAccess: ExecutionAccess
+      readonly capitalAccess: CapitalAccessState
+    }
+
+export const encodeLegacyPaperAuthority = (
+  authority: ExecutionAuthority,
+): Result.Result<LegacyPaperAuthorityMaterial, LegacyPaperAuthorityEncodeFailure> => {
+  if (authority.brokerEnvironment === BrokerEnvironment.Live) {
+    return Result.fail({
+      _tag: 'LegacyBrokerEnvironmentUnsupported',
+      brokerEnvironment: BrokerEnvironment.Live,
+    })
+  }
+
+  if (
+    authority.executionAccess === ExecutionAccess.ReadOnly &&
+    authority.capitalAccess._tag === CapitalAccessState.Disabled
+  ) {
+    return Result.succeed({
+      brokerMode: LegacyBrokerMode.Paper,
+      maximum: LegacyMaximumAuthority.Observe,
+      effective: LegacyMaximumAuthority.Observe,
+    })
+  }
+
+  if (authority.capitalAccess._tag === CapitalAccessState.Enabled) {
+    return Result.succeed({
+      brokerMode: LegacyBrokerMode.Paper,
+      maximum: LegacyMaximumAuthority.Paper,
+      effective:
+        authority.executionAccess === ExecutionAccess.SubmitOrders
+          ? LegacyMaximumAuthority.Paper
+          : LegacyMaximumAuthority.Observe,
+      riskPolicyHash: authority.capitalAccess.policyIdentity,
+    })
+  }
+
+  return Result.fail({
+    _tag: 'LegacyAuthorityCombinationUnsupported',
+    executionAccess: authority.executionAccess,
+    capitalAccess: authority.capitalAccess._tag,
+  })
+}


### PR DESCRIPTION
## Summary

- Add one interface-first execution authority module with independent broker environment, execution access, and capital access values.
- Bind enabled capital access to the existing SHA-256 risk-policy identity without making environment imply submission or capital permission.
- Add explicit legacy PAPER/OBSERVE adapters that preserve `PAPER`, `OBSERVE`, `maximum`, `effective`, and `riskPolicyHash` semantics, including effective OBSERVE containment under maximum PAPER.
- Keep the change source-only: no Paper caller migration, persistence mutation, schema rename, order action, capital enablement, deployment, or GitOps authority change.

## Related Issues

None

## Testing

- `bun test services/bayn/src/execution/authority.test.ts` — 5 passed, 0 failed, 23 assertions.
- `bun run --filter @proompteng/bayn test` — 764 passed, 121 skipped, 0 failed, 4,414 assertions across 885 tests / 65 files.
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint` — 0 warnings, 0 errors.
- `bun run --filter @proompteng/bayn lint:oxlint:type` — 0 warnings, 0 errors.
- `bun run --filter @proompteng/bayn build` — 623 modules, 4.48 MB bundle.

## Breaking Changes

None. Existing durable identifiers remain unchanged behind explicit compatibility adapters.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is handled above.
- [x] Documentation/release notes are not required for this internal foundational contract; broad Paper caller migration remains owned by later tasks.
