### PR TITLE
fix(bayn): bind reviewed candidate diagnostics lineage

### DIFF
--- a/packages/scripts/src/bayn/verify-release-review.test.ts
+++ b/packages/scripts/src/bayn/verify-release-review.test.ts
@@ -23,6 +23,8 @@ import {
   pullRequestReviewEvidenceSha256,
   type AssociatedPullRequest,
   type BaynBuildWorkflowRun,
+  type BaynReleaseCommitFileChange,
+  type BaynReleaseComparison,
   type BaynReleaseEligibilitySnapshot,
   type BaynReleaseRetrySnapshot,
   type BaynReleaseReviewPollResult,
@@ -496,7 +498,8 @@ const remediationHistoryFixture = (): {
   if (
     record.schemaVersion === 'bayn.release-review-remediation.v4' ||
     record.schemaVersion === 'bayn.release-review-remediation.v5' ||
-    record.schemaVersion === 'bayn.release-review-remediation.v6'
+    record.schemaVersion === 'bayn.release-review-remediation.v6' ||
+    record.schemaVersion === 'bayn.release-review-remediation.v7'
   ) {
     throw new Error('expected a legacy remediation record')
   }
@@ -690,6 +693,9 @@ const multiStageRemediationRecordPath =
 const realMultiStageRemediationRecord = parseBaynReleaseReviewRemediationRecord(
   JSON.parse(readFileSync(multiStageRemediationRecordPath, 'utf8')) as unknown,
 )
+if (realMultiStageRemediationRecord.schemaVersion !== 'bayn.release-review-remediation.v3') {
+  throw new Error('expected the immutable multi-stage receipt to use schema v3')
+}
 const multiStageHistory = {
   published: '319291bebe22b0c1dc928f13d0ff3655c4b22284',
   promotion: 'bbef7b18804cf9e30c11eac326e90281d1774b80',
@@ -1702,6 +1708,11 @@ const continuousRemediationRecordPath =
 const realContinuousRemediationRecord = parseBaynReleaseReviewRemediationRecord(
   JSON.parse(readFileSync(continuousRemediationRecordPath, 'utf8')) as unknown,
 )
+const candidateDiagnosticsRemediationRecordPath =
+  'services/bayn/release-review-remediations/ae4d23650c20cecbde2bac8416bc2b734381cb69.json'
+const realCandidateDiagnosticsRemediationRecord = parseBaynReleaseReviewRemediationRecord(
+  JSON.parse(readFileSync(candidateDiagnosticsRemediationRecordPath, 'utf8')) as unknown,
+)
 const continuousHistory = {
   published: '69d803040c8866e7703df50a645a096c54e7eca5',
   blocked: '6737d29cda608c79714046d420ab7396d8e80f70',
@@ -2196,7 +2207,179 @@ const evaluateSuccessorBoundContinuousRemediationFixture = (
         : '0'.repeat(40),
   })
 
+const singleStageSuccessorRemediationFixture = (): ReturnType<typeof successorBoundContinuousRemediationFixture> => {
+  const fixture = successorBoundContinuousRemediationFixture()
+  const comparison = fixture.snapshot.comparison
+  const currentRecord = fixture.evidence.record
+  if (
+    comparison === null ||
+    comparison.status !== 'ahead' ||
+    currentRecord.schemaVersion !== 'bayn.release-review-remediation.v6'
+  ) {
+    throw new Error('missing successor-bound continuous-source fixture')
+  }
+  const record = parseBaynReleaseReviewRemediationRecord({
+    schemaVersion: 'bayn.release-review-remediation.v7',
+    remediationId: 'pr-13438-successor-bound-reviewed-source',
+    blocked: currentRecord.blocked,
+    requiredDescendants: [],
+    requiredSuccessors: currentRecord.requiredSuccessors,
+  })
+  if (record.schemaVersion !== 'bayn.release-review-remediation.v7') {
+    throw new Error('failed to derive the v7 single-stage successor fixture')
+  }
+  const blockedCommit = comparison.commits.find((commit) => commit.sha === record.blocked.mergeCommitSha)
+  const successorCommit = comparison.commits.find(
+    (commit) => commit.sha === record.requiredSuccessors[0].mergeCommitSha,
+  )
+  const originalUpdate = comparison.commits.find((commit) => commit.sha === successorBoundHistory.updateMerge)
+  if (blockedCommit === undefined || successorCommit === undefined || originalUpdate === undefined) {
+    throw new Error('incomplete v7 single-stage successor fixture')
+  }
+  const updateCommit = {
+    ...originalUpdate,
+    parents: [successorCommit.sha],
+    fileChanges: originalUpdate.fileChanges?.map((change) =>
+      change.path === continuousRemediationRecordPath ? { ...change, status: 'added' as const } : change,
+    ),
+    reviewSnapshot: reviewSnapshotFor({
+      commitSha: successorBoundHistory.updateMerge,
+      prNumber: 13446,
+      headSha: successorBoundHistory.updateHead,
+      parents: [successorCommit.sha],
+      mergedAt: '2026-08-01T09:01:00Z',
+      reviews: [
+        review({
+          commitSha: successorBoundHistory.updateHead,
+          submittedAt: '2026-08-01T09:00:00Z',
+        }),
+      ],
+    }),
+  }
+  const commits = [blockedCommit, successorCommit, updateCommit]
+  const evidence = {
+    ...fixture.evidence,
+    record,
+    referencedCommits: fixture.evidence.referencedCommits.filter(
+      (commit) =>
+        commit.sha === record.blocked.finalHeadSha || commit.sha === record.requiredSuccessors[0].finalHeadSha,
+    ),
+  }
+  return {
+    evidence,
+    snapshot: {
+      ...fixture.snapshot,
+      currentCommitParents: [successorCommit.sha],
+      comparison: {
+        ...comparison,
+        headSha: updateCommit.sha,
+        aheadBy: commits.length,
+        totalCommits: commits.length,
+        commits,
+      },
+      remediations: [evidence],
+    },
+  }
+}
+
+const evaluateSingleStageSuccessorRemediationFixture = (
+  fixture: ReturnType<typeof singleStageSuccessorRemediationFixture>,
+) =>
+  evaluateBaynReleaseEligibility({
+    mainCommitSha: successorBoundHistory.updateMerge,
+    baseRefName: 'main',
+    snapshot: fixture.snapshot,
+    nowMs: successorBoundNowMs,
+    pushBeforeSha: fixture.snapshot.currentCommitParents[0]!,
+  })
+
 describe('Bayn publication-range eligibility', () => {
+  test('parses the exact immutable #13438 -> #13442 v7 reviewed-source receipt', () => {
+    expect(realCandidateDiagnosticsRemediationRecord).toMatchObject({
+      schemaVersion: 'bayn.release-review-remediation.v7',
+      remediationId: 'pr-13438-successor-bound-reviewed-source',
+      blocked: {
+        mergeCommitSha: 'ae4d23650c20cecbde2bac8416bc2b734381cb69',
+        sourcePullRequestNumber: 13438,
+        finalHeadSha: 'bf17a9387e69896095096b9447aafed52711333c',
+        sourcePullRequestEvidenceSha256: '25bd010d4dd974cc734799cba99495bbef170995535282e73579f4ba8c4f5afe',
+        affectedPaths: { length: 2 },
+      },
+      requiredDescendants: [],
+      requiredSuccessors: [
+        {
+          mergeCommitSha: 'fa2016a8aa3c8b0f466ab84a7956c704dd9056c7',
+          sourcePullRequestNumber: 13442,
+          finalHeadSha: 'a7b608a873057d9f65625515140e1dd83cda5e35',
+          sourcePullRequestEvidenceSha256: '932e340efbef5df512d6317c05578350b3368ee6b72500d4d764ce622ed8519f',
+          affectedPaths: { length: 11 },
+          protectedPathTransitions: { length: 2 },
+        },
+      ],
+    })
+  })
+
+  test('accepts a reviewed single-stage v7 receipt with one exact reviewed protected-path successor', () => {
+    const fixture = singleStageSuccessorRemediationFixture()
+    expect(evaluateSingleStageSuccessorRemediationFixture(fixture)).toMatchObject({
+      status: 'eligible',
+      lastPublishedRevision: continuousHistory.published,
+      reviewedPullRequests: [
+        { commitSha: continuousHistory.blocked, prNumber: 13426, headSha: continuousHistory.finalHead },
+        { commitSha: '2aa782001a9d7e1d9db68e5fa0929159755334cd', prNumber: 13432 },
+        { commitSha: successorBoundHistory.updateMerge, prNumber: 13446 },
+      ],
+    })
+  })
+
+  test('rejects a v7 receipt whose reviewed successor is missing', () => {
+    const fixture = singleStageSuccessorRemediationFixture()
+    const comparison = fixture.snapshot.comparison
+    const record = fixture.evidence.record
+    if (comparison === null || record.schemaVersion !== 'bayn.release-review-remediation.v7') {
+      throw new Error('missing v7 fixture')
+    }
+    const commits = comparison.commits.filter((commit) => commit.sha !== record.requiredSuccessors[0].mergeCommitSha)
+    ;(fixture.snapshot as unknown as { comparison: BaynReleaseComparison }).comparison = {
+      ...comparison,
+      commits,
+      aheadBy: commits.length,
+      totalCommits: commits.length,
+    }
+    expect(evaluateSingleStageSuccessorRemediationFixture(fixture)).toMatchObject({
+      status: 'hold',
+      code: 'release-review-remediation-invalid',
+      retryable: false,
+    })
+  })
+
+  test('rejects a v7 receipt after an undeclared later protected-path mutation', () => {
+    const fixture = singleStageSuccessorRemediationFixture()
+    const comparison = fixture.snapshot.comparison
+    const record = fixture.evidence.record
+    if (comparison === null || record.schemaVersion !== 'bayn.release-review-remediation.v7') {
+      throw new Error('missing v7 fixture')
+    }
+    const transition = record.requiredSuccessors[0].protectedPathTransitions[0]
+    const later = comparison.commits.find((commit) => commit.sha === successorBoundHistory.updateMerge)
+    if (later === undefined) throw new Error('missing later reviewed commit')
+    ;(later as unknown as { files: string[] }).files = [...later.files, transition.path]
+    ;(later as unknown as { fileChanges: BaynReleaseCommitFileChange[] }).fileChanges = [
+      ...(later.fileChanges ?? []),
+      {
+        path: transition.path,
+        previousPath: null,
+        status: 'modified',
+        blobSha: '0'.repeat(40),
+      },
+    ]
+    expect(evaluateSingleStageSuccessorRemediationFixture(fixture)).toMatchObject({
+      status: 'hold',
+      code: 'release-review-remediation-invalid',
+      retryable: false,
+    })
+  })
+
   test('parses the exact immutable #13426 continuous-source v6 receipt with reviewed successor and completion', () => {
     expect(realContinuousRemediationRecord).toMatchObject({
       schemaVersion: 'bayn.release-review-remediation.v6',
@@ -3085,9 +3268,12 @@ describe('Bayn publication-range eligibility', () => {
     )?.reviewSnapshot?.pullRequest
     if (pull === undefined || pull === null) throw new Error('missing introduction pull')
     mutate(pull)
-    ;(
-      fixture.evidence.record.introduction as { sourcePullRequestEvidenceSha256: string }
-    ).sourcePullRequestEvidenceSha256 = pullRequestReviewEvidenceSha256(pull)
+    const record = fixture.evidence.record
+    if (record.schemaVersion !== 'bayn.release-review-remediation.v3' || record.introduction === undefined) {
+      throw new Error('expected a v3 introduction receipt')
+    }
+    ;(record.introduction as { sourcePullRequestEvidenceSha256: string }).sourcePullRequestEvidenceSha256 =
+      pullRequestReviewEvidenceSha256(pull)
     expect(
       requireEligibilityHold(
         evaluateBaynReleaseEligibility({

--- a/packages/scripts/src/bayn/verify-release-review.ts
+++ b/packages/scripts/src/bayn/verify-release-review.ts
@@ -345,11 +345,20 @@ interface BaynReleaseReviewRemediationSuccessorBoundContinuousSourceRecord {
   readonly completion: BaynReleaseReviewRemediationContinuousSourceCompletion
 }
 
+interface BaynReleaseReviewRemediationSingleStageSuccessorRecord {
+  readonly schemaVersion: 'bayn.release-review-remediation.v7'
+  readonly remediationId: string
+  readonly blocked: BaynReleaseReviewRemediationContinuousSourceRecord['blocked']
+  readonly requiredDescendants: readonly []
+  readonly requiredSuccessors: readonly [BaynReleaseReviewRemediationContinuousSourceSuccessor]
+}
+
 export type BaynReleaseReviewRemediationRecord =
   | BaynReleaseReviewRemediationLegacyRecord
   | BaynReleaseReviewRemediationContinuousSourceRecord
   | BaynReleaseReviewRemediationCompletedContinuousSourceRecord
   | BaynReleaseReviewRemediationSuccessorBoundContinuousSourceRecord
+  | BaynReleaseReviewRemediationSingleStageSuccessorRecord
 
 interface RemediationCommitObject {
   readonly sha: string
@@ -773,6 +782,72 @@ const parseRemediationReconstruction = (value: unknown): BaynReleaseReviewRemedi
   }
 }
 
+const parseContinuousSourceSuccessor = (value: unknown): BaynReleaseReviewRemediationContinuousSourceSuccessor => {
+  const successor = strictRecord(
+    value,
+    [
+      'mergeCommitSha',
+      'mergeParentSha',
+      'mergeTreeSha',
+      'sourcePullRequestNumber',
+      'finalHeadSha',
+      'finalHeadParentSha',
+      'finalHeadTreeSha',
+      'sourcePullRequestEvidenceSha256',
+      'affectedPaths',
+      'protectedPathTransitions',
+    ],
+    'remediation successor',
+  )
+  if (!Array.isArray(successor.affectedPaths)) {
+    throw new Error('remediation successor affectedPaths must be an array')
+  }
+  if (!Array.isArray(successor.protectedPathTransitions) || successor.protectedPathTransitions.length === 0) {
+    throw new Error('remediation successor protectedPathTransitions must be a non-empty array')
+  }
+  const protectedPathTransitions = successor.protectedPathTransitions.map((item, index) => {
+    const transition = strictRecord(
+      item,
+      ['path', 'beforeBlobSha', 'afterBlobSha'],
+      `remediation successor protected path transition ${index}`,
+    )
+    return {
+      path: expectString(transition.path, `remediation successor protected path transition ${index} path`),
+      beforeBlobSha: expectSha(
+        transition.beforeBlobSha,
+        `remediation successor protected path transition ${index} before blob SHA`,
+      ),
+      afterBlobSha: expectSha(
+        transition.afterBlobSha,
+        `remediation successor protected path transition ${index} after blob SHA`,
+      ),
+    }
+  })
+  if (new Set(protectedPathTransitions.map((transition) => transition.path)).size !== protectedPathTransitions.length) {
+    throw new Error('remediation successor protected path transitions contain duplicate paths')
+  }
+  return {
+    mergeCommitSha: expectSha(successor.mergeCommitSha, 'remediation successor merge commit SHA'),
+    mergeParentSha: expectSha(successor.mergeParentSha, 'remediation successor merge parent SHA'),
+    mergeTreeSha: expectSha(successor.mergeTreeSha, 'remediation successor merge tree SHA'),
+    sourcePullRequestNumber: expectPositiveIntegerRecord(
+      successor.sourcePullRequestNumber,
+      'remediation successor source pull request number',
+    ),
+    finalHeadSha: expectSha(successor.finalHeadSha, 'remediation successor final head SHA'),
+    finalHeadParentSha: expectSha(successor.finalHeadParentSha, 'remediation successor final head parent SHA'),
+    finalHeadTreeSha: expectSha(successor.finalHeadTreeSha, 'remediation successor final head tree SHA'),
+    sourcePullRequestEvidenceSha256: expectSha256(
+      successor.sourcePullRequestEvidenceSha256,
+      'remediation successor source pull request evidence hash',
+    ),
+    affectedPaths: successor.affectedPaths.map((item, index) =>
+      parseRemediationCommitPath(item, `remediation successor affected path ${index}`),
+    ),
+    protectedPathTransitions,
+  }
+}
+
 export const parseBaynReleaseReviewRemediationRecord = (value: unknown): BaynReleaseReviewRemediationRecord => {
   const rawRecord = expectRecord(value, 'remediation')
   const rawSchemaVersion = rawRecord.schemaVersion
@@ -782,7 +857,8 @@ export const parseBaynReleaseReviewRemediationRecord = (value: unknown): BaynRel
     rawSchemaVersion !== 'bayn.release-review-remediation.v3' &&
     rawSchemaVersion !== 'bayn.release-review-remediation.v4' &&
     rawSchemaVersion !== 'bayn.release-review-remediation.v5' &&
-    rawSchemaVersion !== 'bayn.release-review-remediation.v6'
+    rawSchemaVersion !== 'bayn.release-review-remediation.v6' &&
+    rawSchemaVersion !== 'bayn.release-review-remediation.v7'
   ) {
     throw new Error('remediation schemaVersion is invalid')
   }
@@ -790,7 +866,8 @@ export const parseBaynReleaseReviewRemediationRecord = (value: unknown): BaynRel
   if (
     schemaVersion === 'bayn.release-review-remediation.v4' ||
     schemaVersion === 'bayn.release-review-remediation.v5' ||
-    schemaVersion === 'bayn.release-review-remediation.v6'
+    schemaVersion === 'bayn.release-review-remediation.v6' ||
+    schemaVersion === 'bayn.release-review-remediation.v7'
   ) {
     const record = strictRecord(
       value,
@@ -798,15 +875,17 @@ export const parseBaynReleaseReviewRemediationRecord = (value: unknown): BaynRel
         ? ['schemaVersion', 'remediationId', 'blocked', 'requiredDescendants']
         : schemaVersion === 'bayn.release-review-remediation.v5'
           ? ['schemaVersion', 'remediationId', 'blocked', 'requiredDescendants', 'introduction']
-          : [
-              'schemaVersion',
-              'remediationId',
-              'blocked',
-              'requiredDescendants',
-              'requiredSuccessors',
-              'introduction',
-              'completion',
-            ],
+          : schemaVersion === 'bayn.release-review-remediation.v7'
+            ? ['schemaVersion', 'remediationId', 'blocked', 'requiredDescendants', 'requiredSuccessors']
+            : [
+                'schemaVersion',
+                'remediationId',
+                'blocked',
+                'requiredDescendants',
+                'requiredSuccessors',
+                'introduction',
+                'completion',
+              ],
       'remediation',
     )
     const remediationId = expectString(record.remediationId, 'remediation ID')
@@ -851,6 +930,18 @@ export const parseBaynReleaseReviewRemediationRecord = (value: unknown): BaynRel
     }
     if (schemaVersion === 'bayn.release-review-remediation.v4') {
       return { schemaVersion, remediationId, blocked: parsedBlocked, requiredDescendants: [] }
+    }
+    if (schemaVersion === 'bayn.release-review-remediation.v7') {
+      if (!Array.isArray(record.requiredSuccessors) || record.requiredSuccessors.length !== 1) {
+        throw new Error('continuous-source remediation requiredSuccessors must contain exactly one successor')
+      }
+      return {
+        schemaVersion,
+        remediationId,
+        blocked: parsedBlocked,
+        requiredDescendants: [],
+        requiredSuccessors: [parseContinuousSourceSuccessor(record.requiredSuccessors[0])],
+      }
     }
     const introduction = strictRecord(
       record.introduction,
@@ -925,78 +1016,12 @@ export const parseBaynReleaseReviewRemediationRecord = (value: unknown): BaynRel
     if (!Array.isArray(record.requiredSuccessors) || record.requiredSuccessors.length !== 1) {
       throw new Error('continuous-source remediation requiredSuccessors must contain exactly one successor')
     }
-    const successor = strictRecord(
-      record.requiredSuccessors[0],
-      [
-        'mergeCommitSha',
-        'mergeParentSha',
-        'mergeTreeSha',
-        'sourcePullRequestNumber',
-        'finalHeadSha',
-        'finalHeadParentSha',
-        'finalHeadTreeSha',
-        'sourcePullRequestEvidenceSha256',
-        'affectedPaths',
-        'protectedPathTransitions',
-      ],
-      'remediation successor',
-    )
-    if (!Array.isArray(successor.affectedPaths)) {
-      throw new Error('remediation successor affectedPaths must be an array')
-    }
-    if (!Array.isArray(successor.protectedPathTransitions) || successor.protectedPathTransitions.length === 0) {
-      throw new Error('remediation successor protectedPathTransitions must be a non-empty array')
-    }
-    const protectedPathTransitions = successor.protectedPathTransitions.map((item, index) => {
-      const transition = strictRecord(
-        item,
-        ['path', 'beforeBlobSha', 'afterBlobSha'],
-        `remediation successor protected path transition ${index}`,
-      )
-      return {
-        path: expectString(transition.path, `remediation successor protected path transition ${index} path`),
-        beforeBlobSha: expectSha(
-          transition.beforeBlobSha,
-          `remediation successor protected path transition ${index} before blob SHA`,
-        ),
-        afterBlobSha: expectSha(
-          transition.afterBlobSha,
-          `remediation successor protected path transition ${index} after blob SHA`,
-        ),
-      }
-    })
-    if (
-      new Set(protectedPathTransitions.map((transition) => transition.path)).size !== protectedPathTransitions.length
-    ) {
-      throw new Error('remediation successor protected path transitions contain duplicate paths')
-    }
     return {
       schemaVersion,
       remediationId,
       blocked: parsedBlocked,
       requiredDescendants: [],
-      requiredSuccessors: [
-        {
-          mergeCommitSha: expectSha(successor.mergeCommitSha, 'remediation successor merge commit SHA'),
-          mergeParentSha: expectSha(successor.mergeParentSha, 'remediation successor merge parent SHA'),
-          mergeTreeSha: expectSha(successor.mergeTreeSha, 'remediation successor merge tree SHA'),
-          sourcePullRequestNumber: expectPositiveIntegerRecord(
-            successor.sourcePullRequestNumber,
-            'remediation successor source pull request number',
-          ),
-          finalHeadSha: expectSha(successor.finalHeadSha, 'remediation successor final head SHA'),
-          finalHeadParentSha: expectSha(successor.finalHeadParentSha, 'remediation successor final head parent SHA'),
-          finalHeadTreeSha: expectSha(successor.finalHeadTreeSha, 'remediation successor final head tree SHA'),
-          sourcePullRequestEvidenceSha256: expectSha256(
-            successor.sourcePullRequestEvidenceSha256,
-            'remediation successor source pull request evidence hash',
-          ),
-          affectedPaths: successor.affectedPaths.map((item, index) =>
-            parseRemediationCommitPath(item, `remediation successor affected path ${index}`),
-          ),
-          protectedPathTransitions,
-        },
-      ],
+      requiredSuccessors: [parseContinuousSourceSuccessor(record.requiredSuccessors[0])],
       introduction: parsedIntroduction,
       completion: {
         mergeCommitSha: expectSha(completion.mergeCommitSha, 'remediation completion merge commit SHA'),
@@ -2423,7 +2448,8 @@ const validateContinuousSourceRemediation = (input: {
   if (
     record.schemaVersion !== 'bayn.release-review-remediation.v4' &&
     record.schemaVersion !== 'bayn.release-review-remediation.v5' &&
-    record.schemaVersion !== 'bayn.release-review-remediation.v6'
+    record.schemaVersion !== 'bayn.release-review-remediation.v6' &&
+    record.schemaVersion !== 'bayn.release-review-remediation.v7'
   ) {
     return remediationInvalid(`remediation ${record.remediationId} continuous source record is missing`)
   }
@@ -2503,7 +2529,10 @@ const validateContinuousSourceRemediation = (input: {
     string,
     BaynReleaseReviewRemediationContinuousSourceSuccessor['protectedPathTransitions'][number]
   > = new Map()
-  if (record.schemaVersion === 'bayn.release-review-remediation.v6') {
+  if (
+    record.schemaVersion === 'bayn.release-review-remediation.v6' ||
+    record.schemaVersion === 'bayn.release-review-remediation.v7'
+  ) {
     const successor = record.requiredSuccessors[0]
     const successorMatches = comparison.commits.filter((commit) => commit.sha === successor.mergeCommitSha)
     const transitionPaths = successor.protectedPathTransitions.map((transition) => transition.path)
@@ -2844,7 +2873,8 @@ const validateReleaseReviewRemediation = (input: {
   if (
     record.schemaVersion === 'bayn.release-review-remediation.v4' ||
     record.schemaVersion === 'bayn.release-review-remediation.v5' ||
-    record.schemaVersion === 'bayn.release-review-remediation.v6'
+    record.schemaVersion === 'bayn.release-review-remediation.v6' ||
+    record.schemaVersion === 'bayn.release-review-remediation.v7'
   ) {
     return validateContinuousSourceRemediation({
       evidence,
@@ -3314,32 +3344,35 @@ export const evaluateBaynReleaseEligibility = (input: {
         coveredDescendantShas.add(introductionIdentity.mergeCommitSha)
       }
       if (
+        remediation[0].record.schemaVersion === 'bayn.release-review-remediation.v6' ||
+        remediation[0].record.schemaVersion === 'bayn.release-review-remediation.v7'
+      ) {
+        const successorIdentity = remediation[0].record.requiredSuccessors[0]
+        const successorCommit = comparison.commits.find(
+          (candidate) => candidate.sha === successorIdentity.mergeCommitSha,
+        )
+        const successorNormalReview = normalReviews.get(successorIdentity.mergeCommitSha)
+        if (successorCommit === undefined || successorNormalReview === undefined) {
+          return remediationInvalid(
+            `remediation ${remediation[0].record.remediationId} successor review snapshot is missing`,
+          )
+        }
+        const successorReview = evaluateBoundRemediationReview({
+          remediationId: remediation[0].record.remediationId,
+          commit: successorCommit,
+          identity: successorIdentity,
+          normalReview: successorNormalReview,
+          nowMs: input.nowMs,
+        })
+        if (successorReview.status === 'hold') return successorReview
+        normalReviews.set(successorIdentity.mergeCommitSha, successorReview)
+        coveredDescendantShas.add(successorIdentity.mergeCommitSha)
+      }
+
+      if (
         remediation[0].record.schemaVersion === 'bayn.release-review-remediation.v5' ||
         remediation[0].record.schemaVersion === 'bayn.release-review-remediation.v6'
       ) {
-        if (remediation[0].record.schemaVersion === 'bayn.release-review-remediation.v6') {
-          const successorIdentity = remediation[0].record.requiredSuccessors[0]
-          const successorCommit = comparison.commits.find(
-            (candidate) => candidate.sha === successorIdentity.mergeCommitSha,
-          )
-          const successorNormalReview = normalReviews.get(successorIdentity.mergeCommitSha)
-          if (successorCommit === undefined || successorNormalReview === undefined) {
-            return remediationInvalid(
-              `remediation ${remediation[0].record.remediationId} successor review snapshot is missing`,
-            )
-          }
-          const successorReview = evaluateBoundRemediationReview({
-            remediationId: remediation[0].record.remediationId,
-            commit: successorCommit,
-            identity: successorIdentity,
-            normalReview: successorNormalReview,
-            nowMs: input.nowMs,
-          })
-          if (successorReview.status === 'hold') return successorReview
-          normalReviews.set(successorIdentity.mergeCommitSha, successorReview)
-          coveredDescendantShas.add(successorIdentity.mergeCommitSha)
-        }
-
         const introductionIdentity = remediation[0].record.introduction
         const introductionCommit = comparison.commits.find(
           (candidate) => candidate.sha === introductionIdentity.mergeCommitSha,
@@ -3387,7 +3420,8 @@ export const evaluateBaynReleaseEligibility = (input: {
       if (
         remediation[0].record.schemaVersion === 'bayn.release-review-remediation.v4' ||
         remediation[0].record.schemaVersion === 'bayn.release-review-remediation.v5' ||
-        remediation[0].record.schemaVersion === 'bayn.release-review-remediation.v6'
+        remediation[0].record.schemaVersion === 'bayn.release-review-remediation.v6' ||
+        remediation[0].record.schemaVersion === 'bayn.release-review-remediation.v7'
       ) {
         const record = remediation[0].record
         const continuousReview = evaluateBoundRemediationReview({
@@ -4718,7 +4752,8 @@ const loadReleaseReviewRemediations = async (
     } else if (
       loaded.record.schemaVersion === 'bayn.release-review-remediation.v4' ||
       loaded.record.schemaVersion === 'bayn.release-review-remediation.v5' ||
-      loaded.record.schemaVersion === 'bayn.release-review-remediation.v6'
+      loaded.record.schemaVersion === 'bayn.release-review-remediation.v6' ||
+      loaded.record.schemaVersion === 'bayn.release-review-remediation.v7'
     ) {
       references.set(
         loaded.record.blocked.finalHeadSha,

--- a/services/bayn/release-review-remediations/ae4d23650c20cecbde2bac8416bc2b734381cb69.json
+++ b/services/bayn/release-review-remediations/ae4d23650c20cecbde2bac8416bc2b734381cb69.json
@@ -1,0 +1,121 @@
+{
+  "schemaVersion": "bayn.release-review-remediation.v7",
+  "remediationId": "pr-13438-successor-bound-reviewed-source",
+  "blocked": {
+    "mergeCommitSha": "ae4d23650c20cecbde2bac8416bc2b734381cb69",
+    "mergeParentSha": "7c2335792707e34ac41e4de5091d2e2af48b7657",
+    "mergeTreeSha": "1b5e5d4d3bcc38f0d25a8efafc7d0d60d689c640",
+    "sourcePullRequestNumber": 13438,
+    "finalHeadSha": "bf17a9387e69896095096b9447aafed52711333c",
+    "finalHeadParentSha": "7c2335792707e34ac41e4de5091d2e2af48b7657",
+    "finalHeadTreeSha": "1b5e5d4d3bcc38f0d25a8efafc7d0d60d689c640",
+    "sourcePullRequestEvidenceSha256": "25bd010d4dd974cc734799cba99495bbef170995535282e73579f4ba8c4f5afe",
+    "affectedPaths": [
+      {
+        "path": "services/bayn/src/candidate-development-command.test.ts",
+        "previousPath": null,
+        "status": "modified",
+        "blobSha": "fb328b420ccc0acd6ca8376ce819909fd7a87eaf"
+      },
+      {
+        "path": "services/bayn/src/candidate-development-command.ts",
+        "previousPath": null,
+        "status": "modified",
+        "blobSha": "eb0e66568f0872434a753de6512844ea2a854ea1"
+      }
+    ]
+  },
+  "requiredDescendants": [],
+  "requiredSuccessors": [
+    {
+      "mergeCommitSha": "fa2016a8aa3c8b0f466ab84a7956c704dd9056c7",
+      "mergeParentSha": "ae4d23650c20cecbde2bac8416bc2b734381cb69",
+      "mergeTreeSha": "f532e9227a17089d2c504dbd241d2bb37ade7cd7",
+      "sourcePullRequestNumber": 13442,
+      "finalHeadSha": "a7b608a873057d9f65625515140e1dd83cda5e35",
+      "finalHeadParentSha": "ae4d23650c20cecbde2bac8416bc2b734381cb69",
+      "finalHeadTreeSha": "f532e9227a17089d2c504dbd241d2bb37ade7cd7",
+      "sourcePullRequestEvidenceSha256": "932e340efbef5df512d6317c05578350b3368ee6b72500d4d764ce622ed8519f",
+      "affectedPaths": [
+        {
+          "path": "services/bayn/candidates/ordinal-20-cross-sectional-short-term-reversal-invalidation.json",
+          "previousPath": null,
+          "status": "added",
+          "blobSha": "660a05860b133ead5242416635973cd82ed6c470"
+        },
+        {
+          "path": "services/bayn/src/candidate-development-calendar.ts",
+          "previousPath": null,
+          "status": "modified",
+          "blobSha": "9b1f80f3d993abc3e0c8838ec9bc786cd361c905"
+        },
+        {
+          "path": "services/bayn/src/candidate-development-candidate-17.test.ts",
+          "previousPath": null,
+          "status": "modified",
+          "blobSha": "cfde95dc53ff095f9fd33aaaf49b753bcdcc9ce6"
+        },
+        {
+          "path": "services/bayn/src/candidate-development-candidate-18.test.ts",
+          "previousPath": null,
+          "status": "modified",
+          "blobSha": "6e58a78c74fc754c1471a04fef8e9f1618732183"
+        },
+        {
+          "path": "services/bayn/src/candidate-development-candidate-19.test.ts",
+          "previousPath": null,
+          "status": "modified",
+          "blobSha": "5940dc6c97a1436bd08cb33a3dca0f47b105dbb1"
+        },
+        {
+          "path": "services/bayn/src/candidate-development-candidate-20.test.ts",
+          "previousPath": null,
+          "status": "modified",
+          "blobSha": "e1c8dedaa0a3fdc1871ee77e263f7091ee6c5cbe"
+        },
+        {
+          "path": "services/bayn/src/candidate-development-command.test.ts",
+          "previousPath": null,
+          "status": "modified",
+          "blobSha": "4a73bd65b65da8ec352147e27733a27abbf53828"
+        },
+        {
+          "path": "services/bayn/src/candidate-development-command.ts",
+          "previousPath": null,
+          "status": "modified",
+          "blobSha": "3d328521e448ecee3c1ff82995b9a85f3b25d7a5"
+        },
+        {
+          "path": "services/bayn/src/candidate-development-evidence.test.ts",
+          "previousPath": null,
+          "status": "modified",
+          "blobSha": "e591e037c97217fb48ec21770478b647954f3d1b"
+        },
+        {
+          "path": "services/bayn/src/candidate-development-trial-history.ts",
+          "previousPath": null,
+          "status": "modified",
+          "blobSha": "0133484cd4d09ae21c03e42beea91e53f4ab70e2"
+        },
+        {
+          "path": "services/bayn/src/strategy/cross-sectional-short-term-reversal/candidate-20.ts",
+          "previousPath": null,
+          "status": "modified",
+          "blobSha": "9f61b1510da5cf973e11a75372b35f539f9b7b4d"
+        }
+      ],
+      "protectedPathTransitions": [
+        {
+          "path": "services/bayn/src/candidate-development-command.test.ts",
+          "beforeBlobSha": "fb328b420ccc0acd6ca8376ce819909fd7a87eaf",
+          "afterBlobSha": "4a73bd65b65da8ec352147e27733a27abbf53828"
+        },
+        {
+          "path": "services/bayn/src/candidate-development-command.ts",
+          "beforeBlobSha": "eb0e66568f0872434a753de6512844ea2a854ea1",
+          "afterBlobSha": "3d328521e448ecee3c1ff82995b9a85f3b25d7a5"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Add a fail-closed v7 release-review receipt for the exact reviewed #13438 source and its sole reviewed protected-path successor #13442.
- Validate exact merge/head parent-tree identity, immutable PR evidence, complete affected paths, protected blob transitions, and reject any undeclared later mutation.
- Add immutable production receipt coverage plus missing-successor and later-mutation regressions.

## Related Issues

PROOMPT-443

## Testing

- bun test packages/scripts/src/bayn/verify-release-review.test.ts (139 pass, 0 fail)
- bunx oxfmt --check packages/scripts/src/bayn/verify-release-review.ts packages/scripts/src/bayn/verify-release-review.test.ts services/bayn/release-review-remediations/ae4d23650c20cecbde2bac8416bc2b734381cb69.json
- bunx oxlint packages/scripts/src/bayn/verify-release-review.ts packages/scripts/src/bayn/verify-release-review.test.ts
- git diff --cached --check
- Mechanically verified the recorded merge/head parents, trees, and protected-path blob transitions with git show and git ls-tree.
- The broader local packages-scripts TypeScript suite has unrelated pre-existing failures outside these files; exact hosted required checks remain mandatory.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is handled.
- [x] The immutable remediation receipt and regression coverage are included.