### PR TITLE
feat(bayn): evaluate bounded candidate strategy plans

### DIFF
--- a/services/bayn/src/candidate-development-command.test.ts
+++ b/services/bayn/src/candidate-development-command.test.ts
@@ -11,6 +11,7 @@ import type { CandidateDevelopmentNextPreregistration } from './candidate-develo
 import {
   authorizeCandidateDevelopmentAttempt,
   bindCandidateDevelopmentVerifiedSource,
+  buildCandidateDevelopmentPlanEvaluation,
   buildCandidateDevelopmentCommandReport as buildCandidateDevelopmentCommandReportPure,
   candidateDevelopmentCommandFailureOutputMaxBytes,
   candidateDevelopmentExecutableProgramSchemaVersion,
@@ -42,6 +43,7 @@ import {
   type CandidateDevelopmentStrategyProtocol,
   type CandidateDevelopmentSourceGit,
   type CandidateDevelopmentSourceManifest,
+  type CandidateDevelopmentStrategyPlan,
   type CandidateDevelopmentSourceVerifier,
   type CandidateDevelopmentVerifiedSource,
   type CandidateDevelopmentVerifiedSourceFiles,
@@ -53,7 +55,9 @@ import {
 } from './candidate-development-trial-history'
 import {
   candidateDevelopmentComparisonSemantics,
+  expectedCandidateDevelopmentRebalanceSchedule,
   officialMonthEndSignalDates,
+  preflightCandidateDevelopment,
   type CandidateDevelopmentPreflightInput,
   type CandidateDevelopmentReport,
 } from './candidate-development'
@@ -714,7 +718,7 @@ const fixtureRuntimePreflightInput: CandidateDevelopmentPreflightInput = {
   featureLookbackSessions: 126,
 }
 
-const fixtureStressedRunId = fixtureRunId
+const fixtureStressedRunId = '9'.repeat(64)
 const fixtureSourceManifest: CandidateDevelopmentSourceManifest = {
   schemaVersion: 'bayn.candidate-development-source-manifest.v1',
   candidateOrdinal: 16,
@@ -4803,7 +4807,7 @@ runCandidateDevelopmentCommandMain(
     }
   })
 
-  test('rejects every accounting decision and order before the first selected rebalance', () => {
+  test('rejects accounting activity not reproduced by the full deterministic replay', () => {
     const report = reportFixture(0.01)
     const baseline = baselineFixture()
     const preRebalance = makeSignalDecisionFixture(fixtureAccountingStart, fixtureSessions[0])
@@ -4874,12 +4878,7 @@ runCandidateDevelopmentCommandMain(
       events: [preRebalanceFill, ...baseline.events],
     }
     expect(buildFixtureReport(report, baselineWithFill)).toMatchObject({
-      failure: {
-        reason: 'selected-trace-mismatch',
-        field: 'baselineSimulation.events.sessionDate',
-        expected: `>=${fixtureSessions[0]}`,
-        observed: fixtureAccountingStart,
-      },
+      failure: { field: 'baseline.replay.monetaryEvents' },
     })
 
     const stressedSimulation = {
@@ -6831,6 +6830,1160 @@ runCandidateDevelopmentCommandMain(
     expect(decoded.baseline.runId).toBe(verifiedSource.baselineRunId)
     expect(decoded.accounting.stressedRunId).toBe(verifiedSource.stressedRunId)
   })
+
+  test('constructs simulator, cost, benchmark, and reconciliation evidence from a bounded strategy plan', async () => {
+    const officialSessions = frozenCandidateDevelopmentSessions()
+    const universe = [...defaultProtocolDocument.universe]
+    const firstSession = officialSessions[0]
+    const lastSession = officialSessions.at(-1)
+    if (firstSession === undefined || lastSession === undefined) {
+      throw new Error('candidate plan regression requires the frozen calendar')
+    }
+    const geometryPreflight = successOf(
+      preflightCandidateDevelopment({
+        candidateOrdinal: 21,
+        priorTrialCount: 20,
+        expectedStrategyProtocolHash: '0'.repeat(64),
+        officialSessions,
+        signalSessionDates: officialMonthEndSignalDates(officialSessions),
+        featureLookbackSessions: 252,
+      }),
+    )
+    if (geometryPreflight.status !== 'PASS') {
+      throw new Error('candidate plan regression requires passing geometry')
+    }
+    const symbols = universe.map((symbol) => ({
+      symbol,
+      rows: officialSessions.length,
+      firstSession,
+      lastSession,
+    }))
+    const manifestMaterial = {
+      schemaVersion: 'bayn.input-manifest.v3' as const,
+      database: 'signal' as const,
+      bounds: {
+        schemaVersion: 'bayn.evaluation-bounds.v1' as const,
+        dataStart: firstSession,
+        dataEnd: lastSession,
+        lookbackStart: firstSession,
+        evaluationStart: geometryPreflight.selectedObservationStart,
+        evaluationEnd: geometryPreflight.selectedObservationEnd,
+      },
+      rowCount: officialSessions.length * universe.length,
+      sessionCount: officialSessions.length,
+      firstSession,
+      lastSession,
+      symbols,
+      tables: {
+        bars: 'adjusted_daily_bars_v2' as const,
+        sessions: 'exchange_sessions_v1' as const,
+        manifests: 'snapshot_manifests_v2' as const,
+      },
+      finalizedSnapshot: {
+        schemaVersion: 'bayn.finalized-snapshot.v3' as const,
+        publicationSchemaVersion: PublicationSchema.AdjustedDailySnapshotV2,
+        universeId: 'cross-asset-taa-v1' as const,
+        universeSymbolHash: sha256(universe.join(',')),
+        snapshotId: 'a'.repeat(64),
+        publicationId: 'b'.repeat(64),
+        source: DataSource.Alpaca,
+        sourceFeed: DataFeed.Sip,
+        adjustment: PriceAdjustment.All,
+        calendarVersion: 'alpaca-us-equity-calendar-v1',
+        publisherSourceRevision: 'c'.repeat(40),
+        publisherImage: {
+          repository: 'registry.example.test/bayn',
+          digest: `sha256:${'d'.repeat(64)}` as const,
+        },
+        finalizedAt: '2026-07-01T00:00:00.000Z',
+        requestedStart: firstSession,
+        firstSession,
+        lastSession,
+        asOfSession: lastSession,
+        symbols: universe,
+        rowCount: officialSessions.length * universe.length,
+        sessionCount: officialSessions.length,
+        contentHash: 'e'.repeat(64),
+        sessionsContentHash: 'f'.repeat(64),
+      },
+    }
+    const inputManifest = { ...manifestMaterial, hash: canonicalHashV1(manifestMaterial) }
+    const bars = officialSessions.flatMap((sessionDate, sessionIndex) =>
+      universe.map((symbol, symbolIndex) => {
+        const close = 100 + sessionIndex * (symbol === 'SPY' ? 0.015 : 0.003 + symbolIndex * 0.001)
+        return {
+          symbol,
+          sessionDate,
+          open: close,
+          high: close + 1,
+          low: close - 1,
+          close,
+          volume: 1_000_000,
+          source: DataSource.Alpaca,
+          sourceFeed: DataFeed.Sip,
+          adjustment: PriceAdjustment.All,
+          publicationSchemaVersion: PublicationSchema.AdjustedDailySnapshotV2,
+        }
+      }),
+    )
+    const marketDataMaterial = {
+      schemaVersion: 'bayn.candidate-development-market-data-witness.v1' as const,
+      snapshotId: inputManifest.finalizedSnapshot.snapshotId,
+      inputManifestHash: inputManifest.hash,
+      bars,
+    }
+    const marketData = { ...marketDataMaterial, contentHash: canonicalHashV1(marketDataMaterial) }
+    const strategyProtocol: CandidateDevelopmentStrategyProtocol = {
+      schemaVersion: 'bayn.candidate-development-strategy-protocol.v2',
+      universe,
+      directVolatilityTarget: defaultProtocolDocument.directVolatilityTarget,
+      initialCapitalMicros: '1000000000000',
+      executionModel: defaultProtocolDocument.executionModel,
+      thresholds: defaultProtocolDocument.thresholds,
+      marketData: {
+        schemaVersion: 'bayn.candidate-development-market-data-contract.v1',
+        snapshotId: marketData.snapshotId,
+        contentHash: marketData.contentHash,
+      },
+      benchmarks: {
+        schemaVersion: 'bayn.candidate-development-benchmark-policy.v1',
+        symbol: 'SPY',
+        directVolatilityWindow: 63,
+        terminalPolicy: 'last-all-cash-strategy-decision',
+      },
+      strategyIdentity: {
+        schemaVersion: 'bayn.candidate-development-strategy-identity.v2',
+        family: 'inverse-volatility-risk-diversification',
+        identifier: 'candidate-plan-host-regression',
+        researchSources: ['source-a', 'source-b', 'source-c'],
+        parameters: {
+          id: 'candidate-plan-host-regression-v1',
+          lookbackSessions: 252,
+          annualizationSessions: 252,
+          riskAssets: ['SPY', 'EFA'],
+          covarianceEstimator: 'sample',
+          targetAnnualizedVolatility: 0.1,
+          maximumGrossExposure: 0.2,
+        },
+        input: 'content-verified adjusted closes',
+        weighting: 'inverse volatility',
+        riskScaling: 'fixed regression scale',
+        allocation: 'single bounded risk asset',
+        schedule: 'governed month end',
+        terminal: 'all cash',
+        missingData: 'fail closed',
+        doubledCost: 'trusted host replay',
+      },
+    }
+    const preflightInput: CandidateDevelopmentPreflightInput = {
+      candidateOrdinal: 21,
+      priorTrialCount: 20,
+      expectedStrategyProtocolHash: canonicalHashV1(strategyProtocol),
+      officialSessions,
+      signalSessionDates: officialMonthEndSignalDates(officialSessions),
+      featureLookbackSessions: 252,
+    }
+    const preflight = successOf(preflightCandidateDevelopment(preflightInput))
+    if (preflight.status !== 'PASS') throw new Error('candidate plan regression requires passing geometry')
+    const selectedStartIndex = officialSessions.indexOf(preflight.selectedObservationStart)
+    const accountingStart = officialSessions[selectedStartIndex - 1]
+    if (accountingStart === undefined) throw new Error('candidate plan regression requires an accounting predecessor')
+    const planSchedule = expectedCandidateDevelopmentRebalanceSchedule(
+      officialSessions,
+      preflightInput.signalSessionDates,
+      accountingStart,
+      preflight.selectedObservationEnd,
+    )
+    expect(planSchedule.slice(1)).toEqual([...preflight.expectedRebalanceSchedule])
+    const inverseVolatilityIdentity = strategyProtocol.strategyIdentity
+    if (inverseVolatilityIdentity?.schemaVersion !== 'bayn.candidate-development-strategy-identity.v2') {
+      throw new Error('candidate plan regression requires inverse-volatility identity')
+    }
+    const inverseVolatilityParameters = inverseVolatilityIdentity.parameters
+    const quantize = (value: number): number => Math.round(value * 1_000_000_000_000) / 1_000_000_000_000
+    const sampleVariance = (values: readonly number[]): number => {
+      const mean = values.reduce((sum, value) => sum + value, 0) / values.length
+      return values.reduce((sum, value) => sum + (value - mean) ** 2, 0) / (values.length - 1)
+    }
+    const sampleCovariance = (first: readonly number[], second: readonly number[]): number => {
+      const firstMean = first.reduce((sum, value) => sum + value, 0) / first.length
+      const secondMean = second.reduce((sum, value) => sum + value, 0) / second.length
+      return (
+        first.reduce(
+          (sum, value, valueIndex) => sum + (value - firstMean) * ((second[valueIndex] as number) - secondMean),
+          0,
+        ) /
+        (first.length - 1)
+      )
+    }
+    const closeBySessionAndSymbol = new Map<string, number>(
+      bars.map((bar) => [`${bar.sessionDate}:${bar.symbol}`, bar.close] as const),
+    )
+    const closeAt = (sessionIndex: number, symbol: string): number => {
+      const session = officialSessions[sessionIndex]
+      const close = session === undefined ? undefined : closeBySessionAndSymbol.get(`${session}:${symbol}`)
+      if (close === undefined) throw new Error(`candidate plan fixture is missing ${sessionIndex}:${symbol}`)
+      return close
+    }
+    const decisions = planSchedule.map(({ signalDate, executionDate }, index) => {
+      const terminal = index === planSchedule.length - 1
+      const signalIndex = officialSessions.indexOf(signalDate)
+      const firstPriceSessionIndex = signalIndex - inverseVolatilityParameters.lookbackSessions
+      const dailyReturns = Object.fromEntries(
+        universe.map((symbol) => [
+          symbol,
+          Array.from({ length: inverseVolatilityParameters.lookbackSessions }, (_, returnIndex) => {
+            const currentIndex = firstPriceSessionIndex + returnIndex + 1
+            return closeAt(currentIndex, symbol) / closeAt(currentIndex - 1, symbol) - 1
+          }),
+        ]),
+      ) as Record<string, readonly number[]>
+      const totalReturns = Object.fromEntries(
+        universe.map((symbol) => [
+          symbol,
+          quantize(closeAt(signalIndex, symbol) / closeAt(firstPriceSessionIndex, symbol) - 1),
+        ]),
+      ) as Record<string, number>
+      const annualizedVolatilities = Object.fromEntries(
+        universe.map((symbol) => [
+          symbol,
+          quantize(
+            Math.sqrt(
+              sampleVariance(dailyReturns[symbol] as readonly number[]) *
+                inverseVolatilityParameters.annualizationSessions,
+            ),
+          ),
+        ]),
+      ) as Record<string, number>
+      const [firstRiskAsset, secondRiskAsset] = inverseVolatilityParameters.riskAssets
+      const firstInverseVolatility = 1 / (annualizedVolatilities[firstRiskAsset] as number)
+      const secondInverseVolatility = 1 / (annualizedVolatilities[secondRiskAsset] as number)
+      const inverseVolatilityDenominator = firstInverseVolatility + secondInverseVolatility
+      const normalizedWeights = {
+        [firstRiskAsset]: firstInverseVolatility / inverseVolatilityDenominator,
+        [secondRiskAsset]: secondInverseVolatility / inverseVolatilityDenominator,
+      }
+      const annualizedCovariance =
+        sampleCovariance(
+          dailyReturns[firstRiskAsset] as readonly number[],
+          dailyReturns[secondRiskAsset] as readonly number[],
+        ) * inverseVolatilityParameters.annualizationSessions
+      const unscaledPortfolioVariance =
+        (normalizedWeights[firstRiskAsset] as number) ** 2 * (annualizedVolatilities[firstRiskAsset] as number) ** 2 +
+        (normalizedWeights[secondRiskAsset] as number) ** 2 * (annualizedVolatilities[secondRiskAsset] as number) ** 2 +
+        2 *
+          (normalizedWeights[firstRiskAsset] as number) *
+          (normalizedWeights[secondRiskAsset] as number) *
+          annualizedCovariance
+      const riskScale = quantize(
+        Math.min(
+          inverseVolatilityParameters.maximumGrossExposure,
+          inverseVolatilityParameters.targetAnnualizedVolatility / Math.sqrt(unscaledPortfolioVariance),
+        ),
+      )
+      const targetWeights = Object.fromEntries(
+        universe.map((symbol) => [
+          symbol,
+          terminal
+            ? 0
+            : symbol === firstRiskAsset || symbol === secondRiskAsset
+              ? quantize((normalizedWeights[symbol] as number) * riskScale)
+              : 0,
+        ]),
+      ) as Record<string, number>
+      const exposureScale = quantize(Object.values(targetWeights).reduce((sum, weight) => sum + weight, 0))
+      const portfolioReturns = Array.from({ length: inverseVolatilityParameters.lookbackSessions }, (_, returnIndex) =>
+        universe.reduce(
+          (sum, symbol) => sum + (dailyReturns[symbol]?.[returnIndex] as number) * (targetWeights[symbol] as number),
+          0,
+        ),
+      )
+      const covarianceWindowSessions = officialSessions.slice(
+        signalIndex - inverseVolatilityParameters.lookbackSessions + 1,
+        signalIndex + 1,
+      )
+      return {
+        schemaVersion: 'bayn.risk-balanced-trend-decision-plan.v1' as const,
+        signalDate,
+        executionDate,
+        covarianceWindow: {
+          returnCount: inverseVolatilityParameters.lookbackSessions,
+          firstSession: covarianceWindowSessions[0] as IsoDate,
+          lastSession: signalDate,
+          sessionsHash: 'a'.repeat(64),
+        },
+        estimatedAnnualizedPortfolioVolatility: quantize(
+          Math.sqrt(sampleVariance(portfolioReturns) * inverseVolatilityParameters.annualizationSessions),
+        ),
+        exposureScale,
+        targetWeights,
+        signals: universe.map((symbol) => ({
+          symbol,
+          horizons: [
+            {
+              horizonSessions: inverseVolatilityParameters.lookbackSessions,
+              return: totalReturns[symbol] as number,
+              normalizedTrend: totalReturns[symbol] as number,
+            },
+          ],
+          dailyVolatility:
+            (annualizedVolatilities[symbol] as number) / Math.sqrt(inverseVolatilityParameters.annualizationSessions),
+          annualizedVolatility: annualizedVolatilities[symbol] as number,
+          compositeScore:
+            symbol === firstRiskAsset || symbol === secondRiskAsset
+              ? 1 / (annualizedVolatilities[symbol] as number)
+              : 0,
+          positiveScore:
+            symbol === firstRiskAsset || symbol === secondRiskAsset
+              ? 1 / (annualizedVolatilities[symbol] as number)
+              : 0,
+          eligible: symbol === firstRiskAsset || symbol === secondRiskAsset,
+          uncappedWeight: targetWeights[symbol] as number,
+          cappedWeight: targetWeights[symbol] as number,
+          targetWeight: targetWeights[symbol] as number,
+        })),
+      }
+    })
+    const plan: CandidateDevelopmentStrategyPlan = {
+      schemaVersion: 'bayn.candidate-development-strategy-plan.v1',
+      decisions,
+    }
+    const sourceManifest: CandidateDevelopmentSourceManifest = {
+      schemaVersion: 'bayn.candidate-development-source-manifest.v1',
+      candidateOrdinal: 21,
+      priorTrialCount: 20,
+      strategyProtocolHash: preflightInput.expectedStrategyProtocolHash,
+      modulePath: 'services/bayn/src/strategy/fixture/candidate-21.ts',
+      moduleFormat: 'self-contained-esm-v1',
+      marketData: {
+        schemaVersion: 'bayn.candidate-development-market-data-source.v1',
+        snapshotId: marketData.snapshotId,
+        finalizedSnapshotContentHash: inputManifest.finalizedSnapshot.contentHash,
+        inputManifestHash: inputManifest.hash,
+        boundedContentHash: marketData.contentHash,
+      },
+    }
+    const runtimeInput = {
+      schemaVersion: 'bayn.candidate-development-verified-source.v1' as const,
+      sourceRevision: '1'.repeat(40),
+      modulePath: sourceManifest.modulePath,
+      moduleBlobOid: '2'.repeat(40),
+      moduleSha256: '3'.repeat(64),
+      sourceManifestPath: 'services/bayn/candidates/fixture-candidate-21-source-manifest.json',
+      sourceManifestBlobOid: '4'.repeat(40),
+      sourceManifestSha256: '5'.repeat(64),
+      sourceManifest,
+      baselineRunId: '6'.repeat(64),
+      stressedRunId: '7'.repeat(64),
+      runtimeDataSchemaVersion: 'bayn.candidate-development-artifact-runtime-input.v1' as const,
+      preflightInput,
+      marketData,
+    }
+    const builtResult = buildCandidateDevelopmentPlanEvaluation(plan, inputManifest, runtimeInput, strategyProtocol)
+    if (Result.isFailure(builtResult)) {
+      throw new Error(`candidate plan evaluation failed: ${JSON.stringify(builtResult.failure)}`)
+    }
+    const built = builtResult.success
+    expect(
+      built.baseline.signalDecisions.map(({ signalDate, executionDate }) => ({ signalDate, executionDate })),
+    ).toEqual([...preflight.expectedRebalanceSchedule])
+    expect(
+      built.accounting.signalDecisions.map(({ signalDate, executionDate }) => ({ signalDate, executionDate })),
+    ).toEqual([...planSchedule])
+    expect(built.accounting.signalDecisions).toHaveLength(built.baseline.signalDecisions.length + 1)
+    expect(built.baseline.simulation.dailyMarks.map(({ sessionDate }) => sessionDate)).toEqual([
+      ...preflight.selectedObservationSessions,
+    ])
+    expect(built.accounting.baselineSimulation.dailyMarks[0]?.sessionDate).toBe(accountingStart)
+    expect(
+      built.accounting.baselineSimulation.dailyMarks[0]?.positions.some(({ quantityMicros }) => quantityMicros !== '0'),
+    ).toBe(true)
+    const baselinePredecessor = built.accounting.baselineSimulation.dailyMarks[0]
+    const baselineTerminal = built.baseline.simulation.dailyMarks.at(-1)
+    if (baselinePredecessor === undefined || baselineTerminal === undefined) {
+      throw new Error('candidate plan regression requires baseline accounting bounds')
+    }
+    expect(BigInt(baselinePredecessor.cumulativeTurnoverMicros)).toBeGreaterThan(0n)
+    expect(BigInt(baselinePredecessor.cumulativeFeesMicros)).toBeGreaterThan(0n)
+    expect(built.baseline.strategy.totalReturn).toBe(
+      Number(BigInt(baselineTerminal.equityMicros)) / Number(BigInt(baselinePredecessor.equityMicros)) - 1,
+    )
+    expect(built.baseline.strategy.annualTurnover).toBeCloseTo(
+      Number(BigInt(baselineTerminal.cumulativeTurnoverMicros) - BigInt(baselinePredecessor.cumulativeTurnoverMicros)) /
+        Number(BigInt(baselinePredecessor.equityMicros)) /
+        (built.baseline.simulation.dailyMarks.length / 252),
+      15,
+    )
+    expect(built.baseline.strategy.totalFeesMicros).toBe(
+      (BigInt(baselineTerminal.cumulativeFeesMicros) - BigInt(baselinePredecessor.cumulativeFeesMicros)).toString(),
+    )
+    expect(built.baseline.strategy.totalSpreadCostMicros).toBe(
+      (
+        BigInt(baselineTerminal.cumulativeSpreadCostMicros) - BigInt(baselinePredecessor.cumulativeSpreadCostMicros)
+      ).toString(),
+    )
+    expect(built.baseline.strategy.totalSlippageCostMicros).toBe(
+      (
+        BigInt(baselineTerminal.cumulativeSlippageCostMicros) - BigInt(baselinePredecessor.cumulativeSlippageCostMicros)
+      ).toString(),
+    )
+    expect(built.baseline.strategy.totalCashYieldMicros).toBe(
+      (
+        BigInt(baselineTerminal.cumulativeCashYieldMicros) - BigInt(baselinePredecessor.cumulativeCashYieldMicros)
+      ).toString(),
+    )
+    expect(built.accounting.evaluatorTotalFeesMicros).toBe(baselineTerminal.cumulativeFeesMicros)
+    expect(built.accounting.evaluatorTotalFeesMicros).not.toBe(built.baseline.strategy.totalFeesMicros)
+    expect(built.accounting.stressedSimulation.dailyMarks[0]?.equityMicros).not.toBe(
+      strategyProtocol.initialCapitalMicros,
+    )
+    expect(built.accounting.baselineSimulation.dailyMarks.length).toBe(built.baseline.simulation.dailyMarks.length + 1)
+    expect(built.accounting.stressedSimulation.costMultiplierMicros).toBe('2000000')
+    expect(built.accounting.runId).not.toBe(built.accounting.stressedRunId)
+    expect(built.accounting.signalDecisions[0]?.decisionId).not.toBe(built.stressed.signalDecisions[0]?.decisionId)
+    const firstSelectedStressedDecision = built.stressed.signalDecisions[0]
+    expect(
+      built.accounting.stressedEvents.find(
+        (event) => event.kind === 'decision' && event.signalDate === firstSelectedStressedDecision?.signalDate,
+      )?.id,
+    ).toBe(firstSelectedStressedDecision?.decisionId)
+    expect(built.accounting.markedEquityReconciliation.exact).toBe(true)
+    expect(built.accounting.stressedMarkedEquityReconciliation.exact).toBe(true)
+    const developmentReport: CandidateDevelopmentReport = {
+      schemaVersion: candidateDevelopmentComparisonSemantics.evidence.reportSchemaVersion,
+      protocolIdentity: preflight.protocolIdentity,
+      comparisonSemantics: built.comparisonSemantics,
+      doubledCostContract: preflight.doubledCostContract,
+      doubledCost: {
+        baseline: {
+          signalDecisions: built.baseline.signalDecisions,
+          simulation: built.baseline.simulation,
+        },
+        stressed: built.stressed,
+      },
+    }
+    const commandReport = buildCandidateDevelopmentCommandReportPure(
+      developmentReport,
+      built,
+      strategyProtocol,
+      preflightInput.officialSessions,
+      runtimeInput,
+    )
+    if (Result.isFailure(commandReport)) {
+      throw new Error(`candidate plan report failed: ${JSON.stringify(commandReport.failure)}`)
+    }
+    expect(commandReport.success.accounting.signalDecisions).toHaveLength(planSchedule.length)
+    const firstDecision = plan.decisions[0]
+    if (firstDecision === undefined) throw new Error('candidate plan regression requires one decision')
+    expect(firstDecision.exposureScale).toBe(
+      quantize(Object.values(firstDecision.targetWeights).reduce((sum, weight) => sum + weight, 0)),
+    )
+    expect(firstDecision.signals.every((signal) => signal.cappedWeight === signal.targetWeight)).toBe(true)
+    expect(firstDecision.signals.every((signal) => signal.uncappedWeight === signal.targetWeight)).toBe(true)
+    const firstDecisionGrossExposure = Object.values(firstDecision.targetWeights).reduce(
+      (sum, weight) => sum + weight,
+      0,
+    )
+    const forgedRiskAllocationSignals = firstDecision.signals.map((signal) => {
+      const targetWeight = signal.symbol === 'SPY' ? firstDecisionGrossExposure : 0
+      return {
+        ...signal,
+        uncappedWeight: targetWeight,
+        cappedWeight: targetWeight,
+        targetWeight,
+      }
+    })
+    expect(
+      buildCandidateDevelopmentPlanEvaluation(
+        {
+          ...plan,
+          decisions: [
+            {
+              ...firstDecision,
+              targetWeights: Object.fromEntries(
+                universe.map((symbol) => [symbol, symbol === 'SPY' ? firstDecisionGrossExposure : 0]),
+              ),
+              signals: forgedRiskAllocationSignals,
+            },
+            ...plan.decisions.slice(1),
+          ],
+        },
+        inputManifest,
+        runtimeInput,
+        strategyProtocol,
+      ),
+    ).toMatchObject({
+      failure: {
+        _tag: 'CandidateDevelopmentCommandSourceVerificationFailed',
+        operation: 'verify-program-binding',
+        cause: { field: 'artifact.plan.decisions[0].inverseVolatility.allocation' },
+      },
+    })
+    const forgedRiskGeometrySignals = firstDecision.signals.map((signal) =>
+      signal.symbol === 'SPY'
+        ? {
+            ...signal,
+            dailyVolatility: 0,
+            annualizedVolatility: 0,
+            compositeScore: 0,
+            positiveScore: 0,
+          }
+        : signal,
+    )
+    expect(
+      buildCandidateDevelopmentPlanEvaluation(
+        {
+          ...plan,
+          decisions: [{ ...firstDecision, signals: forgedRiskGeometrySignals }, ...plan.decisions.slice(1)],
+        },
+        inputManifest,
+        runtimeInput,
+        strategyProtocol,
+      ),
+    ).toMatchObject({
+      failure: {
+        _tag: 'CandidateDevelopmentCommandSourceVerificationFailed',
+        operation: 'verify-program-binding',
+        cause: { field: 'artifact.plan.decisions[0].signals[3].inverseVolatility' },
+      },
+    })
+    expect(
+      buildCandidateDevelopmentPlanEvaluation(
+        {
+          ...plan,
+          decisions: [
+            {
+              ...firstDecision,
+              estimatedAnnualizedPortfolioVolatility: firstDecision.estimatedAnnualizedPortfolioVolatility + 0.01,
+            },
+            ...plan.decisions.slice(1),
+          ],
+        },
+        inputManifest,
+        runtimeInput,
+        strategyProtocol,
+      ),
+    ).toMatchObject({
+      failure: {
+        _tag: 'CandidateDevelopmentCommandSourceVerificationFailed',
+        operation: 'verify-program-binding',
+        cause: { field: 'artifact.plan.decisions[0].inverseVolatility.riskScale' },
+      },
+    })
+    const firstSignalIndex = officialSessions.indexOf(firstDecision.signalDate)
+    expect(built.accounting.signalDecisions[0]?.covarianceWindow).toEqual({
+      returnCount: 252,
+      firstSession: officialSessions[firstSignalIndex - 251],
+      lastSession: firstDecision.signalDate,
+      sessionsHash: canonicalHashV1({
+        schemaVersion: 'bayn.candidate-development-plan-window.v1',
+        sessions: officialSessions.slice(firstSignalIndex - 252, firstSignalIndex + 1),
+      }),
+    })
+    const shiftedCaps = firstDecision.signals.map((signal) => {
+      if (signal.symbol === 'SPY') return { ...signal, cappedWeight: signal.cappedWeight - 0.01 }
+      if (signal.symbol === 'EFA') return { ...signal, cappedWeight: signal.cappedWeight + 0.01 }
+      return signal
+    })
+    const shiftedCapsIndex = firstDecision.signals.findIndex((signal) => signal.symbol === 'EFA')
+    expect(
+      buildCandidateDevelopmentPlanEvaluation(
+        { ...plan, decisions: [{ ...firstDecision, signals: shiftedCaps }, ...plan.decisions.slice(1)] },
+        inputManifest,
+        runtimeInput,
+        strategyProtocol,
+      ),
+    ).toMatchObject({
+      failure: {
+        _tag: 'CandidateDevelopmentCommandSourceVerificationFailed',
+        operation: 'verify-program-binding',
+        cause: { field: `artifact.plan.decisions[0].signals[${shiftedCapsIndex}]` },
+      },
+    })
+    const shiftedUncappedSignals = firstDecision.signals.map((signal) => {
+      if (signal.symbol === 'SPY') return { ...signal, uncappedWeight: signal.uncappedWeight - 0.01 }
+      if (signal.symbol === 'EFA') return { ...signal, uncappedWeight: signal.uncappedWeight + 0.01 }
+      return signal
+    })
+    const shiftedUncappedIndex = firstDecision.signals.findIndex((signal) => signal.symbol === 'EFA')
+    expect(
+      buildCandidateDevelopmentPlanEvaluation(
+        { ...plan, decisions: [{ ...firstDecision, signals: shiftedUncappedSignals }, ...plan.decisions.slice(1)] },
+        inputManifest,
+        runtimeInput,
+        strategyProtocol,
+      ),
+    ).toMatchObject({
+      failure: {
+        _tag: 'CandidateDevelopmentCommandSourceVerificationFailed',
+        operation: 'verify-program-binding',
+        cause: { field: `artifact.plan.decisions[0].signals[${shiftedUncappedIndex}]` },
+      },
+    })
+    const ungovernedSignals = firstDecision.signals.map((signal) => {
+      if (signal.symbol === 'DBC') {
+        return { ...signal, eligible: true, uncappedWeight: 0.175, cappedWeight: 0.175, targetWeight: 0.175 }
+      }
+      if (signal.symbol === 'SPY') {
+        return { ...signal, eligible: false, uncappedWeight: 0, cappedWeight: 0, targetWeight: 0 }
+      }
+      return signal
+    })
+    expect(
+      buildCandidateDevelopmentPlanEvaluation(
+        {
+          ...plan,
+          decisions: [
+            {
+              ...firstDecision,
+              targetWeights: { ...firstDecision.targetWeights, DBC: 0.175, SPY: 0 },
+              signals: ungovernedSignals,
+            },
+            ...plan.decisions.slice(1),
+          ],
+        },
+        inputManifest,
+        runtimeInput,
+        strategyProtocol,
+      ),
+    ).toMatchObject({
+      failure: {
+        _tag: 'CandidateDevelopmentCommandSourceVerificationFailed',
+        operation: 'verify-program-binding',
+        cause: { field: 'artifact.plan.decisions[0].inverseVolatility.allocation' },
+      },
+    })
+    expect(
+      buildCandidateDevelopmentPlanEvaluation(
+        {
+          ...plan,
+          decisions: [
+            {
+              ...firstDecision,
+              covarianceWindow: { ...firstDecision.covarianceWindow, returnCount: 251 },
+            },
+            ...plan.decisions.slice(1),
+          ],
+        },
+        inputManifest,
+        runtimeInput,
+        strategyProtocol,
+      ),
+    ).toMatchObject({
+      failure: {
+        _tag: 'CandidateDevelopmentCommandSourceVerificationFailed',
+        operation: 'verify-program-binding',
+        cause: { field: 'artifact.plan.decisions[0].covarianceWindow' },
+      },
+    })
+    const wrongHorizonSignals = firstDecision.signals.map((signal) => ({
+      ...signal,
+      horizons: [{ ...signal.horizons[0], horizonSessions: 63 }],
+    }))
+    expect(
+      buildCandidateDevelopmentPlanEvaluation(
+        { ...plan, decisions: [{ ...firstDecision, signals: wrongHorizonSignals }, ...plan.decisions.slice(1)] },
+        inputManifest,
+        runtimeInput,
+        strategyProtocol,
+      ),
+    ).toMatchObject({
+      failure: {
+        _tag: 'CandidateDevelopmentCommandSourceVerificationFailed',
+        operation: 'verify-program-binding',
+        cause: { field: 'artifact.plan.decisions[0].signals[0].horizons' },
+      },
+    })
+    const overexposedSignals = firstDecision.signals.map((signal) =>
+      signal.symbol === 'SPY' ? { ...signal, cappedWeight: 0.45, targetWeight: 0.225 } : signal,
+    )
+    expect(
+      buildCandidateDevelopmentPlanEvaluation(
+        {
+          ...plan,
+          decisions: [
+            {
+              ...firstDecision,
+              targetWeights: { ...firstDecision.targetWeights, SPY: 0.225 },
+              signals: overexposedSignals,
+            },
+            ...plan.decisions.slice(1),
+          ],
+        },
+        inputManifest,
+        runtimeInput,
+        strategyProtocol,
+      ),
+    ).toMatchObject({
+      failure: {
+        _tag: 'CandidateDevelopmentCommandSourceVerificationFailed',
+        operation: 'verify-program-binding',
+        cause: { field: 'artifact.plan.decisions[0].inverseVolatility.allocation' },
+      },
+    })
+    const momentumStrategyProtocol: CandidateDevelopmentStrategyProtocol = {
+      ...strategyProtocol,
+      strategyIdentity: {
+        schemaVersion: 'bayn.candidate-development-strategy-identity.v1',
+        family: 'dual-momentum',
+        identifier: 'candidate-plan-momentum-host-regression',
+        researchSources: ['source-a', 'source-b', 'source-c'],
+        parameters: {
+          id: 'candidate-plan-momentum-host-regression-v1',
+          lookbackSessions: 252,
+          volatilityWindowSessions: 252,
+          annualizationSessions: 252,
+          riskAssets: ['SPY', 'EFA'],
+          defensiveAsset: 'IEF',
+          absoluteMomentumThreshold: 0,
+          selectedAssetWeight: 0.2,
+          relativeMomentumTieBreak: 'SPY',
+        },
+        input: 'content-verified adjusted closes',
+        relativeMomentum: 'select the stronger risk asset with the immutable tie break',
+        absoluteMomentum: 'require the winning risk asset to clear the immutable threshold',
+        defensive: 'select the defensive asset only when risk fails and defense clears the threshold',
+        allocation: 'one selected governed asset or cash',
+        schedule: 'governed month end',
+        terminal: 'all cash',
+        missingData: 'fail closed',
+        doubledCost: 'trusted host replay',
+      },
+    }
+    const momentumStrategyProtocolHash = canonicalHashV1(momentumStrategyProtocol)
+    const momentumIdentity = momentumStrategyProtocol.strategyIdentity
+    if (momentumIdentity?.schemaVersion !== 'bayn.candidate-development-strategy-identity.v1') {
+      throw new Error('candidate momentum plan requires the governed momentum identity')
+    }
+    const momentumParameters = momentumIdentity.parameters
+    const momentumRuntimeInput = {
+      ...runtimeInput,
+      preflightInput: {
+        ...runtimeInput.preflightInput,
+        expectedStrategyProtocolHash: momentumStrategyProtocolHash,
+      },
+      sourceManifest: {
+        ...runtimeInput.sourceManifest,
+        strategyProtocolHash: momentumStrategyProtocolHash,
+      },
+    }
+    const momentumDecisions = plan.decisions.map((decision, index) => {
+      const signalIndex = officialSessions.indexOf(decision.signalDate)
+      const firstFeatureSession = officialSessions[signalIndex - momentumParameters.lookbackSessions] as IsoDate
+      const totalReturns = Object.fromEntries(
+        universe.map((symbol) => {
+          const firstClose = closeBySessionAndSymbol.get(`${firstFeatureSession}:${symbol}`) as number
+          const signalClose = closeBySessionAndSymbol.get(`${decision.signalDate}:${symbol}`) as number
+          return [symbol, Math.round((signalClose / firstClose - 1) * 1_000_000_000_000) / 1_000_000_000_000]
+        }),
+      )
+      const relativeWinner = (totalReturns.SPY as number) >= (totalReturns.EFA as number) ? 'SPY' : 'EFA'
+      const selectedSymbol =
+        (totalReturns[relativeWinner] as number) > 0 ? relativeWinner : (totalReturns.IEF as number) > 0 ? 'IEF' : null
+      const terminal = index === plan.decisions.length - 1
+      const targetWeights = Object.fromEntries(
+        universe.map((symbol) => [
+          symbol,
+          !terminal && selectedSymbol === symbol ? momentumParameters.selectedAssetWeight : 0,
+        ]),
+      ) as Record<string, number>
+      const volatilityStartIndex = signalIndex - momentumParameters.volatilityWindowSessions + 1
+      const portfolioReturns = Array.from({ length: momentumParameters.volatilityWindowSessions }, (_, returnIndex) => {
+        const currentIndex = volatilityStartIndex + returnIndex
+        return universe.reduce(
+          (sum, symbol) =>
+            sum +
+            (closeAt(currentIndex, symbol) / closeAt(currentIndex - 1, symbol) - 1) * (targetWeights[symbol] as number),
+          0,
+        )
+      })
+      const estimatedAnnualizedPortfolioVolatility = quantize(
+        Math.sqrt(sampleVariance(portfolioReturns) * momentumParameters.annualizationSessions),
+      )
+      return {
+        ...decision,
+        estimatedAnnualizedPortfolioVolatility,
+        exposureScale: quantize(Object.values(targetWeights).reduce((sum, weight) => sum + weight, 0)),
+        targetWeights,
+        signals: decision.signals.map((signal) => {
+          const totalReturn = totalReturns[signal.symbol] as number
+          const targetWeight = targetWeights[signal.symbol] as number
+          return {
+            ...signal,
+            horizons: [
+              {
+                horizonSessions: momentumParameters.lookbackSessions,
+                return: totalReturn,
+                normalizedTrend: totalReturn,
+              },
+            ],
+            dailyVolatility: 0,
+            annualizedVolatility: selectedSymbol === signal.symbol ? estimatedAnnualizedPortfolioVolatility : 0,
+            compositeScore: totalReturn,
+            positiveScore: Math.max(0, totalReturn),
+            eligible: selectedSymbol === signal.symbol,
+            uncappedWeight: targetWeight,
+            cappedWeight: targetWeight,
+            targetWeight,
+          }
+        }),
+      }
+    })
+    const momentumPlan: CandidateDevelopmentStrategyPlan = { ...plan, decisions: momentumDecisions }
+    expect(
+      buildCandidateDevelopmentPlanEvaluation(
+        momentumPlan,
+        inputManifest,
+        momentumRuntimeInput,
+        momentumStrategyProtocol,
+      ),
+    ).toMatchObject({ success: { baseline: { schemaVersion: 'bayn.evaluation.v6' } } })
+    const momentumFirstDecision = momentumPlan.decisions[0]
+    if (momentumFirstDecision === undefined) throw new Error('candidate momentum plan requires one decision')
+    const forgedMomentumSignals = momentumFirstDecision.signals.map((signal) => {
+      if (signal.symbol === 'EFA') {
+        return { ...signal, eligible: true, uncappedWeight: 0.2, cappedWeight: 0.2, targetWeight: 0.2 }
+      }
+      if (signal.symbol === 'SPY') {
+        return { ...signal, eligible: false, uncappedWeight: 0, cappedWeight: 0, targetWeight: 0 }
+      }
+      return signal
+    })
+    expect(
+      buildCandidateDevelopmentPlanEvaluation(
+        {
+          ...momentumPlan,
+          decisions: [
+            {
+              ...momentumFirstDecision,
+              targetWeights: { ...momentumFirstDecision.targetWeights, EFA: 0.2, SPY: 0 },
+              signals: forgedMomentumSignals,
+            },
+            ...momentumPlan.decisions.slice(1),
+          ],
+        },
+        inputManifest,
+        momentumRuntimeInput,
+        momentumStrategyProtocol,
+      ),
+    ).toMatchObject({
+      failure: {
+        _tag: 'CandidateDevelopmentCommandSourceVerificationFailed',
+        operation: 'verify-program-binding',
+        cause: { field: 'artifact.plan.decisions[0].momentumSelection' },
+      },
+    })
+    const forgedMomentumHorizonSignals = momentumFirstDecision.signals.map((signal) =>
+      signal.symbol === 'SPY'
+        ? {
+            ...signal,
+            horizons: [{ ...signal.horizons[0], return: signal.horizons[0].return + 0.01 }],
+          }
+        : signal,
+    )
+    expect(
+      buildCandidateDevelopmentPlanEvaluation(
+        {
+          ...momentumPlan,
+          decisions: [
+            { ...momentumFirstDecision, signals: forgedMomentumHorizonSignals },
+            ...momentumPlan.decisions.slice(1),
+          ],
+        },
+        inputManifest,
+        momentumRuntimeInput,
+        momentumStrategyProtocol,
+      ),
+    ).toMatchObject({
+      failure: {
+        _tag: 'CandidateDevelopmentCommandSourceVerificationFailed',
+        operation: 'verify-program-binding',
+        cause: { field: 'artifact.plan.decisions[0].signals[3].momentum' },
+      },
+    })
+    expect(
+      buildCandidateDevelopmentPlanEvaluation(
+        {
+          ...momentumPlan,
+          decisions: [
+            {
+              ...momentumFirstDecision,
+              estimatedAnnualizedPortfolioVolatility:
+                momentumFirstDecision.estimatedAnnualizedPortfolioVolatility + 0.01,
+            },
+            ...momentumPlan.decisions.slice(1),
+          ],
+        },
+        inputManifest,
+        momentumRuntimeInput,
+        momentumStrategyProtocol,
+      ),
+    ).toMatchObject({
+      failure: {
+        _tag: 'CandidateDevelopmentCommandSourceVerificationFailed',
+        operation: 'verify-program-binding',
+        cause: { field: 'artifact.plan.decisions[0].momentumVolatility' },
+      },
+    })
+    const forgedMomentumVolatilitySignals = momentumFirstDecision.signals.map((signal) =>
+      signal.eligible
+        ? { ...signal, dailyVolatility: 0.01, annualizedVolatility: signal.annualizedVolatility + 0.01 }
+        : signal,
+    )
+    expect(
+      buildCandidateDevelopmentPlanEvaluation(
+        {
+          ...momentumPlan,
+          decisions: [
+            { ...momentumFirstDecision, signals: forgedMomentumVolatilitySignals },
+            ...momentumPlan.decisions.slice(1),
+          ],
+        },
+        inputManifest,
+        momentumRuntimeInput,
+        momentumStrategyProtocol,
+      ),
+    ).toMatchObject({
+      failure: {
+        _tag: 'CandidateDevelopmentCommandSourceVerificationFailed',
+        operation: 'verify-program-binding',
+        cause: { field: expect.stringContaining('momentum') },
+      },
+    })
+    const planArtifactSource = `
+      const plan = ${JSON.stringify(plan)}
+      export const candidateDevelopmentArtifact = {
+        schemaVersion: 'bayn.candidate-development-plan-artifact.v1',
+        inputManifest: ${JSON.stringify(inputManifest)},
+        buildPlan: () => plan,
+      }
+    `
+    const verifiedFiles: CandidateDevelopmentVerifiedSourceFiles = {
+      schemaVersion: 'bayn.candidate-development-verified-source-files.v1',
+      sourceRevision: runtimeInput.sourceRevision,
+      modulePath: runtimeInput.modulePath,
+      moduleBlobOid: runtimeInput.moduleBlobOid,
+      moduleSha256: runtimeInput.moduleSha256,
+      sourceManifestPath: runtimeInput.sourceManifestPath,
+      sourceManifestBlobOid: runtimeInput.sourceManifestBlobOid,
+      sourceManifestSha256: runtimeInput.sourceManifestSha256,
+      sourceManifest,
+    }
+    const workerBuilt = await Effect.runPromise(
+      executeCandidateDevelopmentArtifactRuntime(
+        `data:text/javascript;base64,${Buffer.from(planArtifactSource).toString('base64')}`,
+        verifiedFiles,
+        strategyProtocol,
+        runtimeInput,
+      ),
+    )
+    const decisionProjection = (evaluation: CandidateDevelopmentCommandEvaluation) =>
+      evaluation.baseline.signalDecisions.map(({ signalDate, executionDate, exposureScale, targetWeights }) => ({
+        signalDate,
+        executionDate,
+        exposureScale,
+        targetWeights,
+      }))
+    expect(decisionProjection(workerBuilt)).toEqual(decisionProjection(built))
+    expect(workerBuilt.accounting.markedEquityReconciliation.exact).toBe(true)
+    let rawMarketDataReads = 0
+    const guardedRuntimeInput = { ...runtimeInput }
+    Object.defineProperty(guardedRuntimeInput, 'marketData', {
+      enumerable: true,
+      get: () => {
+        rawMarketDataReads += 1
+        if (rawMarketDataReads > 1) throw new Error('raw runtime market data was reused after validation')
+        return marketData
+      },
+    })
+    const guardedBuilt = await Effect.runPromise(
+      executeCandidateDevelopmentArtifactRuntime(
+        `data:text/javascript;base64,${Buffer.from(planArtifactSource).toString('base64')}`,
+        verifiedFiles,
+        strategyProtocol,
+        guardedRuntimeInput,
+      ),
+    )
+    expect(decisionProjection(guardedBuilt)).toEqual(decisionProjection(built))
+    expect(rawMarketDataReads).toBe(1)
+    const nondeterministicSource = planArtifactSource
+      .replace('const plan =', 'let invocation = 0\n      const plan =')
+      .replace(
+        'buildPlan: () => plan,',
+        'buildPlan: () => ({ ...plan, decisions: invocation++ === 0 ? plan.decisions : plan.decisions.slice(1) }),',
+      )
+    expect(
+      await Effect.runPromise(
+        Effect.flip(
+          executeCandidateDevelopmentArtifactRuntime(
+            `data:text/javascript;base64,${Buffer.from(nondeterministicSource).toString('base64')}`,
+            verifiedFiles,
+            strategyProtocol,
+            runtimeInput,
+          ),
+        ),
+      ),
+    ).toMatchObject({
+      _tag: 'CandidateDevelopmentCommandProgramExecutionFailed',
+      cause: { message: 'candidate artifact buildPlan must be deterministic' },
+    })
+    expect(
+      buildCandidateDevelopmentPlanEvaluation(
+        { ...plan, decisions: plan.decisions.slice(1) },
+        inputManifest,
+        runtimeInput,
+        strategyProtocol,
+      ),
+    ).toMatchObject({
+      failure: {
+        _tag: 'CandidateDevelopmentCommandSourceVerificationFailed',
+        operation: 'verify-program-binding',
+        cause: { field: 'artifact.plan.decisions.length' },
+      },
+    })
+    const forgedManifest = {
+      ...inputManifest,
+      finalizedSnapshot: {
+        ...inputManifest.finalizedSnapshot,
+        publisherSourceRevision: '9'.repeat(40),
+      },
+    }
+    expect(buildCandidateDevelopmentPlanEvaluation(plan, forgedManifest, runtimeInput, strategyProtocol)).toMatchObject(
+      {
+        failure: {
+          _tag: 'CandidateDevelopmentCommandSourceVerificationFailed',
+          operation: 'verify-program-binding',
+          cause: { field: 'artifact.inputManifest' },
+        },
+      },
+    )
+    const { hash: _, ...inputManifestWithoutHash } = inputManifest
+    const mismatchedManifestMaterial = {
+      ...inputManifestWithoutHash,
+      bounds: {
+        ...inputManifest.bounds,
+        evaluationStart: officialSessions[geometryPreflight.selectedObservationStartIndex + 1] as IsoDate,
+      },
+    }
+    const mismatchedManifest = {
+      ...mismatchedManifestMaterial,
+      hash: canonicalHashV1(mismatchedManifestMaterial),
+    }
+    const mismatchedMarketDataMaterial = {
+      ...marketDataMaterial,
+      inputManifestHash: mismatchedManifest.hash,
+    }
+    const mismatchedMarketData = {
+      ...mismatchedMarketDataMaterial,
+      contentHash: canonicalHashV1(mismatchedMarketDataMaterial),
+    }
+    const mismatchedStrategyProtocol = {
+      ...strategyProtocol,
+      marketData: {
+        ...strategyProtocol.marketData,
+        contentHash: mismatchedMarketData.contentHash,
+      },
+    }
+    const mismatchedStrategyProtocolHash = canonicalHashV1(mismatchedStrategyProtocol)
+    const mismatchedRuntimeInput = {
+      ...runtimeInput,
+      preflightInput: {
+        ...runtimeInput.preflightInput,
+        expectedStrategyProtocolHash: mismatchedStrategyProtocolHash,
+      },
+      sourceManifest: {
+        ...runtimeInput.sourceManifest,
+        strategyProtocolHash: mismatchedStrategyProtocolHash,
+        marketData: {
+          ...runtimeInput.sourceManifest.marketData,
+          inputManifestHash: mismatchedManifest.hash,
+          boundedContentHash: mismatchedMarketData.contentHash,
+        },
+      },
+      marketData: mismatchedMarketData,
+    }
+    expect(
+      buildCandidateDevelopmentPlanEvaluation(
+        plan,
+        mismatchedManifest,
+        mismatchedRuntimeInput,
+        mismatchedStrategyProtocol,
+      ),
+    ).toMatchObject({
+      failure: {
+        _tag: 'CandidateDevelopmentCommandSourceVerificationFailed',
+        operation: 'verify-program-binding',
+        cause: { field: 'artifact.inputManifest.bounds.evaluationStart' },
+      },
+    })
+  }, 60_000)
+
+  test('loads a plan artifact definition through the executable-program boundary', async () => {
+    const source = `
+      const universe = ${JSON.stringify(candidate20StrategyProtocol.universe)}
+      const zeroWeights = Object.fromEntries(universe.map((symbol) => [symbol, 0]))
+      export const candidateDevelopmentArtifact = {
+        schemaVersion: 'bayn.candidate-development-plan-artifact.v1',
+        input: ${JSON.stringify(candidate20Input)},
+        strategyProtocol: ${JSON.stringify(candidate20StrategyProtocol)},
+        structuralBindings: ${JSON.stringify(candidate20StructuralBindings)},
+        inputManifest: ${JSON.stringify(fixtureInputManifest)},
+        buildPlan: (runtimeInput) => {
+          const sessions = runtimeInput.preflightInput.officialSessions
+          const selectedStart = sessions[sessions.length - 504]
+          const schedule = runtimeInput.preflightInput.signalSessionDates.flatMap((signalDate) => {
+            const signalIndex = sessions.indexOf(signalDate)
+            const executionDate = sessions[signalIndex + 1]
+            return executionDate !== undefined && executionDate >= selectedStart
+              ? [{ signalDate, executionDate }]
+              : []
+          })
+          return {
+            schemaVersion: 'bayn.candidate-development-strategy-plan.v1',
+            decisions: schedule.map(({ signalDate, executionDate }) => ({
+              schemaVersion: 'bayn.risk-balanced-trend-decision-plan.v1',
+              signalDate,
+              executionDate,
+              covarianceWindow: {
+                returnCount: 1,
+                firstSession: signalDate,
+                lastSession: signalDate,
+                sessionsHash: 'a'.repeat(64),
+              },
+              estimatedAnnualizedPortfolioVolatility: 0,
+              exposureScale: 0,
+              targetWeights: zeroWeights,
+              signals: universe.map((symbol) => ({
+                symbol,
+                horizons: [{ horizonSessions: 1, return: 0, normalizedTrend: 0 }],
+                dailyVolatility: 0,
+                annualizedVolatility: 0,
+                compositeScore: 0,
+                positiveScore: 0,
+                eligible: false,
+                uncappedWeight: 0,
+                cappedWeight: 0,
+                targetWeight: 0,
+              })),
+            })),
+          }
+        },
+      }
+    `
+    const loaded = await Effect.runPromise(
+      evaluateCandidateDevelopmentArtifact(
+        `data:text/javascript;base64,${Buffer.from(source).toString('base64')}`,
+        candidate20VerifiedSourceFiles,
+      ),
+    )
+    const program = successOf(
+      validateCandidateDevelopmentExecutableProgram(
+        (loaded as { readonly candidateDevelopmentProgram?: unknown }).candidateDevelopmentProgram,
+      ),
+    )
+    expect(program.input).toEqual(candidate20Input)
+    expect(program.strategyProtocol).toEqual(candidate20StrategyProtocol)
+  }, 60_000)
 
   test('rejects dummy runtime reads when the returned evaluation keeps embedded provenance', async () => {
     const input = candidate20Input

--- a/services/bayn/src/candidate-development-command.ts
+++ b/services/bayn/src/candidate-development-command.ts
@@ -15,9 +15,12 @@ import {
   candidateDevelopmentCalendarContract,
   candidateDevelopmentComparisonSemantics,
   candidateDevelopmentDoubledCostContract,
+  expectedCandidateDevelopmentRebalanceSchedule,
+  buildCandidateDevelopmentComparisonSemanticsEvidence,
   officialMonthEndSignalDates,
   preflightCandidateDevelopment,
   runCandidateDevelopment,
+  validateCandidateDevelopmentComparisonSeriesBinding,
   type CandidateDevelopmentAttemptIssue,
   type CandidateDevelopmentComparisonSemanticsIssue,
   type CandidateDevelopmentDoubledCostIssue,
@@ -47,6 +50,7 @@ import {
   type DailyPerformancePoint,
   DailyPerformanceSeriesArtifactSchema,
   DailyPositionMarksArtifactSchema,
+  DecisionPlanSchema,
   EquitySeriesArtifactSchema,
   EvaluationEventsSchema,
   EvaluationSummarySchema,
@@ -58,6 +62,7 @@ import { elapsedCalendarDays, MICROS, referencePriceMicros, type ExecutionModelF
 import { canonicalHashV1Result, type CanonicalHashFailure } from './hash'
 import { DIRECT_VOLATILITY_WINDOW, ExecutionModelSchema } from './protocol'
 import type { QualificationStatisticsFailure } from './qualification-statistics'
+import { prepareQualificationSeries } from './qualification-statistics'
 import {
   DigitsSchema,
   IsoDateSchema,
@@ -90,7 +95,9 @@ import {
   PriceAdjustment,
   PublicationSchema,
   type DailyBar,
+  type DecisionPlan,
   type EvaluationResult,
+  type InputManifest,
   type IsoDate,
   type PerformanceMetrics,
   type SimulationProtocol,
@@ -221,6 +228,15 @@ export interface CandidateDevelopmentArtifactRuntimeInput extends CandidateDevel
   readonly runtimeDataSchemaVersion: 'bayn.candidate-development-artifact-runtime-input.v1'
   readonly preflightInput: CandidateDevelopmentPreflightInput
   readonly marketData: CandidateDevelopmentMarketDataWitness
+}
+
+export interface CandidateDevelopmentPlannedDecision extends DecisionPlan {
+  readonly executionDate: IsoDate
+}
+
+export interface CandidateDevelopmentStrategyPlan {
+  readonly schemaVersion: 'bayn.candidate-development-strategy-plan.v1'
+  readonly decisions: readonly CandidateDevelopmentPlannedDecision[]
 }
 
 export interface CandidateDevelopmentStrategyProtocol extends SimulationProtocol {
@@ -4107,6 +4123,26 @@ const cumulativeMicrosFields = [
   ['cashYieldMicros', 'cumulativeCashYieldMicros'],
 ] as const
 
+interface CandidateDevelopmentPerformanceBaseline {
+  readonly equityMicros: string
+  readonly cumulativeTurnoverMicros: string
+  readonly cumulativeFeesMicros: string
+  readonly cumulativeSpreadCostMicros: string
+  readonly cumulativeSlippageCostMicros: string
+  readonly cumulativeCashYieldMicros: string
+}
+
+const performanceBaselineFromPoint = (
+  point: Pick<DailyPerformancePoint, keyof CandidateDevelopmentPerformanceBaseline>,
+): CandidateDevelopmentPerformanceBaseline => ({
+  equityMicros: point.equityMicros,
+  cumulativeTurnoverMicros: point.cumulativeTurnoverMicros,
+  cumulativeFeesMicros: point.cumulativeFeesMicros,
+  cumulativeSpreadCostMicros: point.cumulativeSpreadCostMicros,
+  cumulativeSlippageCostMicros: point.cumulativeSlippageCostMicros,
+  cumulativeCashYieldMicros: point.cumulativeCashYieldMicros,
+})
+
 const performanceEvidenceFailure = (
   series: CandidateDevelopmentPerformanceSeriesName,
   reason: Extract<
@@ -4131,7 +4167,7 @@ const performanceEvidenceFailure = (
 
 const unsignedMicros = (
   series: CandidateDevelopmentPerformanceSeriesName,
-  index: number,
+  index: number | null,
   field: string,
   value: string,
 ): Result.Result<bigint, CandidateDevelopmentCommandFailure> =>
@@ -4143,7 +4179,7 @@ const recomputePerformanceMetrics = (
   seriesName: CandidateDevelopmentPerformanceSeriesName,
   points: CandidateDevelopmentPerformanceSeries,
   initialCapitalMicros: string,
-  firstPreviousEquityMicros: string = initialCapitalMicros,
+  selectedWindowBaseline?: CandidateDevelopmentPerformanceBaseline,
 ): Result.Result<PerformanceMetrics, CandidateDevelopmentCommandFailure> => {
   if (points.length < 2) {
     return Result.fail(
@@ -4163,25 +4199,45 @@ const recomputePerformanceMetrics = (
         ),
       )
   if (Result.isFailure(initialCapital)) return Result.fail(initialCapital.failure)
-  const firstPreviousEquity = /^(?:[1-9][0-9]*)$/.test(firstPreviousEquityMicros)
-    ? Result.succeed(BigInt(firstPreviousEquityMicros))
+  const performanceBaseline = selectedWindowBaseline ?? {
+    equityMicros: initialCapitalMicros,
+    cumulativeTurnoverMicros: '0',
+    cumulativeFeesMicros: '0',
+    cumulativeSpreadCostMicros: '0',
+    cumulativeSlippageCostMicros: '0',
+    cumulativeCashYieldMicros: '0',
+  }
+  const baselineEquity = /^(?:[1-9][0-9]*)$/.test(performanceBaseline.equityMicros)
+    ? Result.succeed(BigInt(performanceBaseline.equityMicros))
     : Result.fail(
         performanceEvidenceFailure(
           seriesName,
           'micros-invalid',
           null,
-          'firstPreviousEquityMicros',
+          'performanceBaseline.equityMicros',
           'positive micros',
-          firstPreviousEquityMicros,
+          performanceBaseline.equityMicros,
         ),
       )
-  if (Result.isFailure(firstPreviousEquity)) return Result.fail(firstPreviousEquity.failure)
+  if (Result.isFailure(baselineEquity)) return Result.fail(baselineEquity.failure)
 
-  const equityMicros: bigint[] = []
-  const cumulative = Object.fromEntries(cumulativeMicrosFields.map(([, field]) => [field, 0n])) as Record<
+  const baselineCumulative = Object.fromEntries(cumulativeMicrosFields.map(([, field]) => [field, 0n])) as Record<
     (typeof cumulativeMicrosFields)[number][1],
     bigint
   >
+  for (const [, cumulativeField] of cumulativeMicrosFields) {
+    const parsed = unsignedMicros(
+      seriesName,
+      null,
+      `performanceBaseline.${cumulativeField}`,
+      performanceBaseline[cumulativeField],
+    )
+    if (Result.isFailure(parsed)) return Result.fail(parsed.failure)
+    baselineCumulative[cumulativeField] = parsed.success
+  }
+
+  const equityMicros: bigint[] = []
+  const cumulative = { ...baselineCumulative }
   for (let index = 0; index < points.length; index += 1) {
     const point = points[index]
     const previous = points[index - 1]
@@ -4205,7 +4261,7 @@ const recomputePerformanceMetrics = (
       )
     }
     equityMicros.push(equity.success)
-    const previousEquity = index === 0 ? firstPreviousEquity.success : equityMicros[index - 1]
+    const previousEquity = index === 0 ? baselineEquity.success : equityMicros[index - 1]
     const expectedReturn = Number(equity.success) / Number(previousEquity) - 1
     if (!Number.isFinite(expectedReturn) || !Object.is(point.netReturn, expectedReturn)) {
       return Result.fail(
@@ -4226,15 +4282,15 @@ const recomputePerformanceMetrics = (
       const observedCumulative = unsignedMicros(seriesName, index, cumulativeField, point[cumulativeField])
       if (Result.isFailure(observedCumulative)) return Result.fail(observedCumulative.failure)
       const prior = cumulative[cumulativeField]
-      const expected = index === 0 ? observedCumulative.success : prior + daily.success
-      if (index === 0 ? observedCumulative.success < daily.success : observedCumulative.success !== expected) {
+      const expected = prior + daily.success
+      if (observedCumulative.success !== expected) {
         return Result.fail(
           performanceEvidenceFailure(
             seriesName,
             'cumulative-mismatch',
             index,
             cumulativeField,
-            index === 0 ? `>=${daily.success}` : expected.toString(),
+            expected.toString(),
             observedCumulative.success.toString(),
           ),
         )
@@ -4246,12 +4302,12 @@ const recomputePerformanceMetrics = (
   return pipe(
     calculateExactPerformanceMetrics(
       equityMicros,
-      cumulative.cumulativeTurnoverMicros,
-      cumulative.cumulativeFeesMicros,
-      cumulative.cumulativeSpreadCostMicros,
-      cumulative.cumulativeSlippageCostMicros,
-      cumulative.cumulativeCashYieldMicros,
-      initialCapital.success,
+      cumulative.cumulativeTurnoverMicros - baselineCumulative.cumulativeTurnoverMicros,
+      cumulative.cumulativeFeesMicros - baselineCumulative.cumulativeFeesMicros,
+      cumulative.cumulativeSpreadCostMicros - baselineCumulative.cumulativeSpreadCostMicros,
+      cumulative.cumulativeSlippageCostMicros - baselineCumulative.cumulativeSlippageCostMicros,
+      cumulative.cumulativeCashYieldMicros - baselineCumulative.cumulativeCashYieldMicros,
+      baselineEquity.success,
     ),
     Result.mapError((cause) => performanceEvidenceFailure(seriesName, 'metrics-failed', null, null, null, null, cause)),
   )
@@ -5094,6 +5150,60 @@ const validateDecisionEventBinding = (
   return Result.succeed(undefined)
 }
 
+const validateRunIndependentDecisionPlans = (
+  field: string,
+  expected: EvaluationResult['signalDecisions'],
+  observed: EvaluationResult['signalDecisions'],
+): Result.Result<void, CandidateDevelopmentCommandFailure> =>
+  requireCanonicalEvidenceEqual(
+    field,
+    expected.map(({ decisionId: _, ...decision }) => decision),
+    observed.map(({ decisionId: _, ...decision }) => decision),
+  )
+
+const signalDecisionsInSimulationWindow = (
+  signalDecisions: EvaluationResult['signalDecisions'],
+  simulation: EvaluationResult['simulation'],
+): EvaluationResult['signalDecisions'] => {
+  const first = simulation.dailyMarks.at(0)?.sessionDate
+  const last = simulation.dailyMarks.at(-1)?.sessionDate
+  return first === undefined || last === undefined
+    ? []
+    : signalDecisions.filter(({ executionDate }) => executionDate >= first && executionDate <= last)
+}
+
+const decisionEventsInSimulationWindow = (
+  events: EvaluationResult['events'],
+  simulation: EvaluationResult['simulation'],
+): EvaluationResult['events'] => {
+  const first = simulation.dailyMarks.at(0)?.sessionDate
+  const last = simulation.dailyMarks.at(-1)?.sessionDate
+  return first === undefined || last === undefined
+    ? []
+    : events.filter((event) => event.kind === 'decision' && event.executionDate >= first && event.executionDate <= last)
+}
+
+const bindRunIndependentDecisionPlansToEvents = (
+  field: 'baseline' | 'stressed',
+  plans: EvaluationResult['signalDecisions'],
+  events: EvaluationResult['events'],
+): Result.Result<EvaluationResult['signalDecisions'], CandidateDevelopmentCommandFailure> => {
+  const decisionEvents = events.filter(
+    (event): event is Extract<EvaluationResult['events'][number], { readonly kind: 'decision' }> =>
+      event.kind === 'decision',
+  )
+  if (decisionEvents.length !== plans.length) {
+    return Result.fail(
+      markedEquityFailure('binding-mismatch', null, `${field}.decisionCount`, plans.length, decisionEvents.length),
+    )
+  }
+  const bound = plans.map((plan, index) => ({ ...plan, decisionId: decisionEvents[index]!.id }))
+  return pipe(
+    validateDecisionEventBinding(field, bound, events),
+    Result.map(() => bound),
+  )
+}
+
 const governedPriceMicros = (
   field: string,
   index: number,
@@ -5384,13 +5494,12 @@ const validateAccountingUniverse = (
   return Result.succeed(undefined)
 }
 
-const selectedTracePreviousEquity = (
+const selectedTracePerformanceBaseline = (
   field: 'baselineSimulation' | 'stressedSimulation',
   full: EvaluationResult['simulation'],
   selected: EvaluationResult['simulation'],
   events: EvaluationResult['events'],
-  initialCapitalMicros: string,
-): Result.Result<string, CandidateDevelopmentCommandFailure> => {
+): Result.Result<CandidateDevelopmentPerformanceBaseline, CandidateDevelopmentCommandFailure> => {
   const first = selected.dailyMarks.at(0)
   if (first === undefined) {
     return Result.fail(markedEquityFailure('selected-trace-mismatch', null, field, 'nonempty selected trace', 0))
@@ -5405,45 +5514,6 @@ const selectedTracePreviousEquity = (
     return Result.fail(markedEquityFailure('selected-trace-mismatch', null, `${field}.predecessorCount`, 1, startIndex))
   }
   const predecessor = full.dailyMarks[0]
-  const predecessorBindings = [
-    ['equityMicros', initialCapitalMicros, predecessor.equityMicros],
-    ['netReturn', 0, predecessor.netReturn],
-    ['turnoverMicros', '0', predecessor.turnoverMicros],
-    ['cumulativeTurnoverMicros', '0', predecessor.cumulativeTurnoverMicros],
-    ['feeMicros', '0', predecessor.feeMicros],
-    ['cumulativeFeesMicros', '0', predecessor.cumulativeFeesMicros],
-    ['spreadCostMicros', '0', predecessor.spreadCostMicros],
-    ['cumulativeSpreadCostMicros', '0', predecessor.cumulativeSpreadCostMicros],
-    ['slippageCostMicros', '0', predecessor.slippageCostMicros],
-    ['cumulativeSlippageCostMicros', '0', predecessor.cumulativeSlippageCostMicros],
-    ['cashYieldMicros', '0', predecessor.cashYieldMicros],
-    ['cumulativeCashYieldMicros', '0', predecessor.cumulativeCashYieldMicros],
-    ['peakEquityMicros', initialCapitalMicros, predecessor.peakEquityMicros],
-    ['drawdown', 0, predecessor.drawdown],
-    ['cashMicros', initialCapitalMicros, predecessor.cashMicros],
-  ] as const
-  for (const [name, expected, observed] of predecessorBindings) {
-    if (expected !== observed) {
-      return Result.fail(
-        markedEquityFailure('selected-trace-mismatch', 0, `${field}.predecessor.${name}`, expected, observed),
-      )
-    }
-  }
-  const nonzeroPosition = predecessor.positions.findIndex(
-    ({ quantityMicros, costBasisMicros, marketValueMicros }) =>
-      quantityMicros !== '0' || costBasisMicros !== '0' || marketValueMicros !== '0',
-  )
-  if (nonzeroPosition >= 0) {
-    return Result.fail(
-      markedEquityFailure(
-        'selected-trace-mismatch',
-        nonzeroPosition,
-        `${field}.predecessor.positions`,
-        'all-zero positions',
-        predecessor.positions[nonzeroPosition],
-      ),
-    )
-  }
   const last = selected.dailyMarks.at(-1)
   if (last === undefined || startIndex + selected.dailyMarks.length !== full.dailyMarks.length) {
     return Result.fail(
@@ -5477,15 +5547,15 @@ const selectedTracePreviousEquity = (
     for (const [dateField, observed] of evidenceDates) {
       const isEconomicBeforeWindow =
         event.kind === 'decision'
-          ? dateField === 'executionDate' && observed < first.sessionDate
-          : observed < first.sessionDate
+          ? dateField === 'executionDate' && observed < predecessor.sessionDate
+          : observed < predecessor.sessionDate
       if (isEconomicBeforeWindow) {
         return Result.fail(
           markedEquityFailure(
             'selected-trace-mismatch',
             index,
             `${field}.events.${dateField}`,
-            `>=${first.sessionDate}`,
+            `>=${predecessor.sessionDate}`,
             observed,
           ),
         )
@@ -5505,13 +5575,13 @@ const selectedTracePreviousEquity = (
   }
   for (let index = 0; index < full.orders.length; index += 1) {
     const observed = full.orders[index].sessionDate
-    if (observed < first.sessionDate) {
+    if (observed < predecessor.sessionDate) {
       return Result.fail(
         markedEquityFailure(
           'selected-trace-mismatch',
           index,
           `${field}.orders.sessionDate`,
-          `>=${first.sessionDate}`,
+          `>=${predecessor.sessionDate}`,
           observed,
         ),
       )
@@ -5530,13 +5600,13 @@ const selectedTracePreviousEquity = (
   }
   for (let index = 0; index < full.cashChanges.length; index += 1) {
     const observed = full.cashChanges[index].sessionDate
-    if (observed < first.sessionDate) {
+    if (observed < predecessor.sessionDate) {
       return Result.fail(
         markedEquityFailure(
           'selected-trace-mismatch',
           index,
           `${field}.cashChanges.sessionDate`,
-          `>=${first.sessionDate}`,
+          `>=${predecessor.sessionDate}`,
           observed,
         ),
       )
@@ -5553,17 +5623,22 @@ const selectedTracePreviousEquity = (
       )
     }
   }
-  return Result.succeed(initialCapitalMicros)
+  return Result.succeed(performanceBaselineFromPoint(predecessor))
 }
 
 interface CandidateDevelopmentAccountingValidation {
-  readonly strategyPreviousEquityMicros: string
-  readonly stressedPreviousEquityMicros: string
+  readonly strategyPerformanceBaseline: CandidateDevelopmentPerformanceBaseline
+  readonly stressedPerformanceBaseline: CandidateDevelopmentPerformanceBaseline
+}
+
+interface CandidateDevelopmentRebuiltBenchmark {
+  readonly series: readonly DailyPerformancePoint[]
+  readonly performanceBaseline: CandidateDevelopmentPerformanceBaseline
 }
 
 interface CandidateDevelopmentRebuiltBenchmarks {
-  readonly buyAndHold: readonly DailyPerformancePoint[]
-  readonly directVolTiming: readonly DailyPerformancePoint[]
+  readonly buyAndHold: CandidateDevelopmentRebuiltBenchmark
+  readonly directVolTiming: CandidateDevelopmentRebuiltBenchmark
 }
 
 const decisionTarget = (
@@ -5654,9 +5729,8 @@ export const validateCandidateDevelopmentAccountingReplay = (
 const selectRebuiltBenchmarkSeries = (
   series: readonly DailyPerformancePoint[],
   selectedSessions: readonly IsoDate[],
-  initialCapitalMicros: string,
   name: 'buy-and-hold' | 'direct-volatility-timing',
-): Result.Result<readonly DailyPerformancePoint[], CandidateDevelopmentCommandFailure> => {
+): Result.Result<CandidateDevelopmentRebuiltBenchmark, CandidateDevelopmentCommandFailure> => {
   const bySession = new Map(series.map((point) => [point.sessionDate, point] as const))
   const selected = selectedSessions.map((sessionDate) => bySession.get(sessionDate))
   const missing = selected.findIndex((point) => point === undefined)
@@ -5670,13 +5744,21 @@ const selectRebuiltBenchmarkSeries = (
   if (first === undefined) {
     return Result.fail(performanceEvidenceFailure(name, 'observations-insufficient', null, null, '>=2', 0))
   }
-  const normalizedReturn = Number(first.equityMicros) / Number(initialCapitalMicros) - 1
+  const firstIndex = series.findIndex((point) => point.sessionDate === first.sessionDate)
+  if (firstIndex !== 1) {
+    return Result.fail(performanceEvidenceFailure(name, 'session-mismatch', null, 'predecessorCount', 1, firstIndex))
+  }
+  const predecessor = series[0]
+  const normalizedReturn = Number(first.equityMicros) / Number(predecessor.equityMicros) - 1
   if (!Number.isFinite(normalizedReturn)) {
     return Result.fail(
       performanceEvidenceFailure(name, 'return-mismatch', 0, 'netReturn', 'finite normalized return', normalizedReturn),
     )
   }
-  return Result.succeed([{ ...first, netReturn: normalizedReturn }, ...complete.slice(1)])
+  return Result.succeed({
+    series: [{ ...first, netReturn: normalizedReturn }, ...complete.slice(1)],
+    performanceBaseline: performanceBaselineFromPoint(predecessor),
+  })
 }
 
 const rebuildCandidateDevelopmentBenchmarks = (
@@ -5836,16 +5918,10 @@ const rebuildCandidateDevelopmentBenchmarks = (
   }
   const selectedSessions = baseline.simulation.dailyMarks.map((mark) => mark.sessionDate)
   return Result.all({
-    buyAndHold: selectRebuiltBenchmarkSeries(
-      buyAndHold.success.dailyPerformance,
-      selectedSessions,
-      baseline.initialCapitalMicros,
-      'buy-and-hold',
-    ),
+    buyAndHold: selectRebuiltBenchmarkSeries(buyAndHold.success.dailyPerformance, selectedSessions, 'buy-and-hold'),
     directVolTiming: selectRebuiltBenchmarkSeries(
       directVolTiming.success.dailyPerformance,
       selectedSessions,
-      baseline.initialCapitalMicros,
       'direct-volatility-timing',
     ),
   })
@@ -5862,13 +5938,7 @@ const validateCandidateDevelopmentAccounting = (
   const scalarBindings = [
     ['runId', baseline.runId, accounting.runId],
     ['initialCapitalMicros', baseline.initialCapitalMicros, accounting.initialCapitalMicros],
-    ['evaluatorTotalFeesMicros', baseline.strategy.totalFeesMicros, accounting.evaluatorTotalFeesMicros],
     ['evaluatorEndingEquityMicros', baseline.strategy.endingEquityMicros, accounting.evaluatorEndingEquityMicros],
-    [
-      'stressedEvaluatorTotalFeesMicros',
-      baseline.doubleCostStrategy.totalFeesMicros,
-      accounting.stressedEvaluatorTotalFeesMicros,
-    ],
     [
       'stressedEvaluatorEndingEquityMicros',
       baseline.doubleCostStrategy.endingEquityMicros,
@@ -5914,36 +5984,60 @@ const validateCandidateDevelopmentAccounting = (
     if (Result.isFailure(binding)) return Result.fail(binding.failure)
   }
   const selectedTraceBindings = Result.all({
-    strategyPreviousEquityMicros: selectedTracePreviousEquity(
+    strategyPerformanceBaseline: selectedTracePerformanceBaseline(
       'baselineSimulation',
       accounting.baselineSimulation,
       baseline.simulation,
       accounting.events,
-      baseline.initialCapitalMicros,
     ),
-    stressedPreviousEquityMicros: selectedTracePreviousEquity(
+    stressedPerformanceBaseline: selectedTracePerformanceBaseline(
       'stressedSimulation',
       accounting.stressedSimulation,
       report.doubledCost.stressed.simulation,
       accounting.stressedEvents,
-      baseline.initialCapitalMicros,
     ),
   })
   if (Result.isFailure(selectedTraceBindings)) return Result.fail(selectedTraceBindings.failure)
-  const domainBindings = Result.all({
-    baselineCalendar: validateAccountingCalendar('baseline', officialSessions, accounting.baselineSimulation),
-    stressedCalendar: validateAccountingCalendar('stressed', officialSessions, accounting.stressedSimulation),
-    baselineUniverse: validateAccountingUniverse(
+  const selectedBaselinePlans = signalDecisionsInSimulationWindow(accounting.signalDecisions, baseline.simulation)
+  const selectedBaselineEvents = decisionEventsInSimulationWindow(accounting.events, baseline.simulation)
+  const baselineDecisionBindings = Result.all({
+    universe: validateAccountingUniverse(
       'baseline',
       strategyProtocol.universe,
-      baseline.signalDecisions,
+      accounting.signalDecisions,
       accounting.events,
       accounting.baselineSimulation,
     ),
+    selectedPlans: requireCanonicalEvidenceEqual(
+      'baseline.signalDecisions',
+      baseline.signalDecisions,
+      selectedBaselinePlans,
+    ),
+    fullEvents: validateDecisionEventBinding('baseline', accounting.signalDecisions, accounting.events),
+    selectedEvents: validateDecisionEventBinding('baseline', baseline.signalDecisions, selectedBaselineEvents),
+  })
+  if (Result.isFailure(baselineDecisionBindings)) return Result.fail(baselineDecisionBindings.failure)
+  const stressedAccountingPlans = bindRunIndependentDecisionPlansToEvents(
+    'stressed',
+    accounting.signalDecisions,
+    accounting.stressedEvents,
+  )
+  if (Result.isFailure(stressedAccountingPlans)) return Result.fail(stressedAccountingPlans.failure)
+  const selectedStressedPlans = signalDecisionsInSimulationWindow(
+    stressedAccountingPlans.success,
+    report.doubledCost.stressed.simulation,
+  )
+  const selectedStressedEvents = decisionEventsInSimulationWindow(
+    accounting.stressedEvents,
+    report.doubledCost.stressed.simulation,
+  )
+  const domainBindings = Result.all({
+    baselineCalendar: validateAccountingCalendar('baseline', officialSessions, accounting.baselineSimulation),
+    stressedCalendar: validateAccountingCalendar('stressed', officialSessions, accounting.stressedSimulation),
     stressedUniverse: validateAccountingUniverse(
       'stressed',
       strategyProtocol.universe,
-      report.doubledCost.stressed.signalDecisions,
+      stressedAccountingPlans.success,
       accounting.stressedEvents,
       accounting.stressedSimulation,
     ),
@@ -5966,7 +6060,7 @@ const validateCandidateDevelopmentAccounting = (
     baselineReplay: validateCandidateDevelopmentAccountingReplay(
       'baseline',
       accounting.runId,
-      baseline.signalDecisions,
+      accounting.signalDecisions,
       accounting.events,
       accounting.baselineSimulation,
       marketData,
@@ -5975,7 +6069,7 @@ const validateCandidateDevelopmentAccounting = (
     stressedReplay: validateCandidateDevelopmentAccountingReplay(
       'stressed',
       accounting.stressedRunId,
-      report.doubledCost.stressed.signalDecisions,
+      stressedAccountingPlans.success,
       accounting.stressedEvents,
       accounting.stressedSimulation,
       marketData,
@@ -5984,23 +6078,16 @@ const validateCandidateDevelopmentAccounting = (
   })
   if (Result.isFailure(domainBindings)) return Result.fail(domainBindings.failure)
   const decisionBindings = Result.all({
-    baselinePlans: requireCanonicalEvidenceEqual(
-      'baseline.signalDecisions',
-      baseline.signalDecisions,
-      accounting.signalDecisions,
-    ),
-    stressedPlans: requireCanonicalEvidenceEqual(
+    stressedPlans: validateRunIndependentDecisionPlans(
       'stressed.signalDecisions',
       report.doubledCost.stressed.signalDecisions,
-      accounting.signalDecisions,
+      selectedStressedPlans,
     ),
-    baselineFull: validateDecisionEventBinding('baseline', accounting.signalDecisions, accounting.events),
-    baselineSelected: validateDecisionEventBinding('baseline', baseline.signalDecisions, accounting.events),
-    stressed: validateDecisionEventBinding('stressed', accounting.signalDecisions, accounting.stressedEvents),
+    stressedFull: validateDecisionEventBinding('stressed', stressedAccountingPlans.success, accounting.stressedEvents),
     stressedSelected: validateDecisionEventBinding(
       'stressed',
       report.doubledCost.stressed.signalDecisions,
-      accounting.stressedEvents,
+      selectedStressedEvents,
     ),
   })
   if (Result.isFailure(decisionBindings)) return Result.fail(decisionBindings.failure)
@@ -6103,12 +6190,12 @@ const recomputeCandidateDevelopmentMetrics = (
     Result.all({
       buyBinding: requireCanonicalEvidenceEqual(
         'benchmarks.buyAndHold',
-        benchmarks.buyAndHold,
+        benchmarks.buyAndHold.series,
         baseline.benchmarkSeries.buyAndHold,
       ),
       directVolBinding: requireCanonicalEvidenceEqual(
         'benchmarks.directVolatilityTiming',
-        benchmarks.directVolTiming,
+        benchmarks.directVolTiming.series,
         baseline.benchmarkSeries.directVolTiming,
       ),
       doubleCostBinding: requireCanonicalEvidenceEqual(
@@ -6116,8 +6203,12 @@ const recomputeCandidateDevelopmentMetrics = (
         stressedPerformance,
         baseline.benchmarkSeries.doubleCostStrategy,
       ),
-      buySessions: validateSeriesSessions(strategyPoints, benchmarks.buyAndHold, 'buy-and-hold'),
-      volSessions: validateSeriesSessions(strategyPoints, benchmarks.directVolTiming, 'direct-volatility-timing'),
+      buySessions: validateSeriesSessions(strategyPoints, benchmarks.buyAndHold.series, 'buy-and-hold'),
+      volSessions: validateSeriesSessions(
+        strategyPoints,
+        benchmarks.directVolTiming.series,
+        'direct-volatility-timing',
+      ),
       doubleSessions: validateSeriesSessions(
         stressedPerformance,
         baseline.benchmarkSeries.doubleCostStrategy,
@@ -6128,24 +6219,31 @@ const recomputeCandidateDevelopmentMetrics = (
         'strategy',
         strategyPoints,
         baseline.initialCapitalMicros,
-        accounting.strategyPreviousEquityMicros,
+        accounting.strategyPerformanceBaseline,
       ),
-      buyAndHold: recomputePerformanceMetrics('buy-and-hold', benchmarks.buyAndHold, baseline.initialCapitalMicros),
+      buyAndHold: recomputePerformanceMetrics(
+        'buy-and-hold',
+        benchmarks.buyAndHold.series,
+        baseline.initialCapitalMicros,
+        benchmarks.buyAndHold.performanceBaseline,
+      ),
       directVolTiming: recomputePerformanceMetrics(
         'direct-volatility-timing',
-        benchmarks.directVolTiming,
+        benchmarks.directVolTiming.series,
         baseline.initialCapitalMicros,
+        benchmarks.directVolTiming.performanceBaseline,
       ),
       doubleCostSeries: recomputePerformanceMetrics(
         'double-cost-series',
         baseline.benchmarkSeries.doubleCostStrategy,
         baseline.initialCapitalMicros,
+        accounting.stressedPerformanceBaseline,
       ),
       doubleCostStressed: recomputePerformanceMetrics(
         'double-cost-stressed',
         stressedPoints,
         baseline.initialCapitalMicros,
-        accounting.stressedPreviousEquityMicros,
+        accounting.stressedPerformanceBaseline,
       ),
     }),
     Result.flatMap(({ buyAndHold, directVolTiming, doubleCostSeries, doubleCostStressed, strategy }) =>
@@ -6657,6 +6755,16 @@ const CandidateDevelopmentMarketDataWitnessSchema = Schema.Struct({
   bars: Schema.Array(CandidateDevelopmentDailyBarSchema).check(Schema.isMinLength(1)),
 })
 
+const CandidateDevelopmentPlannedDecisionSchema = Schema.Struct({
+  ...DecisionPlanSchema.fields,
+  executionDate: IsoDateSchema,
+})
+
+const CandidateDevelopmentStrategyPlanSchema = Schema.Struct({
+  schemaVersion: Schema.Literal('bayn.candidate-development-strategy-plan.v1'),
+  decisions: Schema.Array(CandidateDevelopmentPlannedDecisionSchema).check(Schema.isMinLength(1)),
+})
+
 const CandidateDevelopmentMomentumStrategyIdentitySchema = Schema.Struct({
   schemaVersion: Schema.Literal('bayn.candidate-development-strategy-identity.v1'),
   family: Schema.String.check(Schema.isMinLength(1)),
@@ -6828,6 +6936,16 @@ const decodeCandidateDevelopmentEvaluation = Schema.decodeUnknownResult(
 
 const decodeCandidateDevelopmentMarketDataWitness = Schema.decodeUnknownResult(
   CandidateDevelopmentMarketDataWitnessSchema,
+  strictParseOptions,
+)
+
+const decodeCandidateDevelopmentStrategyPlan = Schema.decodeUnknownResult(
+  CandidateDevelopmentStrategyPlanSchema,
+  strictParseOptions,
+)
+
+const decodeCandidateDevelopmentInputManifest = Schema.decodeUnknownResult(
+  InputManifestArtifactSchema,
   strictParseOptions,
 )
 
@@ -9468,8 +9586,1286 @@ export const verifyCandidateDevelopmentSourceFiles: CandidateDevelopmentSourceVe
   })
 
 const candidateDevelopmentArtifactSchemaVersion = 'bayn.candidate-development-artifact.v1' as const
+const candidateDevelopmentPlanArtifactSchemaVersion = 'bayn.candidate-development-plan-artifact.v1' as const
 const candidateDevelopmentArtifactEvaluationTimeoutMs = 120_000
 const candidateDevelopmentArtifactInitializationTimeoutMs = 10_000
+
+const candidateDevelopmentPlanFailure = (field: string, cause: unknown): CandidateDevelopmentCommandFailure =>
+  sourceVerificationFailure('verify-program-binding', { field, cause })
+
+const exactStringSet = (expected: readonly string[], observed: readonly string[]): boolean => {
+  if (expected.length !== observed.length) return false
+  const expectedSorted = [...expected].sort()
+  const observedSorted = [...observed].sort()
+  return expectedSorted.every((value, index) => value === observedSorted[index])
+}
+
+const quantizeCandidateDevelopmentPlanNumber = (value: number): number =>
+  Math.round(value * 1_000_000_000_000) / 1_000_000_000_000
+
+const candidateDevelopmentSampleVariance = (values: readonly number[]): number | undefined => {
+  if (values.length < 2 || values.some((value) => !Number.isFinite(value))) return undefined
+  const mean = values.reduce((sum, value) => sum + value, 0) / values.length
+  const variance = values.reduce((sum, value) => sum + (value - mean) ** 2, 0) / (values.length - 1)
+  return Number.isFinite(variance) ? variance : undefined
+}
+
+const candidateDevelopmentSampleCovariance = (
+  first: readonly number[],
+  second: readonly number[],
+): number | undefined => {
+  if (first.length !== second.length || first.length < 2) return undefined
+  const firstMean = first.reduce((sum, value) => sum + value, 0) / first.length
+  const secondMean = second.reduce((sum, value) => sum + value, 0) / second.length
+  const covariance =
+    first.reduce((sum, value, index) => sum + (value - firstMean) * ((second[index] as number) - secondMean), 0) /
+    (first.length - 1)
+  return Number.isFinite(covariance) ? covariance : undefined
+}
+
+interface CandidateDevelopmentInverseVolatilityFeature {
+  readonly totalReturns: Readonly<Record<string, number>>
+  readonly dailyReturns: Readonly<Record<string, readonly number[]>>
+  readonly annualizedVolatilities: Readonly<Record<string, number>>
+  readonly targetWeights: Readonly<Record<string, number>>
+  readonly exposureScale: number
+  readonly estimatedAnnualizedPortfolioVolatility: number
+}
+
+const deriveCandidateDevelopmentInverseVolatilityFeature = (
+  alignedSessions: readonly AlignedSession[],
+  signalSessionIndex: number,
+  universe: readonly string[],
+  strategyIdentity: CandidateDevelopmentInverseVolatilityStrategyIdentity,
+  terminal: boolean,
+  field: string,
+): Result.Result<CandidateDevelopmentInverseVolatilityFeature, CandidateDevelopmentCommandFailure> => {
+  const parameters = strategyIdentity.parameters
+  const [firstRiskAsset, secondRiskAsset] = parameters.riskAssets
+  if (firstRiskAsset === secondRiskAsset || !universe.includes(firstRiskAsset) || !universe.includes(secondRiskAsset)) {
+    return Result.fail(
+      candidateDevelopmentPlanFailure(`${field}.riskAssets`, {
+        expected: 'two distinct members of the governed universe',
+        observed: parameters.riskAssets,
+      }),
+    )
+  }
+  const firstPriceSessionIndex = signalSessionIndex - parameters.lookbackSessions
+  if (firstPriceSessionIndex < 0) {
+    return Result.fail(
+      candidateDevelopmentPlanFailure(`${field}.window`, {
+        expected: parameters.lookbackSessions + 1,
+        observed: signalSessionIndex + 1,
+      }),
+    )
+  }
+  const totalReturns: Record<string, number> = {}
+  const dailyReturns: Record<string, readonly number[]> = {}
+  const annualizedVolatilities: Record<string, number> = {}
+  for (const symbol of universe) {
+    const returns: number[] = []
+    for (let sessionIndex = firstPriceSessionIndex + 1; sessionIndex <= signalSessionIndex; sessionIndex += 1) {
+      const previousClose = alignedSessions[sessionIndex - 1]?.bars[symbol]?.close
+      const currentClose = alignedSessions[sessionIndex]?.bars[symbol]?.close
+      if (
+        previousClose === undefined ||
+        currentClose === undefined ||
+        !Number.isFinite(previousClose) ||
+        !Number.isFinite(currentClose) ||
+        previousClose <= 0 ||
+        currentClose <= 0
+      ) {
+        return Result.fail(
+          candidateDevelopmentPlanFailure(`${field}.marketData.${symbol}`, {
+            expected: 'strictly positive finite adjusted closes across the complete lookback',
+            observed: { previousClose, currentClose },
+          }),
+        )
+      }
+      const dailyReturn = currentClose / previousClose - 1
+      if (!Number.isFinite(dailyReturn)) {
+        return Result.fail(
+          candidateDevelopmentPlanFailure(`${field}.dailyReturns.${symbol}`, {
+            expected: 'finite daily returns',
+            observed: dailyReturn,
+          }),
+        )
+      }
+      returns.push(dailyReturn)
+    }
+    const variance = candidateDevelopmentSampleVariance(returns)
+    const annualizedVolatility =
+      variance === undefined
+        ? undefined
+        : quantizeCandidateDevelopmentPlanNumber(Math.sqrt(variance * parameters.annualizationSessions))
+    if (annualizedVolatility === undefined || !Number.isFinite(annualizedVolatility) || annualizedVolatility <= 0) {
+      return Result.fail(
+        candidateDevelopmentPlanFailure(`${field}.annualizedVolatility.${symbol}`, {
+          expected: 'strictly positive finite sample annualized volatility',
+          observed: annualizedVolatility,
+        }),
+      )
+    }
+    const firstClose = alignedSessions[firstPriceSessionIndex]?.bars[symbol]?.close
+    const signalClose = alignedSessions[signalSessionIndex]?.bars[symbol]?.close
+    if (firstClose === undefined || signalClose === undefined || firstClose <= 0 || !Number.isFinite(signalClose)) {
+      return Result.fail(
+        candidateDevelopmentPlanFailure(`${field}.totalReturn.${symbol}`, {
+          expected: 'complete finite lookback prices',
+          observed: { firstClose, signalClose },
+        }),
+      )
+    }
+    totalReturns[symbol] = quantizeCandidateDevelopmentPlanNumber(signalClose / firstClose - 1)
+    dailyReturns[symbol] = returns
+    annualizedVolatilities[symbol] = annualizedVolatility
+  }
+  const firstRiskVolatility = annualizedVolatilities[firstRiskAsset]
+  const secondRiskVolatility = annualizedVolatilities[secondRiskAsset]
+  const firstRiskReturns = dailyReturns[firstRiskAsset]
+  const secondRiskReturns = dailyReturns[secondRiskAsset]
+  if (
+    firstRiskVolatility === undefined ||
+    secondRiskVolatility === undefined ||
+    firstRiskReturns === undefined ||
+    secondRiskReturns === undefined
+  ) {
+    return Result.fail(
+      candidateDevelopmentPlanFailure(`${field}.riskAssets`, {
+        expected: parameters.riskAssets,
+        observed: Object.keys(annualizedVolatilities),
+      }),
+    )
+  }
+  const firstInverseVolatility = 1 / firstRiskVolatility
+  const secondInverseVolatility = 1 / secondRiskVolatility
+  const inverseVolatilityDenominator = firstInverseVolatility + secondInverseVolatility
+  const covariance = candidateDevelopmentSampleCovariance(firstRiskReturns, secondRiskReturns)
+  if (covariance === undefined || !Number.isFinite(inverseVolatilityDenominator) || inverseVolatilityDenominator <= 0) {
+    return Result.fail(
+      candidateDevelopmentPlanFailure(`${field}.riskGeometry`, {
+        expected: 'finite sample covariance and inverse-volatility denominator',
+        observed: { covariance, inverseVolatilityDenominator },
+      }),
+    )
+  }
+  const normalizedFirstWeight = firstInverseVolatility / inverseVolatilityDenominator
+  const normalizedSecondWeight = secondInverseVolatility / inverseVolatilityDenominator
+  const unscaledPortfolioVariance =
+    normalizedFirstWeight ** 2 * firstRiskVolatility ** 2 +
+    normalizedSecondWeight ** 2 * secondRiskVolatility ** 2 +
+    2 * normalizedFirstWeight * normalizedSecondWeight * covariance * parameters.annualizationSessions
+  if (!Number.isFinite(unscaledPortfolioVariance) || unscaledPortfolioVariance <= 0) {
+    return Result.fail(
+      candidateDevelopmentPlanFailure(`${field}.portfolioVariance`, {
+        expected: 'strictly positive finite sample portfolio variance',
+        observed: unscaledPortfolioVariance,
+      }),
+    )
+  }
+  const unscaledAnnualizedPortfolioVolatility = Math.sqrt(unscaledPortfolioVariance)
+  const riskScale = quantizeCandidateDevelopmentPlanNumber(
+    Math.min(
+      parameters.maximumGrossExposure,
+      parameters.targetAnnualizedVolatility / unscaledAnnualizedPortfolioVolatility,
+    ),
+  )
+  if (!Number.isFinite(riskScale) || riskScale <= 0) {
+    return Result.fail(
+      candidateDevelopmentPlanFailure(`${field}.riskScale`, {
+        expected: 'strictly positive finite bounded risk scale',
+        observed: riskScale,
+      }),
+    )
+  }
+  const targetWeights = Object.fromEntries(
+    universe.map((symbol) => [
+      symbol,
+      terminal
+        ? 0
+        : symbol === firstRiskAsset
+          ? quantizeCandidateDevelopmentPlanNumber(normalizedFirstWeight * riskScale)
+          : symbol === secondRiskAsset
+            ? quantizeCandidateDevelopmentPlanNumber(normalizedSecondWeight * riskScale)
+            : 0,
+    ]),
+  )
+  const exposureScale = quantizeCandidateDevelopmentPlanNumber(
+    Object.values(targetWeights).reduce((sum, weight) => sum + weight, 0),
+  )
+  const portfolioReturns = Array.from({ length: parameters.lookbackSessions }, (_, returnIndex) =>
+    universe.reduce(
+      (sum, symbol) => sum + (dailyReturns[symbol]?.[returnIndex] ?? Number.NaN) * (targetWeights[symbol] ?? 0),
+      0,
+    ),
+  )
+  const portfolioVariance = candidateDevelopmentSampleVariance(portfolioReturns)
+  if (portfolioVariance === undefined) {
+    return Result.fail(
+      candidateDevelopmentPlanFailure(`${field}.estimatedAnnualizedPortfolioVolatility`, {
+        expected: 'finite sample portfolio return variance',
+        observed: portfolioReturns,
+      }),
+    )
+  }
+  return Result.succeed({
+    totalReturns,
+    dailyReturns,
+    annualizedVolatilities,
+    targetWeights,
+    exposureScale,
+    estimatedAnnualizedPortfolioVolatility: quantizeCandidateDevelopmentPlanNumber(
+      Math.sqrt(portfolioVariance * parameters.annualizationSessions),
+    ),
+  })
+}
+
+const candidateDevelopmentMaximumGrossExposure = (strategyProtocol: CandidateDevelopmentStrategyProtocol): number => {
+  const strategyIdentity = strategyProtocol.strategyIdentity
+  if (strategyIdentity?.schemaVersion === 'bayn.candidate-development-strategy-identity.v2') {
+    return strategyIdentity.parameters.maximumGrossExposure
+  }
+  if (strategyIdentity?.schemaVersion === 'bayn.candidate-development-strategy-identity.v1') {
+    return strategyIdentity.parameters.selectedAssetWeight
+  }
+  return 1
+}
+
+const validateCandidateDevelopmentStrategyPlan = (
+  value: unknown,
+  preflight: CandidateDevelopmentPreflightPass,
+  strategyProtocol: CandidateDevelopmentStrategyProtocol,
+  officialSessions: readonly IsoDate[],
+  signalSessionDates: readonly IsoDate[],
+  alignedSessions: readonly AlignedSession[],
+): Result.Result<CandidateDevelopmentStrategyPlan, CandidateDevelopmentCommandFailure> => {
+  const decoded = decodeCandidateDevelopmentStrategyPlan(value)
+  if (Result.isFailure(decoded)) {
+    return Result.fail(candidateDevelopmentPlanFailure('artifact.plan', decoded.failure))
+  }
+  const plan = decoded.success as CandidateDevelopmentStrategyPlan
+  const officialSessionIndexByDate = new Map(officialSessions.map((session, index) => [session, index] as const))
+  const selectedStartIndex = officialSessionIndexByDate.get(preflight.selectedObservationStart)
+  const accountingStart = selectedStartIndex === undefined ? undefined : officialSessions[selectedStartIndex - 1]
+  if (accountingStart === undefined) {
+    return Result.fail(
+      candidateDevelopmentPlanFailure('artifact.plan.openingDecision', {
+        expected: 'an official accounting predecessor for the selected observation window',
+        observed: { selectedStartIndex, selectedObservationStart: preflight.selectedObservationStart },
+      }),
+    )
+  }
+  const expectedSchedule = expectedCandidateDevelopmentRebalanceSchedule(
+    officialSessions,
+    signalSessionDates,
+    accountingStart,
+    preflight.selectedObservationEnd,
+  )
+  const openingDecision = expectedSchedule[0]
+  const selectedSchedule = expectedSchedule.slice(1)
+  if (
+    openingDecision?.executionDate !== accountingStart ||
+    selectedSchedule.length !== preflight.expectedRebalanceSchedule.length ||
+    selectedSchedule.some(
+      (boundary, index) =>
+        boundary.signalDate !== preflight.expectedRebalanceSchedule[index]?.signalDate ||
+        boundary.executionDate !== preflight.expectedRebalanceSchedule[index]?.executionDate,
+    )
+  ) {
+    return Result.fail(
+      candidateDevelopmentPlanFailure('artifact.plan.openingDecision', {
+        expected: {
+          executionDate: accountingStart,
+          selectedSchedule: preflight.expectedRebalanceSchedule,
+        },
+        observed: { openingDecision, selectedSchedule },
+      }),
+    )
+  }
+  if (plan.decisions.length !== expectedSchedule.length) {
+    return Result.fail(
+      candidateDevelopmentPlanFailure('artifact.plan.decisions.length', {
+        expected: expectedSchedule.length,
+        observed: plan.decisions.length,
+      }),
+    )
+  }
+  const universe = strategyProtocol.universe
+  const strategyIdentity = strategyProtocol.strategyIdentity
+  if (strategyIdentity === undefined) {
+    return Result.fail(
+      candidateDevelopmentPlanFailure('artifact.strategyProtocol.strategyIdentity', {
+        expected: 'immutable allocation semantics',
+        observed: undefined,
+      }),
+    )
+  }
+  const maximumGrossExposure = candidateDevelopmentMaximumGrossExposure(strategyProtocol)
+  const lookbackSessions = strategyIdentity.parameters.lookbackSessions
+  const governedAssets = new Set(
+    strategyIdentity.schemaVersion === 'bayn.candidate-development-strategy-identity.v2'
+      ? strategyIdentity.parameters.riskAssets
+      : [...strategyIdentity.parameters.riskAssets, strategyIdentity.parameters.defensiveAsset],
+  )
+  if (
+    alignedSessions.length !== officialSessions.length ||
+    alignedSessions.some((session, index) => session.date !== officialSessions[index])
+  ) {
+    return Result.fail(
+      candidateDevelopmentPlanFailure('artifact.plan.marketDataSessions', {
+        expected: officialSessions,
+        observed: alignedSessions.map(({ date }) => date),
+      }),
+    )
+  }
+  const normalizedDecisions: CandidateDevelopmentPlannedDecision[] = []
+  for (let index = 0; index < plan.decisions.length; index += 1) {
+    const decision = plan.decisions[index]
+    const expected = expectedSchedule[index]
+    if (decision.signalDate !== expected?.signalDate || decision.executionDate !== expected?.executionDate) {
+      return Result.fail(
+        candidateDevelopmentPlanFailure(`artifact.plan.decisions[${index}].schedule`, {
+          expected,
+          observed: { signalDate: decision.signalDate, executionDate: decision.executionDate },
+        }),
+      )
+    }
+    const signalSessionIndex = officialSessionIndexByDate.get(decision.signalDate)
+    const covarianceWindowStartIndex = signalSessionIndex === undefined ? -1 : signalSessionIndex - lookbackSessions + 1
+    const covarianceReturnSessions =
+      covarianceWindowStartIndex < 0 || signalSessionIndex === undefined
+        ? []
+        : officialSessions.slice(covarianceWindowStartIndex, signalSessionIndex + 1)
+    const covariancePriceSessions =
+      covarianceWindowStartIndex < 1 || signalSessionIndex === undefined
+        ? []
+        : officialSessions.slice(covarianceWindowStartIndex - 1, signalSessionIndex + 1)
+    const expectedFirstSession = covarianceReturnSessions[0]
+    if (
+      covarianceReturnSessions.length !== lookbackSessions ||
+      covariancePriceSessions.length !== lookbackSessions + 1 ||
+      expectedFirstSession === undefined ||
+      decision.covarianceWindow.returnCount !== lookbackSessions ||
+      decision.covarianceWindow.firstSession !== expectedFirstSession ||
+      decision.covarianceWindow.lastSession !== decision.signalDate
+    ) {
+      return Result.fail(
+        candidateDevelopmentPlanFailure(`artifact.plan.decisions[${index}].covarianceWindow`, {
+          expected: {
+            returnCount: lookbackSessions,
+            firstSession: expectedFirstSession ?? null,
+            lastSession: decision.signalDate,
+          },
+          observed: decision.covarianceWindow,
+        }),
+      )
+    }
+    const covarianceWindowHash = canonicalHashV1Result({
+      schemaVersion: 'bayn.candidate-development-plan-window.v1',
+      sessions: covariancePriceSessions,
+    })
+    if (Result.isFailure(covarianceWindowHash)) {
+      return Result.fail(
+        candidateDevelopmentPlanFailure(
+          `artifact.plan.decisions[${index}].covarianceWindow.sessionsHash`,
+          covarianceWindowHash.failure,
+        ),
+      )
+    }
+    const allocationTolerance = 1e-12 + Number.EPSILON
+    let inverseVolatilityFeature: CandidateDevelopmentInverseVolatilityFeature | undefined
+    if (strategyIdentity.schemaVersion === 'bayn.candidate-development-strategy-identity.v2') {
+      const derived = deriveCandidateDevelopmentInverseVolatilityFeature(
+        alignedSessions,
+        signalSessionIndex ?? -1,
+        universe,
+        strategyIdentity,
+        index === plan.decisions.length - 1,
+        `artifact.plan.decisions[${index}].inverseVolatility`,
+      )
+      if (Result.isFailure(derived)) return Result.fail(derived.failure)
+      inverseVolatilityFeature = derived.success
+      if (
+        universe.some((symbol) => {
+          const expectedWeight = inverseVolatilityFeature?.targetWeights[symbol]
+          const observedWeight = decision.targetWeights[symbol]
+          return (
+            expectedWeight === undefined ||
+            observedWeight === undefined ||
+            Math.abs(observedWeight - expectedWeight) > allocationTolerance
+          )
+        })
+      ) {
+        return Result.fail(
+          candidateDevelopmentPlanFailure(`artifact.plan.decisions[${index}].inverseVolatility.allocation`, {
+            expected: inverseVolatilityFeature.targetWeights,
+            observed: decision.targetWeights,
+          }),
+        )
+      }
+      if (
+        Math.abs(decision.exposureScale - inverseVolatilityFeature.exposureScale) > allocationTolerance ||
+        Math.abs(
+          decision.estimatedAnnualizedPortfolioVolatility -
+            inverseVolatilityFeature.estimatedAnnualizedPortfolioVolatility,
+        ) > allocationTolerance
+      ) {
+        return Result.fail(
+          candidateDevelopmentPlanFailure(`artifact.plan.decisions[${index}].inverseVolatility.riskScale`, {
+            expected: {
+              exposureScale: inverseVolatilityFeature.exposureScale,
+              estimatedAnnualizedPortfolioVolatility: inverseVolatilityFeature.estimatedAnnualizedPortfolioVolatility,
+            },
+            observed: {
+              exposureScale: decision.exposureScale,
+              estimatedAnnualizedPortfolioVolatility: decision.estimatedAnnualizedPortfolioVolatility,
+            },
+          }),
+        )
+      }
+    }
+    let momentumFeature:
+      | {
+          readonly totalReturns: Readonly<Record<string, number>>
+          readonly selectedSymbol: string | null
+          readonly estimatedAnnualizedPortfolioVolatility: number
+        }
+      | undefined
+    if (strategyIdentity.schemaVersion === 'bayn.candidate-development-strategy-identity.v1') {
+      const parameters = strategyIdentity.parameters
+      const [firstRiskAsset, secondRiskAsset] = parameters.riskAssets
+      if (
+        parameters.relativeMomentumTieBreak !== firstRiskAsset &&
+        parameters.relativeMomentumTieBreak !== secondRiskAsset
+      ) {
+        return Result.fail(
+          candidateDevelopmentPlanFailure(
+            'artifact.strategyProtocol.strategyIdentity.parameters.relativeMomentumTieBreak',
+            {
+              expected: parameters.riskAssets,
+              observed: parameters.relativeMomentumTieBreak,
+            },
+          ),
+        )
+      }
+      const firstFeatureSession =
+        signalSessionIndex === undefined ? undefined : alignedSessions[signalSessionIndex - lookbackSessions]
+      const signalSession = signalSessionIndex === undefined ? undefined : alignedSessions[signalSessionIndex]
+      if (firstFeatureSession === undefined || signalSession === undefined) {
+        return Result.fail(
+          candidateDevelopmentPlanFailure(`artifact.plan.decisions[${index}].momentumWindow`, {
+            expected: { lookbackSessions, signalDate: decision.signalDate },
+            observed: null,
+          }),
+        )
+      }
+      const totalReturns: Record<string, number> = {}
+      for (const symbol of universe) {
+        const firstBar = firstFeatureSession.bars[symbol]
+        const signalBar = signalSession.bars[symbol]
+        if (firstBar === undefined || signalBar === undefined) {
+          return Result.fail(
+            candidateDevelopmentPlanFailure(`artifact.plan.decisions[${index}].momentumWindow.${symbol}`, {
+              expected: [firstFeatureSession.date, signalSession.date],
+              observed: null,
+            }),
+          )
+        }
+        totalReturns[symbol] =
+          Math.round((signalBar.close / firstBar.close - 1) * 1_000_000_000_000) / 1_000_000_000_000
+      }
+      const firstRiskReturn = totalReturns[firstRiskAsset]
+      const secondRiskReturn = totalReturns[secondRiskAsset]
+      const defensiveReturn = totalReturns[parameters.defensiveAsset]
+      if (firstRiskReturn === undefined || secondRiskReturn === undefined || defensiveReturn === undefined) {
+        return Result.fail(
+          candidateDevelopmentPlanFailure(`artifact.plan.decisions[${index}].momentumUniverse`, {
+            expected: [...parameters.riskAssets, parameters.defensiveAsset],
+            observed: Object.keys(totalReturns),
+          }),
+        )
+      }
+      const relativeWinner =
+        firstRiskReturn === secondRiskReturn
+          ? parameters.relativeMomentumTieBreak
+          : firstRiskReturn > secondRiskReturn
+            ? firstRiskAsset
+            : secondRiskAsset
+      const relativeWinnerReturn = totalReturns[relativeWinner]
+      const selectedSymbol =
+        relativeWinnerReturn !== undefined && relativeWinnerReturn > parameters.absoluteMomentumThreshold
+          ? relativeWinner
+          : defensiveReturn > parameters.absoluteMomentumThreshold
+            ? parameters.defensiveAsset
+            : null
+      const terminal = index === plan.decisions.length - 1
+      const expectedWeights = Object.fromEntries(
+        universe.map((symbol) => [symbol, !terminal && selectedSymbol === symbol ? parameters.selectedAssetWeight : 0]),
+      )
+      if (
+        universe.some((symbol) => {
+          const observedWeight = decision.targetWeights[symbol]
+          const expectedWeight = expectedWeights[symbol]
+          return (
+            observedWeight === undefined ||
+            expectedWeight === undefined ||
+            Math.abs(observedWeight - expectedWeight) > 1e-12 + Number.EPSILON
+          )
+        })
+      ) {
+        return Result.fail(
+          candidateDevelopmentPlanFailure(`artifact.plan.decisions[${index}].momentumSelection`, {
+            expected: { selectedSymbol, targetWeights: expectedWeights },
+            observed: decision.targetWeights,
+          }),
+        )
+      }
+      const volatilityWindowStartIndex =
+        signalSessionIndex === undefined ? -1 : signalSessionIndex - parameters.volatilityWindowSessions + 1
+      if (volatilityWindowStartIndex < 1 || signalSessionIndex === undefined) {
+        return Result.fail(
+          candidateDevelopmentPlanFailure(`artifact.plan.decisions[${index}].momentumVolatility.window`, {
+            expected: parameters.volatilityWindowSessions,
+            observed: signalSessionIndex === undefined ? 0 : signalSessionIndex,
+          }),
+        )
+      }
+      const portfolioReturns: number[] = []
+      for (let sessionIndex = volatilityWindowStartIndex; sessionIndex <= signalSessionIndex; sessionIndex += 1) {
+        let portfolioReturn = 0
+        for (const symbol of universe) {
+          const weight = expectedWeights[symbol]
+          if (weight === undefined || weight === 0) continue
+          const previousClose = alignedSessions[sessionIndex - 1]?.bars[symbol]?.close
+          const currentClose = alignedSessions[sessionIndex]?.bars[symbol]?.close
+          if (
+            previousClose === undefined ||
+            currentClose === undefined ||
+            !Number.isFinite(previousClose) ||
+            !Number.isFinite(currentClose) ||
+            previousClose <= 0 ||
+            currentClose <= 0
+          ) {
+            return Result.fail(
+              candidateDevelopmentPlanFailure(
+                `artifact.plan.decisions[${index}].momentumVolatility.marketData.${symbol}`,
+                {
+                  expected: 'strictly positive finite adjusted closes across the complete volatility window',
+                  observed: { previousClose, currentClose },
+                },
+              ),
+            )
+          }
+          portfolioReturn += (currentClose / previousClose - 1) * weight
+        }
+        portfolioReturns.push(portfolioReturn)
+      }
+      const portfolioVariance = candidateDevelopmentSampleVariance(portfolioReturns)
+      if (portfolioVariance === undefined) {
+        return Result.fail(
+          candidateDevelopmentPlanFailure(`artifact.plan.decisions[${index}].momentumVolatility`, {
+            expected: 'finite sample portfolio return variance',
+            observed: portfolioReturns,
+          }),
+        )
+      }
+      const estimatedAnnualizedPortfolioVolatility = quantizeCandidateDevelopmentPlanNumber(
+        Math.sqrt(portfolioVariance * parameters.annualizationSessions),
+      )
+      if (
+        Math.abs(decision.estimatedAnnualizedPortfolioVolatility - estimatedAnnualizedPortfolioVolatility) >
+        allocationTolerance
+      ) {
+        return Result.fail(
+          candidateDevelopmentPlanFailure(`artifact.plan.decisions[${index}].momentumVolatility`, {
+            expected: estimatedAnnualizedPortfolioVolatility,
+            observed: decision.estimatedAnnualizedPortfolioVolatility,
+          }),
+        )
+      }
+      momentumFeature = { totalReturns, selectedSymbol, estimatedAnnualizedPortfolioVolatility }
+    }
+    const weightSymbols = Object.keys(decision.targetWeights)
+    const signalSymbols = decision.signals.map(({ symbol }) => symbol)
+    if (!exactStringSet(universe, weightSymbols) || !exactStringSet(universe, signalSymbols)) {
+      return Result.fail(
+        candidateDevelopmentPlanFailure(`artifact.plan.decisions[${index}].universe`, {
+          expected: universe,
+          observed: { weightSymbols, signalSymbols },
+        }),
+      )
+    }
+    const grossExposure = Object.values(decision.targetWeights).reduce((sum, weight) => sum + weight, 0)
+    const uncappedGrossExposure = decision.signals.reduce((sum, signal) => sum + signal.uncappedWeight, 0)
+    const cappedGrossExposure = decision.signals.reduce((sum, signal) => sum + signal.cappedWeight, 0)
+    const grossTolerance = allocationTolerance * Math.max(1, decision.signals.length)
+    if (!Number.isFinite(grossExposure) || grossExposure < 0 || grossExposure > maximumGrossExposure + grossTolerance) {
+      return Result.fail(
+        candidateDevelopmentPlanFailure(`artifact.plan.decisions[${index}].grossExposure`, {
+          expected: `finite within 0..${maximumGrossExposure}`,
+          observed: grossExposure,
+        }),
+      )
+    }
+    if (
+      !Number.isFinite(uncappedGrossExposure) ||
+      uncappedGrossExposure < 0 ||
+      Math.abs(uncappedGrossExposure - grossExposure) > grossTolerance
+    ) {
+      return Result.fail(
+        candidateDevelopmentPlanFailure(`artifact.plan.decisions[${index}].uncappedGrossExposure`, {
+          expected: 'the bounded final gross exposure',
+          observed: uncappedGrossExposure,
+        }),
+      )
+    }
+    if (
+      !Number.isFinite(cappedGrossExposure) ||
+      cappedGrossExposure < 0 ||
+      cappedGrossExposure > maximumGrossExposure + grossTolerance ||
+      Math.abs(cappedGrossExposure - grossExposure) > grossTolerance
+    ) {
+      return Result.fail(
+        candidateDevelopmentPlanFailure(`artifact.plan.decisions[${index}].cappedGrossExposure`, {
+          expected: 'the bounded final gross exposure',
+          observed: cappedGrossExposure,
+        }),
+      )
+    }
+    if (Math.abs(decision.exposureScale - grossExposure) > grossTolerance) {
+      return Result.fail(
+        candidateDevelopmentPlanFailure(`artifact.plan.decisions[${index}].exposureScale`, {
+          expected: grossExposure,
+          observed: decision.exposureScale,
+        }),
+      )
+    }
+    for (let signalIndex = 0; signalIndex < decision.signals.length; signalIndex += 1) {
+      const signal = decision.signals[signalIndex]
+      const targetWeight = decision.targetWeights[signal.symbol]
+      if (
+        !governedAssets.has(signal.symbol) &&
+        (signal.eligible || signal.targetWeight !== 0 || signal.uncappedWeight !== 0 || signal.cappedWeight !== 0)
+      ) {
+        return Result.fail(
+          candidateDevelopmentPlanFailure(`artifact.plan.decisions[${index}].signals[${signalIndex}].governedAsset`, {
+            expected: { governedAssets: [...governedAssets], eligible: false, weight: 0 },
+            observed: signal,
+          }),
+        )
+      }
+      if (signal.horizons.length !== 1 || signal.horizons[0]?.horizonSessions !== lookbackSessions) {
+        return Result.fail(
+          candidateDevelopmentPlanFailure(`artifact.plan.decisions[${index}].signals[${signalIndex}].horizons`, {
+            expected: [{ horizonSessions: lookbackSessions }],
+            observed: signal.horizons,
+          }),
+        )
+      }
+      if (momentumFeature !== undefined) {
+        const expectedReturn = momentumFeature.totalReturns[signal.symbol]
+        const horizon = signal.horizons[0]
+        if (
+          expectedReturn === undefined ||
+          horizon === undefined ||
+          Math.abs(horizon.return - expectedReturn) > allocationTolerance ||
+          Math.abs(horizon.normalizedTrend - expectedReturn) > allocationTolerance ||
+          Math.abs(signal.dailyVolatility) > allocationTolerance ||
+          Math.abs(
+            signal.annualizedVolatility -
+              (momentumFeature.selectedSymbol === signal.symbol
+                ? momentumFeature.estimatedAnnualizedPortfolioVolatility
+                : 0),
+          ) > allocationTolerance ||
+          Math.abs(signal.compositeScore - expectedReturn) > allocationTolerance ||
+          Math.abs(signal.positiveScore - Math.max(0, expectedReturn)) > allocationTolerance ||
+          signal.eligible !== (momentumFeature.selectedSymbol === signal.symbol)
+        ) {
+          return Result.fail(
+            candidateDevelopmentPlanFailure(`artifact.plan.decisions[${index}].signals[${signalIndex}].momentum`, {
+              expected: {
+                return: expectedReturn,
+                normalizedTrend: expectedReturn,
+                dailyVolatility: 0,
+                annualizedVolatility:
+                  momentumFeature.selectedSymbol === signal.symbol
+                    ? momentumFeature.estimatedAnnualizedPortfolioVolatility
+                    : 0,
+                compositeScore: expectedReturn,
+                positiveScore: expectedReturn === undefined ? undefined : Math.max(0, expectedReturn),
+                eligible: momentumFeature.selectedSymbol === signal.symbol,
+              },
+              observed: signal,
+            }),
+          )
+        }
+      }
+      if (inverseVolatilityFeature !== undefined) {
+        const parameters = strategyIdentity.parameters
+        const expectedReturn = inverseVolatilityFeature.totalReturns[signal.symbol]
+        const expectedAnnualizedVolatility = inverseVolatilityFeature.annualizedVolatilities[signal.symbol]
+        const expectedEligible = parameters.riskAssets.includes(signal.symbol)
+        const expectedScore =
+          expectedEligible && expectedAnnualizedVolatility !== undefined ? 1 / expectedAnnualizedVolatility : 0
+        const horizon = signal.horizons[0]
+        if (
+          expectedReturn === undefined ||
+          expectedAnnualizedVolatility === undefined ||
+          horizon === undefined ||
+          Math.abs(horizon.return - expectedReturn) > allocationTolerance ||
+          Math.abs(horizon.normalizedTrend - expectedReturn) > allocationTolerance ||
+          Math.abs(
+            signal.dailyVolatility - expectedAnnualizedVolatility / Math.sqrt(parameters.annualizationSessions),
+          ) > allocationTolerance ||
+          Math.abs(signal.annualizedVolatility - expectedAnnualizedVolatility) > allocationTolerance ||
+          Math.abs(signal.compositeScore - expectedScore) > allocationTolerance ||
+          Math.abs(signal.positiveScore - expectedScore) > allocationTolerance ||
+          signal.eligible !== expectedEligible
+        ) {
+          return Result.fail(
+            candidateDevelopmentPlanFailure(
+              `artifact.plan.decisions[${index}].signals[${signalIndex}].inverseVolatility`,
+              {
+                expected: {
+                  return: expectedReturn,
+                  normalizedTrend: expectedReturn,
+                  dailyVolatility: expectedAnnualizedVolatility / Math.sqrt(parameters.annualizationSessions),
+                  annualizedVolatility: expectedAnnualizedVolatility,
+                  compositeScore: expectedScore,
+                  positiveScore: expectedScore,
+                  eligible: expectedEligible,
+                },
+                observed: signal,
+              },
+            ),
+          )
+        }
+      }
+      if (
+        targetWeight === undefined ||
+        !Object.is(signal.targetWeight, targetWeight) ||
+        Math.abs(signal.cappedWeight - signal.targetWeight) > allocationTolerance ||
+        Math.abs(signal.uncappedWeight - signal.targetWeight) > allocationTolerance
+      ) {
+        return Result.fail(
+          candidateDevelopmentPlanFailure(`artifact.plan.decisions[${index}].signals[${signalIndex}]`, {
+            expected: {
+              targetWeight,
+              cappedWeight: targetWeight,
+              uncappedWeight: targetWeight,
+            },
+            observed: {
+              targetWeight: signal.targetWeight,
+              cappedWeight: signal.cappedWeight,
+              uncappedWeight: signal.uncappedWeight,
+            },
+          }),
+        )
+      }
+    }
+    if (strategyIdentity.schemaVersion === 'bayn.candidate-development-strategy-identity.v1') {
+      const allocatedWeights = Object.values(decision.targetWeights).filter((weight) => weight > allocationTolerance)
+      if (
+        allocatedWeights.length > 1 ||
+        (allocatedWeights[0] !== undefined &&
+          Math.abs(allocatedWeights[0] - strategyIdentity.parameters.selectedAssetWeight) > allocationTolerance)
+      ) {
+        return Result.fail(
+          candidateDevelopmentPlanFailure(`artifact.plan.decisions[${index}].allocation`, {
+            expected: `all cash or one governed asset at ${strategyIdentity.parameters.selectedAssetWeight}`,
+            observed: decision.targetWeights,
+          }),
+        )
+      }
+    }
+    normalizedDecisions.push({
+      ...decision,
+      covarianceWindow: { ...decision.covarianceWindow, sessionsHash: covarianceWindowHash.success },
+    })
+  }
+  const terminal = plan.decisions.at(-1)
+  if (terminal === undefined || Object.values(terminal.targetWeights).some((weight) => weight !== 0)) {
+    return Result.fail(
+      candidateDevelopmentPlanFailure('artifact.plan.terminalDecision', {
+        expected: 'all-cash target weights',
+        observed: terminal?.targetWeights ?? null,
+      }),
+    )
+  }
+  return Result.succeed({ ...plan, decisions: normalizedDecisions })
+}
+
+const validateCandidateDevelopmentPlanInputManifest = (
+  value: unknown,
+  runtimeInput: CandidateDevelopmentArtifactRuntimeInput,
+  strategyProtocol: CandidateDevelopmentStrategyProtocol,
+  preflight: CandidateDevelopmentPreflightPass,
+): Result.Result<InputManifest, CandidateDevelopmentCommandFailure> => {
+  const decoded = decodeCandidateDevelopmentInputManifest(value)
+  if (Result.isFailure(decoded)) {
+    return Result.fail(candidateDevelopmentPlanFailure('artifact.inputManifest', decoded.failure))
+  }
+  const manifest = decoded.success as InputManifest
+  const { hash: declaredManifestHash, ...manifestMaterial } = manifest
+  const recomputedManifestHash = canonicalHashV1Result(manifestMaterial)
+  if (Result.isFailure(recomputedManifestHash)) {
+    return Result.fail(candidateDevelopmentPlanFailure('artifact.inputManifest.hash', recomputedManifestHash.failure))
+  }
+  if (recomputedManifestHash.success !== declaredManifestHash) {
+    return Result.fail(
+      candidateDevelopmentPlanFailure('artifact.inputManifest.hash', {
+        expected: recomputedManifestHash.success,
+        observed: declaredManifestHash,
+      }),
+    )
+  }
+  const committedMarketData = runtimeInput.sourceManifest.marketData
+  const bindings = [
+    ['hash', runtimeInput.marketData.inputManifestHash, manifest.hash],
+    ['committedInputManifestHash', committedMarketData.inputManifestHash, manifest.hash],
+    ['snapshotId', runtimeInput.marketData.snapshotId, manifest.finalizedSnapshot.snapshotId],
+    [
+      'finalizedSnapshotContentHash',
+      committedMarketData.finalizedSnapshotContentHash,
+      manifest.finalizedSnapshot.contentHash,
+    ],
+    ['sessionCount', runtimeInput.preflightInput.officialSessions.length, manifest.sessionCount],
+    ['rowCount', runtimeInput.marketData.bars.length, manifest.rowCount],
+  ] as const
+  for (const [field, expected, observed] of bindings) {
+    if (expected !== observed) {
+      return Result.fail(candidateDevelopmentPlanFailure(`artifact.inputManifest.${field}`, { expected, observed }))
+    }
+  }
+  const manifestSessions = [manifest.firstSession, manifest.lastSession]
+  const expectedSessions = [
+    runtimeInput.preflightInput.officialSessions[0],
+    runtimeInput.preflightInput.officialSessions.at(-1),
+  ]
+  const manifestUniverse = manifest.symbols.map(({ symbol }) => symbol)
+  if (
+    manifestSessions[0] !== expectedSessions[0] ||
+    manifestSessions[1] !== expectedSessions[1] ||
+    !exactStringSet(strategyProtocol.universe, manifestUniverse)
+  ) {
+    return Result.fail(
+      candidateDevelopmentPlanFailure('artifact.inputManifest.coverage', {
+        expected: { sessions: expectedSessions, universe: strategyProtocol.universe },
+        observed: { sessions: manifestSessions, universe: manifestUniverse },
+      }),
+    )
+  }
+  const expectedBounds = {
+    dataStart: expectedSessions[0],
+    dataEnd: expectedSessions[1],
+    lookbackStart: expectedSessions[0],
+    evaluationStart: preflight.selectedObservationStart,
+    evaluationEnd: preflight.selectedObservationEnd,
+  } as const
+  for (const field of ['dataStart', 'dataEnd', 'lookbackStart', 'evaluationStart', 'evaluationEnd'] as const) {
+    if (manifest.bounds[field] !== expectedBounds[field]) {
+      return Result.fail(
+        candidateDevelopmentPlanFailure(`artifact.inputManifest.bounds.${field}`, {
+          expected: expectedBounds[field],
+          observed: manifest.bounds[field],
+        }),
+      )
+    }
+  }
+  return Result.succeed(manifest)
+}
+
+const selectedCandidateDevelopmentTrace = (
+  simulation: EvaluationResult['simulation'],
+  selectedSessions: readonly IsoDate[],
+): Result.Result<EvaluationResult['simulation'], CandidateDevelopmentCommandFailure> => {
+  const bySession = new Map(simulation.dailyMarks.map((mark) => [mark.sessionDate, mark] as const))
+  const dailyMarks = selectedSessions.map((sessionDate) => bySession.get(sessionDate))
+  const missing = dailyMarks.findIndex((mark) => mark === undefined)
+  if (missing >= 0) {
+    return Result.fail(
+      candidateDevelopmentPlanFailure('artifact.plan.selectedTrace', {
+        index: missing,
+        expected: selectedSessions[missing],
+        observed: null,
+      }),
+    )
+  }
+  return Result.succeed({ ...simulation, dailyMarks: dailyMarks as EvaluationResult['simulation']['dailyMarks'] })
+}
+
+const selectedCandidateDevelopmentPerformance = (
+  series: readonly DailyPerformancePoint[],
+  selectedSessions: readonly IsoDate[],
+  field: string,
+): Result.Result<readonly DailyPerformancePoint[], CandidateDevelopmentCommandFailure> => {
+  const bySession = new Map(series.map((point) => [point.sessionDate, point] as const))
+  const selected = selectedSessions.map((sessionDate) => bySession.get(sessionDate))
+  const missing = selected.findIndex((point) => point === undefined)
+  return missing < 0
+    ? Result.succeed(selected as readonly DailyPerformancePoint[])
+    : Result.fail(
+        candidateDevelopmentPlanFailure(field, {
+          index: missing,
+          expected: selectedSessions[missing],
+          observed: null,
+        }),
+      )
+}
+
+export const buildCandidateDevelopmentPlanEvaluation = (
+  planValue: unknown,
+  inputManifestValue: unknown,
+  runtimeInput: CandidateDevelopmentArtifactRuntimeInput,
+  strategyProtocol: CandidateDevelopmentStrategyProtocol,
+): Result.Result<CandidateDevelopmentCommandEvaluation, CandidateDevelopmentCommandFailure> => {
+  const preflight = preflightCandidateDevelopment(runtimeInput.preflightInput)
+  if (Result.isFailure(preflight) || preflight.success.status !== 'PASS') {
+    return Result.fail(
+      candidateDevelopmentPlanFailure('artifact.plan.preflight', {
+        expected: 'PASS',
+        observed: Result.isFailure(preflight) ? preflight.failure : preflight.success,
+      }),
+    )
+  }
+  const manifest = validateCandidateDevelopmentPlanInputManifest(
+    inputManifestValue,
+    runtimeInput,
+    strategyProtocol,
+    preflight.success,
+  )
+  if (Result.isFailure(manifest)) return Result.fail(manifest.failure)
+  const aligned = alignBars(runtimeInput.marketData.bars, strategyProtocol.universe, manifest.success)
+  if (Result.isFailure(aligned)) {
+    return Result.fail(candidateDevelopmentPlanFailure('artifact.plan.marketData', aligned.failure))
+  }
+  const plan = validateCandidateDevelopmentStrategyPlan(
+    planValue,
+    preflight.success,
+    strategyProtocol,
+    runtimeInput.preflightInput.officialSessions,
+    runtimeInput.preflightInput.signalSessionDates,
+    aligned.success,
+  )
+  if (Result.isFailure(plan)) return Result.fail(plan.failure)
+  const sessions = aligned.success
+  const sessionIndexByDate = new Map(sessions.map((session, index) => [session.date, index] as const))
+  const selectedStartIndex = sessionIndexByDate.get(preflight.success.selectedObservationStart)
+  const selectedEndIndex = sessionIndexByDate.get(preflight.success.selectedObservationEnd)
+  if (
+    selectedStartIndex === undefined ||
+    selectedStartIndex < 1 ||
+    selectedEndIndex === undefined ||
+    selectedEndIndex < selectedStartIndex
+  ) {
+    return Result.fail(
+      candidateDevelopmentPlanFailure('artifact.plan.evaluationWindow', {
+        selectedStart: preflight.success.selectedObservationStart,
+        selectedEnd: preflight.success.selectedObservationEnd,
+      }),
+    )
+  }
+  const targets: SimulationTarget[] = []
+  for (let index = 0; index < plan.success.decisions.length; index += 1) {
+    const planned = plan.success.decisions[index]
+    const signalIndex = sessionIndexByDate.get(planned.signalDate)
+    const executionIndex = sessionIndexByDate.get(planned.executionDate)
+    if (signalIndex === undefined || executionIndex === undefined || executionIndex !== signalIndex + 1) {
+      return Result.fail(
+        candidateDevelopmentPlanFailure(`artifact.plan.decisions[${index}].indices`, {
+          expected: 'adjacent governed sessions',
+          observed: { signalIndex, executionIndex },
+        }),
+      )
+    }
+    const { executionDate: _, ...decision } = planned
+    targets.push({ signalIndex, executionIndex, weights: planned.targetWeights, decision })
+  }
+  const accountingStartIndex = selectedStartIndex - 1
+  const evaluationSessions = sessions.slice(0, selectedEndIndex + 1)
+  const baselineSimulation = simulate(
+    evaluationSessions,
+    targets,
+    accountingStartIndex,
+    strategyProtocol,
+    MICROS,
+    runtimeInput.baselineRunId,
+    true,
+  )
+  if (Result.isFailure(baselineSimulation) || baselineSimulation.success.simulation === null) {
+    return Result.fail(
+      candidateDevelopmentPlanFailure(
+        'artifact.plan.baselineSimulation',
+        Result.isFailure(baselineSimulation) ? baselineSimulation.failure : 'missing trace',
+      ),
+    )
+  }
+  const stressedSimulation = simulate(
+    evaluationSessions,
+    targets,
+    accountingStartIndex,
+    strategyProtocol,
+    MICROS * 2n,
+    runtimeInput.stressedRunId,
+    true,
+  )
+  if (Result.isFailure(stressedSimulation) || stressedSimulation.success.simulation === null) {
+    return Result.fail(
+      candidateDevelopmentPlanFailure(
+        'artifact.plan.stressedSimulation',
+        Result.isFailure(stressedSimulation) ? stressedSimulation.failure : 'missing trace',
+      ),
+    )
+  }
+  const selectedSessions = preflight.success.selectedObservationSessions
+  const baselineTrace = selectedCandidateDevelopmentTrace(baselineSimulation.success.simulation, selectedSessions)
+  const stressedTrace = selectedCandidateDevelopmentTrace(stressedSimulation.success.simulation, selectedSessions)
+  const strategySeries = selectedCandidateDevelopmentPerformance(
+    baselineSimulation.success.dailyPerformance,
+    selectedSessions,
+    'artifact.plan.strategySeries',
+  )
+  const stressedSeries = selectedCandidateDevelopmentPerformance(
+    stressedSimulation.success.dailyPerformance,
+    selectedSessions,
+    'artifact.plan.stressedSeries',
+  )
+  if (Result.isFailure(baselineTrace)) return Result.fail(baselineTrace.failure)
+  if (Result.isFailure(stressedTrace)) return Result.fail(stressedTrace.failure)
+  if (Result.isFailure(strategySeries)) return Result.fail(strategySeries.failure)
+  if (Result.isFailure(stressedSeries)) return Result.fail(stressedSeries.failure)
+  const initialCapitalMicros = strategyProtocol.initialCapitalMicros
+  const baselinePredecessor = baselineSimulation.success.simulation.dailyMarks[0]
+  const stressedPredecessor = stressedSimulation.success.simulation.dailyMarks[0]
+  if (baselinePredecessor === undefined || stressedPredecessor === undefined) {
+    return Result.fail(candidateDevelopmentPlanFailure('artifact.plan.accountingPredecessor', 'missing'))
+  }
+  const strategyMetrics = recomputePerformanceMetrics(
+    'strategy',
+    strategySeries.success,
+    initialCapitalMicros,
+    performanceBaselineFromPoint(baselinePredecessor),
+  )
+  const stressedMetrics = recomputePerformanceMetrics(
+    'double-cost-stressed',
+    stressedSeries.success,
+    initialCapitalMicros,
+    performanceBaselineFromPoint(stressedPredecessor),
+  )
+  if (Result.isFailure(strategyMetrics)) return Result.fail(strategyMetrics.failure)
+  if (Result.isFailure(stressedMetrics)) return Result.fail(stressedMetrics.failure)
+  const terminalTarget = targets.at(-1)
+  if (terminalTarget === undefined) {
+    return Result.fail(candidateDevelopmentPlanFailure('artifact.plan.terminalTarget', 'missing'))
+  }
+  const benchmarkSymbol = strategyProtocol.benchmarks.symbol
+  const benchmarkProtocol: SimulationProtocol = { ...strategyProtocol, universe: [benchmarkSymbol] }
+  const directTargets: SimulationTarget[] = []
+  for (let index = 0; index < targets.length - 1; index += 1) {
+    const target = targets[index]
+    const weights = directVolatilityWeights(sessions, target.signalIndex, benchmarkProtocol)
+    if (Result.isFailure(weights)) {
+      return Result.fail(candidateDevelopmentPlanFailure(`artifact.plan.directVolatility[${index}]`, weights.failure))
+    }
+    directTargets.push({
+      signalIndex: target.signalIndex,
+      executionIndex: target.executionIndex,
+      weights: weights.success,
+    })
+  }
+  const benchmarkRunId = canonicalEvidenceHash('benchmarks.runId', {
+    schemaVersion: 'bayn.candidate-development-benchmark-run.v1',
+    candidateRunId: runtimeInput.baselineRunId,
+    marketDataContentHash: runtimeInput.marketData.contentHash,
+    policy: strategyProtocol.benchmarks,
+  })
+  if (Result.isFailure(benchmarkRunId)) return Result.fail(benchmarkRunId.failure)
+  const buyAndHoldSimulation = simulate(
+    evaluationSessions,
+    [
+      {
+        signalIndex: accountingStartIndex,
+        executionIndex: selectedStartIndex,
+        weights: { [benchmarkSymbol]: 1 },
+      },
+      {
+        signalIndex: terminalTarget.signalIndex,
+        executionIndex: terminalTarget.executionIndex,
+        weights: { [benchmarkSymbol]: 0 },
+      },
+    ],
+    accountingStartIndex,
+    benchmarkProtocol,
+    MICROS,
+    benchmarkRunId.success,
+    false,
+  )
+  const directVolatilitySimulation = simulate(
+    evaluationSessions,
+    [
+      ...directTargets,
+      {
+        signalIndex: terminalTarget.signalIndex,
+        executionIndex: terminalTarget.executionIndex,
+        weights: { [benchmarkSymbol]: 0 },
+      },
+    ],
+    accountingStartIndex,
+    benchmarkProtocol,
+    MICROS,
+    benchmarkRunId.success,
+    false,
+  )
+  if (Result.isFailure(buyAndHoldSimulation)) {
+    return Result.fail(candidateDevelopmentPlanFailure('artifact.plan.buyAndHold', buyAndHoldSimulation.failure))
+  }
+  if (Result.isFailure(directVolatilitySimulation)) {
+    return Result.fail(
+      candidateDevelopmentPlanFailure('artifact.plan.directVolatility', directVolatilitySimulation.failure),
+    )
+  }
+  const buyAndHoldSeries = selectRebuiltBenchmarkSeries(
+    buyAndHoldSimulation.success.dailyPerformance,
+    selectedSessions,
+    'buy-and-hold',
+  )
+  const directVolatilitySeries = selectRebuiltBenchmarkSeries(
+    directVolatilitySimulation.success.dailyPerformance,
+    selectedSessions,
+    'direct-volatility-timing',
+  )
+  if (Result.isFailure(buyAndHoldSeries)) return Result.fail(buyAndHoldSeries.failure)
+  if (Result.isFailure(directVolatilitySeries)) return Result.fail(directVolatilitySeries.failure)
+  const buyAndHoldMetrics = recomputePerformanceMetrics(
+    'buy-and-hold',
+    buyAndHoldSeries.success.series,
+    initialCapitalMicros,
+    buyAndHoldSeries.success.performanceBaseline,
+  )
+  const directVolatilityMetrics = recomputePerformanceMetrics(
+    'direct-volatility-timing',
+    directVolatilitySeries.success.series,
+    initialCapitalMicros,
+    directVolatilitySeries.success.performanceBaseline,
+  )
+  if (Result.isFailure(buyAndHoldMetrics)) return Result.fail(buyAndHoldMetrics.failure)
+  if (Result.isFailure(directVolatilityMetrics)) return Result.fail(directVolatilityMetrics.failure)
+  const baselineAccountingTerminal = baselineSimulation.success.simulation.dailyMarks.at(-1)
+  const stressedAccountingTerminal = stressedSimulation.success.simulation.dailyMarks.at(-1)
+  if (baselineAccountingTerminal === undefined || stressedAccountingTerminal === undefined) {
+    return Result.fail(candidateDevelopmentPlanFailure('artifact.plan.accountingTerminal', 'missing'))
+  }
+  const baselineProof = reconcileMarkedEquity({
+    runId: runtimeInput.baselineRunId,
+    initialCapitalMicros,
+    evaluatorTotalFeesMicros: baselineAccountingTerminal.cumulativeFeesMicros,
+    evaluatorEndingEquityMicros: strategyMetrics.success.endingEquityMicros,
+    events: baselineSimulation.success.events,
+    simulation: baselineSimulation.success.simulation,
+  })
+  const stressedProof = reconcileMarkedEquity({
+    runId: runtimeInput.stressedRunId,
+    initialCapitalMicros,
+    evaluatorTotalFeesMicros: stressedAccountingTerminal.cumulativeFeesMicros,
+    evaluatorEndingEquityMicros: stressedMetrics.success.endingEquityMicros,
+    events: stressedSimulation.success.events,
+    simulation: stressedSimulation.success.simulation,
+  })
+  if (Result.isFailure(baselineProof)) {
+    return Result.fail(candidateDevelopmentPlanFailure('artifact.plan.baselineReconciliation', baselineProof.failure))
+  }
+  if (Result.isFailure(stressedProof)) {
+    return Result.fail(candidateDevelopmentPlanFailure('artifact.plan.stressedReconciliation', stressedProof.failure))
+  }
+  const selectedObservationStart = preflight.success.selectedObservationStart
+  const selectedObservationEnd = preflight.success.selectedObservationEnd
+  const selectedBaselineSignalDecisions = baselineSimulation.success.signalDecisions.filter(
+    ({ executionDate }) => executionDate >= selectedObservationStart && executionDate <= selectedObservationEnd,
+  )
+  const selectedStressedSignalDecisions = stressedSimulation.success.signalDecisions.filter(
+    ({ executionDate }) => executionDate >= selectedObservationStart && executionDate <= selectedObservationEnd,
+  )
+  const protocolHash = canonicalEvidenceHash('strategyProtocol', strategyProtocol)
+  if (Result.isFailure(protocolHash)) return Result.fail(protocolHash.failure)
+  const baseline: EvaluationResult = {
+    schemaVersion: 'bayn.evaluation.v6',
+    runId: runtimeInput.baselineRunId,
+    codeRevision: runtimeInput.sourceRevision,
+    protocolHash: protocolHash.success,
+    initialCapitalMicros,
+    inputManifest: manifest.success,
+    strategy: strategyMetrics.success,
+    buyAndHold: buyAndHoldMetrics.success,
+    directVolTiming: directVolatilityMetrics.success,
+    doubleCostStrategy: stressedMetrics.success,
+    verdict: buildVerdict(
+      strategyMetrics.success,
+      buyAndHoldMetrics.success,
+      directVolatilityMetrics.success,
+      stressedMetrics.success,
+      strategyProtocol,
+    ),
+    events: baselineSimulation.success.events,
+    signalDecisions: selectedBaselineSignalDecisions,
+    simulation: baselineTrace.success,
+    benchmarkSeries: {
+      buyAndHold: buyAndHoldSeries.success.series,
+      directVolTiming: directVolatilitySeries.success.series,
+      doubleCostStrategy: stressedSeries.success,
+    },
+    equitySeries: baselineProof.success.equitySeries,
+    markedEquityReconciliation: baselineProof.success.reconciliation,
+  }
+  const comparisonSeries = prepareQualificationSeries(baseline)
+  if (Result.isFailure(comparisonSeries)) {
+    return Result.fail(candidateDevelopmentPlanFailure('artifact.plan.comparisonSeries', comparisonSeries.failure))
+  }
+  const boundComparisonSeries = validateCandidateDevelopmentComparisonSeriesBinding(
+    preflight.success,
+    baseline,
+    comparisonSeries.success,
+  )
+  if (Result.isFailure(boundComparisonSeries)) {
+    return Result.fail(candidateDevelopmentPlanFailure('artifact.plan.comparisonSeries', boundComparisonSeries.failure))
+  }
+  const comparisonSemantics = buildCandidateDevelopmentComparisonSemanticsEvidence(
+    preflight.success,
+    boundComparisonSeries.success,
+  )
+  if (Result.isFailure(comparisonSemantics)) {
+    return Result.fail(
+      candidateDevelopmentPlanFailure('artifact.plan.comparisonSemantics', comparisonSemantics.failure),
+    )
+  }
+  return Result.succeed({
+    baseline,
+    comparisonSemantics: comparisonSemantics.success,
+    stressed: {
+      signalDecisions: selectedStressedSignalDecisions,
+      simulation: stressedTrace.success,
+    },
+    accounting: {
+      schemaVersion: 'bayn.candidate-development-accounting-evidence.v2',
+      runId: runtimeInput.baselineRunId,
+      initialCapitalMicros,
+      evaluatorTotalFeesMicros: baselineAccountingTerminal.cumulativeFeesMicros,
+      evaluatorEndingEquityMicros: strategyMetrics.success.endingEquityMicros,
+      events: baselineSimulation.success.events,
+      baselineSimulation: baselineSimulation.success.simulation,
+      equitySeries: baselineProof.success.equitySeries,
+      markedEquityReconciliation: baselineProof.success.reconciliation,
+      signalDecisions: baselineSimulation.success.signalDecisions,
+      stressedRunId: runtimeInput.stressedRunId,
+      stressedEvaluatorTotalFeesMicros: stressedAccountingTerminal.cumulativeFeesMicros,
+      stressedEvaluatorEndingEquityMicros: stressedMetrics.success.endingEquityMicros,
+      stressedEvents: stressedSimulation.success.events,
+      stressedSimulation: stressedSimulation.success.simulation,
+      stressedEquitySeries: stressedProof.success.equitySeries,
+      stressedMarkedEquityReconciliation: stressedProof.success.reconciliation,
+    },
+    marketData: runtimeInput.marketData,
+  })
+}
 
 const candidateDevelopmentArtifactSource = (moduleUrl: string): string => {
   const prefix = 'data:text/javascript;base64,'
@@ -9571,10 +10967,10 @@ const candidateDevelopmentArtifactContext = (): vm.Context => {
   return context
 }
 
-const runCandidateDevelopmentArtifactEvaluation = (
+const runCandidateDevelopmentArtifactComputation = (
   context: vm.Context,
   runtimeInput: CandidateDevelopmentArtifactRuntimeInput,
-): CandidateDevelopmentCommandEvaluation => {
+): unknown => {
   const runtimeInputJson = JSON.stringify(runtimeInput)
   Object.defineProperty(context, '__candidateDevelopmentRuntimeInputJson', {
     value: runtimeInputJson,
@@ -9591,19 +10987,35 @@ const runCandidateDevelopmentArtifactEvaluation = (
             return Object.freeze(value)
           }
           const runtimeInput = deepFreeze(JSON.parse(globalThis.__candidateDevelopmentRuntimeInputJson))
-          const evaluation = globalThis.__candidateDevelopmentArtifact.buildEvaluation(
-            runtimeInput,
-          )
+          const builderName =
+            globalThis.__candidateDevelopmentArtifact.schemaVersion === '${candidateDevelopmentPlanArtifactSchemaVersion}'
+              ? 'buildPlan'
+              : 'buildEvaluation'
+          const evaluation = globalThis.__candidateDevelopmentArtifact[builderName](runtimeInput)
           if (
             evaluation !== null &&
             (typeof evaluation === 'object' || typeof evaluation === 'function') &&
             typeof evaluation.then === 'function'
           ) {
-            throw new TypeError('candidate artifact buildEvaluation must be synchronous')
+            throw new TypeError('candidate artifact ' + builderName + ' must be synchronous')
           }
           const encoded = JSON.stringify(evaluation)
           if (typeof encoded !== 'string') {
-            throw new TypeError('candidate artifact evaluation must be JSON serializable')
+            throw new TypeError('candidate artifact output must be JSON serializable')
+          }
+          if (builderName === 'buildPlan') {
+            const repeated = globalThis.__candidateDevelopmentArtifact[builderName](runtimeInput)
+            if (
+              repeated !== null &&
+              (typeof repeated === 'object' || typeof repeated === 'function') &&
+              typeof repeated.then === 'function'
+            ) {
+              throw new TypeError('candidate artifact buildPlan must be synchronous')
+            }
+            const repeatedEncoded = JSON.stringify(repeated)
+            if (repeatedEncoded !== encoded) {
+              throw new TypeError('candidate artifact buildPlan must be deterministic')
+            }
           }
           return encoded
         })()
@@ -9611,12 +11023,8 @@ const runCandidateDevelopmentArtifactEvaluation = (
       context,
       { timeout: candidateDevelopmentArtifactEvaluationTimeoutMs },
     )
-    if (typeof output !== 'string') throw new TypeError('candidate artifact evaluation did not return JSON')
-    const decoded = validateCandidateDevelopmentCommandEvaluation(JSON.parse(output) as unknown)
-    if (Result.isFailure(decoded)) throw decoded.failure
-    const sourceBinding = validateCandidateDevelopmentVerifiedSource(decoded.success, runtimeInput)
-    if (Result.isFailure(sourceBinding)) throw sourceBinding.failure
-    return decoded.success
+    if (typeof output !== 'string') throw new TypeError('candidate artifact output did not return JSON')
+    return JSON.parse(output) as unknown
   } finally {
     Reflect.deleteProperty(context, '__candidateDevelopmentRuntimeInputJson')
   }
@@ -9628,6 +11036,12 @@ interface CandidateDevelopmentArtifactWorkerRequest {
   readonly moduleUrl: string
   readonly verifiedFiles: CandidateDevelopmentVerifiedSourceFiles
   readonly runtimeInput?: CandidateDevelopmentArtifactRuntimeInput
+}
+
+interface CandidateDevelopmentArtifactRuntimeEnvelope {
+  readonly schemaVersion: unknown
+  readonly inputManifest: unknown
+  readonly output: unknown
 }
 
 type CandidateDevelopmentArtifactWorkerResponse =
@@ -9683,14 +11097,19 @@ const loadCandidateDevelopmentArtifactContext = async (
         ) {
           throw new TypeError('candidateDevelopmentArtifact export is missing')
         }
-        if (typeof globalThis.__candidateDevelopmentArtifact.buildEvaluation !== 'function') {
-          throw new TypeError('candidateDevelopmentArtifact.buildEvaluation is missing')
+        const builderName =
+          globalThis.__candidateDevelopmentArtifact.schemaVersion === '${candidateDevelopmentPlanArtifactSchemaVersion}'
+            ? 'buildPlan'
+            : 'buildEvaluation'
+        if (typeof globalThis.__candidateDevelopmentArtifact[builderName] !== 'function') {
+          throw new TypeError('candidateDevelopmentArtifact.' + builderName + ' is missing')
         }
         return JSON.stringify({
           schemaVersion: globalThis.__candidateDevelopmentArtifact.schemaVersion,
           input: globalThis.__candidateDevelopmentArtifact.input,
           strategyProtocol: globalThis.__candidateDevelopmentArtifact.strategyProtocol,
           structuralBindings: globalThis.__candidateDevelopmentArtifact.structuralBindings,
+          inputManifest: globalThis.__candidateDevelopmentArtifact.inputManifest,
         })
       })()
     `,
@@ -9707,7 +11126,19 @@ const runCandidateDevelopmentArtifactWorkerTask = async (
   const loaded = await loadCandidateDevelopmentArtifactContext(request.moduleUrl, request.verifiedFiles)
   if (request.mode === 'definition') return loaded.definition
   if (request.runtimeInput === undefined) throw new TypeError('candidate artifact runtime input is missing')
-  return runCandidateDevelopmentArtifactEvaluation(loaded.context, request.runtimeInput)
+  const definition = recordOf(loaded.definition)
+  const output = runCandidateDevelopmentArtifactComputation(loaded.context, request.runtimeInput)
+  if (definition?.schemaVersion === candidateDevelopmentArtifactSchemaVersion) {
+    const decoded = validateCandidateDevelopmentCommandEvaluation(output)
+    if (Result.isFailure(decoded)) throw decoded.failure
+    const sourceBinding = validateCandidateDevelopmentVerifiedSource(decoded.success, request.runtimeInput)
+    if (Result.isFailure(sourceBinding)) throw sourceBinding.failure
+  }
+  return {
+    schemaVersion: definition?.schemaVersion,
+    inputManifest: definition?.inputManifest,
+    output,
+  } satisfies CandidateDevelopmentArtifactRuntimeEnvelope
 }
 
 class CandidateDevelopmentArtifactWorkerError extends Data.TaggedError('CandidateDevelopmentArtifactWorkerError')<{
@@ -9787,25 +11218,54 @@ export const executeCandidateDevelopmentArtifactRuntime = (
   verifiedFiles: CandidateDevelopmentVerifiedSourceFiles,
   strategyProtocol: CandidateDevelopmentStrategyProtocol,
   runtimeInput: CandidateDevelopmentArtifactRuntimeInput,
-): Effect.Effect<CandidateDevelopmentCommandEvaluation, CandidateDevelopmentCommandFailure> =>
-  Effect.fromResult(
+): Effect.Effect<CandidateDevelopmentCommandEvaluation, CandidateDevelopmentCommandFailure> => {
+  const { marketData: unverifiedMarketData, ...runtimeContext } = runtimeInput
+  return Effect.fromResult(
     validateCandidateDevelopmentRuntimeMarketData(
-      runtimeInput.marketData,
-      runtimeInput,
+      unverifiedMarketData,
+      runtimeContext,
       strategyProtocol,
-      runtimeInput.preflightInput,
+      runtimeContext.preflightInput,
     ),
   ).pipe(
     Effect.flatMap((marketData) =>
-      runCandidateDevelopmentArtifactWorker<unknown>({
-        _tag: 'CandidateDevelopmentArtifactWorkerRequest',
-        mode: 'evaluation',
-        moduleUrl,
-        verifiedFiles,
-        runtimeInput: { ...runtimeInput, marketData },
-      }),
+      pipe({ ...runtimeContext, marketData }, (verifiedRuntimeInput) =>
+        runCandidateDevelopmentArtifactWorker<CandidateDevelopmentArtifactRuntimeEnvelope>({
+          _tag: 'CandidateDevelopmentArtifactWorkerRequest',
+          mode: 'evaluation',
+          moduleUrl,
+          verifiedFiles,
+          runtimeInput: verifiedRuntimeInput,
+        }).pipe(Effect.map((envelope) => ({ envelope, runtimeInput: verifiedRuntimeInput }))),
+      ),
     ),
-    Effect.flatMap((value) => Effect.fromResult(validateCandidateDevelopmentCommandEvaluation(value))),
+    Effect.flatMap(({ envelope, runtimeInput: verifiedRuntimeInput }) => {
+      const evaluation =
+        envelope.schemaVersion === candidateDevelopmentArtifactSchemaVersion
+          ? validateCandidateDevelopmentCommandEvaluation(envelope.output)
+          : envelope.schemaVersion === candidateDevelopmentPlanArtifactSchemaVersion
+            ? buildCandidateDevelopmentPlanEvaluation(
+                envelope.output,
+                envelope.inputManifest,
+                verifiedRuntimeInput,
+                strategyProtocol,
+              )
+            : Result.fail<CandidateDevelopmentCommandFailure>({
+                _tag: 'CandidateDevelopmentCommandProgramInvalid',
+                reason: 'schema-version-mismatch',
+              })
+      return Effect.fromResult(
+        pipe(
+          evaluation,
+          Result.flatMap((decoded) =>
+            pipe(
+              validateCandidateDevelopmentVerifiedSource(decoded, verifiedRuntimeInput),
+              Result.map(() => decoded),
+            ),
+          ),
+        ),
+      )
+    }),
     Effect.mapError(
       (cause): CandidateDevelopmentCommandFailure =>
         cause instanceof CandidateDevelopmentArtifactWorkerError
@@ -9816,6 +11276,7 @@ export const executeCandidateDevelopmentArtifactRuntime = (
           : cause,
     ),
   )
+}
 
 export const evaluateCandidateDevelopmentArtifact: CandidateDevelopmentModuleImporter = (
   moduleUrl,
@@ -9835,12 +11296,23 @@ export const evaluateCandidateDevelopmentArtifact: CandidateDevelopmentModuleImp
       verifiedFiles,
     }).pipe(Effect.mapError(moduleLoadFailure))
     const definition = recordOf(definitionValue)
-    if (definition?.schemaVersion !== candidateDevelopmentArtifactSchemaVersion) {
+    if (
+      definition?.schemaVersion !== candidateDevelopmentArtifactSchemaVersion &&
+      definition?.schemaVersion !== candidateDevelopmentPlanArtifactSchemaVersion
+    ) {
       return yield* Effect.fail<CandidateDevelopmentCommandFailure>({
         _tag: 'CandidateDevelopmentCommandModuleLoadFailed',
         modulePath: verifiedFiles.modulePath,
         cause: new TypeError('candidate artifact schema version is invalid'),
       })
+    }
+    if (definition.schemaVersion === candidateDevelopmentPlanArtifactSchemaVersion) {
+      yield* Effect.fromResult(
+        pipe(
+          decodeCandidateDevelopmentInputManifest(definition.inputManifest),
+          Result.mapError((cause) => moduleLoadFailure(cause)),
+        ),
+      )
     }
     const strategyProtocol = yield* Effect.fromResult(
       decodeCandidateDevelopmentStrategyProtocol(definition.strategyProtocol),


### PR DESCRIPTION
## Summary

- add a compact `bayn.candidate-development-plan-artifact.v1` contract whose reviewed candidate code returns only a deterministic strategy decision plan
- validate exact schedule, universe, exposure, terminal cash, manifest, source, and decoded runtime-data bindings before any trusted evaluation
- keep simulation, doubled-cost stress, benchmarks, metrics, reconciliation, and comparison evidence inside the reviewed Bayn host while retaining v1 compatibility
- cover real VM execution, nondeterminism, incomplete plans, tampered manifests, and decoded-witness reuse without running Candidates 19 or 20

## Related Issues

Closes PROOMPT-447

## Testing

- `bun test services/bayn/src/candidate-development-command.test.ts` — 96 pass, 0 fail
- `bun run --cwd services/bayn test` — 1,202 pass, 153 PostgreSQL-skipped, 0 fail
- `bun run --cwd services/bayn test:postgres` — integration files selected; skipped locally because no PostgreSQL URL is configured (hosted migrated PostgreSQL required)
- `bun run --cwd services/bayn tsc`
- `bun run --cwd services/bayn lint:effect`
- `bun run --cwd services/bayn lint:oxlint:type` — 0 errors; pre-existing generated Candidate 17/18/19 warnings only
- `bun run --cwd services/bayn build`
- `bun node_modules/oxfmt/bin/oxfmt --check services/bayn/src/candidate-development-command.ts services/bayn/src/candidate-development-command.test.ts`
- `git diff --check HEAD^`

## Breaking Changes

None. Existing `bayn.candidate-development-artifact.v1` modules remain supported.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] Follow-up is tracked in PROOMPT-447: merge, natural release/GitOps proof, then one fresh result-blind Candidate 21 preregistration.
