### PR TITLE
fix(bayn): attest PR 13429 reconstruction

### DIFF
--- a/packages/scripts/src/bayn/verify-release-review.test.ts
+++ b/packages/scripts/src/bayn/verify-release-review.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test'
 import { createHash } from 'node:crypto'
 import { readFileSync } from 'node:fs'
+import { gunzipSync } from 'node:zlib'
 
 import {
   baynCodexBotLogin,
@@ -43,6 +44,14 @@ const requireHold = (
 ): Extract<BaynReleaseReviewPollResult, { readonly status: 'hold' }> => {
   expect(result.status).toBe('hold')
   if (result.status !== 'hold') throw new Error('expected release review HOLD')
+  return result
+}
+
+const requireEligibilityHold = (
+  result: ReturnType<typeof evaluateBaynReleaseEligibility>,
+): Extract<ReturnType<typeof evaluateBaynReleaseEligibility>, { readonly status: 'hold' }> => {
+  expect(result.status).toBe('hold')
+  if (result.status !== 'hold') throw new Error('expected release eligibility HOLD')
   return result
 }
 
@@ -669,7 +678,475 @@ const remediationHistoryFixture = (): {
   }
 }
 
+const multiStageRemediationRecordPath =
+  'services/bayn/release-review-remediations/9bea355c17fb9320fc692bb214f76af105650a02.json'
+const realMultiStageRemediationRecord = parseBaynReleaseReviewRemediationRecord(
+  JSON.parse(readFileSync(multiStageRemediationRecordPath, 'utf8')) as unknown,
+)
+const multiStageHistory = {
+  published: '319291bebe22b0c1dc928f13d0ff3655c4b22284',
+  promotion: 'bbef7b18804cf9e30c11eac326e90281d1774b80',
+  blocked: '9bea355c17fb9320fc692bb214f76af105650a02',
+  descendant: 'c778df23b22620fd12764e3bca06d0a58211b0de',
+  descendantHead: '944bc86112380f0484b892389b7864e26018bca9',
+  remediationHead: '6'.repeat(40),
+  remediationMerge: '7'.repeat(40),
+} as const
+
+const decodeCapturedPullRequestReviewState = (chunks: readonly string[]): PullRequestReviewState =>
+  JSON.parse(gunzipSync(Buffer.from(chunks.join(''), 'base64')).toString('utf8')) as PullRequestReviewState
+
+const capturedPr13429ReviewState = decodeCapturedPullRequestReviewState([
+  'H4sIAAAAAAAC/+1dW3PcxpV+z69A5IfEzlxwG8wMZTtLkXSslCQypKJsEruMBtCYgYUBxmhA1DiVqjzt227Vbu377tP+kP0p/gX7E/ZcGjdySA0lmrYuLosc',
+  'YoDu06e7v/P16dMHf/uFYdzLqlUgi3t7huW49nyAlwKh5KmMn4iVhOv3ViLJ7tEXSymis6XAi0Ho2FFgy7mUwdRyzdi17Ti0As+zLdeeilk8jUQQh/zgShYL',
+  'eZCvVkmpn58HUjiTSWhN42Du2GYcenM7CODheOqJ2DIn3sQUps3Ph4UUpYz2S3zUNm1vaE6HjvXUsves+Z5t/qVTzZa73D1rsjdx9F2FfJHIcwU3/RX+NIy/',
+  '0U/4QlTlMi8e5QtoL5QQLkW5WJfDMI/kS/iZZTIs84IKofvDboMcN7S8SMwjORVTaMk0mkXOFJphujPbm1umI9xoNvfax1UVwONXNMu295zJXzo3l6AAvO3g',
+  '+PHjoydPjw7v0Vd/H1zbhkUhF8/zrFLLK8QOhDkL48CJnBm0wLOiUMSxiMK5M3GjuYjcWSQdOQt2FNtx90z77RTbeXOxbzZibrsNU/j/DlRvzTyQfAITPfAs',
+  '6XmWGc7mzjyOomji2u40FI7nwqedxHb2aKy/nWK7b6fYk7dTbO/tFHt217By222Y7Nl3ASs3IhSvEtsl1b+lYu80YuDn18RmyiVwo2gLm0kifO7k9PTpN8/P',
+  'D48fPT99VCnvmYj2H7XlJ+pUqjx9IfHmsqhk55vjqoyQdV38Zi3KJRatZPEiCaUaB2KTjVURjkORRQk+M4zkC5nm65XMyiHQrUhmoRyVqq24KlIsY1mWa7U3',
+  'Hi+SclkFI1DteF3k+WpdymwxTkUwXldpOiZu+lGUqLBSKsmzbwrHm5vOzDW9ab9joMJWF119vM7E6jyzr1QeJqKEyvHJJ8dPjvq3BXm0wW8++eRT6OHP6ccv',
+  '/3piGQ9EtJBf/7puabJajNQykWmkRkkOuoNvxyfWMC9EtpC/VeUmlZ/FqSg//nRMBdFPwziURfJCGuv8XBaGquI4CRPQ6saIi3xllEtpiBciAY2l0gjzCtTw',
+  'ySdfZV9lX+SFITK4rSqrAr6qu8g4X+ZKGnXnGJEMU1FIZfhUxaipouTu9wdQSaKMFyLF50EPhghDuS4VXBelASIvjHPoxrwqjXApw+dJtjD8Rihg/+tUlrCw',
+  'CEQqoMYHaR4+V8bnnxmF/K5KChldcYsP8kdbSjqTNBZ6RdTXfAOaXUgYEeuqREFQQfVN2IZKqpHxdFkpI8lKWWQiTTfwEcaAShQMvrLRzA//+M8YCpMvBVY7',
+  'ML6XRd7RdcDNCKDV/iWdwbOgcGMtlCIJuPcWqH5sEw+t5HtpfFeBWuFZVmyOHZKAZuXLNYxIkBjkIqGWQi0N6AWAJRQTGjMyTnUzuUzdP5LqC7WqdMVNZxcw',
+  'heFv6LgMBVWkIqxQVauVKDZGkOepFNkIR9D+7wB4zkarCGqNoUooACZYf/Y39+w9mgwfee1wv3pig+KC8a6rpvEV1X1E1X2MYv5RybhKfwvqEGFJI9H4v//6',
+  '93/93/8e4+9/G/Wn6zUrygtLr1sg7lQELzsP3mjN2Clo/zWgjJ88u8G6s/vYZVPUu+sWEb0p9u+DnXB8i5W+GrofHz1+cHS6Hby/SF7CZAM0g9kOgwj9HYa/',
+  'a3f7CCiSZ3eWnwPUpilPe/ky4Snmw7WwAnCXf+hO+BOcnT6PWQYqVDhIguYfHw0VzOA0AbTHKc63hHkRobB9JIKJQvrUNgBBW2Y18qk+KNT4CKUwPuTBtzBq',
+  'ALQACNMqQolBgiwSRQQgFRkyjuH7QQukDH51nVAbiheRpYq6RgqKLHO0PXmWhAS1K1GG3NiGHhj7INoSAaaEGwqJWAfFxMlLslyknQvgy41k+3AJfKkTCgkP',
+  'g43wD4+eHT06PsGR+83Rs4eHR08Ojr55+OTZ/qOHh7rnCDqNND8fsjpgVBVamxU0kSvXVZI0dUt7dcciVZJtViHRdwby6aJ7Qpwe/f7oAGaRD7epKi13B6gL',
+  'TpYfEaDepKD93eboDpi0rb13h0mu65izLibpT19vXT9czbpP3yHWPXXeL9YNlGJpxHka/UppRDGiJNZkiBk4sicNNi3x1qQb+R+Cad0nmkozfBDjVkkJHw+b',
+  'Mn0DxodMO+xeVet1miDYcC3de5F8ZtD3hQH/wKpIzcm33CqRaUKVqgQOKBebU27N0FAyJar5AO5bAgd8zt/4CMvYckRvFAQ4YF6g7VjnRQkoZ1QZtGMtC7i8',
+  'YovBJRMCqmQF0CYymVcKWgOjDFUAgFg3uaPHARsFLEPTz4FG0cZMkSBoF+5rOs2FDOl6XIDNRrAmk1cifgK7BxkRgM+TjArDVrS0G/5IMhGhUsrO2mhkPOuy',
+  'aN3jooDpspJgjY2AlVCpemlBAiRUNRMAJtLQEx8o9K3slnyg0DeD57eWQh/VUEv0rYbIztxrlui172N3LGOsYjgVK2lYNpjMMFmJ1CiA1hHhxZU2AglSPiC4',
+  'm/7SfGQ8hCLWEn4wS8XHkOvmVYGWgCwM4NhG4xoWALpY5aqEVb1sq6mypLwPoC2KIXPatoFgGWIguMMwzVEEgC+gzcMa60bGSQ/1mI+Oa/BDVcmGmGrrgY6e',
+  'TgXMN4GtZ3nZ2hWNueoqHn4R56l2MjNhKpKV6oL6FsNDTotv2ZshXsnHb8SFnTtBmp8PF3Z+Si5sedabcuHvHsp3hAu7numZs/eEC7d+RviQ5StAEsCTAp0T',
+  'DUslkEg3THZFWpG4HUf0lW7oVzs6NWkuZFAlCLJYHdDdKAGs3sKSTxip0I38mKW8gidj9XU7xALX6yWy5KTcoA9ZhASwXfaOAAnQjJeKKruCF0M9wAMJC8u8',
+  'FGltgZCDSjYBupIAhuk5cEdATrBDoVgncDuoJUl1c0ibLbSKLEOL9L2MdJkDAxAKkJnZMjvlyTsSFeI8ys8zbZbugx1G1T1jpaHfQWg9QmeDjmvzVfNkzXv9',
+  'k/2zM7/rZ8ZHLnV941ZqOx4V2PVHJ0Xjbe8qtpAp3Q6Dcq1qbl2TdLyhb4J/bEK9K9DfJaG+ENzxdrh8botQb2v8Hdo8xvifF6HedZP/ok9agf4vuoE787W3',
+  '3FbNUn4AyLkZwpfDJZC+AXBbuKkcvshx3qYAYgO8VSqFKF2XQd7pKK8AiSLofEDVHmRo9COsqVboE0d066ACzC4EaF5jt47zI9TCFnAHZl5Sm2gTE0F+oytk',
+  'WBu0lqMPg7XEHQ85DI6oYl8CTjJseI3ra3RhAHwhBTFivbcKVwXSZQOR8ir+3DEZBATw8II87xrYW1zXwNvieg3kLCpWQj2qbuLh3hFqLgVk/YhQc+NIlR+B',
+  'UW9v792hi+fCet18c0advEOM2nLeO0YNi+8S0XYNn4BDd2iVorADQFKgwUUCDBaJ0g4eZp8fVF8C+tDqm2IyoKA8Q7cyPLoEg1K7P9RSINAw68Rqy/Mcd8LQ',
+  'g8EC8UofnSN5eiFcAT0OTDtJTrQNaXenUhO0qDE5zfABaIb6QDhm5WkuaEsz25wjftYOVcReAMm82IyMA2g9QDVh66ANaEC6qiNYQJwgAVUC/jfY2msJseSs',
+  'c5vnDmHUoAMFQ2tIbbT+ALMnu1Cu1yZDDehsNtrlCf5NkR5BDvDe9ihDNTQQgB8907hTAHWBCnudimqosli8gFEDNnNkPEi0Bntdjww6722c9q225tkkI7cV',
+  'OgssKgyFmlpjp/MKJE0WSUAW/AOr/sCq75pVW87bzaobBm2ZA9M0hxo62pnfn7iITRkt9RXugeEUTlaritfqrXOh4es9T0cfcTU35oU6Rpn49TL7oDbXh621',
+  'PiBWnKg8O5MrxIJQHenqfML8cNlj/dyMnvAX7AmAXfRtpRDvS5Gk7IQeMMwO6UoDOgOOLRnoID5Y+m9UwqUgml/mydCeYWd3sKvBLm/uANwVME/eGPY434z9',
+  'uu8Z+3V/SvY7caZvzn6fv0vs932JaD7KYCqHDIT1jh1QFL1lBxSpyIFMhQ14NRj5Cn8yMkcsEygd7va1JSbqgh+DHMoN7jVBHo0buO9RvnJXsY56JqfyhkMC',
+  'MPoCyxpdegrA0z8X6XOQ/xwk3HoDYWVjR7bcAiIWUqJ/laq6QoVJHXWMoYPD5oY8AzNz1KXOrf+6Uqw8KVTSVV4T+KJo7cD+lQZ4WWtZpC0AITAbMe3HBlOQ',
+  'NosUsnztNmq7ncD+Dnpw0HMAi04HU4PhM+1egtr1lmQ/wruRuxPK0eqFNYGGtFlmXdrS6DiFMIikXBZ5taBurp1nPCo/EOcPxPnOifP07SXOD7bMQtrWa4O8',
+  '6jnJMNKFbI4vvuh9biev5sV6sl705dYAOGyRoKhSTbk5KIKCz7r42SBKBwBagk+7eQSFiOjDmCGd4TDYvD4rv8qHrGDOYth0vhWjuzEWN2O8k/eM8U5+Ssbr',
+  'zW7B37t6hxivbb4njLehIj20WMgcScemds81O2AII7u4egluukcCm9jiqBdGLIpCbIwUeqVc3segMiCQseEDkiUZlAjDv8DtsObCURbRn1KV7XfwB18Hieiv',
+  '4wAHEWn1ACXvOZu7TBoGRZmHeforOtcmKAgCVJZARzY6GBlf0LK/As4dEg2UMI42VBvIO8zbylg9zGIaItqw9ZqsMrut0KtRJire1JwfBO2dpdG2pwnbNURc',
+  'cqhgx5mK/HhN82kAClbrhHZVSx3WfOmYYZfjWvPpsD6ag1rDgOQoP1ccVgEqKsBI9eIl2K6wKUFDiJ5qlLirAm6HHjcU8dwLSNbNVO3gKD/Q1Q909a7pqm2+',
+  'A9EThSwq3GVfw5RJk8Wy3Mbp/N4RXF59wxBOu16MK8hpzyQk6GrFAqmNA0IojREE/eipuIShNWyPCV9qzBiwEAiOV2GQtiA63Is5dBt0UH/NIDjoLPp1yDG7',
+  'Kzr2Z2Qc1vi9HbfJgcvw/fpeWu8946zeT8lZZ6b95pw1f5c46/sTo9DLKNAL6ApFpXQs1G6H3qR+ZEjhU5wHQSeR4ChT2iGnWICEEkugkxN3gLKFAgDCLR5i',
+  'r4bn3kevXCYTSmTQIm43qEHTtgxkagLDMLddmmS8aV4HrRkqWWQiHehdK+SbtLJ/KUPaeRquoKNSPJ4G2ChSXJ03j1I8F5+wiAHZIsH76cCAUa+K2pGTI1oX',
+  'juSy73MNKMQByoNBxGdOuOFXRShofazTqnfoohVJn1dD50kbSEuO39rdrtM8XJ9OAu5U6Kl9AZZL6JhsqUNTKMYBLeKATnNc5+g45CFzACPmgHr/BDrfh5GE',
+  '1qSO9qVRUJNXPPZeqQ9U9QNVvXOq+paHJFwOKOBUFDlQScxE0Av8vQoLORo3z1SH/gIK5M/l68104HwduOhm5aEABqbGGPFLKExH8hTxSsJNyfswEqMNxnGS',
+  'YjDc9TjdINaVZ9maxtYFGai21hd92+fULqWCey8Y6+ynZKzzyZt6WYMn2e9vzFgp+8fPj7J6njebuu9dWG2Ti6DGFHVxdwkQo0rlJfLaoOdNj6f1Dwi0vLRz',
+  'sCFAIFqnYtPQnSbEoD2KMarBecSoeFg3wB/QMbak7MTMqksNIk9iLxcEndni79jrQHta2LgtumFkosRA2mlLQIubTLI0oEXiygACIJ+Cci1oVchGJNTImBR3',
+  '8XDbMskihT6V4QLYP3YZxpUVC6jrXOJ11Zze6KZr6yRr6xgtlrTexacD1yjeqjmZIukYXRfX909OTo+fYSoeOtHRDhvS3HlepRxtwFG7nMcCNcg+HL3O0Vl8',
+  'YPQN2SDJTq+04Qtt/wQY34vLg6R/pFw2/VP3DIU5VOWPcjRuPnxkmTtT5l2Ny9WUmeq7Tc58KUXpLSTpvAPbejuceXvj79DQsl35mWWb2LG7NWcWVZSUQzoW',
+  '0ZBaw5q2NkBPWSTSemarfpo2P9xChveLMolBqBHh1lGD7H4/vAxxCqc9zPUcDz9o1K5TSmDABE/6i+fMLqSy6QHBoE1E03dGd8BFp6zARjDb7sI0TfazL/cH',
+  'W48JEoj74VROJlYces7EDmFwuLEzk+bMCWBEwI+ZHdvwSYZu5Flu7HrCdCfOPLLF1I6mc2H5gwbghhrguOB5NPXs6SwWmLthBoTYsswAKpiZ0ptE8Kxr2d50',
+  '7s1c25SWGQszNCfWJJiY04mMLFcH0DXp5jjpEbL8JsNea+A6JhcXC+zR6mR+A0qhYIVAnd7YKePs5M+1adLWjPw3gHnapjeDR2Y0IniR1VtcUH6mdgdg1EqC',
+  'kdHdkVjnkdueP24AXQmDs6UeeLYnTyMMVUG/ilJGHoZVoXZFVHcH//ptIeqbFHRbq5VL2aLvFkQt03Jd13rz1crx3frX26vW9Mdducysn/fKxd5t5WIPNzJN',
+  '8/Pr0s2hlPpoCB44JoDSSFKzPwUd1CTsLTdrvXr5E2U90xHNGtx+f3b8pEEPtclK3LHjBJyckTJg0AXOu0qYxuYFpUEu9Ck+LB/IL3lf6oPUlGyapcDTf9Eq',
+  'aRKt1dYm6p9O8+nI2Vaf0VF7Bs3HPBSwpEGnj2auqs5JoapwSf6YZqAhfUY/+EiFwO7FM1ngoKE01UV+TvoBI4uEII+1S5xOkr8iEWinCxrTF+VhhbKy/QCz',
+  'e0SJUA3/jKr2DVpfgea509p4DQDmlUgxPBm1d2FpGec4GNgui+gFqhNdUt3cT80CAOfma/nDreGjiX2H9J4rvGN+P51MTelMpWPPYm8eOZ7pmMEsNq3YDsx4',
+  'GszdcCKsaPqB378m+r7V/L5BUkLDROnEcky362gMfxs2Pay96bWvo57vQcvJCZ80z+L6mNLXGMGPAJbABFdGDVoD9LV8LzF7UCoRKwZGE1gCuAVceNB6IWof',
+  'zKCJJVlx4HHNFwedjNG8szdogttSCR2frCi/ZY1nfr3IOOM1Bi8FHossiQHofT4N3slu2Y2hpluHK32vweDLDW9gjxJwCnJqXUqo0VlGcB8UyLtblGRTMyS1',
+  'jtH6dMn4brkuGGu29mjdkYzyXwDUysjvp8PX1uNmZHl2J/D08yHLs5+SLHvW1cEozXtRmh5omeLu+mtKAVJU0YvrepTzqrfFoL9WFAT5fw3y8uuWtdZ49ukv',
+  'h0ND3wa/ngcifG4Mh59/lX26/vxTYSwBBD77qtEQ3zmCqdTVEAk1Pjk9Pn588nTomtOv7n3e+evTsQBCuf68w5mvf31e9z1WOr71mltf97U5DaRj4p6ypMA1',
+  '9LkQsg8J2bWPd8/wd50yvvY393c2hx2Q6YfSXXQM1FxMOx6g4NCOvCi0osk8mgee6c3g3yQIXbgwCWYRCGCHURzP5yCQZzk4boK5KS0ntj1KklbnqjDipqFN',
+  'MAg1GCUlU8TJL9Dti76JMjfOvtwf2hMP6HIoIminnDrxREbhFMRw5nM5n1nSFe7MnMzMOABqgk6VaOa5cialGc1tx5rEljXH8OzfASFHTmf4tm3P5qY1c6Bp',
+  'ATCaYCbimRV6c28Kl4Vlxy7MgWmg3Sa2PbDt+cCazoxgU+JrUvbB6JCvg+xPm7yDSKvCrdaU4gnBqj0AOthpOJf4FFD8LCySdcn5MTi0ur2LrQeFKBZ61Wqc',
+  'WJj4XwddK31AhhYuVcba7IQLXksevT3X3mWAN7e+6QB/KjFBKuikMye3DcMu0S9kKkXndTx7SKCHmvW0xp1ddjhX9m5Ag9qScFMJnwT+Mg2s2cx0w3guHTO0',
+  'LCDpju3JuWnPrMiaTt1gZtKT6rsKJwe9WxOe3fXFnfwsCxwUIqMcA5R+jE9xaX+ZxJYQR64RDtW1dVN0iP7Mf7p5qxlbDh7uMX3CIYqECTsoVyX05NkfHqEr',
+  'krdg8PhEHT8wAMnz57IYay5Hpxow4mkVeS78Klb0K2v7j0Pa9FlXGaEMMHJyGOhJ2Ec67NI9I8SUu4b/G8u/z6+XqLJmCug3e2EZfBs/j4t5I80Rvtp3Me0Z',
+  'luW1TsOu/nhqkpTWAAh9qwX9DYt6n182Eo55m62V/waeyPuGn8mXbWT0SSF5g7QgIT/LoGa8qeer3geeAd2OiX1gkR19xu/PuN+AeYRhIDiflK7dsEYjy8MD',
+  'LF3ZZnSh9nvmxcUcRUTQcVY9EcAhycfLXYYBfL5jes505s0sx/ZpYuJeL09NzfWBQi+AyFZBWhfJLFMXM+QehV/QBl7bDLVLBazCk5zjx2nbb0MgeC5A83x0',
+  'GaPunvZeE4Or6tHVJY9eWH6bqBrMGW5OlgVAFPbtpo0mBAgyPiIetYcG4csq0Kn58BR3RRgM82oNMIbR45liTKZd1F/7nDn5h3/5Dw5NwdM//Aku8UIZL/En',
+  'uMQmGy/xJ3yQ5qr/cTexFC8Y2nx7NKhB5jyTFNIJ/Zy33zbQR4BJqLrkrKU5rlL0Sf8uRBm8RcK75Jzrqnmsxcwf/vE/Pjm+9IZKA4n4he6vUKLFwn6KRVBQ',
+  'OHvUOTPEo0evpAq6D7uhNk7krCkWMEYPcc3pn20wBdb4S8CdcrkhlxG/rtigMd3gKgrQ1RfgUppvaCK3Xrl6GvLLDoxUwEqMhiZHNzHq+o41t+dWIANpA2sC',
+  'ThPOgU5ZTmTGseNBXW6A3AD3S6Jkgas5H3QKBGTPC0NvGggxnblRMJlN3ZllO7GcO6Ck0J04AvhD5M69uYwdITy4atmRnJoYoGQFEwEqfITmnFAGWm+NLeP0',
+  'aP/wzwMgE2sRCn2KSTIFRJzrrH8Ze2BFnGQZx2h1JjLqsrP1sRIvk1W1qjfCSjr85h8/ODs6fXbkU7QZqo4OUIRJmjSF4PRJsorfS+Ef/fP+wVO/844hCj3D',
+  'ZXqSpngYAlYhMKvAjNHZCBwFVfY8w+S6deSYvhxuwlQ2UOU/OX76zeEfj3waD6cwKUUBlpDCSF6WmrzK5tURJ6fjhgEYf1ri+bJf26ZpfoxONNrBOkATZPj1',
+  'AiHKk1FeLMaWObLgvzEsjmZDIDX2yDStiQ0w+gDBDFg2zqyRcfLguH14Dav8Qo2UKjJahIHdceqLYbz6rQgUIcw3SfSZDeTAnjjcDk5+FMl6RGqV8niG2QNo',
+  'xXCpZwmsY16QE4A8sTx0EwqkgSeJ1NGLpOrY524YYw2CePuC+rdN0N8k869gLA2h+GUSJGXLpobN5FRhvpa78EV3z3b2HGcXvtjcemHhWUidif/ychHlfJWD',
+  '8MLCUQcc4QO/sXZqgDXZM91LUiH8fYFof1JhEPeWpSxWfj2/JUP4Zm/fuEfc/83ikK8Nn3b2bOsqCv86Lby5dJdbePM38l63njH33MlttvDm0l1u4Y09XK9w',
+  '90/mt9nCm0u3ZZTe+D2/101Rc880r5+idJQannR/8fdf/D9fEzUTqIEAAA==',
+])
+
+const capturedPr13434ReviewState = decodeCapturedPullRequestReviewState([
+  'H4sIAAAAAAAC/+VazXIbxxG++ynG9MExg5/9/4FoOrIk20pJIotinMSiypidmQU2XOyud3ZJIi5X+ZBrkkol9+QxkmsexS+QPEK6Z3axAAjIoEQxqrJURYLY',
+  'npnunu6vv+mdb98jZC+rZ5Eo90bEtB3b6eFXEZXiRMTP6EzA93szmmR76sFUUP58SvHL0HEiFnimadmBERtO4ERBCJ/DyA88R1ieYQYRo6EeyEpBK8HvVzjU',
+  'Miyvb/h92zw13ZEVjizvKy02E+Vkk5Q3Mp2R6y5LPchns6RqlGG+H/DYsiPL8iwj5qblgw42rG943KBuYJlmZHDRWfFZXjJxXMupkDDBi5fXHzzI6wwVMdSj',
+  'Ulwk4lLJwp+EfKt+wgNaV9O8fJJPwEeoyZRWk6Lqs5yLK/iZZYJVeakWVvJsWW/fD6nvhNzwTcNmLGbcphYLOTMZM2PPdT0qItuOuuGyjmD4FlfazshyvloS',
+  'rsDpKPbg6OnTR89OHz3cU4++673ShkkpJud5Bj7YorbpsNCLfN+3HT9yAi8IuR+bMXdjGvqm5fmBYZsuM3dVOxzZ9purfTPX37INjj2yjTtwfeCKyLO5iBzq',
+  'h3FgOYHFGee2yQLOhbBix4B/frCj2q45cqy7dv1t2wDQENyB62+EeD+mtjcy7JHj7qI2/NTwVE0BRfkGDEo4jjs+OTn9+vzy4dGT85MntfS+5BP6ZTd/Ik+E',
+  'zNMLgcJVWYulJ0d1xRGf158UtJri1FKUFwkTchjReTaUJRsymvEEx/S5uBBpXsxEBvu/+NYMBpWQ1aCSnQZ1meJk06oq5Gg4nCTVtI4G4ONhUeb5rKhENhmm',
+  'NBoWdZoOVTn6gCeS1VImefZ1aXuh6dqe4ZirOwQrd05ZdszrhOrSmPtS5iyhFSyOI58dPXu0KhblfI5P9vcPYKsP1Y/3Xxyb5FPKJ+Llz1pLk9lkIKeJSLkc',
+  'JDk4EZ4Oj81+XtJsIj6R1TwVH8cprT46GKqJ1E9CTkSRUiZINRVE5jUUpn4lrioypXJKJDibXIIPCRhRlZRVhErYKFRX7u+fZWfZr6ciI1EOIjhCSJIzVpeE',
+  'ZvPLqSgFSTI19SzndSp++P5vScbSmifZhLRu7REOIUdgS2mP5CWps1KkGCm4KEQsiMC4appIgttNClRBEgiJjCSxml1cFXmJIyioFqOaWU7SHAwvSZRkXKLU',
+  '7B6oWM5SIWVjKYF0FJkolfsJ2kpTmZOYJilJKmV4XlcEtjOboMaRmNKLJC8H5L7yglq7MRsSJ68n01V1IOaqnOUpmiUuaFo3K7XOTMA+tD2PCaYdroHj4ySF',
+  'DYFdGKCH738Omfp8MOMgE4NLMyYgEFfTZSEzehJY/SeB3QXG9hSI0jwa7koPhlsW/KBZ8CNU9VdSxHX6CQQVWqcC579//8sf//2PIf7+02A1tF9B2NZYxi2w',
+  'GjWFZlgPbmui+6+R9nrk8xtQrOVh1/F7ReoW0W8x7Xe9nTBvQ2nbDnNPHz399NHJZqBrKwiBRBFXGEelmOUVJBpmynhXTjUekNOpyvBSKOsAEi4b9JJbQCPJ',
+  'ilojX09JACLkWcJo2slKSNxKTOZdamtxKEpqSDKb1RWNMH/nBcgjltQl6kFlnt1DWOmgCeF1gUUq38lnOWwGjHvQVjliBgr2ACZPYcbnrEyKSq9XiiKXCUTY',
+  'vF8kEGycHF3FMw2Qg5UZPpSgL0DHJFH6ozd++fzoGUEE6DXY3PyhDBHlLMnQ7IuEI97oagD7AKc0wGcFiILfIJ1X2fdbTOcbU+7t6bwtonfJ4A323mEGe2Fg',
+  'B0sZ3Hx6uZGibiN2RSjvlthVZULTPpR5jOjbJ3Wh7RrOT4TUPRRlcqE5XVECYdG+lTqN4zKfAQ5JBWFgA+BG4/QlRrc0DOhZBSgmNQ9CDhcjnbmisyIVCBgd',
+  'TCCxAafqdTrOg7jZEq6LBPekJXSAVMkkw40gqaAXwKPGauVTpe8XMM2YiG9qUKLKG3MaGINfHUEkAGrANkECtCkF7C0AObIpgFtlrkJzjVqtsYCQMBomh8XT',
+  'eQP4U8HOkbKOkTUuEPRhF6VfgmfjRPDnyp4xktiClqj3IqjN4HgVawfXTFLMCLZApLECXEU9GRMF8OtUm5YmmaATAWjLlWHAziuarjtAFx8OvJBWC/YIm9Vn',
+  'aS4VAe22EU1CGdw9SiBQGuPJQvNBGzio0wVaOidqm7q46Uri8tQzGKw+NIT2dXir23/i7cxad4X57awVl7tdzrrWnrmFdtAdFLnb4qybjL/DiqfB/V3lrLs2',
+  'o8bbWZvK9utYDrmJtLaFPCScmKUdsi/N519LUzx3srxI2mErAKuxa0QQfQHymKaNecmRGUpiDgamh9CzgMb2GazU6yjkssDGOjFEEK9hn3F61aDq2LSOoHUz',
+  '1lTURJ8r5OILt6htSOdk7AaxIwLDxIaa7cZOYMdhGAjDYIEVBKEwWORZri8C13VUSx/2JhCUOrEdc8cMx/dIBaUOpm/wdZUUA5h23l6rco1SUOYIT2KFgdrm',
+  'jucjQIBtw+t8X9F44gdDP+iRIq3lCv9XTF876ugKagUcHR4vjh4rk615a6jZ/nBhBf6qkipBNUvxOux+rcH7FoHvxl3dt8LuN9l7d1jnOS5E5Zuye7P/mxuz',
+  '+xjy/l2l957nGl7wE6H3j1UPVaxBc5fR2Wbmr+n9Z8BWp50wjauGX67Ix8kVoigQ6kpTwEXtKAUgikTfdjgD5eCH7/9qelD/AHKjeVsKeiTHNELkHGNLV1an',
+  'TV141Kw/XmD9Emh517oVDUgBaX8cI5oKyUTGkfk3kKvxpuH4cmWyD+U6Lveuza97H4jlENXkcppopq1iW8O+FIva1yNjDeybDgjH61xfVkmqGDLTbeJNFP6e',
+  'JvgCjhKoc8vU9XEEzlCNk5V3UXJRXRuVoIbWGZQDma+0mSme43ImYBXFa9uzxWrcNCeNAUF9GwXbgrYlwnDP1l24CBAqyaVI07d+Bti1GNzlGQDfE4avKoU3',
+  'fsF3B6Xwts4Aay9J77ou6grwrp4Bdt34pm+NfD4VMPrCWgXmRZoh72/ePa1A52a+3rve1B1eQ8VNaa2FhoiLKu1IlU+EaraoNFkm5gC0G9m+7lU3TP4aeX8M',
+  'haTrKrT0fezErm8LDxwTR4FtOibw5yh0jciOYiP2QiZClzm+AW70Xc+gjnDtMDKoG8eUmYZ1/SzVtebXbdSNbUkiQFHedpqSrNsDsztGDAaDsQJa3ZIBSJvA',
+  'J2y+64hJft++48PGUCLhY6y7Z6ojo94AqFMbxsdlicmUKQ9lOXxR1hk+bacCFg6Y1L7BUB27C7EocqDoZnzurX2/Zq8qdJt3Km3JAITd6kGlqUJqOv0CNgiG',
+  'QbDDyeTekudXTiZNaG06ibzuq4ZrVx7eIgK/yUS3dRjZbO/dga5vBm5gbj2MLK6VLHagI+R7tuGZjucYzOUx9anPIbljw7V5bLrwzIpjIwL/tT37PctxPJdy',
+  'akWuMIXhMNdwA8oD04pMoDg8jN0gMjhv5SPYEA+qpMN9GAADmeFGUcA4ox7o7oWB67k281p5Nxa2G4c2fOkx17dM3/PMMPRZGIUw3DaNwIdjq7mY3w9iO7CY',
+  '5QgeGSEzMARsEUA59k3KHNinSATCbuVv+I7rpqfmmzKC3eN3sYuJlLW6FLlystp22UnxylKxihdRXr3sDmdtyTx4v98njRj8Oo8o0N1+//AsOygODyiZAmn8',
+  '+GwRoVpyQItiOUKVUsPjk6Ojp8enfccOzvYOl/46GFI4NxWHS0fDV94TXblhVxf8R0Rf99ZX64JfKNLVlMeddLSNkWvtpmMj+n/QEZzj7qijFr17HbGL4+ym',
+  'YyN61zpqcPd30XEh+gY3Kbck6QOl9IlSekQeJjz7sCIxnFDxjhfQ0d8BmVA5iHcOpiIGpnUOf6vj3/7+Scv7dAUY7e8vU+ExCh007xcPyYGsZzNazg9/+MO/',
+  '/vPPP5P7EV6/0goAG/g8qb6oI2yCaCkYGpXDQ5zjxW+BSwDFpTOkLXCSrkhdNCOrvHE5wUIGn7+pVX9VtUkSqa5RdIfOxjmqDioHDYG41RwOkaqPIYf6xlj6',
+  '0aDxiW6bAjufTNTh+hJfn87z+izrk6MCyd3Kuur1m9YHJZ7S8hwbGiWN8W6dugY2xwcNzJKz1bA521OOfRw3xilra1haqjt5PX1vDZZrGmD3SI5k/TKRYvGo',
+  'XD3lqgn1fz3n4iIczeQl8EGlt+KfeDtPhaDiiMcncFYp5+1S2LFYaEs5R9aqG0gxlGfEdqU8WfoHOzhsd3+3hPBHjrdjQmjRNSKibEdbrpcvoLk3zZHmPQYO',
+  '+Lm5swHuslbvfffe/wBpfD7kIzEAAA==',
+])
+
+const captureMultiStageReceiptEvidence = (
+  record: BaynReleaseReviewRemediationRecord,
+): { readonly sourcePull: PullRequestReviewState; readonly descendantPull: PullRequestReviewState } => {
+  if (record.schemaVersion !== 'bayn.release-review-remediation.v2' || record.blocked.reconstruction === undefined) {
+    throw new Error('expected a v2 multi-stage remediation record')
+  }
+  const sourcePull = structuredClone(capturedPr13429ReviewState)
+  const descendantPull = structuredClone(capturedPr13434ReviewState)
+  if (pullRequestReviewEvidenceSha256(sourcePull) !== record.blocked.sourcePullRequestEvidenceSha256) {
+    throw new Error('captured PR #13429 evidence does not match the committed receipt')
+  }
+  const descendant = record.requiredDescendants[0]
+  if (
+    descendant === undefined ||
+    pullRequestReviewEvidenceSha256(descendantPull) !== descendant.sourcePullRequestEvidenceSha256
+  ) {
+    throw new Error('captured PR #13434 evidence does not match the committed receipt')
+  }
+  for (const feedback of record.blocked.reconstruction.feedback) {
+    const thread = sourcePull.threads.find((candidate) => candidate.id === feedback.threadId)
+    const finding = thread?.comments.find((comment) => comment.url === feedback.findingUrl)
+    const reply = thread?.comments.find((comment) => comment.url === feedback.fixReplyUrl)
+    if (
+      thread === undefined ||
+      finding === undefined ||
+      reply === undefined ||
+      sha256Text(finding.body) !== feedback.findingBodySha256 ||
+      sha256Text(reply.body) !== feedback.fixReplyBodySha256
+    ) {
+      throw new Error(`captured feedback ${feedback.threadId} does not match the committed receipt`)
+    }
+  }
+  return { sourcePull, descendantPull }
+}
+
+const multiStageRemediationFixture = (): {
+  readonly snapshot: BaynReleaseEligibilitySnapshot
+  readonly evidence: BaynReleaseReviewRemediationEvidence
+} => {
+  const record = structuredClone(realMultiStageRemediationRecord) as BaynReleaseReviewRemediationRecord
+  if (record.schemaVersion !== 'bayn.release-review-remediation.v2' || record.blocked.reconstruction === undefined) {
+    throw new Error('expected a v2 multi-stage remediation record')
+  }
+  const reconstruction = record.blocked.reconstruction
+  const { sourcePull, descendantPull } = captureMultiStageReceiptEvidence(record)
+  const descendantRecord = record.requiredDescendants[0]
+  if (descendantRecord === undefined) throw new Error('expected Candidate 18 descendant evidence')
+
+  const sourceSnapshot: BaynReleaseReviewSnapshot = {
+    mainCommitParents: [multiStageHistory.promotion],
+    associatedPullRequests: [
+      associatedPull({
+        number: sourcePull.number,
+        headSha: sourcePull.headSha,
+        mergeCommitSha: multiStageHistory.blocked,
+        mergedAt: sourcePull.mergedAt,
+      }),
+    ],
+    pullRequest: sourcePull,
+  }
+  const descendantSnapshot: BaynReleaseReviewSnapshot = {
+    mainCommitParents: [multiStageHistory.blocked],
+    associatedPullRequests: [
+      associatedPull({
+        number: descendantPull.number,
+        headSha: descendantPull.headSha,
+        mergeCommitSha: multiStageHistory.descendant,
+        mergedAt: descendantPull.mergedAt,
+      }),
+    ],
+    pullRequest: descendantPull,
+  }
+  const remediationSnapshot = reviewSnapshotFor({
+    commitSha: multiStageHistory.remediationMerge,
+    prNumber: 13435,
+    headSha: multiStageHistory.remediationHead,
+    parents: [multiStageHistory.descendant],
+    mergedAt: '2026-07-31T16:30:00Z',
+  })
+  const change = (path: string, blobSha: string, status = 'modified') => ({
+    path,
+    previousPath: null,
+    status,
+    blobSha,
+  })
+  const finalHead = reconstruction.heads.at(-1)
+  if (finalHead === undefined) throw new Error('expected final reconstructed head')
+  const recordBlobSha = '9'.repeat(40)
+  const promotionCommit = {
+    sha: multiStageHistory.promotion,
+    parents: [multiStageHistory.published],
+    treeSha: '8'.repeat(40),
+    files: ['argocd/applications/bayn/deployment.yaml', 'argocd/applications/bayn/kustomization.yaml'],
+    fileChanges: [
+      change('argocd/applications/bayn/deployment.yaml', '1'.repeat(40)),
+      change('argocd/applications/bayn/kustomization.yaml', '2'.repeat(40)),
+    ],
+    reviewSnapshot: null,
+  } as const
+  const blockedCommit = {
+    sha: multiStageHistory.blocked,
+    parents: [multiStageHistory.promotion],
+    treeSha: record.blocked.mergeTreeSha,
+    files: finalHead.affectedPaths.map((path) => path.path),
+    fileChanges: finalHead.affectedPaths.map((path) => ({
+      path: path.path,
+      previousPath: path.previousPath,
+      status: path.status,
+      blobSha: path.blobSha,
+    })),
+    reviewSnapshot: sourceSnapshot,
+  } as const
+  const descendantCommit = {
+    sha: multiStageHistory.descendant,
+    parents: [multiStageHistory.blocked],
+    treeSha: descendantRecord.mergeTreeSha,
+    files: descendantRecord.affectedPaths.map((path) => path.path),
+    fileChanges: descendantRecord.affectedPaths.map((path) => change(path.path, path.mergeBlobSha)),
+    reviewSnapshot: descendantSnapshot,
+  } as const
+  const introductionCommit = {
+    sha: multiStageHistory.remediationMerge,
+    parents: [multiStageHistory.descendant],
+    treeSha: '3'.repeat(40),
+    files: [
+      'packages/scripts/src/bayn/verify-release-review.ts',
+      'packages/scripts/src/bayn/verify-release-review.test.ts',
+      multiStageRemediationRecordPath,
+    ],
+    fileChanges: [
+      change('packages/scripts/src/bayn/verify-release-review.ts', '4'.repeat(40)),
+      change('packages/scripts/src/bayn/verify-release-review.test.ts', '5'.repeat(40)),
+      change(multiStageRemediationRecordPath, recordBlobSha, 'added'),
+    ],
+    reviewSnapshot: remediationSnapshot,
+  } as const
+  const expectedCurrent = new Map(finalHead.affectedPaths.map((path) => [path.path, path.blobSha] as const))
+  for (const path of descendantRecord.affectedPaths) {
+    if (expectedCurrent.has(path.path)) expectedCurrent.set(path.path, path.mergeBlobSha)
+  }
+  const evidence: BaynReleaseReviewRemediationEvidence = {
+    recordPath: multiStageRemediationRecordPath,
+    recordBlobSha,
+    record,
+    referencedCommits: [
+      ...reconstruction.heads.map((head) => ({
+        sha: head.headSha,
+        parents: [head.parentSha],
+        treeSha: head.treeSha,
+        files: head.affectedPaths.map((path) => path.path),
+        fileChanges: head.affectedPaths.map((path) => ({
+          path: path.path,
+          previousPath: path.previousPath,
+          status: path.status,
+          blobSha: path.blobSha,
+        })),
+        pathBlobs: head.affectedPaths.map((path) => ({ path: path.path, blobSha: path.blobSha })),
+      })),
+      {
+        sha: descendantRecord.finalHeadSha,
+        parents: ['0'.repeat(40)],
+        treeSha: descendantRecord.finalHeadTreeSha,
+        files: descendantRecord.affectedPaths.map((path) => path.path),
+        fileChanges: [],
+        pathBlobs: descendantRecord.affectedPaths.map((path) => ({
+          path: path.path,
+          blobSha: path.finalHeadBlobSha,
+        })),
+      },
+    ],
+    currentPathBlobs: [...expectedCurrent].map(([path, blobSha]) => ({ path, blobSha })),
+  }
+  return {
+    evidence,
+    snapshot: {
+      currentCommitParents: [multiStageHistory.descendant],
+      lastPublishedRevision: {
+        status: 'resolved',
+        revision: multiStageHistory.published,
+        runId: 30632855271,
+        runNumber: 910,
+        runAttempt: 1,
+      },
+      comparison: {
+        status: 'ahead',
+        baseSha: multiStageHistory.published,
+        headSha: multiStageHistory.remediationMerge,
+        mergeBaseSha: multiStageHistory.published,
+        aheadBy: 4,
+        totalCommits: 4,
+        commits: [promotionCommit, blockedCommit, descendantCommit, introductionCommit],
+        truncated: false,
+      },
+      remediations: [evidence],
+    },
+  }
+}
+
 describe('Bayn publication-range eligibility', () => {
+  test('accepts the complete #13429 reconstruction only through its reviewed v2 receipt', () => {
+    expect(realMultiStageRemediationRecord).toMatchObject({
+      schemaVersion: 'bayn.release-review-remediation.v2',
+      blocked: {
+        mergeCommitSha: multiStageHistory.blocked,
+        sourcePullRequestNumber: 13429,
+        finalHeadSha: 'bc32db2e9eeb7140f422fc1b6621427a8f7dabfc',
+        reconstruction: { heads: { length: 5 }, forcePushes: { length: 4 }, feedback: { length: 9 } },
+      },
+      requiredDescendants: [{ mergeCommitSha: multiStageHistory.descendant, sourcePullRequestNumber: 13434 }],
+    })
+    const captured = captureMultiStageReceiptEvidence(realMultiStageRemediationRecord)
+    expect(pullRequestReviewEvidenceSha256(captured.sourcePull)).toBe(
+      realMultiStageRemediationRecord.blocked.sourcePullRequestEvidenceSha256,
+    )
+    expect(pullRequestReviewEvidenceSha256(captured.descendantPull)).toBe(
+      realMultiStageRemediationRecord.requiredDescendants[0]?.sourcePullRequestEvidenceSha256,
+    )
+    const fixture = multiStageRemediationFixture()
+    expect(
+      evaluateBaynReleaseEligibility({
+        mainCommitSha: multiStageHistory.remediationMerge,
+        baseRefName: 'main',
+        snapshot: fixture.snapshot,
+        nowMs: Date.parse('2026-07-31T16:31:00Z'),
+        pushBeforeSha: multiStageHistory.descendant,
+      }),
+    ).toMatchObject({ status: 'eligible', checkedCommitCount: 4, baynAffectingCommitCount: 3 })
+  })
+
+  test.each([
+    [
+      'changed force-push chain',
+      (fixture: ReturnType<typeof multiStageRemediationFixture>) => {
+        const pull = fixture.snapshot.comparison?.commits.find((commit) => commit.sha === multiStageHistory.blocked)
+          ?.reviewSnapshot?.pullRequest
+        if (pull === undefined || pull === null) throw new Error('missing source pull')
+        ;(pull.headForcePushes[0] as { afterCommitSha: string }).afterCommitSha = 'f'.repeat(40)
+      },
+    ],
+    [
+      'missing feedback thread',
+      (fixture: ReturnType<typeof multiStageRemediationFixture>) => {
+        const pull = fixture.snapshot.comparison?.commits.find((commit) => commit.sha === multiStageHistory.blocked)
+          ?.reviewSnapshot?.pullRequest
+        if (pull === undefined || pull === null) throw new Error('missing source pull')
+        ;(pull.threads as PullRequestReviewThread[]).pop()
+      },
+    ],
+    [
+      'changed reconstructed blob',
+      (fixture: ReturnType<typeof multiStageRemediationFixture>) => {
+        const head = fixture.evidence.referencedCommits.find(
+          (commit) => commit.sha === fixture.evidence.record.blocked.finalHeadSha,
+        )
+        if (head === undefined) throw new Error('missing final head')
+        ;(head.pathBlobs[0] as { blobSha: string }).blobSha = 'f'.repeat(40)
+      },
+    ],
+    [
+      'spoofed descendant head',
+      (fixture: ReturnType<typeof multiStageRemediationFixture>) => {
+        ;(fixture.evidence.record.requiredDescendants[0] as { finalHeadSha: string }).finalHeadSha = 'f'.repeat(40)
+      },
+    ],
+    [
+      'stale current source blob',
+      (fixture: ReturnType<typeof multiStageRemediationFixture>) => {
+        ;(fixture.evidence.currentPathBlobs[0] as { blobSha: string }).blobSha = 'f'.repeat(40)
+      },
+    ],
+  ] as const)('rejects v2 remediation with %s', (_name, mutate) => {
+    const fixture = multiStageRemediationFixture()
+    mutate(fixture)
+    expect(
+      requireEligibilityHold(
+        evaluateBaynReleaseEligibility({
+          mainCommitSha: multiStageHistory.remediationMerge,
+          baseRefName: 'main',
+          snapshot: fixture.snapshot,
+          nowMs: Date.parse('2026-07-31T16:31:00Z'),
+          pushBeforeSha: multiStageHistory.descendant,
+        }),
+      ),
+    ).toMatchObject({ code: 'release-review-remediation-invalid', retryable: false })
+  })
+
+  test('rejects v2 remediation that omits an unrelated newer Bayn source commit', () => {
+    const fixture = multiStageRemediationFixture()
+    const comparison = fixture.snapshot.comparison
+    if (comparison === null) throw new Error('missing comparison')
+    const introduction = comparison.commits.at(-1)
+    if (introduction === undefined) throw new Error('missing introduction')
+    const extraSha = 'd'.repeat(40)
+    ;(introduction.parents as string[])[0] = extraSha
+    const mutableCommits = comparison.commits as unknown as Array<(typeof comparison.commits)[number]>
+    mutableCommits.splice(-1, 0, {
+      sha: extraSha,
+      parents: [multiStageHistory.descendant],
+      treeSha: 'e'.repeat(40),
+      files: ['services/bayn/src/unrelated-new-source.ts'],
+      fileChanges: [
+        {
+          path: 'services/bayn/src/unrelated-new-source.ts',
+          previousPath: null,
+          status: 'added',
+          blobSha: 'f'.repeat(40),
+        },
+      ],
+      reviewSnapshot: reviewSnapshotFor({
+        commitSha: extraSha,
+        prNumber: 13436,
+        headSha: 'c'.repeat(40),
+        parents: [multiStageHistory.descendant],
+      }),
+    })
+    ;(comparison as { aheadBy: number; totalCommits: number }).aheadBy = 5
+    ;(comparison as { aheadBy: number; totalCommits: number }).totalCommits = 5
+    expect(
+      requireEligibilityHold(
+        evaluateBaynReleaseEligibility({
+          mainCommitSha: multiStageHistory.remediationMerge,
+          baseRefName: 'main',
+          snapshot: fixture.snapshot,
+          nowMs: Date.parse('2026-07-31T16:31:00Z'),
+          pushBeforeSha: multiStageHistory.descendant,
+        }),
+      ),
+    ).toMatchObject({ code: 'release-review-remediation-invalid', retryable: false })
+  })
+
   test('accepts the real #13428 -> #13422 -> #13427 history only through its reviewed exact receipt', () => {
     expect(realRemediationRecord).toMatchObject({
       blocked: {

--- a/packages/scripts/src/bayn/verify-release-review.ts
+++ b/packages/scripts/src/bayn/verify-release-review.ts
@@ -172,6 +172,42 @@ export interface BaynReleaseReviewRemediationPath {
   readonly blockedBlobSha: string
 }
 
+export interface BaynReleaseReviewRemediationReconstructionHead {
+  readonly headSha: string
+  readonly parentSha: string
+  readonly treeSha: string
+  readonly affectedPaths: readonly {
+    readonly path: string
+    readonly previousPath: string | null
+    readonly status: string
+    readonly blobSha: string
+  }[]
+}
+
+export interface BaynReleaseReviewRemediationForcePush {
+  readonly beforeHeadSha: string
+  readonly afterHeadSha: string
+  readonly actorLogin: string
+  readonly createdAt: string
+}
+
+export interface BaynReleaseReviewRemediationFeedback {
+  readonly reviewedHeadSha: string
+  readonly fixedHeadSha: string
+  readonly threadId: string
+  readonly path: string
+  readonly findingUrl: string
+  readonly findingBodySha256: string
+  readonly fixReplyUrl: string
+  readonly fixReplyBodySha256: string
+}
+
+export interface BaynReleaseReviewRemediationReconstruction {
+  readonly heads: readonly BaynReleaseReviewRemediationReconstructionHead[]
+  readonly forcePushes: readonly BaynReleaseReviewRemediationForcePush[]
+  readonly feedback: readonly BaynReleaseReviewRemediationFeedback[]
+}
+
 export interface BaynReleaseReviewRemediationDescendant {
   readonly mergeCommitSha: string
   readonly sourcePullRequestNumber: number
@@ -187,7 +223,7 @@ export interface BaynReleaseReviewRemediationDescendant {
 }
 
 export interface BaynReleaseReviewRemediationRecord {
-  readonly schemaVersion: 'bayn.release-review-remediation.v1'
+  readonly schemaVersion: 'bayn.release-review-remediation.v1' | 'bayn.release-review-remediation.v2'
   readonly remediationId: string
   readonly blocked: {
     readonly mergeCommitSha: string
@@ -208,6 +244,7 @@ export interface BaynReleaseReviewRemediationRecord {
       readonly fixReplyBodySha256: string
     }
     readonly affectedPaths: readonly BaynReleaseReviewRemediationPath[]
+    readonly reconstruction?: BaynReleaseReviewRemediationReconstruction
   }
   readonly requiredDescendants: readonly BaynReleaseReviewRemediationDescendant[]
 }
@@ -542,32 +579,143 @@ const parseRemediationDescendant = (value: unknown, context: string): BaynReleas
   }
 }
 
+const parseRemediationReconstructionHead = (
+  value: unknown,
+  context: string,
+): BaynReleaseReviewRemediationReconstructionHead => {
+  const record = strictRecord(value, ['headSha', 'parentSha', 'treeSha', 'affectedPaths'], context)
+  if (!Array.isArray(record.affectedPaths)) throw new Error(`${context} affectedPaths must be an array`)
+  return {
+    headSha: expectSha(record.headSha, `${context} head SHA`),
+    parentSha: expectSha(record.parentSha, `${context} parent SHA`),
+    treeSha: expectSha(record.treeSha, `${context} tree SHA`),
+    affectedPaths: record.affectedPaths.map((item, index) => {
+      const path = strictRecord(
+        item,
+        ['path', 'previousPath', 'status', 'blobSha'],
+        `${context} affected path ${index}`,
+      )
+      return {
+        path: expectString(path.path, `${context} affected path ${index} path`),
+        previousPath: expectNullableString(path.previousPath, `${context} affected path ${index} previous path`),
+        status: expectString(path.status, `${context} affected path ${index} status`),
+        blobSha: expectSha(path.blobSha, `${context} affected path ${index} blob SHA`),
+      }
+    }),
+  }
+}
+
+const parseRemediationReconstruction = (value: unknown): BaynReleaseReviewRemediationReconstruction => {
+  const record = strictRecord(value, ['heads', 'forcePushes', 'feedback'], 'remediation reconstruction')
+  if (!Array.isArray(record.heads)) throw new Error('remediation reconstruction heads must be an array')
+  if (!Array.isArray(record.forcePushes)) throw new Error('remediation reconstruction forcePushes must be an array')
+  if (!Array.isArray(record.feedback)) throw new Error('remediation reconstruction feedback must be an array')
+  return {
+    heads: record.heads.map((item, index) =>
+      parseRemediationReconstructionHead(item, `remediation reconstruction head ${index}`),
+    ),
+    forcePushes: record.forcePushes.map((item, index) => {
+      const forcePush = strictRecord(
+        item,
+        ['beforeHeadSha', 'afterHeadSha', 'actorLogin', 'createdAt'],
+        `remediation reconstruction force push ${index}`,
+      )
+      return {
+        beforeHeadSha: expectSha(
+          forcePush.beforeHeadSha,
+          `remediation reconstruction force push ${index} before head SHA`,
+        ),
+        afterHeadSha: expectSha(
+          forcePush.afterHeadSha,
+          `remediation reconstruction force push ${index} after head SHA`,
+        ),
+        actorLogin: expectString(forcePush.actorLogin, `remediation reconstruction force push ${index} actor login`),
+        createdAt: expectString(forcePush.createdAt, `remediation reconstruction force push ${index} created at`),
+      }
+    }),
+    feedback: record.feedback.map((item, index) => {
+      const feedback = strictRecord(
+        item,
+        [
+          'reviewedHeadSha',
+          'fixedHeadSha',
+          'threadId',
+          'path',
+          'findingUrl',
+          'findingBodySha256',
+          'fixReplyUrl',
+          'fixReplyBodySha256',
+        ],
+        `remediation reconstruction feedback ${index}`,
+      )
+      return {
+        reviewedHeadSha: expectSha(
+          feedback.reviewedHeadSha,
+          `remediation reconstruction feedback ${index} reviewed head SHA`,
+        ),
+        fixedHeadSha: expectSha(feedback.fixedHeadSha, `remediation reconstruction feedback ${index} fixed head SHA`),
+        threadId: expectString(feedback.threadId, `remediation reconstruction feedback ${index} thread ID`),
+        path: expectString(feedback.path, `remediation reconstruction feedback ${index} path`),
+        findingUrl: expectString(feedback.findingUrl, `remediation reconstruction feedback ${index} finding URL`),
+        findingBodySha256: expectSha256(
+          feedback.findingBodySha256,
+          `remediation reconstruction feedback ${index} finding body hash`,
+        ),
+        fixReplyUrl: expectString(feedback.fixReplyUrl, `remediation reconstruction feedback ${index} fix reply URL`),
+        fixReplyBodySha256: expectSha256(
+          feedback.fixReplyBodySha256,
+          `remediation reconstruction feedback ${index} fix reply body hash`,
+        ),
+      }
+    }),
+  }
+}
+
 export const parseBaynReleaseReviewRemediationRecord = (value: unknown): BaynReleaseReviewRemediationRecord => {
   const record = strictRecord(
     value,
     ['schemaVersion', 'remediationId', 'blocked', 'requiredDescendants'],
     'remediation',
   )
-  if (record.schemaVersion !== 'bayn.release-review-remediation.v1') {
+  if (
+    record.schemaVersion !== 'bayn.release-review-remediation.v1' &&
+    record.schemaVersion !== 'bayn.release-review-remediation.v2'
+  ) {
     throw new Error('remediation schemaVersion is invalid')
   }
+  const schemaVersion = record.schemaVersion
   const remediationId = expectString(record.remediationId, 'remediation ID')
   if (!/^[a-z0-9][a-z0-9-]{2,127}$/.test(remediationId)) throw new Error('remediation ID is invalid')
   const blocked = strictRecord(
     record.blocked,
-    [
-      'mergeCommitSha',
-      'mergeParentSha',
-      'mergeTreeSha',
-      'sourcePullRequestNumber',
-      'reviewedHeadSha',
-      'reviewedHeadTreeSha',
-      'finalHeadSha',
-      'finalHeadTreeSha',
-      'sourcePullRequestEvidenceSha256',
-      'feedback',
-      'affectedPaths',
-    ],
+    schemaVersion === 'bayn.release-review-remediation.v2'
+      ? [
+          'mergeCommitSha',
+          'mergeParentSha',
+          'mergeTreeSha',
+          'sourcePullRequestNumber',
+          'reviewedHeadSha',
+          'reviewedHeadTreeSha',
+          'finalHeadSha',
+          'finalHeadTreeSha',
+          'sourcePullRequestEvidenceSha256',
+          'feedback',
+          'affectedPaths',
+          'reconstruction',
+        ]
+      : [
+          'mergeCommitSha',
+          'mergeParentSha',
+          'mergeTreeSha',
+          'sourcePullRequestNumber',
+          'reviewedHeadSha',
+          'reviewedHeadTreeSha',
+          'finalHeadSha',
+          'finalHeadTreeSha',
+          'sourcePullRequestEvidenceSha256',
+          'feedback',
+          'affectedPaths',
+        ],
     'remediation blocked source',
   )
   const feedback = strictRecord(
@@ -578,7 +726,7 @@ export const parseBaynReleaseReviewRemediationRecord = (value: unknown): BaynRel
   if (!Array.isArray(blocked.affectedPaths)) throw new Error('remediation blocked affectedPaths must be an array')
   if (!Array.isArray(record.requiredDescendants)) throw new Error('remediation requiredDescendants must be an array')
   return {
-    schemaVersion: 'bayn.release-review-remediation.v1',
+    schemaVersion,
     remediationId,
     blocked: {
       mergeCommitSha: expectSha(blocked.mergeCommitSha, 'remediation blocked merge commit SHA'),
@@ -607,6 +755,9 @@ export const parseBaynReleaseReviewRemediationRecord = (value: unknown): BaynRel
       affectedPaths: blocked.affectedPaths.map((item, index) =>
         parseRemediationPath(item, `remediation blocked affected path ${index}`),
       ),
+      ...(schemaVersion === 'bayn.release-review-remediation.v2'
+        ? { reconstruction: parseRemediationReconstruction(blocked.reconstruction) }
+        : {}),
     },
     requiredDescendants: record.requiredDescendants.map((item, index) =>
       parseRemediationDescendant(item, `remediation descendant ${index}`),
@@ -1050,6 +1201,114 @@ const validateRemediationFeedback = (
   record: BaynReleaseReviewRemediationRecord,
   pullRequest: PullRequestReviewState,
 ): BaynReleaseReviewHold | null => {
+  if (record.schemaVersion === 'bayn.release-review-remediation.v2') {
+    const reconstruction = record.blocked.reconstruction
+    if (reconstruction === undefined) {
+      return remediationInvalid(`remediation ${record.remediationId} reconstruction is missing`)
+    }
+    if (pullRequestReviewEvidenceSha256(pullRequest) !== record.blocked.sourcePullRequestEvidenceSha256) {
+      return remediationInvalid(
+        `remediation ${record.remediationId} source PR #${pullRequest.number} review/reaction/thread evidence changed`,
+      )
+    }
+    if (
+      pullRequest.number !== record.blocked.sourcePullRequestNumber ||
+      pullRequest.headSha !== record.blocked.finalHeadSha ||
+      pullRequest.mergeCommitSha !== record.blocked.mergeCommitSha ||
+      pullRequest.headForcePushCount !== reconstruction.forcePushes.length ||
+      pullRequest.headForcePushes.length !== reconstruction.forcePushes.length
+    ) {
+      return remediationInvalid(`remediation ${record.remediationId} source PR metadata is not exact`)
+    }
+    if (pullRequest.threads.some((thread) => !thread.isResolved)) {
+      return remediationInvalid(`remediation ${record.remediationId} source PR contains an unresolved review thread`)
+    }
+    const blockingReviews = pullRequest.reviews.filter(
+      (review) =>
+        review.authorLogin === baynCodexReviewer &&
+        (review.submittedAt === null || review.state === 'PENDING' || review.state === 'CHANGES_REQUESTED'),
+    )
+    if (blockingReviews.length > 0) {
+      return remediationInvalid(`remediation ${record.remediationId} contains a blocking Codex review`)
+    }
+    for (let index = 0; index < reconstruction.forcePushes.length; index += 1) {
+      const expected = reconstruction.forcePushes[index]
+      const observed = pullRequest.headForcePushes[index]
+      if (
+        expected === undefined ||
+        observed === undefined ||
+        observed.beforeCommitSha !== expected.beforeHeadSha ||
+        observed.afterCommitSha !== expected.afterHeadSha ||
+        observed.actorLogin !== expected.actorLogin ||
+        observed.createdAt !== expected.createdAt
+      ) {
+        return remediationInvalid(`remediation ${record.remediationId} force-push transformation ${index} is not exact`)
+      }
+    }
+    const feedbackThreadIds = reconstruction.feedback.map((feedback) => feedback.threadId)
+    if (
+      new Set(feedbackThreadIds).size !== feedbackThreadIds.length ||
+      !exactStringSet(
+        pullRequest.threads.map((thread) => thread.id),
+        feedbackThreadIds,
+      )
+    ) {
+      return remediationInvalid(`remediation ${record.remediationId} feedback thread set is incomplete`)
+    }
+    for (const feedback of reconstruction.feedback) {
+      const reviewMatches = pullRequest.reviews.filter(
+        (review) =>
+          review.authorLogin === baynCodexReviewer &&
+          review.commitSha === feedback.reviewedHeadSha &&
+          review.submittedAt !== null &&
+          eligibleReviewStates.has(review.state),
+      )
+      if (reviewMatches.length !== 1) {
+        return remediationInvalid(
+          `remediation ${record.remediationId} reviewed evidence for ${shortSha(feedback.reviewedHeadSha)} is incomplete`,
+        )
+      }
+      const thread = pullRequest.threads.find((candidate) => candidate.id === feedback.threadId)
+      if (thread === undefined || !thread.isResolved || thread.path !== feedback.path) {
+        return remediationInvalid(`remediation ${record.remediationId} feedback thread ${feedback.threadId} is missing`)
+      }
+      const finding = thread.comments.filter(
+        (comment) =>
+          comment.url === feedback.findingUrl &&
+          sha256Text(comment.body) === feedback.findingBodySha256 &&
+          comment.authorLogin === baynCodexReviewer &&
+          comment.reviewAuthorLogin === baynCodexReviewer &&
+          comment.reviewCommitSha === feedback.reviewedHeadSha,
+      )
+      const reply = thread.comments.filter(
+        (comment) =>
+          comment.url === feedback.fixReplyUrl &&
+          sha256Text(comment.body) === feedback.fixReplyBodySha256 &&
+          comment.authorLogin !== null &&
+          comment.authorLogin !== baynCodexReviewer &&
+          trustedFeedbackAssociations.has(comment.authorAssociation) &&
+          comment.reviewCommitSha === feedback.fixedHeadSha,
+      )
+      if (finding.length !== 1 || reply.length !== 1) {
+        return remediationInvalid(
+          `remediation ${record.remediationId} exact feedback/fix evidence for ${feedback.threadId} is missing`,
+        )
+      }
+    }
+    const reactions = pullRequest.reactions.filter(
+      (reaction) => reaction.userLogin === baynCodexBotLogin && reaction.content === '+1',
+    )
+    const latestForcePush = reconstruction.forcePushes.at(-1)
+    if (
+      reactions.length !== 1 ||
+      reactions[0] === undefined ||
+      latestForcePush === undefined ||
+      reactions[0].createdAt <= latestForcePush.createdAt
+    ) {
+      return remediationInvalid(`remediation ${record.remediationId} exact final-head reaction evidence is missing`)
+    }
+    return null
+  }
   if (pullRequestReviewEvidenceSha256(pullRequest) !== record.blocked.sourcePullRequestEvidenceSha256) {
     return remediationInvalid(
       `remediation ${record.remediationId} source PR #${pullRequest.number} review/reaction/thread evidence changed`,
@@ -1186,6 +1445,270 @@ const validateRemediationCommitPaths = (input: {
   return null
 }
 
+const validateRemediationReconstructionHead = (input: {
+  readonly remediationId: string
+  readonly expected: BaynReleaseReviewRemediationReconstructionHead
+  readonly observed: RemediationCommitObject
+}): BaynReleaseReviewHold | null => {
+  const { expected, observed } = input
+  if (
+    observed.sha !== expected.headSha ||
+    observed.parents.length !== 1 ||
+    observed.parents[0] !== expected.parentSha ||
+    observed.treeSha !== expected.treeSha
+  ) {
+    return remediationInvalid(
+      `remediation ${input.remediationId} reconstructed head ${shortSha(expected.headSha)} identity changed`,
+    )
+  }
+  const changes = commitFileMap(observed.fileChanges)
+  const blobs = pathBlobMap(observed.pathBlobs)
+  const expectedPaths = expected.affectedPaths.map((path) => path.path)
+  if (
+    changes === null ||
+    blobs === null ||
+    new Set(expectedPaths).size !== expectedPaths.length ||
+    !exactStringSet([...changes.keys()], expectedPaths) ||
+    !exactStringSet([...blobs.keys()], expectedPaths)
+  ) {
+    return remediationInvalid(
+      `remediation ${input.remediationId} reconstructed head ${shortSha(expected.headSha)} path set changed`,
+    )
+  }
+  for (const path of expected.affectedPaths) {
+    const change = changes.get(path.path)
+    if (
+      change === undefined ||
+      change.previousPath !== path.previousPath ||
+      change.status !== path.status ||
+      change.blobSha !== path.blobSha ||
+      blobs.get(path.path) !== path.blobSha
+    ) {
+      return remediationInvalid(
+        `remediation ${input.remediationId} reconstructed head ${shortSha(expected.headSha)} blob changed at ${path.path}`,
+      )
+    }
+  }
+  return null
+}
+
+const validateRemediationDescendantPathsV2 = (input: {
+  readonly remediationId: string
+  readonly mergeCommit: BaynReleaseRangeCommit
+  readonly descendant: BaynReleaseReviewRemediationDescendant
+  readonly finalHead: RemediationCommitObject
+}): BaynReleaseReviewHold | null => {
+  const { descendant, finalHead, mergeCommit } = input
+  if (
+    mergeCommit.treeSha !== descendant.mergeTreeSha ||
+    finalHead.sha !== descendant.finalHeadSha ||
+    finalHead.treeSha !== descendant.finalHeadTreeSha ||
+    descendant.mergeTreeSha !== descendant.finalHeadTreeSha
+  ) {
+    return remediationInvalid(`remediation ${input.remediationId} descendant commit tree identity changed`)
+  }
+  const mergeChanges = commitFileMap(mergeCommit.fileChanges)
+  const finalBlobs = pathBlobMap(finalHead.pathBlobs)
+  const expectedPaths = descendant.affectedPaths.map((path) => path.path)
+  if (
+    mergeChanges === null ||
+    finalBlobs === null ||
+    new Set(expectedPaths).size !== expectedPaths.length ||
+    !exactStringSet([...mergeChanges.keys()], expectedPaths) ||
+    !exactStringSet([...finalBlobs.keys()], expectedPaths)
+  ) {
+    return remediationInvalid(`remediation ${input.remediationId} descendant path/blob evidence is incomplete`)
+  }
+  for (const path of descendant.affectedPaths) {
+    if (
+      mergeChanges.get(path.path)?.blobSha !== path.mergeBlobSha ||
+      finalBlobs.get(path.path) !== path.finalHeadBlobSha ||
+      path.mergeBlobSha !== path.finalHeadBlobSha
+    ) {
+      return remediationInvalid(`remediation ${input.remediationId} descendant blob changed at ${path.path}`)
+    }
+  }
+  return null
+}
+
+const validateReleaseReviewRemediationV2 = (input: {
+  readonly evidence: BaynReleaseReviewRemediationEvidence
+  readonly blockedCommit: BaynReleaseRangeCommit
+  readonly comparison: BaynReleaseComparison
+  readonly normalReviews: ReadonlyMap<string, BaynReleaseReviewEvaluation>
+  readonly introduction: BaynReleaseRangeCommit
+  readonly blockedIndex: number
+}): BaynReleaseReviewHold | null => {
+  const { evidence, blockedCommit, comparison } = input
+  const record = evidence.record
+  const reconstruction = record.blocked.reconstruction
+  if (record.schemaVersion !== 'bayn.release-review-remediation.v2' || reconstruction === undefined) {
+    return remediationInvalid(`remediation ${record.remediationId} v2 reconstruction is missing`)
+  }
+  if (
+    reconstruction.heads.length < 2 ||
+    reconstruction.forcePushes.length !== reconstruction.heads.length - 1 ||
+    new Set(reconstruction.heads.map((head) => head.headSha)).size !== reconstruction.heads.length
+  ) {
+    return remediationInvalid(`remediation ${record.remediationId} reconstruction chain is malformed`)
+  }
+  const firstHead = reconstruction.heads[0]
+  const finalHeadRecord = reconstruction.heads.at(-1)
+  if (
+    firstHead === undefined ||
+    finalHeadRecord === undefined ||
+    firstHead.headSha !== record.blocked.reviewedHeadSha ||
+    firstHead.treeSha !== record.blocked.reviewedHeadTreeSha ||
+    finalHeadRecord.headSha !== record.blocked.finalHeadSha ||
+    finalHeadRecord.treeSha !== record.blocked.finalHeadTreeSha ||
+    finalHeadRecord.parentSha !== record.blocked.mergeParentSha ||
+    finalHeadRecord.treeSha !== record.blocked.mergeTreeSha
+  ) {
+    return remediationInvalid(`remediation ${record.remediationId} reconstruction endpoints are invalid`)
+  }
+  for (let index = 0; index < reconstruction.heads.length; index += 1) {
+    const expected = reconstruction.heads[index]
+    if (expected === undefined) return remediationInvalid(`remediation ${record.remediationId} head is missing`)
+    const observed = findReferencedCommit(evidence, expected.headSha)
+    if (observed === null) {
+      return remediationInvalid(
+        `remediation ${record.remediationId} reconstructed head ${shortSha(expected.headSha)} is missing`,
+      )
+    }
+    const headHold = validateRemediationReconstructionHead({ remediationId: record.remediationId, expected, observed })
+    if (headHold !== null) return headHold
+    if (index > 0) {
+      const previous = reconstruction.heads[index - 1]
+      const forcePush = reconstruction.forcePushes[index - 1]
+      if (
+        previous === undefined ||
+        forcePush === undefined ||
+        forcePush.beforeHeadSha !== previous.headSha ||
+        forcePush.afterHeadSha !== expected.headSha
+      ) {
+        return remediationInvalid(`remediation ${record.remediationId} reconstruction force-push chain is incomplete`)
+      }
+    }
+  }
+  for (const feedback of reconstruction.feedback) {
+    const reviewedIndex = reconstruction.heads.findIndex((head) => head.headSha === feedback.reviewedHeadSha)
+    const fixedIndex = reconstruction.heads.findIndex((head) => head.headSha === feedback.fixedHeadSha)
+    if (reviewedIndex < 0 || fixedIndex <= reviewedIndex) {
+      return remediationInvalid(`remediation ${record.remediationId} feedback transformation is not forward-only`)
+    }
+  }
+
+  const finalHead = findReferencedCommit(evidence, record.blocked.finalHeadSha)
+  const finalChanges = finalHead === null ? null : commitFileMap(finalHead.fileChanges)
+  const blockedChanges = commitFileMap(blockedCommit.fileChanges)
+  const finalPaths = finalHeadRecord.affectedPaths.map((path) => path.path)
+  if (
+    finalHead === null ||
+    finalChanges === null ||
+    blockedChanges === null ||
+    blockedCommit.treeSha !== finalHead.treeSha ||
+    !exactStringSet(blockedCommit.files, finalPaths) ||
+    !exactStringSet([...blockedChanges.keys()], finalPaths)
+  ) {
+    return remediationInvalid(`remediation ${record.remediationId} final head/blocked merge binding changed`)
+  }
+  for (const path of finalHeadRecord.affectedPaths) {
+    if (
+      finalChanges.get(path.path)?.blobSha !== path.blobSha ||
+      blockedChanges.get(path.path)?.blobSha !== path.blobSha
+    ) {
+      return remediationInvalid(`remediation ${record.remediationId} blocked merge blob changed at ${path.path}`)
+    }
+  }
+
+  const expectedCurrentBlobs = new Map(finalHeadRecord.affectedPaths.map((path) => [path.path, path.blobSha] as const))
+  let expectedParent = blockedCommit.sha
+  let cursor = input.blockedIndex + 1
+  const nextBaynCommit = (): BaynReleaseRangeCommit | BaynReleaseReviewHold | null => {
+    while (cursor < comparison.commits.length) {
+      const commit = comparison.commits[cursor]
+      if (commit === undefined || commit.parents.length !== 1 || commit.parents[0] !== expectedParent) {
+        return remediationInvalid(`remediation ${record.remediationId} source ancestry is not a direct-parent chain`)
+      }
+      expectedParent = commit.sha
+      cursor += 1
+      if (commit.files.some(isBaynReleaseAffectingPath)) return commit
+    }
+    return null
+  }
+  for (const descendant of record.requiredDescendants) {
+    const next = nextBaynCommit()
+    if (next === null || 'status' in next) {
+      return next ?? remediationInvalid(`remediation ${record.remediationId} descendant chain is incomplete`)
+    }
+    const mergeCommit = next
+    if (mergeCommit.sha !== descendant.mergeCommitSha) {
+      return remediationInvalid(`remediation ${record.remediationId} descendant ancestry is incomplete or downgraded`)
+    }
+    const normalDescendantReview = input.normalReviews.get(mergeCommit.sha)
+    if (normalDescendantReview?.status !== 'eligible')
+      return (
+        normalDescendantReview ??
+        remediationInvalid(`remediation ${record.remediationId} descendant exact-head review is missing`)
+      )
+    const descendantPull = mergeCommit.reviewSnapshot?.pullRequest
+    if (
+      descendantPull === null ||
+      descendantPull === undefined ||
+      descendantPull.number !== descendant.sourcePullRequestNumber ||
+      descendantPull.headSha !== descendant.finalHeadSha ||
+      descendantPull.mergeCommitSha !== descendant.mergeCommitSha ||
+      pullRequestReviewEvidenceSha256(descendantPull) !== descendant.sourcePullRequestEvidenceSha256 ||
+      descendantPull.threads.some((thread) => !thread.isResolved)
+    ) {
+      return remediationInvalid(`remediation ${record.remediationId} descendant review chain is incomplete`)
+    }
+    const finalDescendantHead = findReferencedCommit(evidence, descendant.finalHeadSha)
+    if (finalDescendantHead === null) {
+      return remediationInvalid(`remediation ${record.remediationId} descendant head evidence is missing`)
+    }
+    const pathsHold = validateRemediationDescendantPathsV2({
+      remediationId: record.remediationId,
+      mergeCommit,
+      descendant,
+      finalHead: finalDescendantHead,
+    })
+    if (pathsHold !== null) return pathsHold
+    for (const path of descendant.affectedPaths) {
+      if (expectedCurrentBlobs.has(path.path)) expectedCurrentBlobs.set(path.path, path.mergeBlobSha)
+    }
+  }
+  const introduction = nextBaynCommit()
+  if (introduction === null || 'status' in introduction || introduction.sha !== input.introduction.sha) {
+    return 'status' in (introduction ?? {})
+      ? (introduction as BaynReleaseReviewHold)
+      : remediationInvalid(`remediation ${record.remediationId} is stale or omits a newer source commit`)
+  }
+  while (cursor < comparison.commits.length) {
+    const commit = comparison.commits[cursor]
+    if (commit === undefined || commit.parents.length !== 1 || commit.parents[0] !== expectedParent) {
+      return remediationInvalid(`remediation ${record.remediationId} source ancestry is not a direct-parent chain`)
+    }
+    if (commit.files.some(isBaynReleaseAffectingPath)) {
+      return remediationInvalid(`remediation ${record.remediationId} omits a newer Bayn source commit`)
+    }
+    expectedParent = commit.sha
+    cursor += 1
+  }
+  if (expectedParent !== comparison.headSha) {
+    return remediationInvalid(`remediation ${record.remediationId} does not reach the current source head`)
+  }
+  const currentBlobs = pathBlobMap(evidence.currentPathBlobs)
+  if (
+    currentBlobs === null ||
+    !exactStringSet([...currentBlobs.keys()], [...expectedCurrentBlobs.keys()]) ||
+    [...expectedCurrentBlobs].some(([path, blobSha]) => currentBlobs.get(path) !== blobSha)
+  ) {
+    return remediationInvalid(`remediation ${record.remediationId} current source blobs diverged`)
+  }
+  return null
+}
+
 const validateReleaseReviewRemediation = (input: {
   readonly evidence: BaynReleaseReviewRemediationEvidence
   readonly blockedCommit: BaynReleaseRangeCommit
@@ -1237,6 +1760,17 @@ const validateReleaseReviewRemediation = (input: {
   }
   const feedbackHold = validateRemediationFeedback(record, blockedPull)
   if (feedbackHold !== null) return feedbackHold
+
+  if (record.schemaVersion === 'bayn.release-review-remediation.v2') {
+    return validateReleaseReviewRemediationV2({
+      evidence,
+      blockedCommit,
+      comparison,
+      normalReviews: input.normalReviews,
+      introduction,
+      blockedIndex,
+    })
+  }
 
   const reviewedHead = findReferencedCommit(evidence, record.blocked.reviewedHeadSha)
   const finalHead = findReferencedCommit(evidence, record.blocked.finalHeadSha)
@@ -2913,14 +3447,25 @@ const loadReleaseReviewRemediations = async (
       )
     }
     const references = new Map<string, readonly string[]>()
-    references.set(
-      loaded.record.blocked.reviewedHeadSha,
-      loaded.record.blocked.affectedPaths.map((path) => path.path),
-    )
-    references.set(
-      loaded.record.blocked.finalHeadSha,
-      loaded.record.blocked.affectedPaths.map((path) => path.path),
-    )
+    if (loaded.record.schemaVersion === 'bayn.release-review-remediation.v2') {
+      const reconstruction = loaded.record.blocked.reconstruction
+      if (reconstruction === undefined) throw new Error(`remediation ${loaded.path} reconstruction is missing`)
+      for (const head of reconstruction.heads) {
+        references.set(
+          head.headSha,
+          head.affectedPaths.map((path) => path.path),
+        )
+      }
+    } else {
+      references.set(
+        loaded.record.blocked.reviewedHeadSha,
+        loaded.record.blocked.affectedPaths.map((path) => path.path),
+      )
+      references.set(
+        loaded.record.blocked.finalHeadSha,
+        loaded.record.blocked.affectedPaths.map((path) => path.path),
+      )
+    }
     for (const descendant of loaded.record.requiredDescendants) {
       references.set(
         descendant.finalHeadSha,
@@ -2937,11 +3482,14 @@ const loadReleaseReviewRemediations = async (
       ])
       return { ...commit, pathBlobs }
     })
-    const currentPathBlobs = await mapWithConcurrency(
-      loaded.record.blocked.affectedPaths.map((path) => path.path),
-      4,
-      async (path) => ({ path, blobSha: await fetchPathBlobSha(options, options.mainCommitSha, path) }),
-    )
+    const currentPaths =
+      loaded.record.schemaVersion === 'bayn.release-review-remediation.v2'
+        ? (loaded.record.blocked.reconstruction?.heads.at(-1)?.affectedPaths.map((path) => path.path) ?? [])
+        : loaded.record.blocked.affectedPaths.map((path) => path.path)
+    const currentPathBlobs = await mapWithConcurrency(currentPaths, 4, async (path) => ({
+      path,
+      blobSha: await fetchPathBlobSha(options, options.mainCommitSha, path),
+    }))
     return {
       recordPath: loaded.path,
       recordBlobSha: loaded.blobSha,

--- a/services/bayn/release-review-remediations/9bea355c17fb9320fc692bb214f76af105650a02.json
+++ b/services/bayn/release-review-remediations/9bea355c17fb9320fc692bb214f76af105650a02.json
@@ -1,0 +1,527 @@
+{
+  "schemaVersion": "bayn.release-review-remediation.v2",
+  "remediationId": "pr-13429-complete-reviewed-reconstruction",
+  "blocked": {
+    "mergeCommitSha": "9bea355c17fb9320fc692bb214f76af105650a02",
+    "mergeParentSha": "bbef7b18804cf9e30c11eac326e90281d1774b80",
+    "mergeTreeSha": "798c8d853452bf6598e46c2da3d6accd30770976",
+    "sourcePullRequestNumber": 13429,
+    "reviewedHeadSha": "34c16da9de7a72bb7d8d37056048269103a4d896",
+    "reviewedHeadTreeSha": "6fced3a2fa4d2b716fc84d4c3bf178b07c1b8d9f",
+    "finalHeadSha": "bc32db2e9eeb7140f422fc1b6621427a8f7dabfc",
+    "finalHeadTreeSha": "798c8d853452bf6598e46c2da3d6accd30770976",
+    "sourcePullRequestEvidenceSha256": "76c0ded3097b2d8457b0b5663653d04d3968276f2e76a2a41258e3193a7b35a4",
+    "feedback": {
+      "threadId": "PRRT_kwDOLkRLus6VbNnO",
+      "path": "services/bayn/src/candidate-development-candidate-17-evidence.ts",
+      "findingUrl": "https://github.com/proompteng/lab/pull/13429#discussion_r3690666881",
+      "findingBodySha256": "2e0981a3e7402d209bf1e982cf85396c892d16133ecf9da69cb70284853622fe",
+      "fixReplyUrl": "https://github.com/proompteng/lab/pull/13429#discussion_r3691014612",
+      "fixReplyBodySha256": "93f2a43d9fd5d3dc7cebf14e1831c6ccf2fe36732033215034322a27826a3125"
+    },
+    "affectedPaths": [],
+    "reconstruction": {
+      "heads": [
+        {
+          "headSha": "34c16da9de7a72bb7d8d37056048269103a4d896",
+          "parentSha": "9f4ea79b12dcd32c794a9701160587d9a12e8c4d",
+          "treeSha": "6fced3a2fa4d2b716fc84d4c3bf178b07c1b8d9f",
+          "affectedPaths": [
+            {
+              "path": "services/bayn/src/candidate-development-calendar.ts",
+              "previousPath": null,
+              "status": "modified",
+              "blobSha": "073aa6d0c1bb0789faf4ab47b4165e5bd2a3b703"
+            },
+            {
+              "path": "services/bayn/src/candidate-development-candidate-17-evidence.ts",
+              "previousPath": null,
+              "status": "added",
+              "blobSha": "38bd9102b0fad0a38785544cf791f5fb5a157aeb"
+            },
+            {
+              "path": "services/bayn/src/candidate-development-candidate-17.test.ts",
+              "previousPath": null,
+              "status": "modified",
+              "blobSha": "15522163dc618dd41da41e1a2050348e5f3ea529"
+            },
+            {
+              "path": "services/bayn/src/candidate-development-command.test.ts",
+              "previousPath": null,
+              "status": "modified",
+              "blobSha": "91c643844a36a1dc767915a922f94942b8a3bbf8"
+            },
+            {
+              "path": "services/bayn/src/candidate-development-command.ts",
+              "previousPath": null,
+              "status": "modified",
+              "blobSha": "6a41cde36a78e201bfacc34066d94498e0ec19cf"
+            },
+            {
+              "path": "services/bayn/src/candidate-development-evidence.test.ts",
+              "previousPath": null,
+              "status": "added",
+              "blobSha": "d5de8f1cdc71b6647917c5bf9abf85941cd673bb"
+            },
+            {
+              "path": "services/bayn/src/candidate-development-evidence.ts",
+              "previousPath": null,
+              "status": "added",
+              "blobSha": "5837f52e0a0dde40d2fc3589805343750bb28bc5"
+            }
+          ]
+        },
+        {
+          "headSha": "ba08cfb3d3834c61dcaffadc9354d9ad48de3e8b",
+          "parentSha": "9f4ea79b12dcd32c794a9701160587d9a12e8c4d",
+          "treeSha": "fa02ec6cd87e94fed04d220c549008214458c4ba",
+          "affectedPaths": [
+            {
+              "path": "services/bayn/src/candidate-development-calendar.ts",
+              "previousPath": null,
+              "status": "modified",
+              "blobSha": "073aa6d0c1bb0789faf4ab47b4165e5bd2a3b703"
+            },
+            {
+              "path": "services/bayn/src/candidate-development-candidate-17-evidence.ts",
+              "previousPath": null,
+              "status": "added",
+              "blobSha": "38bd9102b0fad0a38785544cf791f5fb5a157aeb"
+            },
+            {
+              "path": "services/bayn/src/candidate-development-candidate-17.test.ts",
+              "previousPath": null,
+              "status": "modified",
+              "blobSha": "15522163dc618dd41da41e1a2050348e5f3ea529"
+            },
+            {
+              "path": "services/bayn/src/candidate-development-command.test.ts",
+              "previousPath": null,
+              "status": "modified",
+              "blobSha": "91c643844a36a1dc767915a922f94942b8a3bbf8"
+            },
+            {
+              "path": "services/bayn/src/candidate-development-command.ts",
+              "previousPath": null,
+              "status": "modified",
+              "blobSha": "6a41cde36a78e201bfacc34066d94498e0ec19cf"
+            },
+            {
+              "path": "services/bayn/src/candidate-development-evidence.test.ts",
+              "previousPath": null,
+              "status": "added",
+              "blobSha": "f907d9a756f400b75d020f3e97adc0c005d8fb42"
+            },
+            {
+              "path": "services/bayn/src/candidate-development-evidence.ts",
+              "previousPath": null,
+              "status": "added",
+              "blobSha": "d597c71912ec3495b2f9eec4c39feef2635f16ef"
+            }
+          ]
+        },
+        {
+          "headSha": "186ba05662b61e6610c8939fddd54247ca364542",
+          "parentSha": "319291bebe22b0c1dc928f13d0ff3655c4b22284",
+          "treeSha": "fa35e4153ce083da05ec9c1b4eaacb3f20e71c75",
+          "affectedPaths": [
+            {
+              "path": "services/bayn/candidates/ordinal-17-volatility-managed-trend-overlay-development-evidence.json",
+              "previousPath": null,
+              "status": "added",
+              "blobSha": "54a0bf6067a5e42d26dc1a24a96429d89332342b"
+            },
+            {
+              "path": "services/bayn/src/candidate-development-calendar.ts",
+              "previousPath": null,
+              "status": "modified",
+              "blobSha": "a8af61e791b7d1868319575e43bb846c75e6c1f9"
+            },
+            {
+              "path": "services/bayn/src/candidate-development-candidate-17-evidence.ts",
+              "previousPath": null,
+              "status": "added",
+              "blobSha": "4a3c40ace3d6c03ace4a5f6321a5b01ef23025cc"
+            },
+            {
+              "path": "services/bayn/src/candidate-development-candidate-17.test.ts",
+              "previousPath": null,
+              "status": "modified",
+              "blobSha": "15522163dc618dd41da41e1a2050348e5f3ea529"
+            },
+            {
+              "path": "services/bayn/src/candidate-development-command.test.ts",
+              "previousPath": null,
+              "status": "modified",
+              "blobSha": "91c643844a36a1dc767915a922f94942b8a3bbf8"
+            },
+            {
+              "path": "services/bayn/src/candidate-development-command.ts",
+              "previousPath": null,
+              "status": "modified",
+              "blobSha": "815645bea35a800e74fc3a851f262d4808d63949"
+            },
+            {
+              "path": "services/bayn/src/candidate-development-decision.ts",
+              "previousPath": null,
+              "status": "added",
+              "blobSha": "c0b8b4ca910318950d00f267146b85e1aadddce8"
+            },
+            {
+              "path": "services/bayn/src/candidate-development-evidence.test.ts",
+              "previousPath": null,
+              "status": "added",
+              "blobSha": "79313d78786a7b5a3638b3e75016f59cc577d0b9"
+            },
+            {
+              "path": "services/bayn/src/candidate-development-evidence.ts",
+              "previousPath": null,
+              "status": "added",
+              "blobSha": "d0b784e5bf49218950d078eae71eb72c258bf442"
+            },
+            {
+              "path": "services/bayn/src/candidate-development-trial-history.ts",
+              "previousPath": null,
+              "status": "added",
+              "blobSha": "34e334dff988276f9ba20d1f2cd742b910ec9e4b"
+            }
+          ]
+        },
+        {
+          "headSha": "7570e37e328f69d36030b8f01f2b0f7b94c5a1d7",
+          "parentSha": "319291bebe22b0c1dc928f13d0ff3655c4b22284",
+          "treeSha": "0e1f41536eaa0a187eaaa878b24f1b12b8296394",
+          "affectedPaths": [
+            {
+              "path": "services/bayn/candidates/ordinal-17-volatility-managed-trend-overlay-development-evidence.json",
+              "previousPath": null,
+              "status": "added",
+              "blobSha": "222890183c2db10cb8af81c6967901a12f4c1b7b"
+            },
+            {
+              "path": "services/bayn/src/candidate-development-calendar.ts",
+              "previousPath": null,
+              "status": "modified",
+              "blobSha": "a8af61e791b7d1868319575e43bb846c75e6c1f9"
+            },
+            {
+              "path": "services/bayn/src/candidate-development-candidate-17-evidence.ts",
+              "previousPath": null,
+              "status": "added",
+              "blobSha": "4a3c40ace3d6c03ace4a5f6321a5b01ef23025cc"
+            },
+            {
+              "path": "services/bayn/src/candidate-development-candidate-17.test.ts",
+              "previousPath": null,
+              "status": "modified",
+              "blobSha": "15522163dc618dd41da41e1a2050348e5f3ea529"
+            },
+            {
+              "path": "services/bayn/src/candidate-development-command.test.ts",
+              "previousPath": null,
+              "status": "modified",
+              "blobSha": "91c643844a36a1dc767915a922f94942b8a3bbf8"
+            },
+            {
+              "path": "services/bayn/src/candidate-development-command.ts",
+              "previousPath": null,
+              "status": "modified",
+              "blobSha": "815645bea35a800e74fc3a851f262d4808d63949"
+            },
+            {
+              "path": "services/bayn/src/candidate-development-decision.ts",
+              "previousPath": null,
+              "status": "added",
+              "blobSha": "c0b8b4ca910318950d00f267146b85e1aadddce8"
+            },
+            {
+              "path": "services/bayn/src/candidate-development-evidence.test.ts",
+              "previousPath": null,
+              "status": "added",
+              "blobSha": "79313d78786a7b5a3638b3e75016f59cc577d0b9"
+            },
+            {
+              "path": "services/bayn/src/candidate-development-evidence.ts",
+              "previousPath": null,
+              "status": "added",
+              "blobSha": "d0b784e5bf49218950d078eae71eb72c258bf442"
+            },
+            {
+              "path": "services/bayn/src/candidate-development-trial-history.ts",
+              "previousPath": null,
+              "status": "added",
+              "blobSha": "34e334dff988276f9ba20d1f2cd742b910ec9e4b"
+            }
+          ]
+        },
+        {
+          "headSha": "bc32db2e9eeb7140f422fc1b6621427a8f7dabfc",
+          "parentSha": "bbef7b18804cf9e30c11eac326e90281d1774b80",
+          "treeSha": "798c8d853452bf6598e46c2da3d6accd30770976",
+          "affectedPaths": [
+            {
+              "path": "services/bayn/candidates/ordinal-17-volatility-managed-trend-overlay-development-evidence.json",
+              "previousPath": null,
+              "status": "added",
+              "blobSha": "222890183c2db10cb8af81c6967901a12f4c1b7b"
+            },
+            {
+              "path": "services/bayn/src/candidate-development-calendar.ts",
+              "previousPath": null,
+              "status": "modified",
+              "blobSha": "a8af61e791b7d1868319575e43bb846c75e6c1f9"
+            },
+            {
+              "path": "services/bayn/src/candidate-development-candidate-17-evidence.ts",
+              "previousPath": null,
+              "status": "added",
+              "blobSha": "39b8d1143eb75243cca67c9e22ffb9ed9635c2b6"
+            },
+            {
+              "path": "services/bayn/src/candidate-development-candidate-17.test.ts",
+              "previousPath": null,
+              "status": "modified",
+              "blobSha": "15522163dc618dd41da41e1a2050348e5f3ea529"
+            },
+            {
+              "path": "services/bayn/src/candidate-development-command.test.ts",
+              "previousPath": null,
+              "status": "modified",
+              "blobSha": "91c643844a36a1dc767915a922f94942b8a3bbf8"
+            },
+            {
+              "path": "services/bayn/src/candidate-development-command.ts",
+              "previousPath": null,
+              "status": "modified",
+              "blobSha": "00816329683478486f51f88c40b0568ca2dc70b9"
+            },
+            {
+              "path": "services/bayn/src/candidate-development-decision.ts",
+              "previousPath": null,
+              "status": "added",
+              "blobSha": "c0b8b4ca910318950d00f267146b85e1aadddce8"
+            },
+            {
+              "path": "services/bayn/src/candidate-development-evidence.test.ts",
+              "previousPath": null,
+              "status": "added",
+              "blobSha": "cc5e4ea511e3f8cec6641c9350925f5a005c8425"
+            },
+            {
+              "path": "services/bayn/src/candidate-development-evidence.ts",
+              "previousPath": null,
+              "status": "added",
+              "blobSha": "2906c41e74c006725f56db57efe2ffb3a773db01"
+            },
+            {
+              "path": "services/bayn/src/candidate-development-trial-history.ts",
+              "previousPath": null,
+              "status": "added",
+              "blobSha": "b1520bbd86772969c7a9910bf9f0aa36b7366bf0"
+            }
+          ]
+        }
+      ],
+      "forcePushes": [
+        {
+          "beforeHeadSha": "34c16da9de7a72bb7d8d37056048269103a4d896",
+          "afterHeadSha": "ba08cfb3d3834c61dcaffadc9354d9ad48de3e8b",
+          "actorLogin": "gregkonush",
+          "createdAt": "2026-07-31T12:33:21Z"
+        },
+        {
+          "beforeHeadSha": "ba08cfb3d3834c61dcaffadc9354d9ad48de3e8b",
+          "afterHeadSha": "186ba05662b61e6610c8939fddd54247ca364542",
+          "actorLogin": "gregkonush",
+          "createdAt": "2026-07-31T13:10:45Z"
+        },
+        {
+          "beforeHeadSha": "186ba05662b61e6610c8939fddd54247ca364542",
+          "afterHeadSha": "7570e37e328f69d36030b8f01f2b0f7b94c5a1d7",
+          "actorLogin": "gregkonush",
+          "createdAt": "2026-07-31T13:15:59Z"
+        },
+        {
+          "beforeHeadSha": "7570e37e328f69d36030b8f01f2b0f7b94c5a1d7",
+          "afterHeadSha": "bc32db2e9eeb7140f422fc1b6621427a8f7dabfc",
+          "actorLogin": "gregkonush",
+          "createdAt": "2026-07-31T14:10:00Z"
+        }
+      ],
+      "feedback": [
+        {
+          "reviewedHeadSha": "34c16da9de7a72bb7d8d37056048269103a4d896",
+          "fixedHeadSha": "ba08cfb3d3834c61dcaffadc9354d9ad48de3e8b",
+          "threadId": "PRRT_kwDOLkRLus6VadAL",
+          "path": "services/bayn/src/candidate-development-evidence.ts",
+          "findingUrl": "https://github.com/proompteng/lab/pull/13429#discussion_r3690384067",
+          "findingBodySha256": "72e679731552920a3de8bc839db2aef5ff9649b26d437be7f639c6ca781eefb7",
+          "fixReplyUrl": "https://github.com/proompteng/lab/pull/13429#discussion_r3690443087",
+          "fixReplyBodySha256": "d4b98364af37bbec3127d7c654e6c95bb19979cdb84ab1554a937d5801543493"
+        },
+        {
+          "reviewedHeadSha": "34c16da9de7a72bb7d8d37056048269103a4d896",
+          "fixedHeadSha": "ba08cfb3d3834c61dcaffadc9354d9ad48de3e8b",
+          "threadId": "PRRT_kwDOLkRLus6VadAR",
+          "path": "services/bayn/src/candidate-development-evidence.ts",
+          "findingUrl": "https://github.com/proompteng/lab/pull/13429#discussion_r3690384073",
+          "findingBodySha256": "270a58090789b1b8c1ab1ec3924bf0c2ad8f3063e049913fafce1a61724c672a",
+          "fixReplyUrl": "https://github.com/proompteng/lab/pull/13429#discussion_r3690443161",
+          "fixReplyBodySha256": "b83aa2a835a23422b21ad7c1135ad76f78ce795b50d4f0808f8a8fcd59217a46"
+        },
+        {
+          "reviewedHeadSha": "ba08cfb3d3834c61dcaffadc9354d9ad48de3e8b",
+          "fixedHeadSha": "186ba05662b61e6610c8939fddd54247ca364542",
+          "threadId": "PRRT_kwDOLkRLus6VaqIe",
+          "path": "services/bayn/src/candidate-development-evidence.ts",
+          "findingUrl": "https://github.com/proompteng/lab/pull/13429#discussion_r3690460608",
+          "findingBodySha256": "0454889f9b6c01f50e6bf7fc57643d9e63b7b0636675e01c0459b8c2af99aaea",
+          "fixReplyUrl": "https://github.com/proompteng/lab/pull/13429#discussion_r3690648400",
+          "fixReplyBodySha256": "8560763843427a47fecac3f62413acf8eeaacc997bfb197b072a0be970db30f2"
+        },
+        {
+          "reviewedHeadSha": "ba08cfb3d3834c61dcaffadc9354d9ad48de3e8b",
+          "fixedHeadSha": "186ba05662b61e6610c8939fddd54247ca364542",
+          "threadId": "PRRT_kwDOLkRLus6VaqIi",
+          "path": "services/bayn/src/candidate-development-evidence.ts",
+          "findingUrl": "https://github.com/proompteng/lab/pull/13429#discussion_r3690460613",
+          "findingBodySha256": "d94cf02995c1dc17a6bd195e6ec4501b61d1e045973b7243c4a8138cf1b54af4",
+          "fixReplyUrl": "https://github.com/proompteng/lab/pull/13429#discussion_r3690648537",
+          "fixReplyBodySha256": "81ee622e913c54df5f9c72aaaeaa8611afca68c97a498b49b5858bb1ae152bfe"
+        },
+        {
+          "reviewedHeadSha": "ba08cfb3d3834c61dcaffadc9354d9ad48de3e8b",
+          "fixedHeadSha": "186ba05662b61e6610c8939fddd54247ca364542",
+          "threadId": "PRRT_kwDOLkRLus6VaqIk",
+          "path": "services/bayn/src/candidate-development-evidence.ts",
+          "findingUrl": "https://github.com/proompteng/lab/pull/13429#discussion_r3690460617",
+          "findingBodySha256": "0b423873b60dc2c099625bb190ce9fc568575645f96066535f32eb4f6fa28e40",
+          "fixReplyUrl": "https://github.com/proompteng/lab/pull/13429#discussion_r3690648680",
+          "fixReplyBodySha256": "840ecbfe355a2b0a255a8caccb1f6435fbf0ae307f3f1344b9ece33fc3632227"
+        },
+        {
+          "reviewedHeadSha": "ba08cfb3d3834c61dcaffadc9354d9ad48de3e8b",
+          "fixedHeadSha": "186ba05662b61e6610c8939fddd54247ca364542",
+          "threadId": "PRRT_kwDOLkRLus6VaqIm",
+          "path": "services/bayn/src/candidate-development-evidence.ts",
+          "findingUrl": "https://github.com/proompteng/lab/pull/13429#discussion_r3690460620",
+          "findingBodySha256": "9e989f24b6a721e0cd652daf8b15fde7cbc4c98b285ecd137440c354ed8b9323",
+          "fixReplyUrl": "https://github.com/proompteng/lab/pull/13429#discussion_r3690648802",
+          "fixReplyBodySha256": "5dae787633c5953eb9f4ee98d2ba37f090b0007d67226691a29bd8d278d66750"
+        },
+        {
+          "reviewedHeadSha": "ba08cfb3d3834c61dcaffadc9354d9ad48de3e8b",
+          "fixedHeadSha": "186ba05662b61e6610c8939fddd54247ca364542",
+          "threadId": "PRRT_kwDOLkRLus6VaqIo",
+          "path": "services/bayn/src/candidate-development-evidence.ts",
+          "findingUrl": "https://github.com/proompteng/lab/pull/13429#discussion_r3690460623",
+          "findingBodySha256": "c4a8337ac586e501a7997ce18bf2001ed5622f31b054830d1b128dd085d091cd",
+          "fixReplyUrl": "https://github.com/proompteng/lab/pull/13429#discussion_r3690648950",
+          "fixReplyBodySha256": "f3c24d09ea2799336be9379bd912d9a2489c776a5dc997af5a4c9d5ba939ac3a"
+        },
+        {
+          "reviewedHeadSha": "186ba05662b61e6610c8939fddd54247ca364542",
+          "fixedHeadSha": "bc32db2e9eeb7140f422fc1b6621427a8f7dabfc",
+          "threadId": "PRRT_kwDOLkRLus6VbNnJ",
+          "path": "services/bayn/src/candidate-development-evidence.ts",
+          "findingUrl": "https://github.com/proompteng/lab/pull/13429#discussion_r3690666874",
+          "findingBodySha256": "535a6b8a4eb19d34dcbcaa0e8adfb01027838ebf43ee9c615bb9e54f23f70fb3",
+          "fixReplyUrl": "https://github.com/proompteng/lab/pull/13429#discussion_r3691014441",
+          "fixReplyBodySha256": "f708fa67b8fca4314726b39fc73bc59f30a43b543793141618647e2c0d3c3cbc"
+        },
+        {
+          "reviewedHeadSha": "186ba05662b61e6610c8939fddd54247ca364542",
+          "fixedHeadSha": "bc32db2e9eeb7140f422fc1b6621427a8f7dabfc",
+          "threadId": "PRRT_kwDOLkRLus6VbNnO",
+          "path": "services/bayn/src/candidate-development-candidate-17-evidence.ts",
+          "findingUrl": "https://github.com/proompteng/lab/pull/13429#discussion_r3690666881",
+          "findingBodySha256": "2e0981a3e7402d209bf1e982cf85396c892d16133ecf9da69cb70284853622fe",
+          "fixReplyUrl": "https://github.com/proompteng/lab/pull/13429#discussion_r3691014612",
+          "fixReplyBodySha256": "93f2a43d9fd5d3dc7cebf14e1831c6ccf2fe36732033215034322a27826a3125"
+        }
+      ]
+    }
+  },
+  "requiredDescendants": [
+    {
+      "mergeCommitSha": "c778df23b22620fd12764e3bca06d0a58211b0de",
+      "sourcePullRequestNumber": 13434,
+      "finalHeadSha": "944bc86112380f0484b892389b7864e26018bca9",
+      "sourcePullRequestEvidenceSha256": "e30e12746743f5361253edff754a088f47c6b644b3a0a8e9003aaf09bc56c67a",
+      "mergeTreeSha": "385588f9943148e28ce968322b96056d99ddcd1b",
+      "finalHeadTreeSha": "385588f9943148e28ce968322b96056d99ddcd1b",
+      "affectedPaths": [
+        {
+          "path": "services/bayn/candidates/ordinal-18-global-equity-dual-momentum-development-evidence.json",
+          "mergeBlobSha": "1b7b07ca6e611d2b602686f537fe8e0f762f43d3",
+          "finalHeadBlobSha": "1b7b07ca6e611d2b602686f537fe8e0f762f43d3"
+        },
+        {
+          "path": "services/bayn/candidates/ordinal-18-global-equity-dual-momentum-preregistration.json",
+          "mergeBlobSha": "920a4afb8a7e5c1f6ef0875683ddc96a91008079",
+          "finalHeadBlobSha": "920a4afb8a7e5c1f6ef0875683ddc96a91008079"
+        },
+        {
+          "path": "services/bayn/candidates/ordinal-18-global-equity-dual-momentum-preregistration.md",
+          "mergeBlobSha": "a8448f473aa3eb525fe0a1081443ce18f7724559",
+          "finalHeadBlobSha": "a8448f473aa3eb525fe0a1081443ce18f7724559"
+        },
+        {
+          "path": "services/bayn/candidates/ordinal-18-global-equity-dual-momentum-source-manifest.json",
+          "mergeBlobSha": "3007c3e088f1a83228d5be672c232645fa2effa4",
+          "finalHeadBlobSha": "3007c3e088f1a83228d5be672c232645fa2effa4"
+        },
+        {
+          "path": "services/bayn/src/candidate-development-calendar.ts",
+          "mergeBlobSha": "b16681a88e70ec9c0c848f9ad207cf16007b32f7",
+          "finalHeadBlobSha": "b16681a88e70ec9c0c848f9ad207cf16007b32f7"
+        },
+        {
+          "path": "services/bayn/src/candidate-development-candidate-17.test.ts",
+          "mergeBlobSha": "eb244401569cdac1fd5bc840e9952be574fc1d64",
+          "finalHeadBlobSha": "eb244401569cdac1fd5bc840e9952be574fc1d64"
+        },
+        {
+          "path": "services/bayn/src/candidate-development-candidate-18-evidence.ts",
+          "mergeBlobSha": "ec90aca52b2d05df3bdcc3ea518fc3b2e4992904",
+          "finalHeadBlobSha": "ec90aca52b2d05df3bdcc3ea518fc3b2e4992904"
+        },
+        {
+          "path": "services/bayn/src/candidate-development-candidate-18.test.ts",
+          "mergeBlobSha": "34d46d0861a6f695f3c8aa07452498168a8bbd73",
+          "finalHeadBlobSha": "34d46d0861a6f695f3c8aa07452498168a8bbd73"
+        },
+        {
+          "path": "services/bayn/src/candidate-development-command.test.ts",
+          "mergeBlobSha": "4bd587bf077acb1b286719b620af66468d169a77",
+          "finalHeadBlobSha": "4bd587bf077acb1b286719b620af66468d169a77"
+        },
+        {
+          "path": "services/bayn/src/candidate-development-command.ts",
+          "mergeBlobSha": "9b9a48381731e2725b9838c6f1fae9caa959a696",
+          "finalHeadBlobSha": "9b9a48381731e2725b9838c6f1fae9caa959a696"
+        },
+        {
+          "path": "services/bayn/src/candidate-development-decision.ts",
+          "mergeBlobSha": "c49977aec8aa3a574968a4d0699d9801a385d519",
+          "finalHeadBlobSha": "c49977aec8aa3a574968a4d0699d9801a385d519"
+        },
+        {
+          "path": "services/bayn/src/candidate-development-evidence.test.ts",
+          "mergeBlobSha": "1fb65106d8f69e01cef8fb9a868480152f01602b",
+          "finalHeadBlobSha": "1fb65106d8f69e01cef8fb9a868480152f01602b"
+        },
+        {
+          "path": "services/bayn/src/candidate-development-trial-history.ts",
+          "mergeBlobSha": "f953d770c92951ed03dcc03b84a80cdf5e1306a4",
+          "finalHeadBlobSha": "f953d770c92951ed03dcc03b84a80cdf5e1306a4"
+        },
+        {
+          "path": "services/bayn/src/strategy/dual-momentum-global-equity/candidate-18.ts",
+          "mergeBlobSha": "44357f3d98315e7d241e4f0184f7812f5a27e930",
+          "finalHeadBlobSha": "44357f3d98315e7d241e4f0184f7812f5a27e930"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- extend the immutable release-review remediation contract to v2 for complete multi-stage force-push reconstruction chains while preserving v1 behavior
- add one declarative receipt for blocked merge `9bea355c17fb9320fc692bb214f76af105650a02` / PR #13429
- bind all five reconstructed heads, four force-push transitions, nine automatic-review finding/fix threads, exact trees/path/blob identities, and reviewed Candidate 18 PR #13434 as the sole required descendant
- reject changed, stale, missing, spoofed, incomplete, descendant, or unrelated evidence without weakening ordinary exact-head review gates

## Reproduction
Natural `bayn-build-push` run `30646339836` failed closed before image publication with:

`BAYN_RELEASE_REVIEW_HOLD release-review-remediation-missing`

The blocked commit is `9bea355c17fb9320fc692bb214f76af105650a02` from PR #13429. Its final head `bc32db2e9eeb7140f422fc1b6621427a8f7dabfc` dropped reviewed ancestors across four force reconstructions.

## Scope
Exactly three paths:
- `packages/scripts/src/bayn/verify-release-review.ts`
- `packages/scripts/src/bayn/verify-release-review.test.ts`
- `services/bayn/release-review-remediations/9bea355c17fb9320fc692bb214f76af105650a02.json`

## Validation
- focused release-review tests: 80 passed
- all Bayn scripts tests: 230 passed
- full Bayn tests: 1,119 passed, 138 PostgreSQL-gated skips, 0 failed
- Bayn formatting, oxlint, type-aware oxlint, Effect diagnostics, TypeScript, and build passed
- PostgreSQL integration target exited 0; local cases skipped without configured database
- complete scripts suite reached only the existing Docker-unavailable shared test; all preceding tests passed
- owned targeted scripts TypeScript passed; repository-wide scripts TypeScript still has unrelated pre-existing failures outside this lane

No manual release rerun/dispatch, runtime/manifest/policy/permission change, broker action, qualification run, or holdout access.