### PR TITLE
fix(bayn): fail closed qualification dormancy

### DIFF
--- a/.github/workflows/bayn-qualification.yml
+++ b/.github/workflows/bayn-qualification.yml
@@ -32,26 +32,25 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Verify dormant calendar before any privileged access
-        id: calendar
+      - name: Verify typed candidate dormancy before any privileged access
+        id: dormancy
+        timeout-minutes: 2
         shell: bash
         run: |
           set -euo pipefail
           test "$(git rev-parse HEAD)" = "${GITHUB_SHA}"
-          if rg -n 'nextCandidatePreregistration: null' services/bayn/src/candidate-development-calendar.ts >/dev/null; then
-            echo 'PROOMPT-407 has not installed a reviewed non-null preregistration; qualification remains dormant.'
-            echo 'dormant=true' >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          echo 'dormant=false' >> "$GITHUB_OUTPUT"
+          test "$(git rev-parse refs/remotes/origin/main)" = "${GITHUB_SHA}"
+          bun packages/scripts/src/bayn/verify-qualification-dormancy.ts \
+            --repository-root "$GITHUB_WORKSPACE" \
+            --github-output "$GITHUB_OUTPUT"
 
-      - name: Stop safely while preregistration is absent
-        if: steps.calendar.outputs.dormant == 'true'
+      - name: Stop safely while qualification is dormant
+        if: steps.dormancy.outputs.dormant == 'true'
         run: echo 'No credentials, Signal data, PostgreSQL state, holdout, image, or qualification command were accessed.'
 
       - name: Bind the exact promoted unpinned qualification image
         id: image
-        if: steps.calendar.outputs.dormant != 'true'
+        if: steps.dormancy.outputs.dormant == 'false'
         shell: bash
         run: |
           set -euo pipefail
@@ -92,7 +91,7 @@ jobs:
           echo "reference=${image_reference}" >> "$GITHUB_OUTPUT"
 
       - name: Pull and verify the exact qualification image
-        if: steps.calendar.outputs.dormant != 'true'
+        if: steps.dormancy.outputs.dormant == 'false'
         shell: bash
         env:
           IMAGE_REFERENCE: ${{ steps.image.outputs.reference }}
@@ -103,7 +102,7 @@ jobs:
             jq -e --arg expected "$IMAGE_REFERENCE" 'index($expected) != null' >/dev/null
 
       - name: Preflight immutable qualification evidence without credentials
-        if: steps.calendar.outputs.dormant != 'true'
+        if: steps.dormancy.outputs.dormant == 'false'
         shell: bash
         env:
           IMAGE_REFERENCE: ${{ steps.image.outputs.reference }}
@@ -143,7 +142,7 @@ jobs:
 
       - name: Collect, lock, execute once, and independently audit
         id: qualify
-        if: steps.calendar.outputs.dormant != 'true'
+        if: steps.dormancy.outputs.dormant == 'false'
         shell: bash
         env:
           IMAGE_REFERENCE: ${{ steps.image.outputs.reference }}
@@ -213,7 +212,7 @@ jobs:
           echo "terminal=${terminal}" >> "$GITHUB_OUTPUT"
 
       - name: Upload immutable terminal qualification evidence
-        if: steps.calendar.outputs.dormant != 'true' && steps.qualify.outcome == 'success'
+        if: steps.dormancy.outputs.dormant == 'false' && steps.qualify.outcome == 'success'
         uses: actions/upload-artifact@v4
         with:
           name: bayn-qualification-terminal-${{ github.sha }}-${{ github.run_id }}
@@ -222,7 +221,7 @@ jobs:
           retention-days: 90
 
       - name: Summarize terminal qualification evidence
-        if: steps.calendar.outputs.dormant != 'true' && steps.qualify.outcome == 'success'
+        if: steps.dormancy.outputs.dormant == 'false' && steps.qualify.outcome == 'success'
         shell: bash
         env:
           TERMINAL: ${{ steps.qualify.outputs.terminal }}

--- a/packages/scripts/src/bayn/bayn-qualification-workflow.test.ts
+++ b/packages/scripts/src/bayn/bayn-qualification-workflow.test.ts
@@ -9,20 +9,31 @@ const auditCommand = readFileSync('services/bayn/src/qualification-audit-command
 
 describe('Bayn qualification workflow collector/executor contract', () => {
   test('stays dormant before any credential, image, database, Signal, or qualification access', () => {
-    const dormant = workflow.indexOf('Verify dormant calendar before any privileged access')
+    const dormant = workflow.indexOf('Verify typed candidate dormancy before any privileged access')
+    const safeNoop = workflow.indexOf('Stop safely while qualification is dormant')
     const imageBinding = workflow.indexOf('Bind the exact promoted unpinned qualification image')
     const secretReference = workflow.indexOf('secrets.BAYN_QUALIFICATION_CLICKHOUSE_USERNAME')
     const imagePull = workflow.indexOf('docker pull "$IMAGE_REFERENCE"')
 
     expect(dormant).toBeGreaterThan(0)
+    expect(safeNoop).toBeGreaterThan(dormant)
+    expect(imageBinding).toBeGreaterThan(safeNoop)
     expect(imageBinding).toBeGreaterThan(dormant)
     expect(secretReference).toBeGreaterThan(imageBinding)
     expect(imagePull).toBeGreaterThan(imageBinding)
-    expect(workflow).toContain('nextCandidatePreregistration: null')
+    expect(workflow).toContain('bun packages/scripts/src/bayn/verify-qualification-dormancy.ts')
+    expect(workflow).toContain('--repository-root "$GITHUB_WORKSPACE"')
+    expect(workflow).toContain('--github-output "$GITHUB_OUTPUT"')
+    expect(workflow).not.toContain("rg -n 'nextCandidatePreregistration: null'")
+    expect(workflow).not.toContain('services/bayn/src/candidate-development-calendar.ts')
     expect(workflow).toContain(
       'No credentials, Signal data, PostgreSQL state, holdout, image, or qualification command were accessed.',
     )
-    expect(workflow).toContain("if: steps.calendar.outputs.dormant != 'true'")
+    expect(workflow).toContain('id: dormancy')
+    expect(workflow).not.toContain('steps.calendar')
+    expect(workflow).toContain("if: steps.dormancy.outputs.dormant == 'true'")
+    expect(workflow).not.toContain("steps.dormancy.outputs.dormant != 'true'")
+    expect(workflow).toContain("if: steps.dormancy.outputs.dormant == 'false'")
   })
 
   test('binds and executes only the exact promoted unpinned source image', () => {

--- a/packages/scripts/src/bayn/verify-qualification-dormancy.test.ts
+++ b/packages/scripts/src/bayn/verify-qualification-dormancy.test.ts
@@ -1,0 +1,461 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+
+import {
+  evaluateQualificationDormancy,
+  validateQualificationDormancyLoaderMessage,
+  type QualificationCandidatePreregistration,
+} from './verify-qualification-dormancy'
+
+const verifierPath = resolve(import.meta.dir, 'verify-qualification-dormancy.ts')
+const temporaryDirectories: string[] = []
+const hash = (character: string): string => character.repeat(64)
+const revision = (character: string): string => character.repeat(40)
+const authoritativeImports = [
+  "import { candidateDevelopmentCalendarContract } from './candidate-development'",
+  "import { canonicalHashV1Result } from './hash'",
+].join('\n')
+
+const moduleSource = (history: unknown, prefix = ''): string =>
+  `${authoritativeImports}\n${prefix}export const frozenCandidateDevelopmentTrialHistory = ${JSON.stringify(history)} as const\n`
+
+const reviewedPreregistration = (): QualificationCandidatePreregistration => ({
+  schemaVersion: 'bayn.candidate-development-next-preregistration.v1',
+  candidateOrdinal: 3,
+  priorTrialCount: 2,
+  strategyProtocolHash: hash('1'),
+  strategyIdentityHash: hash('2'),
+  candidateDevelopmentProtocolHash: hash('3'),
+  calendarHash: hash('4'),
+  priorTrialsHash: hash('5'),
+  modulePath: 'services/bayn/src/strategy/example/candidate-3.ts',
+  moduleSha256: hash('6'),
+  marketData: {
+    schemaVersion: 'bayn.candidate-development-market-data-source.v1',
+    snapshotId: hash('7'),
+    finalizedSnapshotContentHash: hash('8'),
+    inputManifestHash: hash('9'),
+    boundedContentHash: hash('a'),
+  },
+  preregistration: {
+    sourceRevision: revision('b'),
+    path: 'services/bayn/candidates/ordinal-3-example-preregistration.json',
+    blobOid: revision('c'),
+  },
+})
+
+const trialHistory = (input?: {
+  readonly schemaVersion?: 'bayn.candidate-development-trial-history.v1' | 'bayn.candidate-development-trial-history.v2'
+  readonly next?: QualificationCandidatePreregistration | null
+  readonly invalidation?: unknown
+}): Record<string, unknown> => {
+  const reviewed = reviewedPreregistration()
+  const schemaVersion = input?.schemaVersion ?? 'bayn.candidate-development-trial-history.v1'
+  return {
+    schemaVersion,
+    completedCandidateOrdinals: [1],
+    developmentCandidateOrdinals: [2],
+    latestReviewedCandidateLegacyPriorTrials: {},
+    latestReviewedCandidatePriorTrials: {},
+    latestTerminalEvidence: {},
+    candidatePreregistration: {},
+    latestReviewedCandidatePreregistration: reviewed,
+    latestDevelopmentEvidence: {
+      candidateOrdinal: 2,
+      priorTrialCount: 1,
+      status: 'DEVELOPMENT_REJECTED',
+      evidenceContentHash: hash('d'),
+      evaluatedSourceRevision: revision('e'),
+      failureStage: 'development-evaluation',
+      developmentMetricsObserved: true,
+      qualificationAttemptConsumed: false,
+    },
+    nextCandidatePreregistration: input?.next === undefined ? reviewed : input.next,
+    ...(schemaVersion === 'bayn.candidate-development-trial-history.v2'
+      ? { latestInvalidPrecommit: input?.invalidation ?? null }
+      : {}),
+  }
+}
+
+const invalidPrecommit = (): Record<string, unknown> => {
+  const reviewed = reviewedPreregistration()
+  return {
+    schemaVersion: 'bayn.candidate-development-precommit-invalidation.v1',
+    candidateOrdinal: reviewed.candidateOrdinal,
+    priorTrialCount: reviewed.priorTrialCount,
+    status: 'PRECOMMIT_INVALID',
+    attemptStatus: 'UNATTEMPTED',
+    metricBearingAttemptsConsumed: 0,
+    qualificationAttemptConsumed: false,
+    reviewedHeadRevision: revision('f'),
+    mergedSourceRevision: revision('0'),
+    preregistration: {
+      ...reviewed.preregistration,
+      sha256: hash('b'),
+    },
+    sourceManifest: {
+      path: 'services/bayn/candidates/ordinal-3-example-source-manifest.json',
+      blobOid: revision('1'),
+      sha256: hash('c'),
+    },
+    invalidatedModule: {
+      path: reviewed.modulePath,
+      blobOid: revision('2'),
+      sha256: reviewed.moduleSha256,
+      lineCount: 10,
+      byteCount: 100,
+      findings: [
+        'TYPE_CHECK_DISABLED',
+        'DOWNCOMPILED_BUNDLE',
+        'EMBEDDED_OFFICIAL_SESSIONS',
+        'EMBEDDED_MARKET_BARS',
+        'RUNTIME_INPUT_IGNORED',
+      ],
+    },
+    naturalBuild: {
+      runId: '1234',
+      imagePublished: true,
+      imageDigest: `sha256:${hash('d')}`,
+      deploymentAllowed: false,
+    },
+    release: {
+      runId: '5678',
+      conclusion: 'CANCELLED',
+      promotionCompleted: false,
+      rerunAllowed: false,
+    },
+    nextCandidatePreregistration: null,
+  }
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) rmSync(directory, { recursive: true, force: true })
+})
+
+describe('qualification dormancy verifier', () => {
+  test('returns a clean no-op when no preregistration is authorized', () => {
+    expect(evaluateQualificationDormancy(trialHistory({ next: null }))).toEqual({
+      status: 'dormant',
+      reason: 'preregistration-missing',
+      candidateOrdinal: null,
+    })
+  })
+
+  test('returns a clean no-op for an unattempted invalid precommit', () => {
+    expect(
+      evaluateQualificationDormancy(
+        trialHistory({
+          schemaVersion: 'bayn.candidate-development-trial-history.v2',
+          next: null,
+          invalidation: invalidPrecommit(),
+        }),
+      ),
+    ).toEqual({
+      status: 'dormant',
+      reason: 'precommit-invalid-unattempted',
+      candidateOrdinal: 3,
+    })
+  })
+
+  test('allows only the exact separately reviewed non-null preregistration', () => {
+    expect(evaluateQualificationDormancy(trialHistory())).toEqual({
+      status: 'ready',
+      reason: 'reviewed-preregistration-present',
+      candidateOrdinal: 3,
+      preregistrationSourceRevision: revision('b'),
+      preregistrationBlobOid: revision('c'),
+    })
+  })
+
+  test('accepts exactly one closed authenticated IPC result', () => {
+    const nonce = hash('f')
+    const payload = JSON.stringify(trialHistory({ next: null }))
+    const message = { type: 'result', nonce, payload }
+
+    expect(validateQualificationDormancyLoaderMessage(message, nonce, null)).toBe(payload)
+    for (const invalid of [
+      null,
+      { ...message, nonce: hash('e') },
+      { ...message, type: 'bootstrap' },
+      { ...message, payload: 1 },
+      { ...message, extra: true },
+    ]) {
+      expect(() => validateQualificationDormancyLoaderMessage(invalid, nonce, null)).toThrow()
+    }
+    expect(() => validateQualificationDormancyLoaderMessage(message, 'not-a-nonce', null)).toThrow()
+    expect(() => validateQualificationDormancyLoaderMessage(message, nonce, payload)).toThrow()
+    expect(() =>
+      validateQualificationDormancyLoaderMessage(
+        { type: 'result', nonce, payload: 'x'.repeat(1024 * 1024 + 1) },
+        nonce,
+        null,
+      ),
+    ).toThrow()
+  })
+
+  test('fails closed on malformed, mismatched, and ambiguous evidence', () => {
+    const reviewed = reviewedPreregistration()
+    const mismatched: QualificationCandidatePreregistration = {
+      ...reviewed,
+      preregistration: { ...reviewed.preregistration, sourceRevision: revision('a') },
+    }
+    const invalidation = invalidPrecommit()
+    invalidation.attemptStatus = 'ATTEMPTED'
+
+    const malformed: unknown[] = [
+      null,
+      {},
+      { ...trialHistory(), schemaVersion: 'bayn.candidate-development-trial-history.v3' },
+      { ...trialHistory(), developmentCandidateOrdinals: [3] },
+      { ...trialHistory(), nextCandidatePreregistration: mismatched },
+      trialHistory({
+        schemaVersion: 'bayn.candidate-development-trial-history.v2',
+        next: null,
+        invalidation,
+      }),
+      trialHistory({
+        schemaVersion: 'bayn.candidate-development-trial-history.v2',
+        next: reviewedPreregistration(),
+        invalidation: invalidPrecommit(),
+      }),
+    ]
+
+    for (const evidence of malformed) expect(() => evaluateQualificationDormancy(evidence)).toThrow()
+  })
+
+  test('runs against the fixed authoritative path and writes output only after a valid decision', () => {
+    const cases = [
+      {
+        history: trialHistory({ next: null }),
+        expected: ['dormant=true', 'reason=preregistration-missing', 'candidate_ordinal='],
+      },
+      {
+        history: trialHistory({
+          schemaVersion: 'bayn.candidate-development-trial-history.v2',
+          next: null,
+          invalidation: invalidPrecommit(),
+        }),
+        expected: ['dormant=true', 'reason=precommit-invalid-unattempted', 'candidate_ordinal=3'],
+      },
+      {
+        history: trialHistory(),
+        expected: ['dormant=false', 'reason=reviewed-preregistration-present', 'candidate_ordinal=3'],
+      },
+    ]
+
+    for (const { history, expected } of cases) {
+      const repository = mkdtempSync(join(tmpdir(), 'qualification-dormancy-test-'))
+      temporaryDirectories.push(repository)
+      const modulePath = join(repository, 'services/bayn/src/candidate-development-trial-history.ts')
+      mkdirSync(dirname(modulePath), { recursive: true })
+      writeFileSync(
+        modulePath,
+        moduleSource(
+          history,
+          `if (process.env.GITHUB_OUTPUT) throw new Error('workflow output leaked into the module')\n`,
+        ),
+      )
+      const outputPath = join(repository, 'github-output')
+      writeFileSync(outputPath, '')
+
+      const result = Bun.spawnSync([
+        process.execPath,
+        verifierPath,
+        '--repository-root',
+        repository,
+        '--github-output',
+        outputPath,
+      ])
+
+      if (result.exitCode !== 0) {
+        throw new Error(`valid evidence failed: ${result.stderr.toString()}`)
+      }
+      expect(result.stderr.toString()).toBe('')
+      expect(readFileSync(outputPath, 'utf8')).toBe(`${expected.join('\n')}\n`)
+    }
+  })
+
+  test('leaves no runnable output for missing, throwing, imported, or ambiguous evidence', () => {
+    const moduleSources = [
+      { label: 'missing', source: null },
+      {
+        label: 'throwing',
+        source: moduleSource(trialHistory(), `throw new Error('unloadable')\n`),
+      },
+      {
+        label: 'unsupported import',
+        source: `${authoritativeImports}\nimport 'node:fs'\nexport const frozenCandidateDevelopmentTrialHistory = ${JSON.stringify(trialHistory())}\n`,
+      },
+      {
+        label: 'ambiguous state',
+        source: moduleSource(
+          trialHistory({
+            schemaVersion: 'bayn.candidate-development-trial-history.v2',
+            next: reviewedPreregistration(),
+            invalidation: invalidPrecommit(),
+          }),
+        ),
+      },
+      {
+        label: 'bounded output',
+        source: `${authoritativeImports}
+const history = ${JSON.stringify(trialHistory())}
+history.latestTerminalEvidence = { padding: 'x'.repeat(1024 * 1024 + 1) }
+export const frozenCandidateDevelopmentTrialHistory = history
+`,
+      },
+    ]
+
+    for (const { label, source } of moduleSources) {
+      const repository = mkdtempSync(join(tmpdir(), 'qualification-dormancy-failure-test-'))
+      temporaryDirectories.push(repository)
+      const modulePath = join(repository, 'services/bayn/src/candidate-development-trial-history.ts')
+      mkdirSync(dirname(modulePath), { recursive: true })
+      if (source !== null) writeFileSync(modulePath, source)
+      const outputPath = join(repository, 'github-output')
+      writeFileSync(outputPath, '')
+
+      const result = Bun.spawnSync([
+        process.execPath,
+        verifierPath,
+        '--repository-root',
+        repository,
+        '--github-output',
+        outputPath,
+      ])
+
+      if (result.exitCode === 0) {
+        throw new Error(`${label} evidence unexpectedly succeeded: ${result.stdout.toString()}`)
+      }
+      expect(readFileSync(outputPath, 'utf8')).toBe('')
+    }
+  })
+
+  test('stops null, invalid, and malformed run shapes before fake image or privileged input access', () => {
+    const cases = [
+      {
+        label: 'null preregistration',
+        source: moduleSource(trialHistory({ next: null })),
+        exitCode: 0,
+        access: false,
+      },
+      {
+        label: 'invalid unattempted precommit',
+        source: moduleSource(
+          trialHistory({
+            schemaVersion: 'bayn.candidate-development-trial-history.v2',
+            next: null,
+            invalidation: invalidPrecommit(),
+          }),
+        ),
+        exitCode: 0,
+        access: false,
+      },
+      {
+        label: 'malformed evidence',
+        source: moduleSource({ ...trialHistory(), schemaVersion: 'bayn.candidate-development-trial-history.v3' }),
+        exitCode: 1,
+        access: false,
+      },
+      {
+        label: 'reviewed preregistration',
+        source: moduleSource(trialHistory()),
+        exitCode: 0,
+        access: true,
+      },
+    ]
+
+    for (const testCase of cases) {
+      const repository = mkdtempSync(join(tmpdir(), 'qualification-dormancy-run-shape-test-'))
+      temporaryDirectories.push(repository)
+      const modulePath = join(repository, 'services/bayn/src/candidate-development-trial-history.ts')
+      mkdirSync(dirname(modulePath), { recursive: true })
+      writeFileSync(modulePath, testCase.source)
+      const outputPath = join(repository, 'github-output')
+      const imageInput = join(repository, 'fake-image-input')
+      const privilegedInput = join(repository, 'fake-privileged-input')
+      const accessLog = join(repository, 'access-log')
+      writeFileSync(outputPath, '')
+      writeFileSync(imageInput, 'image\n')
+      writeFileSync(privilegedInput, 'privileged\n')
+
+      const script = `
+set -euo pipefail
+bun ${JSON.stringify(verifierPath)} --repository-root ${JSON.stringify(repository)} --github-output ${JSON.stringify(outputPath)}
+dormant="$(sed -n 's/^dormant=//p' ${JSON.stringify(outputPath)})"
+if [ "$dormant" = 'true' ]; then
+  echo SAFE_NOOP
+  exit 0
+fi
+cat ${JSON.stringify(imageInput)} ${JSON.stringify(privilegedInput)} > ${JSON.stringify(accessLog)}
+echo PROCEEDED
+`
+      const result = Bun.spawnSync(['bash', '-c', script])
+
+      expect(result.exitCode, testCase.label).toBe(testCase.exitCode)
+      expect(existsSync(accessLog), testCase.label).toBe(testCase.access)
+      if (testCase.access) {
+        expect(readFileSync(accessLog, 'utf8')).toBe('image\nprivileged\n')
+        expect(result.stdout.toString()).toContain('PROCEEDED')
+      } else if (testCase.exitCode === 0) {
+        expect(result.stdout.toString()).toContain('SAFE_NOOP')
+      } else {
+        expect(readFileSync(outputPath, 'utf8')).toBe('')
+      }
+    }
+  })
+
+  test('isolates hostile module evaluation from workflow outputs, secrets, files, and child processes', () => {
+    const repository = mkdtempSync(join(tmpdir(), 'qualification-dormancy-hostile-loader-test-'))
+    temporaryDirectories.push(repository)
+    const modulePath = join(repository, 'services/bayn/src/candidate-development-trial-history.ts')
+    const outputPath = join(repository, 'github-output')
+    const sentinelPath = join(repository, 'sentinel')
+    const childMarkerPath = join(repository, 'child-marker')
+    mkdirSync(dirname(modulePath), { recursive: true })
+    writeFileSync(outputPath, '')
+    writeFileSync(sentinelPath, 'safe\n')
+    const hostilePrefix = `
+if (process.env.GITHUB_TOKEN || process.env.BAYN_POSTGRES_URL || process.env.GITHUB_OUTPUT) {
+  throw new Error('privileged environment leaked')
+}
+try { process.send?.({ type: 'result', nonce: 'forged', payload: ${JSON.stringify(JSON.stringify(trialHistory()))} }) } catch {}
+try { process.stdout.write('FORGED_TRIAL_HISTORY') } catch {}
+try {
+  const escapedProcess = globalThis.constructor.constructor('return process')()
+  escapedProcess.stdout.write('FORGED_TRIAL_HISTORY')
+  const fs = escapedProcess.getBuiltinModule('node:fs')
+  for (const path of ${JSON.stringify([outputPath, sentinelPath])}) fs.writeFileSync(path, 'compromised\\n')
+  escapedProcess.getBuiltinModule('node:child_process').spawnSync(escapedProcess.execPath, [
+    '-e',
+    ${JSON.stringify(`require('node:fs').writeFileSync(${JSON.stringify(childMarkerPath)}, 'spawned')`)},
+  ])
+} catch {}
+`
+    writeFileSync(modulePath, moduleSource(trialHistory(), hostilePrefix))
+
+    const result = Bun.spawnSync(
+      [process.execPath, verifierPath, '--repository-root', repository, '--github-output', outputPath],
+      {
+        env: {
+          ...process.env,
+          GITHUB_TOKEN: 'must-not-reach-loader',
+          BAYN_POSTGRES_URL: 'must-not-reach-loader',
+          GITHUB_OUTPUT: outputPath,
+        },
+      },
+    )
+
+    if (result.exitCode !== 0) throw new Error(`hostile loader fixture failed: ${result.stderr.toString()}`)
+    expect(result.stderr.toString()).toBe('')
+    expect(result.stdout.toString()).not.toContain('FORGED_TRIAL_HISTORY')
+    expect(result.stdout.toString().match(/BAYN_QUALIFICATION_DORMANCY=/g)).toHaveLength(1)
+    expect(readFileSync(sentinelPath, 'utf8')).toBe('safe\n')
+    expect(existsSync(childMarkerPath)).toBe(false)
+    expect(readFileSync(outputPath, 'utf8')).toBe(
+      'dormant=false\nreason=reviewed-preregistration-present\ncandidate_ordinal=3\n',
+    )
+  })
+})

--- a/packages/scripts/src/bayn/verify-qualification-dormancy.test.ts
+++ b/packages/scripts/src/bayn/verify-qualification-dormancy.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, test } from 'bun:test'
+import { createHash } from 'node:crypto'
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
@@ -21,16 +22,53 @@ const authoritativeImports = [
 const moduleSource = (history: unknown, prefix = ''): string =>
   `${authoritativeImports}\n${prefix}export const frozenCandidateDevelopmentTrialHistory = ${JSON.stringify(history)} as const\n`
 
-const reviewedPreregistration = (): QualificationCandidatePreregistration => ({
+const canonicalJson = (value: unknown): string => {
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(',')}]`
+  if (value !== null && typeof value === 'object') {
+    const record = value as Record<string, unknown>
+    return `{${Object.keys(record)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${canonicalJson(record[key])}`)
+      .join(',')}}`
+  }
+  return JSON.stringify(value)
+}
+
+const canonicalHash = (value: unknown): string => createHash('sha256').update(canonicalJson(value)).digest('hex')
+
+const exactMainTrialHistoryV1 = JSON.parse(
+  '{"schemaVersion":"bayn.candidate-development-trial-history.v1","completedCandidateOrdinals":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16],"developmentCandidateOrdinals":[17,18,19],"latestReviewedCandidateLegacyPriorTrials":{"schemaVersion":"bayn.candidate-development-prior-trials.v1","qualificationCandidateOrdinals":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16],"developmentCandidateOrdinals":[17],"latestDevelopmentEvidence":{"candidateOrdinal":17,"priorTrialCount":16,"status":"DEVELOPMENT_REJECTED","evidenceContentHash":"97b9c2d6dc1d59d9b60686065bc4d595b8d1f22cdff9930b6131427b90e13f26","qualificationAttemptConsumed":false},"latestReviewedPreregistration":{"schemaVersion":"bayn.candidate-development-next-preregistration.v1","candidateOrdinal":17,"priorTrialCount":16,"strategyProtocolHash":"fa25d8c16bc4f4fde3bab99409ae60a6fd23332d295b3557231796cebb911390","modulePath":"services/bayn/src/strategy/volatility-managed-trend-overlay/candidate-17.ts","moduleSha256":"2e98bc55eae1901ccdde41978b7b32d746dc2ef6afcebbff1de0ed54574065da","marketData":{"schemaVersion":"bayn.candidate-development-market-data-source.v1","snapshotId":"2a91f0177684f7022f746207333e510c8268f9b77a04b778a04220a33ccf79e0","finalizedSnapshotContentHash":"8e376546f6a6cc1dbe2e910db3d68f584fc0bd9c4858166042ce32aa077eed0d","inputManifestHash":"b606cf57fb076f5bd2875206973e7c512817430d5cfbbeac8a99396f9983cab4","boundedContentHash":"e0e7b283de187d8ccaf8a449dacc538f00049cfe446dcf153b558e92bf0e17ed"},"preregistration":{"sourceRevision":"890d8f5801cf7c7576ed7a0cee387a4e79b98877","path":"services/bayn/candidates/ordinal-17-volatility-managed-trend-overlay-preregistration.json","blobOid":"c1d07233df53cc0379b1dfae9f1caffbd6b7abd6"}}},"latestReviewedCandidatePriorTrials":{"schemaVersion":"bayn.candidate-development-prior-trials.v2","qualificationCandidateOrdinals":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16],"latestQualificationEvidence":{"candidateOrdinal":16,"priorTrialCount":15,"terminalStatus":"HOLD_REJECT","sourceRevision":"60a48a2e52fbafdd67a404a33a3cb22e82a98493"},"latestQualificationPreregistration":{"candidateOrdinal":16,"priorTrialCount":15,"sourceRevision":"a0dadcd2f6346968bd9df582e4673608afc04592","path":"services/bayn/candidates/ordinal-16-macro-breadth-regime-preregistration.md","blobOid":"f602e3c8fd1b85768404d5fbc439775cdcd2570b"},"developmentCandidateOrdinals":[17,18,19],"latestDevelopmentEvidence":{"candidateOrdinal":19,"priorTrialCount":18,"status":"DEVELOPMENT_REJECTED","evidenceContentHash":"6170af41ddc14c04412a1929a60c88f35062ec2440f6e4b3beb0539bd411f364","qualificationAttemptConsumed":false},"latestReviewedPreregistration":{"schemaVersion":"bayn.candidate-development-next-preregistration.v1","candidateOrdinal":19,"priorTrialCount":18,"strategyProtocolHash":"b4a2a6c65a7fa5973f7cbc1fd5031e77d529f4884562e5cc8a105fc870ced78f","strategyIdentityHash":"ccf8f03db1f0f9eb54f7ad42194c938e5a53e11573488fd31e7af871967af25a","candidateDevelopmentProtocolHash":"663b59d6c570bbe3373d6e160609e0ad6294a687f435416f2a0956888d960738","calendarHash":"4b2f519f336e4e730c1f0d69e860f25a8d4d0cfbd8e93c6b333ea83623d87237","priorTrialsHash":"1dfc9b6832d4841093becd2c276141110afdfce28a0a88b301cfe9959b900d62","modulePath":"services/bayn/src/strategy/inverse-volatility-risk-diversification/candidate-19.ts","moduleSha256":"90813ab3a3d3cb000bb894309694f94588f98730a6f78b8e1418a5c38d8cb45f","marketData":{"schemaVersion":"bayn.candidate-development-market-data-source.v1","snapshotId":"2a91f0177684f7022f746207333e510c8268f9b77a04b778a04220a33ccf79e0","finalizedSnapshotContentHash":"8e376546f6a6cc1dbe2e910db3d68f584fc0bd9c4858166042ce32aa077eed0d","inputManifestHash":"b606cf57fb076f5bd2875206973e7c512817430d5cfbbeac8a99396f9983cab4","boundedContentHash":"e0e7b283de187d8ccaf8a449dacc538f00049cfe446dcf153b558e92bf0e17ed"},"preregistration":{"sourceRevision":"bb24ec2ab4225b13920a2b50fb137c4134d2d75f","path":"services/bayn/candidates/ordinal-19-inverse-volatility-risk-diversification-preregistration.json","blobOid":"02d9150a1f0007a644a084b3fca4cd543131374e"}}},"latestTerminalEvidence":{"candidateOrdinal":16,"priorTrialCount":15,"terminalStatus":"HOLD_REJECT","sourceRevision":"60a48a2e52fbafdd67a404a33a3cb22e82a98493"},"candidatePreregistration":{"candidateOrdinal":16,"priorTrialCount":15,"sourceRevision":"a0dadcd2f6346968bd9df582e4673608afc04592","path":"services/bayn/candidates/ordinal-16-macro-breadth-regime-preregistration.md","blobOid":"f602e3c8fd1b85768404d5fbc439775cdcd2570b"},"latestReviewedCandidatePreregistration":{"schemaVersion":"bayn.candidate-development-next-preregistration.v1","candidateOrdinal":20,"priorTrialCount":19,"strategyProtocolHash":"18b61d027e2235c7fc8ba718313ae8863650c2cb7c497dc4a7a5028829d19e0f","strategyIdentityHash":"8c99589120d8f3ed36c5286ce119d20490d42becd014e7fc2cc97b1420600278","candidateDevelopmentProtocolHash":"f7d4d78e70401c01c141fc7b63c4c1cfe9e7350b973c40ffbd7d8fe9832b332f","calendarHash":"4b2f519f336e4e730c1f0d69e860f25a8d4d0cfbd8e93c6b333ea83623d87237","priorTrialsHash":"dfda4c7706cdd7b2999a863ac63714c5d46894027442253f031b69bcdeaefde0","modulePath":"services/bayn/src/strategy/cross-sectional-short-term-reversal/candidate-20.ts","moduleSha256":"15570022245f8bba1c121c6657369d66085d6c3659aa326b50048be1ab050441","marketData":{"schemaVersion":"bayn.candidate-development-market-data-source.v1","snapshotId":"2a91f0177684f7022f746207333e510c8268f9b77a04b778a04220a33ccf79e0","finalizedSnapshotContentHash":"8e376546f6a6cc1dbe2e910db3d68f584fc0bd9c4858166042ce32aa077eed0d","inputManifestHash":"b606cf57fb076f5bd2875206973e7c512817430d5cfbbeac8a99396f9983cab4","boundedContentHash":"e0e7b283de187d8ccaf8a449dacc538f00049cfe446dcf153b558e92bf0e17ed"},"preregistration":{"sourceRevision":"0b0a951465e1c4644bc3fd04b7b448b8701dc609","path":"services/bayn/candidates/ordinal-20-cross-sectional-short-term-reversal-preregistration.json","blobOid":"066a4d44cd41b871cad95474eb00e411af532c76"}},"latestDevelopmentEvidence":{"candidateOrdinal":19,"priorTrialCount":18,"status":"DEVELOPMENT_REJECTED","evidenceContentHash":"6170af41ddc14c04412a1929a60c88f35062ec2440f6e4b3beb0539bd411f364","evaluatedSourceRevision":"276805b77d783db907dcb86cba934d7a4f6a0147","failureStage":"development-evaluation","developmentMetricsObserved":true,"qualificationAttemptConsumed":false},"nextCandidatePreregistration":{"schemaVersion":"bayn.candidate-development-next-preregistration.v1","candidateOrdinal":20,"priorTrialCount":19,"strategyProtocolHash":"18b61d027e2235c7fc8ba718313ae8863650c2cb7c497dc4a7a5028829d19e0f","strategyIdentityHash":"8c99589120d8f3ed36c5286ce119d20490d42becd014e7fc2cc97b1420600278","candidateDevelopmentProtocolHash":"f7d4d78e70401c01c141fc7b63c4c1cfe9e7350b973c40ffbd7d8fe9832b332f","calendarHash":"4b2f519f336e4e730c1f0d69e860f25a8d4d0cfbd8e93c6b333ea83623d87237","priorTrialsHash":"dfda4c7706cdd7b2999a863ac63714c5d46894027442253f031b69bcdeaefde0","modulePath":"services/bayn/src/strategy/cross-sectional-short-term-reversal/candidate-20.ts","moduleSha256":"15570022245f8bba1c121c6657369d66085d6c3659aa326b50048be1ab050441","marketData":{"schemaVersion":"bayn.candidate-development-market-data-source.v1","snapshotId":"2a91f0177684f7022f746207333e510c8268f9b77a04b778a04220a33ccf79e0","finalizedSnapshotContentHash":"8e376546f6a6cc1dbe2e910db3d68f584fc0bd9c4858166042ce32aa077eed0d","inputManifestHash":"b606cf57fb076f5bd2875206973e7c512817430d5cfbbeac8a99396f9983cab4","boundedContentHash":"e0e7b283de187d8ccaf8a449dacc538f00049cfe446dcf153b558e92bf0e17ed"},"preregistration":{"sourceRevision":"0b0a951465e1c4644bc3fd04b7b448b8701dc609","path":"services/bayn/candidates/ordinal-20-cross-sectional-short-term-reversal-preregistration.json","blobOid":"066a4d44cd41b871cad95474eb00e411af532c76"}}}',
+) as Record<string, unknown>
+
+const exactCandidate20Invalidation = JSON.parse(
+  '{"schemaVersion":"bayn.candidate-development-precommit-invalidation.v1","candidateOrdinal":20,"priorTrialCount":19,"status":"PRECOMMIT_INVALID","attemptStatus":"UNATTEMPTED","metricBearingAttemptsConsumed":0,"qualificationAttemptConsumed":false,"reviewedHeadRevision":"82f58dd6bd6fc9849e779665873f934841b47ea7","mergedSourceRevision":"69d803040c8866e7703df50a645a096c54e7eca5","preregistration":{"sourceRevision":"0b0a951465e1c4644bc3fd04b7b448b8701dc609","path":"services/bayn/candidates/ordinal-20-cross-sectional-short-term-reversal-preregistration.json","blobOid":"066a4d44cd41b871cad95474eb00e411af532c76","sha256":"e392888970d3c510e3ad20d6e982b81bf6234cd17260c8c5203013b5ce979409"},"sourceManifest":{"path":"services/bayn/candidates/ordinal-20-cross-sectional-short-term-reversal-source-manifest.json","blobOid":"def5faba5a301b8fe4daa8f0557e8d53efb4b697","sha256":"b5d9c4da95f59d4d4483fa80665de5327f4ed0b04c3afa8a94a3316b91f9e1fe"},"invalidatedModule":{"path":"services/bayn/src/strategy/cross-sectional-short-term-reversal/candidate-20.ts","blobOid":"71ae99e9303e7b79a640f185e70faa68a3048910","sha256":"15570022245f8bba1c121c6657369d66085d6c3659aa326b50048be1ab050441","lineCount":123194,"byteCount":2963738,"findings":["TYPE_CHECK_DISABLED","DOWNCOMPILED_BUNDLE","EMBEDDED_OFFICIAL_SESSIONS","EMBEDDED_MARKET_BARS","RUNTIME_INPUT_IGNORED"]},"naturalBuild":{"runId":"30657379582","imagePublished":true,"imageDigest":"sha256:28f59fb44bdb3008eecd17cf3c053098f214f3d982f26673a44a98d53f767fba","deploymentAllowed":false},"release":{"runId":"30657658256","conclusion":"CANCELLED","promotionCompleted":false,"rerunAllowed":false},"nextCandidatePreregistration":null}',
+) as Record<string, unknown>
+
+const exactCandidate20ContainmentHistoryV2: Record<string, unknown> = {
+  ...exactMainTrialHistoryV1,
+  schemaVersion: 'bayn.candidate-development-trial-history.v2',
+  latestInvalidPrecommit: exactCandidate20Invalidation,
+  nextCandidatePreregistration: null,
+}
+
+const candidatePreregistration = (
+  candidateOrdinal: number,
+  completeIdentity: boolean,
+  priorTrialsHash?: string,
+): QualificationCandidatePreregistration => ({
   schemaVersion: 'bayn.candidate-development-next-preregistration.v1',
-  candidateOrdinal: 3,
-  priorTrialCount: 2,
+  candidateOrdinal,
+  priorTrialCount: candidateOrdinal - 1,
   strategyProtocolHash: hash('1'),
-  strategyIdentityHash: hash('2'),
-  candidateDevelopmentProtocolHash: hash('3'),
-  calendarHash: hash('4'),
-  priorTrialsHash: hash('5'),
-  modulePath: 'services/bayn/src/strategy/example/candidate-3.ts',
+  ...(completeIdentity
+    ? {
+        strategyIdentityHash: hash('2'),
+        candidateDevelopmentProtocolHash: hash('3'),
+        calendarHash: hash('4'),
+        priorTrialsHash: priorTrialsHash ?? hash('5'),
+      }
+    : {}),
+  modulePath: `services/bayn/src/strategy/example/candidate-${candidateOrdinal}.ts`,
   moduleSha256: hash('6'),
   marketData: {
     schemaVersion: 'bayn.candidate-development-market-data-source.v1',
@@ -41,37 +79,89 @@ const reviewedPreregistration = (): QualificationCandidatePreregistration => ({
   },
   preregistration: {
     sourceRevision: revision('b'),
-    path: 'services/bayn/candidates/ordinal-3-example-preregistration.json',
+    path: `services/bayn/candidates/ordinal-${candidateOrdinal}-example-preregistration.json`,
     blobOid: revision('c'),
   },
 })
+
+const historyRecords = () => {
+  const completedCandidateOrdinals = [1]
+  const developmentCandidateOrdinals = [2]
+  const latestTerminalEvidence = {
+    candidateOrdinal: 1,
+    priorTrialCount: 0,
+    terminalStatus: 'HOLD_REJECT',
+    sourceRevision: revision('1'),
+  } as const
+  const candidateQualificationPreregistration = {
+    candidateOrdinal: 1,
+    priorTrialCount: 0,
+    sourceRevision: revision('2'),
+    path: 'services/bayn/candidates/ordinal-1-example-preregistration.md',
+    blobOid: revision('3'),
+  } as const
+  const priorDevelopmentEvidence = {
+    candidateOrdinal: 2,
+    priorTrialCount: 1,
+    status: 'DEVELOPMENT_REJECTED',
+    evidenceContentHash: hash('d'),
+    qualificationAttemptConsumed: false,
+  } as const
+  const latestHistoricalPreregistration = candidatePreregistration(2, false)
+  const latestReviewedCandidateLegacyPriorTrials = {
+    schemaVersion: 'bayn.candidate-development-prior-trials.v1',
+    qualificationCandidateOrdinals: completedCandidateOrdinals,
+    developmentCandidateOrdinals,
+    latestDevelopmentEvidence: priorDevelopmentEvidence,
+    latestReviewedPreregistration: latestHistoricalPreregistration,
+  } as const
+  const latestReviewedCandidatePriorTrials = {
+    schemaVersion: 'bayn.candidate-development-prior-trials.v2',
+    qualificationCandidateOrdinals: completedCandidateOrdinals,
+    latestQualificationEvidence: latestTerminalEvidence,
+    latestQualificationPreregistration: candidateQualificationPreregistration,
+    developmentCandidateOrdinals,
+    latestDevelopmentEvidence: priorDevelopmentEvidence,
+    latestReviewedPreregistration: latestHistoricalPreregistration,
+  } as const
+  const reviewed = candidatePreregistration(3, true, canonicalHash(latestReviewedCandidatePriorTrials))
+  return {
+    completedCandidateOrdinals,
+    developmentCandidateOrdinals,
+    latestReviewedCandidateLegacyPriorTrials,
+    latestReviewedCandidatePriorTrials,
+    latestTerminalEvidence,
+    candidateQualificationPreregistration,
+    reviewed,
+    latestDevelopmentEvidence: {
+      ...priorDevelopmentEvidence,
+      evaluatedSourceRevision: revision('e'),
+      failureStage: 'development-evaluation',
+      developmentMetricsObserved: true,
+    } as const,
+  }
+}
+
+const reviewedPreregistration = (): QualificationCandidatePreregistration => historyRecords().reviewed
 
 const trialHistory = (input?: {
   readonly schemaVersion?: 'bayn.candidate-development-trial-history.v1' | 'bayn.candidate-development-trial-history.v2'
   readonly next?: QualificationCandidatePreregistration | null
   readonly invalidation?: unknown
 }): Record<string, unknown> => {
-  const reviewed = reviewedPreregistration()
+  const records = historyRecords()
+  const reviewed = records.reviewed
   const schemaVersion = input?.schemaVersion ?? 'bayn.candidate-development-trial-history.v1'
   return {
     schemaVersion,
-    completedCandidateOrdinals: [1],
-    developmentCandidateOrdinals: [2],
-    latestReviewedCandidateLegacyPriorTrials: {},
-    latestReviewedCandidatePriorTrials: {},
-    latestTerminalEvidence: {},
-    candidatePreregistration: {},
+    completedCandidateOrdinals: records.completedCandidateOrdinals,
+    developmentCandidateOrdinals: records.developmentCandidateOrdinals,
+    latestReviewedCandidateLegacyPriorTrials: records.latestReviewedCandidateLegacyPriorTrials,
+    latestReviewedCandidatePriorTrials: records.latestReviewedCandidatePriorTrials,
+    latestTerminalEvidence: records.latestTerminalEvidence,
+    candidatePreregistration: records.candidateQualificationPreregistration,
     latestReviewedCandidatePreregistration: reviewed,
-    latestDevelopmentEvidence: {
-      candidateOrdinal: 2,
-      priorTrialCount: 1,
-      status: 'DEVELOPMENT_REJECTED',
-      evidenceContentHash: hash('d'),
-      evaluatedSourceRevision: revision('e'),
-      failureStage: 'development-evaluation',
-      developmentMetricsObserved: true,
-      qualificationAttemptConsumed: false,
-    },
+    latestDevelopmentEvidence: records.latestDevelopmentEvidence,
     nextCandidatePreregistration: input?.next === undefined ? reviewed : input.next,
     ...(schemaVersion === 'bayn.candidate-development-trial-history.v2'
       ? { latestInvalidPrecommit: input?.invalidation ?? null }
@@ -135,6 +225,28 @@ afterEach(() => {
 })
 
 describe('qualification dormancy verifier', () => {
+  test('decodes the exact main v1 and #13442 v2 authoritative histories', () => {
+    expect(canonicalHash(exactMainTrialHistoryV1)).toBe(
+      '9d78af3efcc888f07973ec88298ac6c76338edef7139942e573af5d338b4e58c',
+    )
+    expect(evaluateQualificationDormancy(exactMainTrialHistoryV1)).toEqual({
+      status: 'ready',
+      reason: 'reviewed-preregistration-present',
+      candidateOrdinal: 20,
+      preregistrationSourceRevision: '0b0a951465e1c4644bc3fd04b7b448b8701dc609',
+      preregistrationBlobOid: '066a4d44cd41b871cad95474eb00e411af532c76',
+    })
+
+    expect(canonicalHash(exactCandidate20ContainmentHistoryV2)).toBe(
+      '097c8164f2ec3add5e23189039957d76a954a5576705090f75d6614e7f42ea00',
+    )
+    expect(evaluateQualificationDormancy(exactCandidate20ContainmentHistoryV2)).toEqual({
+      status: 'dormant',
+      reason: 'precommit-invalid-unattempted',
+      candidateOrdinal: 20,
+    })
+  })
+
   test('returns a clean no-op when no preregistration is authorized', () => {
     expect(evaluateQualificationDormancy(trialHistory({ next: null }))).toEqual({
       status: 'dormant',
@@ -196,10 +308,15 @@ describe('qualification dormancy verifier', () => {
   })
 
   test('fails closed on malformed, mismatched, and ambiguous evidence', () => {
+    const records = historyRecords()
     const reviewed = reviewedPreregistration()
     const mismatched: QualificationCandidatePreregistration = {
       ...reviewed,
       preregistration: { ...reviewed.preregistration, sourceRevision: revision('a') },
+    }
+    const mismatchedPriorTrialsHash: QualificationCandidatePreregistration = {
+      ...reviewed,
+      priorTrialsHash: hash('0'),
     }
     const invalidation = invalidPrecommit()
     invalidation.attemptStatus = 'ATTEMPTED'
@@ -209,6 +326,28 @@ describe('qualification dormancy verifier', () => {
       {},
       { ...trialHistory(), schemaVersion: 'bayn.candidate-development-trial-history.v3' },
       { ...trialHistory(), developmentCandidateOrdinals: [3] },
+      { ...trialHistory(), latestTerminalEvidence: {} },
+      { ...trialHistory(), candidatePreregistration: {} },
+      { ...trialHistory(), latestReviewedCandidateLegacyPriorTrials: {} },
+      { ...trialHistory(), latestReviewedCandidatePriorTrials: {} },
+      {
+        ...trialHistory(),
+        latestReviewedCandidatePriorTrials: {
+          ...records.latestReviewedCandidatePriorTrials,
+          latestQualificationEvidence: {
+            ...records.latestTerminalEvidence,
+            sourceRevision: revision('f'),
+          },
+        },
+      },
+      {
+        ...trialHistory(),
+        latestDevelopmentEvidence: {
+          ...records.latestDevelopmentEvidence,
+          evidenceContentHash: hash('f'),
+        },
+      },
+      { ...trialHistory(), latestReviewedCandidatePreregistration: mismatchedPriorTrialsHash },
       { ...trialHistory(), nextCandidatePreregistration: mismatched },
       trialHistory({
         schemaVersion: 'bayn.candidate-development-trial-history.v2',
@@ -355,7 +494,7 @@ export const frozenCandidateDevelopmentTrialHistory = history
       },
       {
         label: 'malformed evidence',
-        source: moduleSource({ ...trialHistory(), schemaVersion: 'bayn.candidate-development-trial-history.v3' }),
+        source: moduleSource({ ...trialHistory(), latestReviewedCandidatePriorTrials: {} }),
         exitCode: 1,
         access: false,
       },

--- a/packages/scripts/src/bayn/verify-qualification-dormancy.test.ts
+++ b/packages/scripts/src/bayn/verify-qualification-dormancy.test.ts
@@ -271,6 +271,39 @@ describe('qualification dormancy verifier', () => {
     })
   })
 
+  test('rejects contradictory failure metadata in every exact authoritative history shape', () => {
+    const exactHistories = [
+      ['Candidate 19 dormant v1', exactCandidate19DormantHistoryV1],
+      ['current Candidate 20 ready v1', exactMainTrialHistoryV1],
+      ['#13442 Candidate 20 invalidated v2', exactCandidate20ContainmentHistoryV2],
+    ] as const
+
+    for (const [label, history] of exactHistories) {
+      for (const [failureStage, developmentMetricsObserved] of [
+        ['buildEvaluation-preflight', true],
+        ['development-evaluation', false],
+      ] as const) {
+        const contradictory = structuredClone(history)
+        contradictory.latestDevelopmentEvidence = {
+          ...(contradictory.latestDevelopmentEvidence as Record<string, unknown>),
+          failureStage,
+          developmentMetricsObserved,
+        }
+        expect(() => evaluateQualificationDormancy(contradictory), label).toThrow()
+      }
+
+      for (const missingField of ['failureStage', 'developmentMetricsObserved'] as const) {
+        const incomplete = structuredClone(history)
+        const latestDevelopmentEvidence = {
+          ...(incomplete.latestDevelopmentEvidence as Record<string, unknown>),
+        }
+        delete latestDevelopmentEvidence[missingField]
+        incomplete.latestDevelopmentEvidence = latestDevelopmentEvidence
+        expect(() => evaluateQualificationDormancy(incomplete), label).toThrow()
+      }
+    }
+  })
+
   test('returns a clean no-op when no preregistration is authorized', () => {
     expect(evaluateQualificationDormancy(exactCandidate19DormantHistoryV1)).toEqual({
       status: 'dormant',
@@ -369,6 +402,36 @@ describe('qualification dormancy verifier', () => {
         latestDevelopmentEvidence: {
           ...records.latestDevelopmentEvidence,
           evidenceContentHash: hash('f'),
+        },
+      },
+      {
+        ...trialHistory(),
+        latestDevelopmentEvidence: {
+          ...records.latestDevelopmentEvidence,
+          failureStage: 'buildEvaluation-preflight',
+          developmentMetricsObserved: true,
+        },
+      },
+      {
+        ...trialHistory(),
+        latestDevelopmentEvidence: {
+          ...records.latestDevelopmentEvidence,
+          failureStage: 'development-evaluation',
+          developmentMetricsObserved: false,
+        },
+      },
+      {
+        ...trialHistory(),
+        latestDevelopmentEvidence: {
+          ...records.latestDevelopmentEvidence,
+          developmentMetricsObserved: undefined,
+        },
+      },
+      {
+        ...trialHistory(),
+        latestDevelopmentEvidence: {
+          ...records.latestDevelopmentEvidence,
+          failureStage: undefined,
         },
       },
       { ...trialHistory(), latestReviewedCandidatePreregistration: mismatchedPriorTrialsHash },
@@ -497,6 +560,12 @@ export const frozenCandidateDevelopmentTrialHistory = history
   })
 
   test('stops null, invalid, and malformed run shapes before fake image or privileged input access', () => {
+    const contradictoryFailureHistory = trialHistory()
+    contradictoryFailureHistory.latestDevelopmentEvidence = {
+      ...(contradictoryFailureHistory.latestDevelopmentEvidence as Record<string, unknown>),
+      failureStage: 'buildEvaluation-preflight',
+      developmentMetricsObserved: true,
+    }
     const cases = [
       {
         label: 'null preregistration',
@@ -519,6 +588,12 @@ export const frozenCandidateDevelopmentTrialHistory = history
       {
         label: 'malformed evidence',
         source: moduleSource({ ...trialHistory(), latestReviewedCandidatePriorTrials: {} }),
+        exitCode: 1,
+        access: false,
+      },
+      {
+        label: 'contradictory failure metadata',
+        source: moduleSource(contradictoryFailureHistory),
         exitCode: 1,
         access: false,
       },

--- a/packages/scripts/src/bayn/verify-qualification-dormancy.test.ts
+++ b/packages/scripts/src/bayn/verify-qualification-dormancy.test.ts
@@ -51,6 +51,21 @@ const exactCandidate20ContainmentHistoryV2: Record<string, unknown> = {
   nextCandidatePreregistration: null,
 }
 
+const exactCandidate19PriorTrials = JSON.parse(
+  '{"schemaVersion":"bayn.candidate-development-prior-trials.v2","qualificationCandidateOrdinals":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16],"latestQualificationEvidence":{"candidateOrdinal":16,"priorTrialCount":15,"terminalStatus":"HOLD_REJECT","sourceRevision":"60a48a2e52fbafdd67a404a33a3cb22e82a98493"},"latestQualificationPreregistration":{"candidateOrdinal":16,"priorTrialCount":15,"sourceRevision":"a0dadcd2f6346968bd9df582e4673608afc04592","path":"services/bayn/candidates/ordinal-16-macro-breadth-regime-preregistration.md","blobOid":"f602e3c8fd1b85768404d5fbc439775cdcd2570b"},"developmentCandidateOrdinals":[17,18],"latestDevelopmentEvidence":{"candidateOrdinal":18,"priorTrialCount":17,"status":"DEVELOPMENT_REJECTED","evidenceContentHash":"65d6f044f3f323aa87ff26a3dca011053aa3172c8a4ce422841497ccf370a5b6","qualificationAttemptConsumed":false},"latestReviewedPreregistration":{"schemaVersion":"bayn.candidate-development-next-preregistration.v1","candidateOrdinal":18,"priorTrialCount":17,"strategyProtocolHash":"7e27320b47cd170c1bc9c60ec3692593f2182af44bb48cef4d4a403b09601d75","strategyIdentityHash":"ff762a985c129055670224dca5827a65c689f6f50e1e3765e7b521a05417b1f0","candidateDevelopmentProtocolHash":"46657425873b4f766b5f49d0ebbe2ac3aa9cf53682a8508635be708406271877","calendarHash":"4b2f519f336e4e730c1f0d69e860f25a8d4d0cfbd8e93c6b333ea83623d87237","priorTrialsHash":"58f4e801380f35f483f998e00c82889e0cb6257e85542764e2dc8eaa4f3fd419","modulePath":"services/bayn/src/strategy/dual-momentum-global-equity/candidate-18.ts","moduleSha256":"27466a8c9a9acba475db9cd0d2916532208540a53bd1f0ece307df299e5e34e8","marketData":{"schemaVersion":"bayn.candidate-development-market-data-source.v1","snapshotId":"2a91f0177684f7022f746207333e510c8268f9b77a04b778a04220a33ccf79e0","finalizedSnapshotContentHash":"8e376546f6a6cc1dbe2e910db3d68f584fc0bd9c4858166042ce32aa077eed0d","inputManifestHash":"b606cf57fb076f5bd2875206973e7c512817430d5cfbbeac8a99396f9983cab4","boundedContentHash":"e0e7b283de187d8ccaf8a449dacc538f00049cfe446dcf153b558e92bf0e17ed"},"preregistration":{"sourceRevision":"30614640c5dfa7a7d50bf053df153062ff0bbca4","path":"services/bayn/candidates/ordinal-18-global-equity-dual-momentum-preregistration.json","blobOid":"920a4afb8a7e5c1f6ef0875683ddc96a91008079"}}}',
+) as Record<string, unknown>
+
+const exactCandidate19Preregistration = JSON.parse(
+  '{"schemaVersion":"bayn.candidate-development-next-preregistration.v1","candidateOrdinal":19,"priorTrialCount":18,"strategyProtocolHash":"b4a2a6c65a7fa5973f7cbc1fd5031e77d529f4884562e5cc8a105fc870ced78f","strategyIdentityHash":"ccf8f03db1f0f9eb54f7ad42194c938e5a53e11573488fd31e7af871967af25a","candidateDevelopmentProtocolHash":"663b59d6c570bbe3373d6e160609e0ad6294a687f435416f2a0956888d960738","calendarHash":"4b2f519f336e4e730c1f0d69e860f25a8d4d0cfbd8e93c6b333ea83623d87237","priorTrialsHash":"1dfc9b6832d4841093becd2c276141110afdfce28a0a88b301cfe9959b900d62","modulePath":"services/bayn/src/strategy/inverse-volatility-risk-diversification/candidate-19.ts","moduleSha256":"90813ab3a3d3cb000bb894309694f94588f98730a6f78b8e1418a5c38d8cb45f","marketData":{"schemaVersion":"bayn.candidate-development-market-data-source.v1","snapshotId":"2a91f0177684f7022f746207333e510c8268f9b77a04b778a04220a33ccf79e0","finalizedSnapshotContentHash":"8e376546f6a6cc1dbe2e910db3d68f584fc0bd9c4858166042ce32aa077eed0d","inputManifestHash":"b606cf57fb076f5bd2875206973e7c512817430d5cfbbeac8a99396f9983cab4","boundedContentHash":"e0e7b283de187d8ccaf8a449dacc538f00049cfe446dcf153b558e92bf0e17ed"},"preregistration":{"sourceRevision":"bb24ec2ab4225b13920a2b50fb137c4134d2d75f","path":"services/bayn/candidates/ordinal-19-inverse-volatility-risk-diversification-preregistration.json","blobOid":"02d9150a1f0007a644a084b3fca4cd543131374e"}}',
+) as Record<string, unknown>
+
+const exactCandidate19DormantHistoryV1: Record<string, unknown> = {
+  ...exactMainTrialHistoryV1,
+  latestReviewedCandidatePriorTrials: exactCandidate19PriorTrials,
+  latestReviewedCandidatePreregistration: exactCandidate19Preregistration,
+  nextCandidatePreregistration: null,
+}
+
 const candidatePreregistration = (
   candidateOrdinal: number,
   completeIdentity: boolean,
@@ -124,7 +139,7 @@ const historyRecords = () => {
     latestDevelopmentEvidence: priorDevelopmentEvidence,
     latestReviewedPreregistration: latestHistoricalPreregistration,
   } as const
-  const reviewed = candidatePreregistration(3, true, canonicalHash(latestReviewedCandidatePriorTrials))
+  const reviewed = candidatePreregistration(3, true, canonicalHash(latestReviewedCandidateLegacyPriorTrials))
   return {
     completedCandidateOrdinals,
     developmentCandidateOrdinals,
@@ -237,6 +252,15 @@ describe('qualification dormancy verifier', () => {
       preregistrationBlobOid: '066a4d44cd41b871cad95474eb00e411af532c76',
     })
 
+    expect(canonicalHash(exactCandidate19DormantHistoryV1)).toBe(
+      '081ae8072bd3f05acf9f29554ca2ad74ea51ad5a271d7dfa42847c148ff2c2e5',
+    )
+    expect(evaluateQualificationDormancy(exactCandidate19DormantHistoryV1)).toEqual({
+      status: 'dormant',
+      reason: 'preregistration-missing',
+      candidateOrdinal: null,
+    })
+
     expect(canonicalHash(exactCandidate20ContainmentHistoryV2)).toBe(
       '097c8164f2ec3add5e23189039957d76a954a5576705090f75d6614e7f42ea00',
     )
@@ -248,7 +272,7 @@ describe('qualification dormancy verifier', () => {
   })
 
   test('returns a clean no-op when no preregistration is authorized', () => {
-    expect(evaluateQualificationDormancy(trialHistory({ next: null }))).toEqual({
+    expect(evaluateQualificationDormancy(exactCandidate19DormantHistoryV1)).toEqual({
       status: 'dormant',
       reason: 'preregistration-missing',
       candidateOrdinal: null,
@@ -283,7 +307,7 @@ describe('qualification dormancy verifier', () => {
 
   test('accepts exactly one closed authenticated IPC result', () => {
     const nonce = hash('f')
-    const payload = JSON.stringify(trialHistory({ next: null }))
+    const payload = JSON.stringify(exactCandidate19DormantHistoryV1)
     const message = { type: 'result', nonce, payload }
 
     expect(validateQualificationDormancyLoaderMessage(message, nonce, null)).toBe(payload)
@@ -367,7 +391,7 @@ describe('qualification dormancy verifier', () => {
   test('runs against the fixed authoritative path and writes output only after a valid decision', () => {
     const cases = [
       {
-        history: trialHistory({ next: null }),
+        history: exactCandidate19DormantHistoryV1,
         expected: ['dormant=true', 'reason=preregistration-missing', 'candidate_ordinal='],
       },
       {
@@ -476,7 +500,7 @@ export const frozenCandidateDevelopmentTrialHistory = history
     const cases = [
       {
         label: 'null preregistration',
-        source: moduleSource(trialHistory({ next: null })),
+        source: moduleSource(exactCandidate19DormantHistoryV1),
         exitCode: 0,
         access: false,
       },

--- a/packages/scripts/src/bayn/verify-qualification-dormancy.ts
+++ b/packages/scripts/src/bayn/verify-qualification-dormancy.ts
@@ -1,0 +1,698 @@
+#!/usr/bin/env bun
+
+import { fork } from 'node:child_process'
+import { randomBytes } from 'node:crypto'
+import { appendFile, mkdtemp, readFile, realpath, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import process from 'node:process'
+
+const trialHistoryRelativePath = 'services/bayn/src/candidate-development-trial-history.ts'
+const trialHistoryExport = 'frozenCandidateDevelopmentTrialHistory'
+const maximumLoaderOutputBytes = 1024 * 1024
+const maximumTrialHistorySourceBytes = 512 * 1024
+const loaderTimeoutMs = 5_000
+
+const sha40 = /^[0-9a-f]{40}$/
+const sha64 = /^[0-9a-f]{64}$/
+const imageDigest = /^sha256:[0-9a-f]{64}$/
+const candidateModulePath = /^services\/bayn\/src\/strategy\/[A-Za-z0-9._/-]+\.ts$/
+const candidatePreregistrationPath = /^services\/bayn\/candidates\/[A-Za-z0-9._/-]+\.json$/
+
+export interface QualificationCandidatePreregistration {
+  readonly schemaVersion: 'bayn.candidate-development-next-preregistration.v1'
+  readonly candidateOrdinal: number
+  readonly priorTrialCount: number
+  readonly strategyProtocolHash: string
+  readonly strategyIdentityHash: string
+  readonly candidateDevelopmentProtocolHash: string
+  readonly calendarHash: string
+  readonly priorTrialsHash: string
+  readonly modulePath: string
+  readonly moduleSha256: string
+  readonly marketData: {
+    readonly schemaVersion: 'bayn.candidate-development-market-data-source.v1'
+    readonly snapshotId: string
+    readonly finalizedSnapshotContentHash: string
+    readonly inputManifestHash: string
+    readonly boundedContentHash: string
+  }
+  readonly preregistration: {
+    readonly sourceRevision: string
+    readonly path: string
+    readonly blobOid: string
+  }
+}
+
+export type QualificationDormancyDecision =
+  | {
+      readonly status: 'dormant'
+      readonly reason: 'preregistration-missing'
+      readonly candidateOrdinal: null
+    }
+  | {
+      readonly status: 'dormant'
+      readonly reason: 'precommit-invalid-unattempted'
+      readonly candidateOrdinal: number
+    }
+  | {
+      readonly status: 'ready'
+      readonly reason: 'reviewed-preregistration-present'
+      readonly candidateOrdinal: number
+      readonly preregistrationSourceRevision: string
+      readonly preregistrationBlobOid: string
+    }
+
+const exactKeys = (record: Record<string, unknown>, expected: readonly string[], label: string): void => {
+  const observed = Object.keys(record).sort()
+  const required = [...expected].sort()
+  if (observed.length !== required.length || observed.some((key, index) => key !== required[index])) {
+    throw new Error(`${label} has an unsupported or incomplete schema`)
+  }
+}
+
+const dataRecord = (value: unknown, label: string): Record<string, unknown> => {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) throw new Error(`${label} must be an object`)
+  const prototype = Object.getPrototypeOf(value)
+  if (prototype !== Object.prototype && prototype !== null) throw new Error(`${label} must be a plain object`)
+  const output: Record<string, unknown> = {}
+  for (const key of Reflect.ownKeys(value)) {
+    if (typeof key !== 'string') throw new Error(`${label} must not contain symbol properties`)
+    const descriptor = Object.getOwnPropertyDescriptor(value, key)
+    if (descriptor?.enumerable !== true || !('value' in descriptor)) {
+      throw new Error(`${label}.${key} must be an enumerable data property`)
+    }
+    output[key] = descriptor.value
+  }
+  return output
+}
+
+export const validateQualificationDormancyLoaderMessage = (
+  message: unknown,
+  expectedNonce: string,
+  priorPayload: string | null,
+): string => {
+  if (!sha64.test(expectedNonce)) throw new Error('qualification dormancy loader nonce is malformed')
+  if (priorPayload !== null) throw new Error('qualification dormancy loader emitted duplicate results')
+  const record = dataRecord(message, 'qualification dormancy loader message')
+  exactKeys(record, ['type', 'nonce', 'payload'], 'qualification dormancy loader message')
+  if (record.type !== 'result' || record.nonce !== expectedNonce || typeof record.payload !== 'string') {
+    throw new Error('qualification dormancy loader message is unauthenticated')
+  }
+  if (Buffer.byteLength(record.payload, 'utf8') > maximumLoaderOutputBytes) {
+    throw new Error('qualification dormancy loader result exceeded the bound')
+  }
+  return record.payload
+}
+
+const nonEmptyString = (value: unknown, label: string): string => {
+  if (typeof value !== 'string' || value.length === 0 || value.includes('\n') || value.includes('\r')) {
+    throw new Error(`${label} must be a non-empty single-line string`)
+  }
+  return value
+}
+
+const positiveInteger = (value: unknown, label: string): number => {
+  if (typeof value !== 'number' || !Number.isSafeInteger(value) || value < 1) {
+    throw new Error(`${label} must be a positive integer`)
+  }
+  return value
+}
+
+const nonNegativeInteger = (value: unknown, label: string): number => {
+  if (typeof value !== 'number' || !Number.isSafeInteger(value) || value < 0) {
+    throw new Error(`${label} must be a non-negative integer`)
+  }
+  return value
+}
+
+const hash = (value: unknown, pattern: RegExp, label: string): string => {
+  const decoded = nonEmptyString(value, label)
+  if (!pattern.test(decoded)) throw new Error(`${label} is malformed`)
+  return decoded
+}
+
+const ordinalList = (value: unknown, label: string): readonly number[] => {
+  if (!Array.isArray(value)) throw new Error(`${label} must be an array`)
+  const output = value.map((entry, index) => positiveInteger(entry, `${label}[${index}]`))
+  if (output.some((entry, index) => index > 0 && entry <= (output[index - 1] ?? 0))) {
+    throw new Error(`${label} must be strictly increasing`)
+  }
+  return output
+}
+
+const decodePreregistration = (value: unknown, label: string): QualificationCandidatePreregistration => {
+  const record = dataRecord(value, label)
+  exactKeys(
+    record,
+    [
+      'schemaVersion',
+      'candidateOrdinal',
+      'priorTrialCount',
+      'strategyProtocolHash',
+      'strategyIdentityHash',
+      'candidateDevelopmentProtocolHash',
+      'calendarHash',
+      'priorTrialsHash',
+      'modulePath',
+      'moduleSha256',
+      'marketData',
+      'preregistration',
+    ],
+    label,
+  )
+  if (record.schemaVersion !== 'bayn.candidate-development-next-preregistration.v1') {
+    throw new Error(`${label}.schemaVersion is unsupported`)
+  }
+  const candidateOrdinal = positiveInteger(record.candidateOrdinal, `${label}.candidateOrdinal`)
+  const priorTrialCount = nonNegativeInteger(record.priorTrialCount, `${label}.priorTrialCount`)
+  if (candidateOrdinal !== priorTrialCount + 1) throw new Error(`${label} ordinal lineage is invalid`)
+
+  const modulePath = nonEmptyString(record.modulePath, `${label}.modulePath`)
+  if (!candidateModulePath.test(modulePath) || modulePath.includes('..'))
+    throw new Error(`${label}.modulePath is invalid`)
+
+  const marketData = dataRecord(record.marketData, `${label}.marketData`)
+  exactKeys(
+    marketData,
+    ['schemaVersion', 'snapshotId', 'finalizedSnapshotContentHash', 'inputManifestHash', 'boundedContentHash'],
+    `${label}.marketData`,
+  )
+  if (marketData.schemaVersion !== 'bayn.candidate-development-market-data-source.v1') {
+    throw new Error(`${label}.marketData.schemaVersion is unsupported`)
+  }
+
+  const preregistration = dataRecord(record.preregistration, `${label}.preregistration`)
+  exactKeys(preregistration, ['sourceRevision', 'path', 'blobOid'], `${label}.preregistration`)
+  const preregistrationPath = nonEmptyString(preregistration.path, `${label}.preregistration.path`)
+  if (!candidatePreregistrationPath.test(preregistrationPath) || preregistrationPath.includes('..')) {
+    throw new Error(`${label}.preregistration.path is invalid`)
+  }
+
+  return {
+    schemaVersion: 'bayn.candidate-development-next-preregistration.v1',
+    candidateOrdinal,
+    priorTrialCount,
+    strategyProtocolHash: hash(record.strategyProtocolHash, sha64, `${label}.strategyProtocolHash`),
+    strategyIdentityHash: hash(record.strategyIdentityHash, sha64, `${label}.strategyIdentityHash`),
+    candidateDevelopmentProtocolHash: hash(
+      record.candidateDevelopmentProtocolHash,
+      sha64,
+      `${label}.candidateDevelopmentProtocolHash`,
+    ),
+    calendarHash: hash(record.calendarHash, sha64, `${label}.calendarHash`),
+    priorTrialsHash: hash(record.priorTrialsHash, sha64, `${label}.priorTrialsHash`),
+    modulePath,
+    moduleSha256: hash(record.moduleSha256, sha64, `${label}.moduleSha256`),
+    marketData: {
+      schemaVersion: 'bayn.candidate-development-market-data-source.v1',
+      snapshotId: hash(marketData.snapshotId, sha64, `${label}.marketData.snapshotId`),
+      finalizedSnapshotContentHash: hash(
+        marketData.finalizedSnapshotContentHash,
+        sha64,
+        `${label}.marketData.finalizedSnapshotContentHash`,
+      ),
+      inputManifestHash: hash(marketData.inputManifestHash, sha64, `${label}.marketData.inputManifestHash`),
+      boundedContentHash: hash(marketData.boundedContentHash, sha64, `${label}.marketData.boundedContentHash`),
+    },
+    preregistration: {
+      sourceRevision: hash(preregistration.sourceRevision, sha40, `${label}.preregistration.sourceRevision`),
+      path: preregistrationPath,
+      blobOid: hash(preregistration.blobOid, sha40, `${label}.preregistration.blobOid`),
+    },
+  }
+}
+
+const canonicalJson = (value: unknown): string => {
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(',')}]`
+  if (value !== null && typeof value === 'object') {
+    const record = value as Record<string, unknown>
+    return `{${Object.keys(record)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${canonicalJson(record[key])}`)
+      .join(',')}}`
+  }
+  return JSON.stringify(value)
+}
+
+const decodeInvalidPrecommit = (value: unknown, reviewed: QualificationCandidatePreregistration): number => {
+  const record = dataRecord(value, 'trialHistory.latestInvalidPrecommit')
+  exactKeys(
+    record,
+    [
+      'schemaVersion',
+      'candidateOrdinal',
+      'priorTrialCount',
+      'status',
+      'attemptStatus',
+      'metricBearingAttemptsConsumed',
+      'qualificationAttemptConsumed',
+      'reviewedHeadRevision',
+      'mergedSourceRevision',
+      'preregistration',
+      'sourceManifest',
+      'invalidatedModule',
+      'naturalBuild',
+      'release',
+      'nextCandidatePreregistration',
+    ],
+    'trialHistory.latestInvalidPrecommit',
+  )
+  if (
+    record.schemaVersion !== 'bayn.candidate-development-precommit-invalidation.v1' ||
+    record.status !== 'PRECOMMIT_INVALID' ||
+    record.attemptStatus !== 'UNATTEMPTED' ||
+    record.metricBearingAttemptsConsumed !== 0 ||
+    record.qualificationAttemptConsumed !== false ||
+    record.nextCandidatePreregistration !== null
+  ) {
+    throw new Error('trialHistory.latestInvalidPrecommit is not an unattempted fail-closed invalidation')
+  }
+  const candidateOrdinal = positiveInteger(
+    record.candidateOrdinal,
+    'trialHistory.latestInvalidPrecommit.candidateOrdinal',
+  )
+  const priorTrialCount = nonNegativeInteger(
+    record.priorTrialCount,
+    'trialHistory.latestInvalidPrecommit.priorTrialCount',
+  )
+  if (
+    candidateOrdinal !== priorTrialCount + 1 ||
+    candidateOrdinal !== reviewed.candidateOrdinal ||
+    priorTrialCount !== reviewed.priorTrialCount
+  ) {
+    throw new Error('trialHistory.latestInvalidPrecommit ordinal lineage is invalid')
+  }
+  hash(record.reviewedHeadRevision, sha40, 'trialHistory.latestInvalidPrecommit.reviewedHeadRevision')
+  hash(record.mergedSourceRevision, sha40, 'trialHistory.latestInvalidPrecommit.mergedSourceRevision')
+
+  const preregistration = dataRecord(record.preregistration, 'trialHistory.latestInvalidPrecommit.preregistration')
+  exactKeys(
+    preregistration,
+    ['sourceRevision', 'path', 'blobOid', 'sha256'],
+    'trialHistory.latestInvalidPrecommit.preregistration',
+  )
+  const invalidatedModule = dataRecord(
+    record.invalidatedModule,
+    'trialHistory.latestInvalidPrecommit.invalidatedModule',
+  )
+  exactKeys(
+    invalidatedModule,
+    ['path', 'blobOid', 'sha256', 'lineCount', 'byteCount', 'findings'],
+    'trialHistory.latestInvalidPrecommit.invalidatedModule',
+  )
+  const sourceManifest = dataRecord(record.sourceManifest, 'trialHistory.latestInvalidPrecommit.sourceManifest')
+  exactKeys(sourceManifest, ['path', 'blobOid', 'sha256'], 'trialHistory.latestInvalidPrecommit.sourceManifest')
+  const naturalBuild = dataRecord(record.naturalBuild, 'trialHistory.latestInvalidPrecommit.naturalBuild')
+  exactKeys(
+    naturalBuild,
+    ['runId', 'imagePublished', 'imageDigest', 'deploymentAllowed'],
+    'trialHistory.latestInvalidPrecommit.naturalBuild',
+  )
+  const release = dataRecord(record.release, 'trialHistory.latestInvalidPrecommit.release')
+  exactKeys(
+    release,
+    ['runId', 'conclusion', 'promotionCompleted', 'rerunAllowed'],
+    'trialHistory.latestInvalidPrecommit.release',
+  )
+
+  const findings = [
+    'TYPE_CHECK_DISABLED',
+    'DOWNCOMPILED_BUNDLE',
+    'EMBEDDED_OFFICIAL_SESSIONS',
+    'EMBEDDED_MARKET_BARS',
+    'RUNTIME_INPUT_IGNORED',
+  ] as const
+  if (
+    !Array.isArray(invalidatedModule.findings) ||
+    canonicalJson(invalidatedModule.findings) !== canonicalJson(findings)
+  ) {
+    throw new Error('trialHistory.latestInvalidPrecommit.invalidatedModule.findings is invalid')
+  }
+  positiveInteger(invalidatedModule.lineCount, 'trialHistory.latestInvalidPrecommit.invalidatedModule.lineCount')
+  positiveInteger(invalidatedModule.byteCount, 'trialHistory.latestInvalidPrecommit.invalidatedModule.byteCount')
+  hash(invalidatedModule.blobOid, sha40, 'trialHistory.latestInvalidPrecommit.invalidatedModule.blobOid')
+  hash(invalidatedModule.sha256, sha64, 'trialHistory.latestInvalidPrecommit.invalidatedModule.sha256')
+  hash(sourceManifest.blobOid, sha40, 'trialHistory.latestInvalidPrecommit.sourceManifest.blobOid')
+  hash(sourceManifest.sha256, sha64, 'trialHistory.latestInvalidPrecommit.sourceManifest.sha256')
+  nonEmptyString(sourceManifest.path, 'trialHistory.latestInvalidPrecommit.sourceManifest.path')
+  hash(preregistration.sourceRevision, sha40, 'trialHistory.latestInvalidPrecommit.preregistration.sourceRevision')
+  hash(preregistration.blobOid, sha40, 'trialHistory.latestInvalidPrecommit.preregistration.blobOid')
+  hash(preregistration.sha256, sha64, 'trialHistory.latestInvalidPrecommit.preregistration.sha256')
+  nonEmptyString(preregistration.path, 'trialHistory.latestInvalidPrecommit.preregistration.path')
+  nonEmptyString(naturalBuild.runId, 'trialHistory.latestInvalidPrecommit.naturalBuild.runId')
+  hash(naturalBuild.imageDigest, imageDigest, 'trialHistory.latestInvalidPrecommit.naturalBuild.imageDigest')
+  if (naturalBuild.imagePublished !== true || naturalBuild.deploymentAllowed !== false) {
+    throw new Error('trialHistory.latestInvalidPrecommit.naturalBuild is not contained')
+  }
+  nonEmptyString(release.runId, 'trialHistory.latestInvalidPrecommit.release.runId')
+  if (release.conclusion !== 'CANCELLED' || release.promotionCompleted !== false || release.rerunAllowed !== false) {
+    throw new Error('trialHistory.latestInvalidPrecommit.release is not terminally contained')
+  }
+
+  if (
+    preregistration.sourceRevision !== reviewed.preregistration.sourceRevision ||
+    preregistration.path !== reviewed.preregistration.path ||
+    preregistration.blobOid !== reviewed.preregistration.blobOid ||
+    invalidatedModule.path !== reviewed.modulePath ||
+    invalidatedModule.sha256 !== reviewed.moduleSha256
+  ) {
+    throw new Error('trialHistory.latestInvalidPrecommit does not bind the reviewed preregistration')
+  }
+  return candidateOrdinal
+}
+
+const readBoundedText = async (
+  stream: NodeJS.ReadableStream,
+  maximumBytes: number,
+  onLimit: () => void,
+): Promise<string> =>
+  new Promise((resolveText, rejectText) => {
+    const chunks: Buffer[] = []
+    let totalBytes = 0
+    let settled = false
+    const reject = (error: Error) => {
+      if (settled) return
+      settled = true
+      rejectText(error)
+    }
+    stream.on('data', (chunk: Buffer | string) => {
+      if (settled) return
+      const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
+      totalBytes += bytes.byteLength
+      if (totalBytes > maximumBytes) {
+        onLimit()
+        reject(new Error('authoritative trial-history module output exceeded the bound'))
+        return
+      }
+      chunks.push(bytes)
+    })
+    stream.once('error', (error) => reject(error instanceof Error ? error : new Error(String(error))))
+    stream.once('end', () => {
+      if (settled) return
+      settled = true
+      resolveText(Buffer.concat(chunks, totalBytes).toString('utf8'))
+    })
+  })
+
+export const evaluateQualificationDormancy = (value: unknown): QualificationDormancyDecision => {
+  const history = dataRecord(value, 'trialHistory')
+  const schemaVersion = history.schemaVersion
+  const commonKeys = [
+    'schemaVersion',
+    'completedCandidateOrdinals',
+    'developmentCandidateOrdinals',
+    'latestReviewedCandidateLegacyPriorTrials',
+    'latestReviewedCandidatePriorTrials',
+    'latestTerminalEvidence',
+    'candidatePreregistration',
+    'latestReviewedCandidatePreregistration',
+    'latestDevelopmentEvidence',
+    'nextCandidatePreregistration',
+  ] as const
+  if (schemaVersion === 'bayn.candidate-development-trial-history.v1') exactKeys(history, commonKeys, 'trialHistory')
+  else if (schemaVersion === 'bayn.candidate-development-trial-history.v2') {
+    exactKeys(history, [...commonKeys, 'latestInvalidPrecommit'], 'trialHistory')
+  } else throw new Error('trialHistory.schemaVersion is unsupported')
+
+  const completed = ordinalList(history.completedCandidateOrdinals, 'trialHistory.completedCandidateOrdinals')
+  const development = ordinalList(history.developmentCandidateOrdinals, 'trialHistory.developmentCandidateOrdinals')
+  const combined = [...completed, ...development]
+  if (combined.some((ordinal, index) => ordinal !== index + 1) || development.length === 0) {
+    throw new Error('trialHistory candidate ordinals are incomplete or overlapping')
+  }
+  dataRecord(history.latestReviewedCandidateLegacyPriorTrials, 'trialHistory.latestReviewedCandidateLegacyPriorTrials')
+  dataRecord(history.latestReviewedCandidatePriorTrials, 'trialHistory.latestReviewedCandidatePriorTrials')
+  dataRecord(history.latestTerminalEvidence, 'trialHistory.latestTerminalEvidence')
+  dataRecord(history.candidatePreregistration, 'trialHistory.candidatePreregistration')
+
+  const latestDevelopment = dataRecord(history.latestDevelopmentEvidence, 'trialHistory.latestDevelopmentEvidence')
+  exactKeys(
+    latestDevelopment,
+    [
+      'candidateOrdinal',
+      'priorTrialCount',
+      'status',
+      'evidenceContentHash',
+      'evaluatedSourceRevision',
+      'failureStage',
+      'developmentMetricsObserved',
+      'qualificationAttemptConsumed',
+    ],
+    'trialHistory.latestDevelopmentEvidence',
+  )
+  const latestDevelopmentOrdinal = positiveInteger(
+    latestDevelopment.candidateOrdinal,
+    'trialHistory.latestDevelopmentEvidence.candidateOrdinal',
+  )
+  if (
+    latestDevelopmentOrdinal !== development.at(-1) ||
+    latestDevelopment.priorTrialCount !== latestDevelopmentOrdinal - 1 ||
+    latestDevelopment.status !== 'DEVELOPMENT_REJECTED' ||
+    latestDevelopment.qualificationAttemptConsumed !== false ||
+    typeof latestDevelopment.developmentMetricsObserved !== 'boolean' ||
+    (latestDevelopment.failureStage !== 'buildEvaluation-preflight' &&
+      latestDevelopment.failureStage !== 'development-evaluation')
+  ) {
+    throw new Error('trialHistory.latestDevelopmentEvidence is inconsistent')
+  }
+  hash(latestDevelopment.evidenceContentHash, sha64, 'trialHistory.latestDevelopmentEvidence.evidenceContentHash')
+  hash(
+    latestDevelopment.evaluatedSourceRevision,
+    sha40,
+    'trialHistory.latestDevelopmentEvidence.evaluatedSourceRevision',
+  )
+
+  const reviewed = decodePreregistration(
+    history.latestReviewedCandidatePreregistration,
+    'trialHistory.latestReviewedCandidatePreregistration',
+  )
+  if (
+    reviewed.candidateOrdinal !== latestDevelopmentOrdinal + 1 ||
+    reviewed.priorTrialCount !== latestDevelopmentOrdinal
+  ) {
+    throw new Error('trialHistory.latestReviewedCandidatePreregistration is not the next reviewed ordinal')
+  }
+
+  const invalidOrdinal =
+    schemaVersion === 'bayn.candidate-development-trial-history.v2' && history.latestInvalidPrecommit !== null
+      ? decodeInvalidPrecommit(history.latestInvalidPrecommit, reviewed)
+      : null
+
+  if (history.nextCandidatePreregistration === null) {
+    return invalidOrdinal === null
+      ? { status: 'dormant', reason: 'preregistration-missing', candidateOrdinal: null }
+      : { status: 'dormant', reason: 'precommit-invalid-unattempted', candidateOrdinal: invalidOrdinal }
+  }
+
+  const next = decodePreregistration(history.nextCandidatePreregistration, 'trialHistory.nextCandidatePreregistration')
+  if (canonicalJson(next) !== canonicalJson(reviewed)) {
+    throw new Error('trialHistory.nextCandidatePreregistration is not the separately reviewed preregistration')
+  }
+  if (invalidOrdinal !== null && invalidOrdinal >= next.candidateOrdinal) {
+    throw new Error('trialHistory contains an ambiguous runnable and invalidated candidate state')
+  }
+  return {
+    status: 'ready',
+    reason: 'reviewed-preregistration-present',
+    candidateOrdinal: next.candidateOrdinal,
+    preregistrationSourceRevision: next.preregistration.sourceRevision,
+    preregistrationBlobOid: next.preregistration.blobOid,
+  }
+}
+
+const loadTrialHistoryExport = async (modulePath: string): Promise<unknown> => {
+  const temporaryDirectory = await mkdtemp(join(tmpdir(), 'bayn-qualification-dormancy-'))
+  try {
+    const source = await readFile(modulePath, 'utf8')
+    if (Buffer.byteLength(source, 'utf8') > maximumTrialHistorySourceBytes) {
+      throw new Error('authoritative trial-history source exceeded the bound')
+    }
+    const imports = new Bun.Transpiler({ loader: 'ts' })
+      .scanImports(source)
+      .map(({ kind, path }) => ({ kind, path }))
+      .sort((left, right) => left.path.localeCompare(right.path) || left.kind.localeCompare(right.kind))
+    const allowedImports = [
+      { kind: 'import-statement', path: './candidate-development' },
+      { kind: 'import-statement', path: './hash' },
+    ]
+    if (canonicalJson(imports) !== canonicalJson(allowedImports)) {
+      throw new Error('authoritative trial-history module has unsupported runtime imports')
+    }
+    const build = await Bun.build({
+      entrypoints: [modulePath],
+      outdir: temporaryDirectory,
+      target: 'node',
+      format: 'cjs',
+      sourcemap: 'none',
+      splitting: false,
+      plugins: [
+        {
+          name: 'bayn-qualification-trial-history-isolation',
+          setup(builder) {
+            builder.onResolve({ filter: /.*/ }, (argument) => {
+              if (resolve(argument.importer) !== modulePath) return undefined
+              if (argument.path === './candidate-development') {
+                return { path: 'candidate-development', namespace: 'qualification-trial-history-stub' }
+              }
+              if (argument.path === './hash') return { path: 'hash', namespace: 'qualification-trial-history-stub' }
+              throw new Error(`trial-history module has an unsupported runtime import: ${argument.path}`)
+            })
+            builder.onLoad({ filter: /.*/, namespace: 'qualification-trial-history-stub' }, ({ path }) => ({
+              loader: 'js',
+              contents:
+                path === 'candidate-development'
+                  ? 'export const candidateDevelopmentCalendarContract = Object.freeze({})'
+                  : 'export const canonicalHashV1Result = () => { throw new Error("hashing is unavailable during dormancy verification") }',
+            }))
+          },
+        },
+      ],
+    })
+    if (!build.success || build.outputs.length !== 1) {
+      throw new Error('authoritative trial-history module could not be isolated')
+    }
+    const builtModule = build.outputs[0]?.path
+    if (builtModule === undefined) throw new Error('authoritative trial-history bundle is missing')
+    const runner = join(temporaryDirectory, 'read-trial-history.cjs')
+    await writeFile(
+      runner,
+      [
+        "'use strict'",
+        'const originalSend = process.send?.bind(process)',
+        'const originalDisconnect = process.disconnect.bind(process)',
+        'const stringify = JSON.stringify.bind(JSON)',
+        'const hasOwn = Function.call.bind(Object.prototype.hasOwnProperty)',
+        'const receiveBootstrap = new Promise((resolve, reject) => {',
+        "  process.once('message', resolve)",
+        "  process.once('disconnect', () => reject(new Error('loader IPC disconnected before bootstrap')))",
+        '})',
+        ';(async () => {',
+        "  if (originalSend === undefined) throw new Error('loader IPC is unavailable')",
+        '  const bootstrap = await receiveBootstrap',
+        "  if (typeof bootstrap !== 'object' || bootstrap === null || Array.isArray(bootstrap) || Object.keys(bootstrap).length !== 2 || bootstrap.type !== 'bootstrap' || typeof bootstrap.nonce !== 'string' || !/^[0-9a-f]{64}$/.test(bootstrap.nonce)) throw new Error('loader IPC bootstrap is invalid')",
+        '  const nonce = bootstrap.nonce',
+        "  process.removeAllListeners('message')",
+        "  Object.defineProperty(process, 'send', { value: () => { throw new Error('module IPC is unavailable') }, writable: false, configurable: false })",
+        `  const loaded = require(${JSON.stringify(builtModule)})`,
+        `  if (!hasOwn(loaded, ${JSON.stringify(trialHistoryExport)})) throw new Error('trial-history export is missing')`,
+        `  const payload = stringify(loaded[${JSON.stringify(trialHistoryExport)}])`,
+        "  if (typeof payload !== 'string') throw new Error('trial-history export is not JSON serializable')",
+        "  originalSend({ type: 'result', nonce, payload }, (error) => {",
+        '    if (error) process.exitCode = 1',
+        '    originalDisconnect()',
+        '  })',
+        '})().catch(() => {',
+        "  process.stderr.write('qualification trial-history loader failed\\n')",
+        '  process.exitCode = 1',
+        '  if (process.connected) originalDisconnect()',
+        '})',
+      ].join('\n'),
+      'utf8',
+    )
+    const nodeBinary = Bun.which('node')
+    if (nodeBinary === null) throw new Error('Node.js is unavailable for isolated trial-history evaluation')
+    const nonce = randomBytes(32).toString('hex')
+    let resultPayload: string | null = null
+    let messageFailure: Error | null = null
+    const child = fork(runner, [], {
+      cwd: temporaryDirectory,
+      env: {
+        HOME: temporaryDirectory,
+        TMPDIR: temporaryDirectory,
+        NO_COLOR: '1',
+      },
+      execPath: nodeBinary,
+      execArgv: ['--max-old-space-size=64', '--permission', `--allow-fs-read=${temporaryDirectory}`],
+      stdio: ['ignore', 'ignore', 'pipe', 'ipc'],
+    })
+    child.on('message', (message) => {
+      try {
+        resultPayload = validateQualificationDormancyLoaderMessage(message, nonce, resultPayload)
+      } catch (error) {
+        messageFailure = error instanceof Error ? error : new Error(String(error))
+        child.kill('SIGKILL')
+      }
+    })
+    let timedOut = false
+    const timeout = setTimeout(() => {
+      timedOut = true
+      child.kill('SIGKILL')
+    }, loaderTimeoutMs)
+    const terminateForLimit = () => child.kill('SIGKILL')
+    const sendBootstrap = new Promise<void>((resolveSend, rejectSend) => {
+      child.send({ type: 'bootstrap', nonce }, (error) => {
+        if (error) rejectSend(error)
+        else resolveSend()
+      })
+    })
+    const childExit = new Promise<{ readonly code: number | null; readonly signal: NodeJS.Signals | null }>(
+      (resolveExit) => child.once('close', (code, signal) => resolveExit({ code, signal })),
+    )
+    const stderr = child.stderr
+    if (stderr === null) throw new Error('authoritative trial-history loader stderr is unavailable')
+    const [exitResult, stderrResult, sendResult] = await Promise.allSettled([
+      childExit,
+      readBoundedText(stderr, maximumLoaderOutputBytes, terminateForLimit),
+      sendBootstrap,
+    ])
+    clearTimeout(timeout)
+    if (timedOut) throw new Error('authoritative trial-history module evaluation timed out')
+    if (exitResult.status === 'rejected' || stderrResult.status === 'rejected' || sendResult.status === 'rejected') {
+      throw new Error('authoritative trial-history module output could not be read safely')
+    }
+    if (
+      exitResult.value.code !== 0 ||
+      exitResult.value.signal !== null ||
+      stderrResult.value.length !== 0 ||
+      messageFailure !== null ||
+      resultPayload === null
+    ) {
+      throw new Error('authoritative trial-history module was unloadable')
+    }
+    return JSON.parse(resultPayload) as unknown
+  } finally {
+    await rm(temporaryDirectory, { recursive: true, force: true })
+  }
+}
+
+export const verifyQualificationDormancy = async (repositoryRoot: string): Promise<QualificationDormancyDecision> => {
+  const root = await realpath(repositoryRoot)
+  const expectedModulePath = resolve(root, trialHistoryRelativePath)
+  const modulePath = await realpath(expectedModulePath)
+  if (modulePath !== expectedModulePath || dirname(modulePath) !== resolve(root, 'services/bayn/src')) {
+    throw new Error('authoritative trial-history path is not a regular confined repository path')
+  }
+  return evaluateQualificationDormancy(await loadTrialHistoryExport(modulePath))
+}
+
+const argument = (name: string): string => {
+  const index = process.argv.indexOf(name)
+  const value = index < 0 ? undefined : process.argv[index + 1]
+  if (value === undefined || value.startsWith('--')) throw new Error(`${name} is required`)
+  return value
+}
+
+if (import.meta.main) {
+  try {
+    const repositoryRoot = argument('--repository-root')
+    const githubOutput = argument('--github-output')
+    const decision = await verifyQualificationDormancy(repositoryRoot)
+    await appendFile(
+      githubOutput,
+      [
+        `dormant=${decision.status === 'dormant' ? 'true' : 'false'}`,
+        `reason=${decision.reason}`,
+        `candidate_ordinal=${decision.candidateOrdinal ?? ''}`,
+        '',
+      ].join('\n'),
+      'utf8',
+    )
+    process.stdout.write(`BAYN_QUALIFICATION_DORMANCY=${JSON.stringify(decision)}\n`)
+  } catch (error) {
+    process.stderr.write(
+      `qualification dormancy verification failed: ${error instanceof Error ? error.message : String(error)}\n`,
+    )
+    process.exitCode = 1
+  }
+}

--- a/packages/scripts/src/bayn/verify-qualification-dormancy.ts
+++ b/packages/scripts/src/bayn/verify-qualification-dormancy.ts
@@ -510,7 +510,6 @@ const decodePriorTrials = (
   development: readonly number[],
   latestQualificationEvidence: QualificationEvidence,
   latestQualificationPreregistration: QualificationPreregistration,
-  latestDevelopmentEvidence: LatestDevelopmentEvidence,
 ): PriorTrialsMaterial => {
   const label = 'trialHistory.latestReviewedCandidatePriorTrials'
   const record = dataRecord(value, label)
@@ -553,25 +552,28 @@ const decodePriorTrials = (
     record.developmentCandidateOrdinals,
     `${label}.developmentCandidateOrdinals`,
   )
-  assertSameCanonical(developmentCandidateOrdinals, development, `${label}.developmentCandidateOrdinals`)
+  assertOrdinalRange(developmentCandidateOrdinals, completed.length + 1, `${label}.developmentCandidateOrdinals`)
+  if (
+    developmentCandidateOrdinals.length > development.length ||
+    developmentCandidateOrdinals.some((ordinal, index) => ordinal !== development[index])
+  ) {
+    throw new Error(`${label}.developmentCandidateOrdinals is not a current-history prefix`)
+  }
   const decodedLatestDevelopmentEvidence = decodePriorDevelopmentEvidence(
     record.latestDevelopmentEvidence,
     `${label}.latestDevelopmentEvidence`,
   )
-  const latestDevelopmentPrior: PriorDevelopmentEvidence = {
-    candidateOrdinal: latestDevelopmentEvidence.candidateOrdinal,
-    priorTrialCount: latestDevelopmentEvidence.priorTrialCount,
-    status: latestDevelopmentEvidence.status,
-    evidenceContentHash: latestDevelopmentEvidence.evidenceContentHash,
-    qualificationAttemptConsumed: false,
-  }
-  assertSameCanonical(decodedLatestDevelopmentEvidence, latestDevelopmentPrior, `${label}.latestDevelopmentEvidence`)
   const latestReviewedPreregistration = decodePreregistration(
     record.latestReviewedPreregistration,
     `${label}.latestReviewedPreregistration`,
   )
-  if (latestReviewedPreregistration.candidateOrdinal !== latestDevelopmentEvidence.candidateOrdinal) {
-    throw new Error(`${label}.latestReviewedPreregistration does not bind the latest development ordinal`)
+  const latestOrdinal = developmentCandidateOrdinals.at(-1)
+  if (
+    latestOrdinal === undefined ||
+    decodedLatestDevelopmentEvidence.candidateOrdinal !== latestOrdinal ||
+    latestReviewedPreregistration.candidateOrdinal !== latestOrdinal
+  ) {
+    throw new Error(`${label} does not bind its latest development ordinal`)
   }
   return {
     schemaVersion: 'bayn.candidate-development-prior-trials.v2',
@@ -795,14 +797,17 @@ export const evaluateQualificationDormancy = (value: unknown): QualificationDorm
     throw new Error('trialHistory.latestDevelopmentEvidence does not bind the latest development ordinal')
   }
 
-  decodeLegacyPriorTrials(history.latestReviewedCandidateLegacyPriorTrials, completed, development)
+  const legacyPriorTrials = decodeLegacyPriorTrials(
+    history.latestReviewedCandidateLegacyPriorTrials,
+    completed,
+    development,
+  )
   const latestPriorTrials = decodePriorTrials(
     history.latestReviewedCandidatePriorTrials,
     completed,
     development,
     latestQualificationEvidence,
     latestQualificationPreregistration,
-    latestDevelopment,
   )
 
   const reviewed = decodePreregistration(
@@ -810,20 +815,44 @@ export const evaluateQualificationDormancy = (value: unknown): QualificationDorm
     'trialHistory.latestReviewedCandidatePreregistration',
     true,
   )
+  const hasInvalidPrecommit =
+    schemaVersion === 'bayn.candidate-development-trial-history.v2' && history.latestInvalidPrecommit !== null
+  const expectedReviewedOrdinal =
+    history.nextCandidatePreregistration === null && !hasInvalidPrecommit
+      ? latestDevelopmentOrdinal
+      : latestDevelopmentOrdinal + 1
   if (
-    reviewed.candidateOrdinal !== latestDevelopmentOrdinal + 1 ||
-    reviewed.priorTrialCount !== latestDevelopmentOrdinal
+    reviewed.candidateOrdinal !== expectedReviewedOrdinal ||
+    reviewed.priorTrialCount !== expectedReviewedOrdinal - 1
   ) {
-    throw new Error('trialHistory.latestReviewedCandidatePreregistration is not the next reviewed ordinal')
+    throw new Error('trialHistory.latestReviewedCandidatePreregistration does not bind the reviewed ordinal')
   }
-  if (reviewed.priorTrialsHash !== canonicalHash(latestPriorTrials)) {
+  const selectedPriorTrials = reviewed.candidateOrdinal >= 19 ? latestPriorTrials : legacyPriorTrials
+  const expectedPriorDevelopmentOrdinals = development.filter((ordinal) => ordinal < reviewed.candidateOrdinal)
+  assertSameCanonical(
+    selectedPriorTrials.developmentCandidateOrdinals,
+    expectedPriorDevelopmentOrdinals,
+    'trialHistory reviewed prior-trials development ordinals',
+  )
+  if (reviewed.priorTrialsHash !== canonicalHash(selectedPriorTrials)) {
     throw new Error('trialHistory.latestReviewedCandidatePreregistration does not bind the decoded prior trials')
   }
+  if (reviewed.candidateOrdinal === latestDevelopmentOrdinal + 1) {
+    const latestDevelopmentPrior: PriorDevelopmentEvidence = {
+      candidateOrdinal: latestDevelopment.candidateOrdinal,
+      priorTrialCount: latestDevelopment.priorTrialCount,
+      status: latestDevelopment.status,
+      evidenceContentHash: latestDevelopment.evidenceContentHash,
+      qualificationAttemptConsumed: false,
+    }
+    assertSameCanonical(
+      selectedPriorTrials.latestDevelopmentEvidence,
+      latestDevelopmentPrior,
+      'trialHistory reviewed prior-trials latest development evidence',
+    )
+  }
 
-  const invalidOrdinal =
-    schemaVersion === 'bayn.candidate-development-trial-history.v2' && history.latestInvalidPrecommit !== null
-      ? decodeInvalidPrecommit(history.latestInvalidPrecommit, reviewed)
-      : null
+  const invalidOrdinal = hasInvalidPrecommit ? decodeInvalidPrecommit(history.latestInvalidPrecommit, reviewed) : null
 
   if (history.nextCandidatePreregistration === null) {
     return invalidOrdinal === null

--- a/packages/scripts/src/bayn/verify-qualification-dormancy.ts
+++ b/packages/scripts/src/bayn/verify-qualification-dormancy.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env bun
 
 import { fork } from 'node:child_process'
-import { randomBytes } from 'node:crypto'
+import { createHash, randomBytes } from 'node:crypto'
 import { appendFile, mkdtemp, readFile, realpath, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
@@ -18,16 +18,17 @@ const sha64 = /^[0-9a-f]{64}$/
 const imageDigest = /^sha256:[0-9a-f]{64}$/
 const candidateModulePath = /^services\/bayn\/src\/strategy\/[A-Za-z0-9._/-]+\.ts$/
 const candidatePreregistrationPath = /^services\/bayn\/candidates\/[A-Za-z0-9._/-]+\.json$/
+const qualificationPreregistrationPath = /^services\/bayn\/candidates\/[A-Za-z0-9._/-]+\.(?:json|md)$/
 
 export interface QualificationCandidatePreregistration {
   readonly schemaVersion: 'bayn.candidate-development-next-preregistration.v1'
   readonly candidateOrdinal: number
   readonly priorTrialCount: number
   readonly strategyProtocolHash: string
-  readonly strategyIdentityHash: string
-  readonly candidateDevelopmentProtocolHash: string
-  readonly calendarHash: string
-  readonly priorTrialsHash: string
+  readonly strategyIdentityHash?: string
+  readonly candidateDevelopmentProtocolHash?: string
+  readonly calendarHash?: string
+  readonly priorTrialsHash?: string
   readonly modulePath: string
   readonly moduleSha256: string
   readonly marketData: {
@@ -67,6 +68,19 @@ const exactKeys = (record: Record<string, unknown>, expected: readonly string[],
   const observed = Object.keys(record).sort()
   const required = [...expected].sort()
   if (observed.length !== required.length || observed.some((key, index) => key !== required[index])) {
+    throw new Error(`${label} has an unsupported or incomplete schema`)
+  }
+}
+
+const exactOptionalKeys = (
+  record: Record<string, unknown>,
+  required: readonly string[],
+  optional: readonly string[],
+  label: string,
+): void => {
+  const observed = Object.keys(record)
+  const allowed = new Set([...required, ...optional])
+  if (required.some((key) => !Object.hasOwn(record, key)) || observed.some((key) => !allowed.has(key))) {
     throw new Error(`${label} has an unsupported or incomplete schema`)
   }
 }
@@ -141,26 +155,36 @@ const ordinalList = (value: unknown, label: string): readonly number[] => {
   return output
 }
 
-const decodePreregistration = (value: unknown, label: string): QualificationCandidatePreregistration => {
+const decodePreregistration = (
+  value: unknown,
+  label: string,
+  requireCompleteIdentity = false,
+): QualificationCandidatePreregistration => {
   const record = dataRecord(value, label)
-  exactKeys(
+  const identityKeys = [
+    'strategyIdentityHash',
+    'candidateDevelopmentProtocolHash',
+    'calendarHash',
+    'priorTrialsHash',
+  ] as const
+  exactOptionalKeys(
     record,
     [
       'schemaVersion',
       'candidateOrdinal',
       'priorTrialCount',
       'strategyProtocolHash',
-      'strategyIdentityHash',
-      'candidateDevelopmentProtocolHash',
-      'calendarHash',
-      'priorTrialsHash',
       'modulePath',
       'moduleSha256',
       'marketData',
       'preregistration',
     ],
+    identityKeys,
     label,
   )
+  if (requireCompleteIdentity && identityKeys.some((key) => !Object.hasOwn(record, key))) {
+    throw new Error(`${label} is missing the complete reviewed identity`)
+  }
   if (record.schemaVersion !== 'bayn.candidate-development-next-preregistration.v1') {
     throw new Error(`${label}.schemaVersion is unsupported`)
   }
@@ -189,19 +213,28 @@ const decodePreregistration = (value: unknown, label: string): QualificationCand
     throw new Error(`${label}.preregistration.path is invalid`)
   }
 
+  const strategyIdentityHash = Object.hasOwn(record, 'strategyIdentityHash')
+    ? hash(record.strategyIdentityHash, sha64, `${label}.strategyIdentityHash`)
+    : undefined
+  const candidateDevelopmentProtocolHash = Object.hasOwn(record, 'candidateDevelopmentProtocolHash')
+    ? hash(record.candidateDevelopmentProtocolHash, sha64, `${label}.candidateDevelopmentProtocolHash`)
+    : undefined
+  const calendarHash = Object.hasOwn(record, 'calendarHash')
+    ? hash(record.calendarHash, sha64, `${label}.calendarHash`)
+    : undefined
+  const priorTrialsHash = Object.hasOwn(record, 'priorTrialsHash')
+    ? hash(record.priorTrialsHash, sha64, `${label}.priorTrialsHash`)
+    : undefined
+
   return {
     schemaVersion: 'bayn.candidate-development-next-preregistration.v1',
     candidateOrdinal,
     priorTrialCount,
     strategyProtocolHash: hash(record.strategyProtocolHash, sha64, `${label}.strategyProtocolHash`),
-    strategyIdentityHash: hash(record.strategyIdentityHash, sha64, `${label}.strategyIdentityHash`),
-    candidateDevelopmentProtocolHash: hash(
-      record.candidateDevelopmentProtocolHash,
-      sha64,
-      `${label}.candidateDevelopmentProtocolHash`,
-    ),
-    calendarHash: hash(record.calendarHash, sha64, `${label}.calendarHash`),
-    priorTrialsHash: hash(record.priorTrialsHash, sha64, `${label}.priorTrialsHash`),
+    ...(strategyIdentityHash === undefined ? {} : { strategyIdentityHash }),
+    ...(candidateDevelopmentProtocolHash === undefined ? {} : { candidateDevelopmentProtocolHash }),
+    ...(calendarHash === undefined ? {} : { calendarHash }),
+    ...(priorTrialsHash === undefined ? {} : { priorTrialsHash }),
     modulePath,
     moduleSha256: hash(record.moduleSha256, sha64, `${label}.moduleSha256`),
     marketData: {
@@ -233,6 +266,322 @@ const canonicalJson = (value: unknown): string => {
       .join(',')}}`
   }
   return JSON.stringify(value)
+}
+
+const canonicalHash = (value: unknown): string => createHash('sha256').update(canonicalJson(value)).digest('hex')
+
+interface QualificationEvidence {
+  readonly candidateOrdinal: number
+  readonly priorTrialCount: number
+  readonly terminalStatus: 'HOLD_REJECT'
+  readonly sourceRevision: string
+}
+
+interface QualificationPreregistration {
+  readonly candidateOrdinal: number
+  readonly priorTrialCount: number
+  readonly sourceRevision: string
+  readonly path: string
+  readonly blobOid: string
+}
+
+interface PriorDevelopmentEvidence {
+  readonly candidateOrdinal: number
+  readonly priorTrialCount: number
+  readonly status: 'DEVELOPMENT_REJECTED'
+  readonly evidenceContentHash: string
+  readonly qualificationAttemptConsumed: false
+}
+
+interface LatestDevelopmentEvidence extends PriorDevelopmentEvidence {
+  readonly evaluatedSourceRevision: string
+  readonly reviewedSourceRevision?: string
+  readonly mergedSourceRevision?: string
+  readonly failureStage?: 'buildEvaluation-preflight' | 'development-evaluation'
+  readonly developmentMetricsObserved?: boolean
+}
+
+interface LegacyPriorTrialsMaterial {
+  readonly schemaVersion: 'bayn.candidate-development-prior-trials.v1'
+  readonly qualificationCandidateOrdinals: readonly number[]
+  readonly developmentCandidateOrdinals: readonly number[]
+  readonly latestDevelopmentEvidence: PriorDevelopmentEvidence
+  readonly latestReviewedPreregistration: QualificationCandidatePreregistration
+}
+
+interface PriorTrialsMaterial {
+  readonly schemaVersion: 'bayn.candidate-development-prior-trials.v2'
+  readonly qualificationCandidateOrdinals: readonly number[]
+  readonly latestQualificationEvidence: QualificationEvidence
+  readonly latestQualificationPreregistration: QualificationPreregistration
+  readonly developmentCandidateOrdinals: readonly number[]
+  readonly latestDevelopmentEvidence: PriorDevelopmentEvidence
+  readonly latestReviewedPreregistration: QualificationCandidatePreregistration
+}
+
+const assertSameCanonical = (left: unknown, right: unknown, label: string): void => {
+  if (canonicalJson(left) !== canonicalJson(right)) throw new Error(`${label} is inconsistent`)
+}
+
+const assertOrdinalRange = (ordinals: readonly number[], start: number, label: string): void => {
+  if (ordinals.length === 0 || ordinals.some((ordinal, index) => ordinal !== start + index)) {
+    throw new Error(`${label} is not a contiguous ordinal range`)
+  }
+}
+
+const decodeQualificationEvidence = (value: unknown, label: string): QualificationEvidence => {
+  const record = dataRecord(value, label)
+  exactKeys(record, ['candidateOrdinal', 'priorTrialCount', 'terminalStatus', 'sourceRevision'], label)
+  const candidateOrdinal = positiveInteger(record.candidateOrdinal, `${label}.candidateOrdinal`)
+  const priorTrialCount = nonNegativeInteger(record.priorTrialCount, `${label}.priorTrialCount`)
+  if (candidateOrdinal !== priorTrialCount + 1 || record.terminalStatus !== 'HOLD_REJECT') {
+    throw new Error(`${label} has invalid qualification lineage`)
+  }
+  return {
+    candidateOrdinal,
+    priorTrialCount,
+    terminalStatus: 'HOLD_REJECT',
+    sourceRevision: hash(record.sourceRevision, sha40, `${label}.sourceRevision`),
+  }
+}
+
+const decodeQualificationPreregistration = (value: unknown, label: string): QualificationPreregistration => {
+  const record = dataRecord(value, label)
+  exactKeys(record, ['candidateOrdinal', 'priorTrialCount', 'sourceRevision', 'path', 'blobOid'], label)
+  const candidateOrdinal = positiveInteger(record.candidateOrdinal, `${label}.candidateOrdinal`)
+  const priorTrialCount = nonNegativeInteger(record.priorTrialCount, `${label}.priorTrialCount`)
+  if (candidateOrdinal !== priorTrialCount + 1) throw new Error(`${label} has invalid qualification lineage`)
+  const path = nonEmptyString(record.path, `${label}.path`)
+  if (!qualificationPreregistrationPath.test(path) || path.includes('..')) throw new Error(`${label}.path is invalid`)
+  return {
+    candidateOrdinal,
+    priorTrialCount,
+    sourceRevision: hash(record.sourceRevision, sha40, `${label}.sourceRevision`),
+    path,
+    blobOid: hash(record.blobOid, sha40, `${label}.blobOid`),
+  }
+}
+
+const decodePriorDevelopmentEvidence = (value: unknown, label: string): PriorDevelopmentEvidence => {
+  const record = dataRecord(value, label)
+  exactKeys(
+    record,
+    ['candidateOrdinal', 'priorTrialCount', 'status', 'evidenceContentHash', 'qualificationAttemptConsumed'],
+    label,
+  )
+  const candidateOrdinal = positiveInteger(record.candidateOrdinal, `${label}.candidateOrdinal`)
+  const priorTrialCount = nonNegativeInteger(record.priorTrialCount, `${label}.priorTrialCount`)
+  if (
+    candidateOrdinal !== priorTrialCount + 1 ||
+    record.status !== 'DEVELOPMENT_REJECTED' ||
+    record.qualificationAttemptConsumed !== false
+  ) {
+    throw new Error(`${label} has invalid development lineage`)
+  }
+  return {
+    candidateOrdinal,
+    priorTrialCount,
+    status: 'DEVELOPMENT_REJECTED',
+    evidenceContentHash: hash(record.evidenceContentHash, sha64, `${label}.evidenceContentHash`),
+    qualificationAttemptConsumed: false,
+  }
+}
+
+const decodeLatestDevelopmentEvidence = (value: unknown, label: string): LatestDevelopmentEvidence => {
+  const record = dataRecord(value, label)
+  exactOptionalKeys(
+    record,
+    [
+      'candidateOrdinal',
+      'priorTrialCount',
+      'status',
+      'evidenceContentHash',
+      'evaluatedSourceRevision',
+      'qualificationAttemptConsumed',
+    ],
+    ['reviewedSourceRevision', 'mergedSourceRevision', 'failureStage', 'developmentMetricsObserved'],
+    label,
+  )
+  const prior = decodePriorDevelopmentEvidence(
+    {
+      candidateOrdinal: record.candidateOrdinal,
+      priorTrialCount: record.priorTrialCount,
+      status: record.status,
+      evidenceContentHash: record.evidenceContentHash,
+      qualificationAttemptConsumed: record.qualificationAttemptConsumed,
+    },
+    label,
+  )
+  const reviewedSourceRevision = Object.hasOwn(record, 'reviewedSourceRevision')
+    ? hash(record.reviewedSourceRevision, sha40, `${label}.reviewedSourceRevision`)
+    : undefined
+  const mergedSourceRevision = Object.hasOwn(record, 'mergedSourceRevision')
+    ? hash(record.mergedSourceRevision, sha40, `${label}.mergedSourceRevision`)
+    : undefined
+  const failureStage = Object.hasOwn(record, 'failureStage')
+    ? record.failureStage === 'buildEvaluation-preflight' || record.failureStage === 'development-evaluation'
+      ? record.failureStage
+      : (() => {
+          throw new Error(`${label}.failureStage is unsupported`)
+        })()
+    : undefined
+  const developmentMetricsObserved = Object.hasOwn(record, 'developmentMetricsObserved')
+    ? typeof record.developmentMetricsObserved === 'boolean'
+      ? record.developmentMetricsObserved
+      : (() => {
+          throw new Error(`${label}.developmentMetricsObserved must be boolean`)
+        })()
+    : undefined
+  return {
+    ...prior,
+    evaluatedSourceRevision: hash(record.evaluatedSourceRevision, sha40, `${label}.evaluatedSourceRevision`),
+    ...(reviewedSourceRevision === undefined ? {} : { reviewedSourceRevision }),
+    ...(mergedSourceRevision === undefined ? {} : { mergedSourceRevision }),
+    ...(failureStage === undefined ? {} : { failureStage }),
+    ...(developmentMetricsObserved === undefined ? {} : { developmentMetricsObserved }),
+  }
+}
+
+const decodeLegacyPriorTrials = (
+  value: unknown,
+  completed: readonly number[],
+  development: readonly number[],
+): LegacyPriorTrialsMaterial => {
+  const label = 'trialHistory.latestReviewedCandidateLegacyPriorTrials'
+  const record = dataRecord(value, label)
+  exactKeys(
+    record,
+    [
+      'schemaVersion',
+      'qualificationCandidateOrdinals',
+      'developmentCandidateOrdinals',
+      'latestDevelopmentEvidence',
+      'latestReviewedPreregistration',
+    ],
+    label,
+  )
+  if (record.schemaVersion !== 'bayn.candidate-development-prior-trials.v1') {
+    throw new Error(`${label}.schemaVersion is unsupported`)
+  }
+  const qualificationCandidateOrdinals = ordinalList(
+    record.qualificationCandidateOrdinals,
+    `${label}.qualificationCandidateOrdinals`,
+  )
+  assertSameCanonical(qualificationCandidateOrdinals, completed, `${label}.qualificationCandidateOrdinals`)
+  const developmentCandidateOrdinals = ordinalList(
+    record.developmentCandidateOrdinals,
+    `${label}.developmentCandidateOrdinals`,
+  )
+  assertOrdinalRange(developmentCandidateOrdinals, completed.length + 1, `${label}.developmentCandidateOrdinals`)
+  if (
+    developmentCandidateOrdinals.length > development.length ||
+    developmentCandidateOrdinals.some((ordinal, index) => ordinal !== development[index])
+  ) {
+    throw new Error(`${label}.developmentCandidateOrdinals is not a current-history prefix`)
+  }
+  const latestDevelopmentEvidence = decodePriorDevelopmentEvidence(
+    record.latestDevelopmentEvidence,
+    `${label}.latestDevelopmentEvidence`,
+  )
+  const latestReviewedPreregistration = decodePreregistration(
+    record.latestReviewedPreregistration,
+    `${label}.latestReviewedPreregistration`,
+  )
+  const latestOrdinal = developmentCandidateOrdinals.at(-1)
+  if (
+    latestOrdinal === undefined ||
+    latestDevelopmentEvidence.candidateOrdinal !== latestOrdinal ||
+    latestReviewedPreregistration.candidateOrdinal !== latestOrdinal
+  ) {
+    throw new Error(`${label} does not bind its latest development ordinal`)
+  }
+  return {
+    schemaVersion: 'bayn.candidate-development-prior-trials.v1',
+    qualificationCandidateOrdinals,
+    developmentCandidateOrdinals,
+    latestDevelopmentEvidence,
+    latestReviewedPreregistration,
+  }
+}
+
+const decodePriorTrials = (
+  value: unknown,
+  completed: readonly number[],
+  development: readonly number[],
+  latestQualificationEvidence: QualificationEvidence,
+  latestQualificationPreregistration: QualificationPreregistration,
+  latestDevelopmentEvidence: LatestDevelopmentEvidence,
+): PriorTrialsMaterial => {
+  const label = 'trialHistory.latestReviewedCandidatePriorTrials'
+  const record = dataRecord(value, label)
+  exactKeys(
+    record,
+    [
+      'schemaVersion',
+      'qualificationCandidateOrdinals',
+      'latestQualificationEvidence',
+      'latestQualificationPreregistration',
+      'developmentCandidateOrdinals',
+      'latestDevelopmentEvidence',
+      'latestReviewedPreregistration',
+    ],
+    label,
+  )
+  if (record.schemaVersion !== 'bayn.candidate-development-prior-trials.v2') {
+    throw new Error(`${label}.schemaVersion is unsupported`)
+  }
+  const qualificationCandidateOrdinals = ordinalList(
+    record.qualificationCandidateOrdinals,
+    `${label}.qualificationCandidateOrdinals`,
+  )
+  assertSameCanonical(qualificationCandidateOrdinals, completed, `${label}.qualificationCandidateOrdinals`)
+  const decodedQualificationEvidence = decodeQualificationEvidence(
+    record.latestQualificationEvidence,
+    `${label}.latestQualificationEvidence`,
+  )
+  const decodedQualificationPreregistration = decodeQualificationPreregistration(
+    record.latestQualificationPreregistration,
+    `${label}.latestQualificationPreregistration`,
+  )
+  assertSameCanonical(decodedQualificationEvidence, latestQualificationEvidence, `${label}.latestQualificationEvidence`)
+  assertSameCanonical(
+    decodedQualificationPreregistration,
+    latestQualificationPreregistration,
+    `${label}.latestQualificationPreregistration`,
+  )
+  const developmentCandidateOrdinals = ordinalList(
+    record.developmentCandidateOrdinals,
+    `${label}.developmentCandidateOrdinals`,
+  )
+  assertSameCanonical(developmentCandidateOrdinals, development, `${label}.developmentCandidateOrdinals`)
+  const decodedLatestDevelopmentEvidence = decodePriorDevelopmentEvidence(
+    record.latestDevelopmentEvidence,
+    `${label}.latestDevelopmentEvidence`,
+  )
+  const latestDevelopmentPrior: PriorDevelopmentEvidence = {
+    candidateOrdinal: latestDevelopmentEvidence.candidateOrdinal,
+    priorTrialCount: latestDevelopmentEvidence.priorTrialCount,
+    status: latestDevelopmentEvidence.status,
+    evidenceContentHash: latestDevelopmentEvidence.evidenceContentHash,
+    qualificationAttemptConsumed: false,
+  }
+  assertSameCanonical(decodedLatestDevelopmentEvidence, latestDevelopmentPrior, `${label}.latestDevelopmentEvidence`)
+  const latestReviewedPreregistration = decodePreregistration(
+    record.latestReviewedPreregistration,
+    `${label}.latestReviewedPreregistration`,
+  )
+  if (latestReviewedPreregistration.candidateOrdinal !== latestDevelopmentEvidence.candidateOrdinal) {
+    throw new Error(`${label}.latestReviewedPreregistration does not bind the latest development ordinal`)
+  }
+  return {
+    schemaVersion: 'bayn.candidate-development-prior-trials.v2',
+    qualificationCandidateOrdinals,
+    latestQualificationEvidence: decodedQualificationEvidence,
+    latestQualificationPreregistration: decodedQualificationPreregistration,
+    developmentCandidateOrdinals,
+    latestDevelopmentEvidence: decodedLatestDevelopmentEvidence,
+    latestReviewedPreregistration,
+  }
 }
 
 const decodeInvalidPrecommit = (value: unknown, reviewed: QualificationCandidatePreregistration): number => {
@@ -417,61 +766,58 @@ export const evaluateQualificationDormancy = (value: unknown): QualificationDorm
 
   const completed = ordinalList(history.completedCandidateOrdinals, 'trialHistory.completedCandidateOrdinals')
   const development = ordinalList(history.developmentCandidateOrdinals, 'trialHistory.developmentCandidateOrdinals')
-  const combined = [...completed, ...development]
-  if (combined.some((ordinal, index) => ordinal !== index + 1) || development.length === 0) {
-    throw new Error('trialHistory candidate ordinals are incomplete or overlapping')
-  }
-  dataRecord(history.latestReviewedCandidateLegacyPriorTrials, 'trialHistory.latestReviewedCandidateLegacyPriorTrials')
-  dataRecord(history.latestReviewedCandidatePriorTrials, 'trialHistory.latestReviewedCandidatePriorTrials')
-  dataRecord(history.latestTerminalEvidence, 'trialHistory.latestTerminalEvidence')
-  dataRecord(history.candidatePreregistration, 'trialHistory.candidatePreregistration')
+  assertOrdinalRange(completed, 1, 'trialHistory.completedCandidateOrdinals')
+  assertOrdinalRange(development, completed.length + 1, 'trialHistory.developmentCandidateOrdinals')
 
-  const latestDevelopment = dataRecord(history.latestDevelopmentEvidence, 'trialHistory.latestDevelopmentEvidence')
-  exactKeys(
-    latestDevelopment,
-    [
-      'candidateOrdinal',
-      'priorTrialCount',
-      'status',
-      'evidenceContentHash',
-      'evaluatedSourceRevision',
-      'failureStage',
-      'developmentMetricsObserved',
-      'qualificationAttemptConsumed',
-    ],
+  const latestQualificationEvidence = decodeQualificationEvidence(
+    history.latestTerminalEvidence,
+    'trialHistory.latestTerminalEvidence',
+  )
+  const latestQualificationPreregistration = decodeQualificationPreregistration(
+    history.candidatePreregistration,
+    'trialHistory.candidatePreregistration',
+  )
+  const latestCompletedOrdinal = completed.at(-1)
+  if (
+    latestCompletedOrdinal === undefined ||
+    latestQualificationEvidence.candidateOrdinal !== latestCompletedOrdinal ||
+    latestQualificationPreregistration.candidateOrdinal !== latestCompletedOrdinal
+  ) {
+    throw new Error('trialHistory qualification records do not bind the latest completed ordinal')
+  }
+
+  const latestDevelopment = decodeLatestDevelopmentEvidence(
+    history.latestDevelopmentEvidence,
     'trialHistory.latestDevelopmentEvidence',
   )
-  const latestDevelopmentOrdinal = positiveInteger(
-    latestDevelopment.candidateOrdinal,
-    'trialHistory.latestDevelopmentEvidence.candidateOrdinal',
-  )
-  if (
-    latestDevelopmentOrdinal !== development.at(-1) ||
-    latestDevelopment.priorTrialCount !== latestDevelopmentOrdinal - 1 ||
-    latestDevelopment.status !== 'DEVELOPMENT_REJECTED' ||
-    latestDevelopment.qualificationAttemptConsumed !== false ||
-    typeof latestDevelopment.developmentMetricsObserved !== 'boolean' ||
-    (latestDevelopment.failureStage !== 'buildEvaluation-preflight' &&
-      latestDevelopment.failureStage !== 'development-evaluation')
-  ) {
-    throw new Error('trialHistory.latestDevelopmentEvidence is inconsistent')
+  const latestDevelopmentOrdinal = development.at(-1)
+  if (latestDevelopmentOrdinal === undefined || latestDevelopment.candidateOrdinal !== latestDevelopmentOrdinal) {
+    throw new Error('trialHistory.latestDevelopmentEvidence does not bind the latest development ordinal')
   }
-  hash(latestDevelopment.evidenceContentHash, sha64, 'trialHistory.latestDevelopmentEvidence.evidenceContentHash')
-  hash(
-    latestDevelopment.evaluatedSourceRevision,
-    sha40,
-    'trialHistory.latestDevelopmentEvidence.evaluatedSourceRevision',
+
+  decodeLegacyPriorTrials(history.latestReviewedCandidateLegacyPriorTrials, completed, development)
+  const latestPriorTrials = decodePriorTrials(
+    history.latestReviewedCandidatePriorTrials,
+    completed,
+    development,
+    latestQualificationEvidence,
+    latestQualificationPreregistration,
+    latestDevelopment,
   )
 
   const reviewed = decodePreregistration(
     history.latestReviewedCandidatePreregistration,
     'trialHistory.latestReviewedCandidatePreregistration',
+    true,
   )
   if (
     reviewed.candidateOrdinal !== latestDevelopmentOrdinal + 1 ||
     reviewed.priorTrialCount !== latestDevelopmentOrdinal
   ) {
     throw new Error('trialHistory.latestReviewedCandidatePreregistration is not the next reviewed ordinal')
+  }
+  if (reviewed.priorTrialsHash !== canonicalHash(latestPriorTrials)) {
+    throw new Error('trialHistory.latestReviewedCandidatePreregistration does not bind the decoded prior trials')
   }
 
   const invalidOrdinal =
@@ -485,7 +831,11 @@ export const evaluateQualificationDormancy = (value: unknown): QualificationDorm
       : { status: 'dormant', reason: 'precommit-invalid-unattempted', candidateOrdinal: invalidOrdinal }
   }
 
-  const next = decodePreregistration(history.nextCandidatePreregistration, 'trialHistory.nextCandidatePreregistration')
+  const next = decodePreregistration(
+    history.nextCandidatePreregistration,
+    'trialHistory.nextCandidatePreregistration',
+    true,
+  )
   if (canonicalJson(next) !== canonicalJson(reviewed)) {
     throw new Error('trialHistory.nextCandidatePreregistration is not the separately reviewed preregistration')
   }

--- a/packages/scripts/src/bayn/verify-qualification-dormancy.ts
+++ b/packages/scripts/src/bayn/verify-qualification-dormancy.ts
@@ -418,20 +418,31 @@ const decodeLatestDevelopmentEvidence = (value: unknown, label: string): LatestD
   const mergedSourceRevision = Object.hasOwn(record, 'mergedSourceRevision')
     ? hash(record.mergedSourceRevision, sha40, `${label}.mergedSourceRevision`)
     : undefined
-  const failureStage = Object.hasOwn(record, 'failureStage')
+  const hasFailureStage = Object.hasOwn(record, 'failureStage')
+  const hasDevelopmentMetricsObserved = Object.hasOwn(record, 'developmentMetricsObserved')
+  if (hasFailureStage !== hasDevelopmentMetricsObserved) {
+    throw new Error(`${label} failure stage and metric observation must be recorded together`)
+  }
+  const failureStage = hasFailureStage
     ? record.failureStage === 'buildEvaluation-preflight' || record.failureStage === 'development-evaluation'
       ? record.failureStage
       : (() => {
           throw new Error(`${label}.failureStage is unsupported`)
         })()
     : undefined
-  const developmentMetricsObserved = Object.hasOwn(record, 'developmentMetricsObserved')
+  const developmentMetricsObserved = hasDevelopmentMetricsObserved
     ? typeof record.developmentMetricsObserved === 'boolean'
       ? record.developmentMetricsObserved
       : (() => {
           throw new Error(`${label}.developmentMetricsObserved must be boolean`)
         })()
     : undefined
+  if (
+    (failureStage === 'buildEvaluation-preflight' && developmentMetricsObserved !== false) ||
+    (failureStage === 'development-evaluation' && developmentMetricsObserved !== true)
+  ) {
+    throw new Error(`${label} failure stage contradicts metric observation`)
+  }
   return {
     ...prior,
     evaluatedSourceRevision: hash(record.evaluatedSourceRevision, sha40, `${label}.evaluatedSourceRevision`),


### PR DESCRIPTION
## Summary

- replace the scheduled qualification workflow's stale source-text grep with a strict typed decision from the authoritative immutable candidate-development trial-history export
- treat absent preregistration and exact `PRECOMMIT_INVALID` / `UNATTEMPTED` containment as a clean no-op before image binding or privileged inputs
- isolate trial-history loading in a permission-restricted Node child and authorize only one nonce-authenticated, strictly decoded IPC result; forged stdout, malformed IPC, unsupported imports, unloadable evidence, and ambiguous state fail closed
- require the explicit authenticated `dormant == 'false'` output before every image, preflight, secret-bearing, qualification, artifact, or summary step

## Reproduction evidence

- scheduled run `30663500369` reached image binding because the old workflow searched the obsolete calendar source
- exact containment head `c907e601980941785340cc1cf33dcd34b962e439` now evaluates to `dormant=true`, reason `precommit-invalid-unattempted`, candidate ordinal `20`
- exact base `2aa782001a9d7e1d9db68e5fa0929159755334cd` evaluates its separately reviewed non-null Candidate 20 preregistration as runnable
- no Candidate, calendar, trial-history, strategy, manifest, policy, permission, broker, PAPER, or capital files changed

## Validation

- focused dormancy/workflow: 17 passed, 0 failed
- authenticated IPC stress: 20 consecutive focused runs passed
- Bayn scripts: 330 passed, 0 failed
- Bayn full: 1,178 passed, 149 PostgreSQL-gated skipped, 0 failed
- TypeScript, Effect diagnostics, Oxfmt, Oxlint, type-aware Oxlint, build, and commit hooks passed
- hosted PostgreSQL 18 integration remains required because this workspace has no local PostgreSQL or Docker service

## Sequencing and safety

- PROOMPT-445 must merge before #13442 rebases
- PROOMPT-443 continues to block image publication and deployment
- no Candidate 20/21 execution, holdout/result access, manual workflow dispatch, rerun, release unblocking, or direct deployment was performed
