### PR TITLE
chore(bayn): promote image sha-460b98d4db2d18134a97a98cb5b716a487b806cc

### DIFF
--- a/argocd/applications/bayn/deployment.yaml
+++ b/argocd/applications/bayn/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         app.kubernetes.io/name: bayn
         app.kubernetes.io/part-of: bayn
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-07-31T06:22:53Z"
+        kubectl.kubernetes.io/restartedAt: "2026-07-31T06:37:27Z"
     spec:
       serviceAccountName: bayn
       automountServiceAccountToken: false
@@ -47,11 +47,11 @@ spec:
               protocol: TCP
           env:
             - name: BAYN_CODE_REVISION
-              value: 11f101786021a0c5ee683066b5221365d6843e33
+              value: 460b98d4db2d18134a97a98cb5b716a487b806cc
             - name: BAYN_IMAGE_REPOSITORY
               value: registry.ide-newton.ts.net/lab/bayn
             - name: BAYN_IMAGE_DIGEST
-              value: sha256:296e4e92461eb460b8280014f7fa7539f098f16e3ccc4aefd5ac90661c42c6ff
+              value: sha256:0fbdad29c067f265996531195ae35060cc29698ab39a8ed701a1ccff65e19b96
             - name: BAYN_STRATEGY_BEHAVIOR_HASH
               value: "9e87fe0f66048c48da2191ef1fae36ef3ee0eb4ddcd036ef40881f0fe0f6eb42"
             - name: BAYN_STRATEGY_PARAMETER_HASH

--- a/argocd/applications/bayn/kustomization.yaml
+++ b/argocd/applications/bayn/kustomization.yaml
@@ -22,5 +22,5 @@ configMapGenerator:
 images:
   - name: registry.ide-newton.ts.net/lab/bayn
     newName: registry.ide-newton.ts.net/lab/bayn
-    newTag: "sha-11f101786021a0c5ee683066b5221365d6843e33"
-    digest: sha256:296e4e92461eb460b8280014f7fa7539f098f16e3ccc4aefd5ac90661c42c6ff
+    newTag: "sha-460b98d4db2d18134a97a98cb5b716a487b806cc"
+    digest: sha256:0fbdad29c067f265996531195ae35060cc29698ab39a8ed701a1ccff65e19b96


### PR DESCRIPTION
## Summary

Promote the immutable Bayn image against the current Signal snapshot and dedicated Bayn TigerBeetle
ledger. Qualification-pin handling is selected from the verified compiled behavior identity.

- Source commit: `460b98d4db2d18134a97a98cb5b716a487b806cc`
- Image tag: `sha-460b98d4db2d18134a97a98cb5b716a487b806cc`
- Image digest: `sha256:0fbdad29c067f265996531195ae35060cc29698ab39a8ed701a1ccff65e19b96`
- Qualification mode: `preserve`
- Existing pin: `true`
- Qualification identity bindings match: `true`
- Snapshot changed: `false`
- Deployed snapshot: `2a91f0177684f7022f746207333e510c8268f9b77a04b778a04220a33ccf79e0`
- Candidate snapshot: `2a91f0177684f7022f746207333e510c8268f9b77a04b778a04220a33ccf79e0`
- Deployed behavior hash: `9e87fe0f66048c48da2191ef1fae36ef3ee0eb4ddcd036ef40881f0fe0f6eb42`
- Candidate behavior hash: `9e87fe0f66048c48da2191ef1fae36ef3ee0eb4ddcd036ef40881f0fe0f6eb42`
- Deployed parameter hash: `19bc51c7361b181aa48845d178cb63373b3f2e017bcbea1cf3b70ab16647f8a9`
- Candidate parameter hash: `19bc51c7361b181aa48845d178cb63373b3f2e017bcbea1cf3b70ab16647f8a9`

## Related Issues

PROOMPT-400

## Testing

- OCI index contains `linux/amd64` and `linux/arm64`.

## Screenshots (if applicable)

N/A

## Breaking Changes

This is a one-way current-contract runtime release. Databases with the old migration tracker are rejected;
there is no schema fallback or automatic rename. `preserve` keeps the terminal run only when compiled
behavior, protocol parameters, Signal inputs, TigerBeetle cluster ID, and TigerBeetle ledger all match.
Replica addresses are transport and an explicit candidate may change them without relabeling qualification
evidence. `replace` removes an existing incompatible pin only for a fresh Signal snapshot. `install` is
available only to a controlled invocation that supplies the complete reviewed candidate runtime and exact
independently accepted terminal run ID; automatic image promotion supplies neither and therefore never
creates a pin. Installation can pin only the exact source, image digest, compiled strategy, and runtime
already deployed without a pin. It cannot replace an old pin and advance to a fresh candidate in the same
change.

## Checklist

- [x] Testing section documents exact validation.
- [x] Runtime source revision and image digest are immutable.
- [x] No broker or capital-promotion authority is introduced.