### PR TITLE
feat(bayn): automate governed qualification eligibility

### DIFF
--- a/.github/workflows/bayn-qualification.yml
+++ b/.github/workflows/bayn-qualification.yml
@@ -1,0 +1,66 @@
+name: bayn-qualification
+
+on:
+  schedule:
+    - cron: '17 * * * *'
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  group: bayn-qualification-exactly-once
+  cancel-in-progress: false
+
+jobs:
+  eligibility:
+    name: Verify governed qualification eligibility
+    runs-on: arc-arm64
+    timeout-minutes: 10
+    steps:
+      - name: Reject manual invocation
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          echo 'Manual qualification dispatch is forbidden.' >&2
+          exit 1
+
+      - name: Checkout exact scheduled main
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Verify dormant calendar before any privileged access
+        id: calendar
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "${GITHUB_SHA}"
+          if rg -n 'nextCandidatePreregistration: null' services/bayn/src/candidate-development-calendar.ts >/dev/null; then
+            echo 'PROOMPT-407 has not installed a reviewed non-null preregistration; qualification remains dormant.'
+            echo 'dormant=true' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo 'dormant=false' >> "$GITHUB_OUTPUT"
+
+      - name: Stop safely while preregistration is absent
+        if: steps.calendar.outputs.dormant == 'true'
+        run: echo 'No credentials, Signal data, PostgreSQL state, holdout, or qualification command were accessed.'
+
+      - name: Require separately installed immutable evidence collector
+        if: steps.calendar.outputs.dormant != 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo 'A non-null preregistration exists, but execution stays fail-closed until the reviewed evidence collector writes /run/bayn-qualification/eligibility-input.json.' >&2
+          test -s /run/bayn-qualification/eligibility-input.json
+          bun packages/scripts/src/bayn/verify-qualification-eligibility.ts \
+            --input /run/bayn-qualification/eligibility-input.json
+          echo 'Eligibility verified. The existing governed qualification command must be invoked by the same reviewed collector only after its durable attempt lock is committed.'

--- a/packages/scripts/src/bayn/verify-qualification-eligibility.test.ts
+++ b/packages/scripts/src/bayn/verify-qualification-eligibility.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from 'bun:test'
+
+import {
+  evaluateQualificationEligibility,
+  type QualificationEligibilityInput,
+} from './verify-qualification-eligibility'
+
+const h = (value: string) => value.repeat(64).slice(0, 64)
+const r = (value: string) => value.repeat(40).slice(0, 40)
+
+const fixture = (): QualificationEligibilityInput => ({
+  eventName: 'schedule',
+  repository: 'proompteng/lab',
+  currentMainSha: r('a'),
+  workflowSha: r('a'),
+  sourceSha: r('a'),
+  imageRepository: 'registry.example/bayn',
+  imageDigest: `sha256:${h('b')}`,
+  strategyBehaviorHash: h('c'),
+  strategyParameterHash: h('d'),
+  preregistrationBlobOid: r('e'),
+  preregistration: {
+    schemaVersion: 'bayn.candidate-development-next-preregistration.v1',
+    candidateOrdinal: 17,
+    priorTrialCount: 16,
+    strategyProtocolHash: h('f'),
+    modulePath: 'services/bayn/src/strategy/candidate-17.ts',
+    moduleSha256: h('1'),
+    marketData: {
+      schemaVersion: 'bayn.candidate-development-market-data-source.v1',
+      snapshotId: h('2'),
+      finalizedSnapshotContentHash: h('3'),
+      inputManifestHash: h('4'),
+      boundedContentHash: h('5'),
+    },
+    preregistration: { sourceRevision: r('6'), path: 'candidate.json', blobOid: r('e') },
+  },
+  publication: {
+    natural: true,
+    completed: true,
+    publicationDate: '2026-08-01',
+    sourceSha: r('a'),
+    imageDigest: `sha256:${h('b')}`,
+    snapshotId: h('2'),
+    finalizedSnapshotContentHash: h('3'),
+    inputManifestHash: h('4'),
+    boundedContentHash: h('5'),
+  },
+  attempts: [],
+  database: { lockCount: 0, resultCount: 0, trialCount: 16 },
+})
+
+describe('qualification eligibility', () => {
+  test('is safely dormant before a reviewed preregistration exists', () => {
+    expect(evaluateQualificationEligibility({ ...fixture(), preregistration: null })).toEqual({
+      status: 'dormant',
+      code: 'preregistration-missing',
+    })
+  })
+
+  test('accepts one exact pristine natural publication', () => {
+    const result = evaluateQualificationEligibility(fixture())
+    expect(result.status).toBe('eligible')
+    if (result.status === 'eligible') expect(result.eligibilityHash).toMatch(/^[0-9a-f]{64}$/)
+  })
+
+  test('rejects manual dispatch before qualification access', () => {
+    expect(evaluateQualificationEligibility({ ...fixture(), eventName: 'workflow_dispatch' })).toMatchObject({
+      status: 'hold',
+      code: 'manual-dispatch-rejected',
+    })
+  })
+
+  test.each([
+    ['changed head', { currentMainSha: r('9') }, 'source-head-mismatch'],
+    ['changed preregistration', { preregistrationBlobOid: r('9') }, 'preregistration-invalid'],
+    [
+      'stale publication source',
+      { publication: { ...fixture().publication!, sourceSha: r('9') } },
+      'publication-source-mismatch',
+    ],
+    [
+      'changed data',
+      { publication: { ...fixture().publication!, boundedContentHash: h('9') } },
+      'publication-data-mismatch',
+    ],
+    ['prior lock', { database: { lockCount: 1, resultCount: 0, trialCount: 16 } }, 'database-state-not-pristine'],
+    ['prior result', { database: { lockCount: 0, resultCount: 1, trialCount: 16 } }, 'database-state-not-pristine'],
+    [
+      'in-flight run',
+      { attempts: [{ candidateOrdinal: 17, status: 'in_progress' as const, conclusion: null }] },
+      'prior-or-inflight-attempt',
+    ],
+    [
+      'duplicate completed run',
+      { attempts: [{ candidateOrdinal: 17, status: 'completed' as const, conclusion: 'failure' }] },
+      'prior-or-inflight-attempt',
+    ],
+  ])('rejects %s', (_name, patch, code) => {
+    expect(evaluateQualificationEligibility({ ...fixture(), ...patch })).toMatchObject({ status: 'hold', code })
+  })
+})

--- a/packages/scripts/src/bayn/verify-qualification-eligibility.ts
+++ b/packages/scripts/src/bayn/verify-qualification-eligibility.ts
@@ -1,0 +1,214 @@
+#!/usr/bin/env bun
+
+import { createHash } from 'node:crypto'
+import { readFile } from 'node:fs/promises'
+import process from 'node:process'
+
+export interface QualificationPreregistration {
+  readonly schemaVersion: 'bayn.candidate-development-next-preregistration.v1'
+  readonly candidateOrdinal: number
+  readonly priorTrialCount: number
+  readonly strategyProtocolHash: string
+  readonly modulePath: string
+  readonly moduleSha256: string
+  readonly marketData: {
+    readonly schemaVersion: 'bayn.candidate-development-market-data-source.v1'
+    readonly snapshotId: string
+    readonly finalizedSnapshotContentHash: string
+    readonly inputManifestHash: string
+    readonly boundedContentHash: string
+  }
+  readonly preregistration: {
+    readonly sourceRevision: string
+    readonly path: string
+    readonly blobOid: string
+  }
+}
+
+export interface QualificationEligibilityInput {
+  readonly eventName: string
+  readonly repository: string
+  readonly currentMainSha: string
+  readonly workflowSha: string
+  readonly sourceSha: string
+  readonly imageRepository: string
+  readonly imageDigest: string
+  readonly strategyBehaviorHash: string
+  readonly strategyParameterHash: string
+  readonly preregistration: QualificationPreregistration | null
+  readonly preregistrationBlobOid: string | null
+  readonly publication: null | {
+    readonly natural: boolean
+    readonly completed: boolean
+    readonly publicationDate: string
+    readonly sourceSha: string
+    readonly imageDigest: string
+    readonly snapshotId: string
+    readonly finalizedSnapshotContentHash: string
+    readonly inputManifestHash: string
+    readonly boundedContentHash: string
+  }
+  readonly attempts: readonly {
+    readonly candidateOrdinal: number
+    readonly status: 'queued' | 'in_progress' | 'completed'
+    readonly conclusion: string | null
+  }[]
+  readonly database: {
+    readonly lockCount: number
+    readonly resultCount: number
+    readonly trialCount: number
+  }
+}
+
+export type QualificationEligibilityResult =
+  | { readonly status: 'dormant'; readonly code: 'preregistration-missing' }
+  | { readonly status: 'hold'; readonly code: string; readonly message: string }
+  | {
+      readonly status: 'eligible'
+      readonly candidateOrdinal: number
+      readonly sourceSha: string
+      readonly imageRepository: string
+      readonly imageDigest: string
+      readonly publicationDate: string
+      readonly snapshotId: string
+      readonly eligibilityHash: string
+    }
+
+const sha40 = /^[0-9a-f]{40}$/
+const sha64 = /^[0-9a-f]{64}$/
+const digest = /^sha256:[0-9a-f]{64}$/
+const isoDate = /^\d{4}-\d{2}-\d{2}$/
+
+const canonical = (value: unknown): string => {
+  if (Array.isArray(value)) return `[${value.map(canonical).join(',')}]`
+  if (value !== null && typeof value === 'object') {
+    const record = value as Record<string, unknown>
+    return `{${Object.keys(record)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${canonical(record[key])}`)
+      .join(',')}}`
+  }
+  return JSON.stringify(value)
+}
+
+const hold = (code: string, message: string): QualificationEligibilityResult => ({ status: 'hold', code, message })
+
+export const evaluateQualificationEligibility = (
+  input: QualificationEligibilityInput,
+): QualificationEligibilityResult => {
+  if (input.preregistration === null) return { status: 'dormant', code: 'preregistration-missing' }
+  if (input.eventName === 'workflow_dispatch') return hold('manual-dispatch-rejected', 'manual dispatch is forbidden')
+  if (input.eventName !== 'schedule') return hold('event-not-trusted', `unexpected event ${input.eventName}`)
+  if (
+    !sha40.test(input.currentMainSha) ||
+    input.currentMainSha !== input.workflowSha ||
+    input.currentMainSha !== input.sourceSha
+  ) {
+    return hold('source-head-mismatch', 'workflow, source, and current main must be the same exact revision')
+  }
+  if (!digest.test(input.imageDigest) || input.imageRepository.length === 0) {
+    return hold('image-binding-invalid', 'image repository and digest must be immutable')
+  }
+  if (!sha64.test(input.strategyBehaviorHash) || !sha64.test(input.strategyParameterHash)) {
+    return hold('strategy-binding-invalid', 'strategy hashes must be lowercase SHA-256 values')
+  }
+  const registration = input.preregistration
+  if (
+    registration.schemaVersion !== 'bayn.candidate-development-next-preregistration.v1' ||
+    registration.candidateOrdinal !== registration.priorTrialCount + 1 ||
+    registration.candidateOrdinal < 1 ||
+    !sha64.test(registration.strategyProtocolHash) ||
+    !sha64.test(registration.moduleSha256) ||
+    !sha40.test(registration.preregistration.sourceRevision) ||
+    !sha40.test(registration.preregistration.blobOid) ||
+    registration.preregistration.sourceRevision === input.currentMainSha ||
+    input.preregistrationBlobOid !== registration.preregistration.blobOid
+  ) {
+    return hold('preregistration-invalid', 'preregistration identity or immutable blob binding is invalid')
+  }
+  if (input.publication === null)
+    return hold('publication-missing', 'no post-preregistration natural publication exists')
+  const publication = input.publication
+  if (!publication.natural || !publication.completed || !isoDate.test(publication.publicationDate)) {
+    return hold('publication-not-natural', 'publication must be a completed natural scheduled publication')
+  }
+  if (publication.sourceSha !== input.currentMainSha || publication.imageDigest !== input.imageDigest) {
+    return hold('publication-source-mismatch', 'publication does not bind exact current source and image')
+  }
+  if (
+    publication.snapshotId !== registration.marketData.snapshotId ||
+    publication.finalizedSnapshotContentHash !== registration.marketData.finalizedSnapshotContentHash ||
+    publication.inputManifestHash !== registration.marketData.inputManifestHash ||
+    publication.boundedContentHash !== registration.marketData.boundedContentHash
+  ) {
+    return hold('publication-data-mismatch', 'publication data hashes differ from preregistration')
+  }
+  if (
+    !sha64.test(publication.snapshotId) ||
+    !sha64.test(publication.finalizedSnapshotContentHash) ||
+    !sha64.test(publication.inputManifestHash) ||
+    !sha64.test(publication.boundedContentHash)
+  ) {
+    return hold('publication-evidence-invalid', 'publication evidence is malformed')
+  }
+  const matchingAttempts = input.attempts.filter(
+    (attempt) => attempt.candidateOrdinal === registration.candidateOrdinal,
+  )
+  if (matchingAttempts.length !== 0) {
+    return hold('prior-or-inflight-attempt', 'candidate ordinal already has a queued, in-flight, or terminal attempt')
+  }
+  if (
+    input.database.lockCount !== 0 ||
+    input.database.resultCount !== 0 ||
+    input.database.trialCount !== registration.priorTrialCount
+  ) {
+    return hold(
+      'database-state-not-pristine',
+      'qualification database state is not the exact preregistered zero-attempt state',
+    )
+  }
+  const subject = {
+    candidateOrdinal: registration.candidateOrdinal,
+    sourceSha: input.sourceSha,
+    imageRepository: input.imageRepository,
+    imageDigest: input.imageDigest,
+    strategyBehaviorHash: input.strategyBehaviorHash,
+    strategyParameterHash: input.strategyParameterHash,
+    strategyProtocolHash: registration.strategyProtocolHash,
+    modulePath: registration.modulePath,
+    moduleSha256: registration.moduleSha256,
+    preregistration: registration.preregistration,
+    publication,
+  }
+  return {
+    status: 'eligible',
+    candidateOrdinal: registration.candidateOrdinal,
+    sourceSha: input.sourceSha,
+    imageRepository: input.imageRepository,
+    imageDigest: input.imageDigest,
+    publicationDate: publication.publicationDate,
+    snapshotId: publication.snapshotId,
+    eligibilityHash: createHash('sha256').update(canonical(subject)).digest('hex'),
+  }
+}
+
+const parseArgs = (): { input: string } => {
+  const index = process.argv.indexOf('--input')
+  if (index < 0 || !process.argv[index + 1]) throw new Error('--input is required')
+  return { input: process.argv[index + 1]! }
+}
+
+if (import.meta.main) {
+  try {
+    const args = parseArgs()
+    const input = JSON.parse(await readFile(args.input, 'utf8')) as QualificationEligibilityInput
+    const result = evaluateQualificationEligibility(input)
+    process.stdout.write(`${JSON.stringify(result)}\n`)
+    if (result.status === 'hold') process.exitCode = 1
+  } catch (error) {
+    process.stderr.write(
+      `qualification eligibility verification failed: ${error instanceof Error ? error.message : String(error)}\n`,
+    )
+    process.exitCode = 1
+  }
+}


### PR DESCRIPTION
## Summary
- add a scheduled, non-cancellable Bayn qualification eligibility workflow
- reject manual dispatch and remain credential/data dormant while the calendar preregistration is null
- add a deterministic fail-closed verifier binding exact main/source/image/strategy/module/data/preregistration evidence
- reject prior/in-flight attempts and non-pristine lock/result/trial state

## Validation
- bun test packages/scripts/src/bayn/verify-qualification-eligibility.test.ts
- bun test packages/scripts/src/bayn/*.test.ts (187 pass)
- bun run --cwd packages/scripts lint:oxlint:type
- bun run --cwd packages/scripts lint

PROOMPT-437