### PR TITLE
chore(bumba): promote nix image sha-2b1c8a2fc0ce7fcb32162029632be213cedc665f

### DIFF
--- a/argocd/applications/bumba/deployment.yaml
+++ b/argocd/applications/bumba/deployment.yaml
@@ -73,7 +73,7 @@ spec:
             - name: TEMPORAL_TASK_QUEUE
               value: bumba
             - name: TEMPORAL_WORKER_BUILD_ID
-              value: bumba@4214ec4e148389db331d8adb18d2af52e46f97f6
+              value: bumba@2b1c8a2fc0ce7fcb32162029632be213cedc665f
             - name: TEMPORAL_WORKFLOW_CONCURRENCY
               value: "12"
             - name: TEMPORAL_ACTIVITY_CONCURRENCY

--- a/argocd/applications/bumba/kustomization.yaml
+++ b/argocd/applications/bumba/kustomization.yaml
@@ -6,5 +6,5 @@ resources:
   - deployment.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/bumba
-    digest: sha256:ab9f06c1c33c86f0747974400f515a3cad5300972b20477953e595ec33b728c6
+    digest: sha256:e53a859286f433423f586a4f2453d7bc43a2fd7a05ad9007a7823f81d082e1aa
     newName: registry.ide-newton.ts.net/lab/bumba


### PR DESCRIPTION
## Summary

- Promote `bumba` to `registry.ide-newton.ts.net/lab/bumba@sha256:e53a859286f433423f586a4f2453d7bc43a2fd7a05ad9007a7823f81d082e1aa`.
- Source commit: `2b1c8a2fc0ce7fcb32162029632be213cedc665f`.
- Source version: `v0.596.0-2699-g2b1c8a2fc`.
- Built by the shared Nix OCI workflow without Docker Buildx.

## Related Issues

N/A

## Testing

- `nix run .#assert-oci-platforms -- "registry.ide-newton.ts.net/lab/bumba@sha256:e53a859286f433423f586a4f2453d7bc43a2fd7a05ad9007a7823f81d082e1aa" linux/amd64 linux/arm64`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.