### PR TITLE
fix(bayn): reconcile broker on not-due passes

### DIFF
--- a/services/bayn/src/cycle-runner.test.ts
+++ b/services/bayn/src/cycle-runner.test.ts
@@ -46,6 +46,7 @@ import {
   type CycleRunContext,
   type CycleRunResult,
 } from './cycle-runner'
+import { CycleNotDueReconciliationError } from './cycle-runner/model'
 import { runAutonomousCycleUntilSettled } from './cycle-runner/program'
 import { selectCycleRecovery, type CycleRecoveryState } from './cycle-recovery'
 import { CycleStore, type CycleAuthoritySlot, type CycleStoreShape } from './db/cycle-store'
@@ -61,8 +62,14 @@ import { TargetPlanReason, TargetPlanStatus } from './target-planner'
 import { currentUtcInstant } from './time'
 import { DataFeed, DataSource, PriceAdjustment, PublicationSchema, type InputManifest, type IsoDate } from './types'
 
-const cycleLoop = <E, ContextR, DecisionR>(options: AutonomousCycleLoopOptions<E, ContextR, DecisionR>) =>
-  Effect.fromResult(makeAutonomousCycleLoop(options))
+type CycleLoopTestOptions<E, ContextR, DecisionR> = Omit<
+  AutonomousCycleLoopOptions<E, ContextR, DecisionR>,
+  'reconcileNotDue'
+> &
+  Partial<Pick<AutonomousCycleLoopOptions<E, ContextR, DecisionR>, 'reconcileNotDue'>>
+
+const cycleLoop = <E, ContextR, DecisionR>(options: CycleLoopTestOptions<E, ContextR, DecisionR>) =>
+  Effect.fromResult(makeAutonomousCycleLoop({ reconcileNotDue: Effect.void, ...options }))
 
 const signalCalendarVersion = 'signal-XNYS-2026-v1'
 const snapshotId = 'd'.repeat(64)
@@ -1443,6 +1450,170 @@ describe('autonomous cycle runner', () => {
     expect(control).toEqual({ acquisitions: [], binds: 0 })
   })
 
+  test('reconciles one NOT_DUE pass before recording it as successful', async () => {
+    const control: StoreControl = { acquisitions: [], binds: 0 }
+    const observations: CyclePassObservation[] = []
+    const events: string[] = []
+    let reconciliations = 0
+    const ordinaryCalendar = calendar([
+      {
+        date: '2026-01-29',
+        openAt: '2026-01-29T14:30:00.000Z',
+        closeAt: '2026-01-29T21:00:00.000Z',
+      },
+      {
+        date: '2026-01-30',
+        openAt: '2026-01-30T14:30:00.000Z',
+        closeAt: '2026-01-30T21:00:00.000Z',
+      },
+    ])
+
+    await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          yield* TestClock.setTime(Date.parse('2026-01-29T21:20:00.000Z'))
+          const completed = yield* Deferred.make<CyclePassObservation>()
+          const loop = yield* cycleLoop({
+            context: Effect.succeed(context()),
+            observePass: (observation) =>
+              Effect.sync(() => {
+                events.push('observe')
+                observations.push(observation)
+              }).pipe(Effect.andThen(Deferred.succeed(completed, observation)), Effect.asVoid),
+            pollIntervalMs: 60_000,
+            reconcileNotDue: Effect.sync(() => {
+              reconciliations += 1
+              events.push('reconcile')
+            }),
+          })
+          const fiber = yield* provide(
+            loop,
+            brokerRead(() => Effect.succeed({ value: ordinaryCalendar, evidence })),
+            cycleStore(control),
+            marketDataService(Effect.succeed(finalizedPublication('2026-01-29'))),
+          ).pipe(Effect.forkScoped({ startImmediately: true }))
+          yield* Deferred.await(completed)
+          yield* Fiber.interrupt(fiber)
+        }),
+      ).pipe(Effect.provide(TestClock.layer())),
+    )
+
+    expect(reconciliations).toBe(1)
+    expect(events).toEqual(['reconcile', 'observe'])
+    expect(observations).toHaveLength(1)
+    expect(observations[0]).toMatchObject({ outcome: 'SUCCEEDED', result: { outcome: 'NOT_DUE' } })
+    expect(control).toEqual({ acquisitions: [], binds: 0 })
+  })
+
+  test('records a typed NOT_DUE reconciliation failure instead of a successful pass', async () => {
+    const control: StoreControl = { acquisitions: [], binds: 0 }
+    const cause = { _tag: 'ReconciliationStoreFixtureFailure' }
+    const failure = new CycleNotDueReconciliationError({
+      failure: 'database',
+      message: 'NOT_DUE reconciliation persistence failed',
+      cause,
+    })
+    let attempts = 0
+    const ordinaryCalendar = calendar([
+      {
+        date: '2026-01-29',
+        openAt: '2026-01-29T14:30:00.000Z',
+        closeAt: '2026-01-29T21:00:00.000Z',
+      },
+      {
+        date: '2026-01-30',
+        openAt: '2026-01-30T14:30:00.000Z',
+        closeAt: '2026-01-30T21:00:00.000Z',
+      },
+    ])
+
+    const observation = await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          yield* TestClock.setTime(Date.parse('2026-01-29T21:20:00.000Z'))
+          const completed = yield* Deferred.make<CyclePassObservation>()
+          const loop = yield* cycleLoop({
+            context: Effect.succeed(context()),
+            observePass: (pass) => Deferred.succeed(completed, pass).pipe(Effect.asVoid),
+            pollIntervalMs: 60_000,
+            reconcileNotDue: Effect.sync(() => {
+              attempts += 1
+            }).pipe(Effect.andThen(Effect.fail(failure))),
+          })
+          const fiber = yield* provide(
+            loop,
+            brokerRead(() => Effect.succeed({ value: ordinaryCalendar, evidence })),
+            cycleStore(control),
+            marketDataService(Effect.succeed(finalizedPublication('2026-01-29'))),
+          ).pipe(Effect.forkScoped({ startImmediately: true }))
+          const pass = yield* Deferred.await(completed)
+          yield* Fiber.interrupt(fiber)
+          return pass
+        }),
+      ).pipe(Effect.provide(TestClock.layer())),
+    )
+
+    expect(attempts).toBe(1)
+    expect(observation).toEqual({
+      outcome: 'FAILED',
+      observedAt: '2026-01-29T21:20:00.000Z',
+      error: new CycleRunnerError({
+        operation: 'reconcile-not-due',
+        failure: 'database',
+        message: failure.message,
+        cause: failure,
+      }),
+    })
+    expect(control).toEqual({ acquisitions: [], binds: 0 })
+  })
+
+  test('scope interruption cancels in-flight NOT_DUE reconciliation without recording a pass', async () => {
+    const control: StoreControl = { acquisitions: [], binds: 0 }
+    const observations: CyclePassObservation[] = []
+    let interrupted = false
+    const ordinaryCalendar = calendar([
+      {
+        date: '2026-01-29',
+        openAt: '2026-01-29T14:30:00.000Z',
+        closeAt: '2026-01-29T21:00:00.000Z',
+      },
+      {
+        date: '2026-01-30',
+        openAt: '2026-01-30T14:30:00.000Z',
+        closeAt: '2026-01-30T21:00:00.000Z',
+      },
+    ])
+
+    await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          yield* TestClock.setTime(Date.parse('2026-01-29T21:20:00.000Z'))
+          const started = yield* Deferred.make<void>()
+          const loop = yield* cycleLoop({
+            context: Effect.succeed(context()),
+            observePass: (observation) => Effect.sync(() => observations.push(observation)),
+            pollIntervalMs: 60_000,
+            reconcileNotDue: Deferred.succeed(started, undefined).pipe(
+              Effect.andThen(Effect.never),
+              Effect.onInterrupt(() => Effect.sync(() => void (interrupted = true))),
+            ),
+          })
+          yield* provide(
+            loop,
+            brokerRead(() => Effect.succeed({ value: ordinaryCalendar, evidence })),
+            cycleStore(control),
+            marketDataService(Effect.succeed(finalizedPublication('2026-01-29'))),
+          ).pipe(Effect.forkScoped({ startImmediately: true }))
+          yield* Deferred.await(started)
+        }),
+      ).pipe(Effect.provide(TestClock.layer())),
+    )
+
+    expect(interrupted).toBe(true)
+    expect(observations).toEqual([])
+    expect(control).toEqual({ acquisitions: [], binds: 0 })
+  })
+
   test('catches an unacquired month-end publication hidden by a newer daily publication after downtime', async () => {
     const control: StoreControl = { acquisitions: [], binds: 0 }
     const store = cycleStore(control)
@@ -1979,6 +2150,7 @@ describe('autonomous cycle runner', () => {
     let orderReads = 0
     let mutationSubmits = 0
     let mutationCancels = 0
+    let notDueReconciliations = 0
 
     interface DurableReconciliationEvidence {
       readonly schemaVersion: 'bayn.test-observe-reconciliation.v1'
@@ -2155,6 +2327,9 @@ describe('autonomous cycle runner', () => {
                 Effect.asVoid,
               ),
             pollIntervalMs: 60_000,
+            reconcileNotDue: Effect.sync(() => {
+              notDueReconciliations += 1
+            }),
           })
           const fiber = yield* provide(loop, read, store, marketData).pipe(
             Effect.provideService(BrokerMutation, mutation),
@@ -2253,6 +2428,7 @@ describe('autonomous cycle runner', () => {
     expect(accountReads).toBe(1)
     expect(positionReads).toBe(1)
     expect(orderReads).toBe(1)
+    expect(notDueReconciliations).toBe(0)
     expect(control.binds).toBe(1)
     expect(mutationSubmits).toBe(0)
     expect(mutationCancels).toBe(0)
@@ -2629,6 +2805,7 @@ describe('autonomous cycle runner', () => {
         context: Effect.succeed(context()),
         observePass: ignorePass,
         pollIntervalMs,
+        reconcileNotDue: Effect.void,
       })
       expect(Result.isFailure(result)).toBe(true)
       expect(Result.isFailure(result) ? result.failure : undefined).toMatchObject({

--- a/services/bayn/src/cycle-runner/loop.ts
+++ b/services/bayn/src/cycle-runner/loop.ts
@@ -8,8 +8,8 @@ import { cyclePassLogFacts, validateCycleLoopInterval } from './decisions'
 import {
   runnerError,
   type AutonomousCycleLoopOptions,
+  type CycleNotDueReconciliationError,
   type CyclePassObservation,
-  type CycleRunContext,
   type CycleRunnerError,
   type CycleRunResult,
 } from './model'
@@ -21,14 +21,26 @@ const logCyclePass = (observation: CyclePassObservation): Effect.Effect<void> =>
   return log.pipe(Effect.annotateLogs(facts.annotations))
 }
 
+const reconcileNotDuePass = <DecisionR>(
+  reconcileNotDue: Effect.Effect<void, CycleNotDueReconciliationError, DecisionR>,
+  result: CycleRunResult,
+): Effect.Effect<CycleRunResult, CycleRunnerError, DecisionR> => {
+  if (result.outcome !== 'NOT_DUE') return Effect.succeed(result)
+  return reconcileNotDue.pipe(
+    Effect.mapError((cause) => runnerError('reconcile-not-due', cause.failure, cause.message, cause)),
+    Effect.map((): CycleRunResult => result),
+  )
+}
+
 const runLoopPass = <E, ContextR, DecisionR>(
-  context: Effect.Effect<CycleRunContext<DecisionR>, E, ContextR>,
+  options: AutonomousCycleLoopOptions<E, ContextR, DecisionR>,
 ): Effect.Effect<CycleRunResult, CycleRunnerError, BrokerRead | CycleStore | MarketData | ContextR | DecisionR> =>
-  context.pipe(
+  options.context.pipe(
     Effect.mapError((cause) =>
       runnerError('load-context', 'context', 'autonomous cycle context loading failed', cause),
     ),
     Effect.flatMap(runAutonomousCycleUntilSettled),
+    Effect.flatMap((result) => reconcileNotDuePass(options.reconcileNotDue, result)),
     Effect.withLogSpan('autonomous-cycle'),
   )
 
@@ -60,7 +72,7 @@ const cycleLoopProgram = <E, ContextR, DecisionR>(
   options: AutonomousCycleLoopOptions<E, ContextR, DecisionR>,
 ): Effect.Effect<void, never, BrokerRead | CycleStore | MarketData | ContextR | DecisionR> =>
   pipe(
-    runLoopPass(options.context),
+    runLoopPass(options),
     Effect.flatMap((result) => observeSuccessfulPass(options, result)),
     Effect.catch((error) => observeFailedPass(options, error)),
     Effect.repeat(Schedule.spaced(Duration.millis(options.pollIntervalMs))),

--- a/services/bayn/src/cycle-runner/model.ts
+++ b/services/bayn/src/cycle-runner/model.ts
@@ -14,6 +14,12 @@ export class CycleDecisionBuildError extends Data.TaggedError('CycleDecisionBuil
   readonly cause?: unknown
 }> {}
 
+export class CycleNotDueReconciliationError extends Data.TaggedError('CycleNotDueReconciliationError')<{
+  readonly failure: 'contract' | 'database' | 'market-data' | 'operational' | 'store'
+  readonly message: string
+  readonly cause?: unknown
+}> {}
+
 export interface CycleRunContext<R = never> {
   readonly qualificationRunId: string
   readonly strategyProtocolHash: string
@@ -101,6 +107,7 @@ export class CycleRunnerError extends Data.TaggedError('CycleRunnerError')<{
     | 'market-calendar'
     | 'read-oldest-unfinished'
     | 'read-authority-slot'
+    | 'reconcile-not-due'
     | 'recover-cycle'
     | 'select-session'
   readonly failure:
@@ -133,6 +140,7 @@ export interface AutonomousCycleLoopOptions<E = never, ContextR = never, Decisio
   readonly context: Effect.Effect<CycleRunContext<DecisionR>, E, ContextR>
   readonly observePass: (observation: CyclePassObservation) => Effect.Effect<void>
   readonly pollIntervalMs: number
+  readonly reconcileNotDue: Effect.Effect<void, CycleNotDueReconciliationError, DecisionR>
 }
 
 export const runnerError = (

--- a/services/bayn/src/observe-composition.test.ts
+++ b/services/bayn/src/observe-composition.test.ts
@@ -6,11 +6,14 @@ import { TestClock } from 'effect/testing'
 import type { AutonomousCycleLoop } from './app'
 import { fixtureStrategy } from './app-test-support'
 import {
+  AccountStatus as BrokerAccountStatus,
   BrokerRead,
   BrokerReadError,
   BrokerReadErrorKind,
+  type Account as BrokerAccount,
   type BrokerReadShape,
   type MarketCalendarObservation,
+  type ReadEvidence,
   type ReadResult,
 } from './broker/alpaca'
 import { unusedAssetBySymbol } from './broker/alpaca-test-support'
@@ -27,6 +30,7 @@ import {
 } from './cycle'
 import { makeStrategyProtocolHash } from './contracts'
 import { CycleStore, type CycleStoreShape } from './db/cycle-store'
+import type { BrokerSnapshot, ReconciliationWriteResult } from './db/reconciliation'
 import {
   BrokerEventStore,
   AuthorityGenerationStore,
@@ -1070,6 +1074,246 @@ describe('OBSERVE runtime composition', () => {
         }),
       ),
     )
+  })
+
+  test('persists one writer-fenced reconciliation before reporting a NOT_DUE OBSERVE pass', async () => {
+    const signalSessionDate: IsoDate = '2020-04-29'
+    const calendarMaterial = {
+      schemaVersion: 'bayn.alpaca-market-calendar-observation.v1' as const,
+      source: 'alpaca-v2-calendar' as const,
+      requestedRange: { start: signalSessionDate, end: '2020-05-29' },
+      timeZone: 'UTC' as const,
+      sessions: [
+        {
+          date: signalSessionDate,
+          openAt: '2020-04-29T13:30:00.000Z',
+          closeAt: '2020-04-29T20:00:00.000Z',
+        },
+        {
+          date: signalDate,
+          openAt: '2020-04-30T13:30:00.000Z',
+          closeAt: '2020-04-30T20:00:00.000Z',
+        },
+      ],
+    }
+    const ordinaryCalendar: MarketCalendarObservation = {
+      ...calendarMaterial,
+      normalizedResponseHash: canonicalHashV1(calendarMaterial),
+    }
+    const readEvidence = (identity: string): ReadEvidence => ({
+      requestId: `not-due-${identity}`,
+      status: 200,
+      contentHash: canonicalHashV1({ identity }),
+      observedAt: reconciledAt,
+    })
+    const brokerAccount: BrokerAccount = {
+      id: accountId,
+      status: BrokerAccountStatus.Active,
+      currency: 'USD',
+      cashMicros: account.cashMicros,
+      equityMicros: account.equityMicros,
+      lastEquityMicros: account.equityMicros,
+      buyingPowerMicros: account.buyingPowerMicros,
+      accountBlocked: false,
+      tradingBlocked: false,
+      tradeSuspendedByUser: false,
+      observedAt: reconciledAt,
+    }
+    let accountReads = 0
+    let positionReads = 0
+    let orderReads = 0
+    let fillReads = 0
+    const unusedRead = Effect.die(new Error('NOT_DUE reconciliation used an unrelated broker read'))
+    const brokerRead: BrokerReadShape = {
+      account: Effect.sync(() => {
+        accountReads += 1
+        return { value: brokerAccount, evidence: readEvidence('account') }
+      }),
+      accountConfiguration: unusedRead,
+      assetBySymbol: unusedAssetBySymbol,
+      positions: Effect.sync(() => {
+        positionReads += 1
+        return { value: [], evidence: readEvidence('positions') }
+      }),
+      orders: () =>
+        Effect.sync(() => {
+          orderReads += 1
+          return { value: [], evidence: readEvidence(`orders-${orderReads}`) }
+        }),
+      orderById: () => unusedRead,
+      orderByClientId: () => unusedRead,
+      fillActivities: () =>
+        Effect.sync(() => {
+          fillReads += 1
+          return { value: { items: [] }, evidence: readEvidence(`fills-${fillReads}`) }
+        }),
+      marketCalendar: (query) => {
+        expect(query).toEqual(calendarMaterial.requestedRange)
+        return Effect.succeed({ value: ordinaryCalendar, evidence: readEvidence('calendar') })
+      },
+    }
+    const inspection = {
+      manifest: snapshot.manifest,
+      sessionDates: [signalSessionDate],
+      signalSession: {
+        calendar_version: 'fixture-calendar-v2',
+        session_date: signalSessionDate,
+        close_time: '16:00',
+        timezone: 'America/New_York' as const,
+      },
+    }
+    const marketDataService: MarketDataService = {
+      ...marketData([]),
+      inspectCyclePublications: Effect.succeed({
+        outcome: 'FINALIZED',
+        observedAt: '2020-04-29T22:00:00.000Z',
+        publications: [inspection],
+      }),
+    }
+    let acquisitions = 0
+    const unusedCycleStore = Effect.die(new Error('NOT_DUE pass attempted to mutate cycle state'))
+    const cycleStore: CycleStoreShape = {
+      acquire: () => {
+        acquisitions += 1
+        return unusedCycleStore
+      },
+      read: () => unusedCycleStore,
+      readAuthoritySlot: () => Effect.succeed(Option.none()),
+      readDecisionDocument: () => unusedCycleStore,
+      readOldestUnfinished: () => Effect.succeed(Option.none()),
+      bindSnapshot: () => unusedCycleStore,
+      activate: () => unusedCycleStore,
+      bindDecision: () => unusedCycleStore,
+      finish: () => unusedCycleStore,
+      block: () => unusedCycleStore,
+    }
+    const exact = reconciliationResult()
+    const persisted: ReconciliationWriteResult = {
+      reconciliation: exact.report.reconciliation,
+      metrics: exact.report.metrics,
+      accountingHash: exact.brokerState.accountingHash,
+      riskContext: exact.riskContext,
+    }
+    const reconciledSnapshots: BrokerSnapshot[] = []
+    let brokerEventWrites = 0
+    let positionWrites = 0
+    let valuationWrites = 0
+    let authorityRestrictions = 0
+    const unusedAccounting = Effect.die(new Error('empty NOT_DUE reconciliation must not account a fill'))
+    const executionStore = {
+      ingest: () =>
+        Effect.sync(() => {
+          brokerEventWrites += 1
+          return { eventId: '1'.repeat(64), sourceSequence: '1', deduplicated: false }
+        }),
+      ingestPositions: () =>
+        Effect.sync(() => {
+          positionWrites += 1
+          return { snapshotId: '2'.repeat(64), eventIds: [], deduplicated: false }
+        }),
+      account: () => unusedAccounting,
+      value: () =>
+        Effect.sync(() => {
+          valuationWrites += 1
+          return {
+            schemaVersion: 'bayn.paper-valuation.v1' as const,
+            valuationId: '3'.repeat(64),
+            accountId,
+            sourceHash: '4'.repeat(64),
+            cashMicros: account.cashMicros,
+            longMarketValueMicros: '0',
+            shortMarketValueMicros: '0',
+            equityMicros: account.equityMicros,
+            asOf: reconciledAt,
+          }
+        }),
+      hasAccountBaseline: () => Effect.succeed(true),
+      bindings: () => Effect.succeed([]),
+      reconcile: (brokerSnapshot: BrokerSnapshot) =>
+        Effect.sync(() => {
+          reconciledSnapshots.push(brokerSnapshot)
+          return persisted
+        }),
+      ensureAuthorityGeneration: () => {
+        const authority = exact.riskContext.authority
+        return authority === null
+          ? Effect.die(new Error('NOT_DUE fixture requires OBSERVE authority'))
+          : Effect.succeed(authority)
+      },
+      restrictAuthority: () =>
+        Effect.sync(() => {
+          authorityRestrictions += 1
+        }),
+    } satisfies BrokerEventStoreShape &
+      FillAccountingStoreShape &
+      ValuationStoreShape &
+      ReconciliationStoreShape &
+      AuthorityGenerationStoreShape &
+      AuthorityRestrictionStoreShape
+    let fencedTransactions = 0
+    const writerFence: WriterFenceService = {
+      backendPid: 1,
+      check: Effect.void,
+      transaction: (effect) =>
+        Effect.sync(() => {
+          fencedTransactions += 1
+        }).pipe(Effect.andThen(effect)),
+    }
+    const startup = makeObserveAutonomousCycleStartup({
+      accountId,
+      authorityGenerationHash: generationHash,
+      pollIntervalMs: 30_000,
+      strategy: fixtureStrategy,
+    })
+
+    const observation = await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          yield* TestClock.setTime(Date.parse(reconciledAt))
+          const pass = yield* Deferred.make<Parameters<Parameters<typeof startup>[0]['recordPass']>[0]>()
+          const loop = yield* startup({
+            qualificationRunId: 'c'.repeat(64),
+            recordPass: (result) => Deferred.succeed(pass, result).pipe(Effect.asVoid),
+          }).pipe(Effect.provideService(AuthorityGenerationStore, executionStore))
+          const fiber = yield* loop.pipe(
+            Effect.provideService(BrokerRead, brokerRead),
+            Effect.provideService(CycleStore, cycleStore),
+            Effect.provideService(MarketData, marketDataService),
+            Effect.provideService(BrokerEventStore, executionStore),
+            Effect.provideService(FillAccountingStore, executionStore),
+            Effect.provideService(ValuationStore, executionStore),
+            Effect.provideService(ReconciliationStore, executionStore),
+            Effect.provideService(AuthorityGenerationStore, executionStore),
+            Effect.provideService(AuthorityRestrictionStore, executionStore),
+            Effect.provideService(WriterFence, writerFence),
+            Effect.forkScoped({ startImmediately: true }),
+          )
+          const result = yield* Deferred.await(pass).pipe(Effect.timeout('1 second'))
+          yield* Fiber.interrupt(fiber)
+          return result
+        }),
+      ).pipe(Effect.provide(TestClock.layer())),
+    )
+
+    expect(observation).toMatchObject({ result: 'SUCCESS', outcome: 'NOT_DUE' })
+    expect(acquisitions).toBe(0)
+    expect(accountReads).toBe(1)
+    expect(positionReads).toBe(1)
+    expect(orderReads).toBe(2)
+    expect(fillReads).toBe(2)
+    expect(brokerEventWrites).toBe(1)
+    expect(positionWrites).toBe(1)
+    expect(valuationWrites).toBe(1)
+    expect(reconciledSnapshots).toHaveLength(1)
+    expect(reconciledSnapshots[0]).toMatchObject({
+      account,
+      positions: [],
+      orders: [],
+      fills: [],
+      reconciledAt,
+    })
+    expect(fencedTransactions).toBe(1)
+    expect(authorityRestrictions).toBe(0)
   })
 
   test('starts mutation mode without projecting or initializing OBSERVE authority', async () => {

--- a/services/bayn/src/observe-composition.ts
+++ b/services/bayn/src/observe-composition.ts
@@ -15,6 +15,7 @@ import {
   type CycleRunResult,
 } from './cycle-runner'
 import { validateCycleLoopInterval } from './cycle-runner/decisions'
+import { CycleNotDueReconciliationError } from './cycle-runner/model'
 import { CycleStore } from './db/cycle-store'
 import {
   BrokerEventStore,
@@ -217,6 +218,15 @@ const decisionBuildError = (cause: ObserveDecisionFailure): CycleDecisionBuildEr
     case 'TargetPlannerFailure':
       return new CycleDecisionBuildError({ failure: 'contract', message: cause.message, cause })
   }
+}
+
+const notDueReconciliationError = (cause: ReconciliationPassError): CycleNotDueReconciliationError => {
+  const operational = reconciliationOperationalError(cause)
+  return new CycleNotDueReconciliationError({
+    failure: operationalDecisionFailure(operational.component),
+    message: operational.message,
+    cause: operational,
+  })
 }
 
 const hashObserveMaterial = (
@@ -639,6 +649,7 @@ const makeObserveAutonomousLoop = (
       context: Effect.succeed(context),
       observePass: (observation) => observePass(startup.recordPass, observation),
       pollIntervalMs: input.pollIntervalMs,
+      reconcileNotDue: runOnce.pipe(Effect.mapError(notDueReconciliationError), Effect.asVoid),
     }),
     Result.mapError((cause) =>
       operationalError('strategy', 'cycle-loop', 'autonomous cycle loop failed to start', cause),


### PR DESCRIPTION
## Summary

- Reconcile the broker exactly once on every successful OBSERVE `NOT_DUE` pass before reporting that pass as successful.
- Route reconciliation failures through a typed `reconcile-not-due` cycle-runner failure and keep in-flight work scoped to loop interruption.
- Reuse the existing read-only `runOnce` reconciliation and writer-fenced stores without acquiring a cycle, duplicating DUE reconciliation, or exposing broker mutation authority.
- Add focused loop and composition regressions for exact invocation count, DUE deduplication, durable persistence, failure recording, and interruption.

## Related Issues

None

## Testing

- `bun test services/bayn/src/cycle-runner.test.ts services/bayn/src/observe-composition.test.ts` — 54 pass, 0 fail.
- `bun run --filter @proompteng/bayn test` — 923 pass, 138 skip, 0 fail.
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:effect`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn build`
- `git diff --check origin/main...HEAD`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] No documentation, release notes, or follow-up changes are required for this bounded runtime correction.
