### PR TITLE
fix(bayn): bind reviewed release lineage

### DIFF
--- a/packages/scripts/src/bayn/verify-release-review.test.ts
+++ b/packages/scripts/src/bayn/verify-release-review.test.ts
@@ -495,7 +495,8 @@ const remediationHistoryFixture = (): {
   const record = structuredClone(realRemediationRecord)
   if (
     record.schemaVersion === 'bayn.release-review-remediation.v4' ||
-    record.schemaVersion === 'bayn.release-review-remediation.v5'
+    record.schemaVersion === 'bayn.release-review-remediation.v5' ||
+    record.schemaVersion === 'bayn.release-review-remediation.v6'
   ) {
     throw new Error('expected a legacy remediation record')
   }
@@ -1723,9 +1724,19 @@ const continuousRemediationFixture = (): {
   readonly snapshot: BaynReleaseEligibilitySnapshot
   readonly evidence: BaynReleaseReviewRemediationEvidence
 } => {
-  const record = structuredClone(realContinuousRemediationRecord)
+  const currentRecord = structuredClone(realContinuousRemediationRecord)
+  if (currentRecord.schemaVersion !== 'bayn.release-review-remediation.v6') {
+    throw new Error('expected a v6 continuous-source remediation record')
+  }
+  const record = parseBaynReleaseReviewRemediationRecord({
+    schemaVersion: 'bayn.release-review-remediation.v5',
+    remediationId: currentRecord.remediationId,
+    blocked: currentRecord.blocked,
+    requiredDescendants: [],
+    introduction: currentRecord.introduction,
+  })
   if (record.schemaVersion !== 'bayn.release-review-remediation.v5') {
-    throw new Error('expected a v5 continuous-source remediation record')
+    throw new Error('failed to derive the v5 continuous-source fixture')
   }
   const blockedPull: PullRequestReviewState = {
     number: 13426,
@@ -1996,10 +2007,199 @@ const evaluateContinuousRemediationFixture = (
     pushBeforeSha: continuousHistory.introductionMerge,
   })
 
+const successorBoundHistory = {
+  updateHead: '4'.repeat(40),
+  updateMerge: '9'.repeat(40),
+} as const
+const successorBoundNowMs = Date.parse('2026-08-01T09:02:00Z')
+
+const successorBoundContinuousRemediationFixture = (): {
+  readonly snapshot: BaynReleaseEligibilitySnapshot
+  readonly evidence: BaynReleaseReviewRemediationEvidence
+} => {
+  const fixture = continuousRemediationFixture()
+  const comparison = fixture.snapshot.comparison
+  if (comparison === null || comparison.status !== 'ahead') throw new Error('missing continuous-source comparison')
+  const record = structuredClone(realContinuousRemediationRecord)
+  if (record.schemaVersion !== 'bayn.release-review-remediation.v6') {
+    throw new Error('expected a v6 continuous-source remediation record')
+  }
+
+  const blockedCommit = comparison.commits.find((commit) => commit.sha === record.blocked.mergeCommitSha)
+  const blockedPull = blockedCommit?.reviewSnapshot?.pullRequest
+  if (blockedPull === null || blockedPull === undefined) throw new Error('missing blocked source pull request')
+  ;(record.blocked as unknown as { sourcePullRequestEvidenceSha256: string }).sourcePullRequestEvidenceSha256 =
+    pullRequestReviewEvidenceSha256(blockedPull)
+
+  const successor = record.requiredSuccessors[0]
+  const successorReviewSnapshot = reviewSnapshotFor({
+    commitSha: successor.mergeCommitSha,
+    prNumber: successor.sourcePullRequestNumber,
+    headSha: successor.finalHeadSha,
+    parents: [successor.mergeParentSha],
+    mergedAt: '2026-07-31T21:12:49Z',
+    reviews: [
+      review({
+        commitSha: successor.finalHeadSha,
+        submittedAt: '2026-07-31T21:11:02Z',
+      }),
+    ],
+  })
+  const successorPull = successorReviewSnapshot.pullRequest
+  if (successorPull === null) throw new Error('missing successor pull request')
+  ;(successor as unknown as { sourcePullRequestEvidenceSha256: string }).sourcePullRequestEvidenceSha256 =
+    pullRequestReviewEvidenceSha256(successorPull)
+  const successorCommit = {
+    sha: successor.mergeCommitSha,
+    parents: [successor.mergeParentSha],
+    treeSha: successor.mergeTreeSha,
+    files: successor.affectedPaths.map((path) => path.path),
+    fileChanges: successor.affectedPaths.map((path) => ({ ...path })),
+    reviewSnapshot: successorReviewSnapshot,
+  }
+
+  const completion = record.completion
+  const completionReviewSnapshot = reviewSnapshotFor({
+    commitSha: completion.mergeCommitSha,
+    prNumber: completion.sourcePullRequestNumber,
+    headSha: completion.finalHeadSha,
+    parents: [completion.mergeParentSha],
+    mergedAt: '2026-08-01T08:31:00Z',
+    reviews: [
+      review({
+        commitSha: completion.finalHeadSha,
+        submittedAt: '2026-08-01T08:30:00Z',
+      }),
+    ],
+  })
+  const completionPull = completionReviewSnapshot.pullRequest
+  if (completionPull === null) throw new Error('missing completion pull request')
+  ;(completion as unknown as { sourcePullRequestEvidenceSha256: string }).sourcePullRequestEvidenceSha256 =
+    pullRequestReviewEvidenceSha256(completionPull)
+  const completionCommit = {
+    sha: completion.mergeCommitSha,
+    parents: [completion.mergeParentSha],
+    treeSha: completion.mergeTreeSha,
+    files: completion.affectedPaths.map((path) => path.path),
+    fileChanges: completion.affectedPaths.map((path) => ({ ...path })),
+    reviewSnapshot: completionReviewSnapshot,
+  }
+
+  const currentRecordBlobSha = '8'.repeat(40)
+  const updateChanges = [
+    {
+      path: 'packages/scripts/src/bayn/verify-release-review.test.ts',
+      previousPath: null,
+      status: 'modified',
+      blobSha: '1'.repeat(40),
+    },
+    {
+      path: 'packages/scripts/src/bayn/verify-release-review.ts',
+      previousPath: null,
+      status: 'modified',
+      blobSha: '2'.repeat(40),
+    },
+    {
+      path: continuousRemediationRecordPath,
+      previousPath: null,
+      status: 'modified',
+      blobSha: currentRecordBlobSha,
+    },
+  ] as const
+  const updateCommit = {
+    sha: successorBoundHistory.updateMerge,
+    parents: [completion.mergeCommitSha],
+    treeSha: '3'.repeat(40),
+    files: updateChanges.map((path) => path.path),
+    fileChanges: updateChanges,
+    reviewSnapshot: reviewSnapshotFor({
+      commitSha: successorBoundHistory.updateMerge,
+      prNumber: 13446,
+      headSha: successorBoundHistory.updateHead,
+      parents: [completion.mergeCommitSha],
+      mergedAt: '2026-08-01T09:01:00Z',
+      reviews: [
+        review({
+          commitSha: successorBoundHistory.updateHead,
+          submittedAt: '2026-08-01T09:00:00Z',
+        }),
+      ],
+    }),
+  }
+
+  const commits = comparison.commits
+    .map((commit) => {
+      if (commit.sha === successor.mergeCommitSha) return successorCommit
+      if (commit.sha === continuousHistory.completionMerge) return completionCommit
+      return commit
+    })
+    .concat(updateCommit)
+  const expectedCurrentBlobs = new Map(record.blocked.affectedPaths.map((path) => [path.path, path.blobSha] as const))
+  for (const transition of successor.protectedPathTransitions) {
+    expectedCurrentBlobs.set(transition.path, transition.afterBlobSha)
+  }
+  const evidence: BaynReleaseReviewRemediationEvidence = {
+    recordPath: continuousRemediationRecordPath,
+    recordBlobSha: currentRecordBlobSha,
+    record,
+    referencedCommits: [
+      fixture.evidence.referencedCommits[0]!,
+      {
+        sha: successor.finalHeadSha,
+        parents: [successor.finalHeadParentSha],
+        treeSha: successor.finalHeadTreeSha,
+        files: successor.affectedPaths.map((path) => path.path),
+        fileChanges: successor.affectedPaths.map((path) => ({ ...path })),
+        pathBlobs: successor.affectedPaths.map((path) => ({ path: path.path, blobSha: path.blobSha })),
+      },
+      fixture.evidence.referencedCommits[1]!,
+      {
+        sha: completion.finalHeadSha,
+        parents: [completion.finalHeadParentSha],
+        treeSha: completion.finalHeadTreeSha,
+        files: completion.affectedPaths.map((path) => path.path),
+        fileChanges: completion.affectedPaths.map((path) => ({ ...path })),
+        pathBlobs: completion.affectedPaths.map((path) => ({ path: path.path, blobSha: path.blobSha })),
+      },
+    ],
+    currentPathBlobs: [...expectedCurrentBlobs].map(([path, blobSha]) => ({ path, blobSha })),
+  }
+  return {
+    evidence,
+    snapshot: {
+      ...fixture.snapshot,
+      currentCommitParents: [completion.mergeCommitSha],
+      comparison: {
+        ...comparison,
+        headSha: successorBoundHistory.updateMerge,
+        aheadBy: commits.length,
+        totalCommits: commits.length,
+        commits,
+      },
+      remediations: [evidence],
+    },
+  }
+}
+
+const evaluateSuccessorBoundContinuousRemediationFixture = (
+  fixture: ReturnType<typeof successorBoundContinuousRemediationFixture>,
+  nowMs = successorBoundNowMs,
+) =>
+  evaluateBaynReleaseEligibility({
+    mainCommitSha: successorBoundHistory.updateMerge,
+    baseRefName: 'main',
+    snapshot: fixture.snapshot,
+    nowMs,
+    pushBeforeSha:
+      realContinuousRemediationRecord.schemaVersion === 'bayn.release-review-remediation.v6'
+        ? realContinuousRemediationRecord.completion.mergeCommitSha
+        : '0'.repeat(40),
+  })
+
 describe('Bayn publication-range eligibility', () => {
-  test('parses the exact immutable #13426 continuous-source v5 receipt with #13443 completion', () => {
+  test('parses the exact immutable #13426 continuous-source v6 receipt with reviewed successor and completion', () => {
     expect(realContinuousRemediationRecord).toMatchObject({
-      schemaVersion: 'bayn.release-review-remediation.v5',
+      schemaVersion: 'bayn.release-review-remediation.v6',
       remediationId: 'pr-13426-continuous-reviewed-source',
       blocked: {
         mergeCommitSha: continuousHistory.blocked,
@@ -2013,6 +2213,26 @@ describe('Bayn publication-range eligibility', () => {
         affectedPaths: { length: 18 },
       },
       requiredDescendants: [],
+      requiredSuccessors: [
+        {
+          mergeCommitSha: '2aa782001a9d7e1d9db68e5fa0929159755334cd',
+          mergeParentSha: continuousHistory.blocked,
+          mergeTreeSha: '92065c627993e2844f0990eb032a72e41205b77a',
+          sourcePullRequestNumber: 13432,
+          finalHeadSha: 'c1d955f30a6f004916e885d8d5dd61a5eb11ee92',
+          finalHeadParentSha: continuousHistory.blocked,
+          finalHeadTreeSha: '92065c627993e2844f0990eb032a72e41205b77a',
+          sourcePullRequestEvidenceSha256: 'f22e10837d3842354b3a2d986f27813bdc535630e4277006703273c6fc3c56df',
+          affectedPaths: { length: 7 },
+          protectedPathTransitions: [
+            {
+              path: 'services/bayn/src/observe-composition.ts',
+              beforeBlobSha: 'ab38e8303f0d4482a6daeb6dd8f239cfb59d6223',
+              afterBlobSha: 'aaba2e88d64a0bf20d98e18f181abe9b0deb9860',
+            },
+          ],
+        },
+      ],
       introduction: {
         mergeCommitSha: continuousHistory.introductionMerge,
         mergeParentSha: continuousHistory.intermediates.at(-1),
@@ -2025,6 +2245,313 @@ describe('Bayn publication-range eligibility', () => {
         introducedRecordBlobSha: 'dfde09ca935b9df6d48d34391d1cc0e599eab6c7',
         affectedPaths: { length: 3 },
       },
+      completion: {
+        mergeCommitSha: '8f6ab9086457f2a7e1f2147d57e06fc22c9881fc',
+        mergeParentSha: continuousHistory.introductionMerge,
+        mergeTreeSha: 'a51d7d16f0b9806ec2ae71dfa3862e0067d23851',
+        sourcePullRequestNumber: 13445,
+        finalHeadSha: 'c580b4df79290df7c0760c290cafca9a4d4ae315',
+        finalHeadParentSha: continuousHistory.introductionMerge,
+        finalHeadTreeSha: 'a51d7d16f0b9806ec2ae71dfa3862e0067d23851',
+        sourcePullRequestEvidenceSha256: '729f0f5c8208f284b889e97a8da90ac7aac02fffb3cb3880abc4d156cf459967',
+        completedRecordBlobSha: '5faaf371424c183a176b3659fc8108576d136b84',
+        affectedPaths: { length: 3 },
+      },
+    })
+  })
+
+  test('accepts the v6 receipt only with its exact reviewed successor, protected transition, completion, and update', () => {
+    const fixture = successorBoundContinuousRemediationFixture()
+    expect(evaluateSuccessorBoundContinuousRemediationFixture(fixture)).toMatchObject({
+      status: 'eligible',
+      lastPublishedRevision: continuousHistory.published,
+      checkedCommitCount: 8,
+      baynAffectingCommitCount: 5,
+      reviewedPullRequests: [
+        { commitSha: continuousHistory.blocked, prNumber: 13426, headSha: continuousHistory.finalHead },
+        { commitSha: '2aa782001a9d7e1d9db68e5fa0929159755334cd', prNumber: 13432 },
+        { commitSha: continuousHistory.introductionMerge, prNumber: 13443 },
+        { commitSha: '8f6ab9086457f2a7e1f2147d57e06fc22c9881fc', prNumber: 13445 },
+        { commitSha: successorBoundHistory.updateMerge, prNumber: 13446 },
+      ],
+    })
+  })
+
+  test('carries the v6 reaction-bound completion review into the publication-range decision', () => {
+    const fixture = successorBoundContinuousRemediationFixture()
+    const record = fixture.evidence.record
+    if (record.schemaVersion !== 'bayn.release-review-remediation.v6') throw new Error('expected v6 record')
+    const completion = fixture.snapshot.comparison?.commits.find(
+      (commit) => commit.sha === record.completion.mergeCommitSha,
+    )
+    const pullRequest = completion?.reviewSnapshot?.pullRequest
+    if (pullRequest === null || pullRequest === undefined) throw new Error('missing completion pull request')
+    ;(pullRequest as unknown as { reviews: PullRequestReview[] }).reviews = []
+    ;(pullRequest as unknown as { headForcePushes: PullRequestForcePush[] }).headForcePushes = [
+      {
+        actorLogin: 'gregkonush',
+        beforeCommitSha: '5'.repeat(40),
+        afterCommitSha: record.completion.finalHeadSha,
+        createdAt: '2026-08-01T08:30:10Z',
+      },
+    ]
+    ;(pullRequest as unknown as { headForcePushCount: number }).headForcePushCount = 1
+    ;(pullRequest as unknown as { reactions: PullRequestReaction[] }).reactions = [
+      reaction({ createdAt: '2026-08-01T08:30:20Z' }),
+    ]
+    ;(record.completion as unknown as { sourcePullRequestEvidenceSha256: string }).sourcePullRequestEvidenceSha256 =
+      pullRequestReviewEvidenceSha256(pullRequest)
+
+    const evaluation = evaluateSuccessorBoundContinuousRemediationFixture(fixture)
+    expect(evaluation).toMatchObject({ status: 'eligible' })
+    if (evaluation.status !== 'eligible') throw new Error('expected eligible publication range')
+    expect(
+      evaluation.reviewedPullRequests.find(
+        (reviewedPullRequest) => reviewedPullRequest.commitSha === record.completion.mergeCommitSha,
+      ),
+    ).toMatchObject({
+      prNumber: record.completion.sourcePullRequestNumber,
+      headSha: record.completion.finalHeadSha,
+      reviewSubmittedAt: '2026-08-01T08:30:20Z',
+    })
+  })
+
+  test('carries the v6 reaction-bound successor review into the publication-range decision', () => {
+    const fixture = successorBoundContinuousRemediationFixture()
+    const record = fixture.evidence.record
+    if (record.schemaVersion !== 'bayn.release-review-remediation.v6') throw new Error('expected v6 record')
+    const successorIdentity = record.requiredSuccessors[0]
+    const successor = fixture.snapshot.comparison?.commits.find(
+      (commit) => commit.sha === successorIdentity.mergeCommitSha,
+    )
+    const pullRequest = successor?.reviewSnapshot?.pullRequest
+    if (pullRequest === null || pullRequest === undefined) throw new Error('missing successor pull request')
+    ;(pullRequest as unknown as { reviews: PullRequestReview[] }).reviews = []
+    ;(pullRequest as unknown as { headForcePushes: PullRequestForcePush[] }).headForcePushes = [
+      {
+        actorLogin: 'gregkonush',
+        beforeCommitSha: '6'.repeat(40),
+        afterCommitSha: successorIdentity.finalHeadSha,
+        createdAt: '2026-07-31T21:12:00Z',
+      },
+    ]
+    ;(pullRequest as unknown as { headForcePushCount: number }).headForcePushCount = 1
+    ;(pullRequest as unknown as { reactions: PullRequestReaction[] }).reactions = [
+      reaction({ createdAt: '2026-07-31T21:12:10Z' }),
+    ]
+    ;(successorIdentity as unknown as { sourcePullRequestEvidenceSha256: string }).sourcePullRequestEvidenceSha256 =
+      pullRequestReviewEvidenceSha256(pullRequest)
+
+    const evaluation = evaluateSuccessorBoundContinuousRemediationFixture(fixture)
+    expect(evaluation).toMatchObject({ status: 'eligible' })
+    if (evaluation.status !== 'eligible') throw new Error('expected eligible publication range')
+    expect(
+      evaluation.reviewedPullRequests.find(
+        (reviewedPullRequest) => reviewedPullRequest.commitSha === successorIdentity.mergeCommitSha,
+      ),
+    ).toMatchObject({
+      prNumber: successorIdentity.sourcePullRequestNumber,
+      headSha: successorIdentity.finalHeadSha,
+      reviewSubmittedAt: '2026-07-31T21:12:10Z',
+    })
+  })
+
+  ;(
+    [
+      [
+        'missing successor',
+        (record: Record<string, unknown>) => {
+          record.requiredSuccessors = []
+        },
+      ],
+      [
+        'ambiguous successor set',
+        (record: Record<string, unknown>) => {
+          const successors = record.requiredSuccessors as unknown[]
+          record.requiredSuccessors = [...successors, structuredClone(successors[0])]
+        },
+      ],
+      [
+        'duplicate protected transition',
+        (record: Record<string, unknown>) => {
+          const successor = (record.requiredSuccessors as Record<string, unknown>[])[0]!
+          const transitions = successor.protectedPathTransitions as unknown[]
+          successor.protectedPathTransitions = [...transitions, structuredClone(transitions[0])]
+        },
+      ],
+    ] as const
+  ).forEach(([name, mutate]) => {
+    test(`rejects a v6 receipt with ${name}`, () => {
+      const record = structuredClone(realContinuousRemediationRecord) as unknown as Record<string, unknown>
+      mutate(record)
+      expect(() => parseBaynReleaseReviewRemediationRecord(record)).toThrow()
+    })
+  })
+
+  ;(
+    [
+      [
+        'wrong direct parent',
+        (fixture: ReturnType<typeof successorBoundContinuousRemediationFixture>) => {
+          const record = fixture.evidence.record
+          if (record.schemaVersion !== 'bayn.release-review-remediation.v6') throw new Error('expected v6 record')
+          const successor = fixture.snapshot.comparison?.commits.find(
+            (commit) => commit.sha === record.requiredSuccessors[0].mergeCommitSha,
+          )
+          if (successor === undefined) throw new Error('missing successor commit')
+          ;(successor as unknown as { parents: string[] }).parents = ['0'.repeat(40)]
+        },
+      ],
+      [
+        'wrong merge tree',
+        (fixture: ReturnType<typeof successorBoundContinuousRemediationFixture>) => {
+          const record = fixture.evidence.record
+          if (record.schemaVersion !== 'bayn.release-review-remediation.v6') throw new Error('expected v6 record')
+          const successor = fixture.snapshot.comparison?.commits.find(
+            (commit) => commit.sha === record.requiredSuccessors[0].mergeCommitSha,
+          )
+          if (successor === undefined) throw new Error('missing successor commit')
+          ;(successor as unknown as { treeSha: string }).treeSha = '0'.repeat(40)
+        },
+      ],
+      [
+        'incomplete successor path set',
+        (fixture: ReturnType<typeof successorBoundContinuousRemediationFixture>) => {
+          const record = fixture.evidence.record
+          if (record.schemaVersion !== 'bayn.release-review-remediation.v6') throw new Error('expected v6 record')
+          const finalHead = fixture.evidence.referencedCommits.find(
+            (commit) => commit.sha === record.requiredSuccessors[0].finalHeadSha,
+          )
+          if (finalHead === undefined) throw new Error('missing successor final head')
+          ;(finalHead as unknown as { files: string[] }).files = finalHead.files.slice(1)
+        },
+      ],
+      [
+        'wrong successor source blob',
+        (fixture: ReturnType<typeof successorBoundContinuousRemediationFixture>) => {
+          const record = fixture.evidence.record
+          if (record.schemaVersion !== 'bayn.release-review-remediation.v6') throw new Error('expected v6 record')
+          const finalHead = fixture.evidence.referencedCommits.find(
+            (commit) => commit.sha === record.requiredSuccessors[0].finalHeadSha,
+          )
+          const pathBlob = finalHead?.pathBlobs[0]
+          if (pathBlob === undefined) throw new Error('missing successor source blob')
+          ;(pathBlob as unknown as { blobSha: string }).blobSha = '0'.repeat(40)
+        },
+      ],
+      [
+        'wrong protected transition source blob',
+        (fixture: ReturnType<typeof successorBoundContinuousRemediationFixture>) => {
+          const record = fixture.evidence.record
+          if (record.schemaVersion !== 'bayn.release-review-remediation.v6') throw new Error('expected v6 record')
+          ;(
+            record.requiredSuccessors[0].protectedPathTransitions[0] as unknown as { beforeBlobSha: string }
+          ).beforeBlobSha = '0'.repeat(40)
+        },
+      ],
+      [
+        'stale transitioned current blob',
+        (fixture: ReturnType<typeof successorBoundContinuousRemediationFixture>) => {
+          const record = fixture.evidence.record
+          if (record.schemaVersion !== 'bayn.release-review-remediation.v6') throw new Error('expected v6 record')
+          const transition = record.requiredSuccessors[0].protectedPathTransitions[0]
+          const current = fixture.evidence.currentPathBlobs.find((path) => path.path === transition.path)
+          if (current === undefined) throw new Error('missing current protected blob')
+          ;(current as unknown as { blobSha: string }).blobSha = transition.beforeBlobSha
+        },
+      ],
+      [
+        'later undeclared protected mutation',
+        (fixture: ReturnType<typeof successorBoundContinuousRemediationFixture>) => {
+          const record = fixture.evidence.record
+          if (record.schemaVersion !== 'bayn.release-review-remediation.v6') throw new Error('expected v6 record')
+          const transition = record.requiredSuccessors[0].protectedPathTransitions[0]
+          const update = fixture.snapshot.comparison?.commits.find(
+            (commit) => commit.sha === successorBoundHistory.updateMerge,
+          )
+          if (update === undefined) throw new Error('missing v6 receipt update commit')
+          ;(update as unknown as { files: string[] }).files = [...update.files, transition.path]
+          ;(update as unknown as { fileChanges: unknown[] }).fileChanges = [
+            ...(update.fileChanges ?? []),
+            {
+              path: transition.path,
+              previousPath: null,
+              status: 'modified',
+              blobSha: '0'.repeat(40),
+            },
+          ]
+        },
+      ],
+      [
+        'edited successor review evidence',
+        (fixture: ReturnType<typeof successorBoundContinuousRemediationFixture>) => {
+          const record = fixture.evidence.record
+          if (record.schemaVersion !== 'bayn.release-review-remediation.v6') throw new Error('expected v6 record')
+          const successor = fixture.snapshot.comparison?.commits.find(
+            (commit) => commit.sha === record.requiredSuccessors[0].mergeCommitSha,
+          )
+          const pullRequest = successor?.reviewSnapshot?.pullRequest
+          if (pullRequest === null || pullRequest === undefined) throw new Error('missing successor pull request')
+          ;(pullRequest as unknown as { issueComments: PullRequestIssueComment[] }).issueComments = [
+            issueComment({ body: 'post-receipt edit' }),
+          ]
+        },
+      ],
+      [
+        'wrong completion identity',
+        (fixture: ReturnType<typeof successorBoundContinuousRemediationFixture>) => {
+          const record = fixture.evidence.record
+          if (record.schemaVersion !== 'bayn.release-review-remediation.v6') throw new Error('expected v6 record')
+          const completion = fixture.snapshot.comparison?.commits.find(
+            (commit) => commit.sha === record.completion.mergeCommitSha,
+          )
+          if (completion === undefined) throw new Error('missing completion commit')
+          ;(completion as unknown as { treeSha: string }).treeSha = '0'.repeat(40)
+        },
+      ],
+      [
+        'noncanonical current receipt update',
+        (fixture: ReturnType<typeof successorBoundContinuousRemediationFixture>) => {
+          const update = fixture.snapshot.comparison?.commits.find(
+            (commit) => commit.sha === successorBoundHistory.updateMerge,
+          )
+          const receipt = update?.fileChanges?.find((change) => change.path === continuousRemediationRecordPath)
+          if (receipt === undefined) throw new Error('missing current receipt mutation')
+          ;(receipt as unknown as { previousPath: string | null }).previousPath = 'stale-receipt.json'
+        },
+      ],
+    ] as const
+  ).forEach(([name, mutate]) => {
+    test(`rejects v6 continuous-source evidence with ${name}`, () => {
+      const fixture = successorBoundContinuousRemediationFixture()
+      mutate(fixture)
+      expect(evaluateSuccessorBoundContinuousRemediationFixture(fixture)).toMatchObject({
+        status: 'hold',
+        code: 'release-review-remediation-invalid',
+        retryable: false,
+      })
+    })
+  })
+
+  test('rejects a v6 receipt whose bound successor review has an unresolved thread', () => {
+    const fixture = successorBoundContinuousRemediationFixture()
+    const record = fixture.evidence.record
+    if (record.schemaVersion !== 'bayn.release-review-remediation.v6') throw new Error('expected v6 record')
+    const successor = fixture.snapshot.comparison?.commits.find(
+      (commit) => commit.sha === record.requiredSuccessors[0].mergeCommitSha,
+    )
+    const pullRequest = successor?.reviewSnapshot?.pullRequest
+    if (pullRequest === null || pullRequest === undefined) throw new Error('missing successor pull request')
+    ;(pullRequest as unknown as { threads: PullRequestReviewThread[] }).threads = [
+      thread({ id: 'successor-thread', isResolved: false, path: 'services/bayn/src/observe-composition.ts' }),
+    ]
+    ;(
+      record.requiredSuccessors[0] as unknown as { sourcePullRequestEvidenceSha256: string }
+    ).sourcePullRequestEvidenceSha256 = pullRequestReviewEvidenceSha256(pullRequest)
+    expect(evaluateSuccessorBoundContinuousRemediationFixture(fixture)).toMatchObject({
+      status: 'hold',
+      code: 'release-review-remediation-invalid',
+      retryable: false,
     })
   })
 

--- a/packages/scripts/src/bayn/verify-release-review.ts
+++ b/packages/scripts/src/bayn/verify-release-review.ts
@@ -305,10 +305,51 @@ interface BaynReleaseReviewRemediationCompletedContinuousSourceRecord {
   readonly introduction: BaynReleaseReviewRemediationContinuousSourceIntroduction
 }
 
+interface BaynReleaseReviewRemediationContinuousSourceCompletion {
+  readonly mergeCommitSha: string
+  readonly mergeParentSha: string
+  readonly mergeTreeSha: string
+  readonly sourcePullRequestNumber: number
+  readonly finalHeadSha: string
+  readonly finalHeadParentSha: string
+  readonly finalHeadTreeSha: string
+  readonly sourcePullRequestEvidenceSha256: string
+  readonly completedRecordBlobSha: string
+  readonly affectedPaths: readonly BaynReleaseReviewRemediationCommitPath[]
+}
+
+interface BaynReleaseReviewRemediationContinuousSourceSuccessor {
+  readonly mergeCommitSha: string
+  readonly mergeParentSha: string
+  readonly mergeTreeSha: string
+  readonly sourcePullRequestNumber: number
+  readonly finalHeadSha: string
+  readonly finalHeadParentSha: string
+  readonly finalHeadTreeSha: string
+  readonly sourcePullRequestEvidenceSha256: string
+  readonly affectedPaths: readonly BaynReleaseReviewRemediationCommitPath[]
+  readonly protectedPathTransitions: readonly {
+    readonly path: string
+    readonly beforeBlobSha: string
+    readonly afterBlobSha: string
+  }[]
+}
+
+interface BaynReleaseReviewRemediationSuccessorBoundContinuousSourceRecord {
+  readonly schemaVersion: 'bayn.release-review-remediation.v6'
+  readonly remediationId: string
+  readonly blocked: BaynReleaseReviewRemediationContinuousSourceRecord['blocked']
+  readonly requiredDescendants: readonly []
+  readonly requiredSuccessors: readonly [BaynReleaseReviewRemediationContinuousSourceSuccessor]
+  readonly introduction: BaynReleaseReviewRemediationContinuousSourceIntroduction
+  readonly completion: BaynReleaseReviewRemediationContinuousSourceCompletion
+}
+
 export type BaynReleaseReviewRemediationRecord =
   | BaynReleaseReviewRemediationLegacyRecord
   | BaynReleaseReviewRemediationContinuousSourceRecord
   | BaynReleaseReviewRemediationCompletedContinuousSourceRecord
+  | BaynReleaseReviewRemediationSuccessorBoundContinuousSourceRecord
 
 interface RemediationCommitObject {
   readonly sha: string
@@ -740,20 +781,32 @@ export const parseBaynReleaseReviewRemediationRecord = (value: unknown): BaynRel
     rawSchemaVersion !== 'bayn.release-review-remediation.v2' &&
     rawSchemaVersion !== 'bayn.release-review-remediation.v3' &&
     rawSchemaVersion !== 'bayn.release-review-remediation.v4' &&
-    rawSchemaVersion !== 'bayn.release-review-remediation.v5'
+    rawSchemaVersion !== 'bayn.release-review-remediation.v5' &&
+    rawSchemaVersion !== 'bayn.release-review-remediation.v6'
   ) {
     throw new Error('remediation schemaVersion is invalid')
   }
   const schemaVersion = rawSchemaVersion
   if (
     schemaVersion === 'bayn.release-review-remediation.v4' ||
-    schemaVersion === 'bayn.release-review-remediation.v5'
+    schemaVersion === 'bayn.release-review-remediation.v5' ||
+    schemaVersion === 'bayn.release-review-remediation.v6'
   ) {
     const record = strictRecord(
       value,
-      schemaVersion === 'bayn.release-review-remediation.v5'
-        ? ['schemaVersion', 'remediationId', 'blocked', 'requiredDescendants', 'introduction']
-        : ['schemaVersion', 'remediationId', 'blocked', 'requiredDescendants'],
+      schemaVersion === 'bayn.release-review-remediation.v4'
+        ? ['schemaVersion', 'remediationId', 'blocked', 'requiredDescendants']
+        : schemaVersion === 'bayn.release-review-remediation.v5'
+          ? ['schemaVersion', 'remediationId', 'blocked', 'requiredDescendants', 'introduction']
+          : [
+              'schemaVersion',
+              'remediationId',
+              'blocked',
+              'requiredDescendants',
+              'requiredSuccessors',
+              'introduction',
+              'completion',
+            ],
       'remediation',
     )
     const remediationId = expectString(record.remediationId, 'remediation ID')
@@ -818,35 +871,151 @@ export const parseBaynReleaseReviewRemediationRecord = (value: unknown): BaynRel
     if (!Array.isArray(introduction.affectedPaths)) {
       throw new Error('remediation introduction affectedPaths must be an array')
     }
+    const parsedIntroduction = {
+      mergeCommitSha: expectSha(introduction.mergeCommitSha, 'remediation introduction merge commit SHA'),
+      mergeParentSha: expectSha(introduction.mergeParentSha, 'remediation introduction merge parent SHA'),
+      mergeTreeSha: expectSha(introduction.mergeTreeSha, 'remediation introduction merge tree SHA'),
+      sourcePullRequestNumber: expectPositiveIntegerRecord(
+        introduction.sourcePullRequestNumber,
+        'remediation introduction source pull request number',
+      ),
+      finalHeadSha: expectSha(introduction.finalHeadSha, 'remediation introduction final head SHA'),
+      finalHeadParentSha: expectSha(introduction.finalHeadParentSha, 'remediation introduction final head parent SHA'),
+      finalHeadTreeSha: expectSha(introduction.finalHeadTreeSha, 'remediation introduction final head tree SHA'),
+      sourcePullRequestEvidenceSha256: expectSha256(
+        introduction.sourcePullRequestEvidenceSha256,
+        'remediation introduction source pull request evidence hash',
+      ),
+      introducedRecordBlobSha: expectSha(
+        introduction.introducedRecordBlobSha,
+        'remediation introduction record blob SHA',
+      ),
+      affectedPaths: introduction.affectedPaths.map((item, index) =>
+        parseRemediationCommitPath(item, `remediation introduction affected path ${index}`),
+      ),
+    }
+    if (schemaVersion === 'bayn.release-review-remediation.v5') {
+      return {
+        schemaVersion,
+        remediationId,
+        blocked: parsedBlocked,
+        requiredDescendants: [],
+        introduction: parsedIntroduction,
+      }
+    }
+    const completion = strictRecord(
+      record.completion,
+      [
+        'mergeCommitSha',
+        'mergeParentSha',
+        'mergeTreeSha',
+        'sourcePullRequestNumber',
+        'finalHeadSha',
+        'finalHeadParentSha',
+        'finalHeadTreeSha',
+        'sourcePullRequestEvidenceSha256',
+        'completedRecordBlobSha',
+        'affectedPaths',
+      ],
+      'remediation completion',
+    )
+    if (!Array.isArray(completion.affectedPaths)) {
+      throw new Error('remediation completion affectedPaths must be an array')
+    }
+    if (!Array.isArray(record.requiredSuccessors) || record.requiredSuccessors.length !== 1) {
+      throw new Error('continuous-source remediation requiredSuccessors must contain exactly one successor')
+    }
+    const successor = strictRecord(
+      record.requiredSuccessors[0],
+      [
+        'mergeCommitSha',
+        'mergeParentSha',
+        'mergeTreeSha',
+        'sourcePullRequestNumber',
+        'finalHeadSha',
+        'finalHeadParentSha',
+        'finalHeadTreeSha',
+        'sourcePullRequestEvidenceSha256',
+        'affectedPaths',
+        'protectedPathTransitions',
+      ],
+      'remediation successor',
+    )
+    if (!Array.isArray(successor.affectedPaths)) {
+      throw new Error('remediation successor affectedPaths must be an array')
+    }
+    if (!Array.isArray(successor.protectedPathTransitions) || successor.protectedPathTransitions.length === 0) {
+      throw new Error('remediation successor protectedPathTransitions must be a non-empty array')
+    }
+    const protectedPathTransitions = successor.protectedPathTransitions.map((item, index) => {
+      const transition = strictRecord(
+        item,
+        ['path', 'beforeBlobSha', 'afterBlobSha'],
+        `remediation successor protected path transition ${index}`,
+      )
+      return {
+        path: expectString(transition.path, `remediation successor protected path transition ${index} path`),
+        beforeBlobSha: expectSha(
+          transition.beforeBlobSha,
+          `remediation successor protected path transition ${index} before blob SHA`,
+        ),
+        afterBlobSha: expectSha(
+          transition.afterBlobSha,
+          `remediation successor protected path transition ${index} after blob SHA`,
+        ),
+      }
+    })
+    if (
+      new Set(protectedPathTransitions.map((transition) => transition.path)).size !== protectedPathTransitions.length
+    ) {
+      throw new Error('remediation successor protected path transitions contain duplicate paths')
+    }
     return {
       schemaVersion,
       remediationId,
       blocked: parsedBlocked,
       requiredDescendants: [],
-      introduction: {
-        mergeCommitSha: expectSha(introduction.mergeCommitSha, 'remediation introduction merge commit SHA'),
-        mergeParentSha: expectSha(introduction.mergeParentSha, 'remediation introduction merge parent SHA'),
-        mergeTreeSha: expectSha(introduction.mergeTreeSha, 'remediation introduction merge tree SHA'),
+      requiredSuccessors: [
+        {
+          mergeCommitSha: expectSha(successor.mergeCommitSha, 'remediation successor merge commit SHA'),
+          mergeParentSha: expectSha(successor.mergeParentSha, 'remediation successor merge parent SHA'),
+          mergeTreeSha: expectSha(successor.mergeTreeSha, 'remediation successor merge tree SHA'),
+          sourcePullRequestNumber: expectPositiveIntegerRecord(
+            successor.sourcePullRequestNumber,
+            'remediation successor source pull request number',
+          ),
+          finalHeadSha: expectSha(successor.finalHeadSha, 'remediation successor final head SHA'),
+          finalHeadParentSha: expectSha(successor.finalHeadParentSha, 'remediation successor final head parent SHA'),
+          finalHeadTreeSha: expectSha(successor.finalHeadTreeSha, 'remediation successor final head tree SHA'),
+          sourcePullRequestEvidenceSha256: expectSha256(
+            successor.sourcePullRequestEvidenceSha256,
+            'remediation successor source pull request evidence hash',
+          ),
+          affectedPaths: successor.affectedPaths.map((item, index) =>
+            parseRemediationCommitPath(item, `remediation successor affected path ${index}`),
+          ),
+          protectedPathTransitions,
+        },
+      ],
+      introduction: parsedIntroduction,
+      completion: {
+        mergeCommitSha: expectSha(completion.mergeCommitSha, 'remediation completion merge commit SHA'),
+        mergeParentSha: expectSha(completion.mergeParentSha, 'remediation completion merge parent SHA'),
+        mergeTreeSha: expectSha(completion.mergeTreeSha, 'remediation completion merge tree SHA'),
         sourcePullRequestNumber: expectPositiveIntegerRecord(
-          introduction.sourcePullRequestNumber,
-          'remediation introduction source pull request number',
+          completion.sourcePullRequestNumber,
+          'remediation completion source pull request number',
         ),
-        finalHeadSha: expectSha(introduction.finalHeadSha, 'remediation introduction final head SHA'),
-        finalHeadParentSha: expectSha(
-          introduction.finalHeadParentSha,
-          'remediation introduction final head parent SHA',
-        ),
-        finalHeadTreeSha: expectSha(introduction.finalHeadTreeSha, 'remediation introduction final head tree SHA'),
+        finalHeadSha: expectSha(completion.finalHeadSha, 'remediation completion final head SHA'),
+        finalHeadParentSha: expectSha(completion.finalHeadParentSha, 'remediation completion final head parent SHA'),
+        finalHeadTreeSha: expectSha(completion.finalHeadTreeSha, 'remediation completion final head tree SHA'),
         sourcePullRequestEvidenceSha256: expectSha256(
-          introduction.sourcePullRequestEvidenceSha256,
-          'remediation introduction source pull request evidence hash',
+          completion.sourcePullRequestEvidenceSha256,
+          'remediation completion source pull request evidence hash',
         ),
-        introducedRecordBlobSha: expectSha(
-          introduction.introducedRecordBlobSha,
-          'remediation introduction record blob SHA',
-        ),
-        affectedPaths: introduction.affectedPaths.map((item, index) =>
-          parseRemediationCommitPath(item, `remediation introduction affected path ${index}`),
+        completedRecordBlobSha: expectSha(completion.completedRecordBlobSha, 'remediation completion record blob SHA'),
+        affectedPaths: completion.affectedPaths.map((item, index) =>
+          parseRemediationCommitPath(item, `remediation completion affected path ${index}`),
         ),
       },
     }
@@ -2118,14 +2287,23 @@ const validateReleaseReviewRemediationV2 = (input: {
   return null
 }
 
-const validateContinuousSourceIntroductionIdentity = (input: {
+const validateContinuousSourceCommitIdentity = (input: {
   readonly remediationId: string
   readonly evidence: BaynReleaseReviewRemediationEvidence
-  readonly introduction: BaynReleaseRangeCommit
-  readonly identity: BaynReleaseReviewRemediationContinuousSourceIntroduction
+  readonly commit: BaynReleaseRangeCommit
+  readonly identity: {
+    readonly mergeCommitSha: string
+    readonly mergeParentSha: string
+    readonly mergeTreeSha: string
+    readonly finalHeadSha: string
+    readonly finalHeadParentSha: string
+    readonly finalHeadTreeSha: string
+    readonly affectedPaths: readonly BaynReleaseReviewRemediationCommitPath[]
+  }
+  readonly label: string
 }): BaynReleaseReviewHold | null => {
   const finalHead = findReferencedCommit(input.evidence, input.identity.finalHeadSha)
-  const mergeChanges = commitFileMap(input.introduction.fileChanges)
+  const mergeChanges = commitFileMap(input.commit.fileChanges)
   const finalChanges = finalHead === null ? null : commitFileMap(finalHead.fileChanges)
   const finalBlobs = finalHead === null ? null : pathBlobMap(finalHead.pathBlobs)
   const expectedPaths = input.identity.affectedPaths.map((path) => path.path)
@@ -2134,28 +2312,28 @@ const validateContinuousSourceIntroductionIdentity = (input: {
     mergeChanges === null ||
     finalChanges === null ||
     finalBlobs === null ||
-    input.introduction.sha !== input.identity.mergeCommitSha ||
-    input.introduction.parents.length !== 1 ||
-    input.introduction.parents[0] !== input.identity.mergeParentSha ||
-    input.introduction.treeSha !== input.identity.mergeTreeSha ||
+    input.commit.sha !== input.identity.mergeCommitSha ||
+    input.commit.parents.length !== 1 ||
+    input.commit.parents[0] !== input.identity.mergeParentSha ||
+    input.commit.treeSha !== input.identity.mergeTreeSha ||
     finalHead.sha !== input.identity.finalHeadSha ||
     finalHead.parents.length !== 1 ||
     finalHead.parents[0] !== input.identity.finalHeadParentSha ||
     input.identity.finalHeadParentSha !== input.identity.mergeParentSha ||
     finalHead.treeSha !== input.identity.finalHeadTreeSha ||
     input.identity.finalHeadTreeSha !== input.identity.mergeTreeSha ||
-    input.introduction.treeSha !== finalHead.treeSha
+    input.commit.treeSha !== finalHead.treeSha
   ) {
-    return remediationInvalid(`remediation ${input.remediationId} introduction source identity is not exact`)
+    return remediationInvalid(`remediation ${input.remediationId} ${input.label} source identity is not exact`)
   }
   if (
-    !exactStringSet(expectedPaths, input.introduction.files) ||
+    !exactStringSet(expectedPaths, input.commit.files) ||
     !exactStringSet(expectedPaths, finalHead.files) ||
     !exactStringSet(expectedPaths, [...mergeChanges.keys()]) ||
     !exactStringSet(expectedPaths, [...finalChanges.keys()]) ||
     !exactStringSet(expectedPaths, [...finalBlobs.keys()])
   ) {
-    return remediationInvalid(`remediation ${input.remediationId} introduction path set is incomplete`)
+    return remediationInvalid(`remediation ${input.remediationId} ${input.label} path set is incomplete`)
   }
   for (const expected of input.identity.affectedPaths) {
     const mergeChange = mergeChanges.get(expected.path)
@@ -2171,9 +2349,26 @@ const validateContinuousSourceIntroductionIdentity = (input: {
       finalChange.blobSha !== expected.blobSha ||
       finalBlobs.get(expected.path) !== expected.blobSha
     ) {
-      return remediationInvalid(`remediation ${input.remediationId} introduction blob changed at ${expected.path}`)
+      return remediationInvalid(`remediation ${input.remediationId} ${input.label} blob changed at ${expected.path}`)
     }
   }
+  return null
+}
+
+const validateContinuousSourceIntroductionIdentity = (input: {
+  readonly remediationId: string
+  readonly evidence: BaynReleaseReviewRemediationEvidence
+  readonly introduction: BaynReleaseRangeCommit
+  readonly identity: BaynReleaseReviewRemediationContinuousSourceIntroduction
+}): BaynReleaseReviewHold | null => {
+  const identityHold = validateContinuousSourceCommitIdentity({
+    remediationId: input.remediationId,
+    evidence: input.evidence,
+    commit: input.introduction,
+    identity: input.identity,
+    label: 'introduction',
+  })
+  if (identityHold !== null) return identityHold
   const recordPath = input.identity.affectedPaths.find((path) => path.path === input.evidence.recordPath)
   if (
     recordPath === undefined ||
@@ -2186,6 +2381,32 @@ const validateContinuousSourceIntroductionIdentity = (input: {
   return null
 }
 
+const validateContinuousSourceCompletionIdentity = (input: {
+  readonly remediationId: string
+  readonly evidence: BaynReleaseReviewRemediationEvidence
+  readonly completion: BaynReleaseRangeCommit
+  readonly identity: BaynReleaseReviewRemediationContinuousSourceCompletion
+}): BaynReleaseReviewHold | null => {
+  const identityHold = validateContinuousSourceCommitIdentity({
+    remediationId: input.remediationId,
+    evidence: input.evidence,
+    commit: input.completion,
+    identity: input.identity,
+    label: 'completion',
+  })
+  if (identityHold !== null) return identityHold
+  const recordPath = input.identity.affectedPaths.find((path) => path.path === input.evidence.recordPath)
+  if (
+    recordPath === undefined ||
+    recordPath.status !== 'modified' ||
+    recordPath.previousPath !== null ||
+    recordPath.blobSha !== input.identity.completedRecordBlobSha
+  ) {
+    return remediationInvalid(`remediation ${input.remediationId} completed receipt blob is not exact`)
+  }
+  return null
+}
+
 const validateContinuousSourceRemediation = (input: {
   readonly evidence: BaynReleaseReviewRemediationEvidence
   readonly blockedCommit: BaynReleaseRangeCommit
@@ -2193,6 +2414,7 @@ const validateContinuousSourceRemediation = (input: {
   readonly normalReviews: ReadonlyMap<string, BaynReleaseReviewEvaluation>
   readonly introduction: BaynReleaseRangeCommit
   readonly introductionReview?: BaynReleaseReviewEligible
+  readonly completionReview?: BaynReleaseReviewEligible
   readonly blockedIndex: number
   readonly nowMs: number
 }): BaynReleaseReviewHold | null => {
@@ -2200,7 +2422,8 @@ const validateContinuousSourceRemediation = (input: {
   const record = evidence.record
   if (
     record.schemaVersion !== 'bayn.release-review-remediation.v4' &&
-    record.schemaVersion !== 'bayn.release-review-remediation.v5'
+    record.schemaVersion !== 'bayn.release-review-remediation.v5' &&
+    record.schemaVersion !== 'bayn.release-review-remediation.v6'
   ) {
     return remediationInvalid(`remediation ${record.remediationId} continuous source record is missing`)
   }
@@ -2273,19 +2496,113 @@ const validateContinuousSourceRemediation = (input: {
   if (boundReview.status === 'hold') return boundReview
 
   const protectedPaths = new Set(expectedPaths)
+  const expectedCurrentBlobs = new Map(record.blocked.affectedPaths.map((path) => [path.path, path.blobSha]))
+  let successorCommit: BaynReleaseRangeCommit | undefined
+  let successorBoundReview: BaynReleaseReviewEligible | undefined
+  let protectedTransitions: ReadonlyMap<
+    string,
+    BaynReleaseReviewRemediationContinuousSourceSuccessor['protectedPathTransitions'][number]
+  > = new Map()
+  if (record.schemaVersion === 'bayn.release-review-remediation.v6') {
+    const successor = record.requiredSuccessors[0]
+    const successorMatches = comparison.commits.filter((commit) => commit.sha === successor.mergeCommitSha)
+    const transitionPaths = successor.protectedPathTransitions.map((transition) => transition.path)
+    const transitionMap = new Map(successor.protectedPathTransitions.map((transition) => [transition.path, transition]))
+    if (
+      successorMatches.length !== 1 ||
+      transitionMap.size !== successor.protectedPathTransitions.length ||
+      !exactStringSet(
+        transitionPaths,
+        successor.affectedPaths.filter((path) => protectedPaths.has(path.path)).map((path) => path.path),
+      )
+    ) {
+      return remediationInvalid(`remediation ${record.remediationId} successor declaration is ambiguous`)
+    }
+    successorCommit = successorMatches[0]
+    if (successorCommit === undefined) {
+      return remediationInvalid(`remediation ${record.remediationId} successor commit is missing`)
+    }
+    const successorIdentityHold = validateContinuousSourceCommitIdentity({
+      remediationId: record.remediationId,
+      evidence,
+      commit: successorCommit,
+      identity: successor,
+      label: 'successor',
+    })
+    if (successorIdentityHold !== null) return successorIdentityHold
+    for (const transition of successor.protectedPathTransitions) {
+      const blockedPath = record.blocked.affectedPaths.find((path) => path.path === transition.path)
+      const successorPath = successor.affectedPaths.find((path) => path.path === transition.path)
+      if (
+        blockedPath === undefined ||
+        successorPath === undefined ||
+        successor.mergeParentSha !== blockedCommit.sha ||
+        transition.beforeBlobSha !== blockedPath.blobSha ||
+        transition.afterBlobSha !== successorPath.blobSha ||
+        successorPath.status !== 'modified' ||
+        successorPath.previousPath !== null ||
+        transition.beforeBlobSha === transition.afterBlobSha
+      ) {
+        return remediationInvalid(`remediation ${record.remediationId} successor protected transition is not exact`)
+      }
+      expectedCurrentBlobs.set(transition.path, transition.afterBlobSha)
+    }
+    const successorReview = input.normalReviews.get(successorCommit.sha)
+    if (successorReview === undefined) {
+      return remediationInvalid(`remediation ${record.remediationId} successor review snapshot is missing`)
+    }
+    const reviewedSuccessor = evaluateBoundRemediationReview({
+      remediationId: record.remediationId,
+      commit: successorCommit,
+      identity: successor,
+      normalReview: successorReview,
+      nowMs: input.nowMs,
+    })
+    if (reviewedSuccessor.status === 'hold') return reviewedSuccessor
+    successorBoundReview = reviewedSuccessor
+    protectedTransitions = transitionMap
+  }
   let expectedParent = blockedCommit.sha
   for (const commit of comparison.commits.slice(input.blockedIndex + 1)) {
     if (commit.parents.length !== 1 || commit.parents[0] !== expectedParent) {
       return remediationInvalid(`remediation ${record.remediationId} source ancestry is not a direct-parent chain`)
     }
-    if (commit.files.some((path) => protectedPaths.has(path))) {
+    const protectedChanges = (commit.fileChanges ?? []).filter(
+      (change) =>
+        protectedPaths.has(change.path) || (change.previousPath !== null && protectedPaths.has(change.previousPath)),
+    )
+    if (commit.sha === successorCommit?.sha) {
+      if (
+        !exactStringSet(
+          protectedChanges.map((change) => change.path),
+          [...protectedTransitions.keys()],
+        ) ||
+        protectedChanges.some((change) => {
+          const transition = protectedTransitions.get(change.path)
+          return (
+            transition === undefined ||
+            change.previousPath !== null ||
+            change.status !== 'modified' ||
+            change.blobSha !== transition.afterBlobSha
+          )
+        })
+      ) {
+        return remediationInvalid(`remediation ${record.remediationId} successor protected mutation is not exact`)
+      }
+    } else if (commit.files.some((path) => protectedPaths.has(path)) || protectedChanges.length > 0) {
       return remediationInvalid(`remediation ${record.remediationId} continuous source changed after the blocked merge`)
     }
     if (commit.files.some(isBaynReleaseAffectingPath)) {
       const review =
-        commit.sha === input.introduction.sha && input.introductionReview !== undefined
-          ? input.introductionReview
-          : input.normalReviews.get(commit.sha)
+        commit.sha === successorCommit?.sha && successorBoundReview !== undefined
+          ? successorBoundReview
+          : commit.sha === input.introduction.sha && input.introductionReview !== undefined
+            ? input.introductionReview
+            : record.schemaVersion === 'bayn.release-review-remediation.v6' &&
+                commit.sha === record.completion.mergeCommitSha &&
+                input.completionReview !== undefined
+              ? input.completionReview
+              : input.normalReviews.get(commit.sha)
       if (review === undefined) {
         return remediationInvalid(`remediation ${record.remediationId} newer source review is missing`)
       }
@@ -2301,7 +2618,7 @@ const validateContinuousSourceRemediation = (input: {
   if (
     currentBlobs === null ||
     !exactStringSet(expectedPaths, [...currentBlobs.keys()]) ||
-    record.blocked.affectedPaths.some((path) => currentBlobs.get(path.path) !== path.blobSha)
+    [...expectedCurrentBlobs].some(([path, blobSha]) => currentBlobs.get(path) !== blobSha)
   ) {
     return remediationInvalid(`remediation ${record.remediationId} current continuous source blobs diverged`)
   }
@@ -2326,7 +2643,79 @@ const validateReleaseReviewRemediation = (input: {
   )
   let introduction: BaynReleaseRangeCommit | undefined
   let introductionBoundReview: BaynReleaseReviewEligible | undefined
-  if (record.schemaVersion === 'bayn.release-review-remediation.v5') {
+  let completionBoundReview: BaynReleaseReviewEligible | undefined
+  if (record.schemaVersion === 'bayn.release-review-remediation.v6') {
+    if (recordCommits.length !== 3) {
+      return remediationInvalid(`remediation ${record.remediationId} successor-bound history is not exact`)
+    }
+    introduction = recordCommits.find((commit) => commit.sha === record.introduction.mergeCommitSha)
+    const completion = recordCommits.find((commit) => commit.sha === record.completion.mergeCommitSha)
+    const update = recordCommits.find(
+      (commit) => commit.sha !== record.introduction.mergeCommitSha && commit.sha !== record.completion.mergeCommitSha,
+    )
+    const updateChange = update?.fileChanges?.find((change) => change.path === evidence.recordPath)
+    if (
+      introduction === undefined ||
+      completion === undefined ||
+      update === undefined ||
+      update.parents.length !== 1 ||
+      updateChange?.status !== 'modified' ||
+      updateChange.previousPath !== null ||
+      updateChange.blobSha !== evidence.recordBlobSha ||
+      comparison.commits.indexOf(introduction) >= comparison.commits.indexOf(completion) ||
+      comparison.commits.indexOf(completion) >= comparison.commits.indexOf(update)
+    ) {
+      return remediationInvalid(`remediation ${record.remediationId} successor-bound record mutation is not exact`)
+    }
+    const introductionIdentityHold = validateContinuousSourceIntroductionIdentity({
+      remediationId: record.remediationId,
+      evidence,
+      introduction,
+      identity: record.introduction,
+    })
+    if (introductionIdentityHold !== null) return introductionIdentityHold
+    const completionIdentityHold = validateContinuousSourceCompletionIdentity({
+      remediationId: record.remediationId,
+      evidence,
+      completion,
+      identity: record.completion,
+    })
+    if (completionIdentityHold !== null) return completionIdentityHold
+    const updateReview = input.normalReviews.get(update.sha)
+    if (updateReview === undefined) {
+      return remediationInvalid(`remediation ${record.remediationId} update commit lacks exact-head review`)
+    }
+    if (updateReview.status === 'hold') {
+      if (updateReview.retryable) return updateReview
+      return remediationInvalid(`remediation ${record.remediationId} update commit lacks exact-head review`)
+    }
+    const completionNormalReview = input.normalReviews.get(completion.sha)
+    if (completionNormalReview === undefined) {
+      return remediationInvalid(`remediation ${record.remediationId} completion review snapshot is missing`)
+    }
+    const completionReview = evaluateBoundRemediationReview({
+      remediationId: record.remediationId,
+      commit: completion,
+      identity: record.completion,
+      normalReview: completionNormalReview,
+      nowMs: input.nowMs,
+    })
+    if (completionReview.status === 'hold') return completionReview
+    completionBoundReview = completionReview
+    const introductionNormalReview = input.normalReviews.get(introduction.sha)
+    if (introductionNormalReview === undefined) {
+      return remediationInvalid(`remediation ${record.remediationId} introduction review snapshot is missing`)
+    }
+    const introductionReview = evaluateBoundRemediationReview({
+      remediationId: record.remediationId,
+      commit: introduction,
+      identity: record.introduction,
+      normalReview: introductionNormalReview,
+      nowMs: input.nowMs,
+    })
+    if (introductionReview.status === 'hold') return introductionReview
+    introductionBoundReview = introductionReview
+  } else if (record.schemaVersion === 'bayn.release-review-remediation.v5') {
     const identity = record.introduction
     if (recordCommits.length !== 2) {
       return remediationInvalid(`remediation ${record.remediationId} completion history is not exact`)
@@ -2454,7 +2843,8 @@ const validateReleaseReviewRemediation = (input: {
   }
   if (
     record.schemaVersion === 'bayn.release-review-remediation.v4' ||
-    record.schemaVersion === 'bayn.release-review-remediation.v5'
+    record.schemaVersion === 'bayn.release-review-remediation.v5' ||
+    record.schemaVersion === 'bayn.release-review-remediation.v6'
   ) {
     return validateContinuousSourceRemediation({
       evidence,
@@ -2463,6 +2853,7 @@ const validateReleaseReviewRemediation = (input: {
       normalReviews: input.normalReviews,
       introduction,
       introductionReview: introductionBoundReview,
+      completionReview: completionBoundReview,
       blockedIndex,
       nowMs: input.nowMs,
     })
@@ -2922,7 +3313,33 @@ export const evaluateBaynReleaseEligibility = (input: {
         normalReviews.set(introductionIdentity.mergeCommitSha, introductionReview)
         coveredDescendantShas.add(introductionIdentity.mergeCommitSha)
       }
-      if (remediation[0].record.schemaVersion === 'bayn.release-review-remediation.v5') {
+      if (
+        remediation[0].record.schemaVersion === 'bayn.release-review-remediation.v5' ||
+        remediation[0].record.schemaVersion === 'bayn.release-review-remediation.v6'
+      ) {
+        if (remediation[0].record.schemaVersion === 'bayn.release-review-remediation.v6') {
+          const successorIdentity = remediation[0].record.requiredSuccessors[0]
+          const successorCommit = comparison.commits.find(
+            (candidate) => candidate.sha === successorIdentity.mergeCommitSha,
+          )
+          const successorNormalReview = normalReviews.get(successorIdentity.mergeCommitSha)
+          if (successorCommit === undefined || successorNormalReview === undefined) {
+            return remediationInvalid(
+              `remediation ${remediation[0].record.remediationId} successor review snapshot is missing`,
+            )
+          }
+          const successorReview = evaluateBoundRemediationReview({
+            remediationId: remediation[0].record.remediationId,
+            commit: successorCommit,
+            identity: successorIdentity,
+            normalReview: successorNormalReview,
+            nowMs: input.nowMs,
+          })
+          if (successorReview.status === 'hold') return successorReview
+          normalReviews.set(successorIdentity.mergeCommitSha, successorReview)
+          coveredDescendantShas.add(successorIdentity.mergeCommitSha)
+        }
+
         const introductionIdentity = remediation[0].record.introduction
         const introductionCommit = comparison.commits.find(
           (candidate) => candidate.sha === introductionIdentity.mergeCommitSha,
@@ -2943,10 +3360,34 @@ export const evaluateBaynReleaseEligibility = (input: {
         if (introductionReview.status === 'hold') return introductionReview
         normalReviews.set(introductionIdentity.mergeCommitSha, introductionReview)
         coveredDescendantShas.add(introductionIdentity.mergeCommitSha)
+
+        if (remediation[0].record.schemaVersion === 'bayn.release-review-remediation.v6') {
+          const completionIdentity = remediation[0].record.completion
+          const completionCommit = comparison.commits.find(
+            (candidate) => candidate.sha === completionIdentity.mergeCommitSha,
+          )
+          const completionNormalReview = normalReviews.get(completionIdentity.mergeCommitSha)
+          if (completionCommit === undefined || completionNormalReview === undefined) {
+            return remediationInvalid(
+              `remediation ${remediation[0].record.remediationId} completion review snapshot is missing`,
+            )
+          }
+          const completionReview = evaluateBoundRemediationReview({
+            remediationId: remediation[0].record.remediationId,
+            commit: completionCommit,
+            identity: completionIdentity,
+            normalReview: completionNormalReview,
+            nowMs: input.nowMs,
+          })
+          if (completionReview.status === 'hold') return completionReview
+          normalReviews.set(completionIdentity.mergeCommitSha, completionReview)
+          coveredDescendantShas.add(completionIdentity.mergeCommitSha)
+        }
       }
       if (
         remediation[0].record.schemaVersion === 'bayn.release-review-remediation.v4' ||
-        remediation[0].record.schemaVersion === 'bayn.release-review-remediation.v5'
+        remediation[0].record.schemaVersion === 'bayn.release-review-remediation.v5' ||
+        remediation[0].record.schemaVersion === 'bayn.release-review-remediation.v6'
       ) {
         const record = remediation[0].record
         const continuousReview = evaluateBoundRemediationReview({
@@ -4276,16 +4717,26 @@ const loadReleaseReviewRemediations = async (
       }
     } else if (
       loaded.record.schemaVersion === 'bayn.release-review-remediation.v4' ||
-      loaded.record.schemaVersion === 'bayn.release-review-remediation.v5'
+      loaded.record.schemaVersion === 'bayn.release-review-remediation.v5' ||
+      loaded.record.schemaVersion === 'bayn.release-review-remediation.v6'
     ) {
       references.set(
         loaded.record.blocked.finalHeadSha,
         loaded.record.blocked.affectedPaths.map((path) => path.path),
       )
-      if (loaded.record.schemaVersion === 'bayn.release-review-remediation.v5') {
+      if (
+        loaded.record.schemaVersion === 'bayn.release-review-remediation.v5' ||
+        loaded.record.schemaVersion === 'bayn.release-review-remediation.v6'
+      ) {
         references.set(
           loaded.record.introduction.finalHeadSha,
           loaded.record.introduction.affectedPaths.map((path) => path.path),
+        )
+      }
+      if (loaded.record.schemaVersion === 'bayn.release-review-remediation.v6') {
+        references.set(
+          loaded.record.completion.finalHeadSha,
+          loaded.record.completion.affectedPaths.map((path) => path.path),
         )
       }
     } else {

--- a/services/bayn/release-review-remediations/6737d29cda608c79714046d420ab7396d8e80f70.json
+++ b/services/bayn/release-review-remediations/6737d29cda608c79714046d420ab7396d8e80f70.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "bayn.release-review-remediation.v5",
+  "schemaVersion": "bayn.release-review-remediation.v6",
   "remediationId": "pr-13426-continuous-reviewed-source",
   "blocked": {
     "mergeCommitSha": "6737d29cda608c79714046d420ab7396d8e80f70",
@@ -122,6 +122,69 @@
     ]
   },
   "requiredDescendants": [],
+  "requiredSuccessors": [
+    {
+      "mergeCommitSha": "2aa782001a9d7e1d9db68e5fa0929159755334cd",
+      "mergeParentSha": "6737d29cda608c79714046d420ab7396d8e80f70",
+      "mergeTreeSha": "92065c627993e2844f0990eb032a72e41205b77a",
+      "sourcePullRequestNumber": 13432,
+      "finalHeadSha": "c1d955f30a6f004916e885d8d5dd61a5eb11ee92",
+      "finalHeadParentSha": "6737d29cda608c79714046d420ab7396d8e80f70",
+      "finalHeadTreeSha": "92065c627993e2844f0990eb032a72e41205b77a",
+      "sourcePullRequestEvidenceSha256": "f22e10837d3842354b3a2d986f27813bdc535630e4277006703273c6fc3c56df",
+      "affectedPaths": [
+        {
+          "path": "services/bayn/src/cycle-observability.test.ts",
+          "previousPath": null,
+          "status": "modified",
+          "blobSha": "3b614caf7960040b86e5d20efd9a7235866a93e8"
+        },
+        {
+          "path": "services/bayn/src/cycle-observability.ts",
+          "previousPath": null,
+          "status": "modified",
+          "blobSha": "31f59003a20099163572cd7c7bf407441615c897"
+        },
+        {
+          "path": "services/bayn/src/cycle-runner/pass-decisions-observability.test.ts",
+          "previousPath": null,
+          "status": "added",
+          "blobSha": "2ccd08beed03727847797f803a76d228f4cae633"
+        },
+        {
+          "path": "services/bayn/src/cycle-runner/pass-decisions.ts",
+          "previousPath": null,
+          "status": "modified",
+          "blobSha": "a2b62e81a2d6e1133171a5815bf06f0dba02a128"
+        },
+        {
+          "path": "services/bayn/src/http.test.ts",
+          "previousPath": null,
+          "status": "modified",
+          "blobSha": "1827f6331644dcae0f49bc29c5deecffc0cf6dcd"
+        },
+        {
+          "path": "services/bayn/src/http.ts",
+          "previousPath": null,
+          "status": "modified",
+          "blobSha": "6b7420754525ddb380744709824c81e0ce013f38"
+        },
+        {
+          "path": "services/bayn/src/observe-composition.ts",
+          "previousPath": null,
+          "status": "modified",
+          "blobSha": "aaba2e88d64a0bf20d98e18f181abe9b0deb9860"
+        }
+      ],
+      "protectedPathTransitions": [
+        {
+          "path": "services/bayn/src/observe-composition.ts",
+          "beforeBlobSha": "ab38e8303f0d4482a6daeb6dd8f239cfb59d6223",
+          "afterBlobSha": "aaba2e88d64a0bf20d98e18f181abe9b0deb9860"
+        }
+      ]
+    }
+  ],
   "introduction": {
     "mergeCommitSha": "af1e0b0707c9f3ae6b05568b7e2984888d0d7d14",
     "mergeParentSha": "fa2016a8aa3c8b0f466ab84a7956c704dd9056c7",
@@ -150,6 +213,37 @@
         "previousPath": null,
         "status": "added",
         "blobSha": "dfde09ca935b9df6d48d34391d1cc0e599eab6c7"
+      }
+    ]
+  },
+  "completion": {
+    "mergeCommitSha": "8f6ab9086457f2a7e1f2147d57e06fc22c9881fc",
+    "mergeParentSha": "af1e0b0707c9f3ae6b05568b7e2984888d0d7d14",
+    "mergeTreeSha": "a51d7d16f0b9806ec2ae71dfa3862e0067d23851",
+    "sourcePullRequestNumber": 13445,
+    "finalHeadSha": "c580b4df79290df7c0760c290cafca9a4d4ae315",
+    "finalHeadParentSha": "af1e0b0707c9f3ae6b05568b7e2984888d0d7d14",
+    "finalHeadTreeSha": "a51d7d16f0b9806ec2ae71dfa3862e0067d23851",
+    "sourcePullRequestEvidenceSha256": "729f0f5c8208f284b889e97a8da90ac7aac02fffb3cb3880abc4d156cf459967",
+    "completedRecordBlobSha": "5faaf371424c183a176b3659fc8108576d136b84",
+    "affectedPaths": [
+      {
+        "path": "packages/scripts/src/bayn/verify-release-review.test.ts",
+        "previousPath": null,
+        "status": "modified",
+        "blobSha": "289ad5cc90b0e4a1ebe4bea91bc800f9f13de7f3"
+      },
+      {
+        "path": "packages/scripts/src/bayn/verify-release-review.ts",
+        "previousPath": null,
+        "status": "modified",
+        "blobSha": "0b3260c59a37022496086ef4ad3a5bcc387eec6e"
+      },
+      {
+        "path": "services/bayn/release-review-remediations/6737d29cda608c79714046d420ab7396d8e80f70.json",
+        "previousPath": null,
+        "status": "modified",
+        "blobSha": "5faaf371424c183a176b3659fc8108576d136b84"
       }
     ]
   }


### PR DESCRIPTION
## Summary

- add a strict v6 release-review receipt binding reviewed PR #13432 as the sole allowed successor of blocked PR #13426
- permit only the exact reviewed protected-source transition and carry reaction-bound successor/completion reviews through the full publication decision
- bind reviewed #13445 completion and the current receipt update so natural Bayn publication can proceed fail-closed

## Related Issues

PROOMPT-443

## Testing

- `bun test packages/scripts/src/bayn/verify-release-review.test.ts` (135 pass, 0 fail)
- `bunx tsc --ignoreConfig --noEmit --skipLibCheck --strict --target ESNext --module Preserve --moduleResolution Bundler --types bun packages/scripts/src/bayn/verify-release-review.ts packages/scripts/src/bayn/verify-release-review.test.ts`
- `bunx oxlint packages/scripts/src/bayn/verify-release-review.ts packages/scripts/src/bayn/verify-release-review.test.ts`
- `bunx oxfmt --check packages/scripts/src/bayn/verify-release-review.ts packages/scripts/src/bayn/verify-release-review.test.ts services/bayn/release-review-remediations/6737d29cda608c79714046d420ab7396d8e80f70.json`
- `git diff --check`
- predecessor PR #13446 exact heads passed all 15 hosted checks, including full Bayn, PostgreSQL, amd64, arm64, and the Bayn release gate

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] The immutable remediation receipt records the release follow-up evidence.