### PR TITLE
fix(bayn): trigger promotion merge from eligibility

### DIFF
--- a/.github/workflows/bayn-promotion-automerge.yml
+++ b/.github/workflows/bayn-promotion-automerge.yml
@@ -1,6 +1,11 @@
 name: bayn-promotion-automerge
 
 on:
+  workflow_run:
+    workflows:
+      - bayn-promotion-eligibility
+    types:
+      - completed
   schedule:
     - cron: '12,27,42,57 * * * *'
 
@@ -17,6 +22,14 @@ concurrency:
 jobs:
   merge:
     name: Merge verified Bayn promotion
+    if: >-
+      ${{
+        github.event_name == 'schedule' ||
+        (
+          github.event_name == 'workflow_run' &&
+          github.event.workflow_run.conclusion == 'success'
+        )
+      }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/packages/scripts/src/bayn/bayn-promotion-automerge-workflow.test.ts
+++ b/packages/scripts/src/bayn/bayn-promotion-automerge-workflow.test.ts
@@ -12,12 +12,19 @@ const permissions = parsed.permissions as Record<string, string>
 const count = (value: string): number => workflow.split(value).length - 1
 
 describe('Bayn promotion auto-merge workflow', () => {
-  test('owns one serialized unattended schedule with explicit merge authority', () => {
+  test('owns serialized eligibility-completion and repair-schedule triggers with explicit merge authority', () => {
     expect(parsed.name).toBe('bayn-promotion-automerge')
+    expect(events.workflow_run).toEqual({
+      workflows: ['bayn-promotion-eligibility'],
+      types: ['completed'],
+    })
     expect(events.schedule).toEqual([{ cron: '12,27,42,57 * * * *' }])
     expect(workflow).not.toContain('workflow_dispatch:')
     expect(workflow).not.toContain('pull_request_target:')
     expect(workflow).not.toContain('\n  push:')
+    expect(workflow).toContain("github.event_name == 'schedule'")
+    expect(workflow).toContain("github.event_name == 'workflow_run'")
+    expect(workflow).toContain("github.event.workflow_run.conclusion == 'success'")
     expect(workflow).toContain('group: bayn-promotion-automerge')
     expect(workflow).toContain('cancel-in-progress: false')
     expect(permissions).toEqual({
@@ -28,7 +35,7 @@ describe('Bayn promotion auto-merge workflow', () => {
     })
   })
 
-  test('checks out only the trusted schedule revision and refuses a stale main policy', () => {
+  test('checks out only the trusted default-branch revision and refuses a stale main policy', () => {
     expect(workflow).toContain('name: Checkout trusted current-main merge policy')
     expect(workflow).toContain('ref: ${{ github.sha }}')
     expect(workflow).toContain('persist-credentials: false')

--- a/packages/scripts/src/bayn/verify-promotion-automerge.test.ts
+++ b/packages/scripts/src/bayn/verify-promotion-automerge.test.ts
@@ -9,15 +9,15 @@ import {
 } from './verify-promotion-automerge'
 
 const repository = 'proompteng/lab'
-const headSha = '6ef7fd4d86e27a3ddf805b535f72200f744bce0f'
-const baseSha = '8908acdfbda84e4b35d6ce8c918d87efbca6b8db'
+const headSha = 'a'.repeat(40)
+const baseSha = 'b'.repeat(40)
 const pullNumber = 13_411
 
 const check = (workflow: string, name: string, state = 'SUCCESS') => ({
   workflow,
   name,
   state,
-  link: `https://github.com/${repository}/actions/runs/30593833143/job/91042241936`,
+  link: `https://github.com/${repository}/actions/runs/123456/job/789012`,
 })
 
 const snapshot = (): BaynPromotionAutomergeSnapshot => ({


### PR DESCRIPTION
## Summary

- trigger the trusted standing Bayn promotion merger immediately after successful promotion eligibility completion
- retain the serialized cron schedule as repair while ignoring unsuccessful eligibility runs
- replace operational-looking historical test identifiers with explicitly synthetic fixture values

## Related Issues

None

## Testing

- bun test packages/scripts/src/bayn/verify-promotion-automerge.test.ts packages/scripts/src/bayn/bayn-promotion-automerge-workflow.test.ts (15 passed)
- bun test packages/scripts/src/bayn (176 passed)
- bunx oxlint --config .oxlintrc.json --type-aware --tsconfig packages/scripts/tsconfig.json packages/scripts/src/bayn/bayn-promotion-automerge-workflow.test.ts
- bunx oxfmt --check .github/workflows/bayn-promotion-automerge.yml packages/scripts/src/bayn/verify-promotion-automerge.test.ts packages/scripts/src/bayn/bayn-promotion-automerge-workflow.test.ts
- actionlint .github/workflows/bayn-promotion-automerge.yml
- observed zero scheduled bayn-promotion-automerge runs across the 05:27, 05:42, and 05:57 UTC windows while workflow state remained active

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; this is a workflow trigger correction.
- [x] Documentation and release notes are not required; the workflow and regression tests are the operational contract.