### PR TITLE
chore(oirat): promote nix image sha-4214ec4e148389db331d8adb18d2af52e46f97f6

### DIFF
--- a/argocd/applications/oirat/kustomization.yaml
+++ b/argocd/applications/oirat/kustomization.yaml
@@ -10,4 +10,4 @@ resources:
   - alloy-deployment.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/oirat
-    digest: sha256:01e5f0ea021d4f37b4164cfe9807c6ed13d2afe873b00a3ab2c0717950ec72bf
+    digest: sha256:12b60fbeb5434fe44ff7762c640dc4827a48763f7a9778fdbc2835defd70c9ea


### PR DESCRIPTION
## Summary

- Promote `oirat` to `registry.ide-newton.ts.net/lab/oirat@sha256:12b60fbeb5434fe44ff7762c640dc4827a48763f7a9778fdbc2835defd70c9ea`.
- Source commit: `4214ec4e148389db331d8adb18d2af52e46f97f6`.
- Source version: `v0.596.0-2693-g4214ec4e1`.
- Built by the shared Nix OCI workflow without Docker Buildx.

## Related Issues

N/A

## Testing

- `nix run .#assert-oci-platforms -- "registry.ide-newton.ts.net/lab/oirat@sha256:12b60fbeb5434fe44ff7762c640dc4827a48763f7a9778fdbc2835defd70c9ea" linux/amd64 linux/arm64`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.