### PR TITLE
fix(nix): refresh shared Bun dependency hashes

### DIFF
--- a/nix/images/app.nix
+++ b/nix/images/app.nix
@@ -11,8 +11,8 @@ import ./bun-workspace-service.nix {
   serviceName = "app";
   packageName = "app";
   depsHash = {
-    x86_64-linux = "sha256-1wtJLUMlLWP1kzz/z+gnN51KnwuoVivbcJZKxPnq5zM=";
-    aarch64-linux = "sha256-GvONG2Wt+AwYmsLIS3XeUdMg5lxXJ4e0moCYVZ4ypDg=";
+    x86_64-linux = "sha256-EVMKlgzS4PrQO9aJbD7AZs86qpxUYLh7bZanb0kjS3c=";
+    aarch64-linux = "sha256-Qxe8hANqrWLHwIszNFTr1K+Qnf1MZGHbpBKANWUIf78=";
   };
   dependencyClosure = "bunCache";
   installFilters = [

--- a/nix/images/bayn.nix
+++ b/nix/images/bayn.nix
@@ -20,8 +20,8 @@ import ./bun-workspace-service.nix {
   serviceName = "bayn";
   packageName = "@proompteng/bayn";
   depsHash = {
-    x86_64-linux = "sha256-Ns33RtSQStNJ+5Mh4kRwvpTbiXVrWqIoGCqVl/viajk=";
-    aarch64-linux = "sha256-VTNz0Ch6ogqE7Qy3NhZXACmWJo4csgk2GK4umWGvVBI=";
+    x86_64-linux = "sha256-ArJWIXew2ouT3A2eHmyQPi66Fr+r3zWNiqSe9bU5SeY=";
+    aarch64-linux = "sha256-hjOpPsbw2boo+Wd7gltmkbK5N7vh08SMPougGOgy42s=";
   };
   installFilters = [
     "@proompteng/bayn"

--- a/nix/images/bayn.nix
+++ b/nix/images/bayn.nix
@@ -20,8 +20,8 @@ import ./bun-workspace-service.nix {
   serviceName = "bayn";
   packageName = "@proompteng/bayn";
   depsHash = {
-    x86_64-linux = "sha256-ArJWIXew2ouT3A2eHmyQPi66Fr+r3zWNiqSe9bU5SeY=";
-    aarch64-linux = "sha256-hjOpPsbw2boo+Wd7gltmkbK5N7vh08SMPougGOgy42s=";
+    x86_64-linux = "sha256-TnXWfeZzFjKVroWLF0G8kOWuePxMD058YeqsXevi9kE=";
+    aarch64-linux = "sha256-kEMBQ4Tn5od4hfpbulZPy5VdJNnp3k7uwz6m57+JFWE=";
   };
   installFilters = [
     "@proompteng/bayn"

--- a/nix/images/bumba.nix
+++ b/nix/images/bumba.nix
@@ -11,8 +11,8 @@ import ./bun-workspace-service.nix {
   serviceName = "bumba";
   packageName = "@proompteng/bumba";
   depsHash = {
-    x86_64-linux = "sha256-8uGpIbyL5j0UDwzIZzjoq3SaeHbj2Ng3LhqboXvDktU=";
-    aarch64-linux = "sha256-IOncuGLUmOq5whSI0DQ+RodRaTUhQodTILWsYcIlOS8=";
+    x86_64-linux = "sha256-s+e/4w8v4fyF/IF+2Sz82RYT8FTUFfhuAF2jwxWMWYY=";
+    aarch64-linux = "sha256-FdibRTqjReTfOhaoxAbt5LabR/wYgBtYrG0QwglEF3Y=";
   };
   installFilters = [
     "@proompteng/bumba"

--- a/nix/images/bumba.nix
+++ b/nix/images/bumba.nix
@@ -11,8 +11,8 @@ import ./bun-workspace-service.nix {
   serviceName = "bumba";
   packageName = "@proompteng/bumba";
   depsHash = {
-    x86_64-linux = "sha256-s+e/4w8v4fyF/IF+2Sz82RYT8FTUFfhuAF2jwxWMWYY=";
-    aarch64-linux = "sha256-FdibRTqjReTfOhaoxAbt5LabR/wYgBtYrG0QwglEF3Y=";
+    x86_64-linux = "sha256-UjoTXH90XqiqcIeteXsrUfgs8XIJFRcid9MipMEFAlk=";
+    aarch64-linux = "sha256-CvAEoF7JTgMK1h52N/D5YUbppD1wf7Bu1crfNqvMF3g=";
   };
   installFilters = [
     "@proompteng/bumba"

--- a/nix/images/docs.nix
+++ b/nix/images/docs.nix
@@ -11,8 +11,8 @@ import ./bun-workspace-service.nix {
   serviceName = "docs";
   packageName = "docs";
   depsHash = {
-    x86_64-linux = "sha256-+1GTQCYAE8hb3c3o8VISFGMGSok12cxcm/ytqmsL37Y=";
-    aarch64-linux = "sha256-ITPWCuk7yp79v9JnKEyBntQU04uJ1eyP9P7f3+bbzV0=";
+    x86_64-linux = "sha256-xNGlO9e/UfKqOKeNAaG0uvGcmc8ibVWtEJ6RvQ0N3gU=";
+    aarch64-linux = "sha256-rJZGOUKjkdNC+HyUDcLO1CQ6xFfHnfX5XbXD8MfMeX4=";
   };
   dependencyClosure = "bunCache";
   installFilters = [

--- a/nix/images/froussard.nix
+++ b/nix/images/froussard.nix
@@ -11,8 +11,8 @@ import ./bun-workspace-service.nix {
   serviceName = "froussard";
   packageName = "froussard";
   depsHash = {
-    x86_64-linux = "sha256-PDp28eJpWfMAzRDCWsMVBFwIkJeUt6m/7tRUVk27au4=";
-    aarch64-linux = "sha256-EaohxXM/f1NFx6Sx0tPJZ9RB5yQADHkDK+iJVyxwD20=";
+    x86_64-linux = "sha256-0HkC0E6wnNY9cUsAgYC7pfrTxgAzTblLNl730QNbIHI=";
+    aarch64-linux = "sha256-PzfUuI8vbOUedsg/aS7TE0AMlND/ojeDrhOiKrE9jIY=";
   };
   installFilters = [
     "@proompteng/agent-contracts"

--- a/nix/images/froussard.nix
+++ b/nix/images/froussard.nix
@@ -11,8 +11,8 @@ import ./bun-workspace-service.nix {
   serviceName = "froussard";
   packageName = "froussard";
   depsHash = {
-    x86_64-linux = "sha256-WCnHB5aHxwUgzxCxOHJ6PF9tmb5i9+wIDoz3dCu61Jc=";
-    aarch64-linux = "sha256-iqW52ILyXL46y97OAB0WyhRauk002soLKNN+ZQFIKEk=";
+    x86_64-linux = "sha256-PDp28eJpWfMAzRDCWsMVBFwIkJeUt6m/7tRUVk27au4=";
+    aarch64-linux = "sha256-EaohxXM/f1NFx6Sx0tPJZ9RB5yQADHkDK+iJVyxwD20=";
   };
   installFilters = [
     "@proompteng/agent-contracts"

--- a/nix/images/jangar.nix
+++ b/nix/images/jangar.nix
@@ -55,8 +55,8 @@ import ./bun-workspace-service.nix {
   serviceName = "jangar";
   packageName = "@proompteng/jangar";
   depsHash = {
-    x86_64-linux = "sha256-E+AyeHIW5eRLHadIAVkd3bkLM/zr5dFGLVi4w7mK5jA=";
-    aarch64-linux = "sha256-PUePS0sFdq3fscH0wP9gFqQyse3DfrI2SceelSeouVg=";
+    x86_64-linux = "sha256-aJQg5Kp+a+tkXAPZurIhakmirHSyetsGokttHYz2Qrg=";
+    aarch64-linux = "sha256-0o5l5kGOyyfMcy7CffuuChneiWOhZdBCBuWHfkZYB6A=";
   };
   dependencyClosure = "bunCache";
   installFilters = [

--- a/nix/images/oirat.nix
+++ b/nix/images/oirat.nix
@@ -11,8 +11,8 @@ import ./bun-workspace-service.nix {
   serviceName = "oirat";
   packageName = "@proompteng/oirat";
   depsHash = {
-    x86_64-linux = "sha256-ppri6585oqRrfqIQRN6OVl7vWWh7rgpfJ4TroYtdizk=";
-    aarch64-linux = "sha256-xBaUA5oRO1LGRbBj5k/2lyGnTynyBhelu1Oxuh/cqoU=";
+    x86_64-linux = "sha256-kRz+gHnT+VvVoIFhN7kG3hLYhwTKrIX0igPi2KJ8N00=";
+    aarch64-linux = "sha256-ZvLLMEX4/Hfpvvqt1FP33CvLDU9ADzowP7To3ncLc4E=";
   };
   installFilters = [
     "@proompteng/discord"

--- a/nix/images/oirat.nix
+++ b/nix/images/oirat.nix
@@ -11,8 +11,8 @@ import ./bun-workspace-service.nix {
   serviceName = "oirat";
   packageName = "@proompteng/oirat";
   depsHash = {
-    x86_64-linux = "sha256-7AJjCVxYw+ePXIu2qmXuS0U7nCBRcUis8P5R13gpoE8=";
-    aarch64-linux = "sha256-ODSM8WNMgrCHapcaoJ1rqtUMqz+os0yvCIGUWJbkeas=";
+    x86_64-linux = "sha256-ppri6585oqRrfqIQRN6OVl7vWWh7rgpfJ4TroYtdizk=";
+    aarch64-linux = "sha256-xBaUA5oRO1LGRbBj5k/2lyGnTynyBhelu1Oxuh/cqoU=";
   };
   installFilters = [
     "@proompteng/discord"

--- a/nix/images/olden.nix
+++ b/nix/images/olden.nix
@@ -11,8 +11,8 @@ import ./bun-workspace-service.nix {
   serviceName = "olden";
   packageName = "olden";
   depsHash = {
-    x86_64-linux = "sha256-k+dVAkQ0AwVCV4Y9so8UsfPCuIy5xopYQYpoYsNNPXY=";
-    aarch64-linux = "sha256-cRSLtmid09C9JmOk9mP94++hTyCg1aIZDNyT3kqvry8=";
+    x86_64-linux = "sha256-vc4SG35iiMgmunllrGLQwOucM/cnar+8wsNyJpumuog=";
+    aarch64-linux = "sha256-50VuVS39bpoVVVDj0iYYzKfxMo9cCcuGdIdPtjWThVI=";
   };
   dependencyClosure = "bunCache";
   installFilters = [

--- a/nix/images/sag.nix
+++ b/nix/images/sag.nix
@@ -14,8 +14,8 @@ import ./bun-workspace-service.nix {
   serviceName = "sag";
   packageName = "@proompteng/sag";
   depsHash = {
-    x86_64-linux = "sha256-pa04MfBLi3c1SNFPWzMYnUNdvKuqsAlpNVHifl8Ea0c=";
-    aarch64-linux = "sha256-cvoRLNxlBl/D/vRmwNpk05KfCrKgQNuY0FNMcHanE9I=";
+    x86_64-linux = "sha256-BO+QhpuKBPhK5HJEp5bibPbuYWPuZr41Ww3YMuorHwI=";
+    aarch64-linux = "sha256-Sh+OjRS1vr8Fhbv8zCCq0TdXAiK1yJI6A2XRp37iJeI=";
   };
   dependencyClosure = "bunCache";
   installFilters = [

--- a/nix/images/signal-publisher.nix
+++ b/nix/images/signal-publisher.nix
@@ -16,8 +16,8 @@ import ./bun-workspace-service.nix {
   serviceName = "signal-publisher";
   packageName = "@proompteng/signal-publisher";
   depsHash = {
-    x86_64-linux = "sha256-XZYupbD7PtcQBxBOrr9q3AAkyYe7KtlLEaVZ8bh3us4=";
-    aarch64-linux = "sha256-/SJTzeaa1zoYPlO2vlYuSNUEWK+443kwv8ANF2/DgCo=";
+    x86_64-linux = "sha256-xtEiOy2QuIPN51pX3/KGFQc+EeGy5gnpfK07F95KV+4=";
+    aarch64-linux = "sha256-k4hcwX92uYgqEHaTMV82FFGpekyjf0dGj/Bal8Nof2w=";
   };
   installFilters = [
     "@proompteng/signal-publisher"

--- a/nix/images/signal-publisher.nix
+++ b/nix/images/signal-publisher.nix
@@ -16,8 +16,8 @@ import ./bun-workspace-service.nix {
   serviceName = "signal-publisher";
   packageName = "@proompteng/signal-publisher";
   depsHash = {
-    x86_64-linux = "sha256-uZZOR5tbRorc6Ctks/TxQFLdWFATJu7ymLxkupxi1I4=";
-    aarch64-linux = "sha256-L7sjaOOe36W+MybqUx7a1OT3duorpbuEVTe+kv0DOK8=";
+    x86_64-linux = "sha256-XZYupbD7PtcQBxBOrr9q3AAkyYe7KtlLEaVZ8bh3us4=";
+    aarch64-linux = "sha256-/SJTzeaa1zoYPlO2vlYuSNUEWK+443kwv8ANF2/DgCo=";
   };
   installFilters = [
     "@proompteng/signal-publisher"

--- a/nix/images/symphony.nix
+++ b/nix/images/symphony.nix
@@ -14,8 +14,8 @@ import ./bun-workspace-service.nix {
   serviceName = "symphony";
   packageName = "@proompteng/symphony";
   depsHash = {
-    x86_64-linux = "sha256-wq4GgCCEbcK2Y2d8AE4YmfMSpLeFDPkGWTrQngbr034=";
-    aarch64-linux = "sha256-i/r3ArJvaTRcm34NBODp75WUFu3D7/AsAnrbbj4iMUE=";
+    x86_64-linux = "sha256-OtO6UdBrExseHBP2UubhcD15AIZw1e1I+xhC721F0qM=";
+    aarch64-linux = "sha256-9gpI1De5iNmVMhGgCuf0Yi+TI7yt+itq1JJqCLcJgN0=";
   };
   dependencyClosure = "bunCache";
   installFilters = [

--- a/nix/images/synthesis.nix
+++ b/nix/images/synthesis.nix
@@ -11,8 +11,8 @@ import ./bun-workspace-service.nix {
   serviceName = "synthesis";
   packageName = "synthesis";
   depsHash = {
-    x86_64-linux = "sha256-dG/J1KuH5cvF1e3obc4+yuJfl+Jt6BeuzkBC2ln5hME=";
-    aarch64-linux = "sha256-PJl3Of83HoN4Sp2if9zhAJHx33KR/0Iq9ylMjecDYwk=";
+    x86_64-linux = "sha256-BYgbunlSO+2zrFVF60ghdhBbAd+Wo3/ADnFeIScW5p8=";
+    aarch64-linux = "sha256-6zDKz/gUnNKFI+Rnjm3wLRbi0iIq6jVjntnmBRWOeOk=";
   };
   dependencyClosure = "bunCache";
   installFilters = [


### PR DESCRIPTION
## Summary

- refresh both declared platform hashes for every stale `bun-workspace-service.nix` consumer: app, bayn, bumba, docs, froussard, jangar, oirat, olden, sag, signal-publisher, symphony, and synthesis
- inventory all 14 consumers and retain the agents and proompteng hashes that native fixed-output builds proved unchanged
- restore reproducible dependency derivations after shared root workspace inputs changed

## Related Issues

None

## Testing

- `git diff --check`
- `nix-instantiate --parse` for all 12 changed Nix image definitions
- native `x86_64-linux` fixed-output dependency builds for all 14 consumers
- native `aarch64-linux` fixed-output dependency builds for all 14 consumers
- exact-head GitHub Actions checks

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
