### PR TITLE
fix(bayn): bind durable PAPER cycle decisions

### DIFF
--- a/services/bayn/migrations/0021_expired_paper_cycle_terminalization.ts
+++ b/services/bayn/migrations/0021_expired_paper_cycle_terminalization.ts
@@ -1,0 +1,746 @@
+import { Effect } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient
+
+  yield* sql`
+    ALTER TABLE autonomous_cycle_shadow_decisions
+      DROP CONSTRAINT IF EXISTS autonomous_cycle_shadow_decisions_schema_version_check,
+      DROP CONSTRAINT IF EXISTS autonomous_cycle_shadow_decisions_check,
+      DROP CONSTRAINT IF EXISTS autonomous_cycle_decisions_schema_version_check,
+      DROP CONSTRAINT IF EXISTS autonomous_cycle_decisions_document_check,
+      ADD CONSTRAINT autonomous_cycle_decisions_schema_version_check
+        CHECK (schema_version IN ('bayn.observe-shadow-decision.v1', 'bayn.paper-cycle-decision.v1')),
+      ADD CONSTRAINT autonomous_cycle_decisions_document_check
+        CHECK (
+          document ->> 'schemaVersion' = schema_version
+          AND (
+            (
+              schema_version = 'bayn.observe-shadow-decision.v1'
+              AND document ->> 'mode' = 'OBSERVE'
+              AND document ->> 'dispatchable' = 'false'
+            )
+            OR (
+              schema_version = 'bayn.paper-cycle-decision.v1'
+              AND document ->> 'mode' = 'PAPER'
+              AND (
+                document ->> 'dispatchable' = 'true'
+                OR (
+                  document ->> 'dispatchable' = 'false'
+                  AND jsonb_typeof(document -> 'riskBlock') = 'object'
+                )
+              )
+            )
+          )
+          AND document #>> '{bindings,cycleId}' = cycle_id
+          AND (document ->> 'createdAt')::timestamptz = created_at
+        )
+  `
+
+  yield* sql`
+    CREATE OR REPLACE FUNCTION paper_cycle_generation_is_superseded(
+      bound_cycle_id text,
+      bound_decision_hash text
+    )
+    RETURNS boolean
+    LANGUAGE sql
+    STABLE
+    AS $function$
+      WITH RECURSIVE bound_decision AS (
+        SELECT
+          decision.document #>> '{bindings,authorityGenerationHash}' AS generation_hash,
+          decision.document #>> '{bindings,accountId}' AS account_id,
+          decision.document #>> '{bindings,cycleId}' AS cycle_id,
+          decision.document #>> '{bindings,strategyDecisionHash}' AS strategy_decision_hash,
+          CASE
+            WHEN jsonb_typeof(decision.document -> 'orderedIntentIds') = 'array'
+              THEN decision.document -> 'orderedIntentIds'
+            ELSE '[]'::jsonb
+          END AS ordered_intent_ids
+        FROM autonomous_cycle_shadow_decisions AS decision
+        WHERE decision.cycle_id = bound_cycle_id
+          AND decision.decision_hash = bound_decision_hash
+          AND decision.document ->> 'schemaVersion' = 'bayn.paper-cycle-decision.v1'
+          AND decision.document ->> 'mode' = 'PAPER'
+      ), bound_generation AS (
+        SELECT generation_hash, account_id
+        FROM bound_decision
+      ), generation_lineage AS (
+        SELECT generation.generation_hash, generation.previous_generation_hash, 0 AS depth
+        FROM authority_generations AS generation
+        JOIN bound_generation AS bound
+          ON bound.generation_hash = generation.generation_hash
+        WHERE generation.maximum = 'PAPER'
+          AND generation.account_id = bound.account_id
+
+        UNION ALL
+
+        SELECT successor.generation_hash, successor.previous_generation_hash, lineage.depth + 1
+        FROM authority_generations AS successor
+        JOIN generation_lineage AS lineage
+          ON successor.previous_generation_hash = lineage.generation_hash
+      ), planned_intents AS (
+        SELECT
+          decision.account_id,
+          decision.cycle_id,
+          decision.strategy_decision_hash,
+          planned.intent_id
+        FROM bound_decision AS decision
+        CROSS JOIN LATERAL jsonb_array_elements_text(decision.ordered_intent_ids) AS planned(intent_id)
+      ), durable_intents AS (
+        SELECT
+          planned.intent_id,
+          intent.state
+        FROM planned_intents AS planned
+        LEFT JOIN intents AS intent
+          ON intent.intent_id = planned.intent_id
+          AND intent.account_id = planned.account_id
+          AND intent.cycle_id = planned.cycle_id
+          AND intent.decision_hash = planned.strategy_decision_hash
+      ), latest_mutations AS (
+        SELECT DISTINCT ON (event.intent_id)
+          event.intent_id,
+          event.operation,
+          event.event_type
+        FROM mutation_events AS event
+        JOIN planned_intents AS planned
+          ON planned.intent_id = event.intent_id
+        ORDER BY
+          event.intent_id,
+          CASE event.operation WHEN 'CANCEL' THEN 1 ELSE 0 END DESC,
+          event.sequence DESC
+      )
+      SELECT
+        EXISTS (
+          SELECT 1
+          FROM generation_lineage
+          WHERE depth > 0
+        )
+        AND NOT EXISTS (
+          SELECT 1
+          FROM latest_mutations AS mutation
+          JOIN durable_intents AS intent
+            ON intent.intent_id = mutation.intent_id
+          WHERE intent.state IS DISTINCT FROM 'TERMINAL'
+            OR (
+              mutation.operation = 'SUBMIT'
+              AND mutation.event_type NOT IN (
+                'SUBMIT_ACCEPTED',
+                'SUBMIT_REJECTED',
+                'SUBMIT_DENIED',
+                'RECOVERY_FOUND'
+              )
+            )
+            OR (
+              mutation.operation = 'CANCEL'
+              AND mutation.event_type <> 'RECOVERY_FOUND'
+            )
+        )
+    $function$
+  `
+
+  yield* sql`
+    CREATE OR REPLACE FUNCTION paper_account_has_unresolved_mutation(
+      bound_account_id text,
+      mutation_observed_at timestamptz
+    )
+    RETURNS boolean
+    LANGUAGE sql
+    STABLE
+    AS $function$
+      SELECT EXISTS (
+        SELECT 1
+        FROM intents AS account_intent
+        JOIN LATERAL (
+          SELECT
+            event.operation,
+            event.event_type
+          FROM mutation_events AS event
+          WHERE event.intent_id = account_intent.intent_id
+            AND event.occurred_at <= mutation_observed_at
+          ORDER BY
+            CASE event.operation WHEN 'CANCEL' THEN 1 ELSE 0 END DESC,
+            event.sequence DESC
+          LIMIT 1
+        ) AS latest ON true
+        WHERE account_intent.account_id = bound_account_id
+          AND (
+            account_intent.state <> 'TERMINAL'
+            OR (
+              latest.operation = 'SUBMIT'
+              AND latest.event_type NOT IN (
+                'SUBMIT_ACCEPTED',
+                'SUBMIT_REJECTED',
+                'SUBMIT_DENIED',
+                'RECOVERY_FOUND'
+              )
+            )
+            OR (
+              latest.operation = 'CANCEL'
+              AND latest.event_type <> 'RECOVERY_FOUND'
+            )
+          )
+      )
+    $function$
+  `
+
+  yield* sql`
+    CREATE OR REPLACE FUNCTION paper_cycle_completion_evidence_matches(
+      bound_cycle_id text,
+      bound_decision_hash text,
+      completion_observed_at timestamptz
+    )
+    RETURNS boolean
+    LANGUAGE sql
+    STABLE
+    AS $function$
+      SELECT EXISTS (
+        SELECT 1
+        FROM autonomous_cycles AS cycle
+        JOIN autonomous_cycle_shadow_decisions AS decision
+          ON decision.cycle_id = cycle.cycle_id
+          AND decision.decision_hash = cycle.decision_hash
+        CROSS JOIN LATERAL (
+          SELECT
+            CASE
+              WHEN jsonb_typeof(decision.document -> 'orderedIntentIds') = 'array'
+                THEN decision.document -> 'orderedIntentIds'
+              ELSE '[]'::jsonb
+            END AS ordered_intent_ids,
+            CASE
+              WHEN jsonb_typeof(decision.document -> 'deltaRisk') = 'array'
+                THEN decision.document -> 'deltaRisk'
+              ELSE '[]'::jsonb
+            END AS delta_risk
+        ) AS paper
+        WHERE cycle.cycle_id = bound_cycle_id
+          AND decision.decision_hash = bound_decision_hash
+          AND completion_observed_at >= cycle.updated_at
+          AND decision.document ->> 'schemaVersion' = 'bayn.paper-cycle-decision.v1'
+          AND decision.document ->> 'mode' = 'PAPER'
+          AND decision.document -> 'dispatchable' = 'true'::jsonb
+          AND decision.document -> 'riskBlock' IS NULL
+          AND decision.document #>> '{targetPlan,status}' = 'PLANNED'
+          AND jsonb_array_length(paper.ordered_intent_ids) > 0
+          AND jsonb_array_length(paper.ordered_intent_ids) = jsonb_array_length(paper.delta_risk)
+          AND NOT EXISTS (
+            SELECT 1
+            FROM jsonb_array_elements_text(paper.ordered_intent_ids) WITH ORDINALITY
+              AS planned(intent_id, intent_ordinal)
+            JOIN jsonb_array_elements(paper.delta_risk) WITH ORDINALITY
+              AS risk(entry, risk_ordinal)
+              ON risk.risk_ordinal = planned.intent_ordinal
+            LEFT JOIN intents AS intent
+              ON intent.intent_id = planned.intent_id
+            WHERE risk.entry #>> '{evaluation,input,intentId}' IS DISTINCT FROM planned.intent_id
+              OR risk.entry #>> '{evaluation,decision,outcome}' IS DISTINCT FROM 'APPROVED'
+              OR intent.intent_id IS NULL
+              OR intent.account_id IS DISTINCT FROM cycle.account_id
+              OR intent.cycle_id IS DISTINCT FROM cycle.cycle_id
+              OR intent.strategy_name IS DISTINCT FROM decision.document #>> '{bindings,strategyName}'
+              OR intent.decision_hash IS DISTINCT FROM decision.document #>> '{bindings,strategyDecisionHash}'
+              OR intent.policy_hash IS DISTINCT FROM decision.document #>> '{bindings,policyHash}'
+              OR intent.authority_generation_hash IS DISTINCT FROM
+                decision.document #>> '{bindings,authorityGenerationHash}'
+              OR intent.risk_decision_id IS DISTINCT FROM
+                risk.entry #>> '{evaluation,decision,decisionId}'
+              OR intent.state IS DISTINCT FROM 'TERMINAL'
+              OR intent.terminal_outcome IS DISTINCT FROM 'FILLED'
+          )
+          AND NOT EXISTS (
+            SELECT 1
+            FROM intents AS extra
+            WHERE extra.cycle_id = cycle.cycle_id
+              AND extra.decision_hash = decision.document #>> '{bindings,strategyDecisionHash}'
+              AND NOT (paper.ordered_intent_ids ? extra.intent_id)
+          )
+          AND NOT paper_account_has_unresolved_mutation(cycle.account_id, completion_observed_at)
+          AND NOT EXISTS (
+            SELECT 1
+            FROM orders AS unknown_order
+            WHERE unknown_order.account_id = cycle.account_id
+              AND unknown_order.intent_id IS NULL
+          )
+          AND EXISTS (
+            SELECT 1
+            FROM reconciliations AS reconciliation
+            CROSS JOIN LATERAL (
+              SELECT CASE
+                WHEN jsonb_typeof(reconciliation.discrepancies) = 'array'
+                  THEN reconciliation.discrepancies
+                ELSE '[]'::jsonb
+              END AS discrepancies
+            ) AS exact
+            WHERE reconciliation.account_id = cycle.account_id
+              AND reconciliation.status = 'EXACT'
+              AND reconciliation.expected_hash = reconciliation.observed_hash
+              AND jsonb_array_length(exact.discrepancies) = 0
+              AND reconciliation.reconciled_at > GREATEST(
+                (decision.document ->> 'createdAt')::timestamptz,
+                COALESCE(
+                  (
+                    SELECT max(intent.updated_at)
+                    FROM intents AS intent
+                    WHERE paper.ordered_intent_ids ? intent.intent_id
+                  ),
+                  (decision.document ->> 'createdAt')::timestamptz
+                ),
+                COALESCE(
+                  (
+                    SELECT max(event.occurred_at)
+                    FROM mutation_events AS event
+                    WHERE paper.ordered_intent_ids ? event.intent_id
+                  ),
+                  (decision.document ->> 'createdAt')::timestamptz
+                )
+              )
+              AND reconciliation.reconciled_at <= completion_observed_at
+          )
+      )
+    $function$
+  `
+
+  yield* sql`
+    CREATE OR REPLACE FUNCTION enforce_autonomous_cycle_lifecycle()
+    RETURNS trigger
+    LANGUAGE plpgsql
+    AS $function$
+    DECLARE
+      mutable_columns text[] := ARRAY[
+        'state',
+        'snapshot_id',
+        'decision_hash',
+        'terminal_reason',
+        'state_version',
+        'updated_at',
+        'terminal_at'
+      ];
+      expected_target_status text;
+    BEGIN
+      IF TG_OP = 'DELETE' THEN
+        RAISE EXCEPTION 'autonomous cycles cannot be deleted' USING ERRCODE = '55000';
+      END IF;
+
+      IF TG_OP = 'INSERT' THEN
+        IF NEW.state_version <> 1 OR NEW.created_at <> NEW.updated_at OR NOT (
+          (NEW.state = 'PENDING' AND NEW.snapshot_id IS NULL AND NEW.decision_hash IS NULL)
+          OR (
+            NEW.state = 'BLOCKED'
+            AND NEW.snapshot_id IS NULL
+            AND NEW.decision_hash IS NULL
+            AND NEW.terminal_reason = 'BLOCKED_MISSED_PUBLICATION_DEADLINE'
+            AND NEW.updated_at >= NEW.publication_deadline_at
+          )
+        ) THEN
+          RAISE EXCEPTION 'invalid initial autonomous cycle state' USING ERRCODE = '23514';
+        END IF;
+        RETURN NEW;
+      END IF;
+
+      IF OLD.state IN ('COMPLETED', 'NO_TRADE', 'BLOCKED') THEN
+        RAISE EXCEPTION 'terminal autonomous cycle history cannot change' USING ERRCODE = '55000';
+      END IF;
+
+      IF (OLD.state, NEW.state) NOT IN (
+        ('PENDING', 'PENDING'),
+        ('PENDING', 'ACTIVE'),
+        ('PENDING', 'BLOCKED'),
+        ('ACTIVE', 'ACTIVE'),
+        ('ACTIVE', 'COMPLETED'),
+        ('ACTIVE', 'NO_TRADE'),
+        ('ACTIVE', 'BLOCKED')
+      ) THEN
+        RAISE EXCEPTION 'invalid autonomous cycle state transition' USING ERRCODE = '23514';
+      END IF;
+      IF OLD.state = NEW.state AND NOT (
+        (
+          OLD.state = 'PENDING'
+          AND OLD.snapshot_id IS NULL
+          AND NEW.snapshot_id IS NOT NULL
+          AND NEW.decision_hash IS NOT DISTINCT FROM OLD.decision_hash
+        )
+        OR (
+          OLD.state = 'ACTIVE'
+          AND NEW.snapshot_id IS NOT DISTINCT FROM OLD.snapshot_id
+          AND OLD.decision_hash IS NULL
+          AND NEW.decision_hash IS NOT NULL
+        )
+      ) THEN
+        RAISE EXCEPTION 'invalid autonomous cycle binding transition' USING ERRCODE = '23514';
+      END IF;
+      IF OLD.state <> NEW.state AND (
+        NEW.snapshot_id IS DISTINCT FROM OLD.snapshot_id
+        OR NEW.decision_hash IS DISTINCT FROM OLD.decision_hash
+      ) THEN
+        RAISE EXCEPTION 'autonomous cycle state transitions cannot change bindings' USING ERRCODE = '23514';
+      END IF;
+      IF to_jsonb(OLD) - mutable_columns <> to_jsonb(NEW) - mutable_columns THEN
+        RAISE EXCEPTION 'autonomous cycle identity and deadlines cannot change' USING ERRCODE = '55000';
+      END IF;
+      IF NEW.state_version <> OLD.state_version + 1 OR NEW.updated_at < OLD.updated_at THEN
+        RAISE EXCEPTION 'autonomous cycle version and time must advance monotonically' USING ERRCODE = '23514';
+      END IF;
+      IF OLD.snapshot_id IS NULL AND NEW.snapshot_id IS NOT NULL THEN
+        IF NEW.updated_at < NEW.signal_close_at THEN
+          RAISE EXCEPTION 'autonomous cycle snapshot cannot bind before signal close' USING ERRCODE = '23514';
+        END IF;
+        IF NEW.updated_at >= NEW.publication_deadline_at THEN
+          RAISE EXCEPTION 'autonomous cycle snapshot missed publication deadline' USING ERRCODE = '23514';
+        END IF;
+        IF NOT EXISTS (
+          SELECT 1
+          FROM snapshot_references
+          WHERE snapshot_id = NEW.snapshot_id
+            AND last_session = NEW.signal_session_date
+            AND manifest->>'calendarVersion' = NEW.signal_calendar_version
+        ) THEN
+          RAISE EXCEPTION 'autonomous cycle snapshot does not match signal session and calendar'
+            USING ERRCODE = '23514';
+        END IF;
+      END IF;
+      IF NEW.state = 'ACTIVE' AND NEW.updated_at >= NEW.submission_cutoff_at THEN
+        RAISE EXCEPTION 'autonomous cycle activation or decision missed submission cutoff' USING ERRCODE = '23514';
+      END IF;
+      IF NEW.state IN ('COMPLETED', 'NO_TRADE') THEN
+        expected_target_status := CASE NEW.state
+          WHEN 'COMPLETED' THEN 'PLANNED'
+          ELSE 'NO_TRADE'
+        END;
+        IF NOT EXISTS (
+          SELECT 1
+          FROM autonomous_cycle_shadow_decisions
+          WHERE cycle_id = NEW.cycle_id
+            AND decision_hash = NEW.decision_hash
+            AND document #>> '{targetPlan,status}' = expected_target_status
+            AND NOT paper_account_has_unresolved_mutation(NEW.account_id, NEW.updated_at)
+            AND NOT (
+              document ->> 'mode' = 'PAPER'
+              AND document ->> 'dispatchable' = 'false'
+              AND jsonb_typeof(document -> 'riskBlock') = 'object'
+            )
+            AND (
+              document ->> 'mode' <> 'PAPER'
+              OR NEW.state = 'NO_TRADE'
+              OR paper_cycle_completion_evidence_matches(
+                NEW.cycle_id,
+                NEW.decision_hash,
+                NEW.updated_at
+              )
+            )
+        ) THEN
+          RAISE EXCEPTION 'autonomous cycle terminal state does not match its shadow decision'
+            USING ERRCODE = '23514';
+        END IF;
+      END IF;
+      IF NEW.state = 'BLOCKED' AND OLD.state = 'ACTIVE' AND OLD.decision_hash IS NOT NULL THEN
+        IF NOT EXISTS (
+          SELECT 1
+          FROM autonomous_cycle_shadow_decisions AS decision
+          CROSS JOIN LATERAL (
+            SELECT
+              CASE
+                WHEN jsonb_typeof(decision.document -> 'orderedIntentIds') = 'array'
+                  THEN decision.document -> 'orderedIntentIds'
+                ELSE '[]'::jsonb
+              END AS ordered_intent_ids,
+              CASE
+                WHEN jsonb_typeof(decision.document -> 'deltaRisk') = 'array'
+                  THEN decision.document -> 'deltaRisk'
+                ELSE '[]'::jsonb
+              END AS delta_risk,
+              CASE
+                WHEN jsonb_typeof(decision.document #> '{riskBlock,reasonCodes}') = 'array'
+                  THEN decision.document #> '{riskBlock,reasonCodes}'
+                ELSE '[]'::jsonb
+              END AS risk_block_reason_codes
+          ) AS paper
+          WHERE decision.cycle_id = NEW.cycle_id
+            AND decision.decision_hash = NEW.decision_hash
+            AND NOT paper_account_has_unresolved_mutation(NEW.account_id, NEW.updated_at)
+            AND (
+              (
+                decision.document #>> '{targetPlan,status}' = 'BLOCKED'
+                AND NEW.terminal_reason = CASE decision.document #>> '{targetPlan,reason}'
+                  WHEN 'SUBMISSION_CUTOFF_REACHED' THEN 'BLOCKED_MISSED_SUBMISSION_DEADLINE'
+                  WHEN 'IDENTITY_MISMATCH' THEN 'BLOCKED_PROVENANCE_MISMATCH'
+                  WHEN 'INPUT_MISMATCH' THEN 'BLOCKED_DATA_INVALID'
+                  WHEN 'INPUT_STALE' THEN 'BLOCKED_DATA_STALE'
+                  WHEN 'RECONCILIATION_NOT_EXACT' THEN 'BLOCKED_RECONCILIATION'
+                  WHEN 'ACCOUNT_NOT_ACTIVE' THEN 'BLOCKED_BROKER_DISABLED'
+                  WHEN 'UNKNOWN_ORDER' THEN 'BLOCKED_UNRESOLVED_MUTATION'
+                  WHEN 'UNRESOLVED_ORDER' THEN 'BLOCKED_UNRESOLVED_MUTATION'
+                  WHEN 'BELOW_MINIMUM_BUY_NOTIONAL' THEN 'BLOCKED_RISK'
+                  WHEN 'INSUFFICIENT_BUYING_POWER' THEN 'BLOCKED_RISK'
+                  WHEN 'NON_POSITIVE_EQUITY' THEN 'BLOCKED_RISK'
+                  WHEN 'SHORT_POSITION_NOT_ALLOWED' THEN 'BLOCKED_RISK'
+                  ELSE NULL
+                END
+              )
+              OR (
+                decision.document ->> 'schemaVersion' = 'bayn.paper-cycle-decision.v1'
+                AND decision.document ->> 'mode' = 'PAPER'
+                AND decision.document #>> '{targetPlan,status}' = 'PLANNED'
+                AND decision.document #>> '{bindings,cycleId}' = NEW.cycle_id
+                AND decision.document #>> '{bindings,qualificationRunId}' = NEW.qualification_run_id
+                AND decision.document #>> '{bindings,accountId}' = NEW.account_id
+                AND (decision.document ->> 'submissionCutoffAt')::timestamptz = NEW.submission_cutoff_at
+                AND (decision.document ->> 'expiresAt')::timestamptz = NEW.submission_cutoff_at
+                AND (
+                  (
+                    NEW.terminal_reason = 'BLOCKED_PROVENANCE_MISMATCH'
+                    AND paper_cycle_generation_is_superseded(
+                      NEW.cycle_id,
+                      NEW.decision_hash
+                    )
+                  )
+                  OR (
+                    decision.document -> 'dispatchable' = 'false'::jsonb
+                    AND NEW.terminal_reason = 'BLOCKED_RISK'
+                    AND NEW.updated_at >= (decision.document ->> 'createdAt')::timestamptz
+                    AND jsonb_typeof(decision.document -> 'riskBlock') = 'object'
+                    AND jsonb_array_length(paper.ordered_intent_ids) > 0
+                    AND jsonb_array_length(paper.ordered_intent_ids) = jsonb_array_length(paper.delta_risk)
+                    AND decision.document #>> '{riskBlock,intentId}' =
+                      paper.ordered_intent_ids ->> (jsonb_array_length(paper.ordered_intent_ids) - 1)
+                    AND decision.document #>> '{riskBlock,decisionId}' =
+                      paper.delta_risk #>> ARRAY[
+                        (jsonb_array_length(paper.delta_risk) - 1)::text,
+                        'evaluation',
+                        'decision',
+                        'decisionId'
+                      ]
+                    AND decision.document #> '{riskBlock,reasonCodes}' =
+                      paper.delta_risk #> ARRAY[
+                        (jsonb_array_length(paper.delta_risk) - 1)::text,
+                        'evaluation',
+                        'decision',
+                        'reasonCodes'
+                      ]
+                    AND paper.delta_risk #>> ARRAY[
+                      (jsonb_array_length(paper.delta_risk) - 1)::text,
+                      'evaluation',
+                      'decision',
+                      'outcome'
+                    ] = 'BLOCKED'
+                    AND jsonb_array_length(paper.risk_block_reason_codes) > 0
+                    AND NOT (paper.risk_block_reason_codes ? 'AUTHORITY_NOT_PAPER')
+                    AND NOT EXISTS (
+                      SELECT 1
+                      FROM jsonb_array_elements_text(paper.ordered_intent_ids) WITH ORDINALITY
+                        AS blocked(intent_id, intent_ordinal)
+                      JOIN jsonb_array_elements(paper.delta_risk) WITH ORDINALITY
+                        AS risk(entry, risk_ordinal)
+                        ON risk.risk_ordinal = blocked.intent_ordinal
+                      WHERE risk.entry #>> '{evaluation,input,intentId}' IS DISTINCT FROM blocked.intent_id
+                        OR (
+                          blocked.intent_ordinal < jsonb_array_length(paper.ordered_intent_ids)
+                          AND risk.entry #>> '{evaluation,decision,outcome}' <> 'APPROVED'
+                        )
+                        OR (
+                          blocked.intent_ordinal = jsonb_array_length(paper.ordered_intent_ids)
+                          AND risk.entry #>> '{evaluation,decision,outcome}' <> 'BLOCKED'
+                        )
+                    )
+                    AND NOT EXISTS (
+                      SELECT 1
+                      FROM jsonb_array_elements_text(paper.ordered_intent_ids) AS blocked(intent_id)
+                      WHERE EXISTS (SELECT 1 FROM intents WHERE intent_id = blocked.intent_id)
+                        OR EXISTS (SELECT 1 FROM mutation_events WHERE intent_id = blocked.intent_id)
+                        OR EXISTS (SELECT 1 FROM orders WHERE intent_id = blocked.intent_id)
+                    )
+                  )
+                  OR (
+                    decision.document -> 'dispatchable' = 'true'::jsonb
+                    AND jsonb_array_length(paper.ordered_intent_ids) > 0
+                    AND jsonb_array_length(paper.ordered_intent_ids) = jsonb_array_length(paper.delta_risk)
+                    AND (
+                      (
+                        NOT EXISTS (
+                          SELECT 1
+                          FROM jsonb_array_elements_text(paper.ordered_intent_ids) AS planned(intent_id)
+                          WHERE EXISTS (
+                            SELECT 1
+                            FROM mutation_events AS event
+                            WHERE event.intent_id = planned.intent_id
+                          )
+                            AND NOT EXISTS (
+                              SELECT 1
+                              FROM intents AS intent
+                              WHERE intent.intent_id = planned.intent_id
+                                AND intent.state = 'TERMINAL'
+                                AND intent.terminal_outcome = 'FILLED'
+                            )
+                        )
+                        AND EXISTS (
+                          SELECT 1
+                          FROM jsonb_array_elements_text(paper.ordered_intent_ids) WITH ORDINALITY
+                            AS planned(intent_id, intent_ordinal)
+                          JOIN jsonb_array_elements(paper.delta_risk) WITH ORDINALITY
+                            AS risk(entry, risk_ordinal)
+                            ON risk.risk_ordinal = planned.intent_ordinal
+                          WHERE risk.entry #>> '{evaluation,decision,outcome}' = 'APPROVED'
+                            AND risk.entry #>> '{evaluation,input,intentId}' = planned.intent_id
+                            AND NOT EXISTS (
+                              SELECT 1
+                              FROM intents AS candidate
+                              WHERE candidate.intent_id = planned.intent_id
+                                AND (
+                                  candidate.state <> 'APPROVED'
+                                  OR candidate.terminal_outcome IS NOT NULL
+                                )
+                            )
+                            AND NOT EXISTS (
+                              SELECT 1
+                              FROM mutation_events AS event
+                              WHERE event.intent_id = planned.intent_id
+                            )
+                            AND NOT EXISTS (
+                              SELECT 1
+                              FROM orders AS broker_order
+                              WHERE broker_order.intent_id = planned.intent_id
+                            )
+                            AND NOT EXISTS (
+                              SELECT 1
+                              FROM jsonb_array_elements_text(paper.ordered_intent_ids) WITH ORDINALITY
+                                AS predecessor(intent_id, intent_ordinal)
+                              WHERE predecessor.intent_ordinal < planned.intent_ordinal
+                                AND NOT EXISTS (
+                                  SELECT 1
+                                  FROM intents AS settled
+                                  WHERE settled.intent_id = predecessor.intent_id
+                                    AND settled.state = 'TERMINAL'
+                                    AND settled.terminal_outcome = 'FILLED'
+                                )
+                            )
+                            AND (
+                              (
+                                NEW.terminal_reason = 'BLOCKED_MISSED_SUBMISSION_DEADLINE'
+                                AND NEW.updated_at >= NEW.submission_cutoff_at
+                              )
+                              OR (
+                                NEW.terminal_reason = 'BLOCKED_RISK'
+                                AND NEW.updated_at < NEW.submission_cutoff_at
+                                AND (risk.entry #>> '{evaluation,decision,expiresAt}')::timestamptz <= NEW.updated_at
+                              )
+                            )
+                        )
+                      )
+                      OR (
+                        NEW.terminal_reason = 'BLOCKED_RISK'
+                        AND EXISTS (
+                          SELECT 1
+                          FROM jsonb_array_elements_text(paper.ordered_intent_ids) WITH ORDINALITY
+                            AS failed(intent_id, intent_ordinal)
+                          JOIN jsonb_array_elements(paper.delta_risk) WITH ORDINALITY
+                            AS risk(entry, risk_ordinal)
+                            ON risk.risk_ordinal = failed.intent_ordinal
+                          JOIN intents AS failed_intent
+                            ON failed_intent.intent_id = failed.intent_id
+                          WHERE risk.entry #>> '{evaluation,decision,outcome}' = 'APPROVED'
+                            AND risk.entry #>> '{evaluation,input,intentId}' = failed.intent_id
+                            AND risk.entry #>> '{evaluation,decision,decisionId}' = failed_intent.risk_decision_id
+                            AND failed_intent.account_id = NEW.account_id
+                            AND failed_intent.cycle_id = NEW.cycle_id
+                            AND failed_intent.decision_hash = decision.document #>> '{bindings,strategyDecisionHash}'
+                            AND failed_intent.strategy_name = decision.document #>> '{bindings,strategyName}'
+                            AND failed_intent.policy_hash = decision.document #>> '{bindings,policyHash}'
+                            AND failed_intent.authority_generation_hash =
+                              decision.document #>> '{bindings,authorityGenerationHash}'
+                            AND failed_intent.state = 'TERMINAL'
+                            AND failed_intent.terminal_outcome IN ('CANCELED', 'EXPIRED', 'REJECTED', 'BLOCKED')
+                            AND failed_intent.updated_at <= NEW.updated_at
+                            AND EXISTS (
+                              SELECT 1
+                              FROM LATERAL (
+                                SELECT event.operation, event.event_type
+                                FROM mutation_events AS event
+                                WHERE event.intent_id = failed.intent_id
+                                  AND event.occurred_at <= NEW.updated_at
+                                ORDER BY
+                                  CASE event.operation WHEN 'CANCEL' THEN 1 ELSE 0 END DESC,
+                                  event.sequence DESC
+                                LIMIT 1
+                              ) AS terminal_event
+                              WHERE (
+                                terminal_event.operation = 'SUBMIT'
+                                AND terminal_event.event_type IN (
+                                  'SUBMIT_ACCEPTED',
+                                  'SUBMIT_REJECTED',
+                                  'SUBMIT_DENIED',
+                                  'RECOVERY_FOUND'
+                                )
+                              ) OR (
+                                terminal_event.operation = 'CANCEL'
+                                AND terminal_event.event_type = 'RECOVERY_FOUND'
+                              )
+                            )
+                            AND NOT EXISTS (
+                              SELECT 1
+                              FROM jsonb_array_elements_text(paper.ordered_intent_ids) WITH ORDINALITY
+                                AS predecessor(intent_id, intent_ordinal)
+                              WHERE predecessor.intent_ordinal < failed.intent_ordinal
+                                AND NOT EXISTS (
+                                  SELECT 1
+                                  FROM intents AS settled
+                                  WHERE settled.intent_id = predecessor.intent_id
+                                    AND settled.account_id = NEW.account_id
+                                    AND settled.cycle_id = NEW.cycle_id
+                                    AND settled.decision_hash = decision.document #>> '{bindings,strategyDecisionHash}'
+                                    AND settled.state = 'TERMINAL'
+                                    AND settled.terminal_outcome = 'FILLED'
+                                )
+                            )
+                            AND NOT EXISTS (
+                              SELECT 1
+                              FROM jsonb_array_elements_text(paper.ordered_intent_ids) AS other(intent_id)
+                              WHERE other.intent_id <> failed.intent_id
+                                AND EXISTS (
+                                  SELECT 1
+                                  FROM mutation_events AS other_event
+                                  WHERE other_event.intent_id = other.intent_id
+                                )
+                                AND NOT EXISTS (
+                                  SELECT 1
+                                  FROM intents AS settled
+                                  WHERE settled.intent_id = other.intent_id
+                                    AND settled.state = 'TERMINAL'
+                                    AND settled.terminal_outcome = 'FILLED'
+                                )
+                            )
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+        ) THEN
+          RAISE EXCEPTION 'autonomous cycle blocked reason does not match its blocked, expired, or terminal-failed PAPER decision'
+            USING ERRCODE = '23514';
+        END IF;
+      END IF;
+      IF (
+        NEW.state = 'BLOCKED'
+        AND NEW.terminal_reason = 'BLOCKED_MISSED_PUBLICATION_DEADLINE'
+        AND (
+          OLD.state <> 'PENDING'
+          OR OLD.snapshot_id IS NOT NULL
+          OR NEW.updated_at < NEW.publication_deadline_at
+        )
+      ) THEN
+        RAISE EXCEPTION 'invalid missed-publication transition' USING ERRCODE = '23514';
+      END IF;
+      IF (
+        NEW.state = 'BLOCKED'
+        AND NEW.terminal_reason = 'BLOCKED_MISSED_SUBMISSION_DEADLINE'
+        AND NEW.updated_at < NEW.submission_cutoff_at
+      ) THEN
+        RAISE EXCEPTION 'invalid missed-submission transition' USING ERRCODE = '23514';
+      END IF;
+
+      RETURN NEW;
+    END
+    $function$
+  `
+})

--- a/services/bayn/src/cycle-runner.test.ts
+++ b/services/bayn/src/cycle-runner.test.ts
@@ -50,6 +50,7 @@ import {
 } from './cycle-runner'
 import { CycleNotDueReconciliationError } from './cycle-runner/model'
 import { runAutonomousCycleUntilSettled } from './cycle-runner/program'
+import { selectBoundDecision } from './cycle-runner/recovery-decision-binding'
 import { selectCycleRecovery, type CycleRecoveryState } from './cycle-recovery'
 import { CycleStore, type CycleAuthoritySlot, type CycleStoreShape } from './db/cycle-store'
 import { canonicalHashV1, sha256 } from './hash'
@@ -59,7 +60,11 @@ import {
   type MarketDataInspection,
   type MarketDataService,
 } from './market-data'
-import { makeObserveShadowDecisionDocument, type ObserveShadowDecisionDocument } from './shadow-decision-contract'
+import {
+  makeObserveShadowDecisionDocument,
+  type CycleDecisionDocument,
+  type ObserveShadowDecisionDocument,
+} from './shadow-decision-contract'
 import { TargetPlanReason, TargetPlanStatus } from './target-planner'
 import { currentUtcInstant } from './time'
 import { DataFeed, DataSource, PriceAdjustment, PublicationSchema, type InputManifest, type IsoDate } from './types'
@@ -410,7 +415,7 @@ interface StoreControl {
 interface CycleStorePersistence {
   readonly cycles: Map<string, AutonomousCycle>
   readonly slots: Map<string, string>
-  readonly documents: Map<string, ObserveShadowDecisionDocument>
+  readonly documents: Map<string, CycleDecisionDocument>
   readonly manifests: Map<string, InputManifest>
 }
 
@@ -682,6 +687,10 @@ describe('autonomous cycle runner', () => {
       stateVersion: pending.stateVersion + 1,
       updatedAt: '2026-01-30T21:21:00.000Z',
     }
+    const sameInstantBound: AutonomousCycle = {
+      ...bound,
+      updatedAt: pending.updatedAt,
+    }
     const active: AutonomousCycle = {
       ...bound,
       state: CycleState.Active,
@@ -738,6 +747,26 @@ describe('autonomous cycle runner', () => {
         }),
       ),
     ).toEqual(Result.succeed({ action: 'ACTIVATE', cycleId: bound.identity.cycleId, observedAt: bound.updatedAt }))
+    expect(
+      selectCycleRecovery(
+        recoveryState(pending, {
+          observedAt: pending.updatedAt,
+          readiness: {
+            outcome: 'ALREADY_BOUND',
+            observedAt: pending.updatedAt,
+            cycle: sameInstantBound,
+            snapshotId,
+          },
+        }),
+      ),
+    ).toMatchObject({
+      _tag: 'Success',
+      success: {
+        action: 'RETURN_READINESS',
+        recoveryAction: 'BOUND_SNAPSHOT',
+        result: { outcome: 'BOUND', cycle: { stateVersion: pending.stateVersion + 1 } },
+      },
+    })
     expect(selectCycleRecovery(recoveryState(active))).toEqual(
       Result.succeed({
         action: 'WAIT',
@@ -830,6 +859,44 @@ describe('autonomous cycle runner', () => {
         state: CycleState.NoTrade,
       }),
     )
+
+    const paperDecision = {
+      ...decision,
+      schemaVersion: 'bayn.paper-cycle-decision.v1',
+      mode: 'PAPER',
+      dispatchable: true,
+      bindings: {
+        ...decision.bindings,
+        qualificationRunId: decisionBound.identity.qualificationRunId,
+        authorityGenerationHash: 'b'.repeat(64),
+      },
+      targetPlan: { ...decision.targetPlan, status: TargetPlanStatus.Planned, reason: null },
+      orderedIntentIds: [],
+      contentHash: 'c'.repeat(64),
+    } as unknown as CycleDecisionDocument
+    const paperDecisionBound = {
+      ...decisionBound,
+      bindings: { ...decisionBound.bindings, decisionHash: paperDecision.contentHash },
+    }
+    expect(selectBoundDecision(paperDecisionBound, paperDecision, afterCutoff)).toEqual(
+      Result.succeed({ action: 'WAIT', cycle: paperDecisionBound, observedAt: afterCutoff }),
+    )
+    expect(
+      Result.isFailure(
+        selectBoundDecision(
+          paperDecisionBound,
+          {
+            ...paperDecision,
+            bindings: {
+              ...paperDecision.bindings,
+              qualificationRunId: 'd'.repeat(64),
+              authorityGenerationHash: 'b'.repeat(64),
+            },
+          } as CycleDecisionDocument,
+          afterCutoff,
+        ),
+      ),
+    ).toBe(true)
 
     const blockedDecision = makeDecision(active, decision.createdAt, TargetPlanReason.InputStale)
     const blockedDecisionBound: AutonomousCycle = {

--- a/services/bayn/src/cycle-runner/model.ts
+++ b/services/bayn/src/cycle-runner/model.ts
@@ -4,7 +4,7 @@ import type { AutonomousCycle, CycleExecutionPolicy } from '../cycle'
 import type { CyclePublicationReadiness } from '../cycle-readiness'
 import type { CycleAcquireReceipt } from '../db/cycle-store'
 import type { SignalSessionRow } from '../market-data'
-import type { ObserveShadowDecisionDocument } from '../shadow-decision-contract'
+import type { CycleDecisionDocument } from '../shadow-decision-contract'
 
 type SignalCycleSession = Pick<SignalSessionRow, 'calendar_version' | 'session_date' | 'close_time' | 'timezone'>
 
@@ -28,7 +28,7 @@ export interface CycleRunContext<R = never> {
   readonly buildDecision: (
     cycle: AutonomousCycle,
     reconciliationCompleted?: Effect.Effect<void>,
-  ) => Effect.Effect<ObserveShadowDecisionDocument, CycleDecisionBuildError, R>
+  ) => Effect.Effect<CycleDecisionDocument, CycleDecisionBuildError, R>
 }
 
 export interface CycleCandidate {

--- a/services/bayn/src/cycle-runner/recovery-decision-binding.ts
+++ b/services/bayn/src/cycle-runner/recovery-decision-binding.ts
@@ -1,7 +1,7 @@
 import { Result } from 'effect'
 
 import { CycleState, CycleTerminalReason, type AutonomousCycle, type CycleCompletionState } from '../cycle'
-import type { ObserveShadowDecisionDocument } from '../shadow-decision-contract'
+import type { CycleDecisionDocument } from '../shadow-decision-contract'
 import { TargetPlanReason, TargetPlanStatus, type BlockedTargetPlanReason } from '../target-planner'
 import {
   selectRecoveryFailure,
@@ -12,13 +12,15 @@ import {
 
 const validateDecisionBinding = (
   cycle: AutonomousCycle,
-  document: ObserveShadowDecisionDocument,
+  document: CycleDecisionDocument,
 ): Result.Result<void, CycleRecoveryFailure> => {
   const facts = {
     expectedAccountId: cycle.identity.accountId,
     actualAccountId: document.bindings.accountId,
     expectedCycleId: cycle.identity.cycleId,
     actualCycleId: document.bindings.cycleId,
+    expectedQualificationRunId: cycle.identity.qualificationRunId,
+    actualQualificationRunId: document.mode === 'PAPER' ? document.bindings.qualificationRunId : undefined,
     expectedCycleStateVersion: cycle.stateVersion,
     actualDocumentCreatedAt: document.createdAt,
     expectedDecisionHash: cycle.bindings.decisionHash,
@@ -38,6 +40,7 @@ const validateDecisionBinding = (
   return cycle.bindings.decisionHash !== document.contentHash ||
     cycle.bindings.snapshotId !== document.bindings.snapshotId ||
     cycle.identity.cycleId !== document.bindings.cycleId ||
+    (document.mode === 'PAPER' && document.bindings.qualificationRunId !== cycle.identity.qualificationRunId) ||
     cycle.identity.strategyName !== document.bindings.strategyName ||
     cycle.identity.strategyProtocolHash !== document.bindings.strategyProtocolHash ||
     cycle.identity.accountId !== document.bindings.accountId ||
@@ -93,7 +96,7 @@ export const cycleCompletionStateForTargetPlan = (
 
 export const selectBoundDecision = (
   cycle: AutonomousCycle,
-  document: ObserveShadowDecisionDocument | null | undefined,
+  document: CycleDecisionDocument | null | undefined,
   observedAt: string,
 ): Result.Result<CycleRecoverySelection, CycleRecoveryFailure> => {
   if (document === undefined) return Result.succeed({ action: 'READ_DECISION', cycle })
@@ -109,6 +112,14 @@ export const selectBoundDecision = (
     (): Result.Result<CycleRecoverySelection, CycleRecoveryFailure> => {
       switch (document.targetPlan.status) {
         case TargetPlanStatus.Planned:
+          return document.mode === 'PAPER'
+            ? Result.succeed({ action: 'WAIT', cycle, observedAt })
+            : Result.succeed({
+                action: 'FINISH',
+                cycleId: cycle.identity.cycleId,
+                observedAt,
+                state: cycleCompletionStateForTargetPlan(document.targetPlan.status),
+              })
         case TargetPlanStatus.NoTrade:
           return Result.succeed({
             action: 'FINISH',

--- a/services/bayn/src/cycle-runner/recovery-model.ts
+++ b/services/bayn/src/cycle-runner/recovery-model.ts
@@ -1,7 +1,8 @@
-import { Data, Schema } from 'effect'
+import { Data, Result, Schema } from 'effect'
 
 import {
   AutonomousCycleSchema,
+  CycleState,
   type ActiveDecisionBoundCycle,
   type ActiveUnboundCycle,
   type AutonomousCycle,
@@ -9,7 +10,7 @@ import {
   type PendingCycle,
 } from '../cycle'
 import type { CyclePublicationReadiness } from '../cycle-readiness'
-import { ObserveShadowDecisionDocumentSchema, type ObserveShadowDecisionDocument } from '../shadow-decision-contract'
+import { CycleDecisionDocumentSchema, type CycleDecisionDocument } from '../shadow-decision-contract'
 import {
   NonNegativeFiniteSchema,
   Sha256Schema,
@@ -64,7 +65,7 @@ export interface CycleRecoveryState {
   readonly observedAt: string
   readonly cycle: AutonomousCycle | undefined
   readonly readiness?: CyclePublicationReadiness
-  readonly decisionDocument?: ObserveShadowDecisionDocument | null
+  readonly decisionDocument?: CycleDecisionDocument | null
 }
 
 type RecoveryScope = Pick<
@@ -91,7 +92,7 @@ export type CorrelatedCycleRecoveryState =
   | (RecoveryScope & {
       readonly cycle: ActiveDecisionBoundCycle
       readonly readiness?: undefined
-      readonly decisionDocument?: ObserveShadowDecisionDocument | null
+      readonly decisionDocument?: CycleDecisionDocument | null
     })
 
 interface DecodeRecoveryStateIssue {
@@ -192,8 +193,35 @@ const CycleRecoveryStateSchema = Schema.Struct({
   observedAt: UtcInstantSchema,
   cycle: Schema.UndefinedOr(AutonomousCycleSchema),
   readiness: Schema.optionalKey(CyclePublicationReadinessSchema),
-  decisionDocument: Schema.optionalKey(Schema.NullOr(ObserveShadowDecisionDocumentSchema)),
+  decisionDocument: Schema.optionalKey(Schema.NullOr(CycleDecisionDocumentSchema)),
 })
 
 export type DecodedCycleRecoveryState = typeof CycleRecoveryStateSchema.Type
-export const decodeCycleRecoveryStateResult = Schema.decodeUnknownResult(CycleRecoveryStateSchema, strictParseOptions)
+
+const normalizeSameInstantConcurrentSnapshotBinding = (state: DecodedCycleRecoveryState): DecodedCycleRecoveryState => {
+  const { cycle, readiness } = state
+  if (
+    cycle === undefined ||
+    cycle.state !== CycleState.Pending ||
+    cycle.bindings.snapshotId !== undefined ||
+    readiness?.outcome !== 'ALREADY_BOUND' ||
+    readiness.cycle.identity.cycleId !== cycle.identity.cycleId ||
+    readiness.cycle.state !== CycleState.Pending ||
+    readiness.cycle.bindings.snapshotId !== readiness.snapshotId ||
+    readiness.cycle.bindings.decisionHash !== undefined ||
+    readiness.cycle.stateVersion !== cycle.stateVersion + 1 ||
+    readiness.cycle.updatedAt !== cycle.updatedAt ||
+    readiness.observedAt !== cycle.updatedAt
+  ) {
+    return state
+  }
+  return {
+    ...state,
+    readiness: { ...readiness, outcome: 'BOUND' },
+  }
+}
+
+const decodeCycleRecoveryState = Schema.decodeUnknownResult(CycleRecoveryStateSchema, strictParseOptions)
+
+export const decodeCycleRecoveryStateResult = (input: unknown) =>
+  Result.map(decodeCycleRecoveryState(input), normalizeSameInstantConcurrentSnapshotBinding)

--- a/services/bayn/src/db/cycle-store/binding-program.ts
+++ b/services/bayn/src/db/cycle-store/binding-program.ts
@@ -3,7 +3,7 @@ import { Effect, Match } from 'effect'
 
 import { CycleState } from '../../cycle'
 import { decodeInputManifestArtifact } from '../../evidence-contracts'
-import type { ObserveShadowDecisionDocument } from '../../shadow-decision-contract'
+import type { CycleDecisionDocument } from '../../shadow-decision-contract'
 import type { InputManifest } from '../../types'
 import {
   ensureSnapshotReference,
@@ -33,6 +33,76 @@ export interface CycleBindingPrograms {
   readonly bindSnapshot: CycleStoreShape['bindSnapshot']
   readonly bindDecision: CycleStoreShape['bindDecision']
 }
+
+const upgradeDecisionDocumentConstraints = (sql: PgClient.PgClient): Effect.Effect<void, CycleStoreInternalError> =>
+  sql`
+    DO $migration$
+    BEGIN
+      IF EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conrelid = 'autonomous_cycle_shadow_decisions'::regclass
+          AND conname IN (
+            'autonomous_cycle_shadow_decisions_schema_version_check',
+            'autonomous_cycle_shadow_decisions_check'
+          )
+      ) THEN
+        LOCK TABLE autonomous_cycle_shadow_decisions IN ACCESS EXCLUSIVE MODE;
+
+        ALTER TABLE autonomous_cycle_shadow_decisions
+        DROP CONSTRAINT IF EXISTS autonomous_cycle_shadow_decisions_schema_version_check;
+
+        ALTER TABLE autonomous_cycle_shadow_decisions
+        DROP CONSTRAINT IF EXISTS autonomous_cycle_shadow_decisions_check;
+
+        IF NOT EXISTS (
+          SELECT 1
+          FROM pg_constraint
+          WHERE conrelid = 'autonomous_cycle_shadow_decisions'::regclass
+            AND conname = 'autonomous_cycle_decisions_schema_version_check'
+        ) THEN
+          ALTER TABLE autonomous_cycle_shadow_decisions
+          ADD CONSTRAINT autonomous_cycle_decisions_schema_version_check
+          CHECK (schema_version IN ('bayn.observe-shadow-decision.v1', 'bayn.paper-cycle-decision.v1'));
+        END IF;
+
+        IF NOT EXISTS (
+          SELECT 1
+          FROM pg_constraint
+          WHERE conrelid = 'autonomous_cycle_shadow_decisions'::regclass
+            AND conname = 'autonomous_cycle_decisions_document_check'
+        ) THEN
+          ALTER TABLE autonomous_cycle_shadow_decisions
+          ADD CONSTRAINT autonomous_cycle_decisions_document_check
+          CHECK (
+            document ->> 'schemaVersion' = schema_version
+            AND (
+              (
+                schema_version = 'bayn.observe-shadow-decision.v1'
+                AND document ->> 'mode' = 'OBSERVE'
+                AND document ->> 'dispatchable' = 'false'
+              )
+              OR
+              (
+                schema_version = 'bayn.paper-cycle-decision.v1'
+                AND document ->> 'mode' = 'PAPER'
+                AND (
+                  document ->> 'dispatchable' = 'true'
+                  OR (
+                    document ->> 'dispatchable' = 'false'
+                    AND jsonb_typeof(document -> 'riskBlock') = 'object'
+                  )
+                )
+              )
+            )
+            AND document #>> '{bindings,cycleId}' = cycle_id
+            AND (document ->> 'createdAt')::timestamptz = created_at
+          );
+        END IF;
+      END IF;
+    END
+    $migration$
+  `.pipe(Effect.asVoid)
 
 export const makeCycleBindingPrograms = (
   sql: PgClient.PgClient,
@@ -169,12 +239,13 @@ export const makeCycleBindingPrograms = (
 
   const bindDecision: CycleStoreShape['bindDecision'] = (
     cycleId: string,
-    document: ObserveShadowDecisionDocument,
+    document: CycleDecisionDocument,
     observedAt: string,
   ) =>
     runCycleStore(
       'bind-decision',
-      decodeDecisionInput({ cycleId, document, observedAt }).pipe(
+      upgradeDecisionDocumentConstraints(sql).pipe(
+        Effect.andThen(decodeDecisionInput({ cycleId, document, observedAt })),
         Effect.flatMap((input) =>
           sql.withTransaction(
             mutations.readLocked('bind-decision', input.cycleId).pipe(

--- a/services/bayn/src/db/cycle-store/decisions.ts
+++ b/services/bayn/src/db/cycle-store/decisions.ts
@@ -11,9 +11,10 @@ import {
   type CycleDraft,
 } from '../../cycle'
 import { cycleTerminalReasonForBlockedTargetPlan } from '../../cycle-recovery'
-import { ObserveShadowDecisionDocumentSchema, type ObserveShadowDecisionDocument } from '../../shadow-decision-contract'
+import { CycleDecisionDocumentSchema, type CycleDecisionDocument } from '../../shadow-decision-contract'
 import { TargetPlanStatus } from '../../target-planner'
 import type { InputManifest } from '../../types'
+import { cycleDecisionStoreEvidence } from './model'
 
 export interface CycleStoreDecisionFailure {
   readonly failure: 'conflict' | 'invariant' | 'not-found'
@@ -72,7 +73,7 @@ export type DecisionBindingDecision =
   | {
       readonly _tag: 'Persist'
       readonly cycle: AutonomousCycle
-      readonly document: ObserveShadowDecisionDocument
+      readonly document: CycleDecisionDocument
     }
   | {
       readonly _tag: 'Block'
@@ -107,6 +108,7 @@ export type BlockDecision =
       readonly cycle: AutonomousCycle
       readonly reason: CycleTerminalReason
       readonly decisionHash: string
+      readonly observedAt: string
     }
 
 const fail = (
@@ -114,7 +116,7 @@ const fail = (
   message: string,
 ): Result.Result<never, CycleStoreDecisionFailure> => Result.fail({ failure, message })
 
-const shadowDecisionEquivalent = Schema.toEquivalence(ObserveShadowDecisionDocumentSchema)
+const shadowDecisionEquivalent = Schema.toEquivalence(CycleDecisionDocumentSchema)
 
 export const makeInitialCycle = (draft: CycleDraft, observedAt: string): AutonomousCycle => {
   const missedPublication = observedAt >= draft.window.publicationDeadlineAt
@@ -215,9 +217,9 @@ export const decideActivation = (
 
 export const decideDecisionBinding = (
   cycle: AutonomousCycle,
-  document: ObserveShadowDecisionDocument,
+  document: CycleDecisionDocument,
   observedAt: string,
-  storedDocuments: readonly ObserveShadowDecisionDocument[],
+  storedDocuments: readonly CycleDecisionDocument[],
 ): Result.Result<DecisionBindingDecision, CycleStoreDecisionFailure> => {
   if (cycle.bindings.decisionHash !== undefined) {
     const storedDocument = storedDocuments[0]
@@ -242,6 +244,7 @@ export const decideDecisionBinding = (
     document.bindings.cycleId !== cycle.identity.cycleId ||
     document.bindings.strategyName !== cycle.identity.strategyName ||
     document.bindings.strategyProtocolHash !== cycle.identity.strategyProtocolHash ||
+    (document.mode === 'PAPER' && document.bindings.qualificationRunId !== cycle.identity.qualificationRunId) ||
     document.bindings.snapshotId !== cycle.bindings.snapshotId ||
     document.bindings.accountId !== cycle.identity.accountId ||
     document.submissionCutoffAt !== cycle.window.submissionCutoffAt ||
@@ -273,14 +276,22 @@ export const decideCompletion = (
 
 export const validateCompletionDocument = (
   decision: Extract<CompletionDecision, { readonly _tag: 'VerifyDecision' }>,
-  storedDocuments: readonly ObserveShadowDecisionDocument[],
+  storedDocuments: readonly CycleDecisionDocument[],
+  paperCompletionEvidenceMatches?: boolean,
 ): Result.Result<void, CycleStoreDecisionFailure> => {
   const storedDocument = storedDocuments[0]
+  const completionEvidenceMatches =
+    paperCompletionEvidenceMatches ??
+    (storedDocument === undefined
+      ? false
+      : cycleDecisionStoreEvidence(storedDocument)?.paperCompletionEvidenceMatches === true)
   const expectedStatus = decision.state === CycleState.Completed ? TargetPlanStatus.Planned : TargetPlanStatus.NoTrade
   return storedDocuments.length === 1 &&
     storedDocument !== undefined &&
     storedDocument.contentHash === decision.decisionHash &&
-    storedDocument.targetPlan.status === expectedStatus
+    storedDocument.targetPlan.status === expectedStatus &&
+    !(storedDocument.mode === 'PAPER' && storedDocument.riskBlock !== undefined) &&
+    !(storedDocument.mode === 'PAPER' && decision.state === CycleState.Completed && !completionEvidenceMatches)
     ? Result.succeed(undefined)
     : fail('invariant', 'cycle terminal state must match its exact durable shadow decision')
 }
@@ -313,24 +324,50 @@ export const decideBlock = (
   if (observedAt < cycle.updatedAt) return fail('conflict', 'cycle update time cannot move backward')
   const decisionHash = cycle.bindings.decisionHash
   return cycle.state === CycleState.Active && decisionHash !== undefined
-    ? Result.succeed({ _tag: 'VerifyDecision', cycle, reason, decisionHash })
+    ? Result.succeed({ _tag: 'VerifyDecision', cycle, reason, decisionHash, observedAt })
     : Result.succeed({ _tag: 'Persist', cycle, reason })
 }
 
 export const validateBlockedDecision = (
   decision: Extract<BlockDecision, { readonly _tag: 'VerifyDecision' }>,
-  storedDocuments: readonly ObserveShadowDecisionDocument[],
+  storedDocuments: readonly CycleDecisionDocument[],
+  paperGenerationIsSuperseded?: boolean,
 ): Result.Result<void, CycleStoreDecisionFailure> => {
   const storedDocument = storedDocuments[0]
+  const generationIsSuperseded =
+    paperGenerationIsSuperseded ??
+    (storedDocument === undefined
+      ? false
+      : cycleDecisionStoreEvidence(storedDocument)?.paperGenerationIsSuperseded === true)
   if (
     storedDocuments.length !== 1 ||
     storedDocument === undefined ||
-    storedDocument.contentHash !== decision.decisionHash ||
-    storedDocument.targetPlan.status !== TargetPlanStatus.Blocked
+    storedDocument.contentHash !== decision.decisionHash
   ) {
-    return fail('invariant', 'decision-bound cycle may block only from its exact blocked shadow decision')
+    return fail('invariant', 'decision-bound cycle may block only from its exact durable decision')
   }
-  return decision.reason === cycleTerminalReasonForBlockedTargetPlan(storedDocument.targetPlan.reason)
-    ? Result.succeed(undefined)
-    : fail('invariant', 'cycle blocked reason must match its exact durable shadow decision')
+  if (storedDocument.targetPlan.status === TargetPlanStatus.Blocked) {
+    return decision.reason === cycleTerminalReasonForBlockedTargetPlan(storedDocument.targetPlan.reason)
+      ? Result.succeed(undefined)
+      : fail('invariant', 'cycle blocked reason must match its exact durable shadow decision')
+  }
+  if (storedDocument.mode === 'PAPER' && storedDocument.targetPlan.status === TargetPlanStatus.Planned) {
+    if (decision.reason === CycleTerminalReason.ProvenanceMismatch && generationIsSuperseded) {
+      return Result.succeed(undefined)
+    }
+    if (
+      decision.reason === CycleTerminalReason.MissedSubmission &&
+      decision.observedAt >= storedDocument.submissionCutoffAt
+    ) {
+      return Result.succeed(undefined)
+    }
+    if (decision.reason === CycleTerminalReason.Risk) {
+      return Result.succeed(undefined)
+    }
+    return fail(
+      'invariant',
+      'planned PAPER cycle may block only from exact durable risk failure or submission expiry evidence',
+    )
+  }
+  return fail('invariant', 'decision-bound cycle may block only from its exact blocked or expired PAPER decision')
 }

--- a/services/bayn/src/db/cycle-store/integration.test.ts
+++ b/services/bayn/src/db/cycle-store/integration.test.ts
@@ -20,10 +20,13 @@ import {
   CycleTerminalReason,
   makeCycleDraft,
   makeCycleExecutionPolicy,
+  makeCycleExecutionPolicyFromModel,
   makeCycleIdentity,
   makeCycleWindow,
   makeExecutionCalendarObservation,
+  type AutonomousCycle,
   type CycleDraft,
+  type CycleExecutionPolicy,
 } from '../../cycle'
 import {
   CycleDecisionBuildError,
@@ -42,18 +45,34 @@ import {
   MarketData,
   type FinalizedPublicationInspection,
   type MarketDataService,
+  type MarketDataSnapshot,
   type SignalSessionRow,
 } from '../../market-data'
 import {
+  buildMutationShadowCycleDecision,
   buildObserveCycleDecision,
   loadObserveRiskPolicy,
   prepareObserveStartup,
   type ObserveDecisionFailure,
 } from '../../observe-composition'
-import { Authority, ReconciliationStatus } from '../../execution/contracts'
+import {
+  AccountStatus,
+  Authority,
+  IntentState,
+  KillState,
+  ReconciliationStatus,
+  RiskOutcome,
+} from '../../execution/contracts'
 import { BrokerAccess, noCapitalAuthority } from '../../execution/authority'
-import { runOnce } from '../../reconciler'
-import { makeObserveShadowDecisionDocument } from '../../shadow-decision-contract'
+import { planPaperIntent } from '../../execution/intents'
+import { runOnce, type ReconciliationPassResult } from '../../reconciler'
+import { reconciledStateHash } from '../../reconciliation'
+import { Reason, type Policy } from '../../risk'
+import {
+  makeObserveShadowDecisionDocument,
+  makePaperDecisionDocument,
+  type PaperDecisionDocument,
+} from '../../shadow-decision-contract'
 import { makeStrategy } from '../../strategy'
 import { TargetPlanReason, TargetPlanStatus } from '../../target-planner'
 import { fixtureProtocol, makeSnapshot, makeTestProvenance } from '../../test-fixtures'
@@ -62,6 +81,7 @@ import {
   DataSource,
   PriceAdjustment,
   PublicationSchema,
+  type DecisionPlan,
   type DailyBar,
   type InputManifest,
   type IsoDate,
@@ -790,24 +810,29 @@ const signalSession = (
 const makeDraft = (
   accountId = 'paper-account-1',
   options: {
+    readonly executionPolicy?: CycleExecutionPolicy
     readonly executionCloseAt?: string
     readonly executionOpenAt?: string
     readonly executionSessionDate?: IsoDate
+    readonly qualificationRunId?: string
     readonly signalSessionDate?: IsoDate
     readonly submissionWindowMs?: number
   } = {},
 ): CycleDraft => {
   const signalSessionDate = options.signalSessionDate ?? '2026-03-06'
   const executionSessionDate = options.executionSessionDate ?? '2026-03-09'
-  const executionPolicyResult = makeCycleExecutionPolicy({
-    schemaVersion: 'bayn.autonomous-cycle-execution-policy.v1',
-    strategyExecutionModelHash: 'c'.repeat(64),
-    submissionWindowMs: options.submissionWindowMs ?? 30 * 60 * 1_000,
-    submissionCutoffBeforeOpenMs: 2 * 60 * 1_000,
-  })
-  expect(Result.isSuccess(executionPolicyResult)).toBe(true)
-  if (Result.isFailure(executionPolicyResult)) return expect.unreachable(executionPolicyResult.failure.message)
-  const executionPolicy = executionPolicyResult.success
+  const executionPolicy = (() => {
+    if (options.executionPolicy !== undefined) return options.executionPolicy
+    const executionPolicyResult = makeCycleExecutionPolicy({
+      schemaVersion: 'bayn.autonomous-cycle-execution-policy.v1',
+      strategyExecutionModelHash: 'c'.repeat(64),
+      submissionWindowMs: options.submissionWindowMs ?? 30 * 60 * 1_000,
+      submissionCutoffBeforeOpenMs: 2 * 60 * 1_000,
+    })
+    expect(Result.isSuccess(executionPolicyResult)).toBe(true)
+    if (Result.isFailure(executionPolicyResult)) return expect.unreachable(executionPolicyResult.failure.message)
+    return executionPolicyResult.success
+  })()
 
   const executionCalendarResult = makeExecutionCalendarObservation({
     schemaVersion: 'bayn.alpaca-market-calendar-observation.v1',
@@ -823,7 +848,7 @@ const makeDraft = (
   const identityResult = makeCycleIdentity({
     schemaVersion: 'bayn.autonomous-cycle-identity.v1',
     strategyName: 'risk-balanced-trend',
-    qualificationRunId: 'a'.repeat(64),
+    qualificationRunId: options.qualificationRunId ?? 'a'.repeat(64),
     strategyProtocolHash: 'b'.repeat(64),
     accountId,
     signalSessionDate,
@@ -1034,6 +1059,1125 @@ const makeShadowDecision = (
   if (Result.isFailure(result)) return expect.unreachable(result.failure.message)
   return result.success
 }
+
+const makePaperNoTradeDecision = (draft: CycleDraft, boundSnapshotId: string) => {
+  const observe = makeShadowDecision(draft, boundSnapshotId)
+  const result = makePaperDecisionDocument({
+    schemaVersion: 'bayn.paper-cycle-decision.v1',
+    mode: 'PAPER',
+    dispatchable: true,
+    bindings: {
+      ...observe.bindings,
+      qualificationRunId: draft.identity.qualificationRunId,
+      authorityGenerationHash: 'a'.repeat(64),
+    },
+    targetPlan: observe.targetPlan,
+    deltaRisk: [],
+    orderedIntentIds: [],
+    createdAt: observe.createdAt,
+    submissionCutoffAt: observe.submissionCutoffAt,
+    expiresAt: observe.expiresAt,
+  })
+  expect(Result.isSuccess(result)).toBe(true)
+  if (Result.isFailure(result)) return expect.unreachable(result.failure.message)
+  return result.success
+}
+
+const plannedPaperGenerationHash = 'a'.repeat(64)
+const plannedPaperAccountingHash = '8'.repeat(64)
+
+const plannedPaperReconciliation = (draft: CycleDraft, observedAt = decisionAt): ReconciliationPassResult => {
+  const account = {
+    schemaVersion: 'bayn.paper-account-snapshot.v1' as const,
+    accountId: draft.identity.accountId,
+    status: AccountStatus.Active,
+    currency: 'USD' as const,
+    cashMicros: '1000000000',
+    equityMicros: '1000000000',
+    buyingPowerMicros: '1000000000',
+    observedAt,
+  }
+  const stateHash = Result.getOrThrow(
+    reconciledStateHash({
+      account,
+      positions: [],
+      positionsObservedAt: observedAt,
+      orders: [],
+      ordersObservedAt: observedAt,
+      accountingHash: plannedPaperAccountingHash,
+    }),
+  )
+  const material = {
+    schemaVersion: 'bayn.paper-reconciliation.v1' as const,
+    accountId: draft.identity.accountId,
+    expectedHash: stateHash,
+    observedHash: stateHash,
+    status: ReconciliationStatus.Exact,
+    discrepancies: [],
+    reconciledAt: observedAt,
+  }
+  const reconciliationId = canonicalHashV1({
+    schemaVersion: 'bayn.paper-reconciliation-id.v1',
+    material,
+  })
+  const reconciliation = {
+    ...material,
+    reconciliationId,
+    contentHash: canonicalHashV1({ ...material, reconciliationId }),
+  }
+  return {
+    report: {
+      reconciliation,
+      metrics: {
+        brokerPollAgeMs: 0,
+        oldestUnknownMutationAgeMs: 0,
+        cashDifferenceMicros: '0',
+        positionDifferenceMicros: '0',
+        equityDifferenceMicros: '0',
+        accountingExact: true,
+        discrepancyCount: 0,
+      },
+    },
+    brokerState: {
+      account,
+      positions: [],
+      positionsObservedAt: observedAt,
+      orders: [],
+      ordersObservedAt: observedAt,
+      accountingHash: plannedPaperAccountingHash,
+      reconciliation,
+      unknownOrderCount: 0,
+    },
+    riskContext: {
+      tradingDate: draft.identity.executionSessionDate,
+      authority: {
+        schemaVersion: 'bayn.paper-authority.v1',
+        generationHash: plannedPaperGenerationHash,
+        maximum: Authority.Paper,
+        effective: Authority.Paper,
+        kill: KillState.Clear,
+        version: 1,
+        updatedAt: draft.window.submissionOpenAt,
+      },
+      authorityObservedAt: observedAt,
+      unknownMutationCount: 0,
+      dailyTradedNotionalMicros: '0',
+      dayStartEquityMicros: account.equityMicros,
+      peakEquityMicros: account.equityMicros,
+    },
+  }
+}
+
+const plannedPaperDecisionPlan = (draft: CycleDraft): DecisionPlan => {
+  const targetWeights = Object.fromEntries(
+    fixtureProtocol.universe.map((symbol, index) => [symbol, index === 0 ? 0.5 : 0]),
+  )
+  return {
+    schemaVersion: 'bayn.risk-balanced-trend-decision-plan.v1',
+    signalDate: draft.identity.signalSessionDate,
+    covarianceWindow: {
+      returnCount: 1,
+      firstSession: draft.identity.signalSessionDate,
+      lastSession: draft.identity.signalSessionDate,
+      sessionsHash: '7'.repeat(64),
+    },
+    estimatedAnnualizedPortfolioVolatility: 0.1,
+    exposureScale: 1,
+    targetWeights,
+    signals: fixtureProtocol.universe.map((symbol, index) => ({
+      symbol,
+      horizons: [{ horizonSessions: 1, return: index === 0 ? 0.1 : 0, normalizedTrend: index === 0 ? 1 : 0 }],
+      dailyVolatility: 0.1,
+      annualizedVolatility: 0.1,
+      compositeScore: index === 0 ? 1 : 0,
+      positiveScore: index === 0 ? 1 : 0,
+      eligible: true,
+      uncappedWeight: index === 0 ? 0.5 : 0,
+      cappedWeight: index === 0 ? 0.5 : 0,
+      targetWeight: index === 0 ? 0.5 : 0,
+    })),
+  }
+}
+
+const plannedPaperMarketData = (
+  draft: CycleDraft,
+  boundSnapshotId: string,
+  snapshotFinalizedAt = acquireAt,
+): MarketDataService => {
+  const unused = Effect.die(new Error('planned PAPER persistence fixture used an unrelated market-data capability'))
+  const snapshot: MarketDataSnapshot = {
+    bars: makeSnapshot(1_129).bars,
+    manifest: makeInputManifest(boundSnapshotId, {
+      asOfSession: draft.identity.signalSessionDate,
+      finalizedAt: snapshotFinalizedAt,
+      lastSession: draft.identity.signalSessionDate,
+    }),
+  }
+  return {
+    check: unused,
+    inspect: unused,
+    inspectCyclePublications: unused,
+    inspectPublication: () => unused,
+    inspectSnapshotPublication: () => unused,
+    loadSnapshotPublication: (request) => {
+      expect(request).toEqual({
+        snapshotId: boundSnapshotId,
+        signalSessionDate: draft.identity.signalSessionDate,
+        signalCalendarVersion: draft.identity.signalCalendarVersion,
+      })
+      return Effect.succeed(snapshot)
+    },
+    load: unused,
+  }
+}
+
+const plannedPaperBrokerRead = (draft: CycleDraft, observedAt = decisionAt): BrokerReadShape => {
+  const unused = Effect.die(new Error('planned PAPER persistence fixture used an unrelated broker capability'))
+  return {
+    account: unused,
+    accountConfiguration: unused,
+    assetBySymbol: unusedAssetBySymbol,
+    positions: unused,
+    orders: () => unused,
+    orderById: () => unused,
+    orderByClientId: () => unused,
+    fillActivities: () => unused,
+    marketCalendar: (query) => {
+      const signalOpenAt = new Date(Date.parse(draft.window.signalCloseAt) - 6.5 * 60 * 60 * 1_000).toISOString()
+      const material = {
+        schemaVersion: 'bayn.alpaca-market-calendar-observation.v1' as const,
+        source: 'alpaca-v2-calendar' as const,
+        requestedRange: query,
+        timeZone: 'UTC' as const,
+        sessions: [
+          {
+            date: draft.identity.signalSessionDate,
+            openAt: signalOpenAt,
+            closeAt: draft.window.signalCloseAt,
+          },
+          {
+            date: draft.identity.executionSessionDate,
+            openAt: draft.window.executionOpenAt,
+            closeAt: draft.window.executionCloseAt,
+          },
+        ],
+      }
+      return Effect.succeed({
+        value: { ...material, normalizedResponseHash: canonicalHashV1(material) },
+        evidence: {
+          requestId: 'planned-paper-calendar',
+          status: 200,
+          contentHash: '6'.repeat(64),
+          observedAt,
+        },
+      })
+    },
+  }
+}
+
+const buildPlannedPaperDecision = (
+  cycle: AutonomousCycle,
+  boundSnapshotId: string,
+  options: {
+    readonly evaluatedAt?: string
+    readonly snapshotFinalizedAt?: string
+    readonly transformPolicy?: (policy: Policy) => Policy
+  } = {},
+) =>
+  Effect.gen(function* () {
+    const evaluatedAt = options.evaluatedAt ?? decisionAt
+    const sourcePolicy = yield* loadObserveRiskPolicy(cycle.identity.accountId, fixtureProtocol.universe)
+    const policy = options.transformPolicy?.(sourcePolicy) ?? sourcePolicy
+    const reconciliation = plannedPaperReconciliation(cycle, evaluatedAt)
+    const decision = plannedPaperDecisionPlan(cycle)
+    const priceMicros = Object.fromEntries(fixtureProtocol.universe.map((symbol) => [symbol, '100000000']))
+    yield* TestClock.setTime(Date.parse(evaluatedAt))
+    const document = yield* buildMutationShadowCycleDecision({
+      authorityGenerationHash: plannedPaperGenerationHash,
+      cycle,
+      executionModel: fixtureProtocol.executionModel,
+      policy,
+      reconcile: Effect.succeed(reconciliation),
+      strategy: { currentDecision: () => Result.succeed({ decision, priceMicros }) },
+    }).pipe(
+      Effect.provideService(BrokerRead, plannedPaperBrokerRead(cycle, evaluatedAt)),
+      Effect.provideService(MarketData, plannedPaperMarketData(cycle, boundSnapshotId, options.snapshotFinalizedAt)),
+    )
+    return { document, reconciliation }
+  })
+
+const insertReconciliation = (result: ReconciliationPassResult) =>
+  Effect.gen(function* () {
+    const sql = yield* PgClient.PgClient
+    const reconciliation = result.report.reconciliation
+    yield* sql`
+      INSERT INTO reconciliations (
+        reconciliation_id,
+        schema_version,
+        account_id,
+        expected_hash,
+        observed_hash,
+        content_hash,
+        status,
+        discrepancies,
+        reconciled_at
+      ) VALUES (
+        ${reconciliation.reconciliationId},
+        ${reconciliation.schemaVersion},
+        ${reconciliation.accountId},
+        ${reconciliation.expectedHash},
+        ${reconciliation.observedHash},
+        ${reconciliation.contentHash},
+        ${reconciliation.status},
+        ${sql.json(JSON.stringify(reconciliation.discrepancies))},
+        ${reconciliation.reconciledAt}
+      )
+    `
+    const [stored] = yield* sql<{ discrepancy_type: string }>`
+      SELECT jsonb_typeof(discrepancies) AS discrepancy_type
+      FROM reconciliations
+      WHERE reconciliation_id = ${reconciliation.reconciliationId}
+    `
+    if (stored?.discrepancy_type !== 'array') {
+      return yield* Effect.die(
+        new Error('PAPER lifecycle reconciliation fixture must persist discrepancies as JSON array'),
+      )
+    }
+  })
+
+const insertQualifiedPaperLineage = (
+  document: PaperDecisionDocument,
+  options: { readonly deniedIntent?: boolean } = {},
+) =>
+  Effect.gen(function* () {
+    const target = document.targetPlan.intentTargets[0]
+    const risk = document.deltaRisk[0]
+    if (target === undefined || risk === undefined) {
+      return yield* Effect.die(new Error('terminal PAPER failure fixture requires one ordered intent'))
+    }
+    const intent = yield* planPaperIntent(
+      {
+        schemaVersion: 'bayn.paper-intent-plan.v1',
+        ...target,
+        notionalLimitMicros: risk.notionalLimitMicros,
+        createdAt: document.createdAt,
+      },
+      {
+        authority: {
+          schemaVersion: 'bayn.paper-authority.v1',
+          generationHash: document.bindings.authorityGenerationHash,
+          maximum: Authority.Paper,
+          effective: Authority.Paper,
+          kill: KillState.Clear,
+          version: 1,
+          updatedAt: document.createdAt,
+        },
+      },
+    )
+    const sql = yield* PgClient.PgClient
+    const brokerIdentity = Result.getOrThrow(
+      makeBrokerIdentity({
+        schemaVersion: 'bayn.broker-identity.v2',
+        provider: BrokerProvider.Alpaca,
+        environment: BrokerEnvironment.Sandbox,
+        accountId: document.bindings.accountId,
+      }),
+    )
+    const observeGenerationHash = '9'.repeat(64)
+    const qualificationLockId = '1'.repeat(64)
+    const qualificationResultHash = '2'.repeat(64)
+    const qualificationAnalysisHash = '3'.repeat(64)
+    const qualificationExecutionPolicyHash = '4'.repeat(64)
+    const strategyBehaviorHash = '5'.repeat(64)
+    const strategyParameterHash = '6'.repeat(64)
+    const sourceRevision = '7'.repeat(40)
+    const imageRepository = 'registry.example.test/lab/bayn'
+    const imageDigest = `sha256:${'8'.repeat(64)}`
+    const proofPlanHash = canonicalHashV1({
+      schemaVersion: 'bayn.paper-terminalization-proof-plan.v1',
+      cycleId: document.bindings.cycleId,
+      decisionHash: document.contentHash,
+    })
+    const intentCreatedAt = new Date(Date.parse(document.createdAt) - 1_000).toISOString()
+    const submitStartedAt = new Date(Date.parse(document.createdAt) + 1).toISOString()
+    const deniedAt = new Date(Date.parse(document.createdAt) + 2).toISOString()
+    const mutationId = canonicalHashV1({ intentId: intent.intentId, operation: 'SUBMIT' })
+    const requestHash = canonicalHashV1({ intentId: intent.intentId, request: 'pretransmit-denied' })
+
+    yield* sql.withTransaction(
+      Effect.gen(function* () {
+        yield* sql`
+          INSERT INTO protocol_locks (
+            protocol_hash,
+            schema_version,
+            strategy_name,
+            behavior_hash,
+            parameter_hash,
+            parameters,
+            created_at
+          ) VALUES (
+            ${document.bindings.strategyProtocolHash},
+            'bayn.risk-balanced-trend.protocol.v4',
+            ${document.bindings.strategyName},
+            ${strategyBehaviorHash},
+            ${strategyParameterHash},
+            ${sql.json({ fixture: 'terminal-paper-cycle' })},
+            ${intentCreatedAt}
+          )
+        `
+        yield* sql`
+          INSERT INTO evaluation_runs (
+            run_id,
+            protocol_hash,
+            snapshot_id,
+            evaluation_schema_version,
+            source_revision,
+            image_repository,
+            image_digest,
+            strategy_name,
+            initial_capital_micros,
+            expected_artifact_count,
+            expected_event_count,
+            expected_gate_count,
+            status,
+            created_at,
+            completed_at
+          ) VALUES (
+            ${document.bindings.qualificationRunId},
+            ${document.bindings.strategyProtocolHash},
+            ${document.bindings.snapshotId},
+            'bayn.evaluation.v6',
+            ${sourceRevision},
+            ${imageRepository},
+            ${imageDigest},
+            ${document.bindings.strategyName},
+            1000000000,
+            1,
+            0,
+            1,
+            'COMPLETE',
+            ${intentCreatedAt},
+            ${document.createdAt}
+          )
+        `
+        yield* sql`
+          INSERT INTO qualification_locks (
+            lock_id,
+            schema_version,
+            candidate_run_id,
+            protocol_hash,
+            snapshot_id,
+            source_revision,
+            image_repository,
+            image_digest,
+            payload,
+            created_at
+          ) VALUES (
+            ${qualificationLockId},
+            'bayn.qualification-lock.v3',
+            ${document.bindings.qualificationRunId},
+            ${document.bindings.strategyProtocolHash},
+            ${document.bindings.snapshotId},
+            ${sourceRevision},
+            ${imageRepository},
+            ${imageDigest},
+            ${sql.json({
+              schemaVersion: 'bayn.qualification-lock.v3',
+              lockId: qualificationLockId,
+              candidateRunId: document.bindings.qualificationRunId,
+              protocolHash: document.bindings.strategyProtocolHash,
+              sourceRevision,
+              image: { repository: imageRepository, digest: imageDigest },
+              data: { snapshotId: document.bindings.snapshotId },
+            })},
+            ${intentCreatedAt}
+          )
+        `
+        yield* sql`
+          INSERT INTO qualification_results (
+            lock_id,
+            schema_version,
+            run_id,
+            verdict,
+            committed_at,
+            analysis_hash,
+            result_hash,
+            payload
+          ) VALUES (
+            ${qualificationLockId},
+            'bayn.qualification-result.v2',
+            ${document.bindings.qualificationRunId},
+            'QUALIFIED',
+            ${document.createdAt},
+            ${qualificationAnalysisHash},
+            ${qualificationResultHash},
+            ${sql.json({
+              schemaVersion: 'bayn.qualification-result.v2',
+              lockId: qualificationLockId,
+              runId: document.bindings.qualificationRunId,
+              verdict: 'QUALIFIED',
+              analysis: { analysisHash: qualificationAnalysisHash },
+              resultHash: qualificationResultHash,
+            })}
+          )
+        `
+        yield* sql`
+          INSERT INTO authority_generations (
+            generation_hash,
+            schema_version,
+            previous_generation_hash,
+            maximum,
+            authority_version,
+            account_id,
+            broker_identity_schema_version,
+            broker_identity_hash,
+            broker_provider,
+            broker_environment,
+            activated_at
+          ) VALUES (
+            ${observeGenerationHash},
+            'bayn.authority-generation-history.v1',
+            NULL,
+            'OBSERVE',
+            1,
+            ${document.bindings.accountId},
+            ${brokerIdentity.schemaVersion},
+            ${brokerIdentity.identityHash},
+            ${brokerIdentity.provider},
+            ${brokerIdentity.environment},
+            ${intentCreatedAt}
+          )
+        `
+        yield* sql`
+          INSERT INTO authority_generations (
+            generation_hash,
+            schema_version,
+            activation_schema_version,
+            previous_generation_hash,
+            maximum,
+            authority_version,
+            qualification_run_id,
+            qualification_lock_id,
+            qualification_result_hash,
+            protocol_hash,
+            qualification_execution_policy_hash,
+            qualification_source_revision,
+            qualification_image_repository,
+            qualification_image_digest,
+            activation_source_revision,
+            activation_image_repository,
+            activation_image_digest,
+            strategy_name,
+            strategy_behavior_hash,
+            strategy_parameter_hash,
+            strategy_parameter_schema_version,
+            account_id,
+            broker_identity_schema_version,
+            broker_identity_hash,
+            broker_provider,
+            broker_environment,
+            risk_policy_hash,
+            proof_plan_hash,
+            reconciliation_id,
+            reconciliation_content_hash,
+            activated_at
+          ) VALUES (
+            ${document.bindings.authorityGenerationHash},
+            'bayn.authority-generation-history.v1',
+            'bayn.paper-authority-generation.v2',
+            ${observeGenerationHash},
+            'PAPER',
+            2,
+            ${document.bindings.qualificationRunId},
+            ${qualificationLockId},
+            ${qualificationResultHash},
+            ${document.bindings.strategyProtocolHash},
+            ${qualificationExecutionPolicyHash},
+            ${sourceRevision},
+            ${imageRepository},
+            ${imageDigest},
+            ${sourceRevision},
+            ${imageRepository},
+            ${imageDigest},
+            ${document.bindings.strategyName},
+            ${strategyBehaviorHash},
+            ${strategyParameterHash},
+            'bayn.risk-balanced-trend.protocol.v4',
+            ${document.bindings.accountId},
+            ${brokerIdentity.schemaVersion},
+            ${brokerIdentity.identityHash},
+            ${brokerIdentity.provider},
+            ${brokerIdentity.environment},
+            ${document.bindings.policyHash},
+            ${proofPlanHash},
+            ${document.bindings.reconciliationId},
+            ${document.bindings.reconciliationHash},
+            ${document.createdAt}
+          )
+        `
+        if (options.deniedIntent === true) {
+          yield* sql`
+            INSERT INTO intents (
+            intent_id,
+            schema_version,
+            authority_generation_hash,
+            strategy_name,
+            cycle_id,
+            decision_hash,
+            policy_hash,
+            account_id,
+            client_order_id,
+            symbol,
+            side,
+            order_type,
+            time_in_force,
+            quantity_micros,
+            notional_limit_micros,
+            state,
+            created_at,
+            updated_at
+            ) VALUES (
+            ${intent.intentId},
+            ${intent.schemaVersion},
+            ${intent.authorityGenerationHash},
+            ${intent.strategyName},
+            ${intent.cycleId},
+            ${intent.decisionHash},
+            ${intent.policyHash},
+            ${intent.accountId},
+            ${intent.clientOrderId},
+            ${intent.symbol},
+            ${intent.side},
+            ${intent.orderType},
+            ${intent.timeInForce},
+            ${intent.quantityMicros},
+            ${intent.notionalLimitMicros},
+            'PLANNED',
+            ${intentCreatedAt},
+            ${intentCreatedAt}
+            )
+          `
+          yield* sql`
+            INSERT INTO risk_decisions (
+            decision_id,
+            schema_version,
+            input_hash,
+            intent_id,
+            policy_hash,
+            outcome,
+            reason_codes,
+            decided_at,
+            expires_at
+            ) VALUES (
+            ${risk.evaluation.decision.decisionId},
+            ${risk.evaluation.decision.schemaVersion},
+            ${risk.evaluation.decision.inputHash},
+            ${risk.evaluation.decision.intentId},
+            ${risk.evaluation.decision.policyHash},
+            ${risk.evaluation.decision.outcome},
+            ${risk.evaluation.decision.reasonCodes},
+            ${risk.evaluation.decision.decidedAt},
+            ${risk.evaluation.decision.expiresAt}
+            )
+          `
+          yield* sql`
+            UPDATE intents
+            SET
+              risk_decision_id = ${risk.evaluation.decision.decisionId},
+              state = 'APPROVED',
+              state_version = state_version + 1,
+              updated_at = ${risk.evaluation.decision.decidedAt}
+            WHERE intent_id = ${intent.intentId}
+          `
+          yield* sql`
+            INSERT INTO mutation_events (
+            event_id,
+            schema_version,
+            mutation_id,
+            intent_id,
+            sequence,
+            operation,
+            event_type,
+            request_hash,
+            consistency_delay_ms,
+            occurred_at
+            ) VALUES (
+            ${canonicalHashV1({ mutationId, sequence: 1, eventType: 'SUBMIT_STARTED' })},
+            'bayn.paper-mutation-event.v1',
+            ${mutationId},
+            ${intent.intentId},
+            1,
+            'SUBMIT',
+            'SUBMIT_STARTED',
+            ${requestHash},
+            1000,
+            ${submitStartedAt}
+            )
+          `
+          yield* sql`
+            UPDATE intents
+            SET
+              state = 'IO_STARTED',
+              state_version = state_version + 1,
+              updated_at = ${submitStartedAt}
+            WHERE intent_id = ${intent.intentId}
+          `
+          yield* sql`
+            INSERT INTO mutation_events (
+            event_id,
+            schema_version,
+            mutation_id,
+            intent_id,
+            sequence,
+            operation,
+            event_type,
+            request_hash,
+            consistency_delay_ms,
+            occurred_at
+            ) VALUES (
+            ${canonicalHashV1({ mutationId, sequence: 2, eventType: 'SUBMIT_DENIED' })},
+            'bayn.paper-mutation-event.v1',
+            ${mutationId},
+            ${intent.intentId},
+            2,
+            'SUBMIT',
+            'SUBMIT_DENIED',
+            ${requestHash},
+            1000,
+            ${deniedAt}
+            )
+          `
+          yield* sql`
+            UPDATE intents
+            SET
+              state = 'TERMINAL',
+              terminal_outcome = 'REJECTED',
+              state_version = state_version + 1,
+              updated_at = ${deniedAt}
+            WHERE intent_id = ${intent.intentId}
+          `
+        }
+      }),
+    )
+
+    return { deniedAt, intent }
+  })
+
+const insertSupersedingObserveGeneration = (document: PaperDecisionDocument) =>
+  Effect.gen(function* () {
+    const sql = yield* PgClient.PgClient
+    const generationHash = canonicalHashV1({
+      schemaVersion: 'bayn.superseding-observe-generation-fixture.v1',
+      previousGenerationHash: document.bindings.authorityGenerationHash,
+      cycleId: document.bindings.cycleId,
+    })
+    const brokerIdentity = Result.getOrThrow(
+      makeBrokerIdentity({
+        schemaVersion: 'bayn.broker-identity.v2',
+        provider: BrokerProvider.Alpaca,
+        environment: BrokerEnvironment.Sandbox,
+        accountId: document.bindings.accountId,
+      }),
+    )
+    const activatedAt = new Date(Date.parse(document.createdAt) + 10_000).toISOString()
+    yield* sql`
+      INSERT INTO authority_generations (
+        generation_hash,
+        schema_version,
+        previous_generation_hash,
+        maximum,
+        authority_version,
+        account_id,
+        broker_identity_schema_version,
+        broker_identity_hash,
+        broker_provider,
+        broker_environment,
+        activated_at
+      ) VALUES (
+        ${generationHash},
+        'bayn.authority-generation-history.v1',
+        ${document.bindings.authorityGenerationHash},
+        'OBSERVE',
+        3,
+        ${document.bindings.accountId},
+        ${brokerIdentity.schemaVersion},
+        ${brokerIdentity.identityHash},
+        ${brokerIdentity.provider},
+        ${brokerIdentity.environment},
+        ${activatedAt}
+      )
+    `
+    return { activatedAt, generationHash }
+  })
+
+const insertFilledPlannedPaperIntent = (
+  document: PaperDecisionDocument,
+  latestMutation: 'accepted' | 'started' = 'accepted',
+) =>
+  Effect.gen(function* () {
+    const target = document.targetPlan.intentTargets[0]
+    const risk = document.deltaRisk[0]
+    if (target === undefined || risk === undefined) {
+      return yield* Effect.die(new Error('filled PAPER completion fixture requires one ordered intent'))
+    }
+    const intent = yield* planPaperIntent(
+      {
+        schemaVersion: 'bayn.paper-intent-plan.v1',
+        ...target,
+        notionalLimitMicros: risk.notionalLimitMicros,
+        createdAt: document.createdAt,
+      },
+      {
+        authority: {
+          schemaVersion: 'bayn.paper-authority.v1',
+          generationHash: document.bindings.authorityGenerationHash,
+          maximum: Authority.Paper,
+          effective: Authority.Paper,
+          kill: KillState.Clear,
+          version: 1,
+          updatedAt: document.createdAt,
+        },
+      },
+    )
+    const sql = yield* PgClient.PgClient
+    const intentCreatedAt = new Date(Date.parse(document.createdAt) - 1).toISOString()
+    const submitStartedAt = new Date(Date.parse(document.createdAt) + 1).toISOString()
+    const acceptedAt = new Date(Date.parse(document.createdAt) + 2).toISOString()
+    const filledAt = new Date(Date.parse(document.createdAt) + 3).toISOString()
+    const mutationId = canonicalHashV1({ intentId: intent.intentId, operation: 'SUBMIT' })
+    const requestHash = canonicalHashV1({ intentId: intent.intentId, request: 'filled-completion' })
+    const brokerOrderId = `filled-${intent.intentId.slice(0, 24)}`
+
+    yield* sql.withTransaction(
+      Effect.gen(function* () {
+        yield* sql`
+          INSERT INTO intents (
+            intent_id, schema_version, authority_generation_hash, strategy_name,
+            cycle_id, decision_hash, policy_hash, account_id, client_order_id,
+            symbol, side, order_type, time_in_force, quantity_micros,
+            notional_limit_micros, state, created_at, updated_at
+          ) VALUES (
+            ${intent.intentId}, ${intent.schemaVersion}, ${intent.authorityGenerationHash},
+            ${intent.strategyName}, ${intent.cycleId}, ${intent.decisionHash},
+            ${intent.policyHash}, ${intent.accountId}, ${intent.clientOrderId},
+            ${intent.symbol}, ${intent.side}, ${intent.orderType}, ${intent.timeInForce},
+            ${intent.quantityMicros}, ${intent.notionalLimitMicros}, 'PLANNED',
+            ${intentCreatedAt}, ${intentCreatedAt}
+          )
+        `
+        yield* sql`
+          INSERT INTO risk_decisions (
+            decision_id, schema_version, input_hash, intent_id, policy_hash,
+            outcome, reason_codes, decided_at, expires_at
+          ) VALUES (
+            ${risk.evaluation.decision.decisionId}, ${risk.evaluation.decision.schemaVersion},
+            ${risk.evaluation.decision.inputHash}, ${risk.evaluation.decision.intentId},
+            ${risk.evaluation.decision.policyHash}, ${risk.evaluation.decision.outcome},
+            ${risk.evaluation.decision.reasonCodes}, ${risk.evaluation.decision.decidedAt},
+            ${risk.evaluation.decision.expiresAt}
+          )
+        `
+        yield* sql`
+          UPDATE intents
+          SET
+            risk_decision_id = ${risk.evaluation.decision.decisionId},
+            state = 'APPROVED',
+            state_version = state_version + 1,
+            updated_at = ${risk.evaluation.decision.decidedAt}
+          WHERE intent_id = ${intent.intentId}
+        `
+        yield* sql`
+          INSERT INTO mutation_events (
+            event_id, schema_version, mutation_id, intent_id, sequence,
+            operation, event_type, request_hash, consistency_delay_ms, occurred_at
+          ) VALUES (
+            ${canonicalHashV1({ mutationId, sequence: 1, eventType: 'SUBMIT_STARTED' })},
+            'bayn.paper-mutation-event.v1', ${mutationId}, ${intent.intentId}, 1,
+            'SUBMIT', 'SUBMIT_STARTED', ${requestHash}, 1000, ${submitStartedAt}
+          )
+        `
+        yield* sql`
+          UPDATE intents
+          SET state = 'IO_STARTED', state_version = state_version + 1, updated_at = ${submitStartedAt}
+          WHERE intent_id = ${intent.intentId}
+        `
+        if (latestMutation === 'accepted') {
+          yield* sql`
+            INSERT INTO mutation_events (
+              event_id, schema_version, mutation_id, intent_id, sequence,
+              operation, event_type, request_hash, consistency_delay_ms,
+              broker_order_id, request_id, response_status, response_content_hash, occurred_at
+            ) VALUES (
+              ${canonicalHashV1({ mutationId, sequence: 2, eventType: 'SUBMIT_ACCEPTED' })},
+              'bayn.paper-mutation-event.v1', ${mutationId}, ${intent.intentId}, 2,
+              'SUBMIT', 'SUBMIT_ACCEPTED', ${requestHash}, 1000,
+              ${brokerOrderId}, 'filled-completion-request', 200, ${'a'.repeat(64)}, ${acceptedAt}
+            )
+          `
+          yield* sql`
+            UPDATE intents
+            SET state = 'ACKNOWLEDGED', state_version = state_version + 1, updated_at = ${acceptedAt}
+            WHERE intent_id = ${intent.intentId}
+          `
+        }
+        yield* sql`
+          UPDATE intents
+          SET
+            state = 'TERMINAL',
+            terminal_outcome = 'FILLED',
+            state_version = state_version + 1,
+            updated_at = ${filledAt}
+          WHERE intent_id = ${intent.intentId}
+        `
+      }),
+    )
+    return { acceptedAt, brokerOrderId, filledAt, intent, mutationId, requestHash }
+  })
+
+const settleStartedPaperSubmit = (
+  filled: Effect.Success<ReturnType<typeof insertFilledPlannedPaperIntent>>,
+  occurredAt: string,
+) =>
+  Effect.gen(function* () {
+    const sql = yield* PgClient.PgClient
+    yield* sql`
+      INSERT INTO mutation_events (
+        event_id, schema_version, mutation_id, intent_id, sequence,
+        operation, event_type, request_hash, consistency_delay_ms,
+        broker_order_id, request_id, response_status, response_content_hash, occurred_at
+      ) VALUES (
+        ${canonicalHashV1({ mutationId: filled.mutationId, sequence: 2, eventType: 'SUBMIT_ACCEPTED' })},
+        'bayn.paper-mutation-event.v1', ${filled.mutationId}, ${filled.intent.intentId}, 2,
+        'SUBMIT', 'SUBMIT_ACCEPTED', ${filled.requestHash}, 1000,
+        ${filled.brokerOrderId}, 'filled-completion-recovery', 200, ${'b'.repeat(64)}, ${occurredAt}
+      )
+    `
+  })
+
+type SupersededMutationFixture = 'submit-accepted' | 'submit-unknown' | 'cancel-accepted' | 'cancel-unknown'
+
+const insertUnfinishedPlannedPaperMutation = (document: PaperDecisionDocument, fixture: SupersededMutationFixture) =>
+  Effect.gen(function* () {
+    const target = document.targetPlan.intentTargets[0]
+    const risk = document.deltaRisk[0]
+    if (target === undefined || risk === undefined) {
+      return yield* Effect.die(new Error('superseded mutation fixture requires one ordered intent'))
+    }
+    const intent = yield* planPaperIntent(
+      {
+        schemaVersion: 'bayn.paper-intent-plan.v1',
+        ...target,
+        notionalLimitMicros: risk.notionalLimitMicros,
+        createdAt: document.createdAt,
+      },
+      {
+        authority: {
+          schemaVersion: 'bayn.paper-authority.v1',
+          generationHash: document.bindings.authorityGenerationHash,
+          maximum: Authority.Paper,
+          effective: Authority.Paper,
+          kill: KillState.Clear,
+          version: 1,
+          updatedAt: document.createdAt,
+        },
+      },
+    )
+    const sql = yield* PgClient.PgClient
+    const intentCreatedAt = new Date(Date.parse(document.createdAt) - 1).toISOString()
+    const submitStartedAt = new Date(Date.parse(document.createdAt) + 1).toISOString()
+    const submitOutcomeAt = new Date(Date.parse(document.createdAt) + 2).toISOString()
+    const cancelStartedAt = new Date(Date.parse(document.createdAt) + 3).toISOString()
+    const cancelOutcomeAt = new Date(Date.parse(document.createdAt) + 4).toISOString()
+    const submitMutationId = canonicalHashV1({ intentId: intent.intentId, operation: 'SUBMIT' })
+    const cancelMutationId = canonicalHashV1({ intentId: intent.intentId, operation: 'CANCEL' })
+    const submitRequestHash = canonicalHashV1({ intentId: intent.intentId, fixture, operation: 'SUBMIT' })
+    const cancelRequestHash = canonicalHashV1({ intentId: intent.intentId, fixture, operation: 'CANCEL' })
+    const brokerOrderId = `superseded-${intent.intentId.slice(0, 24)}`
+    const submitAccepted = fixture === 'submit-accepted' || fixture.startsWith('cancel-')
+    const cancelFixture = fixture.startsWith('cancel-')
+
+    yield* sql.withTransaction(
+      Effect.gen(function* () {
+        yield* sql`
+          INSERT INTO intents (
+            intent_id, schema_version, authority_generation_hash, strategy_name,
+            cycle_id, decision_hash, policy_hash, account_id, client_order_id,
+            symbol, side, order_type, time_in_force, quantity_micros,
+            notional_limit_micros, state, created_at, updated_at
+          ) VALUES (
+            ${intent.intentId}, ${intent.schemaVersion}, ${intent.authorityGenerationHash},
+            ${intent.strategyName}, ${intent.cycleId}, ${intent.decisionHash},
+            ${intent.policyHash}, ${intent.accountId}, ${intent.clientOrderId},
+            ${intent.symbol}, ${intent.side}, ${intent.orderType}, ${intent.timeInForce},
+            ${intent.quantityMicros}, ${intent.notionalLimitMicros}, 'PLANNED',
+            ${intentCreatedAt}, ${intentCreatedAt}
+          )
+        `
+        yield* sql`
+          INSERT INTO risk_decisions (
+            decision_id, schema_version, input_hash, intent_id, policy_hash,
+            outcome, reason_codes, decided_at, expires_at
+          ) VALUES (
+            ${risk.evaluation.decision.decisionId}, ${risk.evaluation.decision.schemaVersion},
+            ${risk.evaluation.decision.inputHash}, ${risk.evaluation.decision.intentId},
+            ${risk.evaluation.decision.policyHash}, ${risk.evaluation.decision.outcome},
+            ${risk.evaluation.decision.reasonCodes}, ${risk.evaluation.decision.decidedAt},
+            ${risk.evaluation.decision.expiresAt}
+          )
+        `
+        yield* sql`
+          UPDATE intents
+          SET
+            risk_decision_id = ${risk.evaluation.decision.decisionId},
+            state = 'APPROVED',
+            state_version = state_version + 1,
+            updated_at = ${risk.evaluation.decision.decidedAt}
+          WHERE intent_id = ${intent.intentId}
+        `
+        yield* sql`
+          INSERT INTO mutation_events (
+            event_id, schema_version, mutation_id, intent_id, sequence,
+            operation, event_type, request_hash, consistency_delay_ms, occurred_at
+          ) VALUES (
+            ${canonicalHashV1({ submitMutationId, sequence: 1, eventType: 'SUBMIT_STARTED' })},
+            'bayn.paper-mutation-event.v1', ${submitMutationId}, ${intent.intentId}, 1,
+            'SUBMIT', 'SUBMIT_STARTED', ${submitRequestHash}, 1000, ${submitStartedAt}
+          )
+        `
+        yield* sql`
+          UPDATE intents
+          SET state = 'IO_STARTED', state_version = state_version + 1, updated_at = ${submitStartedAt}
+          WHERE intent_id = ${intent.intentId}
+        `
+        if (submitAccepted) {
+          yield* sql`
+            INSERT INTO mutation_events (
+              event_id, schema_version, mutation_id, intent_id, sequence,
+              operation, event_type, request_hash, consistency_delay_ms,
+              broker_order_id, request_id, response_status, response_content_hash, occurred_at
+            ) VALUES (
+              ${canonicalHashV1({ submitMutationId, sequence: 2, eventType: 'SUBMIT_ACCEPTED' })},
+              'bayn.paper-mutation-event.v1', ${submitMutationId}, ${intent.intentId}, 2,
+              'SUBMIT', 'SUBMIT_ACCEPTED', ${submitRequestHash}, 1000, ${brokerOrderId},
+              ${`${fixture}-submit`}, 200, ${canonicalHashV1({ fixture, response: 'submit' })}, ${submitOutcomeAt}
+            )
+          `
+          yield* sql`
+            UPDATE intents
+            SET state = 'ACKNOWLEDGED', state_version = state_version + 1, updated_at = ${submitOutcomeAt}
+            WHERE intent_id = ${intent.intentId}
+          `
+        } else {
+          yield* sql`
+            INSERT INTO mutation_events (
+              event_id, schema_version, mutation_id, intent_id, sequence,
+              operation, event_type, request_hash, consistency_delay_ms, occurred_at
+            ) VALUES (
+              ${canonicalHashV1({ submitMutationId, sequence: 2, eventType: 'SUBMIT_UNKNOWN' })},
+              'bayn.paper-mutation-event.v1', ${submitMutationId}, ${intent.intentId}, 2,
+              'SUBMIT', 'SUBMIT_UNKNOWN', ${submitRequestHash}, 1000, ${submitOutcomeAt}
+            )
+          `
+          yield* sql`
+            UPDATE intents
+            SET state = 'UNKNOWN', state_version = state_version + 1, updated_at = ${submitOutcomeAt}
+            WHERE intent_id = ${intent.intentId}
+          `
+        }
+        if (cancelFixture) {
+          yield* sql`
+            INSERT INTO mutation_events (
+              event_id, schema_version, mutation_id, intent_id, sequence,
+              operation, event_type, request_hash, consistency_delay_ms, broker_order_id, occurred_at
+            ) VALUES (
+              ${canonicalHashV1({ cancelMutationId, sequence: 1, eventType: 'CANCEL_STARTED' })},
+              'bayn.paper-mutation-event.v1', ${cancelMutationId}, ${intent.intentId}, 1,
+              'CANCEL', 'CANCEL_STARTED', ${cancelRequestHash}, 1000, ${brokerOrderId}, ${cancelStartedAt}
+            )
+          `
+          if (fixture === 'cancel-accepted') {
+            yield* sql`
+              INSERT INTO mutation_events (
+                event_id, schema_version, mutation_id, intent_id, sequence,
+                operation, event_type, request_hash, consistency_delay_ms,
+                broker_order_id, request_id, response_status, response_content_hash, occurred_at
+              ) VALUES (
+                ${canonicalHashV1({ cancelMutationId, sequence: 2, eventType: 'CANCEL_ACCEPTED' })},
+                'bayn.paper-mutation-event.v1', ${cancelMutationId}, ${intent.intentId}, 2,
+                'CANCEL', 'CANCEL_ACCEPTED', ${cancelRequestHash}, 1000, ${brokerOrderId},
+                ${`${fixture}-cancel`}, 204, ${canonicalHashV1({ fixture, response: 'cancel' })}, ${cancelOutcomeAt}
+              )
+            `
+          } else {
+            yield* sql`
+              INSERT INTO mutation_events (
+                event_id, schema_version, mutation_id, intent_id, sequence,
+                operation, event_type, request_hash, consistency_delay_ms, broker_order_id, occurred_at
+              ) VALUES (
+                ${canonicalHashV1({ cancelMutationId, sequence: 2, eventType: 'CANCEL_UNKNOWN' })},
+                'bayn.paper-mutation-event.v1', ${cancelMutationId}, ${intent.intentId}, 2,
+                'CANCEL', 'CANCEL_UNKNOWN', ${cancelRequestHash}, 1000, ${brokerOrderId}, ${cancelOutcomeAt}
+              )
+            `
+          }
+        }
+      }),
+    )
+    return { intent, mutationCount: cancelFixture ? 4 : 2 }
+  })
+
+const settleSupersededMutation = (
+  document: PaperDecisionDocument,
+  intentId: string,
+  fixture: SupersededMutationFixture,
+) =>
+  Effect.gen(function* () {
+    const sql = yield* PgClient.PgClient
+    const operation = fixture.startsWith('cancel-') ? 'CANCEL' : 'SUBMIT'
+    const mutationId = canonicalHashV1({ intentId, operation })
+    const requestHash = canonicalHashV1({ intentId, fixture, operation })
+    const brokerOrderId = `superseded-${intentId.slice(0, 24)}`
+    const recoveredAt = new Date(Date.parse(document.createdAt) + 11_000).toISOString()
+    const terminalAt = fixture === 'submit-unknown' ? new Date(Date.parse(recoveredAt) + 1).toISOString() : recoveredAt
+    const terminalOutcome = operation === 'CANCEL' ? 'CANCELED' : 'FILLED'
+    yield* sql.withTransaction(
+      Effect.gen(function* () {
+        yield* sql`
+          INSERT INTO mutation_events (
+            event_id, schema_version, mutation_id, intent_id, sequence,
+            operation, event_type, request_hash, consistency_delay_ms,
+            broker_order_id, request_id, response_status, response_content_hash, occurred_at
+          ) VALUES (
+            ${canonicalHashV1({ mutationId, sequence: 3, eventType: 'RECOVERY_FOUND' })},
+            'bayn.paper-mutation-event.v1', ${mutationId}, ${intentId}, 3,
+            ${operation}, 'RECOVERY_FOUND', ${requestHash}, 1000, ${brokerOrderId},
+            ${`${fixture}-recovery`}, 200, ${canonicalHashV1({ fixture, response: 'recovery' })}, ${recoveredAt}
+          )
+        `
+        if (fixture === 'submit-unknown') {
+          yield* sql`
+            UPDATE intents
+            SET
+              state = 'RECOVERED',
+              state_version = state_version + 1,
+              updated_at = ${recoveredAt}
+            WHERE intent_id = ${intentId}
+              AND state = 'UNKNOWN'
+          `
+        }
+        yield* sql`
+          UPDATE intents
+          SET
+            state = 'TERMINAL',
+            terminal_outcome = ${terminalOutcome},
+            state_version = state_version + 1,
+            updated_at = ${terminalAt}
+          WHERE intent_id = ${intentId}
+        `
+      }),
+    )
+    return { recoveredAt: terminalAt }
+  })
 
 const insertShadowReconciliation = (draft: CycleDraft) =>
   Effect.gen(function* () {
@@ -1714,6 +2858,7 @@ describePostgres('PostgreSQL autonomous cycle store', () => {
           accountId: draft.identity.accountId,
           signalSessionDate: draft.identity.signalSessionDate,
         })
+
         const conflict = yield* Effect.exit(store.bindDecision(draft.identity.cycleId, divergent, decisionAt))
 
         yield* store.acquire(missingDocumentDraft, acquireAt)
@@ -1839,6 +2984,933 @@ describePostgres('PostgreSQL autonomous cycle store', () => {
       intents: 0,
       risk_decisions: 0,
       mutation_events: 0,
+    })
+  })
+
+  test('persists and recovers one immutable PAPER no-trade decision across store restart', async () => {
+    const draft = makeDraft('paper-account-paper-decision-restart')
+    const document = makePaperNoTradeDecision(draft, snapshotA)
+
+    await runtime.runPromise(
+      Effect.gen(function* () {
+        const store = yield* CycleStore
+        yield* store.acquire(draft, acquireAt)
+        yield* store.bindSnapshot(draft.identity.cycleId, makeInputManifest(snapshotA), snapshotAt)
+        yield* store.activate(draft.identity.cycleId, activeAt)
+        yield* insertShadowReconciliation(draft)
+        yield* store.bindDecision(draft.identity.cycleId, document, decisionAt)
+      }),
+    )
+
+    await runtime.dispose()
+    runtime = makeRuntime()
+
+    const recovered = await runtime.runPromise(
+      Effect.gen(function* () {
+        const store = yield* CycleStore
+        return yield* store.readDecisionDocument(draft.identity.cycleId)
+      }),
+    )
+
+    expect(Option.isSome(recovered)).toBe(true)
+    if (Option.isNone(recovered)) return expect.unreachable('PAPER decision must survive store restart')
+    expect(recovered.value).toEqual(document)
+    expect(recovered.value).toMatchObject({
+      mode: 'PAPER',
+      dispatchable: true,
+      bindings: { authorityGenerationHash: 'a'.repeat(64) },
+      orderedIntentIds: [],
+    })
+  })
+
+  test('terminalizes an expired untouched PAPER plan and releases oldest-unfinished selection', async () => {
+    const executionPolicy = Result.getOrThrow(makeCycleExecutionPolicyFromModel(fixtureProtocol.executionModel))
+    const draft = makeDraft('paper-account-expired-planned', { executionPolicy })
+    const result = await runtime.runPromise(
+      Effect.gen(function* () {
+        const store = yield* CycleStore
+        yield* store.acquire(draft, acquireAt)
+        yield* store.bindSnapshot(draft.identity.cycleId, makeInputManifest(snapshotA), snapshotAt)
+        const activated = yield* store.activate(draft.identity.cycleId, activeAt)
+        const planned = yield* buildPlannedPaperDecision(activated.cycle, snapshotA)
+        if (
+          planned.document.targetPlan.status !== TargetPlanStatus.Planned ||
+          planned.document.deltaRisk.length === 0
+        ) {
+          return yield* Effect.die(new Error('PAPER expiry fixture requires a planned mutation'))
+        }
+        yield* insertReconciliation(planned.reconciliation)
+        yield* insertQualifiedPaperLineage(planned.document)
+        yield* store.bindDecision(draft.identity.cycleId, planned.document, decisionAt)
+
+        const riskExpiresAt = planned.document.deltaRisk[0]?.evaluation.decision.expiresAt
+        if (riskExpiresAt === undefined) return yield* Effect.die(new Error('PAPER risk expiry is missing'))
+        const beforeRiskExpiry = new Date(Date.parse(riskExpiresAt) - 1).toISOString()
+        const beforeSubmissionCutoff = new Date(Date.parse(draft.window.submissionCutoffAt) - 1).toISOString()
+        const sql = yield* PgClient.PgClient
+        const directEarlyRisk = yield* Effect.exit(sql`
+          UPDATE autonomous_cycles
+          SET
+            state = ${CycleState.Blocked},
+            terminal_reason = ${CycleTerminalReason.Risk},
+            state_version = state_version + 1,
+            updated_at = ${beforeRiskExpiry},
+            terminal_at = ${beforeRiskExpiry}
+          WHERE cycle_id = ${draft.identity.cycleId}
+        `)
+        const directEarlyCutoff = yield* Effect.exit(sql`
+          UPDATE autonomous_cycles
+          SET
+            state = ${CycleState.Blocked},
+            terminal_reason = ${CycleTerminalReason.MissedSubmission},
+            state_version = state_version + 1,
+            updated_at = ${beforeSubmissionCutoff},
+            terminal_at = ${beforeSubmissionCutoff}
+          WHERE cycle_id = ${draft.identity.cycleId}
+        `)
+        const directWrongReason = yield* Effect.exit(sql`
+          UPDATE autonomous_cycles
+          SET
+            state = ${CycleState.Blocked},
+            terminal_reason = ${CycleTerminalReason.Reconciliation},
+            state_version = state_version + 1,
+            updated_at = ${riskExpiresAt},
+            terminal_at = ${riskExpiresAt}
+          WHERE cycle_id = ${draft.identity.cycleId}
+        `)
+
+        const blocked = yield* store.block(draft.identity.cycleId, CycleTerminalReason.Risk, riskExpiresAt)
+        const replayed = yield* store.block(draft.identity.cycleId, CycleTerminalReason.Risk, riskExpiresAt)
+        const unfinished = yield* store.readOldestUnfinished({
+          qualificationRunId: draft.identity.qualificationRunId,
+          accountId: draft.identity.accountId,
+        })
+        const [counts] = yield* sql<{
+          authorityGenerations: number
+          authorityStates: number
+          intents: number
+          mutations: number
+          orders: number
+        }>`
+          SELECT
+            (
+              SELECT count(*)::integer
+              FROM authority_generations
+              WHERE account_id = ${draft.identity.accountId}
+            ) AS "authorityGenerations",
+            (SELECT count(*)::integer FROM authority_state) AS "authorityStates",
+            (SELECT count(*)::integer FROM intents WHERE account_id = ${draft.identity.accountId}) AS intents,
+            (
+              SELECT count(*)::integer
+              FROM mutation_events AS event
+              JOIN intents AS intent USING (intent_id)
+              WHERE intent.account_id = ${draft.identity.accountId}
+            ) AS mutations,
+            (SELECT count(*)::integer FROM orders WHERE account_id = ${draft.identity.accountId}) AS orders
+        `
+        const [migration] = yield* sql<{ migration_id: number; name: string }>`
+          SELECT migration_id, name
+          FROM schema_migrations
+          WHERE migration_id = 21
+        `
+        return {
+          blocked,
+          counts,
+          directEarlyCutoff,
+          directEarlyRisk,
+          directWrongReason,
+          document: planned.document,
+          migration,
+          replayed,
+          unfinished,
+        }
+      }).pipe(Effect.provide(TestClock.layer())),
+    )
+
+    expect(result.document).toMatchObject({
+      mode: 'PAPER',
+      dispatchable: true,
+      targetPlan: { status: TargetPlanStatus.Planned },
+    })
+    expect(Exit.isFailure(result.directEarlyRisk)).toBe(true)
+    expect(Exit.isFailure(result.directEarlyCutoff)).toBe(true)
+    expect(Exit.isFailure(result.directWrongReason)).toBe(true)
+    expect(result.blocked.changed).toBe(true)
+    expect(result.blocked.cycle).toMatchObject({
+      state: CycleState.Blocked,
+      terminalReason: CycleTerminalReason.Risk,
+    })
+    expect(result.replayed.changed).toBe(false)
+    expect(result.replayed.cycle).toEqual(result.blocked.cycle)
+    expect(Option.isNone(result.unfinished)).toBe(true)
+    expect(result.counts).toEqual({
+      authorityGenerations: 2,
+      authorityStates: 0,
+      intents: 0,
+      mutations: 0,
+      orders: 0,
+    })
+    expect(result.migration).toEqual({ migration_id: 21, name: 'expired_paper_cycle_terminalization' })
+  })
+
+  test('terminalizes a PAPER cycle whose immutable authority generation has a durable descendant', async () => {
+    const executionPolicy = Result.getOrThrow(makeCycleExecutionPolicyFromModel(fixtureProtocol.executionModel))
+    const draft = makeDraft('paper-account-superseded-generation', { executionPolicy })
+    const result = await runtime.runPromise(
+      Effect.gen(function* () {
+        const store = yield* CycleStore
+        yield* store.acquire(draft, acquireAt)
+        yield* store.bindSnapshot(draft.identity.cycleId, makeInputManifest(snapshotA), snapshotAt)
+        const activated = yield* store.activate(draft.identity.cycleId, activeAt)
+        const planned = yield* buildPlannedPaperDecision(activated.cycle, snapshotA)
+        if (planned.document.targetPlan.status !== TargetPlanStatus.Planned) {
+          return yield* Effect.die(new Error('superseded PAPER fixture requires a planned decision'))
+        }
+        yield* insertReconciliation(planned.reconciliation)
+        yield* insertQualifiedPaperLineage(planned.document)
+        yield* store.bindDecision(draft.identity.cycleId, planned.document, decisionAt)
+        const successor = yield* insertSupersedingObserveGeneration(planned.document)
+        const directWrongReason = yield* Effect.exit(
+          store.block(draft.identity.cycleId, CycleTerminalReason.Risk, successor.activatedAt),
+        )
+        const blocked = yield* store.block(
+          draft.identity.cycleId,
+          CycleTerminalReason.ProvenanceMismatch,
+          successor.activatedAt,
+        )
+        const replayed = yield* store.block(
+          draft.identity.cycleId,
+          CycleTerminalReason.ProvenanceMismatch,
+          successor.activatedAt,
+        )
+        const unfinished = yield* store.readOldestUnfinished({
+          qualificationRunId: draft.identity.qualificationRunId,
+          accountId: draft.identity.accountId,
+        })
+        const sql = yield* PgClient.PgClient
+        const [counts] = yield* sql<{
+          authorityGenerations: number
+          authorityStates: number
+          intents: number
+          mutations: number
+          orders: number
+        }>`
+          SELECT
+            (
+              SELECT count(*)::integer
+              FROM authority_generations
+              WHERE account_id = ${draft.identity.accountId}
+            ) AS "authorityGenerations",
+            (SELECT count(*)::integer FROM authority_state) AS "authorityStates",
+            (SELECT count(*)::integer FROM intents WHERE account_id = ${draft.identity.accountId}) AS intents,
+            (
+              SELECT count(*)::integer
+              FROM mutation_events AS event
+              JOIN intents AS intent USING (intent_id)
+              WHERE intent.account_id = ${draft.identity.accountId}
+            ) AS mutations,
+            (SELECT count(*)::integer FROM orders WHERE account_id = ${draft.identity.accountId}) AS orders
+        `
+        return { blocked, counts, directWrongReason, replayed, successor, unfinished }
+      }).pipe(Effect.provide(TestClock.layer())),
+    )
+
+    expect(Exit.isFailure(result.directWrongReason)).toBe(true)
+    expect(result.blocked.changed).toBe(true)
+    expect(result.blocked.cycle).toMatchObject({
+      state: CycleState.Blocked,
+      terminalReason: CycleTerminalReason.ProvenanceMismatch,
+      terminalAt: result.successor.activatedAt,
+    })
+    expect(result.replayed.changed).toBe(false)
+    expect(result.replayed.cycle).toEqual(result.blocked.cycle)
+    expect(Option.isNone(result.unfinished)).toBe(true)
+    expect(result.counts).toEqual({
+      authorityGenerations: 3,
+      authorityStates: 0,
+      intents: 0,
+      mutations: 0,
+      orders: 0,
+    })
+  })
+
+  test.each(['submit-accepted', 'submit-unknown', 'cancel-accepted', 'cancel-unknown'] as const)(
+    'keeps superseded %s mutation history recoverable before an exact idempotent provenance block',
+    async (fixture) => {
+      const executionPolicy = Result.getOrThrow(makeCycleExecutionPolicyFromModel(fixtureProtocol.executionModel))
+      const result = await runtime.runPromise(
+        Effect.gen(function* () {
+          const sql = yield* PgClient.PgClient
+          const [clock] = yield* sql<{ evaluated_at: string }>`
+            SELECT to_char(
+              (clock_timestamp() - interval '1 second') AT TIME ZONE 'UTC',
+              'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'
+            ) AS evaluated_at
+          `
+          if (clock === undefined) return yield* Effect.die(new Error('database Clock returned no row'))
+          const evaluatedAt = clock.evaluated_at
+          const executionOpen = new Date(Date.parse(evaluatedAt) + 20 * 60_000)
+          const executionSessionDate = executionOpen.toISOString().slice(0, 10) as IsoDate
+          const signalDateValue = new Date(`${executionSessionDate}T00:00:00.000Z`)
+          signalDateValue.setUTCDate(signalDateValue.getUTCDate() - 1)
+          const signalSessionDate = signalDateValue.toISOString().slice(0, 10) as IsoDate
+          const draft = makeDraft(`paper-account-superseded-${fixture}`, {
+            executionPolicy,
+            executionCloseAt: `${executionSessionDate}T23:59:59.999Z`,
+            executionOpenAt: executionOpen.toISOString(),
+            executionSessionDate,
+            signalSessionDate,
+          })
+          const acquisitionAt = new Date(Date.parse(draft.window.signalCloseAt) + 60_000).toISOString()
+          const snapshotBoundAt = new Date(Date.parse(draft.window.signalCloseAt) + 120_000).toISOString()
+          const activatedAt = new Date(Date.parse(draft.window.signalCloseAt) + 180_000).toISOString()
+          const manifest = makeInputManifest(snapshotA, {
+            asOfSession: signalSessionDate,
+            finalizedAt: snapshotBoundAt,
+            lastSession: signalSessionDate,
+          })
+          const store = yield* CycleStore
+          yield* store.acquire(draft, acquisitionAt)
+          yield* store.bindSnapshot(draft.identity.cycleId, manifest, snapshotBoundAt)
+          const activated = yield* store.activate(draft.identity.cycleId, activatedAt)
+          const planned = yield* buildPlannedPaperDecision(activated.cycle, snapshotA, {
+            evaluatedAt,
+            snapshotFinalizedAt: snapshotBoundAt,
+          })
+          if (planned.document.targetPlan.status !== TargetPlanStatus.Planned) {
+            return yield* Effect.die(new Error('superseded mutation fixture requires a planned PAPER decision'))
+          }
+          yield* insertReconciliation(planned.reconciliation)
+          yield* insertQualifiedPaperLineage(planned.document)
+          const unfinishedMutation = yield* insertUnfinishedPlannedPaperMutation(planned.document, fixture)
+          yield* store.bindDecision(draft.identity.cycleId, planned.document, evaluatedAt)
+          const successor = yield* insertSupersedingObserveGeneration(planned.document)
+          const rotatedQualificationRunId = 'e'.repeat(64)
+          const earlierSignalDateValue = new Date(`${signalSessionDate}T00:00:00.000Z`)
+          earlierSignalDateValue.setUTCDate(earlierSignalDateValue.getUTCDate() - 1)
+          const earlierSignalSessionDate = earlierSignalDateValue.toISOString().slice(0, 10) as IsoDate
+          const currentDraft = makeDraft(draft.identity.accountId, {
+            executionCloseAt: `${signalSessionDate}T23:59:59.999Z`,
+            executionOpenAt: `${signalSessionDate}T20:00:00.000Z`,
+            executionPolicy,
+            executionSessionDate: signalSessionDate,
+            qualificationRunId: rotatedQualificationRunId,
+            signalSessionDate: earlierSignalSessionDate,
+          })
+          yield* store.acquire(
+            currentDraft,
+            new Date(Date.parse(currentDraft.window.signalCloseAt) + 60_000).toISOString(),
+          )
+          const recoveryScope = {
+            qualificationRunId: rotatedQualificationRunId,
+            accountId: draft.identity.accountId,
+          }
+          const premature = yield* Effect.exit(
+            store.block(draft.identity.cycleId, CycleTerminalReason.ProvenanceMismatch, successor.activatedAt),
+          )
+          const unfinishedBeforeRecovery = yield* store.readOldestUnfinished(recoveryScope)
+          const settled = yield* settleSupersededMutation(planned.document, unfinishedMutation.intent.intentId, fixture)
+          const unfinishedReadyToTerminalize = yield* store.readOldestUnfinished(recoveryScope)
+          const blocked = yield* store.block(
+            draft.identity.cycleId,
+            CycleTerminalReason.ProvenanceMismatch,
+            settled.recoveredAt,
+          )
+          const replayed = yield* store.block(
+            draft.identity.cycleId,
+            CycleTerminalReason.ProvenanceMismatch,
+            settled.recoveredAt,
+          )
+          const unfinishedAfterRecovery = yield* store.readOldestUnfinished(recoveryScope)
+          const [counts] = yield* sql<{
+            authorityGenerations: number
+            authorityStates: number
+            intents: number
+            mutations: number
+            orders: number
+          }>`
+            SELECT
+              (
+                SELECT count(*)::integer
+                FROM authority_generations
+                WHERE account_id = ${draft.identity.accountId}
+              ) AS "authorityGenerations",
+              (SELECT count(*)::integer FROM authority_state) AS "authorityStates",
+              (SELECT count(*)::integer FROM intents WHERE account_id = ${draft.identity.accountId}) AS intents,
+              (
+                SELECT count(*)::integer
+                FROM mutation_events AS event
+                JOIN intents AS intent USING (intent_id)
+                WHERE intent.account_id = ${draft.identity.accountId}
+              ) AS mutations,
+              (SELECT count(*)::integer FROM orders WHERE account_id = ${draft.identity.accountId}) AS orders
+          `
+          return {
+            blocked,
+            counts,
+            premature,
+            replayed,
+            unfinishedAfterRecovery,
+            unfinishedBeforeRecovery,
+            unfinishedReadyToTerminalize,
+            unfinishedMutation,
+            currentDraft,
+            rotatedQualificationRunId,
+          }
+        }).pipe(Effect.provide(TestClock.layer())),
+      )
+
+      expect(Exit.isFailure(result.premature)).toBe(true)
+      expect(Option.isSome(result.unfinishedBeforeRecovery)).toBe(true)
+      if (Option.isSome(result.unfinishedBeforeRecovery)) {
+        expect(result.unfinishedBeforeRecovery.value.identity.cycleId).toBe(result.blocked.cycle.identity.cycleId)
+        expect(result.unfinishedBeforeRecovery.value.identity.qualificationRunId).not.toBe(
+          result.rotatedQualificationRunId,
+        )
+      }
+      expect(Option.isSome(result.unfinishedReadyToTerminalize)).toBe(true)
+      if (Option.isSome(result.unfinishedReadyToTerminalize)) {
+        expect(result.unfinishedReadyToTerminalize.value.identity.cycleId).toBe(result.blocked.cycle.identity.cycleId)
+      }
+      expect(result.blocked.changed).toBe(true)
+      expect(result.blocked.cycle).toMatchObject({
+        state: CycleState.Blocked,
+        terminalReason: CycleTerminalReason.ProvenanceMismatch,
+      })
+      expect(result.replayed.changed).toBe(false)
+      expect(result.replayed.cycle).toEqual(result.blocked.cycle)
+      expect(Option.isSome(result.unfinishedAfterRecovery)).toBe(true)
+      if (Option.isSome(result.unfinishedAfterRecovery)) {
+        expect(result.unfinishedAfterRecovery.value.identity.cycleId).toBe(result.currentDraft.identity.cycleId)
+      }
+      expect(result.counts).toEqual({
+        authorityGenerations: 3,
+        authorityStates: 0,
+        intents: 1,
+        mutations: result.unfinishedMutation.mutationCount + 1,
+        orders: 0,
+      })
+    },
+    15_000,
+  )
+
+  test('rejects PAPER risk terminalization until a durable cancel outcome is recovered', async () => {
+    const executionPolicy = Result.getOrThrow(makeCycleExecutionPolicyFromModel(fixtureProtocol.executionModel))
+    const result = await runtime.runPromise(
+      Effect.gen(function* () {
+        const sql = yield* PgClient.PgClient
+        const [clock] = yield* sql<{ evaluated_at: string }>`
+          SELECT to_char(
+            (clock_timestamp() - interval '1 second') AT TIME ZONE 'UTC',
+            'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'
+          ) AS evaluated_at
+        `
+        if (clock === undefined) return yield* Effect.die(new Error('database Clock returned no row'))
+        const evaluatedAt = clock.evaluated_at
+        const executionOpen = new Date(Date.parse(evaluatedAt) + 20 * 60_000)
+        const executionSessionDate = executionOpen.toISOString().slice(0, 10) as IsoDate
+        const signalDateValue = new Date(`${executionSessionDate}T00:00:00.000Z`)
+        signalDateValue.setUTCDate(signalDateValue.getUTCDate() - 1)
+        const signalSessionDate = signalDateValue.toISOString().slice(0, 10) as IsoDate
+        const draft = makeDraft('paper-account-unresolved-cancel-terminalization', {
+          executionPolicy,
+          executionCloseAt: `${executionSessionDate}T23:59:59.999Z`,
+          executionOpenAt: executionOpen.toISOString(),
+          executionSessionDate,
+          signalSessionDate,
+        })
+        const acquisitionAt = new Date(Date.parse(draft.window.signalCloseAt) + 60_000).toISOString()
+        const snapshotBoundAt = new Date(Date.parse(draft.window.signalCloseAt) + 120_000).toISOString()
+        const activatedAt = new Date(Date.parse(draft.window.signalCloseAt) + 180_000).toISOString()
+        const manifest = makeInputManifest(snapshotA, {
+          asOfSession: signalSessionDate,
+          finalizedAt: snapshotBoundAt,
+          lastSession: signalSessionDate,
+        })
+        const store = yield* CycleStore
+        yield* store.acquire(draft, acquisitionAt)
+        yield* store.bindSnapshot(draft.identity.cycleId, manifest, snapshotBoundAt)
+        const activated = yield* store.activate(draft.identity.cycleId, activatedAt)
+        const planned = yield* buildPlannedPaperDecision(activated.cycle, snapshotA, {
+          evaluatedAt,
+          snapshotFinalizedAt: snapshotBoundAt,
+        })
+        if (planned.document.targetPlan.status !== TargetPlanStatus.Planned) {
+          return yield* Effect.die(new Error('unresolved cancel fixture requires a planned PAPER decision'))
+        }
+        yield* insertReconciliation(planned.reconciliation)
+        yield* insertQualifiedPaperLineage(planned.document)
+        const unfinished = yield* insertUnfinishedPlannedPaperMutation(planned.document, 'submit-accepted')
+        yield* store.bindDecision(draft.identity.cycleId, planned.document, evaluatedAt)
+
+        const cancelMutationId = canonicalHashV1({
+          intentId: unfinished.intent.intentId,
+          operation: 'CANCEL',
+        })
+        const cancelRequestHash = canonicalHashV1({
+          intentId: unfinished.intent.intentId,
+          fixture: 'cancel-terminalization',
+          operation: 'CANCEL',
+        })
+        const brokerOrderId = `superseded-${unfinished.intent.intentId.slice(0, 24)}`
+        const cancelStartedAt = new Date(Date.parse(planned.document.createdAt) + 3).toISOString()
+        const cancelUnknownAt = new Date(Date.parse(planned.document.createdAt) + 4).toISOString()
+        yield* sql`
+          INSERT INTO mutation_events (
+            event_id, schema_version, mutation_id, intent_id, sequence,
+            operation, event_type, request_hash, consistency_delay_ms, broker_order_id, occurred_at
+          ) VALUES
+          (
+            ${canonicalHashV1({ mutationId: cancelMutationId, sequence: 1, eventType: 'CANCEL_STARTED' })},
+            'bayn.paper-mutation-event.v1', ${cancelMutationId}, ${unfinished.intent.intentId}, 1,
+            'CANCEL', 'CANCEL_STARTED', ${cancelRequestHash}, 1000, ${brokerOrderId}, ${cancelStartedAt}
+          ),
+          (
+            ${canonicalHashV1({ mutationId: cancelMutationId, sequence: 2, eventType: 'CANCEL_UNKNOWN' })},
+            'bayn.paper-mutation-event.v1', ${cancelMutationId}, ${unfinished.intent.intentId}, 2,
+            'CANCEL', 'CANCEL_UNKNOWN', ${cancelRequestHash}, 1000, ${brokerOrderId}, ${cancelUnknownAt}
+          )
+        `
+        const terminalAt = new Date(Date.parse(planned.document.createdAt) + 5).toISOString()
+        yield* sql`
+          UPDATE intents
+          SET
+            state = 'TERMINAL',
+            terminal_outcome = 'EXPIRED',
+            state_version = state_version + 1,
+            updated_at = ${terminalAt}
+          WHERE intent_id = ${unfinished.intent.intentId}
+        `
+        const unresolvedBlock = yield* Effect.exit(
+          store.block(draft.identity.cycleId, CycleTerminalReason.Risk, terminalAt),
+        )
+
+        const recoveryAt = new Date(Date.parse(planned.document.createdAt) + 11_000).toISOString()
+        yield* sql`
+          INSERT INTO mutation_events (
+            event_id, schema_version, mutation_id, intent_id, sequence,
+            operation, event_type, request_hash, consistency_delay_ms,
+            broker_order_id, request_id, response_status, response_content_hash, occurred_at
+          ) VALUES (
+            ${canonicalHashV1({ mutationId: cancelMutationId, sequence: 3, eventType: 'RECOVERY_FOUND' })},
+            'bayn.paper-mutation-event.v1', ${cancelMutationId}, ${unfinished.intent.intentId}, 3,
+            'CANCEL', 'RECOVERY_FOUND', ${cancelRequestHash}, 1000, ${brokerOrderId},
+            'cancel-terminalization-recovery', 200, ${canonicalHashV1({ response: 'cancel-recovered' })}, ${recoveryAt}
+          )
+        `
+        const blocked = yield* store.block(draft.identity.cycleId, CycleTerminalReason.Risk, recoveryAt)
+        return { blocked, unresolvedBlock }
+      }).pipe(Effect.provide(TestClock.layer())),
+    )
+
+    expect(Exit.isFailure(result.unresolvedBlock)).toBe(true)
+    expect(result.blocked.cycle).toMatchObject({
+      state: CycleState.Blocked,
+      terminalReason: CycleTerminalReason.Risk,
+    })
+  }, 15_000)
+
+  test('binds and terminalizes a real PAPER risk block without intent or broker mutation state', async () => {
+    const executionPolicy = Result.getOrThrow(makeCycleExecutionPolicyFromModel(fixtureProtocol.executionModel))
+    const draft = makeDraft('paper-account-risk-blocked', { executionPolicy })
+    const result = await runtime.runPromise(
+      Effect.gen(function* () {
+        const store = yield* CycleStore
+        yield* store.acquire(draft, acquireAt)
+        yield* store.bindSnapshot(draft.identity.cycleId, makeInputManifest(snapshotA), snapshotAt)
+        const activated = yield* store.activate(draft.identity.cycleId, activeAt)
+        const planned = yield* buildPlannedPaperDecision(activated.cycle, snapshotA, {
+          transformPolicy: (policy) => ({ ...policy, maxOrderNotionalMicros: '1' }),
+        })
+        if (
+          planned.document.targetPlan.status !== TargetPlanStatus.Planned ||
+          planned.document.riskBlock === undefined ||
+          planned.document.deltaRisk.length === 0
+        ) {
+          return yield* Effect.die(new Error('PAPER risk-block fixture requires exact blocked cumulative evidence'))
+        }
+        yield* insertReconciliation(planned.reconciliation)
+        yield* insertQualifiedPaperLineage(planned.document)
+        const bound = yield* store.bindDecision(draft.identity.cycleId, planned.document, decisionAt)
+        const bindingReplay = yield* store.bindDecision(draft.identity.cycleId, planned.document, decisionAt)
+
+        const sql = yield* PgClient.PgClient
+        const directCompleted = yield* Effect.exit(sql`
+          UPDATE autonomous_cycles
+          SET
+            state = ${CycleState.Completed},
+            state_version = state_version + 1,
+            updated_at = ${decisionAt},
+            terminal_at = ${decisionAt}
+          WHERE cycle_id = ${draft.identity.cycleId}
+        `)
+        const storeCompleted = yield* Effect.exit(
+          store.finish(draft.identity.cycleId, CycleState.Completed, decisionAt),
+        )
+        const directWrongReason = yield* Effect.exit(sql`
+          UPDATE autonomous_cycles
+          SET
+            state = ${CycleState.Blocked},
+            terminal_reason = ${CycleTerminalReason.Reconciliation},
+            state_version = state_version + 1,
+            updated_at = ${decisionAt},
+            terminal_at = ${decisionAt}
+          WHERE cycle_id = ${draft.identity.cycleId}
+        `)
+
+        const blocked = yield* store.block(draft.identity.cycleId, CycleTerminalReason.Risk, decisionAt)
+        const blockReplay = yield* store.block(draft.identity.cycleId, CycleTerminalReason.Risk, decisionAt)
+        const unfinished = yield* store.readOldestUnfinished({
+          qualificationRunId: draft.identity.qualificationRunId,
+          accountId: draft.identity.accountId,
+        })
+        const [counts] = yield* sql<{
+          authorityGenerations: number
+          authorityStates: number
+          intents: number
+          mutations: number
+          orders: number
+        }>`
+          SELECT
+            (
+              SELECT count(*)::integer
+              FROM authority_generations
+              WHERE account_id = ${draft.identity.accountId}
+            ) AS "authorityGenerations",
+            (SELECT count(*)::integer FROM authority_state) AS "authorityStates",
+            (SELECT count(*)::integer FROM intents WHERE account_id = ${draft.identity.accountId}) AS intents,
+            (
+              SELECT count(*)::integer
+              FROM mutation_events AS event
+              JOIN intents AS intent USING (intent_id)
+              WHERE intent.account_id = ${draft.identity.accountId}
+            ) AS mutations,
+            (SELECT count(*)::integer FROM orders WHERE account_id = ${draft.identity.accountId}) AS orders
+        `
+        return {
+          bindingReplay,
+          blockReplay,
+          blocked,
+          bound,
+          counts,
+          directCompleted,
+          directWrongReason,
+          document: planned.document,
+          storeCompleted,
+          unfinished,
+        }
+      }).pipe(Effect.provide(TestClock.layer())),
+    )
+
+    expect(result.document).toMatchObject({
+      mode: 'PAPER',
+      dispatchable: false,
+      targetPlan: { status: TargetPlanStatus.Planned },
+      riskBlock: {
+        intentId: result.document.orderedIntentIds.at(-1),
+        decisionId: result.document.deltaRisk.at(-1)?.evaluation.decision.decisionId,
+      },
+    })
+    expect(result.document.riskBlock?.reasonCodes).toContain(Reason.OrderNotionalExceeded)
+    expect(result.document.riskBlock?.reasonCodes).not.toContain(Reason.AuthorityNotPaper)
+    expect(result.document.deltaRisk.at(-1)?.evaluation.decision.outcome).toBe(RiskOutcome.Blocked)
+    expect(result.bound.changed).toBe(true)
+    expect(result.bindingReplay.changed).toBe(false)
+    expect(result.bindingReplay.cycle).toEqual(result.bound.cycle)
+    expect(Exit.isFailure(result.directCompleted)).toBe(true)
+    expect(Exit.isFailure(result.storeCompleted)).toBe(true)
+    expect(Exit.isFailure(result.directWrongReason)).toBe(true)
+    expect(result.blocked.changed).toBe(true)
+    expect(result.blocked.cycle).toMatchObject({
+      state: CycleState.Blocked,
+      terminalReason: CycleTerminalReason.Risk,
+      terminalAt: decisionAt,
+    })
+    expect(result.blockReplay.changed).toBe(false)
+    expect(result.blockReplay.cycle).toEqual(result.blocked.cycle)
+    expect(Option.isNone(result.unfinished)).toBe(true)
+    expect(result.counts).toEqual({
+      authorityGenerations: 2,
+      authorityStates: 0,
+      intents: 0,
+      mutations: 0,
+      orders: 0,
+    })
+  })
+
+  test('terminalizes a known denied PAPER intent and releases oldest-unfinished selection immediately', async () => {
+    const result = await runtime.runPromise(
+      Effect.gen(function* () {
+        const sql = yield* PgClient.PgClient
+        const [clock] = yield* sql<{ evaluated_at: string }>`
+          SELECT to_char(
+            (clock_timestamp() - interval '1 second') AT TIME ZONE 'UTC',
+            'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'
+          ) AS evaluated_at
+        `
+        if (clock === undefined) return yield* Effect.die(new Error('database Clock returned no row'))
+        const evaluatedAt = clock.evaluated_at
+        const executionOpen = new Date(Date.parse(evaluatedAt) + 20 * 60_000)
+        const executionSessionDate = executionOpen.toISOString().slice(0, 10) as IsoDate
+        const signalDateValue = new Date(`${executionSessionDate}T00:00:00.000Z`)
+        signalDateValue.setUTCDate(signalDateValue.getUTCDate() - 1)
+        const signalSessionDate = signalDateValue.toISOString().slice(0, 10) as IsoDate
+        const executionCloseAt = `${executionSessionDate}T23:59:59.999Z`
+        const executionPolicy = Result.getOrThrow(makeCycleExecutionPolicyFromModel(fixtureProtocol.executionModel))
+        const draft = makeDraft('paper-account-terminal-denied', {
+          executionPolicy,
+          executionCloseAt,
+          executionOpenAt: executionOpen.toISOString(),
+          executionSessionDate,
+          signalSessionDate,
+        })
+        const acquisitionAt = new Date(Date.parse(draft.window.signalCloseAt) + 60_000).toISOString()
+        const snapshotBoundAt = new Date(Date.parse(draft.window.signalCloseAt) + 120_000).toISOString()
+        const activatedAt = new Date(Date.parse(draft.window.signalCloseAt) + 180_000).toISOString()
+        const manifest = makeInputManifest(snapshotB, {
+          asOfSession: signalSessionDate,
+          finalizedAt: snapshotBoundAt,
+          lastSession: signalSessionDate,
+        })
+
+        const store = yield* CycleStore
+        yield* store.acquire(draft, acquisitionAt)
+        yield* store.bindSnapshot(draft.identity.cycleId, manifest, snapshotBoundAt)
+        const activated = yield* store.activate(draft.identity.cycleId, activatedAt)
+        const planned = yield* buildPlannedPaperDecision(activated.cycle, snapshotB, {
+          evaluatedAt,
+          snapshotFinalizedAt: snapshotBoundAt,
+        })
+        if (
+          planned.document.targetPlan.status !== TargetPlanStatus.Planned ||
+          planned.document.deltaRisk.length === 0
+        ) {
+          return yield* Effect.die(new Error('terminal PAPER failure fixture requires a planned mutation'))
+        }
+        yield* insertReconciliation(planned.reconciliation)
+        yield* store.bindDecision(draft.identity.cycleId, planned.document, evaluatedAt)
+        const denied = yield* insertQualifiedPaperLineage(planned.document, { deniedIntent: true })
+        const prematureAt = new Date(Date.parse(denied.deniedAt) - 1).toISOString()
+
+        const directPremature = yield* Effect.exit(sql`
+          UPDATE autonomous_cycles
+          SET
+            state = ${CycleState.Blocked},
+            terminal_reason = ${CycleTerminalReason.Risk},
+            state_version = state_version + 1,
+            updated_at = ${prematureAt},
+            terminal_at = ${prematureAt}
+          WHERE cycle_id = ${draft.identity.cycleId}
+        `)
+        const directWrongReason = yield* Effect.exit(sql`
+          UPDATE autonomous_cycles
+          SET
+            state = ${CycleState.Blocked},
+            terminal_reason = ${CycleTerminalReason.Reconciliation},
+            state_version = state_version + 1,
+            updated_at = ${denied.deniedAt},
+            terminal_at = ${denied.deniedAt}
+          WHERE cycle_id = ${draft.identity.cycleId}
+        `)
+
+        const blocked = yield* store.block(draft.identity.cycleId, CycleTerminalReason.Risk, denied.deniedAt)
+        const replayed = yield* store.block(draft.identity.cycleId, CycleTerminalReason.Risk, denied.deniedAt)
+        const unfinished = yield* store.readOldestUnfinished({
+          qualificationRunId: draft.identity.qualificationRunId,
+          accountId: draft.identity.accountId,
+        })
+        const [counts] = yield* sql<{
+          authorityGenerations: number
+          authorityStates: number
+          intents: number
+          mutations: number
+          orders: number
+        }>`
+          SELECT
+            (
+              SELECT count(*)::integer
+              FROM authority_generations
+              WHERE account_id = ${draft.identity.accountId}
+            ) AS "authorityGenerations",
+            (SELECT count(*)::integer FROM authority_state) AS "authorityStates",
+            (SELECT count(*)::integer FROM intents WHERE account_id = ${draft.identity.accountId}) AS intents,
+            (
+              SELECT count(*)::integer
+              FROM mutation_events AS event
+              JOIN intents AS intent USING (intent_id)
+              WHERE intent.account_id = ${draft.identity.accountId}
+            ) AS mutations,
+            (SELECT count(*)::integer FROM orders WHERE account_id = ${draft.identity.accountId}) AS orders
+        `
+        return {
+          blocked,
+          counts,
+          denied,
+          directPremature,
+          directWrongReason,
+          replayed,
+          unfinished,
+        }
+      }).pipe(Effect.provide(TestClock.layer())),
+    )
+
+    expect(Exit.isFailure(result.directPremature)).toBe(true)
+    expect(Exit.isFailure(result.directWrongReason)).toBe(true)
+    expect(result.denied.intent.state).toBe(IntentState.Planned)
+    expect(result.blocked.changed).toBe(true)
+    expect(result.blocked.cycle).toMatchObject({
+      state: CycleState.Blocked,
+      terminalReason: CycleTerminalReason.Risk,
+      terminalAt: result.denied.deniedAt,
+    })
+    expect(result.replayed.changed).toBe(false)
+    expect(result.replayed.cycle).toEqual(result.blocked.cycle)
+    expect(Option.isNone(result.unfinished)).toBe(true)
+    expect(result.counts).toEqual({
+      authorityGenerations: 2,
+      authorityStates: 0,
+      intents: 1,
+      mutations: 2,
+      orders: 0,
+    })
+  })
+
+  test('requires terminal-filled PAPER intents and later exact reconciliation before completion', async () => {
+    const result = await runtime.runPromise(
+      Effect.gen(function* () {
+        const sql = yield* PgClient.PgClient
+        const [clock] = yield* sql<{ evaluated_at: string }>`
+          SELECT to_char(
+            (clock_timestamp() - interval '1 second') AT TIME ZONE 'UTC',
+            'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'
+          ) AS evaluated_at
+        `
+        if (clock === undefined) return yield* Effect.die(new Error('database Clock returned no row'))
+        const evaluatedAt = clock.evaluated_at
+        const executionOpen = new Date(Date.parse(evaluatedAt) + 20 * 60_000)
+        const executionSessionDate = executionOpen.toISOString().slice(0, 10) as IsoDate
+        const signalDateValue = new Date(`${executionSessionDate}T00:00:00.000Z`)
+        signalDateValue.setUTCDate(signalDateValue.getUTCDate() - 1)
+        const signalSessionDate = signalDateValue.toISOString().slice(0, 10) as IsoDate
+        const executionPolicy = Result.getOrThrow(makeCycleExecutionPolicyFromModel(fixtureProtocol.executionModel))
+        const draft = makeDraft('paper-account-completion-proof', {
+          executionPolicy,
+          executionCloseAt: `${executionSessionDate}T23:59:59.999Z`,
+          executionOpenAt: executionOpen.toISOString(),
+          executionSessionDate,
+          signalSessionDate,
+        })
+        const acquisitionAt = new Date(Date.parse(draft.window.signalCloseAt) + 60_000).toISOString()
+        const snapshotBoundAt = new Date(Date.parse(draft.window.signalCloseAt) + 120_000).toISOString()
+        const activatedAt = new Date(Date.parse(draft.window.signalCloseAt) + 180_000).toISOString()
+        const manifest = makeInputManifest(snapshotB, {
+          asOfSession: signalSessionDate,
+          finalizedAt: snapshotBoundAt,
+          lastSession: signalSessionDate,
+        })
+
+        const store = yield* CycleStore
+        yield* store.acquire(draft, acquisitionAt)
+        yield* store.bindSnapshot(draft.identity.cycleId, manifest, snapshotBoundAt)
+        const activated = yield* store.activate(draft.identity.cycleId, activatedAt)
+        const planned = yield* buildPlannedPaperDecision(activated.cycle, snapshotB, {
+          evaluatedAt,
+          snapshotFinalizedAt: snapshotBoundAt,
+        })
+        if (
+          planned.document.targetPlan.status !== TargetPlanStatus.Planned ||
+          planned.document.riskBlock !== undefined
+        ) {
+          return yield* Effect.die(new Error('PAPER completion fixture requires a dispatchable planned decision'))
+        }
+        yield* insertReconciliation(planned.reconciliation)
+        yield* insertQualifiedPaperLineage(planned.document)
+        yield* store.bindDecision(draft.identity.cycleId, planned.document, evaluatedAt)
+
+        const directPremature = yield* Effect.exit(sql`
+          UPDATE autonomous_cycles
+          SET
+            state = ${CycleState.Completed},
+            state_version = state_version + 1,
+            updated_at = ${evaluatedAt},
+            terminal_at = ${evaluatedAt}
+          WHERE cycle_id = ${draft.identity.cycleId}
+        `)
+        const storePremature = yield* Effect.exit(
+          store.finish(draft.identity.cycleId, CycleState.Completed, evaluatedAt),
+        )
+
+        const filled = yield* insertFilledPlannedPaperIntent(planned.document, 'started')
+        const unresolvedReconciledAt = new Date(Date.parse(filled.filledAt) + 1).toISOString()
+        yield* insertReconciliation(plannedPaperReconciliation(activated.cycle, unresolvedReconciledAt))
+        const unresolvedStarted = yield* Effect.exit(
+          store.finish(draft.identity.cycleId, CycleState.Completed, unresolvedReconciledAt),
+        )
+        const settledAt = new Date(Date.parse(unresolvedReconciledAt) + 1).toISOString()
+        yield* settleStartedPaperSubmit(filled, settledAt)
+        const reconciledAt = new Date(Date.parse(settledAt) + 1).toISOString()
+        yield* insertReconciliation(plannedPaperReconciliation(activated.cycle, reconciledAt))
+        const completed = yield* store.finish(draft.identity.cycleId, CycleState.Completed, reconciledAt)
+        const replayed = yield* store.finish(draft.identity.cycleId, CycleState.Completed, reconciledAt)
+        const unfinished = yield* store.readOldestUnfinished({
+          qualificationRunId: draft.identity.qualificationRunId,
+          accountId: draft.identity.accountId,
+        })
+        const [counts] = yield* sql<{
+          authorityGenerations: number
+          authorityStates: number
+          intents: number
+          mutations: number
+          orders: number
+        }>`
+          SELECT
+            (
+              SELECT count(*)::integer
+              FROM authority_generations
+              WHERE account_id = ${draft.identity.accountId}
+            ) AS "authorityGenerations",
+            (SELECT count(*)::integer FROM authority_state) AS "authorityStates",
+            (SELECT count(*)::integer FROM intents WHERE account_id = ${draft.identity.accountId}) AS intents,
+            (
+              SELECT count(*)::integer
+              FROM mutation_events AS event
+              JOIN intents AS intent USING (intent_id)
+              WHERE intent.account_id = ${draft.identity.accountId}
+            ) AS mutations,
+            (SELECT count(*)::integer FROM orders WHERE account_id = ${draft.identity.accountId}) AS orders
+        `
+        return {
+          completed,
+          counts,
+          directPremature,
+          filled,
+          reconciledAt,
+          replayed,
+          storePremature,
+          unfinished,
+          unresolvedStarted,
+        }
+      }).pipe(Effect.provide(TestClock.layer())),
+    )
+
+    expect(Exit.isFailure(result.directPremature)).toBe(true)
+    expect(Exit.isFailure(result.storePremature)).toBe(true)
+    expect(Exit.isFailure(result.unresolvedStarted)).toBe(true)
+    expect(result.completed.changed).toBe(true)
+    expect(result.completed.cycle).toMatchObject({
+      state: CycleState.Completed,
+      terminalAt: result.reconciledAt,
+    })
+    expect(result.replayed.changed).toBe(false)
+    expect(result.replayed.cycle).toEqual(result.completed.cycle)
+    expect(Option.isNone(result.unfinished)).toBe(true)
+    expect(result.filled.intent.state).toBe(IntentState.Planned)
+    expect(result.counts).toEqual({
+      authorityGenerations: 2,
+      authorityStates: 0,
+      intents: 1,
+      mutations: 2,
+      orders: 0,
     })
   })
 

--- a/services/bayn/src/db/cycle-store/model.ts
+++ b/services/bayn/src/db/cycle-store/model.ts
@@ -2,9 +2,28 @@ import { Context, Data, Effect, Option, Result, Schema } from 'effect'
 import { isSqlError, type SqlError } from 'effect/unstable/sql/SqlError'
 
 import type { AutonomousCycle, CycleCompletionState, CycleDraft, CycleTerminalReason } from '../../cycle'
-import type { ObserveShadowDecisionDocument } from '../../shadow-decision-contract'
+import type { CycleDecisionDocument } from '../../shadow-decision-contract'
 import type { InputManifest, IsoDate } from '../../types'
 import type { CycleStoreDecisionFailure } from './decisions'
+
+export interface CycleDecisionStoreEvidence {
+  readonly paperCompletionEvidenceMatches: boolean
+  readonly paperGenerationIsSuperseded: boolean
+}
+
+const decisionStoreEvidence = new WeakMap<object, CycleDecisionStoreEvidence>()
+
+export const attachCycleDecisionStoreEvidence = (
+  document: CycleDecisionDocument,
+  evidence: CycleDecisionStoreEvidence,
+): CycleDecisionDocument => {
+  const attached = { ...document } satisfies CycleDecisionDocument
+  decisionStoreEvidence.set(attached, evidence)
+  return attached
+}
+
+export const cycleDecisionStoreEvidence = (document: CycleDecisionDocument): CycleDecisionStoreEvidence | undefined =>
+  decisionStoreEvidence.get(document)
 
 export interface CycleAcquireReceipt {
   readonly cycle: AutonomousCycle
@@ -53,7 +72,7 @@ export interface CycleStoreShape {
   ) => Effect.Effect<Option.Option<AutonomousCycle>, CycleStoreError>
   readonly readDecisionDocument: (
     cycleId: string,
-  ) => Effect.Effect<Option.Option<ObserveShadowDecisionDocument>, CycleStoreError>
+  ) => Effect.Effect<Option.Option<CycleDecisionDocument>, CycleStoreError>
   readonly readOldestUnfinished: (
     scope: CycleRecoveryScope,
   ) => Effect.Effect<Option.Option<AutonomousCycle>, CycleStoreError>
@@ -65,7 +84,7 @@ export interface CycleStoreShape {
   readonly activate: (cycleId: string, observedAt: string) => Effect.Effect<CycleMutationReceipt, CycleStoreError>
   readonly bindDecision: (
     cycleId: string,
-    document: ObserveShadowDecisionDocument,
+    document: CycleDecisionDocument,
     observedAt: string,
   ) => Effect.Effect<CycleMutationReceipt, CycleStoreError>
   readonly finish: (

--- a/services/bayn/src/db/cycle-store/queries.ts
+++ b/services/bayn/src/db/cycle-store/queries.ts
@@ -2,8 +2,13 @@ import { PgClient } from '@effect/sql-pg'
 import { Effect } from 'effect'
 
 import { CycleState, type AutonomousCycle } from '../../cycle'
-import type { ObserveShadowDecisionDocument } from '../../shadow-decision-contract'
-import type { CycleAuthoritySlot, CycleRecoveryScope, CycleStoreInternalError } from './model'
+import type { CycleDecisionDocument, PaperDecisionDocument } from '../../shadow-decision-contract'
+import {
+  attachCycleDecisionStoreEvidence,
+  type CycleAuthoritySlot,
+  type CycleRecoveryScope,
+  type CycleStoreInternalError,
+} from './model'
 import { decodeDecisionEvidenceMatch, decodeStoredCycles, decodeStoredDecisionDocumentRows } from './rows'
 
 export interface CycleQueries {
@@ -16,12 +21,17 @@ export interface CycleQueries {
   ) => Effect.Effect<readonly AutonomousCycle[], CycleStoreInternalError>
   readonly selectDecisionDocuments: (
     cycleId: string,
-  ) => Effect.Effect<readonly ObserveShadowDecisionDocument[], CycleStoreInternalError>
+  ) => Effect.Effect<readonly CycleDecisionDocument[], CycleStoreInternalError>
   readonly selectOldestUnfinishedCycle: (
     scope: CycleRecoveryScope,
   ) => Effect.Effect<readonly AutonomousCycle[], CycleStoreInternalError>
-  readonly decisionEvidenceMatches: (
-    document: ObserveShadowDecisionDocument,
+  readonly decisionEvidenceMatches: (document: CycleDecisionDocument) => Effect.Effect<boolean, CycleStoreInternalError>
+  readonly paperCompletionEvidenceMatches: (
+    document: PaperDecisionDocument,
+    observedAt: string,
+  ) => Effect.Effect<boolean, CycleStoreInternalError>
+  readonly paperGenerationIsSuperseded: (
+    document: PaperDecisionDocument,
   ) => Effect.Effect<boolean, CycleStoreInternalError>
 }
 
@@ -86,33 +96,124 @@ export const makeCycleQueries = (sql: PgClient.PgClient): CycleQueries => {
 
   const selectDecisionDocuments: CycleQueries['selectDecisionDocuments'] = (cycleId) =>
     sql<Record<string, unknown>>`
-      SELECT document
+      SELECT
+        document,
+        paper_cycle_completion_evidence_matches(
+          cycle_id,
+          decision_hash,
+          clock_timestamp()
+        ) AS paper_completion_evidence_matches,
+        paper_cycle_generation_is_superseded(
+          cycle_id,
+          decision_hash
+        ) AS paper_generation_is_superseded
       FROM autonomous_cycle_shadow_decisions
       WHERE cycle_id = ${cycleId}
     `.pipe(
       Effect.flatMap(decodeStoredDecisionDocumentRows),
-      Effect.map((rows) => rows.map(({ document }) => document)),
+      Effect.map((rows) =>
+        rows.map(({ document, paper_completion_evidence_matches, paper_generation_is_superseded }) =>
+          attachCycleDecisionStoreEvidence(document, {
+            paperCompletionEvidenceMatches: paper_completion_evidence_matches,
+            paperGenerationIsSuperseded: paper_generation_is_superseded,
+          }),
+        ),
+      ),
     )
 
   const selectOldestUnfinishedCycle: CycleQueries['selectOldestUnfinishedCycle'] = (scope) =>
     sql<Record<string, unknown>>`
+      WITH cycle_candidates AS (
+        SELECT
+          cycle.*,
+          decision.document IS NOT NULL AS is_planned_paper,
+          CASE
+            WHEN decision.document IS NULL THEN false
+            ELSE paper_cycle_generation_is_superseded(cycle.cycle_id, cycle.decision_hash)
+          END AS generation_is_superseded,
+          CASE
+            WHEN decision.document IS NULL THEN false
+            ELSE EXISTS (
+              SELECT 1
+              FROM jsonb_array_elements_text(
+                CASE
+                  WHEN jsonb_typeof(decision.document -> 'orderedIntentIds') = 'array'
+                    THEN decision.document -> 'orderedIntentIds'
+                  ELSE '[]'::jsonb
+                END
+              ) AS planned(intent_id)
+              JOIN intents AS intent
+                ON intent.intent_id = planned.intent_id
+                AND intent.account_id = cycle.account_id
+                AND intent.cycle_id = cycle.cycle_id
+                AND intent.decision_hash = decision.document #>> '{bindings,strategyDecisionHash}'
+              JOIN LATERAL (
+                SELECT
+                  event.operation,
+                  event.event_type
+                FROM mutation_events AS event
+                WHERE event.intent_id = intent.intent_id
+                ORDER BY
+                  CASE event.operation WHEN 'CANCEL' THEN 1 ELSE 0 END DESC,
+                  event.sequence DESC
+                LIMIT 1
+              ) AS latest ON true
+              WHERE intent.state <> 'TERMINAL'
+                OR (
+                  latest.operation = 'SUBMIT'
+                  AND latest.event_type NOT IN (
+                    'SUBMIT_ACCEPTED',
+                    'SUBMIT_REJECTED',
+                    'SUBMIT_DENIED',
+                    'RECOVERY_FOUND'
+                  )
+                )
+                OR (
+                  latest.operation = 'CANCEL'
+                  AND latest.event_type <> 'RECOVERY_FOUND'
+                )
+            )
+          END AS has_mutation_work
+        FROM autonomous_cycles AS cycle
+        LEFT JOIN autonomous_cycle_shadow_decisions AS decision
+          ON decision.cycle_id = cycle.cycle_id
+          AND decision.decision_hash = cycle.decision_hash
+          AND decision.document ->> 'schemaVersion' = 'bayn.paper-cycle-decision.v1'
+          AND decision.document ->> 'mode' = 'PAPER'
+          AND decision.document #>> '{targetPlan,status}' = 'PLANNED'
+        WHERE cycle.account_id = ${scope.accountId}
+          AND cycle.state IN (${CycleState.Pending}, ${CycleState.Active})
+      ), eligible_cycles AS (
+        SELECT *
+        FROM cycle_candidates
+        WHERE qualification_run_id = ${scope.qualificationRunId}
+          OR (
+            state = ${CycleState.Active}
+            AND is_planned_paper
+            AND (has_mutation_work OR generation_is_superseded)
+          )
+      )
       SELECT
-        cycle_id, schema_version, identity_schema_version, strategy_name,
-        qualification_run_id, strategy_protocol_hash, account_id,
-        signal_session_date::text AS signal_session_date, signal_calendar_version,
-        execution_policy_schema_version, execution_policy_hash,
-        strategy_execution_model_hash, submission_window_ms, submission_cutoff_before_open_ms,
-        window_schema_version, execution_calendar_schema_version,
-        execution_calendar_source, execution_calendar_hash,
-        execution_session_date::text AS execution_session_date,
-        signal_close_at, publication_deadline_at, submission_open_at,
-        execution_open_at, execution_close_at, submission_cutoff_at, state, snapshot_id,
-        decision_hash, terminal_reason, state_version, created_at, updated_at, terminal_at
-      FROM autonomous_cycles
-      WHERE qualification_run_id = ${scope.qualificationRunId}
-        AND account_id = ${scope.accountId}
-        AND state IN (${CycleState.Pending}, ${CycleState.Active})
-      ORDER BY signal_session_date ASC, cycle_id ASC
+        cycle.cycle_id, cycle.schema_version, cycle.identity_schema_version, cycle.strategy_name,
+        cycle.qualification_run_id, cycle.strategy_protocol_hash, cycle.account_id,
+        cycle.signal_session_date::text AS signal_session_date, cycle.signal_calendar_version,
+        cycle.execution_policy_schema_version, cycle.execution_policy_hash,
+        cycle.strategy_execution_model_hash, cycle.submission_window_ms, cycle.submission_cutoff_before_open_ms,
+        cycle.window_schema_version, cycle.execution_calendar_schema_version,
+        cycle.execution_calendar_source, cycle.execution_calendar_hash,
+        cycle.execution_session_date::text AS execution_session_date,
+        cycle.signal_close_at, cycle.publication_deadline_at, cycle.submission_open_at,
+        cycle.execution_open_at, cycle.execution_close_at, cycle.submission_cutoff_at, cycle.state, cycle.snapshot_id,
+        cycle.decision_hash, cycle.terminal_reason, cycle.state_version, cycle.created_at, cycle.updated_at, cycle.terminal_at
+      FROM eligible_cycles AS cycle
+      ORDER BY
+        CASE
+          WHEN cycle.has_mutation_work THEN 0
+          WHEN cycle.is_planned_paper THEN 1
+          ELSE 2
+        END ASC,
+        cycle.signal_session_date ASC,
+        cycle.cycle_id ASC
       LIMIT 1
     `.pipe(Effect.flatMap(decodeStoredCycles))
 
@@ -138,11 +239,36 @@ export const makeCycleQueries = (sql: PgClient.PgClient): CycleQueries => {
       Effect.map(([match]) => match.matches),
     )
 
+  const paperCompletionEvidenceMatches: CycleQueries['paperCompletionEvidenceMatches'] = (document, observedAt) =>
+    sql<Record<string, unknown>>`
+      SELECT paper_cycle_completion_evidence_matches(
+        ${document.bindings.cycleId},
+        ${document.contentHash},
+        ${observedAt}::timestamptz
+      ) AS matches
+    `.pipe(
+      Effect.flatMap(decodeDecisionEvidenceMatch),
+      Effect.map(([match]) => match.matches),
+    )
+
+  const paperGenerationIsSuperseded: CycleQueries['paperGenerationIsSuperseded'] = (document) =>
+    sql<Record<string, unknown>>`
+      SELECT paper_cycle_generation_is_superseded(
+        ${document.bindings.cycleId},
+        ${document.contentHash}
+      ) AS matches
+    `.pipe(
+      Effect.flatMap(decodeDecisionEvidenceMatch),
+      Effect.map(([match]) => match.matches),
+    )
+
   return {
     selectCycle,
     selectCycleByAuthoritySlot,
     selectDecisionDocuments,
     selectOldestUnfinishedCycle,
     decisionEvidenceMatches,
+    paperCompletionEvidenceMatches,
+    paperGenerationIsSuperseded,
   }
 }

--- a/services/bayn/src/db/cycle-store/rows.ts
+++ b/services/bayn/src/db/cycle-store/rows.ts
@@ -15,7 +15,7 @@ import {
   UtcInstantSchema,
   strictParseOptions,
 } from '../../schemas'
-import { ObserveShadowDecisionDocumentSchema } from '../../shadow-decision-contract'
+import { CycleDecisionDocumentSchema } from '../../shadow-decision-contract'
 
 const StoredCycleRowSchema = Schema.Struct({
   cycle_id: Sha256Schema,
@@ -66,7 +66,7 @@ const CycleRecoveryScopeSchema = Schema.Struct({
 const SnapshotInputSchema = Schema.Struct({ cycleId: Sha256Schema, observedAt: UtcInstantSchema })
 const DecisionInputSchema = Schema.Struct({
   cycleId: Sha256Schema,
-  document: ObserveShadowDecisionDocumentSchema,
+  document: CycleDecisionDocumentSchema,
   observedAt: UtcInstantSchema,
 })
 const BlockInputSchema = Schema.Struct({
@@ -81,7 +81,13 @@ const FinishInputSchema = Schema.Struct({
 })
 const MutationRowsSchema = Schema.Array(Schema.Struct({ cycle_id: Sha256Schema })).check(Schema.isMaxLength(1))
 const DecisionEvidenceMatchSchema = Schema.Tuple([Schema.Struct({ matches: Schema.Boolean })])
-const StoredDecisionDocumentRowsSchema = Schema.Array(Schema.Struct({ document: ObserveShadowDecisionDocumentSchema }))
+const StoredDecisionDocumentRowsSchema = Schema.Array(
+  Schema.Struct({
+    document: CycleDecisionDocumentSchema,
+    paper_completion_evidence_matches: Schema.Boolean,
+    paper_generation_is_superseded: Schema.Boolean,
+  }),
+)
 
 export const decodeCycleId = Schema.decodeUnknownEffect(Sha256Schema, strictParseOptions)
 export const decodeCycleIdInput = Schema.decodeUnknownEffect(CycleIdInputSchema, strictParseOptions)

--- a/services/bayn/src/db/evidence-store.integration.test.ts
+++ b/services/bayn/src/db/evidence-store.integration.test.ts
@@ -1173,6 +1173,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
       { migration_id: 18, name: 'robust_trend_protocol' },
       { migration_id: 19, name: 'explicit_execution_authority' },
       { migration_id: 20, name: 'pretransmit_submit_denial' },
+      { migration_id: 21, name: 'expired_paper_cycle_terminalization' },
     ])
   })
 

--- a/services/bayn/src/db/migrations.ts
+++ b/services/bayn/src/db/migrations.ts
@@ -20,6 +20,7 @@ import stableCapitalGrantGeneration from '../../migrations/0017_stable_paper_aut
 import robustTrendProtocol from '../../migrations/0018_robust_trend_protocol'
 import explicitExecutionAuthority from '../../migrations/0019_explicit_execution_authority'
 import pretransmitSubmitDenial from '../../migrations/0020_pretransmit_submit_denial'
+import expiredPaperCycleTerminalization from '../../migrations/0021_expired_paper_cycle_terminalization'
 
 export const migrationLoader = PgMigrator.fromRecord({
   '1_initial_schema': initialSchema,
@@ -42,4 +43,5 @@ export const migrationLoader = PgMigrator.fromRecord({
   '18_robust_trend_protocol': robustTrendProtocol,
   '19_explicit_execution_authority': explicitExecutionAuthority,
   '20_pretransmit_submit_denial': pretransmitSubmitDenial,
+  '21_expired_paper_cycle_terminalization': expiredPaperCycleTerminalization,
 })

--- a/services/bayn/src/execution-candidate-discovery/program.ts
+++ b/services/bayn/src/execution-candidate-discovery/program.ts
@@ -58,6 +58,17 @@ const readDecisionDocument = (
         pipe(Option.getOrNull(document), (value) =>
           requireValue(value, { _tag: 'DocumentMissing', failure: 'document-missing', cycleId }),
         ),
+      ).pipe(
+        Effect.flatMap((stored) =>
+          stored.mode === 'OBSERVE'
+            ? Effect.succeed(stored)
+            : Effect.fail({
+                _tag: 'TargetPlanUnavailable' as const,
+                failure: 'document-mismatch' as const,
+                status: stored.mode,
+                intentTargetCount: stored.targetPlan.intentTargets.length,
+              }),
+        ),
       ),
     ),
   )

--- a/services/bayn/src/observe-composition.test.ts
+++ b/services/bayn/src/observe-composition.test.ts
@@ -21,6 +21,7 @@ import { MutationOperation } from './broker/alpaca-mutations'
 import { BrokerEnvironment, BrokerProvider, makeBrokerIdentity } from './broker/identity'
 import {
   CycleState,
+  CycleTerminalReason,
   decodeAutonomousCycle,
   makeCycleDraft,
   makeCycleExecutionPolicyFromModel,
@@ -30,6 +31,8 @@ import {
 } from './cycle'
 import { makeStrategyProtocolHash } from './contracts'
 import { CycleStore, type CycleStoreShape } from './db/cycle-store'
+import { decideCompletion, validateCompletionDocument } from './db/cycle-store/decisions'
+import { attachCycleDecisionStoreEvidence, cycleDecisionStoreEvidence } from './db/cycle-store/model'
 import type { BrokerSnapshot, ReconciliationWriteResult } from './db/reconciliation'
 import {
   BrokerEventStore,
@@ -48,7 +51,7 @@ import {
 } from './db/execution-store'
 import { operationalError, type OperationalError } from './errors'
 import { BrokerAccess, makeExecutionAuthority, sandboxCapitalAuthority } from './execution/authority'
-import { IntentStore, type IntentStoreService } from './execution/intents'
+import { IntentStore, planPaperIntent, type IntentStoreService, type StoredIntent } from './execution/intents'
 import { MutationEventType, MutationStore, type MutationEvent, type MutationStoreShape } from './execution/mutations'
 import type { ExecutionProgram } from './execution/runtime-program'
 import { WriterFence, WriterFenceError, type WriterFenceService } from './execution/writer-fence'
@@ -58,10 +61,17 @@ import {
   buildMutationShadowCycleDecision,
   buildObserveCycleDecision,
   appendPendingMutationOrder,
+  decidePaperCycleCompletion,
   decidePreparedMutationIntent,
+  decidePreparedMutationIntentAdmission,
+  decidePreparedMutationRecovery,
   decideMutationIntentSettlement,
   executeMutationIntent,
+  expiredPaperPlanTerminalReason,
+  mutationRecoveryIsDue,
   mutationIntentReconciliationDelayMs,
+  paperSubmitExpiresAt,
+  prepareNextMutationIntent,
   projectWorstCasePendingMutationPosition,
   loadObserveRiskPolicy,
   makeMutationAutonomousCycleStartup,
@@ -87,7 +97,9 @@ import {
 } from './paper'
 import { ReconciliationError, type ReconciliationPassResult } from './reconciler'
 import { reconciledStateHash } from './reconciliation'
-import { Reason } from './risk'
+import { Reason, type Policy } from './risk'
+import { decodePaperDecisionDocument, makePaperDecisionDocument } from './shadow-decision-contract'
+import { TargetPlanStatus } from './target-planner'
 import { fixtureProtocol, makeSnapshot } from './test-fixtures'
 import type { DecisionPlan, IsoDate } from './types'
 
@@ -421,6 +433,177 @@ const sandboxExecutionProgram = (
   }
 }
 
+const paperLifecycleFixture = async (transformPolicy: (policy: Policy) => Policy = (policy) => policy) => {
+  const input = {
+    accountId,
+    authorityGenerationHash: generationHash,
+    pollIntervalMs: 30_000,
+    reconciliationIntervalMs: 30_000,
+    reconciliationPassTimeoutMs: 30_000,
+    strategy: fixtureStrategy,
+    executionProgram: sandboxExecutionProgram(),
+  } as const
+  const preparation = Result.getOrThrow(prepareObserveStartup(input))
+  const policy = transformPolicy(await Effect.runPromise(loadObserveRiskPolicy(accountId, fixtureProtocol.universe)))
+  const document = await Effect.runPromise(
+    Effect.gen(function* () {
+      yield* TestClock.setTime(Date.parse(evaluatedAt))
+      return yield* buildMutationShadowCycleDecision({
+        authorityGenerationHash: generationHash,
+        cycle,
+        executionModel: fixtureProtocol.executionModel,
+        policy,
+        reconcile: Effect.succeed(reconciliationResult(generationHash, Authority.Paper)),
+        strategy: { currentDecision: () => Result.succeed({ decision, priceMicros }) },
+      })
+    }).pipe(
+      (program) => provideDecisionServices(program, marketData([]), calendarRead([])),
+      Effect.provide(TestClock.layer()),
+    ),
+  )
+  const boundCycle = Effect.runSync(
+    decodeAutonomousCycle({
+      ...cycle,
+      bindings: { ...cycle.bindings, decisionHash: document.contentHash },
+      stateVersion: cycle.stateVersion + 1,
+      updatedAt: document.createdAt,
+    }),
+  )
+  const target = document.targetPlan.intentTargets[0]
+  const risk = document.deltaRisk[0]
+  if (target === undefined || risk === undefined) {
+    throw new Error('PAPER lifecycle fixture requires one planned intent')
+  }
+  const intent = await Effect.runPromise(
+    planPaperIntent(
+      {
+        schemaVersion: 'bayn.paper-intent-plan.v1',
+        ...target,
+        notionalLimitMicros: risk.notionalLimitMicros,
+        createdAt: document.createdAt,
+      },
+      {
+        authority: {
+          schemaVersion: 'bayn.paper-authority.v1',
+          generationHash,
+          maximum: Authority.Paper,
+          effective: Authority.Paper,
+          kill: KillState.Clear,
+          version: 1,
+          updatedAt: document.createdAt,
+        },
+      },
+    ),
+  )
+  return { boundCycle, document, input, intent, policy, preparation, risk }
+}
+
+const reconciliationResultAt = (
+  observedAt: string,
+  unknownMutationCount = 0,
+  unknownOrderCount = 0,
+): ReconciliationPassResult => {
+  const result = reconciliationResult(generationHash, Authority.Paper)
+  const authority = result.riskContext.authority
+  if (authority === null) throw new Error('post-cutoff reconciliation fixture requires PAPER authority')
+  const exact = { ...result.report.reconciliation, reconciledAt: observedAt }
+  return {
+    report: {
+      ...result.report,
+      reconciliation: exact,
+    },
+    brokerState: {
+      ...result.brokerState,
+      positionsObservedAt: observedAt,
+      ordersObservedAt: observedAt,
+      reconciliation: exact,
+      unknownOrderCount,
+    },
+    riskContext: {
+      tradingDate: result.riskContext.tradingDate,
+      dailyTradedNotionalMicros: result.riskContext.dailyTradedNotionalMicros,
+      dayStartEquityMicros: result.riskContext.dayStartEquityMicros,
+      peakEquityMicros: result.riskContext.peakEquityMicros,
+      authority,
+      authorityObservedAt: observedAt,
+      unknownMutationCount,
+    },
+  }
+}
+
+const storedIntent = (
+  intent: Intent,
+  state: IntentState,
+  updatedAt: string,
+  terminalOutcome?: TerminalOutcome,
+): StoredIntent => ({
+  intent: {
+    ...intent,
+    state,
+    ...(terminalOutcome === undefined ? {} : { terminalOutcome }),
+  },
+  stateVersion: 2,
+  updatedAt,
+})
+
+const prepareStoredPaperStep = async (
+  fixture: Awaited<ReturnType<typeof paperLifecycleFixture>>,
+  record: StoredIntent,
+  latest: MutationEvent | undefined,
+  observedAt: string,
+  unknownMutationCount = 0,
+  onRestriction: (reason: string, updatedAt: string) => void = () => undefined,
+  input: typeof fixture.input = fixture.input,
+  latestCancel?: MutationEvent,
+  allowSubmit = true,
+  policy: Policy = fixture.policy,
+  preparation = fixture.preparation,
+) => {
+  const intentStore: IntentStoreService = {
+    commit: () => Effect.succeed({ record, deduplicated: true }),
+    read: () => Effect.succeed(Option.some(record)),
+  }
+  const mutationStore = {
+    latest: (_intentId: string, operation: MutationOperation) =>
+      Effect.succeed(operation === MutationOperation.Submit ? latest : latestCancel),
+  } as unknown as MutationStoreShape
+  const authorityRestrictionStore: AuthorityRestrictionStoreShape = {
+    restrictAuthority: (reason, updatedAt) => Effect.sync(() => onRestriction(reason, updatedAt)),
+  }
+  const writerFence: WriterFenceService = {
+    backendPid: 1,
+    check: Effect.void,
+    transaction: (effect) => effect,
+  }
+  return Effect.runPromise(
+    Effect.gen(function* () {
+      yield* TestClock.setTime(Date.parse(observedAt))
+      return yield* prepareNextMutationIntent(
+        input,
+        preparation,
+        policy,
+        fixture.boundCycle,
+        fixture.document,
+        Effect.succeed(reconciliationResultAt(observedAt, unknownMutationCount)),
+        allowSubmit,
+      )
+    }).pipe(
+      Effect.provideService(BrokerRead, decisionBrokerRead(calendarRead([]))),
+      Effect.provideService(MarketData, marketData([])),
+      Effect.provideService(IntentStore, intentStore),
+      Effect.provideService(MutationStore, mutationStore),
+      Effect.provideService(BrokerEventStore, {} as BrokerEventStoreShape),
+      Effect.provideService(FillAccountingStore, {} as FillAccountingStoreShape),
+      Effect.provideService(ValuationStore, {} as ValuationStoreShape),
+      Effect.provideService(ReconciliationStore, {} as ReconciliationStoreShape),
+      Effect.provideService(AuthorityGenerationStore, {} as AuthorityGenerationStoreShape),
+      Effect.provideService(AuthorityRestrictionStore, authorityRestrictionStore),
+      Effect.provideService(WriterFence, writerFence),
+      Effect.provide(TestClock.layer()),
+    ),
+  )
+}
+
 describe('OBSERVE runtime composition', () => {
   test('projects accepted nonterminal intents as one unresolved order for the next risk pass', () => {
     const intent: Intent = {
@@ -456,7 +639,6 @@ describe('OBSERVE runtime composition', () => {
       brokerOrderId: 'accepted-broker-order',
       occurredAt: evaluatedAt,
     }
-
     const decision = Result.getOrThrow(decidePreparedMutationIntent(intent, accepted))
     expect(decision._tag).toBe('Pending')
     if (decision._tag !== 'Pending') return expect.unreachable(decision._tag)
@@ -493,7 +675,7 @@ describe('OBSERVE runtime composition', () => {
       createdAt: evaluatedAt,
     }
 
-    expect(Result.getOrThrow(decidePreparedMutationIntent(base, undefined))).toEqual({ _tag: 'Execute' })
+    expect(Result.getOrThrow(decidePreparedMutationIntent(base, undefined))).toEqual({ _tag: 'Submit' })
     expect(
       Result.getOrThrow(
         decidePreparedMutationIntent(
@@ -502,6 +684,242 @@ describe('OBSERVE runtime composition', () => {
         ),
       ),
     ).toEqual({ _tag: 'SkipTerminal' })
+  })
+
+  test('allows lookup recovery after authority restriction and cutoff while forbidding every fresh submit', () => {
+    const recover = {
+      _tag: 'Recover' as const,
+      eventType: MutationEventType.SubmitUnknown,
+    }
+    expect(
+      Result.isSuccess(
+        decidePreparedMutationIntentAdmission(
+          recover,
+          Authority.Observe,
+          cycle.window.submissionCutoffAt,
+          cycle.window.submissionCutoffAt,
+          1,
+        ),
+      ),
+    ).toBe(true)
+
+    const submit = { _tag: 'Submit' as const }
+    expect(
+      Option.getOrUndefined(
+        Result.getFailure(
+          decidePreparedMutationIntentAdmission(
+            submit,
+            Authority.Observe,
+            evaluatedAt,
+            cycle.window.submissionCutoffAt,
+            0,
+          ),
+        ),
+      )?.reason,
+    ).toBe('authority')
+    expect(
+      Option.getOrUndefined(
+        Result.getFailure(
+          decidePreparedMutationIntentAdmission(
+            submit,
+            Authority.Paper,
+            cycle.window.submissionCutoffAt,
+            cycle.window.submissionCutoffAt,
+            0,
+          ),
+        ),
+      )?.reason,
+    ).toBe('expiry')
+    expect(
+      Option.getOrUndefined(
+        Result.getFailure(
+          decidePreparedMutationIntentAdmission(
+            submit,
+            Authority.Paper,
+            evaluatedAt,
+            cycle.window.submissionCutoffAt,
+            1,
+          ),
+        ),
+      )?.reason,
+    ).toBe('unknown-mutation')
+    expect(
+      Option.getOrUndefined(
+        Result.getFailure(
+          decidePreparedMutationIntentAdmission(
+            submit,
+            Authority.Paper,
+            evaluatedAt,
+            cycle.window.submissionCutoffAt,
+            0,
+            ReconciliationStatus.Discrepancy,
+          ),
+        ),
+      )?.reason,
+    ).toBe('reconciliation-not-exact')
+    expect(
+      Option.getOrUndefined(
+        Result.getFailure(
+          decidePreparedMutationIntentAdmission(
+            submit,
+            Authority.Paper,
+            evaluatedAt,
+            cycle.window.submissionCutoffAt,
+            0,
+            ReconciliationStatus.Exact,
+            false,
+          ),
+        ),
+      )?.reason,
+    ).toBe('accounting-inexact')
+    expect(
+      Option.getOrUndefined(
+        Result.getFailure(
+          decidePreparedMutationIntentAdmission(
+            submit,
+            Authority.Paper,
+            evaluatedAt,
+            cycle.window.submissionCutoffAt,
+            0,
+            ReconciliationStatus.Exact,
+            true,
+            1,
+          ),
+        ),
+      )?.reason,
+    ).toBe('unknown-order')
+  })
+
+  test('keeps OBSERVE recovery-only execution lookup-capable while fresh submit remains structurally unavailable', async () => {
+    const fixture = await paperLifecycleFixture()
+    const occurredAt = fixture.document.createdAt
+    const observedAt = new Date(Date.parse(occurredAt) + 1_000).toISOString()
+    const submitUnknown: MutationEvent = {
+      schemaVersion: 'bayn.paper-mutation-event.v1',
+      eventId: '1'.repeat(64),
+      mutationId: '2'.repeat(64),
+      intentId: fixture.intent.intentId,
+      sequence: 2,
+      operation: MutationOperation.Submit,
+      eventType: MutationEventType.SubmitUnknown,
+      requestHash: '3'.repeat(64),
+      consistencyDelayMs: 1_000,
+      occurredAt,
+    }
+    const cancelUnknown: MutationEvent = {
+      ...submitUnknown,
+      eventId: '4'.repeat(64),
+      mutationId: '5'.repeat(64),
+      operation: MutationOperation.Cancel,
+      eventType: MutationEventType.CancelUnknown,
+      requestHash: '6'.repeat(64),
+      brokerOrderId: 'recovery-only-order',
+    }
+
+    const recovery = await prepareStoredPaperStep(
+      fixture,
+      storedIntent(fixture.intent, IntentState.Unknown, occurredAt),
+      submitUnknown,
+      observedAt,
+      1,
+      () => undefined,
+      fixture.input,
+      cancelUnknown,
+      false,
+    )
+    expect(recovery).toEqual({
+      _tag: 'Execute',
+      action: 'RECOVER_CANCEL',
+      intentId: fixture.intent.intentId,
+      observedAt,
+    })
+
+    let commits = 0
+    const intentStore: IntentStoreService = {
+      commit: () =>
+        Effect.sync(() => {
+          commits += 1
+          throw new Error('OBSERVE recovery-only execution must not commit a fresh PAPER intent')
+        }),
+      read: () => Effect.succeed(Option.none()),
+    }
+    const mutationStore = {
+      latest: () => Effect.succeed(undefined),
+    } as unknown as MutationStoreShape
+    const waiting = await Effect.runPromise(
+      Effect.gen(function* () {
+        yield* TestClock.setTime(Date.parse(observedAt))
+        return yield* prepareNextMutationIntent(
+          fixture.input,
+          fixture.preparation,
+          fixture.policy,
+          fixture.boundCycle,
+          fixture.document,
+          Effect.die(new Error('OBSERVE recovery-only execution must not reconcile before refusing fresh submit')),
+          false,
+        )
+      }).pipe(
+        Effect.provideService(BrokerRead, decisionBrokerRead(calendarRead([]))),
+        Effect.provideService(MarketData, marketData([])),
+        Effect.provideService(IntentStore, intentStore),
+        Effect.provideService(MutationStore, mutationStore),
+        Effect.provideService(BrokerEventStore, {} as BrokerEventStoreShape),
+        Effect.provideService(FillAccountingStore, {} as FillAccountingStoreShape),
+        Effect.provideService(ValuationStore, {} as ValuationStoreShape),
+        Effect.provideService(ReconciliationStore, {} as ReconciliationStoreShape),
+        Effect.provideService(AuthorityGenerationStore, {} as AuthorityGenerationStoreShape),
+        Effect.provideService(AuthorityRestrictionStore, {} as AuthorityRestrictionStoreShape),
+        Effect.provideService(WriterFence, {} as WriterFenceService),
+        Effect.provide(TestClock.layer()),
+      ),
+    )
+    expect(waiting).toEqual({ _tag: 'Wait', observedAt })
+    expect(commits).toBe(0)
+  })
+
+  test('completes PAPER only after every intent is filled and a later exact reconciliation closes unknowns', () => {
+    const intentUpdatedAt = '2020-05-01T12:45:03.000Z'
+    const laterReconciliation = {
+      status: ReconciliationStatus.Exact,
+      reconciledAt: '2020-05-01T12:45:04.000Z',
+      accountingExact: true,
+      unknownMutationCount: 0,
+      unknownOrderCount: 0,
+    } as const
+    const filled = {
+      state: IntentState.Terminal,
+      terminalOutcome: TerminalOutcome.Filled,
+      updatedAt: intentUpdatedAt,
+      latestMutationAt: intentUpdatedAt,
+    } as const
+
+    expect(
+      decidePaperCycleCompletion(
+        evaluatedAt,
+        [{ ...filled, state: IntentState.Acknowledged, terminalOutcome: undefined }],
+        laterReconciliation,
+      ),
+    ).toEqual({ _tag: 'Wait', reason: 'intent-nonterminal' })
+    expect(
+      decidePaperCycleCompletion(
+        evaluatedAt,
+        [{ ...filled, terminalOutcome: TerminalOutcome.Rejected }],
+        laterReconciliation,
+      ),
+    ).toEqual({ _tag: 'Wait', reason: 'intent-unsuccessful' })
+    expect(
+      decidePaperCycleCompletion(evaluatedAt, [filled], {
+        ...laterReconciliation,
+        reconciledAt: intentUpdatedAt,
+      }),
+    ).toEqual({ _tag: 'Wait', reason: 'reconciliation-not-later' })
+    expect(
+      decidePaperCycleCompletion(evaluatedAt, [filled], {
+        ...laterReconciliation,
+        unknownMutationCount: 1,
+      }),
+    ).toEqual({ _tag: 'Wait', reason: 'unknown-mutation' })
+    expect(decidePaperCycleCompletion(evaluatedAt, [filled], laterReconciliation)).toEqual({ _tag: 'Complete' })
   })
 
   test('retains an unfilled sell while reserving a later buy in projected risk positions', () => {
@@ -570,12 +988,14 @@ describe('OBSERVE runtime composition', () => {
       mutationIntentReconciliationDelayMs({
         settlement: { _tag: 'Settled', outcome: 'accepted' },
         consistencyDelayMs: 1_250,
+        operation: MutationOperation.Submit,
       }),
     ).toBe(1_250)
     expect(
       mutationIntentReconciliationDelayMs({
         settlement: { _tag: 'Settled', outcome: 'rejected' },
         consistencyDelayMs: 1_250,
+        operation: MutationOperation.Submit,
       }),
     ).toBe(0)
   })
@@ -617,14 +1037,885 @@ describe('OBSERVE runtime composition', () => {
     } as unknown as MutationStoreShape
 
     await Effect.runPromise(
-      Effect.forEach([rejectedIntentId, laterIntentId], (intentId) => executeMutationIntent(program, intentId), {
-        concurrency: 1,
-        discard: true,
-      }).pipe(Effect.provideService(MutationStore, store)),
+      Effect.forEach(
+        [rejectedIntentId, laterIntentId],
+        (intentId) => executeMutationIntent(program, intentId, 'SUBMIT', '9999-12-31T23:59:59.999Z'),
+        {
+          concurrency: 1,
+          discard: true,
+        },
+      ).pipe(Effect.provideService(MutationStore, store)),
     )
 
     expect(submitted).toEqual([laterIntentId])
     expect(recoveries).toBe(0)
+  })
+
+  test('recovers accepted and unknown submits and cancellations by lookup only without mutation dispatch', async () => {
+    const intentId = 'd'.repeat(64)
+    const accepted: MutationEvent = {
+      schemaVersion: 'bayn.paper-mutation-event.v1',
+      eventId: 'e'.repeat(64),
+      mutationId: 'f'.repeat(64),
+      intentId,
+      sequence: 2,
+      operation: MutationOperation.Submit,
+      eventType: MutationEventType.SubmitAccepted,
+      requestHash: '1'.repeat(64),
+      consistencyDelayMs: 1_000,
+      brokerOrderId: 'accepted-broker-order',
+      occurredAt: evaluatedAt,
+    }
+    const unknownEvent: MutationEvent = {
+      ...accepted,
+      eventId: '2'.repeat(64),
+      eventType: MutationEventType.SubmitUnknown,
+      brokerOrderId: undefined,
+    }
+    const cancelAccepted: MutationEvent = {
+      ...accepted,
+      eventId: '3'.repeat(64),
+      mutationId: '4'.repeat(64),
+      operation: MutationOperation.Cancel,
+      eventType: MutationEventType.CancelAccepted,
+      requestHash: '5'.repeat(64),
+    }
+    const cancelUnknown: MutationEvent = {
+      ...cancelAccepted,
+      eventId: '6'.repeat(64),
+      eventType: MutationEventType.CancelUnknown,
+    }
+    const dueAt = new Date(Date.parse(evaluatedAt) + accepted.consistencyDelayMs).toISOString()
+    expect(mutationRecoveryIsDue(accepted, new Date(Date.parse(dueAt) - 1).toISOString())).toBe(false)
+    expect(mutationRecoveryIsDue(accepted, dueAt)).toBe(true)
+    expect(paperSubmitExpiresAt(cycle.window.submissionCutoffAt, evaluatedAt)).toBe(evaluatedAt)
+    expect(paperSubmitExpiresAt(evaluatedAt, cycle.window.submissionCutoffAt)).toBe(evaluatedAt)
+
+    let submits = 0
+    let cancels = 0
+    const recoveries: MutationOperation[] = []
+    const program: ExecutionProgram = {
+      ...sandboxExecutionProgram(),
+      submit: () =>
+        Effect.sync(() => {
+          submits += 1
+          return accepted
+        }),
+      cancel: () =>
+        Effect.sync(() => {
+          cancels += 1
+          return cancelAccepted
+        }),
+      recover: (_intentId, operation) =>
+        Effect.sync(() => {
+          recoveries.push(operation)
+          return {
+            ...(operation === MutationOperation.Submit ? accepted : cancelAccepted),
+            eventId: canonicalHashV1({ intentId, operation, eventType: MutationEventType.RecoveryFound }),
+            eventType: MutationEventType.RecoveryFound,
+          }
+        }),
+    }
+    let latestSubmit: MutationEvent | undefined = accepted
+    let latestCancel: MutationEvent | undefined
+    const store = {
+      latest: (_intentId: string, operation: MutationOperation) =>
+        Effect.succeed(operation === MutationOperation.Submit ? latestSubmit : latestCancel),
+    } as unknown as MutationStoreShape
+
+    await Effect.runPromise(
+      executeMutationIntent(program, intentId, 'RECOVER_SUBMIT').pipe(Effect.provideService(MutationStore, store)),
+    )
+    latestSubmit = unknownEvent
+    await Effect.runPromise(
+      executeMutationIntent(program, intentId, 'RECOVER_SUBMIT').pipe(Effect.provideService(MutationStore, store)),
+    )
+    latestCancel = cancelAccepted
+    await Effect.runPromise(
+      executeMutationIntent(program, intentId, 'RECOVER_CANCEL').pipe(Effect.provideService(MutationStore, store)),
+    )
+    latestCancel = cancelUnknown
+    await Effect.runPromise(
+      executeMutationIntent(program, intentId, 'RECOVER_CANCEL').pipe(Effect.provideService(MutationStore, store)),
+    )
+
+    expect(submits).toBe(0)
+    expect(cancels).toBe(0)
+    expect(recoveries).toEqual([
+      MutationOperation.Submit,
+      MutationOperation.Submit,
+      MutationOperation.Cancel,
+      MutationOperation.Cancel,
+    ])
+
+    const missingStore = {
+      latest: () => Effect.succeed(undefined),
+    } as unknown as MutationStoreShape
+    const failure = await Effect.runPromise(
+      Effect.flip(
+        executeMutationIntent(program, intentId, 'RECOVER_SUBMIT').pipe(
+          Effect.provideService(MutationStore, missingStore),
+        ),
+      ),
+    )
+    expect(failure).toMatchObject({
+      failure: 'contract',
+      message: 'lookup-only PAPER recovery lost its durable submit evidence',
+    })
+    const cancelFailure = await Effect.runPromise(
+      Effect.flip(
+        executeMutationIntent(program, intentId, 'RECOVER_CANCEL').pipe(
+          Effect.provideService(MutationStore, missingStore),
+        ),
+      ),
+    )
+    expect(cancelFailure).toMatchObject({
+      failure: 'contract',
+      message: 'lookup-only PAPER recovery lost its durable cancel evidence',
+    })
+    expect(submits).toBe(0)
+    expect(cancels).toBe(0)
+  })
+
+  test('keeps an accepted pending intent lookup-recoverable after its immutable submission cutoff', async () => {
+    const fixture = await paperLifecycleFixture()
+    const afterCutoff = new Date(Date.parse(fixture.document.submissionCutoffAt) + 1_000).toISOString()
+    const record = storedIntent(fixture.intent, IntentState.Acknowledged, fixture.document.createdAt)
+    const accepted: MutationEvent = {
+      schemaVersion: 'bayn.paper-mutation-event.v1',
+      eventId: '1'.repeat(64),
+      mutationId: '2'.repeat(64),
+      intentId: fixture.intent.intentId,
+      sequence: 2,
+      operation: MutationOperation.Submit,
+      eventType: MutationEventType.SubmitAccepted,
+      requestHash: '3'.repeat(64),
+      consistencyDelayMs: 1_000,
+      brokerOrderId: 'accepted-past-cutoff',
+      occurredAt: fixture.document.createdAt,
+    }
+
+    const step = await prepareStoredPaperStep(fixture, record, accepted, afterCutoff)
+
+    expect(step).toEqual({
+      _tag: 'Execute',
+      action: 'RECOVER_SUBMIT',
+      intentId: fixture.intent.intentId,
+      observedAt: afterCutoff,
+    })
+  })
+
+  test('keeps an unknown submit lookup-recoverable after its immutable submission cutoff', async () => {
+    const fixture = await paperLifecycleFixture()
+    const afterCutoff = new Date(Date.parse(fixture.document.submissionCutoffAt) + 1_000).toISOString()
+    const record = storedIntent(fixture.intent, IntentState.Unknown, fixture.document.createdAt)
+    const unknown: MutationEvent = {
+      schemaVersion: 'bayn.paper-mutation-event.v1',
+      eventId: '4'.repeat(64),
+      mutationId: '5'.repeat(64),
+      intentId: fixture.intent.intentId,
+      sequence: 2,
+      operation: MutationOperation.Submit,
+      eventType: MutationEventType.SubmitUnknown,
+      requestHash: '6'.repeat(64),
+      consistencyDelayMs: 1_000,
+      occurredAt: fixture.document.createdAt,
+    }
+
+    const step = await prepareStoredPaperStep(fixture, record, unknown, afterCutoff, 1)
+
+    expect(step).toEqual({
+      _tag: 'Execute',
+      action: 'RECOVER_SUBMIT',
+      intentId: fixture.intent.intentId,
+      observedAt: afterCutoff,
+    })
+  })
+
+  test('never creates a fresh submit POST once the immutable cutoff is reached', async () => {
+    const fixture = await paperLifecycleFixture()
+    let submits = 0
+    const program: ExecutionProgram = {
+      ...sandboxExecutionProgram(),
+      submit: () =>
+        Effect.sync(() => {
+          submits += 1
+          throw new Error('fresh submit must not reach broker I/O after cutoff')
+        }),
+    }
+    const store = {
+      latest: () => Effect.succeed(undefined),
+    } as unknown as MutationStoreShape
+    const failure = await Effect.runPromise(
+      Effect.flip(
+        Effect.gen(function* () {
+          yield* TestClock.setTime(Date.parse(fixture.document.submissionCutoffAt))
+          return yield* executeMutationIntent(
+            program,
+            fixture.intent.intentId,
+            'SUBMIT',
+            fixture.document.submissionCutoffAt,
+          )
+        }).pipe(Effect.provideService(MutationStore, store), Effect.provide(TestClock.layer())),
+      ),
+    )
+
+    expect(failure).toMatchObject({
+      failure: 'contract',
+      message: 'fresh PAPER submit crossed its immutable submission cutoff before broker I/O',
+    })
+    expect(submits).toBe(0)
+  })
+
+  test('binds a real PAPER risk rejection and terminalizes it without intent or broker work', async () => {
+    const fixture = await paperLifecycleFixture((policy) => ({
+      ...policy,
+      maxOrderNotionalMicros: '1',
+    }))
+    const observedAt = new Date(Date.parse(fixture.document.createdAt) + 1).toISOString()
+
+    expect(fixture.document).toMatchObject({
+      mode: 'PAPER',
+      dispatchable: false,
+      targetPlan: { status: TargetPlanStatus.Planned },
+      riskBlock: {
+        intentId: fixture.intent.intentId,
+        decisionId: fixture.risk.evaluation.decision.decisionId,
+      },
+    })
+    expect(fixture.document.riskBlock?.reasonCodes).toContain(Reason.OrderNotionalExceeded)
+    expect(fixture.document.riskBlock?.reasonCodes).not.toContain(Reason.AuthorityNotPaper)
+    expect(fixture.document.deltaRisk).toHaveLength(1)
+    expect(fixture.document.deltaRisk[0]?.evaluation.decision.outcome).toBe(RiskOutcome.Blocked)
+    const attached = attachCycleDecisionStoreEvidence(fixture.document, {
+      paperCompletionEvidenceMatches: false,
+      paperGenerationIsSuperseded: true,
+    })
+    expect(Reflect.ownKeys(attached)).toEqual(Reflect.ownKeys(fixture.document))
+    expect(Result.isSuccess(decodePaperDecisionDocument(attached))).toBe(true)
+    expect(cycleDecisionStoreEvidence(attached)).toEqual({
+      paperCompletionEvidenceMatches: false,
+      paperGenerationIsSuperseded: true,
+    })
+
+    const step = await prepareStoredPaperStep(
+      fixture,
+      storedIntent(fixture.intent, IntentState.Planned, fixture.document.createdAt),
+      undefined,
+      observedAt,
+    )
+
+    expect(step).toEqual({
+      _tag: 'Block',
+      reason: CycleTerminalReason.Risk,
+      observedAt,
+    })
+
+    const completion = Result.getOrThrow(decideCompletion(fixture.boundCycle, CycleState.Completed, observedAt))
+    if (completion._tag !== 'VerifyDecision') return expect.unreachable('risk-blocked PAPER completion must verify')
+    expect(Result.isFailure(validateCompletionDocument(completion, [fixture.document]))).toBe(true)
+  })
+
+  test('terminalizes an untouched PAPER remainder when its durable approval expires', async () => {
+    const fixture = await paperLifecycleFixture()
+    const riskExpiresAt = fixture.risk.evaluation.decision.expiresAt
+    expect(riskExpiresAt < fixture.document.submissionCutoffAt).toBe(true)
+    expect(expiredPaperPlanTerminalReason(riskExpiresAt, riskExpiresAt, fixture.document.submissionCutoffAt)).toBe(
+      CycleTerminalReason.Risk,
+    )
+    expect(
+      expiredPaperPlanTerminalReason(
+        fixture.document.submissionCutoffAt,
+        fixture.document.submissionCutoffAt,
+        fixture.document.submissionCutoffAt,
+      ),
+    ).toBe(CycleTerminalReason.MissedSubmission)
+
+    const record = storedIntent(fixture.intent, IntentState.Approved, fixture.document.createdAt)
+    const step = await prepareStoredPaperStep(fixture, record, undefined, riskExpiresAt)
+
+    expect(step).toEqual({
+      _tag: 'Block',
+      reason: CycleTerminalReason.Risk,
+      observedAt: riskExpiresAt,
+    })
+  })
+
+  test('terminalizes an uncommitted PAPER intent at approval expiry before any durable commit', async () => {
+    const fixture = await paperLifecycleFixture()
+    const riskExpiresAt = fixture.risk.evaluation.decision.expiresAt
+    let reads = 0
+    let commits = 0
+    const intentStore: IntentStoreService = {
+      commit: () =>
+        Effect.sync(() => {
+          commits += 1
+          throw new Error('expired uncommitted PAPER intent must not reach durable commit')
+        }),
+      read: () =>
+        Effect.sync(() => {
+          reads += 1
+          return Option.none()
+        }),
+    }
+    const mutationStore = {
+      latest: () => Effect.succeed(undefined),
+    } as unknown as MutationStoreShape
+    const authorityRestrictionStore: AuthorityRestrictionStoreShape = {
+      restrictAuthority: () =>
+        Effect.die(new Error('pre-commit expiry must not restrict authority before cycle block')),
+    }
+    const writerFence: WriterFenceService = {
+      backendPid: 1,
+      check: Effect.die(new Error('pre-commit expiry must not enter the writer fence')),
+      transaction: () => Effect.die(new Error('pre-commit expiry must not open a writer-fenced transaction')),
+    }
+
+    const step = await Effect.runPromise(
+      Effect.gen(function* () {
+        yield* TestClock.setTime(Date.parse(riskExpiresAt))
+        return yield* prepareNextMutationIntent(
+          fixture.input,
+          fixture.preparation,
+          fixture.policy,
+          fixture.boundCycle,
+          fixture.document,
+          Effect.die(new Error('pre-commit expiry must not reconcile or read the broker')),
+        )
+      }).pipe(
+        Effect.provideService(BrokerRead, decisionBrokerRead(calendarRead([]))),
+        Effect.provideService(MarketData, marketData([])),
+        Effect.provideService(IntentStore, intentStore),
+        Effect.provideService(MutationStore, mutationStore),
+        Effect.provideService(BrokerEventStore, {} as BrokerEventStoreShape),
+        Effect.provideService(FillAccountingStore, {} as FillAccountingStoreShape),
+        Effect.provideService(ValuationStore, {} as ValuationStoreShape),
+        Effect.provideService(ReconciliationStore, {} as ReconciliationStoreShape),
+        Effect.provideService(AuthorityGenerationStore, {} as AuthorityGenerationStoreShape),
+        Effect.provideService(AuthorityRestrictionStore, authorityRestrictionStore),
+        Effect.provideService(WriterFence, writerFence),
+        Effect.provide(TestClock.layer()),
+      ),
+    )
+
+    expect(step).toEqual({
+      _tag: 'Block',
+      reason: CycleTerminalReason.Risk,
+      observedAt: riskExpiresAt,
+    })
+    expect(reads).toBe(1)
+    expect(commits).toBe(0)
+  })
+
+  test('terminalizes a superseded PAPER generation after proving no mutation exists', async () => {
+    const fixture = await paperLifecycleFixture()
+    const observedAt = new Date(Date.parse(fixture.document.createdAt) + 1).toISOString()
+    let intentReads = 0
+    let mutationReads = 0
+    let commits = 0
+    const intentStore: IntentStoreService = {
+      commit: () =>
+        Effect.sync(() => {
+          commits += 1
+          throw new Error('superseded PAPER generation must not commit an intent')
+        }),
+      read: () =>
+        Effect.sync(() => {
+          intentReads += 1
+          return Option.none()
+        }),
+    }
+    const mutationStore = {
+      latest: () =>
+        Effect.sync(() => {
+          mutationReads += 1
+          return undefined
+        }),
+    } as unknown as MutationStoreShape
+
+    const step = await Effect.runPromise(
+      Effect.gen(function* () {
+        yield* TestClock.setTime(Date.parse(observedAt))
+        return yield* prepareNextMutationIntent(
+          { ...fixture.input, authorityGenerationHash: 'f'.repeat(64) },
+          fixture.preparation,
+          fixture.policy,
+          fixture.boundCycle,
+          fixture.document,
+          Effect.die(new Error('superseded PAPER generation must not reconcile or read the broker')),
+        )
+      }).pipe(
+        Effect.provideService(BrokerRead, decisionBrokerRead(calendarRead([]))),
+        Effect.provideService(MarketData, marketData([])),
+        Effect.provideService(IntentStore, intentStore),
+        Effect.provideService(MutationStore, mutationStore),
+        Effect.provideService(BrokerEventStore, {} as BrokerEventStoreShape),
+        Effect.provideService(FillAccountingStore, {} as FillAccountingStoreShape),
+        Effect.provideService(ValuationStore, {} as ValuationStoreShape),
+        Effect.provideService(ReconciliationStore, {} as ReconciliationStoreShape),
+        Effect.provideService(AuthorityGenerationStore, {} as AuthorityGenerationStoreShape),
+        Effect.provideService(AuthorityRestrictionStore, {} as AuthorityRestrictionStoreShape),
+        Effect.provideService(WriterFence, {} as WriterFenceService),
+        Effect.provide(TestClock.layer()),
+      ),
+    )
+
+    expect(step).toEqual({
+      _tag: 'Block',
+      reason: CycleTerminalReason.ProvenanceMismatch,
+      observedAt,
+    })
+    expect(intentReads).toBe(1)
+    expect(mutationReads).toBe(2)
+    expect(commits).toBe(0)
+  })
+
+  test('recovers superseded accepted and unknown submits and cancellations before provenance blocking', async () => {
+    const fixture = await paperLifecycleFixture()
+    const occurredAt = fixture.document.createdAt
+    const observedAt = new Date(Date.parse(occurredAt) + 1_000).toISOString()
+    const supersededInput = { ...fixture.input, authorityGenerationHash: 'f'.repeat(64) }
+    const driftedPolicy: Policy = {
+      ...fixture.policy,
+      maxOrderNotionalMicros: (BigInt(fixture.policy.maxOrderNotionalMicros) - 1n).toString(),
+    }
+    const accepted: MutationEvent = {
+      schemaVersion: 'bayn.paper-mutation-event.v1',
+      eventId: '1'.repeat(64),
+      mutationId: '2'.repeat(64),
+      intentId: fixture.intent.intentId,
+      sequence: 2,
+      operation: MutationOperation.Submit,
+      eventType: MutationEventType.SubmitAccepted,
+      requestHash: '3'.repeat(64),
+      consistencyDelayMs: 1_000,
+      brokerOrderId: 'superseded-accepted-order',
+      occurredAt,
+    }
+    const unknown: MutationEvent = {
+      ...accepted,
+      eventId: '4'.repeat(64),
+      mutationId: '5'.repeat(64),
+      eventType: MutationEventType.SubmitUnknown,
+      brokerOrderId: undefined,
+    }
+    const cancelAccepted: MutationEvent = {
+      ...accepted,
+      eventId: '6'.repeat(64),
+      mutationId: '7'.repeat(64),
+      operation: MutationOperation.Cancel,
+      eventType: MutationEventType.CancelAccepted,
+      requestHash: '8'.repeat(64),
+    }
+    const cancelUnknown: MutationEvent = {
+      ...cancelAccepted,
+      eventId: '9'.repeat(64),
+      mutationId: 'a'.repeat(64),
+      eventType: MutationEventType.CancelUnknown,
+    }
+    const cancelRecovered: MutationEvent = {
+      ...cancelAccepted,
+      eventId: 'b'.repeat(64),
+      mutationId: 'c'.repeat(64),
+      sequence: 3,
+      eventType: MutationEventType.RecoveryFound,
+    }
+
+    const acceptedStep = await prepareStoredPaperStep(
+      fixture,
+      storedIntent(fixture.intent, IntentState.Acknowledged, occurredAt),
+      accepted,
+      observedAt,
+      0,
+      () => undefined,
+      supersededInput,
+      undefined,
+      true,
+      driftedPolicy,
+    )
+    const unknownStep = await prepareStoredPaperStep(
+      fixture,
+      storedIntent(fixture.intent, IntentState.Unknown, occurredAt),
+      unknown,
+      observedAt,
+      1,
+      () => undefined,
+      supersededInput,
+      undefined,
+      true,
+      driftedPolicy,
+    )
+    const cancelAcceptedStep = await prepareStoredPaperStep(
+      fixture,
+      storedIntent(fixture.intent, IntentState.Acknowledged, occurredAt),
+      accepted,
+      observedAt,
+      0,
+      () => undefined,
+      supersededInput,
+      cancelAccepted,
+      true,
+      driftedPolicy,
+    )
+    const cancelUnknownStep = await prepareStoredPaperStep(
+      fixture,
+      storedIntent(fixture.intent, IntentState.Unknown, occurredAt),
+      unknown,
+      observedAt,
+      1,
+      () => undefined,
+      supersededInput,
+      cancelUnknown,
+      true,
+      driftedPolicy,
+    )
+    const settledSubmitStep = await prepareStoredPaperStep(
+      fixture,
+      storedIntent(fixture.intent, IntentState.Terminal, observedAt, TerminalOutcome.Filled),
+      accepted,
+      observedAt,
+      0,
+      () => undefined,
+      supersededInput,
+      undefined,
+      true,
+      driftedPolicy,
+    )
+    const settledCancelStep = await prepareStoredPaperStep(
+      fixture,
+      storedIntent(fixture.intent, IntentState.Terminal, observedAt, TerminalOutcome.Canceled),
+      accepted,
+      observedAt,
+      0,
+      () => undefined,
+      supersededInput,
+      cancelRecovered,
+      true,
+      driftedPolicy,
+    )
+
+    expect(acceptedStep).toEqual({
+      _tag: 'Execute',
+      action: 'RECOVER_SUBMIT',
+      intentId: fixture.intent.intentId,
+      observedAt,
+    })
+    expect(unknownStep).toEqual({
+      _tag: 'Execute',
+      action: 'RECOVER_SUBMIT',
+      intentId: fixture.intent.intentId,
+      observedAt,
+    })
+    expect(cancelAcceptedStep).toEqual({
+      _tag: 'Execute',
+      action: 'RECOVER_CANCEL',
+      intentId: fixture.intent.intentId,
+      observedAt,
+    })
+    expect(cancelUnknownStep).toEqual({
+      _tag: 'Execute',
+      action: 'RECOVER_CANCEL',
+      intentId: fixture.intent.intentId,
+      observedAt,
+    })
+    expect(settledSubmitStep).toEqual({
+      _tag: 'Block',
+      reason: CycleTerminalReason.ProvenanceMismatch,
+      observedAt,
+    })
+    expect(settledCancelStep).toEqual({
+      _tag: 'Block',
+      reason: CycleTerminalReason.ProvenanceMismatch,
+      observedAt,
+    })
+    expect(
+      Result.getOrThrow(
+        decidePreparedMutationRecovery(
+          storedIntent(fixture.intent, IntentState.Terminal, observedAt, TerminalOutcome.Canceled).intent,
+          accepted,
+          cancelRecovered,
+        ),
+      ),
+    ).toEqual({ _tag: 'NoRecovery' })
+  })
+
+  test('recovers old-policy mutation work before rejecting fresh work under the current policy', async () => {
+    const fixture = await paperLifecycleFixture()
+    const occurredAt = fixture.document.createdAt
+    const observedAt = new Date(Date.parse(occurredAt) + 1_000).toISOString()
+    const driftedPolicy: Policy = {
+      ...fixture.policy,
+      maxOrderNotionalMicros: (BigInt(fixture.policy.maxOrderNotionalMicros) - 1n).toString(),
+    }
+    const accepted: MutationEvent = {
+      schemaVersion: 'bayn.paper-mutation-event.v1',
+      eventId: 'd'.repeat(64),
+      mutationId: 'e'.repeat(64),
+      intentId: fixture.intent.intentId,
+      sequence: 2,
+      operation: MutationOperation.Submit,
+      eventType: MutationEventType.SubmitAccepted,
+      requestHash: 'f'.repeat(64),
+      consistencyDelayMs: 1_000,
+      brokerOrderId: 'old-policy-accepted-order',
+      occurredAt,
+    }
+
+    const recovery = await prepareStoredPaperStep(
+      fixture,
+      storedIntent(fixture.intent, IntentState.Acknowledged, occurredAt),
+      accepted,
+      observedAt,
+      0,
+      () => undefined,
+      fixture.input,
+      undefined,
+      true,
+      driftedPolicy,
+    )
+
+    const plannedRecord = storedIntent(fixture.intent, IntentState.Planned, occurredAt)
+    let commits = 0
+    const intentStore: IntentStoreService = {
+      commit: () =>
+        Effect.sync(() => {
+          commits += 1
+          throw new Error('policy drift must fail before a fresh intent re-commit')
+        }),
+      read: () => Effect.succeed(Option.some(plannedRecord)),
+    }
+    const mutationStore = {
+      latest: () => Effect.succeed(undefined),
+    } as unknown as MutationStoreShape
+    const freshFailure = await Effect.runPromise(
+      Effect.gen(function* () {
+        yield* TestClock.setTime(Date.parse(observedAt))
+        return yield* Effect.flip(
+          prepareNextMutationIntent(
+            fixture.input,
+            fixture.preparation,
+            driftedPolicy,
+            fixture.boundCycle,
+            fixture.document,
+            Effect.die(new Error('policy drift must fail before reconciliation, broker reads, or fresh submission')),
+          ),
+        )
+      }).pipe(
+        Effect.provideService(BrokerRead, decisionBrokerRead(calendarRead([]))),
+        Effect.provideService(MarketData, marketData([])),
+        Effect.provideService(IntentStore, intentStore),
+        Effect.provideService(MutationStore, mutationStore),
+        Effect.provideService(BrokerEventStore, {} as BrokerEventStoreShape),
+        Effect.provideService(FillAccountingStore, {} as FillAccountingStoreShape),
+        Effect.provideService(ValuationStore, {} as ValuationStoreShape),
+        Effect.provideService(ReconciliationStore, {} as ReconciliationStoreShape),
+        Effect.provideService(AuthorityGenerationStore, {} as AuthorityGenerationStoreShape),
+        Effect.provideService(AuthorityRestrictionStore, {} as AuthorityRestrictionStoreShape),
+        Effect.provideService(WriterFence, {} as WriterFenceService),
+        Effect.provide(TestClock.layer()),
+      ),
+    )
+
+    expect(recovery).toEqual({
+      _tag: 'Execute',
+      action: 'RECOVER_SUBMIT',
+      intentId: fixture.intent.intentId,
+      observedAt,
+    })
+    expect(freshFailure).toMatchObject({
+      _tag: 'CycleRunnerError',
+      failure: 'contract',
+      message: 'current source-controlled PAPER risk policy changed from the durable decision binding',
+    })
+    expect(commits).toBe(0)
+  })
+
+  test('recovers old execution-model mutations before gating fresh submission on the current model', async () => {
+    const fixture = await paperLifecycleFixture()
+    const occurredAt = fixture.document.createdAt
+    const observedAt = new Date(Date.parse(occurredAt) + 1_000).toISOString()
+    const supersededInput = { ...fixture.input, authorityGenerationHash: 'f'.repeat(64) }
+    const driftedPreparation = {
+      ...fixture.preparation,
+      executionModel: {
+        ...fixture.preparation.executionModel,
+        priceImpact: {
+          halfSpreadBps: fixture.preparation.executionModel.priceImpact.halfSpreadBps + 100,
+          slippageBps: fixture.preparation.executionModel.priceImpact.slippageBps + 100,
+        },
+      },
+    }
+    const accepted: MutationEvent = {
+      schemaVersion: 'bayn.paper-mutation-event.v1',
+      eventId: '1'.repeat(64),
+      mutationId: '2'.repeat(64),
+      intentId: fixture.intent.intentId,
+      sequence: 2,
+      operation: MutationOperation.Submit,
+      eventType: MutationEventType.SubmitAccepted,
+      requestHash: '3'.repeat(64),
+      consistencyDelayMs: 1_000,
+      brokerOrderId: 'old-model-accepted-order',
+      occurredAt,
+    }
+
+    const recovery = await prepareStoredPaperStep(
+      fixture,
+      storedIntent(fixture.intent, IntentState.Acknowledged, occurredAt),
+      accepted,
+      observedAt,
+      0,
+      () => undefined,
+      supersededInput,
+      undefined,
+      true,
+      fixture.policy,
+      driftedPreparation,
+    )
+    const terminalization = await prepareStoredPaperStep(
+      fixture,
+      storedIntent(fixture.intent, IntentState.Terminal, observedAt, TerminalOutcome.Filled),
+      accepted,
+      observedAt,
+      0,
+      () => undefined,
+      supersededInput,
+      undefined,
+      true,
+      fixture.policy,
+      driftedPreparation,
+    )
+
+    const plannedRecord = storedIntent(fixture.intent, IntentState.Planned, occurredAt)
+    let commits = 0
+    let reconciliations = 0
+    const intentStore: IntentStoreService = {
+      commit: () =>
+        Effect.sync(() => {
+          commits += 1
+          throw new Error('execution-model drift must fail before a fresh intent re-commit')
+        }),
+      read: () => Effect.succeed(Option.some(plannedRecord)),
+    }
+    const mutationStore = {
+      latest: () => Effect.succeed(undefined),
+    } as unknown as MutationStoreShape
+    const freshFailure = await Effect.runPromise(
+      Effect.gen(function* () {
+        yield* TestClock.setTime(Date.parse(observedAt))
+        return yield* Effect.flip(
+          prepareNextMutationIntent(
+            fixture.input,
+            driftedPreparation,
+            fixture.policy,
+            fixture.boundCycle,
+            fixture.document,
+            Effect.sync(() => {
+              reconciliations += 1
+              return reconciliationResultAt(observedAt)
+            }),
+          ),
+        )
+      }).pipe(
+        Effect.provideService(BrokerRead, decisionBrokerRead(calendarRead([]))),
+        Effect.provideService(MarketData, marketData([])),
+        Effect.provideService(IntentStore, intentStore),
+        Effect.provideService(MutationStore, mutationStore),
+        Effect.provideService(BrokerEventStore, {} as BrokerEventStoreShape),
+        Effect.provideService(FillAccountingStore, {} as FillAccountingStoreShape),
+        Effect.provideService(ValuationStore, {} as ValuationStoreShape),
+        Effect.provideService(ReconciliationStore, {} as ReconciliationStoreShape),
+        Effect.provideService(AuthorityGenerationStore, {} as AuthorityGenerationStoreShape),
+        Effect.provideService(AuthorityRestrictionStore, {} as AuthorityRestrictionStoreShape),
+        Effect.provideService(WriterFence, {} as WriterFenceService),
+        Effect.provide(TestClock.layer()),
+      ),
+    )
+
+    expect(recovery).toEqual({
+      _tag: 'Execute',
+      action: 'RECOVER_SUBMIT',
+      intentId: fixture.intent.intentId,
+      observedAt,
+    })
+    expect(terminalization).toEqual({
+      _tag: 'Block',
+      reason: CycleTerminalReason.ProvenanceMismatch,
+      observedAt,
+    })
+    expect(freshFailure).toMatchObject({
+      _tag: 'CycleRunnerError',
+      failure: 'contract',
+      message: 'durable mutation notional changed from the current execution model',
+    })
+    expect(commits).toBe(0)
+    expect(reconciliations).toBe(0)
+  })
+
+  test('terminalizes a known rejected PAPER intent without waiting for cutoff', async () => {
+    const fixture = await paperLifecycleFixture()
+    const rejectedAt = new Date(Date.parse(fixture.document.createdAt) + 1_000).toISOString()
+    expect(rejectedAt < fixture.risk.evaluation.decision.expiresAt).toBe(true)
+    const record = storedIntent(fixture.intent, IntentState.Terminal, rejectedAt, TerminalOutcome.Rejected)
+    const rejected: MutationEvent = {
+      schemaVersion: 'bayn.paper-mutation-event.v1',
+      eventId: 'a'.repeat(64),
+      mutationId: 'b'.repeat(64),
+      intentId: fixture.intent.intentId,
+      sequence: 2,
+      operation: MutationOperation.Submit,
+      eventType: MutationEventType.SubmitRejected,
+      requestHash: 'c'.repeat(64),
+      consistencyDelayMs: 1_000,
+      requestId: 'paper-rejected-request',
+      responseStatus: 422,
+      responseContentHash: 'd'.repeat(64),
+      occurredAt: rejectedAt,
+    }
+    const restrictions: { readonly reason: string; readonly updatedAt: string }[] = []
+
+    const step = await prepareStoredPaperStep(fixture, record, rejected, rejectedAt, 0, (reason, updatedAt) =>
+      restrictions.push({ reason, updatedAt }),
+    )
+
+    expect(step).toEqual({
+      _tag: 'Block',
+      reason: CycleTerminalReason.Risk,
+      observedAt: rejectedAt,
+    })
+    expect(restrictions).toHaveLength(1)
+    expect(restrictions[0]).toMatchObject({
+      updatedAt: rejectedAt,
+    })
+    expect(restrictions[0]?.reason).toContain(`intent ${fixture.intent.intentId} ended REJECTED`)
+  })
+
+  test('completes a filled PAPER cycle after a later exact post-cutoff reconciliation', async () => {
+    const fixture = await paperLifecycleFixture()
+    const terminalAt = new Date(Date.parse(fixture.document.submissionCutoffAt) + 1_000).toISOString()
+    const reconciledLaterAt = new Date(Date.parse(terminalAt) + 1_000).toISOString()
+    const record = storedIntent(fixture.intent, IntentState.Terminal, terminalAt, TerminalOutcome.Filled)
+    const accepted: MutationEvent = {
+      schemaVersion: 'bayn.paper-mutation-event.v1',
+      eventId: '7'.repeat(64),
+      mutationId: '8'.repeat(64),
+      intentId: fixture.intent.intentId,
+      sequence: 2,
+      operation: MutationOperation.Submit,
+      eventType: MutationEventType.SubmitAccepted,
+      requestHash: '9'.repeat(64),
+      consistencyDelayMs: 1_000,
+      brokerOrderId: 'filled-past-cutoff',
+      occurredAt: terminalAt,
+    }
+
+    const step = await prepareStoredPaperStep(fixture, record, accepted, reconciledLaterAt)
+
+    expect(step).toEqual({ _tag: 'Complete', observedAt: reconciledLaterAt })
+    const completion = Result.getOrThrow(decideCompletion(fixture.boundCycle, CycleState.Completed, reconciledLaterAt))
+    if (completion._tag !== 'VerifyDecision') return expect.unreachable('PAPER completion must verify')
+    expect(Result.isFailure(validateCompletionDocument(completion, [fixture.document]))).toBe(true)
+    expect(Result.isSuccess(validateCompletionDocument(completion, [fixture.document], true))).toBe(true)
   })
 
   test('derives the autonomous cycle protocol identity from the current strategy provenance', () => {
@@ -721,7 +2012,7 @@ describe('OBSERVE runtime composition', () => {
     })
   })
 
-  test('builds the durable non-dispatchable shadow plan from an exact PAPER authority without requiring OBSERVE', async () => {
+  test('builds a truthful immutable PAPER decision from the exact authority generation', async () => {
     const policy = await Effect.runPromise(loadObserveRiskPolicy(accountId, fixtureProtocol.universe))
     const program = Effect.gen(function* () {
       yield* TestClock.setTime(Date.parse(evaluatedAt))
@@ -741,20 +2032,73 @@ describe('OBSERVE runtime composition', () => {
     const document = await Effect.runPromise(program)
 
     expect(document).toMatchObject({
-      mode: 'OBSERVE',
-      dispatchable: false,
-      bindings: { accountId, cycleId: cycle.identity.cycleId },
+      schemaVersion: 'bayn.paper-cycle-decision.v1',
+      mode: 'PAPER',
+      dispatchable: true,
+      bindings: {
+        accountId,
+        cycleId: cycle.identity.cycleId,
+        qualificationRunId: cycle.identity.qualificationRunId,
+        authorityGenerationHash: generationHash,
+      },
       deltaRisk: [
         {
           evaluation: {
             decision: {
-              outcome: RiskOutcome.Blocked,
-              reasonCodes: [Reason.AuthorityNotPaper],
+              outcome: RiskOutcome.Approved,
+              reasonCodes: [],
             },
           },
         },
       ],
     })
+    expect(document.orderedIntentIds).toEqual([document.deltaRisk[0]?.evaluation.input.intentId])
+
+    const { contentHash: _contentHash, ...material } = document
+    const target = material.targetPlan.intentTargets[0]
+    const risk = material.deltaRisk[0]
+    expect(target).toBeDefined()
+    expect(risk).toBeDefined()
+    if (target === undefined || risk === undefined) return expect.unreachable('PAPER decision target evidence missing')
+
+    const alteredGeneration = makePaperDecisionDocument({
+      ...material,
+      bindings: { ...material.bindings, authorityGenerationHash: '9'.repeat(64) },
+    })
+    const alteredTarget = makePaperDecisionDocument({
+      ...material,
+      targetPlan: {
+        ...material.targetPlan,
+        intentTargets: [{ ...target, accountId: 'different-paper-account' }],
+      },
+    })
+    const alteredOrder = makePaperDecisionDocument({
+      ...material,
+      orderedIntentIds: ['8'.repeat(64)],
+    })
+    const alteredCumulativeRisk = makePaperDecisionDocument({
+      ...material,
+      deltaRisk: [
+        {
+          ...risk,
+          evaluation: {
+            ...risk.evaluation,
+            metrics: {
+              ...risk.evaluation.metrics,
+              aggregateBuyingPowerMicros: (BigInt(risk.evaluation.metrics.aggregateBuyingPowerMicros) + 1n).toString(),
+            },
+          },
+        },
+      ],
+    })
+    const alteredExpiry = makePaperDecisionDocument({
+      ...material,
+      expiresAt: new Date(Date.parse(material.expiresAt) - 1).toISOString(),
+    })
+
+    for (const altered of [alteredGeneration, alteredTarget, alteredOrder, alteredCumulativeRisk, alteredExpiry]) {
+      expect(Result.isFailure(altered)).toBe(true)
+    }
   })
 
   test('fails closed when same-pass reconciliation observes another authority generation', async () => {
@@ -1047,6 +2391,8 @@ describe('OBSERVE runtime composition', () => {
               | ReconciliationStore
               | AuthorityGenerationStore
               | AuthorityRestrictionStore
+              | IntentStore
+              | MutationStore
               | WriterFence
             >,
             OperationalError,
@@ -1066,6 +2412,8 @@ describe('OBSERVE runtime composition', () => {
             Effect.provideService(ReconciliationStore, executionStore),
             Effect.provideService(AuthorityGenerationStore, executionStore),
             Effect.provideService(AuthorityRestrictionStore, executionStore),
+            Effect.provideService(IntentStore, {} as IntentStoreService),
+            Effect.provideService(MutationStore, {} as MutationStoreShape),
             Effect.provideService(WriterFence, writerFence),
             Effect.forkScoped,
           )
@@ -1319,6 +2667,8 @@ describe('OBSERVE runtime composition', () => {
             Effect.provideService(ReconciliationStore, executionStore),
             Effect.provideService(AuthorityGenerationStore, executionStore),
             Effect.provideService(AuthorityRestrictionStore, executionStore),
+            Effect.provideService(IntentStore, {} as IntentStoreService),
+            Effect.provideService(MutationStore, {} as MutationStoreShape),
             Effect.provideService(WriterFence, writerFence),
             Effect.forkScoped({ startImmediately: true }),
           )
@@ -1811,7 +3161,7 @@ describe('OBSERVE runtime composition', () => {
                 return postReconcilePasses
               }).pipe(
                 Effect.flatMap((count) =>
-                  count === 2
+                  count === 1
                     ? Deferred.succeed(cadenceContinued, undefined).pipe(Effect.as(paperPersisted))
                     : Effect.succeed(paperPersisted),
                 ),
@@ -1872,7 +3222,7 @@ describe('OBSERVE runtime composition', () => {
             Effect.forkScoped({ startImmediately: true }),
           )
           yield* Deferred.await(storeReadStarted).pipe(Effect.timeout('1 second'))
-          expect(postReconcilePasses).toBe(1)
+          expect(postReconcilePasses).toBe(0)
           postReconcileEvents.push('store-read-started')
           yield* TestClock.adjust(50)
           yield* Deferred.await(passFailed).pipe(Effect.timeout('1 second'))
@@ -1891,10 +3241,10 @@ describe('OBSERVE runtime composition', () => {
       failure: 'operational',
       message: 'mutation autonomous cycle pass did not complete or reconcile within 50ms',
     })
-    expect(postReconcilePasses).toBe(2)
-    expect(postReconcileEvents.indexOf('reconcile:1')).toBeLessThan(postReconcileEvents.indexOf('store-read-started'))
+    expect(postReconcilePasses).toBe(1)
+    expect(authorityRestrictions).toBe(3)
     expect(postReconcileEvents.indexOf('store-read-interrupted')).toBeLessThan(
-      postReconcileEvents.indexOf('reconcile:2'),
+      postReconcileEvents.indexOf('reconcile:1'),
     )
   })
 
@@ -2069,6 +3419,8 @@ describe('OBSERVE runtime composition', () => {
             Effect.provideService(ReconciliationStore, executionStore),
             Effect.provideService(AuthorityGenerationStore, executionStore),
             Effect.provideService(AuthorityRestrictionStore, executionStore),
+            Effect.provideService(IntentStore, {} as IntentStoreService),
+            Effect.provideService(MutationStore, {} as MutationStoreShape),
             Effect.provideService(WriterFence, writerFence),
             Effect.forkScoped({ startImmediately: true }),
           )
@@ -2090,6 +3442,165 @@ describe('OBSERVE runtime composition', () => {
     })
     expect(fencedTransactions).toBe(1)
     expect(authorityRestrictions).toBe(0)
+  })
+
+  test('recovers a bound OBSERVE decision before entering PAPER intent or broker execution', async () => {
+    const policy = await Effect.runPromise(loadObserveRiskPolicy(accountId, fixtureProtocol.universe))
+    const document = await Effect.runPromise(
+      Effect.gen(function* () {
+        yield* TestClock.setTime(Date.parse(evaluatedAt))
+        return yield* buildObserveCycleDecision({
+          authorityGenerationHash: generationHash,
+          cycle,
+          executionModel: fixtureProtocol.executionModel,
+          policy,
+          reconcile: Effect.succeed(reconciliationResult()),
+          strategy: { currentDecision: () => Result.succeed({ decision, priceMicros }) },
+        })
+      }).pipe(
+        (program) => provideDecisionServices(program, marketData([]), calendarRead([])),
+        Effect.provide(TestClock.layer()),
+      ),
+    )
+    const boundCycle = Effect.runSync(
+      decodeAutonomousCycle({
+        ...cycle,
+        bindings: { ...cycle.bindings, decisionHash: document.contentHash },
+        stateVersion: cycle.stateVersion + 1,
+        updatedAt: document.createdAt,
+      }),
+    )
+    const recoveredAt = new Date(Date.parse(document.createdAt) + 1).toISOString()
+    const completedCycle = Effect.runSync(
+      decodeAutonomousCycle({
+        ...boundCycle,
+        state: CycleState.Completed,
+        stateVersion: boundCycle.stateVersion + 1,
+        updatedAt: recoveredAt,
+        terminalAt: recoveredAt,
+      }),
+    )
+    let unfinishedReads = 0
+    let documentReads = 0
+    let finishes = 0
+    let terminal = false
+    const forbidden = (capability: string) => Effect.die(new Error(`OBSERVE recovery must not use ${capability}`))
+    const cycleStore: CycleStoreShape = {
+      acquire: () => forbidden('cycle acquisition'),
+      read: () => forbidden('cycle read by ID'),
+      readAuthoritySlot: () => forbidden('authority-slot read'),
+      readOldestUnfinished: () =>
+        Effect.sync(() => {
+          unfinishedReads += 1
+          return terminal ? Option.none() : Option.some(boundCycle)
+        }),
+      readDecisionDocument: (cycleId) =>
+        Effect.sync(() => {
+          documentReads += 1
+          expect(cycleId).toBe(boundCycle.identity.cycleId)
+          return Option.some(document)
+        }),
+      bindSnapshot: () => forbidden('snapshot binding'),
+      activate: () => forbidden('cycle activation'),
+      bindDecision: () => forbidden('decision binding'),
+      finish: (cycleId, state, observedAt) =>
+        Effect.sync(() => {
+          finishes += 1
+          expect(cycleId).toBe(boundCycle.identity.cycleId)
+          expect(state).toBe(CycleState.Completed)
+          expect(observedAt).toBe(recoveredAt)
+          terminal = true
+          return { cycle: completedCycle, changed: true }
+        }),
+      block: () => forbidden('cycle blocking'),
+    }
+    const brokerRead = {
+      account: forbidden('broker account read'),
+      accountConfiguration: forbidden('broker account-configuration read'),
+      assetBySymbol: () => forbidden('broker asset read'),
+      positions: forbidden('broker positions read'),
+      orders: () => forbidden('broker orders read'),
+      orderById: () => forbidden('broker order lookup'),
+      orderByClientId: () => forbidden('broker client-order lookup'),
+      fillActivities: () => forbidden('broker fill read'),
+      marketCalendar: () => forbidden('broker calendar read'),
+    } satisfies BrokerReadShape
+    const executionStore = {
+      ingest: () => forbidden('broker-event persistence'),
+      ingestPositions: () => forbidden('position persistence'),
+      account: () => forbidden('accounting read'),
+      value: () => forbidden('valuation persistence'),
+      hasAccountBaseline: () => forbidden('account baseline read'),
+      bindings: () => forbidden('accounting binding read'),
+      reconcile: () => forbidden('reconciliation persistence'),
+      ensureAuthorityGeneration: () => forbidden('authority initialization'),
+      restrictAuthority: () => forbidden('authority restriction'),
+    } satisfies BrokerEventStoreShape &
+      FillAccountingStoreShape &
+      ValuationStoreShape &
+      ReconciliationStoreShape &
+      AuthorityGenerationStoreShape &
+      AuthorityRestrictionStoreShape
+    const marketDataService: MarketDataService = {
+      check: forbidden('market-data health check'),
+      inspect: forbidden('market-data inspection'),
+      inspectCyclePublications: forbidden('cycle publication inspection'),
+      inspectPublication: () => forbidden('publication inspection'),
+      inspectSnapshotPublication: () => forbidden('snapshot publication inspection'),
+      loadSnapshotPublication: () => forbidden('snapshot publication load'),
+      load: forbidden('market-data load'),
+    }
+    const writerFence: WriterFenceService = {
+      backendPid: 1,
+      check: forbidden('writer-fence check'),
+      transaction: () => forbidden('writer-fence transaction'),
+    }
+    const startup = makeMutationAutonomousCycleStartup({
+      accountId,
+      authorityGenerationHash: generationHash,
+      pollIntervalMs: 30_000,
+      reconciliationIntervalMs: 30_000,
+      reconciliationPassTimeoutMs: 30_000,
+      strategy: fixtureStrategy,
+      executionProgram: sandboxExecutionProgram(),
+    })
+
+    const observation = await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          yield* TestClock.setTime(Date.parse(recoveredAt))
+          const pass = yield* Deferred.make<Parameters<Parameters<typeof startup>[0]['recordPass']>[0]>()
+          const loop = yield* startup({
+            qualificationRunId: boundCycle.identity.qualificationRunId,
+            recordPass: (result) => Deferred.succeed(pass, result).pipe(Effect.asVoid),
+          })
+          const fiber = yield* loop.pipe(
+            Effect.provideService(BrokerRead, brokerRead),
+            Effect.provideService(CycleStore, cycleStore),
+            Effect.provideService(MarketData, marketDataService),
+            Effect.provideService(BrokerEventStore, executionStore),
+            Effect.provideService(FillAccountingStore, executionStore),
+            Effect.provideService(ValuationStore, executionStore),
+            Effect.provideService(ReconciliationStore, executionStore),
+            Effect.provideService(AuthorityGenerationStore, executionStore),
+            Effect.provideService(AuthorityRestrictionStore, executionStore),
+            Effect.provideService(WriterFence, writerFence),
+            Effect.provideService(IntentStore, {} as IntentStoreService),
+            Effect.provideService(MutationStore, {} as MutationStoreShape),
+            Effect.forkScoped({ startImmediately: true }),
+          )
+          const result = yield* Deferred.await(pass).pipe(Effect.timeout('1 second'))
+          yield* Fiber.interrupt(fiber)
+          return result
+        }),
+      ).pipe(Effect.provide(TestClock.layer())),
+    )
+
+    expect(observation).toMatchObject({ result: 'SUCCESS', outcome: 'RECOVERED' })
+    expect(unfinishedReads).toBe(2)
+    expect(documentReads).toBe(2)
+    expect(finishes).toBe(1)
+    expect(terminal).toBe(true)
   })
 
   test('starts mutation mode without projecting or initializing OBSERVE authority', async () => {

--- a/services/bayn/src/observe-composition.ts
+++ b/services/bayn/src/observe-composition.ts
@@ -1,14 +1,19 @@
-import { Clock, Data, Duration, Effect, Option, pipe, Ref, Result } from 'effect'
+import { Clock, Data, Duration, Effect, Option, Ref, Result } from 'effect'
 
 import type { AutonomousCycleLoop, AutonomousCycleStartup } from './app'
 import { BrokerRead, type BrokerReadShape, type MarketCalendarQuery } from './broker/alpaca'
-import { CycleState, makeCycleExecutionPolicyFromModel, type AutonomousCycle, type CycleExecutionPolicy } from './cycle'
+import {
+  CycleState,
+  CycleTerminalReason,
+  makeCycleExecutionPolicyFromModel,
+  type AutonomousCycle,
+  type CycleExecutionPolicy,
+} from './cycle'
 import {
   CycleDecisionBuildError,
   CycleRunnerError,
   cyclePassLogFacts,
   decideIdleReconciliationCadence,
-  makeAutonomousCycleLoop,
   marketCalendarQueryForSignal,
   runAutonomousCyclePass,
   shouldDeferCyclePollForReconciliation,
@@ -31,8 +36,9 @@ import {
 } from './db/execution-store'
 import { WriterFence } from './execution/writer-fence'
 import { MutationOperation } from './broker/alpaca-mutations'
+import { recover as recoverMutation } from './execution/coordinator'
 import { BrokerAccess, CapitalAuthorityKind } from './execution/authority'
-import { IntentStore, planPaperIntent } from './execution/intents'
+import { IntentStore, planPaperIntent, type StoredIntent } from './execution/intents'
 import { MutationEventType, MutationStore, type MutationEvent } from './execution/mutations'
 import type { ExecutionProgram } from './execution/runtime-program'
 import {
@@ -48,10 +54,12 @@ import { MarketData, type MarketDataService } from './market-data'
 import {
   Authority,
   IntentState,
+  KillState,
   OrderSide,
   OrderStatus,
   OrderType,
-  RiskOutcome,
+  ReconciliationStatus,
+  TerminalOutcome,
   TimeInForce,
   type AuthorityState,
   type Intent,
@@ -61,9 +69,18 @@ import {
 import type { CausalProtocol } from './protocol'
 import { runOnce, type ReconciliationPassResult } from './reconciler'
 import { reconciledStateHash } from './reconciliation'
-import { BrokerMode, decodePolicy, evaluate, type Policy, type State } from './risk'
-import { buildObserveShadowDecision, type ShadowDecisionError, type ShadowDeltaRiskInput } from './shadow-decision'
-import type { ObserveShadowDecisionDocument } from './shadow-decision-contract'
+import { BrokerMode, decodePolicy, type Policy, type State } from './risk'
+import {
+  buildObserveShadowDecision,
+  buildPaperDecision,
+  type ShadowDecisionError,
+  type ShadowDeltaRiskInput,
+} from './shadow-decision'
+import type {
+  CycleDecisionDocument,
+  ObserveShadowDecisionDocument,
+  PaperDecisionDocument,
+} from './shadow-decision-contract'
 import { currentUtcInstant } from './time'
 import {
   planTargets,
@@ -387,6 +404,29 @@ const requireDecisionAuthority = (
   return Result.succeed({ authority, observedAt: result.riskContext.authorityObservedAt })
 }
 
+const requireMutationAuthorityGeneration = (
+  result: ReconciliationPassResult,
+  policy: Policy,
+  authorityGenerationHash: string,
+): Result.Result<ObserveAuthorityObservation, ObserveDecisionCompositionFailure> => {
+  const authority = result.riskContext.authority
+  if (
+    authority === null ||
+    result.riskContext.authorityObservedAt === null ||
+    authority.generationHash !== authorityGenerationHash ||
+    authority.maximum !== Authority.Paper ||
+    result.brokerState.account.accountId !== policy.accountId
+  ) {
+    return Result.fail(
+      compositionFailure(
+        'observe-authority',
+        'same-pass reconciliation did not return the configured PAPER authority generation',
+      ),
+    )
+  }
+  return Result.succeed({ authority, observedAt: result.riskContext.authorityObservedAt })
+}
+
 const prepareExecutionSessionBinding = <R>(
   input: ObserveDecisionInput<R>,
   facts: ObserveDecisionFacts,
@@ -530,39 +570,40 @@ export const buildObserveCycleDecision = <R>(
 ): Effect.Effect<ObserveShadowDecisionDocument, ObserveDecisionFailure, BrokerRead | MarketData | R> =>
   buildCycleDecision(input, Authority.Observe)
 
-const projectShadowAuthority = (observation: ObserveAuthorityObservation): ObserveAuthorityObservation => ({
-  // The durable shadow contract is deliberately OBSERVE-only and non-dispatchable. Mutation execution never
-  // consumes this projected authority: it re-reads the same generation and requires exact PAPER authority
-  // before constructing and committing executable intents.
-  ...observation,
-  authority: {
-    ...observation.authority,
-    maximum: Authority.Observe,
-    effective: Authority.Observe,
-  },
-})
-
-const buildCycleDecision = <R>(
+function buildCycleDecision<R>(
+  input: ObserveDecisionInput<R>,
+  authorityRequirement: Authority.Observe,
+): Effect.Effect<ObserveShadowDecisionDocument, ObserveDecisionFailure, BrokerRead | MarketData | R>
+function buildCycleDecision<R>(
+  input: ObserveDecisionInput<R>,
+  authorityRequirement: Authority.Paper,
+): Effect.Effect<PaperDecisionDocument, ObserveDecisionFailure, BrokerRead | MarketData | R>
+function buildCycleDecision<R>(
   input: ObserveDecisionInput<R>,
   authorityRequirement: DecisionAuthorityRequirement,
-): Effect.Effect<ObserveShadowDecisionDocument, ObserveDecisionFailure, BrokerRead | MarketData | R> =>
-  Effect.gen(function* () {
+): Effect.Effect<CycleDecisionDocument, ObserveDecisionFailure, BrokerRead | MarketData | R> {
+  return Effect.gen(function* () {
     const readPreparation = yield* Effect.fromResult(prepareObserveDecisionReads(input))
     const facts = yield* readObserveDecisionFacts(input, readPreparation)
     const executionAuthority = yield* Effect.fromResult(
       requireDecisionAuthority(facts.reconciliation, input.policy, input.authorityGenerationHash, authorityRequirement),
     )
-    const shadowAuthority =
-      authorityRequirement === Authority.Observe ? executionAuthority : projectShadowAuthority(executionAuthority)
     const executionSession = yield* Effect.fromResult(prepareExecutionSessionBinding(input, facts))
     const compiled = yield* compileObserveStrategyDecision(input, facts, executionSession)
     const plannerPreparation = yield* Effect.fromResult(prepareObservePlanner(input, facts, compiled))
     const targetPlan = yield* Effect.fromResult(planTargets(plannerPreparation.plannerInput))
     const riskInputs = yield* Effect.fromResult(
-      reduceObserveRiskInputs(input, facts, shadowAuthority, executionSession, targetPlan, plannerPreparation.prices),
+      reduceObserveRiskInputs(
+        input,
+        facts,
+        executionAuthority,
+        executionSession,
+        targetPlan,
+        plannerPreparation.prices,
+      ),
     )
     const finalizedSnapshot = facts.snapshot.manifest.finalizedSnapshot
-    return yield* buildObserveShadowDecision({
+    const decisionInput = {
       cycle: input.cycle,
       snapshot: {
         snapshotId: finalizedSnapshot.snapshotId,
@@ -574,12 +615,16 @@ const buildCycleDecision = <R>(
       targetPlan,
       policy: input.policy,
       riskInputs,
-    })
+    }
+    return authorityRequirement === Authority.Observe
+      ? yield* buildObserveShadowDecision(decisionInput)
+      : yield* buildPaperDecision({ ...decisionInput, authorityGenerationHash: input.authorityGenerationHash })
   })
+}
 
 export const buildMutationShadowCycleDecision = <R>(
   input: ObserveDecisionInput<R>,
-): Effect.Effect<ObserveShadowDecisionDocument, ObserveDecisionFailure, BrokerRead | MarketData | R> =>
+): Effect.Effect<PaperDecisionDocument, ObserveDecisionFailure, BrokerRead | MarketData | R> =>
   buildCycleDecision(input, Authority.Paper)
 
 const observePass = (
@@ -620,6 +665,7 @@ type ObserveDecisionRuntime =
   | AuthorityRestrictionStore
   | WriterFence
 type ObserveRuntime = CycleStore | ObserveDecisionRuntime
+type RecoveryFirstRuntime = ObserveRuntime | IntentStore | MutationStore
 
 export type ObserveStartupPreparation = {
   readonly executionModel: CausalProtocol['executionModel']
@@ -676,57 +722,6 @@ const initializeObserveAuthority = (
     Effect.flatMap((authority) => Effect.fromResult(validateObserveAuthorityInitialization(authority, input))),
   )
 
-const makeObserveAutonomousLoop = (
-  input: ObserveAutonomousCycleInput,
-  startup: Parameters<AutonomousCycleStartup>[0],
-  preparation: ObserveStartupPreparation,
-  policy: Policy,
-): Result.Result<AutonomousCycleLoop<ObserveRuntime>, OperationalError> => {
-  const reconcile = boundedReconciliationPass(input.reconciliationPassTimeoutMs)
-  const context: CycleRunContext<ObserveDecisionRuntime> = {
-    qualificationRunId: startup.qualificationRunId,
-    strategyProtocolHash: preparation.strategyProtocolHash,
-    accountId: input.accountId,
-    executionPolicy: preparation.executionPolicy,
-    buildDecision: (cycle, reconciliationCompleted = Effect.void) =>
-      buildObserveCycleDecision({
-        authorityGenerationHash: input.authorityGenerationHash,
-        cycle,
-        executionModel: preparation.executionModel,
-        policy,
-        reconcile: reconcile.pipe(Effect.tap(() => reconciliationCompleted)),
-        strategy: input.strategy,
-      }).pipe(Effect.mapError(decisionBuildError)),
-  }
-  return pipe(
-    makeAutonomousCycleLoop({
-      context: Effect.succeed(context),
-      observePass: (observation) => observePass(startup.recordPass, observation),
-      cyclePassTimeoutMs: Math.min(input.reconciliationPassTimeoutMs, input.reconciliationIntervalMs),
-      pollIntervalMs: input.pollIntervalMs,
-      reconciliationIntervalMs: input.reconciliationIntervalMs,
-      reconcileNotDue: reconcile.pipe(Effect.mapError(notDueReconciliationError), Effect.asVoid),
-    }),
-    Result.mapError((cause) =>
-      operationalError('strategy', 'cycle-loop', 'autonomous cycle loop failed to start', cause),
-    ),
-  )
-}
-
-export const makeObserveAutonomousCycleStartup =
-  (input: ObserveAutonomousCycleInput): AutonomousCycleStartup<AuthorityGenerationStore, ObserveRuntime> =>
-  (startup) =>
-    Effect.gen(function* () {
-      const preparation = yield* Effect.fromResult(prepareObserveStartup(input))
-      const policy = yield* loadObserveRiskPolicy(input.accountId, input.strategy.parameters.universe).pipe(
-        Effect.mapError((cause) =>
-          operationalError('strategy', 'risk-policy', 'source-controlled paper risk policy is invalid', cause),
-        ),
-      )
-      yield* initializeObserveAuthority(input)
-      return yield* Effect.fromResult(makeObserveAutonomousLoop(input, startup, preparation, policy))
-    })
-
 const mutationConsistencyDelayMs = 1_000
 const quantityScale = 1_000_000n
 
@@ -734,7 +729,19 @@ export type MutationAutonomousCycleInput = ObserveAutonomousCycleInput & {
   readonly executionProgram: ExecutionProgram
 }
 
-type MutationRuntime = ObserveRuntime | IntentStore | MutationStore
+type PaperExecutionCapability =
+  | { readonly _tag: 'RecoveryOnly' }
+  | { readonly _tag: 'Mutation'; readonly executionProgram: ExecutionProgram }
+
+type PaperMutationExecutor<E, R> = {
+  readonly submit?: (intentId: string, consistencyDelayMs: number) => Effect.Effect<MutationEvent, E, R>
+  readonly recover: (intentId: string, operation: MutationOperation) => Effect.Effect<MutationEvent, E, R>
+}
+
+type RecoveryFirstDecisionBuilder = (
+  cycle: AutonomousCycle,
+  reconcile: Effect.Effect<ReconciliationPassResult, ReconciliationPassError, ObserveDecisionRuntime>,
+) => Effect.Effect<CycleDecisionDocument, CycleDecisionBuildError, ObserveDecisionRuntime>
 
 const mutationRunnerError = (
   message: string,
@@ -832,26 +839,40 @@ export const projectWorstCasePendingMutationPosition = (
 }
 
 const validateBoundMutationDocument = (
-  input: MutationAutonomousCycleInput,
+  input: ObserveAutonomousCycleInput,
   cycle: AutonomousCycle,
+  document: PaperDecisionDocument,
+): Result.Result<void, CycleRunnerError> => {
+  return cycle.state !== CycleState.Active ||
+    cycle.bindings.decisionHash !== document.contentHash ||
+    cycle.bindings.snapshotId !== document.bindings.snapshotId ||
+    cycle.identity.cycleId !== document.bindings.cycleId ||
+    cycle.identity.qualificationRunId !== document.bindings.qualificationRunId ||
+    cycle.identity.accountId !== document.bindings.accountId ||
+    cycle.identity.strategyProtocolHash !== document.bindings.strategyProtocolHash ||
+    input.accountId !== document.bindings.accountId
+    ? Result.fail(
+        mutationRunnerError(
+          'durable shadow plan does not match the mutation cycle account, protocol, and decision binding',
+          undefined,
+          'contract',
+        ),
+      )
+    : Result.succeed(undefined)
+}
+
+const validateCurrentMutationPolicy = (
   policy: Policy,
-  document: ObserveShadowDecisionDocument,
+  document: PaperDecisionDocument,
 ): Result.Result<void, CycleRunnerError> => {
   const policyHash = canonicalHashV1Result(policy)
   if (Result.isFailure(policyHash)) {
     return Result.fail(mutationRunnerError('mutation cycle risk policy is not canonicalizable', policyHash.failure))
   }
-  return cycle.state !== CycleState.Active ||
-    cycle.bindings.decisionHash !== document.contentHash ||
-    cycle.bindings.snapshotId !== document.bindings.snapshotId ||
-    cycle.identity.cycleId !== document.bindings.cycleId ||
-    cycle.identity.accountId !== document.bindings.accountId ||
-    cycle.identity.strategyProtocolHash !== document.bindings.strategyProtocolHash ||
-    input.accountId !== document.bindings.accountId ||
-    policyHash.success !== document.bindings.policyHash
+  return policyHash.success !== document.bindings.policyHash
     ? Result.fail(
         mutationRunnerError(
-          'durable shadow plan does not match the mutation cycle account, protocol, policy, and decision binding',
+          'current source-controlled PAPER risk policy changed from the durable decision binding',
           undefined,
           'contract',
         ),
@@ -861,7 +882,7 @@ const validateBoundMutationDocument = (
 
 const readBoundMutationDocument = (
   cycle: AutonomousCycle,
-): Effect.Effect<ObserveShadowDecisionDocument, CycleRunnerError, CycleStore> =>
+): Effect.Effect<CycleDecisionDocument, CycleRunnerError, CycleStore> =>
   CycleStore.pipe(
     Effect.flatMap((store) => store.readDecisionDocument(cycle.identity.cycleId)),
     Effect.mapError((cause) => mutationRunnerError('durable mutation-cycle shadow plan read failed', cause, 'store')),
@@ -877,7 +898,7 @@ const readBoundMutationDocument = (
   )
 
 const mutationDecisionInput = (
-  input: MutationAutonomousCycleInput,
+  input: ObserveAutonomousCycleInput,
   preparation: ObserveStartupPreparation,
   policy: Policy,
   cycle: AutonomousCycle,
@@ -892,7 +913,8 @@ const mutationDecisionInput = (
 })
 
 export type PreparedMutationIntentDecision =
-  | { readonly _tag: 'Execute' }
+  | { readonly _tag: 'Submit' }
+  | { readonly _tag: 'Recover'; readonly eventType: MutationEventType }
   | { readonly _tag: 'Pending'; readonly order: Order }
   | { readonly _tag: 'SkipTerminal' }
 
@@ -908,7 +930,7 @@ export const decidePreparedMutationIntent = (
   latest: MutationEvent | undefined,
 ): Result.Result<PreparedMutationIntentDecision, PreparedMutationIntentDecisionFailure> => {
   if (intent.state === IntentState.Terminal) return Result.succeed({ _tag: 'SkipTerminal' })
-  if (latest === undefined) return Result.succeed({ _tag: 'Execute' })
+  if (latest === undefined) return Result.succeed({ _tag: 'Submit' })
   switch (latest.eventType) {
     case MutationEventType.SubmitAccepted:
     case MutationEventType.RecoveryFound:
@@ -952,8 +974,76 @@ export const decidePreparedMutationIntent = (
     case MutationEventType.CancelStarted:
     case MutationEventType.CancelAccepted:
     case MutationEventType.CancelUnknown:
-      return Result.succeed({ _tag: 'Execute' })
+      return Result.succeed({ _tag: 'Recover', eventType: latest.eventType })
   }
+}
+
+export type PreparedMutationIntentAdmissionFailure = {
+  readonly _tag: 'PreparedMutationIntentAdmissionFailure'
+  readonly reason:
+    | 'accounting-inexact'
+    | 'authority'
+    | 'expiry'
+    | 'reconciliation-not-exact'
+    | 'unknown-mutation'
+    | 'unknown-order'
+  readonly message: string
+}
+
+export const decidePreparedMutationIntentAdmission = (
+  prepared: PreparedMutationIntentDecision,
+  effectiveAuthority: Authority,
+  observedAt: string,
+  expiresAt: string,
+  unknownMutationCount: number,
+  reconciliationStatus: ReconciliationStatus = ReconciliationStatus.Exact,
+  accountingExact = true,
+  unknownOrderCount = 0,
+): Result.Result<void, PreparedMutationIntentAdmissionFailure> => {
+  if (prepared._tag !== 'Submit') return Result.succeed(undefined)
+  if (effectiveAuthority !== Authority.Paper) {
+    return Result.fail({
+      _tag: 'PreparedMutationIntentAdmissionFailure',
+      reason: 'authority',
+      message: 'fresh PAPER submit requires current effective PAPER authority',
+    })
+  }
+  if (observedAt >= expiresAt) {
+    return Result.fail({
+      _tag: 'PreparedMutationIntentAdmissionFailure',
+      reason: 'expiry',
+      message: 'fresh PAPER submit is forbidden at or after decision expiry',
+    })
+  }
+  if (reconciliationStatus !== ReconciliationStatus.Exact) {
+    return Result.fail({
+      _tag: 'PreparedMutationIntentAdmissionFailure',
+      reason: 'reconciliation-not-exact',
+      message: 'fresh PAPER submit requires exact same-pass reconciliation',
+    })
+  }
+  if (!accountingExact) {
+    return Result.fail({
+      _tag: 'PreparedMutationIntentAdmissionFailure',
+      reason: 'accounting-inexact',
+      message: 'fresh PAPER submit requires exact same-pass accounting',
+    })
+  }
+  if (unknownMutationCount !== 0) {
+    return Result.fail({
+      _tag: 'PreparedMutationIntentAdmissionFailure',
+      reason: 'unknown-mutation',
+      message: 'fresh PAPER submit is forbidden while a mutation outcome is unknown',
+    })
+  }
+  if (unknownOrderCount !== 0) {
+    return Result.fail({
+      _tag: 'PreparedMutationIntentAdmissionFailure',
+      reason: 'unknown-order',
+      message: 'fresh PAPER submit is forbidden while a broker order is unknown',
+    })
+  }
+  return Result.succeed(undefined)
 }
 
 export const appendPendingMutationOrder = (orders: readonly Order[], pending: Order): readonly Order[] =>
@@ -961,17 +1051,458 @@ export const appendPendingMutationOrder = (orders: readonly Order[], pending: Or
     ? orders
     : [...orders, pending]
 
-const prepareNextMutationIntent = (
-  input: MutationAutonomousCycleInput,
+export interface PaperCycleIntentTerminalEvidence {
+  readonly state: IntentState
+  readonly terminalOutcome?: TerminalOutcome
+  readonly updatedAt: string
+  readonly latestMutationAt?: string
+}
+
+export interface PaperCycleReconciliationEvidence {
+  readonly status: ReconciliationStatus
+  readonly reconciledAt: string
+  readonly accountingExact: boolean
+  readonly unknownMutationCount: number
+  readonly unknownOrderCount: number
+}
+
+export type PaperCycleCompletionDecision =
+  | { readonly _tag: 'Complete' }
+  | {
+      readonly _tag: 'Wait'
+      readonly reason:
+        | 'accounting-inexact'
+        | 'intent-nonterminal'
+        | 'intent-unsuccessful'
+        | 'reconciliation-not-later'
+        | 'reconciliation-not-exact'
+        | 'unknown-mutation'
+        | 'unknown-order'
+    }
+
+export const decidePaperCycleCompletion = (
+  documentCreatedAt: string,
+  intents: readonly PaperCycleIntentTerminalEvidence[],
+  reconciliation: PaperCycleReconciliationEvidence,
+): PaperCycleCompletionDecision => {
+  if (intents.some((intent) => intent.state !== IntentState.Terminal)) {
+    return { _tag: 'Wait', reason: 'intent-nonterminal' }
+  }
+  if (intents.some((intent) => intent.terminalOutcome !== TerminalOutcome.Filled)) {
+    return { _tag: 'Wait', reason: 'intent-unsuccessful' }
+  }
+  if (reconciliation.status !== ReconciliationStatus.Exact) {
+    return { _tag: 'Wait', reason: 'reconciliation-not-exact' }
+  }
+  if (!reconciliation.accountingExact) return { _tag: 'Wait', reason: 'accounting-inexact' }
+  if (reconciliation.unknownMutationCount !== 0) return { _tag: 'Wait', reason: 'unknown-mutation' }
+  if (reconciliation.unknownOrderCount !== 0) return { _tag: 'Wait', reason: 'unknown-order' }
+  const latestEvidenceAt = Math.max(
+    Date.parse(documentCreatedAt),
+    ...intents.flatMap((intent) => [
+      Date.parse(intent.updatedAt),
+      Date.parse(intent.latestMutationAt ?? intent.updatedAt),
+    ]),
+  )
+  if (Date.parse(reconciliation.reconciledAt) <= latestEvidenceAt) {
+    return { _tag: 'Wait', reason: 'reconciliation-not-later' }
+  }
+  return { _tag: 'Complete' }
+}
+
+type PreparedPaperIntent = {
+  readonly intent: Intent
+  readonly targetIntent: PaperDecisionDocument['targetPlan']['intentTargets'][number]
+  readonly target: PlannedTargetQuantity
+  readonly riskBinding: PaperDecisionDocument['deltaRisk'][number]
+  readonly stored: StoredIntent | undefined
+  readonly latestSubmit: MutationEvent | undefined
+  readonly latestCancel: MutationEvent | undefined
+}
+
+type PaperIntentRecoveryLookup = Omit<PreparedPaperIntent, 'intent'> & {
+  readonly intentId: string
+}
+
+export type PreparedMutationRecoveryDecision =
+  | { readonly _tag: 'NoRecovery' }
+  | {
+      readonly _tag: 'Recover'
+      readonly operation: MutationOperation
+      readonly event: MutationEvent
+    }
+
+export const decidePreparedMutationRecovery = (
+  intent: Intent,
+  latestSubmit: MutationEvent | undefined,
+  latestCancel: MutationEvent | undefined,
+): Result.Result<PreparedMutationRecoveryDecision, PreparedMutationIntentDecisionFailure> => {
+  if (latestCancel !== undefined) {
+    if (latestCancel.operation !== MutationOperation.Cancel) {
+      return Result.fail({
+        _tag: 'PreparedMutationIntentDecisionFailure',
+        intentId: intent.intentId,
+        eventType: latestCancel.eventType,
+        message: 'durable cancellation recovery read returned a non-cancel mutation',
+      })
+    }
+    return intent.state === IntentState.Terminal && latestCancel.eventType === MutationEventType.RecoveryFound
+      ? Result.succeed({ _tag: 'NoRecovery' })
+      : Result.succeed({ _tag: 'Recover', operation: MutationOperation.Cancel, event: latestCancel })
+  }
+  if (latestSubmit === undefined) return Result.succeed({ _tag: 'NoRecovery' })
+  if (latestSubmit.operation !== MutationOperation.Submit) {
+    return Result.fail({
+      _tag: 'PreparedMutationIntentDecisionFailure',
+      intentId: intent.intentId,
+      eventType: latestSubmit.eventType,
+      message: 'durable submit recovery read returned a non-submit mutation',
+    })
+  }
+  if (
+    intent.state === IntentState.Terminal &&
+    (latestSubmit.eventType === MutationEventType.SubmitAccepted ||
+      latestSubmit.eventType === MutationEventType.SubmitRejected ||
+      latestSubmit.eventType === MutationEventType.SubmitDenied ||
+      latestSubmit.eventType === MutationEventType.RecoveryFound)
+  ) {
+    return Result.succeed({ _tag: 'NoRecovery' })
+  }
+  if (
+    intent.state !== IntentState.Terminal &&
+    (latestSubmit.eventType === MutationEventType.SubmitRejected ||
+      latestSubmit.eventType === MutationEventType.SubmitDenied)
+  ) {
+    return Result.fail({
+      _tag: 'PreparedMutationIntentDecisionFailure',
+      intentId: intent.intentId,
+      eventType: latestSubmit.eventType,
+      message: 'terminal submit event does not match the nonterminal durable intent state',
+    })
+  }
+  return Result.succeed({ _tag: 'Recover', operation: MutationOperation.Submit, event: latestSubmit })
+}
+
+type PreparedMutationCycleStep =
+  | { readonly _tag: 'RunCycle' }
+  | {
+      readonly _tag: 'Execute'
+      readonly action: 'RECOVER_SUBMIT' | 'RECOVER_CANCEL'
+      readonly intentId: string
+      readonly observedAt: string
+    }
+  | {
+      readonly _tag: 'Execute'
+      readonly action: 'SUBMIT'
+      readonly intentId: string
+      readonly observedAt: string
+      readonly submitExpiresAt: string
+    }
+  | {
+      readonly _tag: 'Block'
+      readonly reason:
+        | CycleTerminalReason.MissedSubmission
+        | CycleTerminalReason.ProvenanceMismatch
+        | CycleTerminalReason.Risk
+      readonly observedAt: string
+    }
+  | { readonly _tag: 'Wait'; readonly observedAt: string }
+  | { readonly _tag: 'Complete'; readonly observedAt: string }
+
+type BoundMutationCycleOutcome = Exclude<PreparedMutationCycleStep, { readonly _tag: 'Execute' }>
+
+export const mutationRecoveryIsDue = (event: MutationEvent, observedAt: string): boolean =>
+  Date.parse(observedAt) >= Date.parse(event.occurredAt) + event.consistencyDelayMs
+
+export const paperSubmitExpiresAt = (documentExpiresAt: string, riskDecisionExpiresAt: string): string =>
+  riskDecisionExpiresAt < documentExpiresAt ? riskDecisionExpiresAt : documentExpiresAt
+
+export const expiredPaperPlanTerminalReason = (
+  observedAt: string,
+  submitExpiresAt: string,
+  submissionCutoffAt: string,
+): CycleTerminalReason.MissedSubmission | CycleTerminalReason.Risk | undefined =>
+  observedAt < submitExpiresAt
+    ? undefined
+    : observedAt >= submissionCutoffAt
+      ? CycleTerminalReason.MissedSubmission
+      : CycleTerminalReason.Risk
+
+const boundPaperSubmissionCutoff = (
+  cycle: AutonomousCycle,
+  document: PaperDecisionDocument,
+): Result.Result<string, CycleRunnerError> => {
+  if (
+    document.submissionCutoffAt !== cycle.window.submissionCutoffAt ||
+    document.expiresAt !== cycle.window.submissionCutoffAt
+  ) {
+    return Result.fail(
+      mutationRunnerError(
+        'durable PAPER decision changed from its immutable cycle submission window',
+        undefined,
+        'contract',
+      ),
+    )
+  }
+  return Result.succeed(cycle.window.submissionCutoffAt)
+}
+
+const immutableIntentBindingMatches = (stored: Intent, expected: Intent): boolean =>
+  stored.schemaVersion === expected.schemaVersion &&
+  stored.intentId === expected.intentId &&
+  stored.authorityGenerationHash === expected.authorityGenerationHash &&
+  stored.strategyName === expected.strategyName &&
+  stored.cycleId === expected.cycleId &&
+  stored.decisionHash === expected.decisionHash &&
+  stored.policyHash === expected.policyHash &&
+  stored.accountId === expected.accountId &&
+  stored.clientOrderId === expected.clientOrderId &&
+  stored.symbol === expected.symbol &&
+  stored.side === expected.side &&
+  stored.orderType === expected.orderType &&
+  stored.timeInForce === expected.timeInForce &&
+  stored.quantityMicros === expected.quantityMicros &&
+  stored.notionalLimitMicros === expected.notionalLimitMicros &&
+  stored.createdAt === expected.createdAt
+
+const validateCurrentMutationExecutionTerms = (
+  preparation: ObserveStartupPreparation,
+  targetIntent: PaperDecisionDocument['targetPlan']['intentTargets'][number],
+  target: PlannedTargetQuantity,
+  riskBinding: PaperDecisionDocument['deltaRisk'][number],
+): Result.Result<void, CycleRunnerError> => {
+  const fillTerms = makeFillTerms(
+    targetIntent.side === OrderSide.Buy ? 'buy' : 'sell',
+    BigInt(targetIntent.quantityMicros),
+    BigInt(target.referencePriceMicros),
+    preparation.executionModel,
+    MICROS,
+  )
+  if (Result.isFailure(fillTerms)) {
+    return Result.fail(mutationRunnerError('mutation execution terms are invalid', fillTerms.failure, 'contract'))
+  }
+  return fillTerms.success.notionalMicros.toString() === riskBinding.notionalLimitMicros
+    ? Result.succeed(undefined)
+    : Result.fail(
+        mutationRunnerError(
+          'durable mutation notional changed from the current execution model',
+          undefined,
+          'contract',
+        ),
+      )
+}
+
+export const prepareNextMutationIntent = (
+  input: ObserveAutonomousCycleInput,
   preparation: ObserveStartupPreparation,
   policy: Policy,
   cycle: AutonomousCycle,
-  document: ObserveShadowDecisionDocument,
+  document: PaperDecisionDocument,
   reconcile: Effect.Effect<ReconciliationPassResult, ReconciliationPassError, ObserveDecisionRuntime>,
-): Effect.Effect<string | undefined, CycleRunnerError, ObserveDecisionRuntime | IntentStore | MutationStore> =>
+  allowSubmit = true,
+): Effect.Effect<PreparedMutationCycleStep, CycleRunnerError, ObserveDecisionRuntime | IntentStore | MutationStore> =>
   Effect.gen(function* () {
-    yield* Effect.fromResult(validateBoundMutationDocument(input, cycle, policy, document))
-    if (document.targetPlan.status !== TargetPlanStatus.Planned) return undefined
+    yield* Effect.fromResult(validateBoundMutationDocument(input, cycle, document))
+    const submissionCutoffAt = yield* Effect.fromResult(boundPaperSubmissionCutoff(cycle, document))
+    const generationIsSuperseded = input.authorityGenerationHash !== document.bindings.authorityGenerationHash
+    if (document.riskBlock !== undefined) {
+      return {
+        _tag: 'Block',
+        reason: CycleTerminalReason.Risk,
+        observedAt: yield* currentUtcInstant,
+      }
+    }
+    if (document.targetPlan.status !== TargetPlanStatus.Planned) return { _tag: 'RunCycle' }
+
+    const intentStore = yield* IntentStore
+    const mutationStore = yield* MutationStore
+    const targets = new Map(document.targetPlan.targets.map((target) => [target.symbol, target]))
+    const documentAuthority: AuthorityState = {
+      schemaVersion: 'bayn.paper-authority.v1',
+      generationHash: document.bindings.authorityGenerationHash,
+      maximum: Authority.Paper,
+      effective: Authority.Paper,
+      kill: KillState.Clear,
+      version: 1,
+      updatedAt: document.createdAt,
+    }
+    const recoveryLookups: PaperIntentRecoveryLookup[] = []
+
+    for (const [index, targetIntent] of document.targetPlan.intentTargets.entries()) {
+      const riskBinding = document.deltaRisk[index]
+      const target = targets.get(targetIntent.symbol)
+      const intentId = document.orderedIntentIds[index]
+      if (riskBinding === undefined || target === undefined || intentId === undefined) {
+        return yield* Effect.fail(
+          mutationRunnerError(
+            'durable mutation target is missing its intent, risk, or final-position binding',
+            undefined,
+            'contract',
+          ),
+        )
+      }
+      const stored = yield* intentStore
+        .read(intentId)
+        .pipe(
+          Effect.mapError((cause) => mutationRunnerError('durable PAPER intent recovery read failed', cause, 'store')),
+        )
+      const existing = Option.getOrUndefined(stored)
+      const latestSubmit = yield* mutationStore
+        .latest(intentId, MutationOperation.Submit)
+        .pipe(Effect.mapError((cause) => mutationRunnerError('durable submit state read failed', cause, 'store')))
+      const latestCancel = yield* mutationStore
+        .latest(intentId, MutationOperation.Cancel)
+        .pipe(Effect.mapError((cause) => mutationRunnerError('durable cancel state read failed', cause, 'store')))
+      if (existing === undefined && (latestSubmit !== undefined || latestCancel !== undefined)) {
+        return yield* Effect.fail(
+          mutationRunnerError(
+            'durable mutation exists without its authority-bound intent',
+            { latestSubmit, latestCancel },
+            'contract',
+          ),
+        )
+      }
+      if (existing !== undefined && existing.intent.intentId !== intentId) {
+        return yield* Effect.fail(
+          mutationRunnerError(
+            'durable PAPER intent recovery returned a different intent identity',
+            undefined,
+            'contract',
+          ),
+        )
+      }
+      recoveryLookups.push({
+        intentId,
+        targetIntent,
+        target,
+        riskBinding,
+        stored: existing,
+        latestSubmit,
+        latestCancel,
+      })
+    }
+
+    const preparedIntents: PreparedPaperIntent[] = []
+    for (const lookup of recoveryLookups) {
+      const intent = yield* planPaperIntent(
+        {
+          schemaVersion: 'bayn.paper-intent-plan.v1',
+          ...lookup.targetIntent,
+          notionalLimitMicros: lookup.riskBinding.notionalLimitMicros,
+          createdAt: document.createdAt,
+        },
+        { authority: documentAuthority },
+      ).pipe(
+        Effect.mapError((cause) =>
+          mutationRunnerError('durable PAPER intent reconstruction failed', cause, 'contract'),
+        ),
+      )
+      if (lookup.intentId !== intent.intentId) {
+        return yield* Effect.fail(
+          mutationRunnerError(
+            'durable PAPER intent identity or order changed after decision binding',
+            undefined,
+            'contract',
+          ),
+        )
+      }
+      if (lookup.stored !== undefined && !immutableIntentBindingMatches(lookup.stored.intent, intent)) {
+        return yield* Effect.fail(
+          mutationRunnerError('stored PAPER intent changed from its durable decision binding', undefined, 'contract'),
+        )
+      }
+      preparedIntents.push({ ...lookup, intent })
+    }
+
+    const recoveryObservedAt = yield* currentUtcInstant
+    for (const prepared of preparedIntents) {
+      const existing = prepared.stored
+      if (existing === undefined) continue
+      const recovery = yield* Effect.fromResult(
+        decidePreparedMutationRecovery(existing.intent, prepared.latestSubmit, prepared.latestCancel),
+      ).pipe(Effect.mapError((cause) => mutationRunnerError(cause.message, cause, 'contract')))
+      if (recovery._tag === 'Recover') {
+        return mutationRecoveryIsDue(recovery.event, recoveryObservedAt)
+          ? {
+              _tag: 'Execute',
+              action:
+                recovery.operation === MutationOperation.Submit
+                  ? ('RECOVER_SUBMIT' as const)
+                  : ('RECOVER_CANCEL' as const),
+              intentId: prepared.intent.intentId,
+              observedAt: recoveryObservedAt,
+            }
+          : { _tag: 'Wait', observedAt: recoveryObservedAt }
+      }
+    }
+
+    if (generationIsSuperseded) {
+      return {
+        _tag: 'Block',
+        reason: CycleTerminalReason.ProvenanceMismatch,
+        observedAt: recoveryObservedAt,
+      }
+    }
+
+    yield* Effect.fromResult(validateCurrentMutationPolicy(policy, document))
+
+    const uncommittedIntents = preparedIntents.filter((prepared) => prepared.stored === undefined)
+    if (!allowSubmit && uncommittedIntents.length > 0) {
+      return { _tag: 'Wait', observedAt: recoveryObservedAt }
+    }
+    if (allowSubmit) {
+      for (const prepared of preparedIntents) {
+        const requiresFreshSubmission =
+          prepared.stored === undefined ||
+          (prepared.stored.intent.state !== IntentState.Terminal && prepared.latestSubmit === undefined)
+        if (!requiresFreshSubmission) continue
+        yield* Effect.fromResult(
+          validateCurrentMutationExecutionTerms(
+            preparation,
+            prepared.targetIntent,
+            prepared.target,
+            prepared.riskBinding,
+          ),
+        )
+      }
+    }
+    if (uncommittedIntents.length > 0) {
+      const commitObservedAt = yield* currentUtcInstant
+      const commitExpiresAt = uncommittedIntents.reduce(
+        (expiresAt, prepared) => paperSubmitExpiresAt(expiresAt, prepared.riskBinding.evaluation.decision.expiresAt),
+        document.expiresAt,
+      )
+      const expirationReason = expiredPaperPlanTerminalReason(commitObservedAt, commitExpiresAt, submissionCutoffAt)
+      if (expirationReason !== undefined) {
+        return {
+          _tag: 'Block',
+          reason: expirationReason,
+          observedAt: commitObservedAt,
+        }
+      }
+      if (
+        preparedIntents.some((prepared) => prepared.latestSubmit !== undefined || prepared.latestCancel !== undefined)
+      ) {
+        return yield* Effect.fail(
+          mutationRunnerError(
+            'broker mutation evidence exists before the complete immutable intent set was committed',
+            undefined,
+            'contract',
+          ),
+        )
+      }
+    }
+
+    yield* Effect.forEach(
+      preparedIntents,
+      (prepared) =>
+        intentStore
+          .commit(prepared.intent, prepared.riskBinding.evaluation.decision)
+          .pipe(
+            Effect.mapError((cause) => mutationRunnerError('durable PAPER intent-set commit failed', cause, 'store')),
+          ),
+      { concurrency: 1, discard: true },
+    )
 
     const decisionInput = mutationDecisionInput(input, preparation, policy, cycle, reconcile)
     const reads = yield* Effect.fromResult(prepareObserveDecisionReads(decisionInput)).pipe(
@@ -984,11 +1515,8 @@ const prepareNextMutationIntent = (
       }),
     )
     const authority = yield* Effect.fromResult(
-      requireDecisionAuthority(facts.reconciliation, policy, input.authorityGenerationHash, Authority.Paper),
+      requireMutationAuthorityGeneration(facts.reconciliation, policy, input.authorityGenerationHash),
     ).pipe(Effect.mapError((cause) => mutationRunnerError(cause.message, cause, 'contract')))
-    const executionSession = yield* Effect.fromResult(prepareExecutionSessionBinding(decisionInput, facts)).pipe(
-      Effect.mapError((cause) => mutationRunnerError(cause.message, cause, 'contract')),
-    )
     if (
       document.bindings.snapshotContentHash !== facts.snapshot.manifest.finalizedSnapshot.contentHash ||
       document.bindings.snapshotFinalizedAt !== facts.snapshot.manifest.finalizedSnapshot.finalizedAt
@@ -998,141 +1526,115 @@ const prepareNextMutationIntent = (
       )
     }
 
-    const intentStore = yield* IntentStore
-    const mutationStore = yield* MutationStore
-    const targets = new Map(document.targetPlan.targets.map((target) => [target.symbol, target]))
-    let reservedBuyingPower = 0n
-    let dailyTradedNotional = BigInt(facts.reconciliation.riskContext.dailyTradedNotionalMicros)
-    let projectedPositions: readonly Position[] = facts.reconciliation.brokerState.positions
-    let projectedOrders: readonly Order[] = facts.reconciliation.brokerState.orders
-
-    for (const [index, targetIntent] of document.targetPlan.intentTargets.entries()) {
-      const riskBinding = document.deltaRisk[index]
-      const target = targets.get(targetIntent.symbol)
-      if (riskBinding === undefined || target === undefined) {
-        return yield* Effect.fail(
-          mutationRunnerError(
-            'durable mutation target is missing its risk or final-position binding',
-            undefined,
-            'contract',
-          ),
-        )
-      }
-      const fillTerms = yield* Effect.fromResult(
-        makeFillTerms(
-          targetIntent.side === OrderSide.Buy ? 'buy' : 'sell',
-          BigInt(targetIntent.quantityMicros),
-          BigInt(target.referencePriceMicros),
-          preparation.executionModel,
-          MICROS,
-        ),
-      ).pipe(Effect.mapError((cause) => mutationRunnerError('mutation execution terms are invalid', cause, 'contract')))
-      if (fillTerms.notionalMicros.toString() !== riskBinding.notionalLimitMicros) {
-        return yield* Effect.fail(
-          mutationRunnerError(
-            'durable mutation notional changed from its bound execution model',
-            undefined,
-            'contract',
-          ),
-        )
-      }
-      const state = (): State => ({
-        schemaVersion: 'bayn.paper-risk-state.v2',
-        brokerMode: BrokerMode.Paper,
-        account: facts.reconciliation.brokerState.account,
-        positions: facts.reconciliation.brokerState.positions,
-        positionsObservedAt: facts.reconciliation.brokerState.positionsObservedAt,
-        orders: projectedOrders,
-        ordersObservedAt: facts.reconciliation.brokerState.ordersObservedAt,
-        reconciliation: facts.reconciliation.brokerState.reconciliation,
-        authority: authority.authority,
-        authorityObservedAt: authority.observedAt,
-        unknownMutationCount: facts.reconciliation.riskContext.unknownMutationCount,
-        dailyTradedNotionalMicros: dailyTradedNotional.toString(),
-        dayStartEquityMicros: facts.reconciliation.riskContext.dayStartEquityMicros,
-        peakEquityMicros: facts.reconciliation.riskContext.peakEquityMicros,
-        accountingHash: facts.reconciliation.brokerState.accountingHash,
-        marketDataSymbol: targetIntent.symbol,
-        marketDataHash: document.bindings.snapshotContentHash,
-        referencePriceMicros: target.referencePriceMicros,
-        expectedExecutionPriceMicros: fillTerms.fillPriceMicros.toString(),
-        marketDataObservedAt: facts.evaluatedAt,
-        executionSession,
-        reservedBuyingPowerMicros: reservedBuyingPower.toString(),
-        evaluatedAt: facts.evaluatedAt,
-      })
-      const intent = yield* planPaperIntent(
-        {
-          schemaVersion: 'bayn.paper-intent-plan.v1',
-          ...targetIntent,
-          notionalLimitMicros: riskBinding.notionalLimitMicros,
-          createdAt: document.createdAt,
-        },
-        state(),
-      ).pipe(Effect.mapError((cause) => mutationRunnerError('durable PAPER intent planning failed', cause, 'contract')))
+    const terminalEvidence: PaperCycleIntentTerminalEvidence[] = []
+    for (const prepared of preparedIntents) {
       const stored = yield* intentStore
-        .read(intent.intentId)
-        .pipe(
-          Effect.mapError((cause) => mutationRunnerError('durable PAPER intent recovery read failed', cause, 'store')),
+        .read(prepared.intent.intentId)
+        .pipe(Effect.mapError((cause) => mutationRunnerError('committed PAPER intent readback failed', cause, 'store')))
+      const record = Option.getOrUndefined(stored)
+      if (record === undefined) {
+        return yield* Effect.fail(
+          mutationRunnerError('committed PAPER intent disappeared before execution selection', undefined, 'contract'),
         )
-      const existing = Option.getOrUndefined(stored)
+      }
       const latest = yield* mutationStore
-        .latest(intent.intentId, MutationOperation.Submit)
-        .pipe(Effect.mapError((cause) => mutationRunnerError('durable submit state read failed', cause, 'store')))
-      const prepared = yield* Effect.fromResult(decidePreparedMutationIntent(existing?.intent ?? intent, latest)).pipe(
+        .latest(prepared.intent.intentId, MutationOperation.Submit)
+        .pipe(Effect.mapError((cause) => mutationRunnerError('durable submit state refresh failed', cause, 'store')))
+      const decision = yield* Effect.fromResult(decidePreparedMutationIntent(record.intent, latest)).pipe(
         Effect.mapError((cause) => mutationRunnerError(cause.message, cause, 'contract')),
       )
-      if (prepared._tag === 'SkipTerminal') continue
-      if (prepared._tag === 'Pending') {
-        projectedOrders = appendPendingMutationOrder(projectedOrders, prepared.order)
-        const orderNotional = fillTerms.notionalMicros
-        reservedBuyingPower += targetIntent.side === OrderSide.Buy ? orderNotional : 0n
-        dailyTradedNotional += orderNotional
-        projectedPositions = projectWorstCasePendingMutationPosition(
-          projectedPositions,
-          target,
-          input.accountId,
-          facts.reconciliation.brokerState.positionsObservedAt,
-        )
-        continue
-      }
-      const decision =
-        existing?.decision === undefined
-          ? yield* Effect.fromResult(evaluate(intent, state(), policy, projectedPositions)).pipe(
-              Effect.mapError((cause) => mutationRunnerError('PAPER intent risk evaluation failed', cause, 'contract')),
-              Effect.flatMap((evaluation) =>
-                evaluation.decision.outcome === RiskOutcome.Approved
-                  ? Effect.succeed(evaluation.decision)
-                  : Effect.fail(
-                      mutationRunnerError(
-                        `PAPER intent risk blocked execution: ${evaluation.decision.reasonCodes.join(',')}`,
-                        evaluation,
-                        'operational',
-                      ),
-                    ),
-              ),
+      switch (decision._tag) {
+        case 'SkipTerminal':
+          terminalEvidence.push({
+            state: record.intent.state,
+            terminalOutcome: record.intent.terminalOutcome,
+            updatedAt: record.updatedAt,
+            ...(latest === undefined ? {} : { latestMutationAt: latest.occurredAt }),
+          })
+          if (record.intent.terminalOutcome !== TerminalOutcome.Filled) {
+            yield* restrictMutationAuthority(
+              `bound PAPER cycle ${cycle.identity.cycleId}`,
+              `intent ${prepared.intent.intentId} ended ${record.intent.terminalOutcome ?? 'without outcome'}`,
             )
-          : existing.decision
-      if (decision.outcome !== RiskOutcome.Approved) {
-        return yield* Effect.fail(
-          mutationRunnerError('recovered PAPER intent has a non-approved risk decision', decision, 'contract'),
-        )
+            return {
+              _tag: 'Block',
+              reason: CycleTerminalReason.Risk,
+              observedAt: facts.evaluatedAt,
+            }
+          }
+          break
+        case 'Pending':
+          return latest !== undefined && mutationRecoveryIsDue(latest, facts.evaluatedAt)
+            ? {
+                _tag: 'Execute',
+                action: 'RECOVER_SUBMIT',
+                intentId: prepared.intent.intentId,
+                observedAt: facts.evaluatedAt,
+              }
+            : { _tag: 'Wait', observedAt: facts.evaluatedAt }
+        case 'Recover':
+          return latest !== undefined && mutationRecoveryIsDue(latest, facts.evaluatedAt)
+            ? {
+                _tag: 'Execute',
+                action: 'RECOVER_SUBMIT',
+                intentId: prepared.intent.intentId,
+                observedAt: facts.evaluatedAt,
+              }
+            : { _tag: 'Wait', observedAt: facts.evaluatedAt }
+        case 'Submit':
+          if (!allowSubmit) return { _tag: 'Wait', observedAt: facts.evaluatedAt }
+          const submitExpiresAt = paperSubmitExpiresAt(
+            submissionCutoffAt,
+            prepared.riskBinding.evaluation.decision.expiresAt,
+          )
+          const expirationReason = expiredPaperPlanTerminalReason(
+            facts.evaluatedAt,
+            submitExpiresAt,
+            submissionCutoffAt,
+          )
+          if (expirationReason !== undefined) {
+            return {
+              _tag: 'Block',
+              reason: expirationReason,
+              observedAt: facts.evaluatedAt,
+            }
+          }
+          yield* Effect.fromResult(
+            decidePreparedMutationIntentAdmission(
+              decision,
+              authority.authority.effective,
+              facts.evaluatedAt,
+              submitExpiresAt,
+              facts.reconciliation.riskContext.unknownMutationCount,
+              facts.reconciliation.brokerState.reconciliation.status,
+              facts.reconciliation.report.metrics.accountingExact,
+              facts.reconciliation.brokerState.unknownOrderCount,
+            ),
+          ).pipe(Effect.mapError((cause) => mutationRunnerError(cause.message, cause, 'contract')))
+          return {
+            _tag: 'Execute',
+            action: 'SUBMIT',
+            intentId: prepared.intent.intentId,
+            observedAt: facts.evaluatedAt,
+            submitExpiresAt,
+          }
       }
-      yield* intentStore
-        .commit(intent, decision)
-        .pipe(Effect.mapError((cause) => mutationRunnerError('durable PAPER intent commit failed', cause, 'store')))
-      return intent.intentId
     }
-    return undefined
+
+    const completion = decidePaperCycleCompletion(document.createdAt, terminalEvidence, {
+      status: facts.reconciliation.brokerState.reconciliation.status,
+      reconciledAt: facts.reconciliation.brokerState.reconciliation.reconciledAt,
+      accountingExact: facts.reconciliation.report.metrics.accountingExact,
+      unknownMutationCount: facts.reconciliation.riskContext.unknownMutationCount,
+      unknownOrderCount: facts.reconciliation.brokerState.unknownOrderCount,
+    })
+    return completion._tag === 'Complete'
+      ? { _tag: 'Complete', observedAt: facts.evaluatedAt }
+      : { _tag: 'Wait', observedAt: facts.evaluatedAt }
   })
 
-const submitSucceeded = (eventType: MutationEventType): boolean =>
-  eventType === MutationEventType.SubmitAccepted || eventType === MutationEventType.RecoveryFound
-
-const submitTerminal = (eventType: MutationEventType): boolean =>
-  submitSucceeded(eventType) ||
-  eventType === MutationEventType.SubmitRejected ||
-  eventType === MutationEventType.SubmitDenied
+const submitDoesNotRequireRecovery = (eventType: MutationEventType): boolean =>
+  eventType === MutationEventType.SubmitRejected || eventType === MutationEventType.SubmitDenied
 
 export type MutationIntentSettlementDecision =
   | {
@@ -1161,65 +1663,171 @@ export const decideMutationIntentSettlement = (eventType: MutationEventType): Mu
 export interface MutationIntentExecutionResult {
   readonly settlement: Extract<MutationIntentSettlementDecision, { readonly _tag: 'Settled' }>
   readonly consistencyDelayMs: number
+  readonly operation: MutationOperation
 }
 
 export const mutationIntentReconciliationDelayMs = (result: MutationIntentExecutionResult): number =>
   result.settlement.outcome === 'accepted' ? result.consistencyDelayMs : 0
 
+const restrictMutationAuthority = (
+  subject: string,
+  reason: string,
+): Effect.Effect<void, CycleRunnerError, AuthorityRestrictionStore | WriterFence> =>
+  Effect.gen(function* () {
+    const store = yield* AuthorityRestrictionStore
+    const fence = yield* WriterFence
+    const updatedAt = yield* currentUtcInstant
+    yield* fence
+      .transaction(store.restrictAuthority(`${subject} restricted effective authority: ${reason}`, updatedAt))
+      .pipe(
+        Effect.mapError((cause) =>
+          mutationRunnerError(
+            'authority restriction failed after a bound PAPER cycle failure',
+            { subject, reason, cause },
+            'store',
+          ),
+        ),
+      )
+  })
+
+const restrictMutationLoopFailure = (
+  error: CycleRunnerError,
+): Effect.Effect<void, CycleRunnerError, AuthorityRestrictionStore | WriterFence> =>
+  restrictMutationAuthority('PAPER autonomous cycle loop', `${error.operation}: ${error.message}`)
+
+const executeMutationIntentWithExecutor = <E, R>(
+  executor: PaperMutationExecutor<E, R>,
+  intentId: string,
+  action: 'RECOVER_SUBMIT' | 'RECOVER_CANCEL' | 'SUBMIT',
+  submitExpiresAt?: string,
+): Effect.Effect<MutationIntentExecutionResult, CycleRunnerError, MutationStore | R> =>
+  Effect.gen(function* () {
+    const store = yield* MutationStore
+    const operation = action === 'RECOVER_CANCEL' ? MutationOperation.Cancel : MutationOperation.Submit
+    const existing = yield* store
+      .latest(intentId, operation)
+      .pipe(
+        Effect.mapError((cause) =>
+          mutationRunnerError(`durable ${operation.toLowerCase()} recovery read failed`, cause, 'store'),
+        ),
+      )
+    let event: MutationEvent
+    if (existing === undefined) {
+      if (action !== 'SUBMIT') {
+        return yield* Effect.fail(
+          mutationRunnerError(
+            `lookup-only PAPER recovery lost its durable ${operation.toLowerCase()} evidence`,
+            { intentId, action, operation },
+            'contract',
+          ),
+        )
+      }
+      if (submitExpiresAt === undefined) {
+        return yield* Effect.fail(
+          mutationRunnerError('fresh PAPER submit is missing its immutable submission cutoff', undefined, 'contract'),
+        )
+      }
+      const submitObservedAt = yield* currentUtcInstant
+      if (submitObservedAt >= submitExpiresAt) {
+        return yield* Effect.fail(
+          mutationRunnerError(
+            'fresh PAPER submit crossed its immutable submission cutoff before broker I/O',
+            { intentId, submitObservedAt, submitExpiresAt },
+            'contract',
+          ),
+        )
+      }
+      if (executor.submit === undefined) {
+        return yield* Effect.fail(
+          mutationRunnerError(
+            'fresh PAPER submit is unavailable under OBSERVE recovery-only authority',
+            undefined,
+            'contract',
+          ),
+        )
+      }
+      event = yield* executor
+        .submit(intentId, mutationConsistencyDelayMs)
+        .pipe(Effect.mapError((cause) => mutationRunnerError('guarded PAPER submit failed', cause)))
+    } else if (operation === MutationOperation.Submit && submitDoesNotRequireRecovery(existing.eventType)) {
+      event = existing
+    } else {
+      event = yield* executor
+        .recover(intentId, operation)
+        .pipe(
+          Effect.mapError((cause) =>
+            mutationRunnerError(`lookup-only PAPER ${operation.toLowerCase()} recovery failed`, cause),
+          ),
+        )
+    }
+    const settlement = decideMutationIntentSettlement(event.eventType)
+    if (settlement._tag === 'Unresolved') {
+      return yield* Effect.fail(
+        mutationRunnerError(`guarded PAPER submit remains unresolved at ${settlement.eventType}`, event, 'operational'),
+      )
+    }
+    return { settlement, consistencyDelayMs: event.consistencyDelayMs, operation }
+  })
+
 export const executeMutationIntent = (
   executionProgram: ExecutionProgram,
   intentId: string,
+  action: 'RECOVER_SUBMIT' | 'RECOVER_CANCEL' | 'SUBMIT',
+  submitExpiresAt?: string,
 ): Effect.Effect<MutationIntentExecutionResult, CycleRunnerError, MutationStore> =>
-  MutationStore.pipe(
-    Effect.flatMap((store) => store.latest(intentId, MutationOperation.Submit)),
-    Effect.mapError((cause) => mutationRunnerError('durable submit recovery read failed', cause, 'store')),
-    Effect.flatMap((existing) =>
-      (existing === undefined
-        ? executionProgram.submit(intentId, mutationConsistencyDelayMs)
-        : submitTerminal(existing.eventType)
-          ? Effect.succeed(existing)
-          : executionProgram.recover(intentId, MutationOperation.Submit)
-      ).pipe(Effect.mapError((cause) => mutationRunnerError('guarded PAPER submit or recovery failed', cause))),
-    ),
-    Effect.flatMap((event) => {
-      const settlement = decideMutationIntentSettlement(event.eventType)
-      return settlement._tag === 'Settled'
-        ? Effect.succeed({ settlement, consistencyDelayMs: event.consistencyDelayMs })
-        : Effect.fail(
-            mutationRunnerError(
-              `guarded PAPER submit remains unresolved at ${settlement.eventType}`,
-              event,
-              'operational',
-            ),
-          )
-    }),
+  executeMutationIntentWithExecutor(
+    {
+      submit: executionProgram.submit,
+      recover: executionProgram.recover,
+    },
+    intentId,
+    action,
+    submitExpiresAt,
   )
 
-const executeBoundMutationCycle = (
-  input: MutationAutonomousCycleInput,
+const executeBoundPaperCycle = (
+  input: ObserveAutonomousCycleInput,
   preparation: ObserveStartupPreparation,
   policy: Policy,
   cycle: AutonomousCycle,
+  document: PaperDecisionDocument,
   reconcile: Effect.Effect<ReconciliationPassResult, ReconciliationPassError, ObserveDecisionRuntime>,
-): Effect.Effect<void, CycleRunnerError, MutationRuntime> =>
-  readBoundMutationDocument(cycle).pipe(
-    Effect.flatMap((document) =>
-      Effect.gen(function* () {
-        const maximumPasses =
-          document.targetPlan.status === TargetPlanStatus.Planned ? document.targetPlan.intentTargets.length + 1 : 1
-        for (let pass = 0; pass < maximumPasses; pass += 1) {
-          const intentId = yield* prepareNextMutationIntent(input, preparation, policy, cycle, document, reconcile)
-          if (intentId === undefined) return
-          const executed = yield* executeMutationIntent(input.executionProgram, intentId)
-          const delayMs = mutationIntentReconciliationDelayMs(executed)
-          if (delayMs > 0) yield* Effect.sleep(Duration.millis(delayMs))
-        }
-        return yield* Effect.fail(
-          mutationRunnerError('mutation cycle did not converge after one fresh pass per target', undefined, 'contract'),
+  capability: PaperExecutionCapability,
+): Effect.Effect<BoundMutationCycleOutcome, CycleRunnerError, RecoveryFirstRuntime> =>
+  Effect.gen(function* () {
+    const step = yield* prepareNextMutationIntent(
+      input,
+      preparation,
+      policy,
+      cycle,
+      document,
+      reconcile,
+      capability._tag === 'Mutation',
+    )
+    if (step._tag !== 'Execute') return step
+    const executed = yield* capability._tag === 'Mutation'
+      ? executeMutationIntent(
+          capability.executionProgram,
+          step.intentId,
+          step.action,
+          step.action === 'SUBMIT' ? step.submitExpiresAt : undefined,
         )
-      }),
-    ),
-  )
+      : executeMutationIntentWithExecutor(
+          { recover: recoverMutation },
+          step.intentId,
+          step.action,
+          step.action === 'SUBMIT' ? step.submitExpiresAt : undefined,
+        )
+    if (executed.operation === MutationOperation.Submit && executed.settlement.outcome !== 'accepted') {
+      yield* restrictMutationAuthority(
+        `bound PAPER cycle ${cycle.identity.cycleId}`,
+        `intent ${step.intentId} submit settled ${executed.settlement.outcome}`,
+      )
+    }
+    const delayMs = mutationIntentReconciliationDelayMs(executed)
+    if (delayMs > 0) yield* Effect.sleep(Duration.millis(delayMs))
+    return { _tag: 'Wait' as const, observedAt: step.observedAt }
+  })
 
 const readUnfinishedMutationCycle = (
   context: CycleRunContext<ObserveDecisionRuntime>,
@@ -1238,25 +1846,81 @@ const readUnfinishedMutationCycle = (
 const mutationBound = (cycle: AutonomousCycle | undefined): cycle is AutonomousCycle =>
   cycle !== undefined && cycle.state === CycleState.Active && cycle.bindings.decisionHash !== undefined
 
-const runMutationCyclePass = (
-  input: MutationAutonomousCycleInput,
+const interpretBoundMutationCycleOutcome = (
+  outcome: BoundMutationCycleOutcome,
+  cycle: AutonomousCycle,
+  context: CycleRunContext<ObserveDecisionRuntime>,
+): Effect.Effect<CycleRunResult, CycleRunnerError, CycleStore | ObserveDecisionRuntime> => {
+  switch (outcome._tag) {
+    case 'RunCycle':
+      return runAutonomousCyclePass(context)
+    case 'Wait':
+      return Effect.succeed({
+        outcome: 'RECOVERED',
+        action: 'WAITING',
+        observedAt: outcome.observedAt,
+        cycle,
+      })
+    case 'Block':
+      return CycleStore.pipe(
+        Effect.flatMap((store) => store.block(cycle.identity.cycleId, outcome.reason, outcome.observedAt)),
+        Effect.mapError((cause) => mutationRunnerError('expired PAPER cycle finalization failed', cause, 'store')),
+        Effect.map((receipt) => ({
+          outcome: 'RECOVERED' as const,
+          action: 'BLOCKED' as const,
+          observedAt: outcome.observedAt,
+          cycle: receipt.cycle,
+        })),
+      )
+    case 'Complete':
+      return CycleStore.pipe(
+        Effect.flatMap((store) => store.finish(cycle.identity.cycleId, CycleState.Completed, outcome.observedAt)),
+        Effect.mapError((cause) => mutationRunnerError('completed PAPER cycle finalization failed', cause, 'store')),
+        Effect.map((receipt) => ({
+          outcome: 'RECOVERED' as const,
+          action: 'COMPLETED' as const,
+          observedAt: outcome.observedAt,
+          cycle: receipt.cycle,
+        })),
+      )
+  }
+}
+
+const recoverBoundMutationCycle = (
+  input: ObserveAutonomousCycleInput,
+  preparation: ObserveStartupPreparation,
+  policy: Policy,
+  cycle: AutonomousCycle,
+  context: CycleRunContext<ObserveDecisionRuntime>,
+  reconcile: Effect.Effect<ReconciliationPassResult, ReconciliationPassError, ObserveDecisionRuntime>,
+  capability: PaperExecutionCapability,
+): Effect.Effect<CycleRunResult, CycleRunnerError, RecoveryFirstRuntime> =>
+  readBoundMutationDocument(cycle).pipe(
+    Effect.flatMap((document) =>
+      document.mode === 'OBSERVE'
+        ? runAutonomousCyclePass(context)
+        : executeBoundPaperCycle(input, preparation, policy, cycle, document, reconcile, capability).pipe(
+            Effect.flatMap((outcome) => interpretBoundMutationCycleOutcome(outcome, cycle, context)),
+          ),
+    ),
+  )
+
+const runRecoveryFirstCyclePass = (
+  input: ObserveAutonomousCycleInput,
   preparation: ObserveStartupPreparation,
   policy: Policy,
   context: CycleRunContext<ObserveDecisionRuntime>,
   reconcile: Effect.Effect<ReconciliationPassResult, ReconciliationPassError, ObserveDecisionRuntime>,
-): Effect.Effect<CycleRunResult, CycleRunnerError, MutationRuntime> =>
+  capability: PaperExecutionCapability,
+): Effect.Effect<CycleRunResult, CycleRunnerError, RecoveryFirstRuntime> =>
   readUnfinishedMutationCycle(context).pipe(
     Effect.flatMap((unfinished) =>
       mutationBound(unfinished)
-        ? executeBoundMutationCycle(input, preparation, policy, unfinished, reconcile).pipe(
-            Effect.andThen(runAutonomousCyclePass(context)),
-          )
+        ? recoverBoundMutationCycle(input, preparation, policy, unfinished, context, reconcile, capability)
         : runAutonomousCyclePass(context).pipe(
             Effect.flatMap((result) =>
               result.outcome === 'RECOVERED' && result.action === 'BOUND_DECISION'
-                ? executeBoundMutationCycle(input, preparation, policy, result.cycle, reconcile).pipe(
-                    Effect.andThen(runAutonomousCyclePass(context)),
-                  )
+                ? recoverBoundMutationCycle(input, preparation, policy, result.cycle, context, reconcile, capability)
                 : Effect.succeed(result),
             ),
           ),
@@ -1321,7 +1985,7 @@ const attemptMutationIdleReconciliation = (
   )
 
 const reconcileMutationNotDuePass = (
-  input: MutationAutonomousCycleInput,
+  input: ObserveAutonomousCycleInput,
   cadence: Ref.Ref<ReconciliationCadenceState>,
   reconcile: Effect.Effect<ReconciliationPassResult, ReconciliationPassError, ObserveDecisionRuntime>,
   result: CycleRunResult,
@@ -1341,7 +2005,7 @@ const reconcileMutationNotDuePass = (
 }
 
 const observeMutationIdleReconciliation = (
-  input: MutationAutonomousCycleInput,
+  input: ObserveAutonomousCycleInput,
   startup: Parameters<AutonomousCycleStartup>[0],
   cadence: Ref.Ref<ReconciliationCadenceState>,
   reconcile: Effect.Effect<ReconciliationPassResult, ReconciliationPassError, ObserveDecisionRuntime>,
@@ -1390,7 +2054,7 @@ const observeMutationCadenceReconciliation = (
   )
 
 const waitUntilNextMutationPoll = (
-  input: MutationAutonomousCycleInput,
+  input: ObserveAutonomousCycleInput,
   startup: Parameters<AutonomousCycleStartup>[0],
   cadence: Ref.Ref<ReconciliationCadenceState>,
   reconcile: Effect.Effect<ReconciliationPassResult, ReconciliationPassError, ObserveDecisionRuntime>,
@@ -1429,7 +2093,7 @@ const waitUntilNextMutationPoll = (
   )
 
 const waitAfterMutationPass = (
-  input: MutationAutonomousCycleInput,
+  input: ObserveAutonomousCycleInput,
   startup: Parameters<AutonomousCycleStartup>[0],
   cadence: Ref.Ref<ReconciliationCadenceState>,
   reconcile: Effect.Effect<ReconciliationPassResult, ReconciliationPassError, ObserveDecisionRuntime>,
@@ -1443,7 +2107,7 @@ const waitAfterMutationPass = (
   )
 
 const waitAfterMutationFailure = (
-  input: MutationAutonomousCycleInput,
+  input: ObserveAutonomousCycleInput,
   startup: Parameters<AutonomousCycleStartup>[0],
   cadence: Ref.Ref<ReconciliationCadenceState>,
   reconcile: Effect.Effect<ReconciliationPassResult, ReconciliationPassError, ObserveDecisionRuntime>,
@@ -1462,7 +2126,7 @@ const waitAfterMutationFailure = (
   )
 
 const observeMutationCycleResult = (
-  input: MutationAutonomousCycleInput,
+  input: ObserveAutonomousCycleInput,
   startup: Parameters<AutonomousCycleStartup>[0],
   cadence: Ref.Ref<ReconciliationCadenceState>,
   reconcile: Effect.Effect<ReconciliationPassResult, ReconciliationPassError, ObserveDecisionRuntime>,
@@ -1482,19 +2146,21 @@ const observeMutationCycleResult = (
         ),
       )
 
-const mutationCycleLoop = (
-  input: MutationAutonomousCycleInput,
+const recoveryFirstCycleLoop = (
+  input: ObserveAutonomousCycleInput,
   startup: Parameters<AutonomousCycleStartup>[0],
   preparation: ObserveStartupPreparation,
   policy: Policy,
-): Effect.Effect<void, never, MutationRuntime> =>
+  capability: PaperExecutionCapability,
+  buildDecision: RecoveryFirstDecisionBuilder,
+): Effect.Effect<void, never, RecoveryFirstRuntime> =>
   Effect.gen(function* () {
     const cadence = yield* Ref.make<ReconciliationCadenceState>({})
     const cyclePassTimeoutMs = Math.min(input.reconciliationPassTimeoutMs, input.reconciliationIntervalMs)
     const reconcile = boundedReconciliationPass(input.reconciliationPassTimeoutMs).pipe(
       Effect.tap(() => markMutationReconciliationCompleted(cadence)),
     )
-    const run = (): Effect.Effect<void, never, MutationRuntime> =>
+    const run = (): Effect.Effect<void, never, RecoveryFirstRuntime> =>
       Effect.suspend(() =>
         Effect.gen(function* () {
           const context: CycleRunContext<ObserveDecisionRuntime> = {
@@ -1502,19 +2168,25 @@ const mutationCycleLoop = (
             strategyProtocolHash: preparation.strategyProtocolHash,
             accountId: input.accountId,
             executionPolicy: preparation.executionPolicy,
-            buildDecision: (cycle) =>
-              buildMutationShadowCycleDecision(
-                mutationDecisionInput(input, preparation, policy, cycle, reconcile),
-              ).pipe(Effect.mapError(decisionBuildError)),
+            buildDecision: (cycle) => buildDecision(cycle, reconcile),
           }
           return yield* runMutationPassWithinTimeout(
-            runMutationCyclePass(input, preparation, policy, context, reconcile),
+            runRecoveryFirstCyclePass(input, preparation, policy, context, reconcile, capability),
             cyclePassTimeoutMs,
           )
         }).pipe(
           Effect.matchEffect({
             onFailure: (error) =>
-              currentUtcInstant.pipe(
+              (capability._tag === 'Mutation' ? restrictMutationLoopFailure(error) : Effect.void).pipe(
+                Effect.catch((restrictionError: CycleRunnerError) =>
+                  currentUtcInstant.pipe(
+                    Effect.flatMap((observedAt) =>
+                      observeMutationPass(startup, { outcome: 'FAILED', observedAt, error: restrictionError }),
+                    ),
+                    Effect.andThen(Effect.die(restrictionError)),
+                  ),
+                ),
+                Effect.andThen(currentUtcInstant),
                 Effect.flatMap((observedAt) => observeMutationPass(startup, { outcome: 'FAILED', observedAt, error })),
                 Effect.andThen(waitAfterMutationFailure(input, startup, cadence, reconcile)),
                 Effect.andThen(run()),
@@ -1530,25 +2202,79 @@ const mutationCycleLoop = (
     yield* run()
   })
 
-const makeMutationAutonomousLoop = (
-  input: MutationAutonomousCycleInput,
+const makeRecoveryFirstAutonomousLoop = (
+  input: ObserveAutonomousCycleInput,
   startup: Parameters<AutonomousCycleStartup>[0],
   preparation: ObserveStartupPreparation,
   policy: Policy,
-): Result.Result<AutonomousCycleLoop<MutationRuntime>, OperationalError> => {
+  capability: PaperExecutionCapability,
+  buildDecision: RecoveryFirstDecisionBuilder,
+  operation: 'autonomous cycle loop' | 'mutation autonomous cycle loop',
+): Result.Result<AutonomousCycleLoop<RecoveryFirstRuntime>, OperationalError> => {
   const cyclePassTimeoutMs = Math.min(input.reconciliationPassTimeoutMs, input.reconciliationIntervalMs)
   return Result.mapError(
     Result.map(validateCycleLoopInterval(input.pollIntervalMs), () => input.reconciliationIntervalMs).pipe(
       Result.flatMap(validateReconciliationInterval),
       Result.flatMap(() => validateCyclePassTimeout(cyclePassTimeoutMs, input.reconciliationIntervalMs)),
-      Result.map(() => mutationCycleLoop(input, startup, preparation, policy)),
+      Result.map(() => recoveryFirstCycleLoop(input, startup, preparation, policy, capability, buildDecision)),
     ),
-    (cause) => operationalError('strategy', 'cycle-loop', 'mutation autonomous cycle loop failed to start', cause),
+    (cause) => operationalError('strategy', 'cycle-loop', `${operation} failed to start`, cause),
   )
 }
 
+const observeDecisionBuilder =
+  (
+    input: ObserveAutonomousCycleInput,
+    preparation: ObserveStartupPreparation,
+    policy: Policy,
+  ): RecoveryFirstDecisionBuilder =>
+  (cycle, reconcile) =>
+    buildObserveCycleDecision({
+      authorityGenerationHash: input.authorityGenerationHash,
+      cycle,
+      executionModel: preparation.executionModel,
+      policy,
+      reconcile,
+      strategy: input.strategy,
+    }).pipe(Effect.mapError(decisionBuildError))
+
+const mutationDecisionBuilder =
+  (
+    input: ObserveAutonomousCycleInput,
+    preparation: ObserveStartupPreparation,
+    policy: Policy,
+  ): RecoveryFirstDecisionBuilder =>
+  (cycle, reconcile) =>
+    buildMutationShadowCycleDecision(mutationDecisionInput(input, preparation, policy, cycle, reconcile)).pipe(
+      Effect.mapError(decisionBuildError),
+    )
+
+export const makeObserveAutonomousCycleStartup =
+  (input: ObserveAutonomousCycleInput): AutonomousCycleStartup<AuthorityGenerationStore, RecoveryFirstRuntime> =>
+  (startup) =>
+    Effect.gen(function* () {
+      const preparation = yield* Effect.fromResult(prepareObserveStartup(input))
+      const policy = yield* loadObserveRiskPolicy(input.accountId, input.strategy.parameters.universe).pipe(
+        Effect.mapError((cause) =>
+          operationalError('strategy', 'risk-policy', 'source-controlled paper risk policy is invalid', cause),
+        ),
+      )
+      yield* initializeObserveAuthority(input)
+      return yield* Effect.fromResult(
+        makeRecoveryFirstAutonomousLoop(
+          input,
+          startup,
+          preparation,
+          policy,
+          { _tag: 'RecoveryOnly' },
+          observeDecisionBuilder(input, preparation, policy),
+          'autonomous cycle loop',
+        ),
+      )
+    })
+
 export const makeMutationAutonomousCycleStartup =
-  (input: MutationAutonomousCycleInput): AutonomousCycleStartup<never, MutationRuntime> =>
+  (input: MutationAutonomousCycleInput): AutonomousCycleStartup<never, RecoveryFirstRuntime> =>
   (startup) =>
     Effect.gen(function* () {
       const preparation = yield* Effect.fromResult(prepareObserveStartup(input))
@@ -1558,5 +2284,15 @@ export const makeMutationAutonomousCycleStartup =
           operationalError('strategy', 'risk-policy', 'source-controlled paper risk policy is invalid', cause),
         ),
       )
-      return yield* Effect.fromResult(makeMutationAutonomousLoop(input, startup, preparation, policy))
+      return yield* Effect.fromResult(
+        makeRecoveryFirstAutonomousLoop(
+          input,
+          startup,
+          preparation,
+          policy,
+          { _tag: 'Mutation', executionProgram: input.executionProgram },
+          mutationDecisionBuilder(input, preparation, policy),
+          'mutation autonomous cycle loop',
+        ),
+      )
     })

--- a/services/bayn/src/shadow-decision-contract.ts
+++ b/services/bayn/src/shadow-decision-contract.ts
@@ -2,7 +2,7 @@ import { Data, Result, Schema } from 'effect'
 
 import { intentIdForPlan } from './execution/intents/domain'
 import { canonicalHashV1Result } from './hash'
-import { PositiveMicrosSchema, RiskOutcome } from './execution/contracts'
+import { OrderSide, PositiveMicrosSchema, RiskOutcome } from './execution/contracts'
 import { EvaluationSchema, Reason } from './risk'
 import { Sha256Schema, StrictNonEmptyStringSchema, UtcInstantSchema, strictParseOptions } from './schemas'
 import { TargetPlanResultSchema, TargetPlanStatus } from './target-planner'
@@ -141,6 +141,175 @@ export const ObserveShadowDecisionDocumentSchema = ObserveShadowDecisionDocument
 )
 export type ObserveShadowDecisionDocument = typeof ObserveShadowDecisionDocumentSchema.Type
 
+const PaperDecisionBindingsSchema = Schema.Struct({
+  ...ShadowDecisionBindingsSchema.fields,
+  qualificationRunId: Sha256Schema,
+  authorityGenerationHash: Sha256Schema,
+})
+
+const PaperRiskBlockSchema = Schema.Struct({
+  intentId: Sha256Schema,
+  decisionId: Sha256Schema,
+  reasonCodes: Schema.Array(StrictNonEmptyStringSchema).check(Schema.isMinLength(1), Schema.isUnique()),
+})
+
+const PaperDecisionMaterialSchema = Schema.Struct({
+  schemaVersion: Schema.Literal('bayn.paper-cycle-decision.v1'),
+  mode: Schema.Literal('PAPER'),
+  dispatchable: Schema.Boolean,
+  bindings: PaperDecisionBindingsSchema,
+  targetPlan: TargetPlanResultSchema,
+  deltaRisk: Schema.Array(DeltaRiskEvaluationSchema),
+  orderedIntentIds: Schema.Array(Sha256Schema),
+  riskBlock: Schema.optionalKey(PaperRiskBlockSchema),
+  createdAt: UtcInstantSchema,
+  submissionCutoffAt: UtcInstantSchema,
+  expiresAt: UtcInstantSchema,
+})
+
+const paperMaterialIssues = (document: typeof PaperDecisionMaterialSchema.Type): readonly Schema.FilterIssue[] => {
+  const issues: Schema.FilterIssue[] = []
+  if (document.expiresAt !== document.submissionCutoffAt) {
+    issues.push({ path: ['expiresAt'], issue: 'must equal the immutable cycle submission cutoff' })
+  }
+  if (document.createdAt >= document.expiresAt) {
+    issues.push({ path: ['createdAt'], issue: 'must precede PAPER authority expiry' })
+  }
+  const targets = document.targetPlan.intentTargets
+  const planned = document.targetPlan.status === TargetPlanStatus.Planned
+  const riskBlocked = document.riskBlock !== undefined
+  const riskCount = document.deltaRisk.length
+  if (
+    document.orderedIntentIds.length !== riskCount ||
+    (planned && !riskBlocked && riskCount !== targets.length) ||
+    (planned && riskBlocked && (riskCount < 1 || riskCount > targets.length)) ||
+    (!planned && riskCount !== 0)
+  ) {
+    issues.push({
+      path: ['orderedIntentIds'],
+      issue: 'must align with the exact executable plan or cumulative risk-block prefix',
+    })
+  }
+  if (
+    (planned && riskBlocked && document.dispatchable) ||
+    (planned && !riskBlocked && !document.dispatchable) ||
+    (!planned && (!document.dispatchable || riskBlocked))
+  ) {
+    issues.push({
+      path: ['dispatchable'],
+      issue: 'must be false only for a planned PAPER decision with exact blocked risk evidence',
+    })
+  }
+  if (new Set(document.orderedIntentIds).size !== document.orderedIntentIds.length) {
+    issues.push({ path: ['orderedIntentIds'], issue: 'must not contain duplicate intent identities' })
+  }
+  for (const [index, target] of targets.entries()) {
+    if (
+      target.strategyName !== document.bindings.strategyName ||
+      target.cycleId !== document.bindings.cycleId ||
+      target.decisionHash !== document.bindings.strategyDecisionHash ||
+      target.policyHash !== document.bindings.policyHash ||
+      target.accountId !== document.bindings.accountId ||
+      target.createdAt !== document.createdAt
+    ) {
+      issues.push({ path: ['targetPlan', 'intentTargets', index], issue: 'must match the PAPER decision bindings' })
+    }
+    const risk = document.deltaRisk[index]
+    if (risk === undefined) continue
+    const plan = {
+      schemaVersion: 'bayn.paper-intent-plan.v1',
+      ...target,
+      notionalLimitMicros: risk.notionalLimitMicros,
+    } as const
+    const identity = canonicalHashV1Result({
+      schemaVersion: 'bayn.paper-intent-identity.v2',
+      authorityGenerationHash: document.bindings.authorityGenerationHash,
+      strategyName: plan.strategyName,
+      cycleId: plan.cycleId,
+      decisionHash: plan.decisionHash,
+      accountId: plan.accountId,
+      symbol: plan.symbol,
+      side: plan.side,
+      orderType: plan.orderType,
+      timeInForce: plan.timeInForce,
+      quantityMicros: plan.quantityMicros,
+      notionalLimitMicros: plan.notionalLimitMicros,
+    })
+    if (Result.isFailure(identity) || document.orderedIntentIds[index] !== identity.success) {
+      issues.push({ path: ['orderedIntentIds', index], issue: 'must bind the exact ordered target content' })
+    }
+    if (risk.evaluation.input.intentId !== document.orderedIntentIds[index]) {
+      issues.push({ path: ['deltaRisk', index], issue: 'must bind the corresponding ordered intent identity' })
+    }
+    const notional = BigInt(risk.notionalLimitMicros)
+    const previousRisk = document.deltaRisk[index - 1]
+    const expectedAggregateBuyingPower =
+      (previousRisk === undefined ? 0n : BigInt(previousRisk.evaluation.metrics.aggregateBuyingPowerMicros)) +
+      (target.side === OrderSide.Buy ? notional : 0n)
+    const expectedOutcome = riskBlocked && index === riskCount - 1 ? RiskOutcome.Blocked : RiskOutcome.Approved
+    if (
+      risk.evaluation.policyHash !== document.bindings.policyHash ||
+      risk.evaluation.input.evaluatedAt !== document.createdAt ||
+      risk.evaluation.decision.outcome !== expectedOutcome ||
+      risk.evaluation.decision.decidedAt !== document.createdAt ||
+      risk.evaluation.decision.expiresAt > document.expiresAt ||
+      risk.evaluation.metrics.orderNotionalMicros !== risk.notionalLimitMicros ||
+      BigInt(risk.evaluation.metrics.aggregateBuyingPowerMicros) !== expectedAggregateBuyingPower ||
+      (previousRisk !== undefined &&
+        BigInt(risk.evaluation.metrics.dailyTradedNotionalMicros) !==
+          BigInt(previousRisk.evaluation.metrics.dailyTradedNotionalMicros) + notional)
+    ) {
+      issues.push({
+        path: ['deltaRisk', index],
+        issue: 'must contain complete cumulative PAPER risk evidence through the first blocked delta',
+      })
+    }
+  }
+  if (document.riskBlock !== undefined) {
+    const blockedRisk = document.deltaRisk.at(-1)
+    const blockedDecision = blockedRisk?.evaluation.decision
+    const knownReasonCodes = Object.values(Reason)
+    if (
+      blockedDecision === undefined ||
+      blockedDecision.outcome !== RiskOutcome.Blocked ||
+      blockedDecision.intentId !== document.riskBlock.intentId ||
+      blockedDecision.decisionId !== document.riskBlock.decisionId ||
+      blockedDecision.reasonCodes.length !== document.riskBlock.reasonCodes.length ||
+      blockedDecision.reasonCodes.some((reason, index) => reason !== document.riskBlock?.reasonCodes[index]) ||
+      blockedDecision.reasonCodes.some((reason) => !knownReasonCodes.includes(reason as Reason)) ||
+      blockedDecision.reasonCodes.includes(Reason.AuthorityNotPaper)
+    ) {
+      issues.push({
+        path: ['riskBlock'],
+        issue: 'must bind the final blocked PAPER risk decision and its exact non-authority reasons',
+      })
+    }
+  }
+  return issues
+}
+
+const PaperDecisionDocumentSemanticSchema = Schema.Struct({
+  ...PaperDecisionMaterialSchema.fields,
+  contentHash: Sha256Schema,
+}).check(Schema.makeFilter(paperMaterialIssues))
+
+export const PaperDecisionDocumentSchema = PaperDecisionDocumentSemanticSchema.check(
+  Schema.makeFilter((document) => {
+    const { contentHash, ...material } = document
+    const expectedHash = canonicalHashV1Result(material)
+    return Result.isFailure(expectedHash) || expectedHash.success !== contentHash
+      ? [{ path: ['contentHash'], issue: 'must match the canonical PAPER decision material' }]
+      : []
+  }),
+)
+export type PaperDecisionDocument = typeof PaperDecisionDocumentSchema.Type
+
+export const CycleDecisionDocumentSchema = Schema.Union([
+  ObserveShadowDecisionDocumentSchema,
+  PaperDecisionDocumentSchema,
+])
+export type CycleDecisionDocument = typeof CycleDecisionDocumentSchema.Type
+
 interface MakeShadowDecisionDocumentIssue {
   readonly operation: 'make'
   readonly reason: 'canonicalization' | 'contract'
@@ -181,6 +350,7 @@ const decodeDocumentFailure = (
 ): ShadowDecisionContractFailure => new ShadowDecisionContractFailure({ operation: 'decode', reason, message, cause })
 
 const decodeDocumentResult = Schema.decodeUnknownResult(ObserveShadowDecisionDocumentSchema, strictParseOptions)
+const decodePaperDocumentResult = Schema.decodeUnknownResult(PaperDecisionDocumentSchema, strictParseOptions)
 
 export const makeObserveShadowDecisionDocument = (
   material: unknown,
@@ -212,4 +382,28 @@ export const decodeObserveShadowDecisionDocument = (
 ): Result.Result<ObserveShadowDecisionDocument, ShadowDecisionContractFailure> =>
   Result.mapError(decodeDocumentResult(input), (cause) =>
     decodeDocumentFailure('contract', 'shadow decision document failed its durable contract', cause),
+  )
+
+export const makePaperDecisionDocument = (
+  material: unknown,
+): Result.Result<PaperDecisionDocument, ShadowDecisionContractFailure> => {
+  if (typeof material !== 'object' || material === null || Array.isArray(material)) {
+    return Result.fail(makeDocumentFailure('contract', 'PAPER decision material must be an object'))
+  }
+  return Result.flatMap(
+    Result.mapError(canonicalHashV1Result(material), (cause) =>
+      makeDocumentFailure('canonicalization', 'PAPER decision material is not canonicalizable', cause),
+    ),
+    (contentHash) =>
+      Result.mapError(decodePaperDocumentResult({ ...material, contentHash }), (cause) =>
+        makeDocumentFailure('contract', 'PAPER decision material failed its durable contract', cause),
+      ),
+  )
+}
+
+export const decodePaperDecisionDocument = (
+  input: unknown,
+): Result.Result<PaperDecisionDocument, ShadowDecisionContractFailure> =>
+  Result.mapError(decodePaperDocumentResult(input), (cause) =>
+    decodeDocumentFailure('contract', 'PAPER decision document failed its durable contract', cause),
   )

--- a/services/bayn/src/shadow-decision.ts
+++ b/services/bayn/src/shadow-decision.ts
@@ -8,19 +8,24 @@ import { intentIdForPlan, IntentPlanSchema, type IntentPlan } from './execution/
 import { canonicalHashV1Result } from './hash'
 import {
   Authority,
+  IntentSchema,
   IntentState,
   OrderSide,
   ReferenceIntentSchema,
   RiskOutcome,
+  type Intent,
   type Position,
   type ReferenceIntent,
 } from './execution/contracts'
 import { reconciledStateHash } from './reconciliation'
 import { evaluate, PolicySchema, Reason, StateSchema, type Policy, type State } from './risk'
 import {
+  makePaperDecisionDocument,
   makeObserveShadowDecisionDocument,
+  type CycleDecisionDocument,
   type DeltaRiskEvaluation,
   type ObserveShadowDecisionDocument,
+  type PaperDecisionDocument,
 } from './shadow-decision-contract'
 import {
   TargetPlannerInputSchema,
@@ -60,6 +65,10 @@ export interface ObserveShadowDecisionInput {
   readonly riskInputs: readonly ShadowDeltaRiskInput[]
 }
 
+export interface PaperDecisionInput extends ObserveShadowDecisionInput {
+  readonly authorityGenerationHash: string
+}
+
 export class ShadowDecisionError extends Data.TaggedError('ShadowDecisionError')<{
   readonly failure: 'binding' | 'contract' | 'risk'
   readonly message: string
@@ -97,7 +106,6 @@ const decodeObserveShadowDecisionInputResult = Schema.decodeUnknownResult(
 )
 const decodeDecisionPlanResult = Schema.decodeUnknownResult(DecisionPlanSchema, strictParseOptions)
 const decodeIntentPlanResult = Schema.decodeUnknownResult(IntentPlanSchema, strictParseOptions)
-const decodeReferenceIntentResult = Schema.decodeUnknownResult(ReferenceIntentSchema, strictParseOptions)
 const decodeCumulativeStateResult = Schema.decodeUnknownResult(StateSchema, strictParseOptions)
 
 const QUANTITY_SCALE = 1_000_000n
@@ -230,14 +238,15 @@ const validateBindings = (
 const validateRiskState = (
   input: ObserveShadowDecisionInput,
   riskInput: ShadowDeltaRiskInput,
+  authority: Authority,
   commonExecutionSessionHash: string,
   plannerBrokerStateHash: string,
   plannerReconciliationHash: string,
 ): Result.Result<void, ShadowDecisionError> => {
   const { cycle, plannerInput, snapshot } = input
   const state = riskInput.state
-  if (state.authority.effective !== Authority.Observe) {
-    return Result.fail(error('binding', 'shadow risk requires effective OBSERVE authority'))
+  if (state.authority.effective !== authority) {
+    return Result.fail(error('binding', `decision risk requires effective ${authority} authority`))
   }
   if (state.evaluatedAt !== plannerInput.observedAt) {
     return Result.fail(error('binding', 'shadow risk time must match target planning time'))
@@ -292,23 +301,52 @@ const validateRiskState = (
       )
 }
 
-const makeReferenceIntent = (input: IntentPlan): Result.Result<ReferenceIntent, ShadowDecisionError> => {
+const makeRiskIntent = (
+  input: IntentPlan,
+  authorityGenerationHash?: string,
+): Result.Result<ReferenceIntent | Intent, ShadowDecisionError> => {
   const decodedPlan = Result.mapError(decodeIntentPlanResult(input), (cause) =>
     error('contract', 'shadow target delta could not form a valid risk intent', cause),
   )
   if (Result.isFailure(decodedPlan)) return Result.fail(decodedPlan.failure)
+  const identityResult: Result.Result<string, ShadowDecisionError> =
+    authorityGenerationHash === undefined
+      ? Result.mapError(intentIdForPlan(decodedPlan.success), (cause) =>
+          error('contract', 'shadow target delta identity is not canonicalizable', cause),
+        )
+      : Result.mapError(
+          canonicalHashV1Result({
+            schemaVersion: 'bayn.paper-intent-identity.v2',
+            authorityGenerationHash,
+            strategyName: decodedPlan.success.strategyName,
+            cycleId: decodedPlan.success.cycleId,
+            decisionHash: decodedPlan.success.decisionHash,
+            accountId: decodedPlan.success.accountId,
+            symbol: decodedPlan.success.symbol,
+            side: decodedPlan.success.side,
+            orderType: decodedPlan.success.orderType,
+            timeInForce: decodedPlan.success.timeInForce,
+            quantityMicros: decodedPlan.success.quantityMicros,
+            notionalLimitMicros: decodedPlan.success.notionalLimitMicros,
+          }),
+          (cause) => error('contract', 'PAPER target delta identity is not canonicalizable', cause),
+        )
   const identity = Result.mapError(
-    Result.map(intentIdForPlan(decodedPlan.success), (intentId) => ({
+    Result.map(identityResult, (intentId) => ({
       intentId,
       clientOrderId: `b1_${Buffer.from(intentId, 'hex').toString('base64url')}`,
     })),
-    (cause) => error('contract', 'shadow target delta identity is not canonicalizable', cause),
+    (cause) => cause,
   )
   if (Result.isFailure(identity)) return Result.fail(identity.failure)
   const decoded = decodedPlan.success
   return Result.mapError(
-    decodeReferenceIntentResult({
-      schemaVersion: 'bayn.paper-intent.v2',
+    Schema.decodeUnknownResult(
+      authorityGenerationHash === undefined ? ReferenceIntentSchema : IntentSchema,
+      strictParseOptions,
+    )({
+      schemaVersion: authorityGenerationHash === undefined ? 'bayn.paper-intent.v2' : 'bayn.paper-intent.v3',
+      ...(authorityGenerationHash === undefined ? {} : { authorityGenerationHash }),
       intentId: identity.success.intentId,
       strategyName: decoded.strategyName,
       cycleId: decoded.cycleId,
@@ -334,6 +372,7 @@ interface ShadowReduction {
   readonly dailyTradedNotional: bigint
   readonly projectedPositions: readonly Position[]
   readonly deltaRisk: readonly DeltaRiskEvaluation[]
+  readonly riskBlock?: NonNullable<PaperDecisionDocument['riskBlock']>
 }
 
 interface ShadowReductionContext {
@@ -341,6 +380,8 @@ interface ShadowReductionContext {
   readonly policyHash: string
   readonly riskInputs: ReadonlyMap<string, ShadowDeltaRiskInput>
   readonly targetsBySymbol: ReadonlyMap<string, PlannedTargetQuantity>
+  readonly authority: Authority
+  readonly authorityGenerationHash?: string
 }
 
 const reduceShadowDelta = (
@@ -352,11 +393,14 @@ const reduceShadowDelta = (
   if (provided === undefined) {
     return Result.fail(error('binding', 'planned target delta is missing its risk input'))
   }
-  const intent = makeReferenceIntent({
-    schemaVersion: 'bayn.paper-intent-plan.v1',
-    ...targetIntent,
-    notionalLimitMicros: provided.notionalLimitMicros,
-  })
+  const intent = makeRiskIntent(
+    {
+      schemaVersion: 'bayn.paper-intent-plan.v1',
+      ...targetIntent,
+      notionalLimitMicros: provided.notionalLimitMicros,
+    },
+    context.authorityGenerationHash,
+  )
   if (Result.isFailure(intent)) return Result.fail(intent.failure)
   const state = Result.mapError(
     decodeCumulativeStateResult({
@@ -371,18 +415,38 @@ const reduceShadowDelta = (
   if (Result.isFailure(evaluation)) {
     return Result.fail(error('risk', 'shadow target risk evaluation failed', evaluation.failure))
   }
-  if (
-    evaluation.success.policyHash !== context.policyHash ||
-    evaluation.success.decision.outcome !== RiskOutcome.Blocked ||
-    !evaluation.success.decision.reasonCodes.includes(Reason.AuthorityNotPaper)
-  ) {
-    return Result.fail(error('risk', 'OBSERVE shadow risk must remain blocked by non-paper authority'))
+  const validOutcome =
+    context.authority === Authority.Observe
+      ? evaluation.success.decision.outcome === RiskOutcome.Blocked &&
+        evaluation.success.decision.reasonCodes.includes(Reason.AuthorityNotPaper)
+      : evaluation.success.decision.outcome === RiskOutcome.Approved ||
+        evaluation.success.decision.outcome === RiskOutcome.Blocked
+  if (evaluation.success.policyHash !== context.policyHash || !validOutcome) {
+    return Result.fail(error('risk', `${context.authority} decision risk outcome is incompatible with authority`))
   }
   const target = context.targetsBySymbol.get(targetIntent.symbol)
   if (target === undefined) {
     return Result.fail(error('contract', 'planned target delta is missing its final quantity'))
   }
   const orderNotional = BigInt(evaluation.success.metrics.orderNotionalMicros)
+  const deltaRisk = [
+    ...accumulator.deltaRisk,
+    {
+      notionalLimitMicros: provided.notionalLimitMicros,
+      evaluation: evaluation.success,
+    },
+  ]
+  if (context.authority === Authority.Paper && evaluation.success.decision.outcome === RiskOutcome.Blocked) {
+    return Result.succeed({
+      ...accumulator,
+      deltaRisk,
+      riskBlock: {
+        intentId: evaluation.success.decision.intentId,
+        decisionId: evaluation.success.decision.decisionId,
+        reasonCodes: evaluation.success.decision.reasonCodes,
+      },
+    })
+  }
   return Result.succeed({
     reservedBuyingPower: accumulator.reservedBuyingPower + (targetIntent.side === OrderSide.Buy ? orderNotional : 0n),
     dailyTradedNotional: accumulator.dailyTradedNotional + orderNotional,
@@ -392,13 +456,7 @@ const reduceShadowDelta = (
       context.input.plannerInput.accountId,
       provided.state.positionsObservedAt,
     ),
-    deltaRisk: [
-      ...accumulator.deltaRisk,
-      {
-        notionalLimitMicros: provided.notionalLimitMicros,
-        evaluation: evaluation.success,
-      },
-    ],
+    deltaRisk,
   })
 }
 
@@ -502,6 +560,7 @@ const prepareShadowRisk = (context: ShadowDecisionContext): Result.Result<Prepar
     const stateValidation = validateRiskState(
       input,
       candidate,
+      firstRiskInput?.state.authority.effective ?? Authority.Observe,
       commonExecutionSessionHash,
       plannerBrokerStateHash.success,
       plannerReconciliationHash.success,
@@ -521,16 +580,24 @@ const prepareShadowRisk = (context: ShadowDecisionContext): Result.Result<Prepar
   })
 }
 
-const reduceShadowRisk = (prepared: PreparedShadowRisk): Result.Result<ShadowReduction, ShadowDecisionError> =>
+const reduceShadowRisk = (
+  prepared: PreparedShadowRisk,
+  authority: Authority,
+  authorityGenerationHash?: string,
+): Result.Result<ShadowReduction, ShadowDecisionError> =>
   prepared.input.targetPlan.intentTargets.reduce<Result.Result<ShadowReduction, ShadowDecisionError>>(
     (accumulator, targetIntent) =>
       Result.flatMap(accumulator, (state) =>
-        reduceShadowDelta(state, targetIntent, {
-          input: prepared.input,
-          policyHash: prepared.policyHash,
-          riskInputs: prepared.riskInputs,
-          targetsBySymbol: prepared.targetsBySymbol,
-        }),
+        state.riskBlock !== undefined
+          ? Result.succeed(state)
+          : reduceShadowDelta(state, targetIntent, {
+              input: prepared.input,
+              policyHash: prepared.policyHash,
+              riskInputs: prepared.riskInputs,
+              targetsBySymbol: prepared.targetsBySymbol,
+              authority,
+              authorityGenerationHash,
+            }),
       ),
     Result.succeed({
       reservedBuyingPower: BigInt(prepared.baseReservedBuyingPower),
@@ -593,7 +660,9 @@ const reduceObserveShadowDecision = (
   Result.flatMap(decodeShadowDecisionContext(inputValue), (context) =>
     Result.flatMap(validateShadowPlanningBindings(context), () =>
       Result.flatMap(prepareShadowRisk(context), (prepared) =>
-        Result.flatMap(reduceShadowRisk(prepared), (reduction) => assembleShadowDecisionDocument(context, reduction)),
+        Result.flatMap(reduceShadowRisk(prepared, Authority.Observe), (reduction) =>
+          assembleShadowDecisionDocument(context, reduction),
+        ),
       ),
     ),
   )
@@ -602,3 +671,74 @@ export const buildObserveShadowDecision = (
   input: unknown,
 ): Effect.Effect<ObserveShadowDecisionDocument, ShadowDecisionError> =>
   Effect.fromResult(reduceObserveShadowDecision(input))
+
+const assemblePaperDecisionDocument = (
+  context: ShadowDecisionContext,
+  reduction: ShadowReduction,
+  authorityGenerationHash: string,
+): Result.Result<PaperDecisionDocument, ShadowDecisionError> => {
+  const { input, policyHash, strategyDecisionHash } = context
+  const planningBrokerStateHash = Result.mapError(
+    reconciledStateHash(plannerBrokerStateMaterial(input.plannerInput)),
+    (cause) => error('contract', 'planning broker state hash could not be derived', cause),
+  )
+  if (Result.isFailure(planningBrokerStateHash)) return Result.fail(planningBrokerStateHash.failure)
+  return Result.mapError(
+    makePaperDecisionDocument({
+      schemaVersion: 'bayn.paper-cycle-decision.v1',
+      mode: 'PAPER',
+      dispatchable: reduction.riskBlock === undefined,
+      bindings: {
+        strategyName: input.plannerInput.strategyName,
+        cycleId: input.cycle.identity.cycleId,
+        qualificationRunId: input.cycle.identity.qualificationRunId,
+        strategyProtocolHash: input.cycle.identity.strategyProtocolHash,
+        snapshotId: input.snapshot.snapshotId,
+        snapshotContentHash: input.snapshot.contentHash,
+        snapshotFinalizedAt: input.snapshot.finalizedAt,
+        strategyDecisionHash,
+        policyHash,
+        accountId: input.plannerInput.accountId,
+        planningBrokerStateHash: planningBrokerStateHash.success,
+        reconciliationId: input.plannerInput.brokerState.reconciliation.reconciliationId,
+        reconciliationHash: input.plannerInput.brokerState.reconciliation.contentHash,
+        authorityGenerationHash,
+      },
+      targetPlan: input.targetPlan,
+      deltaRisk: reduction.deltaRisk,
+      orderedIntentIds: reduction.deltaRisk.map((risk) => risk.evaluation.input.intentId),
+      ...(reduction.riskBlock === undefined ? {} : { riskBlock: reduction.riskBlock }),
+      submissionCutoffAt: input.cycle.window.submissionCutoffAt,
+      expiresAt: input.cycle.window.submissionCutoffAt,
+      createdAt: input.plannerInput.observedAt,
+    }),
+    (cause) => error('contract', 'PAPER decision document failed durable contract validation', cause),
+  )
+}
+
+export const buildPaperDecision = (
+  input: PaperDecisionInput,
+): Effect.Effect<PaperDecisionDocument, ShadowDecisionError> =>
+  Effect.fromResult(
+    Result.flatMap(
+      decodeShadowDecisionContext({
+        cycle: input.cycle,
+        snapshot: input.snapshot,
+        compiledDecision: input.compiledDecision,
+        plannerInput: input.plannerInput,
+        targetPlan: input.targetPlan,
+        policy: input.policy,
+        riskInputs: input.riskInputs,
+      }),
+      (context) =>
+        Result.flatMap(validateShadowPlanningBindings(context), () =>
+          Result.flatMap(prepareShadowRisk(context), (prepared) =>
+            Result.flatMap(reduceShadowRisk(prepared, Authority.Paper, input.authorityGenerationHash), (reduction) =>
+              assemblePaperDecisionDocument(context, reduction, input.authorityGenerationHash),
+            ),
+          ),
+        ),
+    ),
+  )
+
+export type DurableCycleDecisionDocument = CycleDecisionDocument


### PR DESCRIPTION
## Summary

- keep one shared recovery-first PAPER interpreter for mutation and OBSERVE authority modes
- recover accepted, unknown, and cancellation outcomes before superseded-generation blocking; no blind resubmit and no submit after the immutable cutoff
- give OBSERVE a recovery-only capability with lookup recovery and no submit function; untouched PAPER work performs no intent commit, reconciliation, or broker mutation
- select unresolved planned PAPER mutation work account-wide across qualification rotation, then retain a settled superseded cycle only long enough for deterministic provenance terminalization
- centralize cancellation-first unresolved mutation evidence in migration 0021 and apply it to completion, blocking, supersession, and terminal-failure validation
- reject `SUBMIT_STARTED`, unresolved submit/recovery states, and unresolved cancel states before any terminal cycle transition
- allow terminal cancel recovery to neutralize stale submit ambiguity only after `CANCEL/RECOVERY_FOUND` is durably present
- preserve deterministic intent/mutation identity, stored decision/session/cutoff evidence, producer-owned cadence/session facts, and ordinary OBSERVE decision construction

## Validation

- focused recovery/cadence: 81 passed, 0 failed, 556 assertions
- full Bayn: 1,164 passed, 0 failed, 149 PostgreSQL-gated skips, 9,143 assertions across 1,313 tests
- TypeScript: clean
- Effect diagnostics: 0 errors, 0 warnings
- Oxfmt: clean
- Oxlint and type-aware Oxlint: 0 errors (generated historical candidate warnings only)
- build: clean
- commit hooks: clean
- exact current-main parent: `69d803040c8866e7703df50a645a096c54e7eca5`
- exact head: `adc96644904d1f1c2640cc6a597d1cfc108caf91`
- diff: exactly 18 existing PROOMPT-409 recovery/cycle paths
- local PostgreSQL is not configured; migrated hosted PostgreSQL remains authoritative

## Causal regressions

- superseded accepted/unknown submit and accepted/unknown cancel recover before provenance blocking
- old bound PAPER mutation recovery uses durable decision evidence before current source-policy comparison
- settled successor-generation PAPER work reaches deterministic provenance terminalization despite later policy drift
- fresh intent work remains blocked before commit, reconciliation, broker reads, or submission when the current policy differs
- durable intent IDs and immutable intent reconstruction precede current execution-model comparison
- accepted/unknown/cancel recovery and successor terminalization survive later price-impact or precision drift
- current execution-model validation applies only to work that can issue a fresh submit, before commit or reconciliation
- rotated qualification with a competing current cycle selects old account-wide mutation work first, retains it after settlement for provenance blocking, then releases selection
- OBSERVE recovery-only mode selects cancel lookup recovery while structurally refusing fresh intent commit or submit
- `SUBMIT_STARTED` cannot satisfy PAPER completion evidence
- stale `SUBMIT_UNKNOWN` plus `CANCEL_UNKNOWN` rejects terminalization; durable `CANCEL/RECOVERY_FOUND` permits the exact terminal failure transition
- exact replay dispatches no new mutation and fresh submit remains forbidden at or after cutoff
- same-instant concurrent snapshot binding is normalized only for the exact one-version durable transition
- PostgreSQL recovery fixtures follow the production `UNKNOWN -> RECOVERED -> TERMINAL` state machine without weakening triggers

## Safety

No PAPER/capital activation, broker submit/cancel action, direct deployment, GitOps edit, credential, permission, RBAC, NetworkPolicy, policy, or security-boundary change is included or performed.

Linear: PROOMPT-409


