### PR TITLE
fix(bayn): bind candidate comparison semantics

### DIFF
--- a/services/bayn/src/candidate-development.test.ts
+++ b/services/bayn/src/candidate-development.test.ts
@@ -3,9 +3,11 @@ import { Effect, Exit, Result } from 'effect'
 
 import {
   bindCandidateDevelopmentAttempt,
+  buildCandidateDevelopmentComparisonSemanticsEvidence,
   candidateDevelopmentAttemptHorizon,
   candidateDevelopmentBootstrapSamples,
   candidateDevelopmentCalendarContract,
+  candidateDevelopmentComparisonSemantics,
   candidateDevelopmentDoubledCostContract,
   candidateDevelopmentStatisticsPolicy,
   candidateDevelopmentWalkForwardProtocol,
@@ -16,13 +18,21 @@ import {
   preflightCandidateDevelopment,
   requiredObservationsForWalkForward,
   runCandidateDevelopment,
+  validateCandidateDevelopmentComparisonSemanticsEvidence,
+  validateCandidateDevelopmentComparisonSeriesBinding,
   validateCandidateDevelopmentDoubledCostCausalPath,
+  type CandidateDevelopmentComparisonSemanticsEvidence,
+  type CandidateDevelopmentPreflightPass,
 } from './candidate-development'
 import { defaultExecutionModel } from './execution-model'
 import { canonicalHashV1Result } from './hash'
-import { defaultQualificationStatisticsPolicy } from './qualification-statistics'
+import {
+  defaultQualificationStatisticsPolicy,
+  prepareQualificationSeries,
+  type QualificationSeries,
+} from './qualification-statistics'
 import type { IsoDate } from './schemas'
-import type { SignalDecision, SimulatedOrder, SimulationTrace } from './types'
+import type { EvaluationResult, SignalDecision, SimulatedOrder, SimulationTrace } from './types'
 
 const fullMarketClosures = new Set<IsoDate>([
   '2016-01-18',
@@ -234,32 +244,192 @@ const signalDecision = (overrides: Partial<SignalDecision> = {}): SignalDecision
   ...overrides,
 })
 
-const simulationTrace = (costMultiplierMicros: string, order: SimulatedOrder = simulatedOrder()): SimulationTrace => ({
+const simulationTrace = (
+  costMultiplierMicros: string,
+  order: SimulatedOrder = simulatedOrder(),
+  dailyMarks: SimulationTrace['dailyMarks'] = [],
+): SimulationTrace => ({
   schemaVersion: 'bayn.simulation-trace.v3',
   executionModel: defaultExecutionModel,
   costMultiplierMicros,
   orders: [order],
   cashChanges: [],
-  dailyMarks: [],
+  dailyMarks,
 })
 
-const candidateDevelopmentEvaluation = <Report>(
-  report: Report,
-  stressedOrder: SimulatedOrder = simulatedOrder(),
-  stressedSignalDecisions: readonly SignalDecision[] = [signalDecision()],
-) => ({
-  report,
-  doubledCost: {
-    baseline: {
-      signalDecisions: [signalDecision()],
-      simulation: simulationTrace(candidateDevelopmentDoubledCostContract.baselineCostMultiplierMicros),
-    },
-    stressed: {
-      signalDecisions: stressedSignalDecisions,
-      simulation: simulationTrace(candidateDevelopmentDoubledCostContract.stressedCostMultiplierMicros, stressedOrder),
-    },
-  },
+const performanceMetrics = () => ({
+  observations: 1,
+  totalReturn: 0,
+  annualizedReturn: 0,
+  annualizedVolatility: 0,
+  sharpe: 0,
+  maximumDrawdown: 0,
+  annualTurnover: 0,
+  totalFeesMicros: '0',
+  totalSpreadCostMicros: '0',
+  totalSlippageCostMicros: '0',
+  totalCashYieldMicros: '0',
+  endingEquityMicros: '1000000',
 })
+
+const evaluationSignalDecisions = (
+  preflight: CandidateDevelopmentPreflightPass,
+  sessions: readonly IsoDate[],
+): readonly SignalDecision[] => {
+  const officialSessions = developmentSessions()
+  return sessions
+    .map((executionDate, index) => ({ executionDate, index }))
+    .filter(({ index }) => index % 100 === 0)
+    .map(({ executionDate, index }, ordinal) =>
+      signalDecision({
+        decisionId: (ordinal + 1).toString(16).padStart(64, '0'),
+        signalDate:
+          officialSessions.at(preflight.selectedObservationStartIndex + index - 1) ??
+          preflight.selectedObservationStart,
+        executionDate,
+      }),
+    )
+}
+
+const baselineEvaluation = (
+  preflight: CandidateDevelopmentPreflightPass,
+  sessions: readonly IsoDate[] = preflight.selectedObservationSessions,
+): EvaluationResult => {
+  const signalDecisions = evaluationSignalDecisions(preflight, sessions)
+  const dailyMarks = sessions.map((sessionDate, index) => ({
+    sessionDate,
+    equityMicros: '1000000',
+    netReturn: index % 2 === 0 ? 0.0012 : 0.0008,
+    turnoverMicros: '0',
+    cumulativeTurnoverMicros: '0',
+    feeMicros: '0',
+    cumulativeFeesMicros: '0',
+    spreadCostMicros: '0',
+    cumulativeSpreadCostMicros: '0',
+    slippageCostMicros: '0',
+    cumulativeSlippageCostMicros: '0',
+    cashYieldMicros: '0',
+    cumulativeCashYieldMicros: '0',
+    peakEquityMicros: '1000000',
+    drawdown: 0,
+    cashMicros: '0',
+    positions: [
+      {
+        symbol: 'SPY',
+        quantityMicros: '1000000',
+        costBasisMicros: '1000000',
+        priceMicros: '1000000',
+        marketValueMicros: '1000000',
+      },
+    ],
+  }))
+  const performancePoint = (sessionDate: IsoDate, netReturn: number) => ({
+    sessionDate,
+    equityMicros: '1000000',
+    netReturn,
+    turnoverMicros: '0',
+    cumulativeTurnoverMicros: '0',
+    feeMicros: '0',
+    cumulativeFeesMicros: '0',
+    spreadCostMicros: '0',
+    cumulativeSpreadCostMicros: '0',
+    slippageCostMicros: '0',
+    cumulativeSlippageCostMicros: '0',
+    cashYieldMicros: '0',
+    cumulativeCashYieldMicros: '0',
+    peakEquityMicros: '1000000',
+    drawdown: 0,
+  })
+  const buyAndHold = sessions.map((sessionDate, index) =>
+    performancePoint(sessionDate, index % 2 === 0 ? 0.0009 : 0.0007),
+  )
+  const directVolTiming = sessions.map((sessionDate, index) =>
+    performancePoint(sessionDate, index % 2 === 0 ? 0.0007 : 0.0005),
+  )
+  return {
+    schemaVersion: 'bayn.evaluation.v6',
+    runId: 'a'.repeat(64),
+    codeRevision: 'b'.repeat(40),
+    protocolHash: preflight.protocolIdentity.protocolHash,
+    initialCapitalMicros: '1000000',
+    inputManifest: {} as EvaluationResult['inputManifest'],
+    strategy: performanceMetrics(),
+    buyAndHold: performanceMetrics(),
+    directVolTiming: performanceMetrics(),
+    doubleCostStrategy: performanceMetrics(),
+    verdict: { status: 'PASS', gates: [] },
+    events: [],
+    simulation: simulationTrace(
+      candidateDevelopmentDoubledCostContract.baselineCostMultiplierMicros,
+      simulatedOrder(),
+      dailyMarks,
+    ),
+    benchmarkSeries: {
+      buyAndHold,
+      directVolTiming,
+      doubleCostStrategy: buyAndHold,
+    },
+    equitySeries: [],
+    markedEquityReconciliation: {} as EvaluationResult['markedEquityReconciliation'],
+    signalDecisions,
+  }
+}
+
+const comparisonSeriesOf = (baseline: EvaluationResult): QualificationSeries =>
+  successOf(prepareQualificationSeries(baseline))
+
+let cachedComparisonEvidence:
+  | {
+      readonly protocolHash: string
+      readonly baseline: EvaluationResult
+      readonly series: QualificationSeries
+      readonly evidence: CandidateDevelopmentComparisonSemanticsEvidence
+    }
+  | undefined
+
+const exactComparisonFixture = (
+  preflight: CandidateDevelopmentPreflightPass,
+): {
+  readonly baseline: EvaluationResult
+  readonly series: QualificationSeries
+  readonly evidence: CandidateDevelopmentComparisonSemanticsEvidence
+} => {
+  if (cachedComparisonEvidence?.protocolHash === preflight.protocolIdentity.protocolHash) {
+    return cachedComparisonEvidence
+  }
+  const baseline = baselineEvaluation(preflight)
+  const series = comparisonSeriesOf(baseline)
+  const evidence = successOf(buildCandidateDevelopmentComparisonSemanticsEvidence(preflight, series))
+  cachedComparisonEvidence = { protocolHash: preflight.protocolIdentity.protocolHash, baseline, series, evidence }
+  return cachedComparisonEvidence
+}
+
+const candidateDevelopmentEvaluation = (
+  preflight: CandidateDevelopmentPreflightPass,
+  overrides: {
+    readonly baseline?: EvaluationResult
+    readonly stressedOrder?: SimulatedOrder
+    readonly stressedSignalDecisions?: readonly SignalDecision[]
+    readonly comparisonSemantics?: CandidateDevelopmentComparisonSemanticsEvidence
+  } = {},
+) => {
+  const fixture = exactComparisonFixture(preflight)
+  const baseline = overrides.baseline ?? fixture.baseline
+  const comparisonSemantics =
+    overrides.comparisonSemantics ??
+    successOf(buildCandidateDevelopmentComparisonSemanticsEvidence(preflight, comparisonSeriesOf(baseline)))
+  return {
+    baseline,
+    comparisonSemantics,
+    stressed: {
+      signalDecisions: overrides.stressedSignalDecisions ?? baseline.signalDecisions,
+      simulation: simulationTrace(
+        candidateDevelopmentDoubledCostContract.stressedCostMultiplierMicros,
+        overrides.stressedOrder ?? baseline.simulation.orders.at(0) ?? simulatedOrder(),
+      ),
+    },
+  }
+}
 
 describe('candidate development walk-forward protocol', () => {
   test('freezes the exact 1,762-session development calendar without touching the holdout', () => {
@@ -386,10 +556,10 @@ describe('candidate development walk-forward protocol', () => {
     expect(first.candidateOrdinal).toBe(13)
     expect(first.priorTrialCount).toBe(12)
     expect(first.featureLookbackSessions).toBe(252)
-    expect(first.protocolHash).toBe('e9cc365a8b1c2cffe2aa37b496387000695e2a78d1093ad36e142261eab88454')
+    expect(first.protocolHash).toBe('5930dfb8922201101ca4edc3c408f0a79a22de8e35bfec2b9fee6e4625aa441e')
     expect(preflight).toMatchObject({
       status: 'PASS',
-      schemaVersion: 'bayn.candidate-development-preflight.v2',
+      schemaVersion: 'bayn.candidate-development-preflight.v3',
       attempt: {
         candidateOrdinal: 13,
         priorTrialCount: 12,
@@ -397,6 +567,270 @@ describe('candidate development walk-forward protocol', () => {
       },
       protocolIdentity: first,
       doubledCostContract: candidateDevelopmentDoubledCostContract,
+      comparisonSemantics: candidateDevelopmentComparisonSemantics,
+    })
+    if (preflight.status === 'FAIL') throw new Error('expected passing preflight')
+    expect(preflight.selectedObservationSessions).toHaveLength(1_489)
+    expect(preflight.selectedObservationSessions.at(0)).toBe('2017-02-02')
+    expect(preflight.selectedObservationSessions.at(-1)).toBe('2022-12-30')
+  })
+
+  test('accepts exact benchmark-relative comparison semantics for every uncertainty and walk-forward gate', () => {
+    const preflight = successOf(preflightCandidateDevelopment(candidate13Input(developmentSessions())))
+    expect(preflight.status).toBe('PASS')
+    if (preflight.status === 'FAIL') throw new Error('expected passing preflight')
+    const { baseline, evidence, series } = exactComparisonFixture(preflight)
+
+    expect(successOf(validateCandidateDevelopmentComparisonSeriesBinding(preflight, baseline, series))).toEqual(series)
+    expect(successOf(validateCandidateDevelopmentComparisonSemanticsEvidence(preflight, series, evidence))).toEqual(
+      evidence,
+    )
+    expect(evidence.analysis.bootstrap.selectedBenchmark).toBe('buy-and-hold')
+    expect(evidence.analysis.walkForward.selectedBenchmark).toBe('buy-and-hold')
+    expect(evidence.comparisonSemantics.gates.annualizedExcessReturnLowerBound).toMatchObject({
+      baseline: 'selected-benchmark',
+    })
+    expect(evidence.comparisonSemantics.gates.sharpeDifferenceLowerBound).toMatchObject({
+      baseline: 'selected-benchmark',
+    })
+    expect(evidence.comparisonSemantics.gates.walkForwardPositiveFraction).toMatchObject({
+      baseline: 'selected-benchmark',
+    })
+    expect(evidence.comparisonSemantics.gates.walkForwardDrawdown).toMatchObject({
+      baseline: 'candidate',
+    })
+  })
+
+  test('binds the derived comparison series to the baseline run, exact preflight window, and rebalance schedule', () => {
+    const preflight = successOf(preflightCandidateDevelopment(candidate13Input(developmentSessions())))
+    expect(preflight.status).toBe('PASS')
+    if (preflight.status === 'FAIL') throw new Error('expected passing preflight')
+    const { baseline, series } = exactComparisonFixture(preflight)
+
+    expect(successOf(validateCandidateDevelopmentComparisonSeriesBinding(preflight, baseline, series))).toEqual(series)
+    expect(
+      validateCandidateDevelopmentComparisonSeriesBinding(
+        preflight,
+        { ...baseline, protocolHash: 'e'.repeat(64) },
+        series,
+      ),
+    ).toMatchObject(
+      Result.fail({
+        _tag: 'CandidateDevelopmentBaselineProtocolMismatch',
+        expected: preflight.protocolIdentity.protocolHash,
+        observed: 'e'.repeat(64),
+      }),
+    )
+    expect(
+      validateCandidateDevelopmentComparisonSeriesBinding(preflight, baseline, {
+        ...series,
+        runId: 'f'.repeat(64),
+      }),
+    ).toMatchObject(
+      Result.fail({
+        _tag: 'CandidateDevelopmentComparisonSeriesRunMismatch',
+        expected: baseline.runId,
+        observed: 'f'.repeat(64),
+      }),
+    )
+    expect(
+      validateCandidateDevelopmentComparisonSeriesBinding(preflight, baseline, {
+        ...series,
+        rebalanceExecutionDates: series.rebalanceExecutionDates.slice(1),
+      }),
+    ).toMatchObject({
+      _tag: 'Failure',
+      failure: {
+        _tag: 'CandidateDevelopmentComparisonRebalanceScheduleMismatch',
+        index: 0,
+      },
+    })
+  })
+
+  test('rejects an unrelated baseline window before returning a metric-bearing report', async () => {
+    const sessions = developmentSessions()
+    const preflight = successOf(preflightCandidateDevelopment(candidate13Input(sessions)))
+    expect(preflight.status).toBe('PASS')
+    if (preflight.status === 'FAIL') throw new Error('expected passing preflight')
+    const unrelatedBaseline = baselineEvaluation(preflight, preflight.selectedObservationSessions.slice(0, 800))
+    const unrelatedSeries = comparisonSeriesOf(unrelatedBaseline)
+    const unrelatedEvidence = successOf(
+      buildCandidateDevelopmentComparisonSemanticsEvidence(preflight, unrelatedSeries),
+    )
+
+    expect(
+      validateCandidateDevelopmentComparisonSeriesBinding(preflight, unrelatedBaseline, unrelatedSeries),
+    ).toMatchObject(
+      Result.fail({
+        _tag: 'CandidateDevelopmentComparisonSeriesWindowMismatch',
+        index: 800,
+        expected: preflight.selectedObservationSessions.at(800),
+        observed: undefined,
+        expectedCount: preflight.selectedObservationSessions.length,
+        observedCount: 800,
+      }),
+    )
+
+    const failure = await Effect.runPromise(
+      Effect.flip(
+        runCandidateDevelopment(candidate13Input(sessions), {
+          preregisterCandidate: () => Effect.succeed('registration'),
+          loadDevelopmentData: () => Effect.succeed('data'),
+          evaluateDevelopment: () =>
+            Effect.succeed(
+              candidateDevelopmentEvaluation(preflight, {
+                baseline: unrelatedBaseline,
+                comparisonSemantics: unrelatedEvidence,
+              }),
+            ),
+        }),
+      ),
+    )
+
+    expect(failure).toMatchObject({
+      _tag: 'CandidateDevelopmentComparisonSemanticsInvalid',
+      cause: {
+        _tag: 'CandidateDevelopmentComparisonSeriesWindowMismatch',
+        index: 800,
+        expectedCount: preflight.selectedObservationSessions.length,
+        observedCount: 800,
+      },
+    })
+  })
+
+  test('rejects annualized-return evidence whose baseline is cash', () => {
+    const preflight = successOf(preflightCandidateDevelopment(candidate13Input(developmentSessions())))
+    expect(preflight.status).toBe('PASS')
+    if (preflight.status === 'FAIL') throw new Error('expected passing preflight')
+    const { evidence, series } = exactComparisonFixture(preflight)
+    const cashRelative = {
+      ...evidence,
+      comparisonSemantics: {
+        ...evidence.comparisonSemantics,
+        gates: {
+          ...evidence.comparisonSemantics.gates,
+          annualizedExcessReturnLowerBound: {
+            ...evidence.comparisonSemantics.gates.annualizedExcessReturnLowerBound,
+            baseline: 'cash',
+          },
+        },
+      },
+    }
+
+    expect(validateCandidateDevelopmentComparisonSemanticsEvidence(preflight, series, cashRelative)).toMatchObject(
+      Result.fail({
+        _tag: 'CandidateDevelopmentComparisonBaselineMismatch',
+        gate: 'annualizedExcessReturnLowerBound',
+        expected: 'selected-benchmark',
+        observed: 'cash',
+      }),
+    )
+  })
+
+  test('rejects walk-forward positive-fold evidence whose baseline is cash', () => {
+    const preflight = successOf(preflightCandidateDevelopment(candidate13Input(developmentSessions())))
+    expect(preflight.status).toBe('PASS')
+    if (preflight.status === 'FAIL') throw new Error('expected passing preflight')
+    const { evidence, series } = exactComparisonFixture(preflight)
+    const cashRelative = {
+      ...evidence,
+      comparisonSemantics: {
+        ...evidence.comparisonSemantics,
+        gates: {
+          ...evidence.comparisonSemantics.gates,
+          walkForwardPositiveFraction: {
+            ...evidence.comparisonSemantics.gates.walkForwardPositiveFraction,
+            baseline: 'cash',
+          },
+        },
+      },
+    }
+
+    expect(validateCandidateDevelopmentComparisonSemanticsEvidence(preflight, series, cashRelative)).toMatchObject(
+      Result.fail({
+        _tag: 'CandidateDevelopmentComparisonBaselineMismatch',
+        gate: 'walkForwardPositiveFraction',
+        expected: 'selected-benchmark',
+        observed: 'cash',
+      }),
+    )
+  })
+
+  test('rejects a selected benchmark that contradicts the bound cash-adjusted Sharpe rule', () => {
+    const preflight = successOf(preflightCandidateDevelopment(candidate13Input(developmentSessions())))
+    expect(preflight.status).toBe('PASS')
+    if (preflight.status === 'FAIL') throw new Error('expected passing preflight')
+    const { evidence, series } = exactComparisonFixture(preflight)
+    const mismatched = {
+      ...evidence,
+      analysis: {
+        ...evidence.analysis,
+        bootstrap: {
+          ...evidence.analysis.bootstrap,
+          selectedBenchmark: 'direct-volatility-timing',
+        },
+      },
+    }
+
+    expect(validateCandidateDevelopmentComparisonSemanticsEvidence(preflight, series, mismatched)).toMatchObject(
+      Result.fail({
+        _tag: 'CandidateDevelopmentSelectedBenchmarkComparisonMismatch',
+        expected: 'buy-and-hold',
+        observedBootstrap: 'direct-volatility-timing',
+        observedWalkForward: 'buy-and-hold',
+      }),
+    )
+  })
+
+  test('rejects a cash-relative annualized result even when its baseline label claims selected benchmark', () => {
+    const preflight = successOf(preflightCandidateDevelopment(candidate13Input(developmentSessions())))
+    expect(preflight.status).toBe('PASS')
+    if (preflight.status === 'FAIL') throw new Error('expected passing preflight')
+    const { evidence, series } = exactComparisonFixture(preflight)
+    const cashRelative = {
+      ...evidence,
+      analysis: {
+        ...evidence.analysis,
+        bootstrap: {
+          ...evidence.analysis.bootstrap,
+          annualizedReturnDifferenceLowerBound: 0.2268,
+        },
+      },
+    }
+
+    expect(validateCandidateDevelopmentComparisonSemanticsEvidence(preflight, series, cashRelative)).toMatchObject(
+      Result.fail({
+        _tag: 'CandidateDevelopmentAnnualizedReturnComparisonMismatch',
+        expected: evidence.analysis.bootstrap.annualizedReturnDifferenceLowerBound,
+        observed: 0.2268,
+      }),
+    )
+  })
+
+  test('rejects walk-forward results that were computed against cash rather than the selected benchmark', () => {
+    const preflight = successOf(preflightCandidateDevelopment(candidate13Input(developmentSessions())))
+    expect(preflight.status).toBe('PASS')
+    if (preflight.status === 'FAIL') throw new Error('expected passing preflight')
+    const { evidence, series } = exactComparisonFixture(preflight)
+    const firstFold = evidence.analysis.walkForward.folds.at(0)
+    if (firstFold === undefined) throw new Error('expected a walk-forward fold')
+    const cashRelative = {
+      ...evidence,
+      analysis: {
+        ...evidence.analysis,
+        walkForward: {
+          ...evidence.analysis.walkForward,
+          folds: [
+            { ...firstFold, returnDifference: firstFold.strategyReturn },
+            ...evidence.analysis.walkForward.folds.slice(1),
+          ],
+        },
+      },
+    }
+
+    expect(validateCandidateDevelopmentComparisonSemanticsEvidence(preflight, series, cashRelative)).toMatchObject({
+      _tag: 'Failure',
+      failure: { _tag: 'CandidateDevelopmentComparisonEvidenceMismatch' },
     })
   })
 
@@ -629,9 +1063,9 @@ describe('candidate development walk-forward protocol', () => {
               loads += 1
               return Effect.succeed('data')
             },
-            evaluateDevelopment: () => {
+            evaluateDevelopment: (_data, preflight) => {
               evaluations += 1
-              return Effect.succeed(candidateDevelopmentEvaluation('report'))
+              return Effect.succeed(candidateDevelopmentEvaluation(preflight))
             },
           },
         ),
@@ -674,9 +1108,9 @@ describe('candidate development walk-forward protocol', () => {
             loads += 1
             return Effect.succeed('data')
           },
-          evaluateDevelopment: () => {
+          evaluateDevelopment: (_data, preflight) => {
             evaluations += 1
-            return Effect.succeed(candidateDevelopmentEvaluation('report'))
+            return Effect.succeed(candidateDevelopmentEvaluation(preflight))
           },
         },
       ),
@@ -704,17 +1138,16 @@ describe('candidate development walk-forward protocol', () => {
             loads += 1
             return Effect.succeed('data')
           },
-          evaluateDevelopment: () => {
+          evaluateDevelopment: (_data, preflight) => {
             evaluations += 1
             return Effect.succeed(
-              candidateDevelopmentEvaluation(
-                'invalid-report',
-                simulatedOrder({
+              candidateDevelopmentEvaluation(preflight, {
+                stressedOrder: simulatedOrder({
                   filledQuantityMicros: '900000',
                   status: 'partially-filled',
                   unfilledRemainder: 'canceled',
                 }),
-              ),
+              }),
             )
           },
         }),
@@ -749,14 +1182,88 @@ describe('candidate development walk-forward protocol', () => {
           loads += 1
           return Effect.succeed(`${registration}:${preflight.selectedObservationStart}`)
         },
-        evaluateDevelopment: (data, preflight) => {
+        evaluateDevelopment: (_data, preflight) => {
           evaluations += 1
-          return Effect.succeed(candidateDevelopmentEvaluation(`${data}:${preflight.selectedObservationEnd}`))
+          return Effect.succeed(candidateDevelopmentEvaluation(preflight))
         },
       }),
     )
 
-    expect(report).toBe('bayn.candidate-development-preflight.v2:2017-02-02:2022-12-30')
+    expect(report).toMatchObject({
+      schemaVersion: 'bayn.candidate-development-report.v1',
+      protocolIdentity: {
+        candidateOrdinal: 13,
+        priorTrialCount: 12,
+        protocolHash: '5930dfb8922201101ca4edc3c408f0a79a22de8e35bfec2b9fee6e4625aa441e',
+      },
+      comparisonSemantics: {
+        protocolHash: '5930dfb8922201101ca4edc3c408f0a79a22de8e35bfec2b9fee6e4625aa441e',
+        analysis: {
+          bootstrap: { selectedBenchmark: 'buy-and-hold' },
+          walkForward: { selectedBenchmark: 'buy-and-hold' },
+        },
+      },
+      doubledCostContract: candidateDevelopmentDoubledCostContract,
+      doubledCost: {
+        baseline: {
+          simulation: { costMultiplierMicros: candidateDevelopmentDoubledCostContract.baselineCostMultiplierMicros },
+        },
+        stressed: {
+          simulation: { costMultiplierMicros: candidateDevelopmentDoubledCostContract.stressedCostMultiplierMicros },
+        },
+      },
+    })
+    expect(preregistrations).toBe(1)
+    expect(loads).toBe(1)
+    expect(evaluations).toBe(1)
+  })
+
+  test('does not return an evaluated report when comparison semantics mismatch the preflight', async () => {
+    const sessions = developmentSessions()
+    let preregistrations = 0
+    let loads = 0
+    let evaluations = 0
+    const failure = await Effect.runPromise(
+      Effect.flip(
+        runCandidateDevelopment(candidate13Input(sessions), {
+          preregisterCandidate: () => {
+            preregistrations += 1
+            return Effect.succeed('registration')
+          },
+          loadDevelopmentData: () => {
+            loads += 1
+            return Effect.succeed('data')
+          },
+          evaluateDevelopment: (_data, preflight) => {
+            evaluations += 1
+            const evidence = exactComparisonFixture(preflight).evidence
+            const cashRelative = {
+              ...evidence,
+              analysis: {
+                ...evidence.analysis,
+                bootstrap: {
+                  ...evidence.analysis.bootstrap,
+                  annualizedReturnDifferenceLowerBound: 0.2268,
+                },
+              },
+            } as unknown as CandidateDevelopmentComparisonSemanticsEvidence
+            return Effect.succeed(
+              candidateDevelopmentEvaluation(preflight, {
+                comparisonSemantics: cashRelative,
+              }),
+            )
+          },
+        }),
+      ),
+    )
+
+    expect(failure).toMatchObject({
+      _tag: 'CandidateDevelopmentComparisonSemanticsInvalid',
+      cause: {
+        _tag: 'CandidateDevelopmentAnnualizedReturnComparisonMismatch',
+        observed: 0.2268,
+      },
+    })
     expect(preregistrations).toBe(1)
     expect(loads).toBe(1)
     expect(evaluations).toBe(1)

--- a/services/bayn/src/candidate-development.ts
+++ b/services/bayn/src/candidate-development.ts
@@ -1,9 +1,18 @@
 import { Effect, pipe, Result } from 'effect'
 
 import { canonicalHashV1Result, type CanonicalHashFailure } from './hash'
-import { defaultQualificationStatisticsPolicy, type QualificationStatisticsPolicy } from './qualification-statistics'
+import {
+  analyzeSelectedBenchmarkComparisonInput,
+  defaultQualificationStatisticsPolicy,
+  prepareQualificationSeries,
+  qualificationSelectedBenchmarkRule,
+  type QualificationSelectedBenchmarkComparisonAnalysis,
+  type QualificationSeries,
+  type QualificationStatisticsFailure,
+  type QualificationStatisticsPolicy,
+} from './qualification-statistics'
 import type { IsoDate } from './schemas'
-import type { SignalDecision, SimulatedOrder, SimulationTrace } from './types'
+import type { EvaluationResult, SignalDecision, SimulatedOrder, SimulationTrace } from './types'
 
 export const candidateDevelopmentCalendarContract = {
   schemaVersion: 'bayn.candidate-development-calendar.v1',
@@ -74,13 +83,69 @@ export const candidateDevelopmentStatisticsPolicy = {
   cashReturn: { ...defaultQualificationStatisticsPolicy.cashReturn },
 } as const satisfies QualificationStatisticsPolicy
 
+export const candidateDevelopmentComparisonSemantics = {
+  schemaVersion: 'bayn.candidate-development-comparison-semantics.v1',
+  selectedBenchmarkRule: qualificationSelectedBenchmarkRule,
+  evidence: {
+    schemaVersion: 'bayn.candidate-development-comparison-semantics-evidence.v2',
+    reportSchemaVersion: 'bayn.candidate-development-report.v1',
+    analysisSchemaVersion: 'bayn.selected-benchmark-comparison-analysis.v1',
+    source: 'baseline-evaluation-result',
+    seriesProjection: 'prepare-qualification-series',
+    windowBinding: 'exact-selected-preflight-sessions',
+    analysis: 'recomputed-selected-benchmark-comparison',
+    validation: 'exact-canonical-match',
+  },
+  gates: {
+    power: {
+      name: 'power',
+      metric: 'complete-rebalance-block-and-session-sufficiency',
+      baseline: 'not-applicable',
+      reason: 'sampling-sufficiency',
+    },
+    bootstrapTailResolution: {
+      name: 'bootstrap_tail_resolution',
+      metric: 'bootstrap-lower-tail-sample-count',
+      baseline: 'not-applicable',
+      reason: 'sampling-sufficiency',
+    },
+    annualizedExcessReturnLowerBound: {
+      name: 'annualized_excess_return_lower_bound',
+      metric: 'annualized-return-difference',
+      baseline: 'selected-benchmark',
+    },
+    sharpeDifferenceLowerBound: {
+      name: 'sharpe_difference_lower_bound',
+      metric: 'cash-adjusted-annualized-sharpe-difference',
+      baseline: 'selected-benchmark',
+    },
+    walkForwardFolds: {
+      name: 'walk_forward_folds',
+      metric: 'walk-forward-fold-count',
+      baseline: 'not-applicable',
+      reason: 'geometry',
+    },
+    walkForwardPositiveFraction: {
+      name: 'walk_forward_positive_fraction',
+      metric: 'walk-forward-compounded-return-difference',
+      baseline: 'selected-benchmark',
+    },
+    walkForwardDrawdown: {
+      name: 'walk_forward_drawdown',
+      metric: 'candidate-walk-forward-maximum-drawdown',
+      baseline: 'candidate',
+    },
+  },
+} as const
+
 export const candidateDevelopmentProtocol = {
-  schemaVersion: 'bayn.candidate-development-protocol.v2',
+  schemaVersion: 'bayn.candidate-development-protocol.v3',
   calendar: candidateDevelopmentCalendarContract,
   walkForward: candidateDevelopmentWalkForwardProtocol,
   attemptHorizon: candidateDevelopmentAttemptHorizon,
   doubledCost: candidateDevelopmentDoubledCostContract,
   statisticsPolicy: candidateDevelopmentStatisticsPolicy,
+  comparisonSemantics: candidateDevelopmentComparisonSemantics,
 } as const
 
 export interface CandidateDevelopmentProtocolIdentity {
@@ -493,16 +558,331 @@ export type CandidateDevelopmentPreflightIssue =
     }
 
 export interface CandidateDevelopmentPreflightPass extends CandidateDevelopmentGeometryPass {
-  readonly schemaVersion: 'bayn.candidate-development-preflight.v2'
+  readonly schemaVersion: 'bayn.candidate-development-preflight.v3'
   readonly attempt: CandidateDevelopmentBootstrapTailCapacity
   readonly featureLookbackSessions: number
   readonly firstEligibleExecution: CandidateDevelopmentExecutionBoundary
   readonly protocolIdentity: CandidateDevelopmentProtocolIdentity
   readonly doubledCostContract: typeof candidateDevelopmentDoubledCostContract
   readonly statisticsPolicy: typeof candidateDevelopmentStatisticsPolicy
+  readonly comparisonSemantics: typeof candidateDevelopmentComparisonSemantics
+  readonly selectedObservationSessions: readonly IsoDate[]
 }
 
 export type CandidateDevelopmentPreflightDecision = CandidateDevelopmentPreflightPass | CandidateDevelopmentGeometryFail
+
+type CandidateDevelopmentComparisonGateKey = keyof typeof candidateDevelopmentComparisonSemantics.gates
+
+export interface CandidateDevelopmentComparisonSemanticsEvidence {
+  readonly schemaVersion: typeof candidateDevelopmentComparisonSemantics.evidence.schemaVersion
+  readonly protocolHash: string
+  readonly comparisonSemantics: typeof candidateDevelopmentComparisonSemantics
+  readonly analysis: QualificationSelectedBenchmarkComparisonAnalysis
+}
+
+export type CandidateDevelopmentComparisonSemanticsIssue =
+  | {
+      readonly _tag: 'CandidateDevelopmentComparisonSemanticsShapeInvalid'
+      readonly path: string
+      readonly observed: unknown
+    }
+  | {
+      readonly _tag: 'CandidateDevelopmentComparisonSemanticsSchemaMismatch'
+      readonly expected: CandidateDevelopmentComparisonSemanticsEvidence['schemaVersion']
+      readonly observed: unknown
+    }
+  | {
+      readonly _tag: 'CandidateDevelopmentComparisonSemanticsProtocolMismatch'
+      readonly expected: string
+      readonly observed: unknown
+    }
+  | {
+      readonly _tag: 'CandidateDevelopmentComparisonAnalysisFailed'
+      readonly cause: QualificationStatisticsFailure
+    }
+  | {
+      readonly _tag: 'CandidateDevelopmentComparisonSeriesProjectionFailed'
+      readonly cause: QualificationStatisticsFailure
+    }
+  | {
+      readonly _tag: 'CandidateDevelopmentBaselineProtocolMismatch'
+      readonly expected: string
+      readonly observed: string
+    }
+  | {
+      readonly _tag: 'CandidateDevelopmentComparisonSeriesRunMismatch'
+      readonly expected: string
+      readonly observed: string
+    }
+  | {
+      readonly _tag: 'CandidateDevelopmentComparisonSeriesWindowMismatch'
+      readonly index: number
+      readonly expected: IsoDate | undefined
+      readonly observed: IsoDate | undefined
+      readonly expectedCount: number
+      readonly observedCount: number
+    }
+  | {
+      readonly _tag: 'CandidateDevelopmentComparisonRebalanceScheduleMismatch'
+      readonly index: number
+      readonly expected: IsoDate | undefined
+      readonly observed: IsoDate | undefined
+      readonly expectedCount: number
+      readonly observedCount: number
+    }
+  | {
+      readonly _tag: 'CandidateDevelopmentComparisonAnalysisSchemaMismatch'
+      readonly expected: typeof candidateDevelopmentComparisonSemantics.evidence.analysisSchemaVersion
+      readonly observed: string
+    }
+  | {
+      readonly _tag: 'CandidateDevelopmentComparisonSemanticsHashFailed'
+      readonly material: 'expected-evidence' | 'observed-evidence'
+      readonly cause: CanonicalHashFailure
+    }
+  | {
+      readonly _tag: 'CandidateDevelopmentComparisonBaselineMismatch'
+      readonly gate: CandidateDevelopmentComparisonGateKey
+      readonly expected: string
+      readonly observed: unknown
+    }
+  | {
+      readonly _tag: 'CandidateDevelopmentAnnualizedReturnComparisonMismatch'
+      readonly expected: number
+      readonly observed: unknown
+    }
+  | {
+      readonly _tag: 'CandidateDevelopmentSelectedBenchmarkComparisonMismatch'
+      readonly expected: string
+      readonly observedBootstrap: unknown
+      readonly observedWalkForward: unknown
+    }
+  | {
+      readonly _tag: 'CandidateDevelopmentComparisonEvidenceMismatch'
+      readonly expectedHash: string
+      readonly observedHash: string
+    }
+
+const comparisonEvidenceRecord = (value: unknown): Record<string, unknown> | undefined =>
+  typeof value === 'object' && value !== null && !Array.isArray(value) ? (value as Record<string, unknown>) : undefined
+
+export const validateCandidateDevelopmentComparisonSeriesBinding = (
+  preflight: CandidateDevelopmentPreflightPass,
+  baseline: EvaluationResult,
+  series: QualificationSeries,
+): Result.Result<QualificationSeries, CandidateDevelopmentComparisonSemanticsIssue> => {
+  if (baseline.protocolHash !== preflight.protocolIdentity.protocolHash) {
+    return Result.fail({
+      _tag: 'CandidateDevelopmentBaselineProtocolMismatch',
+      expected: preflight.protocolIdentity.protocolHash,
+      observed: baseline.protocolHash,
+    })
+  }
+  if (series.runId !== baseline.runId) {
+    return Result.fail({
+      _tag: 'CandidateDevelopmentComparisonSeriesRunMismatch',
+      expected: baseline.runId,
+      observed: series.runId,
+    })
+  }
+
+  const expectedSessions = preflight.selectedObservationSessions
+  const observedSessions = series.observations.map((observation) => observation.sessionDate)
+  const sessionCount = Math.max(expectedSessions.length, observedSessions.length)
+  for (let index = 0; index < sessionCount; index += 1) {
+    const expected = expectedSessions.at(index)
+    const observed = observedSessions.at(index)
+    if (expected !== observed) {
+      return Result.fail({
+        _tag: 'CandidateDevelopmentComparisonSeriesWindowMismatch',
+        index,
+        expected,
+        observed,
+        expectedCount: expectedSessions.length,
+        observedCount: observedSessions.length,
+      })
+    }
+  }
+
+  const expectedRebalanceExecutionDates = baseline.signalDecisions.map((decision) => decision.executionDate)
+  const observedRebalanceExecutionDates = series.rebalanceExecutionDates
+  const rebalanceCount = Math.max(expectedRebalanceExecutionDates.length, observedRebalanceExecutionDates.length)
+  for (let index = 0; index < rebalanceCount; index += 1) {
+    const expected = expectedRebalanceExecutionDates.at(index)
+    const observed = observedRebalanceExecutionDates.at(index)
+    if (expected !== observed) {
+      return Result.fail({
+        _tag: 'CandidateDevelopmentComparisonRebalanceScheduleMismatch',
+        index,
+        expected,
+        observed,
+        expectedCount: expectedRebalanceExecutionDates.length,
+        observedCount: observedRebalanceExecutionDates.length,
+      })
+    }
+  }
+
+  return Result.succeed(series)
+}
+
+export const buildCandidateDevelopmentComparisonSemanticsEvidence = (
+  preflight: CandidateDevelopmentPreflightPass,
+  series: unknown,
+): Result.Result<CandidateDevelopmentComparisonSemanticsEvidence, CandidateDevelopmentComparisonSemanticsIssue> =>
+  pipe(
+    analyzeSelectedBenchmarkComparisonInput(series, preflight.statisticsPolicy, preflight.attempt.priorTrialCount),
+    Result.mapError(
+      (cause): CandidateDevelopmentComparisonSemanticsIssue => ({
+        _tag: 'CandidateDevelopmentComparisonAnalysisFailed',
+        cause,
+      }),
+    ),
+    Result.flatMap((analysis) =>
+      analysis.schemaVersion === preflight.comparisonSemantics.evidence.analysisSchemaVersion
+        ? Result.succeed({
+            schemaVersion: candidateDevelopmentComparisonSemantics.evidence.schemaVersion,
+            protocolHash: preflight.protocolIdentity.protocolHash,
+            comparisonSemantics: preflight.comparisonSemantics,
+            analysis,
+          })
+        : Result.fail({
+            _tag: 'CandidateDevelopmentComparisonAnalysisSchemaMismatch' as const,
+            expected: preflight.comparisonSemantics.evidence.analysisSchemaVersion,
+            observed: analysis.schemaVersion,
+          }),
+    ),
+  )
+
+export const validateCandidateDevelopmentComparisonSemanticsEvidence = (
+  preflight: CandidateDevelopmentPreflightPass,
+  series: unknown,
+  evidence: unknown,
+): Result.Result<CandidateDevelopmentComparisonSemanticsEvidence, CandidateDevelopmentComparisonSemanticsIssue> => {
+  const root = comparisonEvidenceRecord(evidence)
+  if (root === undefined) {
+    return Result.fail({
+      _tag: 'CandidateDevelopmentComparisonSemanticsShapeInvalid',
+      path: 'comparisonSemantics',
+      observed: evidence,
+    })
+  }
+  if (root.schemaVersion !== preflight.comparisonSemantics.evidence.schemaVersion) {
+    return Result.fail({
+      _tag: 'CandidateDevelopmentComparisonSemanticsSchemaMismatch',
+      expected: preflight.comparisonSemantics.evidence.schemaVersion,
+      observed: root.schemaVersion,
+    })
+  }
+  if (root.protocolHash !== preflight.protocolIdentity.protocolHash) {
+    return Result.fail({
+      _tag: 'CandidateDevelopmentComparisonSemanticsProtocolMismatch',
+      expected: preflight.protocolIdentity.protocolHash,
+      observed: root.protocolHash,
+    })
+  }
+  const observedSemantics = comparisonEvidenceRecord(root.comparisonSemantics)
+  const observedGates = comparisonEvidenceRecord(observedSemantics?.gates)
+  if (observedSemantics === undefined || observedGates === undefined) {
+    return Result.fail({
+      _tag: 'CandidateDevelopmentComparisonSemanticsShapeInvalid',
+      path: 'comparisonSemantics.comparisonSemantics',
+      observed: root.comparisonSemantics,
+    })
+  }
+  const expectedGates = preflight.comparisonSemantics.gates
+  const gateKeys = Object.keys(expectedGates) as CandidateDevelopmentComparisonGateKey[]
+  for (const gate of gateKeys) {
+    const expectedGate = expectedGates[gate]
+    const observedGate = comparisonEvidenceRecord(observedGates[gate])
+    if (observedGate === undefined) {
+      return Result.fail({
+        _tag: 'CandidateDevelopmentComparisonSemanticsShapeInvalid',
+        path: `comparisonSemantics.gates.${gate}`,
+        observed: observedGates[gate],
+      })
+    }
+    if (observedGate.baseline !== expectedGate.baseline) {
+      return Result.fail({
+        _tag: 'CandidateDevelopmentComparisonBaselineMismatch',
+        gate,
+        expected: expectedGate.baseline,
+        observed: observedGate.baseline,
+      })
+    }
+  }
+
+  return pipe(
+    buildCandidateDevelopmentComparisonSemanticsEvidence(preflight, series),
+    Result.flatMap((expected) =>
+      (() => {
+        const observedAnalysis = comparisonEvidenceRecord(root.analysis)
+        const observedBootstrap = comparisonEvidenceRecord(observedAnalysis?.bootstrap)
+        const observedWalkForward = comparisonEvidenceRecord(observedAnalysis?.walkForward)
+        if (observedAnalysis === undefined || observedBootstrap === undefined || observedWalkForward === undefined) {
+          return Result.fail<CandidateDevelopmentComparisonSemanticsIssue>({
+            _tag: 'CandidateDevelopmentComparisonSemanticsShapeInvalid',
+            path: 'comparisonSemantics.analysis',
+            observed: root.analysis,
+          })
+        }
+        if (
+          observedBootstrap.annualizedReturnDifferenceLowerBound !==
+          expected.analysis.bootstrap.annualizedReturnDifferenceLowerBound
+        ) {
+          return Result.fail<CandidateDevelopmentComparisonSemanticsIssue>({
+            _tag: 'CandidateDevelopmentAnnualizedReturnComparisonMismatch',
+            expected: expected.analysis.bootstrap.annualizedReturnDifferenceLowerBound,
+            observed: observedBootstrap.annualizedReturnDifferenceLowerBound,
+          })
+        }
+        if (
+          observedBootstrap.selectedBenchmark !== expected.analysis.bootstrap.selectedBenchmark ||
+          observedWalkForward.selectedBenchmark !== expected.analysis.walkForward.selectedBenchmark
+        ) {
+          return Result.fail<CandidateDevelopmentComparisonSemanticsIssue>({
+            _tag: 'CandidateDevelopmentSelectedBenchmarkComparisonMismatch',
+            expected: expected.analysis.bootstrap.selectedBenchmark,
+            observedBootstrap: observedBootstrap.selectedBenchmark,
+            observedWalkForward: observedWalkForward.selectedBenchmark,
+          })
+        }
+        return pipe(
+          Result.all({
+            expectedHash: pipe(
+              canonicalHashV1Result(expected),
+              Result.mapError(
+                (cause): CandidateDevelopmentComparisonSemanticsIssue => ({
+                  _tag: 'CandidateDevelopmentComparisonSemanticsHashFailed',
+                  material: 'expected-evidence',
+                  cause,
+                }),
+              ),
+            ),
+            observedHash: pipe(
+              canonicalHashV1Result(evidence),
+              Result.mapError(
+                (cause): CandidateDevelopmentComparisonSemanticsIssue => ({
+                  _tag: 'CandidateDevelopmentComparisonSemanticsHashFailed',
+                  material: 'observed-evidence',
+                  cause,
+                }),
+              ),
+            ),
+          }),
+          Result.flatMap(({ expectedHash, observedHash }) =>
+            expectedHash === observedHash
+              ? Result.succeed(evidence as CandidateDevelopmentComparisonSemanticsEvidence)
+              : Result.fail<CandidateDevelopmentComparisonSemanticsIssue>({
+                  _tag: 'CandidateDevelopmentComparisonEvidenceMismatch',
+                  expectedHash,
+                  observedHash,
+                }),
+          ),
+        )
+      })(),
+    ),
+  )
+}
 
 export type CandidateDevelopmentRunFailure =
   | {
@@ -517,6 +897,10 @@ export type CandidateDevelopmentRunFailure =
       readonly _tag: 'CandidateDevelopmentDoubledCostInvalid'
       readonly cause: CandidateDevelopmentDoubledCostIssue
     }
+  | {
+      readonly _tag: 'CandidateDevelopmentComparisonSemanticsInvalid'
+      readonly cause: CandidateDevelopmentComparisonSemanticsIssue
+    }
 
 export interface CandidateDevelopmentPreflightInput {
   readonly candidateOrdinal: number
@@ -526,7 +910,7 @@ export interface CandidateDevelopmentPreflightInput {
   readonly featureLookbackSessions: number
 }
 
-export interface CandidateDevelopmentEffects<Registration, Data, Report, Error, Requirements> {
+export interface CandidateDevelopmentEffects<Registration, Data, Error, Requirements> {
   readonly preregisterCandidate: (
     preflight: CandidateDevelopmentPreflightPass,
   ) => Effect.Effect<Registration, Error, Requirements>
@@ -537,15 +921,26 @@ export interface CandidateDevelopmentEffects<Registration, Data, Report, Error, 
   readonly evaluateDevelopment: (
     data: Data,
     preflight: CandidateDevelopmentPreflightPass,
-  ) => Effect.Effect<CandidateDevelopmentEvaluation<Report>, Error, Requirements>
+  ) => Effect.Effect<CandidateDevelopmentEvaluation, Error, Requirements>
 }
 
-export interface CandidateDevelopmentEvaluation<Report> {
-  readonly report: Report
-  readonly doubledCost: {
-    readonly baseline: CandidateDevelopmentDoubledCostRun
-    readonly stressed: CandidateDevelopmentDoubledCostRun
-  }
+export interface CandidateDevelopmentEvaluation {
+  readonly baseline: EvaluationResult
+  readonly comparisonSemantics: CandidateDevelopmentComparisonSemanticsEvidence
+  readonly stressed: CandidateDevelopmentDoubledCostRun
+}
+
+export interface CandidateDevelopmentDoubledCostEvidence {
+  readonly baseline: CandidateDevelopmentDoubledCostRun
+  readonly stressed: CandidateDevelopmentDoubledCostRun
+}
+
+export interface CandidateDevelopmentReport {
+  readonly schemaVersion: typeof candidateDevelopmentComparisonSemantics.evidence.reportSchemaVersion
+  readonly protocolIdentity: CandidateDevelopmentProtocolIdentity
+  readonly comparisonSemantics: CandidateDevelopmentComparisonSemanticsEvidence
+  readonly doubledCostContract: typeof candidateDevelopmentDoubledCostContract
+  readonly doubledCost: CandidateDevelopmentDoubledCostEvidence
 }
 
 const validIsoDate = (value: string): value is IsoDate => {
@@ -904,29 +1299,34 @@ export const preflightCandidateDevelopment = (
               ? geometry
               : {
                   ...geometry,
-                  schemaVersion: 'bayn.candidate-development-preflight.v2',
+                  schemaVersion: 'bayn.candidate-development-preflight.v3',
                   attempt,
                   featureLookbackSessions: input.featureLookbackSessions,
                   firstEligibleExecution,
                   protocolIdentity,
                   doubledCostContract: candidateDevelopmentDoubledCostContract,
                   statisticsPolicy: candidateDevelopmentStatisticsPolicy,
+                  comparisonSemantics: candidateDevelopmentComparisonSemantics,
+                  selectedObservationSessions: input.officialSessions.slice(
+                    geometry.selectedObservationStartIndex,
+                    geometry.selectedObservationEndIndex + 1,
+                  ),
                 },
         ),
       ),
     ),
   )
 
-export const runCandidateDevelopment = <Registration, Data, Report, Error, Requirements>(
+export const runCandidateDevelopment = <Registration, Data, Error, Requirements>(
   input: CandidateDevelopmentPreflightInput,
-  effects: CandidateDevelopmentEffects<Registration, Data, Report, Error, Requirements>,
-): Effect.Effect<Report, CandidateDevelopmentRunFailure | Error, Requirements> =>
+  effects: CandidateDevelopmentEffects<Registration, Data, Error, Requirements>,
+): Effect.Effect<CandidateDevelopmentReport, CandidateDevelopmentRunFailure | Error, Requirements> =>
   Effect.fromResult(preflightCandidateDevelopment(input)).pipe(
     Effect.mapError(
       (cause): CandidateDevelopmentRunFailure => ({ _tag: 'CandidateDevelopmentPreflightInvalid', cause }),
     ),
     Effect.flatMap(
-      (preflight): Effect.Effect<Report, CandidateDevelopmentRunFailure | Error, Requirements> =>
+      (preflight): Effect.Effect<CandidateDevelopmentReport, CandidateDevelopmentRunFailure | Error, Requirements> =>
         preflight.status === 'FAIL'
           ? Effect.fail<CandidateDevelopmentRunFailure>({
               _tag: 'CandidateDevelopmentPreflightFailed',
@@ -937,18 +1337,65 @@ export const runCandidateDevelopment = <Registration, Data, Report, Error, Requi
               Effect.flatMap((data) => effects.evaluateDevelopment(data, preflight)),
               Effect.flatMap((evaluation) =>
                 Effect.fromResult(
-                  validateCandidateDevelopmentDoubledCostCausalPath(
-                    evaluation.doubledCost.baseline,
-                    evaluation.doubledCost.stressed,
+                  pipe(
+                    prepareQualificationSeries(evaluation.baseline),
+                    Result.mapError(
+                      (cause): CandidateDevelopmentComparisonSemanticsIssue => ({
+                        _tag: 'CandidateDevelopmentComparisonSeriesProjectionFailed',
+                        cause,
+                      }),
+                    ),
+                    Result.flatMap((series) =>
+                      validateCandidateDevelopmentComparisonSeriesBinding(preflight, evaluation.baseline, series),
+                    ),
                   ),
                 ).pipe(
                   Effect.mapError(
                     (cause): CandidateDevelopmentRunFailure => ({
-                      _tag: 'CandidateDevelopmentDoubledCostInvalid',
+                      _tag: 'CandidateDevelopmentComparisonSemanticsInvalid',
                       cause,
                     }),
                   ),
-                  Effect.map(() => evaluation.report),
+                  Effect.flatMap((comparisonSeries) =>
+                    Effect.fromResult(
+                      validateCandidateDevelopmentComparisonSemanticsEvidence(
+                        preflight,
+                        comparisonSeries,
+                        evaluation.comparisonSemantics,
+                      ),
+                    ).pipe(
+                      Effect.mapError(
+                        (cause): CandidateDevelopmentRunFailure => ({
+                          _tag: 'CandidateDevelopmentComparisonSemanticsInvalid',
+                          cause,
+                        }),
+                      ),
+                    ),
+                  ),
+                  Effect.flatMap((comparisonSemantics) => {
+                    const baseline = {
+                      signalDecisions: evaluation.baseline.signalDecisions,
+                      simulation: evaluation.baseline.simulation,
+                    }
+                    const doubledCost = { baseline, stressed: evaluation.stressed }
+                    return Effect.fromResult(
+                      validateCandidateDevelopmentDoubledCostCausalPath(baseline, evaluation.stressed),
+                    ).pipe(
+                      Effect.mapError(
+                        (cause): CandidateDevelopmentRunFailure => ({
+                          _tag: 'CandidateDevelopmentDoubledCostInvalid',
+                          cause,
+                        }),
+                      ),
+                      Effect.map(() => ({
+                        schemaVersion: preflight.comparisonSemantics.evidence.reportSchemaVersion,
+                        protocolIdentity: preflight.protocolIdentity,
+                        comparisonSemantics,
+                        doubledCostContract: preflight.doubledCostContract,
+                        doubledCost,
+                      })),
+                    )
+                  }),
                 ),
               ),
             ),

--- a/services/bayn/src/qualification-statistics.test.ts
+++ b/services/bayn/src/qualification-statistics.test.ts
@@ -9,9 +9,12 @@ import {
   QualificationStatisticsPolicySchema,
   analyzeQualification,
   analyzeQualificationInput,
+  analyzeSelectedBenchmarkComparison,
   calculateQualificationPower,
   defaultQualificationStatisticsPolicy,
   prepareQualificationSeries,
+  qualificationSelectedBenchmarkRule,
+  selectQualificationBenchmarkFromCashAdjustedSharpes,
   type QualificationSeries,
   type QualificationStatisticsPolicy,
 } from './qualification-statistics'
@@ -302,6 +305,28 @@ describe('pure numerical and decision kernels', () => {
 })
 
 describe('deterministic paired block bootstrap', () => {
+  test('uses one executable cash-adjusted Sharpe selection rule with buy-and-hold as the exact tie-break', () => {
+    expect(qualificationSelectedBenchmarkRule).toEqual({
+      schemaVersion: 'bayn.qualification-selected-benchmark-rule.v1',
+      eligibleBenchmarks: ['buy-and-hold', 'direct-volatility-timing'],
+      score: 'cash-adjusted-annualized-sharpe',
+      selection: 'maximum',
+      tieBreak: 'buy-and-hold',
+    })
+    expect(
+      selectQualificationBenchmarkFromCashAdjustedSharpes({
+        buyAndHold: 0.6,
+        directVolatilityTiming: 0.7,
+      }),
+    ).toEqual({ name: 'direct-volatility-timing', sharpe: 0.7 })
+    expect(
+      selectQualificationBenchmarkFromCashAdjustedSharpes({
+        buyAndHold: 0.7,
+        directVolatilityTiming: 0.7,
+      }),
+    ).toEqual({ name: 'buy-and-hold', sharpe: 0.7 })
+  })
+
   test('uses complete rebalance intervals, excludes the trailing interval, and reproduces a golden result', () => {
     const input = makeSeries()
     const first = successOf(analyzeQualification(input, policy(), []))
@@ -322,6 +347,31 @@ describe('deterministic paired block bootstrap', () => {
     expect(first.bootstrap.producedSamples).toBe(1_000)
     expect(first.bootstrap.samplesHash).toBe('e7e3f0e6947361137b7eb2376100fdb559fbcb268b3482474b3e311adf80109a')
     expect(second).toEqual(first)
+  })
+
+  test('recomputes annualized and walk-forward evidence against the selected benchmark without changing terminal cash-relative behavior', () => {
+    const base = makeSeries()
+    const input: QualificationSeries = {
+      ...base,
+      observations: base.observations.map((observation) => ({
+        ...observation,
+        strategyReturn: 0.0005,
+        cashReturn: 0,
+        buyAndHoldReturn: 0.0003,
+        directVolatilityReturn: 0.0002,
+      })),
+    }
+    const terminal = successOf(analyzeQualification(input, policy(), []))
+    const comparison = successOf(analyzeSelectedBenchmarkComparison(input, policy(), 0))
+
+    expect(terminal.bootstrap.selectedBenchmark).toBe('buy-and-hold')
+    expect(comparison.bootstrap.selectedBenchmark).toBe('buy-and-hold')
+    expect(comparison.bootstrap.seedHash).toBe(terminal.bootstrap.seedHash)
+    expect(terminal.bootstrap.annualizedExcessReturnLowerBound).toBe(0.126)
+    expect(comparison.bootstrap.annualizedReturnDifferenceLowerBound).toBe(0.0504)
+    expect(terminal.walkForward.folds.every((fold) => fold.excessReturn > 0)).toBe(true)
+    expect(comparison.walkForward.folds.every((fold) => fold.returnDifference > 0)).toBe(true)
+    expect(comparison.walkForward.folds.every((fold) => fold.selectedBenchmark === 'buy-and-hold')).toBe(true)
   })
 
   test('changes samples with the precommitted seed and preserves paired equality', () => {

--- a/services/bayn/src/qualification-statistics.ts
+++ b/services/bayn/src/qualification-statistics.ts
@@ -1,4 +1,15 @@
 export { analyzeQualification, analyzeQualificationInput } from './qualification-statistics/analysis'
+export {
+  qualificationSelectedBenchmarkRule,
+  selectQualificationBenchmarkFromCashAdjustedSharpes,
+  type QualificationBenchmarkCashAdjustedSharpes,
+  type QualificationSelectedBenchmark,
+} from './qualification-statistics/bootstrap'
+export {
+  analyzeSelectedBenchmarkComparison,
+  analyzeSelectedBenchmarkComparisonInput,
+  type QualificationSelectedBenchmarkComparisonAnalysis,
+} from './qualification-statistics/comparison'
 export { calculateQualificationPower } from './qualification-statistics/power'
 export { prepareQualificationSeries } from './qualification-statistics/series'
 export {

--- a/services/bayn/src/qualification-statistics/bootstrap.ts
+++ b/services/bayn/src/qualification-statistics/bootstrap.ts
@@ -11,10 +11,37 @@ import type {
 import { annualizedSharpe, mean, nearestRankLowerQuantile, roundStatistic } from './numerical-methods'
 import type { CompleteBlockWork } from './series'
 
-const strongerBenchmark = (
+export const qualificationSelectedBenchmarkRule = {
+  schemaVersion: 'bayn.qualification-selected-benchmark-rule.v1',
+  eligibleBenchmarks: ['buy-and-hold', 'direct-volatility-timing'],
+  score: 'cash-adjusted-annualized-sharpe',
+  selection: 'maximum',
+  tieBreak: 'buy-and-hold',
+} as const
+
+export type QualificationSelectedBenchmark = (typeof qualificationSelectedBenchmarkRule.eligibleBenchmarks)[number]
+
+export interface QualificationBenchmarkCashAdjustedSharpes {
+  readonly buyAndHold: number
+  readonly directVolatilityTiming: number
+}
+
+interface QualificationSelectedBenchmarkDecision {
+  readonly name: QualificationSelectedBenchmark
+  readonly sharpe: number
+}
+
+export const selectQualificationBenchmarkFromCashAdjustedSharpes = (
+  sharpes: QualificationBenchmarkCashAdjustedSharpes,
+): QualificationSelectedBenchmarkDecision =>
+  sharpes.directVolatilityTiming > sharpes.buyAndHold
+    ? { name: 'direct-volatility-timing', sharpe: sharpes.directVolatilityTiming }
+    : { name: qualificationSelectedBenchmarkRule.tieBreak, sharpe: sharpes.buyAndHold }
+
+export const selectQualificationBenchmark = (
   observations: readonly QualificationObservation[],
   annualizationSessions: number,
-): { readonly name: 'buy-and-hold' | 'direct-volatility-timing'; readonly sharpe: number } => {
+): QualificationSelectedBenchmarkDecision => {
   const buyAndHold = annualizedSharpe(
     observations.map((observation) => observation.buyAndHoldReturn - observation.cashReturn),
     annualizationSessions,
@@ -23,9 +50,28 @@ const strongerBenchmark = (
     observations.map((observation) => observation.directVolatilityReturn - observation.cashReturn),
     annualizationSessions,
   )
-  return directVolatility > buyAndHold
-    ? { name: 'direct-volatility-timing', sharpe: directVolatility }
-    : { name: 'buy-and-hold', sharpe: buyAndHold }
+  return selectQualificationBenchmarkFromCashAdjustedSharpes({
+    buyAndHold,
+    directVolatilityTiming: directVolatility,
+  })
+}
+
+export interface QualificationSelectedBenchmarkBootstrapComparison {
+  readonly schemaVersion: 'bayn.selected-benchmark-bootstrap-comparison.v1'
+  readonly selectedBenchmark: QualificationSelectedBenchmark
+  readonly selectedBenchmarkSharpe: number
+  readonly seedHash: string
+  readonly requestedSamples: number
+  readonly producedSamples: number
+  readonly adjustedOneSidedAlpha: number
+  readonly tailSampleCount: number
+  readonly minimumTailSamples: number
+  readonly tailResolutionSufficient: boolean
+  readonly annualizedReturnDifferenceLowerBound: number
+  readonly sharpeDifferenceLowerBound: number
+  readonly annualizedReturnDifferenceSamples: readonly number[]
+  readonly sharpeDifferenceSamples: readonly number[]
+  readonly samplesHash: string
 }
 
 interface RandomState {
@@ -120,7 +166,7 @@ export const runQualificationBootstrap = (
   policy: QualificationStatisticsPolicy,
   priorTrialCount: number,
 ): Result.Result<BootstrapAnalysis, QualificationStatisticsFailure> => {
-  const benchmark = strongerBenchmark(series.observations, policy.annualizationSessions)
+  const benchmark = selectQualificationBenchmark(series.observations, policy.annualizationSessions)
   const adjustedOneSidedAlpha = policy.confidence.familyOneSidedAlpha / (priorTrialCount + 1)
   const tailSampleCount = Math.floor(policy.bootstrap.samples * adjustedOneSidedAlpha)
   return pipe(
@@ -220,6 +266,122 @@ export const runQualificationBootstrap = (
               annualizedExcessReturnLowerBound: values.annualizedExcessReturnLowerBound,
               sharpeDifferenceLowerBound: values.sharpeDifferenceLowerBound,
               annualizedExcessReturnSamples,
+              sharpeDifferenceSamples,
+              samplesHash: values.samplesHash,
+            })),
+          )
+        }),
+      )
+    }),
+  )
+}
+
+export const runSelectedBenchmarkBootstrapComparison = (
+  series: QualificationSeries,
+  blocks: readonly CompleteBlockWork[],
+  policy: QualificationStatisticsPolicy,
+  priorTrialCount: number,
+): Result.Result<QualificationSelectedBenchmarkBootstrapComparison, QualificationStatisticsFailure> => {
+  const benchmark = selectQualificationBenchmark(series.observations, policy.annualizationSessions)
+  const adjustedOneSidedAlpha = policy.confidence.familyOneSidedAlpha / (priorTrialCount + 1)
+  const tailSampleCount = Math.floor(policy.bootstrap.samples * adjustedOneSidedAlpha)
+  return pipe(
+    hashQualificationEvidence('bootstrap-seed', {
+      schemaVersion: 'bayn.qualification-bootstrap-seed.v1',
+      namespace: policy.bootstrap.seedNamespace,
+      runId: series.runId,
+    }),
+    Result.flatMap((seedHash) => {
+      const sampled =
+        blocks.length === 0
+          ? Result.succeed<BootstrapAccumulator>({
+              random: initialRandomState(seedHash),
+              annualizedExcessReturnSamples: Chunk.empty(),
+              sharpeDifferenceSamples: Chunk.empty(),
+            })
+          : Array.from({ length: policy.bootstrap.samples }).reduce<
+              Result.Result<BootstrapAccumulator, QualificationStatisticsFailure>
+            >(
+              (accumulated) =>
+                pipe(
+                  accumulated,
+                  Result.flatMap((state) =>
+                    pipe(
+                      sampleBlocks(state.random, blocks),
+                      Result.flatMap(({ random, observations }) => {
+                        const candidateReturns = observations.map(
+                          (observation) => observation.strategyReturn - observation.cashReturn,
+                        )
+                        const benchmarkReturns = observations.map(
+                          (observation) =>
+                            (benchmark.name === 'buy-and-hold'
+                              ? observation.buyAndHoldReturn
+                              : observation.directVolatilityReturn) - observation.cashReturn,
+                        )
+                        return pipe(
+                          Result.all({
+                            annualizedReturnDifference: roundStatistic(
+                              (mean(candidateReturns) - mean(benchmarkReturns)) * policy.annualizationSessions,
+                            ),
+                            sharpeDifference: roundStatistic(
+                              annualizedSharpe(candidateReturns, policy.annualizationSessions) -
+                                annualizedSharpe(benchmarkReturns, policy.annualizationSessions),
+                            ),
+                          }),
+                          Result.map(({ annualizedReturnDifference, sharpeDifference }) => ({
+                            random,
+                            annualizedExcessReturnSamples: Chunk.append(
+                              state.annualizedExcessReturnSamples,
+                              annualizedReturnDifference,
+                            ),
+                            sharpeDifferenceSamples: Chunk.append(state.sharpeDifferenceSamples, sharpeDifference),
+                          })),
+                        )
+                      }),
+                    ),
+                  ),
+                ),
+              Result.succeed({
+                random: initialRandomState(seedHash),
+                annualizedExcessReturnSamples: Chunk.empty(),
+                sharpeDifferenceSamples: Chunk.empty(),
+              }),
+            )
+      return pipe(
+        sampled,
+        Result.flatMap((samples) => {
+          const annualizedReturnDifferenceSamples = Chunk.toReadonlyArray(samples.annualizedExcessReturnSamples)
+          const sharpeDifferenceSamples = Chunk.toReadonlyArray(samples.sharpeDifferenceSamples)
+          return pipe(
+            Result.all({
+              selectedBenchmarkSharpe: roundStatistic(benchmark.sharpe),
+              annualizedReturnDifferenceLowerBound: roundStatistic(
+                nearestRankLowerQuantile(annualizedReturnDifferenceSamples, adjustedOneSidedAlpha),
+              ),
+              sharpeDifferenceLowerBound: roundStatistic(
+                nearestRankLowerQuantile(sharpeDifferenceSamples, adjustedOneSidedAlpha),
+              ),
+              samplesHash: hashQualificationEvidence('selected-benchmark-bootstrap-samples', {
+                schemaVersion: 'bayn.selected-benchmark-bootstrap-samples.v1',
+                selectedBenchmark: benchmark.name,
+                annualizedReturnDifferenceSamples,
+                sharpeDifferenceSamples,
+              }),
+            }),
+            Result.map((values) => ({
+              schemaVersion: 'bayn.selected-benchmark-bootstrap-comparison.v1' as const,
+              selectedBenchmark: benchmark.name,
+              selectedBenchmarkSharpe: values.selectedBenchmarkSharpe,
+              seedHash,
+              requestedSamples: policy.bootstrap.samples,
+              producedSamples: annualizedReturnDifferenceSamples.length,
+              adjustedOneSidedAlpha,
+              tailSampleCount,
+              minimumTailSamples: policy.confidence.minimumTailSamples,
+              tailResolutionSufficient: tailSampleCount >= policy.confidence.minimumTailSamples,
+              annualizedReturnDifferenceLowerBound: values.annualizedReturnDifferenceLowerBound,
+              sharpeDifferenceLowerBound: values.sharpeDifferenceLowerBound,
+              annualizedReturnDifferenceSamples,
               sharpeDifferenceSamples,
               samplesHash: values.samplesHash,
             })),

--- a/services/bayn/src/qualification-statistics/comparison.ts
+++ b/services/bayn/src/qualification-statistics/comparison.ts
@@ -1,0 +1,77 @@
+import { pipe, Result } from 'effect'
+
+import {
+  runSelectedBenchmarkBootstrapComparison,
+  type QualificationSelectedBenchmarkBootstrapComparison,
+} from './bootstrap'
+import { decodeQualificationSeries, qualificationStatisticsSchemaFailure } from './decoding'
+import type { QualificationStatisticsFailure } from './failure'
+import { hashQualificationEvidence } from './hashing'
+import type { PowerAnalysis, QualificationSeries, QualificationStatisticsPolicy } from './model'
+import { calculateQualificationPower } from './power'
+import { buildCompleteBlocks } from './series'
+import {
+  calculateSelectedBenchmarkWalkForwardComparison,
+  type QualificationSelectedBenchmarkWalkForwardComparison,
+} from './walk-forward'
+
+export interface QualificationSelectedBenchmarkComparisonAnalysis {
+  readonly schemaVersion: 'bayn.selected-benchmark-comparison-analysis.v1'
+  readonly runId: string
+  readonly seriesHash: string
+  readonly priorTrialCount: number
+  readonly power: PowerAnalysis
+  readonly bootstrap: QualificationSelectedBenchmarkBootstrapComparison
+  readonly walkForward: QualificationSelectedBenchmarkWalkForwardComparison
+  readonly analysisHash: string
+}
+
+export const analyzeSelectedBenchmarkComparison = (
+  series: QualificationSeries,
+  policy: QualificationStatisticsPolicy,
+  priorTrialCount: number,
+): Result.Result<QualificationSelectedBenchmarkComparisonAnalysis, QualificationStatisticsFailure> =>
+  pipe(
+    hashQualificationEvidence('selected-benchmark-comparison-series', series),
+    Result.flatMap((seriesHash) =>
+      pipe(
+        buildCompleteBlocks(series),
+        Result.flatMap((blocks) => {
+          const availableCompleteSessions = blocks.reduce((total, block) => total + block.evidence.observationCount, 0)
+          return pipe(
+            Result.all({
+              power: calculateQualificationPower(policy, blocks.length, availableCompleteSessions),
+              bootstrap: runSelectedBenchmarkBootstrapComparison(series, blocks, policy, priorTrialCount),
+              walkForward: calculateSelectedBenchmarkWalkForwardComparison(series, policy),
+            }),
+            Result.flatMap(({ bootstrap, power, walkForward }) => {
+              const material = {
+                schemaVersion: 'bayn.selected-benchmark-comparison-analysis.v1' as const,
+                runId: series.runId,
+                seriesHash,
+                priorTrialCount,
+                power,
+                bootstrap,
+                walkForward,
+              }
+              return pipe(
+                hashQualificationEvidence('selected-benchmark-comparison-analysis', material),
+                Result.map((analysisHash) => ({ ...material, analysisHash })),
+              )
+            }),
+          )
+        }),
+      ),
+    ),
+  )
+
+export const analyzeSelectedBenchmarkComparisonInput = (
+  series: unknown,
+  policy: QualificationStatisticsPolicy,
+  priorTrialCount: number,
+): Result.Result<QualificationSelectedBenchmarkComparisonAnalysis, QualificationStatisticsFailure> =>
+  pipe(
+    decodeQualificationSeries(series),
+    Result.mapError(qualificationStatisticsSchemaFailure('series')),
+    Result.flatMap((decoded) => analyzeSelectedBenchmarkComparison(decoded, policy, priorTrialCount)),
+  )

--- a/services/bayn/src/qualification-statistics/failure.ts
+++ b/services/bayn/src/qualification-statistics/failure.ts
@@ -11,7 +11,16 @@ export type QualificationStatisticsFailure =
     }
   | {
       readonly _tag: 'QualificationStatisticsCanonicalizationFailed'
-      readonly operation: 'analysis' | 'bootstrap-samples' | 'bootstrap-seed' | 'complete-block' | 'walk-forward-fold'
+      readonly operation:
+        | 'analysis'
+        | 'bootstrap-samples'
+        | 'bootstrap-seed'
+        | 'complete-block'
+        | 'selected-benchmark-bootstrap-samples'
+        | 'selected-benchmark-comparison-analysis'
+        | 'selected-benchmark-comparison-series'
+        | 'selected-benchmark-walk-forward-fold'
+        | 'walk-forward-fold'
       readonly cause: CanonicalJsonFailure
     }
   | {

--- a/services/bayn/src/qualification-statistics/walk-forward.ts
+++ b/services/bayn/src/qualification-statistics/walk-forward.ts
@@ -1,9 +1,41 @@
 import { pipe, Result } from 'effect'
 
+import { selectQualificationBenchmark, type QualificationSelectedBenchmark } from './bootstrap'
 import { statisticsFailure, type QualificationStatisticsFailure } from './failure'
 import { hashQualificationEvidence } from './hashing'
 import type { QualificationSeries, QualificationStatisticsPolicy, WalkForwardAnalysis } from './model'
 import { compoundedReturn, maximumDrawdown, roundStatistic } from './numerical-methods'
+
+export interface QualificationSelectedBenchmarkWalkForwardFold {
+  readonly schemaVersion: 'bayn.selected-benchmark-walk-forward-fold.v1'
+  readonly ordinal: number
+  readonly trainingStart: string
+  readonly trainingEnd: string
+  readonly testStart: string
+  readonly testEnd: string
+  readonly testObservationCount: number
+  readonly strategyReturn: number
+  readonly selectedBenchmark: QualificationSelectedBenchmark
+  readonly selectedBenchmarkReturn: number
+  readonly returnDifference: number
+  readonly maximumDrawdown: number
+  readonly positiveDifference: boolean
+  readonly drawdownWithinLimit: boolean
+  readonly contentHash: string
+}
+
+export interface QualificationSelectedBenchmarkWalkForwardComparison {
+  readonly schemaVersion: 'bayn.selected-benchmark-walk-forward-comparison.v1'
+  readonly selectedBenchmark: QualificationSelectedBenchmark
+  readonly folds: readonly QualificationSelectedBenchmarkWalkForwardFold[]
+  readonly requiredFolds: number
+  readonly positiveFolds: number
+  readonly positiveFoldFraction: number
+  readonly requiredPositiveFoldFraction: number
+  readonly allDrawdownsWithinLimit: boolean
+  readonly maximumFoldDrawdown: number
+  readonly sufficient: boolean
+}
 
 export const calculateWalkForward = (
   series: QualificationSeries,
@@ -78,6 +110,97 @@ export const calculateWalkForward = (
         Result.map((roundedPositiveFoldFraction) => ({
           schemaVersion: 'bayn.walk-forward.v1' as const,
           method: policy.walkForward.method,
+          folds,
+          requiredFolds: policy.walkForward.minimumFolds,
+          positiveFolds,
+          positiveFoldFraction: roundedPositiveFoldFraction,
+          requiredPositiveFoldFraction: policy.walkForward.minimumPositiveFoldFraction,
+          allDrawdownsWithinLimit: folds.every((fold) => fold.drawdownWithinLimit),
+          maximumFoldDrawdown: folds.reduce((maximum, fold) => Math.max(maximum, fold.maximumDrawdown), 0),
+          sufficient: folds.length >= policy.walkForward.minimumFolds,
+        })),
+      )
+    }),
+  )
+}
+
+export const calculateSelectedBenchmarkWalkForwardComparison = (
+  series: QualificationSeries,
+  policy: QualificationStatisticsPolicy,
+): Result.Result<QualificationSelectedBenchmarkWalkForwardComparison, QualificationStatisticsFailure> => {
+  const benchmark = selectQualificationBenchmark(series.observations, policy.annualizationSessions)
+  const { minimumTrainingSessions, testSessions } = policy.walkForward
+  const foldCount = Math.max(0, Math.floor((series.observations.length - minimumTrainingSessions) / testSessions))
+  return pipe(
+    Result.all(
+      Array.from({ length: foldCount }, (_, ordinal) => minimumTrainingSessions + ordinal * testSessions).map(
+        (testStart, ordinal) => {
+          const test = series.observations.slice(testStart, testStart + testSessions)
+          const trainingStart = series.observations.at(0)
+          const trainingEnd = series.observations.at(testStart - 1)
+          const firstTestObservation = test.at(0)
+          const lastTestObservation = test.at(-1)
+          if (
+            trainingStart === undefined ||
+            trainingEnd === undefined ||
+            firstTestObservation === undefined ||
+            lastTestObservation === undefined
+          ) {
+            return statisticsFailure({
+              _tag: 'QualificationWalkForwardBoundaryMissing',
+              testStart,
+              testSessions,
+              observationCount: series.observations.length,
+            })
+          }
+          const strategyReturns = test.map((observation) => observation.strategyReturn)
+          const benchmarkReturns = test.map((observation) =>
+            benchmark.name === 'buy-and-hold' ? observation.buyAndHoldReturn : observation.directVolatilityReturn,
+          )
+          const strategyReturn = compoundedReturn(strategyReturns)
+          const selectedBenchmarkReturn = compoundedReturn(benchmarkReturns)
+          const returnDifference = strategyReturn - selectedBenchmarkReturn
+          return pipe(
+            Result.all({
+              strategyReturn: roundStatistic(strategyReturn),
+              selectedBenchmarkReturn: roundStatistic(selectedBenchmarkReturn),
+              returnDifference: roundStatistic(returnDifference),
+              maximumDrawdown: maximumDrawdown(strategyReturns),
+            }),
+            Result.flatMap((statistics) => {
+              const material = {
+                schemaVersion: 'bayn.selected-benchmark-walk-forward-fold.v1' as const,
+                ordinal,
+                trainingStart: trainingStart.sessionDate,
+                trainingEnd: trainingEnd.sessionDate,
+                testStart: firstTestObservation.sessionDate,
+                testEnd: lastTestObservation.sessionDate,
+                testObservationCount: test.length,
+                strategyReturn: statistics.strategyReturn,
+                selectedBenchmark: benchmark.name,
+                selectedBenchmarkReturn: statistics.selectedBenchmarkReturn,
+                returnDifference: statistics.returnDifference,
+                maximumDrawdown: statistics.maximumDrawdown,
+                positiveDifference: returnDifference > 0,
+                drawdownWithinLimit: statistics.maximumDrawdown <= policy.walkForward.maximumFoldDrawdown,
+              }
+              return pipe(
+                hashQualificationEvidence('selected-benchmark-walk-forward-fold', material),
+                Result.map((contentHash) => ({ ...material, contentHash })),
+              )
+            }),
+          )
+        },
+      ),
+    ),
+    Result.flatMap((folds) => {
+      const positiveFolds = folds.filter((fold) => fold.positiveDifference).length
+      const positiveFoldFraction = folds.length === 0 ? 0 : positiveFolds / folds.length
+      return pipe(
+        roundStatistic(positiveFoldFraction),
+        Result.map((roundedPositiveFoldFraction) => ({
+          schemaVersion: 'bayn.selected-benchmark-walk-forward-comparison.v1' as const,
+          selectedBenchmark: benchmark.name,
           folds,
           requiredFolds: policy.walkForward.minimumFolds,
           positiveFolds,


### PR DESCRIPTION
## Summary

- bind candidate-development protocol v3 to one executable selected-benchmark rule and explicit comparison baselines for every uncertainty and walk-forward gate
- make the evaluator return one baseline `EvaluationResult`; derive the strict qualification series from that exact run and require its protocol, 1,489-session preflight window, run identity, and rebalance schedule before analysis
- deterministically recompute benchmark-relative bootstrap and walk-forward evidence under the preflight-bound policy and require exact canonical equality before report success
- make `runCandidateDevelopment` own the metric-bearing report and derive its doubled-cost baseline from the same evaluation, so unrelated or cash-relative evidence cannot be relabeled
- preserve terminal qualification behavior exactly while reusing its benchmark-selection rule, bootstrap seed, multiplicity, and geometry

## Related Issues

None

## Testing

- `bun test src/candidate-development.test.ts src/qualification-statistics.test.ts` — 41 passed, 0 failed
- `bun run test` — 871 passed, 128 PostgreSQL-dependent tests skipped locally, 0 failed
- `bun run tsc`
- `bun run lint:effect`
- `bun run lint:oxlint`
- `bun run lint:oxlint:type`
- `bunx oxfmt --check src/candidate-development.ts src/candidate-development.test.ts src/qualification-statistics.ts src/qualification-statistics/bootstrap.ts src/qualification-statistics/comparison.ts src/qualification-statistics/failure.ts src/qualification-statistics/walk-forward.ts src/qualification-statistics.test.ts`
- `bun run build`
- `git diff --check`
- PostgreSQL integrations require the repository's PostgreSQL 18 service and are required green in exact-head CI; no local PostgreSQL service was available

## Breaking Changes

Candidate-development protocol and preflight advance from v2 to v3 because selected-benchmark comparison semantics, exact selected-session binding, evidence schemas, and the run-owned report contract are now hash-bound. Historical qualification evidence and terminal qualification schemas/behavior are unchanged.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
