### PR TITLE
fix(bayn): retry promotion merge after final checks

### DIFF
--- a/.github/workflows/bayn-promotion-automerge.yml
+++ b/.github/workflows/bayn-promotion-automerge.yml
@@ -4,6 +4,7 @@ on:
   workflow_run:
     workflows:
       - bayn-promotion-eligibility
+      - bayn
     types:
       - completed
   schedule:

--- a/packages/scripts/src/bayn/bayn-promotion-automerge-workflow.test.ts
+++ b/packages/scripts/src/bayn/bayn-promotion-automerge-workflow.test.ts
@@ -15,7 +15,7 @@ describe('Bayn promotion auto-merge workflow', () => {
   test('owns serialized eligibility-completion and repair-schedule triggers with explicit merge authority', () => {
     expect(parsed.name).toBe('bayn-promotion-automerge')
     expect(events.workflow_run).toEqual({
-      workflows: ['bayn-promotion-eligibility'],
+      workflows: ['bayn-promotion-eligibility', 'bayn'],
       types: ['completed'],
     })
     expect(events.schedule).toEqual([{ cron: '12,27,42,57 * * * *' }])


### PR DESCRIPTION
## Summary

- trigger Bayn promotion auto-merge after the final `bayn` workflow completes as well as after eligibility
- close the measured race where eligibility completed while required Bayn checks were still pending
- preserve the existing serialized, exact-head, fail-closed merge verifier and scheduled repair path

## Related Issues

None

## Testing

- `bun test packages/scripts/src/bayn/bayn-promotion-automerge-workflow.test.ts packages/scripts/src/bayn/verify-promotion-automerge.test.ts` (15 passed)
- `bun test packages/scripts/src/bayn` (176 passed)
- `actionlint .github/workflows/bayn-promotion-automerge.yml`
- `bunx oxfmt --check .github/workflows/bayn-promotion-automerge.yml packages/scripts/src/bayn/bayn-promotion-automerge-workflow.test.ts`
- `bunx oxlint --type-aware packages/scripts/src/bayn/bayn-promotion-automerge-workflow.test.ts`
- observed eligibility-triggered run 30608951030 fail closed with `pull-request-not-mergeable` while `bayn` run 30608812973 still had required checks pending; that workflow completed successfully 15 seconds later

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] No documentation or release-note update is required for this focused workflow correction.