### PR TITLE
fix(bayn): explain expected month-end waits

### DIFF
--- a/services/bayn/src/cycle-observability.test.ts
+++ b/services/bayn/src/cycle-observability.test.ts
@@ -5,8 +5,13 @@ import { Result } from 'effect'
 import {
   CycleOperationsCondition,
   CycleOperationsReason,
+  MonthEndCadenceCondition,
+  MonthEndCadenceReason,
+  decideMonthEndCadenceEligibility,
   deriveCycleOperationsStatus,
   deriveCycleOperationsStatusResult,
+  projectAutonomousCycleCadenceObservation,
+  retainedAutonomousCycleCadenceDecision,
   renderCycleOperationsStatusFailure,
   type CycleOperationsProjection,
   type CycleOperationsSnapshot,
@@ -51,6 +56,201 @@ const projection = (overrides: Partial<CycleOperationsProjection> = {}): CycleOp
   reconciliation: null,
   mutations: { eventCount: 0, unresolvedCount: 0, oldestUnresolvedAt: null, latestOccurredAt: null },
   ...overrides,
+})
+
+describe('month-end cadence observability decisions', () => {
+  test('classifies a same-month execution session as an exact expected wait', () => {
+    expect(
+      decideMonthEndCadenceEligibility({
+        signalSessionDate: '2026-07-30',
+        executionSessionDate: '2026-07-31',
+      }),
+    ).toEqual({
+      schemaVersion: 'bayn.month-end-cadence-decision.v1',
+      condition: MonthEndCadenceCondition.ExpectedWait,
+      reason: MonthEndCadenceReason.SignalAndExecutionSessionSameMonth,
+      signalSessionDate: '2026-07-30',
+      executionSessionDate: '2026-07-31',
+      nextEligibility: {
+        status: 'UNKNOWN',
+        reason: MonthEndCadenceReason.FutureCalendarEvidenceUnavailable,
+      },
+    })
+  })
+
+  test('classifies a month transition as due and proves the execution session', () => {
+    expect(
+      decideMonthEndCadenceEligibility({
+        signalSessionDate: '2026-07-31',
+        executionSessionDate: '2026-08-03',
+      }),
+    ).toEqual({
+      schemaVersion: 'bayn.month-end-cadence-decision.v1',
+      condition: MonthEndCadenceCondition.Due,
+      reason: MonthEndCadenceReason.SignalToExecutionMonthTransition,
+      signalSessionDate: '2026-07-31',
+      executionSessionDate: '2026-08-03',
+      nextEligibility: {
+        status: 'PROVEN',
+        sessionDate: '2026-08-03',
+        basis: 'EXECUTION_SESSION_MONTH_TRANSITION',
+      },
+    })
+  })
+
+  test('uses authoritative session dates without guessing across holiday and weekend gaps', () => {
+    const holidayGap = decideMonthEndCadenceEligibility({
+      signalSessionDate: '2026-11-25',
+      executionSessionDate: '2026-11-27',
+    })
+    const weekendTransition = decideMonthEndCadenceEligibility({
+      signalSessionDate: '2026-01-30',
+      executionSessionDate: '2026-02-02',
+    })
+
+    expect(holidayGap).toMatchObject({
+      condition: MonthEndCadenceCondition.ExpectedWait,
+      reason: MonthEndCadenceReason.SignalAndExecutionSessionSameMonth,
+      nextEligibility: { status: 'UNKNOWN' },
+    })
+    expect(weekendTransition).toMatchObject({
+      condition: MonthEndCadenceCondition.Due,
+      reason: MonthEndCadenceReason.SignalToExecutionMonthTransition,
+      nextEligibility: { status: 'PROVEN', sessionDate: '2026-02-02' },
+    })
+  })
+
+  test('reports bounded unknown for malformed, incomplete, or non-forward calendar evidence', () => {
+    for (const facts of [
+      { signalSessionDate: '2026-07-30' },
+      { signalSessionDate: '2026-02-30', executionSessionDate: '2026-03-02' },
+      { signalSessionDate: '2026-07-31', executionSessionDate: '2026-07-30' },
+    ]) {
+      expect(decideMonthEndCadenceEligibility(facts)).toMatchObject({
+        condition: MonthEndCadenceCondition.Unknown,
+        reason: MonthEndCadenceReason.InvalidOrInsufficientCalendarEvidence,
+        nextEligibility: {
+          status: 'UNKNOWN',
+          reason: MonthEndCadenceReason.InvalidOrInsufficientCalendarEvidence,
+        },
+      })
+    }
+  })
+
+  test('distinguishes a fresh expected wait from a missed or stalled loop', () => {
+    const common = {
+      configured: true,
+      lastPassResult: 'SUCCESS' as const,
+      lastPassOutcome: 'NOT_DUE',
+    }
+    const fresh = projectAutonomousCycleCadenceObservation({ ...common, freshness: 'AVAILABLE' })
+    const stalled = projectAutonomousCycleCadenceObservation({ ...common, freshness: 'STALE' })
+
+    expect(fresh).toMatchObject({
+      condition: MonthEndCadenceCondition.ExpectedWait,
+      reason: MonthEndCadenceReason.MonthEndCadenceNotDue,
+      nextEligibility: {
+        status: 'UNKNOWN',
+        reason: MonthEndCadenceReason.FutureCalendarEvidenceUnavailable,
+      },
+    })
+    expect(stalled).toMatchObject({
+      condition: MonthEndCadenceCondition.Stalled,
+      reason: MonthEndCadenceReason.CyclePassStale,
+      nextEligibility: { status: 'UNKNOWN' },
+    })
+  })
+
+  test('reports a configured first-pass startup hang as stalled after runner classification', () => {
+    expect(
+      projectAutonomousCycleCadenceObservation({
+        configured: true,
+        lastPassResult: null,
+        lastPassOutcome: null,
+        freshness: 'STALE',
+      }),
+    ).toEqual({
+      schemaVersion: 'bayn.autonomous-cycle-cadence-observation.v1',
+      condition: MonthEndCadenceCondition.Stalled,
+      reason: MonthEndCadenceReason.CyclePassStale,
+      signalSessionDate: null,
+      executionSessionDate: null,
+      nextEligibility: {
+        status: 'UNKNOWN',
+        reason: MonthEndCadenceReason.FutureCalendarEvidenceUnavailable,
+      },
+    })
+    expect(
+      projectAutonomousCycleCadenceObservation({
+        configured: true,
+        lastPassResult: null,
+        lastPassOutcome: null,
+        freshness: 'UNAVAILABLE',
+      }),
+    ).toMatchObject({
+      condition: MonthEndCadenceCondition.Unknown,
+      reason: MonthEndCadenceReason.RunnerUnavailable,
+    })
+  })
+
+  test('preserves a proven month-transition eligibility from retained durable cycle facts', () => {
+    const cadenceDecision = decideMonthEndCadenceEligibility({
+      signalSessionDate: '2026-07-31',
+      executionSessionDate: '2026-08-03',
+    })
+
+    expect(
+      projectAutonomousCycleCadenceObservation({
+        configured: true,
+        lastPassResult: 'SUCCESS',
+        lastPassOutcome: 'ACQUIRED',
+        freshness: 'AVAILABLE',
+        cadenceDecision,
+      }),
+    ).toEqual({
+      schemaVersion: 'bayn.autonomous-cycle-cadence-observation.v1',
+      condition: MonthEndCadenceCondition.Due,
+      reason: MonthEndCadenceReason.SignalToExecutionMonthTransition,
+      signalSessionDate: '2026-07-31',
+      executionSessionDate: '2026-08-03',
+      nextEligibility: {
+        status: 'PROVEN',
+        sessionDate: '2026-08-03',
+        basis: 'EXECUTION_SESSION_MONTH_TRANSITION',
+      },
+    })
+  })
+
+  test('recomputes retained latest-pass evidence instead of trusting projected condition fields', () => {
+    expect(
+      retainedAutonomousCycleCadenceDecision({
+        result: 'SUCCESS',
+        outcome: 'RECOVERED',
+        cadenceDecision: {
+          condition: MonthEndCadenceCondition.ExpectedWait,
+          reason: MonthEndCadenceReason.SignalAndExecutionSessionSameMonth,
+          signalSessionDate: '2026-07-31',
+          executionSessionDate: '2026-08-03',
+        },
+      }),
+    ).toEqual({
+      schemaVersion: 'bayn.month-end-cadence-decision.v1',
+      condition: MonthEndCadenceCondition.Due,
+      reason: MonthEndCadenceReason.SignalToExecutionMonthTransition,
+      signalSessionDate: '2026-07-31',
+      executionSessionDate: '2026-08-03',
+      nextEligibility: {
+        status: 'PROVEN',
+        sessionDate: '2026-08-03',
+        basis: 'EXECUTION_SESSION_MONTH_TRANSITION',
+      },
+    })
+    expect(retainedAutonomousCycleCadenceDecision({ result: 'SUCCESS', outcome: 'NO_PUBLICATION' })).toBeUndefined()
+    expect(retainedAutonomousCycleCadenceDecision({ cadenceDecision: 'malformed' })).toMatchObject({
+      condition: MonthEndCadenceCondition.Unknown,
+      reason: MonthEndCadenceReason.InvalidOrInsufficientCalendarEvidence,
+    })
+  })
 })
 
 describe('autonomous cycle operations classification', () => {

--- a/services/bayn/src/cycle-observability.ts
+++ b/services/bayn/src/cycle-observability.ts
@@ -10,6 +10,247 @@ export interface CycleOperationsThresholds {
   readonly unknownMutationThresholdMs: number
 }
 
+export enum MonthEndCadenceCondition {
+  Due = 'DUE',
+  ExpectedWait = 'EXPECTED_WAIT',
+  NotApplicable = 'NOT_APPLICABLE',
+  Stalled = 'STALLED',
+  Unknown = 'UNKNOWN',
+}
+
+export enum MonthEndCadenceReason {
+  CyclePassStale = 'CYCLE_PASS_STALE',
+  FutureCalendarEvidenceUnavailable = 'FUTURE_CALENDAR_EVIDENCE_UNAVAILABLE',
+  InvalidOrInsufficientCalendarEvidence = 'INVALID_OR_INSUFFICIENT_CALENDAR_EVIDENCE',
+  LatestPassFailed = 'LATEST_PASS_FAILED',
+  MonthEndCadenceNotDue = 'MONTH_END_CADENCE_NOT_DUE',
+  NoPassRecorded = 'NO_PASS_RECORDED',
+  PassOutcomeNotApplicable = 'PASS_OUTCOME_NOT_APPLICABLE',
+  RunnerUnavailable = 'RUNNER_UNAVAILABLE',
+  SignalAndExecutionSessionSameMonth = 'SIGNAL_AND_EXECUTION_SESSION_SAME_MONTH',
+  SignalToExecutionMonthTransition = 'SIGNAL_TO_EXECUTION_MONTH_TRANSITION',
+}
+
+export type MonthEndCadenceNextEligibility =
+  | {
+      readonly status: 'PROVEN'
+      readonly sessionDate: string
+      readonly basis: 'EXECUTION_SESSION_MONTH_TRANSITION'
+    }
+  | {
+      readonly status: 'UNKNOWN'
+      readonly reason:
+        | MonthEndCadenceReason.FutureCalendarEvidenceUnavailable
+        | MonthEndCadenceReason.InvalidOrInsufficientCalendarEvidence
+    }
+
+export interface MonthEndCadenceDecision {
+  readonly schemaVersion: 'bayn.month-end-cadence-decision.v1'
+  readonly condition:
+    | MonthEndCadenceCondition.Due
+    | MonthEndCadenceCondition.ExpectedWait
+    | MonthEndCadenceCondition.Unknown
+  readonly reason:
+    | MonthEndCadenceReason.SignalAndExecutionSessionSameMonth
+    | MonthEndCadenceReason.SignalToExecutionMonthTransition
+    | MonthEndCadenceReason.InvalidOrInsufficientCalendarEvidence
+  readonly signalSessionDate: string | null
+  readonly executionSessionDate: string | null
+  readonly nextEligibility: MonthEndCadenceNextEligibility
+}
+
+export type AutonomousCycleCadenceObservation = {
+  readonly schemaVersion: 'bayn.autonomous-cycle-cadence-observation.v1'
+  readonly condition: MonthEndCadenceCondition
+  readonly reason: MonthEndCadenceReason
+  readonly signalSessionDate: string | null
+  readonly executionSessionDate: string | null
+  readonly nextEligibility: MonthEndCadenceNextEligibility
+}
+
+export type AutonomousCycleCadenceFreshness = 'AVAILABLE' | 'STALE' | 'UNAVAILABLE'
+
+const isIsoDate = (value: string | undefined): value is string => {
+  if (value === undefined || !/^\d{4}-\d{2}-\d{2}$/.test(value)) return false
+  const date = new Date(`${value}T00:00:00.000Z`)
+  return !Number.isNaN(date.getTime()) && date.toISOString().slice(0, 10) === value
+}
+
+const unknownNextEligibility = (
+  reason:
+    | MonthEndCadenceReason.FutureCalendarEvidenceUnavailable
+    | MonthEndCadenceReason.InvalidOrInsufficientCalendarEvidence,
+): MonthEndCadenceNextEligibility => ({ status: 'UNKNOWN', reason })
+
+export const decideMonthEndCadenceEligibility = (facts: {
+  readonly signalSessionDate?: string
+  readonly executionSessionDate?: string
+}): MonthEndCadenceDecision => {
+  if (
+    !isIsoDate(facts.signalSessionDate) ||
+    !isIsoDate(facts.executionSessionDate) ||
+    facts.signalSessionDate >= facts.executionSessionDate
+  ) {
+    return {
+      schemaVersion: 'bayn.month-end-cadence-decision.v1',
+      condition: MonthEndCadenceCondition.Unknown,
+      reason: MonthEndCadenceReason.InvalidOrInsufficientCalendarEvidence,
+      signalSessionDate: isIsoDate(facts.signalSessionDate) ? facts.signalSessionDate : null,
+      executionSessionDate: isIsoDate(facts.executionSessionDate) ? facts.executionSessionDate : null,
+      nextEligibility: unknownNextEligibility(MonthEndCadenceReason.InvalidOrInsufficientCalendarEvidence),
+    }
+  }
+
+  if (facts.signalSessionDate.slice(0, 7) !== facts.executionSessionDate.slice(0, 7)) {
+    return {
+      schemaVersion: 'bayn.month-end-cadence-decision.v1',
+      condition: MonthEndCadenceCondition.Due,
+      reason: MonthEndCadenceReason.SignalToExecutionMonthTransition,
+      signalSessionDate: facts.signalSessionDate,
+      executionSessionDate: facts.executionSessionDate,
+      nextEligibility: {
+        status: 'PROVEN',
+        sessionDate: facts.executionSessionDate,
+        basis: 'EXECUTION_SESSION_MONTH_TRANSITION',
+      },
+    }
+  }
+
+  return {
+    schemaVersion: 'bayn.month-end-cadence-decision.v1',
+    condition: MonthEndCadenceCondition.ExpectedWait,
+    reason: MonthEndCadenceReason.SignalAndExecutionSessionSameMonth,
+    signalSessionDate: facts.signalSessionDate,
+    executionSessionDate: facts.executionSessionDate,
+    nextEligibility: unknownNextEligibility(MonthEndCadenceReason.FutureCalendarEvidenceUnavailable),
+  }
+}
+
+const isRecord = (value: unknown): value is Readonly<Record<string, unknown>> =>
+  typeof value === 'object' && value !== null
+
+export const retainedAutonomousCycleCadenceDecision = (observation: unknown): MonthEndCadenceDecision | undefined => {
+  if (!isRecord(observation) || !Object.hasOwn(observation, 'cadenceDecision')) return undefined
+  const retained = observation.cadenceDecision
+  if (!isRecord(retained)) return decideMonthEndCadenceEligibility({})
+  return decideMonthEndCadenceEligibility({
+    ...(typeof retained.signalSessionDate === 'string' ? { signalSessionDate: retained.signalSessionDate } : {}),
+    ...(typeof retained.executionSessionDate === 'string'
+      ? { executionSessionDate: retained.executionSessionDate }
+      : {}),
+  })
+}
+
+export const projectAutonomousCycleCadenceObservation = (input: {
+  readonly configured: boolean
+  readonly lastPassResult: 'SUCCESS' | 'FAILURE' | null
+  readonly lastPassOutcome: string | null
+  readonly freshness: AutonomousCycleCadenceFreshness
+  readonly cadenceDecision?: MonthEndCadenceDecision
+}): AutonomousCycleCadenceObservation => {
+  const common = { schemaVersion: 'bayn.autonomous-cycle-cadence-observation.v1' } as const
+  const unavailable = unknownNextEligibility(MonthEndCadenceReason.FutureCalendarEvidenceUnavailable)
+  const retainedEvidence = {
+    signalSessionDate: input.cadenceDecision?.signalSessionDate ?? null,
+    executionSessionDate: input.cadenceDecision?.executionSessionDate ?? null,
+    nextEligibility: input.cadenceDecision?.nextEligibility ?? unavailable,
+  }
+  if (!input.configured) {
+    return {
+      ...common,
+      condition: MonthEndCadenceCondition.Unknown,
+      reason: MonthEndCadenceReason.NoPassRecorded,
+      signalSessionDate: null,
+      executionSessionDate: null,
+      nextEligibility: unavailable,
+    }
+  }
+  if (input.lastPassResult === null && input.freshness === 'STALE') {
+    return {
+      ...common,
+      condition: MonthEndCadenceCondition.Stalled,
+      reason: MonthEndCadenceReason.CyclePassStale,
+      signalSessionDate: null,
+      executionSessionDate: null,
+      nextEligibility: unavailable,
+    }
+  }
+  if (input.lastPassResult === null && input.freshness === 'UNAVAILABLE') {
+    return {
+      ...common,
+      condition: MonthEndCadenceCondition.Unknown,
+      reason: MonthEndCadenceReason.RunnerUnavailable,
+      signalSessionDate: null,
+      executionSessionDate: null,
+      nextEligibility: unavailable,
+    }
+  }
+  if (input.lastPassResult === null) {
+    return {
+      ...common,
+      condition: MonthEndCadenceCondition.Unknown,
+      reason: MonthEndCadenceReason.NoPassRecorded,
+      signalSessionDate: null,
+      executionSessionDate: null,
+      nextEligibility: unavailable,
+    }
+  }
+  if (input.lastPassResult === 'FAILURE') {
+    return {
+      ...common,
+      condition: MonthEndCadenceCondition.Unknown,
+      reason: MonthEndCadenceReason.LatestPassFailed,
+      signalSessionDate: null,
+      executionSessionDate: null,
+      nextEligibility: unavailable,
+    }
+  }
+  if (input.freshness === 'STALE') {
+    return {
+      ...common,
+      condition: MonthEndCadenceCondition.Stalled,
+      reason: MonthEndCadenceReason.CyclePassStale,
+      ...retainedEvidence,
+    }
+  }
+  if (input.freshness === 'UNAVAILABLE') {
+    return {
+      ...common,
+      condition: MonthEndCadenceCondition.Unknown,
+      reason: MonthEndCadenceReason.RunnerUnavailable,
+      ...retainedEvidence,
+    }
+  }
+  if (input.cadenceDecision !== undefined) {
+    return {
+      ...common,
+      condition: input.cadenceDecision.condition,
+      reason: input.cadenceDecision.reason,
+      signalSessionDate: input.cadenceDecision.signalSessionDate,
+      executionSessionDate: input.cadenceDecision.executionSessionDate,
+      nextEligibility: input.cadenceDecision.nextEligibility,
+    }
+  }
+  if (input.lastPassOutcome !== 'NOT_DUE') {
+    return {
+      ...common,
+      condition: MonthEndCadenceCondition.NotApplicable,
+      reason: MonthEndCadenceReason.PassOutcomeNotApplicable,
+      signalSessionDate: null,
+      executionSessionDate: null,
+      nextEligibility: unavailable,
+    }
+  }
+  return {
+    ...common,
+    condition: MonthEndCadenceCondition.ExpectedWait,
+    reason: MonthEndCadenceReason.MonthEndCadenceNotDue,
+    signalSessionDate: null,
+    executionSessionDate: null,
+    nextEligibility: unavailable,
+  }
+}
+
 export interface CycleOperationsSnapshot {
   readonly cycleId: string
   readonly accountId: string

--- a/services/bayn/src/cycle-runner/pass-decisions-observability.test.ts
+++ b/services/bayn/src/cycle-runner/pass-decisions-observability.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, test } from 'bun:test'
+
+import { MonthEndCadenceCondition, MonthEndCadenceReason } from '../cycle-observability'
+import { CycleState, type AutonomousCycle } from '../cycle'
+import type { CyclePassObservation, CycleRunResult } from './model'
+import { cyclePassLogFacts, retainAutonomousCyclePassObservation } from './pass-decisions'
+
+const observedAt = '2026-08-03T13:30:00.000Z'
+const signalSessionDate = '2026-07-31'
+const executionSessionDate = '2026-08-03'
+
+const terminalCycle = (): AutonomousCycle =>
+  ({
+    identity: {
+      cycleId: 'c'.repeat(64),
+      signalSessionDate,
+      executionSessionDate,
+    },
+    state: CycleState.Completed,
+  }) as unknown as AutonomousCycle
+
+const succeeded = (result: CycleRunResult): CyclePassObservation => ({
+  outcome: 'SUCCEEDED',
+  observedAt,
+  result,
+})
+
+const acquired = (outcome: 'ACQUIRED' | 'REACQUIRED'): CycleRunResult =>
+  ({
+    outcome,
+    signalSessionDate,
+    executionSessionDate,
+    observedAt,
+    calendarResponseHash: 'a'.repeat(64),
+    calendarReadContentHash: 'b'.repeat(64),
+    receipt: { created: outcome === 'ACQUIRED' },
+    readiness: {
+      outcome: 'BOUND',
+      observedAt,
+      cycle: terminalCycle(),
+      snapshotId: 'd'.repeat(64),
+    },
+  }) as CycleRunResult
+
+describe('autonomous cycle pass observability', () => {
+  test('projects the exact NOT_DUE cadence reason and bounded next eligibility into structured logs', () => {
+    const facts = cyclePassLogFacts({
+      outcome: 'SUCCEEDED',
+      observedAt: '2026-07-31T13:00:00.000Z',
+      result: {
+        outcome: 'NOT_DUE',
+        signalSessionDate: '2026-07-30',
+        executionSessionDate: '2026-07-31',
+        observedAt: '2026-07-31T12:59:59.000Z',
+        calendarResponseHash: 'a'.repeat(64),
+        calendarReadContentHash: 'b'.repeat(64),
+      },
+    })
+
+    expect(facts).toEqual({
+      level: 'INFO',
+      message: 'Bayn autonomous cycle pass completed',
+      annotations: {
+        outcome: 'NOT_DUE',
+        signalSessionDate: '2026-07-30',
+        executionSessionDate: '2026-07-31',
+        observedAt: '2026-07-31T12:59:59.000Z',
+        calendarResponseHash: 'a'.repeat(64),
+        calendarReadContentHash: 'b'.repeat(64),
+        cadenceCondition: MonthEndCadenceCondition.ExpectedWait,
+        cadenceReason: MonthEndCadenceReason.SignalAndExecutionSessionSameMonth,
+        nextEligibilityStatus: 'UNKNOWN',
+        nextEligibilityReason: MonthEndCadenceReason.FutureCalendarEvidenceUnavailable,
+      },
+    })
+  })
+
+  test('retains exact latest-pass cadence evidence for every observable month-end outcome', () => {
+    const results: readonly CycleRunResult[] = [
+      {
+        outcome: 'NOT_DUE',
+        signalSessionDate: '2026-07-30',
+        executionSessionDate: '2026-07-31',
+        observedAt,
+        calendarResponseHash: 'a'.repeat(64),
+        calendarReadContentHash: 'b'.repeat(64),
+      },
+      acquired('ACQUIRED'),
+      acquired('REACQUIRED'),
+      { outcome: 'RECOVERED', action: 'COMPLETED', observedAt, cycle: terminalCycle() },
+      { outcome: 'ALREADY_TERMINAL', signalSessionDate, observedAt, cycle: terminalCycle() },
+    ]
+
+    for (const result of results) {
+      const retained = retainAutonomousCyclePassObservation(succeeded(result))
+      expect(retained).toMatchObject({ result: 'SUCCESS', observedAt, outcome: result.outcome })
+      if (retained.result !== 'SUCCESS') throw new Error('successful pass was not retained as success')
+      expect(retained.cadenceDecision).toMatchObject(
+        result.outcome === 'NOT_DUE'
+          ? {
+              condition: MonthEndCadenceCondition.ExpectedWait,
+              reason: MonthEndCadenceReason.SignalAndExecutionSessionSameMonth,
+              signalSessionDate: '2026-07-30',
+              executionSessionDate: '2026-07-31',
+              nextEligibility: { status: 'UNKNOWN' },
+            }
+          : {
+              condition: MonthEndCadenceCondition.Due,
+              reason: MonthEndCadenceReason.SignalToExecutionMonthTransition,
+              signalSessionDate,
+              executionSessionDate,
+              nextEligibility: { status: 'PROVEN', sessionDate: executionSessionDate },
+            },
+      )
+    }
+  })
+
+  test('projects retained terminal-cycle cadence into settled outcome logs', () => {
+    for (const result of [
+      { outcome: 'RECOVERED', action: 'COMPLETED', observedAt, cycle: terminalCycle() },
+      { outcome: 'ALREADY_TERMINAL', signalSessionDate, observedAt, cycle: terminalCycle() },
+    ] as const satisfies readonly CycleRunResult[]) {
+      expect(cyclePassLogFacts(succeeded(result)).annotations).toMatchObject({
+        outcome: result.outcome,
+        signalSessionDate,
+        executionSessionDate,
+        cadenceCondition: MonthEndCadenceCondition.Due,
+        cadenceReason: MonthEndCadenceReason.SignalToExecutionMonthTransition,
+        nextEligibilityStatus: 'PROVEN',
+        nextEligibleSessionDate: executionSessionDate,
+      })
+    }
+  })
+})

--- a/services/bayn/src/cycle-runner/pass-decisions.ts
+++ b/services/bayn/src/cycle-runner/pass-decisions.ts
@@ -1,5 +1,6 @@
 import { Result } from 'effect'
 
+import { decideMonthEndCadenceEligibility, type MonthEndCadenceDecision } from '../cycle-observability'
 import { CycleState, type AutonomousCycle } from '../cycle'
 import type { CycleReadinessError } from '../cycle-readiness'
 import type { CycleRecoverySelection } from '../cycle-recovery'
@@ -42,6 +43,82 @@ export interface CyclePassLogFacts {
   readonly annotations: Readonly<Partial<Record<string, string | boolean>>>
 }
 
+const cadenceDecisionFromCycle = (cycle: AutonomousCycle): MonthEndCadenceDecision =>
+  decideMonthEndCadenceEligibility({
+    signalSessionDate: cycle.identity.signalSessionDate,
+    executionSessionDate: cycle.identity.executionSessionDate,
+  })
+
+export const cycleRunResultCadenceDecision = (result: CycleRunResult): MonthEndCadenceDecision | undefined => {
+  switch (result.outcome) {
+    case 'NO_PUBLICATION':
+      return undefined
+    case 'NOT_DUE':
+    case 'ACQUIRED':
+    case 'REACQUIRED':
+      return decideMonthEndCadenceEligibility({
+        signalSessionDate: result.signalSessionDate,
+        executionSessionDate: result.executionSessionDate,
+      })
+    case 'ALREADY_ACQUIRED':
+    case 'ALREADY_TERMINAL':
+    case 'RECOVERED':
+      return cadenceDecisionFromCycle(result.cycle)
+    case 'RESUMED':
+      return cadenceDecisionFromCycle(result.readiness.cycle)
+  }
+}
+
+export type RetainedAutonomousCyclePassObservation =
+  | {
+      readonly result: 'SUCCESS'
+      readonly observedAt: string
+      readonly outcome: CycleRunResult['outcome']
+      readonly cadenceDecision?: MonthEndCadenceDecision
+    }
+  | {
+      readonly result: 'FAILURE'
+      readonly observedAt: string
+      readonly operation: CycleRunnerError['operation']
+      readonly failure: CycleRunnerError['failure']
+      readonly message: string
+    }
+
+export const retainAutonomousCyclePassObservation = (
+  observation: CyclePassObservation,
+): RetainedAutonomousCyclePassObservation => {
+  if (observation.outcome === 'FAILED') {
+    return {
+      result: 'FAILURE',
+      observedAt: observation.observedAt,
+      operation: observation.error.operation,
+      failure: observation.error.failure,
+      message: observation.error.message,
+    }
+  }
+  const cadenceDecision = cycleRunResultCadenceDecision(observation.result)
+  return {
+    result: 'SUCCESS',
+    observedAt: observation.observedAt,
+    outcome: observation.result.outcome,
+    ...(cadenceDecision === undefined ? {} : { cadenceDecision }),
+  }
+}
+
+const cadenceLogAnnotations = (
+  decision: MonthEndCadenceDecision,
+): Readonly<Partial<Record<string, string | boolean>>> => ({
+  cadenceCondition: decision.condition,
+  cadenceReason: decision.reason,
+  nextEligibilityStatus: decision.nextEligibility.status,
+  ...(decision.nextEligibility.status === 'PROVEN'
+    ? {
+        nextEligibleSessionDate: decision.nextEligibility.sessionDate,
+        nextEligibilityBasis: decision.nextEligibility.basis,
+      }
+    : { nextEligibilityReason: decision.nextEligibility.reason }),
+})
+
 export const cyclePassLogFacts = (observation: CyclePassObservation): CyclePassLogFacts => {
   if (observation.outcome === 'FAILED') {
     return {
@@ -55,6 +132,8 @@ export const cyclePassLogFacts = (observation: CyclePassObservation): CyclePassL
     }
   }
   const result = observation.result
+  const cadenceDecision = cycleRunResultCadenceDecision(result)
+  const cadenceAnnotations = cadenceDecision === undefined ? {} : cadenceLogAnnotations(cadenceDecision)
   switch (result.outcome) {
     case 'NO_PUBLICATION':
       return {
@@ -70,9 +149,11 @@ export const cyclePassLogFacts = (observation: CyclePassObservation): CyclePassL
         annotations: {
           outcome: result.outcome,
           signalSessionDate: result.signalSessionDate,
+          executionSessionDate: result.cycle.identity.executionSessionDate,
           observedAt: result.observedAt,
           cycleId: result.cycle.identity.cycleId,
           cycleState: result.cycle.state,
+          ...cadenceAnnotations,
         },
       }
     case 'RESUMED':
@@ -82,10 +163,12 @@ export const cyclePassLogFacts = (observation: CyclePassObservation): CyclePassL
         annotations: {
           outcome: result.outcome,
           signalSessionDate: result.signalSessionDate,
+          executionSessionDate: result.readiness.cycle.identity.executionSessionDate,
           observedAt: result.observedAt,
           cycleId: result.readiness.cycle.identity.cycleId,
           cycleState: result.readiness.cycle.state,
           publicationReadiness: result.readiness.outcome,
+          ...cadenceAnnotations,
         },
       }
     case 'RECOVERED':
@@ -95,9 +178,12 @@ export const cyclePassLogFacts = (observation: CyclePassObservation): CyclePassL
         annotations: {
           outcome: result.outcome,
           recoveryAction: result.action,
+          signalSessionDate: result.cycle.identity.signalSessionDate,
+          executionSessionDate: result.cycle.identity.executionSessionDate,
           observedAt: result.observedAt,
           cycleId: result.cycle.identity.cycleId,
           cycleState: result.cycle.state,
+          ...cadenceAnnotations,
         },
       }
     case 'NOT_DUE':
@@ -111,6 +197,7 @@ export const cyclePassLogFacts = (observation: CyclePassObservation): CyclePassL
           observedAt: result.observedAt,
           calendarResponseHash: result.calendarResponseHash,
           calendarReadContentHash: result.calendarReadContentHash,
+          ...cadenceAnnotations,
         },
       }
     case 'ACQUIRED':
@@ -129,6 +216,7 @@ export const cyclePassLogFacts = (observation: CyclePassObservation): CyclePassL
           cycleState: result.readiness.cycle.state,
           publicationReadiness: result.readiness.outcome,
           persistenceDeduplicated: !result.receipt.created,
+          ...cadenceAnnotations,
         },
       }
   }

--- a/services/bayn/src/http.test.ts
+++ b/services/bayn/src/http.test.ts
@@ -19,8 +19,15 @@ import { unusedAssetBySymbol, unusedMarketCalendar } from './broker/alpaca-test-
 import { BrokerEnvironment, BrokerProvider, makeBrokerIdentity } from './broker/identity'
 import type { ExecutionPolicy } from './execution/configuration'
 import { BrokerAccess, CapitalAuthorityKind } from './execution/authority'
-import { CycleOperationsCondition, CycleOperationsReason } from './cycle-observability'
-import { CycleState, CycleTerminalReason } from './cycle'
+import {
+  CycleOperationsCondition,
+  CycleOperationsReason,
+  MonthEndCadenceCondition,
+  MonthEndCadenceReason,
+} from './cycle-observability'
+import { CycleState, CycleTerminalReason, type AutonomousCycle } from './cycle'
+import type { CyclePassObservation, CycleRunResult } from './cycle-runner/model'
+import { retainAutonomousCyclePassObservation } from './cycle-runner/pass-decisions'
 import { DatabaseError, type EvidenceStoreService } from './db/evidence-store'
 import type { BrokerProbe } from './health'
 import {
@@ -68,6 +75,49 @@ const sandboxMutationExecution: ExecutionPolicy = {
     authorityGenerationHash: 'a'.repeat(64),
   },
 }
+
+const retainedPass = (result: CycleRunResult): RuntimeState['autonomousCycleLoop']['lastPass'] =>
+  retainAutonomousCyclePassObservation({
+    outcome: 'SUCCEEDED',
+    observedAt: result.observedAt,
+    result,
+  } satisfies CyclePassObservation)
+
+const cadenceCycle = (
+  signalSessionDate: string,
+  executionSessionDate: string,
+  state: CycleState = CycleState.Completed,
+): AutonomousCycle =>
+  ({
+    identity: {
+      cycleId: 'c'.repeat(64),
+      signalSessionDate,
+      executionSessionDate,
+    },
+    state,
+  }) as AutonomousCycle
+
+const acquiredCadenceResult = (
+  outcome: 'ACQUIRED' | 'REACQUIRED',
+  observedAt: string,
+  signalSessionDate: string,
+  executionSessionDate: string,
+): CycleRunResult =>
+  ({
+    outcome,
+    signalSessionDate,
+    executionSessionDate,
+    observedAt,
+    calendarResponseHash: 'a'.repeat(64),
+    calendarReadContentHash: 'b'.repeat(64),
+    receipt: { created: outcome === 'ACQUIRED' },
+    readiness: {
+      outcome: 'BOUND',
+      observedAt,
+      cycle: cadenceCycle(signalSessionDate, executionSessionDate, CycleState.Pending),
+      snapshotId: 'd'.repeat(64),
+    },
+  }) as CycleRunResult
 
 interface TestServer {
   readonly port: number
@@ -1485,6 +1535,168 @@ describe('Bayn HTTP probes', () => {
         Effect.asVoid,
       ),
     )
+  })
+
+  test('exposes fresh NOT_DUE expected waiting and distinguishes a stalled autonomous loop', () => {
+    const observedAt = '2026-07-31T13:00:00.000Z'
+    const notDue: CycleRunResult = {
+      outcome: 'NOT_DUE',
+      signalSessionDate: '2026-07-30',
+      executionSessionDate: '2026-07-31',
+      observedAt,
+      calendarResponseHash: 'a'.repeat(64),
+      calendarReadContentHash: 'b'.repeat(64),
+    }
+    const expectedWait: RuntimeState = {
+      ...readyState(),
+      autonomousCycleLoop: {
+        configured: true,
+        startedAt: observedAt,
+        lastPass: retainedPass(notDue),
+      },
+    }
+    const stalled: RuntimeState = {
+      ...expectedWait,
+      status: 'DEGRADED',
+      health: {
+        ...expectedWait.health,
+        dependencies: {
+          ...expectedWait.health.dependencies,
+          cycleRunner: {
+            status: 'UNAVAILABLE',
+            checkedAt: observedAt,
+            error: `autonomous cycle loop has not completed a successful pass for ${config.cycleStallThresholdMs}ms`,
+          },
+        },
+      },
+    }
+
+    const expectedFacts = statusFacts(expectedWait, readOnlyExecution, provenance, 'embedded')
+    expect(expectedFacts.autonomousCycleLoop.cadence).toEqual({
+      schemaVersion: 'bayn.autonomous-cycle-cadence-observation.v1',
+      condition: MonthEndCadenceCondition.ExpectedWait,
+      reason: MonthEndCadenceReason.SignalAndExecutionSessionSameMonth,
+      signalSessionDate: '2026-07-30',
+      executionSessionDate: '2026-07-31',
+      nextEligibility: {
+        status: 'UNKNOWN',
+        reason: MonthEndCadenceReason.FutureCalendarEvidenceUnavailable,
+      },
+    })
+    expect(expectedFacts.autonomousCycleLoop.lastPass).toEqual({ result: 'SUCCESS', observedAt, outcome: 'NOT_DUE' })
+    expect(expectedFacts.autonomousCycleLoop.lastPass).not.toHaveProperty('cadenceDecision')
+    const expectedMetrics = renderPrometheusMetrics(expectedWait, config, provenance, 'embedded')
+    expect(expectedMetrics).toContain('bayn_autonomous_cycle_cadence_condition{condition="expected_wait"} 1')
+    expect(expectedMetrics).toContain(
+      'bayn_autonomous_cycle_cadence_reason{reason="signal_and_execution_session_same_month"} 1',
+    )
+    expect(expectedMetrics).toContain('bayn_autonomous_cycle_next_eligibility{status="unknown"} 1')
+    expect(expectedMetrics).toContain('bayn_broker_orders_enabled 0')
+
+    const stalledFacts = statusFacts(stalled, readOnlyExecution, provenance, 'embedded')
+    expect(stalledFacts.autonomousCycleLoop.cadence).toMatchObject({
+      condition: MonthEndCadenceCondition.Stalled,
+      reason: MonthEndCadenceReason.CyclePassStale,
+      signalSessionDate: '2026-07-30',
+      executionSessionDate: '2026-07-31',
+      nextEligibility: { status: 'UNKNOWN' },
+    })
+    const stalledMetrics = renderPrometheusMetrics(stalled, config, provenance, 'embedded')
+    expect(stalledMetrics).toContain('bayn_autonomous_cycle_cadence_condition{condition="stalled"} 1')
+    expect(stalledMetrics).toContain('bayn_autonomous_cycle_cadence_reason{reason="cycle_pass_stale"} 1')
+  })
+
+  test('exposes a configured first-pass startup hang as stalled in status and metrics', () => {
+    const startedAt = '2026-07-31T13:00:00.000Z'
+    const startupHang: RuntimeState = {
+      ...readyState(),
+      status: 'DEGRADED',
+      health: {
+        ...readyState().health,
+        checkedAt: '2026-07-31T13:05:00.000Z',
+        dependencies: {
+          ...readyState().health.dependencies,
+          cycleRunner: {
+            status: 'UNAVAILABLE',
+            checkedAt: '2026-07-31T13:05:00.000Z',
+            error: `autonomous cycle loop has not completed a successful pass for ${config.cycleStallThresholdMs}ms`,
+          },
+        },
+      },
+      autonomousCycleLoop: {
+        configured: true,
+        startedAt,
+        lastPass: null,
+      },
+    }
+
+    const facts = statusFacts(startupHang, readOnlyExecution, provenance, 'embedded')
+    expect(facts.autonomousCycleLoop.lastPass).toBeNull()
+    expect(facts.autonomousCycleLoop.cadence).toEqual({
+      schemaVersion: 'bayn.autonomous-cycle-cadence-observation.v1',
+      condition: MonthEndCadenceCondition.Stalled,
+      reason: MonthEndCadenceReason.CyclePassStale,
+      signalSessionDate: null,
+      executionSessionDate: null,
+      nextEligibility: {
+        status: 'UNKNOWN',
+        reason: MonthEndCadenceReason.FutureCalendarEvidenceUnavailable,
+      },
+    })
+
+    const metrics = renderPrometheusMetrics(startupHang, config, provenance, 'embedded')
+    expect(metrics).toContain('bayn_autonomous_cycle_cadence_condition{condition="stalled"} 1')
+    expect(metrics).toContain('bayn_autonomous_cycle_cadence_reason{reason="cycle_pass_stale"} 1')
+    expect(metrics).toContain('bayn_autonomous_cycle_loop_last_pass{result="unknown"} 1')
+    expect(metrics).toContain('bayn_broker_orders_enabled 0')
+  })
+
+  test('preserves retained cadence for acquired, reacquired, recovered, and terminal outcomes', () => {
+    const observedAt = '2026-08-03T13:30:00.000Z'
+    const signalSessionDate = '2026-07-31'
+    const executionSessionDate = '2026-08-03'
+    const terminal = cadenceCycle(signalSessionDate, executionSessionDate)
+    const results: readonly CycleRunResult[] = [
+      acquiredCadenceResult('ACQUIRED', observedAt, signalSessionDate, executionSessionDate),
+      acquiredCadenceResult('REACQUIRED', observedAt, signalSessionDate, executionSessionDate),
+      { outcome: 'RECOVERED', action: 'COMPLETED', observedAt, cycle: terminal },
+      { outcome: 'ALREADY_TERMINAL', signalSessionDate, observedAt, cycle: terminal },
+    ]
+
+    for (const result of results) {
+      const state: RuntimeState = {
+        ...readyState(),
+        autonomousCycleLoop: {
+          configured: true,
+          startedAt: observedAt,
+          lastPass: retainedPass(result),
+        },
+      }
+      expect(state.cycle.current).toBeNull()
+      expect(state.cycle.last).toBeNull()
+
+      const facts = statusFacts(state, readOnlyExecution, provenance, 'embedded')
+      expect(facts.autonomousCycleLoop.cadence).toEqual({
+        schemaVersion: 'bayn.autonomous-cycle-cadence-observation.v1',
+        condition: MonthEndCadenceCondition.Due,
+        reason: MonthEndCadenceReason.SignalToExecutionMonthTransition,
+        signalSessionDate,
+        executionSessionDate,
+        nextEligibility: {
+          status: 'PROVEN',
+          sessionDate: executionSessionDate,
+          basis: 'EXECUTION_SESSION_MONTH_TRANSITION',
+        },
+      })
+      expect(facts.autonomousCycleLoop.lastPass).toEqual({ result: 'SUCCESS', observedAt, outcome: result.outcome })
+      expect(facts.autonomousCycleLoop.lastPass).not.toHaveProperty('cadenceDecision')
+
+      const metrics = renderPrometheusMetrics(state, config, provenance, 'embedded')
+      expect(metrics).toContain('bayn_autonomous_cycle_cadence_condition{condition="due"} 1')
+      expect(metrics).toContain('bayn_autonomous_cycle_cadence_reason{reason="signal_to_execution_month_transition"} 1')
+      expect(metrics).toContain('bayn_autonomous_cycle_next_eligibility{status="proven"} 1')
+      expect(metrics).toContain('bayn_broker_orders_enabled 0')
+    }
   })
 
   test('does not synthesize durable cycle, mutation, reconciliation, or authority observations', () => {

--- a/services/bayn/src/http.ts
+++ b/services/bayn/src/http.ts
@@ -6,7 +6,15 @@ import { HttpRouter, HttpServer, HttpServerRequest, HttpServerResponse } from 'e
 
 import type { RuntimeBuildMetadata, RuntimeConfig } from './config'
 import type { RuntimeProvenance } from './contracts'
-import { CycleOperationsCondition, CycleOperationsReason } from './cycle-observability'
+import {
+  CycleOperationsCondition,
+  CycleOperationsReason,
+  MonthEndCadenceCondition,
+  MonthEndCadenceReason,
+  projectAutonomousCycleCadenceObservation,
+  retainedAutonomousCycleCadenceDecision,
+  type AutonomousCycleCadenceFreshness,
+} from './cycle-observability'
 import { CycleState, CycleTerminalReason } from './cycle'
 import type { DatabaseError, EvidenceStoreService } from './db/evidence-store'
 import type { OperationalError } from './errors'
@@ -128,21 +136,48 @@ const publicDependencies = (state: RuntimeState) => ({
   },
 })
 
+const autonomousCycleCadenceFreshness = (state: RuntimeState): AutonomousCycleCadenceFreshness => {
+  const dependency = state.health.dependencies.cycleRunner
+  if (dependency.status === 'AVAILABLE') return 'AVAILABLE'
+  return dependency.error?.startsWith('autonomous cycle loop has not completed a successful pass for ') === true
+    ? 'STALE'
+    : 'UNAVAILABLE'
+}
+
+const autonomousCycleCadenceObservation = (state: RuntimeState) => {
+  const lastPass = state.autonomousCycleLoop.lastPass
+  const cadenceDecision = retainedAutonomousCycleCadenceDecision(lastPass)
+  return projectAutonomousCycleCadenceObservation({
+    configured: state.autonomousCycleLoop.configured,
+    lastPassResult: lastPass?.result ?? null,
+    lastPassOutcome: lastPass?.result === 'SUCCESS' ? lastPass.outcome : null,
+    freshness: autonomousCycleCadenceFreshness(state),
+    ...(cadenceDecision === undefined ? {} : { cadenceDecision }),
+  })
+}
+
 const publicAutonomousCycleLoop = (state: RuntimeState) => {
   const lastPass = state.autonomousCycleLoop.lastPass
   return {
     configured: state.autonomousCycleLoop.configured,
     startedAt: state.autonomousCycleLoop.startedAt,
+    cadence: autonomousCycleCadenceObservation(state),
     lastPass:
-      lastPass === null || lastPass.result === 'SUCCESS'
-        ? lastPass
-        : {
-            result: lastPass.result,
-            observedAt: lastPass.observedAt,
-            operation: lastPass.operation,
-            failure: lastPass.failure,
-            reasonCode: 'AUTONOMOUS_CYCLE_PASS_FAILED',
-          },
+      lastPass === null
+        ? null
+        : lastPass.result === 'SUCCESS'
+          ? {
+              result: lastPass.result,
+              observedAt: lastPass.observedAt,
+              outcome: lastPass.outcome,
+            }
+          : {
+              result: lastPass.result,
+              observedAt: lastPass.observedAt,
+              operation: lastPass.operation,
+              failure: lastPass.failure,
+              reasonCode: 'AUTONOMOUS_CYCLE_PASS_FAILED',
+            },
   } as const
 }
 
@@ -465,6 +500,10 @@ export const renderPrometheusMetrics = (
     cycleObservationAvailable === false ? 'unknown' : (state.cycle.last?.terminalReason?.toLowerCase() ?? 'none')
   const loopResults = ['unknown', 'success', 'failure'] as const
   const loopResult = state.autonomousCycleLoop.lastPass?.result.toLowerCase() ?? 'unknown'
+  const cadence = autonomousCycleCadenceObservation(state)
+  const cadenceConditions = Object.values(MonthEndCadenceCondition)
+  const cadenceReasons = Object.values(MonthEndCadenceReason)
+  const nextEligibilityStatuses = ['proven', 'unknown'] as const
   const loopHealthy =
     state.autonomousCycleLoop.configured &&
     state.health.dependencies.cycleRunner.status === 'AVAILABLE' &&
@@ -548,6 +587,24 @@ export const renderPrometheusMetrics = (
           '# TYPE bayn_autonomous_cycle_loop_last_pass_age_seconds gauge',
           `bayn_autonomous_cycle_loop_last_pass_age_seconds ${prometheusNumber((loopLastPassAgeMs ?? 0) / 1_000)}`,
         ]),
+    '# HELP bayn_autonomous_cycle_cadence_condition Exact bounded month-end cadence interpretation of the latest pass.',
+    '# TYPE bayn_autonomous_cycle_cadence_condition gauge',
+    ...cadenceConditions.map(
+      (condition) =>
+        `bayn_autonomous_cycle_cadence_condition{condition="${condition.toLowerCase()}"} ${cadence.condition === condition ? 1 : 0}`,
+    ),
+    '# HELP bayn_autonomous_cycle_cadence_reason Stable bounded reason for the latest cadence interpretation.',
+    '# TYPE bayn_autonomous_cycle_cadence_reason gauge',
+    ...cadenceReasons.map(
+      (reason) =>
+        `bayn_autonomous_cycle_cadence_reason{reason="${reason.toLowerCase()}"} ${cadence.reason === reason ? 1 : 0}`,
+    ),
+    '# HELP bayn_autonomous_cycle_next_eligibility Whether current retained evidence proves the next eligible session.',
+    '# TYPE bayn_autonomous_cycle_next_eligibility gauge',
+    ...nextEligibilityStatuses.map(
+      (status) =>
+        `bayn_autonomous_cycle_next_eligibility{status="${status}"} ${cadence.nextEligibility.status.toLowerCase() === status ? 1 : 0}`,
+    ),
     ...(cycleObservationAvailable
       ? [
           '# HELP bayn_mutation_events_total Durable broker mutation event count.',

--- a/services/bayn/src/observe-composition.ts
+++ b/services/bayn/src/observe-composition.ts
@@ -24,6 +24,7 @@ import {
   type CycleRunResult,
 } from './cycle-runner'
 import { validateCycleLoopInterval } from './cycle-runner/decisions'
+import { retainAutonomousCyclePassObservation } from './cycle-runner/pass-decisions'
 import { CycleNotDueReconciliationError, type ReconciliationCadenceState } from './cycle-runner/model'
 import { CycleStore } from './db/cycle-store'
 import {
@@ -630,20 +631,7 @@ export const buildMutationShadowCycleDecision = <R>(
 const observePass = (
   recordPass: Parameters<AutonomousCycleStartup>[0]['recordPass'],
   observation: CyclePassObservation,
-) =>
-  observation.outcome === 'SUCCEEDED'
-    ? recordPass({
-        result: 'SUCCESS',
-        observedAt: observation.observedAt,
-        outcome: observation.result.outcome,
-      })
-    : recordPass({
-        result: 'FAILURE',
-        observedAt: observation.observedAt,
-        operation: observation.error.operation,
-        failure: observation.error.failure,
-        message: observation.error.message,
-      })
+) => recordPass(retainAutonomousCyclePassObservation(observation))
 
 export type ObserveAutonomousCycleInput = {
   readonly accountId: string


### PR DESCRIPTION
## Summary

- add a pure total month-end cadence projection from already-read signal and execution session facts
- expose bounded expected-wait, stalled, and next-eligibility evidence through `/v1/status`, Prometheus metrics, and structured cycle-pass logs
- preserve the existing scheduler and OBSERVE/read-only capability while covering same-month, transition, holiday/weekend, malformed-evidence, and stalled-loop cases

## Related Issues

PROOMPT-384 (Linear)

## Testing

- `bun test services/bayn/src/cycle-observability.test.ts services/bayn/src/cycle-runner/pass-decisions-observability.test.ts services/bayn/src/http.test.ts` — 44 passed, 0 failed
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint` — 0 errors; existing Candidate 17 warnings only
- `bun run --filter @proompteng/bayn lint:oxlint:type` — 0 errors; existing Candidate 17 warnings only
- `bun run --filter @proompteng/bayn lint:effect` — 438 files, 0 findings
- `bun run --filter @proompteng/bayn build`
- `bun run --filter @proompteng/bayn test` — 1,063 passed, 138 PostgreSQL-gated skips, 0 failed
- `bun run --filter @proompteng/bayn test:postgres` — local command exited 0 but skipped because `BAYN_TEST_POSTGRES_URL` is unavailable; the required hosted `postgres-integration` PR check supplies PostgreSQL 18

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable and Breaking Changes is filled in.
- [x] No documentation or release-note change is required; rollout and live proof remain tracked in PROOMPT-384.
