### PR TITLE
fix(bayn): isolate release retry concurrency

### DIFF
--- a/.github/workflows/bayn-build-push.yml
+++ b/.github/workflows/bayn-build-push.yml
@@ -63,8 +63,10 @@ on:
 concurrency:
   group: >-
     ${{ github.workflow }}-${{
-      (github.event_name == 'issue_comment' || github.event_name == 'schedule') &&
-      'retry-trigger' ||
+      github.event_name == 'schedule' &&
+      'retry-schedule' ||
+      github.event_name == 'issue_comment' &&
+      format('retry-comment-{0}', github.event.issue.number) ||
       'main'
     }}
   cancel-in-progress: true

--- a/packages/scripts/src/bayn/bayn-build-push-concurrency.test.ts
+++ b/packages/scripts/src/bayn/bayn-build-push-concurrency.test.ts
@@ -1,0 +1,65 @@
+import { readFileSync } from 'node:fs'
+
+import { describe, expect, test } from 'bun:test'
+import { parse } from 'yaml'
+
+const workflowPath = new URL('../../../../.github/workflows/bayn-build-push.yml', import.meta.url)
+const workflow = readFileSync(workflowPath, 'utf8')
+const parsed = parse(workflow) as {
+  readonly name: string
+  readonly concurrency: {
+    readonly group: string
+    readonly 'cancel-in-progress': boolean
+  }
+}
+
+const normalizedConcurrencyGroup = parsed.concurrency.group.replace(/\s+/g, ' ').trim()
+
+const expectedConcurrencyGroup = [
+  '${{ github.workflow }}-${{',
+  "github.event_name == 'schedule' && 'retry-schedule' ||",
+  "github.event_name == 'issue_comment' && format('retry-comment-{0}', github.event.issue.number) ||",
+  "'main'",
+  '}}',
+].join(' ')
+
+type RetryEvent = { readonly name: 'schedule' } | { readonly name: 'issue_comment'; readonly issueNumber: number }
+
+const concurrencyGroupFor = (event: RetryEvent): string => {
+  if (event.name === 'schedule') return `${parsed.name}-retry-schedule`
+  return `${parsed.name}-retry-comment-${event.issueNumber}`
+}
+
+const cancelsRunningEvent = (running: RetryEvent, incoming: RetryEvent): boolean =>
+  parsed.concurrency['cancel-in-progress'] && concurrencyGroupFor(running) === concurrencyGroupFor(incoming)
+
+describe('Bayn build-push workflow concurrency', () => {
+  test('does not let an unrelated issue comment cancel scheduled retry discovery', () => {
+    expect(normalizedConcurrencyGroup).toBe(expectedConcurrencyGroup)
+
+    const scheduledDiscovery = concurrencyGroupFor({ name: 'schedule' })
+    const unrelatedCandidateComment = concurrencyGroupFor({ name: 'issue_comment', issueNumber: 13_379 })
+
+    expect(scheduledDiscovery).toBe('bayn-build-push-retry-schedule')
+    expect(unrelatedCandidateComment).toBe('bayn-build-push-retry-comment-13379')
+    expect(cancelsRunningEvent({ name: 'schedule' }, { name: 'issue_comment', issueNumber: 13_379 })).toBe(false)
+  })
+
+  test('retains cancellation only for equivalent retry triggers', () => {
+    expect(parsed.concurrency['cancel-in-progress']).toBe(true)
+
+    expect(cancelsRunningEvent({ name: 'schedule' }, { name: 'schedule' })).toBe(true)
+    expect(
+      cancelsRunningEvent(
+        { name: 'issue_comment', issueNumber: 13_404 },
+        { name: 'issue_comment', issueNumber: 13_404 },
+      ),
+    ).toBe(true)
+    expect(
+      cancelsRunningEvent(
+        { name: 'issue_comment', issueNumber: 13_404 },
+        { name: 'issue_comment', issueNumber: 13_379 },
+      ),
+    ).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

- isolate scheduled delayed-attestation discovery from issue-comment concurrency
- scope issue-comment duplicate cancellation to the originating pull request
- add an adversarial workflow regression for schedule run 30551797820 followed by unrelated PR #13379 comment activity

## Related Issues

None

## Testing

- `bun test packages/scripts/src/bayn/bayn-build-push-concurrency.test.ts`
- `bun test packages/scripts/src/bayn`
- `bun node_modules/oxlint/bin/oxlint --config .oxlintrc.json packages/scripts`
- `bun node_modules/oxfmt/bin/oxfmt --check packages/scripts`
- `bun node_modules/oxlint/bin/oxlint --config .oxlintrc.json --type-aware --tsconfig packages/scripts/tsconfig.json packages/scripts`
- `bun node_modules/oxlint/bin/oxlint --config .oxlintrc.json --type-aware --tsconfig packages/scripts/tsconfig.jangar.json packages/scripts/src/jangar packages/scripts/src/shared`
- `bun node_modules/typescript/bin/tsc --noEmit --project packages/scripts/tsconfig.atlas.json`
- `actionlint v1.7.7 -shellcheck '' -pyflakes ''`
- `bun test packages/scripts/src` progressed through the suite until the Docker contract tests required a Docker CLI unavailable in the agents-shell container; PR CI provides that runtime

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] Documentation, release notes, and follow-ups are not required for this workflow-only correction.
