### PR TITLE
fix(bayn): qualify publication query date columns

### DIFF
--- a/services/bayn/src/market-data.test.ts
+++ b/services/bayn/src/market-data.test.ts
@@ -315,13 +315,13 @@ const makeClickhouseFixture = (
     Effect.gen(function* () {
       const text = strings.join('?')
       const parameters = fragments.map((fragment) => fragment.value)
-      if (text.includes('FROM signal.snapshot_manifests_v2') && text.includes('WHERE universe_id')) {
+      if (text.includes('FROM signal.snapshot_manifests_v2 AS manifest')) {
         queries.push({ kind: 'manifest', text, parameters })
         const calendarVersion = parameters.at(-1)
-        const matching = text.includes('AND calendar_version =')
+        const matching = text.includes('AND manifest.calendar_version =')
           ? manifests.filter((manifest) => manifest.calendar_version === calendarVersion)
           : manifests
-        if (text.includes('ORDER BY finalized_at DESC, snapshot_id DESC')) {
+        if (text.includes('ORDER BY manifest.finalized_at DESC, manifest.snapshot_id DESC')) {
           return [...matching]
             .sort((left, right) => {
               if (left.finalized_at !== right.finalized_at) return right.finalized_at.localeCompare(left.finalized_at)
@@ -329,7 +329,7 @@ const makeClickhouseFixture = (
             })
             .slice(0, 1)
         }
-        if (!text.includes('ORDER BY publication_asof DESC')) return matching
+        if (!text.includes('ORDER BY manifest.publication_asof DESC')) return matching
         const ordered = [...matching].sort((left, right) => {
           if (left.publication_asof !== right.publication_asof) {
             return right.publication_asof.localeCompare(left.publication_asof)
@@ -769,7 +769,7 @@ describe('finalized Signal snapshot reader', () => {
     expect(queries.filter((query) => query.kind === 'sessions')).toHaveLength(2)
     expect(queries.filter((query) => query.kind === 'bars')).toHaveLength(0)
     for (const query of manifestQueries) {
-      expect(query.text).toContain('AND calendar_version =')
+      expect(query.text).toContain('AND manifest.calendar_version =')
       expect(query.parameters).toContain(fixture.request.calendarVersion)
     }
   })
@@ -843,8 +843,8 @@ describe('finalized Signal snapshot reader', () => {
     expect(manifestQueries).toHaveLength(1)
     expect(queries.filter((query) => query.kind === 'sessions')).toHaveLength(1)
     expect(queries.filter((query) => query.kind === 'bars')).toHaveLength(0)
-    expect(manifestQueries[0]?.text).toContain('AND universe_symbol_hash =')
-    expect(manifestQueries[0]?.text).toContain('ORDER BY finalized_at DESC, snapshot_id DESC')
+    expect(manifestQueries[0]?.text).toContain('AND manifest.universe_symbol_hash =')
+    expect(manifestQueries[0]?.text).toContain('ORDER BY manifest.finalized_at DESC, manifest.snapshot_id DESC')
     expect(manifestQueries[0]?.text).toContain('LIMIT 1')
     expect(manifestQueries[0]?.parameters).toContain(fixture.request.universeSymbolHash)
     expect(queries.find((query) => query.kind === 'sessions')?.parameters).toEqual([expected.manifest.snapshot_id])
@@ -914,9 +914,14 @@ describe('finalized Signal snapshot reader', () => {
     expect(manifestQueries).toHaveLength(1)
     expect(sessionQueries).toHaveLength(1)
     expect(queries.filter((query) => query.kind === 'bars')).toHaveLength(0)
-    expect(manifestQueries[0]?.text).toContain('AND universe_symbol_hash =')
-    expect(manifestQueries[0]?.text).toContain('ORDER BY publication_asof DESC, finalized_at DESC, snapshot_id DESC')
-    expect(manifestQueries[0]?.text).toContain('LIMIT 1 BY publication_asof')
+    expect(manifestQueries[0]?.text).toContain('toString(manifest.requested_start) AS requested_start')
+    expect(manifestQueries[0]?.text).toContain('AND manifest.universe_symbol_hash =')
+    expect(manifestQueries[0]?.text).toContain('AND manifest.requested_start = toDate(')
+    expect(manifestQueries[0]?.text).not.toContain('AND requested_start = toDate(')
+    expect(manifestQueries[0]?.text).toContain(
+      'ORDER BY manifest.publication_asof DESC, manifest.finalized_at DESC, manifest.snapshot_id DESC',
+    )
+    expect(manifestQueries[0]?.text).toContain('LIMIT 1 BY manifest.publication_asof')
     expect(manifestQueries[0]?.text).toContain('LIMIT ?')
     expect(manifestQueries[0]?.parameters).not.toContain(snapshotId)
     expect(manifestQueries[0]?.parameters).not.toContain(fixture.request.publicationAsOf)

--- a/services/bayn/src/market-data/queries.ts
+++ b/services/bayn/src/market-data/queries.ts
@@ -92,24 +92,24 @@ export const makeMarketDataQueries = (
         source_feed,
         adjustment,
         calendar_version,
-        toString(requested_start) AS requested_start,
-        toString(publication_asof) AS publication_asof,
-        toString(first_session) AS first_session,
-        toString(last_session) AS last_session,
+        toString(manifest.requested_start) AS requested_start,
+        toString(manifest.publication_asof) AS publication_asof,
+        toString(manifest.first_session) AS first_session,
+        toString(manifest.last_session) AS last_session,
         symbol_count,
         session_count,
         bar_count,
         bars_content_hash,
         sessions_content_hash,
         manifest_content_hash,
-        toString(finalized_at) AS finalized_at
-      FROM signal.snapshot_manifests_v2
-      WHERE universe_id = ${sql.param('String', contract.universeId)}
-        AND universe_symbol_hash = ${sql.param('String', contract.universeSymbolHash)}
-        AND requested_start = toDate(${sql.param('String', contract.historyStart)})
-        AND publication_asof = toDate(${sql.param('String', request.signalSessionDate)})
-        AND calendar_version = ${sql.param('String', request.signalCalendarVersion)}
-      ORDER BY finalized_at DESC, snapshot_id DESC
+        toString(manifest.finalized_at) AS finalized_at
+      FROM signal.snapshot_manifests_v2 AS manifest
+      WHERE manifest.universe_id = ${sql.param('String', contract.universeId)}
+        AND manifest.universe_symbol_hash = ${sql.param('String', contract.universeSymbolHash)}
+        AND manifest.requested_start = toDate(${sql.param('String', contract.historyStart)})
+        AND manifest.publication_asof = toDate(${sql.param('String', request.signalSessionDate)})
+        AND manifest.calendar_version = ${sql.param('String', request.signalCalendarVersion)}
+      ORDER BY manifest.finalized_at DESC, manifest.snapshot_id DESC
       LIMIT 1
     `.pipe(sql.withQueryId(`bayn-cycle-manifest-${request.signalSessionDate}`))
 
@@ -126,23 +126,23 @@ export const makeMarketDataQueries = (
       source_feed,
       adjustment,
       calendar_version,
-      toString(requested_start) AS requested_start,
-      toString(publication_asof) AS publication_asof,
-      toString(first_session) AS first_session,
-      toString(last_session) AS last_session,
+      toString(manifest.requested_start) AS requested_start,
+      toString(manifest.publication_asof) AS publication_asof,
+      toString(manifest.first_session) AS first_session,
+      toString(manifest.last_session) AS last_session,
       symbol_count,
       session_count,
       bar_count,
       bars_content_hash,
       sessions_content_hash,
       manifest_content_hash,
-      toString(finalized_at) AS finalized_at
-    FROM signal.snapshot_manifests_v2
-    WHERE universe_id = ${sql.param('String', contract.universeId)}
-      AND universe_symbol_hash = ${sql.param('String', contract.universeSymbolHash)}
-      AND requested_start = toDate(${sql.param('String', contract.historyStart)})
-    ORDER BY publication_asof DESC, finalized_at DESC, snapshot_id DESC
-    LIMIT 1 BY publication_asof
+      toString(manifest.finalized_at) AS finalized_at
+    FROM signal.snapshot_manifests_v2 AS manifest
+    WHERE manifest.universe_id = ${sql.param('String', contract.universeId)}
+      AND manifest.universe_symbol_hash = ${sql.param('String', contract.universeSymbolHash)}
+      AND manifest.requested_start = toDate(${sql.param('String', contract.historyStart)})
+    ORDER BY manifest.publication_asof DESC, manifest.finalized_at DESC, manifest.snapshot_id DESC
+    LIMIT 1 BY manifest.publication_asof
     LIMIT ${sql.param('UInt8', cyclePublicationCandidateLimit)}
   `.pipe(sql.withQueryId('bayn-cycle-publication-candidates'))
 


### PR DESCRIPTION
## Summary

- Qualify the native `Date` columns in finalized publication discovery so ClickHouse does not resolve decoder aliases inside filters or deduplication keys.
- Preserve the existing read-only query ID, bounded ordering, `LIMIT 1 BY` semantics, history-start filter, and string-shaped row decoder contract.
- Strengthen the market-data query regression to require source-qualified `Date` filtering and ordering.

## Related Issues

None

## Testing

- `bun test src/market-data.test.ts` — 21 passed.
- `bun run tsc`
- `bun run lint:effect`
- `bun run lint:oxlint`
- `bun run lint:oxlint:type`
- `bun run lint`
- `bun run test` — 818 passed, 121 PostgreSQL-gated tests skipped locally, 0 failed.
- `bun run build`
- Read-only production-schema reproduction: the pre-fix query ID `bayn-cycle-publication-candidates` failed with ClickHouse code 386 because `toString(requested_start) AS requested_start` shadowed the native `Date` in the unqualified `WHERE requested_start = toDate(...)` expression.
- Read-only production-schema proof: the corrected full bounded query returned HTTP 200 with four publication rows while retaining `String` decoder output for `requested_start` and `publication_asof`.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots section removed because it is not applicable.
- [x] Documentation, release notes, and follow-ups are not required for this bounded query correction.
