### PR TITLE
fix(bayn): preserve release branch after promotion

### DIFF
--- a/.github/workflows/bayn-promotion-automerge.yml
+++ b/.github/workflows/bayn-promotion-automerge.yml
@@ -68,9 +68,11 @@ jobs:
           fi
 
           repository_owner="${GITHUB_REPOSITORY%%/*}"
+          release_branch='codex/bayn-release-current'
+          release_ref="refs/heads/${release_branch}"
           pulls="$(
             gh api \
-              "repos/${GITHUB_REPOSITORY}/pulls?state=open&base=main&head=${repository_owner}:codex/bayn-release-current&per_page=100"
+              "repos/${GITHUB_REPOSITORY}/pulls?state=open&base=main&head=${repository_owner}:${release_branch}&per_page=100"
           )"
           pull_count="$(jq 'length' <<< "${pulls}")"
           if [[ "${pull_count}" == '0' ]]; then
@@ -224,4 +226,39 @@ jobs:
             echo "PR #${pull_number} did not report an exact-head merged state." >&2
             exit 1
           fi
+
+          branch_error="${RUNNER_TEMP}/bayn-promotion-automerge-branch-error"
+          set +e
+          preserved_head_sha="$(
+            gh api \
+              "repos/${GITHUB_REPOSITORY}/git/ref/heads/${release_branch}" \
+              --jq '.object.sha' \
+              2>"${branch_error}"
+          )"
+          branch_status="$?"
+          set -e
+          if [[ "${branch_status}" != '0' ]]; then
+            if ! grep -Fq '(HTTP 404)' "${branch_error}"; then
+              cat "${branch_error}" >&2
+              echo "Unable to read preserved Bayn release branch after merging PR #${pull_number}." >&2
+              exit 1
+            fi
+            gh api \
+              --method POST \
+              "repos/${GITHUB_REPOSITORY}/git/refs" \
+              -f ref="${release_ref}" \
+              -f sha="${expected_head_sha}" \
+              >/dev/null
+          fi
+
+          preserved_head_sha="$(
+            gh api \
+              "repos/${GITHUB_REPOSITORY}/git/ref/heads/${release_branch}" \
+              --jq '.object.sha'
+          )"
+          if [[ "${preserved_head_sha}" != "${expected_head_sha}" ]]; then
+            echo "Preserved Bayn release branch is not bound to merged head ${expected_head_sha}." >&2
+            exit 1
+          fi
           echo "BAYN_PROMOTION_AUTOMERGED pr=#${pull_number} head=${merged_head_sha} merged_at=${merged_at}"
+          echo "BAYN_PROMOTION_BRANCH_PRESERVED ref=${release_ref} head=${preserved_head_sha}"

--- a/packages/scripts/src/bayn/bayn-promotion-automerge-workflow.test.ts
+++ b/packages/scripts/src/bayn/bayn-promotion-automerge-workflow.test.ts
@@ -48,9 +48,9 @@ describe('Bayn promotion auto-merge workflow', () => {
   })
 
   test('discovers exactly one same-repository preserved release branch', () => {
-    expect(workflow).toContain(
-      'pulls?state=open&base=main&head=${repository_owner}:codex/bayn-release-current&per_page=100',
-    )
+    expect(workflow).toContain("release_branch='codex/bayn-release-current'")
+    expect(workflow).toContain('release_ref="refs/heads/${release_branch}"')
+    expect(workflow).toContain('pulls?state=open&base=main&head=${repository_owner}:${release_branch}&per_page=100')
     expect(workflow).toContain('Expected exactly one preserved Bayn promotion PR')
     expect(workflow).toContain('No open Bayn promotion PR is ready for automatic merge.')
     expect(workflow).toContain('[[ ! "${expected_head_sha}" =~ ^[0-9a-f]{40}$ ]]')
@@ -114,7 +114,21 @@ describe('Bayn promotion auto-merge workflow', () => {
     expect(workflow).not.toContain('--delete-branch')
     expect(workflow).not.toContain('git push')
     expect(workflow).toContain("merged_state}\" != 'MERGED'")
+    expect(workflow).toContain('"repos/${GITHUB_REPOSITORY}/git/ref/heads/${release_branch}"')
+    expect(workflow).toContain('--method POST')
+    expect(workflow).toContain('"repos/${GITHUB_REPOSITORY}/git/refs"')
+    expect(workflow).toContain('-f ref="${release_ref}"')
+    expect(workflow).toContain('-f sha="${expected_head_sha}"')
+    expect(workflow).toContain('preserved_head_sha}" != "${expected_head_sha}')
+    expect(workflow).not.toContain('--method DELETE')
     expect(workflow).toContain('BAYN_PROMOTION_AUTOMERGED')
+    expect(workflow).toContain('BAYN_PROMOTION_BRANCH_PRESERVED')
+
+    const mergeIndex = workflow.indexOf('gh pr merge "${pull_number}"')
+    const restoreIndex = workflow.indexOf('--method POST')
+    const preservedIndex = workflow.indexOf('BAYN_PROMOTION_BRANCH_PRESERVED')
+    expect(mergeIndex).toBeLessThan(restoreIndex)
+    expect(restoreIndex).toBeLessThan(preservedIndex)
   })
 
   test('does not mutate repository or cluster security policy', () => {


### PR DESCRIPTION
## Summary

- restore the exact merged `codex/bayn-release-current` ref when repository-wide auto-delete removes it after promotion
- verify the restored branch points to the immutable reviewed promotion head before reporting success
- fail closed on non-404 ref-read errors, creation failures, or any resulting head mismatch

## Related Issues

None

## Testing

- `bun test packages/scripts/src/bayn/bayn-promotion-automerge-workflow.test.ts packages/scripts/src/bayn/verify-promotion-automerge.test.ts` (15 passed)
- `bun test packages/scripts/src/bayn` (176 passed)
- `actionlint .github/workflows/bayn-promotion-automerge.yml`
- `bunx oxfmt --check .github/workflows/bayn-promotion-automerge.yml packages/scripts/src/bayn/bayn-promotion-automerge-workflow.test.ts`
- `bunx oxlint --type-aware packages/scripts/src/bayn/bayn-promotion-automerge-workflow.test.ts`
- live auto-merge run 30609651264 merged #13411 at exact head `59dee866deaac3646831491bb426dd14c17d4afc`; direct Git and GraphQL reads then proved the release branch absent while repository `deleteBranchOnMerge` was true

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] No documentation or release-note update is required for this focused workflow correction.