### PR TITLE
refactor(bayn): bind Alpaca reads to broker connection

### DIFF
--- a/services/bayn/src/broker/alpaca/http.ts
+++ b/services/bayn/src/broker/alpaca/http.ts
@@ -269,7 +269,7 @@ export const make = (connection: BrokerConnection): Effect.Effect<BrokerReadShap
         Effect.withSpan('broker.read', { attributes: { 'broker.system': 'alpaca', 'broker.operation': operation } }),
       )
 
-    const account = readJson('account', accountUrl(connection.baseUrl), decodeAccount).pipe(
+    const account = readJson('account', accountUrl(connection), decodeAccount).pipe(
       Effect.flatMap((result) => {
         const normalized = normalizeAccountResult(
           result.value,
@@ -297,7 +297,7 @@ export const make = (connection: BrokerConnection): Effect.Effect<BrokerReadShap
 
     const accountConfiguration = readJson(
       'account-configuration',
-      accountConfigurationUrl(connection.baseUrl),
+      accountConfigurationUrl(connection),
       decodeAccountConfiguration,
     ).pipe(
       Effect.flatMap((result) =>
@@ -309,7 +309,7 @@ export const make = (connection: BrokerConnection): Effect.Effect<BrokerReadShap
       ),
     )
 
-    const positions = readJson('positions', positionsUrl(connection.baseUrl), decodePositions).pipe(
+    const positions = readJson('positions', positionsUrl(connection), decodePositions).pipe(
       Effect.flatMap((result) =>
         normalizeRead(
           'positions',
@@ -322,7 +322,7 @@ export const make = (connection: BrokerConnection): Effect.Effect<BrokerReadShap
     const assetBySymbol = (symbol: string) =>
       decodeInput('asset-by-symbol', decodeAssetSymbol, symbol, 'invalid Alpaca asset symbol').pipe(
         Effect.flatMap((decoded) =>
-          readJson('asset-by-symbol', assetBySymbolUrl(connection.baseUrl, decoded), decodeAsset).pipe(
+          readJson('asset-by-symbol', assetBySymbolUrl(connection, decoded), decodeAsset).pipe(
             Effect.map((result) => ({ decoded, result })),
           ),
         ),
@@ -338,7 +338,7 @@ export const make = (connection: BrokerConnection): Effect.Effect<BrokerReadShap
     const marketCalendar = (query: MarketCalendarQuery) =>
       decodeInput('market-calendar', decodeMarketCalendarQuery, query, 'invalid Alpaca market calendar query').pipe(
         Effect.flatMap((decoded) =>
-          readJson('market-calendar', marketCalendarUrl(connection.baseUrl, decoded), decodeMarketCalendar).pipe(
+          readJson('market-calendar', marketCalendarUrl(connection, decoded), decodeMarketCalendar).pipe(
             Effect.map((result) => ({ decoded, result })),
           ),
         ),
@@ -349,7 +349,7 @@ export const make = (connection: BrokerConnection): Effect.Effect<BrokerReadShap
 
     const orders = (query: OrdersQuery = {}) =>
       decodeInput('orders', decodeOrdersQuery, query, 'invalid Alpaca orders query').pipe(
-        Effect.flatMap((decoded) => readJson('orders', ordersUrl(connection.baseUrl, decoded), decodeOrders)),
+        Effect.flatMap((decoded) => readJson('orders', ordersUrl(connection, decoded), decodeOrders)),
         Effect.flatMap((result) =>
           normalizeRead(
             'orders',
@@ -361,7 +361,7 @@ export const make = (connection: BrokerConnection): Effect.Effect<BrokerReadShap
 
     const orderById = (orderId: string) =>
       decodeInput('order-by-id', decodeOrderId, orderId, 'invalid Alpaca order ID').pipe(
-        Effect.flatMap((decoded) => readJson('order-by-id', orderByIdUrl(connection.baseUrl, decoded), decodeOrder)),
+        Effect.flatMap((decoded) => readJson('order-by-id', orderByIdUrl(connection, decoded), decodeOrder)),
         Effect.flatMap((result) =>
           normalizeRead(
             'order-by-id',
@@ -379,7 +379,7 @@ export const make = (connection: BrokerConnection): Effect.Effect<BrokerReadShap
         'invalid Alpaca client order ID',
       ).pipe(
         Effect.flatMap((decoded) =>
-          readJson('order-by-client-id', orderByClientIdUrl(connection.baseUrl, decoded), decodeOrder),
+          readJson('order-by-client-id', orderByClientIdUrl(connection, decoded), decodeOrder),
         ),
         Effect.flatMap((result) =>
           normalizeRead(
@@ -393,7 +393,7 @@ export const make = (connection: BrokerConnection): Effect.Effect<BrokerReadShap
     const fillActivities = (query: FillActivitiesQuery = {}) =>
       decodeInput('fill-activities', decodeFillActivitiesQuery, query, 'invalid Alpaca fill activities query').pipe(
         Effect.flatMap((decoded) => {
-          const request = fillActivitiesRequest(connection.baseUrl, decoded)
+          const request = fillActivitiesRequest(connection, decoded)
           return readJson('fill-activities', request.url, decodeFillActivities).pipe(
             Effect.map((result) => ({ result, pageSize: request.pageSize })),
           )

--- a/services/bayn/src/broker/alpaca/requests.test.ts
+++ b/services/bayn/src/broker/alpaca/requests.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from 'bun:test'
+
+import { Redacted, Result } from 'effect'
+
+import { BrokerEnvironment } from '../../execution/authority'
+import { BrokerProvider, alpacaSandboxBaseUrl, decodeBrokerConnection } from '../connection'
+import { OrderCollection, OrderSide, SortDirection } from './model'
+import {
+  accountConfigurationUrl,
+  accountUrl,
+  assetBySymbolUrl,
+  fillActivitiesRequest,
+  marketCalendarUrl,
+  orderByClientIdUrl,
+  orderByIdUrl,
+  ordersUrl,
+  positionsUrl,
+} from './requests'
+
+const connection = Result.getOrThrow(
+  decodeBrokerConnection({
+    provider: BrokerProvider.Alpaca,
+    environment: BrokerEnvironment.Sandbox,
+    baseUrl: alpacaSandboxBaseUrl,
+    expectedAccountId: 'e6fe16f3-64a4-4921-8928-cadf02f92f98',
+    key: Redacted.make('key'),
+    secret: Redacted.make('secret'),
+    proxyUrl: 'http://proxy.test:3128',
+    operationTimeoutMs: 30_000,
+    retryAttempts: 2,
+  }),
+)
+
+describe('Alpaca read request builders', () => {
+  test('binds every fixed read endpoint to the verified connection', () => {
+    expect(accountUrl(connection).toString()).toBe(`${alpacaSandboxBaseUrl}/v2/account`)
+    expect(accountConfigurationUrl(connection).toString()).toBe(`${alpacaSandboxBaseUrl}/v2/account/configurations`)
+    expect(positionsUrl(connection).toString()).toBe(`${alpacaSandboxBaseUrl}/v2/positions`)
+    expect(assetBySymbolUrl(connection, 'BRK/B').toString()).toBe(`${alpacaSandboxBaseUrl}/v2/assets/BRK%2FB`)
+    expect(orderByIdUrl(connection, 'order/id').toString()).toBe(`${alpacaSandboxBaseUrl}/v2/orders/order%2Fid`)
+    expect(orderByClientIdUrl(connection, 'client/order').toString()).toBe(
+      `${alpacaSandboxBaseUrl}/v2/orders:by_client_order_id?client_order_id=client%2Forder`,
+    )
+  })
+
+  test('constructs ordered, encoded collection and calendar queries from decoded values', () => {
+    expect(
+      ordersUrl(connection, {
+        status: OrderCollection.All,
+        limit: 25,
+        after: '2026-07-01T00:00:00Z',
+        until: '2026-07-02T00:00:00Z',
+        direction: SortDirection.Ascending,
+        side: OrderSide.Buy,
+        symbols: ['AAPL', 'BRK/B'],
+      }).toString(),
+    ).toBe(
+      `${alpacaSandboxBaseUrl}/v2/orders?status=all&limit=25&after=2026-07-01T00%3A00%3A00Z&until=2026-07-02T00%3A00%3A00Z&direction=asc&side=buy&symbols=AAPL%2CBRK%2FB`,
+    )
+    expect(marketCalendarUrl(connection, { start: '2026-07-01', end: '2026-07-03' }).toString()).toBe(
+      `${alpacaSandboxBaseUrl}/v2/calendar?start=2026-07-01&end=2026-07-03&date_type=TRADING`,
+    )
+  })
+
+  test('preserves fill pagination metadata while binding the verified endpoint', () => {
+    const request = fillActivitiesRequest(connection, {
+      date: '2026-07-01',
+      after: '2026-07-01T00:00:00Z',
+      until: '2026-07-02T00:00:00Z',
+      direction: SortDirection.Descending,
+      pageSize: 17,
+      pageToken: 'cursor::order',
+    })
+
+    expect(request.pageSize).toBe(17)
+    expect(request.url.toString()).toBe(
+      `${alpacaSandboxBaseUrl}/v2/account/activities/FILL?date=2026-07-01&after=2026-07-01T00%3A00%3A00Z&until=2026-07-02T00%3A00%3A00Z&direction=desc&page_size=17&page_token=cursor%3A%3Aorder`,
+    )
+  })
+})

--- a/services/bayn/src/broker/alpaca/requests.ts
+++ b/services/bayn/src/broker/alpaca/requests.ts
@@ -1,5 +1,6 @@
 import { Result } from 'effect'
 
+import type { BrokerConnection } from '../connection'
 import { contractFailure, type BrokerReadContractFailure } from './failures'
 import {
   ResponseHeadersSchema,
@@ -29,26 +30,26 @@ export const assetRequestMaterial = (requestedSymbol: string) => ({
   requestedSymbol,
 })
 
-export const accountUrl = (baseUrl: string): URL => new URL('/v2/account', baseUrl)
+export const accountUrl = (connection: BrokerConnection): URL => new URL('/v2/account', connection.baseUrl)
 
-export const accountConfigurationUrl = (baseUrl: string): URL =>
-  new URL(accountConfigurationRequestMaterial.path, baseUrl)
+export const accountConfigurationUrl = (connection: BrokerConnection): URL =>
+  new URL(accountConfigurationRequestMaterial.path, connection.baseUrl)
 
-export const positionsUrl = (baseUrl: string): URL => new URL('/v2/positions', baseUrl)
+export const positionsUrl = (connection: BrokerConnection): URL => new URL('/v2/positions', connection.baseUrl)
 
-export const assetBySymbolUrl = (baseUrl: string, requestedSymbol: string): URL =>
-  new URL(assetRequestMaterial(requestedSymbol).path, baseUrl)
+export const assetBySymbolUrl = (connection: BrokerConnection, requestedSymbol: string): URL =>
+  new URL(assetRequestMaterial(requestedSymbol).path, connection.baseUrl)
 
-export const marketCalendarUrl = (baseUrl: string, query: MarketCalendarQuery): URL => {
-  const url = new URL('/v2/calendar', baseUrl)
+export const marketCalendarUrl = (connection: BrokerConnection, query: MarketCalendarQuery): URL => {
+  const url = new URL('/v2/calendar', connection.baseUrl)
   url.searchParams.set('start', query.start)
   url.searchParams.set('end', query.end)
   url.searchParams.set('date_type', 'TRADING')
   return url
 }
 
-export const ordersUrl = (baseUrl: string, query: OrdersQuery): URL => {
-  const url = new URL('/v2/orders', baseUrl)
+export const ordersUrl = (connection: BrokerConnection, query: OrdersQuery): URL => {
+  const url = new URL('/v2/orders', connection.baseUrl)
   if (query.status !== undefined) url.searchParams.set('status', query.status)
   if (query.limit !== undefined) url.searchParams.set('limit', String(query.limit))
   if (query.after !== undefined) url.searchParams.set('after', query.after)
@@ -59,11 +60,11 @@ export const ordersUrl = (baseUrl: string, query: OrdersQuery): URL => {
   return url
 }
 
-export const orderByIdUrl = (baseUrl: string, orderId: string): URL =>
-  new URL(`/v2/orders/${encodeURIComponent(orderId)}`, baseUrl)
+export const orderByIdUrl = (connection: BrokerConnection, orderId: string): URL =>
+  new URL(`/v2/orders/${encodeURIComponent(orderId)}`, connection.baseUrl)
 
-export const orderByClientIdUrl = (baseUrl: string, clientOrderId: string): URL => {
-  const url = new URL('/v2/orders:by_client_order_id', baseUrl)
+export const orderByClientIdUrl = (connection: BrokerConnection, clientOrderId: string): URL => {
+  const url = new URL('/v2/orders:by_client_order_id', connection.baseUrl)
   url.searchParams.set('client_order_id', clientOrderId)
   return url
 }
@@ -73,8 +74,11 @@ export interface FillActivitiesRequest {
   readonly pageSize: number
 }
 
-export const fillActivitiesRequest = (baseUrl: string, query: FillActivitiesQuery): FillActivitiesRequest => {
-  const url = new URL('/v2/account/activities/FILL', baseUrl)
+export const fillActivitiesRequest = (
+  connection: BrokerConnection,
+  query: FillActivitiesQuery,
+): FillActivitiesRequest => {
+  const url = new URL('/v2/account/activities/FILL', connection.baseUrl)
   const pageSize = query.pageSize ?? defaultFillActivitiesPageSize
   if (query.date !== undefined) url.searchParams.set('date', query.date)
   if (query.after !== undefined) url.searchParams.set('after', query.after)


### PR DESCRIPTION
## Summary

- Bind every Alpaca read request builder to the already decoded `BrokerConnection` instead of accepting an unverified base URL string.
- Keep the existing verified `BrokerSession`, typed `BrokerReadError`, response codecs, bounded retries, deadlines, and scoped proxy lifecycle unchanged.
- Add pure characterization coverage for account, configuration, positions, assets, orders, fills, and market-calendar request construction.
- Remove all nine raw `connection.baseUrl` dependency edges from the read interpreter without changing durable identifiers or broker authority.

## Related Issues

None

## Testing

- `bun test services/bayn/src/broker/alpaca/requests.test.ts services/bayn/src/broker/alpaca.test.ts` — 43 passed, 0 failed, 203 assertions.
- `bun run --filter @proompteng/bayn test` — 796 passed, 121 skipped, 0 failed, 4,497 assertions across 917 tests / 67 files.
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint` — 0 warnings, 0 errors.
- `bun run --filter @proompteng/bayn lint:oxlint:type` — 0 warnings, 0 errors.
- `bun run --filter @proompteng/bayn build` — 626 modules, 4.50 MB bundle.

## Breaking Changes

None. No broker mutation, capital, deployment, GitOps, wire, or database authority changes.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is handled above.
- [x] Documentation and release notes are not required for this internal boundary refactor.
