### PR TITLE
fix(bayn): version candidate development protocol

### DIFF
--- a/services/bayn/src/candidate-development.test.ts
+++ b/services/bayn/src/candidate-development.test.ts
@@ -243,6 +243,24 @@ const simulationTrace = (costMultiplierMicros: string, order: SimulatedOrder = s
   dailyMarks: [],
 })
 
+const candidateDevelopmentEvaluation = <Report>(
+  report: Report,
+  stressedOrder: SimulatedOrder = simulatedOrder(),
+  stressedSignalDecisions: readonly SignalDecision[] = [signalDecision()],
+) => ({
+  report,
+  doubledCost: {
+    baseline: {
+      signalDecisions: [signalDecision()],
+      simulation: simulationTrace(candidateDevelopmentDoubledCostContract.baselineCostMultiplierMicros),
+    },
+    stressed: {
+      signalDecisions: stressedSignalDecisions,
+      simulation: simulationTrace(candidateDevelopmentDoubledCostContract.stressedCostMultiplierMicros, stressedOrder),
+    },
+  },
+})
+
 describe('candidate development walk-forward protocol', () => {
   test('freezes the exact 1,762-session development calendar without touching the holdout', () => {
     const sessions = developmentSessions()
@@ -353,17 +371,22 @@ describe('candidate development walk-forward protocol', () => {
 
   test('binds one deterministic versioned protocol identity into preflight', () => {
     const candidate13 = successOf(bindCandidateDevelopmentAttempt(13, 12))
-    const first = successOf(identifyCandidateDevelopmentProtocol(candidate13))
-    const second = successOf(identifyCandidateDevelopmentProtocol(candidate13))
-    const next = successOf(identifyCandidateDevelopmentProtocol(successOf(bindCandidateDevelopmentAttempt(14, 13))))
+    const first = successOf(identifyCandidateDevelopmentProtocol(candidate13, 252))
+    const second = successOf(identifyCandidateDevelopmentProtocol(candidate13, 252))
+    const differentLookback = successOf(identifyCandidateDevelopmentProtocol(candidate13, 63))
+    const next = successOf(
+      identifyCandidateDevelopmentProtocol(successOf(bindCandidateDevelopmentAttempt(14, 13)), 252),
+    )
     const preflight = successOf(preflightCandidateDevelopment(candidate13Input(developmentSessions())))
 
     expect(first).toEqual(second)
+    expect(first).not.toEqual(differentLookback)
     expect(first).not.toEqual(next)
     expect(first.schemaVersion).toBe('bayn.candidate-development-protocol-identity.v1')
     expect(first.candidateOrdinal).toBe(13)
     expect(first.priorTrialCount).toBe(12)
-    expect(first.protocolHash).toBe('fcd9331b0fdbc92815c36182c27b0cee7f66e2cc32f66ab9701c3c0496f34d33')
+    expect(first.featureLookbackSessions).toBe(252)
+    expect(first.protocolHash).toBe('e9cc365a8b1c2cffe2aa37b496387000695e2a78d1093ad36e142261eab88454')
     expect(preflight).toMatchObject({
       status: 'PASS',
       schemaVersion: 'bayn.candidate-development-preflight.v2',
@@ -608,7 +631,7 @@ describe('candidate development walk-forward protocol', () => {
             },
             evaluateDevelopment: () => {
               evaluations += 1
-              return Effect.succeed('report')
+              return Effect.succeed(candidateDevelopmentEvaluation('report'))
             },
           },
         ),
@@ -653,7 +676,7 @@ describe('candidate development walk-forward protocol', () => {
           },
           evaluateDevelopment: () => {
             evaluations += 1
-            return Effect.succeed('report')
+            return Effect.succeed(candidateDevelopmentEvaluation('report'))
           },
         },
       ),
@@ -663,6 +686,52 @@ describe('candidate development walk-forward protocol', () => {
     expect(preregistrations).toBe(0)
     expect(loads).toBe(0)
     expect(evaluations).toBe(0)
+  })
+
+  test('rejects an evaluated report when doubled-cost quantities diverge', async () => {
+    const sessions = developmentSessions()
+    let preregistrations = 0
+    let loads = 0
+    let evaluations = 0
+    const failure = await Effect.runPromise(
+      Effect.flip(
+        runCandidateDevelopment(candidate13Input(sessions), {
+          preregisterCandidate: () => {
+            preregistrations += 1
+            return Effect.succeed('registration')
+          },
+          loadDevelopmentData: () => {
+            loads += 1
+            return Effect.succeed('data')
+          },
+          evaluateDevelopment: () => {
+            evaluations += 1
+            return Effect.succeed(
+              candidateDevelopmentEvaluation(
+                'invalid-report',
+                simulatedOrder({
+                  filledQuantityMicros: '900000',
+                  status: 'partially-filled',
+                  unfilledRemainder: 'canceled',
+                }),
+              ),
+            )
+          },
+        }),
+      ),
+    )
+
+    expect(failure).toMatchObject({
+      _tag: 'CandidateDevelopmentDoubledCostInvalid',
+      cause: {
+        _tag: 'CandidateDevelopmentDoubledCostProtocolDeviation',
+        disposition: 'INVALID_PROTOCOL_DEVIATION',
+        reason: 'ORDER_QUANTITY_PATH_CHANGED',
+      },
+    })
+    expect(preregistrations).toBe(1)
+    expect(loads).toBe(1)
+    expect(evaluations).toBe(1)
   })
 
   test('preregisters, loads, and evaluates exactly once only after a passing preflight', async () => {
@@ -682,7 +751,7 @@ describe('candidate development walk-forward protocol', () => {
         },
         evaluateDevelopment: (data, preflight) => {
           evaluations += 1
-          return Effect.succeed(`${data}:${preflight.selectedObservationEnd}`)
+          return Effect.succeed(candidateDevelopmentEvaluation(`${data}:${preflight.selectedObservationEnd}`))
         },
       }),
     )

--- a/services/bayn/src/candidate-development.test.ts
+++ b/services/bayn/src/candidate-development.test.ts
@@ -2,18 +2,27 @@ import { describe, expect, test } from 'bun:test'
 import { Effect, Exit, Result } from 'effect'
 
 import {
+  bindCandidateDevelopmentAttempt,
+  candidateDevelopmentAttemptHorizon,
+  candidateDevelopmentBootstrapSamples,
   candidateDevelopmentCalendarContract,
+  candidateDevelopmentDoubledCostContract,
   candidateDevelopmentStatisticsPolicy,
   candidateDevelopmentWalkForwardProtocol,
   computeEndAnchoredWalkForwardBoundaries,
   firstEligibleExecutionAfterLookback,
+  identifyCandidateDevelopmentProtocol,
   officialMonthEndSignalDates,
   preflightCandidateDevelopment,
   requiredObservationsForWalkForward,
   runCandidateDevelopment,
+  validateCandidateDevelopmentDoubledCostCausalPath,
 } from './candidate-development'
+import { defaultExecutionModel } from './execution-model'
+import { canonicalHashV1Result } from './hash'
 import { defaultQualificationStatisticsPolicy } from './qualification-statistics'
 import type { IsoDate } from './schemas'
+import type { SignalDecision, SimulatedOrder, SimulationTrace } from './types'
 
 const fullMarketClosures = new Set<IsoDate>([
   '2016-01-18',
@@ -172,16 +181,72 @@ const successOf = <A, E>(result: Result.Result<A, E>): A => {
   return result.success
 }
 
+const candidate13Input = (sessions: readonly IsoDate[]) => ({
+  candidateOrdinal: 13,
+  priorTrialCount: 12,
+  officialSessions: sessions,
+  signalSessionDates: officialMonthEndSignalDates(sessions),
+  featureLookbackSessions: 252,
+})
+
+const simulatedOrder = (overrides: Partial<SimulatedOrder> = {}): SimulatedOrder => ({
+  id: 'a'.repeat(64),
+  decisionId: 'b'.repeat(64),
+  sessionDate: '2022-01-03',
+  symbol: 'SPY',
+  side: 'buy',
+  requestedQuantityMicros: '1000000',
+  filledQuantityMicros: '1000000',
+  status: 'filled',
+  rejectionReason: null,
+  unfilledRemainder: 'none',
+  ...overrides,
+})
+
+const signalDecision = (overrides: Partial<SignalDecision> = {}): SignalDecision => ({
+  schemaVersion: 'bayn.risk-balanced-trend-decision-plan.v1',
+  decisionId: 'b'.repeat(64),
+  signalDate: '2021-12-31',
+  executionDate: '2022-01-03',
+  covarianceWindow: {
+    returnCount: 63,
+    firstSession: '2021-10-01',
+    lastSession: '2021-12-31',
+    sessionsHash: 'c'.repeat(64),
+  },
+  estimatedAnnualizedPortfolioVolatility: 0.16,
+  exposureScale: 1,
+  targetWeights: { SPY: 1 },
+  signals: [
+    {
+      symbol: 'SPY',
+      horizons: [{ horizonSessions: 21, return: 0.05, normalizedTrend: 0.5 }],
+      dailyVolatility: 0.01,
+      annualizedVolatility: 0.16,
+      compositeScore: 0.5,
+      positiveScore: 0.5,
+      eligible: true,
+      uncappedWeight: 1,
+      cappedWeight: 1,
+      targetWeight: 1,
+    },
+  ],
+  ...overrides,
+})
+
+const simulationTrace = (costMultiplierMicros: string, order: SimulatedOrder = simulatedOrder()): SimulationTrace => ({
+  schemaVersion: 'bayn.simulation-trace.v3',
+  executionModel: defaultExecutionModel,
+  costMultiplierMicros,
+  orders: [order],
+  cashChanges: [],
+  dailyMarks: [],
+})
+
 describe('candidate development walk-forward protocol', () => {
   test('freezes the exact 1,762-session development calendar without touching the holdout', () => {
     const sessions = developmentSessions()
-    const result = successOf(
-      preflightCandidateDevelopment({
-        officialSessions: sessions,
-        signalSessionDates: officialMonthEndSignalDates(sessions),
-        featureLookbackSessions: 252,
-      }),
-    )
+    const result = successOf(preflightCandidateDevelopment(candidate13Input(sessions)))
 
     expect(sessions).toHaveLength(1_762)
     expect(sessions.at(0)).toBe('2016-01-04')
@@ -225,6 +290,8 @@ describe('candidate development walk-forward protocol', () => {
     ] of expectedAvailability) {
       const preflight = successOf(
         preflightCandidateDevelopment({
+          candidateOrdinal: 13,
+          priorTrialCount: 12,
           officialSessions: sessions,
           signalSessionDates: signals,
           featureLookbackSessions,
@@ -244,6 +311,112 @@ describe('candidate development walk-forward protocol', () => {
         folds: expectedFolds,
       })
     }
+  })
+
+  test('binds Candidate 13 and the deterministic bootstrap horizon before any effects', () => {
+    const candidate13 = successOf(bindCandidateDevelopmentAttempt(13, 12))
+    const horizon = successOf(bindCandidateDevelopmentAttempt(25, 24))
+
+    expect(candidateDevelopmentBootstrapSamples).toBe(10_000)
+    expect(candidateDevelopmentStatisticsPolicy.bootstrap.samples).toBe(10_000)
+    expect(defaultQualificationStatisticsPolicy.bootstrap.samples).toBe(5_000)
+    expect(bindCandidateDevelopmentAttempt(13, 11)).toEqual(
+      Result.fail({
+        _tag: 'CandidateDevelopmentAttemptLineageMismatch',
+        candidateOrdinal: 13,
+        priorTrialCount: 11,
+        expectedCandidateOrdinal: 12,
+      }),
+    )
+    expect(candidate13).toMatchObject({
+      candidateOrdinal: 13,
+      priorTrialCount: 12,
+      bootstrapSamples: 10_000,
+      tailSampleCount: 38,
+      minimumTailSamples: 20,
+      maximumCandidateOrdinal: 25,
+    })
+    expect(horizon.tailSampleCount).toBe(20)
+    expect(Math.floor((candidateDevelopmentBootstrapSamples - 1) * (0.05 / 25))).toBe(19)
+    expect(bindCandidateDevelopmentAttempt(26, 25)).toMatchObject(
+      Result.fail({
+        _tag: 'CandidateDevelopmentBootstrapTailInfeasible',
+        candidateOrdinal: 26,
+        priorTrialCount: 25,
+        bootstrapSamples: 10_000,
+        tailSampleCount: 19,
+        minimumTailSamples: 20,
+        maximumCandidateOrdinal: 25,
+      }),
+    )
+  })
+
+  test('binds one deterministic versioned protocol identity into preflight', () => {
+    const candidate13 = successOf(bindCandidateDevelopmentAttempt(13, 12))
+    const first = successOf(identifyCandidateDevelopmentProtocol(candidate13))
+    const second = successOf(identifyCandidateDevelopmentProtocol(candidate13))
+    const next = successOf(identifyCandidateDevelopmentProtocol(successOf(bindCandidateDevelopmentAttempt(14, 13))))
+    const preflight = successOf(preflightCandidateDevelopment(candidate13Input(developmentSessions())))
+
+    expect(first).toEqual(second)
+    expect(first).not.toEqual(next)
+    expect(first.schemaVersion).toBe('bayn.candidate-development-protocol-identity.v1')
+    expect(first.candidateOrdinal).toBe(13)
+    expect(first.priorTrialCount).toBe(12)
+    expect(first.protocolHash).toBe('fcd9331b0fdbc92815c36182c27b0cee7f66e2cc32f66ab9701c3c0496f34d33')
+    expect(preflight).toMatchObject({
+      status: 'PASS',
+      schemaVersion: 'bayn.candidate-development-preflight.v2',
+      attempt: {
+        candidateOrdinal: 13,
+        priorTrialCount: 12,
+        tailSampleCount: 38,
+      },
+      protocolIdentity: first,
+      doubledCostContract: candidateDevelopmentDoubledCostContract,
+    })
+  })
+
+  test('rejects Candidate 12 quantity-changing doubled-cost reruns as protocol deviations', () => {
+    const decisions = [signalDecision()]
+    const baseline = {
+      signalDecisions: decisions,
+      simulation: simulationTrace(candidateDevelopmentDoubledCostContract.baselineCostMultiplierMicros),
+    }
+    const invariantStress = {
+      signalDecisions: decisions,
+      simulation: simulationTrace(candidateDevelopmentDoubledCostContract.stressedCostMultiplierMicros),
+    }
+    const quantityChangingStress = {
+      signalDecisions: decisions,
+      simulation: simulationTrace(
+        candidateDevelopmentDoubledCostContract.stressedCostMultiplierMicros,
+        simulatedOrder({ filledQuantityMicros: '900000', status: 'partially-filled', unfilledRemainder: 'canceled' }),
+      ),
+    }
+    const signalChangingStress = {
+      signalDecisions: [signalDecision({ exposureScale: 0.5, targetWeights: { SPY: 0.5 } })],
+      simulation: simulationTrace(candidateDevelopmentDoubledCostContract.stressedCostMultiplierMicros),
+    }
+
+    expect(successOf(validateCandidateDevelopmentDoubledCostCausalPath(baseline, invariantStress))).toMatchObject({
+      schemaVersion: 'bayn.candidate-development-doubled-cost-check.v1',
+      status: 'PASS',
+    })
+    expect(validateCandidateDevelopmentDoubledCostCausalPath(baseline, quantityChangingStress)).toMatchObject(
+      Result.fail({
+        _tag: 'CandidateDevelopmentDoubledCostProtocolDeviation',
+        disposition: 'INVALID_PROTOCOL_DEVIATION',
+        reason: 'ORDER_QUANTITY_PATH_CHANGED',
+      }),
+    )
+    expect(validateCandidateDevelopmentDoubledCostCausalPath(baseline, signalChangingStress)).toMatchObject(
+      Result.fail({
+        _tag: 'CandidateDevelopmentDoubledCostProtocolDeviation',
+        disposition: 'INVALID_PROTOCOL_DEVIATION',
+        reason: 'SIGNAL_DECISIONS_CHANGED',
+      }),
+    )
   })
 
   test('proves the official terminal geometry is impossible while the distinct development geometry is feasible', () => {
@@ -277,7 +450,36 @@ describe('candidate development walk-forward protocol', () => {
     })
     expect(candidateDevelopmentStatisticsPolicy.walkForward.testSessions).toBe(197)
     expect(defaultQualificationStatisticsPolicy.walkForward.testSessions).toBe(252)
-    expect(candidateDevelopmentStatisticsPolicy.bootstrap).toEqual(defaultQualificationStatisticsPolicy.bootstrap)
+    expect(candidateDevelopmentStatisticsPolicy.bootstrap).toEqual({
+      ...defaultQualificationStatisticsPolicy.bootstrap,
+      samples: 10_000,
+    })
+    expect(defaultQualificationStatisticsPolicy).toMatchObject({
+      schemaVersion: 'bayn.qualification-statistics-policy.v1',
+      annualizationSessions: 252,
+      confidence: {
+        familyOneSidedAlpha: 0.05,
+        multiplicityAdjustment: 'bonferroni',
+        minimumTailSamples: 20,
+      },
+      bootstrap: {
+        method: 'paired-complete-rebalance-blocks',
+        samples: 5_000,
+        seedNamespace: 'bayn-risk-balanced-trend-qualification-v1',
+        lowerQuantile: 'nearest-rank',
+      },
+      walkForward: {
+        method: 'expanding-origin',
+        minimumTrainingSessions: 504,
+        testSessions: 252,
+        minimumFolds: 5,
+        minimumPositiveFoldFraction: 0.6,
+        maximumFoldDrawdown: 0.35,
+      },
+    })
+    expect(successOf(canonicalHashV1Result(defaultQualificationStatisticsPolicy))).toBe(
+      '8090c35a5e76e02bde5c74f7a71b5d0b005c3e0409165fde96f2748e827e88de',
+    )
   })
 
   test('covers exact off-by-one pass/fail boundaries and an infeasible 198-session protocol', () => {
@@ -325,6 +527,8 @@ describe('candidate development walk-forward protocol', () => {
 
     expect(
       preflightCandidateDevelopment({
+        candidateOrdinal: 13,
+        priorTrialCount: 12,
         officialSessions: sessions,
         signalSessionDates: officialMonthEndSignalDates(sessions),
         featureLookbackSessions: 63,
@@ -379,6 +583,51 @@ describe('candidate development walk-forward protocol', () => {
     )
   })
 
+  test('rejects the first infeasible ordinal before preregistration or data I/O', async () => {
+    let preregistrations = 0
+    let loads = 0
+    let evaluations = 0
+    const failure = await Effect.runPromise(
+      Effect.flip(
+        runCandidateDevelopment(
+          {
+            candidateOrdinal: candidateDevelopmentAttemptHorizon.maximumCandidateOrdinal + 1,
+            priorTrialCount: candidateDevelopmentAttemptHorizon.maximumCandidateOrdinal,
+            officialSessions: [],
+            signalSessionDates: [],
+            featureLookbackSessions: 0,
+          },
+          {
+            preregisterCandidate: () => {
+              preregistrations += 1
+              return Effect.succeed('registration')
+            },
+            loadDevelopmentData: () => {
+              loads += 1
+              return Effect.succeed('data')
+            },
+            evaluateDevelopment: () => {
+              evaluations += 1
+              return Effect.succeed('report')
+            },
+          },
+        ),
+      ),
+    )
+
+    expect(failure).toMatchObject({
+      _tag: 'CandidateDevelopmentPreflightInvalid',
+      cause: {
+        _tag: 'CandidateDevelopmentBootstrapTailInfeasible',
+        candidateOrdinal: 26,
+        tailSampleCount: 19,
+      },
+    })
+    expect(preregistrations).toBe(0)
+    expect(loads).toBe(0)
+    expect(evaluations).toBe(0)
+  })
+
   test('stops before preregistration, data loading, and evaluation when the schedule is infeasible', async () => {
     const sessions = developmentSessions()
     let preregistrations = 0
@@ -387,6 +636,8 @@ describe('candidate development walk-forward protocol', () => {
     const exit = await Effect.runPromiseExit(
       runCandidateDevelopment(
         {
+          candidateOrdinal: 13,
+          priorTrialCount: 12,
           officialSessions: sessions,
           signalSessionDates: [sessions[273]],
           featureLookbackSessions: 0,
@@ -420,30 +671,23 @@ describe('candidate development walk-forward protocol', () => {
     let loads = 0
     let evaluations = 0
     const report = await Effect.runPromise(
-      runCandidateDevelopment(
-        {
-          officialSessions: sessions,
-          signalSessionDates: officialMonthEndSignalDates(sessions),
-          featureLookbackSessions: 252,
+      runCandidateDevelopment(candidate13Input(sessions), {
+        preregisterCandidate: (preflight) => {
+          preregistrations += 1
+          return Effect.succeed(preflight.schemaVersion)
         },
-        {
-          preregisterCandidate: (preflight) => {
-            preregistrations += 1
-            return Effect.succeed(preflight.schemaVersion)
-          },
-          loadDevelopmentData: (registration, preflight) => {
-            loads += 1
-            return Effect.succeed(`${registration}:${preflight.selectedObservationStart}`)
-          },
-          evaluateDevelopment: (data, preflight) => {
-            evaluations += 1
-            return Effect.succeed(`${data}:${preflight.selectedObservationEnd}`)
-          },
+        loadDevelopmentData: (registration, preflight) => {
+          loads += 1
+          return Effect.succeed(`${registration}:${preflight.selectedObservationStart}`)
         },
-      ),
+        evaluateDevelopment: (data, preflight) => {
+          evaluations += 1
+          return Effect.succeed(`${data}:${preflight.selectedObservationEnd}`)
+        },
+      }),
     )
 
-    expect(report).toBe('bayn.candidate-development-preflight.v1:2017-02-02:2022-12-30')
+    expect(report).toBe('bayn.candidate-development-preflight.v2:2017-02-02:2022-12-30')
     expect(preregistrations).toBe(1)
     expect(loads).toBe(1)
     expect(evaluations).toBe(1)

--- a/services/bayn/src/candidate-development.ts
+++ b/services/bayn/src/candidate-development.ts
@@ -3,6 +3,7 @@ import { Effect, pipe, Result } from 'effect'
 import { canonicalHashV1Result, type CanonicalHashFailure } from './hash'
 import { defaultQualificationStatisticsPolicy, type QualificationStatisticsPolicy } from './qualification-statistics'
 import type { IsoDate } from './schemas'
+import type { SignalDecision, SimulatedOrder, SimulationTrace } from './types'
 
 export const candidateDevelopmentCalendarContract = {
   schemaVersion: 'bayn.candidate-development-calendar.v1',
@@ -34,10 +35,36 @@ export const candidateDevelopmentWalkForwardProtocol = {
   executionLagSessions: 1,
 } as const
 
+export const candidateDevelopmentAttemptHorizon = {
+  schemaVersion: 'bayn.candidate-development-attempt-horizon.v1',
+  maximumCandidateOrdinal: 25,
+  ordinalBinding: 'candidate-ordinal-equals-prior-trial-count-plus-one',
+} as const
+
+/**
+ * Doubled-cost development evidence is a second causal simulator run at exactly 2x modeled execution costs. The run is
+ * admissible only when the complete signal decisions and ordered requested/filled quantity path exactly match the 1x
+ * baseline. Any affordability or equity feedback that changes that path is an invalid protocol deviation rather than
+ * an alternative stressed result. Cash, fill prices, fees, and marked equity remain free to change causally.
+ */
+export const candidateDevelopmentDoubledCostContract = {
+  schemaVersion: 'bayn.candidate-development-doubled-cost.v1',
+  method: 'causal-rerun-with-invariant-signal-and-quantity-path',
+  baselineCostMultiplierMicros: '1000000',
+  stressedCostMultiplierMicros: '2000000',
+  divergenceDisposition: 'INVALID_PROTOCOL_DEVIATION',
+  invariants: ['signal-decisions', 'ordered-order-quantity-path'],
+} as const
+
+export const candidateDevelopmentBootstrapSamples = 10_000
+
 export const candidateDevelopmentStatisticsPolicy = {
   ...defaultQualificationStatisticsPolicy,
   confidence: { ...defaultQualificationStatisticsPolicy.confidence },
-  bootstrap: { ...defaultQualificationStatisticsPolicy.bootstrap },
+  bootstrap: {
+    ...defaultQualificationStatisticsPolicy.bootstrap,
+    samples: candidateDevelopmentBootstrapSamples,
+  },
   power: { ...defaultQualificationStatisticsPolicy.power },
   walkForward: {
     ...defaultQualificationStatisticsPolicy.walkForward,
@@ -46,6 +73,277 @@ export const candidateDevelopmentStatisticsPolicy = {
   },
   cashReturn: { ...defaultQualificationStatisticsPolicy.cashReturn },
 } as const satisfies QualificationStatisticsPolicy
+
+export const candidateDevelopmentProtocol = {
+  schemaVersion: 'bayn.candidate-development-protocol.v2',
+  calendar: candidateDevelopmentCalendarContract,
+  walkForward: candidateDevelopmentWalkForwardProtocol,
+  attemptHorizon: candidateDevelopmentAttemptHorizon,
+  doubledCost: candidateDevelopmentDoubledCostContract,
+  statisticsPolicy: candidateDevelopmentStatisticsPolicy,
+} as const
+
+export interface CandidateDevelopmentProtocolIdentity {
+  readonly schemaVersion: 'bayn.candidate-development-protocol-identity.v1'
+  readonly candidateOrdinal: number
+  readonly priorTrialCount: number
+  readonly protocolHash: string
+}
+
+export const identifyCandidateDevelopmentProtocol = (
+  attempt: CandidateDevelopmentBootstrapTailCapacity,
+): Result.Result<CandidateDevelopmentProtocolIdentity, CanonicalHashFailure> =>
+  pipe(
+    canonicalHashV1Result({
+      schemaVersion: 'bayn.candidate-development-protocol-binding.v1',
+      protocol: candidateDevelopmentProtocol,
+      attempt,
+    }),
+    Result.map((protocolHash) => ({
+      schemaVersion: 'bayn.candidate-development-protocol-identity.v1' as const,
+      candidateOrdinal: attempt.candidateOrdinal,
+      priorTrialCount: attempt.priorTrialCount,
+      protocolHash,
+    })),
+  )
+
+export interface CandidateDevelopmentBootstrapTailCapacity {
+  readonly candidateOrdinal: number
+  readonly priorTrialCount: number
+  readonly bootstrapSamples: number
+  readonly adjustedOneSidedAlpha: number
+  readonly tailSampleCount: number
+  readonly minimumTailSamples: number
+  readonly maximumCandidateOrdinal: number
+}
+
+export type CandidateDevelopmentAttemptIssue =
+  | {
+      readonly _tag: 'CandidateDevelopmentCandidateOrdinalInvalid'
+      readonly candidateOrdinal: number
+    }
+  | {
+      readonly _tag: 'CandidateDevelopmentPriorTrialCountInvalid'
+      readonly priorTrialCount: number
+    }
+  | {
+      readonly _tag: 'CandidateDevelopmentAttemptLineageMismatch'
+      readonly candidateOrdinal: number
+      readonly priorTrialCount: number
+      readonly expectedCandidateOrdinal: number
+    }
+  | ({
+      readonly _tag: 'CandidateDevelopmentBootstrapTailInfeasible'
+    } & CandidateDevelopmentBootstrapTailCapacity)
+
+export const bindCandidateDevelopmentAttempt = (
+  candidateOrdinal: number,
+  priorTrialCount: number,
+): Result.Result<CandidateDevelopmentBootstrapTailCapacity, CandidateDevelopmentAttemptIssue> => {
+  if (!Number.isSafeInteger(candidateOrdinal) || candidateOrdinal <= 0) {
+    return Result.fail({ _tag: 'CandidateDevelopmentCandidateOrdinalInvalid', candidateOrdinal })
+  }
+  if (!Number.isSafeInteger(priorTrialCount) || priorTrialCount < 0) {
+    return Result.fail({ _tag: 'CandidateDevelopmentPriorTrialCountInvalid', priorTrialCount })
+  }
+  const expectedCandidateOrdinal = priorTrialCount + 1
+  if (candidateOrdinal !== expectedCandidateOrdinal) {
+    return Result.fail({
+      _tag: 'CandidateDevelopmentAttemptLineageMismatch',
+      candidateOrdinal,
+      priorTrialCount,
+      expectedCandidateOrdinal,
+    })
+  }
+
+  const adjustedOneSidedAlpha = candidateDevelopmentStatisticsPolicy.confidence.familyOneSidedAlpha / candidateOrdinal
+  const tailSampleCount = Math.floor(candidateDevelopmentStatisticsPolicy.bootstrap.samples * adjustedOneSidedAlpha)
+  const capacity = {
+    candidateOrdinal,
+    priorTrialCount,
+    bootstrapSamples: candidateDevelopmentStatisticsPolicy.bootstrap.samples,
+    adjustedOneSidedAlpha,
+    tailSampleCount,
+    minimumTailSamples: candidateDevelopmentStatisticsPolicy.confidence.minimumTailSamples,
+    maximumCandidateOrdinal: candidateDevelopmentAttemptHorizon.maximumCandidateOrdinal,
+  }
+  return candidateOrdinal <= candidateDevelopmentAttemptHorizon.maximumCandidateOrdinal &&
+    tailSampleCount >= candidateDevelopmentStatisticsPolicy.confidence.minimumTailSamples
+    ? Result.succeed(capacity)
+    : Result.fail({ _tag: 'CandidateDevelopmentBootstrapTailInfeasible', ...capacity })
+}
+
+type CandidateDevelopmentOrderQuantityPathEntry = Pick<
+  SimulatedOrder,
+  | 'decisionId'
+  | 'sessionDate'
+  | 'symbol'
+  | 'side'
+  | 'requestedQuantityMicros'
+  | 'filledQuantityMicros'
+  | 'status'
+  | 'rejectionReason'
+  | 'unfilledRemainder'
+>
+
+export interface CandidateDevelopmentDoubledCostRun {
+  readonly signalDecisions: readonly SignalDecision[]
+  readonly simulation: SimulationTrace
+}
+
+export interface CandidateDevelopmentDoubledCostPass {
+  readonly schemaVersion: 'bayn.candidate-development-doubled-cost-check.v1'
+  readonly status: 'PASS'
+  readonly signalDecisionsHash: string
+  readonly orderQuantityPathHash: string
+  readonly executionModelHash: string
+}
+
+export type CandidateDevelopmentDoubledCostIssue =
+  | {
+      readonly _tag: 'CandidateDevelopmentDoubledCostMultiplierMismatch'
+      readonly run: 'baseline' | 'stressed'
+      readonly expected: string
+      readonly observed: string
+    }
+  | {
+      readonly _tag: 'CandidateDevelopmentDoubledCostHashFailed'
+      readonly material:
+        | 'baseline-signals'
+        | 'stressed-signals'
+        | 'baseline-orders'
+        | 'stressed-orders'
+        | 'baseline-execution-model'
+        | 'stressed-execution-model'
+      readonly cause: CanonicalHashFailure
+    }
+  | {
+      readonly _tag: 'CandidateDevelopmentDoubledCostProtocolDeviation'
+      readonly disposition: 'INVALID_PROTOCOL_DEVIATION'
+      readonly reason: 'EXECUTION_MODEL_CHANGED' | 'SIGNAL_DECISIONS_CHANGED' | 'ORDER_QUANTITY_PATH_CHANGED'
+      readonly baselineHash: string
+      readonly stressedHash: string
+    }
+
+type CandidateDevelopmentDoubledCostHashMaterial = Extract<
+  CandidateDevelopmentDoubledCostIssue,
+  { readonly _tag: 'CandidateDevelopmentDoubledCostHashFailed' }
+>['material']
+
+const orderQuantityPath = (orders: readonly SimulatedOrder[]): readonly CandidateDevelopmentOrderQuantityPathEntry[] =>
+  orders.map(
+    ({
+      decisionId,
+      sessionDate,
+      symbol,
+      side,
+      requestedQuantityMicros,
+      filledQuantityMicros,
+      status,
+      rejectionReason,
+      unfilledRemainder,
+    }) => ({
+      decisionId,
+      sessionDate,
+      symbol,
+      side,
+      requestedQuantityMicros,
+      filledQuantityMicros,
+      status,
+      rejectionReason,
+      unfilledRemainder,
+    }),
+  )
+
+const doubledCostHash = (
+  material: CandidateDevelopmentDoubledCostHashMaterial,
+  value: unknown,
+): Result.Result<string, CandidateDevelopmentDoubledCostIssue> =>
+  pipe(
+    canonicalHashV1Result(value),
+    Result.mapError((cause) => ({
+      _tag: 'CandidateDevelopmentDoubledCostHashFailed' as const,
+      material,
+      cause,
+    })),
+  )
+
+const invariantHash = (
+  reason: Extract<
+    CandidateDevelopmentDoubledCostIssue,
+    { readonly _tag: 'CandidateDevelopmentDoubledCostProtocolDeviation' }
+  >['reason'],
+  baselineHash: string,
+  stressedHash: string,
+): Result.Result<string, CandidateDevelopmentDoubledCostIssue> =>
+  baselineHash === stressedHash
+    ? Result.succeed(baselineHash)
+    : Result.fail({
+        _tag: 'CandidateDevelopmentDoubledCostProtocolDeviation',
+        disposition: candidateDevelopmentDoubledCostContract.divergenceDisposition,
+        reason,
+        baselineHash,
+        stressedHash,
+      })
+
+export const validateCandidateDevelopmentDoubledCostCausalPath = (
+  baseline: CandidateDevelopmentDoubledCostRun,
+  stressed: CandidateDevelopmentDoubledCostRun,
+): Result.Result<CandidateDevelopmentDoubledCostPass, CandidateDevelopmentDoubledCostIssue> => {
+  const multipliers = [
+    ['baseline', candidateDevelopmentDoubledCostContract.baselineCostMultiplierMicros, baseline.simulation],
+    ['stressed', candidateDevelopmentDoubledCostContract.stressedCostMultiplierMicros, stressed.simulation],
+  ] as const
+  for (const [run, expected, simulation] of multipliers) {
+    if (simulation.costMultiplierMicros !== expected) {
+      return Result.fail({
+        _tag: 'CandidateDevelopmentDoubledCostMultiplierMismatch',
+        run,
+        expected,
+        observed: simulation.costMultiplierMicros,
+      })
+    }
+  }
+
+  return pipe(
+    Result.all({
+      baselineSignals: doubledCostHash('baseline-signals', baseline.signalDecisions),
+      stressedSignals: doubledCostHash('stressed-signals', stressed.signalDecisions),
+      baselineOrders: doubledCostHash('baseline-orders', orderQuantityPath(baseline.simulation.orders)),
+      stressedOrders: doubledCostHash('stressed-orders', orderQuantityPath(stressed.simulation.orders)),
+      baselineExecutionModel: doubledCostHash('baseline-execution-model', baseline.simulation.executionModel),
+      stressedExecutionModel: doubledCostHash('stressed-execution-model', stressed.simulation.executionModel),
+    }),
+    Result.flatMap(
+      ({
+        baselineExecutionModel,
+        baselineOrders,
+        baselineSignals,
+        stressedExecutionModel,
+        stressedOrders,
+        stressedSignals,
+      }) =>
+        pipe(
+          Result.all({
+            executionModelHash: invariantHash(
+              'EXECUTION_MODEL_CHANGED',
+              baselineExecutionModel,
+              stressedExecutionModel,
+            ),
+            signalDecisionsHash: invariantHash('SIGNAL_DECISIONS_CHANGED', baselineSignals, stressedSignals),
+            orderQuantityPathHash: invariantHash('ORDER_QUANTITY_PATH_CHANGED', baselineOrders, stressedOrders),
+          }),
+          Result.map(({ executionModelHash, orderQuantityPathHash, signalDecisionsHash }) => ({
+            schemaVersion: 'bayn.candidate-development-doubled-cost-check.v1' as const,
+            status: 'PASS' as const,
+            signalDecisionsHash,
+            orderQuantityPathHash,
+            executionModelHash,
+          })),
+        ),
+    ),
+  )
+}
 
 export interface CandidateDevelopmentWalkForwardGeometry {
   readonly minimumTrainingSessions: number
@@ -133,6 +431,7 @@ export type CandidateDevelopmentGeometryIssue =
 
 export type CandidateDevelopmentPreflightIssue =
   | CandidateDevelopmentGeometryIssue
+  | CandidateDevelopmentAttemptIssue
   | {
       readonly _tag: 'CandidateDevelopmentCalendarDateInvalid'
       readonly index: number
@@ -184,11 +483,18 @@ export type CandidateDevelopmentPreflightIssue =
       readonly _tag: 'CandidateDevelopmentEligibleExecutionMissing'
       readonly featureLookbackSessions: number
     }
+  | {
+      readonly _tag: 'CandidateDevelopmentProtocolHashFailed'
+      readonly cause: CanonicalHashFailure
+    }
 
 export interface CandidateDevelopmentPreflightPass extends CandidateDevelopmentGeometryPass {
-  readonly schemaVersion: 'bayn.candidate-development-preflight.v1'
+  readonly schemaVersion: 'bayn.candidate-development-preflight.v2'
+  readonly attempt: CandidateDevelopmentBootstrapTailCapacity
   readonly featureLookbackSessions: number
   readonly firstEligibleExecution: CandidateDevelopmentExecutionBoundary
+  readonly protocolIdentity: CandidateDevelopmentProtocolIdentity
+  readonly doubledCostContract: typeof candidateDevelopmentDoubledCostContract
   readonly statisticsPolicy: typeof candidateDevelopmentStatisticsPolicy
 }
 
@@ -205,6 +511,8 @@ export type CandidateDevelopmentRunFailure =
     }
 
 export interface CandidateDevelopmentPreflightInput {
+  readonly candidateOrdinal: number
+  readonly priorTrialCount: number
   readonly officialSessions: readonly IsoDate[]
   readonly signalSessionDates: readonly IsoDate[]
   readonly featureLookbackSessions: number
@@ -542,30 +850,50 @@ export const preflightCandidateDevelopment = (
   input: CandidateDevelopmentPreflightInput,
 ): Result.Result<CandidateDevelopmentPreflightDecision, CandidateDevelopmentPreflightIssue> =>
   pipe(
-    validateFrozenDevelopmentCalendar(input.officialSessions),
-    Result.flatMap(() =>
-      firstEligibleExecutionAfterLookback(
-        input.officialSessions,
-        input.signalSessionDates,
-        input.featureLookbackSessions,
+    bindCandidateDevelopmentAttempt(input.candidateOrdinal, input.priorTrialCount),
+    Result.flatMap((attempt) =>
+      pipe(
+        validateFrozenDevelopmentCalendar(input.officialSessions),
+        Result.flatMap(() =>
+          firstEligibleExecutionAfterLookback(
+            input.officialSessions,
+            input.signalSessionDates,
+            input.featureLookbackSessions,
+          ),
+        ),
+        Result.map((firstEligibleExecution) => ({ attempt, firstEligibleExecution })),
       ),
     ),
-    Result.flatMap((firstEligibleExecution) =>
+    Result.flatMap(({ attempt, firstEligibleExecution }) =>
       pipe(
-        computeEndAnchoredWalkForwardBoundaries(
-          input.officialSessions,
-          firstEligibleExecution.executionIndex,
-          candidateDevelopmentWalkForwardProtocol,
-        ),
+        Result.all({
+          geometry: computeEndAnchoredWalkForwardBoundaries(
+            input.officialSessions,
+            firstEligibleExecution.executionIndex,
+            candidateDevelopmentWalkForwardProtocol,
+          ),
+          protocolIdentity: pipe(
+            identifyCandidateDevelopmentProtocol(attempt),
+            Result.mapError(
+              (cause): CandidateDevelopmentPreflightIssue => ({
+                _tag: 'CandidateDevelopmentProtocolHashFailed',
+                cause,
+              }),
+            ),
+          ),
+        }),
         Result.map(
-          (geometry): CandidateDevelopmentPreflightDecision =>
+          ({ geometry, protocolIdentity }): CandidateDevelopmentPreflightDecision =>
             geometry.status === 'FAIL'
               ? geometry
               : {
                   ...geometry,
-                  schemaVersion: 'bayn.candidate-development-preflight.v1',
+                  schemaVersion: 'bayn.candidate-development-preflight.v2',
+                  attempt,
                   featureLookbackSessions: input.featureLookbackSessions,
                   firstEligibleExecution,
+                  protocolIdentity,
+                  doubledCostContract: candidateDevelopmentDoubledCostContract,
                   statisticsPolicy: candidateDevelopmentStatisticsPolicy,
                 },
         ),

--- a/services/bayn/src/candidate-development.ts
+++ b/services/bayn/src/candidate-development.ts
@@ -87,22 +87,26 @@ export interface CandidateDevelopmentProtocolIdentity {
   readonly schemaVersion: 'bayn.candidate-development-protocol-identity.v1'
   readonly candidateOrdinal: number
   readonly priorTrialCount: number
+  readonly featureLookbackSessions: number
   readonly protocolHash: string
 }
 
 export const identifyCandidateDevelopmentProtocol = (
   attempt: CandidateDevelopmentBootstrapTailCapacity,
+  featureLookbackSessions: number,
 ): Result.Result<CandidateDevelopmentProtocolIdentity, CanonicalHashFailure> =>
   pipe(
     canonicalHashV1Result({
       schemaVersion: 'bayn.candidate-development-protocol-binding.v1',
       protocol: candidateDevelopmentProtocol,
       attempt,
+      featureLookbackSessions,
     }),
     Result.map((protocolHash) => ({
       schemaVersion: 'bayn.candidate-development-protocol-identity.v1' as const,
       candidateOrdinal: attempt.candidateOrdinal,
       priorTrialCount: attempt.priorTrialCount,
+      featureLookbackSessions,
       protocolHash,
     })),
   )
@@ -509,6 +513,10 @@ export type CandidateDevelopmentRunFailure =
       readonly _tag: 'CandidateDevelopmentPreflightFailed'
       readonly preflight: CandidateDevelopmentGeometryFail
     }
+  | {
+      readonly _tag: 'CandidateDevelopmentDoubledCostInvalid'
+      readonly cause: CandidateDevelopmentDoubledCostIssue
+    }
 
 export interface CandidateDevelopmentPreflightInput {
   readonly candidateOrdinal: number
@@ -529,7 +537,15 @@ export interface CandidateDevelopmentEffects<Registration, Data, Report, Error, 
   readonly evaluateDevelopment: (
     data: Data,
     preflight: CandidateDevelopmentPreflightPass,
-  ) => Effect.Effect<Report, Error, Requirements>
+  ) => Effect.Effect<CandidateDevelopmentEvaluation<Report>, Error, Requirements>
+}
+
+export interface CandidateDevelopmentEvaluation<Report> {
+  readonly report: Report
+  readonly doubledCost: {
+    readonly baseline: CandidateDevelopmentDoubledCostRun
+    readonly stressed: CandidateDevelopmentDoubledCostRun
+  }
 }
 
 const validIsoDate = (value: string): value is IsoDate => {
@@ -873,7 +889,7 @@ export const preflightCandidateDevelopment = (
             candidateDevelopmentWalkForwardProtocol,
           ),
           protocolIdentity: pipe(
-            identifyCandidateDevelopmentProtocol(attempt),
+            identifyCandidateDevelopmentProtocol(attempt, input.featureLookbackSessions),
             Result.mapError(
               (cause): CandidateDevelopmentPreflightIssue => ({
                 _tag: 'CandidateDevelopmentProtocolHashFailed',
@@ -919,6 +935,22 @@ export const runCandidateDevelopment = <Registration, Data, Report, Error, Requi
           : effects.preregisterCandidate(preflight).pipe(
               Effect.flatMap((registration) => effects.loadDevelopmentData(registration, preflight)),
               Effect.flatMap((data) => effects.evaluateDevelopment(data, preflight)),
+              Effect.flatMap((evaluation) =>
+                Effect.fromResult(
+                  validateCandidateDevelopmentDoubledCostCausalPath(
+                    evaluation.doubledCost.baseline,
+                    evaluation.doubledCost.stressed,
+                  ),
+                ).pipe(
+                  Effect.mapError(
+                    (cause): CandidateDevelopmentRunFailure => ({
+                      _tag: 'CandidateDevelopmentDoubledCostInvalid',
+                      cause,
+                    }),
+                  ),
+                  Effect.map(() => evaluation.report),
+                ),
+              ),
             ),
     ),
   )


### PR DESCRIPTION
## Summary

- version the candidate-development protocol and bind each attempt to `candidateOrdinal = priorTrialCount + 1`, deterministic bootstrap tail capacity, selected feature lookback, and a canonical protocol hash before any I/O
- define doubled-cost development evidence as a causal 2x-cost rerun that is valid only when signal decisions and the ordered requested/filled quantity path remain invariant; divergence is `INVALID_PROTOCOL_DEVIATION`
- require `runCandidateDevelopment` to validate doubled-cost evidence before returning any successful development report, so the contract cannot be bypassed by an evaluator
- raise only the development bootstrap policy from 5,000 to the minimal 10,000 samples required for the explicit ordinal-25 horizon, while preserving terminal qualification policy, alpha, minimum-tail, walk-forward gates, and calendar geometry
- add focused regressions for Candidate 12-style quantity feedback, Candidate 13 feasibility, ordinal/prior-trial mismatch, lookback identity, the ordinal-25/26 boundary, mandatory runner validation, terminal-policy identity, and zero I/O on preflight rejection

## Related Issues

None

## Testing

- `bun test services/bayn/src/candidate-development.test.ts` — 14 pass, 0 fail, 86 assertions
- `bun run --filter @proompteng/bayn test` — 848 pass, 123 PostgreSQL-gated skips, 0 fail, 6,309 assertions across 971 tests
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:effect` — 0 errors, warnings, or messages
- `bun run --filter @proompteng/bayn lint:oxlint` — 0 warnings or errors
- `bun run --filter @proompteng/bayn lint:oxlint:type` — 0 warnings or errors
- `bun run --filter @proompteng/bayn build`
- `git diff --check`
- Candidate 13 / 252-session lookback protocol hash: `e9cc365a8b1c2cffe2aa37b496387000695e2a78d1093ad36e142261eab88454`
- unchanged terminal qualification policy hash: `8090c35a5e76e02bde5c74f7a71b5d0b005c3e0409165fde96f2748e827e88de`
- no market data, holdout data, candidate trial, broker mutation, database mutation, or deployment action was performed

## Breaking Changes

The internal `CandidateDevelopmentPreflightInput` now requires `candidateOrdinal` and `priorTrialCount`, passing preflight evidence uses schema `bayn.candidate-development-preflight.v2`, and `evaluateDevelopment` must return its report together with baseline/stressed doubled-cost evidence for mandatory validation. There is no production-code consumer outside this module's tests on the base commit.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] No candidate-specific documentation, release notes, or unrelated follow-up is required in this scoped protocol repair.
