### PR TITLE
fix(bayn): redact cycle identity errors

### DIFF
--- a/services/bayn/src/http.test.ts
+++ b/services/bayn/src/http.test.ts
@@ -629,6 +629,32 @@ describe('Bayn HTTP pure decisions', () => {
       provenance,
       'embedded',
     )
+    const continuousMismatch = statusFacts(
+      {
+        ...base,
+        error: 'broker: Alpaca account identity drift detected',
+        broker: {
+          ...base.broker!,
+          error: 'Alpaca account identity drift detected',
+        },
+      },
+      readOnlyExecution,
+      provenance,
+      'embedded',
+    )
+    const permissionDrift = statusFacts(
+      {
+        ...base,
+        error: 'broker: Alpaca account permission drift detected: trading is blocked',
+        broker: {
+          ...base.broker!,
+          error: 'Alpaca account permission drift detected: trading is blocked',
+        },
+      },
+      readOnlyExecution,
+      provenance,
+      'embedded',
+    )
     const readFailure = statusFacts(
       {
         ...base,
@@ -658,6 +684,22 @@ describe('Bayn HTTP pure decisions', () => {
       error: 'BROKER_ACCOUNT_IDENTITY_MISMATCH',
     })
     expect(mismatch.error).toBe('broker: BROKER_ACCOUNT_IDENTITY_MISMATCH')
+    expect(continuousMismatch.broker).toMatchObject({
+      configured: true,
+      accountBound: false,
+      readAvailable: false,
+      reasonCode: 'BROKER_ACCOUNT_IDENTITY_MISMATCH',
+      error: 'BROKER_ACCOUNT_IDENTITY_MISMATCH',
+    })
+    expect(continuousMismatch.error).toBe('broker: BROKER_ACCOUNT_IDENTITY_MISMATCH')
+    expect(permissionDrift.broker).toMatchObject({
+      configured: true,
+      accountBound: false,
+      readAvailable: false,
+      reasonCode: 'BROKER_ACCOUNT_PERMISSION_DRIFT',
+      error: 'BROKER_ACCOUNT_PERMISSION_DRIFT',
+    })
+    expect(permissionDrift.error).toBe('broker: BROKER_ACCOUNT_PERMISSION_DRIFT')
     expect(readFailure.broker).toMatchObject({
       configured: true,
       accountBound: false,
@@ -665,7 +707,7 @@ describe('Bayn HTTP pure decisions', () => {
       reasonCode: 'BROKER_READ_UNAVAILABLE',
       error: 'BROKER_READ_UNAVAILABLE',
     })
-    for (const facts of [configured, mismatch, readFailure]) {
+    for (const facts of [configured, mismatch, continuousMismatch, permissionDrift, readFailure]) {
       const rendered = JSON.stringify(facts)
       expect(rendered).not.toContain(expectedAccountId)
       expect(rendered).not.toContain(observedAccountId)
@@ -715,6 +757,89 @@ describe('Bayn HTTP pure decisions', () => {
     if (!('current' in facts.cycle)) return
     expect(facts.cycle.current).not.toHaveProperty('accountId')
     expect(facts.cycle.reconciliation).not.toHaveProperty('accountId')
+  })
+
+  test('replaces account-bearing cycle and runner errors with bounded public reason codes', () => {
+    const accountId = 'paper-account-cycle-error'
+    const observedAt = '2026-07-20T12:00:00.000Z'
+    const cycleError =
+      `PostgreSQL cycle-observability failed: configured account ${accountId} ` +
+      'differs from the projected current or last cycle'
+    const passMessage = `cycle context resolved configured account ${accountId}`
+    const runnerError = `load-context/context: ${passMessage}`
+    const state: RuntimeState = {
+      ...readyState(),
+      status: 'DEGRADED',
+      health: {
+        ...readyState().health,
+        dependencies: {
+          ...readyState().health.dependencies,
+          cycle: { status: 'UNAVAILABLE', checkedAt: observedAt, error: cycleError },
+          cycleRunner: { status: 'UNAVAILABLE', checkedAt: observedAt, error: runnerError },
+        },
+      },
+      cycle: {
+        ...readyState().cycle,
+        condition: CycleOperationsCondition.Unknown,
+        reason: CycleOperationsReason.ObservationUnavailable,
+        checkedAt: observedAt,
+        error: cycleError,
+      },
+      autonomousCycleLoop: {
+        configured: true,
+        startedAt: observedAt,
+        lastPass: {
+          result: 'FAILURE',
+          observedAt,
+          operation: 'load-context',
+          failure: 'context',
+          message: passMessage,
+        },
+      },
+      error: `cycle: ${cycleError}; cycleRunner: ${runnerError}`,
+    }
+
+    const facts = statusFacts(state, readOnlyExecution, provenance, 'embedded')
+    expect(facts.cycle.error).toBe('CYCLE_ACCOUNT_IDENTITY_MISMATCH')
+    expect(facts.dependencies.cycle.error).toBe('CYCLE_ACCOUNT_IDENTITY_MISMATCH')
+    expect(facts.dependencies.cycleRunner.error).toBe('CYCLE_RUNNER_UNAVAILABLE')
+    expect(facts.autonomousCycleLoop.lastPass).toEqual({
+      result: 'FAILURE',
+      observedAt,
+      operation: 'load-context',
+      failure: 'context',
+      reasonCode: 'AUTONOMOUS_CYCLE_PASS_FAILED',
+    })
+    expect(facts.error).toBe('cycle: CYCLE_ACCOUNT_IDENTITY_MISMATCH; cycleRunner: CYCLE_RUNNER_UNAVAILABLE')
+    expect(JSON.stringify(facts)).not.toContain(accountId)
+    expect(JSON.stringify(readinessResponseDecision(state))).not.toContain(accountId)
+    expect(renderPrometheusMetrics(state, config, provenance, 'embedded')).not.toContain(accountId)
+  })
+
+  test('redacts a stale top-level runner failure after the current cycle pass recovers', () => {
+    const accountId = 'paper-account-stale-runner-error'
+    const observedAt = '2026-07-20T12:01:00.000Z'
+    const state: RuntimeState = {
+      ...readyState(),
+      status: 'DEGRADED',
+      autonomousCycleLoop: {
+        configured: true,
+        startedAt: observedAt,
+        lastPass: { result: 'SUCCESS', observedAt, outcome: 'NO_PUBLICATION' },
+      },
+      error:
+        `cycle: prior observation unavailable; ` +
+        `cycleRunner: load-context/context: configured account ${accountId} is unavailable; ` +
+        'broker: account binding unavailable',
+    }
+
+    const facts = statusFacts(state, readOnlyExecution, provenance, 'embedded')
+    expect(facts.dependencies.cycleRunner.error).toBeNull()
+    expect(facts.autonomousCycleLoop.lastPass).toEqual({ result: 'SUCCESS', observedAt, outcome: 'NO_PUBLICATION' })
+    expect(facts.error).toBe(
+      'cycle: prior observation unavailable; cycleRunner: CYCLE_RUNNER_UNAVAILABLE; broker: account binding unavailable',
+    )
+    expect(JSON.stringify(facts)).not.toContain(accountId)
   })
 
   test('maps database and timeout failures to the typed operational boundary with the cause intact', async () => {
@@ -1016,7 +1141,7 @@ describe('Bayn HTTP probes', () => {
                     observedAt: failedAt,
                     operation: 'market-calendar',
                     failure: 'calendar-read',
-                    message: 'authoritative calendar unavailable',
+                    reasonCode: 'AUTONOMOUS_CYCLE_PASS_FAILED',
                   },
                 },
               },

--- a/services/bayn/src/http.ts
+++ b/services/bayn/src/http.ts
@@ -70,10 +70,14 @@ const brokerPresentationReason = (broker: NonNullable<RuntimeState['broker']>): 
   const identityMismatch =
     broker.accountBound === false &&
     (broker.readAvailable === true ||
+      broker.error === 'Alpaca account identity drift detected' ||
       broker.error?.includes('Alpaca credential resolved account ') === true ||
       broker.error?.includes('Alpaca account probe resolved ') === true)
   if (identityMismatch) return 'BROKER_ACCOUNT_IDENTITY_MISMATCH'
   if (broker.accountBound === null || broker.readAvailable === null) return 'BROKER_STATUS_NOT_CHECKED'
+  if (broker.error?.startsWith('Alpaca account permission drift detected') === true) {
+    return 'BROKER_ACCOUNT_PERMISSION_DRIFT'
+  }
   if (broker.readAvailable === false) return 'BROKER_READ_UNAVAILABLE'
   if (broker.accountBound === false) return 'BROKER_ACCOUNT_BINDING_UNAVAILABLE'
   return broker.error === null ? null : 'BROKER_STATUS_UNAVAILABLE'
@@ -105,10 +109,98 @@ const publicBrokerState = (state: RuntimeState) => {
   } as const
 }
 
-const publicRuntimeError = (state: RuntimeState, broker: ReturnType<typeof publicBrokerState>): string | null => {
+const cyclePresentationReason = (error: string | null): string | null => {
+  if (error === null) return null
+  return error.includes('configured account ') && error.includes(' differs from the projected current or last cycle')
+    ? 'CYCLE_ACCOUNT_IDENTITY_MISMATCH'
+    : 'CYCLE_OBSERVATION_UNAVAILABLE'
+}
+
+const publicDependencies = (state: RuntimeState) => ({
+  ...state.health.dependencies,
+  cycle: {
+    ...state.health.dependencies.cycle,
+    error: cyclePresentationReason(state.health.dependencies.cycle.error),
+  },
+  cycleRunner: {
+    ...state.health.dependencies.cycleRunner,
+    error: state.health.dependencies.cycleRunner.error === null ? null : 'CYCLE_RUNNER_UNAVAILABLE',
+  },
+})
+
+const publicAutonomousCycleLoop = (state: RuntimeState) => {
+  const lastPass = state.autonomousCycleLoop.lastPass
+  return {
+    configured: state.autonomousCycleLoop.configured,
+    startedAt: state.autonomousCycleLoop.startedAt,
+    lastPass:
+      lastPass === null || lastPass.result === 'SUCCESS'
+        ? lastPass
+        : {
+            result: lastPass.result,
+            observedAt: lastPass.observedAt,
+            operation: lastPass.operation,
+            failure: lastPass.failure,
+            reasonCode: 'AUTONOMOUS_CYCLE_PASS_FAILED',
+          },
+  } as const
+}
+
+const healthFailurePrefixes = [
+  'postgresql: ',
+  'signal: ',
+  'tigerBeetle: ',
+  'evidence: ',
+  'cycle: ',
+  'cycleRunner: ',
+  'broker: ',
+  'cycle clock: ',
+] as const
+
+const publicCycleRunnerFailure = (error: string): string => {
+  const prefix = 'cycleRunner: '
+  const prefixedAt = error.startsWith(prefix) ? 0 : error.indexOf(`; ${prefix}`)
+  if (prefixedAt === -1) return error
+  const segmentStart = prefixedAt === 0 ? 0 : prefixedAt + 2
+  const contentStart = segmentStart + prefix.length
+  const nextSegment = healthFailurePrefixes.reduce((nearest, candidatePrefix) => {
+    const candidate = error.indexOf(`; ${candidatePrefix}`, contentStart)
+    return candidate === -1 || (nearest !== -1 && candidate >= nearest) ? nearest : candidate
+  }, -1)
+  return `${error.slice(0, segmentStart)}cycleRunner: CYCLE_RUNNER_UNAVAILABLE${
+    nextSegment === -1 ? '' : error.slice(nextSegment)
+  }`
+}
+
+const publicRuntimeError = (
+  state: RuntimeState,
+  broker: ReturnType<typeof publicBrokerState>,
+  dependencies: ReturnType<typeof publicDependencies>,
+): string | null => {
+  if (state.error === null) return null
+  let publicError = publicCycleRunnerFailure(state.error)
   const brokerError = state.broker?.error
-  if (state.error === null || brokerError === null || brokerError === undefined) return state.error
-  return state.error.replaceAll(brokerError, broker.error ?? 'BROKER_STATUS_UNAVAILABLE')
+  if (brokerError !== null && brokerError !== undefined) {
+    publicError = publicError.replaceAll(brokerError, broker.error ?? 'BROKER_STATUS_UNAVAILABLE')
+  }
+  if (state.cycle.error !== null) {
+    publicError = publicError.replaceAll(
+      state.cycle.error,
+      cyclePresentationReason(state.cycle.error) ?? 'CYCLE_OBSERVATION_UNAVAILABLE',
+    )
+  }
+  const cycleDependencyError = state.health.dependencies.cycle.error
+  if (cycleDependencyError !== null) {
+    publicError = publicError.replaceAll(
+      cycleDependencyError,
+      dependencies.cycle.error ?? 'CYCLE_OBSERVATION_UNAVAILABLE',
+    )
+  }
+  const cycleRunnerError = state.health.dependencies.cycleRunner.error
+  if (cycleRunnerError !== null) {
+    publicError = publicError.replaceAll(cycleRunnerError, dependencies.cycleRunner.error ?? 'CYCLE_RUNNER_UNAVAILABLE')
+  }
+  return publicError
 }
 
 const publicCycleSnapshot = (snapshot: RuntimeState['cycle']['current']) =>
@@ -151,7 +243,7 @@ const publicCycleState = (state: RuntimeState) =>
         reason: state.cycle.reason,
         checkedAt: state.cycle.checkedAt,
         zeroMutation: null,
-        error: state.cycle.error,
+        error: cyclePresentationReason(state.cycle.error),
       }
     : {
         ...state.cycle,
@@ -159,6 +251,7 @@ const publicCycleState = (state: RuntimeState) =>
         last: publicCycleSnapshot(state.cycle.last),
         reconciliation: publicCycleReconciliation(state.cycle.reconciliation),
         observationAvailable: true,
+        error: cyclePresentationReason(state.cycle.error),
       }
 
 export const statusFacts = (
@@ -168,6 +261,7 @@ export const statusFacts = (
   provenanceVerification: RuntimeBuildMetadata['verification'],
 ) => {
   const broker = publicBrokerState(state)
+  const dependencies = publicDependencies(state)
   return {
     service: 'bayn',
     operational: {
@@ -176,7 +270,7 @@ export const statusFacts = (
       probeSequence: state.health.sequence,
       checkedAt: state.health.checkedAt,
     },
-    dependencies: state.health.dependencies,
+    dependencies,
     data: {
       status: verifiedState(state, state.health.dependencies.signal),
       input: state.evidence?.evaluation.input ?? null,
@@ -208,7 +302,7 @@ export const statusFacts = (
       reconciliation: state.evidence?.reconciliation ?? null,
     },
     cycle: publicCycleState(state),
-    autonomousCycleLoop: state.autonomousCycleLoop,
+    autonomousCycleLoop: publicAutonomousCycleLoop(state),
     broker,
     authority: {
       brokerEnvironment: execution.brokerIdentity?.environment ?? null,
@@ -246,7 +340,7 @@ export const statusFacts = (
       image: provenance.image,
       verification: provenanceVerification,
     },
-    error: publicRuntimeError(state, broker),
+    error: publicRuntimeError(state, broker, dependencies),
   } as const
 }
 


### PR DESCRIPTION
## Summary
- remove raw broker account identity from public broker, cycle, dependency, loop, and composed runtime status projections
- preserve actionable bounded reason codes for identity mismatch, permission drift, read failure, and stale/non-leading cycle-runner failures
- keep internal fail-closed identity comparisons unchanged while proving status, readiness, metrics, and successful preflight logs expose no raw account identity

## Validation
- `bun test src/http.test.ts` (26 pass, 0 fail)
- `bun test` (925 pass, 138 skip, 0 fail)
- `bun run tsc`
- `bun run lint`
- `bun run lint:effect`
- `bun run lint:oxlint`
- `bun run lint:oxlint:type`
- `bun run build`
