### PR TITLE
chore(oirat): promote nix image sha-5c3bb55917c9082e8b77dc61ae284cbf74dd9268

### DIFF
--- a/argocd/applications/oirat/kustomization.yaml
+++ b/argocd/applications/oirat/kustomization.yaml
@@ -10,4 +10,4 @@ resources:
   - alloy-deployment.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/oirat
-    digest: sha256:ac025160f9fd92e99e16b33424958947d2e713253538d15b95763e906eec8911
+    digest: sha256:c8244accbd4606ff39d324d58f2eb5df11861b744d21e54cd0e0d9e99fcc70a2


### PR DESCRIPTION
## Summary

- Promote `oirat` to `registry.ide-newton.ts.net/lab/oirat@sha256:c8244accbd4606ff39d324d58f2eb5df11861b744d21e54cd0e0d9e99fcc70a2`.
- Source commit: `5c3bb55917c9082e8b77dc61ae284cbf74dd9268`.
- Source version: `v0.596.0-2707-g5c3bb5591`.
- Built by the shared Nix OCI workflow without Docker Buildx.

## Related Issues

N/A

## Testing

- `nix run .#assert-oci-platforms -- "registry.ide-newton.ts.net/lab/oirat@sha256:c8244accbd4606ff39d324d58f2eb5df11861b744d21e54cd0e0d9e99fcc70a2" linux/amd64 linux/arm64`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.