### PR TITLE
fix(bayn): retry delayed release attestations

### DIFF
--- a/.github/workflows/bayn-build-push.yml
+++ b/.github/workflows/bayn-build-push.yml
@@ -37,15 +37,125 @@ on:
       - '.github/actions/setup-nix-toolchain/**'
       - '.github/workflows/bayn-*.yml'
       - '.github/workflows/nix-oci-build-common.yml'
+  issue_comment:
+    types:
+      - created
+  schedule:
+    - cron: '*/10 * * * *'
+  workflow_dispatch:
+    inputs:
+      retry_source_sha:
+        description: Exact merged Bayn source commit whose push review gate failed.
+        required: true
+        type: string
+      retry_pr_number:
+        description: Source pull request number bound to the failed merge.
+        required: true
+        type: string
+      retry_pr_head:
+        description: Never-force-pushed final source pull request head.
+        required: true
+        type: string
+      retry_failed_run_id:
+        description: Failed Bayn push run whose review gate exhausted before publication.
+        required: true
+        type: string
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: >-
+    ${{ github.workflow }}-${{
+      (github.event_name == 'issue_comment' || github.event_name == 'schedule') &&
+      'retry-trigger' ||
+      'main'
+    }}
   cancel-in-progress: true
 
 jobs:
+  retry-discovery:
+    if: >-
+      ${{
+        github.event_name == 'schedule' ||
+        (
+          github.event_name == 'issue_comment' &&
+          github.event.issue.pull_request &&
+          github.event.comment.user.login == 'chatgpt-codex-connector[bot]'
+        )
+      }}
+    name: Discover delayed exact-head attestation
+    runs-on: arc-arm64
+    timeout-minutes: 3
+    outputs:
+      dispatch: ${{ steps.retry.outputs.dispatch }}
+      retry_source_sha: ${{ steps.retry.outputs.retry_source_sha }}
+      retry_pr_number: ${{ steps.retry.outputs.retry_pr_number }}
+      retry_pr_head: ${{ steps.retry.outputs.retry_pr_head }}
+      retry_failed_run_id: ${{ steps.retry.outputs.retry_failed_run_id }}
+    steps:
+      - name: Checkout trusted default-branch verifier
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Discover exact failed source now eligible for retry
+        id: retry
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_PR_NUMBER: ${{ github.event.issue.number }}
+          EVENT_ACTOR: ${{ github.event.comment.user.login }}
+        run: |
+          set -euo pipefail
+          args=(
+            bun packages/scripts/src/bayn/verify-release-review.ts
+            --mode retry-discovery
+            --repository "${GITHUB_REPOSITORY}"
+            --commit "${GITHUB_SHA}"
+            --github-output "${GITHUB_OUTPUT}"
+            --request-timeout-ms 10000
+          )
+          if [ "${EVENT_NAME}" = issue_comment ]; then
+            args+=(
+              --trigger-kind issue-comment
+              --trigger-pr-number "${EVENT_PR_NUMBER}"
+              --trigger-actor-login "${EVENT_ACTOR}"
+            )
+          else
+            args+=(--trigger-kind schedule)
+          fi
+          "${args[@]}"
+
+      - name: Dispatch trusted main publication retry
+        if: steps.retry.outputs.dispatch == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.AGENTS_SPLIT_TOKEN }}
+          RETRY_SOURCE_SHA: ${{ steps.retry.outputs.retry_source_sha }}
+          RETRY_PR_NUMBER: ${{ steps.retry.outputs.retry_pr_number }}
+          RETRY_PR_HEAD: ${{ steps.retry.outputs.retry_pr_head }}
+          RETRY_FAILED_RUN_ID: ${{ steps.retry.outputs.retry_failed_run_id }}
+        run: |
+          set -euo pipefail
+          test -n "${GH_TOKEN}"
+          gh api \
+            --method POST \
+            "repos/${GITHUB_REPOSITORY}/actions/workflows/bayn-build-push.yml/dispatches" \
+            -f ref=main \
+            -f "inputs[retry_source_sha]=${RETRY_SOURCE_SHA}" \
+            -f "inputs[retry_pr_number]=${RETRY_PR_NUMBER}" \
+            -f "inputs[retry_pr_head]=${RETRY_PR_HEAD}" \
+            -f "inputs[retry_failed_run_id]=${RETRY_FAILED_RUN_ID}"
+
   release-review-eligibility:
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     name: Verify exact-head Codex review
     runs-on: arc-arm64
     timeout-minutes: 6
+    outputs:
+      publish: ${{ steps.verify.outputs.publish }}
+      source_sha: ${{ steps.verify.outputs.source_sha }}
     steps:
       - name: Checkout exact main commit
         uses: actions/checkout@v5
@@ -58,28 +168,52 @@ jobs:
           bun-version: 1.3.14
 
       - name: Hold until source PR review is release-eligible
+        id: verify
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT_NAME: ${{ github.event_name }}
           PUSH_BEFORE: ${{ github.event.before }}
+          RETRY_SOURCE_SHA: ${{ inputs.retry_source_sha }}
+          RETRY_PR_NUMBER: ${{ inputs.retry_pr_number }}
+          RETRY_PR_HEAD: ${{ inputs.retry_pr_head }}
+          RETRY_FAILED_RUN_ID: ${{ inputs.retry_failed_run_id }}
         run: |
           set -euo pipefail
-          bun packages/scripts/src/bayn/verify-release-review.ts \
-            --repository "${GITHUB_REPOSITORY}" \
-            --commit "${GITHUB_SHA}" \
-            --push-before "${PUSH_BEFORE}" \
-            --max-attempts 10 \
-            --poll-interval-ms 10000 \
-            --request-timeout-ms 10000
+          if [ "${EVENT_NAME}" = push ]; then
+            bun packages/scripts/src/bayn/verify-release-review.ts \
+              --mode push \
+              --repository "${GITHUB_REPOSITORY}" \
+              --commit "${GITHUB_SHA}" \
+              --push-before "${PUSH_BEFORE}" \
+              --max-attempts 10 \
+              --poll-interval-ms 10000 \
+              --request-timeout-ms 10000 \
+              --github-output "${GITHUB_OUTPUT}"
+          else
+            bun packages/scripts/src/bayn/verify-release-review.ts \
+              --mode retry-publication \
+              --repository "${GITHUB_REPOSITORY}" \
+              --commit "${GITHUB_SHA}" \
+              --retry-source-commit "${RETRY_SOURCE_SHA}" \
+              --retry-pr-number "${RETRY_PR_NUMBER}" \
+              --retry-head "${RETRY_PR_HEAD}" \
+              --retry-failed-run-id "${RETRY_FAILED_RUN_ID}" \
+              --request-timeout-ms 10000 \
+              --github-output "${GITHUB_OUTPUT}"
+          fi
 
   image:
+    if: needs.release-review-eligibility.outputs.publish == 'true'
     needs: release-review-eligibility
     uses: ./.github/workflows/nix-oci-build-common.yml
     with:
       image_name: bayn
       package_attr: bayn-image
-      tag: sha-${{ github.sha }}
+      tag: sha-${{ needs.release-review-eligibility.outputs.source_sha }}
+      source_revision: ${{ needs.release-review-eligibility.outputs.source_sha }}
       # Keep OCI builds out of the repository-wide `ci-pr-*` concurrency group.
       pr_number: ''
-      latest: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+      latest: true
+      publish_on_dispatch: true
       release_artifact_name: bayn-release-contract
     secrets: inherit

--- a/packages/scripts/src/bayn/verify-release-review.test.ts
+++ b/packages/scripts/src/bayn/verify-release-review.test.ts
@@ -4,8 +4,10 @@ import {
   baynCodexBotLogin,
   baynCodexReviewer,
   createGitHubReleaseEligibilityLoader,
+  createGitHubReleaseRetryLoader,
   createGitHubReleaseReviewLoader,
   evaluateBaynReleaseEligibility,
+  evaluateBaynReleaseRetry,
   evaluateBaynReleaseReview,
   GitHubReleaseReviewError,
   isBaynReleaseAffectingPath,
@@ -13,7 +15,9 @@ import {
   pollBaynReleaseReview,
   resolveLastPublishedRevision,
   type AssociatedPullRequest,
+  type BaynBuildWorkflowRun,
   type BaynReleaseEligibilitySnapshot,
+  type BaynReleaseRetrySnapshot,
   type BaynReleaseReviewPollResult,
   type BaynReleaseReviewSnapshot,
   type PullRequestReview,
@@ -157,11 +161,16 @@ const reviewSnapshotFor = (options: {
   readonly parents: readonly string[]
   readonly reviews?: readonly PullRequestReview[]
   readonly threads?: readonly PullRequestReviewThread[]
+  readonly issueComments?: readonly PullRequestIssueComment[]
+  readonly reactions?: readonly PullRequestReaction[]
+  readonly headForcePushCount?: number
+  readonly mergedAt?: string
 }): BaynReleaseReviewSnapshot => {
   const associated = associatedPull({
     number: options.prNumber,
     headSha: options.headSha,
     mergeCommitSha: options.commitSha,
+    mergedAt: options.mergedAt ?? '2026-07-30T07:01:30Z',
   })
   const sourceCreatedAt =
     associated.mergedAt === null
@@ -184,9 +193,9 @@ const reviewSnapshotFor = (options: {
       ],
       threads: options.threads ?? [],
       commitShas: [options.headSha],
-      issueComments: [],
-      reactions: [],
-      headForcePushCount: 0,
+      issueComments: options.issueComments ?? [],
+      reactions: options.reactions ?? [],
+      headForcePushCount: options.headForcePushCount ?? 0,
     },
   }
 }
@@ -221,6 +230,84 @@ const eligibilitySnapshot = (
   },
   ...overrides,
 })
+
+const failedBuildRun = (overrides: Partial<BaynBuildWorkflowRun> = {}): BaynBuildWorkflowRun => ({
+  id: 30540000001,
+  runNumber: 900,
+  runAttempt: 1,
+  headSha: mainCommitSha,
+  headBranch: 'main',
+  event: 'push',
+  status: 'completed',
+  conclusion: 'failure',
+  createdAt: '2026-07-30T07:00:05Z',
+  updatedAt: '2026-07-30T07:02:30Z',
+  ...overrides,
+})
+
+const retrySnapshot = (
+  options: {
+    readonly reviewSnapshot?: BaynReleaseReviewSnapshot
+    readonly failedRun?: BaynBuildWorkflowRun | null
+    readonly retryInProgress?: boolean
+    readonly defaultBranchSha?: string
+    readonly eligibility?: BaynReleaseEligibilitySnapshot
+  } = {},
+): BaynReleaseRetrySnapshot => {
+  const eligibility =
+    options.eligibility ??
+    eligibilitySnapshot({
+      comparison: {
+        status: 'ahead',
+        baseSha: lastPublishedSha,
+        headSha: mainCommitSha,
+        mergeBaseSha: lastPublishedSha,
+        aheadBy: 1,
+        totalCommits: 1,
+        commits: [
+          {
+            sha: mainCommitSha,
+            parents: [lastPublishedSha],
+            files: ['packages/scripts/src/bayn/verify-release-review.ts'],
+            reviewSnapshot:
+              options.reviewSnapshot ??
+              reviewSnapshotFor({
+                commitSha: mainCommitSha,
+                prNumber: 13401,
+                headSha: finalHeadSha,
+                parents: [lastPublishedSha],
+                mergedAt: '2026-07-30T07:00:00Z',
+                reviews: [],
+                issueComments: [
+                  issueComment({
+                    createdAt: '2026-07-30T07:03:00Z',
+                    updatedAt: '2026-07-30T07:03:00Z',
+                  }),
+                ],
+              }),
+          },
+        ],
+        truncated: false,
+      },
+    })
+  const run = options.failedRun === undefined ? failedBuildRun() : options.failedRun
+  return {
+    ...eligibility,
+    defaultBranchSha: options.defaultBranchSha ?? mainCommitSha,
+    failedReviewRun:
+      run === null
+        ? null
+        : {
+            run,
+            jobs: [
+              { name: 'Verify exact-head Codex review', status: 'completed', conclusion: 'failure' },
+              { name: 'image', status: 'completed', conclusion: 'skipped' },
+            ],
+          },
+    publicationSucceeded: false,
+    retryInProgress: options.retryInProgress ?? false,
+  }
+}
 
 describe('Bayn publication-range eligibility', () => {
   test('accepts every clean Bayn-affecting commit since the last published revision', () => {
@@ -522,6 +609,439 @@ describe('Bayn publication-range eligibility', () => {
       lastPublishedRevision: lastPublishedSha,
       checkedCommitCount: 1,
       baynAffectingCommitCount: 1,
+    })
+  })
+})
+
+describe('Bayn delayed-attestation publication retry', () => {
+  const retryNowMs = Date.parse('2026-07-30T07:04:00Z')
+
+  test('dispatches after the original bounded push wait timed out and a clean exact-head comment arrived later', async () => {
+    const timedOut = await pollBaynReleaseEligibility({
+      mainCommitSha,
+      baseRefName: 'main',
+      pushBeforeSha,
+      maxAttempts: 10,
+      pollIntervalMs: 10_000,
+      loadSnapshot: async () =>
+        eligibilitySnapshot({
+          comparison: {
+            status: 'ahead',
+            baseSha: lastPublishedSha,
+            headSha: mainCommitSha,
+            mergeBaseSha: lastPublishedSha,
+            aheadBy: 1,
+            totalCommits: 1,
+            commits: [
+              {
+                sha: mainCommitSha,
+                parents: [lastPublishedSha],
+                files: ['packages/scripts/src/bayn/verify-release-review.ts'],
+                reviewSnapshot: reviewSnapshotFor({
+                  commitSha: mainCommitSha,
+                  prNumber: 13401,
+                  headSha: finalHeadSha,
+                  parents: [lastPublishedSha],
+                  mergedAt: '2026-07-30T07:00:00Z',
+                  reviews: [],
+                }),
+              },
+            ],
+            truncated: false,
+          },
+        }),
+      sleep: async () => {},
+      now: () => Date.parse('2026-07-30T07:02:20Z'),
+    })
+    expect(timedOut).toMatchObject({
+      status: 'hold',
+      code: 'exact-head-review-missing',
+      attempts: 10,
+      timedOut: true,
+    })
+
+    expect(
+      evaluateBaynReleaseRetry({
+        mainCommitSha,
+        baseRefName: 'main',
+        snapshot: retrySnapshot(),
+        trigger: { type: 'issue-comment', prNumber: 13401, actorLogin: baynCodexBotLogin },
+        nowMs: retryNowMs,
+      }),
+    ).toEqual({
+      status: 'dispatch',
+      currentMainSha: mainCommitSha,
+      sourceCommitSha: mainCommitSha,
+      prNumber: 13401,
+      headSha: finalHeadSha,
+      failedRunId: 30540000001,
+    })
+  })
+
+  test('revalidates the exact retry binding on the trusted workflow-dispatch run', () => {
+    expect(
+      evaluateBaynReleaseRetry({
+        mainCommitSha,
+        baseRefName: 'main',
+        snapshot: retrySnapshot(),
+        trigger: {
+          type: 'workflow-dispatch',
+          sourceCommitSha: mainCommitSha,
+          prNumber: 13401,
+          headSha: finalHeadSha,
+          failedRunId: 30540000001,
+        },
+        nowMs: retryNowMs,
+      }),
+    ).toMatchObject({
+      status: 'dispatch',
+      currentMainSha: mainCommitSha,
+      sourceCommitSha: mainCommitSha,
+    })
+  })
+
+  test('rejects spoofed and stale issue-comment retry triggers', () => {
+    for (const trigger of [
+      { type: 'issue-comment', prNumber: 13401, actorLogin: 'spoofed-codex[bot]' } as const,
+      { type: 'issue-comment', prNumber: 13399, actorLogin: baynCodexBotLogin } as const,
+    ]) {
+      expect(
+        evaluateBaynReleaseRetry({
+          mainCommitSha,
+          baseRefName: 'main',
+          snapshot: retrySnapshot(),
+          trigger,
+          nowMs: retryNowMs,
+        }),
+      ).toMatchObject({ status: 'hold', code: 'retry-trigger-mismatch', retryable: false })
+    }
+  })
+
+  test('rejects a delayed source whose final PR head was force-pushed', () => {
+    const forced = reviewSnapshotFor({
+      commitSha: mainCommitSha,
+      prNumber: 13401,
+      headSha: finalHeadSha,
+      parents: [lastPublishedSha],
+      mergedAt: '2026-07-30T07:00:00Z',
+      reviews: [review({ submittedAt: '2026-07-30T07:03:00Z' })],
+      headForcePushCount: 1,
+    })
+    expect(
+      evaluateBaynReleaseRetry({
+        mainCommitSha,
+        baseRefName: 'main',
+        snapshot: retrySnapshot({ reviewSnapshot: forced }),
+        trigger: { type: 'schedule' },
+        nowMs: retryNowMs,
+      }),
+    ).toMatchObject({ status: 'hold', code: 'retry-source-pr-force-pushed', retryable: false })
+  })
+
+  test('keeps actionable reviews and unresolved threads blocking delayed retry', () => {
+    const cases = [
+      {
+        reviewSnapshot: reviewSnapshotFor({
+          commitSha: mainCommitSha,
+          prNumber: 13401,
+          headSha: finalHeadSha,
+          parents: [lastPublishedSha],
+          mergedAt: '2026-07-30T07:00:00Z',
+          reviews: [review({ submittedAt: '2026-07-30T07:03:00Z', state: 'CHANGES_REQUESTED' })],
+          reactions: [reaction({ createdAt: '2026-07-30T07:03:00Z' })],
+        }),
+        code: 'exact-head-review-changes-requested',
+      },
+      {
+        reviewSnapshot: reviewSnapshotFor({
+          commitSha: mainCommitSha,
+          prNumber: 13401,
+          headSha: finalHeadSha,
+          parents: [lastPublishedSha],
+          mergedAt: '2026-07-30T07:00:00Z',
+          reviews: [],
+          reactions: [reaction({ createdAt: '2026-07-30T07:03:00Z' })],
+          threads: [thread({ isResolved: false })],
+        }),
+        code: 'active-unresolved-review-threads',
+      },
+    ] as const
+    for (const item of cases) {
+      expect(
+        evaluateBaynReleaseRetry({
+          mainCommitSha,
+          baseRefName: 'main',
+          snapshot: retrySnapshot({ reviewSnapshot: item.reviewSnapshot }),
+          trigger: { type: 'schedule' },
+          nowMs: retryNowMs,
+        }),
+      ).toMatchObject({ status: 'hold', code: item.code, retryable: false })
+    }
+  })
+
+  test('rejects ambiguous source association and already published or active retry states', () => {
+    const ambiguous = snapshot({
+      associated: [associatedPull({ number: 13401 }), associatedPull({ number: 13402, headSha: olderHeadSha })],
+      reviews: [],
+      issueComments: [issueComment({ createdAt: '2026-07-30T07:03:00Z', updatedAt: '2026-07-30T07:03:00Z' })],
+    })
+    expect(
+      evaluateBaynReleaseRetry({
+        mainCommitSha,
+        baseRefName: 'main',
+        snapshot: retrySnapshot({ reviewSnapshot: ambiguous }),
+        trigger: { type: 'schedule' },
+        nowMs: retryNowMs,
+      }),
+    ).toMatchObject({ status: 'hold', code: 'ambiguous-associated-source-prs', retryable: false })
+
+    expect(
+      evaluateBaynReleaseRetry({
+        mainCommitSha,
+        baseRefName: 'main',
+        snapshot: retrySnapshot({
+          eligibility: eligibilitySnapshot({
+            lastPublishedRevision: {
+              status: 'resolved',
+              revision: mainCommitSha,
+              runId: 101,
+              runNumber: 11,
+              runAttempt: 1,
+            },
+            comparison: {
+              status: 'identical',
+              baseSha: mainCommitSha,
+              headSha: mainCommitSha,
+              mergeBaseSha: mainCommitSha,
+              aheadBy: 0,
+              totalCommits: 0,
+              commits: [],
+              truncated: false,
+            },
+          }),
+        }),
+        trigger: { type: 'schedule' },
+        nowMs: retryNowMs,
+      }),
+    ).toMatchObject({ status: 'noop', code: 'retry-already-published' })
+
+    expect(
+      evaluateBaynReleaseRetry({
+        mainCommitSha,
+        baseRefName: 'main',
+        snapshot: retrySnapshot({ retryInProgress: true }),
+        trigger: { type: 'schedule' },
+        nowMs: retryNowMs,
+      }),
+    ).toMatchObject({ status: 'noop', code: 'retry-in-progress' })
+  })
+
+  test('counts a successful workflow-dispatch image run as the latest publication', () => {
+    expect(
+      resolveLastPublishedRevision([
+        successfulPublishRun(),
+        successfulPublishRun({
+          id: 102,
+          runNumber: 11,
+          headSha: mainCommitSha,
+          event: 'workflow_dispatch',
+        }),
+      ]),
+    ).toMatchObject({ status: 'resolved', revision: mainCommitSha, runId: 102 })
+  })
+
+  test('workflow uses trusted default-branch discovery and a separately rebound main dispatch', async () => {
+    const workflow = await Bun.file('.github/workflows/bayn-build-push.yml').text()
+    expect(workflow).toContain('issue_comment:')
+    expect(workflow).toContain("cron: '*/10 * * * *'")
+    expect(workflow).toContain('Checkout trusted default-branch verifier')
+    expect(workflow).toContain('--mode retry-discovery')
+    expect(workflow).toContain('chatgpt-codex-connector[bot]')
+    expect(workflow).toContain('actions/workflows/bayn-build-push.yml/dispatches')
+    expect(workflow).toContain('-f ref=main')
+    expect(workflow).toContain('--mode retry-publication')
+    expect(workflow).toContain('source_revision: ${{ needs.release-review-eligibility.outputs.source_sha }}')
+    expect(workflow).toContain('publish_on_dispatch: true')
+    expect(workflow).not.toContain('permissions:\n  actions: write')
+  })
+
+  test('decodes a bounded failed push and delayed clean reaction for retry discovery', async () => {
+    const fetchFn = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url.includes('/actions/workflows/') && url.includes('status=success')) {
+        if (url.includes('event=workflow_dispatch')) return Response.json({ workflow_runs: [] })
+        return Response.json({
+          workflow_runs: [
+            {
+              id: 100,
+              run_number: 10,
+              run_attempt: 1,
+              head_sha: lastPublishedSha,
+              head_branch: 'main',
+              event: 'push',
+              status: 'completed',
+              conclusion: 'success',
+            },
+            {
+              id: 101,
+              run_number: 11,
+              run_attempt: 1,
+              head_sha: mainCommitSha,
+              head_branch: 'main',
+              event: 'schedule',
+              status: 'completed',
+              conclusion: 'success',
+            },
+          ],
+        })
+      }
+      if (url.includes('/actions/workflows/')) {
+        if (url.includes('event=workflow_dispatch')) return Response.json({ workflow_runs: [] })
+        return Response.json({
+          workflow_runs: [
+            {
+              id: 30540000001,
+              run_number: 900,
+              run_attempt: 1,
+              head_sha: mainCommitSha,
+              head_branch: 'main',
+              event: 'push',
+              status: 'completed',
+              conclusion: 'failure',
+              created_at: '2026-07-30T07:00:05Z',
+              updated_at: '2026-07-30T07:02:30Z',
+            },
+          ],
+        })
+      }
+      if (url.includes('/actions/runs/30540000001/jobs?')) {
+        return Response.json({
+          jobs: [
+            { name: 'Verify exact-head Codex review', status: 'completed', conclusion: 'failure' },
+            { name: 'image', status: 'completed', conclusion: 'skipped' },
+          ],
+        })
+      }
+      if (url.includes('/compare/')) {
+        return Response.json({
+          status: 'ahead',
+          ahead_by: 1,
+          total_commits: 1,
+          base_commit: { sha: lastPublishedSha },
+          merge_base_commit: { sha: lastPublishedSha },
+          commits: [{ sha: mainCommitSha }],
+        })
+      }
+      if (url.includes('/commits/main?')) {
+        return Response.json({ sha: mainCommitSha })
+      }
+      if (url.includes(`/commits/${mainCommitSha}/pulls?`)) {
+        return Response.json([
+          {
+            number: 13401,
+            base: { ref: 'main' },
+            head: { sha: finalHeadSha },
+            merge_commit_sha: mainCommitSha,
+            merged_at: '2026-07-30T07:00:00Z',
+          },
+        ])
+      }
+      if (url.includes(`/commits/${mainCommitSha}?`)) {
+        return Response.json({
+          sha: mainCommitSha,
+          parents: [{ sha: lastPublishedSha }],
+          files: [{ filename: 'packages/scripts/src/bayn/verify-release-review.ts' }],
+        })
+      }
+      if (url.includes('/issues/13401/comments?')) return Response.json([])
+      if (url.includes('/issues/13401/reactions?')) {
+        return Response.json([
+          {
+            user: { login: baynCodexBotLogin },
+            content: '+1',
+            created_at: '2026-07-30T07:03:00Z',
+          },
+        ])
+      }
+
+      const request = JSON.parse(String(init?.body)) as { readonly query: string }
+      if (request.query.includes('BaynReleasePullRequestMetadata')) {
+        return Response.json({
+          data: {
+            repository: {
+              pullRequest: {
+                number: 13401,
+                baseRefName: 'main',
+                headRefOid: finalHeadSha,
+                createdAt: '2026-07-30T06:59:00Z',
+                mergedAt: '2026-07-30T07:00:00Z',
+                mergeCommit: { oid: mainCommitSha },
+                timelineItems: { nodes: [], pageInfo: { hasNextPage: false, endCursor: null } },
+              },
+            },
+          },
+        })
+      }
+      if (request.query.includes('BaynReleasePullRequestReviews')) {
+        return Response.json({
+          data: {
+            repository: {
+              pullRequest: {
+                reviews: { nodes: [], pageInfo: { hasNextPage: false, endCursor: null } },
+              },
+            },
+          },
+        })
+      }
+      if (request.query.includes('BaynReleasePullRequestThreads')) {
+        return Response.json({
+          data: {
+            repository: {
+              pullRequest: {
+                reviewThreads: { nodes: [], pageInfo: { hasNextPage: false, endCursor: null } },
+              },
+            },
+          },
+        })
+      }
+      if (request.query.includes('BaynReleasePullRequestCommits')) {
+        return Response.json({
+          data: {
+            repository: {
+              pullRequest: {
+                commits: {
+                  nodes: [{ commit: { oid: finalHeadSha } }],
+                  pageInfo: { hasNextPage: false, endCursor: null },
+                },
+              },
+            },
+          },
+        })
+      }
+      throw new Error(`unexpected retry fixture request: ${url}`)
+    }) as typeof fetch
+
+    const loaded = await createGitHubReleaseRetryLoader({
+      repository: 'proompteng/lab',
+      token: 'fixture-token',
+      mainCommitSha,
+      baseRefName: 'main',
+      requestTimeoutMs: 1_000,
+      fetchFn,
+    })()
+    expect(
+      evaluateBaynReleaseRetry({
+        mainCommitSha,
+        baseRefName: 'main',
+        snapshot: loaded,
+        trigger: { type: 'schedule' },
+        nowMs: retryNowMs,
+      }),
+    ).toMatchObject({
+      status: 'dispatch',
+      sourceCommitSha: mainCommitSha,
+      prNumber: 13401,
+      failedRunId: 30540000001,
     })
   })
 })

--- a/packages/scripts/src/bayn/verify-release-review.test.ts
+++ b/packages/scripts/src/bayn/verify-release-review.test.ts
@@ -653,6 +653,7 @@ describe('Bayn delayed-attestation publication retry', () => {
       sleep: async () => {},
       now: () => Date.parse('2026-07-30T07:02:20Z'),
     })
+
     expect(timedOut).toMatchObject({
       status: 'hold',
       code: 'exact-head-review-missing',
@@ -674,6 +675,76 @@ describe('Bayn delayed-attestation publication retry', () => {
       sourceCommitSha: mainCommitSha,
       prNumber: 13401,
       headSha: finalHeadSha,
+      failedRunId: 30540000001,
+    })
+  })
+
+  test('binds a retry to the earlier range commit whose attestation arrived after the failed current-main push', () => {
+    const earlierCommitSha = heldCommitSha
+    const earlierHeadSha = heldHeadSha
+    const earlierReview = reviewSnapshotFor({
+      commitSha: earlierCommitSha,
+      prNumber: 13401,
+      headSha: earlierHeadSha,
+      parents: [lastPublishedSha],
+      mergedAt: '2026-07-30T07:00:00Z',
+      reviews: [],
+      issueComments: [
+        issueComment({
+          body: `Codex Review: Didn't find any major issues.\n\n**Reviewed commit:** \`${earlierHeadSha.slice(0, 10)}\`\n`,
+          createdAt: '2026-07-30T07:03:00Z',
+          updatedAt: '2026-07-30T07:03:00Z',
+        }),
+      ],
+    })
+    const laterReview = reviewSnapshotFor({
+      commitSha: mainCommitSha,
+      prNumber: 13402,
+      headSha: finalHeadSha,
+      parents: [earlierCommitSha],
+      mergedAt: '2026-07-30T07:01:00Z',
+      reviews: [review({ submittedAt: '2026-07-30T07:00:30Z' })],
+    })
+    const range = eligibilitySnapshot({
+      comparison: {
+        status: 'ahead',
+        baseSha: lastPublishedSha,
+        headSha: mainCommitSha,
+        mergeBaseSha: lastPublishedSha,
+        aheadBy: 2,
+        totalCommits: 2,
+        commits: [
+          {
+            sha: earlierCommitSha,
+            parents: [lastPublishedSha],
+            files: ['services/bayn/src/earlier.ts'],
+            reviewSnapshot: earlierReview,
+          },
+          {
+            sha: mainCommitSha,
+            parents: [earlierCommitSha],
+            files: ['services/bayn/src/later.ts'],
+            reviewSnapshot: laterReview,
+          },
+        ],
+        truncated: false,
+      },
+    })
+
+    expect(
+      evaluateBaynReleaseRetry({
+        mainCommitSha,
+        baseRefName: 'main',
+        snapshot: retrySnapshot({ eligibility: range }),
+        trigger: { type: 'issue-comment', prNumber: 13401, actorLogin: baynCodexBotLogin },
+        nowMs: retryNowMs,
+      }),
+    ).toEqual({
+      status: 'dispatch',
+      currentMainSha: mainCommitSha,
+      sourceCommitSha: earlierCommitSha,
+      prNumber: 13401,
+      headSha: earlierHeadSha,
       failedRunId: 30540000001,
     })
   })
@@ -701,20 +772,79 @@ describe('Bayn delayed-attestation publication retry', () => {
   })
 
   test('rejects spoofed and stale issue-comment retry triggers', () => {
-    for (const trigger of [
-      { type: 'issue-comment', prNumber: 13401, actorLogin: 'spoofed-codex[bot]' } as const,
-      { type: 'issue-comment', prNumber: 13399, actorLogin: baynCodexBotLogin } as const,
-    ]) {
-      expect(
-        evaluateBaynReleaseRetry({
-          mainCommitSha,
-          baseRefName: 'main',
-          snapshot: retrySnapshot(),
-          trigger,
-          nowMs: retryNowMs,
-        }),
-      ).toMatchObject({ status: 'hold', code: 'retry-trigger-mismatch', retryable: false })
-    }
+    expect(
+      evaluateBaynReleaseRetry({
+        mainCommitSha,
+        baseRefName: 'main',
+        snapshot: retrySnapshot(),
+        trigger: { type: 'issue-comment', prNumber: 13401, actorLogin: 'spoofed-codex[bot]' },
+        nowMs: retryNowMs,
+      }),
+    ).toMatchObject({ status: 'hold', code: 'retry-trigger-mismatch', retryable: false })
+    expect(
+      evaluateBaynReleaseRetry({
+        mainCommitSha,
+        baseRefName: 'main',
+        snapshot: retrySnapshot(),
+        trigger: { type: 'issue-comment', prNumber: 13399, actorLogin: baynCodexBotLogin },
+        nowMs: retryNowMs,
+      }),
+    ).toMatchObject({ status: 'hold', code: 'retry-attestation-not-delayed', retryable: true })
+  })
+
+  test('fails closed when a scheduled scan sees multiple delayed source attestations', () => {
+    const secondCommitSha = '2'.repeat(40)
+    const secondHeadSha = '3'.repeat(40)
+    const first = reviewSnapshotFor({
+      commitSha: secondCommitSha,
+      prNumber: 13401,
+      headSha: secondHeadSha,
+      parents: [lastPublishedSha],
+      mergedAt: '2026-07-30T07:00:00Z',
+      reviews: [review({ commitSha: secondHeadSha, submittedAt: '2026-07-30T07:03:00Z' })],
+    })
+    const second = reviewSnapshotFor({
+      commitSha: mainCommitSha,
+      prNumber: 13402,
+      headSha: finalHeadSha,
+      parents: [secondCommitSha],
+      mergedAt: '2026-07-30T07:01:00Z',
+      reviews: [review({ submittedAt: '2026-07-30T07:03:10Z' })],
+    })
+    const range = eligibilitySnapshot({
+      comparison: {
+        status: 'ahead',
+        baseSha: lastPublishedSha,
+        headSha: mainCommitSha,
+        mergeBaseSha: lastPublishedSha,
+        aheadBy: 2,
+        totalCommits: 2,
+        commits: [
+          {
+            sha: secondCommitSha,
+            parents: [lastPublishedSha],
+            files: ['services/bayn/src/first.ts'],
+            reviewSnapshot: first,
+          },
+          {
+            sha: mainCommitSha,
+            parents: [secondCommitSha],
+            files: ['services/bayn/src/second.ts'],
+            reviewSnapshot: second,
+          },
+        ],
+        truncated: false,
+      },
+    })
+    expect(
+      evaluateBaynReleaseRetry({
+        mainCommitSha,
+        baseRefName: 'main',
+        snapshot: retrySnapshot({ eligibility: range }),
+        trigger: { type: 'schedule' },
+        nowMs: retryNowMs,
+      }),
+    ).toMatchObject({ status: 'hold', code: 'retry-delayed-source-ambiguous', retryable: false })
   })
 
   test('rejects a delayed source whose final PR head was force-pushed', () => {

--- a/packages/scripts/src/bayn/verify-release-review.ts
+++ b/packages/scripts/src/bayn/verify-release-review.ts
@@ -181,6 +181,7 @@ export type BaynReleaseReviewHoldCode =
   | 'retry-failed-run-missing'
   | 'retry-failed-run-mismatch'
   | 'retry-attestation-not-delayed'
+  | 'retry-delayed-source-ambiguous'
   | 'retry-trigger-mismatch'
   | 'github-api-error'
   | 'github-api-timeout'
@@ -808,8 +809,8 @@ export const evaluateBaynReleaseEligibility = (input: {
   }
 }
 
-const latestBaynAffectingCommit = (snapshot: BaynReleaseEligibilitySnapshot): BaynReleaseRangeCommit | undefined =>
-  snapshot.comparison?.commits.filter((commit) => commit.files.some(isBaynReleaseAffectingPath)).at(-1)
+const baynAffectingCommits = (snapshot: BaynReleaseEligibilitySnapshot): readonly BaynReleaseRangeCommit[] =>
+  snapshot.comparison?.commits.filter((commit) => commit.files.some(isBaynReleaseAffectingPath)) ?? []
 
 const failedReviewRunMatches = (evidence: FailedBaynReleaseReviewRun, sourceCommitSha: string): boolean => {
   const { run, jobs } = evidence
@@ -886,24 +887,79 @@ export const evaluateBaynReleaseRetry = (input: {
       : eligibility
   }
 
-  const sourceCommit = latestBaynAffectingCommit(input.snapshot)
-  const sourcePull = sourceCommit?.reviewSnapshot?.pullRequest
-  const reviewedSource = eligibility.reviewedPullRequests.at(-1)
-  if (
-    sourceCommit === undefined ||
-    sourcePull === null ||
-    sourcePull === undefined ||
-    reviewedSource === undefined ||
-    reviewedSource.commitSha !== sourceCommit.sha ||
-    reviewedSource.prNumber !== sourcePull.number ||
-    reviewedSource.headSha !== sourcePull.headSha
-  ) {
+  const failedReviewRun = input.snapshot.failedReviewRun
+  if (failedReviewRun === null) {
     return hold(
-      'retry-trigger-mismatch',
-      `retry source metadata does not uniquely bind the latest Bayn-affecting commit on ${shortSha(input.mainCommitSha)}`,
+      'retry-failed-run-missing',
+      `current main ${shortSha(input.mainCommitSha)} has no completed failed Bayn push run to retry`,
+      true,
+    )
+  }
+  if (!failedReviewRunMatches(failedReviewRun, input.mainCommitSha)) {
+    return hold(
+      'retry-failed-run-mismatch',
+      `Bayn run ${failedReviewRun.run.id} does not prove an exact failed review gate with a skipped image for current main ${shortSha(input.mainCommitSha)}`,
       false,
     )
   }
+  const failedAtMs = Date.parse(failedReviewRun.run.updatedAt)
+  if (!Number.isFinite(failedAtMs)) {
+    return hold(
+      'retry-failed-run-mismatch',
+      `Bayn run ${failedReviewRun.run.id} has an invalid completion timestamp`,
+      false,
+    )
+  }
+
+  const affectingCommits = baynAffectingCommits(input.snapshot)
+  const delayedCandidates = eligibility.reviewedPullRequests.flatMap((reviewed) => {
+    const attestedAtMs = Date.parse(reviewed.reviewSubmittedAt)
+    if (!Number.isFinite(attestedAtMs) || attestedAtMs <= failedAtMs) return []
+    const commit = affectingCommits.find((candidate) => candidate.sha === reviewed.commitSha)
+    const pullRequest = commit?.reviewSnapshot?.pullRequest
+    if (
+      commit === undefined ||
+      pullRequest === null ||
+      pullRequest === undefined ||
+      pullRequest.number !== reviewed.prNumber ||
+      pullRequest.headSha !== reviewed.headSha
+    ) {
+      return []
+    }
+    return [{ commit, pullRequest, reviewed }]
+  })
+
+  let triggerCandidates = delayedCandidates
+  if (input.trigger.type === 'issue-comment') {
+    const triggerPrNumber = input.trigger.prNumber
+    triggerCandidates = delayedCandidates.filter((candidate) => candidate.pullRequest.number === triggerPrNumber)
+  } else if (input.trigger.type === 'workflow-dispatch') {
+    const trigger = input.trigger
+    triggerCandidates = delayedCandidates.filter(
+      (candidate) =>
+        candidate.commit.sha === trigger.sourceCommitSha &&
+        candidate.pullRequest.number === trigger.prNumber &&
+        candidate.pullRequest.headSha === trigger.headSha,
+    )
+  }
+  if (triggerCandidates.length === 0) {
+    return hold(
+      'retry-attestation-not-delayed',
+      `no exact Bayn source attestation matching the retry trigger is newer than failed run ${failedReviewRun.run.id}`,
+      true,
+    )
+  }
+  if (triggerCandidates.length > 1) {
+    return hold(
+      'retry-delayed-source-ambiguous',
+      `failed run ${failedReviewRun.run.id} has multiple delayed Bayn source attestations matching the retry trigger: ${triggerCandidates.map(({ commit, pullRequest }) => `${shortSha(commit.sha)}/#${pullRequest.number}`).join(', ')}`,
+      false,
+    )
+  }
+  const selected = triggerCandidates[0]
+  if (selected === undefined) throw new Error('delayed retry candidate selection was unexpectedly empty')
+  const sourceCommit = selected.commit
+  const sourcePull = selected.pullRequest
   if (sourcePull.headForcePushCount !== 0) {
     return hold(
       'retry-source-pr-force-pushed',
@@ -912,33 +968,8 @@ export const evaluateBaynReleaseRetry = (input: {
     )
   }
 
-  const failedReviewRun = input.snapshot.failedReviewRun
-  if (failedReviewRun === null) {
-    return hold(
-      'retry-failed-run-missing',
-      `source commit ${shortSha(sourceCommit.sha)} has no completed failed Bayn push run to retry`,
-      true,
-    )
-  }
-  if (!failedReviewRunMatches(failedReviewRun, sourceCommit.sha)) {
-    return hold(
-      'retry-failed-run-mismatch',
-      `Bayn run ${failedReviewRun.run.id} does not prove an exact failed review gate with a skipped image for source ${shortSha(sourceCommit.sha)}`,
-      false,
-    )
-  }
-  const failedAtMs = Date.parse(failedReviewRun.run.updatedAt)
-  const attestedAtMs = Date.parse(reviewedSource.reviewSubmittedAt)
-  if (!Number.isFinite(failedAtMs) || !Number.isFinite(attestedAtMs) || attestedAtMs <= failedAtMs) {
-    return hold(
-      'retry-attestation-not-delayed',
-      `source PR #${sourcePull.number} has no clean exact-head attestation newer than failed run ${failedReviewRun.run.id}`,
-      true,
-    )
-  }
-
   if (input.trigger.type === 'issue-comment') {
-    if (input.trigger.actorLogin !== baynCodexBotLogin || input.trigger.prNumber !== sourcePull.number) {
+    if (input.trigger.actorLogin !== baynCodexBotLogin) {
       return hold(
         'retry-trigger-mismatch',
         `issue-comment retry trigger does not match connector identity and source PR #${sourcePull.number}`,
@@ -2060,17 +2091,17 @@ export const createGitHubReleaseRetryLoader = (options: {
 
   return async () => {
     const [eligibility, defaultBranchSha] = await Promise.all([loadEligibility(), fetchDefaultBranchSha(loaderOptions)])
-    const sourceCommit = latestBaynAffectingCommit(eligibility)
     const [sourcePushRuns, currentDispatchRuns] = await Promise.all([
-      sourceCommit === undefined
-        ? Promise.resolve([])
-        : fetchBaynBuildWorkflowRuns(loaderOptions, { headSha: sourceCommit.sha, event: 'push' }),
+      fetchBaynBuildWorkflowRuns(loaderOptions, {
+        headSha: options.mainCommitSha,
+        event: 'push',
+      }),
       fetchBaynBuildWorkflowRuns(loaderOptions, {
         headSha: options.mainCommitSha,
         event: 'workflow_dispatch',
       }),
     ])
-    const failedRun = sourceCommit === undefined ? undefined : latestFailedSourcePush(sourcePushRuns, sourceCommit.sha)
+    const failedRun = latestFailedSourcePush(sourcePushRuns, options.mainCommitSha)
     const jobs = failedRun === undefined ? [] : await fetchBaynBuildWorkflowJobs(loaderOptions, failedRun.id)
     return {
       ...eligibility,

--- a/packages/scripts/src/bayn/verify-release-review.ts
+++ b/packages/scripts/src/bayn/verify-release-review.ts
@@ -1,3 +1,5 @@
+import { appendFile } from 'node:fs/promises'
+
 const githubApiVersion = '2022-11-28'
 const githubGraphqlUrl = 'https://api.github.com/graphql'
 const maximumGraphqlPages = 20
@@ -90,6 +92,30 @@ export interface SuccessfulPublishRun {
   readonly conclusion: string
 }
 
+export interface BaynBuildWorkflowRun {
+  readonly id: number
+  readonly runNumber: number
+  readonly runAttempt: number
+  readonly headSha: string
+  readonly headBranch: string
+  readonly event: string
+  readonly status: string
+  readonly conclusion: string | null
+  readonly createdAt: string
+  readonly updatedAt: string
+}
+
+export interface BaynBuildWorkflowJob {
+  readonly name: string
+  readonly status: string
+  readonly conclusion: string | null
+}
+
+export interface FailedBaynReleaseReviewRun {
+  readonly run: BaynBuildWorkflowRun
+  readonly jobs: readonly BaynBuildWorkflowJob[]
+}
+
 export type LastPublishedRevisionResolution =
   | {
       readonly status: 'resolved'
@@ -125,6 +151,13 @@ export interface BaynReleaseEligibilitySnapshot {
   readonly comparison: BaynReleaseComparison | null
 }
 
+export interface BaynReleaseRetrySnapshot extends BaynReleaseEligibilitySnapshot {
+  readonly defaultBranchSha: string
+  readonly failedReviewRun: FailedBaynReleaseReviewRun | null
+  readonly publicationSucceeded: boolean
+  readonly retryInProgress: boolean
+}
+
 export type BaynReleaseReviewHoldCode =
   | 'last-published-revision-missing'
   | 'last-published-revision-ambiguous'
@@ -143,6 +176,12 @@ export type BaynReleaseReviewHoldCode =
   | 'exact-head-review-settling'
   | 'feedback-fix-attestation-missing'
   | 'active-unresolved-review-threads'
+  | 'retry-default-branch-mismatch'
+  | 'retry-source-pr-force-pushed'
+  | 'retry-failed-run-missing'
+  | 'retry-failed-run-mismatch'
+  | 'retry-attestation-not-delayed'
+  | 'retry-trigger-mismatch'
   | 'github-api-error'
   | 'github-api-timeout'
   | 'github-api-invalid-response'
@@ -179,6 +218,33 @@ export interface BaynReleaseReviewHold {
 export type BaynReleaseReviewEvaluation = BaynReleaseReviewEligible | BaynReleaseReviewHold
 
 export type BaynReleaseEligibilityEvaluation = BaynReleaseEligibilityEligible | BaynReleaseReviewHold
+
+export type BaynReleaseRetryTrigger =
+  | { readonly type: 'schedule' }
+  | { readonly type: 'issue-comment'; readonly prNumber: number; readonly actorLogin: string }
+  | {
+      readonly type: 'workflow-dispatch'
+      readonly sourceCommitSha: string
+      readonly prNumber: number
+      readonly headSha: string
+      readonly failedRunId: number
+    }
+
+export type BaynReleaseRetryEvaluation =
+  | {
+      readonly status: 'dispatch'
+      readonly currentMainSha: string
+      readonly sourceCommitSha: string
+      readonly prNumber: number
+      readonly headSha: string
+      readonly failedRunId: number
+    }
+  | {
+      readonly status: 'noop'
+      readonly code: 'retry-already-published' | 'retry-attestation-not-ready' | 'retry-in-progress'
+      readonly message: string
+    }
+  | BaynReleaseReviewHold
 
 export type BaynReleaseReviewPollResult = BaynReleaseReviewEvaluation & {
   readonly attempts: number
@@ -294,9 +360,14 @@ const cleanCodexCommentPattern =
 
 const cleanCodexCommentHead = (body: string): string | null => cleanCodexCommentPattern.exec(body)?.[1] ?? null
 
-const timestampWithinPullRequest = (timestamp: string, createdAtMs: number, mergedAtMs: number): boolean => {
+const timestampWithinPullRequest = (
+  timestamp: string,
+  createdAtMs: number,
+  mergedAtMs: number,
+  allowAfterMerge: boolean,
+): boolean => {
   const timestampMs = Date.parse(timestamp)
-  return Number.isFinite(timestampMs) && timestampMs >= createdAtMs && timestampMs <= mergedAtMs
+  return Number.isFinite(timestampMs) && timestampMs >= createdAtMs && (timestampMs <= mergedAtMs || allowAfterMerge)
 }
 
 const exactHeadCodexAttestation = (
@@ -309,7 +380,7 @@ const exactHeadCodexAttestation = (
       if (
         candidate.authorLogin !== baynCodexBotLogin ||
         candidate.createdAt !== candidate.updatedAt ||
-        !timestampWithinPullRequest(candidate.createdAt, createdAtMs, mergedAtMs)
+        !timestampWithinPullRequest(candidate.createdAt, createdAtMs, mergedAtMs, pullRequest.headForcePushCount === 0)
       ) {
         return false
       }
@@ -338,7 +409,7 @@ const exactHeadCodexAttestation = (
       (candidate) =>
         candidate.userLogin === baynCodexBotLogin &&
         candidate.content === '+1' &&
-        timestampWithinPullRequest(candidate.createdAt, createdAtMs, mergedAtMs),
+        timestampWithinPullRequest(candidate.createdAt, createdAtMs, mergedAtMs, true),
     )
     .toSorted((left, right) => right.createdAt.localeCompare(left.createdAt))[0]
   if (reaction === undefined) return undefined
@@ -595,11 +666,11 @@ export const evaluateBaynReleaseEligibility = (input: {
   readonly baseRefName: string
   readonly snapshot: BaynReleaseEligibilitySnapshot
   readonly nowMs: number
-  readonly pushBeforeSha: string
+  readonly pushBeforeSha: string | null
 }): BaynReleaseEligibilityEvaluation => {
   if (
-    input.snapshot.currentCommitParents.length !== 1 ||
-    input.snapshot.currentCommitParents[0] !== input.pushBeforeSha
+    input.pushBeforeSha !== null &&
+    (input.snapshot.currentCommitParents.length !== 1 || input.snapshot.currentCommitParents[0] !== input.pushBeforeSha)
   ) {
     const parents =
       input.snapshot.currentCommitParents.length === 0
@@ -734,6 +805,176 @@ export const evaluateBaynReleaseEligibility = (input: {
     checkedCommitCount: comparison.commits.length,
     baynAffectingCommitCount: affectingCommits.length,
     reviewedPullRequests,
+  }
+}
+
+const latestBaynAffectingCommit = (snapshot: BaynReleaseEligibilitySnapshot): BaynReleaseRangeCommit | undefined =>
+  snapshot.comparison?.commits.filter((commit) => commit.files.some(isBaynReleaseAffectingPath)).at(-1)
+
+const failedReviewRunMatches = (evidence: FailedBaynReleaseReviewRun, sourceCommitSha: string): boolean => {
+  const { run, jobs } = evidence
+  const reviewJobs = jobs.filter((job) => job.name === 'Verify exact-head Codex review')
+  const imageJobs = jobs.filter((job) => job.name === 'image')
+  return (
+    run.headSha === sourceCommitSha &&
+    run.headBranch === 'main' &&
+    run.event === 'push' &&
+    run.status === 'completed' &&
+    run.conclusion === 'failure' &&
+    reviewJobs.length === 1 &&
+    reviewJobs[0]?.status === 'completed' &&
+    reviewJobs[0]?.conclusion === 'failure' &&
+    imageJobs.length === 1 &&
+    imageJobs[0]?.status === 'completed' &&
+    imageJobs[0]?.conclusion === 'skipped'
+  )
+}
+
+export const evaluateBaynReleaseRetry = (input: {
+  readonly mainCommitSha: string
+  readonly baseRefName: string
+  readonly snapshot: BaynReleaseRetrySnapshot
+  readonly trigger: BaynReleaseRetryTrigger
+  readonly nowMs: number
+}): BaynReleaseRetryEvaluation => {
+  if (input.snapshot.defaultBranchSha !== input.mainCommitSha) {
+    return hold(
+      'retry-default-branch-mismatch',
+      `trusted default branch is ${shortSha(input.snapshot.defaultBranchSha)}, not requested retry main ${shortSha(input.mainCommitSha)}`,
+      true,
+    )
+  }
+
+  if (
+    input.snapshot.publicationSucceeded ||
+    (input.snapshot.lastPublishedRevision.status === 'resolved' &&
+      input.snapshot.lastPublishedRevision.revision === input.mainCommitSha)
+  ) {
+    return {
+      status: 'noop',
+      code: 'retry-already-published',
+      message: `current main ${shortSha(input.mainCommitSha)} already has a successful Bayn publication`,
+    }
+  }
+  if (
+    input.snapshot.lastPublishedRevision.status === 'resolved' &&
+    input.snapshot.comparison !== null &&
+    (input.snapshot.comparison.status === 'ahead' || input.snapshot.comparison.status === 'identical') &&
+    input.snapshot.comparison.commits.every((commit) => !commit.files.some(isBaynReleaseAffectingPath))
+  ) {
+    return {
+      status: 'noop',
+      code: 'retry-already-published',
+      message: `no Bayn-affecting commit exists after successful publication ${shortSha(input.snapshot.lastPublishedRevision.revision)}`,
+    }
+  }
+
+  const eligibility = evaluateBaynReleaseEligibility({
+    mainCommitSha: input.mainCommitSha,
+    baseRefName: input.baseRefName,
+    snapshot: input.snapshot,
+    nowMs: input.nowMs,
+    pushBeforeSha: null,
+  })
+  if (eligibility.status === 'hold') {
+    return eligibility.retryable
+      ? {
+          status: 'noop',
+          code: 'retry-attestation-not-ready',
+          message: eligibility.message,
+        }
+      : eligibility
+  }
+
+  const sourceCommit = latestBaynAffectingCommit(input.snapshot)
+  const sourcePull = sourceCommit?.reviewSnapshot?.pullRequest
+  const reviewedSource = eligibility.reviewedPullRequests.at(-1)
+  if (
+    sourceCommit === undefined ||
+    sourcePull === null ||
+    sourcePull === undefined ||
+    reviewedSource === undefined ||
+    reviewedSource.commitSha !== sourceCommit.sha ||
+    reviewedSource.prNumber !== sourcePull.number ||
+    reviewedSource.headSha !== sourcePull.headSha
+  ) {
+    return hold(
+      'retry-trigger-mismatch',
+      `retry source metadata does not uniquely bind the latest Bayn-affecting commit on ${shortSha(input.mainCommitSha)}`,
+      false,
+    )
+  }
+  if (sourcePull.headForcePushCount !== 0) {
+    return hold(
+      'retry-source-pr-force-pushed',
+      `source PR #${sourcePull.number} final head ${shortSha(sourcePull.headSha)} has ${sourcePull.headForcePushCount} force-push event(s) and is ineligible for unattended retry`,
+      false,
+    )
+  }
+
+  const failedReviewRun = input.snapshot.failedReviewRun
+  if (failedReviewRun === null) {
+    return hold(
+      'retry-failed-run-missing',
+      `source commit ${shortSha(sourceCommit.sha)} has no completed failed Bayn push run to retry`,
+      true,
+    )
+  }
+  if (!failedReviewRunMatches(failedReviewRun, sourceCommit.sha)) {
+    return hold(
+      'retry-failed-run-mismatch',
+      `Bayn run ${failedReviewRun.run.id} does not prove an exact failed review gate with a skipped image for source ${shortSha(sourceCommit.sha)}`,
+      false,
+    )
+  }
+  const failedAtMs = Date.parse(failedReviewRun.run.updatedAt)
+  const attestedAtMs = Date.parse(reviewedSource.reviewSubmittedAt)
+  if (!Number.isFinite(failedAtMs) || !Number.isFinite(attestedAtMs) || attestedAtMs <= failedAtMs) {
+    return hold(
+      'retry-attestation-not-delayed',
+      `source PR #${sourcePull.number} has no clean exact-head attestation newer than failed run ${failedReviewRun.run.id}`,
+      true,
+    )
+  }
+
+  if (input.trigger.type === 'issue-comment') {
+    if (input.trigger.actorLogin !== baynCodexBotLogin || input.trigger.prNumber !== sourcePull.number) {
+      return hold(
+        'retry-trigger-mismatch',
+        `issue-comment retry trigger does not match connector identity and source PR #${sourcePull.number}`,
+        false,
+      )
+    }
+  } else if (input.trigger.type === 'workflow-dispatch') {
+    if (
+      input.trigger.sourceCommitSha !== sourceCommit.sha ||
+      input.trigger.prNumber !== sourcePull.number ||
+      input.trigger.headSha !== sourcePull.headSha ||
+      input.trigger.failedRunId !== failedReviewRun.run.id
+    ) {
+      return hold(
+        'retry-trigger-mismatch',
+        `workflow dispatch binding does not match source ${shortSha(sourceCommit.sha)}, PR #${sourcePull.number}, head ${shortSha(sourcePull.headSha)}, and failed run ${failedReviewRun.run.id}`,
+        false,
+      )
+    }
+  }
+
+  if (input.trigger.type !== 'workflow-dispatch' && input.snapshot.retryInProgress) {
+    return {
+      status: 'noop',
+      code: 'retry-in-progress',
+      message: `a Bayn workflow-dispatch retry is already queued or running for current main ${shortSha(input.mainCommitSha)}`,
+    }
+  }
+
+  return {
+    status: 'dispatch',
+    currentMainSha: input.mainCommitSha,
+    sourceCommitSha: sourceCommit.sha,
+    prNumber: sourcePull.number,
+    headSha: sourcePull.headSha,
+    failedRunId: failedReviewRun.run.id,
   }
 }
 
@@ -1008,7 +1249,7 @@ const parseSuccessfulPublishRuns = (value: unknown): readonly SuccessfulPublishR
   if (!Array.isArray(payload.workflow_runs)) {
     throw new GitHubReleaseReviewError('github-api-invalid-response', 'list successful Bayn publish runs')
   }
-  return payload.workflow_runs.map((item, index) => {
+  return payload.workflow_runs.flatMap((item, index) => {
     const run = expectRecord(item, `successful Bayn publish run ${index}`)
     const parsed: SuccessfulPublishRun = {
       id: expectInteger(run.id, `successful Bayn publish run ${index} ID`),
@@ -1020,15 +1261,49 @@ const parseSuccessfulPublishRuns = (value: unknown): readonly SuccessfulPublishR
       status: expectString(run.status, `successful Bayn publish run ${index} status`),
       conclusion: expectString(run.conclusion, `successful Bayn publish run ${index} conclusion`),
     }
-    if (
-      parsed.headBranch !== 'main' ||
-      parsed.event !== 'push' ||
-      parsed.status !== 'completed' ||
-      parsed.conclusion !== 'success'
-    ) {
-      throw new GitHubReleaseReviewError('github-api-invalid-response', `successful Bayn publish run ${index} contract`)
+    return parsed.headBranch === 'main' &&
+      (parsed.event === 'push' || parsed.event === 'workflow_dispatch') &&
+      parsed.status === 'completed' &&
+      parsed.conclusion === 'success'
+      ? [parsed]
+      : []
+  })
+}
+
+const parseBaynBuildWorkflowRuns = (value: unknown): readonly BaynBuildWorkflowRun[] => {
+  const payload = expectRecord(value, 'list Bayn build workflow runs')
+  if (!Array.isArray(payload.workflow_runs)) {
+    throw new GitHubReleaseReviewError('github-api-invalid-response', 'list Bayn build workflow runs')
+  }
+  return payload.workflow_runs.map((item, index) => {
+    const run = expectRecord(item, `Bayn build workflow run ${index}`)
+    return {
+      id: expectInteger(run.id, `Bayn build workflow run ${index} ID`),
+      runNumber: expectInteger(run.run_number, `Bayn build workflow run ${index} number`),
+      runAttempt: expectInteger(run.run_attempt, `Bayn build workflow run ${index} attempt`),
+      headSha: expectSha(run.head_sha, `Bayn build workflow run ${index} head SHA`),
+      headBranch: expectString(run.head_branch, `Bayn build workflow run ${index} head branch`),
+      event: expectString(run.event, `Bayn build workflow run ${index} event`),
+      status: expectString(run.status, `Bayn build workflow run ${index} status`),
+      conclusion: expectNullableString(run.conclusion, `Bayn build workflow run ${index} conclusion`),
+      createdAt: expectString(run.created_at, `Bayn build workflow run ${index} created at`),
+      updatedAt: expectString(run.updated_at, `Bayn build workflow run ${index} updated at`),
     }
-    return parsed
+  })
+}
+
+const parseBaynBuildWorkflowJobs = (value: unknown): readonly BaynBuildWorkflowJob[] => {
+  const payload = expectRecord(value, 'list Bayn build workflow jobs')
+  if (!Array.isArray(payload.jobs)) {
+    throw new GitHubReleaseReviewError('github-api-invalid-response', 'list Bayn build workflow jobs')
+  }
+  return payload.jobs.map((item, index) => {
+    const job = expectRecord(item, `Bayn build workflow job ${index}`)
+    return {
+      name: expectString(job.name, `Bayn build workflow job ${index} name`),
+      status: expectString(job.status, `Bayn build workflow job ${index} status`),
+      conclusion: expectNullableString(job.conclusion, `Bayn build workflow job ${index} conclusion`),
+    }
   })
 }
 
@@ -1570,18 +1845,29 @@ interface StaticReleaseEligibilityContext {
 const loadStaticReleaseEligibilityContext = async (
   options: GitHubLoaderOptions,
 ): Promise<StaticReleaseEligibilityContext> => {
-  const successfulRunsOperation = `list successful ${githubWorkflowFile} main push runs`
-  const [currentCommit, successfulRunsResponse] = await Promise.all([
+  const successfulPushRunsOperation = `read latest successful ${githubWorkflowFile} main push`
+  const successfulDispatchRunsOperation = `read latest successful ${githubWorkflowFile} main workflow dispatch`
+  const [currentCommit, successfulPushRunsResponse, successfulDispatchRunsResponse] = await Promise.all([
     fetchCommitDetail(options, options.mainCommitSha),
     requestGitHubJson({
-      url: `https://api.github.com/repos/${encodeURIComponent(options.owner)}/${encodeURIComponent(options.name)}/actions/workflows/${encodeURIComponent(githubWorkflowFile)}/runs?branch=main&event=push&status=success&per_page=100&page=1`,
-      operation: successfulRunsOperation,
+      url: `https://api.github.com/repos/${encodeURIComponent(options.owner)}/${encodeURIComponent(options.name)}/actions/workflows/${encodeURIComponent(githubWorkflowFile)}/runs?branch=main&event=push&status=success&per_page=1&page=1`,
+      operation: successfulPushRunsOperation,
+      token: options.token,
+      requestTimeoutMs: options.requestTimeoutMs,
+      fetchFn: options.fetchFn,
+    }),
+    requestGitHubJson({
+      url: `https://api.github.com/repos/${encodeURIComponent(options.owner)}/${encodeURIComponent(options.name)}/actions/workflows/${encodeURIComponent(githubWorkflowFile)}/runs?branch=main&event=workflow_dispatch&status=success&per_page=1&page=1`,
+      operation: successfulDispatchRunsOperation,
       token: options.token,
       requestTimeoutMs: options.requestTimeoutMs,
       fetchFn: options.fetchFn,
     }),
   ])
-  const lastPublishedRevision = resolveLastPublishedRevision(parseSuccessfulPublishRuns(successfulRunsResponse.value))
+  const lastPublishedRevision = resolveLastPublishedRevision([
+    ...parseSuccessfulPublishRuns(successfulPushRunsResponse.value),
+    ...parseSuccessfulPublishRuns(successfulDispatchRunsResponse.value),
+  ])
   if (lastPublishedRevision.status !== 'resolved') {
     return { currentCommit, lastPublishedRevision, comparison: null }
   }
@@ -1680,13 +1966,146 @@ export const createGitHubReleaseEligibilityLoader = (options: {
   }
 }
 
+const fetchDefaultBranchSha = async (options: GitHubLoaderOptions): Promise<string> => {
+  const operation = `read trusted default branch ${options.baseRefName}`
+  const response = await requestGitHubJson({
+    url: `https://api.github.com/repos/${encodeURIComponent(options.owner)}/${encodeURIComponent(options.name)}/commits/${encodeURIComponent(options.baseRefName)}?per_page=1`,
+    operation,
+    token: options.token,
+    requestTimeoutMs: options.requestTimeoutMs,
+    fetchFn: options.fetchFn,
+  })
+  return expectSha(expectRecord(response.value, operation).sha, `${operation} SHA`)
+}
+
+const fetchBaynBuildWorkflowRuns = async (
+  options: GitHubLoaderOptions,
+  input: { readonly headSha: string; readonly event: 'push' | 'workflow_dispatch' },
+): Promise<readonly BaynBuildWorkflowRun[]> => {
+  const operation = `list ${githubWorkflowFile} ${input.event} runs for ${shortSha(input.headSha)}`
+  const response = await requestGitHubJson({
+    url: `https://api.github.com/repos/${encodeURIComponent(options.owner)}/${encodeURIComponent(options.name)}/actions/workflows/${encodeURIComponent(githubWorkflowFile)}/runs?branch=main&head_sha=${encodeURIComponent(input.headSha)}&event=${input.event}&per_page=100&page=1`,
+    operation,
+    token: options.token,
+    requestTimeoutMs: options.requestTimeoutMs,
+    fetchFn: options.fetchFn,
+  })
+  if (response.headers.get('link')?.includes('rel="next"') === true) {
+    throw new GitHubReleaseReviewError('github-api-pagination-limit', operation)
+  }
+  const runs = parseBaynBuildWorkflowRuns(response.value)
+  if (runs.some((run) => run.headSha !== input.headSha || run.headBranch !== 'main' || run.event !== input.event)) {
+    throw new GitHubReleaseReviewError('github-api-invalid-response', operation)
+  }
+  return runs
+}
+
+const fetchBaynBuildWorkflowJobs = async (
+  options: GitHubLoaderOptions,
+  runId: number,
+): Promise<readonly BaynBuildWorkflowJob[]> => {
+  const operation = `list ${githubWorkflowFile} run ${runId} jobs`
+  const response = await requestGitHubJson({
+    url: `https://api.github.com/repos/${encodeURIComponent(options.owner)}/${encodeURIComponent(options.name)}/actions/runs/${runId}/jobs?per_page=100&page=1`,
+    operation,
+    token: options.token,
+    requestTimeoutMs: options.requestTimeoutMs,
+    fetchFn: options.fetchFn,
+  })
+  if (response.headers.get('link')?.includes('rel="next"') === true) {
+    throw new GitHubReleaseReviewError('github-api-pagination-limit', operation)
+  }
+  return parseBaynBuildWorkflowJobs(response.value)
+}
+
+const latestFailedSourcePush = (
+  runs: readonly BaynBuildWorkflowRun[],
+  sourceCommitSha: string,
+): BaynBuildWorkflowRun | undefined =>
+  runs
+    .filter(
+      (run) =>
+        run.headSha === sourceCommitSha &&
+        run.headBranch === 'main' &&
+        run.event === 'push' &&
+        run.status === 'completed' &&
+        run.conclusion === 'failure',
+    )
+    .toSorted(
+      (left, right) => right.runNumber - left.runNumber || right.runAttempt - left.runAttempt || right.id - left.id,
+    )[0]
+
+export const createGitHubReleaseRetryLoader = (options: {
+  readonly repository: string
+  readonly token: string
+  readonly mainCommitSha: string
+  readonly baseRefName: string
+  readonly requestTimeoutMs: number
+  readonly fetchFn?: typeof fetch
+}): (() => Promise<BaynReleaseRetrySnapshot>) => {
+  const [owner, name, extra] = options.repository.split('/')
+  if (owner === undefined || owner.length === 0 || name === undefined || name.length === 0 || extra !== undefined) {
+    throw new Error('repository must be in owner/name form')
+  }
+  const loaderOptions: GitHubLoaderOptions = {
+    owner,
+    name,
+    token: options.token,
+    mainCommitSha: options.mainCommitSha,
+    baseRefName: options.baseRefName,
+    requestTimeoutMs: options.requestTimeoutMs,
+    fetchFn: options.fetchFn ?? fetch,
+  }
+  const loadEligibility = createGitHubReleaseEligibilityLoader(options)
+
+  return async () => {
+    const [eligibility, defaultBranchSha] = await Promise.all([loadEligibility(), fetchDefaultBranchSha(loaderOptions)])
+    const sourceCommit = latestBaynAffectingCommit(eligibility)
+    const [sourcePushRuns, currentDispatchRuns] = await Promise.all([
+      sourceCommit === undefined
+        ? Promise.resolve([])
+        : fetchBaynBuildWorkflowRuns(loaderOptions, { headSha: sourceCommit.sha, event: 'push' }),
+      fetchBaynBuildWorkflowRuns(loaderOptions, {
+        headSha: options.mainCommitSha,
+        event: 'workflow_dispatch',
+      }),
+    ])
+    const failedRun = sourceCommit === undefined ? undefined : latestFailedSourcePush(sourcePushRuns, sourceCommit.sha)
+    const jobs = failedRun === undefined ? [] : await fetchBaynBuildWorkflowJobs(loaderOptions, failedRun.id)
+    return {
+      ...eligibility,
+      defaultBranchSha,
+      failedReviewRun: failedRun === undefined ? null : { run: failedRun, jobs },
+      publicationSucceeded:
+        sourcePushRuns.some((run) => run.status === 'completed' && run.conclusion === 'success') ||
+        currentDispatchRuns.some((run) => run.status === 'completed' && run.conclusion === 'success'),
+      retryInProgress: currentDispatchRuns.some(
+        (run) =>
+          run.headSha === options.mainCommitSha &&
+          run.headBranch === 'main' &&
+          run.event === 'workflow_dispatch' &&
+          (run.status === 'queued' || run.status === 'in_progress'),
+      ),
+    }
+  }
+}
+
 interface CliOptions {
+  readonly mode: 'push' | 'retry-discovery' | 'retry-publication'
   readonly repository: string
   readonly mainCommitSha: string
   readonly maxAttempts: number
   readonly pollIntervalMs: number
   readonly requestTimeoutMs: number
   readonly pushBeforeSha: string | null
+  readonly githubOutputPath: string | null
+  readonly triggerKind: 'issue-comment' | 'schedule' | null
+  readonly triggerPrNumber: number | null
+  readonly triggerActorLogin: string | null
+  readonly retrySourceCommitSha: string | null
+  readonly retryPrNumber: number | null
+  readonly retryHeadSha: string | null
+  readonly retryFailedRunId: number | null
 }
 
 const parsePositiveInteger = (value: string, name: string): number => {
@@ -1694,6 +2113,9 @@ const parsePositiveInteger = (value: string, name: string): number => {
   if (!Number.isSafeInteger(parsed) || parsed <= 0) throw new Error(`${name} must be a positive integer`)
   return parsed
 }
+
+const parseOptionalPositiveInteger = (value: string | undefined, name: string): number | null =>
+  value === undefined ? null : parsePositiveInteger(value, name)
 
 export const parseVerifyReleaseReviewArguments = (
   arguments_: readonly string[],
@@ -1710,12 +2132,21 @@ export const parseVerifyReleaseReviewArguments = (
     values.set(name, value)
   }
   const allowed = new Set([
+    '--mode',
     '--repository',
     '--commit',
     '--push-before',
     '--max-attempts',
     '--poll-interval-ms',
     '--request-timeout-ms',
+    '--github-output',
+    '--trigger-kind',
+    '--trigger-pr-number',
+    '--trigger-actor-login',
+    '--retry-source-commit',
+    '--retry-pr-number',
+    '--retry-head',
+    '--retry-failed-run-id',
   ])
   for (const name of values.keys()) {
     if (!allowed.has(name)) throw new Error(`unknown argument ${name}`)
@@ -1724,6 +2155,14 @@ export const parseVerifyReleaseReviewArguments = (
   const repository = values.get('--repository') ?? environment.GITHUB_REPOSITORY
   const mainCommitSha = values.get('--commit') ?? environment.GITHUB_SHA
   const pushBeforeSha = values.get('--push-before') ?? null
+  const modeValue = values.get('--mode') ?? 'push'
+  if (modeValue !== 'push' && modeValue !== 'retry-discovery' && modeValue !== 'retry-publication') {
+    throw new Error('--mode must be push, retry-discovery, or retry-publication')
+  }
+  const triggerKindValue = values.get('--trigger-kind') ?? null
+  if (triggerKindValue !== null && triggerKindValue !== 'issue-comment' && triggerKindValue !== 'schedule') {
+    throw new Error('--trigger-kind must be issue-comment or schedule')
+  }
   if (repository === undefined || repository.length === 0)
     throw new Error('--repository or GITHUB_REPOSITORY is required')
   if (mainCommitSha === undefined || !/^[0-9a-f]{40}$/.test(mainCommitSha)) {
@@ -1733,12 +2172,67 @@ export const parseVerifyReleaseReviewArguments = (
     throw new Error('--push-before must be a lowercase 40-character commit SHA')
   }
   return {
+    mode: modeValue,
     repository,
     mainCommitSha,
     pushBeforeSha,
     maxAttempts: parsePositiveInteger(values.get('--max-attempts') ?? '10', '--max-attempts'),
     pollIntervalMs: parsePositiveInteger(values.get('--poll-interval-ms') ?? '10000', '--poll-interval-ms'),
     requestTimeoutMs: parsePositiveInteger(values.get('--request-timeout-ms') ?? '10000', '--request-timeout-ms'),
+    githubOutputPath: values.get('--github-output') ?? environment.GITHUB_OUTPUT ?? null,
+    triggerKind: triggerKindValue,
+    triggerPrNumber: parseOptionalPositiveInteger(values.get('--trigger-pr-number'), '--trigger-pr-number'),
+    triggerActorLogin: values.get('--trigger-actor-login') ?? null,
+    retrySourceCommitSha: values.get('--retry-source-commit') ?? null,
+    retryPrNumber: parseOptionalPositiveInteger(values.get('--retry-pr-number'), '--retry-pr-number'),
+    retryHeadSha: values.get('--retry-head') ?? null,
+    retryFailedRunId: parseOptionalPositiveInteger(values.get('--retry-failed-run-id'), '--retry-failed-run-id'),
+  }
+}
+
+const appendGitHubOutputs = async (
+  path: string | null,
+  values: Readonly<Record<string, string | number | boolean>>,
+) => {
+  if (path === null) return
+  const output = Object.entries(values)
+    .map(([name, value]) => `${name}=${String(value)}\n`)
+    .join('')
+  await appendFile(path, output, 'utf8')
+}
+
+const retryTriggerFromOptions = (options: CliOptions): BaynReleaseRetryTrigger => {
+  if (options.mode === 'retry-discovery') {
+    if (options.triggerKind === 'schedule') return { type: 'schedule' }
+    if (
+      options.triggerKind === 'issue-comment' &&
+      options.triggerPrNumber !== null &&
+      options.triggerActorLogin !== null
+    ) {
+      return {
+        type: 'issue-comment',
+        prNumber: options.triggerPrNumber,
+        actorLogin: options.triggerActorLogin,
+      }
+    }
+    throw new Error('retry-discovery requires a complete --trigger-kind binding')
+  }
+  if (
+    options.retrySourceCommitSha === null ||
+    !/^[0-9a-f]{40}$/.test(options.retrySourceCommitSha) ||
+    options.retryPrNumber === null ||
+    options.retryHeadSha === null ||
+    !/^[0-9a-f]{40}$/.test(options.retryHeadSha) ||
+    options.retryFailedRunId === null
+  ) {
+    throw new Error('retry-publication requires exact source, PR, head, and failed-run bindings')
+  }
+  return {
+    type: 'workflow-dispatch',
+    sourceCommitSha: options.retrySourceCommitSha,
+    prNumber: options.retryPrNumber,
+    headSha: options.retryHeadSha,
+    failedRunId: options.retryFailedRunId,
   }
 }
 
@@ -1746,28 +2240,93 @@ const run = async (): Promise<void> => {
   const options = parseVerifyReleaseReviewArguments(process.argv.slice(2))
   const token = process.env.GITHUB_TOKEN
   if (token === undefined || token.length === 0) throw new Error('GITHUB_TOKEN is required')
-  if (options.pushBeforeSha === null) throw new Error('--push-before is required for Bayn publication eligibility')
-  const result = await pollBaynReleaseEligibility({
+  if (options.mode === 'push') {
+    if (options.pushBeforeSha === null)
+      throw new Error('--push-before is required for Bayn push publication eligibility')
+    const result = await pollBaynReleaseEligibility({
+      mainCommitSha: options.mainCommitSha,
+      baseRefName: 'main',
+      maxAttempts: options.maxAttempts,
+      pollIntervalMs: options.pollIntervalMs,
+      pushBeforeSha: options.pushBeforeSha,
+      loadSnapshot: createGitHubReleaseEligibilityLoader({
+        repository: options.repository,
+        token,
+        mainCommitSha: options.mainCommitSha,
+        baseRefName: 'main',
+        requestTimeoutMs: options.requestTimeoutMs,
+      }),
+    })
+    if (result.status === 'hold') {
+      console.error(`BAYN_RELEASE_REVIEW_HOLD ${result.code}: ${result.message}`)
+      process.exitCode = 1
+      return
+    }
+    await appendGitHubOutputs(options.githubOutputPath, { publish: true, source_sha: options.mainCommitSha })
+    console.log(
+      `BAYN_RELEASE_REVIEW_ELIGIBLE published=${shortSha(result.lastPublishedRevision)} current=${shortSha(options.mainCommitSha)} checked_commits=${result.checkedCommitCount} bayn_affecting_commits=${result.baynAffectingCommitCount} reviewed_prs=${result.reviewedPullRequests.map((review) => `#${review.prNumber}@${shortSha(review.headSha)}`).join(',')}; attempts=${result.attempts}`,
+    )
+    return
+  }
+
+  const retry = evaluateBaynReleaseRetry({
     mainCommitSha: options.mainCommitSha,
     baseRefName: 'main',
-    maxAttempts: options.maxAttempts,
-    pollIntervalMs: options.pollIntervalMs,
-    pushBeforeSha: options.pushBeforeSha,
-    loadSnapshot: createGitHubReleaseEligibilityLoader({
+    snapshot: await createGitHubReleaseRetryLoader({
       repository: options.repository,
       token,
       mainCommitSha: options.mainCommitSha,
       baseRefName: 'main',
       requestTimeoutMs: options.requestTimeoutMs,
-    }),
+    })(),
+    trigger: retryTriggerFromOptions(options),
+    nowMs: Date.now(),
   })
-  if (result.status === 'hold') {
-    console.error(`BAYN_RELEASE_REVIEW_HOLD ${result.code}: ${result.message}`)
+  if (retry.status === 'hold') {
+    if (options.mode === 'retry-discovery' && retry.retryable) {
+      await appendGitHubOutputs(options.githubOutputPath, {
+        dispatch: false,
+        publish: false,
+        retry_code: retry.code,
+      })
+      console.log(`BAYN_RELEASE_RETRY_NOOP ${retry.code}: ${retry.message}`)
+      return
+    }
+    console.error(`BAYN_RELEASE_RETRY_HOLD ${retry.code}: ${retry.message}`)
     process.exitCode = 1
     return
   }
+  if (retry.status === 'noop') {
+    await appendGitHubOutputs(options.githubOutputPath, {
+      dispatch: false,
+      publish: false,
+      retry_code: retry.code,
+    })
+    console.log(`BAYN_RELEASE_RETRY_NOOP ${retry.code}: ${retry.message}`)
+    if (options.mode === 'retry-publication') process.exitCode = 1
+    return
+  }
+
+  const retryOutputs = {
+    retry_source_sha: retry.sourceCommitSha,
+    retry_pr_number: retry.prNumber,
+    retry_pr_head: retry.headSha,
+    retry_failed_run_id: retry.failedRunId,
+  }
+  if (options.mode === 'retry-discovery') {
+    await appendGitHubOutputs(options.githubOutputPath, { dispatch: true, ...retryOutputs })
+    console.log(
+      `BAYN_RELEASE_RETRY_DISPATCH current=${shortSha(retry.currentMainSha)} source=${shortSha(retry.sourceCommitSha)} pr=#${retry.prNumber}@${shortSha(retry.headSha)} failed_run=${retry.failedRunId}`,
+    )
+    return
+  }
+  await appendGitHubOutputs(options.githubOutputPath, {
+    publish: true,
+    source_sha: retry.currentMainSha,
+    ...retryOutputs,
+  })
   console.log(
-    `BAYN_RELEASE_REVIEW_ELIGIBLE published=${shortSha(result.lastPublishedRevision)} current=${shortSha(options.mainCommitSha)} checked_commits=${result.checkedCommitCount} bayn_affecting_commits=${result.baynAffectingCommitCount} reviewed_prs=${result.reviewedPullRequests.map((review) => `#${review.prNumber}@${shortSha(review.headSha)}`).join(',')}; attempts=${result.attempts}`,
+    `BAYN_RELEASE_RETRY_ELIGIBLE current=${shortSha(retry.currentMainSha)} source=${shortSha(retry.sourceCommitSha)} pr=#${retry.prNumber}@${shortSha(retry.headSha)} failed_run=${retry.failedRunId}`,
   )
 }
 


### PR DESCRIPTION
## Summary

- Add a read-only default-branch observer for delayed Codex issue-comment attestations and a scheduled fallback for delayed PR reactions.
- Dispatch publication only through a separately rebound `workflow_dispatch` on `main`, then revalidate the exact merged source SHA, never-force-pushed source PR head, failed review-gate run, and full unpublished Bayn range before building.
- Treat exact successful push/dispatch publication, superseding Bayn changes, spoofed or stale triggers, actionable reviews, unresolved threads, ambiguous associations, pagination, and malformed run/job evidence fail-closed.
- Count successful retry dispatches as normal Bayn publications while ignoring successful observer-only schedule/comment runs.

## Related Issues

None.

## Testing

- `bun test packages/scripts/src/bayn/*.test.ts` — 68 passed.
- Targeted TypeScript compile for `verify-release-review.ts` and its tests.
- Targeted Oxlint for `verify-release-review.ts` and its tests.
- Oxfmt check for the workflow, verifier, and tests.
- Actionlint 1.7.7 for `.github/workflows/bayn-build-push.yml`.
- `git diff --check HEAD^..HEAD`.
- Live read-only scheduled discovery against current main returned `retry-already-published`, `dispatch=false`, and `publish=false` because no Bayn-affecting source remains unpublished.

## Breaking Changes

None. Existing push publication remains bounded to 10 attempts. The new unattended path is read-only until it has proven an exact delayed attestation and dispatches the same workflow on trusted `main`; it does not change workflow permissions, runtime, image definitions, release logic, manifests, broker authority, or capital authority.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] No documentation or release-note follow-up is required for this bounded release-integrity correction.
