### PR TITLE
fix(bayn): bind qualification eligibility to immutable Git provenance

### DIFF
--- a/.github/workflows/bayn-qualification.yml
+++ b/.github/workflows/bayn-qualification.yml
@@ -62,5 +62,8 @@ jobs:
           echo 'A non-null preregistration exists, but execution stays fail-closed until the reviewed evidence collector writes /run/bayn-qualification/eligibility-input.json.' >&2
           test -s /run/bayn-qualification/eligibility-input.json
           bun packages/scripts/src/bayn/verify-qualification-eligibility.ts \
-            --input /run/bayn-qualification/eligibility-input.json
+            --input /run/bayn-qualification/eligibility-input.json \
+            --repository-root "${GITHUB_WORKSPACE}" \
+            --trusted-repository "${GITHUB_REPOSITORY}" \
+            --git-timeout-ms 10000
           echo 'Eligibility verified. The existing governed qualification command must be invoked by the same reviewed collector only after its durable attempt lock is committed.'

--- a/packages/scripts/src/bayn/bayn-qualification-workflow.test.ts
+++ b/packages/scripts/src/bayn/bayn-qualification-workflow.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
+
+const workflow = readFileSync('.github/workflows/bayn-qualification.yml', 'utf8')
+
+describe('Bayn qualification workflow verifier integrity', () => {
+  test('passes explicit checked-out repository identity and a bounded Git deadline', () => {
+    expect(workflow).toContain('fetch-depth: 0')
+    expect(workflow).toContain('--repository-root "${GITHUB_WORKSPACE}"')
+    expect(workflow).toContain('--trusted-repository "${GITHUB_REPOSITORY}"')
+    expect(workflow).toContain('--git-timeout-ms 10000')
+  })
+
+  test('keeps read-only GitHub permissions and does not claim the missing executor is installed', () => {
+    expect(workflow).toContain('actions: read')
+    expect(workflow).toContain('contents: read')
+    expect(workflow).not.toMatch(/(?:issues|packages|pull-requests|statuses|checks|deployments|id-token): write/)
+    expect(workflow).toContain('Require separately installed immutable evidence collector')
+    expect(workflow).toContain('must be invoked by the same reviewed collector')
+  })
+})

--- a/packages/scripts/src/bayn/verify-qualification-eligibility.test.ts
+++ b/packages/scripts/src/bayn/verify-qualification-eligibility.test.ts
@@ -258,6 +258,26 @@ describe('qualification eligibility immutable Git verification', () => {
     })
   })
 
+  test('rejects a foreign raw origin hidden by repository-local URL rewrite configuration', async () => {
+    const repository = await makeGitFixture('https://github.com/foreign/lab.git')
+    try {
+      await git(repository.repository, [
+        'config',
+        'url.https://github.com/proompteng/lab.git.insteadOf',
+        'https://github.com/foreign/lab.git',
+      ])
+      expect(await git(repository.repository, ['remote', 'get-url', 'origin'])).toBe(
+        'https://github.com/proompteng/lab.git',
+      )
+      expect(await verifyQualificationEligibility(fixture(repository), options(repository))).toMatchObject({
+        status: 'hold',
+        code: 'repository-integrity-invalid',
+      })
+    } finally {
+      await rm(repository.repository, { recursive: true, force: true })
+    }
+  })
+
   test('rejects a checked-out HEAD or origin/main that differs from declared current main', async () => {
     await withRepository(async (repository) => {
       const changed = r('8')

--- a/packages/scripts/src/bayn/verify-qualification-eligibility.test.ts
+++ b/packages/scripts/src/bayn/verify-qualification-eligibility.test.ts
@@ -1,19 +1,63 @@
 import { describe, expect, test } from 'bun:test'
+import { execFile } from 'node:child_process'
+import { createHash } from 'node:crypto'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { promisify } from 'node:util'
+import { tmpdir } from 'node:os'
 
 import {
-  evaluateQualificationEligibility,
+  verifyQualificationEligibility,
   type QualificationEligibilityInput,
+  type QualificationEligibilityOptions,
+  type QualificationGit,
 } from './verify-qualification-eligibility'
 
+const execFilePromise = promisify(execFile)
 const h = (value: string) => value.repeat(64).slice(0, 64)
 const r = (value: string) => value.repeat(40).slice(0, 40)
 
-const fixture = (): QualificationEligibilityInput => ({
+interface GitFixture {
+  readonly repository: string
+  readonly rootRevision: string
+  readonly preregistrationRevision: string
+  readonly currentRevision: string
+}
+
+const git = async (repository: string, args: readonly string[]): Promise<string> => {
+  const result = await execFilePromise('git', ['-C', repository, ...args], {
+    encoding: 'utf8',
+    env: Object.fromEntries(Object.entries(process.env).filter(([name]) => !name.startsWith('GIT_'))),
+  })
+  return result.stdout.trim()
+}
+
+const commit = async (repository: string, value: string, message: string): Promise<string> => {
+  await writeFile(join(repository, 'marker.txt'), `${value}\n`)
+  await git(repository, ['add', 'marker.txt'])
+  await git(repository, ['commit', '-qm', message])
+  return git(repository, ['rev-parse', 'HEAD'])
+}
+
+const makeGitFixture = async (origin = 'https://github.com/proompteng/lab.git'): Promise<GitFixture> => {
+  const repository = await mkdtemp(join(tmpdir(), 'bayn-qualification-eligibility-'))
+  await git(repository, ['init', '-q', '-b', 'main'])
+  await git(repository, ['config', 'user.name', 'Qualification Test'])
+  await git(repository, ['config', 'user.email', 'qualification@example.test'])
+  const rootRevision = await commit(repository, 'root', 'test: root')
+  const preregistrationRevision = await commit(repository, 'preregistered', 'test: preregister candidate')
+  const currentRevision = await commit(repository, 'implemented', 'test: implement candidate')
+  await git(repository, ['remote', 'add', 'origin', origin])
+  await git(repository, ['update-ref', 'refs/remotes/origin/main', currentRevision])
+  return { repository, rootRevision, preregistrationRevision, currentRevision }
+}
+
+const fixture = (repository: GitFixture): QualificationEligibilityInput => ({
   eventName: 'schedule',
   repository: 'proompteng/lab',
-  currentMainSha: r('a'),
-  workflowSha: r('a'),
-  sourceSha: r('a'),
+  currentMainSha: repository.currentRevision,
+  workflowSha: repository.currentRevision,
+  sourceSha: repository.currentRevision,
   imageRepository: 'registry.example/bayn',
   imageDigest: `sha256:${h('b')}`,
   strategyBehaviorHash: h('c'),
@@ -33,13 +77,17 @@ const fixture = (): QualificationEligibilityInput => ({
       inputManifestHash: h('4'),
       boundedContentHash: h('5'),
     },
-    preregistration: { sourceRevision: r('6'), path: 'candidate.json', blobOid: r('e') },
+    preregistration: {
+      sourceRevision: repository.preregistrationRevision,
+      path: 'candidate.json',
+      blobOid: r('e'),
+    },
   },
   publication: {
     natural: true,
     completed: true,
     publicationDate: '2026-08-01',
-    sourceSha: r('a'),
+    sourceSha: repository.currentRevision,
     imageDigest: `sha256:${h('b')}`,
     snapshotId: h('2'),
     finalizedSnapshotContentHash: h('3'),
@@ -50,38 +98,256 @@ const fixture = (): QualificationEligibilityInput => ({
   database: { lockCount: 0, resultCount: 0, trialCount: 16 },
 })
 
-describe('qualification eligibility', () => {
-  test('is safely dormant before a reviewed preregistration exists', () => {
-    expect(evaluateQualificationEligibility({ ...fixture(), preregistration: null })).toEqual({
-      status: 'dormant',
-      code: 'preregistration-missing',
+const options = (
+  repository: GitFixture,
+  patch: Partial<QualificationEligibilityOptions> = {},
+): QualificationEligibilityOptions => ({
+  repositoryRoot: repository.repository,
+  trustedRepository: 'proompteng/lab',
+  gitTimeoutMs: 5_000,
+  ...patch,
+})
+
+const withRepository = async <A>(run: (repository: GitFixture) => Promise<A>): Promise<A> => {
+  const repository = await makeGitFixture()
+  try {
+    return await run(repository)
+  } finally {
+    await rm(repository.repository, { recursive: true, force: true })
+  }
+}
+
+const commitTree = async (repository: GitFixture, parent: string, message: string): Promise<string> => {
+  const tree = await git(repository.repository, ['rev-parse', `${repository.currentRevision}^{tree}`])
+  return git(repository.repository, ['commit-tree', tree, '-p', parent, '-m', message])
+}
+
+describe('qualification eligibility immutable Git verification', () => {
+  test('is safely dormant before a reviewed preregistration exists without opening Git', async () => {
+    const result = await verifyQualificationEligibility(
+      {
+        ...fixture({
+          repository: '/missing',
+          rootRevision: r('1'),
+          preregistrationRevision: r('2'),
+          currentRevision: r('3'),
+        }),
+        preregistration: null,
+      },
+      { repositoryRoot: '/missing', trustedRepository: 'proompteng/lab' },
+    )
+    expect(result).toEqual({ status: 'dormant', code: 'preregistration-missing' })
+  })
+
+  test('accepts a strict proper ancestor in the exact trusted current-main repository', async () => {
+    await withRepository(async (repository) => {
+      const result = await verifyQualificationEligibility(fixture(repository), options(repository))
+      expect(result).toMatchObject({
+        status: 'eligible',
+        trustedRepository: 'proompteng/lab',
+        sourceSha: repository.currentRevision,
+      })
+      if (result.status === 'eligible') {
+        expect(result.repositoryHash).toBe(
+          createHash('sha256').update('github.repository.v1:proompteng/lab').digest('hex'),
+        )
+        expect(result.eligibilityHash).toMatch(/^[0-9a-f]{64}$/)
+      }
     })
   })
 
-  test('accepts one exact pristine natural publication', () => {
-    const result = evaluateQualificationEligibility(fixture())
-    expect(result.status).toBe('eligible')
-    if (result.status === 'eligible') expect(result.eligibilityHash).toMatch(/^[0-9a-f]{64}$/)
+  test('rejects equal, descendant, divergent, and missing preregistration revisions', async () => {
+    await withRepository(async (repository) => {
+      const descendant = await commitTree(repository, repository.currentRevision, 'test: descendant')
+      const divergent = await commitTree(repository, repository.rootRevision, 'test: divergent')
+      for (const sourceRevision of [repository.currentRevision, descendant, divergent, r('9')]) {
+        const input = fixture(repository)
+        const result = await verifyQualificationEligibility(
+          {
+            ...input,
+            preregistration: {
+              ...input.preregistration!,
+              preregistration: { ...input.preregistration!.preregistration, sourceRevision },
+            },
+          },
+          options(repository),
+        )
+        expect(result).toMatchObject({ status: 'hold', code: 'preregistration-lineage-invalid' })
+      }
+    })
   })
 
-  test('rejects manual dispatch before qualification access', () => {
-    expect(evaluateQualificationEligibility({ ...fixture(), eventName: 'workflow_dispatch' })).toMatchObject({
-      status: 'hold',
-      code: 'manual-dispatch-rejected',
+  test('rejects replacement-ref ancestry that makes a divergent current source appear related', async () => {
+    await withRepository(async (repository) => {
+      const divergent = await commitTree(repository, repository.rootRevision, 'test: divergent')
+      const forged = await commitTree(repository, repository.preregistrationRevision, 'test: forged ancestry')
+      await git(repository.repository, ['update-ref', 'refs/heads/main', divergent])
+      await git(repository.repository, ['update-ref', 'refs/remotes/origin/main', divergent])
+      await git(repository.repository, ['replace', divergent, forged])
+      await git(repository.repository, ['merge-base', '--is-ancestor', repository.preregistrationRevision, divergent])
+      const input = fixture({ ...repository, currentRevision: divergent })
+      expect(await verifyQualificationEligibility(input, options(repository))).toMatchObject({
+        status: 'hold',
+        code: 'repository-integrity-invalid',
+      })
     })
+  })
+
+  test('rejects graft-spoofed ancestry before raw parent verification', async () => {
+    await withRepository(async (repository) => {
+      const divergent = await commitTree(repository, repository.rootRevision, 'test: divergent')
+      await git(repository.repository, ['update-ref', 'refs/heads/main', divergent])
+      await git(repository.repository, ['update-ref', 'refs/remotes/origin/main', divergent])
+      const graftsPath = join(
+        repository.repository,
+        await git(repository.repository, ['rev-parse', '--git-path', 'info/grafts']),
+      )
+      await mkdir(dirname(graftsPath), { recursive: true })
+      await writeFile(graftsPath, `${divergent} ${repository.preregistrationRevision}\n`)
+      await git(repository.repository, ['merge-base', '--is-ancestor', repository.preregistrationRevision, divergent])
+      const input = fixture({ ...repository, currentRevision: divergent })
+      expect(await verifyQualificationEligibility(input, options(repository))).toMatchObject({
+        status: 'hold',
+        code: 'repository-integrity-invalid',
+      })
+    })
+  })
+
+  test('rejects alternate-object metadata even when ordinary history is otherwise valid', async () => {
+    await withRepository(async (repository) => {
+      const alternate = await mkdtemp(join(tmpdir(), 'bayn-qualification-alternate-'))
+      try {
+        await git(alternate, ['init', '-q', '--bare'])
+        const alternatesPath = join(
+          repository.repository,
+          await git(repository.repository, ['rev-parse', '--git-path', 'objects/info/alternates']),
+        )
+        await mkdir(dirname(alternatesPath), { recursive: true })
+        await writeFile(alternatesPath, `${join(alternate, 'objects')}\n`)
+        expect(await verifyQualificationEligibility(fixture(repository), options(repository))).toMatchObject({
+          status: 'hold',
+          code: 'repository-integrity-invalid',
+        })
+      } finally {
+        await rm(alternate, { recursive: true, force: true })
+      }
+    })
+  })
+
+  test('rejects identical history from a different repository and hashes the accepted canonical identity', async () => {
+    await withRepository(async (repository) => {
+      const upstream = await verifyQualificationEligibility(fixture(repository), options(repository))
+      expect(upstream.status).toBe('eligible')
+
+      await git(repository.repository, ['remote', 'set-url', 'origin', 'git@github.com:foreign/lab.git'])
+      const foreignInput = { ...fixture(repository), repository: 'foreign/lab' }
+      expect(await verifyQualificationEligibility(foreignInput, options(repository))).toMatchObject({
+        status: 'hold',
+        code: 'repository-identity-invalid',
+      })
+
+      const foreign = await verifyQualificationEligibility(
+        foreignInput,
+        options(repository, { trustedRepository: 'foreign/lab' }),
+      )
+      expect(foreign.status).toBe('eligible')
+      if (upstream.status === 'eligible' && foreign.status === 'eligible') {
+        expect(foreign.repositoryHash).not.toBe(upstream.repositoryHash)
+        expect(foreign.eligibilityHash).not.toBe(upstream.eligibilityHash)
+      }
+    })
+  })
+
+  test('rejects a checked-out HEAD or origin/main that differs from declared current main', async () => {
+    await withRepository(async (repository) => {
+      const changed = r('8')
+      const input = {
+        ...fixture(repository),
+        currentMainSha: changed,
+        workflowSha: changed,
+        sourceSha: changed,
+        publication: { ...fixture(repository).publication!, sourceSha: changed },
+      }
+      expect(await verifyQualificationEligibility(input, options(repository))).toMatchObject({
+        status: 'hold',
+        code: 'source-head-mismatch',
+      })
+    })
+  })
+
+  test('cancels an in-flight Git verification', async () => {
+    await withRepository(async (repository) => {
+      let aborted = false
+      const hangingGit: QualificationGit = {
+        text: (_root, _args, signal) =>
+          new Promise((_resolve, reject) => {
+            const abort = () => {
+              aborted = true
+              reject(signal.reason ?? new Error('aborted'))
+            }
+            if (signal.aborted) abort()
+            else signal.addEventListener('abort', abort, { once: true })
+          }),
+      }
+      const controller = new AbortController()
+      const resultPromise = verifyQualificationEligibility(
+        fixture(repository),
+        options(repository, { git: hangingGit, signal: controller.signal }),
+      )
+      setTimeout(() => controller.abort(new Error('test cancellation')), 10)
+      expect(await resultPromise).toMatchObject({ status: 'hold', code: 'git-verification-cancelled' })
+      expect(aborted).toBe(true)
+    })
+  })
+
+  test('bounds a stalled Git verification with one overall timeout', async () => {
+    await withRepository(async (repository) => {
+      const hangingGit: QualificationGit = {
+        text: (_root, _args, signal) =>
+          new Promise((_resolve, reject) => {
+            const abort = () => reject(signal.reason ?? new Error('aborted'))
+            if (signal.aborted) abort()
+            else signal.addEventListener('abort', abort, { once: true })
+          }),
+      }
+      expect(
+        await verifyQualificationEligibility(
+          fixture(repository),
+          options(repository, { git: hangingGit, gitTimeoutMs: 10 }),
+        ),
+      ).toMatchObject({ status: 'hold', code: 'git-verification-timeout' })
+    })
+  })
+})
+
+describe('qualification eligibility evidence checks', () => {
+  test('rejects manual dispatch before Git access', async () => {
+    const input = fixture({
+      repository: '/missing',
+      rootRevision: r('1'),
+      preregistrationRevision: r('2'),
+      currentRevision: r('3'),
+    })
+    expect(
+      await verifyQualificationEligibility(
+        { ...input, eventName: 'workflow_dispatch' },
+        { repositoryRoot: '/missing', trustedRepository: 'proompteng/lab' },
+      ),
+    ).toMatchObject({ status: 'hold', code: 'manual-dispatch-rejected' })
   })
 
   test.each([
-    ['changed head', { currentMainSha: r('9') }, 'source-head-mismatch'],
-    ['changed preregistration', { preregistrationBlobOid: r('9') }, 'preregistration-invalid'],
+    ['changed preregistration blob', { preregistrationBlobOid: r('9') }, 'preregistration-invalid'],
     [
       'stale publication source',
-      { publication: { ...fixture().publication!, sourceSha: r('9') } },
+      (input: QualificationEligibilityInput) => ({ publication: { ...input.publication!, sourceSha: r('9') } }),
       'publication-source-mismatch',
     ],
     [
       'changed data',
-      { publication: { ...fixture().publication!, boundedContentHash: h('9') } },
+      (input: QualificationEligibilityInput) => ({
+        publication: { ...input.publication!, boundedContentHash: h('9') },
+      }),
       'publication-data-mismatch',
     ],
     ['prior lock', { database: { lockCount: 1, resultCount: 0, trialCount: 16 } }, 'database-state-not-pristine'],
@@ -96,7 +362,14 @@ describe('qualification eligibility', () => {
       { attempts: [{ candidateOrdinal: 17, status: 'completed' as const, conclusion: 'failure' }] },
       'prior-or-inflight-attempt',
     ],
-  ])('rejects %s', (_name, patch, code) => {
-    expect(evaluateQualificationEligibility({ ...fixture(), ...patch })).toMatchObject({ status: 'hold', code })
+  ])('rejects %s after immutable Git verification', async (_name, patch, code) => {
+    await withRepository(async (repository) => {
+      const input = fixture(repository)
+      const resolvedPatch = typeof patch === 'function' ? patch(input) : patch
+      expect(await verifyQualificationEligibility({ ...input, ...resolvedPatch }, options(repository))).toMatchObject({
+        status: 'hold',
+        code,
+      })
+    })
   })
 })

--- a/packages/scripts/src/bayn/verify-qualification-eligibility.ts
+++ b/packages/scripts/src/bayn/verify-qualification-eligibility.ts
@@ -1,7 +1,9 @@
 #!/usr/bin/env bun
 
+import { execFile } from 'node:child_process'
 import { createHash } from 'node:crypto'
-import { readFile } from 'node:fs/promises'
+import { readFile, realpath } from 'node:fs/promises'
+import { resolve } from 'node:path'
 import process from 'node:process'
 
 export interface QualificationPreregistration {
@@ -66,6 +68,8 @@ export type QualificationEligibilityResult =
   | {
       readonly status: 'eligible'
       readonly candidateOrdinal: number
+      readonly trustedRepository: string
+      readonly repositoryHash: string
       readonly sourceSha: string
       readonly imageRepository: string
       readonly imageDigest: string
@@ -74,10 +78,28 @@ export type QualificationEligibilityResult =
       readonly eligibilityHash: string
     }
 
+export interface QualificationGit {
+  readonly text: (repositoryRoot: string, args: readonly string[], signal: AbortSignal) => Promise<string>
+}
+
+export interface QualificationEligibilityOptions {
+  readonly repositoryRoot: string
+  readonly trustedRepository: string
+  readonly gitTimeoutMs?: number
+  readonly maximumHistoryCommits?: number
+  readonly signal?: AbortSignal
+  readonly git?: QualificationGit
+}
+
 const sha40 = /^[0-9a-f]{40}$/
 const sha64 = /^[0-9a-f]{64}$/
 const digest = /^sha256:[0-9a-f]{64}$/
 const isoDate = /^\d{4}-\d{2}-\d{2}$/
+const repositoryIdentity = /^[A-Za-z0-9][A-Za-z0-9.-]*\/[A-Za-z0-9_.-]+$/
+const defaultGitTimeoutMs = 10_000
+const defaultMaximumHistoryCommits = 50_000
+const maximumGitOutputBytes = 16 * 1024 * 1024
+const maximumCommitParents = 256
 
 const canonical = (value: unknown): string => {
   if (Array.isArray(value)) return `[${value.map(canonical).join(',')}]`
@@ -93,9 +115,311 @@ const canonical = (value: unknown): string => {
 
 const hold = (code: string, message: string): QualificationEligibilityResult => ({ status: 'hold', code, message })
 
-export const evaluateQualificationEligibility = (
+class QualificationGitVerificationError extends Error {
+  constructor(
+    readonly code: string,
+    message: string,
+    readonly cause?: unknown,
+  ) {
+    super(message)
+  }
+}
+
+const qualificationGitEnvironment = (): NodeJS.ProcessEnv =>
+  Object.fromEntries(Object.entries(process.env).filter(([name]) => !name.startsWith('GIT_')))
+
+const gitText = (repositoryRoot: string, args: readonly string[], signal: AbortSignal): Promise<string> =>
+  new Promise((resolveGit, rejectGit) => {
+    execFile(
+      'git',
+      ['--no-replace-objects', '-C', repositoryRoot, ...args],
+      {
+        encoding: 'utf8',
+        env: qualificationGitEnvironment(),
+        maxBuffer: maximumGitOutputBytes,
+        signal,
+      },
+      (error, stdout) => {
+        if (error === null) resolveGit(stdout.trim())
+        else rejectGit(error)
+      },
+    )
+  })
+
+const defaultQualificationGit: QualificationGit = { text: gitText }
+
+const canonicalRepository = (value: string): string => {
+  const trimmed = value.trim()
+  if (!repositoryIdentity.test(trimmed) || trimmed.endsWith('.git')) {
+    throw new QualificationGitVerificationError(
+      'repository-identity-invalid',
+      'trusted repository identity must be an explicit owner/repository value',
+    )
+  }
+  const [owner, name] = trimmed.split('/')
+  if (owner === undefined || name === undefined || owner === '.' || owner === '..' || name === '.' || name === '..') {
+    throw new QualificationGitVerificationError('repository-identity-invalid', 'trusted repository identity is invalid')
+  }
+  return `${owner.toLowerCase()}/${name.toLowerCase()}`
+}
+
+const repositoryFromOriginUrl = (value: string): string => {
+  const match =
+    /^(?:https?:\/\/github\.com\/|ssh:\/\/git@github\.com\/|git@github\.com:)([^/]+)\/([^/]+?)(?:\.git)?\/?$/i.exec(
+      value.trim(),
+    )
+  if (match === null || match[1] === undefined || match[2] === undefined) {
+    throw new QualificationGitVerificationError(
+      'repository-identity-invalid',
+      'origin must be an explicit GitHub repository URL',
+    )
+  }
+  return canonicalRepository(`${match[1]}/${match[2]}`)
+}
+
+const activeMetadataLines = (value: string, commentsAllowed: boolean): readonly string[] =>
+  value
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && (!commentsAllowed || !line.startsWith('#')))
+
+const readOptionalMetadata = async (path: string, signal: AbortSignal): Promise<string> => {
+  try {
+    return await readFile(path, { encoding: 'utf8', signal })
+  } catch (error) {
+    if (typeof error === 'object' && error !== null && 'code' in error && error.code === 'ENOENT') return ''
+    throw error
+  }
+}
+
+const verifyRepositoryIntegrity = async (
+  repositoryRoot: string,
+  git: QualificationGit,
+  signal: AbortSignal,
+): Promise<void> => {
+  const shallow = await git.text(repositoryRoot, ['rev-parse', '--is-shallow-repository'], signal)
+  if (shallow !== 'false') {
+    throw new QualificationGitVerificationError(
+      'repository-integrity-invalid',
+      'qualification requires complete non-shallow Git history',
+    )
+  }
+
+  const replacementRefs = await git.text(
+    repositoryRoot,
+    ['for-each-ref', '--format=%(refname)', 'refs/replace'],
+    signal,
+  )
+  if (replacementRefs.length > 0) {
+    throw new QualificationGitVerificationError(
+      'repository-integrity-invalid',
+      'replacement refs are forbidden during qualification history verification',
+    )
+  }
+
+  const configuration = await git.text(repositoryRoot, ['config', '--list'], signal)
+  const replacementConfiguration = configuration
+    .split('\n')
+    .map((line) => line.slice(0, line.indexOf('=')))
+    .filter((key) => key.toLowerCase().startsWith('replace.'))
+  if (replacementConfiguration.length > 0) {
+    throw new QualificationGitVerificationError(
+      'repository-integrity-invalid',
+      'replacement configuration is forbidden during qualification history verification',
+    )
+  }
+
+  for (const metadata of [
+    { name: 'grafts', path: 'info/grafts', commentsAllowed: true },
+    { name: 'alternates', path: 'objects/info/alternates', commentsAllowed: false },
+    { name: 'http alternates', path: 'objects/info/http-alternates', commentsAllowed: false },
+  ] as const) {
+    const gitPath = await git.text(repositoryRoot, ['rev-parse', '--git-path', metadata.path], signal)
+    const contents = await readOptionalMetadata(resolve(repositoryRoot, gitPath), signal)
+    if (activeMetadataLines(contents, metadata.commentsAllowed).length > 0) {
+      throw new QualificationGitVerificationError(
+        'repository-integrity-invalid',
+        `${metadata.name} are forbidden during qualification history verification`,
+      )
+    }
+  }
+}
+
+const parseRawCommitParents = (oid: string, value: string): readonly string[] => {
+  const parents: string[] = []
+  let sawTree = false
+  for (const line of value.split('\n')) {
+    if (line.length === 0) break
+    if (line.startsWith('tree ')) {
+      if (sawTree || !sha40.test(line.slice(5))) {
+        throw new QualificationGitVerificationError('preregistration-lineage-invalid', `commit ${oid} is malformed`)
+      }
+      sawTree = true
+      continue
+    }
+    if (line.startsWith('parent ')) {
+      const parent = line.slice(7)
+      if (!sha40.test(parent) || parents.length >= maximumCommitParents) {
+        throw new QualificationGitVerificationError('preregistration-lineage-invalid', `commit ${oid} is malformed`)
+      }
+      parents.push(parent)
+    }
+  }
+  if (!sawTree) {
+    throw new QualificationGitVerificationError('preregistration-lineage-invalid', `commit ${oid} has no tree`)
+  }
+  return parents
+}
+
+const requireRawProperAncestor = async (
+  repositoryRoot: string,
+  preregistrationRevision: string,
+  sourceRevision: string,
+  maximumHistoryCommits: number,
+  git: QualificationGit,
+  signal: AbortSignal,
+): Promise<void> => {
+  if (preregistrationRevision === sourceRevision) {
+    throw new QualificationGitVerificationError(
+      'preregistration-lineage-invalid',
+      'preregistration source revision must be a strict proper ancestor of current source',
+    )
+  }
+
+  try {
+    parseRawCommitParents(
+      preregistrationRevision,
+      await git.text(repositoryRoot, ['cat-file', 'commit', preregistrationRevision], signal),
+    )
+  } catch (error) {
+    if (error instanceof QualificationGitVerificationError) throw error
+    throw new QualificationGitVerificationError(
+      'preregistration-lineage-invalid',
+      'preregistration source revision is missing or is not a commit',
+      error,
+    )
+  }
+
+  const pending = [sourceRevision]
+  const visited = new Set<string>()
+  while (pending.length > 0) {
+    if (visited.size >= maximumHistoryCommits) {
+      throw new QualificationGitVerificationError(
+        'preregistration-lineage-invalid',
+        'qualification history exceeds the configured commit bound',
+      )
+    }
+    const oid = pending.pop()
+    if (oid === undefined || visited.has(oid)) continue
+    let content: string
+    try {
+      content = await git.text(repositoryRoot, ['cat-file', 'commit', oid], signal)
+    } catch (error) {
+      throw new QualificationGitVerificationError(
+        'preregistration-lineage-invalid',
+        `qualification source history contains a missing or non-commit object: ${oid}`,
+        error,
+      )
+    }
+    visited.add(oid)
+    for (const parent of parseRawCommitParents(oid, content)) {
+      if (parent === preregistrationRevision) return
+      if (!visited.has(parent)) pending.push(parent)
+    }
+  }
+  throw new QualificationGitVerificationError(
+    'preregistration-lineage-invalid',
+    'preregistration source revision is not a proper ancestor of current source',
+  )
+}
+
+const verifyRepositoryAndLineage = async (
   input: QualificationEligibilityInput,
-): QualificationEligibilityResult => {
+  registration: QualificationPreregistration,
+  options: QualificationEligibilityOptions,
+  signal: AbortSignal,
+): Promise<{ readonly trustedRepository: string; readonly repositoryHash: string }> => {
+  const git = options.git ?? defaultQualificationGit
+  const trustedRepository = canonicalRepository(options.trustedRepository)
+  const observedRepository = canonicalRepository(input.repository)
+  if (observedRepository !== trustedRepository) {
+    throw new QualificationGitVerificationError(
+      'repository-identity-invalid',
+      'eligibility evidence repository differs from the explicitly trusted repository',
+    )
+  }
+
+  const [root, topLevel] = await Promise.all([
+    realpath(options.repositoryRoot),
+    git.text(options.repositoryRoot, ['rev-parse', '--show-toplevel'], signal).then((path) => realpath(path)),
+  ])
+  if (root !== topLevel) {
+    throw new QualificationGitVerificationError(
+      'repository-identity-invalid',
+      'repository root does not match the checked-out Git worktree',
+    )
+  }
+
+  await verifyRepositoryIntegrity(root, git, signal)
+  const [headSha, originMainSha, originUrl] = await Promise.all([
+    git.text(root, ['rev-parse', 'HEAD'], signal),
+    git.text(root, ['rev-parse', 'refs/remotes/origin/main'], signal),
+    git.text(root, ['remote', 'get-url', 'origin'], signal),
+  ])
+  if (headSha !== input.currentMainSha || originMainSha !== input.currentMainSha) {
+    throw new QualificationGitVerificationError(
+      'source-head-mismatch',
+      'checked-out HEAD and immutable origin/main must equal the declared current main source',
+    )
+  }
+  if (repositoryFromOriginUrl(originUrl) !== trustedRepository) {
+    throw new QualificationGitVerificationError(
+      'repository-identity-invalid',
+      'checked-out origin differs from the explicitly trusted repository',
+    )
+  }
+
+  const maximumHistoryCommits = options.maximumHistoryCommits ?? defaultMaximumHistoryCommits
+  if (!Number.isSafeInteger(maximumHistoryCommits) || maximumHistoryCommits < 1) {
+    throw new QualificationGitVerificationError('git-verification-invalid', 'history commit bound is invalid')
+  }
+  await requireRawProperAncestor(
+    root,
+    registration.preregistration.sourceRevision,
+    input.sourceSha,
+    maximumHistoryCommits,
+    git,
+    signal,
+  )
+
+  // Re-read all mutable Git metadata and repository bindings after the raw object walk so a concurrent graft,
+  // replacement, alternate-object, origin, or main-ref change cannot authorize eligibility.
+  await verifyRepositoryIntegrity(root, git, signal)
+  const [finalHeadSha, finalOriginMainSha, finalOriginUrl] = await Promise.all([
+    git.text(root, ['rev-parse', 'HEAD'], signal),
+    git.text(root, ['rev-parse', 'refs/remotes/origin/main'], signal),
+    git.text(root, ['remote', 'get-url', 'origin'], signal),
+  ])
+  if (
+    finalHeadSha !== input.currentMainSha ||
+    finalOriginMainSha !== input.currentMainSha ||
+    repositoryFromOriginUrl(finalOriginUrl) !== trustedRepository
+  ) {
+    throw new QualificationGitVerificationError(
+      'repository-identity-invalid',
+      'repository identity or current main changed during immutable Git verification',
+    )
+  }
+
+  return {
+    trustedRepository,
+    repositoryHash: createHash('sha256').update(`github.repository.v1:${trustedRepository}`).digest('hex'),
+  }
+}
+
+const preliminaryEligibility = (
+  input: QualificationEligibilityInput,
+): QualificationEligibilityResult | QualificationPreregistration => {
   if (input.preregistration === null) return { status: 'dormant', code: 'preregistration-missing' }
   if (input.eventName === 'workflow_dispatch') return hold('manual-dispatch-rejected', 'manual dispatch is forbidden')
   if (input.eventName !== 'schedule') return hold('event-not-trusted', `unexpected event ${input.eventName}`)
@@ -121,11 +445,18 @@ export const evaluateQualificationEligibility = (
     !sha64.test(registration.moduleSha256) ||
     !sha40.test(registration.preregistration.sourceRevision) ||
     !sha40.test(registration.preregistration.blobOid) ||
-    registration.preregistration.sourceRevision === input.currentMainSha ||
     input.preregistrationBlobOid !== registration.preregistration.blobOid
   ) {
     return hold('preregistration-invalid', 'preregistration identity or immutable blob binding is invalid')
   }
+  return registration
+}
+
+const finishEligibility = (
+  input: QualificationEligibilityInput,
+  registration: QualificationPreregistration,
+  repository: { readonly trustedRepository: string; readonly repositoryHash: string },
+): QualificationEligibilityResult => {
   if (input.publication === null)
     return hold('publication-missing', 'no post-preregistration natural publication exists')
   const publication = input.publication
@@ -168,6 +499,8 @@ export const evaluateQualificationEligibility = (
     )
   }
   const subject = {
+    repository: repository.trustedRepository,
+    repositoryHash: repository.repositoryHash,
     candidateOrdinal: registration.candidateOrdinal,
     sourceSha: input.sourceSha,
     imageRepository: input.imageRepository,
@@ -183,6 +516,8 @@ export const evaluateQualificationEligibility = (
   return {
     status: 'eligible',
     candidateOrdinal: registration.candidateOrdinal,
+    trustedRepository: repository.trustedRepository,
+    repositoryHash: repository.repositoryHash,
     sourceSha: input.sourceSha,
     imageRepository: input.imageRepository,
     imageDigest: input.imageDigest,
@@ -192,17 +527,77 @@ export const evaluateQualificationEligibility = (
   }
 }
 
-const parseArgs = (): { input: string } => {
-  const index = process.argv.indexOf('--input')
-  if (index < 0 || !process.argv[index + 1]) throw new Error('--input is required')
-  return { input: process.argv[index + 1]! }
+export const verifyQualificationEligibility = async (
+  input: QualificationEligibilityInput,
+  options: QualificationEligibilityOptions,
+): Promise<QualificationEligibilityResult> => {
+  const preliminary = preliminaryEligibility(input)
+  if ('status' in preliminary) return preliminary
+
+  const gitTimeoutMs = options.gitTimeoutMs ?? defaultGitTimeoutMs
+  if (!Number.isSafeInteger(gitTimeoutMs) || gitTimeoutMs < 1) {
+    return hold('git-verification-invalid', 'Git verification timeout is invalid')
+  }
+
+  const controller = new AbortController()
+  let timedOut = false
+  const timeout = setTimeout(() => {
+    timedOut = true
+    controller.abort(new Error('qualification Git verification timed out'))
+  }, gitTimeoutMs)
+  const abort = () => controller.abort(options.signal?.reason ?? new Error('qualification Git verification cancelled'))
+  if (options.signal?.aborted === true) abort()
+  else options.signal?.addEventListener('abort', abort, { once: true })
+  try {
+    const repository = await verifyRepositoryAndLineage(input, preliminary, options, controller.signal)
+    return finishEligibility(input, preliminary, repository)
+  } catch (error) {
+    if (controller.signal.aborted) {
+      return hold(
+        timedOut ? 'git-verification-timeout' : 'git-verification-cancelled',
+        timedOut ? 'bounded Git verification timed out' : 'Git verification was cancelled',
+      )
+    }
+    if (error instanceof QualificationGitVerificationError) return hold(error.code, error.message)
+    return hold('git-verification-failed', 'immutable Git verification failed')
+  } finally {
+    clearTimeout(timeout)
+    options.signal?.removeEventListener('abort', abort)
+  }
 }
+
+const parsePositiveInteger = (name: string, value: string): number => {
+  const parsed = Number(value)
+  if (!Number.isSafeInteger(parsed) || parsed < 1) throw new Error(`${name} must be a positive integer`)
+  return parsed
+}
+
+const argument = (name: string): string => {
+  const index = process.argv.indexOf(name)
+  const value = index < 0 ? undefined : process.argv[index + 1]
+  if (value === undefined || value.startsWith('--')) throw new Error(`${name} is required`)
+  return value
+}
+
+const parseArgs = (): {
+  readonly input: string
+  readonly repositoryRoot: string
+  readonly trustedRepository: string
+  readonly gitTimeoutMs: number
+} => ({
+  input: argument('--input'),
+  repositoryRoot: argument('--repository-root'),
+  trustedRepository: argument('--trusted-repository'),
+  gitTimeoutMs: process.argv.includes('--git-timeout-ms')
+    ? parsePositiveInteger('--git-timeout-ms', argument('--git-timeout-ms'))
+    : defaultGitTimeoutMs,
+})
 
 if (import.meta.main) {
   try {
     const args = parseArgs()
     const input = JSON.parse(await readFile(args.input, 'utf8')) as QualificationEligibilityInput
-    const result = evaluateQualificationEligibility(input)
+    const result = await verifyQualificationEligibility(input, args)
     process.stdout.write(`${JSON.stringify(result)}\n`)
     if (result.status === 'hold') process.exitCode = 1
   } catch (error) {

--- a/packages/scripts/src/bayn/verify-qualification-eligibility.ts
+++ b/packages/scripts/src/bayn/verify-qualification-eligibility.ts
@@ -192,6 +192,31 @@ const readOptionalMetadata = async (path: string, signal: AbortSignal): Promise<
   }
 }
 
+const readRawOriginUrl = async (
+  repositoryRoot: string,
+  git: QualificationGit,
+  signal: AbortSignal,
+): Promise<string> => {
+  let configured: string
+  try {
+    configured = await git.text(repositoryRoot, ['config', '--get-all', 'remote.origin.url'], signal)
+  } catch (error) {
+    throw new QualificationGitVerificationError(
+      'repository-identity-invalid',
+      'checked-out repository has no readable raw origin URL',
+      error,
+    )
+  }
+  const origins = activeMetadataLines(configured, false)
+  if (origins.length !== 1 || origins[0] === undefined) {
+    throw new QualificationGitVerificationError(
+      'repository-identity-invalid',
+      'checked-out repository must have exactly one raw origin URL',
+    )
+  }
+  return origins[0]
+}
+
 const verifyRepositoryIntegrity = async (
   repositoryRoot: string,
   git: QualificationGit,
@@ -218,14 +243,24 @@ const verifyRepositoryIntegrity = async (
   }
 
   const configuration = await git.text(repositoryRoot, ['config', '--list'], signal)
-  const replacementConfiguration = configuration
-    .split('\n')
-    .map((line) => line.slice(0, line.indexOf('=')))
-    .filter((key) => key.toLowerCase().startsWith('replace.'))
+  const configurationKeys = configuration.split('\n').map((line) => {
+    const separator = line.indexOf('=')
+    return (separator < 0 ? line : line.slice(0, separator)).trim().toLowerCase()
+  })
+  const replacementConfiguration = configurationKeys.filter((key) => key.startsWith('replace.'))
   if (replacementConfiguration.length > 0) {
     throw new QualificationGitVerificationError(
       'repository-integrity-invalid',
       'replacement configuration is forbidden during qualification history verification',
+    )
+  }
+  const urlRewriteConfiguration = configurationKeys.filter(
+    (key) => key.startsWith('url.') && (key.endsWith('.insteadof') || key.endsWith('.pushinsteadof')),
+  )
+  if (urlRewriteConfiguration.length > 0) {
+    throw new QualificationGitVerificationError(
+      'repository-integrity-invalid',
+      'Git URL rewrite configuration is forbidden during qualification repository verification',
     )
   }
 
@@ -364,7 +399,7 @@ const verifyRepositoryAndLineage = async (
   const [headSha, originMainSha, originUrl] = await Promise.all([
     git.text(root, ['rev-parse', 'HEAD'], signal),
     git.text(root, ['rev-parse', 'refs/remotes/origin/main'], signal),
-    git.text(root, ['remote', 'get-url', 'origin'], signal),
+    readRawOriginUrl(root, git, signal),
   ])
   if (headSha !== input.currentMainSha || originMainSha !== input.currentMainSha) {
     throw new QualificationGitVerificationError(
@@ -398,7 +433,7 @@ const verifyRepositoryAndLineage = async (
   const [finalHeadSha, finalOriginMainSha, finalOriginUrl] = await Promise.all([
     git.text(root, ['rev-parse', 'HEAD'], signal),
     git.text(root, ['rev-parse', 'refs/remotes/origin/main'], signal),
-    git.text(root, ['remote', 'get-url', 'origin'], signal),
+    readRawOriginUrl(root, git, signal),
   ])
   if (
     finalHeadSha !== input.currentMainSha ||


### PR DESCRIPTION
## Scope

This corrective PR fixes only the two verifier-integrity defects from merged PR #13419:

- require the preregistration source revision to be a strict proper ancestor of exact current source through bounded, cancellable, raw-parent Git verification
- require the checked-out origin and evidence repository to match an explicit trusted repository and bind its canonical hash into eligibility

It rejects equal, descendant, divergent, missing, replacement-ref, graft, alternate-object, shallow, changed-main, and foreign-repository histories. Git integrity and identity are rechecked after traversal.

This does **not** implement or claim completion of the separately recorded qualification collector/executor gap. The workflow remains dormant while `nextCandidatePreregistration` is null and still fails closed until that separate production boundary exists. No qualification or holdout access was performed.

## Validation

- focused verifier/workflow tests: 20 passed
- all `packages/scripts/src/bayn/*.test.ts`: 196 passed
- scripts lint, type-aware oxlint, and scripts CI TypeScript: passed
- Bayn oxlint and TypeScript: passed
- Bayn build: passed
- Bayn PostgreSQL command: passed; integration cases skipped without `BAYN_TEST_POSTGRES_URL`
- full scripts suite reached only the existing Docker-dependent test and stopped because Docker is unavailable locally
- full Bayn suite reached only the unrelated missing `candidate-development-candidate-17.test.ts` entry point

PROOMPT-437