### PR TITLE
fix(bayn): bind delayed review readiness

### DIFF
--- a/packages/scripts/src/bayn/verify-release-review.test.ts
+++ b/packages/scripts/src/bayn/verify-release-review.test.ts
@@ -254,6 +254,7 @@ const retrySnapshot = (
     readonly defaultBranchSha?: string
     readonly eligibility?: BaynReleaseEligibilitySnapshot
     readonly reviewThreadBlock?: { readonly commitShaPrefix: string; readonly prNumber: number } | null
+    readonly failedReviewJobCompletedAt?: string | null
   } = {},
 ): BaynReleaseRetrySnapshot => {
   const eligibility =
@@ -293,6 +294,8 @@ const retrySnapshot = (
       },
     })
   const run = options.failedRun === undefined ? failedBuildRun() : options.failedRun
+  const failedReviewJobCompletedAt =
+    options.failedReviewJobCompletedAt === undefined ? (run?.updatedAt ?? null) : options.failedReviewJobCompletedAt
   return {
     ...eligibility,
     defaultBranchSha: options.defaultBranchSha ?? mainCommitSha,
@@ -302,8 +305,20 @@ const retrySnapshot = (
         : {
             run,
             jobs: [
-              { id: 90860000001, name: 'Verify exact-head Codex review', status: 'completed', conclusion: 'failure' },
-              { id: 90860000002, name: 'image', status: 'completed', conclusion: 'skipped' },
+              {
+                id: 90860000001,
+                name: 'Verify exact-head Codex review',
+                status: 'completed',
+                conclusion: 'failure',
+                completedAt: failedReviewJobCompletedAt,
+              },
+              {
+                id: 90860000002,
+                name: 'image',
+                status: 'completed',
+                conclusion: 'skipped',
+                completedAt: run.updatedAt,
+              },
             ],
             reviewThreadBlock: options.reviewThreadBlock ?? null,
           },
@@ -729,6 +744,35 @@ describe('Bayn delayed-attestation publication retry', () => {
         }),
         trigger: { type: 'schedule' },
         nowMs: Date.parse('2026-07-30T07:02:00Z'),
+      }),
+    ).toMatchObject({
+      status: 'dispatch',
+      sourceCommitSha: mainCommitSha,
+      prNumber: 13401,
+      headSha: finalHeadSha,
+    })
+  })
+
+  test('uses the failed review job completion before later workflow-run finalization', () => {
+    const settlingReview = reviewSnapshotFor({
+      commitSha: mainCommitSha,
+      prNumber: 13401,
+      headSha: finalHeadSha,
+      parents: [lastPublishedSha],
+      mergedAt: '2026-07-30T07:00:00Z',
+      reviews: [review({ submittedAt: '2026-07-30T07:02:01Z' })],
+    })
+    expect(
+      evaluateBaynReleaseRetry({
+        mainCommitSha,
+        baseRefName: 'main',
+        snapshot: retrySnapshot({
+          reviewSnapshot: settlingReview,
+          failedRun: failedBuildRun({ updatedAt: '2026-07-30T07:02:35Z' }),
+          failedReviewJobCompletedAt: '2026-07-30T07:02:30Z',
+        }),
+        trigger: { type: 'schedule' },
+        nowMs: Date.parse('2026-07-30T07:03:00Z'),
       }),
     ).toMatchObject({
       status: 'dispatch',
@@ -1336,8 +1380,15 @@ describe('Bayn delayed-attestation publication retry', () => {
               name: 'Verify exact-head Codex review',
               status: 'completed',
               conclusion: 'failure',
+              completed_at: '2026-07-30T07:02:30Z',
             },
-            { id: 90860000002, name: 'image', status: 'completed', conclusion: 'skipped' },
+            {
+              id: 90860000002,
+              name: 'image',
+              status: 'completed',
+              conclusion: 'skipped',
+              completed_at: '2026-07-30T07:02:31Z',
+            },
           ],
         })
       }

--- a/packages/scripts/src/bayn/verify-release-review.test.ts
+++ b/packages/scripts/src/bayn/verify-release-review.test.ts
@@ -11,7 +11,7 @@ import {
   evaluateBaynReleaseReview,
   GitHubReleaseReviewError,
   isBaynReleaseAffectingPath,
-  parseFailedUnresolvedThreadBlock,
+  parseFailedReviewThreadBlock,
   pollBaynReleaseEligibility,
   pollBaynReleaseReview,
   resolveLastPublishedRevision,
@@ -253,7 +253,7 @@ const retrySnapshot = (
     readonly retryInProgress?: boolean
     readonly defaultBranchSha?: string
     readonly eligibility?: BaynReleaseEligibilitySnapshot
-    readonly unresolvedThreadBlock?: { readonly commitShaPrefix: string; readonly prNumber: number } | null
+    readonly reviewThreadBlock?: { readonly commitShaPrefix: string; readonly prNumber: number } | null
   } = {},
 ): BaynReleaseRetrySnapshot => {
   const eligibility =
@@ -305,7 +305,7 @@ const retrySnapshot = (
               { id: 90860000001, name: 'Verify exact-head Codex review', status: 'completed', conclusion: 'failure' },
               { id: 90860000002, name: 'image', status: 'completed', conclusion: 'skipped' },
             ],
-            unresolvedThreadBlock: options.unresolvedThreadBlock ?? null,
+            reviewThreadBlock: options.reviewThreadBlock ?? null,
           },
     publicationSucceeded: false,
     retryInProgress: options.retryInProgress ?? false,
@@ -755,7 +755,7 @@ describe('Bayn delayed-attestation publication retry', () => {
         snapshot: retrySnapshot({
           reviewSnapshot: resolvedReview,
           failedRun: failedBuildRun({ updatedAt: '2026-07-30T07:02:30Z' }),
-          unresolvedThreadBlock: { commitShaPrefix: mainCommitSha.slice(0, 12), prNumber: 13401 },
+          reviewThreadBlock: { commitShaPrefix: mainCommitSha.slice(0, 12), prNumber: 13401 },
         }),
         trigger: { type: 'schedule' },
         nowMs: Date.parse('2026-07-30T07:04:00Z'),
@@ -780,7 +780,7 @@ describe('Bayn delayed-attestation publication retry', () => {
     })
     const exactSnapshot = retrySnapshot({
       reviewSnapshot: resolvedReview,
-      unresolvedThreadBlock: { commitShaPrefix: mainCommitSha.slice(0, 12), prNumber: 13401 },
+      reviewThreadBlock: { commitShaPrefix: mainCommitSha.slice(0, 12), prNumber: 13401 },
     })
     expect(
       evaluateBaynReleaseRetry({
@@ -798,7 +798,7 @@ describe('Bayn delayed-attestation publication retry', () => {
         baseRefName: 'main',
         snapshot: retrySnapshot({
           reviewSnapshot: resolvedReview,
-          unresolvedThreadBlock: { commitShaPrefix: olderHeadSha.slice(0, 12), prNumber: 13401 },
+          reviewThreadBlock: { commitShaPrefix: olderHeadSha.slice(0, 12), prNumber: 13401 },
         }),
         trigger: { type: 'schedule' },
         nowMs: retryNowMs,
@@ -820,12 +820,69 @@ describe('Bayn delayed-attestation publication retry', () => {
         baseRefName: 'main',
         snapshot: retrySnapshot({
           reviewSnapshot: stillActionable,
-          unresolvedThreadBlock: { commitShaPrefix: mainCommitSha.slice(0, 12), prNumber: 13401 },
+          reviewThreadBlock: { commitShaPrefix: mainCommitSha.slice(0, 12), prNumber: 13401 },
         }),
         trigger: { type: 'schedule' },
         nowMs: retryNowMs,
       }),
     ).toMatchObject({ status: 'hold', code: 'active-unresolved-review-threads', retryable: false })
+  })
+
+  test('dispatches after a trusted feedback reply thread is resolved following the failed gate', () => {
+    const feedbackComments = [
+      threadComment({
+        createdAt: '2026-07-30T07:00:00Z',
+        reviewSubmittedAt: '2026-07-30T07:00:00Z',
+      }),
+      threadComment({
+        authorLogin: 'gregkonush',
+        authorAssociation: 'MEMBER',
+        body: 'Fixed in the final head.',
+        createdAt: '2026-07-30T07:01:00Z',
+        commitSha: finalHeadSha,
+        reviewCommitSha: finalHeadSha,
+        reviewAuthorLogin: 'gregkonush',
+        reviewSubmittedAt: '2026-07-30T07:01:00Z',
+      }),
+    ]
+    const unresolvedFeedback = snapshot({
+      commitShas: [olderHeadSha, finalHeadSha],
+      reviews: [review({ commitSha: olderHeadSha, submittedAt: '2026-07-30T07:00:00Z' })],
+      threads: [thread({ isResolved: false, comments: feedbackComments })],
+    })
+    expect(
+      evaluateBaynReleaseReview({
+        mainCommitSha,
+        baseRefName: 'main',
+        snapshot: unresolvedFeedback,
+        nowMs: retryNowMs,
+        pushBeforeSha: null,
+      }),
+    ).toMatchObject({ status: 'hold', code: 'feedback-fix-attestation-missing', retryable: true })
+
+    const resolvedFeedback = snapshot({
+      commitShas: [olderHeadSha, finalHeadSha],
+      reviews: [review({ commitSha: olderHeadSha, submittedAt: '2026-07-30T07:00:00Z' })],
+      threads: [thread({ isResolved: true, comments: feedbackComments })],
+    })
+    expect(
+      evaluateBaynReleaseRetry({
+        mainCommitSha,
+        baseRefName: 'main',
+        snapshot: retrySnapshot({
+          reviewSnapshot: resolvedFeedback,
+          failedRun: failedBuildRun({ updatedAt: '2026-07-30T07:02:30Z' }),
+          reviewThreadBlock: { commitShaPrefix: mainCommitSha.slice(0, 12), prNumber: 13390 },
+        }),
+        trigger: { type: 'schedule' },
+        nowMs: retryNowMs,
+      }),
+    ).toMatchObject({
+      status: 'dispatch',
+      sourceCommitSha: mainCommitSha,
+      prNumber: 13390,
+      headSha: finalHeadSha,
+    })
   })
 
   test('dispatches when the final required feedback attestation arrives after the failed push', () => {
@@ -1200,17 +1257,22 @@ describe('Bayn delayed-attestation publication retry', () => {
 
   test('parses only exact unresolved-thread failure evidence from the bounded gate log', () => {
     expect(
-      parseFailedUnresolvedThreadBlock(
+      parseFailedReviewThreadBlock(
         `2026-07-30T07:02:30Z BAYN_RELEASE_REVIEW_HOLD active-unresolved-review-threads: Bayn-affecting commit ${mainCommitSha.slice(0, 12)} after last published ${lastPublishedSha.slice(0, 12)} is not release-eligible: source PR #13401 has 1 unresolved review thread(s): https://github.com/proompteng/lab/pull/13401#discussion_r1\n`,
       ),
     ).toEqual({ commitShaPrefix: mainCommitSha.slice(0, 12), prNumber: 13401 })
     expect(
-      parseFailedUnresolvedThreadBlock(
+      parseFailedReviewThreadBlock(
+        `2026-07-30T07:02:30Z BAYN_RELEASE_REVIEW_HOLD feedback-fix-attestation-missing: Bayn-affecting commit ${mainCommitSha.slice(0, 12)} after last published ${lastPublishedSha.slice(0, 12)} is not release-eligible: source PR #13401 final head ${finalHeadSha.slice(0, 12)} carries review from ${olderHeadSha.slice(0, 12)}, but post-review commit ${finalHeadSha.slice(0, 12)} lacks a trusted member reply on a resolved Codex thread from that review\n`,
+      ),
+    ).toEqual({ commitShaPrefix: mainCommitSha.slice(0, 12), prNumber: 13401 })
+    expect(
+      parseFailedReviewThreadBlock(
         `BAYN_RELEASE_REVIEW_HOLD active-unresolved-review-threads: source PR #13401 has unresolved threads\n`,
       ),
     ).toBeNull()
     expect(() =>
-      parseFailedUnresolvedThreadBlock(
+      parseFailedReviewThreadBlock(
         `BAYN_RELEASE_REVIEW_HOLD active-unresolved-review-threads: Bayn-affecting commit ${mainCommitSha.slice(0, 12)} after last published ${lastPublishedSha.slice(0, 12)} is not release-eligible: source PR #13401 has 1 unresolved review thread(s): one\nBAYN_RELEASE_REVIEW_HOLD active-unresolved-review-threads: Bayn-affecting commit ${heldCommitSha.slice(0, 12)} after last published ${lastPublishedSha.slice(0, 12)} is not release-eligible: source PR #13402 has 1 unresolved review thread(s): two\n`,
       ),
     ).toThrow('github-api-invalid-response')

--- a/packages/scripts/src/bayn/verify-release-review.test.ts
+++ b/packages/scripts/src/bayn/verify-release-review.test.ts
@@ -11,6 +11,7 @@ import {
   evaluateBaynReleaseReview,
   GitHubReleaseReviewError,
   isBaynReleaseAffectingPath,
+  loadOptionalFailedReviewThreadBlock,
   parseFailedReviewThreadBlock,
   pollBaynReleaseEligibility,
   pollBaynReleaseReview,
@@ -1320,6 +1321,34 @@ describe('Bayn delayed-attestation publication retry', () => {
         `BAYN_RELEASE_REVIEW_HOLD active-unresolved-review-threads: Bayn-affecting commit ${mainCommitSha.slice(0, 12)} after last published ${lastPublishedSha.slice(0, 12)} is not release-eligible: source PR #13401 has 1 unresolved review thread(s): one\nBAYN_RELEASE_REVIEW_HOLD active-unresolved-review-threads: Bayn-affecting commit ${heldCommitSha.slice(0, 12)} after last published ${lastPublishedSha.slice(0, 12)} is not release-eligible: source PR #13402 has 1 unresolved review thread(s): two\n`,
       ),
     ).toThrow('github-api-invalid-response')
+  })
+
+  test('keeps timestamp-based retries available when failed job logs expired', async () => {
+    for (const status of [404, 410]) {
+      const reviewThreadBlock = await loadOptionalFailedReviewThreadBlock(() =>
+        Promise.reject(
+          new GitHubReleaseReviewError('github-api-error', 'read failed Bayn review-gate job log', { status }),
+        ),
+      )
+      expect(reviewThreadBlock).toBeNull()
+      expect(
+        evaluateBaynReleaseRetry({
+          mainCommitSha,
+          baseRefName: 'main',
+          snapshot: retrySnapshot({ reviewThreadBlock }),
+          trigger: { type: 'schedule' },
+          nowMs: retryNowMs,
+        }),
+      ).toMatchObject({ status: 'dispatch', sourceCommitSha: mainCommitSha })
+    }
+
+    await expect(
+      loadOptionalFailedReviewThreadBlock(() =>
+        Promise.reject(
+          new GitHubReleaseReviewError('github-api-error', 'read failed Bayn review-gate job log', { status: 503 }),
+        ),
+      ),
+    ).rejects.toMatchObject({ code: 'github-api-error', status: 503 })
   })
 
   test('decodes a bounded failed push and delayed clean reaction for retry discovery', async () => {

--- a/packages/scripts/src/bayn/verify-release-review.test.ts
+++ b/packages/scripts/src/bayn/verify-release-review.test.ts
@@ -679,6 +679,88 @@ describe('Bayn delayed-attestation publication retry', () => {
     })
   })
 
+  test('dispatches when an exact-head review finishes settling after the failed push', () => {
+    const settlingReview = reviewSnapshotFor({
+      commitSha: mainCommitSha,
+      prNumber: 13401,
+      headSha: finalHeadSha,
+      parents: [lastPublishedSha],
+      mergedAt: '2026-07-30T07:00:00Z',
+      reviews: [review({ submittedAt: '2026-07-30T07:01:00Z' })],
+    })
+    expect(
+      evaluateBaynReleaseRetry({
+        mainCommitSha,
+        baseRefName: 'main',
+        snapshot: retrySnapshot({
+          reviewSnapshot: settlingReview,
+          failedRun: failedBuildRun({ updatedAt: '2026-07-30T07:01:20Z' }),
+        }),
+        trigger: { type: 'schedule' },
+        nowMs: Date.parse('2026-07-30T07:02:00Z'),
+      }),
+    ).toMatchObject({
+      status: 'dispatch',
+      sourceCommitSha: mainCommitSha,
+      prNumber: 13401,
+      headSha: finalHeadSha,
+    })
+  })
+
+  test('dispatches when the final required feedback attestation arrives after the failed push', () => {
+    const feedbackReview = snapshot({
+      commitShas: [olderHeadSha, finalHeadSha],
+      reviews: [review({ commitSha: olderHeadSha, submittedAt: '2026-07-30T07:00:00Z' })],
+      threads: [
+        thread({
+          comments: [
+            threadComment({
+              createdAt: '2026-07-30T07:00:00Z',
+              reviewSubmittedAt: '2026-07-30T07:00:00Z',
+            }),
+            threadComment({
+              authorLogin: 'gregkonush',
+              authorAssociation: 'MEMBER',
+              body: 'Fixed in the final head.',
+              createdAt: '2026-07-30T07:03:00Z',
+              commitSha: finalHeadSha,
+              reviewCommitSha: finalHeadSha,
+              reviewAuthorLogin: 'gregkonush',
+              reviewSubmittedAt: '2026-07-30T07:03:00Z',
+            }),
+          ],
+        }),
+      ],
+    })
+    expect(
+      evaluateBaynReleaseReview({
+        mainCommitSha,
+        baseRefName: 'main',
+        snapshot: feedbackReview,
+        nowMs: retryNowMs,
+        pushBeforeSha: null,
+      }),
+    ).toMatchObject({
+      status: 'eligible',
+      reviewSubmittedAt: '2026-07-30T07:00:00Z',
+      eligibleAt: '2026-07-30T07:03:00.000Z',
+    })
+    expect(
+      evaluateBaynReleaseRetry({
+        mainCommitSha,
+        baseRefName: 'main',
+        snapshot: retrySnapshot({ reviewSnapshot: feedbackReview }),
+        trigger: { type: 'schedule' },
+        nowMs: retryNowMs,
+      }),
+    ).toMatchObject({
+      status: 'dispatch',
+      sourceCommitSha: mainCommitSha,
+      prNumber: 13390,
+      headSha: finalHeadSha,
+    })
+  })
+
   test('binds a retry to the earlier range commit whose attestation arrived after the failed current-main push', () => {
     const earlierCommitSha = heldCommitSha
     const earlierHeadSha = heldHeadSha
@@ -1191,6 +1273,7 @@ describe('Bayn exact-head release review eligibility', () => {
       prNumber: 13390,
       headSha: finalHeadSha,
       reviewSubmittedAt: '2026-07-30T07:01:00Z',
+      eligibleAt: '2026-07-30T07:01:30.000Z',
     })
   })
 
@@ -1228,6 +1311,7 @@ describe('Bayn exact-head release review eligibility', () => {
       prNumber: 13390,
       headSha: finalHeadSha,
       reviewSubmittedAt: '2026-07-30T07:01:00Z',
+      eligibleAt: '2026-07-30T07:01:30.000Z',
     })
   })
 
@@ -1245,6 +1329,7 @@ describe('Bayn exact-head release review eligibility', () => {
       prNumber: 13390,
       headSha: finalHeadSha,
       reviewSubmittedAt: '2026-07-30T07:01:00Z',
+      eligibleAt: '2026-07-30T07:01:30.000Z',
     })
   })
 
@@ -1359,6 +1444,7 @@ describe('Bayn exact-head release review eligibility', () => {
       prNumber: 13390,
       headSha: finalHeadSha,
       reviewSubmittedAt: '2026-07-30T07:01:00Z',
+      eligibleAt: '2026-07-30T07:01:30.000Z',
     })
   })
 

--- a/packages/scripts/src/bayn/verify-release-review.test.ts
+++ b/packages/scripts/src/bayn/verify-release-review.test.ts
@@ -11,6 +11,7 @@ import {
   evaluateBaynReleaseReview,
   GitHubReleaseReviewError,
   isBaynReleaseAffectingPath,
+  parseFailedUnresolvedThreadBlock,
   pollBaynReleaseEligibility,
   pollBaynReleaseReview,
   resolveLastPublishedRevision,
@@ -252,6 +253,7 @@ const retrySnapshot = (
     readonly retryInProgress?: boolean
     readonly defaultBranchSha?: string
     readonly eligibility?: BaynReleaseEligibilitySnapshot
+    readonly unresolvedThreadBlock?: { readonly commitShaPrefix: string; readonly prNumber: number } | null
   } = {},
 ): BaynReleaseRetrySnapshot => {
   const eligibility =
@@ -300,9 +302,10 @@ const retrySnapshot = (
         : {
             run,
             jobs: [
-              { name: 'Verify exact-head Codex review', status: 'completed', conclusion: 'failure' },
-              { name: 'image', status: 'completed', conclusion: 'skipped' },
+              { id: 90860000001, name: 'Verify exact-head Codex review', status: 'completed', conclusion: 'failure' },
+              { id: 90860000002, name: 'image', status: 'completed', conclusion: 'skipped' },
             ],
+            unresolvedThreadBlock: options.unresolvedThreadBlock ?? null,
           },
     publicationSucceeded: false,
     retryInProgress: options.retryInProgress ?? false,
@@ -735,6 +738,96 @@ describe('Bayn delayed-attestation publication retry', () => {
     })
   })
 
+  test('dispatches when the failed gate proves a matching unresolved thread that is resolved later', () => {
+    const resolvedReview = reviewSnapshotFor({
+      commitSha: mainCommitSha,
+      prNumber: 13401,
+      headSha: finalHeadSha,
+      parents: [lastPublishedSha],
+      mergedAt: '2026-07-30T07:00:00Z',
+      reviews: [review({ submittedAt: '2026-07-30T07:00:00Z' })],
+      threads: [thread({ isResolved: true })],
+    })
+    expect(
+      evaluateBaynReleaseRetry({
+        mainCommitSha,
+        baseRefName: 'main',
+        snapshot: retrySnapshot({
+          reviewSnapshot: resolvedReview,
+          failedRun: failedBuildRun({ updatedAt: '2026-07-30T07:02:30Z' }),
+          unresolvedThreadBlock: { commitShaPrefix: mainCommitSha.slice(0, 12), prNumber: 13401 },
+        }),
+        trigger: { type: 'schedule' },
+        nowMs: Date.parse('2026-07-30T07:04:00Z'),
+      }),
+    ).toMatchObject({
+      status: 'dispatch',
+      sourceCommitSha: mainCommitSha,
+      prNumber: 13401,
+      headSha: finalHeadSha,
+    })
+  })
+
+  test('keeps unresolved-thread retry evidence exact, trusted, and non-actionable', () => {
+    const resolvedReview = reviewSnapshotFor({
+      commitSha: mainCommitSha,
+      prNumber: 13401,
+      headSha: finalHeadSha,
+      parents: [lastPublishedSha],
+      mergedAt: '2026-07-30T07:00:00Z',
+      reviews: [review({ submittedAt: '2026-07-30T07:00:00Z' })],
+      threads: [thread({ isResolved: true })],
+    })
+    const exactSnapshot = retrySnapshot({
+      reviewSnapshot: resolvedReview,
+      unresolvedThreadBlock: { commitShaPrefix: mainCommitSha.slice(0, 12), prNumber: 13401 },
+    })
+    expect(
+      evaluateBaynReleaseRetry({
+        mainCommitSha,
+        baseRefName: 'main',
+        snapshot: exactSnapshot,
+        trigger: { type: 'issue-comment', prNumber: 13401, actorLogin: 'spoofed-codex[bot]' },
+        nowMs: retryNowMs,
+      }),
+    ).toMatchObject({ status: 'hold', code: 'retry-trigger-mismatch', retryable: false })
+
+    expect(
+      evaluateBaynReleaseRetry({
+        mainCommitSha,
+        baseRefName: 'main',
+        snapshot: retrySnapshot({
+          reviewSnapshot: resolvedReview,
+          unresolvedThreadBlock: { commitShaPrefix: olderHeadSha.slice(0, 12), prNumber: 13401 },
+        }),
+        trigger: { type: 'schedule' },
+        nowMs: retryNowMs,
+      }),
+    ).toMatchObject({ status: 'hold', code: 'retry-failed-run-mismatch', retryable: false })
+
+    const stillActionable = reviewSnapshotFor({
+      commitSha: mainCommitSha,
+      prNumber: 13401,
+      headSha: finalHeadSha,
+      parents: [lastPublishedSha],
+      mergedAt: '2026-07-30T07:00:00Z',
+      reviews: [review({ submittedAt: '2026-07-30T07:00:00Z' })],
+      threads: [thread({ isResolved: false })],
+    })
+    expect(
+      evaluateBaynReleaseRetry({
+        mainCommitSha,
+        baseRefName: 'main',
+        snapshot: retrySnapshot({
+          reviewSnapshot: stillActionable,
+          unresolvedThreadBlock: { commitShaPrefix: mainCommitSha.slice(0, 12), prNumber: 13401 },
+        }),
+        trigger: { type: 'schedule' },
+        nowMs: retryNowMs,
+      }),
+    ).toMatchObject({ status: 'hold', code: 'active-unresolved-review-threads', retryable: false })
+  })
+
   test('dispatches when the final required feedback attestation arrives after the failed push', () => {
     const feedbackReview = snapshot({
       commitShas: [olderHeadSha, finalHeadSha],
@@ -1105,7 +1198,26 @@ describe('Bayn delayed-attestation publication retry', () => {
     expect(workflow).not.toContain('permissions:\n  actions: write')
   })
 
+  test('parses only exact unresolved-thread failure evidence from the bounded gate log', () => {
+    expect(
+      parseFailedUnresolvedThreadBlock(
+        `2026-07-30T07:02:30Z BAYN_RELEASE_REVIEW_HOLD active-unresolved-review-threads: Bayn-affecting commit ${mainCommitSha.slice(0, 12)} after last published ${lastPublishedSha.slice(0, 12)} is not release-eligible: source PR #13401 has 1 unresolved review thread(s): https://github.com/proompteng/lab/pull/13401#discussion_r1\n`,
+      ),
+    ).toEqual({ commitShaPrefix: mainCommitSha.slice(0, 12), prNumber: 13401 })
+    expect(
+      parseFailedUnresolvedThreadBlock(
+        `BAYN_RELEASE_REVIEW_HOLD active-unresolved-review-threads: source PR #13401 has unresolved threads\n`,
+      ),
+    ).toBeNull()
+    expect(() =>
+      parseFailedUnresolvedThreadBlock(
+        `BAYN_RELEASE_REVIEW_HOLD active-unresolved-review-threads: Bayn-affecting commit ${mainCommitSha.slice(0, 12)} after last published ${lastPublishedSha.slice(0, 12)} is not release-eligible: source PR #13401 has 1 unresolved review thread(s): one\nBAYN_RELEASE_REVIEW_HOLD active-unresolved-review-threads: Bayn-affecting commit ${heldCommitSha.slice(0, 12)} after last published ${lastPublishedSha.slice(0, 12)} is not release-eligible: source PR #13402 has 1 unresolved review thread(s): two\n`,
+      ),
+    ).toThrow('github-api-invalid-response')
+  })
+
   test('decodes a bounded failed push and delayed clean reaction for retry discovery', async () => {
+    let redirectedLogAuthorization: string | null = 'not-requested'
     const fetchFn = (async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input)
       if (url.includes('/actions/workflows/') && url.includes('status=success')) {
@@ -1157,10 +1269,29 @@ describe('Bayn delayed-attestation publication retry', () => {
       if (url.includes('/actions/runs/30540000001/jobs?')) {
         return Response.json({
           jobs: [
-            { name: 'Verify exact-head Codex review', status: 'completed', conclusion: 'failure' },
-            { name: 'image', status: 'completed', conclusion: 'skipped' },
+            {
+              id: 90860000001,
+              name: 'Verify exact-head Codex review',
+              status: 'completed',
+              conclusion: 'failure',
+            },
+            { id: 90860000002, name: 'image', status: 'completed', conclusion: 'skipped' },
           ],
         })
+      }
+      if (url.includes('/actions/jobs/90860000001/logs')) {
+        return new Response(null, {
+          status: 302,
+          headers: {
+            location: 'https://productionresultssa17.blob.core.windows.net/actions-results/test/job-logs.txt',
+          },
+        })
+      }
+      if (url === 'https://productionresultssa17.blob.core.windows.net/actions-results/test/job-logs.txt') {
+        redirectedLogAuthorization = new Headers(init?.headers).get('authorization')
+        return new Response(
+          'BAYN_RELEASE_REVIEW_HOLD exact-head-review-missing: source PR final head lacks review evidence\n',
+        )
       }
       if (url.includes('/compare/')) {
         return Response.json({
@@ -1283,6 +1414,7 @@ describe('Bayn delayed-attestation publication retry', () => {
       prNumber: 13401,
       failedRunId: 30540000001,
     })
+    expect(redirectedLogAuthorization).toBeNull()
   })
 })
 

--- a/packages/scripts/src/bayn/verify-release-review.test.ts
+++ b/packages/scripts/src/bayn/verify-release-review.test.ts
@@ -707,6 +707,34 @@ describe('Bayn delayed-attestation publication retry', () => {
     })
   })
 
+  test('dispatches when review readiness and failed-run completion share the same GitHub timestamp second', () => {
+    const settlingReview = reviewSnapshotFor({
+      commitSha: mainCommitSha,
+      prNumber: 13401,
+      headSha: finalHeadSha,
+      parents: [lastPublishedSha],
+      mergedAt: '2026-07-30T07:00:00Z',
+      reviews: [review({ submittedAt: '2026-07-30T07:01:00Z' })],
+    })
+    expect(
+      evaluateBaynReleaseRetry({
+        mainCommitSha,
+        baseRefName: 'main',
+        snapshot: retrySnapshot({
+          reviewSnapshot: settlingReview,
+          failedRun: failedBuildRun({ updatedAt: '2026-07-30T07:01:30Z' }),
+        }),
+        trigger: { type: 'schedule' },
+        nowMs: Date.parse('2026-07-30T07:02:00Z'),
+      }),
+    ).toMatchObject({
+      status: 'dispatch',
+      sourceCommitSha: mainCommitSha,
+      prNumber: 13401,
+      headSha: finalHeadSha,
+    })
+  })
+
   test('dispatches when the final required feedback attestation arrives after the failed push', () => {
     const feedbackReview = snapshot({
       commitShas: [olderHeadSha, finalHeadSha],

--- a/packages/scripts/src/bayn/verify-release-review.ts
+++ b/packages/scripts/src/bayn/verify-release-review.ts
@@ -1490,6 +1490,17 @@ export const parseFailedReviewThreadBlock = (log: string): FailedReviewThreadBlo
   return unique.values().next().value ?? null
 }
 
+export const loadOptionalFailedReviewThreadBlock = async (
+  loadLog: () => Promise<string>,
+): Promise<FailedReviewThreadBlock | null> => {
+  try {
+    return parseFailedReviewThreadBlock(await loadLog())
+  } catch (error) {
+    if (error instanceof GitHubReleaseReviewError && (error.status === 404 || error.status === 410)) return null
+    throw error
+  }
+}
+
 interface ParsedComparison {
   readonly status: string
   readonly baseSha: string
@@ -2210,15 +2221,16 @@ const fetchFailedReviewThreadBlock = async (
   const reviewJob = reviewJobs[0]
   if (reviewJob === undefined) return null
   const operation = `read failed Bayn review-gate job ${reviewJob.id} log`
-  const log = await requestGitHubText({
-    url: `https://api.github.com/repos/${encodeURIComponent(options.owner)}/${encodeURIComponent(options.name)}/actions/jobs/${reviewJob.id}/logs`,
-    operation,
-    token: options.token,
-    requestTimeoutMs: options.requestTimeoutMs,
-    maximumBytes: maximumReleaseReviewJobLogBytes,
-    fetchFn: options.fetchFn,
-  })
-  return parseFailedReviewThreadBlock(log)
+  return loadOptionalFailedReviewThreadBlock(() =>
+    requestGitHubText({
+      url: `https://api.github.com/repos/${encodeURIComponent(options.owner)}/${encodeURIComponent(options.name)}/actions/jobs/${reviewJob.id}/logs`,
+      operation,
+      token: options.token,
+      requestTimeoutMs: options.requestTimeoutMs,
+      maximumBytes: maximumReleaseReviewJobLogBytes,
+      fetchFn: options.fetchFn,
+    }),
+  )
 }
 
 const latestFailedSourcePush = (

--- a/packages/scripts/src/bayn/verify-release-review.ts
+++ b/packages/scripts/src/bayn/verify-release-review.ts
@@ -113,7 +113,7 @@ export interface BaynBuildWorkflowJob {
   readonly conclusion: string | null
 }
 
-export interface FailedUnresolvedThreadBlock {
+export interface FailedReviewThreadBlock {
   readonly commitShaPrefix: string
   readonly prNumber: number
 }
@@ -121,7 +121,7 @@ export interface FailedUnresolvedThreadBlock {
 export interface FailedBaynReleaseReviewRun {
   readonly run: BaynBuildWorkflowRun
   readonly jobs: readonly BaynBuildWorkflowJob[]
-  readonly unresolvedThreadBlock: FailedUnresolvedThreadBlock | null
+  readonly reviewThreadBlock: FailedReviewThreadBlock | null
 }
 
 export type LastPublishedRevisionResolution =
@@ -926,18 +926,18 @@ export const evaluateBaynReleaseRetry = (input: {
   }
 
   const affectingCommits = baynAffectingCommits(input.snapshot)
-  const unresolvedThreadBlock = failedReviewRun.unresolvedThreadBlock
+  const reviewThreadBlock = failedReviewRun.reviewThreadBlock
   let resolvedThreadCommitSha: string | null = null
-  if (unresolvedThreadBlock !== null) {
+  if (reviewThreadBlock !== null) {
     const blockedCommits = affectingCommits.filter(
       (commit) =>
-        commit.sha.startsWith(unresolvedThreadBlock.commitShaPrefix) &&
-        commit.reviewSnapshot?.pullRequest?.number === unresolvedThreadBlock.prNumber,
+        commit.sha.startsWith(reviewThreadBlock.commitShaPrefix) &&
+        commit.reviewSnapshot?.pullRequest?.number === reviewThreadBlock.prNumber,
     )
     if (blockedCommits.length !== 1) {
       return hold(
         'retry-failed-run-mismatch',
-        `failed run ${failedReviewRun.run.id} unresolved-thread evidence does not uniquely bind current range commit ${unresolvedThreadBlock.commitShaPrefix}/#${unresolvedThreadBlock.prNumber}`,
+        `failed run ${failedReviewRun.run.id} review-thread evidence does not uniquely bind current range commit ${reviewThreadBlock.commitShaPrefix}/#${reviewThreadBlock.prNumber}`,
         false,
       )
     }
@@ -1468,13 +1468,17 @@ const parseBaynBuildWorkflowJobs = (value: unknown): readonly BaynBuildWorkflowJ
   })
 }
 
-export const parseFailedUnresolvedThreadBlock = (log: string): FailedUnresolvedThreadBlock | null => {
-  const pattern =
-    /BAYN_RELEASE_REVIEW_HOLD active-unresolved-review-threads: Bayn-affecting commit ([0-9a-f]{12}) .*? source PR #(\d+) has \d+ unresolved review thread\(s\):/g
-  const matches = [...log.matchAll(pattern)].map((match) => ({
-    commitShaPrefix: match[1] as string,
-    prNumber: Number(match[2]),
-  }))
+export const parseFailedReviewThreadBlock = (log: string): FailedReviewThreadBlock | null => {
+  const patterns = [
+    /BAYN_RELEASE_REVIEW_HOLD active-unresolved-review-threads: Bayn-affecting commit ([0-9a-f]{12}) .*? source PR #(\d+) has \d+ unresolved review thread\(s\):/g,
+    /BAYN_RELEASE_REVIEW_HOLD feedback-fix-attestation-missing: Bayn-affecting commit ([0-9a-f]{12}) .*? source PR #(\d+) final head [0-9a-f]{12} carries review from [0-9a-f]{12}, but post-review commit [0-9a-f]{12} lacks a trusted member reply on a resolved Codex thread from that review/g,
+  ]
+  const matches = patterns.flatMap((pattern) =>
+    [...log.matchAll(pattern)].map((match) => ({
+      commitShaPrefix: match[1] as string,
+      prNumber: Number(match[2]),
+    })),
+  )
   if (matches.length === 0) return null
   const unique = new Map(matches.map((match) => [`${match.commitShaPrefix}/#${match.prNumber}`, match]))
   if (unique.size !== 1) {
@@ -2194,10 +2198,10 @@ const fetchBaynBuildWorkflowJobs = async (
   return parseBaynBuildWorkflowJobs(response.value)
 }
 
-const fetchFailedUnresolvedThreadBlock = async (
+const fetchFailedReviewThreadBlock = async (
   options: GitHubLoaderOptions,
   jobs: readonly BaynBuildWorkflowJob[],
-): Promise<FailedUnresolvedThreadBlock | null> => {
+): Promise<FailedReviewThreadBlock | null> => {
   const reviewJobs = jobs.filter((job) => job.name === 'Verify exact-head Codex review')
   if (reviewJobs.length !== 1) return null
   const reviewJob = reviewJobs[0]
@@ -2211,7 +2215,7 @@ const fetchFailedUnresolvedThreadBlock = async (
     maximumBytes: maximumReleaseReviewJobLogBytes,
     fetchFn: options.fetchFn,
   })
-  return parseFailedUnresolvedThreadBlock(log)
+  return parseFailedReviewThreadBlock(log)
 }
 
 const latestFailedSourcePush = (
@@ -2268,12 +2272,11 @@ export const createGitHubReleaseRetryLoader = (options: {
     ])
     const failedRun = latestFailedSourcePush(sourcePushRuns, options.mainCommitSha)
     const jobs = failedRun === undefined ? [] : await fetchBaynBuildWorkflowJobs(loaderOptions, failedRun.id)
-    const unresolvedThreadBlock =
-      failedRun === undefined ? null : await fetchFailedUnresolvedThreadBlock(loaderOptions, jobs)
+    const reviewThreadBlock = failedRun === undefined ? null : await fetchFailedReviewThreadBlock(loaderOptions, jobs)
     return {
       ...eligibility,
       defaultBranchSha,
-      failedReviewRun: failedRun === undefined ? null : { run: failedRun, jobs, unresolvedThreadBlock },
+      failedReviewRun: failedRun === undefined ? null : { run: failedRun, jobs, reviewThreadBlock },
       publicationSucceeded:
         sourcePushRuns.some((run) => run.status === 'completed' && run.conclusion === 'success') ||
         currentDispatchRuns.some((run) => run.status === 'completed' && run.conclusion === 'success'),

--- a/packages/scripts/src/bayn/verify-release-review.ts
+++ b/packages/scripts/src/bayn/verify-release-review.ts
@@ -111,6 +111,7 @@ export interface BaynBuildWorkflowJob {
   readonly name: string
   readonly status: string
   readonly conclusion: string | null
+  readonly completedAt: string | null
 }
 
 export interface FailedReviewThreadBlock {
@@ -916,11 +917,12 @@ export const evaluateBaynReleaseRetry = (input: {
       false,
     )
   }
-  const failedAtMs = Date.parse(failedReviewRun.run.updatedAt)
+  const failedReviewJob = failedReviewRun.jobs.find((job) => job.name === 'Verify exact-head Codex review')
+  const failedAtMs = Date.parse(failedReviewJob?.completedAt ?? '')
   if (!Number.isFinite(failedAtMs)) {
     return hold(
       'retry-failed-run-mismatch',
-      `Bayn run ${failedReviewRun.run.id} has an invalid completion timestamp`,
+      `Bayn run ${failedReviewRun.run.id} review gate has an invalid completion timestamp`,
       false,
     )
   }
@@ -1464,6 +1466,7 @@ const parseBaynBuildWorkflowJobs = (value: unknown): readonly BaynBuildWorkflowJ
       name: expectString(job.name, `Bayn build workflow job ${index} name`),
       status: expectString(job.status, `Bayn build workflow job ${index} status`),
       conclusion: expectNullableString(job.conclusion, `Bayn build workflow job ${index} conclusion`),
+      completedAt: expectNullableString(job.completed_at, `Bayn build workflow job ${index} completed at`),
     }
   })
 }

--- a/packages/scripts/src/bayn/verify-release-review.ts
+++ b/packages/scripts/src/bayn/verify-release-review.ts
@@ -5,6 +5,7 @@ const githubGraphqlUrl = 'https://api.github.com/graphql'
 const maximumGraphqlPages = 20
 const minimumExactReviewAgeMs = 30_000
 const maximumReleaseRangeCommits = 100
+const maximumReleaseReviewJobLogBytes = 1_048_576
 const githubWorkflowFile = 'bayn-build-push.yml'
 
 export const baynCodexReviewer = 'chatgpt-codex-connector'
@@ -106,14 +107,21 @@ export interface BaynBuildWorkflowRun {
 }
 
 export interface BaynBuildWorkflowJob {
+  readonly id: number
   readonly name: string
   readonly status: string
   readonly conclusion: string | null
 }
 
+export interface FailedUnresolvedThreadBlock {
+  readonly commitShaPrefix: string
+  readonly prNumber: number
+}
+
 export interface FailedBaynReleaseReviewRun {
   readonly run: BaynBuildWorkflowRun
   readonly jobs: readonly BaynBuildWorkflowJob[]
+  readonly unresolvedThreadBlock: FailedUnresolvedThreadBlock | null
 }
 
 export type LastPublishedRevisionResolution =
@@ -918,9 +926,29 @@ export const evaluateBaynReleaseRetry = (input: {
   }
 
   const affectingCommits = baynAffectingCommits(input.snapshot)
+  const unresolvedThreadBlock = failedReviewRun.unresolvedThreadBlock
+  let resolvedThreadCommitSha: string | null = null
+  if (unresolvedThreadBlock !== null) {
+    const blockedCommits = affectingCommits.filter(
+      (commit) =>
+        commit.sha.startsWith(unresolvedThreadBlock.commitShaPrefix) &&
+        commit.reviewSnapshot?.pullRequest?.number === unresolvedThreadBlock.prNumber,
+    )
+    if (blockedCommits.length !== 1) {
+      return hold(
+        'retry-failed-run-mismatch',
+        `failed run ${failedReviewRun.run.id} unresolved-thread evidence does not uniquely bind current range commit ${unresolvedThreadBlock.commitShaPrefix}/#${unresolvedThreadBlock.prNumber}`,
+        false,
+      )
+    }
+    resolvedThreadCommitSha = blockedCommits[0]?.sha ?? null
+  }
   const delayedCandidates = eligibility.reviewedPullRequests.flatMap((reviewed) => {
     const eligibleAtMs = Date.parse(reviewed.eligibleAt)
-    if (!Number.isFinite(eligibleAtMs) || eligibleAtMs < failedAtMs) return []
+    const delayedByEligibilityTime = Number.isFinite(eligibleAtMs) && eligibleAtMs >= failedAtMs
+    const delayedByResolvedThread =
+      reviewed.commitSha === resolvedThreadCommitSha && Number.isFinite(input.nowMs) && input.nowMs >= failedAtMs
+    if (!delayedByEligibilityTime && !delayedByResolvedThread) return []
     const commit = affectingCommits.find((candidate) => candidate.sha === reviewed.commitSha)
     const pullRequest = commit?.reviewSnapshot?.pullRequest
     if (
@@ -1205,6 +1233,101 @@ const requestGitHubJson = async (options: {
   }
 }
 
+const requestGitHubText = async (options: {
+  readonly url: string
+  readonly operation: string
+  readonly token: string
+  readonly requestTimeoutMs: number
+  readonly maximumBytes: number
+  readonly fetchFn: typeof fetch
+}): Promise<string> => {
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), options.requestTimeoutMs)
+  const readBoundedText = async (response: Response): Promise<string> => {
+    const declaredLength = response.headers.get('content-length')
+    const parsedLength = declaredLength === null ? null : Number(declaredLength)
+    if (parsedLength !== null && (!Number.isFinite(parsedLength) || parsedLength > options.maximumBytes)) {
+      throw new GitHubReleaseReviewError('github-api-invalid-response', `${options.operation} size`)
+    }
+    if (response.body === null) {
+      throw new GitHubReleaseReviewError('github-api-invalid-response', `${options.operation} body`)
+    }
+    const reader = response.body.getReader()
+    const chunks: Uint8Array[] = []
+    let totalBytes = 0
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      totalBytes += value.byteLength
+      if (totalBytes > options.maximumBytes) {
+        await reader.cancel()
+        throw new GitHubReleaseReviewError('github-api-invalid-response', `${options.operation} size`)
+      }
+      chunks.push(value)
+    }
+    const bytes = new Uint8Array(totalBytes)
+    let offset = 0
+    for (const chunk of chunks) {
+      bytes.set(chunk, offset)
+      offset += chunk.byteLength
+    }
+    return new TextDecoder().decode(bytes)
+  }
+  try {
+    const response = await options.fetchFn(options.url, {
+      signal: controller.signal,
+      redirect: 'manual',
+      headers: {
+        Accept: 'application/vnd.github+json',
+        Authorization: `Bearer ${options.token}`,
+        'User-Agent': 'bayn-release-review-gate',
+        'X-GitHub-Api-Version': githubApiVersion,
+      },
+    })
+    if (response.status >= 300 && response.status < 400) {
+      const location = response.headers.get('location')
+      if (location === null) {
+        throw new GitHubReleaseReviewError('github-api-invalid-response', `${options.operation} redirect`)
+      }
+      let downloadUrl: URL
+      try {
+        downloadUrl = new URL(location)
+      } catch (error) {
+        throw new GitHubReleaseReviewError('github-api-invalid-response', `${options.operation} redirect`, {
+          cause: error,
+        })
+      }
+      if (
+        downloadUrl.protocol !== 'https:' ||
+        (!downloadUrl.hostname.endsWith('.blob.core.windows.net') &&
+          downloadUrl.hostname !== 'pipelines.actions.githubusercontent.com')
+      ) {
+        throw new GitHubReleaseReviewError('github-api-invalid-response', `${options.operation} redirect host`)
+      }
+      const download = await options.fetchFn(downloadUrl, {
+        signal: controller.signal,
+        redirect: 'error',
+      })
+      if (!download.ok) {
+        throw new GitHubReleaseReviewError('github-api-error', options.operation, { status: download.status })
+      }
+      return await readBoundedText(download)
+    }
+    if (!response.ok) {
+      throw new GitHubReleaseReviewError('github-api-error', options.operation, { status: response.status })
+    }
+    return await readBoundedText(response)
+  } catch (error) {
+    if (error instanceof GitHubReleaseReviewError) throw error
+    if (controller.signal.aborted) {
+      throw new GitHubReleaseReviewError('github-api-timeout', options.operation, { cause: error })
+    }
+    throw new GitHubReleaseReviewError('github-api-error', options.operation, { cause: error })
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
 const requestGraphql = async (options: {
   readonly query: string
   readonly variables: Record<string, unknown>
@@ -1337,11 +1460,27 @@ const parseBaynBuildWorkflowJobs = (value: unknown): readonly BaynBuildWorkflowJ
   return payload.jobs.map((item, index) => {
     const job = expectRecord(item, `Bayn build workflow job ${index}`)
     return {
+      id: expectInteger(job.id, `Bayn build workflow job ${index} ID`),
       name: expectString(job.name, `Bayn build workflow job ${index} name`),
       status: expectString(job.status, `Bayn build workflow job ${index} status`),
       conclusion: expectNullableString(job.conclusion, `Bayn build workflow job ${index} conclusion`),
     }
   })
+}
+
+export const parseFailedUnresolvedThreadBlock = (log: string): FailedUnresolvedThreadBlock | null => {
+  const pattern =
+    /BAYN_RELEASE_REVIEW_HOLD active-unresolved-review-threads: Bayn-affecting commit ([0-9a-f]{12}) .*? source PR #(\d+) has \d+ unresolved review thread\(s\):/g
+  const matches = [...log.matchAll(pattern)].map((match) => ({
+    commitShaPrefix: match[1] as string,
+    prNumber: Number(match[2]),
+  }))
+  if (matches.length === 0) return null
+  const unique = new Map(matches.map((match) => [`${match.commitShaPrefix}/#${match.prNumber}`, match]))
+  if (unique.size !== 1) {
+    throw new GitHubReleaseReviewError('github-api-invalid-response', 'parse failed Bayn review-gate log')
+  }
+  return unique.values().next().value ?? null
 }
 
 interface ParsedComparison {
@@ -2055,6 +2194,26 @@ const fetchBaynBuildWorkflowJobs = async (
   return parseBaynBuildWorkflowJobs(response.value)
 }
 
+const fetchFailedUnresolvedThreadBlock = async (
+  options: GitHubLoaderOptions,
+  jobs: readonly BaynBuildWorkflowJob[],
+): Promise<FailedUnresolvedThreadBlock | null> => {
+  const reviewJobs = jobs.filter((job) => job.name === 'Verify exact-head Codex review')
+  if (reviewJobs.length !== 1) return null
+  const reviewJob = reviewJobs[0]
+  if (reviewJob === undefined) return null
+  const operation = `read failed Bayn review-gate job ${reviewJob.id} log`
+  const log = await requestGitHubText({
+    url: `https://api.github.com/repos/${encodeURIComponent(options.owner)}/${encodeURIComponent(options.name)}/actions/jobs/${reviewJob.id}/logs`,
+    operation,
+    token: options.token,
+    requestTimeoutMs: options.requestTimeoutMs,
+    maximumBytes: maximumReleaseReviewJobLogBytes,
+    fetchFn: options.fetchFn,
+  })
+  return parseFailedUnresolvedThreadBlock(log)
+}
+
 const latestFailedSourcePush = (
   runs: readonly BaynBuildWorkflowRun[],
   sourceCommitSha: string,
@@ -2109,10 +2268,12 @@ export const createGitHubReleaseRetryLoader = (options: {
     ])
     const failedRun = latestFailedSourcePush(sourcePushRuns, options.mainCommitSha)
     const jobs = failedRun === undefined ? [] : await fetchBaynBuildWorkflowJobs(loaderOptions, failedRun.id)
+    const unresolvedThreadBlock =
+      failedRun === undefined ? null : await fetchFailedUnresolvedThreadBlock(loaderOptions, jobs)
     return {
       ...eligibility,
       defaultBranchSha,
-      failedReviewRun: failedRun === undefined ? null : { run: failedRun, jobs },
+      failedReviewRun: failedRun === undefined ? null : { run: failedRun, jobs, unresolvedThreadBlock },
       publicationSucceeded:
         sourcePushRuns.some((run) => run.status === 'completed' && run.conclusion === 'success') ||
         currentDispatchRuns.some((run) => run.status === 'completed' && run.conclusion === 'success'),

--- a/packages/scripts/src/bayn/verify-release-review.ts
+++ b/packages/scripts/src/bayn/verify-release-review.ts
@@ -194,6 +194,7 @@ export interface BaynReleaseReviewEligible {
   readonly prNumber: number
   readonly headSha: string
   readonly reviewSubmittedAt: string
+  readonly eligibleAt: string
 }
 
 export interface BaynReleaseEligibilityEligible {
@@ -206,6 +207,7 @@ export interface BaynReleaseEligibilityEligible {
     readonly prNumber: number
     readonly headSha: string
     readonly reviewSubmittedAt: string
+    readonly eligibleAt: string
   }[]
 }
 
@@ -604,20 +606,21 @@ export const evaluateBaynReleaseReview = (input: {
       true,
     )
   }
+  let eligibleAtMs = reviewSubmittedAtMs + minimumExactReviewAgeMs
 
   if (feedbackFixCommitShas.length > 0) {
     const reviewedHeadSha = reviewEvidence.commitSha as string
     for (const fixCommitSha of feedbackFixCommitShas) {
-      const hasTrustedAttestation = pullRequest.threads.some((thread) => {
-        if (!thread.isResolved) return false
+      const trustedAttestationTimes = pullRequest.threads.flatMap((thread) => {
+        if (!thread.isResolved) return []
         const belongsToReviewedHead = thread.comments.some(
           (comment) =>
             comment.reviewAuthorLogin === baynCodexReviewer &&
             comment.reviewCommitSha === reviewedHeadSha &&
             comment.reviewSubmittedAt === reviewEvidence.submittedAt,
         )
-        if (!belongsToReviewedHead) return false
-        return thread.comments.some((comment) => {
+        if (!belongsToReviewedHead) return []
+        return thread.comments.flatMap((comment) => {
           if (
             comment.authorLogin === null ||
             comment.authorLogin === baynCodexReviewer ||
@@ -625,19 +628,20 @@ export const evaluateBaynReleaseReview = (input: {
             comment.reviewCommitSha !== fixCommitSha ||
             comment.reviewSubmittedAt === null
           ) {
-            return false
+            return []
           }
           const attestationTime = Date.parse(comment.reviewSubmittedAt)
-          return Number.isFinite(attestationTime) && attestationTime >= reviewSubmittedAtMs
+          return Number.isFinite(attestationTime) && attestationTime >= reviewSubmittedAtMs ? [attestationTime] : []
         })
       })
-      if (!hasTrustedAttestation) {
+      if (trustedAttestationTimes.length === 0) {
         return hold(
           'feedback-fix-attestation-missing',
           `source PR #${pullRequest.number} final head ${shortSha(pullRequest.headSha)} carries review from ${shortSha(reviewedHeadSha)}, but post-review commit ${shortSha(fixCommitSha)} lacks a trusted member reply on a resolved Codex thread from that review`,
           true,
         )
       }
+      eligibleAtMs = Math.max(eligibleAtMs, Math.min(...trustedAttestationTimes))
     }
   }
 
@@ -659,6 +663,7 @@ export const evaluateBaynReleaseReview = (input: {
     prNumber: pullRequest.number,
     headSha: pullRequest.headSha,
     reviewSubmittedAt: reviewEvidence.submittedAt as string,
+    eligibleAt: new Date(eligibleAtMs).toISOString(),
   }
 }
 
@@ -797,6 +802,7 @@ export const evaluateBaynReleaseEligibility = (input: {
       prNumber: review.prNumber,
       headSha: review.headSha,
       reviewSubmittedAt: review.reviewSubmittedAt,
+      eligibleAt: review.eligibleAt,
     })
   }
 
@@ -913,8 +919,8 @@ export const evaluateBaynReleaseRetry = (input: {
 
   const affectingCommits = baynAffectingCommits(input.snapshot)
   const delayedCandidates = eligibility.reviewedPullRequests.flatMap((reviewed) => {
-    const attestedAtMs = Date.parse(reviewed.reviewSubmittedAt)
-    if (!Number.isFinite(attestedAtMs) || attestedAtMs <= failedAtMs) return []
+    const eligibleAtMs = Date.parse(reviewed.eligibleAt)
+    if (!Number.isFinite(eligibleAtMs) || eligibleAtMs <= failedAtMs) return []
     const commit = affectingCommits.find((candidate) => candidate.sha === reviewed.commitSha)
     const pullRequest = commit?.reviewSnapshot?.pullRequest
     if (

--- a/packages/scripts/src/bayn/verify-release-review.ts
+++ b/packages/scripts/src/bayn/verify-release-review.ts
@@ -920,7 +920,7 @@ export const evaluateBaynReleaseRetry = (input: {
   const affectingCommits = baynAffectingCommits(input.snapshot)
   const delayedCandidates = eligibility.reviewedPullRequests.flatMap((reviewed) => {
     const eligibleAtMs = Date.parse(reviewed.eligibleAt)
-    if (!Number.isFinite(eligibleAtMs) || eligibleAtMs <= failedAtMs) return []
+    if (!Number.isFinite(eligibleAtMs) || eligibleAtMs < failedAtMs) return []
     const commit = affectingCommits.find((candidate) => candidate.sha === reviewed.commitSha)
     const pullRequest = commit?.reviewSnapshot?.pullRequest
     if (


### PR DESCRIPTION
## Summary

- Carry the exact time a review becomes release-eligible through the pure source-review evaluation.
- Define readiness as the 30-second review settling deadline plus the earliest required trusted feedback reply for each post-review fix commit.
- Select delayed retry candidates using that eligibility time rather than the raw review timestamp.

## Related Issues

Follow-up to the late exact-head P1 on #13402: https://github.com/proompteng/lab/pull/13402#discussion_r3682504946

## Testing

- `bun test packages/scripts/src/bayn/*.test.ts` — 72 passed.
- Targeted TypeScript compile for the verifier and tests.
- Targeted Oxlint for the verifier and tests.
- Oxfmt check for the Bayn workflow, verifier, and tests.
- Actionlint 1.7.7 for `.github/workflows/bayn-build-push.yml`.
- `git diff --check`.
- Added focused regressions for a review settling after the failed run and a later required feedback attestation.

## Breaking Changes

None. The retry remains bounded, read-only before dispatch, exact-source-bound, and fail-closed. No workflow permissions, runtime, release, image, manifest, broker, or capital authority changed.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] No documentation or release-note follow-up is required.
