### PR TITLE
fix(bayn): enable legacy observe root recovery

### DIFF
--- a/services/bayn/migrations/0023_legacy_observe_recovery.ts
+++ b/services/bayn/migrations/0023_legacy_observe_recovery.ts
@@ -1,0 +1,162 @@
+import { Effect } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient
+
+  yield* sql`
+    CREATE OR REPLACE FUNCTION enforce_authority_transition()
+    RETURNS trigger
+    LANGUAGE plpgsql
+    AS $function$
+    BEGIN
+      IF TG_OP = 'DELETE' THEN
+        RAISE EXCEPTION 'authority state cannot be deleted' USING ERRCODE = '55000';
+      END IF;
+
+      IF TG_OP = 'INSERT' THEN
+        IF NEW.version <> 1
+          OR NEW.maximum <> 'OBSERVE'
+          OR NEW.effective <> 'OBSERVE'
+          OR NEW.kill_state <> 'CLEAR'
+          OR NEW.reason IS NOT NULL
+        THEN
+          RAISE EXCEPTION 'authority state must begin as clear OBSERVE at version 1'
+            USING ERRCODE = '23514';
+        END IF;
+        IF NOT EXISTS (
+          SELECT 1
+          FROM authority_generations AS generation
+          WHERE generation.generation_hash = NEW.generation_hash
+            AND generation.previous_generation_hash IS NULL
+            AND generation.maximum = 'OBSERVE'
+            AND generation.authority_version = 1
+            AND generation.activated_at = NEW.updated_at
+        ) THEN
+          RAISE EXCEPTION 'initial authority state lacks matching immutable OBSERVE history'
+            USING ERRCODE = '23514';
+        END IF;
+        RETURN NEW;
+      END IF;
+
+      IF NEW.singleton <> OLD.singleton
+        OR NEW.schema_version <> OLD.schema_version
+        OR NEW.version <> OLD.version + 1
+        OR NEW.updated_at <= OLD.updated_at
+      THEN
+        RAISE EXCEPTION 'invalid authority state version' USING ERRCODE = '23514';
+      END IF;
+
+      IF NEW.generation_hash = OLD.generation_hash THEN
+        IF NEW.maximum <> OLD.maximum
+          OR (OLD.effective = 'OBSERVE' AND NEW.effective = 'PAPER')
+          OR (OLD.kill_state = 'ACTIVE' AND NEW.kill_state = 'CLEAR')
+        THEN
+          RAISE EXCEPTION 'authority can only decrease within a GitOps generation' USING ERRCODE = '23514';
+        END IF;
+        RETURN NEW;
+      END IF;
+
+      IF NEW.kill_state IS DISTINCT FROM OLD.kill_state
+        OR NEW.reason IS DISTINCT FROM OLD.reason
+      THEN
+        IF NOT (
+          OLD.maximum = 'OBSERVE'
+          AND OLD.effective = 'OBSERVE'
+          AND OLD.kill_state = 'ACTIVE'
+          AND OLD.reason = 'reconciliation pass incomplete'
+          AND NEW.maximum = 'OBSERVE'
+          AND NEW.effective = 'OBSERVE'
+          AND NEW.kill_state = 'CLEAR'
+          AND NEW.reason IS NULL
+          AND EXISTS (
+            SELECT 1
+            FROM authority_generations AS generation
+            JOIN authority_generations AS previous_generation
+              ON previous_generation.generation_hash = OLD.generation_hash
+            JOIN LATERAL (
+              SELECT reconciliation.*
+              FROM reconciliations AS reconciliation
+              WHERE reconciliation.account_id = generation.account_id
+              ORDER BY reconciliation.reconciled_at DESC, reconciliation.reconciliation_id COLLATE "C" DESC
+              LIMIT 1
+            ) AS reconciliation ON true
+            WHERE generation.generation_hash = NEW.generation_hash
+              AND generation.previous_generation_hash = OLD.generation_hash
+              AND generation.maximum = 'OBSERVE'
+              AND generation.authority_version = NEW.version
+              AND generation.activated_at = NEW.updated_at
+              AND generation.broker_identity_schema_version = 'bayn.broker-identity.v2'
+              AND generation.broker_identity_hash IS NOT NULL
+              AND generation.account_id IS NOT NULL
+              AND (
+                (
+                  previous_generation.broker_identity_schema_version = generation.broker_identity_schema_version
+                  AND previous_generation.broker_identity_hash = generation.broker_identity_hash
+                  AND previous_generation.broker_provider = generation.broker_provider
+                  AND previous_generation.broker_environment = generation.broker_environment
+                  AND previous_generation.account_id = generation.account_id
+                )
+                OR (
+                  generation.broker_provider = 'alpaca'
+                  AND generation.broker_environment = 'sandbox'
+                  AND previous_generation.generation_hash =
+                    'd290539ec85334d8ce267f98919c139cb382068101042d69b5433832136dc063'
+                  AND previous_generation.previous_generation_hash IS NULL
+                  AND previous_generation.maximum = 'OBSERVE'
+                  AND previous_generation.authority_version = 1
+                  AND previous_generation.broker_identity_schema_version IS NULL
+                  AND previous_generation.broker_identity_hash IS NULL
+                  AND previous_generation.broker_provider IS NULL
+                  AND previous_generation.broker_environment IS NULL
+                  AND previous_generation.account_id IS NULL
+                )
+              )
+              AND reconciliation.status = 'EXACT'
+              AND reconciliation.expected_hash = reconciliation.observed_hash
+              AND jsonb_array_length(reconciliation.discrepancies) = 0
+              AND reconciliation.reconciled_at > OLD.updated_at
+              AND reconciliation.reconciled_at < NEW.updated_at
+              AND NOT EXISTS (
+                SELECT 1
+                FROM mutation_events AS mutation
+                JOIN intents AS intent ON intent.intent_id = mutation.intent_id
+                WHERE intent.account_id = generation.account_id
+              )
+          )
+        ) THEN
+          RAISE EXCEPTION 'authority generation changes must preserve kill state exactly'
+            USING ERRCODE = '23514';
+        END IF;
+      END IF;
+
+      IF NOT EXISTS (
+        SELECT 1
+        FROM authority_generations AS generation
+        WHERE generation.generation_hash = NEW.generation_hash
+          AND generation.previous_generation_hash = OLD.generation_hash
+          AND generation.maximum = NEW.maximum
+          AND generation.authority_version = NEW.version
+          AND generation.activated_at = NEW.updated_at
+      ) THEN
+        RAISE EXCEPTION 'authority generation change lacks matching immutable history'
+          USING ERRCODE = '23514';
+      END IF;
+
+      IF NEW.maximum = 'PAPER' THEN
+        IF OLD.maximum <> 'OBSERVE'
+          OR NEW.effective <> (
+            CASE WHEN NEW.kill_state = 'ACTIVE' THEN 'OBSERVE' ELSE 'PAPER' END
+          )
+        THEN
+          RAISE EXCEPTION 'invalid PAPER authority generation transition' USING ERRCODE = '23514';
+        END IF;
+      ELSIF NEW.effective <> 'OBSERVE' THEN
+        RAISE EXCEPTION 'OBSERVE generation must remain effectively OBSERVE' USING ERRCODE = '23514';
+      END IF;
+
+      RETURN NEW;
+    END
+    $function$
+  `
+})

--- a/services/bayn/src/db/evidence-store.integration.test.ts
+++ b/services/bayn/src/db/evidence-store.integration.test.ts
@@ -1175,6 +1175,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
       { migration_id: 20, name: 'pretransmit_submit_denial' },
       { migration_id: 21, name: 'expired_paper_cycle_terminalization' },
       { migration_id: 22, name: 'observe_reconciliation_recovery' },
+      { migration_id: 23, name: 'legacy_observe_recovery' },
     ])
   })
 

--- a/services/bayn/src/db/execution-store/observe-authority.ts
+++ b/services/bayn/src/db/execution-store/observe-authority.ts
@@ -219,11 +219,28 @@ export const makeObserveAuthorityInterpreter = (
             AND state.effective = 'OBSERVE'
             AND state.kill_state = 'ACTIVE'
             AND state.reason = ${incompletePassReason}
-            AND previous_generation.broker_identity_schema_version = ${identity.schemaVersion}
-            AND previous_generation.broker_identity_hash = ${identity.identityHash}
-            AND previous_generation.broker_provider = ${identity.provider}
-            AND previous_generation.broker_environment = ${identity.environment}
-            AND previous_generation.account_id = ${identity.accountId}
+            AND (
+              (
+                previous_generation.broker_identity_schema_version = ${identity.schemaVersion}
+                AND previous_generation.broker_identity_hash = ${identity.identityHash}
+                AND previous_generation.broker_provider = ${identity.provider}
+                AND previous_generation.broker_environment = ${identity.environment}
+                AND previous_generation.account_id = ${identity.accountId}
+              )
+              OR (
+                ${identity.provider} = ${BrokerProvider.Alpaca}
+                AND ${identity.environment} = ${BrokerEnvironment.Sandbox}
+                AND previous_generation.generation_hash = ${LEGACY_AUTONOMOUS_OBSERVE_GENERATION_HASH}
+                AND previous_generation.previous_generation_hash IS NULL
+                AND previous_generation.maximum = 'OBSERVE'
+                AND previous_generation.authority_version = 1
+                AND previous_generation.broker_identity_schema_version IS NULL
+                AND previous_generation.broker_identity_hash IS NULL
+                AND previous_generation.broker_provider IS NULL
+                AND previous_generation.broker_environment IS NULL
+                AND previous_generation.account_id IS NULL
+              )
+            )
             AND reconciliation.status = 'EXACT'
             AND reconciliation.expected_hash = reconciliation.observed_hash
             AND jsonb_array_length(reconciliation.discrepancies) = 0

--- a/services/bayn/src/db/migrations.ts
+++ b/services/bayn/src/db/migrations.ts
@@ -22,6 +22,7 @@ import explicitExecutionAuthority from '../../migrations/0019_explicit_execution
 import pretransmitSubmitDenial from '../../migrations/0020_pretransmit_submit_denial'
 import expiredPaperCycleTerminalization from '../../migrations/0021_expired_paper_cycle_terminalization'
 import observeReconciliationRecovery from '../../migrations/0022_observe_reconciliation_recovery'
+import legacyObserveRecovery from '../../migrations/0023_legacy_observe_recovery'
 
 export const migrationLoader = PgMigrator.fromRecord({
   '1_initial_schema': initialSchema,
@@ -46,4 +47,5 @@ export const migrationLoader = PgMigrator.fromRecord({
   '20_pretransmit_submit_denial': pretransmitSubmitDenial,
   '21_expired_paper_cycle_terminalization': expiredPaperCycleTerminalization,
   '22_observe_reconciliation_recovery': observeReconciliationRecovery,
+  '23_legacy_observe_recovery': legacyObserveRecovery,
 })

--- a/services/bayn/src/db/paper-store.integration.test.ts
+++ b/services/bayn/src/db/paper-store.integration.test.ts
@@ -1138,6 +1138,198 @@ describePostgres('paper accounting persistence', () => {
     }
   }, 15_000)
 
+  test('recovers the exact identity-less autonomous OBSERVE root onto the configured sandbox identity', async () => {
+    const runtime = makeStoreRuntime({ fail: false, planHashes: [] })
+    try {
+      const result = await runtime.runPromise(
+        Effect.gen(function* () {
+          const store = yield* ExecutionStore
+          const sql = yield* PgClient.PgClient
+          const activatedAt = '2026-07-28T06:49:28.305Z'
+          yield* sql`
+            INSERT INTO authority_generations (
+              generation_hash, schema_version, previous_generation_hash, maximum,
+              authority_version, activated_at
+            ) VALUES (
+              ${LEGACY_AUTONOMOUS_OBSERVE_GENERATION_HASH},
+              'bayn.authority-generation-history.v1', NULL, 'OBSERVE', 1, ${activatedAt}
+            )
+          `
+          yield* sql`
+            INSERT INTO authority_state (
+              schema_version, generation_hash, maximum, effective, kill_state,
+              reason, version, updated_at
+            ) VALUES (
+              'bayn.paper-authority.v1', ${LEGACY_AUTONOMOUS_OBSERVE_GENERATION_HASH},
+              'OBSERVE', 'OBSERVE', 'CLEAR', NULL, 1, ${activatedAt}
+            )
+          `
+          const [failedAt] = yield* sql<{ updated_at: Date }>`
+            SELECT greatest(clock_timestamp(), updated_at + interval '1 millisecond') AS updated_at
+            FROM authority_state
+            WHERE singleton
+          `
+          if (failedAt === undefined) return yield* Effect.die(new Error('legacy restriction time is unavailable'))
+          yield* sql`
+            UPDATE authority_state
+            SET
+              kill_state = 'ACTIVE',
+              reason = ${incompletePassReason},
+              version = 2,
+              updated_at = ${failedAt.updated_at.toISOString()}
+            WHERE singleton
+          `
+          const [reconciliationTime] = yield* sql<{ reconciled_at: Date }>`
+            SELECT greatest(clock_timestamp(), updated_at + interval '1 millisecond') AS reconciled_at
+            FROM authority_state
+            WHERE singleton
+          `
+          if (reconciliationTime === undefined) {
+            return yield* Effect.die(new Error('legacy reconciliation time is unavailable'))
+          }
+          const reconciliationStateHash = hash('legacy-observe-recovery-state')
+          yield* sql`
+            INSERT INTO reconciliations (
+              reconciliation_id, schema_version, account_id, expected_hash, observed_hash,
+              content_hash, status, discrepancies, reconciled_at
+            ) VALUES (
+              ${hash('legacy-observe-recovery-reconciliation')}, 'bayn.paper-reconciliation.v1', ${accountId},
+              ${reconciliationStateHash}, ${reconciliationStateHash},
+              ${hash('legacy-observe-recovery-content')}, 'EXACT', ${sql.json(JSON.stringify([]))},
+              ${reconciliationTime.reconciled_at.toISOString()}
+            )
+          `
+          const recovered = yield* store.ensureAuthorityGeneration({
+            generationHash: hash('legacy-observe-recovery-generation-v2'),
+            maximum: Authority.Observe,
+          })
+          const history = yield* sql<{
+            account_id: string | null
+            broker_environment: string | null
+            broker_identity_schema_version: string | null
+            broker_provider: string | null
+            previous_generation_hash: string | null
+          }>`
+            SELECT
+              previous_generation_hash,
+              broker_identity_schema_version,
+              broker_provider,
+              broker_environment,
+              account_id
+            FROM authority_generations
+            ORDER BY authority_version
+          `
+          return { history, recovered }
+        }),
+      )
+
+      expect(result.recovered).toMatchObject({
+        maximum: Authority.Observe,
+        effective: Authority.Observe,
+        kill: KillState.Clear,
+        version: 3,
+      })
+      expect(result.history).toEqual([
+        {
+          previous_generation_hash: null,
+          broker_identity_schema_version: null,
+          broker_provider: null,
+          broker_environment: null,
+          account_id: null,
+        },
+        {
+          previous_generation_hash: LEGACY_AUTONOMOUS_OBSERVE_GENERATION_HASH,
+          broker_identity_schema_version: 'bayn.broker-identity.v2',
+          broker_provider: BrokerProvider.Alpaca,
+          broker_environment: BrokerEnvironment.Sandbox,
+          account_id: accountId,
+        },
+      ])
+    } finally {
+      await runtime.dispose()
+    }
+  }, 15_000)
+
+  test('preserves the transient kill for an arbitrary identity-less OBSERVE root', async () => {
+    const runtime = makeStoreRuntime({ fail: false, planHashes: [] })
+    try {
+      const result = await runtime.runPromise(
+        Effect.gen(function* () {
+          const store = yield* ExecutionStore
+          const sql = yield* PgClient.PgClient
+          const untrustedRoot = hash('untrusted-identity-less-observe-root')
+          const activatedAt = '2026-07-28T06:49:28.305Z'
+          yield* sql`
+            INSERT INTO authority_generations (
+              generation_hash, schema_version, previous_generation_hash, maximum,
+              authority_version, activated_at
+            ) VALUES (
+              ${untrustedRoot}, 'bayn.authority-generation-history.v1', NULL, 'OBSERVE', 1, ${activatedAt}
+            )
+          `
+          yield* sql`
+            INSERT INTO authority_state (
+              schema_version, generation_hash, maximum, effective, kill_state,
+              reason, version, updated_at
+            ) VALUES (
+              'bayn.paper-authority.v1', ${untrustedRoot},
+              'OBSERVE', 'OBSERVE', 'CLEAR', NULL, 1, ${activatedAt}
+            )
+          `
+          const [failedAt] = yield* sql<{ updated_at: Date }>`
+            SELECT greatest(clock_timestamp(), updated_at + interval '1 millisecond') AS updated_at
+            FROM authority_state
+            WHERE singleton
+          `
+          if (failedAt === undefined) return yield* Effect.die(new Error('untrusted restriction time is unavailable'))
+          yield* sql`
+            UPDATE authority_state
+            SET
+              kill_state = 'ACTIVE',
+              reason = ${incompletePassReason},
+              version = 2,
+              updated_at = ${failedAt.updated_at.toISOString()}
+            WHERE singleton
+          `
+          const [reconciliationTime] = yield* sql<{ reconciled_at: Date }>`
+            SELECT greatest(clock_timestamp(), updated_at + interval '1 millisecond') AS reconciled_at
+            FROM authority_state
+            WHERE singleton
+          `
+          if (reconciliationTime === undefined) {
+            return yield* Effect.die(new Error('untrusted reconciliation time is unavailable'))
+          }
+          const reconciliationStateHash = hash('untrusted-observe-recovery-state')
+          yield* sql`
+            INSERT INTO reconciliations (
+              reconciliation_id, schema_version, account_id, expected_hash, observed_hash,
+              content_hash, status, discrepancies, reconciled_at
+            ) VALUES (
+              ${hash('untrusted-observe-recovery-reconciliation')}, 'bayn.paper-reconciliation.v1', ${accountId},
+              ${reconciliationStateHash}, ${reconciliationStateHash},
+              ${hash('untrusted-observe-recovery-content')}, 'EXACT', ${sql.json(JSON.stringify([]))},
+              ${reconciliationTime.reconciled_at.toISOString()}
+            )
+          `
+          return yield* store.ensureAuthorityGeneration({
+            generationHash: hash('untrusted-observe-recovery-generation-v2'),
+            maximum: Authority.Observe,
+          })
+        }),
+      )
+
+      expect(result).toMatchObject({
+        maximum: Authority.Observe,
+        effective: Authority.Observe,
+        kill: KillState.Active,
+        reason: incompletePassReason,
+        version: 3,
+      })
+    } finally {
+      await runtime.dispose()
+    }
+  }, 15_000)
+
   test('preserves the transient reconciliation kill across a broker identity rotation', async () => {
     const initialRuntime = makeStoreRuntime({ fail: false, planHashes: [] })
     try {


### PR DESCRIPTION
## Summary

- allow recovery only from the exact source-controlled identity-less autonomous OBSERVE v1 root into a configured Alpaca sandbox v2 identity
- keep exact reconciliation, account, timing, zero-mutation, and transient-kill gates intact in both runtime SQL and the PostgreSQL transition trigger
- add migration 23 plus positive legacy-root and arbitrary-root fail-closed PostgreSQL regressions

## Related Issues

PROOMPT-446

## Testing

- BAYN_TEST_POSTGRES_URL=postgresql://bayn:bayn@127.0.0.1:5432/bayn_test bun run --cwd services/bayn test:postgres (138 pass, 0 fail)
- bun run --cwd services/bayn lint:effect
- bun run --cwd services/bayn tsc
- bun run --cwd services/bayn lint:oxlint:type (0 errors; existing generated-candidate warnings only)
- bun run --cwd services/bayn build
- bunx oxfmt --check on all five changed files

## Breaking Changes

None. Migration 23 replaces the authority transition trigger in place; no manual data rewrite is required.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable and the section was removed.
- [x] Breaking Changes is filled in.
- [x] Documentation and follow-up are tracked in PROOMPT-446.