### PR TITLE
chore(froussard): promote nix image sha-5c3bb55917c9082e8b77dc61ae284cbf74dd9268

### DIFF
--- a/argocd/applications/froussard/knative-service.yaml
+++ b/argocd/applications/froussard/knative-service.yaml
@@ -24,7 +24,7 @@ spec:
       enableServiceLinks: false
       containers:
         - name: app
-          image: registry.ide-newton.ts.net/lab/froussard@sha256:793ba8d0d0aa9ad7aa295d97c2e0fe23222303c9cea4177062a8a4809ecbe2db
+          image: registry.ide-newton.ts.net/lab/froussard@sha256:27c78abda6c70c0636c0682061b3c771ba5b5f161db8828fd1b5eaf80747fc6d
           imagePullPolicy: Always
           ports:
             - containerPort: 8080
@@ -73,9 +73,9 @@ spec:
             - name: OTEL_SERVICE_NAMESPACE
               value: froussard
             - name: FROUSSARD_VERSION
-              value: v0.596.0-2699-g2b1c8a2fc
+              value: v0.596.0-2707-g5c3bb5591
             - name: FROUSSARD_COMMIT
-              value: 2b1c8a2fc0ce7fcb32162029632be213cedc665f
+              value: 5c3bb55917c9082e8b77dc61ae284cbf74dd9268
             - name: LGTM_TEMPO_TRACES_ENDPOINT
               value: http://observability-tempo-gateway.observability.svc.cluster.local:4317
             - name: LGTM_MIMIR_METRICS_ENDPOINT


### PR DESCRIPTION
## Summary

- Promote `froussard` to `registry.ide-newton.ts.net/lab/froussard@sha256:27c78abda6c70c0636c0682061b3c771ba5b5f161db8828fd1b5eaf80747fc6d`.
- Source commit: `5c3bb55917c9082e8b77dc61ae284cbf74dd9268`.
- Source version: `v0.596.0-2707-g5c3bb5591`.
- Built by the shared Nix OCI workflow without Docker Buildx.

## Related Issues

N/A

## Testing

- `nix run .#assert-oci-platforms -- "registry.ide-newton.ts.net/lab/froussard@sha256:27c78abda6c70c0636c0682061b3c771ba5b5f161db8828fd1b5eaf80747fc6d" linux/amd64 linux/arm64`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.