### PR TITLE
fix(bayn): classify broker permission drift

### DIFF
--- a/services/bayn/src/http.test.ts
+++ b/services/bayn/src/http.test.ts
@@ -642,6 +642,19 @@ describe('Bayn HTTP pure decisions', () => {
       provenance,
       'embedded',
     )
+    const permissionDrift = statusFacts(
+      {
+        ...base,
+        error: 'broker: Alpaca account permission drift detected: ACCOUNT_BLOCKED',
+        broker: {
+          ...base.broker!,
+          error: 'Alpaca account permission drift detected: ACCOUNT_BLOCKED',
+        },
+      },
+      readOnlyExecution,
+      provenance,
+      'embedded',
+    )
 
     expect(configured.broker).toMatchObject({
       configured: true,
@@ -665,7 +678,15 @@ describe('Bayn HTTP pure decisions', () => {
       reasonCode: 'BROKER_READ_UNAVAILABLE',
       error: 'BROKER_READ_UNAVAILABLE',
     })
-    for (const facts of [configured, mismatch, readFailure]) {
+    expect(permissionDrift.broker).toMatchObject({
+      configured: true,
+      accountBound: false,
+      readAvailable: false,
+      reasonCode: 'BROKER_ACCOUNT_PERMISSION_DRIFT',
+      error: 'BROKER_ACCOUNT_PERMISSION_DRIFT',
+    })
+    expect(permissionDrift.error).toBe('broker: BROKER_ACCOUNT_PERMISSION_DRIFT')
+    for (const facts of [configured, mismatch, readFailure, permissionDrift]) {
       const rendered = JSON.stringify(facts)
       expect(rendered).not.toContain(expectedAccountId)
       expect(rendered).not.toContain(observedAccountId)

--- a/services/bayn/src/http.ts
+++ b/services/bayn/src/http.ts
@@ -67,6 +67,9 @@ const accountingState = (state: RuntimeState) => {
 }
 
 const brokerPresentationReason = (broker: NonNullable<RuntimeState['broker']>): string | null => {
+  if (broker.error?.startsWith('Alpaca account permission drift detected') === true) {
+    return 'BROKER_ACCOUNT_PERMISSION_DRIFT'
+  }
   const identityMismatch =
     broker.accountBound === false &&
     (broker.readAvailable === true ||


### PR DESCRIPTION
## Summary

- classify continuous Alpaca account permission drift as the explicit safe public reason `BROKER_ACCOUNT_PERMISSION_DRIFT`
- preserve fail-closed broker readiness while distinguishing blocked, trading-blocked, suspended, or fractional-permission changes from ordinary read outages
- keep raw broker/account details out of `/v1/status`

## Related Issues

Release blocker from #13384 review.

## Testing

- `bun test src/http.test.ts` — 24 passed
- `bun run lint`
- `bun run lint:oxlint`
- `bun run lint:oxlint:type`
- `bun run lint:effect`
- `bun run tsc`
- `bun run test` — 923 passed, 138 PostgreSQL-gated tests skipped, 0 failed
- `bun run build`
- `BAYN_TEST_POSTGRES_URL=postgresql://.../bayn_test bun run test:postgres` against PostgreSQL 18.4 — 123 passed, 0 failed

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] The status reason is credential-free and account-ID-free.
- [x] No broker mutation or capital authority is introduced.
