### PR TITLE
refactor(bayn): unify Alpaca mutation and recovery

### DIFF
--- a/services/bayn/src/broker/alpaca-mutations.test.ts
+++ b/services/bayn/src/broker/alpaca-mutations.test.ts
@@ -5,43 +5,119 @@ import { TestClock } from 'effect/testing'
 import { HttpClient, HttpClientError, HttpClientResponse } from 'effect/unstable/http'
 
 import { canonicalHashV1 } from '../hash'
-import { Authority, IntentState, MutationOutcome, OrderSide, OrderType, TimeInForce, type Intent } from '../paper'
+import {
+  BrokerEnvironment,
+  ExecutionAccess,
+  disabledCapitalAccess,
+  enabledCapitalAccess,
+  makeExecutionAuthority,
+  type ExecutionAuthority,
+} from '../execution/authority'
+import { IntentState, MutationOutcome, OrderSide, OrderType, TimeInForce, type Intent } from '../paper'
 import {
   BrokerMutationError,
   MutationFailure,
   MutationOperation,
+  authorizeMutationAccess,
   makeMutation,
   orderRequestBody,
   submitBody,
   type BrokerMutationShape,
-  type MutationOptions,
 } from './alpaca-mutations'
-import { OrderStatus } from './alpaca'
+import {
+  AccountStatus,
+  BrokerProvider,
+  OrderStatus,
+  alpacaSandboxBaseUrl,
+  decodeBrokerConnection,
+  type BrokerReadShape,
+  type BrokerSessionShape,
+  type ReadPreflight,
+} from './alpaca'
+import { unusedAssetBySymbol, unusedMarketCalendar } from './alpaca-test-support'
+import { decodeOrder } from './alpaca/model'
+import { normalizeOrderResult } from './alpaca/normalizers'
 
 const accountId = 'e6fe16f3-64a4-4921-8928-cadf02f92f98'
 const orderId = '61e69015-8549-4bfd-b9c3-01e75843f47d'
 const assetId = 'b0b6dd9d-8b9b-48a9-ba46-b9d54906e415'
 
-const accountResponse = {
-  id: accountId,
-  account_number: '010203ABCD',
-  status: 'ACTIVE',
-  currency: 'USD',
-  cash: '100000',
-  equity: '100000',
-  buying_power: '200000',
-  account_blocked: false,
-  trading_blocked: false,
-  trade_suspended_by_user: false,
+const connection = Result.getOrThrow(
+  decodeBrokerConnection({
+    provider: BrokerProvider.Alpaca,
+    environment: BrokerEnvironment.Sandbox,
+    baseUrl: alpacaSandboxBaseUrl,
+    expectedAccountId: accountId,
+    key: Redacted.make('paper-key'),
+    secret: Redacted.make('paper-secret'),
+    proxyUrl: 'http://bayn-egress-proxy:3128',
+    operationTimeoutMs: 1_000,
+    retryAttempts: 0,
+  }),
+)
+
+const submitAuthority = makeExecutionAuthority(
+  BrokerEnvironment.Sandbox,
+  ExecutionAccess.SubmitOrders,
+  disabledCapitalAccess,
+)
+
+const preflight: ReadPreflight = {
+  provider: BrokerProvider.Alpaca,
+  environment: BrokerEnvironment.Sandbox,
+  baseUrl: alpacaSandboxBaseUrl,
+  accountId,
+  accountStatus: AccountStatus.Active,
+  accountBlocked: false,
+  tradingBlocked: false,
+  tradeSuspendedByUser: false,
+  accountHash: '1'.repeat(64),
+  fractionalTrading: true,
+  accountConfigurationHash: '2'.repeat(64),
+  positionCount: 0,
+  positionsHash: '3'.repeat(64),
+  openOrderCount: 0,
+  recentOrderCount: 0,
+  ordersHash: '4'.repeat(64),
+  fillCount: 0,
+  fillsHash: '5'.repeat(64),
+  marketCalendarSessionCount: 1,
+  marketCalendarHash: '6'.repeat(64),
+  orderById: 'NOT_FOUND',
+  orderByClientId: 'NOT_FOUND',
 }
 
-const options: MutationOptions = {
-  expectedAccountId: accountId,
-  maximumAuthority: Authority.Paper,
-  key: Redacted.make('paper-key'),
-  secret: Redacted.make('paper-secret'),
-  proxyUrl: 'http://bayn-egress-proxy:3128',
-  operationTimeoutMs: 1_000,
+const unexpectedRead = <A>(label: string): Effect.Effect<A> => Effect.die(new Error(`unexpected ${label}`))
+
+const verifiedSession = (
+  options: {
+    readonly operationTimeoutMs?: number
+    readonly read?: Partial<BrokerReadShape>
+  } = {},
+): BrokerSessionShape => ({
+  connection: {
+    ...connection,
+    operationTimeoutMs: options.operationTimeoutMs ?? connection.operationTimeoutMs,
+  },
+  read: {
+    account: unexpectedRead('account read'),
+    accountConfiguration: unexpectedRead('account configuration read'),
+    assetBySymbol: unusedAssetBySymbol,
+    positions: unexpectedRead('positions read'),
+    orders: () => unexpectedRead('orders read'),
+    orderById: () => unexpectedRead('order-by-id read'),
+    orderByClientId: () => unexpectedRead('order-by-client-id read'),
+    fillActivities: () => unexpectedRead('fill activities read'),
+    marketCalendar: unusedMarketCalendar,
+    ...options.read,
+  },
+  preflight,
+})
+
+interface MutationHarnessOptions {
+  readonly authority?: ExecutionAuthority
+  readonly operationTimeoutMs?: number
+  readonly session?: BrokerSessionShape
 }
 
 const intent: Intent = {
@@ -119,19 +195,15 @@ const response = (
     }),
   )
 
-const withVerifiedAccount = (client: HttpClient.HttpClient): HttpClient.HttpClient =>
-  HttpClient.make((request, url) =>
-    url.pathname === '/v2/account' ? Effect.succeed(response(request, accountResponse)) : client.execute(request),
-  )
-
 const withMutation = <A, E>(
   client: HttpClient.HttpClient,
   use: (mutation: BrokerMutationShape) => Effect.Effect<A, E>,
-  mutationOptions: MutationOptions = options,
+  options: MutationHarnessOptions = {},
 ): Effect.Effect<A, BrokerMutationError | E> => {
-  return makeMutation(mutationOptions).pipe(
+  const session = options.session ?? verifiedSession({ operationTimeoutMs: options.operationTimeoutMs })
+  return makeMutation(session, options.authority ?? submitAuthority).pipe(
     Effect.flatMap(use),
-    Effect.provideService(HttpClient.HttpClient, withVerifiedAccount(client)),
+    Effect.provideService(HttpClient.HttpClient, client),
   )
 }
 
@@ -167,48 +239,119 @@ describe('Alpaca paper mutations', () => {
     })
   })
 
-  test('refuses to construct mutation capability below explicit PAPER authority', async () => {
+  test('refuses to construct mutation capability without explicit submit-orders access', async () => {
     let requests = 0
     const client = HttpClient.make(() => {
       requests += 1
-      return Effect.die(new Error('OBSERVE must not make a broker request through the mutation constructor'))
+      return Effect.die(new Error('read-only access must not make a broker mutation request'))
     })
+    const readOnly = makeExecutionAuthority(BrokerEnvironment.Sandbox, ExecutionAccess.ReadOnly, disabledCapitalAccess)
 
     const failure = await Effect.runPromise(
-      Effect.flip(
-        makeMutation({ ...options, maximumAuthority: Authority.Observe }).pipe(
-          Effect.provideService(HttpClient.HttpClient, client),
-        ),
-      ),
+      Effect.flip(makeMutation(verifiedSession(), readOnly).pipe(Effect.provideService(HttpClient.HttpClient, client))),
     )
 
     expect(failure).toMatchObject({
       operation: MutationOperation.Submit,
       failure: MutationFailure.Configuration,
       outcome: MutationOutcome.Known,
-      message: 'Alpaca mutation capability requires explicit PAPER maximum authority',
+      message: 'Alpaca mutation capability requires explicit submit-orders execution access',
     })
     expect(requests).toBe(0)
   })
 
-  test('refuses to expose mutation capability when the credentials resolve a different account', async () => {
+  test('gates execution access independently from broker environment and capital access', () => {
+    for (const environment of [BrokerEnvironment.Sandbox, BrokerEnvironment.Live]) {
+      for (const capitalAccess of [disabledCapitalAccess, enabledCapitalAccess('8'.repeat(64))]) {
+        const readOnly = makeExecutionAuthority(environment, ExecutionAccess.ReadOnly, capitalAccess)
+        const submitOrders = makeExecutionAuthority(environment, ExecutionAccess.SubmitOrders, capitalAccess)
+        expect(Result.isFailure(authorizeMutationAccess(readOnly))).toBe(true)
+        expect(authorizeMutationAccess(submitOrders)).toEqual(Result.succeed(ExecutionAccess.SubmitOrders))
+      }
+    }
+  })
+
+  test('refuses authority and verified-session environment mismatch without broker I/O', async () => {
     let mutationCalls = 0
     const client = HttpClient.make(() => {
       mutationCalls += 1
-      return Effect.die(new Error('mutation request must not run'))
+      return Effect.die(new Error('environment mismatch must not make a mutation request'))
     })
-    const wrongAccount = '40b22fc4-23bc-446c-bf07-bea43b5d6c35'
+    const liveAuthority = makeExecutionAuthority(
+      BrokerEnvironment.Live,
+      ExecutionAccess.SubmitOrders,
+      disabledCapitalAccess,
+    )
 
     const failure = await Effect.runPromise(
-      Effect.flip(withMutation(client, () => Effect.void, { ...options, expectedAccountId: wrongAccount })),
+      Effect.flip(withMutation(client, () => Effect.void, { authority: liveAuthority })),
     )
 
     expect(failure).toMatchObject({
       operation: MutationOperation.Submit,
       failure: MutationFailure.Configuration,
       outcome: MutationOutcome.Known,
+      message: 'Alpaca mutation authority environment does not match the verified broker session',
     })
     expect(mutationCalls).toBe(0)
+  })
+
+  test('refuses a structurally mismatched verified session before broker I/O', async () => {
+    let mutationCalls = 0
+    const client = HttpClient.make(() => {
+      mutationCalls += 1
+      return Effect.die(new Error('session binding mismatch must not make a mutation request'))
+    })
+    const session: BrokerSessionShape = {
+      ...verifiedSession(),
+      preflight: {
+        ...preflight,
+        accountId: '40b22fc4-23bc-446c-bf07-bea43b5d6c35',
+      },
+    }
+
+    const failure = await Effect.runPromise(Effect.flip(withMutation(client, () => Effect.void, { session })))
+
+    expect(failure).toMatchObject({
+      operation: MutationOperation.Submit,
+      failure: MutationFailure.Configuration,
+      outcome: MutationOutcome.Known,
+      message: 'Alpaca mutation capability requires an exact verified broker session binding',
+    })
+    expect(mutationCalls).toBe(0)
+  })
+
+  test('delegates durable recovery lookups to the exact verified session read adapter', async () => {
+    const lookups: string[] = []
+    const readResult = {
+      value: Result.getOrThrow(
+        normalizeOrderResult(Result.getOrThrow(decodeOrder(orderResponse)), accountId, intent.createdAt),
+      ),
+      evidence: { requestId: 'lookup', status: 200, contentHash: '7'.repeat(64), observedAt: intent.createdAt },
+    }
+    const session = verifiedSession({
+      read: {
+        orderById: (value) => {
+          lookups.push(`id:${value}`)
+          return Effect.succeed(readResult)
+        },
+        orderByClientId: (value) => {
+          lookups.push(`client:${value}`)
+          return Effect.succeed(readResult)
+        },
+      },
+    })
+    const client = HttpClient.make(() => Effect.die(new Error('lookup delegation must not use mutation HTTP I/O')))
+
+    await Effect.runPromise(
+      withMutation(
+        client,
+        (mutation) => Effect.all([mutation.orderById(orderId), mutation.orderByClientId(intent.clientOrderId)]),
+        { session },
+      ),
+    )
+
+    expect(lookups).toEqual([`id:${orderId}`, `client:${intent.clientOrderId}`])
   })
 
   test('submits the exact IO_STARTED intent once and verifies the accepted order', async () => {
@@ -299,7 +442,7 @@ describe('Alpaca paper mutations', () => {
           releaseBody()
           return yield* Fiber.join(fiber)
         }),
-      { ...options, operationTimeoutMs: 5_000 },
+      { operationTimeoutMs: 5_000 },
     ).pipe(Effect.provide(TestClock.layer()))
 
     const receipt = await Effect.runPromise(program)
@@ -420,7 +563,7 @@ describe('Alpaca paper mutations', () => {
       )
     })
 
-    const program = makeMutation({ ...options, operationTimeoutMs: 10 }).pipe(
+    const program = makeMutation(verifiedSession({ operationTimeoutMs: 10 }), submitAuthority).pipe(
       Effect.flatMap((mutation) =>
         Effect.gen(function* () {
           const fiber = yield* Effect.flip(mutation.submit(intent)).pipe(Effect.forkChild)
@@ -429,7 +572,7 @@ describe('Alpaca paper mutations', () => {
           return yield* Fiber.join(fiber)
         }),
       ),
-      Effect.provideService(HttpClient.HttpClient, withVerifiedAccount(client)),
+      Effect.provideService(HttpClient.HttpClient, client),
       Effect.provide(TestClock.layer()),
     )
 
@@ -480,7 +623,7 @@ describe('Alpaca paper mutations', () => {
       )
     })
 
-    const program = makeMutation({ ...options, operationTimeoutMs: 10 }).pipe(
+    const program = makeMutation(verifiedSession({ operationTimeoutMs: 10 }), submitAuthority).pipe(
       Effect.flatMap((mutation) =>
         Effect.gen(function* () {
           const fiber = yield* Effect.flip(mutation.submit(intent)).pipe(Effect.forkChild)
@@ -489,7 +632,7 @@ describe('Alpaca paper mutations', () => {
           return yield* Fiber.join(fiber)
         }),
       ),
-      Effect.provideService(HttpClient.HttpClient, withVerifiedAccount(client)),
+      Effect.provideService(HttpClient.HttpClient, client),
       Effect.provide(TestClock.layer()),
     )
 
@@ -515,8 +658,8 @@ describe('Alpaca paper mutations', () => {
             Effect.ensuring(Ref.update(finalized, (count) => count + 1)),
           )
         })
-        const mutation = yield* makeMutation(options).pipe(
-          Effect.provideService(HttpClient.HttpClient, withVerifiedAccount(client)),
+        const mutation = yield* makeMutation(verifiedSession(), submitAuthority).pipe(
+          Effect.provideService(HttpClient.HttpClient, client),
         )
         const fiber = yield* mutation.submit(intent).pipe(Effect.forkChild({ startImmediately: true }))
         yield* Deferred.await(started)
@@ -610,7 +753,7 @@ describe('Alpaca paper mutations', () => {
           releaseBody()
           return yield* Fiber.join(fiber)
         }),
-      { ...options, operationTimeoutMs: 5_000 },
+      { operationTimeoutMs: 5_000 },
     ).pipe(Effect.provide(TestClock.layer()))
 
     const failure = await Effect.runPromise(program)

--- a/services/bayn/src/broker/alpaca-mutations.ts
+++ b/services/bayn/src/broker/alpaca-mutations.ts
@@ -6,13 +6,15 @@ export {
   MutationOperation,
   type BrokerMutationShape,
   type MutationEvidence,
-  type MutationOptions,
 } from './alpaca-mutations/model'
 export {
   OrderRequestError,
+  authorizeMutationAccess,
   cancelRequestHash,
   orderRequestBody,
+  resolveMutationCapability,
   submitBody,
   type OrderRequestBody,
+  type ResolvedMutationCapability,
 } from './alpaca-mutations/decisions'
 export { makeMutation } from './alpaca-mutations/interpreter'

--- a/services/bayn/src/broker/alpaca-mutations/decisions.ts
+++ b/services/bayn/src/broker/alpaca-mutations/decisions.ts
@@ -1,8 +1,8 @@
 import { Data, Redacted, Result, Schema } from 'effect'
 
 import { canonicalHashV1OrThrow, canonicalHashV1Result } from '../../hash'
+import { ExecutionAccess, type ExecutionAuthority } from '../../execution/authority'
 import {
-  Authority,
   IntentSchema,
   IntentState,
   OrderSide as DomainSide,
@@ -10,16 +10,10 @@ import {
   TimeInForce as DomainTimeInForce,
   type Intent,
 } from '../../paper'
-import { StrictNonEmptyStringSchema as NonEmptyString } from '../../schemas'
-import {
-  AssetClass,
-  OrderResponseSchema,
-  OrderSide,
-  OrderType,
-  TimeInForce,
-  normalizeOrder,
-  type Order,
-} from '../alpaca'
+import { AssetClass, OrderSide, OrderType, TimeInForce, type BrokerSessionShape, type Order } from '../alpaca'
+import { decodeErrorResponse, decodeOrder } from '../alpaca/model'
+import { normalizeOrderResult } from '../alpaca/normalizers'
+import type { BrokerConnection } from '../connection'
 import {
   BrokerMutationError,
   MutationOperation,
@@ -30,43 +24,24 @@ import {
   unknownOutcome,
   type CancelReceipt,
   type MutationEvidence,
-  type MutationOptions,
   type SubmitReceipt,
 } from './model'
 
-const responseParseOptions = { onExcessProperty: 'ignore' } as const
 const inputParseOptions = { onExcessProperty: 'error' } as const
 
 const Uuid = Schema.String.check(
   Schema.isPattern(/^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/),
 )
-const ErrorCode = Schema.Union([NonEmptyString.check(Schema.isMaxLength(64)), Schema.Int])
-const ErrorMessage = NonEmptyString.check(Schema.isMaxLength(1_000))
-const PositiveInteger = Schema.Int.check(Schema.isGreaterThan(0))
-
-const ErrorResponseSchema = Schema.Struct({
-  code: ErrorCode,
-  message: ErrorMessage,
-})
-const OptionsSchema = Schema.Struct({
-  expectedAccountId: Uuid,
-  maximumAuthority: Schema.Enum(Authority),
-  operationTimeoutMs: PositiveInteger,
-})
-
-const decodeErrorResponse = Schema.decodeUnknownResult(ErrorResponseSchema, responseParseOptions)
-const decodeOrderResponse = Schema.decodeUnknownResult(OrderResponseSchema, responseParseOptions)
 const decodeIntent = Schema.decodeUnknownResult(IntentSchema, inputParseOptions)
-const decodeOptions = Schema.decodeUnknownResult(OptionsSchema, inputParseOptions)
 const decodeOrderId = Schema.decodeUnknownResult(Uuid)
 const decodeJsonResponseBody = Schema.decodeUnknownResult(Schema.UnknownFromJsonString)
 
-export interface ResolvedMutationOptions {
+export interface ResolvedMutationCapability {
+  readonly connection: BrokerConnection
   readonly expectedAccountId: string
   readonly operationTimeoutMs: number
   readonly key: string
   readonly secret: string
-  readonly proxyUrl: string
 }
 
 export interface OrderRequestBody {
@@ -152,31 +127,57 @@ const microsToDecimal = (micros: bigint): string => {
   return fraction.length === 0 ? whole.toString() : `${whole.toString()}.${fraction}`
 }
 
-export const resolveMutationOptions = (
-  options: MutationOptions,
-): Result.Result<ResolvedMutationOptions, BrokerMutationError> => {
-  const decoded = decodeOptions({
-    expectedAccountId: options.expectedAccountId,
-    maximumAuthority: options.maximumAuthority,
-    operationTimeoutMs: options.operationTimeoutMs,
-  })
-  if (Result.isFailure(decoded)) {
-    return Result.fail(configurationError('invalid Alpaca mutation options', decoded.failure))
+export const authorizeMutationAccess = (
+  authority: ExecutionAuthority,
+): Result.Result<ExecutionAccess.SubmitOrders, BrokerMutationError> =>
+  authority.executionAccess === ExecutionAccess.SubmitOrders
+    ? Result.succeed(ExecutionAccess.SubmitOrders)
+    : Result.fail(configurationError('Alpaca mutation capability requires explicit submit-orders execution access'))
+
+export const resolveMutationCapability = (
+  session: BrokerSessionShape,
+  authority: ExecutionAuthority,
+): Result.Result<ResolvedMutationCapability, BrokerMutationError> => {
+  const connection = session.connection
+  const preflight = session.preflight
+  if (
+    preflight.provider !== connection.provider ||
+    preflight.environment !== connection.environment ||
+    preflight.baseUrl !== connection.baseUrl ||
+    preflight.accountId !== connection.expectedAccountId
+  ) {
+    return Result.fail(
+      configurationError('Alpaca mutation capability requires an exact verified broker session binding', {
+        _tag: 'BrokerSessionBindingMismatch',
+        connectionProvider: connection.provider,
+        preflightProvider: preflight.provider,
+        connectionEnvironment: connection.environment,
+        preflightEnvironment: preflight.environment,
+        connectionBaseUrl: connection.baseUrl,
+        preflightBaseUrl: preflight.baseUrl,
+        connectionAccountId: connection.expectedAccountId,
+        preflightAccountId: preflight.accountId,
+      }),
+    )
   }
-  if (decoded.success.maximumAuthority !== Authority.Paper) {
-    return Result.fail(configurationError('Alpaca mutation capability requires explicit PAPER maximum authority'))
-  }
-  const key = Redacted.value(options.key)
-  const secret = Redacted.value(options.secret)
-  if (key.length === 0 || key.trim() !== key || secret.length === 0 || secret.trim() !== secret) {
-    return Result.fail(configurationError('Alpaca credentials must be non-empty without surrounding whitespace'))
-  }
-  return Result.succeed({
-    expectedAccountId: decoded.success.expectedAccountId,
-    operationTimeoutMs: decoded.success.operationTimeoutMs,
-    key,
-    secret,
-    proxyUrl: options.proxyUrl,
+  return Result.gen(function* () {
+    yield* authorizeMutationAccess(authority)
+    if (authority.brokerEnvironment !== connection.environment) {
+      return yield* Result.fail(
+        configurationError('Alpaca mutation authority environment does not match the verified broker session', {
+          _tag: 'BrokerEnvironmentMismatch',
+          authorityEnvironment: authority.brokerEnvironment,
+          connectionEnvironment: connection.environment,
+        }),
+      )
+    }
+    return {
+      connection,
+      expectedAccountId: connection.expectedAccountId,
+      operationTimeoutMs: connection.operationTimeoutMs,
+      key: Redacted.value(connection.key),
+      secret: Redacted.value(connection.secret),
+    }
   })
 }
 
@@ -324,21 +325,19 @@ const canonicalCancelResponseHash = (facts: CancelResponseFacts): Result.Result<
 }
 
 const normalizeAcceptedOrder = (
-  raw: typeof OrderResponseSchema.Type,
+  raw: Parameters<typeof normalizeOrderResult>[0],
   facts: SubmitResponseFacts,
   evidence: MutationEvidence,
 ): Result.Result<Order, BrokerMutationError> =>
-  Result.try({
-    try: () => normalizeOrder(raw, facts.intent.accountId, facts.observedAt),
-    catch: (cause) =>
-      unknownOutcome(
-        MutationOperation.Submit,
-        'Alpaca submit response violates the order contract',
-        facts.requestHash,
-        evidence,
-        cause,
-      ),
-  })
+  Result.mapError(normalizeOrderResult(raw, facts.intent.accountId, facts.observedAt), (cause) =>
+    unknownOutcome(
+      MutationOperation.Submit,
+      'Alpaca submit response violates the order contract',
+      facts.requestHash,
+      evidence,
+      cause,
+    ),
+  )
 
 const acceptedOrderMatches = (order: Order, facts: SubmitResponseFacts): boolean =>
   order.accountId === facts.intent.accountId &&
@@ -384,7 +383,7 @@ export const classifySubmitResponse = (
     )
   }
 
-  const decoded = decodeOrderResponse(facts.body)
+  const decoded = decodeOrder(facts.body)
   if (Result.isFailure(decoded)) {
     return Result.fail(
       unknownOutcome(

--- a/services/bayn/src/broker/alpaca-mutations/interpreter.ts
+++ b/services/bayn/src/broker/alpaca-mutations/interpreter.ts
@@ -1,43 +1,28 @@
-import { Cause, Effect, Schema } from 'effect'
+import { Cause, Effect } from 'effect'
 import { Headers, HttpClient, HttpClientRequest, HttpClientResponse } from 'effect/unstable/http'
 
+import type { ExecutionAuthority } from '../../execution/authority'
 import type { Intent } from '../../paper'
-import { BrokerEnvironment } from '../../execution/authority'
-import { StrictNonEmptyStringSchema as NonEmptyString } from '../../schemas'
 import { currentUtcInstant } from '../../time'
-import { BrokerProvider, alpacaSandboxBaseUrl, decodeBrokerConnection, make as makeRead } from '../alpaca'
+import type { BrokerSessionShape } from '../alpaca'
+import { ResponseHeadersSchema, redactedHeaders, responseParseOptions } from '../alpaca/model'
+import { cancelOrderUrl, submitOrderUrl } from '../alpaca/requests'
 import {
   classifyCancelResponse,
   classifySubmitResponse,
   prepareCancel,
   prepareSubmit,
-  resolveMutationOptions,
+  resolveMutationCapability,
 } from './decisions'
 import {
   BrokerMutationError,
   MutationOperation,
-  configurationError,
   invalidRequest,
   unknownOutcome,
   type BrokerMutationShape,
-  type MutationOptions,
 } from './model'
 
-const responseParseOptions = { onExcessProperty: 'ignore' } as const
-const RequestId = NonEmptyString.check(Schema.isMaxLength(256))
-const ResponseHeadersSchema = Schema.Struct({
-  'x-request-id': RequestId,
-})
 const decodeHeaders = HttpClientResponse.schemaHeaders(ResponseHeadersSchema, responseParseOptions)
-
-const redactedHeaders = [
-  'authorization',
-  'cookie',
-  'set-cookie',
-  'x-api-key',
-  'apca-api-key-id',
-  'apca-api-secret-key',
-] as const
 
 const credentials = (key: string, secret: string) => ({
   'APCA-API-KEY-ID': key,
@@ -121,28 +106,12 @@ const readCancelBody = (
       )
 
 export const makeMutation = (
-  options: MutationOptions,
+  session: BrokerSessionShape,
+  authority: ExecutionAuthority,
 ): Effect.Effect<BrokerMutationShape, BrokerMutationError, HttpClient.HttpClient> =>
   Effect.gen(function* () {
-    const runtime = yield* Effect.fromResult(resolveMutationOptions(options))
+    const runtime = yield* Effect.fromResult(resolveMutationCapability(session, authority))
     const client = yield* HttpClient.HttpClient
-    const connection = yield* Effect.fromResult(
-      decodeBrokerConnection({
-        provider: BrokerProvider.Alpaca,
-        environment: BrokerEnvironment.Sandbox,
-        baseUrl: alpacaSandboxBaseUrl,
-        expectedAccountId: runtime.expectedAccountId,
-        key: options.key,
-        secret: options.secret,
-        proxyUrl: runtime.proxyUrl,
-        operationTimeoutMs: runtime.operationTimeoutMs,
-        retryAttempts: 0,
-      }),
-    ).pipe(Effect.mapError((cause) => configurationError('Alpaca mutation broker connection is invalid', cause)))
-    const read = yield* makeRead(connection)
-    yield* read.account.pipe(
-      Effect.mapError((cause) => configurationError('Alpaca mutation account verification failed', cause)),
-    )
 
     const submit = Effect.fn('BrokerMutation.submit', {
       attributes: { 'broker.system': 'alpaca', 'broker.operation': MutationOperation.Submit },
@@ -150,7 +119,7 @@ export const makeMutation = (
       function* (input: Intent) {
         const prepared = yield* Effect.fromResult(prepareSubmit(input, runtime.expectedAccountId))
         const request = yield* HttpClientRequest.bodyJson(
-          HttpClientRequest.post(new URL('/v2/orders', alpacaSandboxBaseUrl), {
+          HttpClientRequest.post(submitOrderUrl(runtime.connection), {
             acceptJson: true,
             headers: credentials(runtime.key, runtime.secret),
           }),
@@ -189,10 +158,9 @@ export const makeMutation = (
     })(
       function* (input: string) {
         const prepared = yield* Effect.fromResult(prepareCancel(input))
-        const request = HttpClientRequest.delete(
-          new URL(`/v2/orders/${encodeURIComponent(prepared.brokerOrderId)}`, alpacaSandboxBaseUrl),
-          { headers: credentials(runtime.key, runtime.secret) },
-        )
+        const request = HttpClientRequest.delete(cancelOrderUrl(runtime.connection, prepared.brokerOrderId), {
+          headers: credentials(runtime.key, runtime.secret),
+        })
         return yield* withDeadline(
           MutationOperation.Cancel,
           prepared.requestHash,
@@ -217,5 +185,10 @@ export const makeMutation = (
       (effect) => effect.pipe(Effect.provideService(Headers.CurrentRedactedNames, redactedHeaders)),
     )
 
-    return { submit, cancel }
+    return {
+      submit,
+      cancel,
+      orderById: session.read.orderById,
+      orderByClientId: session.read.orderByClientId,
+    }
   })

--- a/services/bayn/src/broker/alpaca-mutations/model.ts
+++ b/services/bayn/src/broker/alpaca-mutations/model.ts
@@ -1,9 +1,9 @@
-import { Context, Data, Effect, Redacted, Schema } from 'effect'
+import { Context, Data, Effect, Schema } from 'effect'
 
 import { MutationOutcome } from '../../paper'
 import { StrictNonEmptyStringSchema as NonEmptyString, UtcInstantSchema as UtcInstant } from '../../schemas'
 import type { Intent } from '../../paper'
-import type { Order } from '../alpaca'
+import type { BrokerReadError, Order, ReadResult } from '../alpaca'
 
 const RequestId = NonEmptyString.check(Schema.isMaxLength(256))
 
@@ -39,15 +39,6 @@ export class BrokerMutationError extends Data.TaggedError('BrokerMutationError')
   readonly cause?: Readonly<Record<string, string>>
 }> {}
 
-export interface MutationOptions {
-  readonly expectedAccountId: string
-  readonly maximumAuthority: import('../../paper').Authority
-  readonly key: Redacted.Redacted<string>
-  readonly secret: Redacted.Redacted<string>
-  readonly proxyUrl: string
-  readonly operationTimeoutMs: number
-}
-
 export interface SubmitReceipt {
   readonly requestHash: string
   readonly order: Order
@@ -63,6 +54,8 @@ export interface CancelReceipt {
 export interface BrokerMutationShape {
   readonly submit: (intent: Intent) => Effect.Effect<SubmitReceipt, BrokerMutationError>
   readonly cancel: (brokerOrderId: string) => Effect.Effect<CancelReceipt, BrokerMutationError>
+  readonly orderById: (brokerOrderId: string) => Effect.Effect<ReadResult<Order>, BrokerReadError>
+  readonly orderByClientId: (clientOrderId: string) => Effect.Effect<ReadResult<Order>, BrokerReadError>
 }
 
 export class BrokerMutation extends Context.Service<BrokerMutation, BrokerMutationShape>()('bayn/BrokerMutation') {}

--- a/services/bayn/src/broker/alpaca.ts
+++ b/services/bayn/src/broker/alpaca.ts
@@ -1,8 +1,3 @@
-import { Result } from 'effect'
-
-import { OrderResponseSchema, type Order } from './alpaca/model'
-import { normalizeOrderResult } from './alpaca/normalizers'
-
 export {
   BrokerProvider,
   alpacaLiveBaseUrl,
@@ -83,7 +78,3 @@ export {
   live,
   type BrokerSessionShape,
 } from './alpaca/session'
-
-/** @deprecated Mutation compatibility adapter. Read-side normalization uses `normalizeOrderResult`. */
-export const normalizeOrder = (raw: typeof OrderResponseSchema.Type, accountId: string, observedAt: string): Order =>
-  Result.getOrThrow(normalizeOrderResult(raw, accountId, observedAt))

--- a/services/bayn/src/broker/alpaca/requests.test.ts
+++ b/services/bayn/src/broker/alpaca/requests.test.ts
@@ -9,12 +9,14 @@ import {
   accountConfigurationUrl,
   accountUrl,
   assetBySymbolUrl,
+  cancelOrderUrl,
   fillActivitiesRequest,
   marketCalendarUrl,
   orderByClientIdUrl,
   orderByIdUrl,
   ordersUrl,
   positionsUrl,
+  submitOrderUrl,
 } from './requests'
 
 const connection = Result.getOrThrow(
@@ -41,6 +43,8 @@ describe('Alpaca read request builders', () => {
     expect(orderByClientIdUrl(connection, 'client/order').toString()).toBe(
       `${alpacaSandboxBaseUrl}/v2/orders:by_client_order_id?client_order_id=client%2Forder`,
     )
+    expect(submitOrderUrl(connection).toString()).toBe(`${alpacaSandboxBaseUrl}/v2/orders`)
+    expect(cancelOrderUrl(connection, 'order/id').toString()).toBe(`${alpacaSandboxBaseUrl}/v2/orders/order%2Fid`)
   })
 
   test('constructs ordered, encoded collection and calendar queries from decoded values', () => {

--- a/services/bayn/src/broker/alpaca/requests.ts
+++ b/services/bayn/src/broker/alpaca/requests.ts
@@ -60,8 +60,12 @@ export const ordersUrl = (connection: BrokerConnection, query: OrdersQuery): URL
   return url
 }
 
+export const submitOrderUrl = (connection: BrokerConnection): URL => new URL('/v2/orders', connection.baseUrl)
+
 export const orderByIdUrl = (connection: BrokerConnection, orderId: string): URL =>
   new URL(`/v2/orders/${encodeURIComponent(orderId)}`, connection.baseUrl)
+
+export const cancelOrderUrl = (connection: BrokerConnection, orderId: string): URL => orderByIdUrl(connection, orderId)
 
 export const orderByClientIdUrl = (connection: BrokerConnection, clientOrderId: string): URL => {
   const url = new URL('/v2/orders:by_client_order_id', connection.baseUrl)

--- a/services/bayn/src/db/evidence-store.integration.test.ts
+++ b/services/bayn/src/db/evidence-store.integration.test.ts
@@ -2069,6 +2069,8 @@ describePostgres('PostgreSQL evaluation evidence', () => {
           },
         })
       },
+      orderById: () => Effect.die(new Error('unexpected coordinator order-by-id lookup')),
+      orderByClientId: () => Effect.die(new Error('unexpected coordinator order-by-client-id lookup')),
     }
     const coordinator = makeCoordinatorRuntime(broker)
     const observed = await coordinator
@@ -3076,6 +3078,8 @@ describePostgres('PostgreSQL evaluation evidence', () => {
         brokerCalls.cancel += 1
         return Effect.die(new Error('generation-binding failure must not reach the broker'))
       },
+      orderById: () => Effect.die(new Error('generation-binding order lookup must not reach the broker')),
+      orderByClientId: () => Effect.die(new Error('generation-binding order lookup must not reach the broker')),
     })
     try {
       for (const variant of variants) {
@@ -3145,6 +3149,8 @@ describePostgres('PostgreSQL evaluation evidence', () => {
         return Effect.die(new Error('historical-generation submit must not reach the broker'))
       },
       cancel: () => Effect.die(new Error('unexpected cancel')),
+      orderById: () => Effect.die(new Error('historical-generation order lookup must not reach the broker')),
+      orderByClientId: () => Effect.die(new Error('historical-generation order lookup must not reach the broker')),
     })
     try {
       const observed = await coordinator.runPromise(
@@ -3255,6 +3261,8 @@ describePostgres('PostgreSQL evaluation evidence', () => {
         brokerCalls.cancel += 1
         return Effect.die(new Error('mismatched-account cancel must not reach the broker'))
       },
+      orderById: () => Effect.die(new Error('mismatched-account order lookup must not reach the broker')),
+      orderByClientId: () => Effect.die(new Error('mismatched-account order lookup must not reach the broker')),
     }
     const coordinator = makeCoordinatorRuntime(broker)
 

--- a/services/bayn/src/execution/coordinator.test.ts
+++ b/services/bayn/src/execution/coordinator.test.ts
@@ -15,7 +15,6 @@ import {
 } from '../broker/alpaca-mutations'
 import {
   AssetClass,
-  BrokerRead,
   BrokerReadError,
   BrokerReadErrorKind,
   OrderClass,
@@ -23,10 +22,8 @@ import {
   OrderStatus,
   OrderType as BrokerOrderType,
   TimeInForce as BrokerTimeInForce,
-  type BrokerReadShape,
   type Order,
 } from '../broker/alpaca'
-import { unusedAssetBySymbol, unusedMarketCalendar } from '../broker/alpaca-test-support'
 import { canonicalHashV1 } from '../hash'
 import {
   Authority,
@@ -1435,14 +1432,6 @@ const makeHarness = (options: HarnessOptions = {}) => {
       const response = evidence(204, '1970-01-01T00:00:01.100Z')
       return Effect.succeed({ requestHash: cancelRequestHash(brokerOrderId), brokerOrderId, evidence: response })
     },
-  }
-
-  const read: BrokerReadShape = {
-    account: Effect.die(new Error('unexpected account read')),
-    accountConfiguration: Effect.die(new Error('unexpected account configuration read')),
-    assetBySymbol: unusedAssetBySymbol,
-    positions: Effect.die(new Error('unexpected positions read')),
-    orders: () => Effect.die(new Error('unexpected orders read')),
     orderById: () => Effect.die(new Error('unexpected order-by-id read')),
     orderByClientId: () =>
       Effect.gen(function* () {
@@ -1482,8 +1471,6 @@ const makeHarness = (options: HarnessOptions = {}) => {
         const value = { ...selected, observedAt }
         return { value, evidence: evidence(200, observedAt) }
       }),
-    fillActivities: () => Effect.die(new Error('unexpected fill read')),
-    marketCalendar: unusedMarketCalendar,
   }
 
   const fenceCheck = Effect.suspend(() => {
@@ -1504,7 +1491,6 @@ const makeHarness = (options: HarnessOptions = {}) => {
       Effect.provideService(IntentStore, intentStore),
       Effect.provideService(MutationStore, mutationStore),
       Effect.provideService(BrokerMutation, mutation),
-      Effect.provideService(BrokerRead, read),
       Effect.provideService(WriterFence, {
         backendPid: 1,
         check: fenceCheck,
@@ -1899,7 +1885,7 @@ describe('paper execution coordinator', () => {
     expect(harness.state()).toBe(IntentState.Approved)
   })
 
-  test('persists UNKNOWN and refuses lookup until the committed consistency delay elapses', async () => {
+  test('recovers an ambiguous POST through the mutation capability lookup after the committed delay', async () => {
     const harness = makeHarness({ notFoundOnce: true, unknownSubmit: true })
     const result = await Effect.runPromise(
       harness.provide(

--- a/services/bayn/src/execution/coordinator.ts
+++ b/services/bayn/src/execution/coordinator.ts
@@ -1,7 +1,6 @@
 import { Clock, Data, Effect, Match, Result } from 'effect'
 
 import { BrokerMutation, MutationOperation } from '../broker/alpaca-mutations'
-import { BrokerRead } from '../broker/alpaca'
 import { IntentState, type Intent } from '../paper'
 import {
   cancellationIdentity,
@@ -55,7 +54,7 @@ interface MutationServices {
 
 interface RecoveryServices {
   readonly mutations: MutationStore['Service']
-  readonly broker: BrokerRead['Service']
+  readonly broker: BrokerMutation['Service']
 }
 
 const currentInstant = currentUtcInstant
@@ -455,5 +454,5 @@ const runRecovery = (services: RecoveryServices, intentId: string, operation: Mu
 export const recover = (intentId: string, operation: MutationOperation) =>
   Effect.all({
     mutations: MutationStore,
-    broker: BrokerRead,
+    broker: BrokerMutation,
   }).pipe(Effect.flatMap((services) => runRecovery(services, intentId, operation)))


### PR DESCRIPTION
## Summary

- Construct Alpaca mutation capability only from one exact verified `BrokerSession` plus orthogonal `ExecutionAuthority`; reject read-only access, environment mismatch, and session/preflight drift before broker I/O.
- Reuse the read boundary's connection, request builders, header schema, response codecs, normalization, redaction, and scoped HTTP client instead of rebuilding credentials, account verification, URLs, or order contracts.
- Publish submit, cancel, and exact order lookup through one `BrokerMutation` capability so durable recovery cannot use a parallel broker adapter.
- Preserve deterministic request hashes, no-retry mutation semantics, timeout/interruption cancellation, UNKNOWN classification, cancellation containment, and lookup-only recovery without resubmission.
- Remove the obsolete mutation options constructor and deprecated throwing order-normalization compatibility adapter. No deployment, capital enablement, or broker call was performed.

## Related Issues

None

## Testing

- `bun test services/bayn/src/broker/alpaca/requests.test.ts services/bayn/src/broker/alpaca-mutations.test.ts services/bayn/src/execution/coordinator.test.ts` — 53 passed, 0 failed, 494 assertions.
- `bun run --filter @proompteng/bayn test` — 799 passed, 121 environment-gated skips, 0 failed, 4,510 assertions across 920 tests / 67 files.
- `bun run --filter @proompteng/bayn tsc` — passed.
- `cd services/bayn && bun run lint:effect` — 270 files checked, 0 errors, 0 warnings.
- `cd services/bayn && bun run lint` — formatting passed for 252 files.
- `cd services/bayn && bun run lint:oxlint` — 0 warnings, 0 errors.
- `cd services/bayn && bun run lint:oxlint:type` — 0 warnings, 0 errors.
- `cd services/bayn && bun run build` — 626 modules bundled, 4.50 MB output.

## Breaking Changes

The internal `makeMutation` construction API now requires a verified `BrokerSessionShape` and `ExecutionAuthority`; `MutationOptions` and the deprecated throwing `normalizeOrder` compatibility export were removed. There are no production call sites or durable schema changes in this PR. Composition is intentionally deferred to the owned composition-root task.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] Documentation and release notes are not required; the internal construction change is documented above.
