### PR TITLE
chore(oirat): promote nix image sha-2b1c8a2fc0ce7fcb32162029632be213cedc665f

### DIFF
--- a/argocd/applications/oirat/kustomization.yaml
+++ b/argocd/applications/oirat/kustomization.yaml
@@ -10,4 +10,4 @@ resources:
   - alloy-deployment.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/oirat
-    digest: sha256:12b60fbeb5434fe44ff7762c640dc4827a48763f7a9778fdbc2835defd70c9ea
+    digest: sha256:ac025160f9fd92e99e16b33424958947d2e713253538d15b95763e906eec8911


### PR DESCRIPTION
## Summary

- Promote `oirat` to `registry.ide-newton.ts.net/lab/oirat@sha256:ac025160f9fd92e99e16b33424958947d2e713253538d15b95763e906eec8911`.
- Source commit: `2b1c8a2fc0ce7fcb32162029632be213cedc665f`.
- Source version: `v0.596.0-2699-g2b1c8a2fc`.
- Built by the shared Nix OCI workflow without Docker Buildx.

## Related Issues

N/A

## Testing

- `nix run .#assert-oci-platforms -- "registry.ide-newton.ts.net/lab/oirat@sha256:ac025160f9fd92e99e16b33424958947d2e713253538d15b95763e906eec8911" linux/amd64 linux/arm64`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.