### PR TITLE
feat(bayn): add bounded PAPER broker proof command

### DIFF
--- a/services/bayn/src/paper-proof-command.ts
+++ b/services/bayn/src/paper-proof-command.ts
@@ -1,0 +1,46 @@
+import { NodeRuntime } from '@effect/platform-node'
+import { Effect, Result } from 'effect'
+
+import {
+  decodePaperProofCliEnvelopeResult,
+  PaperProofError,
+  runPaperProof,
+  type PaperProofCliEnvelope,
+  type PaperProofDependencies,
+  type PaperProofReceipt,
+} from './paper-proof'
+
+export const runPaperProofCommand = (
+  input: unknown,
+  dependencies: PaperProofDependencies,
+): Effect.Effect<PaperProofReceipt, PaperProofError> => {
+  const decoded = decodePaperProofCliEnvelopeResult(input)
+  if (Result.isFailure(decoded)) {
+    return Effect.fail(
+      new PaperProofError({
+        operation: 'GATE',
+        failure: 'contract',
+        message: 'paper proof command envelope is invalid',
+        cause: decoded.failure,
+      }),
+    )
+  }
+  const envelope: PaperProofCliEnvelope = decoded.success
+  return runPaperProof(envelope.command, {
+    ...dependencies,
+    protectedEntryToken: envelope.protectedEntryToken,
+  })
+}
+
+export const paperProofCommandEntryGate = Effect.fail(
+  new PaperProofError({
+    operation: 'GATE',
+    failure: 'gate-closed',
+    message:
+      'PAPER proof CLI is source-ready but intentionally disabled: no reviewed source plan and protected sandbox entry binding are pinned',
+  }),
+)
+
+if (import.meta.main) {
+  NodeRuntime.runMain(paperProofCommandEntryGate)
+}

--- a/services/bayn/src/paper-proof/gates.ts
+++ b/services/bayn/src/paper-proof/gates.ts
@@ -1,0 +1,79 @@
+import { Result } from 'effect'
+
+import { BrokerEnvironment, BrokerProvider } from '../broker/identity'
+import { BrokerAccess, CapitalAuthorityKind } from '../execution/authority'
+import type { PaperProofCommand, PaperProofRuntimeBinding, PaperProofSourcePlan } from './model'
+import { PaperProofError, protectedEntryToken } from './model'
+
+const mismatch = (message: string): Result.Result<never, PaperProofError> =>
+  Result.fail(
+    new PaperProofError({
+      operation: 'GATE',
+      failure: 'gate-closed',
+      message,
+    }),
+  )
+
+const sameStrategy = (left: PaperProofSourcePlan['strategy'], right: PaperProofRuntimeBinding['strategy']): boolean =>
+  left.name === right.name &&
+  left.behaviorHash === right.behaviorHash &&
+  left.parameterHash === right.parameterHash &&
+  left.parameterSchemaVersion === right.parameterSchemaVersion
+
+export const validatePaperProofEntry = (
+  command: PaperProofCommand,
+  source: PaperProofSourcePlan,
+  runtime: PaperProofRuntimeBinding,
+  entryToken: string,
+): Result.Result<void, PaperProofError> => {
+  if (source.qualificationResult !== 'QUALIFIED' || source.qualificationPinned !== true) {
+    return mismatch('paper proof requires a separately QUALIFIED and pinned strategy')
+  }
+  if (entryToken !== protectedEntryToken(source)) {
+    return mismatch('paper proof protected entry token does not match the source-controlled plan')
+  }
+  if (
+    command.proofPlanHash !== source.proofPlanHash ||
+    command.riskPolicyHash !== source.riskPolicyHash ||
+    command.qualificationRunId !== source.qualificationRunId
+  ) {
+    return mismatch('paper proof command does not match the pinned proof, policy, and qualification')
+  }
+  if (
+    command.sourceRevision !== source.sourceRevision ||
+    command.imageRepository !== source.imageRepository ||
+    command.imageDigest !== source.imageDigest
+  ) {
+    return mismatch('paper proof command build binding does not match the source-controlled plan')
+  }
+  if (
+    runtime.sourceRevision !== source.sourceRevision ||
+    runtime.imageRepository !== source.imageRepository ||
+    runtime.imageDigest !== source.imageDigest
+  ) {
+    return mismatch('paper proof runtime build does not match the source-controlled plan')
+  }
+  if (
+    source.brokerProvider !== BrokerProvider.Alpaca ||
+    source.brokerEnvironment !== BrokerEnvironment.Sandbox ||
+    runtime.brokerProvider !== BrokerProvider.Alpaca ||
+    runtime.brokerEnvironment !== BrokerEnvironment.Sandbox ||
+    runtime.accountId !== source.accountId
+  ) {
+    return mismatch('paper proof requires the pinned Alpaca sandbox account')
+  }
+  if (
+    runtime.authorityGenerationHash !== source.authorityGenerationHash ||
+    !sameStrategy(source.strategy, runtime.strategy)
+  ) {
+    return mismatch('paper proof authority generation or strategy identity does not match the source plan')
+  }
+  if (command.operation === 'PREPARE') {
+    return runtime.brokerAccess === BrokerAccess.ReadOnly && runtime.capitalAuthority === CapitalAuthorityKind.None
+      ? Result.succeed(undefined)
+      : mismatch('PREPARE requires read-only broker access and no capital authority')
+  }
+  return runtime.brokerAccess === BrokerAccess.Mutation && runtime.capitalAuthority === CapitalAuthorityKind.Sandbox
+    ? Result.succeed(undefined)
+    : mismatch('SUBMIT, CANCEL, and RECOVER require explicit sandbox mutation authority')
+}

--- a/services/bayn/src/paper-proof/index.ts
+++ b/services/bayn/src/paper-proof/index.ts
@@ -1,0 +1,22 @@
+export { validatePaperProofEntry } from './gates'
+export {
+  decodePaperProofCliEnvelopeResult,
+  decodePaperProofCommandResult,
+  PaperProofCliEnvelopeSchema,
+  PaperProofCommandSchema,
+  PaperProofError,
+  PaperProofOperationSchema,
+  paperProofCommandSchemaVersion,
+  paperProofReceiptSchemaVersion,
+  protectedEntryToken,
+  proofBinding,
+  type PaperProofCliEnvelope,
+  type PaperProofCommand,
+  type PaperProofOperation,
+  type PaperProofReceipt,
+  type PaperProofReconciliation,
+  type PaperProofRuntimeBinding,
+  type PaperProofSourcePlan,
+  type PreparedPaperProofIntent,
+} from './model'
+export { runPaperProof, type PaperProofDependencies } from './program'

--- a/services/bayn/src/paper-proof/model.ts
+++ b/services/bayn/src/paper-proof/model.ts
@@ -1,0 +1,145 @@
+import { Data, Schema } from 'effect'
+
+import { MutationOperation } from '../broker/alpaca-mutations'
+import { BrokerProvider } from '../broker/connection'
+import { BrokerEnvironment } from '../broker/identity'
+import { BrokerAccess, CapitalAuthorityKind, type ExecutionStrategyIdentity } from '../execution/authority'
+import type { CapitalGrantGeneration, CapitalGrantProofBinding } from '../execution/contracts'
+import type { MutationEvent } from '../execution/mutations'
+import {
+  GitSourceRevisionSchema,
+  ImageDigestSchema,
+  ImageRepositorySchema,
+  PositiveIntegerSchema,
+  Sha256Schema,
+  StrictNonEmptyStringSchema,
+  strictParseOptions,
+} from '../schemas'
+
+export const paperProofCommandSchemaVersion = 'bayn.paper-proof-command.v1' as const
+export const paperProofReceiptSchemaVersion = 'bayn.paper-proof-receipt.v1' as const
+
+export const PaperProofOperationSchema = Schema.Literals(['PREPARE', 'SUBMIT', 'CANCEL', 'RECOVER'])
+export type PaperProofOperation = typeof PaperProofOperationSchema.Type
+
+export const PaperProofCommandSchema = Schema.Struct({
+  schemaVersion: Schema.Literal(paperProofCommandSchemaVersion),
+  operation: PaperProofOperationSchema,
+  timeoutMs: PositiveIntegerSchema,
+  consistencyDelayMs: PositiveIntegerSchema,
+  proofPlanHash: Sha256Schema,
+  riskPolicyHash: Sha256Schema,
+  qualificationRunId: Sha256Schema,
+  sourceRevision: GitSourceRevisionSchema,
+  imageRepository: ImageRepositorySchema,
+  imageDigest: ImageDigestSchema,
+})
+export type PaperProofCommand = typeof PaperProofCommandSchema.Type
+
+export const decodePaperProofCommandResult = Schema.decodeUnknownResult(
+  PaperProofCommandSchema,
+  strictParseOptions,
+)
+
+export interface PaperProofSourcePlan {
+  readonly schemaVersion: 'bayn.paper-proof-plan.v1'
+  readonly proofPlanHash: string
+  readonly riskPolicyHash: string
+  readonly qualificationRunId: string
+  readonly qualificationResult: 'QUALIFIED'
+  readonly qualificationPinned: true
+  readonly sourceRevision: string
+  readonly imageRepository: string
+  readonly imageDigest: string
+  readonly brokerProvider: BrokerProvider.Alpaca
+  readonly brokerEnvironment: BrokerEnvironment.Sandbox
+  readonly accountId: string
+  readonly authorityGenerationHash: string
+  readonly strategy: ExecutionStrategyIdentity
+  readonly intentId: string
+}
+
+export interface PaperProofRuntimeBinding {
+  readonly sourceRevision: string
+  readonly imageRepository: string
+  readonly imageDigest: string
+  readonly brokerProvider: BrokerProvider
+  readonly brokerEnvironment: BrokerEnvironment
+  readonly accountId: string
+  readonly authorityGenerationHash: string
+  readonly brokerAccess: BrokerAccess
+  readonly capitalAuthority: CapitalAuthorityKind
+  readonly strategy: ExecutionStrategyIdentity
+}
+
+export interface PaperProofReconciliation {
+  readonly reconciliationId: string
+  readonly contentHash: string
+  readonly accountId: string
+  readonly status: 'EXACT' | 'DISCREPANCY'
+  readonly unknownMutationCount: number
+  readonly reconciledAt: string
+}
+
+export interface PreparedPaperProofIntent {
+  readonly intentId: string
+  readonly clientOrderId: string
+  readonly deduplicated: boolean
+}
+
+export interface PaperProofReceipt {
+  readonly schemaVersion: typeof paperProofReceiptSchemaVersion
+  readonly operation: PaperProofOperation
+  readonly proofPlanHash: string
+  readonly qualificationRunId: string
+  readonly intentId: string
+  readonly clientOrderId?: string
+  readonly generation?: CapitalGrantGeneration
+  readonly mutation?: MutationEvent
+  readonly reconciliations: readonly PaperProofReconciliation[]
+  readonly restricted: boolean
+  readonly completedAt: string
+}
+
+export class PaperProofError extends Data.TaggedError('PaperProofError')<{
+  readonly operation: PaperProofOperation | 'GATE' | 'RECONCILE' | 'RESTRICT' | 'TIMEOUT'
+  readonly failure:
+    | 'contract'
+    | 'gate-closed'
+    | 'invariant'
+    | 'mutation-unresolved'
+    | 'operational'
+    | 'timeout'
+  readonly message: string
+  readonly cause?: unknown
+}> {}
+
+export const proofBinding = (command: PaperProofCommand): CapitalGrantProofBinding => ({
+  schemaVersion: 'bayn.paper-authority-proof-binding.v1',
+  proofPlanHash: command.proofPlanHash,
+  riskPolicyHash: command.riskPolicyHash,
+})
+
+export const recoveryOperation = (operation: PaperProofOperation): MutationOperation | undefined => {
+  switch (operation) {
+    case 'RECOVER':
+      return MutationOperation.Submit
+    case 'PREPARE':
+    case 'SUBMIT':
+    case 'CANCEL':
+      return undefined
+  }
+}
+
+export const protectedEntryToken = (plan: PaperProofSourcePlan): string =>
+  [plan.proofPlanHash, plan.qualificationRunId, plan.authorityGenerationHash, plan.intentId].join(':')
+
+export const PaperProofCliEnvelopeSchema = Schema.Struct({
+  command: PaperProofCommandSchema,
+  protectedEntryToken: StrictNonEmptyStringSchema,
+})
+export type PaperProofCliEnvelope = typeof PaperProofCliEnvelopeSchema.Type
+export const decodePaperProofCliEnvelopeResult = Schema.decodeUnknownResult(
+  PaperProofCliEnvelopeSchema,
+  strictParseOptions,
+)

--- a/services/bayn/src/paper-proof/program.test.ts
+++ b/services/bayn/src/paper-proof/program.test.ts
@@ -1,0 +1,343 @@
+import { describe, expect, test } from 'bun:test'
+
+import { Effect, Exit } from 'effect'
+
+import { MutationOperation } from '../broker/alpaca-mutations'
+import { BrokerEnvironment, BrokerProvider } from '../broker/identity'
+import { BrokerAccess, CapitalAuthorityKind } from '../execution/authority'
+import { MutationEventType, type MutationEvent } from '../execution/mutations'
+import {
+  protectedEntryToken,
+  runPaperProof,
+  type PaperProofCommand,
+  type PaperProofDependencies,
+  type PaperProofRuntimeBinding,
+  type PaperProofSourcePlan,
+} from './index'
+
+const hash = (character: string) => character.repeat(64)
+const accountId = 'paper-account'
+const intentId = hash('a')
+const strategy = {
+  name: 'risk-balanced-trend',
+  behaviorHash: hash('b'),
+  parameterHash: hash('c'),
+  parameterSchemaVersion: 'bayn.risk-balanced-trend.protocol.v4',
+} as const
+
+const sourcePlan: PaperProofSourcePlan = {
+  schemaVersion: 'bayn.paper-proof-plan.v1',
+  proofPlanHash: hash('d'),
+  riskPolicyHash: hash('e'),
+  qualificationRunId: hash('f'),
+  qualificationResult: 'QUALIFIED',
+  qualificationPinned: true,
+  sourceRevision: hash('1'),
+  imageRepository: 'ghcr.io/proompteng/bayn',
+  imageDigest: `sha256:${hash('2')}`,
+  brokerProvider: BrokerProvider.Alpaca,
+  brokerEnvironment: BrokerEnvironment.Sandbox,
+  accountId,
+  authorityGenerationHash: hash('3'),
+  strategy,
+  intentId,
+}
+
+const runtime = (mutation: boolean): PaperProofRuntimeBinding => ({
+  sourceRevision: sourcePlan.sourceRevision,
+  imageRepository: sourcePlan.imageRepository,
+  imageDigest: sourcePlan.imageDigest,
+  brokerProvider: BrokerProvider.Alpaca,
+  brokerEnvironment: BrokerEnvironment.Sandbox,
+  accountId,
+  authorityGenerationHash: sourcePlan.authorityGenerationHash,
+  brokerAccess: mutation ? BrokerAccess.Mutation : BrokerAccess.ReadOnly,
+  capitalAuthority: mutation ? CapitalAuthorityKind.Sandbox : CapitalAuthorityKind.None,
+  strategy,
+})
+
+const command = (operation: PaperProofCommand['operation']): PaperProofCommand => ({
+  schemaVersion: 'bayn.paper-proof-command.v1',
+  operation,
+  timeoutMs: 1_000,
+  consistencyDelayMs: 1,
+  proofPlanHash: sourcePlan.proofPlanHash,
+  riskPolicyHash: sourcePlan.riskPolicyHash,
+  qualificationRunId: sourcePlan.qualificationRunId,
+  sourceRevision: sourcePlan.sourceRevision,
+  imageRepository: sourcePlan.imageRepository,
+  imageDigest: sourcePlan.imageDigest,
+})
+
+const event = (eventType: MutationEventType, operation = MutationOperation.Submit): MutationEvent => ({
+  schemaVersion: 'bayn.paper-mutation-event.v1',
+  eventId: hash(eventType === MutationEventType.SubmitAccepted ? '4' : '5'),
+  mutationId: hash('6'),
+  intentId,
+  sequence: 1,
+  operation,
+  eventType,
+  requestHash: hash('7'),
+  consistencyDelayMs: 1,
+  ...(eventType === MutationEventType.SubmitAccepted ||
+  eventType === MutationEventType.CancelAccepted ||
+  eventType === MutationEventType.RecoveryFound
+    ? { brokerOrderId: 'broker-order' }
+    : {}),
+  occurredAt: '2026-07-31T08:00:00.000Z',
+})
+
+const generation = {
+  schemaVersion: 'bayn.paper-authority-generation.v2',
+  maximum: 'PAPER',
+  previousGenerationHash: hash('8'),
+  qualificationRunId: sourcePlan.qualificationRunId,
+  qualificationLockId: hash('9'),
+  qualificationResultHash: hash('a'),
+  protocolHash: hash('b'),
+  qualificationExecutionPolicyHash: hash('c'),
+  qualificationSourceRevision: sourcePlan.sourceRevision,
+  qualificationImageRepository: sourcePlan.imageRepository,
+  qualificationImageDigest: sourcePlan.imageDigest,
+  activationSourceRevision: sourcePlan.sourceRevision,
+  activationImageRepository: sourcePlan.imageRepository,
+  activationImageDigest: sourcePlan.imageDigest,
+  strategyName: 'risk-balanced-trend',
+  strategyBehaviorHash: strategy.behaviorHash,
+  strategyParameterHash: strategy.parameterHash,
+  strategyParameterSchemaVersion: strategy.parameterSchemaVersion,
+  accountId,
+  riskPolicyHash: sourcePlan.riskPolicyHash,
+  proofPlanHash: sourcePlan.proofPlanHash,
+  reconciliationId: hash('d'),
+  reconciliationContentHash: hash('e'),
+  generationHash: sourcePlan.authorityGenerationHash,
+} as const
+
+interface FixtureOptions {
+  readonly operation: PaperProofCommand['operation']
+  readonly latestSubmit?: MutationEvent
+  readonly latestCancel?: MutationEvent
+  readonly submitEvent?: MutationEvent
+  readonly cancelEvent?: MutationEvent
+  readonly recoverEvent?: MutationEvent
+  readonly reconciliationUnknownCounts?: readonly number[]
+  readonly neverReconcileAt?: number
+}
+
+const fixture = (options: FixtureOptions) => {
+  const sequence: string[] = []
+  const calls = { prepare: 0, activate: 0, submit: 0, cancel: 0, recover: 0, restrict: 0, reconcile: 0 }
+  const dependencies: PaperProofDependencies = {
+    sourcePlan,
+    runtime: runtime(options.operation !== 'PREPARE'),
+    protectedEntryToken: protectedEntryToken(sourcePlan),
+    prepareCapitalGrant: () => {
+      calls.prepare += 1
+      sequence.push('prepare')
+      return Effect.succeed(generation)
+    },
+    activateCapitalGrant: () => {
+      calls.activate += 1
+      sequence.push('activate')
+      return Effect.succeed(undefined)
+    },
+    restrictAuthority: () => {
+      calls.restrict += 1
+      sequence.push('restrict')
+      return Effect.void
+    },
+    mutations: {
+      latest: (_intentId, operation) =>
+        Effect.succeed(operation === MutationOperation.Submit ? options.latestSubmit : options.latestCancel),
+    },
+    execution: {
+      submit: () => {
+        calls.submit += 1
+        sequence.push('submit')
+        return Effect.succeed(options.submitEvent ?? event(MutationEventType.SubmitAccepted))
+      },
+      cancel: () => {
+        calls.cancel += 1
+        sequence.push('cancel')
+        return Effect.succeed(
+          options.cancelEvent ?? event(MutationEventType.CancelAccepted, MutationOperation.Cancel),
+        )
+      },
+      recover: (_intentId, operation) => {
+        calls.recover += 1
+        sequence.push(`recover:${operation}`)
+        return Effect.succeed(options.recoverEvent ?? event(MutationEventType.RecoveryFound, operation))
+      },
+    },
+    prepareIntent: () =>
+      Effect.succeed({ intentId, clientOrderId: `b1_${'A'.repeat(43)}`, deduplicated: false }),
+    reconcile: () => {
+      calls.reconcile += 1
+      sequence.push(`reconcile:${calls.reconcile.toString()}`)
+      if (options.neverReconcileAt === calls.reconcile) return Effect.never
+      return Effect.succeed({
+        reconciliationId: hash(String(Math.min(calls.reconcile, 9))),
+        contentHash: hash('f'),
+        accountId,
+        status: 'EXACT',
+        unknownMutationCount: options.reconciliationUnknownCounts?.[calls.reconcile - 1] ?? 0,
+        reconciledAt: '2026-07-31T08:00:00.000Z',
+      })
+    },
+    currentUtcInstant: Effect.succeed('2026-07-31T08:00:01.000Z'),
+  }
+  return { calls, dependencies, sequence }
+}
+
+describe('bounded PAPER proof command', () => {
+  test('PREPARE reconciles and derives a generation without mutation services', async () => {
+    const { calls, dependencies } = fixture({ operation: 'PREPARE' })
+    const receipt = await Effect.runPromise(runPaperProof(command('PREPARE'), dependencies))
+
+    expect(receipt.generation?.generationHash).toBe(sourcePlan.authorityGenerationHash)
+    expect(calls).toMatchObject({
+      prepare: 1,
+      activate: 0,
+      submit: 0,
+      cancel: 0,
+      recover: 0,
+      reconcile: 1,
+    })
+  })
+
+  test('SUBMIT performs at most one POST and reconciles around activation', async () => {
+    const { calls, dependencies } = fixture({ operation: 'SUBMIT' })
+    const receipt = await Effect.runPromise(runPaperProof(command('SUBMIT'), dependencies))
+
+    expect(receipt.mutation?.eventType).toBe(MutationEventType.SubmitAccepted)
+    expect(receipt.reconciliations).toHaveLength(3)
+    expect(calls).toMatchObject({ activate: 1, submit: 1, recover: 0, reconcile: 3 })
+  })
+
+  test('duplicate accepted SUBMIT reuses durable evidence without activation or POST', async () => {
+    const accepted = event(MutationEventType.SubmitAccepted)
+    const { calls, dependencies } = fixture({ operation: 'SUBMIT', latestSubmit: accepted })
+    const receipt = await Effect.runPromise(runPaperProof(command('SUBMIT'), dependencies))
+
+    expect(receipt.mutation).toEqual(accepted)
+    expect(calls.activate).toBe(0)
+    expect(calls.submit).toBe(0)
+    expect(calls.recover).toBe(0)
+  })
+
+  test('crash restart recovers an unresolved SUBMIT before exact reconciliation', async () => {
+    const started = event(MutationEventType.SubmitStarted)
+    const recovered = event(MutationEventType.RecoveryFound)
+    const { calls, dependencies, sequence } = fixture({
+      operation: 'SUBMIT',
+      latestSubmit: started,
+      recoverEvent: recovered,
+      reconciliationUnknownCounts: [1, 0],
+    })
+    const receipt = await Effect.runPromise(runPaperProof(command('SUBMIT'), dependencies))
+
+    expect(receipt.mutation).toEqual(recovered)
+    expect(calls.activate).toBe(0)
+    expect(calls.submit).toBe(0)
+    expect(calls.recover).toBe(1)
+    expect(sequence).toEqual([
+      'reconcile:1',
+      `recover:${MutationOperation.Submit}`,
+      'reconcile:2',
+    ])
+  })
+
+  test('unknown SUBMIT is durably contained by restricting authority', async () => {
+    const unknown = event(MutationEventType.SubmitUnknown)
+    const { calls, dependencies } = fixture({ operation: 'SUBMIT', submitEvent: unknown })
+    const receipt = await Effect.runPromise(runPaperProof(command('SUBMIT'), dependencies))
+
+    expect(receipt.restricted).toBe(true)
+    expect(receipt.mutation?.eventType).toBe(MutationEventType.SubmitUnknown)
+    expect(calls.restrict).toBe(1)
+  })
+
+  test('accepted cancellation is lookup-recovered before the zero-unknown gate', async () => {
+    const accepted = event(MutationEventType.CancelAccepted, MutationOperation.Cancel)
+    const recovered = event(MutationEventType.RecoveryFound, MutationOperation.Cancel)
+    const { calls, dependencies, sequence } = fixture({
+      operation: 'CANCEL',
+      cancelEvent: accepted,
+      recoverEvent: recovered,
+      reconciliationUnknownCounts: [1, 0],
+    })
+    const receipt = await Effect.runPromise(runPaperProof(command('CANCEL'), dependencies))
+
+    expect(receipt.mutation).toEqual(recovered)
+    expect(calls.cancel).toBe(1)
+    expect(calls.recover).toBe(1)
+    expect(sequence).toEqual([
+      'reconcile:1',
+      'cancel',
+      `recover:${MutationOperation.Cancel}`,
+      'reconcile:2',
+    ])
+  })
+
+  test('cancel race recovers durable cancellation without another DELETE', async () => {
+    const started = event(MutationEventType.CancelStarted, MutationOperation.Cancel)
+    const { calls, dependencies } = fixture({ operation: 'CANCEL', latestCancel: started })
+    const receipt = await Effect.runPromise(runPaperProof(command('CANCEL'), dependencies))
+
+    expect(receipt.mutation?.eventType).toBe(MutationEventType.RecoveryFound)
+    expect(calls.cancel).toBe(0)
+    expect(calls.recover).toBe(1)
+  })
+
+  test('RECOVER performs durable lookup before final exact reconciliation', async () => {
+    const recovered = event(MutationEventType.RecoveryFound)
+    const { calls, dependencies, sequence } = fixture({
+      operation: 'RECOVER',
+      recoverEvent: recovered,
+      reconciliationUnknownCounts: [1, 0],
+    })
+    const receipt = await Effect.runPromise(runPaperProof(command('RECOVER'), dependencies))
+
+    expect(receipt.mutation).toEqual(recovered)
+    expect(calls.submit).toBe(0)
+    expect(calls.recover).toBe(1)
+    expect(sequence).toEqual([
+      'reconcile:1',
+      `recover:${MutationOperation.Submit}`,
+      'reconcile:2',
+    ])
+  })
+
+  test('post-activation timeout restricts authority and reconciles uninterruptibly', async () => {
+    const { calls, dependencies, sequence } = fixture({
+      operation: 'SUBMIT',
+      neverReconcileAt: 2,
+    })
+    const bounded = { ...command('SUBMIT'), timeoutMs: 5 }
+    const exit = await Effect.runPromiseExit(runPaperProof(bounded, dependencies))
+
+    expect(Exit.isFailure(exit)).toBe(true)
+    if (Exit.isFailure(exit)) expect(String(exit.cause)).toContain('TIMEOUT')
+    expect(calls.activate).toBe(1)
+    expect(calls.submit).toBe(0)
+    expect(calls.restrict).toBe(1)
+    expect(calls.reconcile).toBe(3)
+    expect(sequence).toEqual([
+      'reconcile:1',
+      'activate',
+      'reconcile:2',
+      'restrict',
+      'reconcile:3',
+    ])
+  })
+
+  test('cooperative PREPARE termination enforces the command deadline', async () => {
+    const { dependencies } = fixture({ operation: 'PREPARE', neverReconcileAt: 1 })
+    const bounded = { ...command('PREPARE'), timeoutMs: 1 }
+    const exit = await Effect.runPromiseExit(runPaperProof(bounded, dependencies))
+
+    expect(Exit.isFailure(exit)).toBe(true)
+    if (Exit.isFailure(exit)) expect(String(exit.cause)).toContain('TIMEOUT')
+  })
+})

--- a/services/bayn/src/paper-proof/program.ts
+++ b/services/bayn/src/paper-proof/program.ts
@@ -1,0 +1,450 @@
+import { Duration, Effect, Exit } from 'effect'
+
+import { MutationOperation } from '../broker/alpaca-mutations'
+import type { CapitalGrantGeneration, CapitalGrantProofBinding } from '../execution/contracts'
+import { MutationEventType, type MutationEvent, type MutationStoreShape } from '../execution/mutations'
+import type { ExecutionProgram } from '../execution/runtime-program'
+import { validatePaperProofEntry } from './gates'
+import {
+  PaperProofError,
+  paperProofReceiptSchemaVersion,
+  proofBinding,
+  type PaperProofCommand,
+  type PaperProofReceipt,
+  type PaperProofReconciliation,
+  type PaperProofRuntimeBinding,
+  type PaperProofSourcePlan,
+  type PreparedPaperProofIntent,
+} from './model'
+
+export interface PaperProofDependencies {
+  readonly sourcePlan: PaperProofSourcePlan
+  readonly runtime: PaperProofRuntimeBinding
+  readonly protectedEntryToken: string
+  readonly prepareCapitalGrant: (proof: CapitalGrantProofBinding) => Effect.Effect<CapitalGrantGeneration, unknown>
+  readonly activateCapitalGrant: (proof: CapitalGrantProofBinding) => Effect.Effect<unknown, unknown>
+  readonly restrictAuthority: (reason: string, updatedAt: string) => Effect.Effect<void, unknown>
+  readonly mutations: Pick<MutationStoreShape, 'latest'>
+  readonly execution: Pick<ExecutionProgram, 'submit' | 'cancel' | 'recover'>
+  readonly prepareIntent: () => Effect.Effect<PreparedPaperProofIntent, unknown>
+  readonly reconcile: () => Effect.Effect<PaperProofReconciliation, unknown>
+  readonly currentUtcInstant: Effect.Effect<string, unknown>
+}
+
+const paperProofFailure = (
+  operation: PaperProofError['operation'],
+  message: string,
+  cause: unknown,
+  failure: PaperProofError['failure'] = 'operational',
+): PaperProofError => new PaperProofError({ operation, failure, message, cause })
+
+const lift = <A>(
+  operation: PaperProofError['operation'],
+  message: string,
+  effect: Effect.Effect<A, unknown>,
+): Effect.Effect<A, PaperProofError> =>
+  effect.pipe(Effect.mapError((cause) => paperProofFailure(operation, message, cause)))
+
+const requireSameAccountReconciliation = (
+  expectedAccountId: string,
+  reconciliation: PaperProofReconciliation,
+): Effect.Effect<PaperProofReconciliation, PaperProofError> =>
+  reconciliation.accountId === expectedAccountId
+    ? Effect.succeed(reconciliation)
+    : Effect.fail(
+        paperProofFailure(
+          'RECONCILE',
+          'paper proof reconciliation account does not match the source-controlled account',
+          reconciliation,
+          'invariant',
+        ),
+      )
+
+const requireExactReconciliation = (
+  reconciliation: PaperProofReconciliation,
+): Effect.Effect<PaperProofReconciliation, PaperProofError> => {
+  if (reconciliation.status !== 'EXACT' || reconciliation.unknownMutationCount !== 0) {
+    return Effect.fail(
+      paperProofFailure(
+        'RECONCILE',
+        'paper proof requires exact reconciliation with zero unknown mutations',
+        reconciliation,
+        'invariant',
+      ),
+    )
+  }
+  return Effect.succeed(reconciliation)
+}
+
+const observeReconciliation = (
+  dependencies: PaperProofDependencies,
+): Effect.Effect<PaperProofReconciliation, PaperProofError> =>
+  lift('RECONCILE', 'paper proof reconciliation failed', dependencies.reconcile()).pipe(
+    Effect.flatMap((result) => requireSameAccountReconciliation(dependencies.sourcePlan.accountId, result)),
+  )
+
+const reconcileExact = (
+  dependencies: PaperProofDependencies,
+): Effect.Effect<PaperProofReconciliation, PaperProofError> =>
+  observeReconciliation(dependencies).pipe(Effect.flatMap(requireExactReconciliation))
+
+const restrict = (
+  dependencies: PaperProofDependencies,
+  reason: string,
+): Effect.Effect<void, PaperProofError> =>
+  lift('RESTRICT', 'paper proof failed to read the restriction clock', dependencies.currentUtcInstant).pipe(
+    Effect.flatMap((updatedAt) =>
+      lift(
+        'RESTRICT',
+        'paper proof failed to restrict mutation authority',
+        dependencies.restrictAuthority(reason.slice(0, 240), updatedAt),
+      ),
+    ),
+  )
+
+const finalizeMutationFailure = (
+  dependencies: PaperProofDependencies,
+  reason: string,
+): Effect.Effect<void, PaperProofError> =>
+  Effect.gen(function* () {
+    const restrictionExit = yield* Effect.exit(restrict(dependencies, reason))
+    const reconciliationExit = yield* Effect.exit(observeReconciliation(dependencies))
+    if (Exit.isFailure(restrictionExit)) return yield* restrictionExit
+    if (Exit.isFailure(reconciliationExit)) return yield* reconciliationExit
+  })
+
+const withMutationFailureFinalizer = <A>(
+  dependencies: PaperProofDependencies,
+  reason: string,
+  effect: Effect.Effect<A, PaperProofError>,
+): Effect.Effect<A, PaperProofError> =>
+  Effect.uninterruptibleMask((restore) =>
+    restore(effect).pipe(
+      Effect.onExit((exit) =>
+        Exit.isFailure(exit) ? finalizeMutationFailure(dependencies, reason) : Effect.void,
+      ),
+    ),
+  )
+
+const activateAndRun = <A>(
+  command: PaperProofCommand,
+  dependencies: PaperProofDependencies,
+  effect: Effect.Effect<A, PaperProofError>,
+): Effect.Effect<A, PaperProofError> =>
+  Effect.uninterruptibleMask((restore) =>
+    Effect.gen(function* () {
+      const activationExit = yield* Effect.exit(
+        restore(
+          lift(
+            'SUBMIT',
+            'paper proof generation activation failed',
+            dependencies.activateCapitalGrant(proofBinding(command)),
+          ),
+        ),
+      )
+      if (Exit.isFailure(activationExit)) {
+        yield* finalizeMutationFailure(dependencies, 'paper-proof-submit-activation-failure')
+        return yield* activationExit
+      }
+      return yield* restore(effect).pipe(
+        Effect.onExit((exit) =>
+          Exit.isFailure(exit)
+            ? finalizeMutationFailure(dependencies, 'paper-proof-submit-post-activation-failure')
+            : Effect.void,
+        ),
+      )
+    }),
+  )
+
+const successfulSubmit = (event: MutationEvent): boolean =>
+  event.operation === MutationOperation.Submit &&
+  (event.eventType === MutationEventType.SubmitAccepted || event.eventType === MutationEventType.RecoveryFound)
+
+const terminalSubmit = (event: MutationEvent): boolean =>
+  successfulSubmit(event) ||
+  event.eventType === MutationEventType.SubmitRejected ||
+  event.eventType === MutationEventType.SubmitDenied
+
+const recoveredCancellation = (event: MutationEvent): boolean =>
+  event.operation === MutationOperation.Cancel && event.eventType === MutationEventType.RecoveryFound
+
+const prepareSubmitIntent = (
+  dependencies: PaperProofDependencies,
+): Effect.Effect<PreparedPaperProofIntent, PaperProofError> =>
+  lift('SUBMIT', 'paper proof intent preparation failed', dependencies.prepareIntent()).pipe(
+    Effect.flatMap((prepared) =>
+      prepared.intentId === dependencies.sourcePlan.intentId
+        ? Effect.succeed(prepared)
+        : Effect.fail(
+            paperProofFailure(
+              'SUBMIT',
+              'prepared PAPER intent identity does not match the source-controlled proof plan',
+              prepared,
+              'invariant',
+            ),
+          ),
+    ),
+  )
+
+const readSubmit = (
+  dependencies: PaperProofDependencies,
+): Effect.Effect<MutationEvent | undefined, PaperProofError> =>
+  lift(
+    'SUBMIT',
+    'paper proof durable submit read failed',
+    dependencies.mutations.latest(dependencies.sourcePlan.intentId, MutationOperation.Submit),
+  )
+
+const waitForRecovery = (command: PaperProofCommand): Effect.Effect<void> =>
+  Effect.sleep(Duration.millis(command.consistencyDelayMs))
+
+const recoverSubmit = (
+  command: PaperProofCommand,
+  dependencies: PaperProofDependencies,
+): Effect.Effect<MutationEvent, PaperProofError> =>
+  waitForRecovery(command).pipe(
+    Effect.andThen(
+      lift(
+        'RECOVER',
+        'paper proof lookup-only submit recovery failed',
+        dependencies.execution.recover(dependencies.sourcePlan.intentId, MutationOperation.Submit),
+      ),
+    ),
+  )
+
+const cancelOrRecover = (
+  command: PaperProofCommand,
+  dependencies: PaperProofDependencies,
+): Effect.Effect<MutationEvent, PaperProofError> =>
+  Effect.gen(function* () {
+    const intentId = dependencies.sourcePlan.intentId
+    const existing = yield* lift(
+      'CANCEL',
+      'paper proof durable cancellation read failed',
+      dependencies.mutations.latest(intentId, MutationOperation.Cancel),
+    )
+    const event =
+      existing ??
+      (yield* lift(
+        'CANCEL',
+        'paper proof identified cancellation failed',
+        dependencies.execution.cancel(intentId, command.consistencyDelayMs),
+      ))
+    if (recoveredCancellation(event)) return event
+    yield* waitForRecovery(command)
+    return yield* lift(
+      'CANCEL',
+      'paper proof lookup-only cancellation recovery failed',
+      dependencies.execution.recover(intentId, MutationOperation.Cancel),
+    )
+  })
+
+const completeReceipt = (
+  command: PaperProofCommand,
+  dependencies: PaperProofDependencies,
+  input: Omit<
+    PaperProofReceipt,
+    'schemaVersion' | 'operation' | 'proofPlanHash' | 'qualificationRunId' | 'intentId' | 'completedAt'
+  >,
+): Effect.Effect<PaperProofReceipt, PaperProofError> =>
+  lift(command.operation, 'paper proof completion clock failed', dependencies.currentUtcInstant).pipe(
+    Effect.map((completedAt) => ({
+      schemaVersion: paperProofReceiptSchemaVersion,
+      operation: command.operation,
+      proofPlanHash: command.proofPlanHash,
+      qualificationRunId: command.qualificationRunId,
+      intentId: dependencies.sourcePlan.intentId,
+      completedAt,
+      ...input,
+    })),
+  )
+
+const runPrepare = (
+  command: PaperProofCommand,
+  dependencies: PaperProofDependencies,
+): Effect.Effect<PaperProofReceipt, PaperProofError> =>
+  Effect.gen(function* () {
+    const reconciliation = yield* reconcileExact(dependencies)
+    const generation = yield* lift(
+      'PREPARE',
+      'paper proof generation PREPARE failed',
+      dependencies.prepareCapitalGrant(proofBinding(command)),
+    )
+    return yield* completeReceipt(command, dependencies, {
+      generation,
+      reconciliations: [reconciliation],
+      restricted: false,
+    })
+  })
+
+const runExistingSubmit = (
+  command: PaperProofCommand,
+  dependencies: PaperProofDependencies,
+  prepared: PreparedPaperProofIntent,
+  before: PaperProofReconciliation,
+  existing: MutationEvent,
+): Effect.Effect<PaperProofReceipt, PaperProofError> =>
+  withMutationFailureFinalizer(
+    dependencies,
+    'paper-proof-existing-submit-failure',
+    Effect.gen(function* () {
+      const event = terminalSubmit(existing) ? existing : yield* recoverSubmit(command, dependencies)
+      let restricted = false
+      if (!successfulSubmit(event)) {
+        yield* restrict(dependencies, `paper-proof-submit-${event.eventType.toLowerCase()}`)
+        restricted = true
+      }
+      const finalReconciliation = yield* reconcileExact(dependencies)
+      return yield* completeReceipt(command, dependencies, {
+        clientOrderId: prepared.clientOrderId,
+        mutation: event,
+        reconciliations: [before, finalReconciliation],
+        restricted,
+      })
+    }),
+  )
+
+const runNewSubmit = (
+  command: PaperProofCommand,
+  dependencies: PaperProofDependencies,
+  prepared: PreparedPaperProofIntent,
+  before: PaperProofReconciliation,
+): Effect.Effect<PaperProofReceipt, PaperProofError> =>
+  requireExactReconciliation(before).pipe(
+    Effect.andThen(
+      activateAndRun(
+        command,
+        dependencies,
+        Effect.gen(function* () {
+          const afterActivation = yield* reconcileExact(dependencies)
+          const event = yield* lift(
+            'SUBMIT',
+            'paper proof guarded submit failed',
+            dependencies.execution.submit(prepared.intentId, command.consistencyDelayMs),
+          )
+          let restricted = false
+          if (!successfulSubmit(event)) {
+            yield* restrict(dependencies, `paper-proof-submit-${event.eventType.toLowerCase()}`)
+            restricted = true
+          }
+          const finalReconciliation = yield* reconcileExact(dependencies)
+          return yield* completeReceipt(command, dependencies, {
+            clientOrderId: prepared.clientOrderId,
+            mutation: event,
+            reconciliations: [before, afterActivation, finalReconciliation],
+            restricted,
+          })
+        }),
+      ),
+    ),
+  )
+
+const runSubmit = (
+  command: PaperProofCommand,
+  dependencies: PaperProofDependencies,
+): Effect.Effect<PaperProofReceipt, PaperProofError> =>
+  Effect.gen(function* () {
+    const before = yield* observeReconciliation(dependencies)
+    const prepared = yield* prepareSubmitIntent(dependencies)
+    const existing = yield* readSubmit(dependencies)
+    return yield* (existing === undefined
+      ? runNewSubmit(command, dependencies, prepared, before)
+      : runExistingSubmit(command, dependencies, prepared, before, existing))
+  })
+
+const runCancel = (
+  command: PaperProofCommand,
+  dependencies: PaperProofDependencies,
+): Effect.Effect<PaperProofReceipt, PaperProofError> =>
+  withMutationFailureFinalizer(
+    dependencies,
+    'paper-proof-cancel-failure',
+    Effect.gen(function* () {
+      const before = yield* observeReconciliation(dependencies)
+      const event = yield* cancelOrRecover(command, dependencies)
+      let restricted = false
+      if (!recoveredCancellation(event)) {
+        yield* restrict(dependencies, `paper-proof-cancel-${event.eventType.toLowerCase()}`)
+        restricted = true
+      }
+      const after = yield* reconcileExact(dependencies)
+      return yield* completeReceipt(command, dependencies, {
+        mutation: event,
+        reconciliations: [before, after],
+        restricted,
+      })
+    }),
+  )
+
+const runRecover = (
+  command: PaperProofCommand,
+  dependencies: PaperProofDependencies,
+): Effect.Effect<PaperProofReceipt, PaperProofError> =>
+  withMutationFailureFinalizer(
+    dependencies,
+    'paper-proof-recover-failure',
+    Effect.gen(function* () {
+      const before = yield* observeReconciliation(dependencies)
+      const event = yield* recoverSubmit(command, dependencies)
+      let restricted = false
+      if (!successfulSubmit(event)) {
+        yield* restrict(dependencies, `paper-proof-recover-${event.eventType.toLowerCase()}`)
+        restricted = true
+      }
+      const after = yield* reconcileExact(dependencies)
+      return yield* completeReceipt(command, dependencies, {
+        mutation: event,
+        reconciliations: [before, after],
+        restricted,
+      })
+    }),
+  )
+
+const runValidatedPaperProof = (
+  command: PaperProofCommand,
+  dependencies: PaperProofDependencies,
+): Effect.Effect<PaperProofReceipt, PaperProofError> => {
+  switch (command.operation) {
+    case 'PREPARE':
+      return runPrepare(command, dependencies)
+    case 'SUBMIT':
+      return runSubmit(command, dependencies)
+    case 'CANCEL':
+      return runCancel(command, dependencies)
+    case 'RECOVER':
+      return runRecover(command, dependencies)
+  }
+}
+
+export const runPaperProof = (
+  command: PaperProofCommand,
+  dependencies: PaperProofDependencies,
+): Effect.Effect<PaperProofReceipt, PaperProofError> =>
+  Effect.fromResult(
+    validatePaperProofEntry(
+      command,
+      dependencies.sourcePlan,
+      dependencies.runtime,
+      dependencies.protectedEntryToken,
+    ),
+  ).pipe(
+    Effect.andThen(runValidatedPaperProof(command, dependencies)),
+    Effect.timeoutOrElse({
+      duration: Duration.millis(command.timeoutMs),
+      orElse: () =>
+        Effect.fail(
+          new PaperProofError({
+            operation: 'TIMEOUT',
+            failure: 'timeout',
+            message: `paper proof command exceeded its ${command.timeoutMs.toString()}ms bound`,
+          }),
+        ),
+    }),
+    Effect.onExit((exit) =>
+      Exit.isFailure(exit)
+        ? Effect.logError('Bounded PAPER proof command failed').pipe(
+            Effect.annotateLogs({ operation: command.operation, proofPlanHash: command.proofPlanHash }),
+          )
+        : Effect.void,
+    ),
+  )


### PR DESCRIPTION
## Summary

- add a protected, terminating PAPER proof command boundary
- compose PREPARE, SUBMIT, CANCEL, and lookup-only RECOVER through the existing execution program and durable stores
- enforce exact source/build/qualification/strategy/account/generation sandbox gates
- prevent blind resubmit by reading durable mutation state before coordinator submission
- contain unknown/rejected submit outcomes by restricting authority
- reconcile before and after mutation phases

## Validation

Focused tests cover read-only PREPARE, one-POST success, duplicate invocation, crash/restart recovery, unknown outcome containment, cancel race, and cooperative deadline termination.

The source-plan gate is intentionally unpinned, so the CLI cannot execute against Alpaca in this task.

Linear: PROOMPT-375