### PR TITLE
refactor(bayn): make application composition explicit

### DIFF
--- a/services/bayn/src/app.test.ts
+++ b/services/bayn/src/app.test.ts
@@ -14,17 +14,22 @@ import {
   successfulJournal,
 } from './app-test-support'
 import {
+  type ApplicationIdentity,
   autonomousObserveApplication,
   type AutonomousCycleStartupInput,
   type AutonomousObserveApplicationConfig,
+  type BrokerlessApplicationConfig,
+  makeApplicationPlan,
 } from './app'
 import { AccountStatus, BrokerProvider, alpacaSandboxBaseUrl, type BrokerReadShape } from './broker/alpaca'
 import { unusedAssetBySymbol, unusedMarketCalendar } from './broker/alpaca-test-support'
+import type { LoadedRuntimeConfig } from './config'
 import { makeStrategyProtocolHash } from './contracts'
 import { CycleObservability } from './db/cycle-observability'
 import { EvidenceStore } from './db/evidence-store'
 import { BrokerEnvironment } from './execution/authority'
 import type { BrokerProbe } from './health'
+import { HttpServerLive } from './http'
 import { Journal } from './ledger'
 import { MarketData } from './market-data'
 import { Authority } from './paper'
@@ -105,7 +110,52 @@ const autonomousConfig = (runtime: typeof config): AutonomousObserveApplicationC
   },
 })
 
+const brokerlessConfig = (runtime: typeof config): BrokerlessApplicationConfig => ({
+  ...runtime,
+  runtimeMode: 'BrokerlessService',
+  cyclePollIntervalMs: 30_000,
+  maximumAuthority: Authority.Observe,
+  alpaca: undefined,
+})
+
+const discoveryConfig = (
+  runtime: typeof pinnedRuntimeConfig,
+): Extract<LoadedRuntimeConfig, { readonly runtimeMode: 'PaperCandidateDiscovery' }> => ({
+  ...autonomousConfig(runtime),
+  runtimeMode: 'PaperCandidateDiscovery',
+  qualificationRunId: pinnedEvaluation.runId,
+})
+
+const applicationIdentity = (loaded: LoadedRuntimeConfig): ApplicationIdentity => ({
+  config: loaded,
+  protocol: fixtureProtocol,
+  parameterHash: fixtureStrategy.provenance.strategy.parameterHash,
+  strategy: fixtureStrategy,
+  strategyProtocolHash: makeStrategyProtocolHash(fixtureStrategy.provenance.strategy),
+})
+
 describe('Bayn application composition', () => {
+  test('constructs one exhaustive immutable application plan for every resolved runtime mode', () => {
+    const modes = [
+      { config: brokerlessConfig(config), expectedTag: 'BrokerlessService' },
+      { config: autonomousConfig(config), expectedTag: 'AutonomousObserveService' },
+      { config: discoveryConfig(pinnedRuntimeConfig), expectedTag: 'PaperCandidateDiscovery' },
+    ] as const
+
+    for (const mode of modes) {
+      const identity = Object.freeze(applicationIdentity(mode.config))
+      const plan = makeApplicationPlan(identity)
+
+      expect(plan._tag).toBe(mode.expectedTag)
+      expect(plan.config).toBe(mode.config)
+      expect(plan.protocol).toBe(identity.protocol)
+      expect(plan.strategy).toBe(identity.strategy)
+      expect(plan.parameterHash).toBe(identity.parameterHash)
+      expect(plan.strategyProtocolHash).toBe(identity.strategyProtocolHash)
+      expect(identity).not.toHaveProperty('_tag')
+    }
+  })
+
   test('starts one scoped autonomous cycle after initialization and interrupts it with the application', async () => {
     const calls: string[] = []
     let backgroundInterrupted = false
@@ -143,6 +193,7 @@ describe('Bayn application composition', () => {
             Effect.provideService(Journal, successfulJournal),
             Effect.provideService(EvidenceStore, successfulEvidenceStore),
             Effect.provideService(CycleObservability, cycleObservability),
+            Effect.provide(HttpServerLive(config)),
             Effect.forkScoped,
           )
           yield* pipe(Deferred.await(started), Effect.timeout('1 second'))
@@ -183,6 +234,7 @@ describe('Bayn application composition', () => {
             Effect.provideService(Journal, successfulJournal),
             Effect.provideService(EvidenceStore, pinnedStore()),
             Effect.provideService(CycleObservability, cycleObservability),
+            Effect.provide(HttpServerLive(pinnedRuntimeConfig)),
             Effect.forkScoped,
           )
           yield* pipe(Deferred.await(started), Effect.timeout('1 second'))

--- a/services/bayn/src/app.ts
+++ b/services/bayn/src/app.ts
@@ -1,15 +1,17 @@
-import { Clock, Effect, Fiber, Layer, Option, pipe, Ref, Scope } from 'effect'
+import { Clock, Effect, Fiber, Match, pipe, Ref, Scope } from 'effect'
+import { HttpServer } from 'effect/unstable/http'
 
 import type { LoadedRuntimeConfig, RuntimeConfig } from './config'
-import { CycleObservability } from './db/cycle-observability'
-import { EvidenceStore } from './db/evidence-store'
+import type { CausalProtocol } from './protocol'
+import { CycleObservability, type CycleObservabilityShape } from './db/cycle-observability'
+import { EvidenceStore, type EvidenceStoreService } from './db/evidence-store'
 import { operationalError, type OperationalError } from './errors'
-import { monitor, type BrokerProbe } from './health'
-import { makeHttpLayer } from './http'
-import { Journal } from './ledger'
-import { MarketData } from './market-data'
+import { monitorWithDependencies, type BrokerProbe, type HealthDependencies } from './health'
+import { serveHttp } from './http'
+import { Journal, type JournalService } from './ledger'
+import { MarketData, type MarketDataService } from './market-data'
 import { initialState, type AutonomousCyclePassObservation, type RuntimeState } from './runtime-state'
-import { initialize } from './startup'
+import { initializeWithDependencies, type StartupDependencies } from './startup'
 import type { Strategy } from './strategy'
 import { utcInstantFromEpochMillis } from './time'
 
@@ -33,12 +35,63 @@ export type AutonomousObserveApplicationConfig = Extract<
   { readonly runtimeMode: 'AutonomousObserveService' }
 >
 
-type AutonomousObserveRuntime<StartupR, LoopR> = {
-  readonly broker: BrokerProbe
-  readonly startCycle: AutonomousCycleStartup<StartupR, LoopR>
+export type ApplicationIdentity<C extends LoadedRuntimeConfig = LoadedRuntimeConfig> = {
+  readonly config: C
+  readonly protocol: CausalProtocol
+  readonly parameterHash: string
+  readonly strategy: Strategy
+  readonly strategyProtocolHash: string
 }
 
-type ApplicationRuntime<StartupR, LoopR> = Option.Option<AutonomousObserveRuntime<StartupR, LoopR>>
+type ApplicationMode = LoadedRuntimeConfig['runtimeMode']
+
+export type ApplicationPlanFor<M extends ApplicationMode> = ApplicationIdentity<
+  Extract<LoadedRuntimeConfig, { readonly runtimeMode: M }>
+> & {
+  readonly _tag: M
+}
+
+export type ApplicationPlan = { readonly [M in ApplicationMode]: ApplicationPlanFor<M> }[ApplicationMode]
+
+export const makeApplicationPlan = (identity: ApplicationIdentity): ApplicationPlan =>
+  Match.value(identity.config).pipe(
+    Match.when({ runtimeMode: 'BrokerlessService' }, (config) => ({
+      ...identity,
+      _tag: 'BrokerlessService' as const,
+      config,
+    })),
+    Match.when({ runtimeMode: 'AutonomousObserveService' }, (config) => ({
+      ...identity,
+      _tag: 'AutonomousObserveService' as const,
+      config,
+    })),
+    Match.when({ runtimeMode: 'PaperCandidateDiscovery' }, (config) => ({
+      ...identity,
+      _tag: 'PaperCandidateDiscovery' as const,
+      config,
+    })),
+    Match.exhaustive,
+  )
+
+export interface ApplicationDependencies extends StartupDependencies, HealthDependencies {
+  readonly marketData: MarketDataService
+  readonly journal: JournalService
+  readonly evidenceStore: EvidenceStoreService
+  readonly cycleObservability: CycleObservabilityShape
+}
+
+type ApplicationRuntime<StartupR, LoopR> =
+  | { readonly _tag: 'Brokerless' }
+  | {
+      readonly _tag: 'AutonomousObserve'
+      readonly broker: BrokerProbe
+      readonly startCycle: AutonomousCycleStartup<StartupR, LoopR>
+    }
+
+type AutonomousObserveRuntime<StartupR, LoopR> = Extract<
+  ApplicationRuntime<StartupR, LoopR>,
+  { readonly _tag: 'AutonomousObserve' }
+>
 
 const cyclePassError = (observation: Extract<AutonomousCyclePassObservation, { readonly result: 'FAILURE' }>): string =>
   `cycleRunner: ${observation.operation}/${observation.failure}: ${observation.message}`
@@ -78,20 +131,10 @@ const applyAutonomousCyclePass = (current: RuntimeState, observation: Autonomous
 }
 
 const brokerProbe = <StartupR, LoopR>(runtime: ApplicationRuntime<StartupR, LoopR>): BrokerProbe | undefined =>
-  pipe(
-    runtime,
-    Option.map(({ broker }) => broker),
-    Option.getOrUndefined,
-  )
+  runtime._tag === 'AutonomousObserve' ? runtime.broker : undefined
 
 const initialRuntimeState = <StartupR, LoopR>(runtime: ApplicationRuntime<StartupR, LoopR>): RuntimeState =>
-  pipe(
-    runtime,
-    Option.match({
-      onNone: initialState,
-      onSome: ({ broker }) => initialState(broker, true),
-    }),
-  )
+  runtime._tag === 'AutonomousObserve' ? initialState(runtime.broker, true) : initialState()
 
 const currentUtcInstant = Clock.currentTimeMillis.pipe(
   Effect.flatMap((millis) =>
@@ -135,52 +178,33 @@ const startAutonomousCycle = <StartupR, LoopR>(
   runtime: ApplicationRuntime<StartupR, LoopR>,
   state: Ref.Ref<RuntimeState>,
 ): Effect.Effect<Fiber.Fiber<void, never> | undefined, OperationalError, StartupR | LoopR | Scope.Scope> =>
-  pipe(
-    runtime,
-    Option.match({
-      onNone: () => Effect.succeed(undefined),
-      onSome: (configured) =>
-        pipe(
-          Ref.get(state),
-          Effect.flatMap((initialized) =>
-            initialized.evidence === null
-              ? Effect.succeed(undefined)
-              : forkAutonomousCycle(configured, state, initialized.evidence.evaluation.runId),
-          ),
+  runtime._tag === 'Brokerless'
+    ? Effect.succeed(undefined)
+    : Ref.get(state).pipe(
+        Effect.flatMap((initialized) =>
+          initialized.evidence === null
+            ? Effect.succeed(undefined)
+            : forkAutonomousCycle(runtime, state, initialized.evidence.evaluation.runId),
         ),
-    }),
-  )
+      )
 
-const startHttpServer = (
+const runApplicationWithDependencies = <StartupR, LoopR>(
   config: RuntimeConfig,
   strategy: Strategy,
-  state: Ref.Ref<RuntimeState>,
-  evidenceStore: EvidenceStore['Service'],
-) =>
-  pipe(
-    Layer.build(makeHttpLayer(config, state, strategy.provenance, config.build.verification, evidenceStore.read)),
-    Effect.mapError((cause) => operationalError('http', 'listen', 'HTTP server failed to listen', cause)),
-  )
-
-const runApplication = <StartupR, LoopR>(
-  config: RuntimeConfig,
-  strategy: Strategy,
+  dependencies: ApplicationDependencies,
   runtime: ApplicationRuntime<StartupR, LoopR>,
-): Effect.Effect<
-  never,
-  OperationalError,
-  MarketData | Journal | EvidenceStore | CycleObservability | StartupR | LoopR
-> =>
+): Effect.Effect<never, OperationalError, HttpServer.HttpServer | StartupR | LoopR> =>
   pipe(
     Effect.Do,
-    Effect.bind('evidenceStore', () => EvidenceStore),
     Effect.bind('state', () => Ref.make(initialRuntimeState(runtime))),
-    Effect.tap(({ evidenceStore, state }) => startHttpServer(config, strategy, state, evidenceStore)),
-    Effect.tap(({ state }) => initialize(config, state, strategy)),
+    Effect.tap(({ state }) =>
+      serveHttp(config, state, strategy.provenance, config.build.verification, dependencies.evidenceStore.read),
+    ),
+    Effect.tap(({ state }) => initializeWithDependencies(config, state, strategy, dependencies)),
     Effect.bind('autonomousCycleFiber', ({ state }) => startAutonomousCycle(runtime, state)),
     Effect.tap(({ autonomousCycleFiber, state }) =>
       pipe(
-        monitor(config, state, brokerProbe(runtime), autonomousCycleFiber),
+        monitorWithDependencies(config, state, dependencies, brokerProbe(runtime), autonomousCycleFiber),
         Effect.forkScoped({ startImmediately: true }),
       ),
     ),
@@ -188,11 +212,44 @@ const runApplication = <StartupR, LoopR>(
     Effect.scoped,
   )
 
+const loadApplicationDependencies: Effect.Effect<
+  ApplicationDependencies,
+  never,
+  MarketData | Journal | EvidenceStore | CycleObservability
+> = Effect.all({
+  marketData: MarketData,
+  journal: Journal,
+  evidenceStore: EvidenceStore,
+  cycleObservability: CycleObservability,
+})
+
+export const brokerlessApplicationWithDependencies = (
+  config: BrokerlessApplicationConfig,
+  strategy: Strategy,
+  dependencies: ApplicationDependencies,
+): Effect.Effect<never, OperationalError, HttpServer.HttpServer> =>
+  runApplicationWithDependencies(config, strategy, dependencies, { _tag: 'Brokerless' })
+
+export const autonomousObserveApplicationWithDependencies = <StartupR, LoopR>(
+  config: AutonomousObserveApplicationConfig,
+  strategy: Strategy,
+  dependencies: ApplicationDependencies,
+  broker: BrokerProbe,
+  startCycle: AutonomousCycleStartup<StartupR, LoopR>,
+): Effect.Effect<never, OperationalError, HttpServer.HttpServer | StartupR | LoopR> =>
+  runApplicationWithDependencies(config, strategy, dependencies, { _tag: 'AutonomousObserve', broker, startCycle })
+
 export const brokerlessApplication = (
   config: BrokerlessApplicationConfig,
   strategy: Strategy,
-): Effect.Effect<never, OperationalError, MarketData | Journal | EvidenceStore | CycleObservability> =>
-  runApplication(config, strategy, Option.none())
+): Effect.Effect<
+  never,
+  OperationalError,
+  HttpServer.HttpServer | MarketData | Journal | EvidenceStore | CycleObservability
+> =>
+  loadApplicationDependencies.pipe(
+    Effect.flatMap((dependencies) => brokerlessApplicationWithDependencies(config, strategy, dependencies)),
+  )
 
 export const autonomousObserveApplication = <StartupR, LoopR>(
   config: AutonomousObserveApplicationConfig,
@@ -202,8 +259,13 @@ export const autonomousObserveApplication = <StartupR, LoopR>(
 ): Effect.Effect<
   never,
   OperationalError,
-  MarketData | Journal | EvidenceStore | CycleObservability | StartupR | LoopR
-> => runApplication(config, strategy, Option.some({ broker, startCycle }))
+  HttpServer.HttpServer | MarketData | Journal | EvidenceStore | CycleObservability | StartupR | LoopR
+> =>
+  loadApplicationDependencies.pipe(
+    Effect.flatMap((dependencies) =>
+      autonomousObserveApplicationWithDependencies(config, strategy, dependencies, broker, startCycle),
+    ),
+  )
 
-export { monitor, probe } from './health'
-export { initialize } from './startup'
+export { monitor, monitorWithDependencies, probe, probeWithDependencies } from './health'
+export { initialize, initializeWithDependencies } from './startup'

--- a/services/bayn/src/entrypoint.ts
+++ b/services/bayn/src/entrypoint.ts
@@ -2,7 +2,15 @@ import { NodeHttpClient, NodeServices } from '@effect/platform-node'
 import { ClickhouseClient } from '@effect/sql-clickhouse'
 import { Effect, flow, Layer, Match, pipe, Redacted, Result, Schema, Stdio, Stream } from 'effect'
 
-import { autonomousObserveApplication, brokerlessApplication } from './app'
+import {
+  autonomousObserveApplicationWithDependencies,
+  brokerlessApplicationWithDependencies,
+  makeApplicationPlan,
+  type ApplicationDependencies,
+  type ApplicationIdentity,
+  type ApplicationPlan,
+  type ApplicationPlanFor,
+} from './app'
 import { riskBalancedTrendBehaviorHash } from './behavior'
 import { BrokerSession, live as AlpacaBrokerLive, type BrokerReadShape } from './broker/alpaca'
 import { verifyBehaviorHash, verifyParameterHash } from './build'
@@ -13,17 +21,18 @@ import {
   type ContractConstructionFailure,
   type RuntimeProvenance,
 } from './contracts'
-import { CycleObservabilityLive } from './db/cycle-observability'
+import { CycleObservability, CycleObservabilityLive } from './db/cycle-observability'
 import { CycleStoreLive } from './db/cycle-store'
-import { EvidenceStoreFromPostgres, PostgresClientLive } from './db/evidence-store'
+import { EvidenceStore, EvidenceStoreFromPostgres, PostgresClientLive } from './db/evidence-store'
 import { PaperStoreLive } from './db/paper-store'
 import { WriterFenceLive } from './execution/writer-fence'
 import { operationalError } from './errors'
 import { canonicalHashV1Result, type CanonicalJsonFailure } from './hash'
-import { JournalLive } from './ledger'
-import { MarketDataLive } from './market-data'
+import { HttpServerLive } from './http'
+import { Journal, JournalLive } from './ledger'
+import { MarketData, MarketDataLive } from './market-data'
 import { loadObserveRiskPolicy, makeObserveAutonomousCycleStartup } from './observe-composition'
-import { retrySqlLayer } from './operations'
+import { sqlResource } from './operations'
 import {
   discoverPaperCandidates,
   renderPaperCandidateDiscoveryError,
@@ -31,17 +40,6 @@ import {
 } from './paper-candidate-discovery'
 import { loadDefaultProtocol, type CausalProtocol } from './protocol'
 import { makeStrategy, type Strategy } from './strategy'
-
-type AlpacaBinding = NonNullable<LoadedRuntimeConfig['alpaca']>
-type RuntimeMode = LoadedRuntimeConfig['runtimeMode']
-
-type RuntimeIdentity<C extends LoadedRuntimeConfig = LoadedRuntimeConfig> = {
-  readonly config: C
-  readonly protocol: CausalProtocol
-  readonly parameterHash: string
-  readonly strategy: Strategy
-  readonly strategyProtocolHash: string
-}
 
 type RuntimeIdentityFailure =
   | {
@@ -57,26 +55,13 @@ type RuntimeIdentityFailure =
       readonly cause: ContractConstructionFailure
     }
 
-type RuntimePlanFor<M extends RuntimeMode> = RuntimeIdentity<
-  Extract<LoadedRuntimeConfig, { readonly runtimeMode: M }>
-> & {
-  readonly _tag: M
-}
-
-type RuntimePlan = { readonly [M in RuntimeMode]: RuntimePlanFor<M> }[RuntimeMode]
-
-const mapLayerError = <A, E, R, E2>(layer: Layer.Layer<A, E, R>, map: (error: E) => E2): Layer.Layer<A, E2, R> =>
-  Layer.unwrap(pipe(Layer.build(layer), Effect.mapError(map), Effect.map(Layer.succeedContext)))
-
 type RuntimeSeed = {
   readonly config: LoadedRuntimeConfig
   readonly protocol: CausalProtocol
 }
 
 type ParameterizedRuntime = RuntimeSeed & { readonly parameterHash: string }
-type ProvenanceRuntime = ParameterizedRuntime & {
-  readonly provenance: RuntimeProvenance
-}
+type ProvenanceRuntime = ParameterizedRuntime & { readonly provenance: RuntimeProvenance }
 type StrategyRuntime = ProvenanceRuntime & { readonly strategy: Strategy }
 
 const hashRuntimeParameters = (seed: RuntimeSeed): Result.Result<ParameterizedRuntime, RuntimeIdentityFailure> =>
@@ -117,7 +102,9 @@ const addStrategy = (runtime: ProvenanceRuntime): StrategyRuntime => ({
   strategy: makeStrategy(runtime.protocol, runtime.provenance),
 })
 
-const addStrategyProtocolHash = (runtime: StrategyRuntime): Result.Result<RuntimeIdentity, RuntimeIdentityFailure> =>
+const addStrategyProtocolHash = (
+  runtime: StrategyRuntime,
+): Result.Result<ApplicationIdentity, RuntimeIdentityFailure> =>
   pipe(
     makeStrategyProtocolHashResult(runtime.strategy.provenance.strategy),
     Result.mapError(
@@ -173,8 +160,8 @@ const runtimeIdentityError = (failure: RuntimeIdentityFailure) =>
   )
 
 const verifyRuntimeIdentity = (
-  identity: RuntimeIdentity,
-): Effect.Effect<RuntimeIdentity, ReturnType<typeof operationalError>> =>
+  identity: ApplicationIdentity,
+): Effect.Effect<ApplicationIdentity, ReturnType<typeof operationalError>> =>
   pipe(
     Effect.all(
       [
@@ -186,100 +173,113 @@ const verifyRuntimeIdentity = (
     Effect.as(identity),
   )
 
-const attachRuntimeMode = (identity: RuntimeIdentity): RuntimePlan =>
-  pipe(
-    Match.value(identity.config),
-    Match.when({ runtimeMode: 'BrokerlessService' }, (config) => ({
-      ...identity,
-      _tag: 'BrokerlessService' as const,
-      config,
-    })),
-    Match.when({ runtimeMode: 'AutonomousObserveService' }, (config) => ({
-      ...identity,
-      _tag: 'AutonomousObserveService' as const,
-      config,
-    })),
-    Match.when({ runtimeMode: 'PaperCandidateDiscovery' }, (config) => ({
-      ...identity,
-      _tag: 'PaperCandidateDiscovery' as const,
-      config,
-    })),
-    Match.exhaustive,
-  )
-
-const loadRuntimePlan = pipe(
+export const loadApplicationPlan = pipe(
   Effect.all({ config: loadConfig(), protocol: loadDefaultProtocol }),
   Effect.flatMap(flow(makeRuntimeIdentity, Effect.fromResult, Effect.mapError(runtimeIdentityError))),
   Effect.flatMap(verifyRuntimeIdentity),
-  Effect.map(attachRuntimeMode),
+  Effect.map(makeApplicationPlan),
 )
 
-const clickhouseLayer = (config: LoadedRuntimeConfig) =>
-  retrySqlLayer(
-    pipe(
-      ClickhouseClient.layer({
-        url: config.clickhouse.url,
-        username: config.clickhouse.username,
-        password: Redacted.value(config.clickhouse.password),
-        database: 'signal',
-        application: 'bayn',
-        request_timeout: config.operationTimeoutMs,
-      }),
-      Layer.provide(NodeHttpClient.layerNodeHttp),
-    ),
-  )
+export const ClickHouseClientResourceLive = (config: LoadedRuntimeConfig) =>
+  ClickhouseClient.layer({
+    url: config.clickhouse.url,
+    username: config.clickhouse.username,
+    password: Redacted.value(config.clickhouse.password),
+    database: 'signal',
+    application: 'bayn',
+    request_timeout: config.operationTimeoutMs,
+  })
 
-const postgresClientLayer = (config: LoadedRuntimeConfig) =>
-  retrySqlLayer(pipe(PostgresClientLive(config), Layer.provide(NodeServices.layer)))
+export const PostgresClientResourceLive = (config: LoadedRuntimeConfig) => PostgresClientLive(config)
 
-const databaseLayer = (config: LoadedRuntimeConfig) =>
-  retrySqlLayer(
-    pipe(
-      EvidenceStoreFromPostgres(config),
-      Layer.provideMerge(pipe(PostgresClientLive(config), Layer.provide(NodeServices.layer))),
-    ),
-  )
+export const EvidenceStoreResourceLive = (config: LoadedRuntimeConfig) => EvidenceStoreFromPostgres(config)
 
-const brokerSessionLayer = (alpaca: AlpacaBinding) =>
-  mapLayerError(AlpacaBrokerLive(alpaca), (cause) =>
-    operationalError('config', 'broker-session', 'Alpaca broker session acquisition failed', cause),
-  )
+export const MarketDataResourceLive = (plan: ApplicationIdentity) => MarketDataLive(plan.config, plan.protocol)
 
-const serviceCoreLayers = (plan: RuntimeIdentity) => {
-  const database = databaseLayer(plan.config)
-  const journal = JournalLive(plan.config)
-  const marketData = pipe(MarketDataLive(plan.config, plan.protocol), Layer.provide(clickhouseLayer(plan.config)))
-  const cycleObservability = pipe(CycleObservabilityLive, Layer.provide(database))
-  return {
-    database,
-    journal,
-    core: Layer.mergeAll(marketData, database, journal, cycleObservability),
-  }
+export const JournalResourceLive = (config: LoadedRuntimeConfig) => JournalLive(config)
+
+export const CycleObservabilityResourceLive = CycleObservabilityLive
+
+export const PaperStoreResourceLive = (config: LoadedRuntimeConfig) => PaperStoreLive(config)
+
+export const CycleStoreResourceLive = CycleStoreLive
+
+export const WriterFenceResourceLive = WriterFenceLive
+
+export const BrokerSessionResourceLive = (config: Extract<LoadedRuntimeConfig, { readonly alpaca: object }>) =>
+  AlpacaBrokerLive(config.alpaca)
+
+export const ApplicationPlatformLive = Layer.merge(NodeServices.layer, NodeHttpClient.layerNodeHttp)
+
+const SignalMarketDataLive = (plan: ApplicationIdentity) => {
+  const clickHouse = sqlResource(ClickHouseClientResourceLive(plan.config))
+  return MarketDataResourceLive(plan).pipe(Layer.provide(clickHouse))
 }
 
-const runBrokerlessService = (plan: RuntimePlanFor<'BrokerlessService'>) =>
-  pipe(brokerlessApplication(plan.config, plan.strategy), Effect.provide(serviceCoreLayers(plan).core))
+const PostgresAuthorityLive = (config: LoadedRuntimeConfig) =>
+  sqlResource(EvidenceStoreResourceLive(config).pipe(Layer.provideMerge(PostgresClientResourceLive(config))))
 
-const brokerServiceLayers = (plan: RuntimePlanFor<'AutonomousObserveService'>) => {
-  const { database, journal, core } = serviceCoreLayers(plan)
-  const storage = Layer.merge(database, journal)
+export const BrokerlessApplicationResourcesLive = (plan: ApplicationPlanFor<'BrokerlessService'>) => {
+  const postgres = PostgresAuthorityLive(plan.config)
   return Layer.mergeAll(
-    core,
-    brokerSessionLayer(plan.config.alpaca),
-    pipe(PaperStoreLive(plan.config), Layer.provide(storage)),
-    pipe(WriterFenceLive, Layer.provide(database)),
-    pipe(CycleStoreLive, Layer.provide(database)),
-  )
+    HttpServerLive(plan.config),
+    SignalMarketDataLive(plan),
+    postgres,
+    JournalResourceLive(plan.config),
+    CycleObservabilityResourceLive.pipe(Layer.provide(postgres)),
+  ).pipe(Layer.provideMerge(ApplicationPlatformLive))
 }
 
-const observeBroker = (plan: RuntimePlanFor<'AutonomousObserveService'>, read: BrokerReadShape) => ({
+export const AutonomousObserveApplicationResourcesLive = (plan: ApplicationPlanFor<'AutonomousObserveService'>) => {
+  const postgres = PostgresAuthorityLive(plan.config)
+  const journal = JournalResourceLive(plan.config)
+  return Layer.mergeAll(
+    HttpServerLive(plan.config),
+    SignalMarketDataLive(plan),
+    postgres,
+    journal,
+    CycleObservabilityResourceLive.pipe(Layer.provide(postgres)),
+    BrokerSessionResourceLive(plan.config),
+    PaperStoreResourceLive(plan.config).pipe(Layer.provide(Layer.merge(postgres, journal))),
+    WriterFenceResourceLive.pipe(Layer.provide(postgres)),
+    CycleStoreResourceLive.pipe(Layer.provide(postgres)),
+  ).pipe(Layer.provideMerge(ApplicationPlatformLive))
+}
+
+export const PaperCandidateDiscoveryResourcesLive = (plan: ApplicationPlanFor<'PaperCandidateDiscovery'>) => {
+  const postgres = sqlResource(PostgresClientResourceLive(plan.config))
+  return Layer.mergeAll(
+    postgres,
+    CycleObservabilityResourceLive.pipe(Layer.provide(postgres)),
+    CycleStoreResourceLive.pipe(Layer.provide(postgres)),
+    BrokerSessionResourceLive(plan.config),
+  ).pipe(Layer.provideMerge(ApplicationPlatformLive))
+}
+
+const applicationDependencies: Effect.Effect<
+  ApplicationDependencies,
+  never,
+  MarketData | Journal | EvidenceStore | CycleObservability
+> = Effect.all({
+  marketData: MarketData,
+  journal: Journal,
+  evidenceStore: EvidenceStore,
+  cycleObservability: CycleObservability,
+})
+
+const runBrokerlessService = (plan: ApplicationPlanFor<'BrokerlessService'>) =>
+  applicationDependencies.pipe(
+    Effect.flatMap((dependencies) => brokerlessApplicationWithDependencies(plan.config, plan.strategy, dependencies)),
+  )
+
+const observeBroker = (plan: ApplicationPlanFor<'AutonomousObserveService'>, read: BrokerReadShape) => ({
   read,
   expectedAccountId: plan.config.alpaca.expectedAccountId,
   executionEligible: false,
   executionDisabledReason: 'MAXIMUM_AUTHORITY_OBSERVE' as const,
 })
 
-const observeCycle = (plan: RuntimePlanFor<'AutonomousObserveService'>) =>
+const observeCycle = (plan: ApplicationPlanFor<'AutonomousObserveService'>) =>
   makeObserveAutonomousCycleStartup({
     accountId: plan.config.alpaca.expectedAccountId,
     authorityGenerationHash: plan.config.alpaca.authorityGenerationHash,
@@ -288,13 +288,17 @@ const observeCycle = (plan: RuntimePlanFor<'AutonomousObserveService'>) =>
     strategy: plan.strategy,
   })
 
-const runAutonomousObserveService = (plan: RuntimePlanFor<'AutonomousObserveService'>) =>
-  pipe(
-    BrokerSession,
-    Effect.flatMap((session) =>
-      autonomousObserveApplication(plan.config, plan.strategy, observeBroker(plan, session.read), observeCycle(plan)),
+const runAutonomousObserveService = (plan: ApplicationPlanFor<'AutonomousObserveService'>) =>
+  Effect.all({ dependencies: applicationDependencies, session: BrokerSession }).pipe(
+    Effect.flatMap(({ dependencies, session }) =>
+      autonomousObserveApplicationWithDependencies(
+        plan.config,
+        plan.strategy,
+        dependencies,
+        observeBroker(plan, session.read),
+        observeCycle(plan),
+      ),
     ),
-    Effect.provide(brokerServiceLayers(plan)),
   )
 
 const encodeJson = Schema.encodeUnknownEffect(Schema.fromJsonString(Schema.Json))
@@ -327,17 +331,7 @@ const policyHash = (policy: unknown): Effect.Effect<string, ReturnType<typeof op
     Effect.fromResult,
   )
 
-const discoveryLayers = (plan: RuntimePlanFor<'PaperCandidateDiscovery'>) => {
-  const postgres = postgresClientLayer(plan.config)
-  return Layer.mergeAll(
-    postgres,
-    pipe(CycleObservabilityLive, Layer.provide(postgres)),
-    pipe(CycleStoreLive, Layer.provide(postgres)),
-    brokerSessionLayer(plan.config.alpaca),
-  )
-}
-
-const paperCandidateIdentity = (plan: RuntimePlanFor<'PaperCandidateDiscovery'>, riskPolicyHash: string) => ({
+const paperCandidateIdentity = (plan: ApplicationPlanFor<'PaperCandidateDiscovery'>, riskPolicyHash: string) => ({
   sourceRevision: plan.config.build.sourceRevision,
   image: {
     repository: plan.config.build.imageRepository,
@@ -351,16 +345,14 @@ const paperCandidateIdentity = (plan: RuntimePlanFor<'PaperCandidateDiscovery'>,
   policyHash: riskPolicyHash,
 })
 
-const discoverPaperCandidate = (plan: RuntimePlanFor<'PaperCandidateDiscovery'>, riskPolicyHash: string) =>
-  pipe(
-    discoverPaperCandidates(paperCandidateIdentity(plan, riskPolicyHash)),
+const discoverPaperCandidate = (plan: ApplicationPlanFor<'PaperCandidateDiscovery'>, riskPolicyHash: string) =>
+  discoverPaperCandidates(paperCandidateIdentity(plan, riskPolicyHash)).pipe(
     Effect.mapError((cause) =>
       operationalError('strategy', 'paper-candidate-discovery', renderPaperCandidateDiscoveryError(cause), cause),
     ),
-    Effect.provide(discoveryLayers(plan)),
   )
 
-const runPaperCandidateDiscovery = (plan: RuntimePlanFor<'PaperCandidateDiscovery'>) =>
+const runPaperCandidateDiscovery = (plan: ApplicationPlanFor<'PaperCandidateDiscovery'>) =>
   pipe(
     loadObserveRiskPolicy(plan.config.alpaca.expectedAccountId, plan.strategy.parameters.universe),
     Effect.mapError((cause) =>
@@ -376,12 +368,18 @@ const runPaperCandidateDiscovery = (plan: RuntimePlanFor<'PaperCandidateDiscover
     Effect.flatMap(writeDiscoveryReceipt),
   )
 
-const interpretRuntimePlan = pipe(
-  Match.type<RuntimePlan>(),
-  Match.tag('BrokerlessService', runBrokerlessService),
-  Match.tag('AutonomousObserveService', runAutonomousObserveService),
-  Match.tag('PaperCandidateDiscovery', runPaperCandidateDiscovery),
+export const runApplicationPlan = pipe(
+  Match.type<ApplicationPlan>(),
+  Match.tag('BrokerlessService', (plan) =>
+    runBrokerlessService(plan).pipe(Effect.provide(BrokerlessApplicationResourcesLive(plan))),
+  ),
+  Match.tag('AutonomousObserveService', (plan) =>
+    runAutonomousObserveService(plan).pipe(Effect.provide(AutonomousObserveApplicationResourcesLive(plan))),
+  ),
+  Match.tag('PaperCandidateDiscovery', (plan) =>
+    runPaperCandidateDiscovery(plan).pipe(Effect.provide(PaperCandidateDiscoveryResourcesLive(plan))),
+  ),
   Match.exhaustive,
 )
 
-export const program = pipe(loadRuntimePlan, Effect.flatMap(interpretRuntimePlan), Effect.scoped)
+export const program = loadApplicationPlan.pipe(Effect.flatMap(runApplicationPlan), Effect.scoped)

--- a/services/bayn/src/health/index.ts
+++ b/services/bayn/src/health/index.ts
@@ -2,6 +2,7 @@ export type {
   AutonomousCycleFiberObservation,
   BrokerProbe,
   DurableEvidenceFailure,
+  HealthDependencies,
   HealthDependencyName,
   HealthLogDecision,
   HealthTransition,
@@ -15,4 +16,11 @@ export {
   validateDurableEvidence,
   validateSignalIdentity,
 } from './decisions'
-export { ensureDurableEvidence, ensureSignalIdentity, monitor, probe } from './program'
+export {
+  ensureDurableEvidence,
+  ensureSignalIdentity,
+  monitor,
+  monitorWithDependencies,
+  probe,
+  probeWithDependencies,
+} from './program'

--- a/services/bayn/src/health/model.ts
+++ b/services/bayn/src/health/model.ts
@@ -1,8 +1,11 @@
 import type { BrokerReadShape } from '../broker/alpaca'
 import type { RuntimeConfig } from '../config'
 import type { CycleOperationsProjection } from '../cycle-observability'
-import type { QualificationRecord } from '../db/evidence-store'
+import type { CycleObservabilityShape } from '../db/cycle-observability'
+import type { EvidenceStoreService, QualificationRecord } from '../db/evidence-store'
 import type { CanonicalHashFailure } from '../hash'
+import type { JournalService } from '../ledger'
+import type { MarketDataService } from '../market-data'
 import type { BrokerConfiguration, RuntimeHealth, RuntimeState } from '../runtime-state'
 import type { UtcEpochMillisFailure } from '../time'
 
@@ -17,6 +20,13 @@ export interface HealthProbeResults {
   readonly durableEvidence: ProbeResult<void>
   readonly cycle: ProbeResult<CycleOperationsProjection>
   readonly broker: ProbeResult<string> | null
+}
+
+export interface HealthDependencies {
+  readonly marketData: MarketDataService
+  readonly journal: JournalService
+  readonly evidenceStore: EvidenceStoreService
+  readonly cycleObservability: CycleObservabilityShape
 }
 
 export type SignalIdentityFailure =

--- a/services/bayn/src/health/program.ts
+++ b/services/bayn/src/health/program.ts
@@ -22,6 +22,7 @@ import {
 import type {
   AutonomousCycleFiberObservation,
   BrokerProbe,
+  HealthDependencies,
   HealthLogDecision,
   HealthProbeResults,
   ProbeResult,
@@ -212,25 +213,22 @@ const collectHealthProbeResults = (
     }),
   )
 
-export const probe = (
+export const probeWithDependencies = (
   config: RuntimeConfig,
   state: Ref.Ref<RuntimeState>,
+  dependencies: HealthDependencies,
   broker?: BrokerProbe,
   autonomousCycleFiber?: Fiber.Fiber<void, never>,
-): Effect.Effect<void, never, MarketData | Journal | EvidenceStore | CycleObservability> =>
+): Effect.Effect<void> =>
   Effect.gen(function* () {
-    const marketData = yield* MarketData
-    const journal = yield* Journal
-    const evidenceStore = yield* EvidenceStore
-    const cycleObservability = yield* CycleObservability
     const initial = yield* Ref.get(state)
     const results = yield* collectHealthProbeResults(
       config,
       initial.evidence,
-      marketData,
-      journal,
-      evidenceStore,
-      cycleObservability,
+      dependencies.marketData,
+      dependencies.journal,
+      dependencies.evidenceStore,
+      dependencies.cycleObservability,
       broker,
     )
     const checkedAtMs = yield* Clock.currentTimeMillis
@@ -254,13 +252,47 @@ export const probe = (
     yield* interpretHealthLogs(deriveHealthLogDecisions(transition))
   }).pipe(Effect.withLogSpan('health'))
 
+export const monitorWithDependencies = (
+  config: RuntimeConfig,
+  state: Ref.Ref<RuntimeState>,
+  dependencies: HealthDependencies,
+  broker?: BrokerProbe,
+  autonomousCycleFiber?: Fiber.Fiber<void, never>,
+): Effect.Effect<void> =>
+  probeWithDependencies(config, state, dependencies, broker, autonomousCycleFiber).pipe(
+    Effect.repeat(Schedule.spaced(Duration.millis(config.healthIntervalMs))),
+    Effect.asVoid,
+  )
+
+const loadHealthDependencies: Effect.Effect<
+  HealthDependencies,
+  never,
+  MarketData | Journal | EvidenceStore | CycleObservability
+> = Effect.all({
+  marketData: MarketData,
+  journal: Journal,
+  evidenceStore: EvidenceStore,
+  cycleObservability: CycleObservability,
+})
+
+export const probe = (
+  config: RuntimeConfig,
+  state: Ref.Ref<RuntimeState>,
+  broker?: BrokerProbe,
+  autonomousCycleFiber?: Fiber.Fiber<void, never>,
+): Effect.Effect<void, never, MarketData | Journal | EvidenceStore | CycleObservability> =>
+  loadHealthDependencies.pipe(
+    Effect.flatMap((dependencies) => probeWithDependencies(config, state, dependencies, broker, autonomousCycleFiber)),
+  )
+
 export const monitor = (
   config: RuntimeConfig,
   state: Ref.Ref<RuntimeState>,
   broker?: BrokerProbe,
   autonomousCycleFiber?: Fiber.Fiber<void, never>,
 ): Effect.Effect<void, never, MarketData | Journal | EvidenceStore | CycleObservability> =>
-  probe(config, state, broker, autonomousCycleFiber).pipe(
-    Effect.repeat(Schedule.spaced(Duration.millis(config.healthIntervalMs))),
-    Effect.asVoid,
+  loadHealthDependencies.pipe(
+    Effect.flatMap((dependencies) =>
+      monitorWithDependencies(config, state, dependencies, broker, autonomousCycleFiber),
+    ),
   )

--- a/services/bayn/src/http.test.ts
+++ b/services/bayn/src/http.test.ts
@@ -2,7 +2,7 @@ import { connect, type Socket } from 'node:net'
 
 import { describe, expect, test } from 'bun:test'
 
-import { Cause, Context, Deferred, Effect, Exit, Fiber, Layer, Option, Ref } from 'effect'
+import { Cause, Deferred, Effect, Exit, Fiber, Option, Ref } from 'effect'
 import { TestClock } from 'effect/testing'
 import { HttpServer } from 'effect/unstable/http'
 
@@ -24,10 +24,11 @@ import {
   fallbackResponseDecision,
   historicalEvidenceResponseDecision,
   historicalReadFailureDecision,
-  makeHttpLayer,
+  HttpServerLive,
   readHistoricalEvidence,
   readinessResponseDecision,
   renderPrometheusMetrics,
+  serveHttp,
   statusFacts,
   statusResponseDecision,
   validateHistoricalRunRequest,
@@ -56,38 +57,37 @@ interface TestServer {
 const withHttpServer = (
   options: TestServerOptions,
   use: (server: TestServer) => Effect.Effect<void, unknown>,
-): Promise<void> =>
-  Effect.runPromise(
+): Promise<void> => {
+  const serverConfig = {
+    cycleStallThresholdMs: config.cycleStallThresholdMs,
+    host: '127.0.0.1',
+    maximumAuthority: options.maximumAuthority ?? Authority.Observe,
+    operationTimeoutMs: options.operationTimeoutMs ?? 250,
+    port: 0,
+    reconciliationStaleThresholdMs: config.reconciliationStaleThresholdMs,
+    unknownMutationThresholdMs: config.unknownMutationThresholdMs,
+  }
+  return Effect.runPromise(
     Effect.scoped(
-      Ref.make(options.state ?? initialState()).pipe(
-        Effect.flatMap((state) =>
-          Layer.build(
-            makeHttpLayer(
-              {
-                cycleStallThresholdMs: config.cycleStallThresholdMs,
-                host: '127.0.0.1',
-                maximumAuthority: options.maximumAuthority ?? Authority.Observe,
-                operationTimeoutMs: options.operationTimeoutMs ?? 250,
-                port: 0,
-                reconciliationStaleThresholdMs: config.reconciliationStaleThresholdMs,
-                unknownMutationThresholdMs: config.unknownMutationThresholdMs,
-              },
-              state,
-              provenance,
-              'embedded',
-              options.readEvidence ?? successfulEvidenceStore.read,
-            ),
-          ).pipe(
-            Effect.flatMap((context) => {
-              const address = Context.get(context, HttpServer.HttpServer).address
-              expect(address._tag).toBe('TcpAddress')
-              return address._tag === 'TcpAddress' ? use({ port: address.port, state }) : Effect.die('expected TCP')
-            }),
-          ),
-        ),
-      ),
+      Effect.gen(function* () {
+        const state = yield* Ref.make(options.state ?? initialState())
+        yield* serveHttp(
+          serverConfig,
+          state,
+          provenance,
+          'embedded',
+          options.readEvidence ?? successfulEvidenceStore.read,
+        )
+        const server = yield* HttpServer.HttpServer
+        const address = server.address
+        expect(address._tag).toBe('TcpAddress')
+        return address._tag === 'TcpAddress'
+          ? yield* use({ port: address.port, state })
+          : yield* Effect.die('expected TCP')
+      }).pipe(Effect.provide(HttpServerLive(serverConfig))),
     ),
   )
+}
 
 const request = (port: number, path: string, method = 'GET') =>
   Effect.tryPromise({

--- a/services/bayn/src/http.ts
+++ b/services/bayn/src/http.ts
@@ -1,8 +1,8 @@
 import { createServer } from 'node:http'
 
 import { NodeHttpServer, NodeHttpServerRequest } from '@effect/platform-node'
-import { Deferred, Effect, Layer, Option, Ref } from 'effect'
-import { HttpRouter, HttpServerRequest, HttpServerResponse } from 'effect/unstable/http'
+import { Deferred, Effect, Option, Ref, Scope } from 'effect'
+import { HttpRouter, HttpServer, HttpServerRequest, HttpServerResponse } from 'effect/unstable/http'
 
 import type { RuntimeBuildMetadata, RuntimeConfig } from './config'
 import type { RuntimeProvenance } from './contracts'
@@ -523,22 +523,28 @@ const interruptOnClientDisconnect = <A, E, R>(
   effect: Effect.Effect<A, E, R>,
 ): Effect.Effect<A, E, R> => Effect.raceFirst(effect, clientDisconnect(request)).pipe(Effect.interruptible)
 
-export const makeHttpLayer = (
-  config: Pick<
-    RuntimeConfig,
-    | 'cycleStallThresholdMs'
-    | 'host'
-    | 'maximumAuthority'
-    | 'operationTimeoutMs'
-    | 'port'
-    | 'reconciliationStaleThresholdMs'
-    | 'unknownMutationThresholdMs'
-  >,
+type HttpConfig = Pick<
+  RuntimeConfig,
+  | 'cycleStallThresholdMs'
+  | 'host'
+  | 'maximumAuthority'
+  | 'operationTimeoutMs'
+  | 'port'
+  | 'reconciliationStaleThresholdMs'
+  | 'unknownMutationThresholdMs'
+>
+
+export const HttpServerLive = (config: Pick<RuntimeConfig, 'host' | 'port'>) =>
+  NodeHttpServer.layer(createServer, { host: config.host, port: config.port })
+
+const registerHttpRoutes = (
+  config: HttpConfig,
   state: Ref.Ref<RuntimeState>,
   provenance: RuntimeProvenance,
   provenanceVerification: RuntimeBuildMetadata['verification'],
   readEvidence: ReadEvidence,
-): ReturnType<typeof NodeHttpServer.layer> => {
+  router: HttpRouter.HttpRouter,
+): Effect.Effect<void> => {
   const ready = Ref.get(state).pipe(Effect.map(readinessResponseDecision), Effect.flatMap(interpretResponseDecision))
   const status = Ref.get(state).pipe(
     Effect.map((current) =>
@@ -576,16 +582,28 @@ export const makeHttpLayer = (
     request: HttpServerRequest.HttpServerRequest,
   ): Effect.Effect<HttpServerResponse.HttpServerResponse> =>
     interpretResponseDecision(fallbackResponseDecision(request.method))
-  const routes = HttpRouter.addAll([
-    HttpRouter.route('GET', '/livez', interpretResponseDecision(jsonDecision({ service: 'bayn', live: true }))),
-    HttpRouter.route('GET', '/readyz', ready),
-    HttpRouter.route('GET', '/metrics', metrics),
-    HttpRouter.route('GET', '/v1/status', status),
-    HttpRouter.route('GET', '/v1/evaluations/:runId', historicalEvaluation),
-    HttpRouter.route('*', '*', fallback),
-  ] as const)
-
-  return HttpRouter.serve(routes, { disableLogger: true }).pipe(
-    Layer.provideMerge(NodeHttpServer.layer(createServer, { host: config.host, port: config.port })),
-  )
+  return Effect.gen(function* () {
+    yield* router.add('GET', '/livez', interpretResponseDecision(jsonDecision({ service: 'bayn', live: true })))
+    yield* router.add('GET', '/readyz', ready)
+    yield* router.add('GET', '/metrics', metrics)
+    yield* router.add('GET', '/v1/status', status)
+    yield* router.add('GET', '/v1/evaluations/:runId', historicalEvaluation)
+    yield* router.add('*', '*', fallback)
+  })
 }
+
+export const serveHttp = (
+  config: HttpConfig,
+  state: Ref.Ref<RuntimeState>,
+  provenance: RuntimeProvenance,
+  provenanceVerification: RuntimeBuildMetadata['verification'],
+  readEvidence: ReadEvidence,
+): Effect.Effect<void, never, HttpServer.HttpServer | Scope.Scope> =>
+  Effect.gen(function* () {
+    const router = yield* HttpRouter.make
+    yield* registerHttpRoutes(config, state, provenance, provenanceVerification, readEvidence, router)
+    // The router API erases the closed route error set to unknown; the total fallback makes any residue a defect.
+    // @effect-diagnostics-next-line anyUnknownInErrorContext:off
+    const handler = router.asHttpEffect().pipe(Effect.orDie)
+    yield* HttpServer.serveEffect(handler)
+  })

--- a/services/bayn/src/index.ts
+++ b/services/bayn/src/index.ts
@@ -1,8 +1,8 @@
-import { NodeRuntime, NodeServices } from '@effect/platform-node'
-import { Effect, Layer, Logger, pipe } from 'effect'
+import { NodeRuntime } from '@effect/platform-node'
+import { Effect, Logger, pipe } from 'effect'
 
 import { program } from './entrypoint'
 
-const runtime = Layer.merge(Logger.layer([Logger.consoleJson]), NodeServices.layer)
-
-NodeRuntime.runMain(pipe(program, Effect.annotateLogs({ service: 'bayn' }), Effect.provide(runtime)))
+NodeRuntime.runMain(
+  pipe(program, Effect.annotateLogs({ service: 'bayn' }), Effect.provide(Logger.layer([Logger.consoleJson]))),
+)

--- a/services/bayn/src/operations.test.ts
+++ b/services/bayn/src/operations.test.ts
@@ -12,7 +12,7 @@ import {
 
 import { CycleObservabilityError } from './db/cycle-observability'
 import { DatabaseError } from './db/evidence-store'
-import { acquireSqlLayer, databaseOperation } from './operations'
+import { acquireSqlResource, databaseOperation } from './operations'
 
 describe('Bayn SQL dependency acquisition', () => {
   test('retries only retryable SQL failures', async () => {
@@ -28,7 +28,7 @@ describe('Bayn SQL dependency acquisition', () => {
     )
     const program = Effect.scoped(
       Effect.gen(function* () {
-        const fiber = yield* acquireSqlLayer(dependencies).pipe(Effect.forkScoped({ startImmediately: true }))
+        const fiber = yield* acquireSqlResource(dependencies).pipe(Effect.forkScoped({ startImmediately: true }))
         yield* Effect.yieldNow
         expect(attempts).toBe(1)
         yield* TestClock.adjust('1 second')
@@ -45,7 +45,7 @@ describe('Bayn SQL dependency acquisition', () => {
     })
     const exit = await Effect.runPromiseExit(
       Effect.scoped(
-        acquireSqlLayer(
+        acquireSqlResource(
           Layer.effectDiscard(
             Effect.sync(() => {
               attempts += 1
@@ -78,7 +78,7 @@ describe('Bayn SQL dependency acquisition', () => {
     )
     const program = Effect.scoped(
       Effect.gen(function* () {
-        const fiber = yield* acquireSqlLayer(dependencies).pipe(Effect.forkScoped({ startImmediately: true }))
+        const fiber = yield* acquireSqlResource(dependencies).pipe(Effect.forkScoped({ startImmediately: true }))
         yield* Effect.yieldNow
         expect(attempts).toBe(1)
         yield* TestClock.adjust('1 second')
@@ -111,7 +111,7 @@ describe('Bayn SQL dependency acquisition', () => {
     )
     const program = Effect.scoped(
       Effect.gen(function* () {
-        const fiber = yield* acquireSqlLayer(dependencies).pipe(Effect.forkScoped({ startImmediately: true }))
+        const fiber = yield* acquireSqlResource(dependencies).pipe(Effect.forkScoped({ startImmediately: true }))
         yield* Effect.yieldNow
         expect(attempts).toBe(1)
         yield* TestClock.adjust('1 second')
@@ -128,7 +128,7 @@ describe('Bayn SQL dependency acquisition', () => {
       let attempts = 0
       return Effect.scoped(
         Effect.gen(function* () {
-          const fiber = yield* acquireSqlLayer(
+          const fiber = yield* acquireSqlResource(
             Layer.effectDiscard(
               Effect.sync(() => {
                 attempts += 1
@@ -178,7 +178,7 @@ describe('Bayn SQL dependency acquisition', () => {
     })
     const program = Effect.scoped(
       Effect.gen(function* () {
-        const fiber = yield* acquireSqlLayer(
+        const fiber = yield* acquireSqlResource(
           Layer.effectDiscard(
             Effect.sync(() => {
               attempts += 1
@@ -201,7 +201,7 @@ describe('Bayn SQL dependency acquisition', () => {
 
     await Effect.runPromise(
       Effect.scoped(
-        acquireSqlLayer(
+        acquireSqlResource(
           Layer.effectDiscard(
             Effect.acquireRelease(Effect.void, () =>
               Effect.sync(() => {

--- a/services/bayn/src/operations.ts
+++ b/services/bayn/src/operations.ts
@@ -22,17 +22,16 @@ const isRetryableSqlAcquisition = (error: unknown): boolean => {
   )
 }
 
-export const acquireSqlLayer = <A, E, R>(layer: Layer.Layer<A, E, R>) => Layer.build(retrySqlLayer(layer))
+export const acquireSqlResource = <A, E, R>(layer: Layer.Layer<A, E, R>) => Layer.build(sqlResource(layer))
 
-export const retrySqlLayer = <A, E, R>(layer: Layer.Layer<A, E, R>): Layer.Layer<A, E, R> =>
-  Layer.unwrap(
+export const sqlResource = <A, E, R>(layer: Layer.Layer<A, E, R>): Layer.Layer<A, E, R> =>
+  Layer.effectContext(
     Layer.build(layer).pipe(
       Effect.retry({
         times: 2,
         schedule: Schedule.spaced(Duration.seconds(1)),
         while: isRetryableSqlAcquisition,
       }),
-      Effect.map(Layer.succeedContext),
     ),
   )
 

--- a/services/bayn/src/startup.test.ts
+++ b/services/bayn/src/startup.test.ts
@@ -38,6 +38,7 @@ import {
   type StoredEvaluationEvidence,
 } from './db/evidence-store'
 import { operationalError } from './errors'
+import { HttpServerLive } from './http'
 import { canonicalHashV1 } from './hash'
 import { Journal, type JournalService } from './ledger'
 import { MarketData } from './market-data'
@@ -1349,6 +1350,7 @@ describe('Bayn startup lifecycle', () => {
         Effect.provideService(Journal, successfulJournal),
         Effect.provideService(EvidenceStore, successfulEvidenceStore),
         Effect.provideService(CycleObservability, cycleObservability),
+        Effect.provide(HttpServerLive(config)),
         Effect.timeoutOrElse({
           duration: 250,
           orElse: () =>
@@ -1376,6 +1378,7 @@ describe('Bayn startup lifecycle', () => {
         Effect.provideService(Journal, journal),
         Effect.provideService(EvidenceStore, successfulEvidenceStore),
         Effect.provideService(CycleObservability, cycleObservability),
+        Effect.provide(HttpServerLive(config)),
         Effect.timeoutOrElse({
           duration: 250,
           orElse: () =>

--- a/services/bayn/src/startup/index.ts
+++ b/services/bayn/src/startup/index.ts
@@ -6,6 +6,6 @@ export {
   evaluateLockedSnapshot,
   qualifyEvaluation,
 } from './decisions'
-export type { StartupDecisionFailure } from './model'
+export type { StartupDecisionFailure, StartupDependencies } from './model'
 export { renderStartupDecisionFailure } from './presentation'
-export { initialize } from './program'
+export { initialize, initializeWithDependencies } from './program'

--- a/services/bayn/src/startup/program.ts
+++ b/services/bayn/src/startup/program.ts
@@ -25,6 +25,7 @@ import type {
   EvaluationWorkflow,
   PinnedQualificationFacts,
   QualificationPath,
+  StartupDependencies,
   StartupCompletion,
   StartupDecisionFailure,
 } from './model'
@@ -283,19 +284,16 @@ const recoverPinnedQualification = (
   config: RuntimeConfig,
   runId: string,
   state: Ref.Ref<RuntimeState>,
-): Effect.Effect<void, OperationalError, EvidenceStore> =>
-  EvidenceStore.pipe(
-    Effect.tap(() =>
-      Effect.logInfo('Bayn pinned qualification recovery started').pipe(
-        Effect.annotateLogs({
-          service: 'bayn',
-          runId,
-          currentSourceRevision: config.build.sourceRevision,
-          currentImageDigest: config.build.imageDigest,
-        }),
-      ),
-    ),
-    Effect.flatMap((evidenceStore) =>
+  evidenceStore: EvidenceStoreService,
+): Effect.Effect<void, OperationalError> =>
+  Effect.logInfo('Bayn pinned qualification recovery started').pipe(
+    Effect.annotateLogs({
+      service: 'bayn',
+      runId,
+      currentSourceRevision: config.build.sourceRevision,
+      currentImageDigest: config.build.imageDigest,
+    }),
+    Effect.andThen(
       readPinnedQualification(config, runId, evidenceStore).pipe(
         Effect.flatMap((facts) => fromStartupDecision(decidePinnedQualification(config, runId, facts))),
         Effect.flatMap((decision) =>
@@ -315,6 +313,20 @@ const recoverPinnedQualification = (
     Effect.withLogSpan('startup'),
   )
 
+const logEvaluationStart = (config: RuntimeConfig, strategy: Strategy): Effect.Effect<void> =>
+  Effect.logInfo('Bayn startup evaluation started').pipe(
+    Effect.annotateLogs({
+      service: 'bayn',
+      sourceRevision: config.build.sourceRevision,
+      imageDigest: config.build.imageDigest,
+      strategyBehaviorHash: strategy.provenance.strategy.behaviorHash,
+      parameterHash: strategy.provenance.strategy.parameterHash,
+      snapshotId: config.clickhouse.snapshotId,
+      evaluationStart: config.clickhouse.bounds.evaluationStart,
+      evaluationEnd: config.clickhouse.bounds.evaluationEnd,
+    }),
+  )
+
 const runEvaluationWorkflow = (workflow: EvaluationWorkflow): Effect.Effect<StartupCompletion, OperationalError> =>
   checkStartupDependencies(workflow).pipe(
     Effect.andThen(inspectSignalSnapshot(workflow)),
@@ -330,44 +342,32 @@ const evaluateAndJournal = (
   config: RuntimeConfig,
   state: Ref.Ref<RuntimeState>,
   strategy: Strategy,
-): Effect.Effect<void, OperationalError, MarketData | Journal | EvidenceStore> =>
-  Effect.all({
-    marketData: MarketData,
-    journal: Journal,
-    evidenceStore: EvidenceStore,
-  }).pipe(
-    Effect.map(
-      (dependencies): EvaluationWorkflow => ({
-        config,
-        strategy,
-        dependencies,
-      }),
-    ),
-    Effect.tap(() =>
-      Effect.logInfo('Bayn startup evaluation started').pipe(
-        Effect.annotateLogs({
-          service: 'bayn',
-          sourceRevision: config.build.sourceRevision,
-          imageDigest: config.build.imageDigest,
-          strategyBehaviorHash: strategy.provenance.strategy.behaviorHash,
-          parameterHash: strategy.provenance.strategy.parameterHash,
-          snapshotId: config.clickhouse.snapshotId,
-          evaluationStart: config.clickhouse.bounds.evaluationStart,
-          evaluationEnd: config.clickhouse.bounds.evaluationEnd,
-        }),
-      ),
-    ),
-    Effect.flatMap(runEvaluationWorkflow),
+  dependencies: StartupDependencies,
+): Effect.Effect<void, OperationalError> =>
+  logEvaluationStart(config, strategy).pipe(
+    Effect.andThen(runEvaluationWorkflow({ config, strategy, dependencies })),
     Effect.flatMap((completion) => publishStartupCompletion(state, completion)),
     Effect.withLogSpan('startup'),
   )
+
+export const initializeWithDependencies = (
+  config: RuntimeConfig,
+  state: Ref.Ref<RuntimeState>,
+  strategy: Strategy,
+  dependencies: StartupDependencies,
+): Effect.Effect<void, OperationalError> =>
+  (config.qualificationRunId === undefined
+    ? evaluateAndJournal(config, state, strategy, dependencies)
+    : recoverPinnedQualification(config, config.qualificationRunId, state, dependencies.evidenceStore)
+  ).pipe(Effect.catch((error) => (error.retryable ? Effect.fail(error) : failStartup(state, error))))
 
 export const initialize = (
   config: RuntimeConfig,
   state: Ref.Ref<RuntimeState>,
   strategy: Strategy,
 ): Effect.Effect<void, OperationalError, MarketData | Journal | EvidenceStore> =>
-  (config.qualificationRunId === undefined
-    ? evaluateAndJournal(config, state, strategy)
-    : recoverPinnedQualification(config, config.qualificationRunId, state)
-  ).pipe(Effect.catch((error) => (error.retryable ? Effect.fail(error) : failStartup(state, error))))
+  Effect.all({
+    marketData: MarketData,
+    journal: Journal,
+    evidenceStore: EvidenceStore,
+  }).pipe(Effect.flatMap((dependencies) => initializeWithDependencies(config, state, strategy, dependencies)))


### PR DESCRIPTION
## Summary

- introduce a pure exhaustive `ApplicationPlan` covering brokerless service, autonomous OBSERVE service, and paper candidate discovery
- expose narrow `StartupDependencies`, `HealthDependencies`, and `ApplicationDependencies` records while retaining compatibility facades
- move HTTP server ownership and full resource provision to one outer entrypoint composition root
- replace opaque layer buckets and error-erasing layer adapters with named resource layers
- centralize scoped SQL resource retry without `Layer.unwrap` / `Layer.succeedContext`
- preserve the read-only Alpaca OBSERVE path with `executionEligible: false` and no capital or mutation capability

## Safety invariants

- startup and readiness remain fail-closed
- qualification and evidence identities remain immutable and provenance-bound
- PostgreSQL remains workflow authority; TigerBeetle reconciliation and mutation recovery paths are unchanged
- OBSERVE remains the maximum effective authority in this runtime path
- no qualification, broker mutation, capital enablement, credential change, or deployment was performed

## Validation

Post-rebase onto Effect 4.0.0-beta.102 (`origin/main` `ab08e8e10`):

- `bun run --filter @proompteng/bayn test` — 806 passed, 0 failed; 122 PostgreSQL/environment tests skipped locally because the agents-shell container has no PostgreSQL service
- `bun run --filter @proompteng/bayn tsc` — passed
- `bun run --filter @proompteng/bayn lint` — passed
- `bun run --filter @proompteng/bayn lint:oxlint` — 0 warnings, 0 errors
- `bun run --filter @proompteng/bayn lint:oxlint:type` — 0 warnings, 0 errors
- `bun run --filter @proompteng/bayn lint:effect` — 0 errors, 0 warnings, 0 messages
- `bun run --filter @proompteng/bayn build` — passed, 627 modules bundled

Bayn CI must run the PostgreSQL-backed integration tests with its configured database service.

## Quantitative change

- 14 owned files changed; 518 insertions, 336 deletions
- opaque layer-bucket identifiers: 7 → 0
- `Layer.unwrap`: 2 → 0
- `Layer.succeedContext`: 2 → 0
- `mapLayerError`: 2 → 0
- nested `makeHttpLayer` identifiers: 3 → 0
- direct app/startup/health resource requirement slots: 11 → 1 (only the externally provided HTTP server remains)
- production LOC across changed files: 2,049 → 2,176 (+127) to make plans, dependencies, and resource ownership explicit
