### PR TITLE
chore(symphony): promote image sha-5c3bb55917c9082e8b77dc61ae284cbf74dd9268

### DIFF
--- a/argocd/applications/symphony-jangar/deployment.patch.yaml
+++ b/argocd/applications/symphony-jangar/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-07-18T08:39:21Z"
+        kubectl.kubernetes.io/restartedAt: "2026-07-28T06:30:01Z"
     spec:
       serviceAccountName: symphony-jangar
       containers:

--- a/argocd/applications/symphony-jangar/kustomization.yaml
+++ b/argocd/applications/symphony-jangar/kustomization.yaml
@@ -22,5 +22,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "sha-e32f125fc3d1fdf4e2c98d46eb7c46133d3c93a6"
-    digest: sha256:b0ccfbd2dbc4d37af4a36d2cbd583bf5bf93e524247430b1dc261f324a696d6c
+    newTag: "sha-5c3bb55917c9082e8b77dc61ae284cbf74dd9268"
+    digest: sha256:f95d99912f771d6bd42ad89e32f66c006421188838dfe5083fce879785f1350a

--- a/argocd/applications/symphony-torghut/deployment.patch.yaml
+++ b/argocd/applications/symphony-torghut/deployment.patch.yaml
@@ -7,7 +7,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-07-18T08:39:21Z"
+        kubectl.kubernetes.io/restartedAt: "2026-07-28T06:30:01Z"
     spec:
       serviceAccountName: symphony-torghut
       containers:

--- a/argocd/applications/symphony-torghut/kustomization.yaml
+++ b/argocd/applications/symphony-torghut/kustomization.yaml
@@ -23,5 +23,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "sha-e32f125fc3d1fdf4e2c98d46eb7c46133d3c93a6"
-    digest: sha256:b0ccfbd2dbc4d37af4a36d2cbd583bf5bf93e524247430b1dc261f324a696d6c
+    newTag: "sha-5c3bb55917c9082e8b77dc61ae284cbf74dd9268"
+    digest: sha256:f95d99912f771d6bd42ad89e32f66c006421188838dfe5083fce879785f1350a

--- a/argocd/applications/symphony/deployment.patch.yaml
+++ b/argocd/applications/symphony/deployment.patch.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-07-18T08:39:21Z"
+        kubectl.kubernetes.io/restartedAt: "2026-07-28T06:30:01Z"
     spec:
       volumes:
         - name: codex-auth

--- a/argocd/applications/symphony/kustomization.yaml
+++ b/argocd/applications/symphony/kustomization.yaml
@@ -16,5 +16,5 @@ patches:
 images:
   - name: registry.ide-newton.ts.net/lab/symphony
     newName: registry.ide-newton.ts.net/lab/symphony
-    newTag: "sha-e32f125fc3d1fdf4e2c98d46eb7c46133d3c93a6"
-    digest: sha256:b0ccfbd2dbc4d37af4a36d2cbd583bf5bf93e524247430b1dc261f324a696d6c
+    newTag: "sha-5c3bb55917c9082e8b77dc61ae284cbf74dd9268"
+    digest: sha256:f95d99912f771d6bd42ad89e32f66c006421188838dfe5083fce879785f1350a


### PR DESCRIPTION
## Summary
Promote the Symphony fleet image into GitOps manifests.

- Source commit: `5c3bb55917c9082e8b77dc61ae284cbf74dd9268`
- Image tag: `sha-5c3bb55917c9082e8b77dc61ae284cbf74dd9268`
- Image digest: `sha256:f95d99912f771d6bd42ad89e32f66c006421188838dfe5083fce879785f1350a`