### PR TITLE
fix(bayn): honor idle reconciliation cadence

### DIFF
--- a/services/bayn/src/config.test.ts
+++ b/services/bayn/src/config.test.ts
@@ -256,7 +256,7 @@ describe('pure runtime configuration resolution', () => {
     })
   })
 
-  test('keeps PAPER reconciliation cadence plus operation margin strictly inside the stale threshold', () => {
+  test('keeps PAPER reconciliation cadence plus the enforced full-pass deadline inside the stale threshold', () => {
     const paper = {
       configuredAlpaca: {
         ...alpaca(BrokerEnvironment.Sandbox),
@@ -287,7 +287,7 @@ describe('pure runtime configuration resolution', () => {
       {
         _tag: 'PaperReconciliationCadenceNotWithinStaleThreshold',
         reconciliationIntervalMs: 90_000,
-        operationTimeoutMs: 30_000,
+        reconciliationPassTimeoutMs: 30_000,
         reconciliationStaleThresholdMs: 120_000,
       },
     )
@@ -303,7 +303,7 @@ describe('pure runtime configuration resolution', () => {
       {
         _tag: 'PaperReconciliationCadenceNotWithinStaleThreshold',
         reconciliationIntervalMs: 1,
-        operationTimeoutMs: 120_000,
+        reconciliationPassTimeoutMs: 120_000,
         reconciliationStaleThresholdMs: 120_000,
       },
     )

--- a/services/bayn/src/config.test.ts
+++ b/services/bayn/src/config.test.ts
@@ -256,11 +256,11 @@ describe('pure runtime configuration resolution', () => {
     })
   })
 
-  test('keeps PAPER reconciliation cadence plus the enforced full-pass deadline inside the stale threshold', () => {
+  test('reserves the prior post-timestamp tail and next full-pass deadline inside the PAPER stale threshold', () => {
     const paper = {
       configuredAlpaca: {
         ...alpaca(BrokerEnvironment.Sandbox),
-        reconciliationIntervalMs: 89_999,
+        reconciliationIntervalMs: 59_999,
       },
       legacyMaximumAuthority: 'PAPER' as const,
       brokerAccess: BrokerAccess.Mutation,
@@ -269,7 +269,7 @@ describe('pure runtime configuration resolution', () => {
     const accepted = Result.getOrThrow(resolveRuntimeConfig(resolutionInput(paper)))
     expect(accepted).toMatchObject({
       runtimeMode: 'AutonomousService',
-      alpaca: { reconciliationIntervalMs: 89_999 },
+      alpaca: { reconciliationIntervalMs: 59_999 },
       execution: {
         brokerAccess: BrokerAccess.Mutation,
         capitalAuthority: { _tag: CapitalAuthorityKind.Sandbox },
@@ -281,12 +281,29 @@ describe('pure runtime configuration resolution', () => {
         ...paper,
         configuredAlpaca: {
           ...paper.configuredAlpaca,
-          reconciliationIntervalMs: 90_000,
+          reconciliationIntervalMs: 60_000,
         },
       },
       {
         _tag: 'PaperReconciliationCadenceNotWithinStaleThreshold',
-        reconciliationIntervalMs: 90_000,
+        reconciliationIntervalMs: 60_000,
+        priorReconciliationTailTimeoutMs: 30_000,
+        reconciliationPassTimeoutMs: 30_000,
+        reconciliationStaleThresholdMs: 120_000,
+      },
+    )
+    expectFailure(
+      {
+        ...paper,
+        configuredAlpaca: {
+          ...paper.configuredAlpaca,
+          reconciliationIntervalMs: 89_999,
+        },
+      },
+      {
+        _tag: 'PaperReconciliationCadenceNotWithinStaleThreshold',
+        reconciliationIntervalMs: 89_999,
+        priorReconciliationTailTimeoutMs: 30_000,
         reconciliationPassTimeoutMs: 30_000,
         reconciliationStaleThresholdMs: 120_000,
       },
@@ -303,6 +320,7 @@ describe('pure runtime configuration resolution', () => {
       {
         _tag: 'PaperReconciliationCadenceNotWithinStaleThreshold',
         reconciliationIntervalMs: 1,
+        priorReconciliationTailTimeoutMs: 120_000,
         reconciliationPassTimeoutMs: 120_000,
         reconciliationStaleThresholdMs: 120_000,
       },

--- a/services/bayn/src/config.test.ts
+++ b/services/bayn/src/config.test.ts
@@ -256,6 +256,74 @@ describe('pure runtime configuration resolution', () => {
     })
   })
 
+  test('keeps PAPER reconciliation cadence plus operation margin strictly inside the stale threshold', () => {
+    const paper = {
+      configuredAlpaca: {
+        ...alpaca(BrokerEnvironment.Sandbox),
+        reconciliationIntervalMs: 89_999,
+      },
+      legacyMaximumAuthority: 'PAPER' as const,
+      brokerAccess: BrokerAccess.Mutation,
+      capitalAuthority: CapitalAuthoritySelection.Sandbox,
+    }
+    const accepted = Result.getOrThrow(resolveRuntimeConfig(resolutionInput(paper)))
+    expect(accepted).toMatchObject({
+      runtimeMode: 'AutonomousService',
+      alpaca: { reconciliationIntervalMs: 89_999 },
+      execution: {
+        brokerAccess: BrokerAccess.Mutation,
+        capitalAuthority: { _tag: CapitalAuthorityKind.Sandbox },
+      },
+    })
+
+    expectFailure(
+      {
+        ...paper,
+        configuredAlpaca: {
+          ...paper.configuredAlpaca,
+          reconciliationIntervalMs: 90_000,
+        },
+      },
+      {
+        _tag: 'PaperReconciliationCadenceNotWithinStaleThreshold',
+        reconciliationIntervalMs: 90_000,
+        operationTimeoutMs: 30_000,
+        reconciliationStaleThresholdMs: 120_000,
+      },
+    )
+    expectFailure(
+      {
+        ...paper,
+        operationTimeoutMs: 120_000,
+        configuredAlpaca: {
+          ...paper.configuredAlpaca,
+          reconciliationIntervalMs: 1,
+        },
+      },
+      {
+        _tag: 'PaperReconciliationCadenceNotWithinStaleThreshold',
+        reconciliationIntervalMs: 1,
+        operationTimeoutMs: 120_000,
+        reconciliationStaleThresholdMs: 120_000,
+      },
+    )
+
+    const observe = Result.getOrThrow(
+      resolveRuntimeConfig(
+        resolutionInput({
+          configuredAlpaca: {
+            ...alpaca(BrokerEnvironment.Sandbox),
+            reconciliationIntervalMs: 120_000,
+          },
+        }),
+      ),
+    )
+    expect(observe).toMatchObject({
+      execution: { brokerAccess: BrokerAccess.ReadOnly, capitalAuthority: { _tag: CapitalAuthorityKind.None } },
+      alpaca: { reconciliationIntervalMs: 120_000 },
+    })
+  })
+
   test('translates the historical discovery token into a read-only candidate operation', () => {
     const config = Result.getOrThrow(
       resolveRuntimeConfig(

--- a/services/bayn/src/config.test.ts
+++ b/services/bayn/src/config.test.ts
@@ -256,7 +256,7 @@ describe('pure runtime configuration resolution', () => {
     })
   })
 
-  test('reserves the prior post-timestamp tail and next full-pass deadline inside the PAPER stale threshold', () => {
+  test('reserves the prior post-timestamp tail and next full-pass deadline for every mutation capital mode', () => {
     const paper = {
       configuredAlpaca: {
         ...alpaca(BrokerEnvironment.Sandbox),
@@ -322,6 +322,41 @@ describe('pure runtime configuration resolution', () => {
         reconciliationIntervalMs: 1,
         priorReconciliationTailTimeoutMs: 120_000,
         reconciliationPassTimeoutMs: 120_000,
+        reconciliationStaleThresholdMs: 120_000,
+      },
+    )
+
+    const live = {
+      configuredAlpaca: {
+        ...alpaca(BrokerEnvironment.Live),
+        reconciliationIntervalMs: 59_999,
+      },
+      legacyMaximumAuthority: undefined,
+      brokerAccess: BrokerAccess.Mutation,
+      capitalAuthority: CapitalAuthoritySelection.LiveGrant,
+      liveCapitalGrantHash,
+    }
+    expect(Result.getOrThrow(resolveRuntimeConfig(resolutionInput(live)))).toMatchObject({
+      runtimeMode: 'AutonomousService',
+      alpaca: { reconciliationIntervalMs: 59_999 },
+      execution: {
+        brokerAccess: BrokerAccess.Mutation,
+        capitalAuthority: { _tag: CapitalAuthorityKind.LiveGrant, grantHash: liveCapitalGrantHash },
+      },
+    })
+    expectFailure(
+      {
+        ...live,
+        configuredAlpaca: {
+          ...live.configuredAlpaca,
+          reconciliationIntervalMs: 60_000,
+        },
+      },
+      {
+        _tag: 'PaperReconciliationCadenceNotWithinStaleThreshold',
+        reconciliationIntervalMs: 60_000,
+        priorReconciliationTailTimeoutMs: 30_000,
+        reconciliationPassTimeoutMs: 30_000,
         reconciliationStaleThresholdMs: 120_000,
       },
     )

--- a/services/bayn/src/config/load.ts
+++ b/services/bayn/src/config/load.ts
@@ -25,7 +25,7 @@ const presentRuntimeConfigFailure = (failure: RuntimeConfigResolutionFailure): R
     case 'PaperReconciliationCadenceNotWithinStaleThreshold':
       return {
         operation: 'cycle-loop',
-        message: `PAPER reconciliation interval ${failure.reconciliationIntervalMs.toString()}ms plus full-pass timeout ${failure.reconciliationPassTimeoutMs.toString()}ms must be shorter than the reconciliation stale threshold ${failure.reconciliationStaleThresholdMs.toString()}ms`,
+        message: `PAPER reconciliation interval ${failure.reconciliationIntervalMs.toString()}ms plus prior post-timestamp tail bound ${failure.priorReconciliationTailTimeoutMs.toString()}ms plus next full-pass timeout ${failure.reconciliationPassTimeoutMs.toString()}ms must be shorter than the reconciliation stale threshold ${failure.reconciliationStaleThresholdMs.toString()}ms`,
       }
     case 'IncompleteAlpacaCredentials':
       return {

--- a/services/bayn/src/config/load.ts
+++ b/services/bayn/src/config/load.ts
@@ -25,7 +25,7 @@ const presentRuntimeConfigFailure = (failure: RuntimeConfigResolutionFailure): R
     case 'PaperReconciliationCadenceNotWithinStaleThreshold':
       return {
         operation: 'cycle-loop',
-        message: `PAPER reconciliation interval ${failure.reconciliationIntervalMs.toString()}ms plus operation timeout ${failure.operationTimeoutMs.toString()}ms must be shorter than the reconciliation stale threshold ${failure.reconciliationStaleThresholdMs.toString()}ms`,
+        message: `PAPER reconciliation interval ${failure.reconciliationIntervalMs.toString()}ms plus full-pass timeout ${failure.reconciliationPassTimeoutMs.toString()}ms must be shorter than the reconciliation stale threshold ${failure.reconciliationStaleThresholdMs.toString()}ms`,
       }
     case 'IncompleteAlpacaCredentials':
       return {

--- a/services/bayn/src/config/load.ts
+++ b/services/bayn/src/config/load.ts
@@ -22,6 +22,11 @@ const presentRuntimeConfigFailure = (failure: RuntimeConfigResolutionFailure): R
         operation: 'cycle-loop',
         message: 'cycle poll interval must be shorter than the cycle stall threshold',
       }
+    case 'PaperReconciliationCadenceNotWithinStaleThreshold':
+      return {
+        operation: 'cycle-loop',
+        message: `PAPER reconciliation interval ${failure.reconciliationIntervalMs.toString()}ms plus operation timeout ${failure.operationTimeoutMs.toString()}ms must be shorter than the reconciliation stale threshold ${failure.reconciliationStaleThresholdMs.toString()}ms`,
+      }
     case 'IncompleteAlpacaCredentials':
       return {
         operation: 'broker-connection',

--- a/services/bayn/src/config/model.ts
+++ b/services/bayn/src/config/model.ts
@@ -159,6 +159,12 @@ export type RuntimeConfigResolutionFailure =
       readonly cycleStallThresholdMs: number
     }
   | {
+      readonly _tag: 'PaperReconciliationCadenceNotWithinStaleThreshold'
+      readonly reconciliationIntervalMs: number
+      readonly operationTimeoutMs: number
+      readonly reconciliationStaleThresholdMs: number
+    }
+  | {
       readonly _tag: 'IncompleteAlpacaCredentials'
       readonly configured: AlpacaCredentialPresence
     }

--- a/services/bayn/src/config/model.ts
+++ b/services/bayn/src/config/model.ts
@@ -161,7 +161,7 @@ export type RuntimeConfigResolutionFailure =
   | {
       readonly _tag: 'PaperReconciliationCadenceNotWithinStaleThreshold'
       readonly reconciliationIntervalMs: number
-      readonly operationTimeoutMs: number
+      readonly reconciliationPassTimeoutMs: number
       readonly reconciliationStaleThresholdMs: number
     }
   | {

--- a/services/bayn/src/config/model.ts
+++ b/services/bayn/src/config/model.ts
@@ -161,6 +161,7 @@ export type RuntimeConfigResolutionFailure =
   | {
       readonly _tag: 'PaperReconciliationCadenceNotWithinStaleThreshold'
       readonly reconciliationIntervalMs: number
+      readonly priorReconciliationTailTimeoutMs: number
       readonly reconciliationPassTimeoutMs: number
       readonly reconciliationStaleThresholdMs: number
     }

--- a/services/bayn/src/config/resolution.ts
+++ b/services/bayn/src/config/resolution.ts
@@ -51,9 +51,8 @@ const validatePaperReconciliationTiming = (
   execution: ExecutionPolicy,
   alpaca: AlpacaRuntimeConfig | undefined,
 ): Result.Result<void, RuntimeConfigResolutionFailure> => {
-  const paper =
-    execution.brokerAccess === BrokerAccess.Mutation && execution.capitalAuthority._tag === CapitalAuthorityKind.Sandbox
-  if (!paper || alpaca === undefined) return Result.succeed(undefined)
+  const mutationCapable = execution.brokerAccess === BrokerAccess.Mutation
+  if (!mutationCapable || alpaca === undefined) return Result.succeed(undefined)
   const reconciliationPassTimeoutMs = parsed.operationTimeoutMs
   const priorReconciliationTailTimeoutMs = reconciliationPassTimeoutMs
   const requiredFreshnessWindowMs =

--- a/services/bayn/src/config/resolution.ts
+++ b/services/bayn/src/config/resolution.ts
@@ -55,13 +55,18 @@ const validatePaperReconciliationTiming = (
     execution.brokerAccess === BrokerAccess.Mutation && execution.capitalAuthority._tag === CapitalAuthorityKind.Sandbox
   if (!paper || alpaca === undefined) return Result.succeed(undefined)
   const reconciliationPassTimeoutMs = parsed.operationTimeoutMs
-  const requiredFreshnessWindowMs = BigInt(alpaca.reconciliationIntervalMs) + BigInt(reconciliationPassTimeoutMs)
+  const priorReconciliationTailTimeoutMs = reconciliationPassTimeoutMs
+  const requiredFreshnessWindowMs =
+    BigInt(alpaca.reconciliationIntervalMs) +
+    BigInt(priorReconciliationTailTimeoutMs) +
+    BigInt(reconciliationPassTimeoutMs)
   if (requiredFreshnessWindowMs < BigInt(parsed.reconciliationStaleThresholdMs)) {
     return Result.succeed(undefined)
   }
   return fail({
     _tag: 'PaperReconciliationCadenceNotWithinStaleThreshold',
     reconciliationIntervalMs: alpaca.reconciliationIntervalMs,
+    priorReconciliationTailTimeoutMs,
     reconciliationPassTimeoutMs,
     reconciliationStaleThresholdMs: parsed.reconciliationStaleThresholdMs,
   })

--- a/services/bayn/src/config/resolution.ts
+++ b/services/bayn/src/config/resolution.ts
@@ -46,6 +46,26 @@ const validateCycleTiming = (
         cycleStallThresholdMs: parsed.cycleStallThresholdMs,
       })
 
+const validatePaperReconciliationTiming = (
+  parsed: ParsedRuntimeConfig,
+  execution: ExecutionPolicy,
+  alpaca: AlpacaRuntimeConfig | undefined,
+): Result.Result<void, RuntimeConfigResolutionFailure> => {
+  const paper =
+    execution.brokerAccess === BrokerAccess.Mutation && execution.capitalAuthority._tag === CapitalAuthorityKind.Sandbox
+  if (!paper || alpaca === undefined) return Result.succeed(undefined)
+  const requiredFreshnessWindowMs = BigInt(alpaca.reconciliationIntervalMs) + BigInt(parsed.operationTimeoutMs)
+  if (requiredFreshnessWindowMs < BigInt(parsed.reconciliationStaleThresholdMs)) {
+    return Result.succeed(undefined)
+  }
+  return fail({
+    _tag: 'PaperReconciliationCadenceNotWithinStaleThreshold',
+    reconciliationIntervalMs: alpaca.reconciliationIntervalMs,
+    operationTimeoutMs: parsed.operationTimeoutMs,
+    reconciliationStaleThresholdMs: parsed.reconciliationStaleThresholdMs,
+  })
+}
+
 const credentialPresence = (parsed: ParsedRuntimeConfig): AlpacaCredentialPresence => ({
   accountId: parsed.configuredAlpaca.accountId !== undefined,
   keyId: parsed.configuredAlpaca.key !== undefined,
@@ -330,6 +350,8 @@ export const resolveRuntimeConfig = (
   if (Result.isFailure(alpaca)) return Result.fail(alpaca.failure)
   const execution = resolvePolicy(parsed, alpaca.success)
   if (Result.isFailure(execution)) return Result.fail(execution.failure)
+  const reconciliationTiming = validatePaperReconciliationTiming(parsed, execution.success, alpaca.success)
+  if (Result.isFailure(reconciliationTiming)) return Result.fail(reconciliationTiming.failure)
   const legacy = validateLegacyAuthority(parsed, execution.success)
   if (Result.isFailure(legacy)) return Result.fail(legacy.failure)
   const operation = validateOperation(parsed, execution.success, alpaca.success)

--- a/services/bayn/src/config/resolution.ts
+++ b/services/bayn/src/config/resolution.ts
@@ -54,14 +54,15 @@ const validatePaperReconciliationTiming = (
   const paper =
     execution.brokerAccess === BrokerAccess.Mutation && execution.capitalAuthority._tag === CapitalAuthorityKind.Sandbox
   if (!paper || alpaca === undefined) return Result.succeed(undefined)
-  const requiredFreshnessWindowMs = BigInt(alpaca.reconciliationIntervalMs) + BigInt(parsed.operationTimeoutMs)
+  const reconciliationPassTimeoutMs = parsed.operationTimeoutMs
+  const requiredFreshnessWindowMs = BigInt(alpaca.reconciliationIntervalMs) + BigInt(reconciliationPassTimeoutMs)
   if (requiredFreshnessWindowMs < BigInt(parsed.reconciliationStaleThresholdMs)) {
     return Result.succeed(undefined)
   }
   return fail({
     _tag: 'PaperReconciliationCadenceNotWithinStaleThreshold',
     reconciliationIntervalMs: alpaca.reconciliationIntervalMs,
-    operationTimeoutMs: parsed.operationTimeoutMs,
+    reconciliationPassTimeoutMs,
     reconciliationStaleThresholdMs: parsed.reconciliationStaleThresholdMs,
   })
 }

--- a/services/bayn/src/cycle-runner.test.ts
+++ b/services/bayn/src/cycle-runner.test.ts
@@ -618,6 +618,8 @@ describe('autonomous cycle runner', () => {
     const empty = {}
     const lastAttemptAtNanos = 1_000_000_000n
     const state = { lastAttemptAtNanos }
+    const postPersistenceCompletionAtNanos = lastAttemptAtNanos + 30_000_000n
+    const postPersistenceState = { lastAttemptAtNanos: postPersistenceCompletionAtNanos }
 
     expect(decideIdleReconciliationCadence(empty, lastAttemptAtNanos, 100)).toEqual({ _tag: 'RECONCILE' })
     expect(decideIdleReconciliationCadence(state, lastAttemptAtNanos + 99_000_000n, 100)).toEqual({
@@ -630,7 +632,14 @@ describe('autonomous cycle runner', () => {
     expect(decideIdleReconciliationCadence(state, lastAttemptAtNanos - 1n, 100)).toEqual({
       _tag: 'RECONCILE',
     })
+    expect(
+      decideIdleReconciliationCadence(postPersistenceState, postPersistenceCompletionAtNanos + 99_000_000n, 100),
+    ).toEqual({ _tag: 'WAIT', remainingNanos: 1_000_000n })
+    expect(
+      decideIdleReconciliationCadence(postPersistenceState, postPersistenceCompletionAtNanos + 100_000_000n, 100),
+    ).toEqual({ _tag: 'RECONCILE' })
     expect(state).toEqual({ lastAttemptAtNanos })
+    expect(postPersistenceState).toEqual({ lastAttemptAtNanos: postPersistenceCompletionAtNanos })
   })
 
   test('selects recovery from durable cycle state and publication readiness without effects', () => {
@@ -2354,11 +2363,13 @@ describe('autonomous cycle runner', () => {
     expect(control.acquisitions).toEqual([])
   })
 
-  test('settles durable progress before the scheduled wait and avoids duplicate work', async () => {
+  test('honors a coincident reconciliation deadline after RECOVERED without duplicating durable work', async () => {
     const control: StoreControl = { acquisitions: [], binds: 0 }
     const store = cycleStore(control)
     const observations: CyclePassObservation[] = []
+    const events: string[] = []
     let calendarReads = 0
+    let reconciliations = 0
     const read = brokerRead(() => {
       calendarReads += 1
       return Effect.succeed({ value: monthEndCalendar, evidence })
@@ -2368,8 +2379,17 @@ describe('autonomous cycle runner', () => {
         yield* TestClock.setTime(Date.parse('2026-01-30T21:20:00.000Z'))
         const loop = yield* cycleLoop({
           context: Effect.succeed(context()),
-          observePass: (observation) => Effect.sync(() => observations.push(observation)),
+          observePass: (observation) =>
+            Effect.sync(() => {
+              observations.push(observation)
+              events.push(`observe:${observations.length.toString()}`)
+            }),
           pollIntervalMs: 100,
+          reconciliationIntervalMs: 100,
+          reconcileNotDue: Effect.sync(() => {
+            reconciliations += 1
+            events.push(`reconcile:${reconciliations.toString()}`)
+          }),
         })
         const fiber = yield* provide(
           loop.pipe(Effect.forkScoped({ startImmediately: true })),
@@ -2379,12 +2399,16 @@ describe('autonomous cycle runner', () => {
         ).pipe(Effect.forkScoped({ startImmediately: true }))
         yield* Effect.yieldNow
         expect(control.acquisitions).toHaveLength(1)
+        expect(reconciliations).toBe(1)
         yield* TestClock.adjust(99)
         expect(control.acquisitions).toHaveLength(1)
+        expect(reconciliations).toBe(1)
         yield* TestClock.adjust(1)
         expect(control.acquisitions).toHaveLength(1)
+        expect(reconciliations).toBe(2)
         yield* TestClock.adjust(100)
         expect(control.acquisitions).toHaveLength(1)
+        expect(reconciliations).toBe(3)
         yield* Fiber.interrupt(fiber)
       }),
     ).pipe(Effect.provide(TestClock.layer()))
@@ -2393,6 +2417,8 @@ describe('autonomous cycle runner', () => {
     expect(calendarReads).toBe(1)
     expect(control.binds).toBe(1)
     expect(observations).toHaveLength(3)
+    expect(events.indexOf('reconcile:2')).toBeLessThan(events.indexOf('observe:2'))
+    expect(events.indexOf('reconcile:3')).toBeLessThan(events.indexOf('observe:3'))
     for (const observation of observations) {
       expect(observation).toMatchObject({
         outcome: 'SUCCEEDED',
@@ -2736,7 +2762,7 @@ describe('autonomous cycle runner', () => {
     expect(accountReads).toBe(1)
     expect(positionReads).toBe(1)
     expect(orderReads).toBe(1)
-    expect(notDueReconciliations).toBe(0)
+    expect(notDueReconciliations).toBe(1)
     expect(control.binds).toBe(1)
     expect(mutationSubmits).toBe(0)
     expect(mutationCancels).toBe(0)

--- a/services/bayn/src/cycle-runner.test.ts
+++ b/services/bayn/src/cycle-runner.test.ts
@@ -1632,7 +1632,8 @@ describe('autonomous cycle runner', () => {
           const second = yield* Deferred.make<void>()
           const third = yield* Deferred.make<void>()
           const fourth = yield* Deferred.make<void>()
-          const completions = [first, second, third, fourth]
+          const fifth = yield* Deferred.make<void>()
+          const completions = [first, second, third, fourth, fifth]
           const loop = yield* cycleLoop({
             context: Effect.succeed(context()),
             observePass: (observation) =>
@@ -1819,6 +1820,89 @@ describe('autonomous cycle runner', () => {
     expect(observations).toHaveLength(2)
     expect(observations[0]).toMatchObject({ outcome: 'FAILED' })
     expect(observations[1]).toMatchObject({ outcome: 'SUCCEEDED', result: { outcome: 'NOT_DUE' } })
+    expect(control).toEqual({ acquisitions: [], binds: 0 })
+  })
+
+  test('keeps a failed reconciliation authoritative across non-idle polls until retry succeeds', async () => {
+    const control: StoreControl = { acquisitions: [], binds: 0 }
+    const observations: CyclePassObservation[] = []
+    const failure = new CycleNotDueReconciliationError({
+      failure: 'database',
+      message: 'non-idle reconciliation persistence failed',
+    })
+    let attempts = 0
+    let publicationReads = 0
+
+    await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          yield* TestClock.setTime(Date.parse('2026-01-29T21:20:00.000Z'))
+          const first = yield* Deferred.make<void>()
+          const second = yield* Deferred.make<void>()
+          const third = yield* Deferred.make<void>()
+          const fourth = yield* Deferred.make<void>()
+          const fifth = yield* Deferred.make<void>()
+          const completions = [first, second, third, fourth, fifth]
+          const loop = yield* cycleLoop({
+            context: Effect.succeed(context()),
+            observePass: (observation) =>
+              Effect.sync(() => {
+                observations.push(observation)
+                return completions[observations.length - 1]
+              }).pipe(
+                Effect.flatMap((completion) =>
+                  completion === undefined ? Effect.void : Deferred.succeed(completion, undefined).pipe(Effect.asVoid),
+                ),
+              ),
+            pollIntervalMs: 50,
+            reconciliationIntervalMs: 100,
+            reconcileNotDue: Effect.suspend(() => {
+              attempts += 1
+              return attempts === 1 ? Effect.fail(failure) : Effect.void
+            }),
+          })
+          const fiber = yield* provide(
+            loop,
+            brokerRead(() => Effect.die(new Error('missing-publication loop must not read the broker calendar'))),
+            cycleStore(control),
+            marketDataService(
+              Effect.sync(() => {
+                publicationReads += 1
+                return { outcome: 'MISSING' as const, observedAt: '2026-01-29T21:20:00.000Z' }
+              }),
+            ),
+          ).pipe(Effect.forkScoped({ startImmediately: true }))
+
+          yield* Deferred.await(first)
+          yield* Deferred.await(second)
+          yield* TestClock.adjust(50)
+          yield* Deferred.await(third)
+          yield* TestClock.adjust(50)
+          yield* Deferred.await(fourth)
+          yield* TestClock.adjust(50)
+          yield* Deferred.await(fifth)
+          yield* Fiber.interrupt(fiber)
+        }),
+      ).pipe(Effect.provide(TestClock.layer())),
+    )
+
+    expect(attempts).toBe(2)
+    expect(publicationReads).toBe(4)
+    expect(observations).toHaveLength(5)
+    expect(observations[0]).toMatchObject({ outcome: 'SUCCEEDED', result: { outcome: 'NO_PUBLICATION' } })
+    expect(observations[1]).toMatchObject({
+      outcome: 'FAILED',
+      error: { operation: 'reconcile-not-due', message: failure.message },
+    })
+    expect(observations[2]).toMatchObject({
+      outcome: 'FAILED',
+      error: { operation: 'reconcile-not-due', message: failure.message },
+    })
+    expect(observations[3]).toMatchObject({
+      outcome: 'FAILED',
+      error: { operation: 'reconcile-not-due', message: failure.message },
+    })
+    expect(observations[4]).toMatchObject({ outcome: 'SUCCEEDED', result: { outcome: 'NO_PUBLICATION' } })
     expect(control).toEqual({ acquisitions: [], binds: 0 })
   })
 

--- a/services/bayn/src/cycle-runner.test.ts
+++ b/services/bayn/src/cycle-runner.test.ts
@@ -1633,7 +1633,8 @@ describe('autonomous cycle runner', () => {
           const third = yield* Deferred.make<void>()
           const fourth = yield* Deferred.make<void>()
           const fifth = yield* Deferred.make<void>()
-          const completions = [first, second, third, fourth, fifth]
+          const sixth = yield* Deferred.make<void>()
+          const completions = [first, second, third, fourth, fifth, sixth]
           const loop = yield* cycleLoop({
             context: Effect.succeed(context()),
             observePass: (observation) =>
@@ -1700,7 +1701,8 @@ describe('autonomous cycle runner', () => {
           const third = yield* Deferred.make<void>()
           const fourth = yield* Deferred.make<void>()
           const fifth = yield* Deferred.make<void>()
-          const completions = [first, second, third, fourth, fifth]
+          const sixth = yield* Deferred.make<void>()
+          const completions = [first, second, third, fourth, fifth, sixth]
           const loop = yield* cycleLoop({
             context: Effect.succeed(context()),
             observePass: (observation) =>
@@ -1842,7 +1844,8 @@ describe('autonomous cycle runner', () => {
           const third = yield* Deferred.make<void>()
           const fourth = yield* Deferred.make<void>()
           const fifth = yield* Deferred.make<void>()
-          const completions = [first, second, third, fourth, fifth]
+          const sixth = yield* Deferred.make<void>()
+          const completions = [first, second, third, fourth, fifth, sixth]
           const loop = yield* cycleLoop({
             context: Effect.succeed(context()),
             observePass: (observation) =>
@@ -1879,8 +1882,9 @@ describe('autonomous cycle runner', () => {
           yield* Deferred.await(third)
           yield* TestClock.adjust(50)
           yield* Deferred.await(fourth)
-          yield* TestClock.adjust(50)
           yield* Deferred.await(fifth)
+          yield* TestClock.adjust(50)
+          yield* Deferred.await(sixth)
           yield* Fiber.interrupt(fiber)
         }),
       ).pipe(Effect.provide(TestClock.layer())),
@@ -1888,7 +1892,7 @@ describe('autonomous cycle runner', () => {
 
     expect(attempts).toBe(2)
     expect(publicationReads).toBe(4)
-    expect(observations).toHaveLength(5)
+    expect(observations).toHaveLength(6)
     expect(observations[0]).toMatchObject({ outcome: 'SUCCEEDED', result: { outcome: 'NO_PUBLICATION' } })
     expect(observations[1]).toMatchObject({
       outcome: 'FAILED',
@@ -1903,6 +1907,76 @@ describe('autonomous cycle runner', () => {
       error: { operation: 'reconcile-not-due', message: failure.message },
     })
     expect(observations[4]).toMatchObject({ outcome: 'SUCCEEDED', result: { outcome: 'NO_PUBLICATION' } })
+    expect(observations[5]).toMatchObject({ outcome: 'SUCCEEDED', result: { outcome: 'NO_PUBLICATION' } })
+    expect(control).toEqual({ acquisitions: [], binds: 0 })
+  })
+
+  test('records non-idle recovery immediately when cadence retry succeeds before the next poll', async () => {
+    const control: StoreControl = { acquisitions: [], binds: 0 }
+    const observations: CyclePassObservation[] = []
+    const failure = new CycleNotDueReconciliationError({
+      failure: 'database',
+      message: 'slow-poll reconciliation persistence failed',
+    })
+    let attempts = 0
+    let publicationReads = 0
+
+    await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          yield* TestClock.setTime(Date.parse('2026-01-29T21:20:00.000Z'))
+          const initial = yield* Deferred.make<void>()
+          const failed = yield* Deferred.make<void>()
+          const recovered = yield* Deferred.make<void>()
+          const completions = [initial, failed, recovered]
+          const loop = yield* cycleLoop({
+            context: Effect.succeed(context()),
+            observePass: (observation) =>
+              Effect.sync(() => {
+                observations.push(observation)
+                return completions[observations.length - 1]
+              }).pipe(
+                Effect.flatMap((completion) =>
+                  completion === undefined ? Effect.void : Deferred.succeed(completion, undefined).pipe(Effect.asVoid),
+                ),
+              ),
+            pollIntervalMs: 250,
+            reconciliationIntervalMs: 100,
+            reconcileNotDue: Effect.suspend(() => {
+              attempts += 1
+              return attempts === 1 ? Effect.fail(failure) : Effect.void
+            }),
+          })
+          const fiber = yield* provide(
+            loop,
+            brokerRead(() => Effect.die(new Error('missing-publication loop must not read the broker calendar'))),
+            cycleStore(control),
+            marketDataService(
+              Effect.sync(() => {
+                publicationReads += 1
+                return { outcome: 'MISSING' as const, observedAt: '2026-01-29T21:20:00.000Z' }
+              }),
+            ),
+          ).pipe(Effect.forkScoped({ startImmediately: true }))
+
+          yield* Deferred.await(initial)
+          yield* Deferred.await(failed)
+          yield* TestClock.adjust(100)
+          yield* Deferred.await(recovered)
+          yield* Fiber.interrupt(fiber)
+        }),
+      ).pipe(Effect.provide(TestClock.layer())),
+    )
+
+    expect(attempts).toBe(2)
+    expect(publicationReads).toBe(1)
+    expect(observations).toHaveLength(3)
+    expect(observations[0]).toMatchObject({ outcome: 'SUCCEEDED', result: { outcome: 'NO_PUBLICATION' } })
+    expect(observations[1]).toMatchObject({
+      outcome: 'FAILED',
+      error: { operation: 'reconcile-not-due', message: failure.message },
+    })
+    expect(observations[2]).toMatchObject({ outcome: 'SUCCEEDED', result: { outcome: 'NO_PUBLICATION' } })
     expect(control).toEqual({ acquisitions: [], binds: 0 })
   })
 

--- a/services/bayn/src/cycle-runner.test.ts
+++ b/services/bayn/src/cycle-runner.test.ts
@@ -41,6 +41,7 @@ import {
   selectCycleCalendarCandidate,
   selectDiscoveredPublications,
   selectNextExecutionSession,
+  shouldDeferCyclePollForReconciliation,
   type AutonomousCycleLoopOptions,
   type CycleCandidate,
   type CyclePassObservation,
@@ -648,6 +649,24 @@ describe('autonomous cycle runner', () => {
     expect(
       decideIdleReconciliationCadence(postPersistenceState, postPersistenceCompletionAtNanos + 100_000_000n, 100),
     ).toEqual({ _tag: 'RECONCILE' })
+    expect(
+      shouldDeferCyclePollForReconciliation({
+        lastAttemptAtNanos: 0n,
+        nextPollAtNanos: 99n,
+        pollStartAtNanos: 99n,
+        reconciliationAtNanos: 100n,
+        cyclePassTimeoutNanos: 2n,
+      }),
+    ).toBe(true)
+    expect(
+      shouldDeferCyclePollForReconciliation({
+        lastAttemptAtNanos: 100n,
+        nextPollAtNanos: 99n,
+        pollStartAtNanos: 100n,
+        reconciliationAtNanos: 200n,
+        cyclePassTimeoutNanos: 100n,
+      }),
+    ).toBe(false)
     expect(state).toEqual({ lastAttemptAtNanos })
     expect(postPersistenceState).toEqual({ lastAttemptAtNanos: postPersistenceCompletionAtNanos })
   })
@@ -1588,6 +1607,7 @@ describe('autonomous cycle runner', () => {
                   count === 1 ? Deferred.succeed(firstPass, undefined).pipe(Effect.asVoid) : Effect.void,
                 ),
               ),
+            cyclePassTimeoutMs: 100,
             pollIntervalMs: 100,
             reconciliationIntervalMs: 100,
             reconcileNotDue: Effect.sync(() => {

--- a/services/bayn/src/cycle-runner.test.ts
+++ b/services/bayn/src/cycle-runner.test.ts
@@ -2809,7 +2809,7 @@ describe('autonomous cycle runner', () => {
     const baseContext = context(accountId)
     const dueContext: CycleRunContext<BrokerRead> = {
       ...baseContext,
-      buildDecision: (cycle) =>
+      buildDecision: (cycle, reconciliationCompleted = Effect.void) =>
         Effect.gen(function* () {
           const broker = yield* BrokerRead
           const [accountObservation, positionsObservation, ordersObservation, observedAt] = yield* Effect.all([
@@ -2853,6 +2853,7 @@ describe('autonomous cycle runner', () => {
               contentHash,
             })
           })
+          yield* reconciliationCompleted
           return makeDecision(cycle, observedAt, undefined, {
             planningBrokerStateHash: canonicalHashV1({ accountHash, positionsHash, ordersHash }),
             reconciliationId,
@@ -2992,7 +2993,7 @@ describe('autonomous cycle runner', () => {
     expect(accountReads).toBe(1)
     expect(positionReads).toBe(1)
     expect(orderReads).toBe(1)
-    expect(notDueReconciliations).toBe(0)
+    expect(notDueReconciliations).toBe(1)
     expect(control.binds).toBe(1)
     expect(mutationSubmits).toBe(0)
     expect(mutationCancels).toBe(0)

--- a/services/bayn/src/cycle-runner.test.ts
+++ b/services/bayn/src/cycle-runner.test.ts
@@ -1543,6 +1543,72 @@ describe('autonomous cycle runner', () => {
     expect(control).toEqual({ acquisitions: [], binds: 0 })
   })
 
+  test('reconciles before polling when the idle and cycle deadlines coincide', async () => {
+    const control: StoreControl = { acquisitions: [], binds: 0 }
+    const events: string[] = []
+    let observations = 0
+    let reconciliations = 0
+    let calendarReads = 0
+
+    await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          yield* TestClock.setTime(Date.parse('2026-01-29T21:20:00.000Z'))
+          const firstPass = yield* Deferred.make<void>()
+          const secondCalendarRead = yield* Deferred.make<void>()
+          const loop = yield* cycleLoop({
+            context: Effect.succeed(context()),
+            observePass: () =>
+              Effect.sync(() => {
+                observations += 1
+                events.push(`observe:${observations.toString()}`)
+                return observations
+              }).pipe(
+                Effect.flatMap((count) =>
+                  count === 1 ? Deferred.succeed(firstPass, undefined).pipe(Effect.asVoid) : Effect.void,
+                ),
+              ),
+            pollIntervalMs: 100,
+            reconciliationIntervalMs: 100,
+            reconcileNotDue: Effect.sync(() => {
+              reconciliations += 1
+              events.push(`reconcile:${reconciliations.toString()}`)
+            }),
+          })
+          const fiber = yield* provide(
+            loop,
+            brokerRead(() =>
+              Effect.sync(() => {
+                calendarReads += 1
+                events.push(`calendar:${calendarReads.toString()}`)
+                return calendarReads
+              }).pipe(
+                Effect.tap((count) =>
+                  count === 2 ? Deferred.succeed(secondCalendarRead, undefined).pipe(Effect.asVoid) : Effect.void,
+                ),
+                Effect.as({ value: ordinaryNotDueCalendar, evidence }),
+              ),
+            ),
+            cycleStore(control),
+            marketDataService(Effect.succeed(finalizedPublication('2026-01-29'))),
+          ).pipe(Effect.forkScoped({ startImmediately: true }))
+
+          yield* Deferred.await(firstPass)
+          yield* TestClock.adjust(100)
+          yield* Deferred.await(secondCalendarRead)
+          yield* Fiber.interrupt(fiber)
+        }),
+      ).pipe(Effect.provide(TestClock.layer())),
+    )
+
+    expect(events.indexOf('reconcile:2')).toBeGreaterThan(events.indexOf('observe:1'))
+    expect(events.indexOf('reconcile:2')).toBeLessThan(events.indexOf('calendar:2'))
+    expect(events.indexOf('observe:2')).toBeLessThan(events.indexOf('calendar:2'))
+    expect(calendarReads).toBe(2)
+    expect(reconciliations).toBe(2)
+    expect(control).toEqual({ acquisitions: [], binds: 0 })
+  })
+
   test('keeps faster cycle polling from over-reading reconciliation before the exact cadence boundary', async () => {
     const control: StoreControl = { acquisitions: [], binds: 0 }
     const observations: CyclePassObservation[] = []

--- a/services/bayn/src/cycle-runner.test.ts
+++ b/services/bayn/src/cycle-runner.test.ts
@@ -65,13 +65,23 @@ import { DataFeed, DataSource, PriceAdjustment, PublicationSchema, type InputMan
 
 type CycleLoopTestOptions<E, ContextR, DecisionR> = Omit<
   AutonomousCycleLoopOptions<E, ContextR, DecisionR>,
-  'reconcileNotDue' | 'reconciliationIntervalMs'
+  'cyclePassTimeoutMs' | 'reconcileNotDue' | 'reconciliationIntervalMs'
 > &
-  Partial<Pick<AutonomousCycleLoopOptions<E, ContextR, DecisionR>, 'reconcileNotDue' | 'reconciliationIntervalMs'>>
+  Partial<
+    Pick<
+      AutonomousCycleLoopOptions<E, ContextR, DecisionR>,
+      'cyclePassTimeoutMs' | 'reconcileNotDue' | 'reconciliationIntervalMs'
+    >
+  >
 
 const cycleLoop = <E, ContextR, DecisionR>(options: CycleLoopTestOptions<E, ContextR, DecisionR>) =>
   Effect.fromResult(
-    makeAutonomousCycleLoop({ reconcileNotDue: Effect.void, reconciliationIntervalMs: 30_000, ...options }),
+    makeAutonomousCycleLoop({
+      cyclePassTimeoutMs: 50,
+      reconcileNotDue: Effect.void,
+      reconciliationIntervalMs: 30_000,
+      ...options,
+    }),
   )
 
 const signalCalendarVersion = 'signal-XNYS-2026-v1'
@@ -1522,6 +1532,7 @@ describe('autonomous cycle runner', () => {
           const completed = yield* Deferred.make<CyclePassObservation>()
           const loop = yield* cycleLoop({
             context: Effect.succeed(context()),
+            cyclePassTimeoutMs: 25,
             observePass: (observation) =>
               Effect.sync(() => {
                 events.push('observe')
@@ -1614,6 +1625,75 @@ describe('autonomous cycle runner', () => {
     expect(events.indexOf('reconcile:2')).toBeLessThan(events.indexOf('calendar:2'))
     expect(events.indexOf('observe:2')).toBeLessThan(events.indexOf('calendar:2'))
     expect(calendarReads).toBe(2)
+    expect(reconciliations).toBe(2)
+    expect(control).toEqual({ acquisitions: [], binds: 0 })
+  })
+
+  test('defers a near-deadline poll whose bounded pass would cross reconciliation cadence', async () => {
+    const control: StoreControl = { acquisitions: [], binds: 0 }
+    const events: string[] = []
+    let observations = 0
+    let reconciliations = 0
+    let publicationReads = 0
+
+    await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          yield* TestClock.setTime(Date.parse('2026-01-29T21:20:00.000Z'))
+          const firstPass = yield* Deferred.make<void>()
+          const secondPublicationRead = yield* Deferred.make<void>()
+          const loop = yield* cycleLoop({
+            context: Effect.succeed(context()),
+            cyclePassTimeoutMs: 2,
+            observePass: () =>
+              Effect.sync(() => {
+                observations += 1
+                events.push(`observe:${observations.toString()}`)
+                return observations
+              }).pipe(
+                Effect.flatMap((count) =>
+                  count === 1 ? Deferred.succeed(firstPass, undefined).pipe(Effect.asVoid) : Effect.void,
+                ),
+              ),
+            pollIntervalMs: 99,
+            reconciliationIntervalMs: 100,
+            reconcileNotDue: Effect.sync(() => {
+              reconciliations += 1
+              events.push(`reconcile:${reconciliations.toString()}`)
+            }),
+          })
+          const fiber = yield* provide(
+            loop,
+            brokerRead(() => Effect.die(new Error('missing-publication loop must not read the broker calendar'))),
+            cycleStore(control),
+            marketDataService(
+              Effect.sync(() => {
+                publicationReads += 1
+                events.push(`publication:${publicationReads.toString()}`)
+                return publicationReads
+              }).pipe(
+                Effect.tap((count) =>
+                  count === 2 ? Deferred.succeed(secondPublicationRead, undefined).pipe(Effect.asVoid) : Effect.void,
+                ),
+                Effect.as({ outcome: 'MISSING' as const, observedAt: '2026-01-29T21:20:00.000Z' }),
+              ),
+            ),
+          ).pipe(Effect.forkScoped({ startImmediately: true }))
+
+          yield* Deferred.await(firstPass)
+          yield* TestClock.withLive(Effect.sleep(5))
+          yield* TestClock.adjust(99)
+          expect(publicationReads).toBe(1)
+          expect(reconciliations).toBe(1)
+          yield* TestClock.adjust(1)
+          yield* Deferred.await(secondPublicationRead)
+          yield* Fiber.interrupt(fiber)
+        }),
+      ).pipe(Effect.provide(TestClock.layer())),
+    )
+
+    expect(events.indexOf('reconcile:2')).toBeLessThan(events.indexOf('publication:2'))
+    expect(publicationReads).toBe(2)
     expect(reconciliations).toBe(2)
     expect(control).toEqual({ acquisitions: [], binds: 0 })
   })
@@ -1841,13 +1921,10 @@ describe('autonomous cycle runner', () => {
           yield* TestClock.setTime(Date.parse('2026-01-29T21:20:00.000Z'))
           const first = yield* Deferred.make<void>()
           const second = yield* Deferred.make<void>()
-          const third = yield* Deferred.make<void>()
-          const fourth = yield* Deferred.make<void>()
-          const fifth = yield* Deferred.make<void>()
-          const sixth = yield* Deferred.make<void>()
-          const completions = [first, second, third, fourth, fifth, sixth]
+          const completions = [first, second]
           const loop = yield* cycleLoop({
             context: Effect.succeed(context()),
+            cyclePassTimeoutMs: 2,
             observePass: (observation) =>
               Effect.sync(() => {
                 observations.push(observation)
@@ -1857,8 +1934,8 @@ describe('autonomous cycle runner', () => {
                   completion === undefined ? Effect.void : Deferred.succeed(completion, undefined).pipe(Effect.asVoid),
                 ),
               ),
-            pollIntervalMs: 50,
-            reconciliationIntervalMs: 100,
+            pollIntervalMs: 5,
+            reconciliationIntervalMs: 10,
             reconcileNotDue: Effect.suspend(() => {
               attempts += 1
               return attempts === 1 ? Effect.fail(failure) : Effect.void
@@ -1878,21 +1955,18 @@ describe('autonomous cycle runner', () => {
 
           yield* Deferred.await(first)
           yield* Deferred.await(second)
-          yield* TestClock.adjust(50)
-          yield* Deferred.await(third)
-          yield* TestClock.adjust(50)
-          yield* Deferred.await(fourth)
-          yield* Deferred.await(fifth)
-          yield* TestClock.adjust(50)
-          yield* Deferred.await(sixth)
+          for (let elapsed = 0; elapsed < 15; elapsed += 1) {
+            yield* TestClock.withLive(Effect.sleep(1))
+            yield* TestClock.adjust(1)
+          }
           yield* Fiber.interrupt(fiber)
         }),
       ).pipe(Effect.provide(TestClock.layer())),
     )
 
     expect(attempts).toBe(2)
-    expect(publicationReads).toBe(4)
-    expect(observations).toHaveLength(6)
+    expect(publicationReads).toBe(3)
+    expect(observations).toHaveLength(5)
     expect(observations[0]).toMatchObject({ outcome: 'SUCCEEDED', result: { outcome: 'NO_PUBLICATION' } })
     expect(observations[1]).toMatchObject({
       outcome: 'FAILED',
@@ -1902,12 +1976,8 @@ describe('autonomous cycle runner', () => {
       outcome: 'FAILED',
       error: { operation: 'reconcile-not-due', message: failure.message },
     })
-    expect(observations[3]).toMatchObject({
-      outcome: 'FAILED',
-      error: { operation: 'reconcile-not-due', message: failure.message },
-    })
+    expect(observations[3]).toMatchObject({ outcome: 'SUCCEEDED', result: { outcome: 'NO_PUBLICATION' } })
     expect(observations[4]).toMatchObject({ outcome: 'SUCCEEDED', result: { outcome: 'NO_PUBLICATION' } })
-    expect(observations[5]).toMatchObject({ outcome: 'SUCCEEDED', result: { outcome: 'NO_PUBLICATION' } })
     expect(control).toEqual({ acquisitions: [], binds: 0 })
   })
 
@@ -2813,12 +2883,14 @@ describe('autonomous cycle runner', () => {
           const observed = yield* Deferred.make<CyclePassObservation>()
           const loop = yield* cycleLoop({
             context: Effect.succeed(dueContext),
+            cyclePassTimeoutMs: 604_800_000,
             observePass: (observation) =>
               Effect.sync(() => observations.push(observation)).pipe(
                 Effect.andThen(Deferred.succeed(observed, observation)),
                 Effect.asVoid,
               ),
             pollIntervalMs: 60_000,
+            reconciliationIntervalMs: 604_800_000,
             reconcileNotDue: Effect.sync(() => {
               notDueReconciliations += 1
             }),
@@ -2920,7 +2992,7 @@ describe('autonomous cycle runner', () => {
     expect(accountReads).toBe(1)
     expect(positionReads).toBe(1)
     expect(orderReads).toBe(1)
-    expect(notDueReconciliations).toBe(1)
+    expect(notDueReconciliations).toBe(0)
     expect(control.binds).toBe(1)
     expect(mutationSubmits).toBe(0)
     expect(mutationCancels).toBe(0)
@@ -2954,6 +3026,54 @@ describe('autonomous cycle runner', () => {
       ),
     )
     expect(interrupted).toBe(true)
+    expect(control).toEqual({ acquisitions: [], binds: 0 })
+  })
+
+  test('interrupts a cycle pass that cannot complete before its admission deadline', async () => {
+    const started = await Effect.runPromise(Deferred.make<void>())
+    let interrupted = false
+    const discovery = Deferred.succeed(started, undefined).pipe(
+      Effect.andThen(Effect.never),
+      Effect.onInterrupt(() => Effect.sync(() => void (interrupted = true))),
+    )
+    const control: StoreControl = { acquisitions: [], binds: 0 }
+    const observation = await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          yield* TestClock.setTime(Date.parse('2026-01-30T21:20:00.000Z'))
+          const observed = yield* Deferred.make<CyclePassObservation>()
+          const loop = yield* cycleLoop({
+            context: Effect.succeed(context()),
+            cyclePassTimeoutMs: 10,
+            observePass: (pass) => Deferred.succeed(observed, pass).pipe(Effect.asVoid),
+            pollIntervalMs: 100,
+            reconciliationIntervalMs: 100,
+            reconcileNotDue: Effect.void,
+          })
+          const fiber = yield* provide(
+            loop,
+            brokerRead(() => Effect.die(new Error('timed-out publication read must not reach the broker'))),
+            cycleStore(control),
+            marketDataService(discovery),
+          ).pipe(Effect.forkScoped({ startImmediately: true }))
+          yield* Deferred.await(started)
+          yield* TestClock.adjust(10)
+          const result = yield* Deferred.await(observed)
+          yield* Fiber.interrupt(fiber)
+          return result
+        }),
+      ).pipe(Effect.provide(TestClock.layer())),
+    )
+
+    expect(interrupted).toBe(true)
+    expect(observation).toMatchObject({
+      outcome: 'FAILED',
+      error: {
+        operation: 'run-cycle-pass',
+        failure: 'operational',
+        message: 'autonomous cycle pass did not complete or reconcile within 10ms',
+      },
+    })
     expect(control).toEqual({ acquisitions: [], binds: 0 })
   })
 
@@ -3295,6 +3415,7 @@ describe('autonomous cycle runner', () => {
     for (const pollIntervalMs of [0, -1, 0.5, Number.MAX_SAFE_INTEGER + 1]) {
       const result = makeAutonomousCycleLoop({
         context: Effect.succeed(context()),
+        cyclePassTimeoutMs: 50,
         observePass: ignorePass,
         pollIntervalMs,
         reconciliationIntervalMs: 30_000,
@@ -3310,6 +3431,7 @@ describe('autonomous cycle runner', () => {
     for (const reconciliationIntervalMs of [0, -1, 0.5, Number.MAX_SAFE_INTEGER + 1]) {
       const result = makeAutonomousCycleLoop({
         context: Effect.succeed(context()),
+        cyclePassTimeoutMs: 50,
         observePass: ignorePass,
         pollIntervalMs: 100,
         reconciliationIntervalMs,

--- a/services/bayn/src/cycle-runner.test.ts
+++ b/services/bayn/src/cycle-runner.test.ts
@@ -30,6 +30,7 @@ import {
   CycleDecisionBuildError,
   CycleRunnerError,
   cyclePassLogFacts,
+  decideIdleReconciliationCadence,
   isMonthEndCycleDue,
   makeAutonomousCycleLoop,
   makeDueCycleDraft,
@@ -64,12 +65,14 @@ import { DataFeed, DataSource, PriceAdjustment, PublicationSchema, type InputMan
 
 type CycleLoopTestOptions<E, ContextR, DecisionR> = Omit<
   AutonomousCycleLoopOptions<E, ContextR, DecisionR>,
-  'reconcileNotDue'
+  'reconcileNotDue' | 'reconciliationIntervalMs'
 > &
-  Partial<Pick<AutonomousCycleLoopOptions<E, ContextR, DecisionR>, 'reconcileNotDue'>>
+  Partial<Pick<AutonomousCycleLoopOptions<E, ContextR, DecisionR>, 'reconcileNotDue' | 'reconciliationIntervalMs'>>
 
 const cycleLoop = <E, ContextR, DecisionR>(options: CycleLoopTestOptions<E, ContextR, DecisionR>) =>
-  Effect.fromResult(makeAutonomousCycleLoop({ reconcileNotDue: Effect.void, ...options }))
+  Effect.fromResult(
+    makeAutonomousCycleLoop({ reconcileNotDue: Effect.void, reconciliationIntervalMs: 30_000, ...options }),
+  )
 
 const signalCalendarVersion = 'signal-XNYS-2026-v1'
 const snapshotId = 'd'.repeat(64)
@@ -152,6 +155,22 @@ const monthEndCalendar = calendar([
     closeAt: '2026-02-02T20:00:00.000Z',
   },
 ])
+
+const ordinaryNotDueCalendar = calendar(
+  [
+    {
+      date: '2026-01-29',
+      openAt: '2026-01-29T14:30:00.000Z',
+      closeAt: '2026-01-29T21:00:00.000Z',
+    },
+    {
+      date: '2026-01-30',
+      openAt: '2026-01-30T14:30:00.000Z',
+      closeAt: '2026-01-30T21:00:00.000Z',
+    },
+  ],
+  { start: '2026-01-29', end: '2026-02-28' },
+)
 
 const dueCycleDraftFixture = (
   cycleCandidate: CycleCandidate,
@@ -595,6 +614,25 @@ const recoveryState = (
 })
 
 describe('autonomous cycle runner', () => {
+  test('decides first-pass, boundary, wait, and monotonic-regression reconciliation cadence purely', () => {
+    const empty = {}
+    const lastAttemptAtNanos = 1_000_000_000n
+    const state = { lastAttemptAtNanos }
+
+    expect(decideIdleReconciliationCadence(empty, lastAttemptAtNanos, 100)).toEqual({ _tag: 'RECONCILE' })
+    expect(decideIdleReconciliationCadence(state, lastAttemptAtNanos + 99_000_000n, 100)).toEqual({
+      _tag: 'WAIT',
+      remainingNanos: 1_000_000n,
+    })
+    expect(decideIdleReconciliationCadence(state, lastAttemptAtNanos + 100_000_000n, 100)).toEqual({
+      _tag: 'RECONCILE',
+    })
+    expect(decideIdleReconciliationCadence(state, lastAttemptAtNanos - 1n, 100)).toEqual({
+      _tag: 'RECONCILE',
+    })
+    expect(state).toEqual({ lastAttemptAtNanos })
+  })
+
   test('selects recovery from durable cycle state and publication readiness without effects', () => {
     const executionSession = selectNextExecutionSession('2026-01-30', monthEndCalendar)
     if (executionSession === undefined) throw new Error('recovery fixture requires an execution session')
@@ -1502,6 +1540,210 @@ describe('autonomous cycle runner', () => {
     expect(events).toEqual(['reconcile', 'observe'])
     expect(observations).toHaveLength(1)
     expect(observations[0]).toMatchObject({ outcome: 'SUCCEEDED', result: { outcome: 'NOT_DUE' } })
+    expect(control).toEqual({ acquisitions: [], binds: 0 })
+  })
+
+  test('keeps faster cycle polling from over-reading reconciliation before the exact cadence boundary', async () => {
+    const control: StoreControl = { acquisitions: [], binds: 0 }
+    const observations: CyclePassObservation[] = []
+    let reconciliations = 0
+    let calendarReads = 0
+
+    await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          yield* TestClock.setTime(Date.parse('2026-01-29T21:20:00.000Z'))
+          const first = yield* Deferred.make<void>()
+          const second = yield* Deferred.make<void>()
+          const third = yield* Deferred.make<void>()
+          const fourth = yield* Deferred.make<void>()
+          const completions = [first, second, third, fourth]
+          const loop = yield* cycleLoop({
+            context: Effect.succeed(context()),
+            observePass: (observation) =>
+              Effect.sync(() => {
+                observations.push(observation)
+                return completions[observations.length - 1]
+              }).pipe(
+                Effect.flatMap((completion) =>
+                  completion === undefined ? Effect.void : Deferred.succeed(completion, undefined).pipe(Effect.asVoid),
+                ),
+              ),
+            pollIntervalMs: 100,
+            reconciliationIntervalMs: 250,
+            reconcileNotDue: Effect.sync(() => {
+              reconciliations += 1
+            }),
+          })
+          const fiber = yield* provide(
+            loop,
+            brokerRead(() =>
+              Effect.sync(() => {
+                calendarReads += 1
+                return { value: ordinaryNotDueCalendar, evidence }
+              }),
+            ),
+            cycleStore(control),
+            marketDataService(Effect.succeed(finalizedPublication('2026-01-29'))),
+          ).pipe(Effect.forkScoped({ startImmediately: true }))
+
+          yield* Deferred.await(first)
+          yield* TestClock.adjust(100)
+          yield* Deferred.await(second)
+          yield* TestClock.adjust(100)
+          yield* Deferred.await(third)
+          yield* TestClock.adjust(49)
+          expect(reconciliations).toBe(1)
+          expect(observations).toHaveLength(3)
+          yield* TestClock.adjust(2)
+          yield* Deferred.await(fourth)
+          yield* Fiber.interrupt(fiber)
+        }),
+      ).pipe(Effect.provide(TestClock.layer())),
+    )
+
+    expect(reconciliations).toBe(2)
+    expect(calendarReads).toBe(3)
+    expect(observations).toHaveLength(4)
+    expect(observations.every((observation) => observation.outcome === 'SUCCEEDED')).toBe(true)
+    expect(control).toEqual({ acquisitions: [], binds: 0 })
+  })
+
+  test('runs idle reconciliation independently when cycle polling is slower than its configured cadence', async () => {
+    const control: StoreControl = { acquisitions: [], binds: 0 }
+    const observations: CyclePassObservation[] = []
+    let reconciliations = 0
+    let calendarReads = 0
+
+    await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          yield* TestClock.setTime(Date.parse('2026-01-29T21:20:00.000Z'))
+          const first = yield* Deferred.make<void>()
+          const second = yield* Deferred.make<void>()
+          const third = yield* Deferred.make<void>()
+          const fourth = yield* Deferred.make<void>()
+          const fifth = yield* Deferred.make<void>()
+          const completions = [first, second, third, fourth, fifth]
+          const loop = yield* cycleLoop({
+            context: Effect.succeed(context()),
+            observePass: (observation) =>
+              Effect.sync(() => {
+                observations.push(observation)
+                return completions[observations.length - 1]
+              }).pipe(
+                Effect.flatMap((completion) =>
+                  completion === undefined ? Effect.void : Deferred.succeed(completion, undefined).pipe(Effect.asVoid),
+                ),
+              ),
+            pollIntervalMs: 350,
+            reconciliationIntervalMs: 100,
+            reconcileNotDue: Effect.sync(() => {
+              reconciliations += 1
+            }),
+          })
+          const fiber = yield* provide(
+            loop,
+            brokerRead(() =>
+              Effect.sync(() => {
+                calendarReads += 1
+                return { value: ordinaryNotDueCalendar, evidence }
+              }),
+            ),
+            cycleStore(control),
+            marketDataService(Effect.succeed(finalizedPublication('2026-01-29'))),
+          ).pipe(Effect.forkScoped({ startImmediately: true }))
+
+          yield* Deferred.await(first)
+          yield* TestClock.adjust(100)
+          yield* Deferred.await(second)
+          yield* TestClock.adjust(100)
+          yield* Deferred.await(third)
+          yield* TestClock.adjust(100)
+          yield* Deferred.await(fourth)
+          expect(calendarReads).toBe(1)
+          expect(reconciliations).toBe(4)
+          yield* TestClock.adjust(49)
+          expect(observations).toHaveLength(4)
+          yield* TestClock.adjust(1)
+          yield* Deferred.await(fifth)
+          yield* Fiber.interrupt(fiber)
+        }),
+      ).pipe(Effect.provide(TestClock.layer())),
+    )
+
+    expect(calendarReads).toBe(2)
+    expect(reconciliations).toBe(4)
+    expect(observations).toHaveLength(5)
+    expect(observations.every((observation) => observation.outcome === 'SUCCEEDED')).toBe(true)
+    expect(control).toEqual({ acquisitions: [], binds: 0 })
+  })
+
+  test('retries a failed idle reconciliation on cadence without recording false success or waiting for a slower poll', async () => {
+    const control: StoreControl = { acquisitions: [], binds: 0 }
+    const observations: CyclePassObservation[] = []
+    const failure = new CycleNotDueReconciliationError({
+      failure: 'database',
+      message: 'NOT_DUE reconciliation persistence failed',
+    })
+    let attempts = 0
+    let calendarReads = 0
+
+    await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          yield* TestClock.setTime(Date.parse('2026-01-29T21:20:00.000Z'))
+          const first = yield* Deferred.make<void>()
+          const second = yield* Deferred.make<void>()
+          const completions = [first, second]
+          const loop = yield* cycleLoop({
+            context: Effect.succeed(context()),
+            observePass: (observation) =>
+              Effect.sync(() => {
+                observations.push(observation)
+                return completions[observations.length - 1]
+              }).pipe(
+                Effect.flatMap((completion) =>
+                  completion === undefined ? Effect.void : Deferred.succeed(completion, undefined).pipe(Effect.asVoid),
+                ),
+              ),
+            pollIntervalMs: 1_000,
+            reconciliationIntervalMs: 100,
+            reconcileNotDue: Effect.suspend(() => {
+              attempts += 1
+              return attempts === 1 ? Effect.fail(failure) : Effect.void
+            }),
+          })
+          const fiber = yield* provide(
+            loop,
+            brokerRead(() =>
+              Effect.sync(() => {
+                calendarReads += 1
+                return { value: ordinaryNotDueCalendar, evidence }
+              }),
+            ),
+            cycleStore(control),
+            marketDataService(Effect.succeed(finalizedPublication('2026-01-29'))),
+          ).pipe(Effect.forkScoped({ startImmediately: true }))
+
+          yield* Deferred.await(first)
+          expect(observations).toHaveLength(1)
+          expect(observations[0]).toMatchObject({ outcome: 'FAILED' })
+          yield* TestClock.adjust(99)
+          expect(attempts).toBe(1)
+          expect(observations).toHaveLength(1)
+          yield* TestClock.adjust(1)
+          yield* Deferred.await(second)
+          yield* Fiber.interrupt(fiber)
+        }),
+      ).pipe(Effect.provide(TestClock.layer())),
+    )
+
+    expect(attempts).toBe(2)
+    expect(calendarReads).toBe(1)
+    expect(observations).toHaveLength(2)
+    expect(observations[0]).toMatchObject({ outcome: 'FAILED' })
+    expect(observations[1]).toMatchObject({ outcome: 'SUCCEEDED', result: { outcome: 'NOT_DUE' } })
     expect(control).toEqual({ acquisitions: [], binds: 0 })
   })
 
@@ -2805,6 +3047,7 @@ describe('autonomous cycle runner', () => {
         context: Effect.succeed(context()),
         observePass: ignorePass,
         pollIntervalMs,
+        reconciliationIntervalMs: 30_000,
         reconcileNotDue: Effect.void,
       })
       expect(Result.isFailure(result)).toBe(true)
@@ -2812,6 +3055,22 @@ describe('autonomous cycle runner', () => {
         _tag: 'CycleRunnerError',
         operation: 'configure',
         failure: 'invalid-config',
+      })
+    }
+    for (const reconciliationIntervalMs of [0, -1, 0.5, Number.MAX_SAFE_INTEGER + 1]) {
+      const result = makeAutonomousCycleLoop({
+        context: Effect.succeed(context()),
+        observePass: ignorePass,
+        pollIntervalMs: 100,
+        reconciliationIntervalMs,
+        reconcileNotDue: Effect.void,
+      })
+      expect(Result.isFailure(result)).toBe(true)
+      expect(Result.isFailure(result) ? result.failure : undefined).toMatchObject({
+        _tag: 'CycleRunnerError',
+        operation: 'configure',
+        failure: 'invalid-config',
+        message: 'reconciliation interval must be a positive safe integer',
       })
     }
     expect(control).toEqual({ acquisitions: [], binds: 0 })

--- a/services/bayn/src/cycle-runner/decisions.ts
+++ b/services/bayn/src/cycle-runner/decisions.ts
@@ -35,6 +35,7 @@ export {
 } from './pass-decisions'
 export {
   decideIdleReconciliationCadence,
+  shouldDeferCyclePollForReconciliation,
   validateCyclePassTimeout,
   validateReconciliationInterval,
 } from './reconciliation-cadence'

--- a/services/bayn/src/cycle-runner/decisions.ts
+++ b/services/bayn/src/cycle-runner/decisions.ts
@@ -33,4 +33,5 @@ export {
   validateCycleLoopInterval,
   type CyclePassLogFacts,
 } from './pass-decisions'
+export { decideIdleReconciliationCadence, validateReconciliationInterval } from './reconciliation-cadence'
 export { selectCyclePassContinuation, type CyclePassContinuation, type CyclePassProgress } from './pass-continuation'

--- a/services/bayn/src/cycle-runner/decisions.ts
+++ b/services/bayn/src/cycle-runner/decisions.ts
@@ -33,5 +33,9 @@ export {
   validateCycleLoopInterval,
   type CyclePassLogFacts,
 } from './pass-decisions'
-export { decideIdleReconciliationCadence, validateReconciliationInterval } from './reconciliation-cadence'
+export {
+  decideIdleReconciliationCadence,
+  validateCyclePassTimeout,
+  validateReconciliationInterval,
+} from './reconciliation-cadence'
 export { selectCyclePassContinuation, type CyclePassContinuation, type CyclePassProgress } from './pass-continuation'

--- a/services/bayn/src/cycle-runner/index.ts
+++ b/services/bayn/src/cycle-runner/index.ts
@@ -18,6 +18,7 @@ export {
   selectCycleCalendarCandidate,
   selectDiscoveredPublications,
   selectNextExecutionSession,
+  shouldDeferCyclePollForReconciliation,
   validateCyclePassTimeout,
   validateReconciliationInterval,
 } from './decisions'

--- a/services/bayn/src/cycle-runner/index.ts
+++ b/services/bayn/src/cycle-runner/index.ts
@@ -18,6 +18,7 @@ export {
   selectCycleCalendarCandidate,
   selectDiscoveredPublications,
   selectNextExecutionSession,
+  validateCyclePassTimeout,
   validateReconciliationInterval,
 } from './decisions'
 export { makeAutonomousCycleLoop } from './loop'

--- a/services/bayn/src/cycle-runner/index.ts
+++ b/services/bayn/src/cycle-runner/index.ts
@@ -9,6 +9,7 @@ export type {
 export {
   boundedCyclePublications,
   cyclePassLogFacts,
+  decideIdleReconciliationCadence,
   isMonthEndCycleDue,
   makeDueCycleDraft,
   marketCalendarQueryForPublications,
@@ -17,6 +18,7 @@ export {
   selectCycleCalendarCandidate,
   selectDiscoveredPublications,
   selectNextExecutionSession,
+  validateReconciliationInterval,
 } from './decisions'
 export { makeAutonomousCycleLoop } from './loop'
 export { discoverAutonomousCyclePass, runAutonomousCyclePass } from './program'

--- a/services/bayn/src/cycle-runner/loop.ts
+++ b/services/bayn/src/cycle-runner/loop.ts
@@ -1,4 +1,4 @@
-import { Clock, Duration, Effect, pipe, Ref, Result } from 'effect'
+import { Clock, Deferred, Duration, Effect, Fiber, pipe, Ref, Result } from 'effect'
 
 import type { BrokerRead } from '../broker/alpaca'
 import type { CycleStore } from '../db/cycle-store'
@@ -7,6 +7,7 @@ import { currentUtcInstant } from '../time'
 import {
   cyclePassLogFacts,
   decideIdleReconciliationCadence,
+  validateCyclePassTimeout,
   validateCycleLoopInterval,
   validateReconciliationInterval,
 } from './decisions'
@@ -89,23 +90,61 @@ const reconcileNotDuePass = <DecisionR>(
 
 const trackDecisionReconciliation = <DecisionR>(
   cadence: Ref.Ref<ReconciliationCadenceState>,
+  reconciliationCompleted: Deferred.Deferred<void>,
   context: CycleRunContext<DecisionR>,
 ): CycleRunContext<DecisionR> => ({
   ...context,
-  buildDecision: (cycle) => context.buildDecision(cycle).pipe(Effect.tap(() => markReconciliationCompleted(cadence))),
+  buildDecision: (cycle) =>
+    context.buildDecision(
+      cycle,
+      markReconciliationCompleted(cadence).pipe(
+        Effect.andThen(Deferred.succeed(reconciliationCompleted, undefined)),
+        Effect.asVoid,
+      ),
+    ),
 })
 
 const runLoopPass = <E, ContextR, DecisionR>(
   options: AutonomousCycleLoopOptions<E, ContextR, DecisionR>,
   cadence: Ref.Ref<ReconciliationCadenceState>,
+  reconciliationCompleted: Deferred.Deferred<void>,
 ): Effect.Effect<CycleRunResult, CycleRunnerError, BrokerRead | CycleStore | MarketData | ContextR | DecisionR> =>
   options.context.pipe(
     Effect.mapError((cause) =>
       runnerError('load-context', 'context', 'autonomous cycle context loading failed', cause),
     ),
-    Effect.map((context) => trackDecisionReconciliation(cadence, context)),
+    Effect.map((context) => trackDecisionReconciliation(cadence, reconciliationCompleted, context)),
     Effect.flatMap(runAutonomousCycleUntilSettled),
     Effect.withLogSpan('autonomous-cycle'),
+  )
+
+const cyclePassTimeoutError = (timeoutMs: number): CycleRunnerError =>
+  runnerError(
+    'run-cycle-pass',
+    'operational',
+    `autonomous cycle pass did not complete or reconcile within ${timeoutMs.toString()}ms`,
+  )
+
+const runBoundedLoopPass = <E, ContextR, DecisionR>(
+  options: AutonomousCycleLoopOptions<E, ContextR, DecisionR>,
+  cadence: Ref.Ref<ReconciliationCadenceState>,
+): Effect.Effect<CycleRunResult, CycleRunnerError, BrokerRead | CycleStore | MarketData | ContextR | DecisionR> =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const reconciliationCompleted = yield* Deferred.make<void>()
+      const fiber = yield* runLoopPass(options, cadence, reconciliationCompleted).pipe(Effect.forkScoped)
+      const outcome = yield* Effect.raceFirst(
+        Fiber.await(fiber).pipe(Effect.map((exit) => ({ _tag: 'PassCompleted' as const, exit }))),
+        Effect.raceFirst(
+          Deferred.await(reconciliationCompleted).pipe(Effect.as({ _tag: 'Reconciled' as const })),
+          Effect.sleep(Duration.millis(options.cyclePassTimeoutMs)).pipe(Effect.as({ _tag: 'TimedOut' as const })),
+        ),
+      )
+      if (outcome._tag === 'PassCompleted') return yield* outcome.exit
+      if (outcome._tag === 'Reconciled') return yield* Fiber.join(fiber)
+      yield* Fiber.interrupt(fiber)
+      return yield* Effect.fail(cyclePassTimeoutError(options.cyclePassTimeoutMs))
+    }),
   )
 
 const observeSuccessfulPass = <E, ContextR, DecisionR>(
@@ -145,13 +184,13 @@ const observeIdleReconciliation = <E, ContextR, DecisionR>(
 const observeCadenceReconciliation = <E, ContextR, DecisionR>(
   options: AutonomousCycleLoopOptions<E, ContextR, DecisionR>,
   cadence: Ref.Ref<ReconciliationCadenceState>,
-  result: CycleRunResult,
+  result: CycleRunResult | undefined,
 ): Effect.Effect<void, never, DecisionR> =>
   Ref.get(cadence).pipe(
     Effect.flatMap((state) =>
       attemptIdleReconciliation(options.reconcileNotDue, cadence).pipe(
         Effect.flatMap(() =>
-          result.outcome === 'NOT_DUE' || state.lastFailure !== undefined
+          result !== undefined && (result.outcome === 'NOT_DUE' || state.lastFailure !== undefined)
             ? observeSuccessfulPass(options, result)
             : Effect.void,
         ),
@@ -178,7 +217,7 @@ const observeCycleResult = <E, ContextR, DecisionR>(
 const waitUntilNextCyclePoll = <E, ContextR, DecisionR>(
   options: AutonomousCycleLoopOptions<E, ContextR, DecisionR>,
   cadence: Ref.Ref<ReconciliationCadenceState>,
-  result: CycleRunResult,
+  result: CycleRunResult | undefined,
   nextPollAtNanos: bigint,
 ): Effect.Effect<void, never, DecisionR> =>
   Effect.suspend(() =>
@@ -190,8 +229,16 @@ const waitUntilNextCyclePoll = <E, ContextR, DecisionR>(
         yield* observeCadenceReconciliation(options, cadence, result)
         return yield* waitUntilNextCyclePoll(options, cadence, result, nextPollAtNanos)
       }
-      if (nowNanos >= nextPollAtNanos) return
       const reconciliationAtNanos = nowNanos + decision.remainingNanos
+      const pollStartAtNanos = nowNanos > nextPollAtNanos ? nowNanos : nextPollAtNanos
+      if (
+        pollStartAtNanos < reconciliationAtNanos &&
+        pollStartAtNanos + intervalNanos(options.cyclePassTimeoutMs) > reconciliationAtNanos
+      ) {
+        yield* sleepUntil(reconciliationAtNanos)
+        return yield* waitUntilNextCyclePoll(options, cadence, result, nextPollAtNanos)
+      }
+      if (nowNanos >= nextPollAtNanos) return
       if (nextPollAtNanos < reconciliationAtNanos) return yield* sleepUntil(nextPollAtNanos)
       yield* sleepUntil(reconciliationAtNanos)
       return yield* waitUntilNextCyclePoll(options, cadence, result, nextPollAtNanos)
@@ -210,6 +257,16 @@ const waitAfterSuccessfulPass = <E, ContextR, DecisionR>(
     }),
   )
 
+const waitAfterFailedPass = <E, ContextR, DecisionR>(
+  options: AutonomousCycleLoopOptions<E, ContextR, DecisionR>,
+  cadence: Ref.Ref<ReconciliationCadenceState>,
+): Effect.Effect<void, never, DecisionR> =>
+  Clock.currentTimeNanos.pipe(
+    Effect.flatMap((completedAtNanos) =>
+      waitUntilNextCyclePoll(options, cadence, undefined, completedAtNanos + intervalNanos(options.pollIntervalMs)),
+    ),
+  )
+
 const cycleLoopProgram = <E, ContextR, DecisionR>(
   options: AutonomousCycleLoopOptions<E, ContextR, DecisionR>,
 ): Effect.Effect<void, never, BrokerRead | CycleStore | MarketData | ContextR | DecisionR> =>
@@ -217,11 +274,11 @@ const cycleLoopProgram = <E, ContextR, DecisionR>(
     const cadence = yield* Ref.make<ReconciliationCadenceState>({})
     const run = (): Effect.Effect<void, never, BrokerRead | CycleStore | MarketData | ContextR | DecisionR> =>
       Effect.suspend(() =>
-        runLoopPass(options, cadence).pipe(
+        runBoundedLoopPass(options, cadence).pipe(
           Effect.matchEffect({
             onFailure: (error) =>
               observeFailedPass(options, error).pipe(
-                Effect.andThen(Effect.sleep(Duration.millis(options.pollIntervalMs))),
+                Effect.andThen(waitAfterFailedPass(options, cadence)),
                 Effect.andThen(run()),
               ),
             onSuccess: (result) =>
@@ -244,5 +301,6 @@ export const makeAutonomousCycleLoop = <E, ContextR, DecisionR>(
   pipe(
     validateCycleLoopInterval(options.pollIntervalMs),
     Result.flatMap(() => validateReconciliationInterval(options.reconciliationIntervalMs)),
+    Result.flatMap(() => validateCyclePassTimeout(options.cyclePassTimeoutMs, options.reconciliationIntervalMs)),
     Result.map(() => cycleLoopProgram(options)),
   )

--- a/services/bayn/src/cycle-runner/loop.ts
+++ b/services/bayn/src/cycle-runner/loop.ts
@@ -1,17 +1,24 @@
-import { Duration, Effect, pipe, Result, Schedule } from 'effect'
+import { Clock, Duration, Effect, pipe, Ref, Result } from 'effect'
 
 import type { BrokerRead } from '../broker/alpaca'
 import type { CycleStore } from '../db/cycle-store'
 import type { MarketData } from '../market-data'
 import { currentUtcInstant } from '../time'
-import { cyclePassLogFacts, validateCycleLoopInterval } from './decisions'
+import {
+  cyclePassLogFacts,
+  decideIdleReconciliationCadence,
+  validateCycleLoopInterval,
+  validateReconciliationInterval,
+} from './decisions'
 import {
   runnerError,
   type AutonomousCycleLoopOptions,
   type CycleNotDueReconciliationError,
   type CyclePassObservation,
+  type CycleRunContext,
   type CycleRunnerError,
   type CycleRunResult,
+  type ReconciliationCadenceState,
 } from './model'
 import { runAutonomousCycleUntilSettled } from './program'
 
@@ -21,26 +28,73 @@ const logCyclePass = (observation: CyclePassObservation): Effect.Effect<void> =>
   return log.pipe(Effect.annotateLogs(facts.annotations))
 }
 
+const nanosPerMillisecond = 1_000_000n
+
+const intervalNanos = (intervalMs: number): bigint => BigInt(intervalMs) * nanosPerMillisecond
+
+const sleepUntil = (deadlineNanos: bigint): Effect.Effect<void> =>
+  Clock.currentTimeNanos.pipe(
+    Effect.flatMap((nowNanos) => {
+      const remainingNanos = deadlineNanos - nowNanos
+      if (remainingNanos <= 0n) return Effect.void
+      const remainingMs = Number((remainingNanos + nanosPerMillisecond - 1n) / nanosPerMillisecond)
+      return Effect.sleep(Duration.millis(remainingMs))
+    }),
+  )
+
+const idleReconciliationError = (cause: CycleNotDueReconciliationError): CycleRunnerError =>
+  runnerError('reconcile-not-due', cause.failure, cause.message, cause)
+
+const markReconciliationCompleted = (cadence: Ref.Ref<ReconciliationCadenceState>): Effect.Effect<void> =>
+  Clock.currentTimeNanos.pipe(Effect.flatMap((lastAttemptAtNanos) => Ref.set(cadence, { lastAttemptAtNanos })))
+
 const reconcileNotDuePass = <DecisionR>(
   reconcileNotDue: Effect.Effect<void, CycleNotDueReconciliationError, DecisionR>,
+  cadence: Ref.Ref<ReconciliationCadenceState>,
+  reconciliationIntervalMs: number,
   result: CycleRunResult,
 ): Effect.Effect<CycleRunResult, CycleRunnerError, DecisionR> => {
   if (result.outcome !== 'NOT_DUE') return Effect.succeed(result)
-  return reconcileNotDue.pipe(
-    Effect.mapError((cause) => runnerError('reconcile-not-due', cause.failure, cause.message, cause)),
-    Effect.map((): CycleRunResult => result),
-  )
+  return Effect.gen(function* () {
+    const nowNanos = yield* Clock.currentTimeNanos
+    const state = yield* Ref.get(cadence)
+    const decision = decideIdleReconciliationCadence(state, nowNanos, reconciliationIntervalMs)
+    if (decision._tag === 'WAIT') {
+      if (state.lastFailure !== undefined) return yield* Effect.fail(state.lastFailure)
+      return result
+    }
+    yield* Ref.set(cadence, { lastAttemptAtNanos: nowNanos })
+    yield* reconcileNotDue.pipe(
+      Effect.mapError(idleReconciliationError),
+      Effect.tapError((lastFailure) =>
+        Clock.currentTimeNanos.pipe(
+          Effect.flatMap((lastAttemptAtNanos) => Ref.set(cadence, { lastAttemptAtNanos, lastFailure })),
+        ),
+      ),
+      Effect.tap(() => markReconciliationCompleted(cadence)),
+    )
+    return result
+  })
 }
+
+const trackDecisionReconciliation = <DecisionR>(
+  cadence: Ref.Ref<ReconciliationCadenceState>,
+  context: CycleRunContext<DecisionR>,
+): CycleRunContext<DecisionR> => ({
+  ...context,
+  buildDecision: (cycle) => context.buildDecision(cycle).pipe(Effect.tap(() => markReconciliationCompleted(cadence))),
+})
 
 const runLoopPass = <E, ContextR, DecisionR>(
   options: AutonomousCycleLoopOptions<E, ContextR, DecisionR>,
+  cadence: Ref.Ref<ReconciliationCadenceState>,
 ): Effect.Effect<CycleRunResult, CycleRunnerError, BrokerRead | CycleStore | MarketData | ContextR | DecisionR> =>
   options.context.pipe(
     Effect.mapError((cause) =>
       runnerError('load-context', 'context', 'autonomous cycle context loading failed', cause),
     ),
+    Effect.map((context) => trackDecisionReconciliation(cadence, context)),
     Effect.flatMap(runAutonomousCycleUntilSettled),
-    Effect.flatMap((result) => reconcileNotDuePass(options.reconcileNotDue, result)),
     Effect.withLogSpan('autonomous-cycle'),
   )
 
@@ -68,16 +122,86 @@ const observeFailedPass = <E, ContextR, DecisionR>(
     }),
   )
 
+const observeIdleReconciliation = <E, ContextR, DecisionR>(
+  options: AutonomousCycleLoopOptions<E, ContextR, DecisionR>,
+  cadence: Ref.Ref<ReconciliationCadenceState>,
+  result: Extract<CycleRunResult, { readonly outcome: 'NOT_DUE' }>,
+): Effect.Effect<void, never, DecisionR> =>
+  reconcileNotDuePass(options.reconcileNotDue, cadence, options.reconciliationIntervalMs, result).pipe(
+    Effect.flatMap((reconciled) => observeSuccessfulPass(options, reconciled)),
+    Effect.catch((error) => observeFailedPass(options, error)),
+  )
+
+const observeCycleResult = <E, ContextR, DecisionR>(
+  options: AutonomousCycleLoopOptions<E, ContextR, DecisionR>,
+  cadence: Ref.Ref<ReconciliationCadenceState>,
+  result: CycleRunResult,
+): Effect.Effect<void, never, DecisionR> =>
+  result.outcome === 'NOT_DUE'
+    ? observeIdleReconciliation(options, cadence, result)
+    : observeSuccessfulPass(options, result)
+
+const waitUntilNextCyclePoll = <E, ContextR, DecisionR>(
+  options: AutonomousCycleLoopOptions<E, ContextR, DecisionR>,
+  cadence: Ref.Ref<ReconciliationCadenceState>,
+  result: Extract<CycleRunResult, { readonly outcome: 'NOT_DUE' }>,
+  nextPollAtNanos: bigint,
+): Effect.Effect<void, never, DecisionR> =>
+  Effect.suspend(() =>
+    Effect.gen(function* () {
+      const nowNanos = yield* Clock.currentTimeNanos
+      if (nowNanos >= nextPollAtNanos) return
+      const state = yield* Ref.get(cadence)
+      const decision = decideIdleReconciliationCadence(state, nowNanos, options.reconciliationIntervalMs)
+      if (decision._tag === 'RECONCILE') {
+        yield* observeIdleReconciliation(options, cadence, result)
+        return yield* waitUntilNextCyclePoll(options, cadence, result, nextPollAtNanos)
+      }
+      const reconciliationAtNanos = nowNanos + decision.remainingNanos
+      if (nextPollAtNanos <= reconciliationAtNanos) return yield* sleepUntil(nextPollAtNanos)
+      yield* sleepUntil(reconciliationAtNanos)
+      return yield* waitUntilNextCyclePoll(options, cadence, result, nextPollAtNanos)
+    }),
+  )
+
+const waitAfterSuccessfulPass = <E, ContextR, DecisionR>(
+  options: AutonomousCycleLoopOptions<E, ContextR, DecisionR>,
+  cadence: Ref.Ref<ReconciliationCadenceState>,
+  result: CycleRunResult,
+): Effect.Effect<void, never, DecisionR> =>
+  Clock.currentTimeNanos.pipe(
+    Effect.flatMap((completedAtNanos) => {
+      const nextPollAtNanos = completedAtNanos + intervalNanos(options.pollIntervalMs)
+      return result.outcome === 'NOT_DUE'
+        ? waitUntilNextCyclePoll(options, cadence, result, nextPollAtNanos)
+        : sleepUntil(nextPollAtNanos)
+    }),
+  )
+
 const cycleLoopProgram = <E, ContextR, DecisionR>(
   options: AutonomousCycleLoopOptions<E, ContextR, DecisionR>,
 ): Effect.Effect<void, never, BrokerRead | CycleStore | MarketData | ContextR | DecisionR> =>
-  pipe(
-    runLoopPass(options),
-    Effect.flatMap((result) => observeSuccessfulPass(options, result)),
-    Effect.catch((error) => observeFailedPass(options, error)),
-    Effect.repeat(Schedule.spaced(Duration.millis(options.pollIntervalMs))),
-    Effect.asVoid,
-  )
+  Effect.gen(function* () {
+    const cadence = yield* Ref.make<ReconciliationCadenceState>({})
+    const run = (): Effect.Effect<void, never, BrokerRead | CycleStore | MarketData | ContextR | DecisionR> =>
+      Effect.suspend(() =>
+        runLoopPass(options, cadence).pipe(
+          Effect.matchEffect({
+            onFailure: (error) =>
+              observeFailedPass(options, error).pipe(
+                Effect.andThen(Effect.sleep(Duration.millis(options.pollIntervalMs))),
+                Effect.andThen(run()),
+              ),
+            onSuccess: (result) =>
+              observeCycleResult(options, cadence, result).pipe(
+                Effect.andThen(waitAfterSuccessfulPass(options, cadence, result)),
+                Effect.andThen(run()),
+              ),
+          }),
+        ),
+      )
+    yield* run()
+  })
 
 export const makeAutonomousCycleLoop = <E, ContextR, DecisionR>(
   options: AutonomousCycleLoopOptions<E, ContextR, DecisionR>,
@@ -87,5 +211,6 @@ export const makeAutonomousCycleLoop = <E, ContextR, DecisionR>(
 > =>
   pipe(
     validateCycleLoopInterval(options.pollIntervalMs),
+    Result.flatMap(() => validateReconciliationInterval(options.reconciliationIntervalMs)),
     Result.map(() => cycleLoopProgram(options)),
   )

--- a/services/bayn/src/cycle-runner/loop.ts
+++ b/services/bayn/src/cycle-runner/loop.ts
@@ -48,6 +48,25 @@ const idleReconciliationError = (cause: CycleNotDueReconciliationError): CycleRu
 const markReconciliationCompleted = (cadence: Ref.Ref<ReconciliationCadenceState>): Effect.Effect<void> =>
   Clock.currentTimeNanos.pipe(Effect.flatMap((lastAttemptAtNanos) => Ref.set(cadence, { lastAttemptAtNanos })))
 
+const attemptIdleReconciliation = <DecisionR>(
+  reconcileNotDue: Effect.Effect<void, CycleNotDueReconciliationError, DecisionR>,
+  cadence: Ref.Ref<ReconciliationCadenceState>,
+): Effect.Effect<void, CycleRunnerError, DecisionR> =>
+  Clock.currentTimeNanos.pipe(
+    Effect.tap((lastAttemptAtNanos) => Ref.set(cadence, { lastAttemptAtNanos })),
+    Effect.andThen(
+      reconcileNotDue.pipe(
+        Effect.mapError(idleReconciliationError),
+        Effect.tapError((lastFailure) =>
+          Clock.currentTimeNanos.pipe(
+            Effect.flatMap((lastAttemptAtNanos) => Ref.set(cadence, { lastAttemptAtNanos, lastFailure })),
+          ),
+        ),
+        Effect.tap(() => markReconciliationCompleted(cadence)),
+      ),
+    ),
+  )
+
 const reconcileNotDuePass = <DecisionR>(
   reconcileNotDue: Effect.Effect<void, CycleNotDueReconciliationError, DecisionR>,
   cadence: Ref.Ref<ReconciliationCadenceState>,
@@ -63,16 +82,7 @@ const reconcileNotDuePass = <DecisionR>(
       if (state.lastFailure !== undefined) return yield* Effect.fail(state.lastFailure)
       return result
     }
-    yield* Ref.set(cadence, { lastAttemptAtNanos: nowNanos })
-    yield* reconcileNotDue.pipe(
-      Effect.mapError(idleReconciliationError),
-      Effect.tapError((lastFailure) =>
-        Clock.currentTimeNanos.pipe(
-          Effect.flatMap((lastAttemptAtNanos) => Ref.set(cadence, { lastAttemptAtNanos, lastFailure })),
-        ),
-      ),
-      Effect.tap(() => markReconciliationCompleted(cadence)),
-    )
+    yield* attemptIdleReconciliation(reconcileNotDue, cadence)
     return result
   })
 }
@@ -132,6 +142,16 @@ const observeIdleReconciliation = <E, ContextR, DecisionR>(
     Effect.catch((error) => observeFailedPass(options, error)),
   )
 
+const observeCadenceReconciliation = <E, ContextR, DecisionR>(
+  options: AutonomousCycleLoopOptions<E, ContextR, DecisionR>,
+  cadence: Ref.Ref<ReconciliationCadenceState>,
+  result: CycleRunResult,
+): Effect.Effect<void, never, DecisionR> =>
+  attemptIdleReconciliation(options.reconcileNotDue, cadence).pipe(
+    Effect.flatMap(() => (result.outcome === 'NOT_DUE' ? observeSuccessfulPass(options, result) : Effect.void)),
+    Effect.catch((error) => observeFailedPass(options, error)),
+  )
+
 const observeCycleResult = <E, ContextR, DecisionR>(
   options: AutonomousCycleLoopOptions<E, ContextR, DecisionR>,
   cadence: Ref.Ref<ReconciliationCadenceState>,
@@ -144,7 +164,7 @@ const observeCycleResult = <E, ContextR, DecisionR>(
 const waitUntilNextCyclePoll = <E, ContextR, DecisionR>(
   options: AutonomousCycleLoopOptions<E, ContextR, DecisionR>,
   cadence: Ref.Ref<ReconciliationCadenceState>,
-  result: Extract<CycleRunResult, { readonly outcome: 'NOT_DUE' }>,
+  result: CycleRunResult,
   nextPollAtNanos: bigint,
 ): Effect.Effect<void, never, DecisionR> =>
   Effect.suspend(() =>
@@ -153,7 +173,7 @@ const waitUntilNextCyclePoll = <E, ContextR, DecisionR>(
       const state = yield* Ref.get(cadence)
       const decision = decideIdleReconciliationCadence(state, nowNanos, options.reconciliationIntervalMs)
       if (decision._tag === 'RECONCILE') {
-        yield* observeIdleReconciliation(options, cadence, result)
+        yield* observeCadenceReconciliation(options, cadence, result)
         return yield* waitUntilNextCyclePoll(options, cadence, result, nextPollAtNanos)
       }
       if (nowNanos >= nextPollAtNanos) return
@@ -172,9 +192,7 @@ const waitAfterSuccessfulPass = <E, ContextR, DecisionR>(
   Clock.currentTimeNanos.pipe(
     Effect.flatMap((completedAtNanos) => {
       const nextPollAtNanos = completedAtNanos + intervalNanos(options.pollIntervalMs)
-      return result.outcome === 'NOT_DUE'
-        ? waitUntilNextCyclePoll(options, cadence, result, nextPollAtNanos)
-        : sleepUntil(nextPollAtNanos)
+      return waitUntilNextCyclePoll(options, cadence, result, nextPollAtNanos)
     }),
   )
 

--- a/services/bayn/src/cycle-runner/loop.ts
+++ b/services/bayn/src/cycle-runner/loop.ts
@@ -147,8 +147,16 @@ const observeCadenceReconciliation = <E, ContextR, DecisionR>(
   cadence: Ref.Ref<ReconciliationCadenceState>,
   result: CycleRunResult,
 ): Effect.Effect<void, never, DecisionR> =>
-  attemptIdleReconciliation(options.reconcileNotDue, cadence).pipe(
-    Effect.flatMap(() => (result.outcome === 'NOT_DUE' ? observeSuccessfulPass(options, result) : Effect.void)),
+  Ref.get(cadence).pipe(
+    Effect.flatMap((state) =>
+      attemptIdleReconciliation(options.reconcileNotDue, cadence).pipe(
+        Effect.flatMap(() =>
+          result.outcome === 'NOT_DUE' || state.lastFailure !== undefined
+            ? observeSuccessfulPass(options, result)
+            : Effect.void,
+        ),
+      ),
+    ),
     Effect.catch((error) => observeFailedPass(options, error)),
   )
 

--- a/services/bayn/src/cycle-runner/loop.ts
+++ b/services/bayn/src/cycle-runner/loop.ts
@@ -1,4 +1,4 @@
-import { Clock, Deferred, Duration, Effect, Fiber, pipe, Ref, Result } from 'effect'
+import { Clock, Duration, Effect, pipe, Ref, Result } from 'effect'
 
 import type { BrokerRead } from '../broker/alpaca'
 import type { CycleStore } from '../db/cycle-store'
@@ -90,30 +90,21 @@ const reconcileNotDuePass = <DecisionR>(
 
 const trackDecisionReconciliation = <DecisionR>(
   cadence: Ref.Ref<ReconciliationCadenceState>,
-  reconciliationCompleted: Deferred.Deferred<void>,
   context: CycleRunContext<DecisionR>,
 ): CycleRunContext<DecisionR> => ({
   ...context,
-  buildDecision: (cycle) =>
-    context.buildDecision(
-      cycle,
-      markReconciliationCompleted(cadence).pipe(
-        Effect.andThen(Deferred.succeed(reconciliationCompleted, undefined)),
-        Effect.asVoid,
-      ),
-    ),
+  buildDecision: (cycle) => context.buildDecision(cycle, markReconciliationCompleted(cadence)),
 })
 
 const runLoopPass = <E, ContextR, DecisionR>(
   options: AutonomousCycleLoopOptions<E, ContextR, DecisionR>,
   cadence: Ref.Ref<ReconciliationCadenceState>,
-  reconciliationCompleted: Deferred.Deferred<void>,
 ): Effect.Effect<CycleRunResult, CycleRunnerError, BrokerRead | CycleStore | MarketData | ContextR | DecisionR> =>
   options.context.pipe(
     Effect.mapError((cause) =>
       runnerError('load-context', 'context', 'autonomous cycle context loading failed', cause),
     ),
-    Effect.map((context) => trackDecisionReconciliation(cadence, reconciliationCompleted, context)),
+    Effect.map((context) => trackDecisionReconciliation(cadence, context)),
     Effect.flatMap(runAutonomousCycleUntilSettled),
     Effect.withLogSpan('autonomous-cycle'),
   )
@@ -129,21 +120,10 @@ const runBoundedLoopPass = <E, ContextR, DecisionR>(
   options: AutonomousCycleLoopOptions<E, ContextR, DecisionR>,
   cadence: Ref.Ref<ReconciliationCadenceState>,
 ): Effect.Effect<CycleRunResult, CycleRunnerError, BrokerRead | CycleStore | MarketData | ContextR | DecisionR> =>
-  Effect.scoped(
-    Effect.gen(function* () {
-      const reconciliationCompleted = yield* Deferred.make<void>()
-      const fiber = yield* runLoopPass(options, cadence, reconciliationCompleted).pipe(Effect.forkScoped)
-      const outcome = yield* Effect.raceFirst(
-        Fiber.await(fiber).pipe(Effect.map((exit) => ({ _tag: 'PassCompleted' as const, exit }))),
-        Effect.raceFirst(
-          Deferred.await(reconciliationCompleted).pipe(Effect.as({ _tag: 'Reconciled' as const })),
-          Effect.sleep(Duration.millis(options.cyclePassTimeoutMs)).pipe(Effect.as({ _tag: 'TimedOut' as const })),
-        ),
-      )
-      if (outcome._tag === 'PassCompleted') return yield* outcome.exit
-      if (outcome._tag === 'Reconciled') return yield* Fiber.join(fiber)
-      yield* Fiber.interrupt(fiber)
-      return yield* Effect.fail(cyclePassTimeoutError(options.cyclePassTimeoutMs))
+  runLoopPass(options, cadence).pipe(
+    Effect.timeoutOrElse({
+      duration: Duration.millis(options.cyclePassTimeoutMs),
+      orElse: () => Effect.fail(cyclePassTimeoutError(options.cyclePassTimeoutMs)),
     }),
   )
 

--- a/services/bayn/src/cycle-runner/loop.ts
+++ b/services/bayn/src/cycle-runner/loop.ts
@@ -159,7 +159,13 @@ const observeCycleResult = <E, ContextR, DecisionR>(
 ): Effect.Effect<void, never, DecisionR> =>
   result.outcome === 'NOT_DUE'
     ? observeIdleReconciliation(options, cadence, result)
-    : observeSuccessfulPass(options, result)
+    : Ref.get(cadence).pipe(
+        Effect.flatMap((state) =>
+          state.lastFailure === undefined
+            ? observeSuccessfulPass(options, result)
+            : observeFailedPass(options, state.lastFailure),
+        ),
+      )
 
 const waitUntilNextCyclePoll = <E, ContextR, DecisionR>(
   options: AutonomousCycleLoopOptions<E, ContextR, DecisionR>,

--- a/services/bayn/src/cycle-runner/loop.ts
+++ b/services/bayn/src/cycle-runner/loop.ts
@@ -150,15 +150,15 @@ const waitUntilNextCyclePoll = <E, ContextR, DecisionR>(
   Effect.suspend(() =>
     Effect.gen(function* () {
       const nowNanos = yield* Clock.currentTimeNanos
-      if (nowNanos >= nextPollAtNanos) return
       const state = yield* Ref.get(cadence)
       const decision = decideIdleReconciliationCadence(state, nowNanos, options.reconciliationIntervalMs)
       if (decision._tag === 'RECONCILE') {
         yield* observeIdleReconciliation(options, cadence, result)
         return yield* waitUntilNextCyclePoll(options, cadence, result, nextPollAtNanos)
       }
+      if (nowNanos >= nextPollAtNanos) return
       const reconciliationAtNanos = nowNanos + decision.remainingNanos
-      if (nextPollAtNanos <= reconciliationAtNanos) return yield* sleepUntil(nextPollAtNanos)
+      if (nextPollAtNanos < reconciliationAtNanos) return yield* sleepUntil(nextPollAtNanos)
       yield* sleepUntil(reconciliationAtNanos)
       return yield* waitUntilNextCyclePoll(options, cadence, result, nextPollAtNanos)
     }),

--- a/services/bayn/src/cycle-runner/loop.ts
+++ b/services/bayn/src/cycle-runner/loop.ts
@@ -7,6 +7,7 @@ import { currentUtcInstant } from '../time'
 import {
   cyclePassLogFacts,
   decideIdleReconciliationCadence,
+  shouldDeferCyclePollForReconciliation,
   validateCyclePassTimeout,
   validateCycleLoopInterval,
   validateReconciliationInterval,
@@ -212,8 +213,13 @@ const waitUntilNextCyclePoll = <E, ContextR, DecisionR>(
       const reconciliationAtNanos = nowNanos + decision.remainingNanos
       const pollStartAtNanos = nowNanos > nextPollAtNanos ? nowNanos : nextPollAtNanos
       if (
-        pollStartAtNanos < reconciliationAtNanos &&
-        pollStartAtNanos + intervalNanos(options.cyclePassTimeoutMs) > reconciliationAtNanos
+        shouldDeferCyclePollForReconciliation({
+          lastAttemptAtNanos: state.lastAttemptAtNanos,
+          nextPollAtNanos,
+          pollStartAtNanos,
+          reconciliationAtNanos,
+          cyclePassTimeoutNanos: intervalNanos(options.cyclePassTimeoutMs),
+        })
       ) {
         yield* sleepUntil(reconciliationAtNanos)
         return yield* waitUntilNextCyclePoll(options, cadence, result, nextPollAtNanos)

--- a/services/bayn/src/cycle-runner/model.ts
+++ b/services/bayn/src/cycle-runner/model.ts
@@ -27,6 +27,7 @@ export interface CycleRunContext<R = never> {
   readonly executionPolicy: CycleExecutionPolicy
   readonly buildDecision: (
     cycle: AutonomousCycle,
+    reconciliationCompleted?: Effect.Effect<void>,
   ) => Effect.Effect<ObserveShadowDecisionDocument, CycleDecisionBuildError, R>
 }
 
@@ -109,6 +110,7 @@ export class CycleRunnerError extends Data.TaggedError('CycleRunnerError')<{
     | 'read-authority-slot'
     | 'reconcile-not-due'
     | 'recover-cycle'
+    | 'run-cycle-pass'
     | 'select-session'
   readonly failure:
     | 'calendar-read'
@@ -148,6 +150,7 @@ export type IdleReconciliationCadenceDecision =
 export interface AutonomousCycleLoopOptions<E = never, ContextR = never, DecisionR = never> {
   readonly context: Effect.Effect<CycleRunContext<DecisionR>, E, ContextR>
   readonly observePass: (observation: CyclePassObservation) => Effect.Effect<void>
+  readonly cyclePassTimeoutMs: number
   readonly pollIntervalMs: number
   readonly reconciliationIntervalMs: number
   readonly reconcileNotDue: Effect.Effect<void, CycleNotDueReconciliationError, DecisionR>

--- a/services/bayn/src/cycle-runner/model.ts
+++ b/services/bayn/src/cycle-runner/model.ts
@@ -136,10 +136,20 @@ export type CyclePassObservation =
       readonly error: CycleRunnerError
     }
 
+export interface ReconciliationCadenceState {
+  readonly lastAttemptAtNanos?: bigint
+  readonly lastFailure?: CycleRunnerError
+}
+
+export type IdleReconciliationCadenceDecision =
+  | { readonly _tag: 'RECONCILE' }
+  | { readonly _tag: 'WAIT'; readonly remainingNanos: bigint }
+
 export interface AutonomousCycleLoopOptions<E = never, ContextR = never, DecisionR = never> {
   readonly context: Effect.Effect<CycleRunContext<DecisionR>, E, ContextR>
   readonly observePass: (observation: CyclePassObservation) => Effect.Effect<void>
   readonly pollIntervalMs: number
+  readonly reconciliationIntervalMs: number
   readonly reconcileNotDue: Effect.Effect<void, CycleNotDueReconciliationError, DecisionR>
 }
 

--- a/services/bayn/src/cycle-runner/reconciliation-cadence.ts
+++ b/services/bayn/src/cycle-runner/reconciliation-cadence.ts
@@ -16,6 +16,20 @@ export const validateReconciliationInterval = (
     ? Result.succeed(reconciliationIntervalMs)
     : Result.fail(runnerError('configure', 'invalid-config', 'reconciliation interval must be a positive safe integer'))
 
+export const validateCyclePassTimeout = (
+  cyclePassTimeoutMs: number,
+  reconciliationIntervalMs: number,
+): Result.Result<number, CycleRunnerError> =>
+  Number.isSafeInteger(cyclePassTimeoutMs) && cyclePassTimeoutMs > 0 && cyclePassTimeoutMs <= reconciliationIntervalMs
+    ? Result.succeed(cyclePassTimeoutMs)
+    : Result.fail(
+        runnerError(
+          'configure',
+          'invalid-config',
+          'cycle pass timeout must be a positive safe integer no longer than the reconciliation interval',
+        ),
+      )
+
 export const decideIdleReconciliationCadence = (
   state: ReconciliationCadenceState,
   nowNanos: bigint,

--- a/services/bayn/src/cycle-runner/reconciliation-cadence.ts
+++ b/services/bayn/src/cycle-runner/reconciliation-cadence.ts
@@ -30,6 +30,22 @@ export const validateCyclePassTimeout = (
         ),
       )
 
+export const shouldDeferCyclePollForReconciliation = (input: {
+  readonly lastAttemptAtNanos: bigint | undefined
+  readonly nextPollAtNanos: bigint
+  readonly pollStartAtNanos: bigint
+  readonly reconciliationAtNanos: bigint
+  readonly cyclePassTimeoutNanos: bigint
+}): boolean => {
+  const pollCoveredByLatestReconciliation =
+    input.lastAttemptAtNanos !== undefined && input.nextPollAtNanos <= input.lastAttemptAtNanos
+  return (
+    !pollCoveredByLatestReconciliation &&
+    input.pollStartAtNanos < input.reconciliationAtNanos &&
+    input.pollStartAtNanos + input.cyclePassTimeoutNanos > input.reconciliationAtNanos
+  )
+}
+
 export const decideIdleReconciliationCadence = (
   state: ReconciliationCadenceState,
   nowNanos: bigint,

--- a/services/bayn/src/cycle-runner/reconciliation-cadence.ts
+++ b/services/bayn/src/cycle-runner/reconciliation-cadence.ts
@@ -1,0 +1,31 @@
+import { Result } from 'effect'
+
+import {
+  runnerError,
+  type CycleRunnerError,
+  type IdleReconciliationCadenceDecision,
+  type ReconciliationCadenceState,
+} from './model'
+
+const nanosPerMillisecond = 1_000_000n
+
+export const validateReconciliationInterval = (
+  reconciliationIntervalMs: number,
+): Result.Result<number, CycleRunnerError> =>
+  Number.isSafeInteger(reconciliationIntervalMs) && reconciliationIntervalMs > 0
+    ? Result.succeed(reconciliationIntervalMs)
+    : Result.fail(runnerError('configure', 'invalid-config', 'reconciliation interval must be a positive safe integer'))
+
+export const decideIdleReconciliationCadence = (
+  state: ReconciliationCadenceState,
+  nowNanos: bigint,
+  reconciliationIntervalMs: number,
+): IdleReconciliationCadenceDecision => {
+  const lastAttemptAtNanos = state.lastAttemptAtNanos
+  if (lastAttemptAtNanos === undefined || nowNanos < lastAttemptAtNanos) return { _tag: 'RECONCILE' }
+  const intervalNanos = BigInt(reconciliationIntervalMs) * nanosPerMillisecond
+  const elapsedNanos = nowNanos - lastAttemptAtNanos
+  return elapsedNanos >= intervalNanos
+    ? { _tag: 'RECONCILE' }
+    : { _tag: 'WAIT', remainingNanos: intervalNanos - elapsedNanos }
+}

--- a/services/bayn/src/db/cycle-store/integration.test.ts
+++ b/services/bayn/src/db/cycle-store/integration.test.ts
@@ -512,6 +512,7 @@ const makeProductionDueContext = Effect.gen(function* () {
       accountId: dueAccountId,
       authorityGenerationHash: dueAuthorityGenerationHash,
       pollIntervalMs: 30_000,
+      reconciliationIntervalMs: 30_000,
       strategy: dueStrategy,
     }),
   )

--- a/services/bayn/src/db/cycle-store/integration.test.ts
+++ b/services/bayn/src/db/cycle-store/integration.test.ts
@@ -513,6 +513,7 @@ const makeProductionDueContext = Effect.gen(function* () {
       authorityGenerationHash: dueAuthorityGenerationHash,
       pollIntervalMs: 30_000,
       reconciliationIntervalMs: 30_000,
+      reconciliationPassTimeoutMs: 30_000,
       strategy: dueStrategy,
     }),
   )

--- a/services/bayn/src/entrypoint.ts
+++ b/services/bayn/src/entrypoint.ts
@@ -473,6 +473,7 @@ const observeCycle = (plan: ApplicationPlanFor<'AutonomousService'>) =>
     accountId: plan.config.alpaca.expectedAccountId,
     authorityGenerationHash: plan.config.alpaca.authorityGenerationHash,
     pollIntervalMs: plan.config.cyclePollIntervalMs,
+    reconciliationIntervalMs: plan.config.alpaca.reconciliationIntervalMs,
     strategy: plan.strategy,
   })
 
@@ -481,6 +482,7 @@ const mutationCycle = (plan: ApplicationPlanFor<'AutonomousService'>, executionP
     accountId: plan.config.alpaca.expectedAccountId,
     authorityGenerationHash: plan.config.alpaca.authorityGenerationHash,
     pollIntervalMs: plan.config.cyclePollIntervalMs,
+    reconciliationIntervalMs: plan.config.alpaca.reconciliationIntervalMs,
     strategy: plan.strategy,
     executionProgram,
   })

--- a/services/bayn/src/entrypoint.ts
+++ b/services/bayn/src/entrypoint.ts
@@ -474,6 +474,7 @@ const observeCycle = (plan: ApplicationPlanFor<'AutonomousService'>) =>
     authorityGenerationHash: plan.config.alpaca.authorityGenerationHash,
     pollIntervalMs: plan.config.cyclePollIntervalMs,
     reconciliationIntervalMs: plan.config.alpaca.reconciliationIntervalMs,
+    reconciliationPassTimeoutMs: plan.config.operationTimeoutMs,
     strategy: plan.strategy,
   })
 
@@ -483,6 +484,7 @@ const mutationCycle = (plan: ApplicationPlanFor<'AutonomousService'>, executionP
     authorityGenerationHash: plan.config.alpaca.authorityGenerationHash,
     pollIntervalMs: plan.config.cyclePollIntervalMs,
     reconciliationIntervalMs: plan.config.alpaca.reconciliationIntervalMs,
+    reconciliationPassTimeoutMs: plan.config.operationTimeoutMs,
     strategy: plan.strategy,
     executionProgram,
   })

--- a/services/bayn/src/observe-composition.test.ts
+++ b/services/bayn/src/observe-composition.test.ts
@@ -1131,6 +1131,7 @@ describe('OBSERVE runtime composition', () => {
     let mutationPhase = false
     let mutationCalendarReads = 0
     let mutationReconciliations = 0
+    let nextReconciliationFailure: ExecutionStoreError | undefined
     let secondMutationCalendarRead: Deferred.Deferred<void> | undefined
     const mutationEvents: string[] = []
     const unusedRead = Effect.die(new Error('NOT_DUE reconciliation used an unrelated broker read'))
@@ -1249,13 +1250,21 @@ describe('OBSERVE runtime composition', () => {
       hasAccountBaseline: () => Effect.succeed(true),
       bindings: () => Effect.succeed([]),
       reconcile: (brokerSnapshot: BrokerSnapshot) =>
-        Effect.sync(() => {
-          reconciledSnapshots.push(brokerSnapshot)
-          if (mutationPhase) {
-            mutationReconciliations += 1
-            mutationEvents.push(`reconcile:${mutationReconciliations.toString()}`)
+        Effect.suspend(() => {
+          if (nextReconciliationFailure !== undefined) {
+            const failure = nextReconciliationFailure
+            nextReconciliationFailure = undefined
+            mutationEvents.push('reconcile-failed')
+            return Effect.fail(failure)
           }
-          return persisted
+          return Effect.sync(() => {
+            reconciledSnapshots.push(brokerSnapshot)
+            if (mutationPhase) {
+              mutationReconciliations += 1
+              mutationEvents.push(`reconcile:${mutationReconciliations.toString()}`)
+            }
+            return persisted
+          })
         }),
       ensureAuthorityGeneration: () => {
         const authority = exact.riskContext.authority
@@ -1503,6 +1512,100 @@ describe('OBSERVE runtime composition', () => {
     expect(mutationReconciliations).toBe(2)
     expect(calendarReads).toBe(calendarReadsBeforeNonIdle)
     expect(authorityRestrictions).toBe(0)
+
+    mutationEvents.length = 0
+    mutationReconciliations = 0
+    publicationReads = 0
+    nextReconciliationFailure = new ExecutionStoreError({
+      operation: 'reconciliation',
+      failure: 'query',
+      message: 'mutation cadence reconciliation persistence failed',
+    })
+    const failureStartup = makeMutationAutonomousCycleStartup({
+      accountId,
+      authorityGenerationHash: generationHash,
+      pollIntervalMs: 50,
+      reconciliationIntervalMs: 100,
+      reconciliationPassTimeoutMs: 30_000,
+      strategy: fixtureStrategy,
+      executionProgram: sandboxExecutionProgram(),
+    })
+    const failureObservations: Parameters<Parameters<typeof failureStartup>[0]['recordPass']>[0][] = []
+    mutationPhase = true
+    await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          yield* TestClock.setTime(Date.parse(reconciledAt))
+          const first = yield* Deferred.make<void>()
+          const second = yield* Deferred.make<void>()
+          const third = yield* Deferred.make<void>()
+          const fourth = yield* Deferred.make<void>()
+          const fifth = yield* Deferred.make<void>()
+          const completions = [first, second, third, fourth, fifth]
+          const loop = yield* failureStartup({
+            qualificationRunId: 'c'.repeat(64),
+            recordPass: (observation) =>
+              Effect.sync(() => {
+                failureObservations.push(observation)
+                mutationEvents.push(`failure-observe:${failureObservations.length.toString()}`)
+                return completions[failureObservations.length - 1]
+              }).pipe(
+                Effect.flatMap((completion) =>
+                  completion === undefined ? Effect.void : Deferred.succeed(completion, undefined).pipe(Effect.asVoid),
+                ),
+              ),
+          })
+          const fiber = yield* loop.pipe(
+            Effect.provideService(BrokerRead, brokerRead),
+            Effect.provideService(CycleStore, cycleStore),
+            Effect.provideService(MarketData, missingPublicationMarketData),
+            Effect.provideService(BrokerEventStore, executionStore),
+            Effect.provideService(FillAccountingStore, executionStore),
+            Effect.provideService(ValuationStore, executionStore),
+            Effect.provideService(ReconciliationStore, executionStore),
+            Effect.provideService(AuthorityGenerationStore, executionStore),
+            Effect.provideService(AuthorityRestrictionStore, executionStore),
+            Effect.provideService(WriterFence, writerFence),
+            Effect.provideService(IntentStore, intentStore),
+            Effect.provideService(MutationStore, mutationStore),
+            Effect.forkScoped({ startImmediately: true }),
+          )
+          yield* Deferred.await(first).pipe(Effect.timeout('1 second'))
+          yield* Deferred.await(second).pipe(Effect.timeout('1 second'))
+          yield* TestClock.adjust(50)
+          yield* Deferred.await(third).pipe(Effect.timeout('1 second'))
+          yield* TestClock.adjust(50)
+          yield* Deferred.await(fourth).pipe(Effect.timeout('1 second'))
+          yield* TestClock.adjust(50)
+          yield* Deferred.await(fifth).pipe(Effect.timeout('1 second'))
+          yield* Fiber.interrupt(fiber)
+        }),
+      ).pipe(Effect.provide(TestClock.layer())),
+    )
+    mutationPhase = false
+
+    expect(failureObservations).toHaveLength(5)
+    expect(failureObservations[0]).toMatchObject({ result: 'SUCCESS', outcome: 'NO_PUBLICATION' })
+    expect(failureObservations[1]).toMatchObject({
+      result: 'FAILURE',
+      operation: 'reconcile-not-due',
+      message: 'same-pass reconciliation store operation failed: mutation cadence reconciliation persistence failed',
+    })
+    expect(failureObservations[2]).toMatchObject({
+      result: 'FAILURE',
+      operation: 'reconcile-not-due',
+      message: 'same-pass reconciliation store operation failed: mutation cadence reconciliation persistence failed',
+    })
+    expect(failureObservations[3]).toMatchObject({
+      result: 'FAILURE',
+      operation: 'reconcile-not-due',
+      message: 'same-pass reconciliation store operation failed: mutation cadence reconciliation persistence failed',
+    })
+    expect(failureObservations[4]).toMatchObject({ result: 'SUCCESS', outcome: 'NO_PUBLICATION' })
+    expect(publicationReads).toBe(4)
+    expect(mutationReconciliations).toBe(1)
+    expect(mutationEvents.indexOf('reconcile-failed')).toBeLessThan(mutationEvents.indexOf('failure-observe:2'))
+    expect(authorityRestrictions).toBe(1)
   })
 
   test('bounds the complete writer-fenced reconciliation pass and interrupts stalled persistence', async () => {

--- a/services/bayn/src/observe-composition.test.ts
+++ b/services/bayn/src/observe-composition.test.ts
@@ -1541,7 +1541,8 @@ describe('OBSERVE runtime composition', () => {
           const third = yield* Deferred.make<void>()
           const fourth = yield* Deferred.make<void>()
           const fifth = yield* Deferred.make<void>()
-          const completions = [first, second, third, fourth, fifth]
+          const sixth = yield* Deferred.make<void>()
+          const completions = [first, second, third, fourth, fifth, sixth]
           const loop = yield* failureStartup({
             qualificationRunId: 'c'.repeat(64),
             recordPass: (observation) =>
@@ -1576,15 +1577,16 @@ describe('OBSERVE runtime composition', () => {
           yield* Deferred.await(third).pipe(Effect.timeout('1 second'))
           yield* TestClock.adjust(50)
           yield* Deferred.await(fourth).pipe(Effect.timeout('1 second'))
-          yield* TestClock.adjust(50)
           yield* Deferred.await(fifth).pipe(Effect.timeout('1 second'))
+          yield* TestClock.adjust(50)
+          yield* Deferred.await(sixth).pipe(Effect.timeout('1 second'))
           yield* Fiber.interrupt(fiber)
         }),
       ).pipe(Effect.provide(TestClock.layer())),
     )
     mutationPhase = false
 
-    expect(failureObservations).toHaveLength(5)
+    expect(failureObservations).toHaveLength(6)
     expect(failureObservations[0]).toMatchObject({ result: 'SUCCESS', outcome: 'NO_PUBLICATION' })
     expect(failureObservations[1]).toMatchObject({
       result: 'FAILURE',
@@ -1602,10 +1604,90 @@ describe('OBSERVE runtime composition', () => {
       message: 'same-pass reconciliation store operation failed: mutation cadence reconciliation persistence failed',
     })
     expect(failureObservations[4]).toMatchObject({ result: 'SUCCESS', outcome: 'NO_PUBLICATION' })
+    expect(failureObservations[5]).toMatchObject({ result: 'SUCCESS', outcome: 'NO_PUBLICATION' })
     expect(publicationReads).toBe(4)
     expect(mutationReconciliations).toBe(1)
     expect(mutationEvents.indexOf('reconcile-failed')).toBeLessThan(mutationEvents.indexOf('failure-observe:2'))
     expect(authorityRestrictions).toBe(1)
+
+    mutationEvents.length = 0
+    mutationReconciliations = 0
+    publicationReads = 0
+    nextReconciliationFailure = new ExecutionStoreError({
+      operation: 'reconciliation',
+      failure: 'query',
+      message: 'slow-poll mutation reconciliation persistence failed',
+    })
+    const recoveryStartup = makeMutationAutonomousCycleStartup({
+      accountId,
+      authorityGenerationHash: generationHash,
+      pollIntervalMs: 250,
+      reconciliationIntervalMs: 100,
+      reconciliationPassTimeoutMs: 30_000,
+      strategy: fixtureStrategy,
+      executionProgram: sandboxExecutionProgram(),
+    })
+    const recoveryObservations: Parameters<Parameters<typeof recoveryStartup>[0]['recordPass']>[0][] = []
+    mutationPhase = true
+    await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          yield* TestClock.setTime(Date.parse(reconciledAt))
+          const initial = yield* Deferred.make<void>()
+          const failed = yield* Deferred.make<void>()
+          const recovered = yield* Deferred.make<void>()
+          const completions = [initial, failed, recovered]
+          const loop = yield* recoveryStartup({
+            qualificationRunId: 'c'.repeat(64),
+            recordPass: (observation) =>
+              Effect.sync(() => {
+                recoveryObservations.push(observation)
+                mutationEvents.push(`recovery-observe:${recoveryObservations.length.toString()}`)
+                return completions[recoveryObservations.length - 1]
+              }).pipe(
+                Effect.flatMap((completion) =>
+                  completion === undefined ? Effect.void : Deferred.succeed(completion, undefined).pipe(Effect.asVoid),
+                ),
+              ),
+          })
+          const fiber = yield* loop.pipe(
+            Effect.provideService(BrokerRead, brokerRead),
+            Effect.provideService(CycleStore, cycleStore),
+            Effect.provideService(MarketData, missingPublicationMarketData),
+            Effect.provideService(BrokerEventStore, executionStore),
+            Effect.provideService(FillAccountingStore, executionStore),
+            Effect.provideService(ValuationStore, executionStore),
+            Effect.provideService(ReconciliationStore, executionStore),
+            Effect.provideService(AuthorityGenerationStore, executionStore),
+            Effect.provideService(AuthorityRestrictionStore, executionStore),
+            Effect.provideService(WriterFence, writerFence),
+            Effect.provideService(IntentStore, intentStore),
+            Effect.provideService(MutationStore, mutationStore),
+            Effect.forkScoped({ startImmediately: true }),
+          )
+          yield* Deferred.await(initial).pipe(Effect.timeout('1 second'))
+          yield* Deferred.await(failed).pipe(Effect.timeout('1 second'))
+          yield* TestClock.adjust(100)
+          yield* Deferred.await(recovered).pipe(Effect.timeout('1 second'))
+          yield* Fiber.interrupt(fiber)
+        }),
+      ).pipe(Effect.provide(TestClock.layer())),
+    )
+    mutationPhase = false
+
+    expect(recoveryObservations).toHaveLength(3)
+    expect(recoveryObservations[0]).toMatchObject({ result: 'SUCCESS', outcome: 'NO_PUBLICATION' })
+    expect(recoveryObservations[1]).toMatchObject({
+      result: 'FAILURE',
+      operation: 'reconcile-not-due',
+      message: 'same-pass reconciliation store operation failed: slow-poll mutation reconciliation persistence failed',
+    })
+    expect(recoveryObservations[2]).toMatchObject({ result: 'SUCCESS', outcome: 'NO_PUBLICATION' })
+    expect(publicationReads).toBe(1)
+    expect(mutationReconciliations).toBe(1)
+    expect(mutationEvents.indexOf('reconcile-failed')).toBeLessThan(mutationEvents.indexOf('recovery-observe:2'))
+    expect(mutationEvents.indexOf('reconcile:1')).toBeLessThan(mutationEvents.indexOf('recovery-observe:3'))
+    expect(authorityRestrictions).toBe(2)
   })
 
   test('bounds the complete writer-fenced reconciliation pass and interrupts stalled persistence', async () => {

--- a/services/bayn/src/observe-composition.test.ts
+++ b/services/bayn/src/observe-composition.test.ts
@@ -632,6 +632,7 @@ describe('OBSERVE runtime composition', () => {
       accountId,
       authorityGenerationHash: generationHash,
       pollIntervalMs: 30_000,
+      reconciliationIntervalMs: 30_000,
       strategy: fixtureStrategy,
     })
 
@@ -1025,6 +1026,7 @@ describe('OBSERVE runtime composition', () => {
       accountId,
       authorityGenerationHash: generationHash,
       pollIntervalMs: 30_000,
+      reconciliationIntervalMs: 30_000,
       strategy: fixtureStrategy,
     })
 
@@ -1076,7 +1078,7 @@ describe('OBSERVE runtime composition', () => {
     )
   })
 
-  test('persists one writer-fenced reconciliation before reporting a NOT_DUE OBSERVE pass', async () => {
+  test('persists writer-fenced NOT_DUE reconciliation in OBSERVE and mutation/PAPER without broker mutations', async () => {
     const signalSessionDate: IsoDate = '2020-04-29'
     const calendarMaterial = {
       schemaVersion: 'bayn.alpaca-market-calendar-observation.v1' as const,
@@ -1123,6 +1125,7 @@ describe('OBSERVE runtime composition', () => {
     let positionReads = 0
     let orderReads = 0
     let fillReads = 0
+    let calendarReads = 0
     const unusedRead = Effect.die(new Error('NOT_DUE reconciliation used an unrelated broker read'))
     const brokerRead: BrokerReadShape = {
       account: Effect.sync(() => {
@@ -1149,6 +1152,7 @@ describe('OBSERVE runtime composition', () => {
         }),
       marketCalendar: (query) => {
         expect(query).toEqual(calendarMaterial.requestedRange)
+        calendarReads += 1
         return Effect.succeed({ value: ordinaryCalendar, evidence: readEvidence('calendar') })
       },
     }
@@ -1263,6 +1267,7 @@ describe('OBSERVE runtime composition', () => {
       accountId,
       authorityGenerationHash: generationHash,
       pollIntervalMs: 30_000,
+      reconciliationIntervalMs: 30_000,
       strategy: fixtureStrategy,
     })
 
@@ -1313,6 +1318,84 @@ describe('OBSERVE runtime composition', () => {
       reconciledAt,
     })
     expect(fencedTransactions).toBe(1)
+    expect(authorityRestrictions).toBe(0)
+
+    const mutationStartup = makeMutationAutonomousCycleStartup({
+      accountId,
+      authorityGenerationHash: generationHash,
+      pollIntervalMs: 350,
+      reconciliationIntervalMs: 100,
+      strategy: fixtureStrategy,
+      executionProgram: sandboxExecutionProgram(),
+    })
+    const intentStore = {} as IntentStoreService
+    const mutationStore = {} as MutationStoreShape
+    const mutationObservations: Parameters<Parameters<typeof mutationStartup>[0]['recordPass']>[0][] = []
+    await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          yield* TestClock.setTime(Date.parse(reconciledAt))
+          const first = yield* Deferred.make<void>()
+          const second = yield* Deferred.make<void>()
+          const loop = yield* mutationStartup({
+            qualificationRunId: 'c'.repeat(64),
+            recordPass: (result) =>
+              Effect.sync(() => {
+                mutationObservations.push(result)
+                return mutationObservations.length === 1
+                  ? first
+                  : mutationObservations.length === 2
+                    ? second
+                    : undefined
+              }).pipe(
+                Effect.flatMap((completion) =>
+                  completion === undefined ? Effect.void : Deferred.succeed(completion, undefined).pipe(Effect.asVoid),
+                ),
+              ),
+          })
+          const fiber = yield* loop.pipe(
+            Effect.provideService(BrokerRead, brokerRead),
+            Effect.provideService(CycleStore, cycleStore),
+            Effect.provideService(MarketData, marketDataService),
+            Effect.provideService(BrokerEventStore, executionStore),
+            Effect.provideService(FillAccountingStore, executionStore),
+            Effect.provideService(ValuationStore, executionStore),
+            Effect.provideService(ReconciliationStore, executionStore),
+            Effect.provideService(AuthorityGenerationStore, executionStore),
+            Effect.provideService(AuthorityRestrictionStore, executionStore),
+            Effect.provideService(WriterFence, writerFence),
+            Effect.provideService(IntentStore, intentStore),
+            Effect.provideService(MutationStore, mutationStore),
+            Effect.forkScoped({ startImmediately: true }),
+          )
+          yield* Deferred.await(first).pipe(Effect.timeout('1 second'))
+          yield* TestClock.adjust(101)
+          yield* Deferred.await(second).pipe(Effect.timeout('1 second'))
+          yield* Fiber.interrupt(fiber)
+        }),
+      ).pipe(Effect.provide(TestClock.layer())),
+    )
+
+    expect(mutationObservations).toHaveLength(2)
+    expect(mutationObservations[0]).toMatchObject({ result: 'SUCCESS', outcome: 'NOT_DUE' })
+    expect(mutationObservations[1]).toMatchObject({ result: 'SUCCESS', outcome: 'NOT_DUE' })
+    expect(acquisitions).toBe(0)
+    expect(calendarReads).toBe(2)
+    expect(accountReads).toBe(3)
+    expect(positionReads).toBe(3)
+    expect(orderReads).toBe(6)
+    expect(fillReads).toBe(6)
+    expect(brokerEventWrites).toBe(3)
+    expect(positionWrites).toBe(3)
+    expect(valuationWrites).toBe(3)
+    expect(reconciledSnapshots).toHaveLength(3)
+    expect(reconciledSnapshots[2]).toMatchObject({
+      account,
+      positions: [],
+      orders: [],
+      fills: [],
+    })
+    expect(fencedTransactions).toBe(3)
     expect(authorityRestrictions).toBe(0)
   })
 
@@ -1380,6 +1463,7 @@ describe('OBSERVE runtime composition', () => {
       accountId,
       authorityGenerationHash: generationHash,
       pollIntervalMs: 30_000,
+      reconciliationIntervalMs: 30_000,
       strategy: fixtureStrategy,
       executionProgram: sandboxExecutionProgram(),
     })
@@ -1424,6 +1508,7 @@ describe('OBSERVE runtime composition', () => {
       accountId,
       authorityGenerationHash: generationHash,
       pollIntervalMs: 30_000,
+      reconciliationIntervalMs: 30_000,
       strategy: fixtureStrategy,
     })
 
@@ -1442,6 +1527,7 @@ describe('OBSERVE runtime composition', () => {
         accountId,
         authorityGenerationHash: generationHash,
         pollIntervalMs: 30_000,
+        reconciliationIntervalMs: 30_000,
         strategy: fixtureStrategy,
         executionProgram,
       })

--- a/services/bayn/src/observe-composition.test.ts
+++ b/services/bayn/src/observe-composition.test.ts
@@ -1427,6 +1427,82 @@ describe('OBSERVE runtime composition', () => {
     })
     expect(fencedTransactions).toBe(3)
     expect(authorityRestrictions).toBe(0)
+
+    mutationEvents.length = 0
+    mutationReconciliations = 0
+    const nonIdleObservations: Parameters<Parameters<typeof mutationStartup>[0]['recordPass']>[0][] = []
+    const calendarReadsBeforeNonIdle = calendarReads
+    let publicationReads = 0
+    let secondPublicationRead: Deferred.Deferred<void> | undefined
+    const missingPublicationMarketData: MarketDataService = {
+      ...marketData([]),
+      inspectCyclePublications: Effect.suspend(() => {
+        publicationReads += 1
+        mutationEvents.push(`publication:${publicationReads.toString()}`)
+        const result = {
+          outcome: 'MISSING' as const,
+          observedAt: '2020-04-29T22:00:00.000Z',
+        }
+        return publicationReads === 2 && secondPublicationRead !== undefined
+          ? Deferred.succeed(secondPublicationRead, undefined).pipe(Effect.as(result))
+          : Effect.succeed(result)
+      }),
+    }
+    mutationPhase = true
+    await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          yield* TestClock.setTime(Date.parse(reconciledAt))
+          const first = yield* Deferred.make<void>()
+          const second = yield* Deferred.make<void>()
+          secondPublicationRead = yield* Deferred.make<void>()
+          const loop = yield* mutationStartup({
+            qualificationRunId: 'c'.repeat(64),
+            recordPass: (observation) =>
+              Effect.sync(() => {
+                nonIdleObservations.push(observation)
+                mutationEvents.push(`observe:${nonIdleObservations.length.toString()}`)
+                return nonIdleObservations.length === 1 ? first : nonIdleObservations.length === 2 ? second : undefined
+              }).pipe(
+                Effect.flatMap((completion) =>
+                  completion === undefined ? Effect.void : Deferred.succeed(completion, undefined).pipe(Effect.asVoid),
+                ),
+              ),
+          })
+          const fiber = yield* loop.pipe(
+            Effect.provideService(BrokerRead, brokerRead),
+            Effect.provideService(CycleStore, cycleStore),
+            Effect.provideService(MarketData, missingPublicationMarketData),
+            Effect.provideService(BrokerEventStore, executionStore),
+            Effect.provideService(FillAccountingStore, executionStore),
+            Effect.provideService(ValuationStore, executionStore),
+            Effect.provideService(ReconciliationStore, executionStore),
+            Effect.provideService(AuthorityGenerationStore, executionStore),
+            Effect.provideService(AuthorityRestrictionStore, executionStore),
+            Effect.provideService(WriterFence, writerFence),
+            Effect.provideService(IntentStore, intentStore),
+            Effect.provideService(MutationStore, mutationStore),
+            Effect.forkScoped({ startImmediately: true }),
+          )
+          yield* Deferred.await(first).pipe(Effect.timeout('1 second'))
+          yield* TestClock.adjust(100)
+          yield* Deferred.await(secondPublicationRead).pipe(Effect.timeout('1 second'))
+          yield* Deferred.await(second).pipe(Effect.timeout('1 second'))
+          yield* Fiber.interrupt(fiber)
+        }),
+      ).pipe(Effect.provide(TestClock.layer())),
+    )
+    mutationPhase = false
+
+    expect(nonIdleObservations).toHaveLength(2)
+    expect(nonIdleObservations[0]).toMatchObject({ result: 'SUCCESS', outcome: 'NO_PUBLICATION' })
+    expect(nonIdleObservations[1]).toMatchObject({ result: 'SUCCESS', outcome: 'NO_PUBLICATION' })
+    expect(mutationEvents.indexOf('observe:1')).toBeLessThan(mutationEvents.indexOf('reconcile:1'))
+    expect(mutationEvents.indexOf('reconcile:2')).toBeLessThan(mutationEvents.indexOf('publication:2'))
+    expect(publicationReads).toBe(2)
+    expect(mutationReconciliations).toBe(2)
+    expect(calendarReads).toBe(calendarReadsBeforeNonIdle)
+    expect(authorityRestrictions).toBe(0)
   })
 
   test('bounds the complete writer-fenced reconciliation pass and interrupts stalled persistence', async () => {

--- a/services/bayn/src/observe-composition.test.ts
+++ b/services/bayn/src/observe-composition.test.ts
@@ -1524,9 +1524,9 @@ describe('OBSERVE runtime composition', () => {
     const failureStartup = makeMutationAutonomousCycleStartup({
       accountId,
       authorityGenerationHash: generationHash,
-      pollIntervalMs: 50,
-      reconciliationIntervalMs: 100,
-      reconciliationPassTimeoutMs: 30_000,
+      pollIntervalMs: 5,
+      reconciliationIntervalMs: 10,
+      reconciliationPassTimeoutMs: 2,
       strategy: fixtureStrategy,
       executionProgram: sandboxExecutionProgram(),
     })
@@ -1538,11 +1538,7 @@ describe('OBSERVE runtime composition', () => {
           yield* TestClock.setTime(Date.parse(reconciledAt))
           const first = yield* Deferred.make<void>()
           const second = yield* Deferred.make<void>()
-          const third = yield* Deferred.make<void>()
-          const fourth = yield* Deferred.make<void>()
-          const fifth = yield* Deferred.make<void>()
-          const sixth = yield* Deferred.make<void>()
-          const completions = [first, second, third, fourth, fifth, sixth]
+          const completions = [first, second]
           const loop = yield* failureStartup({
             qualificationRunId: 'c'.repeat(64),
             recordPass: (observation) =>
@@ -1573,20 +1569,17 @@ describe('OBSERVE runtime composition', () => {
           )
           yield* Deferred.await(first).pipe(Effect.timeout('1 second'))
           yield* Deferred.await(second).pipe(Effect.timeout('1 second'))
-          yield* TestClock.adjust(50)
-          yield* Deferred.await(third).pipe(Effect.timeout('1 second'))
-          yield* TestClock.adjust(50)
-          yield* Deferred.await(fourth).pipe(Effect.timeout('1 second'))
-          yield* Deferred.await(fifth).pipe(Effect.timeout('1 second'))
-          yield* TestClock.adjust(50)
-          yield* Deferred.await(sixth).pipe(Effect.timeout('1 second'))
+          for (let elapsed = 0; elapsed < 15; elapsed += 1) {
+            yield* TestClock.withLive(Effect.sleep(1))
+            yield* TestClock.adjust(1)
+          }
           yield* Fiber.interrupt(fiber)
         }),
       ).pipe(Effect.provide(TestClock.layer())),
     )
     mutationPhase = false
 
-    expect(failureObservations).toHaveLength(6)
+    expect(failureObservations).toHaveLength(5)
     expect(failureObservations[0]).toMatchObject({ result: 'SUCCESS', outcome: 'NO_PUBLICATION' })
     expect(failureObservations[1]).toMatchObject({
       result: 'FAILURE',
@@ -1598,14 +1591,9 @@ describe('OBSERVE runtime composition', () => {
       operation: 'reconcile-not-due',
       message: 'same-pass reconciliation store operation failed: mutation cadence reconciliation persistence failed',
     })
-    expect(failureObservations[3]).toMatchObject({
-      result: 'FAILURE',
-      operation: 'reconcile-not-due',
-      message: 'same-pass reconciliation store operation failed: mutation cadence reconciliation persistence failed',
-    })
+    expect(failureObservations[3]).toMatchObject({ result: 'SUCCESS', outcome: 'NO_PUBLICATION' })
     expect(failureObservations[4]).toMatchObject({ result: 'SUCCESS', outcome: 'NO_PUBLICATION' })
-    expect(failureObservations[5]).toMatchObject({ result: 'SUCCESS', outcome: 'NO_PUBLICATION' })
-    expect(publicationReads).toBe(4)
+    expect(publicationReads).toBe(3)
     expect(mutationReconciliations).toBe(1)
     expect(mutationEvents.indexOf('reconcile-failed')).toBeLessThan(mutationEvents.indexOf('failure-observe:2'))
     expect(authorityRestrictions).toBe(1)
@@ -1687,6 +1675,72 @@ describe('OBSERVE runtime composition', () => {
     expect(mutationReconciliations).toBe(1)
     expect(mutationEvents.indexOf('reconcile-failed')).toBeLessThan(mutationEvents.indexOf('recovery-observe:2'))
     expect(mutationEvents.indexOf('reconcile:1')).toBeLessThan(mutationEvents.indexOf('recovery-observe:3'))
+    expect(authorityRestrictions).toBe(2)
+
+    mutationEvents.length = 0
+    mutationReconciliations = 0
+    publicationReads = 0
+    const nearBoundaryStartup = makeMutationAutonomousCycleStartup({
+      accountId,
+      authorityGenerationHash: generationHash,
+      pollIntervalMs: 99,
+      reconciliationIntervalMs: 100,
+      reconciliationPassTimeoutMs: 2,
+      strategy: fixtureStrategy,
+      executionProgram: sandboxExecutionProgram(),
+    })
+    mutationPhase = true
+    await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          yield* TestClock.setTime(Date.parse(reconciledAt))
+          const firstPass = yield* Deferred.make<void>()
+          secondPublicationRead = yield* Deferred.make<void>()
+          let observations = 0
+          const loop = yield* nearBoundaryStartup({
+            qualificationRunId: 'c'.repeat(64),
+            recordPass: () =>
+              Effect.sync(() => {
+                observations += 1
+                mutationEvents.push(`near-observe:${observations.toString()}`)
+                return observations
+              }).pipe(
+                Effect.flatMap((count) =>
+                  count === 1 ? Deferred.succeed(firstPass, undefined).pipe(Effect.asVoid) : Effect.void,
+                ),
+              ),
+          })
+          const fiber = yield* loop.pipe(
+            Effect.provideService(BrokerRead, brokerRead),
+            Effect.provideService(CycleStore, cycleStore),
+            Effect.provideService(MarketData, missingPublicationMarketData),
+            Effect.provideService(BrokerEventStore, executionStore),
+            Effect.provideService(FillAccountingStore, executionStore),
+            Effect.provideService(ValuationStore, executionStore),
+            Effect.provideService(ReconciliationStore, executionStore),
+            Effect.provideService(AuthorityGenerationStore, executionStore),
+            Effect.provideService(AuthorityRestrictionStore, executionStore),
+            Effect.provideService(WriterFence, writerFence),
+            Effect.provideService(IntentStore, intentStore),
+            Effect.provideService(MutationStore, mutationStore),
+            Effect.forkScoped({ startImmediately: true }),
+          )
+          yield* Deferred.await(firstPass).pipe(Effect.timeout('1 second'))
+          yield* TestClock.withLive(Effect.sleep(5))
+          yield* TestClock.adjust(99)
+          expect(publicationReads).toBe(1)
+          expect(mutationReconciliations).toBe(1)
+          yield* TestClock.adjust(1)
+          yield* Deferred.await(secondPublicationRead).pipe(Effect.timeout('1 second'))
+          yield* Fiber.interrupt(fiber)
+        }),
+      ).pipe(Effect.provide(TestClock.layer())),
+    )
+    mutationPhase = false
+
+    expect(mutationEvents.indexOf('reconcile:2')).toBeLessThan(mutationEvents.indexOf('publication:2'))
+    expect(publicationReads).toBe(2)
+    expect(mutationReconciliations).toBe(2)
     expect(authorityRestrictions).toBe(2)
   })
 

--- a/services/bayn/src/observe-composition.test.ts
+++ b/services/bayn/src/observe-composition.test.ts
@@ -633,6 +633,7 @@ describe('OBSERVE runtime composition', () => {
       authorityGenerationHash: generationHash,
       pollIntervalMs: 30_000,
       reconciliationIntervalMs: 30_000,
+      reconciliationPassTimeoutMs: 30_000,
       strategy: fixtureStrategy,
     })
 
@@ -1027,6 +1028,7 @@ describe('OBSERVE runtime composition', () => {
       authorityGenerationHash: generationHash,
       pollIntervalMs: 30_000,
       reconciliationIntervalMs: 30_000,
+      reconciliationPassTimeoutMs: 30_000,
       strategy: fixtureStrategy,
     })
 
@@ -1268,6 +1270,7 @@ describe('OBSERVE runtime composition', () => {
       authorityGenerationHash: generationHash,
       pollIntervalMs: 30_000,
       reconciliationIntervalMs: 30_000,
+      reconciliationPassTimeoutMs: 30_000,
       strategy: fixtureStrategy,
     })
 
@@ -1325,6 +1328,7 @@ describe('OBSERVE runtime composition', () => {
       authorityGenerationHash: generationHash,
       pollIntervalMs: 350,
       reconciliationIntervalMs: 100,
+      reconciliationPassTimeoutMs: 30_000,
       strategy: fixtureStrategy,
       executionProgram: sandboxExecutionProgram(),
     })
@@ -1399,6 +1403,200 @@ describe('OBSERVE runtime composition', () => {
     expect(authorityRestrictions).toBe(0)
   })
 
+  test('bounds the complete writer-fenced reconciliation pass and interrupts stalled persistence', async () => {
+    const signalSessionDate: IsoDate = '2020-04-29'
+    const calendarMaterial = {
+      schemaVersion: 'bayn.alpaca-market-calendar-observation.v1' as const,
+      source: 'alpaca-v2-calendar' as const,
+      requestedRange: { start: signalSessionDate, end: '2020-05-29' },
+      timeZone: 'UTC' as const,
+      sessions: [
+        {
+          date: signalSessionDate,
+          openAt: '2020-04-29T13:30:00.000Z',
+          closeAt: '2020-04-29T20:00:00.000Z',
+        },
+        {
+          date: signalDate,
+          openAt: '2020-04-30T13:30:00.000Z',
+          closeAt: '2020-04-30T20:00:00.000Z',
+        },
+      ],
+    }
+    const ordinaryCalendar: MarketCalendarObservation = {
+      ...calendarMaterial,
+      normalizedResponseHash: canonicalHashV1(calendarMaterial),
+    }
+    const readEvidence = (identity: string): ReadEvidence => ({
+      requestId: `bounded-pass-${identity}`,
+      status: 200,
+      contentHash: canonicalHashV1({ identity }),
+      observedAt: reconciledAt,
+    })
+    const brokerAccount: BrokerAccount = {
+      id: accountId,
+      status: BrokerAccountStatus.Active,
+      currency: 'USD',
+      cashMicros: account.cashMicros,
+      equityMicros: account.equityMicros,
+      lastEquityMicros: account.equityMicros,
+      buyingPowerMicros: account.buyingPowerMicros,
+      accountBlocked: false,
+      tradingBlocked: false,
+      tradeSuspendedByUser: false,
+      observedAt: reconciledAt,
+    }
+    const brokerRead: BrokerReadShape = {
+      account: Effect.succeed({ value: brokerAccount, evidence: readEvidence('account') }),
+      accountConfiguration: Effect.die(new Error('bounded reconciliation used account configuration')),
+      assetBySymbol: unusedAssetBySymbol,
+      positions: Effect.succeed({ value: [], evidence: readEvidence('positions') }),
+      orders: () => Effect.succeed({ value: [], evidence: readEvidence('orders') }),
+      orderById: () => Effect.die(new Error('bounded reconciliation used order lookup')),
+      orderByClientId: () => Effect.die(new Error('bounded reconciliation used client-order lookup')),
+      fillActivities: () => Effect.succeed({ value: { items: [] }, evidence: readEvidence('fills') }),
+      marketCalendar: (query) => {
+        expect(query).toEqual(calendarMaterial.requestedRange)
+        return Effect.succeed({ value: ordinaryCalendar, evidence: readEvidence('calendar') })
+      },
+    }
+    const marketDataService: MarketDataService = {
+      ...marketData([]),
+      inspectCyclePublications: Effect.succeed({
+        outcome: 'FINALIZED',
+        observedAt: '2020-04-29T22:00:00.000Z',
+        publications: [
+          {
+            manifest: snapshot.manifest,
+            sessionDates: [signalSessionDate],
+            signalSession: {
+              calendar_version: 'fixture-calendar-v2',
+              session_date: signalSessionDate,
+              close_time: '16:00',
+              timezone: 'America/New_York' as const,
+            },
+          },
+        ],
+      }),
+    }
+    const unusedCycleStore = Effect.die(new Error('bounded NOT_DUE pass attempted to mutate cycle state'))
+    const cycleStore: CycleStoreShape = {
+      acquire: () => unusedCycleStore,
+      read: () => unusedCycleStore,
+      readAuthoritySlot: () => Effect.succeed(Option.none()),
+      readDecisionDocument: () => unusedCycleStore,
+      readOldestUnfinished: () => Effect.succeed(Option.none()),
+      bindSnapshot: () => unusedCycleStore,
+      activate: () => unusedCycleStore,
+      bindDecision: () => unusedCycleStore,
+      finish: () => unusedCycleStore,
+      block: () => unusedCycleStore,
+    }
+    const exact = reconciliationResult()
+    const authority = exact.riskContext.authority
+    expect(authority).not.toBeNull()
+    if (authority === null) expect.unreachable('bounded reconciliation fixture requires authority')
+    const unusedAccounting = Effect.die(new Error('empty reconciliation must not account a fill'))
+    let authorityRestrictions = 0
+    let fencedTransactions = 0
+
+    const observation = await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          yield* TestClock.setTime(Date.parse(reconciledAt))
+          const persistenceStarted = yield* Deferred.make<void>()
+          const persistenceInterrupted = yield* Deferred.make<void>()
+          const pass =
+            yield* Deferred.make<
+              Parameters<Parameters<ReturnType<typeof makeObserveAutonomousCycleStartup>>[0]['recordPass']>[0]
+            >()
+          const executionStore = {
+            ingest: () => Effect.succeed({ eventId: '1'.repeat(64), sourceSequence: '1', deduplicated: false }),
+            ingestPositions: () => Effect.succeed({ snapshotId: '2'.repeat(64), eventIds: [], deduplicated: false }),
+            account: () => unusedAccounting,
+            value: () =>
+              Effect.succeed({
+                schemaVersion: 'bayn.paper-valuation.v1' as const,
+                valuationId: '3'.repeat(64),
+                accountId,
+                sourceHash: '4'.repeat(64),
+                cashMicros: account.cashMicros,
+                longMarketValueMicros: '0',
+                shortMarketValueMicros: '0',
+                equityMicros: account.equityMicros,
+                asOf: reconciledAt,
+              }),
+            hasAccountBaseline: () => Effect.succeed(true),
+            bindings: () => Effect.succeed([]),
+            reconcile: () =>
+              Deferred.succeed(persistenceStarted, undefined).pipe(
+                Effect.andThen(Effect.never),
+                Effect.onInterrupt(() => Deferred.succeed(persistenceInterrupted, undefined).pipe(Effect.asVoid)),
+              ),
+            ensureAuthorityGeneration: () => Effect.succeed(authority),
+            restrictAuthority: () =>
+              Effect.sync(() => {
+                authorityRestrictions += 1
+              }),
+          } satisfies BrokerEventStoreShape &
+            FillAccountingStoreShape &
+            ValuationStoreShape &
+            ReconciliationStoreShape &
+            AuthorityGenerationStoreShape &
+            AuthorityRestrictionStoreShape
+          const writerFence: WriterFenceService = {
+            backendPid: 1,
+            check: Effect.void,
+            transaction: (effect) =>
+              Effect.sync(() => {
+                fencedTransactions += 1
+              }).pipe(Effect.andThen(effect)),
+          }
+          const startup = makeObserveAutonomousCycleStartup({
+            accountId,
+            authorityGenerationHash: generationHash,
+            pollIntervalMs: 1_000,
+            reconciliationIntervalMs: 100,
+            reconciliationPassTimeoutMs: 50,
+            strategy: fixtureStrategy,
+          })
+          const loop = yield* startup({
+            qualificationRunId: 'c'.repeat(64),
+            recordPass: (result) => Deferred.succeed(pass, result).pipe(Effect.asVoid),
+          }).pipe(Effect.provideService(AuthorityGenerationStore, executionStore))
+          const fiber = yield* loop.pipe(
+            Effect.provideService(BrokerRead, brokerRead),
+            Effect.provideService(CycleStore, cycleStore),
+            Effect.provideService(MarketData, marketDataService),
+            Effect.provideService(BrokerEventStore, executionStore),
+            Effect.provideService(FillAccountingStore, executionStore),
+            Effect.provideService(ValuationStore, executionStore),
+            Effect.provideService(ReconciliationStore, executionStore),
+            Effect.provideService(AuthorityGenerationStore, executionStore),
+            Effect.provideService(AuthorityRestrictionStore, executionStore),
+            Effect.provideService(WriterFence, writerFence),
+            Effect.forkScoped({ startImmediately: true }),
+          )
+          yield* Deferred.await(persistenceStarted)
+          yield* TestClock.adjust(51)
+          const result = yield* Deferred.await(pass).pipe(Effect.timeout('1 second'))
+          yield* Deferred.await(persistenceInterrupted).pipe(Effect.timeout('1 second'))
+          yield* Fiber.interrupt(fiber)
+          return result
+        }),
+      ).pipe(Effect.provide(TestClock.layer())),
+    )
+
+    expect(observation).toMatchObject({
+      result: 'FAILURE',
+      operation: 'reconcile-not-due',
+      failure: 'market-data',
+      message: 'same-pass broker reconciliation timed out after 50ms',
+    })
+    expect(fencedTransactions).toBe(1)
+    expect(authorityRestrictions).toBe(0)
+  })
+
   test('starts mutation mode without projecting or initializing OBSERVE authority', async () => {
     const unused = Effect.die(new Error('missing-publication mutation loop must not use this capability'))
     let authorityInitializations = 0
@@ -1464,6 +1662,7 @@ describe('OBSERVE runtime composition', () => {
       authorityGenerationHash: generationHash,
       pollIntervalMs: 30_000,
       reconciliationIntervalMs: 30_000,
+      reconciliationPassTimeoutMs: 30_000,
       strategy: fixtureStrategy,
       executionProgram: sandboxExecutionProgram(),
     })
@@ -1509,6 +1708,7 @@ describe('OBSERVE runtime composition', () => {
       authorityGenerationHash: generationHash,
       pollIntervalMs: 30_000,
       reconciliationIntervalMs: 30_000,
+      reconciliationPassTimeoutMs: 30_000,
       strategy: fixtureStrategy,
     })
 
@@ -1528,6 +1728,7 @@ describe('OBSERVE runtime composition', () => {
         authorityGenerationHash: generationHash,
         pollIntervalMs: 30_000,
         reconciliationIntervalMs: 30_000,
+        reconciliationPassTimeoutMs: 30_000,
         strategy: fixtureStrategy,
         executionProgram,
       })

--- a/services/bayn/src/observe-composition.test.ts
+++ b/services/bayn/src/observe-composition.test.ts
@@ -1742,6 +1742,160 @@ describe('OBSERVE runtime composition', () => {
     expect(publicationReads).toBe(2)
     expect(mutationReconciliations).toBe(2)
     expect(authorityRestrictions).toBe(2)
+
+    const paperResult = reconciliationResult(generationHash, Authority.Paper)
+    const paperAuthority = paperResult.riskContext.authority
+    if (paperAuthority === null) return expect.unreachable('post-reconcile fixture requires PAPER authority')
+    const paperPersisted: ReconciliationWriteResult = {
+      reconciliation: paperResult.report.reconciliation,
+      metrics: paperResult.report.metrics,
+      accountingHash: paperResult.brokerState.accountingHash,
+      riskContext: paperResult.riskContext,
+    }
+    const postReconcilePolicy = await Effect.runPromise(loadObserveRiskPolicy(accountId, fixtureProtocol.universe))
+    const postReconcileDocument = await Effect.runPromise(
+      Effect.gen(function* () {
+        yield* TestClock.setTime(Date.parse(evaluatedAt))
+        return yield* buildMutationShadowCycleDecision({
+          authorityGenerationHash: generationHash,
+          cycle,
+          executionModel: fixtureProtocol.executionModel,
+          policy: postReconcilePolicy,
+          reconcile: Effect.succeed(paperResult),
+          strategy: { currentDecision: () => Result.succeed({ decision, priceMicros }) },
+        })
+      }).pipe(
+        (program) => provideDecisionServices(program, marketData([]), calendarRead([])),
+        Effect.provide(TestClock.layer()),
+      ),
+    )
+    const postReconcileCycle = Effect.runSync(
+      decodeAutonomousCycle({
+        ...cycle,
+        bindings: { ...cycle.bindings, decisionHash: postReconcileDocument.contentHash },
+        stateVersion: cycle.stateVersion + 1,
+        updatedAt: evaluatedAt,
+      }),
+    )
+    const postReconcileObservations: Parameters<Parameters<typeof mutationStartup>[0]['recordPass']>[0][] = []
+    const postReconcileEvents: string[] = []
+    let postReconcilePasses = 0
+
+    await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          yield* TestClock.setTime(Date.parse(evaluatedAt))
+          const storeReadStarted = yield* Deferred.make<void>()
+          const storeReadInterrupted = yield* Deferred.make<void>()
+          const passFailed = yield* Deferred.make<void>()
+          const cadenceContinued = yield* Deferred.make<void>()
+          const unusedPostReconcile = Effect.die(new Error('post-reconcile fixture used an unrelated operation'))
+          const postReconcileCycleStore: CycleStoreShape = {
+            acquire: () => unusedPostReconcile,
+            read: () => unusedPostReconcile,
+            readAuthoritySlot: () => unusedPostReconcile,
+            readDecisionDocument: () => Effect.succeed(Option.some(postReconcileDocument)),
+            readOldestUnfinished: () => Effect.succeed(Option.some(postReconcileCycle)),
+            bindSnapshot: () => unusedPostReconcile,
+            activate: () => unusedPostReconcile,
+            bindDecision: () => unusedPostReconcile,
+            finish: () => unusedPostReconcile,
+            block: () => unusedPostReconcile,
+          }
+          const postReconcileExecutionStore = {
+            ...executionStore,
+            reconcile: () =>
+              Effect.sync(() => {
+                postReconcilePasses += 1
+                postReconcileEvents.push(`reconcile:${postReconcilePasses.toString()}`)
+                return postReconcilePasses
+              }).pipe(
+                Effect.flatMap((count) =>
+                  count === 2
+                    ? Deferred.succeed(cadenceContinued, undefined).pipe(Effect.as(paperPersisted))
+                    : Effect.succeed(paperPersisted),
+                ),
+              ),
+            ensureAuthorityGeneration: () => Effect.succeed(paperAuthority),
+          } satisfies BrokerEventStoreShape &
+            FillAccountingStoreShape &
+            ValuationStoreShape &
+            ReconciliationStoreShape &
+            AuthorityGenerationStoreShape &
+            AuthorityRestrictionStoreShape
+          const postReconcileIntentStore: IntentStoreService = {
+            commit: () => unusedPostReconcile,
+            read: () =>
+              Deferred.succeed(storeReadStarted, undefined).pipe(
+                Effect.andThen(
+                  Effect.never.pipe(
+                    Effect.onInterrupt(() =>
+                      Effect.sync(() => postReconcileEvents.push('store-read-interrupted')).pipe(
+                        Effect.andThen(Deferred.succeed(storeReadInterrupted, undefined)),
+                        Effect.asVoid,
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+          }
+          const postReconcileStartup = makeMutationAutonomousCycleStartup({
+            accountId,
+            authorityGenerationHash: generationHash,
+            pollIntervalMs: 10_000,
+            reconciliationIntervalMs: 100,
+            reconciliationPassTimeoutMs: 50,
+            strategy: fixtureStrategy,
+            executionProgram: sandboxExecutionProgram(),
+          })
+          const loop = yield* postReconcileStartup({
+            qualificationRunId: 'c'.repeat(64),
+            recordPass: (observation) =>
+              Effect.sync(() => {
+                postReconcileObservations.push(observation)
+                postReconcileEvents.push(`observe:${postReconcileObservations.length.toString()}`)
+              }).pipe(Effect.andThen(Deferred.succeed(passFailed, undefined)), Effect.asVoid),
+          })
+          const fiber = yield* loop.pipe(
+            Effect.provideService(BrokerRead, { ...brokerRead, marketCalendar: calendarRead([]) }),
+            Effect.provideService(CycleStore, postReconcileCycleStore),
+            Effect.provideService(MarketData, marketData([])),
+            Effect.provideService(BrokerEventStore, postReconcileExecutionStore),
+            Effect.provideService(FillAccountingStore, postReconcileExecutionStore),
+            Effect.provideService(ValuationStore, postReconcileExecutionStore),
+            Effect.provideService(ReconciliationStore, postReconcileExecutionStore),
+            Effect.provideService(AuthorityGenerationStore, postReconcileExecutionStore),
+            Effect.provideService(AuthorityRestrictionStore, postReconcileExecutionStore),
+            Effect.provideService(WriterFence, writerFence),
+            Effect.provideService(IntentStore, postReconcileIntentStore),
+            Effect.provideService(MutationStore, {} as MutationStoreShape),
+            Effect.forkScoped({ startImmediately: true }),
+          )
+          yield* Deferred.await(storeReadStarted).pipe(Effect.timeout('1 second'))
+          expect(postReconcilePasses).toBe(1)
+          postReconcileEvents.push('store-read-started')
+          yield* TestClock.adjust(50)
+          yield* Deferred.await(passFailed).pipe(Effect.timeout('1 second'))
+          yield* Deferred.await(storeReadInterrupted).pipe(Effect.timeout('1 second'))
+          yield* TestClock.adjust(51)
+          yield* Deferred.await(cadenceContinued).pipe(Effect.timeout('1 second'))
+          yield* Fiber.interrupt(fiber)
+        }),
+      ).pipe(Effect.provide(TestClock.layer())),
+    )
+
+    expect(postReconcileObservations).toHaveLength(1)
+    expect(postReconcileObservations[0]).toMatchObject({
+      result: 'FAILURE',
+      operation: 'run-cycle-pass',
+      failure: 'operational',
+      message: 'mutation autonomous cycle pass did not complete or reconcile within 50ms',
+    })
+    expect(postReconcilePasses).toBe(2)
+    expect(postReconcileEvents.indexOf('reconcile:1')).toBeLessThan(postReconcileEvents.indexOf('store-read-started'))
+    expect(postReconcileEvents.indexOf('store-read-interrupted')).toBeLessThan(
+      postReconcileEvents.indexOf('reconcile:2'),
+    )
   })
 
   test('bounds the complete writer-fenced reconciliation pass and interrupts stalled persistence', async () => {

--- a/services/bayn/src/observe-composition.test.ts
+++ b/services/bayn/src/observe-composition.test.ts
@@ -1685,7 +1685,7 @@ describe('OBSERVE runtime composition', () => {
       authorityGenerationHash: generationHash,
       pollIntervalMs: 99,
       reconciliationIntervalMs: 100,
-      reconciliationPassTimeoutMs: 2,
+      reconciliationPassTimeoutMs: 100,
       strategy: fixtureStrategy,
       executionProgram: sandboxExecutionProgram(),
     })

--- a/services/bayn/src/observe-composition.test.ts
+++ b/services/bayn/src/observe-composition.test.ts
@@ -1128,6 +1128,11 @@ describe('OBSERVE runtime composition', () => {
     let orderReads = 0
     let fillReads = 0
     let calendarReads = 0
+    let mutationPhase = false
+    let mutationCalendarReads = 0
+    let mutationReconciliations = 0
+    let secondMutationCalendarRead: Deferred.Deferred<void> | undefined
+    const mutationEvents: string[] = []
     const unusedRead = Effect.die(new Error('NOT_DUE reconciliation used an unrelated broker read'))
     const brokerRead: BrokerReadShape = {
       account: Effect.sync(() => {
@@ -1155,7 +1160,15 @@ describe('OBSERVE runtime composition', () => {
       marketCalendar: (query) => {
         expect(query).toEqual(calendarMaterial.requestedRange)
         calendarReads += 1
-        return Effect.succeed({ value: ordinaryCalendar, evidence: readEvidence('calendar') })
+        if (!mutationPhase) {
+          return Effect.succeed({ value: ordinaryCalendar, evidence: readEvidence('calendar') })
+        }
+        mutationCalendarReads += 1
+        mutationEvents.push(`calendar:${mutationCalendarReads.toString()}`)
+        const result = { value: ordinaryCalendar, evidence: readEvidence('calendar') }
+        return mutationCalendarReads === 2 && secondMutationCalendarRead !== undefined
+          ? Deferred.succeed(secondMutationCalendarRead, undefined).pipe(Effect.as(result))
+          : Effect.succeed(result)
       },
     }
     const inspection = {
@@ -1238,6 +1251,10 @@ describe('OBSERVE runtime composition', () => {
       reconcile: (brokerSnapshot: BrokerSnapshot) =>
         Effect.sync(() => {
           reconciledSnapshots.push(brokerSnapshot)
+          if (mutationPhase) {
+            mutationReconciliations += 1
+            mutationEvents.push(`reconcile:${mutationReconciliations.toString()}`)
+          }
           return persisted
         }),
       ensureAuthorityGeneration: () => {
@@ -1326,7 +1343,7 @@ describe('OBSERVE runtime composition', () => {
     const mutationStartup = makeMutationAutonomousCycleStartup({
       accountId,
       authorityGenerationHash: generationHash,
-      pollIntervalMs: 350,
+      pollIntervalMs: 100,
       reconciliationIntervalMs: 100,
       reconciliationPassTimeoutMs: 30_000,
       strategy: fixtureStrategy,
@@ -1335,17 +1352,20 @@ describe('OBSERVE runtime composition', () => {
     const intentStore = {} as IntentStoreService
     const mutationStore = {} as MutationStoreShape
     const mutationObservations: Parameters<Parameters<typeof mutationStartup>[0]['recordPass']>[0][] = []
+    mutationPhase = true
     await Effect.runPromise(
       Effect.scoped(
         Effect.gen(function* () {
           yield* TestClock.setTime(Date.parse(reconciledAt))
           const first = yield* Deferred.make<void>()
           const second = yield* Deferred.make<void>()
+          secondMutationCalendarRead = yield* Deferred.make<void>()
           const loop = yield* mutationStartup({
             qualificationRunId: 'c'.repeat(64),
             recordPass: (result) =>
               Effect.sync(() => {
                 mutationObservations.push(result)
+                mutationEvents.push(`observe:${mutationObservations.length.toString()}`)
                 return mutationObservations.length === 1
                   ? first
                   : mutationObservations.length === 2
@@ -1373,18 +1393,24 @@ describe('OBSERVE runtime composition', () => {
             Effect.forkScoped({ startImmediately: true }),
           )
           yield* Deferred.await(first).pipe(Effect.timeout('1 second'))
-          yield* TestClock.adjust(101)
+          yield* TestClock.adjust(100)
+          yield* Deferred.await(secondMutationCalendarRead).pipe(Effect.timeout('1 second'))
           yield* Deferred.await(second).pipe(Effect.timeout('1 second'))
           yield* Fiber.interrupt(fiber)
         }),
       ).pipe(Effect.provide(TestClock.layer())),
     )
+    mutationPhase = false
 
-    expect(mutationObservations).toHaveLength(2)
+    expect(mutationObservations.length).toBeGreaterThanOrEqual(2)
     expect(mutationObservations[0]).toMatchObject({ result: 'SUCCESS', outcome: 'NOT_DUE' })
     expect(mutationObservations[1]).toMatchObject({ result: 'SUCCESS', outcome: 'NOT_DUE' })
+    expect(mutationEvents.indexOf('reconcile:2')).toBeLessThan(mutationEvents.indexOf('calendar:2'))
+    expect(mutationEvents.indexOf('observe:2')).toBeLessThan(mutationEvents.indexOf('calendar:2'))
+    expect(mutationCalendarReads).toBe(2)
+    expect(mutationReconciliations).toBe(2)
     expect(acquisitions).toBe(0)
-    expect(calendarReads).toBe(2)
+    expect(calendarReads).toBe(3)
     expect(accountReads).toBe(3)
     expect(positionReads).toBe(3)
     expect(orderReads).toBe(6)

--- a/services/bayn/src/observe-composition.ts
+++ b/services/bayn/src/observe-composition.ts
@@ -1,4 +1,4 @@
-import { Clock, Data, Deferred, Duration, Effect, Fiber, Option, pipe, Ref, Result } from 'effect'
+import { Clock, Data, Duration, Effect, Option, pipe, Ref, Result } from 'effect'
 
 import type { AutonomousCycleLoop, AutonomousCycleStartup } from './app'
 import { BrokerRead, type BrokerReadShape, type MarketCalendarQuery } from './broker/alpaca'
@@ -136,23 +136,12 @@ const mutationCyclePassTimeoutError = (timeoutMs: number): CycleRunnerError =>
 
 const runMutationPassWithinTimeout = <A, E, R>(
   effect: Effect.Effect<A, E, R>,
-  reconciliationCompleted: Deferred.Deferred<void>,
   timeoutMs: number,
 ): Effect.Effect<A, E | CycleRunnerError, R> =>
-  Effect.scoped(
-    Effect.gen(function* () {
-      const fiber = yield* effect.pipe(Effect.forkScoped)
-      const outcome = yield* Effect.raceFirst(
-        Fiber.await(fiber).pipe(Effect.map((exit) => ({ _tag: 'PassCompleted' as const, exit }))),
-        Effect.raceFirst(
-          Deferred.await(reconciliationCompleted).pipe(Effect.as({ _tag: 'Reconciled' as const })),
-          Effect.sleep(Duration.millis(timeoutMs)).pipe(Effect.as({ _tag: 'TimedOut' as const })),
-        ),
-      )
-      if (outcome._tag === 'PassCompleted') return yield* outcome.exit
-      if (outcome._tag === 'Reconciled') return yield* Fiber.join(fiber)
-      yield* Fiber.interrupt(fiber)
-      return yield* Effect.fail(mutationCyclePassTimeoutError(timeoutMs))
+  effect.pipe(
+    Effect.timeoutOrElse({
+      duration: Duration.millis(timeoutMs),
+      orElse: () => Effect.fail(mutationCyclePassTimeoutError(timeoutMs)),
     }),
   )
 
@@ -1502,8 +1491,6 @@ const mutationCycleLoop = (
     const run = (): Effect.Effect<void, never, MutationRuntime> =>
       Effect.suspend(() =>
         Effect.gen(function* () {
-          const reconciliationCompleted = yield* Deferred.make<void>()
-          const passReconcile = reconcile.pipe(Effect.tap(() => Deferred.succeed(reconciliationCompleted, undefined)))
           const context: CycleRunContext<ObserveDecisionRuntime> = {
             qualificationRunId: startup.qualificationRunId,
             strategyProtocolHash: preparation.strategyProtocolHash,
@@ -1511,12 +1498,11 @@ const mutationCycleLoop = (
             executionPolicy: preparation.executionPolicy,
             buildDecision: (cycle) =>
               buildMutationShadowCycleDecision(
-                mutationDecisionInput(input, preparation, policy, cycle, passReconcile),
+                mutationDecisionInput(input, preparation, policy, cycle, reconcile),
               ).pipe(Effect.mapError(decisionBuildError)),
           }
           return yield* runMutationPassWithinTimeout(
-            runMutationCyclePass(input, preparation, policy, context, passReconcile),
-            reconciliationCompleted,
+            runMutationCyclePass(input, preparation, policy, context, reconcile),
             cyclePassTimeoutMs,
           )
         }).pipe(

--- a/services/bayn/src/observe-composition.ts
+++ b/services/bayn/src/observe-composition.ts
@@ -1,4 +1,4 @@
-import { Clock, Duration, Effect, Option, pipe, Ref, Result } from 'effect'
+import { Clock, Data, Duration, Effect, Option, pipe, Ref, Result } from 'effect'
 
 import type { AutonomousCycleLoop, AutonomousCycleStartup } from './app'
 import { BrokerRead, type BrokerReadShape, type MarketCalendarQuery } from './broker/alpaca'
@@ -40,7 +40,7 @@ import {
 } from './execution-session'
 import { makeFillTerms, MICROS } from './execution-model'
 import { makeStrategyProtocolHash } from './contracts'
-import { operationalError, type OperationalError } from './errors'
+import { OperationalError, operationalError } from './errors'
 import { canonicalHashV1Result } from './hash'
 import { MarketData, type MarketDataService } from './market-data'
 import {
@@ -103,7 +103,28 @@ export const loadObserveRiskPolicy = (accountId: string, allowedSymbols: readonl
 
 type ObserveStrategy = Pick<Strategy, 'currentDecision'>
 
-type ReconciliationPassError = Effect.Error<typeof runOnce>
+class ReconciliationPassTimeoutError extends Data.TaggedError('ReconciliationPassTimeoutError')<{
+  readonly timeoutMs: number
+  readonly message: string
+}> {}
+
+type ReconciliationPassError = Effect.Error<typeof runOnce> | ReconciliationPassTimeoutError
+
+const boundedReconciliationPass = (
+  timeoutMs: number,
+): Effect.Effect<ReconciliationPassResult, ReconciliationPassError, ObserveDecisionRuntime> =>
+  runOnce.pipe(
+    Effect.timeoutOrElse({
+      duration: timeoutMs,
+      orElse: () =>
+        Effect.fail(
+          new ReconciliationPassTimeoutError({
+            timeoutMs,
+            message: `same-pass broker reconciliation timed out after ${timeoutMs.toString()}ms`,
+          }),
+        ),
+    }),
+  )
 
 export type ObserveDecisionInput<R = never> = {
   readonly authorityGenerationHash: string
@@ -183,6 +204,14 @@ const reconciliationOperationalError = (cause: ReconciliationPassError): Operati
       return operationalError('strategy', 'reconciliation', 'same-pass reconciliation failed', cause)
     case 'WriterFenceError':
       return operationalError('database', 'reconciliation', 'same-pass reconciliation fence operation failed', cause)
+    case 'ReconciliationPassTimeoutError':
+      return new OperationalError({
+        component: 'market-data',
+        operation: 'reconciliation',
+        message: cause.message,
+        retryable: false,
+        cause,
+      })
   }
 }
 
@@ -556,6 +585,7 @@ export type ObserveAutonomousCycleInput = {
   readonly authorityGenerationHash: string
   readonly pollIntervalMs: number
   readonly reconciliationIntervalMs: number
+  readonly reconciliationPassTimeoutMs: number
   readonly strategy: Pick<Strategy, 'currentDecision' | 'parameters' | 'provenance'>
 }
 
@@ -632,6 +662,7 @@ const makeObserveAutonomousLoop = (
   preparation: ObserveStartupPreparation,
   policy: Policy,
 ): Result.Result<AutonomousCycleLoop<ObserveRuntime>, OperationalError> => {
+  const reconcile = boundedReconciliationPass(input.reconciliationPassTimeoutMs)
   const context: CycleRunContext<ObserveDecisionRuntime> = {
     qualificationRunId: startup.qualificationRunId,
     strategyProtocolHash: preparation.strategyProtocolHash,
@@ -643,7 +674,7 @@ const makeObserveAutonomousLoop = (
         cycle,
         executionModel: preparation.executionModel,
         policy,
-        reconcile: runOnce,
+        reconcile,
         strategy: input.strategy,
       }).pipe(Effect.mapError(decisionBuildError)),
   }
@@ -653,7 +684,7 @@ const makeObserveAutonomousLoop = (
       observePass: (observation) => observePass(startup.recordPass, observation),
       pollIntervalMs: input.pollIntervalMs,
       reconciliationIntervalMs: input.reconciliationIntervalMs,
-      reconcileNotDue: runOnce.pipe(Effect.mapError(notDueReconciliationError), Effect.asVoid),
+      reconcileNotDue: reconcile.pipe(Effect.mapError(notDueReconciliationError), Effect.asVoid),
     }),
     Result.mapError((cause) =>
       operationalError('strategy', 'cycle-loop', 'autonomous cycle loop failed to start', cause),
@@ -1348,7 +1379,9 @@ const mutationCycleLoop = (
 ): Effect.Effect<void, never, MutationRuntime> =>
   Effect.gen(function* () {
     const cadence = yield* Ref.make<ReconciliationCadenceState>({})
-    const reconcile = runOnce.pipe(Effect.tap(() => markMutationReconciliationCompleted(cadence)))
+    const reconcile = boundedReconciliationPass(input.reconciliationPassTimeoutMs).pipe(
+      Effect.tap(() => markMutationReconciliationCompleted(cadence)),
+    )
     const context: CycleRunContext<ObserveDecisionRuntime> = {
       qualificationRunId: startup.qualificationRunId,
       strategyProtocolHash: preparation.strategyProtocolHash,

--- a/services/bayn/src/observe-composition.ts
+++ b/services/bayn/src/observe-composition.ts
@@ -11,6 +11,7 @@ import {
   makeAutonomousCycleLoop,
   marketCalendarQueryForSignal,
   runAutonomousCyclePass,
+  shouldDeferCyclePollForReconciliation,
   validateCyclePassTimeout,
   validateReconciliationInterval,
   type CycleRunContext,
@@ -1409,8 +1410,13 @@ const waitUntilNextMutationPoll = (
       const pollStartAtNanos = nowNanos > nextPollAtNanos ? nowNanos : nextPollAtNanos
       const cyclePassTimeoutMs = Math.min(input.reconciliationPassTimeoutMs, input.reconciliationIntervalMs)
       if (
-        pollStartAtNanos < reconciliationAtNanos &&
-        pollStartAtNanos + mutationIntervalNanos(cyclePassTimeoutMs) > reconciliationAtNanos
+        shouldDeferCyclePollForReconciliation({
+          lastAttemptAtNanos: state.lastAttemptAtNanos,
+          nextPollAtNanos,
+          pollStartAtNanos,
+          reconciliationAtNanos,
+          cyclePassTimeoutNanos: mutationIntervalNanos(cyclePassTimeoutMs),
+        })
       ) {
         yield* mutationSleepUntil(reconciliationAtNanos)
         return yield* waitUntilNextMutationPoll(input, startup, cadence, reconcile, result, nextPollAtNanos)

--- a/services/bayn/src/observe-composition.ts
+++ b/services/bayn/src/observe-composition.ts
@@ -1341,15 +1341,15 @@ const waitUntilNextMutationPoll = (
   Effect.suspend(() =>
     Effect.gen(function* () {
       const nowNanos = yield* Clock.currentTimeNanos
-      if (nowNanos >= nextPollAtNanos) return
       const state = yield* Ref.get(cadence)
       const decision = decideIdleReconciliationCadence(state, nowNanos, input.reconciliationIntervalMs)
       if (decision._tag === 'RECONCILE') {
         yield* observeMutationIdleReconciliation(input, startup, cadence, reconcile, result)
         return yield* waitUntilNextMutationPoll(input, startup, cadence, reconcile, result, nextPollAtNanos)
       }
+      if (nowNanos >= nextPollAtNanos) return
       const reconciliationAtNanos = nowNanos + decision.remainingNanos
-      if (nextPollAtNanos <= reconciliationAtNanos) return yield* mutationSleepUntil(nextPollAtNanos)
+      if (nextPollAtNanos < reconciliationAtNanos) return yield* mutationSleepUntil(nextPollAtNanos)
       yield* mutationSleepUntil(reconciliationAtNanos)
       return yield* waitUntilNextMutationPoll(input, startup, cadence, reconcile, result, nextPollAtNanos)
     }),

--- a/services/bayn/src/observe-composition.ts
+++ b/services/bayn/src/observe-composition.ts
@@ -1401,6 +1401,27 @@ const waitAfterMutationPass = (
     }),
   )
 
+const observeMutationCycleResult = (
+  input: MutationAutonomousCycleInput,
+  startup: Parameters<AutonomousCycleStartup>[0],
+  cadence: Ref.Ref<ReconciliationCadenceState>,
+  reconcile: Effect.Effect<ReconciliationPassResult, ReconciliationPassError, ObserveDecisionRuntime>,
+  result: CycleRunResult,
+): Effect.Effect<void, never, ObserveDecisionRuntime> =>
+  result.outcome === 'NOT_DUE'
+    ? observeMutationIdleReconciliation(input, startup, cadence, reconcile, result)
+    : Ref.get(cadence).pipe(
+        Effect.flatMap((state) =>
+          currentUtcInstant.pipe(
+            Effect.flatMap((observedAt) =>
+              state.lastFailure === undefined
+                ? observeMutationPass(startup, { outcome: 'SUCCEEDED', observedAt, result })
+                : observeMutationPass(startup, { outcome: 'FAILED', observedAt, error: state.lastFailure }),
+            ),
+          ),
+        ),
+      )
+
 const mutationCycleLoop = (
   input: MutationAutonomousCycleInput,
   startup: Parameters<AutonomousCycleStartup>[0],
@@ -1433,14 +1454,7 @@ const mutationCycleLoop = (
                 Effect.andThen(run()),
               ),
             onSuccess: (result) =>
-              (result.outcome === 'NOT_DUE'
-                ? observeMutationIdleReconciliation(input, startup, cadence, reconcile, result)
-                : currentUtcInstant.pipe(
-                    Effect.flatMap((observedAt) =>
-                      observeMutationPass(startup, { outcome: 'SUCCEEDED', observedAt, result }),
-                    ),
-                  )
-              ).pipe(
+              observeMutationCycleResult(input, startup, cadence, reconcile, result).pipe(
                 Effect.andThen(waitAfterMutationPass(input, startup, cadence, reconcile, result)),
                 Effect.andThen(run()),
               ),

--- a/services/bayn/src/observe-composition.ts
+++ b/services/bayn/src/observe-composition.ts
@@ -1,4 +1,4 @@
-import { Clock, Data, Duration, Effect, Option, pipe, Ref, Result } from 'effect'
+import { Clock, Data, Deferred, Duration, Effect, Fiber, Option, pipe, Ref, Result } from 'effect'
 
 import type { AutonomousCycleLoop, AutonomousCycleStartup } from './app'
 import { BrokerRead, type BrokerReadShape, type MarketCalendarQuery } from './broker/alpaca'
@@ -11,6 +11,7 @@ import {
   makeAutonomousCycleLoop,
   marketCalendarQueryForSignal,
   runAutonomousCyclePass,
+  validateCyclePassTimeout,
   validateReconciliationInterval,
   type CycleRunContext,
   type CyclePassObservation,
@@ -123,6 +124,35 @@ const boundedReconciliationPass = (
             message: `same-pass broker reconciliation timed out after ${timeoutMs.toString()}ms`,
           }),
         ),
+    }),
+  )
+
+const mutationCyclePassTimeoutError = (timeoutMs: number): CycleRunnerError =>
+  new CycleRunnerError({
+    operation: 'run-cycle-pass',
+    failure: 'operational',
+    message: `mutation autonomous cycle pass did not complete or reconcile within ${timeoutMs.toString()}ms`,
+  })
+
+const runMutationPassWithinTimeout = <A, E, R>(
+  effect: Effect.Effect<A, E, R>,
+  reconciliationCompleted: Deferred.Deferred<void>,
+  timeoutMs: number,
+): Effect.Effect<A, E | CycleRunnerError, R> =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const fiber = yield* effect.pipe(Effect.forkScoped)
+      const outcome = yield* Effect.raceFirst(
+        Fiber.await(fiber).pipe(Effect.map((exit) => ({ _tag: 'PassCompleted' as const, exit }))),
+        Effect.raceFirst(
+          Deferred.await(reconciliationCompleted).pipe(Effect.as({ _tag: 'Reconciled' as const })),
+          Effect.sleep(Duration.millis(timeoutMs)).pipe(Effect.as({ _tag: 'TimedOut' as const })),
+        ),
+      )
+      if (outcome._tag === 'PassCompleted') return yield* outcome.exit
+      if (outcome._tag === 'Reconciled') return yield* Fiber.join(fiber)
+      yield* Fiber.interrupt(fiber)
+      return yield* Effect.fail(mutationCyclePassTimeoutError(timeoutMs))
     }),
   )
 
@@ -668,13 +698,13 @@ const makeObserveAutonomousLoop = (
     strategyProtocolHash: preparation.strategyProtocolHash,
     accountId: input.accountId,
     executionPolicy: preparation.executionPolicy,
-    buildDecision: (cycle) =>
+    buildDecision: (cycle, reconciliationCompleted = Effect.void) =>
       buildObserveCycleDecision({
         authorityGenerationHash: input.authorityGenerationHash,
         cycle,
         executionModel: preparation.executionModel,
         policy,
-        reconcile,
+        reconcile: reconcile.pipe(Effect.tap(() => reconciliationCompleted)),
         strategy: input.strategy,
       }).pipe(Effect.mapError(decisionBuildError)),
   }
@@ -682,6 +712,7 @@ const makeObserveAutonomousLoop = (
     makeAutonomousCycleLoop({
       context: Effect.succeed(context),
       observePass: (observation) => observePass(startup.recordPass, observation),
+      cyclePassTimeoutMs: Math.min(input.reconciliationPassTimeoutMs, input.reconciliationIntervalMs),
       pollIntervalMs: input.pollIntervalMs,
       reconciliationIntervalMs: input.reconciliationIntervalMs,
       reconcileNotDue: reconcile.pipe(Effect.mapError(notDueReconciliationError), Effect.asVoid),
@@ -1345,13 +1376,13 @@ const observeMutationCadenceReconciliation = (
   startup: Parameters<AutonomousCycleStartup>[0],
   cadence: Ref.Ref<ReconciliationCadenceState>,
   reconcile: Effect.Effect<ReconciliationPassResult, ReconciliationPassError, ObserveDecisionRuntime>,
-  result: CycleRunResult,
+  result: CycleRunResult | undefined,
 ): Effect.Effect<void, never, ObserveDecisionRuntime> =>
   Ref.get(cadence).pipe(
     Effect.flatMap((state) =>
       attemptMutationIdleReconciliation(cadence, reconcile).pipe(
         Effect.flatMap(() =>
-          result.outcome === 'NOT_DUE' || state.lastFailure !== undefined
+          result !== undefined && (result.outcome === 'NOT_DUE' || state.lastFailure !== undefined)
             ? currentUtcInstant.pipe(
                 Effect.flatMap((observedAt) =>
                   observeMutationPass(startup, { outcome: 'SUCCEEDED', observedAt, result }),
@@ -1373,7 +1404,7 @@ const waitUntilNextMutationPoll = (
   startup: Parameters<AutonomousCycleStartup>[0],
   cadence: Ref.Ref<ReconciliationCadenceState>,
   reconcile: Effect.Effect<ReconciliationPassResult, ReconciliationPassError, ObserveDecisionRuntime>,
-  result: CycleRunResult,
+  result: CycleRunResult | undefined,
   nextPollAtNanos: bigint,
 ): Effect.Effect<void, never, ObserveDecisionRuntime> =>
   Effect.suspend(() =>
@@ -1385,8 +1416,17 @@ const waitUntilNextMutationPoll = (
         yield* observeMutationCadenceReconciliation(startup, cadence, reconcile, result)
         return yield* waitUntilNextMutationPoll(input, startup, cadence, reconcile, result, nextPollAtNanos)
       }
-      if (nowNanos >= nextPollAtNanos) return
       const reconciliationAtNanos = nowNanos + decision.remainingNanos
+      const pollStartAtNanos = nowNanos > nextPollAtNanos ? nowNanos : nextPollAtNanos
+      const cyclePassTimeoutMs = Math.min(input.reconciliationPassTimeoutMs, input.reconciliationIntervalMs)
+      if (
+        pollStartAtNanos < reconciliationAtNanos &&
+        pollStartAtNanos + mutationIntervalNanos(cyclePassTimeoutMs) > reconciliationAtNanos
+      ) {
+        yield* mutationSleepUntil(reconciliationAtNanos)
+        return yield* waitUntilNextMutationPoll(input, startup, cadence, reconcile, result, nextPollAtNanos)
+      }
+      if (nowNanos >= nextPollAtNanos) return
       if (nextPollAtNanos < reconciliationAtNanos) return yield* mutationSleepUntil(nextPollAtNanos)
       yield* mutationSleepUntil(reconciliationAtNanos)
       return yield* waitUntilNextMutationPoll(input, startup, cadence, reconcile, result, nextPollAtNanos)
@@ -1405,6 +1445,25 @@ const waitAfterMutationPass = (
       const nextPollAtNanos = completedAtNanos + mutationIntervalNanos(input.pollIntervalMs)
       return waitUntilNextMutationPoll(input, startup, cadence, reconcile, result, nextPollAtNanos)
     }),
+  )
+
+const waitAfterMutationFailure = (
+  input: MutationAutonomousCycleInput,
+  startup: Parameters<AutonomousCycleStartup>[0],
+  cadence: Ref.Ref<ReconciliationCadenceState>,
+  reconcile: Effect.Effect<ReconciliationPassResult, ReconciliationPassError, ObserveDecisionRuntime>,
+): Effect.Effect<void, never, ObserveDecisionRuntime> =>
+  Clock.currentTimeNanos.pipe(
+    Effect.flatMap((completedAtNanos) =>
+      waitUntilNextMutationPoll(
+        input,
+        startup,
+        cadence,
+        reconcile,
+        undefined,
+        completedAtNanos + mutationIntervalNanos(input.pollIntervalMs),
+      ),
+    ),
   )
 
 const observeMutationCycleResult = (
@@ -1436,27 +1495,36 @@ const mutationCycleLoop = (
 ): Effect.Effect<void, never, MutationRuntime> =>
   Effect.gen(function* () {
     const cadence = yield* Ref.make<ReconciliationCadenceState>({})
+    const cyclePassTimeoutMs = Math.min(input.reconciliationPassTimeoutMs, input.reconciliationIntervalMs)
     const reconcile = boundedReconciliationPass(input.reconciliationPassTimeoutMs).pipe(
       Effect.tap(() => markMutationReconciliationCompleted(cadence)),
     )
-    const context: CycleRunContext<ObserveDecisionRuntime> = {
-      qualificationRunId: startup.qualificationRunId,
-      strategyProtocolHash: preparation.strategyProtocolHash,
-      accountId: input.accountId,
-      executionPolicy: preparation.executionPolicy,
-      buildDecision: (cycle) =>
-        buildMutationShadowCycleDecision(mutationDecisionInput(input, preparation, policy, cycle, reconcile)).pipe(
-          Effect.mapError(decisionBuildError),
-        ),
-    }
     const run = (): Effect.Effect<void, never, MutationRuntime> =>
       Effect.suspend(() =>
-        runMutationCyclePass(input, preparation, policy, context, reconcile).pipe(
+        Effect.gen(function* () {
+          const reconciliationCompleted = yield* Deferred.make<void>()
+          const passReconcile = reconcile.pipe(Effect.tap(() => Deferred.succeed(reconciliationCompleted, undefined)))
+          const context: CycleRunContext<ObserveDecisionRuntime> = {
+            qualificationRunId: startup.qualificationRunId,
+            strategyProtocolHash: preparation.strategyProtocolHash,
+            accountId: input.accountId,
+            executionPolicy: preparation.executionPolicy,
+            buildDecision: (cycle) =>
+              buildMutationShadowCycleDecision(
+                mutationDecisionInput(input, preparation, policy, cycle, passReconcile),
+              ).pipe(Effect.mapError(decisionBuildError)),
+          }
+          return yield* runMutationPassWithinTimeout(
+            runMutationCyclePass(input, preparation, policy, context, passReconcile),
+            reconciliationCompleted,
+            cyclePassTimeoutMs,
+          )
+        }).pipe(
           Effect.matchEffect({
             onFailure: (error) =>
               currentUtcInstant.pipe(
                 Effect.flatMap((observedAt) => observeMutationPass(startup, { outcome: 'FAILED', observedAt, error })),
-                Effect.andThen(Effect.sleep(Duration.millis(input.pollIntervalMs))),
+                Effect.andThen(waitAfterMutationFailure(input, startup, cadence, reconcile)),
                 Effect.andThen(run()),
               ),
             onSuccess: (result) =>
@@ -1476,9 +1544,11 @@ const makeMutationAutonomousLoop = (
   preparation: ObserveStartupPreparation,
   policy: Policy,
 ): Result.Result<AutonomousCycleLoop<MutationRuntime>, OperationalError> => {
+  const cyclePassTimeoutMs = Math.min(input.reconciliationPassTimeoutMs, input.reconciliationIntervalMs)
   return Result.mapError(
     Result.map(validateCycleLoopInterval(input.pollIntervalMs), () => input.reconciliationIntervalMs).pipe(
       Result.flatMap(validateReconciliationInterval),
+      Result.flatMap(() => validateCyclePassTimeout(cyclePassTimeoutMs, input.reconciliationIntervalMs)),
       Result.map(() => mutationCycleLoop(input, startup, preparation, policy)),
     ),
     (cause) => operationalError('strategy', 'cycle-loop', 'mutation autonomous cycle loop failed to start', cause),

--- a/services/bayn/src/observe-composition.ts
+++ b/services/bayn/src/observe-composition.ts
@@ -1,4 +1,4 @@
-import { Duration, Effect, Option, pipe, Result, Schedule } from 'effect'
+import { Clock, Duration, Effect, Option, pipe, Ref, Result } from 'effect'
 
 import type { AutonomousCycleLoop, AutonomousCycleStartup } from './app'
 import { BrokerRead, type BrokerReadShape, type MarketCalendarQuery } from './broker/alpaca'
@@ -7,15 +7,17 @@ import {
   CycleDecisionBuildError,
   CycleRunnerError,
   cyclePassLogFacts,
+  decideIdleReconciliationCadence,
   makeAutonomousCycleLoop,
   marketCalendarQueryForSignal,
   runAutonomousCyclePass,
+  validateReconciliationInterval,
   type CycleRunContext,
   type CyclePassObservation,
   type CycleRunResult,
 } from './cycle-runner'
 import { validateCycleLoopInterval } from './cycle-runner/decisions'
-import { CycleNotDueReconciliationError } from './cycle-runner/model'
+import { CycleNotDueReconciliationError, type ReconciliationCadenceState } from './cycle-runner/model'
 import { CycleStore } from './db/cycle-store'
 import {
   BrokerEventStore,
@@ -553,6 +555,7 @@ export type ObserveAutonomousCycleInput = {
   readonly accountId: string
   readonly authorityGenerationHash: string
   readonly pollIntervalMs: number
+  readonly reconciliationIntervalMs: number
   readonly strategy: Pick<Strategy, 'currentDecision' | 'parameters' | 'provenance'>
 }
 
@@ -649,6 +652,7 @@ const makeObserveAutonomousLoop = (
       context: Effect.succeed(context),
       observePass: (observation) => observePass(startup.recordPass, observation),
       pollIntervalMs: input.pollIntervalMs,
+      reconciliationIntervalMs: input.reconciliationIntervalMs,
       reconcileNotDue: runOnce.pipe(Effect.mapError(notDueReconciliationError), Effect.asVoid),
     }),
     Result.mapError((cause) =>
@@ -825,12 +829,13 @@ const mutationDecisionInput = (
   preparation: ObserveStartupPreparation,
   policy: Policy,
   cycle: AutonomousCycle,
+  reconcile: Effect.Effect<ReconciliationPassResult, ReconciliationPassError, ObserveDecisionRuntime>,
 ): ObserveDecisionInput<ObserveDecisionRuntime> => ({
   authorityGenerationHash: input.authorityGenerationHash,
   cycle,
   executionModel: preparation.executionModel,
   policy,
-  reconcile: runOnce,
+  reconcile,
   strategy: input.strategy,
 })
 
@@ -910,12 +915,13 @@ const prepareNextMutationIntent = (
   policy: Policy,
   cycle: AutonomousCycle,
   document: ObserveShadowDecisionDocument,
+  reconcile: Effect.Effect<ReconciliationPassResult, ReconciliationPassError, ObserveDecisionRuntime>,
 ): Effect.Effect<string | undefined, CycleRunnerError, ObserveDecisionRuntime | IntentStore | MutationStore> =>
   Effect.gen(function* () {
     yield* Effect.fromResult(validateBoundMutationDocument(input, cycle, policy, document))
     if (document.targetPlan.status !== TargetPlanStatus.Planned) return undefined
 
-    const decisionInput = mutationDecisionInput(input, preparation, policy, cycle)
+    const decisionInput = mutationDecisionInput(input, preparation, policy, cycle, reconcile)
     const reads = yield* Effect.fromResult(prepareObserveDecisionReads(decisionInput)).pipe(
       Effect.mapError((cause) => mutationRunnerError('mutation cycle decision reads are invalid', cause, 'contract')),
     )
@@ -1142,6 +1148,7 @@ const executeBoundMutationCycle = (
   preparation: ObserveStartupPreparation,
   policy: Policy,
   cycle: AutonomousCycle,
+  reconcile: Effect.Effect<ReconciliationPassResult, ReconciliationPassError, ObserveDecisionRuntime>,
 ): Effect.Effect<void, CycleRunnerError, MutationRuntime> =>
   readBoundMutationDocument(cycle).pipe(
     Effect.flatMap((document) =>
@@ -1149,7 +1156,7 @@ const executeBoundMutationCycle = (
         const maximumPasses =
           document.targetPlan.status === TargetPlanStatus.Planned ? document.targetPlan.intentTargets.length + 1 : 1
         for (let pass = 0; pass < maximumPasses; pass += 1) {
-          const intentId = yield* prepareNextMutationIntent(input, preparation, policy, cycle, document)
+          const intentId = yield* prepareNextMutationIntent(input, preparation, policy, cycle, document, reconcile)
           if (intentId === undefined) return
           const executed = yield* executeMutationIntent(input.executionProgram, intentId)
           const delayMs = mutationIntentReconciliationDelayMs(executed)
@@ -1184,17 +1191,18 @@ const runMutationCyclePass = (
   preparation: ObserveStartupPreparation,
   policy: Policy,
   context: CycleRunContext<ObserveDecisionRuntime>,
+  reconcile: Effect.Effect<ReconciliationPassResult, ReconciliationPassError, ObserveDecisionRuntime>,
 ): Effect.Effect<CycleRunResult, CycleRunnerError, MutationRuntime> =>
   readUnfinishedMutationCycle(context).pipe(
     Effect.flatMap((unfinished) =>
       mutationBound(unfinished)
-        ? executeBoundMutationCycle(input, preparation, policy, unfinished).pipe(
+        ? executeBoundMutationCycle(input, preparation, policy, unfinished, reconcile).pipe(
             Effect.andThen(runAutonomousCyclePass(context)),
           )
         : runAutonomousCyclePass(context).pipe(
             Effect.flatMap((result) =>
               result.outcome === 'RECOVERED' && result.action === 'BOUND_DECISION'
-                ? executeBoundMutationCycle(input, preparation, policy, result.cycle).pipe(
+                ? executeBoundMutationCycle(input, preparation, policy, result.cycle, reconcile).pipe(
                     Effect.andThen(runAutonomousCyclePass(context)),
                   )
                 : Effect.succeed(result),
@@ -1214,27 +1222,170 @@ const observeMutationPass = (
   )
 }
 
+const mutationNanosPerMillisecond = 1_000_000n
+
+const mutationIntervalNanos = (intervalMs: number): bigint => BigInt(intervalMs) * mutationNanosPerMillisecond
+
+const mutationSleepUntil = (deadlineNanos: bigint): Effect.Effect<void> =>
+  Clock.currentTimeNanos.pipe(
+    Effect.flatMap((nowNanos) => {
+      const remainingNanos = deadlineNanos - nowNanos
+      if (remainingNanos <= 0n) return Effect.void
+      const remainingMs = Number((remainingNanos + mutationNanosPerMillisecond - 1n) / mutationNanosPerMillisecond)
+      return Effect.sleep(Duration.millis(remainingMs))
+    }),
+  )
+
+const mutationIdleReconciliationError = (cause: ReconciliationPassError): CycleRunnerError => {
+  const converted = notDueReconciliationError(cause)
+  return new CycleRunnerError({
+    operation: 'reconcile-not-due',
+    failure: converted.failure,
+    message: converted.message,
+    cause: converted,
+  })
+}
+
+const markMutationReconciliationCompleted = (cadence: Ref.Ref<ReconciliationCadenceState>): Effect.Effect<void> =>
+  Clock.currentTimeNanos.pipe(Effect.flatMap((lastAttemptAtNanos) => Ref.set(cadence, { lastAttemptAtNanos })))
+
+const reconcileMutationNotDuePass = (
+  input: MutationAutonomousCycleInput,
+  cadence: Ref.Ref<ReconciliationCadenceState>,
+  reconcile: Effect.Effect<ReconciliationPassResult, ReconciliationPassError, ObserveDecisionRuntime>,
+  result: CycleRunResult,
+): Effect.Effect<CycleRunResult, CycleRunnerError, ObserveDecisionRuntime> => {
+  if (result.outcome !== 'NOT_DUE') return Effect.succeed(result)
+  return Effect.gen(function* () {
+    const nowNanos = yield* Clock.currentTimeNanos
+    const state = yield* Ref.get(cadence)
+    const decision = decideIdleReconciliationCadence(state, nowNanos, input.reconciliationIntervalMs)
+    if (decision._tag === 'WAIT') {
+      if (state.lastFailure !== undefined) return yield* Effect.fail(state.lastFailure)
+      return result
+    }
+    yield* Ref.set(cadence, { lastAttemptAtNanos: nowNanos })
+    yield* reconcile.pipe(
+      Effect.mapError(mutationIdleReconciliationError),
+      Effect.tapError((lastFailure) =>
+        Clock.currentTimeNanos.pipe(
+          Effect.flatMap((lastAttemptAtNanos) => Ref.set(cadence, { lastAttemptAtNanos, lastFailure })),
+        ),
+      ),
+    )
+    return result
+  })
+}
+
+const observeMutationIdleReconciliation = (
+  input: MutationAutonomousCycleInput,
+  startup: Parameters<AutonomousCycleStartup>[0],
+  cadence: Ref.Ref<ReconciliationCadenceState>,
+  reconcile: Effect.Effect<ReconciliationPassResult, ReconciliationPassError, ObserveDecisionRuntime>,
+  result: Extract<CycleRunResult, { readonly outcome: 'NOT_DUE' }>,
+): Effect.Effect<void, never, ObserveDecisionRuntime> =>
+  reconcileMutationNotDuePass(input, cadence, reconcile, result).pipe(
+    Effect.flatMap((reconciled) =>
+      currentUtcInstant.pipe(
+        Effect.flatMap((observedAt) =>
+          observeMutationPass(startup, { outcome: 'SUCCEEDED', observedAt, result: reconciled }),
+        ),
+      ),
+    ),
+    Effect.catch((error) =>
+      currentUtcInstant.pipe(
+        Effect.flatMap((observedAt) => observeMutationPass(startup, { outcome: 'FAILED', observedAt, error })),
+      ),
+    ),
+  )
+
+const waitUntilNextMutationPoll = (
+  input: MutationAutonomousCycleInput,
+  startup: Parameters<AutonomousCycleStartup>[0],
+  cadence: Ref.Ref<ReconciliationCadenceState>,
+  reconcile: Effect.Effect<ReconciliationPassResult, ReconciliationPassError, ObserveDecisionRuntime>,
+  result: Extract<CycleRunResult, { readonly outcome: 'NOT_DUE' }>,
+  nextPollAtNanos: bigint,
+): Effect.Effect<void, never, ObserveDecisionRuntime> =>
+  Effect.suspend(() =>
+    Effect.gen(function* () {
+      const nowNanos = yield* Clock.currentTimeNanos
+      if (nowNanos >= nextPollAtNanos) return
+      const state = yield* Ref.get(cadence)
+      const decision = decideIdleReconciliationCadence(state, nowNanos, input.reconciliationIntervalMs)
+      if (decision._tag === 'RECONCILE') {
+        yield* observeMutationIdleReconciliation(input, startup, cadence, reconcile, result)
+        return yield* waitUntilNextMutationPoll(input, startup, cadence, reconcile, result, nextPollAtNanos)
+      }
+      const reconciliationAtNanos = nowNanos + decision.remainingNanos
+      if (nextPollAtNanos <= reconciliationAtNanos) return yield* mutationSleepUntil(nextPollAtNanos)
+      yield* mutationSleepUntil(reconciliationAtNanos)
+      return yield* waitUntilNextMutationPoll(input, startup, cadence, reconcile, result, nextPollAtNanos)
+    }),
+  )
+
+const waitAfterMutationPass = (
+  input: MutationAutonomousCycleInput,
+  startup: Parameters<AutonomousCycleStartup>[0],
+  cadence: Ref.Ref<ReconciliationCadenceState>,
+  reconcile: Effect.Effect<ReconciliationPassResult, ReconciliationPassError, ObserveDecisionRuntime>,
+  result: CycleRunResult,
+): Effect.Effect<void, never, ObserveDecisionRuntime> =>
+  Clock.currentTimeNanos.pipe(
+    Effect.flatMap((completedAtNanos) => {
+      const nextPollAtNanos = completedAtNanos + mutationIntervalNanos(input.pollIntervalMs)
+      return result.outcome === 'NOT_DUE'
+        ? waitUntilNextMutationPoll(input, startup, cadence, reconcile, result, nextPollAtNanos)
+        : mutationSleepUntil(nextPollAtNanos)
+    }),
+  )
+
 const mutationCycleLoop = (
   input: MutationAutonomousCycleInput,
   startup: Parameters<AutonomousCycleStartup>[0],
   preparation: ObserveStartupPreparation,
   policy: Policy,
-  context: CycleRunContext<ObserveDecisionRuntime>,
 ): Effect.Effect<void, never, MutationRuntime> =>
-  runMutationCyclePass(input, preparation, policy, context).pipe(
-    Effect.matchEffect({
-      onFailure: (error) =>
-        currentUtcInstant.pipe(
-          Effect.flatMap((observedAt) => observeMutationPass(startup, { outcome: 'FAILED', observedAt, error })),
+  Effect.gen(function* () {
+    const cadence = yield* Ref.make<ReconciliationCadenceState>({})
+    const reconcile = runOnce.pipe(Effect.tap(() => markMutationReconciliationCompleted(cadence)))
+    const context: CycleRunContext<ObserveDecisionRuntime> = {
+      qualificationRunId: startup.qualificationRunId,
+      strategyProtocolHash: preparation.strategyProtocolHash,
+      accountId: input.accountId,
+      executionPolicy: preparation.executionPolicy,
+      buildDecision: (cycle) =>
+        buildMutationShadowCycleDecision(mutationDecisionInput(input, preparation, policy, cycle, reconcile)).pipe(
+          Effect.mapError(decisionBuildError),
         ),
-      onSuccess: (result) =>
-        currentUtcInstant.pipe(
-          Effect.flatMap((observedAt) => observeMutationPass(startup, { outcome: 'SUCCEEDED', observedAt, result })),
+    }
+    const run = (): Effect.Effect<void, never, MutationRuntime> =>
+      Effect.suspend(() =>
+        runMutationCyclePass(input, preparation, policy, context, reconcile).pipe(
+          Effect.matchEffect({
+            onFailure: (error) =>
+              currentUtcInstant.pipe(
+                Effect.flatMap((observedAt) => observeMutationPass(startup, { outcome: 'FAILED', observedAt, error })),
+                Effect.andThen(Effect.sleep(Duration.millis(input.pollIntervalMs))),
+                Effect.andThen(run()),
+              ),
+            onSuccess: (result) =>
+              (result.outcome === 'NOT_DUE'
+                ? observeMutationIdleReconciliation(input, startup, cadence, reconcile, result)
+                : currentUtcInstant.pipe(
+                    Effect.flatMap((observedAt) =>
+                      observeMutationPass(startup, { outcome: 'SUCCEEDED', observedAt, result }),
+                    ),
+                  )
+              ).pipe(
+                Effect.andThen(waitAfterMutationPass(input, startup, cadence, reconcile, result)),
+                Effect.andThen(run()),
+              ),
+          }),
         ),
-    }),
-    Effect.repeat(Schedule.spaced(Duration.millis(input.pollIntervalMs))),
-    Effect.asVoid,
-  )
+      )
+    yield* run()
+  })
 
 const makeMutationAutonomousLoop = (
   input: MutationAutonomousCycleInput,
@@ -1242,19 +1393,10 @@ const makeMutationAutonomousLoop = (
   preparation: ObserveStartupPreparation,
   policy: Policy,
 ): Result.Result<AutonomousCycleLoop<MutationRuntime>, OperationalError> => {
-  const context: CycleRunContext<ObserveDecisionRuntime> = {
-    qualificationRunId: startup.qualificationRunId,
-    strategyProtocolHash: preparation.strategyProtocolHash,
-    accountId: input.accountId,
-    executionPolicy: preparation.executionPolicy,
-    buildDecision: (cycle) =>
-      buildMutationShadowCycleDecision(mutationDecisionInput(input, preparation, policy, cycle)).pipe(
-        Effect.mapError(decisionBuildError),
-      ),
-  }
   return Result.mapError(
-    Result.map(validateCycleLoopInterval(input.pollIntervalMs), () =>
-      mutationCycleLoop(input, startup, preparation, policy, context),
+    Result.map(validateCycleLoopInterval(input.pollIntervalMs), () => input.reconciliationIntervalMs).pipe(
+      Result.flatMap(validateReconciliationInterval),
+      Result.map(() => mutationCycleLoop(input, startup, preparation, policy)),
     ),
     (cause) => operationalError('strategy', 'cycle-loop', 'mutation autonomous cycle loop failed to start', cause),
   )

--- a/services/bayn/src/observe-composition.ts
+++ b/services/bayn/src/observe-composition.ts
@@ -1280,6 +1280,25 @@ const mutationIdleReconciliationError = (cause: ReconciliationPassError): CycleR
 const markMutationReconciliationCompleted = (cadence: Ref.Ref<ReconciliationCadenceState>): Effect.Effect<void> =>
   Clock.currentTimeNanos.pipe(Effect.flatMap((lastAttemptAtNanos) => Ref.set(cadence, { lastAttemptAtNanos })))
 
+const attemptMutationIdleReconciliation = (
+  cadence: Ref.Ref<ReconciliationCadenceState>,
+  reconcile: Effect.Effect<ReconciliationPassResult, ReconciliationPassError, ObserveDecisionRuntime>,
+): Effect.Effect<void, CycleRunnerError, ObserveDecisionRuntime> =>
+  Clock.currentTimeNanos.pipe(
+    Effect.tap((lastAttemptAtNanos) => Ref.set(cadence, { lastAttemptAtNanos })),
+    Effect.andThen(
+      reconcile.pipe(
+        Effect.asVoid,
+        Effect.mapError(mutationIdleReconciliationError),
+        Effect.tapError((lastFailure) =>
+          Clock.currentTimeNanos.pipe(
+            Effect.flatMap((lastAttemptAtNanos) => Ref.set(cadence, { lastAttemptAtNanos, lastFailure })),
+          ),
+        ),
+      ),
+    ),
+  )
+
 const reconcileMutationNotDuePass = (
   input: MutationAutonomousCycleInput,
   cadence: Ref.Ref<ReconciliationCadenceState>,
@@ -1295,15 +1314,7 @@ const reconcileMutationNotDuePass = (
       if (state.lastFailure !== undefined) return yield* Effect.fail(state.lastFailure)
       return result
     }
-    yield* Ref.set(cadence, { lastAttemptAtNanos: nowNanos })
-    yield* reconcile.pipe(
-      Effect.mapError(mutationIdleReconciliationError),
-      Effect.tapError((lastFailure) =>
-        Clock.currentTimeNanos.pipe(
-          Effect.flatMap((lastAttemptAtNanos) => Ref.set(cadence, { lastAttemptAtNanos, lastFailure })),
-        ),
-      ),
-    )
+    yield* attemptMutationIdleReconciliation(cadence, reconcile)
     return result
   })
 }
@@ -1330,12 +1341,33 @@ const observeMutationIdleReconciliation = (
     ),
   )
 
+const observeMutationCadenceReconciliation = (
+  startup: Parameters<AutonomousCycleStartup>[0],
+  cadence: Ref.Ref<ReconciliationCadenceState>,
+  reconcile: Effect.Effect<ReconciliationPassResult, ReconciliationPassError, ObserveDecisionRuntime>,
+  result: CycleRunResult,
+): Effect.Effect<void, never, ObserveDecisionRuntime> =>
+  attemptMutationIdleReconciliation(cadence, reconcile).pipe(
+    Effect.flatMap(() =>
+      result.outcome === 'NOT_DUE'
+        ? currentUtcInstant.pipe(
+            Effect.flatMap((observedAt) => observeMutationPass(startup, { outcome: 'SUCCEEDED', observedAt, result })),
+          )
+        : Effect.void,
+    ),
+    Effect.catch((error) =>
+      currentUtcInstant.pipe(
+        Effect.flatMap((observedAt) => observeMutationPass(startup, { outcome: 'FAILED', observedAt, error })),
+      ),
+    ),
+  )
+
 const waitUntilNextMutationPoll = (
   input: MutationAutonomousCycleInput,
   startup: Parameters<AutonomousCycleStartup>[0],
   cadence: Ref.Ref<ReconciliationCadenceState>,
   reconcile: Effect.Effect<ReconciliationPassResult, ReconciliationPassError, ObserveDecisionRuntime>,
-  result: Extract<CycleRunResult, { readonly outcome: 'NOT_DUE' }>,
+  result: CycleRunResult,
   nextPollAtNanos: bigint,
 ): Effect.Effect<void, never, ObserveDecisionRuntime> =>
   Effect.suspend(() =>
@@ -1344,7 +1376,7 @@ const waitUntilNextMutationPoll = (
       const state = yield* Ref.get(cadence)
       const decision = decideIdleReconciliationCadence(state, nowNanos, input.reconciliationIntervalMs)
       if (decision._tag === 'RECONCILE') {
-        yield* observeMutationIdleReconciliation(input, startup, cadence, reconcile, result)
+        yield* observeMutationCadenceReconciliation(startup, cadence, reconcile, result)
         return yield* waitUntilNextMutationPoll(input, startup, cadence, reconcile, result, nextPollAtNanos)
       }
       if (nowNanos >= nextPollAtNanos) return
@@ -1365,9 +1397,7 @@ const waitAfterMutationPass = (
   Clock.currentTimeNanos.pipe(
     Effect.flatMap((completedAtNanos) => {
       const nextPollAtNanos = completedAtNanos + mutationIntervalNanos(input.pollIntervalMs)
-      return result.outcome === 'NOT_DUE'
-        ? waitUntilNextMutationPoll(input, startup, cadence, reconcile, result, nextPollAtNanos)
-        : mutationSleepUntil(nextPollAtNanos)
+      return waitUntilNextMutationPoll(input, startup, cadence, reconcile, result, nextPollAtNanos)
     }),
   )
 

--- a/services/bayn/src/observe-composition.ts
+++ b/services/bayn/src/observe-composition.ts
@@ -1347,13 +1347,19 @@ const observeMutationCadenceReconciliation = (
   reconcile: Effect.Effect<ReconciliationPassResult, ReconciliationPassError, ObserveDecisionRuntime>,
   result: CycleRunResult,
 ): Effect.Effect<void, never, ObserveDecisionRuntime> =>
-  attemptMutationIdleReconciliation(cadence, reconcile).pipe(
-    Effect.flatMap(() =>
-      result.outcome === 'NOT_DUE'
-        ? currentUtcInstant.pipe(
-            Effect.flatMap((observedAt) => observeMutationPass(startup, { outcome: 'SUCCEEDED', observedAt, result })),
-          )
-        : Effect.void,
+  Ref.get(cadence).pipe(
+    Effect.flatMap((state) =>
+      attemptMutationIdleReconciliation(cadence, reconcile).pipe(
+        Effect.flatMap(() =>
+          result.outcome === 'NOT_DUE' || state.lastFailure !== undefined
+            ? currentUtcInstant.pipe(
+                Effect.flatMap((observedAt) =>
+                  observeMutationPass(startup, { outcome: 'SUCCEEDED', observedAt, result }),
+                ),
+              )
+            : Effect.void,
+        ),
+      ),
     ),
     Effect.catch((error) =>
       currentUtcInstant.pipe(


### PR DESCRIPTION
## Summary

- Honor `BAYN_RECONCILIATION_INTERVAL_MS` with a pure monotonic cadence decision independent of cycle polling.
- Reconcile idle `NOT_DUE` broker state through the existing read-only writer-fenced `runOnce` path in both OBSERVE and mutation/PAPER modes, while preserving one same-pass DUE reconciliation.
- Keep failures fail-closed and observable, retain interruption within the owning loop fiber, validate impossible timing configuration, enforce one interruptible deadline around the complete reconciliation pass, require PAPER cadence plus that full-pass bound to remain strictly inside the reconciliation staleness threshold, and prioritize a due idle reconciliation when its deadline coincides with the next poll, reserve the prior post-`reconciledAt` persistence tail in PAPER timing validation, and wake on reconciliation cadence after every autonomous result including DUE, RECOVERED, terminal, and missing-publication outcomes; apply the strict freshness window to both sandbox and live-grant mutation authority; and retain any reconciliation failure across intervening non-idle polls, and emit one immediate recovery success when the cadence retry succeeds before a slower poll while keeping ordinary cadence successes silent; and enforce a bounded cycle-pass admission budget so a poll that cannot complete before the next cadence deadline is deferred; keep that same interruptible bound active through reconciliation, submit/recovery, consistency delay, and durable store work; and resume cadence-aware reconciliation after any full-pass timeout.
- Add focused regressions for first pass, exact boundary, faster/slower polling, failure retry, interruption, DUE deduplication, mutation/PAPER idle reconciliation with zero broker mutations, and PAPER staleness-window boundaries.

## Related Issues

None

## Testing

- Exact head: `f05371c1189bfea0688c39c6062c8c5b57267112`.
- `bun test services/bayn/src/config.test.ts services/bayn/src/cycle-runner.test.ts services/bayn/src/observe-composition.test.ts` — 79 pass, 0 fail.
- `bun run --filter @proompteng/bayn test` — 951 pass, 138 environment-gated integration tests skipped, 0 fail.
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:effect`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn build`
- `git diff --check origin/main...HEAD`
- Repository pre-commit `lint-staged` and commit-message hooks.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] No documentation, release notes, or follow-up changes are required for this bounded runtime correction.