### PR TITLE
fix(bayn): separate candidate protocol identities

### DIFF
--- a/services/bayn/src/candidate-development.test.ts
+++ b/services/bayn/src/candidate-development.test.ts
@@ -24,14 +24,17 @@ import {
   type CandidateDevelopmentComparisonSemanticsEvidence,
   type CandidateDevelopmentPreflightPass,
 } from './candidate-development'
+import { makeStrategyProtocolHashResult } from './contracts'
 import { defaultExecutionModel } from './execution-model'
 import { canonicalHashV1Result } from './hash'
+import { makeEvaluationIdentity } from './simulation'
 import {
   defaultQualificationStatisticsPolicy,
   prepareQualificationSeries,
   type QualificationSeries,
 } from './qualification-statistics'
 import type { IsoDate } from './schemas'
+import { fixtureProtocol, makeSnapshot, makeTestProvenance } from './test-fixtures'
 import type { EvaluationResult, SignalDecision, SimulatedOrder, SimulationTrace } from './types'
 
 const fullMarketClosures = new Set<IsoDate>([
@@ -191,9 +194,17 @@ const successOf = <A, E>(result: Result.Result<A, E>): A => {
   return result.success
 }
 
+const genuineProvenance = makeTestProvenance()
+const genuineInputManifest = makeSnapshot().manifest
+const genuineEvaluationIdentity = successOf(
+  makeEvaluationIdentity(genuineInputManifest, fixtureProtocol, genuineProvenance),
+)
+const genuineStrategyProtocolHash = successOf(makeStrategyProtocolHashResult(genuineProvenance.strategy))
+
 const candidate13Input = (sessions: readonly IsoDate[]) => ({
   candidateOrdinal: 13,
   priorTrialCount: 12,
+  expectedStrategyProtocolHash: genuineStrategyProtocolHash,
   officialSessions: sessions,
   signalSessionDates: officialMonthEndSignalDates(sessions),
   featureLookbackSessions: 252,
@@ -277,6 +288,30 @@ const evaluationSignalDecisions = (
   sessions: readonly IsoDate[],
 ): readonly SignalDecision[] => {
   const officialSessions = developmentSessions()
+  const includedSessions = new Set(sessions)
+  return preflight.expectedRebalanceSchedule
+    .filter(({ executionDate }) => includedSessions.has(executionDate))
+    .map(({ executionDate, signalDate }, ordinal) => {
+      const executionIndex = officialSessions.indexOf(executionDate)
+      if (
+        officialSessions.at(executionIndex - candidateDevelopmentWalkForwardProtocol.executionLagSessions) !==
+        signalDate
+      ) {
+        throw new Error(`invalid official signal session for ${executionDate}`)
+      }
+      return signalDecision({
+        decisionId: (ordinal + 1).toString(16).padStart(64, '0'),
+        signalDate,
+        executionDate,
+      })
+    })
+}
+
+const everyHundredthSignalDecisions = (
+  preflight: CandidateDevelopmentPreflightPass,
+  sessions: readonly IsoDate[],
+): readonly SignalDecision[] => {
+  const officialSessions = developmentSessions()
   return sessions
     .map((executionDate, index) => ({ executionDate, index }))
     .filter(({ index }) => index % 100 === 0)
@@ -294,8 +329,12 @@ const evaluationSignalDecisions = (
 const baselineEvaluation = (
   preflight: CandidateDevelopmentPreflightPass,
   sessions: readonly IsoDate[] = preflight.selectedObservationSessions,
+  overrides: {
+    readonly protocolHash?: string
+    readonly signalDecisions?: readonly SignalDecision[]
+  } = {},
 ): EvaluationResult => {
-  const signalDecisions = evaluationSignalDecisions(preflight, sessions)
+  const signalDecisions = overrides.signalDecisions ?? evaluationSignalDecisions(preflight, sessions)
   const dailyMarks = sessions.map((sessionDate, index) => ({
     sessionDate,
     equityMicros: '1000000',
@@ -348,11 +387,11 @@ const baselineEvaluation = (
   )
   return {
     schemaVersion: 'bayn.evaluation.v6',
-    runId: 'a'.repeat(64),
-    codeRevision: 'b'.repeat(40),
-    protocolHash: preflight.protocolIdentity.protocolHash,
+    runId: genuineEvaluationIdentity.runId,
+    codeRevision: genuineProvenance.sourceRevision,
+    protocolHash: overrides.protocolHash ?? genuineEvaluationIdentity.protocolHash,
     initialCapitalMicros: '1000000',
-    inputManifest: {} as EvaluationResult['inputManifest'],
+    inputManifest: genuineInputManifest,
     strategy: performanceMetrics(),
     buyAndHold: performanceMetrics(),
     directVolTiming: performanceMetrics(),
@@ -380,7 +419,8 @@ const comparisonSeriesOf = (baseline: EvaluationResult): QualificationSeries =>
 
 let cachedComparisonEvidence:
   | {
-      readonly protocolHash: string
+      readonly candidateDevelopmentProtocolHash: string
+      readonly strategyProtocolHash: string
       readonly baseline: EvaluationResult
       readonly series: QualificationSeries
       readonly evidence: CandidateDevelopmentComparisonSemanticsEvidence
@@ -394,13 +434,23 @@ const exactComparisonFixture = (
   readonly series: QualificationSeries
   readonly evidence: CandidateDevelopmentComparisonSemanticsEvidence
 } => {
-  if (cachedComparisonEvidence?.protocolHash === preflight.protocolIdentity.protocolHash) {
+  if (
+    cachedComparisonEvidence?.candidateDevelopmentProtocolHash ===
+      preflight.protocolIdentity.candidateDevelopmentProtocolHash &&
+    cachedComparisonEvidence.strategyProtocolHash === preflight.expectedStrategyProtocolHash
+  ) {
     return cachedComparisonEvidence
   }
   const baseline = baselineEvaluation(preflight)
   const series = comparisonSeriesOf(baseline)
   const evidence = successOf(buildCandidateDevelopmentComparisonSemanticsEvidence(preflight, series))
-  cachedComparisonEvidence = { protocolHash: preflight.protocolIdentity.protocolHash, baseline, series, evidence }
+  cachedComparisonEvidence = {
+    candidateDevelopmentProtocolHash: preflight.protocolIdentity.candidateDevelopmentProtocolHash,
+    strategyProtocolHash: preflight.expectedStrategyProtocolHash,
+    baseline,
+    series,
+    evidence,
+  }
   return cachedComparisonEvidence
 }
 
@@ -480,6 +530,7 @@ describe('candidate development walk-forward protocol', () => {
         preflightCandidateDevelopment({
           candidateOrdinal: 13,
           priorTrialCount: 12,
+          expectedStrategyProtocolHash: genuineStrategyProtocolHash,
           officialSessions: sessions,
           signalSessionDates: signals,
           featureLookbackSessions,
@@ -541,31 +592,40 @@ describe('candidate development walk-forward protocol', () => {
 
   test('binds one deterministic versioned protocol identity into preflight', () => {
     const candidate13 = successOf(bindCandidateDevelopmentAttempt(13, 12))
-    const first = successOf(identifyCandidateDevelopmentProtocol(candidate13, 252))
-    const second = successOf(identifyCandidateDevelopmentProtocol(candidate13, 252))
-    const differentLookback = successOf(identifyCandidateDevelopmentProtocol(candidate13, 63))
+    const first = successOf(identifyCandidateDevelopmentProtocol(candidate13, 252, genuineStrategyProtocolHash))
+    const second = successOf(identifyCandidateDevelopmentProtocol(candidate13, 252, genuineStrategyProtocolHash))
+    const differentLookback = successOf(
+      identifyCandidateDevelopmentProtocol(candidate13, 63, genuineStrategyProtocolHash),
+    )
+    const differentStrategy = successOf(identifyCandidateDevelopmentProtocol(candidate13, 252, 'e'.repeat(64)))
     const next = successOf(
-      identifyCandidateDevelopmentProtocol(successOf(bindCandidateDevelopmentAttempt(14, 13)), 252),
+      identifyCandidateDevelopmentProtocol(
+        successOf(bindCandidateDevelopmentAttempt(14, 13)),
+        252,
+        genuineStrategyProtocolHash,
+      ),
     )
     const preflight = successOf(preflightCandidateDevelopment(candidate13Input(developmentSessions())))
 
     expect(first).toEqual(second)
     expect(first).not.toEqual(differentLookback)
+    expect(first).not.toEqual(differentStrategy)
     expect(first).not.toEqual(next)
-    expect(first.schemaVersion).toBe('bayn.candidate-development-protocol-identity.v1')
+    expect(first.schemaVersion).toBe('bayn.candidate-development-protocol-identity.v2')
     expect(first.candidateOrdinal).toBe(13)
     expect(first.priorTrialCount).toBe(12)
     expect(first.featureLookbackSessions).toBe(252)
-    expect(first.protocolHash).toBe('5930dfb8922201101ca4edc3c408f0a79a22de8e35bfec2b9fee6e4625aa441e')
+    expect(first.candidateDevelopmentProtocolHash).toMatch(/^[0-9a-f]{64}$/)
     expect(preflight).toMatchObject({
       status: 'PASS',
-      schemaVersion: 'bayn.candidate-development-preflight.v3',
+      schemaVersion: 'bayn.candidate-development-preflight.v4',
       attempt: {
         candidateOrdinal: 13,
         priorTrialCount: 12,
         tailSampleCount: 38,
       },
       protocolIdentity: first,
+      expectedStrategyProtocolHash: genuineStrategyProtocolHash,
       doubledCostContract: candidateDevelopmentDoubledCostContract,
       comparisonSemantics: candidateDevelopmentComparisonSemantics,
     })
@@ -573,6 +633,15 @@ describe('candidate development walk-forward protocol', () => {
     expect(preflight.selectedObservationSessions).toHaveLength(1_489)
     expect(preflight.selectedObservationSessions.at(0)).toBe('2017-02-02')
     expect(preflight.selectedObservationSessions.at(-1)).toBe('2022-12-30')
+    expect(preflight.expectedRebalanceSchedule).toHaveLength(70)
+    expect(preflight.expectedRebalanceSchedule.at(0)).toEqual({
+      signalDate: '2017-02-28',
+      executionDate: '2017-03-01',
+    })
+    expect(preflight.expectedRebalanceSchedule.at(-1)).toEqual({
+      signalDate: '2022-11-30',
+      executionDate: '2022-12-01',
+    })
   })
 
   test('accepts exact benchmark-relative comparison semantics for every uncertainty and walk-forward gate', () => {
@@ -616,8 +685,8 @@ describe('candidate development walk-forward protocol', () => {
       ),
     ).toMatchObject(
       Result.fail({
-        _tag: 'CandidateDevelopmentBaselineProtocolMismatch',
-        expected: preflight.protocolIdentity.protocolHash,
+        _tag: 'CandidateDevelopmentBaselineStrategyProtocolMismatch',
+        expected: preflight.expectedStrategyProtocolHash,
         observed: 'e'.repeat(64),
       }),
     )
@@ -723,6 +792,180 @@ describe('candidate development walk-forward protocol', () => {
         gate: 'annualizedExcessReturnLowerBound',
         expected: 'selected-benchmark',
         observed: 'cash',
+      }),
+    )
+  })
+
+  test('rejects the previously accepted every-100th-session rebalance schedule', () => {
+    const preflight = successOf(preflightCandidateDevelopment(candidate13Input(developmentSessions())))
+    expect(preflight.status).toBe('PASS')
+    if (preflight.status === 'FAIL') throw new Error('expected passing preflight')
+    const baseline = baselineEvaluation(preflight, preflight.selectedObservationSessions, {
+      signalDecisions: everyHundredthSignalDecisions(preflight, preflight.selectedObservationSessions),
+    })
+    const series = comparisonSeriesOf(baseline)
+
+    expect(series.rebalanceExecutionDates).toEqual(baseline.signalDecisions.map((decision) => decision.executionDate))
+    expect(series.rebalanceExecutionDates).not.toEqual(
+      preflight.expectedRebalanceSchedule.map(({ executionDate }) => executionDate),
+    )
+    expect(validateCandidateDevelopmentComparisonSeriesBinding(preflight, baseline, series)).toMatchObject({
+      _tag: 'Failure',
+      failure: {
+        _tag: 'CandidateDevelopmentComparisonSignalExecutionMismatch',
+      },
+    })
+  })
+
+  test('rejects shifted, missing, and extra rebalance executions against the preregistered schedule', () => {
+    const preflight = successOf(preflightCandidateDevelopment(candidate13Input(developmentSessions())))
+    expect(preflight.status).toBe('PASS')
+    if (preflight.status === 'FAIL') throw new Error('expected passing preflight')
+    const { baseline, series } = exactComparisonFixture(preflight)
+    const expected = preflight.expectedRebalanceSchedule.map(({ executionDate }) => executionDate)
+    const first = expected.at(0)
+    const firstIndex = first === undefined ? -1 : preflight.selectedObservationSessions.indexOf(first)
+    const shiftedFirst = preflight.selectedObservationSessions.at(firstIndex + 1)
+    const last = expected.at(-1)
+    if (first === undefined || shiftedFirst === undefined || last === undefined) {
+      throw new Error('expected complete preregistered rebalance schedule')
+    }
+
+    const cases = [
+      {
+        name: 'shifted',
+        dates: [shiftedFirst, ...expected.slice(1)],
+        index: 0,
+        expected: first,
+        observed: shiftedFirst,
+      },
+      {
+        name: 'missing',
+        dates: expected.slice(0, -1),
+        index: expected.length - 1,
+        expected: last,
+        observed: undefined,
+      },
+      {
+        name: 'extra',
+        dates: [...expected, preflight.selectedObservationEnd],
+        index: expected.length,
+        expected: undefined,
+        observed: preflight.selectedObservationEnd,
+      },
+    ] as const
+
+    for (const mismatch of cases) {
+      expect(
+        validateCandidateDevelopmentComparisonSeriesBinding(preflight, baseline, {
+          ...series,
+          rebalanceExecutionDates: mismatch.dates,
+        }),
+        mismatch.name,
+      ).toMatchObject(
+        Result.fail({
+          _tag: 'CandidateDevelopmentComparisonRebalanceScheduleMismatch',
+          index: mismatch.index,
+          expected: mismatch.expected,
+          observed: mismatch.observed,
+          expectedCount: expected.length,
+          observedCount: mismatch.dates.length,
+        }),
+      )
+    }
+  })
+
+  test('rejects a shifted signal date even when every execution date is preregistered', () => {
+    const preflight = successOf(preflightCandidateDevelopment(candidate13Input(developmentSessions())))
+    expect(preflight.status).toBe('PASS')
+    if (preflight.status === 'FAIL') throw new Error('expected passing preflight')
+    const { baseline } = exactComparisonFixture(preflight)
+    const first = baseline.signalDecisions.at(0)
+    const shiftedSignalDate = preflight.selectedObservationSessions.at(16)
+    if (first === undefined || shiftedSignalDate === undefined) {
+      throw new Error('expected a baseline decision and shifted signal session')
+    }
+    expect(shiftedSignalDate).not.toBe(preflight.expectedRebalanceSchedule.at(0)?.signalDate)
+    const shiftedBaseline = {
+      ...baseline,
+      signalDecisions: [{ ...first, signalDate: shiftedSignalDate }, ...baseline.signalDecisions.slice(1)],
+    }
+    const shiftedSeries = comparisonSeriesOf(shiftedBaseline)
+
+    expect(shiftedSeries.rebalanceExecutionDates).toEqual(
+      preflight.expectedRebalanceSchedule.map(({ executionDate }) => executionDate),
+    )
+    expect(
+      validateCandidateDevelopmentComparisonSeriesBinding(preflight, shiftedBaseline, shiftedSeries),
+    ).toMatchObject(
+      Result.fail({
+        _tag: 'CandidateDevelopmentComparisonSignalExecutionMismatch',
+        index: 0,
+        expected: preflight.expectedRebalanceSchedule.at(0),
+        observed: {
+          signalDate: shiftedSignalDate,
+          executionDate: first.executionDate,
+        },
+      }),
+    )
+  })
+
+  test('accepts a genuine strategy protocol identity independently of the development protocol identity', () => {
+    const preflight = successOf(preflightCandidateDevelopment(candidate13Input(developmentSessions())))
+    expect(preflight.status).toBe('PASS')
+    if (preflight.status === 'FAIL') throw new Error('expected passing preflight')
+    const { baseline } = exactComparisonFixture(preflight)
+    const genuineBaseline = { ...baseline, protocolHash: genuineStrategyProtocolHash }
+    const genuineSeries = comparisonSeriesOf(genuineBaseline)
+
+    expect(genuineEvaluationIdentity.protocolHash).toBe(genuineStrategyProtocolHash)
+    expect(genuineStrategyProtocolHash).not.toBe(preflight.protocolIdentity.candidateDevelopmentProtocolHash)
+    expect(
+      successOf(validateCandidateDevelopmentComparisonSeriesBinding(preflight, genuineBaseline, genuineSeries)),
+    ).toEqual(genuineSeries)
+  })
+
+  test('rejects independent strategy and candidate-development identity drift', () => {
+    const preflight = successOf(preflightCandidateDevelopment(candidate13Input(developmentSessions())))
+    expect(preflight.status).toBe('PASS')
+    if (preflight.status === 'FAIL') throw new Error('expected passing preflight')
+    const { baseline, evidence, series } = exactComparisonFixture(preflight)
+
+    expect(
+      validateCandidateDevelopmentComparisonSeriesBinding(
+        preflight,
+        { ...baseline, protocolHash: 'e'.repeat(64) },
+        series,
+      ),
+    ).toMatchObject(
+      Result.fail({
+        _tag: 'CandidateDevelopmentBaselineStrategyProtocolMismatch',
+        expected: genuineStrategyProtocolHash,
+        observed: 'e'.repeat(64),
+      }),
+    )
+    expect(
+      validateCandidateDevelopmentComparisonSemanticsEvidence(preflight, series, {
+        ...evidence,
+        candidateDevelopmentProtocolHash: 'e'.repeat(64),
+      }),
+    ).toMatchObject(
+      Result.fail({
+        _tag: 'CandidateDevelopmentComparisonDevelopmentProtocolMismatch',
+        expected: preflight.protocolIdentity.candidateDevelopmentProtocolHash,
+        observed: 'e'.repeat(64),
+      }),
+    )
+    expect(
+      validateCandidateDevelopmentComparisonSemanticsEvidence(preflight, series, {
+        ...evidence,
+        strategyProtocolHash: 'e'.repeat(64),
+      }),
+    ).toMatchObject(
+      Result.fail({
+        _tag: 'CandidateDevelopmentComparisonStrategyProtocolMismatch',
+        expected: genuineStrategyProtocolHash,
+        observed: 'e'.repeat(64),
       }),
     )
   })
@@ -986,6 +1229,7 @@ describe('candidate development walk-forward protocol', () => {
       preflightCandidateDevelopment({
         candidateOrdinal: 13,
         priorTrialCount: 12,
+        expectedStrategyProtocolHash: genuineStrategyProtocolHash,
         officialSessions: sessions,
         signalSessionDates: officialMonthEndSignalDates(sessions),
         featureLookbackSessions: 63,
@@ -1050,6 +1294,7 @@ describe('candidate development walk-forward protocol', () => {
           {
             candidateOrdinal: candidateDevelopmentAttemptHorizon.maximumCandidateOrdinal + 1,
             priorTrialCount: candidateDevelopmentAttemptHorizon.maximumCandidateOrdinal,
+            expectedStrategyProtocolHash: genuineStrategyProtocolHash,
             officialSessions: [],
             signalSessionDates: [],
             featureLookbackSessions: 0,
@@ -1085,6 +1330,45 @@ describe('candidate development walk-forward protocol', () => {
     expect(evaluations).toBe(0)
   })
 
+  test('rejects an invalid expected strategy protocol hash before preregistration or data I/O', async () => {
+    const sessions = developmentSessions()
+    let preregistrations = 0
+    let loads = 0
+    let evaluations = 0
+    const failure = await Effect.runPromise(
+      Effect.flip(
+        runCandidateDevelopment(
+          { ...candidate13Input(sessions), expectedStrategyProtocolHash: 'not-a-sha256' },
+          {
+            preregisterCandidate: () => {
+              preregistrations += 1
+              return Effect.succeed('registration')
+            },
+            loadDevelopmentData: () => {
+              loads += 1
+              return Effect.succeed('data')
+            },
+            evaluateDevelopment: (_data, preflight) => {
+              evaluations += 1
+              return Effect.succeed(candidateDevelopmentEvaluation(preflight))
+            },
+          },
+        ),
+      ),
+    )
+
+    expect(failure).toEqual({
+      _tag: 'CandidateDevelopmentPreflightInvalid',
+      cause: {
+        _tag: 'CandidateDevelopmentStrategyProtocolHashInvalid',
+        observed: 'not-a-sha256',
+      },
+    })
+    expect(preregistrations).toBe(0)
+    expect(loads).toBe(0)
+    expect(evaluations).toBe(0)
+  })
+
   test('stops before preregistration, data loading, and evaluation when the schedule is infeasible', async () => {
     const sessions = developmentSessions()
     let preregistrations = 0
@@ -1095,6 +1379,7 @@ describe('candidate development walk-forward protocol', () => {
         {
           candidateOrdinal: 13,
           priorTrialCount: 12,
+          expectedStrategyProtocolHash: genuineStrategyProtocolHash,
           officialSessions: sessions,
           signalSessionDates: [sessions[273]],
           featureLookbackSessions: 0,
@@ -1190,14 +1475,15 @@ describe('candidate development walk-forward protocol', () => {
     )
 
     expect(report).toMatchObject({
-      schemaVersion: 'bayn.candidate-development-report.v1',
+      schemaVersion: 'bayn.candidate-development-report.v2',
       protocolIdentity: {
         candidateOrdinal: 13,
         priorTrialCount: 12,
-        protocolHash: '5930dfb8922201101ca4edc3c408f0a79a22de8e35bfec2b9fee6e4625aa441e',
+        candidateDevelopmentProtocolHash: expect.stringMatching(/^[0-9a-f]{64}$/),
       },
       comparisonSemantics: {
-        protocolHash: '5930dfb8922201101ca4edc3c408f0a79a22de8e35bfec2b9fee6e4625aa441e',
+        candidateDevelopmentProtocolHash: expect.stringMatching(/^[0-9a-f]{64}$/),
+        strategyProtocolHash: genuineStrategyProtocolHash,
         analysis: {
           bootstrap: { selectedBenchmark: 'buy-and-hold' },
           walkForward: { selectedBenchmark: 'buy-and-hold' },

--- a/services/bayn/src/candidate-development.ts
+++ b/services/bayn/src/candidate-development.ts
@@ -50,6 +50,13 @@ export const candidateDevelopmentAttemptHorizon = {
   ordinalBinding: 'candidate-ordinal-equals-prior-trial-count-plus-one',
 } as const
 
+export const candidateDevelopmentRebalanceScheduleContract = {
+  schemaVersion: 'bayn.candidate-development-rebalance-schedule.v1',
+  signalSchedule: 'official-month-end-sessions',
+  executionSchedule: 'next-official-session',
+  comparisonWindow: 'selected-observation-window-inclusive',
+} as const
+
 /**
  * Doubled-cost development evidence is a second causal simulator run at exactly 2x modeled execution costs. The run is
  * admissible only when the complete signal decisions and ordered requested/filled quantity path exactly match the 1x
@@ -84,15 +91,17 @@ export const candidateDevelopmentStatisticsPolicy = {
 } as const satisfies QualificationStatisticsPolicy
 
 export const candidateDevelopmentComparisonSemantics = {
-  schemaVersion: 'bayn.candidate-development-comparison-semantics.v1',
+  schemaVersion: 'bayn.candidate-development-comparison-semantics.v2',
   selectedBenchmarkRule: qualificationSelectedBenchmarkRule,
   evidence: {
-    schemaVersion: 'bayn.candidate-development-comparison-semantics-evidence.v2',
-    reportSchemaVersion: 'bayn.candidate-development-report.v1',
+    schemaVersion: 'bayn.candidate-development-comparison-semantics-evidence.v3',
+    reportSchemaVersion: 'bayn.candidate-development-report.v2',
     analysisSchemaVersion: 'bayn.selected-benchmark-comparison-analysis.v1',
     source: 'baseline-evaluation-result',
     seriesProjection: 'prepare-qualification-series',
     windowBinding: 'exact-selected-preflight-sessions',
+    rebalanceBinding: 'official-signal-next-session-executions',
+    strategyProtocolBinding: 'explicit-expected-strategy-protocol-hash',
     analysis: 'recomputed-selected-benchmark-comparison',
     validation: 'exact-canonical-match',
   },
@@ -139,40 +148,43 @@ export const candidateDevelopmentComparisonSemantics = {
 } as const
 
 export const candidateDevelopmentProtocol = {
-  schemaVersion: 'bayn.candidate-development-protocol.v3',
+  schemaVersion: 'bayn.candidate-development-protocol.v4',
   calendar: candidateDevelopmentCalendarContract,
   walkForward: candidateDevelopmentWalkForwardProtocol,
   attemptHorizon: candidateDevelopmentAttemptHorizon,
+  rebalanceSchedule: candidateDevelopmentRebalanceScheduleContract,
   doubledCost: candidateDevelopmentDoubledCostContract,
   statisticsPolicy: candidateDevelopmentStatisticsPolicy,
   comparisonSemantics: candidateDevelopmentComparisonSemantics,
 } as const
 
 export interface CandidateDevelopmentProtocolIdentity {
-  readonly schemaVersion: 'bayn.candidate-development-protocol-identity.v1'
+  readonly schemaVersion: 'bayn.candidate-development-protocol-identity.v2'
   readonly candidateOrdinal: number
   readonly priorTrialCount: number
   readonly featureLookbackSessions: number
-  readonly protocolHash: string
+  readonly candidateDevelopmentProtocolHash: string
 }
 
 export const identifyCandidateDevelopmentProtocol = (
   attempt: CandidateDevelopmentBootstrapTailCapacity,
   featureLookbackSessions: number,
+  expectedStrategyProtocolHash: string,
 ): Result.Result<CandidateDevelopmentProtocolIdentity, CanonicalHashFailure> =>
   pipe(
     canonicalHashV1Result({
-      schemaVersion: 'bayn.candidate-development-protocol-binding.v1',
+      schemaVersion: 'bayn.candidate-development-protocol-binding.v2',
       protocol: candidateDevelopmentProtocol,
       attempt,
       featureLookbackSessions,
+      expectedStrategyProtocolHash,
     }),
-    Result.map((protocolHash) => ({
-      schemaVersion: 'bayn.candidate-development-protocol-identity.v1' as const,
+    Result.map((candidateDevelopmentProtocolHash) => ({
+      schemaVersion: 'bayn.candidate-development-protocol-identity.v2' as const,
       candidateOrdinal: attempt.candidateOrdinal,
       priorTrialCount: attempt.priorTrialCount,
       featureLookbackSessions,
-      protocolHash,
+      candidateDevelopmentProtocolHash,
     })),
   )
 
@@ -427,6 +439,11 @@ export interface CandidateDevelopmentExecutionBoundary {
   readonly executionDate: IsoDate
 }
 
+export interface CandidateDevelopmentRebalanceBoundary {
+  readonly signalDate: IsoDate
+  readonly executionDate: IsoDate
+}
+
 export interface CandidateDevelopmentFoldBoundary {
   readonly ordinal: number
   readonly trainingStartIndex: number
@@ -556,17 +573,23 @@ export type CandidateDevelopmentPreflightIssue =
       readonly _tag: 'CandidateDevelopmentProtocolHashFailed'
       readonly cause: CanonicalHashFailure
     }
+  | {
+      readonly _tag: 'CandidateDevelopmentStrategyProtocolHashInvalid'
+      readonly observed: string
+    }
 
 export interface CandidateDevelopmentPreflightPass extends CandidateDevelopmentGeometryPass {
-  readonly schemaVersion: 'bayn.candidate-development-preflight.v3'
+  readonly schemaVersion: 'bayn.candidate-development-preflight.v4'
   readonly attempt: CandidateDevelopmentBootstrapTailCapacity
   readonly featureLookbackSessions: number
   readonly firstEligibleExecution: CandidateDevelopmentExecutionBoundary
   readonly protocolIdentity: CandidateDevelopmentProtocolIdentity
+  readonly expectedStrategyProtocolHash: string
   readonly doubledCostContract: typeof candidateDevelopmentDoubledCostContract
   readonly statisticsPolicy: typeof candidateDevelopmentStatisticsPolicy
   readonly comparisonSemantics: typeof candidateDevelopmentComparisonSemantics
   readonly selectedObservationSessions: readonly IsoDate[]
+  readonly expectedRebalanceSchedule: readonly CandidateDevelopmentRebalanceBoundary[]
 }
 
 export type CandidateDevelopmentPreflightDecision = CandidateDevelopmentPreflightPass | CandidateDevelopmentGeometryFail
@@ -575,7 +598,8 @@ type CandidateDevelopmentComparisonGateKey = keyof typeof candidateDevelopmentCo
 
 export interface CandidateDevelopmentComparisonSemanticsEvidence {
   readonly schemaVersion: typeof candidateDevelopmentComparisonSemantics.evidence.schemaVersion
-  readonly protocolHash: string
+  readonly candidateDevelopmentProtocolHash: string
+  readonly strategyProtocolHash: string
   readonly comparisonSemantics: typeof candidateDevelopmentComparisonSemantics
   readonly analysis: QualificationSelectedBenchmarkComparisonAnalysis
 }
@@ -592,7 +616,12 @@ export type CandidateDevelopmentComparisonSemanticsIssue =
       readonly observed: unknown
     }
   | {
-      readonly _tag: 'CandidateDevelopmentComparisonSemanticsProtocolMismatch'
+      readonly _tag: 'CandidateDevelopmentComparisonDevelopmentProtocolMismatch'
+      readonly expected: string
+      readonly observed: unknown
+    }
+  | {
+      readonly _tag: 'CandidateDevelopmentComparisonStrategyProtocolMismatch'
       readonly expected: string
       readonly observed: unknown
     }
@@ -605,7 +634,7 @@ export type CandidateDevelopmentComparisonSemanticsIssue =
       readonly cause: QualificationStatisticsFailure
     }
   | {
-      readonly _tag: 'CandidateDevelopmentBaselineProtocolMismatch'
+      readonly _tag: 'CandidateDevelopmentBaselineStrategyProtocolMismatch'
       readonly expected: string
       readonly observed: string
     }
@@ -627,6 +656,14 @@ export type CandidateDevelopmentComparisonSemanticsIssue =
       readonly index: number
       readonly expected: IsoDate | undefined
       readonly observed: IsoDate | undefined
+      readonly expectedCount: number
+      readonly observedCount: number
+    }
+  | {
+      readonly _tag: 'CandidateDevelopmentComparisonSignalExecutionMismatch'
+      readonly index: number
+      readonly expected: CandidateDevelopmentRebalanceBoundary | undefined
+      readonly observed: CandidateDevelopmentRebalanceBoundary | undefined
       readonly expectedCount: number
       readonly observedCount: number
     }
@@ -671,10 +708,10 @@ export const validateCandidateDevelopmentComparisonSeriesBinding = (
   baseline: EvaluationResult,
   series: QualificationSeries,
 ): Result.Result<QualificationSeries, CandidateDevelopmentComparisonSemanticsIssue> => {
-  if (baseline.protocolHash !== preflight.protocolIdentity.protocolHash) {
+  if (baseline.protocolHash !== preflight.expectedStrategyProtocolHash) {
     return Result.fail({
-      _tag: 'CandidateDevelopmentBaselineProtocolMismatch',
-      expected: preflight.protocolIdentity.protocolHash,
+      _tag: 'CandidateDevelopmentBaselineStrategyProtocolMismatch',
+      expected: preflight.expectedStrategyProtocolHash,
       observed: baseline.protocolHash,
     })
   }
@@ -704,7 +741,28 @@ export const validateCandidateDevelopmentComparisonSeriesBinding = (
     }
   }
 
-  const expectedRebalanceExecutionDates = baseline.signalDecisions.map((decision) => decision.executionDate)
+  const expectedRebalanceSchedule = preflight.expectedRebalanceSchedule
+  const observedRebalanceSchedule = baseline.signalDecisions.map(({ signalDate, executionDate }) => ({
+    signalDate,
+    executionDate,
+  }))
+  const decisionCount = Math.max(expectedRebalanceSchedule.length, observedRebalanceSchedule.length)
+  for (let index = 0; index < decisionCount; index += 1) {
+    const expected = expectedRebalanceSchedule.at(index)
+    const observed = observedRebalanceSchedule.at(index)
+    if (expected?.signalDate !== observed?.signalDate || expected?.executionDate !== observed?.executionDate) {
+      return Result.fail({
+        _tag: 'CandidateDevelopmentComparisonSignalExecutionMismatch',
+        index,
+        expected,
+        observed,
+        expectedCount: expectedRebalanceSchedule.length,
+        observedCount: observedRebalanceSchedule.length,
+      })
+    }
+  }
+
+  const expectedRebalanceExecutionDates = expectedRebalanceSchedule.map(({ executionDate }) => executionDate)
   const observedRebalanceExecutionDates = series.rebalanceExecutionDates
   const rebalanceCount = Math.max(expectedRebalanceExecutionDates.length, observedRebalanceExecutionDates.length)
   for (let index = 0; index < rebalanceCount; index += 1) {
@@ -741,7 +799,8 @@ export const buildCandidateDevelopmentComparisonSemanticsEvidence = (
       analysis.schemaVersion === preflight.comparisonSemantics.evidence.analysisSchemaVersion
         ? Result.succeed({
             schemaVersion: candidateDevelopmentComparisonSemantics.evidence.schemaVersion,
-            protocolHash: preflight.protocolIdentity.protocolHash,
+            candidateDevelopmentProtocolHash: preflight.protocolIdentity.candidateDevelopmentProtocolHash,
+            strategyProtocolHash: preflight.expectedStrategyProtocolHash,
             comparisonSemantics: preflight.comparisonSemantics,
             analysis,
           })
@@ -773,11 +832,18 @@ export const validateCandidateDevelopmentComparisonSemanticsEvidence = (
       observed: root.schemaVersion,
     })
   }
-  if (root.protocolHash !== preflight.protocolIdentity.protocolHash) {
+  if (root.candidateDevelopmentProtocolHash !== preflight.protocolIdentity.candidateDevelopmentProtocolHash) {
     return Result.fail({
-      _tag: 'CandidateDevelopmentComparisonSemanticsProtocolMismatch',
-      expected: preflight.protocolIdentity.protocolHash,
-      observed: root.protocolHash,
+      _tag: 'CandidateDevelopmentComparisonDevelopmentProtocolMismatch',
+      expected: preflight.protocolIdentity.candidateDevelopmentProtocolHash,
+      observed: root.candidateDevelopmentProtocolHash,
+    })
+  }
+  if (root.strategyProtocolHash !== preflight.expectedStrategyProtocolHash) {
+    return Result.fail({
+      _tag: 'CandidateDevelopmentComparisonStrategyProtocolMismatch',
+      expected: preflight.expectedStrategyProtocolHash,
+      observed: root.strategyProtocolHash,
     })
   }
   const observedSemantics = comparisonEvidenceRecord(root.comparisonSemantics)
@@ -905,6 +971,7 @@ export type CandidateDevelopmentRunFailure =
 export interface CandidateDevelopmentPreflightInput {
   readonly candidateOrdinal: number
   readonly priorTrialCount: number
+  readonly expectedStrategyProtocolHash: string
   readonly officialSessions: readonly IsoDate[]
   readonly signalSessionDates: readonly IsoDate[]
   readonly featureLookbackSessions: number
@@ -948,6 +1015,8 @@ const validIsoDate = (value: string): value is IsoDate => {
   const parsed = new Date(`${value}T00:00:00.000Z`)
   return !Number.isNaN(parsed.getTime()) && parsed.toISOString().slice(0, 10) === value
 }
+
+const validStrategyProtocolHash = (value: string): boolean => /^[0-9a-f]{64}$/.test(value)
 
 const positiveInteger = (
   field: Extract<
@@ -1129,6 +1198,25 @@ export const officialMonthEndSignalDates = (sessions: readonly IsoDate[]): reado
     return next !== undefined && session.slice(0, 7) !== next.slice(0, 7)
   })
 
+export const expectedCandidateDevelopmentRebalanceSchedule = (
+  sessions: readonly IsoDate[],
+  signalSessionDates: readonly IsoDate[],
+  selectedObservationStart: IsoDate,
+  selectedObservationEnd: IsoDate,
+): readonly CandidateDevelopmentRebalanceBoundary[] => {
+  const sessionIndices = new Map(sessions.map((session, index) => [session, index] as const))
+  return signalSessionDates.flatMap((signalDate) => {
+    const signalIndex = sessionIndices.get(signalDate)
+    if (signalIndex === undefined) return []
+    const executionDate = sessions.at(signalIndex + candidateDevelopmentWalkForwardProtocol.executionLagSessions)
+    return executionDate !== undefined &&
+      executionDate >= selectedObservationStart &&
+      executionDate <= selectedObservationEnd
+      ? [{ signalDate, executionDate }]
+      : []
+  })
+}
+
 export const firstEligibleExecutionAfterLookback = (
   sessions: readonly IsoDate[],
   signalSessionDates: readonly IsoDate[],
@@ -1261,8 +1349,16 @@ export const preflightCandidateDevelopment = (
   input: CandidateDevelopmentPreflightInput,
 ): Result.Result<CandidateDevelopmentPreflightDecision, CandidateDevelopmentPreflightIssue> =>
   pipe(
-    bindCandidateDevelopmentAttempt(input.candidateOrdinal, input.priorTrialCount),
-    Result.flatMap((attempt) =>
+    Result.all({
+      attempt: bindCandidateDevelopmentAttempt(input.candidateOrdinal, input.priorTrialCount),
+      expectedStrategyProtocolHash: validStrategyProtocolHash(input.expectedStrategyProtocolHash)
+        ? Result.succeed(input.expectedStrategyProtocolHash)
+        : Result.fail<CandidateDevelopmentPreflightIssue>({
+            _tag: 'CandidateDevelopmentStrategyProtocolHashInvalid',
+            observed: input.expectedStrategyProtocolHash,
+          }),
+    }),
+    Result.flatMap(({ attempt, expectedStrategyProtocolHash }) =>
       pipe(
         validateFrozenDevelopmentCalendar(input.officialSessions),
         Result.flatMap(() =>
@@ -1272,10 +1368,10 @@ export const preflightCandidateDevelopment = (
             input.featureLookbackSessions,
           ),
         ),
-        Result.map((firstEligibleExecution) => ({ attempt, firstEligibleExecution })),
+        Result.map((firstEligibleExecution) => ({ attempt, expectedStrategyProtocolHash, firstEligibleExecution })),
       ),
     ),
-    Result.flatMap(({ attempt, firstEligibleExecution }) =>
+    Result.flatMap(({ attempt, expectedStrategyProtocolHash, firstEligibleExecution }) =>
       pipe(
         Result.all({
           geometry: computeEndAnchoredWalkForwardBoundaries(
@@ -1284,7 +1380,7 @@ export const preflightCandidateDevelopment = (
             candidateDevelopmentWalkForwardProtocol,
           ),
           protocolIdentity: pipe(
-            identifyCandidateDevelopmentProtocol(attempt, input.featureLookbackSessions),
+            identifyCandidateDevelopmentProtocol(attempt, input.featureLookbackSessions, expectedStrategyProtocolHash),
             Result.mapError(
               (cause): CandidateDevelopmentPreflightIssue => ({
                 _tag: 'CandidateDevelopmentProtocolHashFailed',
@@ -1297,21 +1393,31 @@ export const preflightCandidateDevelopment = (
           ({ geometry, protocolIdentity }): CandidateDevelopmentPreflightDecision =>
             geometry.status === 'FAIL'
               ? geometry
-              : {
-                  ...geometry,
-                  schemaVersion: 'bayn.candidate-development-preflight.v3',
-                  attempt,
-                  featureLookbackSessions: input.featureLookbackSessions,
-                  firstEligibleExecution,
-                  protocolIdentity,
-                  doubledCostContract: candidateDevelopmentDoubledCostContract,
-                  statisticsPolicy: candidateDevelopmentStatisticsPolicy,
-                  comparisonSemantics: candidateDevelopmentComparisonSemantics,
-                  selectedObservationSessions: input.officialSessions.slice(
+              : (() => {
+                  const selectedObservationSessions = input.officialSessions.slice(
                     geometry.selectedObservationStartIndex,
                     geometry.selectedObservationEndIndex + 1,
-                  ),
-                },
+                  )
+                  return {
+                    ...geometry,
+                    schemaVersion: 'bayn.candidate-development-preflight.v4' as const,
+                    attempt,
+                    featureLookbackSessions: input.featureLookbackSessions,
+                    firstEligibleExecution,
+                    protocolIdentity,
+                    expectedStrategyProtocolHash,
+                    doubledCostContract: candidateDevelopmentDoubledCostContract,
+                    statisticsPolicy: candidateDevelopmentStatisticsPolicy,
+                    comparisonSemantics: candidateDevelopmentComparisonSemantics,
+                    selectedObservationSessions,
+                    expectedRebalanceSchedule: expectedCandidateDevelopmentRebalanceSchedule(
+                      input.officialSessions,
+                      input.signalSessionDates,
+                      geometry.selectedObservationStart,
+                      geometry.selectedObservationEnd,
+                    ),
+                  }
+                })(),
         ),
       ),
     ),


### PR DESCRIPTION
## Summary

- derive candidate-development rebalance identity exclusively from the preregistered official month-end signal schedule and each next official execution session inside the selected 1,489-session comparison window
- validate every baseline signal/execution pair before projected comparison analysis, rejecting shifted signal dates even when all execution dates match
- reject shifted, missing, extra, and the formerly accepted every-100th-session evaluation schedule before any metric-bearing report succeeds
- keep strategy protocol identity explicit and separate from candidate-development protocol identity; validate `EvaluationResult.protocolHash` only against the preregistered strategy-protocol hash
- bind both identity domains independently in comparison evidence and reject drift in either domain
- replace the masked test fixture with a valid manifest/provenance identity produced by `makeEvaluationIdentity`
- preserve terminal qualification policy and production behavior unchanged

This corrects the two post-merge P1 findings from PR #13370:

- https://github.com/proompteng/lab/pull/13370#discussion_r3679370798
- https://github.com/proompteng/lab/pull/13370#discussion_r3679370800

It also addresses the exact-head PR #13372 review finding that signal dates must be bound alongside execution dates.

## Related Issues

None

## Testing

- `bun test src/candidate-development.test.ts src/qualification-statistics.test.ts` — 47 passed, 0 failed
- `bun run test` — 877 passed, 128 PostgreSQL-dependent tests skipped locally, 0 failed
- `bun run tsc`
- `bun run lint:effect`
- `bun run lint:oxlint`
- `bun run lint:oxlint:type`
- `bunx oxfmt --check src/candidate-development.ts src/candidate-development.test.ts src/qualification-statistics.ts src/qualification-statistics/bootstrap.ts src/qualification-statistics/comparison.ts src/qualification-statistics/failure.ts src/qualification-statistics/walk-forward.ts src/qualification-statistics.test.ts`
- `bun run build`
- `git diff --check`
- PostgreSQL integrations require the repository PostgreSQL 18 service and must pass on this exact head in CI

## Screenshots (if applicable)

N/A

## Breaking Changes

Candidate-development protocol advances to v4, preflight to v4, comparison semantics to v2, comparison evidence to v3, report to v2, and candidate-development protocol identity to v2. These versions bind the independently preregistered strategy-protocol hash and exact official signal/execution rebalance schedule. Historical terminal qualification evidence and terminal qualification behavior remain unchanged.

## Checklist

- [x] Testing section documents exact validation.
- [x] The correction is limited to candidate-development protocol code and tests.
- [x] No candidate data, holdout data, broker mutation, or capital authority was accessed or enabled.
