### PR TITLE
refactor(bayn): decode ledger planning input once

### DIFF
--- a/services/bayn/src/ledger-plan.test.ts
+++ b/services/bayn/src/ledger-plan.test.ts
@@ -368,6 +368,31 @@ describe('ledger plan Result algebra', () => {
     })
   })
 
+  test('rejects noncanonical event shapes without invoking accessors or collapsing distinct material', () => {
+    const result = evaluationResult()
+    const fill = firstFill(result, 'buy')
+    let accessorReads = 0
+    const accessorFill = Object.defineProperty({ ...fill }, 'notionalMicros', {
+      enumerable: true,
+      get: () => {
+        accessorReads += 1
+        return fill.notionalMicros
+      },
+    }) as FillEvent
+    const symbolFill = { ...fill } as FillEvent & { [key: symbol]: string }
+    symbolFill[Symbol('distinct-material')] = 'present'
+    const classFill = Object.assign(Object.create({ inherited: true }), fill) as FillEvent
+
+    for (const event of [accessorFill, symbolFill, classFill]) {
+      expect(assertLedgerPlanFailure(buildLedgerPlan({ ...result, events: [event] }, ledger))).toMatchObject({
+        kind: 'input-access-failed',
+        eventIndex: 0,
+        eventKind: 'fill',
+      })
+    }
+    expect(accessorReads).toBe(0)
+  })
+
   test('rejects hostile scalar identities before hashing or rendering can coerce them', () => {
     const result = evaluationResult()
     const fill = firstFill(result, 'buy')

--- a/services/bayn/src/ledger-plan.ts
+++ b/services/bayn/src/ledger-plan.ts
@@ -9,7 +9,11 @@ import {
   stableU64,
   type CanonicalJsonFailure,
 } from './hash'
-import type { CashYieldEvent, EvaluationEvent, FeeEvent, FillEvent, InputManifest, ReconciliationResult } from './types'
+import { decodeLedgerInput, type LedgerInputDecodeFailure } from './ledger-plan/input'
+import type { LedgerInput, LedgerPlanInputField } from './ledger-plan/input'
+import type { CashYieldEvent, EvaluationEvent, FeeEvent, FillEvent, ReconciliationResult } from './types'
+
+export type { LedgerInput, LedgerPlanInputField } from './ledger-plan/input'
 
 export const LEDGER_SCHEMA_VERSION = 2
 export const LEDGER_BATCH_MAX = 8_189
@@ -123,36 +127,12 @@ export interface EvaluationLedgerPlan extends LedgerPlan {
   readonly runId: string
 }
 
-export interface LedgerInput {
-  readonly runId: string
-  readonly initialCapitalMicros: string
-  readonly inputManifest: InputManifest
-  readonly events: readonly EvaluationEvent[]
-}
-
 export type LedgerPlanAmountField =
   | 'cashYield.amountMicros'
   | 'fee.totalMicros'
   | 'fill.costBasisMicros'
   | 'fill.notionalMicros'
   | 'initialCapitalMicros'
-
-export type LedgerPlanInputField =
-  | 'cashYield.amountMicros'
-  | 'cashYield.id'
-  | 'event.kind'
-  | 'events'
-  | 'fee.id'
-  | 'fee.totalMicros'
-  | 'fill.costBasisMicros'
-  | 'fill.id'
-  | 'fill.notionalMicros'
-  | 'fill.side'
-  | 'fill.symbol'
-  | 'initialCapitalMicros'
-  | 'inputManifest.symbol'
-  | 'inputManifest.symbols'
-  | 'runId'
 
 type LedgerPlanInputExpectation = 'evaluation-event-kind' | 'fill-side' | 'string'
 
@@ -446,74 +426,32 @@ const requireFillSide = (
 
 const planEvents = (result: LedgerInput): Result.Result<PlannedEvents, LedgerPlanFailureDetail> =>
   Result.gen(function* () {
-    const events = yield* Result.mapError(
-      Result.try(() => [...result.events]),
-      (cause) => inputAccessFailure('events', cause),
-    )
     const fills: PlannedFillEvent[] = []
     const fees: PlannedFeeEvent[] = []
     const cashYields: PlannedCashYieldEvent[] = []
 
-    for (const [eventIndex, event] of events.entries()) {
-      const rawKind = yield* Result.mapError(
-        Result.try(() => event.kind),
-        (cause) => inputAccessFailure('event.kind', cause, eventIndex),
-      )
-      const kind = yield* requireEventKind(rawKind, eventIndex)
+    for (const [eventIndex, event] of result.events.entries()) {
+      const kind = yield* requireEventKind(event.kind, eventIndex)
       if (kind === 'fill') {
         const fill = event as FillEvent
-        const rawId = yield* Result.mapError(
-          Result.try(() => fill.id),
-          (cause) => inputAccessFailure('fill.id', cause, eventIndex, kind),
-        )
-        const id = yield* requireStringInput('fill.id', rawId, eventIndex, kind)
-        const rawSymbol = yield* Result.mapError(
-          Result.try(() => fill.symbol),
-          (cause) => inputAccessFailure('fill.symbol', cause, eventIndex, kind),
-        )
-        const symbol = yield* requireStringInput('fill.symbol', rawSymbol, eventIndex, kind)
-        const rawSide = yield* Result.mapError(
-          Result.try(() => fill.side),
-          (cause) => inputAccessFailure('fill.side', cause, eventIndex, kind),
-        )
-        const side = yield* requireFillSide(rawSide, eventIndex)
-        const notionalMicros = yield* Result.mapError(
-          Result.try(() => fill.notionalMicros),
-          (cause) => inputAccessFailure('fill.notionalMicros', cause, eventIndex, kind),
-        )
-        const costBasisMicros = yield* Result.mapError(
-          Result.try(() => fill.costBasisMicros),
-          (cause) => inputAccessFailure('fill.costBasisMicros', cause, eventIndex, kind),
-        )
+        const id = yield* requireStringInput('fill.id', fill.id, eventIndex, kind)
+        const symbol = yield* requireStringInput('fill.symbol', fill.symbol, eventIndex, kind)
+        const side = yield* requireFillSide(fill.side, eventIndex)
+        const notionalMicros = fill.notionalMicros
+        const costBasisMicros = fill.costBasisMicros
         fills.push({ event: fill, id, symbol, side, notionalMicros, costBasisMicros })
       } else if (kind === 'fee') {
         const fee = event as FeeEvent
-        const rawId = yield* Result.mapError(
-          Result.try(() => fee.id),
-          (cause) => inputAccessFailure('fee.id', cause, eventIndex, kind),
-        )
-        const id = yield* requireStringInput('fee.id', rawId, eventIndex, kind)
-        const totalMicros = yield* Result.mapError(
-          Result.try(() => fee.totalMicros),
-          (cause) => inputAccessFailure('fee.totalMicros', cause, eventIndex, kind),
-        )
-        fees.push({ event: fee, id, totalMicros })
+        const id = yield* requireStringInput('fee.id', fee.id, eventIndex, kind)
+        fees.push({ event: fee, id, totalMicros: fee.totalMicros })
       } else if (kind === 'cash-yield') {
         const cashYield = event as CashYieldEvent
-        const rawId = yield* Result.mapError(
-          Result.try(() => cashYield.id),
-          (cause) => inputAccessFailure('cashYield.id', cause, eventIndex, kind),
-        )
-        const id = yield* requireStringInput('cashYield.id', rawId, eventIndex, kind)
-        const amountMicros = yield* Result.mapError(
-          Result.try(() => cashYield.amountMicros),
-          (cause) => inputAccessFailure('cashYield.amountMicros', cause, eventIndex, kind),
-        )
-        cashYields.push({ event: cashYield, id, amountMicros })
+        const id = yield* requireStringInput('cashYield.id', cashYield.id, eventIndex, kind)
+        cashYields.push({ event: cashYield, id, amountMicros: cashYield.amountMicros })
       }
     }
 
-    return { eventCount: events.length, fills, fees, cashYields }
+    return { eventCount: result.events.length, fills, fees, cashYields }
   })
 
 const buildLedgerPlanDecision = (
@@ -521,15 +459,8 @@ const buildLedgerPlanDecision = (
   ledger: number,
 ): Result.Result<EvaluationLedgerPlan, LedgerPlanFailureDetail> =>
   Result.gen(function* () {
-    const rawRunId = yield* Result.mapError(
-      Result.try(() => result.runId),
-      (cause) => inputAccessFailure('runId', cause),
-    )
-    const runId = yield* requireStringInput('runId', rawRunId)
-    const initialCapitalMicros = yield* Result.mapError(
-      Result.try(() => result.initialCapitalMicros),
-      (cause) => inputAccessFailure('initialCapitalMicros', cause),
-    )
+    const runId = yield* requireStringInput('runId', result.runId)
+    const initialCapitalMicros = result.initialCapitalMicros
     const runKey = stableU128('bayn-run-v1', runId)
     const runTag = stableU64('bayn-run-v1', runId)
     const accountsByName = new Map<string, Account>()
@@ -544,16 +475,10 @@ const buildLedgerPlanDecision = (
     const cashYieldIncome = addAccount('cash-yield-income', AccountCode.cashYieldIncome)
     const realizedGain = addAccount('realized-gain', AccountCode.realizedGain)
     const realizedLoss = addAccount('realized-loss', AccountCode.realizedLoss)
-    const rawInventorySymbols = yield* Result.mapError(
-      Result.try(() => result.inputManifest.symbols.map((coverage) => coverage.symbol as unknown)),
-      (cause): LedgerPlanFailureDetail => ({
-        kind: 'input-access-failed',
-        field: 'inputManifest.symbols',
-        cause,
-      }),
-    )
     const inventorySymbols = yield* Result.all(
-      rawInventorySymbols.map((symbol, index) => requireStringInput('inputManifest.symbol', symbol, index)),
+      result.inputManifest.symbols.map((coverage, index) =>
+        requireStringInput('inputManifest.symbol', coverage.symbol, index),
+      ),
     )
     for (const symbol of inventorySymbols.toSorted()) {
       addAccount(`inventory:${symbol}`, AccountCode.inventory)
@@ -730,7 +655,15 @@ export const buildLedgerPlan = (
   result: LedgerInput,
   ledger: number,
 ): Result.Result<EvaluationLedgerPlan, LedgerPlanFailure> =>
-  Result.mapError(buildLedgerPlanDecision(result, ledger), (failure) => makeLedgerPlanFailure(ledger, failure))
+  Result.mapError(
+    Result.flatMap(
+      Result.mapError(decodeLedgerInput(result), (failure: LedgerInputDecodeFailure) =>
+        inputAccessFailure(failure.field, failure.cause, failure.eventIndex, failure.eventKind),
+      ),
+      (decoded) => buildLedgerPlanDecision(decoded, ledger),
+    ),
+    (failure) => makeLedgerPlanFailure(ledger, failure),
+  )
 
 const accessLedgerPlan = <A>(
   source: LedgerPlanHashAccessSource,

--- a/services/bayn/src/ledger-plan/input.ts
+++ b/services/bayn/src/ledger-plan/input.ts
@@ -1,0 +1,118 @@
+import { Result, Schema } from 'effect'
+
+import type { EvaluationEvent, InputManifest } from '../types'
+
+export interface LedgerInput {
+  readonly runId: string
+  readonly initialCapitalMicros: string
+  readonly inputManifest: InputManifest
+  readonly events: readonly EvaluationEvent[]
+}
+
+export type LedgerPlanInputField =
+  | 'cashYield.amountMicros'
+  | 'cashYield.id'
+  | 'event.kind'
+  | 'events'
+  | 'fee.id'
+  | 'fee.totalMicros'
+  | 'fill.costBasisMicros'
+  | 'fill.id'
+  | 'fill.notionalMicros'
+  | 'fill.side'
+  | 'fill.symbol'
+  | 'initialCapitalMicros'
+  | 'inputManifest.symbol'
+  | 'inputManifest.symbols'
+  | 'runId'
+
+export interface LedgerInputDecodeFailure {
+  readonly field: LedgerPlanInputField
+  readonly cause: unknown
+  readonly eventIndex?: number
+  readonly eventKind?: EvaluationEvent['kind']
+}
+
+interface InputAccessContext {
+  field: LedgerPlanInputField
+  eventIndex?: number
+  eventKind?: EvaluationEvent['kind']
+}
+
+const LedgerInputBoundarySchema = Schema.Struct({
+  runId: Schema.Unknown,
+  initialCapitalMicros: Schema.Unknown,
+  inputManifest: Schema.Struct({
+    symbols: Schema.Array(Schema.Struct({ symbol: Schema.Unknown })),
+  }),
+  events: Schema.Array(Schema.Record(Schema.String, Schema.Unknown)),
+})
+
+const decodeUnknownLedgerMaterial = Schema.decodeUnknownResult(LedgerInputBoundarySchema)
+
+const eventInputField = (kind: unknown, property: PropertyKey): LedgerPlanInputField => {
+  if (property === 'kind') return 'event.kind'
+  if (kind === 'fill') {
+    if (property === 'id') return 'fill.id'
+    if (property === 'symbol') return 'fill.symbol'
+    if (property === 'side') return 'fill.side'
+    if (property === 'notionalMicros') return 'fill.notionalMicros'
+    if (property === 'costBasisMicros') return 'fill.costBasisMicros'
+  }
+  if (kind === 'fee') {
+    if (property === 'id') return 'fee.id'
+    if (property === 'totalMicros') return 'fee.totalMicros'
+  }
+  if (kind === 'cash-yield') {
+    if (property === 'id') return 'cashYield.id'
+    if (property === 'amountMicros') return 'cashYield.amountMicros'
+  }
+  return 'event.kind'
+}
+
+const inputAccessFailure = (access: InputAccessContext, cause: unknown): LedgerInputDecodeFailure => ({
+  field: access.field,
+  ...(access.eventIndex === undefined ? {} : { eventIndex: access.eventIndex }),
+  ...(access.eventKind === undefined ? {} : { eventKind: access.eventKind }),
+  cause,
+})
+
+export const decodeLedgerInput = (input: unknown): Result.Result<LedgerInput, LedgerInputDecodeFailure> => {
+  let access: InputAccessContext = { field: 'runId' }
+  const snapshot = Result.mapError(
+    Result.try(() => {
+      const source = input as LedgerInput
+      access = { field: 'runId' }
+      const runId = source.runId as unknown
+      access = { field: 'initialCapitalMicros' }
+      const initialCapitalMicros = source.initialCapitalMicros as unknown
+      access = { field: 'inputManifest.symbols' }
+      const rawSymbols = [...source.inputManifest.symbols]
+      const symbols = rawSymbols.map((coverage, index) => {
+        access = { field: 'inputManifest.symbol', eventIndex: index }
+        return { symbol: coverage.symbol as unknown }
+      })
+      access = { field: 'events' }
+      const rawEvents = [...source.events]
+      const events = rawEvents.map((event, eventIndex) => {
+        access = { field: 'event.kind', eventIndex }
+        const kind = event.kind
+        const entries = Object.keys(event).map((property) => {
+          access = { field: eventInputField(kind, property), eventIndex, eventKind: kind }
+          return [property, (event as unknown as Record<string, unknown>)[property]] as const
+        })
+        return Object.fromEntries(entries)
+      })
+      return { runId, initialCapitalMicros, inputManifest: { symbols }, events }
+    }),
+    (cause) => inputAccessFailure(access, cause),
+  )
+  if (Result.isFailure(snapshot)) return Result.fail(snapshot.failure)
+
+  return Result.map(
+    Result.mapError(decodeUnknownLedgerMaterial(snapshot.success), (cause) =>
+      inputAccessFailure({ field: 'runId' }, cause),
+    ),
+    (decoded) => decoded as LedgerInput,
+  )
+}

--- a/services/bayn/src/ledger-plan/input.ts
+++ b/services/bayn/src/ledger-plan/input.ts
@@ -77,6 +77,29 @@ const inputAccessFailure = (access: InputAccessContext, cause: unknown): LedgerI
   cause,
 })
 
+const snapshotEvent = (event: EvaluationEvent, eventIndex: number, access: InputAccessContext): EvaluationEvent => {
+  access.field = 'event.kind'
+  access.eventIndex = eventIndex
+  const kind = event.kind
+  access.eventKind = kind
+
+  const prototype = Object.getPrototypeOf(event)
+  if (prototype !== Object.prototype && prototype !== null) {
+    throw new TypeError('ledger-plan event must be a plain object')
+  }
+
+  const entries = Reflect.ownKeys(event).map((property) => {
+    access.field = eventInputField(kind, property)
+    if (typeof property !== 'string') throw new TypeError('ledger-plan event must not contain symbol keys')
+    const descriptor = Object.getOwnPropertyDescriptor(event, property)
+    if (descriptor?.enumerable !== true || !('value' in descriptor)) {
+      throw new TypeError('ledger-plan event properties must be enumerable data properties')
+    }
+    return [property, descriptor.value] as const
+  })
+  return Object.fromEntries(entries) as unknown as EvaluationEvent
+}
+
 export const decodeLedgerInput = (input: unknown): Result.Result<LedgerInput, LedgerInputDecodeFailure> => {
   let access: InputAccessContext = { field: 'runId' }
   const snapshot = Result.mapError(
@@ -94,15 +117,7 @@ export const decodeLedgerInput = (input: unknown): Result.Result<LedgerInput, Le
       })
       access = { field: 'events' }
       const rawEvents = [...source.events]
-      const events = rawEvents.map((event, eventIndex) => {
-        access = { field: 'event.kind', eventIndex }
-        const kind = event.kind
-        const entries = Object.keys(event).map((property) => {
-          access = { field: eventInputField(kind, property), eventIndex, eventKind: kind }
-          return [property, (event as unknown as Record<string, unknown>)[property]] as const
-        })
-        return Object.fromEntries(entries)
-      })
+      const events = rawEvents.map((event, eventIndex) => snapshotEvent(event, eventIndex, access))
       return { runId, initialCapitalMicros, inputManifest: { symbols }, events }
     }),
     (cause) => inputAccessFailure(access, cause),


### PR DESCRIPTION
## Summary

- decode unknown ledger planning material once through a Schema/Result boundary before semantic planning
- keep event planning, amount validation, TigerBeetle encoding, and canonical hashing pure and behaviorally unchanged
- reduce Result.try sites from 17 to 4 overall and remove all defensive property/array reads from the decoded core

## Related Issues

None

## Testing

- `bun test services/bayn/src/ledger-plan.test.ts` (15 passed)
- `bun run --filter @proompteng/bayn test` (804 passed, 121 skipped)
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:effect`
- `bun build src/index.ts --target=node --external tigerbeetle-node --outdir=dist`
- Type-aware Oxlint is delegated to CI because this minimal shell lacks `/usr/bin/env`, so its `tsgolint` subprocess cannot start locally.

## Breaking Changes

None. The `ledger-plan.ts` public exports and all wire, identity, accounting, balancing, and failure behavior are preserved.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots section removed because this is a pure backend refactor; Breaking Changes is filled in.
- [x] Documentation, release notes, and follow-ups are not required for this internal refactor.