### PR TITLE
feat(bayn): prove forward realized performance

### DIFF
--- a/services/bayn/src/forward-performance-command.ts
+++ b/services/bayn/src/forward-performance-command.ts
@@ -1,0 +1,33 @@
+import { NodeRuntime, NodeServices } from '@effect/platform-node'
+import { Effect, Layer, Logger, Stdio, Stream } from 'effect'
+
+import { loadConfig } from './config'
+import { PostgresClientLive } from './db/evidence-store'
+import { canonicalJsonV1Result, renderCanonicalJsonFailure } from './hash'
+import { runForwardPerformance, ForwardPerformanceProgramError } from './forward-performance'
+
+export { runForwardPerformance } from './forward-performance'
+
+const main = Effect.scoped(
+  Effect.gen(function* () {
+    const config = yield* loadConfig()
+    const receipt = yield* runForwardPerformance(config).pipe(Effect.provide(PostgresClientLive(config)))
+    const output = yield* Effect.fromResult(canonicalJsonV1Result(receipt)).pipe(
+      Effect.mapError(
+        (cause) =>
+          new ForwardPerformanceProgramError({
+            operation: 'construct-receipt',
+            message: `forward-performance output encoding failed: ${renderCanonicalJsonFailure(cause)}`,
+            cause,
+          }),
+      ),
+    )
+    const stdio = yield* Stdio.Stdio
+    yield* Stream.run(Stream.make(`${output}\n`), stdio.stdout())
+  }),
+)
+
+const runtime = Layer.mergeAll(Logger.layer([Logger.consoleJson]), NodeServices.layer)
+const program = main.pipe(Effect.annotateLogs({ service: 'bayn-forward-performance' }), Effect.provide(runtime))
+
+if (import.meta.main) NodeRuntime.runMain(program)

--- a/services/bayn/src/forward-performance/domain.test.ts
+++ b/services/bayn/src/forward-performance/domain.test.ts
@@ -1,0 +1,270 @@
+import assert from 'node:assert/strict'
+
+import { describe, expect, test } from 'bun:test'
+import { Result } from 'effect'
+
+import { makeForwardPerformanceReceipt } from './domain'
+import type { ForwardPerformanceEvidenceInput, ForwardPerformanceReceipt } from './model'
+
+const hash = (character: string): string => character.repeat(64)
+
+const cycle = (name: string, overrides: Partial<ForwardPerformanceEvidenceInput['cycles'][number]> = {}) => ({
+  cycleId: hash(name),
+  qualificationRunId: hash('1'),
+  strategyName: 'risk-balanced-trend',
+  strategyProtocolHash: hash('2'),
+  accountId: 'paper-account-1',
+  executionPolicyHash: hash('3'),
+  strategyExecutionModelHash: hash('4'),
+  state: 'COMPLETED' as const,
+  submissionOpenAt: '2026-07-20T13:00:00.000Z',
+  terminalAt: '2026-07-20T21:00:00.000Z',
+  ...overrides,
+})
+
+const transaction = (
+  name: string,
+  realizedPnlMicros: string,
+  feeMicros: string,
+  overrides: Partial<ForwardPerformanceEvidenceInput['transactions'][number]> = {},
+) => ({
+  transactionId: hash(name),
+  cycleId: hash('a'),
+  side: 'SELL' as const,
+  feeMicros,
+  realizedPnlMicros,
+  occurredAt: '2026-07-20T20:00:00.000Z',
+  ...overrides,
+})
+
+const input = (overrides: Partial<ForwardPerformanceEvidenceInput> = {}): ForwardPerformanceEvidenceInput => ({
+  runtime: {
+    sourceRevision: 'a'.repeat(40),
+    imageRepository: 'registry.example.test/lab/bayn',
+    imageDigest: `sha256:${hash('b')}`,
+  },
+  account: {
+    accountId: 'paper-account-1',
+    accountReferenceHash: hash('5'),
+    provider: 'alpaca',
+    environment: 'sandbox',
+  },
+  durableExecutionBindings: [
+    {
+      accountId: 'paper-account-1',
+      accountReferenceHash: hash('5'),
+      provider: 'alpaca',
+      environment: 'sandbox',
+      qualificationRunId: hash('1'),
+      strategyName: 'risk-balanced-trend',
+      strategyProtocolHash: hash('2'),
+      strategyBehaviorHash: hash('6'),
+      strategyParameterHash: hash('7'),
+      strategyParameterSchemaVersion: 'bayn.risk-balanced-trend.protocol.v4',
+      executionPolicyHash: hash('3'),
+      sourceRevision: 'c'.repeat(40),
+      imageRepository: 'registry.example.test/lab/bayn',
+      imageDigest: `sha256:${hash('d')}`,
+    },
+  ],
+  cycles: [cycle('a')],
+  strategy: {
+    qualificationRunId: hash('1'),
+    strategyName: 'risk-balanced-trend',
+    strategyProtocolHash: hash('2'),
+    strategyBehaviorHash: hash('6'),
+    strategyParameterHash: hash('7'),
+    strategyParameterSchemaVersion: 'bayn.risk-balanced-trend.protocol.v4',
+    sourceRevision: 'c'.repeat(40),
+    imageRepository: 'registry.example.test/lab/bayn',
+    imageDigest: `sha256:${hash('d')}`,
+  },
+  reconciliation: {
+    reconciliationId: hash('8'),
+    contentHash: hash('9'),
+    status: 'EXACT',
+    reconciledAt: '2026-07-20T21:01:00.000Z',
+  },
+  startingCapitalMicros: '1000',
+  transactions: [transaction('e', '100', '20')],
+  ledgerTotals: {
+    realizedGainMicros: '100',
+    realizedLossMicros: '0',
+    brokerExecutionFeesMicros: '20',
+    otherChargedCostsMicros: '0',
+    cashYieldMicros: '0',
+  },
+  accountingReceiptsExact: true,
+  ledgerExact: true,
+  missingLedgerAccountCount: 0,
+  unresolvedMutationCount: 0,
+  unclosedCycleCount: 0,
+  openPositionCount: 0,
+  ...overrides,
+})
+
+const success = (value: Result.Result<ForwardPerformanceReceipt, unknown>): ForwardPerformanceReceipt => {
+  assert(Result.isSuccess(value), 'forward-performance fixture must produce a receipt')
+  return value.success
+}
+
+describe('forward performance domain', () => {
+  test('reports positive net realized returns after charged costs', () => {
+    const receipt = success(makeForwardPerformanceReceipt(input()))
+
+    expect(receipt.evidence).toEqual({ status: 'SUFFICIENT', reasonCodes: [] })
+    expect(receipt.profitability).toBe('PROFITABLE')
+    expect(receipt.totals).toMatchObject({
+      grossRealizedPnlMicros: '100',
+      netRealizedPnlAfterCostsMicros: '80',
+      netRealizedReturn: {
+        numeratorMicros: '80',
+        denominatorMicros: '1000',
+        decimal: '0.080000000000',
+      },
+    })
+  })
+
+  test('reports realized losses without using mark-to-market equity', () => {
+    const receipt = success(
+      makeForwardPerformanceReceipt(
+        input({
+          transactions: [transaction('e', '-50', '10')],
+          ledgerTotals: {
+            realizedGainMicros: '0',
+            realizedLossMicros: '50',
+            brokerExecutionFeesMicros: '10',
+            otherChargedCostsMicros: '0',
+            cashYieldMicros: '0',
+          },
+        }),
+      ),
+    )
+
+    expect(receipt.profitability).toBe('NOT_PROFITABLE')
+    expect(receipt.totals.grossRealizedPnlMicros).toBe('-50')
+    expect(receipt.totals.netRealizedPnlAfterCostsMicros).toBe('-60')
+  })
+
+  test('fees can flip gross profit into a net realized loss', () => {
+    const receipt = success(
+      makeForwardPerformanceReceipt(
+        input({
+          transactions: [transaction('e', '100', '150')],
+          ledgerTotals: {
+            realizedGainMicros: '100',
+            realizedLossMicros: '0',
+            brokerExecutionFeesMicros: '150',
+            otherChargedCostsMicros: '0',
+            cashYieldMicros: '0',
+          },
+        }),
+      ),
+    )
+
+    expect(receipt.profitability).toBe('NOT_PROFITABLE')
+    expect(receipt.totals.grossRealizedPnlMicros).toBe('100')
+    expect(receipt.totals.netRealizedPnlAfterCostsMicros).toBe('-50')
+  })
+
+  test('an open or partial operating window is insufficient evidence', () => {
+    const receipt = success(makeForwardPerformanceReceipt(input({ unclosedCycleCount: 1 })))
+
+    expect(receipt.evidence).toEqual({ status: 'INSUFFICIENT_EVIDENCE', reasonCodes: ['UNCLOSED_WINDOW'] })
+    expect(receipt.profitability).toBe('UNDETERMINED')
+  })
+
+  test('zero activity is never profitable', () => {
+    const receipt = success(
+      makeForwardPerformanceReceipt(
+        input({
+          cycles: [cycle('a', { state: 'NO_TRADE' })],
+          transactions: [],
+          ledgerTotals: {
+            realizedGainMicros: '0',
+            realizedLossMicros: '0',
+            brokerExecutionFeesMicros: '0',
+            otherChargedCostsMicros: '0',
+            cashYieldMicros: '0',
+          },
+        }),
+      ),
+    )
+
+    expect(receipt.evidence.reasonCodes).toContain('ZERO_COMPLETED_EXECUTIONS')
+    expect(receipt.profitability).toBe('UNDETERMINED')
+    expect(receipt.counts.completedExecutionCount).toBe(0)
+  })
+
+  test('missing starting capital is an evidence gap rather than malformed micros', () => {
+    const receipt = success(makeForwardPerformanceReceipt(input({ startingCapitalMicros: undefined })))
+
+    expect(receipt.evidence.reasonCodes).toContain('STARTING_CAPITAL_GAP')
+    expect(receipt.evidence.reasonCodes).not.toContain('INVALID_MICROS')
+    expect(receipt.profitability).toBe('UNDETERMINED')
+  })
+
+  test('invalid or overflowing integer-micro arithmetic fails closed', () => {
+    const max = ((1n << 127n) - 1n).toString()
+    const receipt = success(
+      makeForwardPerformanceReceipt(
+        input({
+          transactions: [transaction('e', `-${max}`, max)],
+          ledgerTotals: {
+            realizedGainMicros: '0',
+            realizedLossMicros: max,
+            brokerExecutionFeesMicros: max,
+            otherChargedCostsMicros: '0',
+            cashYieldMicros: '0',
+          },
+        }),
+      ),
+    )
+
+    expect(receipt.evidence.reasonCodes).toContain('INVALID_MICROS')
+    expect(receipt.profitability).toBe('UNDETERMINED')
+    expect(receipt.totals.netRealizedPnlAfterCostsMicros).toBeNull()
+  })
+
+  test('canonical ordering produces one deterministic content hash', () => {
+    const secondCycle = cycle('f', {
+      submissionOpenAt: '2026-07-21T13:00:00.000Z',
+      terminalAt: '2026-07-21T21:00:00.000Z',
+    })
+    const first = success(makeForwardPerformanceReceipt(input({ cycles: [secondCycle, cycle('a')] })))
+    const second = success(makeForwardPerformanceReceipt(input({ cycles: [cycle('a'), secondCycle] })))
+
+    expect(first).toEqual(second)
+    expect(first.receiptHash).toMatch(/^[0-9a-f]{64}$/)
+    expect(JSON.stringify(first)).not.toContain('paper-account-1')
+  })
+
+  test('identity drift across completed cycles is insufficient', () => {
+    const receipt = success(
+      makeForwardPerformanceReceipt(
+        input({
+          cycles: [cycle('a'), cycle('f', { strategyProtocolHash: hash('f') })],
+        }),
+      ),
+    )
+
+    expect(receipt.evidence.reasonCodes).toContain('CYCLE_IDENTITY_DRIFT')
+    expect(receipt.profitability).toBe('UNDETERMINED')
+  })
+
+  test('durable execution account drift is insufficient', () => {
+    const baseline = input()
+    const binding = baseline.durableExecutionBindings[0]
+    assert(binding !== undefined)
+    const receipt = success(
+      makeForwardPerformanceReceipt(
+        input({
+          durableExecutionBindings: [{ ...binding, environment: 'live' }],
+        }),
+      ),
+    )
+
+    expect(receipt.evidence.reasonCodes).toContain('ACCOUNT_IDENTITY_GAP')
+    expect(receipt.profitability).toBe('UNDETERMINED')
+  })
+})

--- a/services/bayn/src/forward-performance/domain.ts
+++ b/services/bayn/src/forward-performance/domain.ts
@@ -1,0 +1,351 @@
+import { Result } from 'effect'
+
+import { canonicalHashV1Result } from '../hash'
+import {
+  FORWARD_PERFORMANCE_SCHEMA_VERSION,
+  type ForwardPerformanceCycleEvidence,
+  type ForwardPerformanceEvidenceInput,
+  type ForwardPerformanceReasonCode,
+  type ForwardPerformanceReceipt,
+  type ForwardPerformanceReceiptMaterial,
+} from './model'
+
+const SIGNED_MICROS_MIN = -(1n << 127n)
+const SIGNED_MICROS_MAX = (1n << 127n) - 1n
+const RETURN_DECIMAL_PLACES = 12
+const RETURN_SCALE = 10n ** BigInt(RETURN_DECIMAL_PLACES)
+
+export interface ForwardPerformanceDomainFailure {
+  readonly _tag: 'ForwardPerformanceDomainFailure'
+  readonly operation: 'hash-receipt'
+  readonly cause: unknown
+}
+
+interface ParsedTotals {
+  readonly startingCapital: bigint
+  readonly realizedGains: bigint
+  readonly realizedLosses: bigint
+  readonly brokerExecutionFees: bigint
+  readonly otherChargedCosts: bigint
+  readonly cashYield: bigint
+  readonly grossRealizedPnl: bigint
+  readonly netRealizedPnlAfterCosts: bigint
+}
+
+const inSignedMicrosRange = (value: bigint): boolean => value >= SIGNED_MICROS_MIN && value <= SIGNED_MICROS_MAX
+
+const parseSignedMicros = (value: string): bigint | undefined => {
+  if (!/^(?:0|-?[1-9][0-9]*)$/.test(value)) return undefined
+  const parsed = BigInt(value)
+  return inSignedMicrosRange(parsed) ? parsed : undefined
+}
+
+const checkedAdd = (left: bigint, right: bigint): bigint | undefined => {
+  const value = left + right
+  return inSignedMicrosRange(value) ? value : undefined
+}
+
+const compareCycles = (left: ForwardPerformanceCycleEvidence, right: ForwardPerformanceCycleEvidence): number => {
+  if (left.submissionOpenAt !== right.submissionOpenAt) return left.submissionOpenAt < right.submissionOpenAt ? -1 : 1
+  return left.cycleId < right.cycleId ? -1 : left.cycleId > right.cycleId ? 1 : 0
+}
+
+const formatReturn = (numerator: bigint, denominator: bigint): string => {
+  const negative = numerator < 0n
+  const magnitude = negative ? -numerator : numerator
+  const scaledNumerator = magnitude * RETURN_SCALE
+  const quotient = scaledNumerator / denominator
+  const remainder = scaledNumerator % denominator
+  const rounded = remainder * 2n >= denominator ? quotient + 1n : quotient
+  const integer = rounded / RETURN_SCALE
+  const fraction = (rounded % RETURN_SCALE).toString().padStart(RETURN_DECIMAL_PLACES, '0')
+  return `${negative ? '-' : ''}${integer}.${fraction}`
+}
+
+const sameCycleIdentity = (left: ForwardPerformanceCycleEvidence, right: ForwardPerformanceCycleEvidence): boolean =>
+  left.qualificationRunId === right.qualificationRunId &&
+  left.strategyName === right.strategyName &&
+  left.strategyProtocolHash === right.strategyProtocolHash &&
+  left.accountId === right.accountId &&
+  left.executionPolicyHash === right.executionPolicyHash &&
+  left.strategyExecutionModelHash === right.strategyExecutionModelHash
+
+const durableExecutionSortKey = (
+  binding: ForwardPerformanceEvidenceInput['durableExecutionBindings'][number],
+): string =>
+  JSON.stringify([
+    binding.accountReferenceHash,
+    binding.provider,
+    binding.environment,
+    binding.qualificationRunId,
+    binding.strategyName,
+    binding.strategyProtocolHash,
+    binding.strategyBehaviorHash,
+    binding.strategyParameterHash,
+    binding.strategyParameterSchemaVersion,
+    binding.executionPolicyHash,
+    binding.sourceRevision,
+    binding.imageRepository,
+    binding.imageDigest,
+  ])
+
+const parseTotals = (
+  input: ForwardPerformanceEvidenceInput,
+  reasons: Set<ForwardPerformanceReasonCode>,
+): ParsedTotals | undefined => {
+  const ledger = input.ledgerTotals
+  if (input.startingCapitalMicros === undefined) {
+    reasons.add('STARTING_CAPITAL_GAP')
+    return undefined
+  }
+  if (ledger === undefined) {
+    reasons.add('MISSING_LEDGER_ACCOUNT')
+    return undefined
+  }
+  const startingCapital = parseSignedMicros(input.startingCapitalMicros)
+  const realizedGains = parseSignedMicros(ledger.realizedGainMicros)
+  const realizedLosses = parseSignedMicros(ledger.realizedLossMicros)
+  const brokerExecutionFees = parseSignedMicros(ledger.brokerExecutionFeesMicros)
+  const otherChargedCosts = parseSignedMicros(ledger.otherChargedCostsMicros)
+  const cashYield = parseSignedMicros(ledger.cashYieldMicros)
+  if (
+    startingCapital === undefined ||
+    startingCapital <= 0n ||
+    realizedGains === undefined ||
+    realizedGains < 0n ||
+    realizedLosses === undefined ||
+    realizedLosses < 0n ||
+    brokerExecutionFees === undefined ||
+    brokerExecutionFees < 0n ||
+    otherChargedCosts === undefined ||
+    otherChargedCosts < 0n ||
+    cashYield === undefined ||
+    cashYield < 0n
+  ) {
+    reasons.add('INVALID_MICROS')
+    return undefined
+  }
+  const grossRealizedPnl = checkedAdd(realizedGains, -realizedLosses)
+  const afterFees = grossRealizedPnl === undefined ? undefined : checkedAdd(grossRealizedPnl, -brokerExecutionFees)
+  const netRealizedPnlAfterCosts = afterFees === undefined ? undefined : checkedAdd(afterFees, -otherChargedCosts)
+  if (grossRealizedPnl === undefined || netRealizedPnlAfterCosts === undefined) {
+    reasons.add('INVALID_MICROS')
+    return undefined
+  }
+  return {
+    startingCapital,
+    realizedGains,
+    realizedLosses,
+    brokerExecutionFees,
+    otherChargedCosts,
+    cashYield,
+    grossRealizedPnl,
+    netRealizedPnlAfterCosts,
+  }
+}
+
+const transactionTotalsMatch = (
+  input: ForwardPerformanceEvidenceInput,
+  totals: ParsedTotals,
+  reasons: Set<ForwardPerformanceReasonCode>,
+): void => {
+  let gains = 0n
+  let losses = 0n
+  let fees = 0n
+  for (const transaction of input.transactions) {
+    const realizedPnl = parseSignedMicros(transaction.realizedPnlMicros)
+    const fee = parseSignedMicros(transaction.feeMicros)
+    if (realizedPnl === undefined || fee === undefined || fee < 0n) {
+      reasons.add('INVALID_MICROS')
+      return
+    }
+    const nextFees = checkedAdd(fees, fee)
+    const nextGains = realizedPnl > 0n ? checkedAdd(gains, realizedPnl) : gains
+    const nextLosses = realizedPnl < 0n ? checkedAdd(losses, -realizedPnl) : losses
+    if (nextFees === undefined || nextGains === undefined || nextLosses === undefined) {
+      reasons.add('INVALID_MICROS')
+      return
+    }
+    fees = nextFees
+    gains = nextGains
+    losses = nextLosses
+  }
+  if (gains !== totals.realizedGains || losses !== totals.realizedLosses || fees !== totals.brokerExecutionFees) {
+    reasons.add('LEDGER_MISMATCH')
+  }
+}
+
+const makeMaterial = (input: ForwardPerformanceEvidenceInput): ForwardPerformanceReceiptMaterial => {
+  const reasons = new Set<ForwardPerformanceReasonCode>()
+  const cycles = [...input.cycles].sort(compareCycles)
+  const firstCycle = cycles[0]
+  const lastCycle = cycles.at(-1)
+  const strategy = input.strategy
+  const reconciliation = input.reconciliation
+  const durableExecutions = [...input.durableExecutionBindings].sort((left, right) => {
+    const leftKey = durableExecutionSortKey(left)
+    const rightKey = durableExecutionSortKey(right)
+    return leftKey < rightKey ? -1 : leftKey > rightKey ? 1 : 0
+  })
+  const durableExecution = durableExecutions[0]
+
+  if (input.account.accountId.length === 0 || input.account.accountReferenceHash.length === 0) {
+    reasons.add('ACCOUNT_IDENTITY_GAP')
+  }
+  if (
+    input.transactions.length > 0 &&
+    (durableExecutions.length !== 1 ||
+      durableExecution === undefined ||
+      durableExecution.accountId !== input.account.accountId ||
+      durableExecution.accountReferenceHash !== input.account.accountReferenceHash ||
+      durableExecution.provider !== input.account.provider ||
+      durableExecution.environment !== input.account.environment)
+  ) {
+    reasons.add('ACCOUNT_IDENTITY_GAP')
+  }
+  if (
+    input.transactions.length > 0 &&
+    (durableExecution === undefined ||
+      firstCycle === undefined ||
+      strategy === undefined ||
+      durableExecution.qualificationRunId !== firstCycle.qualificationRunId ||
+      durableExecution.strategyName !== firstCycle.strategyName ||
+      durableExecution.strategyProtocolHash !== firstCycle.strategyProtocolHash ||
+      durableExecution.strategyBehaviorHash !== strategy.strategyBehaviorHash ||
+      durableExecution.strategyParameterHash !== strategy.strategyParameterHash ||
+      durableExecution.strategyParameterSchemaVersion !== strategy.strategyParameterSchemaVersion ||
+      durableExecution.executionPolicyHash !== firstCycle.executionPolicyHash ||
+      durableExecution.sourceRevision !== strategy.sourceRevision ||
+      durableExecution.imageRepository !== strategy.imageRepository ||
+      durableExecution.imageDigest !== strategy.imageDigest)
+  ) {
+    reasons.add('CYCLE_IDENTITY_DRIFT')
+  }
+  if (strategy === undefined || firstCycle === undefined) reasons.add('IDENTITY_GAP')
+  if (firstCycle !== undefined) {
+    if (
+      firstCycle.accountId !== input.account.accountId ||
+      cycles.some((cycle) => !sameCycleIdentity(firstCycle, cycle))
+    ) {
+      reasons.add('CYCLE_IDENTITY_DRIFT')
+    }
+    if (
+      strategy !== undefined &&
+      (strategy.qualificationRunId !== firstCycle.qualificationRunId ||
+        strategy.strategyName !== firstCycle.strategyName ||
+        strategy.strategyProtocolHash !== firstCycle.strategyProtocolHash)
+    ) {
+      reasons.add('CYCLE_IDENTITY_DRIFT')
+    }
+  }
+  if (reconciliation === undefined || reconciliation.status !== 'EXACT') reasons.add('NON_EXACT_RECONCILIATION')
+  if (lastCycle !== undefined && reconciliation !== undefined && reconciliation.reconciledAt < lastCycle.terminalAt) {
+    reasons.add('UNCLOSED_WINDOW')
+  }
+  if (input.unclosedCycleCount > 0) reasons.add('UNCLOSED_WINDOW')
+  if (input.unresolvedMutationCount > 0) reasons.add('UNRESOLVED_MUTATION')
+  if (input.openPositionCount > 0) reasons.add('OPEN_POSITION')
+  if (!input.accountingReceiptsExact) reasons.add('ACCOUNTING_RECEIPT_MISMATCH')
+  if (!input.ledgerExact) reasons.add('LEDGER_MISMATCH')
+  if (input.missingLedgerAccountCount > 0) reasons.add('MISSING_LEDGER_ACCOUNT')
+  if (input.transactions.length === 0) reasons.add('ZERO_COMPLETED_EXECUTIONS')
+
+  const cycleIds = new Set(cycles.map((cycle) => cycle.cycleId))
+  if (input.transactions.some((transaction) => !cycleIds.has(transaction.cycleId))) reasons.add('CYCLE_IDENTITY_DRIFT')
+
+  const totals = parseTotals(input, reasons)
+  if (totals !== undefined) transactionTotalsMatch(input, totals, reasons)
+
+  const realizedCloseCount = input.transactions.filter((transaction) => transaction.side === 'SELL').length
+  const reasonCodes = [...reasons].sort()
+  const sufficient = reasonCodes.length === 0
+  const strategyBinding =
+    strategy === undefined || firstCycle === undefined
+      ? null
+      : {
+          qualificationRunId: strategy.qualificationRunId,
+          strategyName: strategy.strategyName,
+          strategyProtocolHash: strategy.strategyProtocolHash,
+          strategyBehaviorHash: strategy.strategyBehaviorHash,
+          strategyParameterHash: strategy.strategyParameterHash,
+          strategyParameterSchemaVersion: strategy.strategyParameterSchemaVersion,
+          executionPolicyHash: firstCycle.executionPolicyHash,
+          strategyExecutionModelHash: firstCycle.strategyExecutionModelHash,
+        }
+
+  return {
+    schemaVersion: FORWARD_PERFORMANCE_SCHEMA_VERSION,
+    bindings: {
+      runtime: input.runtime,
+      source:
+        strategy === undefined
+          ? null
+          : {
+              sourceRevision: strategy.sourceRevision,
+              imageRepository: strategy.imageRepository,
+              imageDigest: strategy.imageDigest,
+            },
+      strategy: strategyBinding,
+      account: {
+        accountReferenceHash: durableExecution?.accountReferenceHash ?? input.account.accountReferenceHash,
+        provider: durableExecution?.provider ?? input.account.provider,
+        environment: durableExecution?.environment ?? input.account.environment,
+      },
+    },
+    window: {
+      firstCycleId: firstCycle?.cycleId ?? null,
+      lastCycleId: lastCycle?.cycleId ?? null,
+      openedAt: firstCycle?.submissionOpenAt ?? null,
+      closedAt: reconciliation?.reconciledAt ?? null,
+      reconciliationId: reconciliation?.reconciliationId ?? null,
+      reconciliationContentHash: reconciliation?.contentHash ?? null,
+    },
+    totals: {
+      startingCapitalMicros: totals?.startingCapital.toString() ?? null,
+      realizedGainsMicros: totals?.realizedGains.toString() ?? null,
+      realizedLossesMicros: totals?.realizedLosses.toString() ?? null,
+      brokerExecutionFeesMicros: totals?.brokerExecutionFees.toString() ?? null,
+      otherChargedCostsMicros: totals?.otherChargedCosts.toString() ?? null,
+      cashYieldMicros: totals?.cashYield.toString() ?? null,
+      grossRealizedPnlMicros: totals?.grossRealizedPnl.toString() ?? null,
+      netRealizedPnlAfterCostsMicros: totals?.netRealizedPnlAfterCosts.toString() ?? null,
+      netRealizedReturn:
+        totals === undefined
+          ? null
+          : {
+              numeratorMicros: totals.netRealizedPnlAfterCosts.toString(),
+              denominatorMicros: totals.startingCapital.toString(),
+              decimal: formatReturn(totals.netRealizedPnlAfterCosts, totals.startingCapital),
+            },
+    },
+    counts: {
+      cycleCount: cycles.length,
+      completedExecutionCount: input.transactions.length,
+      realizedCloseCount,
+    },
+    evidence: {
+      status: sufficient ? 'SUFFICIENT' : 'INSUFFICIENT_EVIDENCE',
+      reasonCodes,
+    },
+    profitability:
+      !sufficient || totals === undefined
+        ? 'UNDETERMINED'
+        : totals.netRealizedPnlAfterCosts > 0n
+          ? 'PROFITABLE'
+          : 'NOT_PROFITABLE',
+  }
+}
+
+export const makeForwardPerformanceReceipt = (
+  input: ForwardPerformanceEvidenceInput,
+): Result.Result<ForwardPerformanceReceipt, ForwardPerformanceDomainFailure> => {
+  const material = makeMaterial(input)
+  return Result.mapError(
+    Result.map(canonicalHashV1Result(material), (receiptHash) => ({ ...material, receiptHash })),
+    (cause): ForwardPerformanceDomainFailure => ({
+      _tag: 'ForwardPerformanceDomainFailure',
+      operation: 'hash-receipt',
+      cause,
+    }),
+  )
+}

--- a/services/bayn/src/forward-performance/index.ts
+++ b/services/bayn/src/forward-performance/index.ts
@@ -1,0 +1,17 @@
+export { makeForwardPerformanceReceipt, type ForwardPerformanceDomainFailure } from './domain'
+export {
+  FORWARD_PERFORMANCE_SCHEMA_VERSION,
+  type ForwardPerformanceEvidenceInput,
+  type ForwardPerformanceEvidenceStatus,
+  type ForwardPerformanceProfitability,
+  type ForwardPerformanceReasonCode,
+  type ForwardPerformanceReceipt,
+  type ForwardPerformanceReceiptMaterial,
+} from './model'
+export {
+  ForwardPerformanceProgramError,
+  liveForwardPerformanceReaders,
+  runForwardPerformance,
+  type ForwardPerformanceProgramCause,
+  type ForwardPerformanceReaders,
+} from './program'

--- a/services/bayn/src/forward-performance/model.ts
+++ b/services/bayn/src/forward-performance/model.ts
@@ -1,0 +1,174 @@
+export const FORWARD_PERFORMANCE_SCHEMA_VERSION = 'bayn.forward-performance-receipt.v1' as const
+
+export type ForwardPerformanceEvidenceStatus = 'SUFFICIENT' | 'INSUFFICIENT_EVIDENCE'
+export type ForwardPerformanceProfitability = 'PROFITABLE' | 'NOT_PROFITABLE' | 'UNDETERMINED'
+
+export type ForwardPerformanceReasonCode =
+  | 'ACCOUNT_IDENTITY_GAP'
+  | 'ACCOUNTING_RECEIPT_MISMATCH'
+  | 'CYCLE_IDENTITY_DRIFT'
+  | 'IDENTITY_GAP'
+  | 'INVALID_MICROS'
+  | 'LEDGER_MISMATCH'
+  | 'MISSING_LEDGER_ACCOUNT'
+  | 'NON_EXACT_RECONCILIATION'
+  | 'OPEN_POSITION'
+  | 'STARTING_CAPITAL_GAP'
+  | 'UNCLOSED_WINDOW'
+  | 'UNRESOLVED_MUTATION'
+  | 'ZERO_COMPLETED_EXECUTIONS'
+
+export interface ForwardPerformanceBuildBinding {
+  readonly sourceRevision: string
+  readonly imageRepository: string
+  readonly imageDigest: string
+}
+
+export interface ForwardPerformanceStrategyBinding {
+  readonly qualificationRunId: string
+  readonly strategyName: string
+  readonly strategyProtocolHash: string
+  readonly strategyBehaviorHash: string
+  readonly strategyParameterHash: string
+  readonly strategyParameterSchemaVersion: string
+  readonly executionPolicyHash: string
+  readonly strategyExecutionModelHash: string
+}
+
+export interface ForwardPerformanceAccountBinding {
+  readonly accountReferenceHash: string
+  readonly provider: string
+  readonly environment: string
+}
+
+export interface ForwardPerformanceCycleEvidence {
+  readonly cycleId: string
+  readonly qualificationRunId: string
+  readonly strategyName: string
+  readonly strategyProtocolHash: string
+  readonly accountId: string
+  readonly executionPolicyHash: string
+  readonly strategyExecutionModelHash: string
+  readonly state: 'COMPLETED' | 'NO_TRADE'
+  readonly submissionOpenAt: string
+  readonly terminalAt: string
+}
+
+export interface ForwardPerformanceStrategyEvidence {
+  readonly qualificationRunId: string
+  readonly strategyName: string
+  readonly strategyProtocolHash: string
+  readonly strategyBehaviorHash: string
+  readonly strategyParameterHash: string
+  readonly strategyParameterSchemaVersion: string
+  readonly sourceRevision: string
+  readonly imageRepository: string
+  readonly imageDigest: string
+}
+
+export interface ForwardPerformanceTransactionEvidence {
+  readonly transactionId: string
+  readonly cycleId: string
+  readonly side: 'BUY' | 'SELL'
+  readonly feeMicros: string
+  readonly realizedPnlMicros: string
+  readonly occurredAt: string
+}
+
+export interface ForwardPerformanceLedgerTotals {
+  readonly realizedGainMicros: string
+  readonly realizedLossMicros: string
+  readonly brokerExecutionFeesMicros: string
+  readonly otherChargedCostsMicros: string
+  readonly cashYieldMicros: string
+}
+
+export interface ForwardPerformanceEvidenceInput {
+  readonly runtime: ForwardPerformanceBuildBinding
+  readonly account: {
+    readonly accountId: string
+    readonly accountReferenceHash: string
+    readonly provider: string
+    readonly environment: string
+  }
+  readonly durableExecutionBindings: readonly {
+    readonly accountId: string
+    readonly accountReferenceHash: string
+    readonly provider: string
+    readonly environment: string
+    readonly qualificationRunId: string
+    readonly strategyName: string
+    readonly strategyProtocolHash: string
+    readonly strategyBehaviorHash: string
+    readonly strategyParameterHash: string
+    readonly strategyParameterSchemaVersion: string
+    readonly executionPolicyHash: string
+    readonly sourceRevision: string
+    readonly imageRepository: string
+    readonly imageDigest: string
+  }[]
+  readonly cycles: readonly ForwardPerformanceCycleEvidence[]
+  readonly strategy?: ForwardPerformanceStrategyEvidence
+  readonly reconciliation?: {
+    readonly reconciliationId: string
+    readonly contentHash: string
+    readonly status: 'EXACT' | 'DISCREPANCY'
+    readonly reconciledAt: string
+  }
+  readonly startingCapitalMicros?: string
+  readonly transactions: readonly ForwardPerformanceTransactionEvidence[]
+  readonly ledgerTotals?: ForwardPerformanceLedgerTotals
+  readonly accountingReceiptsExact: boolean
+  readonly ledgerExact: boolean
+  readonly missingLedgerAccountCount: number
+  readonly unresolvedMutationCount: number
+  readonly unclosedCycleCount: number
+  readonly openPositionCount: number
+}
+
+export interface ForwardPerformanceReceiptMaterial {
+  readonly schemaVersion: typeof FORWARD_PERFORMANCE_SCHEMA_VERSION
+  readonly bindings: {
+    readonly runtime: ForwardPerformanceBuildBinding
+    readonly source: ForwardPerformanceBuildBinding | null
+    readonly strategy: ForwardPerformanceStrategyBinding | null
+    readonly account: ForwardPerformanceAccountBinding
+  }
+  readonly window: {
+    readonly firstCycleId: string | null
+    readonly lastCycleId: string | null
+    readonly openedAt: string | null
+    readonly closedAt: string | null
+    readonly reconciliationId: string | null
+    readonly reconciliationContentHash: string | null
+  }
+  readonly totals: {
+    readonly startingCapitalMicros: string | null
+    readonly realizedGainsMicros: string | null
+    readonly realizedLossesMicros: string | null
+    readonly brokerExecutionFeesMicros: string | null
+    readonly otherChargedCostsMicros: string | null
+    readonly cashYieldMicros: string | null
+    readonly grossRealizedPnlMicros: string | null
+    readonly netRealizedPnlAfterCostsMicros: string | null
+    readonly netRealizedReturn: {
+      readonly numeratorMicros: string
+      readonly denominatorMicros: string
+      readonly decimal: string
+    } | null
+  }
+  readonly counts: {
+    readonly cycleCount: number
+    readonly completedExecutionCount: number
+    readonly realizedCloseCount: number
+  }
+  readonly evidence: {
+    readonly status: ForwardPerformanceEvidenceStatus
+    readonly reasonCodes: readonly ForwardPerformanceReasonCode[]
+  }
+  readonly profitability: ForwardPerformanceProfitability
+}
+
+export interface ForwardPerformanceReceipt extends ForwardPerformanceReceiptMaterial {
+  readonly receiptHash: string
+}

--- a/services/bayn/src/forward-performance/postgres.ts
+++ b/services/bayn/src/forward-performance/postgres.ts
@@ -1,0 +1,554 @@
+import { PgClient } from '@effect/sql-pg'
+import { Data, Effect, Schema } from 'effect'
+
+import type { AccountingTransaction } from '../accounting/schema'
+import { decodeAccountingReceipt, type AccountingReceipt } from '../execution/contracts'
+import {
+  AccountingReceiptRowSchema,
+  AccountingTransactionRowSchema,
+  accountingReceiptFromRow,
+  accountingTransactionFromRow,
+} from '../db/accounting-rows'
+import {
+  ImageDigestSchema,
+  Sha256Schema as Sha256,
+  StrictNonEmptyStringSchema as NonEmptyString,
+  strictParseOptions,
+} from '../schemas'
+import type {
+  ForwardPerformanceCycleEvidence,
+  ForwardPerformanceStrategyEvidence,
+  ForwardPerformanceTransactionEvidence,
+} from './model'
+
+const TerminalCycleRow = Schema.Struct({
+  cycle_id: Sha256,
+  qualification_run_id: Sha256,
+  strategy_name: NonEmptyString,
+  strategy_protocol_hash: Sha256,
+  account_id: NonEmptyString,
+  execution_policy_hash: Sha256,
+  strategy_execution_model_hash: Sha256,
+  state: Schema.Literals(['COMPLETED', 'NO_TRADE']),
+  submission_open_at: Schema.Date,
+  terminal_at: Schema.Date,
+})
+
+const StrategyRow = Schema.Struct({
+  qualification_run_id: Sha256,
+  strategy_name: NonEmptyString,
+  strategy_protocol_hash: Sha256,
+  strategy_behavior_hash: Sha256,
+  strategy_parameter_hash: Sha256,
+  strategy_parameter_schema_version: NonEmptyString,
+  source_revision: Schema.String,
+  image_repository: NonEmptyString,
+  image_digest: ImageDigestSchema,
+})
+
+const ReconciliationRow = Schema.Struct({
+  reconciliation_id: Sha256,
+  content_hash: Sha256,
+  status: Schema.Literals(['EXACT', 'DISCREPANCY']),
+  reconciled_at: Schema.Date,
+})
+
+const StartingCapitalRow = Schema.Struct({ starting_capital_micros: Schema.String })
+const CountRow = Schema.Struct({ count: Schema.Int })
+const DurableExecutionRow = Schema.Struct({
+  account_id: Schema.NullOr(NonEmptyString),
+  broker_identity_hash: Schema.NullOr(Sha256),
+  broker_provider: Schema.NullOr(NonEmptyString),
+  broker_environment: Schema.NullOr(NonEmptyString),
+  qualification_run_id: Schema.NullOr(Sha256),
+  strategy_name: Schema.NullOr(NonEmptyString),
+  protocol_hash: Schema.NullOr(Sha256),
+  strategy_behavior_hash: Schema.NullOr(Sha256),
+  strategy_parameter_hash: Schema.NullOr(Sha256),
+  strategy_parameter_schema_version: Schema.NullOr(NonEmptyString),
+  qualification_execution_policy_hash: Schema.NullOr(Sha256),
+  qualification_source_revision: Schema.NullOr(Schema.String),
+  qualification_image_repository: Schema.NullOr(NonEmptyString),
+  qualification_image_digest: Schema.NullOr(ImageDigestSchema),
+})
+const TransactionRow = Schema.Struct({
+  ...AccountingTransactionRowSchema.fields,
+  cycle_id: Schema.NullOr(Sha256),
+})
+
+const decodeCycles = Schema.decodeUnknownEffect(Schema.Array(TerminalCycleRow), strictParseOptions)
+const decodeStrategy = Schema.decodeUnknownEffect(
+  Schema.Array(StrategyRow).check(Schema.isMaxLength(1)),
+  strictParseOptions,
+)
+const decodeReconciliation = Schema.decodeUnknownEffect(
+  Schema.Array(ReconciliationRow).check(Schema.isMaxLength(1)),
+  strictParseOptions,
+)
+const decodeStartingCapital = Schema.decodeUnknownEffect(
+  Schema.Array(StartingCapitalRow).check(Schema.isMaxLength(1)),
+  strictParseOptions,
+)
+const decodeTransactions = Schema.decodeUnknownEffect(Schema.Array(TransactionRow), strictParseOptions)
+const decodeReceipts = Schema.decodeUnknownEffect(Schema.Array(AccountingReceiptRowSchema), strictParseOptions)
+const decodeCount = Schema.decodeUnknownEffect(Schema.Tuple([CountRow]), strictParseOptions)
+const decodeDurableExecutions = Schema.decodeUnknownEffect(Schema.Array(DurableExecutionRow), strictParseOptions)
+
+export class ForwardPerformancePostgresError extends Data.TaggedError('ForwardPerformancePostgresError')<{
+  readonly operation: 'read'
+  readonly failure: 'decode' | 'query'
+  readonly message: string
+  readonly cause: unknown
+}> {}
+
+export interface ForwardPerformancePostgresEvidence {
+  readonly cycles: readonly ForwardPerformanceCycleEvidence[]
+  readonly strategy?: ForwardPerformanceStrategyEvidence
+  readonly reconciliation?: {
+    readonly reconciliationId: string
+    readonly contentHash: string
+    readonly status: 'EXACT' | 'DISCREPANCY'
+    readonly reconciledAt: string
+  }
+  readonly startingCapitalMicros?: string
+  readonly transactions: readonly AccountingTransaction[]
+  readonly transactionEvidence: readonly ForwardPerformanceTransactionEvidence[]
+  readonly receipts: readonly AccountingReceipt[]
+  readonly durableExecutionBindings: readonly {
+    readonly accountId: string
+    readonly accountReferenceHash: string
+    readonly provider: string
+    readonly environment: string
+    readonly qualificationRunId: string
+    readonly strategyName: string
+    readonly strategyProtocolHash: string
+    readonly strategyBehaviorHash: string
+    readonly strategyParameterHash: string
+    readonly strategyParameterSchemaVersion: string
+    readonly executionPolicyHash: string
+    readonly sourceRevision: string
+    readonly imageRepository: string
+    readonly imageDigest: string
+  }[]
+  readonly unclosedCycleCount: number
+  readonly unresolvedMutationCount: number
+  readonly openPositionCount: number
+  readonly unaccountedFillCount: number
+  readonly postReconciliationActivityCount: number
+}
+
+const postgresError = (cause: unknown): ForwardPerformancePostgresError =>
+  new ForwardPerformancePostgresError({
+    operation: 'read',
+    failure: Schema.isSchemaError(cause) ? 'decode' : 'query',
+    message: 'forward-performance PostgreSQL read failed',
+    cause,
+  })
+
+const transactionQuery = (sql: PgClient.PgClient, accountId: string) => sql<Record<string, unknown>>`
+  WITH latest_reconciliation AS (
+    SELECT reconciled_at
+    FROM reconciliations
+    WHERE account_id = ${accountId}
+    ORDER BY reconciled_at DESC, reconciliation_id COLLATE "C" DESC
+    LIMIT 1
+  )
+  SELECT
+    transaction.schema_version,
+    transaction.transaction_id,
+    transaction.broker_event_id,
+    transaction.intent_id,
+    transaction.account_id,
+    transaction.symbol,
+    transaction.side,
+    transaction.quantity_micros::text AS quantity_micros,
+    transaction.price_micros::text AS price_micros,
+    transaction.notional_micros::text AS notional_micros,
+    transaction.fee_micros::text AS fee_micros,
+    transaction.cost_basis_micros::text AS cost_basis_micros,
+    transaction.realized_pnl_micros::text AS realized_pnl_micros,
+    transaction.quantity_delta_micros::text AS quantity_delta_micros,
+    transaction.cost_basis_delta_micros::text AS cost_basis_delta_micros,
+    transaction.cash_delta_micros::text AS cash_delta_micros,
+    transaction.ledger_plan_hash,
+    transaction.content_hash,
+    transaction.occurred_at,
+    intent.cycle_id
+  FROM accounting_transactions AS transaction
+  CROSS JOIN latest_reconciliation
+  LEFT JOIN intents AS intent ON intent.intent_id = transaction.intent_id
+  WHERE transaction.account_id = ${accountId}
+    AND transaction.occurred_at <= latest_reconciliation.reconciled_at
+  ORDER BY transaction.occurred_at, transaction.transaction_id COLLATE "C"
+`
+
+const receiptQuery = (sql: PgClient.PgClient, accountId: string) => sql<Record<string, unknown>>`
+  WITH latest_reconciliation AS (
+    SELECT reconciled_at
+    FROM reconciliations
+    WHERE account_id = ${accountId}
+    ORDER BY reconciled_at DESC, reconciliation_id COLLATE "C" DESC
+    LIMIT 1
+  ), selected_transactions AS (
+    SELECT broker_event_id
+    FROM accounting_transactions
+    CROSS JOIN latest_reconciliation
+    WHERE account_id = ${accountId}
+      AND occurred_at <= latest_reconciliation.reconciled_at
+  )
+  SELECT
+    receipt.schema_version,
+    receipt.receipt_id,
+    receipt.intent_id,
+    receipt.broker_event_id,
+    receipt.tigerbeetle_cluster_id::text AS tigerbeetle_cluster_id,
+    receipt.tigerbeetle_ledger::integer AS tigerbeetle_ledger,
+    ARRAY(
+      SELECT item.value::text FROM unnest(receipt.account_ids) AS item(value) ORDER BY item.value
+    ) AS account_ids,
+    ARRAY(
+      SELECT item.value::text FROM unnest(receipt.transfer_ids) AS item(value) ORDER BY item.value
+    ) AS transfer_ids,
+    receipt.debit_micros::text AS debit_micros,
+    receipt.credit_micros::text AS credit_micros,
+    receipt.content_hash,
+    receipt.recorded_at
+  FROM accounting_receipts AS receipt
+  JOIN selected_transactions USING (broker_event_id)
+  ORDER BY receipt.broker_event_id COLLATE "C"
+`
+
+export const readForwardPerformancePostgres = (
+  sql: PgClient.PgClient,
+  accountId: string,
+): Effect.Effect<ForwardPerformancePostgresEvidence, ForwardPerformancePostgresError> =>
+  sql
+    .withTransaction(
+      Effect.gen(function* () {
+        yield* sql`SET TRANSACTION ISOLATION LEVEL REPEATABLE READ, READ ONLY`
+
+        const cycleRows = yield* sql<Record<string, unknown>>`
+          SELECT
+            cycle_id,
+            qualification_run_id,
+            strategy_name,
+            strategy_protocol_hash,
+            account_id,
+            execution_policy_hash,
+            strategy_execution_model_hash,
+            state,
+            submission_open_at,
+            terminal_at
+          FROM autonomous_cycles
+          WHERE account_id = ${accountId}
+            AND state IN ('COMPLETED', 'NO_TRADE')
+          ORDER BY submission_open_at, cycle_id COLLATE "C"
+        `.pipe(Effect.flatMap(decodeCycles))
+
+        const strategyRows = yield* sql<Record<string, unknown>>`
+          WITH first_cycle AS (
+            SELECT qualification_run_id, strategy_protocol_hash
+            FROM autonomous_cycles
+            WHERE account_id = ${accountId}
+              AND state IN ('COMPLETED', 'NO_TRADE')
+            ORDER BY submission_open_at, cycle_id COLLATE "C"
+            LIMIT 1
+          )
+          SELECT
+            evaluation.run_id AS qualification_run_id,
+            evaluation.strategy_name,
+            protocol.protocol_hash AS strategy_protocol_hash,
+            protocol.behavior_hash AS strategy_behavior_hash,
+            protocol.parameter_hash AS strategy_parameter_hash,
+            protocol.schema_version AS strategy_parameter_schema_version,
+            evaluation.source_revision,
+            evaluation.image_repository,
+            evaluation.image_digest
+          FROM first_cycle
+          JOIN qualification_results AS result
+            ON result.run_id = first_cycle.qualification_run_id
+            AND result.verdict = 'QUALIFIED'
+          JOIN qualification_locks AS qualification_lock ON qualification_lock.lock_id = result.lock_id
+          JOIN evaluation_runs AS evaluation ON evaluation.run_id = result.run_id
+          JOIN protocol_locks AS protocol
+            ON protocol.protocol_hash = first_cycle.strategy_protocol_hash
+            AND protocol.protocol_hash = qualification_lock.protocol_hash
+            AND protocol.protocol_hash = evaluation.protocol_hash
+          WHERE evaluation.status = 'COMPLETE'
+            AND qualification_lock.source_revision = evaluation.source_revision
+            AND qualification_lock.image_repository = evaluation.image_repository
+            AND qualification_lock.image_digest = evaluation.image_digest
+        `.pipe(Effect.flatMap(decodeStrategy))
+
+        const reconciliationRows = yield* sql<Record<string, unknown>>`
+          SELECT reconciliation_id, content_hash, status, reconciled_at
+          FROM reconciliations
+          WHERE account_id = ${accountId}
+          ORDER BY reconciled_at DESC, reconciliation_id COLLATE "C" DESC
+          LIMIT 1
+        `.pipe(Effect.flatMap(decodeReconciliation))
+
+        const startingCapitalRows = yield* sql<Record<string, unknown>>`
+          WITH latest_reconciliation AS (
+            SELECT reconciled_at
+            FROM reconciliations
+            WHERE account_id = ${accountId}
+            ORDER BY reconciled_at DESC, reconciliation_id COLLATE "C" DESC
+            LIMIT 1
+          ), first_cycle AS (
+            SELECT submission_open_at
+            FROM autonomous_cycles
+            WHERE account_id = ${accountId}
+              AND state IN ('COMPLETED', 'NO_TRADE')
+            ORDER BY submission_open_at, cycle_id COLLATE "C"
+            LIMIT 1
+          )
+          SELECT snapshot.equity_micros::text AS starting_capital_micros
+          FROM account_snapshots AS snapshot
+          JOIN broker_events AS event ON event.event_id = snapshot.event_id
+          CROSS JOIN latest_reconciliation
+          CROSS JOIN first_cycle
+          WHERE snapshot.account_id = ${accountId}
+            AND event.observed_at <= first_cycle.submission_open_at
+            AND event.observed_at <= latest_reconciliation.reconciled_at
+          ORDER BY event.observed_at DESC, event.source_sequence DESC, event.event_id COLLATE "C" DESC
+          LIMIT 1
+        `.pipe(Effect.flatMap(decodeStartingCapital))
+
+        const transactionRows = yield* transactionQuery(sql, accountId).pipe(Effect.flatMap(decodeTransactions))
+        const receiptRows = yield* receiptQuery(sql, accountId).pipe(Effect.flatMap(decodeReceipts))
+        const receipts = yield* Effect.forEach(receiptRows, (row) =>
+          decodeAccountingReceipt(accountingReceiptFromRow(row)),
+        )
+        const durableExecutionRows = yield* sql<Record<string, unknown>>`
+          WITH latest_reconciliation AS (
+            SELECT reconciled_at
+            FROM reconciliations
+            WHERE account_id = ${accountId}
+            ORDER BY reconciled_at DESC, reconciliation_id COLLATE "C" DESC
+            LIMIT 1
+          )
+          SELECT DISTINCT
+            generation.account_id,
+            generation.broker_identity_hash,
+            generation.broker_provider,
+            generation.broker_environment,
+            generation.qualification_run_id,
+            generation.strategy_name,
+            generation.protocol_hash,
+            generation.strategy_behavior_hash,
+            generation.strategy_parameter_hash,
+            generation.strategy_parameter_schema_version,
+            generation.qualification_execution_policy_hash,
+            generation.qualification_source_revision,
+            generation.qualification_image_repository,
+            generation.qualification_image_digest
+          FROM accounting_transactions AS transaction
+          CROSS JOIN latest_reconciliation
+          JOIN intents AS intent ON intent.intent_id = transaction.intent_id
+          JOIN authority_generations AS generation
+            ON generation.generation_hash = intent.authority_generation_hash
+          WHERE transaction.account_id = ${accountId}
+            AND transaction.occurred_at <= latest_reconciliation.reconciled_at
+          ORDER BY
+            generation.account_id,
+            generation.broker_identity_hash,
+            generation.broker_provider,
+            generation.broker_environment,
+            generation.qualification_run_id,
+            generation.strategy_name,
+            generation.protocol_hash,
+            generation.strategy_behavior_hash,
+            generation.strategy_parameter_hash,
+            generation.strategy_parameter_schema_version,
+            generation.qualification_execution_policy_hash,
+            generation.qualification_source_revision,
+            generation.qualification_image_repository,
+            generation.qualification_image_digest
+        `.pipe(Effect.flatMap(decodeDurableExecutions))
+
+        const [unclosedCycles] = yield* sql<Record<string, unknown>>`
+          SELECT count(*)::integer AS count
+          FROM autonomous_cycles AS cycle
+          WHERE cycle.account_id = ${accountId}
+            AND cycle.state IN ('PENDING', 'ACTIVE')
+        `.pipe(Effect.flatMap(decodeCount))
+
+        const [unresolvedMutations] = yield* sql<Record<string, unknown>>`
+          SELECT count(*)::integer AS count
+          FROM intents AS intent
+          LEFT JOIN LATERAL (
+            SELECT event_type
+            FROM mutation_events
+            WHERE intent_id = intent.intent_id
+            ORDER BY
+              CASE operation WHEN 'CANCEL' THEN 1 ELSE 0 END DESC,
+              sequence DESC
+            LIMIT 1
+          ) AS latest_mutation ON true
+          WHERE intent.account_id = ${accountId}
+            AND (
+              intent.state <> 'TERMINAL'
+              OR latest_mutation.event_type IN (
+                'SUBMIT_STARTED', 'SUBMIT_UNKNOWN', 'RECOVERY_UNKNOWN',
+                'CANCEL_STARTED', 'CANCEL_UNKNOWN'
+              )
+            )
+        `.pipe(Effect.flatMap(decodeCount))
+
+        const [postReconciliationActivity] = yield* sql<Record<string, unknown>>`
+          WITH latest_reconciliation AS (
+            SELECT reconciled_at
+            FROM reconciliations
+            WHERE account_id = ${accountId}
+            ORDER BY reconciled_at DESC, reconciliation_id COLLATE "C" DESC
+            LIMIT 1
+          )
+          SELECT count(*)::integer AS count
+          FROM (
+            SELECT transaction.transaction_id AS activity_id
+            FROM accounting_transactions AS transaction
+            CROSS JOIN latest_reconciliation
+            WHERE transaction.account_id = ${accountId}
+              AND transaction.occurred_at > latest_reconciliation.reconciled_at
+            UNION ALL
+            SELECT fill.event_id AS activity_id
+            FROM fills AS fill
+            JOIN broker_events AS event ON event.event_id = fill.event_id
+            CROSS JOIN latest_reconciliation
+            WHERE fill.account_id = ${accountId}
+              AND event.occurred_at > latest_reconciliation.reconciled_at
+              AND NOT EXISTS (
+                SELECT 1
+                FROM accounting_transactions AS transaction
+                WHERE transaction.broker_event_id = fill.event_id
+              )
+          ) AS activity
+        `.pipe(Effect.flatMap(decodeCount))
+
+        const [openPositions] = yield* sql<Record<string, unknown>>`
+          WITH latest_reconciliation AS (
+            SELECT reconciled_at
+            FROM reconciliations
+            WHERE account_id = ${accountId}
+            ORDER BY reconciled_at DESC, reconciliation_id COLLATE "C" DESC
+            LIMIT 1
+          )
+          SELECT count(*)::integer AS count
+          FROM (
+            SELECT transaction.symbol
+            FROM accounting_transactions AS transaction
+            CROSS JOIN latest_reconciliation
+            WHERE transaction.account_id = ${accountId}
+              AND transaction.occurred_at <= latest_reconciliation.reconciled_at
+            GROUP BY transaction.symbol
+            HAVING sum(transaction.quantity_delta_micros) <> 0
+              OR sum(transaction.cost_basis_delta_micros) <> 0
+          ) AS open_position
+        `.pipe(Effect.flatMap(decodeCount))
+
+        const [unaccountedFills] = yield* sql<Record<string, unknown>>`
+          WITH latest_reconciliation AS (
+            SELECT reconciled_at
+            FROM reconciliations
+            WHERE account_id = ${accountId}
+            ORDER BY reconciled_at DESC, reconciliation_id COLLATE "C" DESC
+            LIMIT 1
+          )
+          SELECT count(*)::integer AS count
+          FROM fills AS fill
+          JOIN broker_events AS event ON event.event_id = fill.event_id
+          CROSS JOIN latest_reconciliation
+          LEFT JOIN accounting_transactions AS transaction ON transaction.broker_event_id = fill.event_id
+          LEFT JOIN accounting_receipts AS receipt ON receipt.broker_event_id = fill.event_id
+          WHERE fill.account_id = ${accountId}
+            AND event.occurred_at <= latest_reconciliation.reconciled_at
+            AND (transaction.transaction_id IS NULL OR receipt.receipt_id IS NULL)
+        `.pipe(Effect.flatMap(decodeCount))
+
+        const cycles = cycleRows.map(
+          (row): ForwardPerformanceCycleEvidence => ({
+            cycleId: row.cycle_id,
+            qualificationRunId: row.qualification_run_id,
+            strategyName: row.strategy_name,
+            strategyProtocolHash: row.strategy_protocol_hash,
+            accountId: row.account_id,
+            executionPolicyHash: row.execution_policy_hash,
+            strategyExecutionModelHash: row.strategy_execution_model_hash,
+            state: row.state,
+            submissionOpenAt: row.submission_open_at.toISOString(),
+            terminalAt: row.terminal_at.toISOString(),
+          }),
+        )
+        const strategyRow = strategyRows[0]
+        const strategy: ForwardPerformanceStrategyEvidence | undefined =
+          strategyRow === undefined
+            ? undefined
+            : {
+                qualificationRunId: strategyRow.qualification_run_id,
+                strategyName: strategyRow.strategy_name,
+                strategyProtocolHash: strategyRow.strategy_protocol_hash,
+                strategyBehaviorHash: strategyRow.strategy_behavior_hash,
+                strategyParameterHash: strategyRow.strategy_parameter_hash,
+                strategyParameterSchemaVersion: strategyRow.strategy_parameter_schema_version,
+                sourceRevision: strategyRow.source_revision,
+                imageRepository: strategyRow.image_repository,
+                imageDigest: strategyRow.image_digest,
+              }
+        const reconciliationRow = reconciliationRows[0]
+        const reconciliation =
+          reconciliationRow === undefined
+            ? undefined
+            : {
+                reconciliationId: reconciliationRow.reconciliation_id,
+                contentHash: reconciliationRow.content_hash,
+                status: reconciliationRow.status,
+                reconciledAt: reconciliationRow.reconciled_at.toISOString(),
+              }
+        const transactions = transactionRows.map(accountingTransactionFromRow)
+        const transactionEvidence = transactionRows.map(
+          (row): ForwardPerformanceTransactionEvidence => ({
+            transactionId: row.transaction_id,
+            cycleId: row.cycle_id ?? '',
+            side: row.side,
+            feeMicros: row.fee_micros,
+            realizedPnlMicros: row.realized_pnl_micros,
+            occurredAt: row.occurred_at.toISOString(),
+          }),
+        )
+
+        return {
+          cycles,
+          ...(strategy === undefined ? {} : { strategy }),
+          ...(reconciliation === undefined ? {} : { reconciliation }),
+          ...(startingCapitalRows[0] === undefined
+            ? {}
+            : { startingCapitalMicros: startingCapitalRows[0].starting_capital_micros }),
+          transactions,
+          transactionEvidence,
+          receipts,
+          durableExecutionBindings: durableExecutionRows.map((row) => ({
+            accountId: row.account_id ?? '',
+            accountReferenceHash: row.broker_identity_hash ?? '',
+            provider: row.broker_provider ?? '',
+            environment: row.broker_environment ?? '',
+            qualificationRunId: row.qualification_run_id ?? '',
+            strategyName: row.strategy_name ?? '',
+            strategyProtocolHash: row.protocol_hash ?? '',
+            strategyBehaviorHash: row.strategy_behavior_hash ?? '',
+            strategyParameterHash: row.strategy_parameter_hash ?? '',
+            strategyParameterSchemaVersion: row.strategy_parameter_schema_version ?? '',
+            executionPolicyHash: row.qualification_execution_policy_hash ?? '',
+            sourceRevision: row.qualification_source_revision ?? '',
+            imageRepository: row.qualification_image_repository ?? '',
+            imageDigest: row.qualification_image_digest ?? '',
+          })),
+          unclosedCycleCount: unclosedCycles.count,
+          unresolvedMutationCount: unresolvedMutations.count,
+          openPositionCount: openPositions.count,
+          unaccountedFillCount: unaccountedFills.count,
+          postReconciliationActivityCount: postReconciliationActivity.count,
+        }
+      }),
+    )
+    .pipe(Effect.mapError(postgresError))

--- a/services/bayn/src/forward-performance/program.test.ts
+++ b/services/bayn/src/forward-performance/program.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, test } from 'bun:test'
+
+import { PgClient } from '@effect/sql-pg'
+import { Effect, Layer, Redacted, Result } from 'effect'
+
+import { makeBrokerIdentity, BrokerEnvironment, BrokerProvider } from '../broker/identity'
+import type { LoadedRuntimeConfig } from '../config'
+import { BrokerAccess, noCapitalAuthority } from '../execution/authority'
+import { readForwardPerformancePostgres } from './postgres'
+import { runForwardPerformance, type ForwardPerformanceReaders } from './program'
+
+const identityResult = makeBrokerIdentity({
+  schemaVersion: 'bayn.broker-identity.v2',
+  provider: BrokerProvider.Alpaca,
+  environment: BrokerEnvironment.Sandbox,
+  accountId: 'paper-account-forward-performance',
+})
+if (Result.isFailure(identityResult)) throw new Error('broker identity fixture failed')
+
+const config: LoadedRuntimeConfig = {
+  runtimeMode: 'AutonomousService',
+  host: '127.0.0.1',
+  port: 8080,
+  execution: {
+    brokerIdentity: identityResult.success,
+    brokerAccess: BrokerAccess.ReadOnly,
+    capitalAuthority: noCapitalAuthority,
+  },
+  alpaca: {
+    provider: BrokerProvider.Alpaca,
+    environment: BrokerEnvironment.Sandbox,
+    identity: identityResult.success,
+    baseUrl: 'https://paper-api.alpaca.markets',
+    expectedAccountId: identityResult.success.accountId,
+    key: Redacted.make('unused-key'),
+    secret: Redacted.make('unused-secret'),
+    proxyUrl: 'http://proxy.invalid:3128',
+    operationTimeoutMs: 5_000,
+    retryAttempts: 2,
+    authorityGenerationHash: 'e'.repeat(64),
+    reconciliationIntervalMs: 30_000,
+  },
+  build: {
+    sourceRevision: 'a'.repeat(40),
+    imageRepository: 'registry.example.test/lab/bayn',
+    imageDigest: `sha256:${'b'.repeat(64)}`,
+    strategyBehaviorHash: 'c'.repeat(64),
+    strategyParameterHash: 'd'.repeat(64),
+    verification: 'embedded',
+  },
+  healthIntervalMs: 30_000,
+  operationTimeoutMs: 5_000,
+  cycleStallThresholdMs: 300_000,
+  reconciliationStaleThresholdMs: 120_000,
+  unknownMutationThresholdMs: 300_000,
+  cyclePollIntervalMs: 30_000,
+  clickhouse: {
+    url: 'http://clickhouse.invalid',
+    username: 'bayn',
+    password: Redacted.make('unused'),
+    snapshotId: '1'.repeat(64),
+    publicationAsOf: '2026-07-20',
+    calendarVersion: 'fixture-calendar-v1',
+    bounds: {
+      schemaVersion: 'bayn.evaluation-bounds.v1',
+      dataStart: '2018-01-02',
+      dataEnd: '2026-07-20',
+      lookbackStart: '2018-01-02',
+      evaluationStart: '2019-01-02',
+      evaluationEnd: '2026-07-20',
+    },
+  },
+  postgres: { url: Redacted.make('postgresql://unused'), tls: false, caPath: '/unused' },
+  tigerBeetle: { clusterId: 2_001n, replicaAddresses: ['3000'], ledger: 7_001 },
+}
+
+interface SqlObservation {
+  readonly statements: string[]
+}
+
+const makeReadOnlySql = (observation: SqlObservation): PgClient.PgClient => {
+  const query = ((strings: TemplateStringsArray) => {
+    const statement = strings.join('?').replaceAll(/\s+/g, ' ').trim()
+    observation.statements.push(statement)
+    return Effect.succeed(statement.includes('count(*)::integer AS count') ? [{ count: 0 }] : [])
+  }) as unknown as PgClient.PgClient
+  Object.assign(query, {
+    withTransaction: <A, E, R>(effect: Effect.Effect<A, E, R>) => effect,
+  })
+  return query
+}
+
+describe('forward performance read program', () => {
+  test('executes only read-only PostgreSQL statements and never treats zero activity as profitable', async () => {
+    const observation: SqlObservation = { statements: [] }
+    const sql = makeReadOnlySql(observation)
+    const readers: ForwardPerformanceReaders = {
+      postgres: readForwardPerformancePostgres,
+      ledger: () =>
+        Effect.succeed({
+          totals: {
+            realizedGainMicros: '0',
+            realizedLossMicros: '0',
+            brokerExecutionFeesMicros: '0',
+            otherChargedCostsMicros: '0',
+            cashYieldMicros: '0',
+          },
+          ledgerExact: true,
+          missingLedgerAccountCount: 0,
+          openPositionCount: 0,
+        }),
+    }
+
+    const receipt = await Effect.runPromise(
+      Effect.scoped(runForwardPerformance(config, readers).pipe(Effect.provide(Layer.succeed(PgClient.PgClient, sql)))),
+    )
+
+    expect(observation.statements.length).toBeGreaterThan(8)
+    expect(observation.statements[0]).toBe('SET TRANSACTION ISOLATION LEVEL REPEATABLE READ, READ ONLY')
+    expect(
+      observation.statements.filter((statement) =>
+        /\b(?:INSERT|UPDATE|DELETE|TRUNCATE|ALTER|CREATE|DROP|LOCK)\b/i.test(statement),
+      ),
+    ).toEqual([])
+    expect(receipt.evidence.status).toBe('INSUFFICIENT_EVIDENCE')
+    expect(receipt.evidence.reasonCodes).toContain('ZERO_COMPLETED_EXECUTIONS')
+    expect(receipt.profitability).toBe('UNDETERMINED')
+  })
+})

--- a/services/bayn/src/forward-performance/program.ts
+++ b/services/bayn/src/forward-performance/program.ts
@@ -1,0 +1,132 @@
+import { PgClient } from '@effect/sql-pg'
+import { Data, Effect, Result, Scope } from 'effect'
+
+import type { LoadedRuntimeConfig } from '../config'
+import { verifyAccountingReceipts } from '../db/reconciliation-algebra'
+import { type ReconciliationAlgebraFailure } from '../db/reconciliation-algebra'
+import type { CanonicalJsonFailure } from '../hash'
+import type { BrokerIdentity } from '../broker/identity'
+import { makeForwardPerformanceReceipt, type ForwardPerformanceDomainFailure } from './domain'
+import {
+  readForwardPerformancePostgres,
+  type ForwardPerformancePostgresEvidence,
+  type ForwardPerformancePostgresError,
+} from './postgres'
+import {
+  readForwardPerformanceLedger,
+  type ForwardPerformanceLedgerEvidence,
+  type ForwardPerformanceLedgerError,
+} from './tigerbeetle'
+import type { LedgerPlan } from '../ledger-plan'
+import type { ForwardPerformanceReceipt } from './model'
+
+export type ForwardPerformanceProgramCause =
+  | CanonicalJsonFailure
+  | ForwardPerformanceDomainFailure
+  | ForwardPerformanceLedgerError
+  | ForwardPerformancePostgresError
+  | ReconciliationAlgebraFailure
+
+export class ForwardPerformanceProgramError extends Data.TaggedError('ForwardPerformanceProgramError')<{
+  readonly operation: 'account-binding' | 'construct-receipt' | 'ledger-read' | 'postgres-read'
+  readonly message: string
+  readonly cause?: ForwardPerformanceProgramCause
+}> {}
+
+type BoundForwardPerformanceConfig = LoadedRuntimeConfig & {
+  readonly execution: LoadedRuntimeConfig['execution'] & { readonly brokerIdentity: BrokerIdentity }
+}
+
+export interface ForwardPerformanceReaders {
+  readonly postgres: (
+    sql: PgClient.PgClient,
+    accountId: string,
+  ) => Effect.Effect<ForwardPerformancePostgresEvidence, ForwardPerformancePostgresError>
+  readonly ledger: (
+    config: Pick<LoadedRuntimeConfig, 'operationTimeoutMs' | 'tigerBeetle'>,
+    accountId: string,
+    plans: readonly LedgerPlan[],
+  ) => Effect.Effect<ForwardPerformanceLedgerEvidence, ForwardPerformanceLedgerError, Scope.Scope>
+}
+
+export const liveForwardPerformanceReaders: ForwardPerformanceReaders = {
+  postgres: readForwardPerformancePostgres,
+  ledger: readForwardPerformanceLedger,
+}
+
+const programError = (
+  operation: ForwardPerformanceProgramError['operation'],
+  message: string,
+  cause?: ForwardPerformanceProgramCause,
+): ForwardPerformanceProgramError => new ForwardPerformanceProgramError({ operation, message, cause })
+
+const requireBrokerIdentity = (
+  config: LoadedRuntimeConfig,
+): Effect.Effect<BoundForwardPerformanceConfig, ForwardPerformanceProgramError> => {
+  const brokerIdentity = config.execution.brokerIdentity
+  return brokerIdentity === undefined
+    ? Effect.fail(
+        programError('account-binding', 'forward performance requires one configured broker account identity'),
+      )
+    : Effect.succeed(config as BoundForwardPerformanceConfig)
+}
+
+export const runForwardPerformance = (
+  loadedConfig: LoadedRuntimeConfig,
+  readers: ForwardPerformanceReaders = liveForwardPerformanceReaders,
+): Effect.Effect<ForwardPerformanceReceipt, ForwardPerformanceProgramError, PgClient.PgClient | Scope.Scope> =>
+  Effect.gen(function* () {
+    const config = yield* requireBrokerIdentity(loadedConfig)
+    const identity = config.execution.brokerIdentity
+    const sql = yield* PgClient.PgClient
+    const postgres = yield* readers
+      .postgres(sql, identity.accountId)
+      .pipe(Effect.mapError((cause) => programError('postgres-read', cause.message, cause)))
+
+    const accountingVerification = verifyAccountingReceipts(postgres.transactions, postgres.receipts, config)
+    const plans = Result.isSuccess(accountingVerification) ? accountingVerification.success.plans : []
+    const accountingReceiptsExact =
+      Result.isSuccess(accountingVerification) &&
+      postgres.unaccountedFillCount === 0 &&
+      accountingVerification.success.exactReceipts.size === postgres.transactions.length &&
+      [...accountingVerification.success.exactReceipts.values()].every(Boolean)
+
+    const ledger = yield* readers
+      .ledger(config, identity.accountId, plans)
+      .pipe(Effect.mapError((cause) => programError('ledger-read', cause.message, cause)))
+    const receipt = yield* Effect.fromResult(
+      makeForwardPerformanceReceipt({
+        runtime: {
+          sourceRevision: config.build.sourceRevision,
+          imageRepository: config.build.imageRepository,
+          imageDigest: config.build.imageDigest,
+        },
+        account: {
+          accountId: identity.accountId,
+          accountReferenceHash: identity.identityHash,
+          provider: identity.provider,
+          environment: identity.environment,
+        },
+        durableExecutionBindings: postgres.durableExecutionBindings,
+        cycles: postgres.cycles,
+        ...(postgres.strategy === undefined ? {} : { strategy: postgres.strategy }),
+        ...(postgres.reconciliation === undefined ? {} : { reconciliation: postgres.reconciliation }),
+        ...(postgres.startingCapitalMicros === undefined
+          ? {}
+          : { startingCapitalMicros: postgres.startingCapitalMicros }),
+        transactions: postgres.transactionEvidence,
+        ledgerTotals: ledger.totals,
+        accountingReceiptsExact,
+        ledgerExact: ledger.ledgerExact,
+        missingLedgerAccountCount: ledger.missingLedgerAccountCount,
+        unresolvedMutationCount: postgres.unresolvedMutationCount,
+        unclosedCycleCount: postgres.unclosedCycleCount + postgres.postReconciliationActivityCount,
+        openPositionCount: Math.max(postgres.openPositionCount, ledger.openPositionCount),
+      }),
+    ).pipe(
+      Effect.mapError((cause) =>
+        programError('construct-receipt', 'forward-performance receipt construction failed', cause),
+      ),
+    )
+    return receipt
+  })

--- a/services/bayn/src/forward-performance/tigerbeetle.test.ts
+++ b/services/bayn/src/forward-performance/tigerbeetle.test.ts
@@ -1,0 +1,127 @@
+import assert from 'node:assert/strict'
+
+import { describe, expect, test } from 'bun:test'
+import { Effect, Result } from 'effect'
+import type { Account, Transfer } from 'tigerbeetle-node'
+
+import { prepareAccounting } from '../accounting/domain'
+import type { RuntimeConfig } from '../config'
+import { OrderSide, type Fill } from '../execution/contracts'
+import { assembleAccountPlan } from '../ledger/decisions'
+import type { LedgerPlan } from '../ledger-plan'
+import type { JournalDependencies, TigerBeetleClient } from '../tigerbeetle-client'
+import { readForwardPerformanceLedger } from './tigerbeetle'
+
+const accountId = 'paper-account-forward-performance'
+const ledger = 7_001
+const config = {
+  operationTimeoutMs: 1_000,
+  tigerBeetle: { clusterId: 2_001n, replicaAddresses: ['3000'], ledger },
+} satisfies Pick<RuntimeConfig, 'operationTimeoutMs' | 'tigerBeetle'>
+
+const success = <A, E>(result: Result.Result<A, E>): A => {
+  assert(Result.isSuccess(result), 'forward-performance ledger fixture must succeed')
+  return result.success
+}
+
+const fill = (name: string, side: OrderSide, priceMicros: string, feeMicros: string): Fill => ({
+  schemaVersion: 'bayn.paper-fill.v1',
+  accountId,
+  fillId: `${name}-fill`,
+  brokerOrderId: `${name}-broker-order`,
+  clientOrderId: `${name}-client-order`,
+  symbol: 'NVDA',
+  side,
+  quantityMicros: '1000000',
+  priceMicros,
+  feeMicros,
+  occurredAt: side === OrderSide.Buy ? '2026-07-20T15:30:00.000Z' : '2026-07-21T15:30:00.000Z',
+})
+
+const plans = (): readonly LedgerPlan[] => [
+  success(
+    prepareAccounting(
+      'a'.repeat(64),
+      fill('buy', OrderSide.Buy, '100000000', '100'),
+      { quantityMicros: '0', costMicros: '0' },
+      ledger,
+    ),
+  ).ledger,
+  success(
+    prepareAccounting(
+      'b'.repeat(64),
+      fill('sell', OrderSide.Sell, '110000000', '200'),
+      { quantityMicros: '1000000', costMicros: '100000000' },
+      ledger,
+    ),
+  ).ledger,
+]
+
+const materializeAccounts = (plan: LedgerPlan): readonly Account[] => {
+  const balances = new Map(plan.accounts.map((account) => [account.id, { debits: 0n, credits: 0n }]))
+  for (const transfer of plan.transfers) {
+    const debit = balances.get(transfer.debit_account_id)
+    const credit = balances.get(transfer.credit_account_id)
+    if (debit === undefined || credit === undefined) throw new Error('ledger fixture references an unknown account')
+    debit.debits += transfer.amount
+    credit.credits += transfer.amount
+  }
+  return plan.accounts.map((account) => {
+    const balance = balances.get(account.id)
+    if (balance === undefined) throw new Error('ledger fixture omitted an account balance')
+    return {
+      ...account,
+      debits_posted: balance.debits,
+      credits_posted: balance.credits,
+      timestamp: 1n,
+    }
+  })
+}
+
+const materializeTransfers = (plan: LedgerPlan): readonly Transfer[] =>
+  plan.transfers.map((transfer) => ({ ...transfer, timestamp: 1n }))
+
+const dependencies = (accounts: readonly Account[], transfers: readonly Transfer[]): JournalDependencies => ({
+  resolveReplicaAddresses: () => Effect.succeed(['3000']),
+  createClient: () =>
+    ({
+      createAccounts: async () => [],
+      createTransfers: async () => [],
+      lookupAccounts: async () => [],
+      lookupTransfers: async () => [],
+      queryAccounts: async () => [...accounts],
+      queryTransfers: async () => [...transfers],
+      destroy: () => undefined,
+    }) satisfies TigerBeetleClient,
+})
+
+describe('forward performance TigerBeetle read', () => {
+  test('reconciles authoritative account balances and transfer events exactly', async () => {
+    const accountingPlans = plans()
+    const accountPlan = success(assembleAccountPlan(accountId, accountingPlans))
+
+    const evidence = await Effect.runPromise(
+      Effect.scoped(
+        readForwardPerformanceLedger(
+          config,
+          accountId,
+          accountingPlans,
+          dependencies(materializeAccounts(accountPlan), materializeTransfers(accountPlan)),
+        ),
+      ),
+    )
+
+    expect(evidence).toEqual({
+      totals: {
+        realizedGainMicros: '10000000',
+        realizedLossMicros: '0',
+        brokerExecutionFeesMicros: '300',
+        otherChargedCostsMicros: '0',
+        cashYieldMicros: '0',
+      },
+      ledgerExact: true,
+      missingLedgerAccountCount: 0,
+      openPositionCount: 0,
+    })
+  })
+})

--- a/services/bayn/src/forward-performance/tigerbeetle.ts
+++ b/services/bayn/src/forward-performance/tigerbeetle.ts
@@ -1,0 +1,78 @@
+import { Data, Effect, Result, Scope } from 'effect'
+import type { Account } from 'tigerbeetle-node'
+
+import type { RuntimeConfig } from '../config'
+import { assembleAccountPlan, accountReconciliationQueries } from '../ledger/decisions'
+import { AccountCode, reconcileLedgerPlan, type LedgerPlan, type LedgerValidationError } from '../ledger-plan'
+import { makeTigerBeetleRequestClient, type JournalDependencies } from '../tigerbeetle-client'
+import type { OperationalError } from '../errors'
+import type { ForwardPerformanceLedgerTotals } from './model'
+
+export class ForwardPerformanceLedgerError extends Data.TaggedError('ForwardPerformanceLedgerError')<{
+  readonly operation: 'read'
+  readonly message: string
+  readonly cause: OperationalError | LedgerValidationError
+}> {}
+
+export interface ForwardPerformanceLedgerEvidence {
+  readonly totals: ForwardPerformanceLedgerTotals
+  readonly ledgerExact: boolean
+  readonly missingLedgerAccountCount: number
+  readonly openPositionCount: number
+}
+
+const ledgerError = (cause: OperationalError | LedgerValidationError): ForwardPerformanceLedgerError =>
+  new ForwardPerformanceLedgerError({
+    operation: 'read',
+    message: 'forward-performance TigerBeetle read failed',
+    cause,
+  })
+
+const accountAmount = (accounts: readonly Account[], code: number, side: 'debit' | 'credit'): bigint =>
+  accounts
+    .filter((account) => account.code === code)
+    .reduce((total, account) => total + (side === 'debit' ? account.debits_posted : account.credits_posted), 0n)
+
+const openInventoryCount = (accounts: readonly Account[]): number =>
+  accounts.filter(
+    (account) => account.code === AccountCode.inventory && account.debits_posted !== account.credits_posted,
+  ).length
+
+export const readForwardPerformanceLedger = (
+  config: Pick<RuntimeConfig, 'operationTimeoutMs' | 'tigerBeetle'>,
+  accountId: string,
+  plans: readonly LedgerPlan[],
+  dependencies?: JournalDependencies,
+): Effect.Effect<ForwardPerformanceLedgerEvidence, ForwardPerformanceLedgerError, Scope.Scope> =>
+  Effect.gen(function* () {
+    const plan = yield* Effect.fromResult(assembleAccountPlan(accountId, plans)).pipe(Effect.mapError(ledgerError))
+    const queries = yield* Effect.fromResult(accountReconciliationQueries(plan, config.tigerBeetle.ledger)).pipe(
+      Effect.mapError(ledgerError),
+    )
+    const client = yield* makeTigerBeetleRequestClient(config, dependencies).pipe(Effect.mapError(ledgerError))
+    const [accounts, transfers] = yield* Effect.all(
+      [
+        client.request('forward-performance-accounts', (active) => active.queryAccounts(queries.accounts)),
+        client.request('forward-performance-transfers', (active) => active.queryTransfers(queries.transfers)),
+      ],
+      { concurrency: 'unbounded' },
+    ).pipe(Effect.mapError(ledgerError))
+
+    const expectedAccountIds = new Set(plan.accounts.map((account) => account.id))
+    const actualAccountIds = new Set(accounts.map((account) => account.id))
+    const missingLedgerAccountCount = [...expectedAccountIds].filter((id) => !actualAccountIds.has(id)).length
+    const reconciliation = reconcileLedgerPlan(plan, accounts, transfers, 'verify-account')
+
+    return {
+      totals: {
+        realizedGainMicros: accountAmount(accounts, AccountCode.realizedGain, 'credit').toString(),
+        realizedLossMicros: accountAmount(accounts, AccountCode.realizedLoss, 'debit').toString(),
+        brokerExecutionFeesMicros: accountAmount(accounts, AccountCode.feeExpense, 'debit').toString(),
+        otherChargedCostsMicros: '0',
+        cashYieldMicros: accountAmount(accounts, AccountCode.cashYieldIncome, 'credit').toString(),
+      },
+      ledgerExact: Result.isSuccess(reconciliation),
+      missingLedgerAccountCount,
+      openPositionCount: openInventoryCount(accounts),
+    }
+  })


### PR DESCRIPTION
## Summary

- add a pure, total forward-performance domain that computes integer-micro realized gains, losses, fees, other costs, cash yield, gross/net realized PnL, and net realized return without mark-to-market equity
- add one repeatable-read, read-only PostgreSQL reader and an authoritative TigerBeetle balance/event reconciliation using existing accounting and ledger adapters
- emit one canonical content-hashed receipt bound to runtime, qualification/strategy, durable execution authority, hashed broker account identity, environment, and exact reconciliation window
- fail closed as `INSUFFICIENT_EVIDENCE` for zero executions, open windows/positions, unresolved mutations, reconciliation or ledger drift, identity gaps, missing accounts, and invalid micros
- add a standalone command plus focused domain, read-only SQL, and exact TigerBeetle reconciliation tests

## Related Issues

None.

## Testing

- `cd services/bayn && bun run test` — 895 passed, 128 environment-gated skips, 0 failed
- `cd services/bayn && bun run tsc`
- `cd services/bayn && bun run lint`
- `cd services/bayn && bun run lint:oxlint`
- `cd services/bayn && bun run lint:oxlint:type`
- `cd services/bayn && bun run lint:effect`
- `cd services/bayn && bun run build`
- ran the finalized standalone command twice inside the current Bayn pod against authoritative production PostgreSQL and TigerBeetle; both runs returned the identical receipt hash `73d40077ab673cf52abfe2bb619f41ee298e66872f35d5601ab9982d4487cce6`
- live result: `INSUFFICIENT_EVIDENCE`, profitability `UNDETERMINED`, 0 cycles, 0 completed executions, with `IDENTITY_GAP`, `NON_EXACT_RECONCILIATION`, `STARTING_CAPITAL_GAP`, and `ZERO_COMPLETED_EXECUTIONS`
- production SQL is forced through `SET TRANSACTION ISOLATION LEVEL REPEATABLE READ, READ ONLY`; focused command coverage records every statement and rejects any DDL/DML; TigerBeetle uses query-only methods

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots section removed because this is a read-only command/domain change.
- [x] Breaking Changes section is filled in.
- [x] No documentation, release notes, deployment manifests, package metadata, or runtime composition changes are required; the service image entrypoint is unchanged.
