### PR TITLE
fix(bayn): redact account id from reconciliation logs

### DIFF
--- a/services/bayn/src/simulation-reconciliation/broker-persistence.test.ts
+++ b/services/bayn/src/simulation-reconciliation/broker-persistence.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, test } from 'bun:test'
+
+import { Cause, Effect, Logger, References } from 'effect'
+
+import { AccountStatus, type Account, type ReadEvidence } from '../broker/alpaca'
+import type { ReconciliationPersistence } from '../db/execution-store'
+import type { BrokerSnapshot, ReconciliationWriteResult } from '../db/reconciliation'
+import type { WriterFenceService } from '../execution/writer-fence'
+import { canonicalHashV1 } from '../hash'
+import { ReconciliationStatus, type Valuation } from '../paper'
+import { persistStableSnapshot } from './broker-persistence'
+import type { StableBrokerSnapshot } from './broker-reconciler-model'
+
+const accountId = '61e69015-8549-4bfd-b9c3-01e75843f47d'
+const observedAt = '2026-07-30T10:08:00.000Z'
+const reconciliationId = canonicalHashV1('reconciliation-log-redaction')
+const accountingHash = canonicalHashV1('accounting-state')
+
+const evidence = (identity: string): ReadEvidence => ({
+  requestId: `request-${identity}`,
+  status: 200,
+  contentHash: canonicalHashV1(identity),
+  observedAt,
+})
+
+const account: Account = {
+  id: accountId,
+  status: AccountStatus.Active,
+  currency: 'USD',
+  cashMicros: '1000000000',
+  equityMicros: '1000000000',
+  lastEquityMicros: '1000000000',
+  buyingPowerMicros: '2000000000',
+  accountBlocked: false,
+  tradingBlocked: false,
+  tradeSuspendedByUser: false,
+  observedAt,
+}
+
+const snapshot: StableBrokerSnapshot = {
+  account: { value: account, evidence: evidence('account') },
+  positions: { value: [], evidence: evidence('positions') },
+  history: {
+    orders: { rows: [], observedAt },
+    fills: [],
+  },
+}
+
+const valuation: Valuation = {
+  schemaVersion: 'bayn.paper-valuation.v1',
+  valuationId: canonicalHashV1('valuation'),
+  accountId,
+  sourceHash: canonicalHashV1('valuation-source'),
+  cashMicros: account.cashMicros,
+  longMarketValueMicros: '0',
+  shortMarketValueMicros: '0',
+  equityMicros: account.equityMicros,
+  asOf: observedAt,
+}
+
+const writeResult = (persisted: BrokerSnapshot): ReconciliationWriteResult => ({
+  reconciliation: {
+    schemaVersion: 'bayn.paper-reconciliation.v1',
+    reconciliationId,
+    accountId,
+    expectedHash: canonicalHashV1('expected-state'),
+    observedHash: canonicalHashV1('expected-state'),
+    contentHash: canonicalHashV1('reconciliation-content'),
+    status: ReconciliationStatus.Exact,
+    discrepancies: [],
+    reconciledAt: persisted.reconciledAt,
+  },
+  metrics: {
+    brokerPollAgeMs: 123,
+    oldestUnknownMutationAgeMs: 456,
+    cashDifferenceMicros: '0',
+    positionDifferenceMicros: '0',
+    equityDifferenceMicros: '0',
+    accountingExact: true,
+    discrepancyCount: 0,
+  },
+  accountingHash,
+  riskContext: {
+    tradingDate: '2026-07-30',
+    authority: null,
+    authorityObservedAt: null,
+    unknownMutationCount: 0,
+    dailyTradedNotionalMicros: '0',
+    dayStartEquityMicros: account.equityMicros,
+    peakEquityMicros: account.equityMicros,
+  },
+})
+
+const store: ReconciliationPersistence = {
+  events: {
+    ingest: (input) =>
+      Effect.succeed({
+        eventId: canonicalHashV1(input.sourceEventId),
+        sourceSequence: '1',
+        deduplicated: false,
+      }),
+    ingestPositions: (input) =>
+      Effect.succeed({
+        snapshotId: canonicalHashV1(input.sourceHash),
+        eventIds: [],
+        deduplicated: false,
+      }),
+  },
+  accounting: {
+    account: () => Effect.die(new Error('empty successful reconciliation must not account a fill')),
+  },
+  valuation: {
+    value: () => Effect.succeed(valuation),
+    hasAccountBaseline: () => Effect.die(new Error('empty successful reconciliation must not read a baseline')),
+  },
+  reconciliation: {
+    bindings: (boundAccountId) => {
+      expect(boundAccountId).toBe(accountId)
+      return Effect.succeed([])
+    },
+    reconcile: (persisted) => {
+      expect(persisted.account.accountId).toBe(accountId)
+      return Effect.succeed(writeResult(persisted))
+    },
+  },
+  authorityRestriction: {
+    restrictAuthority: () => Effect.die(new Error('successful reconciliation must not restrict authority')),
+  },
+}
+
+const fence: WriterFenceService = {
+  backendPid: 1,
+  check: Effect.void,
+  transaction: (effect) => effect,
+}
+
+describe('simulation reconciliation persistence logging', () => {
+  test('keeps raw broker identity internal while excluding it from the successful reconciliation log', async () => {
+    const logs: Array<{
+      readonly message: unknown
+      readonly annotations: Record<string, unknown>
+      readonly renderedCause: string
+    }> = []
+    const logger = Logger.make<unknown, void>((entry) => {
+      logs.push({
+        message: entry.message,
+        annotations: { ...entry.fiber.getRef(References.CurrentLogAnnotations) },
+        renderedCause: Cause.pretty(entry.cause),
+      })
+    })
+
+    const result = await Effect.runPromise(
+      persistStableSnapshot(store, fence, snapshot, Effect.succeed(observedAt)).pipe(
+        Effect.provide(Logger.layer([logger])),
+      ),
+    )
+
+    expect(result.report.reconciliation.accountId).toBe(accountId)
+    expect(result.brokerState.account.accountId).toBe(accountId)
+
+    const completed = logs.find((entry) =>
+      JSON.stringify(entry.message).includes('Paper account reconciliation completed'),
+    )
+    expect(completed).toBeDefined()
+    if (completed === undefined) return expect.unreachable('successful reconciliation log was not captured')
+
+    expect(JSON.stringify(completed.message)).not.toContain(accountId)
+    expect(JSON.stringify(completed.annotations)).not.toContain(accountId)
+    expect(completed.renderedCause).not.toContain(accountId)
+    expect(completed.annotations).toMatchObject({
+      status: ReconciliationStatus.Exact,
+      reconciliationId,
+      orderCount: 0,
+      fillCount: 0,
+      discrepancyCount: 0,
+      brokerPollAgeMs: 123,
+      oldestUnknownMutationAgeMs: 456,
+      accountingExact: true,
+    })
+  })
+})

--- a/services/bayn/src/simulation-reconciliation/broker-persistence.ts
+++ b/services/bayn/src/simulation-reconciliation/broker-persistence.ts
@@ -83,7 +83,6 @@ const logCompletedPass = (
 ): Effect.Effect<void> =>
   Effect.logInfo('Paper account reconciliation completed').pipe(
     Effect.annotateLogs({
-      accountId: result.report.reconciliation.accountId,
       status: result.report.reconciliation.status,
       reconciliationId: result.report.reconciliation.reconciliationId,
       orderCount: decision.orderCount,


### PR DESCRIPTION
## Summary

- remove the raw broker account identifier from successful reconciliation log annotations only
- preserve the full account identity inside reconciliation comparison, persistence, and returned broker state
- add a focused log-boundary regression covering message, annotations, rendered cause, and unchanged operational fields

## Related Issues

None

## Testing

- `bun test services/bayn/src/simulation-reconciliation/broker-persistence.test.ts`
- `bun run --filter @proompteng/bayn test` (940 passed, 138 skipped, 0 failed)
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn build`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked. No documentation or release-note change is required for this log-presentation-only fix.
