### PR TITLE
fix(bayn): accept immutable clean codex attestations

### DIFF
--- a/packages/scripts/src/bayn/verify-release-review.test.ts
+++ b/packages/scripts/src/bayn/verify-release-review.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test'
 
 import {
+  baynCodexBotLogin,
   baynCodexReviewer,
   createGitHubReleaseEligibilityLoader,
   createGitHubReleaseReviewLoader,
@@ -16,6 +17,8 @@ import {
   type BaynReleaseReviewPollResult,
   type BaynReleaseReviewSnapshot,
   type PullRequestReview,
+  type PullRequestIssueComment,
+  type PullRequestReaction,
   type PullRequestReviewThread,
   type PullRequestReviewThreadComment,
   type SuccessfulPublishRun,
@@ -43,7 +46,7 @@ const associatedPull = (overrides: Partial<AssociatedPullRequest> = {}): Associa
   baseRefName: 'main',
   headSha: finalHeadSha,
   mergeCommitSha: mainCommitSha,
-  mergedAt: '2026-07-30T07:00:00Z',
+  mergedAt: '2026-07-30T07:01:30Z',
   ...overrides,
 })
 
@@ -52,6 +55,21 @@ const review = (overrides: Partial<PullRequestReview> = {}): PullRequestReview =
   commitSha: finalHeadSha,
   submittedAt: '2026-07-30T07:01:00Z',
   state: 'COMMENTED',
+  ...overrides,
+})
+
+const issueComment = (overrides: Partial<PullRequestIssueComment> = {}): PullRequestIssueComment => ({
+  authorLogin: baynCodexBotLogin,
+  body: `Codex Review: Didn't find any major issues. Bravo.\n\n**Reviewed commit:** \`${finalHeadSha.slice(0, 10)}\`\n`,
+  createdAt: '2026-07-30T07:01:00Z',
+  updatedAt: '2026-07-30T07:01:00Z',
+  ...overrides,
+})
+
+const reaction = (overrides: Partial<PullRequestReaction> = {}): PullRequestReaction => ({
+  userLogin: baynCodexBotLogin,
+  content: '+1',
+  createdAt: '2026-07-30T07:01:00Z',
   ...overrides,
 })
 
@@ -86,10 +104,17 @@ const snapshot = (
     readonly threads?: readonly PullRequestReviewThread[]
     readonly mainCommitParents?: readonly string[]
     readonly commitShas?: readonly string[]
+    readonly issueComments?: readonly PullRequestIssueComment[]
+    readonly reactions?: readonly PullRequestReaction[]
+    readonly headForcePushCount?: number
   } = {},
 ): BaynReleaseReviewSnapshot => {
   const associated = options.associated ?? [associatedPull()]
   const source = associated[0]
+  const sourceCreatedAt =
+    source?.mergedAt === null || source?.mergedAt === undefined
+      ? '2026-07-30T06:59:00Z'
+      : new Date(Date.parse(source.mergedAt) - 60_000).toISOString()
   return {
     mainCommitParents: options.mainCommitParents ?? [pushBeforeSha],
     associatedPullRequests: associated,
@@ -101,10 +126,14 @@ const snapshot = (
             baseRefName: source.baseRefName,
             headSha: source.headSha,
             mergeCommitSha: source.mergeCommitSha,
+            createdAt: sourceCreatedAt,
             mergedAt: source.mergedAt,
             reviews: options.reviews ?? [review()],
             threads: options.threads ?? [],
             commitShas: options.commitShas ?? [source.headSha],
+            issueComments: options.issueComments ?? [],
+            reactions: options.reactions ?? [],
+            headForcePushCount: options.headForcePushCount ?? 0,
           },
   }
 }
@@ -134,6 +163,10 @@ const reviewSnapshotFor = (options: {
     headSha: options.headSha,
     mergeCommitSha: options.commitSha,
   })
+  const sourceCreatedAt =
+    associated.mergedAt === null
+      ? '2026-07-30T06:59:00Z'
+      : new Date(Date.parse(associated.mergedAt) - 60_000).toISOString()
   return {
     mainCommitParents: options.parents,
     associatedPullRequests: [associated],
@@ -142,6 +175,7 @@ const reviewSnapshotFor = (options: {
       baseRefName: 'main',
       headSha: options.headSha,
       mergeCommitSha: options.commitSha,
+      createdAt: sourceCreatedAt,
       mergedAt: associated.mergedAt,
       reviews: options.reviews ?? [
         review({
@@ -150,6 +184,9 @@ const reviewSnapshotFor = (options: {
       ],
       threads: options.threads ?? [],
       commitShas: [options.headSha],
+      issueComments: [],
+      reactions: [],
+      headForcePushCount: 0,
     },
   }
 }
@@ -370,7 +407,7 @@ describe('Bayn publication-range eligibility', () => {
             base: { ref: 'main' },
             head: { sha: finalHeadSha },
             merge_commit_sha: mainCommitSha,
-            merged_at: '2026-07-30T07:00:00Z',
+            merged_at: '2026-07-30T07:01:30Z',
           },
         ])
       }
@@ -386,6 +423,9 @@ describe('Bayn publication-range eligibility', () => {
           ],
         })
       }
+      if (url.includes('/issues/13390/comments?') || url.includes('/issues/13390/reactions?')) {
+        return Response.json([])
+      }
 
       const request = JSON.parse(String(init?.body)) as { readonly query: string }
       if (request.query.includes('BaynReleasePullRequestMetadata')) {
@@ -396,8 +436,13 @@ describe('Bayn publication-range eligibility', () => {
                 number: 13390,
                 baseRefName: 'main',
                 headRefOid: finalHeadSha,
-                mergedAt: '2026-07-30T07:00:00Z',
+                createdAt: '2026-07-30T06:59:00Z',
+                mergedAt: '2026-07-30T07:01:30Z',
                 mergeCommit: { oid: mainCommitSha },
+                timelineItems: {
+                  nodes: [],
+                  pageInfo: { hasNextPage: false, endCursor: null },
+                },
               },
             },
           },
@@ -512,6 +557,122 @@ describe('Bayn exact-head release review eligibility', () => {
       status: 'hold',
       code: 'exact-head-review-missing',
       retryable: true,
+    })
+  })
+
+  test('accepts the #13394 clean connector issue-comment attestation for the exact final head', () => {
+    expect(
+      evaluateBaynReleaseReview({
+        mainCommitSha,
+        baseRefName: 'main',
+        snapshot: snapshot({
+          reviews: [review({ commitSha: olderHeadSha })],
+          issueComments: [issueComment()],
+          headForcePushCount: 6,
+        }),
+        nowMs: evaluationNowMs,
+        pushBeforeSha: null,
+      }),
+    ).toEqual({
+      status: 'eligible',
+      prNumber: 13390,
+      headSha: finalHeadSha,
+      reviewSubmittedAt: '2026-07-30T07:01:00Z',
+    })
+  })
+
+  test('accepts the #13397 clean connector PR reaction only for an immutable single-head history', () => {
+    expect(
+      evaluateBaynReleaseReview({
+        mainCommitSha,
+        baseRefName: 'main',
+        snapshot: snapshot({ reviews: [], reactions: [reaction()] }),
+        nowMs: evaluationNowMs,
+        pushBeforeSha: null,
+      }),
+    ).toEqual({
+      status: 'eligible',
+      prNumber: 13390,
+      headSha: finalHeadSha,
+      reviewSubmittedAt: '2026-07-30T07:01:00Z',
+    })
+  })
+
+  test('rejects a clean-shaped PR reaction from a spoofed actor', () => {
+    expect(
+      evaluateBaynReleaseReview({
+        mainCommitSha,
+        baseRefName: 'main',
+        snapshot: snapshot({ reviews: [], reactions: [reaction({ userLogin: 'spoofed-codex[bot]' })] }),
+        nowMs: evaluationNowMs,
+        pushBeforeSha: null,
+      }),
+    ).toMatchObject({
+      status: 'hold',
+      code: 'exact-head-review-missing',
+      retryable: true,
+    })
+  })
+
+  test('rejects a clean connector comment bound to a stale head', () => {
+    expect(
+      evaluateBaynReleaseReview({
+        mainCommitSha,
+        baseRefName: 'main',
+        snapshot: snapshot({
+          reviews: [],
+          issueComments: [
+            issueComment({
+              body: `Codex Review: Didn't find any major issues.\n\n**Reviewed commit:** \`${olderHeadSha.slice(0, 10)}\`\n`,
+            }),
+          ],
+        }),
+        nowMs: evaluationNowMs,
+        pushBeforeSha: null,
+      }),
+    ).toMatchObject({
+      status: 'hold',
+      code: 'exact-head-review-missing',
+      retryable: true,
+    })
+  })
+
+  test('keeps an actionable exact-head review blocking a clean reaction', () => {
+    expect(
+      evaluateBaynReleaseReview({
+        mainCommitSha,
+        baseRefName: 'main',
+        snapshot: snapshot({
+          reviews: [review({ state: 'CHANGES_REQUESTED' })],
+          reactions: [reaction()],
+        }),
+        nowMs: evaluationNowMs,
+        pushBeforeSha: null,
+      }),
+    ).toMatchObject({
+      status: 'hold',
+      code: 'exact-head-review-changes-requested',
+      retryable: false,
+    })
+  })
+
+  test('keeps an unresolved thread blocking a clean exact-head attestation', () => {
+    expect(
+      evaluateBaynReleaseReview({
+        mainCommitSha,
+        baseRefName: 'main',
+        snapshot: snapshot({
+          reviews: [],
+          reactions: [reaction()],
+          threads: [thread({ isResolved: false })],
+        }),
+        nowMs: evaluationNowMs,
+        pushBeforeSha: null,
+      }),
+    ).toMatchObject({
+      status: 'hold',
+      code: 'active-unresolved-review-threads',
+      retryable: false,
     })
   })
 
@@ -996,9 +1157,12 @@ describe('Bayn exact-head release review eligibility', () => {
             base: { ref: 'main' },
             head: { sha: finalHeadSha },
             merge_commit_sha: mainCommitSha,
-            merged_at: '2026-07-30T07:00:00Z',
+            merged_at: '2026-07-30T07:01:30Z',
           },
         ])
+      }
+      if (url.includes('/issues/13390/comments?') || url.includes('/issues/13390/reactions?')) {
+        return Response.json([])
       }
 
       const request = JSON.parse(String(init?.body)) as { readonly query: string }
@@ -1010,8 +1174,13 @@ describe('Bayn exact-head release review eligibility', () => {
                 number: 13390,
                 baseRefName: 'main',
                 headRefOid: finalHeadSha,
-                mergedAt: '2026-07-30T07:00:00Z',
+                createdAt: '2026-07-30T06:59:00Z',
+                mergedAt: '2026-07-30T07:01:30Z',
                 mergeCommit: { oid: mainCommitSha },
+                timelineItems: {
+                  nodes: [],
+                  pageInfo: { hasNextPage: false, endCursor: null },
+                },
               },
             },
           },

--- a/packages/scripts/src/bayn/verify-release-review.ts
+++ b/packages/scripts/src/bayn/verify-release-review.ts
@@ -6,6 +6,7 @@ const maximumReleaseRangeCommits = 100
 const githubWorkflowFile = 'bayn-build-push.yml'
 
 export const baynCodexReviewer = 'chatgpt-codex-connector'
+export const baynCodexBotLogin = 'chatgpt-codex-connector[bot]'
 
 export interface AssociatedPullRequest {
   readonly number: number
@@ -20,6 +21,19 @@ export interface PullRequestReview {
   readonly commitSha: string | null
   readonly submittedAt: string | null
   readonly state: string
+}
+
+export interface PullRequestIssueComment {
+  readonly authorLogin: string | null
+  readonly body: string
+  readonly createdAt: string
+  readonly updatedAt: string
+}
+
+export interface PullRequestReaction {
+  readonly userLogin: string | null
+  readonly content: string
+  readonly createdAt: string
 }
 
 export interface PullRequestReviewThreadComment {
@@ -49,10 +63,14 @@ export interface PullRequestReviewState {
   readonly baseRefName: string
   readonly headSha: string
   readonly mergeCommitSha: string | null
+  readonly createdAt: string
   readonly mergedAt: string | null
   readonly reviews: readonly PullRequestReview[]
   readonly threads: readonly PullRequestReviewThread[]
   readonly commitShas: readonly string[]
+  readonly issueComments: readonly PullRequestIssueComment[]
+  readonly reactions: readonly PullRequestReaction[]
+  readonly headForcePushCount: number
 }
 
 export interface BaynReleaseReviewSnapshot {
@@ -271,6 +289,66 @@ export const isBaynReleaseAffectingPath = (path: string): boolean =>
 
 const eligibleReviewStates = new Set(['APPROVED', 'COMMENTED'])
 const trustedFeedbackAssociations = new Set(['MEMBER', 'OWNER', 'COLLABORATOR'])
+const cleanCodexCommentPattern =
+  /^Codex Review: Didn't find any (?:major )?issues\.[^\n]*\n\n\*\*Reviewed commit:\*\* `([0-9a-f]{10,40})`(?:\n|$)/
+
+const cleanCodexCommentHead = (body: string): string | null => cleanCodexCommentPattern.exec(body)?.[1] ?? null
+
+const timestampWithinPullRequest = (timestamp: string, createdAtMs: number, mergedAtMs: number): boolean => {
+  const timestampMs = Date.parse(timestamp)
+  return Number.isFinite(timestampMs) && timestampMs >= createdAtMs && timestampMs <= mergedAtMs
+}
+
+const exactHeadCodexAttestation = (
+  pullRequest: PullRequestReviewState,
+  createdAtMs: number,
+  mergedAtMs: number,
+): PullRequestReview | undefined => {
+  const comment = pullRequest.issueComments
+    .filter((candidate) => {
+      if (
+        candidate.authorLogin !== baynCodexBotLogin ||
+        candidate.createdAt !== candidate.updatedAt ||
+        !timestampWithinPullRequest(candidate.createdAt, createdAtMs, mergedAtMs)
+      ) {
+        return false
+      }
+      const reviewedHead = cleanCodexCommentHead(candidate.body)
+      return reviewedHead !== null && pullRequest.headSha.startsWith(reviewedHead)
+    })
+    .toSorted((left, right) => right.createdAt.localeCompare(left.createdAt))[0]
+  if (comment !== undefined) {
+    return {
+      authorLogin: baynCodexReviewer,
+      commitSha: pullRequest.headSha,
+      submittedAt: comment.createdAt,
+      state: 'COMMENTED',
+    }
+  }
+
+  if (
+    pullRequest.commitShas.length !== 1 ||
+    pullRequest.commitShas[0] !== pullRequest.headSha ||
+    pullRequest.headForcePushCount !== 0
+  ) {
+    return undefined
+  }
+  const reaction = pullRequest.reactions
+    .filter(
+      (candidate) =>
+        candidate.userLogin === baynCodexBotLogin &&
+        candidate.content === '+1' &&
+        timestampWithinPullRequest(candidate.createdAt, createdAtMs, mergedAtMs),
+    )
+    .toSorted((left, right) => right.createdAt.localeCompare(left.createdAt))[0]
+  if (reaction === undefined) return undefined
+  return {
+    authorLogin: baynCodexReviewer,
+    commitSha: pullRequest.headSha,
+    submittedAt: reaction.createdAt,
+    state: 'COMMENTED',
+  }
+}
 
 export const evaluateBaynReleaseReview = (input: {
   readonly mainCommitSha: string
@@ -337,6 +415,20 @@ export const evaluateBaynReleaseReview = (input: {
     )
   }
 
+  const pullRequestCreatedAtMs = Date.parse(pullRequest.createdAt)
+  const pullRequestMergedAtMs = Date.parse(pullRequest.mergedAt)
+  if (
+    !Number.isFinite(pullRequestCreatedAtMs) ||
+    !Number.isFinite(pullRequestMergedAtMs) ||
+    pullRequestCreatedAtMs > pullRequestMergedAtMs
+  ) {
+    return hold(
+      'source-pr-metadata-mismatch',
+      `source PR #${pullRequest.number} has invalid created/merged timestamps`,
+      false,
+    )
+  }
+
   const codexReviews = pullRequest.reviews.filter((review) => review.authorLogin === baynCodexReviewer)
   const exactHeadReviews = codexReviews.filter((review) => review.commitSha === pullRequest.headSha)
   const hasPendingExactHeadReview = exactHeadReviews.some(
@@ -353,7 +445,8 @@ export const evaluateBaynReleaseReview = (input: {
     .filter((review) => review.submittedAt !== null)
     .toSorted((left, right) => (right.submittedAt as string).localeCompare(left.submittedAt as string))[0]
 
-  let reviewEvidence = exactSubmittedReview
+  let reviewEvidence =
+    exactSubmittedReview ?? exactHeadCodexAttestation(pullRequest, pullRequestCreatedAtMs, pullRequestMergedAtMs)
   let feedbackFixCommitShas: readonly string[] = []
   if (reviewEvidence === undefined) {
     if (
@@ -879,6 +972,37 @@ const parseAssociatedPullRequests = (value: unknown): readonly AssociatedPullReq
   })
 }
 
+const parsePullRequestIssueComments = (value: unknown): readonly PullRequestIssueComment[] => {
+  if (!Array.isArray(value)) {
+    throw new GitHubReleaseReviewError('github-api-invalid-response', 'list source PR issue comments')
+  }
+  return value.map((item, index) => {
+    const comment = expectRecord(item, `source PR issue comment ${index}`)
+    const user = comment.user === null ? null : expectRecord(comment.user, `source PR issue comment ${index} user`)
+    return {
+      authorLogin: user === null ? null : expectString(user.login, `source PR issue comment ${index} user login`),
+      body: expectAnyString(comment.body, `source PR issue comment ${index} body`),
+      createdAt: expectString(comment.created_at, `source PR issue comment ${index} created at`),
+      updatedAt: expectString(comment.updated_at, `source PR issue comment ${index} updated at`),
+    }
+  })
+}
+
+const parsePullRequestReactions = (value: unknown): readonly PullRequestReaction[] => {
+  if (!Array.isArray(value)) {
+    throw new GitHubReleaseReviewError('github-api-invalid-response', 'list source PR reactions')
+  }
+  return value.map((item, index) => {
+    const reaction = expectRecord(item, `source PR reaction ${index}`)
+    const user = reaction.user === null ? null : expectRecord(reaction.user, `source PR reaction ${index} user`)
+    return {
+      userLogin: user === null ? null : expectString(user.login, `source PR reaction ${index} user login`),
+      content: expectString(reaction.content, `source PR reaction ${index} content`),
+      createdAt: expectString(reaction.created_at, `source PR reaction ${index} created at`),
+    }
+  })
+}
+
 const parseSuccessfulPublishRuns = (value: unknown): readonly SuccessfulPublishRun[] => {
   const payload = expectRecord(value, 'list successful Bayn publish runs')
   if (!Array.isArray(payload.workflow_runs)) {
@@ -1000,8 +1124,13 @@ const pullRequestMetadataQuery = `
         number
         baseRefName
         headRefOid
+        createdAt
         mergedAt
         mergeCommit { oid }
+        timelineItems(first: 100, itemTypes: [HEAD_REF_FORCE_PUSHED_EVENT]) {
+          nodes { __typename }
+          pageInfo { hasNextPage endCursor }
+        }
       }
     }
   }
@@ -1100,13 +1229,65 @@ const fetchPullRequestMetadata = async (options: GitHubLoaderOptions, pullNumber
   })
   const pullRequest = graphqlPullRequest(data, `read source PR #${pullNumber} metadata`)
   const mergeCommit = pullRequest.mergeCommit === null ? null : expectRecord(pullRequest.mergeCommit, 'merge commit')
+  const timelineItems = expectRecord(pullRequest.timelineItems, 'source PR head-force-push history')
+  if (!Array.isArray(timelineItems.nodes)) {
+    throw new GitHubReleaseReviewError('github-api-invalid-response', 'source PR head-force-push history')
+  }
+  const timelinePageInfo = parsePageInfo(timelineItems, 'source PR head-force-push history')
+  if (timelinePageInfo.hasNextPage) {
+    throw new GitHubReleaseReviewError('github-api-pagination-limit', 'source PR head-force-push history')
+  }
+  for (const [index, item] of timelineItems.nodes.entries()) {
+    const event = expectRecord(item, `source PR head-force-push event ${index}`)
+    if (event.__typename !== 'HeadRefForcePushedEvent') {
+      throw new GitHubReleaseReviewError('github-api-invalid-response', `source PR head-force-push event ${index}`)
+    }
+  }
   return {
     number: expectInteger(pullRequest.number, 'source PR number'),
     baseRefName: expectString(pullRequest.baseRefName, 'source PR base ref'),
     headSha: expectString(pullRequest.headRefOid, 'source PR head SHA'),
+    createdAt: expectString(pullRequest.createdAt, 'source PR created at'),
     mergedAt: expectNullableString(pullRequest.mergedAt, 'source PR merged at'),
     mergeCommitSha: mergeCommit === null ? null : expectString(mergeCommit.oid, 'source PR merge commit SHA'),
+    headForcePushCount: timelineItems.nodes.length,
   }
+}
+
+const fetchPullRequestIssueComments = async (
+  options: GitHubLoaderOptions,
+  pullNumber: number,
+): Promise<readonly PullRequestIssueComment[]> => {
+  const operation = `list source PR #${pullNumber} issue comments`
+  const response = await requestGitHubJson({
+    url: `https://api.github.com/repos/${encodeURIComponent(options.owner)}/${encodeURIComponent(options.name)}/issues/${pullNumber}/comments?per_page=100&page=1`,
+    operation,
+    token: options.token,
+    requestTimeoutMs: options.requestTimeoutMs,
+    fetchFn: options.fetchFn,
+  })
+  if (response.headers.get('link')?.includes('rel="next"') === true) {
+    throw new GitHubReleaseReviewError('github-api-pagination-limit', operation)
+  }
+  return parsePullRequestIssueComments(response.value)
+}
+
+const fetchPullRequestReactions = async (
+  options: GitHubLoaderOptions,
+  pullNumber: number,
+): Promise<readonly PullRequestReaction[]> => {
+  const operation = `list source PR #${pullNumber} reactions`
+  const response = await requestGitHubJson({
+    url: `https://api.github.com/repos/${encodeURIComponent(options.owner)}/${encodeURIComponent(options.name)}/issues/${pullNumber}/reactions?per_page=100&page=1`,
+    operation,
+    token: options.token,
+    requestTimeoutMs: options.requestTimeoutMs,
+    fetchFn: options.fetchFn,
+  })
+  if (response.headers.get('link')?.includes('rel="next"') === true) {
+    throw new GitHubReleaseReviewError('github-api-pagination-limit', operation)
+  }
+  return parsePullRequestReactions(response.value)
 }
 
 const fetchPullRequestReviews = async (
@@ -1336,16 +1517,18 @@ const loadCommitReviewSnapshot = async (
 
   const candidate = candidates[0]
   if (candidate === undefined) throw new Error('source pull selection was unexpectedly empty')
-  const [metadata, reviews, threads, commitShas] = await Promise.all([
+  const [metadata, reviews, threads, commitShas, issueComments, reactions] = await Promise.all([
     fetchPullRequestMetadata(options, candidate.number),
     fetchPullRequestReviews(options, candidate.number),
     fetchPullRequestThreads(options, candidate.number),
     fetchPullRequestCommitShas(options, candidate.number),
+    fetchPullRequestIssueComments(options, candidate.number),
+    fetchPullRequestReactions(options, candidate.number),
   ])
   return {
     mainCommitParents: commit.parents,
     associatedPullRequests,
-    pullRequest: { ...metadata, reviews, threads, commitShas },
+    pullRequest: { ...metadata, reviews, threads, commitShas, issueComments, reactions },
   }
 }
 


### PR DESCRIPTION
## Summary

- Accept an unedited connector-bot clean-result issue comment only when it names the exact final PR head SHA.
- Accept a connector-bot PR-level `+1` only for a single-commit PR with zero head force-push history, created after PR creation and before merge.
- Preserve fail-closed precedence for pending or changes-requested exact-head reviews and every unresolved review thread.
- Bound all new comment, reaction, and head-history reads to one GitHub page and reject pagination or malformed metadata.

## Reproduced failures

- Main run `30533815635` held source PR #13394 because its clean exact-head result was issue comment `5129479492`, not a submitted review object.
- Main run `30534637983` held source PR #13397 because its clean exact-head result was the connector-bot PR-level `+1` reaction, with no submitted review object.

## Testing

- `bun test packages/scripts/src/bayn/*.test.ts` — 59 passed.
- Targeted TypeScript check for the verifier and tests.
- Oxlint for the verifier and tests.
- Actionlint 1.7.7 for `.github/workflows/bayn-build-push.yml`.
- Formatting and `git diff --check`.
- Live read-only verifier proof on current main: `published=06c0aa285354 current=5e7af567a758 checked_commits=2 bayn_affecting_commits=2 reviewed_prs=#13394@c31c3d4db402,#13397@7e406a09ccf0; attempts=1`.

## Safety

No workflow permissions, runtime code, manifests, broker authority, or capital authority changed. Arbitrary actors, edited comments, stale SHA comments, multi-commit or force-pushed reaction histories, actionable reviews, and unresolved threads remain ineligible.
