### PR TITLE
chore(jangar): promote image sha-5c3bb55917c9082e8b77dc61ae284cbf74dd9268

### DIFF
--- a/argocd/applications/jangar/deployment.yaml
+++ b/argocd/applications/jangar/deployment.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/part-of: lab
   annotations:
     argocd.argoproj.io/sync-wave: "0"
-    deploy.knative.dev/rollout: 2026-07-18T03:14:12Z
+    deploy.knative.dev/rollout: 2026-07-28T06:26:43Z
 spec:
   replicas: 1
   strategy:
@@ -58,9 +58,9 @@ spec:
             - name: UI_PORT
               value: "8080"
             - name: JANGAR_SOURCE_HEAD_SHA
-              value: 75d316f14b50b1dafaa00c082f1fe87ce699addf
+              value: 5c3bb55917c9082e8b77dc61ae284cbf74dd9268
             - name: JANGAR_GITOPS_REVISION
-              value: 75d316f14b50b1dafaa00c082f1fe87ce699addf
+              value: 5c3bb55917c9082e8b77dc61ae284cbf74dd9268
             - name: JANGAR_HTTP_IDLE_TIMEOUT_SECONDS
               value: "120"
             - name: JANGAR_CONTROL_PLANE_STATUS_CACHE_TTL_MS
@@ -360,15 +360,15 @@ spec:
             - name: ATLAS_CODE_SEARCH_STATEMENT_TIMEOUT_MS
               value: "5000"
             - name: JANGAR_SOURCE_CI_RUN_ID
-              value: "29569402255"
+              value: "30332913119"
             - name: JANGAR_SOURCE_CI_CONCLUSION
               value: success
             - name: JANGAR_MANIFEST_IMAGE_DIGEST
-              value: sha256:c51e049257a2f70a8fbe1b7f85e708d1e493a100e21b1a318439a1ec722c75a8
+              value: sha256:50261e89cd791405fdadb0d13300b348c1ee6f736aed655d357851d9026ac777
             - name: JANGAR_SERVING_BUILD_COMMIT
-              value: 75d316f14b50b1dafaa00c082f1fe87ce699addf
+              value: 5c3bb55917c9082e8b77dc61ae284cbf74dd9268
             - name: JANGAR_SERVING_IMAGE_DIGEST
-              value: sha256:c51e049257a2f70a8fbe1b7f85e708d1e493a100e21b1a318439a1ec722c75a8
+              value: sha256:50261e89cd791405fdadb0d13300b348c1ee6f736aed655d357851d9026ac777
           ports:
             - name: http
               containerPort: 8080

--- a/argocd/applications/jangar/kustomization.yaml
+++ b/argocd/applications/jangar/kustomization.yaml
@@ -37,5 +37,5 @@ helmCharts:
     valuesFile: openwebui-values.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/jangar
-    newTag: sha-75d316f14b50b1dafaa00c082f1fe87ce699addf
-    digest: sha256:c51e049257a2f70a8fbe1b7f85e708d1e493a100e21b1a318439a1ec722c75a8
+    newTag: sha-5c3bb55917c9082e8b77dc61ae284cbf74dd9268
+    digest: sha256:50261e89cd791405fdadb0d13300b348c1ee6f736aed655d357851d9026ac777


### PR DESCRIPTION
## Summary
Promote Jangar image into GitOps manifests.

- Source commit: `5c3bb55917c9082e8b77dc61ae284cbf74dd9268`
- Image tag: `sha-5c3bb55917c9082e8b77dc61ae284cbf74dd9268`
- Image digest: `sha256:50261e89cd791405fdadb0d13300b348c1ee6f736aed655d357851d9026ac777`
- Source CI run: `30332913119`
- Updated API rollout annotation
- Published source-serving proof env for revenue repair custody gates