### PR TITLE
fix(bayn): recover read-only reconciliation containment

### DIFF
--- a/services/bayn/migrations/0022_observe_reconciliation_recovery.ts
+++ b/services/bayn/migrations/0022_observe_reconciliation_recovery.ts
@@ -1,0 +1,143 @@
+import { Effect } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient
+
+  yield* sql`
+    CREATE OR REPLACE FUNCTION enforce_authority_transition()
+    RETURNS trigger
+    LANGUAGE plpgsql
+    AS $function$
+    BEGIN
+      IF TG_OP = 'DELETE' THEN
+        RAISE EXCEPTION 'authority state cannot be deleted' USING ERRCODE = '55000';
+      END IF;
+
+      IF TG_OP = 'INSERT' THEN
+        IF NEW.version <> 1
+          OR NEW.maximum <> 'OBSERVE'
+          OR NEW.effective <> 'OBSERVE'
+          OR NEW.kill_state <> 'CLEAR'
+          OR NEW.reason IS NOT NULL
+        THEN
+          RAISE EXCEPTION 'authority state must begin as clear OBSERVE at version 1'
+            USING ERRCODE = '23514';
+        END IF;
+        IF NOT EXISTS (
+          SELECT 1
+          FROM authority_generations AS generation
+          WHERE generation.generation_hash = NEW.generation_hash
+            AND generation.previous_generation_hash IS NULL
+            AND generation.maximum = 'OBSERVE'
+            AND generation.authority_version = 1
+            AND generation.activated_at = NEW.updated_at
+        ) THEN
+          RAISE EXCEPTION 'initial authority state lacks matching immutable OBSERVE history'
+            USING ERRCODE = '23514';
+        END IF;
+        RETURN NEW;
+      END IF;
+
+      IF NEW.singleton <> OLD.singleton
+        OR NEW.schema_version <> OLD.schema_version
+        OR NEW.version <> OLD.version + 1
+        OR NEW.updated_at <= OLD.updated_at
+      THEN
+        RAISE EXCEPTION 'invalid authority state version' USING ERRCODE = '23514';
+      END IF;
+
+      IF NEW.generation_hash = OLD.generation_hash THEN
+        IF NEW.maximum <> OLD.maximum
+          OR (OLD.effective = 'OBSERVE' AND NEW.effective = 'PAPER')
+          OR (OLD.kill_state = 'ACTIVE' AND NEW.kill_state = 'CLEAR')
+        THEN
+          RAISE EXCEPTION 'authority can only decrease within a GitOps generation' USING ERRCODE = '23514';
+        END IF;
+        RETURN NEW;
+      END IF;
+
+      IF NEW.kill_state IS DISTINCT FROM OLD.kill_state
+        OR NEW.reason IS DISTINCT FROM OLD.reason
+      THEN
+        IF NOT (
+          OLD.maximum = 'OBSERVE'
+          AND OLD.effective = 'OBSERVE'
+          AND OLD.kill_state = 'ACTIVE'
+          AND OLD.reason = 'reconciliation pass incomplete'
+          AND NEW.maximum = 'OBSERVE'
+          AND NEW.effective = 'OBSERVE'
+          AND NEW.kill_state = 'CLEAR'
+          AND NEW.reason IS NULL
+          AND EXISTS (
+            SELECT 1
+            FROM authority_generations AS generation
+            JOIN authority_generations AS previous_generation
+              ON previous_generation.generation_hash = OLD.generation_hash
+            JOIN LATERAL (
+              SELECT reconciliation.*
+              FROM reconciliations AS reconciliation
+              WHERE reconciliation.account_id = generation.account_id
+              ORDER BY reconciliation.reconciled_at DESC, reconciliation.reconciliation_id COLLATE "C" DESC
+              LIMIT 1
+            ) AS reconciliation ON true
+            WHERE generation.generation_hash = NEW.generation_hash
+              AND generation.previous_generation_hash = OLD.generation_hash
+              AND generation.maximum = 'OBSERVE'
+              AND generation.authority_version = NEW.version
+              AND generation.activated_at = NEW.updated_at
+              AND generation.broker_identity_schema_version = 'bayn.broker-identity.v2'
+              AND generation.account_id IS NOT NULL
+              AND previous_generation.broker_identity_schema_version = generation.broker_identity_schema_version
+              AND previous_generation.broker_identity_hash = generation.broker_identity_hash
+              AND previous_generation.broker_provider = generation.broker_provider
+              AND previous_generation.broker_environment = generation.broker_environment
+              AND previous_generation.account_id = generation.account_id
+              AND reconciliation.status = 'EXACT'
+              AND reconciliation.expected_hash = reconciliation.observed_hash
+              AND jsonb_array_length(reconciliation.discrepancies) = 0
+              AND reconciliation.reconciled_at > OLD.updated_at
+              AND reconciliation.reconciled_at < NEW.updated_at
+              AND NOT EXISTS (
+                SELECT 1
+                FROM mutation_events AS mutation
+                JOIN intents AS intent ON intent.intent_id = mutation.intent_id
+                WHERE intent.account_id = generation.account_id
+              )
+          )
+        ) THEN
+          RAISE EXCEPTION 'authority generation changes must preserve kill state exactly'
+            USING ERRCODE = '23514';
+        END IF;
+      END IF;
+
+      IF NOT EXISTS (
+        SELECT 1
+        FROM authority_generations AS generation
+        WHERE generation.generation_hash = NEW.generation_hash
+          AND generation.previous_generation_hash = OLD.generation_hash
+          AND generation.maximum = NEW.maximum
+          AND generation.authority_version = NEW.version
+          AND generation.activated_at = NEW.updated_at
+      ) THEN
+        RAISE EXCEPTION 'authority generation change lacks matching immutable history'
+          USING ERRCODE = '23514';
+      END IF;
+
+      IF NEW.maximum = 'PAPER' THEN
+        IF OLD.maximum <> 'OBSERVE'
+          OR NEW.effective <> (
+            CASE WHEN NEW.kill_state = 'ACTIVE' THEN 'OBSERVE' ELSE 'PAPER' END
+          )
+        THEN
+          RAISE EXCEPTION 'invalid PAPER authority generation transition' USING ERRCODE = '23514';
+        END IF;
+      ELSIF NEW.effective <> 'OBSERVE' THEN
+        RAISE EXCEPTION 'OBSERVE generation must remain effectively OBSERVE' USING ERRCODE = '23514';
+      END IF;
+
+      RETURN NEW;
+    END
+    $function$
+  `
+})

--- a/services/bayn/src/db/evidence-store.integration.test.ts
+++ b/services/bayn/src/db/evidence-store.integration.test.ts
@@ -1174,6 +1174,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
       { migration_id: 19, name: 'explicit_execution_authority' },
       { migration_id: 20, name: 'pretransmit_submit_denial' },
       { migration_id: 21, name: 'expired_paper_cycle_terminalization' },
+      { migration_id: 22, name: 'observe_reconciliation_recovery' },
     ])
   })
 

--- a/services/bayn/src/db/execution-store/observe-authority.ts
+++ b/services/bayn/src/db/execution-store/observe-authority.ts
@@ -8,6 +8,7 @@ import {
   type BrokerIdentity,
 } from '../../broker/identity'
 import { Authority, type AuthorityState } from '../../execution/contracts'
+import { incompletePassReason } from '../../simulation-reconciliation/broker-reconciler-model'
 import {
   decideObserveGeneration,
   validateAuthorityObservation,
@@ -201,17 +202,59 @@ export const makeObserveAuthorityInterpreter = (
         )
       `
       const rotated = yield* sql<Record<string, unknown>>`
-        UPDATE authority_state
+        WITH latest_reconciliation AS (
+          SELECT
+            status,
+            expected_hash,
+            observed_hash,
+            discrepancies,
+            reconciled_at
+          FROM reconciliations
+          WHERE account_id = ${identity.accountId}
+          ORDER BY reconciled_at DESC, reconciliation_id COLLATE "C" DESC
+          LIMIT 1
+        ), recovery AS (
+          SELECT
+            state.maximum = 'OBSERVE'
+            AND state.effective = 'OBSERVE'
+            AND state.kill_state = 'ACTIVE'
+            AND state.reason = ${incompletePassReason}
+            AND previous_generation.broker_identity_schema_version = ${identity.schemaVersion}
+            AND previous_generation.broker_identity_hash = ${identity.identityHash}
+            AND previous_generation.broker_provider = ${identity.provider}
+            AND previous_generation.broker_environment = ${identity.environment}
+            AND previous_generation.account_id = ${identity.accountId}
+            AND reconciliation.status = 'EXACT'
+            AND reconciliation.expected_hash = reconciliation.observed_hash
+            AND jsonb_array_length(reconciliation.discrepancies) = 0
+            AND reconciliation.reconciled_at > state.updated_at
+            AND reconciliation.reconciled_at < ${activatedAt}
+            AND NOT EXISTS (
+              SELECT 1
+              FROM mutation_events AS mutation
+              JOIN intents AS intent ON intent.intent_id = mutation.intent_id
+              WHERE intent.account_id = ${identity.accountId}
+            ) AS eligible
+          FROM authority_state AS state
+          JOIN authority_generations AS previous_generation
+            ON previous_generation.generation_hash = state.generation_hash
+          LEFT JOIN latest_reconciliation AS reconciliation ON true
+          WHERE state.singleton
+        )
+        UPDATE authority_state AS state
         SET
           generation_hash = ${decision.generationHash},
           maximum = ${decision.maximum},
           effective = 'OBSERVE',
+          kill_state = CASE WHEN recovery.eligible THEN 'CLEAR' ELSE state.kill_state END,
+          reason = CASE WHEN recovery.eligible THEN NULL ELSE state.reason END,
           version = ${decision.authorityVersion},
           updated_at = ${activatedAt}
-        WHERE singleton
+        FROM recovery
+        WHERE state.singleton
         RETURNING
-          schema_version, generation_hash, maximum, effective, kill_state, reason,
-          version::text AS version, updated_at
+          state.schema_version, state.generation_hash, state.maximum, state.effective, state.kill_state, state.reason,
+          state.version::text AS version, state.updated_at
       `.pipe(Effect.flatMap(decodeAuthorityStateRows))
       const rotatedRow = rotated[0]
       if (rotatedRow === undefined) {

--- a/services/bayn/src/db/migrations.ts
+++ b/services/bayn/src/db/migrations.ts
@@ -21,6 +21,7 @@ import robustTrendProtocol from '../../migrations/0018_robust_trend_protocol'
 import explicitExecutionAuthority from '../../migrations/0019_explicit_execution_authority'
 import pretransmitSubmitDenial from '../../migrations/0020_pretransmit_submit_denial'
 import expiredPaperCycleTerminalization from '../../migrations/0021_expired_paper_cycle_terminalization'
+import observeReconciliationRecovery from '../../migrations/0022_observe_reconciliation_recovery'
 
 export const migrationLoader = PgMigrator.fromRecord({
   '1_initial_schema': initialSchema,
@@ -44,4 +45,5 @@ export const migrationLoader = PgMigrator.fromRecord({
   '19_explicit_execution_authority': explicitExecutionAuthority,
   '20_pretransmit_submit_denial': pretransmitSubmitDenial,
   '21_expired_paper_cycle_terminalization': expiredPaperCycleTerminalization,
+  '22_observe_reconciliation_recovery': observeReconciliationRecovery,
 })

--- a/services/bayn/src/db/paper-store.integration.test.ts
+++ b/services/bayn/src/db/paper-store.integration.test.ts
@@ -53,6 +53,7 @@ import {
 } from '../broker/observations'
 import { BrokerProvider, alpacaSandboxBaseUrl } from '../broker/alpaca'
 import { makeBrokerIdentity, type BrokerIdentity } from '../broker/identity'
+import { incompletePassReason } from '../simulation-reconciliation/broker-reconciler-model'
 import { EvidenceStore, EvidenceStoreFromPostgres, PostgresClientLive } from './evidence-store'
 import {
   BrokerEventStore,
@@ -1008,6 +1009,218 @@ describePostgres('paper accounting persistence', () => {
       expect(result.historyVersions[1]?.authority_version).toBe(result.rotated.version)
     } finally {
       await runtime.dispose()
+    }
+  }, 15_000)
+
+  test('keeps OBSERVE read-only after reconciliation failures and recovers only the legacy transient kill', async () => {
+    const runtime = makeStoreRuntime({ fail: false, planHashes: [] })
+    try {
+      const result = await runtime.runPromise(
+        Effect.gen(function* () {
+          const store = yield* ExecutionStore
+          const sql = yield* PgClient.PgClient
+          const initial = yield* store.ensureAuthorityGeneration({
+            generationHash: hash('observe-recovery-generation-a'),
+            maximum: Authority.Observe,
+          })
+          const [failedAt] = yield* sql<{ updated_at: Date }>`
+            SELECT greatest(clock_timestamp(), updated_at + interval '1 millisecond') AS updated_at
+            FROM authority_state
+            WHERE singleton
+          `
+          if (failedAt === undefined) return yield* Effect.die(new Error('OBSERVE restriction time is unavailable'))
+
+          yield* store.restrictAuthority(incompletePassReason, failedAt.updated_at.toISOString())
+          const [afterReadOnlyFailure] = yield* sql<{
+            generation_hash: string
+            kill_state: KillState
+            reason: string | null
+            version: number
+          }>`
+            SELECT generation_hash, kill_state, reason, version::integer
+            FROM authority_state
+            WHERE singleton
+          `
+
+          yield* sql`
+            UPDATE authority_state
+            SET
+              effective = 'OBSERVE',
+              kill_state = 'ACTIVE',
+              reason = ${incompletePassReason},
+              version = version + 1,
+              updated_at = ${failedAt.updated_at.toISOString()}
+            WHERE singleton
+          `
+          const preservedWithoutReconciliation = yield* store.ensureAuthorityGeneration({
+            generationHash: hash('observe-recovery-generation-b'),
+            maximum: Authority.Observe,
+          })
+          const [reconciliationTime] = yield* sql<{ reconciled_at: Date }>`
+            SELECT greatest(clock_timestamp(), updated_at + interval '1 millisecond') AS reconciled_at
+            FROM authority_state
+            WHERE singleton
+          `
+          if (reconciliationTime === undefined) {
+            return yield* Effect.die(new Error('OBSERVE reconciliation time is unavailable'))
+          }
+          const reconciliationId = hash('observe-recovery-exact-reconciliation')
+          const reconciliationContentHash = hash('observe-recovery-exact-content')
+          const reconciliationStateHash = hash('observe-recovery-exact-state')
+          yield* sql`
+            INSERT INTO reconciliations (
+              reconciliation_id, schema_version, account_id, expected_hash, observed_hash,
+              content_hash, status, discrepancies, reconciled_at
+            ) VALUES (
+              ${reconciliationId}, 'bayn.paper-reconciliation.v1', ${accountId},
+              ${reconciliationStateHash}, ${reconciliationStateHash}, ${reconciliationContentHash},
+              'EXACT', ${sql.json(JSON.stringify([]))}, ${reconciliationTime.reconciled_at.toISOString()}
+            )
+          `
+          const recovered = yield* store.ensureAuthorityGeneration({
+            generationHash: hash('observe-recovery-generation-c'),
+            maximum: Authority.Observe,
+          })
+
+          const [operatorKillAt] = yield* sql<{ updated_at: Date }>`
+            SELECT greatest(clock_timestamp(), updated_at + interval '1 millisecond') AS updated_at
+            FROM authority_state
+            WHERE singleton
+          `
+          if (operatorKillAt === undefined) return yield* Effect.die(new Error('operator kill time is unavailable'))
+          yield* sql`
+            UPDATE authority_state
+            SET
+              effective = 'OBSERVE',
+              kill_state = 'ACTIVE',
+              reason = 'operator kill',
+              version = version + 1,
+              updated_at = ${operatorKillAt.updated_at.toISOString()}
+            WHERE singleton
+          `
+          const preserved = yield* store.ensureAuthorityGeneration({
+            generationHash: hash('observe-recovery-generation-d'),
+            maximum: Authority.Observe,
+          })
+
+          return { initial, afterReadOnlyFailure, preservedWithoutReconciliation, recovered, preserved }
+        }),
+      )
+
+      expect(result.afterReadOnlyFailure).toEqual({
+        generation_hash: result.initial.generationHash,
+        kill_state: KillState.Clear,
+        reason: null,
+        version: result.initial.version,
+      })
+      expect(result.preservedWithoutReconciliation).toMatchObject({
+        maximum: Authority.Observe,
+        effective: Authority.Observe,
+        kill: KillState.Active,
+        reason: incompletePassReason,
+        version: 3,
+      })
+      expect(result.recovered).toMatchObject({
+        maximum: Authority.Observe,
+        effective: Authority.Observe,
+        kill: KillState.Clear,
+        version: 4,
+      })
+      expect(result.preserved).toMatchObject({
+        maximum: Authority.Observe,
+        effective: Authority.Observe,
+        kill: KillState.Active,
+        reason: 'operator kill',
+        version: 6,
+      })
+    } finally {
+      await runtime.dispose()
+    }
+  }, 15_000)
+
+  test('preserves the transient reconciliation kill across a broker identity rotation', async () => {
+    const initialRuntime = makeStoreRuntime({ fail: false, planHashes: [] })
+    try {
+      await initialRuntime.runPromise(
+        Effect.gen(function* () {
+          const store = yield* ExecutionStore
+          const sql = yield* PgClient.PgClient
+          yield* store.ensureAuthorityGeneration({
+            generationHash: hash('observe-recovery-identity-generation-a'),
+            maximum: Authority.Observe,
+          })
+          const [failedAt] = yield* sql<{ updated_at: Date }>`
+            SELECT greatest(clock_timestamp(), updated_at + interval '1 millisecond') AS updated_at
+            FROM authority_state
+            WHERE singleton
+          `
+          if (failedAt === undefined) return yield* Effect.die(new Error('identity restriction time is unavailable'))
+          yield* sql`
+            UPDATE authority_state
+            SET
+              effective = 'OBSERVE',
+              kill_state = 'ACTIVE',
+              reason = ${incompletePassReason},
+              version = version + 1,
+              updated_at = ${failedAt.updated_at.toISOString()}
+            WHERE singleton
+          `
+        }),
+      )
+    } finally {
+      await initialRuntime.dispose()
+    }
+
+    const changedIdentity = brokerIdentity(BrokerEnvironment.Sandbox, 'changed-observe-recovery-account')
+    const changedRuntime = makeStoreRuntime({ fail: false, planHashes: [] }, observeConfigWithIdentity(changedIdentity))
+    try {
+      const result = await changedRuntime.runPromise(
+        Effect.gen(function* () {
+          const store = yield* ExecutionStore
+          const sql = yield* PgClient.PgClient
+          const [reconciliationTime] = yield* sql<{ reconciled_at: Date }>`
+            SELECT greatest(clock_timestamp(), updated_at + interval '1 millisecond') AS reconciled_at
+            FROM authority_state
+            WHERE singleton
+          `
+          if (reconciliationTime === undefined) {
+            return yield* Effect.die(new Error('identity reconciliation time is unavailable'))
+          }
+          const reconciliationStateHash = hash('observe-recovery-identity-state')
+          yield* sql`
+            INSERT INTO reconciliations (
+              reconciliation_id, schema_version, account_id, expected_hash, observed_hash,
+              content_hash, status, discrepancies, reconciled_at
+            ) VALUES (
+              ${hash('observe-recovery-identity-reconciliation')}, 'bayn.paper-reconciliation.v1',
+              ${changedIdentity.accountId}, ${reconciliationStateHash}, ${reconciliationStateHash},
+              ${hash('observe-recovery-identity-content')}, 'EXACT', ${sql.json(JSON.stringify([]))},
+              ${reconciliationTime.reconciled_at.toISOString()}
+            )
+          `
+          const rotated = yield* store.ensureAuthorityGeneration({
+            generationHash: hash('observe-recovery-identity-generation-b'),
+            maximum: Authority.Observe,
+          })
+          const history = yield* sql<{ account_id: string | null }>`
+            SELECT account_id
+            FROM authority_generations
+            ORDER BY authority_version
+          `
+          return { history, rotated }
+        }),
+      )
+
+      expect(result.rotated).toMatchObject({
+        maximum: Authority.Observe,
+        effective: Authority.Observe,
+        kill: KillState.Active,
+        reason: incompletePassReason,
+        version: 3,
+      })
+      expect(result.history).toEqual([{ account_id: accountId }, { account_id: changedIdentity.accountId }])
+    } finally {
+      await changedRuntime.dispose()
     }
   }, 15_000)
 

--- a/services/bayn/src/db/reconciliation.ts
+++ b/services/bayn/src/db/reconciliation.ts
@@ -227,6 +227,7 @@ export const restrictAuthority = (
         version = version + 1,
         updated_at = ${updatedAt}
       WHERE singleton
+        AND maximum = 'PAPER'
         AND (effective <> 'OBSERVE' OR kill_state <> 'ACTIVE')
     `.pipe(Effect.asVoid),
   )


### PR DESCRIPTION
## Summary

- prevent transient reconciliation failures from permanently latching an already read-only OBSERVE generation
- add a fail-closed migration that clears only the legacy reconciliation kill after later account-bound exact reconciliation, zero discrepancies, and zero mutation history
- preserve every operator and PAPER kill; stage the OBSERVE generation rotation only after this reviewed source is built, promoted, and live

## Related Issues

Closes PROOMPT-446

## Testing

- `env TMPDIR=/private/tmp GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=commit.gpgSign GIT_CONFIG_VALUE_0=false bun run --filter @proompteng/bayn test` — 1,200 pass, 150 PostgreSQL-skipped, 0 fail
- `BAYN_TEST_POSTGRES_URL=postgresql://bayn:bayn@127.0.0.1:55432/bayn_test bun run --filter @proompteng/bayn test:postgres` — 136 pass, 0 fail
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn build`
- `bun run lint:argocd`
- `git diff --check`

## Breaking Changes

None. The migration narrows recovery to one legacy OBSERVE-only containment state; PAPER and operator kill behavior remains fail closed. The GitOps generation remains unchanged in this PR so the old image cannot activate the new recovery transition.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.

