### PR TITLE
fix(bayn): ship forward performance proof

### DIFF
--- a/.github/workflows/bayn-build-push.yml
+++ b/.github/workflows/bayn-build-push.yml
@@ -21,6 +21,7 @@ on:
       - 'nix/oci-inspect-archive.sh'
       - 'nix/oci-push.sh'
       - 'nix/oci-release-contract.sh'
+      - 'nix/verify-bayn-image-command.sh'
       - 'flake.nix'
       - 'flake.lock'
       - 'bun.lock'

--- a/.github/workflows/bayn-ci.yml
+++ b/.github/workflows/bayn-ci.yml
@@ -51,6 +51,7 @@ jobs:
               nix/oci-inspect-archive.sh | \
               nix/oci-push.sh | \
               nix/oci-release-contract.sh | \
+              nix/verify-bayn-image-command.sh | \
               flake.nix | flake.lock | bun.lock | package.json | */package.json | \
               .npmrc | bunfig.toml | patches/* | tsconfig.base.json | \
               .github/actions/setup-nix-toolchain/* | \
@@ -73,6 +74,7 @@ jobs:
               nix/ci-run-timed.sh | \
               nix/oci-inspect-archive.sh | \
               nix/oci-push.sh | \
+              nix/verify-bayn-image-command.sh | \
               flake.nix | flake.lock | bun.lock | package.json | */package.json | \
               .npmrc | bunfig.toml | patches/* | tsconfig.base.json)
                 image=true

--- a/.github/workflows/bayn-release.yml
+++ b/.github/workflows/bayn-release.yml
@@ -81,6 +81,7 @@ jobs:
             nix/ci-run-timed.sh \
             nix/oci-inspect-archive.sh \
             nix/oci-push.sh \
+            nix/verify-bayn-image-command.sh \
             flake.nix \
             flake.lock \
             package.json \

--- a/.github/workflows/nix-oci-build-common.yml
+++ b/.github/workflows/nix-oci-build-common.yml
@@ -179,6 +179,16 @@ jobs:
           bash nix/ci-run-timed.sh "inspect-image-${ARCH}" "${NIX_OCI_LOG_DIR}/inspect-image-${ARCH}.log" \
             bash nix/oci-inspect-archive.sh "${IMAGE_TAR}"
 
+      - name: Verify Bayn forward-performance command from image
+        if: inputs.image_name == 'bayn'
+        env:
+          IMAGE_TAR: ${{ steps.build.outputs.image_tar }}
+          ARCH: ${{ matrix.arch }}
+        run: |
+          set -euo pipefail
+          bash nix/ci-run-timed.sh "verify-bayn-command-${ARCH}" "${NIX_OCI_LOG_DIR}/verify-bayn-command-${ARCH}.log" \
+            bash nix/verify-bayn-image-command.sh "${IMAGE_TAR}"
+
       - name: Push platform image without Docker
         if: >-
           ${{

--- a/nix/images/bayn.nix
+++ b/nix/images/bayn.nix
@@ -13,16 +13,21 @@ let
   strategyBehaviorHash = "9e87fe0f66048c48da2191ef1fae36ef3ee0eb4ddcd036ef40881f0fe0f6eb42";
   # Canonical hash of the compiled bayn.risk-balanced-trend.protocol.v4 document.
   strategyParameterHash = "19bc51c7361b181aa48845d178cb63373b3f2e017bcbea1cf3b70ab16647f8a9";
+  forwardPerformanceCommand = pkgs.writeShellScriptBin "bayn-forward-performance" ''
+    set -eu
+    root="''${BAYN_IMAGE_ROOT:-}"
+    exec "$root/bin/node" "$root/app/services/bayn/dist/forward-performance-command.js" "$@"
+  '';
   buildDefine = name: value: "--define ${name}=${lib.escapeShellArg (builtins.toJSON value)}";
   dependencySource = import ./bun-workspace-deps-source.nix { inherit lib repoRoot; };
   depsHash = {
-    x86_64-linux = "sha256-1klocII3DNB/tQctQ+tBZPQu6pSUPYl97Rpnq+y2WgQ=";
-    aarch64-linux = "sha256-xycrSU7eH29eiEKNkrJDk+YnZURj8+xFMCcuUZgajyY=";
+    x86_64-linux = "sha256-eoTvA2uvy7ktZhMzOIJo3oekxWyxCNCJlNQaYn8BlMU=";
+    aarch64-linux = "sha256-EWmnsW92l5DHPLfe353UEMwKwgygzAEyNS1N1JvYHLY=";
   };
   buildCommands = [
     "bun --cwd=services/bayn run tsc"
     (
-      "bun --cwd=services/bayn build src/index.ts src/verify-build-contract.ts --target=node "
+      "bun --cwd=services/bayn build src/index.ts src/verify-build-contract.ts src/forward-performance-command.ts --target=node "
       + "--external tigerbeetle-node --outdir=dist "
       + buildDefine "__BAYN_BUILD_SOURCE_REVISION__" repoRevision
       + " "
@@ -34,12 +39,14 @@ let
     )
     "node services/bayn/dist/verify-build-contract.js"
     "grep -F -- ${lib.escapeShellArg repoRevision} services/bayn/dist/index.js"
+    "grep -F -- ${lib.escapeShellArg repoRevision} services/bayn/dist/forward-performance-command.js"
     "grep -F -- ${lib.escapeShellArg strategyBehaviorHash} services/bayn/dist/index.js"
     "grep -F -- ${lib.escapeShellArg strategyParameterHash} services/bayn/dist/index.js"
   ];
   runtimeInstallPhase = ''
     mkdir -p "$out/app/services/bayn/dist" "$out/app/services/bayn/node_modules/tigerbeetle-node"
     cp "$TMPDIR/work/services/bayn/dist/index.js" "$out/app/services/bayn/dist/"
+    cp "$TMPDIR/work/services/bayn/dist/forward-performance-command.js" "$out/app/services/bayn/dist/"
     cp "$TMPDIR/work/services/bayn/package.json" "$out/app/services/bayn/package.json"
     cp -R -L "$TMPDIR/work/services/bayn/node_modules/tigerbeetle-node/." \
       "$out/app/services/bayn/node_modules/tigerbeetle-node/"
@@ -78,6 +85,7 @@ import ./bun-workspace-service.nix {
   includeBunRuntime = false;
   extraContents = [
     nodejs
+    forwardPerformanceCommand
   ];
   exposedPorts = {
     "8080/tcp" = { };

--- a/nix/verify-bayn-image-command.sh
+++ b/nix/verify-bayn-image-command.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$#" -ne 1 ]]; then
+  echo "Usage: verify-bayn-image-command <nix-image-tar>" >&2
+  exit 2
+fi
+
+image_tar="$(readlink -f "$1")"
+if [[ ! -f "${image_tar}" ]] || [[ "${image_tar}" != /nix/store/* ]]; then
+  echo "Bayn image command verification requires a Nix-store image archive: ${image_tar}" >&2
+  exit 1
+fi
+
+work="$(mktemp -d)"
+cleanup() {
+  chmod -R u+rwX "${work}" 2>/dev/null || true
+  rm -rf "${work}"
+}
+trap cleanup EXIT
+archive="${work}/archive"
+rootfs="${work}/rootfs"
+mkdir -p "${archive}" "${rootfs}"
+tar -xf "${image_tar}" -C "${archive}"
+
+mapfile -t layers < <(jq -er '.[0].Layers[]' "${archive}/manifest.json")
+if [[ "${#layers[@]}" -eq 0 ]]; then
+  echo 'Bayn image archive contains no filesystem layers.' >&2
+  exit 1
+fi
+for layer in "${layers[@]}"; do
+  tar --no-same-owner -xf "${archive}/${layer}" -C "${rootfs}"
+done
+
+test -x "${rootfs}/bin/bayn-forward-performance"
+test -f "${rootfs}/app/services/bayn/dist/forward-performance-command.js"
+test -x "${rootfs}/bin/node"
+
+actual="$(BAYN_IMAGE_ROOT="${rootfs}" NODE_ENV=production "${rootfs}/bin/bayn-forward-performance" --help)"
+expected='Usage: bayn-forward-performance [--help]'
+if [[ "${actual}" != "${expected}" ]]; then
+  printf 'Unexpected Bayn forward-performance help output:\n%s\n' "${actual}" >&2
+  exit 1
+fi
+
+printf '%s\n' "${actual}"

--- a/services/bayn/package.json
+++ b/services/bayn/package.json
@@ -6,8 +6,9 @@
   "scripts": {
     "audit:qualification": "bun src/qualification-audit-command.ts",
     "candidate:qualification": "bun src/qualification-candidate-command.ts",
-    "build": "bun build src/index.ts --target=node --external tigerbeetle-node --outdir=dist",
+    "build": "bun build src/index.ts src/forward-performance-command.ts --target=node --external tigerbeetle-node --outdir=dist",
     "dev": "BAYN_PROVENANCE_MODE=development bun --watch src/index.ts",
+    "forward:performance": "BAYN_PROVENANCE_MODE=development node dist/forward-performance-command.js",
     "start": "BAYN_PROVENANCE_MODE=development node dist/index.js",
     "lint": "bun ../../node_modules/oxfmt/bin/oxfmt --check src",
     "lint:effect": "find ../../node_modules/.bun -path '*/@effect/tsgo-*/lib/tsc*' -type f ! -name '*.json' -exec chmod +x {} + 2>/dev/null || true; bun node_modules/@effect/tsgo/dist/effect-tsgo.js diagnostics --project tsconfig.json --format text --severity error",

--- a/services/bayn/src/db/cycle-observability.integration.test.ts
+++ b/services/bayn/src/db/cycle-observability.integration.test.ts
@@ -21,6 +21,7 @@ import { CycleObservability, CycleObservabilityLive } from './cycle-observabilit
 import { CycleStore, CycleStoreLive } from './cycle-store'
 import { PostgresClientLive } from './evidence-store'
 import { migrationLoader } from './migrations'
+import { readForwardPerformancePostgres } from '../forward-performance/postgres'
 
 const postgresUrl = process.env.BAYN_TEST_POSTGRES_URL
 const testUrl = postgresUrl ?? 'postgresql://bayn:bayn@127.0.0.1:5432/bayn_test'
@@ -376,6 +377,80 @@ const seedTerminalCanceledMutation = Effect.gen(function* () {
   )
 })
 
+const seedTerminalRejectedMutation = Effect.gen(function* () {
+  const sql = yield* PgClient.PgClient
+  const intentId = '4'.repeat(64)
+  const mutationId = '5'.repeat(64)
+  const requestHash = '6'.repeat(64)
+  yield* sql`
+    INSERT INTO intents (
+      intent_id, schema_version, authority_generation_hash, risk_decision_id, strategy_name, cycle_id,
+      decision_hash, policy_hash, account_id, client_order_id,
+      symbol, side, order_type, time_in_force, quantity_micros, notional_limit_micros,
+      state, terminal_outcome, state_version, created_at, updated_at
+    ) VALUES (
+      ${intentId}, 'bayn.paper-intent.v3', ${'f'.repeat(64)}, NULL,
+      'risk-balanced-trend', ${'7'.repeat(64)}, ${'8'.repeat(64)}, ${'9'.repeat(64)},
+      ${accountId}, 'bayn-observability-rejected-order', 'SPY', 'BUY', 'MARKET', 'DAY',
+      1000000, 1000000, 'PLANNED', NULL, 1,
+      '2026-03-06T21:01:00.000Z', '2026-03-06T21:01:00.000Z'
+    )
+  `
+  yield* sql.withTransaction(
+    Effect.gen(function* () {
+      yield* sql`
+        INSERT INTO risk_decisions (
+          decision_id, schema_version, input_hash, intent_id, policy_hash,
+          outcome, reason_codes, decided_at, expires_at
+        ) VALUES (
+          ${'a'.repeat(64)}, 'bayn.paper-risk-decision.v1', ${'b'.repeat(64)}, ${intentId},
+          ${'9'.repeat(64)}, 'APPROVED', ARRAY[]::text[],
+          '2026-03-06T21:01:00.001Z', '2099-01-01T00:00:00.000Z'
+        )
+      `
+      yield* sql`
+        UPDATE intents
+        SET risk_decision_id = ${'a'.repeat(64)}, state = 'APPROVED', state_version = 2,
+          updated_at = '2026-03-06T21:01:00.002Z'
+        WHERE intent_id = ${intentId}
+      `
+      yield* sql`
+        INSERT INTO mutation_events (
+          event_id, schema_version, mutation_id, intent_id, sequence, operation,
+          event_type, request_hash, consistency_delay_ms, broker_order_id,
+          request_id, response_status, response_content_hash, occurred_at
+        ) VALUES (
+          ${'c'.repeat(64)}, 'bayn.paper-mutation-event.v1', ${mutationId}, ${intentId}, 1,
+          'SUBMIT', 'SUBMIT_STARTED', ${requestHash}, 1000, NULL,
+          NULL, NULL, NULL, '2026-03-06T21:02:00.000Z'
+        )
+      `
+      yield* sql`
+        UPDATE intents
+        SET state = 'IO_STARTED', state_version = 3, updated_at = '2026-03-06T21:02:00.000Z'
+        WHERE intent_id = ${intentId}
+      `
+      yield* sql`
+        INSERT INTO mutation_events (
+          event_id, schema_version, mutation_id, intent_id, sequence, operation,
+          event_type, request_hash, consistency_delay_ms, broker_order_id,
+          request_id, response_status, response_content_hash, occurred_at
+        ) VALUES (
+          ${'d'.repeat(64)}, 'bayn.paper-mutation-event.v1', ${mutationId}, ${intentId}, 2,
+          'SUBMIT', 'SUBMIT_REJECTED', ${requestHash}, 1000, NULL,
+          'rejected-submit', 422, ${'e'.repeat(64)}, '2026-03-06T21:03:00.000Z'
+        )
+      `
+      yield* sql`
+        UPDATE intents
+        SET state = 'TERMINAL', terminal_outcome = 'REJECTED', state_version = 4,
+          updated_at = '2026-03-06T21:03:00.000001Z'
+        WHERE intent_id = ${intentId}
+      `
+    }),
+  )
+})
+
 describePostgres('PostgreSQL cycle observability projection', () => {
   let runtime: ReturnType<typeof makeRuntime>
 
@@ -646,6 +721,99 @@ describePostgres('PostgreSQL cycle observability projection', () => {
         eventCount: 6,
         unresolvedCount: 0,
         oldestUnresolvedAt: null,
+        latestOccurredAt: '2026-03-06T21:07:00.000Z',
+      },
+    })
+  })
+
+  test('forward performance rejects a reconciliation predating a terminal no-fill rejection', async () => {
+    const result = await runtime.runPromise(
+      Effect.gen(function* () {
+        const observability = yield* CycleObservability
+        const sql = yield* PgClient.PgClient
+        yield* seedSafetyState('2026-03-06T21:00:00.000Z')
+        yield* seedTerminalRejectedMutation
+        const evidence = yield* readForwardPerformancePostgres(sql, accountId)
+        const projection = yield* observability.read(qualificationRunId, accountId)
+        const [activity] = yield* sql<{ fills: number; accounting: number }>`
+          SELECT
+            (SELECT count(*)::integer FROM fills WHERE account_id = ${accountId}) AS fills,
+            (SELECT count(*)::integer FROM accounting_transactions WHERE account_id = ${accountId}) AS accounting
+        `
+        return { activity, evidence, projection }
+      }),
+    )
+
+    expect(result.activity).toEqual({ fills: 0, accounting: 0 })
+    expect(result.evidence).toMatchObject({
+      transactions: [],
+      unresolvedMutationCount: 0,
+      unaccountedFillCount: 0,
+      postReconciliationActivityCount: 2,
+    })
+    expect(result.projection).toMatchObject({
+      reconciliation: { coversLatestMutation: false },
+      mutations: {
+        eventCount: 2,
+        unresolvedCount: 0,
+        latestOccurredAt: '2026-03-06T21:03:00.000Z',
+      },
+    })
+  })
+
+  test('forward performance and cycle observability fail closed on a same-timestamp terminal mutation', async () => {
+    const result = await runtime.runPromise(
+      Effect.gen(function* () {
+        const observability = yield* CycleObservability
+        const sql = yield* PgClient.PgClient
+        yield* seedSafetyState('2026-03-06T21:03:00.000Z')
+        yield* seedTerminalRejectedMutation
+        const evidence = yield* readForwardPerformancePostgres(sql, accountId)
+        const projection = yield* observability.read(qualificationRunId, accountId)
+        return { evidence, projection }
+      }),
+    )
+
+    expect(result.evidence).toMatchObject({
+      transactions: [],
+      unresolvedMutationCount: 0,
+      unaccountedFillCount: 0,
+      postReconciliationActivityCount: 1,
+    })
+    expect(result.projection).toMatchObject({
+      reconciliation: { coversLatestMutation: false },
+      mutations: {
+        eventCount: 2,
+        unresolvedCount: 0,
+        latestOccurredAt: '2026-03-06T21:03:00.000Z',
+      },
+    })
+  })
+
+  test('forward performance rejects a reconciliation predating terminal no-fill cancellation history', async () => {
+    const result = await runtime.runPromise(
+      Effect.gen(function* () {
+        const observability = yield* CycleObservability
+        const sql = yield* PgClient.PgClient
+        yield* seedSafetyState('2026-03-06T21:00:00.000Z')
+        yield* seedTerminalCanceledMutation
+        const evidence = yield* readForwardPerformancePostgres(sql, accountId)
+        const projection = yield* observability.read(qualificationRunId, accountId)
+        return { evidence, projection }
+      }),
+    )
+
+    expect(result.evidence).toMatchObject({
+      transactions: [],
+      unresolvedMutationCount: 0,
+      unaccountedFillCount: 0,
+      postReconciliationActivityCount: 6,
+    })
+    expect(result.projection).toMatchObject({
+      reconciliation: { coversLatestMutation: false },
+      mutations: {
+        eventCount: 6,
+        unresolvedCount: 0,
         latestOccurredAt: '2026-03-06T21:07:00.000Z',
       },
     })

--- a/services/bayn/src/db/cycle-observability.ts
+++ b/services/bayn/src/db/cycle-observability.ts
@@ -409,7 +409,7 @@ const makeCycleObservability = Effect.gen(function* () {
             CASE
               WHEN reconciliation.reconciliation_id IS NULL THEN NULL
               WHEN NOT EXISTS (SELECT 1 FROM account_mutation_events) THEN true
-              ELSE reconciliation.reconciled_at >= (SELECT max(occurred_at) FROM account_mutation_events)
+              ELSE reconciliation.reconciled_at > (SELECT max(occurred_at) FROM account_mutation_events)
             END AS reconciliation_covers_latest_mutation,
             (SELECT count(*)::integer FROM account_mutation_events) AS mutation_event_count,
             (SELECT count(*)::integer FROM unresolved_mutations) AS unresolved_mutation_count,

--- a/services/bayn/src/forward-performance-command.ts
+++ b/services/bayn/src/forward-performance-command.ts
@@ -8,7 +8,14 @@ import { runForwardPerformance, ForwardPerformanceProgramError } from './forward
 
 export { runForwardPerformance } from './forward-performance'
 
-const main = Effect.scoped(
+export const FORWARD_PERFORMANCE_COMMAND_USAGE = 'Usage: bayn-forward-performance [--help]'
+
+const printUsage = Effect.gen(function* () {
+  const stdio = yield* Stdio.Stdio
+  yield* Stream.run(Stream.make(`${FORWARD_PERFORMANCE_COMMAND_USAGE}\n`), stdio.stdout())
+})
+
+const runProof = Effect.scoped(
   Effect.gen(function* () {
     const config = yield* loadConfig()
     const receipt = yield* runForwardPerformance(config).pipe(Effect.provide(PostgresClientLive(config)))
@@ -28,6 +35,7 @@ const main = Effect.scoped(
 )
 
 const runtime = Layer.mergeAll(Logger.layer([Logger.consoleJson]), NodeServices.layer)
+const main = process.argv.slice(2).includes('--help') ? printUsage : runProof
 const program = main.pipe(Effect.annotateLogs({ service: 'bayn-forward-performance' }), Effect.provide(runtime))
 
 if (import.meta.main) NodeRuntime.runMain(program)

--- a/services/bayn/src/forward-performance/postgres.ts
+++ b/services/bayn/src/forward-performance/postgres.ts
@@ -423,6 +423,13 @@ export const readForwardPerformancePostgres = (
                 FROM accounting_transactions AS transaction
                 WHERE transaction.broker_event_id = fill.event_id
               )
+            UNION ALL
+            SELECT event.event_id AS activity_id
+            FROM mutation_events AS event
+            JOIN intents AS intent ON intent.intent_id = event.intent_id
+            CROSS JOIN latest_reconciliation
+            WHERE intent.account_id = ${accountId}
+              AND event.occurred_at >= latest_reconciliation.reconciled_at
           ) AS activity
         `.pipe(Effect.flatMap(decodeCount))
 


### PR DESCRIPTION
## Summary

- compile and ship `forward-performance-command.js` in the Bayn runtime image with the supported `bayn-forward-performance` executable
- prove the executable from each built OCI archive by extracting its exact root filesystem and invoking `bayn-forward-performance --help`
- close forward-performance windows over every selected-account mutation event, matching the existing cycle-observability reconciliation coverage predicate
- add PostgreSQL regressions for terminal rejected and canceled no-fill mutation histories that occur after reconciliation

## Corrects

- https://github.com/proompteng/lab/pull/13376#discussion_r3679889279
- https://github.com/proompteng/lab/pull/13376#discussion_r3679889285

## Testing

- `bun run --cwd services/bayn build`
- `node services/bayn/dist/forward-performance-command.js --help`
- `bun test services/bayn/src/forward-performance` — 12 passed, 0 failed
- `bun run --cwd services/bayn test` — 895 passed, 130 environment-gated skips, 0 failed
- `bun run --cwd services/bayn tsc`
- `bun run --cwd services/bayn lint`
- `bun run --cwd services/bayn lint:oxlint`
- `bun run --cwd services/bayn lint:oxlint:type`
- `bun run --cwd services/bayn lint:effect`
- `bun install --frozen-lockfile --ignore-scripts --filter @proompteng/bayn`
- `bash -n nix/verify-bayn-image-command.sh`
- parsed all changed workflows with `yq`
- PR PostgreSQL integration executes the two new terminal no-fill mutation regressions
- PR image jobs execute `nix/verify-bayn-image-command.sh` against the exact amd64 and arm64 OCI archives

## Breaking Changes

None.

## Checklist

- [x] Testing section documents exact validation.
- [x] No screenshots apply.
- [x] Runtime entrypoint, authority, broker mutation, and safety gates remain unchanged.
- [x] The corrective branch will remain after merge.
