### PR TITLE
fix(bayn): attest reconstructed release review

### DIFF
--- a/.github/workflows/bayn-build-push.yml
+++ b/.github/workflows/bayn-build-push.yml
@@ -13,6 +13,7 @@ on:
       - 'services/bayn/**'
       - 'packages/scripts/src/bayn/update-manifests.ts'
       - 'packages/scripts/src/bayn/verify-release-review.ts'
+      - 'services/bayn/release-review-remediations/**'
       - 'nix/images/bayn.nix'
       - 'nix/images/bayn-runtime-root.nix'
       - 'nix/images/bun-workspace-service.nix'
@@ -115,6 +116,7 @@ jobs:
             bun packages/scripts/src/bayn/verify-release-review.ts
             --mode retry-discovery
             --repository "${GITHUB_REPOSITORY}"
+            --repository-root "${GITHUB_WORKSPACE}"
             --commit "${GITHUB_SHA}"
             --github-output "${GITHUB_OUTPUT}"
             --request-timeout-ms 10000
@@ -185,6 +187,7 @@ jobs:
             bun packages/scripts/src/bayn/verify-release-review.ts \
               --mode push \
               --repository "${GITHUB_REPOSITORY}" \
+              --repository-root "${GITHUB_WORKSPACE}" \
               --commit "${GITHUB_SHA}" \
               --push-before "${PUSH_BEFORE}" \
               --max-attempts 10 \
@@ -195,6 +198,7 @@ jobs:
             bun packages/scripts/src/bayn/verify-release-review.ts \
               --mode retry-publication \
               --repository "${GITHUB_REPOSITORY}" \
+              --repository-root "${GITHUB_WORKSPACE}" \
               --commit "${GITHUB_SHA}" \
               --retry-source-commit "${RETRY_SOURCE_SHA}" \
               --retry-pr-number "${RETRY_PR_NUMBER}" \

--- a/packages/scripts/src/bayn/bayn-build-push-concurrency.test.ts
+++ b/packages/scripts/src/bayn/bayn-build-push-concurrency.test.ts
@@ -34,6 +34,11 @@ const cancelsRunningEvent = (running: RetryEvent, incoming: RetryEvent): boolean
   parsed.concurrency['cancel-in-progress'] && concurrencyGroupFor(running) === concurrencyGroupFor(incoming)
 
 describe('Bayn build-push workflow concurrency', () => {
+  test('binds release-review remediations to the exact checked-out repository', () => {
+    expect(workflow).toContain("'services/bayn/release-review-remediations/**'")
+    expect(workflow.match(/--repository-root "\$\{GITHUB_WORKSPACE\}"/g)).toHaveLength(3)
+  })
+
   test('does not let an unrelated issue comment cancel scheduled retry discovery', () => {
     expect(normalizedConcurrencyGroup).toBe(expectedConcurrencyGroup)
 

--- a/packages/scripts/src/bayn/verify-release-review.test.ts
+++ b/packages/scripts/src/bayn/verify-release-review.test.ts
@@ -706,6 +706,95 @@ describe('Bayn publication-range eligibility', () => {
     })
   })
 
+  test('accepts exact remediation descendants across an interleaved direct-parent chain of non-Bayn commits', () => {
+    const fixture = remediationHistoryFixture()
+    const comparison = fixture.snapshot.comparison!
+    const [blocked, candidate, qualification, introduction] = comparison.commits
+    if (blocked === undefined || candidate === undefined || qualification === undefined || introduction === undefined) {
+      throw new Error('remediation fixture commit chain is incomplete')
+    }
+    const nonBaynCommit = (sha: string, parent: string, path: string) => ({
+      sha,
+      parents: [parent],
+      treeSha: sha,
+      files: [path],
+      fileChanges: [{ path, previousPath: null, status: 'modified', blobSha: sha }],
+      reviewSnapshot: null,
+    })
+    const beforeCandidate = nonBaynCommit('1'.repeat(40), blocked.sha, 'docs/bayn-release-review.md')
+    const beforeQualification = nonBaynCommit('2'.repeat(40), candidate.sha, 'docs/bayn-qualification.md')
+    const beforeIntroduction = nonBaynCommit('3'.repeat(40), qualification.sha, 'README.md')
+    const afterIntroduction = nonBaynCommit('4'.repeat(40), introduction.sha, 'docs/operations.md')
+    ;(candidate.parents as string[])[0] = beforeCandidate.sha
+    ;(qualification.parents as string[])[0] = beforeQualification.sha
+    ;(introduction.parents as string[])[0] = beforeIntroduction.sha
+    const candidateHead = fixture.evidence.referencedCommits.find((commit) => commit.sha === realHistory.candidateHead)
+    const qualificationHead = fixture.evidence.referencedCommits.find(
+      (commit) => commit.sha === realHistory.qualificationHead,
+    )
+    if (candidateHead === undefined || qualificationHead === undefined) {
+      throw new Error('remediation fixture descendant head evidence is incomplete')
+    }
+    ;(candidateHead.parents as string[])[0] = beforeCandidate.sha
+    ;(qualificationHead.parents as string[])[0] = beforeQualification.sha
+    ;(
+      comparison as unknown as {
+        headSha: string
+        aheadBy: number
+        totalCommits: number
+        commits: unknown[]
+      }
+    ).headSha = afterIntroduction.sha
+    ;(
+      comparison as unknown as {
+        headSha: string
+        aheadBy: number
+        totalCommits: number
+        commits: unknown[]
+      }
+    ).aheadBy = 8
+    ;(
+      comparison as unknown as {
+        headSha: string
+        aheadBy: number
+        totalCommits: number
+        commits: unknown[]
+      }
+    ).totalCommits = 8
+    ;(
+      comparison as unknown as {
+        headSha: string
+        aheadBy: number
+        totalCommits: number
+        commits: unknown[]
+      }
+    ).commits = [
+      blocked,
+      beforeCandidate,
+      candidate,
+      beforeQualification,
+      qualification,
+      beforeIntroduction,
+      introduction,
+      afterIntroduction,
+    ]
+    ;(fixture.snapshot.currentCommitParents as string[])[0] = introduction.sha
+
+    expect(
+      evaluateBaynReleaseEligibility({
+        mainCommitSha: afterIntroduction.sha,
+        baseRefName: 'main',
+        snapshot: fixture.snapshot,
+        nowMs: Date.parse('2026-07-31T12:30:00Z'),
+        pushBeforeSha: introduction.sha,
+      }),
+    ).toMatchObject({
+      status: 'eligible',
+      checkedCommitCount: 8,
+      baynAffectingCommitCount: 4,
+    })
+  })
+
   test('keeps the dropped reviewed ancestor blocked without the exact receipt', () => {
     const fixture = remediationHistoryFixture()
     expect(

--- a/packages/scripts/src/bayn/verify-release-review.test.ts
+++ b/packages/scripts/src/bayn/verify-release-review.test.ts
@@ -834,6 +834,38 @@ describe('Bayn publication-range eligibility', () => {
       },
     ],
     [
+      'changes-requested review on a dropped descendant head',
+      (fixture: ReturnType<typeof remediationHistoryFixture>) => {
+        const pull = fixture.snapshot.comparison!.commits[1]!.reviewSnapshot!.pullRequest!
+        ;(pull.reviews as PullRequestReview[]).push(
+          review({
+            commitSha: 'c'.repeat(40),
+            submittedAt: '2026-07-31T11:21:00Z',
+            state: 'CHANGES_REQUESTED',
+          }),
+        )
+        ;(
+          fixture.evidence.record as unknown as {
+            requiredDescendants: { sourcePullRequestEvidenceSha256: string }[]
+          }
+        ).requiredDescendants[0]!.sourcePullRequestEvidenceSha256 = pullRequestReviewEvidenceSha256(pull)
+      },
+    ],
+    [
+      'pending review on a dropped descendant head',
+      (fixture: ReturnType<typeof remediationHistoryFixture>) => {
+        const pull = fixture.snapshot.comparison!.commits[1]!.reviewSnapshot!.pullRequest!
+        ;(pull.reviews as PullRequestReview[]).push(
+          review({ commitSha: 'd'.repeat(40), submittedAt: null, state: 'PENDING' }),
+        )
+        ;(
+          fixture.evidence.record as unknown as {
+            requiredDescendants: { sourcePullRequestEvidenceSha256: string }[]
+          }
+        ).requiredDescendants[0]!.sourcePullRequestEvidenceSha256 = pullRequestReviewEvidenceSha256(pull)
+      },
+    ],
+    [
       'incomplete descendant review chain',
       (fixture: ReturnType<typeof remediationHistoryFixture>) => {
         const pull = fixture.snapshot.comparison!.commits[1]!.reviewSnapshot!.pullRequest!

--- a/packages/scripts/src/bayn/verify-release-review.test.ts
+++ b/packages/scripts/src/bayn/verify-release-review.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test } from 'bun:test'
+import { createHash } from 'node:crypto'
+import { readFileSync } from 'node:fs'
 
 import {
   baynCodexBotLogin,
@@ -13,17 +15,23 @@ import {
   isBaynReleaseAffectingPath,
   loadOptionalFailedReviewThreadBlock,
   parseFailedReviewThreadBlock,
+  parseBaynReleaseReviewRemediationRecord,
   pollBaynReleaseEligibility,
   pollBaynReleaseReview,
   resolveLastPublishedRevision,
+  pullRequestReviewEvidenceSha256,
   type AssociatedPullRequest,
   type BaynBuildWorkflowRun,
   type BaynReleaseEligibilitySnapshot,
   type BaynReleaseRetrySnapshot,
   type BaynReleaseReviewPollResult,
   type BaynReleaseReviewSnapshot,
+  type BaynReleaseReviewRemediationEvidence,
+  type BaynReleaseReviewRemediationRecord,
   type PullRequestReview,
+  type PullRequestReviewState,
   type PullRequestIssueComment,
+  type PullRequestForcePush,
   type PullRequestReaction,
   type PullRequestReviewThread,
   type PullRequestReviewThreadComment,
@@ -112,6 +120,7 @@ const snapshot = (
     readonly commitShas?: readonly string[]
     readonly issueComments?: readonly PullRequestIssueComment[]
     readonly reactions?: readonly PullRequestReaction[]
+    readonly headForcePushes?: readonly PullRequestForcePush[]
     readonly headForcePushCount?: number
   } = {},
 ): BaynReleaseReviewSnapshot => {
@@ -139,7 +148,8 @@ const snapshot = (
             commitShas: options.commitShas ?? [source.headSha],
             issueComments: options.issueComments ?? [],
             reactions: options.reactions ?? [],
-            headForcePushCount: options.headForcePushCount ?? 0,
+            headForcePushes: options.headForcePushes ?? [],
+            headForcePushCount: options.headForcePushCount ?? options.headForcePushes?.length ?? 0,
           },
   }
 }
@@ -165,6 +175,7 @@ const reviewSnapshotFor = (options: {
   readonly threads?: readonly PullRequestReviewThread[]
   readonly issueComments?: readonly PullRequestIssueComment[]
   readonly reactions?: readonly PullRequestReaction[]
+  readonly headForcePushes?: readonly PullRequestForcePush[]
   readonly headForcePushCount?: number
   readonly mergedAt?: string
 }): BaynReleaseReviewSnapshot => {
@@ -197,7 +208,8 @@ const reviewSnapshotFor = (options: {
       commitShas: [options.headSha],
       issueComments: options.issueComments ?? [],
       reactions: options.reactions ?? [],
-      headForcePushCount: options.headForcePushCount ?? 0,
+      headForcePushes: options.headForcePushes ?? [],
+      headForcePushCount: options.headForcePushCount ?? options.headForcePushes?.length ?? 0,
     },
   }
 }
@@ -328,7 +340,505 @@ const retrySnapshot = (
   }
 }
 
+const remediationRecordPath = 'services/bayn/release-review-remediations/890d8f5801cf7c7576ed7a0cee387a4e79b98877.json'
+const realRemediationRecord = parseBaynReleaseReviewRemediationRecord(
+  JSON.parse(readFileSync(remediationRecordPath, 'utf8')) as unknown,
+)
+const sha256Text = (value: string): string => createHash('sha256').update(value).digest('hex')
+
+const realHistory = {
+  base: 'e0a38e65e7ba65fb7d00585b02d9fc2cdbeee826',
+  reviewed: '8ef6b67fe799c0dddd70bc70f4648a3b23a7ca5b',
+  final: 'd9903bf860ede2622ab77a9eac8e3a9454586955',
+  blocked: '890d8f5801cf7c7576ed7a0cee387a4e79b98877',
+  candidateHead: '9a293a7a8f7cb4ed5c8ddf41d7dbf9abecb12510',
+  candidateMerge: '4f39bb8ad168c3a459afdfdb30feccd49aba22d8',
+  qualificationHead: '20043b151015acf77e5e1ecd8f7e2e1daa3da090',
+  qualificationMerge: '9f4ea79b12dcd32c794a9701160587d9a12e8c4d',
+  remediationHead: '6'.repeat(40),
+  remediationMerge: '7'.repeat(40),
+} as const
+
+const exactReviewState = (input: {
+  readonly number: number
+  readonly mergeCommitSha: string
+  readonly headSha: string
+  readonly createdAt: string
+  readonly mergedAt: string
+  readonly reviewedHeadSha: string
+  readonly forcePushes?: readonly PullRequestForcePush[]
+  readonly threads?: readonly PullRequestReviewThread[]
+}): PullRequestReviewState => ({
+  number: input.number,
+  baseRefName: 'main',
+  headSha: input.headSha,
+  mergeCommitSha: input.mergeCommitSha,
+  createdAt: input.createdAt,
+  mergedAt: input.mergedAt,
+  reviews: [
+    review({
+      commitSha: input.reviewedHeadSha,
+      submittedAt: new Date(Date.parse(input.mergedAt) - 120_000).toISOString(),
+    }),
+  ],
+  threads: input.threads ?? [],
+  commitShas: [input.headSha],
+  issueComments: [],
+  reactions: [reaction({ createdAt: new Date(Date.parse(input.mergedAt) - 30_000).toISOString() })],
+  headForcePushes: input.forcePushes ?? [],
+  headForcePushCount: input.forcePushes?.length ?? 0,
+})
+
+const remediationHistoryFixture = (): {
+  readonly snapshot: BaynReleaseEligibilitySnapshot
+  readonly evidence: BaynReleaseReviewRemediationEvidence
+} => {
+  const findingBody = 'P1: preregister the TypeScript candidate artifact.'
+  const replyBody = `Fixed at exact head ${realHistory.final}.`
+  const blockedPull: PullRequestReviewState = {
+    number: 13428,
+    baseRefName: 'main',
+    headSha: realHistory.final,
+    mergeCommitSha: realHistory.blocked,
+    createdAt: '2026-07-31T10:58:04Z',
+    mergedAt: '2026-07-31T11:15:17Z',
+    reviews: [
+      review({
+        commitSha: realHistory.reviewed,
+        submittedAt: '2026-07-31T11:01:07Z',
+      }),
+    ],
+    threads: [
+      thread({
+        id: 'PRRT_kwDOLkRLus6VZVPy',
+        isResolved: true,
+        isOutdated: true,
+        path: 'services/bayn/candidates/ordinal-17-volatility-managed-trend-overlay-preregistration.json',
+        url: 'https://github.com/proompteng/lab/pull/13428#discussion_r3689961132',
+        comments: [
+          threadComment({
+            body: findingBody,
+            commitSha: realHistory.reviewed,
+            reviewCommitSha: realHistory.reviewed,
+            reviewSubmittedAt: '2026-07-31T11:01:07Z',
+            createdAt: '2026-07-31T11:01:07Z',
+            url: 'https://github.com/proompteng/lab/pull/13428#discussion_r3689961132',
+          }),
+          threadComment({
+            authorLogin: 'gregkonush',
+            authorAssociation: 'MEMBER',
+            body: replyBody,
+            commitSha: realHistory.reviewed,
+            reviewCommitSha: realHistory.final,
+            reviewAuthorLogin: 'gregkonush',
+            reviewSubmittedAt: '2026-07-31T11:11:10Z',
+            createdAt: '2026-07-31T11:11:10Z',
+            url: 'https://github.com/proompteng/lab/pull/13428#discussion_r3690008122',
+          }),
+        ],
+      }),
+    ],
+    commitShas: [realHistory.final],
+    issueComments: [],
+    reactions: [reaction({ createdAt: '2026-07-31T11:13:26Z' })],
+    headForcePushes: [
+      {
+        actorLogin: 'gregkonush',
+        beforeCommitSha: realHistory.reviewed,
+        afterCommitSha: realHistory.final,
+        createdAt: '2026-07-31T11:10:46Z',
+      },
+    ],
+    headForcePushCount: 1,
+  }
+  const candidatePull = exactReviewState({
+    number: 13422,
+    mergeCommitSha: realHistory.candidateMerge,
+    headSha: realHistory.candidateHead,
+    reviewedHeadSha: '5c5e9f5e0a53b7b0a61b21bb36388d6f8a93195a',
+    createdAt: '2026-07-31T08:32:58Z',
+    mergedAt: '2026-07-31T11:23:15Z',
+    forcePushes: [
+      {
+        actorLogin: 'gregkonush',
+        beforeCommitSha: '5c5e9f5e0a53b7b0a61b21bb36388d6f8a93195a',
+        afterCommitSha: realHistory.candidateHead,
+        createdAt: '2026-07-31T11:18:00Z',
+      },
+    ],
+  })
+  const qualificationPull = exactReviewState({
+    number: 13427,
+    mergeCommitSha: realHistory.qualificationMerge,
+    headSha: realHistory.qualificationHead,
+    reviewedHeadSha: '508f0dd5a600ed26de66a2bf6c231c96055ea664',
+    createdAt: '2026-07-31T10:08:26Z',
+    mergedAt: '2026-07-31T11:37:39Z',
+    forcePushes: [
+      {
+        actorLogin: 'gregkonush',
+        beforeCommitSha: '508f0dd5a600ed26de66a2bf6c231c96055ea664',
+        afterCommitSha: realHistory.qualificationHead,
+        createdAt: '2026-07-31T11:25:00Z',
+      },
+    ],
+  })
+  const record = structuredClone(realRemediationRecord) as BaynReleaseReviewRemediationRecord
+  const mutableRecord = record as unknown as {
+    blocked: {
+      sourcePullRequestEvidenceSha256: string
+      feedback: { findingBodySha256: string; fixReplyBodySha256: string }
+    }
+    requiredDescendants: { sourcePullRequestEvidenceSha256: string }[]
+  }
+  mutableRecord.blocked.sourcePullRequestEvidenceSha256 = pullRequestReviewEvidenceSha256(blockedPull)
+  mutableRecord.blocked.feedback.findingBodySha256 = sha256Text(findingBody)
+  mutableRecord.blocked.feedback.fixReplyBodySha256 = sha256Text(replyBody)
+  mutableRecord.requiredDescendants[0]!.sourcePullRequestEvidenceSha256 = pullRequestReviewEvidenceSha256(candidatePull)
+  mutableRecord.requiredDescendants[1]!.sourcePullRequestEvidenceSha256 =
+    pullRequestReviewEvidenceSha256(qualificationPull)
+
+  const reviewedPaths = record.blocked.affectedPaths.map((path) => ({
+    path: path.path,
+    blobSha: path.reviewedBlobSha,
+  }))
+  const finalPaths = record.blocked.affectedPaths.map((path) => ({ path: path.path, blobSha: path.finalBlobSha }))
+  const candidatePaths = record.requiredDescendants[0]!.affectedPaths.map((path) => ({
+    path: path.path,
+    blobSha: path.finalHeadBlobSha,
+  }))
+  const qualificationPaths = record.requiredDescendants[1]!.affectedPaths.map((path) => ({
+    path: path.path,
+    blobSha: path.finalHeadBlobSha,
+  }))
+  const change = (path: string, blobSha: string, status = 'modified') => ({
+    path,
+    previousPath: null,
+    status,
+    blobSha,
+  })
+  const blockedSnapshot: BaynReleaseReviewSnapshot = {
+    mainCommitParents: [realHistory.base],
+    associatedPullRequests: [
+      associatedPull({
+        number: 13428,
+        headSha: realHistory.final,
+        mergeCommitSha: realHistory.blocked,
+        mergedAt: blockedPull.mergedAt,
+      }),
+    ],
+    pullRequest: blockedPull,
+  }
+  const candidateSnapshot: BaynReleaseReviewSnapshot = {
+    mainCommitParents: [realHistory.blocked],
+    associatedPullRequests: [
+      associatedPull({
+        number: 13422,
+        headSha: realHistory.candidateHead,
+        mergeCommitSha: realHistory.candidateMerge,
+        mergedAt: candidatePull.mergedAt,
+      }),
+    ],
+    pullRequest: candidatePull,
+  }
+  const qualificationSnapshot: BaynReleaseReviewSnapshot = {
+    mainCommitParents: [realHistory.candidateMerge],
+    associatedPullRequests: [
+      associatedPull({
+        number: 13427,
+        headSha: realHistory.qualificationHead,
+        mergeCommitSha: realHistory.qualificationMerge,
+        mergedAt: qualificationPull.mergedAt,
+      }),
+    ],
+    pullRequest: qualificationPull,
+  }
+  const remediationSnapshot = reviewSnapshotFor({
+    commitSha: realHistory.remediationMerge,
+    prNumber: 13430,
+    headSha: realHistory.remediationHead,
+    parents: [realHistory.qualificationMerge],
+    mergedAt: '2026-07-31T12:20:00Z',
+  })
+  const recordBlobSha = '9'.repeat(40)
+  const commits: NonNullable<BaynReleaseEligibilitySnapshot['comparison']>['commits'] = [
+    {
+      sha: realHistory.blocked,
+      parents: [realHistory.base],
+      treeSha: record.blocked.mergeTreeSha,
+      files: record.blocked.affectedPaths.map((path) => path.path),
+      fileChanges: record.blocked.affectedPaths.map((path) => change(path.path, path.blockedBlobSha, 'added')),
+      reviewSnapshot: blockedSnapshot,
+    },
+    {
+      sha: realHistory.candidateMerge,
+      parents: [realHistory.blocked],
+      treeSha: record.requiredDescendants[0]!.mergeTreeSha,
+      files: candidatePaths.map((path) => path.path),
+      fileChanges: candidatePaths.map((path) => change(path.path, path.blobSha)),
+      reviewSnapshot: candidateSnapshot,
+    },
+    {
+      sha: realHistory.qualificationMerge,
+      parents: [realHistory.candidateMerge],
+      treeSha: record.requiredDescendants[1]!.mergeTreeSha,
+      files: qualificationPaths.map((path) => path.path),
+      fileChanges: qualificationPaths.map((path) => change(path.path, path.blobSha)),
+      reviewSnapshot: qualificationSnapshot,
+    },
+    {
+      sha: realHistory.remediationMerge,
+      parents: [realHistory.qualificationMerge],
+      treeSha: '8'.repeat(40),
+      files: [
+        'packages/scripts/src/bayn/verify-release-review.ts',
+        'packages/scripts/src/bayn/verify-release-review.test.ts',
+        remediationRecordPath,
+      ],
+      fileChanges: [
+        change('packages/scripts/src/bayn/verify-release-review.ts', '1'.repeat(40)),
+        change('packages/scripts/src/bayn/verify-release-review.test.ts', '2'.repeat(40)),
+        change(remediationRecordPath, recordBlobSha, 'added'),
+      ],
+      reviewSnapshot: remediationSnapshot,
+    },
+  ]
+  const evidence: BaynReleaseReviewRemediationEvidence = {
+    recordPath: remediationRecordPath,
+    recordBlobSha,
+    record,
+    referencedCommits: [
+      {
+        sha: realHistory.reviewed,
+        parents: [realHistory.base],
+        treeSha: record.blocked.reviewedHeadTreeSha,
+        files: reviewedPaths.map((path) => path.path),
+        fileChanges: reviewedPaths.map((path) => change(path.path, path.blobSha, 'added')),
+        pathBlobs: reviewedPaths,
+      },
+      {
+        sha: realHistory.final,
+        parents: [realHistory.base],
+        treeSha: record.blocked.finalHeadTreeSha,
+        files: finalPaths.map((path) => path.path),
+        fileChanges: finalPaths.map((path) => change(path.path, path.blobSha, 'added')),
+        pathBlobs: finalPaths,
+      },
+      {
+        sha: realHistory.candidateHead,
+        parents: [realHistory.blocked],
+        treeSha: record.requiredDescendants[0]!.finalHeadTreeSha,
+        files: candidatePaths.map((path) => path.path),
+        fileChanges: candidatePaths.map((path) => change(path.path, path.blobSha)),
+        pathBlobs: candidatePaths,
+      },
+      {
+        sha: realHistory.qualificationHead,
+        parents: [realHistory.candidateMerge],
+        treeSha: record.requiredDescendants[1]!.finalHeadTreeSha,
+        files: qualificationPaths.map((path) => path.path),
+        fileChanges: qualificationPaths.map((path) => change(path.path, path.blobSha)),
+        pathBlobs: qualificationPaths,
+      },
+    ],
+    currentPathBlobs: finalPaths,
+  }
+  return {
+    evidence,
+    snapshot: {
+      currentCommitParents: [realHistory.qualificationMerge],
+      lastPublishedRevision: {
+        status: 'resolved',
+        revision: realHistory.base,
+        runId: 1,
+        runNumber: 1,
+        runAttempt: 1,
+      },
+      comparison: {
+        status: 'ahead',
+        baseSha: realHistory.base,
+        headSha: realHistory.remediationMerge,
+        mergeBaseSha: realHistory.base,
+        aheadBy: 4,
+        totalCommits: 4,
+        commits,
+        truncated: false,
+      },
+      remediations: [evidence],
+    },
+  }
+}
+
 describe('Bayn publication-range eligibility', () => {
+  test('accepts the real #13428 -> #13422 -> #13427 history only through its reviewed exact receipt', () => {
+    expect(realRemediationRecord).toMatchObject({
+      blocked: {
+        mergeCommitSha: realHistory.blocked,
+        reviewedHeadSha: realHistory.reviewed,
+        finalHeadSha: realHistory.final,
+        sourcePullRequestNumber: 13428,
+      },
+      requiredDescendants: [
+        { mergeCommitSha: realHistory.candidateMerge, sourcePullRequestNumber: 13422 },
+        { mergeCommitSha: realHistory.qualificationMerge, sourcePullRequestNumber: 13427 },
+      ],
+    })
+    const fixture = remediationHistoryFixture()
+    expect(
+      evaluateBaynReleaseEligibility({
+        mainCommitSha: realHistory.remediationMerge,
+        baseRefName: 'main',
+        snapshot: fixture.snapshot,
+        nowMs: Date.parse('2026-07-31T12:30:00Z'),
+        pushBeforeSha: realHistory.qualificationMerge,
+      }),
+    ).toMatchObject({
+      status: 'eligible',
+      lastPublishedRevision: realHistory.base,
+      checkedCommitCount: 4,
+      baynAffectingCommitCount: 4,
+      reviewedPullRequests: [
+        { commitSha: realHistory.blocked, prNumber: 13428, headSha: realHistory.final },
+        { commitSha: realHistory.candidateMerge, prNumber: 13422, headSha: realHistory.candidateHead },
+        { commitSha: realHistory.qualificationMerge, prNumber: 13427, headSha: realHistory.qualificationHead },
+        { commitSha: realHistory.remediationMerge, prNumber: 13430, headSha: realHistory.remediationHead },
+      ],
+    })
+  })
+
+  test('keeps the dropped reviewed ancestor blocked without the exact receipt', () => {
+    const fixture = remediationHistoryFixture()
+    expect(
+      evaluateBaynReleaseEligibility({
+        mainCommitSha: realHistory.remediationMerge,
+        baseRefName: 'main',
+        snapshot: { ...fixture.snapshot, remediations: [] },
+        nowMs: Date.parse('2026-07-31T12:30:00Z'),
+        pushBeforeSha: realHistory.qualificationMerge,
+      }),
+    ).toMatchObject({ status: 'hold', code: 'release-review-remediation-missing', retryable: false })
+  })
+
+  test.each([
+    [
+      'changed current blob',
+      (fixture: ReturnType<typeof remediationHistoryFixture>) => {
+        ;(fixture.evidence.currentPathBlobs as { path: string; blobSha: string }[])[0]!.blobSha = '0'.repeat(40)
+      },
+    ],
+    [
+      'extra affected path',
+      (fixture: ReturnType<typeof remediationHistoryFixture>) => {
+        ;(
+          fixture.evidence.record.blocked
+            .affectedPaths as BaynReleaseReviewRemediationRecord['blocked']['affectedPaths'] as unknown as {
+            path: string
+            reviewedBlobSha: string
+            finalBlobSha: string
+            blockedBlobSha: string
+          }[]
+        ).push({
+          path: 'services/bayn/src/extra.ts',
+          reviewedBlobSha: '1'.repeat(40),
+          finalBlobSha: '1'.repeat(40),
+          blockedBlobSha: '1'.repeat(40),
+        })
+      },
+    ],
+    [
+      'non-ancestor descendant',
+      (fixture: ReturnType<typeof remediationHistoryFixture>) => {
+        const comparison = fixture.snapshot.comparison!
+        ;(comparison.commits[1]!.parents as string[])[0] = '0'.repeat(40)
+      },
+    ],
+    [
+      'spoofed source reaction',
+      (fixture: ReturnType<typeof remediationHistoryFixture>) => {
+        const pull = fixture.snapshot.comparison!.commits[0]!.reviewSnapshot!.pullRequest!
+        ;(pull.reactions as { userLogin: string | null; content: string; createdAt: string }[])[0]!.userLogin =
+          'spoofed-codex[bot]'
+      },
+    ],
+    [
+      'incomplete descendant review chain',
+      (fixture: ReturnType<typeof remediationHistoryFixture>) => {
+        const pull = fixture.snapshot.comparison!.commits[1]!.reviewSnapshot!.pullRequest!
+        ;(pull.reactions as unknown as unknown[]) = []
+      },
+    ],
+    [
+      'duplicate receipt',
+      (fixture: ReturnType<typeof remediationHistoryFixture>) => {
+        ;(fixture.snapshot.remediations as BaynReleaseReviewRemediationEvidence[]) = [
+          fixture.evidence,
+          structuredClone(fixture.evidence),
+        ]
+      },
+    ],
+    [
+      'later blocked-path mutation',
+      (fixture: ReturnType<typeof remediationHistoryFixture>) => {
+        const commit = fixture.snapshot.comparison!.commits[2]!
+        const path = fixture.evidence.record.blocked.affectedPaths[0]!.path
+        ;(commit.files as string[]).push(path)
+        ;(
+          commit.fileChanges as { path: string; previousPath: string | null; status: string; blobSha: string | null }[]
+        ).push({
+          path,
+          previousPath: null,
+          status: 'modified',
+          blobSha: '2'.repeat(40),
+        })
+      },
+    ],
+    [
+      'newer unreviewed source downgrade',
+      (fixture: ReturnType<typeof remediationHistoryFixture>) => {
+        const comparison = fixture.snapshot.comparison!
+        const introduction = comparison.commits.at(-1)!
+        const unreviewedSha = '3'.repeat(40)
+        const unreviewed = {
+          sha: unreviewedSha,
+          parents: [realHistory.qualificationMerge],
+          treeSha: '4'.repeat(40),
+          files: ['services/bayn/src/unreviewed.ts'],
+          fileChanges: [
+            {
+              path: 'services/bayn/src/unreviewed.ts',
+              previousPath: null,
+              status: 'added',
+              blobSha: '5'.repeat(40),
+            },
+          ],
+          reviewSnapshot: null,
+        }
+        ;(introduction.parents as string[])[0] = unreviewedSha
+        ;(comparison.commits as unknown as typeof comparison.commits as unknown as unknown[]).splice(3, 0, unreviewed)
+        ;(comparison as { aheadBy: number; totalCommits: number }).aheadBy = 5
+        ;(comparison as { aheadBy: number; totalCommits: number }).totalCommits = 5
+      },
+    ],
+  ])('rejects remediation evidence with %s', (name, mutate) => {
+    const fixture = remediationHistoryFixture()
+    mutate(fixture)
+    const result = evaluateBaynReleaseEligibility({
+      mainCommitSha: realHistory.remediationMerge,
+      baseRefName: 'main',
+      snapshot: fixture.snapshot,
+      nowMs: Date.parse('2026-07-31T12:30:00Z'),
+      pushBeforeSha: realHistory.qualificationMerge,
+    })
+    expect(result).toMatchObject({
+      status: 'hold',
+      code:
+        name === 'newer unreviewed source downgrade'
+          ? 'release-range-metadata-mismatch'
+          : 'release-review-remediation-invalid',
+      retryable: false,
+    })
+  })
+
   test('accepts every clean Bayn-affecting commit since the last published revision', () => {
     expect(
       evaluateBaynReleaseEligibility({

--- a/packages/scripts/src/bayn/verify-release-review.test.ts
+++ b/packages/scripts/src/bayn/verify-release-review.test.ts
@@ -721,6 +721,37 @@ describe('Bayn publication-range eligibility', () => {
 
   test.each([
     [
+      'pending',
+      review({ commitSha: realHistory.candidateHead, submittedAt: null, state: 'PENDING' }),
+      'exact-head-review-pending',
+    ],
+    [
+      'changes-requested',
+      review({
+        commitSha: realHistory.candidateHead,
+        submittedAt: '2026-07-31T11:22:50Z',
+        state: 'CHANGES_REQUESTED',
+      }),
+      'exact-head-review-changes-requested',
+    ],
+  ])('keeps a newer %s exact-head descendant review blocking remediation coverage', (_name, blockingReview, code) => {
+    const fixture = remediationHistoryFixture()
+    const pullRequest = fixture.snapshot.comparison!.commits[1]!.reviewSnapshot!.pullRequest!
+    ;(pullRequest.reviews as PullRequestReview[]).push(blockingReview)
+
+    expect(
+      evaluateBaynReleaseEligibility({
+        mainCommitSha: realHistory.remediationMerge,
+        baseRefName: 'main',
+        snapshot: fixture.snapshot,
+        nowMs: Date.parse('2026-07-31T12:30:00Z'),
+        pushBeforeSha: realHistory.qualificationMerge,
+      }),
+    ).toMatchObject({ status: 'hold', code })
+  })
+
+  test.each([
+    [
       'changed current blob',
       (fixture: ReturnType<typeof remediationHistoryFixture>) => {
         ;(fixture.evidence.currentPathBlobs as { path: string; blobSha: string }[])[0]!.blobSha = '0'.repeat(40)

--- a/packages/scripts/src/bayn/verify-release-review.test.ts
+++ b/packages/scripts/src/bayn/verify-release-review.test.ts
@@ -789,6 +789,48 @@ describe('Bayn publication-range eligibility', () => {
         const pull = fixture.snapshot.comparison!.commits[0]!.reviewSnapshot!.pullRequest!
         ;(pull.reactions as { userLogin: string | null; content: string; createdAt: string }[])[0]!.userLogin =
           'spoofed-codex[bot]'
+        ;(
+          fixture.evidence.record as unknown as { blocked: { sourcePullRequestEvidenceSha256: string } }
+        ).blocked.sourcePullRequestEvidenceSha256 = pullRequestReviewEvidenceSha256(pull)
+      },
+    ],
+    [
+      'stale source reaction before force push',
+      (fixture: ReturnType<typeof remediationHistoryFixture>) => {
+        const pull = fixture.snapshot.comparison!.commits[0]!.reviewSnapshot!.pullRequest!
+        ;(pull.reactions as { userLogin: string | null; content: string; createdAt: string }[])[0]!.createdAt =
+          '2026-07-31T11:09:00Z'
+        ;(
+          fixture.evidence.record as unknown as { blocked: { sourcePullRequestEvidenceSha256: string } }
+        ).blocked.sourcePullRequestEvidenceSha256 = pullRequestReviewEvidenceSha256(pull)
+      },
+    ],
+    [
+      'changes-requested review on a dropped source head',
+      (fixture: ReturnType<typeof remediationHistoryFixture>) => {
+        const pull = fixture.snapshot.comparison!.commits[0]!.reviewSnapshot!.pullRequest!
+        ;(pull.reviews as PullRequestReview[]).push(
+          review({
+            commitSha: 'a'.repeat(40),
+            submittedAt: '2026-07-31T11:05:00Z',
+            state: 'CHANGES_REQUESTED',
+          }),
+        )
+        ;(
+          fixture.evidence.record as unknown as { blocked: { sourcePullRequestEvidenceSha256: string } }
+        ).blocked.sourcePullRequestEvidenceSha256 = pullRequestReviewEvidenceSha256(pull)
+      },
+    ],
+    [
+      'pending review on a dropped source head',
+      (fixture: ReturnType<typeof remediationHistoryFixture>) => {
+        const pull = fixture.snapshot.comparison!.commits[0]!.reviewSnapshot!.pullRequest!
+        ;(pull.reviews as PullRequestReview[]).push(
+          review({ commitSha: 'b'.repeat(40), submittedAt: null, state: 'PENDING' }),
+        )
+        ;(
+          fixture.evidence.record as unknown as { blocked: { sourcePullRequestEvidenceSha256: string } }
+        ).blocked.sourcePullRequestEvidenceSha256 = pullRequestReviewEvidenceSha256(pull)
       },
     ],
     [
@@ -796,6 +838,11 @@ describe('Bayn publication-range eligibility', () => {
       (fixture: ReturnType<typeof remediationHistoryFixture>) => {
         const pull = fixture.snapshot.comparison!.commits[1]!.reviewSnapshot!.pullRequest!
         ;(pull.reactions as unknown as unknown[]) = []
+        ;(
+          fixture.evidence.record as unknown as {
+            requiredDescendants: { sourcePullRequestEvidenceSha256: string }[]
+          }
+        ).requiredDescendants[0]!.sourcePullRequestEvidenceSha256 = pullRequestReviewEvidenceSha256(pull)
       },
     ],
     [

--- a/packages/scripts/src/bayn/verify-release-review.test.ts
+++ b/packages/scripts/src/bayn/verify-release-review.test.ts
@@ -923,6 +923,34 @@ describe('Bayn publication-range eligibility', () => {
       },
     ],
     [
+      'additional unresolved source review thread',
+      (fixture: ReturnType<typeof remediationHistoryFixture>) => {
+        const pull = fixture.snapshot.comparison!.commits[0]!.reviewSnapshot!.pullRequest!
+        ;(pull.threads as PullRequestReviewThread[]).push(
+          thread({
+            id: 'PRRT_unresolved_source_finding',
+            isResolved: false,
+            isOutdated: false,
+            path: 'services/bayn/candidates/ordinal-17-volatility-managed-trend-overlay-preregistration.md',
+            url: 'https://github.com/proompteng/lab/pull/13428#discussion_r_unresolved',
+            comments: [
+              threadComment({
+                body: 'P1 unresolved source finding',
+                commitSha: realHistory.reviewed,
+                reviewCommitSha: realHistory.reviewed,
+                reviewSubmittedAt: '2026-07-31T11:02:00Z',
+                createdAt: '2026-07-31T11:02:00Z',
+                url: 'https://github.com/proompteng/lab/pull/13428#discussion_r_unresolved',
+              }),
+            ],
+          }),
+        )
+        ;(
+          fixture.evidence.record as unknown as { blocked: { sourcePullRequestEvidenceSha256: string } }
+        ).blocked.sourcePullRequestEvidenceSha256 = pullRequestReviewEvidenceSha256(pull)
+      },
+    ],
+    [
       'changes-requested review on a dropped descendant head',
       (fixture: ReturnType<typeof remediationHistoryFixture>) => {
         const pull = fixture.snapshot.comparison!.commits[1]!.reviewSnapshot!.pullRequest!

--- a/packages/scripts/src/bayn/verify-release-review.ts
+++ b/packages/scripts/src/bayn/verify-release-review.ts
@@ -1064,6 +1064,9 @@ const validateRemediationFeedback = (
   ) {
     return remediationInvalid(`remediation ${record.remediationId} source PR metadata is not exact`)
   }
+  if (pullRequest.threads.some((thread) => !thread.isResolved)) {
+    return remediationInvalid(`remediation ${record.remediationId} source PR contains an unresolved review thread`)
+  }
   const forcePush = pullRequest.headForcePushes[0]
   if (
     forcePush === undefined ||

--- a/packages/scripts/src/bayn/verify-release-review.ts
+++ b/packages/scripts/src/bayn/verify-release-review.ts
@@ -1292,6 +1292,10 @@ const validateReleaseReviewRemediation = (input: {
     ) {
       return remediationInvalid(`remediation ${record.remediationId} descendant ancestry is incomplete or downgraded`)
     }
+    const normalDescendantReview = input.normalReviews.get(mergeCommit.sha)
+    if (normalDescendantReview?.status === 'hold' && normalDescendantReview.code !== 'exact-head-review-missing') {
+      return normalDescendantReview
+    }
     const descendantPull = mergeCommit.reviewSnapshot?.pullRequest
     const descendantReactions = descendantPull?.reactions.filter(
       (reaction) => reaction.userLogin === baynCodexBotLogin && reaction.content === '+1',
@@ -1498,7 +1502,7 @@ export const evaluateBaynReleaseEligibility = (input: {
     const review = normalReviews.get(commit.sha)
     if (review === undefined) throw new Error(`missing normal review evaluation for ${commit.sha}`)
     if (review.status === 'hold') {
-      if (coveredDescendantShas.has(commit.sha)) {
+      if (coveredDescendantShas.has(commit.sha) && review.code === 'exact-head-review-missing') {
         const sourcePull = commit.reviewSnapshot?.pullRequest
         const reviewedAncestor = sourcePull?.reviews
           .filter(

--- a/packages/scripts/src/bayn/verify-release-review.ts
+++ b/packages/scripts/src/bayn/verify-release-review.ts
@@ -1308,6 +1308,11 @@ const validateReleaseReviewRemediation = (input: {
     const descendantReactions = descendantPull?.reactions.filter(
       (reaction) => reaction.userLogin === baynCodexBotLogin && reaction.content === '+1',
     )
+    const descendantBlockingReviews = descendantPull?.reviews.filter(
+      (review) =>
+        review.authorLogin === baynCodexReviewer &&
+        (review.submittedAt === null || review.state === 'PENDING' || review.state === 'CHANGES_REQUESTED'),
+    )
     const latestForcePush = descendantPull?.headForcePushes.toSorted((left, right) =>
       right.createdAt.localeCompare(left.createdAt),
     )[0]
@@ -1319,6 +1324,7 @@ const validateReleaseReviewRemediation = (input: {
       descendantPull.mergeCommitSha !== descendant.mergeCommitSha ||
       pullRequestReviewEvidenceSha256(descendantPull) !== descendant.sourcePullRequestEvidenceSha256 ||
       descendantPull.threads.some((thread) => !thread.isResolved) ||
+      descendantBlockingReviews?.length !== 0 ||
       !descendantPull.reviews.some(
         (review) =>
           review.authorLogin === baynCodexReviewer &&

--- a/packages/scripts/src/bayn/verify-release-review.ts
+++ b/packages/scripts/src/bayn/verify-release-review.ts
@@ -1072,6 +1072,14 @@ const validateRemediationFeedback = (
   ) {
     return remediationInvalid(`remediation ${record.remediationId} force-push transformation is not exact`)
   }
+  const blockingReviews = pullRequest.reviews.filter(
+    (review) =>
+      review.authorLogin === baynCodexReviewer &&
+      (review.submittedAt === null || review.state === 'PENDING' || review.state === 'CHANGES_REQUESTED'),
+  )
+  if (blockingReviews.length > 0) {
+    return remediationInvalid(`remediation ${record.remediationId} contains a blocking Codex review`)
+  }
   const reviewMatches = pullRequest.reviews.filter(
     (review) =>
       review.authorLogin === baynCodexReviewer &&
@@ -1115,7 +1123,7 @@ const validateRemediationFeedback = (
   const reactions = pullRequest.reactions.filter(
     (reaction) => reaction.userLogin === baynCodexBotLogin && reaction.content === '+1',
   )
-  if (reactions.length !== 1) {
+  if (reactions.length !== 1 || reactions[0] === undefined || reactions[0].createdAt <= forcePush.createdAt) {
     return remediationInvalid(`remediation ${record.remediationId} exact final-head reaction evidence is missing`)
   }
   return null

--- a/packages/scripts/src/bayn/verify-release-review.ts
+++ b/packages/scripts/src/bayn/verify-release-review.ts
@@ -1145,6 +1145,12 @@ const validateRemediationCommitPaths = (input: {
   if (input.finalHead.sha !== input.finalHeadSha || input.mergeTreeSha !== input.finalHeadTreeSha) {
     return remediationInvalid(`remediation ${input.remediationId} merge/head tree binding is invalid`)
   }
+  if (
+    input.mergeCommit.parents.length !== input.finalHead.parents.length ||
+    input.mergeCommit.parents.some((parent, index) => parent !== input.finalHead.parents[index])
+  ) {
+    return remediationInvalid(`remediation ${input.remediationId} merge/head parent binding is invalid`)
+  }
   const changes = commitFileMap(input.mergeCommit.fileChanges)
   const finalBlobs = pathBlobMap(input.finalHead.pathBlobs)
   if (changes === null || finalBlobs === null) {
@@ -1289,15 +1295,26 @@ const validateReleaseReviewRemediation = (input: {
   }
 
   let expectedParent = blockedCommit.sha
-  let expectedIndex = blockedIndex + 1
+  let cursor = blockedIndex + 1
+  const nextBaynCommit = (): BaynReleaseRangeCommit | BaynReleaseReviewHold | null => {
+    while (cursor < comparison.commits.length) {
+      const commit = comparison.commits[cursor]
+      if (commit === undefined || commit.parents.length !== 1 || commit.parents[0] !== expectedParent) {
+        return remediationInvalid(`remediation ${record.remediationId} source ancestry is not a direct-parent chain`)
+      }
+      expectedParent = commit.sha
+      cursor += 1
+      if (commit.files.some(isBaynReleaseAffectingPath)) return commit
+    }
+    return null
+  }
   for (const descendant of record.requiredDescendants) {
-    const mergeCommit = comparison.commits[expectedIndex]
-    if (
-      mergeCommit === undefined ||
-      mergeCommit.sha !== descendant.mergeCommitSha ||
-      mergeCommit.parents.length !== 1 ||
-      mergeCommit.parents[0] !== expectedParent
-    ) {
+    const next = nextBaynCommit()
+    if (next === null || 'status' in next) {
+      return next ?? remediationInvalid(`remediation ${record.remediationId} descendant chain is incomplete`)
+    }
+    const mergeCommit = next
+    if (mergeCommit.sha !== descendant.mergeCommitSha) {
       return remediationInvalid(`remediation ${record.remediationId} descendant ancestry is incomplete or downgraded`)
     }
     const normalDescendantReview = input.normalReviews.get(mergeCommit.sha)
@@ -1357,15 +1374,29 @@ const validateReleaseReviewRemediation = (input: {
       })),
     })
     if (pathsHold !== null) return pathsHold
-    expectedParent = mergeCommit.sha
-    expectedIndex += 1
   }
-  if (
-    introductionIndex !== expectedIndex ||
-    introduction.parents.length !== 1 ||
-    introduction.parents[0] !== expectedParent
-  ) {
+  const next = nextBaynCommit()
+  if (next === null || 'status' in next) {
+    return (
+      next ?? remediationInvalid(`remediation ${record.remediationId} introduction is missing from source ancestry`)
+    )
+  }
+  if (next.sha !== introduction.sha || comparison.commits[cursor - 1]?.sha !== introduction.sha) {
     return remediationInvalid(`remediation ${record.remediationId} is stale or omits a newer source commit`)
+  }
+  while (cursor < comparison.commits.length) {
+    const commit = comparison.commits[cursor]
+    if (commit === undefined || commit.parents.length !== 1 || commit.parents[0] !== expectedParent) {
+      return remediationInvalid(`remediation ${record.remediationId} source ancestry is not a direct-parent chain`)
+    }
+    if (commit.files.some(isBaynReleaseAffectingPath)) {
+      return remediationInvalid(`remediation ${record.remediationId} omits a newer Bayn source commit`)
+    }
+    expectedParent = commit.sha
+    cursor += 1
+  }
+  if (expectedParent !== comparison.headSha) {
+    return remediationInvalid(`remediation ${record.remediationId} does not reach the current source head`)
   }
   return null
 }

--- a/packages/scripts/src/bayn/verify-release-review.ts
+++ b/packages/scripts/src/bayn/verify-release-review.ts
@@ -1,4 +1,6 @@
-import { appendFile } from 'node:fs/promises'
+import { createHash } from 'node:crypto'
+import { appendFile, lstat, readdir, readFile, realpath } from 'node:fs/promises'
+import { resolve } from 'node:path'
 
 const githubApiVersion = '2022-11-28'
 const githubGraphqlUrl = 'https://api.github.com/graphql'
@@ -6,7 +8,10 @@ const maximumGraphqlPages = 20
 const minimumExactReviewAgeMs = 30_000
 const maximumReleaseRangeCommits = 100
 const maximumReleaseReviewJobLogBytes = 1_048_576
+const maximumRemediationRecordBytes = 1_048_576
+const maximumRemediationRecords = 20
 const githubWorkflowFile = 'bayn-build-push.yml'
+const remediationDirectory = 'services/bayn/release-review-remediations'
 
 export const baynCodexReviewer = 'chatgpt-codex-connector'
 export const baynCodexBotLogin = 'chatgpt-codex-connector[bot]'
@@ -36,6 +41,13 @@ export interface PullRequestIssueComment {
 export interface PullRequestReaction {
   readonly userLogin: string | null
   readonly content: string
+  readonly createdAt: string
+}
+
+export interface PullRequestForcePush {
+  readonly actorLogin: string | null
+  readonly beforeCommitSha: string
+  readonly afterCommitSha: string
   readonly createdAt: string
 }
 
@@ -73,6 +85,7 @@ export interface PullRequestReviewState {
   readonly commitShas: readonly string[]
   readonly issueComments: readonly PullRequestIssueComment[]
   readonly reactions: readonly PullRequestReaction[]
+  readonly headForcePushes: readonly PullRequestForcePush[]
   readonly headForcePushCount: number
 }
 
@@ -140,7 +153,80 @@ export interface BaynReleaseRangeCommit {
   readonly sha: string
   readonly parents: readonly string[]
   readonly files: readonly string[]
+  readonly treeSha?: string
+  readonly fileChanges?: readonly BaynReleaseCommitFileChange[]
   readonly reviewSnapshot: BaynReleaseReviewSnapshot | null
+}
+
+export interface BaynReleaseCommitFileChange {
+  readonly path: string
+  readonly previousPath: string | null
+  readonly status: string
+  readonly blobSha: string | null
+}
+
+export interface BaynReleaseReviewRemediationPath {
+  readonly path: string
+  readonly reviewedBlobSha: string
+  readonly finalBlobSha: string
+  readonly blockedBlobSha: string
+}
+
+export interface BaynReleaseReviewRemediationDescendant {
+  readonly mergeCommitSha: string
+  readonly sourcePullRequestNumber: number
+  readonly finalHeadSha: string
+  readonly sourcePullRequestEvidenceSha256: string
+  readonly mergeTreeSha: string
+  readonly finalHeadTreeSha: string
+  readonly affectedPaths: readonly {
+    readonly path: string
+    readonly mergeBlobSha: string
+    readonly finalHeadBlobSha: string
+  }[]
+}
+
+export interface BaynReleaseReviewRemediationRecord {
+  readonly schemaVersion: 'bayn.release-review-remediation.v1'
+  readonly remediationId: string
+  readonly blocked: {
+    readonly mergeCommitSha: string
+    readonly mergeParentSha: string
+    readonly mergeTreeSha: string
+    readonly sourcePullRequestNumber: number
+    readonly reviewedHeadSha: string
+    readonly reviewedHeadTreeSha: string
+    readonly finalHeadSha: string
+    readonly finalHeadTreeSha: string
+    readonly sourcePullRequestEvidenceSha256: string
+    readonly feedback: {
+      readonly threadId: string
+      readonly path: string
+      readonly findingUrl: string
+      readonly findingBodySha256: string
+      readonly fixReplyUrl: string
+      readonly fixReplyBodySha256: string
+    }
+    readonly affectedPaths: readonly BaynReleaseReviewRemediationPath[]
+  }
+  readonly requiredDescendants: readonly BaynReleaseReviewRemediationDescendant[]
+}
+
+interface RemediationCommitObject {
+  readonly sha: string
+  readonly parents: readonly string[]
+  readonly treeSha: string
+  readonly files: readonly string[]
+  readonly fileChanges: readonly BaynReleaseCommitFileChange[]
+  readonly pathBlobs: readonly { readonly path: string; readonly blobSha: string }[]
+}
+
+export interface BaynReleaseReviewRemediationEvidence {
+  readonly recordPath: string
+  readonly recordBlobSha: string
+  readonly record: BaynReleaseReviewRemediationRecord
+  readonly referencedCommits: readonly RemediationCommitObject[]
+  readonly currentPathBlobs: readonly { readonly path: string; readonly blobSha: string }[]
 }
 
 export interface BaynReleaseComparison {
@@ -158,6 +244,7 @@ export interface BaynReleaseEligibilitySnapshot {
   readonly currentCommitParents: readonly string[]
   readonly lastPublishedRevision: LastPublishedRevisionResolution
   readonly comparison: BaynReleaseComparison | null
+  readonly remediations?: readonly BaynReleaseReviewRemediationEvidence[]
 }
 
 export interface BaynReleaseRetrySnapshot extends BaynReleaseEligibilitySnapshot {
@@ -185,6 +272,8 @@ export type BaynReleaseReviewHoldCode =
   | 'exact-head-review-settling'
   | 'feedback-fix-attestation-missing'
   | 'active-unresolved-review-threads'
+  | 'release-review-remediation-invalid'
+  | 'release-review-remediation-missing'
   | 'retry-default-branch-mismatch'
   | 'retry-source-pr-force-pushed'
   | 'retry-failed-run-missing'
@@ -292,6 +381,239 @@ export class GitHubReleaseReviewError extends Error {
 
 const shortSha = (sha: string): string => sha.slice(0, 12)
 
+const sha256Text = (value: string): string => createHash('sha256').update(value).digest('hex')
+
+const gitBlobSha = (bytes: Uint8Array): string =>
+  createHash('sha1').update(`blob ${bytes.byteLength}\0`).update(bytes).digest('hex')
+
+const canonicalJson = (value: unknown): string => {
+  if (value === null || typeof value === 'string' || typeof value === 'boolean') return JSON.stringify(value)
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) throw new TypeError('canonical JSON numbers must be finite')
+    return JSON.stringify(value)
+  }
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(',')}]`
+  if (typeof value !== 'object') throw new TypeError('canonical JSON values must be JSON-compatible')
+  const record = value as Record<string, unknown>
+  return `{${Object.keys(record)
+    .toSorted()
+    .map((key) => `${JSON.stringify(key)}:${canonicalJson(record[key])}`)
+    .join(',')}}`
+}
+
+const normalizePullRequestReviewEvidence = (pullRequest: PullRequestReviewState) => ({
+  number: pullRequest.number,
+  baseRefName: pullRequest.baseRefName,
+  headSha: pullRequest.headSha,
+  mergeCommitSha: pullRequest.mergeCommitSha,
+  createdAt: pullRequest.createdAt,
+  mergedAt: pullRequest.mergedAt,
+  commitShas: [...pullRequest.commitShas],
+  reviews: [...pullRequest.reviews]
+    .map((review) => ({ ...review }))
+    .toSorted((left, right) =>
+      `${left.submittedAt ?? ''}/${left.authorLogin ?? ''}/${left.commitSha ?? ''}/${left.state}`.localeCompare(
+        `${right.submittedAt ?? ''}/${right.authorLogin ?? ''}/${right.commitSha ?? ''}/${right.state}`,
+      ),
+    ),
+  issueComments: [...pullRequest.issueComments]
+    .map((comment) => ({
+      authorLogin: comment.authorLogin,
+      bodySha256: sha256Text(comment.body),
+      createdAt: comment.createdAt,
+      updatedAt: comment.updatedAt,
+    }))
+    .toSorted((left, right) =>
+      `${left.createdAt}/${left.authorLogin ?? ''}/${left.bodySha256}`.localeCompare(
+        `${right.createdAt}/${right.authorLogin ?? ''}/${right.bodySha256}`,
+      ),
+    ),
+  reactions: [...pullRequest.reactions]
+    .map((reaction) => ({ ...reaction }))
+    .toSorted((left, right) =>
+      `${left.createdAt}/${left.userLogin ?? ''}/${left.content}`.localeCompare(
+        `${right.createdAt}/${right.userLogin ?? ''}/${right.content}`,
+      ),
+    ),
+  headForcePushes: [...pullRequest.headForcePushes]
+    .map((forcePush) => ({ ...forcePush }))
+    .toSorted((left, right) =>
+      `${left.createdAt}/${left.beforeCommitSha}/${left.afterCommitSha}/${left.actorLogin ?? ''}`.localeCompare(
+        `${right.createdAt}/${right.beforeCommitSha}/${right.afterCommitSha}/${right.actorLogin ?? ''}`,
+      ),
+    ),
+  threads: [...pullRequest.threads]
+    .map((thread) => ({
+      id: thread.id,
+      isResolved: thread.isResolved,
+      isOutdated: thread.isOutdated,
+      path: thread.path,
+      url: thread.url,
+      comments: [...thread.comments]
+        .map((comment) => ({
+          authorLogin: comment.authorLogin,
+          authorAssociation: comment.authorAssociation,
+          bodySha256: sha256Text(comment.body),
+          createdAt: comment.createdAt,
+          commitSha: comment.commitSha,
+          reviewCommitSha: comment.reviewCommitSha,
+          reviewAuthorLogin: comment.reviewAuthorLogin,
+          reviewSubmittedAt: comment.reviewSubmittedAt,
+          reviewState: comment.reviewState,
+          url: comment.url,
+        }))
+        .toSorted((left, right) => `${left.createdAt}/${left.url}`.localeCompare(`${right.createdAt}/${right.url}`)),
+    }))
+    .toSorted((left, right) => left.id.localeCompare(right.id)),
+})
+
+export const pullRequestReviewEvidenceSha256 = (pullRequest: PullRequestReviewState): string =>
+  sha256Text(canonicalJson(normalizePullRequestReviewEvidence(pullRequest)))
+
+const strictRecord = (value: unknown, keys: readonly string[], context: string): Record<string, unknown> => {
+  const record = expectRecord(value, context)
+  const observed = Object.keys(record).toSorted()
+  const expected = [...keys].toSorted()
+  if (observed.length !== expected.length || observed.some((key, index) => key !== expected[index])) {
+    throw new Error(`${context} must contain exactly: ${expected.join(', ')}`)
+  }
+  return record
+}
+
+const expectSha256 = (value: unknown, context: string): string => {
+  const sha = expectString(value, context)
+  if (!/^[0-9a-f]{64}$/.test(sha)) throw new Error(`${context} must be a lowercase SHA-256`)
+  return sha
+}
+
+const expectPositiveIntegerRecord = (value: unknown, context: string): number => {
+  const parsed = expectInteger(value, context)
+  if (parsed < 1) throw new Error(`${context} must be positive`)
+  return parsed
+}
+
+const parseRemediationPath = (value: unknown, context: string): BaynReleaseReviewRemediationPath => {
+  const record = strictRecord(value, ['path', 'reviewedBlobSha', 'finalBlobSha', 'blockedBlobSha'], context)
+  return {
+    path: expectString(record.path, `${context} path`),
+    reviewedBlobSha: expectSha(record.reviewedBlobSha, `${context} reviewed blob SHA`),
+    finalBlobSha: expectSha(record.finalBlobSha, `${context} final blob SHA`),
+    blockedBlobSha: expectSha(record.blockedBlobSha, `${context} blocked blob SHA`),
+  }
+}
+
+const parseRemediationDescendant = (value: unknown, context: string): BaynReleaseReviewRemediationDescendant => {
+  const record = strictRecord(
+    value,
+    [
+      'mergeCommitSha',
+      'sourcePullRequestNumber',
+      'finalHeadSha',
+      'sourcePullRequestEvidenceSha256',
+      'mergeTreeSha',
+      'finalHeadTreeSha',
+      'affectedPaths',
+    ],
+    context,
+  )
+  if (!Array.isArray(record.affectedPaths)) throw new Error(`${context} affectedPaths must be an array`)
+  const affectedPaths = record.affectedPaths.map((item, index) => {
+    const path = strictRecord(item, ['path', 'mergeBlobSha', 'finalHeadBlobSha'], `${context} affected path ${index}`)
+    return {
+      path: expectString(path.path, `${context} affected path ${index} path`),
+      mergeBlobSha: expectSha(path.mergeBlobSha, `${context} affected path ${index} merge blob SHA`),
+      finalHeadBlobSha: expectSha(path.finalHeadBlobSha, `${context} affected path ${index} final blob SHA`),
+    }
+  })
+  return {
+    mergeCommitSha: expectSha(record.mergeCommitSha, `${context} merge commit SHA`),
+    sourcePullRequestNumber: expectPositiveIntegerRecord(
+      record.sourcePullRequestNumber,
+      `${context} source pull request number`,
+    ),
+    finalHeadSha: expectSha(record.finalHeadSha, `${context} final head SHA`),
+    sourcePullRequestEvidenceSha256: expectSha256(
+      record.sourcePullRequestEvidenceSha256,
+      `${context} source pull request evidence hash`,
+    ),
+    mergeTreeSha: expectSha(record.mergeTreeSha, `${context} merge tree SHA`),
+    finalHeadTreeSha: expectSha(record.finalHeadTreeSha, `${context} final head tree SHA`),
+    affectedPaths,
+  }
+}
+
+export const parseBaynReleaseReviewRemediationRecord = (value: unknown): BaynReleaseReviewRemediationRecord => {
+  const record = strictRecord(
+    value,
+    ['schemaVersion', 'remediationId', 'blocked', 'requiredDescendants'],
+    'remediation',
+  )
+  if (record.schemaVersion !== 'bayn.release-review-remediation.v1') {
+    throw new Error('remediation schemaVersion is invalid')
+  }
+  const remediationId = expectString(record.remediationId, 'remediation ID')
+  if (!/^[a-z0-9][a-z0-9-]{2,127}$/.test(remediationId)) throw new Error('remediation ID is invalid')
+  const blocked = strictRecord(
+    record.blocked,
+    [
+      'mergeCommitSha',
+      'mergeParentSha',
+      'mergeTreeSha',
+      'sourcePullRequestNumber',
+      'reviewedHeadSha',
+      'reviewedHeadTreeSha',
+      'finalHeadSha',
+      'finalHeadTreeSha',
+      'sourcePullRequestEvidenceSha256',
+      'feedback',
+      'affectedPaths',
+    ],
+    'remediation blocked source',
+  )
+  const feedback = strictRecord(
+    blocked.feedback,
+    ['threadId', 'path', 'findingUrl', 'findingBodySha256', 'fixReplyUrl', 'fixReplyBodySha256'],
+    'remediation feedback',
+  )
+  if (!Array.isArray(blocked.affectedPaths)) throw new Error('remediation blocked affectedPaths must be an array')
+  if (!Array.isArray(record.requiredDescendants)) throw new Error('remediation requiredDescendants must be an array')
+  return {
+    schemaVersion: 'bayn.release-review-remediation.v1',
+    remediationId,
+    blocked: {
+      mergeCommitSha: expectSha(blocked.mergeCommitSha, 'remediation blocked merge commit SHA'),
+      mergeParentSha: expectSha(blocked.mergeParentSha, 'remediation blocked merge parent SHA'),
+      mergeTreeSha: expectSha(blocked.mergeTreeSha, 'remediation blocked merge tree SHA'),
+      sourcePullRequestNumber: expectPositiveIntegerRecord(
+        blocked.sourcePullRequestNumber,
+        'remediation blocked source pull request number',
+      ),
+      reviewedHeadSha: expectSha(blocked.reviewedHeadSha, 'remediation reviewed head SHA'),
+      reviewedHeadTreeSha: expectSha(blocked.reviewedHeadTreeSha, 'remediation reviewed head tree SHA'),
+      finalHeadSha: expectSha(blocked.finalHeadSha, 'remediation final head SHA'),
+      finalHeadTreeSha: expectSha(blocked.finalHeadTreeSha, 'remediation final head tree SHA'),
+      sourcePullRequestEvidenceSha256: expectSha256(
+        blocked.sourcePullRequestEvidenceSha256,
+        'remediation source pull request evidence hash',
+      ),
+      feedback: {
+        threadId: expectString(feedback.threadId, 'remediation feedback thread ID'),
+        path: expectString(feedback.path, 'remediation feedback path'),
+        findingUrl: expectString(feedback.findingUrl, 'remediation feedback finding URL'),
+        findingBodySha256: expectSha256(feedback.findingBodySha256, 'remediation feedback finding body hash'),
+        fixReplyUrl: expectString(feedback.fixReplyUrl, 'remediation feedback fix reply URL'),
+        fixReplyBodySha256: expectSha256(feedback.fixReplyBodySha256, 'remediation feedback fix reply body hash'),
+      },
+      affectedPaths: blocked.affectedPaths.map((item, index) =>
+        parseRemediationPath(item, `remediation blocked affected path ${index}`),
+      ),
+    },
+    requiredDescendants: record.requiredDescendants.map((item, index) =>
+      parseRemediationDescendant(item, `remediation descendant ${index}`),
+    ),
+  }
+}
+
 const sourcePullCandidates = (
   pullRequests: readonly AssociatedPullRequest[],
   baseRefName: string,
@@ -359,6 +681,7 @@ const exactBaynReleasePaths = new Set([
 
 export const isBaynReleaseAffectingPath = (path: string): boolean =>
   path.startsWith('services/bayn/') ||
+  path.startsWith(`${remediationDirectory}/`) ||
   path.startsWith('patches/') ||
   path.startsWith('.github/actions/setup-nix-toolchain/') ||
   /^\.github\/workflows\/bayn-[^/]+\.yml$/.test(path) ||
@@ -676,6 +999,359 @@ export const evaluateBaynReleaseReview = (input: {
   }
 }
 
+const sortedUnique = (values: readonly string[]): readonly string[] => [...new Set(values)].toSorted()
+
+const exactStringSet = (left: readonly string[], right: readonly string[]): boolean => {
+  const normalizedLeft = sortedUnique(left)
+  const normalizedRight = sortedUnique(right)
+  return (
+    normalizedLeft.length === left.length &&
+    normalizedRight.length === right.length &&
+    normalizedLeft.length === normalizedRight.length &&
+    normalizedLeft.every((value, index) => value === normalizedRight[index])
+  )
+}
+
+const commitFileMap = (
+  changes: readonly BaynReleaseCommitFileChange[] | undefined,
+): ReadonlyMap<string, BaynReleaseCommitFileChange> | null => {
+  if (changes === undefined) return null
+  const map = new Map<string, BaynReleaseCommitFileChange>()
+  for (const change of changes) {
+    if (map.has(change.path)) return null
+    map.set(change.path, change)
+  }
+  return map
+}
+
+const pathBlobMap = (
+  values: readonly { readonly path: string; readonly blobSha: string }[],
+): ReadonlyMap<string, string> | null => {
+  const map = new Map<string, string>()
+  for (const value of values) {
+    if (map.has(value.path)) return null
+    map.set(value.path, value.blobSha)
+  }
+  return map
+}
+
+const remediationInvalid = (message: string): BaynReleaseReviewHold =>
+  hold('release-review-remediation-invalid', message, false)
+
+const findReferencedCommit = (
+  evidence: BaynReleaseReviewRemediationEvidence,
+  sha: string,
+): RemediationCommitObject | null => {
+  const matches = evidence.referencedCommits.filter((commit) => commit.sha === sha)
+  return matches.length === 1 ? (matches[0] ?? null) : null
+}
+
+const validateRemediationFeedback = (
+  record: BaynReleaseReviewRemediationRecord,
+  pullRequest: PullRequestReviewState,
+): BaynReleaseReviewHold | null => {
+  if (pullRequestReviewEvidenceSha256(pullRequest) !== record.blocked.sourcePullRequestEvidenceSha256) {
+    return remediationInvalid(
+      `remediation ${record.remediationId} source PR #${pullRequest.number} review/reaction/thread evidence changed`,
+    )
+  }
+  if (
+    pullRequest.number !== record.blocked.sourcePullRequestNumber ||
+    pullRequest.headSha !== record.blocked.finalHeadSha ||
+    pullRequest.mergeCommitSha !== record.blocked.mergeCommitSha ||
+    pullRequest.headForcePushCount !== 1 ||
+    pullRequest.headForcePushes.length !== 1
+  ) {
+    return remediationInvalid(`remediation ${record.remediationId} source PR metadata is not exact`)
+  }
+  const forcePush = pullRequest.headForcePushes[0]
+  if (
+    forcePush === undefined ||
+    forcePush.beforeCommitSha !== record.blocked.reviewedHeadSha ||
+    forcePush.afterCommitSha !== record.blocked.finalHeadSha
+  ) {
+    return remediationInvalid(`remediation ${record.remediationId} force-push transformation is not exact`)
+  }
+  const reviewMatches = pullRequest.reviews.filter(
+    (review) =>
+      review.authorLogin === baynCodexReviewer &&
+      review.commitSha === record.blocked.reviewedHeadSha &&
+      review.submittedAt !== null &&
+      eligibleReviewStates.has(review.state),
+  )
+  if (reviewMatches.length !== 1) {
+    return remediationInvalid(`remediation ${record.remediationId} reviewed ancestor evidence is incomplete`)
+  }
+  const thread = pullRequest.threads.find((candidate) => candidate.id === record.blocked.feedback.threadId)
+  if (
+    thread === undefined ||
+    !thread.isResolved ||
+    !thread.isOutdated ||
+    thread.path !== record.blocked.feedback.path
+  ) {
+    return remediationInvalid(`remediation ${record.remediationId} feedback thread is missing or actionable`)
+  }
+  const finding = thread.comments.filter(
+    (comment) =>
+      comment.url === record.blocked.feedback.findingUrl &&
+      sha256Text(comment.body) === record.blocked.feedback.findingBodySha256 &&
+      comment.authorLogin === baynCodexReviewer &&
+      comment.reviewAuthorLogin === baynCodexReviewer &&
+      comment.reviewCommitSha === record.blocked.reviewedHeadSha,
+  )
+  const reply = thread.comments.filter(
+    (comment) =>
+      comment.url === record.blocked.feedback.fixReplyUrl &&
+      sha256Text(comment.body) === record.blocked.feedback.fixReplyBodySha256 &&
+      comment.authorLogin !== null &&
+      comment.authorLogin !== baynCodexReviewer &&
+      trustedFeedbackAssociations.has(comment.authorAssociation) &&
+      comment.commitSha === record.blocked.reviewedHeadSha &&
+      comment.reviewCommitSha === record.blocked.finalHeadSha,
+  )
+  if (finding.length !== 1 || reply.length !== 1) {
+    return remediationInvalid(`remediation ${record.remediationId} exact feedback/fix reply evidence is missing`)
+  }
+  const reactions = pullRequest.reactions.filter(
+    (reaction) => reaction.userLogin === baynCodexBotLogin && reaction.content === '+1',
+  )
+  if (reactions.length !== 1) {
+    return remediationInvalid(`remediation ${record.remediationId} exact final-head reaction evidence is missing`)
+  }
+  return null
+}
+
+const validateRemediationCommitPaths = (input: {
+  readonly remediationId: string
+  readonly mergeCommit: BaynReleaseRangeCommit
+  readonly mergeTreeSha: string
+  readonly mergePathBlobs: readonly { readonly path: string; readonly blobSha: string }[]
+  readonly finalHead: RemediationCommitObject
+  readonly finalHeadSha: string
+  readonly finalHeadTreeSha: string
+  readonly finalHeadPathBlobs: readonly { readonly path: string; readonly blobSha: string }[]
+}): BaynReleaseReviewHold | null => {
+  if (input.mergeCommit.treeSha !== input.mergeTreeSha || input.finalHead.treeSha !== input.finalHeadTreeSha) {
+    return remediationInvalid(`remediation ${input.remediationId} commit tree identity changed`)
+  }
+  if (input.finalHead.sha !== input.finalHeadSha || input.mergeTreeSha !== input.finalHeadTreeSha) {
+    return remediationInvalid(`remediation ${input.remediationId} merge/head tree binding is invalid`)
+  }
+  const changes = commitFileMap(input.mergeCommit.fileChanges)
+  const finalBlobs = pathBlobMap(input.finalHead.pathBlobs)
+  if (changes === null || finalBlobs === null) {
+    return remediationInvalid(`remediation ${input.remediationId} path/blob evidence is ambiguous`)
+  }
+  const expectedPaths = input.mergePathBlobs.map((path) => path.path)
+  if (!exactStringSet([...changes.keys()], expectedPaths)) {
+    return remediationInvalid(`remediation ${input.remediationId} affected path set changed`)
+  }
+  if (
+    !exactStringSet(
+      input.finalHeadPathBlobs.map((path) => path.path),
+      expectedPaths,
+    )
+  ) {
+    return remediationInvalid(`remediation ${input.remediationId} final-head path set is incomplete`)
+  }
+  for (const expected of input.mergePathBlobs) {
+    const change = changes.get(expected.path)
+    const expectedFinal = input.finalHeadPathBlobs.find((path) => path.path === expected.path)
+    if (
+      change === undefined ||
+      change.blobSha !== expected.blobSha ||
+      expectedFinal === undefined ||
+      finalBlobs.get(expected.path) !== expectedFinal.blobSha
+    ) {
+      return remediationInvalid(`remediation ${input.remediationId} blob identity changed at ${expected.path}`)
+    }
+  }
+  return null
+}
+
+const validateReleaseReviewRemediation = (input: {
+  readonly evidence: BaynReleaseReviewRemediationEvidence
+  readonly blockedCommit: BaynReleaseRangeCommit
+  readonly comparison: BaynReleaseComparison
+  readonly normalReviews: ReadonlyMap<string, BaynReleaseReviewEvaluation>
+}): BaynReleaseReviewHold | null => {
+  const { evidence, blockedCommit, comparison } = input
+  const record = evidence.record
+  const expectedRecordPath = `${remediationDirectory}/${record.blocked.mergeCommitSha}.json`
+  if (evidence.recordPath !== expectedRecordPath) {
+    return remediationInvalid(`remediation ${record.remediationId} record path is not canonical`)
+  }
+  const matchingIntroductionCommits = comparison.commits.filter((commit) =>
+    commit.fileChanges?.some((change) => change.path === evidence.recordPath),
+  )
+  if (matchingIntroductionCommits.length !== 1) {
+    return remediationInvalid(`remediation ${record.remediationId} record was not added exactly once`)
+  }
+  const introduction = matchingIntroductionCommits[0]
+  if (introduction === undefined)
+    return remediationInvalid(`remediation ${record.remediationId} introduction is missing`)
+  const introductionChange = introduction.fileChanges?.find((change) => change.path === evidence.recordPath)
+  if (
+    introductionChange === undefined ||
+    introductionChange.status !== 'added' ||
+    introductionChange.blobSha !== evidence.recordBlobSha
+  ) {
+    return remediationInvalid(`remediation ${record.remediationId} record blob/introduction changed`)
+  }
+  const introductionReview = input.normalReviews.get(introduction.sha)
+  if (introductionReview?.status !== 'eligible') {
+    return remediationInvalid(`remediation ${record.remediationId} introducing commit lacks exact-head review`)
+  }
+  const blockedIndex = comparison.commits.findIndex((commit) => commit.sha === blockedCommit.sha)
+  const introductionIndex = comparison.commits.findIndex((commit) => commit.sha === introduction.sha)
+  if (
+    blockedIndex < 0 ||
+    introductionIndex <= blockedIndex ||
+    record.blocked.mergeCommitSha !== blockedCommit.sha ||
+    record.blocked.mergeParentSha !== blockedCommit.parents[0] ||
+    blockedCommit.parents.length !== 1 ||
+    blockedCommit.treeSha !== record.blocked.mergeTreeSha
+  ) {
+    return remediationInvalid(`remediation ${record.remediationId} blocked merge ancestry is invalid`)
+  }
+  const blockedPull = blockedCommit.reviewSnapshot?.pullRequest
+  if (blockedPull === null || blockedPull === undefined) {
+    return remediationInvalid(`remediation ${record.remediationId} blocked source PR snapshot is missing`)
+  }
+  const feedbackHold = validateRemediationFeedback(record, blockedPull)
+  if (feedbackHold !== null) return feedbackHold
+
+  const reviewedHead = findReferencedCommit(evidence, record.blocked.reviewedHeadSha)
+  const finalHead = findReferencedCommit(evidence, record.blocked.finalHeadSha)
+  if (reviewedHead === null || finalHead === null) {
+    return remediationInvalid(`remediation ${record.remediationId} reviewed/final commit evidence is incomplete`)
+  }
+  if (
+    reviewedHead.parents.length !== 1 ||
+    finalHead.parents.length !== 1 ||
+    reviewedHead.parents[0] !== record.blocked.mergeParentSha ||
+    finalHead.parents[0] !== record.blocked.mergeParentSha ||
+    reviewedHead.treeSha !== record.blocked.reviewedHeadTreeSha ||
+    finalHead.treeSha !== record.blocked.finalHeadTreeSha ||
+    blockedCommit.treeSha !== finalHead.treeSha
+  ) {
+    return remediationInvalid(`remediation ${record.remediationId} reconstructed head/tree ancestry changed`)
+  }
+  const reviewedChanges = commitFileMap(reviewedHead.fileChanges)
+  const finalChanges = commitFileMap(finalHead.fileChanges)
+  const reviewedBlobs = pathBlobMap(reviewedHead.pathBlobs)
+  const finalBlobs = pathBlobMap(finalHead.pathBlobs)
+  const currentBlobs = pathBlobMap(evidence.currentPathBlobs)
+  const affectedPaths = record.blocked.affectedPaths.map((path) => path.path)
+  if (
+    reviewedChanges === null ||
+    finalChanges === null ||
+    reviewedBlobs === null ||
+    finalBlobs === null ||
+    currentBlobs === null ||
+    !exactStringSet([...reviewedChanges.keys()], affectedPaths) ||
+    !exactStringSet([...finalChanges.keys()], affectedPaths) ||
+    !exactStringSet([...currentBlobs.keys()], affectedPaths) ||
+    !exactStringSet(blockedCommit.files, affectedPaths)
+  ) {
+    return remediationInvalid(`remediation ${record.remediationId} transformation path set changed`)
+  }
+  const blockedChanges = commitFileMap(blockedCommit.fileChanges)
+  if (blockedChanges === null)
+    return remediationInvalid(`remediation ${record.remediationId} blocked blobs are missing`)
+  for (const path of record.blocked.affectedPaths) {
+    if (
+      reviewedBlobs.get(path.path) !== path.reviewedBlobSha ||
+      finalBlobs.get(path.path) !== path.finalBlobSha ||
+      blockedChanges.get(path.path)?.blobSha !== path.blockedBlobSha ||
+      path.finalBlobSha !== path.blockedBlobSha ||
+      currentBlobs.get(path.path) !== path.finalBlobSha
+    ) {
+      return remediationInvalid(`remediation ${record.remediationId} transformation blob changed at ${path.path}`)
+    }
+  }
+  const laterMutations = comparison.commits
+    .slice(blockedIndex + 1)
+    .filter((commit) => commit.sha !== introduction.sha)
+    .flatMap((commit) => commit.files.filter((path) => affectedPaths.includes(path)))
+  if (laterMutations.length > 0) {
+    return remediationInvalid(
+      `remediation ${record.remediationId} affected source paths changed after the blocked merge`,
+    )
+  }
+
+  let expectedParent = blockedCommit.sha
+  let expectedIndex = blockedIndex + 1
+  for (const descendant of record.requiredDescendants) {
+    const mergeCommit = comparison.commits[expectedIndex]
+    if (
+      mergeCommit === undefined ||
+      mergeCommit.sha !== descendant.mergeCommitSha ||
+      mergeCommit.parents.length !== 1 ||
+      mergeCommit.parents[0] !== expectedParent
+    ) {
+      return remediationInvalid(`remediation ${record.remediationId} descendant ancestry is incomplete or downgraded`)
+    }
+    const descendantPull = mergeCommit.reviewSnapshot?.pullRequest
+    const descendantReactions = descendantPull?.reactions.filter(
+      (reaction) => reaction.userLogin === baynCodexBotLogin && reaction.content === '+1',
+    )
+    const latestForcePush = descendantPull?.headForcePushes.toSorted((left, right) =>
+      right.createdAt.localeCompare(left.createdAt),
+    )[0]
+    if (
+      descendantPull === null ||
+      descendantPull === undefined ||
+      descendantPull.number !== descendant.sourcePullRequestNumber ||
+      descendantPull.headSha !== descendant.finalHeadSha ||
+      descendantPull.mergeCommitSha !== descendant.mergeCommitSha ||
+      pullRequestReviewEvidenceSha256(descendantPull) !== descendant.sourcePullRequestEvidenceSha256 ||
+      descendantPull.threads.some((thread) => !thread.isResolved) ||
+      !descendantPull.reviews.some(
+        (review) =>
+          review.authorLogin === baynCodexReviewer &&
+          review.commitSha !== null &&
+          review.submittedAt !== null &&
+          eligibleReviewStates.has(review.state),
+      ) ||
+      descendantPull.headForcePushCount !== descendantPull.headForcePushes.length ||
+      (latestForcePush !== undefined && latestForcePush.afterCommitSha !== descendantPull.headSha) ||
+      descendantReactions?.length !== 1 ||
+      (latestForcePush !== undefined && (descendantReactions[0]?.createdAt ?? '') <= latestForcePush.createdAt)
+    ) {
+      return remediationInvalid(`remediation ${record.remediationId} descendant review chain is incomplete`)
+    }
+    const finalDescendantHead = findReferencedCommit(evidence, descendant.finalHeadSha)
+    if (finalDescendantHead === null) {
+      return remediationInvalid(`remediation ${record.remediationId} descendant head evidence is missing`)
+    }
+    const pathsHold = validateRemediationCommitPaths({
+      remediationId: record.remediationId,
+      mergeCommit,
+      mergeTreeSha: descendant.mergeTreeSha,
+      mergePathBlobs: descendant.affectedPaths.map((path) => ({ path: path.path, blobSha: path.mergeBlobSha })),
+      finalHead: finalDescendantHead,
+      finalHeadSha: descendant.finalHeadSha,
+      finalHeadTreeSha: descendant.finalHeadTreeSha,
+      finalHeadPathBlobs: descendant.affectedPaths.map((path) => ({
+        path: path.path,
+        blobSha: path.finalHeadBlobSha,
+      })),
+    })
+    if (pathsHold !== null) return pathsHold
+    expectedParent = mergeCommit.sha
+    expectedIndex += 1
+  }
+  if (
+    introductionIndex !== expectedIndex ||
+    introduction.parents.length !== 1 ||
+    introduction.parents[0] !== expectedParent
+  ) {
+    return remediationInvalid(`remediation ${record.remediationId} is stale or omits a newer source commit`)
+  }
+  return null
+}
+
 export const evaluateBaynReleaseEligibility = (input: {
   readonly mainCommitSha: string
   readonly baseRefName: string
@@ -784,7 +1460,7 @@ export const evaluateBaynReleaseEligibility = (input: {
     )
   }
 
-  const reviewedPullRequests: BaynReleaseEligibilityEligible['reviewedPullRequests'][number][] = []
+  const normalReviews = new Map<string, BaynReleaseReviewEvaluation>()
   for (const commit of affectingCommits) {
     if (commit.reviewSnapshot === null) {
       return hold(
@@ -800,11 +1476,122 @@ export const evaluateBaynReleaseEligibility = (input: {
       nowMs: input.nowMs,
       pushBeforeSha: null,
     })
+    normalReviews.set(commit.sha, review)
+  }
+
+  const remediations = input.snapshot.remediations ?? []
+  const remediationIds = remediations.map((remediation) => remediation.record.remediationId)
+  const blockedRemediationShas = remediations.map((remediation) => remediation.record.blocked.mergeCommitSha)
+  const recordPaths = remediations.map((remediation) => remediation.recordPath)
+  if (
+    new Set(remediationIds).size !== remediationIds.length ||
+    new Set(blockedRemediationShas).size !== blockedRemediationShas.length ||
+    new Set(recordPaths).size !== recordPaths.length
+  ) {
+    return remediationInvalid('release review remediations contain duplicate identities or blocked commits')
+  }
+
+  const usedRemediationIds = new Set<string>()
+  const coveredDescendantShas = new Set<string>()
+  const reviewedPullRequests: BaynReleaseEligibilityEligible['reviewedPullRequests'][number][] = []
+  for (const commit of affectingCommits) {
+    const review = normalReviews.get(commit.sha)
+    if (review === undefined) throw new Error(`missing normal review evaluation for ${commit.sha}`)
     if (review.status === 'hold') {
-      return {
-        ...review,
-        message: `Bayn-affecting commit ${shortSha(commit.sha)} after last published ${shortSha(published.revision)} is not release-eligible: ${review.message}`,
+      if (coveredDescendantShas.has(commit.sha)) {
+        const sourcePull = commit.reviewSnapshot?.pullRequest
+        const reviewedAncestor = sourcePull?.reviews
+          .filter(
+            (candidate) =>
+              candidate.authorLogin === baynCodexReviewer &&
+              candidate.commitSha !== null &&
+              candidate.submittedAt !== null &&
+              eligibleReviewStates.has(candidate.state),
+          )
+          .toSorted((left, right) => (right.submittedAt as string).localeCompare(left.submittedAt as string))[0]
+        if (
+          sourcePull === null ||
+          sourcePull === undefined ||
+          reviewedAncestor?.submittedAt === null ||
+          reviewedAncestor?.submittedAt === undefined
+        ) {
+          return remediationInvalid(`covered descendant ${shortSha(commit.sha)} review evidence is incomplete`)
+        }
+        reviewedPullRequests.push({
+          commitSha: commit.sha,
+          prNumber: sourcePull.number,
+          headSha: sourcePull.headSha,
+          reviewSubmittedAt: reviewedAncestor.submittedAt,
+          eligibleAt: reviewedAncestor.submittedAt,
+        })
+        continue
       }
+      if (review.code !== 'exact-head-review-missing') {
+        return {
+          ...review,
+          message: `Bayn-affecting commit ${shortSha(commit.sha)} after last published ${shortSha(published.revision)} is not release-eligible: ${review.message}`,
+        }
+      }
+      const remediation = remediations.filter((candidate) => candidate.record.blocked.mergeCommitSha === commit.sha)
+      if (remediation.length === 0) {
+        const sourcePull = commit.reviewSnapshot?.pullRequest
+        const reviewedAncestorDropped =
+          sourcePull !== null &&
+          sourcePull !== undefined &&
+          sourcePull.headForcePushCount > 0 &&
+          sourcePull.reviews.some(
+            (candidate) =>
+              candidate.authorLogin === baynCodexReviewer &&
+              candidate.commitSha !== null &&
+              !sourcePull.commitShas.includes(candidate.commitSha),
+          )
+        if (reviewedAncestorDropped) {
+          return hold(
+            'release-review-remediation-missing',
+            `Bayn-affecting commit ${shortSha(commit.sha)} after last published ${shortSha(published.revision)} dropped its reviewed ancestor and has no reviewed remediation receipt`,
+            false,
+          )
+        }
+        return {
+          ...review,
+          message: `Bayn-affecting commit ${shortSha(commit.sha)} after last published ${shortSha(published.revision)} is not release-eligible: ${review.message}`,
+        }
+      }
+      if (remediation.length !== 1 || remediation[0] === undefined) {
+        return remediationInvalid(`Bayn-affecting commit ${shortSha(commit.sha)} has ambiguous remediation receipts`)
+      }
+      const remediationHold = validateReleaseReviewRemediation({
+        evidence: remediation[0],
+        blockedCommit: commit,
+        comparison,
+        normalReviews,
+      })
+      if (remediationHold !== null) return remediationHold
+      usedRemediationIds.add(remediation[0].record.remediationId)
+      for (const descendant of remediation[0].record.requiredDescendants) {
+        coveredDescendantShas.add(descendant.mergeCommitSha)
+      }
+      const sourcePull = commit.reviewSnapshot?.pullRequest
+      if (sourcePull === null || sourcePull === undefined) {
+        return remediationInvalid(`remediated commit ${shortSha(commit.sha)} source PR metadata is missing`)
+      }
+      const reviewedAncestor = sourcePull.reviews.find(
+        (candidate) =>
+          candidate.authorLogin === baynCodexReviewer &&
+          candidate.commitSha === remediation[0]?.record.blocked.reviewedHeadSha &&
+          candidate.submittedAt !== null,
+      )
+      if (reviewedAncestor?.submittedAt === null || reviewedAncestor?.submittedAt === undefined) {
+        return remediationInvalid(`remediated commit ${shortSha(commit.sha)} reviewed ancestor timestamp is missing`)
+      }
+      reviewedPullRequests.push({
+        commitSha: commit.sha,
+        prNumber: sourcePull.number,
+        headSha: sourcePull.headSha,
+        reviewSubmittedAt: reviewedAncestor.submittedAt,
+        eligibleAt: reviewedAncestor.submittedAt,
+      })
+      continue
     }
     reviewedPullRequests.push({
       commitSha: commit.sha,
@@ -813,6 +1600,9 @@ export const evaluateBaynReleaseEligibility = (input: {
       reviewSubmittedAt: review.reviewSubmittedAt,
       eligibleAt: review.eligibleAt,
     })
+  }
+  if (usedRemediationIds.size !== remediations.length) {
+    return remediationInvalid('release review range contains unused, stale, or cyclic remediation receipts')
   }
 
   return {
@@ -1536,7 +2326,9 @@ const parseComparison = (value: unknown): ParsedComparison => {
 interface CommitDetail {
   readonly sha: string
   readonly parents: readonly string[]
+  readonly treeSha: string
   readonly files: readonly string[]
+  readonly fileChanges: readonly BaynReleaseCommitFileChange[]
 }
 
 const parseCommitDetail = (value: unknown, expectedSha: string): CommitDetail => {
@@ -1548,21 +2340,39 @@ const parseCommitDetail = (value: unknown, expectedSha: string): CommitDetail =>
   if (!Array.isArray(commit.parents) || !Array.isArray(commit.files)) {
     throw new GitHubReleaseReviewError('github-api-invalid-response', `read commit ${shortSha(expectedSha)} detail`)
   }
+  const commitMetadata =
+    commit.commit === undefined ? null : expectRecord(commit.commit, `commit ${shortSha(expectedSha)} metadata`)
+  const tree =
+    commitMetadata === null || commitMetadata.tree === undefined
+      ? null
+      : expectRecord(commitMetadata.tree, `commit ${shortSha(expectedSha)} tree`)
+  const fileChanges = commit.files.map((item, index): BaynReleaseCommitFileChange => {
+    const file = expectRecord(item, `commit ${shortSha(expectedSha)} file ${index}`)
+    return {
+      path: expectString(file.filename, `commit ${shortSha(expectedSha)} file ${index} path`),
+      previousPath:
+        file.previous_filename === undefined
+          ? null
+          : expectString(file.previous_filename, `commit ${shortSha(expectedSha)} file ${index} previous path`),
+      status:
+        file.status === undefined
+          ? 'unknown'
+          : expectString(file.status, `commit ${shortSha(expectedSha)} file ${index} status`),
+      blobSha:
+        file.sha === undefined || file.sha === null
+          ? null
+          : expectSha(file.sha, `commit ${shortSha(expectedSha)} file ${index} blob SHA`),
+    }
+  })
   return {
     sha,
+    treeSha: tree === null ? '' : expectSha(tree.sha, `commit ${shortSha(expectedSha)} tree SHA`),
     parents: commit.parents.map((item, index) => {
       const parent = expectRecord(item, `commit ${shortSha(expectedSha)} parent ${index}`)
       return expectSha(parent.sha, `commit ${shortSha(expectedSha)} parent ${index} SHA`)
     }),
-    files: commit.files.flatMap((item, index) => {
-      const file = expectRecord(item, `commit ${shortSha(expectedSha)} file ${index}`)
-      const filename = expectString(file.filename, `commit ${shortSha(expectedSha)} file ${index} path`)
-      if (file.previous_filename === undefined) return [filename]
-      return [
-        filename,
-        expectString(file.previous_filename, `commit ${shortSha(expectedSha)} file ${index} previous path`),
-      ]
-    }),
+    files: fileChanges.flatMap((file) => (file.previousPath === null ? [file.path] : [file.path, file.previousPath])),
+    fileChanges,
   }
 }
 
@@ -1597,7 +2407,15 @@ const pullRequestMetadataQuery = `
         mergedAt
         mergeCommit { oid }
         timelineItems(first: 100, itemTypes: [HEAD_REF_FORCE_PUSHED_EVENT]) {
-          nodes { __typename }
+          nodes {
+            __typename
+            ... on HeadRefForcePushedEvent {
+              createdAt
+              actor { login }
+              beforeCommit { oid }
+              afterCommit { oid }
+            }
+          }
           pageInfo { hasNextPage endCursor }
         }
       }
@@ -1706,12 +2524,21 @@ const fetchPullRequestMetadata = async (options: GitHubLoaderOptions, pullNumber
   if (timelinePageInfo.hasNextPage) {
     throw new GitHubReleaseReviewError('github-api-pagination-limit', 'source PR head-force-push history')
   }
-  for (const [index, item] of timelineItems.nodes.entries()) {
+  const headForcePushes = timelineItems.nodes.map((item, index): PullRequestForcePush => {
     const event = expectRecord(item, `source PR head-force-push event ${index}`)
     if (event.__typename !== 'HeadRefForcePushedEvent') {
       throw new GitHubReleaseReviewError('github-api-invalid-response', `source PR head-force-push event ${index}`)
     }
-  }
+    const actor = event.actor === null ? null : expectRecord(event.actor, `source PR force-push actor ${index}`)
+    const beforeCommit = expectRecord(event.beforeCommit, `source PR force-push before commit ${index}`)
+    const afterCommit = expectRecord(event.afterCommit, `source PR force-push after commit ${index}`)
+    return {
+      actorLogin: actor === null ? null : expectString(actor.login, `source PR force-push actor login ${index}`),
+      beforeCommitSha: expectSha(beforeCommit.oid, `source PR force-push before SHA ${index}`),
+      afterCommitSha: expectSha(afterCommit.oid, `source PR force-push after SHA ${index}`),
+      createdAt: expectString(event.createdAt, `source PR force-push created at ${index}`),
+    }
+  })
   return {
     number: expectInteger(pullRequest.number, 'source PR number'),
     baseRefName: expectString(pullRequest.baseRefName, 'source PR base ref'),
@@ -1719,7 +2546,8 @@ const fetchPullRequestMetadata = async (options: GitHubLoaderOptions, pullNumber
     createdAt: expectString(pullRequest.createdAt, 'source PR created at'),
     mergedAt: expectNullableString(pullRequest.mergedAt, 'source PR merged at'),
     mergeCommitSha: mergeCommit === null ? null : expectString(mergeCommit.oid, 'source PR merge commit SHA'),
-    headForcePushCount: timelineItems.nodes.length,
+    headForcePushes,
+    headForcePushCount: headForcePushes.length,
   }
 }
 
@@ -1942,6 +2770,7 @@ interface GitHubLoaderOptions {
   readonly baseRefName: string
   readonly requestTimeoutMs: number
   readonly fetchFn: typeof fetch
+  readonly repositoryRoot: string
 }
 
 const fetchCommitDetail = async (options: GitHubLoaderOptions, commitSha: string): Promise<CommitDetail> => {
@@ -1957,6 +2786,118 @@ const fetchCommitDetail = async (options: GitHubLoaderOptions, commitSha: string
     throw new GitHubReleaseReviewError('github-api-pagination-limit', `${operation} files`)
   }
   return parseCommitDetail(response.value, commitSha)
+}
+
+const fetchPathBlobSha = async (options: GitHubLoaderOptions, commitSha: string, path: string): Promise<string> => {
+  const operation = `read ${path} blob at ${shortSha(commitSha)}`
+  const response = await requestGitHubJson({
+    url: `https://api.github.com/repos/${encodeURIComponent(options.owner)}/${encodeURIComponent(options.name)}/contents/${path
+      .split('/')
+      .map(encodeURIComponent)
+      .join('/')}?ref=${encodeURIComponent(commitSha)}`,
+    operation,
+    token: options.token,
+    requestTimeoutMs: options.requestTimeoutMs,
+    fetchFn: options.fetchFn,
+  })
+  const content = expectRecord(response.value, operation)
+  if (content.type !== 'file' || expectString(content.path, `${operation} path`) !== path) {
+    throw new GitHubReleaseReviewError('github-api-invalid-response', operation)
+  }
+  return expectSha(content.sha, `${operation} SHA`)
+}
+
+const loadLocalRemediationRecords = async (
+  repositoryRoot: string,
+): Promise<
+  readonly { readonly path: string; readonly blobSha: string; readonly record: BaynReleaseReviewRemediationRecord }[]
+> => {
+  const root = await realpath(repositoryRoot)
+  const directory = resolve(root, remediationDirectory)
+  let entries
+  try {
+    entries = await readdir(directory, { withFileTypes: true })
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return []
+    throw error
+  }
+  if (entries.length > maximumRemediationRecords) {
+    throw new Error(`release review remediation count exceeds ${maximumRemediationRecords}`)
+  }
+  const records = []
+  for (const entry of entries.toSorted((left, right) => left.name.localeCompare(right.name))) {
+    if (!entry.isFile() || !/^[0-9a-f]{40}\.json$/.test(entry.name)) {
+      throw new Error(`unexpected release review remediation entry ${entry.name}`)
+    }
+    const path = `${remediationDirectory}/${entry.name}`
+    const absolutePath = resolve(root, path)
+    const metadata = await lstat(absolutePath)
+    if (!metadata.isFile() || metadata.isSymbolicLink() || metadata.size > maximumRemediationRecordBytes) {
+      throw new Error(`release review remediation ${path} is not a bounded regular file`)
+    }
+    const bytes = await readFile(absolutePath)
+    const record = parseBaynReleaseReviewRemediationRecord(JSON.parse(bytes.toString('utf8')) as unknown)
+    if (entry.name !== `${record.blocked.mergeCommitSha}.json`) {
+      throw new Error(`release review remediation ${path} does not match its blocked commit`)
+    }
+    records.push({ path, blobSha: gitBlobSha(bytes), record })
+  }
+  return records
+}
+
+const loadReleaseReviewRemediations = async (
+  options: GitHubLoaderOptions,
+  rangeCommitShas: ReadonlySet<string>,
+): Promise<readonly BaynReleaseReviewRemediationEvidence[]> => {
+  const records = (await loadLocalRemediationRecords(options.repositoryRoot)).filter((loaded) =>
+    rangeCommitShas.has(loaded.record.blocked.mergeCommitSha),
+  )
+  return mapWithConcurrency(records, 2, async (loaded) => {
+    const currentRecordBlob = await fetchPathBlobSha(options, options.mainCommitSha, loaded.path)
+    if (currentRecordBlob !== loaded.blobSha) {
+      throw new GitHubReleaseReviewError(
+        'github-api-invalid-response',
+        `bind remediation ${loaded.path} to current main`,
+      )
+    }
+    const references = new Map<string, readonly string[]>()
+    references.set(
+      loaded.record.blocked.reviewedHeadSha,
+      loaded.record.blocked.affectedPaths.map((path) => path.path),
+    )
+    references.set(
+      loaded.record.blocked.finalHeadSha,
+      loaded.record.blocked.affectedPaths.map((path) => path.path),
+    )
+    for (const descendant of loaded.record.requiredDescendants) {
+      references.set(
+        descendant.finalHeadSha,
+        descendant.affectedPaths.map((path) => path.path),
+      )
+    }
+    const referencedCommits = await mapWithConcurrency([...references.entries()], 3, async ([sha, paths]) => {
+      const [commit, pathBlobs] = await Promise.all([
+        fetchCommitDetail(options, sha),
+        mapWithConcurrency(paths, 4, async (path) => ({
+          path,
+          blobSha: await fetchPathBlobSha(options, sha, path),
+        })),
+      ])
+      return { ...commit, pathBlobs }
+    })
+    const currentPathBlobs = await mapWithConcurrency(
+      loaded.record.blocked.affectedPaths.map((path) => path.path),
+      4,
+      async (path) => ({ path, blobSha: await fetchPathBlobSha(options, options.mainCommitSha, path) }),
+    )
+    return {
+      recordPath: loaded.path,
+      recordBlobSha: loaded.blobSha,
+      record: loaded.record,
+      referencedCommits,
+      currentPathBlobs,
+    }
+  })
 }
 
 const loadCommitReviewSnapshot = async (
@@ -2007,6 +2948,7 @@ export const createGitHubReleaseReviewLoader = (options: {
   readonly mainCommitSha: string
   readonly baseRefName: string
   readonly requestTimeoutMs: number
+  readonly repositoryRoot?: string
   readonly fetchFn?: typeof fetch
 }): (() => Promise<BaynReleaseReviewSnapshot>) => {
   const [owner, name, extra] = options.repository.split('/')
@@ -2021,6 +2963,7 @@ export const createGitHubReleaseReviewLoader = (options: {
     baseRefName: options.baseRefName,
     requestTimeoutMs: options.requestTimeoutMs,
     fetchFn: options.fetchFn ?? fetch,
+    repositoryRoot: options.repositoryRoot ?? process.cwd(),
   }
 
   return () => loadCommitReviewSnapshot(loaderOptions, loaderOptions.mainCommitSha)
@@ -2118,6 +3061,7 @@ export const createGitHubReleaseEligibilityLoader = (options: {
   readonly mainCommitSha: string
   readonly baseRefName: string
   readonly requestTimeoutMs: number
+  readonly repositoryRoot?: string
   readonly fetchFn?: typeof fetch
 }): (() => Promise<BaynReleaseEligibilitySnapshot>) => {
   const [owner, name, extra] = options.repository.split('/')
@@ -2132,6 +3076,7 @@ export const createGitHubReleaseEligibilityLoader = (options: {
     baseRefName: options.baseRefName,
     requestTimeoutMs: options.requestTimeoutMs,
     fetchFn: options.fetchFn ?? fetch,
+    repositoryRoot: options.repositoryRoot ?? process.cwd(),
   }
   let staticContext: StaticReleaseEligibilityContext | null = null
 
@@ -2146,16 +3091,23 @@ export const createGitHubReleaseEligibilityLoader = (options: {
       }
     }
 
-    const commits = await mapWithConcurrency(loadedContext.comparison.commits, 3, async (commit) => ({
-      ...commit,
-      reviewSnapshot: commit.files.some(isBaynReleaseAffectingPath)
-        ? await loadCommitReviewSnapshot(loaderOptions, commit.sha, commit)
-        : null,
-    }))
+    const [commits, remediations] = await Promise.all([
+      mapWithConcurrency(loadedContext.comparison.commits, 3, async (commit) => ({
+        ...commit,
+        reviewSnapshot: commit.files.some(isBaynReleaseAffectingPath)
+          ? await loadCommitReviewSnapshot(loaderOptions, commit.sha, commit)
+          : null,
+      })),
+      loadReleaseReviewRemediations(
+        loaderOptions,
+        new Set(loadedContext.comparison.commits.map((commit) => commit.sha)),
+      ),
+    ])
     return {
       currentCommitParents: loadedContext.currentCommit.parents,
       lastPublishedRevision: loadedContext.lastPublishedRevision,
       comparison: { ...loadedContext.comparison, commits },
+      remediations,
     }
   }
 }
@@ -2256,6 +3208,7 @@ export const createGitHubReleaseRetryLoader = (options: {
   readonly mainCommitSha: string
   readonly baseRefName: string
   readonly requestTimeoutMs: number
+  readonly repositoryRoot?: string
   readonly fetchFn?: typeof fetch
 }): (() => Promise<BaynReleaseRetrySnapshot>) => {
   const [owner, name, extra] = options.repository.split('/')
@@ -2270,6 +3223,7 @@ export const createGitHubReleaseRetryLoader = (options: {
     baseRefName: options.baseRefName,
     requestTimeoutMs: options.requestTimeoutMs,
     fetchFn: options.fetchFn ?? fetch,
+    repositoryRoot: options.repositoryRoot ?? process.cwd(),
   }
   const loadEligibility = createGitHubReleaseEligibilityLoader(options)
 
@@ -2309,6 +3263,7 @@ export const createGitHubReleaseRetryLoader = (options: {
 interface CliOptions {
   readonly mode: 'push' | 'retry-discovery' | 'retry-publication'
   readonly repository: string
+  readonly repositoryRoot: string
   readonly mainCommitSha: string
   readonly maxAttempts: number
   readonly pollIntervalMs: number
@@ -2350,6 +3305,7 @@ export const parseVerifyReleaseReviewArguments = (
   const allowed = new Set([
     '--mode',
     '--repository',
+    '--repository-root',
     '--commit',
     '--push-before',
     '--max-attempts',
@@ -2369,6 +3325,7 @@ export const parseVerifyReleaseReviewArguments = (
   }
 
   const repository = values.get('--repository') ?? environment.GITHUB_REPOSITORY
+  const repositoryRoot = values.get('--repository-root') ?? environment.GITHUB_WORKSPACE ?? process.cwd()
   const mainCommitSha = values.get('--commit') ?? environment.GITHUB_SHA
   const pushBeforeSha = values.get('--push-before') ?? null
   const modeValue = values.get('--mode') ?? 'push'
@@ -2390,6 +3347,7 @@ export const parseVerifyReleaseReviewArguments = (
   return {
     mode: modeValue,
     repository,
+    repositoryRoot,
     mainCommitSha,
     pushBeforeSha,
     maxAttempts: parsePositiveInteger(values.get('--max-attempts') ?? '10', '--max-attempts'),
@@ -2471,6 +3429,7 @@ const run = async (): Promise<void> => {
         mainCommitSha: options.mainCommitSha,
         baseRefName: 'main',
         requestTimeoutMs: options.requestTimeoutMs,
+        repositoryRoot: options.repositoryRoot,
       }),
     })
     if (result.status === 'hold') {
@@ -2494,6 +3453,7 @@ const run = async (): Promise<void> => {
       mainCommitSha: options.mainCommitSha,
       baseRefName: 'main',
       requestTimeoutMs: options.requestTimeoutMs,
+      repositoryRoot: options.repositoryRoot,
     })(),
     trigger: retryTriggerFromOptions(options),
     nowMs: Date.now(),

--- a/services/bayn/release-review-remediations/890d8f5801cf7c7576ed7a0cee387a4e79b98877.json
+++ b/services/bayn/release-review-remediations/890d8f5801cf7c7576ed7a0cee387a4e79b98877.json
@@ -1,0 +1,129 @@
+{
+  "schemaVersion": "bayn.release-review-remediation.v1",
+  "remediationId": "pr-13428-reviewed-ancestor-reconstruction",
+  "blocked": {
+    "mergeCommitSha": "890d8f5801cf7c7576ed7a0cee387a4e79b98877",
+    "mergeParentSha": "e0a38e65e7ba65fb7d00585b02d9fc2cdbeee826",
+    "mergeTreeSha": "f952421bcffb499d62fd9f4c436d04ac68fbd398",
+    "sourcePullRequestNumber": 13428,
+    "reviewedHeadSha": "8ef6b67fe799c0dddd70bc70f4648a3b23a7ca5b",
+    "reviewedHeadTreeSha": "9bf02129bb8b4b896b3b86c7c79892ef90a37f16",
+    "finalHeadSha": "d9903bf860ede2622ab77a9eac8e3a9454586955",
+    "finalHeadTreeSha": "f952421bcffb499d62fd9f4c436d04ac68fbd398",
+    "sourcePullRequestEvidenceSha256": "a99e94c869ee29df706221d21abfe734b20c9ae460705c7c4c3a58680a92f584",
+    "feedback": {
+      "threadId": "PRRT_kwDOLkRLus6VZVPy",
+      "path": "services/bayn/candidates/ordinal-17-volatility-managed-trend-overlay-preregistration.json",
+      "findingUrl": "https://github.com/proompteng/lab/pull/13428#discussion_r3689961132",
+      "findingBodySha256": "01b8065d9c0e4c2e98519b1d9e6568e1d9eb15cbd7370fedf72bae717996d655",
+      "fixReplyUrl": "https://github.com/proompteng/lab/pull/13428#discussion_r3690008122",
+      "fixReplyBodySha256": "f640af6adb0d7b3b48ec6d06e40579536863534ab66382c7732afa3fb39bac40"
+    },
+    "affectedPaths": [
+      {
+        "path": "services/bayn/candidates/ordinal-17-volatility-managed-trend-overlay-preregistration.json",
+        "reviewedBlobSha": "466b8007fe2fffcff15497597877841089d9eaf2",
+        "finalBlobSha": "c1d07233df53cc0379b1dfae9f1caffbd6b7abd6",
+        "blockedBlobSha": "c1d07233df53cc0379b1dfae9f1caffbd6b7abd6"
+      },
+      {
+        "path": "services/bayn/candidates/ordinal-17-volatility-managed-trend-overlay-preregistration.md",
+        "reviewedBlobSha": "7ddcb5a224d3118cca48841935f34b4b476bf4aa",
+        "finalBlobSha": "38f22acecda596dc42ef651ce852a78869d5c333",
+        "blockedBlobSha": "38f22acecda596dc42ef651ce852a78869d5c333"
+      }
+    ]
+  },
+  "requiredDescendants": [
+    {
+      "mergeCommitSha": "4f39bb8ad168c3a459afdfdb30feccd49aba22d8",
+      "sourcePullRequestNumber": 13422,
+      "finalHeadSha": "9a293a7a8f7cb4ed5c8ddf41d7dbf9abecb12510",
+      "sourcePullRequestEvidenceSha256": "05a851a72a62ea4e2f40e878206e55db5491b57029dddb2dfab723b5a8f93c3c",
+      "mergeTreeSha": "63bd2cd7449f19839227d8a01d1f0839f63a31ec",
+      "finalHeadTreeSha": "63bd2cd7449f19839227d8a01d1f0839f63a31ec",
+      "affectedPaths": [
+        {
+          "path": "services/bayn/candidates/ordinal-17-volatility-managed-trend-overlay-source-manifest.json",
+          "mergeBlobSha": "23521cd435a97045adf18d1f075599fe5d22d750",
+          "finalHeadBlobSha": "23521cd435a97045adf18d1f075599fe5d22d750"
+        },
+        {
+          "path": "services/bayn/src/candidate-development-calendar.ts",
+          "mergeBlobSha": "6fc8363cd2b22f8c183a5898ceee3c45d0449c00",
+          "finalHeadBlobSha": "6fc8363cd2b22f8c183a5898ceee3c45d0449c00"
+        },
+        {
+          "path": "services/bayn/src/candidate-development-candidate-17.test.ts",
+          "mergeBlobSha": "059ea94b92fb0de3305d09a75cce8017a717163a",
+          "finalHeadBlobSha": "059ea94b92fb0de3305d09a75cce8017a717163a"
+        },
+        {
+          "path": "services/bayn/src/candidate-development-command.test.ts",
+          "mergeBlobSha": "8b9add1c6dcdeea4d33de3e1bf51a6b32677e904",
+          "finalHeadBlobSha": "8b9add1c6dcdeea4d33de3e1bf51a6b32677e904"
+        },
+        {
+          "path": "services/bayn/src/strategy/volatility-managed-trend-overlay/candidate-17.ts",
+          "mergeBlobSha": "8d1ccbfc6bef2c1707ac85f51d1647a7a8bfd98b",
+          "finalHeadBlobSha": "8d1ccbfc6bef2c1707ac85f51d1647a7a8bfd98b"
+        }
+      ]
+    },
+    {
+      "mergeCommitSha": "9f4ea79b12dcd32c794a9701160587d9a12e8c4d",
+      "sourcePullRequestNumber": 13427,
+      "finalHeadSha": "20043b151015acf77e5e1ecd8f7e2e1daa3da090",
+      "sourcePullRequestEvidenceSha256": "3ec2c9ffbc0ad305058e4051c48b22e88994650b26b6dfda7b796794645b1f85",
+      "mergeTreeSha": "502d494e3c66f4a82fa9c62c4615b537eb6dee00",
+      "finalHeadTreeSha": "502d494e3c66f4a82fa9c62c4615b537eb6dee00",
+      "affectedPaths": [
+        {
+          "path": ".github/workflows/bayn-qualification.yml",
+          "mergeBlobSha": "baf93e5ef1a814b1bc4ac9ef109fc980890ec959",
+          "finalHeadBlobSha": "baf93e5ef1a814b1bc4ac9ef109fc980890ec959"
+        },
+        {
+          "path": "nix/images/bayn.nix",
+          "mergeBlobSha": "f066365b17b89fdb6c25bd610444a74759fc3862",
+          "finalHeadBlobSha": "f066365b17b89fdb6c25bd610444a74759fc3862"
+        },
+        {
+          "path": "packages/scripts/src/bayn/bayn-qualification-workflow.test.ts",
+          "mergeBlobSha": "d06d3fd5fbb59d7520a595cdcf2558596362ef9b",
+          "finalHeadBlobSha": "d06d3fd5fbb59d7520a595cdcf2558596362ef9b"
+        },
+        {
+          "path": "services/bayn/package.json",
+          "mergeBlobSha": "b5f0b8d1a3c8672cea57a1aa306232186506501e",
+          "finalHeadBlobSha": "b5f0b8d1a3c8672cea57a1aa306232186506501e"
+        },
+        {
+          "path": "services/bayn/src/qualification-audit-command.ts",
+          "mergeBlobSha": "0d799c144df41c6bcebe927b7197581bb83eee86",
+          "finalHeadBlobSha": "0d799c144df41c6bcebe927b7197581bb83eee86"
+        },
+        {
+          "path": "services/bayn/src/qualification-candidate-command.test.ts",
+          "mergeBlobSha": "e479cad34c0d913a97dae39dd5d025f9cac512e9",
+          "finalHeadBlobSha": "e479cad34c0d913a97dae39dd5d025f9cac512e9"
+        },
+        {
+          "path": "services/bayn/src/qualification-candidate-command.ts",
+          "mergeBlobSha": "b88d927de6d3112dfef58bc966f66138cd873069",
+          "finalHeadBlobSha": "b88d927de6d3112dfef58bc966f66138cd873069"
+        },
+        {
+          "path": "services/bayn/src/qualification-collector-command.test.ts",
+          "mergeBlobSha": "470bdf9f87a70ca05856028668233a8910dd94bc",
+          "finalHeadBlobSha": "470bdf9f87a70ca05856028668233a8910dd94bc"
+        },
+        {
+          "path": "services/bayn/src/qualification-collector-command.ts",
+          "mergeBlobSha": "2475549f37d1e51ab0ef2f397e20baacaef8588b",
+          "finalHeadBlobSha": "2475549f37d1e51ab0ef2f397e20baacaef8588b"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Scope

Adds one general, reviewed remediation-receipt path for a merged Bayn source commit whose reviewed ancestor was dropped by a force-reconstructed final head. This does not weaken the ordinary exact-head gate.

- binds the blocked #13428 merge, original reviewed head, final head, exact force-push, complete PR/review/reaction/thread snapshot, and exact feedback/fix bodies
- binds every affected path plus reviewed/final/merge/current Git blob and tree identity
- binds the direct #13428 -> #13422 -> #13427 source ancestry and each descendant PR evidence snapshot
- requires the receipt-introducing commit to pass the existing normal exact-head review gate
- rejects missing, duplicate, cyclic, stale, changed, extra, spoofed, unresolved, downgraded, or later-mutated evidence
- leaves every unrelated/unreviewed Bayn input on the existing fail-closed path

## Exact failure remediated

Natural bayn-build-push run `30627693653` on main `9f4ea79b12dcd32c794a9701160587d9a12e8c4d` failed with `exact-head-review-missing` because PR #13428 final head `d9903bf860ede2622ab77a9eac8e3a9454586955` dropped reviewed head `8ef6b67fe799c0dddd70bc70f4648a3b23a7ca5b`.

## Validation

- focused release-review/workflow: 67 passed
- complete Bayn scripts: 214 passed
- targeted oxlint and type-aware oxlint: zero owned errors
- owned TypeScript: zero errors; repository-wide compiler has unrelated existing failures
- workflow YAML parse: passed
- Bayn production build: passed
- PostgreSQL target: exit 0 locally; integration cases skip without test database
- full scripts stopped only at the known Docker-required shared test because Docker is unavailable
- live GitHub receipt hashes for #13428, #13422, and #13427 revalidated immediately before commit

No manual release rerun, qualification, holdout access, permissions, credentials, rulesets, RBAC, NetworkPolicy, manifests, runtime, or broker changes.

PROOMPT-437