### PR TITLE
chore(bayn): qualify Effect beta.102 cohort

### DIFF
--- a/.github/workflows/bayn-ci.yml
+++ b/.github/workflows/bayn-ci.yml
@@ -33,6 +33,44 @@ jobs:
       build-command: bun run --cwd services/bayn build
     secrets: inherit
 
+  effect-runtime-compatibility:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v5
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+      - name: Install focused dependencies
+        run: >-
+          bun install --frozen-lockfile --ignore-scripts
+          --filter @proompteng/source
+          --filter @proompteng/bayn
+      - name: Verify Effect runtime compatibility cohort
+        run: bun run --cwd services/bayn test:effect-runtime
+
+  broker-sandbox-contract:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v5
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+      - name: Install focused dependencies
+        run: >-
+          bun install --frozen-lockfile --ignore-scripts
+          --filter @proompteng/source
+          --filter @proompteng/bayn
+      - name: Verify OBSERVE sandbox contract without broker I/O
+        run: >-
+          env -u BAYN_ALPACA_ACCOUNT_ID
+          -u BAYN_ALPACA_KEY_ID
+          -u BAYN_ALPACA_SECRET_KEY
+          bun run --cwd services/bayn test:broker-sandbox
+
   postgres-integration:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
@@ -63,8 +101,5 @@ jobs:
           bun install --frozen-lockfile --ignore-scripts
           --filter @proompteng/source
           --filter @proompteng/bayn
-      - name: Verify durable evidence on PostgreSQL 18
-        run: |
-          bun test services/bayn/src/db/evidence-store.integration.test.ts
-          bun test services/bayn/src/db/paper-store.integration.test.ts
-          bun test services/bayn/src/db/cycle-store/integration.test.ts
+      - name: Verify complete durable workflow and Effect SQL compatibility on PostgreSQL 18
+        run: bun run --cwd services/bayn test:postgres

--- a/bun.lock
+++ b/bun.lock
@@ -718,10 +718,10 @@
       "version": "0.1.0",
       "dependencies": {
         "@clickhouse/client": "1.23.1",
-        "@effect/platform-node": "4.0.0-beta.100",
-        "@effect/sql-clickhouse": "4.0.0-beta.100",
-        "@effect/sql-pg": "4.0.0-beta.100",
-        "effect": "4.0.0-beta.100",
+        "@effect/platform-node": "4.0.0-beta.102",
+        "@effect/sql-clickhouse": "4.0.0-beta.102",
+        "@effect/sql-pg": "4.0.0-beta.102",
+        "effect": "4.0.0-beta.102",
         "tigerbeetle-node": "0.17.9",
       },
       "devDependencies": {
@@ -1031,7 +1031,8 @@
   },
   "patchedDependencies": {
     "@effect/sql-clickhouse@4.0.0-beta.99": "patches/@effect%2Fsql-clickhouse@4.0.0-beta.99.patch",
-    "@effect/sql-clickhouse@4.0.0-beta.100": "patches/@effect%2Fsql-clickhouse@4.0.0-beta.100.patch",
+    "@effect/sql-clickhouse@4.0.0-beta.102": "patches/@effect%2Fsql-clickhouse@4.0.0-beta.102.patch",
+    "effect@4.0.0-beta.102": "patches/effect@4.0.0-beta.102.patch",
   },
   "packages": {
     "@a2a-js/sdk": ["@a2a-js/sdk@0.3.13", "", { "dependencies": { "uuid": "^11.1.0" }, "peerDependencies": { "@bufbuild/protobuf": "^2.10.2", "@grpc/grpc-js": "^1.11.0", "express": "^4.21.2 || ^5.1.0" }, "optionalPeers": ["@bufbuild/protobuf", "@grpc/grpc-js", "express"] }, "sha512-BZr0f9JVNQs3GKOM9xINWCh6OKIJWZFPyqqVqTym5mxO2Eemc6I/0zL7zWnljHzGdaf5aZQyQN5xa6PSH62q+A=="],
@@ -1406,9 +1407,9 @@
 
     "@effect/sql": ["@effect/sql@0.51.1", "", { "dependencies": { "uuid": "^11.0.3" }, "peerDependencies": { "@effect/experimental": "^0.60.0", "@effect/platform": "^0.96.1", "effect": "^3.21.2" } }, "sha512-iPDAefrJcI0HcTk9keP9Gq8Pg08K1HmpnmZZt85AqyTcvorhoNsXDFiKBbPldfV2CortwVkacX8KjO9GPpSYCA=="],
 
-    "@effect/sql-clickhouse": ["@effect/sql-clickhouse@4.0.0-beta.100", "", { "dependencies": { "@clickhouse/client": "^1.23.1" }, "peerDependencies": { "@effect/platform-node": "^4.0.0-beta.100", "effect": "^4.0.0-beta.100" } }, "sha512-Ezypiv/jySrTHQ4GReAikQHwnHP1NB1Ae/uV/FyVHVfsOJSrdSzzN9rzOvihuga+OnyJUmNfWuPhhNrenWLqIw=="],
+    "@effect/sql-clickhouse": ["@effect/sql-clickhouse@4.0.0-beta.102", "", { "dependencies": { "@clickhouse/client": "^1.23.1" }, "peerDependencies": { "@effect/platform-node": "^4.0.0-beta.102", "effect": "^4.0.0-beta.102" } }, "sha512-fuPzG3JTGM2Z7TB5KRQWgXkyNr/lhIp1w2mdipl6txXGuNHYTArGlha3i4G0xqWDTZJgG98F0p2m6mNONE69pg=="],
 
-    "@effect/sql-pg": ["@effect/sql-pg@4.0.0-beta.100", "", { "dependencies": { "pg": "^8.22.0", "pg-connection-string": "2.14.0", "pg-cursor": "^2.21.0", "pg-pool": "^3.14.0", "pg-types": "^4.1.0" }, "peerDependencies": { "effect": "^4.0.0-beta.100" } }, "sha512-KU8P7FMeYw/0bbTrqpRIvmRaUetY/r5JAkX8ydsxtryBJu4JL7v8lm6ijOtoDHHS9kdcNGYGpiZZnn5AaQQJMQ=="],
+    "@effect/sql-pg": ["@effect/sql-pg@4.0.0-beta.102", "", { "dependencies": { "pg": "^8.22.0", "pg-connection-string": "2.14.0", "pg-cursor": "^2.21.0", "pg-pool": "^3.14.0", "pg-types": "^4.1.0" }, "peerDependencies": { "effect": "^4.0.0-beta.102" } }, "sha512-02a+fNfECWCZIZcgHl7OLQN2jZj42gq90EdwdnvR3KA6GLGypY02swABS4zFtaW9H80rTa0ukqVnTdcO/DT5GQ=="],
 
     "@effect/tsgo": ["@effect/tsgo@0.24.3", "", { "optionalDependencies": { "@effect/tsgo-darwin-arm64": "0.24.3", "@effect/tsgo-darwin-x64": "0.24.3", "@effect/tsgo-linux-arm": "0.24.3", "@effect/tsgo-linux-arm64": "0.24.3", "@effect/tsgo-linux-x64": "0.24.3", "@effect/tsgo-win32-arm64": "0.24.3", "@effect/tsgo-win32-x64": "0.24.3" }, "bin": { "effect-tsgo": "dist/effect-tsgo.js" } }, "sha512-WQxKU3MFzWzI38GbE9cf0POkVX4y0xahD8QqDjLfixW1AEValuHNfOQvyKM2MDWOLdGff4hP8VnIOeduwQt66A=="],
 
@@ -5978,11 +5979,11 @@
 
     "@effect/platform-node-shared/ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
 
-    "@effect/sql-clickhouse/@effect/platform-node": ["@effect/platform-node@4.0.0-beta.100", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.100", "mime": "^4.1.0", "undici": "^8.7.0" }, "peerDependencies": { "effect": "^4.0.0-beta.100", "ioredis": "^5.7.0" } }, "sha512-nH5xgxOLfPj5Bi0/o4OaDsR98Z59lHKGty+TDqckg7zRz6jry82hGW982NRPduzX0MJloDsGp/3rfeN4Hu7Keg=="],
+    "@effect/sql-clickhouse/@effect/platform-node": ["@effect/platform-node@4.0.0-beta.102", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.102", "mime": "^4.1.0", "undici": "^8.7.0" }, "peerDependencies": { "effect": "^4.0.0-beta.102", "ioredis": "^5.7.0" } }, "sha512-wYVAU9jAePT+gouMr/EVz1CaW6yDLjPAgXYeEFLz7wugT5iZhFRag6mqajV/wwN3bzWP2fzZHokLuPmqD/rqeA=="],
 
-    "@effect/sql-clickhouse/effect": ["effect@4.0.0-beta.100", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.9.0", "find-my-way-ts": "^0.1.6", "ini": "^7.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^2.0.4", "multipasta": "^0.2.8", "toml": "^4.1.2", "uuid": "^14.0.1", "yaml": "^2.9.0" } }, "sha512-K4ed+BS3HyE+NoAZ8pJss2DpuK41mb856IO7ZlPfnwBXbq8oTtAAurrsVnwe2hzPamIuaZp/Pq4/xp9qORYv8Q=="],
+    "@effect/sql-clickhouse/effect": ["effect@4.0.0-beta.102", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.9.0", "find-my-way-ts": "^0.1.6", "ini": "^7.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^2.0.4", "multipasta": "^0.2.8", "toml": "^4.1.2", "uuid": "^14.0.1", "yaml": "^2.9.0" } }, "sha512-z8Y+Q76Hh/kjLFZrXu8tGn6e+tDsg45R+UHhxd190pXxD53OGwf/G/zDxXTkse4HJ5mobNZfitLfUCp4fMvu6w=="],
 
-    "@effect/sql-pg/effect": ["effect@4.0.0-beta.100", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.9.0", "find-my-way-ts": "^0.1.6", "ini": "^7.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^2.0.4", "multipasta": "^0.2.8", "toml": "^4.1.2", "uuid": "^14.0.1", "yaml": "^2.9.0" } }, "sha512-K4ed+BS3HyE+NoAZ8pJss2DpuK41mb856IO7ZlPfnwBXbq8oTtAAurrsVnwe2hzPamIuaZp/Pq4/xp9qORYv8Q=="],
+    "@effect/sql-pg/effect": ["effect@4.0.0-beta.102", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.9.0", "find-my-way-ts": "^0.1.6", "ini": "^7.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^2.0.4", "multipasta": "^0.2.8", "toml": "^4.1.2", "uuid": "^14.0.1", "yaml": "^2.9.0" } }, "sha512-z8Y+Q76Hh/kjLFZrXu8tGn6e+tDsg45R+UHhxd190pXxD53OGwf/G/zDxXTkse4HJ5mobNZfitLfUCp4fMvu6w=="],
 
     "@effect/sql-pg/pg": ["pg@8.22.0", "", { "dependencies": { "pg-connection-string": "^2.14.0", "pg-pool": "^3.14.0", "pg-protocol": "^1.15.0", "pg-types": "2.2.0", "pgpass": "1.0.5" }, "optionalDependencies": { "pg-cloudflare": "^1.4.0" }, "peerDependencies": { "pg-native": ">=3.0.1" }, "optionalPeers": ["pg-native"] }, "sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA=="],
 
@@ -6252,9 +6253,9 @@
 
     "@proompteng/agents/nitro": ["nitro@3.0.260522-beta", "", { "dependencies": { "consola": "^3.4.2", "crossws": "^0.4.5", "db0": "^0.3.4", "env-runner": "^0.1.9", "h3": "^2.0.1-rc.22", "hookable": "^6.1.1", "nf3": "^0.3.17", "ocache": "^0.1.4", "ofetch": "^2.0.0-alpha.3", "ohash": "^2.0.11", "rolldown": "^1.0.2", "srvx": "^0.11.15", "unenv": "^2.0.0-rc.24", "unstorage": "^2.0.0-alpha.7" }, "peerDependencies": { "@vercel/queue": "^0.2.0", "dotenv": "*", "giget": "*", "jiti": "^2.6.1", "rollup": "^4.60.3", "vite": "^7 || ^8", "xml2js": "^0.6.2", "zephyr-agent": "^0.2.0" }, "optionalPeers": ["@vercel/queue", "dotenv", "giget", "jiti", "rollup", "vite", "xml2js", "zephyr-agent"], "bin": { "nitro": "dist/cli/index.mjs" } }, "sha512-L/z2eOWgkiQHc65kv+SEMgau505afSRF7NJlbooaaZEZscFrNSD7rXZzeVubQlgIzPbhOG8o73bk9soIiGTHRA=="],
 
-    "@proompteng/bayn/@effect/platform-node": ["@effect/platform-node@4.0.0-beta.100", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.100", "mime": "^4.1.0", "undici": "^8.7.0" }, "peerDependencies": { "effect": "^4.0.0-beta.100", "ioredis": "^5.7.0" } }, "sha512-nH5xgxOLfPj5Bi0/o4OaDsR98Z59lHKGty+TDqckg7zRz6jry82hGW982NRPduzX0MJloDsGp/3rfeN4Hu7Keg=="],
+    "@proompteng/bayn/@effect/platform-node": ["@effect/platform-node@4.0.0-beta.102", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.102", "mime": "^4.1.0", "undici": "^8.7.0" }, "peerDependencies": { "effect": "^4.0.0-beta.102", "ioredis": "^5.7.0" } }, "sha512-wYVAU9jAePT+gouMr/EVz1CaW6yDLjPAgXYeEFLz7wugT5iZhFRag6mqajV/wwN3bzWP2fzZHokLuPmqD/rqeA=="],
 
-    "@proompteng/bayn/effect": ["effect@4.0.0-beta.100", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.9.0", "find-my-way-ts": "^0.1.6", "ini": "^7.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^2.0.4", "multipasta": "^0.2.8", "toml": "^4.1.2", "uuid": "^14.0.1", "yaml": "^2.9.0" } }, "sha512-K4ed+BS3HyE+NoAZ8pJss2DpuK41mb856IO7ZlPfnwBXbq8oTtAAurrsVnwe2hzPamIuaZp/Pq4/xp9qORYv8Q=="],
+    "@proompteng/bayn/effect": ["effect@4.0.0-beta.102", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.9.0", "find-my-way-ts": "^0.1.6", "ini": "^7.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^2.0.4", "multipasta": "^0.2.8", "toml": "^4.1.2", "uuid": "^14.0.1", "yaml": "^2.9.0" } }, "sha512-z8Y+Q76Hh/kjLFZrXu8tGn6e+tDsg45R+UHhxd190pXxD53OGwf/G/zDxXTkse4HJ5mobNZfitLfUCp4fMvu6w=="],
 
     "@proompteng/design/react": ["react@19.2.5", "", {}, "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA=="],
 
@@ -6454,7 +6455,7 @@
 
     "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
-    "app/nitro": ["nitro-nightly@3.0.1-20260721-095825-c1ff6ba6", "", { "dependencies": { "consola": "^3.4.2", "crossws": "^0.4.10", "db0": "^0.3.4", "env-runner": "^0.1.16", "h3": "^2.0.1-rc.25", "h3-rules": "^0.1.0", "hookable": "^6.1.1", "nf3": "^0.3.22", "ocache": "^0.2.0", "ofetch": "^2.0.0-alpha.3", "ohash": "^2.0.11", "rolldown": "^1.2.0", "rou3": "^0.9.1", "srvx": "^0.11.22", "unenv": "^2.0.0-rc.24", "unstorage": "^2.0.0-alpha.7" }, "peerDependencies": { "@vercel/queue": "^0.4.0", "dotenv": "*", "giget": "*", "jiti": "^2.7.0", "rollup": "^4.62.2", "vite": "^7 || ^8", "xml2js": "^0.6.2", "zephyr-agent": "^1.1.2" }, "optionalPeers": ["@vercel/queue", "dotenv", "giget", "jiti", "rollup", "vite", "xml2js", "zephyr-agent"], "bin": { "nitro": "dist/cli/index.mjs" } }, "sha512-/zs7m2lfMlrt45B0cqbemv04cLsbc2cEwd6SsdU2zQ2NDww58BxqT87D1EWu8w08RxOqqBR7T1hb0m5I3fz0JA=="],
+    "app/nitro": ["nitro-nightly@3.0.1-20260722-224121-77b77ffb", "", { "dependencies": { "consola": "^3.4.2", "crossws": "^0.4.10", "db0": "^0.3.4", "env-runner": "^0.1.16", "h3": "^2.0.1-rc.25", "h3-rules": "^0.1.0", "hookable": "^6.1.1", "nf3": "^0.3.22", "ocache": "^0.2.0", "ofetch": "^2.0.0-alpha.3", "ohash": "^2.0.11", "rolldown": "^1.2.0", "rou3": "^0.9.1", "srvx": "^0.11.22", "unenv": "^2.0.0-rc.24", "unstorage": "^2.0.0-alpha.7" }, "peerDependencies": { "@vercel/queue": "^0.4.0", "dotenv": "*", "giget": "*", "jiti": "^2.7.0", "rollup": "^4.62.2", "vite": "^7 || ^8", "xml2js": "^0.6.2", "zephyr-agent": "^1.1.2" }, "optionalPeers": ["@vercel/queue", "dotenv", "giget", "jiti", "rollup", "vite", "xml2js", "zephyr-agent"], "bin": { "nitro": "dist/cli/index.mjs" } }, "sha512-29DHcZ8+KRozWOq9VrEyBMIzx1jJVv9fAeHDiQkiaS9I9fT5FAYmofwAeOYT6pgg31unbLVGvDkcQ9U3mIxvFA=="],
 
     "app/pg": ["pg@8.22.0", "", { "dependencies": { "pg-connection-string": "^2.14.0", "pg-pool": "^3.14.0", "pg-protocol": "^1.15.0", "pg-types": "2.2.0", "pgpass": "1.0.5" }, "optionalDependencies": { "pg-cloudflare": "^1.4.0" }, "peerDependencies": { "pg-native": ">=3.0.1" }, "optionalPeers": ["pg-native"] }, "sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA=="],
 
@@ -7196,7 +7197,7 @@
 
     "@effect/experimental/@effect/platform/msgpackr": ["msgpackr@1.11.8", "", { "optionalDependencies": { "msgpackr-extract": "^3.0.2" } }, "sha512-bC4UGzHhVvgDNS7kn9tV8fAucIYUBuGojcaLiz7v+P63Lmtm0Xeji8B/8tYKddALXxJLpwIeBmUN3u64C4YkRA=="],
 
-    "@effect/sql-clickhouse/@effect/platform-node/@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-beta.100", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.21.0" }, "peerDependencies": { "effect": "^4.0.0-beta.100" } }, "sha512-PMsCXQeK2wnlmnqGCc79oqK9CX8ipZvoHxAy/CRojMF+zHIluxh61L3pzWAYEbMb19Be4Bxgqs7gK2hiV8H8Pg=="],
+    "@effect/sql-clickhouse/@effect/platform-node/@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-beta.102", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.21.0" }, "peerDependencies": { "effect": "^4.0.0-beta.102" } }, "sha512-gVd793I72MrkX4dXo7eYtRKfNj0RW4eMRfVEKEJI16h2+mBDCzQ+gqMrog2hSTHQnaIbvbYShNQ4TVGuRCYZeQ=="],
 
     "@effect/sql-clickhouse/@effect/platform-node/mime": ["mime@4.1.0", "", { "bin": { "mime": "bin/cli.js" } }, "sha512-X5ju04+cAzsojXKes0B/S4tcYtFAJ6tTMuSPBEn9CPGlrWr8Fiw7qYeLT0XyH80HSoAoqWCaz+MWKh22P7G1cw=="],
 
@@ -7524,7 +7525,7 @@
 
     "@proompteng/agents/nitro/rolldown": ["rolldown@1.0.2", "", { "dependencies": { "@oxc-project/types": "=0.132.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.2", "@rolldown/binding-darwin-arm64": "1.0.2", "@rolldown/binding-darwin-x64": "1.0.2", "@rolldown/binding-freebsd-x64": "1.0.2", "@rolldown/binding-linux-arm-gnueabihf": "1.0.2", "@rolldown/binding-linux-arm64-gnu": "1.0.2", "@rolldown/binding-linux-arm64-musl": "1.0.2", "@rolldown/binding-linux-ppc64-gnu": "1.0.2", "@rolldown/binding-linux-s390x-gnu": "1.0.2", "@rolldown/binding-linux-x64-gnu": "1.0.2", "@rolldown/binding-linux-x64-musl": "1.0.2", "@rolldown/binding-openharmony-arm64": "1.0.2", "@rolldown/binding-wasm32-wasi": "1.0.2", "@rolldown/binding-win32-arm64-msvc": "1.0.2", "@rolldown/binding-win32-x64-msvc": "1.0.2" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g=="],
 
-    "@proompteng/bayn/@effect/platform-node/@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-beta.100", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.21.0" }, "peerDependencies": { "effect": "^4.0.0-beta.100" } }, "sha512-PMsCXQeK2wnlmnqGCc79oqK9CX8ipZvoHxAy/CRojMF+zHIluxh61L3pzWAYEbMb19Be4Bxgqs7gK2hiV8H8Pg=="],
+    "@proompteng/bayn/@effect/platform-node/@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-beta.102", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.21.0" }, "peerDependencies": { "effect": "^4.0.0-beta.102" } }, "sha512-gVd793I72MrkX4dXo7eYtRKfNj0RW4eMRfVEKEJI16h2+mBDCzQ+gqMrog2hSTHQnaIbvbYShNQ4TVGuRCYZeQ=="],
 
     "@proompteng/bayn/@effect/platform-node/mime": ["mime@4.1.0", "", { "bin": { "mime": "bin/cli.js" } }, "sha512-X5ju04+cAzsojXKes0B/S4tcYtFAJ6tTMuSPBEn9CPGlrWr8Fiw7qYeLT0XyH80HSoAoqWCaz+MWKh22P7G1cw=="],
 

--- a/nix/images/bayn.nix
+++ b/nix/images/bayn.nix
@@ -20,8 +20,8 @@ import ./bun-workspace-service.nix {
   serviceName = "bayn";
   packageName = "@proompteng/bayn";
   depsHash = {
-    x86_64-linux = "sha256-sB5XSc9spXbq5ZwPz+tn6Y8w6ssgZPuRXEIWn63A8jY=";
-    aarch64-linux = "sha256-Yah2AFAbxYkEx0ltHbCL6d9Sye9r1K8cr8Rek6WSWCE=";
+    x86_64-linux = "sha256-3/ypVWbFqQkrWzEYntOFsJ0Qjsyd6kJJrnNsQVJXMzA=";
+    aarch64-linux = "sha256-LItp5mJ1QkOiCRCVODH3QTyNQTmAztZam1FzoAkuIVo=";
   };
   installFilters = [
     "@proompteng/bayn"

--- a/nix/images/signal-publisher.nix
+++ b/nix/images/signal-publisher.nix
@@ -16,8 +16,8 @@ import ./bun-workspace-service.nix {
   serviceName = "signal-publisher";
   packageName = "@proompteng/signal-publisher";
   depsHash = {
-    x86_64-linux = "sha256-mNpd0O8anbQwConzOo62V7zvh38ucqN0JJ9mV4KBS+M=";
-    aarch64-linux = "sha256-Hfow1Chee6xSsHH41a6U4SqwJvXmwNKYB+P3VNDhLjs=";
+    x86_64-linux = "sha256-11HJObm2gcoZdUi8JUMvZFEuUPavmRhjtn4guR5tLvQ=";
+    aarch64-linux = "sha256-Kyyx9wMWJiIUYm2eD+kW7A/jNvYtXZ1c7qaLo7Xgd7A=";
   };
   installFilters = [
     "@proompteng/signal-publisher"

--- a/package.json
+++ b/package.json
@@ -145,6 +145,8 @@
   "packageManager": "bun@1.3.14",
   "patchedDependencies": {
     "@effect/sql-clickhouse@4.0.0-beta.99": "patches/@effect%2Fsql-clickhouse@4.0.0-beta.99.patch",
-    "@effect/sql-clickhouse@4.0.0-beta.100": "patches/@effect%2Fsql-clickhouse@4.0.0-beta.100.patch"
+    "@effect/sql-clickhouse@4.0.0-beta.100": "patches/@effect%2Fsql-clickhouse@4.0.0-beta.100.patch",
+    "@effect/sql-clickhouse@4.0.0-beta.102": "patches/@effect%2Fsql-clickhouse@4.0.0-beta.102.patch",
+    "effect@4.0.0-beta.102": "patches/effect@4.0.0-beta.102.patch"
   }
 }

--- a/patches/@effect%2Fsql-clickhouse@4.0.0-beta.102.patch
+++ b/patches/@effect%2Fsql-clickhouse@4.0.0-beta.102.patch
@@ -1,0 +1,26 @@
+diff --git a/dist/ClickhouseClient.js b/dist/ClickhouseClient.js
+index c97676fc8913cfedc2c793bf9d4fed179a265f32..ea431cb7f2760cceba5e52f719c66245e05de4c4 100644
+--- a/dist/ClickhouseClient.js
++++ b/dist/ClickhouseClient.js
+@@ -97,7 +97,7 @@ export const make = options => Effect.gen(function* () {
+   const transformRows = options.transformResultNames ? Statement.defaultTransforms(options.transformResultNames).array : undefined;
+   const client = Clickhouse.createClient(options);
+   yield* Effect.acquireRelease(Effect.tryPromise({
+-    try: () => client.exec({
++    try: () => client.command({
+       query: "SELECT 1"
+     }),
+     catch: cause => new SqlError({
+diff --git a/src/ClickhouseClient.ts b/src/ClickhouseClient.ts
+index fb5883eb1201b651040b50059c4f991657a5252a..69350d70013a4bfc3268da4e6318c544ea0f5c54 100644
+--- a/src/ClickhouseClient.ts
++++ b/src/ClickhouseClient.ts
+@@ -179,7 +179,7 @@ export const make = (
+ 
+     yield* Effect.acquireRelease(
+       Effect.tryPromise({
+-        try: () => client.exec({ query: "SELECT 1" }),
++        try: () => client.command({ query: "SELECT 1" }),
+         catch: (cause) =>
+           new SqlError({ reason: classifyError(cause, "ClickhouseClient: Failed to connect", "connect", "connection") })
+       }),

--- a/patches/effect@4.0.0-beta.102.patch
+++ b/patches/effect@4.0.0-beta.102.patch
@@ -1,0 +1,58 @@
+diff --git a/dist/Schema.d.ts b/dist/Schema.d.ts
+index c766b84ab80a1d4675acc01c1456c4ffefe3d161..d445383c519284bf9391638018a5792e4b43b72d 100644
+--- a/dist/Schema.d.ts
++++ b/dist/Schema.d.ts
+@@ -7771,6 +7771,14 @@ export interface Date extends declare<globalThis.Date> {
+  * @since 4.0.0
+  */
+ export declare const Date: Date;
++/**
++ * Compatibility alias for cohorts that named the valid JavaScript Date schema
++ * explicitly. `Date` rejects invalid dates in beta.102.
++ *
++ * @category Date
++ * @since 4.0.0
++ */
++export declare const DateValid: Date;
+ /**
+  * Reviver for persisted `Date` declarations.
+  *
+diff --git a/dist/Schema.js b/dist/Schema.js
+index 6ec7466a3ef077cf7f6beea86af5b61edbe6a542..625e71ffd0443189b3a83bb8119209d733507e34 100644
+--- a/dist/Schema.js
++++ b/dist/Schema.js
+@@ -7482,6 +7482,14 @@ export const Date = /*#__PURE__*/declare(input => input instanceof globalThis.Da
+     noInvalidDate: true
+   }))
+ });
++/**
++ * Compatibility alias for cohorts that named the valid JavaScript Date schema
++ * explicitly. `Date` rejects invalid dates in beta.102.
++ *
++ * @category Date
++ * @since 4.0.0
++ */
++export const DateValid = Date;
+ /**
+  * Reviver for persisted `Date` declarations.
+  *
+diff --git a/src/Schema.ts b/src/Schema.ts
+index 6c320d5cb49d42eb8f318dc400d2a71fe1921917..d6d2611adad5818786da232e9f4a0b70607f474f 100644
+--- a/src/Schema.ts
++++ b/src/Schema.ts
+@@ -11866,6 +11866,15 @@ export const Date: Date = declare(
+   }
+ )
+ 
++/**
++ * Compatibility alias for cohorts that named the valid JavaScript Date schema
++ * explicitly. `Date` rejects invalid dates in beta.102.
++ *
++ * @category Date
++ * @since 4.0.0
++ */
++export const DateValid: Date = Date
++
+ /**
+  * Reviver for persisted `Date` declarations.
+  *

--- a/services/bayn/package.json
+++ b/services/bayn/package.json
@@ -9,19 +9,22 @@
     "build": "bun build src/index.ts --target=node --external tigerbeetle-node --outdir=dist",
     "dev": "BAYN_PROVENANCE_MODE=development bun --watch src/index.ts",
     "start": "BAYN_PROVENANCE_MODE=development node dist/index.js",
-    "lint": "bunx oxfmt --check src",
+    "lint": "bun ../../node_modules/oxfmt/bin/oxfmt --check src",
     "lint:effect": "find ../../node_modules/.bun -path '*/@effect/tsgo-*/lib/tsc*' -type f ! -name '*.json' -exec chmod +x {} + 2>/dev/null || true; bun node_modules/@effect/tsgo/dist/effect-tsgo.js diagnostics --project tsconfig.json --format text --severity error",
-    "lint:oxlint": "oxlint --config ../../.oxlintrc.json .",
-    "lint:oxlint:type": "oxlint --config ../../.oxlintrc.json --type-aware --tsconfig ./tsconfig.json .",
+    "lint:oxlint": "bun ../../node_modules/oxlint/bin/oxlint --config ../../.oxlintrc.json .",
+    "lint:oxlint:type": "bun ../../node_modules/oxlint/bin/oxlint --config ../../.oxlintrc.json --type-aware --tsconfig ./tsconfig.json .",
     "test": "bun test",
-    "tsc": "bunx tsc --noEmit"
+    "test:broker-sandbox": "bun test src/broker-sandbox-contract.test.ts",
+    "test:effect-runtime": "bun test src/clickhouse-patch.test.ts src/effect-runtime-compatibility.test.ts",
+    "test:postgres": "bun test src/db/cycle-observability.integration.test.ts && bun test src/db/evidence-store.integration.test.ts && bun test src/db/paper-store.integration.test.ts && bun test src/db/cycle-store/integration.test.ts && bun test src/effect-sql-runtime-compatibility.integration.test.ts",
+    "tsc": "bun node_modules/typescript/bin/tsc --noEmit"
   },
   "dependencies": {
     "@clickhouse/client": "1.23.1",
-    "@effect/platform-node": "4.0.0-beta.100",
-    "@effect/sql-clickhouse": "4.0.0-beta.100",
-    "@effect/sql-pg": "4.0.0-beta.100",
-    "effect": "4.0.0-beta.100",
+    "@effect/platform-node": "4.0.0-beta.102",
+    "@effect/sql-clickhouse": "4.0.0-beta.102",
+    "@effect/sql-pg": "4.0.0-beta.102",
+    "effect": "4.0.0-beta.102",
     "tigerbeetle-node": "0.17.9"
   },
   "devDependencies": {

--- a/services/bayn/src/broker-sandbox-contract.test.ts
+++ b/services/bayn/src/broker-sandbox-contract.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from 'bun:test'
+
+import { Redacted, Result } from 'effect'
+
+import {
+  alpacaLiveBaseUrl,
+  alpacaSandboxBaseUrl,
+  BrokerProvider,
+  decodeBrokerConnection,
+  type BrokerConnectionInput,
+} from './broker/connection'
+import { BrokerEnvironment } from './execution/authority'
+import { Authority } from './paper'
+
+const accountId = '61e69015-8549-4bfd-b9c3-01e75843f47d'
+const input = (overrides: Partial<BrokerConnectionInput> = {}): BrokerConnectionInput => ({
+  provider: BrokerProvider.Alpaca,
+  environment: BrokerEnvironment.Sandbox,
+  baseUrl: alpacaSandboxBaseUrl,
+  expectedAccountId: accountId,
+  key: Redacted.make('paper-key'),
+  secret: Redacted.make('paper-secret'),
+  proxyUrl: 'http://bayn-egress-proxy:3128',
+  operationTimeoutMs: 30_000,
+  retryAttempts: 2,
+  ...overrides,
+})
+
+describe('committed broker sandbox contract', () => {
+  test('admits only a frozen, redacted Alpaca sandbox connection without capital authority', () => {
+    const result = decodeBrokerConnection(input())
+
+    expect(Result.isSuccess(result)).toBe(true)
+    if (Result.isFailure(result)) return
+    expect(result.success).toMatchObject({
+      provider: BrokerProvider.Alpaca,
+      environment: BrokerEnvironment.Sandbox,
+      baseUrl: alpacaSandboxBaseUrl,
+      expectedAccountId: accountId,
+    })
+    expect(Object.isFrozen(result.success)).toBe(true)
+    expect(Redacted.isRedacted(result.success.key)).toBe(true)
+    expect(Redacted.isRedacted(result.success.secret)).toBe(true)
+    expect(Object.hasOwn(result.success, 'maximumAuthority')).toBe(false)
+    expect(String(Authority.Observe)).toBe('OBSERVE')
+  })
+
+  test('rejects the live endpoint before any broker client or mutation capability exists', () => {
+    expect(
+      decodeBrokerConnection(
+        input({
+          environment: BrokerEnvironment.Live,
+          baseUrl: alpacaLiveBaseUrl,
+        }),
+      ),
+    ).toMatchObject({
+      _tag: 'Failure',
+      failure: {
+        _tag: 'BrokerEnvironmentUnsupported',
+        provider: BrokerProvider.Alpaca,
+        environment: BrokerEnvironment.Live,
+        baseUrl: alpacaLiveBaseUrl,
+        reason: 'DURABLE_IDENTITY_UNAVAILABLE',
+      },
+    })
+  })
+
+  test('rejects incomplete or unsafe credential material without exposing secrets', () => {
+    const result = decodeBrokerConnection(input({ secret: Redacted.make('') }))
+
+    expect(result).toMatchObject({
+      _tag: 'Failure',
+      failure: {
+        _tag: 'InvalidBrokerCredentials',
+        invalid: ['secret'],
+      },
+    })
+    expect(JSON.stringify(result)).not.toContain('paper-key')
+    expect(JSON.stringify(result)).not.toContain('paper-secret')
+  })
+})

--- a/services/bayn/src/effect-runtime-compatibility.test.ts
+++ b/services/bayn/src/effect-runtime-compatibility.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, test } from 'bun:test'
+
+import {
+  Deferred,
+  Effect,
+  Exit,
+  Fiber,
+  Layer,
+  ManagedRuntime,
+  Option,
+  PartitionedSemaphore,
+  Result,
+  Schema,
+  Scope,
+  Semaphore,
+  Stream,
+} from 'effect'
+import { HttpBody, HttpClient, HttpClientResponse } from 'effect/unstable/http'
+import { OtlpExporter } from 'effect/unstable/observability'
+
+describe('Effect beta.102 runtime compatibility', () => {
+  test('keeps deeply nested JSON validation stack safe and rejects invalid dates', () => {
+    let nested: unknown = null
+    for (let index = 0; index < 25_000; index += 1) nested = [nested]
+
+    expect(Schema.DateValid).toBe(Schema.Date)
+    expect(Result.isSuccess(Schema.decodeUnknownResult(Schema.Json)(nested))).toBe(true)
+    expect(Result.isFailure(Schema.decodeUnknownResult(Schema.Date)(new Date(Number.NaN)))).toBe(true)
+    expect(Result.isFailure(Schema.decodeUnknownResult(Schema.DateValid)(new Date(Number.NaN)))).toBe(true)
+    expect(Result.isFailure(Schema.decodeUnknownResult(Schema.DateFromString)('not-a-date'))).toBe(true)
+    expect(Result.isFailure(Schema.decodeUnknownResult(Schema.DateFromMillis)(8_640_000_000_000_001))).toBe(true)
+  })
+
+  test('recovers permits after interrupted semaphore waiters', async () => {
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const semaphore = yield* Semaphore.make(1)
+        const blocked = yield* semaphore.withPermits(2)(Effect.void).pipe(Effect.forkChild)
+
+        yield* Effect.yieldNow
+        yield* Fiber.interrupt(blocked)
+        expect(Option.isSome(yield* semaphore.withPermitsIfAvailable(1)(Effect.void))).toBe(true)
+
+        const partitioned = yield* PartitionedSemaphore.make<string>({ permits: 4 })
+        yield* PartitionedSemaphore.take(partitioned, 'held', 3)
+        const waiter = yield* PartitionedSemaphore.take(partitioned, 'waiting', 3).pipe(Effect.forkChild)
+        yield* Effect.yieldNow
+        yield* PartitionedSemaphore.release(partitioned, 1)
+        yield* Fiber.interrupt(waiter)
+
+        expect(yield* PartitionedSemaphore.available(partitioned)).toBe(2)
+        yield* PartitionedSemaphore.release(partitioned, 2)
+        expect(yield* PartitionedSemaphore.available(partitioned)).toBe(4)
+      }),
+    )
+  })
+
+  test('interrupts an in-flight stream pull when the async iterator closes', async () => {
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const started = yield* Deferred.make<void>()
+        let interrupted = false
+        const iterator = Stream.toAsyncIterable(
+          Stream.fromEffect(
+            Deferred.succeed(started, undefined).pipe(
+              Effect.andThen(Effect.never),
+              Effect.onInterrupt(() =>
+                Effect.sync(() => {
+                  interrupted = true
+                }),
+              ),
+            ),
+          ),
+        )[Symbol.asyncIterator]()
+
+        const pending = iterator.next()
+        yield* Deferred.await(started)
+        const returned = yield* Effect.promise(() => iterator.return!(undefined))
+        const pendingResult = yield* Effect.promise(() => pending)
+
+        expect(returned).toEqual({ done: true, value: undefined })
+        expect(pendingResult).toEqual({ done: true, value: undefined })
+        expect(interrupted).toBe(true)
+      }),
+    )
+  })
+
+  test('removes Fiber.joinAll observers when the join is interrupted', async () => {
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const fiber = yield* Effect.forkChild(Effect.never)
+        let cleaned = 0
+        const tracked = new Proxy(fiber, {
+          get(target, property, receiver) {
+            if (property !== 'addObserver') return Reflect.get(target, property, receiver)
+            return (observer: Parameters<typeof target.addObserver>[0]) => {
+              const cancel = target.addObserver(observer)
+              return () => {
+                cleaned += 1
+                cancel()
+              }
+            }
+          },
+        })
+        const joining = yield* Fiber.joinAll([tracked]).pipe(Effect.forkChild({ startImmediately: true }))
+
+        yield* Fiber.interrupt(joining)
+        expect(cleaned).toBe(1)
+      }),
+    )
+  })
+
+  test('waits for in-flight telemetry during scoped exporter shutdown', async () => {
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const scope = yield* Scope.make()
+        const started = yield* Deferred.make<void>()
+        const release = yield* Deferred.make<void>()
+        const client = HttpClient.make((request) =>
+          Deferred.succeed(started, undefined).pipe(
+            Effect.andThen(Deferred.await(release)),
+            Effect.as(HttpClientResponse.fromWeb(request, new Response())),
+          ),
+        )
+        const exporter = yield* OtlpExporter.make({
+          label: 'BaynEffectCompatibility',
+          url: 'http://localhost:4318/v1/logs',
+          headers: undefined,
+          exportInterval: '1 hour',
+          maxBatchSize: 1,
+          body: () => HttpBody.empty,
+          shutdownTimeout: '1 second',
+        }).pipe(
+          Effect.provideService(HttpClient.HttpClient, client),
+          Effect.provide(OtlpExporter.layerFlusher),
+          Scope.provide(scope),
+        )
+
+        exporter.push({ message: 'flush-before-close' })
+        yield* Deferred.await(started)
+        const closing = yield* Scope.close(scope, Exit.void).pipe(Effect.forkChild({ startImmediately: true }))
+        yield* Effect.yieldNow
+
+        expect(closing.pollUnsafe()).toBeUndefined()
+        yield* Deferred.succeed(release, undefined)
+        yield* Fiber.join(closing)
+      }),
+    )
+  })
+
+  test('disposes scoped managed runtimes through Symbol.asyncDispose', async () => {
+    let finalized = 0
+    const runtime = ManagedRuntime.make(
+      Layer.effectDiscard(
+        Effect.addFinalizer(() =>
+          Effect.sync(() => {
+            finalized += 1
+          }),
+        ),
+      ),
+    )
+
+    await runtime.runPromise(Effect.void)
+    expect(finalized).toBe(0)
+    await runtime[Symbol.asyncDispose]()
+    expect(finalized).toBe(1)
+  })
+})

--- a/services/bayn/src/effect-sql-runtime-compatibility.integration.test.ts
+++ b/services/bayn/src/effect-sql-runtime-compatibility.integration.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, test } from 'bun:test'
+
+import { PgClient } from '@effect/sql-pg'
+import { Effect, Exit, Layer, Redacted, Schedule } from 'effect'
+import {
+  Runner,
+  RunnerAddress,
+  RunnerStorage,
+  ShardId,
+  ShardingConfig,
+  SqlRunnerStorage,
+} from 'effect/unstable/cluster'
+import { SqlClient, type SqlConnection, SqlError } from 'effect/unstable/sql'
+
+const postgresUrl = process.env.BAYN_TEST_POSTGRES_URL
+const describePostgres = postgresUrl === undefined ? describe.skip : describe
+
+interface PartitionState {
+  current: boolean
+  activeQueries: number
+  interruptedQueries: number
+  maxActiveQueries: number
+  reservedConnections: number
+}
+
+const makePartitionState = (): PartitionState => ({
+  current: false,
+  activeQueries: 0,
+  interruptedQueries: 0,
+  maxActiveQueries: 0,
+  reservedConnections: 0,
+})
+
+const waitUntil = (predicate: () => boolean) =>
+  Effect.suspend(function poll(): Effect.Effect<void> {
+    return predicate() ? Effect.void : Effect.sleep(20).pipe(Effect.andThen(poll))
+  }).pipe(
+    Effect.timeoutOrElse({
+      duration: 10_000,
+      orElse: () => Effect.die('timed out waiting for reserved connection rebuild'),
+    }),
+  )
+
+const blackholeReservedConnection = (state: PartitionState, url: string) =>
+  Layer.effect(
+    SqlClient.SqlClient,
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient
+      const wrapConnection = (connection: SqlConnection.Connection): SqlConnection.Connection => {
+        const execute = <A, E extends SqlError.SqlError, R>(effect: Effect.Effect<A, E, R>) =>
+          Effect.suspend(function waitForConnection(): Effect.Effect<A, E, R> {
+            if (!state.current) return effect
+            return Effect.never
+          }).pipe(
+            Effect.onExit((exit) =>
+              Effect.sync(() => {
+                state.activeQueries -= 1
+                if (Exit.hasInterrupts(exit)) state.interruptedQueries += 1
+              }),
+            ),
+          )
+
+        const tracked = <A, E extends SqlError.SqlError, R>(effect: Effect.Effect<A, E, R>) =>
+          Effect.sync(() => {
+            state.activeQueries += 1
+            state.maxActiveQueries = Math.max(state.maxActiveQueries, state.activeQueries)
+          }).pipe(Effect.andThen(execute(effect)))
+
+        return {
+          ...connection,
+          execute: (...arguments_) => tracked(connection.execute(...arguments_)),
+          executeRaw: (...arguments_) => tracked(connection.executeRaw(...arguments_)),
+          executeStream: connection.executeStream,
+          executeUnprepared: (...arguments_) => tracked(connection.executeUnprepared(...arguments_)),
+          executeValues: (...arguments_) => tracked(connection.executeValues(...arguments_)),
+          executeValuesUnprepared: (...arguments_) => tracked(connection.executeValuesUnprepared(...arguments_)),
+        }
+      }
+
+      let client: SqlClient.SqlClient
+      client = new Proxy(sql, {
+        get(target, property, receiver) {
+          if (property === 'reserve') {
+            return Effect.map(target.reserve, (connection) => {
+              state.reservedConnections += 1
+              return wrapConnection(connection)
+            })
+          }
+          if (property === 'withoutTransforms') return () => client
+          return Reflect.get(target, property, receiver)
+        },
+      })
+      return client
+    }),
+  ).pipe(
+    Layer.provide(
+      PgClient.layer({
+        url: Redacted.make(url),
+        maxConnections: 4,
+      }),
+    ),
+  )
+
+describePostgres('Effect beta.102 SQL runner compatibility', () => {
+  test('bounds lock refreshes and rebuilds an unresponsive reserved PostgreSQL connection', async () => {
+    const state = makePartitionState()
+    const prefix = `bayn_effect_beta102_${process.pid}`
+    const storageLayer = SqlRunnerStorage.layerWith({ prefix }).pipe(
+      Layer.provideMerge(blackholeReservedConnection(state, postgresUrl!)),
+      Layer.provide(
+        ShardingConfig.layer({
+          shardLockDisableAdvisory: true,
+          shardLockExpiration: 1_000,
+          shardLockRefreshInterval: 100,
+        }),
+      ),
+    )
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const storage = yield* RunnerStorage.RunnerStorage
+        const address = RunnerAddress.make('127.0.0.1', 49_061)
+        const runner = Runner.make({ address, groups: ['default'], weight: 1 })
+        const shards = [ShardId.make('default', 1)]
+
+        yield* storage.register(runner, true)
+        expect(yield* storage.acquire(address, shards)).toEqual(shards)
+        const initialReservations = state.reservedConnections
+
+        state.current = true
+        const startedAt = Date.now()
+        const failedRefresh = yield* storage.refresh(address, shards).pipe(Effect.exit)
+        const elapsedMs = Date.now() - startedAt
+
+        expect(Exit.isFailure(failedRefresh)).toBe(true)
+        expect(elapsedMs).toBeGreaterThanOrEqual(80)
+        expect(elapsedMs).toBeLessThan(1_000)
+        yield* waitUntil(() => state.reservedConnections > initialReservations)
+        expect(state.interruptedQueries).toBeGreaterThanOrEqual(1)
+        expect(state.maxActiveQueries).toBeLessThanOrEqual(1)
+
+        state.current = false
+        expect(
+          yield* storage.refresh(address, shards).pipe(Effect.retry({ times: 10, schedule: Schedule.spaced(20) })),
+        ).toEqual(shards)
+        yield* storage.releaseAll(address)
+        yield* storage.unregister(address)
+      }).pipe(Effect.provide(storageLayer)),
+    )
+  }, 60_000)
+})


### PR DESCRIPTION
## Summary

- upgrades `effect`, `@effect/platform-node`, `@effect/sql-clickhouse`, and `@effect/sql-pg` as one exact `4.0.0-beta.102` cohort, with Bun-managed ClickHouse drain and `Schema.DateValid` compatibility patches
- characterizes the beta.102 SQL lock deadline/rebuild, telemetry shutdown, Schema stack/Date, semaphore interruption, stream cancellation, fiber cleanup, and scoped runtime disposal fixes against the matching Effect sources
- adds an explicit no-I/O Alpaca sandbox contract job and centralizes the complete PostgreSQL workflow suite, including the reserved-connection regression
- preserves the committed release path as OBSERVE-only: no broker mutation, capital enablement, credentials, GitOps authority, or direct deployment changes

## Related Issues

None

## Testing

- `bun install --frozen-lockfile --ignore-scripts --filter @proompteng/source --filter @proompteng/bayn --filter @proompteng/scripts`
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint:effect`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn build`
- `bun run --filter @proompteng/bayn test` — 805 passed, 122 PostgreSQL-gated skipped locally, 0 failed
- `bun test packages/scripts/src/bayn` — 20 passed, 0 failed
- `bun run --cwd services/bayn test:effect-runtime` — 7 passed, 0 failed
- `bun run --cwd services/bayn test:broker-sandbox` — 3 passed, 0 failed
- PostgreSQL 18 and linux/amd64 + linux/arm64 image validation are explicit required PR checks

## Quantitative change

- direct Effect cohort dependencies: 4 → 4; additions/removals: 0/0
- Bayn production domain/application modules changed: 0
- dedicated compatibility regressions added: 10
- PostgreSQL files explicitly exercised by the dedicated command: 3 → 5
- workflow-local PostgreSQL test invocations: 3 → 1 centralized package command
- compatibility facade avoids changing 25 existing `Schema.DateValid` call sites across 5 production files
- diff: 11 files, +558 / -33 LOC; two image files change only derived Bun dependency hashes; no registry, repository, DI container, scheduler, event bus, or generic wrapper added

## Breaking Changes

None. The exact beta.102 cohort remains behind stable Bayn ownership boundaries; invalid `Date` values continue to fail closed.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] Dependency, CI, compatibility, and release-safety changes are documented in this PR.
