### PR TITLE
chore(bayn): promote image sha-60c0152ab7b49062991deed3c583d5ec5f9ccb13

### DIFF
--- a/argocd/applications/bayn/deployment.yaml
+++ b/argocd/applications/bayn/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         app.kubernetes.io/name: bayn
         app.kubernetes.io/part-of: bayn
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-08-01T12:08:37Z"
+        kubectl.kubernetes.io/restartedAt: "2026-08-01T13:43:45Z"
     spec:
       serviceAccountName: bayn
       automountServiceAccountToken: false
@@ -47,11 +47,11 @@ spec:
               protocol: TCP
           env:
             - name: BAYN_CODE_REVISION
-              value: 1d723cf4e7a0ece49bca72beeacb6510f387fbca
+              value: 60c0152ab7b49062991deed3c583d5ec5f9ccb13
             - name: BAYN_IMAGE_REPOSITORY
               value: registry.ide-newton.ts.net/lab/bayn
             - name: BAYN_IMAGE_DIGEST
-              value: sha256:77ea039811fb47d2057b16068086a0ae28e346c2ac6cbbb4a08dfd75f85c3162
+              value: sha256:bf06278b77b2e5c00ced79bb72ea1ed46b7e8af2ad8c5eba49095a49586bc309
             - name: BAYN_STRATEGY_BEHAVIOR_HASH
               value: "9e87fe0f66048c48da2191ef1fae36ef3ee0eb4ddcd036ef40881f0fe0f6eb42"
             - name: BAYN_STRATEGY_PARAMETER_HASH

--- a/argocd/applications/bayn/kustomization.yaml
+++ b/argocd/applications/bayn/kustomization.yaml
@@ -22,5 +22,5 @@ configMapGenerator:
 images:
   - name: registry.ide-newton.ts.net/lab/bayn
     newName: registry.ide-newton.ts.net/lab/bayn
-    newTag: "sha-1d723cf4e7a0ece49bca72beeacb6510f387fbca"
-    digest: sha256:77ea039811fb47d2057b16068086a0ae28e346c2ac6cbbb4a08dfd75f85c3162
+    newTag: "sha-60c0152ab7b49062991deed3c583d5ec5f9ccb13"
+    digest: sha256:bf06278b77b2e5c00ced79bb72ea1ed46b7e8af2ad8c5eba49095a49586bc309


### PR DESCRIPTION
## Summary

Promote the immutable Bayn image against the current Signal snapshot and dedicated Bayn TigerBeetle
ledger. Qualification-pin handling is selected from the verified compiled behavior identity.

- Source commit: `60c0152ab7b49062991deed3c583d5ec5f9ccb13`
- Image tag: `sha-60c0152ab7b49062991deed3c583d5ec5f9ccb13`
- Image digest: `sha256:bf06278b77b2e5c00ced79bb72ea1ed46b7e8af2ad8c5eba49095a49586bc309`
- Qualification mode: `preserve`
- Existing pin: `true`
- Qualification identity bindings match: `true`
- Snapshot changed: `false`
- Deployed snapshot: `2a91f0177684f7022f746207333e510c8268f9b77a04b778a04220a33ccf79e0`
- Candidate snapshot: `2a91f0177684f7022f746207333e510c8268f9b77a04b778a04220a33ccf79e0`
- Deployed behavior hash: `9e87fe0f66048c48da2191ef1fae36ef3ee0eb4ddcd036ef40881f0fe0f6eb42`
- Candidate behavior hash: `9e87fe0f66048c48da2191ef1fae36ef3ee0eb4ddcd036ef40881f0fe0f6eb42`
- Deployed parameter hash: `19bc51c7361b181aa48845d178cb63373b3f2e017bcbea1cf3b70ab16647f8a9`
- Candidate parameter hash: `19bc51c7361b181aa48845d178cb63373b3f2e017bcbea1cf3b70ab16647f8a9`

## Related Issues

PROOMPT-400

## Testing

- OCI index contains `linux/amd64` and `linux/arm64`.

## Screenshots (if applicable)

N/A

## Breaking Changes

This is a one-way current-contract runtime release. Databases with the old migration tracker are rejected;
there is no schema fallback or automatic rename. `preserve` keeps the terminal run only when compiled
behavior, protocol parameters, Signal inputs, TigerBeetle cluster ID, and TigerBeetle ledger all match.
Replica addresses are transport and an explicit candidate may change them without relabeling qualification
evidence. `replace` removes an existing incompatible pin only for a fresh Signal snapshot. `install` is
available only to a controlled invocation that supplies the complete reviewed candidate runtime and exact
independently accepted terminal run ID; automatic image promotion supplies neither and therefore never
creates a pin. Installation can pin only the exact source, image digest, compiled strategy, and runtime
already deployed without a pin. It cannot replace an old pin and advance to a fresh candidate in the same
change.

## Checklist

- [x] Testing section documents exact validation.
- [x] Runtime source revision and image digest are immutable.
- [x] No broker or capital-promotion authority is introduced.