### PR TITLE
chore(bumba): promote nix image sha-4214ec4e148389db331d8adb18d2af52e46f97f6

### DIFF
--- a/argocd/applications/bumba/deployment.yaml
+++ b/argocd/applications/bumba/deployment.yaml
@@ -73,7 +73,7 @@ spec:
             - name: TEMPORAL_TASK_QUEUE
               value: bumba
             - name: TEMPORAL_WORKER_BUILD_ID
-              value: bumba@4000b49f4435a9b8b27a6cc2b368258ace30e4e7
+              value: bumba@4214ec4e148389db331d8adb18d2af52e46f97f6
             - name: TEMPORAL_WORKFLOW_CONCURRENCY
               value: "12"
             - name: TEMPORAL_ACTIVITY_CONCURRENCY

--- a/argocd/applications/bumba/kustomization.yaml
+++ b/argocd/applications/bumba/kustomization.yaml
@@ -6,5 +6,5 @@ resources:
   - deployment.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/bumba
-    digest: sha256:cb12e8bf2ea5915eb74286be0710ee77fbf6ab67eab0da2b20551c9206b3780e
+    digest: sha256:ab9f06c1c33c86f0747974400f515a3cad5300972b20477953e595ec33b728c6
     newName: registry.ide-newton.ts.net/lab/bumba


### PR DESCRIPTION
## Summary

- Promote `bumba` to `registry.ide-newton.ts.net/lab/bumba@sha256:ab9f06c1c33c86f0747974400f515a3cad5300972b20477953e595ec33b728c6`.
- Source commit: `4214ec4e148389db331d8adb18d2af52e46f97f6`.
- Source version: `v0.596.0-2693-g4214ec4e1`.
- Built by the shared Nix OCI workflow without Docker Buildx.

## Related Issues

N/A

## Testing

- `nix run .#assert-oci-platforms -- "registry.ide-newton.ts.net/lab/bumba@sha256:ab9f06c1c33c86f0747974400f515a3cad5300972b20477953e595ec33b728c6" linux/amd64 linux/arm64`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.