### PR TITLE
fix(bayn): bind continuous reviewed source merges

### DIFF
--- a/packages/scripts/src/bayn/verify-release-review.test.ts
+++ b/packages/scripts/src/bayn/verify-release-review.test.ts
@@ -492,7 +492,10 @@ const remediationHistoryFixture = (): {
       },
     ],
   })
-  const record = structuredClone(realRemediationRecord) as BaynReleaseReviewRemediationRecord
+  const record = structuredClone(realRemediationRecord)
+  if (record.schemaVersion === 'bayn.release-review-remediation.v4') {
+    throw new Error('expected a legacy remediation record')
+  }
   const mutableRecord = record as unknown as {
     blocked: {
       sourcePullRequestEvidenceSha256: string
@@ -1690,7 +1693,366 @@ const multiStageRemediationFixture = (): {
   }
 }
 
+const continuousRemediationRecordPath =
+  'services/bayn/release-review-remediations/6737d29cda608c79714046d420ab7396d8e80f70.json'
+const realContinuousRemediationRecord = parseBaynReleaseReviewRemediationRecord(
+  JSON.parse(readFileSync(continuousRemediationRecordPath, 'utf8')) as unknown,
+)
+const continuousHistory = {
+  published: '69d803040c8866e7703df50a645a096c54e7eca5',
+  blocked: '6737d29cda608c79714046d420ab7396d8e80f70',
+  finalHead: 'adc96644904d1f1c2640cc6a597d1cfc108caf91',
+  priorHead: 'ab989db8b42f9814f7aa22f7460becdee847a492',
+  introductionHead: '6'.repeat(40),
+  introductionMerge: '7'.repeat(40),
+} as const
+const continuousNowMs = Date.parse('2026-07-31T20:42:00Z')
+
+const continuousRemediationFixture = (): {
+  readonly snapshot: BaynReleaseEligibilitySnapshot
+  readonly evidence: BaynReleaseReviewRemediationEvidence
+} => {
+  const record = structuredClone(realContinuousRemediationRecord)
+  if (record.schemaVersion !== 'bayn.release-review-remediation.v4') {
+    throw new Error('expected a v4 continuous-source remediation record')
+  }
+  const blockedPull: PullRequestReviewState = {
+    number: 13426,
+    baseRefName: 'main',
+    headSha: continuousHistory.finalHead,
+    mergeCommitSha: continuousHistory.blocked,
+    createdAt: '2026-07-31T09:38:15Z',
+    mergedAt: '2026-07-31T20:36:05Z',
+    reviews: [
+      review({
+        commitSha: continuousHistory.priorHead,
+        submittedAt: '2026-07-31T20:14:12Z',
+      }),
+    ],
+    threads: [],
+    commitShas: [continuousHistory.finalHead],
+    issueComments: [],
+    reactions: [reaction({ createdAt: '2026-07-31T20:35:28Z' })],
+    headForcePushes: [
+      {
+        actorLogin: 'gregkonush',
+        beforeCommitSha: continuousHistory.priorHead,
+        afterCommitSha: continuousHistory.finalHead,
+        createdAt: '2026-07-31T20:29:25Z',
+      },
+    ],
+    headForcePushCount: 1,
+  }
+  ;(
+    record as unknown as { blocked: { sourcePullRequestEvidenceSha256: string } }
+  ).blocked.sourcePullRequestEvidenceSha256 = pullRequestReviewEvidenceSha256(blockedPull)
+
+  const changes = record.blocked.affectedPaths.map((path) => ({ ...path }))
+  const pathBlobs = changes.map((path) => ({ path: path.path, blobSha: path.blobSha }))
+  const blockedCommit = {
+    sha: continuousHistory.blocked,
+    parents: [continuousHistory.published],
+    treeSha: record.blocked.mergeTreeSha,
+    files: changes.map((path) => path.path),
+    fileChanges: changes,
+    reviewSnapshot: {
+      mainCommitParents: [continuousHistory.published],
+      associatedPullRequests: [
+        associatedPull({
+          number: 13426,
+          headSha: continuousHistory.finalHead,
+          mergeCommitSha: continuousHistory.blocked,
+          mergedAt: blockedPull.mergedAt,
+        }),
+      ],
+      pullRequest: blockedPull,
+    },
+  }
+  const introductionSnapshot = reviewSnapshotFor({
+    commitSha: continuousHistory.introductionMerge,
+    prNumber: 13443,
+    headSha: continuousHistory.introductionHead,
+    parents: [continuousHistory.blocked],
+    mergedAt: '2026-07-31T20:41:00Z',
+    reviews: [
+      review({
+        commitSha: continuousHistory.introductionHead,
+        submittedAt: '2026-07-31T20:40:00Z',
+      }),
+    ],
+  })
+  const recordBlobSha = '8'.repeat(40)
+  const introductionCommit = {
+    sha: continuousHistory.introductionMerge,
+    parents: [continuousHistory.blocked],
+    treeSha: '9'.repeat(40),
+    files: [
+      'packages/scripts/src/bayn/verify-release-review.ts',
+      'packages/scripts/src/bayn/verify-release-review.test.ts',
+      continuousRemediationRecordPath,
+    ],
+    fileChanges: [
+      {
+        path: 'packages/scripts/src/bayn/verify-release-review.ts',
+        previousPath: null,
+        status: 'modified',
+        blobSha: '1'.repeat(40),
+      },
+      {
+        path: 'packages/scripts/src/bayn/verify-release-review.test.ts',
+        previousPath: null,
+        status: 'modified',
+        blobSha: '2'.repeat(40),
+      },
+      {
+        path: continuousRemediationRecordPath,
+        previousPath: null,
+        status: 'added',
+        blobSha: recordBlobSha,
+      },
+    ],
+    reviewSnapshot: introductionSnapshot,
+  }
+  const evidence: BaynReleaseReviewRemediationEvidence = {
+    recordPath: continuousRemediationRecordPath,
+    recordBlobSha,
+    record,
+    referencedCommits: [
+      {
+        sha: continuousHistory.finalHead,
+        parents: [continuousHistory.published],
+        treeSha: record.blocked.finalHeadTreeSha,
+        files: changes.map((path) => path.path),
+        fileChanges: changes,
+        pathBlobs,
+      },
+    ],
+    currentPathBlobs: pathBlobs,
+  }
+  return {
+    evidence,
+    snapshot: {
+      currentCommitParents: [continuousHistory.blocked],
+      lastPublishedRevision: {
+        status: 'resolved',
+        revision: continuousHistory.published,
+        runId: 30663490856,
+        runNumber: 930,
+        runAttempt: 1,
+      },
+      comparison: {
+        status: 'ahead',
+        baseSha: continuousHistory.published,
+        headSha: continuousHistory.introductionMerge,
+        mergeBaseSha: continuousHistory.published,
+        aheadBy: 2,
+        totalCommits: 2,
+        commits: [blockedCommit, introductionCommit],
+        truncated: false,
+      },
+      remediations: [evidence],
+    },
+  }
+}
+
 describe('Bayn publication-range eligibility', () => {
+  test('parses the exact immutable #13426 continuous-source v4 receipt', () => {
+    expect(realContinuousRemediationRecord).toMatchObject({
+      schemaVersion: 'bayn.release-review-remediation.v4',
+      remediationId: 'pr-13426-continuous-reviewed-source',
+      blocked: {
+        mergeCommitSha: continuousHistory.blocked,
+        mergeParentSha: continuousHistory.published,
+        mergeTreeSha: 'b8f61426c9e182125208356d1bb50c14e83b1e65',
+        sourcePullRequestNumber: 13426,
+        finalHeadSha: continuousHistory.finalHead,
+        finalHeadParentSha: continuousHistory.published,
+        finalHeadTreeSha: 'b8f61426c9e182125208356d1bb50c14e83b1e65',
+        sourcePullRequestEvidenceSha256: '2d7c74531595b8b889b39e5ebe7281cb5f397cbe2cf832300a80a62e293fbd0f',
+        affectedPaths: { length: 18 },
+      },
+      requiredDescendants: [],
+    })
+  })
+
+  test('accepts #13426 only through its exact continuous reviewed source binding', () => {
+    const fixture = continuousRemediationFixture()
+    expect(
+      evaluateBaynReleaseEligibility({
+        mainCommitSha: continuousHistory.introductionMerge,
+        baseRefName: 'main',
+        snapshot: fixture.snapshot,
+        nowMs: continuousNowMs,
+        pushBeforeSha: continuousHistory.blocked,
+      }),
+    ).toEqual({
+      status: 'eligible',
+      lastPublishedRevision: continuousHistory.published,
+      checkedCommitCount: 2,
+      baynAffectingCommitCount: 2,
+      reviewedPullRequests: [
+        {
+          commitSha: continuousHistory.blocked,
+          prNumber: 13426,
+          headSha: continuousHistory.finalHead,
+          reviewSubmittedAt: '2026-07-31T20:35:28Z',
+          eligibleAt: '2026-07-31T20:35:58.000Z',
+        },
+        {
+          commitSha: continuousHistory.introductionMerge,
+          prNumber: 13443,
+          headSha: continuousHistory.introductionHead,
+          reviewSubmittedAt: '2026-07-31T20:40:00Z',
+          eligibleAt: '2026-07-31T20:40:30.000Z',
+        },
+      ],
+    })
+  })
+
+  test('keeps #13426 blocked without the exact v4 receipt', () => {
+    const fixture = continuousRemediationFixture()
+    expect(
+      evaluateBaynReleaseEligibility({
+        mainCommitSha: continuousHistory.introductionMerge,
+        baseRefName: 'main',
+        snapshot: { ...fixture.snapshot, remediations: [] },
+        nowMs: continuousNowMs,
+        pushBeforeSha: continuousHistory.blocked,
+      }),
+    ).toMatchObject({ status: 'hold', code: 'release-review-remediation-missing', retryable: false })
+  })
+
+  ;(
+    [
+      [
+        'edited immutable PR evidence',
+        (fixture: ReturnType<typeof continuousRemediationFixture>) => {
+          const pullRequest = fixture.snapshot.comparison?.commits[0]?.reviewSnapshot?.pullRequest
+          if (pullRequest === null || pullRequest === undefined) throw new Error('missing blocked pull request')
+          ;(pullRequest as unknown as { issueComments: PullRequestIssueComment[] }).issueComments = [
+            issueComment({ createdAt: '2026-07-31T20:34:00Z', updatedAt: '2026-07-31T20:34:01Z' }),
+          ]
+        },
+      ],
+      [
+        'pre-head reaction',
+        (fixture: ReturnType<typeof continuousRemediationFixture>) => {
+          const pullRequest = fixture.snapshot.comparison?.commits[0]?.reviewSnapshot?.pullRequest
+          if (pullRequest === null || pullRequest === undefined) throw new Error('missing blocked pull request')
+          ;(pullRequest.reactions[0] as unknown as { createdAt: string }).createdAt = '2026-07-31T20:29:25Z'
+          ;(
+            fixture.evidence.record as unknown as { blocked: { sourcePullRequestEvidenceSha256: string } }
+          ).blocked.sourcePullRequestEvidenceSha256 = pullRequestReviewEvidenceSha256(pullRequest)
+        },
+      ],
+      [
+        'spoofed reaction actor',
+        (fixture: ReturnType<typeof continuousRemediationFixture>) => {
+          const pullRequest = fixture.snapshot.comparison?.commits[0]?.reviewSnapshot?.pullRequest
+          if (pullRequest === null || pullRequest === undefined) throw new Error('missing blocked pull request')
+          ;(pullRequest.reactions[0] as unknown as { userLogin: string }).userLogin = 'codex-lookalike[bot]'
+          ;(
+            fixture.evidence.record as unknown as { blocked: { sourcePullRequestEvidenceSha256: string } }
+          ).blocked.sourcePullRequestEvidenceSha256 = pullRequestReviewEvidenceSha256(pullRequest)
+        },
+      ],
+      [
+        'ambiguous trusted reactions',
+        (fixture: ReturnType<typeof continuousRemediationFixture>) => {
+          const pullRequest = fixture.snapshot.comparison?.commits[0]?.reviewSnapshot?.pullRequest
+          if (pullRequest === null || pullRequest === undefined) throw new Error('missing blocked pull request')
+          ;(pullRequest as unknown as { reactions: PullRequestReaction[] }).reactions = [
+            ...pullRequest.reactions,
+            reaction({ createdAt: '2026-07-31T20:35:29Z' }),
+          ]
+          ;(
+            fixture.evidence.record as unknown as { blocked: { sourcePullRequestEvidenceSha256: string } }
+          ).blocked.sourcePullRequestEvidenceSha256 = pullRequestReviewEvidenceSha256(pullRequest)
+        },
+      ],
+      [
+        'unrelated source PR identity',
+        (fixture: ReturnType<typeof continuousRemediationFixture>) => {
+          ;(
+            fixture.evidence.record as unknown as { blocked: { sourcePullRequestNumber: number } }
+          ).blocked.sourcePullRequestNumber = 13425
+        },
+      ],
+      [
+        'mismatched final source head',
+        (fixture: ReturnType<typeof continuousRemediationFixture>) => {
+          ;(fixture.evidence.record as unknown as { blocked: { finalHeadSha: string } }).blocked.finalHeadSha =
+            'f'.repeat(40)
+        },
+      ],
+      [
+        'discontinuous final source parent',
+        (fixture: ReturnType<typeof continuousRemediationFixture>) => {
+          const finalHead = fixture.evidence.referencedCommits[0]
+          if (finalHead === undefined) throw new Error('missing final source head')
+          ;(finalHead as unknown as { parents: string[] }).parents = ['0'.repeat(40)]
+        },
+      ],
+      [
+        'mismatched final source tree',
+        (fixture: ReturnType<typeof continuousRemediationFixture>) => {
+          const finalHead = fixture.evidence.referencedCommits[0]
+          if (finalHead === undefined) throw new Error('missing final source head')
+          ;(finalHead as unknown as { treeSha: string }).treeSha = '0'.repeat(40)
+        },
+      ],
+      [
+        'source-dropping path evidence',
+        (fixture: ReturnType<typeof continuousRemediationFixture>) => {
+          const finalHead = fixture.evidence.referencedCommits[0]
+          if (finalHead === undefined) throw new Error('missing final source head')
+          ;(finalHead as unknown as { files: string[] }).files = finalHead.files.slice(1)
+          ;(finalHead as unknown as { fileChanges: unknown[] }).fileChanges = finalHead.fileChanges.slice(1)
+          ;(finalHead as unknown as { pathBlobs: unknown[] }).pathBlobs = finalHead.pathBlobs.slice(1)
+        },
+      ],
+      [
+        'mismatched source blob',
+        (fixture: ReturnType<typeof continuousRemediationFixture>) => {
+          const finalHead = fixture.evidence.referencedCommits[0]
+          const pathBlob = finalHead?.pathBlobs[0]
+          if (pathBlob === undefined) throw new Error('missing final source blob')
+          ;(pathBlob as unknown as { blobSha: string }).blobSha = '0'.repeat(40)
+        },
+      ],
+      [
+        'discontinuous release ancestry',
+        (fixture: ReturnType<typeof continuousRemediationFixture>) => {
+          const introduction = fixture.snapshot.comparison?.commits[1]
+          if (introduction === undefined) throw new Error('missing introduction commit')
+          ;(introduction as unknown as { parents: string[] }).parents = ['0'.repeat(40)]
+        },
+      ],
+      [
+        'stale current source blob',
+        (fixture: ReturnType<typeof continuousRemediationFixture>) => {
+          const pathBlob = fixture.evidence.currentPathBlobs[0]
+          if (pathBlob === undefined) throw new Error('missing current source blob')
+          ;(pathBlob as unknown as { blobSha: string }).blobSha = '0'.repeat(40)
+        },
+      ],
+    ] as const
+  ).forEach(([name, mutate]) => {
+    test(`rejects v4 continuous-source remediation with ${name}`, () => {
+      const fixture = continuousRemediationFixture()
+      mutate(fixture)
+      expect(
+        evaluateBaynReleaseEligibility({
+          mainCommitSha: continuousHistory.introductionMerge,
+          baseRefName: 'main',
+          snapshot: fixture.snapshot,
+          nowMs: continuousNowMs,
+          pushBeforeSha: continuousHistory.blocked,
+        }),
+      ).toMatchObject({ status: 'hold', code: 'release-review-remediation-invalid', retryable: false })
+    })
+  })
+
   test('accepts the exact #13429 through #13435 chain only through its reviewed v3 receipt completion', () => {
     expect(realMultiStageRemediationRecord).toMatchObject({
       schemaVersion: 'bayn.release-review-remediation.v3',

--- a/packages/scripts/src/bayn/verify-release-review.ts
+++ b/packages/scripts/src/bayn/verify-release-review.ts
@@ -176,12 +176,14 @@ export interface BaynReleaseReviewRemediationReconstructionHead {
   readonly headSha: string
   readonly parentSha: string
   readonly treeSha: string
-  readonly affectedPaths: readonly {
-    readonly path: string
-    readonly previousPath: string | null
-    readonly status: string
-    readonly blobSha: string
-  }[]
+  readonly affectedPaths: readonly BaynReleaseReviewRemediationCommitPath[]
+}
+
+export interface BaynReleaseReviewRemediationCommitPath {
+  readonly path: string
+  readonly previousPath: string | null
+  readonly status: string
+  readonly blobSha: string
 }
 
 export interface BaynReleaseReviewRemediationForcePush {
@@ -230,7 +232,7 @@ export interface BaynReleaseReviewRemediationIntroduction {
   readonly introducedRecordBlobSha: string
 }
 
-export interface BaynReleaseReviewRemediationRecord {
+interface BaynReleaseReviewRemediationLegacyRecord {
   readonly schemaVersion:
     | 'bayn.release-review-remediation.v1'
     | 'bayn.release-review-remediation.v2'
@@ -261,6 +263,29 @@ export interface BaynReleaseReviewRemediationRecord {
   readonly requiredSuccessors?: readonly BaynReleaseReviewRemediationDescendant[]
   readonly introduction?: BaynReleaseReviewRemediationIntroduction
 }
+
+interface BaynReleaseReviewRemediationContinuousSourceRecord {
+  readonly schemaVersion: 'bayn.release-review-remediation.v4'
+  readonly remediationId: string
+  readonly blocked: {
+    readonly mergeCommitSha: string
+    readonly mergeParentSha: string
+    readonly mergeTreeSha: string
+    readonly sourcePullRequestNumber: number
+    readonly finalHeadSha: string
+    readonly finalHeadParentSha: string
+    readonly finalHeadTreeSha: string
+    readonly sourcePullRequestEvidenceSha256: string
+    readonly affectedPaths: readonly BaynReleaseReviewRemediationCommitPath[]
+  }
+  readonly requiredDescendants: readonly []
+  readonly requiredSuccessors?: undefined
+  readonly introduction?: undefined
+}
+
+export type BaynReleaseReviewRemediationRecord =
+  | BaynReleaseReviewRemediationLegacyRecord
+  | BaynReleaseReviewRemediationContinuousSourceRecord
 
 interface RemediationCommitObject {
   readonly sha: string
@@ -552,6 +577,16 @@ const parseRemediationPath = (value: unknown, context: string): BaynReleaseRevie
   }
 }
 
+const parseRemediationCommitPath = (value: unknown, context: string): BaynReleaseReviewRemediationCommitPath => {
+  const path = strictRecord(value, ['path', 'previousPath', 'status', 'blobSha'], context)
+  return {
+    path: expectString(path.path, `${context} path`),
+    previousPath: expectNullableString(path.previousPath, `${context} previous path`),
+    status: expectString(path.status, `${context} status`),
+    blobSha: expectSha(path.blobSha, `${context} blob SHA`),
+  }
+}
+
 const parseRemediationDescendant = (value: unknown, context: string): BaynReleaseReviewRemediationDescendant => {
   const record = strictRecord(
     value,
@@ -602,19 +637,9 @@ const parseRemediationReconstructionHead = (
     headSha: expectSha(record.headSha, `${context} head SHA`),
     parentSha: expectSha(record.parentSha, `${context} parent SHA`),
     treeSha: expectSha(record.treeSha, `${context} tree SHA`),
-    affectedPaths: record.affectedPaths.map((item, index) => {
-      const path = strictRecord(
-        item,
-        ['path', 'previousPath', 'status', 'blobSha'],
-        `${context} affected path ${index}`,
-      )
-      return {
-        path: expectString(path.path, `${context} affected path ${index} path`),
-        previousPath: expectNullableString(path.previousPath, `${context} affected path ${index} previous path`),
-        status: expectString(path.status, `${context} affected path ${index} status`),
-        blobSha: expectSha(path.blobSha, `${context} affected path ${index} blob SHA`),
-      }
-    }),
+    affectedPaths: record.affectedPaths.map((item, index) =>
+      parseRemediationCommitPath(item, `${context} affected path ${index}`),
+    ),
   }
 }
 
@@ -690,11 +715,64 @@ export const parseBaynReleaseReviewRemediationRecord = (value: unknown): BaynRel
   if (
     rawSchemaVersion !== 'bayn.release-review-remediation.v1' &&
     rawSchemaVersion !== 'bayn.release-review-remediation.v2' &&
-    rawSchemaVersion !== 'bayn.release-review-remediation.v3'
+    rawSchemaVersion !== 'bayn.release-review-remediation.v3' &&
+    rawSchemaVersion !== 'bayn.release-review-remediation.v4'
   ) {
     throw new Error('remediation schemaVersion is invalid')
   }
   const schemaVersion = rawSchemaVersion
+  if (schemaVersion === 'bayn.release-review-remediation.v4') {
+    const record = strictRecord(
+      value,
+      ['schemaVersion', 'remediationId', 'blocked', 'requiredDescendants'],
+      'remediation',
+    )
+    const remediationId = expectString(record.remediationId, 'remediation ID')
+    if (!/^[a-z0-9][a-z0-9-]{2,127}$/.test(remediationId)) throw new Error('remediation ID is invalid')
+    const blocked = strictRecord(
+      record.blocked,
+      [
+        'mergeCommitSha',
+        'mergeParentSha',
+        'mergeTreeSha',
+        'sourcePullRequestNumber',
+        'finalHeadSha',
+        'finalHeadParentSha',
+        'finalHeadTreeSha',
+        'sourcePullRequestEvidenceSha256',
+        'affectedPaths',
+      ],
+      'remediation blocked source',
+    )
+    if (!Array.isArray(blocked.affectedPaths)) throw new Error('remediation blocked affectedPaths must be an array')
+    if (!Array.isArray(record.requiredDescendants) || record.requiredDescendants.length !== 0) {
+      throw new Error('v4 remediation requiredDescendants must be an empty array')
+    }
+    return {
+      schemaVersion,
+      remediationId,
+      blocked: {
+        mergeCommitSha: expectSha(blocked.mergeCommitSha, 'remediation blocked merge commit SHA'),
+        mergeParentSha: expectSha(blocked.mergeParentSha, 'remediation blocked merge parent SHA'),
+        mergeTreeSha: expectSha(blocked.mergeTreeSha, 'remediation blocked merge tree SHA'),
+        sourcePullRequestNumber: expectPositiveIntegerRecord(
+          blocked.sourcePullRequestNumber,
+          'remediation blocked source pull request number',
+        ),
+        finalHeadSha: expectSha(blocked.finalHeadSha, 'remediation final head SHA'),
+        finalHeadParentSha: expectSha(blocked.finalHeadParentSha, 'remediation final head parent SHA'),
+        finalHeadTreeSha: expectSha(blocked.finalHeadTreeSha, 'remediation final head tree SHA'),
+        sourcePullRequestEvidenceSha256: expectSha256(
+          blocked.sourcePullRequestEvidenceSha256,
+          'remediation source pull request evidence hash',
+        ),
+        affectedPaths: blocked.affectedPaths.map((item, index) =>
+          parseRemediationCommitPath(item, `remediation blocked affected path ${index}`),
+        ),
+      },
+      requiredDescendants: [],
+    }
+  }
   const record = strictRecord(
     value,
     schemaVersion === 'bayn.release-review-remediation.v3'
@@ -1364,7 +1442,7 @@ const findReferencedCommit = (
 }
 
 const validateRemediationFeedback = (
-  record: BaynReleaseReviewRemediationRecord,
+  record: BaynReleaseReviewRemediationLegacyRecord,
   pullRequest: PullRequestReviewState,
 ): BaynReleaseReviewHold | null => {
   if (
@@ -1711,12 +1789,14 @@ const validateReleaseReviewRemediationV2 = (input: {
 }): BaynReleaseReviewHold | null => {
   const { evidence, blockedCommit, comparison } = input
   const record = evidence.record
-  const reconstruction = record.blocked.reconstruction
   if (
-    (record.schemaVersion !== 'bayn.release-review-remediation.v2' &&
-      record.schemaVersion !== 'bayn.release-review-remediation.v3') ||
-    reconstruction === undefined
+    record.schemaVersion !== 'bayn.release-review-remediation.v2' &&
+    record.schemaVersion !== 'bayn.release-review-remediation.v3'
   ) {
+    return remediationInvalid(`remediation ${record.remediationId} v2 reconstruction is missing`)
+  }
+  const reconstruction = record.blocked.reconstruction
+  if (reconstruction === undefined) {
     return remediationInvalid(`remediation ${record.remediationId} v2 reconstruction is missing`)
   }
   if (
@@ -1960,6 +2040,121 @@ const validateReleaseReviewRemediationV2 = (input: {
   return null
 }
 
+const validateContinuousSourceRemediation = (input: {
+  readonly evidence: BaynReleaseReviewRemediationEvidence
+  readonly blockedCommit: BaynReleaseRangeCommit
+  readonly comparison: BaynReleaseComparison
+  readonly normalReviews: ReadonlyMap<string, BaynReleaseReviewEvaluation>
+  readonly introduction: BaynReleaseRangeCommit
+  readonly blockedIndex: number
+  readonly nowMs: number
+}): BaynReleaseReviewHold | null => {
+  const { evidence, blockedCommit, comparison } = input
+  const record = evidence.record
+  if (record.schemaVersion !== 'bayn.release-review-remediation.v4') {
+    return remediationInvalid(`remediation ${record.remediationId} continuous source record is missing`)
+  }
+
+  const finalHead = findReferencedCommit(evidence, record.blocked.finalHeadSha)
+  const mergeChanges = commitFileMap(blockedCommit.fileChanges)
+  const finalChanges = finalHead === null ? null : commitFileMap(finalHead.fileChanges)
+  const finalBlobs = finalHead === null ? null : pathBlobMap(finalHead.pathBlobs)
+  const expectedPaths = record.blocked.affectedPaths.map((path) => path.path)
+  if (
+    finalHead === null ||
+    mergeChanges === null ||
+    finalChanges === null ||
+    finalBlobs === null ||
+    finalHead.sha !== record.blocked.finalHeadSha ||
+    finalHead.parents.length !== 1 ||
+    finalHead.parents[0] !== record.blocked.finalHeadParentSha ||
+    record.blocked.finalHeadParentSha !== record.blocked.mergeParentSha ||
+    finalHead.treeSha !== record.blocked.finalHeadTreeSha ||
+    record.blocked.finalHeadTreeSha !== record.blocked.mergeTreeSha ||
+    blockedCommit.treeSha !== finalHead.treeSha
+  ) {
+    return remediationInvalid(`remediation ${record.remediationId} continuous source identity is not exact`)
+  }
+  if (
+    !exactStringSet(expectedPaths, blockedCommit.files) ||
+    !exactStringSet(expectedPaths, finalHead.files) ||
+    !exactStringSet(expectedPaths, [...mergeChanges.keys()]) ||
+    !exactStringSet(expectedPaths, [...finalChanges.keys()]) ||
+    !exactStringSet(expectedPaths, [...finalBlobs.keys()])
+  ) {
+    return remediationInvalid(`remediation ${record.remediationId} continuous source path set is incomplete`)
+  }
+  for (const expected of record.blocked.affectedPaths) {
+    const mergeChange = mergeChanges.get(expected.path)
+    const finalChange = finalChanges.get(expected.path)
+    if (
+      mergeChange === undefined ||
+      finalChange === undefined ||
+      mergeChange.previousPath !== expected.previousPath ||
+      finalChange.previousPath !== expected.previousPath ||
+      mergeChange.status !== expected.status ||
+      finalChange.status !== expected.status ||
+      mergeChange.blobSha !== expected.blobSha ||
+      finalChange.blobSha !== expected.blobSha ||
+      finalBlobs.get(expected.path) !== expected.blobSha
+    ) {
+      return remediationInvalid(
+        `remediation ${record.remediationId} continuous source blob changed at ${expected.path}`,
+      )
+    }
+  }
+
+  const blockedReview = input.normalReviews.get(blockedCommit.sha)
+  if (blockedReview === undefined) {
+    return remediationInvalid(`remediation ${record.remediationId} blocked source review snapshot is missing`)
+  }
+  const boundReview = evaluateBoundRemediationReview({
+    remediationId: record.remediationId,
+    commit: blockedCommit,
+    identity: {
+      mergeCommitSha: record.blocked.mergeCommitSha,
+      sourcePullRequestNumber: record.blocked.sourcePullRequestNumber,
+      finalHeadSha: record.blocked.finalHeadSha,
+      sourcePullRequestEvidenceSha256: record.blocked.sourcePullRequestEvidenceSha256,
+    },
+    normalReview: blockedReview,
+    nowMs: input.nowMs,
+  })
+  if (boundReview.status === 'hold') return boundReview
+
+  const protectedPaths = new Set(expectedPaths)
+  let expectedParent = blockedCommit.sha
+  for (const commit of comparison.commits.slice(input.blockedIndex + 1)) {
+    if (commit.parents.length !== 1 || commit.parents[0] !== expectedParent) {
+      return remediationInvalid(`remediation ${record.remediationId} source ancestry is not a direct-parent chain`)
+    }
+    if (commit.files.some((path) => protectedPaths.has(path))) {
+      return remediationInvalid(`remediation ${record.remediationId} continuous source changed after the blocked merge`)
+    }
+    if (commit.files.some(isBaynReleaseAffectingPath)) {
+      const review = input.normalReviews.get(commit.sha)
+      if (review === undefined) {
+        return remediationInvalid(`remediation ${record.remediationId} newer source review is missing`)
+      }
+      if (review.status === 'hold') return review
+    }
+    expectedParent = commit.sha
+  }
+  if (expectedParent !== comparison.headSha) {
+    return remediationInvalid(`remediation ${record.remediationId} is stale or does not reach the current source head`)
+  }
+
+  const currentBlobs = pathBlobMap(evidence.currentPathBlobs)
+  if (
+    currentBlobs === null ||
+    !exactStringSet(expectedPaths, [...currentBlobs.keys()]) ||
+    record.blocked.affectedPaths.some((path) => currentBlobs.get(path.path) !== path.blobSha)
+  ) {
+    return remediationInvalid(`remediation ${record.remediationId} current continuous source blobs diverged`)
+  }
+  return null
+}
+
 const validateReleaseReviewRemediation = (input: {
   readonly evidence: BaynReleaseReviewRemediationEvidence
   readonly blockedCommit: BaynReleaseRangeCommit
@@ -2054,6 +2249,17 @@ const validateReleaseReviewRemediation = (input: {
   const blockedPull = blockedCommit.reviewSnapshot?.pullRequest
   if (blockedPull === null || blockedPull === undefined) {
     return remediationInvalid(`remediation ${record.remediationId} blocked source PR snapshot is missing`)
+  }
+  if (record.schemaVersion === 'bayn.release-review-remediation.v4') {
+    return validateContinuousSourceRemediation({
+      evidence,
+      blockedCommit,
+      comparison,
+      normalReviews: input.normalReviews,
+      introduction,
+      blockedIndex,
+      nowMs: input.nowMs,
+    })
   }
   const feedbackHold = validateRemediationFeedback(record, blockedPull)
   if (feedbackHold !== null) return feedbackHold
@@ -2510,6 +2716,31 @@ export const evaluateBaynReleaseEligibility = (input: {
         normalReviews.set(introductionIdentity.mergeCommitSha, introductionReview)
         coveredDescendantShas.add(introductionIdentity.mergeCommitSha)
       }
+      if (remediation[0].record.schemaVersion === 'bayn.release-review-remediation.v4') {
+        const record = remediation[0].record
+        const continuousReview = evaluateBoundRemediationReview({
+          remediationId: record.remediationId,
+          commit,
+          identity: {
+            mergeCommitSha: record.blocked.mergeCommitSha,
+            sourcePullRequestNumber: record.blocked.sourcePullRequestNumber,
+            finalHeadSha: record.blocked.finalHeadSha,
+            sourcePullRequestEvidenceSha256: record.blocked.sourcePullRequestEvidenceSha256,
+          },
+          normalReview: review,
+          nowMs: input.nowMs,
+        })
+        if (continuousReview.status === 'hold') return continuousReview
+        reviewedPullRequests.push({
+          commitSha: commit.sha,
+          prNumber: continuousReview.prNumber,
+          headSha: continuousReview.headSha,
+          reviewSubmittedAt: continuousReview.reviewSubmittedAt,
+          eligibleAt: continuousReview.eligibleAt,
+        })
+        continue
+      }
+      const legacyRecord = remediation[0].record
       const sourcePull = commit.reviewSnapshot?.pullRequest
       if (sourcePull === null || sourcePull === undefined) {
         return remediationInvalid(`remediated commit ${shortSha(commit.sha)} source PR metadata is missing`)
@@ -2517,7 +2748,7 @@ export const evaluateBaynReleaseEligibility = (input: {
       const reviewedAncestor = sourcePull.reviews.find(
         (candidate) =>
           candidate.authorLogin === baynCodexReviewer &&
-          candidate.commitSha === remediation[0]?.record.blocked.reviewedHeadSha &&
+          candidate.commitSha === legacyRecord.blocked.reviewedHeadSha &&
           candidate.submittedAt !== null,
       )
       if (reviewedAncestor?.submittedAt === null || reviewedAncestor?.submittedAt === undefined) {
@@ -3812,6 +4043,11 @@ const loadReleaseReviewRemediations = async (
           head.affectedPaths.map((path) => path.path),
         )
       }
+    } else if (loaded.record.schemaVersion === 'bayn.release-review-remediation.v4') {
+      references.set(
+        loaded.record.blocked.finalHeadSha,
+        loaded.record.blocked.affectedPaths.map((path) => path.path),
+      )
     } else {
       references.set(
         loaded.record.blocked.reviewedHeadSha,

--- a/services/bayn/release-review-remediations/6737d29cda608c79714046d420ab7396d8e80f70.json
+++ b/services/bayn/release-review-remediations/6737d29cda608c79714046d420ab7396d8e80f70.json
@@ -1,0 +1,125 @@
+{
+  "schemaVersion": "bayn.release-review-remediation.v4",
+  "remediationId": "pr-13426-continuous-reviewed-source",
+  "blocked": {
+    "mergeCommitSha": "6737d29cda608c79714046d420ab7396d8e80f70",
+    "mergeParentSha": "69d803040c8866e7703df50a645a096c54e7eca5",
+    "mergeTreeSha": "b8f61426c9e182125208356d1bb50c14e83b1e65",
+    "sourcePullRequestNumber": 13426,
+    "finalHeadSha": "adc96644904d1f1c2640cc6a597d1cfc108caf91",
+    "finalHeadParentSha": "69d803040c8866e7703df50a645a096c54e7eca5",
+    "finalHeadTreeSha": "b8f61426c9e182125208356d1bb50c14e83b1e65",
+    "sourcePullRequestEvidenceSha256": "2d7c74531595b8b889b39e5ebe7281cb5f397cbe2cf832300a80a62e293fbd0f",
+    "affectedPaths": [
+      {
+        "path": "services/bayn/migrations/0021_expired_paper_cycle_terminalization.ts",
+        "previousPath": null,
+        "status": "added",
+        "blobSha": "717010f5ab97d40c339f1987d1b12be5b840dce6"
+      },
+      {
+        "path": "services/bayn/src/cycle-runner.test.ts",
+        "previousPath": null,
+        "status": "modified",
+        "blobSha": "6376cba88183608c59e5fb15d46dbc99e8694af5"
+      },
+      {
+        "path": "services/bayn/src/cycle-runner/model.ts",
+        "previousPath": null,
+        "status": "modified",
+        "blobSha": "f42d1f2b55ee7a1c5f9f4a8a1b740764d48c9e34"
+      },
+      {
+        "path": "services/bayn/src/cycle-runner/recovery-decision-binding.ts",
+        "previousPath": null,
+        "status": "modified",
+        "blobSha": "0f6d68cfb4b119f4527a0bd775db4f32c40e8693"
+      },
+      {
+        "path": "services/bayn/src/cycle-runner/recovery-model.ts",
+        "previousPath": null,
+        "status": "modified",
+        "blobSha": "edab01249f1d9f7bc3a7a153944fc5d77ba483c0"
+      },
+      {
+        "path": "services/bayn/src/db/cycle-store/binding-program.ts",
+        "previousPath": null,
+        "status": "modified",
+        "blobSha": "abf4ad6837980e4eb03609634a86a6f6622e55a8"
+      },
+      {
+        "path": "services/bayn/src/db/cycle-store/decisions.ts",
+        "previousPath": null,
+        "status": "modified",
+        "blobSha": "feb6b75ab4239b5c3c1ea85ab4b14a7e48705b92"
+      },
+      {
+        "path": "services/bayn/src/db/cycle-store/integration.test.ts",
+        "previousPath": null,
+        "status": "modified",
+        "blobSha": "91e778d4f40b1cb0249ee29fd64b58f55266cc35"
+      },
+      {
+        "path": "services/bayn/src/db/cycle-store/model.ts",
+        "previousPath": null,
+        "status": "modified",
+        "blobSha": "20931b0632bb790740b95f9b6fece9e081f5c5c2"
+      },
+      {
+        "path": "services/bayn/src/db/cycle-store/queries.ts",
+        "previousPath": null,
+        "status": "modified",
+        "blobSha": "df7b7dd5ff33745f94d89938aa0ae5170ad201e8"
+      },
+      {
+        "path": "services/bayn/src/db/cycle-store/rows.ts",
+        "previousPath": null,
+        "status": "modified",
+        "blobSha": "11c6e080c6e5444ce97186e64b26080b80274fc1"
+      },
+      {
+        "path": "services/bayn/src/db/evidence-store.integration.test.ts",
+        "previousPath": null,
+        "status": "modified",
+        "blobSha": "eeb53deddb024057beff098ab7c97ea5d90052c0"
+      },
+      {
+        "path": "services/bayn/src/db/migrations.ts",
+        "previousPath": null,
+        "status": "modified",
+        "blobSha": "b3e6d31d76b6e8ab1add9e20dca8176d63566dc8"
+      },
+      {
+        "path": "services/bayn/src/execution-candidate-discovery/program.ts",
+        "previousPath": null,
+        "status": "modified",
+        "blobSha": "937a75dc11668df5d53ab0470d98ed1c28961d60"
+      },
+      {
+        "path": "services/bayn/src/observe-composition.test.ts",
+        "previousPath": null,
+        "status": "modified",
+        "blobSha": "680cd7d2c7ba6c8607fd05c734331266c3b39d12"
+      },
+      {
+        "path": "services/bayn/src/observe-composition.ts",
+        "previousPath": null,
+        "status": "modified",
+        "blobSha": "ab38e8303f0d4482a6daeb6dd8f239cfb59d6223"
+      },
+      {
+        "path": "services/bayn/src/shadow-decision-contract.ts",
+        "previousPath": null,
+        "status": "modified",
+        "blobSha": "5b86a01873d4f9cae739136451337f2820a6190f"
+      },
+      {
+        "path": "services/bayn/src/shadow-decision.ts",
+        "previousPath": null,
+        "status": "modified",
+        "blobSha": "a059fae815156f68b825daf722b71d2f94708c46"
+      }
+    ]
+  },
+  "requiredDescendants": []
+}


### PR DESCRIPTION
## Summary

- add immutable `bayn.release-review-remediation.v4` support for normal reviewed continuous-source squash merges
- bind PR #13426 final source head, direct parent, exact tree, all 18 Bayn path blobs, immutable pull-request evidence, and one trusted post-final-force-push reaction
- reject stale, pre-head, edited, spoofed, ambiguous, unrelated, mismatched, discontinuous, source-dropping, and later-mutated evidence
- add the exact immutable v4 receipt for squash merge `6737d29c`

## Immutable source evidence

- final reviewed source head: `adc96644904d1f1c2640cc6a597d1cfc108caf91`
- source/merge direct parent: `69d803040c8866e7703df50a645a096c54e7eca5`
- source/merge tree: `b8f61426c9e182125208356d1bb50c14e83b1e65`
- source PR evidence SHA-256: `2d7c74531595b8b889b39e5ebe7281cb5f397cbe2cf832300a80a62e293fbd0f`
- final force-push: `2026-07-31T20:29:25Z`
- unique trusted review reaction: `2026-07-31T20:35:28Z`

## Exact current head

- base: `fa2016a8aa3c8b0f466ab84a7956c704dd9056c7`
- head: `3870d78808d0eec4f8d8a6b6d6f91af406d8fe05`
- one commit, exactly three paths

## Local validation

- focused verifier: 106 pass, 0 fail
- Bayn script cohort: 347 pass, 0 fail
- full Bayn service test, TypeScript, Effect diagnostics, Oxlint, type-aware Oxlint, Oxfmt, and build: pass
- full packages-scripts build/static/type gates and tests passed until the local environment-only Docker CLI prerequisite; hosted packages-scripts supplies the complete Docker-backed result
- migrated PostgreSQL 18, both images, and release gate are required hosted exact-head gates

## Safety

No Candidate/runtime/broker/PAPER/credential/policy/deployment files are changed. No manual workflow dispatch or deploy is part of this PR.

Linear: PROOMPT-443
