### PR TITLE
fix(bayn): compose reviewed release remediations

### DIFF
--- a/packages/scripts/src/bayn/verify-release-review.test.ts
+++ b/packages/scripts/src/bayn/verify-release-review.test.ts
@@ -2218,17 +2218,133 @@ const singleStageSuccessorRemediationFixture = (): ReturnType<typeof successorBo
   ) {
     throw new Error('missing successor-bound continuous-source fixture')
   }
+  const currentSuccessor = currentRecord.requiredSuccessors[0]
+  const successorAffectedPaths = new Set(currentSuccessor.affectedPaths.map((path) => path.path))
+  const additionalBlockedPath = currentRecord.blocked.affectedPaths.find(
+    (path) => !successorAffectedPaths.has(path.path),
+  )
+  if (additionalBlockedPath === undefined) throw new Error('missing second synthetic v7 protected path')
+  const additionalAfterBlobSha = 'f'.repeat(40)
+  const successor = {
+    ...currentSuccessor,
+    affectedPaths: [
+      ...currentSuccessor.affectedPaths,
+      {
+        ...additionalBlockedPath,
+        previousPath: null,
+        status: 'modified' as const,
+        blobSha: additionalAfterBlobSha,
+      },
+    ],
+    protectedPathTransitions: [
+      ...currentSuccessor.protectedPathTransitions,
+      {
+        path: additionalBlockedPath.path,
+        beforeBlobSha: additionalBlockedPath.blobSha,
+        afterBlobSha: additionalAfterBlobSha,
+      },
+    ],
+  }
+  const successorTransitionPaths = new Set(successor.protectedPathTransitions.map((transition) => transition.path))
+  const blockedCommit = comparison.commits.find((commit) => commit.sha === currentRecord.blocked.mergeCommitSha)
+  const blockedPull = blockedCommit?.reviewSnapshot?.pullRequest
+  if (blockedCommit === undefined || blockedPull === null || blockedPull === undefined) {
+    throw new Error('missing v7 blocked source pull request')
+  }
+  const reviewedHeadSha = 'c'.repeat(40)
+  const reviewedHeadTreeSha = 'd'.repeat(40)
+  const reviewSubmittedAt = '2026-07-31T20:10:00Z'
+  const forcePushAt = '2026-07-31T20:20:00Z'
+  const findingBody = 'Catch the synchronous writer throw before it escapes the Effect boundary.'
+  const replyBody = 'Fixed in the final exact head with a real process regression.'
+  const reviewedAffectedPaths = currentRecord.blocked.affectedPaths
+    .filter((path) => successorTransitionPaths.has(path.path))
+    .map((path, index) => ({ ...path, blobSha: `${index + 5}`.repeat(40) }))
+  const feedbackPath = reviewedAffectedPaths[0]
+  if (feedbackPath === undefined) throw new Error('missing v7 feedback path')
+  ;(blockedPull as unknown as { createdAt: string; mergedAt: string }).createdAt = '2026-07-31T20:00:00Z'
+  ;(blockedPull as unknown as { mergedAt: string }).mergedAt = '2026-07-31T20:30:00Z'
+  ;(blockedPull as unknown as { reviews: readonly PullRequestReview[] }).reviews = [
+    review({ commitSha: reviewedHeadSha, submittedAt: reviewSubmittedAt }),
+  ]
+  ;(blockedPull as unknown as { threads: readonly PullRequestReviewThread[] }).threads = [
+    thread({
+      id: 'v7-reviewed-lineage-thread',
+      isResolved: true,
+      isOutdated: true,
+      path: feedbackPath.path,
+      comments: [
+        threadComment({
+          body: findingBody,
+          commitSha: reviewedHeadSha,
+          reviewCommitSha: reviewedHeadSha,
+          reviewSubmittedAt,
+          createdAt: reviewSubmittedAt,
+          url: 'https://github.com/proompteng/lab/pull/13438#discussion_r1',
+        }),
+        threadComment({
+          authorLogin: 'gregkonush',
+          authorAssociation: 'MEMBER',
+          body: replyBody,
+          commitSha: reviewedHeadSha,
+          reviewCommitSha: currentRecord.blocked.finalHeadSha,
+          reviewAuthorLogin: 'gregkonush',
+          reviewSubmittedAt: '2026-07-31T20:21:00Z',
+          createdAt: '2026-07-31T20:21:00Z',
+          url: 'https://github.com/proompteng/lab/pull/13438#discussion_r2',
+        }),
+      ],
+    }),
+  ]
+  ;(blockedPull as unknown as { reactions: readonly PullRequestReaction[] }).reactions = [
+    reaction({ createdAt: '2026-07-31T20:22:00Z' }),
+  ]
+  ;(blockedPull as unknown as { headForcePushes: readonly PullRequestForcePush[] }).headForcePushes = [
+    {
+      actorLogin: 'gregkonush',
+      beforeCommitSha: reviewedHeadSha,
+      afterCommitSha: currentRecord.blocked.finalHeadSha,
+      createdAt: forcePushAt,
+    },
+  ]
+  ;(blockedPull as unknown as { headForcePushCount: number }).headForcePushCount = 1
   const record = parseBaynReleaseReviewRemediationRecord({
     schemaVersion: 'bayn.release-review-remediation.v7',
     remediationId: 'pr-13438-successor-bound-reviewed-source',
-    blocked: currentRecord.blocked,
+    blocked: {
+      ...currentRecord.blocked,
+      affectedPaths: currentRecord.blocked.affectedPaths.filter((path) => successorTransitionPaths.has(path.path)),
+      sourcePullRequestEvidenceSha256: pullRequestReviewEvidenceSha256(blockedPull),
+      reviewedLineage: {
+        reviewedHeadSha,
+        reviewedHeadParentSha: currentRecord.blocked.mergeParentSha,
+        reviewedHeadTreeSha,
+        reviewSubmittedAt,
+        forcePush: {
+          beforeHeadSha: reviewedHeadSha,
+          afterHeadSha: currentRecord.blocked.finalHeadSha,
+          actorLogin: 'gregkonush',
+          createdAt: forcePushAt,
+        },
+        feedback: {
+          reviewedHeadSha,
+          fixedHeadSha: currentRecord.blocked.finalHeadSha,
+          threadId: 'v7-reviewed-lineage-thread',
+          path: feedbackPath.path,
+          findingUrl: 'https://github.com/proompteng/lab/pull/13438#discussion_r1',
+          findingBodySha256: sha256Text(findingBody),
+          fixReplyUrl: 'https://github.com/proompteng/lab/pull/13438#discussion_r2',
+          fixReplyBodySha256: sha256Text(replyBody),
+        },
+        affectedPaths: reviewedAffectedPaths,
+      },
+    },
     requiredDescendants: [],
-    requiredSuccessors: currentRecord.requiredSuccessors,
+    requiredSuccessors: [successor],
   })
   if (record.schemaVersion !== 'bayn.release-review-remediation.v7') {
     throw new Error('failed to derive the v7 single-stage successor fixture')
   }
-  const blockedCommit = comparison.commits.find((commit) => commit.sha === record.blocked.mergeCommitSha)
   const successorCommit = comparison.commits.find(
     (commit) => commit.sha === record.requiredSuccessors[0].mergeCommitSha,
   )
@@ -2236,6 +2352,16 @@ const singleStageSuccessorRemediationFixture = (): ReturnType<typeof successorBo
   if (blockedCommit === undefined || successorCommit === undefined || originalUpdate === undefined) {
     throw new Error('incomplete v7 single-stage successor fixture')
   }
+  ;(blockedCommit as unknown as { files: readonly string[] }).files = record.blocked.affectedPaths.map(
+    (path) => path.path,
+  )
+  ;(blockedCommit as unknown as { fileChanges: typeof record.blocked.affectedPaths }).fileChanges =
+    record.blocked.affectedPaths
+  ;(successorCommit as unknown as { files: readonly string[] }).files = record.requiredSuccessors[0].affectedPaths.map(
+    (path) => path.path,
+  )
+  ;(successorCommit as unknown as { fileChanges: readonly BaynReleaseCommitFileChange[] }).fileChanges =
+    record.requiredSuccessors[0].affectedPaths
   const updateCommit = {
     ...originalUpdate,
     parents: [successorCommit.sha],
@@ -2260,10 +2386,38 @@ const singleStageSuccessorRemediationFixture = (): ReturnType<typeof successorBo
   const evidence = {
     ...fixture.evidence,
     record,
-    referencedCommits: fixture.evidence.referencedCommits.filter(
-      (commit) =>
-        commit.sha === record.blocked.finalHeadSha || commit.sha === record.requiredSuccessors[0].finalHeadSha,
-    ),
+    referencedCommits: fixture.evidence.referencedCommits
+      .filter(
+        (commit) =>
+          commit.sha === record.blocked.finalHeadSha || commit.sha === record.requiredSuccessors[0].finalHeadSha,
+      )
+      .map((commit) => {
+        const affectedPaths =
+          commit.sha === record.blocked.finalHeadSha
+            ? record.blocked.affectedPaths
+            : record.requiredSuccessors[0].affectedPaths
+        return {
+          ...commit,
+          files: affectedPaths.map((path) => path.path),
+          fileChanges: affectedPaths,
+          pathBlobs: affectedPaths.map((path) => ({ path: path.path, blobSha: path.blobSha })),
+        }
+      })
+      .concat({
+        sha: record.blocked.reviewedLineage.reviewedHeadSha,
+        parents: [record.blocked.reviewedLineage.reviewedHeadParentSha],
+        treeSha: record.blocked.reviewedLineage.reviewedHeadTreeSha,
+        files: record.blocked.reviewedLineage.affectedPaths.map((path) => path.path),
+        fileChanges: record.blocked.reviewedLineage.affectedPaths,
+        pathBlobs: record.blocked.reviewedLineage.affectedPaths.map((path) => ({
+          path: path.path,
+          blobSha: path.blobSha,
+        })),
+      }),
+    currentPathBlobs: record.requiredSuccessors[0].protectedPathTransitions.map((transition) => ({
+      path: transition.path,
+      blobSha: transition.afterBlobSha,
+    })),
   }
   return {
     evidence,
@@ -2293,10 +2447,166 @@ const evaluateSingleStageSuccessorRemediationFixture = (
     pushBeforeSha: fixture.snapshot.currentCommitParents[0]!,
   })
 
+const nestedSingleStageSuccessorRemediationFixture = (): BaynReleaseEligibilitySnapshot => {
+  const fixture = singleStageSuccessorRemediationFixture()
+  const comparison = fixture.snapshot.comparison
+  const innerRecord = fixture.evidence.record
+  if (
+    comparison === null ||
+    comparison.status !== 'ahead' ||
+    innerRecord.schemaVersion !== 'bayn.release-review-remediation.v7'
+  ) {
+    throw new Error('missing nested v7 fixture')
+  }
+  const innerBlocked = comparison.commits.find((commit) => commit.sha === innerRecord.blocked.mergeCommitSha)
+  const update = comparison.commits.find((commit) => commit.sha === successorBoundHistory.updateMerge)
+  const innerFinalHead = fixture.evidence.referencedCommits.find(
+    (commit) => commit.sha === innerRecord.blocked.finalHeadSha,
+  )
+  const innerReviewedHead = fixture.evidence.referencedCommits.find(
+    (commit) => commit.sha === innerRecord.blocked.reviewedLineage.reviewedHeadSha,
+  )
+  if (
+    innerBlocked === undefined ||
+    update === undefined ||
+    innerFinalHead === undefined ||
+    innerReviewedHead === undefined
+  ) {
+    throw new Error('incomplete nested v7 fixture')
+  }
+
+  const outerMerge = 'd'.repeat(40)
+  const outerHead = 'e'.repeat(40)
+  const outerTree = 'f'.repeat(40)
+  const outerPath = 'services/bayn/src/nested-release-review-source.ts'
+  const outerBlob = '1'.repeat(40)
+  const outerRecordPath = `services/bayn/release-review-remediations/${outerMerge}.json`
+  const outerRecordBlob = '2'.repeat(40)
+  const outerReviewSnapshot = reviewSnapshotFor({
+    commitSha: outerMerge,
+    prNumber: 13425,
+    headSha: outerHead,
+    parents: [continuousHistory.published],
+    mergedAt: '2026-07-31T20:00:00Z',
+    reviews: [review({ commitSha: '3'.repeat(40), submittedAt: '2026-07-31T19:55:00Z' })],
+    reactions: [reaction({ createdAt: '2026-07-31T19:59:30Z' })],
+    headForcePushes: [
+      {
+        actorLogin: 'gregkonush',
+        beforeCommitSha: '3'.repeat(40),
+        afterCommitSha: outerHead,
+        createdAt: '2026-07-31T19:59:10Z',
+      },
+    ],
+    headForcePushCount: 1,
+  })
+  const outerPull = outerReviewSnapshot.pullRequest
+  if (outerPull === null) throw new Error('missing nested outer pull request')
+  const outerRecord = parseBaynReleaseReviewRemediationRecord({
+    schemaVersion: 'bayn.release-review-remediation.v4',
+    remediationId: 'nested-reviewed-source',
+    blocked: {
+      mergeCommitSha: outerMerge,
+      mergeParentSha: continuousHistory.published,
+      mergeTreeSha: outerTree,
+      sourcePullRequestNumber: 13425,
+      finalHeadSha: outerHead,
+      finalHeadParentSha: continuousHistory.published,
+      finalHeadTreeSha: outerTree,
+      sourcePullRequestEvidenceSha256: pullRequestReviewEvidenceSha256(outerPull),
+      affectedPaths: [
+        {
+          path: outerPath,
+          previousPath: null,
+          status: 'modified',
+          blobSha: outerBlob,
+        },
+      ],
+    },
+    requiredDescendants: [],
+  })
+  const outerCommit = {
+    sha: outerMerge,
+    parents: [continuousHistory.published],
+    treeSha: outerTree,
+    files: [outerPath],
+    fileChanges: [
+      {
+        path: outerPath,
+        previousPath: null,
+        status: 'modified',
+        blobSha: outerBlob,
+      },
+    ] satisfies readonly BaynReleaseCommitFileChange[],
+    reviewSnapshot: outerReviewSnapshot,
+  }
+
+  ;(innerBlocked as unknown as { parents: readonly string[] }).parents = [outerMerge]
+  if (innerBlocked.reviewSnapshot !== null) {
+    ;(innerBlocked.reviewSnapshot as unknown as { mainCommitParents: readonly string[] }).mainCommitParents = [
+      outerMerge,
+    ]
+  }
+  ;(innerRecord.blocked as unknown as { mergeParentSha: string; finalHeadParentSha: string }).mergeParentSha =
+    outerMerge
+  ;(innerRecord.blocked as unknown as { mergeParentSha: string; finalHeadParentSha: string }).finalHeadParentSha =
+    outerMerge
+  ;(innerRecord.blocked.reviewedLineage as unknown as { reviewedHeadParentSha: string }).reviewedHeadParentSha =
+    outerMerge
+  ;(innerFinalHead as unknown as { parents: readonly string[] }).parents = [outerMerge]
+  ;(innerReviewedHead as unknown as { parents: readonly string[] }).parents = [outerMerge]
+
+  const outerRecordChange: BaynReleaseCommitFileChange = {
+    path: outerRecordPath,
+    previousPath: null,
+    status: 'added',
+    blobSha: outerRecordBlob,
+  }
+  ;(update as unknown as { files: readonly string[] }).files = [...update.files, outerRecordPath]
+  ;(update as unknown as { fileChanges: readonly BaynReleaseCommitFileChange[] }).fileChanges = [
+    ...(update.fileChanges ?? []),
+    outerRecordChange,
+  ]
+  const outerEvidence: BaynReleaseReviewRemediationEvidence = {
+    recordPath: outerRecordPath,
+    recordBlobSha: outerRecordBlob,
+    record: outerRecord,
+    referencedCommits: [
+      {
+        sha: outerHead,
+        parents: [continuousHistory.published],
+        treeSha: outerTree,
+        files: [outerPath],
+        fileChanges: [
+          {
+            path: outerPath,
+            previousPath: null,
+            status: 'modified',
+            blobSha: outerBlob,
+          },
+        ],
+        pathBlobs: [{ path: outerPath, blobSha: outerBlob }],
+      },
+    ],
+    currentPathBlobs: [{ path: outerPath, blobSha: outerBlob }],
+  }
+  const commits = [outerCommit, ...comparison.commits]
+  return {
+    ...fixture.snapshot,
+    comparison: {
+      ...comparison,
+      aheadBy: commits.length,
+      totalCommits: commits.length,
+      commits,
+    },
+    remediations: [outerEvidence, fixture.evidence],
+  }
+}
+
 describe('Bayn publication-range eligibility', () => {
-  test('parses the exact immutable #13438 -> #13442 v7 reviewed-source receipt', () => {
+  test('parses the exact immutable #13438 -> #13442 v8 reviewed-source receipt', () => {
     expect(realCandidateDiagnosticsRemediationRecord).toMatchObject({
-      schemaVersion: 'bayn.release-review-remediation.v7',
+      schemaVersion: 'bayn.release-review-remediation.v8',
       remediationId: 'pr-13438-successor-bound-reviewed-source',
       blocked: {
         mergeCommitSha: 'ae4d23650c20cecbde2bac8416bc2b734381cb69',
@@ -2304,6 +2614,24 @@ describe('Bayn publication-range eligibility', () => {
         finalHeadSha: 'bf17a9387e69896095096b9447aafed52711333c',
         sourcePullRequestEvidenceSha256: '25bd010d4dd974cc734799cba99495bbef170995535282e73579f4ba8c4f5afe',
         affectedPaths: { length: 2 },
+        reviewedLineage: {
+          reviewedHeadSha: '9452b41b051f79f65a3dcc825593afb0390a0b2f',
+          reviewedHeadParentSha: '7c2335792707e34ac41e4de5091d2e2af48b7657',
+          reviewedHeadTreeSha: '3e11aedd2f991db054b78143956719fc3dad6744',
+          reviewSubmittedAt: '2026-08-01T01:01:06Z',
+          forcePush: {
+            beforeHeadSha: '9452b41b051f79f65a3dcc825593afb0390a0b2f',
+            afterHeadSha: 'bf17a9387e69896095096b9447aafed52711333c',
+            actorLogin: 'gregkonush',
+            createdAt: '2026-08-01T01:05:01Z',
+          },
+          feedback: {
+            threadId: 'PRRT_kwDOLkRLus6VkaW3',
+            findingBodySha256: 'b2888751b80020f76a4fbd9a733304a607fc3c6725a5ae3f5766ddbe560a0e72',
+            fixReplyBodySha256: 'd790110b2808020d52559efbe5e72042d746c593baf94536e0034acb01f4dfc0',
+          },
+          affectedPaths: { length: 2 },
+        },
       },
       requiredDescendants: [],
       requiredSuccessors: [
@@ -2316,20 +2644,112 @@ describe('Bayn publication-range eligibility', () => {
           protectedPathTransitions: { length: 2 },
         },
       ],
+      introduction: {
+        mergeCommitSha: '628d3fd16d63f7b9e3fc02d3bbdfa130a121ed31',
+        mergeParentSha: '045b69acf7681162983fa228b6d66b6677233ff2',
+        sourcePullRequestNumber: 13448,
+        finalHeadSha: '211a901ddeacf6cab997252dee85e180e94595fa',
+        sourcePullRequestEvidenceSha256: '8e59ead9e8a8c57c8c64c0b37ea1c5298b292dbc0b1efd69645ceb1678ae49b0',
+        introducedRecordBlobSha: '2855013d0a960ebc9b2ee100301334fc1640d297',
+        affectedPaths: { length: 3 },
+      },
     })
   })
 
-  test('accepts a reviewed single-stage v7 receipt with one exact reviewed protected-path successor', () => {
+  test('accepts a v7 receipt only through exact reviewed lineage and a reviewed successor', () => {
     const fixture = singleStageSuccessorRemediationFixture()
+    const record = fixture.evidence.record
+    if (record.schemaVersion !== 'bayn.release-review-remediation.v7') throw new Error('missing v7 fixture')
     expect(evaluateSingleStageSuccessorRemediationFixture(fixture)).toMatchObject({
       status: 'eligible',
       lastPublishedRevision: continuousHistory.published,
       reviewedPullRequests: [
-        { commitSha: continuousHistory.blocked, prNumber: 13426, headSha: continuousHistory.finalHead },
+        {
+          commitSha: continuousHistory.blocked,
+          prNumber: record.requiredSuccessors[0].sourcePullRequestNumber,
+          headSha: record.requiredSuccessors[0].finalHeadSha,
+        },
         { commitSha: '2aa782001a9d7e1d9db68e5fa0929159755334cd', prNumber: 13432 },
         { commitSha: successorBoundHistory.updateMerge, prNumber: 13446 },
       ],
     })
+  })
+
+  test('rejects a touched-only v7 successor without exact reviewed-head lineage', () => {
+    const record = structuredClone(realCandidateDiagnosticsRemediationRecord) as unknown as Record<string, unknown>
+    const blocked = record.blocked as Record<string, unknown>
+    delete blocked.reviewedLineage
+    expect(() => parseBaynReleaseReviewRemediationRecord(record)).toThrow()
+  })
+
+  test('rejects a v7 receipt when the reconstructed reviewed blob differs', () => {
+    const fixture = singleStageSuccessorRemediationFixture()
+    const record = fixture.evidence.record
+    if (record.schemaVersion !== 'bayn.release-review-remediation.v7') throw new Error('missing v7 fixture')
+    const reviewedHead = fixture.evidence.referencedCommits.find(
+      (commit) => commit.sha === record.blocked.reviewedLineage.reviewedHeadSha,
+    )
+    const reviewedBlob = reviewedHead?.pathBlobs[0]
+    if (reviewedBlob === undefined) throw new Error('missing reviewed lineage blob')
+    ;(reviewedBlob as unknown as { blobSha: string }).blobSha = '0'.repeat(40)
+    expect(evaluateSingleStageSuccessorRemediationFixture(fixture)).toMatchObject({
+      status: 'hold',
+      code: 'release-review-remediation-invalid',
+      retryable: false,
+    })
+  })
+
+  test('rejects a v7 receipt when the latest reviewed-head force push differs', () => {
+    const fixture = singleStageSuccessorRemediationFixture()
+    const record = fixture.evidence.record
+    if (record.schemaVersion !== 'bayn.release-review-remediation.v7') throw new Error('missing v7 fixture')
+    const blockedCommit = fixture.snapshot.comparison?.commits.find(
+      (commit) => commit.sha === record.blocked.mergeCommitSha,
+    )
+    const pullRequest = blockedCommit?.reviewSnapshot?.pullRequest
+    const forcePush = pullRequest?.headForcePushes[0]
+    if (pullRequest === null || pullRequest === undefined || forcePush === undefined) {
+      throw new Error('missing v7 reviewed lineage force push')
+    }
+    ;(forcePush as unknown as { beforeCommitSha: string }).beforeCommitSha = '0'.repeat(40)
+    ;(record.blocked as unknown as { sourcePullRequestEvidenceSha256: string }).sourcePullRequestEvidenceSha256 =
+      pullRequestReviewEvidenceSha256(pullRequest)
+    expect(evaluateSingleStageSuccessorRemediationFixture(fixture)).toMatchObject({
+      status: 'hold',
+      code: 'release-review-remediation-invalid',
+      retryable: false,
+    })
+  })
+
+  test('rejects a v7 receipt whose reviewed successor leaves any unreviewed blocked path intact', () => {
+    const fixture = singleStageSuccessorRemediationFixture()
+    const record = fixture.evidence.record
+    if (record.schemaVersion !== 'bayn.release-review-remediation.v7') throw new Error('missing v7 fixture')
+    const firstTransition = record.requiredSuccessors[0].protectedPathTransitions[0]
+    if (firstTransition === undefined) throw new Error('missing v7 protected transition')
+    ;(
+      record.requiredSuccessors[0] as unknown as {
+        protectedPathTransitions: readonly [typeof firstTransition]
+      }
+    ).protectedPathTransitions = [firstTransition]
+    expect(evaluateSingleStageSuccessorRemediationFixture(fixture)).toMatchObject({
+      status: 'hold',
+      code: 'release-review-remediation-invalid',
+      retryable: false,
+    })
+  })
+
+  test('composes an earlier continuous receipt with a later v7 remediation instead of requiring the blocked head twice', () => {
+    const snapshot = nestedSingleStageSuccessorRemediationFixture()
+    expect(
+      evaluateBaynReleaseEligibility({
+        mainCommitSha: successorBoundHistory.updateMerge,
+        baseRefName: 'main',
+        snapshot,
+        nowMs: successorBoundNowMs,
+        pushBeforeSha: snapshot.currentCommitParents[0]!,
+      }),
+    ).toMatchObject({ status: 'eligible' })
   })
 
   test('rejects a v7 receipt whose reviewed successor is missing', () => {

--- a/packages/scripts/src/bayn/verify-release-review.ts
+++ b/packages/scripts/src/bayn/verify-release-review.ts
@@ -335,6 +335,16 @@ interface BaynReleaseReviewRemediationContinuousSourceSuccessor {
   }[]
 }
 
+interface BaynReleaseReviewRemediationReviewedLineage {
+  readonly reviewedHeadSha: string
+  readonly reviewedHeadParentSha: string
+  readonly reviewedHeadTreeSha: string
+  readonly reviewSubmittedAt: string
+  readonly forcePush: BaynReleaseReviewRemediationForcePush
+  readonly feedback: BaynReleaseReviewRemediationFeedback
+  readonly affectedPaths: readonly BaynReleaseReviewRemediationCommitPath[]
+}
+
 interface BaynReleaseReviewRemediationSuccessorBoundContinuousSourceRecord {
   readonly schemaVersion: 'bayn.release-review-remediation.v6'
   readonly remediationId: string
@@ -348,9 +358,20 @@ interface BaynReleaseReviewRemediationSuccessorBoundContinuousSourceRecord {
 interface BaynReleaseReviewRemediationSingleStageSuccessorRecord {
   readonly schemaVersion: 'bayn.release-review-remediation.v7'
   readonly remediationId: string
-  readonly blocked: BaynReleaseReviewRemediationContinuousSourceRecord['blocked']
+  readonly blocked: BaynReleaseReviewRemediationContinuousSourceRecord['blocked'] & {
+    readonly reviewedLineage: BaynReleaseReviewRemediationReviewedLineage
+  }
   readonly requiredDescendants: readonly []
   readonly requiredSuccessors: readonly [BaynReleaseReviewRemediationContinuousSourceSuccessor]
+}
+
+interface BaynReleaseReviewRemediationCompletedSingleStageSuccessorRecord {
+  readonly schemaVersion: 'bayn.release-review-remediation.v8'
+  readonly remediationId: string
+  readonly blocked: BaynReleaseReviewRemediationSingleStageSuccessorRecord['blocked']
+  readonly requiredDescendants: readonly []
+  readonly requiredSuccessors: readonly [BaynReleaseReviewRemediationContinuousSourceSuccessor]
+  readonly introduction: BaynReleaseReviewRemediationContinuousSourceIntroduction
 }
 
 export type BaynReleaseReviewRemediationRecord =
@@ -359,6 +380,7 @@ export type BaynReleaseReviewRemediationRecord =
   | BaynReleaseReviewRemediationCompletedContinuousSourceRecord
   | BaynReleaseReviewRemediationSuccessorBoundContinuousSourceRecord
   | BaynReleaseReviewRemediationSingleStageSuccessorRecord
+  | BaynReleaseReviewRemediationCompletedSingleStageSuccessorRecord
 
 interface RemediationCommitObject {
   readonly sha: string
@@ -782,6 +804,75 @@ const parseRemediationReconstruction = (value: unknown): BaynReleaseReviewRemedi
   }
 }
 
+const parseReviewedLineage = (value: unknown): BaynReleaseReviewRemediationReviewedLineage => {
+  const lineage = strictRecord(
+    value,
+    [
+      'reviewedHeadSha',
+      'reviewedHeadParentSha',
+      'reviewedHeadTreeSha',
+      'reviewSubmittedAt',
+      'forcePush',
+      'feedback',
+      'affectedPaths',
+    ],
+    'remediation reviewed lineage',
+  )
+  const forcePush = strictRecord(
+    lineage.forcePush,
+    ['beforeHeadSha', 'afterHeadSha', 'actorLogin', 'createdAt'],
+    'remediation reviewed lineage force push',
+  )
+  const feedback = strictRecord(
+    lineage.feedback,
+    [
+      'reviewedHeadSha',
+      'fixedHeadSha',
+      'threadId',
+      'path',
+      'findingUrl',
+      'findingBodySha256',
+      'fixReplyUrl',
+      'fixReplyBodySha256',
+    ],
+    'remediation reviewed lineage feedback',
+  )
+  if (!Array.isArray(lineage.affectedPaths) || lineage.affectedPaths.length === 0) {
+    throw new Error('remediation reviewed lineage affectedPaths must be a non-empty array')
+  }
+  return {
+    reviewedHeadSha: expectSha(lineage.reviewedHeadSha, 'remediation reviewed lineage head SHA'),
+    reviewedHeadParentSha: expectSha(lineage.reviewedHeadParentSha, 'remediation reviewed lineage parent SHA'),
+    reviewedHeadTreeSha: expectSha(lineage.reviewedHeadTreeSha, 'remediation reviewed lineage tree SHA'),
+    reviewSubmittedAt: expectString(lineage.reviewSubmittedAt, 'remediation reviewed lineage review submitted at'),
+    forcePush: {
+      beforeHeadSha: expectSha(forcePush.beforeHeadSha, 'remediation reviewed lineage force push before head SHA'),
+      afterHeadSha: expectSha(forcePush.afterHeadSha, 'remediation reviewed lineage force push after head SHA'),
+      actorLogin: expectString(forcePush.actorLogin, 'remediation reviewed lineage force push actor login'),
+      createdAt: expectString(forcePush.createdAt, 'remediation reviewed lineage force push created at'),
+    },
+    feedback: {
+      reviewedHeadSha: expectSha(feedback.reviewedHeadSha, 'remediation reviewed lineage feedback reviewed head SHA'),
+      fixedHeadSha: expectSha(feedback.fixedHeadSha, 'remediation reviewed lineage feedback fixed head SHA'),
+      threadId: expectString(feedback.threadId, 'remediation reviewed lineage feedback thread ID'),
+      path: expectString(feedback.path, 'remediation reviewed lineage feedback path'),
+      findingUrl: expectString(feedback.findingUrl, 'remediation reviewed lineage feedback finding URL'),
+      findingBodySha256: expectSha256(
+        feedback.findingBodySha256,
+        'remediation reviewed lineage feedback finding body hash',
+      ),
+      fixReplyUrl: expectString(feedback.fixReplyUrl, 'remediation reviewed lineage feedback fix reply URL'),
+      fixReplyBodySha256: expectSha256(
+        feedback.fixReplyBodySha256,
+        'remediation reviewed lineage feedback fix reply body hash',
+      ),
+    },
+    affectedPaths: lineage.affectedPaths.map((item, index) =>
+      parseRemediationCommitPath(item, `remediation reviewed lineage affected path ${index}`),
+    ),
+  }
+}
+
 const parseContinuousSourceSuccessor = (value: unknown): BaynReleaseReviewRemediationContinuousSourceSuccessor => {
   const successor = strictRecord(
     value,
@@ -858,7 +949,8 @@ export const parseBaynReleaseReviewRemediationRecord = (value: unknown): BaynRel
     rawSchemaVersion !== 'bayn.release-review-remediation.v4' &&
     rawSchemaVersion !== 'bayn.release-review-remediation.v5' &&
     rawSchemaVersion !== 'bayn.release-review-remediation.v6' &&
-    rawSchemaVersion !== 'bayn.release-review-remediation.v7'
+    rawSchemaVersion !== 'bayn.release-review-remediation.v7' &&
+    rawSchemaVersion !== 'bayn.release-review-remediation.v8'
   ) {
     throw new Error('remediation schemaVersion is invalid')
   }
@@ -867,7 +959,8 @@ export const parseBaynReleaseReviewRemediationRecord = (value: unknown): BaynRel
     schemaVersion === 'bayn.release-review-remediation.v4' ||
     schemaVersion === 'bayn.release-review-remediation.v5' ||
     schemaVersion === 'bayn.release-review-remediation.v6' ||
-    schemaVersion === 'bayn.release-review-remediation.v7'
+    schemaVersion === 'bayn.release-review-remediation.v7' ||
+    schemaVersion === 'bayn.release-review-remediation.v8'
   ) {
     const record = strictRecord(
       value,
@@ -877,15 +970,24 @@ export const parseBaynReleaseReviewRemediationRecord = (value: unknown): BaynRel
           ? ['schemaVersion', 'remediationId', 'blocked', 'requiredDescendants', 'introduction']
           : schemaVersion === 'bayn.release-review-remediation.v7'
             ? ['schemaVersion', 'remediationId', 'blocked', 'requiredDescendants', 'requiredSuccessors']
-            : [
-                'schemaVersion',
-                'remediationId',
-                'blocked',
-                'requiredDescendants',
-                'requiredSuccessors',
-                'introduction',
-                'completion',
-              ],
+            : schemaVersion === 'bayn.release-review-remediation.v8'
+              ? [
+                  'schemaVersion',
+                  'remediationId',
+                  'blocked',
+                  'requiredDescendants',
+                  'requiredSuccessors',
+                  'introduction',
+                ]
+              : [
+                  'schemaVersion',
+                  'remediationId',
+                  'blocked',
+                  'requiredDescendants',
+                  'requiredSuccessors',
+                  'introduction',
+                  'completion',
+                ],
       'remediation',
     )
     const remediationId = expectString(record.remediationId, 'remediation ID')
@@ -902,6 +1004,10 @@ export const parseBaynReleaseReviewRemediationRecord = (value: unknown): BaynRel
         'finalHeadTreeSha',
         'sourcePullRequestEvidenceSha256',
         'affectedPaths',
+        ...(schemaVersion === 'bayn.release-review-remediation.v7' ||
+        schemaVersion === 'bayn.release-review-remediation.v8'
+          ? ['reviewedLineage']
+          : []),
       ],
       'remediation blocked source',
     )
@@ -938,7 +1044,7 @@ export const parseBaynReleaseReviewRemediationRecord = (value: unknown): BaynRel
       return {
         schemaVersion,
         remediationId,
-        blocked: parsedBlocked,
+        blocked: { ...parsedBlocked, reviewedLineage: parseReviewedLineage(blocked.reviewedLineage) },
         requiredDescendants: [],
         requiredSuccessors: [parseContinuousSourceSuccessor(record.requiredSuccessors[0])],
       }
@@ -991,6 +1097,19 @@ export const parseBaynReleaseReviewRemediationRecord = (value: unknown): BaynRel
         remediationId,
         blocked: parsedBlocked,
         requiredDescendants: [],
+        introduction: parsedIntroduction,
+      }
+    }
+    if (schemaVersion === 'bayn.release-review-remediation.v8') {
+      if (!Array.isArray(record.requiredSuccessors) || record.requiredSuccessors.length !== 1) {
+        throw new Error('continuous-source remediation requiredSuccessors must contain exactly one successor')
+      }
+      return {
+        schemaVersion,
+        remediationId,
+        blocked: { ...parsedBlocked, reviewedLineage: parseReviewedLineage(blocked.reviewedLineage) },
+        requiredDescendants: [],
+        requiredSuccessors: [parseContinuousSourceSuccessor(record.requiredSuccessors[0])],
         introduction: parsedIntroduction,
       }
     }
@@ -1608,13 +1727,16 @@ interface BoundRemediationReviewIdentity {
   readonly sourcePullRequestEvidenceSha256: string
 }
 
-const evaluateBoundRemediationReview = (input: {
+interface ExactBoundRemediationReviewEvidence {
+  readonly status: 'exact'
+  readonly pullRequest: PullRequestReviewState
+}
+
+const validateBoundRemediationReviewEvidence = (input: {
   readonly remediationId: string
   readonly commit: BaynReleaseRangeCommit
   readonly identity: BoundRemediationReviewIdentity
-  readonly normalReview: BaynReleaseReviewEvaluation
-  readonly nowMs: number
-}): BaynReleaseReviewEligible | BaynReleaseReviewHold => {
+}): ExactBoundRemediationReviewEvidence | BaynReleaseReviewHold => {
   const pullRequest = input.commit.reviewSnapshot?.pullRequest
   if (
     pullRequest === null ||
@@ -1638,6 +1760,19 @@ const evaluateBoundRemediationReview = (input: {
   if (blockingReviews.length > 0) {
     return remediationInvalid(`remediation ${input.remediationId} bound source PR has a blocking Codex review`)
   }
+  return { status: 'exact', pullRequest }
+}
+
+const evaluateBoundRemediationReview = (input: {
+  readonly remediationId: string
+  readonly commit: BaynReleaseRangeCommit
+  readonly identity: BoundRemediationReviewIdentity
+  readonly normalReview: BaynReleaseReviewEvaluation
+  readonly nowMs: number
+}): BaynReleaseReviewEligible | BaynReleaseReviewHold => {
+  const evidence = validateBoundRemediationReviewEvidence(input)
+  if (evidence.status === 'hold') return evidence
+  const { pullRequest } = evidence
   if (input.normalReview.status === 'eligible') return input.normalReview
   if (input.normalReview.code !== 'exact-head-review-missing') return input.normalReview
   if (
@@ -2432,14 +2567,163 @@ const validateContinuousSourceCompletionIdentity = (input: {
   return null
 }
 
+const validateContinuousReviewedLineage = (input: {
+  readonly record:
+    | BaynReleaseReviewRemediationSingleStageSuccessorRecord
+    | BaynReleaseReviewRemediationCompletedSingleStageSuccessorRecord
+  readonly evidence: BaynReleaseReviewRemediationEvidence
+  readonly pullRequest: PullRequestReviewState
+}): BaynReleaseReviewHold | null => {
+  const { blocked, remediationId } = input.record
+  const { reviewedLineage } = blocked
+  const reviewedHead = findReferencedCommit(input.evidence, reviewedLineage.reviewedHeadSha)
+  const expectedPaths = blocked.affectedPaths.map((path) => path.path)
+  if (
+    reviewedHead === null ||
+    reviewedLineage.reviewedHeadParentSha !== blocked.mergeParentSha ||
+    reviewedLineage.forcePush.beforeHeadSha !== reviewedLineage.reviewedHeadSha ||
+    reviewedLineage.forcePush.afterHeadSha !== blocked.finalHeadSha ||
+    reviewedLineage.feedback.reviewedHeadSha !== reviewedLineage.reviewedHeadSha ||
+    reviewedLineage.feedback.fixedHeadSha !== blocked.finalHeadSha ||
+    !exactStringSet(
+      reviewedLineage.affectedPaths.map((path) => path.path),
+      expectedPaths,
+    )
+  ) {
+    return remediationInvalid(`remediation ${remediationId} reviewed lineage endpoints are not exact`)
+  }
+  const reviewedHeadHold = validateRemediationReconstructionHead({
+    remediationId,
+    expected: {
+      headSha: reviewedLineage.reviewedHeadSha,
+      parentSha: reviewedLineage.reviewedHeadParentSha,
+      treeSha: reviewedLineage.reviewedHeadTreeSha,
+      affectedPaths: reviewedLineage.affectedPaths,
+    },
+    observed: reviewedHead,
+  })
+  if (reviewedHeadHold !== null) return reviewedHeadHold
+  for (const reviewedPath of reviewedLineage.affectedPaths) {
+    const finalPath = blocked.affectedPaths.find((path) => path.path === reviewedPath.path)
+    if (
+      finalPath === undefined ||
+      finalPath.previousPath !== reviewedPath.previousPath ||
+      finalPath.status !== reviewedPath.status
+    ) {
+      return remediationInvalid(`remediation ${remediationId} reviewed lineage changed at ${reviewedPath.path}`)
+    }
+  }
+  const feedbackReviewedPath = reviewedLineage.affectedPaths.find((path) => path.path === reviewedLineage.feedback.path)
+  const feedbackFinalPath = blocked.affectedPaths.find((path) => path.path === reviewedLineage.feedback.path)
+  if (
+    feedbackReviewedPath === undefined ||
+    feedbackFinalPath === undefined ||
+    feedbackReviewedPath.blobSha === feedbackFinalPath.blobSha
+  ) {
+    return remediationInvalid(`remediation ${remediationId} reviewed feedback transformation is not exact`)
+  }
+
+  const reviewSubmittedAtMs = Date.parse(reviewedLineage.reviewSubmittedAt)
+  const forcePushAtMs = Date.parse(reviewedLineage.forcePush.createdAt)
+  const mergedAtMs = Date.parse(input.pullRequest.mergedAt ?? '')
+  const codexReviews = input.pullRequest.reviews
+    .filter(
+      (review) =>
+        review.authorLogin === baynCodexReviewer &&
+        review.submittedAt !== null &&
+        eligibleReviewStates.has(review.state),
+    )
+    .toSorted((left, right) => (left.submittedAt ?? '').localeCompare(right.submittedAt ?? ''))
+  const latestCodexReview = codexReviews.at(-1)
+  const exactReviews = codexReviews.filter(
+    (review) =>
+      review.commitSha === reviewedLineage.reviewedHeadSha && review.submittedAt === reviewedLineage.reviewSubmittedAt,
+  )
+  const forcePushes = input.pullRequest.headForcePushes.toSorted((left, right) =>
+    left.createdAt.localeCompare(right.createdAt),
+  )
+  const latestForcePush = forcePushes.at(-1)
+  if (
+    !Number.isFinite(reviewSubmittedAtMs) ||
+    !Number.isFinite(forcePushAtMs) ||
+    !Number.isFinite(mergedAtMs) ||
+    reviewSubmittedAtMs >= forcePushAtMs ||
+    forcePushAtMs >= mergedAtMs ||
+    input.pullRequest.headForcePushCount !== input.pullRequest.headForcePushes.length ||
+    exactReviews.length !== 1 ||
+    latestCodexReview !== exactReviews[0] ||
+    latestForcePush === undefined ||
+    latestForcePush.beforeCommitSha !== reviewedLineage.forcePush.beforeHeadSha ||
+    latestForcePush.afterCommitSha !== reviewedLineage.forcePush.afterHeadSha ||
+    latestForcePush.actorLogin !== reviewedLineage.forcePush.actorLogin ||
+    latestForcePush.createdAt !== reviewedLineage.forcePush.createdAt
+  ) {
+    return remediationInvalid(`remediation ${remediationId} latest reviewed-head transition is not exact`)
+  }
+
+  const threadMatches = input.pullRequest.threads.filter((thread) => thread.id === reviewedLineage.feedback.threadId)
+  const feedbackThread = threadMatches[0]
+  if (
+    threadMatches.length !== 1 ||
+    feedbackThread === undefined ||
+    !feedbackThread.isResolved ||
+    !feedbackThread.isOutdated ||
+    feedbackThread.path !== reviewedLineage.feedback.path
+  ) {
+    return remediationInvalid(`remediation ${remediationId} reviewed feedback thread is missing or actionable`)
+  }
+  const findings = feedbackThread.comments.filter(
+    (comment) =>
+      comment.url === reviewedLineage.feedback.findingUrl &&
+      sha256Text(comment.body) === reviewedLineage.feedback.findingBodySha256 &&
+      comment.authorLogin === baynCodexReviewer &&
+      comment.reviewAuthorLogin === baynCodexReviewer &&
+      comment.reviewCommitSha === reviewedLineage.reviewedHeadSha &&
+      comment.reviewSubmittedAt === reviewedLineage.reviewSubmittedAt,
+  )
+  const replies = feedbackThread.comments.filter(
+    (comment) =>
+      comment.url === reviewedLineage.feedback.fixReplyUrl &&
+      sha256Text(comment.body) === reviewedLineage.feedback.fixReplyBodySha256 &&
+      comment.authorLogin !== null &&
+      comment.authorLogin !== baynCodexReviewer &&
+      trustedFeedbackAssociations.has(comment.authorAssociation) &&
+      comment.reviewCommitSha === blocked.finalHeadSha,
+  )
+  const findingAtMs = Date.parse(findings[0]?.createdAt ?? '')
+  const replyAtMs = Date.parse(replies[0]?.createdAt ?? '')
+  if (
+    findings.length !== 1 ||
+    replies.length !== 1 ||
+    !Number.isFinite(findingAtMs) ||
+    !Number.isFinite(replyAtMs) ||
+    findingAtMs < reviewSubmittedAtMs ||
+    replyAtMs <= forcePushAtMs ||
+    replyAtMs >= mergedAtMs
+  ) {
+    return remediationInvalid(`remediation ${remediationId} exact reviewed feedback/fix evidence is missing`)
+  }
+  const reactions = input.pullRequest.reactions.filter(
+    (reaction) => reaction.userLogin === baynCodexBotLogin && reaction.content === '+1',
+  )
+  const reactionAtMs = Date.parse(reactions[0]?.createdAt ?? '')
+  if (
+    reactions.length !== 1 ||
+    !Number.isFinite(reactionAtMs) ||
+    reactionAtMs <= replyAtMs ||
+    reactionAtMs >= mergedAtMs
+  ) {
+    return remediationInvalid(`remediation ${remediationId} reviewed lineage final-head reaction is missing`)
+  }
+  return null
+}
+
 const validateContinuousSourceRemediation = (input: {
   readonly evidence: BaynReleaseReviewRemediationEvidence
   readonly blockedCommit: BaynReleaseRangeCommit
   readonly comparison: BaynReleaseComparison
   readonly normalReviews: ReadonlyMap<string, BaynReleaseReviewEvaluation>
   readonly introduction: BaynReleaseRangeCommit
-  readonly introductionReview?: BaynReleaseReviewEligible
-  readonly completionReview?: BaynReleaseReviewEligible
   readonly blockedIndex: number
   readonly nowMs: number
 }): BaynReleaseReviewHold | null => {
@@ -2449,7 +2733,8 @@ const validateContinuousSourceRemediation = (input: {
     record.schemaVersion !== 'bayn.release-review-remediation.v4' &&
     record.schemaVersion !== 'bayn.release-review-remediation.v5' &&
     record.schemaVersion !== 'bayn.release-review-remediation.v6' &&
-    record.schemaVersion !== 'bayn.release-review-remediation.v7'
+    record.schemaVersion !== 'bayn.release-review-remediation.v7' &&
+    record.schemaVersion !== 'bayn.release-review-remediation.v8'
   ) {
     return remediationInvalid(`remediation ${record.remediationId} continuous source record is missing`)
   }
@@ -2503,11 +2788,7 @@ const validateContinuousSourceRemediation = (input: {
     }
   }
 
-  const blockedReview = input.normalReviews.get(blockedCommit.sha)
-  if (blockedReview === undefined) {
-    return remediationInvalid(`remediation ${record.remediationId} blocked source review snapshot is missing`)
-  }
-  const boundReview = evaluateBoundRemediationReview({
+  const blockedReviewInput = {
     remediationId: record.remediationId,
     commit: blockedCommit,
     identity: {
@@ -2516,22 +2797,43 @@ const validateContinuousSourceRemediation = (input: {
       finalHeadSha: record.blocked.finalHeadSha,
       sourcePullRequestEvidenceSha256: record.blocked.sourcePullRequestEvidenceSha256,
     },
-    normalReview: blockedReview,
-    nowMs: input.nowMs,
-  })
-  if (boundReview.status === 'hold') return boundReview
+  }
+  if (
+    record.schemaVersion === 'bayn.release-review-remediation.v7' ||
+    record.schemaVersion === 'bayn.release-review-remediation.v8'
+  ) {
+    const reviewEvidence = validateBoundRemediationReviewEvidence(blockedReviewInput)
+    if (reviewEvidence.status === 'hold') return reviewEvidence
+    const lineageHold = validateContinuousReviewedLineage({
+      record,
+      evidence,
+      pullRequest: reviewEvidence.pullRequest,
+    })
+    if (lineageHold !== null) return lineageHold
+  } else {
+    const blockedReview = input.normalReviews.get(blockedCommit.sha)
+    if (blockedReview === undefined) {
+      return remediationInvalid(`remediation ${record.remediationId} blocked source review snapshot is missing`)
+    }
+    const boundReview = evaluateBoundRemediationReview({
+      ...blockedReviewInput,
+      normalReview: blockedReview,
+      nowMs: input.nowMs,
+    })
+    if (boundReview.status === 'hold') return boundReview
+  }
 
   const protectedPaths = new Set(expectedPaths)
   const expectedCurrentBlobs = new Map(record.blocked.affectedPaths.map((path) => [path.path, path.blobSha]))
   let successorCommit: BaynReleaseRangeCommit | undefined
-  let successorBoundReview: BaynReleaseReviewEligible | undefined
   let protectedTransitions: ReadonlyMap<
     string,
     BaynReleaseReviewRemediationContinuousSourceSuccessor['protectedPathTransitions'][number]
   > = new Map()
   if (
     record.schemaVersion === 'bayn.release-review-remediation.v6' ||
-    record.schemaVersion === 'bayn.release-review-remediation.v7'
+    record.schemaVersion === 'bayn.release-review-remediation.v7' ||
+    record.schemaVersion === 'bayn.release-review-remediation.v8'
   ) {
     const successor = record.requiredSuccessors[0]
     const successorMatches = comparison.commits.filter((commit) => commit.sha === successor.mergeCommitSha)
@@ -2546,6 +2848,15 @@ const validateContinuousSourceRemediation = (input: {
       )
     ) {
       return remediationInvalid(`remediation ${record.remediationId} successor declaration is ambiguous`)
+    }
+    if (
+      (record.schemaVersion === 'bayn.release-review-remediation.v7' ||
+        record.schemaVersion === 'bayn.release-review-remediation.v8') &&
+      !exactStringSet(transitionPaths, expectedPaths)
+    ) {
+      return remediationInvalid(
+        `remediation ${record.remediationId} reviewed successor does not replace every blocked source path`,
+      )
     }
     successorCommit = successorMatches[0]
     if (successorCommit === undefined) {
@@ -2588,7 +2899,6 @@ const validateContinuousSourceRemediation = (input: {
       nowMs: input.nowMs,
     })
     if (reviewedSuccessor.status === 'hold') return reviewedSuccessor
-    successorBoundReview = reviewedSuccessor
     protectedTransitions = transitionMap
   }
   let expectedParent = blockedCommit.sha
@@ -2621,22 +2931,9 @@ const validateContinuousSourceRemediation = (input: {
     } else if (commit.files.some((path) => protectedPaths.has(path)) || protectedChanges.length > 0) {
       return remediationInvalid(`remediation ${record.remediationId} continuous source changed after the blocked merge`)
     }
-    if (commit.files.some(isBaynReleaseAffectingPath)) {
-      const review =
-        commit.sha === successorCommit?.sha && successorBoundReview !== undefined
-          ? successorBoundReview
-          : commit.sha === input.introduction.sha && input.introductionReview !== undefined
-            ? input.introductionReview
-            : record.schemaVersion === 'bayn.release-review-remediation.v6' &&
-                commit.sha === record.completion.mergeCommitSha &&
-                input.completionReview !== undefined
-              ? input.completionReview
-              : input.normalReviews.get(commit.sha)
-      if (review === undefined) {
-        return remediationInvalid(`remediation ${record.remediationId} newer source review is missing`)
-      }
-      if (review.status === 'hold') return review
-    }
+    // The bound successor, introduction, and completion reviews are validated before this ancestry walk. Other
+    // Bayn-affecting commits are deliberately left to the top-level publication loop, where each commit can apply
+    // its own exact remediation instead of being rejected again by an earlier continuous-source receipt.
     expectedParent = commit.sha
   }
   if (expectedParent !== comparison.headSha) {
@@ -2671,8 +2968,6 @@ const validateReleaseReviewRemediation = (input: {
     commit.fileChanges?.some((change) => change.path === evidence.recordPath),
   )
   let introduction: BaynReleaseRangeCommit | undefined
-  let introductionBoundReview: BaynReleaseReviewEligible | undefined
-  let completionBoundReview: BaynReleaseReviewEligible | undefined
   if (record.schemaVersion === 'bayn.release-review-remediation.v6') {
     if (recordCommits.length !== 3) {
       return remediationInvalid(`remediation ${record.remediationId} successor-bound history is not exact`)
@@ -2730,7 +3025,6 @@ const validateReleaseReviewRemediation = (input: {
       nowMs: input.nowMs,
     })
     if (completionReview.status === 'hold') return completionReview
-    completionBoundReview = completionReview
     const introductionNormalReview = input.normalReviews.get(introduction.sha)
     if (introductionNormalReview === undefined) {
       return remediationInvalid(`remediation ${record.remediationId} introduction review snapshot is missing`)
@@ -2743,7 +3037,53 @@ const validateReleaseReviewRemediation = (input: {
       nowMs: input.nowMs,
     })
     if (introductionReview.status === 'hold') return introductionReview
-    introductionBoundReview = introductionReview
+  } else if (record.schemaVersion === 'bayn.release-review-remediation.v8') {
+    const identity = record.introduction
+    if (recordCommits.length !== 2) {
+      return remediationInvalid(`remediation ${record.remediationId} completion history is not exact`)
+    }
+    introduction = recordCommits.find((commit) => commit.sha === identity.mergeCommitSha)
+    const completion = recordCommits.find((commit) => commit.sha !== identity.mergeCommitSha)
+    const completionChange = completion?.fileChanges?.find((change) => change.path === evidence.recordPath)
+    if (
+      introduction === undefined ||
+      completion === undefined ||
+      completion.parents.length !== 1 ||
+      completion.parents[0] !== introduction.sha ||
+      completionChange?.status !== 'modified' ||
+      completionChange.previousPath !== null ||
+      completionChange.blobSha !== evidence.recordBlobSha ||
+      comparison.commits.indexOf(completion) <= comparison.commits.indexOf(introduction)
+    ) {
+      return remediationInvalid(`remediation ${record.remediationId} completion record mutation is not exact`)
+    }
+    const introductionIdentityHold = validateContinuousSourceIntroductionIdentity({
+      remediationId: record.remediationId,
+      evidence,
+      introduction,
+      identity,
+    })
+    if (introductionIdentityHold !== null) return introductionIdentityHold
+    const completionReview = input.normalReviews.get(completion.sha)
+    if (completionReview === undefined) {
+      return remediationInvalid(`remediation ${record.remediationId} completion commit lacks exact-head review`)
+    }
+    if (completionReview.status === 'hold') {
+      if (completionReview.retryable) return completionReview
+      return remediationInvalid(`remediation ${record.remediationId} completion commit lacks exact-head review`)
+    }
+    const introductionNormalReview = input.normalReviews.get(introduction.sha)
+    if (introductionNormalReview === undefined) {
+      return remediationInvalid(`remediation ${record.remediationId} introduction review snapshot is missing`)
+    }
+    const introductionReview = evaluateBoundRemediationReview({
+      remediationId: record.remediationId,
+      commit: introduction,
+      identity,
+      normalReview: introductionNormalReview,
+      nowMs: input.nowMs,
+    })
+    if (introductionReview.status === 'hold') return introductionReview
   } else if (record.schemaVersion === 'bayn.release-review-remediation.v5') {
     const identity = record.introduction
     if (recordCommits.length !== 2) {
@@ -2791,7 +3131,6 @@ const validateReleaseReviewRemediation = (input: {
       nowMs: input.nowMs,
     })
     if (introductionReview.status === 'hold') return introductionReview
-    introductionBoundReview = introductionReview
   } else if (record.schemaVersion === 'bayn.release-review-remediation.v3') {
     const identity = record.introduction
     if (identity === undefined || recordCommits.length !== 2) {
@@ -2874,7 +3213,8 @@ const validateReleaseReviewRemediation = (input: {
     record.schemaVersion === 'bayn.release-review-remediation.v4' ||
     record.schemaVersion === 'bayn.release-review-remediation.v5' ||
     record.schemaVersion === 'bayn.release-review-remediation.v6' ||
-    record.schemaVersion === 'bayn.release-review-remediation.v7'
+    record.schemaVersion === 'bayn.release-review-remediation.v7' ||
+    record.schemaVersion === 'bayn.release-review-remediation.v8'
   ) {
     return validateContinuousSourceRemediation({
       evidence,
@@ -2882,8 +3222,6 @@ const validateReleaseReviewRemediation = (input: {
       comparison,
       normalReviews: input.normalReviews,
       introduction,
-      introductionReview: introductionBoundReview,
-      completionReview: completionBoundReview,
       blockedIndex,
       nowMs: input.nowMs,
     })
@@ -3345,7 +3683,8 @@ export const evaluateBaynReleaseEligibility = (input: {
       }
       if (
         remediation[0].record.schemaVersion === 'bayn.release-review-remediation.v6' ||
-        remediation[0].record.schemaVersion === 'bayn.release-review-remediation.v7'
+        remediation[0].record.schemaVersion === 'bayn.release-review-remediation.v7' ||
+        remediation[0].record.schemaVersion === 'bayn.release-review-remediation.v8'
       ) {
         const successorIdentity = remediation[0].record.requiredSuccessors[0]
         const successorCommit = comparison.commits.find(
@@ -3371,7 +3710,8 @@ export const evaluateBaynReleaseEligibility = (input: {
 
       if (
         remediation[0].record.schemaVersion === 'bayn.release-review-remediation.v5' ||
-        remediation[0].record.schemaVersion === 'bayn.release-review-remediation.v6'
+        remediation[0].record.schemaVersion === 'bayn.release-review-remediation.v6' ||
+        remediation[0].record.schemaVersion === 'bayn.release-review-remediation.v8'
       ) {
         const introductionIdentity = remediation[0].record.introduction
         const introductionCommit = comparison.commits.find(
@@ -3421,9 +3761,27 @@ export const evaluateBaynReleaseEligibility = (input: {
         remediation[0].record.schemaVersion === 'bayn.release-review-remediation.v4' ||
         remediation[0].record.schemaVersion === 'bayn.release-review-remediation.v5' ||
         remediation[0].record.schemaVersion === 'bayn.release-review-remediation.v6' ||
-        remediation[0].record.schemaVersion === 'bayn.release-review-remediation.v7'
+        remediation[0].record.schemaVersion === 'bayn.release-review-remediation.v7' ||
+        remediation[0].record.schemaVersion === 'bayn.release-review-remediation.v8'
       ) {
         const record = remediation[0].record
+        if (
+          record.schemaVersion === 'bayn.release-review-remediation.v7' ||
+          record.schemaVersion === 'bayn.release-review-remediation.v8'
+        ) {
+          const successorReview = normalReviews.get(record.requiredSuccessors[0].mergeCommitSha)
+          if (successorReview?.status !== 'eligible') {
+            return remediationInvalid(`remediation ${record.remediationId} reviewed successor is not eligible`)
+          }
+          reviewedPullRequests.push({
+            commitSha: commit.sha,
+            prNumber: successorReview.prNumber,
+            headSha: successorReview.headSha,
+            reviewSubmittedAt: successorReview.reviewSubmittedAt,
+            eligibleAt: successorReview.eligibleAt,
+          })
+          continue
+        }
         const continuousReview = evaluateBoundRemediationReview({
           remediationId: record.remediationId,
           commit,
@@ -4753,15 +5111,26 @@ const loadReleaseReviewRemediations = async (
       loaded.record.schemaVersion === 'bayn.release-review-remediation.v4' ||
       loaded.record.schemaVersion === 'bayn.release-review-remediation.v5' ||
       loaded.record.schemaVersion === 'bayn.release-review-remediation.v6' ||
-      loaded.record.schemaVersion === 'bayn.release-review-remediation.v7'
+      loaded.record.schemaVersion === 'bayn.release-review-remediation.v7' ||
+      loaded.record.schemaVersion === 'bayn.release-review-remediation.v8'
     ) {
       references.set(
         loaded.record.blocked.finalHeadSha,
         loaded.record.blocked.affectedPaths.map((path) => path.path),
       )
       if (
+        loaded.record.schemaVersion === 'bayn.release-review-remediation.v7' ||
+        loaded.record.schemaVersion === 'bayn.release-review-remediation.v8'
+      ) {
+        references.set(
+          loaded.record.blocked.reviewedLineage.reviewedHeadSha,
+          loaded.record.blocked.reviewedLineage.affectedPaths.map((path) => path.path),
+        )
+      }
+      if (
         loaded.record.schemaVersion === 'bayn.release-review-remediation.v5' ||
-        loaded.record.schemaVersion === 'bayn.release-review-remediation.v6'
+        loaded.record.schemaVersion === 'bayn.release-review-remediation.v6' ||
+        loaded.record.schemaVersion === 'bayn.release-review-remediation.v8'
       ) {
         references.set(
           loaded.record.introduction.finalHeadSha,

--- a/services/bayn/release-review-remediations/ae4d23650c20cecbde2bac8416bc2b734381cb69.json
+++ b/services/bayn/release-review-remediations/ae4d23650c20cecbde2bac8416bc2b734381cb69.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "bayn.release-review-remediation.v7",
+  "schemaVersion": "bayn.release-review-remediation.v8",
   "remediationId": "pr-13438-successor-bound-reviewed-source",
   "blocked": {
     "mergeCommitSha": "ae4d23650c20cecbde2bac8416bc2b734381cb69",
@@ -23,7 +23,43 @@
         "status": "modified",
         "blobSha": "eb0e66568f0872434a753de6512844ea2a854ea1"
       }
-    ]
+    ],
+    "reviewedLineage": {
+      "reviewedHeadSha": "9452b41b051f79f65a3dcc825593afb0390a0b2f",
+      "reviewedHeadParentSha": "7c2335792707e34ac41e4de5091d2e2af48b7657",
+      "reviewedHeadTreeSha": "3e11aedd2f991db054b78143956719fc3dad6744",
+      "reviewSubmittedAt": "2026-08-01T01:01:06Z",
+      "forcePush": {
+        "beforeHeadSha": "9452b41b051f79f65a3dcc825593afb0390a0b2f",
+        "afterHeadSha": "bf17a9387e69896095096b9447aafed52711333c",
+        "actorLogin": "gregkonush",
+        "createdAt": "2026-08-01T01:05:01Z"
+      },
+      "feedback": {
+        "reviewedHeadSha": "9452b41b051f79f65a3dcc825593afb0390a0b2f",
+        "fixedHeadSha": "bf17a9387e69896095096b9447aafed52711333c",
+        "threadId": "PRRT_kwDOLkRLus6VkaW3",
+        "path": "services/bayn/src/candidate-development-command.ts",
+        "findingUrl": "https://github.com/proompteng/lab/pull/13438#discussion_r3694182686",
+        "findingBodySha256": "b2888751b80020f76a4fbd9a733304a607fc3c6725a5ae3f5766ddbe560a0e72",
+        "fixReplyUrl": "https://github.com/proompteng/lab/pull/13438#discussion_r3694191020",
+        "fixReplyBodySha256": "d790110b2808020d52559efbe5e72042d746c593baf94536e0034acb01f4dfc0"
+      },
+      "affectedPaths": [
+        {
+          "path": "services/bayn/src/candidate-development-command.test.ts",
+          "previousPath": null,
+          "status": "modified",
+          "blobSha": "2d85889b0bf8902478055cb5f3c625fa27884148"
+        },
+        {
+          "path": "services/bayn/src/candidate-development-command.ts",
+          "previousPath": null,
+          "status": "modified",
+          "blobSha": "0862930e0c4dfe5576593a79f5602241ee8f2ce6"
+        }
+      ]
+    }
   },
   "requiredDescendants": [],
   "requiredSuccessors": [
@@ -117,5 +153,36 @@
         }
       ]
     }
-  ]
+  ],
+  "introduction": {
+    "mergeCommitSha": "628d3fd16d63f7b9e3fc02d3bbdfa130a121ed31",
+    "mergeParentSha": "045b69acf7681162983fa228b6d66b6677233ff2",
+    "mergeTreeSha": "e0fd13cdf5b879dd7be5fbb282e9e2390ad39e6f",
+    "sourcePullRequestNumber": 13448,
+    "finalHeadSha": "211a901ddeacf6cab997252dee85e180e94595fa",
+    "finalHeadParentSha": "045b69acf7681162983fa228b6d66b6677233ff2",
+    "finalHeadTreeSha": "e0fd13cdf5b879dd7be5fbb282e9e2390ad39e6f",
+    "sourcePullRequestEvidenceSha256": "8e59ead9e8a8c57c8c64c0b37ea1c5298b292dbc0b1efd69645ceb1678ae49b0",
+    "introducedRecordBlobSha": "2855013d0a960ebc9b2ee100301334fc1640d297",
+    "affectedPaths": [
+      {
+        "path": "packages/scripts/src/bayn/verify-release-review.test.ts",
+        "previousPath": null,
+        "status": "modified",
+        "blobSha": "f76bd1f1250ccc712e070bcffcd69e1ec5b6d223"
+      },
+      {
+        "path": "packages/scripts/src/bayn/verify-release-review.ts",
+        "previousPath": null,
+        "status": "modified",
+        "blobSha": "bc0d8af96af4d40ca2a30c2ee40729f6523bd505"
+      },
+      {
+        "path": "services/bayn/release-review-remediations/ae4d23650c20cecbde2bac8416bc2b734381cb69.json",
+        "previousPath": null,
+        "status": "added",
+        "blobSha": "2855013d0a960ebc9b2ee100301334fc1640d297"
+      }
+    ]
+  }
 }


### PR DESCRIPTION
## Summary

- compose nested release-review remediations so an earlier continuous-source receipt does not reject a later commit before its own exact receipt is evaluated
- require v7 reviewed successors to replace every path from the unreviewed blocked source while retaining exact PR, ancestry, tree, blob, thread, and blocking-review checks
- record the reviewed successor as the accepted review identity and add fail-closed composition and incomplete-replacement regressions
- reproduce and clear natural build failure 30696691919 against exact main 628d3fd16d63f7b9e3fc02d3bbdfa130a121ed31

## Related Issues

Linear PROOMPT-443

## Testing

- `bun test packages/scripts/src/bayn/verify-release-review.test.ts` — 141 passed, 0 failed
- `bunx oxfmt --check packages/scripts/src/bayn/verify-release-review.ts packages/scripts/src/bayn/verify-release-review.test.ts`
- `bunx oxlint packages/scripts/src/bayn/verify-release-review.ts packages/scripts/src/bayn/verify-release-review.test.ts`
- `bunx tsc --ignoreConfig --noEmit --strict --moduleResolution bundler --module esnext --target esnext --lib esnext,dom --types bun-types --skipLibCheck packages/scripts/src/bayn/verify-release-review.ts packages/scripts/src/bayn/verify-release-review.test.ts`
- `git diff --check`
- exact GitHub-history verifier for 628d3fd16d63f7b9e3fc02d3bbdfa130a121ed31 returned `BAYN_RELEASE_REVIEW_ELIGIBLE` for all nine Bayn-affecting commits since the last published revision

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked in PROOMPT-443.
