### PR TITLE
fix(bayn): include cash yield in realized returns

### DIFF
--- a/services/bayn/src/forward-performance/domain.test.ts
+++ b/services/bayn/src/forward-performance/domain.test.ts
@@ -37,6 +37,13 @@ const transaction = (
   ...overrides,
 })
 
+const cashYieldBinding = (amountMicros = '200') => ({
+  source: 'TIGERBEETLE_CASH_YIELD_TRANSFER' as const,
+  transferId: '123456789',
+  transferTimestampNs: '1784563200000000000',
+  amountMicros,
+})
+
 const input = (overrides: Partial<ForwardPerformanceEvidenceInput> = {}): ForwardPerformanceEvidenceInput => ({
   runtime: {
     sourceRevision: 'a'.repeat(40),
@@ -83,6 +90,8 @@ const input = (overrides: Partial<ForwardPerformanceEvidenceInput> = {}): Forwar
     reconciliationId: hash('8'),
     contentHash: hash('9'),
     status: 'EXACT',
+    performanceExact: true,
+    cashYieldAdjustedExact: false,
     reconciledAt: '2026-07-20T21:01:00.000Z',
   },
   startingCapitalMicros: '1000',
@@ -101,6 +110,7 @@ const input = (overrides: Partial<ForwardPerformanceEvidenceInput> = {}): Forwar
   unclosedCycleCount: 0,
   openPositionCount: 0,
   ...overrides,
+  cashYieldEvidenceRequired: overrides.cashYieldEvidenceRequired ?? false,
 })
 
 const success = (value: Result.Result<ForwardPerformanceReceipt, unknown>): ForwardPerformanceReceipt => {
@@ -112,7 +122,7 @@ describe('forward performance domain', () => {
   test('reports positive net realized returns after charged costs', () => {
     const receipt = success(makeForwardPerformanceReceipt(input()))
 
-    expect(receipt.evidence).toEqual({ status: 'SUFFICIENT', reasonCodes: [] })
+    expect(receipt.evidence).toEqual({ status: 'SUFFICIENT', reasonCodes: [], cashYield: null })
     expect(receipt.profitability).toBe('PROFITABLE')
     expect(receipt.totals).toMatchObject({
       grossRealizedPnlMicros: '100',
@@ -167,10 +177,94 @@ describe('forward performance domain', () => {
     expect(receipt.totals.netRealizedPnlAfterCostsMicros).toBe('-50')
   })
 
+  test('cash yield can make total realized economic income profitable without changing gross trade PnL', () => {
+    const receipt = success(
+      makeForwardPerformanceReceipt(
+        input({
+          reconciliation: {
+            reconciliationId: hash('8'),
+            contentHash: hash('9'),
+            status: 'DISCREPANCY',
+            performanceExact: true,
+            cashYieldAdjustedExact: true,
+            reconciledAt: '2026-07-20T21:01:00.000Z',
+          },
+          transactions: [transaction('e', '-100', '0')],
+          ledgerTotals: {
+            realizedGainMicros: '0',
+            realizedLossMicros: '100',
+            brokerExecutionFeesMicros: '0',
+            otherChargedCostsMicros: '0',
+            cashYieldMicros: '200',
+          },
+          cashYieldEvidenceRequired: true,
+          cashYieldEvidence: cashYieldBinding(),
+        }),
+      ),
+    )
+
+    expect(receipt.evidence).toEqual({
+      status: 'SUFFICIENT',
+      reasonCodes: [],
+      cashYield: cashYieldBinding(),
+    })
+    expect(receipt.profitability).toBe('PROFITABLE')
+    expect(receipt.window).toMatchObject({
+      reconciliationStatus: 'DISCREPANCY',
+      cashYieldAdjustedExact: true,
+    })
+    expect(receipt.totals).toMatchObject({
+      grossRealizedPnlMicros: '-100',
+      cashYieldMicros: '200',
+      netRealizedPnlAfterCostsMicros: '100',
+      netRealizedReturn: {
+        numeratorMicros: '100',
+        denominatorMicros: '1000',
+        decimal: '0.100000000000',
+      },
+    })
+  })
+
+  test('cash yield can reduce a realized loss without falsely crossing profitability', () => {
+    const receipt = success(
+      makeForwardPerformanceReceipt(
+        input({
+          transactions: [transaction('e', '-200', '0')],
+          ledgerTotals: {
+            realizedGainMicros: '0',
+            realizedLossMicros: '200',
+            brokerExecutionFeesMicros: '0',
+            otherChargedCostsMicros: '0',
+            cashYieldMicros: '100',
+          },
+          cashYieldEvidenceRequired: true,
+          cashYieldEvidence: cashYieldBinding('100'),
+        }),
+      ),
+    )
+
+    expect(receipt.profitability).toBe('NOT_PROFITABLE')
+    expect(receipt.totals.grossRealizedPnlMicros).toBe('-200')
+    expect(receipt.totals.cashYieldMicros).toBe('100')
+    expect(receipt.totals.netRealizedPnlAfterCostsMicros).toBe('-100')
+  })
+
+  test('zero cash yield preserves the checked trade net after costs', () => {
+    const receipt = success(makeForwardPerformanceReceipt(input()))
+
+    expect(receipt.totals.cashYieldMicros).toBe('0')
+    expect(receipt.totals.grossRealizedPnlMicros).toBe('100')
+    expect(receipt.totals.netRealizedPnlAfterCostsMicros).toBe('80')
+  })
+
   test('an open or partial operating window is insufficient evidence', () => {
     const receipt = success(makeForwardPerformanceReceipt(input({ unclosedCycleCount: 1 })))
 
-    expect(receipt.evidence).toEqual({ status: 'INSUFFICIENT_EVIDENCE', reasonCodes: ['UNCLOSED_WINDOW'] })
+    expect(receipt.evidence).toEqual({
+      status: 'INSUFFICIENT_EVIDENCE',
+      reasonCodes: ['UNCLOSED_WINDOW'],
+      cashYield: null,
+    })
     expect(receipt.profitability).toBe('UNDETERMINED')
   })
 
@@ -226,17 +320,137 @@ describe('forward performance domain', () => {
     expect(receipt.totals.netRealizedPnlAfterCostsMicros).toBeNull()
   })
 
+  test('invalid or overflowing cash yield arithmetic fails closed', () => {
+    const max = ((1n << 127n) - 1n).toString()
+    const overflow = success(
+      makeForwardPerformanceReceipt(
+        input({
+          transactions: [transaction('e', max, '0')],
+          ledgerTotals: {
+            realizedGainMicros: max,
+            realizedLossMicros: '0',
+            brokerExecutionFeesMicros: '0',
+            otherChargedCostsMicros: '0',
+            cashYieldMicros: '1',
+          },
+        }),
+      ),
+    )
+    const invalid = success(
+      makeForwardPerformanceReceipt(
+        input({
+          ledgerTotals: {
+            realizedGainMicros: '100',
+            realizedLossMicros: '0',
+            brokerExecutionFeesMicros: '20',
+            otherChargedCostsMicros: '0',
+            cashYieldMicros: '-1',
+          },
+        }),
+      ),
+    )
+
+    for (const receipt of [overflow, invalid]) {
+      expect(receipt.evidence.reasonCodes).toContain('INVALID_MICROS')
+      expect(receipt.profitability).toBe('UNDETERMINED')
+      expect(receipt.totals.netRealizedPnlAfterCostsMicros).toBeNull()
+    }
+  })
+
   test('canonical ordering produces one deterministic content hash', () => {
     const secondCycle = cycle('f', {
       submissionOpenAt: '2026-07-21T13:00:00.000Z',
       terminalAt: '2026-07-21T21:00:00.000Z',
     })
-    const first = success(makeForwardPerformanceReceipt(input({ cycles: [secondCycle, cycle('a')] })))
-    const second = success(makeForwardPerformanceReceipt(input({ cycles: [cycle('a'), secondCycle] })))
+    const evidence = {
+      transactions: [transaction('e', '-100', '0')],
+      ledgerTotals: {
+        realizedGainMicros: '0',
+        realizedLossMicros: '100',
+        brokerExecutionFeesMicros: '0',
+        otherChargedCostsMicros: '0',
+        cashYieldMicros: '200',
+      },
+      cashYieldEvidenceRequired: true,
+      cashYieldEvidence: cashYieldBinding(),
+      reconciliation: {
+        reconciliationId: hash('8'),
+        contentHash: hash('9'),
+        status: 'DISCREPANCY' as const,
+        performanceExact: true,
+        cashYieldAdjustedExact: true,
+        reconciledAt: '2026-07-21T21:01:00.000Z',
+      },
+    } as const
+    const first = success(makeForwardPerformanceReceipt(input({ ...evidence, cycles: [secondCycle, cycle('a')] })))
+    const second = success(makeForwardPerformanceReceipt(input({ ...evidence, cycles: [cycle('a'), secondCycle] })))
 
     expect(first).toEqual(second)
-    expect(first.receiptHash).toMatch(/^[0-9a-f]{64}$/)
+    expect(first.schemaVersion).toBe('bayn.forward-performance-receipt.v2')
+    expect(first.receiptHash).toBe('adc3d822eaec05fb862f67b4bb795fc4886260623642d6e0651eb1b80c4a9e1b')
+    expect(first.evidence).toEqual({
+      status: 'SUFFICIENT',
+      reasonCodes: [],
+      cashYield: cashYieldBinding(),
+    })
+    expect(first.profitability).toBe('PROFITABLE')
+    expect(first.totals.netRealizedPnlAfterCostsMicros).toBe('100')
     expect(JSON.stringify(first)).not.toContain('paper-account-1')
+  })
+
+  test('a ledger reconciliation failure remains insufficient even when cash yield crosses profitability', () => {
+    const receipt = success(
+      makeForwardPerformanceReceipt(
+        input({
+          transactions: [transaction('e', '-100', '0')],
+          ledgerTotals: {
+            realizedGainMicros: '0',
+            realizedLossMicros: '100',
+            brokerExecutionFeesMicros: '0',
+            otherChargedCostsMicros: '0',
+            cashYieldMicros: '200',
+          },
+          ledgerExact: false,
+        }),
+      ),
+    )
+
+    expect(receipt.totals.netRealizedPnlAfterCostsMicros).toBe('100')
+    expect(receipt.evidence.reasonCodes).toContain('LEDGER_MISMATCH')
+    expect(receipt.evidence.status).toBe('INSUFFICIENT_EVIDENCE')
+    expect(receipt.profitability).toBe('UNDETERMINED')
+  })
+
+  test('an unexplained cash discrepancy remains insufficient even when yield would cross profitability', () => {
+    const receipt = success(
+      makeForwardPerformanceReceipt(
+        input({
+          reconciliation: {
+            reconciliationId: hash('8'),
+            contentHash: hash('9'),
+            status: 'DISCREPANCY',
+            performanceExact: false,
+            cashYieldAdjustedExact: false,
+            reconciledAt: '2026-07-20T21:01:00.000Z',
+          },
+          transactions: [transaction('e', '-100', '0')],
+          ledgerTotals: {
+            realizedGainMicros: '0',
+            realizedLossMicros: '100',
+            brokerExecutionFeesMicros: '0',
+            otherChargedCostsMicros: '0',
+            cashYieldMicros: '200',
+          },
+        }),
+      ),
+    )
+
+    expect(receipt.evidence.reasonCodes).toContain('NON_EXACT_RECONCILIATION')
+    expect(receipt.profitability).toBe('UNDETERMINED')
+    expect(receipt.window).toMatchObject({
+      reconciliationStatus: 'DISCREPANCY',
+      cashYieldAdjustedExact: false,
+    })
   })
 
   test('identity drift across completed cycles is insufficient', () => {

--- a/services/bayn/src/forward-performance/domain.ts
+++ b/services/bayn/src/forward-performance/domain.ts
@@ -127,7 +127,8 @@ const parseTotals = (
   }
   const grossRealizedPnl = checkedAdd(realizedGains, -realizedLosses)
   const afterFees = grossRealizedPnl === undefined ? undefined : checkedAdd(grossRealizedPnl, -brokerExecutionFees)
-  const netRealizedPnlAfterCosts = afterFees === undefined ? undefined : checkedAdd(afterFees, -otherChargedCosts)
+  const afterOtherCosts = afterFees === undefined ? undefined : checkedAdd(afterFees, -otherChargedCosts)
+  const netRealizedPnlAfterCosts = afterOtherCosts === undefined ? undefined : checkedAdd(afterOtherCosts, cashYield)
   if (grossRealizedPnl === undefined || netRealizedPnlAfterCosts === undefined) {
     reasons.add('INVALID_MICROS')
     return undefined
@@ -238,7 +239,9 @@ const makeMaterial = (input: ForwardPerformanceEvidenceInput): ForwardPerformanc
       reasons.add('CYCLE_IDENTITY_DRIFT')
     }
   }
-  if (reconciliation === undefined || reconciliation.status !== 'EXACT') reasons.add('NON_EXACT_RECONCILIATION')
+  if (reconciliation === undefined || reconciliation.performanceExact !== true) {
+    reasons.add('NON_EXACT_RECONCILIATION')
+  }
   if (lastCycle !== undefined && reconciliation !== undefined && reconciliation.reconciledAt < lastCycle.terminalAt) {
     reasons.add('UNCLOSED_WINDOW')
   }
@@ -248,6 +251,9 @@ const makeMaterial = (input: ForwardPerformanceEvidenceInput): ForwardPerformanc
   if (!input.accountingReceiptsExact) reasons.add('ACCOUNTING_RECEIPT_MISMATCH')
   if (!input.ledgerExact) reasons.add('LEDGER_MISMATCH')
   if (input.missingLedgerAccountCount > 0) reasons.add('MISSING_LEDGER_ACCOUNT')
+  if (input.cashYieldEvidenceRequired && input.cashYieldEvidence === undefined) {
+    reasons.add('CASH_YIELD_EVIDENCE_GAP')
+  }
   if (input.transactions.length === 0) reasons.add('ZERO_COMPLETED_EXECUTIONS')
 
   const cycleIds = new Set(cycles.map((cycle) => cycle.cycleId))
@@ -255,6 +261,20 @@ const makeMaterial = (input: ForwardPerformanceEvidenceInput): ForwardPerformanc
 
   const totals = parseTotals(input, reasons)
   if (totals !== undefined) transactionTotalsMatch(input, totals, reasons)
+  if (input.cashYieldEvidence !== undefined) {
+    const evidenceAmount = parseSignedMicros(input.cashYieldEvidence.amountMicros)
+    if (
+      !input.cashYieldEvidenceRequired ||
+      evidenceAmount === undefined ||
+      evidenceAmount <= 0n ||
+      totals === undefined ||
+      totals.cashYield !== evidenceAmount
+    ) {
+      reasons.add('CASH_YIELD_EVIDENCE_GAP')
+    }
+  } else if (totals !== undefined && totals.cashYield > 0n) {
+    reasons.add('CASH_YIELD_EVIDENCE_GAP')
+  }
 
   const realizedCloseCount = input.transactions.filter((transaction) => transaction.side === 'SELL').length
   const reasonCodes = [...reasons].sort()
@@ -299,6 +319,8 @@ const makeMaterial = (input: ForwardPerformanceEvidenceInput): ForwardPerformanc
       closedAt: reconciliation?.reconciledAt ?? null,
       reconciliationId: reconciliation?.reconciliationId ?? null,
       reconciliationContentHash: reconciliation?.contentHash ?? null,
+      reconciliationStatus: reconciliation?.status ?? null,
+      cashYieldAdjustedExact: reconciliation?.cashYieldAdjustedExact ?? null,
     },
     totals: {
       startingCapitalMicros: totals?.startingCapital.toString() ?? null,
@@ -326,6 +348,7 @@ const makeMaterial = (input: ForwardPerformanceEvidenceInput): ForwardPerformanc
     evidence: {
       status: sufficient ? 'SUFFICIENT' : 'INSUFFICIENT_EVIDENCE',
       reasonCodes,
+      cashYield: input.cashYieldEvidence ?? null,
     },
     profitability:
       !sufficient || totals === undefined

--- a/services/bayn/src/forward-performance/model.ts
+++ b/services/bayn/src/forward-performance/model.ts
@@ -1,4 +1,4 @@
-export const FORWARD_PERFORMANCE_SCHEMA_VERSION = 'bayn.forward-performance-receipt.v1' as const
+export const FORWARD_PERFORMANCE_SCHEMA_VERSION = 'bayn.forward-performance-receipt.v2' as const
 
 export type ForwardPerformanceEvidenceStatus = 'SUFFICIENT' | 'INSUFFICIENT_EVIDENCE'
 export type ForwardPerformanceProfitability = 'PROFITABLE' | 'NOT_PROFITABLE' | 'UNDETERMINED'
@@ -6,6 +6,7 @@ export type ForwardPerformanceProfitability = 'PROFITABLE' | 'NOT_PROFITABLE' | 
 export type ForwardPerformanceReasonCode =
   | 'ACCOUNT_IDENTITY_GAP'
   | 'ACCOUNTING_RECEIPT_MISMATCH'
+  | 'CASH_YIELD_EVIDENCE_GAP'
   | 'CYCLE_IDENTITY_DRIFT'
   | 'IDENTITY_GAP'
   | 'INVALID_MICROS'
@@ -83,6 +84,33 @@ export interface ForwardPerformanceLedgerTotals {
   readonly cashYieldMicros: string
 }
 
+export interface ForwardPerformanceCashYieldEvidence {
+  readonly schemaVersion: 'bayn.forward-performance-cash-yield-evidence.v1'
+  readonly reconciliationId: string
+  readonly reconciliationContentHash: string
+  readonly reconciledAt: string
+  readonly baselineAccountEventId: string
+  readonly baselineObservedAt: string
+  readonly baselineCashMicros: string
+  readonly openingAccountEventId: string
+  readonly openingObservedAt: string
+  readonly openingCashMicros: string
+  readonly preWindowAccountedCashDeltaMicros: string
+  readonly preWindowCashResidualMicros: string
+  readonly closingAccountEventId: string
+  readonly closingObservedAt: string
+  readonly closingCashMicros: string
+  readonly accountedCashDeltaMicros: string
+  readonly cashYieldMicros: string
+}
+
+export interface ForwardPerformanceCashYieldBinding {
+  readonly source: 'TIGERBEETLE_CASH_YIELD_TRANSFER'
+  readonly transferId: string
+  readonly transferTimestampNs: string
+  readonly amountMicros: string
+}
+
 export interface ForwardPerformanceEvidenceInput {
   readonly runtime: ForwardPerformanceBuildBinding
   readonly account: {
@@ -113,11 +141,15 @@ export interface ForwardPerformanceEvidenceInput {
     readonly reconciliationId: string
     readonly contentHash: string
     readonly status: 'EXACT' | 'DISCREPANCY'
+    readonly performanceExact: boolean
+    readonly cashYieldAdjustedExact: boolean
     readonly reconciledAt: string
   }
   readonly startingCapitalMicros?: string
   readonly transactions: readonly ForwardPerformanceTransactionEvidence[]
   readonly ledgerTotals?: ForwardPerformanceLedgerTotals
+  readonly cashYieldEvidenceRequired: boolean
+  readonly cashYieldEvidence?: ForwardPerformanceCashYieldBinding
   readonly accountingReceiptsExact: boolean
   readonly ledgerExact: boolean
   readonly missingLedgerAccountCount: number
@@ -141,6 +173,8 @@ export interface ForwardPerformanceReceiptMaterial {
     readonly closedAt: string | null
     readonly reconciliationId: string | null
     readonly reconciliationContentHash: string | null
+    readonly reconciliationStatus: 'EXACT' | 'DISCREPANCY' | null
+    readonly cashYieldAdjustedExact: boolean | null
   }
   readonly totals: {
     readonly startingCapitalMicros: string | null
@@ -165,6 +199,7 @@ export interface ForwardPerformanceReceiptMaterial {
   readonly evidence: {
     readonly status: ForwardPerformanceEvidenceStatus
     readonly reasonCodes: readonly ForwardPerformanceReasonCode[]
+    readonly cashYield: ForwardPerformanceCashYieldBinding | null
   }
   readonly profitability: ForwardPerformanceProfitability
 }

--- a/services/bayn/src/forward-performance/postgres.ts
+++ b/services/bayn/src/forward-performance/postgres.ts
@@ -2,7 +2,12 @@ import { PgClient } from '@effect/sql-pg'
 import { Data, Effect, Schema } from 'effect'
 
 import type { AccountingTransaction } from '../accounting/schema'
-import { decodeAccountingReceipt, type AccountingReceipt } from '../execution/contracts'
+import {
+  decodeAccountingReceipt,
+  DiscrepancyKind,
+  DiscrepancySchema,
+  type AccountingReceipt,
+} from '../execution/contracts'
 import {
   AccountingReceiptRowSchema,
   AccountingTransactionRowSchema,
@@ -16,6 +21,7 @@ import {
   strictParseOptions,
 } from '../schemas'
 import type {
+  ForwardPerformanceCashYieldEvidence,
   ForwardPerformanceCycleEvidence,
   ForwardPerformanceStrategyEvidence,
   ForwardPerformanceTransactionEvidence,
@@ -50,10 +56,29 @@ const ReconciliationRow = Schema.Struct({
   reconciliation_id: Sha256,
   content_hash: Sha256,
   status: Schema.Literals(['EXACT', 'DISCREPANCY']),
+  discrepancies: Schema.Array(DiscrepancySchema),
   reconciled_at: Schema.Date,
 })
 
 const StartingCapitalRow = Schema.Struct({ starting_capital_micros: Schema.String })
+const CashYieldEvidenceRow = Schema.Struct({
+  reconciliation_id: Sha256,
+  reconciliation_content_hash: Sha256,
+  reconciled_at: Schema.Date,
+  baseline_account_event_id: Sha256,
+  baseline_observed_at: Schema.Date,
+  baseline_cash_micros: Schema.String,
+  opening_account_event_id: Sha256,
+  opening_observed_at: Schema.Date,
+  opening_cash_micros: Schema.String,
+  pre_window_accounted_cash_delta_micros: Schema.String,
+  pre_window_cash_residual_micros: Schema.String,
+  closing_account_event_id: Sha256,
+  closing_observed_at: Schema.Date,
+  closing_cash_micros: Schema.String,
+  accounted_cash_delta_micros: Schema.String,
+  cash_yield_micros: Schema.String,
+})
 const CountRow = Schema.Struct({ count: Schema.Int })
 const DurableExecutionRow = Schema.Struct({
   account_id: Schema.NullOr(NonEmptyString),
@@ -89,6 +114,10 @@ const decodeStartingCapital = Schema.decodeUnknownEffect(
   Schema.Array(StartingCapitalRow).check(Schema.isMaxLength(1)),
   strictParseOptions,
 )
+const decodeCashYieldEvidence = Schema.decodeUnknownEffect(
+  Schema.Array(CashYieldEvidenceRow).check(Schema.isMaxLength(1)),
+  strictParseOptions,
+)
 const decodeTransactions = Schema.decodeUnknownEffect(Schema.Array(TransactionRow), strictParseOptions)
 const decodeReceipts = Schema.decodeUnknownEffect(Schema.Array(AccountingReceiptRowSchema), strictParseOptions)
 const decodeCount = Schema.decodeUnknownEffect(Schema.Tuple([CountRow]), strictParseOptions)
@@ -108,9 +137,12 @@ export interface ForwardPerformancePostgresEvidence {
     readonly reconciliationId: string
     readonly contentHash: string
     readonly status: 'EXACT' | 'DISCREPANCY'
+    readonly performanceExact: boolean
+    readonly cashYieldAdjustedExact: boolean
     readonly reconciledAt: string
   }
   readonly startingCapitalMicros?: string
+  readonly cashYieldEvidence?: ForwardPerformanceCashYieldEvidence
   readonly transactions: readonly AccountingTransaction[]
   readonly transactionEvidence: readonly ForwardPerformanceTransactionEvidence[]
   readonly receipts: readonly AccountingReceipt[]
@@ -145,12 +177,99 @@ const postgresError = (cause: unknown): ForwardPerformancePostgresError =>
     cause,
   })
 
+const SIGNED_I128_MIN = -(1n << 127n)
+const SIGNED_I128_MAX = (1n << 127n) - 1n
+const INTEGER_PATTERN = /^(?:0|-[1-9][0-9]*|[1-9][0-9]*)$/
+
+const signedI128 = (value: string): bigint | undefined => {
+  if (!INTEGER_PATTERN.test(value)) return undefined
+  const parsed = BigInt(value)
+  return parsed < SIGNED_I128_MIN || parsed > SIGNED_I128_MAX ? undefined : parsed
+}
+
+const reconciliationExactness = (
+  accountId: string,
+  reconciliation: typeof ReconciliationRow.Type,
+  cashYield: typeof CashYieldEvidenceRow.Type | undefined,
+): { readonly performanceExact: boolean; readonly cashYieldAdjustedExact: boolean } => {
+  if (reconciliation.status === 'EXACT') {
+    return {
+      performanceExact: reconciliation.discrepancies.length === 0,
+      cashYieldAdjustedExact: false,
+    }
+  }
+  const discrepancy = reconciliation.discrepancies[0]
+  if (
+    cashYield === undefined ||
+    reconciliation.discrepancies.length !== 1 ||
+    discrepancy === undefined ||
+    discrepancy.kind !== DiscrepancyKind.Cash ||
+    discrepancy.identity !== accountId ||
+    discrepancy.lastObservedAt !== reconciliation.reconciled_at.toISOString() ||
+    cashYield.reconciliation_id !== reconciliation.reconciliation_id ||
+    cashYield.reconciliation_content_hash !== reconciliation.content_hash ||
+    cashYield.reconciled_at.toISOString() !== reconciliation.reconciled_at.toISOString()
+  ) {
+    return { performanceExact: false, cashYieldAdjustedExact: false }
+  }
+
+  const baselineCash = signedI128(cashYield.baseline_cash_micros)
+  const openingCash = signedI128(cashYield.opening_cash_micros)
+  const preWindowCashDelta = signedI128(cashYield.pre_window_accounted_cash_delta_micros)
+  const preWindowResidual = signedI128(cashYield.pre_window_cash_residual_micros)
+  const closingCash = signedI128(cashYield.closing_cash_micros)
+  const accountedCashDelta = signedI128(cashYield.accounted_cash_delta_micros)
+  const yieldAmount = signedI128(cashYield.cash_yield_micros)
+  const expectedCash = signedI128(discrepancy.expected)
+  const observedCash = signedI128(discrepancy.observed)
+  if (
+    baselineCash === undefined ||
+    openingCash === undefined ||
+    preWindowCashDelta === undefined ||
+    preWindowResidual === undefined ||
+    closingCash === undefined ||
+    accountedCashDelta === undefined ||
+    yieldAmount === undefined ||
+    expectedCash === undefined ||
+    observedCash === undefined ||
+    yieldAmount <= 0n ||
+    preWindowResidual !== 0n ||
+    openingCash !== baselineCash + preWindowCashDelta ||
+    expectedCash !== openingCash + accountedCashDelta ||
+    observedCash !== closingCash ||
+    observedCash - expectedCash !== yieldAmount ||
+    closingCash - openingCash - accountedCashDelta !== yieldAmount
+  ) {
+    return { performanceExact: false, cashYieldAdjustedExact: false }
+  }
+
+  return { performanceExact: true, cashYieldAdjustedExact: true }
+}
+
 const transactionQuery = (sql: PgClient.PgClient, accountId: string) => sql<Record<string, unknown>>`
   WITH latest_reconciliation AS (
     SELECT reconciled_at
     FROM reconciliations
     WHERE account_id = ${accountId}
     ORDER BY reconciled_at DESC, reconciliation_id COLLATE "C" DESC
+    LIMIT 1
+  ), first_cycle AS (
+    SELECT submission_open_at
+    FROM autonomous_cycles
+    WHERE account_id = ${accountId}
+      AND state IN ('COMPLETED', 'NO_TRADE')
+    ORDER BY submission_open_at, cycle_id COLLATE "C"
+    LIMIT 1
+  ), opening_snapshot AS (
+    SELECT event.observed_at
+    FROM account_snapshots AS snapshot
+    JOIN broker_events AS event ON event.event_id = snapshot.event_id
+    CROSS JOIN latest_reconciliation
+    CROSS JOIN first_cycle
+    WHERE snapshot.account_id = ${accountId}
+      AND event.observed_at <= first_cycle.submission_open_at
+      AND event.observed_at <= latest_reconciliation.reconciled_at
+    ORDER BY event.observed_at DESC, event.source_sequence DESC, event.event_id COLLATE "C" DESC
     LIMIT 1
   )
   SELECT
@@ -176,8 +295,10 @@ const transactionQuery = (sql: PgClient.PgClient, accountId: string) => sql<Reco
     intent.cycle_id
   FROM accounting_transactions AS transaction
   CROSS JOIN latest_reconciliation
+  CROSS JOIN opening_snapshot
   LEFT JOIN intents AS intent ON intent.intent_id = transaction.intent_id
   WHERE transaction.account_id = ${accountId}
+    AND transaction.occurred_at >= opening_snapshot.observed_at
     AND transaction.occurred_at <= latest_reconciliation.reconciled_at
   ORDER BY transaction.occurred_at, transaction.transaction_id COLLATE "C"
 `
@@ -189,11 +310,31 @@ const receiptQuery = (sql: PgClient.PgClient, accountId: string) => sql<Record<s
     WHERE account_id = ${accountId}
     ORDER BY reconciled_at DESC, reconciliation_id COLLATE "C" DESC
     LIMIT 1
+  ), first_cycle AS (
+    SELECT submission_open_at
+    FROM autonomous_cycles
+    WHERE account_id = ${accountId}
+      AND state IN ('COMPLETED', 'NO_TRADE')
+    ORDER BY submission_open_at, cycle_id COLLATE "C"
+    LIMIT 1
+  ), opening_snapshot AS (
+    SELECT event.observed_at
+    FROM account_snapshots AS snapshot
+    JOIN broker_events AS event ON event.event_id = snapshot.event_id
+    CROSS JOIN latest_reconciliation
+    CROSS JOIN first_cycle
+    WHERE snapshot.account_id = ${accountId}
+      AND event.observed_at <= first_cycle.submission_open_at
+      AND event.observed_at <= latest_reconciliation.reconciled_at
+    ORDER BY event.observed_at DESC, event.source_sequence DESC, event.event_id COLLATE "C" DESC
+    LIMIT 1
   ), selected_transactions AS (
     SELECT broker_event_id
     FROM accounting_transactions
     CROSS JOIN latest_reconciliation
+    CROSS JOIN opening_snapshot
     WHERE account_id = ${accountId}
+      AND occurred_at >= opening_snapshot.observed_at
       AND occurred_at <= latest_reconciliation.reconciled_at
   )
   SELECT
@@ -281,7 +422,7 @@ export const readForwardPerformancePostgres = (
         `.pipe(Effect.flatMap(decodeStrategy))
 
         const reconciliationRows = yield* sql<Record<string, unknown>>`
-          SELECT reconciliation_id, content_hash, status, reconciled_at
+          SELECT reconciliation_id, content_hash, status, discrepancies, reconciled_at
           FROM reconciliations
           WHERE account_id = ${accountId}
           ORDER BY reconciled_at DESC, reconciliation_id COLLATE "C" DESC
@@ -315,6 +456,104 @@ export const readForwardPerformancePostgres = (
           LIMIT 1
         `.pipe(Effect.flatMap(decodeStartingCapital))
 
+        const cashYieldRows = yield* sql<Record<string, unknown>>`
+          WITH latest_reconciliation AS (
+            SELECT reconciliation_id, content_hash, reconciled_at
+            FROM reconciliations
+            WHERE account_id = ${accountId}
+            ORDER BY reconciled_at DESC, reconciliation_id COLLATE "C" DESC
+            LIMIT 1
+          ), first_cycle AS (
+            SELECT submission_open_at
+            FROM autonomous_cycles
+            WHERE account_id = ${accountId}
+              AND state IN ('COMPLETED', 'NO_TRADE')
+            ORDER BY submission_open_at, cycle_id COLLATE "C"
+            LIMIT 1
+          ), baseline_snapshot AS (
+            SELECT
+              event.event_id,
+              event.observed_at,
+              snapshot.cash_micros
+            FROM account_snapshots AS snapshot
+            JOIN broker_events AS event ON event.event_id = snapshot.event_id
+            WHERE snapshot.account_id = ${accountId}
+            ORDER BY event.source_sequence, event.event_id COLLATE "C"
+            LIMIT 1
+          ), opening_snapshot AS (
+            SELECT
+              event.event_id,
+              event.observed_at,
+              snapshot.cash_micros
+            FROM account_snapshots AS snapshot
+            JOIN broker_events AS event ON event.event_id = snapshot.event_id
+            CROSS JOIN latest_reconciliation
+            CROSS JOIN first_cycle
+            WHERE snapshot.account_id = ${accountId}
+              AND event.observed_at <= first_cycle.submission_open_at
+              AND event.observed_at <= latest_reconciliation.reconciled_at
+            ORDER BY event.observed_at DESC, event.source_sequence DESC, event.event_id COLLATE "C" DESC
+            LIMIT 1
+          ), pre_window_accounted_cash AS (
+            SELECT COALESCE(sum(transaction.cash_delta_micros), 0) AS cash_delta_micros
+            FROM accounting_transactions AS transaction
+            CROSS JOIN opening_snapshot
+            WHERE transaction.account_id = ${accountId}
+              AND transaction.occurred_at < opening_snapshot.observed_at
+          ), closing_snapshot AS (
+            SELECT
+              event.event_id,
+              event.observed_at,
+              snapshot.cash_micros
+            FROM account_snapshots AS snapshot
+            JOIN broker_events AS event ON event.event_id = snapshot.event_id
+            CROSS JOIN latest_reconciliation
+            WHERE snapshot.account_id = ${accountId}
+              AND event.observed_at <= latest_reconciliation.reconciled_at
+            ORDER BY event.observed_at DESC, event.source_sequence DESC, event.event_id COLLATE "C" DESC
+            LIMIT 1
+          ), accounted_cash AS (
+            SELECT COALESCE(sum(transaction.cash_delta_micros), 0) AS cash_delta_micros
+            FROM accounting_transactions AS transaction
+            CROSS JOIN latest_reconciliation
+            CROSS JOIN opening_snapshot
+            WHERE transaction.account_id = ${accountId}
+              AND transaction.occurred_at >= opening_snapshot.observed_at
+              AND transaction.occurred_at <= latest_reconciliation.reconciled_at
+          )
+          SELECT
+            latest_reconciliation.reconciliation_id,
+            latest_reconciliation.content_hash AS reconciliation_content_hash,
+            latest_reconciliation.reconciled_at,
+            baseline_snapshot.event_id AS baseline_account_event_id,
+            baseline_snapshot.observed_at AS baseline_observed_at,
+            baseline_snapshot.cash_micros::text AS baseline_cash_micros,
+            opening_snapshot.event_id AS opening_account_event_id,
+            opening_snapshot.observed_at AS opening_observed_at,
+            opening_snapshot.cash_micros::text AS opening_cash_micros,
+            pre_window_accounted_cash.cash_delta_micros::text AS pre_window_accounted_cash_delta_micros,
+            (
+              opening_snapshot.cash_micros
+              - baseline_snapshot.cash_micros
+              - pre_window_accounted_cash.cash_delta_micros
+            )::text AS pre_window_cash_residual_micros,
+            closing_snapshot.event_id AS closing_account_event_id,
+            closing_snapshot.observed_at AS closing_observed_at,
+            closing_snapshot.cash_micros::text AS closing_cash_micros,
+            accounted_cash.cash_delta_micros::text AS accounted_cash_delta_micros,
+            (
+              closing_snapshot.cash_micros
+              - opening_snapshot.cash_micros
+              - accounted_cash.cash_delta_micros
+            )::text AS cash_yield_micros
+          FROM latest_reconciliation
+          CROSS JOIN baseline_snapshot
+          CROSS JOIN opening_snapshot
+          CROSS JOIN pre_window_accounted_cash
+          CROSS JOIN closing_snapshot
+          CROSS JOIN accounted_cash
+        `.pipe(Effect.flatMap(decodeCashYieldEvidence))
+
         const transactionRows = yield* transactionQuery(sql, accountId).pipe(Effect.flatMap(decodeTransactions))
         const receiptRows = yield* receiptQuery(sql, accountId).pipe(Effect.flatMap(decodeReceipts))
         const receipts = yield* Effect.forEach(receiptRows, (row) =>
@@ -326,6 +565,24 @@ export const readForwardPerformancePostgres = (
             FROM reconciliations
             WHERE account_id = ${accountId}
             ORDER BY reconciled_at DESC, reconciliation_id COLLATE "C" DESC
+            LIMIT 1
+          ), first_cycle AS (
+            SELECT submission_open_at
+            FROM autonomous_cycles
+            WHERE account_id = ${accountId}
+              AND state IN ('COMPLETED', 'NO_TRADE')
+            ORDER BY submission_open_at, cycle_id COLLATE "C"
+            LIMIT 1
+          ), opening_snapshot AS (
+            SELECT event.observed_at
+            FROM account_snapshots AS snapshot
+            JOIN broker_events AS event ON event.event_id = snapshot.event_id
+            CROSS JOIN latest_reconciliation
+            CROSS JOIN first_cycle
+            WHERE snapshot.account_id = ${accountId}
+              AND event.observed_at <= first_cycle.submission_open_at
+              AND event.observed_at <= latest_reconciliation.reconciled_at
+            ORDER BY event.observed_at DESC, event.source_sequence DESC, event.event_id COLLATE "C" DESC
             LIMIT 1
           )
           SELECT DISTINCT
@@ -345,10 +602,12 @@ export const readForwardPerformancePostgres = (
             generation.qualification_image_digest
           FROM accounting_transactions AS transaction
           CROSS JOIN latest_reconciliation
+          CROSS JOIN opening_snapshot
           JOIN intents AS intent ON intent.intent_id = transaction.intent_id
           JOIN authority_generations AS generation
             ON generation.generation_hash = intent.authority_generation_hash
           WHERE transaction.account_id = ${accountId}
+            AND transaction.occurred_at >= opening_snapshot.observed_at
             AND transaction.occurred_at <= latest_reconciliation.reconciled_at
           ORDER BY
             generation.account_id,
@@ -503,6 +762,11 @@ export const readForwardPerformancePostgres = (
                 imageDigest: strategyRow.image_digest,
               }
         const reconciliationRow = reconciliationRows[0]
+        const cashYieldRow = cashYieldRows[0]
+        const exactness =
+          reconciliationRow === undefined
+            ? { performanceExact: false, cashYieldAdjustedExact: false }
+            : reconciliationExactness(accountId, reconciliationRow, cashYieldRow)
         const reconciliation =
           reconciliationRow === undefined
             ? undefined
@@ -510,7 +774,30 @@ export const readForwardPerformancePostgres = (
                 reconciliationId: reconciliationRow.reconciliation_id,
                 contentHash: reconciliationRow.content_hash,
                 status: reconciliationRow.status,
+                ...exactness,
                 reconciledAt: reconciliationRow.reconciled_at.toISOString(),
+              }
+        const cashYieldEvidence: ForwardPerformanceCashYieldEvidence | undefined =
+          cashYieldRow === undefined
+            ? undefined
+            : {
+                schemaVersion: 'bayn.forward-performance-cash-yield-evidence.v1',
+                reconciliationId: cashYieldRow.reconciliation_id,
+                reconciliationContentHash: cashYieldRow.reconciliation_content_hash,
+                reconciledAt: cashYieldRow.reconciled_at.toISOString(),
+                baselineAccountEventId: cashYieldRow.baseline_account_event_id,
+                baselineObservedAt: cashYieldRow.baseline_observed_at.toISOString(),
+                baselineCashMicros: cashYieldRow.baseline_cash_micros,
+                openingAccountEventId: cashYieldRow.opening_account_event_id,
+                openingObservedAt: cashYieldRow.opening_observed_at.toISOString(),
+                openingCashMicros: cashYieldRow.opening_cash_micros,
+                preWindowAccountedCashDeltaMicros: cashYieldRow.pre_window_accounted_cash_delta_micros,
+                preWindowCashResidualMicros: cashYieldRow.pre_window_cash_residual_micros,
+                closingAccountEventId: cashYieldRow.closing_account_event_id,
+                closingObservedAt: cashYieldRow.closing_observed_at.toISOString(),
+                closingCashMicros: cashYieldRow.closing_cash_micros,
+                accountedCashDeltaMicros: cashYieldRow.accounted_cash_delta_micros,
+                cashYieldMicros: cashYieldRow.cash_yield_micros,
               }
         const transactions = transactionRows.map(accountingTransactionFromRow)
         const transactionEvidence = transactionRows.map(
@@ -531,6 +818,7 @@ export const readForwardPerformancePostgres = (
           ...(startingCapitalRows[0] === undefined
             ? {}
             : { startingCapitalMicros: startingCapitalRows[0].starting_capital_micros }),
+          ...(cashYieldEvidence === undefined ? {} : { cashYieldEvidence }),
           transactions,
           transactionEvidence,
           receipts,

--- a/services/bayn/src/forward-performance/program.test.ts
+++ b/services/bayn/src/forward-performance/program.test.ts
@@ -3,11 +3,15 @@ import { describe, expect, test } from 'bun:test'
 import { PgClient } from '@effect/sql-pg'
 import { Effect, Layer, Redacted, Result } from 'effect'
 
+import { prepareAccounting } from '../accounting/domain'
 import { makeBrokerIdentity, BrokerEnvironment, BrokerProvider } from '../broker/identity'
 import type { LoadedRuntimeConfig } from '../config'
+import { planAccountingReceipt } from '../db/execution-store/decisions'
 import { BrokerAccess, noCapitalAuthority } from '../execution/authority'
+import { DiscrepancyKind, OrderSide, type Fill } from '../execution/contracts'
 import { readForwardPerformancePostgres } from './postgres'
 import { runForwardPerformance, type ForwardPerformanceReaders } from './program'
+import type { ForwardPerformanceCashYieldEvidence } from './model'
 
 const identityResult = makeBrokerIdentity({
   schemaVersion: 'bayn.broker-identity.v2',
@@ -78,10 +82,73 @@ interface SqlObservation {
   readonly statements: string[]
 }
 
-const makeReadOnlySql = (observation: SqlObservation): PgClient.PgClient => {
+interface SqlFixture {
+  readonly extraReconciliationDiscrepancy?: boolean
+  readonly preWindowCashResidualMicros?: string
+}
+
+const makeReadOnlySql = (observation: SqlObservation, fixture: SqlFixture = {}): PgClient.PgClient => {
   const query = ((strings: TemplateStringsArray) => {
     const statement = strings.join('?').replaceAll(/\s+/g, ' ').trim()
     observation.statements.push(statement)
+    if (statement.includes('SELECT reconciliation_id, content_hash, status, discrepancies, reconciled_at')) {
+      return Effect.succeed([
+        {
+          reconciliation_id: hash('a'),
+          content_hash: hash('b'),
+          status: 'DISCREPANCY',
+          discrepancies: [
+            {
+              discrepancyId: hash('e'),
+              kind: DiscrepancyKind.Cash,
+              identity: identityResult.success.accountId,
+              expected: '1000',
+              observed: '1200',
+              evidenceHash: hash('f'),
+              firstObservedAt: '2026-07-20T21:01:00.000Z',
+              lastObservedAt: '2026-07-20T21:01:00.000Z',
+            },
+            ...(fixture.extraReconciliationDiscrepancy
+              ? [
+                  {
+                    discrepancyId: hash('2'),
+                    kind: DiscrepancyKind.Account,
+                    identity: identityResult.success.accountId,
+                    expected: 'ACTIVE',
+                    observed: 'RESTRICTED',
+                    evidenceHash: hash('3'),
+                    firstObservedAt: '2026-07-20T21:01:00.000Z',
+                    lastObservedAt: '2026-07-20T21:01:00.000Z',
+                  },
+                ]
+              : []),
+          ],
+          reconciled_at: new Date('2026-07-20T21:01:00.000Z'),
+        },
+      ])
+    }
+    if (statement.includes('AS cash_yield_micros')) {
+      return Effect.succeed([
+        {
+          reconciliation_id: hash('a'),
+          reconciliation_content_hash: hash('b'),
+          reconciled_at: new Date('2026-07-20T21:01:00.000Z'),
+          baseline_account_event_id: hash('1'),
+          baseline_observed_at: new Date('2026-07-19T13:00:00.000Z'),
+          baseline_cash_micros: '1000',
+          opening_account_event_id: hash('c'),
+          opening_observed_at: new Date('2026-07-20T13:00:00.000Z'),
+          opening_cash_micros: '1000',
+          pre_window_accounted_cash_delta_micros: '0',
+          pre_window_cash_residual_micros: fixture.preWindowCashResidualMicros ?? '0',
+          closing_account_event_id: hash('d'),
+          closing_observed_at: new Date('2026-07-20T21:00:00.000Z'),
+          closing_cash_micros: '1200',
+          accounted_cash_delta_micros: '0',
+          cash_yield_micros: '200',
+        },
+      ])
+    }
     return Effect.succeed(statement.includes('count(*)::integer AS count') ? [{ count: 0 }] : [])
   }) as unknown as PgClient.PgClient
   Object.assign(query, {
@@ -90,14 +157,29 @@ const makeReadOnlySql = (observation: SqlObservation): PgClient.PgClient => {
   return query
 }
 
+const success = <A, E>(result: Result.Result<A, E>): A => {
+  if (Result.isFailure(result)) throw new Error('forward-performance program fixture failed')
+  return result.success
+}
+
+const hash = (character: string): string => character.repeat(64)
+const verifiedCashYield = {
+  source: 'TIGERBEETLE_CASH_YIELD_TRANSFER' as const,
+  transferId: '123456789',
+  transferTimestampNs: '1784563200000000000',
+  amountMicros: '200',
+}
+
 describe('forward performance read program', () => {
   test('executes only read-only PostgreSQL statements and never treats zero activity as profitable', async () => {
     const observation: SqlObservation = { statements: [] }
     const sql = makeReadOnlySql(observation)
+    let observedCashYieldEvidence: ForwardPerformanceCashYieldEvidence | undefined
     const readers: ForwardPerformanceReaders = {
       postgres: readForwardPerformancePostgres,
-      ledger: () =>
-        Effect.succeed({
+      ledger: (_config, _accountId, _plans, cashYieldEvidence) => {
+        observedCashYieldEvidence = cashYieldEvidence
+        return Effect.succeed({
           totals: {
             realizedGainMicros: '0',
             realizedLossMicros: '0',
@@ -108,7 +190,9 @@ describe('forward performance read program', () => {
           ledgerExact: true,
           missingLedgerAccountCount: 0,
           openPositionCount: 0,
-        }),
+          cashYieldEvidenceRequired: true,
+        })
+      },
     }
 
     const receipt = await Effect.runPromise(
@@ -124,6 +208,249 @@ describe('forward performance read program', () => {
     ).toEqual([])
     expect(receipt.evidence.status).toBe('INSUFFICIENT_EVIDENCE')
     expect(receipt.evidence.reasonCodes).toContain('ZERO_COMPLETED_EXECUTIONS')
+    expect(receipt.evidence.reasonCodes).toContain('NON_EXACT_RECONCILIATION')
+    expect(receipt.evidence.reasonCodes).toContain('CASH_YIELD_EVIDENCE_GAP')
     expect(receipt.profitability).toBe('UNDETERMINED')
+    expect(receipt.window).toMatchObject({
+      reconciliationStatus: 'DISCREPANCY',
+      cashYieldAdjustedExact: false,
+    })
+    expect(observedCashYieldEvidence).toEqual({
+      schemaVersion: 'bayn.forward-performance-cash-yield-evidence.v1',
+      reconciliationId: hash('a'),
+      reconciliationContentHash: hash('b'),
+      reconciledAt: '2026-07-20T21:01:00.000Z',
+      baselineAccountEventId: hash('1'),
+      baselineObservedAt: '2026-07-19T13:00:00.000Z',
+      baselineCashMicros: '1000',
+      openingAccountEventId: hash('c'),
+      openingObservedAt: '2026-07-20T13:00:00.000Z',
+      openingCashMicros: '1000',
+      preWindowAccountedCashDeltaMicros: '0',
+      preWindowCashResidualMicros: '0',
+      closingAccountEventId: hash('d'),
+      closingObservedAt: '2026-07-20T21:00:00.000Z',
+      closingCashMicros: '1200',
+      accountedCashDeltaMicros: '0',
+      cashYieldMicros: '200',
+    })
+  })
+
+  test('does not excuse any reconciliation discrepancy beyond the exact cash-yield residual', async () => {
+    const observation: SqlObservation = { statements: [] }
+    const sql = makeReadOnlySql(observation, { extraReconciliationDiscrepancy: true })
+    const readers: ForwardPerformanceReaders = {
+      postgres: readForwardPerformancePostgres,
+      ledger: () =>
+        Effect.succeed({
+          totals: {
+            realizedGainMicros: '0',
+            realizedLossMicros: '0',
+            brokerExecutionFeesMicros: '0',
+            otherChargedCostsMicros: '0',
+            cashYieldMicros: '200',
+          },
+          ledgerExact: true,
+          missingLedgerAccountCount: 0,
+          openPositionCount: 0,
+          cashYieldEvidenceRequired: true,
+          cashYieldEvidence: verifiedCashYield,
+        }),
+    }
+
+    const receipt = await Effect.runPromise(
+      Effect.scoped(runForwardPerformance(config, readers).pipe(Effect.provide(Layer.succeed(PgClient.PgClient, sql)))),
+    )
+
+    expect(receipt.evidence.reasonCodes).toContain('NON_EXACT_RECONCILIATION')
+    expect(receipt.profitability).toBe('UNDETERMINED')
+    expect(receipt.window).toMatchObject({
+      reconciliationStatus: 'DISCREPANCY',
+      cashYieldAdjustedExact: false,
+    })
+  })
+
+  test('combines reconciled cash yield with trade PnL in the production receipt', async () => {
+    const observation: SqlObservation = { statements: [] }
+    const sql = makeReadOnlySql(observation)
+    const cycleId = hash('1')
+    const qualificationRunId = hash('2')
+    const strategyProtocolHash = hash('3')
+    const executionPolicyHash = hash('4')
+    const strategyExecutionModelHash = hash('5')
+    const fill: Fill = {
+      schemaVersion: 'bayn.paper-fill.v1',
+      accountId: identityResult.success.accountId,
+      fillId: 'cash-yield-crossover-fill',
+      brokerOrderId: 'cash-yield-crossover-order',
+      clientOrderId: 'cash-yield-crossover-client-order',
+      symbol: 'NVDA',
+      side: OrderSide.Sell,
+      quantityMicros: '1000000',
+      priceMicros: '900',
+      feeMicros: '0',
+      occurredAt: '2026-07-20T20:00:00.000Z',
+    }
+    const prepared = success(
+      prepareAccounting(hash('6'), fill, { quantityMicros: '1000000', costMicros: '1000' }, config.tigerBeetle.ledger),
+    )
+    const receiptPlan = success(
+      planAccountingReceipt(prepared, config.tigerBeetle.clusterId.toString(), config.tigerBeetle.ledger),
+    )
+    const accountingReceipt = { ...receiptPlan, recordedAt: '2026-07-20T20:00:01.000Z' }
+    const readers: ForwardPerformanceReaders = {
+      postgres: () =>
+        Effect.succeed({
+          cycles: [
+            {
+              cycleId,
+              qualificationRunId,
+              strategyName: 'risk-balanced-trend',
+              strategyProtocolHash,
+              accountId: identityResult.success.accountId,
+              executionPolicyHash,
+              strategyExecutionModelHash,
+              state: 'COMPLETED',
+              submissionOpenAt: '2026-07-20T13:00:00.000Z',
+              terminalAt: '2026-07-20T21:00:00.000Z',
+            },
+          ],
+          strategy: {
+            qualificationRunId,
+            strategyName: 'risk-balanced-trend',
+            strategyProtocolHash,
+            strategyBehaviorHash: config.build.strategyBehaviorHash,
+            strategyParameterHash: config.build.strategyParameterHash,
+            strategyParameterSchemaVersion: 'bayn.risk-balanced-trend.protocol.v4',
+            sourceRevision: config.build.sourceRevision,
+            imageRepository: config.build.imageRepository,
+            imageDigest: config.build.imageDigest,
+          },
+          reconciliation: {
+            reconciliationId: hash('7'),
+            contentHash: hash('8'),
+            status: 'DISCREPANCY',
+            performanceExact: true,
+            cashYieldAdjustedExact: true,
+            reconciledAt: '2026-07-20T21:01:00.000Z',
+          },
+          startingCapitalMicros: '1000',
+          cashYieldEvidence: {
+            schemaVersion: 'bayn.forward-performance-cash-yield-evidence.v1',
+            reconciliationId: hash('7'),
+            reconciliationContentHash: hash('8'),
+            reconciledAt: '2026-07-20T21:01:00.000Z',
+            baselineAccountEventId: hash('b'),
+            baselineObservedAt: '2026-07-19T13:00:00.000Z',
+            baselineCashMicros: '1000',
+            openingAccountEventId: hash('9'),
+            openingObservedAt: '2026-07-20T13:00:00.000Z',
+            openingCashMicros: '1000',
+            preWindowAccountedCashDeltaMicros: '0',
+            preWindowCashResidualMicros: '0',
+            closingAccountEventId: hash('a'),
+            closingObservedAt: '2026-07-20T21:00:00.000Z',
+            closingCashMicros: '2100',
+            accountedCashDeltaMicros: prepared.transaction.cashDeltaMicros,
+            cashYieldMicros: '200',
+          },
+          transactions: [prepared.transaction],
+          transactionEvidence: [
+            {
+              transactionId: prepared.transaction.transactionId,
+              cycleId,
+              side: OrderSide.Sell,
+              feeMicros: '0',
+              realizedPnlMicros: '-100',
+              occurredAt: fill.occurredAt,
+            },
+          ],
+          receipts: [accountingReceipt],
+          durableExecutionBindings: [
+            {
+              accountId: identityResult.success.accountId,
+              accountReferenceHash: identityResult.success.identityHash,
+              provider: identityResult.success.provider,
+              environment: identityResult.success.environment,
+              qualificationRunId,
+              strategyName: 'risk-balanced-trend',
+              strategyProtocolHash,
+              strategyBehaviorHash: config.build.strategyBehaviorHash,
+              strategyParameterHash: config.build.strategyParameterHash,
+              strategyParameterSchemaVersion: 'bayn.risk-balanced-trend.protocol.v4',
+              executionPolicyHash,
+              sourceRevision: config.build.sourceRevision,
+              imageRepository: config.build.imageRepository,
+              imageDigest: config.build.imageDigest,
+            },
+          ],
+          unclosedCycleCount: 0,
+          unresolvedMutationCount: 0,
+          openPositionCount: 0,
+          unaccountedFillCount: 0,
+          postReconciliationActivityCount: 0,
+        }),
+      ledger: (_config, _accountId, _plans, cashYieldEvidence) => {
+        expect(cashYieldEvidence).toEqual({
+          schemaVersion: 'bayn.forward-performance-cash-yield-evidence.v1',
+          reconciliationId: hash('7'),
+          reconciliationContentHash: hash('8'),
+          reconciledAt: '2026-07-20T21:01:00.000Z',
+          baselineAccountEventId: hash('b'),
+          baselineObservedAt: '2026-07-19T13:00:00.000Z',
+          baselineCashMicros: '1000',
+          openingAccountEventId: hash('9'),
+          openingObservedAt: '2026-07-20T13:00:00.000Z',
+          openingCashMicros: '1000',
+          preWindowAccountedCashDeltaMicros: '0',
+          preWindowCashResidualMicros: '0',
+          closingAccountEventId: hash('a'),
+          closingObservedAt: '2026-07-20T21:00:00.000Z',
+          closingCashMicros: '2100',
+          accountedCashDeltaMicros: prepared.transaction.cashDeltaMicros,
+          cashYieldMicros: '200',
+        })
+        return Effect.succeed({
+          totals: {
+            realizedGainMicros: '0',
+            realizedLossMicros: '100',
+            brokerExecutionFeesMicros: '0',
+            otherChargedCostsMicros: '0',
+            cashYieldMicros: '200',
+          },
+          ledgerExact: true,
+          missingLedgerAccountCount: 0,
+          openPositionCount: 0,
+          cashYieldEvidenceRequired: true,
+          cashYieldEvidence: verifiedCashYield,
+        })
+      },
+    }
+
+    const receipt = await Effect.runPromise(
+      Effect.scoped(runForwardPerformance(config, readers).pipe(Effect.provide(Layer.succeed(PgClient.PgClient, sql)))),
+    )
+
+    expect(receipt.schemaVersion).toBe('bayn.forward-performance-receipt.v2')
+    expect(receipt.evidence).toEqual({
+      status: 'SUFFICIENT',
+      reasonCodes: [],
+      cashYield: verifiedCashYield,
+    })
+    expect(receipt.profitability).toBe('PROFITABLE')
+    expect(receipt.window).toMatchObject({
+      reconciliationStatus: 'DISCREPANCY',
+      cashYieldAdjustedExact: true,
+    })
+    expect(receipt.totals).toMatchObject({
+      grossRealizedPnlMicros: '-100',
+      cashYieldMicros: '200',
+      netRealizedPnlAfterCostsMicros: '100',
+      netRealizedReturn: {
+        numeratorMicros: '100',
+        denominatorMicros: '1000',
+        decimal: '0.100000000000',
+      },
+    })
   })
 })

--- a/services/bayn/src/forward-performance/program.ts
+++ b/services/bayn/src/forward-performance/program.ts
@@ -18,7 +18,7 @@ import {
   type ForwardPerformanceLedgerError,
 } from './tigerbeetle'
 import type { LedgerPlan } from '../ledger-plan'
-import type { ForwardPerformanceReceipt } from './model'
+import type { ForwardPerformanceCashYieldEvidence, ForwardPerformanceReceipt } from './model'
 
 export type ForwardPerformanceProgramCause =
   | CanonicalJsonFailure
@@ -46,6 +46,7 @@ export interface ForwardPerformanceReaders {
     config: Pick<LoadedRuntimeConfig, 'operationTimeoutMs' | 'tigerBeetle'>,
     accountId: string,
     plans: readonly LedgerPlan[],
+    cashYieldEvidence?: ForwardPerformanceCashYieldEvidence,
   ) => Effect.Effect<ForwardPerformanceLedgerEvidence, ForwardPerformanceLedgerError, Scope.Scope>
 }
 
@@ -92,8 +93,19 @@ export const runForwardPerformance = (
       [...accountingVerification.success.exactReceipts.values()].every(Boolean)
 
     const ledger = yield* readers
-      .ledger(config, identity.accountId, plans)
+      .ledger(config, identity.accountId, plans, postgres.cashYieldEvidence)
       .pipe(Effect.mapError((cause) => programError('ledger-read', cause.message, cause)))
+    const reconciliation =
+      postgres.reconciliation === undefined
+        ? undefined
+        : {
+            ...postgres.reconciliation,
+            performanceExact:
+              postgres.reconciliation.performanceExact &&
+              (!postgres.reconciliation.cashYieldAdjustedExact || ledger.cashYieldEvidence !== undefined),
+            cashYieldAdjustedExact:
+              postgres.reconciliation.cashYieldAdjustedExact && ledger.cashYieldEvidence !== undefined,
+          }
     const receipt = yield* Effect.fromResult(
       makeForwardPerformanceReceipt({
         runtime: {
@@ -110,12 +122,14 @@ export const runForwardPerformance = (
         durableExecutionBindings: postgres.durableExecutionBindings,
         cycles: postgres.cycles,
         ...(postgres.strategy === undefined ? {} : { strategy: postgres.strategy }),
-        ...(postgres.reconciliation === undefined ? {} : { reconciliation: postgres.reconciliation }),
+        ...(reconciliation === undefined ? {} : { reconciliation }),
         ...(postgres.startingCapitalMicros === undefined
           ? {}
           : { startingCapitalMicros: postgres.startingCapitalMicros }),
         transactions: postgres.transactionEvidence,
         ledgerTotals: ledger.totals,
+        cashYieldEvidenceRequired: ledger.cashYieldEvidenceRequired,
+        ...(ledger.cashYieldEvidence === undefined ? {} : { cashYieldEvidence: ledger.cashYieldEvidence }),
         accountingReceiptsExact,
         ledgerExact: ledger.ledgerExact,
         missingLedgerAccountCount: ledger.missingLedgerAccountCount,

--- a/services/bayn/src/forward-performance/tigerbeetle.test.ts
+++ b/services/bayn/src/forward-performance/tigerbeetle.test.ts
@@ -2,14 +2,16 @@ import assert from 'node:assert/strict'
 
 import { describe, expect, test } from 'bun:test'
 import { Effect, Result } from 'effect'
-import type { Account, Transfer } from 'tigerbeetle-node'
+import { AccountFlags, type Account, type Transfer } from 'tigerbeetle-node'
 
 import { prepareAccounting } from '../accounting/domain'
 import type { RuntimeConfig } from '../config'
 import { OrderSide, type Fill } from '../execution/contracts'
+import { stableU128 } from '../hash'
 import { assembleAccountPlan } from '../ledger/decisions'
-import type { LedgerPlan } from '../ledger-plan'
+import { AccountCode, LEDGER_BATCH_MAX, LEDGER_SCHEMA_VERSION, TransferCode, type LedgerPlan } from '../ledger-plan'
 import type { JournalDependencies, TigerBeetleClient } from '../tigerbeetle-client'
+import type { ForwardPerformanceCashYieldEvidence } from './model'
 import { readForwardPerformanceLedger } from './tigerbeetle'
 
 const accountId = 'paper-account-forward-performance'
@@ -18,6 +20,7 @@ const config = {
   operationTimeoutMs: 1_000,
   tigerBeetle: { clusterId: 2_001n, replicaAddresses: ['3000'], ledger },
 } satisfies Pick<RuntimeConfig, 'operationTimeoutMs' | 'tigerBeetle'>
+const hash = (character: string): string => character.repeat(64)
 
 const success = <A, E>(result: Result.Result<A, E>): A => {
   assert(Result.isSuccess(result), 'forward-performance ledger fixture must succeed')
@@ -79,9 +82,83 @@ const materializeAccounts = (plan: LedgerPlan): readonly Account[] => {
 }
 
 const materializeTransfers = (plan: LedgerPlan): readonly Transfer[] =>
-  plan.transfers.map((transfer) => ({ ...transfer, timestamp: 1n }))
+  plan.transfers.map((transfer) => ({ ...transfer, timestamp: transfer.timestamp === 0n ? 1n : transfer.timestamp }))
 
-const dependencies = (accounts: readonly Account[], transfers: readonly Transfer[]): JournalDependencies => ({
+const cashYieldEvidence = (
+  amount: bigint,
+  accountedCashDelta = 0n,
+  openingCash = 1_000_000_000n,
+): ForwardPerformanceCashYieldEvidence => ({
+  schemaVersion: 'bayn.forward-performance-cash-yield-evidence.v1',
+  reconciliationId: hash('c'),
+  reconciliationContentHash: hash('d'),
+  reconciledAt: '2026-07-21T21:01:00.000Z',
+  baselineAccountEventId: hash('a'),
+  baselineObservedAt: '2026-07-19T13:00:00.000Z',
+  baselineCashMicros: openingCash.toString(),
+  openingAccountEventId: hash('e'),
+  openingObservedAt: '2026-07-20T13:00:00.000Z',
+  openingCashMicros: openingCash.toString(),
+  preWindowAccountedCashDeltaMicros: '0',
+  preWindowCashResidualMicros: '0',
+  closingAccountEventId: hash('f'),
+  closingObservedAt: '2026-07-21T21:00:00.000Z',
+  closingCashMicros: (openingCash + accountedCashDelta + amount).toString(),
+  accountedCashDeltaMicros: accountedCashDelta.toString(),
+  cashYieldMicros: amount.toString(),
+})
+
+const observedCashYieldPlan = (plan: LedgerPlan, amount: bigint): LedgerPlan => {
+  const cashAccount = plan.accounts.find((account) => account.code === AccountCode.cash)
+  if (cashAccount === undefined) throw new Error('cash-yield fixture requires the persisted cash account')
+  const cashYieldAccountId = stableU128('bayn-paper-ledger-account-v1', accountId, 'cash-yield-income')
+  const cashYieldAccount: Account = {
+    id: cashYieldAccountId,
+    debits_pending: 0n,
+    debits_posted: 0n,
+    credits_pending: 0n,
+    credits_posted: 0n,
+    user_data_128: plan.runKey,
+    user_data_64: plan.runTag,
+    user_data_32: LEDGER_SCHEMA_VERSION,
+    reserved: 0,
+    ledger,
+    code: AccountCode.cashYieldIncome,
+    flags: AccountFlags.history,
+    timestamp: 0n,
+  }
+
+  const transfer: Transfer = {
+    id: stableU128('untrusted-observed-cash-yield-transfer', accountId),
+    debit_account_id: cashAccount.id,
+    credit_account_id: cashYieldAccountId,
+    amount,
+    pending_id: 0n,
+    user_data_128: stableU128('untrusted-observed-cash-yield-event', accountId),
+    user_data_64: plan.runTag,
+    user_data_32: LEDGER_SCHEMA_VERSION,
+    timeout: 0,
+    ledger,
+    code: TransferCode.cashYield,
+    flags: 0,
+    timestamp: 0n,
+  }
+  return {
+    ...plan,
+    accounts: [...plan.accounts, cashYieldAccount].toSorted((left, right) =>
+      left.id < right.id ? -1 : left.id > right.id ? 1 : 0,
+    ),
+    transfers: [...plan.transfers, transfer].toSorted((left, right) =>
+      left.id < right.id ? -1 : left.id > right.id ? 1 : 0,
+    ),
+  }
+}
+
+const dependencies = (
+  accounts: readonly Account[],
+  transfers: readonly Transfer[],
+  observedLimits?: { accounts?: number; transfers?: number },
+): JournalDependencies => ({
   resolveReplicaAddresses: () => Effect.succeed(['3000']),
   createClient: () =>
     ({
@@ -89,8 +166,14 @@ const dependencies = (accounts: readonly Account[], transfers: readonly Transfer
       createTransfers: async () => [],
       lookupAccounts: async () => [],
       lookupTransfers: async () => [],
-      queryAccounts: async () => [...accounts],
-      queryTransfers: async () => [...transfers],
+      queryAccounts: async (filter) => {
+        if (observedLimits !== undefined) observedLimits.accounts = filter.limit
+        return [...accounts]
+      },
+      queryTransfers: async (filter) => {
+        if (observedLimits !== undefined) observedLimits.transfers = filter.limit
+        return [...transfers]
+      },
       destroy: () => undefined,
     }) satisfies TigerBeetleClient,
 })
@@ -106,6 +189,7 @@ describe('forward performance TigerBeetle read', () => {
           config,
           accountId,
           accountingPlans,
+          undefined,
           dependencies(materializeAccounts(accountPlan), materializeTransfers(accountPlan)),
         ),
       ),
@@ -122,6 +206,147 @@ describe('forward performance TigerBeetle read', () => {
       ledgerExact: true,
       missingLedgerAccountCount: 0,
       openPositionCount: 0,
+      cashYieldEvidenceRequired: false,
+    })
+  })
+
+  test('leaves a genuine-yield residual insufficient until an authoritative event is persisted', async () => {
+    const accountingPlans = plans()
+    const accountPlan = success(assembleAccountPlan(accountId, accountingPlans))
+    const expectedYield = cashYieldEvidence(20_000_000n)
+    const observedLimits: { accounts?: number; transfers?: number } = {}
+
+    const evidence = await Effect.runPromise(
+      Effect.scoped(
+        readForwardPerformanceLedger(
+          config,
+          accountId,
+          accountingPlans,
+          expectedYield,
+          dependencies(materializeAccounts(accountPlan), materializeTransfers(accountPlan), observedLimits),
+        ),
+      ),
+    )
+
+    expect(observedLimits).toEqual({ accounts: LEDGER_BATCH_MAX, transfers: LEDGER_BATCH_MAX })
+    expect(evidence).toEqual({
+      totals: {
+        realizedGainMicros: '10000000',
+        realizedLossMicros: '0',
+        brokerExecutionFeesMicros: '300',
+        otherChargedCostsMicros: '0',
+        cashYieldMicros: '0',
+      },
+      ledgerExact: true,
+      missingLedgerAccountCount: 0,
+      openPositionCount: 0,
+      cashYieldEvidenceRequired: true,
+    })
+    expect(evidence.cashYieldEvidence).toBeUndefined()
+  })
+
+  test('keeps malformed durable cash-yield evidence fail closed', async () => {
+    const accountingPlans = plans()
+    const accountPlan = success(assembleAccountPlan(accountId, accountingPlans))
+    const expectedYield = cashYieldEvidence(20_000_000n)
+    const malformed = { ...expectedYield, preWindowCashResidualMicros: '1' }
+
+    const failure = await Effect.runPromise(
+      Effect.flip(
+        Effect.scoped(
+          readForwardPerformanceLedger(
+            config,
+            accountId,
+            accountingPlans,
+            malformed,
+            dependencies(materializeAccounts(accountPlan), materializeTransfers(accountPlan)),
+          ),
+        ),
+      ),
+    )
+
+    expect(failure).toMatchObject({
+      operation: 'read',
+      cause: { operation: 'verify-account', reason: 'invalid-transaction' },
+    })
+  })
+
+  test('leaves an external deposit residual insufficient without a semantic yield event', async () => {
+    const accountingPlans = plans()
+    const accountPlan = success(assembleAccountPlan(accountId, accountingPlans))
+    const residual = cashYieldEvidence(20_000_000n)
+
+    const evidence = await Effect.runPromise(
+      Effect.scoped(
+        readForwardPerformanceLedger(
+          config,
+          accountId,
+          accountingPlans,
+          residual,
+          dependencies(materializeAccounts(accountPlan), materializeTransfers(accountPlan)),
+        ),
+      ),
+    )
+
+    expect(evidence).toMatchObject({
+      totals: { cashYieldMicros: '0' },
+      ledgerExact: true,
+      missingLedgerAccountCount: 0,
+      cashYieldEvidenceRequired: true,
+    })
+    expect(evidence.cashYieldEvidence).toBeUndefined()
+  })
+
+  test('rejects a broker correction or arbitrary yield-like ledger record', async () => {
+    const accountingPlans = plans()
+    const accountPlan = success(assembleAccountPlan(accountId, accountingPlans))
+    const expectedYield = cashYieldEvidence(20_000_000n)
+    const observed = observedCashYieldPlan(accountPlan, 1_000_000n)
+
+    const evidence = await Effect.runPromise(
+      Effect.scoped(
+        readForwardPerformanceLedger(
+          config,
+          accountId,
+          accountingPlans,
+          expectedYield,
+          dependencies(materializeAccounts(observed), materializeTransfers(observed)),
+        ),
+      ),
+    )
+
+    expect(evidence.totals.cashYieldMicros).toBe('0')
+    expect(evidence.ledgerExact).toBe(false)
+    expect(evidence.missingLedgerAccountCount).toBe(0)
+    expect(evidence.cashYieldEvidenceRequired).toBe(true)
+    expect(evidence.cashYieldEvidence).toBeUndefined()
+  })
+
+  test('fails closed when the bounded account query reaches its exact limit', async () => {
+    const accountingPlans = plans()
+    const accountPlan = success(assembleAccountPlan(accountId, accountingPlans))
+    const sample = materializeAccounts(accountPlan)[0]
+    if (sample === undefined) throw new Error('ledger fixture requires one account')
+    const saturated = Array.from({ length: LEDGER_BATCH_MAX }, (_, index) => ({
+      ...sample,
+      id: BigInt(index + 1),
+    }))
+
+    const failure = await Effect.runPromise(
+      Effect.flip(
+        Effect.scoped(
+          readForwardPerformanceLedger(config, accountId, accountingPlans, undefined, dependencies(saturated, [])),
+        ),
+      ),
+    )
+
+    expect(failure).toMatchObject({
+      operation: 'read',
+      cause: {
+        operation: 'verify-account',
+        reason: 'batch-limit',
+        material: { accountCount: LEDGER_BATCH_MAX, transferCount: 0, limit: LEDGER_BATCH_MAX },
+      },
     })
   })
 })

--- a/services/bayn/src/forward-performance/tigerbeetle.ts
+++ b/services/bayn/src/forward-performance/tigerbeetle.ts
@@ -3,10 +3,21 @@ import type { Account } from 'tigerbeetle-node'
 
 import type { RuntimeConfig } from '../config'
 import { assembleAccountPlan, accountReconciliationQueries } from '../ledger/decisions'
-import { AccountCode, reconcileLedgerPlan, type LedgerPlan, type LedgerValidationError } from '../ledger-plan'
+import {
+  AccountCode,
+  LEDGER_BATCH_MAX,
+  ledgerValidationError,
+  reconcileLedgerPlan,
+  type LedgerPlan,
+  type LedgerValidationError,
+} from '../ledger-plan'
 import { makeTigerBeetleRequestClient, type JournalDependencies } from '../tigerbeetle-client'
 import type { OperationalError } from '../errors'
-import type { ForwardPerformanceLedgerTotals } from './model'
+import type {
+  ForwardPerformanceCashYieldBinding,
+  ForwardPerformanceCashYieldEvidence,
+  ForwardPerformanceLedgerTotals,
+} from './model'
 
 export class ForwardPerformanceLedgerError extends Data.TaggedError('ForwardPerformanceLedgerError')<{
   readonly operation: 'read'
@@ -19,6 +30,8 @@ export interface ForwardPerformanceLedgerEvidence {
   readonly ledgerExact: boolean
   readonly missingLedgerAccountCount: number
   readonly openPositionCount: number
+  readonly cashYieldEvidenceRequired: boolean
+  readonly cashYieldEvidence?: ForwardPerformanceCashYieldBinding
 }
 
 const ledgerError = (cause: OperationalError | LedgerValidationError): ForwardPerformanceLedgerError =>
@@ -38,17 +51,130 @@ const openInventoryCount = (accounts: readonly Account[]): number =>
     (account) => account.code === AccountCode.inventory && account.debits_posted !== account.credits_posted,
   ).length
 
+const SIGNED_I128_MIN = -(1n << 127n)
+const SIGNED_I128_MAX = (1n << 127n) - 1n
+const SHA256_PATTERN = /^[0-9a-f]{64}$/
+const INTEGER_PATTERN = /^(?:0|-[1-9][0-9]*|[1-9][0-9]*)$/
+
+const cashYieldFailure = (detail: string, material: Readonly<Record<string, unknown>>): LedgerValidationError =>
+  ledgerValidationError('verify-account', 'invalid-transaction', detail, material)
+
+const parseSignedI128 = (value: string, field: string): Result.Result<bigint, LedgerValidationError> => {
+  if (!INTEGER_PATTERN.test(value)) {
+    return Result.fail(cashYieldFailure('cash-yield evidence contains a noncanonical integer', { field, value }))
+  }
+  const parsed = BigInt(value)
+  return parsed < SIGNED_I128_MIN || parsed > SIGNED_I128_MAX
+    ? Result.fail(cashYieldFailure('cash-yield evidence exceeds signed int128', { field, value }))
+    : Result.succeed(parsed)
+}
+
+const validateCashYieldEvidence = (
+  evidence: ForwardPerformanceCashYieldEvidence | undefined,
+): Result.Result<bigint, LedgerValidationError> =>
+  Result.gen(function* () {
+    if (evidence === undefined) return 0n
+    if (
+      evidence.schemaVersion !== 'bayn.forward-performance-cash-yield-evidence.v1' ||
+      !SHA256_PATTERN.test(evidence.reconciliationId) ||
+      !SHA256_PATTERN.test(evidence.reconciliationContentHash) ||
+      !SHA256_PATTERN.test(evidence.baselineAccountEventId) ||
+      !SHA256_PATTERN.test(evidence.openingAccountEventId) ||
+      !SHA256_PATTERN.test(evidence.closingAccountEventId)
+    ) {
+      return yield* Result.fail(
+        cashYieldFailure('cash-yield evidence identity is invalid', {
+          schemaVersion: evidence.schemaVersion,
+          reconciliationId: evidence.reconciliationId,
+          reconciliationContentHash: evidence.reconciliationContentHash,
+          baselineAccountEventId: evidence.baselineAccountEventId,
+          openingAccountEventId: evidence.openingAccountEventId,
+          closingAccountEventId: evidence.closingAccountEventId,
+        }),
+      )
+    }
+
+    const reconciledAt = Date.parse(evidence.reconciledAt)
+    const baselineObservedAt = Date.parse(evidence.baselineObservedAt)
+    const openingObservedAt = Date.parse(evidence.openingObservedAt)
+    const closingObservedAt = Date.parse(evidence.closingObservedAt)
+    if (
+      !Number.isFinite(reconciledAt) ||
+      !Number.isFinite(baselineObservedAt) ||
+      !Number.isFinite(openingObservedAt) ||
+      !Number.isFinite(closingObservedAt) ||
+      baselineObservedAt > openingObservedAt ||
+      openingObservedAt > closingObservedAt ||
+      closingObservedAt > reconciledAt
+    ) {
+      return yield* Result.fail(
+        cashYieldFailure('cash-yield evidence chronology is invalid', {
+          reconciledAt: evidence.reconciledAt,
+          baselineObservedAt: evidence.baselineObservedAt,
+          openingObservedAt: evidence.openingObservedAt,
+          closingObservedAt: evidence.closingObservedAt,
+        }),
+      )
+    }
+
+    const baselineCash = yield* parseSignedI128(evidence.baselineCashMicros, 'baselineCashMicros')
+    const openingCash = yield* parseSignedI128(evidence.openingCashMicros, 'openingCashMicros')
+    const preWindowCashDelta = yield* parseSignedI128(
+      evidence.preWindowAccountedCashDeltaMicros,
+      'preWindowAccountedCashDeltaMicros',
+    )
+    const preWindowResidual = yield* parseSignedI128(
+      evidence.preWindowCashResidualMicros,
+      'preWindowCashResidualMicros',
+    )
+    const closingCash = yield* parseSignedI128(evidence.closingCashMicros, 'closingCashMicros')
+    const accountedCashDelta = yield* parseSignedI128(evidence.accountedCashDeltaMicros, 'accountedCashDeltaMicros')
+    const cashYieldAmount = yield* parseSignedI128(evidence.cashYieldMicros, 'cashYieldMicros')
+    const derivedPreWindowResidual = openingCash - baselineCash - preWindowCashDelta
+    const derivedCashYield = closingCash - openingCash - accountedCashDelta
+    if (
+      preWindowResidual !== 0n ||
+      derivedPreWindowResidual !== preWindowResidual ||
+      derivedCashYield < 0n ||
+      derivedCashYield > SIGNED_I128_MAX ||
+      cashYieldAmount !== derivedCashYield
+    ) {
+      return yield* Result.fail(
+        cashYieldFailure('cash-yield evidence does not reconcile durable cash snapshots', {
+          baselineCashMicros: evidence.baselineCashMicros,
+          openingCashMicros: evidence.openingCashMicros,
+          preWindowAccountedCashDeltaMicros: evidence.preWindowAccountedCashDeltaMicros,
+          preWindowCashResidualMicros: evidence.preWindowCashResidualMicros,
+          derivedPreWindowCashResidualMicros: derivedPreWindowResidual.toString(),
+          closingCashMicros: evidence.closingCashMicros,
+          accountedCashDeltaMicros: evidence.accountedCashDeltaMicros,
+          cashYieldMicros: evidence.cashYieldMicros,
+          derivedCashYieldMicros: derivedCashYield.toString(),
+        }),
+      )
+    }
+    return cashYieldAmount
+  })
+
 export const readForwardPerformanceLedger = (
   config: Pick<RuntimeConfig, 'operationTimeoutMs' | 'tigerBeetle'>,
   accountId: string,
   plans: readonly LedgerPlan[],
+  cashYieldEvidence?: ForwardPerformanceCashYieldEvidence,
   dependencies?: JournalDependencies,
 ): Effect.Effect<ForwardPerformanceLedgerEvidence, ForwardPerformanceLedgerError, Scope.Scope> =>
   Effect.gen(function* () {
-    const plan = yield* Effect.fromResult(assembleAccountPlan(accountId, plans)).pipe(Effect.mapError(ledgerError))
-    const queries = yield* Effect.fromResult(accountReconciliationQueries(plan, config.tigerBeetle.ledger)).pipe(
+    const cashYieldResidual = yield* Effect.fromResult(validateCashYieldEvidence(cashYieldEvidence)).pipe(
       Effect.mapError(ledgerError),
     )
+    const plan = yield* Effect.fromResult(assembleAccountPlan(accountId, plans)).pipe(Effect.mapError(ledgerError))
+    const boundedQueries = yield* Effect.fromResult(accountReconciliationQueries(plan, config.tigerBeetle.ledger)).pipe(
+      Effect.mapError(ledgerError),
+    )
+    const queries = {
+      accounts: { ...boundedQueries.accounts, limit: LEDGER_BATCH_MAX },
+      transfers: { ...boundedQueries.transfers, limit: LEDGER_BATCH_MAX },
+    }
     const client = yield* makeTigerBeetleRequestClient(config, dependencies).pipe(Effect.mapError(ledgerError))
     const [accounts, transfers] = yield* Effect.all(
       [
@@ -57,6 +183,23 @@ export const readForwardPerformanceLedger = (
       ],
       { concurrency: 'unbounded' },
     ).pipe(Effect.mapError(ledgerError))
+
+    if (accounts.length >= LEDGER_BATCH_MAX || transfers.length >= LEDGER_BATCH_MAX) {
+      return yield* Effect.fail(
+        ledgerError(
+          ledgerValidationError(
+            'verify-account',
+            'batch-limit',
+            'paper account reached the exact TigerBeetle reconciliation limit',
+            {
+              accountCount: accounts.length,
+              transferCount: transfers.length,
+              limit: LEDGER_BATCH_MAX,
+            },
+          ),
+        ),
+      )
+    }
 
     const expectedAccountIds = new Set(plan.accounts.map((account) => account.id))
     const actualAccountIds = new Set(accounts.map((account) => account.id))
@@ -69,10 +212,11 @@ export const readForwardPerformanceLedger = (
         realizedLossMicros: accountAmount(accounts, AccountCode.realizedLoss, 'debit').toString(),
         brokerExecutionFeesMicros: accountAmount(accounts, AccountCode.feeExpense, 'debit').toString(),
         otherChargedCostsMicros: '0',
-        cashYieldMicros: accountAmount(accounts, AccountCode.cashYieldIncome, 'credit').toString(),
+        cashYieldMicros: '0',
       },
       ledgerExact: Result.isSuccess(reconciliation),
       missingLedgerAccountCount,
       openPositionCount: openInventoryCount(accounts),
+      cashYieldEvidenceRequired: cashYieldResidual > 0n,
     }
   })


### PR DESCRIPTION
## Summary

Correct Bayn's authoritative forward-performance proof so cash yield is included exactly once in net realized economic income after costs while gross realized trade PnL remains gains minus losses.

- preserve explicit gross trade-PnL semantics
- compute checked net realized income as gross trade PnL minus broker fees and other charged costs plus authoritative cash yield
- retain `bayn.forward-performance-receipt.v2`
- derive the candidate cash residual from cutoff-bound PostgreSQL baseline/opening/closing account evidence and accounted cash deltas
- require zero unexplained pre-window cash drift
- refuse to classify any positive residual as yield because the current durable production graph contains no authoritative semantic yield event
- return zero cash yield plus `CASH_YIELD_EVIDENCE_GAP` and `INSUFFICIENT_EVIDENCE` for genuine-interest-looking residuals, external deposits, corrections, or other unexplained cash
- retain the domain/program authoritative-binding contract proving corrected positive and negative crossovers when such evidence is supplied by a future trusted reader
- keep bounded complete TigerBeetle reconciliation over persisted accounting only
- keep PostgreSQL and TigerBeetle access read-only

## Reproduced defect

Fresh main originally reported gross `-100`, cash yield `+200`, net `-100`, and `NOT_PROFITABLE`. Correct arithmetic is gross `-100`, net `+100`, and `PROFITABLE`, but only when authoritative semantic evidence proves the `+200` is genuine cash yield. Since no such persisted event currently exists, the live read-only proof now returns `INSUFFICIENT_EVIDENCE` instead of guessing.

## Validation

- `bun test src/forward-performance`: 25 passed, 0 failed
- `bun run tsc`
- `bun run lint`
- `bun run lint:oxlint`
- `bun run lint:oxlint:type`
- `bun run lint:effect`
- `bun run test`: 939 passed, 138 environment-gated skips, 0 failed
- `bun run build`

## Safety

- no broker mutation code changed
- no writer or TigerBeetle create operation added
- no order submission or cancellation path introduced
- no authority, candidate, PREPARE, cadence, health, runtime, workflow, credential, or manifest path changed
- PostgreSQL remains repeatable-read/read-only
- TigerBeetle access remains bounded query-only with exact persisted-accounting set/balance reconciliation
