### PR TITLE
fix(bayn): include cash yield in realized returns

### DIFF
--- a/services/bayn/src/forward-performance/domain.test.ts
+++ b/services/bayn/src/forward-performance/domain.test.ts
@@ -167,6 +167,66 @@ describe('forward performance domain', () => {
     expect(receipt.totals.netRealizedPnlAfterCostsMicros).toBe('-50')
   })
 
+  test('cash yield can make total realized economic income profitable without changing gross trade PnL', () => {
+    const receipt = success(
+      makeForwardPerformanceReceipt(
+        input({
+          transactions: [transaction('e', '-100', '0')],
+          ledgerTotals: {
+            realizedGainMicros: '0',
+            realizedLossMicros: '100',
+            brokerExecutionFeesMicros: '0',
+            otherChargedCostsMicros: '0',
+            cashYieldMicros: '200',
+          },
+        }),
+      ),
+    )
+
+    expect(receipt.evidence).toEqual({ status: 'SUFFICIENT', reasonCodes: [] })
+    expect(receipt.profitability).toBe('PROFITABLE')
+    expect(receipt.totals).toMatchObject({
+      grossRealizedPnlMicros: '-100',
+      cashYieldMicros: '200',
+      netRealizedPnlAfterCostsMicros: '100',
+      netRealizedReturn: {
+        numeratorMicros: '100',
+        denominatorMicros: '1000',
+        decimal: '0.100000000000',
+      },
+    })
+  })
+
+  test('cash yield can reduce a realized loss without falsely crossing profitability', () => {
+    const receipt = success(
+      makeForwardPerformanceReceipt(
+        input({
+          transactions: [transaction('e', '-200', '0')],
+          ledgerTotals: {
+            realizedGainMicros: '0',
+            realizedLossMicros: '200',
+            brokerExecutionFeesMicros: '0',
+            otherChargedCostsMicros: '0',
+            cashYieldMicros: '100',
+          },
+        }),
+      ),
+    )
+
+    expect(receipt.profitability).toBe('NOT_PROFITABLE')
+    expect(receipt.totals.grossRealizedPnlMicros).toBe('-200')
+    expect(receipt.totals.cashYieldMicros).toBe('100')
+    expect(receipt.totals.netRealizedPnlAfterCostsMicros).toBe('-100')
+  })
+
+  test('zero cash yield preserves the checked trade net after costs', () => {
+    const receipt = success(makeForwardPerformanceReceipt(input()))
+
+    expect(receipt.totals.cashYieldMicros).toBe('0')
+    expect(receipt.totals.grossRealizedPnlMicros).toBe('100')
+    expect(receipt.totals.netRealizedPnlAfterCostsMicros).toBe('80')
+  })
+
   test('an open or partial operating window is insufficient evidence', () => {
     const receipt = success(makeForwardPerformanceReceipt(input({ unclosedCycleCount: 1 })))
 
@@ -226,17 +286,96 @@ describe('forward performance domain', () => {
     expect(receipt.totals.netRealizedPnlAfterCostsMicros).toBeNull()
   })
 
+  test('invalid or overflowing cash yield arithmetic fails closed', () => {
+    const max = ((1n << 127n) - 1n).toString()
+    const overflow = success(
+      makeForwardPerformanceReceipt(
+        input({
+          transactions: [transaction('e', max, '0')],
+          ledgerTotals: {
+            realizedGainMicros: max,
+            realizedLossMicros: '0',
+            brokerExecutionFeesMicros: '0',
+            otherChargedCostsMicros: '0',
+            cashYieldMicros: '1',
+          },
+        }),
+      ),
+    )
+    const invalid = success(
+      makeForwardPerformanceReceipt(
+        input({
+          ledgerTotals: {
+            realizedGainMicros: '100',
+            realizedLossMicros: '0',
+            brokerExecutionFeesMicros: '20',
+            otherChargedCostsMicros: '0',
+            cashYieldMicros: '-1',
+          },
+        }),
+      ),
+    )
+
+    for (const receipt of [overflow, invalid]) {
+      expect(receipt.evidence.reasonCodes).toContain('INVALID_MICROS')
+      expect(receipt.profitability).toBe('UNDETERMINED')
+      expect(receipt.totals.netRealizedPnlAfterCostsMicros).toBeNull()
+    }
+  })
+
   test('canonical ordering produces one deterministic content hash', () => {
     const secondCycle = cycle('f', {
       submissionOpenAt: '2026-07-21T13:00:00.000Z',
       terminalAt: '2026-07-21T21:00:00.000Z',
     })
-    const first = success(makeForwardPerformanceReceipt(input({ cycles: [secondCycle, cycle('a')] })))
-    const second = success(makeForwardPerformanceReceipt(input({ cycles: [cycle('a'), secondCycle] })))
+    const evidence = {
+      transactions: [transaction('e', '-100', '0')],
+      ledgerTotals: {
+        realizedGainMicros: '0',
+        realizedLossMicros: '100',
+        brokerExecutionFeesMicros: '0',
+        otherChargedCostsMicros: '0',
+        cashYieldMicros: '200',
+      },
+      reconciliation: {
+        reconciliationId: hash('8'),
+        contentHash: hash('9'),
+        status: 'EXACT' as const,
+        reconciledAt: '2026-07-21T21:01:00.000Z',
+      },
+    } as const
+    const first = success(makeForwardPerformanceReceipt(input({ ...evidence, cycles: [secondCycle, cycle('a')] })))
+    const second = success(makeForwardPerformanceReceipt(input({ ...evidence, cycles: [cycle('a'), secondCycle] })))
 
     expect(first).toEqual(second)
-    expect(first.receiptHash).toMatch(/^[0-9a-f]{64}$/)
+    expect(first.receiptHash).toBe('8cb3d4c458d8a17859c866884e6bb15652be9283d8bbc495297844054b0ff42c')
+    expect(first.evidence).toEqual({ status: 'SUFFICIENT', reasonCodes: [] })
+    expect(first.profitability).toBe('PROFITABLE')
+    expect(first.totals.netRealizedPnlAfterCostsMicros).toBe('100')
     expect(JSON.stringify(first)).not.toContain('paper-account-1')
+  })
+
+  test('a ledger reconciliation failure remains insufficient even when cash yield crosses profitability', () => {
+    const receipt = success(
+      makeForwardPerformanceReceipt(
+        input({
+          transactions: [transaction('e', '-100', '0')],
+          ledgerTotals: {
+            realizedGainMicros: '0',
+            realizedLossMicros: '100',
+            brokerExecutionFeesMicros: '0',
+            otherChargedCostsMicros: '0',
+            cashYieldMicros: '200',
+          },
+          ledgerExact: false,
+        }),
+      ),
+    )
+
+    expect(receipt.totals.netRealizedPnlAfterCostsMicros).toBe('100')
+    expect(receipt.evidence.reasonCodes).toContain('LEDGER_MISMATCH')
+    expect(receipt.evidence.status).toBe('INSUFFICIENT_EVIDENCE')
+    expect(receipt.profitability).toBe('UNDETERMINED')
   })
 
   test('identity drift across completed cycles is insufficient', () => {

--- a/services/bayn/src/forward-performance/domain.ts
+++ b/services/bayn/src/forward-performance/domain.ts
@@ -127,7 +127,8 @@ const parseTotals = (
   }
   const grossRealizedPnl = checkedAdd(realizedGains, -realizedLosses)
   const afterFees = grossRealizedPnl === undefined ? undefined : checkedAdd(grossRealizedPnl, -brokerExecutionFees)
-  const netRealizedPnlAfterCosts = afterFees === undefined ? undefined : checkedAdd(afterFees, -otherChargedCosts)
+  const afterOtherCosts = afterFees === undefined ? undefined : checkedAdd(afterFees, -otherChargedCosts)
+  const netRealizedPnlAfterCosts = afterOtherCosts === undefined ? undefined : checkedAdd(afterOtherCosts, cashYield)
   if (grossRealizedPnl === undefined || netRealizedPnlAfterCosts === undefined) {
     reasons.add('INVALID_MICROS')
     return undefined


### PR DESCRIPTION
## Summary

Correct Bayn's authoritative forward-performance arithmetic so cash yield is included exactly once in net realized economic income after costs while gross realized trade PnL remains gains minus losses.

- preserve explicit gross trade-PnL semantics
- compute net realized income as gross trade PnL minus broker fees and other charged costs plus authoritative cash yield
- keep every signed-micro operation checked and fail closed on invalid or overflowing yield
- preserve ledger mismatch as insufficient evidence even when yield would otherwise cross profitability
- pin the corrected canonical receipt hash

## Reproduced defect

Fresh main `5fa8e184d6001ff868093d50d110af4be0639695` reported gross `-100`, cash yield `+200`, net `-100`, and `NOT_PROFITABLE`; corrected output is net `+100` and `PROFITABLE`.

## Validation

- `bun test src/forward-performance`
- `bun run tsc`
- `bun run lint`
- `bun run lint:oxlint`
- `bun run lint:oxlint:type`
- `bun run lint:effect`
- `bun run test`: 931 passed, 138 environment-gated skips, 0 failed
- `bun run build`

## Safety

- no broker mutation code changed
- no order submission or cancellation path introduced
- no authority, health, cadence, candidate, PREPARE, workflow, credential, or manifest path changed
- forward-performance PostgreSQL and TigerBeetle readers remain read-only and fail closed
