### PR TITLE
fix(bayn): retry recoverable broker session acquisition

### DIFF
--- a/services/bayn/src/broker/alpaca/session.test.ts
+++ b/services/bayn/src/broker/alpaca/session.test.ts
@@ -1,0 +1,304 @@
+import { describe, expect, test } from 'bun:test'
+
+import { Deferred, Effect, Fiber, Layer, Logger, Redacted, Ref, References, Result } from 'effect'
+import { TestClock } from 'effect/testing'
+import { HttpClient, HttpClientResponse } from 'effect/unstable/http'
+
+import { alpacaSandboxBaseUrl, decodeBrokerConnection } from '../connection'
+import { BrokerEnvironment, BrokerProvider } from '../identity'
+import { BrokerReadErrorKind } from './failures'
+import { AccountStatus, BrokerRead } from './model'
+import {
+  BrokerSession,
+  BrokerSessionAcquisitionError,
+  BrokerSessionAcquisitionStage,
+  acquireBrokerSession,
+  layer,
+} from './session'
+
+const accountId = 'e6fe16f3-64a4-4921-8928-cadf02f92f98'
+const key = 'paper-key-session-retry-secret'
+const secret = 'paper-secret-session-retry-secret'
+
+const accountResponse = {
+  id: accountId,
+  account_number: '010203ABCD',
+  status: 'ACTIVE',
+  currency: 'USD',
+  cash: '100000.00',
+  equity: '100000.00',
+  last_equity: '100000.00',
+  buying_power: '200000.00',
+  account_blocked: false,
+  trading_blocked: false,
+  trade_suspended_by_user: false,
+  options_buying_power: '0',
+}
+
+const accountConfigurationResponse = {
+  fractional_trading: true,
+  no_shorting: true,
+  suspend_trade: false,
+}
+
+const connection = (retryAttempts: number) =>
+  Result.getOrThrow(
+    decodeBrokerConnection({
+      provider: BrokerProvider.Alpaca,
+      environment: BrokerEnvironment.Sandbox,
+      baseUrl: alpacaSandboxBaseUrl,
+      expectedAccountId: accountId,
+      key: Redacted.make(key),
+      secret: Redacted.make(secret),
+      proxyUrl: 'http://bayn-egress-proxy:3128',
+      operationTimeoutMs: 30_000,
+      retryAttempts,
+    }),
+  )
+
+const responseHeaders = (requestId: string) => ({
+  'content-type': 'application/json',
+  'x-request-id': requestId,
+  'x-ratelimit-limit': '200',
+  'x-ratelimit-remaining': '199',
+  'x-ratelimit-reset': '1784664000',
+})
+
+const jsonResponse = (
+  request: Parameters<typeof HttpClientResponse.fromWeb>[0],
+  body: unknown,
+  requestId: string,
+  status = 200,
+) =>
+  HttpClientResponse.fromWeb(
+    request,
+    new Response(JSON.stringify(body), {
+      status,
+      headers: responseHeaders(requestId),
+    }),
+  )
+
+const completePreflightResponse = (
+  request: Parameters<typeof HttpClientResponse.fromWeb>[0],
+  url: URL,
+  requestId: string,
+) => {
+  if (url.pathname === '/v2/account') return jsonResponse(request, accountResponse, requestId)
+  if (url.pathname === '/v2/account/configurations') {
+    return jsonResponse(request, accountConfigurationResponse, requestId)
+  }
+  if (
+    url.pathname === '/v2/positions' ||
+    url.pathname === '/v2/orders' ||
+    url.pathname === '/v2/account/activities/FILL' ||
+    url.pathname === '/v2/calendar'
+  ) {
+    return jsonResponse(request, [], requestId)
+  }
+  return jsonResponse(request, { code: 40410000, message: 'order not found' }, requestId, 404)
+}
+
+describe('Alpaca broker session acquisition retry', () => {
+  test('re-runs the complete preflight after request retry exhaustion and publishes one frozen verified session', async () => {
+    const options = connection(1)
+    let requests = 0
+    let accountRequests = 0
+    const logs: Array<{ readonly message: unknown; readonly annotations: Record<string, unknown> }> = []
+    const logger = Logger.make<unknown, void>((entry) => {
+      logs.push({
+        message: entry.message,
+        annotations: { ...entry.fiber.getRef(References.CurrentLogAnnotations) },
+      })
+    })
+    const client = HttpClient.make((request, url) => {
+      requests += 1
+      if (url.pathname === '/v2/account') {
+        accountRequests += 1
+        if (accountRequests <= 2) {
+          return Effect.succeed(
+            jsonResponse(request, { code: 50010000, message: 'temporary account failure' }, `req-${requests}`, 500),
+          )
+        }
+      }
+      return Effect.succeed(completePreflightResponse(request, url, `req-${requests}`))
+    })
+    const testLayer = layer(options).pipe(Layer.provide(Layer.succeed(HttpClient.HttpClient, client)))
+
+    const services = await Effect.runPromise(
+      Effect.gen(function* () {
+        const fiber = yield* Effect.all({ session: BrokerSession, read: BrokerRead }).pipe(
+          Effect.provide(testLayer),
+          Effect.forkChild({ startImmediately: true }),
+        )
+        yield* Effect.yieldNow
+        expect(accountRequests).toBe(2)
+        yield* TestClock.adjust(1_000)
+        return yield* Fiber.join(fiber)
+      }).pipe(Effect.provide(Logger.layer([logger])), Effect.provide(TestClock.layer())),
+    )
+
+    expect(services.session.read).toBe(services.read)
+    expect(Object.isFrozen(services.session)).toBe(true)
+    expect(services.session.connection).toBe(options)
+    expect(services.session.preflight).toMatchObject({
+      provider: BrokerProvider.Alpaca,
+      environment: BrokerEnvironment.Sandbox,
+      baseUrl: alpacaSandboxBaseUrl,
+      accountId,
+      accountStatus: AccountStatus.Active,
+      accountBlocked: false,
+      tradingBlocked: false,
+      tradeSuspendedByUser: false,
+      fractionalTrading: true,
+      orderById: 'NOT_FOUND',
+      orderByClientId: 'NOT_FOUND',
+    })
+    expect(accountRequests).toBe(3)
+    expect(requests).toBe(11)
+    expect(JSON.stringify(logs)).not.toContain(key)
+    expect(JSON.stringify(logs)).not.toContain(secret)
+  })
+
+  test('attempts a deterministic account mismatch once and preserves its typed stage without credentials', async () => {
+    const options = connection(2)
+    const wrongAccountId = '8f2a5d40-3a43-4e80-9ef0-4b8a4db1d276'
+    let requests = 0
+    const client = HttpClient.make((request) => {
+      requests += 1
+      return Effect.succeed(jsonResponse(request, { ...accountResponse, id: wrongAccountId }, `req-${requests}`))
+    })
+
+    const failure = await Effect.runPromise(
+      Effect.flip(
+        acquireBrokerSession(options).pipe(
+          Effect.provideService(HttpClient.HttpClient, client),
+          Effect.provide(TestClock.layer()),
+        ),
+      ),
+    )
+
+    expect(requests).toBe(1)
+    expect(failure).toBeInstanceOf(BrokerSessionAcquisitionError)
+    expect(failure).toMatchObject({
+      stage: BrokerSessionAcquisitionStage.Account,
+      provider: BrokerProvider.Alpaca,
+      environment: BrokerEnvironment.Sandbox,
+      baseUrl: alpacaSandboxBaseUrl,
+      expectedAccountId: accountId,
+      cause: {
+        operation: 'account',
+        kind: BrokerReadErrorKind.AccountMismatch,
+        retryable: false,
+        requestId: 'req-1',
+      },
+    })
+    expect(JSON.stringify(failure)).not.toContain(key)
+    expect(JSON.stringify(failure)).not.toContain(secret)
+  })
+
+  test('bounds whole-session retry exhaustion and returns the final typed read failure', async () => {
+    const options = connection(2)
+    let requests = 0
+    const client = HttpClient.make((request) => {
+      requests += 1
+      return Effect.succeed(
+        jsonResponse(request, { code: 50010000, message: 'temporary account failure' }, `req-${requests}`, 500),
+      )
+    })
+
+    const failure = await Effect.runPromise(
+      Effect.gen(function* () {
+        const fiber = yield* Effect.flip(
+          acquireBrokerSession(options).pipe(Effect.provideService(HttpClient.HttpClient, client)),
+        ).pipe(Effect.forkChild({ startImmediately: true }))
+        yield* Effect.yieldNow
+        expect(requests).toBe(3)
+        yield* TestClock.adjust(1_000)
+        expect(requests).toBe(6)
+        yield* TestClock.adjust(1_000)
+        return yield* Fiber.join(fiber)
+      }).pipe(Effect.provide(TestClock.layer())),
+    )
+
+    expect(requests).toBe(9)
+    expect(failure).toMatchObject({
+      stage: BrokerSessionAcquisitionStage.Account,
+      cause: {
+        operation: 'account',
+        kind: BrokerReadErrorKind.Server,
+        retryable: true,
+        status: 500,
+        requestId: 'req-9',
+      },
+    })
+    expect(JSON.stringify(failure)).not.toContain(key)
+    expect(JSON.stringify(failure)).not.toContain(secret)
+  })
+
+  test('does not start a late whole-session retry after the bounded startup retry window closes', async () => {
+    const options = connection(2)
+    let requests = 0
+    const client = HttpClient.make((request) => {
+      requests += 1
+      const requestId = `req-${requests}`
+      return Effect.sleep(6_000).pipe(
+        Effect.as(jsonResponse(request, { code: 50010000, message: 'slow temporary failure' }, requestId, 500)),
+      )
+    })
+
+    const failure = await Effect.runPromise(
+      Effect.gen(function* () {
+        const fiber = yield* Effect.flip(
+          acquireBrokerSession(options).pipe(Effect.provideService(HttpClient.HttpClient, client)),
+        ).pipe(Effect.forkChild({ startImmediately: true }))
+        yield* Effect.yieldNow
+        expect(requests).toBe(1)
+        yield* TestClock.adjust(6_000)
+        expect(requests).toBe(2)
+        yield* TestClock.adjust(6_000)
+        expect(requests).toBe(3)
+        yield* TestClock.adjust(6_000)
+        return yield* Fiber.join(fiber)
+      }).pipe(Effect.provide(TestClock.layer())),
+    )
+
+    expect(requests).toBe(3)
+    expect(failure).toMatchObject({
+      stage: BrokerSessionAcquisitionStage.Account,
+      cause: {
+        operation: 'account',
+        kind: BrokerReadErrorKind.Server,
+        retryable: true,
+        requestId: 'req-3',
+      },
+    })
+  })
+
+  test('propagates interruption and finalizes the in-flight read exactly once without retrying', async () => {
+    const options = connection(2)
+    let requests = 0
+    const finalizations = await Effect.runPromise(
+      Effect.gen(function* () {
+        const started = yield* Deferred.make<void>()
+        const finalized = yield* Ref.make(0)
+        const client = HttpClient.make(() => {
+          requests += 1
+          return Deferred.succeed(started, undefined).pipe(
+            Effect.andThen(Effect.never),
+            Effect.ensuring(Ref.update(finalized, (count) => count + 1)),
+          )
+        })
+        const fiber = yield* acquireBrokerSession(options).pipe(
+          Effect.provideService(HttpClient.HttpClient, client),
+          Effect.forkChild({ startImmediately: true }),
+        )
+        yield* Deferred.await(started)
+        yield* Fiber.interrupt(fiber)
+        return yield* Ref.get(finalized)
+      }),
+    )
+
+    expect(requests).toBe(1)
+    expect(finalizations).toBe(1)
+  })
+})

--- a/services/bayn/src/broker/alpaca/session.test.ts
+++ b/services/bayn/src/broker/alpaca/session.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, test } from 'bun:test'
 
-import { Deferred, Effect, Fiber, Layer, Logger, Redacted, Ref, References, Result } from 'effect'
+import { Clock, Deferred, Effect, Fiber, Layer, Logger, Redacted, Ref, References, Result } from 'effect'
 import { TestClock } from 'effect/testing'
 import { HttpClient, HttpClientResponse } from 'effect/unstable/http'
 
 import { alpacaSandboxBaseUrl, decodeBrokerConnection } from '../connection'
 import { BrokerEnvironment, BrokerProvider } from '../identity'
-import { BrokerReadErrorKind } from './failures'
+import { BrokerReadError, BrokerReadErrorKind } from './failures'
 import { AccountStatus, BrokerRead } from './model'
 import {
   BrokerSession,
@@ -14,6 +14,7 @@ import {
   BrokerSessionAcquisitionStage,
   acquireBrokerSession,
   layer,
+  retryRecoverableBrokerSessionAcquisition,
 } from './session'
 
 const accountId = 'e6fe16f3-64a4-4921-8928-cadf02f92f98'
@@ -272,6 +273,50 @@ describe('Alpaca broker session acquisition retry', () => {
         requestId: 'req-3',
       },
     })
+  })
+
+  test('does not start a retry when delayed wake-up crosses the bounded startup retry deadline', async () => {
+    const options = connection(1)
+    let attempts = 0
+    let clockReads = 0
+    const clockTimes = [0, 0, 6_000] as const
+    const readTime = () => clockTimes[Math.min(clockReads++, clockTimes.length - 1)]
+    const currentTime = () => clockTimes[Math.min(clockReads, clockTimes.length - 1)]
+    const clock: Clock.Clock = {
+      currentTimeMillisUnsafe: readTime,
+      currentTimeMillis: Effect.sync(readTime),
+      currentTimeNanosUnsafe: () => BigInt(currentTime()) * 1_000_000n,
+      currentTimeNanos: Effect.sync(() => BigInt(currentTime()) * 1_000_000n),
+      sleep: () => Effect.succeed(undefined),
+    }
+    const cause = new BrokerReadError({
+      operation: 'account',
+      kind: BrokerReadErrorKind.Server,
+      message: 'temporary account failure',
+      retryable: true,
+      status: 500,
+      requestId: 'req-1',
+    })
+    const acquisitionFailure = new BrokerSessionAcquisitionError({
+      stage: BrokerSessionAcquisitionStage.Account,
+      provider: options.provider,
+      environment: options.environment,
+      baseUrl: options.baseUrl,
+      expectedAccountId: options.expectedAccountId,
+      cause,
+    })
+    const acquisition = Effect.sync(() => {
+      attempts += 1
+    }).pipe(Effect.andThen(Effect.fail(acquisitionFailure)))
+
+    const failure = await Effect.runPromise(
+      Effect.flip(retryRecoverableBrokerSessionAcquisition(options, acquisition)).pipe(
+        Effect.provideService(Clock.Clock, clock),
+      ),
+    )
+
+    expect(attempts).toBe(1)
+    expect(failure).toBe(acquisitionFailure)
   })
 
   test('propagates interruption and finalizes the in-flight read exactly once without retrying', async () => {

--- a/services/bayn/src/broker/alpaca/session.ts
+++ b/services/bayn/src/broker/alpaca/session.ts
@@ -1,4 +1,4 @@
-import { Context, Data, Effect, Layer, pipe } from 'effect'
+import { Clock, Context, Data, Duration, Effect, Layer, pipe } from 'effect'
 import { HttpClient } from 'effect/unstable/http'
 
 import type { BrokerConnection } from '../connection'
@@ -30,6 +30,10 @@ export interface BrokerSessionShape {
 }
 
 export class BrokerSession extends Context.Service<BrokerSession, BrokerSessionShape>()('bayn/BrokerSession') {}
+
+const brokerSessionRetrySpacing = Duration.seconds(1)
+const brokerSessionRetrySpacingMs = 1_000
+const brokerSessionRetryWindowMs = 5_000
 
 const acquisitionStage = (cause: BrokerReadError | BrokerAccountPreflightError): BrokerSessionAcquisitionStage => {
   if (cause instanceof BrokerAccountPreflightError) return BrokerSessionAcquisitionStage.Permissions
@@ -68,18 +72,47 @@ const acquisitionError = (
     cause,
   })
 
+const isRetryableBrokerSessionAcquisition = (error: BrokerSessionAcquisitionError): boolean =>
+  error.cause instanceof BrokerReadError && error.cause.retryable
+
+const retryRecoverableBrokerSessionAcquisition = <A, R>(
+  connection: BrokerConnection,
+  effect: Effect.Effect<A, BrokerSessionAcquisitionError, R>,
+): Effect.Effect<A, BrokerSessionAcquisitionError, R> =>
+  Effect.gen(function* () {
+    const startedAtMs = yield* Clock.currentTimeMillis
+    const retryDeadlineMs = startedAtMs + brokerSessionRetryWindowMs
+    const attempt = (retriesRemaining: number): Effect.Effect<A, BrokerSessionAcquisitionError, R> =>
+      effect.pipe(
+        Effect.catch((error) => {
+          if (retriesRemaining === 0 || !isRetryableBrokerSessionAcquisition(error)) return Effect.fail(error)
+          return Clock.currentTimeMillis.pipe(
+            Effect.flatMap((failedAtMs) =>
+              failedAtMs + brokerSessionRetrySpacingMs >= retryDeadlineMs
+                ? Effect.fail(error)
+                : Effect.sleep(brokerSessionRetrySpacing).pipe(Effect.andThen(attempt(retriesRemaining - 1))),
+            ),
+          )
+        }),
+      )
+    return yield* attempt(connection.retryAttempts)
+  })
+
 export const acquireBrokerSession = (
   connection: BrokerConnection,
 ): Effect.Effect<BrokerSessionShape, BrokerSessionAcquisitionError, HttpClient.HttpClient> =>
   pipe(
-    make(connection),
-    Effect.flatMap((read) =>
-      pipe(
-        verifyReadAccess(connection, read),
-        Effect.map((preflight) => Object.freeze({ connection, read, preflight })),
+    pipe(
+      make(connection),
+      Effect.flatMap((read) =>
+        pipe(
+          verifyReadAccess(connection, read),
+          Effect.map((preflight) => Object.freeze({ connection, read, preflight })),
+        ),
       ),
+      Effect.mapError((cause) => acquisitionError(connection, cause)),
     ),
-    Effect.mapError((cause) => acquisitionError(connection, cause)),
+    (acquisition) => retryRecoverableBrokerSessionAcquisition(connection, acquisition),
     Effect.withLogSpan('broker.session.acquire'),
   )
 

--- a/services/bayn/src/broker/alpaca/session.ts
+++ b/services/bayn/src/broker/alpaca/session.ts
@@ -75,7 +75,7 @@ const acquisitionError = (
 const isRetryableBrokerSessionAcquisition = (error: BrokerSessionAcquisitionError): boolean =>
   error.cause instanceof BrokerReadError && error.cause.retryable
 
-const retryRecoverableBrokerSessionAcquisition = <A, R>(
+export const retryRecoverableBrokerSessionAcquisition = <A, R>(
   connection: BrokerConnection,
   effect: Effect.Effect<A, BrokerSessionAcquisitionError, R>,
 ): Effect.Effect<A, BrokerSessionAcquisitionError, R> =>
@@ -90,7 +90,12 @@ const retryRecoverableBrokerSessionAcquisition = <A, R>(
             Effect.flatMap((failedAtMs) =>
               failedAtMs + brokerSessionRetrySpacingMs >= retryDeadlineMs
                 ? Effect.fail(error)
-                : Effect.sleep(brokerSessionRetrySpacing).pipe(Effect.andThen(attempt(retriesRemaining - 1))),
+                : Effect.sleep(brokerSessionRetrySpacing).pipe(
+                    Effect.andThen(Clock.currentTimeMillis),
+                    Effect.flatMap((wokeAtMs) =>
+                      wokeAtMs >= retryDeadlineMs ? Effect.fail(error) : attempt(retriesRemaining - 1),
+                    ),
+                  ),
             ),
           )
         }),


### PR DESCRIPTION
## Summary

- retry only recoverable typed Alpaca broker-read failures at the complete broker-session acquisition boundary
- recreate and rerun the full read-only preflight before publishing one frozen verified session
- bound retry starts to the existing connection retry count, one-second spacing, and a five-second window from acquisition start
- preserve immediate fail-closed behavior for deterministic account, permission, decoding, and contract failures
- add focused regressions for recovery, exhaustion, late-retry suppression, interruption/finalization, and credential redaction

## Related Issues

None

## Testing

- `bun test services/bayn/src/broker/alpaca/session.test.ts` — 5 pass, 0 fail
- `bun test services/bayn/src/broker/alpaca.test.ts` — 40 pass, 0 fail
- `bun run --filter @proompteng/bayn test` — 882 pass, 128 skip, 0 fail
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn lint:effect`
- `bun run --filter @proompteng/bayn build`
- pre-commit lint-staged and commitlint hooks

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots section removed because this change has no UI.
- [x] Breaking Changes section is filled in.
- [x] No documentation or release-note change is required for this internal reliability policy.
