### PR TITLE
fix(bayn): settle deterministic autonomous cycles

### DIFF
--- a/services/bayn/src/cycle-runner.test.ts
+++ b/services/bayn/src/cycle-runner.test.ts
@@ -4,14 +4,18 @@ import { Cause, Deferred, Effect, Fiber, Logger, Option, References, Result } fr
 import { TestClock } from 'effect/testing'
 
 import {
+  AccountStatus,
   BrokerRead,
   BrokerReadError,
   BrokerReadErrorKind,
+  type Account,
   type BrokerReadShape,
   type MarketCalendarObservation,
   type MarketCalendarQuery,
   type MarketCalendarSession,
+  type ReadEvidence,
 } from './broker/alpaca'
+import { BrokerMutation, type BrokerMutationShape } from './broker/alpaca-mutations'
 import { unusedAssetBySymbol } from './broker/alpaca-test-support'
 import {
   CycleState,
@@ -42,6 +46,7 @@ import {
   type CycleRunContext,
   type CycleRunResult,
 } from './cycle-runner'
+import { runAutonomousCycleUntilSettled } from './cycle-runner/program'
 import { selectCycleRecovery, type CycleRecoveryState } from './cycle-recovery'
 import { CycleStore, type CycleAuthoritySlot, type CycleStoreShape } from './db/cycle-store'
 import { canonicalHashV1, sha256 } from './hash'
@@ -53,9 +58,10 @@ import {
 } from './market-data'
 import { makeObserveShadowDecisionDocument, type ObserveShadowDecisionDocument } from './shadow-decision-contract'
 import { TargetPlanReason, TargetPlanStatus } from './target-planner'
+import { currentUtcInstant } from './time'
 import { DataFeed, DataSource, PriceAdjustment, PublicationSchema, type InputManifest, type IsoDate } from './types'
 
-const cycleLoop = <E, R>(options: AutonomousCycleLoopOptions<E, R>) =>
+const cycleLoop = <E, ContextR, DecisionR>(options: AutonomousCycleLoopOptions<E, ContextR, DecisionR>) =>
   Effect.fromResult(makeAutonomousCycleLoop(options))
 
 const signalCalendarVersion = 'signal-XNYS-2026-v1'
@@ -296,6 +302,7 @@ const makeDecision = (
   cycle: AutonomousCycle,
   createdAt: string,
   blockedReason?: Exclude<TargetPlanReason, TargetPlanReason.TargetsSatisfied>,
+  bindingOverrides: Partial<ObserveShadowDecisionDocument['bindings']> = {},
 ): ObserveShadowDecisionDocument => {
   const targetPlanMaterial = {
     schemaVersion: 'bayn.paper-reference-target-plan.v1' as const,
@@ -339,6 +346,7 @@ const makeDecision = (
       planningBrokerStateHash: '8'.repeat(64),
       reconciliationId: '9'.repeat(64),
       reconciliationHash: 'a'.repeat(64),
+      ...bindingOverrides,
     },
     targetPlan: {
       ...targetPlanMaterial,
@@ -362,10 +370,25 @@ interface StoreControl {
   binds: number
 }
 
-const cycleStore = (control: StoreControl): CycleStoreShape => {
-  const cycles = new Map<string, AutonomousCycle>()
-  const slots = new Map<string, string>()
-  const documents = new Map<string, ObserveShadowDecisionDocument>()
+interface CycleStorePersistence {
+  readonly cycles: Map<string, AutonomousCycle>
+  readonly slots: Map<string, string>
+  readonly documents: Map<string, ObserveShadowDecisionDocument>
+  readonly manifests: Map<string, InputManifest>
+}
+
+const makeCycleStorePersistence = (): CycleStorePersistence => ({
+  cycles: new Map(),
+  slots: new Map(),
+  documents: new Map(),
+  manifests: new Map(),
+})
+
+const cycleStore = (
+  control: StoreControl,
+  persistence: CycleStorePersistence = makeCycleStorePersistence(),
+): CycleStoreShape => {
+  const { cycles, documents, manifests, slots } = persistence
   const readCycle = (cycleId: string): AutonomousCycle | undefined => cycles.get(cycleId)
   return {
     acquire: (draft, observedAt) =>
@@ -435,6 +458,7 @@ const cycleStore = (control: StoreControl): CycleStoreShape => {
           stateVersion: cycle.stateVersion + 1,
           updatedAt: observedAt,
         }
+        manifests.set(cycleId, manifest)
         cycles.set(cycleId, updated)
         return { cycle: updated, changed: true }
       }),
@@ -1851,7 +1875,7 @@ describe('autonomous cycle runner', () => {
     expect(control.acquisitions).toEqual([])
   })
 
-  test('runs immediately, repeats on Schedule.spaced, and avoids duplicate work after acquisition', async () => {
+  test('settles durable progress before the scheduled wait and avoids duplicate work', async () => {
     const control: StoreControl = { acquisitions: [], binds: 0 }
     const store = cycleStore(control)
     const observations: CyclePassObservation[] = []
@@ -1890,25 +1914,347 @@ describe('autonomous cycle runner', () => {
     expect(calendarReads).toBe(1)
     expect(control.binds).toBe(1)
     expect(observations).toHaveLength(3)
-    expect(observations[0]).toMatchObject({
-      outcome: 'SUCCEEDED',
-      result: { outcome: 'ACQUIRED' },
+    for (const observation of observations) {
+      expect(observation).toMatchObject({
+        outcome: 'SUCCEEDED',
+        result: {
+          outcome: 'RECOVERED',
+          action: 'WAITING',
+          cycle: {
+            state: CycleState.Active,
+            bindings: { snapshotId },
+          },
+        },
+      })
+    }
+  })
+
+  test('fails typed when a store reports progress without a durable state transition', async () => {
+    const control: StoreControl = { acquisitions: [], binds: 0 }
+    const persistence = makeCycleStorePersistence()
+    const store = cycleStore(control, persistence)
+    const stuckStore: CycleStoreShape = {
+      ...store,
+      activate: (cycleId) =>
+        Effect.sync(() => {
+          const cycle = persistence.cycles.get(cycleId)
+          if (cycle === undefined) throw new Error('stuck activation could not find the cycle')
+          return { cycle, changed: false }
+        }),
+    }
+    const program = Effect.gen(function* () {
+      yield* TestClock.setTime(Date.parse('2026-01-30T21:20:00.000Z'))
+      return yield* provide(
+        runAutonomousCycleUntilSettled(context()),
+        brokerRead(() => Effect.succeed({ value: monthEndCalendar, evidence })),
+        stuckStore,
+        marketDataService(Effect.succeed(finalizedPublication()), finalizedPublicationInspection()),
+      ).pipe(Effect.flip)
+    }).pipe(Effect.provide(TestClock.layer()))
+
+    const failure = await Effect.runPromise(program)
+    expect(failure).toMatchObject({
+      _tag: 'CycleRunnerError',
+      operation: 'recover-cycle',
+      failure: 'contract',
+      message: 'autonomous cycle pass repeated ACTIVATED without durable progress',
     })
-    expect(observations[1]).toMatchObject({
-      outcome: 'SUCCEEDED',
-      result: { outcome: 'RECOVERED', action: 'ACTIVATED' },
+    expect(control.acquisitions).toHaveLength(1)
+    expect(control.binds).toBe(1)
+  })
+
+  test('completes one deterministic due OBSERVE pass and restarts without duplicate evidence or orders', async () => {
+    const accountId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+    const discoveryAt = '2026-01-30T21:20:00.000Z'
+    const submissionOpenAt = '2026-02-02T13:58:00.000Z'
+    const inspection = finalizedPublicationInspection()
+    const persistence = makeCycleStorePersistence()
+    const control: StoreControl = { acquisitions: [], binds: 0 }
+    const observations: CyclePassObservation[] = []
+    let calendarReads = 0
+    let publicationDiscoveries = 0
+    let exactSnapshotReads = 0
+    let accountReads = 0
+    let positionReads = 0
+    let orderReads = 0
+    let mutationSubmits = 0
+    let mutationCancels = 0
+
+    interface DurableReconciliationEvidence {
+      readonly schemaVersion: 'bayn.test-observe-reconciliation.v1'
+      readonly reconciliationId: string
+      readonly cycleId: string
+      readonly snapshotId: string
+      readonly accountId: string
+      readonly observedAt: string
+      readonly authority: 'OBSERVE'
+      readonly accountHash: string
+      readonly positionsHash: string
+      readonly ordersHash: string
+      readonly brokerOrderCount: number
+      readonly contentHash: string
+    }
+
+    const reconciliations = new Map<string, DurableReconciliationEvidence>()
+    const readEvidence = (identity: string): ReadEvidence => ({
+      requestId: `request-${identity}`,
+      status: 200,
+      contentHash: canonicalHashV1(identity),
+      observedAt: submissionOpenAt,
     })
-    expect(observations[2]).toMatchObject({
-      outcome: 'SUCCEEDED',
-      result: {
-        outcome: 'RECOVERED',
-        action: 'WAITING',
-        cycle: {
-          state: CycleState.Active,
-          bindings: { snapshotId },
+    const account: Account = {
+      id: accountId,
+      status: AccountStatus.Active,
+      currency: 'USD',
+      cashMicros: '1000000000',
+      equityMicros: '1000000000',
+      buyingPowerMicros: '2000000000',
+      accountBlocked: false,
+      tradingBlocked: false,
+      tradeSuspendedByUser: false,
+      observedAt: submissionOpenAt,
+    }
+    const unexpectedRead = Effect.die(new Error('deterministic due-cycle proof performed an unexpected broker read'))
+    const read: BrokerReadShape = {
+      account: Effect.sync(() => {
+        accountReads += 1
+        return { value: account, evidence: readEvidence('account') }
+      }),
+      accountConfiguration: unexpectedRead,
+      assetBySymbol: unusedAssetBySymbol,
+      positions: Effect.sync(() => {
+        positionReads += 1
+        return { value: [], evidence: readEvidence('positions') }
+      }),
+      orders: () =>
+        Effect.sync(() => {
+          orderReads += 1
+          return { value: [], evidence: readEvidence('orders') }
+        }),
+      orderById: () => unexpectedRead,
+      orderByClientId: () => unexpectedRead,
+      fillActivities: () => unexpectedRead,
+      marketCalendar: (query) =>
+        Effect.sync(() => {
+          calendarReads += 1
+          expect(query).toEqual({ start: '2026-01-30', end: '2026-03-01' })
+          return { value: monthEndCalendar, evidence }
+        }),
+    }
+    const exactPublication = () =>
+      Effect.sync(() => {
+        exactSnapshotReads += 1
+        return {
+          outcome: 'FINALIZED' as const,
+          observedAt: inspection.manifest.finalizedSnapshot.finalizedAt,
+          inspection,
+        }
+      })
+    const marketData: MarketDataService = {
+      ...marketDataService(Effect.die(new Error('deterministic discovery override was not installed'))),
+      inspectCyclePublications: Effect.sync(() => {
+        publicationDiscoveries += 1
+        return finalizedPublications([inspection], discoveryAt)
+      }),
+      inspectPublication: exactPublication,
+      inspectSnapshotPublication: exactPublication,
+    }
+    const mutation: BrokerMutationShape = {
+      submit: () =>
+        Effect.sync(() => {
+          mutationSubmits += 1
+          throw new Error('OBSERVE cycle attempted to submit an order')
+        }),
+      cancel: () =>
+        Effect.sync(() => {
+          mutationCancels += 1
+          throw new Error('OBSERVE cycle attempted to cancel an order')
+        }),
+    }
+    const baseContext = context(accountId)
+    const dueContext: CycleRunContext<BrokerRead> = {
+      ...baseContext,
+      buildDecision: (cycle) =>
+        Effect.gen(function* () {
+          const broker = yield* BrokerRead
+          const [accountObservation, positionsObservation, ordersObservation, observedAt] = yield* Effect.all([
+            broker.account,
+            broker.positions,
+            broker.orders(),
+            currentUtcInstant,
+          ])
+          const boundSnapshotId = cycle.bindings.snapshotId
+          if (boundSnapshotId === undefined) {
+            return yield* Effect.die(new Error('same-pass reconciliation requires the immutable snapshot binding'))
+          }
+          const accountHash = canonicalHashV1(accountObservation.value)
+          const positionsHash = canonicalHashV1(positionsObservation.value)
+          const ordersHash = canonicalHashV1(ordersObservation.value)
+          const reconciliationMaterial = {
+            schemaVersion: 'bayn.test-observe-reconciliation.v1' as const,
+            cycleId: cycle.identity.cycleId,
+            snapshotId: boundSnapshotId,
+            accountId: accountObservation.value.id,
+            observedAt,
+            authority: 'OBSERVE' as const,
+            accountHash,
+            positionsHash,
+            ordersHash,
+            brokerOrderCount: ordersObservation.value.length,
+          }
+          const reconciliationId = canonicalHashV1({
+            schemaVersion: reconciliationMaterial.schemaVersion,
+            cycleId: reconciliationMaterial.cycleId,
+            observedAt,
+          })
+          const contentHash = canonicalHashV1(reconciliationMaterial)
+          yield* Effect.sync(() => {
+            if (reconciliations.has(cycle.identity.cycleId)) {
+              throw new Error('same-pass reconciliation evidence was duplicated')
+            }
+            reconciliations.set(cycle.identity.cycleId, {
+              ...reconciliationMaterial,
+              reconciliationId,
+              contentHash,
+            })
+          })
+          return makeDecision(cycle, observedAt, undefined, {
+            planningBrokerStateHash: canonicalHashV1({ accountHash, positionsHash, ordersHash }),
+            reconciliationId,
+            reconciliationHash: contentHash,
+          })
+        }).pipe(
+          Effect.mapError(
+            (cause) =>
+              new CycleDecisionBuildError({
+                failure: 'market-data',
+                message: 'deterministic same-pass broker reconciliation failed',
+                cause,
+              }),
+          ),
+        ),
+    }
+    const durableStore = cycleStore(control, persistence)
+    const dueStore: CycleStoreShape = {
+      ...durableStore,
+      bindSnapshot: (cycleId, manifest, observedAt) =>
+        durableStore
+          .bindSnapshot(cycleId, manifest, observedAt)
+          .pipe(Effect.tap((receipt) => TestClock.setTime(Date.parse(receipt.cycle.window.submissionOpenAt)))),
+    }
+    const runOnePass = (store: CycleStoreShape) =>
+      Effect.scoped(
+        Effect.gen(function* () {
+          const observed = yield* Deferred.make<CyclePassObservation>()
+          const loop = yield* cycleLoop({
+            context: Effect.succeed(dueContext),
+            observePass: (observation) =>
+              Effect.sync(() => observations.push(observation)).pipe(
+                Effect.andThen(Deferred.succeed(observed, observation)),
+                Effect.asVoid,
+              ),
+            pollIntervalMs: 60_000,
+          })
+          const fiber = yield* provide(loop, read, store, marketData).pipe(
+            Effect.provideService(BrokerMutation, mutation),
+            Effect.forkScoped({ startImmediately: true }),
+          )
+          const observation = yield* Deferred.await(observed)
+          yield* Fiber.interrupt(fiber)
+          return observation
+        }),
+      )
+
+    const proof = await Effect.runPromise(
+      Effect.gen(function* () {
+        yield* TestClock.setTime(Date.parse(discoveryAt))
+        const completed = yield* runOnePass(dueStore)
+        const restarted = yield* runOnePass(cycleStore(control, persistence))
+        return { completed, restarted }
+      }).pipe(Effect.provide(TestClock.layer())),
+    )
+
+    expect(isMonthEndCycleDue('2026-01-30', '2026-02-02')).toBe(true)
+    expect(control.acquisitions).toHaveLength(1)
+    expect(control.acquisitions[0]).toMatchObject({
+      observedAt: discoveryAt,
+      draft: {
+        identity: {
+          qualificationRunId: dueContext.qualificationRunId,
+          strategyProtocolHash: dueContext.strategyProtocolHash,
+          accountId,
+          signalSessionDate: '2026-01-30',
+          executionSessionDate: '2026-02-02',
         },
       },
     })
+    expect(proof.completed).toMatchObject({
+      outcome: 'SUCCEEDED',
+      observedAt: submissionOpenAt,
+      result: {
+        outcome: 'RECOVERED',
+        action: 'NO_TRADE',
+        cycle: {
+          state: CycleState.NoTrade,
+          bindings: { snapshotId, decisionHash: expect.any(String) },
+          terminalAt: submissionOpenAt,
+        },
+      },
+    })
+    expect(proof.restarted).toMatchObject({
+      outcome: 'SUCCEEDED',
+      observedAt: submissionOpenAt,
+      result: {
+        outcome: 'ALREADY_TERMINAL',
+        signalSessionDate: '2026-01-30',
+        cycle: { state: CycleState.NoTrade },
+      },
+    })
+    expect(observations).toEqual([proof.completed, proof.restarted])
+    expect(persistence.cycles).toHaveLength(1)
+    expect(persistence.manifests).toHaveLength(1)
+    expect(persistence.documents).toHaveLength(1)
+    expect(reconciliations).toHaveLength(1)
+    const durableCycle = [...persistence.cycles.values()][0]
+    if (durableCycle === undefined) throw new Error('due-cycle proof did not persist its cycle')
+    const durableManifest = persistence.manifests.get(durableCycle.identity.cycleId)
+    const durableDecision = persistence.documents.get(durableCycle.identity.cycleId)
+    const durableReconciliation = reconciliations.get(durableCycle.identity.cycleId)
+    expect(durableCycle).toMatchObject({
+      state: CycleState.NoTrade,
+      stateVersion: 5,
+      bindings: { snapshotId, decisionHash: durableDecision?.contentHash },
+    })
+    expect(durableManifest?.finalizedSnapshot.snapshotId).toBe(snapshotId)
+    expect(durableDecision).toMatchObject({
+      mode: 'OBSERVE',
+      dispatchable: false,
+      bindings: {
+        cycleId: durableCycle.identity.cycleId,
+        snapshotId,
+        reconciliationId: durableReconciliation?.reconciliationId,
+        reconciliationHash: durableReconciliation?.contentHash,
+      },
+      targetPlan: { status: TargetPlanStatus.NoTrade, intentTargets: [] },
+      createdAt: submissionOpenAt,
+    })
+    expect(durableReconciliation).toMatchObject({
+      cycleId: durableCycle.identity.cycleId,
+      snapshotId,
+      accountId,
+      observedAt: submissionOpenAt,
+      authority: 'OBSERVE',
+      brokerOrderCount: 0,
+    })
+    expect(calendarReads).toBe(1)
+    expect(publicationDiscoveries).toBe(2)
+    expect(exactSnapshotReads).toBe(1)
+    expect(accountReads).toBe(1)
+    expect(positionReads).toBe(1)
+    expect(orderReads).toBe(1)
+    expect(control.binds).toBe(1)
+    expect(mutationSubmits).toBe(0)
+    expect(mutationCancels).toBe(0)
   })
 
   test('scope closure interrupts in-flight publication discovery', async () => {
@@ -2152,6 +2498,7 @@ describe('autonomous cycle runner', () => {
     let contextLoads = 0
     const logs: Array<{ readonly message: unknown; readonly annotations: Record<string, unknown> }> = []
     const observations: CyclePassObservation[] = []
+    const secondPassObserved = await Effect.runPromise(Deferred.make<void>())
     const logger = Logger.make<unknown, void>((options) => {
       logs.push({
         message: options.message,
@@ -2166,19 +2513,25 @@ describe('autonomous cycle runner', () => {
             contextLoads += 1
             return contextLoads === 1 ? Effect.fail(contextFailure) : Effect.succeed(context())
           }),
-          observePass: (observation) => Effect.sync(() => observations.push(observation)),
+          observePass: (observation) =>
+            Effect.sync(() => observations.push(observation)).pipe(
+              Effect.flatMap((count) =>
+                count === 2 ? Deferred.succeed(secondPassObserved, undefined).pipe(Effect.asVoid) : Effect.void,
+              ),
+            ),
           pollIntervalMs: 100,
         })
         const fiber = yield* provide(
           loop,
           brokerRead(() => Effect.succeed({ value: monthEndCalendar, evidence })),
           cycleStore(control),
-          marketDataService(Effect.succeed(finalizedPublication())),
+          marketDataService(Effect.succeed(finalizedPublication()), finalizedPublicationInspection()),
         ).pipe(Effect.forkScoped({ startImmediately: true }))
         yield* Effect.yieldNow
         expect(contextLoads).toBe(1)
         expect(control.acquisitions).toEqual([])
         yield* TestClock.adjust(100)
+        yield* Deferred.await(secondPassObserved)
         expect(contextLoads).toBe(2)
         expect(control.acquisitions).toHaveLength(1)
         yield* Fiber.interrupt(fiber)
@@ -2209,7 +2562,7 @@ describe('autonomous cycle runner', () => {
     expect(observations[1]).toMatchObject({
       outcome: 'SUCCEEDED',
       observedAt: '2026-01-30T21:20:00.100Z',
-      result: { outcome: 'ACQUIRED' },
+      result: { outcome: 'RECOVERED', action: 'WAITING' },
     })
     expect(control.binds).toBe(1)
   })
@@ -2221,7 +2574,7 @@ describe('autonomous cycle runner', () => {
     const exit = await Effect.runPromise(
       Effect.scoped(
         Effect.gen(function* () {
-          const loop = yield* cycleLoop({
+          const loop = yield* cycleLoop<never, never, never>({
             context: Effect.die(defect),
             observePass: (observation) => Effect.sync(() => observations.push(observation)),
             pollIntervalMs: 100,
@@ -2249,7 +2602,7 @@ describe('autonomous cycle runner', () => {
     await Effect.runPromise(
       Effect.scoped(
         Effect.gen(function* () {
-          const loop = yield* cycleLoop({
+          const loop = yield* cycleLoop<Error, never, never>({
             context: Effect.fail(contextFailure),
             observePass: ignorePass,
             pollIntervalMs: 100,

--- a/services/bayn/src/cycle-runner/decisions.ts
+++ b/services/bayn/src/cycle-runner/decisions.ts
@@ -33,3 +33,4 @@ export {
   validateCycleLoopInterval,
   type CyclePassLogFacts,
 } from './pass-decisions'
+export { selectCyclePassContinuation, type CyclePassContinuation, type CyclePassProgress } from './pass-continuation'

--- a/services/bayn/src/cycle-runner/loop.ts
+++ b/services/bayn/src/cycle-runner/loop.ts
@@ -13,7 +13,7 @@ import {
   type CycleRunnerError,
   type CycleRunResult,
 } from './model'
-import { runAutonomousCyclePass } from './program'
+import { runAutonomousCycleUntilSettled } from './program'
 
 const logCyclePass = (observation: CyclePassObservation): Effect.Effect<void> => {
   const facts = cyclePassLogFacts(observation)
@@ -28,7 +28,7 @@ const runLoopPass = <E, ContextR, DecisionR>(
     Effect.mapError((cause) =>
       runnerError('load-context', 'context', 'autonomous cycle context loading failed', cause),
     ),
-    Effect.flatMap(runAutonomousCyclePass),
+    Effect.flatMap(runAutonomousCycleUntilSettled),
     Effect.withLogSpan('autonomous-cycle'),
   )
 

--- a/services/bayn/src/cycle-runner/pass-continuation.ts
+++ b/services/bayn/src/cycle-runner/pass-continuation.ts
@@ -1,0 +1,48 @@
+import type { AutonomousCycle } from '../cycle'
+import type { CycleRunResult } from './model'
+
+export type CyclePassProgress = 'ACTIVATED' | 'DECISION_BOUND' | 'DISCOVERED_EXISTING' | 'SNAPSHOT_BOUND'
+
+export type CyclePassContinuation =
+  | { readonly _tag: 'RETURN' }
+  | {
+      readonly _tag: 'CONTINUE'
+      readonly cycle: AutonomousCycle
+      readonly progress: CyclePassProgress
+    }
+
+const continueFromReadiness = (
+  result: Extract<CycleRunResult, { readonly outcome: 'ACQUIRED' | 'REACQUIRED' | 'RESUMED' }>,
+): CyclePassContinuation =>
+  result.readiness.outcome === 'BOUND' || result.readiness.outcome === 'ALREADY_BOUND'
+    ? { _tag: 'CONTINUE', cycle: result.readiness.cycle, progress: 'SNAPSHOT_BOUND' }
+    : { _tag: 'RETURN' }
+
+export const selectCyclePassContinuation = (result: CycleRunResult): CyclePassContinuation => {
+  switch (result.outcome) {
+    case 'ACQUIRED':
+    case 'REACQUIRED':
+    case 'RESUMED':
+      return continueFromReadiness(result)
+    case 'ALREADY_ACQUIRED':
+      return { _tag: 'CONTINUE', cycle: result.cycle, progress: 'DISCOVERED_EXISTING' }
+    case 'RECOVERED':
+      switch (result.action) {
+        case 'BOUND_SNAPSHOT':
+          return { _tag: 'CONTINUE', cycle: result.cycle, progress: 'SNAPSHOT_BOUND' }
+        case 'ACTIVATED':
+          return { _tag: 'CONTINUE', cycle: result.cycle, progress: 'ACTIVATED' }
+        case 'BOUND_DECISION':
+          return { _tag: 'CONTINUE', cycle: result.cycle, progress: 'DECISION_BOUND' }
+        case 'BLOCKED':
+        case 'COMPLETED':
+        case 'NO_TRADE':
+        case 'WAITING':
+          return { _tag: 'RETURN' }
+      }
+    case 'ALREADY_TERMINAL':
+    case 'NO_PUBLICATION':
+    case 'NOT_DUE':
+      return { _tag: 'RETURN' }
+  }
+}

--- a/services/bayn/src/cycle-runner/program.ts
+++ b/services/bayn/src/cycle-runner/program.ts
@@ -22,11 +22,13 @@ import {
   readinessFailure,
   reduceCycleAuthoritySelection,
   selectCycleCalendarCandidate,
+  selectCyclePassContinuation,
   selectDiscoveredPublications,
   type CycleAcquireMaterial,
   type CycleAuthoritySelection,
   type CycleAuthoritySelectionState,
   type CycleAuthoritySlot,
+  type CyclePassProgress,
   type NonEmptyPublications,
 } from './decisions'
 import {
@@ -459,3 +461,43 @@ export const runAutonomousCyclePass = <R>(
       ),
     ),
   )
+
+const cycleProgressKey = (cycle: AutonomousCycle): string =>
+  `${cycle.identity.cycleId}:${cycle.state}:${cycle.stateVersion}`
+
+const continueAutonomousCyclePass = <R>(
+  context: CycleRunContext<R>,
+  completedProgress: ReadonlySet<CyclePassProgress>,
+  previousProgressKey?: string,
+): Effect.Effect<CycleRunResult, CycleRunnerError, BrokerRead | CycleStore | MarketData | R> =>
+  runAutonomousCyclePass(context).pipe(
+    Effect.flatMap((result) => {
+      const continuation = selectCyclePassContinuation(result)
+      if (continuation._tag === 'RETURN') return Effect.succeed(result)
+      const progressKey = cycleProgressKey(continuation.cycle)
+      if (progressKey === previousProgressKey) {
+        return Effect.fail(
+          runnerError(
+            'recover-cycle',
+            'contract',
+            `autonomous cycle pass repeated ${continuation.progress} without durable progress`,
+          ),
+        )
+      }
+      if (completedProgress.has(continuation.progress)) {
+        return Effect.fail(
+          runnerError(
+            'recover-cycle',
+            'contract',
+            `autonomous cycle pass repeated ${continuation.progress} after durable progress`,
+          ),
+        )
+      }
+      return continueAutonomousCyclePass(context, new Set([...completedProgress, continuation.progress]), progressKey)
+    }),
+  )
+
+export const runAutonomousCycleUntilSettled = <R>(
+  context: CycleRunContext<R>,
+): Effect.Effect<CycleRunResult, CycleRunnerError, BrokerRead | CycleStore | MarketData | R> =>
+  continueAutonomousCyclePass(context, new Set())

--- a/services/bayn/src/db/cycle-store/integration.test.ts
+++ b/services/bayn/src/db/cycle-store/integration.test.ts
@@ -2,11 +2,18 @@ import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:tes
 
 import { NodeServices } from '@effect/platform-node'
 import { PgClient, PgMigrator } from '@effect/sql-pg'
-import { Cause, Effect, Exit, Layer, ManagedRuntime, Option, Redacted, Result } from 'effect'
+import { Cause, Deferred, Effect, Exit, Layer, ManagedRuntime, Option, Redacted, Result } from 'effect'
 import { TestClock } from 'effect/testing'
 
-import { BrokerRead, type BrokerReadShape, type MarketCalendarObservation } from '../../broker/alpaca'
+import {
+  AccountStatus as BrokerAccountStatus,
+  BrokerRead,
+  type BrokerReadShape,
+  type MarketCalendarObservation,
+  type ReadEvidence,
+} from '../../broker/alpaca'
 import { unusedAssetBySymbol } from '../../broker/alpaca-test-support'
+import type { RuntimeConfig } from '../../config'
 import {
   CycleState,
   CycleTerminalReason,
@@ -18,23 +25,46 @@ import {
   type CycleDraft,
 } from '../../cycle'
 import {
+  CycleDecisionBuildError,
   makeDueCycleDraft,
   runAutonomousCyclePass,
   selectNextExecutionSession,
   type CycleRunContext,
   type CycleRunResult,
 } from '../../cycle-runner'
+import { runAutonomousCycleUntilSettled } from '../../cycle-runner/program'
+import { AuthorityGenerationStore, ExecutionStoreLive } from '../execution-store'
+import { WriterFenceLive } from '../../execution/writer-fence'
 import { canonicalHashV1, sha256 } from '../../hash'
+import { Journal, type JournalService } from '../../ledger'
 import {
   MarketData,
   type FinalizedPublicationInspection,
   type MarketDataService,
   type SignalSessionRow,
 } from '../../market-data'
-import { ReconciliationStatus } from '../../execution/contracts'
+import {
+  buildObserveCycleDecision,
+  loadObserveRiskPolicy,
+  prepareObserveStartup,
+  type ObserveDecisionFailure,
+} from '../../observe-composition'
+import { Authority, ReconciliationStatus } from '../../execution/contracts'
+import { runOnce } from '../../reconciler'
 import { makeObserveShadowDecisionDocument } from '../../shadow-decision-contract'
+import { makeStrategy } from '../../strategy'
 import { TargetPlanReason, TargetPlanStatus } from '../../target-planner'
-import { DataFeed, DataSource, PriceAdjustment, PublicationSchema, type InputManifest, type IsoDate } from '../../types'
+import { fixtureProtocol, makeSnapshot, makeTestProvenance } from '../../test-fixtures'
+import {
+  DataFeed,
+  DataSource,
+  PriceAdjustment,
+  PublicationSchema,
+  type DailyBar,
+  type InputManifest,
+  type IsoDate,
+  type Protocol,
+} from '../../types'
 import { PostgresClientLive } from '../evidence-store'
 import { migrationLoader } from '../migrations'
 import { CycleStore, CycleStoreLive, type CycleStoreShape } from '.'
@@ -60,6 +90,588 @@ const makeRuntime = () =>
   ManagedRuntime.make(
     CycleStoreLive.pipe(Layer.provideMerge(PostgresClientLive(databaseConfig)), Layer.provideMerge(NodeServices.layer)),
   )
+
+const dueAccountId = '13354000-0000-4000-8000-000000000054'
+const dueAuthorityGenerationHash = '5'.repeat(64)
+const dueSignalDate = '2099-12-31' as const
+const dueExecutionDate = '2100-01-04' as const
+const dueHistoryStart = '2089-06-03' as const
+const dueEvaluationStart = '2090-06-05' as const
+const dueAcquisitionAt = '2099-12-31T21:01:02.000Z'
+const dueObservedAt = '2100-01-04T13:45:02.000Z'
+const dueSnapshotId = '4'.repeat(64)
+
+const dueProtocol: Protocol = {
+  ...fixtureProtocol,
+  historyStart: dueHistoryStart,
+  evaluationStart: dueEvaluationStart,
+}
+const dueStrategy = makeStrategy(dueProtocol, makeTestProvenance(dueProtocol))
+
+const autonomousRuntimeConfig: RuntimeConfig = {
+  host: '127.0.0.1',
+  port: 0,
+  maximumAuthority: Authority.Observe,
+  build: {
+    sourceRevision: '1'.repeat(40),
+    imageRepository: 'registry.example.test/lab/bayn',
+    imageDigest: `sha256:${'2'.repeat(64)}`,
+    strategyBehaviorHash: dueStrategy.provenance.strategy.behaviorHash,
+    strategyParameterHash: dueStrategy.provenance.strategy.parameterHash,
+    verification: 'embedded',
+  },
+  healthIntervalMs: 30_000,
+  operationTimeoutMs: databaseConfig.operationTimeoutMs,
+  cycleStallThresholdMs: 300_000,
+  reconciliationStaleThresholdMs: 120_000,
+  unknownMutationThresholdMs: 300_000,
+  clickhouse: {
+    url: 'http://clickhouse.invalid',
+    username: 'bayn',
+    password: Redacted.make('unused'),
+    snapshotId: dueSnapshotId,
+    publicationAsOf: dueSignalDate,
+    calendarVersion: 'fixture-calendar-v2',
+    bounds: {
+      schemaVersion: 'bayn.evaluation-bounds.v1',
+      dataStart: dueHistoryStart,
+      dataEnd: dueSignalDate,
+      lookbackStart: dueHistoryStart,
+      evaluationStart: dueEvaluationStart,
+      evaluationEnd: dueSignalDate,
+    },
+  },
+  postgres: databaseConfig.postgres,
+  tigerBeetle: { clusterId: 2_001n, replicaAddresses: ['127.0.0.1:3000'], ledger: 7_001 },
+}
+
+const autonomousJournal: JournalService = {
+  post: () => Effect.void,
+  verifyAccount: () => Effect.succeed(true),
+  journalAndReconcile: () => Effect.die(new Error('autonomous OBSERVE proof must not run simulation journaling')),
+  check: Effect.void,
+  checkRun: () => Effect.void,
+}
+
+const makeAutonomousRuntime = () =>
+  ManagedRuntime.make(
+    Layer.mergeAll(CycleStoreLive, ExecutionStoreLive(autonomousRuntimeConfig)).pipe(
+      Layer.provideMerge(WriterFenceLive),
+      Layer.provideMerge(Layer.succeed(Journal, autonomousJournal)),
+      Layer.provideMerge(PostgresClientLive(autonomousRuntimeConfig)),
+      Layer.provide(NodeServices.layer),
+    ),
+  )
+
+const weekdaySessions = (start: IsoDate, count: number): readonly IsoDate[] => {
+  const sessions: IsoDate[] = []
+  const cursor = new Date(`${start}T00:00:00.000Z`)
+  while (sessions.length < count) {
+    const day = cursor.getUTCDay()
+    if (day !== 0 && day !== 6) sessions.push(cursor.toISOString().slice(0, 10) as IsoDate)
+    cursor.setUTCDate(cursor.getUTCDate() + 1)
+  }
+  return sessions
+}
+
+const dueBaseSnapshot = makeSnapshot(2_760)
+const dueBaseSessionDates = [...new Set(dueBaseSnapshot.bars.map((bar) => bar.sessionDate))].sort()
+const dueSessionDates = weekdaySessions(dueHistoryStart, dueBaseSessionDates.length)
+if (
+  dueSessionDates.at(-1) !== dueSignalDate ||
+  dueSessionDates[dueBaseSessionDates.indexOf(fixtureProtocol.evaluationStart)] !== dueEvaluationStart
+) {
+  throw new Error('autonomous due-cycle fixture calendar does not match its deterministic protocol dates')
+}
+const dueSessionByBaseSession = new Map(dueBaseSessionDates.map((session, index) => [session, dueSessionDates[index]]))
+const dueBars: readonly DailyBar[] = dueBaseSnapshot.bars.map((bar) => {
+  const sessionDate = dueSessionByBaseSession.get(bar.sessionDate)
+  if (sessionDate === undefined) throw new Error(`missing shifted session for ${bar.sessionDate}`)
+  return { ...bar, sessionDate }
+})
+const { hash: _dueSourceManifestHash, ...dueSourceManifestMaterial } = dueBaseSnapshot.manifest
+const dueManifestMaterial: Omit<InputManifest, 'hash'> = {
+  ...dueSourceManifestMaterial,
+  bounds: {
+    ...dueSourceManifestMaterial.bounds,
+    dataStart: dueHistoryStart,
+    dataEnd: dueSignalDate,
+    lookbackStart: dueHistoryStart,
+    evaluationStart: dueEvaluationStart,
+    evaluationEnd: dueSignalDate,
+  },
+  firstSession: dueHistoryStart,
+  lastSession: dueSignalDate,
+  symbols: dueSourceManifestMaterial.symbols.map((symbol) => ({
+    ...symbol,
+    firstSession: dueHistoryStart,
+    lastSession: dueSignalDate,
+  })),
+  finalizedSnapshot: {
+    ...dueSourceManifestMaterial.finalizedSnapshot,
+    snapshotId: dueSnapshotId,
+    publicationId: '3'.repeat(64),
+    finalizedAt: '2099-12-31T21:01:00.000Z',
+    requestedStart: dueHistoryStart,
+    firstSession: dueHistoryStart,
+    lastSession: dueSignalDate,
+    asOfSession: dueSignalDate,
+  },
+}
+const dueManifest: InputManifest = {
+  ...dueManifestMaterial,
+  hash: canonicalHashV1(dueManifestMaterial),
+}
+const duePublication = (): Extract<FinalizedPublicationInspection, { readonly outcome: 'FINALIZED' }> => ({
+  outcome: 'FINALIZED',
+  observedAt: '2099-12-31T21:01:00.000Z',
+  inspection: {
+    manifest: dueManifest,
+    sessionDates: dueSessionDates,
+    signalSession: {
+      calendar_version: dueManifest.finalizedSnapshot.calendarVersion,
+      session_date: dueSignalDate,
+      close_time: '16:00',
+      timezone: 'America/New_York',
+    },
+  },
+})
+
+const dueCalendarMaterial = {
+  schemaVersion: 'bayn.alpaca-market-calendar-observation.v1' as const,
+  source: 'alpaca-v2-calendar' as const,
+  requestedRange: { start: dueSignalDate, end: '2100-01-30' },
+  timeZone: 'UTC' as const,
+  sessions: [
+    {
+      date: dueSignalDate,
+      openAt: '2099-12-31T14:30:00.000Z',
+      closeAt: '2099-12-31T21:00:00.000Z',
+    },
+    {
+      date: dueExecutionDate,
+      openAt: '2100-01-04T14:30:00.000Z',
+      closeAt: '2100-01-04T21:00:00.000Z',
+    },
+  ],
+}
+const dueCalendar: MarketCalendarObservation = {
+  ...dueCalendarMaterial,
+  normalizedResponseHash: canonicalHashV1(dueCalendarMaterial),
+}
+
+interface DueIoControl {
+  accountReads: number
+  calendarReads: number
+  discoveryReads: number
+  fillReads: number
+  orderReads: number
+  positionReads: number
+  publicationReads: number
+  snapshotLoads: number
+}
+
+const makeDueIoControl = (): DueIoControl => ({
+  accountReads: 0,
+  calendarReads: 0,
+  discoveryReads: 0,
+  fillReads: 0,
+  orderReads: 0,
+  positionReads: 0,
+  publicationReads: 0,
+  snapshotLoads: 0,
+})
+
+const dueReadEvidence = (identity: string, observedAt = dueObservedAt): ReadEvidence => ({
+  requestId: `pr13354-${identity}`,
+  status: 200,
+  contentHash: canonicalHashV1({ identity }),
+  observedAt,
+})
+
+const dueBrokerRead = (control: DueIoControl): BrokerReadShape => {
+  const unused = Effect.die(new Error('autonomous durability proof used an unrelated broker capability'))
+  return {
+    account: Effect.sync(() => {
+      control.accountReads += 1
+      return {
+        value: {
+          id: dueAccountId,
+          status: BrokerAccountStatus.Active,
+          currency: 'USD',
+          cashMicros: '1000000000',
+          equityMicros: '1000000000',
+          buyingPowerMicros: '1000000000',
+          accountBlocked: false,
+          tradingBlocked: false,
+          tradeSuspendedByUser: false,
+          observedAt: dueObservedAt,
+        },
+        evidence: dueReadEvidence('account'),
+      }
+    }),
+    accountConfiguration: unused,
+    assetBySymbol: unusedAssetBySymbol,
+    positions: Effect.sync(() => {
+      control.positionReads += 1
+      return { value: [], evidence: dueReadEvidence('positions') }
+    }),
+    orders: () =>
+      Effect.sync(() => {
+        control.orderReads += 1
+        return { value: [], evidence: dueReadEvidence('orders') }
+      }),
+    orderById: () => unused,
+    orderByClientId: () => unused,
+    fillActivities: () =>
+      Effect.sync(() => {
+        control.fillReads += 1
+        return { value: { items: [] }, evidence: dueReadEvidence('fills') }
+      }),
+    marketCalendar: (query) =>
+      Effect.sync(() => {
+        control.calendarReads += 1
+        if (query.start !== dueSignalDate || query.end !== dueCalendar.requestedRange.end) {
+          throw new Error(`unexpected autonomous calendar query ${query.start}..${query.end}`)
+        }
+        return {
+          value: dueCalendar,
+          evidence: dueReadEvidence(
+            `calendar-${control.calendarReads}`,
+            control.calendarReads === 1 ? dueAcquisitionAt : dueObservedAt,
+          ),
+        }
+      }),
+  }
+}
+
+const dueMarketData = (control: DueIoControl, boundPublicationBoundary = Effect.void): MarketDataService => {
+  const unused = Effect.die(new Error('autonomous durability proof used an unrelated market-data capability'))
+  const inspectPublication = () =>
+    Effect.sync(() => {
+      control.publicationReads += 1
+      return duePublication()
+    })
+  const inspectSnapshotPublication = () =>
+    Effect.sync(() => {
+      control.publicationReads += 1
+    }).pipe(Effect.andThen(boundPublicationBoundary), Effect.as(duePublication()))
+  return {
+    check: unused,
+    inspect: unused,
+    inspectCyclePublications: Effect.sync(() => {
+      control.discoveryReads += 1
+      const publication = duePublication()
+      return {
+        outcome: 'FINALIZED' as const,
+        observedAt: publication.observedAt,
+        publications: [publication.inspection],
+      }
+    }),
+    inspectPublication,
+    inspectSnapshotPublication,
+    loadSnapshotPublication: (request) =>
+      Effect.sync(() => {
+        control.snapshotLoads += 1
+        if (
+          request.snapshotId !== dueSnapshotId ||
+          request.signalSessionDate !== dueSignalDate ||
+          request.signalCalendarVersion !== dueManifest.finalizedSnapshot.calendarVersion
+        ) {
+          throw new Error('autonomous snapshot reload did not use the immutable cycle binding')
+        }
+        return { bars: dueBars, manifest: dueManifest }
+      }),
+    load: unused,
+  }
+}
+
+const observeFailureToCycleDecision = (cause: ObserveDecisionFailure): CycleDecisionBuildError => {
+  const failure =
+    cause._tag === 'OperationalError'
+      ? cause.component === 'database'
+        ? 'database'
+        : cause.component === 'market-data'
+          ? 'market-data'
+          : 'operational'
+      : 'contract'
+  const message =
+    cause._tag === 'CycleCalendarQueryRangeOutOfRange'
+      ? 'cycle decision calendar query construction failed'
+      : cause.message
+  return new CycleDecisionBuildError({ failure, message, cause })
+}
+
+const makeProductionDueContext = Effect.gen(function* () {
+  const preparation = yield* Effect.fromResult(
+    prepareObserveStartup({
+      accountId: dueAccountId,
+      authorityGenerationHash: dueAuthorityGenerationHash,
+      maximumAuthority: Authority.Observe,
+      pollIntervalMs: 30_000,
+      strategy: dueStrategy,
+    }),
+  )
+  const policy = yield* loadObserveRiskPolicy(dueAccountId, dueProtocol.universe)
+  return {
+    qualificationRunId: '6'.repeat(64),
+    strategyProtocolHash: preparation.strategyProtocolHash,
+    accountId: dueAccountId,
+    executionPolicy: preparation.executionPolicy,
+    buildDecision: (cycle) =>
+      buildObserveCycleDecision({
+        authorityGenerationHash: dueAuthorityGenerationHash,
+        cycle,
+        executionModel: preparation.executionModel,
+        policy,
+        reconcile: runOnce,
+        strategy: dueStrategy,
+      }).pipe(Effect.mapError(observeFailureToCycleDecision)),
+  } satisfies CycleRunContext<
+    | BrokerRead
+    | MarketData
+    | import('../execution-store').BrokerEventStore
+    | import('../execution-store').FillAccountingStore
+    | import('../execution-store').ValuationStore
+    | import('../execution-store').ReconciliationStore
+    | import('../execution-store').AuthorityRestrictionStore
+    | import('../../execution/writer-fence').WriterFence
+  >
+})
+
+const ensureDueObserveAuthority = AuthorityGenerationStore.pipe(
+  Effect.flatMap((store) =>
+    store.ensureAuthorityGeneration({
+      generationHash: dueAuthorityGenerationHash,
+      maximum: Authority.Observe,
+    }),
+  ),
+)
+
+interface DueDurabilityRows {
+  readonly counts: {
+    readonly brokerEvents: number
+    readonly brokerOrderEvents: number
+    readonly brokerOrders: number
+    readonly cycles: number
+    readonly distinctBrokerEvents: number
+    readonly distinctReconciliations: number
+    readonly distinctShadowDecisions: number
+    readonly distinctSnapshots: number
+    readonly intents: number
+    readonly mutationEvents: number
+    readonly reconciliations: number
+    readonly riskDecisions: number
+    readonly shadowDecisions: number
+    readonly snapshots: number
+    readonly unfinishedCycles: number
+  }
+  readonly cycle:
+    | {
+        readonly cycle_id: string
+        readonly decision_hash: string | null
+        readonly snapshot_id: string | null
+        readonly state: string
+        readonly terminal_at: Date | null
+      }
+    | undefined
+  readonly reconciliation:
+    | {
+        readonly content_hash: string
+        readonly reconciliation_id: string
+        readonly status: string
+      }
+    | undefined
+  readonly shadow:
+    | {
+        readonly cycle_id: string
+        readonly decision_hash: string
+        readonly document: unknown
+      }
+    | undefined
+  readonly snapshot:
+    | {
+        readonly manifest: unknown
+        readonly snapshot_id: string
+      }
+    | undefined
+}
+
+const readDueDurabilityRows = Effect.gen(function* () {
+  const sql = yield* PgClient.PgClient
+  const [counts] = yield* sql<DueDurabilityRows['counts']>`
+    SELECT
+      (SELECT count(*)::integer FROM autonomous_cycles WHERE account_id = ${dueAccountId}) AS "cycles",
+      (
+        SELECT count(*)::integer
+        FROM autonomous_cycles
+        WHERE account_id = ${dueAccountId}
+          AND state NOT IN (${CycleState.NoTrade}, ${CycleState.Completed}, ${CycleState.Blocked})
+      ) AS "unfinishedCycles",
+      (SELECT count(*)::integer FROM snapshot_references WHERE snapshot_id = ${dueSnapshotId}) AS "snapshots",
+      (
+        SELECT count(DISTINCT snapshot_id)::integer
+        FROM snapshot_references
+        WHERE snapshot_id = ${dueSnapshotId}
+      ) AS "distinctSnapshots",
+      (
+        SELECT count(*)::integer
+        FROM autonomous_cycle_shadow_decisions AS decision
+        JOIN autonomous_cycles AS cycle USING (cycle_id)
+        WHERE cycle.account_id = ${dueAccountId}
+      ) AS "shadowDecisions",
+      (
+        SELECT count(DISTINCT decision.decision_hash)::integer
+        FROM autonomous_cycle_shadow_decisions AS decision
+        JOIN autonomous_cycles AS cycle USING (cycle_id)
+        WHERE cycle.account_id = ${dueAccountId}
+      ) AS "distinctShadowDecisions",
+      (SELECT count(*)::integer FROM reconciliations WHERE account_id = ${dueAccountId}) AS "reconciliations",
+      (
+        SELECT count(DISTINCT content_hash)::integer
+        FROM reconciliations
+        WHERE account_id = ${dueAccountId}
+      ) AS "distinctReconciliations",
+      (SELECT count(*)::integer FROM intents WHERE account_id = ${dueAccountId}) AS "intents",
+      (
+        SELECT count(*)::integer
+        FROM risk_decisions AS decision
+        JOIN intents AS intent USING (intent_id)
+        WHERE intent.account_id = ${dueAccountId}
+      ) AS "riskDecisions",
+      (
+        SELECT count(*)::integer
+        FROM mutation_events AS mutation
+        JOIN intents AS intent USING (intent_id)
+        WHERE intent.account_id = ${dueAccountId}
+      ) AS "mutationEvents",
+      (SELECT count(*)::integer FROM orders WHERE account_id = ${dueAccountId}) AS "brokerOrders",
+      (
+        SELECT count(*)::integer
+        FROM broker_events
+        WHERE account_id = ${dueAccountId} AND event_kind = 'ORDER'
+      ) AS "brokerOrderEvents",
+      (SELECT count(*)::integer FROM broker_events WHERE account_id = ${dueAccountId}) AS "brokerEvents",
+      (
+        SELECT count(DISTINCT event_id)::integer
+        FROM broker_events
+        WHERE account_id = ${dueAccountId}
+      ) AS "distinctBrokerEvents"
+  `
+  if (counts === undefined) return yield* Effect.die(new Error('durability count query returned no row'))
+  const [cycle] = yield* sql<NonNullable<DueDurabilityRows['cycle']>>`
+    SELECT cycle_id, state, snapshot_id, decision_hash, terminal_at
+    FROM autonomous_cycles
+    WHERE account_id = ${dueAccountId}
+  `
+  const [snapshot] = yield* sql<NonNullable<DueDurabilityRows['snapshot']>>`
+    SELECT snapshot_id, manifest
+    FROM snapshot_references
+    WHERE snapshot_id = ${dueSnapshotId}
+  `
+  const [shadow] = yield* sql<NonNullable<DueDurabilityRows['shadow']>>`
+    SELECT decision.cycle_id, decision.decision_hash, decision.document
+    FROM autonomous_cycle_shadow_decisions AS decision
+    JOIN autonomous_cycles AS cycle USING (cycle_id)
+    WHERE cycle.account_id = ${dueAccountId}
+  `
+  const [reconciliation] = yield* sql<NonNullable<DueDurabilityRows['reconciliation']>>`
+    SELECT reconciliation_id, content_hash, status
+    FROM reconciliations
+    WHERE account_id = ${dueAccountId}
+  `
+  return { counts, cycle, reconciliation, shadow, snapshot }
+})
+
+const installShadowEvidenceFailure = Effect.gen(function* () {
+  const sql = yield* PgClient.PgClient
+  yield* sql`
+    CREATE FUNCTION pr13354_reject_shadow_evidence()
+    RETURNS trigger
+    LANGUAGE plpgsql
+    AS $function$
+    BEGIN
+      RAISE EXCEPTION 'pr13354 injected shadow evidence failure';
+    END
+    $function$
+  `
+  yield* sql`
+    CREATE TRIGGER pr13354_reject_shadow_evidence
+    BEFORE INSERT ON autonomous_cycle_shadow_decisions
+    FOR EACH ROW EXECUTE FUNCTION pr13354_reject_shadow_evidence()
+  `
+})
+
+const removeShadowEvidenceFailure = Effect.gen(function* () {
+  const sql = yield* PgClient.PgClient
+  yield* sql`DROP TRIGGER pr13354_reject_shadow_evidence ON autonomous_cycle_shadow_decisions`
+  yield* sql`DROP FUNCTION pr13354_reject_shadow_evidence()`
+})
+
+const installTerminalTransitionFailure = Effect.gen(function* () {
+  const sql = yield* PgClient.PgClient
+  yield* sql`
+    CREATE FUNCTION pr13354_reject_terminal_transition()
+    RETURNS trigger
+    LANGUAGE plpgsql
+    AS $function$
+    BEGIN
+      IF OLD.state = 'ACTIVE' AND NEW.state IN ('NO_TRADE', 'COMPLETED') THEN
+        RAISE EXCEPTION 'pr13354 injected terminal transition failure';
+      END IF;
+      RETURN NEW;
+    END
+    $function$
+  `
+  yield* sql`
+    CREATE TRIGGER pr13354_reject_terminal_transition
+    BEFORE UPDATE OF state ON autonomous_cycles
+    FOR EACH ROW
+    EXECUTE FUNCTION pr13354_reject_terminal_transition()
+  `
+})
+
+const removeTerminalTransitionFailure = Effect.gen(function* () {
+  const sql = yield* PgClient.PgClient
+  yield* sql`DROP TRIGGER pr13354_reject_terminal_transition ON autonomous_cycles`
+  yield* sql`DROP FUNCTION pr13354_reject_terminal_transition()`
+})
+
+const productionDuePass = (control: DueIoControl, phase: 'ACQUIRE_AND_DUE' | 'DUE' = 'DUE') =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      yield* TestClock.setTime(Date.parse(phase === 'ACQUIRE_AND_DUE' ? dueAcquisitionAt : dueObservedAt))
+      yield* ensureDueObserveAuthority
+      if (phase === 'DUE') {
+        const context = yield* makeProductionDueContext
+        return yield* runAutonomousCycleUntilSettled(context).pipe(
+          Effect.provideService(BrokerRead, dueBrokerRead(control)),
+          Effect.provideService(MarketData, dueMarketData(control)),
+        )
+      }
+      const advanceRequested = yield* Deferred.make<void>()
+      const advanceCompleted = yield* Deferred.make<void>()
+      yield* Deferred.await(advanceRequested).pipe(
+        Effect.andThen(TestClock.setTime(Date.parse(dueObservedAt))),
+        Effect.andThen(Deferred.succeed(advanceCompleted, undefined)),
+        Effect.forkScoped,
+      )
+      const context = yield* makeProductionDueContext
+      return yield* runAutonomousCycleUntilSettled(context).pipe(
+        Effect.provideService(BrokerRead, dueBrokerRead(control)),
+        Effect.provideService(
+          MarketData,
+          dueMarketData(
+            control,
+            Deferred.succeed(advanceRequested, undefined).pipe(Effect.andThen(Deferred.await(advanceCompleted))),
+          ),
+        ),
+      )
+    }),
+  ).pipe(Effect.provide(TestClock.layer()))
+
+const runProductionDuePass = (runtime: ReturnType<typeof makeAutonomousRuntime>, control: DueIoControl) =>
+  runtime.runPromise(productionDuePass(control))
 
 const signalSession = (
   sessionDate: IsoDate,
@@ -1426,4 +2038,174 @@ describePostgres('PostgreSQL autonomous cycle store', () => {
     expect(result.decisionAtCutoff.cycle.bindings.decisionHash).toBeUndefined()
     expect(decisionDraft.window.submissionCutoffAt < decisionDraft.window.executionOpenAt).toBe(true)
   })
+
+  test('persists and replays one production OBSERVE due cycle across PostgreSQL process restart', async () => {
+    const io = makeDueIoControl()
+    const firstRuntime = makeAutonomousRuntime()
+    let restartedRuntime: ReturnType<typeof makeAutonomousRuntime> | undefined
+
+    try {
+      await firstRuntime.runPromise(installShadowEvidenceFailure)
+      const shadowFailure = await firstRuntime.runPromiseExit(productionDuePass(io, 'ACQUIRE_AND_DUE'))
+      expect(Exit.isFailure(shadowFailure)).toBe(true)
+      if (Exit.isFailure(shadowFailure)) {
+        expect(Cause.pretty(shadowFailure.cause)).toContain('pr13354 injected shadow evidence failure')
+      }
+      const afterShadowFailure = await firstRuntime.runPromise(readDueDurabilityRows)
+      expect(afterShadowFailure.counts).toMatchObject({
+        cycles: 1,
+        snapshots: 1,
+        distinctSnapshots: 1,
+        shadowDecisions: 0,
+        distinctShadowDecisions: 0,
+        reconciliations: 1,
+        distinctReconciliations: 1,
+        unfinishedCycles: 1,
+        intents: 0,
+        riskDecisions: 0,
+        mutationEvents: 0,
+        brokerOrders: 0,
+        brokerOrderEvents: 0,
+        brokerEvents: 1,
+        distinctBrokerEvents: 1,
+      })
+      expect(afterShadowFailure.cycle).toMatchObject({
+        state: CycleState.Active,
+        snapshot_id: dueSnapshotId,
+        decision_hash: null,
+        terminal_at: null,
+      })
+
+      await firstRuntime.runPromise(removeShadowEvidenceFailure)
+      await firstRuntime.runPromise(installTerminalTransitionFailure)
+      const terminalFailure = await firstRuntime.runPromiseExit(productionDuePass(io))
+      expect(Exit.isFailure(terminalFailure)).toBe(true)
+      if (Exit.isFailure(terminalFailure)) {
+        expect(Cause.pretty(terminalFailure.cause)).toContain('pr13354 injected terminal transition failure')
+      }
+      const afterTerminalFailure = await firstRuntime.runPromise(readDueDurabilityRows)
+      expect(afterTerminalFailure.counts).toMatchObject({
+        cycles: 1,
+        snapshots: 1,
+        distinctSnapshots: 1,
+        shadowDecisions: 1,
+        distinctShadowDecisions: 1,
+        reconciliations: 1,
+        distinctReconciliations: 1,
+        unfinishedCycles: 1,
+        intents: 0,
+        riskDecisions: 0,
+        mutationEvents: 0,
+        brokerOrders: 0,
+        brokerOrderEvents: 0,
+        brokerEvents: 1,
+        distinctBrokerEvents: 1,
+      })
+      expect(afterTerminalFailure.cycle).toMatchObject({
+        state: CycleState.Active,
+        snapshot_id: dueSnapshotId,
+        decision_hash: afterTerminalFailure.shadow?.decision_hash,
+        terminal_at: null,
+      })
+
+      await firstRuntime.runPromise(removeTerminalTransitionFailure)
+      const settled = await runProductionDuePass(firstRuntime, io)
+      expect(settled.outcome).toBe('RECOVERED')
+      if (settled.outcome !== 'RECOVERED') return expect.unreachable(settled.outcome)
+      expect([CycleState.NoTrade, CycleState.Completed]).toContain(settled.cycle.state)
+      expect(settled.action).toBe(
+        settled.cycle.state === CycleState.NoTrade ? CycleState.NoTrade : CycleState.Completed,
+      )
+
+      const terminalRows = await firstRuntime.runPromise(readDueDurabilityRows)
+      expect(terminalRows.counts).toEqual({
+        cycles: 1,
+        unfinishedCycles: 0,
+        snapshots: 1,
+        distinctSnapshots: 1,
+        shadowDecisions: 1,
+        distinctShadowDecisions: 1,
+        reconciliations: 1,
+        distinctReconciliations: 1,
+        intents: 0,
+        riskDecisions: 0,
+        mutationEvents: 0,
+        brokerOrders: 0,
+        brokerOrderEvents: 0,
+        brokerEvents: 1,
+        distinctBrokerEvents: 1,
+      })
+      expect(terminalRows.cycle).toMatchObject({
+        cycle_id: settled.cycle.identity.cycleId,
+        state: settled.cycle.state,
+        snapshot_id: dueSnapshotId,
+        decision_hash: terminalRows.shadow?.decision_hash,
+      })
+      expect(terminalRows.cycle?.terminal_at).not.toBeNull()
+      expect(terminalRows.snapshot).toEqual({
+        snapshot_id: dueSnapshotId,
+        manifest: dueManifest.finalizedSnapshot,
+      })
+      expect(terminalRows.reconciliation).toMatchObject({ status: ReconciliationStatus.Exact })
+      expect(terminalRows.shadow?.cycle_id).toBe(settled.cycle.identity.cycleId)
+      const shadowDocument = terminalRows.shadow?.document as
+        | {
+            readonly bindings: {
+              readonly accountId: string
+              readonly cycleId: string
+              readonly reconciliationHash: string
+              readonly reconciliationId: string
+              readonly snapshotId: string
+            }
+            readonly contentHash: string
+            readonly dispatchable: boolean
+            readonly mode: string
+            readonly targetPlan: { readonly status: string }
+          }
+        | undefined
+      expect(shadowDocument).toMatchObject({
+        mode: 'OBSERVE',
+        dispatchable: false,
+        contentHash: terminalRows.shadow?.decision_hash,
+        bindings: {
+          accountId: dueAccountId,
+          cycleId: settled.cycle.identity.cycleId,
+          snapshotId: dueSnapshotId,
+          reconciliationId: terminalRows.reconciliation?.reconciliation_id,
+          reconciliationHash: terminalRows.reconciliation?.content_hash,
+        },
+      })
+      expect(shadowDocument?.targetPlan.status).toBe(
+        settled.cycle.state === CycleState.NoTrade ? TargetPlanStatus.NoTrade : TargetPlanStatus.Planned,
+      )
+
+      const ioBeforeRestart = { ...io }
+      await firstRuntime.dispose()
+
+      restartedRuntime = makeAutonomousRuntime()
+      const restarted = await runProductionDuePass(restartedRuntime, io)
+      expect(restarted).toMatchObject({
+        outcome: 'ALREADY_TERMINAL',
+        signalSessionDate: dueSignalDate,
+        cycle: {
+          identity: { cycleId: settled.cycle.identity.cycleId },
+          state: settled.cycle.state,
+          bindings: {
+            snapshotId: dueSnapshotId,
+            decisionHash: terminalRows.shadow?.decision_hash,
+          },
+        },
+      })
+      expect(io).toEqual({
+        ...ioBeforeRestart,
+        discoveryReads: ioBeforeRestart.discoveryReads + 1,
+      })
+
+      const restartedRows = await restartedRuntime.runPromise(readDueDurabilityRows)
+      expect(restartedRows).toEqual(terminalRows)
+    } finally {
+      await firstRuntime.dispose()
+      if (restartedRuntime !== undefined) await restartedRuntime.dispose()
+    }
+  }, 30_000)
 })

--- a/services/bayn/src/db/cycle-store/integration.test.ts
+++ b/services/bayn/src/db/cycle-store/integration.test.ts
@@ -86,6 +86,95 @@ const databaseConfig = {
   postgres: { url: Redacted.make(testUrl), tls: false, caPath: '/unused' },
 }
 
+interface CommandResult {
+  readonly exitCode: number
+  readonly stderr: string
+  readonly stdout: string
+}
+
+const runCommand = async (command: readonly string[]): Promise<CommandResult> => {
+  const childProcess = Bun.spawn({ cmd: [...command], stdout: 'pipe', stderr: 'pipe' })
+  const [exitCode, stdout, stderr] = await Promise.all([
+    childProcess.exited,
+    new Response(childProcess.stdout).text(),
+    new Response(childProcess.stderr).text(),
+  ])
+  return { exitCode, stdout: stdout.trim(), stderr: stderr.trim() }
+}
+
+const requireCommand = async (command: readonly string[]): Promise<string> => {
+  const result = await runCommand(command)
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `command failed (${command.join(' ')}): ${result.stderr.length === 0 ? result.stdout : result.stderr}`,
+    )
+  }
+  return result.stdout
+}
+
+interface PostgresProcessRestartEvidence {
+  readonly containerId: string
+  readonly image: string
+  readonly startedAtBefore: string
+  readonly startedAtAfter: string
+}
+
+const restartGithubPostgres18Process = async (): Promise<PostgresProcessRestartEvidence | undefined> => {
+  if (process.env.GITHUB_ACTIONS !== 'true') return undefined
+
+  const url = new URL(testUrl)
+  const port = url.port.length === 0 ? '5432' : url.port
+  const database = url.pathname.slice(1)
+  const containers = (
+    await requireCommand(['docker', 'ps', '--filter', `publish=${port}`, '--format', '{{.ID}}\t{{.Image}}'])
+  )
+    .split('\n')
+    .filter((line) => line.length > 0)
+    .map((line) => {
+      const [containerId, image] = line.split('\t')
+      return { containerId, image }
+    })
+    .filter(
+      (entry): entry is { readonly containerId: string; readonly image: string } =>
+        entry.containerId !== undefined && entry.image !== undefined && /^postgres:18(?:-|$)/.test(entry.image),
+    )
+
+  if (containers.length !== 1) {
+    throw new Error(`expected exactly one published PostgreSQL 18 service container, found ${containers.length}`)
+  }
+  const [{ containerId, image }] = containers
+  const startedAtBefore = await requireCommand(['docker', 'inspect', '--format', '{{.State.StartedAt}}', containerId])
+
+  await requireCommand(['docker', 'restart', '--time', '0', containerId])
+  let ready = false
+  let lastReadiness = ''
+  for (let attempt = 0; attempt < 60; attempt += 1) {
+    const result = await runCommand([
+      'docker',
+      'exec',
+      containerId,
+      'pg_isready',
+      '-U',
+      decodeURIComponent(url.username),
+      '-d',
+      decodeURIComponent(database),
+    ])
+    lastReadiness = result.stderr.length === 0 ? result.stdout : result.stderr
+    if (result.exitCode === 0) {
+      ready = true
+      break
+    }
+    await Bun.sleep(250)
+  }
+  if (!ready) throw new Error(`PostgreSQL 18 did not become ready after process restart: ${lastReadiness}`)
+
+  const startedAtAfter = await requireCommand(['docker', 'inspect', '--format', '{{.State.StartedAt}}', containerId])
+  if (startedAtAfter === startedAtBefore) {
+    throw new Error('PostgreSQL 18 service container did not record a new process start')
+  }
+  return { containerId, image, startedAtBefore, startedAtAfter }
+}
+
 const makeRuntime = () =>
   ManagedRuntime.make(
     CycleStoreLive.pipe(Layer.provideMerge(PostgresClientLive(databaseConfig)), Layer.provideMerge(NodeServices.layer)),
@@ -2182,6 +2271,17 @@ describePostgres('PostgreSQL autonomous cycle store', () => {
       const ioBeforeRestart = { ...io }
       await firstRuntime.dispose()
 
+      const processRestart = await restartGithubPostgres18Process()
+      if (process.env.GITHUB_ACTIONS === 'true') {
+        expect(processRestart).toMatchObject({
+          containerId: expect.any(String),
+          image: expect.stringMatching(/^postgres:18(?:-|$)/),
+          startedAtBefore: expect.any(String),
+          startedAtAfter: expect.any(String),
+        })
+        expect(processRestart?.startedAtAfter).not.toBe(processRestart?.startedAtBefore)
+      }
+
       restartedRuntime = makeAutonomousRuntime()
       const restarted = await runProductionDuePass(restartedRuntime, io)
       expect(restarted).toMatchObject({
@@ -2207,5 +2307,5 @@ describePostgres('PostgreSQL autonomous cycle store', () => {
       await firstRuntime.dispose()
       if (restartedRuntime !== undefined) await restartedRuntime.dispose()
     }
-  }, 30_000)
+  }, 60_000)
 })


### PR DESCRIPTION
## Summary

- settle each autonomous loop pass through durable transition phases until it reaches a terminal result or a genuine wait state
- keep the existing deterministic `cycle-runner.test.ts` proof as in-memory unit evidence for pass continuation, terminal replay, and zero broker mutation
- add a separate PostgreSQL 18 integration proof that runs `runAutonomousCycleUntilSettled` through the production `CycleStoreLive`, `ExecutionStoreLive`, `WriterFenceLive`, `buildObserveCycleDecision`, and `runOnce` reconciliation composition
- use `TestClock` plus deterministic broker and market-data capabilities only at external I/O boundaries to force one explicit DUE OBSERVE pass without wall-clock waiting
- inject PostgreSQL failures at shadow-evidence insertion and terminal transition boundaries and prove fail-closed rollback before a successful retry
- dispose the first production SQL/service runtime, construct fresh layers, rerun the exact pass, and recover the existing terminal cycle without re-running reconciliation or duplicating evidence
- query durable tables to prove exactly one cycle, snapshot manifest/binding, shadow decision, reconciliation receipt, and broker observation; zero unfinished cycles, intents, risk decisions, mutation events, orders, or order events

## Evidence tiers

- **In-memory unit evidence:** `services/bayn/src/cycle-runner.test.ts` exercises deterministic runner algebra and restart behavior with a Map-backed persistence test double.
- **PostgreSQL process-restart evidence:** `services/bayn/src/db/cycle-store/integration.test.ts` exercises the production PostgreSQL interpreters and OBSERVE decision/reconciliation graph across disposed and reconstructed runtimes.

## Related Issues

None

## Testing

- PostgreSQL 18: `BAYN_TEST_POSTGRES_URL=... bun test src/db/cycle-store/integration.test.ts` — 14 passed
- PostgreSQL 18: `BAYN_TEST_POSTGRES_URL=... bun run test:postgres` — cycle observability, evidence store, paper store, and cycle store all passed
- `bun run test` — 834 passed, 123 PostgreSQL-gated skips, 0 failed
- `bun run tsc`
- `bun run lint`
- `bun run lint:effect`
- `bun run lint:oxlint`
- `bun run lint:oxlint:type`
- `bun run build`
- repository pre-commit lint-staged and commit-message hooks

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or not required for this internal regression.
