### PR TITLE
chore(bumba): promote nix image sha-5c3bb55917c9082e8b77dc61ae284cbf74dd9268

### DIFF
--- a/argocd/applications/bumba/deployment.yaml
+++ b/argocd/applications/bumba/deployment.yaml
@@ -73,7 +73,7 @@ spec:
             - name: TEMPORAL_TASK_QUEUE
               value: bumba
             - name: TEMPORAL_WORKER_BUILD_ID
-              value: bumba@2b1c8a2fc0ce7fcb32162029632be213cedc665f
+              value: bumba@5c3bb55917c9082e8b77dc61ae284cbf74dd9268
             - name: TEMPORAL_WORKFLOW_CONCURRENCY
               value: "12"
             - name: TEMPORAL_ACTIVITY_CONCURRENCY

--- a/argocd/applications/bumba/kustomization.yaml
+++ b/argocd/applications/bumba/kustomization.yaml
@@ -6,5 +6,5 @@ resources:
   - deployment.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/bumba
-    digest: sha256:e53a859286f433423f586a4f2453d7bc43a2fd7a05ad9007a7823f81d082e1aa
+    digest: sha256:a84649615ad9134bc0eedd6414836f47a146e4b60d30d7f8095fc5047fd170f5
     newName: registry.ide-newton.ts.net/lab/bumba


### PR DESCRIPTION
## Summary

- Promote `bumba` to `registry.ide-newton.ts.net/lab/bumba@sha256:a84649615ad9134bc0eedd6414836f47a146e4b60d30d7f8095fc5047fd170f5`.
- Source commit: `5c3bb55917c9082e8b77dc61ae284cbf74dd9268`.
- Source version: `v0.596.0-2707-g5c3bb5591`.
- Built by the shared Nix OCI workflow without Docker Buildx.

## Related Issues

N/A

## Testing

- `nix run .#assert-oci-platforms -- "registry.ide-newton.ts.net/lab/bumba@sha256:a84649615ad9134bc0eedd6414836f47a146e4b60d30d7f8095fc5047fd170f5" linux/amd64 linux/arm64`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.