### PR TITLE
fix(bayn): bind promotion reactions to head history

### DIFF
--- a/packages/scripts/src/bayn/verify-promotion-eligibility.test.ts
+++ b/packages/scripts/src/bayn/verify-promotion-eligibility.test.ts
@@ -168,7 +168,7 @@ const pullRequest = (overrides: Partial<BaynPromotionPullRequest> = {}): BaynPro
   createdAt: '2026-07-30T09:59:00Z',
   headCommittedAt: '2026-07-30T10:00:00Z',
   commitCount: 1,
-  headForcePushCount: 0,
+  headForcePushes: [],
   files: [
     {
       path: 'argocd/applications/bayn/deployment.yaml',
@@ -358,7 +358,7 @@ describe('Bayn promotion eligibility', () => {
     ).toMatchObject({ status: 'hold', code: 'exact-head-review-missing' })
   })
 
-  test('accepts a clean connector reaction only for a single never-force-pushed head', () => {
+  test('accepts a clean connector reaction for a single immutable head without force-push history', () => {
     const reactions = [
       {
         userLogin: baynPromotionCodexBotLogin,
@@ -367,12 +367,194 @@ describe('Bayn promotion eligibility', () => {
       },
     ]
     expect(evaluate(snapshot({ reviews: [], reactions }))).toMatchObject({ status: 'eligible' })
+  })
+
+  test('accepts the #13410 one-force-push-then-clean-reaction sequence for the exact current head', () => {
+    const realPullNumber = 13410
+    const priorHeadSha = 'caee18e8b951700d75161f00a9d88a4696c2c323'
+    const realHeadSha = '94ecab66c681e1044c7a7e9f62982892ddac81ae'
+    const result = evaluateBaynPromotionEligibility({
+      expectedRepository: repository,
+      expectedPullNumber: realPullNumber,
+      expectedHeadSha: realHeadSha,
+      nowMs: Date.parse('2026-07-30T23:00:00Z'),
+      snapshot: snapshot({
+        pullRequest: pullRequest({
+          number: realPullNumber,
+          baseSha: '7cb3d25454e39f3dea04f4f60f1ec068c5a79807',
+          headSha: realHeadSha,
+          createdAt: '2026-07-30T22:57:10Z',
+          headCommittedAt: '2026-07-30T22:57:06Z',
+          headForcePushes: [
+            {
+              beforeSha: priorHeadSha,
+              afterSha: realHeadSha,
+              createdAt: '2026-07-30T22:57:11Z',
+            },
+          ],
+        }),
+        reviews: [],
+        reactions: [
+          {
+            userLogin: baynPromotionCodexBotLogin,
+            content: '+1',
+            createdAt: '2026-07-30T22:58:50Z',
+          },
+        ],
+        provenance: provenance({
+          promotionPullNumber: realPullNumber,
+          promotionHeadSha: realHeadSha,
+        }),
+      }),
+    })
+
+    expect(result).toMatchObject({
+      status: 'eligible',
+      prNumber: realPullNumber,
+      headSha: realHeadSha,
+      reviewSubmittedAt: '2026-07-30T22:58:50Z',
+    })
+  })
+
+  test.each([
+    ['before the latest-head force-push', '2026-07-30T22:57:10Z', baynPromotionCodexBotLogin],
+    ['at the same second as the latest-head force-push', '2026-07-30T22:57:11Z', baynPromotionCodexBotLogin],
+    ['from a spoofed actor', '2026-07-30T22:58:50Z', 'spoofed-codex[bot]'],
+  ] as const)('rejects a connector reaction %s', (_name, reactionCreatedAt, userLogin) => {
     expect(
       evaluate(
         snapshot({
           reviews: [],
-          reactions,
-          pullRequest: pullRequest({ headForcePushCount: 1 }),
+          pullRequest: pullRequest({
+            createdAt: '2026-07-30T22:57:10Z',
+            headCommittedAt: '2026-07-30T22:57:06Z',
+            headForcePushes: [
+              {
+                beforeSha: staleHeadSha,
+                afterSha: headSha,
+                createdAt: '2026-07-30T22:57:11Z',
+              },
+            ],
+          }),
+          reactions: [{ userLogin, content: '+1', createdAt: reactionCreatedAt }],
+        }),
+      ),
+    ).toMatchObject({ status: 'hold', code: 'exact-head-review-missing' })
+  })
+
+  test('rejects a reaction invalidated by a later force-push to the current head', () => {
+    expect(
+      evaluate(
+        snapshot({
+          reviews: [],
+          pullRequest: pullRequest({
+            createdAt: '2026-07-30T22:57:10Z',
+            headCommittedAt: '2026-07-30T22:57:06Z',
+            headForcePushes: [
+              {
+                beforeSha: oldSourceSha,
+                afterSha: staleHeadSha,
+                createdAt: '2026-07-30T22:57:11Z',
+              },
+              {
+                beforeSha: staleHeadSha,
+                afterSha: headSha,
+                createdAt: '2026-07-30T22:59:00Z',
+              },
+            ],
+          }),
+          reactions: [
+            {
+              userLogin: baynPromotionCodexBotLogin,
+              content: '+1',
+              createdAt: '2026-07-30T22:58:50Z',
+            },
+          ],
+        }),
+      ),
+    ).toMatchObject({ status: 'hold', code: 'exact-head-review-missing' })
+  })
+
+  test('rejects stale or ambiguous force-push history instead of guessing a reaction binding', () => {
+    const reaction = {
+      userLogin: baynPromotionCodexBotLogin,
+      content: '+1',
+      createdAt: '2026-07-30T22:58:50Z',
+    }
+    expect(
+      evaluate(
+        snapshot({
+          reviews: [],
+          reactions: [reaction],
+          pullRequest: pullRequest({
+            createdAt: '2026-07-30T22:57:10Z',
+            headCommittedAt: '2026-07-30T22:57:06Z',
+            headForcePushes: [
+              {
+                beforeSha: oldSourceSha,
+                afterSha: staleHeadSha,
+                createdAt: '2026-07-30T22:57:11Z',
+              },
+            ],
+          }),
+        }),
+      ),
+    ).toMatchObject({ status: 'hold', code: 'exact-head-review-missing' })
+
+    expect(
+      evaluate(
+        snapshot({
+          reviews: [],
+          reactions: [reaction],
+          pullRequest: pullRequest({
+            createdAt: '2026-07-30T22:57:10Z',
+            headCommittedAt: '2026-07-30T22:57:06Z',
+            headForcePushes: [
+              {
+                beforeSha: oldSourceSha,
+                afterSha: staleHeadSha,
+                createdAt: '2026-07-30T22:57:11Z',
+              },
+              {
+                beforeSha: sourceSha,
+                afterSha: headSha,
+                createdAt: '2026-07-30T22:57:12Z',
+              },
+            ],
+          }),
+        }),
+      ),
+    ).toMatchObject({ status: 'hold', code: 'exact-head-review-missing' })
+  })
+
+  test('rejects multiple clean fallback attestations as ambiguous', () => {
+    const reaction = {
+      userLogin: baynPromotionCodexBotLogin,
+      content: '+1',
+      createdAt: '2026-07-30T10:01:00Z',
+    }
+    expect(
+      evaluate(
+        snapshot({
+          reviews: [],
+          reactions: [reaction, { ...reaction, createdAt: '2026-07-30T10:01:01Z' }],
+        }),
+      ),
+    ).toMatchObject({ status: 'hold', code: 'exact-head-review-missing' })
+
+    expect(
+      evaluate(
+        snapshot({
+          reviews: [],
+          reactions: [reaction],
+          issueComments: [
+            {
+              authorLogin: baynPromotionCodexBotLogin,
+              body: `Codex Review: Didn't find any issues.\n\n**Reviewed commit:** \`${headSha}\`\n`,
+              createdAt: '2026-07-30T10:01:02Z',
+              updatedAt: '2026-07-30T10:01:02Z',
+            },
+          ],
         }),
       ),
     ).toMatchObject({ status: 'hold', code: 'exact-head-review-missing' })
@@ -725,6 +907,17 @@ describe('bounded GitHub failure handling', () => {
       ['argocd/applicationsets/product.yaml', manifests(basePins).applicationSet],
     ])
     const emptyConnection = { nodes: [], pageInfo: { hasNextPage: false, endCursor: null } }
+    const forcePushConnection = {
+      nodes: [
+        {
+          __typename: 'HeadRefForcePushedEvent',
+          createdAt: '2026-07-30T10:00:01Z',
+          beforeCommit: { oid: staleHeadSha },
+          afterCommit: { oid: headSha },
+        },
+      ],
+      pageInfo: { hasNextPage: false, endCursor: 'force-push-cursor' },
+    }
 
     const fetchFn = (async (input, init) => {
       const url = String(input)
@@ -732,7 +925,7 @@ describe('bounded GitHub failure handling', () => {
         const body = JSON.parse(String(init?.body)) as { readonly query: string }
         if (body.query.includes('BaynPromotionHeadForcePushes')) {
           return Response.json({
-            data: { repository: { pullRequest: { timelineItems: emptyConnection } } },
+            data: { repository: { pullRequest: { timelineItems: forcePushConnection } } },
           })
         }
         if (body.query.includes('BaynPromotionReviews')) {
@@ -817,6 +1010,14 @@ describe('bounded GitHub failure handling', () => {
     expect(comparedBases).toEqual([baseSha, nextBaseSha])
     expect(headManifestReads).toEqual([...baynPromotionManifestPaths])
     expect(commitReadCount).toBe(1)
+    expect(first.pullRequest.headForcePushes).toEqual([
+      {
+        beforeSha: staleHeadSha,
+        afterSha: headSha,
+        createdAt: '2026-07-30T10:00:01Z',
+      },
+    ])
+    expect(second.pullRequest.headForcePushes).toEqual(first.pullRequest.headForcePushes)
   })
 
   test.each([

--- a/packages/scripts/src/bayn/verify-promotion-eligibility.ts
+++ b/packages/scripts/src/bayn/verify-promotion-eligibility.ts
@@ -93,6 +93,12 @@ export interface BaynPromotionPullRequestFile {
   readonly previousPath: string | null
 }
 
+export interface BaynPromotionHeadForcePush {
+  readonly beforeSha: string
+  readonly afterSha: string
+  readonly createdAt: string
+}
+
 export interface BaynPromotionPullRequest {
   readonly number: number
   readonly title: string
@@ -105,7 +111,7 @@ export interface BaynPromotionPullRequest {
   readonly createdAt: string
   readonly headCommittedAt: string
   readonly commitCount: number
-  readonly headForcePushCount: number
+  readonly headForcePushes: readonly BaynPromotionHeadForcePush[]
   readonly files: readonly BaynPromotionPullRequestFile[]
 }
 
@@ -295,12 +301,42 @@ const timestampWithinOpenPullRequest = (timestamp: string, createdAt: string, no
   )
 }
 
+const exactHeadEstablishedAt = (pullRequest: BaynPromotionPullRequest, nowMs: number): number | null => {
+  const pullRequestCreatedAtMs = Date.parse(pullRequest.createdAt)
+  const headCommittedAtMs = Date.parse(pullRequest.headCommittedAt)
+  if (!Number.isFinite(pullRequestCreatedAtMs) || !Number.isFinite(headCommittedAtMs)) return null
+
+  const forcePushes = pullRequest.headForcePushes.toSorted((left, right) =>
+    left.createdAt.localeCompare(right.createdAt),
+  )
+  let previous: BaynPromotionHeadForcePush | undefined
+  let previousCreatedAtMs: number | undefined
+  for (const forcePush of forcePushes) {
+    const createdAtMs = Date.parse(forcePush.createdAt)
+    if (
+      !Number.isFinite(createdAtMs) ||
+      createdAtMs < pullRequestCreatedAtMs ||
+      createdAtMs > nowMs ||
+      forcePush.beforeSha === forcePush.afterSha ||
+      (previous !== undefined && previous.afterSha !== forcePush.beforeSha) ||
+      (previousCreatedAtMs !== undefined && createdAtMs <= previousCreatedAtMs)
+    ) {
+      return null
+    }
+    previous = forcePush
+    previousCreatedAtMs = createdAtMs
+  }
+
+  if (previous !== undefined && previous.afterSha !== pullRequest.headSha) return null
+  return Math.max(pullRequestCreatedAtMs, headCommittedAtMs, previousCreatedAtMs ?? Number.NEGATIVE_INFINITY)
+}
+
 const exactHeadCodexAttestation = (
   snapshot: BaynPromotionEligibilitySnapshot,
   nowMs: number,
 ): BaynPromotionReview | undefined => {
   const pullRequest = snapshot.pullRequest
-  const comment = snapshot.issueComments
+  const comments = snapshot.issueComments
     .filter((candidate) => {
       if (
         candidate.authorLogin !== baynPromotionCodexBotLogin ||
@@ -312,30 +348,32 @@ const exactHeadCodexAttestation = (
       const reviewedHead = cleanCodexCommentPattern.exec(candidate.body)?.[1]
       return reviewedHead !== undefined && pullRequest.headSha.startsWith(reviewedHead)
     })
-    .toSorted((left, right) => right.createdAt.localeCompare(left.createdAt))[0]
-  if (comment !== undefined) {
-    return {
-      authorLogin: baynPromotionCodexReviewer,
-      commitSha: pullRequest.headSha,
-      submittedAt: comment.createdAt,
-      state: 'COMMENTED',
-    }
-  }
+    .map((comment) => comment.createdAt)
 
-  if (pullRequest.commitCount !== 1 || pullRequest.headForcePushCount !== 0) return undefined
-  const reaction = snapshot.reactions
-    .filter(
-      (candidate) =>
-        candidate.userLogin === baynPromotionCodexBotLogin &&
-        candidate.content === '+1' &&
-        timestampWithinOpenPullRequest(candidate.createdAt, pullRequest.createdAt, nowMs),
-    )
-    .toSorted((left, right) => right.createdAt.localeCompare(left.createdAt))[0]
-  if (reaction === undefined) return undefined
+  const headEstablishedAtMs = pullRequest.commitCount === 1 ? exactHeadEstablishedAt(pullRequest, nowMs) : null
+  const reactions =
+    headEstablishedAtMs === null
+      ? []
+      : snapshot.reactions
+          .filter((candidate) => {
+            if (
+              candidate.userLogin !== baynPromotionCodexBotLogin ||
+              candidate.content !== '+1' ||
+              !timestampWithinOpenPullRequest(candidate.createdAt, pullRequest.createdAt, nowMs)
+            ) {
+              return false
+            }
+            const reactionCreatedAtMs = Date.parse(candidate.createdAt)
+            return Number.isFinite(reactionCreatedAtMs) && reactionCreatedAtMs > headEstablishedAtMs
+          })
+          .map((reaction) => reaction.createdAt)
+
+  const attestations = [...comments, ...reactions]
+  if (attestations.length !== 1) return undefined
   return {
     authorLogin: baynPromotionCodexReviewer,
     commitSha: pullRequest.headSha,
-    submittedAt: reaction.createdAt,
+    submittedAt: attestations[0] as string,
     state: 'COMMENTED',
   }
 }
@@ -954,7 +992,7 @@ const apiRepository = (repository: string): string => {
 
 const fetchPullRequest = async (
   options: GitHubRequestOptions & { readonly repository: string; readonly pullNumber: number },
-): Promise<Omit<BaynPromotionPullRequest, 'files' | 'headForcePushCount' | 'headCommittedAt'>> => {
+): Promise<Omit<BaynPromotionPullRequest, 'files' | 'headForcePushes' | 'headCommittedAt'>> => {
   const operation = `read promotion PR #${options.pullNumber}`
   const response = await requestJson({
     ...options,
@@ -1167,7 +1205,14 @@ const headForcePushQuery = `
     repository(owner: $owner, name: $name) {
       pullRequest(number: $number) {
         timelineItems(first: 100, itemTypes: [HEAD_REF_FORCE_PUSHED_EVENT]) {
-          nodes { __typename }
+          nodes {
+            __typename
+            ... on HeadRefForcePushedEvent {
+              createdAt
+              beforeCommit { oid }
+              afterCommit { oid }
+            }
+          }
           pageInfo { hasNextPage endCursor }
         }
       }
@@ -1292,9 +1337,9 @@ const fetchThreads = async (
   )
 }
 
-const fetchHeadForcePushCount = async (
+const fetchHeadForcePushes = async (
   options: GitHubRequestOptions & { readonly repository: string; readonly pullNumber: number },
-): Promise<number> => {
+): Promise<readonly BaynPromotionHeadForcePush[]> => {
   const [owner, name] = repositoryParts(options.repository)
   const operation = `read promotion PR #${options.pullNumber} head-force-push history`
   const data = await requestGraphql({
@@ -1311,13 +1356,21 @@ const fetchHeadForcePushCount = async (
   if (pagination.hasNextPage) {
     throw new GitHubPromotionEligibilityError('github-api-pagination-limit', operation)
   }
+  const forcePushes: BaynPromotionHeadForcePush[] = []
   for (const [index, item] of connection.nodes.entries()) {
     const event = expectRecord(item, `${operation} event ${index}`)
     if (event.__typename !== 'HeadRefForcePushedEvent') {
       throw new GitHubPromotionEligibilityError('github-api-invalid-response', `${operation} event ${index}`)
     }
+    const beforeCommit = expectRecord(event.beforeCommit, `${operation} event ${index} before commit`)
+    const afterCommit = expectRecord(event.afterCommit, `${operation} event ${index} after commit`)
+    forcePushes.push({
+      beforeSha: expectSha(beforeCommit.oid, `${operation} event ${index} before SHA`),
+      afterSha: expectSha(afterCommit.oid, `${operation} event ${index} after SHA`),
+      createdAt: expectTimestamp(event.createdAt, `${operation} event ${index} created at`),
+    })
   }
-  return connection.nodes.length
+  return forcePushes
 }
 
 const fetchIssueComments = async (
@@ -2170,14 +2223,14 @@ export const createGitHubPromotionEligibilityLoader = (options: {
       fetchPullRequest({ ...requestOptions, repository: options.repository, pullNumber: options.pullNumber }),
       fetchPullRequestFiles({ ...requestOptions, repository: options.repository, pullNumber: options.pullNumber }),
     ])
-    const headForcePushCount =
+    const headForcePushes =
       pullRequestWithoutFiles.headRefName === promotionBranch
-        ? await fetchHeadForcePushCount({
+        ? await fetchHeadForcePushes({
             ...requestOptions,
             repository: options.repository,
             pullNumber: options.pullNumber,
           })
-        : 0
+        : []
     const headCommittedAt =
       pullRequestWithoutFiles.headRefName === promotionBranch && pullRequestWithoutFiles.headSha === options.headSha
         ? headCommittedAtCache?.headSha === pullRequestWithoutFiles.headSha
@@ -2189,7 +2242,7 @@ export const createGitHubPromotionEligibilityLoader = (options: {
             })
         : pullRequestWithoutFiles.createdAt
     headCommittedAtCache = { headSha: pullRequestWithoutFiles.headSha, committedAt: headCommittedAt }
-    const pullRequest = { ...pullRequestWithoutFiles, headCommittedAt, headForcePushCount, files }
+    const pullRequest = { ...pullRequestWithoutFiles, headCommittedAt, headForcePushes, files }
     if (pullRequest.headSha !== options.headSha) {
       return {
         repository: options.repository,


### PR DESCRIPTION
## Summary

- replace cumulative force-push-count rejection with bounded immutable force-push history containing exact before/after commit SHAs and event timestamps
- accept a sole trusted connector `+1` only when the force-push chain terminates at the current one-commit promotion head and the reaction occurs strictly after that head was established
- fail closed on stale or broken head history, reactions before or concurrent with the latest force-push, later force-pushes, spoofed actors, and multiple fallback attestations
- add a real-run-shaped regression for PR #13410 (`caee18e8` -> `94ecab66` at 22:57:11Z, clean `+1` at 22:58:50Z) plus adversarial timing and ambiguity coverage

## Related Issues

Related to #13410.

## Testing

- `bun test packages/scripts/src/bayn/verify-promotion-eligibility.test.ts packages/scripts/src/bayn/bayn-promotion-eligibility-workflow.test.ts` — 71 pass
- `bun test packages/scripts/src/bayn` — 152 pass
- targeted TypeScript validation for the verifier and promotion workflow tests — pass
- focused Oxlint and Oxfmt checks — pass
- repository pre-commit lint-staged and commitlint hooks — pass
- `git diff --check` — pass
- read-only live loader reproduction parsed the exact #13410 force-push and connector-reaction timestamps

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
