### PR TITLE
fix(bayn): rotate observe recovery generation

### DIFF
--- a/argocd/applications/bayn/deployment.yaml
+++ b/argocd/applications/bayn/deployment.yaml
@@ -60,9 +60,9 @@ spec:
               value: "a6530496d594a5425f091f30148012b12b6b030d49b396f925efe9ead3496217"
             - name: BAYN_MAXIMUM_AUTHORITY
               value: OBSERVE
-            # sha256("bayn/authority-generation/autonomous-observe-v1")
+            # sha256("bayn/authority-generation/autonomous-observe-v2")
             - name: BAYN_AUTHORITY_GENERATION_HASH
-              value: "d290539ec85334d8ce267f98919c139cb382068101042d69b5433832136dc063"
+              value: "10e59caf06d0a50f40a38a7d5c01867be18de00ce637b3a3687f49bc0ec45789"
             - name: BAYN_CYCLE_POLL_INTERVAL_MS
               value: "30000"
             - name: BAYN_BROKER_PROVIDER


### PR DESCRIPTION
## Summary

- Rotate the immutable Bayn authority-generation hash from autonomous OBSERVE v1 to v2.
- Keep maximum authority at OBSERVE with no broker mutation or capital authority change.
- Trigger migration 22 only after the reviewed recovery image is live, a later exact reconciliation exists, and mutation history is empty.

## Related Issues

PROOMPT-446

## Testing

- `printf %s bayn/authority-generation/autonomous-observe-v2 | shasum -a 256`
- `git diff --check`
- `kustomize build --enable-helm argocd/applications/bayn`
- `bun run lint:argocd` (83/113/104/113/147/160/92 resources; 0 invalid, 0 errors)
- Live precondition: source `60c0152a` / digest `sha256:bf06278b...` is running; reconciliation EXACT with zero discrepancies; broker read preflight shows zero positions/orders/fills; mutation count zero; durable kill reason is the recoverable `reconciliation pass incomplete` condition.

## Breaking Changes

None. This remains OBSERVE-only and cannot authorize broker orders or capital.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked in PROOMPT-446.