### PR TITLE
chore(bayn): promote image sha-5fdf3b23ed4b49074f7e24eaa1dcb5b3e0fa0ba8

### DIFF
--- a/argocd/applications/bayn/deployment.yaml
+++ b/argocd/applications/bayn/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         app.kubernetes.io/name: bayn
         app.kubernetes.io/part-of: bayn
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-07-30T13:30:02Z"
+        kubectl.kubernetes.io/restartedAt: "2026-07-30T14:58:38Z"
     spec:
       serviceAccountName: bayn
       automountServiceAccountToken: false
@@ -47,11 +47,11 @@ spec:
               protocol: TCP
           env:
             - name: BAYN_CODE_REVISION
-              value: c07281d0c20f824df786b75e588ff4720a36afb5
+              value: 5fdf3b23ed4b49074f7e24eaa1dcb5b3e0fa0ba8
             - name: BAYN_IMAGE_REPOSITORY
               value: registry.ide-newton.ts.net/lab/bayn
             - name: BAYN_IMAGE_DIGEST
-              value: sha256:e0317d9dd663f14b8f8994e1f062a88e175d5b093380e23fda824021d84357ad
+              value: sha256:f996d1b87800716cdc7e2b7265ea021c2d82b2c251564a222abb68cd2cc1129e
             - name: BAYN_STRATEGY_BEHAVIOR_HASH
               value: "9e87fe0f66048c48da2191ef1fae36ef3ee0eb4ddcd036ef40881f0fe0f6eb42"
             - name: BAYN_STRATEGY_PARAMETER_HASH

--- a/argocd/applications/bayn/kustomization.yaml
+++ b/argocd/applications/bayn/kustomization.yaml
@@ -22,5 +22,5 @@ configMapGenerator:
 images:
   - name: registry.ide-newton.ts.net/lab/bayn
     newName: registry.ide-newton.ts.net/lab/bayn
-    newTag: "sha-c07281d0c20f824df786b75e588ff4720a36afb5"
-    digest: sha256:e0317d9dd663f14b8f8994e1f062a88e175d5b093380e23fda824021d84357ad
+    newTag: "sha-5fdf3b23ed4b49074f7e24eaa1dcb5b3e0fa0ba8"
+    digest: sha256:f996d1b87800716cdc7e2b7265ea021c2d82b2c251564a222abb68cd2cc1129e


### PR DESCRIPTION
## Summary

Promote the immutable Bayn image against the current Signal snapshot and dedicated Bayn TigerBeetle
ledger. Qualification-pin handling is selected from the verified compiled behavior identity.

- Source commit: `5fdf3b23ed4b49074f7e24eaa1dcb5b3e0fa0ba8`
- Image tag: `sha-5fdf3b23ed4b49074f7e24eaa1dcb5b3e0fa0ba8`
- Image digest: `sha256:f996d1b87800716cdc7e2b7265ea021c2d82b2c251564a222abb68cd2cc1129e`
- Qualification mode: `preserve`
- Existing pin: `true`
- Qualification identity bindings match: `true`
- Snapshot changed: `false`
- Deployed snapshot: `2a91f0177684f7022f746207333e510c8268f9b77a04b778a04220a33ccf79e0`
- Candidate snapshot: `2a91f0177684f7022f746207333e510c8268f9b77a04b778a04220a33ccf79e0`
- Deployed behavior hash: `9e87fe0f66048c48da2191ef1fae36ef3ee0eb4ddcd036ef40881f0fe0f6eb42`
- Candidate behavior hash: `9e87fe0f66048c48da2191ef1fae36ef3ee0eb4ddcd036ef40881f0fe0f6eb42`
- Deployed parameter hash: `19bc51c7361b181aa48845d178cb63373b3f2e017bcbea1cf3b70ab16647f8a9`
- Candidate parameter hash: `19bc51c7361b181aa48845d178cb63373b3f2e017bcbea1cf3b70ab16647f8a9`

## Related Issues

PROOMPT-400

## Testing

- `bayn-build-push` run `30554056532` completed successfully for exact source `5fdf3b23ed4b49074f7e24eaa1dcb5b3e0fa0ba8` and emitted the immutable release contract for digest `sha256:f996d1b87800716cdc7e2b7265ea021c2d82b2c251564a222abb68cd2cc1129e`.
- Platform job `90909958404` verified and published `linux/amd64` successfully.
- Platform job `90909958276` verified the Bayn forward-performance command and published `linux/arm64` successfully.
- Publish-index job `90910489915` verified both platforms and uploaded the exact release contract consumed by `bayn-release` run `30554285014`.

## Rollout and Impact

- Rolls only the Bayn Deployment to tag `sha-5fdf3b23ed4b49074f7e24eaa1dcb5b3e0fa0ba8` at digest `sha256:f996d1b87800716cdc7e2b7265ea021c2d82b2c251564a222abb68cd2cc1129e`.
- Compiled strategy behavior, parameters, Signal snapshot, and qualification identity are unchanged, so the existing qualification pin is preserved.
- No permission, RBAC, environment, database, broker-authority, or capital-authority change is included.

## Screenshots (if applicable)

N/A

## Breaking Changes

This is a one-way current-contract runtime release. Databases with the old migration tracker are rejected;
there is no schema fallback or automatic rename. `preserve` keeps the terminal run only when compiled
behavior, protocol parameters, Signal inputs, TigerBeetle cluster ID, and TigerBeetle ledger all match.
Replica addresses are transport and an explicit candidate may change them without relabeling qualification
evidence. `replace` removes an existing incompatible pin only for a fresh Signal snapshot. `install` is
available only to a controlled invocation that supplies the complete reviewed candidate runtime and exact
independently accepted terminal run ID; automatic image promotion supplies neither and therefore never
creates a pin. Installation can pin only the exact source, image digest, compiled strategy, and runtime
already deployed without a pin. It cannot replace an old pin and advance to a fresh candidate in the same
change.

## Checklist

- [x] Testing section documents exact validation.
- [x] Runtime source revision and image digest are immutable.
- [x] Rollout and impact notes are bound to the promoted release contract.
- [x] No broker or capital-promotion authority is introduced.
