### PR TITLE
fix(nix): refresh Effect patch dependency hashes

### DIFF
--- a/nix/images/bumba.nix
+++ b/nix/images/bumba.nix
@@ -11,8 +11,8 @@ import ./bun-workspace-service.nix {
   serviceName = "bumba";
   packageName = "@proompteng/bumba";
   depsHash = {
-    x86_64-linux = "sha256-NM+BPCnISkk2k1PauM49xSsGaaCP9p0sdUFq/gcolck=";
-    aarch64-linux = "sha256-bT36tSGaXh0nKCPWLJOve9P2EuWBAEJ2oWWsmou45Dg=";
+    x86_64-linux = "sha256-ye5UQaYX6XVAzmSjMxoXw9J2F+hBhhsJtLwrOxILXMw=";
+    aarch64-linux = "sha256-Q0gBGuWkS6yOQCL0TnaJqSSPWxgeymcUqIELgqwv9/k=";
   };
   installFilters = [
     "@proompteng/bumba"

--- a/nix/images/froussard.nix
+++ b/nix/images/froussard.nix
@@ -11,8 +11,8 @@ import ./bun-workspace-service.nix {
   serviceName = "froussard";
   packageName = "froussard";
   depsHash = {
-    x86_64-linux = "sha256-Q6BOhqton41StaCJ7xf+xxNl0xTg60kPDWehi39ElFk=";
-    aarch64-linux = "sha256-e0YrfnZItavJzZDl1oFt3RGt9W0SNl52ZNIP7izA2A4=";
+    x86_64-linux = "sha256-Nelh65T/AmEZHXenX4HmWXvMmXcFyaQY219zfEL2GwA=";
+    aarch64-linux = "sha256-PHVaadK7Fs1Ul9+IaGCJ710HmGJIfY6NavTycjbBAes=";
   };
   installFilters = [
     "@proompteng/agent-contracts"

--- a/nix/images/oirat.nix
+++ b/nix/images/oirat.nix
@@ -11,8 +11,8 @@ import ./bun-workspace-service.nix {
   serviceName = "oirat";
   packageName = "@proompteng/oirat";
   depsHash = {
-    x86_64-linux = "sha256-u3v9tkwhCCRO1UVIPk9N3EboACBt124Mr6ao7WpmWaw=";
-    aarch64-linux = "sha256-BHt13fiIkXK6vRAV+2zLOFZu5do/pn+hbIRz32hH8P8=";
+    x86_64-linux = "sha256-kClC6ZiD81hOVPNo2zmIHNvfNcH1LDx4RyFBQRBk7cs=";
+    aarch64-linux = "sha256-HOW37bOzb6OjdlctzVJ2HhNxDlEH+Z8xqrpPrjypFN8=";
   };
   installFilters = [
     "@proompteng/discord"


### PR DESCRIPTION
## Summary

- completes the Effect beta.102 cohort remediation from #13313 by refreshing every remaining default `nodeModules` fixed-output dependency closure affected by the root manifest and patch-tree change
- updates Bumba, Oirat, and Froussard hashes for both x86_64-linux and aarch64-linux using values emitted by clean architecture-specific Nix builds
- changes no application source, runtime configuration, credentials, GitOps authority, or deployment manifests

## Related Issues

Follow-up to #13313 and its final automated Codex P1 review.

## Testing

Hash derivation runs on the merged #13313 source:
- Bumba: workflow run 30324428323
- Oirat: workflow run 30324429365
- Froussard: workflow run 30324430485

Post-fix verification runs before rebase:
- Bumba: workflow run 30324790382
- Oirat: workflow run 30324791613
- Froussard: workflow run 30324792876

Final verification runs after rebasing onto current `origin/main`:
- Bumba: workflow run 30325027038
- Oirat: workflow run 30325028064
- Froussard: workflow run 30325029040

Each verification workflow builds linux/amd64 and linux/arm64. Normal PR checks also validate each affected service.

## Quantitative change

- affected stale image definitions fixed: 3/3
- architecture hashes refreshed: 6
- source/runtime/GitOps files changed: 0
- diff: 3 files, +6 / -6 LOC

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] The change is limited to fixed-output dependency hashes derived by CI.
