### PR TITLE
fix(bayn): redact broker account identity

### DIFF
--- a/services/bayn/src/broker/alpaca/preflight.ts
+++ b/services/bayn/src/broker/alpaca/preflight.ts
@@ -226,7 +226,6 @@ export const verifyReadAccess = (
     )
     yield* Effect.logInfo('Alpaca observe-only read preflight passed').pipe(
       Effect.annotateLogs({
-        accountId: proof.accountId,
         provider: proof.provider,
         environment: proof.environment,
         baseUrl: proof.baseUrl,

--- a/services/bayn/src/broker/alpaca/session.test.ts
+++ b/services/bayn/src/broker/alpaca/session.test.ts
@@ -156,8 +156,18 @@ describe('Alpaca broker session acquisition retry', () => {
     })
     expect(accountRequests).toBe(3)
     expect(requests).toBe(11)
-    expect(JSON.stringify(logs)).not.toContain(key)
-    expect(JSON.stringify(logs)).not.toContain(secret)
+    const renderedLogs = JSON.stringify(logs)
+    expect(renderedLogs).not.toContain(key)
+    expect(renderedLogs).not.toContain(secret)
+    expect(renderedLogs).not.toContain(accountId)
+    expect(renderedLogs).not.toContain(accountResponse.account_number)
+    expect(logs).toContainEqual(
+      expect.objectContaining({
+        annotations: expect.objectContaining({
+          accountHash: services.session.preflight.accountHash,
+        }),
+      }),
+    )
   })
 
   test('attempts a deterministic account mismatch once and preserves its typed stage without credentials', async () => {

--- a/services/bayn/src/http.test.ts
+++ b/services/bayn/src/http.test.ts
@@ -36,7 +36,7 @@ import {
   statusResponseDecision,
   validateHistoricalRunRequest,
 } from './http'
-import { Authority, KillState } from './paper'
+import { Authority, KillState, ReconciliationStatus } from './paper'
 import { initialState, type RuntimeState } from './runtime-state'
 
 const metricValue = (metrics: string, name: string): number => {
@@ -581,6 +581,140 @@ describe('Bayn HTTP pure decisions', () => {
         testCase.name,
       ).toEqual(testCase.expected)
     }
+  })
+
+  test('omits raw broker account identity while preserving safe configured, mismatch, and read-failure facts', () => {
+    const expectedAccountId = 'paper-account-expected'
+    const observedAccountId = 'paper-account-observed'
+    const checkedAt = '2026-07-20T00:00:00.000Z'
+    const base: RuntimeState = {
+      ...readyState(),
+      status: 'DEGRADED',
+      broker: {
+        configured: true,
+        expectedAccountId,
+        accountId: null,
+        accountBound: false,
+        readAvailable: false,
+        checkedAt,
+        error: null,
+        executionEligible: false,
+        executionDisabledReason: 'MAXIMUM_AUTHORITY_OBSERVE',
+      },
+    }
+    const configured = statusFacts(
+      {
+        ...base,
+        broker: {
+          ...base.broker!,
+          accountBound: null,
+          readAvailable: null,
+        },
+      },
+      readOnlyExecution,
+      provenance,
+      'embedded',
+    )
+    const mismatchMessage = `Alpaca credential resolved account ${observedAccountId}, expected ${expectedAccountId}`
+    const mismatch = statusFacts(
+      {
+        ...base,
+        error: `broker: ${mismatchMessage}`,
+        broker: {
+          ...base.broker!,
+          error: mismatchMessage,
+        },
+      },
+      readOnlyExecution,
+      provenance,
+      'embedded',
+    )
+    const readFailure = statusFacts(
+      {
+        ...base,
+        error: 'broker: Alpaca account unavailable',
+        broker: {
+          ...base.broker!,
+          error: 'Alpaca account unavailable',
+        },
+      },
+      readOnlyExecution,
+      provenance,
+      'embedded',
+    )
+
+    expect(configured.broker).toMatchObject({
+      configured: true,
+      accountBound: null,
+      readAvailable: null,
+      reasonCode: 'BROKER_STATUS_NOT_CHECKED',
+      error: null,
+    })
+    expect(mismatch.broker).toMatchObject({
+      configured: true,
+      accountBound: false,
+      readAvailable: false,
+      reasonCode: 'BROKER_ACCOUNT_IDENTITY_MISMATCH',
+      error: 'BROKER_ACCOUNT_IDENTITY_MISMATCH',
+    })
+    expect(mismatch.error).toBe('broker: BROKER_ACCOUNT_IDENTITY_MISMATCH')
+    expect(readFailure.broker).toMatchObject({
+      configured: true,
+      accountBound: false,
+      readAvailable: false,
+      reasonCode: 'BROKER_READ_UNAVAILABLE',
+      error: 'BROKER_READ_UNAVAILABLE',
+    })
+    for (const facts of [configured, mismatch, readFailure]) {
+      const rendered = JSON.stringify(facts)
+      expect(rendered).not.toContain(expectedAccountId)
+      expect(rendered).not.toContain(observedAccountId)
+      expect(facts.broker).not.toHaveProperty('expectedAccountId')
+      expect(facts.broker).not.toHaveProperty('accountId')
+    }
+  })
+
+  test('omits broker account identity from public cycle observations', () => {
+    const accountId = 'paper-account-cycle-observation'
+    const observedAt = '2026-07-20T12:00:00.000Z'
+    const state: RuntimeState = {
+      ...readyState(),
+      cycle: {
+        ...readyState().cycle,
+        current: {
+          cycleId: '1'.repeat(64),
+          accountId,
+          signalSessionDate: '2026-07-17',
+          executionSessionDate: '2026-07-20',
+          phase: CycleState.Pending,
+          snapshotId: '2'.repeat(64),
+          decisionHash: null,
+          terminalReason: null,
+          submissionOpenAt: '2026-07-20T11:30:00.000Z',
+          submissionCutoffAt: '2026-07-20T12:30:00.000Z',
+          executionOpenAt: '2026-07-20T12:32:00.000Z',
+          executionCloseAt: '2026-07-20T20:00:00.000Z',
+          createdAt: '2026-07-20T11:29:00.000Z',
+          updatedAt: observedAt,
+          terminalAt: null,
+        },
+        reconciliation: {
+          accountId,
+          reconciliationId: '3'.repeat(64),
+          status: ReconciliationStatus.Exact,
+          discrepancyCount: 0,
+          reconciledAt: observedAt,
+          coversLatestMutation: true,
+        },
+      },
+    }
+
+    const facts = statusFacts(state, readOnlyExecution, provenance, 'embedded')
+    expect(JSON.stringify(facts)).not.toContain(accountId)
+    expect('current' in facts.cycle).toBe(true)
+    if (!('current' in facts.cycle)) return
+    expect(facts.cycle.current).not.toHaveProperty('accountId')
+    expect(facts.cycle.reconciliation).not.toHaveProperty('accountId')
   })
 
   test('maps database and timeout failures to the typed operational boundary with the cause intact', async () => {
@@ -1178,7 +1312,7 @@ describe('Bayn HTTP probes', () => {
     )
   })
 
-  test('keeps broker read capability out of runtime state and public status', async () => {
+  test('keeps broker read capability and raw account identity out of runtime state and public status', async () => {
     const unused = Effect.die('status must not invoke broker reads')
     const read: BrokerReadShape = {
       account: unused,
@@ -1208,13 +1342,18 @@ describe('Bayn HTTP probes', () => {
             expect(response.body).toMatchObject({
               broker: {
                 configured: true,
-                expectedAccountId: 'paper-account-1',
+                accountBound: null,
+                readAvailable: null,
                 executionEligible: false,
                 executionDisabledReason: 'MAXIMUM_AUTHORITY_OBSERVE',
+                reasonCode: 'BROKER_STATUS_NOT_CHECKED',
               },
             })
             const body = response.body as { readonly broker: Record<string, unknown> }
             expect(body.broker).not.toHaveProperty('read')
+            expect(body.broker).not.toHaveProperty('expectedAccountId')
+            expect(body.broker).not.toHaveProperty('accountId')
+            expect(JSON.stringify(response.body)).not.toContain('paper-account-1')
             expect(Object.values(body.broker).some((value) => typeof value === 'function')).toBe(false)
           }),
         ),

--- a/services/bayn/src/http.ts
+++ b/services/bayn/src/http.ts
@@ -66,20 +66,81 @@ const accountingState = (state: RuntimeState) => {
   return state.health.dependencies.tigerBeetle.status === 'AVAILABLE' ? 'EXACT' : 'UNAVAILABLE'
 }
 
-const publicBrokerState = (state: RuntimeState) =>
-  state.broker === null
-    ? {
-        configured: false,
-        expectedAccountId: null,
-        accountId: null,
-        accountBound: false,
-        readAvailable: false,
-        checkedAt: null,
-        executionEligible: false,
-        executionDisabledReason: 'ALPACA_NOT_CONFIGURED',
-        error: null,
+const brokerPresentationReason = (broker: NonNullable<RuntimeState['broker']>): string | null => {
+  const identityMismatch =
+    broker.accountBound === false &&
+    (broker.readAvailable === true ||
+      broker.error?.includes('Alpaca credential resolved account ') === true ||
+      broker.error?.includes('Alpaca account probe resolved ') === true)
+  if (identityMismatch) return 'BROKER_ACCOUNT_IDENTITY_MISMATCH'
+  if (broker.accountBound === null || broker.readAvailable === null) return 'BROKER_STATUS_NOT_CHECKED'
+  if (broker.readAvailable === false) return 'BROKER_READ_UNAVAILABLE'
+  if (broker.accountBound === false) return 'BROKER_ACCOUNT_BINDING_UNAVAILABLE'
+  return broker.error === null ? null : 'BROKER_STATUS_UNAVAILABLE'
+}
+
+const publicBrokerState = (state: RuntimeState) => {
+  if (state.broker === null) {
+    return {
+      configured: false,
+      accountBound: false,
+      readAvailable: false,
+      checkedAt: null,
+      executionEligible: false,
+      executionDisabledReason: 'ALPACA_NOT_CONFIGURED',
+      reasonCode: 'ALPACA_NOT_CONFIGURED',
+      error: null,
+    } as const
+  }
+  const reasonCode = brokerPresentationReason(state.broker)
+  return {
+    configured: true,
+    accountBound: state.broker.accountBound,
+    readAvailable: state.broker.readAvailable,
+    checkedAt: state.broker.checkedAt,
+    executionEligible: state.broker.executionEligible,
+    executionDisabledReason: state.broker.executionDisabledReason,
+    reasonCode,
+    error: state.broker.error === null ? null : reasonCode,
+  } as const
+}
+
+const publicRuntimeError = (state: RuntimeState, broker: ReturnType<typeof publicBrokerState>): string | null => {
+  const brokerError = state.broker?.error
+  if (state.error === null || brokerError === null || brokerError === undefined) return state.error
+  return state.error.replaceAll(brokerError, broker.error ?? 'BROKER_STATUS_UNAVAILABLE')
+}
+
+const publicCycleSnapshot = (snapshot: RuntimeState['cycle']['current']) =>
+  snapshot === null
+    ? null
+    : {
+        cycleId: snapshot.cycleId,
+        signalSessionDate: snapshot.signalSessionDate,
+        executionSessionDate: snapshot.executionSessionDate,
+        phase: snapshot.phase,
+        snapshotId: snapshot.snapshotId,
+        decisionHash: snapshot.decisionHash,
+        terminalReason: snapshot.terminalReason,
+        submissionOpenAt: snapshot.submissionOpenAt,
+        submissionCutoffAt: snapshot.submissionCutoffAt,
+        executionOpenAt: snapshot.executionOpenAt,
+        executionCloseAt: snapshot.executionCloseAt,
+        createdAt: snapshot.createdAt,
+        updatedAt: snapshot.updatedAt,
+        terminalAt: snapshot.terminalAt,
       }
-    : state.broker
+
+const publicCycleReconciliation = (reconciliation: RuntimeState['cycle']['reconciliation']) =>
+  reconciliation === null
+    ? null
+    : {
+        reconciliationId: reconciliation.reconciliationId,
+        status: reconciliation.status,
+        discrepancyCount: reconciliation.discrepancyCount,
+        reconciledAt: reconciliation.reconciledAt,
+        coversLatestMutation: reconciliation.coversLatestMutation,
+      }
 
 const publicCycleState = (state: RuntimeState) =>
   state.cycle.condition === CycleOperationsCondition.Unknown
@@ -94,6 +155,9 @@ const publicCycleState = (state: RuntimeState) =>
       }
     : {
         ...state.cycle,
+        current: publicCycleSnapshot(state.cycle.current),
+        last: publicCycleSnapshot(state.cycle.last),
+        reconciliation: publicCycleReconciliation(state.cycle.reconciliation),
         observationAvailable: true,
       }
 
@@ -103,6 +167,7 @@ export const statusFacts = (
   provenance: RuntimeProvenance,
   provenanceVerification: RuntimeBuildMetadata['verification'],
 ) => {
+  const broker = publicBrokerState(state)
   return {
     service: 'bayn',
     operational: {
@@ -144,7 +209,7 @@ export const statusFacts = (
     },
     cycle: publicCycleState(state),
     autonomousCycleLoop: state.autonomousCycleLoop,
-    broker: publicBrokerState(state),
+    broker,
     authority: {
       brokerEnvironment: execution.brokerIdentity?.environment ?? null,
       brokerAccess: execution.brokerAccess,
@@ -181,7 +246,7 @@ export const statusFacts = (
       image: provenance.image,
       verification: provenanceVerification,
     },
-    error: state.error,
+    error: publicRuntimeError(state, broker),
   } as const
 }
 


### PR DESCRIPTION
## Summary
- remove raw expected and observed broker account identifiers from `/v1/status`, including nested cycle and reconciliation projections
- replace broker mismatch/read errors with bounded public reason codes while preserving internal fail-closed identity comparison and readiness behavior
- omit raw account identity from successful Alpaca observe-only preflight logs while retaining the existing account proof hash

## Validation
- `bun test src/http.test.ts src/broker/alpaca/session.test.ts`
- `bun test` (897 pass, 131 skip, 0 fail)
- `bun run tsc`
- `bun run lint`
- `bun run lint:effect`
- `bun run lint:oxlint`
- `bun run lint:oxlint:type`
- `bun run build`
