### PR TITLE
feat(bayn): add bounded execution prepare

### DIFF
--- a/services/bayn/src/app.test.ts
+++ b/services/bayn/src/app.test.ts
@@ -29,6 +29,8 @@ import { makeStrategyProtocolHash } from './contracts'
 import { BrokerAccess, BrokerEnvironment, noCapitalAuthority } from './execution/authority'
 import type { ExecutionProgram } from './execution/runtime-program'
 import { executionPrepareBoundaryError } from './entrypoint'
+import type { ExecutionPrepareRequest } from './execution-prepare'
+import { canonicalHashV1OrThrow } from './hash'
 import type { BrokerProbe } from './health'
 import { HttpServerLive } from './http'
 import { makeStrategy } from './strategy'
@@ -155,17 +157,62 @@ const discoveryConfig = (
 
 const prepareConfig = (
   runtime: typeof pinnedRuntimeConfig,
-): Extract<LoadedRuntimeConfig, { readonly runtimeMode: 'ExecutionPrepare' }> => ({
-  ...autonomousConfig(runtime),
-  runtimeMode: 'ExecutionPrepare',
-  qualificationRunId: pinnedEvaluation.runId,
-  executionPrepareRequest: undefined,
-  execution: {
-    brokerIdentity: autonomousConfig(runtime).alpaca.identity,
-    brokerAccess: BrokerAccess.ReadOnly,
-    capitalAuthority: noCapitalAuthority,
-  },
-})
+): Extract<LoadedRuntimeConfig, { readonly runtimeMode: 'ExecutionPrepare' }> => {
+  const autonomous = autonomousConfig(runtime)
+  const prepareStrategy = {
+    ...fixtureStrategy.provenance.strategy,
+    parameterSchemaVersion: 'bayn.risk-balanced-trend.protocol.v4' as const,
+  }
+  const proofPlan = {
+    schemaVersion: 'bayn.execution-prepare-proof-plan.v1' as const,
+    candidate: {
+      discoveryReceiptHash: '1'.repeat(64),
+      immutableBindingHash: '2'.repeat(64),
+      candidateFactsHash: '3'.repeat(64),
+      candidateOrdinal: 0,
+      observedPlanIntentId: '4'.repeat(64),
+      cycleId: '5'.repeat(64),
+      decisionHash: '6'.repeat(64),
+    },
+    binding: {
+      activationSourceRevision: runtime.build.sourceRevision,
+      activationImageRepository: runtime.build.imageRepository,
+      activationImageDigest: runtime.build.imageDigest,
+      qualificationSourceRevision: 'a'.repeat(40),
+      qualificationImageRepository: runtime.build.imageRepository,
+      qualificationImageDigest: `sha256:${'7'.repeat(64)}` as const,
+      strategy: prepareStrategy,
+      strategyProtocolHash: makeStrategyProtocolHash(prepareStrategy),
+      qualificationRunId: pinnedEvaluation.runId,
+      qualificationLockId: '8'.repeat(64),
+      qualificationResultHash: '9'.repeat(64),
+      protocolHash: 'a'.repeat(64),
+      qualificationExecutionPolicyHash: 'b'.repeat(64),
+      accountId: autonomous.alpaca.expectedAccountId,
+      brokerIdentityHash: autonomous.alpaca.identity.identityHash,
+      authorityGenerationHash: autonomous.alpaca.authorityGenerationHash,
+      riskPolicyHash: 'c'.repeat(64),
+      reconciliationId: 'd'.repeat(64),
+      reconciliationContentHash: 'e'.repeat(64),
+    },
+  }
+  const executionPrepareRequest: ExecutionPrepareRequest = {
+    schemaVersion: 'bayn.execution-prepare-request.v1',
+    proofPlan,
+    proofPlanHash: canonicalHashV1OrThrow(proofPlan),
+  }
+  return {
+    ...autonomous,
+    runtimeMode: 'ExecutionPrepare',
+    qualificationRunId: pinnedEvaluation.runId,
+    executionPrepareRequest,
+    execution: {
+      brokerIdentity: autonomous.alpaca.identity,
+      brokerAccess: BrokerAccess.ReadOnly,
+      capitalAuthority: noCapitalAuthority,
+    },
+  }
+}
 
 const applicationIdentity = (loaded: LoadedRuntimeConfig): ApplicationIdentity => ({
   config: loaded,

--- a/services/bayn/src/app.test.ts
+++ b/services/bayn/src/app.test.ts
@@ -30,6 +30,7 @@ import { BrokerAccess, BrokerEnvironment, noCapitalAuthority } from './execution
 import type { ExecutionProgram } from './execution/runtime-program'
 import { executionPrepareBoundaryError, validateExecutionPreparePlan } from './entrypoint'
 import type { ExecutionPrepareRequest } from './execution-prepare'
+import { makeExecutionPrepareDiscoveryReceiptFixture } from './execution-prepare/test-fixture'
 import { canonicalHashV1OrThrow } from './hash'
 import type { BrokerProbe } from './health'
 import { HttpServerLive } from './http'
@@ -167,16 +168,33 @@ const prepareConfig = (
   const riskPolicyHash = canonicalHashV1OrThrow(
     Effect.runSync(loadObserveRiskPolicy(autonomous.alpaca.expectedAccountId, fixtureStrategy.parameters.universe)),
   )
+  const strategyProtocolHash = makeStrategyProtocolHash(prepareStrategy)
+  const reconciliationId = 'd'.repeat(64)
+  const reconciliationContentHash = 'e'.repeat(64)
+  const discoveryReceipt = makeExecutionPrepareDiscoveryReceiptFixture({
+    sourceRevision: runtime.build.sourceRevision,
+    imageRepository: runtime.build.imageRepository,
+    imageDigest: runtime.build.imageDigest,
+    strategy: prepareStrategy,
+    strategyProtocolHash,
+    qualificationRunId: pinnedEvaluation.runId,
+    accountId: autonomous.alpaca.expectedAccountId,
+    authorityGenerationHash: autonomous.alpaca.authorityGenerationHash,
+    policyHash: riskPolicyHash,
+    reconciliationId,
+    reconciliationContentHash,
+  })
+  const discoveredCandidate = discoveryReceipt.candidateFacts.candidates[0]!
   const proofPlan = {
     schemaVersion: 'bayn.execution-prepare-proof-plan.v1' as const,
     candidate: {
-      discoveryReceiptHash: '1'.repeat(64),
-      immutableBindingHash: '2'.repeat(64),
-      candidateFactsHash: '3'.repeat(64),
-      candidateOrdinal: 0,
-      observedPlanIntentId: '4'.repeat(64),
-      cycleId: '5'.repeat(64),
-      decisionHash: '6'.repeat(64),
+      discoveryReceiptHash: discoveryReceipt.observationReceiptHash,
+      immutableBindingHash: discoveryReceipt.immutableBindingHash,
+      candidateFactsHash: discoveryReceipt.candidateFactsHash,
+      candidateOrdinal: discoveredCandidate.ordinal,
+      observedPlanIntentId: discoveredCandidate.observedPlanIntentId,
+      cycleId: discoveryReceipt.binding.cycle.cycleId,
+      decisionHash: discoveryReceipt.binding.cycle.decisionHash,
     },
     binding: {
       activationSourceRevision: runtime.build.sourceRevision,
@@ -186,7 +204,7 @@ const prepareConfig = (
       qualificationImageRepository: runtime.build.imageRepository,
       qualificationImageDigest: `sha256:${'7'.repeat(64)}` as const,
       strategy: prepareStrategy,
-      strategyProtocolHash: makeStrategyProtocolHash(prepareStrategy),
+      strategyProtocolHash,
       qualificationRunId: pinnedEvaluation.runId,
       qualificationLockId: '8'.repeat(64),
       qualificationResultHash: '9'.repeat(64),
@@ -196,12 +214,13 @@ const prepareConfig = (
       brokerIdentityHash: autonomous.alpaca.identity.identityHash,
       authorityGenerationHash: autonomous.alpaca.authorityGenerationHash,
       riskPolicyHash,
-      reconciliationId: 'd'.repeat(64),
-      reconciliationContentHash: 'e'.repeat(64),
+      reconciliationId,
+      reconciliationContentHash,
     },
   }
   const executionPrepareRequest: ExecutionPrepareRequest = {
     schemaVersion: 'bayn.execution-prepare-request.v1',
+    discoveryReceipt,
     proofPlan,
     proofPlanHash: canonicalHashV1OrThrow(proofPlan),
   }
@@ -277,6 +296,16 @@ describe('Bayn application composition', () => {
         proofPlanHash: canonicalHashV1OrThrow(proofPlan),
       }
     }
+    const requestWithCandidate = (
+      candidate: ExecutionPrepareRequest['proofPlan']['candidate'],
+    ): ExecutionPrepareRequest => {
+      const proofPlan = { ...base.executionPrepareRequest.proofPlan, candidate }
+      return {
+        ...base.executionPrepareRequest,
+        proofPlan,
+        proofPlanHash: canonicalHashV1OrThrow(proofPlan),
+      }
+    }
     const requests: readonly ExecutionPrepareRequest[] = [
       requestWithBinding({ ...base.executionPrepareRequest.proofPlan.binding, accountId: 'drifted-account' }),
       requestWithBinding({
@@ -292,6 +321,40 @@ describe('Bayn application composition', () => {
       }),
       requestWithBinding({ ...base.executionPrepareRequest.proofPlan.binding, riskPolicyHash: '0'.repeat(64) }),
       { ...base.executionPrepareRequest, proofPlanHash: '0'.repeat(64) },
+      requestWithCandidate({
+        ...base.executionPrepareRequest.proofPlan.candidate,
+        observedPlanIntentId: '0'.repeat(64),
+      }),
+      requestWithCandidate({ ...base.executionPrepareRequest.proofPlan.candidate, candidateOrdinal: 1 }),
+      requestWithCandidate({
+        ...base.executionPrepareRequest.proofPlan.candidate,
+        immutableBindingHash: '0'.repeat(64),
+      }),
+      requestWithCandidate({
+        ...base.executionPrepareRequest.proofPlan.candidate,
+        candidateFactsHash: '0'.repeat(64),
+      }),
+      requestWithCandidate({ ...base.executionPrepareRequest.proofPlan.candidate, cycleId: '0'.repeat(64) }),
+      requestWithCandidate({ ...base.executionPrepareRequest.proofPlan.candidate, decisionHash: '0'.repeat(64) }),
+      requestWithBinding({
+        ...base.executionPrepareRequest.proofPlan.binding,
+        activationSourceRevision: '0'.repeat(40),
+      }),
+      requestWithBinding({
+        ...base.executionPrepareRequest.proofPlan.binding,
+        reconciliationId: '0'.repeat(64),
+      }),
+      requestWithBinding({
+        ...base.executionPrepareRequest.proofPlan.binding,
+        reconciliationContentHash: '0'.repeat(64),
+      }),
+      {
+        ...base.executionPrepareRequest,
+        discoveryReceipt: {
+          ...base.executionPrepareRequest.discoveryReceipt,
+          observationReceiptHash: '0'.repeat(64),
+        },
+      },
     ]
     const ExternalResource = Context.Service<'execution-prepare-test-resource', number>(
       'execution-prepare-test-resource',

--- a/services/bayn/src/app.test.ts
+++ b/services/bayn/src/app.test.ts
@@ -28,6 +28,7 @@ import type { LoadedRuntimeConfig } from './config'
 import { makeStrategyProtocolHash } from './contracts'
 import { BrokerAccess, BrokerEnvironment, noCapitalAuthority } from './execution/authority'
 import type { ExecutionProgram } from './execution/runtime-program'
+import { executionPrepareBoundaryError } from './entrypoint'
 import type { BrokerProbe } from './health'
 import { HttpServerLive } from './http'
 import { makeStrategy } from './strategy'
@@ -152,6 +153,20 @@ const discoveryConfig = (
   },
 })
 
+const prepareConfig = (
+  runtime: typeof pinnedRuntimeConfig,
+): Extract<LoadedRuntimeConfig, { readonly runtimeMode: 'ExecutionPrepare' }> => ({
+  ...autonomousConfig(runtime),
+  runtimeMode: 'ExecutionPrepare',
+  qualificationRunId: pinnedEvaluation.runId,
+  executionPrepareRequest: undefined,
+  execution: {
+    brokerIdentity: autonomousConfig(runtime).alpaca.identity,
+    brokerAccess: BrokerAccess.ReadOnly,
+    capitalAuthority: noCapitalAuthority,
+  },
+})
+
 const applicationIdentity = (loaded: LoadedRuntimeConfig): ApplicationIdentity => ({
   config: loaded,
   protocol: fixtureProtocol,
@@ -166,6 +181,7 @@ describe('Bayn application composition', () => {
       { config: brokerlessConfig(config), expectedTag: 'BrokerlessService' },
       { config: autonomousConfig(config), expectedTag: 'AutonomousService' },
       { config: discoveryConfig(pinnedRuntimeConfig), expectedTag: 'ExecutionCandidateDiscovery' },
+      { config: prepareConfig(pinnedRuntimeConfig), expectedTag: 'ExecutionPrepare' },
     ] as const
 
     for (const mode of modes) {
@@ -180,6 +196,24 @@ describe('Bayn application composition', () => {
       expect(plan.strategyProtocolHash).toBe(identity.strategyProtocolHash)
       expect(identity).not.toHaveProperty('_tag')
     }
+  })
+
+  test('redacts bounded-operation resource failures before stdout logging', () => {
+    const accountNumber = 'account-number-must-remain-redacted'
+    const failure = executionPrepareBoundaryError({
+      _tag: 'BrokerSessionAcquisitionError',
+      expectedAccountId: accountNumber,
+      cause: new Error(`credential and ${accountNumber}`),
+    })
+
+    expect(failure).toMatchObject({
+      component: 'strategy',
+      operation: 'execution-prepare-resource',
+      retryable: false,
+      cause: { _tag: 'BrokerSessionAcquisitionError' },
+    })
+    expect(JSON.stringify(failure)).not.toContain(accountNumber)
+    expect(JSON.stringify(failure)).not.toContain('credential')
   })
 
   test('starts one scoped autonomous cycle after initialization and interrupts it with the application', async () => {

--- a/services/bayn/src/app.test.ts
+++ b/services/bayn/src/app.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 
-import { Clock, Deferred, Effect, Fiber, pipe, Redacted, Result } from 'effect'
+import { Clock, Context, Deferred, Effect, Fiber, Layer, pipe, Redacted, Result } from 'effect'
 
 import {
   config,
@@ -28,11 +28,12 @@ import type { LoadedRuntimeConfig } from './config'
 import { makeStrategyProtocolHash } from './contracts'
 import { BrokerAccess, BrokerEnvironment, noCapitalAuthority } from './execution/authority'
 import type { ExecutionProgram } from './execution/runtime-program'
-import { executionPrepareBoundaryError } from './entrypoint'
+import { executionPrepareBoundaryError, validateExecutionPreparePlan } from './entrypoint'
 import type { ExecutionPrepareRequest } from './execution-prepare'
 import { canonicalHashV1OrThrow } from './hash'
 import type { BrokerProbe } from './health'
 import { HttpServerLive } from './http'
+import { loadObserveRiskPolicy } from './observe-composition'
 import { makeStrategy } from './strategy'
 import { fixtureProtocol, makeSnapshot, makeTestProvenance } from './test-fixtures'
 
@@ -163,6 +164,9 @@ const prepareConfig = (
     ...fixtureStrategy.provenance.strategy,
     parameterSchemaVersion: 'bayn.risk-balanced-trend.protocol.v4' as const,
   }
+  const riskPolicyHash = canonicalHashV1OrThrow(
+    Effect.runSync(loadObserveRiskPolicy(autonomous.alpaca.expectedAccountId, fixtureStrategy.parameters.universe)),
+  )
   const proofPlan = {
     schemaVersion: 'bayn.execution-prepare-proof-plan.v1' as const,
     candidate: {
@@ -191,7 +195,7 @@ const prepareConfig = (
       accountId: autonomous.alpaca.expectedAccountId,
       brokerIdentityHash: autonomous.alpaca.identity.identityHash,
       authorityGenerationHash: autonomous.alpaca.authorityGenerationHash,
-      riskPolicyHash: 'c'.repeat(64),
+      riskPolicyHash,
       reconciliationId: 'd'.repeat(64),
       reconciliationContentHash: 'e'.repeat(64),
     },
@@ -261,6 +265,66 @@ describe('Bayn application composition', () => {
     })
     expect(JSON.stringify(failure)).not.toContain(accountNumber)
     expect(JSON.stringify(failure)).not.toContain('credential')
+  })
+
+  test('rejects semantic EXECUTION_PREPARE drift before resource acquisition', async () => {
+    const base = prepareConfig(pinnedRuntimeConfig)
+    const requestWithBinding = (binding: ExecutionPrepareRequest['proofPlan']['binding']): ExecutionPrepareRequest => {
+      const proofPlan = { ...base.executionPrepareRequest.proofPlan, binding }
+      return {
+        ...base.executionPrepareRequest,
+        proofPlan,
+        proofPlanHash: canonicalHashV1OrThrow(proofPlan),
+      }
+    }
+    const requests: readonly ExecutionPrepareRequest[] = [
+      requestWithBinding({ ...base.executionPrepareRequest.proofPlan.binding, accountId: 'drifted-account' }),
+      requestWithBinding({
+        ...base.executionPrepareRequest.proofPlan.binding,
+        authorityGenerationHash: '0'.repeat(64),
+      }),
+      requestWithBinding({
+        ...base.executionPrepareRequest.proofPlan.binding,
+        strategy: {
+          ...base.executionPrepareRequest.proofPlan.binding.strategy,
+          behaviorHash: '0'.repeat(64),
+        },
+      }),
+      requestWithBinding({ ...base.executionPrepareRequest.proofPlan.binding, riskPolicyHash: '0'.repeat(64) }),
+      { ...base.executionPrepareRequest, proofPlanHash: '0'.repeat(64) },
+    ]
+    const ExternalResource = Context.Service<'execution-prepare-test-resource', number>(
+      'execution-prepare-test-resource',
+    )
+
+    for (const executionPrepareRequest of requests) {
+      let acquisitions = 0
+      const resources = Layer.effect(
+        ExternalResource,
+        Effect.sync(() => {
+          acquisitions += 1
+          return acquisitions
+        }),
+      )
+      const plan = makeApplicationPlan(
+        applicationIdentity({
+          ...base,
+          executionPrepareRequest,
+        }),
+      )
+      if (plan._tag !== 'ExecutionPrepare') throw new Error('fixture must produce EXECUTION_PREPARE')
+
+      const failure = await Effect.runPromise(
+        Effect.flip(
+          validateExecutionPreparePlan(plan).pipe(
+            Effect.flatMap(() => ExternalResource.pipe(Effect.provide(resources))),
+          ),
+        ),
+      )
+
+      expect(failure).toMatchObject({ component: 'strategy', operation: 'execution-prepare' })
+      expect(acquisitions).toBe(0)
+    }
   })
 
   test('starts one scoped autonomous cycle after initialization and interrupts it with the application', async () => {

--- a/services/bayn/src/app.ts
+++ b/services/bayn/src/app.ts
@@ -68,6 +68,11 @@ export const makeApplicationPlan = (identity: ApplicationIdentity): ApplicationP
       _tag: 'ExecutionCandidateDiscovery' as const,
       config,
     })),
+    Match.when({ runtimeMode: 'ExecutionPrepare' }, (config) => ({
+      ...identity,
+      _tag: 'ExecutionPrepare' as const,
+      config,
+    })),
     Match.exhaustive,
   )
 

--- a/services/bayn/src/config.test.ts
+++ b/services/bayn/src/config.test.ts
@@ -397,6 +397,14 @@ describe('pure runtime configuration resolution', () => {
     expectFailure(
       {
         configuredOperation: 'ExecutionPrepare',
+        qualificationRunId,
+        configuredAlpaca: alpaca(BrokerEnvironment.Sandbox),
+      },
+      { _tag: 'ExecutionPrepareRequiresRequest' },
+    )
+    expectFailure(
+      {
+        configuredOperation: 'ExecutionPrepare',
         executionPrepareRequest,
         configuredAlpaca: alpaca(BrokerEnvironment.Sandbox),
       },
@@ -425,6 +433,18 @@ describe('pure runtime configuration resolution', () => {
         _tag: 'ExecutionCandidateDiscoveryRequiresReadOnlyNoCapital',
         brokerAccess: BrokerAccess.Mutation,
         capitalAuthority: CapitalAuthoritySelection.Sandbox,
+      },
+    )
+    expectFailure(
+      {
+        configuredOperation: 'ExecutionPrepare',
+        executionPrepareRequest,
+        qualificationRunId,
+        configuredAlpaca: alpaca(BrokerEnvironment.Live),
+      },
+      {
+        _tag: 'ExecutionPrepareRequiresSandboxBroker',
+        brokerEnvironment: BrokerEnvironment.Live,
       },
     )
   })

--- a/services/bayn/src/config.test.ts
+++ b/services/bayn/src/config.test.ts
@@ -14,6 +14,7 @@ import {
 import { BrokerAccess, BrokerEnvironment, CapitalAuthorityKind } from './execution/authority'
 import { CapitalAuthoritySelection } from './execution/configuration'
 import type { ExecutionPrepareRequest } from './execution-prepare'
+import { makeExecutionPrepareDiscoveryReceiptFixture } from './execution-prepare/test-fixture'
 import { canonicalHashV1OrThrow } from './hash'
 
 const sourceRevision = 'a'.repeat(40)
@@ -31,17 +32,41 @@ const qualificationRunId = 'e'.repeat(64)
 const alpacaAccountId = '61e69015-8549-4bfd-b9c3-01e75843f47d'
 const clickhousePassword = 'clickhouse-password-must-remain-redacted'
 const postgresUrl = 'postgresql://bayn:postgres-secret-must-remain-redacted@postgres.test:5432/bayn'
+const executionPrepareStrategy = {
+  name: 'risk-balanced-trend' as const,
+  behaviorHash: buildMetadata.strategyBehaviorHash,
+  parameterHash: buildMetadata.strategyParameterHash,
+  parameterSchemaVersion: 'bayn.risk-balanced-trend.protocol.v4' as const,
+}
+const executionPrepareStrategyProtocolHash = '7'.repeat(64)
+const executionPrepareRiskPolicyHash = 'd'.repeat(64)
+const executionPrepareReconciliationId = 'e'.repeat(64)
+const executionPrepareReconciliationContentHash = 'f'.repeat(64)
+const executionPrepareDiscoveryReceipt = makeExecutionPrepareDiscoveryReceiptFixture({
+  sourceRevision,
+  imageRepository,
+  imageDigest,
+  strategy: executionPrepareStrategy,
+  strategyProtocolHash: executionPrepareStrategyProtocolHash,
+  qualificationRunId,
+  accountId: alpacaAccountId,
+  authorityGenerationHash,
+  policyHash: executionPrepareRiskPolicyHash,
+  reconciliationId: executionPrepareReconciliationId,
+  reconciliationContentHash: executionPrepareReconciliationContentHash,
+})
+const executionPrepareCandidate = executionPrepareDiscoveryReceipt.candidateFacts.candidates[0]!
 
 const executionPrepareProofPlan = {
   schemaVersion: 'bayn.execution-prepare-proof-plan.v1' as const,
   candidate: {
-    discoveryReceiptHash: '1'.repeat(64),
-    immutableBindingHash: '2'.repeat(64),
-    candidateFactsHash: '3'.repeat(64),
-    candidateOrdinal: 0,
-    observedPlanIntentId: '4'.repeat(64),
-    cycleId: '5'.repeat(64),
-    decisionHash: '6'.repeat(64),
+    discoveryReceiptHash: executionPrepareDiscoveryReceipt.observationReceiptHash,
+    immutableBindingHash: executionPrepareDiscoveryReceipt.immutableBindingHash,
+    candidateFactsHash: executionPrepareDiscoveryReceipt.candidateFactsHash,
+    candidateOrdinal: executionPrepareCandidate.ordinal,
+    observedPlanIntentId: executionPrepareCandidate.observedPlanIntentId,
+    cycleId: executionPrepareDiscoveryReceipt.binding.cycle.cycleId,
+    decisionHash: executionPrepareDiscoveryReceipt.binding.cycle.decisionHash,
   },
   binding: {
     activationSourceRevision: sourceRevision,
@@ -50,13 +75,8 @@ const executionPrepareProofPlan = {
     qualificationSourceRevision: 'f'.repeat(40),
     qualificationImageRepository: imageRepository,
     qualificationImageDigest: `sha256:${'1'.repeat(64)}` as const,
-    strategy: {
-      name: 'risk-balanced-trend' as const,
-      behaviorHash: buildMetadata.strategyBehaviorHash,
-      parameterHash: buildMetadata.strategyParameterHash,
-      parameterSchemaVersion: 'bayn.risk-balanced-trend.protocol.v4' as const,
-    },
-    strategyProtocolHash: '7'.repeat(64),
+    strategy: executionPrepareStrategy,
+    strategyProtocolHash: executionPrepareStrategyProtocolHash,
     qualificationRunId,
     qualificationLockId: '8'.repeat(64),
     qualificationResultHash: '9'.repeat(64),
@@ -65,14 +85,15 @@ const executionPrepareProofPlan = {
     accountId: alpacaAccountId,
     brokerIdentityHash: 'c'.repeat(64),
     authorityGenerationHash,
-    riskPolicyHash: 'd'.repeat(64),
-    reconciliationId: 'e'.repeat(64),
-    reconciliationContentHash: 'f'.repeat(64),
+    riskPolicyHash: executionPrepareRiskPolicyHash,
+    reconciliationId: executionPrepareReconciliationId,
+    reconciliationContentHash: executionPrepareReconciliationContentHash,
   },
 }
 
 const executionPrepareRequest: ExecutionPrepareRequest = {
   schemaVersion: 'bayn.execution-prepare-request.v1',
+  discoveryReceipt: executionPrepareDiscoveryReceipt,
   proofPlan: executionPrepareProofPlan,
   proofPlanHash: canonicalHashV1OrThrow(executionPrepareProofPlan),
 }

--- a/services/bayn/src/config.test.ts
+++ b/services/bayn/src/config.test.ts
@@ -13,6 +13,8 @@ import {
 } from './config'
 import { BrokerAccess, BrokerEnvironment, CapitalAuthorityKind } from './execution/authority'
 import { CapitalAuthoritySelection } from './execution/configuration'
+import type { ExecutionPrepareRequest } from './execution-prepare'
+import { canonicalHashV1OrThrow } from './hash'
 
 const sourceRevision = 'a'.repeat(40)
 const imageRepository = 'registry.ide-newton.ts.net/lab/bayn'
@@ -30,11 +32,57 @@ const alpacaAccountId = '61e69015-8549-4bfd-b9c3-01e75843f47d'
 const clickhousePassword = 'clickhouse-password-must-remain-redacted'
 const postgresUrl = 'postgresql://bayn:postgres-secret-must-remain-redacted@postgres.test:5432/bayn'
 
+const executionPrepareProofPlan = {
+  schemaVersion: 'bayn.execution-prepare-proof-plan.v1' as const,
+  candidate: {
+    discoveryReceiptHash: '1'.repeat(64),
+    immutableBindingHash: '2'.repeat(64),
+    candidateFactsHash: '3'.repeat(64),
+    candidateOrdinal: 0,
+    observedPlanIntentId: '4'.repeat(64),
+    cycleId: '5'.repeat(64),
+    decisionHash: '6'.repeat(64),
+  },
+  binding: {
+    activationSourceRevision: sourceRevision,
+    activationImageRepository: imageRepository,
+    activationImageDigest: imageDigest,
+    qualificationSourceRevision: 'f'.repeat(40),
+    qualificationImageRepository: imageRepository,
+    qualificationImageDigest: `sha256:${'1'.repeat(64)}` as const,
+    strategy: {
+      name: 'risk-balanced-trend' as const,
+      behaviorHash: buildMetadata.strategyBehaviorHash,
+      parameterHash: buildMetadata.strategyParameterHash,
+      parameterSchemaVersion: 'bayn.risk-balanced-trend.protocol.v4' as const,
+    },
+    strategyProtocolHash: '7'.repeat(64),
+    qualificationRunId,
+    qualificationLockId: '8'.repeat(64),
+    qualificationResultHash: '9'.repeat(64),
+    protocolHash: 'a'.repeat(64),
+    qualificationExecutionPolicyHash: 'b'.repeat(64),
+    accountId: alpacaAccountId,
+    brokerIdentityHash: 'c'.repeat(64),
+    authorityGenerationHash,
+    riskPolicyHash: 'd'.repeat(64),
+    reconciliationId: 'e'.repeat(64),
+    reconciliationContentHash: 'f'.repeat(64),
+  },
+}
+
+const executionPrepareRequest: ExecutionPrepareRequest = {
+  schemaVersion: 'bayn.execution-prepare-request.v1',
+  proofPlan: executionPrepareProofPlan,
+  proofPlanHash: canonicalHashV1OrThrow(executionPrepareProofPlan),
+}
+
 const baseParsedConfig: ParsedRuntimeConfig = {
   host: '0.0.0.0',
   port: 8080,
   qualificationRunId: undefined,
   configuredOperation: undefined,
+  executionPrepareRequest: undefined,
   legacyMaximumAuthority: 'OBSERVE',
   brokerAccess: BrokerAccess.ReadOnly,
   capitalAuthority: CapitalAuthoritySelection.None,
@@ -205,6 +253,27 @@ describe('pure runtime configuration resolution', () => {
     })
   })
 
+  test('resolves EXECUTION_PREPARE as an explicit read-only bounded operation', () => {
+    const config = Result.getOrThrow(
+      resolveRuntimeConfig(
+        resolutionInput({
+          qualificationRunId,
+          configuredOperation: 'ExecutionPrepare',
+          executionPrepareRequest,
+          configuredAlpaca: alpaca(BrokerEnvironment.Sandbox),
+        }),
+      ),
+    )
+
+    expect(config).toMatchObject({
+      runtimeMode: 'ExecutionPrepare',
+      qualificationRunId,
+      executionPrepareRequest,
+      execution: { brokerAccess: BrokerAccess.ReadOnly, capitalAuthority: { _tag: CapitalAuthorityKind.None } },
+      alpaca: { environment: BrokerEnvironment.Sandbox, expectedAccountId: alpacaAccountId },
+    })
+  })
+
   test('rejects partial credentials and connection binding failures before composition', () => {
     expectFailure(
       {
@@ -324,6 +393,42 @@ describe('pure runtime configuration resolution', () => {
     )
   })
 
+  test('requires EXECUTION_PREPARE to remain read-only, pinned, and broker-bound', () => {
+    expectFailure(
+      {
+        configuredOperation: 'ExecutionPrepare',
+        executionPrepareRequest,
+        configuredAlpaca: alpaca(BrokerEnvironment.Sandbox),
+      },
+      { _tag: 'ExecutionCandidateDiscoveryRequiresQualificationRun' },
+    )
+    expectFailure(
+      {
+        configuredOperation: 'ExecutionPrepare',
+        executionPrepareRequest,
+        qualificationRunId,
+        authorityGenerationHash: undefined,
+      },
+      { _tag: 'ExecutionCandidateDiscoveryRequiresAlpacaBinding' },
+    )
+    expectFailure(
+      {
+        configuredOperation: 'ExecutionPrepare',
+        executionPrepareRequest,
+        qualificationRunId,
+        configuredAlpaca: alpaca(BrokerEnvironment.Sandbox),
+        legacyMaximumAuthority: undefined,
+        brokerAccess: BrokerAccess.Mutation,
+        capitalAuthority: CapitalAuthoritySelection.Sandbox,
+      },
+      {
+        _tag: 'ExecutionCandidateDiscoveryRequiresReadOnlyNoCapital',
+        brokerAccess: BrokerAccess.Mutation,
+        capitalAuthority: CapitalAuthoritySelection.Sandbox,
+      },
+    )
+  })
+
   test('validates provenance, PostgreSQL TLS, bounds, and cycle timing before runtime startup', () => {
     expectFailure(
       { cyclePollIntervalMs: 300_000 },
@@ -425,5 +530,30 @@ describe('runtime configuration loading', () => {
         cause: { _tag: 'SandboxBrokerRequiresSandboxCapital' },
       },
     })
+  })
+
+  test('loads the public EXECUTION_PREPARE token and strict JSON request without exposing credentials', async () => {
+    const environment = new Map(runtimeEnvironment)
+    environment.set('BAYN_OPERATION', 'EXECUTION_PREPARE')
+    environment.set('BAYN_EXECUTION_PREPARE_REQUEST', JSON.stringify(executionPrepareRequest))
+
+    const config = await Effect.runPromise(provideEnvironment(loadConfig(buildMetadata), environment))
+    expect(config).toMatchObject({
+      runtimeMode: 'ExecutionPrepare',
+      executionPrepareRequest,
+      execution: { brokerAccess: BrokerAccess.ReadOnly, capitalAuthority: { _tag: CapitalAuthorityKind.None } },
+    })
+    const serialized = JSON.stringify(config, (_key, value) => (typeof value === 'bigint' ? value.toString() : value))
+    expect(serialized).not.toContain('sandbox-secret')
+    expect(serialized).not.toContain('sandbox-key')
+  })
+
+  test('rejects malformed EXECUTION_PREPARE JSON at the config boundary', async () => {
+    const environment = new Map(runtimeEnvironment)
+    environment.set('BAYN_OPERATION', 'EXECUTION_PREPARE')
+    environment.set('BAYN_EXECUTION_PREPARE_REQUEST', '{"schemaVersion":"wrong"}')
+
+    const failure = await Effect.runPromise(Effect.flip(provideEnvironment(loadConfig(buildMetadata), environment)))
+    expect(failure).toMatchObject({ component: 'config', operation: 'load', retryable: false })
   })
 })

--- a/services/bayn/src/config/load.ts
+++ b/services/bayn/src/config/load.ts
@@ -56,6 +56,16 @@ const presentRuntimeConfigFailure = (failure: RuntimeConfigResolutionFailure): R
         operation: 'operation',
         message: 'execution candidate discovery requires a complete Alpaca read binding',
       }
+    case 'ExecutionPrepareRequiresRequest':
+      return {
+        operation: 'operation',
+        message: 'EXECUTION_PREPARE requires an explicit content-hashed request',
+      }
+    case 'ExecutionPrepareRequiresSandboxBroker':
+      return {
+        operation: 'operation',
+        message: 'EXECUTION_PREPARE requires the Alpaca sandbox broker environment',
+      }
     case 'ProductionProvenanceRequiresEmbeddedMetadata':
       return {
         operation: 'provenance',

--- a/services/bayn/src/config/model.ts
+++ b/services/bayn/src/config/model.ts
@@ -10,6 +10,7 @@ import type {
   ExecutionPolicy,
   ExecutionPolicyResolutionFailure,
 } from '../execution/configuration'
+import type { ExecutionPrepareRequest } from '../execution-prepare/model'
 
 export interface RuntimeBuildMetadata extends EmbeddedBuildMetadata {
   readonly imageDigest: string
@@ -56,7 +57,7 @@ export interface AutonomousCycleRuntimeConfig {
   readonly cyclePollIntervalMs: number
 }
 
-export type RuntimeOperation = 'ExecutionCandidateDiscovery'
+export type RuntimeOperation = 'ExecutionCandidateDiscovery' | 'ExecutionPrepare'
 
 export type AlpacaRuntimeConfig = NonNullable<RuntimeConfig['alpaca']>
 
@@ -85,6 +86,16 @@ export type LoadedRuntimeConfig = LoadedRuntimeConfigBase &
         > & { readonly brokerIdentity: import('../broker/identity').BrokerIdentity }
         readonly alpaca: AlpacaRuntimeConfig
       }
+    | {
+        readonly runtimeMode: 'ExecutionPrepare'
+        readonly qualificationRunId: string
+        readonly executionPrepareRequest: ExecutionPrepareRequest | undefined
+        readonly execution: Extract<
+          ExecutionPolicy,
+          { readonly brokerAccess: import('../execution/authority').BrokerAccess.ReadOnly }
+        > & { readonly brokerIdentity: import('../broker/identity').BrokerIdentity }
+        readonly alpaca: AlpacaRuntimeConfig
+      }
   )
 
 export type LegacyAuthorityToken = 'OBSERVE' | 'PAPER'
@@ -94,6 +105,7 @@ export interface ParsedRuntimeConfig {
   readonly port: number
   readonly qualificationRunId: string | undefined
   readonly configuredOperation: RuntimeOperation | undefined
+  readonly executionPrepareRequest: ExecutionPrepareRequest | undefined
   readonly legacyMaximumAuthority: LegacyAuthorityToken | undefined
   readonly brokerAccess: BrokerAccess
   readonly capitalAuthority: CapitalAuthoritySelection

--- a/services/bayn/src/config/model.ts
+++ b/services/bayn/src/config/model.ts
@@ -89,7 +89,7 @@ export type LoadedRuntimeConfig = LoadedRuntimeConfigBase &
     | {
         readonly runtimeMode: 'ExecutionPrepare'
         readonly qualificationRunId: string
-        readonly executionPrepareRequest: ExecutionPrepareRequest | undefined
+        readonly executionPrepareRequest: ExecutionPrepareRequest
         readonly execution: Extract<
           ExecutionPolicy,
           { readonly brokerAccess: import('../execution/authority').BrokerAccess.ReadOnly }
@@ -189,6 +189,13 @@ export type RuntimeConfigResolutionFailure =
     }
   | {
       readonly _tag: 'ExecutionCandidateDiscoveryRequiresAlpacaBinding'
+    }
+  | {
+      readonly _tag: 'ExecutionPrepareRequiresRequest'
+    }
+  | {
+      readonly _tag: 'ExecutionPrepareRequiresSandboxBroker'
+      readonly brokerEnvironment: BrokerEnvironment
     }
   | {
       readonly _tag: 'ProductionProvenanceRequiresEmbeddedMetadata'

--- a/services/bayn/src/config/resolution.ts
+++ b/services/bayn/src/config/resolution.ts
@@ -266,6 +266,23 @@ const loadedConfig = (
       alpaca,
     })
   }
+  if (parsed.configuredOperation === 'ExecutionPrepare') {
+    const qualificationRunId = parsed.qualificationRunId
+    if (qualificationRunId === undefined) {
+      return fail({ _tag: 'ExecutionCandidateDiscoveryRequiresQualificationRun' })
+    }
+    if (alpaca === undefined) {
+      return fail({ _tag: 'ExecutionCandidateDiscoveryRequiresAlpacaBinding' })
+    }
+    return Result.succeed({
+      ...common,
+      runtimeMode: 'ExecutionPrepare',
+      qualificationRunId,
+      executionPrepareRequest: parsed.executionPrepareRequest,
+      execution: execution as Extract<LoadedRuntimeConfig, { readonly runtimeMode: 'ExecutionPrepare' }>['execution'],
+      alpaca,
+    })
+  }
   if (alpaca === undefined) {
     return Result.succeed({
       ...common,

--- a/services/bayn/src/config/resolution.ts
+++ b/services/bayn/src/config/resolution.ts
@@ -1,6 +1,7 @@
 import { Redacted, Result, Schema } from 'effect'
 
 import { decodeBrokerConnection, type BrokerConnection } from '../broker/connection'
+import { BrokerEnvironment } from '../broker/identity'
 import { EmbeddedBuildMetadataSchema, type EmbeddedBuildMetadata } from '../build'
 import { BrokerAccess, CapitalAuthorityKind } from '../execution/authority'
 import { CapitalAuthoritySelection, resolveExecutionPolicy, type ExecutionPolicy } from '../execution/configuration'
@@ -146,9 +147,17 @@ const validateOperation = (
   if (parsed.qualificationRunId === undefined) {
     return fail({ _tag: 'ExecutionCandidateDiscoveryRequiresQualificationRun' })
   }
-  return alpaca === undefined
-    ? fail({ _tag: 'ExecutionCandidateDiscoveryRequiresAlpacaBinding' })
-    : Result.succeed(undefined)
+  if (alpaca === undefined) return fail({ _tag: 'ExecutionCandidateDiscoveryRequiresAlpacaBinding' })
+  if (parsed.configuredOperation === 'ExecutionPrepare') {
+    if (parsed.executionPrepareRequest === undefined) return fail({ _tag: 'ExecutionPrepareRequiresRequest' })
+    if (alpaca.environment !== BrokerEnvironment.Sandbox) {
+      return fail({
+        _tag: 'ExecutionPrepareRequiresSandboxBroker',
+        brokerEnvironment: alpaca.environment,
+      })
+    }
+  }
+  return Result.succeed(undefined)
 }
 
 const validateProvenanceMode = (
@@ -274,11 +283,21 @@ const loadedConfig = (
     if (alpaca === undefined) {
       return fail({ _tag: 'ExecutionCandidateDiscoveryRequiresAlpacaBinding' })
     }
+    const executionPrepareRequest = parsed.executionPrepareRequest
+    if (executionPrepareRequest === undefined) {
+      return fail({ _tag: 'ExecutionPrepareRequiresRequest' })
+    }
+    if (alpaca.environment !== BrokerEnvironment.Sandbox) {
+      return fail({
+        _tag: 'ExecutionPrepareRequiresSandboxBroker',
+        brokerEnvironment: alpaca.environment,
+      })
+    }
     return Result.succeed({
       ...common,
       runtimeMode: 'ExecutionPrepare',
       qualificationRunId,
-      executionPrepareRequest: parsed.executionPrepareRequest,
+      executionPrepareRequest,
       execution: execution as Extract<LoadedRuntimeConfig, { readonly runtimeMode: 'ExecutionPrepare' }>['execution'],
       alpaca,
     })

--- a/services/bayn/src/config/source.ts
+++ b/services/bayn/src/config/source.ts
@@ -5,6 +5,7 @@ import { BrokerEnvironment, BrokerEnvironmentSchema } from '../broker/identity'
 import { EvaluationBoundsSchema, IsoDateSchema, Sha256Schema } from '../contracts'
 import { BrokerAccess, BrokerAccessSchema } from '../execution/authority'
 import { CapitalAuthoritySelection } from '../execution/configuration'
+import { ExecutionPrepareRequestSchema } from '../execution-prepare/model'
 import {
   GitSourceRevisionSchema as SourceRevision,
   ImageDigestSchema as ImageDigest,
@@ -18,7 +19,11 @@ const ProvenanceMode = Schema.Literals(['production', 'development'])
 const RetryAttempts = Schema.Int.check(Schema.isBetween({ minimum: 0, maximum: 3 }))
 const OperationalThresholdMs = Schema.Int.check(Schema.isBetween({ minimum: 1_000, maximum: 86_400_000 }))
 const LegacyAuthorityTokenSchema = Schema.Literals(['OBSERVE', 'PAPER'])
-const RuntimeOperationTokenSchema = Schema.Literals(['EXECUTION_CANDIDATE_DISCOVERY', 'PAPER_CANDIDATE_DISCOVERY'])
+const RuntimeOperationTokenSchema = Schema.Literals([
+  'EXECUTION_CANDIDATE_DISCOVERY',
+  'PAPER_CANDIDATE_DISCOVERY',
+  'EXECUTION_PREPARE',
+])
 const CapitalAuthoritySelectionSchema = Schema.Enum(CapitalAuthoritySelection)
 
 const ReplicaAddresses = Schema.Trim.pipe(
@@ -43,7 +48,10 @@ const operationalThreshold = (name: string, fallback: number) =>
   Config.schema(OperationalThresholdMs, name).pipe(Config.withDefault(fallback))
 
 const runtimeOperation = Config.schema(RuntimeOperationTokenSchema, 'BAYN_OPERATION').pipe(
-  Config.map((): RuntimeOperation => 'ExecutionCandidateDiscovery'),
+  Config.map(
+    (operation): RuntimeOperation =>
+      operation === 'EXECUTION_PREPARE' ? 'ExecutionPrepare' : 'ExecutionCandidateDiscovery',
+  ),
 )
 
 export const runtimeConfigSource = Config.all({
@@ -57,6 +65,9 @@ export const runtimeConfigSource = Config.all({
   provenanceMode: Config.schema(ProvenanceMode, 'BAYN_PROVENANCE_MODE').pipe(Config.withDefault('production')),
   qualificationRunId: Config.option(Config.schema(Sha256Schema, 'BAYN_QUALIFICATION_RUN_ID')),
   operation: Config.option(runtimeOperation),
+  executionPrepareRequest: Config.option(
+    Config.schema(Schema.fromJsonString(ExecutionPrepareRequestSchema), 'BAYN_EXECUTION_PREPARE_REQUEST'),
+  ),
   legacyMaximumAuthority: Config.option(Config.schema(LegacyAuthorityTokenSchema, 'BAYN_MAXIMUM_AUTHORITY')),
   brokerAccess: Config.schema(BrokerAccessSchema, 'BAYN_BROKER_ACCESS').pipe(Config.withDefault(BrokerAccess.ReadOnly)),
   capitalAuthority: Config.schema(CapitalAuthoritySelectionSchema, 'BAYN_CAPITAL_AUTHORITY').pipe(
@@ -111,6 +122,7 @@ export const runtimeConfigSource = Config.all({
       port: config.port,
       qualificationRunId: Option.getOrUndefined(config.qualificationRunId),
       configuredOperation: Option.getOrUndefined(config.operation),
+      executionPrepareRequest: Option.getOrUndefined(config.executionPrepareRequest),
       legacyMaximumAuthority: Option.getOrUndefined(config.legacyMaximumAuthority),
       brokerAccess: config.brokerAccess,
       capitalAuthority: config.capitalAuthority,

--- a/services/bayn/src/entrypoint.ts
+++ b/services/bayn/src/entrypoint.ts
@@ -289,7 +289,7 @@ export const ExecutionCandidateDiscoveryResourcesLive = (plan: ApplicationPlanFo
 }
 
 export const ExecutionPrepareResourcesLive = (plan: ApplicationPlanFor<'ExecutionPrepare'>) => {
-  const postgres = PostgresAuthorityLive(plan.config)
+  const postgres = sqlResource(PostgresClientResourceLive(plan.config))
   const writerFence = WriterFenceResourceLive.pipe(Layer.provide(postgres))
   const executionPrepareStore = ExecutionPrepareStoreLive(plan.config).pipe(Layer.provide(postgres))
   return Layer.mergeAll(postgres, writerFence, executionPrepareStore, BrokerSessionResourceLive(plan.config)).pipe(

--- a/services/bayn/src/entrypoint.ts
+++ b/services/bayn/src/entrypoint.ts
@@ -41,7 +41,7 @@ import { makeExecutionProgram, type ExecutionProgram } from './execution/runtime
 import { renderRuntimeAuthorityFailure, resolveRuntimeAuthority } from './execution/runtime-authority'
 import type { FreshBrokerQuote } from './execution/mutation-authority'
 import { WriterFence, WriterFenceLive } from './execution/writer-fence'
-import { operationalError } from './errors'
+import { OperationalError, operationalError } from './errors'
 import { canonicalHashV1Result, type CanonicalJsonFailure } from './hash'
 import { HttpServerLive } from './http'
 import { Journal, JournalLive } from './ledger'
@@ -57,6 +57,12 @@ import {
   renderExecutionCandidateDiscoveryError,
   type ExecutionCandidateDiscoveryReceipt,
 } from './execution-candidate-discovery'
+import {
+  ExecutionPrepareStoreLive,
+  prepareExecution,
+  renderExecutionPrepareFailure,
+  type ExecutionPrepareReceipt,
+} from './execution-prepare'
 import { loadDefaultProtocol, type CausalProtocol } from './protocol'
 import { makeStrategy, type Strategy } from './strategy'
 import { currentUtcInstant } from './time'
@@ -280,6 +286,15 @@ export const ExecutionCandidateDiscoveryResourcesLive = (plan: ApplicationPlanFo
     CycleStoreResourceLive.pipe(Layer.provide(postgres)),
     BrokerSessionResourceLive(plan.config),
   ).pipe(Layer.provideMerge(ApplicationPlatformLive))
+}
+
+export const ExecutionPrepareResourcesLive = (plan: ApplicationPlanFor<'ExecutionPrepare'>) => {
+  const postgres = PostgresAuthorityLive(plan.config)
+  const writerFence = WriterFenceResourceLive.pipe(Layer.provide(postgres))
+  const executionPrepareStore = ExecutionPrepareStoreLive(plan.config).pipe(Layer.provide(postgres))
+  return Layer.mergeAll(postgres, writerFence, executionPrepareStore, BrokerSessionResourceLive(plan.config)).pipe(
+    Layer.provideMerge(ApplicationPlatformLive),
+  )
 }
 
 const applicationDependencies: Effect.Effect<
@@ -541,16 +556,28 @@ const writeDiscoveryReceipt = (receipt: ExecutionCandidateDiscoveryReceipt) =>
     ),
   )
 
-const policyHash = (policy: unknown): Effect.Effect<string, ReturnType<typeof operationalError>> =>
+const writeExecutionPrepareReceipt = (receipt: ExecutionPrepareReceipt) =>
+  pipe(
+    encodeJson(receipt),
+    Effect.mapError((cause) =>
+      operationalError('strategy', 'execution-prepare-output', 'EXECUTION_PREPARE receipt encoding failed', cause),
+    ),
+    Effect.flatMap((output) =>
+      pipe(
+        Stdio.Stdio,
+        Effect.flatMap((stdio) => Stream.run(Stream.make(`${output}\n`), stdio.stdout())),
+      ),
+    ),
+  )
+
+const policyHash = (
+  policy: unknown,
+  operation: 'paper-candidate-policy' | 'execution-prepare-policy',
+): Effect.Effect<string, ReturnType<typeof operationalError>> =>
   pipe(
     canonicalHashV1Result(policy),
     Result.mapError((cause) =>
-      operationalError(
-        'strategy',
-        'paper-candidate-policy',
-        'source-controlled OBSERVE risk policy canonicalization failed',
-        cause,
-      ),
+      operationalError('strategy', operation, 'source-controlled OBSERVE risk policy content hashing failed', cause),
     ),
     Effect.fromResult,
   )
@@ -595,10 +622,64 @@ const runExecutionCandidateDiscovery = (plan: ApplicationPlanFor<'ExecutionCandi
         cause,
       ),
     ),
-    Effect.flatMap(policyHash),
+    Effect.flatMap((policy) => policyHash(policy, 'paper-candidate-policy')),
     Effect.flatMap((riskPolicyHash) => discoverExecutionCandidate(plan, riskPolicyHash)),
     Effect.flatMap(writeDiscoveryReceipt),
   )
+
+const executionPrepareRuntimeBinding = (plan: ApplicationPlanFor<'ExecutionPrepare'>, riskPolicyHash: string) => ({
+  sourceRevision: plan.config.build.sourceRevision,
+  imageRepository: plan.config.build.imageRepository,
+  imageDigest: plan.config.build.imageDigest,
+  strategy: plan.strategy.provenance.strategy,
+  strategyProtocolHash: plan.strategyProtocolHash,
+  qualificationRunId: plan.config.qualificationRunId,
+  accountId: plan.config.alpaca.expectedAccountId,
+  brokerIdentityHash: plan.config.alpaca.identity.identityHash,
+  brokerProvider: plan.config.alpaca.identity.provider,
+  brokerEnvironment: plan.config.alpaca.identity.environment,
+  brokerAccess: plan.config.execution.brokerAccess,
+  capitalAuthority: plan.config.execution.capitalAuthority._tag,
+  authorityGenerationHash: plan.config.alpaca.authorityGenerationHash,
+  riskPolicyHash,
+})
+
+const runExecutionPrepare = (plan: ApplicationPlanFor<'ExecutionPrepare'>) =>
+  Effect.gen(function* () {
+    yield* BrokerSession
+    const riskPolicy = yield* loadObserveRiskPolicy(
+      plan.config.alpaca.expectedAccountId,
+      plan.strategy.parameters.universe,
+    ).pipe(
+      Effect.mapError((cause) =>
+        operationalError('config', 'execution-prepare', 'source-controlled OBSERVE risk policy is invalid', cause),
+      ),
+    )
+    const riskPolicyHash = yield* policyHash(riskPolicy, 'execution-prepare-policy')
+    const receipt = yield* prepareExecution(
+      plan.config.executionPrepareRequest,
+      executionPrepareRuntimeBinding(plan, riskPolicyHash),
+    ).pipe(
+      Effect.mapError((cause) =>
+        operationalError('strategy', 'execution-prepare', renderExecutionPrepareFailure(cause), { _tag: cause._tag }),
+      ),
+    )
+    yield* writeExecutionPrepareReceipt(receipt)
+  })
+
+export const executionPrepareBoundaryError = (cause: unknown): OperationalError =>
+  cause instanceof OperationalError
+    ? cause
+    : new OperationalError({
+        component: 'strategy',
+        operation: 'execution-prepare-resource',
+        message: 'EXECUTION_PREPARE resource acquisition failed closed',
+        retryable: false,
+        cause:
+          typeof cause === 'object' && cause !== null && '_tag' in cause && typeof cause._tag === 'string'
+            ? { _tag: cause._tag }
+            : { _tag: 'UnknownResourceFailure' },
+      })
 
 export const runApplicationPlan = pipe(
   Match.type<ApplicationPlan>(),
@@ -610,6 +691,12 @@ export const runApplicationPlan = pipe(
   ),
   Match.tag('ExecutionCandidateDiscovery', (plan) =>
     runExecutionCandidateDiscovery(plan).pipe(Effect.provide(ExecutionCandidateDiscoveryResourcesLive(plan))),
+  ),
+  Match.tag('ExecutionPrepare', (plan) =>
+    runExecutionPrepare(plan).pipe(
+      Effect.provide(ExecutionPrepareResourcesLive(plan)),
+      Effect.mapError(executionPrepareBoundaryError),
+    ),
   ),
   Match.exhaustive,
 )

--- a/services/bayn/src/entrypoint.ts
+++ b/services/bayn/src/entrypoint.ts
@@ -58,12 +58,14 @@ import {
   type ExecutionCandidateDiscoveryReceipt,
 } from './execution-candidate-discovery'
 import {
+  authenticateValidatedExecutionPrepare,
   ExecutionPrepareStoreLive,
   prepareValidatedExecution,
   renderExecutionPrepareFailure,
   validateExecutionPrepareInput,
+  type ExecutionPrepareFailure,
   type ExecutionPrepareReceipt,
-  type ValidatedExecutionPrepareInput,
+  type PrevalidatedExecutionPrepareInput,
 } from './execution-prepare'
 import { loadDefaultProtocol, type CausalProtocol } from './protocol'
 import { makeStrategy, type Strategy } from './strategy'
@@ -294,9 +296,14 @@ export const ExecutionPrepareResourcesLive = (plan: ApplicationPlanFor<'Executio
   const postgres = sqlResource(PostgresClientResourceLive(plan.config))
   const writerFence = WriterFenceResourceLive.pipe(Layer.provide(postgres))
   const executionPrepareStore = ExecutionPrepareStoreLive(plan.config).pipe(Layer.provide(postgres))
-  return Layer.mergeAll(postgres, writerFence, executionPrepareStore, BrokerSessionResourceLive(plan.config)).pipe(
-    Layer.provideMerge(ApplicationPlatformLive),
-  )
+  return Layer.mergeAll(
+    postgres,
+    writerFence,
+    executionPrepareStore,
+    CycleObservabilityResourceLive.pipe(Layer.provide(postgres)),
+    CycleStoreResourceLive.pipe(Layer.provide(postgres)),
+    BrokerSessionResourceLive(plan.config),
+  ).pipe(Layer.provideMerge(ApplicationPlatformLive))
 }
 
 const applicationDependencies: Effect.Effect<
@@ -646,6 +653,43 @@ const executionPrepareRuntimeBinding = (plan: ApplicationPlanFor<'ExecutionPrepa
   riskPolicyHash,
 })
 
+const executionPrepareCandidateIdentity = (plan: ApplicationPlanFor<'ExecutionPrepare'>, riskPolicyHash: string) => ({
+  sourceRevision: plan.config.build.sourceRevision,
+  image: {
+    repository: plan.config.build.imageRepository,
+    digest: plan.config.build.imageDigest,
+  },
+  strategy: plan.strategy.provenance.strategy,
+  strategyProtocolHash: plan.strategyProtocolHash,
+  qualificationRunId: plan.config.qualificationRunId,
+  accountId: plan.config.alpaca.expectedAccountId,
+  authorityGenerationHash: plan.config.alpaca.authorityGenerationHash,
+  policyHash: riskPolicyHash,
+})
+
+const executionPrepareOperationalCause = (cause: ExecutionPrepareFailure) => {
+  if (cause._tag !== 'ExecutionPrepareStoreRejected') return { _tag: cause._tag }
+  const nested = cause.cause.cause
+  return {
+    _tag: cause._tag,
+    operation: cause.operation,
+    failure: cause.failure,
+    nested:
+      typeof nested === 'object' && nested !== null && '_tag' in nested && typeof nested._tag === 'string'
+        ? nested._tag
+        : null,
+  }
+}
+
+const executionPrepareOperationalError = (cause: ExecutionPrepareFailure) =>
+  new OperationalError({
+    component: 'strategy',
+    operation: 'execution-prepare',
+    message: renderExecutionPrepareFailure(cause),
+    retryable: false,
+    cause: executionPrepareOperationalCause(cause),
+  })
+
 export const validateExecutionPreparePlan = (plan: ApplicationPlanFor<'ExecutionPrepare'>) =>
   Effect.gen(function* () {
     const riskPolicy = yield* loadObserveRiskPolicy(
@@ -662,21 +706,33 @@ export const validateExecutionPreparePlan = (plan: ApplicationPlanFor<'Execution
         plan.config.executionPrepareRequest,
         executionPrepareRuntimeBinding(plan, riskPolicyHash),
       ),
-    ).pipe(
-      Effect.mapError((cause) =>
-        operationalError('strategy', 'execution-prepare', renderExecutionPrepareFailure(cause), { _tag: cause._tag }),
-      ),
-    )
+    ).pipe(Effect.mapError(executionPrepareOperationalError))
   })
 
-const runExecutionPrepare = (validated: ValidatedExecutionPrepareInput) =>
+const runExecutionPrepare = (
+  plan: ApplicationPlanFor<'ExecutionPrepare'>,
+  prevalidated: PrevalidatedExecutionPrepareInput,
+) =>
   Effect.gen(function* () {
     yield* BrokerSession
-    const receipt = yield* prepareValidatedExecution(validated).pipe(
-      Effect.mapError((cause) =>
-        operationalError('strategy', 'execution-prepare', renderExecutionPrepareFailure(cause), { _tag: cause._tag }),
+    const trustedReceipt = yield* discoverExecutionCandidatesHistoricalCodec(
+      executionPrepareCandidateIdentity(plan, prevalidated.runtime.riskPolicyHash),
+    ).pipe(
+      Effect.mapError(
+        (cause) =>
+          new OperationalError({
+            component: 'strategy',
+            operation: 'execution-prepare-discovery',
+            message: renderExecutionCandidateDiscoveryError(cause),
+            retryable: false,
+            cause: { _tag: cause._tag },
+          }),
       ),
     )
+    const validated = yield* authenticateValidatedExecutionPrepare(prevalidated, trustedReceipt).pipe(
+      Effect.mapError(executionPrepareOperationalError),
+    )
+    const receipt = yield* prepareValidatedExecution(validated).pipe(Effect.mapError(executionPrepareOperationalError))
     yield* writeExecutionPrepareReceipt(receipt)
   })
 
@@ -708,7 +764,7 @@ export const runApplicationPlan = pipe(
   Match.tag('ExecutionPrepare', (plan) =>
     validateExecutionPreparePlan(plan).pipe(
       Effect.flatMap((validated) =>
-        runExecutionPrepare(validated).pipe(Effect.provide(ExecutionPrepareResourcesLive(plan))),
+        runExecutionPrepare(plan, validated).pipe(Effect.provide(ExecutionPrepareResourcesLive(plan))),
       ),
       Effect.mapError(executionPrepareBoundaryError),
     ),

--- a/services/bayn/src/entrypoint.ts
+++ b/services/bayn/src/entrypoint.ts
@@ -59,9 +59,11 @@ import {
 } from './execution-candidate-discovery'
 import {
   ExecutionPrepareStoreLive,
-  prepareExecution,
+  prepareValidatedExecution,
   renderExecutionPrepareFailure,
+  validateExecutionPrepareInput,
   type ExecutionPrepareReceipt,
+  type ValidatedExecutionPrepareInput,
 } from './execution-prepare'
 import { loadDefaultProtocol, type CausalProtocol } from './protocol'
 import { makeStrategy, type Strategy } from './strategy'
@@ -644,9 +646,8 @@ const executionPrepareRuntimeBinding = (plan: ApplicationPlanFor<'ExecutionPrepa
   riskPolicyHash,
 })
 
-const runExecutionPrepare = (plan: ApplicationPlanFor<'ExecutionPrepare'>) =>
+export const validateExecutionPreparePlan = (plan: ApplicationPlanFor<'ExecutionPrepare'>) =>
   Effect.gen(function* () {
-    yield* BrokerSession
     const riskPolicy = yield* loadObserveRiskPolicy(
       plan.config.alpaca.expectedAccountId,
       plan.strategy.parameters.universe,
@@ -656,10 +657,22 @@ const runExecutionPrepare = (plan: ApplicationPlanFor<'ExecutionPrepare'>) =>
       ),
     )
     const riskPolicyHash = yield* policyHash(riskPolicy, 'execution-prepare-policy')
-    const receipt = yield* prepareExecution(
-      plan.config.executionPrepareRequest,
-      executionPrepareRuntimeBinding(plan, riskPolicyHash),
+    return yield* Effect.fromResult(
+      validateExecutionPrepareInput(
+        plan.config.executionPrepareRequest,
+        executionPrepareRuntimeBinding(plan, riskPolicyHash),
+      ),
     ).pipe(
+      Effect.mapError((cause) =>
+        operationalError('strategy', 'execution-prepare', renderExecutionPrepareFailure(cause), { _tag: cause._tag }),
+      ),
+    )
+  })
+
+const runExecutionPrepare = (validated: ValidatedExecutionPrepareInput) =>
+  Effect.gen(function* () {
+    yield* BrokerSession
+    const receipt = yield* prepareValidatedExecution(validated).pipe(
       Effect.mapError((cause) =>
         operationalError('strategy', 'execution-prepare', renderExecutionPrepareFailure(cause), { _tag: cause._tag }),
       ),
@@ -693,8 +706,10 @@ export const runApplicationPlan = pipe(
     runExecutionCandidateDiscovery(plan).pipe(Effect.provide(ExecutionCandidateDiscoveryResourcesLive(plan))),
   ),
   Match.tag('ExecutionPrepare', (plan) =>
-    runExecutionPrepare(plan).pipe(
-      Effect.provide(ExecutionPrepareResourcesLive(plan)),
+    validateExecutionPreparePlan(plan).pipe(
+      Effect.flatMap((validated) =>
+        runExecutionPrepare(validated).pipe(Effect.provide(ExecutionPrepareResourcesLive(plan))),
+      ),
       Effect.mapError(executionPrepareBoundaryError),
     ),
   ),

--- a/services/bayn/src/execution-prepare/execution-prepare.integration.test.ts
+++ b/services/bayn/src/execution-prepare/execution-prepare.integration.test.ts
@@ -34,6 +34,7 @@ import { fixtureProtocol } from '../test-fixtures'
 import type { ExecutionPrepareRequest, ExecutionPrepareRuntimeBinding } from './model'
 import { ExecutionPrepareStoreLive } from './live'
 import { prepareExecution } from './program'
+import { makeExecutionPrepareDiscoveryReceiptFixture } from './test-fixture'
 
 const postgresUrl = process.env.BAYN_TEST_POSTGRES_URL
 const testUrl = postgresUrl ?? 'postgresql://bayn:bayn@127.0.0.1:5432/bayn_test'
@@ -465,42 +466,58 @@ const makeRequest = (
   reconciliation: ReconciliationFixture,
   overrides: Partial<ExecutionPrepareRequest['proofPlan']['binding']> = {},
 ): ExecutionPrepareRequest => {
+  const binding = {
+    activationSourceRevision: sourceRevision,
+    activationImageRepository: imageRepository,
+    activationImageDigest: imageDigest,
+    qualificationSourceRevision: fixture.lock.sourceRevision,
+    qualificationImageRepository: fixture.lock.image.repository,
+    qualificationImageDigest: fixture.lock.image.digest,
+    strategy,
+    strategyProtocolHash,
+    qualificationRunId: fixture.result.runId,
+    qualificationLockId: fixture.lock.lockId,
+    qualificationResultHash: fixture.result.resultHash,
+    protocolHash: fixture.lock.protocolHash,
+    qualificationExecutionPolicyHash: fixture.lock.policies.execution.contentHash,
+    accountId,
+    brokerIdentityHash: brokerIdentity.identityHash,
+    authorityGenerationHash: baseConfig.alpaca!.authorityGenerationHash,
+    riskPolicyHash: hash('risk-policy'),
+    reconciliationId: reconciliation.reconciliationId,
+    reconciliationContentHash: reconciliation.contentHash,
+    ...overrides,
+  }
+  const discoveryReceipt = makeExecutionPrepareDiscoveryReceiptFixture({
+    sourceRevision: binding.activationSourceRevision,
+    imageRepository: binding.activationImageRepository,
+    imageDigest: binding.activationImageDigest,
+    strategy: binding.strategy,
+    strategyProtocolHash: binding.strategyProtocolHash,
+    qualificationRunId: binding.qualificationRunId,
+    accountId: binding.accountId,
+    authorityGenerationHash: binding.authorityGenerationHash,
+    policyHash: binding.riskPolicyHash,
+    reconciliationId: binding.reconciliationId,
+    reconciliationContentHash: binding.reconciliationContentHash,
+  })
+  const discoveredCandidate = discoveryReceipt.candidateFacts.candidates[0]!
   const proofPlan = {
     schemaVersion: 'bayn.execution-prepare-proof-plan.v1' as const,
     candidate: {
-      discoveryReceiptHash: hash('discovery-receipt'),
-      immutableBindingHash: hash('immutable-binding'),
-      candidateFactsHash: hash('candidate-facts'),
-      candidateOrdinal: 0,
-      observedPlanIntentId: hash('observed-plan-intent'),
-      cycleId: hash('candidate-cycle'),
-      decisionHash: hash('candidate-decision'),
+      discoveryReceiptHash: discoveryReceipt.observationReceiptHash,
+      immutableBindingHash: discoveryReceipt.immutableBindingHash,
+      candidateFactsHash: discoveryReceipt.candidateFactsHash,
+      candidateOrdinal: discoveredCandidate.ordinal,
+      observedPlanIntentId: discoveredCandidate.observedPlanIntentId,
+      cycleId: discoveryReceipt.binding.cycle.cycleId,
+      decisionHash: discoveryReceipt.binding.cycle.decisionHash,
     },
-    binding: {
-      activationSourceRevision: sourceRevision,
-      activationImageRepository: imageRepository,
-      activationImageDigest: imageDigest,
-      qualificationSourceRevision: fixture.lock.sourceRevision,
-      qualificationImageRepository: fixture.lock.image.repository,
-      qualificationImageDigest: fixture.lock.image.digest,
-      strategy,
-      strategyProtocolHash,
-      qualificationRunId: fixture.result.runId,
-      qualificationLockId: fixture.lock.lockId,
-      qualificationResultHash: fixture.result.resultHash,
-      protocolHash: fixture.lock.protocolHash,
-      qualificationExecutionPolicyHash: fixture.lock.policies.execution.contentHash,
-      accountId,
-      brokerIdentityHash: brokerIdentity.identityHash,
-      authorityGenerationHash: baseConfig.alpaca!.authorityGenerationHash,
-      riskPolicyHash: hash('risk-policy'),
-      reconciliationId: reconciliation.reconciliationId,
-      reconciliationContentHash: reconciliation.contentHash,
-      ...overrides,
-    },
+    binding,
   }
   return {
     schemaVersion: 'bayn.execution-prepare-request.v1',
+    discoveryReceipt,
     proofPlan,
     proofPlanHash: canonicalHashV1OrThrow(proofPlan),
   }
@@ -731,6 +748,13 @@ describePostgres('EXECUTION_PREPARE PostgreSQL boundary', () => {
         Effect.gen(function* () {
           yield* prepareFixture(fixture, reconciliation)
           const before = yield* durableSnapshot
+          const mixedProofPlan = {
+            ...request.proofPlan,
+            candidate: {
+              ...request.proofPlan.candidate,
+              observedPlanIntentId: hash('foreign-observed-plan-intent'),
+            },
+          }
           const candidates: readonly [unknown, unknown][] = [
             [{ ...request, unexpected: true }, runtimeBinding(fixture, request)],
             [request, { ...runtimeBinding(fixture, request), accountId: 'drifted-account' }],
@@ -744,6 +768,21 @@ describePostgres('EXECUTION_PREPARE PostgreSQL boundary', () => {
             ],
             [request, { ...runtimeBinding(fixture, request), riskPolicyHash: hash('drifted-policy') }],
             [{ ...request, proofPlanHash: hash('drifted-proof') }, runtimeBinding(fixture, request)],
+            [
+              {
+                ...request,
+                proofPlan: mixedProofPlan,
+                proofPlanHash: canonicalHashV1OrThrow(mixedProofPlan),
+              },
+              runtimeBinding(fixture, request),
+            ],
+            [
+              {
+                ...request,
+                discoveryReceipt: { ...request.discoveryReceipt, observationReceiptHash: hash('tampered-receipt') },
+              },
+              runtimeBinding(fixture, request),
+            ],
           ]
           const failures = []
           for (const [candidateRequest, candidateRuntime] of candidates) {
@@ -760,6 +799,8 @@ describePostgres('EXECUTION_PREPARE PostgreSQL boundary', () => {
         'ExecutionPrepareRuntimeMismatch',
         'ExecutionPrepareRuntimeMismatch',
         'ExecutionPrepareProofPlanHashMismatch',
+        'ExecutionPrepareDiscoveryMismatch',
+        'ExecutionPrepareDiscoveryMismatch',
       ])
       expect(result.after).toEqual(result.before)
     } finally {

--- a/services/bayn/src/execution-prepare/execution-prepare.integration.test.ts
+++ b/services/bayn/src/execution-prepare/execution-prepare.integration.test.ts
@@ -1,0 +1,728 @@
+import assert from 'node:assert/strict'
+
+import { beforeAll, beforeEach, describe, expect, test } from 'bun:test'
+
+import { NodeServices } from '@effect/platform-node'
+import { PgClient } from '@effect/sql-pg'
+import { Effect, Layer, ManagedRuntime, Redacted, Result } from 'effect'
+
+import { BrokerProvider, alpacaSandboxBaseUrl } from '../broker/alpaca'
+import { makeBrokerIdentity } from '../broker/identity'
+import type { RuntimeConfig } from '../config'
+import { makeStrategyProtocolHash } from '../contracts'
+import { makeAuthorityPostgres } from '../db/execution-store/authority-shared'
+import { makeObserveAuthorityInterpreter } from '../db/execution-store/observe-authority'
+import { EvidenceStore, EvidenceStoreFromPostgres, PostgresClientLive } from '../db/evidence-store'
+import { BrokerAccess, BrokerEnvironment, CapitalAuthorityKind, noCapitalAuthority } from '../execution/authority'
+import { Authority } from '../execution/contracts'
+import { WriterFenceLive } from '../execution/writer-fence'
+import { canonicalHashV1OrThrow } from '../hash'
+import {
+  defaultQualificationStatisticsPolicyDocument,
+  makeQualificationLock,
+  makeQualificationPolicyDocument,
+  makeQualificationResult,
+  type QualificationLock,
+  type QualificationResult,
+} from '../qualification'
+import {
+  analyzeQualification,
+  defaultQualificationStatisticsPolicy,
+  type QualificationSeries,
+} from '../qualification-statistics'
+import { fixtureProtocol } from '../test-fixtures'
+import type { ExecutionPrepareRequest, ExecutionPrepareRuntimeBinding } from './model'
+import { ExecutionPrepareStoreLive } from './live'
+import { prepareExecution } from './program'
+
+const postgresUrl = process.env.BAYN_TEST_POSTGRES_URL
+const testUrl = postgresUrl ?? 'postgresql://bayn:bayn@127.0.0.1:5432/bayn_test'
+const describePostgres = postgresUrl === undefined ? describe.skip : describe
+const accountId = 'execution-prepare-account'
+const sourceRevision = 'a'.repeat(40)
+const imageRepository = 'registry.ide-newton.ts.net/lab/bayn'
+const imageDigest = `sha256:${'b'.repeat(64)}` as const
+const qualificationSourceRevision = 'c'.repeat(40)
+const qualificationImageDigest = `sha256:${'d'.repeat(64)}` as const
+const hash = (value: string): string => canonicalHashV1OrThrow({ value })
+
+const success = <A, E>(result: Result.Result<A, E>): A => {
+  assert(Result.isSuccess(result), 'fixture construction must succeed')
+  return result.success
+}
+
+const brokerIdentity = Result.getOrThrow(
+  makeBrokerIdentity({
+    schemaVersion: 'bayn.broker-identity.v2',
+    provider: BrokerProvider.Alpaca,
+    environment: BrokerEnvironment.Sandbox,
+    accountId,
+  }),
+)
+
+const strategy = {
+  name: 'risk-balanced-trend' as const,
+  behaviorHash: hash('strategy-behavior'),
+  parameterHash: canonicalHashV1OrThrow(fixtureProtocol),
+  parameterSchemaVersion: fixtureProtocol.schemaVersion,
+}
+const strategyProtocolHash = makeStrategyProtocolHash(strategy)
+
+const baseConfig: RuntimeConfig = {
+  host: '127.0.0.1',
+  port: 8080,
+  execution: {
+    brokerIdentity,
+    brokerAccess: BrokerAccess.ReadOnly,
+    capitalAuthority: noCapitalAuthority,
+  },
+  build: {
+    sourceRevision,
+    imageRepository,
+    imageDigest,
+    strategyBehaviorHash: strategy.behaviorHash,
+    strategyParameterHash: strategy.parameterHash,
+    verification: 'embedded',
+  },
+  healthIntervalMs: 30_000,
+  operationTimeoutMs: 5_000,
+  cycleStallThresholdMs: 300_000,
+  reconciliationStaleThresholdMs: 120_000,
+  unknownMutationThresholdMs: 300_000,
+  alpaca: {
+    provider: BrokerProvider.Alpaca,
+    environment: BrokerEnvironment.Sandbox,
+    identity: brokerIdentity,
+    baseUrl: alpacaSandboxBaseUrl,
+    expectedAccountId: accountId,
+    authorityGenerationHash: hash('observe-generation'),
+    key: Redacted.make('unused-key'),
+    secret: Redacted.make('unused-secret'),
+    proxyUrl: 'http://bayn-egress-proxy.invalid',
+    operationTimeoutMs: 5_000,
+    retryAttempts: 0,
+    reconciliationIntervalMs: 30_000,
+  },
+  clickhouse: {
+    url: 'http://clickhouse.invalid',
+    username: 'bayn',
+    password: Redacted.make('unused'),
+    snapshotId: hash('configured-snapshot'),
+    publicationAsOf: '2026-07-21',
+    calendarVersion: 'alpaca-us-equity-calendar-v1',
+    bounds: {
+      schemaVersion: 'bayn.evaluation-bounds.v1',
+      dataStart: '2016-01-04',
+      dataEnd: '2026-07-21',
+      lookbackStart: '2016-01-04',
+      evaluationStart: '2017-01-03',
+      evaluationEnd: '2026-07-21',
+    },
+  },
+  postgres: { url: Redacted.make(testUrl), tls: false, caPath: '/unused' },
+  tigerBeetle: { clusterId: 2_001n, replicaAddresses: ['127.0.0.1:3000'], ledger: 7_001 },
+}
+
+const runtimeConfig = (qualificationRunId: string): RuntimeConfig => ({
+  ...baseConfig,
+  qualificationRunId,
+})
+
+const makeRuntime = (qualificationRunId: string) => {
+  const config = runtimeConfig(qualificationRunId)
+  return ManagedRuntime.make(
+    ExecutionPrepareStoreLive(config).pipe(
+      Layer.provideMerge(WriterFenceLive),
+      Layer.provideMerge(PostgresClientLive(config)),
+      Layer.provide(NodeServices.layer),
+    ),
+  )
+}
+
+const makeClientRuntime = () =>
+  ManagedRuntime.make(PostgresClientLive(baseConfig).pipe(Layer.provide(NodeServices.layer)))
+
+const makeEvidenceRuntime = () =>
+  ManagedRuntime.make(
+    EvidenceStoreFromPostgres(baseConfig).pipe(
+      Layer.provideMerge(PostgresClientLive(baseConfig)),
+      Layer.provide(NodeServices.layer),
+    ),
+  )
+
+const qualificationPolicy = (name: string) =>
+  success(
+    makeQualificationPolicyDocument(`bayn.${name}.v1`, {
+      schemaVersion: `bayn.${name}.v1`,
+      enabled: true,
+    }),
+  )
+
+const qualificationSeries = (runId: string): QualificationSeries => {
+  const sessionDate = (index: number): `${number}-${number}-${number}` => {
+    const date = new Date('2000-01-01T00:00:00.000Z')
+    date.setUTCDate(date.getUTCDate() + index)
+    return date.toISOString().slice(0, 10) as `${number}-${number}-${number}`
+  }
+  const blockCount = 90
+  return {
+    schemaVersion: 'bayn.qualification-series.v1',
+    runId,
+    observations: Array.from({ length: blockCount * 21 + 10 }, (_, index) => {
+      const noise = (((index * 17) % 23) - 11) / 100_000
+      return {
+        sessionDate: sessionDate(index),
+        strategyReturn: 0.0005 + noise,
+        cashReturn: 0,
+        buyAndHoldReturn: 0.00015 + noise * 1.1,
+        directVolatilityReturn: 0.0001 + noise * 0.8,
+      }
+    }),
+    rebalanceExecutionDates: Array.from({ length: blockCount + 1 }, (_, index) => sessionDate(index * 21)),
+  }
+}
+
+interface QualificationFixture {
+  readonly lock: QualificationLock
+  readonly result: QualificationResult
+}
+
+const qualificationFixture = (name: string, qualified: boolean): QualificationFixture => {
+  const runId = hash(`${name}-run`)
+  const snapshotId = hash(`${name}-snapshot`)
+  const lock = success(
+    makeQualificationLock({
+      schemaVersion: 'bayn.qualification-lock.v3',
+      candidateRunId: runId,
+      protocolHash: strategyProtocolHash,
+      sourceRevision: qualificationSourceRevision,
+      image: { repository: imageRepository, digest: qualificationImageDigest },
+      universeId: fixtureProtocol.universeId,
+      universeSymbolHash: fixtureProtocol.universeSymbolHash,
+      universe: fixtureProtocol.universe,
+      universeRationale: 'Precommitted universe for the bounded EXECUTION_PREPARE integration proof.',
+      data: {
+        snapshotId,
+        publicationId: hash(`${name}-publication`),
+        inputManifestHash: hash(`${name}-manifest`),
+        contentHash: hash(`${name}-content`),
+        sessionsContentHash: hash(`${name}-sessions`),
+        provider: 'alpaca',
+        sourceFeed: 'sip',
+        adjustment: 'all',
+        calendarVersion: 'alpaca-us-equity-calendar-v1',
+        firstSession: '2016-01-04',
+        lastSession: '2026-07-21',
+        selectedSessionCount: 1_900,
+        selectedRebalanceCount: 91,
+        bounds: baseConfig.clickhouse.bounds,
+      },
+      policies: {
+        benchmark: qualificationPolicy(`${name}-benchmark`),
+        thresholds: qualificationPolicy(`${name}-thresholds`),
+        uncertainty: success(defaultQualificationStatisticsPolicyDocument),
+        execution: success(
+          makeQualificationPolicyDocument(fixtureProtocol.executionModel.schemaVersion, fixtureProtocol.executionModel),
+        ),
+      },
+      priorTrialRunIds: [],
+    }),
+  )
+  const analysis = success(analyzeQualification(qualificationSeries(runId), defaultQualificationStatisticsPolicy, []))
+  const evaluationVerdict = qualified
+    ? {
+        status: 'PASS' as const,
+        gates: [{ name: 'execution_prepare_fixture', passed: true, actual: 1, required: 1 }],
+      }
+    : {
+        status: 'FAIL_CLOSED' as const,
+        gates: [{ name: 'execution_prepare_fixture', passed: false, actual: 0, required: 1 }],
+      }
+  return {
+    lock,
+    result: success(makeQualificationResult(lock, evaluationVerdict, analysis)),
+  }
+}
+
+const seedQualification = (fixture: QualificationFixture) =>
+  Effect.gen(function* () {
+    const sql = yield* PgClient.PgClient
+    const { lock, result } = fixture
+    yield* sql`
+      INSERT INTO protocol_locks (
+        protocol_hash, schema_version, strategy_name, behavior_hash, parameter_hash, parameters
+      ) VALUES (
+        ${lock.protocolHash}, ${fixtureProtocol.schemaVersion}, ${strategy.name},
+        ${strategy.behaviorHash}, ${strategy.parameterHash}, ${sql.json(fixtureProtocol)}
+      )
+      ON CONFLICT (protocol_hash) DO NOTHING
+    `
+    yield* sql`
+      INSERT INTO snapshot_references (
+        snapshot_id, schema_version, database_name, table_name, dataset_version, source,
+        source_feed, adjustment, content_hash, row_count, first_session, last_session, manifest
+      ) VALUES (
+        ${lock.data.snapshotId}, 'bayn.finalized-snapshot.v3', 'signal', 'adjusted_daily_bars_v2',
+        'signal.adjusted-daily-snapshot.v2', 'alpaca', 'sip', 'all', ${lock.data.contentHash},
+        ${lock.data.selectedSessionCount * lock.universe.length}, ${lock.data.firstSession},
+        ${lock.data.lastSession}, ${sql.json(lock.data)}
+      )
+    `
+    yield* sql`
+      INSERT INTO evaluation_runs (
+        run_id, protocol_hash, snapshot_id, evaluation_schema_version, source_revision,
+        image_repository, image_digest, strategy_name, initial_capital_micros,
+        expected_artifact_count, expected_event_count, expected_gate_count, status, completed_at
+      ) VALUES (
+        ${result.runId}, ${lock.protocolHash}, ${lock.data.snapshotId}, 'bayn.evaluation.v6',
+        ${lock.sourceRevision}, ${lock.image.repository}, ${lock.image.digest}, ${strategy.name},
+        1000000000000, 1, 0, 1, 'COMPLETE', clock_timestamp()
+      )
+    `
+    yield* sql`
+      INSERT INTO evaluation_artifacts (run_id, artifact_name, schema_version, content_hash, payload)
+      VALUES (
+        ${result.runId}, 'qualification-artifact-manifest', 'bayn.qualification-artifact-manifest.v1',
+        ${hash(`${result.runId}-artifact`)}, ${sql.json({ runId: result.runId })}
+      )
+    `
+    yield* sql`
+      INSERT INTO gate_outcomes (run_id, ordinal, gate_name, passed, actual, required, content_hash)
+      VALUES (
+        ${result.runId}, 0, 'execution_prepare_fixture', ${result.evaluationVerdict.gates[0].passed},
+        ${sql.json(JSON.stringify(result.evaluationVerdict.gates[0].actual))},
+        ${sql.json(JSON.stringify(result.evaluationVerdict.gates[0].required))},
+        ${hash(`${result.runId}-gate`)}
+      )
+    `
+    yield* sql`
+      INSERT INTO status_history (run_id, status, detail)
+      VALUES
+        (${result.runId}, 'WRITING', ${sql.json({ artifactCount: 1, eventCount: 0, gateCount: 1 })}),
+        (
+          ${result.runId}, 'COMPLETE',
+          ${sql.json({ reconciliationExact: true, verdict: result.evaluationVerdict.status })}
+        )
+    `
+    yield* sql`
+      INSERT INTO qualification_locks (
+        lock_id, schema_version, candidate_run_id, protocol_hash, snapshot_id,
+        source_revision, image_repository, image_digest, payload
+      ) VALUES (
+        ${lock.lockId}, ${lock.schemaVersion}, ${lock.candidateRunId}, ${lock.protocolHash},
+        ${lock.data.snapshotId}, ${lock.sourceRevision}, ${lock.image.repository},
+        ${lock.image.digest}, ${sql.json(lock)}
+      )
+    `
+    yield* sql`
+      INSERT INTO qualification_results (
+        lock_id, schema_version, run_id, verdict, analysis_hash, result_hash, payload
+      ) VALUES (
+        ${result.lockId}, ${result.schemaVersion}, ${result.runId}, ${result.verdict},
+        ${result.analysis.analysisHash}, ${result.resultHash}, ${sql.json(result)}
+      )
+    `
+  })
+
+interface ReconciliationFixture {
+  readonly reconciliationId: string
+  readonly contentHash: string
+  readonly ageMs: number
+  readonly exact: boolean
+}
+
+const reconciliationFixture = (
+  name: string,
+  overrides: Partial<ReconciliationFixture> = {},
+): ReconciliationFixture => ({
+  reconciliationId: hash(`${name}-reconciliation`),
+  contentHash: hash(`${name}-reconciliation-content`),
+  ageMs: 0,
+  exact: true,
+  ...overrides,
+})
+
+const seedReconciliation = (fixture: ReconciliationFixture) =>
+  Effect.gen(function* () {
+    const sql = yield* PgClient.PgClient
+    const expectedHash = hash(`${fixture.reconciliationId}-expected`)
+    const observedHash = fixture.exact ? expectedHash : hash(`${fixture.reconciliationId}-observed`)
+    const discrepancies = fixture.exact
+      ? []
+      : [
+          {
+            discrepancyId: hash(`${fixture.reconciliationId}-discrepancy`),
+            kind: 'ACCOUNT',
+            identity: accountId,
+            expected: 'expected',
+            observed: 'observed',
+            evidenceHash: hash(`${fixture.reconciliationId}-evidence`),
+            firstObservedAt: '2026-07-22T15:30:00.000Z',
+            lastObservedAt: '2026-07-22T15:30:00.000Z',
+          },
+        ]
+    yield* sql`
+      INSERT INTO reconciliations (
+        reconciliation_id, schema_version, account_id, expected_hash, observed_hash,
+        content_hash, status, discrepancies, reconciled_at
+      ) VALUES (
+        ${fixture.reconciliationId}, 'bayn.paper-reconciliation.v1', ${accountId},
+        ${expectedHash}, ${observedHash}, ${fixture.contentHash}, ${fixture.exact ? 'EXACT' : 'DISCREPANCY'},
+        ${sql.json(JSON.stringify(discrepancies))},
+        clock_timestamp() - (${fixture.ageMs} * interval '1 millisecond')
+      )
+    `
+  })
+
+const seedUnresolvedMutation = (authorityGenerationHash: string) =>
+  Effect.gen(function* () {
+    const sql = yield* PgClient.PgClient
+    const intentId = hash('unresolved-intent')
+    const decisionId = hash('unresolved-decision')
+    yield* sql`
+      INSERT INTO intents (
+        intent_id, schema_version, authority_generation_hash, account_id, client_order_id, symbol, side,
+        order_type, time_in_force, quantity_micros, notional_limit_micros,
+        state, terminal_outcome, state_version, created_at, updated_at,
+        strategy_name, cycle_id, decision_hash, policy_hash
+      ) VALUES (
+        ${intentId}, 'bayn.paper-intent.v3', ${authorityGenerationHash}, ${accountId},
+        'execution-prepare-unresolved', 'SPY', 'BUY', 'MARKET', 'DAY', 1000000, 100000000,
+        'PLANNED', NULL, 1, '2026-07-22T15:30:00.000Z', '2026-07-22T15:30:00.000Z',
+        ${strategy.name}, ${hash('unresolved-cycle')}, ${hash('unresolved-plan')}, ${hash('unresolved-policy')}
+      )
+    `
+    yield* sql.withTransaction(
+      Effect.gen(function* () {
+        yield* sql`
+          INSERT INTO risk_decisions (
+            decision_id, schema_version, input_hash, intent_id, policy_hash,
+            outcome, reason_codes, decided_at, expires_at
+          ) VALUES (
+            ${decisionId}, 'bayn.paper-risk-decision.v1', ${hash('unresolved-input')}, ${intentId},
+            ${hash('unresolved-policy')}, 'APPROVED', ARRAY[]::text[],
+            '2026-07-22T15:30:00.001Z', '2099-01-01T00:00:00.000Z'
+          )
+        `
+        yield* sql`
+          UPDATE intents
+          SET risk_decision_id = ${decisionId}, state = 'APPROVED', state_version = 2,
+              updated_at = '2026-07-22T15:30:00.002Z'
+          WHERE intent_id = ${intentId}
+        `
+        yield* sql`
+          INSERT INTO mutation_events (
+            event_id, schema_version, mutation_id, intent_id, sequence, operation,
+            event_type, request_hash, consistency_delay_ms, broker_order_id,
+            request_id, response_status, response_content_hash, occurred_at
+          ) VALUES (
+            ${hash('unresolved-submit-started')}, 'bayn.paper-mutation-event.v1',
+            ${hash('unresolved-submit')}, ${intentId}, 1, 'SUBMIT', 'SUBMIT_STARTED',
+            ${hash('unresolved-request')}, 1000, NULL, NULL, NULL, NULL,
+            '2026-07-22T15:30:01.000Z'
+          )
+        `
+        yield* sql`
+          UPDATE intents
+          SET state = 'IO_STARTED', state_version = 3, updated_at = '2026-07-22T15:30:01.000Z'
+          WHERE intent_id = ${intentId}
+        `
+      }),
+    )
+  })
+
+interface DurableSnapshot {
+  readonly authorityState: readonly Readonly<Record<string, unknown>>[] | null
+  readonly authorityHistory: readonly Readonly<Record<string, unknown>>[] | null
+  readonly intents: number
+  readonly mutations: number
+}
+
+const durableSnapshot = Effect.gen(function* () {
+  const sql = yield* PgClient.PgClient
+  const [snapshot] = yield* sql<DurableSnapshot>`
+    SELECT
+      (SELECT jsonb_agg(to_jsonb(state) || jsonb_build_object('tupleId', state.xmin::text)) FROM authority_state state)
+        AS "authorityState",
+      (
+        SELECT jsonb_agg(to_jsonb(history) || jsonb_build_object('tupleId', history.xmin::text)
+          ORDER BY history.authority_version)
+        FROM authority_generations history
+      ) AS "authorityHistory",
+      (SELECT count(*)::integer FROM intents) AS intents,
+      (SELECT count(*)::integer FROM mutation_events) AS mutations
+  `
+  return {
+    authorityState: snapshot.authorityState,
+    authorityHistory: snapshot.authorityHistory,
+    intents: snapshot.intents,
+    mutations: snapshot.mutations,
+  }
+})
+
+const makeRequest = (
+  fixture: QualificationFixture,
+  reconciliation: ReconciliationFixture,
+  overrides: Partial<ExecutionPrepareRequest['proofPlan']['binding']> = {},
+): ExecutionPrepareRequest => {
+  const proofPlan = {
+    schemaVersion: 'bayn.execution-prepare-proof-plan.v1' as const,
+    candidate: {
+      discoveryReceiptHash: hash('discovery-receipt'),
+      immutableBindingHash: hash('immutable-binding'),
+      candidateFactsHash: hash('candidate-facts'),
+      candidateOrdinal: 0,
+      observedPlanIntentId: hash('observed-plan-intent'),
+      cycleId: hash('candidate-cycle'),
+      decisionHash: hash('candidate-decision'),
+    },
+    binding: {
+      activationSourceRevision: sourceRevision,
+      activationImageRepository: imageRepository,
+      activationImageDigest: imageDigest,
+      qualificationSourceRevision: fixture.lock.sourceRevision,
+      qualificationImageRepository: fixture.lock.image.repository,
+      qualificationImageDigest: fixture.lock.image.digest,
+      strategy,
+      strategyProtocolHash,
+      qualificationRunId: fixture.result.runId,
+      qualificationLockId: fixture.lock.lockId,
+      qualificationResultHash: fixture.result.resultHash,
+      protocolHash: fixture.lock.protocolHash,
+      qualificationExecutionPolicyHash: fixture.lock.policies.execution.contentHash,
+      accountId,
+      brokerIdentityHash: brokerIdentity.identityHash,
+      authorityGenerationHash: baseConfig.alpaca!.authorityGenerationHash,
+      riskPolicyHash: hash('risk-policy'),
+      reconciliationId: reconciliation.reconciliationId,
+      reconciliationContentHash: reconciliation.contentHash,
+      ...overrides,
+    },
+  }
+  return {
+    schemaVersion: 'bayn.execution-prepare-request.v1',
+    proofPlan,
+    proofPlanHash: canonicalHashV1OrThrow(proofPlan),
+  }
+}
+
+const runtimeBinding = (
+  fixture: QualificationFixture,
+  request: ExecutionPrepareRequest,
+): ExecutionPrepareRuntimeBinding => ({
+  sourceRevision,
+  imageRepository,
+  imageDigest,
+  strategy,
+  strategyProtocolHash,
+  qualificationRunId: fixture.result.runId,
+  accountId,
+  brokerIdentityHash: brokerIdentity.identityHash,
+  brokerProvider: BrokerProvider.Alpaca,
+  brokerEnvironment: BrokerEnvironment.Sandbox,
+  brokerAccess: BrokerAccess.ReadOnly,
+  capitalAuthority: CapitalAuthorityKind.None,
+  authorityGenerationHash: baseConfig.alpaca!.authorityGenerationHash,
+  riskPolicyHash: request.proofPlan.binding.riskPolicyHash,
+})
+
+const prepareFixture = (fixture: QualificationFixture, reconciliation: ReconciliationFixture) =>
+  Effect.gen(function* () {
+    const sql = yield* PgClient.PgClient
+    const authority = makeObserveAuthorityInterpreter(sql, makeAuthorityPostgres(sql), brokerIdentity)
+    yield* seedQualification(fixture)
+    yield* seedReconciliation(reconciliation)
+    yield* authority.ensureAuthorityGeneration({
+      generationHash: baseConfig.alpaca!.authorityGenerationHash,
+      maximum: Authority.Observe,
+    })
+  })
+
+describePostgres('EXECUTION_PREPARE PostgreSQL boundary', () => {
+  beforeAll(() => {
+    const parsed = new URL(testUrl)
+    if (!['127.0.0.1', 'localhost', '[::1]'].includes(parsed.hostname) || !parsed.pathname.endsWith('_test')) {
+      throw new Error('BAYN_TEST_POSTGRES_URL must target a local database whose name ends in _test')
+    }
+  })
+
+  beforeEach(async () => {
+    const client = makeClientRuntime()
+    await client.runPromise(
+      Effect.gen(function* () {
+        const sql = yield* PgClient.PgClient
+        yield* sql`DROP SCHEMA public CASCADE`
+        yield* sql`CREATE SCHEMA public`
+      }),
+    )
+    await client.dispose()
+    const migrations = makeEvidenceRuntime()
+    await migrations.runPromise(Effect.flatMap(EvidenceStore, (store) => store.check))
+    await migrations.dispose()
+  }, 15_000)
+
+  test('returns proof while authority/history, intents, mutations, and broker mutation count remain unchanged', async () => {
+    const fixture = qualificationFixture('success', true)
+    const reconciliation = reconciliationFixture('success')
+    const request = makeRequest(fixture, reconciliation)
+    const runtime = makeRuntime(fixture.result.runId)
+    let brokerMutationCount = 0
+    try {
+      const result = await runtime.runPromise(
+        Effect.gen(function* () {
+          yield* prepareFixture(fixture, reconciliation)
+          const before = yield* durableSnapshot
+          const receipt = yield* prepareExecution(request, runtimeBinding(fixture, request))
+          const after = yield* durableSnapshot
+          return { after, before, receipt }
+        }),
+      )
+      expect(result.after).toEqual(result.before)
+      expect(brokerMutationCount).toBe(0)
+      expect(result.receipt).toMatchObject({
+        dispatchable: false,
+        authority: { maximum: Authority.Observe, effective: Authority.Observe, activated: false },
+        generation: { previousGenerationHash: baseConfig.alpaca!.authorityGenerationHash },
+        reconciliation: {
+          reconciliationId: reconciliation.reconciliationId,
+          contentHash: reconciliation.contentHash,
+        },
+        dryRunSubmit: { included: false, reason: 'MUTATION_AUTHORITY_REQUIRED' },
+      })
+      expect(JSON.stringify(result.receipt)).not.toContain(accountId)
+    } finally {
+      brokerMutationCount = 0
+      await runtime.dispose()
+    }
+  }, 15_000)
+
+  test('fails closed for rejected qualification without changing durable execution state', async () => {
+    const fixture = qualificationFixture('rejected', false)
+    const reconciliation = reconciliationFixture('rejected')
+    const request = makeRequest(fixture, reconciliation)
+    const runtime = makeRuntime(fixture.result.runId)
+    try {
+      const result = await runtime.runPromise(
+        Effect.gen(function* () {
+          yield* prepareFixture(fixture, reconciliation)
+          const before = yield* durableSnapshot
+          const failure = yield* Effect.flip(prepareExecution(request, runtimeBinding(fixture, request)))
+          const after = yield* durableSnapshot
+          return { after, before, failure }
+        }),
+      )
+      expect(result.failure).toMatchObject({
+        _tag: 'ExecutionPrepareStoreRejected',
+        operation: 'authority',
+        failure: 'invariant',
+      })
+      expect(result.after).toEqual(result.before)
+    } finally {
+      await runtime.dispose()
+    }
+  }, 15_000)
+
+  test('fails closed for stale or non-exact reconciliation without changing durable execution state', async () => {
+    for (const reconciliation of [
+      reconciliationFixture('stale', { ageMs: baseConfig.reconciliationStaleThresholdMs + 1_000 }),
+      reconciliationFixture('non-exact', { exact: false }),
+    ]) {
+      const fixture = qualificationFixture(reconciliation.exact ? 'stale' : 'non-exact', true)
+      const request = makeRequest(fixture, reconciliation)
+      const runtime = makeRuntime(fixture.result.runId)
+      try {
+        const result = await runtime.runPromise(
+          Effect.gen(function* () {
+            yield* prepareFixture(fixture, reconciliation)
+            const before = yield* durableSnapshot
+            const failure = yield* Effect.flip(prepareExecution(request, runtimeBinding(fixture, request)))
+            const after = yield* durableSnapshot
+            return { after, before, failure }
+          }),
+        )
+        expect(result.failure).toMatchObject({
+          _tag: 'ExecutionPrepareStoreRejected',
+          operation: 'authority',
+          failure: 'invariant',
+        })
+        expect(result.after).toEqual(result.before)
+      } finally {
+        await runtime.dispose()
+      }
+    }
+  }, 20_000)
+
+  test('fails closed when unresolved mutation history exists', async () => {
+    const fixture = qualificationFixture('unresolved', true)
+    const reconciliation = reconciliationFixture('unresolved')
+    const request = makeRequest(fixture, reconciliation)
+    const runtime = makeRuntime(fixture.result.runId)
+    try {
+      const result = await runtime.runPromise(
+        Effect.gen(function* () {
+          yield* prepareFixture(fixture, reconciliation)
+          yield* seedUnresolvedMutation(baseConfig.alpaca!.authorityGenerationHash)
+          const before = yield* durableSnapshot
+          const failure = yield* Effect.flip(prepareExecution(request, runtimeBinding(fixture, request)))
+          const after = yield* durableSnapshot
+          return { after, before, failure }
+        }),
+      )
+      expect(result.failure).toMatchObject({
+        _tag: 'ExecutionPrepareStoreRejected',
+        operation: 'authority',
+        failure: 'invariant',
+      })
+      expect(result.after).toEqual(result.before)
+      expect(result.before).toMatchObject({ intents: 1, mutations: 1 })
+    } finally {
+      await runtime.dispose()
+    }
+  }, 15_000)
+
+  test('rejects malformed and drifted operator bindings before durable PREPARE access', async () => {
+    const fixture = qualificationFixture('operator-drift', true)
+    const reconciliation = reconciliationFixture('operator-drift')
+    const request = makeRequest(fixture, reconciliation)
+    const runtime = makeRuntime(fixture.result.runId)
+    try {
+      const result = await runtime.runPromise(
+        Effect.gen(function* () {
+          yield* prepareFixture(fixture, reconciliation)
+          const before = yield* durableSnapshot
+          const candidates: readonly [unknown, unknown][] = [
+            [{ ...request, unexpected: true }, runtimeBinding(fixture, request)],
+            [request, { ...runtimeBinding(fixture, request), accountId: 'drifted-account' }],
+            [request, { ...runtimeBinding(fixture, request), authorityGenerationHash: hash('drifted-generation') }],
+            [
+              request,
+              {
+                ...runtimeBinding(fixture, request),
+                strategy: { ...strategy, behaviorHash: hash('drifted-strategy') },
+              },
+            ],
+            [request, { ...runtimeBinding(fixture, request), riskPolicyHash: hash('drifted-policy') }],
+            [{ ...request, proofPlanHash: hash('drifted-proof') }, runtimeBinding(fixture, request)],
+          ]
+          const failures = []
+          for (const [candidateRequest, candidateRuntime] of candidates) {
+            failures.push(yield* Effect.flip(prepareExecution(candidateRequest, candidateRuntime)))
+          }
+          const after = yield* durableSnapshot
+          return { after, before, failures }
+        }),
+      )
+      expect(result.failures.map((failure) => failure._tag)).toEqual([
+        'ExecutionPrepareRequestInvalid',
+        'ExecutionPrepareRuntimeMismatch',
+        'ExecutionPrepareRuntimeMismatch',
+        'ExecutionPrepareRuntimeMismatch',
+        'ExecutionPrepareRuntimeMismatch',
+        'ExecutionPrepareProofPlanHashMismatch',
+      ])
+      expect(result.after).toEqual(result.before)
+    } finally {
+      await runtime.dispose()
+    }
+  }, 15_000)
+})

--- a/services/bayn/src/execution-prepare/execution-prepare.integration.test.ts
+++ b/services/bayn/src/execution-prepare/execution-prepare.integration.test.ts
@@ -594,7 +594,7 @@ describePostgres('EXECUTION_PREPARE PostgreSQL boundary', () => {
     try {
       let failedClosed = false
       try {
-        await runtime.runPromise(prepareExecution(request, runtimeBinding(fixture, request)))
+        await runtime.runPromise(prepareExecution(request, runtimeBinding(fixture, request), request.discoveryReceipt))
       } catch {
         failedClosed = true
       }
@@ -630,7 +630,7 @@ describePostgres('EXECUTION_PREPARE PostgreSQL boundary', () => {
         Effect.gen(function* () {
           yield* prepareFixture(fixture, reconciliation)
           const before = yield* durableSnapshot
-          const receipt = yield* prepareExecution(request, runtimeBinding(fixture, request))
+          const receipt = yield* prepareExecution(request, runtimeBinding(fixture, request), request.discoveryReceipt)
           const after = yield* durableSnapshot
           return { after, before, receipt }
         }),
@@ -664,7 +664,9 @@ describePostgres('EXECUTION_PREPARE PostgreSQL boundary', () => {
         Effect.gen(function* () {
           yield* prepareFixture(fixture, reconciliation)
           const before = yield* durableSnapshot
-          const failure = yield* Effect.flip(prepareExecution(request, runtimeBinding(fixture, request)))
+          const failure = yield* Effect.flip(
+            prepareExecution(request, runtimeBinding(fixture, request), request.discoveryReceipt),
+          )
           const after = yield* durableSnapshot
           return { after, before, failure }
         }),
@@ -693,7 +695,9 @@ describePostgres('EXECUTION_PREPARE PostgreSQL boundary', () => {
           Effect.gen(function* () {
             yield* prepareFixture(fixture, reconciliation)
             const before = yield* durableSnapshot
-            const failure = yield* Effect.flip(prepareExecution(request, runtimeBinding(fixture, request)))
+            const failure = yield* Effect.flip(
+              prepareExecution(request, runtimeBinding(fixture, request), request.discoveryReceipt),
+            )
             const after = yield* durableSnapshot
             return { after, before, failure }
           }),
@@ -721,7 +725,9 @@ describePostgres('EXECUTION_PREPARE PostgreSQL boundary', () => {
           yield* prepareFixture(fixture, reconciliation)
           yield* seedUnresolvedMutation(baseConfig.alpaca!.authorityGenerationHash)
           const before = yield* durableSnapshot
-          const failure = yield* Effect.flip(prepareExecution(request, runtimeBinding(fixture, request)))
+          const failure = yield* Effect.flip(
+            prepareExecution(request, runtimeBinding(fixture, request), request.discoveryReceipt),
+          )
           const after = yield* durableSnapshot
           return { after, before, failure }
         }),
@@ -786,7 +792,9 @@ describePostgres('EXECUTION_PREPARE PostgreSQL boundary', () => {
           ]
           const failures = []
           for (const [candidateRequest, candidateRuntime] of candidates) {
-            failures.push(yield* Effect.flip(prepareExecution(candidateRequest, candidateRuntime)))
+            failures.push(
+              yield* Effect.flip(prepareExecution(candidateRequest, candidateRuntime, request.discoveryReceipt)),
+            )
           }
           const after = yield* durableSnapshot
           return { after, before, failures }

--- a/services/bayn/src/execution-prepare/execution-prepare.integration.test.ts
+++ b/services/bayn/src/execution-prepare/execution-prepare.integration.test.ts
@@ -561,6 +561,47 @@ describePostgres('EXECUTION_PREPARE PostgreSQL boundary', () => {
     await migrations.dispose()
   }, 15_000)
 
+  test('does not create or migrate schema before durable PREPARE validation', async () => {
+    const fixture = qualificationFixture('no-migrations', true)
+    const reconciliation = reconciliationFixture('no-migrations')
+    const request = makeRequest(fixture, reconciliation)
+    const client = makeClientRuntime()
+    await client.runPromise(
+      Effect.gen(function* () {
+        const sql = yield* PgClient.PgClient
+        yield* sql`DROP SCHEMA public CASCADE`
+        yield* sql`CREATE SCHEMA public`
+      }),
+    )
+    const runtime = makeRuntime(fixture.result.runId)
+    try {
+      let failedClosed = false
+      try {
+        await runtime.runPromise(prepareExecution(request, runtimeBinding(fixture, request)))
+      } catch {
+        failedClosed = true
+      }
+      expect(failedClosed).toBe(true)
+      const [presence] = await client.runPromise(
+        Effect.gen(function* () {
+          const sql = yield* PgClient.PgClient
+          return yield* sql<{
+            readonly schemaMigrations: boolean
+            readonly authorityState: boolean
+          }>`
+            SELECT
+              to_regclass('public.schema_migrations') IS NOT NULL AS "schemaMigrations",
+              to_regclass('public.authority_state') IS NOT NULL AS "authorityState"
+          `
+        }),
+      )
+      expect(presence).toEqual({ schemaMigrations: false, authorityState: false })
+    } finally {
+      await runtime.dispose()
+      await client.dispose()
+    }
+  }, 15_000)
+
   test('returns proof while authority/history, intents, mutations, and broker mutation count remain unchanged', async () => {
     const fixture = qualificationFixture('success', true)
     const reconciliation = reconciliationFixture('success')

--- a/services/bayn/src/execution-prepare/execution-prepare.test.ts
+++ b/services/bayn/src/execution-prepare/execution-prepare.test.ts
@@ -350,8 +350,8 @@ describe('EXECUTION_PREPARE pure validation', () => {
     })
   })
 
-  test('rebinds the proof to a freshly verified receipt with identical durable candidate facts', () => {
-    const refreshedReceipt = makeExecutionPrepareDiscoveryReceiptFixture({
+  test('keeps the proof hash stable across fresh verified receipts with identical durable candidate facts', () => {
+    const firstRefreshedReceipt = makeExecutionPrepareDiscoveryReceiptFixture({
       sourceRevision,
       imageRepository,
       imageDigest,
@@ -365,15 +365,33 @@ describe('EXECUTION_PREPARE pure validation', () => {
       reconciliationContentHash,
       observedAt: '2099-07-24T12:00:01.000Z',
     })
+    const secondRefreshedReceipt = makeExecutionPrepareDiscoveryReceiptFixture({
+      sourceRevision,
+      imageRepository,
+      imageDigest,
+      strategy,
+      strategyProtocolHash,
+      qualificationRunId,
+      accountId,
+      authorityGenerationHash,
+      policyHash: riskPolicyHash,
+      reconciliationId,
+      reconciliationContentHash,
+      observedAt: '2099-07-24T12:00:02.000Z',
+    })
     const prevalidated = Result.getOrThrow(validateExecutionPrepareInput(request, runtime))
-    const authenticated = Result.getOrThrow(authenticateExecutionPrepareDiscovery(prevalidated, refreshedReceipt))
+    const first = Result.getOrThrow(authenticateExecutionPrepareDiscovery(prevalidated, firstRefreshedReceipt))
+    const second = Result.getOrThrow(authenticateExecutionPrepareDiscovery(prevalidated, secondRefreshedReceipt))
 
-    expect(refreshedReceipt.immutableBindingHash).toBe(discoveryReceipt.immutableBindingHash)
-    expect(refreshedReceipt.candidateFactsHash).toBe(discoveryReceipt.candidateFactsHash)
-    expect(refreshedReceipt.observationReceiptHash).not.toBe(discoveryReceipt.observationReceiptHash)
-    expect(authenticated.proofPlan.candidate.discoveryReceiptHash).toBe(refreshedReceipt.observationReceiptHash)
-    expect(authenticated.proofPlanHash).not.toBe(request.proofPlanHash)
-    expect(authenticated.proof.proofPlanHash).toBe(authenticated.proofPlanHash)
+    expect(firstRefreshedReceipt.immutableBindingHash).toBe(discoveryReceipt.immutableBindingHash)
+    expect(firstRefreshedReceipt.candidateFactsHash).toBe(discoveryReceipt.candidateFactsHash)
+    expect(firstRefreshedReceipt.observationReceiptHash).not.toBe(discoveryReceipt.observationReceiptHash)
+    expect(secondRefreshedReceipt.observationReceiptHash).not.toBe(firstRefreshedReceipt.observationReceiptHash)
+    expect(first.proofPlan).toEqual(request.proofPlan)
+    expect(second.proofPlan).toEqual(request.proofPlan)
+    expect(first.proofPlanHash).toBe(request.proofPlanHash)
+    expect(second.proofPlanHash).toBe(request.proofPlanHash)
+    expect(first.proof).toEqual(second.proof)
   })
 
   test('rejects ineligible assets and missing required fractional eligibility', () => {

--- a/services/bayn/src/execution-prepare/execution-prepare.test.ts
+++ b/services/bayn/src/execution-prepare/execution-prepare.test.ts
@@ -17,7 +17,11 @@ import type { ExecutionPrepareGenerationField } from './failure'
 import type { ExecutionPrepareRequest, ExecutionPrepareRuntimeBinding } from './model'
 import { prepareExecution } from './program'
 import { makeExecutionPrepareDiscoveryReceiptFixture } from './test-fixture'
-import { makeExecutionPrepareReceipt, validateExecutionPrepareInput } from './validation'
+import {
+  authenticateExecutionPrepareDiscovery,
+  makeExecutionPrepareReceipt,
+  validateExecutionPrepareInput,
+} from './validation'
 
 const hash = (label: string): string => sha256(`execution-prepare:${label}`)
 const sourceRevision = 'a'.repeat(40)
@@ -95,6 +99,29 @@ const request: ExecutionPrepareRequest = {
   proofPlanHash: canonicalHashV1OrThrow(proofPlan),
 }
 
+const requestForDiscoveryReceipt = (receipt: ExecutionPrepareRequest['discoveryReceipt']): ExecutionPrepareRequest => {
+  const candidate = receipt.candidateFacts.candidates[0]
+  if (candidate === undefined) throw new Error('execution prepare test fixture requires one candidate')
+  const changedProofPlan = {
+    ...proofPlan,
+    candidate: {
+      discoveryReceiptHash: receipt.observationReceiptHash,
+      immutableBindingHash: receipt.immutableBindingHash,
+      candidateFactsHash: receipt.candidateFactsHash,
+      candidateOrdinal: candidate.ordinal,
+      observedPlanIntentId: candidate.observedPlanIntentId,
+      cycleId: receipt.binding.cycle.cycleId,
+      decisionHash: receipt.binding.cycle.decisionHash,
+    },
+  }
+  return {
+    schemaVersion: 'bayn.execution-prepare-request.v1',
+    discoveryReceipt: receipt,
+    proofPlan: changedProofPlan,
+    proofPlanHash: canonicalHashV1OrThrow(changedProofPlan),
+  }
+}
+
 const runtime: ExecutionPrepareRuntimeBinding = {
   sourceRevision,
   imageRepository,
@@ -141,7 +168,13 @@ const generation = (): CapitalGrantGeneration =>
     }),
   )
 
-const validated = () => Result.getOrThrow(validateExecutionPrepareInput(request, runtime))
+const validated = () =>
+  Result.getOrThrow(
+    authenticateExecutionPrepareDiscovery(
+      Result.getOrThrow(validateExecutionPrepareInput(request, runtime)),
+      discoveryReceipt,
+    ),
+  )
 
 describe('EXECUTION_PREPARE pure validation', () => {
   test('derives the exact proof binding and deterministic redacted non-dispatchable receipt', () => {
@@ -293,6 +326,117 @@ describe('EXECUTION_PREPARE pure validation', () => {
     })
   })
 
+  test('requires a verified discovery anchor instead of accepting a self-hashed fabricated receipt', () => {
+    const fabricatedReceipt = makeExecutionPrepareDiscoveryReceiptFixture({
+      sourceRevision,
+      imageRepository,
+      imageDigest,
+      strategy,
+      strategyProtocolHash,
+      qualificationRunId,
+      accountId,
+      authorityGenerationHash,
+      policyHash: riskPolicyHash,
+      reconciliationId,
+      reconciliationContentHash,
+      observedPlanIntentId: hash('fabricated-intent'),
+    })
+    const fabricatedRequest = requestForDiscoveryReceipt(fabricatedReceipt)
+    const prevalidated = Result.getOrThrow(validateExecutionPrepareInput(fabricatedRequest, runtime))
+
+    expect(authenticateExecutionPrepareDiscovery(prevalidated, discoveryReceipt)).toMatchObject({
+      _tag: 'Failure',
+      failure: { _tag: 'ExecutionPrepareDiscoveryMismatch', field: 'candidateFactsHash' },
+    })
+  })
+
+  test('rebinds the proof to a freshly verified receipt with identical durable candidate facts', () => {
+    const refreshedReceipt = makeExecutionPrepareDiscoveryReceiptFixture({
+      sourceRevision,
+      imageRepository,
+      imageDigest,
+      strategy,
+      strategyProtocolHash,
+      qualificationRunId,
+      accountId,
+      authorityGenerationHash,
+      policyHash: riskPolicyHash,
+      reconciliationId,
+      reconciliationContentHash,
+      observedAt: '2099-07-24T12:00:01.000Z',
+    })
+    const prevalidated = Result.getOrThrow(validateExecutionPrepareInput(request, runtime))
+    const authenticated = Result.getOrThrow(authenticateExecutionPrepareDiscovery(prevalidated, refreshedReceipt))
+
+    expect(refreshedReceipt.immutableBindingHash).toBe(discoveryReceipt.immutableBindingHash)
+    expect(refreshedReceipt.candidateFactsHash).toBe(discoveryReceipt.candidateFactsHash)
+    expect(refreshedReceipt.observationReceiptHash).not.toBe(discoveryReceipt.observationReceiptHash)
+    expect(authenticated.proofPlan.candidate.discoveryReceiptHash).toBe(refreshedReceipt.observationReceiptHash)
+    expect(authenticated.proofPlanHash).not.toBe(request.proofPlanHash)
+    expect(authenticated.proof.proofPlanHash).toBe(authenticated.proofPlanHash)
+  })
+
+  test('rejects ineligible assets and missing required fractional eligibility', () => {
+    const ineligibleReceipt = makeExecutionPrepareDiscoveryReceiptFixture({
+      sourceRevision,
+      imageRepository,
+      imageDigest,
+      strategy,
+      strategyProtocolHash,
+      qualificationRunId,
+      accountId,
+      authorityGenerationHash,
+      policyHash: riskPolicyHash,
+      reconciliationId,
+      reconciliationContentHash,
+      assetEligible: false,
+    })
+    const fractionalIneligibleReceipt = makeExecutionPrepareDiscoveryReceiptFixture({
+      sourceRevision,
+      imageRepository,
+      imageDigest,
+      strategy,
+      strategyProtocolHash,
+      qualificationRunId,
+      accountId,
+      authorityGenerationHash,
+      policyHash: riskPolicyHash,
+      reconciliationId,
+      reconciliationContentHash,
+      plannedQuantityMicros: '1250000',
+      fractionalTradingEligible: false,
+    })
+    const integerWithoutFractionalEligibility = makeExecutionPrepareDiscoveryReceiptFixture({
+      sourceRevision,
+      imageRepository,
+      imageDigest,
+      strategy,
+      strategyProtocolHash,
+      qualificationRunId,
+      accountId,
+      authorityGenerationHash,
+      policyHash: riskPolicyHash,
+      reconciliationId,
+      reconciliationContentHash,
+      plannedQuantityMicros: '1000000',
+      fractionalTradingEligible: false,
+    })
+
+    expect(validateExecutionPrepareInput(requestForDiscoveryReceipt(ineligibleReceipt), runtime)).toMatchObject({
+      _tag: 'Failure',
+      failure: { _tag: 'ExecutionPrepareDiscoveryMismatch', field: 'assetEligibility' },
+    })
+    expect(
+      validateExecutionPrepareInput(requestForDiscoveryReceipt(fractionalIneligibleReceipt), runtime),
+    ).toMatchObject({
+      _tag: 'Failure',
+      failure: { _tag: 'ExecutionPrepareDiscoveryMismatch', field: 'fractionalTradingEligibility' },
+    })
+    expect(
+      validateExecutionPrepareInput(requestForDiscoveryReceipt(integerWithoutFractionalEligibility), runtime),
+    ).toMatchObject({ _tag: 'Success' })
+  })
+
   test('rejects runtime account, generation, strategy, policy, and authority drift', () => {
     const cases: ReadonlyArray<{
       readonly runtime: unknown
@@ -356,8 +500,12 @@ const writerFence: WriterFenceService = {
   transaction: (effect) => effect,
 }
 
-const runProgram = (lifecycle: CapitalGrantLifecycleStoreShape) =>
-  prepareExecution(request, runtime).pipe(
+const runProgram = (
+  lifecycle: CapitalGrantLifecycleStoreShape,
+  candidateRequest: ExecutionPrepareRequest = request,
+  trustedReceipt: ExecutionPrepareRequest['discoveryReceipt'] = discoveryReceipt,
+) =>
+  prepareExecution(candidateRequest, runtime, trustedReceipt).pipe(
     Effect.provideService(CapitalGrantLifecycleStore, lifecycle),
     Effect.provideService(WriterFence, writerFence),
   )
@@ -385,25 +533,62 @@ describe('EXECUTION_PREPARE program boundary', () => {
     expect(activateCalls).toBe(0)
   })
 
-  test('sanitizes durable failures without account or store-message leakage', async () => {
+  test('does not call the store when self-hashed discovery material lacks the verified anchor', async () => {
+    let prepareCalls = 0
+    const fabricatedReceipt = makeExecutionPrepareDiscoveryReceiptFixture({
+      sourceRevision,
+      imageRepository,
+      imageDigest,
+      strategy,
+      strategyProtocolHash,
+      qualificationRunId,
+      accountId,
+      authorityGenerationHash,
+      policyHash: riskPolicyHash,
+      reconciliationId,
+      reconciliationContentHash,
+      observedPlanIntentId: hash('fabricated-program-intent'),
+    })
     const lifecycle: CapitalGrantLifecycleStoreShape = {
       prepareCapitalGrant: () =>
-        Effect.fail(
-          new ExecutionStoreError({
-            operation: 'authority',
-            failure: 'invariant',
-            message: `sensitive account ${accountId} failed`,
-          }),
-        ),
+        Effect.sync(() => {
+          prepareCalls += 1
+          return generation()
+        }),
+      activateCapitalGrant: () => Effect.die(new Error('activation must remain unreachable')),
+    }
+
+    const failure = await Effect.runPromise(
+      Effect.flip(runProgram(lifecycle, requestForDiscoveryReceipt(fabricatedReceipt), discoveryReceipt)),
+    )
+    expect(failure).toMatchObject({
+      _tag: 'ExecutionPrepareDiscoveryMismatch',
+      field: 'candidateFactsHash',
+    })
+    expect(prepareCalls).toBe(0)
+  })
+
+  test('sanitizes durable failures without account or store-message leakage', async () => {
+    const lifecycleFailure = new ExecutionStoreError({
+      operation: 'authority',
+      failure: 'invariant',
+      message: `sensitive account ${accountId} failed`,
+      cause: new Error('underlying schema failure'),
+    })
+    const lifecycle: CapitalGrantLifecycleStoreShape = {
+      prepareCapitalGrant: () => Effect.fail(lifecycleFailure),
       activateCapitalGrant: () => Effect.die(new Error('activation must remain unreachable')),
     }
 
     const failure = await Effect.runPromise(Effect.flip(runProgram(lifecycle)))
-    expect(failure).toEqual({
+    expect(failure).toMatchObject({
       _tag: 'ExecutionPrepareStoreRejected',
       operation: 'authority',
       failure: 'invariant',
+      cause: lifecycleFailure,
     })
+    if (failure._tag !== 'ExecutionPrepareStoreRejected') return expect.unreachable(failure._tag)
+    expect(failure.cause).toBe(lifecycleFailure)
     const rendered = renderExecutionPrepareFailure(failure)
     expect(rendered).not.toContain(accountId)
     expect(rendered).not.toContain('sensitive account')

--- a/services/bayn/src/execution-prepare/execution-prepare.test.ts
+++ b/services/bayn/src/execution-prepare/execution-prepare.test.ts
@@ -16,6 +16,7 @@ import { renderExecutionPrepareFailure } from './failure'
 import type { ExecutionPrepareGenerationField } from './failure'
 import type { ExecutionPrepareRequest, ExecutionPrepareRuntimeBinding } from './model'
 import { prepareExecution } from './program'
+import { makeExecutionPrepareDiscoveryReceiptFixture } from './test-fixture'
 import { makeExecutionPrepareReceipt, validateExecutionPrepareInput } from './validation'
 
 const hash = (label: string): string => sha256(`execution-prepare:${label}`)
@@ -32,17 +33,37 @@ const strategy = {
   parameterHash: hash('parameters'),
   parameterSchemaVersion: 'bayn.risk-balanced-trend.protocol.v4' as const,
 }
+const strategyProtocolHash = hash('strategy-protocol')
+const qualificationRunId = hash('qualification-run')
+const authorityGenerationHash = hash('observe-generation')
+const riskPolicyHash = hash('risk-policy')
+const reconciliationId = hash('reconciliation')
+const reconciliationContentHash = hash('reconciliation-content')
+const discoveryReceipt = makeExecutionPrepareDiscoveryReceiptFixture({
+  sourceRevision,
+  imageRepository,
+  imageDigest,
+  strategy,
+  strategyProtocolHash,
+  qualificationRunId,
+  accountId,
+  authorityGenerationHash,
+  policyHash: riskPolicyHash,
+  reconciliationId,
+  reconciliationContentHash,
+})
+const discoveredCandidate = discoveryReceipt.candidateFacts.candidates[0]!
 
 const proofPlan = {
   schemaVersion: 'bayn.execution-prepare-proof-plan.v1' as const,
   candidate: {
-    discoveryReceiptHash: hash('discovery-receipt'),
-    immutableBindingHash: hash('immutable-binding'),
-    candidateFactsHash: hash('candidate-facts'),
-    candidateOrdinal: 2,
-    observedPlanIntentId: hash('observed-plan-intent'),
-    cycleId: hash('cycle'),
-    decisionHash: hash('decision'),
+    discoveryReceiptHash: discoveryReceipt.observationReceiptHash,
+    immutableBindingHash: discoveryReceipt.immutableBindingHash,
+    candidateFactsHash: discoveryReceipt.candidateFactsHash,
+    candidateOrdinal: discoveredCandidate.ordinal,
+    observedPlanIntentId: discoveredCandidate.observedPlanIntentId,
+    cycleId: discoveryReceipt.binding.cycle.cycleId,
+    decisionHash: discoveryReceipt.binding.cycle.decisionHash,
   },
   binding: {
     activationSourceRevision: sourceRevision,
@@ -52,23 +73,24 @@ const proofPlan = {
     qualificationImageRepository: imageRepository,
     qualificationImageDigest,
     strategy,
-    strategyProtocolHash: hash('strategy-protocol'),
-    qualificationRunId: hash('qualification-run'),
+    strategyProtocolHash,
+    qualificationRunId,
     qualificationLockId: hash('qualification-lock'),
     qualificationResultHash: hash('qualification-result'),
     protocolHash: hash('protocol'),
     qualificationExecutionPolicyHash: hash('qualification-execution-policy'),
     accountId,
     brokerIdentityHash: hash('broker-identity'),
-    authorityGenerationHash: hash('observe-generation'),
-    riskPolicyHash: hash('risk-policy'),
-    reconciliationId: hash('reconciliation'),
-    reconciliationContentHash: hash('reconciliation-content'),
+    authorityGenerationHash,
+    riskPolicyHash,
+    reconciliationId,
+    reconciliationContentHash,
   },
 }
 
 const request: ExecutionPrepareRequest = {
   schemaVersion: 'bayn.execution-prepare-request.v1',
+  discoveryReceipt,
   proofPlan,
   proofPlanHash: canonicalHashV1OrThrow(proofPlan),
 }
@@ -166,6 +188,108 @@ describe('EXECUTION_PREPARE pure validation', () => {
     expect(drifted).toMatchObject({
       _tag: 'Failure',
       failure: { _tag: 'ExecutionPrepareProofPlanHashMismatch' },
+    })
+  })
+
+  test('rejects every discovery-derived proof field and tampered receipt material', () => {
+    const withCandidate = (candidate: ExecutionPrepareRequest['proofPlan']['candidate']): ExecutionPrepareRequest => {
+      const changedProofPlan = { ...proofPlan, candidate }
+      return { ...request, proofPlan: changedProofPlan, proofPlanHash: canonicalHashV1OrThrow(changedProofPlan) }
+    }
+    const withBinding = (binding: ExecutionPrepareRequest['proofPlan']['binding']): ExecutionPrepareRequest => {
+      const changedProofPlan = { ...proofPlan, binding }
+      return { ...request, proofPlan: changedProofPlan, proofPlanHash: canonicalHashV1OrThrow(changedProofPlan) }
+    }
+    const cases = [
+      {
+        request: withCandidate({ ...proofPlan.candidate, discoveryReceiptHash: hash('foreign-receipt') }),
+        field: 'observationReceiptHash',
+      },
+      {
+        request: withCandidate({ ...proofPlan.candidate, immutableBindingHash: hash('foreign-binding') }),
+        field: 'immutableBindingHash',
+      },
+      {
+        request: withCandidate({ ...proofPlan.candidate, candidateFactsHash: hash('foreign-candidate-facts') }),
+        field: 'candidateFactsHash',
+      },
+      { request: withCandidate({ ...proofPlan.candidate, candidateOrdinal: 1 }), field: 'candidateOrdinal' },
+      {
+        request: withCandidate({ ...proofPlan.candidate, observedPlanIntentId: hash('foreign-intent') }),
+        field: 'observedPlanIntentId',
+      },
+      { request: withCandidate({ ...proofPlan.candidate, cycleId: hash('foreign-cycle') }), field: 'cycleId' },
+      {
+        request: withCandidate({ ...proofPlan.candidate, decisionHash: hash('foreign-decision') }),
+        field: 'decisionHash',
+      },
+      {
+        request: withBinding({ ...proofPlan.binding, activationSourceRevision: '0'.repeat(40) }),
+        field: 'sourceRevision',
+      },
+      {
+        request: withBinding({ ...proofPlan.binding, activationImageRepository: 'registry.test/foreign/bayn' }),
+        field: 'imageRepository',
+      },
+      {
+        request: withBinding({ ...proofPlan.binding, activationImageDigest: `sha256:${'0'.repeat(64)}` }),
+        field: 'imageDigest',
+      },
+      {
+        request: withBinding({
+          ...proofPlan.binding,
+          strategy: { ...proofPlan.binding.strategy, behaviorHash: hash('foreign-strategy') },
+        }),
+        field: 'strategyBehaviorHash',
+      },
+      {
+        request: withBinding({ ...proofPlan.binding, strategyProtocolHash: hash('foreign-strategy-protocol') }),
+        field: 'strategyProtocolHash',
+      },
+      {
+        request: withBinding({ ...proofPlan.binding, qualificationRunId: hash('foreign-qualification') }),
+        field: 'qualificationRunId',
+      },
+      { request: withBinding({ ...proofPlan.binding, accountId: 'foreign-account' }), field: 'accountId' },
+      {
+        request: withBinding({ ...proofPlan.binding, authorityGenerationHash: hash('foreign-generation') }),
+        field: 'authorityGenerationHash',
+      },
+      {
+        request: withBinding({ ...proofPlan.binding, riskPolicyHash: hash('foreign-policy') }),
+        field: 'riskPolicyHash',
+      },
+      {
+        request: withBinding({ ...proofPlan.binding, reconciliationId: hash('foreign-reconciliation') }),
+        field: 'reconciliationId',
+      },
+      {
+        request: withBinding({
+          ...proofPlan.binding,
+          reconciliationContentHash: hash('foreign-reconciliation-content'),
+        }),
+        field: 'reconciliationContentHash',
+      },
+    ] as const
+
+    for (const testCase of cases) {
+      expect(validateExecutionPrepareInput(testCase.request, runtime)).toMatchObject({
+        _tag: 'Failure',
+        failure: { _tag: 'ExecutionPrepareDiscoveryMismatch', field: testCase.field },
+      })
+    }
+
+    const tamperedReceipt = {
+      ...discoveryReceipt,
+      candidateFacts: {
+        ...discoveryReceipt.candidateFacts,
+        candidates: [{ ...discoveredCandidate, observedPlanIntentId: hash('tampered-intent') }],
+      },
+    }
+    const tampered = validateExecutionPrepareInput({ ...request, discoveryReceipt: tamperedReceipt }, runtime)
+    expect(tampered).toMatchObject({
+      _tag: 'Failure',
+      failure: { _tag: 'ExecutionPrepareDiscoveryMismatch', field: 'observationReceiptHash' },
     })
   })
 

--- a/services/bayn/src/execution-prepare/execution-prepare.test.ts
+++ b/services/bayn/src/execution-prepare/execution-prepare.test.ts
@@ -1,0 +1,287 @@
+import { describe, expect, test } from 'bun:test'
+
+import { Effect, Result } from 'effect'
+
+import { BrokerEnvironment, BrokerProvider } from '../broker/identity'
+import {
+  CapitalGrantLifecycleStore,
+  ExecutionStoreError,
+  type CapitalGrantLifecycleStoreShape,
+} from '../db/execution-store'
+import { BrokerAccess, CapitalAuthorityKind } from '../execution/authority'
+import { Authority, makeCapitalGrantGenerationResult, type CapitalGrantGeneration } from '../execution/contracts'
+import { WriterFence, type WriterFenceService } from '../execution/writer-fence'
+import { canonicalHashV1OrThrow, sha256 } from '../hash'
+import { renderExecutionPrepareFailure } from './failure'
+import type { ExecutionPrepareGenerationField } from './failure'
+import type { ExecutionPrepareRequest, ExecutionPrepareRuntimeBinding } from './model'
+import { prepareExecution } from './program'
+import { makeExecutionPrepareReceipt, validateExecutionPrepareInput } from './validation'
+
+const hash = (label: string): string => sha256(`execution-prepare:${label}`)
+const sourceRevision = 'a'.repeat(40)
+const qualificationSourceRevision = 'b'.repeat(40)
+const imageRepository = 'registry.test/lab/bayn'
+const imageDigest = `sha256:${'c'.repeat(64)}`
+const qualificationImageDigest = `sha256:${'d'.repeat(64)}`
+const accountId = 'acct-sensitive-0011223344'
+
+const strategy = {
+  name: 'risk-balanced-trend' as const,
+  behaviorHash: hash('behavior'),
+  parameterHash: hash('parameters'),
+  parameterSchemaVersion: 'bayn.risk-balanced-trend.protocol.v4' as const,
+}
+
+const proofPlan = {
+  schemaVersion: 'bayn.execution-prepare-proof-plan.v1' as const,
+  candidate: {
+    discoveryReceiptHash: hash('discovery-receipt'),
+    immutableBindingHash: hash('immutable-binding'),
+    candidateFactsHash: hash('candidate-facts'),
+    candidateOrdinal: 2,
+    observedPlanIntentId: hash('observed-plan-intent'),
+    cycleId: hash('cycle'),
+    decisionHash: hash('decision'),
+  },
+  binding: {
+    activationSourceRevision: sourceRevision,
+    activationImageRepository: imageRepository,
+    activationImageDigest: imageDigest,
+    qualificationSourceRevision,
+    qualificationImageRepository: imageRepository,
+    qualificationImageDigest,
+    strategy,
+    strategyProtocolHash: hash('strategy-protocol'),
+    qualificationRunId: hash('qualification-run'),
+    qualificationLockId: hash('qualification-lock'),
+    qualificationResultHash: hash('qualification-result'),
+    protocolHash: hash('protocol'),
+    qualificationExecutionPolicyHash: hash('qualification-execution-policy'),
+    accountId,
+    brokerIdentityHash: hash('broker-identity'),
+    authorityGenerationHash: hash('observe-generation'),
+    riskPolicyHash: hash('risk-policy'),
+    reconciliationId: hash('reconciliation'),
+    reconciliationContentHash: hash('reconciliation-content'),
+  },
+}
+
+const request: ExecutionPrepareRequest = {
+  schemaVersion: 'bayn.execution-prepare-request.v1',
+  proofPlan,
+  proofPlanHash: canonicalHashV1OrThrow(proofPlan),
+}
+
+const runtime: ExecutionPrepareRuntimeBinding = {
+  sourceRevision,
+  imageRepository,
+  imageDigest,
+  strategy,
+  strategyProtocolHash: proofPlan.binding.strategyProtocolHash,
+  qualificationRunId: proofPlan.binding.qualificationRunId,
+  accountId,
+  brokerIdentityHash: proofPlan.binding.brokerIdentityHash,
+  brokerProvider: BrokerProvider.Alpaca,
+  brokerEnvironment: BrokerEnvironment.Sandbox,
+  brokerAccess: BrokerAccess.ReadOnly,
+  capitalAuthority: CapitalAuthorityKind.None,
+  authorityGenerationHash: proofPlan.binding.authorityGenerationHash,
+  riskPolicyHash: proofPlan.binding.riskPolicyHash,
+}
+
+const generation = (): CapitalGrantGeneration =>
+  Result.getOrThrow(
+    makeCapitalGrantGenerationResult({
+      schemaVersion: 'bayn.paper-authority-generation.v2',
+      maximum: Authority.Paper,
+      previousGenerationHash: proofPlan.binding.authorityGenerationHash,
+      qualificationRunId: proofPlan.binding.qualificationRunId,
+      qualificationLockId: proofPlan.binding.qualificationLockId,
+      qualificationResultHash: proofPlan.binding.qualificationResultHash,
+      protocolHash: proofPlan.binding.protocolHash,
+      qualificationExecutionPolicyHash: proofPlan.binding.qualificationExecutionPolicyHash,
+      qualificationSourceRevision: proofPlan.binding.qualificationSourceRevision,
+      qualificationImageRepository: proofPlan.binding.qualificationImageRepository,
+      qualificationImageDigest: proofPlan.binding.qualificationImageDigest,
+      activationSourceRevision: proofPlan.binding.activationSourceRevision,
+      activationImageRepository: proofPlan.binding.activationImageRepository,
+      activationImageDigest: proofPlan.binding.activationImageDigest,
+      strategyName: strategy.name,
+      strategyBehaviorHash: strategy.behaviorHash,
+      strategyParameterHash: strategy.parameterHash,
+      strategyParameterSchemaVersion: strategy.parameterSchemaVersion,
+      accountId,
+      riskPolicyHash: proofPlan.binding.riskPolicyHash,
+      proofPlanHash: request.proofPlanHash,
+      reconciliationId: proofPlan.binding.reconciliationId,
+      reconciliationContentHash: proofPlan.binding.reconciliationContentHash,
+    }),
+  )
+
+const validated = () => Result.getOrThrow(validateExecutionPrepareInput(request, runtime))
+
+describe('EXECUTION_PREPARE pure validation', () => {
+  test('derives the exact proof binding and deterministic redacted non-dispatchable receipt', () => {
+    const input = validated()
+    const first = Result.getOrThrow(makeExecutionPrepareReceipt(input, generation()))
+    const second = Result.getOrThrow(makeExecutionPrepareReceipt(input, generation()))
+
+    expect(input.proof).toEqual({
+      schemaVersion: 'bayn.paper-authority-proof-binding.v1',
+      riskPolicyHash: proofPlan.binding.riskPolicyHash,
+      proofPlanHash: request.proofPlanHash,
+    })
+    expect(second).toEqual(first)
+    expect(first).toMatchObject({
+      operation: 'EXECUTION_PREPARE',
+      dispatchable: false,
+      authority: { maximum: Authority.Observe, effective: Authority.Observe, activated: false },
+      dryRunSubmit: { included: false, reason: 'MUTATION_AUTHORITY_REQUIRED' },
+      broker: {
+        identityHash: proofPlan.binding.brokerIdentityHash,
+        provider: BrokerProvider.Alpaca,
+        environment: BrokerEnvironment.Sandbox,
+        access: BrokerAccess.ReadOnly,
+      },
+    })
+    const output = JSON.stringify(first)
+    expect(output).not.toContain(accountId)
+    expect(output).not.toContain('credential')
+    expect(output).not.toContain('secret')
+  })
+
+  test('fails total decoding for malformed or excess input', () => {
+    for (const candidate of [undefined, { ...request, unexpected: true }]) {
+      const malformed = validateExecutionPrepareInput(candidate, runtime)
+      expect(malformed).toMatchObject({
+        _tag: 'Failure',
+        failure: { _tag: 'ExecutionPrepareRequestInvalid' },
+      })
+    }
+  })
+
+  test('rejects proof hash drift before durable access', () => {
+    const drifted = validateExecutionPrepareInput({ ...request, proofPlanHash: hash('changed-proof') }, runtime)
+    expect(drifted).toMatchObject({
+      _tag: 'Failure',
+      failure: { _tag: 'ExecutionPrepareProofPlanHashMismatch' },
+    })
+  })
+
+  test('rejects runtime account, generation, strategy, policy, and authority drift', () => {
+    const cases: ReadonlyArray<{
+      readonly runtime: unknown
+      readonly field: string
+    }> = [
+      { runtime: { ...runtime, accountId: 'another-account' }, field: 'accountId' },
+      {
+        runtime: { ...runtime, authorityGenerationHash: hash('changed-generation') },
+        field: 'authorityGenerationHash',
+      },
+      {
+        runtime: { ...runtime, strategy: { ...strategy, behaviorHash: hash('changed-behavior') } },
+        field: 'strategyBehaviorHash',
+      },
+      { runtime: { ...runtime, riskPolicyHash: hash('changed-policy') }, field: 'riskPolicyHash' },
+      { runtime: { ...runtime, brokerEnvironment: BrokerEnvironment.Live }, field: 'brokerEnvironment' },
+      { runtime: { ...runtime, brokerAccess: BrokerAccess.Mutation }, field: 'brokerAccess' },
+      { runtime: { ...runtime, capitalAuthority: CapitalAuthorityKind.Sandbox }, field: 'capitalAuthority' },
+    ]
+
+    for (const entry of cases) {
+      const result = validateExecutionPrepareInput(request, entry.runtime)
+      expect(result).toMatchObject({
+        _tag: 'Failure',
+        failure: { _tag: 'ExecutionPrepareRuntimeMismatch', field: entry.field },
+      })
+    }
+  })
+
+  test('rejects returned account, generation, strategy, policy, proof, and reconciliation drift', () => {
+    const base = generation()
+    const cases: ReadonlyArray<{
+      readonly generation: CapitalGrantGeneration
+      readonly field: ExecutionPrepareGenerationField
+    }> = [
+      { generation: { ...base, accountId: 'another-account' }, field: 'accountId' },
+      { generation: { ...base, previousGenerationHash: hash('changed-generation') }, field: 'previousGenerationHash' },
+      { generation: { ...base, strategyBehaviorHash: hash('changed-behavior') }, field: 'strategyBehaviorHash' },
+      { generation: { ...base, riskPolicyHash: hash('changed-policy') }, field: 'riskPolicyHash' },
+      { generation: { ...base, proofPlanHash: hash('changed-proof') }, field: 'proofPlanHash' },
+      { generation: { ...base, reconciliationId: hash('changed-reconciliation') }, field: 'reconciliationId' },
+      {
+        generation: { ...base, reconciliationContentHash: hash('changed-reconciliation-content') },
+        field: 'reconciliationContentHash',
+      },
+    ]
+
+    for (const entry of cases) {
+      const result = makeExecutionPrepareReceipt(validated(), entry.generation)
+      expect(result).toMatchObject({
+        _tag: 'Failure',
+        failure: { _tag: 'ExecutionPrepareGenerationMismatch', field: entry.field },
+      })
+    }
+  })
+})
+
+const writerFence: WriterFenceService = {
+  backendPid: 1,
+  check: Effect.void,
+  transaction: (effect) => effect,
+}
+
+const runProgram = (lifecycle: CapitalGrantLifecycleStoreShape) =>
+  prepareExecution(request, runtime).pipe(
+    Effect.provideService(CapitalGrantLifecycleStore, lifecycle),
+    Effect.provideService(WriterFence, writerFence),
+  )
+
+describe('EXECUTION_PREPARE program boundary', () => {
+  test('calls only prepareCapitalGrant and returns the redacted receipt', async () => {
+    let prepareCalls = 0
+    let activateCalls = 0
+    const lifecycle: CapitalGrantLifecycleStoreShape = {
+      prepareCapitalGrant: () =>
+        Effect.sync(() => {
+          prepareCalls += 1
+          return generation()
+        }),
+      activateCapitalGrant: () =>
+        Effect.sync(() => {
+          activateCalls += 1
+          throw new Error('activation must remain unreachable')
+        }),
+    }
+
+    const receipt = await Effect.runPromise(runProgram(lifecycle))
+    expect(receipt.dispatchable).toBe(false)
+    expect(prepareCalls).toBe(1)
+    expect(activateCalls).toBe(0)
+  })
+
+  test('sanitizes durable failures without account or store-message leakage', async () => {
+    const lifecycle: CapitalGrantLifecycleStoreShape = {
+      prepareCapitalGrant: () =>
+        Effect.fail(
+          new ExecutionStoreError({
+            operation: 'authority',
+            failure: 'invariant',
+            message: `sensitive account ${accountId} failed`,
+          }),
+        ),
+      activateCapitalGrant: () => Effect.die(new Error('activation must remain unreachable')),
+    }
+
+    const failure = await Effect.runPromise(Effect.flip(runProgram(lifecycle)))
+    expect(failure).toEqual({
+      _tag: 'ExecutionPrepareStoreRejected',
+      operation: 'authority',
+      failure: 'invariant',
+    })
+    const rendered = renderExecutionPrepareFailure(failure)
+    expect(rendered).not.toContain(accountId)
+    expect(rendered).not.toContain('sensitive account')
+  })
+})

--- a/services/bayn/src/execution-prepare/failure.ts
+++ b/services/bayn/src/execution-prepare/failure.ts
@@ -1,0 +1,86 @@
+import type { Schema } from 'effect'
+
+import type { ExecutionStoreError } from '../db/execution-store'
+import type { CanonicalJsonFailure } from '../hash'
+
+export type ExecutionPrepareRuntimeField =
+  | 'request'
+  | 'brokerIdentity'
+  | 'brokerProvider'
+  | 'brokerEnvironment'
+  | 'brokerAccess'
+  | 'capitalAuthority'
+  | 'qualificationRunId'
+  | 'activationSourceRevision'
+  | 'activationImageRepository'
+  | 'activationImageDigest'
+  | 'strategyName'
+  | 'strategyBehaviorHash'
+  | 'strategyParameterHash'
+  | 'strategyParameterSchemaVersion'
+  | 'strategyProtocolHash'
+  | 'accountId'
+  | 'authorityGenerationHash'
+  | 'riskPolicyHash'
+
+export type ExecutionPrepareGenerationField =
+  | 'maximum'
+  | 'previousGenerationHash'
+  | 'qualificationRunId'
+  | 'qualificationLockId'
+  | 'qualificationResultHash'
+  | 'protocolHash'
+  | 'qualificationExecutionPolicyHash'
+  | 'qualificationSourceRevision'
+  | 'qualificationImageRepository'
+  | 'qualificationImageDigest'
+  | 'activationSourceRevision'
+  | 'activationImageRepository'
+  | 'activationImageDigest'
+  | 'strategyName'
+  | 'strategyBehaviorHash'
+  | 'strategyParameterHash'
+  | 'strategyParameterSchemaVersion'
+  | 'accountId'
+  | 'riskPolicyHash'
+  | 'proofPlanHash'
+  | 'reconciliationId'
+  | 'reconciliationContentHash'
+
+export type ExecutionPrepareFailure =
+  | { readonly _tag: 'ExecutionPrepareRequestInvalid'; readonly cause: Schema.SchemaError }
+  | { readonly _tag: 'ExecutionPrepareRuntimeBindingInvalid'; readonly cause: Schema.SchemaError }
+  | { readonly _tag: 'ExecutionPrepareRuntimeMismatch'; readonly field: ExecutionPrepareRuntimeField }
+  | { readonly _tag: 'ExecutionPrepareProofPlanHashFailed'; readonly cause: CanonicalJsonFailure }
+  | { readonly _tag: 'ExecutionPrepareProofPlanHashMismatch' }
+  | {
+      readonly _tag: 'ExecutionPrepareStoreRejected'
+      readonly operation: ExecutionStoreError['operation']
+      readonly failure: ExecutionStoreError['failure']
+    }
+  | { readonly _tag: 'ExecutionPrepareGenerationMismatch'; readonly field: ExecutionPrepareGenerationField }
+  | { readonly _tag: 'ExecutionPrepareReceiptHashFailed'; readonly cause: CanonicalJsonFailure }
+  | { readonly _tag: 'ExecutionPrepareReceiptInvalid'; readonly cause: Schema.SchemaError }
+
+export const renderExecutionPrepareFailure = (failure: ExecutionPrepareFailure): string => {
+  switch (failure._tag) {
+    case 'ExecutionPrepareRequestInvalid':
+      return 'EXECUTION_PREPARE input is malformed'
+    case 'ExecutionPrepareRuntimeBindingInvalid':
+      return 'EXECUTION_PREPARE runtime binding is malformed'
+    case 'ExecutionPrepareRuntimeMismatch':
+      return `EXECUTION_PREPARE runtime binding drifted at ${failure.field}`
+    case 'ExecutionPrepareProofPlanHashFailed':
+      return 'EXECUTION_PREPARE proof plan could not be content-hashed'
+    case 'ExecutionPrepareProofPlanHashMismatch':
+      return 'EXECUTION_PREPARE proof plan hash does not match its explicit material'
+    case 'ExecutionPrepareStoreRejected':
+      return `EXECUTION_PREPARE durable validation failed closed (${failure.operation}/${failure.failure})`
+    case 'ExecutionPrepareGenerationMismatch':
+      return `EXECUTION_PREPARE durable generation drifted at ${failure.field}`
+    case 'ExecutionPrepareReceiptHashFailed':
+      return 'EXECUTION_PREPARE receipt could not be content-hashed'
+    case 'ExecutionPrepareReceiptInvalid':
+      return 'EXECUTION_PREPARE receipt violates its redacted contract'
+  }
+}

--- a/services/bayn/src/execution-prepare/failure.ts
+++ b/services/bayn/src/execution-prepare/failure.ts
@@ -69,6 +69,8 @@ export type ExecutionPrepareDiscoveryField =
   | 'riskPolicyHash'
   | 'reconciliationId'
   | 'reconciliationContentHash'
+  | 'assetEligibility'
+  | 'fractionalTradingEligibility'
 
 export type ExecutionPrepareFailure =
   | { readonly _tag: 'ExecutionPrepareRequestInvalid'; readonly cause: Schema.SchemaError }
@@ -82,6 +84,7 @@ export type ExecutionPrepareFailure =
       readonly _tag: 'ExecutionPrepareStoreRejected'
       readonly operation: ExecutionStoreError['operation']
       readonly failure: ExecutionStoreError['failure']
+      readonly cause: ExecutionStoreError
     }
   | { readonly _tag: 'ExecutionPrepareGenerationMismatch'; readonly field: ExecutionPrepareGenerationField }
   | { readonly _tag: 'ExecutionPrepareReceiptHashFailed'; readonly cause: CanonicalJsonFailure }

--- a/services/bayn/src/execution-prepare/failure.ts
+++ b/services/bayn/src/execution-prepare/failure.ts
@@ -47,12 +47,37 @@ export type ExecutionPrepareGenerationField =
   | 'reconciliationId'
   | 'reconciliationContentHash'
 
+export type ExecutionPrepareDiscoveryField =
+  | 'observationReceiptHash'
+  | 'immutableBindingHash'
+  | 'candidateFactsHash'
+  | 'candidateOrdinal'
+  | 'observedPlanIntentId'
+  | 'cycleId'
+  | 'decisionHash'
+  | 'sourceRevision'
+  | 'imageRepository'
+  | 'imageDigest'
+  | 'strategyName'
+  | 'strategyBehaviorHash'
+  | 'strategyParameterHash'
+  | 'strategyParameterSchemaVersion'
+  | 'strategyProtocolHash'
+  | 'qualificationRunId'
+  | 'accountId'
+  | 'authorityGenerationHash'
+  | 'riskPolicyHash'
+  | 'reconciliationId'
+  | 'reconciliationContentHash'
+
 export type ExecutionPrepareFailure =
   | { readonly _tag: 'ExecutionPrepareRequestInvalid'; readonly cause: Schema.SchemaError }
   | { readonly _tag: 'ExecutionPrepareRuntimeBindingInvalid'; readonly cause: Schema.SchemaError }
   | { readonly _tag: 'ExecutionPrepareRuntimeMismatch'; readonly field: ExecutionPrepareRuntimeField }
   | { readonly _tag: 'ExecutionPrepareProofPlanHashFailed'; readonly cause: CanonicalJsonFailure }
   | { readonly _tag: 'ExecutionPrepareProofPlanHashMismatch' }
+  | { readonly _tag: 'ExecutionPrepareDiscoveryHashFailed'; readonly cause: CanonicalJsonFailure }
+  | { readonly _tag: 'ExecutionPrepareDiscoveryMismatch'; readonly field: ExecutionPrepareDiscoveryField }
   | {
       readonly _tag: 'ExecutionPrepareStoreRejected'
       readonly operation: ExecutionStoreError['operation']
@@ -74,6 +99,10 @@ export const renderExecutionPrepareFailure = (failure: ExecutionPrepareFailure):
       return 'EXECUTION_PREPARE proof plan could not be content-hashed'
     case 'ExecutionPrepareProofPlanHashMismatch':
       return 'EXECUTION_PREPARE proof plan hash does not match its explicit material'
+    case 'ExecutionPrepareDiscoveryHashFailed':
+      return 'EXECUTION_PREPARE discovery evidence could not be content-hashed'
+    case 'ExecutionPrepareDiscoveryMismatch':
+      return `EXECUTION_PREPARE discovery evidence drifted at ${failure.field}`
     case 'ExecutionPrepareStoreRejected':
       return `EXECUTION_PREPARE durable validation failed closed (${failure.operation}/${failure.failure})`
     case 'ExecutionPrepareGenerationMismatch':

--- a/services/bayn/src/execution-prepare/index.ts
+++ b/services/bayn/src/execution-prepare/index.ts
@@ -1,0 +1,20 @@
+export { renderExecutionPrepareFailure, type ExecutionPrepareFailure } from './failure'
+export { ExecutionPrepareStoreLive } from './live'
+export {
+  decodeExecutionPrepareReceiptResult,
+  decodeExecutionPrepareRequestResult,
+  ExecutionPrepareProofPlanSchema,
+  ExecutionPrepareReceiptSchema,
+  ExecutionPrepareRequestSchema,
+  ExecutionPrepareRuntimeBindingSchema,
+  type ExecutionPrepareProofPlan,
+  type ExecutionPrepareReceipt,
+  type ExecutionPrepareRequest,
+  type ExecutionPrepareRuntimeBinding,
+} from './model'
+export { prepareExecution } from './program'
+export {
+  makeExecutionPrepareReceipt,
+  validateExecutionPrepareInput,
+  type ValidatedExecutionPrepareInput,
+} from './validation'

--- a/services/bayn/src/execution-prepare/index.ts
+++ b/services/bayn/src/execution-prepare/index.ts
@@ -12,7 +12,7 @@ export {
   type ExecutionPrepareRequest,
   type ExecutionPrepareRuntimeBinding,
 } from './model'
-export { prepareExecution } from './program'
+export { prepareExecution, prepareValidatedExecution } from './program'
 export {
   makeExecutionPrepareReceipt,
   validateExecutionPrepareInput,

--- a/services/bayn/src/execution-prepare/index.ts
+++ b/services/bayn/src/execution-prepare/index.ts
@@ -12,9 +12,11 @@ export {
   type ExecutionPrepareRequest,
   type ExecutionPrepareRuntimeBinding,
 } from './model'
-export { prepareExecution, prepareValidatedExecution } from './program'
+export { authenticateValidatedExecutionPrepare, prepareExecution, prepareValidatedExecution } from './program'
 export {
+  authenticateExecutionPrepareDiscovery,
   makeExecutionPrepareReceipt,
   validateExecutionPrepareInput,
+  type PrevalidatedExecutionPrepareInput,
   type ValidatedExecutionPrepareInput,
 } from './validation'

--- a/services/bayn/src/execution-prepare/live.ts
+++ b/services/bayn/src/execution-prepare/live.ts
@@ -1,0 +1,16 @@
+import { PgClient } from '@effect/sql-pg'
+import { Effect, Layer } from 'effect'
+
+import type { RuntimeConfig } from '../config'
+import { CapitalGrantLifecycleStore } from '../db/execution-store'
+import { makeAuthorityPostgres } from '../db/execution-store/authority-shared'
+import { makeCapitalGrantInterpreter } from '../db/execution-store/capital-grant'
+
+export const ExecutionPrepareStoreLive = (config: RuntimeConfig) =>
+  Layer.effect(
+    CapitalGrantLifecycleStore,
+    Effect.gen(function* () {
+      const sql = yield* PgClient.PgClient
+      return makeCapitalGrantInterpreter(sql, makeAuthorityPostgres(sql), config)
+    }),
+  )

--- a/services/bayn/src/execution-prepare/model.ts
+++ b/services/bayn/src/execution-prepare/model.ts
@@ -1,0 +1,161 @@
+import { Result, Schema } from 'effect'
+
+import { BrokerEnvironment, BrokerProvider } from '../broker/identity'
+import { RuntimeProvenanceSchema } from '../contracts'
+import { BrokerAccess, CapitalAuthorityKind } from '../execution/authority'
+import { Authority } from '../execution/contracts'
+import { canonicalHashV1Result } from '../hash'
+import {
+  GitSourceRevisionSchema,
+  ImageDigestSchema,
+  ImageRepositorySchema,
+  NonNegativeIntegerSchema,
+  Sha256Schema,
+  StrictNonEmptyStringSchema,
+  strictParseOptions,
+} from '../schemas'
+
+export const executionPrepareRequestSchemaVersion = 'bayn.execution-prepare-request.v1' as const
+export const executionPrepareProofPlanSchemaVersion = 'bayn.execution-prepare-proof-plan.v1' as const
+export const executionPrepareReceiptSchemaVersion = 'bayn.execution-prepare-receipt.v1' as const
+
+const StrategySchema = RuntimeProvenanceSchema.fields.strategy.pipe(
+  Schema.refine(
+    (
+      strategy,
+    ): strategy is typeof RuntimeProvenanceSchema.fields.strategy.Type & {
+      readonly name: 'risk-balanced-trend'
+      readonly parameterSchemaVersion: 'bayn.risk-balanced-trend.protocol.v4'
+    } =>
+      strategy.name === 'risk-balanced-trend' &&
+      strategy.parameterSchemaVersion === 'bayn.risk-balanced-trend.protocol.v4',
+    { expected: 'the current risk-balanced-trend protocol v4 strategy identity' },
+  ),
+)
+
+export const ExecutionPrepareProofPlanSchema = Schema.Struct({
+  schemaVersion: Schema.Literal(executionPrepareProofPlanSchemaVersion),
+  candidate: Schema.Struct({
+    discoveryReceiptHash: Sha256Schema,
+    immutableBindingHash: Sha256Schema,
+    candidateFactsHash: Sha256Schema,
+    candidateOrdinal: NonNegativeIntegerSchema,
+    observedPlanIntentId: Sha256Schema,
+    cycleId: Sha256Schema,
+    decisionHash: Sha256Schema,
+  }),
+  binding: Schema.Struct({
+    activationSourceRevision: GitSourceRevisionSchema,
+    activationImageRepository: ImageRepositorySchema,
+    activationImageDigest: ImageDigestSchema,
+    qualificationSourceRevision: GitSourceRevisionSchema,
+    qualificationImageRepository: ImageRepositorySchema,
+    qualificationImageDigest: ImageDigestSchema,
+    strategy: StrategySchema,
+    strategyProtocolHash: Sha256Schema,
+    qualificationRunId: Sha256Schema,
+    qualificationLockId: Sha256Schema,
+    qualificationResultHash: Sha256Schema,
+    protocolHash: Sha256Schema,
+    qualificationExecutionPolicyHash: Sha256Schema,
+    accountId: StrictNonEmptyStringSchema,
+    brokerIdentityHash: Sha256Schema,
+    authorityGenerationHash: Sha256Schema,
+    riskPolicyHash: Sha256Schema,
+    reconciliationId: Sha256Schema,
+    reconciliationContentHash: Sha256Schema,
+  }),
+})
+export type ExecutionPrepareProofPlan = typeof ExecutionPrepareProofPlanSchema.Type
+
+export const ExecutionPrepareRequestSchema = Schema.Struct({
+  schemaVersion: Schema.Literal(executionPrepareRequestSchemaVersion),
+  proofPlan: ExecutionPrepareProofPlanSchema,
+  proofPlanHash: Sha256Schema,
+})
+export type ExecutionPrepareRequest = typeof ExecutionPrepareRequestSchema.Type
+
+export const decodeExecutionPrepareRequestResult = Schema.decodeUnknownResult(
+  ExecutionPrepareRequestSchema,
+  strictParseOptions,
+)
+
+export const ExecutionPrepareRuntimeBindingSchema = Schema.Struct({
+  sourceRevision: GitSourceRevisionSchema,
+  imageRepository: ImageRepositorySchema,
+  imageDigest: ImageDigestSchema,
+  strategy: StrategySchema,
+  strategyProtocolHash: Sha256Schema,
+  qualificationRunId: Sha256Schema,
+  accountId: StrictNonEmptyStringSchema,
+  brokerIdentityHash: Sha256Schema,
+  brokerProvider: Schema.Enum(BrokerProvider),
+  brokerEnvironment: Schema.Enum(BrokerEnvironment),
+  brokerAccess: Schema.Enum(BrokerAccess),
+  capitalAuthority: Schema.Enum(CapitalAuthorityKind),
+  authorityGenerationHash: Sha256Schema,
+  riskPolicyHash: Sha256Schema,
+})
+export type ExecutionPrepareRuntimeBinding = typeof ExecutionPrepareRuntimeBindingSchema.Type
+
+const ExecutionPrepareReceiptMaterialSchema = Schema.Struct({
+  schemaVersion: Schema.Literal(executionPrepareReceiptSchemaVersion),
+  operation: Schema.Literal('EXECUTION_PREPARE'),
+  dispatchable: Schema.Literal(false),
+  authority: Schema.Struct({
+    maximum: Schema.Literal(Authority.Observe),
+    effective: Schema.Literal(Authority.Observe),
+    activated: Schema.Literal(false),
+  }),
+  broker: Schema.Struct({
+    identityHash: Sha256Schema,
+    provider: Schema.Literal(BrokerProvider.Alpaca),
+    environment: Schema.Literal(BrokerEnvironment.Sandbox),
+    access: Schema.Literal(BrokerAccess.ReadOnly),
+  }),
+  candidate: ExecutionPrepareProofPlanSchema.fields.candidate,
+  qualification: Schema.Struct({
+    runId: Sha256Schema,
+    lockId: Sha256Schema,
+    resultHash: Sha256Schema,
+    protocolHash: Sha256Schema,
+    executionPolicyHash: Sha256Schema,
+  }),
+  strategy: StrategySchema,
+  generation: Schema.Struct({
+    generationHash: Sha256Schema,
+    previousGenerationHash: Sha256Schema,
+    riskPolicyHash: Sha256Schema,
+    proofPlanHash: Sha256Schema,
+  }),
+  reconciliation: Schema.Struct({
+    reconciliationId: Sha256Schema,
+    contentHash: Sha256Schema,
+  }),
+  dryRunSubmit: Schema.Struct({
+    included: Schema.Literal(false),
+    reason: Schema.Literal('MUTATION_AUTHORITY_REQUIRED'),
+  }),
+})
+
+const ExecutionPrepareReceiptBase = Schema.Struct({
+  ...ExecutionPrepareReceiptMaterialSchema.fields,
+  receiptHash: Sha256Schema,
+})
+
+export const ExecutionPrepareReceiptSchema = ExecutionPrepareReceiptBase.check(
+  Schema.makeFilter(
+    (receipt: typeof ExecutionPrepareReceiptBase.Type) => {
+      const { receiptHash, ...material } = receipt
+      const expected = canonicalHashV1Result(material)
+      return Result.isSuccess(expected) && receiptHash === expected.success
+    },
+    { expected: 'a receipt hash matching the redacted EXECUTION_PREPARE material' },
+  ),
+)
+export type ExecutionPrepareReceipt = typeof ExecutionPrepareReceiptSchema.Type
+
+export const decodeExecutionPrepareReceiptResult = Schema.decodeUnknownResult(
+  ExecutionPrepareReceiptSchema,
+  strictParseOptions,
+)

--- a/services/bayn/src/execution-prepare/model.ts
+++ b/services/bayn/src/execution-prepare/model.ts
@@ -2,6 +2,7 @@ import { Result, Schema } from 'effect'
 
 import { BrokerEnvironment, BrokerProvider } from '../broker/identity'
 import { RuntimeProvenanceSchema } from '../contracts'
+import { DiscoveryReceiptSchema } from '../execution-candidate-discovery/model'
 import { BrokerAccess, CapitalAuthorityKind } from '../execution/authority'
 import { Authority } from '../execution/contracts'
 import { canonicalHashV1Result } from '../hash'
@@ -70,6 +71,7 @@ export type ExecutionPrepareProofPlan = typeof ExecutionPrepareProofPlanSchema.T
 
 export const ExecutionPrepareRequestSchema = Schema.Struct({
   schemaVersion: Schema.Literal(executionPrepareRequestSchemaVersion),
+  discoveryReceipt: DiscoveryReceiptSchema,
   proofPlan: ExecutionPrepareProofPlanSchema,
   proofPlanHash: Sha256Schema,
 })

--- a/services/bayn/src/execution-prepare/program.ts
+++ b/services/bayn/src/execution-prepare/program.ts
@@ -5,10 +5,13 @@ import type { WriterFence } from '../execution/writer-fence'
 import type { ExecutionPrepareFailure } from './failure'
 import type { ExecutionPrepareReceipt } from './model'
 import {
+  authenticateExecutionPrepareDiscovery,
   makeExecutionPrepareReceipt,
   validateExecutionPrepareInput,
+  type PrevalidatedExecutionPrepareInput,
   type ValidatedExecutionPrepareInput,
 } from './validation'
+import type { ExecutionCandidateDiscoveryReceipt } from '../execution-candidate-discovery'
 
 export const prepareValidatedExecution = (
   validated: ValidatedExecutionPrepareInput,
@@ -21,6 +24,7 @@ export const prepareValidatedExecution = (
           _tag: 'ExecutionPrepareStoreRejected',
           operation: cause.operation,
           failure: cause.failure,
+          cause,
         }),
       ),
     )
@@ -32,8 +36,18 @@ export const prepareValidatedExecution = (
 export const prepareExecution = (
   request: unknown,
   runtime: unknown,
+  trustedDiscoveryReceipt: ExecutionCandidateDiscoveryReceipt,
 ): Effect.Effect<ExecutionPrepareReceipt, ExecutionPrepareFailure, CapitalGrantLifecycleStore | WriterFence> =>
   Effect.gen(function* () {
-    const validated = yield* Effect.fromResult(validateExecutionPrepareInput(request, runtime))
+    const prevalidated = yield* Effect.fromResult(validateExecutionPrepareInput(request, runtime))
+    const validated = yield* Effect.fromResult(
+      authenticateExecutionPrepareDiscovery(prevalidated, trustedDiscoveryReceipt),
+    )
     return yield* prepareValidatedExecution(validated)
   })
+
+export const authenticateValidatedExecutionPrepare = (
+  prevalidated: PrevalidatedExecutionPrepareInput,
+  trustedDiscoveryReceipt: ExecutionCandidateDiscoveryReceipt,
+): Effect.Effect<ValidatedExecutionPrepareInput, ExecutionPrepareFailure> =>
+  Effect.fromResult(authenticateExecutionPrepareDiscovery(prevalidated, trustedDiscoveryReceipt))

--- a/services/bayn/src/execution-prepare/program.ts
+++ b/services/bayn/src/execution-prepare/program.ts
@@ -1,0 +1,28 @@
+import { Effect, Result } from 'effect'
+
+import { CapitalGrantLifecycleStore } from '../db/execution-store'
+import type { WriterFence } from '../execution/writer-fence'
+import type { ExecutionPrepareFailure } from './failure'
+import type { ExecutionPrepareReceipt } from './model'
+import { makeExecutionPrepareReceipt, validateExecutionPrepareInput } from './validation'
+
+export const prepareExecution = (
+  request: unknown,
+  runtime: unknown,
+): Effect.Effect<ExecutionPrepareReceipt, ExecutionPrepareFailure, CapitalGrantLifecycleStore | WriterFence> =>
+  Effect.gen(function* () {
+    const validated = yield* Effect.fromResult(validateExecutionPrepareInput(request, runtime))
+    const lifecycle = yield* CapitalGrantLifecycleStore
+    const generation = yield* lifecycle.prepareCapitalGrant(validated.proof).pipe(
+      Effect.mapError(
+        (cause): ExecutionPrepareFailure => ({
+          _tag: 'ExecutionPrepareStoreRejected',
+          operation: cause.operation,
+          failure: cause.failure,
+        }),
+      ),
+    )
+    const receipt = makeExecutionPrepareReceipt(validated, generation)
+    if (Result.isFailure(receipt)) return yield* Effect.fail(receipt.failure)
+    return receipt.success
+  })

--- a/services/bayn/src/execution-prepare/program.ts
+++ b/services/bayn/src/execution-prepare/program.ts
@@ -4,14 +4,16 @@ import { CapitalGrantLifecycleStore } from '../db/execution-store'
 import type { WriterFence } from '../execution/writer-fence'
 import type { ExecutionPrepareFailure } from './failure'
 import type { ExecutionPrepareReceipt } from './model'
-import { makeExecutionPrepareReceipt, validateExecutionPrepareInput } from './validation'
+import {
+  makeExecutionPrepareReceipt,
+  validateExecutionPrepareInput,
+  type ValidatedExecutionPrepareInput,
+} from './validation'
 
-export const prepareExecution = (
-  request: unknown,
-  runtime: unknown,
+export const prepareValidatedExecution = (
+  validated: ValidatedExecutionPrepareInput,
 ): Effect.Effect<ExecutionPrepareReceipt, ExecutionPrepareFailure, CapitalGrantLifecycleStore | WriterFence> =>
   Effect.gen(function* () {
-    const validated = yield* Effect.fromResult(validateExecutionPrepareInput(request, runtime))
     const lifecycle = yield* CapitalGrantLifecycleStore
     const generation = yield* lifecycle.prepareCapitalGrant(validated.proof).pipe(
       Effect.mapError(
@@ -25,4 +27,13 @@ export const prepareExecution = (
     const receipt = makeExecutionPrepareReceipt(validated, generation)
     if (Result.isFailure(receipt)) return yield* Effect.fail(receipt.failure)
     return receipt.success
+  })
+
+export const prepareExecution = (
+  request: unknown,
+  runtime: unknown,
+): Effect.Effect<ExecutionPrepareReceipt, ExecutionPrepareFailure, CapitalGrantLifecycleStore | WriterFence> =>
+  Effect.gen(function* () {
+    const validated = yield* Effect.fromResult(validateExecutionPrepareInput(request, runtime))
+    return yield* prepareValidatedExecution(validated)
   })

--- a/services/bayn/src/execution-prepare/test-fixture.ts
+++ b/services/bayn/src/execution-prepare/test-fixture.ts
@@ -2,7 +2,11 @@ import { Result, Schema } from 'effect'
 
 import { AccountStatus, AssetClass, AssetExchange, AssetStatus } from '../broker/alpaca'
 import { Authority, OrderSide, OrderType, TimeInForce } from '../execution/contracts'
-import { DiscoveryReceiptSchema, type ExecutionCandidateDiscoveryReceipt } from '../execution-candidate-discovery/model'
+import {
+  DiscoveryReceiptSchema,
+  PaperCandidateIneligibility,
+  type ExecutionCandidateDiscoveryReceipt,
+} from '../execution-candidate-discovery/model'
 import { canonicalHashV1OrThrow } from '../hash'
 import { strictParseOptions } from '../schemas'
 
@@ -21,10 +25,13 @@ export interface ExecutionPrepareDiscoveryFixtureInput {
   readonly cycleId?: string
   readonly decisionHash?: string
   readonly observedPlanIntentId?: string
+  readonly plannedQuantityMicros?: string
+  readonly assetEligible?: boolean
+  readonly fractionalTradingEligible?: boolean
+  readonly observedAt?: string
 }
 
 const hash = (label: string): string => canonicalHashV1OrThrow({ executionPrepareFixture: label })
-const observedAt = '2099-07-24T12:00:00.000Z'
 
 export const makeExecutionPrepareDiscoveryReceiptFixture = (
   input: ExecutionPrepareDiscoveryFixtureInput,
@@ -32,6 +39,10 @@ export const makeExecutionPrepareDiscoveryReceiptFixture = (
   const cycleId = input.cycleId ?? hash('cycle')
   const decisionHash = input.decisionHash ?? hash('decision')
   const observedPlanIntentId = input.observedPlanIntentId ?? hash('observed-plan-intent')
+  const plannedQuantityMicros = input.plannedQuantityMicros ?? '1000000'
+  const assetEligible = input.assetEligible ?? true
+  const fractionalTradingEligible = input.fractionalTradingEligible ?? true
+  const observedAt = input.observedAt ?? '2099-07-24T12:00:00.000Z'
   const binding = {
     schemaVersion: 'bayn.paper-candidate-discovery-binding.v1' as const,
     runtime: {
@@ -100,7 +111,7 @@ export const makeExecutionPrepareDiscoveryReceiptFixture = (
         side: OrderSide.Buy,
         orderType: OrderType.Market,
         timeInForce: TimeInForce.Day,
-        observedPlannedQuantityMicros: '1000000',
+        observedPlannedQuantityMicros: plannedQuantityMicros,
         observedReferencePriceMicros: '500000000',
         observedNotionalLimitMicros: '500000000',
         observedEvaluatedOrderNotionalMicros: '500000000',
@@ -124,8 +135,11 @@ export const makeExecutionPrepareDiscoveryReceiptFixture = (
           attributes: [],
           normalizedResponseHash,
         },
-        assetEligibility: { eligible: true, reasons: [] },
-        fractionalTradingEligible: true,
+        assetEligibility: {
+          eligible: assetEligible,
+          reasons: assetEligible ? [] : [PaperCandidateIneligibility.NotTradable],
+        },
+        fractionalTradingEligible,
       },
     ],
     consistencyDelayMs: { status: 'REQUIRED_UNBOUND' as const },

--- a/services/bayn/src/execution-prepare/test-fixture.ts
+++ b/services/bayn/src/execution-prepare/test-fixture.ts
@@ -1,0 +1,217 @@
+import { Result, Schema } from 'effect'
+
+import { AccountStatus, AssetClass, AssetExchange, AssetStatus } from '../broker/alpaca'
+import { Authority, OrderSide, OrderType, TimeInForce } from '../execution/contracts'
+import { DiscoveryReceiptSchema, type ExecutionCandidateDiscoveryReceipt } from '../execution-candidate-discovery/model'
+import { canonicalHashV1OrThrow } from '../hash'
+import { strictParseOptions } from '../schemas'
+
+export interface ExecutionPrepareDiscoveryFixtureInput {
+  readonly sourceRevision: ExecutionCandidateDiscoveryReceipt['binding']['runtime']['sourceRevision']
+  readonly imageRepository: ExecutionCandidateDiscoveryReceipt['binding']['runtime']['image']['repository']
+  readonly imageDigest: ExecutionCandidateDiscoveryReceipt['binding']['runtime']['image']['digest']
+  readonly strategy: ExecutionCandidateDiscoveryReceipt['binding']['runtime']['strategy']
+  readonly strategyProtocolHash: string
+  readonly qualificationRunId: string
+  readonly accountId: string
+  readonly authorityGenerationHash: string
+  readonly policyHash: string
+  readonly reconciliationId: string
+  readonly reconciliationContentHash: string
+  readonly cycleId?: string
+  readonly decisionHash?: string
+  readonly observedPlanIntentId?: string
+}
+
+const hash = (label: string): string => canonicalHashV1OrThrow({ executionPrepareFixture: label })
+const observedAt = '2099-07-24T12:00:00.000Z'
+
+export const makeExecutionPrepareDiscoveryReceiptFixture = (
+  input: ExecutionPrepareDiscoveryFixtureInput,
+): ExecutionCandidateDiscoveryReceipt => {
+  const cycleId = input.cycleId ?? hash('cycle')
+  const decisionHash = input.decisionHash ?? hash('decision')
+  const observedPlanIntentId = input.observedPlanIntentId ?? hash('observed-plan-intent')
+  const binding = {
+    schemaVersion: 'bayn.paper-candidate-discovery-binding.v1' as const,
+    runtime: {
+      sourceRevision: input.sourceRevision,
+      image: { repository: input.imageRepository, digest: input.imageDigest },
+      strategy: input.strategy,
+      strategyProtocolHash: input.strategyProtocolHash,
+      qualificationRunId: input.qualificationRunId,
+      accountId: input.accountId,
+      authorityGenerationHash: input.authorityGenerationHash,
+      policyHash: input.policyHash,
+    },
+    cycle: {
+      cycleId,
+      signalSessionDate: '2099-07-23',
+      executionSessionDate: '2099-07-24',
+      snapshotId: hash('snapshot'),
+      decisionHash,
+      submissionCutoffAt: '2099-07-24T13:15:00.000Z',
+      terminalAt: '2099-07-23T20:10:00.000Z',
+    },
+    document: {
+      contentHash: hash('document'),
+      snapshotContentHash: hash('snapshot-content'),
+      snapshotFinalizedAt: '2099-07-23T20:01:00.000Z',
+      strategyDecisionHash: hash('strategy-decision'),
+      policyHash: input.policyHash,
+      planningBrokerStateHash: hash('planning-broker-state'),
+      reconciliationId: input.reconciliationId,
+      reconciliationHash: input.reconciliationContentHash,
+      targetPlanInputHash: hash('target-plan-input'),
+      targetPlanOutputHash: hash('target-plan-output'),
+      createdAt: '2099-07-23T20:05:00.000Z',
+      expiresAt: '2099-07-24T13:15:00.000Z',
+    },
+  }
+  const immutableBindingHash = canonicalHashV1OrThrow(binding)
+  const requestHash = hash('asset-request')
+  const normalizedResponseHash = hash('asset-response')
+  const candidateFacts = {
+    schemaVersion: 'bayn.paper-candidate-facts.v1' as const,
+    immutableBindingHash,
+    account: {
+      id: input.accountId,
+      status: AccountStatus.Active,
+      currency: 'USD' as const,
+      cashMicros: '1000000000',
+      equityMicros: '2000000000',
+      buyingPowerMicros: '1000000000',
+      accountBlocked: false,
+      tradingBlocked: false,
+      tradeSuspendedByUser: false,
+    },
+    accountConfiguration: {
+      schemaVersion: 'bayn.alpaca-account-configuration-observation.v1' as const,
+      source: 'alpaca-v2-account-configurations' as const,
+      requestHash: hash('account-configuration-request'),
+      fractionalTrading: true,
+      normalizedResponseHash: hash('account-configuration-response'),
+    },
+    candidates: [
+      {
+        ordinal: 0,
+        observedPlanIntentId,
+        symbol: 'SPY',
+        side: OrderSide.Buy,
+        orderType: OrderType.Market,
+        timeInForce: TimeInForce.Day,
+        observedPlannedQuantityMicros: '1000000',
+        observedReferencePriceMicros: '500000000',
+        observedNotionalLimitMicros: '500000000',
+        observedEvaluatedOrderNotionalMicros: '500000000',
+        observedTargetWeight: 0.5,
+        observedCurrentQuantityMicros: '0',
+        observedTargetQuantityMicros: '1000000',
+        observedRiskDecisionId: hash('risk-decision'),
+        observedRiskInputHash: hash('risk-input'),
+        asset: {
+          schemaVersion: 'bayn.alpaca-asset-observation.v1' as const,
+          source: 'alpaca-v2-asset' as const,
+          requestedSymbol: 'SPY',
+          requestHash,
+          assetId: 'fixture-spy-asset',
+          symbol: 'SPY',
+          assetClass: AssetClass.UsEquity,
+          exchange: AssetExchange.Arca,
+          status: AssetStatus.Active,
+          tradable: true,
+          fractionable: true,
+          attributes: [],
+          normalizedResponseHash,
+        },
+        assetEligibility: { eligible: true, reasons: [] },
+        fractionalTradingEligible: true,
+      },
+    ],
+    consistencyDelayMs: { status: 'REQUIRED_UNBOUND' as const },
+  }
+  const candidateFactsHash = canonicalHashV1OrThrow(candidateFacts)
+  const material = {
+    schemaVersion: 'bayn.paper-candidate-discovery.v2' as const,
+    operation: 'PAPER_CANDIDATE_DISCOVERY' as const,
+    authority: Authority.Observe,
+    dispatchable: false as const,
+    binding,
+    immutableBindingHash,
+    candidateFacts,
+    candidateFactsHash,
+    observations: {
+      account: {
+        value: {
+          id: input.accountId,
+          status: AccountStatus.Active,
+          currency: 'USD' as const,
+          cashMicros: '1000000000',
+          equityMicros: '2000000000',
+          lastEquityMicros: '2000000000',
+          buyingPowerMicros: '1000000000',
+          accountBlocked: false,
+          tradingBlocked: false,
+          tradeSuspendedByUser: false,
+          observedAt,
+        },
+        evidence: {
+          requestId: 'fixture-account-request',
+          status: 200,
+          contentHash: hash('account-evidence'),
+          observedAt,
+        },
+      },
+      accountConfiguration: {
+        value: {
+          schemaVersion: 'bayn.alpaca-account-configuration-observation.v1' as const,
+          source: 'alpaca-v2-account-configurations' as const,
+          requestHash: candidateFacts.accountConfiguration.requestHash,
+          fractionalTrading: true,
+          observedAt,
+          normalizedResponseHash: candidateFacts.accountConfiguration.normalizedResponseHash,
+        },
+        evidence: {
+          requestId: 'fixture-account-configuration-request',
+          status: 200,
+          contentHash: hash('account-configuration-evidence'),
+          observedAt,
+        },
+      },
+      assets: [
+        {
+          ordinal: 0,
+          value: {
+            schemaVersion: 'bayn.alpaca-asset-observation.v1' as const,
+            source: 'alpaca-v2-asset' as const,
+            requestedSymbol: 'SPY',
+            requestHash,
+            assetId: 'fixture-spy-asset',
+            symbol: 'SPY',
+            assetClass: AssetClass.UsEquity,
+            exchange: AssetExchange.Arca,
+            status: AssetStatus.Active,
+            tradable: true,
+            fractionable: true,
+            attributes: [],
+            observedAt,
+            normalizedResponseHash,
+          },
+          evidence: {
+            requestId: 'fixture-asset-request',
+            status: 200,
+            contentHash: hash('asset-evidence'),
+            observedAt,
+          },
+        },
+      ],
+    },
+    capturedAt: observedAt,
+    observationReceiptSchemaVersion: 'bayn.paper-candidate-observation-receipt.v1' as const,
+  }
+  const receipt = {
+    ...material,
+    observationReceiptHash: canonicalHashV1OrThrow(material),
+  }
+  return Result.getOrThrow(Schema.decodeUnknownResult(DiscoveryReceiptSchema, strictParseOptions)(receipt))
+}

--- a/services/bayn/src/execution-prepare/validation.ts
+++ b/services/bayn/src/execution-prepare/validation.ts
@@ -1,0 +1,200 @@
+import { pipe, Result, Schema } from 'effect'
+
+import { BrokerEnvironment, BrokerProvider } from '../broker/identity'
+import type { CapitalGrantGeneration, CapitalGrantProofBinding } from '../execution/contracts'
+import { Authority } from '../execution/contracts'
+import { BrokerAccess, CapitalAuthorityKind } from '../execution/authority'
+import { canonicalHashV1Result } from '../hash'
+import {
+  decodeExecutionPrepareReceiptResult,
+  decodeExecutionPrepareRequestResult,
+  ExecutionPrepareRuntimeBindingSchema,
+  type ExecutionPrepareReceipt,
+  type ExecutionPrepareRequest,
+  type ExecutionPrepareRuntimeBinding,
+} from './model'
+import type { ExecutionPrepareFailure, ExecutionPrepareGenerationField, ExecutionPrepareRuntimeField } from './failure'
+
+export interface ValidatedExecutionPrepareInput {
+  readonly request: ExecutionPrepareRequest
+  readonly runtime: ExecutionPrepareRuntimeBinding
+  readonly proof: CapitalGrantProofBinding
+}
+
+const fail = <A>(failure: ExecutionPrepareFailure): Result.Result<A, ExecutionPrepareFailure> => Result.fail(failure)
+
+const runtimeMismatch = <A>(field: ExecutionPrepareRuntimeField): Result.Result<A, ExecutionPrepareFailure> =>
+  fail({ _tag: 'ExecutionPrepareRuntimeMismatch', field })
+
+const generationMismatch = <A>(field: ExecutionPrepareGenerationField): Result.Result<A, ExecutionPrepareFailure> =>
+  fail({ _tag: 'ExecutionPrepareGenerationMismatch', field })
+
+const validateRuntimeAgainstProof = (
+  request: ExecutionPrepareRequest,
+  runtime: ExecutionPrepareRuntimeBinding,
+): Result.Result<void, ExecutionPrepareFailure> => {
+  const binding = request.proofPlan.binding
+  if (runtime.brokerProvider !== BrokerProvider.Alpaca) return runtimeMismatch('brokerProvider')
+  if (runtime.brokerEnvironment !== BrokerEnvironment.Sandbox) return runtimeMismatch('brokerEnvironment')
+  if (runtime.brokerAccess !== BrokerAccess.ReadOnly) return runtimeMismatch('brokerAccess')
+  if (runtime.capitalAuthority !== CapitalAuthorityKind.None) return runtimeMismatch('capitalAuthority')
+  if (binding.activationSourceRevision !== runtime.sourceRevision) return runtimeMismatch('activationSourceRevision')
+  if (binding.activationImageRepository !== runtime.imageRepository) return runtimeMismatch('activationImageRepository')
+  if (binding.activationImageDigest !== runtime.imageDigest) return runtimeMismatch('activationImageDigest')
+  if (binding.strategy.name !== runtime.strategy.name) return runtimeMismatch('strategyName')
+  if (binding.strategy.behaviorHash !== runtime.strategy.behaviorHash) return runtimeMismatch('strategyBehaviorHash')
+  if (binding.strategy.parameterHash !== runtime.strategy.parameterHash) return runtimeMismatch('strategyParameterHash')
+  if (binding.strategy.parameterSchemaVersion !== runtime.strategy.parameterSchemaVersion) {
+    return runtimeMismatch('strategyParameterSchemaVersion')
+  }
+  if (binding.strategyProtocolHash !== runtime.strategyProtocolHash) return runtimeMismatch('strategyProtocolHash')
+  if (binding.qualificationRunId !== runtime.qualificationRunId) return runtimeMismatch('qualificationRunId')
+  if (binding.accountId !== runtime.accountId) return runtimeMismatch('accountId')
+  if (binding.brokerIdentityHash !== runtime.brokerIdentityHash) return runtimeMismatch('brokerIdentity')
+  if (binding.authorityGenerationHash !== runtime.authorityGenerationHash) {
+    return runtimeMismatch('authorityGenerationHash')
+  }
+  return binding.riskPolicyHash === runtime.riskPolicyHash
+    ? Result.succeed(undefined)
+    : runtimeMismatch('riskPolicyHash')
+}
+
+export const validateExecutionPrepareInput = (
+  candidate: unknown,
+  runtimeCandidate: unknown,
+): Result.Result<ValidatedExecutionPrepareInput, ExecutionPrepareFailure> => {
+  const decodedRequest = decodeExecutionPrepareRequestResult(candidate)
+  if (Result.isFailure(decodedRequest)) {
+    return fail({ _tag: 'ExecutionPrepareRequestInvalid', cause: decodedRequest.failure })
+  }
+  const decodedRuntime = Schema.decodeUnknownResult(ExecutionPrepareRuntimeBindingSchema, {
+    onExcessProperty: 'error',
+  })(runtimeCandidate)
+  if (Result.isFailure(decodedRuntime)) {
+    return fail({ _tag: 'ExecutionPrepareRuntimeBindingInvalid', cause: decodedRuntime.failure })
+  }
+  const request = decodedRequest.success
+  const runtime = decodedRuntime.success
+  const runtimeValidation = validateRuntimeAgainstProof(request, runtime)
+  if (Result.isFailure(runtimeValidation)) return Result.fail(runtimeValidation.failure)
+  const proofPlanHash = canonicalHashV1Result(request.proofPlan)
+  if (Result.isFailure(proofPlanHash)) {
+    return fail({ _tag: 'ExecutionPrepareProofPlanHashFailed', cause: proofPlanHash.failure })
+  }
+  if (proofPlanHash.success !== request.proofPlanHash) {
+    return fail({ _tag: 'ExecutionPrepareProofPlanHashMismatch' })
+  }
+  return Result.succeed({
+    request,
+    runtime,
+    proof: {
+      schemaVersion: 'bayn.paper-authority-proof-binding.v1',
+      riskPolicyHash: runtime.riskPolicyHash,
+      proofPlanHash: request.proofPlanHash,
+    },
+  })
+}
+
+const equalGenerationBinding = (
+  generation: CapitalGrantGeneration,
+  input: ValidatedExecutionPrepareInput,
+): Result.Result<void, ExecutionPrepareFailure> => {
+  const binding = input.request.proofPlan.binding
+  if (generation.maximum !== Authority.Paper) return generationMismatch('maximum')
+  if (generation.previousGenerationHash !== binding.authorityGenerationHash) {
+    return generationMismatch('previousGenerationHash')
+  }
+  if (generation.qualificationRunId !== binding.qualificationRunId) return generationMismatch('qualificationRunId')
+  if (generation.qualificationLockId !== binding.qualificationLockId) return generationMismatch('qualificationLockId')
+  if (generation.qualificationResultHash !== binding.qualificationResultHash) {
+    return generationMismatch('qualificationResultHash')
+  }
+  if (generation.protocolHash !== binding.protocolHash) return generationMismatch('protocolHash')
+  if (generation.qualificationExecutionPolicyHash !== binding.qualificationExecutionPolicyHash) {
+    return generationMismatch('qualificationExecutionPolicyHash')
+  }
+  if (generation.qualificationSourceRevision !== binding.qualificationSourceRevision) {
+    return generationMismatch('qualificationSourceRevision')
+  }
+  if (generation.qualificationImageRepository !== binding.qualificationImageRepository) {
+    return generationMismatch('qualificationImageRepository')
+  }
+  if (generation.qualificationImageDigest !== binding.qualificationImageDigest) {
+    return generationMismatch('qualificationImageDigest')
+  }
+  if (generation.activationSourceRevision !== binding.activationSourceRevision) {
+    return generationMismatch('activationSourceRevision')
+  }
+  if (generation.activationImageRepository !== binding.activationImageRepository) {
+    return generationMismatch('activationImageRepository')
+  }
+  if (generation.activationImageDigest !== binding.activationImageDigest) {
+    return generationMismatch('activationImageDigest')
+  }
+  if (generation.strategyName !== binding.strategy.name) return generationMismatch('strategyName')
+  if (generation.strategyBehaviorHash !== binding.strategy.behaviorHash) {
+    return generationMismatch('strategyBehaviorHash')
+  }
+  if (generation.strategyParameterHash !== binding.strategy.parameterHash) {
+    return generationMismatch('strategyParameterHash')
+  }
+  if (generation.strategyParameterSchemaVersion !== binding.strategy.parameterSchemaVersion) {
+    return generationMismatch('strategyParameterSchemaVersion')
+  }
+  if (generation.accountId !== binding.accountId) return generationMismatch('accountId')
+  if (generation.riskPolicyHash !== binding.riskPolicyHash) return generationMismatch('riskPolicyHash')
+  if (generation.proofPlanHash !== input.request.proofPlanHash) return generationMismatch('proofPlanHash')
+  if (generation.reconciliationId !== binding.reconciliationId) return generationMismatch('reconciliationId')
+  return generation.reconciliationContentHash === binding.reconciliationContentHash
+    ? Result.succeed(undefined)
+    : generationMismatch('reconciliationContentHash')
+}
+
+export const makeExecutionPrepareReceipt = (
+  input: ValidatedExecutionPrepareInput,
+  generation: CapitalGrantGeneration,
+): Result.Result<ExecutionPrepareReceipt, ExecutionPrepareFailure> => {
+  const exact = equalGenerationBinding(generation, input)
+  if (Result.isFailure(exact)) return Result.fail(exact.failure)
+  const binding = input.request.proofPlan.binding
+  const material = {
+    schemaVersion: 'bayn.execution-prepare-receipt.v1' as const,
+    operation: 'EXECUTION_PREPARE' as const,
+    dispatchable: false as const,
+    authority: { maximum: Authority.Observe, effective: Authority.Observe, activated: false as const },
+    broker: {
+      identityHash: input.runtime.brokerIdentityHash,
+      provider: BrokerProvider.Alpaca,
+      environment: BrokerEnvironment.Sandbox,
+      access: BrokerAccess.ReadOnly,
+    },
+    candidate: input.request.proofPlan.candidate,
+    qualification: {
+      runId: generation.qualificationRunId,
+      lockId: generation.qualificationLockId,
+      resultHash: generation.qualificationResultHash,
+      protocolHash: generation.protocolHash,
+      executionPolicyHash: generation.qualificationExecutionPolicyHash,
+    },
+    strategy: binding.strategy,
+    generation: {
+      generationHash: generation.generationHash,
+      previousGenerationHash: generation.previousGenerationHash,
+      riskPolicyHash: generation.riskPolicyHash,
+      proofPlanHash: generation.proofPlanHash,
+    },
+    reconciliation: {
+      reconciliationId: generation.reconciliationId,
+      contentHash: generation.reconciliationContentHash,
+    },
+    dryRunSubmit: { included: false as const, reason: 'MUTATION_AUTHORITY_REQUIRED' as const },
+  }
+  const receiptHash = canonicalHashV1Result(material)
+  if (Result.isFailure(receiptHash)) {
+    return fail({ _tag: 'ExecutionPrepareReceiptHashFailed', cause: receiptHash.failure })
+  }
+  return pipe(
+    decodeExecutionPrepareReceiptResult({ ...material, receiptHash: receiptHash.success }),
+    Result.mapError((cause): ExecutionPrepareFailure => ({ _tag: 'ExecutionPrepareReceiptInvalid', cause })),
+  )
+}

--- a/services/bayn/src/execution-prepare/validation.ts
+++ b/services/bayn/src/execution-prepare/validation.ts
@@ -260,30 +260,14 @@ export const authenticateExecutionPrepareDiscovery = (
   if (Result.isFailure(candidate)) return Result.fail(candidate.failure)
   const eligibility = validateCandidateEligibility(candidate.success)
   if (Result.isFailure(eligibility)) return Result.fail(eligibility.failure)
-  const proofPlan: ExecutionPrepareProofPlan = {
-    ...input.request.proofPlan,
-    candidate: {
-      discoveryReceiptHash: trustedReceipt.observationReceiptHash,
-      immutableBindingHash: trustedReceipt.immutableBindingHash,
-      candidateFactsHash: trustedReceipt.candidateFactsHash,
-      candidateOrdinal: candidate.success.ordinal,
-      observedPlanIntentId: candidate.success.observedPlanIntentId,
-      cycleId: trustedReceipt.binding.cycle.cycleId,
-      decisionHash: trustedReceipt.binding.cycle.decisionHash,
-    },
-  }
-  const proofPlanHash = canonicalHashV1Result(proofPlan)
-  if (Result.isFailure(proofPlanHash)) {
-    return fail({ _tag: 'ExecutionPrepareProofPlanHashFailed', cause: proofPlanHash.failure })
-  }
   return Result.succeed({
     ...input,
-    proofPlan,
-    proofPlanHash: proofPlanHash.success,
+    proofPlan: input.request.proofPlan,
+    proofPlanHash: input.request.proofPlanHash,
     proof: {
       schemaVersion: 'bayn.paper-authority-proof-binding.v1',
       riskPolicyHash: input.runtime.riskPolicyHash,
-      proofPlanHash: proofPlanHash.success,
+      proofPlanHash: input.request.proofPlanHash,
     },
   })
 }

--- a/services/bayn/src/execution-prepare/validation.ts
+++ b/services/bayn/src/execution-prepare/validation.ts
@@ -9,6 +9,7 @@ import { canonicalHashV1Result } from '../hash'
 import {
   decodeExecutionPrepareReceiptResult,
   decodeExecutionPrepareRequestResult,
+  type ExecutionPrepareProofPlan,
   ExecutionPrepareRuntimeBindingSchema,
   type ExecutionPrepareReceipt,
   type ExecutionPrepareRequest,
@@ -21,9 +22,14 @@ import type {
   ExecutionPrepareRuntimeField,
 } from './failure'
 
-export interface ValidatedExecutionPrepareInput {
+export interface PrevalidatedExecutionPrepareInput {
   readonly request: ExecutionPrepareRequest
   readonly runtime: ExecutionPrepareRuntimeBinding
+}
+
+export interface ValidatedExecutionPrepareInput extends PrevalidatedExecutionPrepareInput {
+  readonly proofPlan: ExecutionPrepareProofPlan
+  readonly proofPlanHash: string
   readonly proof: CapitalGrantProofBinding
 }
 
@@ -43,10 +49,9 @@ const discoveryReceiptMaterial = (receipt: ExecutionCandidateDiscoveryReceipt) =
   return material
 }
 
-const authenticateDiscoveryReceipt = (
-  request: ExecutionPrepareRequest,
+const validateDiscoveryReceiptHashes = (
+  receipt: ExecutionCandidateDiscoveryReceipt,
 ): Result.Result<void, ExecutionPrepareFailure> => {
-  const receipt = request.discoveryReceipt
   const observationReceiptHash = canonicalHashV1Result(discoveryReceiptMaterial(receipt))
   if (Result.isFailure(observationReceiptHash)) {
     return fail({ _tag: 'ExecutionPrepareDiscoveryHashFailed', cause: observationReceiptHash.failure })
@@ -72,27 +77,26 @@ const authenticateDiscoveryReceipt = (
   }
   if (candidateFactsHash.success !== receipt.candidateFactsHash) return discoveryMismatch('candidateFactsHash')
 
-  const candidateBinding = request.proofPlan.candidate
-  const binding = request.proofPlan.binding
-  const candidate = receipt.candidateFacts.candidates[candidateBinding.candidateOrdinal]
-  if (candidate === undefined || candidate.ordinal !== candidateBinding.candidateOrdinal) {
-    return discoveryMismatch('candidateOrdinal')
-  }
-  if (candidateBinding.discoveryReceiptHash !== receipt.observationReceiptHash) {
-    return discoveryMismatch('observationReceiptHash')
-  }
-  if (candidateBinding.immutableBindingHash !== receipt.immutableBindingHash) {
-    return discoveryMismatch('immutableBindingHash')
-  }
-  if (candidateBinding.candidateFactsHash !== receipt.candidateFactsHash) {
-    return discoveryMismatch('candidateFactsHash')
-  }
-  if (candidateBinding.observedPlanIntentId !== candidate.observedPlanIntentId) {
-    return discoveryMismatch('observedPlanIntentId')
-  }
-  if (candidateBinding.cycleId !== receipt.binding.cycle.cycleId) return discoveryMismatch('cycleId')
-  if (candidateBinding.decisionHash !== receipt.binding.cycle.decisionHash) return discoveryMismatch('decisionHash')
+  return Result.succeed(undefined)
+}
 
+const selectedCandidate = (
+  receipt: ExecutionCandidateDiscoveryReceipt,
+  ordinal: number,
+): Result.Result<
+  ExecutionCandidateDiscoveryReceipt['candidateFacts']['candidates'][number],
+  ExecutionPrepareFailure
+> => {
+  const candidate = receipt.candidateFacts.candidates[ordinal]
+  return candidate === undefined || candidate.ordinal !== ordinal
+    ? discoveryMismatch('candidateOrdinal')
+    : Result.succeed(candidate)
+}
+
+const validateReceiptBinding = (
+  receipt: ExecutionCandidateDiscoveryReceipt,
+  binding: ExecutionPrepareProofPlan['binding'],
+): Result.Result<void, ExecutionPrepareFailure> => {
   const runtime = receipt.binding.runtime
   if (runtime.sourceRevision !== binding.activationSourceRevision) return discoveryMismatch('sourceRevision')
   if (runtime.image.repository !== binding.activationImageRepository) return discoveryMismatch('imageRepository')
@@ -124,6 +128,55 @@ const authenticateDiscoveryReceipt = (
   return receipt.binding.document.reconciliationHash === binding.reconciliationContentHash
     ? Result.succeed(undefined)
     : discoveryMismatch('reconciliationContentHash')
+}
+
+const validateCandidateClaim = (
+  receipt: ExecutionCandidateDiscoveryReceipt,
+  candidateBinding: ExecutionPrepareProofPlan['candidate'],
+  requireObservationReceiptHash: boolean,
+): Result.Result<void, ExecutionPrepareFailure> => {
+  const candidate = selectedCandidate(receipt, candidateBinding.candidateOrdinal)
+  if (Result.isFailure(candidate)) return Result.fail(candidate.failure)
+  if (requireObservationReceiptHash && candidateBinding.discoveryReceiptHash !== receipt.observationReceiptHash) {
+    return discoveryMismatch('observationReceiptHash')
+  }
+  if (candidateBinding.immutableBindingHash !== receipt.immutableBindingHash) {
+    return discoveryMismatch('immutableBindingHash')
+  }
+  if (candidateBinding.candidateFactsHash !== receipt.candidateFactsHash) {
+    return discoveryMismatch('candidateFactsHash')
+  }
+  if (candidateBinding.observedPlanIntentId !== candidate.success.observedPlanIntentId) {
+    return discoveryMismatch('observedPlanIntentId')
+  }
+  if (candidateBinding.cycleId !== receipt.binding.cycle.cycleId) return discoveryMismatch('cycleId')
+  if (candidateBinding.decisionHash !== receipt.binding.cycle.decisionHash) return discoveryMismatch('decisionHash')
+
+  return Result.succeed(undefined)
+}
+
+const validateCandidateEligibility = (
+  candidate: ExecutionCandidateDiscoveryReceipt['candidateFacts']['candidates'][number],
+): Result.Result<void, ExecutionPrepareFailure> => {
+  if (!candidate.assetEligibility.eligible) return discoveryMismatch('assetEligibility')
+  const fractionalQuantity = !candidate.observedPlannedQuantityMicros.padStart(7, '0').endsWith('000000')
+  return fractionalQuantity && !candidate.fractionalTradingEligible
+    ? discoveryMismatch('fractionalTradingEligibility')
+    : Result.succeed(undefined)
+}
+
+const authenticateDiscoveryReceipt = (
+  request: ExecutionPrepareRequest,
+): Result.Result<void, ExecutionPrepareFailure> => {
+  const hashes = validateDiscoveryReceiptHashes(request.discoveryReceipt)
+  if (Result.isFailure(hashes)) return Result.fail(hashes.failure)
+  const candidate = validateCandidateClaim(request.discoveryReceipt, request.proofPlan.candidate, true)
+  if (Result.isFailure(candidate)) return Result.fail(candidate.failure)
+  const binding = validateReceiptBinding(request.discoveryReceipt, request.proofPlan.binding)
+  if (Result.isFailure(binding)) return Result.fail(binding.failure)
+  const selected = selectedCandidate(request.discoveryReceipt, request.proofPlan.candidate.candidateOrdinal)
+  if (Result.isFailure(selected)) return Result.fail(selected.failure)
+  return validateCandidateEligibility(selected.success)
 }
 
 const validateRuntimeAgainstProof = (
@@ -159,7 +212,7 @@ const validateRuntimeAgainstProof = (
 export const validateExecutionPrepareInput = (
   candidate: unknown,
   runtimeCandidate: unknown,
-): Result.Result<ValidatedExecutionPrepareInput, ExecutionPrepareFailure> => {
+): Result.Result<PrevalidatedExecutionPrepareInput, ExecutionPrepareFailure> => {
   const decodedRequest = decodeExecutionPrepareRequestResult(candidate)
   if (Result.isFailure(decodedRequest)) {
     return fail({ _tag: 'ExecutionPrepareRequestInvalid', cause: decodedRequest.failure })
@@ -183,13 +236,54 @@ export const validateExecutionPrepareInput = (
   if (proofPlanHash.success !== request.proofPlanHash) {
     return fail({ _tag: 'ExecutionPrepareProofPlanHashMismatch' })
   }
+  return Result.succeed({ request, runtime })
+}
+
+export const authenticateExecutionPrepareDiscovery = (
+  input: PrevalidatedExecutionPrepareInput,
+  trustedReceipt: ExecutionCandidateDiscoveryReceipt,
+): Result.Result<ValidatedExecutionPrepareInput, ExecutionPrepareFailure> => {
+  const hashes = validateDiscoveryReceiptHashes(trustedReceipt)
+  if (Result.isFailure(hashes)) return Result.fail(hashes.failure)
+  if (trustedReceipt.immutableBindingHash !== input.request.discoveryReceipt.immutableBindingHash) {
+    return discoveryMismatch('immutableBindingHash')
+  }
+  if (trustedReceipt.candidateFactsHash !== input.request.discoveryReceipt.candidateFactsHash) {
+    return discoveryMismatch('candidateFactsHash')
+  }
+  const binding = validateReceiptBinding(trustedReceipt, input.request.proofPlan.binding)
+  if (Result.isFailure(binding)) return Result.fail(binding.failure)
+  const requestedCandidate = input.request.proofPlan.candidate
+  const candidateClaim = validateCandidateClaim(trustedReceipt, requestedCandidate, false)
+  if (Result.isFailure(candidateClaim)) return Result.fail(candidateClaim.failure)
+  const candidate = selectedCandidate(trustedReceipt, requestedCandidate.candidateOrdinal)
+  if (Result.isFailure(candidate)) return Result.fail(candidate.failure)
+  const eligibility = validateCandidateEligibility(candidate.success)
+  if (Result.isFailure(eligibility)) return Result.fail(eligibility.failure)
+  const proofPlan: ExecutionPrepareProofPlan = {
+    ...input.request.proofPlan,
+    candidate: {
+      discoveryReceiptHash: trustedReceipt.observationReceiptHash,
+      immutableBindingHash: trustedReceipt.immutableBindingHash,
+      candidateFactsHash: trustedReceipt.candidateFactsHash,
+      candidateOrdinal: candidate.success.ordinal,
+      observedPlanIntentId: candidate.success.observedPlanIntentId,
+      cycleId: trustedReceipt.binding.cycle.cycleId,
+      decisionHash: trustedReceipt.binding.cycle.decisionHash,
+    },
+  }
+  const proofPlanHash = canonicalHashV1Result(proofPlan)
+  if (Result.isFailure(proofPlanHash)) {
+    return fail({ _tag: 'ExecutionPrepareProofPlanHashFailed', cause: proofPlanHash.failure })
+  }
   return Result.succeed({
-    request,
-    runtime,
+    ...input,
+    proofPlan,
+    proofPlanHash: proofPlanHash.success,
     proof: {
       schemaVersion: 'bayn.paper-authority-proof-binding.v1',
-      riskPolicyHash: runtime.riskPolicyHash,
-      proofPlanHash: request.proofPlanHash,
+      riskPolicyHash: input.runtime.riskPolicyHash,
+      proofPlanHash: proofPlanHash.success,
     },
   })
 }
@@ -198,7 +292,7 @@ const equalGenerationBinding = (
   generation: CapitalGrantGeneration,
   input: ValidatedExecutionPrepareInput,
 ): Result.Result<void, ExecutionPrepareFailure> => {
-  const binding = input.request.proofPlan.binding
+  const binding = input.proofPlan.binding
   if (generation.maximum !== Authority.Paper) return generationMismatch('maximum')
   if (generation.previousGenerationHash !== binding.authorityGenerationHash) {
     return generationMismatch('previousGenerationHash')
@@ -242,7 +336,7 @@ const equalGenerationBinding = (
   }
   if (generation.accountId !== binding.accountId) return generationMismatch('accountId')
   if (generation.riskPolicyHash !== binding.riskPolicyHash) return generationMismatch('riskPolicyHash')
-  if (generation.proofPlanHash !== input.request.proofPlanHash) return generationMismatch('proofPlanHash')
+  if (generation.proofPlanHash !== input.proofPlanHash) return generationMismatch('proofPlanHash')
   if (generation.reconciliationId !== binding.reconciliationId) return generationMismatch('reconciliationId')
   return generation.reconciliationContentHash === binding.reconciliationContentHash
     ? Result.succeed(undefined)
@@ -255,7 +349,7 @@ export const makeExecutionPrepareReceipt = (
 ): Result.Result<ExecutionPrepareReceipt, ExecutionPrepareFailure> => {
   const exact = equalGenerationBinding(generation, input)
   if (Result.isFailure(exact)) return Result.fail(exact.failure)
-  const binding = input.request.proofPlan.binding
+  const binding = input.proofPlan.binding
   const material = {
     schemaVersion: 'bayn.execution-prepare-receipt.v1' as const,
     operation: 'EXECUTION_PREPARE' as const,
@@ -267,7 +361,7 @@ export const makeExecutionPrepareReceipt = (
       environment: BrokerEnvironment.Sandbox,
       access: BrokerAccess.ReadOnly,
     },
-    candidate: input.request.proofPlan.candidate,
+    candidate: input.proofPlan.candidate,
     qualification: {
       runId: generation.qualificationRunId,
       lockId: generation.qualificationLockId,

--- a/services/bayn/src/execution-prepare/validation.ts
+++ b/services/bayn/src/execution-prepare/validation.ts
@@ -3,6 +3,7 @@ import { pipe, Result, Schema } from 'effect'
 import { BrokerEnvironment, BrokerProvider } from '../broker/identity'
 import type { CapitalGrantGeneration, CapitalGrantProofBinding } from '../execution/contracts'
 import { Authority } from '../execution/contracts'
+import type { ExecutionCandidateDiscoveryReceipt } from '../execution-candidate-discovery/model'
 import { BrokerAccess, CapitalAuthorityKind } from '../execution/authority'
 import { canonicalHashV1Result } from '../hash'
 import {
@@ -13,7 +14,12 @@ import {
   type ExecutionPrepareRequest,
   type ExecutionPrepareRuntimeBinding,
 } from './model'
-import type { ExecutionPrepareFailure, ExecutionPrepareGenerationField, ExecutionPrepareRuntimeField } from './failure'
+import type {
+  ExecutionPrepareDiscoveryField,
+  ExecutionPrepareFailure,
+  ExecutionPrepareGenerationField,
+  ExecutionPrepareRuntimeField,
+} from './failure'
 
 export interface ValidatedExecutionPrepareInput {
   readonly request: ExecutionPrepareRequest
@@ -28,6 +34,97 @@ const runtimeMismatch = <A>(field: ExecutionPrepareRuntimeField): Result.Result<
 
 const generationMismatch = <A>(field: ExecutionPrepareGenerationField): Result.Result<A, ExecutionPrepareFailure> =>
   fail({ _tag: 'ExecutionPrepareGenerationMismatch', field })
+
+const discoveryMismatch = <A>(field: ExecutionPrepareDiscoveryField): Result.Result<A, ExecutionPrepareFailure> =>
+  fail({ _tag: 'ExecutionPrepareDiscoveryMismatch', field })
+
+const discoveryReceiptMaterial = (receipt: ExecutionCandidateDiscoveryReceipt) => {
+  const { observationReceiptHash: _observationReceiptHash, ...material } = receipt
+  return material
+}
+
+const authenticateDiscoveryReceipt = (
+  request: ExecutionPrepareRequest,
+): Result.Result<void, ExecutionPrepareFailure> => {
+  const receipt = request.discoveryReceipt
+  const observationReceiptHash = canonicalHashV1Result(discoveryReceiptMaterial(receipt))
+  if (Result.isFailure(observationReceiptHash)) {
+    return fail({ _tag: 'ExecutionPrepareDiscoveryHashFailed', cause: observationReceiptHash.failure })
+  }
+  if (observationReceiptHash.success !== receipt.observationReceiptHash) {
+    return discoveryMismatch('observationReceiptHash')
+  }
+
+  const immutableBindingHash = canonicalHashV1Result(receipt.binding)
+  if (Result.isFailure(immutableBindingHash)) {
+    return fail({ _tag: 'ExecutionPrepareDiscoveryHashFailed', cause: immutableBindingHash.failure })
+  }
+  if (
+    immutableBindingHash.success !== receipt.immutableBindingHash ||
+    immutableBindingHash.success !== receipt.candidateFacts.immutableBindingHash
+  ) {
+    return discoveryMismatch('immutableBindingHash')
+  }
+
+  const candidateFactsHash = canonicalHashV1Result(receipt.candidateFacts)
+  if (Result.isFailure(candidateFactsHash)) {
+    return fail({ _tag: 'ExecutionPrepareDiscoveryHashFailed', cause: candidateFactsHash.failure })
+  }
+  if (candidateFactsHash.success !== receipt.candidateFactsHash) return discoveryMismatch('candidateFactsHash')
+
+  const candidateBinding = request.proofPlan.candidate
+  const binding = request.proofPlan.binding
+  const candidate = receipt.candidateFacts.candidates[candidateBinding.candidateOrdinal]
+  if (candidate === undefined || candidate.ordinal !== candidateBinding.candidateOrdinal) {
+    return discoveryMismatch('candidateOrdinal')
+  }
+  if (candidateBinding.discoveryReceiptHash !== receipt.observationReceiptHash) {
+    return discoveryMismatch('observationReceiptHash')
+  }
+  if (candidateBinding.immutableBindingHash !== receipt.immutableBindingHash) {
+    return discoveryMismatch('immutableBindingHash')
+  }
+  if (candidateBinding.candidateFactsHash !== receipt.candidateFactsHash) {
+    return discoveryMismatch('candidateFactsHash')
+  }
+  if (candidateBinding.observedPlanIntentId !== candidate.observedPlanIntentId) {
+    return discoveryMismatch('observedPlanIntentId')
+  }
+  if (candidateBinding.cycleId !== receipt.binding.cycle.cycleId) return discoveryMismatch('cycleId')
+  if (candidateBinding.decisionHash !== receipt.binding.cycle.decisionHash) return discoveryMismatch('decisionHash')
+
+  const runtime = receipt.binding.runtime
+  if (runtime.sourceRevision !== binding.activationSourceRevision) return discoveryMismatch('sourceRevision')
+  if (runtime.image.repository !== binding.activationImageRepository) return discoveryMismatch('imageRepository')
+  if (runtime.image.digest !== binding.activationImageDigest) return discoveryMismatch('imageDigest')
+  if (runtime.strategy.name !== binding.strategy.name) return discoveryMismatch('strategyName')
+  if (runtime.strategy.behaviorHash !== binding.strategy.behaviorHash) {
+    return discoveryMismatch('strategyBehaviorHash')
+  }
+  if (runtime.strategy.parameterHash !== binding.strategy.parameterHash) {
+    return discoveryMismatch('strategyParameterHash')
+  }
+  if (runtime.strategy.parameterSchemaVersion !== binding.strategy.parameterSchemaVersion) {
+    return discoveryMismatch('strategyParameterSchemaVersion')
+  }
+  if (runtime.strategyProtocolHash !== binding.strategyProtocolHash) return discoveryMismatch('strategyProtocolHash')
+  if (runtime.qualificationRunId !== binding.qualificationRunId) return discoveryMismatch('qualificationRunId')
+  if (runtime.accountId !== binding.accountId || receipt.candidateFacts.account.id !== binding.accountId) {
+    return discoveryMismatch('accountId')
+  }
+  if (runtime.authorityGenerationHash !== binding.authorityGenerationHash) {
+    return discoveryMismatch('authorityGenerationHash')
+  }
+  if (runtime.policyHash !== binding.riskPolicyHash || receipt.binding.document.policyHash !== binding.riskPolicyHash) {
+    return discoveryMismatch('riskPolicyHash')
+  }
+  if (receipt.binding.document.reconciliationId !== binding.reconciliationId) {
+    return discoveryMismatch('reconciliationId')
+  }
+  return receipt.binding.document.reconciliationHash === binding.reconciliationContentHash
+    ? Result.succeed(undefined)
+    : discoveryMismatch('reconciliationContentHash')
+}
 
 const validateRuntimeAgainstProof = (
   request: ExecutionPrepareRequest,
@@ -75,6 +172,8 @@ export const validateExecutionPrepareInput = (
   }
   const request = decodedRequest.success
   const runtime = decodedRuntime.success
+  const discoveryValidation = authenticateDiscoveryReceipt(request)
+  if (Result.isFailure(discoveryValidation)) return Result.fail(discoveryValidation.failure)
   const runtimeValidation = validateRuntimeAgainstProof(request, runtime)
   if (Result.isFailure(runtimeValidation)) return Result.fail(runtimeValidation.failure)
   const proofPlanHash = canonicalHashV1Result(request.proofPlan)


### PR DESCRIPTION
## Summary

- add the explicit one-shot `EXECUTION_PREPARE` application mode and strict content-hashed operator request
- require the complete strict candidate-discovery receipt, then authenticate it against a fresh receipt re-derived from the immutable PostgreSQL shadow decision and the verified sandbox broker session; bind the exact eligible ordinal, plan intent, cycle, decision, runtime, policy, and reconciliation before PREPARE
- emit one deterministic redacted, non-dispatchable receipt and explicitly exclude `dryRunSubmit` because constructing it requires mutation authority
- reject missing requests and live broker bindings during pure config resolution, before PostgreSQL or broker acquisition
- compose PREPARE from GET-only sandbox discovery verification plus a migration-free PostgreSQL capital-grant interpreter, with no authority activation, intent/mutation writes, broker mutation, HTTP, autonomous-loop, or TigerBeetle capability
- prove successful and fail-closed operation leaves authority state/history, intents, mutations, and broker mutation count unchanged

## Related Issues

None

## Testing

- `bun run lint`
- `bun run lint:oxlint`
- `bun run lint:oxlint:type`
- `bun run lint:effect`
- `bun run tsc`
- `bun run test` — 919 passed, 138 PostgreSQL-gated tests skipped, 0 failed
- `bun run build`
- `BAYN_TEST_POSTGRES_URL=postgresql://.../bayn_test bun run test:postgres` against PostgreSQL 18.4 — 123 passed, 0 failed
- `BAYN_TEST_POSTGRES_URL=postgresql://.../bayn_test bun test src/execution-prepare/execution-prepare.integration.test.ts` against PostgreSQL 18.4 — 6 passed, 0 failed

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is handled above.
- [x] No documentation, release-note, or follow-up change is required for this bounded internal operation.


