### PR TITLE
chore(product): promote nix product images

### DIFF
--- a/argocd/applications/app/kustomization.yaml
+++ b/argocd/applications/app/kustomization.yaml
@@ -8,5 +8,5 @@ resources:
   - secret.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/app
-    digest: sha256:8c6a731c676256e39570389041ab4762245c27e0452a11998c3a11b21f8d310e
+    digest: sha256:7e8dcfd4b334c6fe0838a1d971cb2f83f97b9dcd7995acddb53d11dd50d9290a
     newName: registry.ide-newton.ts.net/lab/app

--- a/argocd/applications/docs/kustomization.yaml
+++ b/argocd/applications/docs/kustomization.yaml
@@ -4,5 +4,5 @@ resources:
   - generated
 images:
   - name: registry.ide-newton.ts.net/lab/docs
-    digest: sha256:edb3e93f3c61f865bbd34628e134b5be5206432618aac80eccd7dcdfc66d5a15
+    digest: sha256:436862334370c11b9539fe0f2d1dd190b2bcf0bb3e0d3a0812b97ce12402aaf8
     newName: registry.ide-newton.ts.net/lab/docs

--- a/argocd/applications/synthesis/kustomization.yaml
+++ b/argocd/applications/synthesis/kustomization.yaml
@@ -11,5 +11,5 @@ resources:
   - agents-domain
 images:
   - name: registry.ide-newton.ts.net/lab/synthesis
-    digest: sha256:85d8bb25f7a358c81c695120827a72582754ed1789aa11f41d46ead11914a5b6
+    digest: sha256:9a04243c4a6ab27de3a8bebb7febd0cd8497be75d22f52c52a05a12af27f40d4
     newName: registry.ide-newton.ts.net/lab/synthesis


### PR DESCRIPTION
## Summary

- Promote enabled product app image digests built by the shared Nix OCI workflow.
- `app`: `registry.ide-newton.ts.net/lab/app@sha256:7e8dcfd4b334c6fe0838a1d971cb2f83f97b9dcd7995acddb53d11dd50d9290a` from `5c3bb55917c9082e8b77dc61ae284cbf74dd9268`
- `docs`: `registry.ide-newton.ts.net/lab/docs@sha256:436862334370c11b9539fe0f2d1dd190b2bcf0bb3e0d3a0812b97ce12402aaf8` from `5c3bb55917c9082e8b77dc61ae284cbf74dd9268`
- `synthesis`: `registry.ide-newton.ts.net/lab/synthesis@sha256:9a04243c4a6ab27de3a8bebb7febd0cd8497be75d22f52c52a05a12af27f40d4` from `5c3bb55917c9082e8b77dc61ae284cbf74dd9268`

## Related Issues

N/A

## Testing

- `nix run .#assert-oci-platforms -- <image>@<digest> linux/amd64 linux/arm64` for each promoted image.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.