### PR TITLE
fix(bayn): carry reviewed feedback fixes

### DIFF
--- a/packages/scripts/src/bayn/verify-release-review.test.ts
+++ b/packages/scripts/src/bayn/verify-release-review.test.ts
@@ -551,6 +551,49 @@ describe('Bayn exact-head release review eligibility', () => {
     })
   })
 
+  test('retries a stale feedback-attestation read and then accepts the indexed reply', async () => {
+    let calls = 0
+    const sleeps: number[] = []
+    const result = await pollBaynReleaseReview({
+      mainCommitSha,
+      baseRefName: 'main',
+      maxAttempts: 2,
+      pollIntervalMs: 10_000,
+      loadSnapshot: async () => {
+        calls += 1
+        return snapshot({
+          commitShas: [olderHeadSha, finalHeadSha],
+          reviews: [review({ commitSha: olderHeadSha })],
+          threads: [
+            thread({
+              comments: [
+                threadComment(),
+                ...(calls === 1
+                  ? []
+                  : [
+                      threadComment({
+                        authorLogin: 'gregkonush',
+                        authorAssociation: 'MEMBER',
+                        reviewCommitSha: finalHeadSha,
+                        reviewAuthorLogin: 'gregkonush',
+                        reviewSubmittedAt: '2026-07-30T07:01:30Z',
+                      }),
+                    ]),
+              ],
+            }),
+          ],
+        })
+      },
+      sleep: async (milliseconds) => {
+        sleeps.push(milliseconds)
+      },
+      now: () => evaluationNowMs,
+    })
+
+    expect(result).toMatchObject({ status: 'eligible', attempts: 2, timedOut: false })
+    expect(sleeps).toEqual([10_000])
+  })
+
   test('rejects an unreviewed post-review commit without a trusted feedback attestation', () => {
     expect(
       evaluateBaynReleaseReview({
@@ -567,7 +610,7 @@ describe('Bayn exact-head release review eligibility', () => {
     ).toMatchObject({
       status: 'hold',
       code: 'feedback-fix-attestation-missing',
-      retryable: false,
+      retryable: true,
     })
   })
 
@@ -600,7 +643,7 @@ describe('Bayn exact-head release review eligibility', () => {
     ).toMatchObject({
       status: 'hold',
       code: 'feedback-fix-attestation-missing',
-      retryable: false,
+      retryable: true,
     })
   })
 
@@ -634,7 +677,7 @@ describe('Bayn exact-head release review eligibility', () => {
     ).toMatchObject({
       status: 'hold',
       code: 'feedback-fix-attestation-missing',
-      retryable: false,
+      retryable: true,
     })
   })
 

--- a/packages/scripts/src/bayn/verify-release-review.test.ts
+++ b/packages/scripts/src/bayn/verify-release-review.test.ts
@@ -17,6 +17,7 @@ import {
   type BaynReleaseReviewSnapshot,
   type PullRequestReview,
   type PullRequestReviewThread,
+  type PullRequestReviewThreadComment,
   type SuccessfulPublishRun,
 } from './verify-release-review'
 
@@ -60,6 +61,21 @@ const thread = (overrides: Partial<PullRequestReviewThread> = {}): PullRequestRe
   isOutdated: false,
   path: 'packages/scripts/src/bayn/verify-release-review.ts',
   url: 'https://github.com/proompteng/lab/pull/13390#discussion_r1',
+  comments: [],
+  ...overrides,
+})
+
+const threadComment = (overrides: Partial<PullRequestReviewThreadComment> = {}): PullRequestReviewThreadComment => ({
+  authorLogin: baynCodexReviewer,
+  authorAssociation: 'NONE',
+  body: 'Review finding',
+  createdAt: '2026-07-30T07:01:00Z',
+  commitSha: olderHeadSha,
+  reviewCommitSha: olderHeadSha,
+  reviewAuthorLogin: baynCodexReviewer,
+  reviewSubmittedAt: '2026-07-30T07:01:00Z',
+  reviewState: 'COMMENTED',
+  url: 'https://github.com/proompteng/lab/pull/13390#discussion_r1',
   ...overrides,
 })
 
@@ -69,6 +85,7 @@ const snapshot = (
     readonly reviews?: readonly PullRequestReview[]
     readonly threads?: readonly PullRequestReviewThread[]
     readonly mainCommitParents?: readonly string[]
+    readonly commitShas?: readonly string[]
   } = {},
 ): BaynReleaseReviewSnapshot => {
   const associated = options.associated ?? [associatedPull()]
@@ -87,6 +104,7 @@ const snapshot = (
             mergedAt: source.mergedAt,
             reviews: options.reviews ?? [review()],
             threads: options.threads ?? [],
+            commitShas: options.commitShas ?? [source.headSha],
           },
   }
 }
@@ -131,6 +149,7 @@ const reviewSnapshotFor = (options: {
         }),
       ],
       threads: options.threads ?? [],
+      commitShas: [options.headSha],
     },
   }
 }
@@ -419,6 +438,20 @@ describe('Bayn publication-range eligibility', () => {
           },
         })
       }
+      if (request.query.includes('BaynReleasePullRequestCommits')) {
+        return Response.json({
+          data: {
+            repository: {
+              pullRequest: {
+                commits: {
+                  nodes: [{ commit: { oid: finalHeadSha } }],
+                  pageInfo: { hasNextPage: false, endCursor: null },
+                },
+              },
+            },
+          },
+        })
+      }
       throw new Error(`unexpected fixture request: ${url}`)
     }) as typeof fetch
 
@@ -479,6 +512,129 @@ describe('Bayn exact-head release review eligibility', () => {
       status: 'hold',
       code: 'exact-head-review-missing',
       retryable: true,
+    })
+  })
+
+  test('carries a reviewed head across an auditable feedback-fix commit', () => {
+    expect(
+      evaluateBaynReleaseReview({
+        mainCommitSha,
+        baseRefName: 'main',
+        snapshot: snapshot({
+          commitShas: [olderHeadSha, finalHeadSha],
+          reviews: [review({ commitSha: olderHeadSha })],
+          threads: [
+            thread({
+              comments: [
+                threadComment(),
+                threadComment({
+                  authorLogin: 'gregkonush',
+                  authorAssociation: 'MEMBER',
+                  body: 'Fixed in final head.',
+                  createdAt: '2026-07-30T07:01:30Z',
+                  reviewCommitSha: finalHeadSha,
+                  reviewAuthorLogin: 'gregkonush',
+                  reviewSubmittedAt: '2026-07-30T07:01:30Z',
+                }),
+              ],
+            }),
+          ],
+        }),
+        nowMs: evaluationNowMs,
+        pushBeforeSha: null,
+      }),
+    ).toEqual({
+      status: 'eligible',
+      prNumber: 13390,
+      headSha: finalHeadSha,
+      reviewSubmittedAt: '2026-07-30T07:01:00Z',
+    })
+  })
+
+  test('rejects an unreviewed post-review commit without a trusted feedback attestation', () => {
+    expect(
+      evaluateBaynReleaseReview({
+        mainCommitSha,
+        baseRefName: 'main',
+        snapshot: snapshot({
+          commitShas: [olderHeadSha, finalHeadSha],
+          reviews: [review({ commitSha: olderHeadSha })],
+          threads: [thread({ comments: [threadComment()] })],
+        }),
+        nowMs: evaluationNowMs,
+        pushBeforeSha: null,
+      }),
+    ).toMatchObject({
+      status: 'hold',
+      code: 'feedback-fix-attestation-missing',
+      retryable: false,
+    })
+  })
+
+  test('rejects a feedback reply from an untrusted association', () => {
+    expect(
+      evaluateBaynReleaseReview({
+        mainCommitSha,
+        baseRefName: 'main',
+        snapshot: snapshot({
+          commitShas: [olderHeadSha, finalHeadSha],
+          reviews: [review({ commitSha: olderHeadSha })],
+          threads: [
+            thread({
+              comments: [
+                threadComment(),
+                threadComment({
+                  authorLogin: 'external-user',
+                  authorAssociation: 'NONE',
+                  reviewCommitSha: finalHeadSha,
+                  reviewAuthorLogin: 'external-user',
+                  reviewSubmittedAt: '2026-07-30T07:01:30Z',
+                }),
+              ],
+            }),
+          ],
+        }),
+        nowMs: evaluationNowMs,
+        pushBeforeSha: null,
+      }),
+    ).toMatchObject({
+      status: 'hold',
+      code: 'feedback-fix-attestation-missing',
+      retryable: false,
+    })
+  })
+
+  test('requires an attestation for every commit after the reviewed head', () => {
+    const intermediateFixSha = '4'.repeat(40)
+    expect(
+      evaluateBaynReleaseReview({
+        mainCommitSha,
+        baseRefName: 'main',
+        snapshot: snapshot({
+          commitShas: [olderHeadSha, intermediateFixSha, finalHeadSha],
+          reviews: [review({ commitSha: olderHeadSha })],
+          threads: [
+            thread({
+              comments: [
+                threadComment(),
+                threadComment({
+                  authorLogin: 'gregkonush',
+                  authorAssociation: 'MEMBER',
+                  reviewCommitSha: finalHeadSha,
+                  reviewAuthorLogin: 'gregkonush',
+                  reviewSubmittedAt: '2026-07-30T07:01:30Z',
+                }),
+              ],
+            }),
+          ],
+        }),
+        nowMs: evaluationNowMs,
+        pushBeforeSha: null,
+      }),
+    ).toMatchObject({
+      status: 'hold',
+      code: 'feedback-fix-attestation-missing',
+      retryable: false,
     })
   })
 
@@ -846,6 +1002,20 @@ describe('Bayn exact-head release review eligibility', () => {
               pullRequest: {
                 reviewThreads: {
                   nodes: [],
+                  pageInfo: { hasNextPage: false, endCursor: null },
+                },
+              },
+            },
+          },
+        })
+      }
+      if (request.query.includes('BaynReleasePullRequestCommits')) {
+        return Response.json({
+          data: {
+            repository: {
+              pullRequest: {
+                commits: {
+                  nodes: [{ commit: { oid: finalHeadSha } }],
                   pageInfo: { hasNextPage: false, endCursor: null },
                 },
               },

--- a/packages/scripts/src/bayn/verify-release-review.ts
+++ b/packages/scripts/src/bayn/verify-release-review.ts
@@ -22,12 +22,26 @@ export interface PullRequestReview {
   readonly state: string
 }
 
+export interface PullRequestReviewThreadComment {
+  readonly authorLogin: string | null
+  readonly authorAssociation: string
+  readonly body: string
+  readonly createdAt: string
+  readonly commitSha: string | null
+  readonly reviewCommitSha: string | null
+  readonly reviewAuthorLogin: string | null
+  readonly reviewSubmittedAt: string | null
+  readonly reviewState: string | null
+  readonly url: string
+}
+
 export interface PullRequestReviewThread {
   readonly id: string
   readonly isResolved: boolean
   readonly isOutdated: boolean
   readonly path: string | null
   readonly url: string | null
+  readonly comments: readonly PullRequestReviewThreadComment[]
 }
 
 export interface PullRequestReviewState {
@@ -38,6 +52,7 @@ export interface PullRequestReviewState {
   readonly mergedAt: string | null
   readonly reviews: readonly PullRequestReview[]
   readonly threads: readonly PullRequestReviewThread[]
+  readonly commitShas: readonly string[]
 }
 
 export interface BaynReleaseReviewSnapshot {
@@ -103,10 +118,12 @@ export type BaynReleaseReviewHoldCode =
   | 'non-single-commit-main-push'
   | 'associated-source-pr-merge-mismatch'
   | 'source-pr-metadata-mismatch'
+  | 'source-pr-commit-history-mismatch'
   | 'exact-head-review-pending'
   | 'exact-head-review-missing'
   | 'exact-head-review-changes-requested'
   | 'exact-head-review-settling'
+  | 'feedback-fix-attestation-missing'
   | 'active-unresolved-review-threads'
   | 'github-api-error'
   | 'github-api-timeout'
@@ -253,6 +270,7 @@ export const isBaynReleaseAffectingPath = (path: string): boolean =>
   exactBaynReleasePaths.has(path)
 
 const eligibleReviewStates = new Set(['APPROVED', 'COMMENTED'])
+const trustedFeedbackAssociations = new Set(['MEMBER', 'OWNER', 'COLLABORATOR'])
 
 export const evaluateBaynReleaseReview = (input: {
   readonly mainCommitSha: string
@@ -319,9 +337,8 @@ export const evaluateBaynReleaseReview = (input: {
     )
   }
 
-  const exactHeadReviews = pullRequest.reviews.filter(
-    (review) => review.authorLogin === baynCodexReviewer && review.commitSha === pullRequest.headSha,
-  )
+  const codexReviews = pullRequest.reviews.filter((review) => review.authorLogin === baynCodexReviewer)
+  const exactHeadReviews = codexReviews.filter((review) => review.commitSha === pullRequest.headSha)
   const hasPendingExactHeadReview = exactHeadReviews.some(
     (review) => review.submittedAt === null || review.state === 'PENDING',
   )
@@ -335,47 +352,82 @@ export const evaluateBaynReleaseReview = (input: {
   const exactSubmittedReview = exactHeadReviews
     .filter((review) => review.submittedAt !== null)
     .toSorted((left, right) => (right.submittedAt as string).localeCompare(left.submittedAt as string))[0]
-  if (exactSubmittedReview === undefined) {
-    const olderReviewedHeads = [
-      ...new Set(
-        pullRequest.reviews
-          .filter(
-            (review) =>
-              review.authorLogin === baynCodexReviewer && review.commitSha !== null && review.submittedAt !== null,
-          )
-          .map((review) => shortSha(review.commitSha as string)),
-      ),
-    ]
-    const olderReviewDetail =
-      olderReviewedHeads.length === 0
-        ? 'no submitted Codex review exists'
-        : `reviewed older head(s): ${olderReviewedHeads.join(', ')}`
-    return hold(
-      'exact-head-review-missing',
-      `source PR #${pullRequest.number} final head ${shortSha(pullRequest.headSha)} lacks a submitted ${baynCodexReviewer} review; ${olderReviewDetail}`,
-      true,
-    )
+
+  let reviewEvidence = exactSubmittedReview
+  let feedbackFixCommitShas: readonly string[] = []
+  if (reviewEvidence === undefined) {
+    if (
+      pullRequest.commitShas.length === 0 ||
+      pullRequest.commitShas.at(-1) !== pullRequest.headSha ||
+      new Set(pullRequest.commitShas).size !== pullRequest.commitShas.length
+    ) {
+      return hold(
+        'source-pr-commit-history-mismatch',
+        `source PR #${pullRequest.number} commit history does not uniquely terminate at final head ${shortSha(pullRequest.headSha)}`,
+        false,
+      )
+    }
+
+    const priorSubmittedReviews = codexReviews
+      .filter(
+        (review) =>
+          review.commitSha !== null &&
+          review.commitSha !== pullRequest.headSha &&
+          review.submittedAt !== null &&
+          pullRequest.commitShas.includes(review.commitSha),
+      )
+      .toSorted((left, right) => (right.submittedAt as string).localeCompare(left.submittedAt as string))
+    reviewEvidence = priorSubmittedReviews[0]
+    if (reviewEvidence === undefined) {
+      const olderReviewedHeads = [
+        ...new Set(
+          codexReviews
+            .filter((review) => review.commitSha !== null && review.submittedAt !== null)
+            .map((review) => shortSha(review.commitSha as string)),
+        ),
+      ]
+      const olderReviewDetail =
+        olderReviewedHeads.length === 0
+          ? 'no submitted Codex review exists'
+          : `reviewed head(s) outside the final PR history: ${olderReviewedHeads.join(', ')}`
+      return hold(
+        'exact-head-review-missing',
+        `source PR #${pullRequest.number} final head ${shortSha(pullRequest.headSha)} lacks exact-head or auditable feedback-fix review evidence; ${olderReviewDetail}`,
+        true,
+      )
+    }
+
+    const reviewedCommitIndex = pullRequest.commitShas.indexOf(reviewEvidence.commitSha as string)
+    if (reviewedCommitIndex < 0 || reviewedCommitIndex >= pullRequest.commitShas.length - 1) {
+      return hold(
+        'source-pr-commit-history-mismatch',
+        `source PR #${pullRequest.number} reviewed head ${shortSha(reviewEvidence.commitSha as string)} does not precede final head ${shortSha(pullRequest.headSha)}`,
+        false,
+      )
+    }
+    feedbackFixCommitShas = pullRequest.commitShas.slice(reviewedCommitIndex + 1)
   }
-  if (exactSubmittedReview.state === 'CHANGES_REQUESTED') {
+
+  if (reviewEvidence.state === 'CHANGES_REQUESTED') {
     return hold(
       'exact-head-review-changes-requested',
-      `source PR #${pullRequest.number} latest exact-head ${baynCodexReviewer} review requests changes`,
+      `source PR #${pullRequest.number} latest applicable ${baynCodexReviewer} review requests changes`,
       false,
     )
   }
-  if (!eligibleReviewStates.has(exactSubmittedReview.state)) {
+  if (!eligibleReviewStates.has(reviewEvidence.state)) {
     return hold(
       'exact-head-review-missing',
-      `source PR #${pullRequest.number} latest exact-head ${baynCodexReviewer} review state ${exactSubmittedReview.state} is not release-eligible`,
+      `source PR #${pullRequest.number} latest applicable ${baynCodexReviewer} review state ${reviewEvidence.state} is not release-eligible`,
       false,
     )
   }
 
-  const reviewSubmittedAtMs = Date.parse(exactSubmittedReview.submittedAt as string)
+  const reviewSubmittedAtMs = Date.parse(reviewEvidence.submittedAt as string)
   if (!Number.isFinite(reviewSubmittedAtMs)) {
     return hold(
       'source-pr-metadata-mismatch',
-      `source PR #${pullRequest.number} exact-head review has an invalid submitted-at timestamp`,
+      `source PR #${pullRequest.number} applicable review has an invalid submitted-at timestamp`,
       false,
     )
   }
@@ -386,6 +438,42 @@ export const evaluateBaynReleaseReview = (input: {
       `source PR #${pullRequest.number} exact-head review is ${Math.max(0, Math.floor(reviewAgeMs / 1_000))}s old; waiting for review threads to settle`,
       true,
     )
+  }
+
+  if (feedbackFixCommitShas.length > 0) {
+    const reviewedHeadSha = reviewEvidence.commitSha as string
+    for (const fixCommitSha of feedbackFixCommitShas) {
+      const hasTrustedAttestation = pullRequest.threads.some((thread) => {
+        if (!thread.isResolved) return false
+        const belongsToReviewedHead = thread.comments.some(
+          (comment) =>
+            comment.reviewAuthorLogin === baynCodexReviewer &&
+            comment.reviewCommitSha === reviewedHeadSha &&
+            comment.reviewSubmittedAt === reviewEvidence.submittedAt,
+        )
+        if (!belongsToReviewedHead) return false
+        return thread.comments.some((comment) => {
+          if (
+            comment.authorLogin === null ||
+            comment.authorLogin === baynCodexReviewer ||
+            !trustedFeedbackAssociations.has(comment.authorAssociation) ||
+            comment.reviewCommitSha !== fixCommitSha ||
+            comment.reviewSubmittedAt === null
+          ) {
+            return false
+          }
+          const attestationTime = Date.parse(comment.reviewSubmittedAt)
+          return Number.isFinite(attestationTime) && attestationTime >= reviewSubmittedAtMs
+        })
+      })
+      if (!hasTrustedAttestation) {
+        return hold(
+          'feedback-fix-attestation-missing',
+          `source PR #${pullRequest.number} final head ${shortSha(pullRequest.headSha)} carries review from ${shortSha(reviewedHeadSha)}, but post-review commit ${shortSha(fixCommitSha)} lacks a trusted member reply on a resolved Codex thread from that review`,
+          false,
+        )
+      }
+    }
   }
 
   const unresolvedThreads = pullRequest.threads.filter((thread) => !thread.isResolved)
@@ -405,7 +493,7 @@ export const evaluateBaynReleaseReview = (input: {
     status: 'eligible',
     prNumber: pullRequest.number,
     headSha: pullRequest.headSha,
-    reviewSubmittedAt: exactSubmittedReview.submittedAt as string,
+    reviewSubmittedAt: reviewEvidence.submittedAt as string,
   }
 }
 
@@ -667,6 +755,11 @@ const expectString = (value: unknown, context: string): string => {
   if (typeof value !== 'string' || value.length === 0) {
     throw new GitHubReleaseReviewError('github-api-invalid-response', context)
   }
+  return value
+}
+
+const expectAnyString = (value: unknown, context: string): string => {
+  if (typeof value !== 'string') throw new GitHubReleaseReviewError('github-api-invalid-response', context)
   return value
 }
 
@@ -942,8 +1035,37 @@ const pullRequestThreadsQuery = `
             isResolved
             isOutdated
             path
-            comments(first: 1) { nodes { url } }
+            comments(first: 100) {
+              nodes {
+                author { login }
+                authorAssociation
+                body
+                createdAt
+                commit { oid }
+                pullRequestReview {
+                  author { login }
+                  commit { oid }
+                  submittedAt
+                  state
+                }
+                url
+              }
+              pageInfo { hasNextPage endCursor }
+            }
           }
+          pageInfo { hasNextPage endCursor }
+        }
+      }
+    }
+  }
+`
+
+const pullRequestCommitsQuery = `
+  query BaynReleasePullRequestCommits($owner: String!, $name: String!, $number: Int!, $cursor: String) {
+    repository(owner: $owner, name: $name) {
+      pullRequest(number: $number) {
+        commits(first: 100, after: $cursor) {
+          nodes { commit { oid } }
           pageInfo { hasNextPage endCursor }
         }
       }
@@ -1048,15 +1170,79 @@ const fetchPullRequestThreads = async (
       if (!Array.isArray(comments.nodes)) {
         throw new GitHubReleaseReviewError('github-api-invalid-response', `${operation} thread comments ${index}`)
       }
-      const firstComment = comments.nodes[0]
-      const comment =
-        firstComment === undefined ? null : expectRecord(firstComment, `${operation} first comment ${index}`)
+      const commentPageInfo = parsePageInfo(comments, `${operation} thread comments ${index}`)
+      if (commentPageInfo.hasNextPage) {
+        throw new GitHubReleaseReviewError('github-api-pagination-limit', `${operation} thread comments ${index}`)
+      }
+      const parsedComments = comments.nodes.map((commentItem, commentIndex): PullRequestReviewThreadComment => {
+        const comment = expectRecord(commentItem, `${operation} thread ${index} comment ${commentIndex}`)
+        const author =
+          comment.author === null
+            ? null
+            : expectRecord(comment.author, `${operation} thread ${index} comment ${commentIndex} author`)
+        const commit =
+          comment.commit === null
+            ? null
+            : expectRecord(comment.commit, `${operation} thread ${index} comment ${commentIndex} commit`)
+        const review =
+          comment.pullRequestReview === null
+            ? null
+            : expectRecord(comment.pullRequestReview, `${operation} thread ${index} comment ${commentIndex} review`)
+        const reviewAuthor =
+          review === null || review.author === null
+            ? null
+            : expectRecord(review.author, `${operation} thread ${index} comment ${commentIndex} review author`)
+        const reviewCommit =
+          review === null || review.commit === null
+            ? null
+            : expectRecord(review.commit, `${operation} thread ${index} comment ${commentIndex} review commit`)
+        return {
+          authorLogin:
+            author === null
+              ? null
+              : expectString(author.login, `${operation} thread ${index} comment ${commentIndex} author login`),
+          authorAssociation: expectString(
+            comment.authorAssociation,
+            `${operation} thread ${index} comment ${commentIndex} author association`,
+          ),
+          body: expectAnyString(comment.body, `${operation} thread ${index} comment ${commentIndex} body`),
+          createdAt: expectString(comment.createdAt, `${operation} thread ${index} comment ${commentIndex} created at`),
+          commitSha:
+            commit === null
+              ? null
+              : expectSha(commit.oid, `${operation} thread ${index} comment ${commentIndex} commit SHA`),
+          reviewCommitSha:
+            reviewCommit === null
+              ? null
+              : expectSha(reviewCommit.oid, `${operation} thread ${index} comment ${commentIndex} review commit SHA`),
+          reviewAuthorLogin:
+            reviewAuthor === null
+              ? null
+              : expectString(
+                  reviewAuthor.login,
+                  `${operation} thread ${index} comment ${commentIndex} review author login`,
+                ),
+          reviewSubmittedAt:
+            review === null
+              ? null
+              : expectNullableString(
+                  review.submittedAt,
+                  `${operation} thread ${index} comment ${commentIndex} review submitted at`,
+                ),
+          reviewState:
+            review === null
+              ? null
+              : expectString(review.state, `${operation} thread ${index} comment ${commentIndex} review state`),
+          url: expectString(comment.url, `${operation} thread ${index} comment ${commentIndex} URL`),
+        }
+      })
       threads.push({
         id: expectString(thread.id, `${operation} thread ID ${index}`),
         isResolved: expectBoolean(thread.isResolved, `${operation} resolved ${index}`),
         isOutdated: expectBoolean(thread.isOutdated, `${operation} outdated ${index}`),
         path: expectNullableString(thread.path, `${operation} path ${index}`),
-        url: comment === null ? null : expectString(comment.url, `${operation} comment URL ${index}`),
+        url: parsedComments[0]?.url ?? null,
+        comments: parsedComments,
       })
     }
     const pageInfo = parsePageInfo(connection, operation)
@@ -1065,6 +1251,37 @@ const fetchPullRequestThreads = async (
     cursor = pageInfo.endCursor
   }
   throw new GitHubReleaseReviewError('github-api-pagination-limit', `read source PR #${pullNumber} review threads`)
+}
+
+const fetchPullRequestCommitShas = async (
+  options: GitHubLoaderOptions,
+  pullNumber: number,
+): Promise<readonly string[]> => {
+  const commitShas: string[] = []
+  let cursor: string | null = null
+  for (let page = 0; page < maximumGraphqlPages; page += 1) {
+    const operation = `read source PR #${pullNumber} commits page ${page + 1}`
+    const data = await requestGraphql({
+      query: pullRequestCommitsQuery,
+      variables: { owner: options.owner, name: options.name, number: pullNumber, cursor },
+      operation,
+      token: options.token,
+      requestTimeoutMs: options.requestTimeoutMs,
+      fetchFn: options.fetchFn,
+    })
+    const connection = expectRecord(graphqlPullRequest(data, operation).commits, operation)
+    if (!Array.isArray(connection.nodes)) throw new GitHubReleaseReviewError('github-api-invalid-response', operation)
+    for (const [index, item] of connection.nodes.entries()) {
+      const node = expectRecord(item, `${operation} node ${index}`)
+      const commit = expectRecord(node.commit, `${operation} commit ${index}`)
+      commitShas.push(expectSha(commit.oid, `${operation} commit ${index} SHA`))
+    }
+    const pageInfo = parsePageInfo(connection, operation)
+    if (!pageInfo.hasNextPage) return commitShas
+    if (pageInfo.endCursor === null) throw new GitHubReleaseReviewError('github-api-invalid-response', operation)
+    cursor = pageInfo.endCursor
+  }
+  throw new GitHubReleaseReviewError('github-api-pagination-limit', `read source PR #${pullNumber} commits`)
 }
 
 interface GitHubLoaderOptions {
@@ -1119,13 +1336,16 @@ const loadCommitReviewSnapshot = async (
 
   const candidate = candidates[0]
   if (candidate === undefined) throw new Error('source pull selection was unexpectedly empty')
-  const metadata = await fetchPullRequestMetadata(options, candidate.number)
-  const reviews = await fetchPullRequestReviews(options, candidate.number)
-  const threads = await fetchPullRequestThreads(options, candidate.number)
+  const [metadata, reviews, threads, commitShas] = await Promise.all([
+    fetchPullRequestMetadata(options, candidate.number),
+    fetchPullRequestReviews(options, candidate.number),
+    fetchPullRequestThreads(options, candidate.number),
+    fetchPullRequestCommitShas(options, candidate.number),
+  ])
   return {
     mainCommitParents: commit.parents,
     associatedPullRequests,
-    pullRequest: { ...metadata, reviews, threads },
+    pullRequest: { ...metadata, reviews, threads, commitShas },
   }
 }
 

--- a/packages/scripts/src/bayn/verify-release-review.ts
+++ b/packages/scripts/src/bayn/verify-release-review.ts
@@ -470,7 +470,7 @@ export const evaluateBaynReleaseReview = (input: {
         return hold(
           'feedback-fix-attestation-missing',
           `source PR #${pullRequest.number} final head ${shortSha(pullRequest.headSha)} carries review from ${shortSha(reviewedHeadSha)}, but post-review commit ${shortSha(fixCommitSha)} lacks a trusted member reply on a resolved Codex thread from that review`,
-          false,
+          true,
         )
       }
     }


### PR DESCRIPTION
## Summary

- Carry a prior Codex-reviewed PR head forward only when every later PR commit has an auditable trusted-member feedback reply recorded at that exact commit.
- Require those replies to live on resolved Codex threads from the carried review; exact-head reviews still take precedence and all unresolved threads remain blocking.
- Fetch bounded PR commit history and complete bounded thread-comment metadata with fail-closed pagination, identity, association, and timestamp validation.
- Add regressions for valid feedback-fix carry-forward, stale indexing recovery, missing/untrusted attestations, and multiple post-review commits.

## Related Issues

Follow-up to #13390 and discussion_r3681634392.

## Testing

- `bun test packages/scripts/src/bayn/*.test.ts` — 53 tests passed.
- `bun node_modules/oxlint/bin/oxlint --config .oxlintrc.json packages/scripts/src/bayn/verify-release-review.ts packages/scripts/src/bayn/verify-release-review.test.ts`
- `bun node_modules/typescript/bin/tsc --ignoreConfig --noEmit --target esnext --module esnext --moduleResolution bundler --lib esnext,dom --types bun-types --skipLibCheck packages/scripts/src/bayn/verify-release-review.ts packages/scripts/src/bayn/verify-release-review.test.ts`
- `/tmp/actionlint-1.7.7/actionlint -shellcheck '' -pyflakes '' .github/workflows/bayn-build-push.yml`
- `git diff --check`
- Live read-only proof against merge `247c7245bf68`: the gate still blocks on the unresolved exact-head P1, proving exact-head review evidence takes precedence over carry-forward.

## Breaking Changes

None. The Bayn publication gate remains read-only and fail closed. Carry-forward is limited to repository-member replies whose GitHub review metadata binds each post-review commit to a resolved Codex thread from the carried reviewed head.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked. No external documentation change is required for this internal Bayn CI integrity correction.
