### PR TITLE
fix(bayn): reject inadequate development candidates

### DIFF
--- a/services/bayn/src/candidate-development-calendar.ts
+++ b/services/bayn/src/candidate-development-calendar.ts
@@ -1,83 +1,13 @@
 import { candidateDevelopmentCalendarContract } from './candidate-development'
 import type { IsoDate } from './schemas'
 
-export interface CandidateDevelopmentNextPreregistration {
-  readonly schemaVersion: 'bayn.candidate-development-next-preregistration.v1'
-  readonly candidateOrdinal: number
-  readonly priorTrialCount: number
-  readonly strategyProtocolHash: string
-  readonly modulePath: string
-  readonly moduleSha256: string
-  readonly marketData: {
-    readonly schemaVersion: 'bayn.candidate-development-market-data-source.v1'
-    readonly snapshotId: string
-    readonly finalizedSnapshotContentHash: string
-    readonly inputManifestHash: string
-    readonly boundedContentHash: string
-  }
-  readonly preregistration: {
-    readonly sourceRevision: string
-    readonly path: string
-    readonly blobOid: string
-  }
-}
-
-interface CandidateDevelopmentTrialHistory {
-  readonly schemaVersion: 'bayn.candidate-development-trial-history.v1'
-  readonly completedCandidateOrdinals: readonly number[]
-  readonly latestTerminalEvidence: {
-    readonly candidateOrdinal: number
-    readonly priorTrialCount: number
-    readonly terminalStatus: 'HOLD_REJECT'
-    readonly sourceRevision: string
-  }
-  readonly candidatePreregistration: {
-    readonly candidateOrdinal: number
-    readonly priorTrialCount: number
-    readonly sourceRevision: string
-    readonly path: string
-    readonly blobOid: string
-  }
-  readonly nextCandidatePreregistration: CandidateDevelopmentNextPreregistration | null
-}
-
-export const frozenCandidateDevelopmentTrialHistory: CandidateDevelopmentTrialHistory = {
-  schemaVersion: 'bayn.candidate-development-trial-history.v1',
-  completedCandidateOrdinals: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
-  latestTerminalEvidence: {
-    candidateOrdinal: 16,
-    priorTrialCount: 15,
-    terminalStatus: 'HOLD_REJECT',
-    sourceRevision: '60a48a2e52fbafdd67a404a33a3cb22e82a98493',
-  },
-  candidatePreregistration: {
-    candidateOrdinal: 16,
-    priorTrialCount: 15,
-    sourceRevision: 'a0dadcd2f6346968bd9df582e4673608afc04592',
-    path: 'services/bayn/candidates/ordinal-16-macro-breadth-regime-preregistration.md',
-    blobOid: 'f602e3c8fd1b85768404d5fbc439775cdcd2570b',
-  },
-  nextCandidatePreregistration: {
-    schemaVersion: 'bayn.candidate-development-next-preregistration.v1',
-    candidateOrdinal: 17,
-    priorTrialCount: 16,
-    strategyProtocolHash: 'fa25d8c16bc4f4fde3bab99409ae60a6fd23332d295b3557231796cebb911390',
-    modulePath: 'services/bayn/src/strategy/volatility-managed-trend-overlay/candidate-17.ts',
-    moduleSha256: '2e98bc55eae1901ccdde41978b7b32d746dc2ef6afcebbff1de0ed54574065da',
-    marketData: {
-      schemaVersion: 'bayn.candidate-development-market-data-source.v1',
-      snapshotId: '2a91f0177684f7022f746207333e510c8268f9b77a04b778a04220a33ccf79e0',
-      finalizedSnapshotContentHash: '8e376546f6a6cc1dbe2e910db3d68f584fc0bd9c4858166042ce32aa077eed0d',
-      inputManifestHash: 'b606cf57fb076f5bd2875206973e7c512817430d5cfbbeac8a99396f9983cab4',
-      boundedContentHash: 'e0e7b283de187d8ccaf8a449dacc538f00049cfe446dcf153b558e92bf0e17ed',
-    },
-    preregistration: {
-      sourceRevision: '890d8f5801cf7c7576ed7a0cee387a4e79b98877',
-      path: 'services/bayn/candidates/ordinal-17-volatility-managed-trend-overlay-preregistration.json',
-      blobOid: 'c1d07233df53cc0379b1dfae9f1caffbd6b7abd6',
-    },
-  },
-}
+export type { CandidateDevelopmentNextPreregistration } from './candidate-development-decision'
+export {
+  candidate17DevelopmentEligibility,
+  candidate17DevelopmentEvidenceExpectation,
+  candidate17Preregistration,
+  frozenCandidateDevelopmentTrialHistory,
+} from './candidate-development-trial-history'
 
 const fullMarketClosures = new Set<IsoDate>([
   '2016-01-18',

--- a/services/bayn/src/candidate-development-candidate-17-evidence.ts
+++ b/services/bayn/src/candidate-development-candidate-17-evidence.ts
@@ -1,0 +1,26 @@
+import rawEvidence from '../candidates/ordinal-17-volatility-managed-trend-overlay-development-evidence.json' with { type: 'json' }
+
+import { pipe, Result } from 'effect'
+
+import {
+  buildCandidateDevelopmentIndependentReproduction,
+  decodeCandidateDevelopmentImmutableEvidence,
+} from './candidate-development-evidence'
+import { candidateDevelopmentArtifact } from './strategy/volatility-managed-trend-overlay/candidate-17'
+
+export const candidate17DevelopmentEvidenceResult = decodeCandidateDevelopmentImmutableEvidence(rawEvidence)
+
+export const candidate17DevelopmentIndependentReproductionResult = pipe(
+  candidate17DevelopmentEvidenceResult,
+  Result.flatMap((evidence) =>
+    pipe(
+      Result.try({
+        try: () => candidateDevelopmentArtifact.buildEvaluation(evidence.verifiedSource),
+        catch: (cause) => ({ _tag: 'CandidateDevelopmentEvidenceReproductionFailed' as const, cause }),
+      }),
+      Result.flatMap((evaluation) =>
+        buildCandidateDevelopmentIndependentReproduction(evidence.verifiedSource, evaluation),
+      ),
+    ),
+  ),
+)

--- a/services/bayn/src/candidate-development-candidate-17.test.ts
+++ b/services/bayn/src/candidate-development-candidate-17.test.ts
@@ -6,6 +6,8 @@ import { join } from 'node:path'
 import { Effect } from 'effect'
 
 import {
+  candidate17DevelopmentEligibility,
+  candidate17Preregistration,
   frozenCandidateDevelopmentSessions,
   frozenCandidateDevelopmentTrialHistory,
 } from './candidate-development-calendar'
@@ -215,7 +217,7 @@ describe('Candidate 17 preregistration', () => {
       minimumCashReserveWeight: 0.005,
       targetActiveAnnualizedVolatility: 0.1,
     })
-    expect(frozenCandidateDevelopmentTrialHistory.nextCandidatePreregistration).toEqual({
+    expect(candidate17Preregistration).toEqual({
       schemaVersion: 'bayn.candidate-development-next-preregistration.v1',
       candidateOrdinal: 17,
       priorTrialCount: 16,
@@ -235,6 +237,14 @@ describe('Candidate 17 preregistration', () => {
         blobOid: preregistrationBlobOid,
       },
     })
+    expect(frozenCandidateDevelopmentTrialHistory.latestReviewedCandidatePreregistration).toEqual(
+      candidate17Preregistration,
+    )
+    expect(candidate17DevelopmentEligibility).toMatchObject({
+      status: 'DEVELOPMENT_REJECTED',
+      nextCandidatePreregistration: null,
+    })
+    expect(frozenCandidateDevelopmentTrialHistory.nextCandidatePreregistration).toBeNull()
   })
 
   test('keeps future observations out of the causal signal and preserves the financing reserve', () => {

--- a/services/bayn/src/candidate-development-command.test.ts
+++ b/services/bayn/src/candidate-development-command.test.ts
@@ -2635,7 +2635,7 @@ describe('candidate development command', () => {
         _tag: 'CandidateDevelopmentCommandSourceVerificationFailed',
         operation: 'verify-program-binding',
         cause: {
-          field: 'trialHistory.nextCandidatePreregistration.moduleSha256',
+          field: 'trialHistory.latestReviewedCandidatePreregistration.moduleSha256',
           expected: candidate17ModuleSha256,
           observed: 'f'.repeat(64),
         },
@@ -2691,7 +2691,7 @@ describe('candidate development command', () => {
         _tag: 'CandidateDevelopmentCommandSourceVerificationFailed',
         operation: 'verify-program-binding',
         cause: {
-          field: 'trialHistory.nextCandidatePreregistration.input.candidateOrdinal',
+          field: 'trialHistory.latestReviewedCandidatePreregistration.input.candidateOrdinal',
           expected: 17,
           observed: 1,
         },
@@ -2823,7 +2823,7 @@ describe('candidate development command', () => {
         _tag: 'CandidateDevelopmentCommandSourceVerificationFailed',
         operation: 'verify-program-binding',
         cause: {
-          field: 'trialHistory.nextCandidatePreregistration.input.candidateOrdinal',
+          field: 'trialHistory.latestReviewedCandidatePreregistration.input.candidateOrdinal',
           expected: 17,
           observed: 16,
         },

--- a/services/bayn/src/candidate-development-command.ts
+++ b/services/bayn/src/candidate-development-command.ts
@@ -12,7 +12,6 @@ import { Data, Effect, pipe, Result, Schema } from 'effect'
 import {
   candidateDevelopmentComparisonSemantics,
   candidateDevelopmentDoubledCostContract,
-  candidateDevelopmentStatisticsPolicy,
   runCandidateDevelopment,
   type CandidateDevelopmentEffects,
   type CandidateDevelopmentEvaluation,
@@ -21,10 +20,12 @@ import {
   type CandidateDevelopmentReport,
   type CandidateDevelopmentRunFailure,
 } from './candidate-development'
+import { frozenCandidateDevelopmentTrialHistory } from './candidate-development-trial-history'
 import {
-  frozenCandidateDevelopmentTrialHistory,
+  deriveCandidateDevelopmentDecision,
+  type CandidateDevelopmentDecision as CandidateDevelopmentCommandDecision,
   type CandidateDevelopmentNextPreregistration,
-} from './candidate-development-calendar'
+} from './candidate-development-decision'
 import {
   type DailyPerformancePoint,
   DailyPerformanceSeriesArtifactSchema,
@@ -173,27 +174,6 @@ export interface CandidateDevelopmentExecutableProgram<Registration, Development
   readonly input: CandidateDevelopmentPreflightInput
   readonly strategyProtocol: CandidateDevelopmentStrategyProtocol
   readonly effects: CandidateDevelopmentCommandEffects<Registration, DevelopmentData, Error, Requirements>
-}
-
-type CandidateDevelopmentComparisonGateName =
-  (typeof candidateDevelopmentComparisonSemantics.gates)[keyof typeof candidateDevelopmentComparisonSemantics.gates]['name']
-
-export interface CandidateDevelopmentCommandGate {
-  readonly name:
-    | CandidateDevelopmentComparisonGateName
-    | 'double_cost_return'
-    | 'economic_verdict'
-    | 'baseline_terminal_cash'
-    | 'stressed_terminal_cash'
-  readonly passed: boolean
-  readonly actual: number | boolean
-  readonly required: number | boolean
-}
-
-export interface CandidateDevelopmentCommandDecision {
-  readonly status: 'PASS' | 'HOLD_REJECT'
-  readonly selectedBenchmark: 'buy-and-hold' | 'direct-volatility-timing'
-  readonly gates: readonly CandidateDevelopmentCommandGate[]
 }
 
 export interface CandidateDevelopmentCommandReportMaterial {
@@ -652,38 +632,34 @@ export const bindCandidateDevelopmentVerifiedSource = (
       }),
     )
   }
-  const nextCandidatePreregistration = frozenCandidateDevelopmentTrialHistory.nextCandidatePreregistration
-  if (nextCandidatePreregistration !== null) {
-    const expectedNextCandidateOrdinal = completedCandidateOrdinals.length + 1
-    const expectedPriorTrialCount = completedCandidateOrdinals.length
-    const nextBindings = [
-      ['candidateOrdinal', expectedNextCandidateOrdinal, nextCandidatePreregistration.candidateOrdinal],
-      ['priorTrialCount', expectedPriorTrialCount, nextCandidatePreregistration.priorTrialCount],
-      ['input.candidateOrdinal', nextCandidatePreregistration.candidateOrdinal, input.candidateOrdinal],
-      ['input.priorTrialCount', nextCandidatePreregistration.priorTrialCount, input.priorTrialCount],
-      ['strategyProtocolHash', nextCandidatePreregistration.strategyProtocolHash, input.expectedStrategyProtocolHash],
-      ['modulePath', nextCandidatePreregistration.modulePath, files.modulePath],
-      ['moduleSha256', nextCandidatePreregistration.moduleSha256, files.moduleSha256],
-    ] as const
-    for (const [field, expected, observed] of nextBindings) {
-      if (expected !== observed) {
-        return Result.fail(
-          sourceVerificationFailure('verify-program-binding', {
-            field: `trialHistory.nextCandidatePreregistration.${field}`,
-            expected,
-            observed,
-          }),
-        )
-      }
+  const candidatePreregistration = frozenCandidateDevelopmentTrialHistory.latestReviewedCandidatePreregistration
+  const expectedNextCandidateOrdinal = completedCandidateOrdinals.length + 1
+  const expectedPriorTrialCount = completedCandidateOrdinals.length
+  const reviewedBindings = [
+    ['candidateOrdinal', expectedNextCandidateOrdinal, candidatePreregistration.candidateOrdinal],
+    ['priorTrialCount', expectedPriorTrialCount, candidatePreregistration.priorTrialCount],
+    ['input.candidateOrdinal', candidatePreregistration.candidateOrdinal, input.candidateOrdinal],
+    ['input.priorTrialCount', candidatePreregistration.priorTrialCount, input.priorTrialCount],
+    ['strategyProtocolHash', candidatePreregistration.strategyProtocolHash, input.expectedStrategyProtocolHash],
+    ['modulePath', candidatePreregistration.modulePath, files.modulePath],
+    ['moduleSha256', candidatePreregistration.moduleSha256, files.moduleSha256],
+  ] as const
+  for (const [field, expected, observed] of reviewedBindings) {
+    if (expected !== observed) {
+      return Result.fail(
+        sourceVerificationFailure('verify-program-binding', {
+          field: `trialHistory.latestReviewedCandidatePreregistration.${field}`,
+          expected,
+          observed,
+        }),
+      )
     }
-    const marketDataBinding = validateCandidateDevelopmentPreregisteredMarketData(
-      nextCandidatePreregistration.marketData,
-      files.sourceManifest.marketData,
-    )
-    if (Result.isFailure(marketDataBinding)) return Result.fail(marketDataBinding.failure)
   }
-  const candidatePreregistration =
-    nextCandidatePreregistration ?? frozenCandidateDevelopmentTrialHistory.candidatePreregistration
+  const marketDataBinding = validateCandidateDevelopmentPreregisteredMarketData(
+    candidatePreregistration.marketData,
+    files.sourceManifest.marketData,
+  )
+  if (Result.isFailure(marketDataBinding)) return Result.fail(marketDataBinding.failure)
   if (
     input.candidateOrdinal !== candidatePreregistration.candidateOrdinal ||
     input.priorTrialCount !== candidatePreregistration.priorTrialCount
@@ -2228,83 +2204,14 @@ const decideCandidateDevelopment = (
   baseline: EvaluationResult,
   doubledCostAnnualizedReturn: number,
   economicPass: boolean,
-): CandidateDevelopmentCommandDecision => {
-  const { bootstrap, power, walkForward } = report.comparisonSemantics.analysis
-  const protocolGates = candidateDevelopmentComparisonSemantics.gates
-  const gates: readonly CandidateDevelopmentCommandGate[] = [
-    {
-      name: protocolGates.power.name,
-      passed: power.sufficient,
-      actual: power.sufficient,
-      required: true,
-    },
-    {
-      name: protocolGates.bootstrapTailResolution.name,
-      passed: bootstrap.tailResolutionSufficient,
-      actual: bootstrap.tailSampleCount,
-      required: bootstrap.minimumTailSamples,
-    },
-    {
-      name: protocolGates.annualizedExcessReturnLowerBound.name,
-      passed: bootstrap.annualizedReturnDifferenceLowerBound > 0,
-      actual: bootstrap.annualizedReturnDifferenceLowerBound,
-      required: 0,
-    },
-    {
-      name: protocolGates.sharpeDifferenceLowerBound.name,
-      passed: bootstrap.sharpeDifferenceLowerBound > 0,
-      actual: bootstrap.sharpeDifferenceLowerBound,
-      required: 0,
-    },
-    {
-      name: protocolGates.walkForwardFolds.name,
-      passed: walkForward.sufficient,
-      actual: walkForward.folds.length,
-      required: walkForward.requiredFolds,
-    },
-    {
-      name: protocolGates.walkForwardPositiveFraction.name,
-      passed: walkForward.positiveFoldFraction >= walkForward.requiredPositiveFoldFraction,
-      actual: walkForward.positiveFoldFraction,
-      required: walkForward.requiredPositiveFoldFraction,
-    },
-    {
-      name: protocolGates.walkForwardDrawdown.name,
-      passed: walkForward.allDrawdownsWithinLimit,
-      actual: walkForward.maximumFoldDrawdown,
-      required: candidateDevelopmentStatisticsPolicy.walkForward.maximumFoldDrawdown,
-    },
-    {
-      name: 'double_cost_return',
-      passed: doubledCostAnnualizedReturn > 0,
-      actual: doubledCostAnnualizedReturn,
-      required: 0,
-    },
-    {
-      name: 'economic_verdict',
-      passed: economicPass,
-      actual: economicPass,
-      required: true,
-    },
-    {
-      name: 'baseline_terminal_cash',
-      passed: terminalCash(baseline.simulation.dailyMarks),
-      actual: terminalCash(baseline.simulation.dailyMarks),
-      required: true,
-    },
-    {
-      name: 'stressed_terminal_cash',
-      passed: terminalCash(report.doubledCost.stressed.simulation.dailyMarks),
-      actual: terminalCash(report.doubledCost.stressed.simulation.dailyMarks),
-      required: true,
-    },
-  ]
-  return {
-    status: gates.every((gate) => gate.passed) ? 'PASS' : 'HOLD_REJECT',
-    selectedBenchmark: bootstrap.selectedBenchmark,
-    gates,
-  }
-}
+): CandidateDevelopmentCommandDecision =>
+  deriveCandidateDevelopmentDecision({
+    comparison: report.comparisonSemantics.analysis,
+    doubledCostAnnualizedReturn,
+    economicPass,
+    baselineTerminalCash: terminalCash(baseline.simulation.dailyMarks),
+    stressedTerminalCash: terminalCash(report.doubledCost.stressed.simulation.dailyMarks),
+  })
 
 export const buildCandidateDevelopmentCommandReport = (
   report: CandidateDevelopmentReport,
@@ -2479,7 +2386,7 @@ export interface CandidateDevelopmentVerifiedModuleSource {
   readonly moduleUrl: string
 }
 
-const CandidateDevelopmentPreflightInputSchema = Schema.Struct({
+export const CandidateDevelopmentPreflightInputSchema = Schema.Struct({
   candidateOrdinal: PositiveIntegerSchema,
   priorTrialCount: NonNegativeIntegerSchema,
   expectedStrategyProtocolHash: Sha256Schema,
@@ -2600,7 +2507,7 @@ const CandidateDevelopmentMarketDataWitnessSchema = Schema.Struct({
   bars: Schema.Array(CandidateDevelopmentDailyBarSchema).check(Schema.isMinLength(1)),
 })
 
-const CandidateDevelopmentStrategyProtocolSchema = Schema.Struct({
+export const CandidateDevelopmentStrategyProtocolSchema = Schema.Struct({
   schemaVersion: Schema.Literal('bayn.candidate-development-strategy-protocol.v2'),
   universe: Schema.Array(SymbolSchema).check(Schema.isMinLength(1)),
   directVolatilityTarget: PositiveFiniteSchema,
@@ -2627,7 +2534,7 @@ const CandidateDevelopmentStrategyProtocolSchema = Schema.Struct({
   }),
 })
 
-const CandidateDevelopmentSourceManifestSchema = Schema.Struct({
+export const CandidateDevelopmentSourceManifestSchema = Schema.Struct({
   schemaVersion: Schema.Literal('bayn.candidate-development-source-manifest.v1'),
   candidateOrdinal: PositiveIntegerSchema,
   priorTrialCount: NonNegativeIntegerSchema,
@@ -2672,7 +2579,7 @@ const CandidateDevelopmentDoubledCostRunSchema = Schema.Struct({
   simulation: CandidateDevelopmentSimulationTraceSchema,
 })
 
-const CandidateDevelopmentEvaluationSchema = Schema.Struct({
+export const CandidateDevelopmentEvaluationSchema = Schema.Struct({
   baseline: CandidateDevelopmentEvaluationResultSchema,
   comparisonSemantics: CandidateDevelopmentComparisonSemanticsEvidenceBoundarySchema,
   stressed: CandidateDevelopmentDoubledCostRunSchema,
@@ -3673,9 +3580,10 @@ export const verifyCandidateDevelopmentSourceFiles: CandidateDevelopmentSourceVe
           observed: sourceRevision,
         })
       }
-      const nextCandidatePreregistration = frozenCandidateDevelopmentTrialHistory.nextCandidatePreregistration
-      if (nextCandidatePreregistration !== null) {
-        const preregistration = nextCandidatePreregistration.preregistration
+      const reviewedCandidatePreregistration =
+        frozenCandidateDevelopmentTrialHistory.latestReviewedCandidatePreregistration
+      {
+        const preregistration = reviewedCandidatePreregistration.preregistration
         if (
           !/^[0-9a-f]{40}$/.test(preregistration.sourceRevision) ||
           !/^[0-9a-f]{40}$/.test(preregistration.blobOid) ||
@@ -3715,7 +3623,7 @@ export const verifyCandidateDevelopmentSourceFiles: CandidateDevelopmentSourceVe
           async () => JSON.parse(preregistrationBytes.toString('utf8')) as unknown,
         )
         const preregistrationDocument = validateCandidateDevelopmentPreregistrationDocument(
-          nextCandidatePreregistration,
+          reviewedCandidatePreregistration,
           preregistrationJson,
         )
         if (Result.isFailure(preregistrationDocument)) {
@@ -3777,10 +3685,10 @@ export const verifyCandidateDevelopmentSourceFiles: CandidateDevelopmentSourceVe
             sourceGit.text(repositoryRoot, ['rev-parse', sourceManifestSpec], batchSignal),
           ),
       )
-      if (nextCandidatePreregistration !== null) {
+      {
         await verifyCandidateDevelopmentPreregistrationModuleNoveltyPromise(
           repositoryRoot,
-          nextCandidatePreregistration.preregistration.sourceRevision,
+          reviewedCandidatePreregistration.preregistration.sourceRevision,
           moduleRepositoryPath.success,
           moduleBlobOid,
           sourceGit,

--- a/services/bayn/src/candidate-development-decision.ts
+++ b/services/bayn/src/candidate-development-decision.ts
@@ -1,0 +1,131 @@
+import { candidateDevelopmentComparisonSemantics, candidateDevelopmentStatisticsPolicy } from './candidate-development'
+import type { QualificationSelectedBenchmarkComparisonAnalysis } from './qualification-statistics'
+
+export interface CandidateDevelopmentNextPreregistration {
+  readonly schemaVersion: 'bayn.candidate-development-next-preregistration.v1'
+  readonly candidateOrdinal: number
+  readonly priorTrialCount: number
+  readonly strategyProtocolHash: string
+  readonly modulePath: string
+  readonly moduleSha256: string
+  readonly marketData: {
+    readonly schemaVersion: 'bayn.candidate-development-market-data-source.v1'
+    readonly snapshotId: string
+    readonly finalizedSnapshotContentHash: string
+    readonly inputManifestHash: string
+    readonly boundedContentHash: string
+  }
+  readonly preregistration: {
+    readonly sourceRevision: string
+    readonly path: string
+    readonly blobOid: string
+  }
+}
+
+export type CandidateDevelopmentGateName =
+  | (typeof candidateDevelopmentComparisonSemantics.gates)[keyof typeof candidateDevelopmentComparisonSemantics.gates]['name']
+  | 'double_cost_return'
+  | 'economic_verdict'
+  | 'baseline_terminal_cash'
+  | 'stressed_terminal_cash'
+
+export interface CandidateDevelopmentGate {
+  readonly name: CandidateDevelopmentGateName
+  readonly passed: boolean
+  readonly actual: number | boolean
+  readonly required: number | boolean
+}
+
+export interface CandidateDevelopmentDecision {
+  readonly status: 'PASS' | 'HOLD_REJECT'
+  readonly selectedBenchmark: 'buy-and-hold' | 'direct-volatility-timing'
+  readonly gates: readonly CandidateDevelopmentGate[]
+}
+
+export interface CandidateDevelopmentDecisionEvidence {
+  readonly comparison: QualificationSelectedBenchmarkComparisonAnalysis
+  readonly doubledCostAnnualizedReturn: number
+  readonly economicPass: boolean
+  readonly baselineTerminalCash: boolean
+  readonly stressedTerminalCash: boolean
+}
+
+export const deriveCandidateDevelopmentDecision = (
+  evidence: CandidateDevelopmentDecisionEvidence,
+): CandidateDevelopmentDecision => {
+  const { bootstrap, power, walkForward } = evidence.comparison
+  const protocolGates = candidateDevelopmentComparisonSemantics.gates
+  const gates: readonly CandidateDevelopmentGate[] = [
+    {
+      name: protocolGates.power.name,
+      passed: power.sufficient,
+      actual: power.sufficient,
+      required: true,
+    },
+    {
+      name: protocolGates.bootstrapTailResolution.name,
+      passed: bootstrap.tailResolutionSufficient,
+      actual: bootstrap.tailSampleCount,
+      required: bootstrap.minimumTailSamples,
+    },
+    {
+      name: protocolGates.annualizedExcessReturnLowerBound.name,
+      passed: bootstrap.annualizedReturnDifferenceLowerBound > 0,
+      actual: bootstrap.annualizedReturnDifferenceLowerBound,
+      required: 0,
+    },
+    {
+      name: protocolGates.sharpeDifferenceLowerBound.name,
+      passed: bootstrap.sharpeDifferenceLowerBound > 0,
+      actual: bootstrap.sharpeDifferenceLowerBound,
+      required: 0,
+    },
+    {
+      name: protocolGates.walkForwardFolds.name,
+      passed: walkForward.sufficient,
+      actual: walkForward.folds.length,
+      required: walkForward.requiredFolds,
+    },
+    {
+      name: protocolGates.walkForwardPositiveFraction.name,
+      passed: walkForward.positiveFoldFraction >= walkForward.requiredPositiveFoldFraction,
+      actual: walkForward.positiveFoldFraction,
+      required: walkForward.requiredPositiveFoldFraction,
+    },
+    {
+      name: protocolGates.walkForwardDrawdown.name,
+      passed: walkForward.allDrawdownsWithinLimit,
+      actual: walkForward.maximumFoldDrawdown,
+      required: candidateDevelopmentStatisticsPolicy.walkForward.maximumFoldDrawdown,
+    },
+    {
+      name: 'double_cost_return',
+      passed: evidence.doubledCostAnnualizedReturn > 0,
+      actual: evidence.doubledCostAnnualizedReturn,
+      required: 0,
+    },
+    {
+      name: 'economic_verdict',
+      passed: evidence.economicPass,
+      actual: evidence.economicPass,
+      required: true,
+    },
+    {
+      name: 'baseline_terminal_cash',
+      passed: evidence.baselineTerminalCash,
+      actual: evidence.baselineTerminalCash,
+      required: true,
+    },
+    {
+      name: 'stressed_terminal_cash',
+      passed: evidence.stressedTerminalCash,
+      actual: evidence.stressedTerminalCash,
+      required: true,
+    },
+  ]
+  return {
+    status: gates.every((gate) => gate.passed) ? 'PASS' : 'HOLD_REJECT',
+    selectedBenchmark: bootstrap.selectedBenchmark,
+    gates,
+  }
+}

--- a/services/bayn/src/candidate-development-evidence.test.ts
+++ b/services/bayn/src/candidate-development-evidence.test.ts
@@ -1,0 +1,400 @@
+import { describe, expect, test } from 'bun:test'
+import { Result } from 'effect'
+
+import {
+  candidate17DevelopmentEligibility,
+  candidate17DevelopmentEvidenceExpectation,
+  candidate17Preregistration,
+  frozenCandidateDevelopmentTrialHistory,
+} from './candidate-development-calendar'
+import {
+  candidate17DevelopmentEvidenceResult,
+  candidate17DevelopmentIndependentReproductionResult,
+} from './candidate-development-candidate-17-evidence'
+import { deriveCandidateDevelopmentDecision } from './candidate-development-decision'
+import {
+  candidateDevelopmentDecisionOutputMaterial,
+  decideCandidateDevelopmentEligibility,
+  decideCandidateDevelopmentEligibilityFromUnknown,
+  validateCandidateDevelopmentIndependentReproduction,
+  withCandidateDevelopmentQualificationAuthorization,
+  type CandidateDevelopmentEvidenceExpectation,
+  type CandidateDevelopmentEvidenceIssue,
+  type CandidateDevelopmentImmutableEvidence,
+} from './candidate-development-evidence'
+import { canonicalHashV1 } from './hash'
+import type { QualificationSelectedBenchmarkComparisonAnalysis } from './qualification-statistics'
+
+const successOf = <A, E>(result: Result.Result<A, E>): A => {
+  expect(Result.isSuccess(result)).toBe(true)
+  if (Result.isFailure(result)) throw new Error('expected Candidate 17 evidence decode success')
+  return result.success
+}
+
+const candidate17DevelopmentEvidence = successOf(candidate17DevelopmentEvidenceResult)
+const candidate17DevelopmentIndependentReproduction = successOf(candidate17DevelopmentIndependentReproductionResult)
+
+const candidate17ValidatedEligibility = decideCandidateDevelopmentEligibility(
+  candidate17DevelopmentEvidence,
+  candidate17DevelopmentEvidenceExpectation,
+  candidate17Preregistration,
+)
+
+const selfExpectation = (evidence: CandidateDevelopmentImmutableEvidence): CandidateDevelopmentEvidenceExpectation => ({
+  bindings: evidence.bindings,
+  evidenceContentHash: evidence.contentHash,
+  independentlyReproducedEvaluationHash:
+    candidate17DevelopmentEvidenceExpectation.independentlyReproducedEvaluationHash,
+  independentlyReproducedDecisionOutputHash:
+    candidate17DevelopmentEvidenceExpectation.independentlyReproducedDecisionOutputHash,
+})
+
+const rehashEvidence = (mutate: (evidence: Record<string, any>) => void): CandidateDevelopmentImmutableEvidence => {
+  const evidence = structuredClone(candidate17DevelopmentEvidence) as unknown as Record<string, any>
+  mutate(evidence)
+  const { contentHash: _, ...material } = evidence
+  evidence.contentHash = canonicalHashV1(material)
+  return evidence as unknown as CandidateDevelopmentImmutableEvidence
+}
+
+const invalidIssue = (
+  evidence: CandidateDevelopmentImmutableEvidence,
+  tag: CandidateDevelopmentEvidenceIssue['_tag'],
+): boolean => {
+  const decision = decideCandidateDevelopmentEligibility(
+    evidence,
+    selfExpectation(evidence),
+    candidate17Preregistration,
+  )
+  expect(decision).toMatchObject({ status: 'DEVELOPMENT_EVIDENCE_INVALID', nextCandidatePreregistration: null })
+  return decision.status === 'DEVELOPMENT_EVIDENCE_INVALID' && decision.issues.some((issue) => issue._tag === tag)
+}
+
+const passingAnalysis = (): QualificationSelectedBenchmarkComparisonAnalysis => {
+  const analysis = structuredClone(
+    candidate17DevelopmentEvidence.evaluation.comparisonSemantics.analysis,
+  ) as unknown as Record<string, any>
+  analysis.power.sufficient = true
+  analysis.bootstrap.tailResolutionSufficient = true
+  analysis.bootstrap.annualizedReturnDifferenceLowerBound = 0.01
+  analysis.bootstrap.sharpeDifferenceLowerBound = 0.01
+  analysis.walkForward.folds = analysis.walkForward.folds.map((fold: Record<string, any>, ordinal: number) => ({
+    ...fold,
+    ordinal,
+    strategyReturn: 0.1,
+    selectedBenchmarkReturn: 0.05,
+    returnDifference: 0.05,
+    maximumDrawdown: 0.1,
+    positiveDifference: true,
+    drawdownWithinLimit: true,
+  }))
+  analysis.walkForward.positiveFolds = analysis.walkForward.folds.length
+  analysis.walkForward.positiveFoldFraction = 1
+  analysis.walkForward.allDrawdownsWithinLimit = true
+  analysis.walkForward.maximumFoldDrawdown = 0.1
+  analysis.walkForward.sufficient = true
+  return analysis as unknown as QualificationSelectedBenchmarkComparisonAnalysis
+}
+
+describe('candidate development immutable evidence gate', () => {
+  test('requires every existing development gate for a pure PASS decision', () => {
+    const comparison = passingAnalysis()
+    const passed = deriveCandidateDevelopmentDecision({
+      comparison,
+      doubledCostAnnualizedReturn: 0.1,
+      economicPass: true,
+      baselineTerminalCash: true,
+      stressedTerminalCash: true,
+    })
+    expect(passed.status).toBe('PASS')
+    expect(passed.gates.every((gate) => gate.passed)).toBe(true)
+
+    const failures = [
+      {
+        comparison,
+        doubledCostAnnualizedReturn: -0.01,
+        economicPass: true,
+        baselineTerminalCash: true,
+        stressedTerminalCash: true,
+      },
+      {
+        comparison: {
+          ...comparison,
+          bootstrap: { ...comparison.bootstrap, annualizedReturnDifferenceLowerBound: 0 },
+        },
+        doubledCostAnnualizedReturn: 0.1,
+        economicPass: true,
+        baselineTerminalCash: true,
+        stressedTerminalCash: true,
+      },
+      {
+        comparison: {
+          ...comparison,
+          bootstrap: { ...comparison.bootstrap, sharpeDifferenceLowerBound: 0 },
+        },
+        doubledCostAnnualizedReturn: 0.1,
+        economicPass: true,
+        baselineTerminalCash: true,
+        stressedTerminalCash: true,
+      },
+      {
+        comparison: { ...comparison, power: { ...comparison.power, sufficient: false } },
+        doubledCostAnnualizedReturn: 0.1,
+        economicPass: true,
+        baselineTerminalCash: true,
+        stressedTerminalCash: true,
+      },
+      {
+        comparison: {
+          ...comparison,
+          walkForward: { ...comparison.walkForward, positiveFoldFraction: 0.4 },
+        },
+        doubledCostAnnualizedReturn: 0.1,
+        economicPass: true,
+        baselineTerminalCash: true,
+        stressedTerminalCash: true,
+      },
+      {
+        comparison,
+        doubledCostAnnualizedReturn: 0.1,
+        economicPass: false,
+        baselineTerminalCash: true,
+        stressedTerminalCash: true,
+      },
+    ] as const
+    for (const failure of failures) expect(deriveCandidateDevelopmentDecision(failure).status).toBe('HOLD_REJECT')
+  })
+
+  test('binds the complete evaluation and decision output reproduced by the reviewed module', () => {
+    const reproduced = candidate17DevelopmentIndependentReproduction.evaluation
+    expect(canonicalHashV1(reproduced)).toBe(
+      candidate17DevelopmentEvidenceExpectation.independentlyReproducedEvaluationHash,
+    )
+    expect(canonicalHashV1(candidateDevelopmentDecisionOutputMaterial(reproduced))).toBe(
+      candidate17DevelopmentEvidenceExpectation.independentlyReproducedDecisionOutputHash,
+    )
+    expect(canonicalHashV1(reproduced)).toBe(canonicalHashV1(candidate17DevelopmentEvidence.evaluation))
+    expect(
+      validateCandidateDevelopmentIndependentReproduction(
+        candidate17DevelopmentEvidence,
+        candidate17DevelopmentEvidenceExpectation,
+        candidate17DevelopmentIndependentReproduction,
+      ),
+    ).toEqual([])
+  }, 30_000)
+
+  test('rejects hindsight decisions that the reviewed module did not reproduce', () => {
+    const hindsight = rehashEvidence((record) => {
+      const baseline = record.evaluation.baseline.signalDecisions[0]
+      const stressed = record.evaluation.stressed.signalDecisions[0]
+      baseline.targetWeights = { ...baseline.targetWeights, SPY: 0.99 }
+      stressed.targetWeights = { ...stressed.targetWeights, SPY: 0.99 }
+    })
+    const issues = validateCandidateDevelopmentIndependentReproduction(
+      hindsight,
+      selfExpectation(hindsight),
+      candidate17DevelopmentIndependentReproduction,
+    )
+    expect(issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          _tag: 'CandidateDevelopmentEvidenceBindingMismatch',
+          field: 'reproduction.evaluation',
+        }),
+      ]),
+    )
+  })
+
+  test('recomputes economic metrics from complete equity and accounting evidence', () => {
+    const evidence = rehashEvidence((record) => {
+      record.evaluation.baseline.strategy = {
+        ...record.evaluation.baseline.strategy,
+        totalReturn: -0.5,
+        annualizedReturn: 0.5,
+        sharpe: 2,
+        maximumDrawdown: 0.01,
+      }
+      record.evaluation.baseline.verdict.status = 'PASS'
+      for (const gate of record.evaluation.baseline.verdict.gates) gate.passed = true
+    })
+    expect(invalidIssue(evidence, 'CandidateDevelopmentEvidenceEconomicInvalid')).toBe(true)
+  })
+
+  test('recomputes bootstrap distributions, hashes, quantiles, and power from the bound series', () => {
+    const forgedBootstrap = rehashEvidence((record) => {
+      const bootstrap = record.evaluation.comparisonSemantics.analysis.bootstrap
+      bootstrap.annualizedReturnDifferenceSamples = bootstrap.annualizedReturnDifferenceSamples.map(() => 1)
+      bootstrap.sharpeDifferenceSamples = bootstrap.sharpeDifferenceSamples.map(() => 1)
+      bootstrap.annualizedReturnDifferenceLowerBound = 1
+      bootstrap.sharpeDifferenceLowerBound = 1
+      bootstrap.samplesHash = 'f'.repeat(64)
+      record.evaluation.comparisonSemantics.analysis.analysisHash = 'e'.repeat(64)
+    })
+    expect(invalidIssue(forgedBootstrap, 'CandidateDevelopmentEvidenceComparisonInvalid')).toBe(true)
+
+    const forgedPower = rehashEvidence((record) => {
+      const power = record.evaluation.comparisonSemantics.analysis.power
+      power.availableCompleteRebalanceBlocks = 0
+      power.availableCompleteSessions = 0
+      power.sufficient = true
+      record.evaluation.comparisonSemantics.analysis.analysisHash = 'd'.repeat(64)
+    })
+    expect(invalidIssue(forgedPower, 'CandidateDevelopmentEvidenceComparisonInvalid')).toBe(true)
+  }, 30_000)
+
+  test('enforces policy-selected benchmark and expanding-origin fold geometry', () => {
+    const forgedBenchmark = rehashEvidence((record) => {
+      const analysis = record.evaluation.comparisonSemantics.analysis
+      analysis.bootstrap.selectedBenchmark = 'direct-volatility-timing'
+      analysis.walkForward.selectedBenchmark = 'direct-volatility-timing'
+      for (const fold of analysis.walkForward.folds) {
+        fold.selectedBenchmark = 'direct-volatility-timing'
+        fold.selectedBenchmarkReturn = -0.5
+        fold.returnDifference = 0.5
+        fold.positiveDifference = true
+      }
+      analysis.walkForward.positiveFolds = analysis.walkForward.folds.length
+      analysis.walkForward.positiveFoldFraction = 1
+      analysis.analysisHash = 'c'.repeat(64)
+    })
+    expect(invalidIssue(forgedBenchmark, 'CandidateDevelopmentEvidenceComparisonInvalid')).toBe(true)
+
+    const forgedGeometry = rehashEvidence((record) => {
+      const analysis = record.evaluation.comparisonSemantics.analysis
+      const first = analysis.walkForward.folds[0]
+      analysis.walkForward.folds = analysis.walkForward.folds.map((fold: Record<string, any>, ordinal: number) => ({
+        ...fold,
+        ordinal,
+        trainingStart: first.trainingStart,
+        trainingEnd: first.trainingEnd,
+        testStart: first.testStart,
+        testEnd: first.testStart,
+        testObservationCount: 1,
+      }))
+      analysis.analysisHash = 'b'.repeat(64)
+    })
+    expect(invalidIssue(forgedGeometry, 'CandidateDevelopmentEvidenceComparisonInvalid')).toBe(true)
+  }, 30_000)
+
+  test('revalidates the baseline and stressed doubled-cost causal paths', () => {
+    const evidence = rehashEvidence((record) => {
+      const order = record.evaluation.stressed.simulation.orders.find(
+        (candidate: Record<string, any>) => candidate.filledQuantityMicros !== '0',
+      )
+      if (order === undefined) throw new Error('Candidate 17 stressed evidence must contain a nonzero order')
+      order.requestedQuantityMicros = (BigInt(order.requestedQuantityMicros) + 1n).toString()
+      order.filledQuantityMicros = (BigInt(order.filledQuantityMicros) + 1n).toString()
+    })
+    expect(invalidIssue(evidence, 'CandidateDevelopmentEvidenceDoubledCostInvalid')).toBe(true)
+  })
+
+  test('fails closed on missing, malformed, tampered, stale, or mismatched evidence', () => {
+    const malformed = structuredClone(candidate17DevelopmentEvidence) as unknown as Record<string, any>
+    delete malformed.bindings.schemaVersion
+    malformed.evaluation.baseline.strategy.annualizedReturn = 'not-a-number'
+    const malformedDecision = decideCandidateDevelopmentEligibilityFromUnknown(
+      malformed,
+      candidate17DevelopmentEvidenceExpectation,
+      candidate17Preregistration,
+    )
+    expect(malformedDecision).toMatchObject({
+      status: 'DEVELOPMENT_EVIDENCE_INVALID',
+      issues: [{ _tag: 'CandidateDevelopmentEvidenceDecodeFailed' }],
+      nextCandidatePreregistration: null,
+    })
+
+    const missing = decideCandidateDevelopmentEligibility(
+      null,
+      candidate17DevelopmentEvidenceExpectation,
+      candidate17Preregistration,
+    )
+    expect(missing).toMatchObject({ status: 'DEVELOPMENT_EVIDENCE_INVALID', nextCandidatePreregistration: null })
+
+    const tampered = structuredClone(candidate17DevelopmentEvidence) as unknown as Record<string, any>
+    tampered.evaluation.baseline.strategy.annualizedReturn = 1
+    expect(
+      decideCandidateDevelopmentEligibility(
+        tampered as unknown as CandidateDevelopmentImmutableEvidence,
+        candidate17DevelopmentEvidenceExpectation,
+        candidate17Preregistration,
+      ),
+    ).toMatchObject({ status: 'DEVELOPMENT_EVIDENCE_INVALID', nextCandidatePreregistration: null })
+
+    const stale = rehashEvidence((record) => {
+      record.bindings.mergedSourceRevision = 'f'.repeat(40)
+    })
+    expect(
+      decideCandidateDevelopmentEligibility(
+        stale,
+        candidate17DevelopmentEvidenceExpectation,
+        candidate17Preregistration,
+      ),
+    ).toMatchObject({ status: 'DEVELOPMENT_EVIDENCE_INVALID', nextCandidatePreregistration: null })
+
+    const mismatchedPreregistration = { ...candidate17Preregistration, moduleSha256: '0'.repeat(64) }
+    expect(
+      decideCandidateDevelopmentEligibility(
+        candidate17DevelopmentEvidence,
+        candidate17DevelopmentEvidenceExpectation,
+        mismatchedPreregistration,
+      ),
+    ).toMatchObject({ status: 'DEVELOPMENT_EVIDENCE_INVALID', nextCandidatePreregistration: null })
+  }, 30_000)
+
+  test('records Candidate 17 as development rejected without consuming qualification or creating Candidate 18', () => {
+    expect(candidate17ValidatedEligibility).toMatchObject({
+      status: 'DEVELOPMENT_REJECTED',
+      evidenceContentHash: candidate17DevelopmentEligibility.evidenceContentHash,
+      nextCandidatePreregistration: null,
+    })
+    expect(candidate17DevelopmentEligibility).toEqual({
+      status: 'DEVELOPMENT_REJECTED',
+      evidenceContentHash: candidate17DevelopmentEvidenceExpectation.evidenceContentHash,
+      nextCandidatePreregistration: null,
+    })
+    expect(frozenCandidateDevelopmentTrialHistory.completedCandidateOrdinals).toEqual([
+      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16,
+    ])
+    expect(frozenCandidateDevelopmentTrialHistory.latestDevelopmentEvidence).toMatchObject({
+      candidateOrdinal: 17,
+      priorTrialCount: 16,
+      status: 'DEVELOPMENT_REJECTED',
+      qualificationAttemptConsumed: false,
+    })
+    expect(frozenCandidateDevelopmentTrialHistory.nextCandidatePreregistration).toBeNull()
+    expect(Math.max(...frozenCandidateDevelopmentTrialHistory.completedCandidateOrdinals)).toBe(16)
+  })
+
+  test('does not call a holdout loader for rejected, missing, or stale evidence', () => {
+    let calls = 0
+    const loadHoldout = () => {
+      calls += 1
+      return 'holdout'
+    }
+    const rejected = withCandidateDevelopmentQualificationAuthorization(candidate17ValidatedEligibility, loadHoldout)
+    const missing = withCandidateDevelopmentQualificationAuthorization(
+      decideCandidateDevelopmentEligibility(
+        null,
+        candidate17DevelopmentEvidenceExpectation,
+        candidate17Preregistration,
+      ),
+      loadHoldout,
+    )
+    const staleEvidence = rehashEvidence((record) => {
+      record.bindings.strategyProtocolHash = '0'.repeat(64)
+    })
+    const stale = withCandidateDevelopmentQualificationAuthorization(
+      decideCandidateDevelopmentEligibility(
+        staleEvidence,
+        candidate17DevelopmentEvidenceExpectation,
+        candidate17Preregistration,
+      ),
+      loadHoldout,
+    )
+
+    expect(rejected).toMatchObject({ status: 'BLOCKED', reason: 'DEVELOPMENT_REJECTED' })
+    expect(missing).toMatchObject({ status: 'BLOCKED', reason: 'DEVELOPMENT_EVIDENCE_INVALID' })
+    expect(stale).toMatchObject({ status: 'BLOCKED', reason: 'DEVELOPMENT_EVIDENCE_INVALID' })
+    expect(calls).toBe(0)
+  })
+})

--- a/services/bayn/src/candidate-development-evidence.ts
+++ b/services/bayn/src/candidate-development-evidence.ts
@@ -1,0 +1,1033 @@
+import { pipe, Result, Schema } from 'effect'
+
+import {
+  candidateDevelopmentCalendarContract,
+  candidateDevelopmentComparisonSemantics,
+  preflightCandidateDevelopment,
+  validateCandidateDevelopmentComparisonSemanticsEvidence,
+  validateCandidateDevelopmentComparisonSeriesBinding,
+  validateCandidateDevelopmentDoubledCostCausalPath,
+  type CandidateDevelopmentDoubledCostRun,
+  type CandidateDevelopmentPreflightInput,
+  type CandidateDevelopmentPreflightPass,
+  type CandidateDevelopmentReport,
+} from './candidate-development'
+import {
+  deriveCandidateDevelopmentDecision,
+  type CandidateDevelopmentDecision,
+  type CandidateDevelopmentNextPreregistration,
+} from './candidate-development-decision'
+import {
+  buildCandidateDevelopmentCommandReport,
+  CandidateDevelopmentEvaluationSchema,
+  CandidateDevelopmentPreflightInputSchema,
+  CandidateDevelopmentSourceManifestSchema,
+  CandidateDevelopmentStrategyProtocolSchema,
+  validateCandidateDevelopmentCommandEvaluation,
+  type CandidateDevelopmentCommandEvaluation,
+  type CandidateDevelopmentStrategyProtocol,
+  type CandidateDevelopmentVerifiedSource,
+} from './candidate-development-command'
+import { canonicalHashV1Result, type CanonicalHashFailure } from './hash'
+import { prepareQualificationSeries } from './qualification-statistics'
+import {
+  GitSourceRevisionSchema,
+  NonNegativeIntegerSchema,
+  PositiveIntegerSchema,
+  Sha256Schema,
+  StrictNonEmptyStringSchema,
+  UtcInstantSchema,
+  strictParseOptions,
+} from './schemas'
+import { buildVerdict, calculateExactPerformanceMetrics } from './simulation/metrics'
+import type { DailyPerformancePoint, EvaluationResult, PerformanceMetrics } from './types'
+
+export interface CandidateDevelopmentEvidenceBindings {
+  readonly schemaVersion: 'bayn.candidate-development-evidence-bindings.v1'
+  readonly candidateOrdinal: number
+  readonly priorTrialCount: number
+  readonly preregistration: CandidateDevelopmentNextPreregistration['preregistration']
+  readonly reviewedSourceRevision: string
+  readonly mergedSourceRevision: string
+  readonly module: {
+    readonly path: string
+    readonly blobOid: string
+    readonly sha256: string
+  }
+  readonly sourceManifest: {
+    readonly path: string
+    readonly blobOid: string
+    readonly sha256: string
+  }
+  readonly strategyProtocolHash: string
+  readonly candidateDevelopmentProtocolHash: string
+  readonly marketData: CandidateDevelopmentNextPreregistration['marketData']
+  readonly calendar: typeof candidateDevelopmentCalendarContract
+}
+
+export interface CandidateDevelopmentReviewedTerminalSummary {
+  readonly schemaVersion: 'bayn.candidate-development-reviewed-terminal-summary.v1'
+  readonly source: 'reviewed-development-only-evaluation'
+  readonly strategyAnnualizedReturn: number
+  readonly buyAndHoldAnnualizedReturn: number
+  readonly annualizedReturnDifferenceLowerBound: number
+  readonly sharpeDifferenceLowerBound: number
+  readonly verdict: 'PASS' | 'FAIL_CLOSED'
+  readonly researchContext: readonly [
+    'https://doi.org/10.1111/1468-0262.00152',
+    'https://papers.ssrn.com/sol3/papers.cfm?abstract_id=2326253',
+  ]
+}
+
+export interface CandidateDevelopmentImmutableEvidence {
+  readonly schemaVersion: 'bayn.candidate-development-immutable-evidence.v2'
+  readonly recordedAt: string
+  readonly bindings: CandidateDevelopmentEvidenceBindings
+  readonly input: CandidateDevelopmentPreflightInput
+  readonly verifiedSource: CandidateDevelopmentVerifiedSource
+  readonly strategyProtocol: CandidateDevelopmentStrategyProtocol
+  readonly evaluation: CandidateDevelopmentCommandEvaluation
+  readonly reviewedTerminalSummary: CandidateDevelopmentReviewedTerminalSummary
+  readonly contentHash: string
+}
+
+export interface CandidateDevelopmentEvidenceExpectation {
+  readonly bindings: CandidateDevelopmentEvidenceBindings
+  readonly evidenceContentHash: string
+  readonly independentlyReproducedEvaluationHash: string
+  readonly independentlyReproducedDecisionOutputHash: string
+}
+
+export interface CandidateDevelopmentIndependentReproduction {
+  readonly schemaVersion: 'bayn.candidate-development-independent-reproduction.v1'
+  readonly sourceRevision: string
+  readonly modulePath: string
+  readonly moduleBlobOid: string
+  readonly moduleSha256: string
+  readonly evaluation: CandidateDevelopmentCommandEvaluation
+  readonly evaluationHash: string
+  readonly decisionOutputHash: string
+}
+
+const CandidateDevelopmentMarketDataBindingSchema = Schema.Struct({
+  schemaVersion: Schema.Literal('bayn.candidate-development-market-data-source.v1'),
+  snapshotId: Sha256Schema,
+  finalizedSnapshotContentHash: Sha256Schema,
+  inputManifestHash: Sha256Schema,
+  boundedContentHash: Sha256Schema,
+})
+
+const CandidateDevelopmentEvidenceBindingsSchema = Schema.Struct({
+  schemaVersion: Schema.Literal('bayn.candidate-development-evidence-bindings.v1'),
+  candidateOrdinal: PositiveIntegerSchema,
+  priorTrialCount: NonNegativeIntegerSchema,
+  preregistration: Schema.Struct({
+    sourceRevision: GitSourceRevisionSchema,
+    path: StrictNonEmptyStringSchema,
+    blobOid: GitSourceRevisionSchema,
+  }),
+  reviewedSourceRevision: GitSourceRevisionSchema,
+  mergedSourceRevision: GitSourceRevisionSchema,
+  module: Schema.Struct({
+    path: StrictNonEmptyStringSchema,
+    blobOid: GitSourceRevisionSchema,
+    sha256: Sha256Schema,
+  }),
+  sourceManifest: Schema.Struct({
+    path: StrictNonEmptyStringSchema,
+    blobOid: GitSourceRevisionSchema,
+    sha256: Sha256Schema,
+  }),
+  strategyProtocolHash: Sha256Schema,
+  candidateDevelopmentProtocolHash: Sha256Schema,
+  marketData: CandidateDevelopmentMarketDataBindingSchema,
+  calendar: Schema.Struct({
+    schemaVersion: Schema.Literal('bayn.candidate-development-calendar.v1'),
+    calendarVersion: Schema.Literal('alpaca-us-equity-calendar-v1'),
+    start: Schema.Literal('2016-01-04'),
+    end: Schema.Literal('2022-12-30'),
+    sessionCount: Schema.Literal(1_762),
+    sessionsHash: Schema.Literal('a6df7a68249842fa35814f282b3df63db19c52f6ea0697899979d3a8c970d9b1'),
+  }),
+})
+
+const CandidateDevelopmentVerifiedSourceSchema = Schema.Struct({
+  schemaVersion: Schema.Literal('bayn.candidate-development-verified-source.v1'),
+  sourceRevision: GitSourceRevisionSchema,
+  modulePath: StrictNonEmptyStringSchema,
+  moduleBlobOid: GitSourceRevisionSchema,
+  moduleSha256: Sha256Schema,
+  sourceManifestPath: StrictNonEmptyStringSchema,
+  sourceManifestBlobOid: GitSourceRevisionSchema,
+  sourceManifestSha256: Sha256Schema,
+  sourceManifest: CandidateDevelopmentSourceManifestSchema,
+  baselineRunId: Sha256Schema,
+  stressedRunId: Sha256Schema,
+})
+
+const CandidateDevelopmentReviewedTerminalSummarySchema = Schema.Struct({
+  schemaVersion: Schema.Literal('bayn.candidate-development-reviewed-terminal-summary.v1'),
+  source: Schema.Literal('reviewed-development-only-evaluation'),
+  strategyAnnualizedReturn: Schema.Finite,
+  buyAndHoldAnnualizedReturn: Schema.Finite,
+  annualizedReturnDifferenceLowerBound: Schema.Finite,
+  sharpeDifferenceLowerBound: Schema.Finite,
+  verdict: Schema.Literals(['PASS', 'FAIL_CLOSED']),
+  researchContext: Schema.Tuple([
+    Schema.Literal('https://doi.org/10.1111/1468-0262.00152'),
+    Schema.Literal('https://papers.ssrn.com/sol3/papers.cfm?abstract_id=2326253'),
+  ]),
+})
+
+export const CandidateDevelopmentImmutableEvidenceSchema = Schema.Struct({
+  schemaVersion: Schema.Literal('bayn.candidate-development-immutable-evidence.v2'),
+  recordedAt: UtcInstantSchema,
+  bindings: CandidateDevelopmentEvidenceBindingsSchema,
+  input: CandidateDevelopmentPreflightInputSchema,
+  verifiedSource: CandidateDevelopmentVerifiedSourceSchema,
+  strategyProtocol: CandidateDevelopmentStrategyProtocolSchema,
+  evaluation: CandidateDevelopmentEvaluationSchema,
+  reviewedTerminalSummary: CandidateDevelopmentReviewedTerminalSummarySchema,
+  contentHash: Sha256Schema,
+})
+
+export interface CandidateDevelopmentEvidenceDecodeIssue {
+  readonly _tag: 'CandidateDevelopmentEvidenceDecodeFailed'
+  readonly cause: unknown
+}
+
+const decodeCandidateDevelopmentImmutableEvidenceBoundary = Schema.decodeUnknownResult(
+  CandidateDevelopmentImmutableEvidenceSchema,
+  strictParseOptions,
+)
+
+export const decodeCandidateDevelopmentImmutableEvidence = (
+  value: unknown,
+): Result.Result<CandidateDevelopmentImmutableEvidence, CandidateDevelopmentEvidenceDecodeIssue> => {
+  const decoded = decodeCandidateDevelopmentImmutableEvidenceBoundary(value)
+  if (Result.isFailure(decoded)) {
+    return Result.fail({ _tag: 'CandidateDevelopmentEvidenceDecodeFailed', cause: decoded.failure })
+  }
+  const evaluation = validateCandidateDevelopmentCommandEvaluation(decoded.success.evaluation)
+  if (Result.isFailure(evaluation)) {
+    return Result.fail({ _tag: 'CandidateDevelopmentEvidenceDecodeFailed', cause: evaluation.failure })
+  }
+  return Result.succeed({ ...decoded.success, evaluation: evaluation.success } as CandidateDevelopmentImmutableEvidence)
+}
+
+export type CandidateDevelopmentEvidenceIssue =
+  | { readonly _tag: 'CandidateDevelopmentEvidenceMissing' }
+  | CandidateDevelopmentEvidenceDecodeIssue
+  | { readonly _tag: 'CandidateDevelopmentEvidenceHashFailed'; readonly cause: CanonicalHashFailure }
+  | {
+      readonly _tag: 'CandidateDevelopmentEvidenceContentHashMismatch'
+      readonly expected: string
+      readonly observed: string
+    }
+  | {
+      readonly _tag: 'CandidateDevelopmentEvidenceBindingMismatch'
+      readonly field: string
+      readonly expected: unknown
+      readonly observed: unknown
+    }
+  | {
+      readonly _tag: 'CandidateDevelopmentEvidencePreflightInvalid'
+      readonly cause: unknown
+    }
+  | {
+      readonly _tag: 'CandidateDevelopmentEvidenceEvaluationInvalid'
+      readonly cause: unknown
+    }
+  | {
+      readonly _tag: 'CandidateDevelopmentEvidenceComparisonInvalid'
+      readonly cause: unknown
+    }
+  | {
+      readonly _tag: 'CandidateDevelopmentEvidenceEconomicInvalid'
+      readonly field: string
+      readonly expected: unknown
+      readonly observed: unknown
+      readonly cause?: unknown
+    }
+  | {
+      readonly _tag: 'CandidateDevelopmentEvidenceDoubledCostInvalid'
+      readonly cause: unknown
+    }
+  | {
+      readonly _tag: 'CandidateDevelopmentEvidenceReproductionMismatch'
+      readonly field:
+        | 'sourceRevision'
+        | 'modulePath'
+        | 'moduleBlobOid'
+        | 'moduleSha256'
+        | 'evaluation'
+        | 'decisionOutput'
+      readonly expected: string
+      readonly observed: string
+    }
+  | { readonly _tag: 'CandidateDevelopmentEvidenceReproductionMissing' }
+  | {
+      readonly _tag: 'CandidateDevelopmentEvidenceReproductionFailed'
+      readonly cause: unknown
+    }
+  | {
+      readonly _tag: 'CandidateDevelopmentEvidenceApprovalInvalid'
+      readonly cause: unknown
+    }
+
+export type CandidateDevelopmentEligibilityDecision =
+  | {
+      readonly status: 'DEVELOPMENT_APPROVED'
+      readonly evidenceContentHash: string
+      readonly decision: CandidateDevelopmentDecision
+      readonly nextCandidatePreregistration: CandidateDevelopmentNextPreregistration
+    }
+  | {
+      readonly status: 'DEVELOPMENT_REJECTED'
+      readonly evidenceContentHash: string
+      readonly decision: CandidateDevelopmentDecision
+      readonly nextCandidatePreregistration: null
+    }
+  | {
+      readonly status: 'DEVELOPMENT_EVIDENCE_INVALID'
+      readonly issues: readonly CandidateDevelopmentEvidenceIssue[]
+      readonly nextCandidatePreregistration: null
+    }
+
+export type CandidateDevelopmentQualificationAuthorization<A> =
+  | { readonly status: 'AUTHORIZED'; readonly value: A }
+  | {
+      readonly status: 'BLOCKED'
+      readonly reason: Exclude<CandidateDevelopmentEligibilityDecision['status'], 'DEVELOPMENT_APPROVED'>
+    }
+
+export const withCandidateDevelopmentQualificationAuthorization = <A>(
+  decision: CandidateDevelopmentEligibilityDecision,
+  loadQualificationInput: (preregistration: CandidateDevelopmentNextPreregistration) => A,
+): CandidateDevelopmentQualificationAuthorization<A> =>
+  decision.status === 'DEVELOPMENT_APPROVED'
+    ? { status: 'AUTHORIZED', value: loadQualificationInput(decision.nextCandidatePreregistration) }
+    : { status: 'BLOCKED', reason: decision.status }
+
+const evidenceMaterial = (
+  evidence: CandidateDevelopmentImmutableEvidence,
+): Omit<CandidateDevelopmentImmutableEvidence, 'contentHash'> => {
+  const { contentHash: _, ...material } = evidence
+  return material
+}
+
+export const candidateDevelopmentDecisionOutputMaterial = (evaluation: CandidateDevelopmentCommandEvaluation) => ({
+  schemaVersion: 'bayn.candidate-development-decision-output.v1' as const,
+  baselineRunId: evaluation.baseline.runId,
+  stressedRunId: evaluation.accounting.stressedRunId,
+  baseline: {
+    signalDecisions: evaluation.baseline.signalDecisions,
+    orders: evaluation.baseline.simulation.orders,
+  },
+  stressed: {
+    signalDecisions: evaluation.stressed.signalDecisions,
+    orders: evaluation.stressed.simulation.orders,
+  },
+})
+
+export const buildCandidateDevelopmentIndependentReproduction = (
+  verifiedSource: CandidateDevelopmentVerifiedSource,
+  evaluation: CandidateDevelopmentCommandEvaluation,
+): Result.Result<CandidateDevelopmentIndependentReproduction, CandidateDevelopmentEvidenceIssue> =>
+  pipe(
+    Result.all({
+      evaluationHash: pipe(
+        canonicalHashV1Result(evaluation),
+        Result.mapError(
+          (cause): CandidateDevelopmentEvidenceIssue => ({
+            _tag: 'CandidateDevelopmentEvidenceHashFailed',
+            cause,
+          }),
+        ),
+      ),
+      decisionOutputHash: pipe(
+        canonicalHashV1Result(candidateDevelopmentDecisionOutputMaterial(evaluation)),
+        Result.mapError(
+          (cause): CandidateDevelopmentEvidenceIssue => ({
+            _tag: 'CandidateDevelopmentEvidenceHashFailed',
+            cause,
+          }),
+        ),
+      ),
+    }),
+    Result.map(({ decisionOutputHash, evaluationHash }) => ({
+      schemaVersion: 'bayn.candidate-development-independent-reproduction.v1' as const,
+      sourceRevision: verifiedSource.sourceRevision,
+      modulePath: verifiedSource.modulePath,
+      moduleBlobOid: verifiedSource.moduleBlobOid,
+      moduleSha256: verifiedSource.moduleSha256,
+      evaluation,
+      evaluationHash,
+      decisionOutputHash,
+    })),
+  )
+
+export const validateCandidateDevelopmentIndependentReproduction = (
+  evidence: CandidateDevelopmentImmutableEvidence,
+  expectation: CandidateDevelopmentEvidenceExpectation,
+  reproduction: CandidateDevelopmentIndependentReproduction,
+): readonly CandidateDevelopmentEvidenceIssue[] => {
+  const issues: CandidateDevelopmentEvidenceIssue[] = []
+  const decoded = validateCandidateDevelopmentCommandEvaluation(reproduction.evaluation)
+  if (Result.isFailure(decoded)) {
+    return [{ _tag: 'CandidateDevelopmentEvidenceReproductionFailed', cause: decoded.failure }]
+  }
+
+  const bindings = [
+    ['sourceRevision', evidence.verifiedSource.sourceRevision, reproduction.sourceRevision],
+    ['modulePath', evidence.verifiedSource.modulePath, reproduction.modulePath],
+    ['moduleBlobOid', evidence.verifiedSource.moduleBlobOid, reproduction.moduleBlobOid],
+    ['moduleSha256', evidence.verifiedSource.moduleSha256, reproduction.moduleSha256],
+  ] as const
+  for (const [field, expected, observed] of bindings) {
+    if (expected !== observed) {
+      issues.push({
+        _tag: 'CandidateDevelopmentEvidenceReproductionMismatch',
+        field,
+        expected,
+        observed,
+      })
+    }
+  }
+
+  const reproducedEvaluationHash = canonicalHashV1Result(decoded.success)
+  if (Result.isFailure(reproducedEvaluationHash)) {
+    issues.push({ _tag: 'CandidateDevelopmentEvidenceHashFailed', cause: reproducedEvaluationHash.failure })
+  } else {
+    for (const expected of [expectation.independentlyReproducedEvaluationHash, reproduction.evaluationHash]) {
+      if (expected !== reproducedEvaluationHash.success) {
+        issues.push({
+          _tag: 'CandidateDevelopmentEvidenceReproductionMismatch',
+          field: 'evaluation',
+          expected,
+          observed: reproducedEvaluationHash.success,
+        })
+      }
+    }
+  }
+
+  const reproducedDecisionOutputHash = canonicalHashV1Result(
+    candidateDevelopmentDecisionOutputMaterial(decoded.success),
+  )
+  if (Result.isFailure(reproducedDecisionOutputHash)) {
+    issues.push({ _tag: 'CandidateDevelopmentEvidenceHashFailed', cause: reproducedDecisionOutputHash.failure })
+  } else {
+    for (const expected of [expectation.independentlyReproducedDecisionOutputHash, reproduction.decisionOutputHash]) {
+      if (expected !== reproducedDecisionOutputHash.success) {
+        issues.push({
+          _tag: 'CandidateDevelopmentEvidenceReproductionMismatch',
+          field: 'decisionOutput',
+          expected,
+          observed: reproducedDecisionOutputHash.success,
+        })
+      }
+    }
+  }
+
+  collectCanonicalBinding(issues, 'reproduction.evaluation', evidence.evaluation, decoded.success)
+  return issues
+}
+
+const sameCanonical = (left: unknown, right: unknown): Result.Result<boolean, CanonicalHashFailure> => {
+  const leftHash = canonicalHashV1Result(left)
+  if (Result.isFailure(leftHash)) return Result.fail(leftHash.failure)
+  const rightHash = canonicalHashV1Result(right)
+  return Result.isFailure(rightHash)
+    ? Result.fail(rightHash.failure)
+    : Result.succeed(leftHash.success === rightHash.success)
+}
+
+const collectCanonicalBinding = (
+  issues: CandidateDevelopmentEvidenceIssue[],
+  field: string,
+  expected: unknown,
+  observed: unknown,
+): void => {
+  const equal = sameCanonical(expected, observed)
+  if (Result.isFailure(equal)) {
+    issues.push({ _tag: 'CandidateDevelopmentEvidenceHashFailed', cause: equal.failure })
+  } else if (!equal.success) {
+    issues.push({ _tag: 'CandidateDevelopmentEvidenceBindingMismatch', field, expected, observed })
+  }
+}
+
+const collectEvidenceBindings = (
+  issues: CandidateDevelopmentEvidenceIssue[],
+  expected: CandidateDevelopmentEvidenceBindings,
+  observed: CandidateDevelopmentEvidenceBindings,
+): void => {
+  const fields: readonly (readonly [string, unknown, unknown])[] = [
+    ['schemaVersion', expected.schemaVersion, observed.schemaVersion],
+    ['candidateOrdinal', expected.candidateOrdinal, observed.candidateOrdinal],
+    ['priorTrialCount', expected.priorTrialCount, observed.priorTrialCount],
+    ['preregistration', expected.preregistration, observed.preregistration],
+    ['reviewedSourceRevision', expected.reviewedSourceRevision, observed.reviewedSourceRevision],
+    ['mergedSourceRevision', expected.mergedSourceRevision, observed.mergedSourceRevision],
+    ['module', expected.module, observed.module],
+    ['sourceManifest', expected.sourceManifest, observed.sourceManifest],
+    ['strategyProtocolHash', expected.strategyProtocolHash, observed.strategyProtocolHash],
+    [
+      'candidateDevelopmentProtocolHash',
+      expected.candidateDevelopmentProtocolHash,
+      observed.candidateDevelopmentProtocolHash,
+    ],
+    ['marketData', expected.marketData, observed.marketData],
+    ['calendar', expected.calendar, observed.calendar],
+  ]
+  for (const [field, expectedValue, observedValue] of fields) {
+    collectCanonicalBinding(issues, field, expectedValue, observedValue)
+  }
+}
+
+const expectedPreregistrationFromBindings = (
+  bindings: CandidateDevelopmentEvidenceBindings,
+): CandidateDevelopmentNextPreregistration => ({
+  schemaVersion: 'bayn.candidate-development-next-preregistration.v1',
+  candidateOrdinal: bindings.candidateOrdinal,
+  priorTrialCount: bindings.priorTrialCount,
+  strategyProtocolHash: bindings.strategyProtocolHash,
+  modulePath: bindings.module.path,
+  moduleSha256: bindings.module.sha256,
+  marketData: bindings.marketData,
+  preregistration: bindings.preregistration,
+})
+
+const fullMetricFields = [
+  'observations',
+  'totalReturn',
+  'annualizedReturn',
+  'annualizedVolatility',
+  'sharpe',
+  'maximumDrawdown',
+  'annualTurnover',
+  'totalFeesMicros',
+  'totalSpreadCostMicros',
+  'totalSlippageCostMicros',
+  'totalCashYieldMicros',
+  'endingEquityMicros',
+] as const satisfies readonly (keyof PerformanceMetrics)[]
+
+type ExactPerformancePoint = Pick<
+  DailyPerformancePoint,
+  | 'equityMicros'
+  | 'cumulativeTurnoverMicros'
+  | 'cumulativeFeesMicros'
+  | 'cumulativeSpreadCostMicros'
+  | 'cumulativeSlippageCostMicros'
+  | 'cumulativeCashYieldMicros'
+>
+
+const exactMetricsFromPoints = (
+  field: string,
+  points: readonly ExactPerformancePoint[],
+  initialCapitalMicros: string,
+): Result.Result<PerformanceMetrics, CandidateDevelopmentEvidenceIssue> => {
+  const last = points.at(-1)
+  const values = [
+    initialCapitalMicros,
+    ...(last === undefined
+      ? []
+      : [
+          last.cumulativeTurnoverMicros,
+          last.cumulativeFeesMicros,
+          last.cumulativeSpreadCostMicros,
+          last.cumulativeSlippageCostMicros,
+          last.cumulativeCashYieldMicros,
+        ]),
+    ...points.map((point) => point.equityMicros),
+  ]
+  const invalid = values.find((value) => !/^\d+$/.test(value))
+  if (last === undefined || invalid !== undefined) {
+    return Result.fail({
+      _tag: 'CandidateDevelopmentEvidenceEconomicInvalid',
+      field,
+      expected: 'nonempty performance series with unsigned integer micros',
+      observed: invalid ?? null,
+    })
+  }
+  return pipe(
+    calculateExactPerformanceMetrics(
+      points.map((point) => BigInt(point.equityMicros)),
+      BigInt(last.cumulativeTurnoverMicros),
+      BigInt(last.cumulativeFeesMicros),
+      BigInt(last.cumulativeSpreadCostMicros),
+      BigInt(last.cumulativeSlippageCostMicros),
+      BigInt(last.cumulativeCashYieldMicros),
+      BigInt(initialCapitalMicros),
+    ),
+    Result.mapError(
+      (cause): CandidateDevelopmentEvidenceIssue => ({
+        _tag: 'CandidateDevelopmentEvidenceEconomicInvalid',
+        field,
+        expected: 'metrics reproducible from the bound equity and cumulative accounting series',
+        observed: null,
+        cause,
+      }),
+    ),
+  )
+}
+
+const collectMetricBinding = (
+  issues: CandidateDevelopmentEvidenceIssue[],
+  field: string,
+  expected: PerformanceMetrics,
+  observed: PerformanceMetrics,
+): void => {
+  const expectedProjection = Object.fromEntries(fullMetricFields.map((key) => [key, expected[key]]))
+  const observedProjection = Object.fromEntries(fullMetricFields.map((key) => [key, observed[key]]))
+  const equal = sameCanonical(expectedProjection, observedProjection)
+  if (Result.isFailure(equal)) {
+    issues.push({ _tag: 'CandidateDevelopmentEvidenceHashFailed', cause: equal.failure })
+  } else if (!equal.success) {
+    issues.push({
+      _tag: 'CandidateDevelopmentEvidenceEconomicInvalid',
+      field,
+      expected: expectedProjection,
+      observed: observedProjection,
+    })
+  }
+}
+
+const terminalCash = (simulation: EvaluationResult['simulation']): boolean =>
+  simulation.dailyMarks.at(-1)?.positions.every((position) => position.quantityMicros === '0') ?? false
+
+const buildDevelopmentReport = (
+  preflight: CandidateDevelopmentPreflightPass,
+  evaluation: CandidateDevelopmentCommandEvaluation,
+): CandidateDevelopmentReport => ({
+  schemaVersion: candidateDevelopmentComparisonSemantics.evidence.reportSchemaVersion,
+  protocolIdentity: preflight.protocolIdentity,
+  comparisonSemantics: evaluation.comparisonSemantics,
+  doubledCostContract: preflight.doubledCostContract,
+  doubledCost: {
+    baseline: {
+      signalDecisions: evaluation.baseline.signalDecisions,
+      simulation: evaluation.baseline.simulation,
+    },
+    stressed: evaluation.stressed,
+  },
+})
+
+interface CandidateDevelopmentValidatedEvidence {
+  readonly preflight: CandidateDevelopmentPreflightPass
+  readonly evaluation: CandidateDevelopmentCommandEvaluation
+  readonly decision: CandidateDevelopmentDecision
+  readonly development: CandidateDevelopmentReport
+}
+
+const validateCompleteEvidence = (
+  evidence: CandidateDevelopmentImmutableEvidence,
+  issues: CandidateDevelopmentEvidenceIssue[],
+): CandidateDevelopmentValidatedEvidence | null => {
+  const strategyProtocolHash = canonicalHashV1Result(evidence.strategyProtocol)
+  if (Result.isFailure(strategyProtocolHash)) {
+    issues.push({ _tag: 'CandidateDevelopmentEvidenceHashFailed', cause: strategyProtocolHash.failure })
+  } else if (strategyProtocolHash.success !== evidence.bindings.strategyProtocolHash) {
+    issues.push({
+      _tag: 'CandidateDevelopmentEvidenceBindingMismatch',
+      field: 'strategyProtocol',
+      expected: evidence.bindings.strategyProtocolHash,
+      observed: strategyProtocolHash.success,
+    })
+  }
+
+  const preflightResult = preflightCandidateDevelopment(evidence.input)
+  if (Result.isFailure(preflightResult) || preflightResult.success.status !== 'PASS') {
+    issues.push({
+      _tag: 'CandidateDevelopmentEvidencePreflightInvalid',
+      cause: Result.isFailure(preflightResult) ? preflightResult.failure : preflightResult.success,
+    })
+    return null
+  }
+  const preflight = preflightResult.success
+  collectCanonicalBinding(
+    issues,
+    'preflight.candidateDevelopmentProtocolHash',
+    evidence.bindings.candidateDevelopmentProtocolHash,
+    preflight.protocolIdentity.candidateDevelopmentProtocolHash,
+  )
+  collectCanonicalBinding(
+    issues,
+    'preflight.strategyProtocolHash',
+    evidence.bindings.strategyProtocolHash,
+    preflight.expectedStrategyProtocolHash,
+  )
+
+  const evaluationResult = validateCandidateDevelopmentCommandEvaluation(evidence.evaluation)
+  if (Result.isFailure(evaluationResult)) {
+    issues.push({ _tag: 'CandidateDevelopmentEvidenceEvaluationInvalid', cause: evaluationResult.failure })
+    return null
+  }
+  const evaluation = evaluationResult.success
+  const sourceBindings: readonly (readonly [string, unknown, unknown])[] = [
+    ['evaluation.baseline.codeRevision', evidence.verifiedSource.sourceRevision, evaluation.baseline.codeRevision],
+    ['evaluation.baseline.runId', evidence.verifiedSource.baselineRunId, evaluation.baseline.runId],
+    ['evaluation.accounting.runId', evidence.verifiedSource.baselineRunId, evaluation.accounting.runId],
+    ['evaluation.accounting.stressedRunId', evidence.verifiedSource.stressedRunId, evaluation.accounting.stressedRunId],
+    ['evaluation.baseline.protocolHash', evidence.bindings.strategyProtocolHash, evaluation.baseline.protocolHash],
+    ['evaluation.marketData.snapshotId', evidence.bindings.marketData.snapshotId, evaluation.marketData.snapshotId],
+    [
+      'evaluation.marketData.contentHash',
+      evidence.bindings.marketData.boundedContentHash,
+      evaluation.marketData.contentHash,
+    ],
+    [
+      'evaluation.baseline.inputManifest.hash',
+      evidence.bindings.marketData.inputManifestHash,
+      evaluation.baseline.inputManifest.hash,
+    ],
+    [
+      'evaluation.baseline.inputManifest.finalizedSnapshot.contentHash',
+      evidence.bindings.marketData.finalizedSnapshotContentHash,
+      evaluation.baseline.inputManifest.finalizedSnapshot.contentHash,
+    ],
+  ]
+  for (const [field, expected, observed] of sourceBindings) {
+    collectCanonicalBinding(issues, field, expected, observed)
+  }
+
+  const series = prepareQualificationSeries(evaluation.baseline)
+  if (Result.isFailure(series)) {
+    issues.push({ _tag: 'CandidateDevelopmentEvidenceComparisonInvalid', cause: series.failure })
+    return null
+  }
+  const seriesBinding = validateCandidateDevelopmentComparisonSeriesBinding(
+    preflight,
+    evaluation.baseline,
+    series.success,
+  )
+  if (Result.isFailure(seriesBinding)) {
+    issues.push({ _tag: 'CandidateDevelopmentEvidenceComparisonInvalid', cause: seriesBinding.failure })
+    return null
+  }
+  const comparison = validateCandidateDevelopmentComparisonSemanticsEvidence(
+    preflight,
+    seriesBinding.success,
+    evaluation.comparisonSemantics,
+  )
+  if (Result.isFailure(comparison)) {
+    issues.push({ _tag: 'CandidateDevelopmentEvidenceComparisonInvalid', cause: comparison.failure })
+    return null
+  }
+
+  const initialCapitalMicros = evaluation.baseline.initialCapitalMicros
+  const metrics = Result.all({
+    strategy: exactMetricsFromPoints(
+      'economic.strategy',
+      evaluation.baseline.simulation.dailyMarks,
+      initialCapitalMicros,
+    ),
+    buyAndHold: exactMetricsFromPoints(
+      'economic.buyAndHold',
+      evaluation.baseline.benchmarkSeries.buyAndHold,
+      initialCapitalMicros,
+    ),
+    directVolTiming: exactMetricsFromPoints(
+      'economic.directVolTiming',
+      evaluation.baseline.benchmarkSeries.directVolTiming,
+      initialCapitalMicros,
+    ),
+    doubleCostStrategy: exactMetricsFromPoints(
+      'economic.doubleCostStrategy',
+      evaluation.stressed.simulation.dailyMarks,
+      initialCapitalMicros,
+    ),
+    recordedDoubleCostSeries: exactMetricsFromPoints(
+      'economic.recordedDoubleCostSeries',
+      evaluation.baseline.benchmarkSeries.doubleCostStrategy,
+      initialCapitalMicros,
+    ),
+  })
+  if (Result.isFailure(metrics)) {
+    issues.push(metrics.failure)
+    return null
+  }
+  collectMetricBinding(issues, 'economic.strategy', metrics.success.strategy, evaluation.baseline.strategy)
+  collectMetricBinding(issues, 'economic.buyAndHold', metrics.success.buyAndHold, evaluation.baseline.buyAndHold)
+  collectMetricBinding(
+    issues,
+    'economic.directVolTiming',
+    metrics.success.directVolTiming,
+    evaluation.baseline.directVolTiming,
+  )
+  collectMetricBinding(
+    issues,
+    'economic.doubleCostStrategy',
+    metrics.success.doubleCostStrategy,
+    evaluation.baseline.doubleCostStrategy,
+  )
+  collectMetricBinding(
+    issues,
+    'economic.doubleCostSeries',
+    metrics.success.doubleCostStrategy,
+    metrics.success.recordedDoubleCostSeries,
+  )
+
+  const expectedVerdict = buildVerdict(
+    metrics.success.strategy,
+    metrics.success.buyAndHold,
+    metrics.success.directVolTiming,
+    metrics.success.doubleCostStrategy,
+    evidence.strategyProtocol,
+  )
+  collectCanonicalBinding(issues, 'economic.verdict', expectedVerdict, evaluation.baseline.verdict)
+
+  const baselineRun: CandidateDevelopmentDoubledCostRun = {
+    signalDecisions: evaluation.baseline.signalDecisions,
+    simulation: evaluation.baseline.simulation,
+  }
+  const causalPath = validateCandidateDevelopmentDoubledCostCausalPath(baselineRun, evaluation.stressed)
+  if (Result.isFailure(causalPath)) {
+    issues.push({ _tag: 'CandidateDevelopmentEvidenceDoubledCostInvalid', cause: causalPath.failure })
+  }
+
+  const baselineTerminalCash = terminalCash(evaluation.baseline.simulation)
+  const stressedTerminalCash = terminalCash(evaluation.stressed.simulation)
+  const decision = deriveCandidateDevelopmentDecision({
+    comparison: comparison.success.analysis,
+    doubledCostAnnualizedReturn: metrics.success.doubleCostStrategy.annualizedReturn,
+    economicPass: expectedVerdict.gates.every((gate) => gate.passed),
+    baselineTerminalCash,
+    stressedTerminalCash,
+  })
+
+  const reviewedMetrics = [
+    [
+      'reviewedTerminalSummary.strategyAnnualizedReturn',
+      Number(metrics.success.strategy.annualizedReturn.toFixed(5)),
+      evidence.reviewedTerminalSummary.strategyAnnualizedReturn,
+    ],
+    [
+      'reviewedTerminalSummary.buyAndHoldAnnualizedReturn',
+      Number(metrics.success.buyAndHold.annualizedReturn.toFixed(6)),
+      evidence.reviewedTerminalSummary.buyAndHoldAnnualizedReturn,
+    ],
+  ] as const
+  for (const [field, expected, observed] of reviewedMetrics) {
+    if (!Object.is(expected, observed)) {
+      issues.push({ _tag: 'CandidateDevelopmentEvidenceEconomicInvalid', field, expected, observed })
+    }
+  }
+  for (const [field, value] of [
+    [
+      'reviewedTerminalSummary.annualizedReturnDifferenceLowerBound',
+      evidence.reviewedTerminalSummary.annualizedReturnDifferenceLowerBound,
+    ],
+    ['reviewedTerminalSummary.sharpeDifferenceLowerBound', evidence.reviewedTerminalSummary.sharpeDifferenceLowerBound],
+  ] as const) {
+    if (!Number.isFinite(value)) {
+      issues.push({
+        _tag: 'CandidateDevelopmentEvidenceEconomicInvalid',
+        field,
+        expected: 'finite reviewed development statistic',
+        observed: value,
+      })
+    }
+  }
+
+  return {
+    preflight,
+    evaluation,
+    decision,
+    development: buildDevelopmentReport(preflight, evaluation),
+  }
+}
+
+export const decideCandidateDevelopmentEligibility = (
+  evidence: CandidateDevelopmentImmutableEvidence | null,
+  expectation: CandidateDevelopmentEvidenceExpectation,
+  preregistration: CandidateDevelopmentNextPreregistration,
+  reproduction: CandidateDevelopmentIndependentReproduction | null = null,
+): CandidateDevelopmentEligibilityDecision => {
+  if (evidence === null) {
+    return {
+      status: 'DEVELOPMENT_EVIDENCE_INVALID',
+      issues: [{ _tag: 'CandidateDevelopmentEvidenceMissing' }],
+      nextCandidatePreregistration: null,
+    }
+  }
+  const issues: CandidateDevelopmentEvidenceIssue[] = []
+  const computedHash = canonicalHashV1Result(evidenceMaterial(evidence))
+  if (Result.isFailure(computedHash)) {
+    issues.push({ _tag: 'CandidateDevelopmentEvidenceHashFailed', cause: computedHash.failure })
+  } else {
+    if (computedHash.success !== evidence.contentHash) {
+      issues.push({
+        _tag: 'CandidateDevelopmentEvidenceContentHashMismatch',
+        expected: computedHash.success,
+        observed: evidence.contentHash,
+      })
+    }
+    if (evidence.contentHash !== expectation.evidenceContentHash) {
+      issues.push({
+        _tag: 'CandidateDevelopmentEvidenceContentHashMismatch',
+        expected: expectation.evidenceContentHash,
+        observed: evidence.contentHash,
+      })
+    }
+  }
+  const evaluationHash = canonicalHashV1Result(evidence.evaluation)
+  if (Result.isFailure(evaluationHash)) {
+    issues.push({ _tag: 'CandidateDevelopmentEvidenceHashFailed', cause: evaluationHash.failure })
+  } else if (evaluationHash.success !== expectation.independentlyReproducedEvaluationHash) {
+    issues.push({
+      _tag: 'CandidateDevelopmentEvidenceReproductionMismatch',
+      field: 'evaluation',
+      expected: expectation.independentlyReproducedEvaluationHash,
+      observed: evaluationHash.success,
+    })
+  }
+  const decisionOutputHash = canonicalHashV1Result(candidateDevelopmentDecisionOutputMaterial(evidence.evaluation))
+  if (Result.isFailure(decisionOutputHash)) {
+    issues.push({ _tag: 'CandidateDevelopmentEvidenceHashFailed', cause: decisionOutputHash.failure })
+  } else if (decisionOutputHash.success !== expectation.independentlyReproducedDecisionOutputHash) {
+    issues.push({
+      _tag: 'CandidateDevelopmentEvidenceReproductionMismatch',
+      field: 'decisionOutput',
+      expected: expectation.independentlyReproducedDecisionOutputHash,
+      observed: decisionOutputHash.success,
+    })
+  }
+  collectEvidenceBindings(issues, expectation.bindings, evidence.bindings)
+  collectCanonicalBinding(
+    issues,
+    'qualificationPreregistration',
+    expectedPreregistrationFromBindings(evidence.bindings),
+    preregistration,
+  )
+  collectCanonicalBinding(
+    issues,
+    'input.candidateOrdinal',
+    evidence.bindings.candidateOrdinal,
+    evidence.input.candidateOrdinal,
+  )
+  collectCanonicalBinding(
+    issues,
+    'input.priorTrialCount',
+    evidence.bindings.priorTrialCount,
+    evidence.input.priorTrialCount,
+  )
+  collectCanonicalBinding(
+    issues,
+    'verifiedSource.sourceRevision',
+    evidence.bindings.reviewedSourceRevision,
+    evidence.verifiedSource.sourceRevision,
+  )
+  collectCanonicalBinding(
+    issues,
+    'verifiedSource.modulePath',
+    evidence.bindings.module.path,
+    evidence.verifiedSource.modulePath,
+  )
+  collectCanonicalBinding(
+    issues,
+    'verifiedSource.moduleBlobOid',
+    evidence.bindings.module.blobOid,
+    evidence.verifiedSource.moduleBlobOid,
+  )
+  collectCanonicalBinding(
+    issues,
+    'verifiedSource.moduleSha256',
+    evidence.bindings.module.sha256,
+    evidence.verifiedSource.moduleSha256,
+  )
+  collectCanonicalBinding(
+    issues,
+    'verifiedSource.sourceManifestPath',
+    evidence.bindings.sourceManifest.path,
+    evidence.verifiedSource.sourceManifestPath,
+  )
+  collectCanonicalBinding(
+    issues,
+    'verifiedSource.sourceManifestBlobOid',
+    evidence.bindings.sourceManifest.blobOid,
+    evidence.verifiedSource.sourceManifestBlobOid,
+  )
+  collectCanonicalBinding(
+    issues,
+    'verifiedSource.sourceManifestSha256',
+    evidence.bindings.sourceManifest.sha256,
+    evidence.verifiedSource.sourceManifestSha256,
+  )
+
+  const validated = validateCompleteEvidence(evidence, issues)
+  if (issues.length > 0 || validated === null) {
+    return { status: 'DEVELOPMENT_EVIDENCE_INVALID', issues, nextCandidatePreregistration: null }
+  }
+  if (validated.decision.status === 'HOLD_REJECT') {
+    return {
+      status: 'DEVELOPMENT_REJECTED',
+      evidenceContentHash: evidence.contentHash,
+      decision: validated.decision,
+      nextCandidatePreregistration: null,
+    }
+  }
+
+  if (reproduction === null) {
+    return {
+      status: 'DEVELOPMENT_EVIDENCE_INVALID',
+      issues: [{ _tag: 'CandidateDevelopmentEvidenceReproductionMissing' }],
+      nextCandidatePreregistration: null,
+    }
+  }
+  const reproductionIssues = validateCandidateDevelopmentIndependentReproduction(evidence, expectation, reproduction)
+  if (reproductionIssues.length > 0) {
+    return {
+      status: 'DEVELOPMENT_EVIDENCE_INVALID',
+      issues: reproductionIssues,
+      nextCandidatePreregistration: null,
+    }
+  }
+
+  const approval = buildCandidateDevelopmentCommandReport(
+    validated.development,
+    validated.evaluation,
+    evidence.strategyProtocol,
+    evidence.input.officialSessions,
+    evidence.verifiedSource,
+  )
+  if (Result.isFailure(approval) || approval.success.decision.status !== 'PASS') {
+    return {
+      status: 'DEVELOPMENT_EVIDENCE_INVALID',
+      issues: [
+        {
+          _tag: 'CandidateDevelopmentEvidenceApprovalInvalid',
+          cause: Result.isFailure(approval) ? approval.failure : approval.success.decision,
+        },
+      ],
+      nextCandidatePreregistration: null,
+    }
+  }
+  collectCanonicalBinding(issues, 'approval.decision', validated.decision, approval.success.decision)
+  if (issues.length > 0) {
+    return { status: 'DEVELOPMENT_EVIDENCE_INVALID', issues, nextCandidatePreregistration: null }
+  }
+  return {
+    status: 'DEVELOPMENT_APPROVED',
+    evidenceContentHash: evidence.contentHash,
+    decision: validated.decision,
+    nextCandidatePreregistration: preregistration,
+  }
+}
+
+export const decideCandidateDevelopmentEligibilityFromUnknown = (
+  value: unknown,
+  expectation: CandidateDevelopmentEvidenceExpectation,
+  preregistration: CandidateDevelopmentNextPreregistration,
+  reproduction: CandidateDevelopmentIndependentReproduction | null = null,
+): CandidateDevelopmentEligibilityDecision => {
+  if (value === null) return decideCandidateDevelopmentEligibility(null, expectation, preregistration, reproduction)
+  const decoded = decodeCandidateDevelopmentImmutableEvidence(value)
+  return Result.isFailure(decoded)
+    ? {
+        status: 'DEVELOPMENT_EVIDENCE_INVALID',
+        issues: [decoded.failure],
+        nextCandidatePreregistration: null,
+      }
+    : decideCandidateDevelopmentEligibility(decoded.success, expectation, preregistration, reproduction)
+}

--- a/services/bayn/src/candidate-development-trial-history.ts
+++ b/services/bayn/src/candidate-development-trial-history.ts
@@ -1,0 +1,115 @@
+import { candidateDevelopmentCalendarContract } from './candidate-development'
+import type { CandidateDevelopmentNextPreregistration } from './candidate-development-decision'
+
+export interface CandidateDevelopmentTrialHistory {
+  readonly schemaVersion: 'bayn.candidate-development-trial-history.v1'
+  readonly completedCandidateOrdinals: readonly number[]
+  readonly latestTerminalEvidence: {
+    readonly candidateOrdinal: number
+    readonly priorTrialCount: number
+    readonly terminalStatus: 'HOLD_REJECT'
+    readonly sourceRevision: string
+  }
+  readonly candidatePreregistration: {
+    readonly candidateOrdinal: number
+    readonly priorTrialCount: number
+    readonly sourceRevision: string
+    readonly path: string
+    readonly blobOid: string
+  }
+  readonly latestReviewedCandidatePreregistration: CandidateDevelopmentNextPreregistration
+  readonly latestDevelopmentEvidence: {
+    readonly candidateOrdinal: 17
+    readonly priorTrialCount: 16
+    readonly status: 'DEVELOPMENT_REJECTED'
+    readonly evidenceContentHash: string
+    readonly reviewedSourceRevision: string
+    readonly mergedSourceRevision: string
+    readonly qualificationAttemptConsumed: false
+  }
+  readonly nextCandidatePreregistration: CandidateDevelopmentNextPreregistration | null
+}
+
+export const candidate17Preregistration: CandidateDevelopmentNextPreregistration = {
+  schemaVersion: 'bayn.candidate-development-next-preregistration.v1',
+  candidateOrdinal: 17,
+  priorTrialCount: 16,
+  strategyProtocolHash: 'fa25d8c16bc4f4fde3bab99409ae60a6fd23332d295b3557231796cebb911390',
+  modulePath: 'services/bayn/src/strategy/volatility-managed-trend-overlay/candidate-17.ts',
+  moduleSha256: '2e98bc55eae1901ccdde41978b7b32d746dc2ef6afcebbff1de0ed54574065da',
+  marketData: {
+    schemaVersion: 'bayn.candidate-development-market-data-source.v1',
+    snapshotId: '2a91f0177684f7022f746207333e510c8268f9b77a04b778a04220a33ccf79e0',
+    finalizedSnapshotContentHash: '8e376546f6a6cc1dbe2e910db3d68f584fc0bd9c4858166042ce32aa077eed0d',
+    inputManifestHash: 'b606cf57fb076f5bd2875206973e7c512817430d5cfbbeac8a99396f9983cab4',
+    boundedContentHash: 'e0e7b283de187d8ccaf8a449dacc538f00049cfe446dcf153b558e92bf0e17ed',
+  },
+  preregistration: {
+    sourceRevision: '890d8f5801cf7c7576ed7a0cee387a4e79b98877',
+    path: 'services/bayn/candidates/ordinal-17-volatility-managed-trend-overlay-preregistration.json',
+    blobOid: 'c1d07233df53cc0379b1dfae9f1caffbd6b7abd6',
+  },
+}
+
+export const candidate17DevelopmentEvidenceExpectation = {
+  bindings: {
+    schemaVersion: 'bayn.candidate-development-evidence-bindings.v1',
+    candidateOrdinal: 17,
+    priorTrialCount: 16,
+    preregistration: candidate17Preregistration.preregistration,
+    reviewedSourceRevision: '9a293a7a8f7cb4ed5c8ddf41d7dbf9abecb12510',
+    mergedSourceRevision: '4f39bb8ad168c3a459afdfdb30feccd49aba22d8',
+    module: {
+      path: candidate17Preregistration.modulePath,
+      blobOid: '8d1ccbfc6bef2c1707ac85f51d1647a7a8bfd98b',
+      sha256: candidate17Preregistration.moduleSha256,
+    },
+    sourceManifest: {
+      path: 'services/bayn/candidates/ordinal-17-volatility-managed-trend-overlay-source-manifest.json',
+      blobOid: '23521cd435a97045adf18d1f075599fe5d22d750',
+      sha256: 'ffc4d8cb6e473d660096dc18fe786d0b498adbab70bce9a3814c8bf3fdaeb954',
+    },
+    strategyProtocolHash: candidate17Preregistration.strategyProtocolHash,
+    candidateDevelopmentProtocolHash: '72754b1178308c721a43aa1b295a374ccb82cb6c0a790187bdfc4f4ed066302a',
+    marketData: candidate17Preregistration.marketData,
+    calendar: candidateDevelopmentCalendarContract,
+  },
+  evidenceContentHash: '97b9c2d6dc1d59d9b60686065bc4d595b8d1f22cdff9930b6131427b90e13f26',
+  independentlyReproducedEvaluationHash: 'c7e551fc6352c4294f38e083b8743b882f2874ec4d614f46a04539d2a72d79a1',
+  independentlyReproducedDecisionOutputHash: '9d76278fa34c18d38110b42980e65dd7941267968420e10fa0c0515b5075ed14',
+} as const
+
+export const candidate17DevelopmentEligibility = {
+  status: 'DEVELOPMENT_REJECTED',
+  evidenceContentHash: candidate17DevelopmentEvidenceExpectation.evidenceContentHash,
+  nextCandidatePreregistration: null,
+} as const
+
+export const frozenCandidateDevelopmentTrialHistory: CandidateDevelopmentTrialHistory = {
+  schemaVersion: 'bayn.candidate-development-trial-history.v1',
+  completedCandidateOrdinals: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
+  latestTerminalEvidence: {
+    candidateOrdinal: 16,
+    priorTrialCount: 15,
+    terminalStatus: 'HOLD_REJECT',
+    sourceRevision: '60a48a2e52fbafdd67a404a33a3cb22e82a98493',
+  },
+  candidatePreregistration: {
+    candidateOrdinal: 16,
+    priorTrialCount: 15,
+    sourceRevision: 'a0dadcd2f6346968bd9df582e4673608afc04592',
+    path: 'services/bayn/candidates/ordinal-16-macro-breadth-regime-preregistration.md',
+    blobOid: 'f602e3c8fd1b85768404d5fbc439775cdcd2570b',
+  },
+  latestReviewedCandidatePreregistration: candidate17Preregistration,
+  latestDevelopmentEvidence: {
+    candidateOrdinal: 17,
+    priorTrialCount: 16,
+    status: 'DEVELOPMENT_REJECTED',
+    evidenceContentHash: candidate17DevelopmentEvidenceExpectation.evidenceContentHash,
+    reviewedSourceRevision: candidate17DevelopmentEvidenceExpectation.bindings.reviewedSourceRevision,
+    mergedSourceRevision: candidate17DevelopmentEvidenceExpectation.bindings.mergedSourceRevision,
+    qualificationAttemptConsumed: false,
+  },
+  nextCandidatePreregistration: null,
+}


### PR DESCRIPTION
## Summary

- add a generic immutable Candidate-development gate that authorizes qualification only after the complete development evaluation passes the existing production preflight, economic, selected-benchmark, bootstrap, walk-forward, power, doubled-cost, accounting, and terminal-cash checks
- source-control Candidate 17's complete 2016-01-04 through 2022-12-30 development evaluation and bind it to the reviewed preregistration/source/module/manifest/protocol/data/calendar commitments
- record Candidate 17 as `DEVELOPMENT_REJECTED`, preserve completed ordinals 1 through 16, keep `nextCandidatePreregistration` literally `null`, and record `qualificationAttemptConsumed: false`
- separate historical reviewed-source verification from future qualification eligibility, without changing qualification workflows, collectors, release logic, broker code, manifests, permissions, or PAPER authority

## Exact provenance

- exact base: `bbef7b18804cf9e30c11eac326e90281d1774b80`
- exact head: `bc32db2e9eeb7140f422fc1b6621427a8f7dabfc`
- complete evidence canonical hash: `97b9c2d6dc1d59d9b60686065bc4d595b8d1f22cdff9930b6131427b90e13f26`
- evidence file SHA-256: `dcadb0fe73f5edc7068399e981e4a480580fbc8946a0d864e8ee0d92315f119d`
- evidence Git blob: `222890183c2db10cb8af81c6967901a12f4c1b7b`
- evidence bytes: `22,229,178`
- reviewed source revision: `9a293a7a8f7cb4ed5c8ddf41d7dbf9abecb12510`
- merged source revision: `4f39bb8ad168c3a459afdfdb30feccd49aba22d8`
- preregistration revision/blob: `890d8f5801cf7c7576ed7a0cee387a4e79b98877` / `c1d07233df53cc0379b1dfae9f1caffbd6b7abd6`
- module SHA-256/blob: `2e98bc55eae1901ccdde41978b7b32d746dc2ef6afcebbff1de0ed54574065da` / `8d1ccbfc6bef2c1707ac85f51d1647a7a8bfd98b`
- strategy protocol hash: `fa25d8c16bc4f4fde3bab99409ae60a6fd23332d295b3557231796cebb911390`
- Candidate-development protocol hash: `72754b1178308c721a43aa1b295a374ccb82cb6c0a790187bdfc4f4ed066302a`
- bounded development data hash: `e0e7b283de187d8ccaf8a449dacc538f00049cfe446dcf153b558e92bf0e17ed`
- independently reproduced complete-evaluation hash: `c7e551fc6352c4294f38e083b8743b882f2874ec4d614f46a04539d2a72d79a1`
- independently reproduced decision-output hash: `9d76278fa34c18d38110b42980e65dd7941267968420e10fa0c0515b5075ed14`

The complete evidence artifact is audit/test-only. The runtime calendar carries only the small immutable rejection receipt and null qualification pointer, so Bayn runtime and qualification command bundles retain their normal sizes.

## Recomputed development decision

The gate does not trust summarized PASS fields. It:

- reruns `preflightCandidateDevelopment` against the frozen calendar and protocol
- decodes the complete evaluation through `validateCandidateDevelopmentCommandEvaluation`
- rebuilds qualification series and recomputes the complete selected-benchmark analysis, including the 10,000 bootstrap samples, sample hash, lower-tail quantiles, power, benchmark selection, and expanding-origin fold geometry
- recomputes strategy, buy-and-hold, direct-volatility, stressed, and recorded doubled-cost metrics from equity and cumulative accounting series
- rebuilds the economic verdict from the reviewed thresholds
- recomputes baseline/stressed signal, quantity, and execution-model invariants with `validateCandidateDevelopmentDoubledCostCausalPath`
- requires terminal cash and, for an apparent PASS, requires the production `buildCandidateDevelopmentCommandReport` approval path to return PASS
- strictly decodes the entire committed evidence document with Effect Schema before field access, including `verifiedSource.sourceManifest` and the complete evaluation shape
- executes the reviewed Candidate 17 module independently and requires its full evaluation and decision-output hashes to match the immutable expectation before any approval

Candidate 17 remains terminally inadequate:

- strategy annualized return: `8.8470%`
- SPY buy-and-hold annualized return: `12.1446%`
- reviewed annualized excess-return lower bound: `-8.9139%`
- reviewed Sharpe-difference lower bound: `-0.1910`
- independently reproduced comparison also remains negative with one positive walk-forward fold out of five
- terminal status: `DEVELOPMENT_REJECTED`

The reviewed rounded values and complete reproducible evaluation are retained as distinct, explicitly bound evidence rather than falsely represented as the same byte stream.

Research context:

- White (2000), Reality Check: `https://doi.org/10.1111/1468-0262.00152`
- Bailey et al., Probability of Backtest Overfitting: `https://papers.ssrn.com/sol3/papers.cfm?abstract_id=2326253`

## Fail-closed behavior

Missing, malformed, stale, tampered, mismatched, coherently rehashed, economically inconsistent, benchmark-switched, fold-forged, bootstrap-forged, power-forged, noncausal, or module-output-divergent evidence yields `DEVELOPMENT_EVIDENCE_INVALID` and a null qualification pointer. Valid evidence with any existing gate failure yields `DEVELOPMENT_REJECTED` and a null pointer. Rejected, missing, and stale regressions prove the holdout callback is never called.

No qualification command or holdout data was accessed. No Candidate 18 was created.

## Related Issues

PROOMPT-407

## Testing

- Candidate-development suite: 116 passed, 0 failed, 1,547 assertions
- full Bayn suite on a clean exact-main archive: 1,066 passed, 0 failed; 138 database-gated tests skipped locally
- formatting, TypeScript, Oxlint, type-aware Oxlint, Effect diagnostics, and build: passed
- runtime bundle sizes remain normal: index `4.84 MB`; qualification collector `5.21 MB`; qualification candidate `3.53 MB`
- dedicated PostgreSQL command: exited successfully; local cases skipped because no test database was configured
- exact-head CI is required for real PostgreSQL execution and both image architectures

## Breaking Changes

Candidate 17 is no longer eligible for governed qualification. This is the intended fail-closed correction. Completed ordinals remain 1 through 16, and no Candidate 18 is introduced.

## Checklist

- [x] Complete immutable development evaluation is source-controlled and hash-bound.
- [x] Every existing development gate is recomputed through production validators.
- [x] The complete document is Effect-Schema decoded and the reviewed module is independently re-executed before any approval.
- [x] Candidate 17 is recorded as development-rejected without consuming qualification.
- [x] No holdout, qualification workflow, collector, release, PAPER, broker, manifest, permission, or credential path changes.


