### PR TITLE
feat(bayn): add dormant fail-closed PAPER activation contract

### DIFF
--- a/.github/workflows/bayn-paper-activation.yml
+++ b/.github/workflows/bayn-paper-activation.yml
@@ -1,0 +1,1992 @@
+name: bayn-paper-activation
+run-name: >-
+  ${{
+    github.event_name == 'workflow_run' &&
+    format(
+      'bayn-paper-activation-qualification-{0}-{1}',
+      github.event.workflow_run.id,
+      github.event.workflow_run.run_attempt
+    ) ||
+    'bayn-paper-rollback-watchdog'
+  }}
+
+# GitHub loads workflow_run and schedule workflows from the default branch.
+# GITHUB_TOKEN remains read-only. The existing non-recursive token is exposed
+# only to those trusted default-branch runs after the activation evidence is
+# authenticated and the mandatory OBSERVE rollback is precommitted.
+permissions:
+  actions: read
+  contents: read
+
+on:
+  workflow_run:
+    workflows:
+      - bayn-qualification
+    types:
+      - completed
+    branches:
+      - main
+  schedule:
+    - cron: '3,8,13,18,23,28,33,38,43,48,53,58 * * * *'
+
+concurrency:
+  group: >-
+    ${{
+      github.event_name == 'schedule' &&
+      'bayn-paper-rollback-watchdog' ||
+      format(
+        'bayn-paper-activation-qualification-{0}-{1}',
+        github.event.workflow_run.id,
+        github.event.workflow_run.run_attempt
+      )
+    }}
+  cancel-in-progress: false
+
+jobs:
+  verify-and-prepare:
+    name: Verify and precommit bounded PAPER transition
+    if: >-
+      github.event_name == 'workflow_run' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'schedule' &&
+      github.event.workflow_run.head_branch == 'main'
+    runs-on: arc-arm64
+    timeout-minutes: 20
+    outputs:
+      live: ${{ steps.identity.outputs.live }}
+      activation_id: ${{ steps.identity.outputs.activation_id }}
+      current_main_sha: ${{ steps.identity.outputs.current_main_sha }}
+      authority_expires_at: ${{ steps.contract.outputs.authority_expires_at }}
+      qualification_expires_at: ${{ steps.contract.outputs.qualification_expires_at }}
+      authority_generation_hash: ${{ steps.contract.outputs.authority_generation_hash }}
+      source_sha: ${{ steps.contract.outputs.source_sha }}
+      image_digest: ${{ steps.contract.outputs.image_digest }}
+      baseline_cycle_id: ${{ steps.baseline.outputs.baseline_cycle_id }}
+      observe_authority_generation_hash: ${{ steps.rollback_generation.outputs.observe_authority_generation_hash }}
+      previous_observe_authority_generation_hash: ${{ steps.rollback_generation.outputs.previous_observe_generation_hash }}
+      activation_branch: ${{ steps.gitops.outputs.activation_branch }}
+      activation_commit_sha: ${{ steps.gitops.outputs.activation_commit_sha }}
+      rollback_branch: ${{ steps.gitops.outputs.rollback_branch }}
+      rollback_commit_sha: ${{ steps.gitops.outputs.rollback_commit_sha }}
+      rollback_metadata_b64: ${{ steps.gitops.outputs.rollback_metadata_b64 }}
+      activation_pr: ${{ steps.gitops.outputs.activation_pr }}
+      rollback_pr: ${{ steps.gitops.outputs.rollback_pr }}
+    steps:
+      - name: Checkout exact current main
+        uses: actions/checkout@v5
+        with:
+          ref: main
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Authenticate activation identity and evidence producer
+        id: identity
+        env:
+          ACTIVATION_ID: ${{ format('qualification-{0}-{1}', github.event.workflow_run.id, github.event.workflow_run.run_attempt) }}
+          ARTIFACT_NAME: ${{ format('bayn-paper-activation-evidence-{0}-{1}', github.event.workflow_run.id, github.event.workflow_run.run_attempt) }}
+          EVIDENCE_RUN_ATTEMPT: ${{ github.event.workflow_run.run_attempt }}
+          EVIDENCE_RUN_ID: ${{ github.event.workflow_run.id }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          [[ "${ACTIVATION_ID}" =~ ^[a-z0-9][a-z0-9._-]{0,127}$ ]] || {
+            echo 'BAYN_PAPER_ACTIVATION_HOLD invalid-activation-id: activation id is not canonical' >&2
+            exit 1
+          }
+          [[ "${EVIDENCE_RUN_ID}" =~ ^[1-9][0-9]{0,19}$ ]] || {
+            echo 'BAYN_PAPER_ACTIVATION_HOLD invalid-evidence-run-id: run id is not canonical' >&2
+            exit 1
+          }
+          [[ "${EVIDENCE_RUN_ATTEMPT}" =~ ^[1-9][0-9]{0,9}$ ]] || {
+            echo 'BAYN_PAPER_ACTIVATION_HOLD invalid-evidence-run-attempt: run attempt is not canonical' >&2
+            exit 1
+          }
+          [[ "${ARTIFACT_NAME}" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$ ]] || {
+            echo 'BAYN_PAPER_ACTIVATION_HOLD invalid-artifact-name: artifact name is not canonical' >&2
+            exit 1
+          }
+          current_main_sha="$(gh api "repos/${GITHUB_REPOSITORY}/commits/main" --jq '.sha')"
+          [[ "$(git rev-parse HEAD)" == "${current_main_sha}" ]] || {
+            echo 'BAYN_PAPER_ACTIVATION_HOLD noncurrent-main: checkout is not exact current main' >&2
+            exit 1
+          }
+
+          self_workflow_id="$(gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/bayn-paper-activation.yml" --jq '.id')"
+          prior_runs="$(
+            gh api --paginate \
+              "repos/${GITHUB_REPOSITORY}/actions/workflows/${self_workflow_id}/runs?event=workflow_run&per_page=100"
+          )"
+          duplicate_count="$(
+            jq -s --argjson current "${GITHUB_RUN_ID}" --arg title "bayn-paper-activation-${ACTIVATION_ID}" '
+              [[.[].workflow_runs[]] | .[] | select(.id != $current and .display_title == $title)] | length
+            ' <<< "${prior_runs}"
+          )"
+          [[ "${duplicate_count}" == 0 ]] || {
+            echo 'BAYN_PAPER_ACTIVATION_HOLD activation-already-claimed: an earlier workflow run owns this activation id' >&2
+            exit 1
+          }
+
+          evidence_workflow="$(gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/bayn-qualification.yml")"
+          evidence_run="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${EVIDENCE_RUN_ID}")"
+          evidence_attempt="$(jq -r '.run_attempt' <<< "${evidence_run}")"
+          expected_artifact_name="bayn-paper-activation-evidence-${EVIDENCE_RUN_ID}-${evidence_attempt}"
+          if
+            [[ "$(jq -r '.workflow_id' <<< "${evidence_run}")" != "$(jq -r '.id' <<< "${evidence_workflow}")" ]] ||
+            [[ "$(jq -r '.path' <<< "${evidence_run}")" != '.github/workflows/bayn-qualification.yml' ]] ||
+            [[ "$(jq -r '.event' <<< "${evidence_run}")" != schedule ]] ||
+            [[ "$(jq -r '.status' <<< "${evidence_run}")" != completed ]] ||
+            [[ "$(jq -r '.conclusion' <<< "${evidence_run}")" != success ]] ||
+            [[ "$(jq -r '.head_branch' <<< "${evidence_run}")" != main ]] ||
+            [[ "$(jq -r '.head_sha' <<< "${evidence_run}")" != "${current_main_sha}" ]] ||
+            [[ "$(jq -r '.repository.full_name' <<< "${evidence_run}")" != "${GITHUB_REPOSITORY}" ]] ||
+            [[ "${evidence_attempt}" != "${EVIDENCE_RUN_ATTEMPT}" ]] ||
+            [[ "${ARTIFACT_NAME}" != "${expected_artifact_name}" ]]
+          then
+            echo 'BAYN_PAPER_ACTIVATION_HOLD untrusted-evidence-run: artifact producer is not the designated successful current-main scheduled qualification run' >&2
+            exit 1
+          fi
+          artifacts="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${EVIDENCE_RUN_ID}/artifacts?name=${ARTIFACT_NAME}&per_page=100")"
+          artifact_count="$(jq --arg name "${ARTIFACT_NAME}" '[.artifacts[] | select(.expired == false and .name == $name)] | length' <<< "${artifacts}")"
+          if [[ "${artifact_count}" == 0 ]]; then
+            echo 'No exact activation evidence artifact exists; PAPER activation remains dormant.'
+            {
+              echo "activation_id=${ACTIVATION_ID}"
+              echo "current_main_sha=${current_main_sha}"
+              echo 'live=false'
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          [[ "${artifact_count}" == 1 ]] || {
+            echo 'BAYN_PAPER_ACTIVATION_HOLD evidence-artifact-ambiguous: expected one unexpired exact artifact' >&2
+            exit 1
+          }
+
+          {
+            echo "activation_id=${ACTIVATION_ID}"
+            echo "current_main_sha=${current_main_sha}"
+            echo 'live=true'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Download authenticated immutable activation evidence
+        if: steps.identity.outputs.live == 'true'
+        env:
+          ARTIFACT_NAME: ${{ format('bayn-paper-activation-evidence-{0}-{1}', github.event.workflow_run.id, github.event.workflow_run.run_attempt) }}
+          EVIDENCE_RUN_ID: ${{ github.event.workflow_run.id }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          mkdir -p activation-evidence
+          gh run download "${EVIDENCE_RUN_ID}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --name "${ARTIFACT_NAME}" \
+            --dir activation-evidence
+          test -s activation-evidence/evidence.json
+          test -s activation-evidence/pins.json
+
+      - name: Extract deployment and effective Kustomize pins
+        if: steps.identity.outputs.live == 'true'
+        run: |
+          set -euo pipefail
+          bun packages/scripts/src/bayn/verify-paper-activation.ts \
+            --mode extract-manifest-pins \
+            --deployment argocd/applications/bayn/deployment.yaml \
+            --kustomization argocd/applications/bayn/kustomization.yaml \
+            --output activation-evidence/manifest-pins.json
+
+      - name: Verify exact tuple and fail-closed runtime state
+        id: contract
+        if: steps.identity.outputs.live == 'true'
+        env:
+          ACTIVATION_ID: ${{ steps.identity.outputs.activation_id }}
+          CURRENT_MAIN_SHA: ${{ steps.identity.outputs.current_main_sha }}
+        run: |
+          set -euo pipefail
+          bun packages/scripts/src/bayn/verify-paper-activation.ts \
+            --repository "${GITHUB_REPOSITORY}" \
+            --activation-id "${ACTIVATION_ID}" \
+            --current-main-sha "${CURRENT_MAIN_SHA}" \
+            --evidence activation-evidence/evidence.json \
+            --pins activation-evidence/pins.json \
+            --manifest-pins activation-evidence/manifest-pins.json
+          {
+            echo "authority_expires_at=$(jq -r '.authorityExpiresAt' activation-evidence/evidence.json)"
+            echo "qualification_expires_at=$(jq -r '.qualificationExpiresAt' activation-evidence/evidence.json)"
+            echo "authority_generation_hash=$(jq -r '.authorityGeneration.generationHash' activation-evidence/evidence.json)"
+            echo "image_digest=$(jq -r '.imageDigest' activation-evidence/evidence.json)"
+            echo "source_sha=$(jq -r '.sourceSha' activation-evidence/evidence.json)"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Precommit a fresh OBSERVE rollback generation
+        id: rollback_generation
+        if: steps.identity.outputs.live == 'true'
+        env:
+          ACTIVATION_ID: ${{ steps.identity.outputs.activation_id }}
+          CURRENT_MAIN_SHA: ${{ steps.identity.outputs.current_main_sha }}
+          PAPER_AUTHORITY_GENERATION_HASH: ${{ steps.contract.outputs.authority_generation_hash }}
+        run: |
+          set -euo pipefail
+          previous_observe_generation_hash="$(jq -r '.currentAuthorityGenerationHash' activation-evidence/manifest-pins.json)"
+          bun packages/scripts/src/bayn/verify-paper-activation.ts \
+            --mode derive-observe-rollback \
+            --repository "${GITHUB_REPOSITORY}" \
+            --activation-id "${ACTIVATION_ID}" \
+            --source-main-sha "${CURRENT_MAIN_SHA}" \
+            --previous-observe-generation-hash "${previous_observe_generation_hash}" \
+            --paper-authority-generation-hash "${PAPER_AUTHORITY_GENERATION_HASH}" \
+            --output activation-evidence/observe-rollback-generation.json
+          observe_authority_generation_hash="$(jq -r '.generationHash' activation-evidence/observe-rollback-generation.json)"
+          [[ "${observe_authority_generation_hash}" =~ ^[0-9a-f]{64}$ ]]
+          [[ "${observe_authority_generation_hash}" != "${previous_observe_generation_hash}" ]]
+          [[ "${observe_authority_generation_hash}" != "${PAPER_AUTHORITY_GENERATION_HASH}" ]]
+          {
+            echo "observe_authority_generation_hash=${observe_authority_generation_hash}"
+            echo "previous_observe_generation_hash=${previous_observe_generation_hash}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Render reviewed activation and mandatory OBSERVE rollback
+        if: steps.identity.outputs.live == 'true'
+        run: |
+          set -euo pipefail
+          bun packages/scripts/src/bayn/verify-paper-activation.ts \
+            --mode render-transition \
+            --deployment argocd/applications/bayn/deployment.yaml \
+            --authority-generation-hash "${{ steps.contract.outputs.authority_generation_hash }}" \
+            --observe-authority-generation-hash "${{ steps.rollback_generation.outputs.observe_authority_generation_hash }}" \
+            --authority-expires-at "${{ steps.contract.outputs.authority_expires_at }}" \
+            --paper-output deployment.paper.yaml \
+            --observe-output deployment.observe.yaml
+          diff -u \
+            --label a/argocd/applications/bayn/deployment.yaml \
+            --label b/argocd/applications/bayn/deployment.yaml \
+            argocd/applications/bayn/deployment.yaml deployment.paper.yaml > activation.patch || true
+          diff -u \
+            --label a/argocd/applications/bayn/deployment.yaml \
+            --label b/argocd/applications/bayn/deployment.yaml \
+            deployment.paper.yaml deployment.observe.yaml > rollback.patch || true
+          test -s activation.patch
+          test -s rollback.patch
+          grep -q 'value: PAPER' activation.patch
+          grep -q 'value: mutation' activation.patch
+          grep -q 'value: sandbox-capital' activation.patch
+          grep -q 'value: OBSERVE' rollback.patch
+          grep -q 'value: read-only' rollback.patch
+          grep -q 'value: none' rollback.patch
+          ! grep -Eq 'api\.alpaca\.markets|BAYN_BROKER_ENVIRONMENT.*live|value: LIVE|live-capital-grant' activation.patch
+
+      - name: Capture exact OBSERVE baseline before any GitOps write
+        id: baseline
+        if: steps.identity.outputs.live == 'true'
+        run: |
+          set -euo pipefail
+          status_file="${RUNNER_TEMP}/bayn-observe-baseline.json"
+          curl -fsS --connect-timeout 5 --max-time 15 \
+            http://bayn.bayn.svc.cluster.local/v1/status > "${status_file}"
+          jq -e '
+            .operational.ready == true and
+            .qualification.verdict == "QUALIFIED" and
+            .authority.brokerEnvironment == "sandbox" and
+            .authority.brokerAccess == "read-only" and
+            .authority.capitalAuthority == "none" and
+            .authority.durable.available == true and
+            .authority.durable.maximum == "observe" and
+            .authority.durable.effective == "observe" and
+            .authority.durable.kill == "clear" and
+            .cycle.observationAvailable == true and
+            .cycle.mutations.unresolvedCount == 0 and
+            .cycle.reconciliation.status == "EXACT" and
+            .cycle.reconciliation.discrepancyCount == 0 and
+            .cycle.reconciliation.coversLatestMutation == true
+          ' "${status_file}" >/dev/null
+          echo "baseline_cycle_id=$(jq -r '.cycle.last.cycleId // ""' "${status_file}")" >> "$GITHUB_OUTPUT"
+
+      - name: Persist verified transition contract
+        if: steps.identity.outputs.live == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: bayn-paper-activation-contract-${{ steps.identity.outputs.activation_id }}-${{ github.run_id }}
+          if-no-files-found: error
+          retention-days: 90
+          path: |
+            activation.patch
+            rollback.patch
+            activation-evidence/evidence.json
+            activation-evidence/pins.json
+            activation-evidence/manifest-pins.json
+            activation-evidence/observe-rollback-generation.json
+
+      - name: Atomically claim and create paired reviewed GitOps pull requests
+        id: gitops
+        if: steps.identity.outputs.live == 'true'
+        env:
+          ACTIVATION_ID: ${{ steps.identity.outputs.activation_id }}
+          AUTHORITY_EXPIRES_AT: ${{ steps.contract.outputs.authority_expires_at }}
+          AUTHORITY_GENERATION_HASH: ${{ steps.contract.outputs.authority_generation_hash }}
+          BASELINE_CYCLE_ID: ${{ steps.baseline.outputs.baseline_cycle_id }}
+          CURRENT_MAIN_SHA: ${{ steps.identity.outputs.current_main_sha }}
+          GH_TOKEN: ${{ secrets.AGENTS_SPLIT_TOKEN }}
+          OBSERVE_AUTHORITY_GENERATION_HASH: ${{ steps.rollback_generation.outputs.observe_authority_generation_hash }}
+          PREVIOUS_OBSERVE_GENERATION_HASH: ${{ steps.rollback_generation.outputs.previous_observe_generation_hash }}
+        run: |
+          set -euo pipefail
+          [[ -n "${GH_TOKEN}" ]] || {
+            echo 'BAYN_PAPER_ACTIVATION_HOLD protected-gitops-token-missing: non-dry-run activation is unavailable' >&2
+            exit 1
+          }
+          activation_branch="codex/bayn-paper-activation/${ACTIVATION_ID}"
+          rollback_branch="codex/bayn-paper-rollback/${ACTIVATION_ID}"
+          if git ls-remote --exit-code --heads origin "refs/heads/${activation_branch}" >/dev/null 2>&1; then
+            echo 'BAYN_PAPER_ACTIVATION_HOLD activation-already-claimed: durable activation branch already exists' >&2
+            exit 1
+          fi
+          if git ls-remote --exit-code --heads origin "refs/heads/${rollback_branch}" >/dev/null 2>&1; then
+            echo 'BAYN_PAPER_ACTIVATION_HOLD rollback-already-precommitted: durable rollback branch already exists' >&2
+            exit 1
+          fi
+
+          metadata="$(
+            jq -nc \
+              --arg activationBranch "${activation_branch}" \
+              --arg activationId "${ACTIVATION_ID}" \
+              --arg authorityExpiresAt "${AUTHORITY_EXPIRES_AT}" \
+              --arg authorityGenerationHash "${AUTHORITY_GENERATION_HASH}" \
+              --arg baselineCycleId "${BASELINE_CYCLE_ID}" \
+              --arg observeAuthorityGenerationHash "${OBSERVE_AUTHORITY_GENERATION_HASH}" \
+              --arg previousObserveGenerationHash "${PREVIOUS_OBSERVE_GENERATION_HASH}" \
+              --arg rollbackBranch "${rollback_branch}" \
+              --arg sourceMainSha "${CURRENT_MAIN_SHA}" \
+              --arg workflowRunAttempt "${GITHUB_RUN_ATTEMPT}" \
+              --arg workflowRunId "${GITHUB_RUN_ID}" \
+              '{schemaVersion:1,activationId:$activationId,activationBranch:$activationBranch,rollbackBranch:$rollbackBranch,sourceMainSha:$sourceMainSha,authorityGenerationHash:$authorityGenerationHash,previousObserveGenerationHash:$previousObserveGenerationHash,observeAuthorityGenerationHash:$observeAuthorityGenerationHash,authorityExpiresAt:$authorityExpiresAt,baselineCycleId:$baselineCycleId,workflowRunId:($workflowRunId|tonumber),workflowRunAttempt:($workflowRunAttempt|tonumber)}'
+          )"
+          metadata_b64="$(printf '%s' "${metadata}" | base64 -w0)"
+
+          make_commit() {
+            local base="$1" deployment="$2" message="$3"
+            local index tree blob commit
+            index="$(mktemp)"
+            rm -f "${index}"
+            GIT_INDEX_FILE="${index}" git read-tree "${base}"
+            blob="$(git hash-object -w "${deployment}")"
+            GIT_INDEX_FILE="${index}" git update-index --add --cacheinfo \
+              100644,"${blob}",argocd/applications/bayn/deployment.yaml
+            tree="$(GIT_INDEX_FILE="${index}" git write-tree)"
+            commit="$(printf '%s\n' "${message}" | git commit-tree "${tree}" -p "${base}")"
+            rm -f "${index}"
+            printf '%s' "${commit}"
+          }
+
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          activation_commit="$(make_commit "${CURRENT_MAIN_SHA}" deployment.paper.yaml "chore(bayn): activate bounded PAPER ${ACTIVATION_ID}")"
+          rollback_message="$(printf 'chore(bayn): precommit OBSERVE rollback %s\n\nBAYN_PAPER_ROLLBACK_METADATA=%s' "${ACTIVATION_ID}" "${metadata_b64}")"
+          rollback_commit="$(make_commit "${CURRENT_MAIN_SHA}" deployment.observe.yaml "${rollback_message}")"
+          gh auth setup-git
+          git push origin "${activation_commit}:refs/heads/${activation_branch}"
+          git push origin "${rollback_commit}:refs/heads/${rollback_branch}"
+
+          template_file='.github/PULL_REQUEST_TEMPLATE.md'
+          test -s "${template_file}"
+          for heading in '## Summary' '## Related Issues' '## Testing' '## Breaking Changes' '## Checklist'; do
+            grep -Fxq "${heading}" "${template_file}"
+          done
+          cat > rollback-pr-body.md <<EOF
+          ## Summary
+
+          - Restore Bayn to explicit OBSERVE / read-only / no-capital authority after activation \`${ACTIVATION_ID}\`.
+          - Use the precommitted fresh OBSERVE generation bound to the paired PAPER transition.
+          - Preserve the rollback branch for automatic retargeting to the exact activated main.
+
+          ## Related Issues
+
+          PROOMPT-405
+
+          ## Testing
+
+          - The parent activation workflow verified and persisted the exact rollback patch before creating this PR.
+          - Protected checks and unresolved-thread state are revalidated on the unchanged exact head before merge.
+
+          ## Breaking Changes
+
+          None
+
+          ## Checklist
+
+          - [x] Testing section documents the exact validation performed (or \`N/A\` with justification).
+          - [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
+          - [x] Documentation, release notes, and follow-ups are updated or tracked.
+          EOF
+          cat > activation-pr-body.md <<EOF
+          ## Summary
+
+          - Activate the reviewed bounded sandbox PAPER generation for \`${ACTIVATION_ID}\`.
+          - Bind the transition to exact current-main source, image, qualification, account, and authority evidence.
+          - Pair this transition with rollback branch \`${rollback_branch}\` and authority deadline \`${AUTHORITY_EXPIRES_AT}\`.
+
+          ## Related Issues
+
+          PROOMPT-405
+
+          ## Testing
+
+          - The activation workflow verified the immutable evidence tuple and rendered the exact PAPER and OBSERVE patches.
+          - Protected checks, exact head/base, review threads, qualification expiry, and authority expiry are revalidated before merge.
+
+          ## Breaking Changes
+
+          None
+
+          ## Checklist
+
+          - [x] Testing section documents the exact validation performed (or \`N/A\` with justification).
+          - [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
+          - [x] Documentation, release notes, and follow-ups are updated or tracked.
+          EOF
+
+          rollback_url="$(
+            gh pr create \
+              --repo "${GITHUB_REPOSITORY}" \
+              --base main \
+              --head "${rollback_branch}" \
+              --draft \
+              --title "chore(bayn): restore OBSERVE after ${ACTIVATION_ID}" \
+              --body-file rollback-pr-body.md
+          )"
+          activation_url="$(
+            gh pr create \
+              --repo "${GITHUB_REPOSITORY}" \
+              --base main \
+              --head "${activation_branch}" \
+              --draft \
+              --title "chore(bayn): activate bounded PAPER ${ACTIVATION_ID}" \
+              --body-file activation-pr-body.md
+          )"
+          {
+            echo "activation_branch=${activation_branch}"
+            echo "activation_commit_sha=${activation_commit}"
+            echo "activation_pr=${activation_url##*/}"
+            echo "rollback_branch=${rollback_branch}"
+            echo "rollback_commit_sha=${rollback_commit}"
+            echo "rollback_metadata_b64=${metadata_b64}"
+            echo "rollback_pr=${rollback_url##*/}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Persist rollback watchdog attestation
+        if: steps.identity.outputs.live == 'true'
+        env:
+          ACTIVATION_BRANCH: ${{ steps.gitops.outputs.activation_branch }}
+          ACTIVATION_COMMIT_SHA: ${{ steps.gitops.outputs.activation_commit_sha }}
+          ACTIVATION_ID: ${{ steps.identity.outputs.activation_id }}
+          AUTHORITY_EXPIRES_AT: ${{ steps.contract.outputs.authority_expires_at }}
+          AUTHORITY_GENERATION_HASH: ${{ steps.contract.outputs.authority_generation_hash }}
+          CURRENT_MAIN_SHA: ${{ steps.identity.outputs.current_main_sha }}
+          OBSERVE_AUTHORITY_GENERATION_HASH: ${{ steps.rollback_generation.outputs.observe_authority_generation_hash }}
+          ROLLBACK_BRANCH: ${{ steps.gitops.outputs.rollback_branch }}
+          ROLLBACK_COMMIT_SHA: ${{ steps.gitops.outputs.rollback_commit_sha }}
+          ROLLBACK_METADATA_B64: ${{ steps.gitops.outputs.rollback_metadata_b64 }}
+          WORKFLOW_HEAD_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          jq -nc \
+            --arg activationBranch "${ACTIVATION_BRANCH}" \
+            --arg activationCommitSha "${ACTIVATION_COMMIT_SHA}" \
+            --arg activationId "${ACTIVATION_ID}" \
+            --arg authorityExpiresAt "${AUTHORITY_EXPIRES_AT}" \
+            --arg authorityGenerationHash "${AUTHORITY_GENERATION_HASH}" \
+            --arg observeAuthorityGenerationHash "${OBSERVE_AUTHORITY_GENERATION_HASH}" \
+            --arg repository "${GITHUB_REPOSITORY}" \
+            --arg rollbackBranch "${ROLLBACK_BRANCH}" \
+            --arg rollbackCommitSha "${ROLLBACK_COMMIT_SHA}" \
+            --arg rollbackMetadataB64 "${ROLLBACK_METADATA_B64}" \
+            --arg sourceMainSha "${CURRENT_MAIN_SHA}" \
+            --arg workflowHeadSha "${WORKFLOW_HEAD_SHA}" \
+            --arg workflowPath '.github/workflows/bayn-paper-activation.yml' \
+            --arg workflowRunAttempt "${GITHUB_RUN_ATTEMPT}" \
+            --arg workflowRunId "${GITHUB_RUN_ID}" '
+              {
+                schemaVersion: 1,
+                repository: $repository,
+                workflowPath: $workflowPath,
+                workflowRunId: ($workflowRunId | tonumber),
+                workflowRunAttempt: ($workflowRunAttempt | tonumber),
+                activationId: $activationId,
+                activationBranch: $activationBranch,
+                activationCommitSha: $activationCommitSha,
+                rollbackBranch: $rollbackBranch,
+                rollbackCommitSha: $rollbackCommitSha,
+                rollbackMetadataB64: $rollbackMetadataB64,
+                sourceMainSha: $sourceMainSha,
+                workflowHeadSha: $workflowHeadSha,
+                authorityGenerationHash: $authorityGenerationHash,
+                observeAuthorityGenerationHash: $observeAuthorityGenerationHash,
+                authorityExpiresAt: $authorityExpiresAt
+              }
+            ' > bayn-paper-rollback-attestation.json
+
+      - name: Upload rollback watchdog attestation
+        if: steps.identity.outputs.live == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: bayn-paper-rollback-attestation-${{ steps.identity.outputs.activation_id }}-${{ github.run_id }}-${{ github.run_attempt }}
+          if-no-files-found: error
+          retention-days: 90
+          path: bayn-paper-rollback-attestation.json
+
+      - name: Release activation only after durable rollback attestation
+        if: steps.identity.outputs.live == 'true'
+        env:
+          ACTIVATION_BRANCH: ${{ steps.gitops.outputs.activation_branch }}
+          EXPECTED_ACTIVATION_SHA: ${{ steps.gitops.outputs.activation_commit_sha }}
+          EXPECTED_BASE_SHA: ${{ steps.identity.outputs.current_main_sha }}
+          GH_TOKEN: ${{ secrets.AGENTS_SPLIT_TOKEN }}
+          PR_NUMBER: ${{ steps.gitops.outputs.activation_pr }}
+        run: |
+          set -euo pipefail
+          pull="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}")"
+          current_main_sha="$(gh api "repos/${GITHUB_REPOSITORY}/commits/main" --jq '.sha')"
+          if
+            [[ "${current_main_sha}" != "${EXPECTED_BASE_SHA}" ]] ||
+            [[ "$(jq -r '.state' <<< "${pull}")" != open ]] ||
+            [[ "$(jq -r '.draft' <<< "${pull}")" != true ]] ||
+            [[ "$(jq -r '.merged_at // ""' <<< "${pull}")" != '' ]] ||
+            [[ "$(jq -r '.head.sha' <<< "${pull}")" != "${EXPECTED_ACTIVATION_SHA}" ]] ||
+            [[ "$(jq -r '.head.ref' <<< "${pull}")" != "${ACTIVATION_BRANCH}" ]] ||
+            [[ "$(jq -r '.base.ref' <<< "${pull}")" != main ]] ||
+            [[ "$(jq -r '.base.sha' <<< "${pull}")" != "${EXPECTED_BASE_SHA}" ]]
+          then
+            echo 'BAYN_PAPER_ACTIVATION_HOLD activation-draft-changed: activation is not the exact attested draft' >&2
+            exit 1
+          fi
+          gh pr ready "${PR_NUMBER}" --repo "${GITHUB_REPOSITORY}"
+          ready_pull="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}")"
+          if
+            [[ "$(jq -r '.state' <<< "${ready_pull}")" != open ]] ||
+            [[ "$(jq -r '.draft' <<< "${ready_pull}")" != false ]] ||
+            [[ "$(jq -r '.merged_at // ""' <<< "${ready_pull}")" != '' ]] ||
+            [[ "$(jq -r '.head.sha' <<< "${ready_pull}")" != "${EXPECTED_ACTIVATION_SHA}" ]] ||
+            [[ "$(jq -r '.head.ref' <<< "${ready_pull}")" != "${ACTIVATION_BRANCH}" ]] ||
+            [[ "$(jq -r '.base.ref' <<< "${ready_pull}")" != main ]] ||
+            [[ "$(jq -r '.base.sha' <<< "${ready_pull}")" != "${EXPECTED_BASE_SHA}" ]]
+          then
+            gh pr ready "${PR_NUMBER}" --undo --repo "${GITHUB_REPOSITORY}" >/dev/null
+            contained_pull="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}")"
+            if
+              [[ "$(jq -r '.state' <<< "${contained_pull}")" != open ]] ||
+              [[ "$(jq -r '.draft' <<< "${contained_pull}")" != true ]] ||
+              [[ "$(jq -r '.merged_at // ""' <<< "${contained_pull}")" != '' ]]
+            then
+              echo 'BAYN_PAPER_ACTIVATION_HOLD activation-containment-failed: drifted activation did not return to an unmerged draft' >&2
+              exit 1
+            fi
+            echo 'BAYN_PAPER_ACTIVATION_HOLD activation-ready-changed: activation changed while leaving draft' >&2
+            exit 1
+          fi
+
+  activate-and-observe:
+    name: Merge reviewed activation and observe one natural cycle
+    needs: verify-and-prepare
+    if: >-
+      needs.verify-and-prepare.outputs.live == 'true' &&
+      github.event_name == 'workflow_run'
+    runs-on: arc-arm64
+    timeout-minutes: 120
+    outputs:
+      observation: ${{ steps.observe.outputs.observation }}
+      rollback_commit_sha: ${{ steps.rebase_rollback.outputs.rollback_commit_sha }}
+    steps:
+      - name: Checkout trusted transition controller
+        uses: actions/checkout@v5
+        with:
+          ref: main
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Merge only a clean exact-head protected activation PR
+        id: merge_activation
+        env:
+          ACTIVATION_BRANCH: ${{ needs.verify-and-prepare.outputs.activation_branch }}
+          EXPECTED_ACTIVATION_SHA: ${{ needs.verify-and-prepare.outputs.activation_commit_sha }}
+          EXPECTED_ROLLBACK_SHA: ${{ needs.verify-and-prepare.outputs.rollback_commit_sha }}
+          AUTHORITY_EXPIRES_AT: ${{ needs.verify-and-prepare.outputs.authority_expires_at }}
+          EXPECTED_BASE_SHA: ${{ needs.verify-and-prepare.outputs.current_main_sha }}
+          GH_TOKEN: ${{ secrets.AGENTS_SPLIT_TOKEN }}
+          PR_NUMBER: ${{ needs.verify-and-prepare.outputs.activation_pr }}
+          QUALIFICATION_EXPIRES_AT: ${{ needs.verify-and-prepare.outputs.qualification_expires_at }}
+          ROLLBACK_BRANCH: ${{ needs.verify-and-prepare.outputs.rollback_branch }}
+          ROLLBACK_PR_NUMBER: ${{ needs.verify-and-prepare.outputs.rollback_pr }}
+        run: |
+          set -euo pipefail
+          expected_sha="${EXPECTED_ACTIVATION_SHA}"
+          [[ "${expected_sha}" =~ ^[0-9a-f]{40}$ ]] || {
+            echo 'BAYN_PAPER_ACTIVATION_HOLD invalid-activation-commit: workflow-produced activation SHA is malformed' >&2
+            exit 1
+          }
+          branch_sha="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/${ACTIVATION_BRANCH}" --jq '.object.sha')"
+          [[ "${branch_sha}" == "${expected_sha}" ]] || {
+            echo 'BAYN_PAPER_ACTIVATION_HOLD activation-head-changed: activation branch differs from the verified workflow-produced commit' >&2
+            exit 1
+          }
+          [[ "${EXPECTED_ROLLBACK_SHA}" =~ ^[0-9a-f]{40}$ ]] || {
+            echo 'BAYN_PAPER_ACTIVATION_HOLD invalid-rollback-commit: workflow-produced rollback SHA is malformed' >&2
+            exit 1
+          }
+          ensure_rollback_pr_open() {
+            local rollback_pull rollback_state
+            rollback_pull="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${ROLLBACK_PR_NUMBER}")"
+            if
+              [[ "$(jq -r '.head.sha' <<< "${rollback_pull}")" != "${EXPECTED_ROLLBACK_SHA}" ]] ||
+              [[ "$(jq -r '.head.ref' <<< "${rollback_pull}")" != "${ROLLBACK_BRANCH}" ]] ||
+              [[ "$(jq -r '.base.ref' <<< "${rollback_pull}")" != main ]] ||
+              [[ "$(jq -r '.merged_at // ""' <<< "${rollback_pull}")" != '' ]]
+            then
+              echo 'BAYN_PAPER_ACTIVATION_HOLD rollback-pr-drift: paired rollback PR no longer matches the workflow-produced OBSERVE commit' >&2
+              return 1
+            fi
+            rollback_state="$(jq -r '.state' <<< "${rollback_pull}")"
+            if [[ "${rollback_state}" == closed ]]; then
+              gh api --method PATCH "repos/${GITHUB_REPOSITORY}/pulls/${ROLLBACK_PR_NUMBER}" -f state=open >/dev/null || {
+                echo 'BAYN_PAPER_ACTIVATION_HOLD rollback-pr-closed: paired rollback PR could not be reopened' >&2
+                return 1
+              }
+              rollback_pull="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${ROLLBACK_PR_NUMBER}")"
+            fi
+            if
+              [[ "$(jq -r '.state' <<< "${rollback_pull}")" != open ]] ||
+              [[ "$(jq -r '.head.sha' <<< "${rollback_pull}")" != "${EXPECTED_ROLLBACK_SHA}" ]] ||
+              [[ "$(jq -r '.head.ref' <<< "${rollback_pull}")" != "${ROLLBACK_BRANCH}" ]] ||
+              [[ "$(jq -r '.base.ref' <<< "${rollback_pull}")" != main ]] ||
+              [[ "$(jq -r '.merged_at // ""' <<< "${rollback_pull}")" != '' ]]
+            then
+              echo 'BAYN_PAPER_ACTIVATION_HOLD rollback-pr-closed: paired rollback PR is not open and exact' >&2
+              return 1
+            fi
+          }
+          ensure_rollback_pr_open
+          count_unresolved_threads() {
+            local pr_number="$1" cursor='' page page_unresolved has_next end_cursor unresolved=0
+            local query='query($owner:String!,$name:String!,$number:Int!,$after:String){repository(owner:$owner,name:$name){pullRequest(number:$number){reviewThreads(first:100,after:$after){nodes{isResolved}pageInfo{hasNextPage endCursor}}}}}'
+            for page_number in $(seq 1 100); do
+              local -a request=(
+                graphql
+                -f "query=${query}"
+                -F "owner=${GITHUB_REPOSITORY%%/*}"
+                -F "name=${GITHUB_REPOSITORY##*/}"
+                -F "number=${pr_number}"
+              )
+              [[ -z "${cursor}" ]] || request+=(-f "after=${cursor}")
+              page="$(gh api "${request[@]}")"
+              jq -e '
+                ((.errors // []) | length) == 0 and
+                (.data.repository.pullRequest.reviewThreads.nodes | type) == "array" and
+                (.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage | type) == "boolean"
+              ' <<< "${page}" >/dev/null || {
+                echo 'BAYN_PAPER_ACTIVATION_HOLD review-thread-pagination-invalid: GitHub returned incomplete review-thread evidence' >&2
+                return 1
+              }
+              page_unresolved="$(
+                jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length' \
+                  <<< "${page}"
+              )"
+              unresolved="$((unresolved + page_unresolved))"
+              has_next="$(jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage' <<< "${page}")"
+              if [[ "${has_next}" == false ]]; then
+                printf '%s\n' "${unresolved}"
+                return 0
+              fi
+              end_cursor="$(jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.endCursor // ""' <<< "${page}")"
+              [[ -n "${end_cursor}" ]] || {
+                echo 'BAYN_PAPER_ACTIVATION_HOLD review-thread-pagination-invalid: next review-thread page has no cursor' >&2
+                return 1
+              }
+              cursor="${end_cursor}"
+            done
+            echo 'BAYN_PAPER_ACTIVATION_HOLD review-thread-pagination-limit: review-thread evidence exceeds the bounded 100-page limit' >&2
+            return 1
+          }
+          load_check_runs() {
+            local commit_sha="$1" pages
+            pages="$(
+              gh api --paginate --slurp \
+                "repos/${GITHUB_REPOSITORY}/commits/${commit_sha}/check-runs?filter=latest&per_page=100"
+            )"
+            jq -e '
+              type == "array" and length > 0 and
+              all(.[];
+                (.total_count | type) == "number" and
+                (.check_runs | type) == "array" and
+                (.check_runs | length) <= 100 and
+                all(.check_runs[]; (.id | type) == "number")
+              ) and
+              ([.[].total_count] | unique | length) == 1 and
+              ([.[] | .check_runs[]] | length) == .[0].total_count and
+              ([.[] | .check_runs[].id] | length) == ([.[] | .check_runs[].id] | unique | length)
+            ' <<< "${pages}" >/dev/null || {
+              echo 'BAYN_PAPER_ACTIVATION_HOLD check-run-pagination-invalid: GitHub returned incomplete or duplicate check-run evidence' >&2
+              return 1
+            }
+            jq -c '{check_runs: [.[] | .check_runs[]]}' <<< "${pages}"
+          }
+          expiry_epoch="$(date -u -d "${AUTHORITY_EXPIRES_AT}" +%s)"
+          qualification_expiry_epoch="$(date -u -d "${QUALIFICATION_EXPIRES_AT}" +%s)"
+          for attempt in $(seq 1 80); do
+            pull="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}")"
+            [[ "$(jq -r '.head.sha' <<< "${pull}")" == "${expected_sha}" ]]
+            [[ "$(jq -r '.base.ref' <<< "${pull}")" == main ]]
+            current_main_sha="$(gh api "repos/${GITHUB_REPOSITORY}/commits/main" --jq '.sha')"
+            if
+              [[ "${current_main_sha}" != "${EXPECTED_BASE_SHA}" ]] ||
+              [[ "$(jq -r '.base.sha' <<< "${pull}")" != "${EXPECTED_BASE_SHA}" ]]
+            then
+              echo 'BAYN_PAPER_ACTIVATION_HOLD activation-base-changed: current main differs from the verified activation base' >&2
+              exit 1
+            fi
+            now_epoch="$(date -u +%s)"
+            if [[ "$((qualification_expiry_epoch - now_epoch))" -lt 900 ]]; then
+              echo 'BAYN_PAPER_ACTIVATION_HOLD qualification-stale: fewer than 15 minutes remain before qualification expiry' >&2
+              exit 1
+            fi
+            if [[ "$((expiry_epoch - now_epoch))" -lt 900 ]]; then
+              echo 'BAYN_PAPER_ACTIVATION_HOLD authority-window-too-short: fewer than 15 minutes remain before PAPER expiry' >&2
+              exit 1
+            fi
+            unresolved="$(count_unresolved_threads "${PR_NUMBER}")"
+            checks="$(load_check_runs "${expected_sha}")"
+            pending="$(jq '[.check_runs[] | select(.status != "completed")] | length' <<< "${checks}")"
+            failed="$(jq '[.check_runs[] | select(.status == "completed" and (.conclusion | IN("success", "neutral", "skipped") | not))] | length' <<< "${checks}")"
+            if
+              [[ "${unresolved}" == 0 ]] &&
+              [[ "${pending}" == 0 ]] &&
+              [[ "${failed}" == 0 ]] &&
+              [[ "$(jq '.check_runs | length' <<< "${checks}")" -gt 0 ]] &&
+              [[ "$(jq -r '.mergeable_state' <<< "${pull}")" =~ ^(clean|unstable)$ ]]
+            then
+              final_pull="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}")"
+              final_main_sha="$(gh api "repos/${GITHUB_REPOSITORY}/commits/main" --jq '.sha')"
+              if
+                [[ "$(jq -r '.head.sha' <<< "${final_pull}")" != "${expected_sha}" ]] ||
+                [[ "$(jq -r '.base.ref' <<< "${final_pull}")" != main ]] ||
+                [[ "$(jq -r '.base.sha' <<< "${final_pull}")" != "${EXPECTED_BASE_SHA}" ]] ||
+                [[ "${final_main_sha}" != "${EXPECTED_BASE_SHA}" ]]
+              then
+                echo 'BAYN_PAPER_ACTIVATION_HOLD activation-base-changed: base changed immediately before merge' >&2
+                exit 1
+              fi
+              final_now_epoch="$(date -u +%s)"
+              if [[ "$((qualification_expiry_epoch - final_now_epoch))" -lt 900 ]]; then
+                echo 'BAYN_PAPER_ACTIVATION_HOLD qualification-stale: qualification expired or is too close immediately before merge' >&2
+                exit 1
+              fi
+              if [[ "$((expiry_epoch - final_now_epoch))" -lt 900 ]]; then
+                echo 'BAYN_PAPER_ACTIVATION_HOLD authority-window-too-short: expiry is too close immediately before merge' >&2
+                exit 1
+              fi
+              ensure_rollback_pr_open
+              result="$(
+                gh api --method PUT "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/merge" \
+                  -f merge_method=squash \
+                  -f sha="${expected_sha}"
+              )"
+              [[ "$(jq -r '.merged' <<< "${result}")" == true ]]
+              merged_pull="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}")"
+              activation_merged_at="$(jq -r '.merged_at // ""' <<< "${merged_pull}")"
+              [[ -n "${activation_merged_at}" ]]
+              date -u -d "${activation_merged_at}" +%s >/dev/null
+              echo "activation_merged_at=${activation_merged_at}" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            sleep 15
+          done
+          echo 'BAYN_PAPER_ACTIVATION_HOLD activation-review-timeout: exact-head GitOps review did not settle' >&2
+          exit 1
+
+      - name: Rebase the precommitted rollback tree onto activated main
+        id: rebase_rollback
+        env:
+          ACTIVATION_BRANCH: ${{ needs.verify-and-prepare.outputs.activation_branch }}
+          ACTIVATION_ID: ${{ needs.verify-and-prepare.outputs.activation_id }}
+          AUTHORITY_EXPIRES_AT: ${{ needs.verify-and-prepare.outputs.authority_expires_at }}
+          AUTHORITY_GENERATION_HASH: ${{ needs.verify-and-prepare.outputs.authority_generation_hash }}
+          BASELINE_CYCLE_ID: ${{ needs.verify-and-prepare.outputs.baseline_cycle_id }}
+          EXPECTED_ROLLBACK_METADATA_B64: ${{ needs.verify-and-prepare.outputs.rollback_metadata_b64 }}
+          EXPECTED_ROLLBACK_SHA: ${{ needs.verify-and-prepare.outputs.rollback_commit_sha }}
+          GH_TOKEN: ${{ secrets.AGENTS_SPLIT_TOKEN }}
+          OBSERVE_AUTHORITY_GENERATION_HASH: ${{ needs.verify-and-prepare.outputs.observe_authority_generation_hash }}
+          PREVIOUS_OBSERVE_AUTHORITY_GENERATION_HASH: ${{ needs.verify-and-prepare.outputs.previous_observe_authority_generation_hash }}
+          ROLLBACK_BRANCH: ${{ needs.verify-and-prepare.outputs.rollback_branch }}
+          SOURCE_MAIN_SHA: ${{ needs.verify-and-prepare.outputs.current_main_sha }}
+        run: |
+          set -euo pipefail
+          [[ "${EXPECTED_ROLLBACK_SHA}" =~ ^[0-9a-f]{40}$ ]] || {
+            echo 'BAYN_PAPER_ACTIVATION_HOLD invalid-rollback-commit: workflow-produced rollback SHA is malformed' >&2
+            exit 1
+          }
+          [[ -n "${EXPECTED_ROLLBACK_METADATA_B64}" ]] || {
+            echo 'BAYN_PAPER_ACTIVATION_HOLD invalid-rollback-metadata: workflow-produced rollback metadata is missing' >&2
+            exit 1
+          }
+          gh auth setup-git
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git fetch origin \
+            "main:refs/remotes/origin/main" \
+            "${ROLLBACK_BRANCH}:refs/remotes/origin/${ROLLBACK_BRANCH}"
+          current_main_sha="$(git rev-parse origin/main)"
+          old_rollback_sha="$(git rev-parse "origin/${ROLLBACK_BRANCH}")"
+          [[ "${old_rollback_sha}" == "${EXPECTED_ROLLBACK_SHA}" ]] || {
+            echo 'BAYN_PAPER_ACTIVATION_HOLD rollback-precommit-changed: rollback branch differs from the workflow-produced commit' >&2
+            exit 1
+          }
+          mapfile -t metadata_lines < <(
+            git show -s --format=%B "${old_rollback_sha}" | sed -n 's/^BAYN_PAPER_ROLLBACK_METADATA=//p'
+          )
+          [[ "${#metadata_lines[@]}" == 1 ]] || {
+            echo 'BAYN_PAPER_ACTIVATION_HOLD rollback-metadata-drift: rollback commit must contain exactly one metadata record' >&2
+            exit 1
+          }
+          metadata_line="${metadata_lines[0]}"
+          [[ "${metadata_line}" == "${EXPECTED_ROLLBACK_METADATA_B64}" ]] || {
+            echo 'BAYN_PAPER_ACTIVATION_HOLD rollback-metadata-drift: rollback metadata differs from the workflow-produced record' >&2
+            exit 1
+          }
+          metadata="$(printf '%s' "${metadata_line}" | base64 -d)" || {
+            echo 'BAYN_PAPER_ACTIVATION_HOLD rollback-metadata-drift: rollback metadata is not valid Base64' >&2
+            exit 1
+          }
+          jq -e \
+            --arg activationBranch "${ACTIVATION_BRANCH}" \
+            --arg activationId "${ACTIVATION_ID}" \
+            --arg authorityExpiresAt "${AUTHORITY_EXPIRES_AT}" \
+            --arg authorityGenerationHash "${AUTHORITY_GENERATION_HASH}" \
+            --arg baselineCycleId "${BASELINE_CYCLE_ID}" \
+            --arg observeAuthorityGenerationHash "${OBSERVE_AUTHORITY_GENERATION_HASH}" \
+            --arg previousObserveGenerationHash "${PREVIOUS_OBSERVE_AUTHORITY_GENERATION_HASH}" \
+            --arg rollbackBranch "${ROLLBACK_BRANCH}" \
+            --arg sourceMainSha "${SOURCE_MAIN_SHA}" \
+            --arg workflowRunAttempt "${GITHUB_RUN_ATTEMPT}" \
+            --arg workflowRunId "${GITHUB_RUN_ID}" '
+              type == "object" and
+              keys == [
+                "activationBranch",
+                "activationId",
+                "authorityExpiresAt",
+                "authorityGenerationHash",
+                "baselineCycleId",
+                "observeAuthorityGenerationHash",
+                "previousObserveGenerationHash",
+                "rollbackBranch",
+                "schemaVersion",
+                "sourceMainSha",
+                "workflowRunAttempt",
+                "workflowRunId"
+              ] and
+              .schemaVersion == 1 and
+              .activationBranch == $activationBranch and
+              .activationId == $activationId and
+              .authorityExpiresAt == $authorityExpiresAt and
+              .authorityGenerationHash == $authorityGenerationHash and
+              .baselineCycleId == $baselineCycleId and
+              .observeAuthorityGenerationHash == $observeAuthorityGenerationHash and
+              .previousObserveGenerationHash == $previousObserveGenerationHash and
+              .rollbackBranch == $rollbackBranch and
+              .sourceMainSha == $sourceMainSha and
+              (.workflowRunAttempt | tostring) == $workflowRunAttempt and
+              (.workflowRunId | tostring) == $workflowRunId
+            ' <<< "${metadata}" >/dev/null || {
+            echo 'BAYN_PAPER_ACTIVATION_HOLD rollback-metadata-drift: decoded rollback metadata differs from the workflow-produced tuple' >&2
+            exit 1
+          }
+          git show "${current_main_sha}:argocd/applications/bayn/deployment.yaml" > deployment.paper.yaml
+          bun packages/scripts/src/bayn/verify-paper-activation.ts \
+            --mode inspect-deployment-authority \
+            --deployment deployment.paper.yaml \
+            --output deployment-paper-authority.json
+          if
+            [[ "$(jq -r '.maximumAuthority' deployment-paper-authority.json)" != PAPER ]] ||
+            [[ "$(jq -r '.authorityGenerationHash' deployment-paper-authority.json)" != "${AUTHORITY_GENERATION_HASH}" ]]
+          then
+            echo 'BAYN_PAPER_ACTIVATION_HOLD foreign-paper-generation: current main no longer contains this activation PAPER generation' >&2
+            exit 1
+          fi
+          bun packages/scripts/src/bayn/verify-paper-activation.ts \
+            --mode render-rollback \
+            --deployment deployment.paper.yaml \
+            --observe-authority-generation-hash "${OBSERVE_AUTHORITY_GENERATION_HASH}" \
+            --output deployment.observe.yaml
+          index="$(mktemp)"
+          rm -f "${index}"
+          GIT_INDEX_FILE="${index}" git read-tree "${current_main_sha}"
+          blob="$(git hash-object -w deployment.observe.yaml)"
+          GIT_INDEX_FILE="${index}" git update-index --add --cacheinfo \
+            100644,"${blob}",argocd/applications/bayn/deployment.yaml
+          tree="$(GIT_INDEX_FILE="${index}" git write-tree)"
+          rollback_commit="$(
+            printf 'chore(bayn): restore OBSERVE after %s\n\nBAYN_PAPER_ROLLBACK_METADATA=%s\n' \
+              "${ACTIVATION_ID}" "${metadata_line}" | git commit-tree "${tree}" -p "${current_main_sha}"
+          )"
+          rm -f "${index}"
+          git push --force-with-lease="refs/heads/${ROLLBACK_BRANCH}:${old_rollback_sha}" \
+            origin "${rollback_commit}:refs/heads/${ROLLBACK_BRANCH}"
+          echo "rollback_commit_sha=${rollback_commit}" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for the verified PAPER rollout
+        id: rollout
+        env:
+          AUTHORITY_EXPIRES_AT: ${{ needs.verify-and-prepare.outputs.authority_expires_at }}
+          AUTHORITY_GENERATION_HASH: ${{ needs.verify-and-prepare.outputs.authority_generation_hash }}
+          ACTIVATION_MERGED_AT: ${{ steps.merge_activation.outputs.activation_merged_at }}
+          EXPECTED_IMAGE_DIGEST: ${{ needs.verify-and-prepare.outputs.image_digest }}
+          EXPECTED_SOURCE_SHA: ${{ needs.verify-and-prepare.outputs.source_sha }}
+          PREACTIVATION_BASELINE_CYCLE_ID: ${{ needs.verify-and-prepare.outputs.baseline_cycle_id }}
+        run: |
+          set -euo pipefail
+          evidence_dir="${RUNNER_TEMP}/bayn-paper-observation"
+          mkdir -p "${evidence_dir}"
+          rollout_status="${evidence_dir}/rollout-status.json"
+          printf 'null\n' > "${rollout_status}"
+          activation_merge_epoch_ms="$(date -u -d "${ACTIVATION_MERGED_AT}" +%s%3N)"
+          expiry_epoch="$(date -u -d "${AUTHORITY_EXPIRES_AT}" +%s)"
+          rollout_deadline="$(( $(date -u +%s) + 600 ))"
+          if [[ "${expiry_epoch}" -lt "${rollout_deadline}" ]]; then
+            rollout_deadline="${expiry_epoch}"
+          fi
+          while [[ "$(date -u +%s)" -lt "${rollout_deadline}" ]]; do
+            if curl -fsS --connect-timeout 5 --max-time 15 \
+              http://bayn.bayn.svc.cluster.local/v1/status > "${rollout_status}"
+            then
+              if jq -e \
+                --arg digest "${EXPECTED_IMAGE_DIGEST}" \
+                --arg generation "${AUTHORITY_GENERATION_HASH}" \
+                --arg source "${EXPECTED_SOURCE_SHA}" '
+                  .operational.ready == true and
+                  .qualification.verdict == "QUALIFIED" and
+                  .build.sourceRevision == $source and
+                  .build.image.digest == $digest and
+                  .authority.brokerEnvironment == "sandbox" and
+                  .authority.brokerAccess == "mutation" and
+                  .authority.capitalAuthority == "sandbox-capital" and
+                  .authority.durable.maximum == "paper" and
+                  .authority.durable.effective == "paper" and
+                  .authority.durable.kill == "clear" and
+                  .cycle.observationAvailable == true and
+                  .cycle.authority.generationHash == $generation and
+                  .cycle.mutations.unresolvedCount == 0 and
+                  .cycle.reconciliation.status == "EXACT" and
+                  .cycle.reconciliation.discrepancyCount == 0 and
+                  .cycle.reconciliation.coversLatestMutation == true
+                ' "${rollout_status}" >/dev/null
+              then
+                paper_rollout_observed_at="$(jq -r '.operational.checkedAt // ""' "${rollout_status}")"
+                paper_rollout_observed_epoch_ms="$(date -u -d "${paper_rollout_observed_at}" +%s%3N)"
+                paper_authority_updated_at="$(jq -r '.cycle.authority.updatedAt // ""' "${rollout_status}")"
+                paper_authority_updated_epoch_ms="$(date -u -d "${paper_authority_updated_at}" +%s%3N)"
+                if
+                  [[ "${paper_authority_updated_epoch_ms}" -lt "${activation_merge_epoch_ms}" ]] ||
+                  [[ "${paper_authority_updated_epoch_ms}" -gt "${paper_rollout_observed_epoch_ms}" ]]
+                then
+                  echo 'BAYN_PAPER_ACTIVATION_HOLD paper-authority-chronology: reviewed PAPER authority transition is not within the activation visibility window' >&2
+                  exit 1
+                fi
+                paper_baseline_current_cycle_id="$(jq -r '.cycle.current.cycleId // ""' "${rollout_status}")"
+                if [[ -n "${paper_baseline_current_cycle_id}" ]]; then
+                  paper_baseline_current_created_at="$(jq -r '.cycle.current.createdAt // ""' "${rollout_status}")"
+                  if
+                    ! paper_baseline_current_created_epoch_ms="$(date -u -d "${paper_baseline_current_created_at}" +%s%3N)" ||
+                    [[ "${paper_baseline_current_created_epoch_ms}" -le "${activation_merge_epoch_ms}" ]] ||
+                    [[ "${paper_baseline_current_created_epoch_ms}" -le "${paper_authority_updated_epoch_ms}" ]]
+                  then
+                    echo 'BAYN_PAPER_ACTIVATION_HOLD active-cycle-before-paper-authority: current cycle did not start under the reviewed PAPER authority' >&2
+                    exit 1
+                  fi
+                fi
+                first_paper_last_cycle_id="$(jq -r '.cycle.last.cycleId // ""' "${rollout_status}")"
+                initial_terminal_cycle_id=''
+                if [[ -n "${first_paper_last_cycle_id}" && "${first_paper_last_cycle_id}" != "${PREACTIVATION_BASELINE_CYCLE_ID}" ]]; then
+                  first_paper_last_phase="$(jq -r '.cycle.last.phase // ""' "${rollout_status}")"
+                  first_paper_last_created_at="$(jq -r '.cycle.last.createdAt // ""' "${rollout_status}")"
+                  if
+                    ! first_paper_last_created_epoch_ms="$(date -u -d "${first_paper_last_created_at}" +%s%3N)" ||
+                    [[ "${first_paper_last_created_epoch_ms}" -le "${activation_merge_epoch_ms}" ]] ||
+                    [[ "${first_paper_last_created_epoch_ms}" -le "${paper_authority_updated_epoch_ms}" ]]
+                  then
+                    echo 'BAYN_PAPER_ACTIVATION_HOLD initial-cycle-before-paper-authority: changed terminal cycle did not start under the reviewed PAPER authority' >&2
+                    exit 1
+                  fi
+                  case "${first_paper_last_phase}" in
+                    COMPLETED | NO_TRADE | BLOCKED)
+                      if [[ -n "${paper_baseline_current_cycle_id}" ]]; then
+                        echo 'BAYN_PAPER_ACTIVATION_HOLD multiple-paper-cycles-before-observation: PAPER already contains a terminal and active cycle' >&2
+                        exit 1
+                      fi
+                      initial_terminal_cycle_id="${first_paper_last_cycle_id}"
+                      ;;
+                    *)
+                      echo 'BAYN_PAPER_ACTIVATION_HOLD invalid-first-paper-cycle: first PAPER status contains a changed nonterminal last cycle' >&2
+                      exit 1
+                      ;;
+                  esac
+                fi
+                {
+                  echo "paper_baseline_last_cycle_id=${PREACTIVATION_BASELINE_CYCLE_ID}"
+                  echo "paper_baseline_current_cycle_id=${paper_baseline_current_cycle_id}"
+                  echo "paper_initial_terminal_cycle_id=${initial_terminal_cycle_id}"
+                  echo "paper_authority_updated_at=${paper_authority_updated_at}"
+                  echo "paper_rollout_observed_at=${paper_rollout_observed_at}"
+                } >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+              if jq -e '
+                .authority.brokerEnvironment == "live" or
+                .authority.capitalAuthority == "live-capital-grant"
+              ' "${rollout_status}" >/dev/null
+              then
+                echo 'BAYN_PAPER_ACTIVATION_HOLD live-money-rollout: rollout exposed live-money authority' >&2
+                exit 1
+              fi
+            fi
+            sleep 10
+          done
+          echo 'BAYN_PAPER_ACTIVATION_HOLD paper-rollout-timeout: reviewed PAPER state did not become ready within 10 minutes' >&2
+          exit 1
+
+      - name: Observe exactly one new natural scheduled cycle
+        id: observe
+        env:
+          AUTHORITY_EXPIRES_AT: ${{ needs.verify-and-prepare.outputs.authority_expires_at }}
+          AUTHORITY_GENERATION_HASH: ${{ needs.verify-and-prepare.outputs.authority_generation_hash }}
+          ACTIVATION_MERGED_AT: ${{ steps.merge_activation.outputs.activation_merged_at }}
+          BASELINE_CURRENT_CYCLE_ID: ${{ steps.rollout.outputs.paper_baseline_current_cycle_id }}
+          BASELINE_LAST_CYCLE_ID: ${{ steps.rollout.outputs.paper_baseline_last_cycle_id }}
+          EXPECTED_IMAGE_DIGEST: ${{ needs.verify-and-prepare.outputs.image_digest }}
+          EXPECTED_SOURCE_SHA: ${{ needs.verify-and-prepare.outputs.source_sha }}
+          INITIAL_TERMINAL_CYCLE_ID: ${{ steps.rollout.outputs.paper_initial_terminal_cycle_id }}
+          PAPER_ROLLOUT_OBSERVED_AT: ${{ steps.rollout.outputs.paper_rollout_observed_at }}
+        run: |
+          set -euo pipefail
+          evidence_dir="${RUNNER_TEMP}/bayn-paper-observation"
+          mkdir -p "${evidence_dir}"
+          cp "${evidence_dir}/rollout-status.json" "${evidence_dir}/status.json"
+          outcome='timeout'
+          observed_cycle_id="${BASELINE_CURRENT_CYCLE_ID}"
+          rollout_epoch_ms="$(date -u -d "${PAPER_ROLLOUT_OBSERVED_AT}" +%s%3N)"
+          if [[ -n "${INITIAL_TERMINAL_CYCLE_ID}" ]]; then
+            initial_phase="$(jq -r '.cycle.last.phase // ""' "${evidence_dir}/status.json")"
+            [[ "$(jq -r '.cycle.last.cycleId // ""' "${evidence_dir}/status.json")" == "${INITIAL_TERMINAL_CYCLE_ID}" ]]
+            observed_cycle_id="${INITIAL_TERMINAL_CYCLE_ID}"
+            case "${initial_phase}" in
+              COMPLETED | NO_TRADE) outcome='terminal_success' ;;
+              BLOCKED) outcome='terminal_failure' ;;
+              *) outcome='invalid-initial-terminal-cycle' ;;
+            esac
+          fi
+          while
+            [[ "${outcome}" == timeout ]] &&
+            [[ "$(date -u +%s)" -lt "$(date -u -d "${AUTHORITY_EXPIRES_AT}" +%s)" ]]
+          do
+            status_file="${evidence_dir}/status.json"
+            if ! curl -fsS --connect-timeout 5 --max-time 15 \
+              http://bayn.bayn.svc.cluster.local/v1/status > "${status_file}"; then
+              outcome='status_unavailable'
+              break
+            fi
+            if ! jq -e \
+              --arg digest "${EXPECTED_IMAGE_DIGEST}" \
+              --arg generation "${AUTHORITY_GENERATION_HASH}" \
+              --arg source "${EXPECTED_SOURCE_SHA}" '
+                .operational.ready == true and
+                .qualification.verdict == "QUALIFIED" and
+                .build.sourceRevision == $source and
+                .build.image.digest == $digest and
+                .authority.brokerEnvironment == "sandbox" and
+                .authority.brokerAccess == "mutation" and
+                .authority.capitalAuthority == "sandbox-capital" and
+                .authority.durable.maximum == "paper" and
+                .authority.durable.effective == "paper" and
+                .authority.durable.kill == "clear" and
+                .cycle.observationAvailable == true and
+                .cycle.authority.generationHash == $generation and
+                .cycle.mutations.unresolvedCount == 0 and
+                .cycle.reconciliation.status == "EXACT" and
+                .cycle.reconciliation.discrepancyCount == 0 and
+                .cycle.reconciliation.coversLatestMutation == true
+              ' "${status_file}" >/dev/null
+            then
+              outcome='safety_discrepancy'
+              break
+            fi
+            current_cycle_id="$(jq -r '.cycle.current.cycleId // ""' "${status_file}")"
+            if [[ -n "${current_cycle_id}" ]]; then
+              current_created_at="$(jq -r '.cycle.current.createdAt // ""' "${status_file}")"
+              if [[ "${current_cycle_id}" != "${BASELINE_CURRENT_CYCLE_ID}" ]]; then
+                if
+                  ! current_created_epoch_ms="$(date -u -d "${current_created_at}" +%s%3N)" ||
+                  [[ "${current_created_epoch_ms}" -le "${rollout_epoch_ms}" ]]
+                then
+                  outcome='cycle-not-started-under-visible-paper'
+                  break
+                fi
+              fi
+              if [[ -n "${observed_cycle_id}" && "${current_cycle_id}" != "${observed_cycle_id}" ]]; then
+                outcome='multiple-paper-cycles'
+                break
+              fi
+              observed_cycle_id="${current_cycle_id}"
+            fi
+            last_cycle_id="$(jq -r '.cycle.last.cycleId // ""' "${status_file}")"
+            last_phase="$(jq -r '.cycle.last.phase // ""' "${status_file}")"
+            last_created_at="$(jq -r '.cycle.last.createdAt // ""' "${status_file}")"
+            if
+              [[ -n "${last_cycle_id}" ]] &&
+              [[ "${last_cycle_id}" != "${BASELINE_LAST_CYCLE_ID}" ]]
+            then
+              if [[ "${last_cycle_id}" == "${BASELINE_CURRENT_CYCLE_ID}" ]]; then
+                if [[ "${observed_cycle_id}" != "${last_cycle_id}" ]]; then
+                  outcome='cycle-not-started-under-visible-paper'
+                  break
+                fi
+              elif
+                ! last_created_epoch_ms="$(date -u -d "${last_created_at}" +%s%3N)" ||
+                [[ "${last_created_epoch_ms}" -le "${rollout_epoch_ms}" ]] ||
+                { [[ -n "${observed_cycle_id}" ]] && [[ "${last_cycle_id}" != "${observed_cycle_id}" ]]; }
+              then
+                outcome='cycle-not-started-under-visible-paper'
+                break
+              fi
+              observed_cycle_id="${last_cycle_id}"
+              case "${last_phase}" in
+                COMPLETED | NO_TRADE)
+                  outcome='terminal_success'
+                  break
+                  ;;
+                BLOCKED)
+                  outcome='terminal_failure'
+                  break
+                  ;;
+              esac
+            fi
+            sleep 30
+          done
+          jq -n \
+            --arg authorityExpiresAt "${AUTHORITY_EXPIRES_AT}" \
+            --arg authorityGenerationHash "${AUTHORITY_GENERATION_HASH}" \
+            --arg activationMergedAt "${ACTIVATION_MERGED_AT}" \
+            --arg baselineCurrentCycleId "${BASELINE_CURRENT_CYCLE_ID}" \
+            --arg baselineLastCycleId "${BASELINE_LAST_CYCLE_ID}" \
+            --arg observedAt "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --arg observedCycleId "${observed_cycle_id}" \
+            --arg outcome "${outcome}" \
+            --arg paperRolloutObservedAt "${PAPER_ROLLOUT_OBSERVED_AT}" \
+            --slurpfile status "${evidence_dir}/status.json" \
+            '{schemaVersion:1,authorityExpiresAt:$authorityExpiresAt,authorityGenerationHash:$authorityGenerationHash,activationMergedAt:$activationMergedAt,paperRolloutObservedAt:$paperRolloutObservedAt,baselineCurrentCycleId:$baselineCurrentCycleId,baselineLastCycleId:$baselineLastCycleId,observedCycleId:$observedCycleId,observedAt:$observedAt,outcome:$outcome,status:($status[0] // null)}' \
+            > "${evidence_dir}/proof.json"
+          echo "observation=${outcome}" >> "$GITHUB_OUTPUT"
+          [[ "${outcome}" == terminal_success || "${outcome}" == terminal_failure ]] || exit 1
+
+      - name: Persist natural-cycle observation
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bayn-paper-observation-${{ needs.verify-and-prepare.outputs.activation_id }}-${{ github.run_id }}
+          if-no-files-found: warn
+          retention-days: 90
+          path: ${{ runner.temp }}/bayn-paper-observation/*.json
+
+  rollback:
+    name: Always restore reviewed OBSERVE GitOps state
+    needs:
+      - verify-and-prepare
+      - activate-and-observe
+    if: >-
+      always() &&
+      needs.verify-and-prepare.outputs.live == 'true' &&
+      github.event_name == 'workflow_run'
+    runs-on: arc-arm64
+    timeout-minutes: 45
+    steps:
+      - name: Checkout trusted rollback controller
+        uses: actions/checkout@v5
+        with:
+          ref: main
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Determine whether activation merged
+        id: activation_state
+        env:
+          EXPECTED_ACTIVATION_SHA: ${{ needs.verify-and-prepare.outputs.activation_commit_sha }}
+          GH_TOKEN: ${{ secrets.AGENTS_SPLIT_TOKEN }}
+          PR_NUMBER: ${{ needs.verify-and-prepare.outputs.activation_pr }}
+        run: |
+          set -euo pipefail
+          restore='true'
+          if pull="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" 2>/dev/null)"; then
+            if
+              [[ "$(jq -r '.head.sha // ""' <<< "${pull}")" == "${EXPECTED_ACTIVATION_SHA}" ]] &&
+              [[ "$(jq -r '.state // ""' <<< "${pull}")" == closed ]] &&
+              [[ -n "$(jq -r '.merged_at // ""' <<< "${pull}")" ]] &&
+              [[ -n "$(jq -r '.base.ref // ""' <<< "${pull}")" ]] &&
+              [[ "$(jq -r '.base.ref // ""' <<< "${pull}")" != main ]]
+            then
+              restore='false'
+              echo 'Activation PR merged only into a foreign base; production OBSERVE rollback is not required for this attempt.'
+            elif
+              [[ "$(jq -r '.head.sha // ""' <<< "${pull}")" == "${EXPECTED_ACTIVATION_SHA}" ]] &&
+              [[ "$(jq -r '.merged_at // ""' <<< "${pull}")" == '' ]]
+            then
+              if [[ "$(jq -r '.state // ""' <<< "${pull}")" != closed ]]; then
+                if gh api --method PATCH "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" -f state=closed >/dev/null; then
+                  pull="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}")"
+                else
+                  echo 'Activation PR could not be closed; retaining fail-closed OBSERVE rollback.' >&2
+                fi
+              fi
+              if
+                [[ "$(jq -r '.head.sha // ""' <<< "${pull}")" == "${EXPECTED_ACTIVATION_SHA}" ]] &&
+                [[ "$(jq -r '.state // ""' <<< "${pull}")" == closed ]] &&
+                [[ "$(jq -r '.merged_at // ""' <<< "${pull}")" == '' ]]
+              then
+                restore='false'
+                echo 'Activation PR is exact, closed, and unmerged; OBSERVE rollback is not required for this attempt.'
+              fi
+            fi
+          else
+            echo 'Activation PR state is unavailable; retaining fail-closed OBSERVE rollback.' >&2
+          fi
+          echo "restore=${restore}" >> "$GITHUB_OUTPUT"
+
+      - name: Reopen and mark precommitted rollback ready
+        if: steps.activation_state.outputs.restore == 'true'
+        env:
+          EXPECTED_ROLLBACK_SHA: ${{ needs.activate-and-observe.outputs.rollback_commit_sha || needs.verify-and-prepare.outputs.rollback_commit_sha }}
+          GH_TOKEN: ${{ secrets.AGENTS_SPLIT_TOKEN }}
+          PR_NUMBER: ${{ needs.verify-and-prepare.outputs.rollback_pr }}
+        run: |
+          set -euo pipefail
+          pull="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}")"
+          if [[ "$(jq -r '.state' <<< "${pull}")" == closed && "$(jq -r '.merged_at // ""' <<< "${pull}")" == '' ]]; then
+            gh api --method PATCH "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" -f state=open >/dev/null
+            pull="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}")"
+          fi
+          if
+            [[ "$(jq -r '.state' <<< "${pull}")" != open ]] ||
+            [[ "$(jq -r '.head.sha' <<< "${pull}")" != "${EXPECTED_ROLLBACK_SHA}" ]] ||
+            [[ "$(jq -r '.base.ref' <<< "${pull}")" != main ]] ||
+            [[ "$(jq -r '.merged_at // ""' <<< "${pull}")" != '' ]]
+          then
+            echo 'BAYN_PAPER_ACTIVATION_HOLD rollback-pr-closed: mandatory OBSERVE rollback PR is not open and exact' >&2
+            exit 1
+          fi
+          gh pr ready "${PR_NUMBER}" --repo "${GITHUB_REPOSITORY}" || true
+
+      - name: Merge only clean exact-head protected rollback
+        if: steps.activation_state.outputs.restore == 'true'
+        env:
+          EXPECTED_ROLLBACK_SHA: ${{ needs.activate-and-observe.outputs.rollback_commit_sha || needs.verify-and-prepare.outputs.rollback_commit_sha }}
+          GH_TOKEN: ${{ secrets.AGENTS_SPLIT_TOKEN }}
+          PR_NUMBER: ${{ needs.verify-and-prepare.outputs.rollback_pr }}
+        run: |
+          set -euo pipefail
+          expected_sha="${EXPECTED_ROLLBACK_SHA}"
+          [[ "${expected_sha}" =~ ^[0-9a-f]{40}$ ]] || {
+            echo 'BAYN_PAPER_ACTIVATION_HOLD invalid-rollback-commit: workflow-produced rollback SHA is malformed' >&2
+            exit 1
+          }
+          initial_pull="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}")"
+          [[ "$(jq -r '.head.sha' <<< "${initial_pull}")" == "${expected_sha}" ]] || {
+            echo 'BAYN_PAPER_ACTIVATION_HOLD rollback-head-changed: rollback PR differs from the workflow-produced commit' >&2
+            exit 1
+          }
+          [[ "$(jq -r '.base.ref' <<< "${initial_pull}")" == main ]] || {
+            echo 'BAYN_PAPER_ACTIVATION_HOLD rollback-base-changed: mandatory rollback PR no longer targets main' >&2
+            exit 1
+          }
+          [[ "$(jq -r '.state' <<< "${initial_pull}")" == open ]] || {
+            echo 'BAYN_PAPER_ACTIVATION_HOLD rollback-pr-closed: mandatory rollback PR is not open' >&2
+            exit 1
+          }
+          count_unresolved_threads() {
+            local pr_number="$1" cursor='' page page_unresolved has_next end_cursor unresolved=0
+            local query='query($owner:String!,$name:String!,$number:Int!,$after:String){repository(owner:$owner,name:$name){pullRequest(number:$number){reviewThreads(first:100,after:$after){nodes{isResolved}pageInfo{hasNextPage endCursor}}}}}'
+            for page_number in $(seq 1 100); do
+              local -a request=(
+                graphql
+                -f "query=${query}"
+                -F "owner=${GITHUB_REPOSITORY%%/*}"
+                -F "name=${GITHUB_REPOSITORY##*/}"
+                -F "number=${pr_number}"
+              )
+              [[ -z "${cursor}" ]] || request+=(-f "after=${cursor}")
+              page="$(gh api "${request[@]}")"
+              jq -e '
+                ((.errors // []) | length) == 0 and
+                (.data.repository.pullRequest.reviewThreads.nodes | type) == "array" and
+                (.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage | type) == "boolean"
+              ' <<< "${page}" >/dev/null || {
+                echo 'BAYN_PAPER_ACTIVATION_HOLD review-thread-pagination-invalid: GitHub returned incomplete review-thread evidence' >&2
+                return 1
+              }
+              page_unresolved="$(
+                jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length' \
+                  <<< "${page}"
+              )"
+              unresolved="$((unresolved + page_unresolved))"
+              has_next="$(jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage' <<< "${page}")"
+              if [[ "${has_next}" == false ]]; then
+                printf '%s\n' "${unresolved}"
+                return 0
+              fi
+              end_cursor="$(jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.endCursor // ""' <<< "${page}")"
+              [[ -n "${end_cursor}" ]] || {
+                echo 'BAYN_PAPER_ACTIVATION_HOLD review-thread-pagination-invalid: next review-thread page has no cursor' >&2
+                return 1
+              }
+              cursor="${end_cursor}"
+            done
+            echo 'BAYN_PAPER_ACTIVATION_HOLD review-thread-pagination-limit: review-thread evidence exceeds the bounded 100-page limit' >&2
+            return 1
+          }
+          load_check_runs() {
+            local commit_sha="$1" pages
+            pages="$(
+              gh api --paginate --slurp \
+                "repos/${GITHUB_REPOSITORY}/commits/${commit_sha}/check-runs?filter=latest&per_page=100"
+            )"
+            jq -e '
+              type == "array" and length > 0 and
+              all(.[];
+                (.total_count | type) == "number" and
+                (.check_runs | type) == "array" and
+                (.check_runs | length) <= 100 and
+                all(.check_runs[]; (.id | type) == "number")
+              ) and
+              ([.[].total_count] | unique | length) == 1 and
+              ([.[] | .check_runs[]] | length) == .[0].total_count and
+              ([.[] | .check_runs[].id] | length) == ([.[] | .check_runs[].id] | unique | length)
+            ' <<< "${pages}" >/dev/null || {
+              echo 'BAYN_PAPER_ACTIVATION_HOLD check-run-pagination-invalid: GitHub returned incomplete or duplicate check-run evidence' >&2
+              return 1
+            }
+            jq -c '{check_runs: [.[] | .check_runs[]]}' <<< "${pages}"
+          }
+          for attempt in $(seq 1 100); do
+            pull="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}")"
+            [[ "$(jq -r '.head.sha' <<< "${pull}")" == "${expected_sha}" ]]
+            [[ "$(jq -r '.base.ref' <<< "${pull}")" == main ]] || {
+              echo 'BAYN_PAPER_ACTIVATION_HOLD rollback-base-changed: mandatory rollback PR no longer targets main' >&2
+              exit 1
+            }
+            [[ "$(jq -r '.state' <<< "${pull}")" == open ]] || {
+              echo 'BAYN_PAPER_ACTIVATION_HOLD rollback-pr-closed: mandatory rollback PR closed during protected-check wait' >&2
+              exit 1
+            }
+            unresolved="$(count_unresolved_threads "${PR_NUMBER}")"
+            checks="$(load_check_runs "${expected_sha}")"
+            pending="$(jq '[.check_runs[] | select(.status != "completed")] | length' <<< "${checks}")"
+            failed="$(jq '[.check_runs[] | select(.status == "completed" and (.conclusion | IN("success", "neutral", "skipped") | not))] | length' <<< "${checks}")"
+            if
+              [[ "${unresolved}" == 0 ]] &&
+              [[ "${pending}" == 0 ]] &&
+              [[ "${failed}" == 0 ]] &&
+              [[ "$(jq '.check_runs | length' <<< "${checks}")" -gt 0 ]] &&
+              [[ "$(jq -r '.mergeable_state' <<< "${pull}")" =~ ^(clean|unstable)$ ]]
+            then
+              final_pull="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}")"
+              if
+                [[ "$(jq -r '.head.sha' <<< "${final_pull}")" != "${expected_sha}" ]] ||
+                [[ "$(jq -r '.base.ref' <<< "${final_pull}")" != main ]] ||
+                [[ "$(jq -r '.state' <<< "${final_pull}")" != open ]]
+              then
+                echo 'BAYN_PAPER_ACTIVATION_HOLD rollback-base-changed: rollback head or base changed immediately before merge' >&2
+                exit 1
+              fi
+              result="$(
+                gh api --method PUT "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/merge" \
+                  -f merge_method=squash \
+                  -f sha="${expected_sha}"
+              )"
+              [[ "$(jq -r '.merged' <<< "${result}")" == true ]]
+              exit 0
+            fi
+            sleep 15
+          done
+          echo 'BAYN_PAPER_ACTIVATION_HOLD rollback-review-timeout: mandatory OBSERVE rollback did not settle' >&2
+          exit 1
+
+      - name: Verify live OBSERVE restoration
+        if: steps.activation_state.outputs.restore == 'true'
+        run: |
+          set -euo pipefail
+          for attempt in $(seq 1 60); do
+            if
+              curl -fsS --connect-timeout 5 --max-time 15 \
+                http://bayn.bayn.svc.cluster.local/v1/status > "${RUNNER_TEMP}/bayn-observe-restored.json" &&
+              jq -e '
+                .authority.brokerAccess == "read-only" and
+                .authority.capitalAuthority == "none" and
+                .authority.durable.maximum == "observe" and
+                .authority.durable.effective == "observe"
+              ' "${RUNNER_TEMP}/bayn-observe-restored.json" >/dev/null
+            then
+              exit 0
+            fi
+            sleep 10
+          done
+          exit 1
+
+      - name: Persist OBSERVE restoration proof
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: bayn-observe-restoration-${{ needs.verify-and-prepare.outputs.activation_id }}-${{ github.run_id }}
+          if-no-files-found: warn
+          retention-days: 90
+          path: ${{ runner.temp }}/bayn-observe-restored.json
+
+  rollback-watchdog:
+    name: Recover abandoned PAPER activation
+    if: >-
+      github.event_name == 'schedule'
+    runs-on: arc-arm64
+    timeout-minutes: 30
+    steps:
+      - name: Checkout current main rollback controller
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
+      - name: Restore OBSERVE for expired or abandoned activation
+        env:
+          GH_TOKEN: ${{ secrets.AGENTS_SPLIT_TOKEN }}
+        run: |
+          set -euo pipefail
+          [[ -n "${GH_TOKEN}" ]] || {
+            echo 'AGENTS_SPLIT_TOKEN is required for the PAPER rollback watchdog.' >&2
+            exit 1
+          }
+          repository_owner="${GITHUB_REPOSITORY%%/*}"
+          gh auth setup-git
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git fetch origin "main:refs/remotes/origin/main"
+          watchdog_main_sha="$(git rev-parse origin/main)"
+          git show "${watchdog_main_sha}:argocd/applications/bayn/deployment.yaml" > deployment.watchdog-current.yaml
+          bun packages/scripts/src/bayn/verify-paper-activation.ts \
+            --mode inspect-deployment-authority \
+            --deployment deployment.watchdog-current.yaml \
+            --output deployment-watchdog-authority.json
+          watchdog_maximum="$(jq -r '.maximumAuthority' deployment-watchdog-authority.json)"
+          watchdog_paper_generation="$(jq -r '.authorityGenerationHash' deployment-watchdog-authority.json)"
+          if [[ "${watchdog_maximum}" == OBSERVE ]]; then
+            echo 'GitOps already declares OBSERVE; no rollback discovery is required.'
+            exit 0
+          fi
+          [[ "${watchdog_maximum}" == PAPER ]] || {
+            echo "Current GitOps authority ${watchdog_maximum} is neither PAPER nor OBSERVE." >&2
+            exit 1
+          }
+          count_unresolved_threads() {
+            local pr_number="$1" cursor='' page page_unresolved has_next end_cursor unresolved=0
+            local query='query($owner:String!,$name:String!,$number:Int!,$after:String){repository(owner:$owner,name:$name){pullRequest(number:$number){reviewThreads(first:100,after:$after){nodes{isResolved}pageInfo{hasNextPage endCursor}}}}}'
+            for page_number in $(seq 1 100); do
+              local -a request=(
+                graphql
+                -f "query=${query}"
+                -F "owner=${GITHUB_REPOSITORY%%/*}"
+                -F "name=${GITHUB_REPOSITORY##*/}"
+                -F "number=${pr_number}"
+              )
+              [[ -z "${cursor}" ]] || request+=(-f "after=${cursor}")
+              page="$(gh api "${request[@]}")"
+              jq -e '
+                ((.errors // []) | length) == 0 and
+                (.data.repository.pullRequest.reviewThreads.nodes | type) == "array" and
+                (.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage | type) == "boolean"
+              ' <<< "${page}" >/dev/null || {
+                echo 'BAYN_PAPER_ACTIVATION_HOLD review-thread-pagination-invalid: GitHub returned incomplete review-thread evidence' >&2
+                return 1
+              }
+              page_unresolved="$(
+                jq '[.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length' \
+                  <<< "${page}"
+              )"
+              unresolved="$((unresolved + page_unresolved))"
+              has_next="$(jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage' <<< "${page}")"
+              if [[ "${has_next}" == false ]]; then
+                printf '%s\n' "${unresolved}"
+                return 0
+              fi
+              end_cursor="$(jq -r '.data.repository.pullRequest.reviewThreads.pageInfo.endCursor // ""' <<< "${page}")"
+              [[ -n "${end_cursor}" ]] || {
+                echo 'BAYN_PAPER_ACTIVATION_HOLD review-thread-pagination-invalid: next review-thread page has no cursor' >&2
+                return 1
+              }
+              cursor="${end_cursor}"
+            done
+            echo 'BAYN_PAPER_ACTIVATION_HOLD review-thread-pagination-limit: review-thread evidence exceeds the bounded 100-page limit' >&2
+            return 1
+          }
+          load_check_runs() {
+            local commit_sha="$1" pages
+            pages="$(
+              gh api --paginate --slurp \
+                "repos/${GITHUB_REPOSITORY}/commits/${commit_sha}/check-runs?filter=latest&per_page=100"
+            )"
+            jq -e '
+              type == "array" and length > 0 and
+              all(.[];
+                (.total_count | type) == "number" and
+                (.check_runs | type) == "array" and
+                (.check_runs | length) <= 100 and
+                all(.check_runs[]; (.id | type) == "number")
+              ) and
+              ([.[].total_count] | unique | length) == 1 and
+              ([.[] | .check_runs[]] | length) == .[0].total_count and
+              ([.[] | .check_runs[].id] | length) == ([.[] | .check_runs[].id] | unique | length)
+            ' <<< "${pages}" >/dev/null || {
+              echo 'BAYN_PAPER_ACTIVATION_HOLD check-run-pagination-invalid: GitHub returned incomplete or duplicate check-run evidence' >&2
+              return 1
+            }
+            jq -c '{check_runs: [.[] | .check_runs[]]}' <<< "${pages}"
+          }
+          retention_cutoff="$(date -u -d '91 days ago' +%Y-%m-%dT%H:%M:%SZ)"
+          artifact_pages="$(
+            gh api --paginate --slurp \
+              "repos/${GITHUB_REPOSITORY}/actions/artifacts?per_page=100"
+          )"
+          jq -e '
+            type == "array" and length > 0 and
+            all(.[];
+              (.total_count | type) == "number" and
+              (.artifacts | type) == "array" and
+              (.artifacts | length) <= 100 and
+              all(.artifacts[];
+                (.id | type) == "number" and
+                (.name | type) == "string" and
+                (.expired | type) == "boolean" and
+                (.created_at | type) == "string" and
+                (.workflow_run | type) == "object" and
+                (.workflow_run.id | type) == "number" and
+                .workflow_run.id > 0
+              )
+            ) and
+            ([.[].total_count] | unique | length) == 1 and
+            ([.[] | .artifacts[]] | length) == .[0].total_count and
+            ([.[] | .artifacts[].id] | length) == ([.[] | .artifacts[].id] | unique | length)
+          ' <<< "${artifact_pages}" >/dev/null || {
+            echo 'BAYN_PAPER_ACTIVATION_HOLD watchdog-artifact-list-invalid: repository artifact discovery is incomplete or duplicated' >&2
+            exit 1
+          }
+          mapfile -t attestation_artifacts < <(
+            jq -c --arg cutoff "${retention_cutoff}" '
+              .[] | .artifacts[] |
+              select(.expired == false and .created_at >= $cutoff) |
+              (.name | capture("^bayn-paper-rollback-attestation-(?<activationId>.+)-(?<runId>[1-9][0-9]*)-(?<attempt>[1-9][0-9]*)$")) as $identity |
+              select((.workflow_run.id | tostring) == $identity.runId)
+            ' <<< "${artifact_pages}"
+          )
+          for artifact in "${attestation_artifacts[@]}"; do
+            artifact_id="$(jq -r '.id' <<< "${artifact}")"
+            artifact_name="$(jq -r '.name' <<< "${artifact}")"
+            artifact_workflow_run_id="$(jq -r '.workflow_run.id' <<< "${artifact}")"
+            attestation_zip="$(mktemp)"
+            attestation_file="$(mktemp)"
+            if
+              ! gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts/${artifact_id}/zip" > "${attestation_zip}" ||
+              ! python3 -c 'import pathlib,sys,zipfile; bundle=zipfile.ZipFile(sys.argv[1]); names=bundle.namelist(); names == ["bayn-paper-rollback-attestation.json"] or (_ for _ in ()).throw(SystemExit("activation attestation archive shape is invalid")); pathlib.Path(sys.argv[2]).write_bytes(bundle.read(names[0]))' "${attestation_zip}" "${attestation_file}"
+            then
+              rm -f "${attestation_zip}" "${attestation_file}"
+              echo "Skipping attestation artifact ${artifact_id}: archive is invalid."
+              continue
+            fi
+            attestation="$(cat "${attestation_file}")"
+            rm -f "${attestation_zip}" "${attestation_file}"
+            if ! jq -e \
+              --arg artifactWorkflowRunId "${artifact_workflow_run_id}" \
+              --arg repository "${GITHUB_REPOSITORY}" \
+              --arg workflowPath '.github/workflows/bayn-paper-activation.yml' '
+                type == "object" and
+                keys == [
+                  "activationBranch",
+                  "activationCommitSha",
+                  "activationId",
+                  "authorityExpiresAt",
+                  "authorityGenerationHash",
+                  "observeAuthorityGenerationHash",
+                  "repository",
+                  "rollbackBranch",
+                  "rollbackCommitSha",
+                  "rollbackMetadataB64",
+                  "schemaVersion",
+                  "sourceMainSha",
+                  "workflowHeadSha",
+                  "workflowPath",
+                  "workflowRunAttempt",
+                  "workflowRunId"
+                ] and
+                .schemaVersion == 1 and
+                .repository == $repository and
+                .workflowPath == $workflowPath and
+                (.workflowRunId | type == "number" and floor == . and . > 0 and (tostring == $artifactWorkflowRunId)) and
+                (.workflowRunAttempt | type == "number" and floor == . and . > 0) and
+                (.activationId | type == "string" and test("^[a-z0-9][a-z0-9._-]{0,127}$")) and
+                (.activationBranch | type == "string" and startswith("codex/bayn-paper-activation/")) and
+                (.activationCommitSha | type == "string" and test("^[0-9a-f]{40}$")) and
+                (.rollbackBranch | type == "string" and startswith("codex/bayn-paper-rollback/")) and
+                (.rollbackCommitSha | type == "string" and test("^[0-9a-f]{40}$")) and
+                (.rollbackMetadataB64 | type == "string" and length > 0) and
+                (.sourceMainSha | type == "string" and test("^[0-9a-f]{40}$")) and
+                (.workflowHeadSha | type == "string" and test("^[0-9a-f]{40}$")) and
+                (.authorityGenerationHash | type == "string" and test("^[0-9a-f]{64}$")) and
+                (.observeAuthorityGenerationHash | type == "string" and test("^[0-9a-f]{64}$")) and
+                (.authorityExpiresAt | type == "string" and length > 0)
+              ' <<< "${attestation}" >/dev/null
+            then
+              echo "Skipping attestation artifact ${artifact_id}: attestation is malformed."
+              continue
+            fi
+            workflow_run_id="$(jq -r '.workflowRunId' <<< "${attestation}")"
+            workflow_run_attempt="$(jq -r '.workflowRunAttempt' <<< "${attestation}")"
+            activation_id="$(jq -r '.activationId' <<< "${attestation}")"
+            activation_branch="$(jq -r '.activationBranch' <<< "${attestation}")"
+            rollback_branch="$(jq -r '.rollbackBranch' <<< "${attestation}")"
+            metadata_b64="$(jq -r '.rollbackMetadataB64' <<< "${attestation}")"
+            expected_artifact_name="bayn-paper-rollback-attestation-${activation_id}-${workflow_run_id}-${workflow_run_attempt}"
+            [[ "${artifact_name}" == "${expected_artifact_name}" ]] || {
+              echo "Skipping activation run ${workflow_run_id}: activation attestation name is not exact."
+              continue
+            }
+            [[ "$(jq -r '.authorityGenerationHash' <<< "${attestation}")" == "${watchdog_paper_generation}" ]] || {
+              echo "Skipping stale attestation ${artifact_name}: current PAPER generation belongs to another activation."
+              continue
+            }
+            workflow_attempt="$(
+              gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${workflow_run_id}/attempts/${workflow_run_attempt}"
+            )" || {
+              echo "Skipping activation run ${workflow_run_id} attempt ${workflow_run_attempt}: workflow attempt is unavailable."
+              continue
+            }
+            if ! jq -e \
+              --arg repository "${GITHUB_REPOSITORY}" \
+              --arg workflowPath '.github/workflows/bayn-paper-activation.yml' \
+              --arg workflowRunAttempt "${workflow_run_attempt}" \
+              --arg workflowRunId "${workflow_run_id}" '
+                (.id | tostring) == $workflowRunId and
+                (.run_attempt | tostring) == $workflowRunAttempt and
+                .event == "workflow_run" and
+                .path == $workflowPath and
+                (.head_sha | type == "string" and test("^[0-9a-f]{40}$")) and
+                .repository.full_name == $repository and
+                (.status | IN("queued", "in_progress", "completed"))
+              ' <<< "${workflow_attempt}" >/dev/null
+            then
+              echo "Skipping activation run ${workflow_run_id} attempt ${workflow_run_attempt}: workflow attempt identity is invalid."
+              continue
+            fi
+            workflow_status="$(jq -r '.status' <<< "${workflow_attempt}")"
+            workflow_head_sha="$(jq -r '.head_sha' <<< "${workflow_attempt}")"
+            [[ "$(jq -r '.workflowHeadSha' <<< "${attestation}")" == "${workflow_head_sha}" ]] || {
+              echo "Skipping activation run ${workflow_run_id} attempt ${workflow_run_attempt}: workflow head differs from the attestation."
+              continue
+            }
+            source_main_sha="$(jq -r '.sourceMainSha' <<< "${attestation}")"
+            if
+              ! metadata="$(printf '%s' "${metadata_b64}" | base64 -d 2>/dev/null)" ||
+              ! jq -e \
+                --arg activationBranch "${activation_branch}" \
+                --arg activationId "${activation_id}" \
+                --arg authorityExpiresAt "$(jq -r '.authorityExpiresAt' <<< "${attestation}")" \
+                --arg authorityGenerationHash "$(jq -r '.authorityGenerationHash' <<< "${attestation}")" \
+                --arg observeAuthorityGenerationHash "$(jq -r '.observeAuthorityGenerationHash' <<< "${attestation}")" \
+                --arg rollbackBranch "${rollback_branch}" \
+                --arg sourceMainSha "${source_main_sha}" \
+                --arg workflowRunAttempt "${workflow_run_attempt}" \
+                --arg workflowRunId "${workflow_run_id}" '
+                  type == "object" and
+                  keys == [
+                    "activationBranch",
+                    "activationId",
+                    "authorityExpiresAt",
+                    "authorityGenerationHash",
+                    "baselineCycleId",
+                    "observeAuthorityGenerationHash",
+                    "previousObserveGenerationHash",
+                    "rollbackBranch",
+                    "schemaVersion",
+                    "sourceMainSha",
+                    "workflowRunAttempt",
+                    "workflowRunId"
+                  ] and
+                  .schemaVersion == 1 and
+                  .activationId == $activationId and
+                  .activationBranch == $activationBranch and
+                  .rollbackBranch == $rollbackBranch and
+                  .sourceMainSha == $sourceMainSha and
+                  .authorityGenerationHash == $authorityGenerationHash and
+                  (.previousObserveGenerationHash | type == "string" and test("^[0-9a-f]{64}$")) and
+                  .observeAuthorityGenerationHash == $observeAuthorityGenerationHash and
+                  .authorityExpiresAt == $authorityExpiresAt and
+                  (.baselineCycleId | type == "string") and
+                  (.workflowRunAttempt | tostring) == $workflowRunAttempt and
+                  (.workflowRunId | tostring) == $workflowRunId
+                ' <<< "${metadata}" >/dev/null
+            then
+              echo "Skipping activation run ${workflow_run_id}: rollback metadata is malformed or does not match the attestation."
+              continue
+            fi
+            activation_commit_sha="$(jq -r '.activationCommitSha' <<< "${attestation}")"
+            initial_rollback_sha="$(jq -r '.rollbackCommitSha' <<< "${attestation}")"
+            activation_commit_record="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${activation_commit_sha}")"
+            initial_rollback_record="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${initial_rollback_sha}")"
+            jq -e \
+              --arg activationCommitSha "${activation_commit_sha}" \
+              --arg sourceMainSha "${source_main_sha}" '
+                .sha == $activationCommitSha and
+                (.parents | length) == 1 and
+                .parents[0].sha == $sourceMainSha and
+                (.files | length) == 1 and
+                .files[0].filename == "argocd/applications/bayn/deployment.yaml" and
+                .files[0].status == "modified"
+              ' <<< "${activation_commit_record}" >/dev/null || {
+              echo "Skipping activation run ${workflow_run_id}: workflow-produced activation commit is invalid."
+              continue
+            }
+            jq -e \
+              --arg metadataLine "BAYN_PAPER_ROLLBACK_METADATA=${metadata_b64}" \
+              --arg rollbackCommitSha "${initial_rollback_sha}" \
+              --arg sourceMainSha "${source_main_sha}" '
+                .sha == $rollbackCommitSha and
+                (.parents | length) == 1 and
+                .parents[0].sha == $sourceMainSha and
+                (.files | length) == 1 and
+                .files[0].filename == "argocd/applications/bayn/deployment.yaml" and
+                .files[0].status == "modified" and
+                ([.commit.message | split("\n")[] | select(startswith("BAYN_PAPER_ROLLBACK_METADATA="))] == [$metadataLine])
+              ' <<< "${initial_rollback_record}" >/dev/null || {
+              echo "Skipping activation run ${workflow_run_id}: workflow-produced rollback commit is invalid."
+              continue
+            }
+            activation_prs="$(
+              gh api "repos/${GITHUB_REPOSITORY}/pulls?state=all&head=${repository_owner}:${activation_branch}&per_page=100"
+            )"
+            activation_candidates="$(
+              jq --arg branch "${activation_branch}" --arg head "${activation_commit_sha}" '
+                [.[] | select(
+                  .merged_at != null and
+                  (.base.ref | type) == "string" and
+                  (.base.ref | length) > 0 and
+                  .head.ref == $branch and
+                  .head.sha == $head
+                )]
+              ' <<< "${activation_prs}"
+            )"
+            [[ "$(jq 'length' <<< "${activation_candidates}")" == 1 ]] || continue
+            if ! deadline_epoch="$(date -u -d "$(jq -r '.authorityExpiresAt' <<< "${metadata}")" +%s 2>/dev/null)"; then
+              echo "Skipping activation run ${workflow_run_id}: authority deadline is malformed."
+              continue
+            fi
+            now_epoch="$(date -u +%s)"
+            if [[ "${workflow_status}" =~ ^(queued|in_progress)$ && "${now_epoch}" -lt "${deadline_epoch}" ]]; then
+              continue
+            fi
+
+            observe_generation="$(jq -r '.observeAuthorityGenerationHash' <<< "${metadata}")"
+            gh auth setup-git
+            git config user.name 'github-actions[bot]'
+            git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+            git fetch origin "main:refs/remotes/origin/main"
+            current_main_sha="$(git rev-parse origin/main)"
+            git show "${current_main_sha}:argocd/applications/bayn/deployment.yaml" > deployment.current.yaml
+            bun packages/scripts/src/bayn/verify-paper-activation.ts \
+              --mode inspect-deployment-authority \
+              --deployment deployment.current.yaml \
+              --output deployment-authority.json
+            current_maximum="$(jq -r '.maximumAuthority' deployment-authority.json)"
+            current_generation="$(jq -r '.authorityGenerationHash' deployment-authority.json)"
+            if [[ "${current_maximum}" == OBSERVE ]]; then
+              continue
+            fi
+            [[ "${current_maximum}" == PAPER ]] || {
+              echo "Current GitOps authority ${current_maximum} is neither PAPER nor OBSERVE." >&2
+              exit 1
+            }
+            expected_paper_generation="$(jq -r '.authorityGenerationHash' <<< "${metadata}")"
+            if [[ "${current_generation}" != "${expected_paper_generation}" ]]; then
+              echo "Skipping stale rollback ${rollback_branch}: current PAPER generation belongs to another activation."
+              continue
+            fi
+            bun packages/scripts/src/bayn/verify-paper-activation.ts \
+              --mode render-rollback \
+              --deployment deployment.current.yaml \
+              --observe-authority-generation-hash "${observe_generation}" \
+              --output deployment.observe.yaml
+            desired_blob="$(git hash-object -w deployment.observe.yaml)"
+            index="$(mktemp)"
+            rm -f "${index}"
+            GIT_INDEX_FILE="${index}" git read-tree "${current_main_sha}"
+            GIT_INDEX_FILE="${index}" git update-index --add --cacheinfo \
+              100644,"${desired_blob}",argocd/applications/bayn/deployment.yaml
+            tree="$(GIT_INDEX_FILE="${index}" git write-tree)"
+            commit_date="$(jq -r '.authorityExpiresAt' <<< "${metadata}")"
+            new_rollback_sha="$(
+              printf 'chore(bayn): watchdog restore OBSERVE %s\n\nBAYN_PAPER_ROLLBACK_METADATA=%s\n' \
+                "${activation_id}" "${metadata_b64}" |
+                GIT_AUTHOR_DATE="${commit_date}" GIT_COMMITTER_DATE="${commit_date}" \
+                  git commit-tree "${tree}" -p "${current_main_sha}"
+            )"
+            rm -f "${index}"
+            mapfile -t rollback_remote_refs < <(git ls-remote --heads origin "refs/heads/${rollback_branch}")
+            [[ "${#rollback_remote_refs[@]}" -le 1 ]] || {
+              echo "Rollback branch ${rollback_branch} resolved to multiple remote refs." >&2
+              exit 1
+            }
+            existing_rollback_sha=''
+            if [[ "${#rollback_remote_refs[@]}" == 1 ]]; then
+              existing_rollback_sha="${rollback_remote_refs[0]%%$'\t'*}"
+              [[ "${existing_rollback_sha}" =~ ^[0-9a-f]{40}$ ]] || {
+                echo "Rollback branch ${rollback_branch} has an invalid remote head." >&2
+                exit 1
+              }
+            fi
+            if [[ "${existing_rollback_sha}" != "${new_rollback_sha}" ]]; then
+              git push --force-with-lease="refs/heads/${rollback_branch}:${existing_rollback_sha}" \
+                origin "${new_rollback_sha}:refs/heads/${rollback_branch}"
+            fi
+            rollback_prs="$(
+              gh api "repos/${GITHUB_REPOSITORY}/pulls?state=all&head=${repository_owner}:${rollback_branch}&per_page=100"
+            )"
+            rollback_candidates="$(
+              jq --arg branch "${rollback_branch}" --arg head "${new_rollback_sha}" '
+                [.[] | select(.merged_at == null and .base.ref == "main" and .head.ref == $branch and .head.sha == $head)]
+              ' <<< "${rollback_prs}"
+            )"
+            candidate_count="$(jq 'length' <<< "${rollback_candidates}")"
+            [[ "${candidate_count}" -le 1 ]] || {
+              echo "Rollback branch ${rollback_branch} has multiple exact unmerged main PRs." >&2
+              exit 1
+            }
+            if [[ "${candidate_count}" == 0 ]]; then
+              template_file='.github/PULL_REQUEST_TEMPLATE.md'
+              test -s "${template_file}"
+              for heading in '## Summary' '## Related Issues' '## Testing' '## Breaking Changes' '## Checklist'; do
+                grep -Fxq "${heading}" "${template_file}"
+              done
+              {
+                printf '%s\n' '## Summary' ''
+                printf -- '- Restore Bayn to explicit OBSERVE / read-only / no-capital authority after activation `%s`.\n' "${activation_id}"
+                printf '%s\n' \
+                  '- Recreate the exact main-targeted rollback after the prior pull-request path became unusable.' \
+                  '- Preserve the workflow-attested authority and rollback generation binding.' \
+                  '' \
+                  '## Related Issues' \
+                  '' \
+                  'PROOMPT-405' \
+                  '' \
+                  '## Testing' \
+                  '' \
+                  '- The watchdog authenticated the exact activation workflow run, attestation artifact, activation commit, rollback commit, and current PAPER generation.' \
+                  '- Protected checks and every review-thread page are revalidated on the unchanged exact head before merge.' \
+                  '' \
+                  '## Breaking Changes' \
+                  '' \
+                  'None' \
+                  '' \
+                  '## Checklist' \
+                  '' \
+                  '- [x] Testing section documents the exact validation performed (or `N/A` with justification).' \
+                  '- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).' \
+                  '- [x] Documentation, release notes, and follow-ups are updated or tracked.'
+              } > rollback-watchdog-pr-body.md
+              rollback_url="$(
+                gh pr create \
+                  --repo "${GITHUB_REPOSITORY}" \
+                  --base main \
+                  --head "${rollback_branch}" \
+                  --title "chore(bayn): watchdog restore OBSERVE ${activation_id}" \
+                  --body-file rollback-watchdog-pr-body.md
+              )"
+              rollback_pr="${rollback_url##*/}"
+            else
+              rollback_pr="$(jq -r '.[0].number' <<< "${rollback_candidates}")"
+            fi
+            rollback_pull="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${rollback_pr}")"
+            if [[ "$(jq -r '.state' <<< "${rollback_pull}")" == closed && "$(jq -r '.merged_at // ""' <<< "${rollback_pull}")" == '' ]]; then
+              gh api --method PATCH "repos/${GITHUB_REPOSITORY}/pulls/${rollback_pr}" -f state=open >/dev/null
+              rollback_pull="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${rollback_pr}")"
+            fi
+            if
+              [[ "$(jq -r '.state' <<< "${rollback_pull}")" != open ]] ||
+              [[ "$(jq -r '.head.sha' <<< "${rollback_pull}")" != "${new_rollback_sha}" ]] ||
+              [[ "$(jq -r '.head.ref' <<< "${rollback_pull}")" != "${rollback_branch}" ]] ||
+              [[ "$(jq -r '.base.ref' <<< "${rollback_pull}")" != main ]] ||
+              [[ "$(jq -r '.merged_at // ""' <<< "${rollback_pull}")" != '' ]]
+            then
+              echo "Rollback PR #${rollback_pr} is not the exact open main-targeted rollback." >&2
+              exit 1
+            fi
+            gh pr ready "${rollback_pr}" --repo "${GITHUB_REPOSITORY}" || true
+            rollback_merged='false'
+            for check_attempt in $(seq 1 40); do
+              pull="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${rollback_pr}")"
+              [[ "$(jq -r '.head.sha' <<< "${pull}")" == "${new_rollback_sha}" ]] || {
+                echo "Rollback PR #${rollback_pr} head changed during protected-check wait." >&2
+                exit 1
+              }
+              [[ "$(jq -r '.base.ref' <<< "${pull}")" == main ]] || {
+                echo "Rollback PR #${rollback_pr} no longer targets main." >&2
+                exit 1
+              }
+              [[ "$(jq -r '.state' <<< "${pull}")" == open ]] || {
+                echo "Rollback PR #${rollback_pr} closed during protected-check wait." >&2
+                exit 1
+              }
+              unresolved="$(count_unresolved_threads "${rollback_pr}")"
+              checks="$(load_check_runs "${new_rollback_sha}")"
+              pending="$(jq '[.check_runs[] | select(.status != "completed")] | length' <<< "${checks}")"
+              failed="$(jq '[.check_runs[] | select(.status == "completed" and (.conclusion | IN("success", "neutral", "skipped") | not))] | length' <<< "${checks}")"
+              if
+                [[ "${unresolved}" == 0 ]] &&
+                [[ "${pending}" == 0 ]] &&
+                [[ "${failed}" == 0 ]] &&
+                [[ "$(jq '.check_runs | length' <<< "${checks}")" -gt 0 ]] &&
+                [[ "$(jq -r '.mergeable_state' <<< "${pull}")" =~ ^(clean|unstable)$ ]]
+              then
+                final_pull="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${rollback_pr}")"
+                if
+                  [[ "$(jq -r '.head.sha' <<< "${final_pull}")" != "${new_rollback_sha}" ]] ||
+                  [[ "$(jq -r '.base.ref' <<< "${final_pull}")" != main ]] ||
+                  [[ "$(jq -r '.state' <<< "${final_pull}")" != open ]]
+                then
+                  echo "Rollback PR #${rollback_pr} head or base changed immediately before merge." >&2
+                  exit 1
+                fi
+                result="$(
+                  gh api --method PUT "repos/${GITHUB_REPOSITORY}/pulls/${rollback_pr}/merge" \
+                    -f merge_method=squash \
+                    -f sha="${new_rollback_sha}"
+                )"
+                [[ "$(jq -r '.merged' <<< "${result}")" == true ]]
+                rollback_merged='true'
+                break
+              fi
+              sleep 15
+            done
+            [[ "${rollback_merged}" == true ]] || {
+              echo "Rollback PR #${rollback_pr} did not reach a clean exact-head reviewed state." >&2
+              exit 1
+            }
+          done

--- a/packages/scripts/src/bayn/bayn-paper-activation-workflow.test.ts
+++ b/packages/scripts/src/bayn/bayn-paper-activation-workflow.test.ts
@@ -1,0 +1,2121 @@
+import { chmodSync, existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+
+import { describe, expect, test } from 'bun:test'
+import { parse } from 'yaml'
+
+const path = new URL('../../../../.github/workflows/bayn-paper-activation.yml', import.meta.url)
+const workflow = readFileSync(path, 'utf8')
+const parsed = parse(workflow) as {
+  readonly name: string
+  readonly on: Readonly<{
+    readonly workflow_run?: Readonly<{
+      readonly workflows: readonly string[]
+      readonly types: readonly string[]
+      readonly branches: readonly string[]
+    }>
+    readonly schedule?: readonly { readonly cron: string }[]
+    readonly workflow_dispatch?: unknown
+    readonly push?: unknown
+    readonly pull_request?: unknown
+    readonly pull_request_target?: unknown
+  }>
+  readonly jobs: Readonly<
+    Record<
+      string,
+      {
+        readonly if?: string
+        readonly steps: readonly {
+          readonly name?: string
+          readonly run?: string
+          readonly if?: string
+          readonly uses?: string
+          readonly with?: Readonly<Record<string, unknown>>
+        }[]
+      }
+    >
+  >
+}
+
+const count = (value: string): number => workflow.split(value).length - 1
+const scriptFor = (jobName: string, stepName: string): string => {
+  const step = parsed.jobs[jobName]?.steps.find((candidate) => candidate.name === stepName)
+  if (step?.run === undefined) throw new Error(`workflow step ${jobName}/${stepName} is missing`)
+  return step.run
+}
+const stepFor = (jobName: string, stepName: string) => {
+  const step = parsed.jobs[jobName]?.steps.find((candidate) => candidate.name === stepName)
+  if (step === undefined) throw new Error(`workflow step ${jobName}/${stepName} is missing`)
+  return step
+}
+
+const writeExecutable = (directory: string, name: string, contents: string): void => {
+  const target = join(directory, name)
+  writeFileSync(target, `#!/bin/bash\nset -euo pipefail\n${contents}\n`)
+  chmodSync(target, 0o755)
+}
+
+const isoSeconds = (epochMs: number): string => new Date(epochMs).toISOString().replace(/\.\d{3}Z$/, 'Z')
+
+const portableDate = `
+python3 - "$@" <<'PY'
+import datetime
+import sys
+
+args = sys.argv[1:]
+value = None
+if '-d' in args:
+    index = args.index('-d')
+    value = args[index + 1]
+    if value.endswith(' days ago'):
+        days = int(value.removesuffix(' days ago'))
+        instant = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=days)
+    else:
+        instant = datetime.datetime.fromisoformat(value.replace('Z', '+00:00'))
+else:
+    instant = datetime.datetime.now(datetime.timezone.utc)
+format_arg = next((arg for arg in args if arg.startswith('+')), '+%Y-%m-%dT%H:%M:%SZ')
+if format_arg == '+%s':
+    print(int(instant.timestamp()))
+elif format_arg == '+%s%3N':
+    print(int(instant.timestamp()) * 1000 + instant.microsecond // 1000)
+else:
+    print(instant.astimezone(datetime.timezone.utc).strftime(format_arg[1:]))
+PY
+`
+
+const runWorkflowScript = async (input: {
+  readonly script: string
+  readonly environment: Readonly<Record<string, string>>
+  readonly executables?: Readonly<Record<string, string>>
+  readonly files?: Readonly<Record<string, string>>
+}) => {
+  const root = mkdtempSync(join(tmpdir(), 'bayn-paper-workflow-'))
+  const bin = join(root, 'bin')
+  mkdirSync(bin)
+  writeExecutable(bin, 'date', portableDate)
+  for (const [name, contents] of Object.entries(input.executables ?? {})) writeExecutable(bin, name, contents)
+  for (const [name, contents] of Object.entries(input.files ?? {})) {
+    const target = join(root, name)
+    mkdirSync(dirname(target), { recursive: true })
+    writeFileSync(target, contents)
+  }
+  const output = join(root, 'github-output')
+  const process = Bun.spawn(['bash', '-c', input.script], {
+    cwd: root,
+    env: {
+      ...globalThis.process.env,
+      PATH: `${bin}:${globalThis.process.env.PATH ?? ''}`,
+      GITHUB_OUTPUT: output,
+      GITHUB_REPOSITORY: 'proompteng/lab',
+      RUNNER_TEMP: root,
+      ...input.environment,
+    },
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+  const [exitCode, stdout, stderr] = await Promise.all([
+    process.exited,
+    new Response(process.stdout).text(),
+    new Response(process.stderr).text(),
+  ])
+  const githubOutput = readFileSync(output, { encoding: 'utf8', flag: 'a+' })
+  return {
+    exitCode,
+    stdout,
+    stderr,
+    githubOutput,
+    root,
+    dispose: () => rmSync(root, { recursive: true, force: true }),
+  }
+}
+
+const mergeGh = `
+case "$*" in
+  *"/merge"*)
+    printf '%s\n' merge >> "${'${FAKE_MERGE_LOG}'}"
+    printf '%s\n' '{"merged":true}'
+    ;;
+  *"--method PATCH"*"pulls/${'${ROLLBACK_PR_NUMBER}'}"*)
+    printf '%s\n' reopen >> "${'${FAKE_ROLLBACK_REOPEN_LOG}'}"
+    printf '%s\n' '{"state":"open"}'
+    ;;
+  *"git/ref/heads/"*) printf '%s\n' "${'${FAKE_HEAD_SHA}'}" ;;
+  *"check-runs?filter=latest"*)
+    printf '%s\n' '[{"total_count":1,"check_runs":[{"id":1,"status":"completed","conclusion":"success"}]}]'
+    ;;
+  *"commits/main"*) printf '%s\n' "${'${FAKE_MAIN_SHA}'}" ;;
+  *"api graphql"*)
+    printf '%s\n' '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}'
+    ;;
+  *"pulls/${'${ROLLBACK_PR_NUMBER}'}"*)
+    rollback_state="${'${FAKE_ROLLBACK_STATE}'}"
+    [[ -s "${'${FAKE_ROLLBACK_REOPEN_LOG}'}" ]] && rollback_state=open
+    printf '{"state":"%s","head":{"sha":"%s","ref":"%s"},"base":{"ref":"%s"},"merged_at":null}\n' \
+      "${'${rollback_state}'}" "${'${FAKE_ROLLBACK_HEAD_SHA}'}" "${'${ROLLBACK_BRANCH}'}" "${'${FAKE_ROLLBACK_BASE_REF}'}"
+    ;;
+  *"pulls/${'${PR_NUMBER}'}"*)
+    printf '{"head":{"sha":"%s"},"base":{"ref":"main","sha":"%s"},"mergeable_state":"clean","merged_at":"2026-07-31T00:05:00Z"}\n' \
+      "${'${FAKE_HEAD_SHA}'}" "${'${FAKE_PULL_BASE_SHA}'}"
+    ;;
+  *) printf 'unexpected gh invocation: %s\n' "$*" >&2; exit 90 ;;
+esac
+`
+
+const activationRollbackEnvironment = {
+  EXPECTED_ROLLBACK_SHA: '4'.repeat(40),
+  ROLLBACK_BRANCH: 'codex/bayn-paper-rollback/test',
+  ROLLBACK_PR_NUMBER: '2',
+  FAKE_ROLLBACK_HEAD_SHA: '4'.repeat(40),
+  FAKE_ROLLBACK_STATE: 'open',
+  FAKE_ROLLBACK_BASE_REF: 'main',
+  FAKE_ROLLBACK_REOPEN_LOG: 'rollback-reopen.log',
+} as const
+
+const paperStatus = (input: {
+  readonly checkedAt: string
+  readonly access?: 'mutation' | 'read-only'
+  readonly capital?: 'sandbox-capital' | 'none'
+  readonly maximum?: 'paper' | 'observe'
+  readonly effective?: 'paper' | 'observe'
+  readonly current?: unknown
+  readonly last?: unknown
+  readonly zeroMutation?: boolean
+  readonly mutationEventCount?: number
+  readonly unresolvedMutationCount?: number
+  readonly coversLatestMutation?: boolean
+  readonly authorityGenerationHash?: string
+  readonly authorityUpdatedAt?: string
+}) =>
+  JSON.stringify({
+    operational: { ready: true, checkedAt: input.checkedAt },
+    qualification: { verdict: 'QUALIFIED' },
+    build: { sourceRevision: 'b'.repeat(40), image: { digest: `sha256:${'c'.repeat(64)}` } },
+    authority: {
+      brokerEnvironment: 'sandbox',
+      brokerAccess: input.access ?? 'mutation',
+      capitalAuthority: input.capital ?? 'sandbox-capital',
+      durable: {
+        available: true,
+        maximum: input.maximum ?? 'paper',
+        effective: input.effective ?? 'paper',
+        kill: 'clear',
+      },
+    },
+    cycle: {
+      observationAvailable: true,
+      zeroMutation: input.zeroMutation ?? true,
+      authority: {
+        generationHash: input.authorityGenerationHash ?? 'f'.repeat(64),
+        updatedAt: input.authorityUpdatedAt ?? input.checkedAt,
+      },
+      current: input.current ?? null,
+      last: input.last ?? null,
+      mutations: {
+        eventCount: input.mutationEventCount ?? 0,
+        unresolvedCount: input.unresolvedMutationCount ?? 0,
+      },
+      reconciliation: {
+        status: 'EXACT',
+        discrepancyCount: 0,
+        coversLatestMutation: input.coversLatestMutation ?? true,
+      },
+    },
+  })
+
+const runWatchdog = async (
+  runtimeStatus: string,
+  options: {
+    readonly expected?: string
+    readonly current?: string
+    readonly initialBaseRef?: string
+    readonly finalBaseRef?: string
+    readonly rollbackState?: 'open' | 'closed'
+    readonly foreignBaseMergedOnly?: boolean
+    readonly attestationMatches?: boolean
+    readonly branchMissing?: boolean
+    readonly gitopsObserve?: boolean
+    readonly latestRunAttempt?: number
+    readonly attestationAttempt?: number
+    readonly unrelatedArtifactCount?: number
+    readonly artifactProducerRunId?: number
+    readonly activationBaseRef?: string
+  } = {},
+) => {
+  const rollbackBranch = 'codex/bayn-paper-rollback/test-activation'
+  const activationBranch = 'codex/bayn-paper-activation/test-activation'
+  const activationSha = '1'.repeat(40)
+  const initialRollbackSha = '2'.repeat(40)
+  const rollbackSha = '4'.repeat(40)
+  const mainSha = '5'.repeat(40)
+  const workflowHeadSha = 'a'.repeat(40)
+  const desiredBlob = '6'.repeat(40)
+  const authorityGenerationHash = options.expected ?? '8'.repeat(64)
+  const observeAuthorityGenerationHash = '7'.repeat(64)
+  const latestRunAttempt = options.latestRunAttempt ?? 1
+  const attestationAttempt = options.attestationAttempt ?? 1
+  const metadata = Buffer.from(
+    JSON.stringify({
+      schemaVersion: 1,
+      activationId: 'test-activation',
+      activationBranch,
+      rollbackBranch,
+      sourceMainSha: mainSha,
+      authorityExpiresAt: '2026-07-31T00:00:00Z',
+      authorityGenerationHash,
+      previousObserveGenerationHash: '6'.repeat(64),
+      observeAuthorityGenerationHash,
+      baselineCycleId: '',
+      workflowRunId: 1,
+      workflowRunAttempt: attestationAttempt,
+    }),
+  ).toString('base64')
+  const attestation = JSON.stringify({
+    schemaVersion: 1,
+    repository: 'proompteng/lab',
+    workflowPath: '.github/workflows/bayn-paper-activation.yml',
+    workflowRunId: 1,
+    workflowRunAttempt: attestationAttempt,
+    activationId: 'test-activation',
+    activationBranch,
+    activationCommitSha: activationSha,
+    rollbackBranch,
+    rollbackCommitSha: initialRollbackSha,
+    rollbackMetadataB64: options.attestationMatches === false ? `${metadata}forged` : metadata,
+    sourceMainSha: mainSha,
+    workflowHeadSha,
+    authorityGenerationHash,
+    observeAuthorityGenerationHash,
+    authorityExpiresAt: '2026-07-31T00:00:00Z',
+  })
+  return runWorkflowScript({
+    script: scriptFor('rollback-watchdog', 'Restore OBSERVE for expired or abandoned activation'),
+    executables: {
+      curl: `cat "${'${FAKE_RUNTIME_STATUS}'}"`,
+      bun: `
+mode=''
+output=''
+previous=''
+for argument in "$@"; do
+  if [[ "${'${previous}'}" == --mode ]]; then mode="${'${argument}'}"; fi
+  if [[ "${'${previous}'}" == --output ]]; then output="${'${argument}'}"; fi
+  previous="${'${argument}'}"
+done
+case "${'${mode}'}" in
+  inspect-deployment-authority)
+    if [[ "${'${FAKE_GITOPS_MAXIMUM}'}" == OBSERVE ]]; then
+      printf '{"maximumAuthority":"OBSERVE","brokerAccess":"read-only","capitalAuthority":"none","authorityGenerationHash":"%s"}\n' \
+        "${'${FAKE_PAPER_GENERATION}'}" > "${'${output}'}"
+    else
+      printf '{"maximumAuthority":"PAPER","brokerAccess":"mutation","capitalAuthority":"sandbox-capital","authorityGenerationHash":"%s"}\n' \
+        "${'${FAKE_PAPER_GENERATION}'}" > "${'${output}'}"
+    fi
+    ;;
+  render-rollback) cat "${'${FAKE_OBSERVE_DEPLOYMENT}'}" > "${'${output}'}" ;;
+  *) printf 'unexpected bun mode: %s\n' "${'${mode}'}" >&2; exit 92 ;;
+esac
+`,
+      git: `
+case "$*" in
+  "config "*|"fetch "*|"read-tree "*|"update-index "*) exit 0 ;;
+  "rev-parse origin/main") printf '%s\n' "${'${FAKE_MAIN_SHA}'}" ;;
+  "show ${'${FAKE_MAIN_SHA}'}:argocd/applications/bayn/deployment.yaml") cat "${'${FAKE_PAPER_DEPLOYMENT}'}" ;;
+  "hash-object -w deployment.observe.yaml") printf '%s\n' "${'${FAKE_DESIRED_BLOB}'}" ;;
+  "write-tree") printf '%s\n' "${'${FAKE_TREE_SHA}'}" ;;
+  "commit-tree "*) printf '%s\n' "${'${FAKE_ROLLBACK_SHA}'}" ;;
+  "ls-remote --heads origin refs/heads/${'${FAKE_ROLLBACK_BRANCH}'}")
+    if [[ "${'${FAKE_BRANCH_MISSING}'}" != true ]]; then
+      printf '%s\trefs/heads/%s\n' "${'${FAKE_ROLLBACK_SHA}'}" "${'${FAKE_ROLLBACK_BRANCH}'}"
+    fi
+    ;;
+  "push "*) printf '%s\n' push >> "${'${FAKE_PUSH_LOG}'}" ;;
+  *) printf 'unexpected git invocation: %s\n' "$*" >&2; exit 93 ;;
+esac
+`,
+      gh: `
+case "$*" in
+  *"pr comment"*) printf 'manual review trigger is prohibited\n' >&2; exit 94 ;;
+  *"branches?per_page=100"*)
+    printf 'branch-first watchdog discovery is prohibited\n' >&2
+    exit 96
+    ;;
+  *"actions/runs/"*"/artifacts"*)
+    printf 'per-run artifact discovery is prohibited\n' >&2
+    exit 97
+    ;;
+  *"actions/artifacts?per_page=100"*)
+    printf '%s\n' scan >> "${'${FAKE_ARTIFACT_SCAN_LOG}'}"
+    python3 - "${'${FAKE_UNRELATED_ARTIFACT_COUNT}'}" "${'${FAKE_ATTESTATION_ATTEMPT}'}" "${'${FAKE_LATEST_RUN_ATTEMPT}'}" "${'${FAKE_ARTIFACT_PRODUCER_RUN_ID}'}" <<'PY'
+import json
+import sys
+
+unrelated = int(sys.argv[1])
+attestation_attempt = int(sys.argv[2])
+latest_attempt = int(sys.argv[3])
+producer_run_id = int(sys.argv[4])
+artifacts = [{
+    "id": 99,
+    "name": f"bayn-paper-rollback-attestation-test-activation-1-{attestation_attempt}",
+    "expired": False,
+    "created_at": "2026-07-31T00:00:00Z",
+    "workflow_run": {"id": producer_run_id},
+}]
+if latest_attempt != attestation_attempt:
+    artifacts.append({
+        "id": 98,
+        "name": f"bayn-paper-rollback-attestation-test-activation-1-{latest_attempt}",
+        "expired": True,
+        "created_at": "2026-07-31T00:01:00Z",
+        "workflow_run": {"id": 1},
+    })
+for index in range(unrelated):
+    artifacts.append({
+        "id": 1000 + index,
+        "name": f"unrelated-artifact-{index}",
+        "expired": False,
+        "created_at": "2026-07-31T00:00:00Z",
+        "workflow_run": {"id": 1000 + index},
+    })
+total = len(artifacts)
+pages = [{"total_count": total, "artifacts": artifacts[offset:offset + 100]} for offset in range(0, total, 100)]
+print(json.dumps(pages, separators=(",", ":")))
+PY
+    ;;
+  *"actions/runs/1/attempts/${'${FAKE_ATTESTATION_ATTEMPT}'}"*)
+    printf '{"id":1,"run_attempt":%s,"event":"workflow_run","path":".github/workflows/bayn-paper-activation.yml","head_sha":"%s","repository":{"full_name":"proompteng/lab"},"status":"completed"}\n' \
+      "${'${FAKE_ATTESTATION_ATTEMPT}'}" "${'${FAKE_WORKFLOW_HEAD_SHA}'}"
+    ;;
+  *"commits/${'${FAKE_ACTIVATION_SHA}'}"*)
+    printf '{"sha":"%s","parents":[{"sha":"%s"}],"files":[{"filename":"argocd/applications/bayn/deployment.yaml","status":"modified"}],"commit":{"message":"activation"}}\n' \
+      "${'${FAKE_ACTIVATION_SHA}'}" "${'${FAKE_MAIN_SHA}'}"
+    ;;
+  *"commits/${'${FAKE_INITIAL_ROLLBACK_SHA}'}"*)
+    message="$(printf 'chore(bayn): rollback\n\nBAYN_PAPER_ROLLBACK_METADATA=%s' "${'${FAKE_METADATA_B64}'}")"
+    jq -nc \
+      --arg sha "${'${FAKE_INITIAL_ROLLBACK_SHA}'}" \
+      --arg parent "${'${FAKE_MAIN_SHA}'}" \
+      --arg message "${'${message}'}" \
+      '{sha:$sha,parents:[{sha:$parent}],files:[{filename:"argocd/applications/bayn/deployment.yaml",status:"modified"}],commit:{message:$message}}'
+    ;;
+  *"actions/artifacts/99/zip"*)
+    printf '%s\n' open >> "${'${FAKE_ARTIFACT_OPEN_LOG}'}"
+    python3 - "${'${FAKE_ATTESTATION_FILE}'}" <<'PY'
+import io
+import pathlib
+import sys
+import zipfile
+
+buffer = io.BytesIO()
+with zipfile.ZipFile(buffer, 'w') as archive:
+    archive.writestr('bayn-paper-rollback-attestation.json', pathlib.Path(sys.argv[1]).read_bytes())
+sys.stdout.buffer.write(buffer.getvalue())
+PY
+    ;;
+  *"pulls?state=all"*"${'${FAKE_ACTIVATION_BRANCH}'}"*)
+    printf '[{"number":40,"state":"closed","merged_at":"2026-07-31T00:00:00Z","head":{"sha":"%s","ref":"%s"},"base":{"ref":"%s"}}]\n' \
+      "${'${FAKE_ACTIVATION_SHA}'}" "${'${FAKE_ACTIVATION_BRANCH}'}" "${'${FAKE_ACTIVATION_BASE_REF}'}"
+    ;;
+  *"pulls?state=all"*"${'${FAKE_ROLLBACK_BRANCH}'}"*)
+    if [[ "${'${FAKE_BRANCH_MISSING}'}" == true ]]; then
+      printf '%s\n' '[]'
+    elif [[ "${'${FAKE_FOREIGN_BASE_MERGED_ONLY}'}" == true ]]; then
+      printf '[{"number":41,"state":"closed","merged_at":"2026-07-31T00:01:00Z","head":{"sha":"%s","ref":"%s"},"base":{"ref":"foreign"}}]\n' \
+        "${'${FAKE_ROLLBACK_SHA}'}" "${'${FAKE_ROLLBACK_BRANCH}'}"
+    else
+      printf '[{"number":42,"state":"%s","merged_at":null,"head":{"sha":"%s","ref":"%s"},"base":{"ref":"%s"}}]\n' \
+        "${'${FAKE_ROLLBACK_STATE}'}" "${'${FAKE_ROLLBACK_SHA}'}" "${'${FAKE_ROLLBACK_BRANCH}'}" "${'${FAKE_INITIAL_BASE_REF}'}"
+    fi
+    ;;
+  *"pr create"*)
+    printf '%s\n' create >> "${'${FAKE_PR_CREATE_LOG}'}"
+    printf '%s\n' 'https://github.com/proompteng/lab/pull/77'
+    ;;
+  *"--method PATCH"*"pulls/42"*|*"--method PATCH"*"pulls/77"*)
+    printf '%s\n' reopen >> "${'${FAKE_WATCHDOG_REOPEN_LOG}'}"
+    printf '%s\n' '{"state":"open"}'
+    ;;
+  "auth setup-git"|"pr ready 42 --repo proompteng/lab"|"pr ready 77 --repo proompteng/lab") exit 0 ;;
+  *"api graphql"*)
+    printf '%s\n' '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}'
+    ;;
+  *"commits/${'${FAKE_ROLLBACK_SHA}'}/check-runs"*) printf '%s\n' '[{"total_count":1,"check_runs":[{"id":1,"status":"completed","conclusion":"success"}]}]' ;;
+  *"pulls/42/merge"*|*"pulls/77/merge"*) printf '%s\n' merge >> "${'${FAKE_MERGE_LOG}'}"; printf '%s\n' '{"merged":true}' ;;
+  *"pulls/42"*|*"pulls/77"*)
+    count=0
+    [[ -s "${'${FAKE_PULL_COUNTER}'}" ]] && count="$(cat "${'${FAKE_PULL_COUNTER}'}")"
+    count=$((count + 1))
+    printf '%s' "${'${count}'}" > "${'${FAKE_PULL_COUNTER}'}"
+    base_ref="${'${FAKE_INITIAL_BASE_REF}'}"
+    [[ "${'${count}'}" -gt 2 ]] && base_ref="${'${FAKE_FINAL_BASE_REF}'}"
+    rollback_state="${'${FAKE_ROLLBACK_STATE}'}"
+    [[ -s "${'${FAKE_WATCHDOG_REOPEN_LOG}'}" ]] && rollback_state=open
+    if [[ "$*" == *"pulls/77"* ]]; then rollback_state=open; base_ref=main; fi
+    printf '{"state":"%s","merged_at":null,"head":{"sha":"%s","ref":"%s"},"base":{"ref":"%s"},"mergeable_state":"clean"}\n' \
+      "${'${rollback_state}'}" "${'${FAKE_ROLLBACK_SHA}'}" "${'${FAKE_ROLLBACK_BRANCH}'}" "${'${base_ref}'}"
+    ;;
+  *) printf 'unexpected gh invocation: %s\n' "$*" >&2; exit 95 ;;
+esac
+`,
+      sleep: 'exit 0',
+    },
+    files: {
+      'runtime-status.json': runtimeStatus,
+      'paper-deployment.yaml': 'paper manifest\n',
+      'observe-deployment.yaml': 'observe manifest\n',
+      'attestation.json': attestation,
+      '.github/PULL_REQUEST_TEMPLATE.md':
+        '## Summary\n## Related Issues\n## Testing\n## Breaking Changes\n## Checklist\n',
+    },
+    environment: {
+      GH_TOKEN: 'test-token',
+      FAKE_RUNTIME_STATUS: 'runtime-status.json',
+      FAKE_PAPER_DEPLOYMENT: 'paper-deployment.yaml',
+      FAKE_OBSERVE_DEPLOYMENT: 'observe-deployment.yaml',
+      FAKE_PAPER_GENERATION: options.current ?? options.expected ?? '8'.repeat(64),
+      FAKE_GITOPS_MAXIMUM: options.gitopsObserve === true ? 'OBSERVE' : 'PAPER',
+      FAKE_MAIN_SHA: mainSha,
+      FAKE_WORKFLOW_HEAD_SHA: workflowHeadSha,
+      FAKE_ROLLBACK_SHA: rollbackSha,
+      FAKE_INITIAL_ROLLBACK_SHA: initialRollbackSha,
+      FAKE_ACTIVATION_SHA: activationSha,
+      FAKE_DESIRED_BLOB: desiredBlob,
+      FAKE_TREE_SHA: '9'.repeat(40),
+      FAKE_ROLLBACK_BRANCH: rollbackBranch,
+      FAKE_ACTIVATION_BRANCH: activationBranch,
+      FAKE_METADATA_B64: metadata,
+      FAKE_MERGE_LOG: 'merge.log',
+      FAKE_INITIAL_BASE_REF: options.initialBaseRef ?? 'main',
+      FAKE_FINAL_BASE_REF: options.finalBaseRef ?? options.initialBaseRef ?? 'main',
+      FAKE_PULL_COUNTER: 'pull-counter',
+      FAKE_ROLLBACK_STATE: options.rollbackState ?? 'open',
+      FAKE_WATCHDOG_REOPEN_LOG: 'watchdog-reopen.log',
+      FAKE_ATTESTATION_FILE: 'attestation.json',
+      FAKE_FOREIGN_BASE_MERGED_ONLY: options.foreignBaseMergedOnly === true ? 'true' : 'false',
+      FAKE_BRANCH_MISSING: options.branchMissing === true ? 'true' : 'false',
+      FAKE_LATEST_RUN_ATTEMPT: String(latestRunAttempt),
+      FAKE_ATTESTATION_ATTEMPT: String(attestationAttempt),
+      FAKE_UNRELATED_ARTIFACT_COUNT: String(options.unrelatedArtifactCount ?? 0),
+      FAKE_ARTIFACT_PRODUCER_RUN_ID: String(options.artifactProducerRunId ?? 1),
+      FAKE_ACTIVATION_BASE_REF: options.activationBaseRef ?? 'main',
+      FAKE_ARTIFACT_SCAN_LOG: 'artifact-scan.log',
+      FAKE_ARTIFACT_OPEN_LOG: 'artifact-open.log',
+      FAKE_PR_CREATE_LOG: 'pr-create.log',
+      FAKE_PUSH_LOG: 'push.log',
+    },
+  })
+}
+
+describe('Bayn PAPER activation workflow', () => {
+  test('uses only default-branch-loaded triggers and retains a read-only event token', () => {
+    expect(parsed.name).toBe('bayn-paper-activation')
+    expect(Object.keys(parsed.on).sort()).toEqual(['schedule', 'workflow_run'])
+    expect(parsed.on.workflow_run).toEqual({
+      workflows: ['bayn-qualification'],
+      types: ['completed'],
+      branches: ['main'],
+    })
+    expect(parsed.on.schedule).toEqual([{ cron: '3,8,13,18,23,28,33,38,43,48,53,58 * * * *' }])
+    for (const branchSelectableEvent of ['workflow_dispatch', 'push', 'pull_request', 'pull_request_target'] as const)
+      expect(parsed.on[branchSelectableEvent], branchSelectableEvent).toBeUndefined()
+    expect(workflow).not.toContain('inputs.')
+    expect(workflow).toContain('cancel-in-progress: false')
+    expect(workflow).toContain('contents: read')
+    expect(workflow).toContain('actions: read')
+    expect(workflow).not.toContain(': write')
+    expect(workflow).toContain('AGENTS_SPLIT_TOKEN')
+    expect(workflow).not.toContain('kubectl')
+  })
+
+  test('cannot expose GitOps secrets through an attacker-selected workflow ref', () => {
+    expect(workflow).not.toContain('workflow_dispatch')
+    expect(workflow).not.toContain('github.ref_protected')
+    expect(workflow).not.toContain('github.workflow_ref')
+    expect(parsed.jobs['verify-and-prepare']?.if).toContain("github.event_name == 'workflow_run'")
+    expect(parsed.jobs['verify-and-prepare']?.if).toContain("github.event.workflow_run.event == 'schedule'")
+    expect(parsed.jobs['activate-and-observe']?.if).toContain("github.event_name == 'workflow_run'")
+    expect(parsed.jobs.rollback?.if).toContain("github.event_name == 'workflow_run'")
+    expect(parsed.jobs['rollback-watchdog']?.if).toBe("github.event_name == 'schedule'")
+
+    const identity = scriptFor('verify-and-prepare', 'Authenticate activation identity and evidence producer')
+    expect(identity).not.toContain('AGENTS_SPLIT_TOKEN')
+    expect(identity).not.toContain('GITOPS_TOKEN')
+    expect(identity).toContain('event=workflow_run')
+    expect(workflow).toContain('protected-gitops-token-missing')
+  })
+
+  test('stays dormant without an exact qualification activation artifact', async () => {
+    const mainSha = 'a'.repeat(40)
+    const result = await runWorkflowScript({
+      script: scriptFor('verify-and-prepare', 'Authenticate activation identity and evidence producer'),
+      executables: {
+        git: `
+case "$*" in
+  "rev-parse HEAD") printf '%s\n' "${'${FAKE_MAIN_SHA}'}" ;;
+  *) printf 'unexpected git invocation: %s\n' "$*" >&2; exit 96 ;;
+esac
+`,
+        gh: `
+case "$*" in
+  *"commits/main"*) printf '%s\n' "${'${FAKE_MAIN_SHA}'}" ;;
+  *"actions/workflows/bayn-paper-activation.yml"*"--jq .id"*) printf '%s\n' 123 ;;
+  *"actions/workflows/123/runs?event=workflow_run"*) printf '%s\n' '{"workflow_runs":[]}' ;;
+  *"actions/workflows/bayn-qualification.yml"*) printf '%s\n' '{"id":456}' ;;
+  *"actions/runs/77/artifacts?name=bayn-paper-activation-evidence-77-1"*) printf '%s\n' '{"artifacts":[]}' ;;
+  *"actions/runs/77"*)
+    printf '{"workflow_id":456,"path":".github/workflows/bayn-qualification.yml","event":"schedule","status":"completed","conclusion":"success","head_branch":"main","head_sha":"%s","repository":{"full_name":"proompteng/lab"},"run_attempt":1}\n' "${'${FAKE_MAIN_SHA}'}"
+    ;;
+  *) printf 'unexpected gh invocation: %s\n' "$*" >&2; exit 97 ;;
+esac
+`,
+      },
+      environment: {
+        ACTIVATION_ID: 'qualification-77-1',
+        ARTIFACT_NAME: 'bayn-paper-activation-evidence-77-1',
+        EVIDENCE_RUN_ATTEMPT: '1',
+        EVIDENCE_RUN_ID: '77',
+        GH_TOKEN: 'read-only-event-token',
+        GITHUB_RUN_ID: '88',
+        FAKE_MAIN_SHA: mainSha,
+      },
+    })
+    try {
+      expect(result.exitCode, result.stderr).toBe(0)
+      expect(result.stdout).toContain('PAPER activation remains dormant')
+      expect(result.githubOutput).toContain('activation_id=qualification-77-1')
+      expect(result.githubOutput).toContain(`current_main_sha=${mainSha}`)
+      expect(result.githubOutput).toContain('live=false')
+    } finally {
+      result.dispose()
+    }
+  })
+
+  test('authenticates a current-main qualification artifact and canonical generation', () => {
+    expect(workflow).toContain('actions/workflows/bayn-qualification.yml')
+    expect(workflow).toContain('bayn-paper-activation-evidence-${EVIDENCE_RUN_ID}-${evidence_attempt}')
+    expect(workflow).toContain('--mode extract-manifest-pins')
+    expect(workflow).toContain('--kustomization argocd/applications/bayn/kustomization.yaml')
+    expect(workflow).toContain('.authorityGeneration.generationHash')
+    expect(workflow).toContain('--mode derive-observe-rollback')
+    expect(workflow).toContain('--previous-observe-generation-hash')
+    expect(workflow).toContain('--paper-authority-generation-hash')
+    expect(workflow).toContain('observe-rollback-generation.json')
+  })
+
+  test('precommits reviewed activation and a fresh rollback before PAPER can merge', () => {
+    const preparationSteps = parsed.jobs['verify-and-prepare']?.steps ?? []
+    const uploadIndex = preparationSteps.findIndex((step) => step.name === 'Upload rollback watchdog attestation')
+    const releaseIndex = preparationSteps.findIndex(
+      (step) => step.name === 'Release activation only after durable rollback attestation',
+    )
+    const upload = stepFor('verify-and-prepare', 'Upload rollback watchdog attestation')
+    const release = stepFor('verify-and-prepare', 'Release activation only after durable rollback attestation')
+    expect(workflow).toContain('--mode render-transition')
+    expect(workflow).toContain('--observe-authority-generation-hash')
+    expect(workflow).toContain('--authority-expires-at')
+    expect(workflow).toContain('codex/bayn-paper-activation/${ACTIVATION_ID}')
+    expect(workflow).toContain('codex/bayn-paper-rollback/${ACTIVATION_ID}')
+    expect(workflow).toContain('activation_commit_sha=${activation_commit}')
+    expect(workflow).toContain('rollback_commit_sha=${rollback_commit}')
+    expect(workflow).toContain('rollback_metadata_b64=${metadata_b64}')
+    expect(workflow).toContain('EXPECTED_ACTIVATION_SHA: ${{ needs.verify-and-prepare.outputs.activation_commit_sha }}')
+    expect(workflow).toContain(
+      'EXPECTED_ROLLBACK_METADATA_B64: ${{ needs.verify-and-prepare.outputs.rollback_metadata_b64 }}',
+    )
+    expect(workflow).toContain('rollback_commit_sha: ${{ steps.rebase_rollback.outputs.rollback_commit_sha }}')
+    expect(workflow).toContain(
+      'EXPECTED_ROLLBACK_SHA: ${{ needs.activate-and-observe.outputs.rollback_commit_sha || needs.verify-and-prepare.outputs.rollback_commit_sha }}',
+    )
+    expect(workflow).toContain('BAYN_PAPER_ROLLBACK_METADATA=')
+    expect(count('--draft')).toBeGreaterThanOrEqual(2)
+    expect(uploadIndex).toBeGreaterThan(-1)
+    expect(releaseIndex).toBeGreaterThan(uploadIndex)
+    expect(upload.uses).toBe('actions/upload-artifact@v4')
+    expect(upload.with?.['if-no-files-found']).toBe('error')
+    expect(release.if).toBe("steps.identity.outputs.live == 'true'")
+    expect(release.run).toContain('activation-draft-changed')
+    expect(release.run).toContain('activation-containment-failed')
+    expect(release.run).toContain('gh pr ready "${PR_NUMBER}" --undo')
+    expect(workflow.indexOf('git push origin "${rollback_commit}:refs/heads/${rollback_branch}"')).toBeLessThan(
+      workflow.indexOf('gh pr create'),
+    )
+    expect(workflow).toContain("template_file='.github/PULL_REQUEST_TEMPLATE.md'")
+    expect(workflow).toContain('--body-file rollback-pr-body.md')
+    expect(workflow).toContain('--body-file activation-pr-body.md')
+    expect(workflow).toContain('## Related Issues')
+    expect(workflow).toContain('## Breaking Changes')
+    expect(workflow).toContain('- [x] Testing section documents the exact validation performed')
+    expect(workflow).not.toContain('--body "Precommitted automatic OBSERVE rollback')
+    expect(workflow).not.toContain('--body "Reviewed GitOps PAPER transition')
+    expect(workflow).toContain('rollback-precommit-changed')
+    expect(workflow).toContain('ensure_rollback_pr_open')
+    expect(workflow).toContain('bayn-paper-rollback-attestation-${{ steps.identity.outputs.activation_id }}')
+    expect(workflow).toContain('rollbackMetadataB64')
+    expect(workflow).toContain('workflowRunAttempt')
+    expect(workflow).toContain('workflowHeadSha')
+    expect(workflow).toContain('actions/runs/${workflow_run_id}/attempts/${workflow_run_attempt}')
+    expect(workflow).not.toContain('branches?per_page=100')
+    expect(workflow).toContain('--body-file rollback-watchdog-pr-body.md')
+    const watchdog = scriptFor('rollback-watchdog', 'Restore OBSERVE for expired or abandoned activation')
+    expect(watchdog).toContain('GitOps already declares OBSERVE; no rollback discovery is required.')
+    expect(watchdog).toContain('actions/artifacts?per_page=100')
+    expect(watchdog).not.toContain('actions/runs/${workflow_run_id}/artifacts')
+    expect(watchdog).toContain('.workflow_run.id')
+    expect(watchdog).toContain('artifactWorkflowRunId')
+    expect(watchdog.indexOf('--mode inspect-deployment-authority')).toBeLessThan(
+      watchdog.indexOf('actions/artifacts?per_page=100'),
+    )
+    expect(count('reviewThreads(first:100,after:$after)')).toBe(3)
+    expect(count('pageInfo{hasNextPage endCursor}')).toBe(3)
+    expect(count('load_check_runs()')).toBe(3)
+    expect(count('check-run-pagination-invalid')).toBe(3)
+    expect(count('merge_method=squash')).toBe(3)
+  })
+
+  test('leaves no mergeable activation when attestation persistence fails or the job is cancelled', async () => {
+    const activationBranch = 'codex/bayn-paper-activation/test-activation'
+    const rollbackBranch = 'codex/bayn-paper-rollback/test-activation'
+    const result = await runWorkflowScript({
+      script: scriptFor('verify-and-prepare', 'Atomically claim and create paired reviewed GitOps pull requests'),
+      executables: {
+        git: `
+case "$*" in
+  "ls-remote --exit-code --heads origin refs/heads/"*) exit 2 ;;
+  "config "*|"read-tree "*|"update-index "*) exit 0 ;;
+  "hash-object -w deployment.paper.yaml") printf '%s\n' "${'${FAKE_PAPER_BLOB}'}" ;;
+  "hash-object -w deployment.observe.yaml") printf '%s\n' "${'${FAKE_OBSERVE_BLOB}'}" ;;
+  "write-tree") printf '%s\n' "${'${FAKE_TREE_SHA}'}" ;;
+  "commit-tree "*)
+    count=0
+    [[ -s "${'${FAKE_COMMIT_COUNTER}'}" ]] && count="$(cat "${'${FAKE_COMMIT_COUNTER}'}")"
+    count=$((count + 1))
+    printf '%s' "${'${count}'}" > "${'${FAKE_COMMIT_COUNTER}'}"
+    if [[ "${'${count}'}" == 1 ]]; then printf '%s\n' "${'${FAKE_ACTIVATION_SHA}'}"; else printf '%s\n' "${'${FAKE_ROLLBACK_SHA}'}"; fi
+    ;;
+  "push "*) printf '%s\n' "$*" >> "${'${FAKE_PUSH_LOG}'}" ;;
+  *) printf 'unexpected git invocation: %s\n' "$*" >&2; exit 96 ;;
+esac
+`,
+        gh: `
+case "$*" in
+  "auth setup-git") exit 0 ;;
+  "pr create "*)
+    printf '%s\n' "$*" >> "${'${FAKE_PR_CREATE_LOG}'}"
+    if [[ "$*" == *"${'${FAKE_ROLLBACK_BRANCH}'}"* ]]; then
+      printf '%s\n' 'https://github.com/proompteng/lab/pull/42'
+    else
+      printf '%s\n' 'https://github.com/proompteng/lab/pull/41'
+    fi
+    ;;
+  "pr ready "*) printf '%s\n' "$*" >> "${'${FAKE_READY_LOG}'}"; exit 97 ;;
+  *) printf 'unexpected gh invocation: %s\n' "$*" >&2; exit 98 ;;
+esac
+`,
+      },
+      files: {
+        'deployment.paper.yaml': 'paper\n',
+        'deployment.observe.yaml': 'observe\n',
+        '.github/PULL_REQUEST_TEMPLATE.md':
+          '## Summary\n## Related Issues\n## Testing\n## Breaking Changes\n## Checklist\n',
+      },
+      environment: {
+        ACTIVATION_ID: 'test-activation',
+        AUTHORITY_EXPIRES_AT: '2026-07-31T18:00:00Z',
+        AUTHORITY_GENERATION_HASH: '8'.repeat(64),
+        BASELINE_CYCLE_ID: '',
+        CURRENT_MAIN_SHA: '5'.repeat(40),
+        GH_TOKEN: 'test-token',
+        OBSERVE_AUTHORITY_GENERATION_HASH: '7'.repeat(64),
+        PREVIOUS_OBSERVE_GENERATION_HASH: '6'.repeat(64),
+        GITHUB_RUN_ATTEMPT: '1',
+        GITHUB_RUN_ID: '77',
+        FAKE_ACTIVATION_SHA: '1'.repeat(40),
+        FAKE_ROLLBACK_SHA: '2'.repeat(40),
+        FAKE_PAPER_BLOB: '3'.repeat(40),
+        FAKE_OBSERVE_BLOB: '4'.repeat(40),
+        FAKE_TREE_SHA: '9'.repeat(40),
+        FAKE_COMMIT_COUNTER: 'commit-counter',
+        FAKE_PUSH_LOG: 'push.log',
+        FAKE_PR_CREATE_LOG: 'pr-create.log',
+        FAKE_READY_LOG: 'ready.log',
+        FAKE_ROLLBACK_BRANCH: rollbackBranch,
+      },
+    })
+    try {
+      expect(result.exitCode, result.stderr).toBe(0)
+      const createCalls = readFileSync(join(result.root, 'pr-create.log'), 'utf8').trim().split('\n')
+      expect(createCalls).toHaveLength(2)
+      expect(createCalls.find((call) => call.includes(rollbackBranch))).toContain('--draft')
+      expect(createCalls.find((call) => call.includes(activationBranch))).toContain('--draft')
+      expect(result.githubOutput).toContain('activation_pr=41')
+      expect(result.githubOutput).toContain('rollback_pr=42')
+      expect(existsSync(join(result.root, 'ready.log'))).toBe(false)
+    } finally {
+      result.dispose()
+    }
+  })
+
+  test('marks the exact activation ready only on the normal attested path', async () => {
+    const head = '1'.repeat(40)
+    const base = '2'.repeat(40)
+    const branch = 'codex/bayn-paper-activation/test-activation'
+    const result = await runWorkflowScript({
+      script: scriptFor('verify-and-prepare', 'Release activation only after durable rollback attestation'),
+      executables: {
+        gh: `
+case "$*" in
+  *"commits/main"*) printf '%s\n' "${'${FAKE_MAIN_SHA}'}" ;;
+  "pr ready ${'${PR_NUMBER}'} --undo "*) printf 'unexpected undo\n' >&2; exit 96 ;;
+  "pr ready ${'${PR_NUMBER}'} --repo "*) printf '%s\n' ready >> "${'${FAKE_READY_LOG}'}" ;;
+  *"pulls/${'${PR_NUMBER}'}"*)
+    draft=true
+    [[ -s "${'${FAKE_READY_LOG}'}" ]] && draft=false
+    printf '{"state":"open","draft":%s,"merged_at":null,"head":{"sha":"%s","ref":"%s"},"base":{"ref":"main","sha":"%s"}}\n' \
+      "${'${draft}'}" "${'${EXPECTED_ACTIVATION_SHA}'}" "${'${ACTIVATION_BRANCH}'}" "${'${EXPECTED_BASE_SHA}'}"
+    ;;
+  *) printf 'unexpected gh invocation: %s\n' "$*" >&2; exit 97 ;;
+esac
+`,
+      },
+      environment: {
+        ACTIVATION_BRANCH: branch,
+        EXPECTED_ACTIVATION_SHA: head,
+        EXPECTED_BASE_SHA: base,
+        GH_TOKEN: 'test-token',
+        PR_NUMBER: '41',
+        FAKE_MAIN_SHA: base,
+        FAKE_READY_LOG: 'ready.log',
+      },
+    })
+    try {
+      expect(result.exitCode, result.stderr).toBe(0)
+      expect(readFileSync(join(result.root, 'ready.log'), 'utf8')).toContain('ready')
+      expect(result.stderr).not.toContain('activation-draft-changed')
+      expect(result.stderr).not.toContain('activation-ready-changed')
+    } finally {
+      result.dispose()
+    }
+  })
+
+  test('returns a drifted activation to draft during the post-attestation release interleaving', async () => {
+    const head = '1'.repeat(40)
+    const replacement = '9'.repeat(40)
+    const base = '2'.repeat(40)
+    const branch = 'codex/bayn-paper-activation/test-activation'
+    const result = await runWorkflowScript({
+      script: scriptFor('verify-and-prepare', 'Release activation only after durable rollback attestation'),
+      executables: {
+        gh: `
+case "$*" in
+  *"commits/main"*) printf '%s\n' "${'${FAKE_MAIN_SHA}'}" ;;
+  "pr ready ${'${PR_NUMBER}'} --undo "*) printf '%s\n' undo >> "${'${FAKE_READY_LOG}'}" ;;
+  "pr ready ${'${PR_NUMBER}'} --repo "*) printf '%s\n' ready >> "${'${FAKE_READY_LOG}'}" ;;
+  *"pulls/${'${PR_NUMBER}'}"*)
+    count=0
+    [[ -s "${'${FAKE_PULL_COUNTER}'}" ]] && count="$(cat "${'${FAKE_PULL_COUNTER}'}")"
+    count=$((count + 1))
+    printf '%s' "${'${count}'}" > "${'${FAKE_PULL_COUNTER}'}"
+    if [[ "${'${count}'}" == 1 ]]; then
+      printf '{"state":"open","draft":true,"merged_at":null,"head":{"sha":"%s","ref":"%s"},"base":{"ref":"main","sha":"%s"}}\n' \
+        "${'${EXPECTED_ACTIVATION_SHA}'}" "${'${ACTIVATION_BRANCH}'}" "${'${EXPECTED_BASE_SHA}'}"
+    elif [[ "${'${count}'}" == 2 ]]; then
+      printf '{"state":"open","draft":false,"merged_at":null,"head":{"sha":"%s","ref":"%s"},"base":{"ref":"main","sha":"%s"}}\n' \
+        "${'${FAKE_REPLACEMENT_SHA}'}" "${'${ACTIVATION_BRANCH}'}" "${'${EXPECTED_BASE_SHA}'}"
+    else
+      printf '{"state":"open","draft":true,"merged_at":null,"head":{"sha":"%s","ref":"%s"},"base":{"ref":"main","sha":"%s"}}\n' \
+        "${'${FAKE_REPLACEMENT_SHA}'}" "${'${ACTIVATION_BRANCH}'}" "${'${EXPECTED_BASE_SHA}'}"
+    fi
+    ;;
+  *) printf 'unexpected gh invocation: %s\n' "$*" >&2; exit 98 ;;
+esac
+`,
+      },
+      environment: {
+        ACTIVATION_BRANCH: branch,
+        EXPECTED_ACTIVATION_SHA: head,
+        EXPECTED_BASE_SHA: base,
+        GH_TOKEN: 'test-token',
+        PR_NUMBER: '41',
+        FAKE_MAIN_SHA: base,
+        FAKE_REPLACEMENT_SHA: replacement,
+        FAKE_PULL_COUNTER: 'pull-counter',
+        FAKE_READY_LOG: 'ready.log',
+      },
+    })
+    try {
+      expect(result.exitCode).toBe(1)
+      expect(readFileSync(join(result.root, 'ready.log'), 'utf8').trim().split('\n')).toEqual(['ready', 'undo'])
+      expect(result.stderr).toContain('activation-ready-changed')
+      expect(result.stderr).not.toContain('activation-containment-failed')
+    } finally {
+      result.dispose()
+    }
+  })
+
+  test('merges only while the exact verified base and authority window remain current', async () => {
+    const script = scriptFor('activate-and-observe', 'Merge only a clean exact-head protected activation PR')
+    const head = '1'.repeat(40)
+    const base = '2'.repeat(40)
+    const expiry = isoSeconds(Date.now() + 60 * 60 * 1_000)
+    const result = await runWorkflowScript({
+      script,
+      executables: { gh: mergeGh },
+      environment: {
+        ...activationRollbackEnvironment,
+        ACTIVATION_BRANCH: 'codex/test',
+        EXPECTED_ACTIVATION_SHA: head,
+        AUTHORITY_EXPIRES_AT: expiry,
+        QUALIFICATION_EXPIRES_AT: expiry,
+        EXPECTED_BASE_SHA: base,
+        PR_NUMBER: '1',
+        FAKE_HEAD_SHA: head,
+        FAKE_MAIN_SHA: base,
+        FAKE_PULL_BASE_SHA: base,
+        FAKE_MERGE_LOG: join(tmpdir(), `bayn-paper-merge-${crypto.randomUUID()}`),
+      },
+    })
+
+    try {
+      expect(result.exitCode, result.stderr).toBe(0)
+      expect(result.githubOutput).toContain('activation_merged_at=2026-07-31T00:05:00Z')
+    } finally {
+      result.dispose()
+    }
+  })
+
+  test('paginates review threads and blocks an unresolved thread after the first page', async () => {
+    const head = '1'.repeat(40)
+    const base = '2'.repeat(40)
+    const expiry = isoSeconds(Date.now() + 60 * 60 * 1_000)
+    const result = await runWorkflowScript({
+      script: scriptFor('activate-and-observe', 'Merge only a clean exact-head protected activation PR'),
+      executables: {
+        gh: `
+case "$*" in
+  *"/merge"*)
+    printf '%s\n' merge >> "${'${FAKE_MERGE_LOG}'}"
+    printf '%s\n' '{"merged":true}'
+    ;;
+  *"git/ref/heads/"*) printf '%s\n' "${'${FAKE_HEAD_SHA}'}" ;;
+  *"check-runs?filter=latest"*) printf '%s\n' '[{"total_count":1,"check_runs":[{"id":1,"status":"completed","conclusion":"success"}]}]' ;;
+  *"commits/main"*) printf '%s\n' "${'${FAKE_MAIN_SHA}'}" ;;
+  *"api graphql"*)
+    printf '%s\n' "$*" >> "${'${FAKE_PAGINATION_LOG}'}"
+    if [[ "$*" == *"after=cursor-1"* ]]; then
+      printf '%s\n' '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"isResolved":false}],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}'
+    else
+      printf '%s\n' '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[{"isResolved":true}],"pageInfo":{"hasNextPage":true,"endCursor":"cursor-1"}}}}}}'
+    fi
+    ;;
+  *"pulls/${'${ROLLBACK_PR_NUMBER}'}"*)
+    printf '{"state":"open","head":{"sha":"%s","ref":"%s"},"base":{"ref":"main"},"merged_at":null}\n' \
+      "${'${EXPECTED_ROLLBACK_SHA}'}" "${'${ROLLBACK_BRANCH}'}"
+    ;;
+  *"pulls/${'${PR_NUMBER}'}"*)
+    printf '{"head":{"sha":"%s"},"base":{"ref":"main","sha":"%s"},"mergeable_state":"clean","merged_at":null}\n' \
+      "${'${FAKE_HEAD_SHA}'}" "${'${FAKE_PULL_BASE_SHA}'}"
+    ;;
+  *) printf 'unexpected gh invocation: %s\n' "$*" >&2; exit 90 ;;
+esac
+`,
+        sleep: 'exit 99',
+      },
+      environment: {
+        ...activationRollbackEnvironment,
+        ACTIVATION_BRANCH: 'codex/test',
+        EXPECTED_ACTIVATION_SHA: head,
+        AUTHORITY_EXPIRES_AT: expiry,
+        QUALIFICATION_EXPIRES_AT: expiry,
+        EXPECTED_BASE_SHA: base,
+        PR_NUMBER: '1',
+        FAKE_HEAD_SHA: head,
+        FAKE_MAIN_SHA: base,
+        FAKE_PULL_BASE_SHA: base,
+        FAKE_MERGE_LOG: 'merge.log',
+        FAKE_PAGINATION_LOG: 'pagination.log',
+      },
+    })
+
+    try {
+      expect(result.exitCode).not.toBe(0)
+      const pagination = readFileSync(join(result.root, 'pagination.log'), 'utf8')
+      expect(pagination).toContain('after=cursor-1')
+      expect(pagination.trim().split('\n')).toHaveLength(2)
+      expect(existsSync(join(result.root, 'merge.log'))).toBe(false)
+    } finally {
+      result.dispose()
+    }
+  })
+
+  test('paginates check runs and blocks a failed run after the first page', async () => {
+    const head = '1'.repeat(40)
+    const base = '2'.repeat(40)
+    const expiry = isoSeconds(Date.now() + 60 * 60 * 1_000)
+    const result = await runWorkflowScript({
+      script: scriptFor('activate-and-observe', 'Merge only a clean exact-head protected activation PR'),
+      executables: {
+        gh: `
+case "$*" in
+  *"/merge"*)
+    printf '%s\n' merge >> "${'${FAKE_MERGE_LOG}'}"
+    printf '%s\n' '{"merged":true}'
+    ;;
+  *"git/ref/heads/"*) printf '%s\n' "${'${FAKE_HEAD_SHA}'}" ;;
+  *"check-runs?filter=latest"*)
+    [[ "$*" == *"--paginate --slurp"* ]] || { printf 'check pagination flags are required\n' >&2; exit 96; }
+    printf '%s\n' "$*" >> "${'${FAKE_CHECK_PAGINATION_LOG}'}"
+    python3 - <<'PY'
+import json
+first = [{"id": index, "status": "completed", "conclusion": "success"} for index in range(1, 101)]
+second = [{"id": 101, "status": "completed", "conclusion": "failure"}]
+print(json.dumps([
+    {"total_count": 101, "check_runs": first},
+    {"total_count": 101, "check_runs": second},
+], separators=(",", ":")))
+PY
+    ;;
+  *"commits/main"*) printf '%s\n' "${'${FAKE_MAIN_SHA}'}" ;;
+  *"api graphql"*)
+    printf '%s\n' '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}'
+    ;;
+  *"pulls/${'${ROLLBACK_PR_NUMBER}'}"*)
+    printf '{"state":"open","head":{"sha":"%s","ref":"%s"},"base":{"ref":"main"},"merged_at":null}\n' \
+      "${'${EXPECTED_ROLLBACK_SHA}'}" "${'${ROLLBACK_BRANCH}'}"
+    ;;
+  *"pulls/${'${PR_NUMBER}'}"*)
+    printf '{"head":{"sha":"%s"},"base":{"ref":"main","sha":"%s"},"mergeable_state":"clean","merged_at":null}\n' \
+      "${'${FAKE_HEAD_SHA}'}" "${'${FAKE_PULL_BASE_SHA}'}"
+    ;;
+  *) printf 'unexpected gh invocation: %s\n' "$*" >&2; exit 90 ;;
+esac
+`,
+        sleep: 'exit 99',
+      },
+      environment: {
+        ...activationRollbackEnvironment,
+        ACTIVATION_BRANCH: 'codex/test',
+        EXPECTED_ACTIVATION_SHA: head,
+        AUTHORITY_EXPIRES_AT: expiry,
+        QUALIFICATION_EXPIRES_AT: expiry,
+        EXPECTED_BASE_SHA: base,
+        PR_NUMBER: '1',
+        FAKE_HEAD_SHA: head,
+        FAKE_MAIN_SHA: base,
+        FAKE_PULL_BASE_SHA: base,
+        FAKE_MERGE_LOG: 'merge.log',
+        FAKE_CHECK_PAGINATION_LOG: 'check-pagination.log',
+      },
+    })
+    try {
+      expect(result.exitCode).not.toBe(0)
+      expect(readFileSync(join(result.root, 'check-pagination.log'), 'utf8')).toContain('--paginate --slurp')
+      expect(existsSync(join(result.root, 'merge.log'))).toBe(false)
+    } finally {
+      result.dispose()
+    }
+  })
+
+  test('reopens a closed paired rollback PR immediately before activation merge', async () => {
+    const head = '1'.repeat(40)
+    const base = '2'.repeat(40)
+    const expiry = isoSeconds(Date.now() + 60 * 60 * 1_000)
+    const result = await runWorkflowScript({
+      script: scriptFor('activate-and-observe', 'Merge only a clean exact-head protected activation PR'),
+      executables: { gh: mergeGh },
+      environment: {
+        ...activationRollbackEnvironment,
+        ACTIVATION_BRANCH: 'codex/test',
+        EXPECTED_ACTIVATION_SHA: head,
+        AUTHORITY_EXPIRES_AT: expiry,
+        QUALIFICATION_EXPIRES_AT: expiry,
+        EXPECTED_BASE_SHA: base,
+        PR_NUMBER: '1',
+        FAKE_HEAD_SHA: head,
+        FAKE_MAIN_SHA: base,
+        FAKE_PULL_BASE_SHA: base,
+        FAKE_MERGE_LOG: 'merge.log',
+        FAKE_ROLLBACK_STATE: 'closed',
+        FAKE_ROLLBACK_REOPEN_LOG: 'rollback-reopen.log',
+      },
+    })
+    try {
+      expect(result.exitCode, result.stderr).toBe(0)
+      expect(readFileSync(join(result.root, 'rollback-reopen.log'), 'utf8')).toContain('reopen')
+      expect(readFileSync(join(result.root, 'merge.log'), 'utf8')).toContain('merge')
+    } finally {
+      result.dispose()
+    }
+  })
+
+  test('refuses changed base and near-expiry authority before merge', async () => {
+    const script = scriptFor('activate-and-observe', 'Merge only a clean exact-head protected activation PR')
+    const base = '2'.repeat(40)
+    const common = {
+      ...activationRollbackEnvironment,
+      ACTIVATION_BRANCH: 'codex/test',
+      EXPECTED_ACTIVATION_SHA: '1'.repeat(40),
+      EXPECTED_BASE_SHA: base,
+      PR_NUMBER: '1',
+      FAKE_HEAD_SHA: '1'.repeat(40),
+      FAKE_PULL_BASE_SHA: base,
+      FAKE_MERGE_LOG: join(tmpdir(), `bayn-paper-merge-${crypto.randomUUID()}`),
+    }
+    const changedBase = await runWorkflowScript({
+      script,
+      executables: { gh: mergeGh },
+      environment: {
+        ...common,
+        AUTHORITY_EXPIRES_AT: isoSeconds(Date.now() + 60 * 60 * 1_000),
+        QUALIFICATION_EXPIRES_AT: isoSeconds(Date.now() + 60 * 60 * 1_000),
+        FAKE_MAIN_SHA: '3'.repeat(40),
+      },
+    })
+
+    const expiring = await runWorkflowScript({
+      script,
+      executables: { gh: mergeGh },
+      environment: {
+        ...common,
+        AUTHORITY_EXPIRES_AT: isoSeconds(Date.now() + 5 * 60 * 1_000),
+        QUALIFICATION_EXPIRES_AT: isoSeconds(Date.now() + 60 * 60 * 1_000),
+        FAKE_MAIN_SHA: base,
+      },
+    })
+
+    try {
+      expect(changedBase.exitCode).not.toBe(0)
+      expect(changedBase.stderr).toContain('activation-base-changed')
+      expect(expiring.exitCode).not.toBe(0)
+      expect(expiring.stderr).toContain('authority-window-too-short')
+    } finally {
+      changedBase.dispose()
+      expiring.dispose()
+    }
+  })
+
+  test('refuses an activation base retarget with the same base SHA immediately before merge', async () => {
+    const head = '1'.repeat(40)
+    const base = '2'.repeat(40)
+    const expiry = isoSeconds(Date.now() + 60 * 60 * 1_000)
+    const result = await runWorkflowScript({
+      script: scriptFor('activate-and-observe', 'Merge only a clean exact-head protected activation PR'),
+      executables: {
+        gh: `
+case "$*" in
+  *"pulls/1/merge"*)
+    printf '%s\n' merge >> "${'${FAKE_MERGE_LOG}'}"
+    printf '%s\n' '{"merged":true}'
+    ;;
+  *"git/ref/heads/"*) printf '%s\n' "${'${FAKE_HEAD_SHA}'}" ;;
+  *"check-runs?filter=latest"*) printf '%s\n' '[{"total_count":1,"check_runs":[{"id":1,"status":"completed","conclusion":"success"}]}]' ;;
+  *"commits/main"*) printf '%s\n' "${'${FAKE_MAIN_SHA}'}" ;;
+  *"api graphql"*)
+    printf '%s\n' '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}'
+    ;;
+  *"pulls/2"*)
+    printf '{"state":"open","head":{"sha":"%s","ref":"%s"},"base":{"ref":"main"},"merged_at":null}\n' \
+      "${'${EXPECTED_ROLLBACK_SHA}'}" "${'${ROLLBACK_BRANCH}'}"
+    ;;
+  *"pulls/1"*)
+    count=0
+    [[ -s "${'${FAKE_PULL_COUNTER}'}" ]] && count="$(cat "${'${FAKE_PULL_COUNTER}'}")"
+    count=$((count + 1))
+    printf '%s' "${'${count}'}" > "${'${FAKE_PULL_COUNTER}'}"
+    base_ref=main
+    [[ "${'${count}'}" -gt 1 ]] && base_ref=retargeted
+    printf '{"head":{"sha":"%s"},"base":{"ref":"%s","sha":"%s"},"mergeable_state":"clean","merged_at":null}\n' \
+      "${'${FAKE_HEAD_SHA}'}" "${'${base_ref}'}" "${'${FAKE_MAIN_SHA}'}"
+    ;;
+  *) printf 'unexpected gh invocation: %s\n' "$*" >&2; exit 90 ;;
+esac
+`,
+      },
+      environment: {
+        ...activationRollbackEnvironment,
+        ACTIVATION_BRANCH: 'codex/test',
+        EXPECTED_ACTIVATION_SHA: head,
+        AUTHORITY_EXPIRES_AT: expiry,
+        QUALIFICATION_EXPIRES_AT: expiry,
+        EXPECTED_BASE_SHA: base,
+        PR_NUMBER: '1',
+        FAKE_HEAD_SHA: head,
+        FAKE_MAIN_SHA: base,
+        FAKE_MERGE_LOG: 'merge.log',
+        FAKE_PULL_COUNTER: 'pull-counter',
+      },
+    })
+    try {
+      expect(result.exitCode).not.toBe(0)
+      expect(result.stderr).toContain('activation-base-changed')
+      expect(existsSync(join(result.root, 'merge.log'))).toBe(false)
+    } finally {
+      result.dispose()
+    }
+  })
+
+  test('rechecks qualification freshness after the review wait and before merge', async () => {
+    const script = scriptFor('activate-and-observe', 'Merge only a clean exact-head protected activation PR')
+    const initialEpoch = Math.floor(Date.now() / 1_000)
+    const expiry = isoSeconds((initialEpoch + 20 * 60) * 1_000)
+    const result = await runWorkflowScript({
+      script,
+      executables: {
+        gh: mergeGh,
+        date: `
+if [[ "$*" == *" -d "* || "$1" == "-d" || "${'${2:-}'}" == "-d" ]]; then
+  exec python3 - "$@" <<'PY'
+import datetime
+import sys
+args = sys.argv[1:]
+index = args.index('-d')
+instant = datetime.datetime.fromisoformat(args[index + 1].replace('Z', '+00:00'))
+print(int(instant.timestamp()))
+PY
+fi
+count=0
+[[ -s "${'${FAKE_DATE_COUNTER}'}" ]] && count="$(cat "${'${FAKE_DATE_COUNTER}'}")"
+count=$((count + 1))
+printf '%s' "${'${count}'}" > "${'${FAKE_DATE_COUNTER}'}"
+if [[ "${'${count}'}" == 1 ]]; then printf '%s\n' "${'${FAKE_NOW_INITIAL}'}"; else printf '%s\n' "${'${FAKE_NOW_LATER}'}"; fi
+`,
+      },
+      environment: {
+        ...activationRollbackEnvironment,
+        ACTIVATION_BRANCH: 'codex/test',
+        EXPECTED_ACTIVATION_SHA: '1'.repeat(40),
+        AUTHORITY_EXPIRES_AT: expiry,
+        QUALIFICATION_EXPIRES_AT: expiry,
+        EXPECTED_BASE_SHA: '2'.repeat(40),
+        PR_NUMBER: '1',
+        FAKE_HEAD_SHA: '1'.repeat(40),
+        FAKE_MAIN_SHA: '2'.repeat(40),
+        FAKE_PULL_BASE_SHA: '2'.repeat(40),
+        FAKE_MERGE_LOG: join(tmpdir(), `bayn-paper-merge-${crypto.randomUUID()}`),
+        FAKE_DATE_COUNTER: join(tmpdir(), `bayn-paper-date-${crypto.randomUUID()}`),
+        FAKE_NOW_INITIAL: String(initialEpoch),
+        FAKE_NOW_LATER: String(initialEpoch + 21 * 60),
+      },
+    })
+
+    try {
+      expect(result.exitCode).not.toBe(0)
+      expect(result.stderr).toContain('qualification-stale')
+    } finally {
+      result.dispose()
+    }
+  })
+
+  test('refuses an activation branch replacement before the merge job starts', async () => {
+    const expected = '1'.repeat(40)
+    const replacement = '9'.repeat(40)
+    const result = await runWorkflowScript({
+      script: scriptFor('activate-and-observe', 'Merge only a clean exact-head protected activation PR'),
+      executables: { gh: mergeGh },
+      environment: {
+        ...activationRollbackEnvironment,
+        ACTIVATION_BRANCH: 'codex/test',
+        EXPECTED_ACTIVATION_SHA: expected,
+        AUTHORITY_EXPIRES_AT: isoSeconds(Date.now() + 60 * 60 * 1_000),
+        QUALIFICATION_EXPIRES_AT: isoSeconds(Date.now() + 60 * 60 * 1_000),
+        EXPECTED_BASE_SHA: '2'.repeat(40),
+        PR_NUMBER: '1',
+        FAKE_HEAD_SHA: replacement,
+        FAKE_MAIN_SHA: '2'.repeat(40),
+        FAKE_PULL_BASE_SHA: '2'.repeat(40),
+        FAKE_MERGE_LOG: 'merge.log',
+      },
+    })
+
+    try {
+      expect(result.exitCode).not.toBe(0)
+      expect(result.stderr).toContain('activation-head-changed')
+      expect(existsSync(join(result.root, 'merge.log'))).toBe(false)
+    } finally {
+      result.dispose()
+    }
+  })
+
+  test('refuses a force-pushed rollback branch before rebasing its metadata', async () => {
+    const expected = '4'.repeat(40)
+    const replacement = '9'.repeat(40)
+    const result = await runWorkflowScript({
+      script: scriptFor('activate-and-observe', 'Rebase the precommitted rollback tree onto activated main'),
+      executables: {
+        gh: `
+case "$*" in
+  "auth setup-git") exit 0 ;;
+  *) printf 'unexpected gh invocation: %s\n' "$*" >&2; exit 96 ;;
+esac
+`,
+        git: `
+case "$*" in
+  "config "*|"fetch "*) exit 0 ;;
+  "rev-parse origin/main") printf '%s\n' "${'${FAKE_MAIN_SHA}'}" ;;
+  "rev-parse origin/${'${ROLLBACK_BRANCH}'}") printf '%s\n' "${'${FAKE_REPLACEMENT_SHA}'}" ;;
+  *"push "*) printf '%s\n' push >> "${'${FAKE_PUSH_LOG}'}" ;;
+  *) printf 'unexpected git invocation: %s\n' "$*" >&2; exit 97 ;;
+esac
+`,
+      },
+      environment: {
+        EXPECTED_ROLLBACK_SHA: expected,
+        EXPECTED_ROLLBACK_METADATA_B64: 'metadata',
+        ROLLBACK_BRANCH: 'codex/bayn-paper-rollback/test',
+        FAKE_MAIN_SHA: '5'.repeat(40),
+        FAKE_REPLACEMENT_SHA: replacement,
+        FAKE_PUSH_LOG: 'push.log',
+      },
+    })
+    try {
+      expect(result.exitCode).not.toBe(0)
+      expect(result.stderr).toContain('rollback-precommit-changed')
+      expect(existsSync(join(result.root, 'push.log'))).toBe(false)
+    } finally {
+      result.dispose()
+    }
+  })
+
+  test('refuses to rebase its rollback over a foreign PAPER generation', async () => {
+    const activationBranch = 'codex/bayn-paper-activation/test'
+    const rollbackBranch = 'codex/bayn-paper-rollback/test'
+    const expectedRollbackSha = '4'.repeat(40)
+    const mainSha = '5'.repeat(40)
+    const authorityGenerationHash = '8'.repeat(64)
+    const observeGenerationHash = '7'.repeat(64)
+    const previousObserveGenerationHash = '6'.repeat(64)
+    const metadata = Buffer.from(
+      JSON.stringify({
+        schemaVersion: 1,
+        activationId: 'test',
+        activationBranch,
+        rollbackBranch,
+        sourceMainSha: mainSha,
+        authorityGenerationHash,
+        previousObserveGenerationHash,
+        observeAuthorityGenerationHash: observeGenerationHash,
+        authorityExpiresAt: '2026-07-31T13:00:00Z',
+        baselineCycleId: '',
+        workflowRunId: 77,
+        workflowRunAttempt: 1,
+      }),
+    ).toString('base64')
+    const result = await runWorkflowScript({
+      script: scriptFor('activate-and-observe', 'Rebase the precommitted rollback tree onto activated main'),
+      executables: {
+        gh: `
+case "$*" in
+  "auth setup-git") exit 0 ;;
+  *) printf 'unexpected gh invocation: %s\n' "$*" >&2; exit 96 ;;
+esac
+`,
+        git: `
+case "$*" in
+  "config "*|"fetch "*) exit 0 ;;
+  "rev-parse origin/main") printf '%s\n' "${'${FAKE_MAIN_SHA}'}" ;;
+  "rev-parse origin/${'${ROLLBACK_BRANCH}'}") printf '%s\n' "${'${EXPECTED_ROLLBACK_SHA}'}" ;;
+  "show -s --format=%B ${'${EXPECTED_ROLLBACK_SHA}'}")
+    printf 'chore(bayn): rollback\n\nBAYN_PAPER_ROLLBACK_METADATA=%s\n' "${'${EXPECTED_ROLLBACK_METADATA_B64}'}"
+    ;;
+  "show ${'${FAKE_MAIN_SHA}'}:argocd/applications/bayn/deployment.yaml") printf '%s\n' 'foreign paper manifest' ;;
+  *"push "*) printf '%s\n' push >> "${'${FAKE_PUSH_LOG}'}" ;;
+  *) printf 'unexpected git invocation: %s\n' "$*" >&2; exit 97 ;;
+esac
+`,
+        bun: `
+mode=''
+output=''
+previous=''
+for argument in "$@"; do
+  if [[ "${'${previous}'}" == --mode ]]; then mode="${'${argument}'}"; fi
+  if [[ "${'${previous}'}" == --output ]]; then output="${'${argument}'}"; fi
+  previous="${'${argument}'}"
+done
+case "${'${mode}'}" in
+  inspect-deployment-authority)
+    printf '{"maximumAuthority":"PAPER","brokerAccess":"mutation","capitalAuthority":"sandbox-capital","authorityGenerationHash":"%s"}\n' \
+      "${'${FAKE_FOREIGN_GENERATION}'}" > "${'${output}'}"
+    ;;
+  render-rollback) printf '%s\n' render >> "${'${FAKE_RENDER_LOG}'}" ;;
+  *) printf 'unexpected bun mode: %s\n' "${'${mode}'}" >&2; exit 98 ;;
+esac
+`,
+      },
+      environment: {
+        ACTIVATION_BRANCH: activationBranch,
+        ACTIVATION_ID: 'test',
+        AUTHORITY_EXPIRES_AT: '2026-07-31T13:00:00Z',
+        AUTHORITY_GENERATION_HASH: authorityGenerationHash,
+        BASELINE_CYCLE_ID: '',
+        EXPECTED_ROLLBACK_METADATA_B64: metadata,
+        EXPECTED_ROLLBACK_SHA: expectedRollbackSha,
+        GITHUB_RUN_ID: '77',
+        GITHUB_RUN_ATTEMPT: '1',
+        OBSERVE_AUTHORITY_GENERATION_HASH: observeGenerationHash,
+        PREVIOUS_OBSERVE_AUTHORITY_GENERATION_HASH: previousObserveGenerationHash,
+        ROLLBACK_BRANCH: rollbackBranch,
+        SOURCE_MAIN_SHA: mainSha,
+        FAKE_MAIN_SHA: mainSha,
+        FAKE_FOREIGN_GENERATION: '9'.repeat(64),
+        FAKE_PUSH_LOG: 'push.log',
+        FAKE_RENDER_LOG: 'render.log',
+      },
+    })
+    try {
+      expect(result.exitCode).not.toBe(0)
+      expect(result.stderr).toContain('foreign-paper-generation')
+      expect(existsSync(join(result.root, 'render.log'))).toBe(false)
+      expect(existsSync(join(result.root, 'push.log'))).toBe(false)
+    } finally {
+      result.dispose()
+    }
+  })
+
+  test('accepts an OBSERVE baseline with resolved historical mutations', async () => {
+    const baseline = paperStatus({
+      checkedAt: isoSeconds(Date.now()),
+      access: 'read-only',
+      capital: 'none',
+      maximum: 'observe',
+      effective: 'observe',
+      zeroMutation: false,
+      mutationEventCount: 4,
+      unresolvedMutationCount: 0,
+      coversLatestMutation: true,
+      last: { cycleId: 'historical-terminal-cycle', phase: 'COMPLETED' },
+    })
+    const result = await runWorkflowScript({
+      script: scriptFor('verify-and-prepare', 'Capture exact OBSERVE baseline before any GitOps write'),
+      executables: { curl: `cat "${'${FAKE_STATUS}'}"` },
+      files: { 'status.json': baseline },
+      environment: { FAKE_STATUS: 'status.json' },
+    })
+    try {
+      expect(result.exitCode, result.stderr).toBe(0)
+      expect(result.githubOutput).toContain('baseline_cycle_id=historical-terminal-cycle')
+    } finally {
+      result.dispose()
+    }
+  })
+
+  test('waits through OBSERVE rollout lag before recording PAPER visibility', async () => {
+    const script = scriptFor('activate-and-observe', 'Wait for the verified PAPER rollout')
+    const checkedAt = isoSeconds(Date.now() - 10_000)
+    const transitional = paperStatus({
+      checkedAt,
+      access: 'read-only',
+      capital: 'none',
+      maximum: 'observe',
+      effective: 'observe',
+    })
+    const ready = paperStatus({ checkedAt, last: { cycleId: 'baseline-cycle' } })
+    const result = await runWorkflowScript({
+      script,
+      executables: {
+        curl: `
+count=0
+[[ -s "${'${FAKE_COUNTER}'}" ]] && count="$(cat "${'${FAKE_COUNTER}'}")"
+count=$((count + 1))
+printf '%s' "${'${count}'}" > "${'${FAKE_COUNTER}'}"
+if [[ "${'${count}'}" == 1 ]]; then cat "${'${FAKE_STATUS_ONE}'}"; else cat "${'${FAKE_STATUS_TWO}'}"; fi
+`,
+        sleep: 'exit 0',
+      },
+      files: { 'status-one.json': transitional, 'status-two.json': ready },
+      environment: {
+        ACTIVATION_MERGED_AT: isoSeconds(Date.now() - 60_000),
+        AUTHORITY_EXPIRES_AT: isoSeconds(Date.now() + 60 * 60 * 1_000),
+        AUTHORITY_GENERATION_HASH: 'f'.repeat(64),
+        EXPECTED_IMAGE_DIGEST: `sha256:${'c'.repeat(64)}`,
+        EXPECTED_SOURCE_SHA: 'b'.repeat(40),
+        PREACTIVATION_BASELINE_CYCLE_ID: 'baseline-cycle',
+        FAKE_COUNTER: join(tmpdir(), `bayn-paper-curl-${crypto.randomUUID()}`),
+        FAKE_STATUS_ONE: 'status-one.json',
+        FAKE_STATUS_TWO: 'status-two.json',
+      },
+    })
+    try {
+      expect(result.exitCode, result.stderr).toBe(0)
+      expect(result.githubOutput).toContain('paper_baseline_last_cycle_id=baseline-cycle')
+      expect(result.githubOutput).toContain(`paper_rollout_observed_at=${checkedAt}`)
+    } finally {
+      result.dispose()
+    }
+  })
+
+  test('counts a terminal cycle completed before the first PAPER status poll', async () => {
+    const nowMs = Date.now()
+    const checkedAt = isoSeconds(nowMs)
+    const activationMergedAt = isoSeconds(nowMs - 10_000)
+    const fastTerminal = paperStatus({
+      checkedAt,
+      authorityUpdatedAt: isoSeconds(nowMs - 8_000),
+      last: {
+        cycleId: 'fast-paper-cycle',
+        phase: 'NO_TRADE',
+        createdAt: isoSeconds(nowMs - 5_000),
+      },
+    })
+    const rollout = await runWorkflowScript({
+      script: scriptFor('activate-and-observe', 'Wait for the verified PAPER rollout'),
+      executables: { curl: `cat "${'${FAKE_STATUS}'}"`, sleep: 'exit 0' },
+      files: { 'status.json': fastTerminal },
+      environment: {
+        ACTIVATION_MERGED_AT: activationMergedAt,
+        AUTHORITY_EXPIRES_AT: isoSeconds(Date.now() + 60 * 60 * 1_000),
+        AUTHORITY_GENERATION_HASH: 'f'.repeat(64),
+        EXPECTED_IMAGE_DIGEST: `sha256:${'c'.repeat(64)}`,
+        EXPECTED_SOURCE_SHA: 'b'.repeat(40),
+        PREACTIVATION_BASELINE_CYCLE_ID: 'observe-baseline-cycle',
+        FAKE_STATUS: 'status.json',
+      },
+    })
+    expect(rollout.exitCode, rollout.stderr).toBe(0)
+    expect(rollout.githubOutput).toContain('paper_baseline_last_cycle_id=observe-baseline-cycle')
+    expect(rollout.githubOutput).toContain('paper_initial_terminal_cycle_id=fast-paper-cycle')
+    rollout.dispose()
+
+    const observe = await runWorkflowScript({
+      script: scriptFor('activate-and-observe', 'Observe exactly one new natural scheduled cycle'),
+      executables: { curl: 'printf "observer must not wait for a second cycle\\n" >&2; exit 96' },
+      files: { 'bayn-paper-observation/rollout-status.json': fastTerminal },
+      environment: {
+        ACTIVATION_MERGED_AT: activationMergedAt,
+        AUTHORITY_EXPIRES_AT: isoSeconds(Date.now() + 60 * 60 * 1_000),
+        AUTHORITY_GENERATION_HASH: 'f'.repeat(64),
+        BASELINE_CURRENT_CYCLE_ID: '',
+        BASELINE_LAST_CYCLE_ID: 'observe-baseline-cycle',
+        EXPECTED_IMAGE_DIGEST: `sha256:${'c'.repeat(64)}`,
+        EXPECTED_SOURCE_SHA: 'b'.repeat(40),
+        INITIAL_TERMINAL_CYCLE_ID: 'fast-paper-cycle',
+        PAPER_ROLLOUT_OBSERVED_AT: checkedAt,
+      },
+    })
+    try {
+      expect(observe.exitCode, observe.stderr).toBe(0)
+      expect(observe.githubOutput).toContain('observation=terminal_success')
+      expect(observe.stderr).not.toContain('observer must not wait for a second cycle')
+      const proof = JSON.parse(readFileSync(join(observe.root, 'bayn-paper-observation/proof.json'), 'utf8')) as {
+        readonly observedCycleId: string
+      }
+      expect(proof.observedCycleId).toBe('fast-paper-cycle')
+    } finally {
+      observe.dispose()
+    }
+  })
+
+  test('tracks a cycle already active under the reviewed PAPER generation to terminal', async () => {
+    const secondBoundary = Math.floor(Date.now() / 1_000) * 1_000
+    const checkedAt = new Date(secondBoundary + 900).toISOString()
+    const activationMergedAt = new Date(secondBoundary + 100).toISOString()
+    const authorityUpdatedAt = new Date(secondBoundary + 200).toISOString()
+    const createdAt = new Date(secondBoundary + 300).toISOString()
+    const active = paperStatus({
+      checkedAt,
+      authorityUpdatedAt,
+      current: { cycleId: 'already-active-paper-cycle', phase: 'ACTIVE', createdAt },
+      last: {
+        cycleId: 'observe-baseline-cycle',
+        phase: 'NO_TRADE',
+        createdAt: new Date(secondBoundary - 60_000).toISOString(),
+      },
+    })
+    const terminal = paperStatus({
+      checkedAt: new Date(secondBoundary + 5_000).toISOString(),
+      authorityUpdatedAt,
+      last: { cycleId: 'already-active-paper-cycle', phase: 'COMPLETED', createdAt },
+    })
+    const rollout = await runWorkflowScript({
+      script: scriptFor('activate-and-observe', 'Wait for the verified PAPER rollout'),
+      executables: { curl: `cat "${'${FAKE_STATUS}'}"`, sleep: 'exit 0' },
+      files: { 'status.json': active },
+      environment: {
+        ACTIVATION_MERGED_AT: activationMergedAt,
+        AUTHORITY_EXPIRES_AT: isoSeconds(secondBoundary + 60 * 60 * 1_000),
+        AUTHORITY_GENERATION_HASH: 'f'.repeat(64),
+        EXPECTED_IMAGE_DIGEST: `sha256:${'c'.repeat(64)}`,
+        EXPECTED_SOURCE_SHA: 'b'.repeat(40),
+        PREACTIVATION_BASELINE_CYCLE_ID: 'observe-baseline-cycle',
+        FAKE_STATUS: 'status.json',
+      },
+    })
+    expect(rollout.exitCode, rollout.stderr).toBe(0)
+    expect(rollout.githubOutput).toContain('paper_baseline_current_cycle_id=already-active-paper-cycle')
+    rollout.dispose()
+
+    const observe = await runWorkflowScript({
+      script: scriptFor('activate-and-observe', 'Observe exactly one new natural scheduled cycle'),
+      executables: { curl: `cat "${'${FAKE_STATUS}'}"`, sleep: 'exit 0' },
+      files: {
+        'bayn-paper-observation/rollout-status.json': active,
+        'terminal-status.json': terminal,
+      },
+      environment: {
+        ACTIVATION_MERGED_AT: activationMergedAt,
+        AUTHORITY_EXPIRES_AT: isoSeconds(secondBoundary + 60 * 60 * 1_000),
+        AUTHORITY_GENERATION_HASH: 'f'.repeat(64),
+        BASELINE_CURRENT_CYCLE_ID: 'already-active-paper-cycle',
+        BASELINE_LAST_CYCLE_ID: 'observe-baseline-cycle',
+        EXPECTED_IMAGE_DIGEST: `sha256:${'c'.repeat(64)}`,
+        EXPECTED_SOURCE_SHA: 'b'.repeat(40),
+        INITIAL_TERMINAL_CYCLE_ID: '',
+        PAPER_ROLLOUT_OBSERVED_AT: checkedAt,
+        FAKE_STATUS: 'terminal-status.json',
+      },
+    })
+    try {
+      expect(observe.exitCode, observe.stderr).toBe(0)
+      expect(observe.githubOutput).toContain('observation=terminal_success')
+      const proof = JSON.parse(readFileSync(join(observe.root, 'bayn-paper-observation/proof.json'), 'utf8')) as {
+        readonly observedCycleId: string
+      }
+      expect(proof.observedCycleId).toBe('already-active-paper-cycle')
+    } finally {
+      observe.dispose()
+    }
+  })
+
+  test('rejects an intervening OBSERVE terminal cycle at the first PAPER status poll', async () => {
+    const nowMs = Date.now()
+    const status = paperStatus({
+      checkedAt: isoSeconds(nowMs),
+      authorityUpdatedAt: isoSeconds(nowMs - 10_000),
+      last: {
+        cycleId: 'intervening-observe-cycle',
+        phase: 'COMPLETED',
+        createdAt: isoSeconds(nowMs - 15_000),
+      },
+    })
+    const result = await runWorkflowScript({
+      script: scriptFor('activate-and-observe', 'Wait for the verified PAPER rollout'),
+      executables: { curl: `cat "${'${FAKE_STATUS}'}"`, sleep: 'exit 0' },
+      files: { 'status.json': status },
+      environment: {
+        ACTIVATION_MERGED_AT: isoSeconds(nowMs - 20_000),
+        AUTHORITY_EXPIRES_AT: isoSeconds(nowMs + 60 * 60 * 1_000),
+        AUTHORITY_GENERATION_HASH: 'f'.repeat(64),
+        EXPECTED_IMAGE_DIGEST: `sha256:${'c'.repeat(64)}`,
+        EXPECTED_SOURCE_SHA: 'b'.repeat(40),
+        PREACTIVATION_BASELINE_CYCLE_ID: 'observe-baseline-cycle',
+        FAKE_STATUS: 'status.json',
+      },
+    })
+    try {
+      expect(result.exitCode).not.toBe(0)
+      expect(result.stderr).toContain('initial-cycle-before-paper-authority')
+    } finally {
+      result.dispose()
+    }
+  })
+
+  test('accepts one resolved-trade terminal cycle first created after PAPER became visible', async () => {
+    const script = scriptFor('activate-and-observe', 'Observe exactly one new natural scheduled cycle')
+    const rolloutAt = isoSeconds(Date.now() - 5 * 60 * 1_000)
+    const createdAt = isoSeconds(Date.now() - 4 * 60 * 1_000)
+    const active = paperStatus({
+      checkedAt: isoSeconds(Date.now()),
+      current: { cycleId: 'fresh-paper-cycle', phase: 'ACTIVE', createdAt },
+      last: { cycleId: 'baseline-cycle', phase: 'NO_TRADE', createdAt: rolloutAt },
+    })
+    const terminal = paperStatus({
+      checkedAt: isoSeconds(Date.now()),
+      zeroMutation: false,
+      mutationEventCount: 2,
+      unresolvedMutationCount: 0,
+      coversLatestMutation: true,
+      last: { cycleId: 'fresh-paper-cycle', phase: 'COMPLETED', createdAt },
+    })
+    const result = await runWorkflowScript({
+      script,
+      executables: {
+        curl: `
+count=0
+[[ -s "${'${FAKE_COUNTER}'}" ]] && count="$(cat "${'${FAKE_COUNTER}'}")"
+count=$((count + 1))
+printf '%s' "${'${count}'}" > "${'${FAKE_COUNTER}'}"
+if [[ "${'${count}'}" == 1 ]]; then cat "${'${FAKE_STATUS_ONE}'}"; else cat "${'${FAKE_STATUS_TWO}'}"; fi
+`,
+        sleep: 'exit 0',
+      },
+      files: {
+        'bayn-paper-observation/rollout-status.json': active,
+        'status-one.json': active,
+        'status-two.json': terminal,
+      },
+      environment: {
+        ACTIVATION_MERGED_AT: isoSeconds(Date.parse(rolloutAt) - 60_000),
+        AUTHORITY_EXPIRES_AT: isoSeconds(Date.now() + 60 * 60 * 1_000),
+        AUTHORITY_GENERATION_HASH: 'f'.repeat(64),
+        BASELINE_CURRENT_CYCLE_ID: '',
+        BASELINE_LAST_CYCLE_ID: 'baseline-cycle',
+        EXPECTED_IMAGE_DIGEST: `sha256:${'c'.repeat(64)}`,
+        EXPECTED_SOURCE_SHA: 'b'.repeat(40),
+        INITIAL_TERMINAL_CYCLE_ID: '',
+        PAPER_ROLLOUT_OBSERVED_AT: rolloutAt,
+        FAKE_COUNTER: join(tmpdir(), `bayn-paper-curl-${crypto.randomUUID()}`),
+        FAKE_STATUS_ONE: 'status-one.json',
+        FAKE_STATUS_TWO: 'status-two.json',
+      },
+    })
+    try {
+      expect(result.exitCode, result.stderr).toBe(0)
+      expect(result.githubOutput).toContain('observation=terminal_success')
+      const proof = JSON.parse(readFileSync(join(result.root, 'bayn-paper-observation/proof.json'), 'utf8')) as {
+        readonly observedCycleId: string
+        readonly authorityGenerationHash: string
+      }
+      expect(proof.observedCycleId).toBe('fresh-paper-cycle')
+      expect(proof.authorityGenerationHash).toBe('f'.repeat(64))
+    } finally {
+      result.dispose()
+    }
+  })
+
+  test('rejects a terminal cycle created before PAPER visibility', async () => {
+    const script = scriptFor('activate-and-observe', 'Observe exactly one new natural scheduled cycle')
+    const rolloutAt = isoSeconds(Date.now() - 5 * 60 * 1_000)
+    const stale = paperStatus({
+      checkedAt: isoSeconds(Date.now()),
+      last: {
+        cycleId: 'stale-observe-cycle',
+        phase: 'COMPLETED',
+        createdAt: isoSeconds(Date.now() - 6 * 60 * 1_000),
+      },
+    })
+    const result = await runWorkflowScript({
+      script,
+      executables: { curl: `cat "${'${FAKE_STATUS}'}"`, sleep: 'exit 0' },
+      files: { 'bayn-paper-observation/rollout-status.json': stale, 'status.json': stale },
+      environment: {
+        ACTIVATION_MERGED_AT: isoSeconds(Date.parse(rolloutAt) - 60_000),
+        AUTHORITY_EXPIRES_AT: isoSeconds(Date.now() + 60 * 60 * 1_000),
+        AUTHORITY_GENERATION_HASH: 'f'.repeat(64),
+        BASELINE_CURRENT_CYCLE_ID: '',
+        BASELINE_LAST_CYCLE_ID: 'baseline-cycle',
+        EXPECTED_IMAGE_DIGEST: `sha256:${'c'.repeat(64)}`,
+        EXPECTED_SOURCE_SHA: 'b'.repeat(40),
+        INITIAL_TERMINAL_CYCLE_ID: '',
+        PAPER_ROLLOUT_OBSERVED_AT: rolloutAt,
+        FAKE_STATUS: 'status.json',
+      },
+    })
+    try {
+      expect(result.exitCode).not.toBe(0)
+      const proof = JSON.parse(readFileSync(join(result.root, 'bayn-paper-observation/proof.json'), 'utf8')) as {
+        readonly outcome: string
+      }
+      expect(proof.outcome).toBe('cycle-not-started-under-visible-paper')
+    } finally {
+      result.dispose()
+    }
+  })
+
+  test('restores committed PAPER GitOps even when the serving runtime reports OBSERVE', async () => {
+    const result = await runWatchdog(
+      paperStatus({
+        checkedAt: isoSeconds(Date.now()),
+        access: 'read-only',
+        capital: 'none',
+        maximum: 'observe',
+        effective: 'observe',
+      }),
+    )
+    try {
+      expect(result.exitCode, result.stderr).toBe(0)
+      expect(existsSync(join(result.root, 'merge.log')), `${result.stdout}\n${result.stderr}`).toBe(true)
+      expect(readFileSync(join(result.root, 'merge.log'), 'utf8')).toContain('merge')
+    } finally {
+      result.dispose()
+    }
+  })
+
+  test('watchdog consumes automatic protected checks without a manual review trigger', async () => {
+    const result = await runWatchdog(paperStatus({ checkedAt: isoSeconds(Date.now()) }))
+    try {
+      expect(result.exitCode, result.stderr).toBe(0)
+      expect(readFileSync(join(result.root, 'merge.log'), 'utf8')).toContain('merge')
+      expect(result.stderr).not.toContain('manual review trigger is prohibited')
+    } finally {
+      result.dispose()
+    }
+  })
+
+  test('watchdog discovers recovery from the authenticated attestation without listing rollback branches', async () => {
+    const result = await runWatchdog(paperStatus({ checkedAt: isoSeconds(Date.now()) }))
+    try {
+      expect(result.exitCode, result.stderr).toBe(0)
+      expect(readFileSync(join(result.root, 'merge.log'), 'utf8')).toContain('merge')
+      expect(result.stderr).not.toContain('branch-first watchdog discovery is prohibited')
+    } finally {
+      result.dispose()
+    }
+  })
+
+  test('watchdog rejects an attestation artifact from another producer before opening its archive', async () => {
+    const result = await runWatchdog(paperStatus({ checkedAt: isoSeconds(Date.now()) }), {
+      artifactProducerRunId: 2,
+    })
+    try {
+      expect(result.exitCode, result.stderr).toBe(0)
+      expect(readFileSync(join(result.root, 'artifact-scan.log'), 'utf8')).toContain('scan')
+      expect(existsSync(join(result.root, 'artifact-open.log'))).toBe(false)
+      expect(existsSync(join(result.root, 'merge.log'))).toBe(false)
+    } finally {
+      result.dispose()
+    }
+  })
+
+  test('watchdog restores an exact foreign-base activation after its PAPER generation reaches current main', async () => {
+    const result = await runWatchdog(paperStatus({ checkedAt: isoSeconds(Date.now()) }), {
+      activationBaseRef: 'staging',
+    })
+    try {
+      expect(result.exitCode, result.stderr).toBe(0)
+      expect(readFileSync(join(result.root, 'artifact-open.log'), 'utf8')).toContain('open')
+      expect(readFileSync(join(result.root, 'merge.log'), 'utf8')).toContain('merge')
+    } finally {
+      result.dispose()
+    }
+  })
+
+  test('watchdog accepts a retained earlier-attempt attestation after a later rerun fails early', async () => {
+    const result = await runWatchdog(paperStatus({ checkedAt: isoSeconds(Date.now()) }), {
+      latestRunAttempt: 2,
+      attestationAttempt: 1,
+    })
+
+    try {
+      expect(result.exitCode, result.stderr).toBe(0)
+      expect(readFileSync(join(result.root, 'merge.log'), 'utf8')).toContain('merge')
+    } finally {
+      result.dispose()
+    }
+  })
+
+  test('watchdog authenticates the dispatch head separately from the later exact-main source', async () => {
+    const result = await runWatchdog(paperStatus({ checkedAt: isoSeconds(Date.now()) }))
+    try {
+      expect(result.exitCode, result.stderr).toBe(0)
+      expect(readFileSync(join(result.root, 'merge.log'), 'utf8')).toContain('merge')
+    } finally {
+      result.dispose()
+    }
+  })
+
+  test('watchdog performs one artifact scan with thousands of unrelated retained artifacts', async () => {
+    const result = await runWatchdog(paperStatus({ checkedAt: isoSeconds(Date.now()) }), {
+      unrelatedArtifactCount: 2184,
+    })
+    try {
+      expect(result.exitCode, result.stderr).toBe(0)
+      expect(readFileSync(join(result.root, 'artifact-scan.log'), 'utf8').trim().split('\n')).toHaveLength(1)
+      expect(result.stderr).not.toContain('per-run artifact discovery is prohibited')
+      expect(readFileSync(join(result.root, 'merge.log'), 'utf8')).toContain('merge')
+    } finally {
+      result.dispose()
+    }
+  })
+
+  test('watchdog exits on committed OBSERVE before any artifact discovery', async () => {
+    const result = await runWatchdog(paperStatus({ checkedAt: isoSeconds(Date.now()) }), { gitopsObserve: true })
+    try {
+      expect(result.exitCode, result.stderr).toBe(0)
+      expect(result.stdout).toContain('GitOps already declares OBSERVE; no rollback discovery is required.')
+      expect(existsSync(join(result.root, 'artifact-scan.log'))).toBe(false)
+      expect(existsSync(join(result.root, 'merge.log'))).toBe(false)
+    } finally {
+      result.dispose()
+    }
+  })
+
+  test('watchdog recreates a deleted rollback branch from the authenticated workflow attestation', async () => {
+    const result = await runWatchdog(paperStatus({ checkedAt: isoSeconds(Date.now()) }), { branchMissing: true })
+    try {
+      expect(result.exitCode, result.stderr).toBe(0)
+      expect(readFileSync(join(result.root, 'push.log'), 'utf8')).toContain('push')
+      expect(readFileSync(join(result.root, 'pr-create.log'), 'utf8')).toContain('create')
+      expect(readFileSync(join(result.root, 'merge.log'), 'utf8')).toContain('merge')
+    } finally {
+      result.dispose()
+    }
+  })
+
+  test('watchdog recreates an exact main rollback PR after the prior PR merged into a foreign base', async () => {
+    const result = await runWatchdog(paperStatus({ checkedAt: isoSeconds(Date.now()) }), {
+      foreignBaseMergedOnly: true,
+    })
+    try {
+      expect(result.exitCode, result.stderr).toBe(0)
+      expect(readFileSync(join(result.root, 'pr-create.log'), 'utf8')).toContain('create')
+      expect(readFileSync(join(result.root, 'merge.log'), 'utf8')).toContain('merge')
+    } finally {
+      result.dispose()
+    }
+  })
+
+  test('watchdog rejects self-authored rollback metadata without the exact workflow attestation', async () => {
+    const result = await runWatchdog(paperStatus({ checkedAt: isoSeconds(Date.now()) }), {
+      attestationMatches: false,
+    })
+    try {
+      expect(result.exitCode, result.stderr).toBe(0)
+      expect(result.stdout).toContain('rollback metadata is malformed or does not match the attestation')
+      expect(existsSync(join(result.root, 'merge.log'))).toBe(false)
+      expect(existsSync(join(result.root, 'pr-create.log'))).toBe(false)
+    } finally {
+      result.dispose()
+    }
+  })
+
+  test('watchdog refuses to apply an old rollback to a later PAPER generation', async () => {
+    const result = await runWatchdog(paperStatus({ checkedAt: isoSeconds(Date.now()) }), {
+      expected: '8'.repeat(64),
+      current: '9'.repeat(64),
+    })
+    try {
+      expect(result.exitCode, result.stderr).toBe(0)
+      expect(result.stdout).toContain('current PAPER generation belongs to another activation')
+      expect(existsSync(join(result.root, 'merge.log'))).toBe(false)
+    } finally {
+      result.dispose()
+    }
+  })
+
+  test('closes an exact unmerged activation before skipping OBSERVE rollback', async () => {
+    const exactHead = '1'.repeat(40)
+    const result = await runWorkflowScript({
+      script: scriptFor('rollback', 'Determine whether activation merged'),
+      executables: {
+        gh: `
+case "$*" in
+  *"--method PATCH"*"pulls/41"*)
+    printf '%s\n' close >> "${'${FAKE_ACTIVATION_CLOSE_LOG}'}"
+    printf '%s\n' '{"state":"closed"}'
+    ;;
+  *"pulls/41"*)
+    state=open
+    [[ -s "${'${FAKE_ACTIVATION_CLOSE_LOG}'}" ]] && state=closed
+    printf '{"state":"%s","head":{"sha":"%s"},"merged_at":null}\n' "${'${state}'}" "${'${EXPECTED_ACTIVATION_SHA}'}"
+    ;;
+  *) printf 'unexpected gh invocation: %s\n' "$*" >&2; exit 97 ;;
+esac
+`,
+      },
+      environment: {
+        EXPECTED_ACTIVATION_SHA: exactHead,
+        PR_NUMBER: '41',
+        FAKE_ACTIVATION_CLOSE_LOG: 'activation-close.log',
+      },
+    })
+    try {
+      expect(result.exitCode, result.stderr).toBe(0)
+      expect(result.githubOutput).toContain('restore=false')
+      expect(readFileSync(join(result.root, 'activation-close.log'), 'utf8')).toContain('close')
+    } finally {
+      result.dispose()
+    }
+  })
+
+  test('skips rollback after the exact activation merged only into a foreign base', async () => {
+    const exactHead = '1'.repeat(40)
+    const result = await runWorkflowScript({
+      script: scriptFor('rollback', 'Determine whether activation merged'),
+      executables: {
+        gh: `
+case "$*" in
+  *"pulls/41"*)
+    printf '{"state":"closed","head":{"sha":"%s"},"base":{"ref":"staging"},"merged_at":"2026-07-31T00:05:00Z"}\n' \
+      "${'${EXPECTED_ACTIVATION_SHA}'}"
+    ;;
+  *) printf 'unexpected gh invocation: %s\n' "$*" >&2; exit 97 ;;
+esac
+`,
+      },
+      environment: { EXPECTED_ACTIVATION_SHA: exactHead, PR_NUMBER: '41' },
+    })
+    try {
+      expect(result.exitCode, result.stderr).toBe(0)
+      expect(result.githubOutput).toContain('restore=false')
+      expect(result.stdout).toContain('merged only into a foreign base')
+    } finally {
+      result.dispose()
+    }
+  })
+
+  test('retains fail-closed rollback after the exact activation merged into main', async () => {
+    const exactHead = '1'.repeat(40)
+    const result = await runWorkflowScript({
+      script: scriptFor('rollback', 'Determine whether activation merged'),
+      executables: {
+        gh: `
+case "$*" in
+  *"pulls/41"*)
+    printf '{"state":"closed","head":{"sha":"%s"},"base":{"ref":"main"},"merged_at":"2026-07-31T00:05:00Z"}\n' \
+      "${'${EXPECTED_ACTIVATION_SHA}'}"
+    ;;
+  *) printf 'unexpected gh invocation: %s\n' "$*" >&2; exit 97 ;;
+esac
+`,
+      },
+      environment: { EXPECTED_ACTIVATION_SHA: exactHead, PR_NUMBER: '41' },
+    })
+    try {
+      expect(result.exitCode, result.stderr).toBe(0)
+      expect(result.githubOutput).toContain('restore=true')
+      expect(result.stdout).not.toContain('merged only into a foreign base')
+    } finally {
+      result.dispose()
+    }
+  })
+
+  test('retains fail-closed rollback for ambiguous activation state', async () => {
+    const exactHead = '1'.repeat(40)
+    const result = await runWorkflowScript({
+      script: scriptFor('rollback', 'Determine whether activation merged'),
+      executables: {
+        gh: `
+case "$*" in
+  *"pulls/41"*)
+    printf '{"state":"closed","head":{"sha":"%s"},"merged_at":"2026-07-31T00:05:00Z"}\n' \
+      "${'${EXPECTED_ACTIVATION_SHA}'}"
+    ;;
+  *) printf 'unexpected gh invocation: %s\n' "$*" >&2; exit 97 ;;
+esac
+`,
+      },
+      environment: { EXPECTED_ACTIVATION_SHA: exactHead, PR_NUMBER: '41' },
+    })
+    try {
+      expect(result.exitCode, result.stderr).toBe(0)
+      expect(result.githubOutput).toContain('restore=true')
+      expect(result.stdout).not.toContain('merged only into a foreign base')
+    } finally {
+      result.dispose()
+    }
+  })
+
+  test('retains fail-closed rollback when activation state is unavailable', async () => {
+    const result = await runWorkflowScript({
+      script: scriptFor('rollback', 'Determine whether activation merged'),
+      executables: { gh: 'exit 1' },
+      environment: { EXPECTED_ACTIVATION_SHA: '1'.repeat(40), PR_NUMBER: '41' },
+    })
+    try {
+      expect(result.exitCode, result.stderr).toBe(0)
+      expect(result.githubOutput).toContain('restore=true')
+      expect(result.stderr).toContain('Activation PR state is unavailable; retaining fail-closed OBSERVE rollback.')
+    } finally {
+      result.dispose()
+    }
+  })
+
+  test('owning rollback refuses a base retarget immediately before merge', async () => {
+    const result = await runWorkflowScript({
+      script: scriptFor('rollback', 'Merge only clean exact-head protected rollback'),
+      executables: {
+        gh: `
+case "$*" in
+  *"pulls/42/merge"*) printf '%s\n' merge >> "${'${FAKE_MERGE_LOG}'}"; printf '%s\n' '{"merged":true}' ;;
+  *"api graphql"*)
+    printf '%s\n' '{"data":{"repository":{"pullRequest":{"reviewThreads":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}}'
+    ;;
+  *"check-runs?filter=latest"*) printf '%s\n' '[{"total_count":1,"check_runs":[{"id":1,"status":"completed","conclusion":"success"}]}]' ;;
+  *"pulls/42"*)
+    count=0
+    [[ -s "${'${FAKE_PULL_COUNTER}'}" ]] && count="$(cat "${'${FAKE_PULL_COUNTER}'}")"
+    count=$((count + 1))
+    printf '%s' "${'${count}'}" > "${'${FAKE_PULL_COUNTER}'}"
+    base_ref=main
+    [[ "${'${count}'}" -gt 2 ]] && base_ref=retargeted
+    printf '{"state":"open","head":{"sha":"%s"},"base":{"ref":"%s"},"mergeable_state":"clean"}\n' \
+      "${'${FAKE_HEAD_SHA}'}" "${'${base_ref}'}"
+    ;;
+  *) printf 'unexpected gh invocation: %s\n' "$*" >&2; exit 97 ;;
+esac
+`,
+        sleep: 'exit 0',
+      },
+      environment: {
+        EXPECTED_ROLLBACK_SHA: 'a'.repeat(40),
+        PR_NUMBER: '42',
+        FAKE_HEAD_SHA: 'a'.repeat(40),
+        FAKE_PULL_COUNTER: 'pull-counter',
+        FAKE_MERGE_LOG: 'merge.log',
+      },
+    })
+
+    try {
+      expect(result.exitCode).not.toBe(0)
+      expect(result.stderr).toContain('rollback head or base changed immediately before merge')
+      expect(existsSync(join(result.root, 'merge.log'))).toBe(false)
+    } finally {
+      result.dispose()
+    }
+  })
+
+  test('owning rollback refuses a branch replacement before the merge job starts', async () => {
+    const expected = 'a'.repeat(40)
+    const replacement = 'b'.repeat(40)
+    const result = await runWorkflowScript({
+      script: scriptFor('rollback', 'Merge only clean exact-head protected rollback'),
+      executables: {
+        gh: `
+case "$*" in
+  *"pulls/42/merge"*) printf '%s\n' merge >> "${'${FAKE_MERGE_LOG}'}"; printf '%s\n' '{"merged":true}' ;;
+  *"pulls/42"*)
+    printf '{"state":"open","head":{"sha":"%s"},"base":{"ref":"main"},"mergeable_state":"clean"}\n' "${'${FAKE_REPLACEMENT_SHA}'}"
+    ;;
+  *) printf 'unexpected gh invocation: %s\n' "$*" >&2; exit 98 ;;
+esac
+`,
+      },
+      environment: {
+        EXPECTED_ROLLBACK_SHA: expected,
+        PR_NUMBER: '42',
+        FAKE_REPLACEMENT_SHA: replacement,
+        FAKE_MERGE_LOG: 'merge.log',
+      },
+    })
+    try {
+      expect(result.exitCode).not.toBe(0)
+      expect(result.stderr).toContain('rollback-head-changed')
+      expect(existsSync(join(result.root, 'merge.log'))).toBe(false)
+    } finally {
+      result.dispose()
+    }
+  })
+
+  test('watchdog refuses a base retarget immediately before merge', async () => {
+    const result = await runWatchdog(paperStatus({ checkedAt: isoSeconds(Date.now()) }), {
+      initialBaseRef: 'main',
+      finalBaseRef: 'retargeted',
+    })
+    try {
+      expect(result.exitCode).not.toBe(0)
+      expect(result.stderr).toContain('head or base changed immediately before merge')
+      expect(existsSync(join(result.root, 'merge.log'))).toBe(false)
+    } finally {
+      result.dispose()
+    }
+  })
+
+  test('always restores OBSERVE through the owning job and independent watchdog', () => {
+    expect(parsed.jobs.rollback?.if ?? '').toContain('always()')
+    expect(parsed.jobs.rollback?.if ?? '').toContain("needs.verify-and-prepare.outputs.live == 'true'")
+    expect(workflow).toContain('--mode render-rollback')
+    expect(workflow).toContain('Always restore reviewed OBSERVE GitOps state')
+    expect(workflow).toContain("if: steps.activation_state.outputs.restore == 'true'")
+    expect(workflow).toContain('Recover abandoned PAPER activation')
+    expect(workflow).toContain('bayn-paper-rollback-watchdog')
+    expect(workflow).toContain('--force-with-lease=')
+    expect(workflow).toContain('--mode inspect-deployment-authority')
+    expect(workflow).not.toContain('@codex review')
+    expect(workflow).not.toContain('gh pr comment')
+    expect(workflow).not.toContain('/reviews?per_page=100')
+    expect(workflow).not.toContain('/reactions?per_page=100')
+    expect(workflow).not.toContain('chatgpt-codex-connector[bot]')
+    expect(workflow.match(/\.base\.ref/g)?.length ?? 0).toBeGreaterThanOrEqual(6)
+    expect(count('-f sha="${')).toBe(3)
+    expect(workflow).not.toContain('https://api.alpaca.markets')
+    expect(workflow).not.toContain('value: live-capital-grant')
+  })
+})

--- a/packages/scripts/src/bayn/verify-paper-activation.test.ts
+++ b/packages/scripts/src/bayn/verify-paper-activation.test.ts
@@ -1,0 +1,590 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { describe, expect, test } from 'bun:test'
+import { parse } from 'yaml'
+
+import {
+  deriveObserveRollbackGeneration,
+  evaluatePaperActivation,
+  extractDeploymentAuthorityState,
+  extractPaperActivationManifestPins,
+  paperAuthorityGenerationHash,
+  renderObserveRollback,
+  renderPaperActivationTransition,
+  type PaperActivationEvidence,
+  type PaperAuthorityGenerationMaterial,
+} from './verify-paper-activation'
+
+const hash = 'a'.repeat(64)
+const sourceSha = 'b'.repeat(40)
+const now = '2026-07-31T08:00:00Z'
+const deploymentPath = new URL('../../../../argocd/applications/bayn/deployment.yaml', import.meta.url)
+const kustomizationPath = new URL('../../../../argocd/applications/bayn/kustomization.yaml', import.meta.url)
+const generationMaterial = (
+  overrides: Partial<PaperAuthorityGenerationMaterial> = {},
+): PaperAuthorityGenerationMaterial => ({
+  schemaVersion: 'bayn.paper-authority-generation.v2',
+  maximum: 'PAPER',
+  previousGenerationHash: '0'.repeat(64),
+  qualificationRunId: hash,
+  qualificationLockId: '1'.repeat(64),
+  qualificationResultHash: '2'.repeat(64),
+  protocolHash: hash,
+  qualificationExecutionPolicyHash: '3'.repeat(64),
+  qualificationSourceRevision: sourceSha,
+  qualificationImageRepository: 'registry.ide-newton.ts.net/lab/bayn',
+  qualificationImageDigest: `sha256:${'c'.repeat(64)}`,
+  activationSourceRevision: sourceSha,
+  activationImageRepository: 'registry.ide-newton.ts.net/lab/bayn',
+  activationImageDigest: `sha256:${'c'.repeat(64)}`,
+  strategyName: 'risk-balanced-trend',
+  strategyBehaviorHash: hash,
+  strategyParameterHash: hash,
+  strategyParameterSchemaVersion: 'bayn.risk-balanced-trend.protocol.v4',
+  accountId: 'paper-account-1',
+  riskPolicyHash: '4'.repeat(64),
+  proofPlanHash: '5'.repeat(64),
+  reconciliationId: '6'.repeat(64),
+  reconciliationContentHash: '7'.repeat(64),
+  ...overrides,
+})
+const authorityGeneration = (overrides: Partial<PaperAuthorityGenerationMaterial> = {}) => {
+  const material = generationMaterial(overrides)
+  return { ...material, generationHash: paperAuthorityGenerationHash(material) }
+}
+const evidence = (overrides: Partial<PaperActivationEvidence> = {}): PaperActivationEvidence => ({
+  schemaVersion: 1,
+  repository: 'proompteng/lab',
+  mainSha: sourceSha,
+  currentMainSha: sourceSha,
+  sourceSha,
+  imageRepository: 'registry.ide-newton.ts.net/lab/bayn',
+  imageDigest: `sha256:${'c'.repeat(64)}`,
+  protocolHash: hash,
+  strategyBehaviorHash: hash,
+  strategyParameterHash: hash,
+  qualificationRunId: hash,
+  qualificationDecision: 'QUALIFIED',
+  qualificationObservedAt: '2026-07-31T07:00:00Z',
+  qualificationExpiresAt: '2026-08-01T07:00:00Z',
+  accountBindingHash: hash,
+  brokerEnvironment: 'sandbox',
+  brokerBaseUrl: 'https://paper-api.alpaca.markets',
+  maximumAuthority: 'PAPER',
+  authorityGeneration: authorityGeneration(),
+  authorityExpiresAt: '2026-07-31T09:00:00Z',
+  unresolvedMutationCount: 0,
+  unknownMutationCount: 0,
+  openOrderCount: 0,
+  discrepancyCount: 0,
+  reconciliation: 'EXACT',
+  killSwitchActive: false,
+  identityGap: false,
+  activationState: 'PRECOMMITTED',
+  activationId: 'proompt-405-paper-proof-1',
+  ...overrides,
+})
+const manifestPins = (value: PaperActivationEvidence) => ({
+  sourceSha: value.sourceSha,
+  strategyBehaviorHash: value.strategyBehaviorHash,
+  strategyParameterHash: value.strategyParameterHash,
+  qualificationRunId: value.qualificationRunId,
+  deploymentImageRepository: value.imageRepository,
+  deploymentImageDigest: value.imageDigest,
+  kustomizeImageRepository: value.imageRepository,
+  kustomizeImageDigest: value.imageDigest,
+  kustomizeImageTag: `sha-${value.sourceSha}`,
+  currentAuthorityGenerationHash: value.authorityGeneration.previousGenerationHash,
+})
+const evaluate = (value = evidence()) =>
+  evaluatePaperActivation({
+    evidence: value,
+    pins: {
+      sourceSha: value.sourceSha,
+      imageRepository: value.imageRepository,
+      imageDigest: value.imageDigest,
+      protocolHash: value.protocolHash,
+      strategyBehaviorHash: value.strategyBehaviorHash,
+      strategyParameterHash: value.strategyParameterHash,
+      qualificationRunId: value.qualificationRunId,
+      accountBindingHash: value.accountBindingHash,
+    },
+    manifestPins: manifestPins(value),
+    now,
+    expectedRepository: 'proompteng/lab',
+    expectedActivationId: 'proompt-405-paper-proof-1',
+    trustedCurrentMainSha: sourceSha,
+  })
+
+describe('Bayn PAPER activation verifier', () => {
+  test('accepts one exact current-main precommitted sandbox PAPER tuple', () =>
+    expect(evaluate()).toMatchObject({ status: 'eligible' }))
+  const holds: Array<[string, Partial<PaperActivationEvidence>, string]> = [
+    ['rejected', { qualificationDecision: 'REJECTED' }, 'qualification-not-qualified'],
+    ['stale', { qualificationExpiresAt: now }, 'qualification-stale'],
+    ['noncurrent', { currentMainSha: 'd'.repeat(40) }, 'noncurrent-main'],
+    ['duplicate', { activationState: 'CONSUMED' }, 'activation-not-precommitted'],
+    ['in-flight', { activationState: 'IN_FLIGHT' }, 'activation-not-precommitted'],
+    ['mutation', { unresolvedMutationCount: 1 }, 'unsafe-runtime-state'],
+    ['unknown mutation', { unknownMutationCount: 1 }, 'unsafe-runtime-state'],
+    ['open order', { openOrderCount: 1 }, 'unsafe-runtime-state'],
+    ['discrepancy', { discrepancyCount: 1 }, 'unsafe-runtime-state'],
+    ['non-exact', { reconciliation: 'NON_EXACT' }, 'reconciliation-not-exact'],
+    ['kill', { killSwitchActive: true }, 'kill-switch-active'],
+    ['identity gap', { identityGap: true }, 'identity-gap'],
+    ['expired authority', { authorityExpiresAt: now }, 'authority-expired'],
+    [
+      'authority beyond qualification',
+      { qualificationExpiresAt: '2026-07-31T08:30:00Z', authorityExpiresAt: '2026-07-31T08:45:00Z' },
+      'authority-outlives-qualification',
+    ],
+    ['unbounded authority', { authorityExpiresAt: '2026-07-31T10:00:01Z' }, 'authority-window-too-long'],
+    ['live endpoint', { brokerBaseUrl: 'https://api.alpaca.markets' }, 'live-money-endpoint'],
+    ['live environment', { brokerEnvironment: 'live' }, 'not-paper-only'],
+    ['live authority', { maximumAuthority: 'LIVE' }, 'not-paper-only'],
+  ]
+  test.each(holds)('rejects %s', (_name, override, code) =>
+    expect(evaluate(evidence(override))).toMatchObject({ status: 'hold', code }),
+  )
+  test('rejects changed pins', () => {
+    const value = evidence()
+    expect(
+      evaluatePaperActivation({
+        evidence: value,
+        pins: {
+          sourceSha: 'e'.repeat(40),
+          imageRepository: value.imageRepository,
+          imageDigest: value.imageDigest,
+          protocolHash: value.protocolHash,
+          strategyBehaviorHash: value.strategyBehaviorHash,
+          strategyParameterHash: value.strategyParameterHash,
+          qualificationRunId: value.qualificationRunId,
+          accountBindingHash: value.accountBindingHash,
+        },
+        manifestPins: manifestPins(value),
+        now,
+        expectedRepository: 'proompteng/lab',
+        expectedActivationId: value.activationId,
+        trustedCurrentMainSha: sourceSha,
+      }),
+    ).toMatchObject({ status: 'hold', code: 'pin-mismatch' })
+  })
+  test('rejects an unbound authority generation', () =>
+    expect(
+      evaluate(
+        evidence({
+          authorityGeneration: { ...authorityGeneration(), generationHash: hash },
+        }),
+      ),
+    ).toMatchObject({
+      status: 'hold',
+      code: 'authority-generation-mismatch',
+    }))
+  test('uses Bayn canonical v2 generation identity and ignores reconciliation-only drift', () => {
+    const golden: PaperAuthorityGenerationMaterial = {
+      schemaVersion: 'bayn.paper-authority-generation.v2',
+      maximum: 'PAPER',
+      previousGenerationHash: '0'.repeat(64),
+      qualificationRunId: '1'.repeat(64),
+      qualificationLockId: '2'.repeat(64),
+      qualificationResultHash: '3'.repeat(64),
+      protocolHash: '4'.repeat(64),
+      qualificationExecutionPolicyHash: '5'.repeat(64),
+      qualificationSourceRevision: '6'.repeat(40),
+      qualificationImageRepository: 'registry.ide-newton.ts.net/lab/bayn',
+      qualificationImageDigest: `sha256:${'7'.repeat(64)}`,
+      activationSourceRevision: '8'.repeat(40),
+      activationImageRepository: 'registry.ide-newton.ts.net/lab/bayn',
+      activationImageDigest: `sha256:${'9'.repeat(64)}`,
+      strategyName: 'risk-balanced-trend',
+      strategyBehaviorHash: 'a'.repeat(64),
+      strategyParameterHash: 'b'.repeat(64),
+      strategyParameterSchemaVersion: 'bayn.risk-balanced-trend.protocol.v4',
+      accountId: 'paper-account-1',
+      riskPolicyHash: 'c'.repeat(64),
+      proofPlanHash: 'd'.repeat(64),
+      reconciliationId: 'e'.repeat(64),
+      reconciliationContentHash: 'f'.repeat(64),
+    }
+    expect(paperAuthorityGenerationHash(golden)).toBe(
+      '2ca5928d4b5330c61686cf691891529a8dbe71c49a3f92b8857c1ef3965ecb56',
+    )
+    expect(
+      paperAuthorityGenerationHash({
+        ...golden,
+        reconciliationId: '0'.repeat(64),
+        reconciliationContentHash: '1'.repeat(64),
+      }),
+    ).toBe(paperAuthorityGenerationHash(golden))
+    expect(paperAuthorityGenerationHash({ ...golden, proofPlanHash: '0'.repeat(64) })).not.toBe(
+      paperAuthorityGenerationHash(golden),
+    )
+  })
+  test('rejects canonical generation drift from the reviewed runtime and prior OBSERVE generation', () => {
+    const value = evidence()
+    const changedPrevious = authorityGeneration({ previousGenerationHash: '8'.repeat(64) })
+    expect(
+      evaluatePaperActivation({
+        evidence: { ...value, authorityGeneration: changedPrevious },
+        pins: {
+          sourceSha: value.sourceSha,
+          imageRepository: value.imageRepository,
+          imageDigest: value.imageDigest,
+          protocolHash: value.protocolHash,
+          strategyBehaviorHash: value.strategyBehaviorHash,
+          strategyParameterHash: value.strategyParameterHash,
+          qualificationRunId: value.qualificationRunId,
+          accountBindingHash: value.accountBindingHash,
+        },
+        manifestPins: manifestPins(value),
+        now,
+        expectedRepository: value.repository,
+        expectedActivationId: value.activationId,
+        trustedCurrentMainSha: sourceSha,
+      }),
+    ).toMatchObject({ status: 'hold', code: 'authority-generation-binding-mismatch' })
+    const changedActivation = authorityGeneration({ activationSourceRevision: '9'.repeat(40) })
+    expect(evaluate({ ...value, authorityGeneration: changedActivation })).toMatchObject({
+      status: 'hold',
+      code: 'authority-generation-binding-mismatch',
+    })
+  })
+  test('rejects incomplete reviewed pins', () => {
+    const value = evidence()
+    expect(
+      evaluatePaperActivation({
+        evidence: value,
+        pins: {},
+        manifestPins: {},
+        now,
+        expectedRepository: value.repository,
+        expectedActivationId: value.activationId,
+        trustedCurrentMainSha: sourceSha,
+      }),
+    ).toMatchObject({ status: 'hold', code: 'invalid-pins' })
+  })
+  test.each(['killSwitchActive', 'identityGap'] as const)('rejects omitted %s evidence', (field) => {
+    const complete = evidence()
+    const incomplete = { ...complete } as Record<string, unknown>
+    delete incomplete[field]
+    expect(
+      evaluatePaperActivation({
+        evidence: incomplete,
+        pins: {
+          sourceSha: complete.sourceSha,
+          imageRepository: complete.imageRepository,
+          imageDigest: complete.imageDigest,
+          protocolHash: complete.protocolHash,
+          strategyBehaviorHash: complete.strategyBehaviorHash,
+          strategyParameterHash: complete.strategyParameterHash,
+          qualificationRunId: complete.qualificationRunId,
+          accountBindingHash: complete.accountBindingHash,
+        },
+        manifestPins: manifestPins(complete),
+        now,
+        expectedRepository: complete.repository,
+        expectedActivationId: complete.activationId,
+        trustedCurrentMainSha: sourceSha,
+      }),
+    ).toMatchObject({ status: 'hold', code: 'invalid-evidence' })
+  })
+  test.each(['killSwitchActive', 'identityGap'] as const)('rejects non-boolean %s evidence', (field) => {
+    const complete = evidence()
+    const malformed = { ...complete, [field]: 0 }
+    expect(
+      evaluatePaperActivation({
+        evidence: malformed,
+        pins: {
+          sourceSha: complete.sourceSha,
+          imageRepository: complete.imageRepository,
+          imageDigest: complete.imageDigest,
+          protocolHash: complete.protocolHash,
+          strategyBehaviorHash: complete.strategyBehaviorHash,
+          strategyParameterHash: complete.strategyParameterHash,
+          qualificationRunId: complete.qualificationRunId,
+          accountBindingHash: complete.accountBindingHash,
+        },
+        manifestPins: manifestPins(complete),
+        now,
+        expectedRepository: complete.repository,
+        expectedActivationId: complete.activationId,
+        trustedCurrentMainSha: sourceSha,
+      }),
+    ).toMatchObject({ status: 'hold', code: 'invalid-evidence' })
+  })
+  test('rejects a self-asserted stale main and deployment drift', () => {
+    const value = evidence()
+    expect(
+      evaluatePaperActivation({
+        evidence: value,
+        pins: {
+          sourceSha: value.sourceSha,
+          imageRepository: value.imageRepository,
+          imageDigest: value.imageDigest,
+          protocolHash: value.protocolHash,
+          strategyBehaviorHash: value.strategyBehaviorHash,
+          strategyParameterHash: value.strategyParameterHash,
+          qualificationRunId: value.qualificationRunId,
+          accountBindingHash: value.accountBindingHash,
+        },
+        manifestPins: { ...manifestPins(value), kustomizeImageDigest: `sha256:${'d'.repeat(64)}` },
+        now,
+        expectedRepository: value.repository,
+        expectedActivationId: value.activationId,
+        trustedCurrentMainSha: 'e'.repeat(40),
+      }),
+    ).toMatchObject({ status: 'hold', code: 'noncurrent-main' })
+    expect(
+      evaluatePaperActivation({
+        evidence: value,
+        pins: {
+          sourceSha: value.sourceSha,
+          imageRepository: value.imageRepository,
+          imageDigest: value.imageDigest,
+          protocolHash: value.protocolHash,
+          strategyBehaviorHash: value.strategyBehaviorHash,
+          strategyParameterHash: value.strategyParameterHash,
+          qualificationRunId: value.qualificationRunId,
+          accountBindingHash: value.accountBindingHash,
+        },
+        manifestPins: { ...manifestPins(value), kustomizeImageDigest: `sha256:${'d'.repeat(64)}` },
+        now,
+        expectedRepository: value.repository,
+        expectedActivationId: value.activationId,
+        trustedCurrentMainSha: sourceSha,
+      }),
+    ).toMatchObject({ status: 'hold', code: 'manifest-pin-mismatch' })
+  })
+
+  test('binds evidence to the effective Kustomize image', () => {
+    const deployment = readFileSync(deploymentPath, 'utf8')
+    const kustomization = readFileSync(kustomizationPath, 'utf8')
+    const extracted = extractPaperActivationManifestPins(deployment, kustomization)
+    expect(extracted.deploymentImageRepository).toBe(extracted.kustomizeImageRepository)
+    expect(extracted.deploymentImageDigest).toBe(extracted.kustomizeImageDigest)
+    expect(extracted.kustomizeImageTag).toBe(`sha-${extracted.sourceSha}`)
+
+    const value = evidence({
+      sourceSha: extracted.sourceSha,
+      imageRepository: extracted.kustomizeImageRepository,
+      imageDigest: extracted.kustomizeImageDigest,
+      strategyBehaviorHash: extracted.strategyBehaviorHash,
+      strategyParameterHash: extracted.strategyParameterHash,
+      qualificationRunId: extracted.qualificationRunId,
+    })
+    const drifted = extractPaperActivationManifestPins(
+      deployment,
+      kustomization.replace(extracted.kustomizeImageDigest, `sha256:${'d'.repeat(64)}`),
+    )
+    expect(
+      evaluatePaperActivation({
+        evidence: value,
+        pins: {
+          sourceSha: value.sourceSha,
+          imageRepository: value.imageRepository,
+          imageDigest: value.imageDigest,
+          protocolHash: value.protocolHash,
+          strategyBehaviorHash: value.strategyBehaviorHash,
+          strategyParameterHash: value.strategyParameterHash,
+          qualificationRunId: value.qualificationRunId,
+          accountBindingHash: value.accountBindingHash,
+        },
+        manifestPins: drifted,
+        now,
+        expectedRepository: value.repository,
+        expectedActivationId: value.activationId,
+        trustedCurrentMainSha: sourceSha,
+      }),
+    ).toMatchObject({ status: 'hold', code: 'manifest-pin-mismatch' })
+
+    expect(() =>
+      extractPaperActivationManifestPins(
+        deployment.replace(
+          '          image: registry.ide-newton.ts.net/lab/bayn\n',
+          '          image: registry.example.invalid/unreviewed/bayn\n',
+        ),
+        kustomization,
+      ),
+    ).toThrow('Bayn container image does not match BAYN_IMAGE_REPOSITORY')
+  })
+
+  test('renders one runtime-valid PAPER capability transition and explicit OBSERVE rollback', () => {
+    const nextAuthorityHash = 'f'.repeat(64)
+    const authorityExpiresAt = '2026-07-31T09:00:00Z'
+    const rollbackGeneration = deriveObserveRollbackGeneration({
+      repository: 'proompteng/lab',
+      activationId: 'proompt-405-paper-proof-1',
+      sourceMainSha: sourceSha,
+      previousObserveGenerationHash: '0'.repeat(64),
+      paperAuthorityGenerationHash: nextAuthorityHash,
+    })
+    const rendered = renderPaperActivationTransition(
+      readFileSync(deploymentPath, 'utf8'),
+      nextAuthorityHash,
+      rollbackGeneration.generationHash,
+      authorityExpiresAt,
+    )
+    const envValues = (document: string): ReadonlyMap<string, string> => {
+      const deployment = parse(document) as {
+        spec: { template: { spec: { containers: readonly [{ env: readonly { name: string; value?: string }[] }] } } }
+      }
+      return new Map(
+        deployment.spec.template.spec.containers[0].env.flatMap((entry) =>
+          entry.value === undefined ? [] : [[entry.name, entry.value] as const],
+        ),
+      )
+    }
+    const paper = envValues(rendered.paperDeployment)
+    const observe = envValues(rendered.observeDeployment)
+    expect(paper.get('BAYN_MAXIMUM_AUTHORITY')).toBe('PAPER')
+    expect(paper.get('BAYN_BROKER_ACCESS')).toBe('mutation')
+    expect(paper.get('BAYN_CAPITAL_AUTHORITY')).toBe('sandbox-capital')
+    expect(paper.get('BAYN_AUTHORITY_GENERATION_HASH')).toBe(nextAuthorityHash)
+    expect(paper.get('BAYN_PAPER_AUTHORITY_EXPIRES_AT')).toBe(authorityExpiresAt)
+    expect(observe.get('BAYN_MAXIMUM_AUTHORITY')).toBe('OBSERVE')
+    expect(observe.get('BAYN_BROKER_ACCESS')).toBe('read-only')
+    expect(observe.get('BAYN_CAPITAL_AUTHORITY')).toBe('none')
+    expect(observe.get('BAYN_AUTHORITY_GENERATION_HASH')).toBe(rollbackGeneration.generationHash)
+    expect(observe.has('BAYN_PAPER_AUTHORITY_EXPIRES_AT')).toBe(false)
+    expect(observe.get('BAYN_AUTHORITY_GENERATION_HASH')).not.toBe('0'.repeat(64))
+    expect(renderObserveRollback(rendered.paperDeployment, observe.get('BAYN_AUTHORITY_GENERATION_HASH') ?? '')).toBe(
+      rendered.observeDeployment,
+    )
+    expect(extractDeploymentAuthorityState(rendered.paperDeployment)).toEqual({
+      maximumAuthority: 'PAPER',
+      brokerAccess: 'mutation',
+      capitalAuthority: 'sandbox-capital',
+      authorityGenerationHash: nextAuthorityHash,
+    })
+    expect(extractDeploymentAuthorityState(rendered.observeDeployment)).toEqual({
+      maximumAuthority: 'OBSERVE',
+      brokerAccess: 'read-only',
+      capitalAuthority: 'none',
+      authorityGenerationHash: rollbackGeneration.generationHash,
+    })
+
+    const paperDeployment = parse(rendered.paperDeployment) as {
+      spec: {
+        template: {
+          spec: {
+            containers: readonly [{ command?: readonly string[]; args?: readonly string[] }]
+          }
+        }
+      }
+    }
+    const observeDeployment = parse(rendered.observeDeployment) as {
+      spec: {
+        template: {
+          spec: {
+            containers: readonly [{ command?: readonly string[]; args?: readonly string[] }]
+          }
+        }
+      }
+    }
+    const paperContainer = paperDeployment.spec.template.spec.containers[0]
+    const observeContainer = observeDeployment.spec.template.spec.containers[0]
+    expect(paperContainer.command).toEqual(['node'])
+    expect(paperContainer.args?.[0]).toBe('-e')
+    expect(paperContainer.args?.[1]).toContain('BAYN_PAPER_AUTHORITY_EXPIRES_AT')
+    expect(observeContainer.command).toBeUndefined()
+    expect(observeContainer.args).toBeUndefined()
+  })
+
+  test('hard-stops at expiry, refuses expired restart, and preserves graceful termination signals', async () => {
+    const nextAuthorityHash = 'f'.repeat(64)
+    const rollbackGeneration = deriveObserveRollbackGeneration({
+      repository: 'proompteng/lab',
+      activationId: 'proompt-405-paper-proof-1',
+      sourceMainSha: sourceSha,
+      previousObserveGenerationHash: '0'.repeat(64),
+      paperAuthorityGenerationHash: nextAuthorityHash,
+    })
+    const rendered = renderPaperActivationTransition(
+      readFileSync(deploymentPath, 'utf8'),
+      nextAuthorityHash,
+      rollbackGeneration.generationHash,
+      '2026-07-31T09:00:00Z',
+    )
+    const deployment = parse(rendered.paperDeployment) as {
+      spec: { template: { spec: { containers: readonly [{ args: readonly string[] }] } } }
+    }
+    const guard = deployment.spec.template.spec.containers[0].args[1] ?? ''
+    const root = mkdtempSync(join(tmpdir(), 'bayn-paper-expiry-'))
+    const marker = join(root, 'started')
+    mkdirSync(join(root, 'dist'))
+    writeFileSync(
+      join(root, 'dist/index.js'),
+      `require('node:fs').writeFileSync(${JSON.stringify(marker)}, 'started'); setInterval(() => {}, 1000);\n`,
+    )
+    try {
+      const deadline = new Date(Date.now() + 200).toISOString()
+      const startedAt = Date.now()
+      const running = Bun.spawnSync({
+        cmd: ['node', '-e', guard],
+        cwd: root,
+        env: { ...process.env, BAYN_PAPER_AUTHORITY_EXPIRES_AT: deadline },
+      })
+      expect(running.exitCode).toBe(78)
+      expect(Date.now() - startedAt).toBeLessThan(2_000)
+      expect(existsSync(marker)).toBe(true)
+
+      const expired = Bun.spawnSync({
+        cmd: ['node', '-e', guard],
+        cwd: root,
+        env: { ...process.env, BAYN_PAPER_AUTHORITY_EXPIRES_AT: new Date(Date.now() - 1_000).toISOString() },
+      })
+      expect(expired.exitCode).toBe(78)
+
+      const signalMarker = join(root, 'signal-started')
+      writeFileSync(
+        join(root, 'dist/index.js'),
+        `require('node:fs').writeFileSync(${JSON.stringify(signalMarker)}, 'started'); setInterval(() => {}, 1000);\n`,
+      )
+      const supervisor = Bun.spawn(['node', '-e', guard], {
+        cwd: root,
+        env: { ...process.env, BAYN_PAPER_AUTHORITY_EXPIRES_AT: new Date(Date.now() + 10_000).toISOString() },
+        stdout: 'ignore',
+        stderr: 'ignore',
+      })
+      for (let attempt = 0; attempt < 100 && !existsSync(signalMarker); attempt++) await Bun.sleep(10)
+      expect(existsSync(signalMarker)).toBe(true)
+      const signaledAt = Date.now()
+      supervisor.kill('SIGTERM')
+      const signalExit = await Promise.race([supervisor.exited, Bun.sleep(2_000).then(() => -1)])
+      expect(signalExit).toBe(143)
+      expect(supervisor.signalCode).toBe('SIGTERM')
+      expect(Date.now() - signaledAt).toBeLessThan(2_000)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+  test('precommits a deterministic fresh OBSERVE rollback generation', () => {
+    const input = {
+      repository: 'proompteng/lab',
+      activationId: 'proompt-405-paper-proof-1',
+      sourceMainSha: sourceSha,
+      previousObserveGenerationHash: '0'.repeat(64),
+      paperAuthorityGenerationHash: 'f'.repeat(64),
+    }
+    const generation = deriveObserveRollbackGeneration(input)
+    expect(deriveObserveRollbackGeneration(input)).toEqual(generation)
+    expect(generation.generationHash).not.toBe(input.previousObserveGenerationHash)
+    expect(generation.generationHash).not.toBe(input.paperAuthorityGenerationHash)
+    expect(deriveObserveRollbackGeneration({ ...input, activationId: 'another-activation' }).generationHash).not.toBe(
+      generation.generationHash,
+    )
+    expect(() =>
+      renderPaperActivationTransition(
+        readFileSync(deploymentPath, 'utf8'),
+        input.paperAuthorityGenerationHash,
+        extractPaperActivationManifestPins(
+          readFileSync(deploymentPath, 'utf8'),
+          readFileSync(kustomizationPath, 'utf8'),
+        ).currentAuthorityGenerationHash,
+        '2026-07-31T09:00:00Z',
+      ),
+    ).toThrow('OBSERVE rollback generation must be fresh')
+  })
+})

--- a/packages/scripts/src/bayn/verify-paper-activation.ts
+++ b/packages/scripts/src/bayn/verify-paper-activation.ts
@@ -1,0 +1,877 @@
+import { readFileSync, writeFileSync } from 'node:fs'
+import { createHash } from 'node:crypto'
+
+import { parse } from 'yaml'
+
+export type PaperAuthorityGenerationMaterial = {
+  readonly schemaVersion: 'bayn.paper-authority-generation.v2'
+  readonly maximum: 'PAPER'
+  readonly previousGenerationHash: string
+  readonly qualificationRunId: string
+  readonly qualificationLockId: string
+  readonly qualificationResultHash: string
+  readonly protocolHash: string
+  readonly qualificationExecutionPolicyHash: string
+  readonly qualificationSourceRevision: string
+  readonly qualificationImageRepository: string
+  readonly qualificationImageDigest: string
+  readonly activationSourceRevision: string
+  readonly activationImageRepository: string
+  readonly activationImageDigest: string
+  readonly strategyName: 'risk-balanced-trend'
+  readonly strategyBehaviorHash: string
+  readonly strategyParameterHash: string
+  readonly strategyParameterSchemaVersion:
+    | 'bayn.risk-balanced-trend.protocol.v3'
+    | 'bayn.risk-balanced-trend.protocol.v4'
+  readonly accountId: string
+  readonly riskPolicyHash: string
+  readonly proofPlanHash: string
+  readonly reconciliationId: string
+  readonly reconciliationContentHash: string
+}
+
+export type PaperAuthorityGeneration = PaperAuthorityGenerationMaterial & {
+  readonly generationHash: string
+}
+
+export type ObserveRollbackGeneration = {
+  readonly schemaVersion: 'bayn.observe-authority-rollback.v1'
+  readonly repository: string
+  readonly activationId: string
+  readonly sourceMainSha: string
+  readonly previousObserveGenerationHash: string
+  readonly paperAuthorityGenerationHash: string
+  readonly generationHash: string
+}
+
+export type DeploymentAuthorityState = {
+  readonly maximumAuthority: 'OBSERVE' | 'PAPER' | 'LIVE'
+  readonly brokerAccess: 'read-only' | 'mutation' | null
+  readonly capitalAuthority: 'none' | 'sandbox-capital' | 'live-capital-grant' | null
+  readonly authorityGenerationHash: string
+}
+
+export type PaperActivationEvidence = {
+  readonly schemaVersion: 1
+  readonly repository: string
+  readonly mainSha: string
+  readonly currentMainSha: string
+  readonly sourceSha: string
+  readonly imageRepository: string
+  readonly imageDigest: string
+  readonly protocolHash: string
+  readonly strategyBehaviorHash: string
+  readonly strategyParameterHash: string
+  readonly qualificationRunId: string
+  readonly qualificationDecision: 'QUALIFIED' | 'REJECTED'
+  readonly qualificationObservedAt: string
+  readonly qualificationExpiresAt: string
+  readonly accountBindingHash: string
+  readonly brokerEnvironment: 'sandbox' | 'live'
+  readonly brokerBaseUrl: string
+  readonly maximumAuthority: 'OBSERVE' | 'PAPER' | 'LIVE'
+  readonly authorityGeneration: PaperAuthorityGeneration
+  readonly authorityExpiresAt: string
+  readonly unresolvedMutationCount: number
+  readonly unknownMutationCount: number
+  readonly openOrderCount: number
+  readonly discrepancyCount: number
+  readonly reconciliation: 'EXACT' | 'NON_EXACT' | 'UNKNOWN'
+  readonly killSwitchActive: boolean
+  readonly identityGap: boolean
+  readonly activationState: 'PRECOMMITTED' | 'IN_FLIGHT' | 'CONSUMED' | 'CANCELLED'
+  readonly activationId: string
+}
+
+export type PaperActivationPins = Pick<
+  PaperActivationEvidence,
+  | 'sourceSha'
+  | 'imageRepository'
+  | 'imageDigest'
+  | 'protocolHash'
+  | 'strategyBehaviorHash'
+  | 'strategyParameterHash'
+  | 'qualificationRunId'
+  | 'accountBindingHash'
+>
+
+export type PaperActivationManifestPins = Pick<
+  PaperActivationEvidence,
+  'sourceSha' | 'strategyBehaviorHash' | 'strategyParameterHash' | 'qualificationRunId'
+> & {
+  readonly deploymentImageRepository: string
+  readonly deploymentImageDigest: string
+  readonly kustomizeImageRepository: string
+  readonly kustomizeImageDigest: string
+  readonly kustomizeImageTag: string
+  readonly currentAuthorityGenerationHash: string
+}
+
+export type PaperActivationDecision =
+  | { readonly status: 'eligible'; readonly activationId: string; readonly authorityGenerationHash: string }
+  | { readonly status: 'hold'; readonly code: string; readonly message: string }
+
+export type PaperActivationTransition = {
+  readonly paperDeployment: string
+  readonly observeDeployment: string
+}
+
+const sha256 = (value: string): string => createHash('sha256').update(value).digest('hex')
+const maximumAuthorityDurationMs = 90 * 60 * 1_000
+const isSha = (value: string): boolean => /^[0-9a-f]{40}$/.test(value)
+const isHash = (value: string): boolean => /^[0-9a-f]{64}$/.test(value)
+const isDigest = (value: string): boolean => /^sha256:[0-9a-f]{64}$/.test(value)
+const hold = (code: string, message: string): PaperActivationDecision => ({ status: 'hold', code, message })
+const evidenceKeys = [
+  'schemaVersion',
+  'repository',
+  'mainSha',
+  'currentMainSha',
+  'sourceSha',
+  'imageRepository',
+  'imageDigest',
+  'protocolHash',
+  'strategyBehaviorHash',
+  'strategyParameterHash',
+  'qualificationRunId',
+  'qualificationDecision',
+  'qualificationObservedAt',
+  'qualificationExpiresAt',
+  'accountBindingHash',
+  'brokerEnvironment',
+  'brokerBaseUrl',
+  'maximumAuthority',
+  'authorityGeneration',
+  'authorityExpiresAt',
+  'unresolvedMutationCount',
+  'unknownMutationCount',
+  'openOrderCount',
+  'discrepancyCount',
+  'reconciliation',
+  'killSwitchActive',
+  'identityGap',
+  'activationState',
+  'activationId',
+] as const satisfies readonly (keyof PaperActivationEvidence)[]
+const pinKeys = [
+  'sourceSha',
+  'imageRepository',
+  'imageDigest',
+  'protocolHash',
+  'strategyBehaviorHash',
+  'strategyParameterHash',
+  'qualificationRunId',
+  'accountBindingHash',
+] as const satisfies readonly (keyof PaperActivationPins)[]
+const manifestPinKeys = [
+  'sourceSha',
+  'strategyBehaviorHash',
+  'strategyParameterHash',
+  'qualificationRunId',
+  'deploymentImageRepository',
+  'deploymentImageDigest',
+  'kustomizeImageRepository',
+  'kustomizeImageDigest',
+  'kustomizeImageTag',
+  'currentAuthorityGenerationHash',
+] as const satisfies readonly (keyof PaperActivationManifestPins)[]
+
+const paperGenerationKeys = [
+  'schemaVersion',
+  'maximum',
+  'previousGenerationHash',
+  'qualificationRunId',
+  'qualificationLockId',
+  'qualificationResultHash',
+  'protocolHash',
+  'qualificationExecutionPolicyHash',
+  'qualificationSourceRevision',
+  'qualificationImageRepository',
+  'qualificationImageDigest',
+  'activationSourceRevision',
+  'activationImageRepository',
+  'activationImageDigest',
+  'strategyName',
+  'strategyBehaviorHash',
+  'strategyParameterHash',
+  'strategyParameterSchemaVersion',
+  'accountId',
+  'riskPolicyHash',
+  'proofPlanHash',
+  'reconciliationId',
+  'reconciliationContentHash',
+  'generationHash',
+] as const satisfies readonly (keyof PaperAuthorityGeneration)[]
+
+const requirePins = <Key extends string>(value: unknown, keys: readonly Key[]): Record<Key, string> | null => {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return null
+  const record = value as Record<string, unknown>
+  if (Object.keys(record).length !== keys.length) return null
+  for (const key of keys) if (typeof record[key] !== 'string' || record[key].length === 0) return null
+  return record as Record<Key, string>
+}
+
+const hasExactKeys = (record: Record<string, unknown>, keys: readonly string[]): boolean =>
+  Object.keys(record).length === keys.length && keys.every((key) => Object.hasOwn(record, key))
+
+const hasInvalidUnicodeSurrogate = (value: string): boolean => {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index)
+    if (code >= 0xd800 && code <= 0xdbff) {
+      const next = value.charCodeAt(index + 1)
+      if (index + 1 >= value.length || next < 0xdc00 || next > 0xdfff) return true
+      index += 1
+    } else if (code >= 0xdc00 && code <= 0xdfff) {
+      return true
+    }
+  }
+  return false
+}
+
+const canonicalJsonV1 = (value: unknown, ancestors: readonly object[] = []): string => {
+  if (value === null) return 'null'
+  if (typeof value === 'boolean') return value ? 'true' : 'false'
+  if (typeof value === 'string') {
+    if (hasInvalidUnicodeSurrogate(value)) throw new Error('canonical JSON contains an invalid Unicode surrogate')
+    return JSON.stringify(value)
+  }
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) throw new Error('canonical JSON contains a non-finite number')
+    return JSON.stringify(Object.is(value, -0) ? 0 : value)
+  }
+  if (typeof value !== 'object') throw new Error(`canonical JSON contains a non-JSON ${typeof value} value`)
+  if (ancestors.includes(value)) throw new Error('canonical JSON contains a cycle')
+
+  if (Array.isArray(value)) {
+    const keys = Reflect.ownKeys(value)
+    if (
+      keys.some(
+        (key) =>
+          key !== 'length' && (typeof key !== 'string' || !/^(?:0|[1-9]\d*)$/.test(key) || Number(key) >= value.length),
+      ) ||
+      Object.keys(value).some((key, index) => key !== String(index))
+    )
+      throw new Error('canonical JSON array is sparse or has custom properties')
+    return `[${value.map((entry) => canonicalJsonV1(entry, [...ancestors, value])).join(',')}]`
+  }
+
+  const prototype = Object.getPrototypeOf(value)
+  if (prototype !== Object.prototype && prototype !== null)
+    throw new Error('canonical JSON contains a non-plain object')
+  const keys = Reflect.ownKeys(value)
+  if (keys.some((key) => typeof key !== 'string')) throw new Error('canonical JSON contains a symbol key')
+  const entries = (keys as readonly string[])
+    .slice()
+    .sort((left, right) => (left < right ? -1 : left > right ? 1 : 0))
+    .map((key) => {
+      if (hasInvalidUnicodeSurrogate(key)) throw new Error('canonical JSON contains an invalid Unicode key')
+      const descriptor = Object.getOwnPropertyDescriptor(value, key)
+      if (descriptor?.enumerable !== true || !('value' in descriptor))
+        throw new Error('canonical JSON contains a non-data property')
+      return `${JSON.stringify(key)}:${canonicalJsonV1(descriptor.value, [...ancestors, value])}`
+    })
+  return `{${entries.join(',')}}`
+}
+
+const canonicalHashV1 = (value: unknown): string => sha256(canonicalJsonV1(value))
+
+const requirePaperAuthorityGeneration = (value: unknown): PaperAuthorityGeneration | null => {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return null
+  const record = value as Record<string, unknown>
+  if (!hasExactKeys(record, paperGenerationKeys)) return null
+  if (record.schemaVersion !== 'bayn.paper-authority-generation.v2' || record.maximum !== 'PAPER') return null
+  if (record.strategyName !== 'risk-balanced-trend') return null
+  if (
+    record.strategyParameterSchemaVersion !== 'bayn.risk-balanced-trend.protocol.v3' &&
+    record.strategyParameterSchemaVersion !== 'bayn.risk-balanced-trend.protocol.v4'
+  )
+    return null
+  const hashKeys = [
+    'previousGenerationHash',
+    'qualificationRunId',
+    'qualificationLockId',
+    'qualificationResultHash',
+    'protocolHash',
+    'qualificationExecutionPolicyHash',
+    'strategyBehaviorHash',
+    'strategyParameterHash',
+    'riskPolicyHash',
+    'proofPlanHash',
+    'reconciliationId',
+    'reconciliationContentHash',
+    'generationHash',
+  ] as const
+  if (hashKeys.some((key) => typeof record[key] !== 'string' || !isHash(record[key]))) return null
+  const sourceKeys = ['qualificationSourceRevision', 'activationSourceRevision'] as const
+  if (sourceKeys.some((key) => typeof record[key] !== 'string' || !isSha(record[key]))) return null
+  const digestKeys = ['qualificationImageDigest', 'activationImageDigest'] as const
+  if (digestKeys.some((key) => typeof record[key] !== 'string' || !isDigest(record[key]))) return null
+  const nonEmptyKeys = ['qualificationImageRepository', 'activationImageRepository', 'accountId'] as const
+  if (nonEmptyKeys.some((key) => typeof record[key] !== 'string' || record[key].length === 0)) return null
+  return record as unknown as PaperAuthorityGeneration
+}
+
+const requireEvidence = (value: unknown): PaperActivationEvidence | null => {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return null
+  const record = value as Record<string, unknown>
+  if (!hasExactKeys(record, evidenceKeys)) return null
+  const stringKeys = [
+    'repository',
+    'mainSha',
+    'currentMainSha',
+    'sourceSha',
+    'imageRepository',
+    'imageDigest',
+    'protocolHash',
+    'strategyBehaviorHash',
+    'strategyParameterHash',
+    'qualificationRunId',
+    'qualificationObservedAt',
+    'qualificationExpiresAt',
+    'accountBindingHash',
+    'brokerBaseUrl',
+    'authorityExpiresAt',
+    'activationId',
+  ] as const
+  if (stringKeys.some((key) => typeof record[key] !== 'string' || record[key].length === 0)) return null
+  const countKeys = ['unresolvedMutationCount', 'unknownMutationCount', 'openOrderCount', 'discrepancyCount'] as const
+  if (
+    countKeys.some((key) => {
+      const value = record[key]
+      return typeof value !== 'number' || !Number.isSafeInteger(value) || value < 0
+    })
+  )
+    return null
+  if (record.schemaVersion !== 1) return null
+  if (record.qualificationDecision !== 'QUALIFIED' && record.qualificationDecision !== 'REJECTED') return null
+  if (record.brokerEnvironment !== 'sandbox' && record.brokerEnvironment !== 'live') return null
+  if (
+    record.maximumAuthority !== 'OBSERVE' &&
+    record.maximumAuthority !== 'PAPER' &&
+    record.maximumAuthority !== 'LIVE'
+  )
+    return null
+  if (record.reconciliation !== 'EXACT' && record.reconciliation !== 'NON_EXACT' && record.reconciliation !== 'UNKNOWN')
+    return null
+  if (
+    record.activationState !== 'PRECOMMITTED' &&
+    record.activationState !== 'IN_FLIGHT' &&
+    record.activationState !== 'CONSUMED' &&
+    record.activationState !== 'CANCELLED'
+  )
+    return null
+  if (typeof record.killSwitchActive !== 'boolean' || typeof record.identityGap !== 'boolean') return null
+  const authorityGeneration = requirePaperAuthorityGeneration(record.authorityGeneration)
+  if (authorityGeneration === null) return null
+  return { ...(record as unknown as Omit<PaperActivationEvidence, 'authorityGeneration'>), authorityGeneration }
+}
+
+const expectRecord = (value: unknown, label: string): Record<string, unknown> => {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) throw new Error(`${label} must be an object`)
+  return value as Record<string, unknown>
+}
+
+const expectArray = (value: unknown, label: string): readonly unknown[] => {
+  if (!Array.isArray(value)) throw new Error(`${label} must be an array`)
+  return value
+}
+
+const expectString = (value: unknown, label: string): string => {
+  if (typeof value !== 'string' || value.length === 0) throw new Error(`${label} must be a non-empty string`)
+  return value
+}
+
+export const extractPaperActivationManifestPins = (
+  deploymentContents: string,
+  kustomizationContents: string,
+): PaperActivationManifestPins => {
+  const deployment = expectRecord(parse(deploymentContents), 'deployment')
+  const deploymentSpec = expectRecord(deployment.spec, 'deployment.spec')
+  const template = expectRecord(deploymentSpec.template, 'deployment.spec.template')
+  const podSpec = expectRecord(template.spec, 'deployment.spec.template.spec')
+  const containers = expectArray(podSpec.containers, 'deployment containers').map((value, index) =>
+    expectRecord(value, `deployment container ${index}`),
+  )
+  const baynContainers = containers.filter((container) => container.name === 'bayn')
+  if (baynContainers.length !== 1) throw new Error('deployment must contain exactly one Bayn container')
+  const environment = expectArray(baynContainers[0]?.env, 'Bayn environment').map((value, index) =>
+    expectRecord(value, `Bayn environment entry ${index}`),
+  )
+  const environmentValue = (name: string): string => {
+    const matches = environment.filter((entry) => entry.name === name)
+    if (matches.length !== 1) throw new Error(`deployment must contain exactly one ${name} value`)
+    return expectString(matches[0]?.value, name)
+  }
+
+  const deploymentContainerImage = expectString(baynContainers[0]?.image, 'Bayn container image')
+  const deploymentImageRepository = environmentValue('BAYN_IMAGE_REPOSITORY')
+  const deploymentImageDigest = environmentValue('BAYN_IMAGE_DIGEST')
+  if (deploymentContainerImage !== deploymentImageRepository)
+    throw new Error('Bayn container image does not match BAYN_IMAGE_REPOSITORY')
+  const kustomization = expectRecord(parse(kustomizationContents), 'kustomization')
+  const images = expectArray(kustomization.images, 'kustomization images').map((value, index) =>
+    expectRecord(value, `kustomization image ${index}`),
+  )
+  const matchingImages = images.filter((image) => image.name === deploymentContainerImage)
+  if (matchingImages.length !== 1) throw new Error('kustomization must contain exactly one effective Bayn image')
+  const image = matchingImages[0]
+  if (image === undefined) throw new Error('effective Bayn image is missing')
+
+  return {
+    sourceSha: environmentValue('BAYN_CODE_REVISION'),
+    strategyBehaviorHash: environmentValue('BAYN_STRATEGY_BEHAVIOR_HASH'),
+    strategyParameterHash: environmentValue('BAYN_STRATEGY_PARAMETER_HASH'),
+    qualificationRunId: environmentValue('BAYN_QUALIFICATION_RUN_ID'),
+    deploymentImageRepository,
+    deploymentImageDigest,
+    kustomizeImageRepository: expectString(image.newName, 'kustomization Bayn newName'),
+    kustomizeImageDigest: expectString(image.digest, 'kustomization Bayn digest'),
+    kustomizeImageTag: expectString(image.newTag, 'kustomization Bayn tag'),
+    currentAuthorityGenerationHash: environmentValue('BAYN_AUTHORITY_GENERATION_HASH'),
+  }
+}
+
+export const extractDeploymentAuthorityState = (deploymentContents: string): DeploymentAuthorityState => {
+  const deployment = expectRecord(parse(deploymentContents), 'deployment')
+  const deploymentSpec = expectRecord(deployment.spec, 'deployment.spec')
+  const template = expectRecord(deploymentSpec.template, 'deployment.spec.template')
+  const podSpec = expectRecord(template.spec, 'deployment.spec.template.spec')
+  const containers = expectArray(podSpec.containers, 'deployment containers').map((value, index) =>
+    expectRecord(value, `deployment container ${index}`),
+  )
+  const baynContainers = containers.filter((container) => container.name === 'bayn')
+  if (baynContainers.length !== 1) throw new Error('deployment must contain exactly one Bayn container')
+  const environment = expectArray(baynContainers[0]?.env, 'Bayn environment').map((value, index) =>
+    expectRecord(value, `Bayn environment entry ${index}`),
+  )
+  const optionalEnvironmentValue = (name: string): string | null => {
+    const matches = environment.filter((entry) => entry.name === name)
+    if (matches.length > 1) throw new Error(`deployment must not contain duplicate ${name} values`)
+    if (matches.length === 0) return null
+    return expectString(matches[0]?.value, name)
+  }
+  const maximumAuthority = optionalEnvironmentValue('BAYN_MAXIMUM_AUTHORITY')
+  const brokerAccess = optionalEnvironmentValue('BAYN_BROKER_ACCESS')
+  const capitalAuthority = optionalEnvironmentValue('BAYN_CAPITAL_AUTHORITY')
+  const authorityGenerationHash = optionalEnvironmentValue('BAYN_AUTHORITY_GENERATION_HASH')
+  if (maximumAuthority !== 'OBSERVE' && maximumAuthority !== 'PAPER' && maximumAuthority !== 'LIVE')
+    throw new Error('deployment maximum authority is invalid')
+  if (brokerAccess !== null && brokerAccess !== 'read-only' && brokerAccess !== 'mutation')
+    throw new Error('deployment broker access is invalid')
+  if (
+    capitalAuthority !== null &&
+    capitalAuthority !== 'none' &&
+    capitalAuthority !== 'sandbox-capital' &&
+    capitalAuthority !== 'live-capital-grant'
+  )
+    throw new Error('deployment capital authority is invalid')
+  if (authorityGenerationHash === null || !isHash(authorityGenerationHash))
+    throw new Error('deployment authority generation hash is invalid')
+  if (maximumAuthority === 'PAPER' && (brokerAccess !== 'mutation' || capitalAuthority !== 'sandbox-capital'))
+    throw new Error('PAPER deployment capability is incoherent')
+  if (
+    maximumAuthority === 'OBSERVE' &&
+    ((brokerAccess !== null && brokerAccess !== 'read-only') ||
+      (capitalAuthority !== null && capitalAuthority !== 'none'))
+  )
+    throw new Error('OBSERVE deployment capability is incoherent')
+  return { maximumAuthority, brokerAccess, capitalAuthority, authorityGenerationHash }
+}
+
+const replaceExactlyOnce = (source: string, expected: string, replacement: string, label: string): string => {
+  if (source.split(expected).length !== 2) throw new Error(`${label} is missing or ambiguous`)
+  return source.replace(expected, replacement)
+}
+
+const capabilityBlock = (brokerAccess: 'read-only' | 'mutation', capitalAuthority: 'none' | 'sandbox-capital') =>
+  `            - name: BAYN_BROKER_ACCESS\n              value: ${brokerAccess}\n            - name: BAYN_CAPITAL_AUTHORITY\n              value: ${capitalAuthority}\n`
+
+const paperAuthorityExpiryMarker = '            - name: BAYN_PAPER_AUTHORITY_EXPIRES_AT\n              value: '
+const imagePullPolicyMarker = '          imagePullPolicy: IfNotPresent\n'
+const paperAuthorityGuardScript = [
+  'const { spawn } = require("node:child_process");',
+  'const deadline = Date.parse(process.env.BAYN_PAPER_AUTHORITY_EXPIRES_AT ?? "");',
+  'if (!Number.isFinite(deadline) || deadline <= Date.now()) process.exit(78);',
+  'let expired = false;',
+  'const child = spawn(process.execPath, ["dist/index.js"], { stdio: "inherit" });',
+  'const expiryTimer = setTimeout(() => { expired = true; child.kill("SIGKILL"); }, Math.max(0, deadline - Date.now()));',
+  'const forwardedSignals = new Map();',
+  'for (const signal of ["SIGTERM", "SIGINT"]) { const handler = () => child.kill(signal); forwardedSignals.set(signal, handler); process.on(signal, handler); }',
+  'child.on("error", () => process.exit(70));',
+  'child.on("exit", (code, signal) => { clearTimeout(expiryTimer); if (expired) process.exit(78); if (signal) { const handler = forwardedSignals.get(signal); if (handler) process.off(signal, handler); process.kill(process.pid, signal); return; } process.exit(code ?? 1); });',
+].join('\n')
+const paperAuthorityProcessGuard = `          command:\n            - node\n          args:\n            - -e\n            - |\n${paperAuthorityGuardScript
+  .split('\n')
+  .map((line) => `              ${line}`)
+  .join('\n')}\n`
+
+const paperAuthorityExpiryBlock = (authorityExpiresAt: string): string => {
+  if (!Number.isFinite(Date.parse(authorityExpiresAt)) || authorityExpiresAt.includes('\n'))
+    throw new Error('authority expiry is malformed')
+  return `${paperAuthorityExpiryMarker}${JSON.stringify(authorityExpiresAt)}\n`
+}
+
+const removePaperAuthorityDeadline = (paperDeployment: string): string => {
+  const expiryStart = paperDeployment.indexOf(paperAuthorityExpiryMarker)
+  const guardStart = paperDeployment.indexOf(paperAuthorityProcessGuard)
+  if (expiryStart < 0 !== guardStart < 0) throw new Error('PAPER authority deadline guard is incomplete')
+  if (expiryStart < 0) return paperDeployment
+  if (
+    paperDeployment.indexOf(paperAuthorityExpiryMarker, expiryStart + 1) >= 0 ||
+    paperDeployment.indexOf(paperAuthorityProcessGuard, guardStart + 1) >= 0
+  )
+    throw new Error('PAPER authority deadline guard is ambiguous')
+  const expiryEnd = paperDeployment.indexOf('\n', expiryStart + paperAuthorityExpiryMarker.length)
+  if (expiryEnd < 0) throw new Error('PAPER authority expiry value is unterminated')
+  return paperDeployment
+    .slice(0, expiryStart)
+    .concat(paperDeployment.slice(expiryEnd + 1))
+    .replace(paperAuthorityProcessGuard, '')
+}
+
+export const renderPaperActivationTransition = (
+  sourceDeployment: string,
+  authorityGenerationHash: string,
+  observeRollbackGenerationHash: string,
+  authorityExpiresAt: string,
+): PaperActivationTransition => {
+  if (!isHash(authorityGenerationHash)) throw new Error('authority generation hash is malformed')
+  if (!isHash(observeRollbackGenerationHash)) throw new Error('OBSERVE rollback generation hash is malformed')
+  if (observeRollbackGenerationHash === authorityGenerationHash)
+    throw new Error('OBSERVE rollback generation must differ from PAPER generation')
+  if (sourceDeployment.includes('            - name: BAYN_BROKER_ACCESS\n'))
+    throw new Error('source deployment already contains explicit broker access')
+  if (sourceDeployment.includes('            - name: BAYN_CAPITAL_AUTHORITY\n'))
+    throw new Error('source deployment already contains explicit capital authority')
+  if (!sourceDeployment.includes('            - name: BAYN_BROKER_ENVIRONMENT\n              value: sandbox\n'))
+    throw new Error('source deployment is not bound to the sandbox broker environment')
+  if (
+    !sourceDeployment.includes(
+      '            - name: BAYN_ALPACA_BASE_URL\n              value: https://paper-api.alpaca.markets\n',
+    )
+  )
+    throw new Error('source deployment is not bound to the canonical Alpaca paper endpoint')
+
+  const maximumObserve = '            - name: BAYN_MAXIMUM_AUTHORITY\n              value: OBSERVE\n'
+  const maximumPaper = '            - name: BAYN_MAXIMUM_AUTHORITY\n              value: PAPER\n'
+  const authorityMarker = '            - name: BAYN_AUTHORITY_GENERATION_HASH\n              value: "'
+  const markerStart = sourceDeployment.indexOf(authorityMarker)
+  if (markerStart < 0 || sourceDeployment.indexOf(authorityMarker, markerStart + 1) >= 0)
+    throw new Error('authority generation field is missing or ambiguous')
+  const valueStart = markerStart + authorityMarker.length
+  const valueEnd = sourceDeployment.indexOf('"', valueStart)
+  if (valueEnd < 0) throw new Error('authority generation value is unterminated')
+  const previousAuthorityGenerationHash = sourceDeployment.slice(valueStart, valueEnd)
+  if (!isHash(previousAuthorityGenerationHash)) throw new Error('source authority generation hash is malformed')
+  if (observeRollbackGenerationHash === previousAuthorityGenerationHash)
+    throw new Error('OBSERVE rollback generation must be fresh')
+
+  let observeDeployment = replaceExactlyOnce(
+    sourceDeployment,
+    maximumObserve,
+    maximumObserve + capabilityBlock('read-only', 'none'),
+    'OBSERVE authority field',
+  )
+  const observeMarkerStart = observeDeployment.indexOf(authorityMarker)
+  const observeValueStart = observeMarkerStart + authorityMarker.length
+  const observeValueEnd = observeDeployment.indexOf('"', observeValueStart)
+  observeDeployment = `${observeDeployment.slice(0, observeValueStart)}${observeRollbackGenerationHash}${observeDeployment.slice(observeValueEnd)}`
+  let paperDeployment = replaceExactlyOnce(
+    sourceDeployment,
+    maximumObserve,
+    maximumPaper + capabilityBlock('mutation', 'sandbox-capital') + paperAuthorityExpiryBlock(authorityExpiresAt),
+    'OBSERVE authority field',
+  )
+  paperDeployment = replaceExactlyOnce(
+    paperDeployment,
+    imagePullPolicyMarker,
+    imagePullPolicyMarker + paperAuthorityProcessGuard,
+    'Bayn image pull policy field',
+  )
+  const paperMarkerStart = paperDeployment.indexOf(authorityMarker)
+  const paperValueStart = paperMarkerStart + authorityMarker.length
+  const paperValueEnd = paperDeployment.indexOf('"', paperValueStart)
+  paperDeployment = `${paperDeployment.slice(0, paperValueStart)}${authorityGenerationHash}${paperDeployment.slice(paperValueEnd)}`
+  return { paperDeployment, observeDeployment }
+}
+
+export const renderObserveRollback = (paperDeployment: string, observeAuthorityGenerationHash: string): string => {
+  if (!isHash(observeAuthorityGenerationHash)) throw new Error('OBSERVE authority generation hash is malformed')
+  let observeDeployment = replaceExactlyOnce(
+    removePaperAuthorityDeadline(paperDeployment),
+    '            - name: BAYN_MAXIMUM_AUTHORITY\n              value: PAPER\n',
+    '            - name: BAYN_MAXIMUM_AUTHORITY\n              value: OBSERVE\n',
+    'PAPER authority field',
+  )
+  observeDeployment = replaceExactlyOnce(
+    observeDeployment,
+    '            - name: BAYN_BROKER_ACCESS\n              value: mutation\n',
+    '            - name: BAYN_BROKER_ACCESS\n              value: read-only\n',
+    'mutation broker access field',
+  )
+  observeDeployment = replaceExactlyOnce(
+    observeDeployment,
+    '            - name: BAYN_CAPITAL_AUTHORITY\n              value: sandbox-capital\n',
+    '            - name: BAYN_CAPITAL_AUTHORITY\n              value: none\n',
+    'sandbox capital authority field',
+  )
+  const authorityMarker = '            - name: BAYN_AUTHORITY_GENERATION_HASH\n              value: "'
+  const markerStart = observeDeployment.indexOf(authorityMarker)
+  if (markerStart < 0 || observeDeployment.indexOf(authorityMarker, markerStart + 1) >= 0)
+    throw new Error('authority generation field is missing or ambiguous')
+  const valueStart = markerStart + authorityMarker.length
+  const valueEnd = observeDeployment.indexOf('"', valueStart)
+  if (valueEnd < 0) throw new Error('authority generation value is unterminated')
+  return `${observeDeployment.slice(0, valueStart)}${observeAuthorityGenerationHash}${observeDeployment.slice(valueEnd)}`
+}
+
+const paperAuthorityGenerationIdentity = (
+  generation: PaperAuthorityGenerationMaterial | PaperAuthorityGeneration,
+): Omit<PaperAuthorityGenerationMaterial, 'reconciliationId' | 'reconciliationContentHash'> => {
+  const {
+    generationHash: _generationHash,
+    reconciliationContentHash: _reconciliationContentHash,
+    reconciliationId: _reconciliationId,
+    ...identity
+  } = generation as PaperAuthorityGeneration
+  return identity
+}
+
+export const paperAuthorityGenerationHash = (
+  generation: PaperAuthorityGenerationMaterial | PaperAuthorityGeneration,
+): string => canonicalHashV1(paperAuthorityGenerationIdentity(generation))
+
+export const deriveObserveRollbackGeneration = (input: {
+  readonly repository: string
+  readonly activationId: string
+  readonly sourceMainSha: string
+  readonly previousObserveGenerationHash: string
+  readonly paperAuthorityGenerationHash: string
+}): ObserveRollbackGeneration => {
+  if (input.repository.length === 0 || input.activationId.length === 0)
+    throw new Error('rollback generation repository and activation id are required')
+  if (!isSha(input.sourceMainSha)) throw new Error('rollback generation source main SHA is malformed')
+  if (!isHash(input.previousObserveGenerationHash) || !isHash(input.paperAuthorityGenerationHash))
+    throw new Error('rollback generation authority hash is malformed')
+  const identity = {
+    schemaVersion: 'bayn.observe-authority-rollback.v1' as const,
+    repository: input.repository,
+    activationId: input.activationId,
+    sourceMainSha: input.sourceMainSha,
+    previousObserveGenerationHash: input.previousObserveGenerationHash,
+    paperAuthorityGenerationHash: input.paperAuthorityGenerationHash,
+  }
+  const generationHash = canonicalHashV1(identity)
+  if (generationHash === input.previousObserveGenerationHash || generationHash === input.paperAuthorityGenerationHash)
+    throw new Error('rollback generation is not fresh')
+  return { ...identity, generationHash }
+}
+
+export const evaluatePaperActivation = (input: {
+  readonly evidence: unknown
+  readonly pins: unknown
+  readonly manifestPins: unknown
+  readonly now: string
+  readonly expectedRepository: string
+  readonly expectedActivationId: string
+  readonly trustedCurrentMainSha: string
+}): PaperActivationDecision => {
+  const evidence = requireEvidence(input.evidence)
+  if (evidence === null) return hold('invalid-evidence', 'activation evidence must contain the complete exact schema')
+  const pins = requirePins(input.pins, pinKeys)
+  if (pins === null) return hold('invalid-pins', 'reviewed pins must contain the complete exact schema')
+  const manifestPins = requirePins(input.manifestPins, manifestPinKeys)
+  if (manifestPins === null)
+    return hold('invalid-manifest-pins', 'manifest pins must contain the complete exact schema')
+  if (evidence.schemaVersion !== 1) return hold('unsupported-schema', 'activation evidence schema is unsupported')
+  if (evidence.repository !== input.expectedRepository)
+    return hold('repository-mismatch', 'evidence belongs to another repository')
+  if (evidence.activationId !== input.expectedActivationId)
+    return hold('activation-id-mismatch', 'activation id does not match the precommit')
+  if (
+    !isSha(input.trustedCurrentMainSha) ||
+    !isSha(evidence.mainSha) ||
+    evidence.mainSha !== evidence.currentMainSha ||
+    evidence.mainSha !== input.trustedCurrentMainSha
+  )
+    return hold('noncurrent-main', 'activation source is not exact current main')
+  if (!isSha(evidence.sourceSha) || !isDigest(evidence.imageDigest))
+    return hold('invalid-source-pin', 'source or image digest pin is malformed')
+  for (const [name, value] of Object.entries({
+    protocolHash: evidence.protocolHash,
+    strategyBehaviorHash: evidence.strategyBehaviorHash,
+    strategyParameterHash: evidence.strategyParameterHash,
+    qualificationRunId: evidence.qualificationRunId,
+    accountBindingHash: evidence.accountBindingHash,
+  })) {
+    if (!isHash(value)) return hold('invalid-hash', `${name} is malformed`)
+  }
+  for (const key of pinKeys) {
+    if (evidence[key] !== pins[key]) return hold('pin-mismatch', `${key} does not match the reviewed manifest pin`)
+  }
+  for (const key of ['sourceSha', 'strategyBehaviorHash', 'strategyParameterHash', 'qualificationRunId'] as const) {
+    if (evidence[key] !== manifestPins[key])
+      return hold('manifest-pin-mismatch', `${key} does not match the checked-out deployment pin`)
+  }
+  if (
+    evidence.imageRepository !== manifestPins.deploymentImageRepository ||
+    evidence.imageRepository !== manifestPins.kustomizeImageRepository
+  )
+    return hold('manifest-pin-mismatch', 'image repository does not match deployment and Kustomize')
+  if (
+    evidence.imageDigest !== manifestPins.deploymentImageDigest ||
+    evidence.imageDigest !== manifestPins.kustomizeImageDigest
+  )
+    return hold('manifest-pin-mismatch', 'image digest does not match deployment and Kustomize')
+  if (manifestPins.kustomizeImageTag !== `sha-${evidence.sourceSha}`)
+    return hold('manifest-pin-mismatch', 'Kustomize image tag does not match the exact source SHA')
+  if (!isHash(manifestPins.currentAuthorityGenerationHash))
+    return hold('manifest-pin-mismatch', 'current OBSERVE authority generation is malformed')
+  if (evidence.qualificationDecision !== 'QUALIFIED')
+    return hold('qualification-not-qualified', 'qualification is not QUALIFIED')
+  const now = Date.parse(input.now)
+  const observed = Date.parse(evidence.qualificationObservedAt)
+  const qualificationExpiry = Date.parse(evidence.qualificationExpiresAt)
+  const authorityExpiry = Date.parse(evidence.authorityExpiresAt)
+  if (![now, observed, qualificationExpiry, authorityExpiry].every(Number.isFinite))
+    return hold('invalid-time', 'activation evidence contains an invalid timestamp')
+  if (observed > now || qualificationExpiry <= now)
+    return hold('qualification-stale', 'qualification evidence is future-dated or expired')
+  if (authorityExpiry <= now) return hold('authority-expired', 'paper authority is expired')
+  if (authorityExpiry > qualificationExpiry)
+    return hold('authority-outlives-qualification', 'paper authority expires after its qualification evidence')
+  if (authorityExpiry - now > maximumAuthorityDurationMs)
+    return hold('authority-window-too-long', 'paper authority exceeds the bounded 90-minute window')
+  if (evidence.brokerEnvironment !== 'sandbox' || evidence.maximumAuthority !== 'PAPER')
+    return hold('not-paper-only', 'authority is not sandbox PAPER')
+  if (evidence.brokerBaseUrl !== 'https://paper-api.alpaca.markets')
+    return hold('live-money-endpoint', 'broker endpoint is not the canonical Alpaca paper endpoint')
+  if (evidence.activationState !== 'PRECOMMITTED')
+    return hold('activation-not-precommitted', 'activation is duplicate, in flight, consumed, or cancelled')
+  const generation = evidence.authorityGeneration
+  if (generation.generationHash !== paperAuthorityGenerationHash(generation))
+    return hold('authority-generation-mismatch', 'authority generation hash is not Bayn canonical v2 identity')
+  if (
+    generation.previousGenerationHash !== manifestPins.currentAuthorityGenerationHash ||
+    generation.qualificationRunId !== evidence.qualificationRunId ||
+    generation.protocolHash !== evidence.protocolHash ||
+    generation.activationSourceRevision !== evidence.sourceSha ||
+    generation.activationImageRepository !== evidence.imageRepository ||
+    generation.activationImageDigest !== evidence.imageDigest ||
+    generation.strategyBehaviorHash !== evidence.strategyBehaviorHash ||
+    generation.strategyParameterHash !== evidence.strategyParameterHash
+  )
+    return hold(
+      'authority-generation-binding-mismatch',
+      'canonical authority generation does not match the reviewed runtime and current OBSERVE generation',
+    )
+  if (
+    evidence.unresolvedMutationCount !== 0 ||
+    evidence.unknownMutationCount !== 0 ||
+    evidence.openOrderCount !== 0 ||
+    evidence.discrepancyCount !== 0
+  )
+    return hold('unsafe-runtime-state', 'mutations, orders, or discrepancies remain unresolved')
+  if (evidence.reconciliation !== 'EXACT') return hold('reconciliation-not-exact', 'broker reconciliation is not exact')
+  if (evidence.killSwitchActive !== false) return hold('kill-switch-active', 'kill switch is active')
+  if (evidence.identityGap !== false) return hold('identity-gap', 'broker identity evidence is incomplete')
+  return {
+    status: 'eligible',
+    activationId: evidence.activationId,
+    authorityGenerationHash: generation.generationHash,
+  }
+}
+
+const parseArguments = (arguments_: readonly string[]): Record<string, string> => {
+  const result: Record<string, string> = {}
+  for (let index = 0; index < arguments_.length; index += 2) {
+    const key = arguments_[index]
+    const value = arguments_[index + 1]
+    if (key === undefined || value === undefined || !key.startsWith('--'))
+      throw new Error('arguments must be --key value pairs')
+    result[key.slice(2)] = value
+  }
+  return result
+}
+
+if (import.meta.main) {
+  try {
+    const args = parseArguments(process.argv.slice(2))
+    if (args.mode === 'extract-manifest-pins') {
+      const manifestPins = extractPaperActivationManifestPins(
+        readFileSync(args.deployment ?? '', 'utf8'),
+        readFileSync(args.kustomization ?? '', 'utf8'),
+      )
+      writeFileSync(args.output ?? '', `${JSON.stringify(manifestPins, null, 2)}\n`)
+      console.log('BAYN_PAPER_ACTIVATION_MANIFEST_PINS_EXTRACTED')
+      process.exit(0)
+    }
+    if (args.mode === 'inspect-deployment-authority') {
+      const authority = extractDeploymentAuthorityState(readFileSync(args.deployment ?? '', 'utf8'))
+      writeFileSync(args.output ?? '', `${JSON.stringify(authority, null, 2)}\n`)
+      console.log(`BAYN_PAPER_ACTIVATION_DEPLOYMENT_AUTHORITY ${authority.maximumAuthority}`)
+      process.exit(0)
+    }
+    if (args.mode === 'render-transition') {
+      const rendered = renderPaperActivationTransition(
+        readFileSync(args.deployment ?? '', 'utf8'),
+        args['authority-generation-hash'] ?? '',
+        args['observe-authority-generation-hash'] ?? '',
+        args['authority-expires-at'] ?? '',
+      )
+      writeFileSync(args['paper-output'] ?? '', rendered.paperDeployment)
+      writeFileSync(args['observe-output'] ?? '', rendered.observeDeployment)
+      console.log('BAYN_PAPER_ACTIVATION_TRANSITION_RENDERED')
+      process.exit(0)
+    }
+    if (args.mode === 'derive-observe-rollback') {
+      const generation = deriveObserveRollbackGeneration({
+        repository: args.repository ?? '',
+        activationId: args['activation-id'] ?? '',
+        sourceMainSha: args['source-main-sha'] ?? '',
+        previousObserveGenerationHash: args['previous-observe-generation-hash'] ?? '',
+        paperAuthorityGenerationHash: args['paper-authority-generation-hash'] ?? '',
+      })
+      writeFileSync(args.output ?? '', `${JSON.stringify(generation, null, 2)}\n`)
+      console.log(`BAYN_PAPER_ACTIVATION_OBSERVE_ROLLBACK_GENERATION ${generation.generationHash}`)
+      process.exit(0)
+    }
+    if (args.mode === 'render-rollback') {
+      writeFileSync(
+        args.output ?? '',
+        renderObserveRollback(
+          readFileSync(args.deployment ?? '', 'utf8'),
+          args['observe-authority-generation-hash'] ?? '',
+        ),
+      )
+      console.log('BAYN_PAPER_ACTIVATION_ROLLBACK_RENDERED')
+      process.exit(0)
+    }
+    const evidence = JSON.parse(readFileSync(args.evidence ?? '', 'utf8')) as unknown
+    const pins = JSON.parse(readFileSync(args.pins ?? '', 'utf8')) as unknown
+    const manifestPins = JSON.parse(readFileSync(args['manifest-pins'] ?? '', 'utf8')) as unknown
+    const decision = evaluatePaperActivation({
+      evidence,
+      pins,
+      now: args.now ?? new Date().toISOString(),
+      expectedRepository: args.repository ?? '',
+      expectedActivationId: args['activation-id'] ?? '',
+      trustedCurrentMainSha: args['current-main-sha'] ?? '',
+      manifestPins,
+    })
+    if (decision.status === 'hold') {
+      console.error(`BAYN_PAPER_ACTIVATION_HOLD ${decision.code}: ${decision.message}`)
+      process.exitCode = 1
+    } else {
+      console.log(
+        `BAYN_PAPER_ACTIVATION_ELIGIBLE activation=${decision.activationId} authority_generation_hash=${decision.authorityGenerationHash}`,
+      )
+    }
+  } catch (error) {
+    console.error(
+      `BAYN_PAPER_ACTIVATION_HOLD verifier-error: ${error instanceof Error ? error.message : 'unknown error'}`,
+    )
+    process.exitCode = 1
+  }
+}


### PR DESCRIPTION
## Summary
- run only from GitHub default-branch-loaded `workflow_run` and `schedule` events; no branch-selectable privileged trigger
- remain dormant when the completed scheduled qualification run has no exact activation artifact
- authenticate exact current-main qualification evidence before any GitOps secret is exposed
- verify canonical PAPER authority generation, current deployment/image pins, qualification lifetime, sandbox-only capability, and zero unresolved mutation state
- create both generated GitOps pull requests as drafts and persist the rollback watchdog attestation before activation can leave draft
- release only the exact activation draft after durable attestation upload and exact pre/post-ready head/base/state validation
- return any activation that drifts during ready transition to an open, unmerged draft before failing closed
- precommit and authenticate a fresh OBSERVE rollback before activation can merge
- bind every retained attestation artifact to its own producer run before archive access
- enforce hard PAPER process expiry while preserving graceful termination signals
- fully paginate protected checks, review threads, and retained attestation discovery
- reconstruct deleted rollback state and recover authenticated foreign-base activation only when current main proves the exact PAPER generation

## Safety
- no committed Bayn manifest, broker/runtime, credential, permission, ruleset, RBAC, NetworkPolicy, environment, or security-policy changes
- no workflow dispatch, PAPER/capital activation, broker mutation, or order performed
- default event token remains read-only; existing GitOps token is used only inside trusted default-branch runs after evidence authentication

## Exact scope
- `.github/workflows/bayn-paper-activation.yml`
- `packages/scripts/src/bayn/bayn-paper-activation-workflow.test.ts`
- `packages/scripts/src/bayn/verify-paper-activation.test.ts`
- `packages/scripts/src/bayn/verify-paper-activation.ts`

## Validation on exact main `b546df44616a28629a816c982c1b6f766de41902`
- focused verifier/workflow tests: 80 pass, 0 fail
- full Bayn scripts cohort: 303 pass, 0 fail
- Oxfmt: pass
- owned-file TypeScript and Oxlint: clean
- scripts Oxlint: 0 errors; 3 unrelated existing warnings
- workflow YAML parse: pass
- all 19 embedded workflow shell programs: `bash -n` pass
- default-branch trigger adversarial checks: pass; no branch-selectable privileged trigger
- Bayn TypeScript and Effect diagnostics: clean across 451 files
- full Bayn test suite: 1,119 pass, 138 PostgreSQL-gated local skips, 0 fail
- Bayn production build: pass

## Attestation ordering regressions
- upload failure or cancellation leaves both generated PRs draft and performs no activation ready transition
- normal durable-attestation path marks only the exact activation ready
- post-ready head replacement is returned to draft and fails closed

## PostgreSQL
The natural exact-head hosted `postgres-integration` job is required before merge; no manual rerun or workflow dispatch is used.

Linear: PROOMPT-405
