### PR TITLE
feat(bayn): measure forward execution quality and capacity

### DIFF
--- a/services/bayn/src/forward-performance/domain.test.ts
+++ b/services/bayn/src/forward-performance/domain.test.ts
@@ -3,8 +3,14 @@ import assert from 'node:assert/strict'
 import { describe, expect, test } from 'bun:test'
 import { Result } from 'effect'
 
+import { canonicalHashV1 } from '../hash'
 import { makeForwardPerformanceReceipt } from './domain'
-import type { ForwardPerformanceEvidenceInput, ForwardPerformanceReceipt } from './model'
+import type {
+  ForwardPerformanceEvidenceInput,
+  ForwardPerformanceExecutionEvidence,
+  ForwardPerformanceMarketVolumeEvidence,
+  ForwardPerformanceReceipt,
+} from './model'
 
 const hash = (character: string): string => character.repeat(64)
 
@@ -29,8 +35,14 @@ const transaction = (
   overrides: Partial<ForwardPerformanceEvidenceInput['transactions'][number]> = {},
 ) => ({
   transactionId: hash(name),
+  brokerEventId: hash('b'),
+  intentId: hash('c'),
   cycleId: hash('a'),
+  symbol: 'NVDA',
   side: 'SELL' as const,
+  quantityMicros: '1000000',
+  priceMicros: '109000000',
+  notionalMicros: '109000000',
   feeMicros,
   realizedPnlMicros,
   occurredAt: '2026-07-20T20:00:00.000Z',
@@ -113,6 +125,146 @@ const input = (overrides: Partial<ForwardPerformanceEvidenceInput> = {}): Forwar
   cashYieldEvidenceRequired: overrides.cashYieldEvidenceRequired ?? false,
 })
 
+const exactExecutionEvidence = (reverse = false) => {
+  const fills = [
+    {
+      brokerEventId: hash('b'),
+      fillId: 'fill-1',
+      brokerOrderId: 'broker-order-1',
+      clientOrderId: 'client-order-1',
+      intentId: hash('c'),
+      accountId: 'paper-account-1',
+      symbol: 'NVDA',
+      side: 'SELL' as const,
+      quantityMicros: '400000',
+      priceMicros: '109000000',
+      feeMicros: '10',
+      sourceTimestamp: '2026-07-20T20:00:00.000000000Z',
+      occurredAt: '2026-07-20T20:00:00.000Z',
+      observedAt: '2026-07-20T20:00:00.100Z',
+    },
+    {
+      brokerEventId: hash('d'),
+      fillId: 'fill-2',
+      brokerOrderId: 'broker-order-1',
+      clientOrderId: 'client-order-1',
+      intentId: hash('c'),
+      accountId: 'paper-account-1',
+      symbol: 'NVDA',
+      side: 'SELL' as const,
+      quantityMicros: '600000',
+      priceMicros: '108000000',
+      feeMicros: '10',
+      sourceTimestamp: '2026-07-20T20:00:01.000000000Z',
+      occurredAt: '2026-07-20T20:00:01.000Z',
+      observedAt: '2026-07-20T20:00:01.100Z',
+    },
+  ]
+  return [
+    {
+      cycleId: hash('a'),
+      decisionDocumentHash: hash('8'),
+      decisionHash: hash('e'),
+      decisionCreatedAt: '2026-07-20T13:00:00.000Z',
+      intentId: hash('c'),
+      accountId: 'paper-account-1',
+      symbol: 'NVDA',
+      side: 'SELL' as const,
+      plannedQuantityMicros: '1000000',
+      referencePriceMicros: '110000000',
+      intent: {
+        intentId: hash('c'),
+        accountId: 'paper-account-1',
+        clientOrderId: 'client-order-1',
+        cycleId: hash('a'),
+        decisionHash: hash('e'),
+        symbol: 'NVDA',
+        side: 'SELL' as const,
+        quantityMicros: '1000000',
+        terminalOutcome: 'FILLED' as const,
+        createdAt: '2026-07-20T13:00:00.000Z',
+        updatedAt: '2026-07-20T20:00:02.000Z',
+      },
+      terminalOrder: {
+        eventId: hash('f'),
+        brokerOrderId: 'broker-order-1',
+        clientOrderId: 'client-order-1',
+        intentId: hash('c'),
+        accountId: 'paper-account-1',
+        symbol: 'NVDA',
+        side: 'SELL' as const,
+        quantityMicros: '1000000',
+        filledQuantityMicros: '1000000',
+        status: 'FILLED' as const,
+        occurredAt: '2026-07-20T20:00:02.000Z',
+        observedAt: '2026-07-20T20:00:02.100Z',
+      },
+      fills: reverse ? fills.toReversed() : fills,
+    },
+  ]
+}
+
+const exactMarketVolumeEvidence = (): readonly ForwardPerformanceMarketVolumeEvidence[] => {
+  const material: Omit<ForwardPerformanceMarketVolumeEvidence, 'contentHash'> = {
+    schemaVersion: 'bayn.forward-performance-market-volume-evidence.v1' as const,
+    cycleId: hash('a'),
+    decisionSnapshotId: hash('5'),
+    decisionSnapshotAsOfSession: '2026-07-19',
+    symbol: 'NVDA',
+    executionSessionDate: '2026-07-20',
+    windowOpenedAt: '2026-07-20T13:30:00.000Z',
+    windowClosedAt: '2026-07-20T21:00:00.000Z',
+    evidenceCutoffAt: '2026-07-20T21:10:00.000Z',
+    quantityMicros: '100000000',
+    closePriceMicros: '103000000',
+    snapshotId: hash('1'),
+    manifestContentHash: hash('2'),
+    barsContentHash: hash('3'),
+    finalizedAt: '2026-07-20T21:05:00.000Z',
+    universeId: 'cross-asset-taa-v1' as const,
+    universeSymbolHash: hash('4'),
+    requestedStart: '2018-01-02',
+    evaluationStart: '2019-01-02',
+    calendarVersion: 'fixture-calendar-v1',
+    source: 'alpaca' as const,
+    sourceFeed: 'sip' as const,
+    adjustment: 'all' as const,
+  }
+  return [{ ...material, contentHash: canonicalHashV1(material) }]
+}
+
+const terminalReferencePriceFor = (
+  volume: ForwardPerformanceMarketVolumeEvidence,
+): NonNullable<ForwardPerformanceExecutionEvidence['terminalReferencePrice']> => {
+  const material = {
+    schemaVersion: 'bayn.forward-performance-terminal-reference-price.v1' as const,
+    cycleId: volume.cycleId,
+    symbol: volume.symbol,
+    executionSessionDate: volume.executionSessionDate,
+    priceMicros: volume.closePriceMicros,
+    observedAt: volume.finalizedAt,
+    sourceEvidenceHash: volume.contentHash,
+  }
+  return { ...material, contentHash: canonicalHashV1(material) }
+}
+
+const exactTransactions = () => [
+  transaction('1', '40', '10', {
+    brokerEventId: hash('b'),
+    quantityMicros: '400000',
+    priceMicros: '109000000',
+    notionalMicros: '43600000',
+    occurredAt: '2026-07-20T20:00:00.000Z',
+  }),
+  transaction('2', '60', '10', {
+    brokerEventId: hash('d'),
+    quantityMicros: '600000',
+    priceMicros: '108000000',
+    notionalMicros: '64800000',
+    occurredAt: '2026-07-20T20:00:01.000Z',
+  }),
+]
+
 const success = (value: Result.Result<ForwardPerformanceReceipt, unknown>): ForwardPerformanceReceipt => {
   assert(Result.isSuccess(value), 'forward-performance fixture must produce a receipt')
   return value.success
@@ -133,6 +285,632 @@ describe('forward performance domain', () => {
         decimal: '0.080000000000',
       },
     })
+  })
+
+  test('keeps profitability independent while execution quality and capacity lack immutable source evidence', () => {
+    const receipt = success(makeForwardPerformanceReceipt(input()))
+
+    expect(receipt.profitability).toBe('PROFITABLE')
+    expect(receipt.executionQuality).toEqual({
+      status: 'UNDETERMINED',
+      reasonCodes: ['PLANNED_DECISION_EVIDENCE_GAP'],
+      evidenceHash: null,
+      implementationShortfall: null,
+    })
+    expect(receipt.observedCapacity).toEqual({
+      status: 'UNDETERMINED',
+      reasonCodes: ['EXECUTION_QUALITY_UNDETERMINED', 'MARKET_VOLUME_EVIDENCE_GAP'],
+      evidenceHash: null,
+      observations: [],
+      boundedObservedReferenceNotionalMicros: null,
+      boundedObservedExecutedNotionalMicros: null,
+      maximumParticipationRate: null,
+    })
+  })
+
+  test('measures Perold implementation shortfall and bounded observed participation from exact immutable evidence', () => {
+    const transactions = exactTransactions()
+    const evidence = {
+      transactions,
+      executionEvidence: exactExecutionEvidence(),
+      marketVolumeEvidence: exactMarketVolumeEvidence(),
+    }
+    const first = success(makeForwardPerformanceReceipt(input(evidence)))
+    const second = success(
+      makeForwardPerformanceReceipt(
+        input({
+          ...evidence,
+          transactions: transactions.toReversed(),
+          executionEvidence: exactExecutionEvidence(true),
+        }),
+      ),
+    )
+
+    expect(first).toEqual(second)
+    expect(first.profitability).toBe('PROFITABLE')
+    expect(first.executionQuality).toMatchObject({
+      status: 'MEASURED',
+      reasonCodes: [],
+      implementationShortfall: {
+        plannedOrderCount: 1,
+        fillCount: 2,
+        plannedQuantityMicros: '1000000',
+        filledQuantityMicros: '1000000',
+        unfilledQuantityMicros: '0',
+        plannedReferenceNotionalMicros: '110000000',
+        executedNotionalMicros: '108400000',
+        executionPriceShortfallMicros: '1600000',
+        opportunityShortfallMicros: '0',
+        explicitCostsMicros: '20',
+        totalImplementationShortfallMicros: '1600020',
+        implementationShortfallRate: {
+          numeratorMicros: '1600020',
+          denominatorMicros: '110000000',
+          decimal: '0.014545636364',
+        },
+        firstDecisionAt: '2026-07-20T13:00:00.000Z',
+        firstFillAt: '2026-07-20T20:00:00.000Z',
+        lastFillAt: '2026-07-20T20:00:01.000Z',
+        lastTerminalOrderObservedAt: '2026-07-20T20:00:02.100Z',
+      },
+    })
+    expect(first.executionQuality.evidenceHash).toMatch(/^[a-f0-9]{64}$/)
+    expect(first.observedCapacity).toMatchObject({
+      status: 'MEASURED',
+      reasonCodes: [],
+      boundedObservedReferenceNotionalMicros: '110000000',
+      boundedObservedExecutedNotionalMicros: '108400000',
+      maximumParticipationRate: {
+        numeratorQuantityMicros: '1000000',
+        denominatorQuantityMicros: '100000000',
+        decimal: '0.010000000000',
+      },
+      observations: [
+        {
+          cycleId: hash('a'),
+          symbol: 'NVDA',
+          windowOpenedAt: '2026-07-20T13:30:00.000Z',
+          windowClosedAt: '2026-07-20T21:00:00.000Z',
+          filledQuantityMicros: '1000000',
+          marketVolumeQuantityMicros: '100000000',
+          participationRate: {
+            numeratorQuantityMicros: '1000000',
+            denominatorQuantityMicros: '100000000',
+            decimal: '0.010000000000',
+          },
+        },
+      ],
+    })
+    expect(first.observedCapacity.evidenceHash).toMatch(/^[a-f0-9]{64}$/)
+  })
+
+  test('orders terminal fills by broker occurrence even when fill observation completes after order observation', () => {
+    const [execution] = exactExecutionEvidence()
+    if (execution === undefined) throw new Error('execution fixture missing')
+    const receipt = success(
+      makeForwardPerformanceReceipt(
+        input({
+          transactions: exactTransactions(),
+          executionEvidence: [
+            {
+              ...execution,
+              fills: execution.fills.map((fill, index) => ({
+                ...fill,
+                observedAt: `2026-07-20T20:00:0${index + 3}.100Z`,
+              })),
+            },
+          ],
+          marketVolumeEvidence: exactMarketVolumeEvidence(),
+        }),
+      ),
+    )
+
+    expect(receipt.executionQuality.status).toBe('MEASURED')
+    expect(receipt.executionQuality.reasonCodes).toEqual([])
+    expect(receipt.observedCapacity.status).toBe('MEASURED')
+  })
+
+  test('keeps implementation shortfall undetermined when the immutable decision reference price is absent', () => {
+    const execution = exactExecutionEvidence().map(
+      ({ referencePriceMicros: _referencePriceMicros, ...evidence }) => evidence,
+    )
+    const receipt = success(
+      makeForwardPerformanceReceipt(
+        input({
+          transactions: exactTransactions(),
+          executionEvidence: execution,
+          marketVolumeEvidence: exactMarketVolumeEvidence(),
+        }),
+      ),
+    )
+
+    expect(receipt.profitability).toBe('PROFITABLE')
+    expect(receipt.executionQuality.status).toBe('UNDETERMINED')
+    expect(receipt.executionQuality.reasonCodes).toContain('REFERENCE_PRICE_EVIDENCE_GAP')
+    expect(receipt.executionQuality.implementationShortfall).toBeNull()
+    expect(receipt.observedCapacity).toMatchObject({
+      status: 'UNDETERMINED',
+      reasonCodes: ['EXECUTION_QUALITY_UNDETERMINED'],
+      observations: [],
+    })
+  })
+
+  test('fails execution measurement closed when a terminal fill lacks accounting and quantity binding', () => {
+    const [execution] = exactExecutionEvidence()
+    if (execution === undefined) throw new Error('execution fixture missing')
+    const receipt = success(
+      makeForwardPerformanceReceipt(
+        input({
+          transactions: exactTransactions(),
+          executionEvidence: [{ ...execution, fills: execution.fills.slice(0, 1) }],
+        }),
+      ),
+    )
+
+    expect(receipt.executionQuality.status).toBe('UNDETERMINED')
+    expect(receipt.executionQuality.reasonCodes).toEqual(
+      expect.arrayContaining(['ACCOUNTING_FILL_BINDING_GAP', 'FILL_QUANTITY_MISMATCH']),
+    )
+    expect(receipt.executionQuality.implementationShortfall).toBeNull()
+  })
+
+  test('measures shortfall but leaves observed capacity undetermined without market volume', () => {
+    const receipt = success(
+      makeForwardPerformanceReceipt(
+        input({ transactions: exactTransactions(), executionEvidence: exactExecutionEvidence() }),
+      ),
+    )
+
+    expect(receipt.executionQuality.status).toBe('MEASURED')
+    expect(receipt.observedCapacity).toEqual({
+      status: 'UNDETERMINED',
+      reasonCodes: ['MARKET_VOLUME_EVIDENCE_GAP'],
+      evidenceHash: null,
+      observations: [],
+      boundedObservedReferenceNotionalMicros: null,
+      boundedObservedExecutedNotionalMicros: null,
+      maximumParticipationRate: null,
+    })
+  })
+
+  test('includes adverse unfilled opportunity cost only with an immutable terminal reference price', () => {
+    const [marketVolume] = exactMarketVolumeEvidence()
+    if (marketVolume === undefined) throw new Error('market-volume fixture missing')
+    const executionEvidence = [
+      {
+        cycleId: hash('a'),
+        decisionDocumentHash: hash('8'),
+        decisionHash: hash('e'),
+        decisionCreatedAt: '2026-07-20T13:00:00.000Z',
+        intentId: hash('c'),
+        accountId: 'paper-account-1',
+        symbol: 'NVDA',
+        side: 'BUY' as const,
+        plannedQuantityMicros: '1000000',
+        referencePriceMicros: '100000000',
+        intent: {
+          intentId: hash('c'),
+          accountId: 'paper-account-1',
+          clientOrderId: 'client-order-1',
+          cycleId: hash('a'),
+          decisionHash: hash('e'),
+          symbol: 'NVDA',
+          side: 'BUY' as const,
+          quantityMicros: '1000000',
+          terminalOutcome: 'CANCELED' as const,
+          createdAt: '2026-07-20T13:00:00.000Z',
+          updatedAt: '2026-07-20T20:00:02.000Z',
+        },
+        terminalOrder: {
+          eventId: hash('f'),
+          brokerOrderId: 'broker-order-1',
+          clientOrderId: 'client-order-1',
+          intentId: hash('c'),
+          accountId: 'paper-account-1',
+          symbol: 'NVDA',
+          side: 'BUY' as const,
+          quantityMicros: '1000000',
+          filledQuantityMicros: '400000',
+          status: 'CANCELED' as const,
+          occurredAt: '2026-07-20T20:00:02.000Z',
+          observedAt: '2026-07-20T21:06:00.000Z',
+        },
+        fills: [
+          {
+            brokerEventId: hash('b'),
+            fillId: 'fill-1',
+            brokerOrderId: 'broker-order-1',
+            clientOrderId: 'client-order-1',
+            intentId: hash('c'),
+            accountId: 'paper-account-1',
+            symbol: 'NVDA',
+            side: 'BUY' as const,
+            quantityMicros: '400000',
+            priceMicros: '101000000',
+            feeMicros: '10',
+            sourceTimestamp: '2026-07-20T20:00:00.000000000Z',
+            occurredAt: '2026-07-20T20:00:00.000Z',
+            observedAt: '2026-07-20T20:00:00.100Z',
+          },
+        ],
+        terminalReferencePrice: terminalReferencePriceFor(marketVolume),
+      },
+    ]
+    const transactions = [
+      transaction('1', '0', '10', {
+        brokerEventId: hash('b'),
+        side: 'BUY',
+        quantityMicros: '400000',
+        priceMicros: '101000000',
+        notionalMicros: '40400000',
+        occurredAt: '2026-07-20T20:00:00.000Z',
+      }),
+    ]
+    const receipt = success(
+      makeForwardPerformanceReceipt(
+        input({
+          transactions,
+          executionEvidence,
+          marketVolumeEvidence: [marketVolume],
+          ledgerTotals: {
+            realizedGainMicros: '0',
+            realizedLossMicros: '0',
+            brokerExecutionFeesMicros: '10',
+            otherChargedCostsMicros: '0',
+            cashYieldMicros: '0',
+          },
+        }),
+      ),
+    )
+
+    expect(receipt.executionQuality).toMatchObject({
+      status: 'MEASURED',
+      implementationShortfall: {
+        filledQuantityMicros: '400000',
+        unfilledQuantityMicros: '600000',
+        executionPriceShortfallMicros: '400000',
+        opportunityShortfallMicros: '1800000',
+        explicitCostsMicros: '10',
+        totalImplementationShortfallMicros: '2200010',
+      },
+    })
+  })
+
+  test('measures terminal zero-fill opportunity shortfall without requiring fabricated fills', () => {
+    const [marketVolume] = exactMarketVolumeEvidence()
+    const [filledExecution] = exactExecutionEvidence()
+    if (marketVolume === undefined || filledExecution === undefined) throw new Error('execution fixture missing')
+    const zeroFillIntentId = hash('0')
+    const zeroFillExecution: ForwardPerformanceExecutionEvidence = {
+      cycleId: hash('a'),
+      decisionDocumentHash: hash('8'),
+      decisionHash: hash('e'),
+      decisionCreatedAt: '2026-07-20T13:00:00.000Z',
+      intentId: zeroFillIntentId,
+      accountId: 'paper-account-1',
+      symbol: 'NVDA',
+      side: 'BUY',
+      plannedQuantityMicros: '1000000',
+      referencePriceMicros: '100000000',
+      intent: {
+        intentId: zeroFillIntentId,
+        accountId: 'paper-account-1',
+        clientOrderId: 'zero-fill-client-order',
+        cycleId: hash('a'),
+        decisionHash: hash('e'),
+        symbol: 'NVDA',
+        side: 'BUY',
+        quantityMicros: '1000000',
+        terminalOutcome: 'CANCELED',
+        createdAt: '2026-07-20T13:00:00.000Z',
+        updatedAt: '2026-07-20T20:00:03.000Z',
+      },
+      terminalOrder: {
+        eventId: hash('9'),
+        brokerOrderId: 'zero-fill-broker-order',
+        clientOrderId: 'zero-fill-client-order',
+        intentId: zeroFillIntentId,
+        accountId: 'paper-account-1',
+        symbol: 'NVDA',
+        side: 'BUY',
+        quantityMicros: '1000000',
+        filledQuantityMicros: '0',
+        status: 'CANCELED',
+        occurredAt: '2026-07-20T20:00:03.000Z',
+        observedAt: '2026-07-20T20:00:03.100Z',
+      },
+      fills: [],
+      terminalReferencePrice: terminalReferencePriceFor(marketVolume),
+    }
+    const receipt = success(
+      makeForwardPerformanceReceipt(
+        input({
+          transactions: exactTransactions(),
+          executionEvidence: [filledExecution, zeroFillExecution],
+          marketVolumeEvidence: [marketVolume],
+        }),
+      ),
+    )
+
+    expect(receipt.executionQuality.reasonCodes).not.toContain('FILL_EVIDENCE_GAP')
+    expect(receipt.executionQuality).toMatchObject({
+      status: 'MEASURED',
+      implementationShortfall: {
+        plannedOrderCount: 2,
+        fillCount: 2,
+        plannedQuantityMicros: '2000000',
+        filledQuantityMicros: '1000000',
+        unfilledQuantityMicros: '1000000',
+        opportunityShortfallMicros: '3000000',
+      },
+    })
+    expect(receipt.observedCapacity).toMatchObject({
+      status: 'MEASURED',
+      observations: [
+        {
+          cycleId: hash('a'),
+          symbol: 'NVDA',
+          filledQuantityMicros: '1000000',
+          marketVolumeQuantityMicros: '100000000',
+        },
+      ],
+    })
+  })
+
+  test('measures an all-zero terminal plan while profitability remains unproven', () => {
+    const [marketVolume] = exactMarketVolumeEvidence()
+    if (marketVolume === undefined) throw new Error('market-volume fixture missing')
+    const intentId = hash('0')
+    const zeroFillExecution: ForwardPerformanceExecutionEvidence = {
+      cycleId: hash('a'),
+      decisionDocumentHash: hash('8'),
+      decisionHash: hash('e'),
+      decisionCreatedAt: '2026-07-20T13:00:00.000Z',
+      intentId,
+      accountId: 'paper-account-1',
+      symbol: 'NVDA',
+      side: 'BUY',
+      plannedQuantityMicros: '1000000',
+      referencePriceMicros: '100000000',
+      intent: {
+        intentId,
+        accountId: 'paper-account-1',
+        clientOrderId: 'all-zero-client-order',
+        cycleId: hash('a'),
+        decisionHash: hash('e'),
+        symbol: 'NVDA',
+        side: 'BUY',
+        quantityMicros: '1000000',
+        terminalOutcome: 'CANCELED',
+        createdAt: '2026-07-20T13:00:00.000Z',
+        updatedAt: '2026-07-20T20:00:03.000Z',
+      },
+      terminalOrder: {
+        eventId: hash('9'),
+        brokerOrderId: 'all-zero-broker-order',
+        clientOrderId: 'all-zero-client-order',
+        intentId,
+        accountId: 'paper-account-1',
+        symbol: 'NVDA',
+        side: 'BUY',
+        quantityMicros: '1000000',
+        filledQuantityMicros: '0',
+        status: 'CANCELED',
+        occurredAt: '2026-07-20T20:00:03.000Z',
+        observedAt: '2026-07-20T20:00:03.100Z',
+      },
+      fills: [],
+      terminalReferencePrice: terminalReferencePriceFor(marketVolume),
+    }
+    const receipt = success(
+      makeForwardPerformanceReceipt(
+        input({
+          transactions: [],
+          executionEvidence: [zeroFillExecution],
+          marketVolumeEvidence: [marketVolume],
+          ledgerTotals: {
+            realizedGainMicros: '0',
+            realizedLossMicros: '0',
+            brokerExecutionFeesMicros: '0',
+            otherChargedCostsMicros: '0',
+            cashYieldMicros: '0',
+          },
+        }),
+      ),
+    )
+
+    expect(receipt.evidence.reasonCodes).toContain('ZERO_COMPLETED_EXECUTIONS')
+    expect(receipt.profitability).toBe('UNDETERMINED')
+    expect(receipt.executionQuality).toMatchObject({
+      status: 'MEASURED',
+      reasonCodes: [],
+      implementationShortfall: {
+        plannedOrderCount: 1,
+        fillCount: 0,
+        plannedQuantityMicros: '1000000',
+        filledQuantityMicros: '0',
+        unfilledQuantityMicros: '1000000',
+        opportunityShortfallMicros: '3000000',
+        totalImplementationShortfallMicros: '3000000',
+        firstFillAt: null,
+        lastFillAt: null,
+      },
+    })
+    expect(receipt.observedCapacity).toMatchObject({
+      status: 'MEASURED',
+      observations: [
+        {
+          cycleId: hash('a'),
+          symbol: 'NVDA',
+          filledQuantityMicros: '0',
+          marketVolumeQuantityMicros: '100000000',
+          participationRate: {
+            numeratorQuantityMicros: '0',
+            denominatorQuantityMicros: '100000000',
+            decimal: '0.000000000000',
+          },
+        },
+      ],
+      maximumParticipationRate: {
+        numeratorQuantityMicros: '0',
+        denominatorQuantityMicros: '100000000',
+        decimal: '0.000000000000',
+      },
+    })
+  })
+
+  test('measures a risk-blocked plan without requiring broker-order evidence', () => {
+    const [marketVolume] = exactMarketVolumeEvidence()
+    if (marketVolume === undefined) throw new Error('market-volume fixture missing')
+    const intentId = hash('0')
+    const blockedExecution: ForwardPerformanceExecutionEvidence = {
+      cycleId: hash('a'),
+      decisionDocumentHash: hash('8'),
+      decisionHash: hash('e'),
+      decisionCreatedAt: '2026-07-20T13:00:00.000Z',
+      intentId,
+      accountId: 'paper-account-1',
+      symbol: 'NVDA',
+      side: 'BUY',
+      plannedQuantityMicros: '1000000',
+      referencePriceMicros: '100000000',
+      intent: {
+        intentId,
+        accountId: 'paper-account-1',
+        clientOrderId: 'blocked-client-order',
+        cycleId: hash('a'),
+        decisionHash: hash('e'),
+        symbol: 'NVDA',
+        side: 'BUY',
+        quantityMicros: '1000000',
+        terminalOutcome: 'BLOCKED',
+        createdAt: '2026-07-20T13:00:00.000Z',
+        updatedAt: '2026-07-20T13:05:00.000Z',
+      },
+      fills: [],
+      terminalReferencePrice: terminalReferencePriceFor(marketVolume),
+    }
+    const receipt = success(
+      makeForwardPerformanceReceipt(
+        input({
+          transactions: [],
+          executionEvidence: [blockedExecution],
+          marketVolumeEvidence: [marketVolume],
+          ledgerTotals: {
+            realizedGainMicros: '0',
+            realizedLossMicros: '0',
+            brokerExecutionFeesMicros: '0',
+            otherChargedCostsMicros: '0',
+            cashYieldMicros: '0',
+          },
+        }),
+      ),
+    )
+
+    expect(receipt.profitability).toBe('UNDETERMINED')
+    expect(receipt.executionQuality.reasonCodes).not.toEqual(
+      expect.arrayContaining(['TERMINAL_ORDER_EVIDENCE_GAP', 'FILL_TIMESTAMP_GAP', 'TERMINAL_PRICE_EVIDENCE_GAP']),
+    )
+    expect(receipt.executionQuality).toMatchObject({
+      status: 'MEASURED',
+      implementationShortfall: {
+        fillCount: 0,
+        filledQuantityMicros: '0',
+        unfilledQuantityMicros: '1000000',
+        opportunityShortfallMicros: '3000000',
+        firstFillAt: null,
+        lastFillAt: null,
+        lastTerminalOrderObservedAt: '2026-07-20T13:05:00.000Z',
+      },
+    })
+    expect(receipt.observedCapacity).toMatchObject({
+      status: 'MEASURED',
+      observations: [
+        {
+          cycleId: hash('a'),
+          symbol: 'NVDA',
+          filledQuantityMicros: '0',
+          participationRate: { decimal: '0.000000000000' },
+        },
+      ],
+    })
+  })
+
+  test('does not estimate opportunity cost when the terminal reference price is absent', () => {
+    const [execution] = exactExecutionEvidence()
+    if (execution === undefined || execution.terminalOrder === undefined || execution.intent === undefined) {
+      throw new Error('execution fixture missing')
+    }
+    const receipt = success(
+      makeForwardPerformanceReceipt(
+        input({
+          transactions: [exactTransactions()[0]!],
+          executionEvidence: [
+            {
+              ...execution,
+              intent: { ...execution.intent, terminalOutcome: 'CANCELED' },
+              terminalOrder: {
+                ...execution.terminalOrder,
+                status: 'CANCELED',
+                filledQuantityMicros: '400000',
+              },
+              fills: execution.fills.slice(0, 1),
+            },
+          ],
+          ledgerTotals: {
+            realizedGainMicros: '40',
+            realizedLossMicros: '0',
+            brokerExecutionFeesMicros: '10',
+            otherChargedCostsMicros: '0',
+            cashYieldMicros: '0',
+          },
+        }),
+      ),
+    )
+
+    expect(receipt.executionQuality.status).toBe('UNDETERMINED')
+    expect(receipt.executionQuality.reasonCodes).toContain('TERMINAL_PRICE_EVIDENCE_GAP')
+    expect(receipt.executionQuality.implementationShortfall).toBeNull()
+  })
+
+  test('rejects market-volume evidence that does not cover the fill-to-terminal interval', () => {
+    const [volume] = exactMarketVolumeEvidence()
+    if (volume === undefined) throw new Error('volume fixture missing')
+    const { contentHash: _contentHash, ...volumeMaterial } = volume
+    const driftedMaterial = { ...volumeMaterial, windowOpenedAt: '2026-07-20T20:00:00.500Z' }
+    const receipt = success(
+      makeForwardPerformanceReceipt(
+        input({
+          transactions: exactTransactions(),
+          executionEvidence: exactExecutionEvidence(),
+          marketVolumeEvidence: [{ ...driftedMaterial, contentHash: canonicalHashV1(driftedMaterial) }],
+        }),
+      ),
+    )
+
+    expect(receipt.executionQuality.status).toBe('MEASURED')
+    expect(receipt.observedCapacity.status).toBe('UNDETERMINED')
+    expect(receipt.observedCapacity.reasonCodes).toEqual(['MARKET_VOLUME_IDENTITY_DRIFT'])
+    expect(receipt.observedCapacity.observations).toEqual([])
+  })
+
+  test('rejects self-inconsistent immutable market-volume evidence', () => {
+    const [volume] = exactMarketVolumeEvidence()
+    if (volume === undefined) throw new Error('volume fixture missing')
+    const receipt = success(
+      makeForwardPerformanceReceipt(
+        input({
+          transactions: exactTransactions(),
+          executionEvidence: exactExecutionEvidence(),
+          marketVolumeEvidence: [{ ...volume, quantityMicros: '100000001' }],
+        }),
+      ),
+    )
+
+    expect(receipt.executionQuality.status).toBe('MEASURED')
+    expect(receipt.observedCapacity.status).toBe('UNDETERMINED')
+    expect(receipt.observedCapacity.reasonCodes).toEqual(['INVALID_MARKET_VOLUME_EVIDENCE'])
+    expect(receipt.observedCapacity.observations).toEqual([])
   })
 
   test('reports realized losses without using mark-to-market equity', () => {
@@ -288,6 +1066,21 @@ describe('forward performance domain', () => {
     expect(receipt.evidence.reasonCodes).toContain('ZERO_COMPLETED_EXECUTIONS')
     expect(receipt.profitability).toBe('UNDETERMINED')
     expect(receipt.counts.completedExecutionCount).toBe(0)
+    expect(receipt.executionQuality).toEqual({
+      status: 'NOT_ELIGIBLE',
+      reasonCodes: ['ZERO_COMPLETED_EXECUTIONS'],
+      evidenceHash: null,
+      implementationShortfall: null,
+    })
+    expect(receipt.observedCapacity).toEqual({
+      status: 'NOT_ELIGIBLE',
+      reasonCodes: ['ZERO_COMPLETED_EXECUTIONS'],
+      evidenceHash: null,
+      observations: [],
+      boundedObservedReferenceNotionalMicros: null,
+      boundedObservedExecutedNotionalMicros: null,
+      maximumParticipationRate: null,
+    })
   })
 
   test('missing starting capital is an evidence gap rather than malformed micros', () => {
@@ -386,8 +1179,8 @@ describe('forward performance domain', () => {
     const second = success(makeForwardPerformanceReceipt(input({ ...evidence, cycles: [cycle('a'), secondCycle] })))
 
     expect(first).toEqual(second)
-    expect(first.schemaVersion).toBe('bayn.forward-performance-receipt.v2')
-    expect(first.receiptHash).toBe('adc3d822eaec05fb862f67b4bb795fc4886260623642d6e0651eb1b80c4a9e1b')
+    expect(first.schemaVersion).toBe('bayn.forward-performance-receipt.v3')
+    expect(first.receiptHash).toBe('4c3ca795ead141e908c3d7b397937408f5b4f75b723c983a22081b05197f9c88')
     expect(first.evidence).toEqual({
       status: 'SUFFICIENT',
       reasonCodes: [],

--- a/services/bayn/src/forward-performance/domain.ts
+++ b/services/bayn/src/forward-performance/domain.ts
@@ -2,6 +2,10 @@ import { Result } from 'effect'
 
 import { canonicalHashV1Result } from '../hash'
 import {
+  makeForwardPerformanceExecutionMeasurements,
+  type ForwardPerformanceExecutionMeasurements,
+} from './execution-quality'
+import {
   FORWARD_PERFORMANCE_SCHEMA_VERSION,
   type ForwardPerformanceCycleEvidence,
   type ForwardPerformanceEvidenceInput,
@@ -17,7 +21,7 @@ const RETURN_SCALE = 10n ** BigInt(RETURN_DECIMAL_PLACES)
 
 export interface ForwardPerformanceDomainFailure {
   readonly _tag: 'ForwardPerformanceDomainFailure'
-  readonly operation: 'hash-receipt'
+  readonly operation: 'hash-execution-evidence' | 'hash-receipt'
   readonly cause: unknown
 }
 
@@ -176,7 +180,10 @@ const transactionTotalsMatch = (
   }
 }
 
-const makeMaterial = (input: ForwardPerformanceEvidenceInput): ForwardPerformanceReceiptMaterial => {
+const makeMaterial = (
+  input: ForwardPerformanceEvidenceInput,
+  measurements: ForwardPerformanceExecutionMeasurements,
+): ForwardPerformanceReceiptMaterial => {
   const reasons = new Set<ForwardPerformanceReasonCode>()
   const cycles = [...input.cycles].sort(compareCycles)
   const firstCycle = cycles[0]
@@ -350,6 +357,8 @@ const makeMaterial = (input: ForwardPerformanceEvidenceInput): ForwardPerformanc
       reasonCodes,
       cashYield: input.cashYieldEvidence ?? null,
     },
+    executionQuality: measurements.executionQuality,
+    observedCapacity: measurements.observedCapacity,
     profitability:
       !sufficient || totals === undefined
         ? 'UNDETERMINED'
@@ -361,14 +370,25 @@ const makeMaterial = (input: ForwardPerformanceEvidenceInput): ForwardPerformanc
 
 export const makeForwardPerformanceReceipt = (
   input: ForwardPerformanceEvidenceInput,
-): Result.Result<ForwardPerformanceReceipt, ForwardPerformanceDomainFailure> => {
-  const material = makeMaterial(input)
-  return Result.mapError(
-    Result.map(canonicalHashV1Result(material), (receiptHash) => ({ ...material, receiptHash })),
-    (cause): ForwardPerformanceDomainFailure => ({
-      _tag: 'ForwardPerformanceDomainFailure',
-      operation: 'hash-receipt',
-      cause,
-    }),
+): Result.Result<ForwardPerformanceReceipt, ForwardPerformanceDomainFailure> =>
+  Result.flatMap(
+    Result.mapError(
+      makeForwardPerformanceExecutionMeasurements(input),
+      (cause): ForwardPerformanceDomainFailure => ({
+        _tag: 'ForwardPerformanceDomainFailure',
+        operation: 'hash-execution-evidence',
+        cause,
+      }),
+    ),
+    (measurements) => {
+      const material = makeMaterial(input, measurements)
+      return Result.mapError(
+        Result.map(canonicalHashV1Result(material), (receiptHash) => ({ ...material, receiptHash })),
+        (cause): ForwardPerformanceDomainFailure => ({
+          _tag: 'ForwardPerformanceDomainFailure',
+          operation: 'hash-receipt',
+          cause,
+        }),
+      )
+    },
   )
-}

--- a/services/bayn/src/forward-performance/execution-quality.ts
+++ b/services/bayn/src/forward-performance/execution-quality.ts
@@ -1,0 +1,800 @@
+import { Result } from 'effect'
+
+import { canonicalHashV1Result, type CanonicalHashFailure } from '../hash'
+import type {
+  ForwardPerformanceEvidenceInput,
+  ForwardPerformanceExecutionEvidence,
+  ForwardPerformanceExecutionQualityReasonCode,
+  ForwardPerformanceObservedCapacityReasonCode,
+  ForwardPerformanceReceiptMaterial,
+  ForwardPerformanceTransactionEvidence,
+} from './model'
+
+const MICROS = 1_000_000n
+const SIGNED_MICROS_MIN = -(1n << 127n)
+const SIGNED_MICROS_MAX = (1n << 127n) - 1n
+const RATIO_DECIMAL_PLACES = 12
+const RATIO_SCALE = 10n ** BigInt(RATIO_DECIMAL_PLACES)
+const SOURCE_TIMESTAMP_PATTERN = /^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}[.][0-9]{9}Z$/
+const UTC_INSTANT_PATTERN = /^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}[.][0-9]{3}Z$/
+const SHA256_PATTERN = /^[0-9a-f]{64}$/
+
+type ExecutionQuality = ForwardPerformanceReceiptMaterial['executionQuality']
+type ObservedCapacity = ForwardPerformanceReceiptMaterial['observedCapacity']
+
+export interface ForwardPerformanceExecutionMeasurements {
+  readonly executionQuality: ExecutionQuality
+  readonly observedCapacity: ObservedCapacity
+}
+
+interface ExecutionContribution {
+  readonly cycleId: string
+  readonly symbol: string
+  readonly coverageOpenedAt: string
+  readonly terminalOrderOccurredAt: string
+  readonly preBrokerBlocked: boolean
+  readonly filledQuantity: bigint
+  readonly filledReferenceNotional: bigint
+  readonly executedNotional: bigint
+}
+
+const parseUnsigned = (value: string | undefined, positive: boolean): bigint | undefined => {
+  if (value === undefined || !/^(?:0|[1-9][0-9]*)$/.test(value)) return undefined
+  const parsed = BigInt(value)
+  if (parsed > SIGNED_MICROS_MAX || (positive && parsed === 0n)) return undefined
+  return parsed
+}
+
+const inSignedRange = (value: bigint): boolean => value >= SIGNED_MICROS_MIN && value <= SIGNED_MICROS_MAX
+
+const checkedAdd = (left: bigint, right: bigint): bigint | undefined => {
+  const value = left + right
+  return inSignedRange(value) ? value : undefined
+}
+
+const roundHalfUp = (quantity: bigint, price: bigint): bigint | undefined => {
+  const value = (quantity * price + MICROS / 2n) / MICROS
+  return inSignedRange(value) ? value : undefined
+}
+
+const validInstant = (value: string): boolean =>
+  UTC_INSTANT_PATTERN.test(value) && Number.isFinite(Date.parse(value)) && new Date(value).toISOString() === value
+
+const validIsoDate = (value: string): boolean => {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return false
+  const instant = new Date(`${value}T00:00:00.000Z`)
+  return Number.isFinite(instant.getTime()) && instant.toISOString().startsWith(`${value}T`)
+}
+
+const compareStrings = (left: string, right: string): number => (left < right ? -1 : left > right ? 1 : 0)
+
+const formatRatio = (numerator: bigint, denominator: bigint): string => {
+  const negative = numerator < 0n
+  const magnitude = negative ? -numerator : numerator
+  const scaledNumerator = magnitude * RATIO_SCALE
+  const quotient = scaledNumerator / denominator
+  const remainder = scaledNumerator % denominator
+  const rounded = remainder * 2n >= denominator ? quotient + 1n : quotient
+  const integer = rounded / RATIO_SCALE
+  const fraction = (rounded % RATIO_SCALE).toString().padStart(RATIO_DECIMAL_PLACES, '0')
+  return `${negative ? '-' : ''}${integer}.${fraction}`
+}
+
+const executionSortKey = (evidence: ForwardPerformanceExecutionEvidence): string =>
+  JSON.stringify([evidence.decisionCreatedAt, evidence.cycleId, evidence.intentId])
+
+const transactionSortKey = (transaction: ForwardPerformanceTransactionEvidence): string =>
+  JSON.stringify([transaction.occurredAt, transaction.brokerEventId ?? '', transaction.transactionId])
+
+const fillSortKey = (fill: ForwardPerformanceExecutionEvidence['fills'][number]): string =>
+  JSON.stringify([fill.sourceTimestamp, fill.fillId, fill.brokerEventId])
+
+const volumeSortKey = (volume: NonNullable<ForwardPerformanceEvidenceInput['marketVolumeEvidence']>[number]): string =>
+  JSON.stringify([volume.cycleId, volume.symbol, volume.windowOpenedAt, volume.windowClosedAt, volume.contentHash])
+
+const sourceEvidenceHash = (
+  input: ForwardPerformanceEvidenceInput,
+  executionEvidence: readonly ForwardPerformanceExecutionEvidence[],
+  transactions: readonly ForwardPerformanceTransactionEvidence[],
+): Result.Result<string, CanonicalHashFailure> =>
+  canonicalHashV1Result({
+    schemaVersion: 'bayn.forward-performance-execution-evidence.v1',
+    account: input.account,
+    reconciliation: input.reconciliation ?? null,
+    accountingReceiptsExact: input.accountingReceiptsExact,
+    ledgerExact: input.ledgerExact,
+    missingLedgerAccountCount: input.missingLedgerAccountCount,
+    ledgerTotals: input.ledgerTotals ?? null,
+    executions: executionEvidence.map((evidence) => ({
+      ...evidence,
+      fills: [...evidence.fills].sort((left, right) => compareStrings(fillSortKey(left), fillSortKey(right))),
+    })),
+    transactions,
+  })
+
+const emptyExecutionQuality = (
+  status: ExecutionQuality['status'],
+  reasonCodes: readonly ForwardPerformanceExecutionQualityReasonCode[],
+): ExecutionQuality => ({
+  status,
+  reasonCodes,
+  evidenceHash: null,
+  implementationShortfall: null,
+})
+
+const emptyObservedCapacity = (
+  status: ObservedCapacity['status'],
+  reasonCodes: readonly ForwardPerformanceObservedCapacityReasonCode[],
+): ObservedCapacity => ({
+  status,
+  reasonCodes,
+  evidenceHash: null,
+  observations: [],
+  boundedObservedReferenceNotionalMicros: null,
+  boundedObservedExecutedNotionalMicros: null,
+  maximumParticipationRate: null,
+})
+
+const identityMatches = (
+  input: ForwardPerformanceEvidenceInput,
+  evidence: ForwardPerformanceExecutionEvidence,
+): boolean => {
+  const intent = evidence.intent
+  if (intent === undefined) return false
+  return (
+    SHA256_PATTERN.test(evidence.cycleId) &&
+    SHA256_PATTERN.test(evidence.decisionDocumentHash) &&
+    SHA256_PATTERN.test(evidence.decisionHash) &&
+    SHA256_PATTERN.test(evidence.intentId) &&
+    input.cycles.some((cycle) => cycle.cycleId === evidence.cycleId && cycle.state === 'COMPLETED') &&
+    evidence.accountId === input.account.accountId &&
+    intent.intentId === evidence.intentId &&
+    intent.accountId === evidence.accountId &&
+    intent.cycleId === evidence.cycleId &&
+    intent.decisionHash === evidence.decisionHash &&
+    intent.symbol === evidence.symbol &&
+    intent.side === evidence.side &&
+    intent.quantityMicros === evidence.plannedQuantityMicros &&
+    intent.createdAt === evidence.decisionCreatedAt
+  )
+}
+
+const orderMatches = (evidence: ForwardPerformanceExecutionEvidence): boolean => {
+  const intent = evidence.intent
+  const order = evidence.terminalOrder
+  if (intent === undefined || order === undefined) return false
+  return (
+    SHA256_PATTERN.test(order.eventId) &&
+    order.intentId === evidence.intentId &&
+    order.accountId === evidence.accountId &&
+    order.clientOrderId === intent.clientOrderId &&
+    order.symbol === evidence.symbol &&
+    order.side === evidence.side &&
+    order.quantityMicros === evidence.plannedQuantityMicros &&
+    ((order.status === 'FILLED' && intent.terminalOutcome === 'FILLED') ||
+      (order.status === 'CANCELED' && intent.terminalOutcome === 'CANCELED') ||
+      (order.status === 'EXPIRED' && intent.terminalOutcome === 'EXPIRED') ||
+      (order.status === 'REJECTED' && intent.terminalOutcome === 'REJECTED'))
+  )
+}
+
+const blockedIntentMatches = (evidence: ForwardPerformanceExecutionEvidence): boolean =>
+  evidence.intent?.terminalOutcome === 'BLOCKED' &&
+  evidence.terminalOrder === undefined &&
+  evidence.fills.length === 0 &&
+  validInstant(evidence.intent.updatedAt) &&
+  evidence.intent.updatedAt >= evidence.decisionCreatedAt
+
+const transactionMatchesFill = (
+  transaction: ForwardPerformanceTransactionEvidence,
+  evidence: ForwardPerformanceExecutionEvidence,
+  fill: ForwardPerformanceExecutionEvidence['fills'][number],
+): boolean =>
+  transaction.brokerEventId === fill.brokerEventId &&
+  transaction.intentId === evidence.intentId &&
+  transaction.cycleId === evidence.cycleId &&
+  transaction.symbol === evidence.symbol &&
+  transaction.side === evidence.side &&
+  transaction.quantityMicros === fill.quantityMicros &&
+  transaction.priceMicros === fill.priceMicros &&
+  transaction.feeMicros === fill.feeMicros &&
+  transaction.occurredAt === fill.occurredAt
+
+const validMarketVolumeEvidence = (
+  volume: NonNullable<ForwardPerformanceEvidenceInput['marketVolumeEvidence']>[number],
+): Result.Result<boolean, CanonicalHashFailure> => {
+  const marketVolume = parseUnsigned(volume.quantityMicros, true)
+  const closePrice = parseUnsigned(volume.closePriceMicros, true)
+  const { contentHash, ...material } = volume
+  return Result.map(canonicalHashV1Result(material), (expectedHash) =>
+    Boolean(
+      marketVolume !== undefined &&
+      closePrice !== undefined &&
+      volume.schemaVersion === 'bayn.forward-performance-market-volume-evidence.v1' &&
+      SHA256_PATTERN.test(contentHash) &&
+      contentHash === expectedHash &&
+      SHA256_PATTERN.test(volume.decisionSnapshotId) &&
+      SHA256_PATTERN.test(volume.snapshotId) &&
+      volume.snapshotId !== volume.decisionSnapshotId &&
+      SHA256_PATTERN.test(volume.manifestContentHash) &&
+      SHA256_PATTERN.test(volume.barsContentHash) &&
+      SHA256_PATTERN.test(volume.universeSymbolHash) &&
+      volume.universeId === 'cross-asset-taa-v1' &&
+      volume.calendarVersion.length > 0 &&
+      volume.calendarVersion === volume.calendarVersion.trim() &&
+      validIsoDate(volume.executionSessionDate) &&
+      validIsoDate(volume.decisionSnapshotAsOfSession) &&
+      volume.decisionSnapshotAsOfSession < volume.executionSessionDate &&
+      validIsoDate(volume.requestedStart) &&
+      validIsoDate(volume.evaluationStart) &&
+      volume.requestedStart <= volume.evaluationStart &&
+      volume.evaluationStart <= volume.executionSessionDate &&
+      volume.source === 'alpaca' &&
+      volume.sourceFeed === 'sip' &&
+      volume.adjustment === 'all' &&
+      validInstant(volume.windowOpenedAt) &&
+      validInstant(volume.windowClosedAt) &&
+      validInstant(volume.evidenceCutoffAt) &&
+      validInstant(volume.finalizedAt) &&
+      volume.windowOpenedAt.startsWith(`${volume.executionSessionDate}T`) &&
+      volume.windowClosedAt.startsWith(`${volume.executionSessionDate}T`) &&
+      volume.finalizedAt >= volume.windowClosedAt &&
+      volume.finalizedAt <= volume.evidenceCutoffAt &&
+      volume.windowClosedAt > volume.windowOpenedAt,
+    ),
+  )
+}
+
+const validTerminalReferencePrice = (
+  input: ForwardPerformanceEvidenceInput,
+  evidence: ForwardPerformanceExecutionEvidence,
+  terminalOccurredAt: string,
+  terminalObservedAt: string,
+  preBrokerBlocked: boolean,
+): Result.Result<bigint | undefined, CanonicalHashFailure> => {
+  const terminal = evidence.terminalReferencePrice
+  if (terminal === undefined) return Result.succeed(undefined)
+  const matchingVolumes = (input.marketVolumeEvidence ?? []).filter(
+    (volume) => volume.cycleId === evidence.cycleId && volume.symbol === evidence.symbol,
+  )
+  const volume = matchingVolumes.length === 1 ? matchingVolumes[0] : undefined
+  if (volume === undefined) return Result.succeed(undefined)
+  return Result.flatMap(validMarketVolumeEvidence(volume), (validVolume) => {
+    const terminalPrice = parseUnsigned(terminal.priceMicros, true)
+    const { contentHash, ...material } = terminal
+    return Result.map(canonicalHashV1Result(material), (expectedHash) =>
+      validVolume &&
+      terminalPrice !== undefined &&
+      terminal.schemaVersion === 'bayn.forward-performance-terminal-reference-price.v1' &&
+      terminal.cycleId === evidence.cycleId &&
+      terminal.symbol === evidence.symbol &&
+      terminal.executionSessionDate === volume.executionSessionDate &&
+      terminal.priceMicros === volume.closePriceMicros &&
+      terminal.observedAt === volume.finalizedAt &&
+      terminal.sourceEvidenceHash === volume.contentHash &&
+      SHA256_PATTERN.test(contentHash) &&
+      contentHash === expectedHash &&
+      terminalObservedAt <= volume.evidenceCutoffAt &&
+      terminalOccurredAt <= volume.windowClosedAt &&
+      (preBrokerBlocked || terminalOccurredAt >= volume.windowOpenedAt)
+        ? terminalPrice
+        : undefined,
+    )
+  })
+}
+
+const measureExecutionQuality = (
+  input: ForwardPerformanceEvidenceInput,
+): Result.Result<
+  {
+    readonly executionQuality: ExecutionQuality
+    readonly contributions: readonly ExecutionContribution[]
+  },
+  CanonicalHashFailure
+> => {
+  const executions = [...(input.executionEvidence ?? [])].sort((left, right) =>
+    compareStrings(executionSortKey(left), executionSortKey(right)),
+  )
+  if (executions.length === 0) {
+    return Result.succeed({
+      executionQuality:
+        input.transactions.length === 0
+          ? emptyExecutionQuality('NOT_ELIGIBLE', ['ZERO_COMPLETED_EXECUTIONS'])
+          : emptyExecutionQuality('UNDETERMINED', ['PLANNED_DECISION_EVIDENCE_GAP']),
+      contributions: [],
+    })
+  }
+
+  const transactions = [...input.transactions].sort((left, right) =>
+    compareStrings(transactionSortKey(left), transactionSortKey(right)),
+  )
+  const evidenceHash = sourceEvidenceHash(input, executions, transactions)
+  if (Result.isFailure(evidenceHash)) return Result.fail(evidenceHash.failure)
+
+  const reasons = new Set<ForwardPerformanceExecutionQualityReasonCode>()
+  const seenIntents = new Set<string>()
+  const seenFillEvents = new Set<string>()
+  const transactionByBrokerEvent = new Map<string, ForwardPerformanceTransactionEvidence>()
+  for (const transaction of transactions) {
+    const brokerEventId = transaction.brokerEventId
+    if (brokerEventId === undefined || transactionByBrokerEvent.has(brokerEventId)) {
+      reasons.add('ACCOUNTING_FILL_BINDING_GAP')
+      continue
+    }
+    transactionByBrokerEvent.set(brokerEventId, transaction)
+  }
+
+  if (
+    input.reconciliation?.performanceExact !== true ||
+    !input.accountingReceiptsExact ||
+    !input.ledgerExact ||
+    input.missingLedgerAccountCount > 0
+  ) {
+    reasons.add('ACCOUNT_LEDGER_RECONCILIATION_GAP')
+  }
+
+  const brokerFees = parseUnsigned(input.ledgerTotals?.brokerExecutionFeesMicros, false)
+  const otherCosts = parseUnsigned(input.ledgerTotals?.otherChargedCostsMicros, false)
+  if (brokerFees === undefined || otherCosts === undefined) reasons.add('EXPLICIT_COST_EVIDENCE_GAP')
+
+  let plannedQuantity = 0n
+  let filledQuantity = 0n
+  let plannedReferenceNotional = 0n
+  let executedNotional = 0n
+  let executionPriceShortfall = 0n
+  let opportunityShortfall = 0n
+  let observedFillFees = 0n
+  let firstDecisionAt: string | undefined
+  let firstFillAt: string | undefined
+  let lastFillAt: string | undefined
+  let lastTerminalOrderObservedAt: string | undefined
+  let fillCount = 0
+  const contributions: ExecutionContribution[] = []
+
+  for (const evidence of executions) {
+    if (seenIntents.has(evidence.intentId)) reasons.add('DUPLICATE_EXECUTION_EVIDENCE')
+    seenIntents.add(evidence.intentId)
+
+    const planned = parseUnsigned(evidence.plannedQuantityMicros, true)
+    const referencePrice = parseUnsigned(evidence.referencePriceMicros, true)
+    if (planned === undefined) reasons.add('PLANNED_DECISION_EVIDENCE_GAP')
+    if (referencePrice === undefined) reasons.add('REFERENCE_PRICE_EVIDENCE_GAP')
+    if (!identityMatches(input, evidence)) reasons.add('FILL_IDENTITY_DRIFT')
+
+    const order = evidence.terminalOrder
+    const blocked = blockedIntentMatches(evidence)
+    if (!blocked && (order === undefined || !orderMatches(evidence))) reasons.add('TERMINAL_ORDER_EVIDENCE_GAP')
+    const terminalOccurredAt = blocked ? evidence.intent?.updatedAt : order?.occurredAt
+    const terminalObservedAt = blocked ? evidence.intent?.updatedAt : order?.observedAt
+    if (
+      !validInstant(evidence.decisionCreatedAt) ||
+      terminalOccurredAt === undefined ||
+      terminalObservedAt === undefined ||
+      !validInstant(terminalOccurredAt) ||
+      !validInstant(terminalObservedAt) ||
+      terminalObservedAt < terminalOccurredAt ||
+      terminalObservedAt < evidence.decisionCreatedAt
+    ) {
+      reasons.add('FILL_TIMESTAMP_GAP')
+    }
+
+    const fills = [...evidence.fills].sort((left, right) => compareStrings(fillSortKey(left), fillSortKey(right)))
+    const reportedFilledQuantity = parseUnsigned(order?.filledQuantityMicros, false)
+    if (reportedFilledQuantity !== undefined && reportedFilledQuantity > 0n && fills.length === 0) {
+      reasons.add('FILL_EVIDENCE_GAP')
+    }
+
+    let executionFilledQuantity = 0n
+    let executionFilledReferenceNotional = 0n
+    let executionActualNotional = 0n
+    let executionFirstFillAt: string | undefined
+    let executionLastFillAt: string | undefined
+
+    for (const fill of fills) {
+      fillCount += 1
+      if (seenFillEvents.has(fill.brokerEventId)) reasons.add('DUPLICATE_EXECUTION_EVIDENCE')
+      seenFillEvents.add(fill.brokerEventId)
+
+      const quantity = parseUnsigned(fill.quantityMicros, true)
+      const price = parseUnsigned(fill.priceMicros, true)
+      const fee = parseUnsigned(fill.feeMicros, false)
+      if (quantity === undefined || price === undefined || fee === undefined) {
+        reasons.add('INVALID_EXECUTION_MICROS')
+        continue
+      }
+      if (
+        !SHA256_PATTERN.test(fill.brokerEventId) ||
+        !SHA256_PATTERN.test(fill.intentId) ||
+        fill.intentId !== evidence.intentId ||
+        fill.accountId !== evidence.accountId ||
+        fill.symbol !== evidence.symbol ||
+        fill.side !== evidence.side ||
+        fill.clientOrderId !== evidence.intent?.clientOrderId ||
+        fill.brokerOrderId !== order?.brokerOrderId
+      ) {
+        reasons.add('FILL_IDENTITY_DRIFT')
+      }
+      if (
+        !SOURCE_TIMESTAMP_PATTERN.test(fill.sourceTimestamp) ||
+        !validInstant(fill.occurredAt) ||
+        !validInstant(fill.observedAt) ||
+        fill.observedAt < fill.occurredAt ||
+        fill.occurredAt < evidence.decisionCreatedAt ||
+        (order !== undefined && fill.occurredAt > order.occurredAt)
+      ) {
+        reasons.add('FILL_TIMESTAMP_GAP')
+      }
+
+      const transaction = transactionByBrokerEvent.get(fill.brokerEventId)
+      const transactionNotional = parseUnsigned(transaction?.notionalMicros, true)
+      const expectedNotional = roundHalfUp(quantity, price)
+      if (
+        transaction === undefined ||
+        transactionNotional === undefined ||
+        expectedNotional === undefined ||
+        transactionNotional !== expectedNotional ||
+        !transactionMatchesFill(transaction, evidence, fill)
+      ) {
+        reasons.add('ACCOUNTING_FILL_BINDING_GAP')
+        continue
+      }
+      const referenceNotional = referencePrice === undefined ? undefined : roundHalfUp(quantity, referencePrice)
+      if (referenceNotional === undefined) {
+        reasons.add('INVALID_EXECUTION_MICROS')
+        continue
+      }
+
+      // Perold shortfall is positive when execution is worse than the immutable decision price.
+      const priceShortfall =
+        evidence.side === 'BUY' ? transactionNotional - referenceNotional : referenceNotional - transactionNotional
+      const nextExecutionFilled = checkedAdd(executionFilledQuantity, quantity)
+      const nextFilled = checkedAdd(filledQuantity, quantity)
+      const nextReference = checkedAdd(executionFilledReferenceNotional, referenceNotional)
+      const nextActual = checkedAdd(executionActualNotional, transactionNotional)
+      const nextObservedFees = checkedAdd(observedFillFees, fee)
+      const nextPriceShortfall = checkedAdd(executionPriceShortfall, priceShortfall)
+      if (
+        nextExecutionFilled === undefined ||
+        nextFilled === undefined ||
+        nextReference === undefined ||
+        nextActual === undefined ||
+        nextObservedFees === undefined ||
+        nextPriceShortfall === undefined
+      ) {
+        reasons.add('INVALID_EXECUTION_MICROS')
+        continue
+      }
+      executionFilledQuantity = nextExecutionFilled
+      filledQuantity = nextFilled
+      executionFilledReferenceNotional = nextReference
+      executionActualNotional = nextActual
+      observedFillFees = nextObservedFees
+      executionPriceShortfall = nextPriceShortfall
+      executionFirstFillAt =
+        executionFirstFillAt === undefined || fill.occurredAt < executionFirstFillAt
+          ? fill.occurredAt
+          : executionFirstFillAt
+      executionLastFillAt =
+        executionLastFillAt === undefined || fill.occurredAt > executionLastFillAt
+          ? fill.occurredAt
+          : executionLastFillAt
+    }
+
+    if (planned !== undefined && referencePrice !== undefined) {
+      const planNotional = roundHalfUp(planned, referencePrice)
+      const nextPlannedQuantity = checkedAdd(plannedQuantity, planned)
+      const nextPlanNotional =
+        planNotional === undefined ? undefined : checkedAdd(plannedReferenceNotional, planNotional)
+      if (planNotional === undefined || nextPlannedQuantity === undefined || nextPlanNotional === undefined) {
+        reasons.add('INVALID_EXECUTION_MICROS')
+      } else {
+        plannedQuantity = nextPlannedQuantity
+        plannedReferenceNotional = nextPlanNotional
+      }
+
+      const orderFilled = blocked ? 0n : parseUnsigned(order?.filledQuantityMicros, false)
+      const orderQuantity = blocked ? planned : parseUnsigned(order?.quantityMicros, true)
+      if (
+        orderFilled === undefined ||
+        orderQuantity === undefined ||
+        orderQuantity !== planned ||
+        orderFilled !== executionFilledQuantity ||
+        executionFilledQuantity > planned ||
+        (order?.status === 'FILLED' && executionFilledQuantity !== planned)
+      ) {
+        reasons.add('FILL_QUANTITY_MISMATCH')
+      }
+
+      const unfilled = planned >= executionFilledQuantity ? planned - executionFilledQuantity : 0n
+      if (unfilled > 0n) {
+        const terminalPriceResult =
+          terminalOccurredAt === undefined || terminalObservedAt === undefined
+            ? Result.succeed<bigint | undefined>(undefined)
+            : validTerminalReferencePrice(input, evidence, terminalOccurredAt, terminalObservedAt, blocked)
+        if (Result.isFailure(terminalPriceResult)) return Result.fail(terminalPriceResult.failure)
+        const terminalPrice = terminalPriceResult.success
+        if (terminalPrice === undefined) {
+          reasons.add('TERMINAL_PRICE_EVIDENCE_GAP')
+        } else {
+          const terminalNotional = roundHalfUp(unfilled, terminalPrice)
+          const unfilledReference = roundHalfUp(unfilled, referencePrice)
+          if (terminalNotional === undefined || unfilledReference === undefined) {
+            reasons.add('INVALID_EXECUTION_MICROS')
+          } else {
+            const opportunity =
+              evidence.side === 'BUY' ? terminalNotional - unfilledReference : unfilledReference - terminalNotional
+            const nextOpportunity = checkedAdd(opportunityShortfall, opportunity)
+            if (nextOpportunity === undefined) reasons.add('INVALID_EXECUTION_MICROS')
+            else opportunityShortfall = nextOpportunity
+          }
+        }
+      }
+    }
+
+    const nextExecutedNotional = checkedAdd(executedNotional, executionActualNotional)
+    if (nextExecutedNotional === undefined) reasons.add('INVALID_EXECUTION_MICROS')
+    else executedNotional = nextExecutedNotional
+
+    if (
+      terminalOccurredAt !== undefined &&
+      terminalObservedAt !== undefined &&
+      planned !== undefined &&
+      referencePrice !== undefined
+    ) {
+      contributions.push({
+        cycleId: evidence.cycleId,
+        symbol: evidence.symbol,
+        coverageOpenedAt: executionFirstFillAt ?? terminalOccurredAt,
+        terminalOrderOccurredAt: terminalOccurredAt,
+        preBrokerBlocked: blocked,
+        filledQuantity: executionFilledQuantity,
+        filledReferenceNotional: executionFilledReferenceNotional,
+        executedNotional: executionActualNotional,
+      })
+      firstDecisionAt =
+        firstDecisionAt === undefined || evidence.decisionCreatedAt < firstDecisionAt
+          ? evidence.decisionCreatedAt
+          : firstDecisionAt
+      if (executionFirstFillAt !== undefined) {
+        firstFillAt =
+          firstFillAt === undefined || executionFirstFillAt < firstFillAt ? executionFirstFillAt : firstFillAt
+      }
+      if (executionLastFillAt !== undefined) {
+        lastFillAt = lastFillAt === undefined || executionLastFillAt > lastFillAt ? executionLastFillAt : lastFillAt
+      }
+      lastTerminalOrderObservedAt =
+        lastTerminalOrderObservedAt === undefined || terminalObservedAt > lastTerminalOrderObservedAt
+          ? terminalObservedAt
+          : lastTerminalOrderObservedAt
+    }
+  }
+
+  if (seenFillEvents.size !== transactions.length) reasons.add('ACCOUNTING_FILL_BINDING_GAP')
+  if (brokerFees === undefined || observedFillFees !== brokerFees) reasons.add('EXPLICIT_COST_EVIDENCE_GAP')
+
+  const reasonCodes = [...reasons].sort()
+  if (
+    reasonCodes.length > 0 ||
+    brokerFees === undefined ||
+    otherCosts === undefined ||
+    firstDecisionAt === undefined ||
+    lastTerminalOrderObservedAt === undefined ||
+    plannedReferenceNotional <= 0n
+  ) {
+    return Result.succeed({
+      executionQuality: {
+        status: 'UNDETERMINED',
+        reasonCodes,
+        evidenceHash: evidenceHash.success,
+        implementationShortfall: null,
+      },
+      contributions: [],
+    })
+  }
+
+  const explicitCosts = checkedAdd(brokerFees, otherCosts)
+  const priceAndOpportunity = checkedAdd(executionPriceShortfall, opportunityShortfall)
+  const total =
+    explicitCosts === undefined || priceAndOpportunity === undefined
+      ? undefined
+      : checkedAdd(priceAndOpportunity, explicitCosts)
+  if (explicitCosts === undefined || total === undefined) {
+    return Result.succeed({
+      executionQuality: {
+        status: 'UNDETERMINED',
+        reasonCodes: ['INVALID_EXECUTION_MICROS'],
+        evidenceHash: evidenceHash.success,
+        implementationShortfall: null,
+      },
+      contributions: [],
+    })
+  }
+
+  return Result.succeed({
+    executionQuality: {
+      status: 'MEASURED',
+      reasonCodes: [],
+      evidenceHash: evidenceHash.success,
+      implementationShortfall: {
+        plannedOrderCount: executions.length,
+        fillCount,
+        plannedQuantityMicros: plannedQuantity.toString(),
+        filledQuantityMicros: filledQuantity.toString(),
+        unfilledQuantityMicros: (plannedQuantity - filledQuantity).toString(),
+        plannedReferenceNotionalMicros: plannedReferenceNotional.toString(),
+        executedNotionalMicros: executedNotional.toString(),
+        executionPriceShortfallMicros: executionPriceShortfall.toString(),
+        opportunityShortfallMicros: opportunityShortfall.toString(),
+        explicitCostsMicros: explicitCosts.toString(),
+        totalImplementationShortfallMicros: total.toString(),
+        implementationShortfallRate: {
+          numeratorMicros: total.toString(),
+          denominatorMicros: plannedReferenceNotional.toString(),
+          decimal: formatRatio(total, plannedReferenceNotional),
+        },
+        firstDecisionAt,
+        firstFillAt: firstFillAt ?? null,
+        lastFillAt: lastFillAt ?? null,
+        lastTerminalOrderObservedAt,
+      },
+    },
+    contributions,
+  })
+}
+
+const measureObservedCapacity = (
+  input: ForwardPerformanceEvidenceInput,
+  executionQuality: ExecutionQuality,
+  contributions: readonly ExecutionContribution[],
+): Result.Result<ObservedCapacity, CanonicalHashFailure> => {
+  if (executionQuality.status === 'NOT_ELIGIBLE') {
+    return Result.succeed(emptyObservedCapacity('NOT_ELIGIBLE', ['ZERO_COMPLETED_EXECUTIONS']))
+  }
+
+  const volumes = [...(input.marketVolumeEvidence ?? [])].sort((left, right) =>
+    compareStrings(volumeSortKey(left), volumeSortKey(right)),
+  )
+  const reasons = new Set<ForwardPerformanceObservedCapacityReasonCode>()
+  if (executionQuality.status !== 'MEASURED') reasons.add('EXECUTION_QUALITY_UNDETERMINED')
+  if (volumes.length === 0) reasons.add('MARKET_VOLUME_EVIDENCE_GAP')
+  if (reasons.size > 0) return Result.succeed(emptyObservedCapacity('UNDETERMINED', [...reasons].sort()))
+
+  const executionHash = executionQuality.evidenceHash
+  if (executionHash === null) {
+    return Result.succeed(emptyObservedCapacity('UNDETERMINED', ['EXECUTION_QUALITY_UNDETERMINED']))
+  }
+  const evidenceHash = canonicalHashV1Result({
+    schemaVersion: 'bayn.forward-performance-observed-capacity-evidence.v1',
+    executionEvidenceHash: executionHash,
+    marketVolumeEvidence: volumes,
+  })
+  if (Result.isFailure(evidenceHash)) return Result.fail(evidenceHash.failure)
+
+  const contributionGroups = new Map<string, ExecutionContribution[]>()
+  for (const contribution of contributions) {
+    const key = JSON.stringify([contribution.cycleId, contribution.symbol])
+    const group = contributionGroups.get(key)
+    if (group === undefined) contributionGroups.set(key, [contribution])
+    else group.push(contribution)
+  }
+  const volumeGroups = new Map<string, typeof volumes>()
+  for (const volume of volumes) {
+    const key = JSON.stringify([volume.cycleId, volume.symbol])
+    const group = volumeGroups.get(key)
+    if (group === undefined) volumeGroups.set(key, [volume])
+    else volumeGroups.set(key, [...group, volume])
+  }
+
+  let boundedReferenceNotional = 0n
+  let boundedExecutedNotional = 0n
+  let maximumNumerator = 0n
+  let maximumDenominator = 0n
+  const observations: ObservedCapacity['observations'][number][] = []
+
+  for (const [key, group] of [...contributionGroups.entries()].sort(([left], [right]) => compareStrings(left, right))) {
+    const matchingVolumes = volumeGroups.get(key) ?? []
+    const volume = matchingVolumes[0]
+    if (matchingVolumes.length !== 1 || volume === undefined) {
+      reasons.add(matchingVolumes.length === 0 ? 'MARKET_VOLUME_EVIDENCE_GAP' : 'INVALID_MARKET_VOLUME_EVIDENCE')
+      continue
+    }
+    const marketVolume = parseUnsigned(volume.quantityMicros, true)
+    const validVolume = validMarketVolumeEvidence(volume)
+    if (Result.isFailure(validVolume)) return Result.fail(validVolume.failure)
+    if (marketVolume === undefined || !validVolume.success) {
+      reasons.add('INVALID_MARKET_VOLUME_EVIDENCE')
+      continue
+    }
+
+    let filled = 0n
+    let referenceNotional = 0n
+    let actualNotional = 0n
+    let coverageOpenedAt: string | undefined
+    let lastTerminalAt: string | undefined
+    for (const contribution of group) {
+      filled += contribution.filledQuantity
+      referenceNotional += contribution.filledReferenceNotional
+      actualNotional += contribution.executedNotional
+      const contributionCoverageOpenedAt =
+        contribution.preBrokerBlocked && contribution.coverageOpenedAt < volume.windowOpenedAt
+          ? volume.windowOpenedAt
+          : contribution.coverageOpenedAt
+      if (coverageOpenedAt === undefined || contributionCoverageOpenedAt < coverageOpenedAt) {
+        coverageOpenedAt = contributionCoverageOpenedAt
+      }
+      const contributionTerminalAt =
+        contribution.preBrokerBlocked && contribution.terminalOrderOccurredAt < volume.windowOpenedAt
+          ? volume.windowOpenedAt
+          : contribution.terminalOrderOccurredAt
+      if (lastTerminalAt === undefined || contributionTerminalAt > lastTerminalAt) {
+        lastTerminalAt = contributionTerminalAt
+      }
+    }
+    if (
+      coverageOpenedAt === undefined ||
+      lastTerminalAt === undefined ||
+      volume.windowOpenedAt > coverageOpenedAt ||
+      volume.windowClosedAt < lastTerminalAt ||
+      filled > marketVolume
+    ) {
+      reasons.add('MARKET_VOLUME_IDENTITY_DRIFT')
+      continue
+    }
+
+    boundedReferenceNotional += referenceNotional
+    boundedExecutedNotional += actualNotional
+    if (observations.length === 0 || filled * maximumDenominator > maximumNumerator * marketVolume) {
+      maximumNumerator = filled
+      maximumDenominator = marketVolume
+    }
+    const [cycleId, symbol] = JSON.parse(key) as [string, string]
+    observations.push({
+      cycleId,
+      symbol,
+      windowOpenedAt: volume.windowOpenedAt,
+      windowClosedAt: volume.windowClosedAt,
+      filledQuantityMicros: filled.toString(),
+      marketVolumeQuantityMicros: marketVolume.toString(),
+      participationRate: {
+        numeratorQuantityMicros: filled.toString(),
+        denominatorQuantityMicros: marketVolume.toString(),
+        decimal: formatRatio(filled, marketVolume),
+      },
+    })
+  }
+
+  for (const key of volumeGroups.keys()) {
+    if (!contributionGroups.has(key)) reasons.add('MARKET_VOLUME_IDENTITY_DRIFT')
+  }
+  const reasonCodes = [...reasons].sort()
+  if (reasonCodes.length > 0 || observations.length !== contributionGroups.size) {
+    return Result.succeed({
+      ...emptyObservedCapacity('UNDETERMINED', reasonCodes),
+      evidenceHash: evidenceHash.success,
+    })
+  }
+
+  return Result.succeed({
+    status: 'MEASURED',
+    reasonCodes: [],
+    evidenceHash: evidenceHash.success,
+    observations,
+    boundedObservedReferenceNotionalMicros: boundedReferenceNotional.toString(),
+    boundedObservedExecutedNotionalMicros: boundedExecutedNotional.toString(),
+    maximumParticipationRate: {
+      numeratorQuantityMicros: maximumNumerator.toString(),
+      denominatorQuantityMicros: maximumDenominator.toString(),
+      decimal: formatRatio(maximumNumerator, maximumDenominator),
+    },
+  })
+}
+
+export const makeForwardPerformanceExecutionMeasurements = (
+  input: ForwardPerformanceEvidenceInput,
+): Result.Result<ForwardPerformanceExecutionMeasurements, CanonicalHashFailure> =>
+  Result.flatMap(measureExecutionQuality(input), ({ executionQuality, contributions }) =>
+    Result.map(measureObservedCapacity(input, executionQuality, contributions), (observedCapacity) => ({
+      executionQuality,
+      observedCapacity,
+    })),
+  )

--- a/services/bayn/src/forward-performance/index.ts
+++ b/services/bayn/src/forward-performance/index.ts
@@ -1,5 +1,9 @@
 export { makeForwardPerformanceReceipt, type ForwardPerformanceDomainFailure } from './domain'
 export {
+  makeForwardPerformanceExecutionMeasurements,
+  type ForwardPerformanceExecutionMeasurements,
+} from './execution-quality'
+export {
   FORWARD_PERFORMANCE_SCHEMA_VERSION,
   type ForwardPerformanceEvidenceInput,
   type ForwardPerformanceEvidenceStatus,

--- a/services/bayn/src/forward-performance/model.ts
+++ b/services/bayn/src/forward-performance/model.ts
@@ -1,7 +1,11 @@
-export const FORWARD_PERFORMANCE_SCHEMA_VERSION = 'bayn.forward-performance-receipt.v2' as const
+import type { FinalizedSnapshotProvenance } from '../contracts'
+import type { IsoDate } from '../schemas'
+
+export const FORWARD_PERFORMANCE_SCHEMA_VERSION = 'bayn.forward-performance-receipt.v3' as const
 
 export type ForwardPerformanceEvidenceStatus = 'SUFFICIENT' | 'INSUFFICIENT_EVIDENCE'
 export type ForwardPerformanceProfitability = 'PROFITABLE' | 'NOT_PROFITABLE' | 'UNDETERMINED'
+export type ForwardPerformanceMeasurementStatus = 'MEASURED' | 'NOT_ELIGIBLE' | 'UNDETERMINED'
 
 export type ForwardPerformanceReasonCode =
   | 'ACCOUNT_IDENTITY_GAP'
@@ -17,6 +21,29 @@ export type ForwardPerformanceReasonCode =
   | 'STARTING_CAPITAL_GAP'
   | 'UNCLOSED_WINDOW'
   | 'UNRESOLVED_MUTATION'
+  | 'ZERO_COMPLETED_EXECUTIONS'
+
+export type ForwardPerformanceExecutionQualityReasonCode =
+  | 'ACCOUNT_LEDGER_RECONCILIATION_GAP'
+  | 'ACCOUNTING_FILL_BINDING_GAP'
+  | 'DUPLICATE_EXECUTION_EVIDENCE'
+  | 'EXPLICIT_COST_EVIDENCE_GAP'
+  | 'FILL_EVIDENCE_GAP'
+  | 'FILL_IDENTITY_DRIFT'
+  | 'FILL_QUANTITY_MISMATCH'
+  | 'FILL_TIMESTAMP_GAP'
+  | 'INVALID_EXECUTION_MICROS'
+  | 'PLANNED_DECISION_EVIDENCE_GAP'
+  | 'REFERENCE_PRICE_EVIDENCE_GAP'
+  | 'TERMINAL_ORDER_EVIDENCE_GAP'
+  | 'TERMINAL_PRICE_EVIDENCE_GAP'
+  | 'ZERO_COMPLETED_EXECUTIONS'
+
+export type ForwardPerformanceObservedCapacityReasonCode =
+  | 'EXECUTION_QUALITY_UNDETERMINED'
+  | 'INVALID_MARKET_VOLUME_EVIDENCE'
+  | 'MARKET_VOLUME_EVIDENCE_GAP'
+  | 'MARKET_VOLUME_IDENTITY_DRIFT'
   | 'ZERO_COMPLETED_EXECUTIONS'
 
 export interface ForwardPerformanceBuildBinding {
@@ -69,11 +96,131 @@ export interface ForwardPerformanceStrategyEvidence {
 
 export interface ForwardPerformanceTransactionEvidence {
   readonly transactionId: string
+  readonly brokerEventId?: string
+  readonly intentId?: string
   readonly cycleId: string
+  readonly symbol?: string
   readonly side: 'BUY' | 'SELL'
+  readonly quantityMicros?: string
+  readonly priceMicros?: string
+  readonly notionalMicros?: string
   readonly feeMicros: string
   readonly realizedPnlMicros: string
   readonly occurredAt: string
+}
+
+export interface ForwardPerformanceExecutionFillEvidence {
+  readonly brokerEventId: string
+  readonly fillId: string
+  readonly brokerOrderId: string
+  readonly clientOrderId: string
+  readonly intentId: string
+  readonly accountId: string
+  readonly symbol: string
+  readonly side: 'BUY' | 'SELL'
+  readonly quantityMicros: string
+  readonly priceMicros: string
+  readonly feeMicros: string
+  readonly sourceTimestamp: string
+  readonly occurredAt: string
+  readonly observedAt: string
+}
+
+export interface ForwardPerformanceExecutionEvidence {
+  readonly cycleId: string
+  readonly decisionDocumentHash: string
+  readonly decisionHash: string
+  readonly decisionCreatedAt: string
+  readonly intentId: string
+  readonly accountId: string
+  readonly symbol: string
+  readonly side: 'BUY' | 'SELL'
+  readonly plannedQuantityMicros?: string
+  readonly referencePriceMicros?: string
+  readonly intent?: {
+    readonly intentId: string
+    readonly accountId: string
+    readonly clientOrderId: string
+    readonly cycleId: string
+    readonly decisionHash: string
+    readonly symbol: string
+    readonly side: 'BUY' | 'SELL'
+    readonly quantityMicros: string
+    readonly terminalOutcome: 'FILLED' | 'CANCELED' | 'EXPIRED' | 'REJECTED' | 'BLOCKED'
+    readonly createdAt: string
+    readonly updatedAt: string
+  }
+  readonly terminalOrder?: {
+    readonly eventId: string
+    readonly brokerOrderId: string
+    readonly clientOrderId: string
+    readonly intentId: string
+    readonly accountId: string
+    readonly symbol: string
+    readonly side: 'BUY' | 'SELL'
+    readonly quantityMicros: string
+    readonly filledQuantityMicros: string
+    readonly status: 'NEW' | 'PARTIALLY_FILLED' | 'FILLED' | 'CANCELED' | 'EXPIRED' | 'REJECTED' | 'PENDING'
+    readonly occurredAt: string
+    readonly observedAt: string
+  }
+  readonly fills: readonly ForwardPerformanceExecutionFillEvidence[]
+  readonly terminalReferencePrice?: {
+    readonly schemaVersion: 'bayn.forward-performance-terminal-reference-price.v1'
+    readonly cycleId: string
+    readonly symbol: string
+    readonly executionSessionDate: IsoDate
+    readonly priceMicros: string
+    readonly observedAt: string
+    readonly sourceEvidenceHash: string
+    readonly contentHash: string
+  }
+}
+
+export interface ForwardPerformanceMarketVolumeEvidence {
+  readonly schemaVersion: 'bayn.forward-performance-market-volume-evidence.v1'
+  readonly cycleId: string
+  readonly decisionSnapshotId: string
+  readonly decisionSnapshotAsOfSession: IsoDate
+  readonly symbol: string
+  readonly executionSessionDate: IsoDate
+  readonly windowOpenedAt: string
+  readonly windowClosedAt: string
+  readonly evidenceCutoffAt: string
+  readonly quantityMicros: string
+  readonly closePriceMicros: string
+  readonly snapshotId: string
+  readonly manifestContentHash: string
+  readonly barsContentHash: string
+  readonly finalizedAt: string
+  readonly universeId: FinalizedSnapshotProvenance['universeId']
+  readonly universeSymbolHash: string
+  readonly requestedStart: IsoDate
+  readonly evaluationStart: IsoDate
+  readonly calendarVersion: string
+  readonly source: 'alpaca'
+  readonly sourceFeed: 'sip'
+  readonly adjustment: 'all'
+  readonly contentHash: string
+}
+
+export interface ForwardPerformanceMarketVolumeRequest {
+  readonly cycleId: string
+  readonly decisionSnapshotId: string
+  readonly decisionSnapshotAsOfSession: IsoDate
+  readonly symbol: string
+  readonly executionSessionDate: IsoDate
+  readonly windowOpenedAt: string
+  readonly windowClosedAt: string
+  readonly evidenceCutoffAt: string
+  readonly universeId: FinalizedSnapshotProvenance['universeId']
+  readonly universeSymbolHash: string
+  readonly symbols: FinalizedSnapshotProvenance['symbols']
+  readonly requestedStart: IsoDate
+  readonly calendarVersion: string
+  readonly source: 'alpaca'
+  readonly sourceFeed: 'sip'
+  readonly adjustment: 'all'
 }
 
 export interface ForwardPerformanceLedgerTotals {
@@ -147,6 +294,8 @@ export interface ForwardPerformanceEvidenceInput {
   }
   readonly startingCapitalMicros?: string
   readonly transactions: readonly ForwardPerformanceTransactionEvidence[]
+  readonly executionEvidence?: readonly ForwardPerformanceExecutionEvidence[]
+  readonly marketVolumeEvidence?: readonly ForwardPerformanceMarketVolumeEvidence[]
   readonly ledgerTotals?: ForwardPerformanceLedgerTotals
   readonly cashYieldEvidenceRequired: boolean
   readonly cashYieldEvidence?: ForwardPerformanceCashYieldBinding
@@ -200,6 +349,58 @@ export interface ForwardPerformanceReceiptMaterial {
     readonly status: ForwardPerformanceEvidenceStatus
     readonly reasonCodes: readonly ForwardPerformanceReasonCode[]
     readonly cashYield: ForwardPerformanceCashYieldBinding | null
+  }
+  readonly executionQuality: {
+    readonly status: ForwardPerformanceMeasurementStatus
+    readonly reasonCodes: readonly ForwardPerformanceExecutionQualityReasonCode[]
+    readonly evidenceHash: string | null
+    readonly implementationShortfall: {
+      readonly plannedOrderCount: number
+      readonly fillCount: number
+      readonly plannedQuantityMicros: string
+      readonly filledQuantityMicros: string
+      readonly unfilledQuantityMicros: string
+      readonly plannedReferenceNotionalMicros: string
+      readonly executedNotionalMicros: string
+      readonly executionPriceShortfallMicros: string
+      readonly opportunityShortfallMicros: string
+      readonly explicitCostsMicros: string
+      readonly totalImplementationShortfallMicros: string
+      readonly implementationShortfallRate: {
+        readonly numeratorMicros: string
+        readonly denominatorMicros: string
+        readonly decimal: string
+      }
+      readonly firstDecisionAt: string
+      readonly firstFillAt: string | null
+      readonly lastFillAt: string | null
+      readonly lastTerminalOrderObservedAt: string
+    } | null
+  }
+  readonly observedCapacity: {
+    readonly status: ForwardPerformanceMeasurementStatus
+    readonly reasonCodes: readonly ForwardPerformanceObservedCapacityReasonCode[]
+    readonly evidenceHash: string | null
+    readonly observations: readonly {
+      readonly cycleId: string
+      readonly symbol: string
+      readonly windowOpenedAt: string
+      readonly windowClosedAt: string
+      readonly filledQuantityMicros: string
+      readonly marketVolumeQuantityMicros: string
+      readonly participationRate: {
+        readonly numeratorQuantityMicros: string
+        readonly denominatorQuantityMicros: string
+        readonly decimal: string
+      }
+    }[]
+    readonly boundedObservedReferenceNotionalMicros: string | null
+    readonly boundedObservedExecutedNotionalMicros: string | null
+    readonly maximumParticipationRate: {
+      readonly numeratorQuantityMicros: string
+      readonly denominatorQuantityMicros: string
+      readonly decimal: string
+    } | null
   }
   readonly profitability: ForwardPerformanceProfitability
 }

--- a/services/bayn/src/forward-performance/postgres.ts
+++ b/services/bayn/src/forward-performance/postgres.ts
@@ -2,6 +2,7 @@ import { PgClient } from '@effect/sql-pg'
 import { Data, Effect, Schema } from 'effect'
 
 import type { AccountingTransaction } from '../accounting/schema'
+import { FinalizedSnapshotProvenanceSchema } from '../contracts'
 import {
   decodeAccountingReceipt,
   DiscrepancyKind,
@@ -16,13 +17,17 @@ import {
 } from '../db/accounting-rows'
 import {
   ImageDigestSchema,
+  IsoDateSchema,
   Sha256Schema as Sha256,
   StrictNonEmptyStringSchema as NonEmptyString,
   strictParseOptions,
 } from '../schemas'
+import { ObserveShadowDecisionDocumentSchema } from '../shadow-decision-contract'
 import type {
   ForwardPerformanceCashYieldEvidence,
   ForwardPerformanceCycleEvidence,
+  ForwardPerformanceExecutionEvidence,
+  ForwardPerformanceMarketVolumeRequest,
   ForwardPerformanceStrategyEvidence,
   ForwardPerformanceTransactionEvidence,
 } from './model'
@@ -101,6 +106,64 @@ const TransactionRow = Schema.Struct({
   cycle_id: Schema.NullOr(Sha256),
 })
 
+const ObserveDecisionRow = Schema.Struct({
+  cycle_id: Sha256,
+  decision_hash: Sha256,
+  document: ObserveShadowDecisionDocumentSchema,
+  created_at: Schema.Date,
+})
+const MarketVolumeBindingRow = Schema.Struct({
+  cycle_id: Sha256,
+  snapshot_id: Sha256,
+  execution_session_date: IsoDateSchema,
+  execution_open_at: Schema.Date,
+  execution_close_at: Schema.Date,
+  manifest: FinalizedSnapshotProvenanceSchema,
+})
+const IntentExecutionRow = Schema.Struct({
+  intent_id: Sha256,
+  account_id: NonEmptyString,
+  client_order_id: NonEmptyString,
+  cycle_id: Sha256,
+  decision_hash: Sha256,
+  symbol: NonEmptyString,
+  side: Schema.Literals(['BUY', 'SELL']),
+  quantity_micros: Schema.String,
+  terminal_outcome: Schema.NullOr(Schema.Literals(['FILLED', 'CANCELED', 'EXPIRED', 'REJECTED', 'BLOCKED'])),
+  created_at: Schema.Date,
+  updated_at: Schema.Date,
+})
+const OrderExecutionRow = Schema.Struct({
+  event_id: Sha256,
+  broker_order_id: NonEmptyString,
+  client_order_id: NonEmptyString,
+  intent_id: Sha256,
+  account_id: NonEmptyString,
+  symbol: NonEmptyString,
+  side: Schema.Literals(['BUY', 'SELL']),
+  quantity_micros: Schema.String,
+  filled_quantity_micros: Schema.String,
+  status: Schema.Literals(['NEW', 'PARTIALLY_FILLED', 'FILLED', 'CANCELED', 'EXPIRED', 'REJECTED', 'PENDING']),
+  occurred_at: Schema.Date,
+  observed_at: Schema.Date,
+})
+const FillExecutionRow = Schema.Struct({
+  event_id: Sha256,
+  fill_id: NonEmptyString,
+  broker_order_id: NonEmptyString,
+  client_order_id: NonEmptyString,
+  intent_id: Sha256,
+  account_id: NonEmptyString,
+  symbol: NonEmptyString,
+  side: Schema.Literals(['BUY', 'SELL']),
+  quantity_micros: Schema.String,
+  price_micros: Schema.String,
+  fee_micros: Schema.String,
+  source_timestamp: Schema.String,
+  occurred_at: Schema.Date,
+  observed_at: Schema.Date,
+})
+
 const decodeCycles = Schema.decodeUnknownEffect(Schema.Array(TerminalCycleRow), strictParseOptions)
 const decodeStrategy = Schema.decodeUnknownEffect(
   Schema.Array(StrategyRow).check(Schema.isMaxLength(1)),
@@ -122,6 +185,11 @@ const decodeTransactions = Schema.decodeUnknownEffect(Schema.Array(TransactionRo
 const decodeReceipts = Schema.decodeUnknownEffect(Schema.Array(AccountingReceiptRowSchema), strictParseOptions)
 const decodeCount = Schema.decodeUnknownEffect(Schema.Tuple([CountRow]), strictParseOptions)
 const decodeDurableExecutions = Schema.decodeUnknownEffect(Schema.Array(DurableExecutionRow), strictParseOptions)
+const decodeObserveDecisions = Schema.decodeUnknownEffect(Schema.Array(ObserveDecisionRow), strictParseOptions)
+const decodeMarketVolumeBindings = Schema.decodeUnknownEffect(Schema.Array(MarketVolumeBindingRow), strictParseOptions)
+const decodeExecutionIntents = Schema.decodeUnknownEffect(Schema.Array(IntentExecutionRow), strictParseOptions)
+const decodeExecutionOrders = Schema.decodeUnknownEffect(Schema.Array(OrderExecutionRow), strictParseOptions)
+const decodeExecutionFills = Schema.decodeUnknownEffect(Schema.Array(FillExecutionRow), strictParseOptions)
 
 export class ForwardPerformancePostgresError extends Data.TaggedError('ForwardPerformancePostgresError')<{
   readonly operation: 'read'
@@ -145,6 +213,8 @@ export interface ForwardPerformancePostgresEvidence {
   readonly cashYieldEvidence?: ForwardPerformanceCashYieldEvidence
   readonly transactions: readonly AccountingTransaction[]
   readonly transactionEvidence: readonly ForwardPerformanceTransactionEvidence[]
+  readonly executionEvidence: readonly ForwardPerformanceExecutionEvidence[]
+  readonly marketVolumeRequests: readonly ForwardPerformanceMarketVolumeRequest[]
   readonly receipts: readonly AccountingReceipt[]
   readonly durableExecutionBindings: readonly {
     readonly accountId: string
@@ -359,6 +429,198 @@ const receiptQuery = (sql: PgClient.PgClient, accountId: string) => sql<Record<s
   ORDER BY receipt.broker_event_id COLLATE "C"
 `
 
+const uniqueRows = <Row>(rows: readonly Row[], key: (row: Row) => string): ReadonlyMap<string, Row | null> => {
+  const byKey = new Map<string, Row | null>()
+  for (const row of rows) {
+    const identity = key(row)
+    byKey.set(identity, byKey.has(identity) ? null : row)
+  }
+  return byKey
+}
+
+const intentExecutionKey = (input: {
+  readonly cycleId: string
+  readonly decisionHash: string
+  readonly accountId: string
+  readonly symbol: string
+  readonly side: 'BUY' | 'SELL'
+  readonly quantityMicros: string
+  readonly createdAt: string
+}): string =>
+  JSON.stringify([
+    input.cycleId,
+    input.decisionHash,
+    input.accountId,
+    input.symbol,
+    input.side,
+    input.quantityMicros,
+    input.createdAt,
+  ])
+
+const executionEvidenceFromRows = (
+  decisionRows: readonly (typeof ObserveDecisionRow.Type)[],
+  intentRows: readonly (typeof IntentExecutionRow.Type)[],
+  orderRows: readonly (typeof OrderExecutionRow.Type)[],
+  fillRows: readonly (typeof FillExecutionRow.Type)[],
+): readonly ForwardPerformanceExecutionEvidence[] => {
+  const intents = uniqueRows(intentRows, (row) =>
+    intentExecutionKey({
+      cycleId: row.cycle_id,
+      decisionHash: row.decision_hash,
+      accountId: row.account_id,
+      symbol: row.symbol,
+      side: row.side,
+      quantityMicros: row.quantity_micros,
+      createdAt: row.created_at.toISOString(),
+    }),
+  )
+  const orders = uniqueRows(orderRows, (row) => row.intent_id)
+  const fills = new Map<string, (typeof FillExecutionRow.Type)[]>()
+  for (const row of fillRows) {
+    const found = fills.get(row.intent_id)
+    if (found === undefined) fills.set(row.intent_id, [row])
+    else found.push(row)
+  }
+
+  const evidence: ForwardPerformanceExecutionEvidence[] = []
+  for (const row of decisionRows) {
+    const document = row.document
+    if (document.targetPlan.status !== 'PLANNED') continue
+    for (const target of document.targetPlan.intentTargets) {
+      const matchingReferences = document.targetPlan.targets.filter((candidate) => candidate.symbol === target.symbol)
+      const reference = matchingReferences.length === 1 ? matchingReferences[0] : undefined
+      const intentRow = intents.get(
+        intentExecutionKey({
+          cycleId: row.cycle_id,
+          decisionHash: document.bindings.strategyDecisionHash,
+          accountId: document.bindings.accountId,
+          symbol: target.symbol,
+          side: target.side,
+          quantityMicros: target.quantityMicros,
+          createdAt: document.createdAt,
+        }),
+      )
+      const intentId = intentRow === undefined || intentRow === null ? '' : intentRow.intent_id
+      const orderRow = orders.get(intentId)
+      const fillEvidence = (fills.get(intentId) ?? []).map((fill) => ({
+        brokerEventId: fill.event_id,
+        fillId: fill.fill_id,
+        brokerOrderId: fill.broker_order_id,
+        clientOrderId: fill.client_order_id,
+        intentId: fill.intent_id,
+        accountId: fill.account_id,
+        symbol: fill.symbol,
+        side: fill.side,
+        quantityMicros: fill.quantity_micros,
+        priceMicros: fill.price_micros,
+        feeMicros: fill.fee_micros,
+        sourceTimestamp: fill.source_timestamp,
+        occurredAt: fill.occurred_at.toISOString(),
+        observedAt: fill.observed_at.toISOString(),
+      }))
+      evidence.push({
+        cycleId: row.cycle_id,
+        decisionDocumentHash:
+          row.decision_hash === document.contentHash &&
+          document.bindings.cycleId === row.cycle_id &&
+          document.createdAt === row.created_at.toISOString()
+            ? document.contentHash
+            : '',
+        decisionHash: document.bindings.strategyDecisionHash,
+        decisionCreatedAt: document.createdAt,
+        intentId,
+        accountId: document.bindings.accountId,
+        symbol: target.symbol,
+        side: target.side,
+        plannedQuantityMicros: target.quantityMicros,
+        ...(reference === undefined ? {} : { referencePriceMicros: reference.referencePriceMicros }),
+        ...(intentRow === undefined || intentRow === null || intentRow.terminal_outcome === null
+          ? {}
+          : {
+              intent: {
+                intentId: intentRow.intent_id,
+                accountId: intentRow.account_id,
+                clientOrderId: intentRow.client_order_id,
+                cycleId: intentRow.cycle_id,
+                decisionHash: intentRow.decision_hash,
+                symbol: intentRow.symbol,
+                side: intentRow.side,
+                quantityMicros: intentRow.quantity_micros,
+                terminalOutcome: intentRow.terminal_outcome,
+                createdAt: intentRow.created_at.toISOString(),
+                updatedAt: intentRow.updated_at.toISOString(),
+              },
+            }),
+        ...(orderRow === undefined || orderRow === null
+          ? {}
+          : {
+              terminalOrder: {
+                eventId: orderRow.event_id,
+                brokerOrderId: orderRow.broker_order_id,
+                clientOrderId: orderRow.client_order_id,
+                intentId: orderRow.intent_id,
+                accountId: orderRow.account_id,
+                symbol: orderRow.symbol,
+                side: orderRow.side,
+                quantityMicros: orderRow.quantity_micros,
+                filledQuantityMicros: orderRow.filled_quantity_micros,
+                status: orderRow.status,
+                occurredAt: orderRow.occurred_at.toISOString(),
+                observedAt: orderRow.observed_at.toISOString(),
+              },
+            }),
+        fills: fillEvidence,
+      })
+    }
+  }
+  return evidence
+}
+
+const marketVolumeRequestsFromRows = (
+  executionEvidence: readonly ForwardPerformanceExecutionEvidence[],
+  bindingRows: readonly (typeof MarketVolumeBindingRow.Type)[],
+  evidenceCutoffAt: string | undefined,
+): readonly ForwardPerformanceMarketVolumeRequest[] => {
+  if (evidenceCutoffAt === undefined) return []
+  const bindings = uniqueRows(bindingRows, (row) => row.cycle_id)
+  const requests = new Map<string, ForwardPerformanceMarketVolumeRequest>()
+  for (const execution of executionEvidence) {
+    const binding = bindings.get(execution.cycleId)
+    if (
+      binding === undefined ||
+      binding === null ||
+      binding.snapshot_id !== binding.manifest.snapshotId ||
+      !binding.manifest.symbols.includes(execution.symbol)
+    ) {
+      continue
+    }
+    const request: ForwardPerformanceMarketVolumeRequest = {
+      cycleId: execution.cycleId,
+      decisionSnapshotId: binding.snapshot_id,
+      decisionSnapshotAsOfSession: binding.manifest.asOfSession,
+      symbol: execution.symbol,
+      executionSessionDate: binding.execution_session_date,
+      windowOpenedAt: binding.execution_open_at.toISOString(),
+      windowClosedAt: binding.execution_close_at.toISOString(),
+      evidenceCutoffAt,
+      universeId: binding.manifest.universeId,
+      universeSymbolHash: binding.manifest.universeSymbolHash,
+      symbols: binding.manifest.symbols,
+      requestedStart: binding.manifest.requestedStart,
+      calendarVersion: binding.manifest.calendarVersion,
+      source: binding.manifest.source,
+      sourceFeed: binding.manifest.sourceFeed,
+      adjustment: binding.manifest.adjustment,
+    }
+    requests.set(JSON.stringify([request.cycleId, request.symbol]), request)
+  }
+  return [...requests.values()].sort((left, right) => {
+    const leftKey = JSON.stringify([left.executionSessionDate, left.cycleId, left.symbol])
+    const rightKey = JSON.stringify([right.executionSessionDate, right.cycleId, right.symbol])
+    return leftKey < rightKey ? -1 : leftKey > rightKey ? 1 : 0
+  })
+}
+
 export const readForwardPerformancePostgres = (
   sql: PgClient.PgClient,
   accountId: string,
@@ -559,6 +821,158 @@ export const readForwardPerformancePostgres = (
         const receipts = yield* Effect.forEach(receiptRows, (row) =>
           decodeAccountingReceipt(accountingReceiptFromRow(row)),
         )
+        const observeDecisionRows = yield* sql<Record<string, unknown>>`
+          WITH latest_reconciliation AS (
+            SELECT reconciled_at
+            FROM reconciliations
+            WHERE account_id = ${accountId}
+            ORDER BY reconciled_at DESC, reconciliation_id COLLATE "C" DESC
+            LIMIT 1
+          )
+          SELECT
+            cycle.cycle_id,
+            decision.decision_hash,
+            decision.document,
+            decision.created_at
+          FROM autonomous_cycles AS cycle
+          JOIN autonomous_cycle_shadow_decisions AS decision
+            ON decision.cycle_id = cycle.cycle_id
+            AND decision.decision_hash = cycle.decision_hash
+          CROSS JOIN latest_reconciliation
+          WHERE cycle.account_id = ${accountId}
+            AND cycle.state = 'COMPLETED'
+            AND cycle.terminal_at <= latest_reconciliation.reconciled_at
+            AND decision.schema_version = 'bayn.observe-shadow-decision.v1'
+            AND decision.document ->> 'mode' = 'OBSERVE'
+          ORDER BY cycle.submission_open_at, cycle.cycle_id COLLATE "C"
+        `.pipe(Effect.flatMap(decodeObserveDecisions))
+        const marketVolumeBindingRows = yield* sql<Record<string, unknown>>`
+          WITH latest_reconciliation AS (
+            SELECT reconciled_at
+            FROM reconciliations
+            WHERE account_id = ${accountId}
+            ORDER BY reconciled_at DESC, reconciliation_id COLLATE "C" DESC
+            LIMIT 1
+          )
+          SELECT
+            cycle.cycle_id,
+            cycle.snapshot_id,
+            cycle.execution_session_date::text AS execution_session_date,
+            cycle.execution_open_at,
+            cycle.execution_close_at,
+            reference.manifest
+          FROM autonomous_cycles AS cycle
+          JOIN snapshot_references AS reference ON reference.snapshot_id = cycle.snapshot_id
+          CROSS JOIN latest_reconciliation
+          WHERE cycle.account_id = ${accountId}
+            AND cycle.state = 'COMPLETED'
+            AND cycle.terminal_at <= latest_reconciliation.reconciled_at
+          ORDER BY cycle.submission_open_at, cycle.cycle_id COLLATE "C"
+        `.pipe(Effect.flatMap(decodeMarketVolumeBindings))
+        const executionIntentRows = yield* sql<Record<string, unknown>>`
+          WITH latest_reconciliation AS (
+            SELECT reconciled_at
+            FROM reconciliations
+            WHERE account_id = ${accountId}
+            ORDER BY reconciled_at DESC, reconciliation_id COLLATE "C" DESC
+            LIMIT 1
+          )
+          SELECT
+            intent.intent_id,
+            intent.account_id,
+            intent.client_order_id,
+            intent.cycle_id,
+            intent.decision_hash,
+            intent.symbol,
+            intent.side,
+            intent.quantity_micros::text AS quantity_micros,
+            intent.terminal_outcome,
+            intent.created_at,
+            intent.updated_at
+          FROM intents AS intent
+          JOIN autonomous_cycles AS cycle ON cycle.cycle_id = intent.cycle_id
+          CROSS JOIN latest_reconciliation
+          WHERE intent.account_id = ${accountId}
+            AND cycle.account_id = ${accountId}
+            AND cycle.state = 'COMPLETED'
+            AND cycle.terminal_at <= latest_reconciliation.reconciled_at
+          ORDER BY intent.cycle_id COLLATE "C", intent.intent_id COLLATE "C"
+        `.pipe(Effect.flatMap(decodeExecutionIntents))
+        const executionOrderRows = yield* sql<Record<string, unknown>>`
+          WITH latest_reconciliation AS (
+            SELECT reconciled_at
+            FROM reconciliations
+            WHERE account_id = ${accountId}
+            ORDER BY reconciled_at DESC, reconciliation_id COLLATE "C" DESC
+            LIMIT 1
+          )
+          SELECT DISTINCT ON (observed_order.intent_id)
+            event.event_id,
+            observed_order.broker_order_id,
+            observed_order.client_order_id,
+            observed_order.intent_id,
+            observed_order.account_id,
+            observed_order.symbol,
+            observed_order.side,
+            observed_order.quantity_micros::text AS quantity_micros,
+            observed_order.filled_quantity_micros::text AS filled_quantity_micros,
+            observed_order.status,
+            event.occurred_at,
+            event.observed_at
+          FROM orders AS observed_order
+          JOIN broker_events AS event ON event.event_id = observed_order.event_id
+          JOIN intents AS intent ON intent.intent_id = observed_order.intent_id
+          JOIN autonomous_cycles AS cycle ON cycle.cycle_id = intent.cycle_id
+          CROSS JOIN latest_reconciliation
+          WHERE observed_order.account_id = ${accountId}
+            AND cycle.account_id = ${accountId}
+            AND cycle.state = 'COMPLETED'
+            AND cycle.terminal_at <= latest_reconciliation.reconciled_at
+            AND event.observed_at <= latest_reconciliation.reconciled_at
+          ORDER BY
+            observed_order.intent_id,
+            event.source_sequence DESC,
+            event.event_id COLLATE "C" DESC
+        `.pipe(Effect.flatMap(decodeExecutionOrders))
+        const executionFillRows = yield* sql<Record<string, unknown>>`
+          WITH latest_reconciliation AS (
+            SELECT reconciled_at
+            FROM reconciliations
+            WHERE account_id = ${accountId}
+            ORDER BY reconciled_at DESC, reconciliation_id COLLATE "C" DESC
+            LIMIT 1
+          )
+          SELECT
+            event.event_id,
+            fill.fill_id,
+            fill.broker_order_id,
+            fill.client_order_id,
+            fill.intent_id,
+            fill.account_id,
+            fill.symbol,
+            fill.side,
+            fill.quantity_micros::text AS quantity_micros,
+            fill.price_micros::text AS price_micros,
+            fill.fee_micros::text AS fee_micros,
+            fill.source_timestamp,
+            event.occurred_at,
+            event.observed_at
+          FROM fills AS fill
+          JOIN broker_events AS event ON event.event_id = fill.event_id
+          JOIN intents AS intent ON intent.intent_id = fill.intent_id
+          JOIN autonomous_cycles AS cycle ON cycle.cycle_id = intent.cycle_id
+          CROSS JOIN latest_reconciliation
+          WHERE fill.account_id = ${accountId}
+            AND cycle.account_id = ${accountId}
+            AND cycle.state = 'COMPLETED'
+            AND cycle.terminal_at <= latest_reconciliation.reconciled_at
+            AND event.observed_at <= latest_reconciliation.reconciled_at
+          ORDER BY
+            intent.cycle_id COLLATE "C",
+            fill.intent_id COLLATE "C",
+            fill.source_timestamp COLLATE "C",
+            fill.fill_id COLLATE "C"
+        `.pipe(Effect.flatMap(decodeExecutionFills))
         const durableExecutionRows = yield* sql<Record<string, unknown>>`
           WITH latest_reconciliation AS (
             SELECT reconciled_at
@@ -803,12 +1217,29 @@ export const readForwardPerformancePostgres = (
         const transactionEvidence = transactionRows.map(
           (row): ForwardPerformanceTransactionEvidence => ({
             transactionId: row.transaction_id,
+            brokerEventId: row.broker_event_id,
+            ...(row.intent_id === null ? {} : { intentId: row.intent_id }),
             cycleId: row.cycle_id ?? '',
+            symbol: row.symbol,
             side: row.side,
+            quantityMicros: row.quantity_micros,
+            priceMicros: row.price_micros,
+            notionalMicros: row.notional_micros,
             feeMicros: row.fee_micros,
             realizedPnlMicros: row.realized_pnl_micros,
             occurredAt: row.occurred_at.toISOString(),
           }),
+        )
+        const executionEvidence = executionEvidenceFromRows(
+          observeDecisionRows,
+          executionIntentRows,
+          executionOrderRows,
+          executionFillRows,
+        )
+        const marketVolumeRequests = marketVolumeRequestsFromRows(
+          executionEvidence,
+          marketVolumeBindingRows,
+          reconciliation?.reconciledAt,
         )
 
         return {
@@ -821,6 +1252,8 @@ export const readForwardPerformancePostgres = (
           ...(cashYieldEvidence === undefined ? {} : { cashYieldEvidence }),
           transactions,
           transactionEvidence,
+          executionEvidence,
+          marketVolumeRequests,
           receipts,
           durableExecutionBindings: durableExecutionRows.map((row) => ({
             accountId: row.account_id ?? '',

--- a/services/bayn/src/forward-performance/program.test.ts
+++ b/services/bayn/src/forward-performance/program.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 
+import { ClickhouseClient } from '@effect/sql-clickhouse'
 import { PgClient } from '@effect/sql-pg'
 import { Effect, Layer, Redacted, Result } from 'effect'
 
@@ -9,9 +10,16 @@ import type { LoadedRuntimeConfig } from '../config'
 import { planAccountingReceipt } from '../db/execution-store/decisions'
 import { BrokerAccess, noCapitalAuthority } from '../execution/authority'
 import { DiscrepancyKind, OrderSide, type Fill } from '../execution/contracts'
+import { canonicalHashV1, sha256 } from '../hash'
 import { readForwardPerformancePostgres } from './postgres'
-import { runForwardPerformance, type ForwardPerformanceReaders } from './program'
-import type { ForwardPerformanceCashYieldEvidence } from './model'
+import {
+  bindForwardPerformanceTerminalReferencePrices,
+  makeForwardPerformanceMarketVolumeEvidence,
+  readForwardPerformanceMarketVolumeWithClient,
+  runForwardPerformance,
+  type ForwardPerformanceReaders,
+} from './program'
+import type { ForwardPerformanceCashYieldEvidence, ForwardPerformanceMarketVolumeRequest } from './model'
 
 const identityResult = makeBrokerIdentity({
   schemaVersion: 'bayn.broker-identity.v2',
@@ -169,14 +177,435 @@ const verifiedCashYield = {
   transferTimestampNs: '1784563200000000000',
   amountMicros: '200',
 }
+const marketSymbols = ['NVDA'] as const
+const marketUniverseSymbolHash = sha256(marketSymbols.join(','))
+const marketEvaluationStart = '2026-07-19' as const
+const marketDecisionSnapshotId = hash('d')
+const marketVolumeRequestBase = {
+  cycleId: hash('1'),
+  decisionSnapshotId: marketDecisionSnapshotId,
+  decisionSnapshotAsOfSession: '2026-07-19',
+  symbol: 'NVDA',
+  executionSessionDate: '2026-07-20',
+  windowOpenedAt: '2026-07-20T13:30:00.000Z',
+  windowClosedAt: '2026-07-20T20:00:00.000Z',
+  evidenceCutoffAt: '2026-07-20T21:15:00.000Z',
+  universeId: 'cross-asset-taa-v1',
+  universeSymbolHash: marketUniverseSymbolHash,
+  symbols: marketSymbols,
+  requestedStart: '2026-07-19',
+  calendarVersion: 'fixture-calendar-v1',
+  source: 'alpaca',
+  sourceFeed: 'sip',
+  adjustment: 'all',
+} as const
+const marketSessionMaterial = [
+  {
+    calendar_version: 'fixture-calendar-v1',
+    session_date: '2026-07-19',
+    open_time: '09:30',
+    close_time: '16:00',
+    timezone: 'America/New_York',
+    provider: 'alpaca',
+  },
+  {
+    calendar_version: 'fixture-calendar-v1',
+    session_date: '2026-07-20',
+    open_time: '09:30',
+    close_time: '16:00',
+    timezone: 'America/New_York',
+    provider: 'alpaca',
+  },
+] as const
+const marketBarMaterial = [
+  {
+    symbol: 'NVDA',
+    session_date: '2026-07-19',
+    adjusted_open: '99.00000000',
+    adjusted_high: '101.00000000',
+    adjusted_low: '98.00000000',
+    adjusted_close: '100.00000000',
+    adjusted_volume: '100.00000000',
+    trade_count: '100',
+    vwap: '99.50000000',
+    provider: 'alpaca',
+    source_feed: 'sip',
+    adjustment: 'all',
+    publication_asof: '2026-07-20',
+  },
+  {
+    symbol: 'NVDA',
+    session_date: '2026-07-20',
+    adjusted_open: '101.00000000',
+    adjusted_high: '104.00000000',
+    adjusted_low: '100.00000000',
+    adjusted_close: '103.00000000',
+    adjusted_volume: '123.45678900',
+    trade_count: '123',
+    vwap: '102.00000000',
+    provider: 'alpaca',
+    source_feed: 'sip',
+    adjustment: 'all',
+    publication_asof: '2026-07-20',
+  },
+] as const
+const marketBarsContentHash = canonicalHashV1(marketBarMaterial)
+const marketSessionsContentHash = canonicalHashV1(marketSessionMaterial)
+const marketSnapshotId = canonicalHashV1({
+  schemaVersion: 'signal.adjusted-daily-snapshot.v2',
+  provider: 'alpaca',
+  feed: 'sip',
+  adjustment: 'all',
+  calendarVersion: 'fixture-calendar-v1',
+  requestedStart: '2026-07-19',
+  publicationAsOf: '2026-07-20',
+  symbols: marketSymbols,
+  barsContentHash: marketBarsContentHash,
+  sessionsContentHash: marketSessionsContentHash,
+  universeId: 'cross-asset-taa-v1',
+  universeSymbolHash: marketUniverseSymbolHash,
+})
+const marketVolumeRequest: ForwardPerformanceMarketVolumeRequest = {
+  ...marketVolumeRequestBase,
+}
+const marketManifestMaterial = {
+  snapshot_id: marketSnapshotId,
+  schema_version: 'signal.adjusted-daily-snapshot.v2',
+  publisher_source_revision: 'a'.repeat(40),
+  publisher_image_repository: 'registry.example.test/lab/signal-publisher',
+  publisher_image_digest: `sha256:${'b'.repeat(64)}`,
+  universe_id: 'cross-asset-taa-v1',
+  universe_symbol_hash: marketUniverseSymbolHash,
+  provider: 'alpaca',
+  source_feed: 'sip',
+  adjustment: 'all',
+  calendar_version: 'fixture-calendar-v1',
+  requested_start: '2026-07-19',
+  publication_asof: '2026-07-20',
+  first_session: '2026-07-19',
+  last_session: '2026-07-20',
+  symbol_count: 1,
+  session_count: 2,
+  bar_count: 2,
+  bars_content_hash: marketBarsContentHash,
+  sessions_content_hash: marketSessionsContentHash,
+  finalized_at: '2026-07-20 21:05:00.000',
+} as const
+const marketSnapshotRows = {
+  bars: marketBarMaterial.map((bar) => ({ snapshot_id: marketSnapshotId, ...bar })),
+  sessions: marketSessionMaterial.map((session) => ({ snapshot_id: marketSnapshotId, ...session })),
+  manifests: [
+    {
+      ...marketManifestMaterial,
+      manifest_content_hash: canonicalHashV1(marketManifestMaterial),
+    },
+  ],
+}
+
+const makeMarketSnapshotRevision = (close: string, volume: string, finalizedAt: string) => {
+  const bars = marketBarMaterial.map((bar) =>
+    bar.session_date === '2026-07-20' ? { ...bar, adjusted_close: close, adjusted_volume: volume } : bar,
+  )
+  const barsContentHash = canonicalHashV1(bars)
+  const snapshotId = canonicalHashV1({
+    schemaVersion: 'signal.adjusted-daily-snapshot.v2',
+    provider: 'alpaca',
+    feed: 'sip',
+    adjustment: 'all',
+    calendarVersion: 'fixture-calendar-v1',
+    requestedStart: '2026-07-19',
+    publicationAsOf: '2026-07-20',
+    symbols: marketSymbols,
+    barsContentHash,
+    sessionsContentHash: marketSessionsContentHash,
+    universeId: 'cross-asset-taa-v1',
+    universeSymbolHash: marketUniverseSymbolHash,
+  })
+  const manifestMaterial = {
+    ...marketManifestMaterial,
+    snapshot_id: snapshotId,
+    bars_content_hash: barsContentHash,
+    finalized_at: finalizedAt,
+  }
+  return {
+    snapshotId,
+    rows: {
+      bars: bars.map((bar) => ({ snapshot_id: snapshotId, ...bar })),
+      sessions: marketSessionMaterial.map((session) => ({ snapshot_id: snapshotId, ...session })),
+      manifests: [
+        {
+          ...manifestMaterial,
+          manifest_content_hash: canonicalHashV1(manifestMaterial),
+        },
+      ],
+    },
+  }
+}
+
+const newerMarketSnapshot = makeMarketSnapshotRevision('104.00000000', '999.00000000', '2026-07-20 21:10:00.000')
+const marketReaderConfig = {
+  ...config,
+  clickhouse: {
+    ...config.clickhouse,
+    bounds: {
+      schemaVersion: 'bayn.evaluation-bounds.v1' as const,
+      dataStart: '2026-07-19' as const,
+      dataEnd: '2026-07-20' as const,
+      lookbackStart: '2026-07-19' as const,
+      evaluationStart: marketEvaluationStart,
+      evaluationEnd: '2026-07-20' as const,
+    },
+  },
+}
 
 describe('forward performance read program', () => {
+  test('constructs exact immutable Signal volume evidence without rounding fractional microshares', () => {
+    const first = success(
+      makeForwardPerformanceMarketVolumeEvidence(marketVolumeRequest, marketSnapshotRows, marketEvaluationStart),
+    )
+    const second = success(
+      makeForwardPerformanceMarketVolumeEvidence(marketVolumeRequest, marketSnapshotRows, marketEvaluationStart),
+    )
+
+    expect(first).toEqual(second)
+    expect(first).toMatchObject({
+      schemaVersion: 'bayn.forward-performance-market-volume-evidence.v1',
+      cycleId: marketVolumeRequest.cycleId,
+      symbol: 'NVDA',
+      executionSessionDate: '2026-07-20',
+      quantityMicros: '123456789',
+      closePriceMicros: '103000000',
+      snapshotId: marketSnapshotId,
+      manifestContentHash: canonicalHashV1(marketManifestMaterial),
+      barsContentHash: marketBarsContentHash,
+      finalizedAt: '2026-07-20T21:05:00.000Z',
+      requestedStart: '2026-07-19',
+      evaluationStart: marketEvaluationStart,
+      calendarVersion: 'fixture-calendar-v1',
+      source: 'alpaca',
+      sourceFeed: 'sip',
+      adjustment: 'all',
+    })
+    expect(first?.contentHash).toMatch(/^[a-f0-9]{64}$/)
+  })
+
+  test('keeps tampered finalized manifest and bar evidence unavailable for capacity measurement', () => {
+    const tamperedManifest = success(
+      makeForwardPerformanceMarketVolumeEvidence(
+        marketVolumeRequest,
+        {
+          ...marketSnapshotRows,
+          manifests: marketSnapshotRows.manifests.map((manifest) => ({
+            ...manifest,
+            publisher_source_revision: 'c'.repeat(40),
+          })),
+        },
+        marketEvaluationStart,
+      ),
+    )
+    const tamperedBar = success(
+      makeForwardPerformanceMarketVolumeEvidence(
+        marketVolumeRequest,
+        {
+          ...marketSnapshotRows,
+          bars: marketSnapshotRows.bars.map((bar) =>
+            bar.session_date === '2026-07-20' ? { ...bar, adjusted_close: '102.00000000' } : bar,
+          ),
+        },
+        marketEvaluationStart,
+      ),
+    )
+
+    expect(tamperedManifest).toBeUndefined()
+    expect(tamperedBar).toBeUndefined()
+  })
+
+  test('binds the earliest execution-session snapshot separately from the signal snapshot', async () => {
+    interface ClickhouseParameter {
+      readonly value: unknown
+    }
+    const queries: Array<{ readonly text: string; readonly parameters: readonly unknown[] }> = []
+    const manifests = [...marketSnapshotRows.manifests, ...newerMarketSnapshot.rows.manifests]
+    const sessions = [...marketSnapshotRows.sessions, ...newerMarketSnapshot.rows.sessions]
+    const bars = [...marketSnapshotRows.bars, ...newerMarketSnapshot.rows.bars]
+    const statement = (
+      strings: TemplateStringsArray,
+      ...fragments: readonly ClickhouseParameter[]
+    ): Effect.Effect<readonly unknown[]> =>
+      Effect.sync(() => {
+        const text = strings.join('?')
+        const parameters = fragments.map((fragment) => fragment.value)
+        queries.push({ text, parameters })
+        if (text.includes('FROM signal.snapshot_manifests_v2') && text.includes('WHERE snapshot_id')) {
+          return manifests.filter((manifest) => manifest.snapshot_id === parameters[0])
+        }
+        if (text.includes('FROM signal.snapshot_manifests_v2 AS manifest')) {
+          return text.includes('ORDER BY manifest.finalized_at ASC') ? marketSnapshotRows.manifests : []
+        }
+        if (text.includes('FROM signal.exchange_sessions_v1')) {
+          return sessions.filter((session) => session.snapshot_id === parameters[0])
+        }
+        if (text.includes('FROM signal.adjusted_daily_bars_v2')) {
+          return bars.filter((bar) => bar.snapshot_id === parameters[0])
+        }
+        return []
+      })
+    const client = Object.assign(statement, {
+      param: (_dataType: string, value: unknown): ClickhouseParameter => ({ value }),
+      withQueryId:
+        (_queryId: string) =>
+        <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+          effect,
+    }) as unknown as ClickhouseClient.ClickhouseClient
+
+    const evidence = await Effect.runPromise(
+      readForwardPerformanceMarketVolumeWithClient(marketReaderConfig, [marketVolumeRequest]).pipe(
+        Effect.provide(Layer.succeed(ClickhouseClient.ClickhouseClient, client)),
+      ),
+    )
+
+    expect(evidence).toHaveLength(1)
+    expect(evidence[0]).toMatchObject({
+      decisionSnapshotId: marketDecisionSnapshotId,
+      decisionSnapshotAsOfSession: '2026-07-19',
+      snapshotId: marketSnapshotId,
+      closePriceMicros: '103000000',
+      quantityMicros: '123456789',
+    })
+    expect(evidence[0]?.snapshotId).not.toBe(newerMarketSnapshot.snapshotId)
+    expect(
+      queries.some(
+        (query) =>
+          query.text.includes('FROM signal.snapshot_manifests_v2') &&
+          query.text.includes('WHERE snapshot_id') &&
+          query.parameters[0] === marketSnapshotId,
+      ),
+    ).toBe(true)
+    expect(
+      queries.some((query) => query.text.includes('ORDER BY manifest.finalized_at ASC, manifest.snapshot_id ASC')),
+    ).toBe(true)
+    const discovery = queries.find((query) =>
+      query.text.includes('ORDER BY manifest.finalized_at ASC, manifest.snapshot_id ASC'),
+    )
+    expect(discovery?.text).toContain('manifest.finalized_at >= parseDateTime64BestEffort')
+    expect(discovery?.text).toContain('manifest.finalized_at <= parseDateTime64BestEffort')
+    expect(discovery?.parameters).toContain(marketVolumeRequest.windowClosedAt)
+    expect(discovery?.parameters).toContain(marketVolumeRequest.evidenceCutoffAt)
+    expect(queries.some((query) => query.parameters[0] === marketDecisionSnapshotId)).toBe(false)
+    expect(
+      queries
+        .filter(
+          (query) =>
+            query.text.includes('FROM signal.exchange_sessions_v1') ||
+            query.text.includes('FROM signal.adjusted_daily_bars_v2'),
+        )
+        .every((query) => query.parameters[0] === marketSnapshotId),
+    ).toBe(true)
+  })
+
+  test('binds partial terminal prices independently of later broker observation order', () => {
+    const marketVolume = success(
+      makeForwardPerformanceMarketVolumeEvidence(marketVolumeRequest, marketSnapshotRows, marketEvaluationStart),
+    )
+    if (marketVolume === undefined) throw new Error('market-volume fixture failed')
+    const execution = {
+      cycleId: marketVolumeRequest.cycleId,
+      decisionDocumentHash: hash('6'),
+      decisionHash: hash('7'),
+      decisionCreatedAt: '2026-07-20T13:00:00.000Z',
+      intentId: hash('8'),
+      accountId: identityResult.success.accountId,
+      symbol: 'NVDA',
+      side: 'BUY' as const,
+      plannedQuantityMicros: '1000000',
+      referencePriceMicros: '100000000',
+      terminalOrder: {
+        eventId: hash('9'),
+        brokerOrderId: 'partial-broker-order',
+        clientOrderId: 'partial-client-order',
+        intentId: hash('8'),
+        accountId: identityResult.success.accountId,
+        symbol: 'NVDA',
+        side: 'BUY' as const,
+        quantityMicros: '1000000',
+        filledQuantityMicros: '400000',
+        status: 'CANCELED' as const,
+        occurredAt: '2026-07-20T20:00:00.000Z',
+        observedAt: '2026-07-20T21:06:00.000Z',
+      },
+      fills: [],
+    }
+    const first = success(bindForwardPerformanceTerminalReferencePrices([execution], [marketVolume]))
+    const second = success(bindForwardPerformanceTerminalReferencePrices([execution], [marketVolume]))
+
+    expect(first).toEqual(second)
+    expect(first[0]?.terminalReferencePrice).toMatchObject({
+      schemaVersion: 'bayn.forward-performance-terminal-reference-price.v1',
+      cycleId: marketVolumeRequest.cycleId,
+      symbol: 'NVDA',
+      executionSessionDate: '2026-07-20',
+      priceMicros: '103000000',
+      observedAt: '2026-07-20T21:05:00.000Z',
+      sourceEvidenceHash: marketVolume.contentHash,
+    })
+    expect(first[0]?.terminalReferencePrice?.contentHash).toMatch(/^[a-f0-9]{64}$/)
+  })
+
+  test('binds a blocked intent terminal price without fabricating a broker order', () => {
+    const marketVolume = success(
+      makeForwardPerformanceMarketVolumeEvidence(marketVolumeRequest, marketSnapshotRows, marketEvaluationStart),
+    )
+    if (marketVolume === undefined) throw new Error('market-volume fixture failed')
+    const intentId = hash('8')
+    const execution = {
+      cycleId: marketVolumeRequest.cycleId,
+      decisionDocumentHash: hash('6'),
+      decisionHash: hash('7'),
+      decisionCreatedAt: '2026-07-20T13:00:00.000Z',
+      intentId,
+      accountId: identityResult.success.accountId,
+      symbol: 'NVDA',
+      side: 'BUY' as const,
+      plannedQuantityMicros: '1000000',
+      referencePriceMicros: '100000000',
+      intent: {
+        intentId,
+        accountId: identityResult.success.accountId,
+        clientOrderId: 'blocked-client-order',
+        cycleId: marketVolumeRequest.cycleId,
+        decisionHash: hash('7'),
+        symbol: 'NVDA',
+        side: 'BUY' as const,
+        quantityMicros: '1000000',
+        terminalOutcome: 'BLOCKED' as const,
+        createdAt: '2026-07-20T13:00:00.000Z',
+        updatedAt: '2026-07-20T13:05:00.000Z',
+      },
+      fills: [],
+    }
+
+    const first = success(bindForwardPerformanceTerminalReferencePrices([execution], [marketVolume]))
+    const second = success(bindForwardPerformanceTerminalReferencePrices([execution], [marketVolume]))
+
+    expect(first).toEqual(second)
+    expect(first[0]?.terminalOrder).toBeUndefined()
+    expect(first[0]?.terminalReferencePrice).toMatchObject({
+      schemaVersion: 'bayn.forward-performance-terminal-reference-price.v1',
+      cycleId: marketVolumeRequest.cycleId,
+      symbol: 'NVDA',
+      priceMicros: '103000000',
+      observedAt: '2026-07-20T21:05:00.000Z',
+      sourceEvidenceHash: marketVolume.contentHash,
+    })
+  })
+
   test('executes only read-only PostgreSQL statements and never treats zero activity as profitable', async () => {
     const observation: SqlObservation = { statements: [] }
     const sql = makeReadOnlySql(observation)
     let observedCashYieldEvidence: ForwardPerformanceCashYieldEvidence | undefined
     const readers: ForwardPerformanceReaders = {
       postgres: readForwardPerformancePostgres,
+      marketVolume: () => Effect.succeed([]),
       ledger: (_config, _accountId, _plans, cashYieldEvidence) => {
         observedCashYieldEvidence = cashYieldEvidence
         return Effect.succeed({
@@ -206,11 +635,38 @@ describe('forward performance read program', () => {
         /\b(?:INSERT|UPDATE|DELETE|TRUNCATE|ALTER|CREATE|DROP|LOCK)\b/i.test(statement),
       ),
     ).toEqual([])
+    expect(
+      observation.statements.some((statement) =>
+        statement.includes('JOIN autonomous_cycle_shadow_decisions AS decision'),
+      ),
+    ).toBe(true)
+    expect(
+      observation.statements.some(
+        (statement) =>
+          statement.includes("decision.schema_version = 'bayn.observe-shadow-decision.v1'") &&
+          statement.includes("decision.document ->> 'mode' = 'OBSERVE'"),
+      ),
+    ).toBe(true)
+    expect(observation.statements.some((statement) => statement.includes('bayn.paper-cycle-decision.v1'))).toBe(false)
+    expect(
+      observation.statements.some((statement) => statement.includes('JOIN snapshot_references AS reference')),
+    ).toBe(true)
+    expect(observation.statements.some((statement) => statement.includes('FROM intents AS intent'))).toBe(true)
+    expect(observation.statements.some((statement) => statement.includes('FROM orders AS observed_order'))).toBe(true)
+    expect(observation.statements.some((statement) => statement.includes('FROM fills AS fill'))).toBe(true)
     expect(receipt.evidence.status).toBe('INSUFFICIENT_EVIDENCE')
     expect(receipt.evidence.reasonCodes).toContain('ZERO_COMPLETED_EXECUTIONS')
     expect(receipt.evidence.reasonCodes).toContain('NON_EXACT_RECONCILIATION')
     expect(receipt.evidence.reasonCodes).toContain('CASH_YIELD_EVIDENCE_GAP')
     expect(receipt.profitability).toBe('UNDETERMINED')
+    expect(receipt.executionQuality).toMatchObject({
+      status: 'NOT_ELIGIBLE',
+      reasonCodes: ['ZERO_COMPLETED_EXECUTIONS'],
+    })
+    expect(receipt.observedCapacity).toMatchObject({
+      status: 'NOT_ELIGIBLE',
+      reasonCodes: ['ZERO_COMPLETED_EXECUTIONS'],
+    })
     expect(receipt.window).toMatchObject({
       reconciliationStatus: 'DISCREPANCY',
       cashYieldAdjustedExact: false,
@@ -241,6 +697,7 @@ describe('forward performance read program', () => {
     const sql = makeReadOnlySql(observation, { extraReconciliationDiscrepancy: true })
     const readers: ForwardPerformanceReaders = {
       postgres: readForwardPerformancePostgres,
+      marketVolume: () => Effect.succeed([]),
       ledger: () =>
         Effect.succeed({
           totals: {
@@ -298,6 +755,11 @@ describe('forward performance read program', () => {
       planAccountingReceipt(prepared, config.tigerBeetle.clusterId.toString(), config.tigerBeetle.ledger),
     )
     const accountingReceipt = { ...receiptPlan, recordedAt: '2026-07-20T20:00:01.000Z' }
+    const marketVolumeEvidence = success(
+      makeForwardPerformanceMarketVolumeEvidence(marketVolumeRequest, marketSnapshotRows, marketEvaluationStart),
+    )
+    if (marketVolumeEvidence === undefined) throw new Error('market-volume fixture failed')
+    let observedMarketVolumeRequests: readonly ForwardPerformanceMarketVolumeRequest[] | undefined
     const readers: ForwardPerformanceReaders = {
       postgres: () =>
         Effect.succeed({
@@ -365,6 +827,8 @@ describe('forward performance read program', () => {
               occurredAt: fill.occurredAt,
             },
           ],
+          executionEvidence: [],
+          marketVolumeRequests: [marketVolumeRequest],
           receipts: [accountingReceipt],
           durableExecutionBindings: [
             {
@@ -390,6 +854,10 @@ describe('forward performance read program', () => {
           unaccountedFillCount: 0,
           postReconciliationActivityCount: 0,
         }),
+      marketVolume: (_config, requests) => {
+        observedMarketVolumeRequests = requests
+        return Effect.succeed([marketVolumeEvidence])
+      },
       ledger: (_config, _accountId, _plans, cashYieldEvidence) => {
         expect(cashYieldEvidence).toEqual({
           schemaVersion: 'bayn.forward-performance-cash-yield-evidence.v1',
@@ -431,7 +899,8 @@ describe('forward performance read program', () => {
       Effect.scoped(runForwardPerformance(config, readers).pipe(Effect.provide(Layer.succeed(PgClient.PgClient, sql)))),
     )
 
-    expect(receipt.schemaVersion).toBe('bayn.forward-performance-receipt.v2')
+    expect(receipt.schemaVersion).toBe('bayn.forward-performance-receipt.v3')
+    expect(observedMarketVolumeRequests).toEqual([marketVolumeRequest])
     expect(receipt.evidence).toEqual({
       status: 'SUFFICIENT',
       reasonCodes: [],

--- a/services/bayn/src/forward-performance/program.ts
+++ b/services/bayn/src/forward-performance/program.ts
@@ -1,11 +1,18 @@
+import { ClickhouseClient } from '@effect/sql-clickhouse'
 import { PgClient } from '@effect/sql-pg'
-import { Data, Effect, Result, Scope } from 'effect'
+import { Data, Effect, Redacted, Result, Scope } from 'effect'
 
 import type { LoadedRuntimeConfig } from '../config'
 import { verifyAccountingReceipts } from '../db/reconciliation-algebra'
 import { type ReconciliationAlgebraFailure } from '../db/reconciliation-algebra'
 import type { CanonicalJsonFailure } from '../hash'
+import { canonicalHashV1Result } from '../hash'
+import type { MarketDataSnapshot, SnapshotRequest } from '../market-data'
+import { makeMarketDataQueries } from '../market-data/queries'
+import { decodeSnapshotRows, type SnapshotRows } from '../market-data/rows'
+import { verifyFinalizedSnapshot } from '../market-data-verification'
 import type { BrokerIdentity } from '../broker/identity'
+import type { IsoDate } from '../schemas'
 import { makeForwardPerformanceReceipt, type ForwardPerformanceDomainFailure } from './domain'
 import {
   readForwardPerformancePostgres,
@@ -18,19 +25,32 @@ import {
   type ForwardPerformanceLedgerError,
 } from './tigerbeetle'
 import type { LedgerPlan } from '../ledger-plan'
-import type { ForwardPerformanceCashYieldEvidence, ForwardPerformanceReceipt } from './model'
+import type {
+  ForwardPerformanceCashYieldEvidence,
+  ForwardPerformanceExecutionEvidence,
+  ForwardPerformanceMarketVolumeEvidence,
+  ForwardPerformanceMarketVolumeRequest,
+  ForwardPerformanceReceipt,
+} from './model'
 
 export type ForwardPerformanceProgramCause =
   | CanonicalJsonFailure
   | ForwardPerformanceDomainFailure
   | ForwardPerformanceLedgerError
+  | ForwardPerformanceMarketVolumeError
   | ForwardPerformancePostgresError
   | ReconciliationAlgebraFailure
 
 export class ForwardPerformanceProgramError extends Data.TaggedError('ForwardPerformanceProgramError')<{
-  readonly operation: 'account-binding' | 'construct-receipt' | 'ledger-read' | 'postgres-read'
+  readonly operation: 'account-binding' | 'construct-receipt' | 'ledger-read' | 'market-volume-read' | 'postgres-read'
   readonly message: string
   readonly cause?: ForwardPerformanceProgramCause
+}> {}
+
+export class ForwardPerformanceMarketVolumeError extends Data.TaggedError('ForwardPerformanceMarketVolumeError')<{
+  readonly operation: 'read'
+  readonly message: string
+  readonly cause: unknown
 }> {}
 
 type BoundForwardPerformanceConfig = LoadedRuntimeConfig & {
@@ -48,11 +68,414 @@ export interface ForwardPerformanceReaders {
     plans: readonly LedgerPlan[],
     cashYieldEvidence?: ForwardPerformanceCashYieldEvidence,
   ) => Effect.Effect<ForwardPerformanceLedgerEvidence, ForwardPerformanceLedgerError, Scope.Scope>
+  readonly marketVolume: (
+    config: Pick<LoadedRuntimeConfig, 'clickhouse' | 'operationTimeoutMs'>,
+    requests: readonly ForwardPerformanceMarketVolumeRequest[],
+  ) => Effect.Effect<readonly ForwardPerformanceMarketVolumeEvidence[], ForwardPerformanceMarketVolumeError>
 }
 
 export const liveForwardPerformanceReaders: ForwardPerformanceReaders = {
   postgres: readForwardPerformancePostgres,
   ledger: readForwardPerformanceLedger,
+  marketVolume: readForwardPerformanceMarketVolume,
+}
+
+const SIGNED_I128_MAX = (1n << 127n) - 1n
+
+const marketVolumeError = (cause: unknown): ForwardPerformanceMarketVolumeError =>
+  new ForwardPerformanceMarketVolumeError({
+    operation: 'read',
+    message: 'forward-performance immutable market-volume read failed',
+    cause,
+  })
+
+const fixedDecimalMicros = (value: string): string | undefined => {
+  const match = /^(0|[1-9][0-9]*)[.]([0-9]{8})$/.exec(value)
+  if (match === null || match[1] === undefined || match[2] === undefined || !match[2].endsWith('00')) return undefined
+  const micros = BigInt(match[1]) * 1_000_000n + BigInt(match[2].slice(0, 6))
+  return micros > 0n && micros <= SIGNED_I128_MAX ? micros.toString() : undefined
+}
+
+const finalizedInstant = (value: string): string | undefined => {
+  const match = /^(\d{4}-\d{2}-\d{2}) (\d{2}:\d{2}:\d{2})(?:[.]([0-9]{3}))?$/.exec(value)
+  if (match === null || match[1] === undefined || match[2] === undefined) return undefined
+  const instant = `${match[1]}T${match[2]}.${match[3] ?? '000'}Z`
+  return Number.isFinite(Date.parse(instant)) && new Date(instant).toISOString() === instant ? instant : undefined
+}
+
+interface ForwardPerformanceMarketSnapshotRows {
+  readonly bars: readonly unknown[]
+  readonly sessions: readonly unknown[]
+  readonly manifests: readonly unknown[]
+}
+
+interface VerifiedForwardPerformanceMarketSnapshot {
+  readonly rows: SnapshotRows
+  readonly snapshot: MarketDataSnapshot
+}
+
+const snapshotRequest = (
+  request: ForwardPerformanceMarketVolumeRequest,
+  rows: SnapshotRows,
+  evaluationStart: IsoDate,
+): SnapshotRequest | undefined => {
+  const manifest = rows.manifests[0]
+  if (
+    rows.manifests.length !== 1 ||
+    manifest === undefined ||
+    manifest.snapshot_id === request.decisionSnapshotId ||
+    request.decisionSnapshotAsOfSession >= request.executionSessionDate
+  ) {
+    return undefined
+  }
+  const observedAt = finalizedInstant(manifest.finalized_at)
+  if (observedAt === undefined || observedAt < request.windowClosedAt || observedAt > request.evidenceCutoffAt) {
+    return undefined
+  }
+  return {
+    snapshotId: manifest.snapshot_id,
+    publicationAsOf: request.executionSessionDate,
+    calendarVersion: request.calendarVersion,
+    universe: request.symbols,
+    bounds: {
+      schemaVersion: 'bayn.evaluation-bounds.v1',
+      dataStart: request.requestedStart,
+      dataEnd: request.executionSessionDate,
+      lookbackStart: request.requestedStart,
+      evaluationStart,
+      evaluationEnd: request.executionSessionDate,
+    },
+    observedAt,
+    universeId: request.universeId,
+    universeSymbolHash: request.universeSymbolHash,
+    historyStart: request.requestedStart,
+    evaluationStart,
+  }
+}
+
+const verifyForwardPerformanceMarketSnapshot = (
+  request: ForwardPerformanceMarketVolumeRequest,
+  rawRows: ForwardPerformanceMarketSnapshotRows,
+  evaluationStart: IsoDate,
+): VerifiedForwardPerformanceMarketSnapshot | undefined => {
+  const decoded = decodeSnapshotRows(rawRows.bars, rawRows.sessions, rawRows.manifests)
+  if (Result.isFailure(decoded)) return undefined
+  const verificationRequest = snapshotRequest(request, decoded.success, evaluationStart)
+  if (verificationRequest === undefined) return undefined
+  const verified = verifyFinalizedSnapshot(decoded.success, verificationRequest)
+  if (Result.isFailure(verified)) return undefined
+  const source = verified.success.manifest.finalizedSnapshot
+  if (
+    source.snapshotId === request.decisionSnapshotId ||
+    source.source !== request.source ||
+    source.sourceFeed !== request.sourceFeed ||
+    source.adjustment !== request.adjustment ||
+    source.calendarVersion !== request.calendarVersion ||
+    source.asOfSession !== request.executionSessionDate ||
+    source.universeId !== request.universeId ||
+    source.universeSymbolHash !== request.universeSymbolHash ||
+    source.requestedStart !== request.requestedStart
+  ) {
+    return undefined
+  }
+  return { rows: decoded.success, snapshot: verified.success }
+}
+
+const projectForwardPerformanceMarketVolumeEvidence = (
+  request: ForwardPerformanceMarketVolumeRequest,
+  verified: VerifiedForwardPerformanceMarketSnapshot,
+  evaluationStart: IsoDate,
+): Result.Result<ForwardPerformanceMarketVolumeEvidence | undefined, ForwardPerformanceMarketVolumeError> => {
+  const matchingBars = verified.rows.bars.filter(
+    (bar) => bar.symbol === request.symbol && bar.session_date === request.executionSessionDate,
+  )
+  const row = matchingBars.length === 1 ? matchingBars[0] : undefined
+  if (row === undefined) return Result.succeed(undefined)
+  const quantityMicros = fixedDecimalMicros(row.adjusted_volume)
+  const closePriceMicros = fixedDecimalMicros(row.adjusted_close)
+  if (quantityMicros === undefined || closePriceMicros === undefined) return Result.succeed(undefined)
+  const source = verified.snapshot.manifest.finalizedSnapshot
+  const material = {
+    schemaVersion: 'bayn.forward-performance-market-volume-evidence.v1' as const,
+    cycleId: request.cycleId,
+    decisionSnapshotId: request.decisionSnapshotId,
+    decisionSnapshotAsOfSession: request.decisionSnapshotAsOfSession,
+    symbol: request.symbol,
+    executionSessionDate: request.executionSessionDate,
+    windowOpenedAt: request.windowOpenedAt,
+    windowClosedAt: request.windowClosedAt,
+    evidenceCutoffAt: request.evidenceCutoffAt,
+    quantityMicros,
+    closePriceMicros,
+    snapshotId: source.snapshotId,
+    manifestContentHash: source.publicationId,
+    barsContentHash: source.contentHash,
+    finalizedAt: source.finalizedAt,
+    universeId: request.universeId,
+    universeSymbolHash: request.universeSymbolHash,
+    requestedStart: request.requestedStart,
+    evaluationStart,
+    calendarVersion: request.calendarVersion,
+    source: request.source,
+    sourceFeed: request.sourceFeed,
+    adjustment: request.adjustment,
+  }
+  return Result.mapError(
+    Result.map(canonicalHashV1Result(material), (contentHash) => ({ ...material, contentHash })),
+    marketVolumeError,
+  )
+}
+
+export const makeForwardPerformanceMarketVolumeEvidence = (
+  request: ForwardPerformanceMarketVolumeRequest,
+  rows: ForwardPerformanceMarketSnapshotRows,
+  evaluationStart: IsoDate,
+): Result.Result<ForwardPerformanceMarketVolumeEvidence | undefined, ForwardPerformanceMarketVolumeError> => {
+  const verified = verifyForwardPerformanceMarketSnapshot(request, rows, evaluationStart)
+  return verified === undefined
+    ? Result.succeed(undefined)
+    : projectForwardPerformanceMarketVolumeEvidence(request, verified, evaluationStart)
+}
+
+const requestGroupKey = (request: ForwardPerformanceMarketVolumeRequest): string =>
+  JSON.stringify([
+    request.decisionSnapshotId,
+    request.decisionSnapshotAsOfSession,
+    request.executionSessionDate,
+    request.evidenceCutoffAt,
+    request.universeId,
+    request.universeSymbolHash,
+    request.symbols,
+    request.requestedStart,
+    request.calendarVersion,
+    request.source,
+    request.sourceFeed,
+    request.adjustment,
+  ])
+
+const groupMarketVolumeRequests = (
+  requests: readonly ForwardPerformanceMarketVolumeRequest[],
+): readonly (readonly ForwardPerformanceMarketVolumeRequest[])[] => {
+  const groups = new Map<string, ForwardPerformanceMarketVolumeRequest[]>()
+  for (const request of requests) {
+    const key = requestGroupKey(request)
+    const group = groups.get(key)
+    if (group === undefined) groups.set(key, [request])
+    else group.push(request)
+  }
+  return [...groups.entries()]
+    .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
+    .map(([, group]) => group)
+}
+
+export const readForwardPerformanceMarketVolumeWithClient = (
+  config: Pick<LoadedRuntimeConfig, 'clickhouse' | 'operationTimeoutMs'>,
+  requests: readonly ForwardPerformanceMarketVolumeRequest[],
+): Effect.Effect<
+  readonly ForwardPerformanceMarketVolumeEvidence[],
+  ForwardPerformanceMarketVolumeError,
+  ClickhouseClient.ClickhouseClient
+> => {
+  if (requests.length === 0) return Effect.succeed([])
+  return Effect.gen(function* () {
+    const sql = yield* ClickhouseClient.ClickhouseClient
+    const groups = yield* Effect.forEach(
+      groupMarketVolumeRequests(requests),
+      (group) =>
+        Effect.gen(function* () {
+          const request = group[0]
+          if (request === undefined) return []
+          const queries = makeMarketDataQueries(sql, config, {
+            universeId: request.universeId,
+            universeSymbolHash: request.universeSymbolHash,
+            universe: request.symbols,
+            historyStart: request.requestedStart,
+            evaluationStart: config.clickhouse.bounds.evaluationStart,
+          })
+          const candidateRows = yield* sql<Record<string, unknown>>`
+            SELECT
+              snapshot_id,
+              schema_version,
+              publisher_source_revision,
+              publisher_image_repository,
+              publisher_image_digest,
+              universe_id,
+              universe_symbol_hash,
+              provider,
+              source_feed,
+              adjustment,
+              calendar_version,
+              toString(requested_start) AS requested_start,
+              toString(publication_asof) AS publication_asof,
+              toString(first_session) AS first_session,
+              toString(last_session) AS last_session,
+              symbol_count,
+              session_count,
+              bar_count,
+              bars_content_hash,
+              sessions_content_hash,
+              manifest_content_hash,
+              toString(finalized_at) AS finalized_at
+            FROM signal.snapshot_manifests_v2 AS manifest
+            WHERE manifest.universe_id = ${sql.param('String', request.universeId)}
+              AND manifest.universe_symbol_hash = ${sql.param('String', request.universeSymbolHash)}
+              AND manifest.requested_start = toDate(${sql.param('String', request.requestedStart)})
+              AND manifest.publication_asof = toDate(${sql.param('String', request.executionSessionDate)})
+              AND manifest.calendar_version = ${sql.param('String', request.calendarVersion)}
+              AND manifest.provider = ${sql.param('String', request.source)}
+              AND manifest.source_feed = ${sql.param('String', request.sourceFeed)}
+              AND manifest.adjustment = ${sql.param('String', request.adjustment)}
+              AND manifest.finalized_at >= parseDateTime64BestEffort(${sql.param('String', request.windowClosedAt)})
+              AND manifest.finalized_at <= parseDateTime64BestEffort(${sql.param('String', request.evidenceCutoffAt)})
+            ORDER BY manifest.finalized_at ASC, manifest.snapshot_id ASC
+            LIMIT 1
+          `
+          const decodedCandidates = decodeSnapshotRows([], [], candidateRows)
+          if (Result.isFailure(decodedCandidates)) return []
+          const candidate = decodedCandidates.success.manifests[0]
+          if (
+            decodedCandidates.success.manifests.length !== 1 ||
+            candidate === undefined ||
+            candidate.snapshot_id === request.decisionSnapshotId
+          ) {
+            return []
+          }
+          const manifests = yield* queries.loadSnapshotPublicationManifest({
+            snapshotId: candidate.snapshot_id,
+            signalSessionDate: request.executionSessionDate,
+            signalCalendarVersion: request.calendarVersion,
+          })
+          const decodedManifests = decodeSnapshotRows([], [], manifests)
+          if (Result.isFailure(decodedManifests)) return []
+          const manifest = decodedManifests.success.manifests[0]
+          if (
+            decodedManifests.success.manifests.length !== 1 ||
+            manifest === undefined ||
+            manifest.snapshot_id !== candidate.snapshot_id ||
+            manifest.manifest_content_hash !== candidate.manifest_content_hash
+          ) {
+            return []
+          }
+          const rows = yield* Effect.all(
+            {
+              bars: queries.loadSnapshotPublicationBars(candidate.snapshot_id),
+              sessions: queries.loadPublicationSessions(candidate.snapshot_id),
+            },
+            { concurrency: 2 },
+          )
+          const verified = verifyForwardPerformanceMarketSnapshot(
+            request,
+            { bars: rows.bars, sessions: rows.sessions, manifests },
+            config.clickhouse.bounds.evaluationStart,
+          )
+          if (verified === undefined) return []
+          const projected = yield* Effect.forEach(group, (item) =>
+            Effect.fromResult(
+              projectForwardPerformanceMarketVolumeEvidence(item, verified, config.clickhouse.bounds.evaluationStart),
+            ),
+          )
+          return projected.filter((item): item is ForwardPerformanceMarketVolumeEvidence => item !== undefined)
+        }).pipe(
+          Effect.mapError((cause) =>
+            cause instanceof ForwardPerformanceMarketVolumeError ? cause : marketVolumeError(cause),
+          ),
+        ),
+      { concurrency: 2 },
+    )
+    return groups.flat().sort((left, right) => {
+      const leftKey = JSON.stringify([left.executionSessionDate, left.cycleId, left.symbol])
+      const rightKey = JSON.stringify([right.executionSessionDate, right.cycleId, right.symbol])
+      return leftKey < rightKey ? -1 : leftKey > rightKey ? 1 : 0
+    })
+  }).pipe(
+    Effect.mapError((cause) =>
+      cause instanceof ForwardPerformanceMarketVolumeError ? cause : marketVolumeError(cause),
+    ),
+  )
+}
+
+export function readForwardPerformanceMarketVolume(
+  config: Pick<LoadedRuntimeConfig, 'clickhouse' | 'operationTimeoutMs'>,
+  requests: readonly ForwardPerformanceMarketVolumeRequest[],
+): Effect.Effect<readonly ForwardPerformanceMarketVolumeEvidence[], ForwardPerformanceMarketVolumeError> {
+  if (requests.length === 0) return Effect.succeed([])
+  const client = ClickhouseClient.layer({
+    url: config.clickhouse.url,
+    username: config.clickhouse.username,
+    password: Redacted.value(config.clickhouse.password),
+    database: 'signal',
+    application: 'bayn-forward-performance',
+    request_timeout: config.operationTimeoutMs,
+  })
+  return Effect.scoped(
+    readForwardPerformanceMarketVolumeWithClient(config, requests).pipe(Effect.provide(client)),
+  ).pipe(
+    Effect.mapError((cause) =>
+      cause instanceof ForwardPerformanceMarketVolumeError ? cause : marketVolumeError(cause),
+    ),
+  )
+}
+
+const canonicalUnsigned = (value: string): bigint | undefined =>
+  /^(?:0|[1-9][0-9]*)$/.test(value) ? BigInt(value) : undefined
+
+export const bindForwardPerformanceTerminalReferencePrices = (
+  executionEvidence: readonly ForwardPerformanceExecutionEvidence[],
+  marketVolumeEvidence: readonly ForwardPerformanceMarketVolumeEvidence[],
+): Result.Result<readonly ForwardPerformanceExecutionEvidence[], CanonicalJsonFailure> => {
+  const volumes = new Map<string, ForwardPerformanceMarketVolumeEvidence | null>()
+  for (const volume of marketVolumeEvidence) {
+    const key = JSON.stringify([volume.cycleId, volume.symbol])
+    volumes.set(key, volumes.has(key) ? null : volume)
+  }
+  return Result.all(
+    executionEvidence.map((execution) => {
+      const order = execution.terminalOrder
+      const orderQuantity = order === undefined ? undefined : canonicalUnsigned(order.quantityMicros)
+      const filledQuantity = order === undefined ? undefined : canonicalUnsigned(order.filledQuantityMicros)
+      const blockedAt =
+        execution.intent?.terminalOutcome === 'BLOCKED' && order === undefined && execution.fills.length === 0
+          ? execution.intent.updatedAt
+          : undefined
+      const incompleteOrder =
+        order !== undefined &&
+        ['CANCELED', 'EXPIRED', 'REJECTED'].includes(order.status) &&
+        orderQuantity !== undefined &&
+        filledQuantity !== undefined &&
+        filledQuantity < orderQuantity
+          ? order
+          : undefined
+      const terminalOccurredAt = blockedAt ?? incompleteOrder?.occurredAt
+      const terminalObservedAt = blockedAt ?? incompleteOrder?.observedAt
+      if (terminalOccurredAt === undefined || terminalObservedAt === undefined) {
+        return Result.succeed(execution)
+      }
+      const volume = volumes.get(JSON.stringify([execution.cycleId, execution.symbol]))
+      if (volume === undefined || volume === null) {
+        return Result.succeed(execution)
+      }
+      const terminalWithinExecutionWindow =
+        blockedAt === undefined
+          ? terminalOccurredAt >= volume.windowOpenedAt && terminalOccurredAt <= volume.windowClosedAt
+          : terminalOccurredAt <= volume.windowClosedAt
+      if (!terminalWithinExecutionWindow || terminalObservedAt > volume.evidenceCutoffAt) {
+        return Result.succeed(execution)
+      }
+      const material = {
+        schemaVersion: 'bayn.forward-performance-terminal-reference-price.v1' as const,
+        cycleId: execution.cycleId,
+        symbol: execution.symbol,
+        executionSessionDate: volume.executionSessionDate,
+        priceMicros: volume.closePriceMicros,
+        observedAt: volume.finalizedAt,
+        sourceEvidenceHash: volume.contentHash,
+      }
+      return Result.map(canonicalHashV1Result(material), (contentHash) => ({
+        ...execution,
+        terminalReferencePrice: { ...material, contentHash },
+      }))
+    }),
+  )
 }
 
 const programError = (
@@ -83,6 +506,16 @@ export const runForwardPerformance = (
     const postgres = yield* readers
       .postgres(sql, identity.accountId)
       .pipe(Effect.mapError((cause) => programError('postgres-read', cause.message, cause)))
+    const marketVolumeEvidence = yield* readers
+      .marketVolume(config, postgres.marketVolumeRequests)
+      .pipe(Effect.mapError((cause) => programError('market-volume-read', cause.message, cause)))
+    const executionEvidence = yield* Effect.fromResult(
+      bindForwardPerformanceTerminalReferencePrices(postgres.executionEvidence, marketVolumeEvidence),
+    ).pipe(
+      Effect.mapError((cause) =>
+        programError('construct-receipt', 'forward-performance terminal reference binding failed', cause),
+      ),
+    )
 
     const accountingVerification = verifyAccountingReceipts(postgres.transactions, postgres.receipts, config)
     const plans = Result.isSuccess(accountingVerification) ? accountingVerification.success.plans : []
@@ -127,6 +560,8 @@ export const runForwardPerformance = (
           ? {}
           : { startingCapitalMicros: postgres.startingCapitalMicros }),
         transactions: postgres.transactionEvidence,
+        executionEvidence,
+        marketVolumeEvidence,
         ledgerTotals: ledger.totals,
         cashYieldEvidenceRequired: ledger.cashYieldEvidenceRequired,
         ...(ledger.cashYieldEvidence === undefined ? {} : { cashYieldEvidence: ledger.cashYieldEvidence }),


### PR DESCRIPTION
## Summary

- extend the deterministic forward-performance receipt with independent execution-quality and observed-capacity sections without changing the existing P&L sufficiency or profitability decision
- reconstruct immutable PAPER plan evidence, terminal order/fill evidence, accounting transactions, explicit costs, timestamps, and reconciliation facts through the existing repeatable-read read-only command
- compute Perold-style execution-price and opportunity shortfall only from exact source evidence; missing plan, reference, fill, cost, reconciliation, terminal-price, or market-volume facts produce explicit `UNDETERMINED` gaps
- report only bounded observed participation/notional where an immutable market-volume window covers the exact decision-to-terminal interval; the current production read supplies no market-volume evidence, so capacity remains honestly `UNDETERMINED`
- preserve `IDENTITY_GAP`, `STARTING_CAPITAL_GAP`, `ZERO_COMPLETED_EXECUTIONS`, and existing profitability behavior; do not run the 252-session M5 evaluation
- bind canonical source-evidence hashes into receipt v3 so reordered identical evidence produces the same receipt hash

## Design sources

- André F. Perold, “The Implementation Shortfall,” DOI `10.3905/jpm.1988.409150`
- Robert Almgren and Neil Chriss, “Optimal execution of portfolio transactions,” DOI `10.21314/JOR.2001.041`
- Alpaca Broker API order fields: `https://github.com/alpacahq/alpaca-docs/blob/master/content/api-references/broker-api/trading/orders.md`

## Validation

- regression-first baseline: focused tests failed on the absent execution-quality/capacity sections before implementation
- focused forward-performance: `33 pass, 0 fail`
- scoped Oxfmt: pass
- scoped Oxlint: `0 warnings, 0 errors`
- scoped type-aware Oxlint: `0 warnings, 0 errors`
- full Bayn build: pass, including `forward-performance-command.js`
- full Bayn tests in the shared dirty checkout: `1072 pass, 148 skip, 4 fail`; all four failures are in the concurrently modified OBSERVE runtime composition lane, outside this PR
- full TypeScript and Effect lint in the shared dirty checkout: blocked only by concurrent `cycle-store` / `observe-composition` errors outside this PR
- full format check in the shared dirty checkout: blocked only by `src/db/cycle-store/lifecycle-program.ts`, outside this PR
- PostgreSQL command: `0 fail`; integration bodies skipped because no PostgreSQL test URL is configured locally
- exact-head GitHub CI is required before merge

## Scope

Exactly eight files under `services/bayn/src/forward-performance/**`. No migrations, execution/cycle/observe/activation/paper-proof, manifests, workflows, credentials, permissions, broker mutations, or holdout access.

Linear: PROOMPT-388
