### PR TITLE
fix(bayn): redact cycle account drift errors

### DIFF
--- a/services/bayn/src/health.test.ts
+++ b/services/bayn/src/health.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, test } from 'bun:test'
 import { Deferred, Effect, Fiber, Ref, Result } from 'effect'
 import { TestClock } from 'effect/testing'
 
-import { config, fixtureLock, successfulJournal, readyState, recoveringStore } from './app-test-support'
+import { config, fixtureLock, provenance, successfulJournal, readyState, recoveringStore } from './app-test-support'
 import {
   AccountStatus,
   BrokerProvider,
@@ -39,6 +39,7 @@ import {
   validateDurableEvidence,
   validateSignalIdentity,
 } from './health'
+import { readinessResponseDecision, statusFacts } from './http'
 import { Journal, type JournalService } from './ledger'
 import { MarketData, type MarketDataService } from './market-data'
 import { initialState, type RuntimeState } from './runtime-state'
@@ -982,6 +983,70 @@ describe('Bayn continuous health', () => {
     })
   })
 
+  test('redacts cycle account identity drift from runtime health, status, and logs', () => {
+    const current = readyState()
+    const checkedAt = '2026-07-20T00:04:00.000Z'
+    const accountId = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc'
+    const rawError =
+      `PostgreSQL cycle-observability failed: configured account ${accountId} ` +
+      'differs from the projected current or last cycle'
+    const publicError = 'configured account binding differs from the projected current or last cycle'
+    const transition = deriveHealthTransition(current, {
+      config,
+      evidenceAvailable: true,
+      results: {
+        postgresql: { _tag: 'Available', value: undefined },
+        signal: { _tag: 'Available', value: undefined },
+        tigerBeetle: { _tag: 'Available', value: undefined },
+        durableEvidence: { _tag: 'Available', value: undefined },
+        cycle: { _tag: 'Unavailable', error: rawError },
+        broker: null,
+      },
+      broker: undefined,
+      cycleFiber: { _tag: 'NotProvided' },
+      clock: availableClock(checkedAt),
+    })
+    const logDecisions = deriveHealthLogDecisions(transition)
+
+    expect(transition).toMatchObject({
+      next: {
+        status: 'DEGRADED',
+        error: `cycle: ${publicError}`,
+        health: {
+          dependencies: {
+            cycle: {
+              status: 'UNAVAILABLE',
+              checkedAt,
+              error: publicError,
+            },
+          },
+        },
+        cycle: {
+          condition: CycleOperationsCondition.Unknown,
+          reason: CycleOperationsReason.ObservationUnavailable,
+          checkedAt,
+          error: publicError,
+        },
+      },
+      failedDependencies: ['cycle'],
+    })
+    expect(logDecisions).toMatchObject([
+      {
+        _tag: 'RuntimeStatusChanged',
+        annotations: { failedDependencies: 'cycle' },
+      },
+      {
+        _tag: 'CycleOperationsChanged',
+        annotations: { cycleError: publicError },
+      },
+    ])
+    const publicStatus = statusFacts(transition.next, config.execution, provenance, 'embedded')
+    expect(publicStatus.dependencies.cycle.error).toBe('CYCLE_ACCOUNT_IDENTITY_MISMATCH')
+    expect(publicStatus.cycle.error).toBe('CYCLE_ACCOUNT_IDENTITY_MISMATCH')
+    expect(JSON.stringify({ transition, logDecisions })).not.toContain(accountId)
+    expect(JSON.stringify({ transition, logDecisions })).not.toContain(rawError)
+  })
+
   test('retains clock failure alongside an unavailable cycle projection and logs clock recovery', () => {
     const projectionError = 'cycle projection timed out'
     const clockError = 'cycle operations clock must be a safe integer epoch millisecond: observed=NaN'
@@ -1265,7 +1330,7 @@ describe('Bayn continuous health', () => {
     }
   })
 
-  test('degrades on account identity or permission drift and recovers after exact restoration', async () => {
+  test('preserves identity mismatch precedence and recovers from every permission drift', async () => {
     const control = brokerReadControl()
     const broker = brokerProbe(brokerRead(control))
     const initial = brokerRuntimeState(broker)
@@ -1274,16 +1339,26 @@ describe('Bayn continuous health', () => {
 
     const expectDriftAndRecovery = async (expectedError: string, restore: () => void) => {
       await Effect.runPromise(provideHealthyDependencies(initial, probe(config, state, broker, cycleFiber)))
-      expect(await Effect.runPromise(Ref.get(state))).toMatchObject({
+      const drifted = await Effect.runPromise(Ref.get(state))
+      expect(drifted).toMatchObject({
         status: 'DEGRADED',
         broker: {
-          accountId: null,
-          accountBound: false,
+          accountId: brokerAccountId,
+          accountBound: true,
           readAvailable: false,
           error: expectedError,
         },
         error: `broker: ${expectedError}`,
       })
+      const readiness = readinessResponseDecision(drifted)
+      expect(readiness).toMatchObject({ _tag: 'Json', status: 503 })
+      if (readiness._tag !== 'Json') throw new Error('expected JSON readiness decision')
+      const readinessBody = readiness.body as {
+        readonly ready: boolean
+        readonly failedDependencies: readonly string[]
+      }
+      expect(readinessBody.ready).toBe(false)
+      expect(readinessBody.failedDependencies).toContain('broker')
       restore()
       await Effect.runPromise(provideHealthyDependencies(initial, probe(config, state, broker, cycleFiber)))
       expect(await Effect.runPromise(Ref.get(state))).toMatchObject({
@@ -1294,9 +1369,59 @@ describe('Bayn continuous health', () => {
     }
 
     try {
-      control.accountId = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
-      await expectDriftAndRecovery('Alpaca account identity drift detected', () => {
-        control.accountId = brokerAccountId
+      const observedAccountId = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+      control.accountId = observedAccountId
+      await Effect.runPromise(provideHealthyDependencies(initial, probe(config, state, broker, cycleFiber)))
+      expect(await Effect.runPromise(Ref.get(state))).toMatchObject({
+        status: 'DEGRADED',
+        broker: {
+          accountId: observedAccountId,
+          accountBound: false,
+          readAvailable: true,
+          error: 'Alpaca account identity drift detected',
+        },
+        error: 'broker: Alpaca account identity drift detected',
+      })
+
+      control.accountId = brokerAccountId
+      await Effect.runPromise(provideHealthyDependencies(initial, probe(config, state, broker, cycleFiber)))
+      expect(await Effect.runPromise(Ref.get(state))).toMatchObject({
+        status: 'READY',
+        broker: {
+          accountId: brokerAccountId,
+          accountBound: true,
+          readAvailable: true,
+          error: null,
+        },
+        error: null,
+      })
+
+      control.accountId = observedAccountId
+      control.tradingBlocked = true
+      await Effect.runPromise(provideHealthyDependencies(initial, probe(config, state, broker, cycleFiber)))
+      expect(await Effect.runPromise(Ref.get(state))).toMatchObject({
+        status: 'DEGRADED',
+        broker: {
+          accountId: observedAccountId,
+          accountBound: false,
+          readAvailable: false,
+          error: 'Alpaca account identity drift detected',
+        },
+        error: 'broker: Alpaca account identity drift detected',
+      })
+
+      control.accountId = brokerAccountId
+      control.tradingBlocked = false
+      await Effect.runPromise(provideHealthyDependencies(initial, probe(config, state, broker, cycleFiber)))
+      expect(await Effect.runPromise(Ref.get(state))).toMatchObject({
+        status: 'READY',
+        broker: {
+          accountId: brokerAccountId,
+          accountBound: true,
+          readAvailable: true,
+          error: null,
+        },
+        error: null,
       })
 
       const permissionCases = [

--- a/services/bayn/src/health/decisions.ts
+++ b/services/bayn/src/health/decisions.ts
@@ -24,6 +24,7 @@ import type {
 } from '../runtime-state'
 import type {
   AutonomousCycleFiberObservation,
+  BrokerHealthObservation,
   DurableEvidenceFailure,
   HealthDependencyName,
   HealthFailureSummary,
@@ -177,6 +178,21 @@ const dependencyHealth = <A>(result: ProbeResult<A>, checkedAt: string | null): 
   error: result._tag === 'Available' ? null : result.error,
 })
 
+const redactCycleObservationError = (error: string): string =>
+  error.includes('configured account ') && error.includes(' differs from the projected current or last cycle')
+    ? 'configured account binding differs from the projected current or last cycle'
+    : error
+
+const publicCycleObservation = (
+  result: ProbeResult<CycleOperationsProjection>,
+): ProbeResult<CycleOperationsProjection> =>
+  result._tag === 'Available'
+    ? result
+    : {
+        _tag: 'Unavailable',
+        error: redactCycleObservationError(result.error),
+      }
+
 const cycleLoopHealth = (
   previous: DependencyHealth,
   loop: AutonomousCycleLoopStatus,
@@ -213,21 +229,25 @@ const cycleLoopHealth = (
 const deriveBrokerStatus = (
   current: BrokerStatus | null,
   broker: BrokerConfiguration | undefined,
-  result: ProbeResult<string> | null,
+  result: ProbeResult<BrokerHealthObservation> | null,
   checkedAt: string | null,
 ): BrokerStatus | null => {
   if (broker === undefined) return current
   const observed = result ?? { _tag: 'Unavailable', error: 'broker probe did not run' }
-  const accountId = observed._tag === 'Available' ? observed.value : null
+  const accountId = observed._tag === 'Available' ? observed.value.accountId : null
   const accountBound = observed._tag === 'Available' && accountId === broker.expectedAccountId
   const bindingError =
-    observed._tag === 'Unavailable' ? observed.error : accountBound ? null : 'Alpaca account identity drift detected'
+    observed._tag === 'Unavailable'
+      ? observed.error
+      : accountBound
+        ? observed.value.permissionError
+        : 'Alpaca account identity drift detected'
   return {
     configured: true,
     expectedAccountId: broker.expectedAccountId,
     accountId,
     accountBound,
-    readAvailable: observed._tag === 'Available',
+    readAvailable: observed._tag === 'Available' && observed.value.permissionError === null,
     checkedAt,
     error: bindingError,
     executionEligible: broker.executionEligible,
@@ -362,9 +382,10 @@ export const deriveHealthTransition = (current: RuntimeState, input: HealthTrans
     input.config.cycleStallThresholdMs,
     input.broker !== undefined,
   )
-  const cycle = deriveCycleStatus(input.results.cycle, input.config, input.clock)
+  const cycleObservation = publicCycleObservation(input.results.cycle)
+  const cycle = deriveCycleStatus(cycleObservation, input.config, input.clock)
   const broker = deriveBrokerStatus(current.broker, input.broker, input.results.broker, checkedAt)
-  const health = deriveRuntimeHealth(current, input.results, cycleRunner, checkedAt)
+  const health = deriveRuntimeHealth(current, { ...input.results, cycle: cycleObservation }, cycleRunner, checkedAt)
   const failures = summarizeHealthFailures(health, broker, cycle, clockError)
   const next = deriveNextRuntimeState(current, input.evidenceAvailable, health, cycle, broker, failures)
   return {

--- a/services/bayn/src/health/model.ts
+++ b/services/bayn/src/health/model.ts
@@ -13,13 +13,18 @@ export type ProbeResult<A> =
   | { readonly _tag: 'Available'; readonly value: A }
   | { readonly _tag: 'Unavailable'; readonly error: string }
 
+export interface BrokerHealthObservation {
+  readonly accountId: string
+  readonly permissionError: string | null
+}
+
 export interface HealthProbeResults {
   readonly postgresql: ProbeResult<void>
   readonly signal: ProbeResult<void>
   readonly tigerBeetle: ProbeResult<void>
   readonly durableEvidence: ProbeResult<void>
   readonly cycle: ProbeResult<CycleOperationsProjection>
-  readonly broker: ProbeResult<string> | null
+  readonly broker: ProbeResult<BrokerHealthObservation> | null
 }
 
 export interface HealthDependencies {

--- a/services/bayn/src/health/program.ts
+++ b/services/bayn/src/health/program.ts
@@ -24,6 +24,7 @@ import {
 } from './decisions'
 import type {
   AutonomousCycleFiberObservation,
+  BrokerHealthObservation,
   BrokerProbe,
   HealthDependencies,
   HealthLogDecision,
@@ -88,11 +89,7 @@ const namedBrokerRead = <A, E, R>(
     }),
   )
 
-const observeBroker = (
-  expectedAccountId: string,
-  read: BrokerReadShape,
-  timeoutMs: number,
-): Effect.Effect<ProbeResult<string>> =>
+const observeBroker = (read: BrokerReadShape, timeoutMs: number): Effect.Effect<ProbeResult<BrokerHealthObservation>> =>
   Effect.all(
     {
       account: namedBrokerRead('account read', read.account, timeoutMs),
@@ -116,27 +113,26 @@ const observeBroker = (
     },
     { concurrency: 6 },
   ).pipe(
-    Effect.map((results): ProbeResult<string> => {
+    Effect.map((results): ProbeResult<BrokerHealthObservation> => {
       const failures = Object.values(results).flatMap((result) => (result._tag === 'Unavailable' ? [result.error] : []))
       if (failures.length > 0) return { _tag: 'Unavailable', error: failures.join('; ') }
 
       if (results.account._tag !== 'Available' || results.accountConfiguration._tag !== 'Available') {
         return { _tag: 'Unavailable', error: 'Alpaca continuous broker-read health did not complete' }
       }
-      if (results.account.value.value.id !== expectedAccountId) {
-        return { _tag: 'Unavailable', error: 'Alpaca account identity drift detected' }
-      }
       const permissions = verifyBrokerAccountPermissions(
         results.account.value.value,
         results.accountConfiguration.value.value,
       )
-      if (Result.isFailure(permissions)) {
-        return {
-          _tag: 'Unavailable',
-          error: `Alpaca account permission drift detected: ${renderBrokerPermissionFailure(permissions.failure)}`,
-        }
+      return {
+        _tag: 'Available',
+        value: {
+          accountId: results.account.value.value.id,
+          permissionError: Result.isFailure(permissions)
+            ? `Alpaca account permission drift detected: ${renderBrokerPermissionFailure(permissions.failure)}`
+            : null,
+        },
       }
-      return { _tag: 'Available', value: results.account.value.value.id }
     }),
   )
 
@@ -272,9 +268,7 @@ const collectHealthProbeResults = (
                 'cycle-observability',
               ),
         ),
-        broker === undefined
-          ? Effect.succeed(null)
-          : observeBroker(broker.expectedAccountId, broker.read, config.operationTimeoutMs),
+        broker === undefined ? Effect.succeed(null) : observeBroker(broker.read, config.operationTimeoutMs),
       ],
       { concurrency: 'unbounded' },
     ),


### PR DESCRIPTION
## Summary

- redact the known cycle-observability account-binding mismatch before it enters public runtime health, cycle status, aggregate errors, or health logs
- preserve a successful continuous account read through exact identity binding so public status reports account mismatch rather than a read outage
- retain detailed evidence for non-sensitive cycle and broker-read failures, with regressions proving raw account identifiers never survive the health decision boundary

## Related Issues

Follow-up to #13383 and promotion findings:
- https://github.com/proompteng/lab/pull/13384#discussion_r3680315750
- https://github.com/proompteng/lab/pull/13384#discussion_r3680339323

## Testing

- `bun test services/bayn/src/health.test.ts` (27 passed, 0 failed)
- `bun run --filter @proompteng/bayn test` (926 passed, 138 expected integration skips, 0 failed)
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn lint:effect`
- `bun run --filter @proompteng/bayn build`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents exact validation.
- [x] No visual surface is changed.
- [x] The correction remains inside the health ownership boundary.
