### PR TITLE
chore(bayn): pin candidate five terminal result

### DIFF
--- a/argocd/applications/bayn/deployment.yaml
+++ b/argocd/applications/bayn/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         app.kubernetes.io/name: bayn
         app.kubernetes.io/part-of: bayn
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-07-28T06:38:06Z"
+        kubectl.kubernetes.io/restartedAt: "2026-07-28T07:08:17Z"
     spec:
       serviceAccountName: bayn
       automountServiceAccountToken: false
@@ -56,6 +56,8 @@ spec:
               value: "9e87fe0f66048c48da2191ef1fae36ef3ee0eb4ddcd036ef40881f0fe0f6eb42"
             - name: BAYN_STRATEGY_PARAMETER_HASH
               value: "19bc51c7361b181aa48845d178cb63373b3f2e017bcbea1cf3b70ab16647f8a9"
+            - name: BAYN_QUALIFICATION_RUN_ID
+              value: "a6530496d594a5425f091f30148012b12b6b030d49b396f925efe9ead3496217"
             - name: BAYN_MAXIMUM_AUTHORITY
               value: OBSERVE
             # sha256("bayn/authority-generation/autonomous-observe-v1")


### PR DESCRIPTION
## Summary

- pin the terminal candidate-5 qualification run `a6530496d594a5425f091f30148012b12b6b030d49b396f925efe9ead3496217`
- preserve exact source `5c3bb55917c9082e8b77dc61ae284cbf74dd9268`, image digest `sha256:f1310487798cafd7909266f36a4f94e135f812f310d3fc1220836ea6a6e1c4a8`, Alpaca sandbox binding, maximum authority `OBSERVE`, and absent `BAYN_OPERATION`
- force one committed restart so startup must recover the immutable terminal evidence instead of evaluating again

The terminal result is `REJECTED`; this PR grants no capital or broker mutation authority.

## Qualification evidence

- result hash `a603d712a8d948af7e7de42165b9e81c9a3b42a4ebd38b45753e69755d94cc75`
- analysis hash `26b0d52008573a925b0b78ea5065a3744025aa726df5280d16074f2f5972626c`
- lock ID `d337891d3b0b930c9e182c324430e6c16a16872de8eb6d21294b18b27f15cb7e`
- two independent source-pinned audits: 45/45 checks passed with identical audit hash `acd78215c8c0c81093f153570be0b8580382373fbf153a5102c1834a4abd0882` and canonical output hash `7bb9d660a8c9b55d20492354ddba1d48e8f2024572a48890c5bd38c52fa76f5b`

## Testing

- `kubectl kustomize argocd/applications/bayn` with exact pin, source/digest, OBSERVE, and absent-operation assertions
- `bun test services/bayn/src/config.test.ts services/bayn/src/observe-composition.test.ts` — 79 passed, 0 failed
- `git diff --check`
- live pre-pin status: account bound/readable, capital promotion false, zero mutations, zero unfinished cycles

## Known operational blocker

The current exact image fails autonomous publication discovery before a cycle can be created with ClickHouse `NO_COMMON_TYPE` (`String` versus `Date`) in `bayn-cycle-publication-candidates`. This PR does not change TypeScript or weaken readiness; the service remains fail-closed until the separately owned production query is corrected.

## Breaking Changes

None.
