### PR TITLE
refactor(bayn): make application composition explicit

### DIFF
--- a/services/bayn/src/app.test.ts
+++ b/services/bayn/src/app.test.ts
@@ -15,23 +15,19 @@ import {
 } from './app-test-support'
 import {
   type ApplicationIdentity,
-  autonomousObserveApplication,
   type AutonomousCycleStartupInput,
   type AutonomousObserveApplicationConfig,
   type BrokerlessApplicationConfig,
   makeApplicationPlan,
+  runApplication,
 } from './app'
 import { AccountStatus, BrokerProvider, alpacaSandboxBaseUrl, type BrokerReadShape } from './broker/alpaca'
 import { unusedAssetBySymbol, unusedMarketCalendar } from './broker/alpaca-test-support'
 import type { LoadedRuntimeConfig } from './config'
 import { makeStrategyProtocolHash } from './contracts'
-import { CycleObservability } from './db/cycle-observability'
-import { EvidenceStore } from './db/evidence-store'
 import { BrokerEnvironment } from './execution/authority'
 import type { BrokerProbe } from './health'
 import { HttpServerLive } from './http'
-import { Journal } from './ledger'
-import { MarketData } from './market-data'
 import { Authority } from './paper'
 import { makeStrategy } from './strategy'
 import { fixtureProtocol, makeSnapshot, makeTestProvenance } from './test-fixtures'
@@ -188,11 +184,17 @@ describe('Bayn application composition', () => {
               ),
             )
           const fiber = yield* pipe(
-            autonomousObserveApplication(autonomousConfig(config), fixtureStrategy, broker, startCycle),
-            Effect.provideService(MarketData, marketData),
-            Effect.provideService(Journal, successfulJournal),
-            Effect.provideService(EvidenceStore, successfulEvidenceStore),
-            Effect.provideService(CycleObservability, cycleObservability),
+            runApplication(
+              autonomousConfig(config),
+              fixtureStrategy,
+              {
+                marketData,
+                journal: successfulJournal,
+                evidenceStore: successfulEvidenceStore,
+                cycleObservability,
+              },
+              { _tag: 'AutonomousObserve', broker, startCycle },
+            ),
             Effect.provide(HttpServerLive(config)),
             Effect.forkScoped,
           )
@@ -226,14 +228,17 @@ describe('Bayn application composition', () => {
               Effect.as(pipe(Deferred.succeed(started, undefined), Effect.andThen(Effect.never))),
             )
           const fiber = yield* pipe(
-            autonomousObserveApplication(autonomousConfig(pinnedRuntimeConfig), currentStrategy, broker, startCycle),
-            Effect.provideService(
-              MarketData,
-              marketDataService(Effect.die(new Error('pinned startup must not load Signal bars'))),
+            runApplication(
+              autonomousConfig(pinnedRuntimeConfig),
+              currentStrategy,
+              {
+                marketData: marketDataService(Effect.die(new Error('pinned startup must not load Signal bars'))),
+                journal: successfulJournal,
+                evidenceStore: pinnedStore(),
+                cycleObservability,
+              },
+              { _tag: 'AutonomousObserve', broker, startCycle },
             ),
-            Effect.provideService(Journal, successfulJournal),
-            Effect.provideService(EvidenceStore, pinnedStore()),
-            Effect.provideService(CycleObservability, cycleObservability),
             Effect.provide(HttpServerLive(pinnedRuntimeConfig)),
             Effect.forkScoped,
           )

--- a/services/bayn/src/app.ts
+++ b/services/bayn/src/app.ts
@@ -3,15 +3,15 @@ import { HttpServer } from 'effect/unstable/http'
 
 import type { LoadedRuntimeConfig, RuntimeConfig } from './config'
 import type { CausalProtocol } from './protocol'
-import { CycleObservability, type CycleObservabilityShape } from './db/cycle-observability'
-import { EvidenceStore, type EvidenceStoreService } from './db/evidence-store'
+import type { CycleObservabilityShape } from './db/cycle-observability'
+import type { EvidenceStoreService } from './db/evidence-store'
 import { operationalError, type OperationalError } from './errors'
-import { monitorWithDependencies, type BrokerProbe, type HealthDependencies } from './health'
+import { runHealthMonitor, type BrokerProbe, type HealthDependencies } from './health'
 import { serveHttp } from './http'
-import { Journal, type JournalService } from './ledger'
-import { MarketData, type MarketDataService } from './market-data'
+import type { JournalService } from './ledger'
+import type { MarketDataService } from './market-data'
 import { initialState, type AutonomousCyclePassObservation, type RuntimeState } from './runtime-state'
-import { initializeWithDependencies, type StartupDependencies } from './startup'
+import { runStartup, type StartupDependencies } from './startup'
 import type { Strategy } from './strategy'
 import { utcInstantFromEpochMillis } from './time'
 
@@ -80,7 +80,7 @@ export interface ApplicationDependencies extends StartupDependencies, HealthDepe
   readonly cycleObservability: CycleObservabilityShape
 }
 
-type ApplicationRuntime<StartupR, LoopR> =
+export type ApplicationRuntime<StartupR, LoopR> =
   | { readonly _tag: 'Brokerless' }
   | {
       readonly _tag: 'AutonomousObserve'
@@ -188,7 +188,7 @@ const startAutonomousCycle = <StartupR, LoopR>(
         ),
       )
 
-const runApplicationWithDependencies = <StartupR, LoopR>(
+export const runApplication = <StartupR, LoopR>(
   config: RuntimeConfig,
   strategy: Strategy,
   dependencies: ApplicationDependencies,
@@ -200,72 +200,14 @@ const runApplicationWithDependencies = <StartupR, LoopR>(
     Effect.tap(({ state }) =>
       serveHttp(config, state, strategy.provenance, config.build.verification, dependencies.evidenceStore.read),
     ),
-    Effect.tap(({ state }) => initializeWithDependencies(config, state, strategy, dependencies)),
+    Effect.tap(({ state }) => runStartup(config, state, strategy, dependencies)),
     Effect.bind('autonomousCycleFiber', ({ state }) => startAutonomousCycle(runtime, state)),
     Effect.tap(({ autonomousCycleFiber, state }) =>
       pipe(
-        monitorWithDependencies(config, state, dependencies, brokerProbe(runtime), autonomousCycleFiber),
+        runHealthMonitor(config, state, dependencies, brokerProbe(runtime), autonomousCycleFiber),
         Effect.forkScoped({ startImmediately: true }),
       ),
     ),
     Effect.andThen(Effect.never),
     Effect.scoped,
   )
-
-const loadApplicationDependencies: Effect.Effect<
-  ApplicationDependencies,
-  never,
-  MarketData | Journal | EvidenceStore | CycleObservability
-> = Effect.all({
-  marketData: MarketData,
-  journal: Journal,
-  evidenceStore: EvidenceStore,
-  cycleObservability: CycleObservability,
-})
-
-export const brokerlessApplicationWithDependencies = (
-  config: BrokerlessApplicationConfig,
-  strategy: Strategy,
-  dependencies: ApplicationDependencies,
-): Effect.Effect<never, OperationalError, HttpServer.HttpServer> =>
-  runApplicationWithDependencies(config, strategy, dependencies, { _tag: 'Brokerless' })
-
-export const autonomousObserveApplicationWithDependencies = <StartupR, LoopR>(
-  config: AutonomousObserveApplicationConfig,
-  strategy: Strategy,
-  dependencies: ApplicationDependencies,
-  broker: BrokerProbe,
-  startCycle: AutonomousCycleStartup<StartupR, LoopR>,
-): Effect.Effect<never, OperationalError, HttpServer.HttpServer | StartupR | LoopR> =>
-  runApplicationWithDependencies(config, strategy, dependencies, { _tag: 'AutonomousObserve', broker, startCycle })
-
-export const brokerlessApplication = (
-  config: BrokerlessApplicationConfig,
-  strategy: Strategy,
-): Effect.Effect<
-  never,
-  OperationalError,
-  HttpServer.HttpServer | MarketData | Journal | EvidenceStore | CycleObservability
-> =>
-  loadApplicationDependencies.pipe(
-    Effect.flatMap((dependencies) => brokerlessApplicationWithDependencies(config, strategy, dependencies)),
-  )
-
-export const autonomousObserveApplication = <StartupR, LoopR>(
-  config: AutonomousObserveApplicationConfig,
-  strategy: Strategy,
-  broker: BrokerProbe,
-  startCycle: AutonomousCycleStartup<StartupR, LoopR>,
-): Effect.Effect<
-  never,
-  OperationalError,
-  HttpServer.HttpServer | MarketData | Journal | EvidenceStore | CycleObservability | StartupR | LoopR
-> =>
-  loadApplicationDependencies.pipe(
-    Effect.flatMap((dependencies) =>
-      autonomousObserveApplicationWithDependencies(config, strategy, dependencies, broker, startCycle),
-    ),
-  )
-
-export { monitor, monitorWithDependencies, probe, probeWithDependencies } from './health'
-export { initialize, initializeWithDependencies } from './startup'

--- a/services/bayn/src/entrypoint.ts
+++ b/services/bayn/src/entrypoint.ts
@@ -3,9 +3,8 @@ import { ClickhouseClient } from '@effect/sql-clickhouse'
 import { Effect, flow, Layer, Match, pipe, Redacted, Result, Schema, Stdio, Stream } from 'effect'
 
 import {
-  autonomousObserveApplicationWithDependencies,
-  brokerlessApplicationWithDependencies,
   makeApplicationPlan,
+  runApplication,
   type ApplicationDependencies,
   type ApplicationIdentity,
   type ApplicationPlan,
@@ -269,7 +268,9 @@ const applicationDependencies: Effect.Effect<
 
 const runBrokerlessService = (plan: ApplicationPlanFor<'BrokerlessService'>) =>
   applicationDependencies.pipe(
-    Effect.flatMap((dependencies) => brokerlessApplicationWithDependencies(plan.config, plan.strategy, dependencies)),
+    Effect.flatMap((dependencies) =>
+      runApplication<never, never>(plan.config, plan.strategy, dependencies, { _tag: 'Brokerless' }),
+    ),
   )
 
 const observeBroker = (plan: ApplicationPlanFor<'AutonomousObserveService'>, read: BrokerReadShape) => ({
@@ -291,13 +292,11 @@ const observeCycle = (plan: ApplicationPlanFor<'AutonomousObserveService'>) =>
 const runAutonomousObserveService = (plan: ApplicationPlanFor<'AutonomousObserveService'>) =>
   Effect.all({ dependencies: applicationDependencies, session: BrokerSession }).pipe(
     Effect.flatMap(({ dependencies, session }) =>
-      autonomousObserveApplicationWithDependencies(
-        plan.config,
-        plan.strategy,
-        dependencies,
-        observeBroker(plan, session.read),
-        observeCycle(plan),
-      ),
+      runApplication(plan.config, plan.strategy, dependencies, {
+        _tag: 'AutonomousObserve',
+        broker: observeBroker(plan, session.read),
+        startCycle: observeCycle(plan),
+      }),
     ),
   )
 

--- a/services/bayn/src/health.test.ts
+++ b/services/bayn/src/health.test.ts
@@ -4,7 +4,6 @@ import { Deferred, Effect, Fiber, Ref, Result } from 'effect'
 import { TestClock } from 'effect/testing'
 
 import { config, fixtureLock, successfulJournal, readyState, recoveringStore } from './app-test-support'
-import { monitor, probe } from './app'
 import { AccountStatus, type BrokerReadShape, type ReadResult, type Account } from './broker/alpaca'
 import { unusedAssetBySymbol, unusedMarketCalendar } from './broker/alpaca-test-support'
 import { CycleOperationsCondition, CycleOperationsReason, type CycleOperationsProjection } from './cycle-observability'
@@ -14,6 +13,8 @@ import { EvidenceStore } from './db/evidence-store'
 import {
   deriveHealthLogDecisions,
   deriveHealthTransition,
+  checkHealth,
+  runHealthMonitor,
   type BrokerProbe,
   ensureDurableEvidence,
   ensureSignalIdentity,
@@ -26,6 +27,33 @@ import { Journal, type JournalService } from './ledger'
 import { MarketData, type MarketDataService } from './market-data'
 import { initialState, type RuntimeState } from './runtime-state'
 import { makeSnapshot } from './test-fixtures'
+
+const testHealthDependencies = Effect.all({
+  marketData: MarketData,
+  journal: Journal,
+  evidenceStore: EvidenceStore,
+  cycleObservability: CycleObservability,
+})
+
+const probe = (
+  runtimeConfig: typeof config,
+  state: Ref.Ref<RuntimeState>,
+  broker?: BrokerProbe,
+  cycleFiber?: Fiber.Fiber<void, never>,
+) =>
+  testHealthDependencies.pipe(
+    Effect.flatMap((dependencies) => checkHealth(runtimeConfig, state, dependencies, broker, cycleFiber)),
+  )
+
+const monitor = (
+  runtimeConfig: typeof config,
+  state: Ref.Ref<RuntimeState>,
+  broker?: BrokerProbe,
+  cycleFiber?: Fiber.Fiber<void, never>,
+) =>
+  testHealthDependencies.pipe(
+    Effect.flatMap((dependencies) => runHealthMonitor(runtimeConfig, state, dependencies, broker, cycleFiber)),
+  )
 
 const brokerAccountId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
 const availableClock = (checkedAt: string) =>

--- a/services/bayn/src/health/index.ts
+++ b/services/bayn/src/health/index.ts
@@ -16,11 +16,4 @@ export {
   validateDurableEvidence,
   validateSignalIdentity,
 } from './decisions'
-export {
-  ensureDurableEvidence,
-  ensureSignalIdentity,
-  monitor,
-  monitorWithDependencies,
-  probe,
-  probeWithDependencies,
-} from './program'
+export { checkHealth, ensureDurableEvidence, ensureSignalIdentity, runHealthMonitor } from './program'

--- a/services/bayn/src/health/program.ts
+++ b/services/bayn/src/health/program.ts
@@ -3,11 +3,8 @@ import { Cause, Clock, Duration, Effect, Exit, Fiber, Option, Ref, Result, Sched
 import type { BrokerReadShape } from '../broker/alpaca'
 import type { RuntimeConfig } from '../config'
 import type { FinalizedSnapshotProvenance } from '../contracts'
-import { CycleObservability } from '../db/cycle-observability'
-import { EvidenceStore, type QualificationRecord, type RecoveredEvaluationEvidence } from '../db/evidence-store'
+import type { QualificationRecord, RecoveredEvaluationEvidence } from '../db/evidence-store'
 import { OperationalError, operationalError } from '../errors'
-import { Journal } from '../ledger'
-import { MarketData } from '../market-data'
 import { databaseOperation, withinDeadline } from '../operations'
 import type { BrokerConfiguration, RuntimeEvidence, RuntimeState } from '../runtime-state'
 import { utcInstantFromEpochMillisResult } from '../time'
@@ -133,10 +130,10 @@ const interpretHealthLogs = (decisions: readonly HealthLogDecision[]): Effect.Ef
 const collectHealthProbeResults = (
   config: RuntimeConfig,
   evidence: RuntimeEvidence | null,
-  marketData: MarketData['Service'],
-  journal: Journal['Service'],
-  evidenceStore: EvidenceStore['Service'],
-  cycleObservability: CycleObservability['Service'],
+  marketData: HealthDependencies['marketData'],
+  journal: HealthDependencies['journal'],
+  evidenceStore: HealthDependencies['evidenceStore'],
+  cycleObservability: HealthDependencies['cycleObservability'],
   broker: BrokerProbe | undefined,
 ): Effect.Effect<HealthProbeResults, never> =>
   Effect.map(
@@ -213,7 +210,7 @@ const collectHealthProbeResults = (
     }),
   )
 
-export const probeWithDependencies = (
+export const checkHealth = (
   config: RuntimeConfig,
   state: Ref.Ref<RuntimeState>,
   dependencies: HealthDependencies,
@@ -252,47 +249,14 @@ export const probeWithDependencies = (
     yield* interpretHealthLogs(deriveHealthLogDecisions(transition))
   }).pipe(Effect.withLogSpan('health'))
 
-export const monitorWithDependencies = (
+export const runHealthMonitor = (
   config: RuntimeConfig,
   state: Ref.Ref<RuntimeState>,
   dependencies: HealthDependencies,
   broker?: BrokerProbe,
   autonomousCycleFiber?: Fiber.Fiber<void, never>,
 ): Effect.Effect<void> =>
-  probeWithDependencies(config, state, dependencies, broker, autonomousCycleFiber).pipe(
+  checkHealth(config, state, dependencies, broker, autonomousCycleFiber).pipe(
     Effect.repeat(Schedule.spaced(Duration.millis(config.healthIntervalMs))),
     Effect.asVoid,
-  )
-
-const loadHealthDependencies: Effect.Effect<
-  HealthDependencies,
-  never,
-  MarketData | Journal | EvidenceStore | CycleObservability
-> = Effect.all({
-  marketData: MarketData,
-  journal: Journal,
-  evidenceStore: EvidenceStore,
-  cycleObservability: CycleObservability,
-})
-
-export const probe = (
-  config: RuntimeConfig,
-  state: Ref.Ref<RuntimeState>,
-  broker?: BrokerProbe,
-  autonomousCycleFiber?: Fiber.Fiber<void, never>,
-): Effect.Effect<void, never, MarketData | Journal | EvidenceStore | CycleObservability> =>
-  loadHealthDependencies.pipe(
-    Effect.flatMap((dependencies) => probeWithDependencies(config, state, dependencies, broker, autonomousCycleFiber)),
-  )
-
-export const monitor = (
-  config: RuntimeConfig,
-  state: Ref.Ref<RuntimeState>,
-  broker?: BrokerProbe,
-  autonomousCycleFiber?: Fiber.Fiber<void, never>,
-): Effect.Effect<void, never, MarketData | Journal | EvidenceStore | CycleObservability> =>
-  loadHealthDependencies.pipe(
-    Effect.flatMap((dependencies) =>
-      monitorWithDependencies(config, state, dependencies, broker, autonomousCycleFiber),
-    ),
   )

--- a/services/bayn/src/operations.test.ts
+++ b/services/bayn/src/operations.test.ts
@@ -12,7 +12,9 @@ import {
 
 import { CycleObservabilityError } from './db/cycle-observability'
 import { DatabaseError } from './db/evidence-store'
-import { acquireSqlResource, databaseOperation } from './operations'
+import { databaseOperation, sqlResource } from './operations'
+
+const buildSqlResource = <A, E, R>(layer: Layer.Layer<A, E, R>) => Layer.build(sqlResource(layer))
 
 describe('Bayn SQL dependency acquisition', () => {
   test('retries only retryable SQL failures', async () => {
@@ -28,7 +30,7 @@ describe('Bayn SQL dependency acquisition', () => {
     )
     const program = Effect.scoped(
       Effect.gen(function* () {
-        const fiber = yield* acquireSqlResource(dependencies).pipe(Effect.forkScoped({ startImmediately: true }))
+        const fiber = yield* buildSqlResource(dependencies).pipe(Effect.forkScoped({ startImmediately: true }))
         yield* Effect.yieldNow
         expect(attempts).toBe(1)
         yield* TestClock.adjust('1 second')
@@ -45,7 +47,7 @@ describe('Bayn SQL dependency acquisition', () => {
     })
     const exit = await Effect.runPromiseExit(
       Effect.scoped(
-        acquireSqlResource(
+        buildSqlResource(
           Layer.effectDiscard(
             Effect.sync(() => {
               attempts += 1
@@ -78,7 +80,7 @@ describe('Bayn SQL dependency acquisition', () => {
     )
     const program = Effect.scoped(
       Effect.gen(function* () {
-        const fiber = yield* acquireSqlResource(dependencies).pipe(Effect.forkScoped({ startImmediately: true }))
+        const fiber = yield* buildSqlResource(dependencies).pipe(Effect.forkScoped({ startImmediately: true }))
         yield* Effect.yieldNow
         expect(attempts).toBe(1)
         yield* TestClock.adjust('1 second')
@@ -111,7 +113,7 @@ describe('Bayn SQL dependency acquisition', () => {
     )
     const program = Effect.scoped(
       Effect.gen(function* () {
-        const fiber = yield* acquireSqlResource(dependencies).pipe(Effect.forkScoped({ startImmediately: true }))
+        const fiber = yield* buildSqlResource(dependencies).pipe(Effect.forkScoped({ startImmediately: true }))
         yield* Effect.yieldNow
         expect(attempts).toBe(1)
         yield* TestClock.adjust('1 second')
@@ -128,7 +130,7 @@ describe('Bayn SQL dependency acquisition', () => {
       let attempts = 0
       return Effect.scoped(
         Effect.gen(function* () {
-          const fiber = yield* acquireSqlResource(
+          const fiber = yield* buildSqlResource(
             Layer.effectDiscard(
               Effect.sync(() => {
                 attempts += 1
@@ -178,7 +180,7 @@ describe('Bayn SQL dependency acquisition', () => {
     })
     const program = Effect.scoped(
       Effect.gen(function* () {
-        const fiber = yield* acquireSqlResource(
+        const fiber = yield* buildSqlResource(
           Layer.effectDiscard(
             Effect.sync(() => {
               attempts += 1
@@ -201,7 +203,7 @@ describe('Bayn SQL dependency acquisition', () => {
 
     await Effect.runPromise(
       Effect.scoped(
-        acquireSqlResource(
+        buildSqlResource(
           Layer.effectDiscard(
             Effect.acquireRelease(Effect.void, () =>
               Effect.sync(() => {

--- a/services/bayn/src/operations.ts
+++ b/services/bayn/src/operations.ts
@@ -22,8 +22,6 @@ const isRetryableSqlAcquisition = (error: unknown): boolean => {
   )
 }
 
-export const acquireSqlResource = <A, E, R>(layer: Layer.Layer<A, E, R>) => Layer.build(sqlResource(layer))
-
 export const sqlResource = <A, E, R>(layer: Layer.Layer<A, E, R>): Layer.Layer<A, E, R> =>
   Layer.effectContext(
     Layer.build(layer).pipe(

--- a/services/bayn/src/resources.test.ts
+++ b/services/bayn/src/resources.test.ts
@@ -3,15 +3,15 @@ import { describe, expect, test } from 'bun:test'
 import { Cause, Effect, Exit, Option, Redacted, Ref, Result } from 'effect'
 import { AuthorizationError, SqlError } from 'effect/unstable/sql/SqlError'
 
-import { initialize } from './app'
 import type { RuntimeConfig } from './config'
 import { EvidenceStore, type EvidenceStoreService } from './db/evidence-store'
 import { operationalError } from './errors'
 import { Journal, JournalLive, type JournalService, type TigerBeetleClient } from './ledger'
 import { MarketData, marketDataOperationError, type MarketDataService } from './market-data'
 import { Authority } from './paper'
-import { initialState } from './runtime-state'
-import { makeStrategy } from './strategy'
+import { initialState, type RuntimeState } from './runtime-state'
+import { runStartup } from './startup'
+import { makeStrategy, type Strategy } from './strategy'
 import { fixtureProtocol, makeSnapshot, makeTestProvenance } from './test-fixtures'
 import {
   parseReplicaEndpoints,
@@ -20,6 +20,11 @@ import {
   validateResolvedReplicaEndpoint,
   type ReplicaAddressValidationError,
 } from './tigerbeetle-client'
+
+const initialize = (runtimeConfig: RuntimeConfig, state: Ref.Ref<RuntimeState>, strategy: Strategy) =>
+  Effect.all({ marketData: MarketData, journal: Journal, evidenceStore: EvidenceStore }).pipe(
+    Effect.flatMap((dependencies) => runStartup(runtimeConfig, state, strategy, dependencies)),
+  )
 
 const provenance = makeTestProvenance()
 const fixtureStrategy = makeStrategy(fixtureProtocol, provenance)

--- a/services/bayn/src/startup.test.ts
+++ b/services/bayn/src/startup.test.ts
@@ -26,7 +26,7 @@ import {
   pinnedStrategy,
   pinnedStore,
 } from './app-test-support'
-import { brokerlessApplication, initialize, type BrokerlessApplicationConfig } from './app'
+import { runApplication, type BrokerlessApplicationConfig } from './app'
 import { makeStrategyProtocolHash } from './contracts'
 import { CycleObservability } from './db/cycle-observability'
 import {
@@ -46,7 +46,7 @@ import { Authority } from './paper'
 import { defaultProtocolDocument, loadProtocol } from './protocol'
 import { makeQualificationLock, makeQualificationResult } from './qualification'
 import { evaluateRiskBalancedTrend, summarizeEvaluation } from './risk-balanced-trend'
-import { initialState } from './runtime-state'
+import { initialState, type RuntimeState } from './runtime-state'
 import {
   decidePinnedQualification,
   decidePinnedRecovery,
@@ -55,10 +55,34 @@ import {
   evaluateLockedSnapshot,
   qualifyEvaluation,
   renderStartupDecisionFailure,
+  runStartup,
   type StartupDecisionFailure,
 } from './startup'
 import type { Strategy } from './strategy'
 import { fixtureProtocol, makeSnapshot, makeTestProvenance } from './test-fixtures'
+
+const testStartupDependencies = Effect.all({
+  marketData: MarketData,
+  journal: Journal,
+  evidenceStore: EvidenceStore,
+})
+
+const initialize = (runtimeConfig: typeof config, state: Ref.Ref<RuntimeState>, strategy: Strategy) =>
+  testStartupDependencies.pipe(
+    Effect.flatMap((dependencies) => runStartup(runtimeConfig, state, strategy, dependencies)),
+  )
+
+const brokerlessApplication = (runtimeConfig: BrokerlessApplicationConfig, strategy: Strategy) =>
+  Effect.all({
+    marketData: MarketData,
+    journal: Journal,
+    evidenceStore: EvidenceStore,
+    cycleObservability: CycleObservability,
+  }).pipe(
+    Effect.flatMap((dependencies) =>
+      runApplication<never, never>(runtimeConfig, strategy, dependencies, { _tag: 'Brokerless' }),
+    ),
+  )
 
 const cycleObservability = {
   read: () =>

--- a/services/bayn/src/startup/index.ts
+++ b/services/bayn/src/startup/index.ts
@@ -8,4 +8,4 @@ export {
 } from './decisions'
 export type { StartupDecisionFailure, StartupDependencies } from './model'
 export { renderStartupDecisionFailure } from './presentation'
-export { initialize, initializeWithDependencies } from './program'
+export { runStartup } from './program'

--- a/services/bayn/src/startup/program.ts
+++ b/services/bayn/src/startup/program.ts
@@ -1,10 +1,9 @@
 import { Effect, Ref, Result } from 'effect'
 
 import type { RuntimeConfig } from '../config'
-import { EvidenceStore, type EvidenceStoreService } from '../db/evidence-store'
+import type { EvidenceStoreService } from '../db/evidence-store'
 import { OperationalError, formatError } from '../errors'
-import { Journal } from '../ledger'
-import { MarketData, type MarketDataInspection } from '../market-data'
+import type { MarketDataInspection } from '../market-data'
 import { databaseOperation, withinDeadline } from '../operations'
 import type { RuntimeState } from '../runtime-state'
 import type { Strategy } from '../strategy'
@@ -350,7 +349,7 @@ const evaluateAndJournal = (
     Effect.withLogSpan('startup'),
   )
 
-export const initializeWithDependencies = (
+export const runStartup = (
   config: RuntimeConfig,
   state: Ref.Ref<RuntimeState>,
   strategy: Strategy,
@@ -360,14 +359,3 @@ export const initializeWithDependencies = (
     ? evaluateAndJournal(config, state, strategy, dependencies)
     : recoverPinnedQualification(config, config.qualificationRunId, state, dependencies.evidenceStore)
   ).pipe(Effect.catch((error) => (error.retryable ? Effect.fail(error) : failStartup(state, error))))
-
-export const initialize = (
-  config: RuntimeConfig,
-  state: Ref.Ref<RuntimeState>,
-  strategy: Strategy,
-): Effect.Effect<void, OperationalError, MarketData | Journal | EvidenceStore> =>
-  Effect.all({
-    marketData: MarketData,
-    journal: Journal,
-    evidenceStore: EvidenceStore,
-  }).pipe(Effect.flatMap((dependencies) => initializeWithDependencies(config, state, strategy, dependencies)))


### PR DESCRIPTION
## Summary

- replace hidden Context-loading application, startup, and health facades with explicit typed dependency APIs
- compose each runtime mode once at the entrypoint and preserve scoped HTTP, health, cycle, and shutdown lifecycles
- remove `acquireSqlResource`; exercise the scoped `sqlResource` directly and retain retry/finalizer coverage
- reduce owned production LOC from 3,535 to 3,431, Layer operations from 23 to 21, Context lookups from 39 to 21, and wrapper exports from 6 to 0

## Related Issues

None

## Testing

- `bun test src/app.test.ts src/startup.test.ts src/health.test.ts src/operations.test.ts` (62 passed)
- `bun run --filter @proompteng/bayn test` (806 passed, 122 environment-gated skipped, 0 failed)
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:effect`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn build`

## Breaking Changes

Internal Bayn callers now pass explicit dependency values to `runApplication`, `runStartup`, `checkHealth`, and `runHealthMonitor`. The removed compatibility facades were not an external or persisted contract.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.