### PR TITLE
test(bayn): add real Alpaca sandbox contract proof

### DIFF
--- a/.github/workflows/bayn-ci.yml
+++ b/.github/workflows/bayn-ci.yml
@@ -410,7 +410,7 @@ jobs:
           --filter @proompteng/source
           --filter @proompteng/bayn
       - name: Execute bounded real Alpaca sandbox proof
-        run: bun run --cwd services/bayn test:broker-sandbox-real
+        run: bun test --cwd services/bayn src/broker/alpaca-sandbox-contract.test.ts
       - name: Upload redacted exact-head contract receipt
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/bayn-ci.yml
+++ b/.github/workflows/bayn-ci.yml
@@ -15,6 +15,11 @@ on:
         description: Successful exact-head bayn-build-push workflow_dispatch run containing bayn-release-contract
         required: true
         type: string
+      authorize_broker_mutation:
+        description: Explicitly authorize one bounded Alpaca paper submit/cancel proof for exact_head_sha
+        required: true
+        default: false
+        type: boolean
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -292,6 +297,8 @@ jobs:
     env:
       BAYN_ALPACA_SANDBOX_CONTRACT: '1'
       BAYN_ALPACA_BASE_URL: https://paper-api.alpaca.markets
+      BAYN_ALPACA_SANDBOX_GITHUB_ENVIRONMENT: bayn-alpaca-sandbox
+      BAYN_ALPACA_SANDBOX_MUTATION_AUTHORIZED: ${{ inputs.authorize_broker_mutation }}
       BAYN_ALPACA_SANDBOX_EXACT_HEAD_SHA: ${{ inputs.exact_head_sha }}
       BAYN_ALPACA_SANDBOX_RELEASE_IMAGE_BUILD_RUN_ID: ${{ inputs.image_build_run_id }}
       BAYN_ALPACA_SANDBOX_RECEIPT_PATH: /tmp/alpaca-sandbox-contract-receipt.json
@@ -307,12 +314,84 @@ jobs:
             printf 'BAYN_ALPACA_SANDBOX_JOB_STARTED_EPOCH_MS=%s\n' "${job_started_epoch_ms}"
             printf 'BAYN_ALPACA_SANDBOX_JOB_DEADLINE_EPOCH_MS=%s\n' "${job_deadline_epoch_ms}"
           } >> "${GITHUB_ENV}"
+      - name: Initialize sanitized protected proof receipt
+        shell: bash
+        run: |
+          set -euo pipefail
+          umask 077
+
+          jq -n \
+            --arg sourceSha "${GITHUB_SHA}" \
+            --arg imageBuildRunId "${BAYN_ALPACA_SANDBOX_RELEASE_IMAGE_BUILD_RUN_ID}" \
+            --arg githubEnvironment "${BAYN_ALPACA_SANDBOX_GITHUB_ENVIRONMENT}" \
+            --arg actor "${GITHUB_ACTOR}" \
+            --arg triggeringActor "${GITHUB_TRIGGERING_ACTOR}" \
+            --arg runAttempt "${GITHUB_RUN_ATTEMPT}" \
+            --arg startedAt "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            '{
+              schemaVersion: "bayn.alpaca-sandbox-contract-receipt.v4",
+              proofStatus: "GUARD_PENDING",
+              sourceSha: $sourceSha,
+              githubEnvironment: $githubEnvironment,
+              authorization: {
+                eventName: "workflow_dispatch",
+                actor: $actor,
+                triggeringActor: $triggeringActor,
+                runAttempt: $runAttempt,
+                explicitBrokerMutation: false
+              },
+              releaseGate: {
+                buildRunId: $imageBuildRunId,
+                claim: "EXACT_IMAGE_ARTIFACT_VERIFIED_NOT_PROOF_RUNTIME"
+              },
+              proofRuntime: {
+                kind: "CHECKED_OUT_SOURCE",
+                sourceSha: $sourceSha
+              },
+              timestamps: { startedAt: $startedAt },
+              endpointClass: "ALPACA_PAPER"
+            }' > "${BAYN_ALPACA_SANDBOX_RECEIPT_PATH}"
       - name: Validate protected dispatch inputs
         shell: bash
         run: |
           set -euo pipefail
-          [[ "${BAYN_ALPACA_SANDBOX_EXACT_HEAD_SHA}" =~ ^[0-9a-f]{40}$ ]]
-          [[ "${BAYN_ALPACA_SANDBOX_RELEASE_IMAGE_BUILD_RUN_ID}" =~ ^[0-9]+$ ]]
+          fail_guard() {
+            local code="$1"
+            local message="$2"
+            local receipt_tmp="${BAYN_ALPACA_SANDBOX_RECEIPT_PATH}.tmp"
+            jq \
+              --arg code "${code}" \
+              '.proofStatus = "GUARD_FAILURE"
+              | .guardFailure = { stage: "DISPATCH_AUTHORIZATION", code: $code }' \
+              "${BAYN_ALPACA_SANDBOX_RECEIPT_PATH}" > "${receipt_tmp}"
+            mv "${receipt_tmp}" "${BAYN_ALPACA_SANDBOX_RECEIPT_PATH}"
+            echo "::error title=Protected Alpaca proof blocked::${message}" >&2
+            exit 2
+          }
+
+          [[ "${GITHUB_EVENT_NAME}" == 'workflow_dispatch' ]] || \
+            fail_guard 'EVENT_NOT_WORKFLOW_DISPATCH' 'The broker-mutating proof may run only from workflow_dispatch.'
+          [[ "${GITHUB_REPOSITORY}" == 'proompteng/lab' ]] || \
+            fail_guard 'REPOSITORY_MISMATCH' 'The protected proof is bound to proompteng/lab.'
+          [[ "${BAYN_ALPACA_SANDBOX_GITHUB_ENVIRONMENT}" == 'bayn-alpaca-sandbox' ]] || \
+            fail_guard 'GITHUB_ENVIRONMENT_MISMATCH' 'The protected proof must use environment bayn-alpaca-sandbox.'
+          [[ "${BAYN_ALPACA_SANDBOX_MUTATION_AUTHORIZED}" == 'true' ]] || \
+            fail_guard 'BROKER_MUTATION_NOT_AUTHORIZED' 'Check authorize_broker_mutation only after approving one bounded paper submit/cancel proof.'
+          [[ "${GITHUB_ACTOR}" == "${GITHUB_TRIGGERING_ACTOR}" ]] || \
+            fail_guard 'RERUN_ACTOR_MISMATCH' 'A different actor cannot rerun a broker-mutating proof; create a fresh authorized dispatch.'
+          [[ "${GITHUB_RUN_ATTEMPT}" == '1' ]] || \
+            fail_guard 'WORKFLOW_RERUN_FORBIDDEN' 'Broker-mutating proof reruns are forbidden; create a fresh dispatch with explicit authorization.'
+          [[ "${BAYN_ALPACA_SANDBOX_EXACT_HEAD_SHA}" =~ ^[0-9a-f]{40}$ ]] || \
+            fail_guard 'INVALID_EXACT_HEAD_SHA' 'exact_head_sha must be a lowercase 40-character commit SHA.'
+          [[ "${BAYN_ALPACA_SANDBOX_RELEASE_IMAGE_BUILD_RUN_ID}" =~ ^[0-9]+$ ]] || \
+            fail_guard 'INVALID_IMAGE_BUILD_RUN_ID' 'image_build_run_id must be a numeric GitHub Actions run ID.'
+
+          receipt_tmp="${BAYN_ALPACA_SANDBOX_RECEIPT_PATH}.tmp"
+          jq \
+            '.authorization.explicitBrokerMutation = true
+            | .proofStatus = "DISPATCH_AUTHORIZED"' \
+            "${BAYN_ALPACA_SANDBOX_RECEIPT_PATH}" > "${receipt_tmp}"
+          mv "${receipt_tmp}" "${BAYN_ALPACA_SANDBOX_RECEIPT_PATH}"
       - uses: actions/checkout@v5
         with:
           ref: ${{ env.BAYN_ALPACA_SANDBOX_EXACT_HEAD_SHA }}
@@ -329,32 +408,30 @@ jobs:
           set -euo pipefail
           set +x
           umask 077
+          fail_guard() {
+            local code="$1"
+            local field="$2"
+            local message="$3"
+            local receipt_tmp="${BAYN_ALPACA_SANDBOX_RECEIPT_PATH}.tmp"
+            jq \
+              --arg code "${code}" \
+              --arg field "${field}" \
+              '.proofStatus = "GUARD_FAILURE"
+              | .guardFailure = { stage: "CREDENTIAL_BINDING", code: $code, field: $field }' \
+              "${BAYN_ALPACA_SANDBOX_RECEIPT_PATH}" > "${receipt_tmp}"
+            mv "${receipt_tmp}" "${BAYN_ALPACA_SANDBOX_RECEIPT_PATH}"
+            echo "::error title=Protected Alpaca binding blocked::${message}" >&2
+            exit 2
+          }
 
-          jq -n \
-            --arg sourceSha "${GITHUB_SHA}" \
-            --arg imageBuildRunId "${BAYN_ALPACA_SANDBOX_RELEASE_IMAGE_BUILD_RUN_ID}" \
-            --arg startedAt "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-            '{
-              schemaVersion: "bayn.alpaca-sandbox-contract-receipt.v3",
-              proofStatus: "GUARD_PENDING",
-              sourceSha: $sourceSha,
-              releaseGate: {
-                buildRunId: $imageBuildRunId,
-                claim: "EXACT_IMAGE_ARTIFACT_VERIFIED_NOT_PROOF_RUNTIME"
-              },
-              proofRuntime: {
-                kind: "CHECKED_OUT_SOURCE",
-                sourceSha: $sourceSha
-              },
-              timestamps: { startedAt: $startedAt },
-              endpointClass: "ALPACA_PAPER"
-            }' > "${BAYN_ALPACA_SANDBOX_RECEIPT_PATH}"
-
-          [[ "${GITHUB_SHA}" =~ ^[0-9a-f]{40}$ ]]
-          [[ "${GITHUB_SHA}" == "${BAYN_ALPACA_SANDBOX_EXACT_HEAD_SHA}" ]]
-          [[ "${BAYN_ALPACA_BASE_URL}" == 'https://paper-api.alpaca.markets' ]]
-          [[ "${BAYN_ALPACA_SANDBOX_CONTRACT}" == '1' ]]
-          [[ "${BAYN_ALPACA_SANDBOX_RELEASE_IMAGE_BUILD_RUN_ID}" =~ ^[0-9]+$ ]]
+          [[ "${GITHUB_SHA}" =~ ^[0-9a-f]{40}$ ]] || \
+            fail_guard 'INVALID_EVENT_SHA' 'GITHUB_SHA' 'The workflow event SHA is not an exact lowercase commit SHA.'
+          [[ "${GITHUB_SHA}" == "${BAYN_ALPACA_SANDBOX_EXACT_HEAD_SHA}" ]] || \
+            fail_guard 'EXACT_HEAD_MISMATCH' 'exact_head_sha' 'The authorized exact_head_sha does not match the workflow event SHA.'
+          [[ "${BAYN_ALPACA_BASE_URL}" == 'https://paper-api.alpaca.markets' ]] || \
+            fail_guard 'NON_SANDBOX_ENDPOINT' 'BAYN_ALPACA_BASE_URL' 'The broker endpoint must be exactly https://paper-api.alpaca.markets.'
+          [[ "${BAYN_ALPACA_SANDBOX_CONTRACT}" == '1' ]] || \
+            fail_guard 'CONTRACT_FLAG_DISABLED' 'BAYN_ALPACA_SANDBOX_CONTRACT' 'The protected sandbox contract flag is not enabled.'
 
           required_secrets=(
             BAYN_ALPACA_ACCOUNT_ID
@@ -364,13 +441,15 @@ jobs:
           for name in "${required_secrets[@]}"; do
             value="${!name:-}"
             if [[ -z "${value}" || "${value}" != "${value//[$'\t\r\n ']/}" ]]; then
-              echo "::error title=Missing protected Alpaca binding::${name} is absent or malformed in environment bayn-alpaca-sandbox." >&2
-              exit 2
+              fail_guard 'MISSING_OR_MALFORMED_SECRET' "${name}" "${name} is absent or malformed in environment bayn-alpaca-sandbox."
             fi
           done
-          [[ "${BAYN_ALPACA_ACCOUNT_ID}" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$ ]]
-          [[ "${BAYN_ALPACA_ACCOUNT_ID}" != "${BAYN_ALPACA_KEY_ID}" ]]
-          [[ "${BAYN_ALPACA_KEY_ID}" != "${BAYN_ALPACA_SECRET_KEY}" ]]
+          [[ "${BAYN_ALPACA_ACCOUNT_ID}" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$ ]] || \
+            fail_guard 'INVALID_SANDBOX_ACCOUNT_ID' 'BAYN_ALPACA_ACCOUNT_ID' 'The protected sandbox account ID must be a lowercase UUID.'
+          [[ "${BAYN_ALPACA_ACCOUNT_ID}" != "${BAYN_ALPACA_KEY_ID}" ]] || \
+            fail_guard 'CREDENTIAL_ALIAS' 'BAYN_ALPACA_KEY_ID' 'The Alpaca key ID must not alias the sandbox account ID.'
+          [[ "${BAYN_ALPACA_KEY_ID}" != "${BAYN_ALPACA_SECRET_KEY}" ]] || \
+            fail_guard 'CREDENTIAL_ALIAS' 'BAYN_ALPACA_SECRET_KEY' 'The Alpaca secret key must not alias the key ID.'
       - name: Verify the exact multi-architecture release artifact
         shell: bash
         run: |
@@ -514,6 +593,47 @@ jobs:
           kill -0 "${proxy_pid}"
 
           bun test --cwd services/bayn src/broker/alpaca-sandbox-contract.test.ts
+      - name: Finalize sanitized pre-proof failure receipt
+        if: failure()
+        shell: bash
+        run: |
+          set -euo pipefail
+          set +x
+          umask 077
+
+          if [[ ! -f "${BAYN_ALPACA_SANDBOX_RECEIPT_PATH}" ]]; then
+            jq -n \
+              --arg sourceSha "${GITHUB_SHA}" \
+              --arg githubEnvironment "${BAYN_ALPACA_SANDBOX_GITHUB_ENVIRONMENT}" \
+              '{
+                schemaVersion: "bayn.alpaca-sandbox-contract-receipt.v4",
+                proofStatus: "WORKFLOW_FAILURE",
+                sourceSha: $sourceSha,
+                githubEnvironment: $githubEnvironment,
+                workflowFailure: {
+                  stage: "PROTECTED_WORKFLOW",
+                  code: "RECEIPT_INITIALIZATION_FAILED"
+                }
+              }' > "${BAYN_ALPACA_SANDBOX_RECEIPT_PATH}"
+            exit 0
+          fi
+
+          proof_status="$(jq -r '.proofStatus // ""' "${BAYN_ALPACA_SANDBOX_RECEIPT_PATH}")"
+          case "${proof_status}" in
+            FAILURE | GUARD_FAILURE | SUCCESS)
+              exit 0
+              ;;
+          esac
+
+          receipt_tmp="${BAYN_ALPACA_SANDBOX_RECEIPT_PATH}.tmp"
+          jq \
+            '.proofStatus = "WORKFLOW_FAILURE"
+            | .workflowFailure = {
+                stage: "PROTECTED_WORKFLOW",
+                code: "STEP_FAILED_BEFORE_FINAL_PROOF_RECEIPT"
+              }' \
+            "${BAYN_ALPACA_SANDBOX_RECEIPT_PATH}" > "${receipt_tmp}"
+          mv "${receipt_tmp}" "${BAYN_ALPACA_SANDBOX_RECEIPT_PATH}"
       - name: Upload redacted exact-head contract receipt
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/bayn-ci.yml
+++ b/.github/workflows/bayn-ci.yml
@@ -11,10 +11,14 @@ on:
         description: Exact commit SHA approved for the protected Alpaca sandbox proof
         required: true
         type: string
+      image_build_run_id:
+        description: Successful exact-head bayn-build-push workflow_dispatch run containing bayn-release-contract
+        required: true
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   changes:
@@ -280,9 +284,10 @@ jobs:
   alpaca-sandbox-contract-proof:
     if: github.event_name == 'workflow_dispatch' && github.sha == inputs.exact_head_sha
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     environment: bayn-alpaca-sandbox
     permissions:
+      actions: read
       contents: read
     env:
       BAYN_ALPACA_SANDBOX_CONTRACT: '1'
@@ -290,7 +295,9 @@ jobs:
       BAYN_ALPACA_ACCOUNT_ID: ${{ secrets.BAYN_ALPACA_SANDBOX_ACCOUNT_ID }}
       BAYN_ALPACA_KEY_ID: ${{ secrets.BAYN_ALPACA_SANDBOX_KEY_ID }}
       BAYN_ALPACA_SECRET_KEY: ${{ secrets.BAYN_ALPACA_SANDBOX_SECRET_KEY }}
+      BAYN_ALPACA_SANDBOX_IMAGE_BUILD_RUN_ID: ${{ inputs.image_build_run_id }}
       BAYN_ALPACA_SANDBOX_RECEIPT_PATH: /tmp/alpaca-sandbox-contract-receipt.json
+      GH_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -298,6 +305,102 @@ jobs:
           persist-credentials: false
       - name: Verify exact checked-out head
         run: test "$(git rev-parse HEAD)" = "${{ inputs.exact_head_sha }}"
+      - name: Fail closed on protected credential binding
+        shell: bash
+        run: |
+          set -euo pipefail
+          set +x
+          umask 077
+
+          jq -n \
+            --arg sourceSha "${GITHUB_SHA}" \
+            --arg imageBuildRunId "${BAYN_ALPACA_SANDBOX_IMAGE_BUILD_RUN_ID}" \
+            --arg startedAt "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            '{
+              schemaVersion: "bayn.alpaca-sandbox-contract-receipt.v2",
+              proofStatus: "GUARD_PENDING",
+              sourceSha: $sourceSha,
+              image: { buildRunId: $imageBuildRunId },
+              timestamps: { startedAt: $startedAt },
+              endpointClass: "ALPACA_PAPER"
+            }' > "${BAYN_ALPACA_SANDBOX_RECEIPT_PATH}"
+
+          [[ "${GITHUB_SHA}" =~ ^[0-9a-f]{40}$ ]]
+          [[ "${GITHUB_SHA}" == "${{ inputs.exact_head_sha }}" ]]
+          [[ "${BAYN_ALPACA_BASE_URL}" == 'https://paper-api.alpaca.markets' ]]
+          [[ "${BAYN_ALPACA_SANDBOX_CONTRACT}" == '1' ]]
+          [[ "${BAYN_ALPACA_SANDBOX_IMAGE_BUILD_RUN_ID}" =~ ^[0-9]+$ ]]
+
+          required_secrets=(
+            BAYN_ALPACA_ACCOUNT_ID
+            BAYN_ALPACA_KEY_ID
+            BAYN_ALPACA_SECRET_KEY
+          )
+          for name in "${required_secrets[@]}"; do
+            value="${!name:-}"
+            if [[ -z "${value}" || "${value}" != "${value//[$'\t\r\n ']/}" ]]; then
+              echo "::error title=Missing protected Alpaca binding::${name} is absent or malformed in environment bayn-alpaca-sandbox." >&2
+              exit 2
+            fi
+          done
+          [[ "${BAYN_ALPACA_ACCOUNT_ID}" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$ ]]
+          [[ "${BAYN_ALPACA_ACCOUNT_ID}" != "${BAYN_ALPACA_KEY_ID}" ]]
+          [[ "${BAYN_ALPACA_KEY_ID}" != "${BAYN_ALPACA_SECRET_KEY}" ]]
+      - name: Bind the proof to the exact multi-architecture image
+        shell: bash
+        run: |
+          set -euo pipefail
+          set +x
+          umask 077
+
+          image_run_json="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${BAYN_ALPACA_SANDBOX_IMAGE_BUILD_RUN_ID}")"
+          jq -e \
+            --arg sourceSha "${GITHUB_SHA}" '
+            .name == "bayn-build-push"
+            and .path == ".github/workflows/bayn-build-push.yml"
+            and .event == "workflow_dispatch"
+            and .head_sha == $sourceSha
+            and .status == "completed"
+            and .conclusion == "success"
+          ' <<<"${image_run_json}" >/dev/null
+
+          image_contract_dir="$(mktemp -d "${RUNNER_TEMP}/bayn-image-contract.XXXXXXXX")"
+          gh run download "${BAYN_ALPACA_SANDBOX_IMAGE_BUILD_RUN_ID}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --name bayn-release-contract \
+            --dir "${image_contract_dir}"
+          image_contract="${image_contract_dir}/release-contract.json"
+          test -f "${image_contract}"
+          jq -e \
+            --arg sourceSha "${GITHUB_SHA}" '
+            .service == "bayn"
+            and .image == "registry.ide-newton.ts.net/lab/bayn"
+            and .tag == ("sha-" + $sourceSha)
+            and .sourceSha == $sourceSha
+            and .packageAttr == "bayn-image"
+            and .builder == "nix-dockerTools-skopeo"
+            and .invocation == "github-actions"
+            and (.digest | test("^sha256:[0-9a-f]{64}$"))
+            and .reference == (.image + "@" + .digest)
+            and ((.platforms | sort) == ["linux/amd64", "linux/arm64"])
+            and (.platformDigests["linux/amd64"] | test("^sha256:[0-9a-f]{64}$"))
+            and (.platformDigests["linux/arm64"] | test("^sha256:[0-9a-f]{64}$"))
+          ' "${image_contract}" >/dev/null
+
+          image_identity="$(jq -r '.reference' "${image_contract}")"
+          image_tag="$(jq -r '.image + ":" + .tag' "${image_contract}")"
+          printf 'BAYN_ALPACA_SANDBOX_IMAGE_IDENTITY=%s\n' "${image_identity}" >> "${GITHUB_ENV}"
+          printf 'BAYN_ALPACA_SANDBOX_IMAGE_TAG=%s\n' "${image_tag}" >> "${GITHUB_ENV}"
+
+          receipt_tmp="${BAYN_ALPACA_SANDBOX_RECEIPT_PATH}.tmp"
+          jq \
+            --arg imageIdentity "${image_identity}" \
+            --arg imageTag "${image_tag}" '
+            .proofStatus = "GUARD_READY"
+            | .image.identity = $imageIdentity
+            | .image.tag = $imageTag
+          ' "${BAYN_ALPACA_SANDBOX_RECEIPT_PATH}" > "${receipt_tmp}"
+          mv "${receipt_tmp}" "${BAYN_ALPACA_SANDBOX_RECEIPT_PATH}"
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.14
@@ -309,6 +412,7 @@ jobs:
       - name: Execute bounded real Alpaca sandbox proof
         run: bun run --cwd services/bayn test:broker-sandbox-real
       - name: Upload redacted exact-head contract receipt
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: alpaca-sandbox-contract-${{ inputs.exact_head_sha }}

--- a/.github/workflows/bayn-ci.yml
+++ b/.github/workflows/bayn-ci.yml
@@ -292,14 +292,21 @@ jobs:
     env:
       BAYN_ALPACA_SANDBOX_CONTRACT: '1'
       BAYN_ALPACA_BASE_URL: https://paper-api.alpaca.markets
-      BAYN_ALPACA_ACCOUNT_ID: ${{ secrets.BAYN_ALPACA_SANDBOX_ACCOUNT_ID }}
-      BAYN_ALPACA_KEY_ID: ${{ secrets.BAYN_ALPACA_SANDBOX_KEY_ID }}
-      BAYN_ALPACA_SECRET_KEY: ${{ secrets.BAYN_ALPACA_SANDBOX_SECRET_KEY }}
       BAYN_ALPACA_SANDBOX_EXACT_HEAD_SHA: ${{ inputs.exact_head_sha }}
       BAYN_ALPACA_SANDBOX_IMAGE_BUILD_RUN_ID: ${{ inputs.image_build_run_id }}
       BAYN_ALPACA_SANDBOX_RECEIPT_PATH: /tmp/alpaca-sandbox-contract-receipt.json
       GH_TOKEN: ${{ github.token }}
     steps:
+      - name: Establish overall protected proof deadline
+        shell: bash
+        run: |
+          set -euo pipefail
+          job_started_epoch_ms="$(date +%s%3N)"
+          job_deadline_epoch_ms="$((job_started_epoch_ms + 13 * 60 * 1000))"
+          {
+            printf 'BAYN_ALPACA_SANDBOX_JOB_STARTED_EPOCH_MS=%s\n' "${job_started_epoch_ms}"
+            printf 'BAYN_ALPACA_SANDBOX_JOB_DEADLINE_EPOCH_MS=%s\n' "${job_deadline_epoch_ms}"
+          } >> "${GITHUB_ENV}"
       - name: Validate protected dispatch inputs
         shell: bash
         run: |
@@ -314,6 +321,10 @@ jobs:
         run: test "$(git rev-parse HEAD)" = "${BAYN_ALPACA_SANDBOX_EXACT_HEAD_SHA}"
       - name: Fail closed on protected credential binding
         shell: bash
+        env:
+          BAYN_ALPACA_ACCOUNT_ID: ${{ secrets.BAYN_ALPACA_SANDBOX_ACCOUNT_ID }}
+          BAYN_ALPACA_KEY_ID: ${{ secrets.BAYN_ALPACA_SANDBOX_KEY_ID }}
+          BAYN_ALPACA_SECRET_KEY: ${{ secrets.BAYN_ALPACA_SANDBOX_SECRET_KEY }}
         run: |
           set -euo pipefail
           set +x
@@ -417,6 +428,10 @@ jobs:
           --filter @proompteng/source
           --filter @proompteng/bayn
       - name: Execute bounded real Alpaca sandbox proof
+        env:
+          BAYN_ALPACA_ACCOUNT_ID: ${{ secrets.BAYN_ALPACA_SANDBOX_ACCOUNT_ID }}
+          BAYN_ALPACA_KEY_ID: ${{ secrets.BAYN_ALPACA_SANDBOX_KEY_ID }}
+          BAYN_ALPACA_SECRET_KEY: ${{ secrets.BAYN_ALPACA_SANDBOX_SECRET_KEY }}
         run: bun test --cwd services/bayn src/broker/alpaca-sandbox-contract.test.ts
       - name: Upload redacted exact-head contract receipt
         if: always()

--- a/.github/workflows/bayn-ci.yml
+++ b/.github/workflows/bayn-ci.yml
@@ -293,7 +293,7 @@ jobs:
       BAYN_ALPACA_SANDBOX_CONTRACT: '1'
       BAYN_ALPACA_BASE_URL: https://paper-api.alpaca.markets
       BAYN_ALPACA_SANDBOX_EXACT_HEAD_SHA: ${{ inputs.exact_head_sha }}
-      BAYN_ALPACA_SANDBOX_IMAGE_BUILD_RUN_ID: ${{ inputs.image_build_run_id }}
+      BAYN_ALPACA_SANDBOX_RELEASE_IMAGE_BUILD_RUN_ID: ${{ inputs.image_build_run_id }}
       BAYN_ALPACA_SANDBOX_RECEIPT_PATH: /tmp/alpaca-sandbox-contract-receipt.json
       GH_TOKEN: ${{ github.token }}
     steps:
@@ -312,7 +312,7 @@ jobs:
         run: |
           set -euo pipefail
           [[ "${BAYN_ALPACA_SANDBOX_EXACT_HEAD_SHA}" =~ ^[0-9a-f]{40}$ ]]
-          [[ "${BAYN_ALPACA_SANDBOX_IMAGE_BUILD_RUN_ID}" =~ ^[0-9]+$ ]]
+          [[ "${BAYN_ALPACA_SANDBOX_RELEASE_IMAGE_BUILD_RUN_ID}" =~ ^[0-9]+$ ]]
       - uses: actions/checkout@v5
         with:
           ref: ${{ env.BAYN_ALPACA_SANDBOX_EXACT_HEAD_SHA }}
@@ -332,13 +332,20 @@ jobs:
 
           jq -n \
             --arg sourceSha "${GITHUB_SHA}" \
-            --arg imageBuildRunId "${BAYN_ALPACA_SANDBOX_IMAGE_BUILD_RUN_ID}" \
+            --arg imageBuildRunId "${BAYN_ALPACA_SANDBOX_RELEASE_IMAGE_BUILD_RUN_ID}" \
             --arg startedAt "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
             '{
-              schemaVersion: "bayn.alpaca-sandbox-contract-receipt.v2",
+              schemaVersion: "bayn.alpaca-sandbox-contract-receipt.v3",
               proofStatus: "GUARD_PENDING",
               sourceSha: $sourceSha,
-              image: { buildRunId: $imageBuildRunId },
+              releaseGate: {
+                buildRunId: $imageBuildRunId,
+                claim: "EXACT_IMAGE_ARTIFACT_VERIFIED_NOT_PROOF_RUNTIME"
+              },
+              proofRuntime: {
+                kind: "CHECKED_OUT_SOURCE",
+                sourceSha: $sourceSha
+              },
               timestamps: { startedAt: $startedAt },
               endpointClass: "ALPACA_PAPER"
             }' > "${BAYN_ALPACA_SANDBOX_RECEIPT_PATH}"
@@ -347,7 +354,7 @@ jobs:
           [[ "${GITHUB_SHA}" == "${BAYN_ALPACA_SANDBOX_EXACT_HEAD_SHA}" ]]
           [[ "${BAYN_ALPACA_BASE_URL}" == 'https://paper-api.alpaca.markets' ]]
           [[ "${BAYN_ALPACA_SANDBOX_CONTRACT}" == '1' ]]
-          [[ "${BAYN_ALPACA_SANDBOX_IMAGE_BUILD_RUN_ID}" =~ ^[0-9]+$ ]]
+          [[ "${BAYN_ALPACA_SANDBOX_RELEASE_IMAGE_BUILD_RUN_ID}" =~ ^[0-9]+$ ]]
 
           required_secrets=(
             BAYN_ALPACA_ACCOUNT_ID
@@ -364,14 +371,14 @@ jobs:
           [[ "${BAYN_ALPACA_ACCOUNT_ID}" =~ ^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$ ]]
           [[ "${BAYN_ALPACA_ACCOUNT_ID}" != "${BAYN_ALPACA_KEY_ID}" ]]
           [[ "${BAYN_ALPACA_KEY_ID}" != "${BAYN_ALPACA_SECRET_KEY}" ]]
-      - name: Bind the proof to the exact multi-architecture image
+      - name: Verify the exact multi-architecture release artifact
         shell: bash
         run: |
           set -euo pipefail
           set +x
           umask 077
 
-          image_run_json="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${BAYN_ALPACA_SANDBOX_IMAGE_BUILD_RUN_ID}")"
+          image_run_json="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${BAYN_ALPACA_SANDBOX_RELEASE_IMAGE_BUILD_RUN_ID}")"
           jq -e \
             --arg sourceSha "${GITHUB_SHA}" '
             .name == "bayn-build-push"
@@ -383,7 +390,7 @@ jobs:
           ' <<<"${image_run_json}" >/dev/null
 
           image_contract_dir="$(mktemp -d "${RUNNER_TEMP}/bayn-image-contract.XXXXXXXX")"
-          gh run download "${BAYN_ALPACA_SANDBOX_IMAGE_BUILD_RUN_ID}" \
+          gh run download "${BAYN_ALPACA_SANDBOX_RELEASE_IMAGE_BUILD_RUN_ID}" \
             --repo "${GITHUB_REPOSITORY}" \
             --name bayn-release-contract \
             --dir "${image_contract_dir}"
@@ -407,16 +414,16 @@ jobs:
 
           image_identity="$(jq -r '.reference' "${image_contract}")"
           image_tag="$(jq -r '.image + ":" + .tag' "${image_contract}")"
-          printf 'BAYN_ALPACA_SANDBOX_IMAGE_IDENTITY=%s\n' "${image_identity}" >> "${GITHUB_ENV}"
-          printf 'BAYN_ALPACA_SANDBOX_IMAGE_TAG=%s\n' "${image_tag}" >> "${GITHUB_ENV}"
+          printf 'BAYN_ALPACA_SANDBOX_RELEASE_IMAGE_IDENTITY=%s\n' "${image_identity}" >> "${GITHUB_ENV}"
+          printf 'BAYN_ALPACA_SANDBOX_RELEASE_IMAGE_TAG=%s\n' "${image_tag}" >> "${GITHUB_ENV}"
 
           receipt_tmp="${BAYN_ALPACA_SANDBOX_RECEIPT_PATH}.tmp"
           jq \
             --arg imageIdentity "${image_identity}" \
             --arg imageTag "${image_tag}" '
             .proofStatus = "GUARD_READY"
-            | .image.identity = $imageIdentity
-            | .image.tag = $imageTag
+            | .releaseGate.identity = $imageIdentity
+            | .releaseGate.tag = $imageTag
           ' "${BAYN_ALPACA_SANDBOX_RECEIPT_PATH}" > "${receipt_tmp}"
           mv "${receipt_tmp}" "${BAYN_ALPACA_SANDBOX_RECEIPT_PATH}"
       - uses: oven-sh/setup-bun@v2
@@ -432,7 +439,81 @@ jobs:
           BAYN_ALPACA_ACCOUNT_ID: ${{ secrets.BAYN_ALPACA_SANDBOX_ACCOUNT_ID }}
           BAYN_ALPACA_KEY_ID: ${{ secrets.BAYN_ALPACA_SANDBOX_KEY_ID }}
           BAYN_ALPACA_SECRET_KEY: ${{ secrets.BAYN_ALPACA_SANDBOX_SECRET_KEY }}
-        run: bun test --cwd services/bayn src/broker/alpaca-sandbox-contract.test.ts
+          BAYN_ALPACA_SANDBOX_PROXY_URL: http://127.0.0.1:18080
+        shell: bash
+        run: |
+          set -euo pipefail
+          proxy_script="${RUNNER_TEMP}/bayn-alpaca-connect-proxy.mjs"
+          proxy_pid=''
+          cleanup_proxy() {
+            if [[ -n "${proxy_pid}" ]]; then
+              kill "${proxy_pid}" 2>/dev/null || true
+              wait "${proxy_pid}" 2>/dev/null || true
+            fi
+            rm -f "${proxy_script}"
+          }
+          trap cleanup_proxy EXIT
+
+          cat > "${proxy_script}" <<'EOF'
+          import http from 'node:http'
+          import net from 'node:net'
+
+          const allowedHost = 'paper-api.alpaca.markets'
+          const allowedPort = 443
+          const listenHost = '127.0.0.1'
+          const listenPort = 18080
+
+          const reject = (socket, status) => {
+            socket.end(`HTTP/1.1 ${status}\r\nConnection: close\r\n\r\n`)
+          }
+
+          const server = http.createServer((_request, response) => {
+            response.writeHead(405, { Connection: 'close' })
+            response.end()
+          })
+
+          server.on('connect', (request, client, head) => {
+            let target
+            try {
+              target = new URL(`http://${request.url}`)
+            } catch {
+              reject(client, '400 Bad Request')
+              return
+            }
+            if (target.hostname !== allowedHost || Number(target.port) !== allowedPort) {
+              reject(client, '403 Forbidden')
+              return
+            }
+
+            const upstream = net.connect({ host: allowedHost, port: allowedPort }, () => {
+              client.write('HTTP/1.1 200 Connection Established\r\n\r\n')
+              if (head.length > 0) upstream.write(head)
+              upstream.pipe(client)
+              client.pipe(upstream)
+            })
+            const close = () => {
+              upstream.destroy()
+              client.destroy()
+            }
+            upstream.on('error', close)
+            client.on('error', close)
+          })
+
+          server.listen(listenPort, listenHost)
+          process.on('SIGTERM', () => server.close(() => process.exit(0)))
+          EOF
+
+          node "${proxy_script}" >/dev/null 2>&1 &
+          proxy_pid="$!"
+          for _ in $(seq 1 50); do
+            if node -e "const net=require('node:net');const socket=net.connect(18080,'127.0.0.1',()=>{socket.end();process.exit(0)});socket.on('error',()=>process.exit(1))"; then
+              break
+            fi
+            sleep 0.1
+          done
+          kill -0 "${proxy_pid}"
+
+          bun test --cwd services/bayn src/broker/alpaca-sandbox-contract.test.ts
       - name: Upload redacted exact-head contract receipt
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/bayn-ci.yml
+++ b/.github/workflows/bayn-ci.yml
@@ -282,7 +282,7 @@ jobs:
           echo 'All applicable Bayn unit, type, Effect, PostgreSQL, dependency-boundary, and multi-architecture image checks passed.'
 
   alpaca-sandbox-contract-proof:
-    if: github.event_name == 'workflow_dispatch' && github.sha == inputs.exact_head_sha
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment: bayn-alpaca-sandbox

--- a/.github/workflows/bayn-ci.yml
+++ b/.github/workflows/bayn-ci.yml
@@ -295,16 +295,23 @@ jobs:
       BAYN_ALPACA_ACCOUNT_ID: ${{ secrets.BAYN_ALPACA_SANDBOX_ACCOUNT_ID }}
       BAYN_ALPACA_KEY_ID: ${{ secrets.BAYN_ALPACA_SANDBOX_KEY_ID }}
       BAYN_ALPACA_SECRET_KEY: ${{ secrets.BAYN_ALPACA_SANDBOX_SECRET_KEY }}
+      BAYN_ALPACA_SANDBOX_EXACT_HEAD_SHA: ${{ inputs.exact_head_sha }}
       BAYN_ALPACA_SANDBOX_IMAGE_BUILD_RUN_ID: ${{ inputs.image_build_run_id }}
       BAYN_ALPACA_SANDBOX_RECEIPT_PATH: /tmp/alpaca-sandbox-contract-receipt.json
       GH_TOKEN: ${{ github.token }}
     steps:
+      - name: Validate protected dispatch inputs
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "${BAYN_ALPACA_SANDBOX_EXACT_HEAD_SHA}" =~ ^[0-9a-f]{40}$ ]]
+          [[ "${BAYN_ALPACA_SANDBOX_IMAGE_BUILD_RUN_ID}" =~ ^[0-9]+$ ]]
       - uses: actions/checkout@v5
         with:
-          ref: ${{ inputs.exact_head_sha }}
+          ref: ${{ env.BAYN_ALPACA_SANDBOX_EXACT_HEAD_SHA }}
           persist-credentials: false
       - name: Verify exact checked-out head
-        run: test "$(git rev-parse HEAD)" = "${{ inputs.exact_head_sha }}"
+        run: test "$(git rev-parse HEAD)" = "${BAYN_ALPACA_SANDBOX_EXACT_HEAD_SHA}"
       - name: Fail closed on protected credential binding
         shell: bash
         run: |
@@ -326,7 +333,7 @@ jobs:
             }' > "${BAYN_ALPACA_SANDBOX_RECEIPT_PATH}"
 
           [[ "${GITHUB_SHA}" =~ ^[0-9a-f]{40}$ ]]
-          [[ "${GITHUB_SHA}" == "${{ inputs.exact_head_sha }}" ]]
+          [[ "${GITHUB_SHA}" == "${BAYN_ALPACA_SANDBOX_EXACT_HEAD_SHA}" ]]
           [[ "${BAYN_ALPACA_BASE_URL}" == 'https://paper-api.alpaca.markets' ]]
           [[ "${BAYN_ALPACA_SANDBOX_CONTRACT}" == '1' ]]
           [[ "${BAYN_ALPACA_SANDBOX_IMAGE_BUILD_RUN_ID}" =~ ^[0-9]+$ ]]
@@ -415,7 +422,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: alpaca-sandbox-contract-${{ inputs.exact_head_sha }}
+          name: alpaca-sandbox-contract-${{ github.sha }}
           path: /tmp/alpaca-sandbox-contract-receipt.json
           if-no-files-found: error
           retention-days: 30

--- a/.github/workflows/bayn-ci.yml
+++ b/.github/workflows/bayn-ci.yml
@@ -6,6 +6,11 @@ permissions:
 on:
   pull_request:
   workflow_dispatch:
+    inputs:
+      exact_head_sha:
+        description: Exact commit SHA approved for the protected Alpaca sandbox proof
+        required: true
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -271,3 +276,42 @@ jobs:
             exit 1
           fi
           echo 'All applicable Bayn unit, type, Effect, PostgreSQL, dependency-boundary, and multi-architecture image checks passed.'
+
+  alpaca-sandbox-contract-proof:
+    if: github.event_name == 'workflow_dispatch' && github.sha == inputs.exact_head_sha
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: bayn-alpaca-sandbox
+    permissions:
+      contents: read
+    env:
+      BAYN_ALPACA_SANDBOX_CONTRACT: '1'
+      BAYN_ALPACA_BASE_URL: https://paper-api.alpaca.markets
+      BAYN_ALPACA_ACCOUNT_ID: ${{ secrets.BAYN_ALPACA_SANDBOX_ACCOUNT_ID }}
+      BAYN_ALPACA_KEY_ID: ${{ secrets.BAYN_ALPACA_SANDBOX_KEY_ID }}
+      BAYN_ALPACA_SECRET_KEY: ${{ secrets.BAYN_ALPACA_SANDBOX_SECRET_KEY }}
+      BAYN_ALPACA_SANDBOX_RECEIPT_PATH: /tmp/alpaca-sandbox-contract-receipt.json
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.exact_head_sha }}
+          persist-credentials: false
+      - name: Verify exact checked-out head
+        run: test "$(git rev-parse HEAD)" = "${{ inputs.exact_head_sha }}"
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+      - name: Install focused dependencies
+        run: >-
+          bun install --frozen-lockfile --ignore-scripts
+          --filter @proompteng/source
+          --filter @proompteng/bayn
+      - name: Execute bounded real Alpaca sandbox proof
+        run: bun run --cwd services/bayn test:broker-sandbox-real
+      - name: Upload redacted exact-head contract receipt
+        uses: actions/upload-artifact@v4
+        with:
+          name: alpaca-sandbox-contract-${{ inputs.exact_head_sha }}
+          path: /tmp/alpaca-sandbox-contract-receipt.json
+          if-no-files-found: error
+          retention-days: 30

--- a/services/bayn/package.json
+++ b/services/bayn/package.json
@@ -15,7 +15,6 @@
     "lint:oxlint:type": "bun ../../node_modules/oxlint/bin/oxlint --config ../../.oxlintrc.json --type-aware --tsconfig ./tsconfig.json .",
     "test": "bun test",
     "test:broker-sandbox": "bun test src/broker-sandbox-contract.test.ts",
-    "test:broker-sandbox-real": "bun test src/broker/alpaca-sandbox-contract.test.ts",
     "test:effect-runtime": "bun test src/clickhouse-patch.test.ts src/effect-runtime-compatibility.test.ts",
     "test:postgres": "bun test src/db/cycle-observability.integration.test.ts && bun test src/db/evidence-store.integration.test.ts && bun test src/db/paper-store.integration.test.ts && bun test src/db/cycle-store/integration.test.ts",
     "tsc": "bun node_modules/typescript/bin/tsc --noEmit"

--- a/services/bayn/package.json
+++ b/services/bayn/package.json
@@ -15,6 +15,7 @@
     "lint:oxlint:type": "bun ../../node_modules/oxlint/bin/oxlint --config ../../.oxlintrc.json --type-aware --tsconfig ./tsconfig.json .",
     "test": "bun test",
     "test:broker-sandbox": "bun test src/broker-sandbox-contract.test.ts",
+    "test:broker-sandbox-real": "bun test src/broker/alpaca-sandbox-contract.test.ts",
     "test:effect-runtime": "bun test src/clickhouse-patch.test.ts src/effect-runtime-compatibility.test.ts",
     "test:postgres": "bun test src/db/cycle-observability.integration.test.ts && bun test src/db/evidence-store.integration.test.ts && bun test src/db/paper-store.integration.test.ts && bun test src/db/cycle-store/integration.test.ts",
     "tsc": "bun node_modules/typescript/bin/tsc --noEmit"

--- a/services/bayn/src/broker/alpaca-sandbox-contract.test.ts
+++ b/services/bayn/src/broker/alpaca-sandbox-contract.test.ts
@@ -1,0 +1,200 @@
+import { expect, test } from 'bun:test'
+
+import { NodeHttpClient } from '@effect/platform-node'
+import { Effect, Redacted, Result } from 'effect'
+import { HttpClient } from 'effect/unstable/http'
+
+import { canonicalHashV1 } from '../hash'
+import {
+  BrokerEnvironment,
+  ExecutionAccess,
+  disabledCapitalAccess,
+  makeExecutionAuthority,
+} from '../execution/authority'
+import { IntentState, OrderSide, OrderType, TimeInForce, type Intent } from '../paper'
+import { BrokerMutationError, MutationFailure, makeMutation } from './alpaca-mutations'
+import {
+  BrokerProvider,
+  OrderStatus,
+  alpacaLiveBaseUrl,
+  alpacaSandboxBaseUrl,
+  acquireBrokerSession,
+  decodeBrokerConnection,
+} from './alpaca'
+
+const enabled = Bun.env.BAYN_ALPACA_SANDBOX_CONTRACT === '1'
+const receiptPath = Bun.env.BAYN_ALPACA_SANDBOX_RECEIPT_PATH
+
+const required = (name: string): string => {
+  const value = Bun.env[name]
+  if (value === undefined || value.length === 0 || value.trim() !== value) {
+    throw new Error(`${name} must be present and free of surrounding whitespace`)
+  }
+  return value
+}
+
+const redact = (value: string): string => canonicalHashV1({ value }).slice(0, 16)
+
+test.skipIf(!enabled)('proves the bounded Alpaca sandbox contract through the production adapter', async () => {
+  const expectedAccountId = required('BAYN_ALPACA_ACCOUNT_ID')
+  const key = required('BAYN_ALPACA_KEY_ID')
+  const secret = required('BAYN_ALPACA_SECRET_KEY')
+  const configuredOrigin = required('BAYN_ALPACA_BASE_URL')
+
+  expect(configuredOrigin).toBe(alpacaSandboxBaseUrl)
+  expect(configuredOrigin).not.toBe(alpacaLiveBaseUrl)
+
+  const decoded = decodeBrokerConnection({
+    provider: BrokerProvider.Alpaca,
+    environment: BrokerEnvironment.Sandbox,
+    baseUrl: configuredOrigin,
+    expectedAccountId,
+    key: Redacted.make(key),
+    secret: Redacted.make(secret),
+    // The credentialed CI proof supplies a direct Node client. This value remains
+    // validated because it is part of the same production BrokerConnection.
+    proxyUrl: 'http://127.0.0.1:1',
+    operationTimeoutMs: 30_000,
+    retryAttempts: 0,
+  })
+  if (Result.isFailure(decoded)) throw new Error(`sandbox connection rejected: ${decoded.failure._tag}`)
+  const connection = decoded.success
+  const run = <A, E>(effect: Effect.Effect<A, E, HttpClient.HttpClient>) =>
+    Effect.runPromise(effect.pipe(Effect.provide(NodeHttpClient.layerNodeHttp)))
+
+  // Acquisition performs the real account/configuration/read preflight before
+  // mutation capability can exist. Account identifiers never enter the receipt.
+  const session = await run(acquireBrokerSession(connection))
+  expect(session.preflight.accountId).toBe(expectedAccountId)
+  expect(session.preflight.environment).toBe(BrokerEnvironment.Sandbox)
+  expect(session.preflight.baseUrl).toBe(alpacaSandboxBaseUrl)
+
+  const authority = makeExecutionAuthority(
+    BrokerEnvironment.Sandbox,
+    ExecutionAccess.SubmitOrders,
+    disabledCapitalAccess,
+  )
+  const mutation = await run(makeMutation(session, authority))
+  const runId = required('GITHUB_RUN_ID')
+  const runAttempt = required('GITHUB_RUN_ATTEMPT')
+  const identity = canonicalHashV1({ runId, runAttempt, head: required('GITHUB_SHA') })
+  const clientOrderId = `b1_${identity.slice(0, 43)}`
+  const intent: Intent = {
+    schemaVersion: 'bayn.paper-intent.v3',
+    intentId: canonicalHashV1({ identity, kind: 'intent' }),
+    authorityGenerationHash: canonicalHashV1({ identity, kind: 'authority' }),
+    riskDecisionId: canonicalHashV1({ identity, kind: 'risk' }),
+    strategyName: 'alpaca-sandbox-contract-proof',
+    cycleId: canonicalHashV1({ identity, kind: 'cycle' }),
+    decisionHash: canonicalHashV1({ identity, kind: 'decision' }),
+    policyHash: canonicalHashV1({ identity, kind: 'policy' }),
+    accountId: expectedAccountId,
+    clientOrderId,
+    symbol: 'AAPL',
+    side: OrderSide.Buy,
+    orderType: OrderType.Market,
+    timeInForce: TimeInForce.Day,
+    quantityMicros: '1',
+    notionalLimitMicros: '1000000',
+    state: IntentState.IoStarted,
+    createdAt: new Date().toISOString(),
+  }
+
+  let brokerOrderId: string | undefined
+  let submitStatus: OrderStatus | undefined
+  let cancelStatus: OrderStatus | undefined
+  let cleanupStatus = 'not-required'
+  let submitEvidence: { readonly status: number; readonly request: string; readonly content: string } | undefined
+  let cancelEvidence: { readonly status: number; readonly request: string; readonly content: string } | undefined
+
+  try {
+    const submit = await run(mutation.submit(intent))
+    brokerOrderId = submit.order.brokerOrderId
+    submitEvidence = {
+      status: submit.evidence.status,
+      request: redact(submit.evidence.requestId),
+      content: submit.evidence.contentHash,
+    }
+
+    // Model the interruption window by discarding the acknowledged outcome and
+    // recovering solely from the deterministic client ID. No second POST occurs.
+    const recoveredSubmit = await run(mutation.orderByClientId!(clientOrderId))
+    expect(recoveredSubmit.value.brokerOrderId).toBe(brokerOrderId)
+    expect(recoveredSubmit.value.clientOrderId).toBe(clientOrderId)
+    expect(recoveredSubmit.value.quantityMicros).toBe('1')
+    submitStatus = recoveredSubmit.value.status
+
+    try {
+      const cancel = await run(mutation.cancel(brokerOrderId))
+      cancelEvidence = {
+        status: cancel.evidence.status,
+        request: redact(cancel.evidence.requestId),
+        content: cancel.evidence.contentHash,
+      }
+    } catch (cause) {
+      if (!(cause instanceof BrokerMutationError) || cause.failure !== MutationFailure.Unknown) throw cause
+    }
+
+    // Both a lost 204 and an ambiguous DELETE are recovered by the same GET path.
+    const recoveredCancel = await run(mutation.orderById!(brokerOrderId))
+    expect(recoveredCancel.value.brokerOrderId).toBe(brokerOrderId)
+    cancelStatus = recoveredCancel.value.status
+    expect([OrderStatus.Canceled, OrderStatus.Filled, OrderStatus.PendingCancel]).toContain(cancelStatus)
+
+    const fills = await run(session.read.fillActivities({ pageSize: 100 }))
+    const matchingFills = fills.value.items.filter((fill) => fill.brokerOrderId === brokerOrderId)
+    for (const fill of matchingFills) expect(fill.brokerOrderId).toBe(brokerOrderId)
+  } finally {
+    if (brokerOrderId === undefined) {
+      try {
+        const recovered = await run(mutation.orderByClientId!(clientOrderId))
+        brokerOrderId = recovered.value.brokerOrderId
+        cleanupStatus = 'recovered-after-submit-failure'
+      } catch {
+        cleanupStatus = 'no-order-found-after-submit-failure'
+      }
+    }
+    if (brokerOrderId !== undefined) {
+      try {
+        await run(mutation.cancel(brokerOrderId))
+        cleanupStatus = 'cancel-acknowledged'
+      } catch {
+        const observed = await run(mutation.orderById!(brokerOrderId))
+        cleanupStatus = `idempotent-${observed.value.status.toLowerCase()}`
+      }
+    }
+  }
+
+  const receipt = {
+    schemaVersion: 'bayn.alpaca-sandbox-contract-receipt.v1',
+    head: required('GITHUB_SHA'),
+    endpoint: alpacaSandboxBaseUrl,
+    accountBinding: redact(session.preflight.accountHash),
+    preflight: {
+      accountStatus: session.preflight.accountStatus,
+      accountBlocked: session.preflight.accountBlocked,
+      tradingBlocked: session.preflight.tradingBlocked,
+      readLookups: [session.preflight.orderById, session.preflight.orderByClientId],
+    },
+    order: {
+      clientOrderBinding: redact(clientOrderId),
+      brokerOrderBinding: brokerOrderId === undefined ? undefined : redact(brokerOrderId),
+      quantityMicros: '1',
+      submitStatus,
+      cancelStatus,
+    },
+    evidence: { submit: submitEvidence, cancel: cancelEvidence },
+    cleanup: cleanupStatus,
+    duplicateSubmitCount: 0,
+    liveEndpointUsed: false,
+    residualOmissions: [
+      'Alpaca cannot deterministically inject a lost POST or DELETE response; real acknowledgement-loss recovery is represented by discarding the acknowledgement before production GET recovery.',
+      'A fill is decoded and reconciled only if the minimum fractional market order fills before cancellation.',
+    ],
+  }
+  expect(JSON.stringify(receipt)).not.toContain(expectedAccountId)
+  expect(JSON.stringify(receipt)).not.toContain(key)
+  expect(JSON.stringify(receipt)).not.toContain(secret)
+  if (receiptPath === undefined) throw new Error('BAYN_ALPACA_SANDBOX_RECEIPT_PATH is required')
+  await Bun.write(receiptPath, `${JSON.stringify(receipt, null, 2)}\n`)
+})

--- a/services/bayn/src/broker/alpaca-sandbox-contract.test.ts
+++ b/services/bayn/src/broker/alpaca-sandbox-contract.test.ts
@@ -21,14 +21,19 @@ import {
   type BrokerMutationShape,
 } from './alpaca-mutations'
 import {
+  AssetClass,
   AssetStatus,
   BrokerProvider,
   BrokerReadError,
   BrokerReadErrorKind,
   BrokerSessionAcquisitionError,
   BrokerSessionAcquisitionStage,
+  OrderClass,
   OrderCollection,
+  OrderSide as BrokerOrderSide,
   OrderStatus,
+  OrderType as BrokerOrderType,
+  TimeInForce as BrokerTimeInForce,
   alpacaSandboxBaseUrl,
   acquireBrokerSession,
   decodeBrokerConnection,
@@ -43,8 +48,9 @@ const proofSymbol = 'AAPL'
 const proofQuantityMicros = '10000'
 const brokerOperationTimeoutMs = 5_000
 const lookupRetryCount = 2
-const terminalPollCount = 5
+const terminalPollCount = 4
 const retryDelayMs = 1_000
+const minimumPreOpenSafetyMs = 30 * 60_000
 const mutationPhaseDeadlineMs = 2 * 60_000
 const cleanupDeadlineMs = 3 * 60_000
 const retryDelay = Duration.millis(retryDelayMs)
@@ -53,9 +59,7 @@ const cleanupDeadline = Duration.millis(cleanupDeadlineMs)
 const maximumRetryReadMs = (lookupRetryCount + 1) * brokerOperationTimeoutMs + lookupRetryCount * retryDelayMs
 const maximumCleanupNetworkMs =
   maximumRetryReadMs +
-  brokerOperationTimeoutMs +
-  (terminalPollCount + 1) * maximumRetryReadMs +
-  terminalPollCount * retryDelayMs +
+  (terminalPollCount + 1) * (brokerOperationTimeoutMs + retryDelayMs + maximumRetryReadMs) +
   maximumRetryReadMs
 
 const required = (name: string): string => {
@@ -67,6 +71,12 @@ const required = (name: string): string => {
 }
 
 const hashIdentity = (value: string): string => canonicalHashV1({ value })
+
+const addUtcDays = (date: string, days: number): string => {
+  const value = new Date(`${date}T00:00:00.000Z`)
+  value.setUTCDate(value.getUTCDate() + days)
+  return value.toISOString().slice(0, 10)
+}
 
 type ProofStage =
   | 'CONFIGURATION'
@@ -111,6 +121,8 @@ interface ProofState {
   clock?: {
     readonly observedAt: string
     readonly marketOpen: false
+    readonly nextMarketOpenAt: string
+    readonly millisecondsUntilNextOpen: number
     readonly sessionCount: number
     readonly calendarHash: string
   }
@@ -124,6 +136,7 @@ interface ProofState {
   brokerOrderId?: string
   acceptedOrderContractMismatch: boolean
   finalStatus?: OrderStatus
+  filledQuantityMicros?: string
   cancelAttempts: number
   cancelAcknowledged: boolean
   lifecycle: LifecycleEvent[]
@@ -228,6 +241,15 @@ const terminalOrderStatuses: ReadonlySet<OrderStatus> = new Set([
 ])
 
 const isOpenStatus = (status: OrderStatus): boolean => !terminalOrderStatuses.has(status)
+const isCancellableStatus = (status: OrderStatus): boolean =>
+  isOpenStatus(status) && status !== OrderStatus.PendingCancel
+const hasFilledQuantity = (order: Order): boolean => order.filledQuantityMicros !== '0'
+const preOpenSafetyMillis = (observedAt: string, nextMarketOpenAt: string): number =>
+  Date.parse(nextMarketOpenAt) - Date.parse(observedAt)
+const requireZeroFill = (order: Order): Effect.Effect<void, SandboxContractProofError> =>
+  hasFilledQuantity(order)
+    ? Effect.fail(proofFailure('CLEANUP', 'ORDER_FILLED_DURING_PROOF'))
+    : Effect.succeed(undefined)
 
 const retryRead = <A>(
   effect: Effect.Effect<A, BrokerReadError>,
@@ -271,57 +293,12 @@ const requireOrderBinding = (
     ? Effect.succeed(undefined)
     : Effect.fail(proofFailure(stage, 'ORDER_BINDING_MISMATCH'))
 
-const waitForTerminalOrder = (
-  orderById: (brokerOrderId: string) => Effect.Effect<ReadResult<Order>, BrokerReadError>,
-  brokerOrderId: string,
-  clientOrderId: string,
-  allowAcceptedContractMismatch: boolean,
-  state: ProofState,
-  attempt = 0,
-): Effect.Effect<ReadResult<Order>, BrokerReadError | SandboxContractProofError> =>
-  retryRead(orderById(brokerOrderId)).pipe(
-    Effect.flatMap((result) =>
-      requireOrderBinding(
-        result.value,
-        clientOrderId,
-        brokerOrderId,
-        allowAcceptedContractMismatch,
-        'TERMINAL_LOOKUP',
-      ).pipe(
-        Effect.andThen(
-          Effect.sync(() => {
-            state.lifecycle.push(readEvidence('TERMINAL_LOOKUP', result))
-            state.finalStatus = result.value.status
-          }),
-        ),
-        Effect.andThen(
-          !isOpenStatus(result.value.status)
-            ? Effect.succeed(result)
-            : attempt >= terminalPollCount
-              ? Effect.fail(proofFailure('TERMINAL_LOOKUP', 'ORDER_REMAINED_OPEN'))
-              : Effect.sleep(retryDelay).pipe(
-                  Effect.andThen(
-                    waitForTerminalOrder(
-                      orderById,
-                      brokerOrderId,
-                      clientOrderId,
-                      allowAcceptedContractMismatch,
-                      state,
-                      attempt + 1,
-                    ),
-                  ),
-                ),
-        ),
-      ),
-    ),
-  )
-
-const cancelIfOpen = (
+const attemptCancellation = (
   mutation: BrokerMutationShape,
   order: Order,
   state: ProofState,
 ): Effect.Effect<void, BrokerMutationError> => {
-  if (!isOpenStatus(order.status)) return Effect.succeed(undefined)
+  if (!isCancellableStatus(order.status)) return Effect.succeed(undefined)
   state.cancelAttempts += 1
   return mutation.cancel(order.brokerOrderId).pipe(
     Effect.tap((receipt) =>
@@ -346,6 +323,61 @@ const cancelIfOpen = (
     ),
   )
 }
+
+const resolveOrderCleanup = (
+  mutation: BrokerMutationShape,
+  orderById: (brokerOrderId: string) => Effect.Effect<ReadResult<Order>, BrokerReadError>,
+  current: ReadResult<Order>,
+  clientOrderId: string,
+  brokerOrderId: string,
+  allowAcceptedContractMismatch: boolean,
+  state: ProofState,
+  attempt = 0,
+  pollDelayMs = retryDelayMs,
+): Effect.Effect<ReadResult<Order>, BrokerReadError | BrokerMutationError | SandboxContractProofError> =>
+  requireOrderBinding(
+    current.value,
+    clientOrderId,
+    brokerOrderId,
+    allowAcceptedContractMismatch,
+    'TERMINAL_LOOKUP',
+  ).pipe(
+    Effect.andThen(
+      Effect.sync(() => {
+        state.finalStatus = current.value.status
+        state.filledQuantityMicros = current.value.filledQuantityMicros
+      }),
+    ),
+    Effect.andThen(
+      !isOpenStatus(current.value.status)
+        ? Effect.succeed(current)
+        : attempt > terminalPollCount
+          ? Effect.fail(proofFailure('TERMINAL_LOOKUP', 'ORDER_REMAINED_OPEN_AFTER_CANCEL_RETRIES'))
+          : attemptCancellation(mutation, current.value, state).pipe(
+              Effect.andThen(Effect.sleep(Duration.millis(pollDelayMs))),
+              Effect.andThen(retryRead(orderById(brokerOrderId))),
+              Effect.flatMap((next) =>
+                Effect.sync(() => {
+                  state.lifecycle.push(readEvidence('TERMINAL_LOOKUP', next))
+                }).pipe(
+                  Effect.andThen(
+                    resolveOrderCleanup(
+                      mutation,
+                      orderById,
+                      next,
+                      clientOrderId,
+                      brokerOrderId,
+                      allowAcceptedContractMismatch,
+                      state,
+                      attempt + 1,
+                      pollDelayMs,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+    ),
+  )
 
 const verifyNoOpenProofOrder = (
   session: BrokerSessionShape,
@@ -412,7 +444,10 @@ const cleanupOrder = (
       state.lifecycle.push(readEvidence('CLEANUP_LOOKUP_BY_CLIENT_ID', lookup.result))
     }
 
-    if (observed === undefined) observed = yield* retryRead(orderById(brokerOrderId))
+    if (observed === undefined) {
+      observed = yield* retryRead(orderById(brokerOrderId))
+      state.lifecycle.push(readEvidence('CLEANUP_LOOKUP_BY_ID', observed))
+    }
     yield* requireOrderBinding(
       observed.value,
       clientOrderId,
@@ -420,16 +455,19 @@ const cleanupOrder = (
       state.acceptedOrderContractMismatch,
       'CLEANUP',
     )
-    yield* cancelIfOpen(mutation, observed.value, state)
-    const terminal = yield* waitForTerminalOrder(
+    const terminal = yield* resolveOrderCleanup(
+      mutation,
       orderById,
-      brokerOrderId,
+      observed,
       clientOrderId,
+      brokerOrderId,
       state.acceptedOrderContractMismatch,
       state,
     )
     yield* verifyNoOpenProofOrder(session, clientOrderId, state)
     state.finalStatus = terminal.value.status
+    state.filledQuantityMicros = terminal.value.filledQuantityMicros
+    yield* requireZeroFill(terminal.value)
     state.cleanup.result = 'VERIFIED_TERMINAL'
     state.cleanup.verifiedAt = yield* currentUtcInstant
   }).pipe(
@@ -450,6 +488,44 @@ const recordSubmitFailure = (state: ProofState, error: BrokerMutationError): voi
   }
 }
 
+const testProofState = (): ProofState => ({
+  submitOutcome: 'NOT_ATTEMPTED',
+  acceptedOrderContractMismatch: false,
+  cancelAttempts: 0,
+  cancelAcknowledged: false,
+  lifecycle: [],
+  cleanup: { result: 'NOT_RUN' },
+})
+
+const testOrder = (status: OrderStatus, filledQuantityMicros = '0'): Order => ({
+  accountId: '00000000-0000-4000-8000-000000000001',
+  brokerOrderId: '00000000-0000-4000-8000-000000000002',
+  clientOrderId: 'sandbox-proof-client-order',
+  createdAt: '2026-07-28T00:00:00.000Z',
+  assetId: '00000000-0000-4000-8000-000000000003',
+  symbol: proofSymbol,
+  assetClass: AssetClass.UsEquity,
+  quantityMicros: proofQuantityMicros,
+  filledQuantityMicros,
+  orderClass: OrderClass.Simple,
+  orderType: BrokerOrderType.Market,
+  side: BrokerOrderSide.Buy,
+  timeInForce: BrokerTimeInForce.Day,
+  status,
+  extendedHours: false,
+  observedAt: '2026-07-28T00:00:01.000Z',
+})
+
+const testReadResult = (status: OrderStatus, filledQuantityMicros = '0'): ReadResult<Order> => ({
+  value: testOrder(status, filledQuantityMicros),
+  evidence: {
+    requestId: `request-${status}`,
+    status: 200,
+    contentHash: '0'.repeat(64),
+    observedAt: '2026-07-28T00:00:01.000Z',
+  },
+})
+
 test('treats every Alpaca nonterminal status as open for cleanup', () => {
   for (const status of Object.values(OrderStatus)) {
     expect(isOpenStatus(status)).toBe(!terminalOrderStatuses.has(status))
@@ -463,6 +539,79 @@ test('treats every Alpaca nonterminal status as open for cleanup', () => {
 test('keeps the cleanup network bound below its explicit deadline', () => {
   expect(maximumCleanupNetworkMs).toBeLessThan(cleanupDeadlineMs)
   expect(mutationPhaseDeadlineMs + cleanupDeadlineMs).toBeLessThan(15 * 60_000)
+})
+
+test('requires a full pre-open safety window', () => {
+  const observedAt = '2026-07-28T13:00:00.000Z'
+  expect(preOpenSafetyMillis(observedAt, '2026-07-28T13:30:00.000Z')).toBe(minimumPreOpenSafetyMs)
+  expect(preOpenSafetyMillis(observedAt, '2026-07-28T13:29:59.999Z')).toBeLessThan(minimumPreOpenSafetyMs)
+})
+
+test('rejects terminal cleanup when any quantity filled', () => {
+  expect(Exit.isSuccess(Effect.runSync(Effect.exit(requireZeroFill(testOrder(OrderStatus.Canceled)))))).toBeTrue()
+  expect(Exit.isFailure(Effect.runSync(Effect.exit(requireZeroFill(testOrder(OrderStatus.Canceled, '1')))))).toBeTrue()
+  expect(
+    Exit.isFailure(Effect.runSync(Effect.exit(requireZeroFill(testOrder(OrderStatus.Filled, '10000'))))),
+  ).toBeTrue()
+})
+
+test('retries exact cancellation after an unknown outcome', async () => {
+  const state = testProofState()
+  const initial = testReadResult(OrderStatus.New)
+  let cancelCalls = 0
+  let readCalls = 0
+  const orderById: NonNullable<BrokerMutationShape['orderById']> = (brokerOrderId) => {
+    expect(brokerOrderId).toBe(initial.value.brokerOrderId)
+    readCalls += 1
+    return Effect.succeed(testReadResult(readCalls === 1 ? OrderStatus.New : OrderStatus.Canceled))
+  }
+  const mutation: BrokerMutationShape = {
+    submit: () => Effect.die(new Error('submit is not used by cleanup retry coverage')),
+    cancel: (brokerOrderId) => {
+      expect(brokerOrderId).toBe(initial.value.brokerOrderId)
+      cancelCalls += 1
+      return cancelCalls === 1
+        ? Effect.fail(
+            new BrokerMutationError({
+              operation: MutationOperation.Cancel,
+              failure: MutationFailure.Unknown,
+              outcome: MutationOutcome.Unknown,
+              message: 'cancel response was lost',
+            }),
+          )
+        : Effect.succeed({
+            requestHash: '1'.repeat(64),
+            brokerOrderId,
+            evidence: {
+              requestId: 'cancel-retry-acknowledged',
+              status: 204,
+              contentHash: '2'.repeat(64),
+              observedAt: '2026-07-28T00:00:02.000Z',
+            },
+          })
+    },
+    orderById,
+  }
+
+  const terminal = await Effect.runPromise(
+    resolveOrderCleanup(
+      mutation,
+      orderById,
+      initial,
+      initial.value.clientOrderId,
+      initial.value.brokerOrderId,
+      false,
+      state,
+      0,
+      0,
+    ),
+  )
+
+  expect(cancelCalls).toBe(2)
+  expect(readCalls).toBe(2)
+  expect(terminal.value.status).toBe(OrderStatus.Canceled)
+  expect(state.cancelAttempts).toBe(2)
+  expect(state.cancelAcknowledged).toBeTrue()
 })
 
 test('preserves typed session acquisition evidence in the sanitized failure', () => {
@@ -496,14 +645,7 @@ test('preserves typed session acquisition evidence in the sanitized failure', ()
 })
 
 test('retains an accepted mismatched broker ID for exact cleanup', () => {
-  const state: ProofState = {
-    submitOutcome: 'NOT_ATTEMPTED',
-    acceptedOrderContractMismatch: false,
-    cancelAttempts: 0,
-    cancelAcknowledged: false,
-    lifecycle: [],
-    cleanup: { result: 'NOT_RUN' },
-  }
+  const state = testProofState()
   recordSubmitFailure(
     state,
     new BrokerMutationError({
@@ -611,14 +753,26 @@ test.skipIf(!enabled)('proves the bounded Alpaca sandbox contract through the pr
 
     const today = yield* currentUtcDate
     const clockObservedAt = yield* currentUtcInstant
-    const calendar = yield* session.read.marketCalendar({ start: today, end: today })
+    const calendar = yield* session.read.marketCalendar({ start: today, end: addUtcDays(today, 14) })
     const marketOpen = calendar.value.sessions.some(
       (marketSession) => clockObservedAt >= marketSession.openAt && clockObservedAt < marketSession.closeAt,
     )
     if (marketOpen) return yield* Effect.fail(proofFailure('CLOCK_PREFLIGHT', 'REGULAR_MARKET_IS_OPEN'))
+    const nextMarketSession = [...calendar.value.sessions]
+      .filter((marketSession) => marketSession.openAt > clockObservedAt)
+      .sort((left, right) => left.openAt.localeCompare(right.openAt))[0]
+    if (nextMarketSession === undefined) {
+      return yield* Effect.fail(proofFailure('CLOCK_PREFLIGHT', 'NEXT_MARKET_OPEN_UNAVAILABLE'))
+    }
+    const millisecondsUntilNextOpen = preOpenSafetyMillis(clockObservedAt, nextMarketSession.openAt)
+    if (millisecondsUntilNextOpen < minimumPreOpenSafetyMs) {
+      return yield* Effect.fail(proofFailure('CLOCK_PREFLIGHT', 'NEXT_MARKET_OPEN_TOO_CLOSE'))
+    }
     state.clock = {
       observedAt: clockObservedAt,
       marketOpen: false,
+      nextMarketOpenAt: nextMarketSession.openAt,
+      millisecondsUntilNextOpen,
       sessionCount: calendar.value.sessions.length,
       calendarHash: calendar.value.normalizedResponseHash,
     }
@@ -672,7 +826,7 @@ test.skipIf(!enabled)('proves the bounded Alpaca sandbox contract through the pr
             return yield* Effect.fail(proofFailure('LOOKUP_BY_CLIENT_ID', 'ORDER_QUANTITY_MISMATCH'))
           }
           state.lifecycle.push(readEvidence('LOOKUP_BY_CLIENT_ID', recoveredSubmit))
-          yield* cancelIfOpen(mutation, recoveredSubmit.value, state)
+          yield* attemptCancellation(mutation, recoveredSubmit.value, state)
         }).pipe(
           Effect.timeoutOrElse({
             duration: mutationPhaseDeadline,
@@ -747,6 +901,7 @@ test.skipIf(!enabled)('proves the bounded Alpaca sandbox contract through the pr
       submitOutcome: state.submitOutcome,
       acceptedOrderContractMismatch: state.acceptedOrderContractMismatch,
       finalStatus: state.finalStatus,
+      filledQuantityMicros: state.filledQuantityMicros,
     },
     orderLifecycle: state.lifecycle,
     cleanup: {

--- a/services/bayn/src/broker/alpaca-sandbox-contract.test.ts
+++ b/services/bayn/src/broker/alpaca-sandbox-contract.test.ts
@@ -53,7 +53,6 @@ const retryDelayMs = 1_000
 const minimumPreOpenSafetyMs = 30 * 60_000
 const mutationPhaseDeadlineMs = 2 * 60_000
 const cleanupDeadlineMs = 3 * 60_000
-const retryDelay = Duration.millis(retryDelayMs)
 const mutationPhaseDeadline = Duration.millis(mutationPhaseDeadlineMs)
 const cleanupDeadline = Duration.millis(cleanupDeadlineMs)
 const maximumRetryReadMs = (lookupRetryCount + 1) * brokerOperationTimeoutMs + lookupRetryCount * retryDelayMs
@@ -306,11 +305,12 @@ const verifySafeMarketWindow = (
 const retryRead = <A>(
   effect: Effect.Effect<A, BrokerReadError>,
   retryNotFound = false,
+  retrySpacingMs = retryDelayMs,
 ): Effect.Effect<A, BrokerReadError> =>
   effect.pipe(
     Effect.retry({
       times: lookupRetryCount,
-      schedule: Schedule.spaced(retryDelay),
+      schedule: Schedule.spaced(Duration.millis(retrySpacingMs)),
       while: (error) => error.retryable || (retryNotFound && error.kind === BrokerReadErrorKind.NotFound),
     }),
   )
@@ -407,7 +407,7 @@ const resolveOrderCleanup = (
           ? Effect.fail(proofFailure('TERMINAL_LOOKUP', 'ORDER_REMAINED_OPEN_AFTER_CANCEL_RETRIES'))
           : attemptCancellation(mutation, current.value, state).pipe(
               Effect.andThen(Effect.sleep(Duration.millis(pollDelayMs))),
-              Effect.andThen(retryRead(orderById(brokerOrderId))),
+              Effect.andThen(retryRead(orderById(brokerOrderId), true)),
               Effect.flatMap((next) =>
                 Effect.sync(() => {
                   state.lifecycle.push(readEvidence('TERMINAL_LOOKUP', next))
@@ -497,7 +497,7 @@ const cleanupOrder = (
     }
 
     if (observed === undefined) {
-      observed = yield* retryRead(orderById(brokerOrderId))
+      observed = yield* retryRead(orderById(brokerOrderId), true)
       state.lifecycle.push(readEvidence('CLEANUP_LOOKUP_BY_ID', observed))
     }
     yield* requireOrderBinding(
@@ -683,6 +683,33 @@ test('retries exact cancellation after an unknown outcome', async () => {
   expect(terminal.value.status).toBe(OrderStatus.Canceled)
   expect(state.cancelAttempts).toBe(2)
   expect(state.cancelAcknowledged).toBeTrue()
+})
+
+test('retries bounded not-found reads for a known broker order ID', async () => {
+  let attempts = 0
+  const result = await Effect.runPromise(
+    retryRead(
+      Effect.suspend(() => {
+        attempts += 1
+        return attempts === 1
+          ? Effect.fail(
+              new BrokerReadError({
+                operation: 'order-by-id',
+                kind: BrokerReadErrorKind.NotFound,
+                message: 'accepted order is not visible yet',
+                retryable: false,
+                status: 404,
+              }),
+            )
+          : Effect.succeed('visible')
+      }),
+      true,
+      0,
+    ),
+  )
+
+  expect(result).toBe('visible')
+  expect(attempts).toBe(2)
 })
 
 test('preserves typed session acquisition evidence in the sanitized failure', () => {

--- a/services/bayn/src/broker/alpaca-sandbox-contract.test.ts
+++ b/services/bayn/src/broker/alpaca-sandbox-contract.test.ts
@@ -250,6 +250,58 @@ const requireZeroFill = (order: Order): Effect.Effect<void, SandboxContractProof
   hasFilledQuantity(order)
     ? Effect.fail(proofFailure('CLEANUP', 'ORDER_FILLED_DURING_PROOF'))
     : Effect.succeed(undefined)
+const hasCancellationEvidence = (state: ProofState): boolean =>
+  state.lifecycle.some((event) => event.stage === 'CANCEL' || event.stage === 'CANCEL_UNKNOWN')
+const requireCanceledCleanup = (order: Order, state: ProofState): Effect.Effect<void, SandboxContractProofError> =>
+  Effect.gen(function* () {
+    yield* requireZeroFill(order)
+    if (order.status !== OrderStatus.Canceled) {
+      return yield* Effect.fail(proofFailure('CLEANUP', 'ORDER_DID_NOT_REACH_CANCELED'))
+    }
+    if (state.cancelAttempts === 0 || !hasCancellationEvidence(state)) {
+      return yield* Effect.fail(proofFailure('CLEANUP', 'CANCEL_PATH_NOT_PROVEN'))
+    }
+  })
+
+const verifySafeMarketWindow = (
+  session: BrokerSessionShape,
+  state: ProofState,
+  lifecycleStage: 'CLOCK_PREFLIGHT' | 'SUBMIT_CLOCK_PREFLIGHT',
+): Effect.Effect<void, BrokerReadError | SandboxContractProofError> =>
+  Effect.gen(function* () {
+    const today = yield* currentUtcDate
+    const clockObservedAt = yield* currentUtcInstant
+    const calendar = yield* session.read.marketCalendar({ start: today, end: addUtcDays(today, 14) })
+    const marketOpen = calendar.value.sessions.some(
+      (marketSession) => clockObservedAt >= marketSession.openAt && clockObservedAt < marketSession.closeAt,
+    )
+    if (marketOpen) return yield* Effect.fail(proofFailure('CLOCK_PREFLIGHT', 'REGULAR_MARKET_IS_OPEN'))
+    const nextMarketSession = [...calendar.value.sessions]
+      .filter((marketSession) => marketSession.openAt > clockObservedAt)
+      .sort((left, right) => left.openAt.localeCompare(right.openAt))[0]
+    if (nextMarketSession === undefined) {
+      return yield* Effect.fail(proofFailure('CLOCK_PREFLIGHT', 'NEXT_MARKET_OPEN_UNAVAILABLE'))
+    }
+    const millisecondsUntilNextOpen = preOpenSafetyMillis(clockObservedAt, nextMarketSession.openAt)
+    if (millisecondsUntilNextOpen < minimumPreOpenSafetyMs) {
+      return yield* Effect.fail(proofFailure('CLOCK_PREFLIGHT', 'NEXT_MARKET_OPEN_TOO_CLOSE'))
+    }
+    state.clock = {
+      observedAt: clockObservedAt,
+      marketOpen: false,
+      nextMarketOpenAt: nextMarketSession.openAt,
+      millisecondsUntilNextOpen,
+      sessionCount: calendar.value.sessions.length,
+      calendarHash: calendar.value.normalizedResponseHash,
+    }
+    state.lifecycle.push({
+      stage: lifecycleStage,
+      observedAt: calendar.evidence.observedAt,
+      status: calendar.value.sessions.length,
+      requestBinding: hashIdentity(calendar.evidence.requestId),
+      contentHash: calendar.evidence.contentHash,
+    })
+  })
 
 const retryRead = <A>(
   effect: Effect.Effect<A, BrokerReadError>,
@@ -467,7 +519,7 @@ const cleanupOrder = (
     yield* verifyNoOpenProofOrder(session, clientOrderId, state)
     state.finalStatus = terminal.value.status
     state.filledQuantityMicros = terminal.value.filledQuantityMicros
-    yield* requireZeroFill(terminal.value)
+    yield* requireCanceledCleanup(terminal.value, state)
     state.cleanup.result = 'VERIFIED_TERMINAL'
     state.cleanup.verifiedAt = yield* currentUtcInstant
   }).pipe(
@@ -552,6 +604,25 @@ test('rejects terminal cleanup when any quantity filled', () => {
   expect(Exit.isFailure(Effect.runSync(Effect.exit(requireZeroFill(testOrder(OrderStatus.Canceled, '1')))))).toBeTrue()
   expect(
     Exit.isFailure(Effect.runSync(Effect.exit(requireZeroFill(testOrder(OrderStatus.Filled, '10000'))))),
+  ).toBeTrue()
+})
+
+test('requires an exact canceled outcome with cancellation evidence', () => {
+  const state = testProofState()
+  expect(
+    Exit.isFailure(Effect.runSync(Effect.exit(requireCanceledCleanup(testOrder(OrderStatus.Canceled), state)))),
+  ).toBeTrue()
+
+  state.cancelAttempts = 1
+  state.lifecycle.push({
+    stage: 'CANCEL_UNKNOWN',
+    observedAt: '2026-07-28T00:00:02.000Z',
+  })
+  expect(
+    Exit.isSuccess(Effect.runSync(Effect.exit(requireCanceledCleanup(testOrder(OrderStatus.Canceled), state)))),
+  ).toBeTrue()
+  expect(
+    Exit.isFailure(Effect.runSync(Effect.exit(requireCanceledCleanup(testOrder(OrderStatus.Filled), state)))),
   ).toBeTrue()
 })
 
@@ -750,32 +821,7 @@ test.skipIf(!enabled)('proves the bounded Alpaca sandbox contract through the pr
       return yield* Effect.fail(proofFailure('SESSION_PREFLIGHT', 'VERIFIED_SESSION_BINDING_MISMATCH'))
     }
     state.preflightCompletedAt = yield* currentUtcInstant
-
-    const today = yield* currentUtcDate
-    const clockObservedAt = yield* currentUtcInstant
-    const calendar = yield* session.read.marketCalendar({ start: today, end: addUtcDays(today, 14) })
-    const marketOpen = calendar.value.sessions.some(
-      (marketSession) => clockObservedAt >= marketSession.openAt && clockObservedAt < marketSession.closeAt,
-    )
-    if (marketOpen) return yield* Effect.fail(proofFailure('CLOCK_PREFLIGHT', 'REGULAR_MARKET_IS_OPEN'))
-    const nextMarketSession = [...calendar.value.sessions]
-      .filter((marketSession) => marketSession.openAt > clockObservedAt)
-      .sort((left, right) => left.openAt.localeCompare(right.openAt))[0]
-    if (nextMarketSession === undefined) {
-      return yield* Effect.fail(proofFailure('CLOCK_PREFLIGHT', 'NEXT_MARKET_OPEN_UNAVAILABLE'))
-    }
-    const millisecondsUntilNextOpen = preOpenSafetyMillis(clockObservedAt, nextMarketSession.openAt)
-    if (millisecondsUntilNextOpen < minimumPreOpenSafetyMs) {
-      return yield* Effect.fail(proofFailure('CLOCK_PREFLIGHT', 'NEXT_MARKET_OPEN_TOO_CLOSE'))
-    }
-    state.clock = {
-      observedAt: clockObservedAt,
-      marketOpen: false,
-      nextMarketOpenAt: nextMarketSession.openAt,
-      millisecondsUntilNextOpen,
-      sessionCount: calendar.value.sessions.length,
-      calendarHash: calendar.value.normalizedResponseHash,
-    }
+    yield* verifySafeMarketWindow(session, state, 'CLOCK_PREFLIGHT')
 
     const asset = yield* session.read.assetBySymbol(proofSymbol)
     if (asset.value.status !== AssetStatus.Active || !asset.value.tradable || !asset.value.fractionable) {
@@ -803,6 +849,7 @@ test.skipIf(!enabled)('proves the bounded Alpaca sandbox contract through the pr
       Effect.succeed(undefined),
       () =>
         Effect.gen(function* () {
+          yield* verifySafeMarketWindow(session, state, 'SUBMIT_CLOCK_PREFLIGHT')
           const submit = yield* mutation.submit(intent).pipe(
             Effect.tapError((error) =>
               Effect.sync(() => {

--- a/services/bayn/src/broker/alpaca-sandbox-contract.test.ts
+++ b/services/bayn/src/broker/alpaca-sandbox-contract.test.ts
@@ -6,6 +6,7 @@ import { HttpClient } from 'effect/unstable/http'
 import { canonicalHashV1 } from '../hash'
 import {
   BrokerEnvironment,
+  CapitalAccessState,
   ExecutionAccess,
   disabledCapitalAccess,
   makeExecutionAuthority,
@@ -17,6 +18,7 @@ import {
   MutationFailure,
   MutationOperation,
   makeMutation,
+  submitBody,
   type BrokerMutationShape,
 } from './alpaca-mutations'
 import {
@@ -57,6 +59,9 @@ const workflowJobTimeoutMs = 15 * 60_000
 const overallProofDeadlineMs = 13 * 60_000
 const requiredSubmitBudgetMs = mutationPhaseDeadlineMs + cleanupDeadlineMs
 const protectedProxyUrl = 'http://127.0.0.1:18080'
+const protectedGithubEnvironment = 'bayn-alpaca-sandbox'
+const protectedRepository = 'proompteng/lab'
+const protectedEventName = 'workflow_dispatch'
 const mutationPhaseDeadline = Duration.millis(mutationPhaseDeadlineMs)
 const cleanupDeadline = Duration.millis(cleanupDeadlineMs)
 const maximumRetryReadMs = (lookupRetryCount + 1) * brokerOperationTimeoutMs + lookupRetryCount * retryDelayMs
@@ -92,6 +97,92 @@ const jsonSafeObject = (value: unknown): Record<string, unknown> => {
 }
 
 const hashIdentity = (value: string): string => canonicalHashV1({ value })
+
+interface ProtectedProofBinding {
+  readonly configuredOrigin: string
+  readonly exactHeadSha: string
+  readonly sourceSha: string
+  readonly repository: string
+  readonly eventName: string
+  readonly githubEnvironment: string
+  readonly mutationAuthorized: string
+  readonly actor: string
+  readonly triggeringActor: string
+  readonly runAttempt: string
+  readonly proxyUrl: string
+}
+
+const validateProtectedProofBinding = (binding: ProtectedProofBinding): void => {
+  if (binding.configuredOrigin !== alpacaSandboxBaseUrl) {
+    throw new Error('sandbox endpoint must be exactly https://paper-api.alpaca.markets')
+  }
+  if (!/^[0-9a-f]{40}$/.test(binding.sourceSha)) {
+    throw new Error('GITHUB_SHA must be an exact lowercase commit SHA')
+  }
+  if (binding.exactHeadSha !== binding.sourceSha) {
+    throw new Error('authorized exact head SHA does not match GITHUB_SHA')
+  }
+  if (binding.repository !== protectedRepository) {
+    throw new Error(`protected proof repository must be ${protectedRepository}`)
+  }
+  if (binding.eventName !== protectedEventName) {
+    throw new Error('protected proof may run only from workflow_dispatch')
+  }
+  if (binding.githubEnvironment !== protectedGithubEnvironment) {
+    throw new Error(`protected proof must use GitHub environment ${protectedGithubEnvironment}`)
+  }
+  if (binding.mutationAuthorized !== 'true') {
+    throw new Error('protected broker mutation was not explicitly authorized')
+  }
+  if (binding.actor !== binding.triggeringActor) {
+    throw new Error('broker-mutating reruns require a fresh dispatch by the authorizing actor')
+  }
+  if (binding.runAttempt !== '1') {
+    throw new Error('broker-mutating proof reruns are forbidden; create a fresh authorized dispatch')
+  }
+  if (binding.proxyUrl !== protectedProxyUrl) {
+    throw new Error('sandbox proof must use the restricted loopback CONNECT proxy')
+  }
+}
+
+interface ProofIdentityInput {
+  readonly runId: string
+  readonly runAttempt: string
+  readonly sourceSha: string
+  readonly releaseImageIdentity: string
+}
+
+const proofIdentity = (input: ProofIdentityInput): string => canonicalHashV1(input)
+const proofClientOrderId = (input: ProofIdentityInput): string => `b1_${proofIdentity(input).slice(0, 43)}`
+
+const makeSandboxProofAuthority = () =>
+  makeExecutionAuthority(BrokerEnvironment.Sandbox, ExecutionAccess.SubmitOrders, disabledCapitalAccess)
+
+const makeProofIntent = (
+  expectedAccountId: string,
+  clientOrderId: string,
+  identity: string,
+  createdAt: string,
+): Intent => ({
+  schemaVersion: 'bayn.paper-intent.v3',
+  intentId: canonicalHashV1({ identity, kind: 'intent' }),
+  authorityGenerationHash: canonicalHashV1({ identity, kind: 'authority' }),
+  riskDecisionId: canonicalHashV1({ identity, kind: 'risk' }),
+  strategyName: 'alpaca-sandbox-contract-proof',
+  cycleId: canonicalHashV1({ identity, kind: 'cycle' }),
+  decisionHash: canonicalHashV1({ identity, kind: 'decision' }),
+  policyHash: canonicalHashV1({ identity, kind: 'policy' }),
+  accountId: expectedAccountId,
+  clientOrderId,
+  symbol: proofSymbol,
+  side: OrderSide.Buy,
+  orderType: OrderType.Market,
+  timeInForce: TimeInForce.Day,
+  quantityMicros: proofQuantityMicros,
+  notionalLimitMicros: '5000000',
+  state: IntentState.IoStarted,
+  createdAt,
+})
 
 const addUtcDays = (date: string, days: number): string => {
   const value = new Date(`${date}T00:00:00.000Z`)
@@ -153,6 +244,7 @@ interface ProofState {
     readonly fractionable: true
     readonly observationHash: string
   }
+  submitAttempts: number
   submitOutcome: 'NOT_ATTEMPTED' | 'ACKNOWLEDGED' | 'REJECTED' | 'UNKNOWN'
   brokerOrderId?: string
   finalStatus?: OrderStatus
@@ -629,7 +721,27 @@ const recordSubmitFailure = (state: ProofState, error: BrokerMutationError): voi
   state.submitOutcome = error.failure === MutationFailure.Rejected ? 'REJECTED' : 'UNKNOWN'
 }
 
+const submitProofOrder = (mutation: BrokerMutationShape, intent: Intent, state: ProofState) =>
+  Effect.sync(() => {
+    state.submitAttempts += 1
+  }).pipe(
+    Effect.andThen(mutation.submit(intent)),
+    Effect.tapError((error) =>
+      Effect.sync(() => {
+        recordSubmitFailure(state, error)
+      }),
+    ),
+    Effect.tap((submit) =>
+      Effect.sync(() => {
+        state.submitOutcome = 'ACKNOWLEDGED'
+        state.brokerOrderId = submit.order.brokerOrderId
+        state.lifecycle.push(mutationEvidence('SUBMIT', submit.evidence))
+      }),
+    ),
+  )
+
 const testProofState = (): ProofState => ({
+  submitAttempts: 0,
   submitOutcome: 'NOT_ATTEMPTED',
   cancelAttempts: 0,
   cancelAcknowledged: false,
@@ -720,6 +832,115 @@ test('binds the real proof to the restricted production proxy transport', () => 
     port: '18080',
     pathname: '/',
   })
+})
+
+test('requires exact dispatch, environment, endpoint, actor, and mutation authorization binding', () => {
+  const binding: ProtectedProofBinding = {
+    configuredOrigin: alpacaSandboxBaseUrl,
+    exactHeadSha: 'a'.repeat(40),
+    sourceSha: 'a'.repeat(40),
+    repository: protectedRepository,
+    eventName: protectedEventName,
+    githubEnvironment: protectedGithubEnvironment,
+    mutationAuthorized: 'true',
+    actor: 'gregkonush',
+    triggeringActor: 'gregkonush',
+    runAttempt: '1',
+    proxyUrl: protectedProxyUrl,
+  }
+
+  expect(() => validateProtectedProofBinding(binding)).not.toThrow()
+  expect(() => validateProtectedProofBinding({ ...binding, configuredOrigin: 'https://api.alpaca.markets' })).toThrow(
+    'sandbox endpoint',
+  )
+  expect(() => validateProtectedProofBinding({ ...binding, githubEnvironment: 'production' })).toThrow(
+    protectedGithubEnvironment,
+  )
+  expect(() => validateProtectedProofBinding({ ...binding, mutationAuthorized: 'false' })).toThrow(
+    'not explicitly authorized',
+  )
+  expect(() => validateProtectedProofBinding({ ...binding, triggeringActor: 'other-actor' })).toThrow('fresh dispatch')
+  expect(() => validateProtectedProofBinding({ ...binding, runAttempt: '2' })).toThrow('reruns are forbidden')
+})
+
+test('uses sandbox submit authority with capital access disabled', () => {
+  const authority = makeSandboxProofAuthority()
+  expect(authority).toEqual({
+    brokerEnvironment: BrokerEnvironment.Sandbox,
+    executionAccess: ExecutionAccess.SubmitOrders,
+    capitalAccess: { _tag: CapitalAccessState.Disabled },
+  })
+})
+
+test('derives a deterministic per-attempt Alpaca client order ID', () => {
+  const input: ProofIdentityInput = {
+    runId: '12345',
+    runAttempt: '1',
+    sourceSha: 'a'.repeat(40),
+    releaseImageIdentity: `registry.ide-newton.ts.net/lab/bayn@sha256:${'b'.repeat(64)}`,
+  }
+  const clientOrderId = proofClientOrderId(input)
+
+  expect(clientOrderId).toBe(proofClientOrderId(input))
+  expect(clientOrderId).toMatch(/^b1_[0-9a-f]{43}$/)
+  expect(clientOrderId.length).toBeLessThanOrEqual(48)
+  expect(clientOrderId).not.toBe(proofClientOrderId({ ...input, runAttempt: '2' }))
+})
+
+test('constructs the exact non-extended fractional DAY market request', () => {
+  const identity = 'c'.repeat(64)
+  const clientOrderId = `b1_${identity.slice(0, 43)}`
+  const intent = makeProofIntent(
+    '00000000-0000-4000-8000-000000000001',
+    clientOrderId,
+    identity,
+    '2026-07-28T00:00:00.000Z',
+  )
+  const request = submitBody(intent)
+  expect(Result.isSuccess(request)).toBeTrue()
+  if (Result.isFailure(request)) throw request.failure
+  expect(request.success).toEqual({
+    symbol: proofSymbol,
+    qty: '0.01',
+    side: BrokerOrderSide.Buy,
+    type: BrokerOrderType.Market,
+    time_in_force: BrokerTimeInForce.Day,
+    client_order_id: clientOrderId,
+    extended_hours: false,
+  })
+})
+
+test('never retries an ambiguous submit mutation', async () => {
+  const state = testProofState()
+  const identity = 'd'.repeat(64)
+  const intent = makeProofIntent(
+    '00000000-0000-4000-8000-000000000001',
+    `b1_${identity.slice(0, 43)}`,
+    identity,
+    '2026-07-28T00:00:00.000Z',
+  )
+  let submitCalls = 0
+  const mutation: BrokerMutationShape = {
+    submit: () => {
+      submitCalls += 1
+      return Effect.fail(
+        new BrokerMutationError({
+          operation: MutationOperation.Submit,
+          failure: MutationFailure.Unknown,
+          outcome: MutationOutcome.Unknown,
+          message: 'submit acknowledgement was lost',
+        }),
+      )
+    },
+    cancel: () => Effect.die(new Error('cancel is not used by submit retry coverage')),
+  }
+
+  const exit = await Effect.runPromiseExit(submitProofOrder(mutation, intent, state))
+  expect(Exit.isFailure(exit)).toBeTrue()
+  expect(submitCalls).toBe(1)
+  expect(state.submitAttempts).toBe(1)
+  expect(state.submitOutcome).toBe('UNKNOWN')
+  expect(state.brokerOrderId).toBeUndefined()
 })
 
 test('requires a full pre-open safety window', () => {
@@ -946,7 +1167,14 @@ test.skipIf(!enabled)('proves the bounded Alpaca sandbox contract through the pr
   const key = required('BAYN_ALPACA_KEY_ID')
   const secret = required('BAYN_ALPACA_SECRET_KEY')
   const configuredOrigin = required('BAYN_ALPACA_BASE_URL')
+  const exactHeadSha = required('BAYN_ALPACA_SANDBOX_EXACT_HEAD_SHA')
   const sourceSha = required('GITHUB_SHA')
+  const repository = required('GITHUB_REPOSITORY')
+  const eventName = required('GITHUB_EVENT_NAME')
+  const githubEnvironment = required('BAYN_ALPACA_SANDBOX_GITHUB_ENVIRONMENT')
+  const mutationAuthorized = required('BAYN_ALPACA_SANDBOX_MUTATION_AUTHORIZED')
+  const actor = required('GITHUB_ACTOR')
+  const triggeringActor = required('GITHUB_TRIGGERING_ACTOR')
   const runId = required('GITHUB_RUN_ID')
   const runAttempt = required('GITHUB_RUN_ATTEMPT')
   const releaseImageIdentity = required('BAYN_ALPACA_SANDBOX_RELEASE_IMAGE_IDENTITY')
@@ -956,17 +1184,25 @@ test.skipIf(!enabled)('proves the bounded Alpaca sandbox contract through the pr
   const jobStartedEpochMs = requiredEpochMillis('BAYN_ALPACA_SANDBOX_JOB_STARTED_EPOCH_MS')
   const jobDeadlineEpochMs = requiredEpochMillis('BAYN_ALPACA_SANDBOX_JOB_DEADLINE_EPOCH_MS')
 
-  if (configuredOrigin !== alpacaSandboxBaseUrl) throw new Error('sandbox endpoint guard failed')
-  if (!/^[0-9a-f]{40}$/.test(sourceSha)) throw new Error('GITHUB_SHA must be an exact lowercase commit SHA')
+  validateProtectedProofBinding({
+    configuredOrigin,
+    exactHeadSha,
+    sourceSha,
+    repository,
+    eventName,
+    githubEnvironment,
+    mutationAuthorized,
+    actor,
+    triggeringActor,
+    runAttempt,
+    proxyUrl,
+  })
   if (!/^[0-9]+$/.test(releaseImageBuildRunId)) throw new Error('release image build run ID must be numeric')
   if (!/^registry\.ide-newton\.ts\.net\/lab\/bayn@sha256:[0-9a-f]{64}$/.test(releaseImageIdentity)) {
     throw new Error('release image identity must be the verified Bayn multi-architecture digest reference')
   }
   if (releaseImageTag !== `registry.ide-newton.ts.net/lab/bayn:sha-${sourceSha}`) {
     throw new Error('release image tag is not bound to the exact proof source SHA')
-  }
-  if (proxyUrl !== protectedProxyUrl) {
-    throw new Error('sandbox proof must use the restricted loopback CONNECT proxy')
   }
   if (jobDeadlineEpochMs - jobStartedEpochMs !== overallProofDeadlineMs) {
     throw new Error('overall protected proof deadline is not bound to the configured job budget')
@@ -996,29 +1232,12 @@ test.skipIf(!enabled)('proves the bounded Alpaca sandbox contract through the pr
       ),
     )
 
-  const identity = canonicalHashV1({ runId, runAttempt, sourceSha, releaseImageIdentity })
-  const clientOrderId = `b1_${identity.slice(0, 43)}`
-  const intent: Intent = {
-    schemaVersion: 'bayn.paper-intent.v3',
-    intentId: canonicalHashV1({ identity, kind: 'intent' }),
-    authorityGenerationHash: canonicalHashV1({ identity, kind: 'authority' }),
-    riskDecisionId: canonicalHashV1({ identity, kind: 'risk' }),
-    strategyName: 'alpaca-sandbox-contract-proof',
-    cycleId: canonicalHashV1({ identity, kind: 'cycle' }),
-    decisionHash: canonicalHashV1({ identity, kind: 'decision' }),
-    policyHash: canonicalHashV1({ identity, kind: 'policy' }),
-    accountId: expectedAccountId,
-    clientOrderId,
-    symbol: proofSymbol,
-    side: OrderSide.Buy,
-    orderType: OrderType.Market,
-    timeInForce: TimeInForce.Day,
-    quantityMicros: proofQuantityMicros,
-    notionalLimitMicros: '5000000',
-    state: IntentState.IoStarted,
-    createdAt: await run(currentUtcInstant),
-  }
+  const identityInput = { runId, runAttempt, sourceSha, releaseImageIdentity }
+  const identity = proofIdentity(identityInput)
+  const clientOrderId = proofClientOrderId(identityInput)
+  const intent = makeProofIntent(expectedAccountId, clientOrderId, identity, await run(currentUtcInstant))
   const state: ProofState = {
+    submitAttempts: 0,
     submitOutcome: 'NOT_ATTEMPTED',
     cancelAttempts: 0,
     cancelAcknowledged: false,
@@ -1050,11 +1269,14 @@ test.skipIf(!enabled)('proves the bounded Alpaca sandbox contract through the pr
       observationHash: asset.value.normalizedResponseHash,
     }
 
-    const authority = makeExecutionAuthority(
-      BrokerEnvironment.Sandbox,
-      ExecutionAccess.SubmitOrders,
-      disabledCapitalAccess,
-    )
+    const authority = makeSandboxProofAuthority()
+    if (
+      authority.brokerEnvironment !== BrokerEnvironment.Sandbox ||
+      authority.executionAccess !== ExecutionAccess.SubmitOrders ||
+      authority.capitalAccess._tag !== CapitalAccessState.Disabled
+    ) {
+      return yield* Effect.fail(proofFailure('CONFIGURATION', 'SANDBOX_ONLY_AUTHORITY_BINDING_MISMATCH'))
+    }
     const mutation = yield* makeMutation(session, authority)
     const orderByClientId = mutation.orderByClientId
     if (orderByClientId === undefined) {
@@ -1067,16 +1289,7 @@ test.skipIf(!enabled)('proves the bounded Alpaca sandbox contract through the pr
         Effect.gen(function* () {
           yield* verifySafeMarketWindow(session, state, 'SUBMIT_CLOCK_PREFLIGHT')
           yield* requireOverallSubmitBudget(jobDeadlineEpochMs, state)
-          const submit = yield* mutation.submit(intent).pipe(
-            Effect.tapError((error) =>
-              Effect.sync(() => {
-                recordSubmitFailure(state, error)
-              }),
-            ),
-          )
-          state.submitOutcome = 'ACKNOWLEDGED'
-          state.brokerOrderId = submit.order.brokerOrderId
-          state.lifecycle.push(mutationEvidence('SUBMIT', submit.evidence))
+          const submit = yield* submitProofOrder(mutation, intent, state)
 
           const recoveredSubmit = yield* retryRead(orderByClientId(clientOrderId), true)
           yield* requireOrderBinding(
@@ -1117,10 +1330,17 @@ test.skipIf(!enabled)('proves the bounded Alpaca sandbox contract through the pr
   const proofExit = await run(Effect.exit(proof))
   state.completedAt = await run(currentUtcInstant)
   const receiptBody = {
-    schemaVersion: 'bayn.alpaca-sandbox-contract-receipt.v3',
+    schemaVersion: 'bayn.alpaca-sandbox-contract-receipt.v4',
     proofStatus: Exit.isSuccess(proofExit) ? 'SUCCESS' : 'FAILURE',
     sourceSha,
-    repository: required('GITHUB_REPOSITORY'),
+    repository,
+    githubEnvironment,
+    authorization: {
+      eventName,
+      actor,
+      triggeringActor,
+      explicitBrokerMutation: true,
+    },
     workflow: {
       runId,
       runAttempt,
@@ -1156,14 +1376,11 @@ test.skipIf(!enabled)('proves the bounded Alpaca sandbox contract through the pr
     endpointClass: 'ALPACA_PAPER',
     endpoint: alpacaSandboxBaseUrl,
     accountIdentityHash: hashIdentity(expectedAccountId),
-    credentialBindingHash: canonicalHashV1({
-      identity,
-      endpoint: configuredOrigin,
-      proxyUrl,
-      accountId: expectedAccountId,
-      key,
-      secret,
-    }),
+    credentialBinding: {
+      source: 'GITHUB_ENVIRONMENT_SECRETS',
+      verifiedBy: 'BROKER_SESSION_PREFLIGHT',
+      secretDerivedEvidenceRecorded: false,
+    },
     preflight: {
       accountStatus: state.preflightCompletedAt === undefined ? undefined : 'ACTIVE',
       paperEnvironment: true,
@@ -1186,7 +1403,8 @@ test.skipIf(!enabled)('proves the bounded Alpaca sandbox contract through the pr
       cancelAttempts: state.cancelAttempts,
       cancelAcknowledged: state.cancelAcknowledged,
     },
-    duplicateSubmitCount: 0,
+    submitAttempts: state.submitAttempts,
+    duplicateSubmitCount: Math.max(0, state.submitAttempts - 1),
     liveEndpointUsed: false,
     failure: state.failure,
     cleanupFailure: state.cleanupFailure,
@@ -1204,5 +1422,8 @@ test.skipIf(!enabled)('proves the bounded Alpaca sandbox contract through the pr
   }
   if (state.cleanup.result !== 'VERIFIED_TERMINAL' || state.cleanup.residualOpenOrderCount !== 0) {
     throw new Error('Alpaca sandbox cleanup was not proven terminal and residual-free')
+  }
+  if (state.submitAttempts !== 1) {
+    throw new Error('Alpaca sandbox proof must perform exactly one submit attempt')
   }
 })

--- a/services/bayn/src/broker/alpaca-sandbox-contract.test.ts
+++ b/services/bayn/src/broker/alpaca-sandbox-contract.test.ts
@@ -384,6 +384,49 @@ const readEvidence = (stage: string, result: ReadResult<Order>): LifecycleEvent 
   contentHash: result.evidence.contentHash,
 })
 
+const recoverUnknownSubmitOrder = (
+  orderByClientId: (clientOrderId: string) => Effect.Effect<ReadResult<Order>, BrokerReadError>,
+  openOrders: BrokerSessionShape['read']['orders'],
+  clientOrderId: string,
+  state: ProofState,
+  pollDelayMs = retryDelayMs,
+): Effect.Effect<ReadResult<Order>, BrokerReadError | SandboxContractProofError> =>
+  Effect.gen(function* () {
+    const lookup = yield* retryRead(orderByClientId(clientOrderId), true, pollDelayMs).pipe(
+      Effect.map((result) => ({ _tag: 'Found' as const, result })),
+      Effect.catch((error) => Effect.succeed({ _tag: 'Failed' as const, error })),
+    )
+    if (lookup._tag === 'Found') {
+      state.lifecycle.push(readEvidence('CLEANUP_LOOKUP_BY_CLIENT_ID', lookup.result))
+      return lookup.result
+    }
+    if (lookup.error.kind !== BrokerReadErrorKind.NotFound) return yield* Effect.fail(lookup.error)
+
+    const open = yield* retryRead(openOrders({ status: OrderCollection.Open, limit: 500 }), false, pollDelayMs)
+    const matching = open.value.filter((order) => order.clientOrderId === clientOrderId)
+    state.lifecycle.push({
+      stage: 'UNKNOWN_SUBMIT_OPEN_ORDER_SCAN',
+      observedAt: open.evidence.observedAt,
+      status: matching.length,
+      requestBinding: hashIdentity(open.evidence.requestId),
+      contentHash: open.evidence.contentHash,
+    })
+    if (matching.length > 1) {
+      return yield* Effect.fail(proofFailure('CLEANUP', 'MULTIPLE_MATCHING_OPEN_ORDERS'))
+    }
+    const recovered = matching[0]
+    if (recovered !== undefined) {
+      const result = { value: recovered, evidence: open.evidence }
+      state.lifecycle.push(readEvidence('CLEANUP_RECOVERED_FROM_OPEN_ORDERS', result))
+      return result
+    }
+
+    yield* Effect.sleep(Duration.millis(pollDelayMs))
+    return yield* Effect.suspend(() =>
+      recoverUnknownSubmitOrder(orderByClientId, openOrders, clientOrderId, state, pollDelayMs),
+    )
+  })
+
 const requireOrderBinding = (
   order: Order,
   clientOrderId: string,
@@ -535,17 +578,29 @@ const cleanupOrder = (
           state.cleanup.verifiedAt = yield* currentUtcInstant
           return
         }
-        if (lookup.error.kind === BrokerReadErrorKind.NotFound) {
-          return yield* Effect.fail(proofFailure('CLEANUP', 'UNKNOWN_SUBMIT_NOT_RESOLVED'))
+        if (lookup.error.kind === BrokerReadErrorKind.NotFound && state.submitOutcome === 'UNKNOWN') {
+          observed = yield* recoverUnknownSubmitOrder(orderByClientId, session.read.orders, clientOrderId, state)
+          brokerOrderId = observed.value.brokerOrderId
+          state.brokerOrderId = brokerOrderId
         }
-        return yield* Effect.fail(lookup.error)
+        if (lookup.error.kind === BrokerReadErrorKind.NotFound) {
+          if (observed === undefined) {
+            return yield* Effect.fail(proofFailure('CLEANUP', 'UNKNOWN_SUBMIT_NOT_RESOLVED'))
+          }
+        } else {
+          return yield* Effect.fail(lookup.error)
+        }
+      } else {
+        observed = lookup.result
+        brokerOrderId = lookup.result.value.brokerOrderId
+        state.brokerOrderId = brokerOrderId
+        state.lifecycle.push(readEvidence('CLEANUP_LOOKUP_BY_CLIENT_ID', lookup.result))
       }
-      observed = lookup.result
-      brokerOrderId = lookup.result.value.brokerOrderId
-      state.brokerOrderId = brokerOrderId
-      state.lifecycle.push(readEvidence('CLEANUP_LOOKUP_BY_CLIENT_ID', lookup.result))
     }
 
+    if (brokerOrderId === undefined) {
+      return yield* Effect.fail(proofFailure('CLEANUP', 'BROKER_ORDER_ID_UNAVAILABLE'))
+    }
     if (observed === undefined) {
       observed = yield* retryRead(orderById(brokerOrderId), true)
       state.lifecycle.push(readEvidence('CLEANUP_LOOKUP_BY_ID', observed))
@@ -790,6 +845,50 @@ test('retries bounded not-found reads for a known broker order ID', async () => 
 
   expect(result).toBe('visible')
   expect(attempts).toBe(2)
+})
+
+test('keeps recovering an unknown submit after bounded client lookup misses', async () => {
+  const state = testProofState()
+  state.submitOutcome = 'UNKNOWN'
+  const order = testOrder(OrderStatus.New)
+  let lookupAttempts = 0
+  let openOrderScans = 0
+  const orderByClientId: NonNullable<BrokerMutationShape['orderByClientId']> = (clientOrderId) => {
+    expect(clientOrderId).toBe(order.clientOrderId)
+    return Effect.suspend(() => {
+      lookupAttempts += 1
+      return Effect.fail(
+        new BrokerReadError({
+          operation: 'order-by-client-id',
+          kind: BrokerReadErrorKind.NotFound,
+          message: 'accepted order is not visible by client ID yet',
+          retryable: false,
+          status: 404,
+        }),
+      )
+    })
+  }
+  const openOrders: BrokerSessionShape['read']['orders'] = () => {
+    openOrderScans += 1
+    return Effect.succeed({
+      value: openOrderScans === 1 ? [] : [order],
+      evidence: {
+        requestId: `open-order-scan-${openOrderScans}`,
+        status: 200,
+        contentHash: `${openOrderScans}`.repeat(64),
+        observedAt: `2026-07-28T00:00:0${openOrderScans}.000Z`,
+      },
+    })
+  }
+
+  const recovered = await Effect.runPromise(
+    recoverUnknownSubmitOrder(orderByClientId, openOrders, order.clientOrderId, state, 0),
+  )
+
+  expect(lookupAttempts).toBe((lookupRetryCount + 1) * 2)
+  expect(openOrderScans).toBe(2)
+  expect(recovered.value.brokerOrderId).toBe(order.brokerOrderId)
+  expect(state.lifecycle.map((event) => event.stage)).toContain('CLEANUP_RECOVERED_FROM_OPEN_ORDERS')
 })
 
 test('preserves typed session acquisition evidence in the sanitized failure', () => {

--- a/services/bayn/src/broker/alpaca-sandbox-contract.test.ts
+++ b/services/bayn/src/broker/alpaca-sandbox-contract.test.ts
@@ -1,7 +1,7 @@
-import { expect, test } from 'bun:test'
+import { test } from 'bun:test'
 
 import { NodeHttpClient } from '@effect/platform-node'
-import { Effect, Redacted, Result } from 'effect'
+import { Data, Duration, Effect, Exit, Redacted, References, Result, Schedule } from 'effect'
 import { HttpClient } from 'effect/unstable/http'
 
 import { canonicalHashV1 } from '../hash'
@@ -12,18 +12,30 @@ import {
   makeExecutionAuthority,
 } from '../execution/authority'
 import { IntentState, OrderSide, OrderType, TimeInForce, type Intent } from '../paper'
-import { BrokerMutationError, MutationFailure, makeMutation } from './alpaca-mutations'
+import { currentUtcDate, currentUtcInstant } from '../time'
+import { BrokerMutationError, MutationFailure, makeMutation, type BrokerMutationShape } from './alpaca-mutations'
 import {
+  AssetStatus,
   BrokerProvider,
+  BrokerReadError,
+  BrokerReadErrorKind,
+  OrderCollection,
   OrderStatus,
-  alpacaLiveBaseUrl,
   alpacaSandboxBaseUrl,
   acquireBrokerSession,
   decodeBrokerConnection,
+  type BrokerSessionShape,
+  type Order,
+  type ReadResult,
 } from './alpaca'
 
 const enabled = Bun.env.BAYN_ALPACA_SANDBOX_CONTRACT === '1'
 const receiptPath = Bun.env.BAYN_ALPACA_SANDBOX_RECEIPT_PATH
+const proofSymbol = 'AAPL'
+const proofQuantityMicros = '10000'
+const lookupRetryCount = 4
+const terminalPollCount = 15
+const retryDelay = Duration.seconds(1)
 
 const required = (name: string): string => {
   const value = Bun.env[name]
@@ -33,16 +45,347 @@ const required = (name: string): string => {
   return value
 }
 
-const redact = (value: string): string => canonicalHashV1({ value }).slice(0, 16)
+const hashIdentity = (value: string): string => canonicalHashV1({ value })
+
+type ProofStage =
+  | 'CONFIGURATION'
+  | 'SESSION_PREFLIGHT'
+  | 'CLOCK_PREFLIGHT'
+  | 'ASSET_PREFLIGHT'
+  | 'SUBMIT'
+  | 'LOOKUP_BY_CLIENT_ID'
+  | 'CANCEL'
+  | 'TERMINAL_LOOKUP'
+  | 'CLEANUP'
+
+class SandboxContractProofError extends Data.TaggedError('SandboxContractProofError')<{
+  readonly stage: ProofStage
+  readonly failure: string
+}> {}
+
+interface SanitizedFailure {
+  readonly stage: ProofStage
+  readonly tag: string
+  readonly failure: string
+  readonly operation?: string
+  readonly status?: number
+  readonly retryable?: boolean
+}
+
+interface LifecycleEvent {
+  readonly stage: string
+  readonly observedAt: string
+  readonly status?: string | number
+  readonly requestBinding?: string
+  readonly contentHash?: string
+}
+
+interface ProofState {
+  startedAt?: string
+  completedAt?: string
+  preflightCompletedAt?: string
+  clock?: {
+    readonly observedAt: string
+    readonly marketOpen: false
+    readonly sessionCount: number
+    readonly calendarHash: string
+  }
+  asset?: {
+    readonly status: AssetStatus.Active
+    readonly tradable: true
+    readonly fractionable: true
+    readonly observationHash: string
+  }
+  submitOutcome: 'NOT_ATTEMPTED' | 'ACKNOWLEDGED' | 'REJECTED' | 'UNKNOWN'
+  brokerOrderId?: string
+  finalStatus?: OrderStatus
+  cancelAttempts: number
+  cancelAcknowledged: boolean
+  lifecycle: LifecycleEvent[]
+  cleanup: {
+    result: 'NOT_RUN' | 'CONFIRMED_NOT_CREATED' | 'VERIFIED_TERMINAL' | 'FAILED'
+    verifiedAt?: string
+    residualOpenOrderCount?: number
+  }
+  failure?: SanitizedFailure
+  cleanupFailure?: SanitizedFailure
+}
+
+const proofFailure = (stage: ProofStage, failure: string): SandboxContractProofError =>
+  new SandboxContractProofError({ stage, failure })
+
+const sanitizeFailure = (stage: ProofStage, error: unknown): SanitizedFailure => {
+  if (error instanceof BrokerReadError) {
+    return {
+      stage,
+      tag: error._tag,
+      failure: error.kind,
+      operation: error.operation,
+      status: error.status,
+      retryable: error.retryable,
+    }
+  }
+  if (error instanceof BrokerMutationError) {
+    return {
+      stage,
+      tag: error._tag,
+      failure: error.failure,
+      operation: error.operation,
+      status: error.evidence?.status,
+      retryable: error.failure === MutationFailure.Unknown,
+    }
+  }
+  if (error instanceof SandboxContractProofError) {
+    return { stage: error.stage, tag: error._tag, failure: error.failure, retryable: false }
+  }
+  return { stage, tag: 'UnexpectedFailure', failure: 'UNCLASSIFIED', retryable: false }
+}
+
+const failureStage = (error: unknown): ProofStage => {
+  if (error instanceof SandboxContractProofError) return error.stage
+  if (error instanceof BrokerMutationError) return error.operation === 'CANCEL' ? 'CANCEL' : 'SUBMIT'
+  if (error instanceof BrokerReadError) {
+    switch (error.operation) {
+      case 'market-calendar':
+        return 'CLOCK_PREFLIGHT'
+      case 'asset-by-symbol':
+        return 'ASSET_PREFLIGHT'
+      case 'order-by-client-id':
+        return 'LOOKUP_BY_CLIENT_ID'
+      case 'order-by-id':
+      case 'orders':
+        return 'CLEANUP'
+      case 'configuration':
+      case 'proxy':
+        return 'CONFIGURATION'
+      case 'preflight':
+      case 'account':
+      case 'account-configuration':
+      case 'positions':
+      case 'fill-activities':
+        return 'SESSION_PREFLIGHT'
+    }
+  }
+  return 'CONFIGURATION'
+}
+
+const isOpenStatus = (status: OrderStatus): boolean =>
+  [
+    OrderStatus.New,
+    OrderStatus.PartiallyFilled,
+    OrderStatus.PendingCancel,
+    OrderStatus.PendingReplace,
+    OrderStatus.PendingReview,
+    OrderStatus.Accepted,
+    OrderStatus.PendingNew,
+    OrderStatus.AcceptedForBidding,
+    OrderStatus.Held,
+  ].includes(status)
+
+const retryRead = <A>(
+  effect: Effect.Effect<A, BrokerReadError>,
+  retryNotFound = false,
+): Effect.Effect<A, BrokerReadError> =>
+  effect.pipe(
+    Effect.retry({
+      times: lookupRetryCount,
+      schedule: Schedule.spaced(retryDelay),
+      while: (error) => error.retryable || (retryNotFound && error.kind === BrokerReadErrorKind.NotFound),
+    }),
+  )
+
+const mutationEvidence = (
+  stage: string,
+  evidence: { status: number; requestId: string; contentHash: string; observedAt: string },
+): LifecycleEvent => ({
+  stage,
+  observedAt: evidence.observedAt,
+  status: evidence.status,
+  requestBinding: hashIdentity(evidence.requestId),
+  contentHash: evidence.contentHash,
+})
+
+const readEvidence = (stage: string, result: ReadResult<Order>): LifecycleEvent => ({
+  stage,
+  observedAt: result.evidence.observedAt,
+  status: result.value.status,
+  requestBinding: hashIdentity(result.evidence.requestId),
+  contentHash: result.evidence.contentHash,
+})
+
+const requireOrderBinding = (
+  order: Order,
+  clientOrderId: string,
+  brokerOrderId: string,
+  stage: ProofStage,
+): Effect.Effect<void, SandboxContractProofError> =>
+  order.clientOrderId === clientOrderId && order.brokerOrderId === brokerOrderId
+    ? Effect.succeed(undefined)
+    : Effect.fail(proofFailure(stage, 'ORDER_BINDING_MISMATCH'))
+
+const waitForTerminalOrder = (
+  orderById: (brokerOrderId: string) => Effect.Effect<ReadResult<Order>, BrokerReadError>,
+  brokerOrderId: string,
+  clientOrderId: string,
+  state: ProofState,
+  attempt = 0,
+): Effect.Effect<ReadResult<Order>, BrokerReadError | SandboxContractProofError> =>
+  retryRead(orderById(brokerOrderId)).pipe(
+    Effect.flatMap((result) =>
+      requireOrderBinding(result.value, clientOrderId, brokerOrderId, 'TERMINAL_LOOKUP').pipe(
+        Effect.andThen(
+          Effect.sync(() => {
+            state.lifecycle.push(readEvidence('TERMINAL_LOOKUP', result))
+            state.finalStatus = result.value.status
+          }),
+        ),
+        Effect.andThen(
+          !isOpenStatus(result.value.status)
+            ? Effect.succeed(result)
+            : attempt >= terminalPollCount
+              ? Effect.fail(proofFailure('TERMINAL_LOOKUP', 'ORDER_REMAINED_OPEN'))
+              : Effect.sleep(retryDelay).pipe(
+                  Effect.andThen(waitForTerminalOrder(orderById, brokerOrderId, clientOrderId, state, attempt + 1)),
+                ),
+        ),
+      ),
+    ),
+  )
+
+const cancelIfOpen = (
+  mutation: BrokerMutationShape,
+  order: Order,
+  state: ProofState,
+): Effect.Effect<void, BrokerMutationError> => {
+  if (!isOpenStatus(order.status)) return Effect.succeed(undefined)
+  state.cancelAttempts += 1
+  return mutation.cancel(order.brokerOrderId).pipe(
+    Effect.tap((receipt) =>
+      Effect.sync(() => {
+        state.cancelAcknowledged = true
+        state.lifecycle.push(mutationEvidence('CANCEL', receipt.evidence))
+      }),
+    ),
+    Effect.asVoid,
+    Effect.catch((error) =>
+      Effect.gen(function* () {
+        const observedAt = error.evidence?.observedAt ?? (yield* currentUtcInstant)
+        state.lifecycle.push({
+          stage: 'CANCEL_UNKNOWN',
+          observedAt,
+          status: error.evidence?.status,
+          requestBinding: error.evidence?.requestId === undefined ? undefined : hashIdentity(error.evidence.requestId),
+          contentHash: error.evidence?.contentHash,
+        })
+        if (error.failure !== MutationFailure.Unknown) return yield* Effect.fail(error)
+      }),
+    ),
+  )
+}
+
+const verifyNoOpenProofOrder = (
+  session: BrokerSessionShape,
+  clientOrderId: string,
+  state: ProofState,
+): Effect.Effect<void, BrokerReadError | SandboxContractProofError> =>
+  retryRead(session.read.orders({ status: OrderCollection.Open, limit: 500, symbols: [proofSymbol] })).pipe(
+    Effect.flatMap((result) => {
+      const residual = result.value.filter((order) => order.clientOrderId === clientOrderId)
+      state.cleanup.residualOpenOrderCount = residual.length
+      state.lifecycle.push({
+        stage: 'OPEN_ORDER_VERIFICATION',
+        observedAt: result.evidence.observedAt,
+        status: residual.length,
+        requestBinding: hashIdentity(result.evidence.requestId),
+        contentHash: result.evidence.contentHash,
+      })
+      return residual.length === 0
+        ? Effect.succeed(undefined)
+        : Effect.fail(proofFailure('CLEANUP', 'RESIDUAL_OPEN_ORDER'))
+    }),
+  )
+
+const cleanupOrder = (
+  session: BrokerSessionShape,
+  mutation: BrokerMutationShape,
+  clientOrderId: string,
+  state: ProofState,
+): Effect.Effect<void, BrokerReadError | BrokerMutationError | SandboxContractProofError> => {
+  const orderById = mutation.orderById
+  const orderByClientId = mutation.orderByClientId
+  if (orderById === undefined || orderByClientId === undefined) {
+    return Effect.fail(proofFailure('CLEANUP', 'RECOVERY_LOOKUP_UNAVAILABLE'))
+  }
+
+  return Effect.gen(function* () {
+    let brokerOrderId = state.brokerOrderId
+    let observed: ReadResult<Order> | undefined
+
+    if (brokerOrderId === undefined) {
+      const lookup = yield* retryRead(orderByClientId(clientOrderId), true).pipe(
+        Effect.map((result) => ({ _tag: 'Found' as const, result })),
+        Effect.catch((error) => Effect.succeed({ _tag: 'Failed' as const, error })),
+      )
+      if (lookup._tag === 'Failed') {
+        if (lookup.error.kind === BrokerReadErrorKind.NotFound && state.submitOutcome === 'REJECTED') {
+          yield* verifyNoOpenProofOrder(session, clientOrderId, state)
+          state.cleanup.result = 'CONFIRMED_NOT_CREATED'
+          state.cleanup.verifiedAt = yield* currentUtcInstant
+          return
+        }
+        if (lookup.error.kind === BrokerReadErrorKind.NotFound) {
+          return yield* Effect.fail(proofFailure('CLEANUP', 'UNKNOWN_SUBMIT_NOT_RESOLVED'))
+        }
+        return yield* Effect.fail(lookup.error)
+      }
+      observed = lookup.result
+      brokerOrderId = lookup.result.value.brokerOrderId
+      state.brokerOrderId = brokerOrderId
+      state.lifecycle.push(readEvidence('CLEANUP_LOOKUP_BY_CLIENT_ID', lookup.result))
+    }
+
+    if (observed === undefined) observed = yield* retryRead(orderById(brokerOrderId))
+    yield* requireOrderBinding(observed.value, clientOrderId, brokerOrderId, 'CLEANUP')
+    yield* cancelIfOpen(mutation, observed.value, state)
+    const terminal = yield* waitForTerminalOrder(orderById, brokerOrderId, clientOrderId, state)
+    yield* verifyNoOpenProofOrder(session, clientOrderId, state)
+    state.finalStatus = terminal.value.status
+    state.cleanup.result = 'VERIFIED_TERMINAL'
+    state.cleanup.verifiedAt = yield* currentUtcInstant
+  }).pipe(
+    Effect.tapError((error) =>
+      Effect.sync(() => {
+        state.cleanup.result = 'FAILED'
+        state.cleanupFailure = sanitizeFailure('CLEANUP', error)
+      }),
+    ),
+  )
+}
 
 test.skipIf(!enabled)('proves the bounded Alpaca sandbox contract through the production adapter', async () => {
   const expectedAccountId = required('BAYN_ALPACA_ACCOUNT_ID')
   const key = required('BAYN_ALPACA_KEY_ID')
   const secret = required('BAYN_ALPACA_SECRET_KEY')
   const configuredOrigin = required('BAYN_ALPACA_BASE_URL')
+  const sourceSha = required('GITHUB_SHA')
+  const runId = required('GITHUB_RUN_ID')
+  const runAttempt = required('GITHUB_RUN_ATTEMPT')
+  const imageIdentity = required('BAYN_ALPACA_SANDBOX_IMAGE_IDENTITY')
+  const imageTag = required('BAYN_ALPACA_SANDBOX_IMAGE_TAG')
+  const imageBuildRunId = required('BAYN_ALPACA_SANDBOX_IMAGE_BUILD_RUN_ID')
 
-  expect(configuredOrigin).toBe(alpacaSandboxBaseUrl)
-  expect(configuredOrigin).not.toBe(alpacaLiveBaseUrl)
+  if (configuredOrigin !== alpacaSandboxBaseUrl) throw new Error('sandbox endpoint guard failed')
+  if (!/^[0-9a-f]{40}$/.test(sourceSha)) throw new Error('GITHUB_SHA must be an exact lowercase commit SHA')
+  if (!/^[0-9]+$/.test(imageBuildRunId)) throw new Error('image build run ID must be numeric')
+  if (!/^registry\.ide-newton\.ts\.net\/lab\/bayn@sha256:[0-9a-f]{64}$/.test(imageIdentity)) {
+    throw new Error('image identity must be the verified Bayn multi-architecture digest reference')
+  }
+  if (imageTag !== `registry.ide-newton.ts.net/lab/bayn:sha-${sourceSha}`) {
+    throw new Error('image tag is not bound to the exact proof source SHA')
+  }
+  if (receiptPath === undefined || receiptPath !== '/tmp/alpaca-sandbox-contract-receipt.json') {
+    throw new Error('BAYN_ALPACA_SANDBOX_RECEIPT_PATH must use the protected temporary receipt path')
+  }
 
   const decoded = decodeBrokerConnection({
     provider: BrokerProvider.Alpaca,
@@ -51,33 +394,21 @@ test.skipIf(!enabled)('proves the bounded Alpaca sandbox contract through the pr
     expectedAccountId,
     key: Redacted.make(key),
     secret: Redacted.make(secret),
-    // The credentialed CI proof supplies a direct Node client. This value remains
-    // validated because it is part of the same production BrokerConnection.
     proxyUrl: 'http://127.0.0.1:1',
     operationTimeoutMs: 30_000,
     retryAttempts: 0,
   })
-  if (Result.isFailure(decoded)) throw new Error(`sandbox connection rejected: ${decoded.failure._tag}`)
+  if (Result.isFailure(decoded)) throw new Error('sandbox broker connection guard rejected the protected binding')
   const connection = decoded.success
   const run = <A, E>(effect: Effect.Effect<A, E, HttpClient.HttpClient>) =>
-    Effect.runPromise(effect.pipe(Effect.provide(NodeHttpClient.layerNodeHttp)))
+    Effect.runPromise(
+      effect.pipe(
+        Effect.provideService(References.MinimumLogLevel, 'None'),
+        Effect.provide(NodeHttpClient.layerNodeHttp),
+      ),
+    )
 
-  // Acquisition performs the real account/configuration/read preflight before
-  // mutation capability can exist. Account identifiers never enter the receipt.
-  const session = await run(acquireBrokerSession(connection))
-  expect(session.preflight.accountId).toBe(expectedAccountId)
-  expect(session.preflight.environment).toBe(BrokerEnvironment.Sandbox)
-  expect(session.preflight.baseUrl).toBe(alpacaSandboxBaseUrl)
-
-  const authority = makeExecutionAuthority(
-    BrokerEnvironment.Sandbox,
-    ExecutionAccess.SubmitOrders,
-    disabledCapitalAccess,
-  )
-  const mutation = await run(makeMutation(session, authority))
-  const runId = required('GITHUB_RUN_ID')
-  const runAttempt = required('GITHUB_RUN_ATTEMPT')
-  const identity = canonicalHashV1({ runId, runAttempt, head: required('GITHUB_SHA') })
+  const identity = canonicalHashV1({ runId, runAttempt, sourceSha, imageIdentity })
   const clientOrderId = `b1_${identity.slice(0, 43)}`
   const intent: Intent = {
     schemaVersion: 'bayn.paper-intent.v3',
@@ -90,111 +421,177 @@ test.skipIf(!enabled)('proves the bounded Alpaca sandbox contract through the pr
     policyHash: canonicalHashV1({ identity, kind: 'policy' }),
     accountId: expectedAccountId,
     clientOrderId,
-    symbol: 'AAPL',
+    symbol: proofSymbol,
     side: OrderSide.Buy,
     orderType: OrderType.Market,
     timeInForce: TimeInForce.Day,
-    quantityMicros: '1',
-    notionalLimitMicros: '1000000',
+    quantityMicros: proofQuantityMicros,
+    notionalLimitMicros: '5000000',
     state: IntentState.IoStarted,
-    createdAt: new Date().toISOString(),
+    createdAt: await run(currentUtcInstant),
+  }
+  const state: ProofState = {
+    submitOutcome: 'NOT_ATTEMPTED',
+    cancelAttempts: 0,
+    cancelAcknowledged: false,
+    lifecycle: [],
+    cleanup: { result: 'NOT_RUN' },
   }
 
-  let brokerOrderId: string | undefined
-  let submitStatus: OrderStatus | undefined
-  let cancelStatus: OrderStatus | undefined
-  let cleanupStatus = 'not-required'
-  let submitEvidence: { readonly status: number; readonly request: string; readonly content: string } | undefined
-  let cancelEvidence: { readonly status: number; readonly request: string; readonly content: string } | undefined
+  const proof = Effect.gen(function* () {
+    state.startedAt = yield* currentUtcInstant
+    const session = yield* acquireBrokerSession(connection)
+    if (
+      session.preflight.accountId !== expectedAccountId ||
+      session.preflight.environment !== BrokerEnvironment.Sandbox ||
+      session.preflight.baseUrl !== alpacaSandboxBaseUrl
+    ) {
+      return yield* Effect.fail(proofFailure('SESSION_PREFLIGHT', 'VERIFIED_SESSION_BINDING_MISMATCH'))
+    }
+    state.preflightCompletedAt = yield* currentUtcInstant
 
-  try {
-    const submit = await run(mutation.submit(intent))
-    brokerOrderId = submit.order.brokerOrderId
-    submitEvidence = {
-      status: submit.evidence.status,
-      request: redact(submit.evidence.requestId),
-      content: submit.evidence.contentHash,
+    const today = yield* currentUtcDate
+    const clockObservedAt = yield* currentUtcInstant
+    const calendar = yield* session.read.marketCalendar({ start: today, end: today })
+    const marketOpen = calendar.value.sessions.some(
+      (marketSession) => clockObservedAt >= marketSession.openAt && clockObservedAt < marketSession.closeAt,
+    )
+    if (marketOpen) return yield* Effect.fail(proofFailure('CLOCK_PREFLIGHT', 'REGULAR_MARKET_IS_OPEN'))
+    state.clock = {
+      observedAt: clockObservedAt,
+      marketOpen: false,
+      sessionCount: calendar.value.sessions.length,
+      calendarHash: calendar.value.normalizedResponseHash,
     }
 
-    // Model the interruption window by discarding the acknowledged outcome and
-    // recovering solely from the deterministic client ID. No second POST occurs.
-    const recoveredSubmit = await run(mutation.orderByClientId!(clientOrderId))
-    expect(recoveredSubmit.value.brokerOrderId).toBe(brokerOrderId)
-    expect(recoveredSubmit.value.clientOrderId).toBe(clientOrderId)
-    expect(recoveredSubmit.value.quantityMicros).toBe('1')
-    submitStatus = recoveredSubmit.value.status
-
-    try {
-      const cancel = await run(mutation.cancel(brokerOrderId))
-      cancelEvidence = {
-        status: cancel.evidence.status,
-        request: redact(cancel.evidence.requestId),
-        content: cancel.evidence.contentHash,
-      }
-    } catch (cause) {
-      if (!(cause instanceof BrokerMutationError) || cause.failure !== MutationFailure.Unknown) throw cause
+    const asset = yield* session.read.assetBySymbol(proofSymbol)
+    if (asset.value.status !== AssetStatus.Active || !asset.value.tradable || !asset.value.fractionable) {
+      return yield* Effect.fail(proofFailure('ASSET_PREFLIGHT', 'PROOF_ASSET_NOT_SAFE'))
+    }
+    state.asset = {
+      status: AssetStatus.Active,
+      tradable: true,
+      fractionable: true,
+      observationHash: asset.value.normalizedResponseHash,
     }
 
-    // Both a lost 204 and an ambiguous DELETE are recovered by the same GET path.
-    const recoveredCancel = await run(mutation.orderById!(brokerOrderId))
-    expect(recoveredCancel.value.brokerOrderId).toBe(brokerOrderId)
-    cancelStatus = recoveredCancel.value.status
-    expect([OrderStatus.Canceled, OrderStatus.Filled, OrderStatus.PendingCancel]).toContain(cancelStatus)
-
-    const fills = await run(session.read.fillActivities({ pageSize: 100 }))
-    const matchingFills = fills.value.items.filter((fill) => fill.brokerOrderId === brokerOrderId)
-    for (const fill of matchingFills) expect(fill.brokerOrderId).toBe(brokerOrderId)
-  } finally {
-    if (brokerOrderId === undefined) {
-      try {
-        const recovered = await run(mutation.orderByClientId!(clientOrderId))
-        brokerOrderId = recovered.value.brokerOrderId
-        cleanupStatus = 'recovered-after-submit-failure'
-      } catch {
-        cleanupStatus = 'no-order-found-after-submit-failure'
-      }
+    const authority = makeExecutionAuthority(
+      BrokerEnvironment.Sandbox,
+      ExecutionAccess.SubmitOrders,
+      disabledCapitalAccess,
+    )
+    const mutation = yield* makeMutation(session, authority)
+    const orderByClientId = mutation.orderByClientId
+    if (orderByClientId === undefined) {
+      return yield* Effect.fail(proofFailure('CONFIGURATION', 'CLIENT_ORDER_LOOKUP_UNAVAILABLE'))
     }
-    if (brokerOrderId !== undefined) {
-      try {
-        await run(mutation.cancel(brokerOrderId))
-        cleanupStatus = 'cancel-acknowledged'
-      } catch {
-        const observed = await run(mutation.orderById!(brokerOrderId))
-        cleanupStatus = `idempotent-${observed.value.status.toLowerCase()}`
-      }
-    }
-  }
 
-  const receipt = {
-    schemaVersion: 'bayn.alpaca-sandbox-contract-receipt.v1',
-    head: required('GITHUB_SHA'),
+    return yield* Effect.acquireUseRelease(
+      Effect.succeed(undefined),
+      () =>
+        Effect.gen(function* () {
+          const submit = yield* mutation.submit(intent).pipe(
+            Effect.tapError((error) =>
+              Effect.sync(() => {
+                state.submitOutcome = error.failure === MutationFailure.Rejected ? 'REJECTED' : 'UNKNOWN'
+              }),
+            ),
+          )
+          state.submitOutcome = 'ACKNOWLEDGED'
+          state.brokerOrderId = submit.order.brokerOrderId
+          state.lifecycle.push(mutationEvidence('SUBMIT', submit.evidence))
+
+          const recoveredSubmit = yield* retryRead(orderByClientId(clientOrderId), true)
+          yield* requireOrderBinding(
+            recoveredSubmit.value,
+            clientOrderId,
+            submit.order.brokerOrderId,
+            'LOOKUP_BY_CLIENT_ID',
+          )
+          if (recoveredSubmit.value.quantityMicros !== proofQuantityMicros) {
+            return yield* Effect.fail(proofFailure('LOOKUP_BY_CLIENT_ID', 'ORDER_QUANTITY_MISMATCH'))
+          }
+          state.lifecycle.push(readEvidence('LOOKUP_BY_CLIENT_ID', recoveredSubmit))
+          yield* cancelIfOpen(mutation, recoveredSubmit.value, state)
+        }),
+      () => cleanupOrder(session, mutation, clientOrderId, state),
+    )
+  }).pipe(
+    Effect.tapError((error) =>
+      Effect.sync(() => {
+        if (state.failure === undefined) state.failure = sanitizeFailure(failureStage(error), error)
+      }),
+    ),
+  )
+
+  const proofExit = await run(Effect.exit(proof))
+  state.completedAt = await run(currentUtcInstant)
+  const receiptBody = {
+    schemaVersion: 'bayn.alpaca-sandbox-contract-receipt.v2',
+    proofStatus: Exit.isSuccess(proofExit) ? 'SUCCESS' : 'FAILURE',
+    sourceSha,
+    repository: required('GITHUB_REPOSITORY'),
+    workflow: {
+      runId,
+      runAttempt,
+    },
+    image: {
+      buildRunId: imageBuildRunId,
+      tag: imageTag,
+      identity: imageIdentity,
+    },
+    timestamps: {
+      startedAt: state.startedAt,
+      preflightCompletedAt: state.preflightCompletedAt,
+      completedAt: state.completedAt,
+    },
+    endpointClass: 'ALPACA_PAPER',
     endpoint: alpacaSandboxBaseUrl,
-    accountBinding: redact(session.preflight.accountHash),
+    accountIdentityHash: hashIdentity(expectedAccountId),
+    credentialBindingHash: canonicalHashV1({
+      identity,
+      endpoint: configuredOrigin,
+      accountId: expectedAccountId,
+      key,
+      secret,
+    }),
     preflight: {
-      accountStatus: session.preflight.accountStatus,
-      accountBlocked: session.preflight.accountBlocked,
-      tradingBlocked: session.preflight.tradingBlocked,
-      readLookups: [session.preflight.orderById, session.preflight.orderByClientId],
+      accountStatus: state.preflightCompletedAt === undefined ? undefined : 'ACTIVE',
+      paperEnvironment: true,
+      liveCapitalAccess: false,
+      clock: state.clock,
+      asset: state.asset,
     },
     order: {
-      clientOrderBinding: redact(clientOrderId),
-      brokerOrderBinding: brokerOrderId === undefined ? undefined : redact(brokerOrderId),
-      quantityMicros: '1',
-      submitStatus,
-      cancelStatus,
+      clientOrderId,
+      brokerOrderIdentityHash: state.brokerOrderId === undefined ? undefined : hashIdentity(state.brokerOrderId),
+      symbol: proofSymbol,
+      quantityMicros: proofQuantityMicros,
+      submitOutcome: state.submitOutcome,
+      finalStatus: state.finalStatus,
     },
-    evidence: { submit: submitEvidence, cancel: cancelEvidence },
-    cleanup: cleanupStatus,
+    orderLifecycle: state.lifecycle,
+    cleanup: {
+      ...state.cleanup,
+      cancelAttempts: state.cancelAttempts,
+      cancelAcknowledged: state.cancelAcknowledged,
+    },
     duplicateSubmitCount: 0,
     liveEndpointUsed: false,
-    residualOmissions: [
-      'Alpaca cannot deterministically inject a lost POST or DELETE response; real acknowledgement-loss recovery is represented by discarding the acknowledgement before production GET recovery.',
-      'A fill is decoded and reconciled only if the minimum fractional market order fills before cancellation.',
-    ],
+    failure: state.failure,
+    cleanupFailure: state.cleanupFailure,
   }
-  expect(JSON.stringify(receipt)).not.toContain(expectedAccountId)
-  expect(JSON.stringify(receipt)).not.toContain(key)
-  expect(JSON.stringify(receipt)).not.toContain(secret)
-  if (receiptPath === undefined) throw new Error('BAYN_ALPACA_SANDBOX_RECEIPT_PATH is required')
-  await Bun.write(receiptPath, `${JSON.stringify(receipt, null, 2)}\n`)
+  const receipt = { ...receiptBody, receiptHash: canonicalHashV1(receiptBody) }
+  const serialized = `${JSON.stringify(receipt, null, 2)}\n`
+  if ([expectedAccountId, key, secret].some((sensitive) => serialized.includes(sensitive))) {
+    throw new Error('sanitized receipt secret-leak guard failed')
+  }
+  await Bun.write(receiptPath, serialized)
+
+  if (Exit.isFailure(proofExit)) {
+    throw new Error('Alpaca sandbox contract proof failed; inspect the sanitized receipt artifact')
+  }
+  if (state.cleanup.result !== 'VERIFIED_TERMINAL' || state.cleanup.residualOpenOrderCount !== 0) {
+    throw new Error('Alpaca sandbox cleanup was not proven terminal and residual-free')
+  }
 })

--- a/services/bayn/src/broker/alpaca-sandbox-contract.test.ts
+++ b/services/bayn/src/broker/alpaca-sandbox-contract.test.ts
@@ -53,6 +53,9 @@ const retryDelayMs = 1_000
 const minimumPreOpenSafetyMs = 30 * 60_000
 const mutationPhaseDeadlineMs = 2 * 60_000
 const cleanupDeadlineMs = 3 * 60_000
+const workflowJobTimeoutMs = 15 * 60_000
+const overallProofDeadlineMs = 13 * 60_000
+const requiredSubmitBudgetMs = mutationPhaseDeadlineMs + cleanupDeadlineMs
 const mutationPhaseDeadline = Duration.millis(mutationPhaseDeadlineMs)
 const cleanupDeadline = Duration.millis(cleanupDeadlineMs)
 const maximumRetryReadMs = (lookupRetryCount + 1) * brokerOperationTimeoutMs + lookupRetryCount * retryDelayMs
@@ -67,6 +70,14 @@ const required = (name: string): string => {
     throw new Error(`${name} must be present and free of surrounding whitespace`)
   }
   return value
+}
+
+const requiredEpochMillis = (name: string): number => {
+  const value = required(name)
+  if (!/^[0-9]{13}$/.test(value)) throw new Error(`${name} must be a 13-digit epoch-millisecond value`)
+  const parsed = Number(value)
+  if (!Number.isSafeInteger(parsed)) throw new Error(`${name} must be a safe epoch-millisecond integer`)
+  return parsed
 }
 
 const hashIdentity = (value: string): string => canonicalHashV1({ value })
@@ -138,6 +149,12 @@ interface ProofState {
   filledQuantityMicros?: string
   cancelAttempts: number
   cancelAcknowledged: boolean
+  submitBudget?: {
+    readonly checkedAt: string
+    readonly jobDeadlineAt: string
+    readonly remainingMs: number
+    readonly requiredRemainingMs: number
+  }
   lifecycle: LifecycleEvent[]
   cleanup: {
     result: 'NOT_RUN' | 'CONFIRMED_NOT_CREATED' | 'VERIFIED_TERMINAL' | 'FAILED'
@@ -245,6 +262,28 @@ const isCancellableStatus = (status: OrderStatus): boolean =>
 const hasFilledQuantity = (order: Order): boolean => order.filledQuantityMicros !== '0'
 const preOpenSafetyMillis = (observedAt: string, nextMarketOpenAt: string): number =>
   Date.parse(nextMarketOpenAt) - Date.parse(observedAt)
+const remainingJobBudgetMs = (checkedAtEpochMs: number, jobDeadlineEpochMs: number): number =>
+  jobDeadlineEpochMs - checkedAtEpochMs
+const hasRequiredSubmitBudget = (checkedAtEpochMs: number, jobDeadlineEpochMs: number): boolean =>
+  remainingJobBudgetMs(checkedAtEpochMs, jobDeadlineEpochMs) >= requiredSubmitBudgetMs
+const requireOverallSubmitBudget = (
+  jobDeadlineEpochMs: number,
+  state: ProofState,
+): Effect.Effect<void, SandboxContractProofError> =>
+  Effect.gen(function* () {
+    const checkedAt = yield* currentUtcInstant
+    const checkedAtEpochMs = Date.parse(checkedAt)
+    const remainingMs = remainingJobBudgetMs(checkedAtEpochMs, jobDeadlineEpochMs)
+    state.submitBudget = {
+      checkedAt,
+      jobDeadlineAt: new Date(jobDeadlineEpochMs).toISOString(),
+      remainingMs,
+      requiredRemainingMs: requiredSubmitBudgetMs,
+    }
+    if (!hasRequiredSubmitBudget(checkedAtEpochMs, jobDeadlineEpochMs)) {
+      return yield* Effect.fail(proofFailure('SUBMIT', 'OVERALL_JOB_DEADLINE_CANNOT_RESERVE_CLEANUP'))
+    }
+  })
 const requireZeroFill = (order: Order): Effect.Effect<void, SandboxContractProofError> =>
   hasFilledQuantity(order)
     ? Effect.fail(proofFailure('CLEANUP', 'ORDER_FILLED_DURING_PROOF'))
@@ -590,7 +629,14 @@ test('treats every Alpaca nonterminal status as open for cleanup', () => {
 
 test('keeps the cleanup network bound below its explicit deadline', () => {
   expect(maximumCleanupNetworkMs).toBeLessThan(cleanupDeadlineMs)
-  expect(mutationPhaseDeadlineMs + cleanupDeadlineMs).toBeLessThan(15 * 60_000)
+  expect(requiredSubmitBudgetMs).toBeLessThan(overallProofDeadlineMs)
+  expect(overallProofDeadlineMs).toBeLessThan(workflowJobTimeoutMs)
+})
+
+test('reserves the complete mutation and cleanup budget before submit', () => {
+  const checkedAtEpochMs = Date.parse('2026-07-28T00:00:00.000Z')
+  expect(hasRequiredSubmitBudget(checkedAtEpochMs, checkedAtEpochMs + requiredSubmitBudgetMs)).toBeTrue()
+  expect(hasRequiredSubmitBudget(checkedAtEpochMs, checkedAtEpochMs + requiredSubmitBudgetMs - 1)).toBeFalse()
 })
 
 test('requires a full pre-open safety window', () => {
@@ -771,6 +817,8 @@ test.skipIf(!enabled)('proves the bounded Alpaca sandbox contract through the pr
   const imageIdentity = required('BAYN_ALPACA_SANDBOX_IMAGE_IDENTITY')
   const imageTag = required('BAYN_ALPACA_SANDBOX_IMAGE_TAG')
   const imageBuildRunId = required('BAYN_ALPACA_SANDBOX_IMAGE_BUILD_RUN_ID')
+  const jobStartedEpochMs = requiredEpochMillis('BAYN_ALPACA_SANDBOX_JOB_STARTED_EPOCH_MS')
+  const jobDeadlineEpochMs = requiredEpochMillis('BAYN_ALPACA_SANDBOX_JOB_DEADLINE_EPOCH_MS')
 
   if (configuredOrigin !== alpacaSandboxBaseUrl) throw new Error('sandbox endpoint guard failed')
   if (!/^[0-9a-f]{40}$/.test(sourceSha)) throw new Error('GITHUB_SHA must be an exact lowercase commit SHA')
@@ -780,6 +828,9 @@ test.skipIf(!enabled)('proves the bounded Alpaca sandbox contract through the pr
   }
   if (imageTag !== `registry.ide-newton.ts.net/lab/bayn:sha-${sourceSha}`) {
     throw new Error('image tag is not bound to the exact proof source SHA')
+  }
+  if (jobDeadlineEpochMs - jobStartedEpochMs !== overallProofDeadlineMs) {
+    throw new Error('overall protected proof deadline is not bound to the configured job budget')
   }
   if (receiptPath === undefined || receiptPath !== '/tmp/alpaca-sandbox-contract-receipt.json') {
     throw new Error('BAYN_ALPACA_SANDBOX_RECEIPT_PATH must use the protected temporary receipt path')
@@ -877,6 +928,7 @@ test.skipIf(!enabled)('proves the bounded Alpaca sandbox contract through the pr
       () =>
         Effect.gen(function* () {
           yield* verifySafeMarketWindow(session, state, 'SUBMIT_CLOCK_PREFLIGHT')
+          yield* requireOverallSubmitBudget(jobDeadlineEpochMs, state)
           const submit = yield* mutation.submit(intent).pipe(
             Effect.tapError((error) =>
               Effect.sync(() => {
@@ -949,6 +1001,13 @@ test.skipIf(!enabled)('proves the bounded Alpaca sandbox contract through the pr
       startedAt: state.startedAt,
       preflightCompletedAt: state.preflightCompletedAt,
       completedAt: state.completedAt,
+    },
+    overallJobBudget: {
+      startedAt: new Date(jobStartedEpochMs).toISOString(),
+      deadlineAt: new Date(jobDeadlineEpochMs).toISOString(),
+      proofWindowMs: overallProofDeadlineMs,
+      requiredRemainingBeforeSubmitMs: requiredSubmitBudgetMs,
+      submitCheck: state.submitBudget,
     },
     endpointClass: 'ALPACA_PAPER',
     endpoint: alpacaSandboxBaseUrl,

--- a/services/bayn/src/broker/alpaca-sandbox-contract.test.ts
+++ b/services/bayn/src/broker/alpaca-sandbox-contract.test.ts
@@ -80,6 +80,16 @@ const requiredEpochMillis = (name: string): number => {
   return parsed
 }
 
+const jsonSafeObject = (value: unknown): Record<string, unknown> => {
+  const serialized = JSON.stringify(value)
+  if (serialized === undefined) throw new Error('receipt body is not JSON serializable')
+  const parsed: unknown = JSON.parse(serialized)
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    throw new Error('receipt body must serialize to a JSON object')
+  }
+  return parsed as Record<string, unknown>
+}
+
 const hashIdentity = (value: string): string => canonicalHashV1({ value })
 
 const addUtcDays = (date: string, days: number): string => {
@@ -639,6 +649,19 @@ test('reserves the complete mutation and cleanup budget before submit', () => {
   expect(hasRequiredSubmitBudget(checkedAtEpochMs, checkedAtEpochMs + requiredSubmitBudgetMs - 1)).toBeFalse()
 })
 
+test('hashes the exact JSON-safe receipt representation', () => {
+  const body = jsonSafeObject({
+    proofStatus: 'SUCCESS',
+    failure: undefined,
+    nested: {
+      retained: 'evidence',
+      omitted: undefined,
+    },
+  })
+  expect(body).toEqual({ proofStatus: 'SUCCESS', nested: { retained: 'evidence' } })
+  expect(canonicalHashV1(body)).toBe(canonicalHashV1({ proofStatus: 'SUCCESS', nested: { retained: 'evidence' } }))
+})
+
 test('requires a full pre-open safety window', () => {
   const observedAt = '2026-07-28T13:00:00.000Z'
   expect(preOpenSafetyMillis(observedAt, '2026-07-28T13:30:00.000Z')).toBe(minimumPreOpenSafetyMs)
@@ -1047,7 +1070,8 @@ test.skipIf(!enabled)('proves the bounded Alpaca sandbox contract through the pr
     failure: state.failure,
     cleanupFailure: state.cleanupFailure,
   }
-  const receipt = { ...receiptBody, receiptHash: canonicalHashV1(receiptBody) }
+  const jsonSafeReceiptBody = jsonSafeObject(receiptBody)
+  const receipt = { ...jsonSafeReceiptBody, receiptHash: canonicalHashV1(jsonSafeReceiptBody) }
   const serialized = `${JSON.stringify(receipt, null, 2)}\n`
   if ([expectedAccountId, key, secret].some((sensitive) => serialized.includes(sensitive))) {
     throw new Error('sanitized receipt secret-leak guard failed')

--- a/services/bayn/src/broker/alpaca-sandbox-contract.test.ts
+++ b/services/bayn/src/broker/alpaca-sandbox-contract.test.ts
@@ -1,6 +1,5 @@
 import { expect, test } from 'bun:test'
 
-import { NodeHttpClient } from '@effect/platform-node'
 import { Data, Duration, Effect, Exit, Redacted, References, Result, Schedule } from 'effect'
 import { HttpClient } from 'effect/unstable/http'
 
@@ -34,6 +33,7 @@ import {
   OrderStatus,
   OrderType as BrokerOrderType,
   TimeInForce as BrokerTimeInForce,
+  alpacaHttpLayer,
   alpacaSandboxBaseUrl,
   acquireBrokerSession,
   decodeBrokerConnection,
@@ -56,6 +56,7 @@ const cleanupDeadlineMs = 3 * 60_000
 const workflowJobTimeoutMs = 15 * 60_000
 const overallProofDeadlineMs = 13 * 60_000
 const requiredSubmitBudgetMs = mutationPhaseDeadlineMs + cleanupDeadlineMs
+const protectedProxyUrl = 'http://127.0.0.1:18080'
 const mutationPhaseDeadline = Duration.millis(mutationPhaseDeadlineMs)
 const cleanupDeadline = Duration.millis(cleanupDeadlineMs)
 const maximumRetryReadMs = (lookupRetryCount + 1) * brokerOperationTimeoutMs + lookupRetryCount * retryDelayMs
@@ -658,8 +659,18 @@ test('hashes the exact JSON-safe receipt representation', () => {
       omitted: undefined,
     },
   })
+
   expect(body).toEqual({ proofStatus: 'SUCCESS', nested: { retained: 'evidence' } })
   expect(canonicalHashV1(body)).toBe(canonicalHashV1({ proofStatus: 'SUCCESS', nested: { retained: 'evidence' } }))
+})
+
+test('binds the real proof to the restricted production proxy transport', () => {
+  expect(new URL(protectedProxyUrl)).toMatchObject({
+    protocol: 'http:',
+    hostname: '127.0.0.1',
+    port: '18080',
+    pathname: '/',
+  })
 })
 
 test('requires a full pre-open safety window', () => {
@@ -837,20 +848,24 @@ test.skipIf(!enabled)('proves the bounded Alpaca sandbox contract through the pr
   const sourceSha = required('GITHUB_SHA')
   const runId = required('GITHUB_RUN_ID')
   const runAttempt = required('GITHUB_RUN_ATTEMPT')
-  const imageIdentity = required('BAYN_ALPACA_SANDBOX_IMAGE_IDENTITY')
-  const imageTag = required('BAYN_ALPACA_SANDBOX_IMAGE_TAG')
-  const imageBuildRunId = required('BAYN_ALPACA_SANDBOX_IMAGE_BUILD_RUN_ID')
+  const releaseImageIdentity = required('BAYN_ALPACA_SANDBOX_RELEASE_IMAGE_IDENTITY')
+  const releaseImageTag = required('BAYN_ALPACA_SANDBOX_RELEASE_IMAGE_TAG')
+  const releaseImageBuildRunId = required('BAYN_ALPACA_SANDBOX_RELEASE_IMAGE_BUILD_RUN_ID')
+  const proxyUrl = required('BAYN_ALPACA_SANDBOX_PROXY_URL')
   const jobStartedEpochMs = requiredEpochMillis('BAYN_ALPACA_SANDBOX_JOB_STARTED_EPOCH_MS')
   const jobDeadlineEpochMs = requiredEpochMillis('BAYN_ALPACA_SANDBOX_JOB_DEADLINE_EPOCH_MS')
 
   if (configuredOrigin !== alpacaSandboxBaseUrl) throw new Error('sandbox endpoint guard failed')
   if (!/^[0-9a-f]{40}$/.test(sourceSha)) throw new Error('GITHUB_SHA must be an exact lowercase commit SHA')
-  if (!/^[0-9]+$/.test(imageBuildRunId)) throw new Error('image build run ID must be numeric')
-  if (!/^registry\.ide-newton\.ts\.net\/lab\/bayn@sha256:[0-9a-f]{64}$/.test(imageIdentity)) {
-    throw new Error('image identity must be the verified Bayn multi-architecture digest reference')
+  if (!/^[0-9]+$/.test(releaseImageBuildRunId)) throw new Error('release image build run ID must be numeric')
+  if (!/^registry\.ide-newton\.ts\.net\/lab\/bayn@sha256:[0-9a-f]{64}$/.test(releaseImageIdentity)) {
+    throw new Error('release image identity must be the verified Bayn multi-architecture digest reference')
   }
-  if (imageTag !== `registry.ide-newton.ts.net/lab/bayn:sha-${sourceSha}`) {
-    throw new Error('image tag is not bound to the exact proof source SHA')
+  if (releaseImageTag !== `registry.ide-newton.ts.net/lab/bayn:sha-${sourceSha}`) {
+    throw new Error('release image tag is not bound to the exact proof source SHA')
+  }
+  if (proxyUrl !== protectedProxyUrl) {
+    throw new Error('sandbox proof must use the restricted loopback CONNECT proxy')
   }
   if (jobDeadlineEpochMs - jobStartedEpochMs !== overallProofDeadlineMs) {
     throw new Error('overall protected proof deadline is not bound to the configured job budget')
@@ -866,7 +881,7 @@ test.skipIf(!enabled)('proves the bounded Alpaca sandbox contract through the pr
     expectedAccountId,
     key: Redacted.make(key),
     secret: Redacted.make(secret),
-    proxyUrl: 'http://127.0.0.1:1',
+    proxyUrl,
     operationTimeoutMs: brokerOperationTimeoutMs,
     retryAttempts: 0,
   })
@@ -876,11 +891,11 @@ test.skipIf(!enabled)('proves the bounded Alpaca sandbox contract through the pr
     Effect.runPromise(
       effect.pipe(
         Effect.provideService(References.MinimumLogLevel, 'None'),
-        Effect.provide(NodeHttpClient.layerNodeHttp),
+        Effect.provide(alpacaHttpLayer(connection)),
       ),
     )
 
-  const identity = canonicalHashV1({ runId, runAttempt, sourceSha, imageIdentity })
+  const identity = canonicalHashV1({ runId, runAttempt, sourceSha, releaseImageIdentity })
   const clientOrderId = `b1_${identity.slice(0, 43)}`
   const intent: Intent = {
     schemaVersion: 'bayn.paper-intent.v3',
@@ -1007,7 +1022,7 @@ test.skipIf(!enabled)('proves the bounded Alpaca sandbox contract through the pr
   const proofExit = await run(Effect.exit(proof))
   state.completedAt = await run(currentUtcInstant)
   const receiptBody = {
-    schemaVersion: 'bayn.alpaca-sandbox-contract-receipt.v2',
+    schemaVersion: 'bayn.alpaca-sandbox-contract-receipt.v3',
     proofStatus: Exit.isSuccess(proofExit) ? 'SUCCESS' : 'FAILURE',
     sourceSha,
     repository: required('GITHUB_REPOSITORY'),
@@ -1015,10 +1030,21 @@ test.skipIf(!enabled)('proves the bounded Alpaca sandbox contract through the pr
       runId,
       runAttempt,
     },
-    image: {
-      buildRunId: imageBuildRunId,
-      tag: imageTag,
-      identity: imageIdentity,
+    releaseGate: {
+      buildRunId: releaseImageBuildRunId,
+      tag: releaseImageTag,
+      identity: releaseImageIdentity,
+      platforms: ['linux/amd64', 'linux/arm64'],
+      claim: 'EXACT_IMAGE_ARTIFACT_VERIFIED_NOT_PROOF_RUNTIME',
+    },
+    proofRuntime: {
+      kind: 'CHECKED_OUT_SOURCE',
+      sourceSha,
+    },
+    transport: {
+      httpLayer: 'ALPACA_HTTP_LAYER',
+      proxyClass: 'LOOPBACK_CONNECT_ALLOWLIST',
+      proxyUrlHash: hashIdentity(proxyUrl),
     },
     timestamps: {
       startedAt: state.startedAt,
@@ -1038,6 +1064,7 @@ test.skipIf(!enabled)('proves the bounded Alpaca sandbox contract through the pr
     credentialBindingHash: canonicalHashV1({
       identity,
       endpoint: configuredOrigin,
+      proxyUrl,
       accountId: expectedAccountId,
       key,
       secret,

--- a/services/bayn/src/broker/alpaca-sandbox-contract.test.ts
+++ b/services/bayn/src/broker/alpaca-sandbox-contract.test.ts
@@ -178,6 +178,18 @@ interface ProofState {
 const proofFailure = (stage: ProofStage, failure: string): SandboxContractProofError =>
   new SandboxContractProofError({ stage, failure })
 
+const withInterruptibleCleanupDeadline = <A, E, R>(
+  cleanup: Effect.Effect<A, E, R>,
+  duration = cleanupDeadline,
+): Effect.Effect<A, E | SandboxContractProofError, R> =>
+  cleanup.pipe(
+    Effect.timeoutOrElse({
+      duration,
+      orElse: () => Effect.fail(proofFailure('CLEANUP', 'CLEANUP_DEADLINE_EXCEEDED')),
+    }),
+    Effect.interruptible,
+  )
+
 const sanitizeFailure = (stage: ProofStage, error: unknown): SanitizedFailure => {
   if (error instanceof BrokerSessionAcquisitionError) {
     const cause = error.cause
@@ -670,6 +682,17 @@ test('keeps the cleanup network bound below its explicit deadline', () => {
   expect(overallProofDeadlineMs).toBeLessThan(workflowJobTimeoutMs)
 })
 
+test('keeps the cleanup deadline interruptible inside the release finalizer', async () => {
+  const exit = await Effect.runPromise(
+    Effect.acquireUseRelease(
+      Effect.succeed(undefined),
+      () => Effect.succeed(undefined),
+      () => withInterruptibleCleanupDeadline(Effect.never, Duration.millis(5)),
+    ).pipe(Effect.exit),
+  )
+  expect(Exit.isFailure(exit)).toBeTrue()
+})
+
 test('reserves the complete mutation and cleanup budget before submit', () => {
   const checkedAtEpochMs = Date.parse('2026-07-28T00:00:00.000Z')
   expect(hasRequiredSubmitBudget(checkedAtEpochMs, checkedAtEpochMs + requiredSubmitBudgetMs)).toBeTrue()
@@ -1074,11 +1097,7 @@ test.skipIf(!enabled)('proves the bounded Alpaca sandbox contract through the pr
           }),
         ),
       () =>
-        cleanupOrder(session, mutation, clientOrderId, state).pipe(
-          Effect.timeoutOrElse({
-            duration: cleanupDeadline,
-            orElse: () => Effect.fail(proofFailure('CLEANUP', 'CLEANUP_DEADLINE_EXCEEDED')),
-          }),
+        withInterruptibleCleanupDeadline(cleanupOrder(session, mutation, clientOrderId, state)).pipe(
           Effect.tapError((error) =>
             Effect.sync(() => {
               state.cleanup.result = 'FAILED'

--- a/services/bayn/src/broker/alpaca-sandbox-contract.test.ts
+++ b/services/bayn/src/broker/alpaca-sandbox-contract.test.ts
@@ -1,4 +1,4 @@
-import { test } from 'bun:test'
+import { expect, test } from 'bun:test'
 
 import { NodeHttpClient } from '@effect/platform-node'
 import { Data, Duration, Effect, Exit, Redacted, References, Result, Schedule } from 'effect'
@@ -11,14 +11,22 @@ import {
   disabledCapitalAccess,
   makeExecutionAuthority,
 } from '../execution/authority'
-import { IntentState, OrderSide, OrderType, TimeInForce, type Intent } from '../paper'
+import { IntentState, MutationOutcome, OrderSide, OrderType, TimeInForce, type Intent } from '../paper'
 import { currentUtcDate, currentUtcInstant } from '../time'
-import { BrokerMutationError, MutationFailure, makeMutation, type BrokerMutationShape } from './alpaca-mutations'
+import {
+  BrokerMutationError,
+  MutationFailure,
+  MutationOperation,
+  makeMutation,
+  type BrokerMutationShape,
+} from './alpaca-mutations'
 import {
   AssetStatus,
   BrokerProvider,
   BrokerReadError,
   BrokerReadErrorKind,
+  BrokerSessionAcquisitionError,
+  BrokerSessionAcquisitionStage,
   OrderCollection,
   OrderStatus,
   alpacaSandboxBaseUrl,
@@ -33,9 +41,22 @@ const enabled = Bun.env.BAYN_ALPACA_SANDBOX_CONTRACT === '1'
 const receiptPath = Bun.env.BAYN_ALPACA_SANDBOX_RECEIPT_PATH
 const proofSymbol = 'AAPL'
 const proofQuantityMicros = '10000'
-const lookupRetryCount = 4
-const terminalPollCount = 15
-const retryDelay = Duration.seconds(1)
+const brokerOperationTimeoutMs = 5_000
+const lookupRetryCount = 2
+const terminalPollCount = 5
+const retryDelayMs = 1_000
+const mutationPhaseDeadlineMs = 2 * 60_000
+const cleanupDeadlineMs = 3 * 60_000
+const retryDelay = Duration.millis(retryDelayMs)
+const mutationPhaseDeadline = Duration.millis(mutationPhaseDeadlineMs)
+const cleanupDeadline = Duration.millis(cleanupDeadlineMs)
+const maximumRetryReadMs = (lookupRetryCount + 1) * brokerOperationTimeoutMs + lookupRetryCount * retryDelayMs
+const maximumCleanupNetworkMs =
+  maximumRetryReadMs +
+  brokerOperationTimeoutMs +
+  (terminalPollCount + 1) * maximumRetryReadMs +
+  terminalPollCount * retryDelayMs +
+  maximumRetryReadMs
 
 const required = (name: string): string => {
   const value = Bun.env[name]
@@ -67,6 +88,9 @@ interface SanitizedFailure {
   readonly stage: ProofStage
   readonly tag: string
   readonly failure: string
+  readonly acquisitionStage?: string
+  readonly causeTag?: string
+  readonly causeFailure?: string
   readonly operation?: string
   readonly status?: number
   readonly retryable?: boolean
@@ -98,6 +122,7 @@ interface ProofState {
   }
   submitOutcome: 'NOT_ATTEMPTED' | 'ACKNOWLEDGED' | 'REJECTED' | 'UNKNOWN'
   brokerOrderId?: string
+  acceptedOrderContractMismatch: boolean
   finalStatus?: OrderStatus
   cancelAttempts: number
   cancelAcknowledged: boolean
@@ -115,6 +140,31 @@ const proofFailure = (stage: ProofStage, failure: string): SandboxContractProofE
   new SandboxContractProofError({ stage, failure })
 
 const sanitizeFailure = (stage: ProofStage, error: unknown): SanitizedFailure => {
+  if (error instanceof BrokerSessionAcquisitionError) {
+    const cause = error.cause
+    if (cause instanceof BrokerReadError) {
+      return {
+        stage: 'SESSION_PREFLIGHT',
+        tag: error._tag,
+        failure: error.stage,
+        acquisitionStage: error.stage,
+        causeTag: cause._tag,
+        causeFailure: cause.kind,
+        operation: cause.operation,
+        status: cause.status,
+        retryable: cause.retryable,
+      }
+    }
+    return {
+      stage: 'SESSION_PREFLIGHT',
+      tag: error._tag,
+      failure: error.stage,
+      acquisitionStage: error.stage,
+      causeTag: cause._tag,
+      causeFailure: cause.failure._tag,
+      retryable: false,
+    }
+  }
   if (error instanceof BrokerReadError) {
     return {
       stage,
@@ -143,6 +193,7 @@ const sanitizeFailure = (stage: ProofStage, error: unknown): SanitizedFailure =>
 
 const failureStage = (error: unknown): ProofStage => {
   if (error instanceof SandboxContractProofError) return error.stage
+  if (error instanceof BrokerSessionAcquisitionError) return 'SESSION_PREFLIGHT'
   if (error instanceof BrokerMutationError) return error.operation === 'CANCEL' ? 'CANCEL' : 'SUBMIT'
   if (error instanceof BrokerReadError) {
     switch (error.operation) {
@@ -169,18 +220,14 @@ const failureStage = (error: unknown): ProofStage => {
   return 'CONFIGURATION'
 }
 
-const isOpenStatus = (status: OrderStatus): boolean =>
-  [
-    OrderStatus.New,
-    OrderStatus.PartiallyFilled,
-    OrderStatus.PendingCancel,
-    OrderStatus.PendingReplace,
-    OrderStatus.PendingReview,
-    OrderStatus.Accepted,
-    OrderStatus.PendingNew,
-    OrderStatus.AcceptedForBidding,
-    OrderStatus.Held,
-  ].includes(status)
+const terminalOrderStatuses: ReadonlySet<OrderStatus> = new Set([
+  OrderStatus.Filled,
+  OrderStatus.Canceled,
+  OrderStatus.Expired,
+  OrderStatus.Rejected,
+])
+
+const isOpenStatus = (status: OrderStatus): boolean => !terminalOrderStatuses.has(status)
 
 const retryRead = <A>(
   effect: Effect.Effect<A, BrokerReadError>,
@@ -217,9 +264,10 @@ const requireOrderBinding = (
   order: Order,
   clientOrderId: string,
   brokerOrderId: string,
+  allowAcceptedContractMismatch: boolean,
   stage: ProofStage,
 ): Effect.Effect<void, SandboxContractProofError> =>
-  order.clientOrderId === clientOrderId && order.brokerOrderId === brokerOrderId
+  order.brokerOrderId === brokerOrderId && (allowAcceptedContractMismatch || order.clientOrderId === clientOrderId)
     ? Effect.succeed(undefined)
     : Effect.fail(proofFailure(stage, 'ORDER_BINDING_MISMATCH'))
 
@@ -227,12 +275,19 @@ const waitForTerminalOrder = (
   orderById: (brokerOrderId: string) => Effect.Effect<ReadResult<Order>, BrokerReadError>,
   brokerOrderId: string,
   clientOrderId: string,
+  allowAcceptedContractMismatch: boolean,
   state: ProofState,
   attempt = 0,
 ): Effect.Effect<ReadResult<Order>, BrokerReadError | SandboxContractProofError> =>
   retryRead(orderById(brokerOrderId)).pipe(
     Effect.flatMap((result) =>
-      requireOrderBinding(result.value, clientOrderId, brokerOrderId, 'TERMINAL_LOOKUP').pipe(
+      requireOrderBinding(
+        result.value,
+        clientOrderId,
+        brokerOrderId,
+        allowAcceptedContractMismatch,
+        'TERMINAL_LOOKUP',
+      ).pipe(
         Effect.andThen(
           Effect.sync(() => {
             state.lifecycle.push(readEvidence('TERMINAL_LOOKUP', result))
@@ -245,7 +300,16 @@ const waitForTerminalOrder = (
             : attempt >= terminalPollCount
               ? Effect.fail(proofFailure('TERMINAL_LOOKUP', 'ORDER_REMAINED_OPEN'))
               : Effect.sleep(retryDelay).pipe(
-                  Effect.andThen(waitForTerminalOrder(orderById, brokerOrderId, clientOrderId, state, attempt + 1)),
+                  Effect.andThen(
+                    waitForTerminalOrder(
+                      orderById,
+                      brokerOrderId,
+                      clientOrderId,
+                      allowAcceptedContractMismatch,
+                      state,
+                      attempt + 1,
+                    ),
+                  ),
                 ),
         ),
       ),
@@ -288,9 +352,13 @@ const verifyNoOpenProofOrder = (
   clientOrderId: string,
   state: ProofState,
 ): Effect.Effect<void, BrokerReadError | SandboxContractProofError> =>
-  retryRead(session.read.orders({ status: OrderCollection.Open, limit: 500, symbols: [proofSymbol] })).pipe(
+  retryRead(session.read.orders({ status: OrderCollection.Open, limit: 500 })).pipe(
     Effect.flatMap((result) => {
-      const residual = result.value.filter((order) => order.clientOrderId === clientOrderId)
+      const residual = result.value.filter(
+        (order) =>
+          order.clientOrderId === clientOrderId ||
+          (state.brokerOrderId !== undefined && order.brokerOrderId === state.brokerOrderId),
+      )
       state.cleanup.residualOpenOrderCount = residual.length
       state.lifecycle.push({
         stage: 'OPEN_ORDER_VERIFICATION',
@@ -345,9 +413,21 @@ const cleanupOrder = (
     }
 
     if (observed === undefined) observed = yield* retryRead(orderById(brokerOrderId))
-    yield* requireOrderBinding(observed.value, clientOrderId, brokerOrderId, 'CLEANUP')
+    yield* requireOrderBinding(
+      observed.value,
+      clientOrderId,
+      brokerOrderId,
+      state.acceptedOrderContractMismatch,
+      'CLEANUP',
+    )
     yield* cancelIfOpen(mutation, observed.value, state)
-    const terminal = yield* waitForTerminalOrder(orderById, brokerOrderId, clientOrderId, state)
+    const terminal = yield* waitForTerminalOrder(
+      orderById,
+      brokerOrderId,
+      clientOrderId,
+      state.acceptedOrderContractMismatch,
+      state,
+    )
     yield* verifyNoOpenProofOrder(session, clientOrderId, state)
     state.finalStatus = terminal.value.status
     state.cleanup.result = 'VERIFIED_TERMINAL'
@@ -361,6 +441,84 @@ const cleanupOrder = (
     ),
   )
 }
+
+const recordSubmitFailure = (state: ProofState, error: BrokerMutationError): void => {
+  state.submitOutcome = error.failure === MutationFailure.Rejected ? 'REJECTED' : 'UNKNOWN'
+  if (error.brokerOrderId !== undefined) {
+    state.brokerOrderId = error.brokerOrderId
+    state.acceptedOrderContractMismatch = true
+  }
+}
+
+test('treats every Alpaca nonterminal status as open for cleanup', () => {
+  for (const status of Object.values(OrderStatus)) {
+    expect(isOpenStatus(status)).toBe(!terminalOrderStatuses.has(status))
+  }
+  expect(isOpenStatus(OrderStatus.DoneForDay)).toBeTrue()
+  expect(isOpenStatus(OrderStatus.Calculated)).toBeTrue()
+  expect(isOpenStatus(OrderStatus.Stopped)).toBeTrue()
+  expect(isOpenStatus(OrderStatus.Suspended)).toBeTrue()
+})
+
+test('keeps the cleanup network bound below its explicit deadline', () => {
+  expect(maximumCleanupNetworkMs).toBeLessThan(cleanupDeadlineMs)
+  expect(mutationPhaseDeadlineMs + cleanupDeadlineMs).toBeLessThan(15 * 60_000)
+})
+
+test('preserves typed session acquisition evidence in the sanitized failure', () => {
+  const cause = new BrokerReadError({
+    operation: 'account',
+    kind: BrokerReadErrorKind.Authentication,
+    message: 'Alpaca account request was rejected',
+    retryable: false,
+    status: 401,
+  })
+  const error = new BrokerSessionAcquisitionError({
+    stage: BrokerSessionAcquisitionStage.Account,
+    provider: BrokerProvider.Alpaca,
+    environment: BrokerEnvironment.Sandbox,
+    baseUrl: alpacaSandboxBaseUrl,
+    expectedAccountId: 'not-in-receipt',
+    cause,
+  })
+
+  expect(sanitizeFailure(failureStage(error), error)).toEqual({
+    stage: 'SESSION_PREFLIGHT',
+    tag: 'BrokerSessionAcquisitionError',
+    failure: BrokerSessionAcquisitionStage.Account,
+    acquisitionStage: BrokerSessionAcquisitionStage.Account,
+    causeTag: 'BrokerReadError',
+    causeFailure: BrokerReadErrorKind.Authentication,
+    operation: 'account',
+    status: 401,
+    retryable: false,
+  })
+})
+
+test('retains an accepted mismatched broker ID for exact cleanup', () => {
+  const state: ProofState = {
+    submitOutcome: 'NOT_ATTEMPTED',
+    acceptedOrderContractMismatch: false,
+    cancelAttempts: 0,
+    cancelAcknowledged: false,
+    lifecycle: [],
+    cleanup: { result: 'NOT_RUN' },
+  }
+  recordSubmitFailure(
+    state,
+    new BrokerMutationError({
+      operation: MutationOperation.Submit,
+      failure: MutationFailure.Unknown,
+      outcome: MutationOutcome.Unknown,
+      message: 'accepted order did not match the request',
+      brokerOrderId: '00000000-0000-4000-8000-000000000001',
+    }),
+  )
+
+  expect(state.submitOutcome).toBe('UNKNOWN')
+  expect(state.brokerOrderId).toBe('00000000-0000-4000-8000-000000000001')
+  expect(state.acceptedOrderContractMismatch).toBeTrue()
+})
 
 test.skipIf(!enabled)('proves the bounded Alpaca sandbox contract through the production adapter', async () => {
   const expectedAccountId = required('BAYN_ALPACA_ACCOUNT_ID')
@@ -395,7 +553,7 @@ test.skipIf(!enabled)('proves the bounded Alpaca sandbox contract through the pr
     key: Redacted.make(key),
     secret: Redacted.make(secret),
     proxyUrl: 'http://127.0.0.1:1',
-    operationTimeoutMs: 30_000,
+    operationTimeoutMs: brokerOperationTimeoutMs,
     retryAttempts: 0,
   })
   if (Result.isFailure(decoded)) throw new Error('sandbox broker connection guard rejected the protected binding')
@@ -432,6 +590,7 @@ test.skipIf(!enabled)('proves the bounded Alpaca sandbox contract through the pr
   }
   const state: ProofState = {
     submitOutcome: 'NOT_ATTEMPTED',
+    acceptedOrderContractMismatch: false,
     cancelAttempts: 0,
     cancelAcknowledged: false,
     lifecycle: [],
@@ -493,7 +652,7 @@ test.skipIf(!enabled)('proves the bounded Alpaca sandbox contract through the pr
           const submit = yield* mutation.submit(intent).pipe(
             Effect.tapError((error) =>
               Effect.sync(() => {
-                state.submitOutcome = error.failure === MutationFailure.Rejected ? 'REJECTED' : 'UNKNOWN'
+                recordSubmitFailure(state, error)
               }),
             ),
           )
@@ -506,6 +665,7 @@ test.skipIf(!enabled)('proves the bounded Alpaca sandbox contract through the pr
             recoveredSubmit.value,
             clientOrderId,
             submit.order.brokerOrderId,
+            false,
             'LOOKUP_BY_CLIENT_ID',
           )
           if (recoveredSubmit.value.quantityMicros !== proofQuantityMicros) {
@@ -513,8 +673,25 @@ test.skipIf(!enabled)('proves the bounded Alpaca sandbox contract through the pr
           }
           state.lifecycle.push(readEvidence('LOOKUP_BY_CLIENT_ID', recoveredSubmit))
           yield* cancelIfOpen(mutation, recoveredSubmit.value, state)
-        }),
-      () => cleanupOrder(session, mutation, clientOrderId, state),
+        }).pipe(
+          Effect.timeoutOrElse({
+            duration: mutationPhaseDeadline,
+            orElse: () => Effect.fail(proofFailure('SUBMIT', 'MUTATION_PHASE_DEADLINE_EXCEEDED')),
+          }),
+        ),
+      () =>
+        cleanupOrder(session, mutation, clientOrderId, state).pipe(
+          Effect.timeoutOrElse({
+            duration: cleanupDeadline,
+            orElse: () => Effect.fail(proofFailure('CLEANUP', 'CLEANUP_DEADLINE_EXCEEDED')),
+          }),
+          Effect.tapError((error) =>
+            Effect.sync(() => {
+              state.cleanup.result = 'FAILED'
+              state.cleanupFailure = sanitizeFailure('CLEANUP', error)
+            }),
+          ),
+        ),
     )
   }).pipe(
     Effect.tapError((error) =>
@@ -568,6 +745,7 @@ test.skipIf(!enabled)('proves the bounded Alpaca sandbox contract through the pr
       symbol: proofSymbol,
       quantityMicros: proofQuantityMicros,
       submitOutcome: state.submitOutcome,
+      acceptedOrderContractMismatch: state.acceptedOrderContractMismatch,
       finalStatus: state.finalStatus,
     },
     orderLifecycle: state.lifecycle,

--- a/services/bayn/src/broker/alpaca-sandbox-contract.test.ts
+++ b/services/bayn/src/broker/alpaca-sandbox-contract.test.ts
@@ -155,7 +155,6 @@ interface ProofState {
   }
   submitOutcome: 'NOT_ATTEMPTED' | 'ACKNOWLEDGED' | 'REJECTED' | 'UNKNOWN'
   brokerOrderId?: string
-  acceptedOrderContractMismatch: boolean
   finalStatus?: OrderStatus
   filledQuantityMicros?: string
   cancelAttempts: number
@@ -431,10 +430,9 @@ const requireOrderBinding = (
   order: Order,
   clientOrderId: string,
   brokerOrderId: string,
-  allowAcceptedContractMismatch: boolean,
   stage: ProofStage,
 ): Effect.Effect<void, SandboxContractProofError> =>
-  order.brokerOrderId === brokerOrderId && (allowAcceptedContractMismatch || order.clientOrderId === clientOrderId)
+  order.brokerOrderId === brokerOrderId && order.clientOrderId === clientOrderId
     ? Effect.succeed(undefined)
     : Effect.fail(proofFailure(stage, 'ORDER_BINDING_MISMATCH'))
 
@@ -475,18 +473,11 @@ const resolveOrderCleanup = (
   current: ReadResult<Order>,
   clientOrderId: string,
   brokerOrderId: string,
-  allowAcceptedContractMismatch: boolean,
   state: ProofState,
   attempt = 0,
   pollDelayMs = retryDelayMs,
 ): Effect.Effect<ReadResult<Order>, BrokerReadError | BrokerMutationError | SandboxContractProofError> =>
-  requireOrderBinding(
-    current.value,
-    clientOrderId,
-    brokerOrderId,
-    allowAcceptedContractMismatch,
-    'TERMINAL_LOOKUP',
-  ).pipe(
+  requireOrderBinding(current.value, clientOrderId, brokerOrderId, 'TERMINAL_LOOKUP').pipe(
     Effect.andThen(
       Effect.sync(() => {
         state.finalStatus = current.value.status
@@ -512,7 +503,6 @@ const resolveOrderCleanup = (
                       next,
                       clientOrderId,
                       brokerOrderId,
-                      allowAcceptedContractMismatch,
                       state,
                       attempt + 1,
                       pollDelayMs,
@@ -605,22 +595,8 @@ const cleanupOrder = (
       observed = yield* retryRead(orderById(brokerOrderId), true)
       state.lifecycle.push(readEvidence('CLEANUP_LOOKUP_BY_ID', observed))
     }
-    yield* requireOrderBinding(
-      observed.value,
-      clientOrderId,
-      brokerOrderId,
-      state.acceptedOrderContractMismatch,
-      'CLEANUP',
-    )
-    const terminal = yield* resolveOrderCleanup(
-      mutation,
-      orderById,
-      observed,
-      clientOrderId,
-      brokerOrderId,
-      state.acceptedOrderContractMismatch,
-      state,
-    )
+    yield* requireOrderBinding(observed.value, clientOrderId, brokerOrderId, 'CLEANUP')
+    const terminal = yield* resolveOrderCleanup(mutation, orderById, observed, clientOrderId, brokerOrderId, state)
     yield* verifyNoOpenProofOrder(session, clientOrderId, state)
     state.finalStatus = terminal.value.status
     state.filledQuantityMicros = terminal.value.filledQuantityMicros
@@ -639,15 +615,10 @@ const cleanupOrder = (
 
 const recordSubmitFailure = (state: ProofState, error: BrokerMutationError): void => {
   state.submitOutcome = error.failure === MutationFailure.Rejected ? 'REJECTED' : 'UNKNOWN'
-  if (error.brokerOrderId !== undefined) {
-    state.brokerOrderId = error.brokerOrderId
-    state.acceptedOrderContractMismatch = true
-  }
 }
 
 const testProofState = (): ProofState => ({
   submitOutcome: 'NOT_ATTEMPTED',
-  acceptedOrderContractMismatch: false,
   cancelAttempts: 0,
   cancelAcknowledged: false,
   lifecycle: [],
@@ -806,7 +777,6 @@ test('retries exact cancellation after an unknown outcome', async () => {
       initial,
       initial.value.clientOrderId,
       initial.value.brokerOrderId,
-      false,
       state,
       0,
       0,
@@ -921,7 +891,7 @@ test('preserves typed session acquisition evidence in the sanitized failure', ()
   })
 })
 
-test('retains an accepted mismatched broker ID for exact cleanup', () => {
+test('discards an unbound accepted broker ID and requires exact client-order recovery', async () => {
   const state = testProofState()
   recordSubmitFailure(
     state,
@@ -935,8 +905,17 @@ test('retains an accepted mismatched broker ID for exact cleanup', () => {
   )
 
   expect(state.submitOutcome).toBe('UNKNOWN')
-  expect(state.brokerOrderId).toBe('00000000-0000-4000-8000-000000000001')
-  expect(state.acceptedOrderContractMismatch).toBeTrue()
+  expect(state.brokerOrderId).toBeUndefined()
+
+  const mismatched = {
+    ...testOrder(OrderStatus.New),
+    brokerOrderId: '00000000-0000-4000-8000-000000000001',
+    clientOrderId: 'unrelated-client-order',
+  }
+  const binding = await Effect.runPromiseExit(
+    requireOrderBinding(mismatched, 'sandbox-proof-client-order', mismatched.brokerOrderId, 'CLEANUP'),
+  )
+  expect(Exit.isFailure(binding)).toBeTrue()
 })
 
 test.skipIf(!enabled)('proves the bounded Alpaca sandbox contract through the production adapter', async () => {
@@ -1018,7 +997,6 @@ test.skipIf(!enabled)('proves the bounded Alpaca sandbox contract through the pr
   }
   const state: ProofState = {
     submitOutcome: 'NOT_ATTEMPTED',
-    acceptedOrderContractMismatch: false,
     cancelAttempts: 0,
     cancelAcknowledged: false,
     lifecycle: [],
@@ -1082,7 +1060,6 @@ test.skipIf(!enabled)('proves the bounded Alpaca sandbox contract through the pr
             recoveredSubmit.value,
             clientOrderId,
             submit.order.brokerOrderId,
-            false,
             'LOOKUP_BY_CLIENT_ID',
           )
           if (recoveredSubmit.value.quantityMicros !== proofQuantityMicros) {
@@ -1181,7 +1158,6 @@ test.skipIf(!enabled)('proves the bounded Alpaca sandbox contract through the pr
       symbol: proofSymbol,
       quantityMicros: proofQuantityMicros,
       submitOutcome: state.submitOutcome,
-      acceptedOrderContractMismatch: state.acceptedOrderContractMismatch,
       finalStatus: state.finalStatus,
       filledQuantityMicros: state.filledQuantityMicros,
     },


### PR DESCRIPTION
## Summary

- add an opt-in real Alpaca paper contract proof through the production connection, verified session, read, submit, lookup, cancel, and cleanup interpreters
- fail closed on the exact paper endpoint, protected credential binding, verified sandbox account identity, closed regular session, safe fractional asset, exact source SHA, and an exact multi-architecture release artifact
- establish one absolute protected-job deadline and refuse submission unless the complete two-minute mutation phase plus three-minute cleanup phase remains
- keep the three-minute cleanup deadline interruptible even inside the `acquireUseRelease` finalizer, with regression coverage against a never-ending cleanup
- expose the Alpaca account ID, key ID, and secret key only to the credential guard and the real broker proof step
- exercise the production `alpacaHttpLayer` through a restricted loopback CONNECT proxy that permits only `paper-api.alpaca.markets:443`
- continue unknown-submit recovery through the cleanup window by polling the exact client ID and scanning bounded open orders until the exact broker order becomes visible
- discard an unbound broker order ID returned by an accepted-contract mismatch; all cancellation requires both the proof client-order ID and exact recovered broker order ID
- submit one unique 0.01 AAPL DAY paper order only when every guard passes, cancel only that exact order, and require `Canceled`, zero fill, and no residual open order
- upload a sanitized canonical receipt; receipt schema v3 explicitly distinguishes the verified release artifact from the checked-out-source proof runtime

## Exact-head evidence

Source head: `50b422208aafbebe5216a198f9641c9b5e2ada76`  
Rebased base: `344ca27ec30efb472f45b8124acfa32260eaae43`

Changed files are limited to:

- `.github/workflows/bayn-ci.yml`
- `services/bayn/src/broker/alpaca-sandbox-contract.test.ts`

### Ordinary CI and release gate

Main Bayn PR run: https://github.com/proompteng/lab/actions/runs/30393604803

Green on the exact head:

- focused broker sandbox contract
- Effect runtime compatibility
- dependency-input invariant
- PostgreSQL integration
- complete PR checks
- amd64 image
- arm64 image
- Bayn release gate

Repository workflow lint, commit lint, title validation, changed-area validation, and `ci-pr` are also green.

### Exact multi-architecture release artifact

Run: https://github.com/proompteng/lab/actions/runs/30393632161

- conclusion: `SUCCESS`
- amd64: `SUCCESS`
- arm64: `SUCCESS`
- multi-architecture index and release contract: `SUCCESS`
- image: `registry.ide-newton.ts.net/lab/bayn@sha256:a7bd8b525eea1dcdadcd5dc6665bade35bbe88d2be32a737de0c82ecdd47ae18`
- amd64 digest: `sha256:60c77be6ffd75f7ce00695c3a38e483da062973d8001405433e93d89e00e4ad5`
- arm64 digest: `sha256:ae790c25f1b6791bee20f0e108baf4423250e31cd917ffb84a63fdc6b22365c0`

The downloaded `bayn-release-contract` was independently checked for the exact source SHA, tag, image, digest, package attribute, and both platforms. Receipt schema v3 records this only as `releaseGate.claim=EXACT_IMAGE_ARTIFACT_VERIFIED_NOT_PROOF_RUNTIME`; the host proof runtime is explicitly `CHECKED_OUT_SOURCE` at the same exact SHA.

### Protected paper proof

Run: https://github.com/proompteng/lab/actions/runs/30393835769  
Protected job: https://github.com/proompteng/lab/actions/runs/30393835769/job/90391811608

- the protected job ran and failed; it was not skipped
- overall deadline establishment, dispatch validation, exact checkout, and exact-head verification passed
- the credential-binding guard failed because the protected environment supplies none of the three required secrets
- release-artifact verification, dependency setup, restricted proxy startup, and the real broker proof were skipped after the guard failure
- no Alpaca request was made, no paper order was submitted, and no residual order was created
- the same manual workflow completed its ordinary broker, Effect, dependency, PostgreSQL, full PR, and release-gate jobs successfully
- sanitized artifact: `alpaca-sandbox-contract-50b422208aafbebe5216a198f9641c9b5e2ada76`
- receipt schema/status: `bayn.alpaca-sandbox-contract-receipt.v3` / `GUARD_PENDING`
- receipt binds source `50b422208aafbebe5216a198f9641c9b5e2ada76`, release run `30393632161`, checked-out-source proof runtime, timestamp, and `ALPACA_PAPER`
- the downloaded guard receipt contains no account, credential, secret, token, authorization, or key-ID material

Current external-authority blocker in GitHub environment `bayn-alpaca-sandbox`:

- zero environment secrets
- zero protection/reviewer rules
- no deployment branch policy

Required environment secret names:

- `BAYN_ALPACA_SANDBOX_ACCOUNT_ID`
- `BAYN_ALPACA_SANDBOX_KEY_ID`
- `BAYN_ALPACA_SANDBOX_SECRET_KEY`

The cluster-managed Kubernetes secret was not read, copied, or exposed.

## Local validation

Exact rebased head:

- `actionlint -shellcheck '' -pyflakes '' .github/workflows/bayn-ci.yml`
- focused contract test: 14 passed, 1 credential-gated skip, 0 failed
- TypeScript: passed
- Oxfmt: passed
- Oxlint standard: 0 warnings, 0 errors
- Oxlint type-aware: 0 warnings, 0 errors
- Effect diagnostics: 0 errors, 0 warnings, 0 messages
- restricted proxy check: Alpaca paper reachable through the proxy; unrelated HTTPS target rejected with 403
- full Bayn suite: 846 passed, 123 expected skips, 0 failed; 6,254 assertions across 969 tests and 74 files
- build: passed
- `git diff --check`: passed

## Merge status

Do not merge until the protected environment has the intended reviewer policy and all three secrets, and an exact-head protected run succeeds with a sanitized receipt proving submit, lookup, exact cancellation, zero fill, and no residual order.

## Breaking Changes

None.
