### PR TITLE
fix(bayn): bind reviewed remediation completion

### DIFF
--- a/packages/scripts/src/bayn/verify-release-review.test.ts
+++ b/packages/scripts/src/bayn/verify-release-review.test.ts
@@ -2447,6 +2447,209 @@ const evaluateSingleStageSuccessorRemediationFixture = (
     pushBeforeSha: fixture.snapshot.currentCommitParents[0]!,
   })
 
+const reviewedCompletionHistory = {
+  completionMerge: '16'.repeat(20),
+  completionHead: '17'.repeat(20),
+  completionPriorHead: '18'.repeat(20),
+  completionTree: '19'.repeat(20),
+  completionRecordBlob: '1a'.repeat(20),
+  updateMerge: '1b'.repeat(20),
+  updateHead: '1c'.repeat(20),
+  updateTree: '1d'.repeat(20),
+  updateRecordBlob: '1e'.repeat(20),
+} as const
+
+const reviewedCompletionSingleStageSuccessorRemediationFixture = () => {
+  const fixture = singleStageSuccessorRemediationFixture()
+  const comparison = fixture.snapshot.comparison
+  const v7Record = fixture.evidence.record
+  if (
+    comparison === null ||
+    comparison.status !== 'ahead' ||
+    v7Record.schemaVersion !== 'bayn.release-review-remediation.v7'
+  ) {
+    throw new Error('missing v7 single-stage successor fixture')
+  }
+  const introductionCommit = comparison.commits.find((commit) => commit.sha === successorBoundHistory.updateMerge)
+  const introductionPull = introductionCommit?.reviewSnapshot?.pullRequest
+  const introductionRecordPath = introductionCommit?.fileChanges?.find(
+    (change) => change.path === fixture.evidence.recordPath,
+  )
+  if (
+    introductionCommit === undefined ||
+    introductionPull === null ||
+    introductionPull === undefined ||
+    introductionRecordPath === undefined
+  ) {
+    throw new Error('missing reviewed-completion introduction evidence')
+  }
+
+  const completionChanges = introductionCommit.files.map((path, index) => ({
+    path,
+    previousPath: null,
+    status: 'modified' as const,
+    blobSha:
+      path === fixture.evidence.recordPath
+        ? reviewedCompletionHistory.completionRecordBlob
+        : `${index + 2}a`.repeat(20),
+  }))
+  const completionSnapshot = reviewSnapshotFor({
+    commitSha: reviewedCompletionHistory.completionMerge,
+    prNumber: 13449,
+    headSha: reviewedCompletionHistory.completionHead,
+    parents: [introductionCommit.sha],
+    mergedAt: '2026-08-01T09:30:00Z',
+    reviews: [
+      review({
+        commitSha: reviewedCompletionHistory.completionPriorHead,
+        submittedAt: '2026-08-01T09:29:05Z',
+      }),
+    ],
+    reactions: [reaction({ createdAt: '2026-08-01T09:29:20Z' })],
+    headForcePushes: [
+      {
+        actorLogin: 'gregkonush',
+        beforeCommitSha: reviewedCompletionHistory.completionPriorHead,
+        afterCommitSha: reviewedCompletionHistory.completionHead,
+        createdAt: '2026-08-01T09:29:10Z',
+      },
+    ],
+    headForcePushCount: 1,
+  })
+  const completionPull = completionSnapshot.pullRequest
+  if (completionPull === null) throw new Error('missing reviewed-completion pull request')
+  const completionCommit = {
+    sha: reviewedCompletionHistory.completionMerge,
+    parents: [introductionCommit.sha],
+    treeSha: reviewedCompletionHistory.completionTree,
+    files: completionChanges.map((change) => change.path),
+    fileChanges: completionChanges,
+    reviewSnapshot: completionSnapshot,
+  } as const
+
+  const updateChanges = completionChanges.map((change, index) => ({
+    ...change,
+    blobSha:
+      change.path === fixture.evidence.recordPath
+        ? reviewedCompletionHistory.updateRecordBlob
+        : `${index + 5}a`.repeat(20),
+  }))
+  const updateCommit = {
+    sha: reviewedCompletionHistory.updateMerge,
+    parents: [completionCommit.sha],
+    treeSha: reviewedCompletionHistory.updateTree,
+    files: updateChanges.map((change) => change.path),
+    fileChanges: updateChanges,
+    reviewSnapshot: reviewSnapshotFor({
+      commitSha: reviewedCompletionHistory.updateMerge,
+      prNumber: 13450,
+      headSha: reviewedCompletionHistory.updateHead,
+      parents: [completionCommit.sha],
+      mergedAt: '2026-08-01T09:40:00Z',
+      reviews: [
+        review({
+          commitSha: reviewedCompletionHistory.updateHead,
+          submittedAt: '2026-08-01T09:39:00Z',
+        }),
+      ],
+    }),
+  } as const
+  const updatePull = updateCommit.reviewSnapshot.pullRequest
+  if (updatePull === null) throw new Error('missing reviewed-completion update pull request')
+
+  const introductionFinalHead = {
+    sha: introductionPull.headSha,
+    parents: [introductionCommit.parents[0]!],
+    treeSha: introductionCommit.treeSha,
+    files: introductionCommit.files,
+    fileChanges: introductionCommit.fileChanges ?? [],
+    pathBlobs: (introductionCommit.fileChanges ?? []).map((change) => ({
+      path: change.path,
+      blobSha: change.blobSha,
+    })),
+  }
+  const completionFinalHead = {
+    sha: reviewedCompletionHistory.completionHead,
+    parents: [introductionCommit.sha],
+    treeSha: reviewedCompletionHistory.completionTree,
+    files: completionCommit.files,
+    fileChanges: completionChanges,
+    pathBlobs: completionChanges.map((change) => ({ path: change.path, blobSha: change.blobSha })),
+  }
+  const record = parseBaynReleaseReviewRemediationRecord({
+    schemaVersion: 'bayn.release-review-remediation.v9',
+    remediationId: v7Record.remediationId,
+    blocked: v7Record.blocked,
+    requiredDescendants: [],
+    requiredSuccessors: v7Record.requiredSuccessors,
+    introduction: {
+      mergeCommitSha: introductionCommit.sha,
+      mergeParentSha: introductionCommit.parents[0],
+      mergeTreeSha: introductionCommit.treeSha,
+      sourcePullRequestNumber: introductionPull.number,
+      finalHeadSha: introductionPull.headSha,
+      finalHeadParentSha: introductionCommit.parents[0],
+      finalHeadTreeSha: introductionCommit.treeSha,
+      sourcePullRequestEvidenceSha256: pullRequestReviewEvidenceSha256(introductionPull),
+      introducedRecordBlobSha: introductionRecordPath.blobSha,
+      affectedPaths: introductionCommit.fileChanges,
+    },
+    completion: {
+      mergeCommitSha: completionCommit.sha,
+      mergeParentSha: introductionCommit.sha,
+      mergeTreeSha: completionCommit.treeSha,
+      sourcePullRequestNumber: completionPull.number,
+      finalHeadSha: completionPull.headSha,
+      finalHeadParentSha: introductionCommit.sha,
+      finalHeadTreeSha: completionCommit.treeSha,
+      sourcePullRequestEvidenceSha256: pullRequestReviewEvidenceSha256(completionPull),
+      completedRecordBlobSha: reviewedCompletionHistory.completionRecordBlob,
+      affectedPaths: completionChanges,
+    },
+  })
+  if (record.schemaVersion !== 'bayn.release-review-remediation.v9') {
+    throw new Error('failed to derive the v9 reviewed-completion fixture')
+  }
+  const commits = [
+    ...comparison.commits.filter((commit) => commit.sha !== introductionCommit.sha),
+    introductionCommit,
+    completionCommit,
+    updateCommit,
+  ]
+  const evidence: BaynReleaseReviewRemediationEvidence = {
+    ...fixture.evidence,
+    recordBlobSha: reviewedCompletionHistory.updateRecordBlob,
+    record,
+    referencedCommits: [...fixture.evidence.referencedCommits, introductionFinalHead, completionFinalHead],
+  }
+  return {
+    evidence,
+    snapshot: {
+      ...fixture.snapshot,
+      currentCommitParents: [completionCommit.sha],
+      comparison: {
+        ...comparison,
+        headSha: updateCommit.sha,
+        aheadBy: commits.length,
+        totalCommits: commits.length,
+        commits,
+      },
+      remediations: [evidence],
+    },
+  }
+}
+
+const evaluateReviewedCompletionSingleStageSuccessorRemediationFixture = (
+  fixture: ReturnType<typeof reviewedCompletionSingleStageSuccessorRemediationFixture>,
+) =>
+  evaluateBaynReleaseEligibility({
+    mainCommitSha: reviewedCompletionHistory.updateMerge,
+    baseRefName: 'main',
+    snapshot: fixture.snapshot,
+    nowMs: Date.parse('2026-08-01T09:45:00Z'),
+    pushBeforeSha: reviewedCompletionHistory.completionMerge,
+  })
+
 const nestedSingleStageSuccessorRemediationFixture = (): BaynReleaseEligibilitySnapshot => {
   const fixture = singleStageSuccessorRemediationFixture()
   const comparison = fixture.snapshot.comparison
@@ -2662,6 +2865,71 @@ describe('Bayn publication-range eligibility', () => {
         completedRecordBlobSha: '63f78435bffefe00b904e02492693f53fb6cb6d4',
         affectedPaths: { length: 3 },
       },
+    })
+  })
+
+  test('accepts a v9 receipt only through its reviewed completion and exact reviewed update', () => {
+    const fixture = reviewedCompletionSingleStageSuccessorRemediationFixture()
+    expect(evaluateReviewedCompletionSingleStageSuccessorRemediationFixture(fixture)).toMatchObject({
+      status: 'eligible',
+      lastPublishedRevision: continuousHistory.published,
+      checkedCommitCount: 5,
+      baynAffectingCommitCount: 5,
+      reviewedPullRequests: [
+        { commitSha: continuousHistory.blocked, prNumber: 13432 },
+        { commitSha: '2aa782001a9d7e1d9db68e5fa0929159755334cd', prNumber: 13432 },
+        { commitSha: successorBoundHistory.updateMerge, prNumber: 13446 },
+        { commitSha: reviewedCompletionHistory.completionMerge, prNumber: 13449 },
+        { commitSha: reviewedCompletionHistory.updateMerge, prNumber: 13450 },
+      ],
+    })
+  })
+
+  test('rejects a v9 receipt whose update is not the direct child of the bound completion', () => {
+    const fixture = reviewedCompletionSingleStageSuccessorRemediationFixture()
+    const update = fixture.snapshot.comparison?.commits.find(
+      (commit) => commit.sha === reviewedCompletionHistory.updateMerge,
+    )
+    if (update === undefined) throw new Error('missing v9 reviewed update')
+    ;(update as unknown as { parents: readonly string[] }).parents = [successorBoundHistory.updateMerge]
+    expect(evaluateReviewedCompletionSingleStageSuccessorRemediationFixture(fixture)).toMatchObject({
+      status: 'hold',
+      code: 'release-review-remediation-invalid',
+      retryable: false,
+    })
+  })
+
+  test('rejects a v9 receipt without an exact-head-reviewed update', () => {
+    const fixture = reviewedCompletionSingleStageSuccessorRemediationFixture()
+    const update = fixture.snapshot.comparison?.commits.find(
+      (commit) => commit.sha === reviewedCompletionHistory.updateMerge,
+    )
+    const pullRequest = update?.reviewSnapshot?.pullRequest
+    if (pullRequest === null || pullRequest === undefined) throw new Error('missing v9 update pull request')
+    ;(pullRequest as unknown as { reviews: readonly PullRequestReview[] }).reviews = []
+    expect(evaluateReviewedCompletionSingleStageSuccessorRemediationFixture(fixture)).toMatchObject({
+      status: 'hold',
+      code: 'exact-head-review-missing',
+      retryable: true,
+    })
+  })
+
+  test('rejects a v9 completion that lacks the bound final-head review reaction', () => {
+    const fixture = reviewedCompletionSingleStageSuccessorRemediationFixture()
+    const record = fixture.evidence.record
+    if (record.schemaVersion !== 'bayn.release-review-remediation.v9') throw new Error('missing v9 fixture')
+    const completion = fixture.snapshot.comparison?.commits.find(
+      (commit) => commit.sha === reviewedCompletionHistory.completionMerge,
+    )
+    const pullRequest = completion?.reviewSnapshot?.pullRequest
+    if (pullRequest === null || pullRequest === undefined) throw new Error('missing v9 completion pull request')
+    ;(pullRequest as unknown as { reactions: readonly PullRequestReaction[] }).reactions = []
+    ;(record.completion as unknown as { sourcePullRequestEvidenceSha256: string }).sourcePullRequestEvidenceSha256 =
+      pullRequestReviewEvidenceSha256(pullRequest)
+    expect(evaluateReviewedCompletionSingleStageSuccessorRemediationFixture(fixture)).toMatchObject({
+      status: 'hold',
+      code: 'release-review-remediation-invalid',
+      retryable: false,
     })
   })
 

--- a/packages/scripts/src/bayn/verify-release-review.test.ts
+++ b/packages/scripts/src/bayn/verify-release-review.test.ts
@@ -2604,9 +2604,9 @@ const nestedSingleStageSuccessorRemediationFixture = (): BaynReleaseEligibilityS
 }
 
 describe('Bayn publication-range eligibility', () => {
-  test('parses the exact immutable #13438 -> #13442 v8 reviewed-source receipt', () => {
+  test('parses the exact immutable #13438 -> #13442 v9 reviewed-source receipt', () => {
     expect(realCandidateDiagnosticsRemediationRecord).toMatchObject({
-      schemaVersion: 'bayn.release-review-remediation.v8',
+      schemaVersion: 'bayn.release-review-remediation.v9',
       remediationId: 'pr-13438-successor-bound-reviewed-source',
       blocked: {
         mergeCommitSha: 'ae4d23650c20cecbde2bac8416bc2b734381cb69',
@@ -2651,6 +2651,15 @@ describe('Bayn publication-range eligibility', () => {
         finalHeadSha: '211a901ddeacf6cab997252dee85e180e94595fa',
         sourcePullRequestEvidenceSha256: '8e59ead9e8a8c57c8c64c0b37ea1c5298b292dbc0b1efd69645ceb1678ae49b0',
         introducedRecordBlobSha: '2855013d0a960ebc9b2ee100301334fc1640d297',
+        affectedPaths: { length: 3 },
+      },
+      completion: {
+        mergeCommitSha: '3dabfa8b73e8a7de2c61a171b49e635a56774af3',
+        mergeParentSha: '628d3fd16d63f7b9e3fc02d3bbdfa130a121ed31',
+        sourcePullRequestNumber: 13449,
+        finalHeadSha: '711a3bfda038f696bc805ab32c1a8bfb93ce5d2b',
+        sourcePullRequestEvidenceSha256: 'a7234519bd57e2fdd1be320eae0a0dab802ee952ca3d379f180bbcc13c592a48',
+        completedRecordBlobSha: '63f78435bffefe00b904e02492693f53fb6cb6d4',
         affectedPaths: { length: 3 },
       },
     })

--- a/packages/scripts/src/bayn/verify-release-review.ts
+++ b/packages/scripts/src/bayn/verify-release-review.ts
@@ -374,6 +374,16 @@ interface BaynReleaseReviewRemediationCompletedSingleStageSuccessorRecord {
   readonly introduction: BaynReleaseReviewRemediationContinuousSourceIntroduction
 }
 
+interface BaynReleaseReviewRemediationReviewedCompletionSingleStageSuccessorRecord {
+  readonly schemaVersion: 'bayn.release-review-remediation.v9'
+  readonly remediationId: string
+  readonly blocked: BaynReleaseReviewRemediationSingleStageSuccessorRecord['blocked']
+  readonly requiredDescendants: readonly []
+  readonly requiredSuccessors: readonly [BaynReleaseReviewRemediationContinuousSourceSuccessor]
+  readonly introduction: BaynReleaseReviewRemediationContinuousSourceIntroduction
+  readonly completion: BaynReleaseReviewRemediationContinuousSourceCompletion
+}
+
 export type BaynReleaseReviewRemediationRecord =
   | BaynReleaseReviewRemediationLegacyRecord
   | BaynReleaseReviewRemediationContinuousSourceRecord
@@ -381,6 +391,7 @@ export type BaynReleaseReviewRemediationRecord =
   | BaynReleaseReviewRemediationSuccessorBoundContinuousSourceRecord
   | BaynReleaseReviewRemediationSingleStageSuccessorRecord
   | BaynReleaseReviewRemediationCompletedSingleStageSuccessorRecord
+  | BaynReleaseReviewRemediationReviewedCompletionSingleStageSuccessorRecord
 
 interface RemediationCommitObject {
   readonly sha: string
@@ -950,7 +961,8 @@ export const parseBaynReleaseReviewRemediationRecord = (value: unknown): BaynRel
     rawSchemaVersion !== 'bayn.release-review-remediation.v5' &&
     rawSchemaVersion !== 'bayn.release-review-remediation.v6' &&
     rawSchemaVersion !== 'bayn.release-review-remediation.v7' &&
-    rawSchemaVersion !== 'bayn.release-review-remediation.v8'
+    rawSchemaVersion !== 'bayn.release-review-remediation.v8' &&
+    rawSchemaVersion !== 'bayn.release-review-remediation.v9'
   ) {
     throw new Error('remediation schemaVersion is invalid')
   }
@@ -960,7 +972,8 @@ export const parseBaynReleaseReviewRemediationRecord = (value: unknown): BaynRel
     schemaVersion === 'bayn.release-review-remediation.v5' ||
     schemaVersion === 'bayn.release-review-remediation.v6' ||
     schemaVersion === 'bayn.release-review-remediation.v7' ||
-    schemaVersion === 'bayn.release-review-remediation.v8'
+    schemaVersion === 'bayn.release-review-remediation.v8' ||
+    schemaVersion === 'bayn.release-review-remediation.v9'
   ) {
     const record = strictRecord(
       value,
@@ -1005,7 +1018,8 @@ export const parseBaynReleaseReviewRemediationRecord = (value: unknown): BaynRel
         'sourcePullRequestEvidenceSha256',
         'affectedPaths',
         ...(schemaVersion === 'bayn.release-review-remediation.v7' ||
-        schemaVersion === 'bayn.release-review-remediation.v8'
+        schemaVersion === 'bayn.release-review-remediation.v8' ||
+        schemaVersion === 'bayn.release-review-remediation.v9'
           ? ['reviewedLineage']
           : []),
       ],
@@ -1135,33 +1149,46 @@ export const parseBaynReleaseReviewRemediationRecord = (value: unknown): BaynRel
     if (!Array.isArray(record.requiredSuccessors) || record.requiredSuccessors.length !== 1) {
       throw new Error('continuous-source remediation requiredSuccessors must contain exactly one successor')
     }
+    const parsedCompletion = {
+      mergeCommitSha: expectSha(completion.mergeCommitSha, 'remediation completion merge commit SHA'),
+      mergeParentSha: expectSha(completion.mergeParentSha, 'remediation completion merge parent SHA'),
+      mergeTreeSha: expectSha(completion.mergeTreeSha, 'remediation completion merge tree SHA'),
+      sourcePullRequestNumber: expectPositiveIntegerRecord(
+        completion.sourcePullRequestNumber,
+        'remediation completion source pull request number',
+      ),
+      finalHeadSha: expectSha(completion.finalHeadSha, 'remediation completion final head SHA'),
+      finalHeadParentSha: expectSha(completion.finalHeadParentSha, 'remediation completion final head parent SHA'),
+      finalHeadTreeSha: expectSha(completion.finalHeadTreeSha, 'remediation completion final head tree SHA'),
+      sourcePullRequestEvidenceSha256: expectSha256(
+        completion.sourcePullRequestEvidenceSha256,
+        'remediation completion source pull request evidence hash',
+      ),
+      completedRecordBlobSha: expectSha(completion.completedRecordBlobSha, 'remediation completion record blob SHA'),
+      affectedPaths: completion.affectedPaths.map((item, index) =>
+        parseRemediationCommitPath(item, `remediation completion affected path ${index}`),
+      ),
+    }
+    const parsedSuccessor = parseContinuousSourceSuccessor(record.requiredSuccessors[0])
+    if (schemaVersion === 'bayn.release-review-remediation.v9') {
+      return {
+        schemaVersion,
+        remediationId,
+        blocked: { ...parsedBlocked, reviewedLineage: parseReviewedLineage(blocked.reviewedLineage) },
+        requiredDescendants: [],
+        requiredSuccessors: [parsedSuccessor],
+        introduction: parsedIntroduction,
+        completion: parsedCompletion,
+      }
+    }
     return {
       schemaVersion,
       remediationId,
       blocked: parsedBlocked,
       requiredDescendants: [],
-      requiredSuccessors: [parseContinuousSourceSuccessor(record.requiredSuccessors[0])],
+      requiredSuccessors: [parsedSuccessor],
       introduction: parsedIntroduction,
-      completion: {
-        mergeCommitSha: expectSha(completion.mergeCommitSha, 'remediation completion merge commit SHA'),
-        mergeParentSha: expectSha(completion.mergeParentSha, 'remediation completion merge parent SHA'),
-        mergeTreeSha: expectSha(completion.mergeTreeSha, 'remediation completion merge tree SHA'),
-        sourcePullRequestNumber: expectPositiveIntegerRecord(
-          completion.sourcePullRequestNumber,
-          'remediation completion source pull request number',
-        ),
-        finalHeadSha: expectSha(completion.finalHeadSha, 'remediation completion final head SHA'),
-        finalHeadParentSha: expectSha(completion.finalHeadParentSha, 'remediation completion final head parent SHA'),
-        finalHeadTreeSha: expectSha(completion.finalHeadTreeSha, 'remediation completion final head tree SHA'),
-        sourcePullRequestEvidenceSha256: expectSha256(
-          completion.sourcePullRequestEvidenceSha256,
-          'remediation completion source pull request evidence hash',
-        ),
-        completedRecordBlobSha: expectSha(completion.completedRecordBlobSha, 'remediation completion record blob SHA'),
-        affectedPaths: completion.affectedPaths.map((item, index) =>
-          parseRemediationCommitPath(item, `remediation completion affected path ${index}`),
-        ),
-      },
+      completion: parsedCompletion,
     }
   }
   const record = strictRecord(
@@ -2571,6 +2598,7 @@ const validateContinuousReviewedLineage = (input: {
   readonly record:
     | BaynReleaseReviewRemediationSingleStageSuccessorRecord
     | BaynReleaseReviewRemediationCompletedSingleStageSuccessorRecord
+    | BaynReleaseReviewRemediationReviewedCompletionSingleStageSuccessorRecord
   readonly evidence: BaynReleaseReviewRemediationEvidence
   readonly pullRequest: PullRequestReviewState
 }): BaynReleaseReviewHold | null => {
@@ -2734,7 +2762,8 @@ const validateContinuousSourceRemediation = (input: {
     record.schemaVersion !== 'bayn.release-review-remediation.v5' &&
     record.schemaVersion !== 'bayn.release-review-remediation.v6' &&
     record.schemaVersion !== 'bayn.release-review-remediation.v7' &&
-    record.schemaVersion !== 'bayn.release-review-remediation.v8'
+    record.schemaVersion !== 'bayn.release-review-remediation.v8' &&
+    record.schemaVersion !== 'bayn.release-review-remediation.v9'
   ) {
     return remediationInvalid(`remediation ${record.remediationId} continuous source record is missing`)
   }
@@ -2800,7 +2829,8 @@ const validateContinuousSourceRemediation = (input: {
   }
   if (
     record.schemaVersion === 'bayn.release-review-remediation.v7' ||
-    record.schemaVersion === 'bayn.release-review-remediation.v8'
+    record.schemaVersion === 'bayn.release-review-remediation.v8' ||
+    record.schemaVersion === 'bayn.release-review-remediation.v9'
   ) {
     const reviewEvidence = validateBoundRemediationReviewEvidence(blockedReviewInput)
     if (reviewEvidence.status === 'hold') return reviewEvidence
@@ -2833,7 +2863,8 @@ const validateContinuousSourceRemediation = (input: {
   if (
     record.schemaVersion === 'bayn.release-review-remediation.v6' ||
     record.schemaVersion === 'bayn.release-review-remediation.v7' ||
-    record.schemaVersion === 'bayn.release-review-remediation.v8'
+    record.schemaVersion === 'bayn.release-review-remediation.v8' ||
+    record.schemaVersion === 'bayn.release-review-remediation.v9'
   ) {
     const successor = record.requiredSuccessors[0]
     const successorMatches = comparison.commits.filter((commit) => commit.sha === successor.mergeCommitSha)
@@ -2851,7 +2882,8 @@ const validateContinuousSourceRemediation = (input: {
     }
     if (
       (record.schemaVersion === 'bayn.release-review-remediation.v7' ||
-        record.schemaVersion === 'bayn.release-review-remediation.v8') &&
+        record.schemaVersion === 'bayn.release-review-remediation.v8' ||
+        record.schemaVersion === 'bayn.release-review-remediation.v9') &&
       !exactStringSet(transitionPaths, expectedPaths)
     ) {
       return remediationInvalid(
@@ -2990,6 +3022,76 @@ const validateReleaseReviewRemediation = (input: {
       comparison.commits.indexOf(completion) >= comparison.commits.indexOf(update)
     ) {
       return remediationInvalid(`remediation ${record.remediationId} successor-bound record mutation is not exact`)
+    }
+    const introductionIdentityHold = validateContinuousSourceIntroductionIdentity({
+      remediationId: record.remediationId,
+      evidence,
+      introduction,
+      identity: record.introduction,
+    })
+    if (introductionIdentityHold !== null) return introductionIdentityHold
+    const completionIdentityHold = validateContinuousSourceCompletionIdentity({
+      remediationId: record.remediationId,
+      evidence,
+      completion,
+      identity: record.completion,
+    })
+    if (completionIdentityHold !== null) return completionIdentityHold
+    const updateReview = input.normalReviews.get(update.sha)
+    if (updateReview === undefined) {
+      return remediationInvalid(`remediation ${record.remediationId} update commit lacks exact-head review`)
+    }
+    if (updateReview.status === 'hold') {
+      if (updateReview.retryable) return updateReview
+      return remediationInvalid(`remediation ${record.remediationId} update commit lacks exact-head review`)
+    }
+    const completionNormalReview = input.normalReviews.get(completion.sha)
+    if (completionNormalReview === undefined) {
+      return remediationInvalid(`remediation ${record.remediationId} completion review snapshot is missing`)
+    }
+    const completionReview = evaluateBoundRemediationReview({
+      remediationId: record.remediationId,
+      commit: completion,
+      identity: record.completion,
+      normalReview: completionNormalReview,
+      nowMs: input.nowMs,
+    })
+    if (completionReview.status === 'hold') return completionReview
+    const introductionNormalReview = input.normalReviews.get(introduction.sha)
+    if (introductionNormalReview === undefined) {
+      return remediationInvalid(`remediation ${record.remediationId} introduction review snapshot is missing`)
+    }
+    const introductionReview = evaluateBoundRemediationReview({
+      remediationId: record.remediationId,
+      commit: introduction,
+      identity: record.introduction,
+      normalReview: introductionNormalReview,
+      nowMs: input.nowMs,
+    })
+    if (introductionReview.status === 'hold') return introductionReview
+  } else if (record.schemaVersion === 'bayn.release-review-remediation.v9') {
+    if (recordCommits.length !== 3) {
+      return remediationInvalid(`remediation ${record.remediationId} reviewed completion history is not exact`)
+    }
+    introduction = recordCommits.find((commit) => commit.sha === record.introduction.mergeCommitSha)
+    const completion = recordCommits.find((commit) => commit.sha === record.completion.mergeCommitSha)
+    const update = recordCommits.find(
+      (commit) => commit.sha !== record.introduction.mergeCommitSha && commit.sha !== record.completion.mergeCommitSha,
+    )
+    const updateChange = update?.fileChanges?.find((change) => change.path === evidence.recordPath)
+    if (
+      introduction === undefined ||
+      completion === undefined ||
+      update === undefined ||
+      update.parents.length !== 1 ||
+      update.parents[0] !== completion.sha ||
+      updateChange?.status !== 'modified' ||
+      updateChange.previousPath !== null ||
+      updateChange.blobSha !== evidence.recordBlobSha ||
+      comparison.commits.indexOf(introduction) >= comparison.commits.indexOf(completion) ||
+      comparison.commits.indexOf(completion) >= comparison.commits.indexOf(update)
+    ) {
+      return remediationInvalid(`remediation ${record.remediationId} reviewed completion mutation is not exact`)
     }
     const introductionIdentityHold = validateContinuousSourceIntroductionIdentity({
       remediationId: record.remediationId,
@@ -3214,7 +3316,8 @@ const validateReleaseReviewRemediation = (input: {
     record.schemaVersion === 'bayn.release-review-remediation.v5' ||
     record.schemaVersion === 'bayn.release-review-remediation.v6' ||
     record.schemaVersion === 'bayn.release-review-remediation.v7' ||
-    record.schemaVersion === 'bayn.release-review-remediation.v8'
+    record.schemaVersion === 'bayn.release-review-remediation.v8' ||
+    record.schemaVersion === 'bayn.release-review-remediation.v9'
   ) {
     return validateContinuousSourceRemediation({
       evidence,
@@ -3684,7 +3787,8 @@ export const evaluateBaynReleaseEligibility = (input: {
       if (
         remediation[0].record.schemaVersion === 'bayn.release-review-remediation.v6' ||
         remediation[0].record.schemaVersion === 'bayn.release-review-remediation.v7' ||
-        remediation[0].record.schemaVersion === 'bayn.release-review-remediation.v8'
+        remediation[0].record.schemaVersion === 'bayn.release-review-remediation.v8' ||
+        remediation[0].record.schemaVersion === 'bayn.release-review-remediation.v9'
       ) {
         const successorIdentity = remediation[0].record.requiredSuccessors[0]
         const successorCommit = comparison.commits.find(
@@ -3711,7 +3815,8 @@ export const evaluateBaynReleaseEligibility = (input: {
       if (
         remediation[0].record.schemaVersion === 'bayn.release-review-remediation.v5' ||
         remediation[0].record.schemaVersion === 'bayn.release-review-remediation.v6' ||
-        remediation[0].record.schemaVersion === 'bayn.release-review-remediation.v8'
+        remediation[0].record.schemaVersion === 'bayn.release-review-remediation.v8' ||
+        remediation[0].record.schemaVersion === 'bayn.release-review-remediation.v9'
       ) {
         const introductionIdentity = remediation[0].record.introduction
         const introductionCommit = comparison.commits.find(
@@ -3734,7 +3839,10 @@ export const evaluateBaynReleaseEligibility = (input: {
         normalReviews.set(introductionIdentity.mergeCommitSha, introductionReview)
         coveredDescendantShas.add(introductionIdentity.mergeCommitSha)
 
-        if (remediation[0].record.schemaVersion === 'bayn.release-review-remediation.v6') {
+        if (
+          remediation[0].record.schemaVersion === 'bayn.release-review-remediation.v6' ||
+          remediation[0].record.schemaVersion === 'bayn.release-review-remediation.v9'
+        ) {
           const completionIdentity = remediation[0].record.completion
           const completionCommit = comparison.commits.find(
             (candidate) => candidate.sha === completionIdentity.mergeCommitSha,
@@ -3762,12 +3870,14 @@ export const evaluateBaynReleaseEligibility = (input: {
         remediation[0].record.schemaVersion === 'bayn.release-review-remediation.v5' ||
         remediation[0].record.schemaVersion === 'bayn.release-review-remediation.v6' ||
         remediation[0].record.schemaVersion === 'bayn.release-review-remediation.v7' ||
-        remediation[0].record.schemaVersion === 'bayn.release-review-remediation.v8'
+        remediation[0].record.schemaVersion === 'bayn.release-review-remediation.v8' ||
+        remediation[0].record.schemaVersion === 'bayn.release-review-remediation.v9'
       ) {
         const record = remediation[0].record
         if (
           record.schemaVersion === 'bayn.release-review-remediation.v7' ||
-          record.schemaVersion === 'bayn.release-review-remediation.v8'
+          record.schemaVersion === 'bayn.release-review-remediation.v8' ||
+          record.schemaVersion === 'bayn.release-review-remediation.v9'
         ) {
           const successorReview = normalReviews.get(record.requiredSuccessors[0].mergeCommitSha)
           if (successorReview?.status !== 'eligible') {
@@ -5112,7 +5222,8 @@ const loadReleaseReviewRemediations = async (
       loaded.record.schemaVersion === 'bayn.release-review-remediation.v5' ||
       loaded.record.schemaVersion === 'bayn.release-review-remediation.v6' ||
       loaded.record.schemaVersion === 'bayn.release-review-remediation.v7' ||
-      loaded.record.schemaVersion === 'bayn.release-review-remediation.v8'
+      loaded.record.schemaVersion === 'bayn.release-review-remediation.v8' ||
+      loaded.record.schemaVersion === 'bayn.release-review-remediation.v9'
     ) {
       references.set(
         loaded.record.blocked.finalHeadSha,
@@ -5120,7 +5231,8 @@ const loadReleaseReviewRemediations = async (
       )
       if (
         loaded.record.schemaVersion === 'bayn.release-review-remediation.v7' ||
-        loaded.record.schemaVersion === 'bayn.release-review-remediation.v8'
+        loaded.record.schemaVersion === 'bayn.release-review-remediation.v8' ||
+        loaded.record.schemaVersion === 'bayn.release-review-remediation.v9'
       ) {
         references.set(
           loaded.record.blocked.reviewedLineage.reviewedHeadSha,
@@ -5130,14 +5242,18 @@ const loadReleaseReviewRemediations = async (
       if (
         loaded.record.schemaVersion === 'bayn.release-review-remediation.v5' ||
         loaded.record.schemaVersion === 'bayn.release-review-remediation.v6' ||
-        loaded.record.schemaVersion === 'bayn.release-review-remediation.v8'
+        loaded.record.schemaVersion === 'bayn.release-review-remediation.v8' ||
+        loaded.record.schemaVersion === 'bayn.release-review-remediation.v9'
       ) {
         references.set(
           loaded.record.introduction.finalHeadSha,
           loaded.record.introduction.affectedPaths.map((path) => path.path),
         )
       }
-      if (loaded.record.schemaVersion === 'bayn.release-review-remediation.v6') {
+      if (
+        loaded.record.schemaVersion === 'bayn.release-review-remediation.v6' ||
+        loaded.record.schemaVersion === 'bayn.release-review-remediation.v9'
+      ) {
         references.set(
           loaded.record.completion.finalHeadSha,
           loaded.record.completion.affectedPaths.map((path) => path.path),

--- a/services/bayn/release-review-remediations/ae4d23650c20cecbde2bac8416bc2b734381cb69.json
+++ b/services/bayn/release-review-remediations/ae4d23650c20cecbde2bac8416bc2b734381cb69.json
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "bayn.release-review-remediation.v8",
+  "schemaVersion": "bayn.release-review-remediation.v9",
   "remediationId": "pr-13438-successor-bound-reviewed-source",
   "blocked": {
     "mergeCommitSha": "ae4d23650c20cecbde2bac8416bc2b734381cb69",
@@ -182,6 +182,37 @@
         "previousPath": null,
         "status": "added",
         "blobSha": "2855013d0a960ebc9b2ee100301334fc1640d297"
+      }
+    ]
+  },
+  "completion": {
+    "mergeCommitSha": "3dabfa8b73e8a7de2c61a171b49e635a56774af3",
+    "mergeParentSha": "628d3fd16d63f7b9e3fc02d3bbdfa130a121ed31",
+    "mergeTreeSha": "217604b0c12d97ed2efb8f09caa1b3e4f1c5efd2",
+    "sourcePullRequestNumber": 13449,
+    "finalHeadSha": "711a3bfda038f696bc805ab32c1a8bfb93ce5d2b",
+    "finalHeadParentSha": "628d3fd16d63f7b9e3fc02d3bbdfa130a121ed31",
+    "finalHeadTreeSha": "217604b0c12d97ed2efb8f09caa1b3e4f1c5efd2",
+    "sourcePullRequestEvidenceSha256": "a7234519bd57e2fdd1be320eae0a0dab802ee952ca3d379f180bbcc13c592a48",
+    "completedRecordBlobSha": "63f78435bffefe00b904e02492693f53fb6cb6d4",
+    "affectedPaths": [
+      {
+        "path": "packages/scripts/src/bayn/verify-release-review.test.ts",
+        "previousPath": null,
+        "status": "modified",
+        "blobSha": "b05c0ca5efaa459e2902e5e5c1faad5870ce3de0"
+      },
+      {
+        "path": "packages/scripts/src/bayn/verify-release-review.ts",
+        "previousPath": null,
+        "status": "modified",
+        "blobSha": "316c12955710cb52c1725eda319c6effe8d24ae2"
+      },
+      {
+        "path": "services/bayn/release-review-remediations/ae4d23650c20cecbde2bac8416bc2b734381cb69.json",
+        "previousPath": null,
+        "status": "modified",
+        "blobSha": "63f78435bffefe00b904e02492693f53fb6cb6d4"
       }
     ]
   }


### PR DESCRIPTION
## Summary

- bind merged PR #13449 to its exact merge/head/tree/path blobs and immutable pull-request evidence
- accept its force-pushed final head only through the exact post-head Codex reaction, without weakening the generic release-review rule
- advance the #13438 receipt to v9 with reviewed introduction, reviewed completion, and one exact-head-reviewed update
- clear natural build failure 30698216360 while preserving Candidate 20 invalidation and zero attempts

## Related Issues

Linear PROOMPT-443

## Testing

- `bun test packages/scripts/src/bayn/verify-release-review.test.ts` — 144 passed, 0 failed
- `bunx oxlint packages/scripts/src/bayn/verify-release-review.ts packages/scripts/src/bayn/verify-release-review.test.ts` — 0 warnings/errors
- `bunx oxfmt --check packages/scripts/src/bayn/verify-release-review.ts packages/scripts/src/bayn/verify-release-review.test.ts services/bayn/release-review-remediations/ae4d23650c20cecbde2bac8416bc2b734381cb69.json`
- `bunx tsc --ignoreConfig --noEmit --strict --skipLibCheck --target ES2024 --module ESNext --moduleResolution Bundler --types bun packages/scripts/src/bayn/verify-release-review.ts`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are tracked in PROOMPT-443.