### PR TITLE
feat(bayn): execute governed qualification once

### DIFF
--- a/.github/workflows/bayn-qualification.yml
+++ b/.github/workflows/bayn-qualification.yml
@@ -15,9 +15,9 @@ concurrency:
 
 jobs:
   eligibility:
-    name: Verify governed qualification eligibility
+    name: Run governed qualification once
     runs-on: arc-arm64
-    timeout-minutes: 10
+    timeout-minutes: 180
     steps:
       - name: Reject manual invocation
         if: github.event_name == 'workflow_dispatch'
@@ -31,11 +31,6 @@ jobs:
           ref: ${{ github.sha }}
           fetch-depth: 0
           persist-credentials: false
-
-      - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.3.14
 
       - name: Verify dormant calendar before any privileged access
         id: calendar
@@ -52,18 +47,198 @@ jobs:
 
       - name: Stop safely while preregistration is absent
         if: steps.calendar.outputs.dormant == 'true'
-        run: echo 'No credentials, Signal data, PostgreSQL state, holdout, or qualification command were accessed.'
+        run: echo 'No credentials, Signal data, PostgreSQL state, holdout, image, or qualification command were accessed.'
 
-      - name: Require separately installed immutable evidence collector
+      - name: Bind the exact promoted unpinned qualification image
+        id: image
         if: steps.calendar.outputs.dormant != 'true'
         shell: bash
         run: |
           set -euo pipefail
-          echo 'A non-null preregistration exists, but execution stays fail-closed until the reviewed evidence collector writes /run/bayn-qualification/eligibility-input.json.' >&2
-          test -s /run/bayn-qualification/eligibility-input.json
-          bun packages/scripts/src/bayn/verify-qualification-eligibility.ts \
-            --input /run/bayn-qualification/eligibility-input.json \
-            --repository-root "${GITHUB_WORKSPACE}" \
-            --trusted-repository "${GITHUB_REPOSITORY}" \
-            --git-timeout-ms 10000
-          echo 'Eligibility verified. The existing governed qualification command must be invoked by the same reviewed collector only after its durable attempt lock is committed.'
+          test "$(git rev-parse HEAD)" = "${GITHUB_SHA}"
+          test "$(git rev-parse refs/remotes/origin/main)" = "${GITHUB_SHA}"
+
+          deployment='argocd/applications/bayn/deployment.yaml'
+          read_bayn_env() {
+            local name="$1"
+            NAME="$name" yq -er '
+              [.spec.template.spec.containers[]
+                | select(.name == "bayn")
+                | .env[]
+                | select(.name == strenv(NAME) and has("value"))
+                | .value]
+              | select(length == 1)
+              | .[0]
+            ' "$deployment"
+          }
+
+          qualification_pin_count="$(NAME=BAYN_QUALIFICATION_RUN_ID yq -r '
+            [.spec.template.spec.containers[]
+              | select(.name == "bayn")
+              | .env[]
+              | select(.name == strenv(NAME))]
+            | length
+          ' "$deployment")"
+          test "$qualification_pin_count" = 0
+
+          source_sha="$(read_bayn_env BAYN_CODE_REVISION)"
+          image_repository="$(read_bayn_env BAYN_IMAGE_REPOSITORY)"
+          image_digest="$(read_bayn_env BAYN_IMAGE_DIGEST)"
+          [[ "$source_sha" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$image_repository" =~ ^[A-Za-z0-9._:/-]+$ ]]
+          [[ "$image_digest" =~ ^sha256:[0-9a-f]{64}$ ]]
+
+          image_reference="${image_repository}@${image_digest}"
+          echo "reference=${image_reference}" >> "$GITHUB_OUTPUT"
+
+      - name: Pull and verify the exact qualification image
+        if: steps.calendar.outputs.dormant != 'true'
+        shell: bash
+        env:
+          IMAGE_REFERENCE: ${{ steps.image.outputs.reference }}
+        run: |
+          set -euo pipefail
+          docker pull "$IMAGE_REFERENCE"
+          docker image inspect "$IMAGE_REFERENCE" --format '{{json .RepoDigests}}' |
+            jq -e --arg expected "$IMAGE_REFERENCE" 'index($expected) != null' >/dev/null
+
+      - name: Preflight immutable qualification evidence without credentials
+        if: steps.calendar.outputs.dormant != 'true'
+        shell: bash
+        env:
+          IMAGE_REFERENCE: ${{ steps.image.outputs.reference }}
+        run: |
+          set -euo pipefail
+          preflight="${RUNNER_TEMP}/bayn-qualification-preflight.log"
+          rm -f -- "$preflight"
+
+          docker run --rm \
+            --read-only \
+            --user "$(id -u):$(id -g)" \
+            --tmpfs /tmp:rw,noexec,nosuid,size=64m \
+            --mount "type=bind,src=${GITHUB_WORKSPACE},dst=/workspace,readonly" \
+            -e GITHUB_EVENT_NAME \
+            -e GITHUB_REPOSITORY \
+            -e GITHUB_RUN_ATTEMPT \
+            -e GITHUB_RUN_ID \
+            -e GITHUB_SHA \
+            -e BAYN_QUALIFICATION_REPOSITORY_PATH=/workspace \
+            -e BAYN_QUALIFICATION_TRUSTED_REPOSITORY="${GITHUB_REPOSITORY}" \
+            -e BAYN_QUALIFICATION_IMAGE_REFERENCE="$IMAGE_REFERENCE" \
+            -e BAYN_QUALIFICATION_MODE=preflight \
+            --entrypoint bayn-qualification-collector \
+            "$IMAGE_REFERENCE" | tee "$preflight"
+
+          mapfile -t preflight_lines < <(grep '^BAYN_QUALIFICATION_TERMINAL=' "$preflight")
+          test "${#preflight_lines[@]}" -eq 1
+          jq -e '
+            .schemaVersion == "bayn.qualification-collector-preflight.v1"
+            and .status == "READY"
+            and (.currentMainSha | test("^[0-9a-f]{40}$"))
+            and (.sourceSha | test("^[0-9a-f]{40}$"))
+            and (.image.digest | test("^sha256:[0-9a-f]{64}$"))
+            and (.candidateOrdinal | type == "number")
+            and (.preregistrationHash | test("^[0-9a-f]{64}$"))
+          ' <<< "${preflight_lines[0]#BAYN_QUALIFICATION_TERMINAL=}" >/dev/null
+
+      - name: Collect, lock, execute once, and independently audit
+        id: qualify
+        if: steps.calendar.outputs.dormant != 'true'
+        shell: bash
+        env:
+          IMAGE_REFERENCE: ${{ steps.image.outputs.reference }}
+          GITHUB_TOKEN: ${{ github.token }}
+          BAYN_CLICKHOUSE_USERNAME: ${{ secrets.BAYN_QUALIFICATION_CLICKHOUSE_USERNAME }}
+          BAYN_CLICKHOUSE_PASSWORD: ${{ secrets.BAYN_QUALIFICATION_CLICKHOUSE_PASSWORD }}
+          BAYN_POSTGRES_URL: ${{ secrets.BAYN_QUALIFICATION_POSTGRES_URL }}
+          BAYN_QUALIFICATION_POSTGRES_CA_PEM: ${{ secrets.BAYN_QUALIFICATION_POSTGRES_CA_PEM }}
+          BAYN_AUDIT_SIGNAL_PUBLISHER_USERNAME: ${{ secrets.BAYN_QUALIFICATION_SIGNAL_PUBLISHER_USERNAME }}
+          BAYN_AUDIT_CLICKHOUSE_USERNAME: ${{ secrets.BAYN_QUALIFICATION_AUDIT_CLICKHOUSE_USERNAME }}
+          BAYN_AUDIT_CLICKHOUSE_PASSWORD: ${{ secrets.BAYN_QUALIFICATION_AUDIT_CLICKHOUSE_PASSWORD }}
+        run: |
+          set -euo pipefail
+          set +x
+          umask 077
+
+          log="${RUNNER_TEMP}/bayn-qualification.log"
+          terminal="${RUNNER_TEMP}/bayn-qualification-terminal.json"
+          rm -f -- "$log" "$terminal"
+
+          docker run --rm \
+            --network host \
+            --read-only \
+            --user "$(id -u):$(id -g)" \
+            --tmpfs /tmp:rw,noexec,nosuid,size=128m \
+            --mount "type=bind,src=${GITHUB_WORKSPACE},dst=/workspace,readonly" \
+            -e GITHUB_API_URL \
+            -e GITHUB_EVENT_NAME \
+            -e GITHUB_REPOSITORY \
+            -e GITHUB_RUN_ATTEMPT \
+            -e GITHUB_RUN_ID \
+            -e GITHUB_SHA \
+            -e GITHUB_TOKEN \
+            -e BAYN_CLICKHOUSE_USERNAME \
+            -e BAYN_CLICKHOUSE_PASSWORD \
+            -e BAYN_POSTGRES_URL \
+            -e BAYN_QUALIFICATION_POSTGRES_CA_PEM \
+            -e BAYN_AUDIT_SIGNAL_PUBLISHER_USERNAME \
+            -e BAYN_AUDIT_CLICKHOUSE_USERNAME \
+            -e BAYN_AUDIT_CLICKHOUSE_PASSWORD \
+            -e BAYN_QUALIFICATION_REPOSITORY_PATH=/workspace \
+            -e BAYN_QUALIFICATION_TRUSTED_REPOSITORY="${GITHUB_REPOSITORY}" \
+            -e BAYN_QUALIFICATION_IMAGE_REFERENCE="$IMAGE_REFERENCE" \
+            -e BAYN_QUALIFICATION_MODE=execute \
+            --entrypoint bayn-qualification-collector \
+            "$IMAGE_REFERENCE" | tee "$log"
+
+          mapfile -t terminal_lines < <(grep '^BAYN_QUALIFICATION_TERMINAL=' "$log")
+          test "${#terminal_lines[@]}" -eq 1
+          printf '%s\n' "${terminal_lines[0]#BAYN_QUALIFICATION_TERMINAL=}" > "$terminal"
+          jq -e '
+            .schemaVersion == "bayn.qualification-collector-terminal.v1"
+            and (.sourceSha | test("^[0-9a-f]{40}$"))
+            and (.eligibilityHash | test("^[0-9a-f]{64}$"))
+            and (.candidateBindingHash | test("^[0-9a-f]{64}$"))
+            and (.terminal.schemaVersion == "bayn.qualification-execution.v1")
+            and (.terminal.runId | test("^[0-9a-f]{64}$"))
+            and (.terminal.lockId | test("^[0-9a-f]{64}$"))
+            and (.terminal.resultHash | test("^[0-9a-f]{64}$"))
+            and (.audit.schemaVersion == "bayn.qualification-audit.v2")
+            and (.audit.status == "PASS")
+            and (.audit.runId == .terminal.runId)
+            and (.audit.evidence.lockId == .terminal.lockId)
+            and (.audit.evidence.resultHash == .terminal.resultHash)
+            and (.evidenceHash | test("^[0-9a-f]{64}$"))
+          ' "$terminal" >/dev/null
+          echo "terminal=${terminal}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload immutable terminal qualification evidence
+        if: steps.calendar.outputs.dormant != 'true' && steps.qualify.outcome == 'success'
+        uses: actions/upload-artifact@v4
+        with:
+          name: bayn-qualification-terminal-${{ github.sha }}-${{ github.run_id }}
+          path: ${{ steps.qualify.outputs.terminal }}
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: Summarize terminal qualification evidence
+        if: steps.calendar.outputs.dormant != 'true' && steps.qualify.outcome == 'success'
+        shell: bash
+        env:
+          TERMINAL: ${{ steps.qualify.outputs.terminal }}
+        run: |
+          set -euo pipefail
+          {
+            echo '## Bayn governed qualification'
+            jq -r '
+              "- Source: `\(.sourceSha)`\n" +
+              "- Image: `\(.image.repository)@\(.image.digest)`\n" +
+              "- Candidate ordinal: `\(.candidateOrdinal)`\n" +
+              "- Run: `\(.terminal.runId)`\n" +
+              "- Lock: `\(.terminal.lockId)`\n" +
+              "- Result: `\(.terminal.resultHash)`\n" +
+              "- Verdict: `\(.terminal.verdict)`\n" +
+              "- Audit: `\(.audit.auditHash)`\n" +
+              "- Terminal evidence: `\(.evidenceHash)`"
+            ' "$TERMINAL"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/nix/images/bayn.nix
+++ b/nix/images/bayn.nix
@@ -18,16 +18,31 @@ let
     root="''${BAYN_IMAGE_ROOT:-}"
     exec "$root/bin/node" "$root/app/services/bayn/dist/forward-performance-command.js" "$@"
   '';
+  qualificationCandidateCommand = pkgs.writeShellScriptBin "bayn-qualification-candidate" ''
+    set -eu
+    root="''${BAYN_IMAGE_ROOT:-}"
+    exec "$root/bin/node" "$root/app/services/bayn/dist/qualification-candidate-command.js" "$@"
+  '';
+  qualificationAuditCommand = pkgs.writeShellScriptBin "bayn-qualification-audit" ''
+    set -eu
+    root="''${BAYN_IMAGE_ROOT:-}"
+    exec "$root/bin/node" "$root/app/services/bayn/dist/qualification-audit-command.js" "$@"
+  '';
+  qualificationCollectorCommand = pkgs.writeShellScriptBin "bayn-qualification-collector" ''
+    set -eu
+    root="''${BAYN_IMAGE_ROOT:-}"
+    exec "$root/bin/bun" "$root/app/services/bayn/dist/qualification-collector-command.js" "$@"
+  '';
   buildDefine = name: value: "--define ${name}=${lib.escapeShellArg (builtins.toJSON value)}";
   dependencySource = import ./bun-workspace-deps-source.nix { inherit lib repoRoot; };
   depsHash = {
-    x86_64-linux = "sha256-eoTvA2uvy7ktZhMzOIJo3oekxWyxCNCJlNQaYn8BlMU=";
-    aarch64-linux = "sha256-EWmnsW92l5DHPLfe353UEMwKwgygzAEyNS1N1JvYHLY=";
+    x86_64-linux = "sha256-y7PRw8e/DeerQppuopDJREtOGA5qB24hX9HUyumngzg=";
+    aarch64-linux = "sha256-SnSTaAPp9/4mjEQxUwZGApZWqsfPd+2MWtvwJ10iqkQ=";
   };
   buildCommands = [
     "bun --cwd=services/bayn run tsc"
     (
-      "bun --cwd=services/bayn build src/index.ts src/verify-build-contract.ts src/forward-performance-command.ts --target=node "
+      "bun --cwd=services/bayn build src/index.ts src/verify-build-contract.ts src/qualification-audit-command.ts src/qualification-candidate-command.ts src/qualification-collector-command.ts src/forward-performance-command.ts --target=node "
       + "--external tigerbeetle-node --outdir=dist "
       + buildDefine "__BAYN_BUILD_SOURCE_REVISION__" repoRevision
       + " "
@@ -39,6 +54,7 @@ let
     )
     "node services/bayn/dist/verify-build-contract.js"
     "grep -F -- ${lib.escapeShellArg repoRevision} services/bayn/dist/index.js"
+    "grep -F -- ${lib.escapeShellArg repoRevision} services/bayn/dist/qualification-collector-command.js"
     "grep -F -- ${lib.escapeShellArg repoRevision} services/bayn/dist/forward-performance-command.js"
     "grep -F -- ${lib.escapeShellArg strategyBehaviorHash} services/bayn/dist/index.js"
     "grep -F -- ${lib.escapeShellArg strategyParameterHash} services/bayn/dist/index.js"
@@ -46,6 +62,9 @@ let
   runtimeInstallPhase = ''
     mkdir -p "$out/app/services/bayn/dist" "$out/app/services/bayn/node_modules/tigerbeetle-node"
     cp "$TMPDIR/work/services/bayn/dist/index.js" "$out/app/services/bayn/dist/"
+    cp "$TMPDIR/work/services/bayn/dist/qualification-audit-command.js" "$out/app/services/bayn/dist/"
+    cp "$TMPDIR/work/services/bayn/dist/qualification-candidate-command.js" "$out/app/services/bayn/dist/"
+    cp "$TMPDIR/work/services/bayn/dist/qualification-collector-command.js" "$out/app/services/bayn/dist/"
     cp "$TMPDIR/work/services/bayn/dist/forward-performance-command.js" "$out/app/services/bayn/dist/"
     cp "$TMPDIR/work/services/bayn/package.json" "$out/app/services/bayn/package.json"
     cp -R -L "$TMPDIR/work/services/bayn/node_modules/tigerbeetle-node/." \
@@ -82,10 +101,15 @@ import ./bun-workspace-service.nix {
     "dist/index.js"
   ];
   workingDir = "/app/services/bayn";
-  includeBunRuntime = false;
+  includeBunRuntime = true;
   extraContents = [
     nodejs
+    pkgs.cacert
+    pkgs.git
     forwardPerformanceCommand
+    qualificationCandidateCommand
+    qualificationAuditCommand
+    qualificationCollectorCommand
   ];
   exposedPorts = {
     "8080/tcp" = { };

--- a/packages/scripts/src/bayn/bayn-qualification-workflow.test.ts
+++ b/packages/scripts/src/bayn/bayn-qualification-workflow.test.ts
@@ -2,20 +2,137 @@ import { describe, expect, test } from 'bun:test'
 import { readFileSync } from 'node:fs'
 
 const workflow = readFileSync('.github/workflows/bayn-qualification.yml', 'utf8')
+const image = readFileSync('nix/images/bayn.nix', 'utf8')
+const packageManifest = readFileSync('services/bayn/package.json', 'utf8')
+const collector = readFileSync('services/bayn/src/qualification-collector-command.ts', 'utf8')
+const auditCommand = readFileSync('services/bayn/src/qualification-audit-command.ts', 'utf8')
 
-describe('Bayn qualification workflow verifier integrity', () => {
-  test('passes explicit checked-out repository identity and a bounded Git deadline', () => {
-    expect(workflow).toContain('fetch-depth: 0')
-    expect(workflow).toContain('--repository-root "${GITHUB_WORKSPACE}"')
-    expect(workflow).toContain('--trusted-repository "${GITHUB_REPOSITORY}"')
-    expect(workflow).toContain('--git-timeout-ms 10000')
+describe('Bayn qualification workflow collector/executor contract', () => {
+  test('stays dormant before any credential, image, database, Signal, or qualification access', () => {
+    const dormant = workflow.indexOf('Verify dormant calendar before any privileged access')
+    const imageBinding = workflow.indexOf('Bind the exact promoted unpinned qualification image')
+    const secretReference = workflow.indexOf('secrets.BAYN_QUALIFICATION_CLICKHOUSE_USERNAME')
+    const imagePull = workflow.indexOf('docker pull "$IMAGE_REFERENCE"')
+
+    expect(dormant).toBeGreaterThan(0)
+    expect(imageBinding).toBeGreaterThan(dormant)
+    expect(secretReference).toBeGreaterThan(imageBinding)
+    expect(imagePull).toBeGreaterThan(imageBinding)
+    expect(workflow).toContain('nextCandidatePreregistration: null')
+    expect(workflow).toContain(
+      'No credentials, Signal data, PostgreSQL state, holdout, image, or qualification command were accessed.',
+    )
+    expect(workflow).toContain("if: steps.calendar.outputs.dormant != 'true'")
   })
 
-  test('keeps read-only GitHub permissions and does not claim the missing executor is installed', () => {
+  test('binds and executes only the exact promoted unpinned source image', () => {
+    expect(workflow).toContain('fetch-depth: 0')
+    expect(workflow).toContain('persist-credentials: false')
+    expect(workflow).toContain('test "$(git rev-parse refs/remotes/origin/main)" = "${GITHUB_SHA}"')
+    expect(workflow).toContain('qualification_pin_count')
+    expect(workflow).toContain('test "$qualification_pin_count" = 0')
+    expect(workflow).toContain('[[ "$source_sha" =~ ^[0-9a-f]{40}$ ]]')
+    expect(workflow).toContain('image_reference="${image_repository}@${image_digest}"')
+    expect(workflow).toContain('docker pull "$IMAGE_REFERENCE"')
+    expect(workflow).toContain('jq -e --arg expected "$IMAGE_REFERENCE" \'index($expected) != null\'')
+    expect(workflow).toContain('--read-only')
+    expect(workflow).toContain('--mount "type=bind,src=${GITHUB_WORKSPACE},dst=/workspace,readonly"')
+    expect(workflow).toContain('--entrypoint bayn-qualification-collector')
+    expect(workflow).toContain('"$IMAGE_REFERENCE" | tee "$log"')
+  })
+
+  test('uses in-process evidence rather than an arbitrary prewritten eligibility file', () => {
+    expect(workflow).not.toContain('/run/bayn-qualification/eligibility-input.json')
+    expect(workflow).not.toContain('verify-qualification-eligibility.ts')
+    expect(collector).toContain('verifyCandidateDevelopmentRepositoryIntegrity')
+    expect(collector).toContain('verifyCandidateDevelopmentPreregistrationLineage')
+    expect(collector).toContain('validateCandidateDevelopmentPreregistrationDocument')
+    expect(collector).toContain('verifyCandidateDevelopmentPreregistrationModuleNovelty')
+    expect(collector).toContain('verifyQualificationCandidateImmutableSource')
+    expect(collector).toContain('compiledBoundedContentHash')
+    expect(collector).toContain('isQualificationSourceAffectingPath')
+    expect(collector).toContain("['diff', '--no-renames', '--name-only'")
+    expect(collector).toContain('verifyQualificationCandidateBinding')
+    expect(collector).toContain('runStartup(input.plan.config')
+    expect(collector).toContain('collectQualificationAuditReport')
+    expect(collector.indexOf('readQualification(candidate.candidateRunId)')).toBeLessThan(
+      collector.indexOf('runStartup(input.plan.config'),
+    )
+  })
+
+  test('runs the exact image preflight without credentials before the secret-bearing execution step', () => {
+    const preflight = workflow.indexOf('Preflight immutable qualification evidence without credentials')
+    const secretExecution = workflow.indexOf('Collect, lock, execute once, and independently audit')
+    const firstSecret = workflow.indexOf('secrets.BAYN_QUALIFICATION_CLICKHOUSE_USERNAME')
+
+    expect(preflight).toBeGreaterThan(0)
+    expect(secretExecution).toBeGreaterThan(preflight)
+    expect(firstSecret).toBeGreaterThan(secretExecution)
+    expect(workflow).toContain('-e BAYN_QUALIFICATION_MODE=preflight')
+    expect(workflow).toContain('-e BAYN_QUALIFICATION_MODE=execute')
+    expect(workflow).toContain('bayn.qualification-collector-preflight.v1')
+  })
+
+  test('keeps GitHub permissions read-only and declares only explicit secret wiring', () => {
     expect(workflow).toContain('actions: read')
     expect(workflow).toContain('contents: read')
     expect(workflow).not.toMatch(/(?:issues|packages|pull-requests|statuses|checks|deployments|id-token): write/)
-    expect(workflow).toContain('Require separately installed immutable evidence collector')
-    expect(workflow).toContain('must be invoked by the same reviewed collector')
+    for (const secret of [
+      'BAYN_QUALIFICATION_CLICKHOUSE_USERNAME',
+      'BAYN_QUALIFICATION_CLICKHOUSE_PASSWORD',
+      'BAYN_QUALIFICATION_POSTGRES_URL',
+      'BAYN_QUALIFICATION_POSTGRES_CA_PEM',
+      'BAYN_QUALIFICATION_SIGNAL_PUBLISHER_USERNAME',
+      'BAYN_QUALIFICATION_AUDIT_CLICKHOUSE_USERNAME',
+      'BAYN_QUALIFICATION_AUDIT_CLICKHOUSE_PASSWORD',
+    ]) {
+      expect(workflow).toContain(`secrets.${secret}`)
+    }
+    expect(workflow).toContain("if: github.event_name == 'workflow_dispatch'")
+    expect(workflow).toContain('Manual qualification dispatch is forbidden.')
+  })
+
+  test('packages the candidate, collector, and independent audit into both production image platforms', () => {
+    expect(packageManifest).toContain('"collect:qualification": "bun src/qualification-collector-command.ts"')
+    for (const command of [
+      'qualification-audit-command',
+      'qualification-candidate-command',
+      'qualification-collector-command',
+    ]) {
+      expect(packageManifest).toContain(`src/${command}.ts`)
+      expect(image).toContain(`src/${command}.ts`)
+      expect(image).toContain(`dist/${command}.js`)
+    }
+    expect(image).toContain('pkgs.git')
+    expect(image).toContain('bayn-qualification-candidate')
+    expect(image).toContain('bayn-qualification-audit')
+    expect(image).toContain('bayn-qualification-collector')
+    expect(image).toContain('exec "$root/bin/bun" "$root/app/services/bayn/dist/qualification-collector-command.js"')
+    expect(image).toContain('includeBunRuntime = true;')
+    expect(image).toContain('sha256-y7PRw8e/DeerQppuopDJREtOGA5qB24hX9HUyumngzg=')
+    expect(image).toContain('sha256-SnSTaAPp9/4mjEQxUwZGApZWqsfPd+2MWtvwJ10iqkQ=')
+  })
+
+  test('keeps standalone dossier output while the collector imports the report-only audit wrapper', () => {
+    expect(auditCommand).toContain('const collectQualificationAuditOutput')
+    expect(auditCommand).toContain('const { input, report } = yield* collectQualificationAuditOutput')
+    expect(auditCommand).toContain('renderQualificationAuditCommandOutput(report)')
+    expect(auditCommand).toContain('completeQualificationAuditCommand(input, report)')
+    expect(auditCommand).toContain("input.output === 'audit' && 'status' in report && report.status !== 'PASS'")
+    expect(auditCommand).toContain('export const requireQualificationAuditReport')
+    expect(auditCommand).toContain(
+      'export const collectQualificationAuditReport = collectQualificationAuditOutput.pipe(',
+    )
+    expect(collector).toContain("import { collectQualificationAuditReport } from './qualification-audit-command'")
+  })
+
+  test('keeps collector configuration failures typed and delegates termination to NodeRuntime', () => {
+    expect(collector).toContain('export const requiredQualificationEnvironment')
+    expect(collector).toContain('export const loadQualificationCollectorInvocation')
+    expect(collector).toContain('export const qualificationCollectorMain')
+    expect(collector).toContain('Effect.tapError')
+    expect(collector).toContain('NodeRuntime.runMain(qualificationCollectorMain)')
+    expect(collector).not.toContain('process.exitCode')
+    expect(collector).not.toContain('Effect.catch((error)')
   })
 })

--- a/services/bayn/package.json
+++ b/services/bayn/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "audit:qualification": "bun src/qualification-audit-command.ts",
     "candidate:qualification": "bun src/qualification-candidate-command.ts",
-    "build": "bun build src/index.ts src/forward-performance-command.ts --target=node --external tigerbeetle-node --outdir=dist",
+    "collect:qualification": "bun src/qualification-collector-command.ts",
+    "build": "bun build src/index.ts src/qualification-audit-command.ts src/qualification-candidate-command.ts src/qualification-collector-command.ts src/forward-performance-command.ts --target=node --external tigerbeetle-node --outdir=dist",
     "dev": "BAYN_PROVENANCE_MODE=development bun --watch src/index.ts",
     "forward:performance": "BAYN_PROVENANCE_MODE=development node dist/forward-performance-command.js",
     "start": "BAYN_PROVENANCE_MODE=development node dist/index.js",

--- a/services/bayn/src/qualification-audit-command.ts
+++ b/services/bayn/src/qualification-audit-command.ts
@@ -2,7 +2,14 @@ import { NodeRuntime, NodeServices } from '@effect/platform-node'
 import { Effect, Layer, Logger, Schema, Stdio, Stream } from 'effect'
 import * as Reactivity from 'effect/unstable/reactivity/Reactivity'
 
-import { qualificationAuditConfig, qualificationAuditCommandError } from './qualification/audit-command/model'
+import type { QualificationAuditReport } from './audit/audit'
+import type { QualificationDossier } from './audit/dossier'
+import {
+  qualificationAuditConfig,
+  qualificationAuditCommandError,
+  type AuditConfig,
+  type QualificationAuditCommandError,
+} from './qualification/audit-command/model'
 import {
   liveQualificationAuditAcquirers,
   makeQualificationAuditReaders,
@@ -30,23 +37,52 @@ export {
 export { makeQualificationAuditReaders, runQualificationAudit } from './qualification/audit-command/program'
 
 const encodeJson = Schema.encodeUnknownEffect(Schema.fromJsonString(Schema.Json))
+type QualificationAuditOutput = QualificationAuditReport | QualificationDossier
 
-const main = Effect.gen(function* () {
+export const requireQualificationAuditReport = (
+  report: QualificationAuditOutput,
+): Effect.Effect<QualificationAuditReport, QualificationAuditCommandError> =>
+  'status' in report
+    ? Effect.succeed(report)
+    : Effect.fail(qualificationAuditCommandError('audit', 'qualification audit command produced a dossier'))
+
+export const renderQualificationAuditCommandOutput = (
+  report: QualificationAuditOutput,
+): Effect.Effect<string, QualificationAuditCommandError> =>
+  encodeJson(report).pipe(
+    Effect.mapError((cause) =>
+      qualificationAuditCommandError('audit', 'qualification audit output encoding failed', cause),
+    ),
+    Effect.map((output) => `${output}\n`),
+  )
+
+export const completeQualificationAuditCommand = (
+  input: Pick<AuditConfig, 'output'>,
+  report: QualificationAuditOutput,
+): Effect.Effect<void, QualificationAuditCommandError> =>
+  input.output === 'audit' && 'status' in report && report.status !== 'PASS'
+    ? Effect.fail(qualificationAuditCommandError('audit', 'qualification audit failed'))
+    : Effect.void
+
+const collectQualificationAuditOutput = Effect.gen(function* () {
   const input = yield* qualificationAuditConfig
   const report = yield* runQualificationAudit(
     input,
     makeQualificationAuditReaders(input, liveQualificationAuditAcquirers),
   )
-  const output = yield* encodeJson(report).pipe(
-    Effect.mapError((cause) =>
-      qualificationAuditCommandError('audit', 'qualification audit output encoding failed', cause),
-    ),
-  )
+  return { input, report }
+})
+
+export const collectQualificationAuditReport = collectQualificationAuditOutput.pipe(
+  Effect.flatMap(({ report }) => requireQualificationAuditReport(report)),
+)
+
+const main = Effect.gen(function* () {
+  const { input, report } = yield* collectQualificationAuditOutput
+  const output = yield* renderQualificationAuditCommandOutput(report)
   const stdio = yield* Stdio.Stdio
-  yield* Stream.run(Stream.make(`${output}\n`), stdio.stdout())
-  if (input.output === 'audit' && 'status' in report && report.status !== 'PASS') {
-    return yield* qualificationAuditCommandError('audit', 'qualification audit failed')
-  }
+  yield* Stream.run(Stream.make(output), stdio.stdout())
+  yield* completeQualificationAuditCommand(input, report)
 })
 
 const runtime = Layer.mergeAll(Logger.layer([Logger.consoleJson]), NodeServices.layer, Reactivity.layer)

--- a/services/bayn/src/qualification-candidate-command.test.ts
+++ b/services/bayn/src/qualification-candidate-command.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, test } from 'bun:test'
+import { Effect } from 'effect'
+
+import type { ApplicationIdentity } from './app'
+import { config, fixtureLock, fixtureSnapshot, fixtureStrategy, provenance } from './app-test-support'
+import type { CandidateDevelopmentNextPreregistration } from './candidate-development-calendar'
+import type { LoadedRuntimeConfig } from './config'
+import { BrokerAccess, noCapitalAuthority } from './execution/authority'
+import { marketDataService } from './app-test-support'
+import { verifyQualificationCandidateBinding } from './qualification-candidate-command'
+import { fixtureProtocol } from './test-fixtures'
+
+const inspection = Effect.runSync(marketDataService(Effect.succeed(fixtureSnapshot)).inspect)
+const compiledBoundedContentHash = '2'.repeat(64)
+
+const loadedConfig: LoadedRuntimeConfig = {
+  ...config,
+  runtimeMode: 'BrokerlessService',
+  cyclePollIntervalMs: 30_000,
+  alpaca: undefined,
+  execution: {
+    brokerAccess: BrokerAccess.ReadOnly,
+    capitalAuthority: noCapitalAuthority,
+  },
+}
+
+const identity: ApplicationIdentity = {
+  config: loadedConfig,
+  protocol: fixtureProtocol,
+  parameterHash: provenance.strategy.parameterHash,
+  strategy: fixtureStrategy,
+  strategyProtocolHash: fixtureLock.protocolHash,
+}
+
+const preregistration = (
+  overrides: Partial<CandidateDevelopmentNextPreregistration> = {},
+): CandidateDevelopmentNextPreregistration => ({
+  schemaVersion: 'bayn.candidate-development-next-preregistration.v1',
+  candidateOrdinal: 1,
+  priorTrialCount: 0,
+  strategyProtocolHash: identity.strategyProtocolHash,
+  modulePath: 'services/bayn/src/strategy/candidate-17.ts',
+  moduleSha256: '1'.repeat(64),
+  marketData: {
+    schemaVersion: 'bayn.candidate-development-market-data-source.v1',
+    snapshotId: fixtureSnapshot.manifest.finalizedSnapshot.snapshotId,
+    finalizedSnapshotContentHash: fixtureSnapshot.manifest.finalizedSnapshot.contentHash,
+    inputManifestHash: fixtureSnapshot.manifest.hash,
+    boundedContentHash: compiledBoundedContentHash,
+  },
+  preregistration: {
+    sourceRevision: '3'.repeat(40),
+    path: 'services/bayn/candidates/candidate-17-preregistration.json',
+    blobOid: '4'.repeat(40),
+  },
+  ...overrides,
+})
+
+describe('qualification candidate metadata binding', () => {
+  test('prepares the exact production lock from immutable metadata without loading bars or writing', () => {
+    const result = verifyQualificationCandidateBinding(
+      preregistration(),
+      compiledBoundedContentHash,
+      identity,
+      inspection,
+      [],
+    )
+
+    expect(result._tag).toBe('Success')
+    if (result._tag === 'Success') {
+      expect(result.success).toMatchObject({
+        schemaVersion: 'bayn.qualification-candidate-binding.v1',
+        candidateOrdinal: 1,
+        priorTrialCount: 0,
+        sourceRevision: config.build.sourceRevision,
+        imageRepository: config.build.imageRepository,
+        imageDigest: config.build.imageDigest,
+        snapshotId: fixtureSnapshot.manifest.finalizedSnapshot.snapshotId,
+        inputManifestHash: fixtureSnapshot.manifest.hash,
+        finalizedSnapshotContentHash: fixtureSnapshot.manifest.finalizedSnapshot.contentHash,
+        committedBoundedContentHash: compiledBoundedContentHash,
+        compiledBoundedContentHash,
+        candidateRunId: fixtureLock.candidateRunId,
+        lockId: fixtureLock.lockId,
+      })
+      expect(result.success.bindingHash).toMatch(/^[0-9a-f]{64}$/)
+      expect(result.success.lock).toEqual(fixtureLock)
+    }
+  })
+
+  test('rejects a preregistered bounded dataset that differs from the compiled candidate protocol before lock preparation', () => {
+    const result = verifyQualificationCandidateBinding(preregistration(), 'a'.repeat(64), identity, inspection, [])
+
+    expect(result).toMatchObject({
+      _tag: 'Failure',
+      failure: {
+        _tag: 'QualificationCandidateBindingMismatch',
+        field: 'marketData.boundedContentHash',
+        expected: 'a'.repeat(64),
+        observed: compiledBoundedContentHash,
+      },
+    })
+  })
+
+  test.each([
+    ['ordinal lineage', preregistration({ candidateOrdinal: 2 }), [], 'preregistration.candidateOrdinal'],
+    ['database trial lineage', preregistration(), ['5'.repeat(64)], 'database.priorTrialCount'],
+    ['strategy protocol', preregistration({ strategyProtocolHash: '6'.repeat(64) }), [], 'strategyProtocolHash'],
+    [
+      'snapshot identity',
+      preregistration({
+        marketData: { ...preregistration().marketData, snapshotId: '0'.repeat(64) },
+      }),
+      [],
+      'marketData.snapshotId',
+    ],
+    [
+      'finalized content',
+      preregistration({
+        marketData: { ...preregistration().marketData, finalizedSnapshotContentHash: '8'.repeat(64) },
+      }),
+      [],
+      'marketData.finalizedSnapshotContentHash',
+    ],
+    [
+      'input manifest',
+      preregistration({
+        marketData: { ...preregistration().marketData, inputManifestHash: '9'.repeat(64) },
+      }),
+      [],
+      'marketData.inputManifestHash',
+    ],
+  ] as const)('rejects changed %s before a lock can be requested', (_name, registration, priorTrials, field) => {
+    const result = verifyQualificationCandidateBinding(
+      registration,
+      compiledBoundedContentHash,
+      identity,
+      inspection,
+      priorTrials,
+    )
+
+    expect(result).toMatchObject({
+      _tag: 'Failure',
+      failure: { _tag: 'QualificationCandidateBindingMismatch', field },
+    })
+  })
+})

--- a/services/bayn/src/qualification-candidate-command.ts
+++ b/services/bayn/src/qualification-candidate-command.ts
@@ -1,8 +1,156 @@
 import { NodeRuntime, NodeServices } from '@effect/platform-node'
-import { Effect, Layer } from 'effect'
+import { Effect, Layer, Result } from 'effect'
 import * as Reactivity from 'effect/unstable/reactivity/Reactivity'
 
+import type { ApplicationIdentity } from './app'
+import type { CandidateDevelopmentNextPreregistration } from './candidate-development-calendar'
+import { canonicalHashV1Result } from './hash'
+import type { MarketDataInspection } from './market-data'
+import type { QualificationLock } from './qualification'
 import { qualificationCandidateMain } from './qualification-candidate/program'
+import { prepareQualificationLock } from './startup/decisions'
+
+export type QualificationCandidateBindingFailure =
+  | {
+      readonly _tag: 'QualificationCandidateBindingMismatch'
+      readonly field: string
+      readonly expected: unknown
+      readonly observed: unknown
+    }
+  | {
+      readonly _tag: 'QualificationCandidateLockPreparationFailed'
+      readonly cause: unknown
+    }
+  | {
+      readonly _tag: 'QualificationCandidateBindingHashFailed'
+      readonly cause: unknown
+    }
+
+export interface QualificationCandidateBindingReceipt {
+  readonly schemaVersion: 'bayn.qualification-candidate-binding.v1'
+  readonly candidateOrdinal: number
+  readonly priorTrialCount: number
+  readonly sourceRevision: string
+  readonly imageRepository: string
+  readonly imageDigest: string
+  readonly snapshotId: string
+  readonly inputManifestHash: string
+  readonly finalizedSnapshotContentHash: string
+  readonly committedBoundedContentHash: string
+  readonly compiledBoundedContentHash: string
+  readonly candidateRunId: string
+  readonly lockId: string
+  readonly bindingHash: string
+  readonly lock: QualificationLock
+}
+
+const mismatch = (
+  field: string,
+  expected: unknown,
+  observed: unknown,
+): Result.Result<never, QualificationCandidateBindingFailure> =>
+  Result.fail({
+    _tag: 'QualificationCandidateBindingMismatch',
+    field,
+    expected,
+    observed,
+  })
+
+/**
+ * Metadata-only candidate command used by the unattended collector before the
+ * production startup path opens the durable qualification lock. It never loads
+ * bars, touches TigerBeetle, or writes PostgreSQL.
+ */
+export const verifyQualificationCandidateBinding = (
+  preregistration: CandidateDevelopmentNextPreregistration,
+  compiledBoundedContentHash: string,
+  identity: ApplicationIdentity,
+  inspection: MarketDataInspection,
+  priorTrialRunIds: readonly string[],
+): Result.Result<QualificationCandidateBindingReceipt, QualificationCandidateBindingFailure> =>
+  Result.gen(function* () {
+    if (preregistration.candidateOrdinal !== preregistration.priorTrialCount + 1) {
+      return yield* mismatch(
+        'preregistration.candidateOrdinal',
+        preregistration.priorTrialCount + 1,
+        preregistration.candidateOrdinal,
+      )
+    }
+    if (priorTrialRunIds.length !== preregistration.priorTrialCount) {
+      return yield* mismatch('database.priorTrialCount', preregistration.priorTrialCount, priorTrialRunIds.length)
+    }
+    if (identity.strategyProtocolHash !== preregistration.strategyProtocolHash) {
+      return yield* mismatch(
+        'strategyProtocolHash',
+        preregistration.strategyProtocolHash,
+        identity.strategyProtocolHash,
+      )
+    }
+    if (preregistration.marketData.boundedContentHash !== compiledBoundedContentHash) {
+      return yield* mismatch(
+        'marketData.boundedContentHash',
+        compiledBoundedContentHash,
+        preregistration.marketData.boundedContentHash,
+      )
+    }
+
+    const manifest = inspection.manifest
+    const snapshot = manifest.finalizedSnapshot
+    for (const [field, expected, observed] of [
+      ['marketData.snapshotId', preregistration.marketData.snapshotId, snapshot.snapshotId],
+      [
+        'marketData.finalizedSnapshotContentHash',
+        preregistration.marketData.finalizedSnapshotContentHash,
+        snapshot.contentHash,
+      ],
+      ['marketData.inputManifestHash', preregistration.marketData.inputManifestHash, manifest.hash],
+    ] as const) {
+      if (expected !== observed) return yield* mismatch(field, expected, observed)
+    }
+
+    const lock = yield* Result.mapError(
+      prepareQualificationLock(identity.strategy, inspection, priorTrialRunIds),
+      (cause): QualificationCandidateBindingFailure => ({
+        _tag: 'QualificationCandidateLockPreparationFailed',
+        cause,
+      }),
+    )
+    for (const [field, expected, observed] of [
+      ['lock.sourceRevision', identity.config.build.sourceRevision, lock.sourceRevision],
+      ['lock.image.repository', identity.config.build.imageRepository, lock.image.repository],
+      ['lock.image.digest', identity.config.build.imageDigest, lock.image.digest],
+      ['lock.protocolHash', identity.strategyProtocolHash, lock.protocolHash],
+      ['lock.data.snapshotId', preregistration.marketData.snapshotId, lock.data.snapshotId],
+      ['lock.data.inputManifestHash', preregistration.marketData.inputManifestHash, lock.data.inputManifestHash],
+      ['lock.data.contentHash', preregistration.marketData.finalizedSnapshotContentHash, lock.data.contentHash],
+    ] as const) {
+      if (expected !== observed) return yield* mismatch(field, expected, observed)
+    }
+
+    const material = {
+      schemaVersion: 'bayn.qualification-candidate-binding.v1' as const,
+      candidateOrdinal: preregistration.candidateOrdinal,
+      priorTrialCount: preregistration.priorTrialCount,
+      sourceRevision: identity.config.build.sourceRevision,
+      imageRepository: identity.config.build.imageRepository,
+      imageDigest: identity.config.build.imageDigest,
+      snapshotId: snapshot.snapshotId,
+      inputManifestHash: manifest.hash,
+      finalizedSnapshotContentHash: snapshot.contentHash,
+      committedBoundedContentHash: preregistration.marketData.boundedContentHash,
+      compiledBoundedContentHash,
+      candidateRunId: lock.candidateRunId,
+      lockId: lock.lockId,
+    }
+    const bindingHash = yield* Result.mapError(
+      canonicalHashV1Result(material),
+      (cause): QualificationCandidateBindingFailure => ({
+        _tag: 'QualificationCandidateBindingHashFailed',
+        cause,
+      }),
+    )
+    return { ...material, bindingHash, lock }
+  })
 
 if (import.meta.main) {
   NodeRuntime.runMain(

--- a/services/bayn/src/qualification-collector-command.test.ts
+++ b/services/bayn/src/qualification-collector-command.test.ts
@@ -1,0 +1,687 @@
+import { describe, expect, test } from 'bun:test'
+import { createHash } from 'node:crypto'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { Effect, Option } from 'effect'
+
+import type { QualificationAuditReport } from './audit/audit'
+import type { QualificationDossier } from './audit/dossier'
+import {
+  completeQualificationAuditCommand,
+  QualificationAuditCommandError,
+  renderQualificationAuditCommandOutput,
+  requireQualificationAuditReport,
+} from './qualification-audit-command'
+import {
+  blockingQualificationWorkflowRunIds,
+  executeQualificationAttempt,
+  freezeQualificationPrelockDependencies,
+  isQualificationSourceAffectingPath,
+  loadQualificationCollectorInvocation,
+  missingQualificationWiring,
+  qualificationAttemptState,
+  QualificationCollectorError,
+  runQualificationCollector,
+  verifyQualificationCandidateImmutableSource,
+  type QualificationCollectorExecutionReceipt,
+  type QualificationCollectorPrelockEvidence,
+} from './qualification-collector-command'
+import type { CandidateDevelopmentNextPreregistration } from './candidate-development-calendar'
+import type { QualificationCandidateBindingReceipt } from './qualification-candidate-command'
+import {
+  config,
+  fixtureEvaluation,
+  fixtureQualification,
+  fixtureLock,
+  fixtureSnapshot,
+  fixtureStrategy,
+  marketDataService,
+  provenance,
+  readyState,
+  successfulEvidenceStore,
+  successfulJournal,
+} from './app-test-support'
+import type { LoadedRuntimeConfig } from './config'
+import { BrokerAccess, noCapitalAuthority } from './execution/authority'
+import { canonicalHashV1 } from './hash'
+import { fixtureProtocol } from './test-fixtures'
+
+const prelock = (
+  overrides: Partial<QualificationCollectorPrelockEvidence> = {},
+): QualificationCollectorPrelockEvidence => ({
+  schemaVersion: 'bayn.qualification-collector-prelock.v1',
+  repository: 'proompteng/lab',
+  currentMainSha: '0'.repeat(40),
+  sourceSha: 'a'.repeat(40),
+  imageRepository: 'registry.ide-newton.ts.net/lab/bayn',
+  imageDigest: `sha256:${'b'.repeat(64)}`,
+  strategyBehaviorHash: 'c'.repeat(64),
+  strategyParameterHash: 'd'.repeat(64),
+  candidateOrdinal: 17,
+  priorTrialCount: 16,
+  preregistrationHash: 'e'.repeat(64),
+  moduleBlobOid: '7'.repeat(40),
+  candidateDefinitionHash: '8'.repeat(64),
+  compiledBoundedContentHash: '3'.repeat(64),
+  activeAttemptRunIds: [],
+  githubRunId: '123456',
+  githubRunAttempt: 1,
+  ...overrides,
+})
+
+const candidate = (input = prelock()): QualificationCandidateBindingReceipt => ({
+  schemaVersion: 'bayn.qualification-candidate-binding.v1',
+  candidateOrdinal: input.candidateOrdinal,
+  priorTrialCount: input.priorTrialCount,
+  sourceRevision: input.sourceSha,
+  imageRepository: input.imageRepository,
+  imageDigest: input.imageDigest,
+  snapshotId: 'f'.repeat(64),
+  inputManifestHash: '1'.repeat(64),
+  finalizedSnapshotContentHash: '2'.repeat(64),
+  committedBoundedContentHash: input.compiledBoundedContentHash,
+  compiledBoundedContentHash: input.compiledBoundedContentHash,
+  candidateRunId: '4'.repeat(64),
+  lockId: '5'.repeat(64),
+  bindingHash: '6'.repeat(64),
+  lock: fixtureLock,
+})
+
+const execution = (binding = candidate()): QualificationCollectorExecutionReceipt => ({
+  schemaVersion: 'bayn.qualification-execution.v1',
+  runId: binding.candidateRunId,
+  lockId: binding.lockId,
+  resultHash: '7'.repeat(64),
+  verdict: 'REJECTED',
+  persistence: { artifactCount: 17, eventCount: 230, gateCount: 7 },
+})
+
+const audit = (receipt = execution()): QualificationAuditReport => ({
+  schemaVersion: 'bayn.qualification-audit.v2',
+  runId: receipt.runId,
+  status: 'PASS',
+  reference: { economicStatus: 'FAIL_CLOSED', observations: 1_000, rebalanceCount: 100 },
+  evidence: {
+    artifactCount: receipt.persistence.artifactCount,
+    eventCount: receipt.persistence.eventCount,
+    gateCount: receipt.persistence.gateCount,
+    lockId: receipt.lockId,
+    resultHash: receipt.resultHash,
+  },
+  policies: {
+    declaredAt: '2026-07-31T00:00:00.000Z',
+    lockId: receipt.lockId,
+    policySetHash: '8'.repeat(64),
+    documents: [],
+  },
+  contamination: {
+    lockCreatedAt: '2026-07-31T00:00:00.000000Z',
+    resultCommittedAt: '2026-07-31T00:01:00.000000Z',
+    replicas: ['replica-0', 'replica-1'],
+    principals: { candidate: 'signal-publisher', publishers: ['signal-publisher'] },
+    access: [],
+  },
+  repository: {
+    sourceRevision: prelock().sourceSha,
+    sourceCommitExists: true,
+    sourceCommitAncestorOfMain: true,
+    preLockResultReferences: [],
+  },
+  checks: [],
+  auditHash: '9'.repeat(64),
+})
+
+const loadedConfig: LoadedRuntimeConfig = {
+  ...config,
+  runtimeMode: 'BrokerlessService',
+  cyclePollIntervalMs: 30_000,
+  alpaca: undefined,
+  execution: {
+    brokerAccess: BrokerAccess.ReadOnly,
+    capitalAuthority: noCapitalAuthority,
+  },
+}
+
+const plan = {
+  _tag: 'BrokerlessService' as const,
+  config: loadedConfig,
+  protocol: fixtureProtocol,
+  parameterHash: provenance.strategy.parameterHash,
+  strategy: fixtureStrategy,
+  strategyProtocolHash: fixtureLock.protocolHash,
+}
+
+const collectorCommandPath = new URL('./qualification-collector-command.ts', import.meta.url).pathname
+const typedConfigurationSecret = 'typed-configuration-secret-marker'
+
+const runCollectorEntrypoint = async (environment: Record<string, string>) => {
+  const child = Bun.spawn({
+    cmd: [process.execPath, collectorCommandPath],
+    cwd: import.meta.dir,
+    env: environment,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+  const [exitCode, stdout, stderr] = await Promise.all([
+    child.exited,
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+  ])
+  return { exitCode, stdout, stderr }
+}
+
+const gitText = async (cwd: string, args: readonly string[]): Promise<string> => {
+  const child = Bun.spawn({ cmd: ['git', ...args], cwd, stdout: 'pipe', stderr: 'pipe' })
+  const [exitCode, stdout, stderr] = await Promise.all([
+    child.exited,
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+  ])
+  if (exitCode !== 0) throw new Error(`git ${args.join(' ')} failed: ${stderr}`)
+  return stdout.trim()
+}
+
+const immutableSourceFixture = async (
+  options: { readonly malformed?: boolean; readonly preexisting?: boolean } = {},
+) => {
+  const repositoryPath = await mkdtemp(join(tmpdir(), 'bayn-qualification-source-'))
+  const modulePath = 'services/bayn/src/strategy/candidate-17.mjs'
+  const preregistrationPath = 'services/bayn/candidates/candidate-17-preregistration.json'
+  const compiledBoundedContentHash = 'a'.repeat(64)
+  const strategyProtocol = {
+    schemaVersion: 'bayn.candidate-development-strategy-protocol.v2',
+    marketData: {
+      schemaVersion: 'bayn.candidate-development-market-data-contract.v1',
+      snapshotId: 'b'.repeat(64),
+      contentHash: compiledBoundedContentHash,
+    },
+  }
+  const strategyProtocolHash = canonicalHashV1(strategyProtocol)
+  const moduleSource = `
+    export const candidateDevelopmentArtifact = {
+      schemaVersion: 'bayn.candidate-development-artifact.v1',
+      input: {
+        candidateOrdinal: 17,
+        priorTrialCount: 16,
+        expectedStrategyProtocolHash: '${strategyProtocolHash}',
+        officialSessions: [],
+        signalSessionDates: [],
+        featureLookbackSessions: 252,
+      },
+      strategyProtocol: ${JSON.stringify(strategyProtocol)},
+      buildEvaluation: function () { throw new Error('qualification source verification must not evaluate holdout data') },
+    }
+  `
+  const moduleBytes = Buffer.from(moduleSource)
+  const moduleSha256 = createHash('sha256').update(moduleBytes).digest('hex')
+  const marketData = {
+    schemaVersion: 'bayn.candidate-development-market-data-source.v1' as const,
+    snapshotId: strategyProtocol.marketData.snapshotId,
+    finalizedSnapshotContentHash: 'c'.repeat(64),
+    inputManifestHash: 'd'.repeat(64),
+    boundedContentHash: compiledBoundedContentHash,
+  }
+  const document = {
+    schemaVersion: 'bayn.candidate-development-next-preregistration.v1' as const,
+    candidateOrdinal: 17,
+    priorTrialCount: 16,
+    strategyProtocolHash,
+    modulePath,
+    moduleSha256,
+    marketData,
+  }
+  const preregistrationBytes = Buffer.from(options.malformed === true ? '{' : `${JSON.stringify(document)}\n`)
+
+  await gitText(repositoryPath, ['init', '-b', 'main'])
+  await gitText(repositoryPath, ['config', 'user.email', 'qualification-test@example.invalid'])
+  await gitText(repositoryPath, ['config', 'user.name', 'Qualification Test'])
+  await mkdir(join(repositoryPath, dirname(preregistrationPath)), { recursive: true })
+  await writeFile(join(repositoryPath, preregistrationPath), preregistrationBytes)
+  if (options.preexisting === true) {
+    const preexistingPath = join(repositoryPath, 'history', 'preexisting-candidate.mjs')
+    await mkdir(dirname(preexistingPath), { recursive: true })
+    await writeFile(preexistingPath, moduleBytes)
+  }
+  await gitText(repositoryPath, ['add', '.'])
+  await gitText(repositoryPath, ['commit', '-m', 'preregister candidate'])
+  const preregistrationRevision = await gitText(repositoryPath, ['rev-parse', 'HEAD'])
+  const preregistrationBlobOid = await gitText(repositoryPath, ['rev-parse', `HEAD:${preregistrationPath}`])
+  await mkdir(join(repositoryPath, dirname(modulePath)), { recursive: true })
+  await writeFile(join(repositoryPath, modulePath), moduleBytes)
+  await gitText(repositoryPath, ['add', modulePath])
+  await gitText(repositoryPath, ['commit', '-m', 'add candidate module'])
+  const sourceRevision = await gitText(repositoryPath, ['rev-parse', 'HEAD'])
+  const moduleBlobOid = await gitText(repositoryPath, ['rev-parse', `HEAD:${modulePath}`])
+  const preregistration: CandidateDevelopmentNextPreregistration = {
+    ...document,
+    preregistration: {
+      sourceRevision: preregistrationRevision,
+      path: preregistrationPath,
+      blobOid: preregistrationBlobOid,
+    },
+  }
+  return {
+    repositoryPath,
+    compiledBoundedContentHash,
+    input: {
+      repositoryPath,
+      sourceRevision,
+      preregistration,
+      preregistrationBytes,
+      moduleBlobOid,
+      moduleBytes,
+    },
+    cleanup: () => rm(repositoryPath, { recursive: true, force: true }),
+  }
+}
+
+describe('qualification collector orchestration', () => {
+  test.each([
+    ['GITHUB_EVENT_NAME', { GITHUB_SHA: 'a'.repeat(40) }, 'GITHUB_EVENT_NAME is required'],
+    ['GITHUB_SHA', { GITHUB_EVENT_NAME: 'schedule' }, 'GITHUB_SHA is required'],
+  ] as const)(
+    'returns missing %s as a typed failure and lets NodeRuntime own nonzero termination',
+    async (_name, overrides, message) => {
+      const environment = {
+        PATH: process.env.PATH ?? '',
+        HOME: process.env.HOME ?? '',
+        BAYN_POSTGRES_URL: `postgresql://${typedConfigurationSecret}@invalid/bayn`,
+        ...overrides,
+      }
+      const failure = await Effect.runPromise(Effect.flip(loadQualificationCollectorInvocation(environment)))
+      const result = await runCollectorEntrypoint(environment)
+      const output = `${result.stdout}\n${result.stderr}`
+
+      expect(failure).toBeInstanceOf(QualificationCollectorError)
+      expect(failure).toMatchObject({
+        phase: 'configuration',
+        code: 'environment-missing',
+        message,
+      })
+      expect(result.exitCode).toBe(1)
+      expect(output).toContain(`qualification collector failed [configuration/environment-missing]: ${message}`)
+      expect(output).toContain(`QualificationCollectorError: ${message}`)
+      expect(output).not.toContain('BAYN_QUALIFICATION_TERMINAL=')
+      expect(output).not.toContain(typedConfigurationSecret)
+    },
+  )
+
+  test('accepts a reviewed preregistration document and a module blob created only after preregistration', async () => {
+    const fixture = await immutableSourceFixture()
+    try {
+      const receipt = await Effect.runPromise(verifyQualificationCandidateImmutableSource(fixture.input))
+
+      expect(receipt).toMatchObject({
+        schemaVersion: 'bayn.qualification-candidate-source.v1',
+        moduleBlobOid: fixture.input.moduleBlobOid,
+        compiledBoundedContentHash: fixture.compiledBoundedContentHash,
+      })
+      expect(receipt.definitionHash).toMatch(/^[0-9a-f]{64}$/)
+    } finally {
+      await fixture.cleanup()
+    }
+  })
+
+  test('rejects a malformed reviewed preregistration document before module or privileged access', async () => {
+    const fixture = await immutableSourceFixture({ malformed: true })
+    try {
+      const failure = await Effect.runPromise(Effect.flip(verifyQualificationCandidateImmutableSource(fixture.input)))
+
+      expect(failure).toBeInstanceOf(QualificationCollectorError)
+      expect(failure).toMatchObject({
+        phase: 'candidate',
+        code: 'preregistration-document-malformed',
+      })
+    } finally {
+      await fixture.cleanup()
+    }
+  })
+
+  test('rejects reviewed preregistration bytes whose module or data binding differs from the compiled calendar entry', async () => {
+    const fixture = await immutableSourceFixture()
+    try {
+      const mismatched = {
+        ...fixture.input,
+        preregistration: {
+          ...fixture.input.preregistration,
+          marketData: {
+            ...fixture.input.preregistration.marketData,
+            boundedContentHash: 'f'.repeat(64),
+          },
+        },
+      }
+      const failure = await Effect.runPromise(Effect.flip(verifyQualificationCandidateImmutableSource(mismatched)))
+
+      expect(failure).toBeInstanceOf(QualificationCollectorError)
+      expect(failure).toMatchObject({
+        phase: 'candidate',
+        code: 'preregistration-document-invalid',
+      })
+    } finally {
+      await fixture.cleanup()
+    }
+  })
+
+  test('rejects a candidate module blob that was already reachable at preregistration', async () => {
+    const fixture = await immutableSourceFixture({ preexisting: true })
+    try {
+      const failure = await Effect.runPromise(Effect.flip(verifyQualificationCandidateImmutableSource(fixture.input)))
+
+      expect(failure).toBeInstanceOf(QualificationCollectorError)
+      expect(failure).toMatchObject({
+        phase: 'candidate',
+        code: 'candidate-module-not-novel',
+      })
+    } finally {
+      await fixture.cleanup()
+    }
+  })
+
+  test('standalone dossier mode renders the deliberate dossier output without report-only rejection', async () => {
+    const dossier = {
+      schemaVersion: 'bayn.qualification-dossier.v2',
+      dossierHash: 'a'.repeat(64),
+    } as unknown as QualificationDossier
+
+    const output = await Effect.runPromise(renderQualificationAuditCommandOutput(dossier))
+
+    expect(output.endsWith('\n')).toBe(true)
+    expect(JSON.parse(output)).toEqual({
+      schemaVersion: 'bayn.qualification-dossier.v2',
+      dossierHash: 'a'.repeat(64),
+    })
+  })
+
+  test('collector report-only boundary rejects a dossier before terminal evidence can be emitted', async () => {
+    const dossier = {
+      schemaVersion: 'bayn.qualification-dossier.v2',
+      dossierHash: 'b'.repeat(64),
+    } as unknown as QualificationDossier
+
+    const failure = await Effect.runPromise(Effect.flip(requireQualificationAuditReport(dossier)))
+
+    expect(failure).toBeInstanceOf(QualificationAuditCommandError)
+    expect(failure.message).toBe('qualification audit command produced a dossier')
+  })
+
+  test('standalone failed audits render their JSON evidence before nonzero completion', async () => {
+    const failed = { ...audit(), status: 'FAIL' as const }
+
+    const output = await Effect.runPromise(renderQualificationAuditCommandOutput(failed))
+    const failure = await Effect.runPromise(Effect.flip(completeQualificationAuditCommand({ output: 'audit' }, failed)))
+
+    expect(JSON.parse(output)).toMatchObject({
+      schemaVersion: 'bayn.qualification-audit.v2',
+      status: 'FAIL',
+      runId: failed.runId,
+      auditHash: failed.auditHash,
+    })
+    expect(failure.message).toBe('qualification audit failed')
+  })
+
+  test('distinguishes fresh, terminal-recoverable, and incomplete durable attempt states', async () => {
+    expect(await Effect.runPromise(qualificationAttemptState(Option.none()))).toBe('FRESH')
+    expect(
+      await Effect.runPromise(
+        qualificationAttemptState(Option.some({ state: 'TERMINAL', lock: fixtureLock, result: fixtureQualification })),
+      ),
+    ).toBe('RECOVER_TERMINAL')
+    const failure = await Effect.runPromise(
+      Effect.flip(qualificationAttemptState(Option.some({ state: 'OPENED_INCOMPLETE', lock: fixtureLock }))),
+    )
+    expect(failure.code).toBe('qualification-opened-incomplete')
+  })
+
+  test('recovers and re-audits a terminal retry without loading holdout bars again', async () => {
+    let loadCalls = 0
+    const inspection = await Effect.runPromise(marketDataService(Effect.succeed(fixtureSnapshot)).inspect)
+    const recovered = readyState().evidence
+    if (recovered === null) throw new Error('fixture recovered evidence is missing')
+    const terminalStore = {
+      ...successfulEvidenceStore,
+      readQualification: () =>
+        Effect.succeed(Option.some({ state: 'TERMINAL' as const, lock: fixtureLock, result: fixtureQualification })),
+      openQualification: () =>
+        Effect.succeed({ state: 'TERMINAL' as const, lock: fixtureLock, result: fixtureQualification }),
+      recover: () =>
+        Effect.succeed(
+          Option.some({
+            evaluation: recovered.evaluation,
+            reconciliation: recovered.reconciliation,
+            persistence: recovered.persistence,
+          }),
+        ),
+    }
+    const receipt = await Effect.runPromise(
+      executeQualificationAttempt(
+        {
+          plan,
+          inspection,
+          priorTrialRunIds: [],
+          dependencies: {
+            marketData: {
+              ...marketDataService(
+                Effect.sync(() => {
+                  loadCalls += 1
+                  return fixtureSnapshot
+                }),
+              ),
+              inspect: Effect.succeed(inspection),
+            },
+            journal: successfulJournal,
+            evidenceStore: terminalStore,
+          },
+        },
+        {
+          ...candidate(prelock({ priorTrialCount: 0, candidateOrdinal: 1 })),
+          candidateOrdinal: 1,
+          priorTrialCount: 0,
+          candidateRunId: fixtureLock.candidateRunId,
+          lockId: fixtureLock.lockId,
+          lock: fixtureLock,
+        },
+      ),
+    )
+
+    expect(loadCalls).toBe(0)
+    expect(receipt).toMatchObject({
+      runId: fixtureEvaluation.runId,
+      lockId: fixtureQualification.lockId,
+      resultHash: fixtureQualification.resultHash,
+      verdict: fixtureQualification.verdict,
+    })
+  })
+
+  test('collects, verifies, executes, and independently audits exactly once in causal order', async () => {
+    const calls: string[] = []
+    const input = prelock()
+    const binding = candidate(input)
+    const terminal = execution(binding)
+
+    const result = await Effect.runPromise(
+      runQualificationCollector({
+        collectPrelock: Effect.sync(() => {
+          calls.push('collect')
+          return input
+        }),
+        verifyCandidate: () =>
+          Effect.sync(() => {
+            calls.push('candidate')
+            return binding
+          }),
+        executeQualification: () =>
+          Effect.sync(() => {
+            calls.push('execute')
+            return terminal
+          }),
+        auditQualification: () =>
+          Effect.sync(() => {
+            calls.push('audit')
+            return audit(terminal)
+          }),
+      }),
+    )
+
+    expect(calls).toEqual(['collect', 'candidate', 'execute', 'audit'])
+    expect(result).toMatchObject({
+      schemaVersion: 'bayn.qualification-collector-terminal.v1',
+      sourceSha: input.sourceSha,
+      candidateOrdinal: input.candidateOrdinal,
+      terminal,
+      audit: { status: 'PASS', runId: terminal.runId },
+    })
+    expect(result.eligibilityHash).toMatch(/^[0-9a-f]{64}$/)
+    expect(result.evidenceHash).toMatch(/^[0-9a-f]{64}$/)
+  })
+
+  test('rejects an in-flight workflow before candidate verification or qualification execution', async () => {
+    const calls: string[] = []
+    const failure = await Effect.runPromise(
+      Effect.flip(
+        runQualificationCollector({
+          collectPrelock: Effect.succeed(prelock({ activeAttemptRunIds: ['other-run'] })),
+          verifyCandidate: () =>
+            Effect.sync(() => {
+              calls.push('candidate')
+              return candidate()
+            }),
+          executeQualification: () =>
+            Effect.sync(() => {
+              calls.push('execute')
+              return execution()
+            }),
+          auditQualification: () => Effect.succeed(audit()),
+        }),
+      ),
+    )
+
+    expect(calls).toEqual([])
+    expect(failure).toMatchObject({
+      _tag: 'QualificationCollectorError',
+      phase: 'eligibility',
+      code: 'qualification-attempt-in-flight',
+    })
+  })
+
+  test.each([
+    [
+      'candidate binding',
+      { candidateOrdinal: 18 } as Partial<QualificationCandidateBindingReceipt>,
+      {} as Partial<QualificationCollectorExecutionReceipt>,
+      {} as Partial<QualificationAuditReport>,
+      'candidate-binding-mismatch',
+    ],
+    [
+      'terminal lock',
+      {} as Partial<QualificationCandidateBindingReceipt>,
+      { lockId: 'a'.repeat(64) } as Partial<QualificationCollectorExecutionReceipt>,
+      {} as Partial<QualificationAuditReport>,
+      'terminal-binding-mismatch',
+    ],
+    [
+      'audit result',
+      {} as Partial<QualificationCandidateBindingReceipt>,
+      {} as Partial<QualificationCollectorExecutionReceipt>,
+      { evidence: { ...audit().evidence, resultHash: 'b'.repeat(64) } } as Partial<QualificationAuditReport>,
+      'terminal-audit-mismatch',
+    ],
+  ])('fails closed on changed %s', async (_name, candidatePatch, executionPatch, auditPatch, code) => {
+    const input = prelock()
+    const binding = { ...candidate(input), ...candidatePatch }
+    const terminal = { ...execution(binding), ...executionPatch }
+    const report = { ...audit(terminal), ...auditPatch } as QualificationAuditReport
+    const failure = await Effect.runPromise(
+      Effect.flip(
+        runQualificationCollector({
+          collectPrelock: Effect.succeed(input),
+          verifyCandidate: () => Effect.succeed(binding),
+          executeQualification: () => Effect.succeed(terminal),
+          auditQualification: () => Effect.succeed(report),
+        }),
+      ),
+    )
+
+    expect(failure).toBeInstanceOf(QualificationCollectorError)
+    expect(failure.code).toBe(code)
+  })
+
+  test('names the exact separately authorized secret wiring and accepts no implicit aliases', () => {
+    expect(missingQualificationWiring({})).toEqual([
+      'GITHUB_TOKEN',
+      'BAYN_CLICKHOUSE_USERNAME',
+      'BAYN_CLICKHOUSE_PASSWORD',
+      'BAYN_POSTGRES_URL',
+      'BAYN_QUALIFICATION_POSTGRES_CA_PEM',
+      'BAYN_AUDIT_SIGNAL_PUBLISHER_USERNAME',
+      'BAYN_AUDIT_CLICKHOUSE_USERNAME',
+      'BAYN_AUDIT_CLICKHOUSE_PASSWORD',
+    ])
+    const configured = Object.fromEntries(
+      missingQualificationWiring({}).map((name) => [name, `${name.toLowerCase()}-configured`]),
+    )
+    expect(missingQualificationWiring(configured)).toEqual([])
+  })
+
+  test('freezes the exact prelock inspection and trial lineage while delegating the post-lock load', async () => {
+    let underlyingInspections = 0
+    let underlyingLineageReads = 0
+    const underlyingMarketData = {
+      ...marketDataService(Effect.succeed(fixtureSnapshot)),
+      inspect: Effect.sync(() => {
+        underlyingInspections += 1
+        throw new Error('frozen prelock inspection must be reused')
+      }),
+    }
+    const underlyingEvidenceStore = {
+      ...successfulEvidenceStore,
+      listPriorTrials: Effect.sync(() => {
+        underlyingLineageReads += 1
+        throw new Error('frozen trial lineage must be reused')
+      }),
+    }
+    const capturedInspection = await Effect.runPromise(marketDataService(Effect.succeed(fixtureSnapshot)).inspect)
+    const frozen = freezeQualificationPrelockDependencies(
+      { marketData: underlyingMarketData, journal: successfulJournal, evidenceStore: underlyingEvidenceStore },
+      capturedInspection,
+      ['a'.repeat(64)],
+    )
+
+    expect(await Effect.runPromise(frozen.marketData.inspect)).toBe(capturedInspection)
+    expect(await Effect.runPromise(frozen.evidenceStore.listPriorTrials)).toEqual(['a'.repeat(64)])
+    expect(await Effect.runPromise(frozen.marketData.load)).toBe(fixtureSnapshot)
+    expect(underlyingInspections).toBe(0)
+    expect(underlyingLineageReads).toBe(0)
+  })
+
+  test('matches the release gate Bayn image-input freshness boundary', () => {
+    for (const path of [
+      'services/bayn/src/index.ts',
+      'nix/images/bayn.nix',
+      '.github/workflows/bayn-qualification.yml',
+      'packages/scripts/package.json',
+      'patches/effect.patch',
+    ]) {
+      expect(isQualificationSourceAffectingPath(path)).toBe(true)
+    }
+    for (const path of [
+      'argocd/applications/bayn/deployment.yaml',
+      'argocd/applications/bayn/kustomization.yaml',
+      'argocd/applicationsets/product.yaml',
+      'docs/bayn.md',
+    ]) {
+      expect(isQualificationSourceAffectingPath(path)).toBe(false)
+    }
+  })
+
+  test('does not let a later serialized queue starve the currently executing run', () => {
+    expect(
+      blockingQualificationWorkflowRunIds(200, [
+        { id: 200, status: 'in_progress' },
+        { id: 201, status: 'queued' },
+        { id: 199, status: 'queued' },
+        { id: 198, status: 'in_progress' },
+      ]),
+    ).toEqual(['198', '199'])
+  })
+})

--- a/services/bayn/src/qualification-collector-command.ts
+++ b/services/bayn/src/qualification-collector-command.ts
@@ -1,0 +1,1589 @@
+import { execFile } from 'node:child_process'
+import { createHash } from 'node:crypto'
+import { mkdtemp, readFile, realpath, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import process from 'node:process'
+import * as vm from 'node:vm'
+
+import { NodeHttpClient, NodeRuntime, NodeServices } from '@effect/platform-node'
+import { Data, Effect, Layer, Logger, Option, Ref, Result } from 'effect'
+import * as Reactivity from 'effect/unstable/reactivity/Reactivity'
+
+import type { ApplicationPlanFor } from './app'
+import { embeddedBuildMetadata } from './build'
+import {
+  type CandidateDevelopmentNextPreregistration,
+  frozenCandidateDevelopmentTrialHistory,
+} from './candidate-development-calendar'
+import {
+  validateCandidateDevelopmentPreregistrationDocument,
+  verifyCandidateDevelopmentPreregistrationLineage,
+  verifyCandidateDevelopmentPreregistrationModuleNovelty,
+  verifyCandidateDevelopmentRepositoryIntegrity,
+} from './candidate-development-command'
+import { EvidenceStore, type EvidenceStoreService, type QualificationRecord } from './db/evidence-store'
+import {
+  ApplicationPlatformLive,
+  ClickHouseClientResourceLive,
+  EvidenceStoreResourceLive,
+  JournalResourceLive,
+  loadApplicationPlan,
+  MarketDataResourceLive,
+  PostgresClientResourceLive,
+} from './entrypoint'
+import { canonicalHashV1Result } from './hash'
+import { Journal, type JournalService } from './ledger'
+import { MarketData, type MarketDataInspection, type MarketDataService } from './market-data'
+import { sqlResource } from './operations'
+import { collectQualificationAuditReport } from './qualification-audit-command'
+import {
+  verifyQualificationCandidateBinding,
+  type QualificationCandidateBindingReceipt,
+} from './qualification-candidate-command'
+import type { QualificationAuditReport } from './audit/audit'
+import { initialState } from './runtime-state'
+import { runStartup } from './startup'
+
+const sha40 = /^[0-9a-f]{40}$/
+const sha64 = /^[0-9a-f]{64}$/
+const imageDigest = /^sha256:[0-9a-f]{64}$/
+const maximumGitOutputBytes = 16 * 1024 * 1024
+const defaultOperationTimeoutMs = 60_000
+const defaultAuditReplicaUrls = [
+  'http://chi-torghut-clickhouse-default-0-0.torghut.svc.cluster.local:8123',
+  'http://chi-torghut-clickhouse-default-0-1.torghut.svc.cluster.local:8123',
+] as const
+const candidateArtifactSchemaVersion = 'bayn.candidate-development-artifact.v1'
+const candidateStrategyProtocolSchemaVersion = 'bayn.candidate-development-strategy-protocol.v2'
+const candidateMarketDataContractSchemaVersion = 'bayn.candidate-development-market-data-contract.v1'
+const candidateDefinitionTimeoutMs = 10_000
+const forbiddenCandidateDefinitionIdentifiers = new Set([
+  'Atomics',
+  'Bun',
+  'Date',
+  'EventSource',
+  'FinalizationRegistry',
+  'Function',
+  'Intl',
+  'Loader',
+  'Promise',
+  'ShadowRealm',
+  'SharedArrayBuffer',
+  'SharedWorker',
+  'Temporal',
+  'WebAssembly',
+  'WebSocket',
+  'WeakRef',
+  'Worker',
+  'XMLHttpRequest',
+  'async',
+  'await',
+  'console',
+  'crypto',
+  'eval',
+  'fetch',
+  'import',
+  'localeCompare',
+  'module',
+  'navigator',
+  'performance',
+  'process',
+  'queueMicrotask',
+  'require',
+  'setImmediate',
+  'setInterval',
+  'setTimeout',
+  'toLocaleLowerCase',
+  'toLocaleString',
+  'toLocaleUpperCase',
+])
+
+export class QualificationCollectorError extends Data.TaggedError('QualificationCollectorError')<{
+  readonly phase: 'audit' | 'candidate' | 'configuration' | 'eligibility' | 'execution' | 'repository' | 'wiring'
+  readonly code: string
+  readonly message: string
+  readonly cause?: unknown
+}> {}
+
+const collectorError = (
+  phase: QualificationCollectorError['phase'],
+  code: string,
+  message: string,
+  cause?: unknown,
+): QualificationCollectorError => new QualificationCollectorError({ phase, code, message, cause })
+
+const recordOf = (value: unknown): Record<string, unknown> | undefined =>
+  typeof value === 'object' && value !== null && !Array.isArray(value) ? (value as Record<string, unknown>) : undefined
+
+const candidateDefinitionIdentifierIssues = (source: string): readonly string[] => {
+  const issues: string[] = []
+  let index = 0
+  while (index < source.length) {
+    const character = source[index]
+    const next = source[index + 1]
+    if (character === "'" || character === '"') {
+      const quote = character
+      index += 1
+      while (index < source.length) {
+        if (source[index] === '\\') index += 2
+        else if (source[index] === quote) {
+          index += 1
+          break
+        } else index += 1
+      }
+      continue
+    }
+    if (character === '`') {
+      issues.push('template-literal')
+      break
+    }
+    if (character === '/' && next === '/') {
+      index += 2
+      while (index < source.length && source[index] !== '\n') index += 1
+      continue
+    }
+    if (character === '/' && next === '*') {
+      index += 2
+      while (index + 1 < source.length && !(source[index] === '*' && source[index + 1] === '/')) index += 1
+      index += 2
+      continue
+    }
+    if (character !== undefined && /[A-Za-z_$]/.test(character)) {
+      let end = index + 1
+      while (end < source.length && /[A-Za-z0-9_$]/.test(source[end] ?? '')) end += 1
+      const identifier = source.slice(index, end)
+      if (forbiddenCandidateDefinitionIdentifiers.has(identifier)) issues.push(identifier)
+      index = end
+      continue
+    }
+    index += 1
+  }
+  return [...new Set(issues)].sort()
+}
+
+const candidateDefinitionContext = (): vm.Context => {
+  const context = vm.createContext(Object.create(null), {
+    codeGeneration: { strings: false, wasm: false },
+    microtaskMode: 'afterEvaluate',
+    name: 'bayn-qualification-candidate-definition',
+  })
+  vm.runInContext(
+    `
+      Object.defineProperty(globalThis, 'constructor', {
+        value: null,
+        writable: false,
+        configurable: false,
+      })
+      Object.defineProperty(Error, 'prepareStackTrace', {
+        value: undefined,
+        writable: false,
+        configurable: false,
+      })
+      Object.defineProperty(Error, 'captureStackTrace', {
+        value: undefined,
+        writable: false,
+        configurable: false,
+      })
+      Error.stackTraceLimit = 0
+      for (const name of [
+        'process',
+        'Bun',
+        'console',
+        'Date',
+        'Intl',
+        'Loader',
+        'Temporal',
+        'performance',
+        'crypto',
+        'navigator',
+        'fetch',
+        'require',
+        'module',
+        'exports',
+        'Promise',
+        'ShadowRealm',
+        'Atomics',
+        'SharedArrayBuffer',
+        'FinalizationRegistry',
+        'WeakRef',
+        'WebAssembly',
+        'Worker',
+        'SharedWorker',
+        'XMLHttpRequest',
+        'WebSocket',
+        'EventSource',
+        'setTimeout',
+        'setInterval',
+        'setImmediate',
+        'queueMicrotask',
+      ]) {
+        Object.defineProperty(globalThis, name, {
+          value: undefined,
+          writable: false,
+          configurable: false,
+        })
+      }
+      Object.defineProperty(Math, 'random', {
+        value: undefined,
+        writable: false,
+        configurable: false,
+      })
+      for (const [prototype, names] of [
+        [String.prototype, ['localeCompare', 'toLocaleLowerCase', 'toLocaleUpperCase']],
+        [Number.prototype, ['toLocaleString']],
+        [BigInt.prototype, ['toLocaleString']],
+      ]) {
+        for (const name of names) {
+          Object.defineProperty(prototype, name, {
+            value: undefined,
+            writable: false,
+            configurable: false,
+          })
+        }
+      }
+    `,
+    context,
+    { timeout: candidateDefinitionTimeoutMs },
+  )
+  return context
+}
+
+export interface QualificationCandidateImmutableSourceInput {
+  readonly repositoryPath: string
+  readonly sourceRevision: string
+  readonly preregistration: CandidateDevelopmentNextPreregistration
+  readonly preregistrationBytes: Uint8Array
+  readonly moduleBlobOid: string
+  readonly moduleBytes: Uint8Array
+}
+
+export interface QualificationCandidateImmutableSourceReceipt {
+  readonly schemaVersion: 'bayn.qualification-candidate-source.v1'
+  readonly moduleBlobOid: string
+  readonly compiledBoundedContentHash: string
+  readonly definitionHash: string
+}
+
+const loadCandidateCompiledDefinition = (
+  input: QualificationCandidateImmutableSourceInput,
+): Effect.Effect<
+  { readonly compiledBoundedContentHash: string; readonly definitionHash: string },
+  QualificationCollectorError
+> =>
+  Effect.tryPromise({
+    try: async (signal) => {
+      if (signal.aborted) throw signal.reason
+      const source = Buffer.from(input.moduleBytes).toString('utf8')
+      const transpiler = new Bun.Transpiler({ loader: 'js' })
+      const imports = transpiler.scanImports(source)
+      const normalized = transpiler.transformSync(source)
+      const identifiers = candidateDefinitionIdentifierIssues(normalized)
+      if (imports.length > 0 || identifiers.length > 0) {
+        throw new TypeError(
+          `candidate module is not self-contained: imports=${JSON.stringify(imports)} identifiers=${JSON.stringify(identifiers)}`,
+        )
+      }
+      const context = candidateDefinitionContext()
+      const artifactModule = new vm.SourceTextModule(source, {
+        context,
+        identifier: `git:${input.sourceRevision}:${input.moduleBlobOid}`,
+        initializeImportMeta: (meta) => Object.freeze(meta),
+      })
+      await artifactModule.link(() => {
+        throw new TypeError('candidate artifact imports are prohibited')
+      })
+      await artifactModule.evaluate({ timeout: candidateDefinitionTimeoutMs })
+      if (signal.aborted) throw signal.reason
+      const artifact = Reflect.get(artifactModule.namespace, 'candidateDevelopmentArtifact') as unknown
+      Object.defineProperty(context, '__candidateDevelopmentArtifact', {
+        value: artifact,
+        writable: false,
+        configurable: false,
+      })
+      const encoded = vm.runInContext(
+        `
+          (() => {
+            const artifact = globalThis.__candidateDevelopmentArtifact
+            if (artifact === null || typeof artifact !== 'object') {
+              throw new TypeError('candidateDevelopmentArtifact export is missing')
+            }
+            if (typeof artifact.buildEvaluation !== 'function') {
+              throw new TypeError('candidateDevelopmentArtifact.buildEvaluation is missing')
+            }
+            return JSON.stringify({
+              schemaVersion: artifact.schemaVersion,
+              input: artifact.input,
+              strategyProtocol: artifact.strategyProtocol,
+            })
+          })()
+        `,
+        context,
+        { timeout: candidateDefinitionTimeoutMs },
+      )
+      if (typeof encoded !== 'string') throw new TypeError('candidate artifact definition is not JSON serializable')
+      const definition = JSON.parse(encoded) as unknown
+      const definitionRecord = recordOf(definition)
+      const candidateInput = recordOf(definitionRecord?.input)
+      const strategyProtocol = recordOf(definitionRecord?.strategyProtocol)
+      const marketData = recordOf(strategyProtocol?.marketData)
+      if (
+        definitionRecord?.schemaVersion !== candidateArtifactSchemaVersion ||
+        candidateInput?.candidateOrdinal !== input.preregistration.candidateOrdinal ||
+        candidateInput?.priorTrialCount !== input.preregistration.priorTrialCount ||
+        candidateInput?.expectedStrategyProtocolHash !== input.preregistration.strategyProtocolHash ||
+        strategyProtocol?.schemaVersion !== candidateStrategyProtocolSchemaVersion ||
+        marketData?.schemaVersion !== candidateMarketDataContractSchemaVersion ||
+        marketData.snapshotId !== input.preregistration.marketData.snapshotId ||
+        typeof marketData.contentHash !== 'string' ||
+        !sha64.test(marketData.contentHash)
+      ) {
+        throw new TypeError('candidate artifact definition differs from the reviewed preregistration')
+      }
+      const strategyProtocolHash = Result.getOrThrow(canonicalHashV1Result(strategyProtocol))
+      if (strategyProtocolHash !== input.preregistration.strategyProtocolHash) {
+        throw new TypeError('candidate artifact strategy protocol hash differs from the reviewed preregistration')
+      }
+      const definitionHash = Result.getOrThrow(canonicalHashV1Result(definition))
+      return { compiledBoundedContentHash: marketData.contentHash, definitionHash }
+    },
+    catch: (cause) =>
+      collectorError(
+        'candidate',
+        'candidate-definition-invalid',
+        'candidate module definition could not be verified',
+        cause,
+      ),
+  })
+
+export const verifyQualificationCandidateImmutableSource = (
+  input: QualificationCandidateImmutableSourceInput,
+): Effect.Effect<QualificationCandidateImmutableSourceReceipt, QualificationCollectorError> =>
+  Effect.gen(function* () {
+    const preregistrationDocument = yield* Effect.try({
+      try: () => JSON.parse(Buffer.from(input.preregistrationBytes).toString('utf8')) as unknown,
+      catch: (cause) =>
+        collectorError(
+          'candidate',
+          'preregistration-document-malformed',
+          'reviewed preregistration document is not valid JSON',
+          cause,
+        ),
+    })
+    yield* Effect.fromResult(
+      validateCandidateDevelopmentPreregistrationDocument(input.preregistration, preregistrationDocument),
+    ).pipe(
+      Effect.mapError((cause) =>
+        collectorError(
+          'candidate',
+          'preregistration-document-invalid',
+          'reviewed preregistration document differs from the compiled calendar/module/data binding',
+          cause,
+        ),
+      ),
+    )
+    yield* verifyCandidateDevelopmentPreregistrationModuleNovelty(
+      input.repositoryPath,
+      input.preregistration.preregistration.sourceRevision,
+      input.preregistration.modulePath,
+      input.moduleBlobOid,
+    ).pipe(
+      Effect.mapError((cause) =>
+        collectorError(
+          'candidate',
+          'candidate-module-not-novel',
+          'candidate module blob existed at or before preregistration',
+          cause,
+        ),
+      ),
+    )
+    const definition = yield* loadCandidateCompiledDefinition(input)
+    return {
+      schemaVersion: 'bayn.qualification-candidate-source.v1',
+      moduleBlobOid: input.moduleBlobOid,
+      ...definition,
+    }
+  })
+
+export interface QualificationCollectorPrelockEvidence {
+  readonly schemaVersion: 'bayn.qualification-collector-prelock.v1'
+  readonly repository: string
+  readonly currentMainSha: string
+  readonly sourceSha: string
+  readonly imageRepository: string
+  readonly imageDigest: string
+  readonly strategyBehaviorHash: string
+  readonly strategyParameterHash: string
+  readonly candidateOrdinal: number
+  readonly priorTrialCount: number
+  readonly preregistrationHash: string
+  readonly moduleBlobOid: string
+  readonly candidateDefinitionHash: string
+  readonly compiledBoundedContentHash: string
+  readonly activeAttemptRunIds: readonly string[]
+  readonly githubRunId: string
+  readonly githubRunAttempt: number
+}
+
+export interface QualificationCollectorExecutionReceipt {
+  readonly schemaVersion: 'bayn.qualification-execution.v1'
+  readonly runId: string
+  readonly lockId: string
+  readonly resultHash: string
+  readonly verdict: 'QUALIFIED' | 'REJECTED'
+  readonly persistence: {
+    readonly artifactCount: number
+    readonly eventCount: number
+    readonly gateCount: number
+  }
+}
+
+export interface QualificationCollectorTerminalEvidence {
+  readonly schemaVersion: 'bayn.qualification-collector-terminal.v1'
+  readonly repository: string
+  readonly currentMainSha: string
+  readonly sourceSha: string
+  readonly image: { readonly repository: string; readonly digest: string }
+  readonly candidateOrdinal: number
+  readonly githubRunId: string
+  readonly githubRunAttempt: number
+  readonly preregistrationHash: string
+  readonly eligibilityHash: string
+  readonly candidateBindingHash: string
+  readonly terminal: QualificationCollectorExecutionReceipt
+  readonly audit: QualificationAuditReport
+  readonly evidenceHash: string
+}
+
+export interface QualificationCollectorOperations<Prelock extends QualificationCollectorPrelockEvidence, R = never> {
+  readonly collectPrelock: Effect.Effect<Prelock, QualificationCollectorError, R>
+  readonly verifyCandidate: (
+    prelock: Prelock,
+  ) => Effect.Effect<QualificationCandidateBindingReceipt, QualificationCollectorError, R>
+  readonly executeQualification: (
+    prelock: Prelock,
+    candidate: QualificationCandidateBindingReceipt,
+  ) => Effect.Effect<QualificationCollectorExecutionReceipt, QualificationCollectorError, R>
+  readonly auditQualification: (
+    execution: QualificationCollectorExecutionReceipt,
+  ) => Effect.Effect<QualificationAuditReport, QualificationCollectorError, R>
+}
+
+export const runQualificationCollector = <Prelock extends QualificationCollectorPrelockEvidence, R>(
+  operations: QualificationCollectorOperations<Prelock, R>,
+): Effect.Effect<QualificationCollectorTerminalEvidence, QualificationCollectorError, R> =>
+  Effect.gen(function* () {
+    const prelock = yield* operations.collectPrelock
+    if (prelock.activeAttemptRunIds.length > 0) {
+      return yield* collectorError(
+        'eligibility',
+        'qualification-attempt-in-flight',
+        'another qualification workflow run is queued or in progress',
+      )
+    }
+    const candidate = yield* operations.verifyCandidate(prelock)
+    if (
+      candidate.candidateOrdinal !== prelock.candidateOrdinal ||
+      candidate.priorTrialCount !== prelock.priorTrialCount ||
+      candidate.sourceRevision !== prelock.sourceSha ||
+      candidate.imageRepository !== prelock.imageRepository ||
+      candidate.imageDigest !== prelock.imageDigest ||
+      candidate.compiledBoundedContentHash !== prelock.compiledBoundedContentHash
+    ) {
+      return yield* collectorError(
+        'candidate',
+        'candidate-binding-mismatch',
+        'candidate binding differs from the immutable collector prelock evidence',
+      )
+    }
+
+    const eligibilityMaterial = {
+      repository: prelock.repository,
+      currentMainSha: prelock.currentMainSha,
+      sourceSha: prelock.sourceSha,
+      imageRepository: prelock.imageRepository,
+      imageDigest: prelock.imageDigest,
+      strategyBehaviorHash: prelock.strategyBehaviorHash,
+      strategyParameterHash: prelock.strategyParameterHash,
+      candidateOrdinal: prelock.candidateOrdinal,
+      priorTrialCount: prelock.priorTrialCount,
+      preregistrationHash: prelock.preregistrationHash,
+      moduleBlobOid: prelock.moduleBlobOid,
+      candidateDefinitionHash: prelock.candidateDefinitionHash,
+      compiledBoundedContentHash: prelock.compiledBoundedContentHash,
+      candidateBindingHash: candidate.bindingHash,
+      candidateRunId: candidate.candidateRunId,
+      lockId: candidate.lockId,
+      githubRunId: prelock.githubRunId,
+      githubRunAttempt: prelock.githubRunAttempt,
+    }
+    const eligibilityHash = yield* Effect.fromResult(canonicalHashV1Result(eligibilityMaterial)).pipe(
+      Effect.mapError((cause) =>
+        collectorError('eligibility', 'eligibility-hash-failed', 'eligibility evidence could not be hashed', cause),
+      ),
+    )
+
+    const execution = yield* operations.executeQualification(prelock, candidate)
+    if (execution.runId !== candidate.candidateRunId || execution.lockId !== candidate.lockId) {
+      return yield* collectorError(
+        'execution',
+        'terminal-binding-mismatch',
+        'terminal qualification differs from the precommitted candidate lock',
+      )
+    }
+    const audit = yield* operations.auditQualification(execution)
+    if (
+      audit.status !== 'PASS' ||
+      audit.runId !== execution.runId ||
+      audit.evidence.lockId !== execution.lockId ||
+      audit.evidence.resultHash !== execution.resultHash
+    ) {
+      return yield* collectorError(
+        'audit',
+        'terminal-audit-mismatch',
+        'independent audit did not reproduce the exact terminal qualification',
+      )
+    }
+
+    const material = {
+      schemaVersion: 'bayn.qualification-collector-terminal.v1' as const,
+      repository: prelock.repository,
+      currentMainSha: prelock.currentMainSha,
+      sourceSha: prelock.sourceSha,
+      image: { repository: prelock.imageRepository, digest: prelock.imageDigest },
+      candidateOrdinal: prelock.candidateOrdinal,
+      githubRunId: prelock.githubRunId,
+      githubRunAttempt: prelock.githubRunAttempt,
+      preregistrationHash: prelock.preregistrationHash,
+      eligibilityHash,
+      candidateBindingHash: candidate.bindingHash,
+      terminal: execution,
+      audit,
+    }
+    const evidenceHash = yield* Effect.fromResult(canonicalHashV1Result(material)).pipe(
+      Effect.mapError((cause) =>
+        collectorError('audit', 'terminal-evidence-hash-failed', 'terminal evidence could not be hashed', cause),
+      ),
+    )
+    return { ...material, evidenceHash }
+  })
+
+interface DeploymentRuntime {
+  readonly sourceSha: string
+  readonly imageRepository: string
+  readonly imageDigest: string
+  readonly strategyBehaviorHash: string
+  readonly strategyParameterHash: string
+  readonly maximumAuthority: string
+  readonly clickhouseUrl: string
+  readonly signalSnapshotId: string
+  readonly signalPublicationAsOf: string
+  readonly signalCalendarVersion: string
+  readonly signalDataStart: string
+  readonly signalDataEnd: string
+  readonly signalLookbackStart: string
+  readonly signalEvaluationStart: string
+  readonly signalEvaluationEnd: string
+  readonly tigerBeetleClusterId: string
+  readonly tigerBeetleAddresses: string
+  readonly tigerBeetleLedger: string
+}
+
+interface StaticQualificationEvidence {
+  readonly preregistration: CandidateDevelopmentNextPreregistration
+  readonly preregistrationHash: string
+  readonly repositoryPath: string
+  readonly repository: string
+  readonly currentMainSha: string
+  readonly sourceSha: string
+  readonly githubRunId: string
+  readonly githubRunAttempt: number
+  readonly moduleBlobOid: string
+  readonly candidateDefinitionHash: string
+  readonly compiledBoundedContentHash: string
+  readonly deployment: DeploymentRuntime
+}
+
+export interface QualificationCollectorInvocation {
+  readonly mode: 'execute' | 'preflight'
+  readonly eventName: 'schedule'
+  readonly currentMainSha: string
+}
+
+interface QualificationWiring {
+  readonly githubToken: string
+  readonly clickhouseUsername: string
+  readonly clickhousePassword: string
+  readonly postgresUrl: string
+  readonly postgresCaPem: string
+  readonly signalPublisherUsername: string
+  readonly auditClickhouseUsername: string
+  readonly auditClickhousePassword: string
+}
+
+interface ProductionPrelockEvidence extends QualificationCollectorPrelockEvidence {
+  readonly plan: ApplicationPlanFor<'BrokerlessService'>
+  readonly inspection: MarketDataInspection
+  readonly priorTrialRunIds: readonly string[]
+  readonly preregistration: CandidateDevelopmentNextPreregistration
+  readonly dependencies: {
+    readonly marketData: MarketDataService
+    readonly journal: JournalService
+    readonly evidenceStore: EvidenceStoreService
+  }
+}
+
+export type QualificationAttemptState = 'FRESH' | 'RECOVER_TERMINAL'
+
+export const qualificationAttemptState = (
+  existing: Option.Option<QualificationRecord>,
+): Effect.Effect<QualificationAttemptState, QualificationCollectorError> => {
+  if (Option.isNone(existing)) return Effect.succeed('FRESH')
+  if (existing.value.state === 'OPENED_INCOMPLETE') {
+    return Effect.fail(
+      collectorError(
+        'execution',
+        'qualification-opened-incomplete',
+        'the exact candidate has an incomplete durable qualification lock and cannot be retried automatically',
+      ),
+    )
+  }
+  return Effect.succeed('RECOVER_TERMINAL')
+}
+
+export interface QualificationExecutionInput {
+  readonly plan: ApplicationPlanFor<'BrokerlessService'>
+  readonly inspection: MarketDataInspection
+  readonly priorTrialRunIds: readonly string[]
+  readonly dependencies: ProductionPrelockEvidence['dependencies']
+}
+
+export const executeQualificationAttempt = (
+  input: QualificationExecutionInput,
+  candidate: QualificationCandidateBindingReceipt,
+): Effect.Effect<QualificationCollectorExecutionReceipt, QualificationCollectorError> =>
+  Effect.gen(function* () {
+    const existing = yield* input.dependencies.evidenceStore
+      .readQualification(candidate.candidateRunId)
+      .pipe(
+        Effect.mapError((cause) =>
+          collectorError(
+            'execution',
+            'qualification-state-read-failed',
+            'qualification state could not be read',
+            cause,
+          ),
+        ),
+      )
+    const attemptState = yield* qualificationAttemptState(existing)
+
+    const state = yield* Ref.make(initialState())
+    const executionDependencies = freezeQualificationPrelockDependencies(
+      input.dependencies,
+      input.inspection,
+      input.priorTrialRunIds,
+    )
+    yield* runStartup(input.plan.config, state, input.plan.strategy, executionDependencies).pipe(
+      Effect.mapError((cause) =>
+        collectorError('execution', 'qualification-runtime-failed', 'qualification runtime failed', cause),
+      ),
+    )
+    const completed = yield* Ref.get(state)
+    if (completed.status === 'FAILED' || completed.evidence === null) {
+      return yield* collectorError(
+        'execution',
+        'qualification-terminal-missing',
+        completed.error ?? 'qualification did not produce terminal durable evidence',
+      )
+    }
+    if (
+      completed.evidence.startupMode === 'pinned' ||
+      (attemptState === 'RECOVER_TERMINAL' && completed.evidence.startupMode !== 'recovered')
+    ) {
+      return yield* collectorError(
+        'execution',
+        'qualification-replay-invalid',
+        'collector did not evaluate or recover the exact unpinned qualification attempt',
+      )
+    }
+    const qualification = completed.evidence.qualification
+    return {
+      schemaVersion: 'bayn.qualification-execution.v1',
+      runId: completed.evidence.evaluation.runId,
+      lockId: qualification.lockId,
+      resultHash: qualification.resultHash,
+      verdict: qualification.verdict,
+      persistence: {
+        artifactCount: completed.evidence.persistence.artifactCount,
+        eventCount: completed.evidence.persistence.eventCount,
+        gateCount: completed.evidence.persistence.gateCount,
+      },
+    }
+  })
+
+export const freezeQualificationPrelockDependencies = (
+  dependencies: ProductionPrelockEvidence['dependencies'],
+  inspection: MarketDataInspection,
+  priorTrialRunIds: readonly string[],
+): ProductionPrelockEvidence['dependencies'] => ({
+  marketData: { ...dependencies.marketData, inspect: Effect.succeed(inspection) },
+  journal: dependencies.journal,
+  evidenceStore: { ...dependencies.evidenceStore, listPriorTrials: Effect.succeed(priorTrialRunIds) },
+})
+
+export const requiredQualificationEnvironment = (
+  environment: NodeJS.ProcessEnv,
+  name: string,
+): Effect.Effect<string, QualificationCollectorError> => {
+  const value = environment[name]?.trim()
+  return value === undefined || value.length === 0
+    ? Effect.fail(collectorError('configuration', 'environment-missing', `${name} is required`))
+    : Effect.succeed(value)
+}
+
+const positiveIntegerQualificationEnvironment = (
+  environment: NodeJS.ProcessEnv,
+  name: string,
+): Effect.Effect<number, QualificationCollectorError> =>
+  requiredQualificationEnvironment(environment, name).pipe(
+    Effect.flatMap((raw) => {
+      const value = Number(raw)
+      return Number.isSafeInteger(value) && value >= 1
+        ? Effect.succeed(value)
+        : Effect.fail(collectorError('configuration', 'environment-invalid', `${name} must be a positive integer`))
+    }),
+  )
+
+const canonicalRepository = (value: string): Effect.Effect<string, QualificationCollectorError> => {
+  const match = /^([A-Za-z0-9][A-Za-z0-9.-]*)\/([A-Za-z0-9_.-]+)$/.exec(value.trim())
+  if (match === null || match[1] === undefined || match[2] === undefined) {
+    return Effect.fail(
+      collectorError('repository', 'repository-identity-invalid', 'repository must be an owner/name identity'),
+    )
+  }
+  return Effect.succeed(`${match[1].toLowerCase()}/${match[2].toLowerCase()}`)
+}
+
+const repositoryFromOrigin = (value: string): Effect.Effect<string, QualificationCollectorError> => {
+  const match =
+    /^(?:https?:\/\/github\.com\/|ssh:\/\/git@github\.com\/|git@github\.com:)([^/]+)\/([^/]+?)(?:\.git)?\/?$/i.exec(
+      value.trim(),
+    )
+  if (match === null || match[1] === undefined || match[2] === undefined) {
+    return Effect.fail(
+      collectorError('repository', 'origin-invalid', 'origin must be an explicit GitHub repository URL'),
+    )
+  }
+  return canonicalRepository(`${match[1]}/${match[2]}`)
+}
+
+const gitEnvironment = (): NodeJS.ProcessEnv =>
+  Object.fromEntries(Object.entries(process.env).filter(([name]) => !name.startsWith('GIT_')))
+
+const gitOutput = (
+  repositoryPath: string,
+  args: readonly string[],
+  signal: AbortSignal,
+  encoding: 'buffer' | 'utf8' = 'utf8',
+): Promise<Buffer | string> =>
+  new Promise((resolveGit, rejectGit) => {
+    execFile(
+      'git',
+      ['--no-replace-objects', '-C', repositoryPath, ...args],
+      { encoding, env: gitEnvironment(), maxBuffer: maximumGitOutputBytes, signal },
+      (error, stdout) => {
+        if (error !== null) rejectGit(error)
+        else resolveGit(encoding === 'utf8' ? String(stdout).trim() : (stdout as Buffer))
+      },
+    )
+  })
+
+const gitText = (repositoryPath: string, args: readonly string[], signal: AbortSignal): Promise<string> =>
+  gitOutput(repositoryPath, args, signal, 'utf8').then(String)
+
+const gitBytes = (repositoryPath: string, args: readonly string[], signal: AbortSignal): Promise<Buffer> =>
+  gitOutput(repositoryPath, args, signal, 'buffer').then((value) => value as Buffer)
+
+const environmentValue = (deployment: string, name: string): string => {
+  const pattern = new RegExp(`^\\s*- name: ${name}\\n\\s+value: ([^\\n]+)$`, 'gm')
+  const matches = [...deployment.matchAll(pattern)]
+  if (matches.length !== 1 || matches[0]?.[1] === undefined) {
+    throw collectorError('configuration', 'deployment-binding-missing', `expected exactly one ${name} value`)
+  }
+  const value = matches[0][1].trim()
+  return value.startsWith('"') ? String(JSON.parse(value)) : value
+}
+
+const hasEnvironmentBlock = (deployment: string, name: string): boolean =>
+  new RegExp(`^\\s*- name: ${name}$`, 'm').test(deployment)
+
+const exactBaynBuildInputPaths = new Set([
+  'packages/scripts/src/bayn/update-manifests.ts',
+  'packages/scripts/src/bayn/verify-release-review.ts',
+  'nix/images/bayn.nix',
+  'nix/images/bayn-runtime-root.nix',
+  'nix/images/bun-workspace-service.nix',
+  'nix/images/bun-workspace-deps-source.nix',
+  'nix/packages.nix',
+  'nix/cache-push.sh',
+  'nix/ci-nix-oci-summary.sh',
+  'nix/ci-run-timed.sh',
+  'nix/oci-inspect-archive.sh',
+  'nix/oci-push.sh',
+  'nix/oci-release-contract.sh',
+  'nix/verify-bayn-image-command.sh',
+  'flake.nix',
+  'flake.lock',
+  'package.json',
+  'bun.lock',
+  '.npmrc',
+  'bunfig.toml',
+  'tsconfig.base.json',
+])
+
+export const isQualificationSourceAffectingPath = (path: string): boolean =>
+  path.startsWith('services/bayn/') ||
+  path.startsWith('patches/') ||
+  path.startsWith('.github/actions/setup-nix-toolchain/') ||
+  /^\.github\/workflows\/bayn-[^/]+\.yml$/.test(path) ||
+  path.endsWith('/package.json') ||
+  exactBaynBuildInputPaths.has(path) ||
+  path === '.github/workflows/nix-oci-build-common.yml'
+
+const loadDeploymentRuntime = async (repositoryPath: string): Promise<DeploymentRuntime> => {
+  const path = resolve(repositoryPath, 'argocd/applications/bayn/deployment.yaml')
+  const deployment = await readFile(path, 'utf8')
+  if (hasEnvironmentBlock(deployment, 'BAYN_QUALIFICATION_RUN_ID')) {
+    throw collectorError(
+      'eligibility',
+      'qualification-pin-present',
+      'a fresh qualification attempt requires the exact promoted runtime to be unpinned',
+    )
+  }
+  const runtime: DeploymentRuntime = {
+    sourceSha: environmentValue(deployment, 'BAYN_CODE_REVISION'),
+    imageRepository: environmentValue(deployment, 'BAYN_IMAGE_REPOSITORY'),
+    imageDigest: environmentValue(deployment, 'BAYN_IMAGE_DIGEST'),
+    strategyBehaviorHash: environmentValue(deployment, 'BAYN_STRATEGY_BEHAVIOR_HASH'),
+    strategyParameterHash: environmentValue(deployment, 'BAYN_STRATEGY_PARAMETER_HASH'),
+    maximumAuthority: environmentValue(deployment, 'BAYN_MAXIMUM_AUTHORITY'),
+    clickhouseUrl: environmentValue(deployment, 'BAYN_CLICKHOUSE_URL'),
+    signalSnapshotId: environmentValue(deployment, 'BAYN_SIGNAL_SNAPSHOT_ID'),
+    signalPublicationAsOf: environmentValue(deployment, 'BAYN_SIGNAL_PUBLICATION_ASOF'),
+    signalCalendarVersion: environmentValue(deployment, 'BAYN_SIGNAL_CALENDAR_VERSION'),
+    signalDataStart: environmentValue(deployment, 'BAYN_SIGNAL_DATA_START'),
+    signalDataEnd: environmentValue(deployment, 'BAYN_SIGNAL_DATA_END'),
+    signalLookbackStart: environmentValue(deployment, 'BAYN_SIGNAL_LOOKBACK_START'),
+    signalEvaluationStart: environmentValue(deployment, 'BAYN_SIGNAL_EVALUATION_START'),
+    signalEvaluationEnd: environmentValue(deployment, 'BAYN_SIGNAL_EVALUATION_END'),
+    tigerBeetleClusterId: environmentValue(deployment, 'BAYN_TIGERBEETLE_CLUSTER_ID'),
+    tigerBeetleAddresses: environmentValue(deployment, 'BAYN_TIGERBEETLE_ADDRESSES'),
+    tigerBeetleLedger: environmentValue(deployment, 'BAYN_TIGERBEETLE_LEDGER'),
+  }
+  if (!sha40.test(runtime.sourceSha) || !imageDigest.test(runtime.imageDigest)) {
+    throw collectorError('configuration', 'deployment-binding-invalid', 'deployment source or image digest is invalid')
+  }
+  if (!sha64.test(runtime.strategyBehaviorHash) || !sha64.test(runtime.strategyParameterHash)) {
+    throw collectorError('configuration', 'deployment-binding-invalid', 'deployment strategy hashes are invalid')
+  }
+  if (runtime.maximumAuthority !== 'OBSERVE') {
+    throw collectorError('configuration', 'authority-not-observe', 'qualification image must remain OBSERVE-only')
+  }
+  return runtime
+}
+
+export const loadQualificationCollectorInvocation = (
+  environment: NodeJS.ProcessEnv,
+): Effect.Effect<QualificationCollectorInvocation, QualificationCollectorError> =>
+  Effect.gen(function* () {
+    const eventName = yield* requiredQualificationEnvironment(environment, 'GITHUB_EVENT_NAME')
+    if (eventName === 'workflow_dispatch') {
+      return yield* collectorError(
+        'eligibility',
+        'manual-dispatch-rejected',
+        'manual qualification dispatch is forbidden',
+      )
+    }
+    if (eventName !== 'schedule') {
+      return yield* collectorError('eligibility', 'event-not-trusted', `unexpected qualification event ${eventName}`)
+    }
+    const currentMainSha = yield* requiredQualificationEnvironment(environment, 'GITHUB_SHA')
+    if (!sha40.test(currentMainSha)) {
+      return yield* collectorError('repository', 'source-sha-invalid', 'scheduled source SHA is invalid')
+    }
+    const rawMode = environment.BAYN_QUALIFICATION_MODE?.trim() || 'execute'
+    if (rawMode !== 'execute' && rawMode !== 'preflight') {
+      return yield* collectorError(
+        'configuration',
+        'collector-mode-invalid',
+        'BAYN_QUALIFICATION_MODE must be execute or preflight',
+      )
+    }
+    return { mode: rawMode, eventName: 'schedule', currentMainSha }
+  })
+
+const collectStaticQualificationEvidence = (invocation: QualificationCollectorInvocation) =>
+  Effect.gen(function* () {
+    const preregistration = frozenCandidateDevelopmentTrialHistory.nextCandidatePreregistration
+    if (preregistration === null) return Option.none<StaticQualificationEvidence>()
+
+    const repositoryPathInput = yield* requiredQualificationEnvironment(
+      process.env,
+      'BAYN_QUALIFICATION_REPOSITORY_PATH',
+    )
+    const repositoryPath = yield* Effect.tryPromise({
+      try: () => realpath(repositoryPathInput),
+      catch: (cause) => collectorError('repository', 'repository-path-invalid', 'repository path is invalid', cause),
+    })
+    const repository = yield* requiredQualificationEnvironment(process.env, 'GITHUB_REPOSITORY').pipe(
+      Effect.flatMap(canonicalRepository),
+    )
+    const trustedRepository = yield* requiredQualificationEnvironment(
+      process.env,
+      'BAYN_QUALIFICATION_TRUSTED_REPOSITORY',
+    ).pipe(Effect.flatMap(canonicalRepository))
+    if (repository !== trustedRepository) {
+      return yield* collectorError('repository', 'repository-identity-mismatch', 'workflow repository is not trusted')
+    }
+    const currentMainSha = invocation.currentMainSha
+    if (embeddedBuildMetadata === undefined) {
+      return yield* collectorError(
+        'configuration',
+        'embedded-build-missing',
+        'qualification collector requires production build metadata',
+      )
+    }
+
+    yield* verifyCandidateDevelopmentRepositoryIntegrity(repositoryPath).pipe(
+      Effect.mapError((cause) =>
+        collectorError('repository', 'repository-integrity-invalid', 'repository integrity verification failed', cause),
+      ),
+    )
+
+    const deployment = yield* Effect.tryPromise({
+      try: () => loadDeploymentRuntime(repositoryPath),
+      catch: (cause) =>
+        cause instanceof QualificationCollectorError
+          ? cause
+          : collectorError('configuration', 'deployment-read-failed', 'deployment runtime could not be read', cause),
+    })
+    if (embeddedBuildMetadata.sourceRevision !== deployment.sourceSha) {
+      return yield* collectorError(
+        'configuration',
+        'image-source-mismatch',
+        'qualification image source differs from the promoted deployment source',
+      )
+    }
+    if (deployment.sourceSha !== currentMainSha) {
+      yield* verifyCandidateDevelopmentPreregistrationLineage(
+        repositoryPath,
+        deployment.sourceSha,
+        currentMainSha,
+      ).pipe(
+        Effect.mapError((cause) =>
+          collectorError(
+            'repository',
+            'image-source-lineage-invalid',
+            'promoted image source is not an ancestor of current main',
+            cause,
+          ),
+        ),
+      )
+    }
+    yield* verifyCandidateDevelopmentPreregistrationLineage(
+      repositoryPath,
+      preregistration.preregistration.sourceRevision,
+      deployment.sourceSha,
+    ).pipe(
+      Effect.mapError((cause) =>
+        collectorError(
+          'repository',
+          'preregistration-lineage-invalid',
+          'preregistration lineage verification failed',
+          cause,
+        ),
+      ),
+    )
+
+    const staticGit = yield* Effect.tryPromise({
+      try: async (signal) => {
+        const [
+          topLevel,
+          head,
+          originMain,
+          originUrls,
+          configuration,
+          preregistrationBytes,
+          preregistrationBlobOid,
+          moduleBlobOid,
+          moduleBytes,
+          sourceAdvancePaths,
+        ] = await Promise.all([
+          gitText(repositoryPath, ['rev-parse', '--show-toplevel'], signal).then(realpath),
+          gitText(repositoryPath, ['rev-parse', 'HEAD'], signal),
+          gitText(repositoryPath, ['rev-parse', 'refs/remotes/origin/main'], signal),
+          gitText(repositoryPath, ['config', '--get-all', 'remote.origin.url'], signal),
+          gitText(repositoryPath, ['config', '--list'], signal),
+          gitBytes(
+            repositoryPath,
+            [
+              'cat-file',
+              'blob',
+              `${preregistration.preregistration.sourceRevision}:${preregistration.preregistration.path}`,
+            ],
+            signal,
+          ),
+          gitText(
+            repositoryPath,
+            ['rev-parse', `${preregistration.preregistration.sourceRevision}:${preregistration.preregistration.path}`],
+            signal,
+          ),
+          gitText(repositoryPath, ['rev-parse', `${deployment.sourceSha}:${preregistration.modulePath}`], signal),
+          gitBytes(
+            repositoryPath,
+            ['cat-file', 'blob', `${deployment.sourceSha}:${preregistration.modulePath}`],
+            signal,
+          ),
+          deployment.sourceSha === currentMainSha
+            ? Promise.resolve('')
+            : gitText(
+                repositoryPath,
+                ['diff', '--no-renames', '--name-only', `${deployment.sourceSha}..${currentMainSha}`],
+                signal,
+              ),
+        ])
+        return {
+          topLevel,
+          head,
+          originMain,
+          originUrls,
+          configuration,
+          preregistrationBytes,
+          preregistrationBlobOid,
+          moduleBlobOid,
+          moduleBytes,
+          moduleSha256: createHash('sha256').update(moduleBytes).digest('hex'),
+          sourceAdvancePaths: sourceAdvancePaths
+            .split('\n')
+            .map((path) => path.trim())
+            .filter(Boolean),
+        }
+      },
+      catch: (cause) =>
+        collectorError('repository', 'git-read-failed', 'immutable Git evidence collection failed', cause),
+    })
+    const rawOriginUrls = staticGit.originUrls
+      .split('\n')
+      .map((value) => value.trim())
+      .filter(Boolean)
+    const rewriteKeys = staticGit.configuration
+      .split('\n')
+      .map((line) => line.slice(0, line.indexOf('=')).toLowerCase())
+      .filter((key) => key.startsWith('url.') && (key.endsWith('.insteadof') || key.endsWith('.pushinsteadof')))
+    const observedRepository =
+      rawOriginUrls.length === 1 ? yield* repositoryFromOrigin(rawOriginUrls[0] ?? '') : undefined
+    if (
+      staticGit.topLevel !== repositoryPath ||
+      staticGit.head !== currentMainSha ||
+      staticGit.originMain !== currentMainSha ||
+      rawOriginUrls.length !== 1 ||
+      observedRepository !== trustedRepository ||
+      rewriteKeys.length !== 0
+    ) {
+      return yield* collectorError(
+        'repository',
+        'repository-binding-invalid',
+        'checked-out repository, origin, or exact main binding is invalid',
+      )
+    }
+
+    if (
+      staticGit.preregistrationBlobOid !== preregistration.preregistration.blobOid ||
+      staticGit.moduleBlobOid.length !== 40 ||
+      staticGit.moduleSha256 !== preregistration.moduleSha256
+    ) {
+      return yield* collectorError(
+        'repository',
+        'preregistration-source-mismatch',
+        'preregistration document or candidate module differs from the reviewed immutable source',
+      )
+    }
+    const candidateSource = yield* verifyQualificationCandidateImmutableSource({
+      repositoryPath,
+      sourceRevision: deployment.sourceSha,
+      preregistration,
+      preregistrationBytes: staticGit.preregistrationBytes,
+      moduleBlobOid: staticGit.moduleBlobOid,
+      moduleBytes: staticGit.moduleBytes,
+    })
+
+    yield* verifyCandidateDevelopmentRepositoryIntegrity(repositoryPath).pipe(
+      Effect.mapError((cause) =>
+        collectorError(
+          'repository',
+          'repository-integrity-invalid',
+          'repository changed during evidence collection',
+          cause,
+        ),
+      ),
+    )
+    const finalGit = yield* Effect.tryPromise({
+      try: async (signal) => {
+        const [head, originMain, originUrls, configuration] = await Promise.all([
+          gitText(repositoryPath, ['rev-parse', 'HEAD'], signal),
+          gitText(repositoryPath, ['rev-parse', 'refs/remotes/origin/main'], signal),
+          gitText(repositoryPath, ['config', '--get-all', 'remote.origin.url'], signal),
+          gitText(repositoryPath, ['config', '--list'], signal),
+        ])
+        return { head, originMain, originUrls, configuration }
+      },
+      catch: (cause) =>
+        collectorError('repository', 'git-recheck-failed', 'repository bindings could not be rechecked', cause),
+    })
+    const finalOrigins = finalGit.originUrls
+      .split('\n')
+      .map((value) => value.trim())
+      .filter(Boolean)
+    const finalRewriteKeys = finalGit.configuration
+      .split('\n')
+      .map((line) => line.slice(0, line.indexOf('=')).toLowerCase())
+      .filter((key) => key.startsWith('url.') && (key.endsWith('.insteadof') || key.endsWith('.pushinsteadof')))
+    const finalRepository = finalOrigins.length === 1 ? yield* repositoryFromOrigin(finalOrigins[0] ?? '') : undefined
+    if (
+      finalGit.head !== currentMainSha ||
+      finalGit.originMain !== currentMainSha ||
+      finalOrigins.length !== 1 ||
+      finalRepository !== trustedRepository ||
+      finalRewriteKeys.length !== 0
+    ) {
+      return yield* collectorError(
+        'repository',
+        'repository-binding-changed',
+        'repository identity or current main changed during evidence collection',
+      )
+    }
+    const staleSourcePaths = staticGit.sourceAdvancePaths.filter(isQualificationSourceAffectingPath)
+    if (staleSourcePaths.length > 0) {
+      return yield* collectorError(
+        'repository',
+        'image-source-stale',
+        `current main contains Bayn image input changes after the promoted source: ${staleSourcePaths.slice(0, 5).join(', ')}`,
+      )
+    }
+    const imageReference = yield* requiredQualificationEnvironment(process.env, 'BAYN_QUALIFICATION_IMAGE_REFERENCE')
+    if (
+      deployment.imageRepository !== embeddedBuildMetadata.imageRepository ||
+      deployment.strategyBehaviorHash !== embeddedBuildMetadata.strategyBehaviorHash ||
+      deployment.strategyParameterHash !== embeddedBuildMetadata.strategyParameterHash ||
+      imageReference !== `${deployment.imageRepository}@${deployment.imageDigest}`
+    ) {
+      return yield* collectorError(
+        'configuration',
+        'promoted-image-binding-invalid',
+        'promoted deployment does not bind the exact collector image and scheduled main',
+      )
+    }
+    const preregistrationHash = yield* Effect.fromResult(canonicalHashV1Result(preregistration)).pipe(
+      Effect.mapError((cause) =>
+        collectorError('eligibility', 'preregistration-hash-failed', 'preregistration could not be hashed', cause),
+      ),
+    )
+    const githubRunId = yield* requiredQualificationEnvironment(process.env, 'GITHUB_RUN_ID')
+    const githubRunAttempt = yield* positiveIntegerQualificationEnvironment(process.env, 'GITHUB_RUN_ATTEMPT')
+    return Option.some<StaticQualificationEvidence>({
+      preregistration,
+      preregistrationHash,
+      repositoryPath,
+      repository,
+      currentMainSha,
+      sourceSha: deployment.sourceSha,
+      githubRunId,
+      githubRunAttempt,
+      moduleBlobOid: candidateSource.moduleBlobOid,
+      candidateDefinitionHash: candidateSource.definitionHash,
+      compiledBoundedContentHash: candidateSource.compiledBoundedContentHash,
+      deployment,
+    })
+  })
+
+const requiredWiringNames = [
+  'GITHUB_TOKEN',
+  'BAYN_CLICKHOUSE_USERNAME',
+  'BAYN_CLICKHOUSE_PASSWORD',
+  'BAYN_POSTGRES_URL',
+  'BAYN_QUALIFICATION_POSTGRES_CA_PEM',
+  'BAYN_AUDIT_SIGNAL_PUBLISHER_USERNAME',
+  'BAYN_AUDIT_CLICKHOUSE_USERNAME',
+  'BAYN_AUDIT_CLICKHOUSE_PASSWORD',
+] as const
+
+export const missingQualificationWiring = (environment: NodeJS.ProcessEnv): readonly string[] =>
+  requiredWiringNames.filter((name) => environment[name]?.trim().length === 0 || environment[name] === undefined)
+
+const loadQualificationWiring = (
+  environment: NodeJS.ProcessEnv,
+): Effect.Effect<QualificationWiring, QualificationCollectorError> => {
+  const missing = missingQualificationWiring(environment)
+  if (missing.length > 0) {
+    return Effect.fail(
+      collectorError(
+        'wiring',
+        'qualification-wiring-missing',
+        `qualification secret wiring is missing: ${missing.join(', ')}`,
+      ),
+    )
+  }
+  return Effect.succeed({
+    githubToken: environment.GITHUB_TOKEN?.trim() ?? '',
+    clickhouseUsername: environment.BAYN_CLICKHOUSE_USERNAME?.trim() ?? '',
+    clickhousePassword: environment.BAYN_CLICKHOUSE_PASSWORD?.trim() ?? '',
+    postgresUrl: environment.BAYN_POSTGRES_URL?.trim() ?? '',
+    postgresCaPem: environment.BAYN_QUALIFICATION_POSTGRES_CA_PEM?.trim() ?? '',
+    signalPublisherUsername: environment.BAYN_AUDIT_SIGNAL_PUBLISHER_USERNAME?.trim() ?? '',
+    auditClickhouseUsername: environment.BAYN_AUDIT_CLICKHOUSE_USERNAME?.trim() ?? '',
+    auditClickhousePassword: environment.BAYN_AUDIT_CLICKHOUSE_PASSWORD?.trim() ?? '',
+  })
+}
+
+export interface QualificationWorkflowRunIdentity {
+  readonly id: number
+  readonly status: 'in_progress' | 'queued'
+}
+
+export const blockingQualificationWorkflowRunIds = (
+  currentRunId: number,
+  runs: readonly QualificationWorkflowRunIdentity[],
+): readonly string[] => {
+  if (!Number.isSafeInteger(currentRunId) || currentRunId < 1) {
+    throw new TypeError('current GitHub Actions run ID is invalid')
+  }
+  const blocking = new Set<string>()
+  for (const run of runs) {
+    if (!Number.isSafeInteger(run.id) || run.id < 1) throw new TypeError('GitHub Actions run ID is invalid')
+    if (run.id !== currentRunId && (run.status === 'in_progress' || run.id < currentRunId)) {
+      blocking.add(String(run.id))
+    }
+  }
+  return [...blocking].sort((left, right) => Number(left) - Number(right))
+}
+
+const configureRuntimeEnvironment = (
+  staticEvidence: StaticQualificationEvidence,
+  caPath: string,
+  wiring: QualificationWiring,
+): void => {
+  const deployment = staticEvidence.deployment
+  const operationTimeout =
+    process.env.BAYN_QUALIFICATION_OPERATION_TIMEOUT_MS?.trim() || String(defaultOperationTimeoutMs)
+  Object.assign(process.env, {
+    NODE_ENV: 'production',
+    BAYN_PROVENANCE_MODE: 'production',
+    BAYN_CODE_REVISION: deployment.sourceSha,
+    BAYN_IMAGE_REPOSITORY: deployment.imageRepository,
+    BAYN_IMAGE_DIGEST: deployment.imageDigest,
+    BAYN_STRATEGY_BEHAVIOR_HASH: deployment.strategyBehaviorHash,
+    BAYN_STRATEGY_PARAMETER_HASH: deployment.strategyParameterHash,
+    BAYN_MAXIMUM_AUTHORITY: deployment.maximumAuthority,
+    BAYN_OPERATION_TIMEOUT_MS: operationTimeout,
+    BAYN_CLICKHOUSE_URL: deployment.clickhouseUrl,
+    BAYN_SIGNAL_SNAPSHOT_ID: deployment.signalSnapshotId,
+    BAYN_SIGNAL_PUBLICATION_ASOF: deployment.signalPublicationAsOf,
+    BAYN_SIGNAL_CALENDAR_VERSION: deployment.signalCalendarVersion,
+    BAYN_SIGNAL_DATA_START: deployment.signalDataStart,
+    BAYN_SIGNAL_DATA_END: deployment.signalDataEnd,
+    BAYN_SIGNAL_LOOKBACK_START: deployment.signalLookbackStart,
+    BAYN_SIGNAL_EVALUATION_START: deployment.signalEvaluationStart,
+    BAYN_SIGNAL_EVALUATION_END: deployment.signalEvaluationEnd,
+    BAYN_POSTGRES_TLS: 'true',
+    BAYN_POSTGRES_CA_PATH: caPath,
+    BAYN_TIGERBEETLE_CLUSTER_ID: deployment.tigerBeetleClusterId,
+    BAYN_TIGERBEETLE_ADDRESSES: deployment.tigerBeetleAddresses,
+    BAYN_TIGERBEETLE_LEDGER: deployment.tigerBeetleLedger,
+    BAYN_AUDIT_OUTPUT: 'audit',
+    BAYN_AUDIT_POSTGRES_URL: wiring.postgresUrl,
+    BAYN_AUDIT_POSTGRES_TLS: 'true',
+    BAYN_AUDIT_POSTGRES_CA_PATH: caPath,
+    BAYN_AUDIT_SIGNAL_URL: deployment.clickhouseUrl,
+    BAYN_AUDIT_SIGNAL_USERNAME: wiring.clickhouseUsername,
+    BAYN_AUDIT_SIGNAL_PUBLISHER_USERNAME: wiring.signalPublisherUsername,
+    BAYN_AUDIT_SIGNAL_PASSWORD: wiring.clickhousePassword,
+    BAYN_AUDIT_CLICKHOUSE_URLS: process.env.BAYN_AUDIT_CLICKHOUSE_URLS?.trim() || defaultAuditReplicaUrls.join(','),
+    BAYN_AUDIT_CLICKHOUSE_USERNAME: wiring.auditClickhouseUsername,
+    BAYN_AUDIT_CLICKHOUSE_PASSWORD: wiring.auditClickhousePassword,
+    BAYN_AUDIT_REPOSITORY_PATH: staticEvidence.repositoryPath,
+    BAYN_AUDIT_OPERATION_TIMEOUT_MS: operationTimeout,
+  })
+  delete process.env.BAYN_QUALIFICATION_RUN_ID
+}
+
+const activeWorkflowRuns = (
+  repository: string,
+  currentRunId: string,
+  githubToken: string,
+): Effect.Effect<readonly string[], QualificationCollectorError> =>
+  Effect.tryPromise({
+    try: async (signal) => {
+      const currentRunNumber = Number(currentRunId)
+      if (!Number.isSafeInteger(currentRunNumber) || currentRunNumber < 1) {
+        throw new Error('current GitHub Actions run ID is invalid')
+      }
+      const api = (process.env.GITHUB_API_URL?.trim() || 'https://api.github.com').replace(/\/$/, '')
+      const runs: QualificationWorkflowRunIdentity[] = []
+      for (const status of ['queued', 'in_progress'] as const) {
+        const response = await fetch(
+          `${api}/repos/${repository}/actions/workflows/bayn-qualification.yml/runs?status=${status}&per_page=100`,
+          {
+            headers: {
+              Accept: 'application/vnd.github+json',
+              Authorization: `Bearer ${githubToken}`,
+              'X-GitHub-Api-Version': '2022-11-28',
+            },
+            signal,
+          },
+        )
+        if (!response.ok) throw new Error(`GitHub Actions run query returned ${response.status}`)
+        if (response.headers.get('link')?.includes('rel="next"') === true) {
+          throw new Error('GitHub Actions run query exceeded one bounded page')
+        }
+        const body = (await response.json()) as {
+          readonly total_count?: number
+          readonly workflow_runs?: readonly { readonly id?: number; readonly head_sha?: string }[]
+        }
+        if (
+          !Number.isSafeInteger(body.total_count) ||
+          body.total_count === undefined ||
+          body.total_count < 0 ||
+          !Array.isArray(body.workflow_runs) ||
+          body.total_count !== body.workflow_runs.length
+        ) {
+          throw new Error('GitHub Actions run query returned incomplete or malformed evidence')
+        }
+        for (const run of body.workflow_runs) {
+          if (!Number.isSafeInteger(run.id) || run.id === undefined || run.id < 1 || !sha40.test(run.head_sha ?? '')) {
+            throw new Error('GitHub Actions run query returned an invalid run identity')
+          }
+          runs.push({ id: run.id, status })
+        }
+      }
+      return blockingQualificationWorkflowRunIds(currentRunNumber, runs)
+    },
+    catch: (cause) =>
+      cause instanceof QualificationCollectorError
+        ? cause
+        : collectorError(
+            'eligibility',
+            'github-attempt-read-failed',
+            'active workflow attempts could not be read',
+            cause,
+          ),
+  })
+
+const qualificationResources = (plan: ApplicationPlanFor<'BrokerlessService'>) => {
+  const clickhouse = sqlResource(ClickHouseClientResourceLive(plan.config))
+  const marketData = MarketDataResourceLive(plan).pipe(Layer.provide(clickhouse))
+  const postgres = sqlResource(
+    EvidenceStoreResourceLive(plan.config).pipe(Layer.provideMerge(PostgresClientResourceLive(plan.config))),
+  )
+  return Layer.mergeAll(marketData, postgres, JournalResourceLive(plan.config)).pipe(
+    Layer.provideMerge(ApplicationPlatformLive),
+  )
+}
+
+const makeProductionOperations = (
+  staticEvidence: StaticQualificationEvidence,
+  plan: ApplicationPlanFor<'BrokerlessService'>,
+  githubToken: string,
+): QualificationCollectorOperations<
+  ProductionPrelockEvidence,
+  MarketData | Journal | EvidenceStore | NodeServices.NodeServices | Reactivity.Reactivity
+> => {
+  let collected: ProductionPrelockEvidence | undefined
+  return {
+    collectPrelock: Effect.gen(function* () {
+      const dependencies = yield* Effect.all({
+        marketData: MarketData,
+        journal: Journal,
+        evidenceStore: EvidenceStore,
+      })
+      const [inspection, priorTrialRunIds, activeAttemptRunIds] = yield* Effect.all([
+        dependencies.marketData.inspect.pipe(
+          Effect.mapError((cause) =>
+            collectorError(
+              'eligibility',
+              'publication-inspection-failed',
+              'Signal publication inspection failed',
+              cause,
+            ),
+          ),
+        ),
+        dependencies.evidenceStore.listPriorTrials.pipe(
+          Effect.mapError((cause) =>
+            collectorError(
+              'eligibility',
+              'trial-lineage-read-failed',
+              'qualification trial lineage could not be read',
+              cause,
+            ),
+          ),
+        ),
+        activeWorkflowRuns(staticEvidence.repository, staticEvidence.githubRunId, githubToken),
+      ])
+      const value: ProductionPrelockEvidence = {
+        schemaVersion: 'bayn.qualification-collector-prelock.v1',
+        repository: staticEvidence.repository,
+        currentMainSha: staticEvidence.currentMainSha,
+        sourceSha: staticEvidence.sourceSha,
+        imageRepository: staticEvidence.deployment.imageRepository,
+        imageDigest: staticEvidence.deployment.imageDigest,
+        strategyBehaviorHash: staticEvidence.deployment.strategyBehaviorHash,
+        strategyParameterHash: staticEvidence.deployment.strategyParameterHash,
+        candidateOrdinal: staticEvidence.preregistration.candidateOrdinal,
+        priorTrialCount: staticEvidence.preregistration.priorTrialCount,
+        preregistrationHash: staticEvidence.preregistrationHash,
+        moduleBlobOid: staticEvidence.moduleBlobOid,
+        candidateDefinitionHash: staticEvidence.candidateDefinitionHash,
+        compiledBoundedContentHash: staticEvidence.compiledBoundedContentHash,
+        activeAttemptRunIds,
+        githubRunId: staticEvidence.githubRunId,
+        githubRunAttempt: staticEvidence.githubRunAttempt,
+        plan,
+        inspection,
+        priorTrialRunIds,
+        preregistration: staticEvidence.preregistration,
+        dependencies,
+      }
+      collected = value
+      return value
+    }),
+    verifyCandidate: (prelock) =>
+      Effect.fromResult(
+        verifyQualificationCandidateBinding(
+          prelock.preregistration,
+          prelock.compiledBoundedContentHash,
+          prelock.plan,
+          prelock.inspection,
+          prelock.priorTrialRunIds,
+        ),
+      ).pipe(
+        Effect.mapError((cause) =>
+          collectorError('candidate', 'candidate-binding-invalid', 'candidate metadata binding failed', cause),
+        ),
+      ),
+    executeQualification: (prelock, candidate) =>
+      Effect.gen(function* () {
+        if (collected !== prelock) {
+          return yield* collectorError(
+            'execution',
+            'prelock-evidence-replaced',
+            'qualification execution must consume the exact collected prelock evidence',
+          )
+        }
+        return yield* executeQualificationAttempt(
+          {
+            plan: prelock.plan,
+            inspection: prelock.inspection,
+            priorTrialRunIds: prelock.priorTrialRunIds,
+            dependencies: prelock.dependencies,
+          },
+          candidate,
+        )
+      }),
+    auditQualification: (execution) =>
+      Effect.sync(() => {
+        process.env.BAYN_AUDIT_RUN_ID = execution.runId
+      }).pipe(
+        Effect.andThen(collectQualificationAuditReport),
+        Effect.mapError((cause) =>
+          collectorError('audit', 'qualification-audit-failed', 'independent qualification audit failed', cause),
+        ),
+      ),
+  }
+}
+
+const privateCaFile = (pem: string) =>
+  Effect.acquireRelease(
+    Effect.tryPromise({
+      try: async () => {
+        const directory = await mkdtemp(join(tmpdir(), 'bayn-qualification-'))
+        const path = join(directory, 'postgres-ca.crt')
+        await writeFile(path, pem, { encoding: 'utf8', mode: 0o600 })
+        return { directory, path }
+      },
+      catch: (cause) =>
+        collectorError('wiring', 'postgres-ca-write-failed', 'PostgreSQL CA could not be staged', cause),
+    }),
+    ({ directory }) => Effect.promise(() => rm(directory, { recursive: true, force: true })),
+  )
+
+export const qualificationCollectorProgram = Effect.gen(function* () {
+  const invocation = yield* loadQualificationCollectorInvocation(process.env)
+  const staticEvidence = yield* collectStaticQualificationEvidence(invocation)
+  if (Option.isNone(staticEvidence)) {
+    return {
+      schemaVersion: 'bayn.qualification-collector-dormant.v1' as const,
+      status: 'DORMANT' as const,
+      reason: 'preregistration-missing' as const,
+    }
+  }
+  if (invocation.mode === 'preflight') {
+    return {
+      schemaVersion: 'bayn.qualification-collector-preflight.v1' as const,
+      status: 'READY' as const,
+      repository: staticEvidence.value.repository,
+      currentMainSha: staticEvidence.value.currentMainSha,
+      sourceSha: staticEvidence.value.sourceSha,
+      image: {
+        repository: staticEvidence.value.deployment.imageRepository,
+        digest: staticEvidence.value.deployment.imageDigest,
+      },
+      candidateOrdinal: staticEvidence.value.preregistration.candidateOrdinal,
+      preregistrationHash: staticEvidence.value.preregistrationHash,
+    }
+  }
+  const wiring = yield* loadQualificationWiring(process.env)
+  const ca = yield* privateCaFile(wiring.postgresCaPem)
+  configureRuntimeEnvironment(staticEvidence.value, ca.path, wiring)
+  const plan = yield* loadApplicationPlan.pipe(
+    Effect.mapError((cause) =>
+      collectorError('configuration', 'application-plan-invalid', 'qualification runtime plan is invalid', cause),
+    ),
+  )
+  if (plan._tag !== 'BrokerlessService' || plan.config.qualificationRunId !== undefined) {
+    return yield* collectorError(
+      'configuration',
+      'qualification-runtime-mode-invalid',
+      'qualification collector requires an unpinned brokerless production runtime',
+    )
+  }
+  return yield* runQualificationCollector(
+    makeProductionOperations(staticEvidence.value, plan, wiring.githubToken),
+  ).pipe(
+    Effect.provide(qualificationResources(plan)),
+    Effect.mapError((cause) =>
+      cause instanceof QualificationCollectorError
+        ? cause
+        : collectorError('configuration', 'qualification-resource-failed', 'qualification resources failed', cause),
+    ),
+  )
+}).pipe(Effect.scoped)
+
+const runtime = Layer.mergeAll(
+  Logger.layer([Logger.consoleJson]),
+  NodeServices.layer,
+  NodeHttpClient.layerNodeHttp,
+  Reactivity.layer,
+)
+
+export const qualificationCollectorMain = qualificationCollectorProgram.pipe(
+  Effect.tap((output) =>
+    Effect.sync(() => process.stdout.write(`BAYN_QUALIFICATION_TERMINAL=${JSON.stringify(output)}\n`)),
+  ),
+  Effect.tapError((error) =>
+    Effect.sync(() =>
+      process.stderr.write(`qualification collector failed [${error.phase}/${error.code}]: ${error.message}\n`),
+    ),
+  ),
+  Effect.provide(runtime),
+)
+
+if (import.meta.main) NodeRuntime.runMain(qualificationCollectorMain)


### PR DESCRIPTION
## Scope

Implements the remaining PROOMPT-437 collector/executor boundary without running qualification or reading holdout data.

- replaces the nonexistent `/run/bayn-qualification/eligibility-input.json` handoff with an in-process immutable collector
- packages the qualification candidate, collector, and independent audit entrypoints in the exact Bayn production image
- keeps the schedule dormant before image or secret access while preregistration is null
- performs a credential-free exact-image preflight before the secret-bearing execution step
- binds current main, trusted origin, promoted source/image, strategy, reviewed preregistration document, candidate module, Signal manifest/content hashes, prior trial lineage, and active workflow attempts
- reuses the existing `runStartup` path, which opens the durable PostgreSQL qualification lock before `marketData.load` can access bars
- freezes the exact prelock inspection and trial lineage while PostgreSQL transactionally revalidates real state
- executes the one fresh qualification attempt once and runs the existing independent audit once
- emits one hash-bound terminal artifact containing identities, verdict, counts, and audit evidence but no market rows or holdout contents

The existing full `candidate:qualification` CLI reads bars before the lock, so the collector invokes the new metadata-only governed candidate binding in the same candidate entrypoint; the actual metric-bearing evaluation remains exclusively behind the existing durable lock.

## Separately authorized wiring

The source/image/workflow contract is complete and fails before client acquisition when these repository Actions secrets are absent:

- `BAYN_QUALIFICATION_CLICKHOUSE_USERNAME`
- `BAYN_QUALIFICATION_CLICKHOUSE_PASSWORD`
- `BAYN_QUALIFICATION_POSTGRES_URL`
- `BAYN_QUALIFICATION_POSTGRES_CA_PEM`
- `BAYN_QUALIFICATION_SIGNAL_PUBLISHER_USERNAME`
- `BAYN_QUALIFICATION_AUDIT_CLICKHOUSE_USERNAME`
- `BAYN_QUALIFICATION_AUDIT_CLICKHOUSE_PASSWORD`

The ARC Docker network must also reach the existing internal Signal, Bayn PostgreSQL, and TigerBeetle endpoints. No credentials, RBAC, NetworkPolicy, environment, manifest, or permission changes are included here.

## Validation

- focused qualification candidate/collector/audit: 27 passed
- qualification workflow contract: 6 passed
- all Bayn scripts tests: 200 passed
- scripts lint, type-aware lint, and TypeScript: passed with existing unrelated warnings only
- Bayn lint, type-aware lint, TypeScript, and five-entrypoint build: passed
- PostgreSQL target: exit 0 locally; integration cases skip without `BAYN_TEST_POSTGRES_URL`
- full local Bayn run: 1,034 passed, 138 skipped; 9 failures are confined to concurrently modified uncommitted PROOMPT-407 Candidate 17 fixture paths excluded from this commit
- hosted exact-head PostgreSQL and amd64/arm64 image builds are required before merge

No manual dispatch, qualification attempt, broker mutation, or holdout access was performed.

PROOMPT-437