### PR TITLE
feat(bayn): verify broker connection preflight

### DIFF
--- a/services/bayn/src/app.test.ts
+++ b/services/bayn/src/app.test.ts
@@ -18,11 +18,12 @@ import {
   type AutonomousCycleStartupInput,
   type AutonomousObserveApplicationConfig,
 } from './app'
-import { AccountStatus, type BrokerReadShape } from './broker/alpaca'
+import { AccountStatus, BrokerProvider, alpacaSandboxBaseUrl, type BrokerReadShape } from './broker/alpaca'
 import { unusedAssetBySymbol, unusedMarketCalendar } from './broker/alpaca-test-support'
 import { makeStrategyProtocolHash } from './contracts'
 import { CycleObservability } from './db/cycle-observability'
 import { EvidenceStore } from './db/evidence-store'
+import { BrokerEnvironment } from './execution/authority'
 import type { BrokerProbe } from './health'
 import { Journal } from './ledger'
 import { MarketData } from './market-data'
@@ -90,11 +91,15 @@ const autonomousConfig = (runtime: typeof config): AutonomousObserveApplicationC
   cyclePollIntervalMs: 30_000,
   maximumAuthority: Authority.Observe,
   alpaca: {
-    accountId: brokerAccountId,
+    provider: BrokerProvider.Alpaca,
+    environment: BrokerEnvironment.Sandbox,
+    baseUrl: alpacaSandboxBaseUrl,
+    expectedAccountId: brokerAccountId,
     authorityGenerationHash: 'f'.repeat(64),
     key: Redacted.make('test-key'),
     secret: Redacted.make('test-secret'),
     proxyUrl: 'http://proxy.test:3128',
+    operationTimeoutMs: runtime.operationTimeoutMs,
     retryAttempts: 0,
     reconciliationIntervalMs: 30_000,
   },

--- a/services/bayn/src/broker/alpaca-mutations/interpreter.ts
+++ b/services/bayn/src/broker/alpaca-mutations/interpreter.ts
@@ -2,9 +2,10 @@ import { Cause, Effect, Schema } from 'effect'
 import { Headers, HttpClient, HttpClientRequest, HttpClientResponse } from 'effect/unstable/http'
 
 import type { Intent } from '../../paper'
+import { BrokerEnvironment } from '../../execution/authority'
 import { StrictNonEmptyStringSchema as NonEmptyString } from '../../schemas'
 import { currentUtcInstant } from '../../time'
-import { make as makeRead, paperTradingUrl } from '../alpaca'
+import { BrokerProvider, alpacaSandboxBaseUrl, decodeBrokerConnection, make as makeRead } from '../alpaca'
 import {
   classifyCancelResponse,
   classifySubmitResponse,
@@ -125,16 +126,20 @@ export const makeMutation = (
   Effect.gen(function* () {
     const runtime = yield* Effect.fromResult(resolveMutationOptions(options))
     const client = yield* HttpClient.HttpClient
-    const read = yield* makeRead({
-      expectedAccountId: runtime.expectedAccountId,
-      key: options.key,
-      secret: options.secret,
-      proxyUrl: runtime.proxyUrl,
-      operationTimeoutMs: runtime.operationTimeoutMs,
-      retryAttempts: 0,
-    }).pipe(
-      Effect.mapError((cause) => configurationError('Alpaca mutation account verification could not start', cause)),
-    )
+    const connection = yield* Effect.fromResult(
+      decodeBrokerConnection({
+        provider: BrokerProvider.Alpaca,
+        environment: BrokerEnvironment.Sandbox,
+        baseUrl: alpacaSandboxBaseUrl,
+        expectedAccountId: runtime.expectedAccountId,
+        key: options.key,
+        secret: options.secret,
+        proxyUrl: runtime.proxyUrl,
+        operationTimeoutMs: runtime.operationTimeoutMs,
+        retryAttempts: 0,
+      }),
+    ).pipe(Effect.mapError((cause) => configurationError('Alpaca mutation broker connection is invalid', cause)))
+    const read = yield* makeRead(connection)
     yield* read.account.pipe(
       Effect.mapError((cause) => configurationError('Alpaca mutation account verification failed', cause)),
     )
@@ -145,7 +150,7 @@ export const makeMutation = (
       function* (input: Intent) {
         const prepared = yield* Effect.fromResult(prepareSubmit(input, runtime.expectedAccountId))
         const request = yield* HttpClientRequest.bodyJson(
-          HttpClientRequest.post(new URL('/v2/orders', paperTradingUrl), {
+          HttpClientRequest.post(new URL('/v2/orders', alpacaSandboxBaseUrl), {
             acceptJson: true,
             headers: credentials(runtime.key, runtime.secret),
           }),
@@ -185,7 +190,7 @@ export const makeMutation = (
       function* (input: string) {
         const prepared = yield* Effect.fromResult(prepareCancel(input))
         const request = HttpClientRequest.delete(
-          new URL(`/v2/orders/${encodeURIComponent(prepared.brokerOrderId)}`, paperTradingUrl),
+          new URL(`/v2/orders/${encodeURIComponent(prepared.brokerOrderId)}`, alpacaSandboxBaseUrl),
           { headers: credentials(runtime.key, runtime.secret) },
         )
         return yield* withDeadline(

--- a/services/bayn/src/broker/alpaca.test.ts
+++ b/services/bayn/src/broker/alpaca.test.ts
@@ -6,6 +6,7 @@ import { TestClock } from 'effect/testing'
 import { HttpClient, HttpClientError, HttpClientResponse } from 'effect/unstable/http'
 
 import { canonicalHashV1 } from '../hash'
+import { BrokerEnvironment } from '../execution/authority'
 import {
   AccountStatus,
   AssetClass,
@@ -14,6 +15,11 @@ import {
   BrokerRead,
   BrokerReadError,
   BrokerReadErrorKind,
+  BrokerAccountPreflightError,
+  BrokerProvider,
+  BrokerSession,
+  BrokerSessionAcquisitionError,
+  BrokerSessionAcquisitionStage,
   OrderCollection,
   OrderSide,
   OrderStatus,
@@ -21,13 +27,15 @@ import {
   PositionSide,
   SortDirection,
   TradeActivityType,
+  alpacaSandboxBaseUrl,
+  decodeBrokerConnection,
   layer,
   make,
   makeProxyDispatcher,
   readPreflightTimeoutMs,
   verifyReadAccess,
   type BrokerReadShape,
-  type ReadOptions,
+  type BrokerConnection,
 } from './alpaca'
 import { parseProxyUrl } from './alpaca/http'
 import { decodeOrder } from './alpaca/model'
@@ -39,14 +47,19 @@ const assetId = 'b0b6dd9d-8b9b-48a9-ba46-b9d54906e415'
 const orderId = '61e69015-8549-4bfd-b9c3-01e75843f47d'
 const clientOrderId = 'bayn-test-order-1'
 
-const options: ReadOptions = {
-  expectedAccountId: accountId,
-  key: Redacted.make('paper-key'),
-  secret: Redacted.make('paper-secret'),
-  proxyUrl: 'http://bayn-egress-proxy:3128',
-  operationTimeoutMs: 1_000,
-  retryAttempts: 2,
-}
+const options = Result.getOrThrow(
+  decodeBrokerConnection({
+    provider: BrokerProvider.Alpaca,
+    environment: BrokerEnvironment.Sandbox,
+    baseUrl: alpacaSandboxBaseUrl,
+    expectedAccountId: accountId,
+    key: Redacted.make('paper-key'),
+    secret: Redacted.make('paper-secret'),
+    proxyUrl: 'http://bayn-egress-proxy:3128',
+    operationTimeoutMs: 1_000,
+    retryAttempts: 2,
+  }),
+)
 
 const accountResponse = {
   id: accountId,
@@ -171,9 +184,11 @@ const jsonResponse = (
 const withClient = <A, E>(
   client: HttpClient.HttpClient,
   use: (read: BrokerReadShape) => Effect.Effect<A, E>,
-  readOptions: ReadOptions = options,
+  readOptions: BrokerConnection = options,
 ): Effect.Effect<A, BrokerReadError | E> =>
   make(readOptions).pipe(Effect.flatMap(use), Effect.provideService(HttpClient.HttpClient, client))
+
+const verifyConnectionReadAccess = (read: BrokerReadShape) => verifyReadAccess(options, read)
 
 describe('Alpaca paper reads', () => {
   test('reads and runtime-decodes the configured paper account without leaking credentials', async () => {
@@ -654,6 +669,9 @@ describe('Alpaca paper reads', () => {
     const client = HttpClient.make((request, url) => {
       requests.push({ method: request.method, url })
       if (url.pathname === '/v2/account') return Effect.succeed(jsonResponse(request, accountResponse))
+      if (url.pathname === '/v2/account/configurations') {
+        return Effect.succeed(jsonResponse(request, accountConfigurationResponse))
+      }
       if (url.pathname === '/v2/positions') return Effect.succeed(jsonResponse(request, []))
       if (
         url.pathname === '/v2/orders' ||
@@ -665,10 +683,20 @@ describe('Alpaca paper reads', () => {
       return Effect.succeed(jsonResponse(request, { code: 40410000, message: 'order not found' }, 404))
     })
 
-    const proof = await Effect.runPromise(withClient(client, verifyReadAccess).pipe(Effect.provide(TestClock.layer())))
+    const proof = await Effect.runPromise(
+      withClient(client, verifyConnectionReadAccess).pipe(Effect.provide(TestClock.layer())),
+    )
 
     expect(proof).toMatchObject({
+      provider: BrokerProvider.Alpaca,
+      environment: BrokerEnvironment.Sandbox,
+      baseUrl: alpacaSandboxBaseUrl,
       accountId,
+      accountStatus: AccountStatus.Active,
+      accountBlocked: false,
+      tradingBlocked: false,
+      tradeSuspendedByUser: false,
+      fractionalTrading: true,
       positionCount: 0,
       openOrderCount: 0,
       recentOrderCount: 0,
@@ -678,11 +706,12 @@ describe('Alpaca paper reads', () => {
       orderByClientId: 'NOT_FOUND',
     })
     expect(proof.accountHash).toMatch(/^[a-f0-9]{64}$/)
+    expect(proof.accountConfigurationHash).toMatch(/^[a-f0-9]{64}$/)
     expect(proof.positionsHash).toMatch(/^[a-f0-9]{64}$/)
     expect(proof.ordersHash).toMatch(/^[a-f0-9]{64}$/)
     expect(proof.fillsHash).toMatch(/^[a-f0-9]{64}$/)
     expect(proof.marketCalendarHash).toMatch(/^[a-f0-9]{64}$/)
-    expect(requests).toHaveLength(8)
+    expect(requests).toHaveLength(9)
     expect(requests.every(({ method }) => method === 'GET')).toBe(true)
     expect(
       requests
@@ -702,6 +731,9 @@ describe('Alpaca paper reads', () => {
   test('preflights ordinary non-empty orders whose optional Alpaca fields are null', async () => {
     const client = HttpClient.make((request, url) => {
       if (url.pathname === '/v2/account') return Effect.succeed(jsonResponse(request, accountResponse))
+      if (url.pathname === '/v2/account/configurations') {
+        return Effect.succeed(jsonResponse(request, accountConfigurationResponse))
+      }
       if (
         url.pathname === '/v2/positions' ||
         url.pathname === '/v2/account/activities/FILL' ||
@@ -712,7 +744,7 @@ describe('Alpaca paper reads', () => {
       return Effect.succeed(jsonResponse(request, url.pathname === '/v2/orders' ? [orderResponse] : orderResponse))
     })
 
-    const proof = await Effect.runPromise(withClient(client, verifyReadAccess))
+    const proof = await Effect.runPromise(withClient(client, verifyConnectionReadAccess))
 
     expect(proof).toMatchObject({
       accountId,
@@ -727,19 +759,83 @@ describe('Alpaca paper reads', () => {
   test('fails the complete startup preflight when the market calendar payload is invalid', async () => {
     const client = HttpClient.make((request, url) => {
       if (url.pathname === '/v2/account') return Effect.succeed(jsonResponse(request, accountResponse))
+      if (url.pathname === '/v2/account/configurations') {
+        return Effect.succeed(jsonResponse(request, accountConfigurationResponse))
+      }
       if (url.pathname === '/v2/calendar') {
         return Effect.succeed(jsonResponse(request, [{ date: '2026-07-23', open: '9:30', close: '16:00' }]))
       }
       return Effect.succeed(jsonResponse(request, []))
     })
 
-    const failure = await Effect.runPromise(Effect.flip(withClient(client, verifyReadAccess)))
+    const failure = await Effect.runPromise(Effect.flip(withClient(client, verifyConnectionReadAccess)))
 
     expect(failure).toMatchObject({
       operation: 'market-calendar',
       kind: BrokerReadErrorKind.InvalidResponse,
       retryable: false,
     })
+  })
+
+  test('fails closed on every account permission gate before reading positions, orders, fills, or calendar', async () => {
+    const cases = [
+      {
+        name: 'inactive account',
+        account: { ...accountResponse, status: AccountStatus.Inactive },
+        configuration: accountConfigurationResponse,
+        failure: { _tag: 'BrokerAccountNotActive', status: AccountStatus.Inactive },
+      },
+      {
+        name: 'blocked account',
+        account: { ...accountResponse, account_blocked: true },
+        configuration: accountConfigurationResponse,
+        failure: { _tag: 'BrokerAccountBlocked' },
+      },
+      {
+        name: 'trading blocked',
+        account: { ...accountResponse, trading_blocked: true },
+        configuration: accountConfigurationResponse,
+        failure: { _tag: 'BrokerTradingBlocked' },
+      },
+      {
+        name: 'trading suspended by user',
+        account: { ...accountResponse, trade_suspended_by_user: true },
+        configuration: accountConfigurationResponse,
+        failure: { _tag: 'BrokerTradingSuspendedByUser' },
+      },
+      {
+        name: 'fractional trading disabled',
+        account: accountResponse,
+        configuration: { ...accountConfigurationResponse, fractional_trading: false },
+        failure: { _tag: 'BrokerFractionalTradingDisabled' },
+      },
+    ] as const
+
+    for (const invalid of cases) {
+      const paths: string[] = []
+      const client = HttpClient.make((request, url) => {
+        paths.push(url.pathname)
+        if (url.pathname === '/v2/account') return Effect.succeed(jsonResponse(request, invalid.account))
+        if (url.pathname === '/v2/account/configurations') {
+          return Effect.succeed(jsonResponse(request, invalid.configuration))
+        }
+        return Effect.die(new Error(`unexpected preflight request to ${url.pathname}`))
+      })
+
+      const failure = await Effect.runPromise(
+        Effect.flip(withClient(client, verifyConnectionReadAccess)).pipe(Effect.provide(TestClock.layer())),
+      )
+
+      expect(failure, invalid.name).toBeInstanceOf(BrokerAccountPreflightError)
+      expect(failure, invalid.name).toMatchObject({
+        provider: BrokerProvider.Alpaca,
+        environment: BrokerEnvironment.Sandbox,
+        baseUrl: alpacaSandboxBaseUrl,
+        expectedAccountId: accountId,
+        failure: invalid.failure,
+      })
+      expect(paths, invalid.name).toEqual(['/v2/account', '/v2/account/configurations'])
+    }
   })
 
   test('bounds the complete startup preflight below the Kubernetes startup-probe budget', async () => {
@@ -759,7 +855,7 @@ describe('Alpaca paper reads', () => {
       client,
       (read) =>
         Effect.gen(function* () {
-          const fiber = yield* Effect.flip(verifyReadAccess(read)).pipe(Effect.forkChild)
+          const fiber = yield* Effect.flip(verifyReadAccess(options, read)).pipe(Effect.forkChild)
           yield* Effect.yieldNow
           yield* TestClock.adjust(readPreflightTimeoutMs)
           return yield* Fiber.join(fiber)
@@ -1382,26 +1478,46 @@ describe('Alpaca paper reads', () => {
     expect(JSON.stringify(failure.cause)).not.toContain('paper-secret')
   })
 
-  test('retains the failing configuration path without invoking Alpaca', async () => {
-    let calls = 0
-    const client = HttpClient.make((request) => {
-      calls += 1
-      return Effect.succeed(jsonResponse(request, accountResponse))
+  test('acquires one verified session and publishes its exact read capability once', async () => {
+    const paths: string[] = []
+    const client = HttpClient.make((request, url) => {
+      paths.push(url.pathname)
+      if (url.pathname === '/v2/account') return Effect.succeed(jsonResponse(request, accountResponse))
+      if (url.pathname === '/v2/account/configurations') {
+        return Effect.succeed(jsonResponse(request, accountConfigurationResponse))
+      }
+      if (
+        url.pathname === '/v2/positions' ||
+        url.pathname === '/v2/orders' ||
+        url.pathname === '/v2/account/activities/FILL' ||
+        url.pathname === '/v2/calendar'
+      ) {
+        return Effect.succeed(jsonResponse(request, []))
+      }
+      return Effect.succeed(jsonResponse(request, { code: 40410000, message: 'order not found' }, 404))
     })
+    const testLayer = layer(options).pipe(Layer.provide(Layer.succeed(HttpClient.HttpClient, client)))
 
-    const failure = await Effect.runPromise(
-      Effect.flip(withClient(client, (read) => read.account, { ...options, operationTimeoutMs: 0 })),
+    const services = await Effect.runPromise(
+      Effect.all({ session: BrokerSession, read: BrokerRead }).pipe(
+        Effect.provide(testLayer),
+        Effect.provide(TestClock.layer()),
+      ),
     )
 
-    expect(failure).toMatchObject({
-      kind: BrokerReadErrorKind.Configuration,
-      operation: 'configuration',
-      cause: {
-        tag: 'SchemaError',
-        message: expect.stringContaining('["operationTimeoutMs"]'),
-      },
+    expect(services.session.read).toBe(services.read)
+    expect(services.session.connection).toBe(options)
+    expect(services.session.preflight).toMatchObject({
+      provider: BrokerProvider.Alpaca,
+      environment: BrokerEnvironment.Sandbox,
+      baseUrl: alpacaSandboxBaseUrl,
+      accountId,
+      accountStatus: AccountStatus.Active,
+      fractionalTrading: true,
     })
-    expect(calls).toBe(0)
+    expect(paths).toHaveLength(9)
+    expect(paths.filter((path) => path === '/v2/account')).toHaveLength(1)
+    expect(paths.filter((path) => path === '/v2/account/configurations')).toHaveLength(1)
   })
 
   test('refuses to publish the live capability for the wrong paper account', async () => {
@@ -1417,14 +1533,22 @@ describe('Alpaca paper reads', () => {
         }).pipe(Effect.provide(testLayer)),
       ),
     )
+    expect(failure).toBeInstanceOf(BrokerSessionAcquisitionError)
     expect(failure).toMatchObject({
-      kind: BrokerReadErrorKind.AccountMismatch,
-      operation: 'account',
-      retryable: false,
-      requestId: 'req-123',
+      stage: BrokerSessionAcquisitionStage.Account,
+      provider: BrokerProvider.Alpaca,
+      environment: BrokerEnvironment.Sandbox,
+      baseUrl: alpacaSandboxBaseUrl,
+      expectedAccountId: accountId,
+      cause: {
+        kind: BrokerReadErrorKind.AccountMismatch,
+        operation: 'account',
+        retryable: false,
+        requestId: 'req-123',
+      },
     })
-    expect(failure.message).toContain(wrongAccount)
-    expect(failure.message).toContain(accountId)
+    expect(failure.cause.message).toContain(wrongAccount)
+    expect(failure.cause.message).toContain(accountId)
   })
 })
 

--- a/services/bayn/src/broker/alpaca.ts
+++ b/services/bayn/src/broker/alpaca.ts
@@ -1,10 +1,19 @@
-import { Effect, Layer, Result } from 'effect'
-import { HttpClient } from 'effect/unstable/http'
+import { Result } from 'effect'
 
-import { alpacaHttpLayer, make } from './alpaca/http'
-import { BrokerRead, OrderResponseSchema, type Order, type ReadOptions } from './alpaca/model'
+import { OrderResponseSchema, type Order } from './alpaca/model'
 import { normalizeOrderResult } from './alpaca/normalizers'
-import { verifyReadAccess } from './alpaca/preflight'
+
+export {
+  BrokerProvider,
+  alpacaLiveBaseUrl,
+  alpacaSandboxBaseUrl,
+  decodeBrokerConnection,
+  decodeBrokerProxyUrl,
+  renderBrokerConnectionDecodeFailure,
+  type BrokerConnection,
+  type BrokerConnectionDecodeFailure,
+  type BrokerConnectionInput,
+} from './connection'
 
 export {
   BrokerReadContractFailure,
@@ -37,7 +46,6 @@ export {
   SortDirection,
   TimeInForce,
   TradeActivityType,
-  paperTradingUrl,
   readPreflightTimeoutMs,
   type Account,
   type AccountConfigurationObservation,
@@ -55,26 +63,27 @@ export {
   type Position,
   type RateLimitEvidence,
   type ReadEvidence,
-  type ReadOptions,
   type ReadPreflight,
   type ReadResult,
 } from './alpaca/model'
 export { alpacaHttpLayer, make, makeProxyDispatcher } from './alpaca/http'
-export { verifyReadAccess } from './alpaca/preflight'
+export {
+  BrokerAccountPreflightError,
+  verifyBrokerAccountPermissions,
+  verifyReadAccess,
+  type BrokerAccountPreflightFailure,
+  type VerifiedBrokerAccountPermissions,
+} from './alpaca/preflight'
+export {
+  BrokerSession,
+  BrokerSessionAcquisitionError,
+  BrokerSessionAcquisitionStage,
+  acquireBrokerSession,
+  layer,
+  live,
+  type BrokerSessionShape,
+} from './alpaca/session'
 
 /** @deprecated Mutation compatibility adapter. Read-side normalization uses `normalizeOrderResult`. */
 export const normalizeOrder = (raw: typeof OrderResponseSchema.Type, accountId: string, observedAt: string): Order =>
   Result.getOrThrow(normalizeOrderResult(raw, accountId, observedAt))
-
-export const layer = (
-  options: ReadOptions,
-): Layer.Layer<BrokerRead, import('./alpaca/failures').BrokerReadError, HttpClient.HttpClient> =>
-  Layer.effect(BrokerRead, make(options).pipe(Effect.tap(verifyReadAccess)))
-
-export const scopedReadAdapterLayer = (
-  options: ReadOptions,
-): Layer.Layer<BrokerRead, import('./alpaca/failures').BrokerReadError> =>
-  Layer.effect(BrokerRead, make(options)).pipe(Layer.provide(alpacaHttpLayer(options.proxyUrl)))
-
-export const live = (options: ReadOptions): Layer.Layer<BrokerRead, import('./alpaca/failures').BrokerReadError> =>
-  layer(options).pipe(Layer.provide(alpacaHttpLayer(options.proxyUrl)))

--- a/services/bayn/src/broker/alpaca/http.ts
+++ b/services/bayn/src/broker/alpaca/http.ts
@@ -4,6 +4,7 @@ import { Headers, HttpClient, HttpClientRequest, HttpClientResponse } from 'effe
 
 import { canonicalHashV1Result, renderCanonicalJsonFailure } from '../../hash'
 import { currentUtcInstant } from '../../time'
+import { decodeBrokerProxyUrl, type BrokerConnection } from '../connection'
 import {
   BrokerReadContractFailure,
   BrokerReadError,
@@ -34,7 +35,6 @@ import {
   decodeOrders,
   decodeOrdersQuery,
   decodePositions,
-  decodeRuntimeOptions,
   redactedHeaders,
   responseParseOptions,
   type BrokerReadShape,
@@ -44,7 +44,6 @@ import {
   type OrdersQuery,
   type ProxyDispatcherDependencies,
   type ReadEvidence,
-  type ReadOptions,
   type ReadResult,
 } from './model'
 import {
@@ -114,49 +113,49 @@ export const makeProxyDispatcher = (
 
 export const parseProxyUrl = (proxyUrl: string): Result.Result<URL, BrokerReadError> =>
   pipe(
-    Result.try({
-      try: () => new URL(proxyUrl),
-      catch: (cause) => configurationError('proxy', 'invalid Alpaca proxy configuration', cause),
-    }),
-    Result.flatMap((url) => {
-      if (url.protocol !== 'http:' && url.protocol !== 'https:') {
-        return Result.fail(configurationError('proxy', 'Alpaca proxy URL must use HTTP or HTTPS'))
-      }
-      if (url.username !== '' || url.password !== '') {
-        return Result.fail(configurationError('proxy', 'Alpaca proxy credentials must not be embedded in the URL'))
-      }
-      if (url.pathname !== '/' || url.search !== '' || url.hash !== '') {
-        return Result.fail(configurationError('proxy', 'Alpaca proxy URL must contain only an origin'))
-      }
-      return Result.succeed(url)
+    decodeBrokerProxyUrl(proxyUrl),
+    Result.map((origin) => new URL(origin)),
+    Result.mapError((cause) => {
+      const message =
+        cause.reason === 'INVALID_URL'
+          ? 'invalid Alpaca proxy configuration'
+          : cause.reason === 'HTTP_OR_HTTPS_REQUIRED'
+            ? 'Alpaca proxy URL must use HTTP or HTTPS'
+            : cause.reason === 'CREDENTIALS_FORBIDDEN'
+              ? 'Alpaca proxy credentials must not be embedded in the URL'
+              : 'Alpaca proxy URL must contain only an origin'
+      return configurationError('proxy', message, cause)
     }),
   )
 
-const proxyLayer = (proxyUrl: string): Layer.Layer<NodeHttpClient.Dispatcher, BrokerReadError> =>
-  Layer.effect(NodeHttpClient.Dispatcher, makeProxyDispatcher(proxyUrl))
+const makeVerifiedProxyDispatcher = (
+  proxyUrl: string,
+  dependencies: ProxyDispatcherDependencies = {
+    create: (url) => new Undici.ProxyAgent({ uri: url.toString() }),
+    destroy: (dispatcher) => dispatcher.destroy(),
+  },
+): Effect.Effect<Undici.Dispatcher, BrokerReadError, Scope.Scope> =>
+  Effect.acquireRelease(
+    Effect.try({
+      try: () => dependencies.create(new URL(proxyUrl)),
+      catch: (cause) => configurationError('proxy', 'Alpaca proxy dispatcher acquisition failed', cause),
+    }),
+    (dispatcher) => Effect.promise(() => dependencies.destroy(dispatcher)),
+  )
 
-export const alpacaHttpLayer = (proxyUrl: string): Layer.Layer<HttpClient.HttpClient, BrokerReadError> =>
-  NodeHttpClient.layerUndiciNoDispatcher.pipe(Layer.provide(proxyLayer(proxyUrl)))
+const proxyLayer = (connection: BrokerConnection): Layer.Layer<NodeHttpClient.Dispatcher, BrokerReadError> =>
+  Layer.effect(NodeHttpClient.Dispatcher, makeVerifiedProxyDispatcher(connection.proxyUrl))
 
-export const make = (options: ReadOptions): Effect.Effect<BrokerReadShape, BrokerReadError, HttpClient.HttpClient> =>
+export const alpacaHttpLayer = (connection: BrokerConnection): Layer.Layer<HttpClient.HttpClient, BrokerReadError> =>
+  NodeHttpClient.layerUndiciNoDispatcher.pipe(Layer.provide(proxyLayer(connection)))
+
+export const make = (connection: BrokerConnection): Effect.Effect<BrokerReadShape, never, HttpClient.HttpClient> =>
   Effect.gen(function* () {
-    const runtime = yield* Effect.fromResult(
-      decodeRuntimeOptions({
-        expectedAccountId: options.expectedAccountId,
-        operationTimeoutMs: options.operationTimeoutMs,
-        retryAttempts: options.retryAttempts,
-      }),
-    ).pipe(Effect.mapError((cause) => configurationError('configuration', 'invalid Alpaca read options', cause)))
-    const key = Redacted.value(options.key)
-    const secret = Redacted.value(options.secret)
-    if (key.length === 0 || key.trim() !== key || secret.length === 0 || secret.trim() !== secret) {
-      return yield* Effect.fail(
-        configurationError('configuration', 'Alpaca credentials must be non-empty without surrounding whitespace'),
-      )
-    }
+    const key = Redacted.value(connection.key)
+    const secret = Redacted.value(connection.secret)
     const sensitiveValues = [key, secret]
     const baseClient = yield* HttpClient.HttpClient
-    const client = baseClient.pipe(HttpClient.retryTransient({ times: runtime.retryAttempts }))
+    const client = baseClient.pipe(HttpClient.retryTransient({ times: connection.retryAttempts }))
 
     const readJson = <A>(
       operation: BrokerReadOperation,
@@ -258,27 +257,31 @@ export const make = (options: ReadOptions): Effect.Effect<BrokerReadShape, Broke
         })
         return { value, evidence }
       }).pipe(
-        Effect.timeout(`${runtime.operationTimeoutMs} millis`),
+        Effect.timeout(`${connection.operationTimeoutMs} millis`),
         Effect.mapError((cause) =>
           cause instanceof BrokerReadError
             ? cause
             : Cause.isTimeoutError(cause)
-              ? timeoutError(operation, runtime.operationTimeoutMs, cause, sensitiveValues)
+              ? timeoutError(operation, connection.operationTimeoutMs, cause, sensitiveValues)
               : transportError(operation, cause, sensitiveValues),
         ),
         Effect.provideService(Headers.CurrentRedactedNames, redactedHeaders),
         Effect.withSpan('broker.read', { attributes: { 'broker.system': 'alpaca', 'broker.operation': operation } }),
       )
 
-    const account = readJson('account', accountUrl(), decodeAccount).pipe(
+    const account = readJson('account', accountUrl(connection.baseUrl), decodeAccount).pipe(
       Effect.flatMap((result) => {
-        const normalized = normalizeAccountResult(result.value, runtime.expectedAccountId, result.evidence.observedAt)
+        const normalized = normalizeAccountResult(
+          result.value,
+          connection.expectedAccountId,
+          result.evidence.observedAt,
+        )
         if (Result.isFailure(normalized) && normalized.failure.reason === 'ACCOUNT_BINDING') {
           return Effect.fail(
             new BrokerReadError({
               operation: 'account',
               kind: BrokerReadErrorKind.AccountMismatch,
-              message: `Alpaca credential resolved account ${result.value.id}, expected ${runtime.expectedAccountId}`,
+              message: `Alpaca credential resolved account ${result.value.id}, expected ${connection.expectedAccountId}`,
               retryable: false,
               status: result.evidence.status,
               requestId: result.evidence.requestId,
@@ -294,7 +297,7 @@ export const make = (options: ReadOptions): Effect.Effect<BrokerReadShape, Broke
 
     const accountConfiguration = readJson(
       'account-configuration',
-      accountConfigurationUrl(),
+      accountConfigurationUrl(connection.baseUrl),
       decodeAccountConfiguration,
     ).pipe(
       Effect.flatMap((result) =>
@@ -306,12 +309,12 @@ export const make = (options: ReadOptions): Effect.Effect<BrokerReadShape, Broke
       ),
     )
 
-    const positions = readJson('positions', positionsUrl(), decodePositions).pipe(
+    const positions = readJson('positions', positionsUrl(connection.baseUrl), decodePositions).pipe(
       Effect.flatMap((result) =>
         normalizeRead(
           'positions',
           result.evidence,
-          normalizePositionsResult(result.value, runtime.expectedAccountId, result.evidence.observedAt),
+          normalizePositionsResult(result.value, connection.expectedAccountId, result.evidence.observedAt),
         ),
       ),
     )
@@ -319,7 +322,7 @@ export const make = (options: ReadOptions): Effect.Effect<BrokerReadShape, Broke
     const assetBySymbol = (symbol: string) =>
       decodeInput('asset-by-symbol', decodeAssetSymbol, symbol, 'invalid Alpaca asset symbol').pipe(
         Effect.flatMap((decoded) =>
-          readJson('asset-by-symbol', assetBySymbolUrl(decoded), decodeAsset).pipe(
+          readJson('asset-by-symbol', assetBySymbolUrl(connection.baseUrl, decoded), decodeAsset).pipe(
             Effect.map((result) => ({ decoded, result })),
           ),
         ),
@@ -335,7 +338,7 @@ export const make = (options: ReadOptions): Effect.Effect<BrokerReadShape, Broke
     const marketCalendar = (query: MarketCalendarQuery) =>
       decodeInput('market-calendar', decodeMarketCalendarQuery, query, 'invalid Alpaca market calendar query').pipe(
         Effect.flatMap((decoded) =>
-          readJson('market-calendar', marketCalendarUrl(decoded), decodeMarketCalendar).pipe(
+          readJson('market-calendar', marketCalendarUrl(connection.baseUrl, decoded), decodeMarketCalendar).pipe(
             Effect.map((result) => ({ decoded, result })),
           ),
         ),
@@ -346,24 +349,24 @@ export const make = (options: ReadOptions): Effect.Effect<BrokerReadShape, Broke
 
     const orders = (query: OrdersQuery = {}) =>
       decodeInput('orders', decodeOrdersQuery, query, 'invalid Alpaca orders query').pipe(
-        Effect.flatMap((decoded) => readJson('orders', ordersUrl(decoded), decodeOrders)),
+        Effect.flatMap((decoded) => readJson('orders', ordersUrl(connection.baseUrl, decoded), decodeOrders)),
         Effect.flatMap((result) =>
           normalizeRead(
             'orders',
             result.evidence,
-            normalizeOrdersResult(result.value, runtime.expectedAccountId, result.evidence.observedAt),
+            normalizeOrdersResult(result.value, connection.expectedAccountId, result.evidence.observedAt),
           ),
         ),
       )
 
     const orderById = (orderId: string) =>
       decodeInput('order-by-id', decodeOrderId, orderId, 'invalid Alpaca order ID').pipe(
-        Effect.flatMap((decoded) => readJson('order-by-id', orderByIdUrl(decoded), decodeOrder)),
+        Effect.flatMap((decoded) => readJson('order-by-id', orderByIdUrl(connection.baseUrl, decoded), decodeOrder)),
         Effect.flatMap((result) =>
           normalizeRead(
             'order-by-id',
             result.evidence,
-            normalizeOrderResult(result.value, runtime.expectedAccountId, result.evidence.observedAt),
+            normalizeOrderResult(result.value, connection.expectedAccountId, result.evidence.observedAt),
           ),
         ),
       )
@@ -375,12 +378,14 @@ export const make = (options: ReadOptions): Effect.Effect<BrokerReadShape, Broke
         clientOrderId,
         'invalid Alpaca client order ID',
       ).pipe(
-        Effect.flatMap((decoded) => readJson('order-by-client-id', orderByClientIdUrl(decoded), decodeOrder)),
+        Effect.flatMap((decoded) =>
+          readJson('order-by-client-id', orderByClientIdUrl(connection.baseUrl, decoded), decodeOrder),
+        ),
         Effect.flatMap((result) =>
           normalizeRead(
             'order-by-client-id',
             result.evidence,
-            normalizeOrderResult(result.value, runtime.expectedAccountId, result.evidence.observedAt),
+            normalizeOrderResult(result.value, connection.expectedAccountId, result.evidence.observedAt),
           ),
         ),
       )
@@ -388,13 +393,13 @@ export const make = (options: ReadOptions): Effect.Effect<BrokerReadShape, Broke
     const fillActivities = (query: FillActivitiesQuery = {}) =>
       decodeInput('fill-activities', decodeFillActivitiesQuery, query, 'invalid Alpaca fill activities query').pipe(
         Effect.flatMap((decoded) => {
-          const request = fillActivitiesRequest(decoded)
+          const request = fillActivitiesRequest(connection.baseUrl, decoded)
           return readJson('fill-activities', request.url, decodeFillActivities).pipe(
             Effect.map((result) => ({ result, pageSize: request.pageSize })),
           )
         }),
         Effect.flatMap(({ pageSize, result }) =>
-          Effect.fromResult(normalizeFillActivitiesResult(result.value, runtime.expectedAccountId)).pipe(
+          Effect.fromResult(normalizeFillActivitiesResult(result.value, connection.expectedAccountId)).pipe(
             Effect.map((items) => ({
               value: {
                 items,

--- a/services/bayn/src/broker/alpaca/model.ts
+++ b/services/bayn/src/broker/alpaca/model.ts
@@ -1,14 +1,15 @@
 import type { Undici } from '@effect/platform-node'
-import { Context, Effect, Redacted, Schema, type Result } from 'effect'
+import { Context, Effect, Schema, type Result } from 'effect'
 
+import type { BrokerEnvironment } from '../../execution/authority'
 import {
   IsoDateSchema as IsoDate,
   StrictNonEmptyStringSchema as NonEmptyString,
   SymbolSchema as SymbolName,
 } from '../../schemas'
+import type { BrokerProvider } from '../connection'
 import { BrokerReadError } from './failures'
 
-export const paperTradingUrl = 'https://paper-api.alpaca.markets'
 export const defaultFillActivitiesPageSize = 100
 const maxMarketCalendarRangeDays = 31
 export const marketCalendarPreflightRangeDays = 14
@@ -40,7 +41,6 @@ const Uuid = Schema.String.check(
   Schema.isPattern(/^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/),
 )
 const Decimal = Schema.String.check(Schema.isPattern(/^(?:0|[1-9][0-9]*)(?:\.[0-9]+)?$|^-[1-9][0-9]*(?:\.[0-9]+)?$/))
-const PositiveInteger = Schema.Int.check(Schema.isGreaterThan(0))
 const isUtcTimestamp = (value: string): boolean => {
   const match = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d{1,9}))?Z$/.exec(value)
   if (match === null) return false
@@ -195,15 +195,6 @@ export enum SortDirection {
 export enum TradeActivityType {
   Fill = 'fill',
   PartialFill = 'partial_fill',
-}
-
-export interface ReadOptions {
-  readonly expectedAccountId: string
-  readonly key: Redacted.Redacted<string>
-  readonly secret: Redacted.Redacted<string>
-  readonly proxyUrl: string
-  readonly operationTimeoutMs: number
-  readonly retryAttempts: number
 }
 
 export interface ProxyDispatcherDependencies {
@@ -399,8 +390,17 @@ export interface BrokerReadShape {
 export class BrokerRead extends Context.Service<BrokerRead, BrokerReadShape>()('bayn/BrokerRead') {}
 
 export interface ReadPreflight {
+  readonly provider: BrokerProvider
+  readonly environment: BrokerEnvironment
+  readonly baseUrl: string
   readonly accountId: string
+  readonly accountStatus: AccountStatus.Active
+  readonly accountBlocked: false
+  readonly tradingBlocked: false
+  readonly tradeSuspendedByUser: false
   readonly accountHash: string
+  readonly fractionalTrading: true
+  readonly accountConfigurationHash: string
   readonly positionCount: number
   readonly positionsHash: string
   readonly openOrderCount: number
@@ -587,12 +587,6 @@ const MarketCalendarQuerySchema = MarketCalendarQueryBase.check(
   }),
 )
 
-const RuntimeOptionsSchema = Schema.Struct({
-  expectedAccountId: Uuid,
-  operationTimeoutMs: PositiveInteger,
-  retryAttempts: Schema.Int.check(Schema.isBetween({ minimum: 0, maximum: 3 })),
-})
-
 export type Decoder<A> = (input: unknown) => Result.Result<A, Schema.SchemaError>
 
 export const decodeAccount = Schema.decodeUnknownResult(AccountResponseSchema, responseParseOptions)
@@ -616,4 +610,3 @@ export const decodeMarketCalendarQuery = Schema.decodeUnknownResult(MarketCalend
 export const decodeAssetSymbol = Schema.decodeUnknownResult(SymbolName)
 export const decodeOrderId = Schema.decodeUnknownResult(Uuid)
 export const decodeExternalClientOrderId = Schema.decodeUnknownResult(ExternalClientOrderId)
-export const decodeRuntimeOptions = Schema.decodeUnknownResult(RuntimeOptionsSchema, inputParseOptions)

--- a/services/bayn/src/broker/alpaca/preflight.ts
+++ b/services/bayn/src/broker/alpaca/preflight.ts
@@ -1,7 +1,8 @@
-import { Effect, Result } from 'effect'
+import { Data, Effect, Result } from 'effect'
 
 import { canonicalHashV1Result, renderCanonicalJsonFailure } from '../../hash'
 import { addUtcDays, currentUtcDate } from '../../time'
+import type { BrokerConnection } from '../connection'
 import {
   BrokerReadError,
   BrokerReadErrorKind,
@@ -11,10 +12,13 @@ import {
   type BrokerReadContractFailure,
 } from './failures'
 import {
+  AccountStatus,
   OrderCollection,
   SortDirection,
   marketCalendarPreflightRangeDays,
   readPreflightTimeoutMs,
+  type Account,
+  type AccountConfigurationObservation,
   type BrokerReadShape,
   type Order,
   type ReadPreflight,
@@ -23,6 +27,72 @@ import {
 
 const missingOrderId = '00000000-0000-4000-8000-000000000000'
 const missingClientOrderId = 'bayn-observe-read-proof-does-not-exist'
+
+export type BrokerAccountPreflightFailure =
+  | {
+      readonly _tag: 'BrokerAccountNotActive'
+      readonly status: AccountStatus
+    }
+  | {
+      readonly _tag: 'BrokerAccountBlocked'
+    }
+  | {
+      readonly _tag: 'BrokerTradingBlocked'
+    }
+  | {
+      readonly _tag: 'BrokerTradingSuspendedByUser'
+    }
+  | {
+      readonly _tag: 'BrokerFractionalTradingDisabled'
+    }
+
+export interface VerifiedBrokerAccountPermissions {
+  readonly accountStatus: AccountStatus.Active
+  readonly accountBlocked: false
+  readonly tradingBlocked: false
+  readonly tradeSuspendedByUser: false
+  readonly fractionalTrading: true
+}
+
+export class BrokerAccountPreflightError extends Data.TaggedError('BrokerAccountPreflightError')<{
+  readonly provider: BrokerConnection['provider']
+  readonly environment: BrokerConnection['environment']
+  readonly baseUrl: string
+  readonly expectedAccountId: string
+  readonly failure: BrokerAccountPreflightFailure
+}> {}
+
+export const verifyBrokerAccountPermissions = (
+  account: Account,
+  configuration: AccountConfigurationObservation,
+): Result.Result<VerifiedBrokerAccountPermissions, BrokerAccountPreflightFailure> => {
+  if (account.status !== AccountStatus.Active) {
+    return Result.fail({ _tag: 'BrokerAccountNotActive', status: account.status })
+  }
+  if (account.accountBlocked) return Result.fail({ _tag: 'BrokerAccountBlocked' })
+  if (account.tradingBlocked) return Result.fail({ _tag: 'BrokerTradingBlocked' })
+  if (account.tradeSuspendedByUser) return Result.fail({ _tag: 'BrokerTradingSuspendedByUser' })
+  if (!configuration.fractionalTrading) return Result.fail({ _tag: 'BrokerFractionalTradingDisabled' })
+  return Result.succeed({
+    accountStatus: AccountStatus.Active,
+    accountBlocked: false,
+    tradingBlocked: false,
+    tradeSuspendedByUser: false,
+    fractionalTrading: true,
+  })
+}
+
+const permissionFailure = (
+  connection: BrokerConnection,
+  failure: BrokerAccountPreflightFailure,
+): BrokerAccountPreflightError =>
+  new BrokerAccountPreflightError({
+    provider: connection.provider,
+    environment: connection.environment,
+    baseUrl: connection.baseUrl,
+    expectedAccountId: connection.expectedAccountId,
+    failure,
+  })
 
 const proofHashResult = (value: unknown, field: string): Result.Result<string, BrokerReadContractFailure> =>
   Result.mapError(canonicalHashV1Result(value), (failure) =>
@@ -72,9 +142,16 @@ const verifyOrderLookup = (
     ),
   )
 
-export const verifyReadAccess = (read: BrokerReadShape): Effect.Effect<ReadPreflight, BrokerReadError> =>
+export const verifyReadAccess = (
+  connection: BrokerConnection,
+  read: BrokerReadShape,
+): Effect.Effect<ReadPreflight, BrokerReadError | BrokerAccountPreflightError> =>
   Effect.gen(function* () {
     const account = yield* read.account
+    const accountConfiguration = yield* read.accountConfiguration
+    const permissions = yield* Effect.fromResult(
+      verifyBrokerAccountPermissions(account.value, accountConfiguration.value),
+    ).pipe(Effect.mapError((failure) => permissionFailure(connection, failure)))
     const calendarStart = yield* currentUtcDate
     const calendarEnd = addUtcDays(calendarStart, marketCalendarPreflightRangeDays - 1)
     const responses = yield* Effect.all(
@@ -105,6 +182,10 @@ export const verifyReadAccess = (read: BrokerReadShape): Effect.Effect<ReadPrefl
     const proof = yield* Effect.fromResult(
       Result.gen(function* (): Generator<Result.Result<unknown, BrokerReadContractFailure>, ReadPreflight, never> {
         const accountHash = yield* proofHashResult(account.value, 'preflight account')
+        const accountConfigurationHash = yield* proofHashResult(
+          accountConfiguration.value,
+          'preflight account configuration',
+        )
         const positionsHash = yield* proofHashResult(responses.positions.value, 'preflight positions')
         const ordersHash = yield* proofHashResult(
           { open: responses.openOrders.value, recent: responses.recentOrders.value },
@@ -112,8 +193,13 @@ export const verifyReadAccess = (read: BrokerReadShape): Effect.Effect<ReadPrefl
         )
         const fillsHash = yield* proofHashResult(responses.fills.value.items, 'preflight fills')
         return {
+          provider: connection.provider,
+          environment: connection.environment,
+          baseUrl: connection.baseUrl,
           accountId: account.value.id,
+          ...permissions,
           accountHash,
+          accountConfigurationHash,
           positionCount: responses.positions.value.length,
           positionsHash,
           openOrderCount: responses.openOrders.value.length,
@@ -141,7 +227,16 @@ export const verifyReadAccess = (read: BrokerReadShape): Effect.Effect<ReadPrefl
     yield* Effect.logInfo('Alpaca observe-only read preflight passed').pipe(
       Effect.annotateLogs({
         accountId: proof.accountId,
+        provider: proof.provider,
+        environment: proof.environment,
+        baseUrl: proof.baseUrl,
+        accountStatus: proof.accountStatus,
+        accountBlocked: proof.accountBlocked,
+        tradingBlocked: proof.tradingBlocked,
+        tradeSuspendedByUser: proof.tradeSuspendedByUser,
+        fractionalTrading: proof.fractionalTrading,
         accountHash: proof.accountHash,
+        accountConfigurationHash: proof.accountConfigurationHash,
         positionCount: proof.positionCount,
         positionsHash: proof.positionsHash,
         openOrderCount: proof.openOrderCount,

--- a/services/bayn/src/broker/alpaca/requests.ts
+++ b/services/bayn/src/broker/alpaca/requests.ts
@@ -8,7 +8,6 @@ import {
   assetObservationSchemaVersion,
   assetObservationSource,
   defaultFillActivitiesPageSize,
-  paperTradingUrl,
   type FillActivitiesQuery,
   type MarketCalendarQuery,
   type OrdersQuery,
@@ -30,25 +29,26 @@ export const assetRequestMaterial = (requestedSymbol: string) => ({
   requestedSymbol,
 })
 
-export const accountUrl = (): URL => new URL('/v2/account', paperTradingUrl)
+export const accountUrl = (baseUrl: string): URL => new URL('/v2/account', baseUrl)
 
-export const accountConfigurationUrl = (): URL => new URL(accountConfigurationRequestMaterial.path, paperTradingUrl)
+export const accountConfigurationUrl = (baseUrl: string): URL =>
+  new URL(accountConfigurationRequestMaterial.path, baseUrl)
 
-export const positionsUrl = (): URL => new URL('/v2/positions', paperTradingUrl)
+export const positionsUrl = (baseUrl: string): URL => new URL('/v2/positions', baseUrl)
 
-export const assetBySymbolUrl = (requestedSymbol: string): URL =>
-  new URL(assetRequestMaterial(requestedSymbol).path, paperTradingUrl)
+export const assetBySymbolUrl = (baseUrl: string, requestedSymbol: string): URL =>
+  new URL(assetRequestMaterial(requestedSymbol).path, baseUrl)
 
-export const marketCalendarUrl = (query: MarketCalendarQuery): URL => {
-  const url = new URL('/v2/calendar', paperTradingUrl)
+export const marketCalendarUrl = (baseUrl: string, query: MarketCalendarQuery): URL => {
+  const url = new URL('/v2/calendar', baseUrl)
   url.searchParams.set('start', query.start)
   url.searchParams.set('end', query.end)
   url.searchParams.set('date_type', 'TRADING')
   return url
 }
 
-export const ordersUrl = (query: OrdersQuery): URL => {
-  const url = new URL('/v2/orders', paperTradingUrl)
+export const ordersUrl = (baseUrl: string, query: OrdersQuery): URL => {
+  const url = new URL('/v2/orders', baseUrl)
   if (query.status !== undefined) url.searchParams.set('status', query.status)
   if (query.limit !== undefined) url.searchParams.set('limit', String(query.limit))
   if (query.after !== undefined) url.searchParams.set('after', query.after)
@@ -59,11 +59,11 @@ export const ordersUrl = (query: OrdersQuery): URL => {
   return url
 }
 
-export const orderByIdUrl = (orderId: string): URL =>
-  new URL(`/v2/orders/${encodeURIComponent(orderId)}`, paperTradingUrl)
+export const orderByIdUrl = (baseUrl: string, orderId: string): URL =>
+  new URL(`/v2/orders/${encodeURIComponent(orderId)}`, baseUrl)
 
-export const orderByClientIdUrl = (clientOrderId: string): URL => {
-  const url = new URL('/v2/orders:by_client_order_id', paperTradingUrl)
+export const orderByClientIdUrl = (baseUrl: string, clientOrderId: string): URL => {
+  const url = new URL('/v2/orders:by_client_order_id', baseUrl)
   url.searchParams.set('client_order_id', clientOrderId)
   return url
 }
@@ -73,8 +73,8 @@ export interface FillActivitiesRequest {
   readonly pageSize: number
 }
 
-export const fillActivitiesRequest = (query: FillActivitiesQuery): FillActivitiesRequest => {
-  const url = new URL('/v2/account/activities/FILL', paperTradingUrl)
+export const fillActivitiesRequest = (baseUrl: string, query: FillActivitiesQuery): FillActivitiesRequest => {
+  const url = new URL('/v2/account/activities/FILL', baseUrl)
   const pageSize = query.pageSize ?? defaultFillActivitiesPageSize
   if (query.date !== undefined) url.searchParams.set('date', query.date)
   if (query.after !== undefined) url.searchParams.set('after', query.after)

--- a/services/bayn/src/broker/alpaca/session.ts
+++ b/services/bayn/src/broker/alpaca/session.ts
@@ -1,0 +1,114 @@
+import { Context, Data, Effect, Layer, pipe } from 'effect'
+import { HttpClient } from 'effect/unstable/http'
+
+import type { BrokerConnection } from '../connection'
+import { BrokerReadError } from './failures'
+import { alpacaHttpLayer, make } from './http'
+import { BrokerRead, type BrokerReadShape, type ReadPreflight } from './model'
+import { BrokerAccountPreflightError, verifyReadAccess } from './preflight'
+
+export enum BrokerSessionAcquisitionStage {
+  Connection = 'CONNECTION',
+  Account = 'ACCOUNT',
+  Permissions = 'PERMISSIONS',
+  ReadSurface = 'READ_SURFACE',
+}
+
+export class BrokerSessionAcquisitionError extends Data.TaggedError('BrokerSessionAcquisitionError')<{
+  readonly stage: BrokerSessionAcquisitionStage
+  readonly provider: BrokerConnection['provider']
+  readonly environment: BrokerConnection['environment']
+  readonly baseUrl: string
+  readonly expectedAccountId: string
+  readonly cause: BrokerReadError | BrokerAccountPreflightError
+}> {}
+
+export interface BrokerSessionShape {
+  readonly connection: BrokerConnection
+  readonly read: BrokerReadShape
+  readonly preflight: ReadPreflight
+}
+
+export class BrokerSession extends Context.Service<BrokerSession, BrokerSessionShape>()('bayn/BrokerSession') {}
+
+const acquisitionStage = (cause: BrokerReadError | BrokerAccountPreflightError): BrokerSessionAcquisitionStage => {
+  if (cause instanceof BrokerAccountPreflightError) return BrokerSessionAcquisitionStage.Permissions
+  switch (cause.operation) {
+    case 'configuration':
+    case 'proxy':
+      return BrokerSessionAcquisitionStage.Connection
+    case 'account':
+      return BrokerSessionAcquisitionStage.Account
+    case 'account-configuration':
+      return BrokerSessionAcquisitionStage.Permissions
+    case 'preflight':
+    case 'positions':
+    case 'orders':
+    case 'order-by-id':
+    case 'order-by-client-id':
+    case 'fill-activities':
+    case 'asset-by-symbol':
+    case 'market-calendar':
+      return BrokerSessionAcquisitionStage.ReadSurface
+  }
+  const exhaustive: never = cause.operation
+  return exhaustive
+}
+
+const acquisitionError = (
+  connection: BrokerConnection,
+  cause: BrokerReadError | BrokerAccountPreflightError,
+): BrokerSessionAcquisitionError =>
+  new BrokerSessionAcquisitionError({
+    stage: acquisitionStage(cause),
+    provider: connection.provider,
+    environment: connection.environment,
+    baseUrl: connection.baseUrl,
+    expectedAccountId: connection.expectedAccountId,
+    cause,
+  })
+
+export const acquireBrokerSession = (
+  connection: BrokerConnection,
+): Effect.Effect<BrokerSessionShape, BrokerSessionAcquisitionError, HttpClient.HttpClient> =>
+  pipe(
+    make(connection),
+    Effect.flatMap((read) =>
+      pipe(
+        verifyReadAccess(connection, read),
+        Effect.map((preflight) => Object.freeze({ connection, read, preflight })),
+      ),
+    ),
+    Effect.mapError((cause) => acquisitionError(connection, cause)),
+    Effect.withLogSpan('broker.session.acquire'),
+  )
+
+export const layer = (
+  connection: BrokerConnection,
+): Layer.Layer<BrokerSession | BrokerRead, BrokerSessionAcquisitionError, HttpClient.HttpClient> => {
+  const session = Layer.effect(BrokerSession, acquireBrokerSession(connection))
+  return Layer.effect(
+    BrokerRead,
+    pipe(
+      BrokerSession,
+      Effect.map((brokerSession) => brokerSession.read),
+    ),
+  ).pipe(Layer.provideMerge(session))
+}
+
+const mapHttpAcquisitionError = (
+  connection: BrokerConnection,
+  http: Layer.Layer<HttpClient.HttpClient, BrokerReadError>,
+): Layer.Layer<HttpClient.HttpClient, BrokerSessionAcquisitionError> =>
+  Layer.unwrap(
+    pipe(
+      Layer.build(http),
+      Effect.mapError((cause) => acquisitionError(connection, cause)),
+      Effect.map(Layer.succeedContext),
+    ),
+  )
+
+export const live = (
+  connection: BrokerConnection,
+): Layer.Layer<BrokerSession | BrokerRead, BrokerSessionAcquisitionError> =>
+  layer(connection).pipe(Layer.provide(mapHttpAcquisitionError(connection, alpacaHttpLayer(connection))))

--- a/services/bayn/src/broker/connection.test.ts
+++ b/services/bayn/src/broker/connection.test.ts
@@ -50,14 +50,19 @@ describe('BrokerConnection decoding', () => {
     expect(JSON.stringify(result.success)).not.toContain(secret)
   })
 
-  test('decodes only the approved Alpaca live endpoint for the live environment', () => {
+  test('rejects the approved Alpaca live endpoint until durable identities encode the environment', () => {
     const result = decodeBrokerConnection(input({ environment: BrokerEnvironment.Live, baseUrl: alpacaLiveBaseUrl }))
 
-    expect(Result.isSuccess(result)).toBe(true)
-    if (Result.isSuccess(result)) {
-      expect(result.success.environment).toBe(BrokerEnvironment.Live)
-      expect(result.success.baseUrl).toBe(alpacaLiveBaseUrl)
-    }
+    expect(result).toMatchObject({
+      _tag: 'Failure',
+      failure: {
+        _tag: 'BrokerEnvironmentUnsupported',
+        provider: BrokerProvider.Alpaca,
+        environment: BrokerEnvironment.Live,
+        baseUrl: alpacaLiveBaseUrl,
+        reason: 'DURABLE_IDENTITY_UNAVAILABLE',
+      },
+    })
   })
 
   for (const [environment, baseUrl, approvedBaseUrl] of [

--- a/services/bayn/src/broker/connection.test.ts
+++ b/services/bayn/src/broker/connection.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, test } from 'bun:test'
+
+import { Redacted, Result } from 'effect'
+
+import { BrokerEnvironment } from '../execution/authority'
+import {
+  BrokerProvider,
+  alpacaLiveBaseUrl,
+  alpacaSandboxBaseUrl,
+  decodeBrokerConnection,
+  type BrokerConnectionInput,
+} from './connection'
+
+const accountId = 'e6fe16f3-64a4-4921-8928-cadf02f92f98'
+const key = 'alpaca-key-must-remain-redacted'
+const secret = 'alpaca-secret-must-remain-redacted'
+
+const input = (overrides: Partial<BrokerConnectionInput> = {}): BrokerConnectionInput => ({
+  provider: BrokerProvider.Alpaca,
+  environment: BrokerEnvironment.Sandbox,
+  baseUrl: alpacaSandboxBaseUrl,
+  expectedAccountId: accountId,
+  key: Redacted.make(key),
+  secret: Redacted.make(secret),
+  proxyUrl: 'http://bayn-egress-proxy:3128',
+  operationTimeoutMs: 30_000,
+  retryAttempts: 2,
+  ...overrides,
+})
+
+describe('BrokerConnection decoding', () => {
+  test('decodes and freezes the approved Alpaca sandbox connection once', () => {
+    const result = decodeBrokerConnection(input({ baseUrl: `${alpacaSandboxBaseUrl}/` }))
+
+    expect(Result.isSuccess(result)).toBe(true)
+    if (Result.isFailure(result)) return
+    expect(result.success).toMatchObject({
+      provider: BrokerProvider.Alpaca,
+      environment: BrokerEnvironment.Sandbox,
+      baseUrl: alpacaSandboxBaseUrl,
+      expectedAccountId: accountId,
+      proxyUrl: 'http://bayn-egress-proxy:3128',
+      operationTimeoutMs: 30_000,
+      retryAttempts: 2,
+    })
+    expect(Object.isFrozen(result.success)).toBe(true)
+    expect(Redacted.isRedacted(result.success.key)).toBe(true)
+    expect(Redacted.isRedacted(result.success.secret)).toBe(true)
+    expect(JSON.stringify(result.success)).not.toContain(key)
+    expect(JSON.stringify(result.success)).not.toContain(secret)
+  })
+
+  test('decodes only the approved Alpaca live endpoint for the live environment', () => {
+    const result = decodeBrokerConnection(input({ environment: BrokerEnvironment.Live, baseUrl: alpacaLiveBaseUrl }))
+
+    expect(Result.isSuccess(result)).toBe(true)
+    if (Result.isSuccess(result)) {
+      expect(result.success.environment).toBe(BrokerEnvironment.Live)
+      expect(result.success.baseUrl).toBe(alpacaLiveBaseUrl)
+    }
+  })
+
+  for (const [environment, baseUrl, approvedBaseUrl] of [
+    [BrokerEnvironment.Sandbox, alpacaLiveBaseUrl, alpacaSandboxBaseUrl],
+    [BrokerEnvironment.Live, alpacaSandboxBaseUrl, alpacaLiveBaseUrl],
+  ] as const) {
+    test(`rejects ${environment} credentials paired with ${baseUrl}`, () => {
+      const result = decodeBrokerConnection(input({ environment, baseUrl }))
+
+      expect(result).toMatchObject({
+        _tag: 'Failure',
+        failure: {
+          _tag: 'BrokerEndpointEnvironmentMismatch',
+          provider: BrokerProvider.Alpaca,
+          environment,
+          baseUrl,
+          approvedBaseUrl,
+        },
+      })
+    })
+  }
+
+  for (const [baseUrl, reason] of [
+    ['not a URL', 'INVALID_URL'],
+    ['http://paper-api.alpaca.markets', 'HTTPS_REQUIRED'],
+    ['https://user:secret@paper-api.alpaca.markets', 'ORIGIN_REQUIRED'],
+    ['https://paper-api.alpaca.markets/v2', 'ORIGIN_REQUIRED'],
+    ['https://paper-api.alpaca.markets?environment=paper', 'ORIGIN_REQUIRED'],
+    ['https://paper-api.alpaca.markets#paper', 'ORIGIN_REQUIRED'],
+  ] as const) {
+    test(`rejects unsafe broker base URL ${baseUrl}`, () => {
+      expect(decodeBrokerConnection(input({ baseUrl }))).toMatchObject({
+        _tag: 'Failure',
+        failure: { _tag: 'InvalidBrokerBaseUrl', reason },
+      })
+    })
+  }
+
+  for (const [proxyUrl, reason] of [
+    ['not a URL', 'INVALID_URL'],
+    ['socks5://proxy.test:1080', 'HTTP_OR_HTTPS_REQUIRED'],
+    ['http://user:secret@proxy.test:3128', 'CREDENTIALS_FORBIDDEN'],
+    ['http://proxy.test:3128/route', 'ORIGIN_REQUIRED'],
+    ['http://proxy.test:3128?route=paper', 'ORIGIN_REQUIRED'],
+    ['http://proxy.test:3128#paper', 'ORIGIN_REQUIRED'],
+  ] as const) {
+    test(`rejects unsafe broker proxy URL ${proxyUrl}`, () => {
+      expect(decodeBrokerConnection(input({ proxyUrl }))).toMatchObject({
+        _tag: 'Failure',
+        failure: { _tag: 'InvalidBrokerProxyUrl', reason },
+      })
+    })
+  }
+
+  for (const [name, overrides, invalid] of [
+    ['empty key', { key: Redacted.make('') }, ['key']],
+    ['padded key', { key: Redacted.make(' key ') }, ['key']],
+    ['empty secret', { secret: Redacted.make('') }, ['secret']],
+    ['padded secret', { secret: Redacted.make(' secret ') }, ['secret']],
+    [
+      'both malformed credentials',
+      { key: Redacted.make(' key '), secret: Redacted.make(' secret ') },
+      ['key', 'secret'],
+    ],
+  ] as const) {
+    test(`rejects ${name} without exposing credential values`, () => {
+      const result = decodeBrokerConnection(input(overrides))
+
+      expect(result).toMatchObject({
+        _tag: 'Failure',
+        failure: { _tag: 'InvalidBrokerCredentials', invalid },
+      })
+      expect(JSON.stringify(result)).not.toContain(' key ')
+      expect(JSON.stringify(result)).not.toContain(' secret ')
+    })
+  }
+
+  for (const [name, overrides, path] of [
+    ['unknown provider', { provider: 'other' }, '["provider"]'],
+    ['unknown environment', { environment: 'paper' }, '["environment"]'],
+    ['malformed account identity', { expectedAccountId: 'account-1' }, '["expectedAccountId"]'],
+    ['zero timeout', { operationTimeoutMs: 0 }, '["operationTimeoutMs"]'],
+    ['excess retries', { retryAttempts: 4 }, '["retryAttempts"]'],
+  ] as const) {
+    test(`rejects ${name} as typed connection material`, () => {
+      const result = decodeBrokerConnection(input(overrides))
+
+      expect(result).toMatchObject({
+        _tag: 'Failure',
+        failure: { _tag: 'InvalidBrokerConnectionMaterial' },
+      })
+      if (Result.isFailure(result) && result.failure._tag === 'InvalidBrokerConnectionMaterial') {
+        expect(result.failure.cause.message).toContain(path)
+      }
+    })
+  }
+})

--- a/services/bayn/src/broker/connection.ts
+++ b/services/bayn/src/broker/connection.ts
@@ -1,0 +1,216 @@
+import { Redacted, Result, Schema } from 'effect'
+
+import { BrokerEnvironment, BrokerEnvironmentSchema } from '../execution/authority'
+import {
+  PositiveIntegerSchema as PositiveInteger,
+  StrictNonEmptyStringSchema as NonEmptyString,
+  strictParseOptions as StrictParseOptions,
+} from '../schemas'
+
+export enum BrokerProvider {
+  Alpaca = 'alpaca',
+}
+
+export const alpacaSandboxBaseUrl = 'https://paper-api.alpaca.markets' as const
+export const alpacaLiveBaseUrl = 'https://api.alpaca.markets' as const
+
+const BrokerProviderSchema = Schema.Enum(BrokerProvider)
+const AccountId = Schema.String.check(
+  Schema.isPattern(/^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/),
+)
+const RetryAttempts = Schema.Int.check(Schema.isBetween({ minimum: 0, maximum: 3 }))
+const BrokerConnectionMaterialSchema = Schema.Struct({
+  provider: BrokerProviderSchema,
+  environment: BrokerEnvironmentSchema,
+  baseUrl: NonEmptyString,
+  expectedAccountId: AccountId,
+  proxyUrl: NonEmptyString,
+  operationTimeoutMs: PositiveInteger,
+  retryAttempts: RetryAttempts,
+})
+
+export interface BrokerConnectionInput {
+  readonly provider: unknown
+  readonly environment: unknown
+  readonly baseUrl: unknown
+  readonly expectedAccountId: unknown
+  readonly key: Redacted.Redacted<string>
+  readonly secret: Redacted.Redacted<string>
+  readonly proxyUrl: unknown
+  readonly operationTimeoutMs: unknown
+  readonly retryAttempts: unknown
+}
+
+export interface BrokerConnection {
+  readonly provider: BrokerProvider.Alpaca
+  readonly environment: BrokerEnvironment
+  readonly baseUrl: string
+  readonly expectedAccountId: string
+  readonly key: Redacted.Redacted<string>
+  readonly secret: Redacted.Redacted<string>
+  readonly proxyUrl: string
+  readonly operationTimeoutMs: number
+  readonly retryAttempts: number
+}
+
+export type BrokerConnectionDecodeFailure =
+  | {
+      readonly _tag: 'InvalidBrokerConnectionMaterial'
+      readonly cause: Schema.SchemaError
+    }
+  | {
+      readonly _tag: 'InvalidBrokerCredentials'
+      readonly invalid: readonly ('key' | 'secret')[]
+    }
+  | {
+      readonly _tag: 'InvalidBrokerBaseUrl'
+      readonly reason: 'INVALID_URL' | 'HTTPS_REQUIRED' | 'ORIGIN_REQUIRED'
+    }
+  | {
+      readonly _tag: 'BrokerEndpointEnvironmentMismatch'
+      readonly provider: BrokerProvider.Alpaca
+      readonly environment: BrokerEnvironment
+      readonly baseUrl: string
+      readonly approvedBaseUrl: string
+    }
+  | {
+      readonly _tag: 'InvalidBrokerProxyUrl'
+      readonly reason: 'INVALID_URL' | 'HTTP_OR_HTTPS_REQUIRED' | 'CREDENTIALS_FORBIDDEN' | 'ORIGIN_REQUIRED'
+    }
+
+const decodeBrokerConnectionMaterial = Schema.decodeUnknownResult(BrokerConnectionMaterialSchema, StrictParseOptions)
+
+const parseUrl = (value: string): Result.Result<URL, 'INVALID_URL'> =>
+  Result.try({
+    try: () => new URL(value),
+    catch: () => 'INVALID_URL' as const,
+  })
+
+const invalidBrokerBaseUrl = (
+  reason: Extract<BrokerConnectionDecodeFailure, { readonly _tag: 'InvalidBrokerBaseUrl' }>['reason'],
+): Extract<BrokerConnectionDecodeFailure, { readonly _tag: 'InvalidBrokerBaseUrl' }> => ({
+  _tag: 'InvalidBrokerBaseUrl',
+  reason,
+})
+
+const validateBrokerBaseUrl = (
+  value: string,
+): Result.Result<string, Extract<BrokerConnectionDecodeFailure, { readonly _tag: 'InvalidBrokerBaseUrl' }>> =>
+  Result.flatMap(parseUrl(value), (url) => {
+    if (url.protocol !== 'https:') {
+      return Result.fail(invalidBrokerBaseUrl('HTTPS_REQUIRED'))
+    }
+    if (url.username !== '' || url.password !== '' || url.pathname !== '/' || url.search !== '' || url.hash !== '') {
+      return Result.fail(invalidBrokerBaseUrl('ORIGIN_REQUIRED'))
+    }
+    return Result.succeed(url.origin)
+  }).pipe(Result.mapError((failure) => (failure === 'INVALID_URL' ? invalidBrokerBaseUrl(failure) : failure)))
+
+const approvedAlpacaBaseUrl = (environment: BrokerEnvironment): string =>
+  environment === BrokerEnvironment.Sandbox ? alpacaSandboxBaseUrl : alpacaLiveBaseUrl
+
+const validateEndpointPairing = (
+  provider: BrokerProvider.Alpaca,
+  environment: BrokerEnvironment,
+  baseUrl: string,
+): Result.Result<string, BrokerConnectionDecodeFailure> => {
+  const approvedBaseUrl = approvedAlpacaBaseUrl(environment)
+  return baseUrl === approvedBaseUrl
+    ? Result.succeed(baseUrl)
+    : Result.fail({
+        _tag: 'BrokerEndpointEnvironmentMismatch',
+        provider,
+        environment,
+        baseUrl,
+        approvedBaseUrl,
+      })
+}
+
+const invalidBrokerProxyUrl = (
+  reason: Extract<BrokerConnectionDecodeFailure, { readonly _tag: 'InvalidBrokerProxyUrl' }>['reason'],
+): Extract<BrokerConnectionDecodeFailure, { readonly _tag: 'InvalidBrokerProxyUrl' }> => ({
+  _tag: 'InvalidBrokerProxyUrl',
+  reason,
+})
+
+export const decodeBrokerProxyUrl = (
+  value: string,
+): Result.Result<string, Extract<BrokerConnectionDecodeFailure, { readonly _tag: 'InvalidBrokerProxyUrl' }>> =>
+  Result.flatMap(parseUrl(value), (url) => {
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+      return Result.fail(invalidBrokerProxyUrl('HTTP_OR_HTTPS_REQUIRED'))
+    }
+    if (url.username !== '' || url.password !== '') {
+      return Result.fail(invalidBrokerProxyUrl('CREDENTIALS_FORBIDDEN'))
+    }
+    if (url.pathname !== '/' || url.search !== '' || url.hash !== '') {
+      return Result.fail(invalidBrokerProxyUrl('ORIGIN_REQUIRED'))
+    }
+    return Result.succeed(url.origin)
+  }).pipe(Result.mapError((failure) => (failure === 'INVALID_URL' ? invalidBrokerProxyUrl(failure) : failure)))
+
+const invalidCredentials = (
+  key: Redacted.Redacted<string>,
+  secret: Redacted.Redacted<string>,
+): readonly ('key' | 'secret')[] => {
+  const invalid: Array<'key' | 'secret'> = []
+  const keyValue = Redacted.value(key)
+  const secretValue = Redacted.value(secret)
+  if (keyValue.length === 0 || keyValue.trim() !== keyValue) invalid.push('key')
+  if (secretValue.length === 0 || secretValue.trim() !== secretValue) invalid.push('secret')
+  return invalid
+}
+
+export const decodeBrokerConnection = (
+  input: BrokerConnectionInput,
+): Result.Result<BrokerConnection, BrokerConnectionDecodeFailure> => {
+  const material = decodeBrokerConnectionMaterial({
+    provider: input.provider,
+    environment: input.environment,
+    baseUrl: input.baseUrl,
+    expectedAccountId: input.expectedAccountId,
+    proxyUrl: input.proxyUrl,
+    operationTimeoutMs: input.operationTimeoutMs,
+    retryAttempts: input.retryAttempts,
+  })
+  if (Result.isFailure(material)) {
+    return Result.fail({ _tag: 'InvalidBrokerConnectionMaterial', cause: material.failure })
+  }
+
+  const invalid = invalidCredentials(input.key, input.secret)
+  if (invalid.length > 0) return Result.fail({ _tag: 'InvalidBrokerCredentials', invalid })
+
+  return Result.gen(function* () {
+    const baseUrl = yield* validateBrokerBaseUrl(material.success.baseUrl)
+    yield* validateEndpointPairing(material.success.provider, material.success.environment, baseUrl)
+    const proxyUrl = yield* decodeBrokerProxyUrl(material.success.proxyUrl)
+    return Object.freeze({
+      provider: material.success.provider,
+      environment: material.success.environment,
+      baseUrl,
+      expectedAccountId: material.success.expectedAccountId,
+      key: input.key,
+      secret: input.secret,
+      proxyUrl,
+      operationTimeoutMs: material.success.operationTimeoutMs,
+      retryAttempts: material.success.retryAttempts,
+    })
+  })
+}
+
+export const renderBrokerConnectionDecodeFailure = (failure: BrokerConnectionDecodeFailure): string => {
+  switch (failure._tag) {
+    case 'InvalidBrokerConnectionMaterial':
+      return `invalid broker connection material: ${failure.cause.message}`
+    case 'InvalidBrokerCredentials':
+      return `invalid broker credentials: ${failure.invalid.join(', ')} must be non-empty without surrounding whitespace`
+    case 'InvalidBrokerBaseUrl':
+      return `invalid broker base URL: ${failure.reason}`
+    case 'BrokerEndpointEnvironmentMismatch':
+      return `broker endpoint ${failure.baseUrl} is not approved for ${failure.environment}; expected ${failure.approvedBaseUrl}`
+    case 'InvalidBrokerProxyUrl':
+      return `invalid broker proxy URL: ${failure.reason}`
+  }
+  const exhaustive: never = failure
+  return exhaustive
+}

--- a/services/bayn/src/broker/connection.ts
+++ b/services/bayn/src/broker/connection.ts
@@ -43,7 +43,7 @@ export interface BrokerConnectionInput {
 
 export interface BrokerConnection {
   readonly provider: BrokerProvider.Alpaca
-  readonly environment: BrokerEnvironment
+  readonly environment: BrokerEnvironment.Sandbox
   readonly baseUrl: string
   readonly expectedAccountId: string
   readonly key: Redacted.Redacted<string>
@@ -72,6 +72,13 @@ export type BrokerConnectionDecodeFailure =
       readonly environment: BrokerEnvironment
       readonly baseUrl: string
       readonly approvedBaseUrl: string
+    }
+  | {
+      readonly _tag: 'BrokerEnvironmentUnsupported'
+      readonly provider: BrokerProvider.Alpaca
+      readonly environment: BrokerEnvironment.Live
+      readonly baseUrl: string
+      readonly reason: 'DURABLE_IDENTITY_UNAVAILABLE'
     }
   | {
       readonly _tag: 'InvalidBrokerProxyUrl'
@@ -125,6 +132,21 @@ const validateEndpointPairing = (
         approvedBaseUrl,
       })
 }
+
+const validateSupportedEnvironment = (
+  provider: BrokerProvider.Alpaca,
+  environment: BrokerEnvironment,
+  baseUrl: string,
+): Result.Result<BrokerEnvironment.Sandbox, BrokerConnectionDecodeFailure> =>
+  environment === BrokerEnvironment.Sandbox
+    ? Result.succeed(BrokerEnvironment.Sandbox)
+    : Result.fail({
+        _tag: 'BrokerEnvironmentUnsupported',
+        provider,
+        environment: BrokerEnvironment.Live,
+        baseUrl,
+        reason: 'DURABLE_IDENTITY_UNAVAILABLE',
+      })
 
 const invalidBrokerProxyUrl = (
   reason: Extract<BrokerConnectionDecodeFailure, { readonly _tag: 'InvalidBrokerProxyUrl' }>['reason'],
@@ -183,10 +205,15 @@ export const decodeBrokerConnection = (
   return Result.gen(function* () {
     const baseUrl = yield* validateBrokerBaseUrl(material.success.baseUrl)
     yield* validateEndpointPairing(material.success.provider, material.success.environment, baseUrl)
+    const environment = yield* validateSupportedEnvironment(
+      material.success.provider,
+      material.success.environment,
+      baseUrl,
+    )
     const proxyUrl = yield* decodeBrokerProxyUrl(material.success.proxyUrl)
     return Object.freeze({
       provider: material.success.provider,
-      environment: material.success.environment,
+      environment,
       baseUrl,
       expectedAccountId: material.success.expectedAccountId,
       key: input.key,
@@ -208,6 +235,8 @@ export const renderBrokerConnectionDecodeFailure = (failure: BrokerConnectionDec
       return `invalid broker base URL: ${failure.reason}`
     case 'BrokerEndpointEnvironmentMismatch':
       return `broker endpoint ${failure.baseUrl} is not approved for ${failure.environment}; expected ${failure.approvedBaseUrl}`
+    case 'BrokerEnvironmentUnsupported':
+      return `broker environment ${failure.environment} is unsupported until durable broker identities encode the environment`
     case 'InvalidBrokerProxyUrl':
       return `invalid broker proxy URL: ${failure.reason}`
   }

--- a/services/bayn/src/config.test.ts
+++ b/services/bayn/src/config.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test'
 
 import { ConfigProvider, Effect, Redacted, Result } from 'effect'
 
+import { BrokerProvider, alpacaLiveBaseUrl, alpacaSandboxBaseUrl } from './broker/connection'
 import type { EmbeddedBuildMetadata } from './build'
 import {
   loadConfig,
@@ -11,6 +12,7 @@ import {
   type RuntimeConfigResolutionInput,
 } from './config'
 import { Authority } from './paper'
+import { BrokerEnvironment } from './execution/authority'
 
 const sourceRevision = 'a'.repeat(40)
 const imageRepository = 'registry.ide-newton.ts.net/lab/bayn'
@@ -48,6 +50,9 @@ const baseParsedConfig: ParsedRuntimeConfig = {
   cyclePollIntervalMs: 30_000,
   authorityGenerationHash,
   configuredAlpaca: {
+    provider: BrokerProvider.Alpaca,
+    environment: BrokerEnvironment.Sandbox,
+    baseUrl: alpacaSandboxBaseUrl,
     accountId: undefined,
     key: undefined,
     secret: undefined,
@@ -250,6 +255,51 @@ describe('pure runtime configuration resolution', () => {
       }
     })
   }
+
+  test('resolves one approved live Alpaca connection without changing execution authority', () => {
+    const result = resolveRuntimeConfig(
+      resolutionInput({
+        configuredAlpaca: {
+          ...completeAlpacaConfig,
+          environment: BrokerEnvironment.Live,
+          baseUrl: alpacaLiveBaseUrl,
+        },
+      }),
+    )
+
+    expect(Result.isSuccess(result)).toBe(true)
+    if (Result.isSuccess(result) && result.success.alpaca !== undefined) {
+      expect(result.success.maximumAuthority).toBe(Authority.Observe)
+      expect(result.success.alpaca).toMatchObject({
+        provider: BrokerProvider.Alpaca,
+        environment: BrokerEnvironment.Live,
+        baseUrl: alpacaLiveBaseUrl,
+        expectedAccountId: alpacaAccountId,
+      })
+    }
+  })
+
+  test('rejects a mismatched Alpaca endpoint and environment before runtime composition', () => {
+    expectResolutionFailure(
+      resolutionInput({
+        configuredAlpaca: {
+          ...completeAlpacaConfig,
+          environment: BrokerEnvironment.Live,
+          baseUrl: alpacaSandboxBaseUrl,
+        },
+      }),
+      {
+        _tag: 'InvalidBrokerConnection',
+        cause: {
+          _tag: 'BrokerEndpointEnvironmentMismatch',
+          provider: BrokerProvider.Alpaca,
+          environment: BrokerEnvironment.Live,
+          baseUrl: alpacaSandboxBaseUrl,
+          approvedBaseUrl: alpacaLiveBaseUrl,
+        },
+      },
+    )
+  })
 
   const partialCredentialCases = [
     ['account ID only', true, false, false],
@@ -803,7 +853,7 @@ describe('Effect configuration', () => {
     expect(config.maximumAuthority).toBe(Authority.Observe)
     if (config.runtimeMode === 'PaperCandidateDiscovery') {
       expect(config.qualificationRunId).toBe('e'.repeat(64))
-      expect(config.alpaca.accountId).toBe('61e69015-8549-4bfd-b9c3-01e75843f47d')
+      expect(config.alpaca.expectedAccountId).toBe('61e69015-8549-4bfd-b9c3-01e75843f47d')
     }
   })
 
@@ -906,7 +956,10 @@ describe('Effect configuration', () => {
     const config = await Effect.runPromise(provideEnvironment(loadConfig(buildMetadata), configured))
 
     expect(config.alpaca).toMatchObject({
-      accountId: '61e69015-8549-4bfd-b9c3-01e75843f47d',
+      provider: BrokerProvider.Alpaca,
+      environment: BrokerEnvironment.Sandbox,
+      baseUrl: alpacaSandboxBaseUrl,
+      expectedAccountId: '61e69015-8549-4bfd-b9c3-01e75843f47d',
       authorityGenerationHash,
       proxyUrl: 'http://bayn-egress-proxy:3128',
       retryAttempts: 2,

--- a/services/bayn/src/config.test.ts
+++ b/services/bayn/src/config.test.ts
@@ -256,8 +256,8 @@ describe('pure runtime configuration resolution', () => {
     })
   }
 
-  test('resolves one approved live Alpaca connection without changing execution authority', () => {
-    const result = resolveRuntimeConfig(
+  test('rejects a live Alpaca connection until durable identities encode the broker environment', () => {
+    expectResolutionFailure(
       resolutionInput({
         configuredAlpaca: {
           ...completeAlpacaConfig,
@@ -265,18 +265,17 @@ describe('pure runtime configuration resolution', () => {
           baseUrl: alpacaLiveBaseUrl,
         },
       }),
+      {
+        _tag: 'InvalidBrokerConnection',
+        cause: {
+          _tag: 'BrokerEnvironmentUnsupported',
+          provider: BrokerProvider.Alpaca,
+          environment: BrokerEnvironment.Live,
+          baseUrl: alpacaLiveBaseUrl,
+          reason: 'DURABLE_IDENTITY_UNAVAILABLE',
+        },
+      },
     )
-
-    expect(Result.isSuccess(result)).toBe(true)
-    if (Result.isSuccess(result) && result.success.alpaca !== undefined) {
-      expect(result.success.maximumAuthority).toBe(Authority.Observe)
-      expect(result.success.alpaca).toMatchObject({
-        provider: BrokerProvider.Alpaca,
-        environment: BrokerEnvironment.Live,
-        baseUrl: alpacaLiveBaseUrl,
-        expectedAccountId: alpacaAccountId,
-      })
-    }
   })
 
   test('rejects a mismatched Alpaca endpoint and environment before runtime composition', () => {

--- a/services/bayn/src/config.ts
+++ b/services/bayn/src/config.ts
@@ -1,8 +1,17 @@
 import { Config, Effect, Option, pipe, Redacted, Result, Schema, SchemaTransformation } from 'effect'
 
+import {
+  BrokerProvider,
+  alpacaSandboxBaseUrl,
+  decodeBrokerConnection,
+  renderBrokerConnectionDecodeFailure,
+  type BrokerConnection,
+  type BrokerConnectionDecodeFailure,
+} from './broker/connection'
 import { EmbeddedBuildMetadataSchema, embeddedBuildMetadata, type EmbeddedBuildMetadata } from './build'
 import { EvaluationBoundsSchema, IsoDateSchema, Sha256Schema, type EvaluationBounds } from './contracts'
 import { OperationalError, operationalError } from './errors'
+import { BrokerEnvironment, BrokerEnvironmentSchema } from './execution/authority'
 import { Authority } from './paper'
 import {
   GitSourceRevisionSchema as SourceRevision,
@@ -29,13 +38,8 @@ export interface RuntimeConfig {
   readonly cycleStallThresholdMs: number
   readonly reconciliationStaleThresholdMs: number
   readonly unknownMutationThresholdMs: number
-  readonly alpaca?: {
-    readonly accountId: string
+  readonly alpaca?: BrokerConnection & {
     readonly authorityGenerationHash: string
-    readonly key: Redacted.Redacted<string>
-    readonly secret: Redacted.Redacted<string>
-    readonly proxyUrl: string
-    readonly retryAttempts: number
     readonly reconciliationIntervalMs: number
   }
   readonly clickhouse: {
@@ -110,6 +114,9 @@ export interface ParsedRuntimeConfig {
   readonly cyclePollIntervalMs: number
   readonly authorityGenerationHash: string | undefined
   readonly configuredAlpaca: {
+    readonly provider: BrokerProvider
+    readonly environment: BrokerEnvironment
+    readonly baseUrl: string
     readonly accountId: string | undefined
     readonly key: Redacted.Redacted<string> | undefined
     readonly secret: Redacted.Redacted<string> | undefined
@@ -149,6 +156,10 @@ export type RuntimeConfigResolutionFailure =
     }
   | {
       readonly _tag: 'MissingAlpacaAuthorityGeneration'
+    }
+  | {
+      readonly _tag: 'InvalidBrokerConnection'
+      readonly cause: BrokerConnectionDecodeFailure
     }
   | {
       readonly _tag: 'PaperAuthorityRequiresAlpacaBinding'
@@ -253,6 +264,13 @@ const runtimeConfig = Config.all({
   unknownMutationThresholdMs: operationalThreshold('BAYN_UNKNOWN_MUTATION_THRESHOLD_MS', 300_000),
   cyclePollIntervalMs: operationalThreshold('BAYN_CYCLE_POLL_INTERVAL_MS', 30_000),
   authorityGenerationHash: Config.option(Config.schema(Sha256Schema, 'BAYN_AUTHORITY_GENERATION_HASH')),
+  brokerProvider: Config.schema(Schema.Enum(BrokerProvider), 'BAYN_BROKER_PROVIDER').pipe(
+    Config.withDefault(BrokerProvider.Alpaca),
+  ),
+  brokerEnvironment: Config.schema(BrokerEnvironmentSchema, 'BAYN_BROKER_ENVIRONMENT').pipe(
+    Config.withDefault(BrokerEnvironment.Sandbox),
+  ),
+  alpacaBaseUrl: nonEmptyString('BAYN_ALPACA_BASE_URL').pipe(Config.withDefault(alpacaSandboxBaseUrl)),
   alpacaAccountId: Config.option(nonEmptyString('BAYN_ALPACA_ACCOUNT_ID')),
   alpacaKey: Config.option(secretString('BAYN_ALPACA_KEY_ID')),
   alpacaSecret: Config.option(secretString('BAYN_ALPACA_SECRET_KEY')),
@@ -304,6 +322,9 @@ const runtimeConfig = Config.all({
       cyclePollIntervalMs: config.cyclePollIntervalMs,
       authorityGenerationHash: Option.getOrUndefined(config.authorityGenerationHash),
       configuredAlpaca: {
+        provider: config.brokerProvider,
+        environment: config.brokerEnvironment,
+        baseUrl: config.alpacaBaseUrl,
         accountId: Option.getOrUndefined(config.alpacaAccountId),
         key: Option.getOrUndefined(config.alpacaKey),
         secret: Option.getOrUndefined(config.alpacaSecret),
@@ -518,16 +539,34 @@ const resolveAlpacaBinding = (
   if (input.parsed.authorityGenerationHash === undefined) {
     return Result.fail({ _tag: 'MissingAlpacaAuthorityGeneration' })
   }
-  return Result.succeed({
-    ...input,
-    alpaca: {
-      ...input.alpacaCredentials,
-      authorityGenerationHash: input.parsed.authorityGenerationHash,
+  const authorityGenerationHash = input.parsed.authorityGenerationHash
+  return pipe(
+    decodeBrokerConnection({
+      provider: input.parsed.configuredAlpaca.provider,
+      environment: input.parsed.configuredAlpaca.environment,
+      baseUrl: input.parsed.configuredAlpaca.baseUrl,
+      expectedAccountId: input.alpacaCredentials.accountId,
+      key: input.alpacaCredentials.key,
+      secret: input.alpacaCredentials.secret,
       proxyUrl: input.parsed.configuredAlpaca.proxyUrl,
+      operationTimeoutMs: input.parsed.operationTimeoutMs,
       retryAttempts: input.parsed.configuredAlpaca.retryAttempts,
-      reconciliationIntervalMs: input.parsed.configuredAlpaca.reconciliationIntervalMs,
-    },
-  })
+    }),
+    Result.mapError(
+      (cause): RuntimeConfigResolutionFailure => ({
+        _tag: 'InvalidBrokerConnection',
+        cause,
+      }),
+    ),
+    Result.map((connection) => ({
+      ...input,
+      alpaca: {
+        ...connection,
+        authorityGenerationHash,
+        reconciliationIntervalMs: input.parsed.configuredAlpaca.reconciliationIntervalMs,
+      },
+    })),
+  )
 }
 
 const resolveConfiguredRuntimeMode = (
@@ -718,6 +757,11 @@ const presentRuntimeConfigFailure = (failure: RuntimeConfigResolutionFailure): R
       return {
         operation: 'authority-generation',
         message: 'Alpaca account binding requires an authority generation hash',
+      }
+    case 'InvalidBrokerConnection':
+      return {
+        operation: 'broker-connection',
+        message: renderBrokerConnectionDecodeFailure(failure.cause),
       }
     case 'PaperAuthorityRequiresAlpacaBinding':
       return {

--- a/services/bayn/src/db/evidence-store.integration.test.ts
+++ b/services/bayn/src/db/evidence-store.integration.test.ts
@@ -28,13 +28,16 @@ import {
 } from '../broker/alpaca-mutations'
 import {
   AssetClass,
+  BrokerProvider,
   OrderClass,
   OrderSide as BrokerOrderSide,
   OrderStatus,
   OrderType as BrokerOrderType,
   TimeInForce as BrokerTimeInForce,
+  alpacaSandboxBaseUrl,
 } from '../broker/alpaca'
 import { cancel, submit } from '../execution/coordinator'
+import { BrokerEnvironment } from '../execution/authority'
 import { WriterFence, WriterFenceLive, type WriterFenceService } from '../execution/writer-fence'
 import { canonicalHashV1 } from '../hash'
 import { buildLedgerPlan, Journal, type JournalService } from '../ledger'
@@ -729,11 +732,15 @@ const makePaperActivationConfig = (activation: PaperAuthorityGeneration): Runtim
       strategyParameterHash: activation.strategyParameterHash,
     },
     alpaca: {
-      accountId: activation.accountId,
+      provider: BrokerProvider.Alpaca,
+      environment: BrokerEnvironment.Sandbox,
+      baseUrl: alpacaSandboxBaseUrl,
+      expectedAccountId: activation.accountId,
       authorityGenerationHash: activation.generationHash,
       key: Redacted.make('unused'),
       secret: Redacted.make('unused'),
       proxyUrl: 'http://bayn-egress-proxy.invalid',
+      operationTimeoutMs: config.operationTimeoutMs,
       retryAttempts: 0,
       reconciliationIntervalMs: 30_000,
     },

--- a/services/bayn/src/db/paper-store.integration.test.ts
+++ b/services/bayn/src/db/paper-store.integration.test.ts
@@ -9,6 +9,7 @@ import { Cause, Deferred, Duration, Effect, Exit, Fiber, Layer, ManagedRuntime, 
 import type { RuntimeConfig } from '../config'
 import { makeStrategyProtocolHash } from '../contracts'
 import { operationalError } from '../errors'
+import { BrokerEnvironment } from '../execution/authority'
 import { WriterFence, WriterFenceError, WriterFenceLive, type WriterFenceService } from '../execution/writer-fence'
 import { canonicalHashV1 } from '../hash'
 import { hashLedgerPlanResult } from '../ledger-plan'
@@ -48,6 +49,7 @@ import {
   type PositionSnapshotInput,
   type ValuationInput,
 } from '../broker/observations'
+import { BrokerProvider, alpacaSandboxBaseUrl } from '../broker/alpaca'
 import { EvidenceStore, EvidenceStoreLive, PostgresClientLive } from './evidence-store'
 import { PaperStore, PaperStoreError, PaperStoreLive } from './paper-store'
 
@@ -655,11 +657,15 @@ const paperRuntimeConfig = (
     strategyParameterHash: activation.strategyParameterHash,
   },
   alpaca: {
-    accountId: activation.accountId,
+    provider: BrokerProvider.Alpaca,
+    environment: BrokerEnvironment.Sandbox,
+    baseUrl: alpacaSandboxBaseUrl,
+    expectedAccountId: activation.accountId,
     authorityGenerationHash: activation.generationHash,
     key: Redacted.make('unused'),
     secret: Redacted.make('unused'),
     proxyUrl: 'http://bayn-egress-proxy.invalid',
+    operationTimeoutMs: config.operationTimeoutMs,
     retryAttempts: 0,
     reconciliationIntervalMs: 30_000,
   },
@@ -1464,7 +1470,7 @@ describePostgres('paper accounting persistence', () => {
         ...validConfig,
         alpaca: {
           ...validAlpaca,
-          accountId: 'wrong-configured-paper-account',
+          expectedAccountId: 'wrong-configured-paper-account',
         },
       },
       { ...validConfig, qualificationRunId: hash('wrong-configured-qualification-run') },
@@ -1909,7 +1915,7 @@ describePostgres('paper accounting persistence', () => {
         ...validConfig,
         alpaca: {
           ...validAlpaca,
-          accountId: 'changed-replay-account',
+          expectedAccountId: 'changed-replay-account',
         },
       },
     )

--- a/services/bayn/src/db/paper-store/contract.ts
+++ b/services/bayn/src/db/paper-store/contract.ts
@@ -86,5 +86,5 @@ export type PaperStoreRuntimeConfig = Pick<
   RuntimeConfig,
   'build' | 'maximumAuthority' | 'qualificationRunId' | 'reconciliationStaleThresholdMs' | 'tigerBeetle'
 > & {
-  readonly alpaca?: Pick<NonNullable<RuntimeConfig['alpaca']>, 'accountId' | 'authorityGenerationHash'>
+  readonly alpaca?: Pick<NonNullable<RuntimeConfig['alpaca']>, 'expectedAccountId' | 'authorityGenerationHash'>
 }

--- a/services/bayn/src/db/paper-store/paper-authority.ts
+++ b/services/bayn/src/db/paper-store/paper-authority.ts
@@ -66,7 +66,7 @@ export const makePaperAuthorityInterpreter = (
             config.alpaca === undefined
               ? undefined
               : {
-                  accountId: config.alpaca.accountId,
+                  accountId: config.alpaca.expectedAccountId,
                   authorityGenerationHash: config.alpaca.authorityGenerationHash,
                 },
           qualificationRunId: config.qualificationRunId,

--- a/services/bayn/src/entrypoint.ts
+++ b/services/bayn/src/entrypoint.ts
@@ -4,7 +4,7 @@ import { Effect, flow, Layer, Match, pipe, Redacted, Result, Schema, Stdio, Stre
 
 import { autonomousObserveApplication, brokerlessApplication } from './app'
 import { riskBalancedTrendBehaviorHash } from './behavior'
-import { BrokerRead, live as AlpacaReadLive, scopedReadAdapterLayer, type BrokerReadShape } from './broker/alpaca'
+import { BrokerSession, live as AlpacaBrokerLive, type BrokerReadShape } from './broker/alpaca'
 import { verifyBehaviorHash, verifyParameterHash } from './build'
 import { loadConfig, type LoadedRuntimeConfig } from './config'
 import {
@@ -240,23 +240,9 @@ const databaseLayer = (config: LoadedRuntimeConfig) =>
     ),
   )
 
-const alpacaReadConfig = (config: LoadedRuntimeConfig, alpaca: AlpacaBinding) => ({
-  expectedAccountId: alpaca.accountId,
-  key: alpaca.key,
-  secret: alpaca.secret,
-  proxyUrl: alpaca.proxyUrl,
-  operationTimeoutMs: config.operationTimeoutMs,
-  retryAttempts: alpaca.retryAttempts,
-})
-
-const serviceBrokerReadLayer = (config: LoadedRuntimeConfig, alpaca: AlpacaBinding) =>
-  mapLayerError(AlpacaReadLive(alpacaReadConfig(config, alpaca)), (cause) =>
-    operationalError('config', 'alpaca', 'Alpaca paper account binding failed', cause),
-  )
-
-const discoveryBrokerReadLayer = (config: LoadedRuntimeConfig, alpaca: AlpacaBinding) =>
-  mapLayerError(scopedReadAdapterLayer(alpacaReadConfig(config, alpaca)), (cause) =>
-    operationalError('config', 'alpaca', 'Alpaca scoped read adapter construction failed', cause),
+const brokerSessionLayer = (alpaca: AlpacaBinding) =>
+  mapLayerError(AlpacaBrokerLive(alpaca), (cause) =>
+    operationalError('config', 'broker-session', 'Alpaca broker session acquisition failed', cause),
   )
 
 const serviceCoreLayers = (plan: RuntimeIdentity) => {
@@ -279,7 +265,7 @@ const brokerServiceLayers = (plan: RuntimePlanFor<'AutonomousObserveService'>) =
   const storage = Layer.merge(database, journal)
   return Layer.mergeAll(
     core,
-    serviceBrokerReadLayer(plan.config, plan.config.alpaca),
+    brokerSessionLayer(plan.config.alpaca),
     pipe(PaperStoreLive(plan.config), Layer.provide(storage)),
     pipe(WriterFenceLive, Layer.provide(database)),
     pipe(CycleStoreLive, Layer.provide(database)),
@@ -288,14 +274,14 @@ const brokerServiceLayers = (plan: RuntimePlanFor<'AutonomousObserveService'>) =
 
 const observeBroker = (plan: RuntimePlanFor<'AutonomousObserveService'>, read: BrokerReadShape) => ({
   read,
-  expectedAccountId: plan.config.alpaca.accountId,
+  expectedAccountId: plan.config.alpaca.expectedAccountId,
   executionEligible: false,
   executionDisabledReason: 'MAXIMUM_AUTHORITY_OBSERVE' as const,
 })
 
 const observeCycle = (plan: RuntimePlanFor<'AutonomousObserveService'>) =>
   makeObserveAutonomousCycleStartup({
-    accountId: plan.config.alpaca.accountId,
+    accountId: plan.config.alpaca.expectedAccountId,
     authorityGenerationHash: plan.config.alpaca.authorityGenerationHash,
     maximumAuthority: plan.config.maximumAuthority,
     pollIntervalMs: plan.config.cyclePollIntervalMs,
@@ -304,9 +290,9 @@ const observeCycle = (plan: RuntimePlanFor<'AutonomousObserveService'>) =>
 
 const runAutonomousObserveService = (plan: RuntimePlanFor<'AutonomousObserveService'>) =>
   pipe(
-    BrokerRead,
-    Effect.flatMap((read) =>
-      autonomousObserveApplication(plan.config, plan.strategy, observeBroker(plan, read), observeCycle(plan)),
+    BrokerSession,
+    Effect.flatMap((session) =>
+      autonomousObserveApplication(plan.config, plan.strategy, observeBroker(plan, session.read), observeCycle(plan)),
     ),
     Effect.provide(brokerServiceLayers(plan)),
   )
@@ -347,7 +333,7 @@ const discoveryLayers = (plan: RuntimePlanFor<'PaperCandidateDiscovery'>) => {
     postgres,
     pipe(CycleObservabilityLive, Layer.provide(postgres)),
     pipe(CycleStoreLive, Layer.provide(postgres)),
-    discoveryBrokerReadLayer(plan.config, plan.config.alpaca),
+    brokerSessionLayer(plan.config.alpaca),
   )
 }
 
@@ -360,7 +346,7 @@ const paperCandidateIdentity = (plan: RuntimePlanFor<'PaperCandidateDiscovery'>,
   strategy: plan.strategy.provenance.strategy,
   strategyProtocolHash: plan.strategyProtocolHash,
   qualificationRunId: plan.config.qualificationRunId,
-  accountId: plan.config.alpaca.accountId,
+  accountId: plan.config.alpaca.expectedAccountId,
   authorityGenerationHash: plan.config.alpaca.authorityGenerationHash,
   policyHash: riskPolicyHash,
 })
@@ -376,7 +362,7 @@ const discoverPaperCandidate = (plan: RuntimePlanFor<'PaperCandidateDiscovery'>,
 
 const runPaperCandidateDiscovery = (plan: RuntimePlanFor<'PaperCandidateDiscovery'>) =>
   pipe(
-    loadObserveRiskPolicy(plan.config.alpaca.accountId, plan.strategy.parameters.universe),
+    loadObserveRiskPolicy(plan.config.alpaca.expectedAccountId, plan.strategy.parameters.universe),
     Effect.mapError((cause) =>
       operationalError(
         'config',

--- a/services/bayn/src/paper-candidate-discovery.test.ts
+++ b/services/bayn/src/paper-candidate-discovery.test.ts
@@ -27,12 +27,15 @@ import {
   AssetExchange,
   AssetStatus,
   BrokerRead,
-  make as makeAlpacaRead,
+  BrokerProvider,
+  BrokerSession,
+  alpacaSandboxBaseUrl,
+  decodeBrokerConnection,
+  layer as alpacaBrokerLayer,
   type AccountConfigurationObservation,
   type AssetObservation,
   type BrokerReadShape,
   type ReadEvidence,
-  type ReadOptions,
   type ReadResult,
 } from './broker/alpaca'
 import { makeStrategyProtocolHash, type RuntimeProvenance } from './contracts'
@@ -58,6 +61,7 @@ import { PaperCandidateIneligibility as PaperCandidateIneligibilityImplementatio
 import { discoverPaperCandidates as discoverPaperCandidatesImplementation } from './paper-candidate-discovery/program'
 import { validatePaperCandidateDiscoverySnapshot as validateSnapshotImplementation } from './paper-candidate-discovery/snapshot-validation'
 import { Gate, Reason } from './risk'
+import { BrokerEnvironment } from './execution/authority'
 import type { ObserveShadowDecisionDocument } from './shadow-decision-contract'
 import { TargetPlanStatus } from './target-planner'
 
@@ -719,17 +723,22 @@ describe('paper candidate discovery', () => {
     expect(state.assetSymbols).toEqual([])
   })
 
-  test('constructs the read adapter without preflight and receipts only bounded DISCOVER GETs', async () => {
+  test('acquires one verified broker session before bounded DISCOVER GETs', async () => {
     const state = control()
     const requests: Array<{ method: string; path: string }> = []
-    const readOptions: ReadOptions = {
-      expectedAccountId: accountId,
-      key: Redacted.make('paper-key'),
-      secret: Redacted.make('paper-secret'),
-      proxyUrl: 'http://bayn-egress-proxy:3128',
-      operationTimeoutMs: 1_000,
-      retryAttempts: 0,
-    }
+    const connection = Result.getOrThrow(
+      decodeBrokerConnection({
+        provider: BrokerProvider.Alpaca,
+        environment: BrokerEnvironment.Sandbox,
+        baseUrl: alpacaSandboxBaseUrl,
+        expectedAccountId: accountId,
+        key: Redacted.make('paper-key'),
+        secret: Redacted.make('paper-secret'),
+        proxyUrl: 'http://bayn-egress-proxy:3128',
+        operationTimeoutMs: 1_000,
+        retryAttempts: 0,
+      }),
+    )
     const client = HttpClient.make((request, url) => {
       requests.push({ method: request.method, path: url.pathname })
       let body: unknown
@@ -748,6 +757,23 @@ describe('paper candidate discovery', () => {
         }
       } else if (url.pathname === '/v2/account/configurations') {
         body = { fractional_trading: true }
+      } else if (
+        url.pathname === '/v2/positions' ||
+        url.pathname === '/v2/orders' ||
+        url.pathname === '/v2/account/activities/FILL' ||
+        url.pathname === '/v2/calendar'
+      ) {
+        body = []
+      } else if (url.pathname.startsWith('/v2/orders')) {
+        return Effect.succeed(
+          HttpClientResponse.fromWeb(
+            request,
+            new Response(JSON.stringify({ code: 40410000, message: 'order not found' }), {
+              status: 404,
+              headers: { 'content-type': 'application/json', 'x-request-id': `request-${requests.length}` },
+            }),
+          ),
+        )
       } else {
         const symbol = decodeURIComponent(url.pathname.slice('/v2/assets/'.length))
         body = {
@@ -776,22 +802,22 @@ describe('paper candidate discovery', () => {
       Effect.scoped(
         Effect.gen(function* () {
           const brokerContext = yield* Layer.build(
-            Layer.effect(BrokerRead, makeAlpacaRead(readOptions)).pipe(
-              Layer.provide(Layer.succeed(HttpClient.HttpClient, client)),
-            ),
+            alpacaBrokerLayer(connection).pipe(Layer.provide(Layer.succeed(HttpClient.HttpClient, client))),
           )
-          expect(requests).toEqual([])
+          const session = Context.get(brokerContext, BrokerSession)
+          expect(session.preflight.accountId).toBe(accountId)
+          expect(requests).toHaveLength(9)
           return yield* program(state, fixture(), Context.get(brokerContext, BrokerRead))
         }),
       ),
     )
 
     expect(receipt.candidateFacts.candidates).toHaveLength(symbols.length)
-    expect(requests.slice(0, 2)).toEqual([
+    expect(requests.slice(9, 11)).toEqual([
       { method: 'GET', path: '/v2/account' },
       { method: 'GET', path: '/v2/account/configurations' },
     ])
-    expect(requests.slice(2).sort((left, right) => left.path.localeCompare(right.path))).toEqual([
+    expect(requests.slice(11).sort((left, right) => left.path.localeCompare(right.path))).toEqual([
       { method: 'GET', path: '/v2/assets/SPY' },
       { method: 'GET', path: '/v2/assets/VNQ' },
     ])


### PR DESCRIPTION
## Summary

- Add one immutable, typed `BrokerConnection` decoder for Alpaca provider, broker environment, approved base URL, redacted credentials, proxy, timeout/retry policy, and expected account identity.
- Acquire one scoped `BrokerSession` that publishes the exact preflighted read capability and fails closed with tagged connection, account, permission, or read-surface acquisition errors.
- Validate active/unblocked account state and fractional-trading permission before any broader read preflight, and route both autonomous service and paper-candidate discovery through the same verified session.
- Remove the global Alpaca base-URL assumption, the duplicate runtime read-option decoder, and the unpreflighted discovery adapter without changing execution/capital authority or performing broker mutations.

## Related Issues

None

## Testing

- `bun test src/broker/connection.test.ts src/broker/alpaca.test.ts src/config.test.ts src/paper-candidate-discovery.test.ts` — 150 passed, 1 PostgreSQL-environment skip, 0 failed.
- `bun run --filter @proompteng/bayn test` — 793 passed, 121 PostgreSQL-environment skips, 0 failed.
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:effect`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn build`
- PostgreSQL integration suites require `BAYN_TEST_POSTGRES_URL`; the local agents-shell runner has no PostgreSQL/container runtime, so the repository PostgreSQL 18 CI job is the authoritative integration run for this PR.

## Breaking Changes

None. The new broker provider/environment/base-URL settings default compatibly to Alpaca sandbox; no durable wire/database identifiers, migrations, GitOps authority, or capital settings changed.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] Documentation/release notes are not required; the referenced architecture-audit document is absent from current repository history and is not recreated in this source change.
