### PR TITLE
fix(bayn): make candidate development walk-forward feasible

### DIFF
--- a/services/bayn/src/candidate-development.test.ts
+++ b/services/bayn/src/candidate-development.test.ts
@@ -367,6 +367,16 @@ describe('candidate development walk-forward protocol', () => {
         signalDate: '2015-12-31',
       }),
     )
+    expect(firstEligibleExecutionAfterLookback(sessions, signals.slice(1), 0)).toEqual(
+      Result.fail({
+        _tag: 'CandidateDevelopmentSignalScheduleMismatch',
+        index: 0,
+        expected: '2016-01-29',
+        observed: '2016-02-29',
+        expectedCount: signals.length,
+        observedCount: signals.length - 1,
+      }),
+    )
   })
 
   test('stops before preregistration, data loading, and evaluation when the schedule is infeasible', async () => {

--- a/services/bayn/src/candidate-development.test.ts
+++ b/services/bayn/src/candidate-development.test.ts
@@ -1,0 +1,441 @@
+import { describe, expect, test } from 'bun:test'
+import { Effect, Exit, Result } from 'effect'
+
+import {
+  candidateDevelopmentCalendarContract,
+  candidateDevelopmentStatisticsPolicy,
+  candidateDevelopmentWalkForwardProtocol,
+  computeEndAnchoredWalkForwardBoundaries,
+  firstEligibleExecutionAfterLookback,
+  officialMonthEndSignalDates,
+  preflightCandidateDevelopment,
+  requiredObservationsForWalkForward,
+  runCandidateDevelopment,
+} from './candidate-development'
+import { defaultQualificationStatisticsPolicy } from './qualification-statistics'
+import type { IsoDate } from './schemas'
+
+const fullMarketClosures = new Set<IsoDate>([
+  '2016-01-18',
+  '2016-02-15',
+  '2016-03-25',
+  '2016-05-30',
+  '2016-07-04',
+  '2016-09-05',
+  '2016-11-24',
+  '2016-12-26',
+  '2017-01-02',
+  '2017-01-16',
+  '2017-02-20',
+  '2017-04-14',
+  '2017-05-29',
+  '2017-07-04',
+  '2017-09-04',
+  '2017-11-23',
+  '2017-12-25',
+  '2018-01-01',
+  '2018-01-15',
+  '2018-02-19',
+  '2018-03-30',
+  '2018-05-28',
+  '2018-07-04',
+  '2018-09-03',
+  '2018-11-22',
+  '2018-12-05',
+  '2018-12-25',
+  '2019-01-01',
+  '2019-01-21',
+  '2019-02-18',
+  '2019-04-19',
+  '2019-05-27',
+  '2019-07-04',
+  '2019-09-02',
+  '2019-11-28',
+  '2019-12-25',
+  '2020-01-01',
+  '2020-01-20',
+  '2020-02-17',
+  '2020-04-10',
+  '2020-05-25',
+  '2020-07-03',
+  '2020-09-07',
+  '2020-11-26',
+  '2020-12-25',
+  '2021-01-01',
+  '2021-01-18',
+  '2021-02-15',
+  '2021-04-02',
+  '2021-05-31',
+  '2021-07-05',
+  '2021-09-06',
+  '2021-11-25',
+  '2021-12-24',
+  '2022-01-17',
+  '2022-02-21',
+  '2022-04-15',
+  '2022-05-30',
+  '2022-06-20',
+  '2022-07-04',
+  '2022-09-05',
+  '2022-11-24',
+  '2022-12-26',
+])
+
+const isoDate = (date: Date): IsoDate => date.toISOString().slice(0, 10) as IsoDate
+
+const developmentSessions = (): readonly IsoDate[] => {
+  const sessions: IsoDate[] = []
+  for (
+    let date = new Date(`${candidateDevelopmentCalendarContract.start}T00:00:00.000Z`);
+    date <= new Date(`${candidateDevelopmentCalendarContract.end}T00:00:00.000Z`);
+    date = new Date(date.getTime() + 86_400_000)
+  ) {
+    const session = isoDate(date)
+    if (date.getUTCDay() !== 0 && date.getUTCDay() !== 6 && !fullMarketClosures.has(session)) {
+      sessions.push(session)
+    }
+  }
+  return sessions
+}
+
+const expectedFolds = [
+  {
+    ordinal: 0,
+    trainingStartIndex: 273,
+    trainingStart: '2017-02-02',
+    trainingEndIndex: 776,
+    trainingEnd: '2019-02-04',
+    trainingObservationCount: 504,
+    testStartIndex: 777,
+    testStart: '2019-02-05',
+    testEndIndex: 973,
+    testEnd: '2019-11-13',
+    testObservationCount: 197,
+  },
+  {
+    ordinal: 1,
+    trainingStartIndex: 273,
+    trainingStart: '2017-02-02',
+    trainingEndIndex: 973,
+    trainingEnd: '2019-11-13',
+    trainingObservationCount: 701,
+    testStartIndex: 974,
+    testStart: '2019-11-14',
+    testEndIndex: 1_170,
+    testEnd: '2020-08-26',
+    testObservationCount: 197,
+  },
+  {
+    ordinal: 2,
+    trainingStartIndex: 273,
+    trainingStart: '2017-02-02',
+    trainingEndIndex: 1_170,
+    trainingEnd: '2020-08-26',
+    trainingObservationCount: 898,
+    testStartIndex: 1_171,
+    testStart: '2020-08-27',
+    testEndIndex: 1_367,
+    testEnd: '2021-06-09',
+    testObservationCount: 197,
+  },
+  {
+    ordinal: 3,
+    trainingStartIndex: 273,
+    trainingStart: '2017-02-02',
+    trainingEndIndex: 1_367,
+    trainingEnd: '2021-06-09',
+    trainingObservationCount: 1_095,
+    testStartIndex: 1_368,
+    testStart: '2021-06-10',
+    testEndIndex: 1_564,
+    testEnd: '2022-03-21',
+    testObservationCount: 197,
+  },
+  {
+    ordinal: 4,
+    trainingStartIndex: 273,
+    trainingStart: '2017-02-02',
+    trainingEndIndex: 1_564,
+    trainingEnd: '2022-03-21',
+    trainingObservationCount: 1_292,
+    testStartIndex: 1_565,
+    testStart: '2022-03-22',
+    testEndIndex: 1_761,
+    testEnd: '2022-12-30',
+    testObservationCount: 197,
+  },
+] as const
+
+const successOf = <A, E>(result: Result.Result<A, E>): A => {
+  expect(Result.isSuccess(result)).toBe(true)
+  if (Result.isFailure(result)) throw new Error('expected Result success')
+  return result.success
+}
+
+describe('candidate development walk-forward protocol', () => {
+  test('freezes the exact 1,762-session development calendar without touching the holdout', () => {
+    const sessions = developmentSessions()
+    const result = successOf(
+      preflightCandidateDevelopment({
+        officialSessions: sessions,
+        signalSessionDates: officialMonthEndSignalDates(sessions),
+        featureLookbackSessions: 252,
+      }),
+    )
+
+    expect(sessions).toHaveLength(1_762)
+    expect(sessions.at(0)).toBe('2016-01-04')
+    expect(sessions.at(-1)).toBe('2022-12-30')
+    expect(result.status).toBe('PASS')
+  })
+
+  test('computes exact first next-session executions for zero, 63, and 252-session lookbacks', () => {
+    const sessions = developmentSessions()
+    const signals = officialMonthEndSignalDates(sessions)
+    const expected = [
+      [0, 18, '2016-01-29', 19, '2016-02-01'],
+      [63, 81, '2016-04-29', 82, '2016-05-02'],
+      [252, 271, '2017-01-31', 272, '2017-02-01'],
+    ] as const
+
+    for (const [lookback, signalIndex, signalDate, executionIndex, executionDate] of expected) {
+      expect(successOf(firstEligibleExecutionAfterLookback(sessions, signals, lookback))).toEqual({
+        signalIndex,
+        signalDate,
+        executionIndex,
+        executionDate,
+      })
+    }
+  })
+
+  test('uses deterministic end-anchored folds for every supported lookback', () => {
+    const sessions = developmentSessions()
+    const signals = officialMonthEndSignalDates(sessions)
+    const expectedAvailability = [
+      [0, 1_743, 254, 6],
+      [63, 1_680, 191, 5],
+      [252, 1_490, 1, 5],
+    ] as const
+
+    for (const [
+      featureLookbackSessions,
+      availableObservations,
+      unusedEligibleObservations,
+      availableFoldCount,
+    ] of expectedAvailability) {
+      const preflight = successOf(
+        preflightCandidateDevelopment({
+          officialSessions: sessions,
+          signalSessionDates: signals,
+          featureLookbackSessions,
+        }),
+      )
+      expect(preflight).toMatchObject({
+        status: 'PASS',
+        requiredObservations: 1_489,
+        availableObservations,
+        availableFoldCount,
+        requiredFoldCount: 5,
+        unusedEligibleObservations,
+        selectedObservationStartIndex: 273,
+        selectedObservationStart: '2017-02-02',
+        selectedObservationEndIndex: 1_761,
+        selectedObservationEnd: '2022-12-30',
+        folds: expectedFolds,
+      })
+    }
+  })
+
+  test('proves the official terminal geometry is impossible while the distinct development geometry is feasible', () => {
+    const sessions = developmentSessions()
+    const official = successOf(
+      computeEndAnchoredWalkForwardBoundaries(sessions, 0, {
+        minimumTrainingSessions: defaultQualificationStatisticsPolicy.walkForward.minimumTrainingSessions,
+        testSessions: defaultQualificationStatisticsPolicy.walkForward.testSessions,
+        requiredFolds: defaultQualificationStatisticsPolicy.walkForward.minimumFolds,
+      }),
+    )
+    const development = successOf(
+      computeEndAnchoredWalkForwardBoundaries(sessions, 272, candidateDevelopmentWalkForwardProtocol),
+    )
+
+    expect(official).toEqual({
+      status: 'FAIL',
+      reason: 'INSUFFICIENT_WALK_FORWARD_OBSERVATIONS',
+      requiredObservations: 1_764,
+      availableObservations: 1_762,
+      availableFoldCount: 4,
+      requiredFoldCount: 5,
+      observationDeficit: 2,
+    })
+    expect(development).toMatchObject({
+      status: 'PASS',
+      requiredObservations: 1_489,
+      availableObservations: 1_490,
+      unusedEligibleObservations: 1,
+      folds: expectedFolds,
+    })
+    expect(candidateDevelopmentStatisticsPolicy.walkForward.testSessions).toBe(197)
+    expect(defaultQualificationStatisticsPolicy.walkForward.testSessions).toBe(252)
+    expect(candidateDevelopmentStatisticsPolicy.bootstrap).toEqual(defaultQualificationStatisticsPolicy.bootstrap)
+  })
+
+  test('covers exact off-by-one pass/fail boundaries and an infeasible 198-session protocol', () => {
+    const sessions = developmentSessions()
+    expect(successOf(requiredObservationsForWalkForward(candidateDevelopmentWalkForwardProtocol))).toBe(1_489)
+    expect(
+      successOf(computeEndAnchoredWalkForwardBoundaries(sessions, 273, candidateDevelopmentWalkForwardProtocol)),
+    ).toMatchObject({
+      status: 'PASS',
+      availableObservations: 1_489,
+      unusedEligibleObservations: 0,
+    })
+    expect(
+      successOf(computeEndAnchoredWalkForwardBoundaries(sessions, 274, candidateDevelopmentWalkForwardProtocol)),
+    ).toEqual({
+      status: 'FAIL',
+      reason: 'INSUFFICIENT_WALK_FORWARD_OBSERVATIONS',
+      requiredObservations: 1_489,
+      availableObservations: 1_488,
+      availableFoldCount: 4,
+      requiredFoldCount: 5,
+      observationDeficit: 1,
+    })
+    expect(
+      successOf(
+        computeEndAnchoredWalkForwardBoundaries(sessions, 272, {
+          ...candidateDevelopmentWalkForwardProtocol,
+          testSessions: 198,
+        }),
+      ),
+    ).toEqual({
+      status: 'FAIL',
+      reason: 'INSUFFICIENT_WALK_FORWARD_OBSERVATIONS',
+      requiredObservations: 1_494,
+      availableObservations: 1_490,
+      availableFoldCount: 4,
+      requiredFoldCount: 5,
+      observationDeficit: 4,
+    })
+  })
+
+  test('fails closed for a calendar with the right endpoints, count, and order but wrong identity', () => {
+    const sessions = [...developmentSessions()]
+    sessions[102] = '2016-05-30'
+
+    expect(
+      preflightCandidateDevelopment({
+        officialSessions: sessions,
+        signalSessionDates: officialMonthEndSignalDates(sessions),
+        featureLookbackSessions: 63,
+      }),
+    ).toMatchObject(
+      Result.fail({
+        _tag: 'CandidateDevelopmentCalendarMismatch',
+        field: 'sessionsHash',
+        expected: candidateDevelopmentCalendarContract.sessionsHash,
+      }),
+    )
+  })
+
+  test('returns typed failures for invalid geometry, excessive lookback, and a malformed later signal', () => {
+    const sessions = developmentSessions()
+    const signals = officialMonthEndSignalDates(sessions)
+
+    expect(
+      requiredObservationsForWalkForward({
+        ...candidateDevelopmentWalkForwardProtocol,
+        minimumTrainingSessions: 0,
+      }),
+    ).toEqual(
+      Result.fail({
+        _tag: 'CandidateDevelopmentGeometryPositiveIntegerRequired',
+        field: 'minimumTrainingSessions',
+        value: 0,
+      }),
+    )
+    expect(firstEligibleExecutionAfterLookback(sessions, signals, 253)).toEqual(
+      Result.fail({
+        _tag: 'CandidateDevelopmentLookbackInvalid',
+        featureLookbackSessions: 253,
+        maximumFeatureLookbackSessions: 252,
+      }),
+    )
+    expect(firstEligibleExecutionAfterLookback(sessions, ['2015-12-31', signals[0]], 0)).toEqual(
+      Result.fail({
+        _tag: 'CandidateDevelopmentSignalOutsideCalendar',
+        signalDate: '2015-12-31',
+      }),
+    )
+  })
+
+  test('stops before preregistration, data loading, and evaluation when the schedule is infeasible', async () => {
+    const sessions = developmentSessions()
+    let preregistrations = 0
+    let loads = 0
+    let evaluations = 0
+    const exit = await Effect.runPromiseExit(
+      runCandidateDevelopment(
+        {
+          officialSessions: sessions,
+          signalSessionDates: [sessions[273]],
+          featureLookbackSessions: 0,
+        },
+        {
+          preregisterCandidate: () => {
+            preregistrations += 1
+            return Effect.succeed('registration')
+          },
+          loadDevelopmentData: () => {
+            loads += 1
+            return Effect.succeed('data')
+          },
+          evaluateDevelopment: () => {
+            evaluations += 1
+            return Effect.succeed('report')
+          },
+        },
+      ),
+    )
+
+    expect(Exit.isFailure(exit)).toBe(true)
+    expect(preregistrations).toBe(0)
+    expect(loads).toBe(0)
+    expect(evaluations).toBe(0)
+  })
+
+  test('preregisters, loads, and evaluates exactly once only after a passing preflight', async () => {
+    const sessions = developmentSessions()
+    let preregistrations = 0
+    let loads = 0
+    let evaluations = 0
+    const report = await Effect.runPromise(
+      runCandidateDevelopment(
+        {
+          officialSessions: sessions,
+          signalSessionDates: officialMonthEndSignalDates(sessions),
+          featureLookbackSessions: 252,
+        },
+        {
+          preregisterCandidate: (preflight) => {
+            preregistrations += 1
+            return Effect.succeed(preflight.schemaVersion)
+          },
+          loadDevelopmentData: (registration, preflight) => {
+            loads += 1
+            return Effect.succeed(`${registration}:${preflight.selectedObservationStart}`)
+          },
+          evaluateDevelopment: (data, preflight) => {
+            evaluations += 1
+            return Effect.succeed(`${data}:${preflight.selectedObservationEnd}`)
+          },
+        },
+      ),
+    )
+
+    expect(report).toBe('bayn.candidate-development-preflight.v1:2017-02-02:2022-12-30')
+    expect(preregistrations).toBe(1)
+    expect(loads).toBe(1)
+    expect(evaluations).toBe(1)
+  })
+})

--- a/services/bayn/src/candidate-development.ts
+++ b/services/bayn/src/candidate-development.ts
@@ -173,6 +173,14 @@ export type CandidateDevelopmentPreflightIssue =
       readonly signalDate: IsoDate
     }
   | {
+      readonly _tag: 'CandidateDevelopmentSignalScheduleMismatch'
+      readonly index: number
+      readonly expected: IsoDate | undefined
+      readonly observed: IsoDate | undefined
+      readonly expectedCount: number
+      readonly observedCount: number
+    }
+  | {
       readonly _tag: 'CandidateDevelopmentEligibleExecutionMissing'
       readonly featureLookbackSessions: number
     }
@@ -437,6 +445,23 @@ export const firstEligibleExecutionAfterLookback = (
     const signalIndex = sessionIndices.get(signalDate)
     if (signalIndex === undefined) {
       return Result.fail({ _tag: 'CandidateDevelopmentSignalOutsideCalendar', signalDate })
+    }
+  }
+
+  const expectedSignalSessionDates = officialMonthEndSignalDates(sessions)
+  const scheduleLength = Math.max(expectedSignalSessionDates.length, signalSessionDates.length)
+  for (let index = 0; index < scheduleLength; index += 1) {
+    const expected = expectedSignalSessionDates.at(index)
+    const observed = signalSessionDates.at(index)
+    if (expected !== observed) {
+      return Result.fail({
+        _tag: 'CandidateDevelopmentSignalScheduleMismatch',
+        index,
+        expected,
+        observed,
+        expectedCount: expectedSignalSessionDates.length,
+        observedCount: signalSessionDates.length,
+      })
     }
   }
 

--- a/services/bayn/src/candidate-development.ts
+++ b/services/bayn/src/candidate-development.ts
@@ -1,0 +1,571 @@
+import { Effect, pipe, Result } from 'effect'
+
+import { canonicalHashV1Result, type CanonicalHashFailure } from './hash'
+import { defaultQualificationStatisticsPolicy, type QualificationStatisticsPolicy } from './qualification-statistics'
+import type { IsoDate } from './schemas'
+
+export const candidateDevelopmentCalendarContract = {
+  schemaVersion: 'bayn.candidate-development-calendar.v1',
+  calendarVersion: 'alpaca-us-equity-calendar-v1',
+  start: '2016-01-04',
+  end: '2022-12-30',
+  sessionCount: 1_762,
+  sessionsHash: 'a6df7a68249842fa35814f282b3df63db19c52f6ea0697899979d3a8c970d9b1',
+} as const
+
+/**
+ * Development model selection uses multiple chronological rolling origins with expanding training data, as described
+ * by Tashman (2000, doi:10.1016/S0169-2070(00)00065-0). The 197-session test length is not a weakened terminal gate:
+ * it is the largest equal test block that preserves 504 training sessions and five non-overlapping tests after a
+ * 252-session causal lookback and next-session execution inside the frozen 1,762-session development calendar.
+ * Latest-contiguous selection maximizes recency while deriving every boundary only from the frozen calendar and
+ * preregistered geometry, never from realized returns.
+ * Terminal qualification continues to use defaultQualificationStatisticsPolicy unchanged. Its paired complete-block
+ * bootstrap also remains unchanged and samples only observed, non-wrapping rebalance blocks, following the dependent
+ * block-resampling principle of Künsch (1989, doi:10.1214/aos/1176347265).
+ */
+export const candidateDevelopmentWalkForwardProtocol = {
+  method: 'expanding-origin',
+  foldSelection: 'latest-contiguous',
+  minimumTrainingSessions: 504,
+  testSessions: 197,
+  requiredFolds: 5,
+  maximumFeatureLookbackSessions: 252,
+  executionLagSessions: 1,
+} as const
+
+export const candidateDevelopmentStatisticsPolicy = {
+  ...defaultQualificationStatisticsPolicy,
+  confidence: { ...defaultQualificationStatisticsPolicy.confidence },
+  bootstrap: { ...defaultQualificationStatisticsPolicy.bootstrap },
+  power: { ...defaultQualificationStatisticsPolicy.power },
+  walkForward: {
+    ...defaultQualificationStatisticsPolicy.walkForward,
+    testSessions: candidateDevelopmentWalkForwardProtocol.testSessions,
+    minimumFolds: candidateDevelopmentWalkForwardProtocol.requiredFolds,
+  },
+  cashReturn: { ...defaultQualificationStatisticsPolicy.cashReturn },
+} as const satisfies QualificationStatisticsPolicy
+
+export interface CandidateDevelopmentWalkForwardGeometry {
+  readonly minimumTrainingSessions: number
+  readonly testSessions: number
+  readonly requiredFolds: number
+}
+
+export interface CandidateDevelopmentExecutionBoundary {
+  readonly signalIndex: number
+  readonly signalDate: IsoDate
+  readonly executionIndex: number
+  readonly executionDate: IsoDate
+}
+
+export interface CandidateDevelopmentFoldBoundary {
+  readonly ordinal: number
+  readonly trainingStartIndex: number
+  readonly trainingStart: IsoDate
+  readonly trainingEndIndex: number
+  readonly trainingEnd: IsoDate
+  readonly trainingObservationCount: number
+  readonly testStartIndex: number
+  readonly testStart: IsoDate
+  readonly testEndIndex: number
+  readonly testEnd: IsoDate
+  readonly testObservationCount: number
+}
+
+export interface CandidateDevelopmentGeometryPass {
+  readonly status: 'PASS'
+  readonly requiredObservations: number
+  readonly availableObservations: number
+  readonly availableFoldCount: number
+  readonly requiredFoldCount: number
+  readonly unusedEligibleObservations: number
+  readonly selectedObservationStartIndex: number
+  readonly selectedObservationStart: IsoDate
+  readonly selectedObservationEndIndex: number
+  readonly selectedObservationEnd: IsoDate
+  readonly folds: readonly CandidateDevelopmentFoldBoundary[]
+}
+
+export interface CandidateDevelopmentGeometryFail {
+  readonly status: 'FAIL'
+  readonly reason: 'INSUFFICIENT_WALK_FORWARD_OBSERVATIONS'
+  readonly requiredObservations: number
+  readonly availableObservations: number
+  readonly availableFoldCount: number
+  readonly requiredFoldCount: number
+  readonly observationDeficit: number
+}
+
+export type CandidateDevelopmentGeometryDecision = CandidateDevelopmentGeometryPass | CandidateDevelopmentGeometryFail
+
+export type CandidateDevelopmentGeometryIssue =
+  | {
+      readonly _tag: 'CandidateDevelopmentGeometryIntegerInvalid'
+      readonly field:
+        | 'availableSessions'
+        | 'firstExecutionIndex'
+        | 'minimumTrainingSessions'
+        | 'testSessions'
+        | 'requiredFolds'
+      readonly value: number
+    }
+  | {
+      readonly _tag: 'CandidateDevelopmentGeometryPositiveIntegerRequired'
+      readonly field: 'availableSessions' | 'minimumTrainingSessions' | 'testSessions' | 'requiredFolds'
+      readonly value: number
+    }
+  | {
+      readonly _tag: 'CandidateDevelopmentExecutionOutsideCalendar'
+      readonly firstExecutionIndex: number
+      readonly availableSessions: number
+    }
+  | {
+      readonly _tag: 'CandidateDevelopmentGeometryOverflow'
+      readonly operation: 'required-test-observations' | 'required-observations'
+    }
+  | {
+      readonly _tag: 'CandidateDevelopmentFoldBoundaryMissing'
+      readonly field: keyof CandidateDevelopmentFoldBoundary
+      readonly index: number
+    }
+
+export type CandidateDevelopmentPreflightIssue =
+  | CandidateDevelopmentGeometryIssue
+  | {
+      readonly _tag: 'CandidateDevelopmentCalendarDateInvalid'
+      readonly index: number
+      readonly value: string
+    }
+  | {
+      readonly _tag: 'CandidateDevelopmentCalendarNotStrictlyOrdered'
+      readonly index: number
+      readonly previous: IsoDate
+      readonly current: IsoDate
+    }
+  | {
+      readonly _tag: 'CandidateDevelopmentCalendarMismatch'
+      readonly field: 'sessionCount' | 'start' | 'end' | 'sessionsHash'
+      readonly expected: number | string
+      readonly observed: number | string
+    }
+  | {
+      readonly _tag: 'CandidateDevelopmentCalendarHashFailed'
+      readonly cause: CanonicalHashFailure
+    }
+  | {
+      readonly _tag: 'CandidateDevelopmentLookbackInvalid'
+      readonly featureLookbackSessions: number
+      readonly maximumFeatureLookbackSessions: number
+    }
+  | {
+      readonly _tag: 'CandidateDevelopmentSignalScheduleEmpty'
+    }
+  | {
+      readonly _tag: 'CandidateDevelopmentSignalScheduleNotStrictlyOrdered'
+      readonly index: number
+      readonly previous: IsoDate
+      readonly current: IsoDate
+    }
+  | {
+      readonly _tag: 'CandidateDevelopmentSignalOutsideCalendar'
+      readonly signalDate: IsoDate
+    }
+  | {
+      readonly _tag: 'CandidateDevelopmentEligibleExecutionMissing'
+      readonly featureLookbackSessions: number
+    }
+
+export interface CandidateDevelopmentPreflightPass extends CandidateDevelopmentGeometryPass {
+  readonly schemaVersion: 'bayn.candidate-development-preflight.v1'
+  readonly featureLookbackSessions: number
+  readonly firstEligibleExecution: CandidateDevelopmentExecutionBoundary
+  readonly statisticsPolicy: typeof candidateDevelopmentStatisticsPolicy
+}
+
+export type CandidateDevelopmentPreflightDecision = CandidateDevelopmentPreflightPass | CandidateDevelopmentGeometryFail
+
+export type CandidateDevelopmentRunFailure =
+  | {
+      readonly _tag: 'CandidateDevelopmentPreflightInvalid'
+      readonly cause: CandidateDevelopmentPreflightIssue
+    }
+  | {
+      readonly _tag: 'CandidateDevelopmentPreflightFailed'
+      readonly preflight: CandidateDevelopmentGeometryFail
+    }
+
+export interface CandidateDevelopmentPreflightInput {
+  readonly officialSessions: readonly IsoDate[]
+  readonly signalSessionDates: readonly IsoDate[]
+  readonly featureLookbackSessions: number
+}
+
+export interface CandidateDevelopmentEffects<Registration, Data, Report, Error, Requirements> {
+  readonly preregisterCandidate: (
+    preflight: CandidateDevelopmentPreflightPass,
+  ) => Effect.Effect<Registration, Error, Requirements>
+  readonly loadDevelopmentData: (
+    registration: Registration,
+    preflight: CandidateDevelopmentPreflightPass,
+  ) => Effect.Effect<Data, Error, Requirements>
+  readonly evaluateDevelopment: (
+    data: Data,
+    preflight: CandidateDevelopmentPreflightPass,
+  ) => Effect.Effect<Report, Error, Requirements>
+}
+
+const validIsoDate = (value: string): value is IsoDate => {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return false
+  const parsed = new Date(`${value}T00:00:00.000Z`)
+  return !Number.isNaN(parsed.getTime()) && parsed.toISOString().slice(0, 10) === value
+}
+
+const positiveInteger = (
+  field: Extract<
+    CandidateDevelopmentGeometryIssue,
+    { readonly _tag: 'CandidateDevelopmentGeometryPositiveIntegerRequired' }
+  >['field'],
+  value: number,
+): Result.Result<number, CandidateDevelopmentGeometryIssue> =>
+  !Number.isSafeInteger(value)
+    ? Result.fail({ _tag: 'CandidateDevelopmentGeometryIntegerInvalid', field, value })
+    : value <= 0
+      ? Result.fail({ _tag: 'CandidateDevelopmentGeometryPositiveIntegerRequired', field, value })
+      : Result.succeed(value)
+
+const nonNegativeInteger = (
+  field: 'firstExecutionIndex',
+  value: number,
+): Result.Result<number, CandidateDevelopmentGeometryIssue> =>
+  !Number.isSafeInteger(value) || value < 0
+    ? Result.fail({ _tag: 'CandidateDevelopmentGeometryIntegerInvalid', field, value })
+    : Result.succeed(value)
+
+export const requiredObservationsForWalkForward = (
+  geometry: CandidateDevelopmentWalkForwardGeometry,
+): Result.Result<number, CandidateDevelopmentGeometryIssue> =>
+  pipe(
+    Result.all({
+      minimumTrainingSessions: positiveInteger('minimumTrainingSessions', geometry.minimumTrainingSessions),
+      testSessions: positiveInteger('testSessions', geometry.testSessions),
+      requiredFolds: positiveInteger('requiredFolds', geometry.requiredFolds),
+    }),
+    Result.flatMap(({ minimumTrainingSessions, requiredFolds, testSessions }) => {
+      const requiredTestObservations = testSessions * requiredFolds
+      if (!Number.isSafeInteger(requiredTestObservations)) {
+        return Result.fail<CandidateDevelopmentGeometryIssue>({
+          _tag: 'CandidateDevelopmentGeometryOverflow',
+          operation: 'required-test-observations',
+        })
+      }
+      const requiredObservations = minimumTrainingSessions + requiredTestObservations
+      return Number.isSafeInteger(requiredObservations)
+        ? Result.succeed(requiredObservations)
+        : Result.fail<CandidateDevelopmentGeometryIssue>({
+            _tag: 'CandidateDevelopmentGeometryOverflow',
+            operation: 'required-observations',
+          })
+    }),
+  )
+
+export const availableObservationsAfterFirstExecution = (
+  availableSessions: number,
+  firstExecutionIndex: number,
+): Result.Result<number, CandidateDevelopmentGeometryIssue> =>
+  pipe(
+    Result.all({
+      availableSessions: positiveInteger('availableSessions', availableSessions),
+      firstExecutionIndex: nonNegativeInteger('firstExecutionIndex', firstExecutionIndex),
+    }),
+    Result.flatMap(({ availableSessions: sessions, firstExecutionIndex: executionIndex }) =>
+      executionIndex < sessions
+        ? Result.succeed(sessions - executionIndex)
+        : Result.fail<CandidateDevelopmentGeometryIssue>({
+            _tag: 'CandidateDevelopmentExecutionOutsideCalendar',
+            firstExecutionIndex: executionIndex,
+            availableSessions: sessions,
+          }),
+    ),
+  )
+
+const requiredSession = (
+  sessions: readonly IsoDate[],
+  field: keyof CandidateDevelopmentFoldBoundary,
+  index: number,
+): Result.Result<IsoDate, CandidateDevelopmentGeometryIssue> => {
+  const session = sessions.at(index)
+  return session === undefined
+    ? Result.fail({ _tag: 'CandidateDevelopmentFoldBoundaryMissing', field, index })
+    : Result.succeed(session)
+}
+
+const buildFoldBoundary = (
+  sessions: readonly IsoDate[],
+  selectedObservationStartIndex: number,
+  geometry: CandidateDevelopmentWalkForwardGeometry,
+  ordinal: number,
+): Result.Result<CandidateDevelopmentFoldBoundary, CandidateDevelopmentGeometryIssue> => {
+  const trainingStartIndex = selectedObservationStartIndex
+  const testStartIndex =
+    selectedObservationStartIndex + geometry.minimumTrainingSessions + ordinal * geometry.testSessions
+  const trainingEndIndex = testStartIndex - 1
+  const testEndIndex = testStartIndex + geometry.testSessions - 1
+  return pipe(
+    Result.all({
+      trainingStart: requiredSession(sessions, 'trainingStart', trainingStartIndex),
+      trainingEnd: requiredSession(sessions, 'trainingEnd', trainingEndIndex),
+      testStart: requiredSession(sessions, 'testStart', testStartIndex),
+      testEnd: requiredSession(sessions, 'testEnd', testEndIndex),
+    }),
+    Result.map(({ testEnd, testStart, trainingEnd, trainingStart }) => ({
+      ordinal,
+      trainingStartIndex,
+      trainingStart,
+      trainingEndIndex,
+      trainingEnd,
+      trainingObservationCount: trainingEndIndex - trainingStartIndex + 1,
+      testStartIndex,
+      testStart,
+      testEndIndex,
+      testEnd,
+      testObservationCount: geometry.testSessions,
+    })),
+  )
+}
+
+export const computeEndAnchoredWalkForwardBoundaries = (
+  sessions: readonly IsoDate[],
+  firstExecutionIndex: number,
+  geometry: CandidateDevelopmentWalkForwardGeometry,
+): Result.Result<CandidateDevelopmentGeometryDecision, CandidateDevelopmentGeometryIssue> =>
+  pipe(
+    Result.all({
+      requiredObservations: requiredObservationsForWalkForward(geometry),
+      availableObservations: availableObservationsAfterFirstExecution(sessions.length, firstExecutionIndex),
+    }),
+    Result.flatMap(
+      ({
+        availableObservations,
+        requiredObservations,
+      }): Result.Result<CandidateDevelopmentGeometryDecision, CandidateDevelopmentGeometryIssue> => {
+        const availableFoldCount = Math.max(
+          0,
+          Math.floor((availableObservations - geometry.minimumTrainingSessions) / geometry.testSessions),
+        )
+        if (availableObservations < requiredObservations) {
+          return Result.succeed({
+            status: 'FAIL' as const,
+            reason: 'INSUFFICIENT_WALK_FORWARD_OBSERVATIONS' as const,
+            requiredObservations,
+            availableObservations,
+            availableFoldCount,
+            requiredFoldCount: geometry.requiredFolds,
+            observationDeficit: requiredObservations - availableObservations,
+          })
+        }
+
+        const selectedObservationStartIndex = sessions.length - requiredObservations
+        const selectedObservationEndIndex = sessions.length - 1
+        return pipe(
+          Result.all({
+            selectedObservationStart: requiredSession(sessions, 'trainingStart', selectedObservationStartIndex),
+            selectedObservationEnd: requiredSession(sessions, 'testEnd', selectedObservationEndIndex),
+            folds: Result.all(
+              Array.from({ length: geometry.requiredFolds }, (_, ordinal) =>
+                buildFoldBoundary(sessions, selectedObservationStartIndex, geometry, ordinal),
+              ),
+            ),
+          }),
+          Result.map(({ folds, selectedObservationEnd, selectedObservationStart }) => ({
+            status: 'PASS' as const,
+            requiredObservations,
+            availableObservations,
+            availableFoldCount,
+            requiredFoldCount: geometry.requiredFolds,
+            unusedEligibleObservations: selectedObservationStartIndex - firstExecutionIndex,
+            selectedObservationStartIndex,
+            selectedObservationStart,
+            selectedObservationEndIndex,
+            selectedObservationEnd,
+            folds,
+          })),
+        )
+      },
+    ),
+  )
+
+export const officialMonthEndSignalDates = (sessions: readonly IsoDate[]): readonly IsoDate[] =>
+  sessions.filter((session, index) => {
+    const next = sessions.at(index + 1)
+    return next !== undefined && session.slice(0, 7) !== next.slice(0, 7)
+  })
+
+export const firstEligibleExecutionAfterLookback = (
+  sessions: readonly IsoDate[],
+  signalSessionDates: readonly IsoDate[],
+  featureLookbackSessions: number,
+): Result.Result<CandidateDevelopmentExecutionBoundary, CandidateDevelopmentPreflightIssue> => {
+  if (
+    !Number.isSafeInteger(featureLookbackSessions) ||
+    featureLookbackSessions < 0 ||
+    featureLookbackSessions > candidateDevelopmentWalkForwardProtocol.maximumFeatureLookbackSessions
+  ) {
+    return Result.fail({
+      _tag: 'CandidateDevelopmentLookbackInvalid',
+      featureLookbackSessions,
+      maximumFeatureLookbackSessions: candidateDevelopmentWalkForwardProtocol.maximumFeatureLookbackSessions,
+    })
+  }
+  if (signalSessionDates.length === 0) {
+    return Result.fail({ _tag: 'CandidateDevelopmentSignalScheduleEmpty' })
+  }
+
+  const sessionIndices = new Map(sessions.map((session, index) => [session, index] as const))
+  for (let index = 0; index < signalSessionDates.length; index += 1) {
+    const signalDate = signalSessionDates[index]
+    const previous = index === 0 ? undefined : signalSessionDates[index - 1]
+    if (previous !== undefined && previous >= signalDate) {
+      return Result.fail({
+        _tag: 'CandidateDevelopmentSignalScheduleNotStrictlyOrdered',
+        index,
+        previous,
+        current: signalDate,
+      })
+    }
+    const signalIndex = sessionIndices.get(signalDate)
+    if (signalIndex === undefined) {
+      return Result.fail({ _tag: 'CandidateDevelopmentSignalOutsideCalendar', signalDate })
+    }
+  }
+
+  for (const signalDate of signalSessionDates) {
+    const signalIndex = sessionIndices.get(signalDate)
+    if (signalIndex === undefined) {
+      return Result.fail({ _tag: 'CandidateDevelopmentSignalOutsideCalendar', signalDate })
+    }
+    const executionDate = sessions.at(signalIndex + candidateDevelopmentWalkForwardProtocol.executionLagSessions)
+    if (signalIndex >= featureLookbackSessions && executionDate !== undefined) {
+      return Result.succeed({
+        signalIndex,
+        signalDate,
+        executionIndex: signalIndex + candidateDevelopmentWalkForwardProtocol.executionLagSessions,
+        executionDate,
+      })
+    }
+  }
+
+  return Result.fail({ _tag: 'CandidateDevelopmentEligibleExecutionMissing', featureLookbackSessions })
+}
+
+const validateFrozenDevelopmentCalendar = (
+  sessions: readonly IsoDate[],
+): Result.Result<void, CandidateDevelopmentPreflightIssue> => {
+  for (let index = 0; index < sessions.length; index += 1) {
+    const session = sessions[index]
+    if (!validIsoDate(session)) {
+      return Result.fail({ _tag: 'CandidateDevelopmentCalendarDateInvalid', index, value: session })
+    }
+    const previous = index === 0 ? undefined : sessions[index - 1]
+    if (previous !== undefined && previous >= session) {
+      return Result.fail({
+        _tag: 'CandidateDevelopmentCalendarNotStrictlyOrdered',
+        index,
+        previous,
+        current: session,
+      })
+    }
+  }
+
+  const exactFields = [
+    ['sessionCount', candidateDevelopmentCalendarContract.sessionCount, sessions.length],
+    ['start', candidateDevelopmentCalendarContract.start, sessions.at(0) ?? ''],
+    ['end', candidateDevelopmentCalendarContract.end, sessions.at(-1) ?? ''],
+  ] as const
+  for (const [field, expected, observed] of exactFields) {
+    if (observed !== expected) {
+      return Result.fail({ _tag: 'CandidateDevelopmentCalendarMismatch', field, expected, observed })
+    }
+  }
+
+  return pipe(
+    canonicalHashV1Result({
+      schemaVersion: candidateDevelopmentCalendarContract.schemaVersion,
+      sessions,
+    }),
+    Result.mapError(
+      (cause): CandidateDevelopmentPreflightIssue => ({
+        _tag: 'CandidateDevelopmentCalendarHashFailed',
+        cause,
+      }),
+    ),
+    Result.flatMap((observed) =>
+      observed === candidateDevelopmentCalendarContract.sessionsHash
+        ? Result.succeed(undefined)
+        : Result.fail<CandidateDevelopmentPreflightIssue>({
+            _tag: 'CandidateDevelopmentCalendarMismatch',
+            field: 'sessionsHash',
+            expected: candidateDevelopmentCalendarContract.sessionsHash,
+            observed,
+          }),
+    ),
+  )
+}
+
+export const preflightCandidateDevelopment = (
+  input: CandidateDevelopmentPreflightInput,
+): Result.Result<CandidateDevelopmentPreflightDecision, CandidateDevelopmentPreflightIssue> =>
+  pipe(
+    validateFrozenDevelopmentCalendar(input.officialSessions),
+    Result.flatMap(() =>
+      firstEligibleExecutionAfterLookback(
+        input.officialSessions,
+        input.signalSessionDates,
+        input.featureLookbackSessions,
+      ),
+    ),
+    Result.flatMap((firstEligibleExecution) =>
+      pipe(
+        computeEndAnchoredWalkForwardBoundaries(
+          input.officialSessions,
+          firstEligibleExecution.executionIndex,
+          candidateDevelopmentWalkForwardProtocol,
+        ),
+        Result.map(
+          (geometry): CandidateDevelopmentPreflightDecision =>
+            geometry.status === 'FAIL'
+              ? geometry
+              : {
+                  ...geometry,
+                  schemaVersion: 'bayn.candidate-development-preflight.v1',
+                  featureLookbackSessions: input.featureLookbackSessions,
+                  firstEligibleExecution,
+                  statisticsPolicy: candidateDevelopmentStatisticsPolicy,
+                },
+        ),
+      ),
+    ),
+  )
+
+export const runCandidateDevelopment = <Registration, Data, Report, Error, Requirements>(
+  input: CandidateDevelopmentPreflightInput,
+  effects: CandidateDevelopmentEffects<Registration, Data, Report, Error, Requirements>,
+): Effect.Effect<Report, CandidateDevelopmentRunFailure | Error, Requirements> =>
+  Effect.fromResult(preflightCandidateDevelopment(input)).pipe(
+    Effect.mapError(
+      (cause): CandidateDevelopmentRunFailure => ({ _tag: 'CandidateDevelopmentPreflightInvalid', cause }),
+    ),
+    Effect.flatMap(
+      (preflight): Effect.Effect<Report, CandidateDevelopmentRunFailure | Error, Requirements> =>
+        preflight.status === 'FAIL'
+          ? Effect.fail<CandidateDevelopmentRunFailure>({
+              _tag: 'CandidateDevelopmentPreflightFailed',
+              preflight,
+            })
+          : effects.preregisterCandidate(preflight).pipe(
+              Effect.flatMap((registration) => effects.loadDevelopmentData(registration, preflight)),
+              Effect.flatMap((data) => effects.evaluateDevelopment(data, preflight)),
+            ),
+    ),
+  )


### PR DESCRIPTION
## Summary

- Add one pure candidate-development protocol/preflight boundary that validates the exact frozen `2016-01-04` through `2022-12-30` official-session calendar before preregistration or data/evaluation effects.
- Freeze a development-only expanding-origin contract with 504 training sessions and five non-overlapping 197-session test folds, end-anchored to `2022-12-30`; terminal qualification remains unchanged at five 252-session folds.
- Compute typed exact geometry for required/available observations, first eligible next-session execution after causal lookback, deterministic fold boundaries, and fail-closed infeasibility.
- Require the supplied signal schedule to equal the canonical official month-end schedule exactly, then provide the single future candidate-development Effect entrypoint; it cannot preregister, load development data, or evaluate until pure preflight passes.

## Method and exact geometry

Rolling-origin evaluation follows Leonard Tashman's out-of-sample design guidance, which recommends multiple rolling-origin test periods for more reliable evaluation: https://doi.org/10.1016/S0169-2070(00)00065-0. The chronological no-future-data constraint also matches the rolling forecasting-origin formulation documented by Hyndman: https://otexts.robjhyndman.com/fpp3/tscv.html.

The frozen calendar has 1,762 sessions and is bound by canonical hash `a6df7a68249842fa35814f282b3df63db19c52f6ea0697899979d3a8c970d9b1`.

- Terminal qualification geometry: `504 + 5 * 252 = 1,764`; infeasible by 2 observations even with zero lookback.
- Development geometry: `504 + 5 * 197 = 1,489`.
- Maximum supported causal lookback: 252 sessions.
- 252-session lookback first eligible month-end signal: index 271 / `2017-01-31`.
- Next-session execution: index 272 / `2017-02-01`.
- Available comparable observations: 1,490; one-observation surplus.
- Selected common end-anchored evaluation window: index 273 / `2017-02-02` through index 1,761 / `2022-12-30`.
- Test folds: `2019-02-05..2019-11-13`, `2019-11-14..2020-08-26`, `2020-08-27..2021-06-09`, `2021-06-10..2022-03-21`, and `2022-03-22..2022-12-30`.

The development statistics policy changes only the development walk-forward test length. The official terminal policy and paired complete-rebalance-block bootstrap, including its non-wrapping observed-block sampling semantics, are not modified.

## Related Issues

None.

## Testing

Exact head `262f6e6bd`:

- `bun test src/candidate-development.test.ts` — 9 passed, 0 failed.
- `bun run --filter @proompteng/bayn test` — 843 passed, 123 skipped integration tests, 0 failed; 966 tests across 74 files.
- `bun node_modules/typescript/bin/tsc --noEmit` — passed.
- `bun run lint:effect` — passed.
- `bun run lint:oxlint` — passed.
- `bun run lint:oxlint:type` — passed.
- `bun run lint` — Oxfmt passed.
- `bun run build` — passed; 726 modules bundled.
- `git diff --cached --check` before commit — passed.
- Repository pre-commit lint-staged and commitlint hooks — passed.

## Breaking Changes

None. No runtime, strategy, broker, authority, persistence, GitOps, candidate 5-8, or deployment path changed. No production rollout is required.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots section removed because this is a pure protocol change; Breaking Changes is filled in.
- [x] Methodological rationale is recorded at the code-facing protocol boundary; no release note or follow-up is required.
