### PR TITLE
feat(bayn): support local candidate development

### DIFF
--- a/.github/workflows/bayn-build-push.yml
+++ b/.github/workflows/bayn-build-push.yml
@@ -9,35 +9,10 @@ on:
   push:
     branches:
       - main
-    paths:
-      - 'services/bayn/**'
-      - 'packages/scripts/src/bayn/update-manifests.ts'
-      - 'packages/scripts/src/bayn/verify-release-review.ts'
-      - 'services/bayn/release-review-remediations/**'
-      - 'nix/images/bayn.nix'
-      - 'nix/images/bayn-runtime-root.nix'
-      - 'nix/images/bun-workspace-service.nix'
-      - 'nix/images/bun-workspace-deps-source.nix'
-      - 'nix/packages.nix'
-      - 'nix/cache-push.sh'
-      - 'nix/ci-nix-oci-summary.sh'
-      - 'nix/ci-run-timed.sh'
-      - 'nix/oci-inspect-archive.sh'
-      - 'nix/oci-push.sh'
-      - 'nix/oci-release-contract.sh'
-      - 'nix/verify-bayn-image-command.sh'
-      - 'flake.nix'
-      - 'flake.lock'
-      - 'bun.lock'
-      - 'package.json'
-      - '**/package.json'
-      - '.npmrc'
-      - 'bunfig.toml'
-      - 'patches/**'
-      - 'tsconfig.base.json'
-      - '.github/actions/setup-nix-toolchain/**'
-      - '.github/workflows/bayn-*.yml'
-      - '.github/workflows/nix-oci-build-common.yml'
+    # Qualification binds to sha-${GITHUB_SHA}; publish an immutable image for
+    # every main SHA. The release-review verifier still gates Bayn-affecting
+    # changes, while unrelated commits receive an exact-source image without a
+    # review requirement.
   issue_comment:
     types:
       - created

--- a/.github/workflows/bayn-qualification.yml
+++ b/.github/workflows/bayn-qualification.yml
@@ -48,7 +48,13 @@ jobs:
         if: steps.dormancy.outputs.dormant == 'true'
         run: echo 'No credentials, Signal data, PostgreSQL state, holdout, image, or qualification command were accessed.'
 
-      - name: Bind the exact promoted unpinned qualification image
+      - name: Set up the runner image-build toolchain
+        if: steps.dormancy.outputs.dormant == 'false'
+        uses: ./.github/actions/setup-nix-toolchain
+        with:
+          require-preinstalled: 'true'
+
+      - name: Build the exact checked-out source image locally
         id: image
         if: steps.dormancy.outputs.dormant == 'false'
         shell: bash
@@ -57,54 +63,26 @@ jobs:
           test "$(git rev-parse HEAD)" = "${GITHUB_SHA}"
           test "$(git rev-parse refs/remotes/origin/main)" = "${GITHUB_SHA}"
 
-          deployment='argocd/applications/bayn/deployment.yaml'
-          read_bayn_env() {
-            local name="$1"
-            NAME="$name" yq -er '
-              [.spec.template.spec.containers[]
-                | select(.name == "bayn")
-                | .env[]
-                | select(.name == strenv(NAME) and has("value"))
-                | .value]
-              | select(length == 1)
-              | .[0]
-            ' "$deployment"
-          }
+          image_link="${RUNNER_TEMP}/bayn-qualification-image"
+          image_load_log="${RUNNER_TEMP}/bayn-qualification-image-load.log"
+          rm -f -- "$image_link" "$image_load_log"
+          nix build .#bayn-image --print-build-logs --out-link "$image_link"
+          image_tar="$(readlink -f "$image_link")"
+          test -f "$image_tar"
 
-          qualification_pin_count="$(NAME=BAYN_QUALIFICATION_RUN_ID yq -r '
-            [.spec.template.spec.containers[]
-              | select(.name == "bayn")
-              | .env[]
-              | select(.name == strenv(NAME))]
-            | length
-          ' "$deployment")"
-          test "$qualification_pin_count" = 0
+          docker load --input "$image_tar" | tee "$image_load_log"
+          image_tag="$(sed -n 's/^Loaded image: //p' "$image_load_log" | tail -n 1)"
+          test -n "$image_tag"
+          image_id="$(docker image inspect "$image_tag" --format '{{.Id}}')"
+          [[ "$image_id" =~ ^sha256:[0-9a-f]{64}$ ]]
+          echo "tag=${image_tag}" >> "$GITHUB_OUTPUT"
+          echo "reference=${image_tag}@${image_id}" >> "$GITHUB_OUTPUT"
 
-          source_sha="$(read_bayn_env BAYN_CODE_REVISION)"
-          image_repository="$(read_bayn_env BAYN_IMAGE_REPOSITORY)"
-          image_digest="$(read_bayn_env BAYN_IMAGE_DIGEST)"
-          [[ "$source_sha" =~ ^[0-9a-f]{40}$ ]]
-          [[ "$image_repository" =~ ^[A-Za-z0-9._:/-]+$ ]]
-          [[ "$image_digest" =~ ^sha256:[0-9a-f]{64}$ ]]
-
-          image_reference="${image_repository}@${image_digest}"
-          echo "reference=${image_reference}" >> "$GITHUB_OUTPUT"
-
-      - name: Pull and verify the exact qualification image
+      - name: Preflight the exact source image without credentials or network
         if: steps.dormancy.outputs.dormant == 'false'
         shell: bash
         env:
-          IMAGE_REFERENCE: ${{ steps.image.outputs.reference }}
-        run: |
-          set -euo pipefail
-          docker pull "$IMAGE_REFERENCE"
-          docker image inspect "$IMAGE_REFERENCE" --format '{{json .RepoDigests}}' |
-            jq -e --arg expected "$IMAGE_REFERENCE" 'index($expected) != null' >/dev/null
-
-      - name: Preflight immutable qualification evidence without credentials
-        if: steps.dormancy.outputs.dormant == 'false'
-        shell: bash
-        env:
+          IMAGE_TAG: ${{ steps.image.outputs.tag }}
           IMAGE_REFERENCE: ${{ steps.image.outputs.reference }}
         run: |
           set -euo pipefail
@@ -112,6 +90,8 @@ jobs:
           rm -f -- "$preflight"
 
           docker run --rm \
+            --pull=never \
+            --network none \
             --read-only \
             --user "$(id -u):$(id -g)" \
             --tmpfs /tmp:rw,noexec,nosuid,size=64m \
@@ -126,7 +106,7 @@ jobs:
             -e BAYN_QUALIFICATION_IMAGE_REFERENCE="$IMAGE_REFERENCE" \
             -e BAYN_QUALIFICATION_MODE=preflight \
             --entrypoint bayn-qualification-collector \
-            "$IMAGE_REFERENCE" | tee "$preflight"
+            "$IMAGE_TAG" | tee "$preflight"
 
           mapfile -t preflight_lines < <(grep '^BAYN_QUALIFICATION_TERMINAL=' "$preflight")
           test "${#preflight_lines[@]}" -eq 1
@@ -140,11 +120,12 @@ jobs:
             and (.preregistrationHash | test("^[0-9a-f]{64}$"))
           ' <<< "${preflight_lines[0]#BAYN_QUALIFICATION_TERMINAL=}" >/dev/null
 
-      - name: Collect, lock, execute once, and independently audit
+      - name: Collect, lock, execute once, and independently audit the sealed holdout
         id: qualify
         if: steps.dormancy.outputs.dormant == 'false'
         shell: bash
         env:
+          IMAGE_TAG: ${{ steps.image.outputs.tag }}
           IMAGE_REFERENCE: ${{ steps.image.outputs.reference }}
           GITHUB_TOKEN: ${{ github.token }}
           BAYN_CLICKHOUSE_USERNAME: ${{ secrets.BAYN_QUALIFICATION_CLICKHOUSE_USERNAME }}
@@ -164,6 +145,7 @@ jobs:
           rm -f -- "$log" "$terminal"
 
           docker run --rm \
+            --pull=never \
             --network host \
             --read-only \
             --user "$(id -u):$(id -g)" \
@@ -188,7 +170,7 @@ jobs:
             -e BAYN_QUALIFICATION_IMAGE_REFERENCE="$IMAGE_REFERENCE" \
             -e BAYN_QUALIFICATION_MODE=execute \
             --entrypoint bayn-qualification-collector \
-            "$IMAGE_REFERENCE" | tee "$log"
+            "$IMAGE_TAG" | tee "$log"
 
           mapfile -t terminal_lines < <(grep '^BAYN_QUALIFICATION_TERMINAL=' "$log")
           test "${#terminal_lines[@]}" -eq 1

--- a/.github/workflows/bayn-qualification.yml
+++ b/.github/workflows/bayn-qualification.yml
@@ -48,41 +48,37 @@ jobs:
         if: steps.dormancy.outputs.dormant == 'true'
         run: echo 'No credentials, Signal data, PostgreSQL state, holdout, image, or qualification command were accessed.'
 
-      - name: Set up the runner image-build toolchain
+      - name: Set up the runner image-inspection toolchain
         if: steps.dormancy.outputs.dormant == 'false'
         uses: ./.github/actions/setup-nix-toolchain
         with:
           require-preinstalled: 'true'
 
-      - name: Build the exact checked-out source image locally
+      - name: Resolve and load the exact checked-out source image
         id: image
         if: steps.dormancy.outputs.dormant == 'false'
         shell: bash
+        env:
+          IMAGE_REPOSITORY: registry.ide-newton.ts.net/lab/bayn
         run: |
           set -euo pipefail
           test "$(git rev-parse HEAD)" = "${GITHUB_SHA}"
           test "$(git rev-parse refs/remotes/origin/main)" = "${GITHUB_SHA}"
 
-          image_link="${RUNNER_TEMP}/bayn-qualification-image"
-          image_load_log="${RUNNER_TEMP}/bayn-qualification-image-load.log"
-          rm -f -- "$image_link" "$image_load_log"
-          nix build .#bayn-image --print-build-logs --out-link "$image_link"
-          image_tar="$(readlink -f "$image_link")"
-          test -f "$image_tar"
-
-          docker load --input "$image_tar" | tee "$image_load_log"
-          image_tag="$(sed -n 's/^Loaded image: //p' "$image_load_log" | tail -n 1)"
-          test -n "$image_tag"
-          image_id="$(docker image inspect "$image_tag" --format '{{.Id}}')"
-          [[ "$image_id" =~ ^sha256:[0-9a-f]{64}$ ]]
-          echo "tag=${image_tag}" >> "$GITHUB_OUTPUT"
-          echo "reference=${image_tag}@${image_id}" >> "$GITHUB_OUTPUT"
+          image_tag="${IMAGE_REPOSITORY}:sha-${GITHUB_SHA}"
+          image_digest="$(crane digest "$image_tag")"
+          [[ "$image_digest" =~ ^sha256:[0-9a-f]{64}$ ]]
+          image_reference="${IMAGE_REPOSITORY}@${image_digest}"
+          image_config="$(crane config --platform linux/arm64 "$image_reference")"
+          test "$(jq -r '.config.Labels["org.opencontainers.image.revision"] // empty' <<< "$image_config")" = "${GITHUB_SHA}"
+          docker pull --platform linux/arm64 "$image_reference"
+          docker image inspect "$image_reference" >/dev/null
+          echo "reference=${image_reference}" >> "$GITHUB_OUTPUT"
 
       - name: Preflight the exact source image without credentials or network
         if: steps.dormancy.outputs.dormant == 'false'
         shell: bash
         env:
-          IMAGE_TAG: ${{ steps.image.outputs.tag }}
           IMAGE_REFERENCE: ${{ steps.image.outputs.reference }}
         run: |
           set -euo pipefail
@@ -106,7 +102,7 @@ jobs:
             -e BAYN_QUALIFICATION_IMAGE_REFERENCE="$IMAGE_REFERENCE" \
             -e BAYN_QUALIFICATION_MODE=preflight \
             --entrypoint bayn-qualification-collector \
-            "$IMAGE_TAG" | tee "$preflight"
+            "$IMAGE_REFERENCE" | tee "$preflight"
 
           mapfile -t preflight_lines < <(grep '^BAYN_QUALIFICATION_TERMINAL=' "$preflight")
           test "${#preflight_lines[@]}" -eq 1
@@ -125,7 +121,6 @@ jobs:
         if: steps.dormancy.outputs.dormant == 'false'
         shell: bash
         env:
-          IMAGE_TAG: ${{ steps.image.outputs.tag }}
           IMAGE_REFERENCE: ${{ steps.image.outputs.reference }}
           GITHUB_TOKEN: ${{ github.token }}
           BAYN_CLICKHOUSE_USERNAME: ${{ secrets.BAYN_QUALIFICATION_CLICKHOUSE_USERNAME }}
@@ -170,7 +165,7 @@ jobs:
             -e BAYN_QUALIFICATION_IMAGE_REFERENCE="$IMAGE_REFERENCE" \
             -e BAYN_QUALIFICATION_MODE=execute \
             --entrypoint bayn-qualification-collector \
-            "$IMAGE_TAG" | tee "$log"
+            "$IMAGE_REFERENCE" | tee "$log"
 
           mapfile -t terminal_lines < <(grep '^BAYN_QUALIFICATION_TERMINAL=' "$log")
           test "${#terminal_lines[@]}" -eq 1

--- a/nix/images/bayn.nix
+++ b/nix/images/bayn.nix
@@ -36,8 +36,8 @@ let
   buildDefine = name: value: "--define ${name}=${lib.escapeShellArg (builtins.toJSON value)}";
   dependencySource = import ./bun-workspace-deps-source.nix { inherit lib repoRoot; };
   depsHash = {
-    x86_64-linux = "sha256-y7PRw8e/DeerQppuopDJREtOGA5qB24hX9HUyumngzg=";
-    aarch64-linux = "sha256-SnSTaAPp9/4mjEQxUwZGApZWqsfPd+2MWtvwJ10iqkQ=";
+    x86_64-linux = "sha256-Q5PHTSy/pvZRncOcPD/u2WkmtMO9a63xYv1Mo3ZT5ow=";
+    aarch64-linux = "sha256-RsZvQF78pOgM/MJMznUvTesMo0QNBoVVJWAKuZNs/TM=";
   };
   buildCommands = [
     "bun --cwd=services/bayn run tsc"

--- a/packages/scripts/src/bayn/bayn-build-push-concurrency.test.ts
+++ b/packages/scripts/src/bayn/bayn-build-push-concurrency.test.ts
@@ -34,8 +34,9 @@ const cancelsRunningEvent = (running: RetryEvent, incoming: RetryEvent): boolean
   parsed.concurrency['cancel-in-progress'] && concurrencyGroupFor(running) === concurrencyGroupFor(incoming)
 
 describe('Bayn build-push workflow concurrency', () => {
-  test('binds release-review remediations to the exact checked-out repository', () => {
-    expect(workflow).toContain("'services/bayn/release-review-remediations/**'")
+  test('publishes every main SHA while retaining trusted review verification', () => {
+    expect(workflow).not.toContain('    paths:')
+    expect(workflow).toContain('packages/scripts/src/bayn/verify-release-review.ts')
     expect(workflow.match(/--repository-root "\$\{GITHUB_WORKSPACE\}"/g)).toHaveLength(3)
   })
 

--- a/packages/scripts/src/bayn/bayn-qualification-workflow.test.ts
+++ b/packages/scripts/src/bayn/bayn-qualification-workflow.test.ts
@@ -46,8 +46,8 @@ describe('Bayn qualification workflow contract', () => {
   test('keeps dormancy ahead of every privileged or image operation', () => {
     const dormancy = stepIndex('Verify typed candidate dormancy before any privileged access')
     const stop = stepIndex('Stop safely while qualification is dormant')
-    const toolchain = stepIndex('Set up the runner image-build toolchain')
-    const build = stepIndex('Build the exact checked-out source image locally')
+    const toolchain = stepIndex('Set up the runner image-inspection toolchain')
+    const build = stepIndex('Resolve and load the exact checked-out source image')
     const preflight = stepIndex('Preflight the exact source image without credentials or network')
     const execution = stepIndex('Collect, lock, execute once, and independently audit the sealed holdout')
 
@@ -59,8 +59,8 @@ describe('Bayn qualification workflow contract', () => {
     expect(execution).toBeGreaterThan(preflight)
     expect(step('Stop safely while qualification is dormant').if).toBe("steps.dormancy.outputs.dormant == 'true'")
     for (const name of [
-      'Set up the runner image-build toolchain',
-      'Build the exact checked-out source image locally',
+      'Set up the runner image-inspection toolchain',
+      'Resolve and load the exact checked-out source image',
       'Preflight the exact source image without credentials or network',
       'Collect, lock, execute once, and independently audit the sealed holdout',
     ]) {
@@ -77,7 +77,7 @@ describe('Bayn qualification workflow contract', () => {
     )
   })
 
-  test('builds and runs the exact checked-out source without release or deployment orchestration', () => {
+  test('runs the exact checked-out source image without release or deployment orchestration', () => {
     const checkout = step('Checkout exact scheduled main')
     expect(checkout.uses).toBe('actions/checkout@v5')
     expect(checkout.with).toMatchObject({
@@ -86,15 +86,15 @@ describe('Bayn qualification workflow contract', () => {
       'persist-credentials': false,
     })
 
-    const build = runText('Build the exact checked-out source image locally')
-    expect(build).toContain('nix build .#bayn-image')
-    expect(build).toContain('docker load --input "$image_tar"')
-    expect(build).toContain('echo "tag=${image_tag}" >> "$GITHUB_OUTPUT"')
-    expect(build).toContain('echo "reference=${image_tag}@${image_id}" >> "$GITHUB_OUTPUT"')
+    const build = runText('Resolve and load the exact checked-out source image')
+    expect(build).toContain('crane digest "$image_tag"')
+    expect(build).toContain('image_reference="${IMAGE_REPOSITORY}@${image_digest}"')
+    expect(build).toContain('crane config --platform linux/arm64 "$image_reference"')
+    expect(build).toContain('docker pull --platform linux/arm64 "$image_reference"')
+    expect(build).toContain('echo "reference=${image_reference}" >> "$GITHUB_OUTPUT"')
 
     const allRuns = steps.flatMap((candidate) => (candidate.run === undefined ? [] : [candidate.run]))
     const orchestrationText = allRuns.join('\n')
-    expect(orchestrationText).not.toContain('docker pull')
     expect(orchestrationText).not.toContain('docker push')
     expect(orchestrationText).not.toContain('kubectl')
     expect(orchestrationText).not.toContain('argocd')

--- a/packages/scripts/src/bayn/bayn-qualification-workflow.test.ts
+++ b/packages/scripts/src/bayn/bayn-qualification-workflow.test.ts
@@ -1,94 +1,127 @@
 import { describe, expect, test } from 'bun:test'
+import { execFileSync } from 'node:child_process'
 import { readFileSync } from 'node:fs'
 
-const workflow = readFileSync('.github/workflows/bayn-qualification.yml', 'utf8')
-const image = readFileSync('nix/images/bayn.nix', 'utf8')
-const packageManifest = readFileSync('services/bayn/package.json', 'utf8')
-const collector = readFileSync('services/bayn/src/qualification-collector-command.ts', 'utf8')
-const auditCommand = readFileSync('services/bayn/src/qualification-audit-command.ts', 'utf8')
+import { parse } from 'yaml'
 
-describe('Bayn qualification workflow collector/executor contract', () => {
-  test('stays dormant before any credential, image, database, Signal, or qualification access', () => {
-    const dormant = workflow.indexOf('Verify typed candidate dormancy before any privileged access')
-    const safeNoop = workflow.indexOf('Stop safely while qualification is dormant')
-    const imageBinding = workflow.indexOf('Bind the exact promoted unpinned qualification image')
-    const secretReference = workflow.indexOf('secrets.BAYN_QUALIFICATION_CLICKHOUSE_USERNAME')
-    const imagePull = workflow.indexOf('docker pull "$IMAGE_REFERENCE"')
+const workflowPath = '.github/workflows/bayn-qualification.yml'
+const packageManifestPath = 'services/bayn/package.json'
 
-    expect(dormant).toBeGreaterThan(0)
-    expect(safeNoop).toBeGreaterThan(dormant)
-    expect(imageBinding).toBeGreaterThan(safeNoop)
-    expect(imageBinding).toBeGreaterThan(dormant)
-    expect(secretReference).toBeGreaterThan(imageBinding)
-    expect(imagePull).toBeGreaterThan(imageBinding)
-    expect(workflow).toContain('bun packages/scripts/src/bayn/verify-qualification-dormancy.ts')
-    expect(workflow).toContain('--repository-root "$GITHUB_WORKSPACE"')
-    expect(workflow).toContain('--github-output "$GITHUB_OUTPUT"')
-    expect(workflow).not.toContain("rg -n 'nextCandidatePreregistration: null'")
-    expect(workflow).not.toContain('services/bayn/src/candidate-development-calendar.ts')
-    expect(workflow).toContain(
-      'No credentials, Signal data, PostgreSQL state, holdout, image, or qualification command were accessed.',
+interface WorkflowStep {
+  readonly name?: string
+  readonly id?: string
+  readonly if?: string
+  readonly run?: string
+  readonly uses?: string
+  readonly with?: Record<string, unknown>
+  readonly env?: Record<string, unknown>
+}
+
+interface QualificationWorkflow {
+  readonly permissions: Record<string, string>
+  readonly jobs: {
+    readonly eligibility: {
+      readonly steps: readonly WorkflowStep[]
+    }
+  }
+}
+
+const workflow = parse(readFileSync(workflowPath, 'utf8')) as QualificationWorkflow
+const packageManifest = JSON.parse(readFileSync(packageManifestPath, 'utf8')) as {
+  readonly scripts: Record<string, string>
+}
+const steps = workflow.jobs.eligibility.steps
+
+const step = (name: string): WorkflowStep => {
+  const found = steps.find((candidate) => candidate.name === name)
+  if (found === undefined) throw new Error(`workflow step is missing: ${name}`)
+  return found
+}
+
+const stepIndex = (name: string): number => steps.findIndex((candidate) => candidate.name === name)
+
+const runText = (name: string): string => step(name).run ?? ''
+
+describe('Bayn qualification workflow contract', () => {
+  test('keeps dormancy ahead of every privileged or image operation', () => {
+    const dormancy = stepIndex('Verify typed candidate dormancy before any privileged access')
+    const stop = stepIndex('Stop safely while qualification is dormant')
+    const toolchain = stepIndex('Set up the runner image-build toolchain')
+    const build = stepIndex('Build the exact checked-out source image locally')
+    const preflight = stepIndex('Preflight the exact source image without credentials or network')
+    const execution = stepIndex('Collect, lock, execute once, and independently audit the sealed holdout')
+
+    expect(dormancy).toBeGreaterThanOrEqual(0)
+    expect(stop).toBeGreaterThan(dormancy)
+    expect(toolchain).toBeGreaterThan(stop)
+    expect(build).toBeGreaterThan(toolchain)
+    expect(preflight).toBeGreaterThan(build)
+    expect(execution).toBeGreaterThan(preflight)
+    expect(step('Stop safely while qualification is dormant').if).toBe("steps.dormancy.outputs.dormant == 'true'")
+    for (const name of [
+      'Set up the runner image-build toolchain',
+      'Build the exact checked-out source image locally',
+      'Preflight the exact source image without credentials or network',
+      'Collect, lock, execute once, and independently audit the sealed holdout',
+    ]) {
+      expect(step(name).if).toBe("steps.dormancy.outputs.dormant == 'false'")
+    }
+    expect(runText('Verify typed candidate dormancy before any privileged access')).toContain(
+      'verify-qualification-dormancy.ts',
     )
-    expect(workflow).toContain('id: dormancy')
-    expect(workflow).not.toContain('steps.calendar')
-    expect(workflow).toContain("if: steps.dormancy.outputs.dormant == 'true'")
-    expect(workflow).not.toContain("steps.dormancy.outputs.dormant != 'true'")
-    expect(workflow).toContain("if: steps.dormancy.outputs.dormant == 'false'")
-  })
-
-  test('binds and executes only the exact promoted unpinned source image', () => {
-    expect(workflow).toContain('fetch-depth: 0')
-    expect(workflow).toContain('persist-credentials: false')
-    expect(workflow).toContain('test "$(git rev-parse refs/remotes/origin/main)" = "${GITHUB_SHA}"')
-    expect(workflow).toContain('qualification_pin_count')
-    expect(workflow).toContain('test "$qualification_pin_count" = 0')
-    expect(workflow).toContain('[[ "$source_sha" =~ ^[0-9a-f]{40}$ ]]')
-    expect(workflow).toContain('image_reference="${image_repository}@${image_digest}"')
-    expect(workflow).toContain('docker pull "$IMAGE_REFERENCE"')
-    expect(workflow).toContain('jq -e --arg expected "$IMAGE_REFERENCE" \'index($expected) != null\'')
-    expect(workflow).toContain('--read-only')
-    expect(workflow).toContain('--mount "type=bind,src=${GITHUB_WORKSPACE},dst=/workspace,readonly"')
-    expect(workflow).toContain('--entrypoint bayn-qualification-collector')
-    expect(workflow).toContain('"$IMAGE_REFERENCE" | tee "$log"')
-  })
-
-  test('uses in-process evidence rather than an arbitrary prewritten eligibility file', () => {
-    expect(workflow).not.toContain('/run/bayn-qualification/eligibility-input.json')
-    expect(workflow).not.toContain('verify-qualification-eligibility.ts')
-    expect(collector).toContain('verifyCandidateDevelopmentRepositoryIntegrity')
-    expect(collector).toContain('verifyCandidateDevelopmentPreregistrationLineage')
-    expect(collector).toContain('validateCandidateDevelopmentPreregistrationDocument')
-    expect(collector).toContain('verifyCandidateDevelopmentPreregistrationModuleNovelty')
-    expect(collector).toContain('verifyQualificationCandidateImmutableSource')
-    expect(collector).toContain('compiledBoundedContentHash')
-    expect(collector).toContain('isQualificationSourceAffectingPath')
-    expect(collector).toContain("['diff', '--no-renames', '--name-only'")
-    expect(collector).toContain('verifyQualificationCandidateBinding')
-    expect(collector).toContain('runStartup(input.plan.config')
-    expect(collector).toContain('collectQualificationAuditReport')
-    expect(collector.indexOf('readQualification(candidate.candidateRunId)')).toBeLessThan(
-      collector.indexOf('runStartup(input.plan.config'),
+    expect(runText('Verify typed candidate dormancy before any privileged access')).toContain(
+      '--repository-root "$GITHUB_WORKSPACE"',
+    )
+    expect(runText('Verify typed candidate dormancy before any privileged access')).toContain(
+      '--github-output "$GITHUB_OUTPUT"',
     )
   })
 
-  test('runs the exact image preflight without credentials before the secret-bearing execution step', () => {
-    const preflight = workflow.indexOf('Preflight immutable qualification evidence without credentials')
-    const secretExecution = workflow.indexOf('Collect, lock, execute once, and independently audit')
-    const firstSecret = workflow.indexOf('secrets.BAYN_QUALIFICATION_CLICKHOUSE_USERNAME')
+  test('builds and runs the exact checked-out source without release or deployment orchestration', () => {
+    const checkout = step('Checkout exact scheduled main')
+    expect(checkout.uses).toBe('actions/checkout@v5')
+    expect(checkout.with).toMatchObject({
+      ref: '${{ github.sha }}',
+      'fetch-depth': 0,
+      'persist-credentials': false,
+    })
 
-    expect(preflight).toBeGreaterThan(0)
-    expect(secretExecution).toBeGreaterThan(preflight)
-    expect(firstSecret).toBeGreaterThan(secretExecution)
-    expect(workflow).toContain('-e BAYN_QUALIFICATION_MODE=preflight')
-    expect(workflow).toContain('-e BAYN_QUALIFICATION_MODE=execute')
-    expect(workflow).toContain('bayn.qualification-collector-preflight.v1')
+    const build = runText('Build the exact checked-out source image locally')
+    expect(build).toContain('nix build .#bayn-image')
+    expect(build).toContain('docker load --input "$image_tar"')
+    expect(build).toContain('echo "tag=${image_tag}" >> "$GITHUB_OUTPUT"')
+    expect(build).toContain('echo "reference=${image_tag}@${image_id}" >> "$GITHUB_OUTPUT"')
+
+    const allRuns = steps.flatMap((candidate) => (candidate.run === undefined ? [] : [candidate.run]))
+    const orchestrationText = allRuns.join('\n')
+    expect(orchestrationText).not.toContain('docker pull')
+    expect(orchestrationText).not.toContain('docker push')
+    expect(orchestrationText).not.toContain('kubectl')
+    expect(orchestrationText).not.toContain('argocd')
+    expect(orchestrationText).not.toContain('deployment.yaml')
+    expect(orchestrationText).not.toContain('BAYN_QUALIFICATION_RUN_ID')
+
+    const preflight = runText('Preflight the exact source image without credentials or network')
+    expect(preflight).toContain('--network none')
+    expect(preflight).toContain('--read-only')
+    expect(preflight).toContain('--mount "type=bind,src=${GITHUB_WORKSPACE},dst=/workspace,readonly"')
+    expect(preflight).toContain('-e BAYN_QUALIFICATION_MODE=preflight')
+    expect(preflight).toContain('--entrypoint bayn-qualification-collector')
+
+    const execution = runText('Collect, lock, execute once, and independently audit the sealed holdout')
+    expect(execution).toContain('--network host')
+    expect(execution).toContain('--read-only')
+    expect(execution).toContain('-e BAYN_QUALIFICATION_MODE=execute')
+    expect(execution).toContain('--entrypoint bayn-qualification-collector')
+    expect((orchestrationText.match(/BAYN_QUALIFICATION_MODE=execute/g) ?? []).length).toBe(1)
   })
 
-  test('keeps GitHub permissions read-only and declares only explicit secret wiring', () => {
-    expect(workflow).toContain('actions: read')
-    expect(workflow).toContain('contents: read')
-    expect(workflow).not.toMatch(/(?:issues|packages|pull-requests|statuses|checks|deployments|id-token): write/)
-    for (const secret of [
+  test('keeps the qualification boundary read-only and wires only the declared execution secrets', () => {
+    expect(workflow.permissions).toEqual({ actions: 'read', contents: 'read' })
+    expect(step('Reject manual invocation').if).toBe("github.event_name == 'workflow_dispatch'")
+    expect(runText('Reject manual invocation')).toContain('Manual qualification dispatch is forbidden.')
+
+    const expectedSecrets = [
       'BAYN_QUALIFICATION_CLICKHOUSE_USERNAME',
       'BAYN_QUALIFICATION_CLICKHOUSE_PASSWORD',
       'BAYN_QUALIFICATION_POSTGRES_URL',
@@ -96,54 +129,32 @@ describe('Bayn qualification workflow collector/executor contract', () => {
       'BAYN_QUALIFICATION_SIGNAL_PUBLISHER_USERNAME',
       'BAYN_QUALIFICATION_AUDIT_CLICKHOUSE_USERNAME',
       'BAYN_QUALIFICATION_AUDIT_CLICKHOUSE_PASSWORD',
-    ]) {
-      expect(workflow).toContain(`secrets.${secret}`)
+    ]
+    const executionEnv = step('Collect, lock, execute once, and independently audit the sealed holdout').env ?? {}
+    expect(Object.keys(executionEnv).filter((key) => key.startsWith('BAYN_'))).toEqual([
+      'BAYN_CLICKHOUSE_USERNAME',
+      'BAYN_CLICKHOUSE_PASSWORD',
+      'BAYN_POSTGRES_URL',
+      'BAYN_QUALIFICATION_POSTGRES_CA_PEM',
+      'BAYN_AUDIT_SIGNAL_PUBLISHER_USERNAME',
+      'BAYN_AUDIT_CLICKHOUSE_USERNAME',
+      'BAYN_AUDIT_CLICKHOUSE_PASSWORD',
+    ])
+    for (const secret of expectedSecrets) {
+      expect(JSON.stringify(executionEnv)).toContain(`secrets.${secret}`)
     }
-    expect(workflow).toContain("if: github.event_name == 'workflow_dispatch'")
-    expect(workflow).toContain('Manual qualification dispatch is forbidden.')
+    expect(
+      JSON.stringify(step('Preflight the exact source image without credentials or network').env ?? {}),
+    ).not.toContain('secrets.')
   })
 
-  test('packages the candidate, collector, and independent audit into both production image platforms', () => {
-    expect(packageManifest).toContain('"collect:qualification": "bun src/qualification-collector-command.ts"')
-    for (const command of [
-      'qualification-audit-command',
-      'qualification-candidate-command',
-      'qualification-collector-command',
-    ]) {
-      expect(packageManifest).toContain(`src/${command}.ts`)
-      expect(image).toContain(`src/${command}.ts`)
-      expect(image).toContain(`dist/${command}.js`)
+  test('parses every shell step with Bash and exposes the local candidate-development wrapper', () => {
+    for (const candidate of steps) {
+      if (candidate.run === undefined) continue
+      expect(() => execFileSync('bash', ['-n'], { input: candidate.run, encoding: 'utf8' })).not.toThrow()
     }
-    expect(image).toContain('pkgs.git')
-    expect(image).toContain('bayn-qualification-candidate')
-    expect(image).toContain('bayn-qualification-audit')
-    expect(image).toContain('bayn-qualification-collector')
-    expect(image).toContain('exec "$root/bin/bun" "$root/app/services/bayn/dist/qualification-collector-command.js"')
-    expect(image).toContain('includeBunRuntime = true;')
-    expect(image).toContain('sha256-y7PRw8e/DeerQppuopDJREtOGA5qB24hX9HUyumngzg=')
-    expect(image).toContain('sha256-SnSTaAPp9/4mjEQxUwZGApZWqsfPd+2MWtvwJ10iqkQ=')
-  })
-
-  test('keeps standalone dossier output while the collector imports the report-only audit wrapper', () => {
-    expect(auditCommand).toContain('const collectQualificationAuditOutput')
-    expect(auditCommand).toContain('const { input, report } = yield* collectQualificationAuditOutput')
-    expect(auditCommand).toContain('renderQualificationAuditCommandOutput(report)')
-    expect(auditCommand).toContain('completeQualificationAuditCommand(input, report)')
-    expect(auditCommand).toContain("input.output === 'audit' && 'status' in report && report.status !== 'PASS'")
-    expect(auditCommand).toContain('export const requireQualificationAuditReport')
-    expect(auditCommand).toContain(
-      'export const collectQualificationAuditReport = collectQualificationAuditOutput.pipe(',
+    expect(packageManifest.scripts['candidate:development:local']).toBe(
+      'bun ../../packages/scripts/src/bayn/candidate-development-local/command.ts',
     )
-    expect(collector).toContain("import { collectQualificationAuditReport } from './qualification-audit-command'")
-  })
-
-  test('keeps collector configuration failures typed and delegates termination to NodeRuntime', () => {
-    expect(collector).toContain('export const requiredQualificationEnvironment')
-    expect(collector).toContain('export const loadQualificationCollectorInvocation')
-    expect(collector).toContain('export const qualificationCollectorMain')
-    expect(collector).toContain('Effect.tapError')
-    expect(collector).toContain('NodeRuntime.runMain(qualificationCollectorMain)')
-    expect(collector).not.toContain('process.exitCode')
-    expect(collector).not.toContain('Effect.catch((error)')
   })
 })

--- a/packages/scripts/src/bayn/candidate-development-local/command.test.ts
+++ b/packages/scripts/src/bayn/candidate-development-local/command.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, test } from 'bun:test'
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import {
+  makeCandidateDevelopmentLocalAttemptReceipt,
+  parseCandidateDevelopmentLocalArguments,
+  serializeCandidateDevelopmentLocalReceipt,
+  validateCandidateDevelopmentLocalSourceBinding,
+  type CandidateDevelopmentLocalAttemptReceipt,
+} from './contract'
+import {
+  runCandidateDevelopmentLocally,
+  finalizeCandidateDevelopmentLocalReceipt,
+  reserveCandidateDevelopmentLocalReceipt,
+  type CandidateDevelopmentLocalDependencies,
+  type CandidateDevelopmentLocalProcessRequest,
+  type CandidateDevelopmentLocalSourceResolution,
+} from './command'
+
+const source = validateCandidateDevelopmentLocalSourceBinding({
+  sourceRevision: 'a'.repeat(40),
+  modulePath: 'services/bayn/src/strategy/example.ts',
+  moduleBlobOid: 'b'.repeat(40),
+  moduleSha256: 'c'.repeat(64),
+  sourceManifestPath: 'services/bayn/candidates/example.json',
+  sourceManifestBlobOid: 'd'.repeat(40),
+  sourceManifestSha256: 'e'.repeat(64),
+})
+
+if (!source.ok) throw new Error(source.message)
+
+const resolved: CandidateDevelopmentLocalSourceResolution = {
+  repositoryRoot: '/repo',
+  modulePath: 'services/bayn/src/strategy/example.ts',
+  sourceManifestPath: 'services/bayn/candidates/example.json',
+  runtimeMarketDataPath: '/sealed/typed-runtime-market-data.json',
+  receiptPath: '/repo/.git/bayn-candidate-development-local-receipt.json',
+  source: source.value,
+}
+
+const dependenciesFor = (
+  exitCode: number | null = 0,
+): {
+  readonly dependencies: CandidateDevelopmentLocalDependencies
+  readonly receipts: CandidateDevelopmentLocalAttemptReceipt[]
+  readonly processes: CandidateDevelopmentLocalProcessRequest[]
+} => {
+  const receipts: CandidateDevelopmentLocalAttemptReceipt[] = []
+  const processes: CandidateDevelopmentLocalProcessRequest[] = []
+  const consumed = { value: false }
+  return {
+    receipts,
+    processes,
+    dependencies: {
+      resolveSourceBinding: async () => resolved,
+      reserveReceipt: async (_path, receipt) => {
+        if (consumed.value) throw new Error('receipt exists')
+        consumed.value = true
+        receipts.push(receipt)
+      },
+      finalizeReceipt: async (_path, receipt) => {
+        receipts.push(receipt)
+      },
+      runCandidateDevelopment: async (request) => {
+        processes.push(request)
+        if (exitCode === null) throw new Error('child process failed')
+        return exitCode
+      },
+    },
+  }
+}
+
+describe('candidate development local contract', () => {
+  test('requires exactly three paths and does not interpret runtime market data', () => {
+    expect(parseCandidateDevelopmentLocalArguments(['module.ts', 'manifest.json', 'runtime.json'])).toEqual({
+      ok: true,
+      value: { modulePath: 'module.ts', sourceManifestPath: 'manifest.json', runtimeMarketDataPath: 'runtime.json' },
+    })
+    expect(parseCandidateDevelopmentLocalArguments(['module.ts', 'manifest.json'])).toMatchObject({
+      ok: false,
+      code: 'invalid-arguments',
+    })
+  })
+
+  test('binds source and manifest identity without putting runtime data in the compact receipt', () => {
+    const receipt = makeCandidateDevelopmentLocalAttemptReceipt(source.value, 'reserved')
+    const serialized = serializeCandidateDevelopmentLocalReceipt(receipt)
+    expect(receipt.source.bindingHash).toMatch(/^[0-9a-f]{64}$/)
+    expect(serialized).not.toContain('/sealed/typed-runtime-market-data.json')
+    expect(serialized).not.toContain('runtime')
+  })
+})
+
+describe('candidate development local command', () => {
+  test('rejects invalid arguments before source resolution or process execution', async () => {
+    const fixture = dependenciesFor()
+    let resolvedCount = 0
+    const dependencies: CandidateDevelopmentLocalDependencies = {
+      ...fixture.dependencies,
+      resolveSourceBinding: async () => {
+        resolvedCount += 1
+        return resolved
+      },
+    }
+
+    await expect(runCandidateDevelopmentLocally(['module.ts'], dependencies)).rejects.toMatchObject({
+      code: 'invalid-arguments',
+    })
+    expect(resolvedCount).toBe(0)
+    expect(fixture.processes).toEqual([])
+  })
+
+  test('reserves once, invokes the exact existing command, and finalizes success', async () => {
+    const fixture = dependenciesFor()
+    const result = await runCandidateDevelopmentLocally(
+      ['module.ts', 'manifest.json', '/sealed/typed-runtime-market-data.json'],
+      fixture.dependencies,
+    )
+
+    expect(fixture.processes).toEqual([
+      {
+        repositoryRoot: '/repo',
+        argv: [
+          'services/bayn/src/strategy/example.ts',
+          'services/bayn/candidates/example.json',
+          '/sealed/typed-runtime-market-data.json',
+        ],
+      },
+    ])
+    expect(fixture.receipts.map(({ status }) => status)).toEqual(['reserved', 'completed'])
+    expect(result.receipt.status).toBe('completed')
+    expect(JSON.stringify(result.receipt)).not.toContain('/sealed/typed-runtime-market-data.json')
+  })
+
+  test('consumes the one-shot receipt when the child exits nonzero', async () => {
+    const fixture = dependenciesFor(7)
+    await expect(
+      runCandidateDevelopmentLocally(['module.ts', 'manifest.json', 'runtime.json'], fixture.dependencies),
+    ).rejects.toMatchObject({ code: 'candidate-exited' })
+    expect(fixture.receipts.map(({ status, exitCode }) => [status, exitCode])).toEqual([
+      ['reserved', undefined],
+      ['failed', 7],
+    ])
+    expect(fixture.processes).toHaveLength(1)
+  })
+
+  test('finalizes a failed receipt when process startup throws', async () => {
+    const fixture = dependenciesFor(null)
+    await expect(
+      runCandidateDevelopmentLocally(['module.ts', 'manifest.json', 'runtime.json'], fixture.dependencies),
+    ).rejects.toMatchObject({ code: 'candidate-process-failed' })
+    expect(fixture.receipts.map(({ status }) => status)).toEqual(['reserved', 'failed'])
+  })
+
+  test('does not start a second process after receipt reservation fails', async () => {
+    const fixture = dependenciesFor()
+    await runCandidateDevelopmentLocally(['module.ts', 'manifest.json', 'runtime.json'], fixture.dependencies)
+    await expect(
+      runCandidateDevelopmentLocally(['module.ts', 'manifest.json', 'runtime.json'], fixture.dependencies),
+    ).rejects.toMatchObject({})
+    expect(fixture.processes).toHaveLength(1)
+  })
+
+  test('claims and finalizes the compact receipt atomically', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'bayn-candidate-development-local-'))
+    const receiptPath = join(directory, 'receipt.json')
+    const reserved = makeCandidateDevelopmentLocalAttemptReceipt(source.value, 'reserved')
+    const completed = makeCandidateDevelopmentLocalAttemptReceipt(source.value, 'completed', 0)
+    try {
+      await reserveCandidateDevelopmentLocalReceipt(receiptPath, reserved)
+      expect(JSON.parse(await readFile(receiptPath, 'utf8'))).toMatchObject({ status: 'reserved', attempt: 1 })
+      await expect(reserveCandidateDevelopmentLocalReceipt(receiptPath, reserved)).rejects.toMatchObject({
+        code: 'receipt-already-consumed',
+      })
+      await finalizeCandidateDevelopmentLocalReceipt(receiptPath, completed)
+      expect(JSON.parse(await readFile(receiptPath, 'utf8'))).toMatchObject({ status: 'completed', exitCode: 0 })
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/scripts/src/bayn/candidate-development-local/command.test.ts
+++ b/packages/scripts/src/bayn/candidate-development-local/command.test.ts
@@ -143,6 +143,7 @@ describe('candidate development local command', () => {
           'services/bayn/candidates/example.json',
           '/sealed/typed-runtime-market-data.json',
         ],
+        sourceRevision: 'a'.repeat(40),
       },
     ])
     expect(fixture.receipts.map(({ status }) => status)).toEqual(['reserved', 'completed'])

--- a/packages/scripts/src/bayn/candidate-development-local/command.test.ts
+++ b/packages/scripts/src/bayn/candidate-development-local/command.test.ts
@@ -12,6 +12,7 @@ import {
 } from './contract'
 import {
   CandidateDevelopmentLocalError,
+  candidateDevelopmentGitCommand,
   runCandidateDevelopmentLocally,
   finalizeCandidateDevelopmentLocalReceipt,
   reserveCandidateDevelopmentLocalReceipt,
@@ -96,6 +97,19 @@ describe('candidate development local contract', () => {
 })
 
 describe('candidate development local command', () => {
+  test('uses the hardened Git view for every reviewed source read', () => {
+    const previousReplacementRef = process.env.GIT_REPLACE_REF_BASE
+    process.env.GIT_REPLACE_REF_BASE = '/tmp/replacement-refs'
+    try {
+      const command = candidateDevelopmentGitCommand(['rev-parse', 'HEAD'])
+      expect(command.args).toEqual(['--no-replace-objects', 'rev-parse', 'HEAD'])
+      expect(command.env).not.toHaveProperty('GIT_REPLACE_REF_BASE')
+    } finally {
+      if (previousReplacementRef === undefined) delete process.env.GIT_REPLACE_REF_BASE
+      else process.env.GIT_REPLACE_REF_BASE = previousReplacementRef
+    }
+  })
+
   test('rejects invalid arguments before source resolution or process execution', async () => {
     const fixture = dependenciesFor()
     let resolvedCount = 0

--- a/packages/scripts/src/bayn/candidate-development-local/command.test.ts
+++ b/packages/scripts/src/bayn/candidate-development-local/command.test.ts
@@ -11,6 +11,7 @@ import {
   type CandidateDevelopmentLocalAttemptReceipt,
 } from './contract'
 import {
+  CandidateDevelopmentLocalError,
   runCandidateDevelopmentLocally,
   finalizeCandidateDevelopmentLocalReceipt,
   reserveCandidateDevelopmentLocalReceipt,
@@ -55,6 +56,7 @@ const dependenciesFor = (
     processes,
     dependencies: {
       resolveSourceBinding: async () => resolved,
+      revalidateSourceBinding: async () => undefined,
       reserveReceipt: async (_path, receipt) => {
         if (consumed.value) throw new Error('receipt exists')
         consumed.value = true
@@ -132,6 +134,48 @@ describe('candidate development local command', () => {
     expect(fixture.receipts.map(({ status }) => status)).toEqual(['reserved', 'completed'])
     expect(result.receipt.status).toBe('completed')
     expect(JSON.stringify(result.receipt)).not.toContain('/sealed/typed-runtime-market-data.json')
+  })
+
+  test('does not launch when the reviewed binding changes before the child starts', async () => {
+    const fixture = dependenciesFor()
+    let revalidationCount = 0
+    const dependencies: CandidateDevelopmentLocalDependencies = {
+      ...fixture.dependencies,
+      revalidateSourceBinding: async () => {
+        revalidationCount += 1
+        throw new CandidateDevelopmentLocalError('source-binding-invalid', 'source changed')
+      },
+    }
+
+    await expect(
+      runCandidateDevelopmentLocally(['module.ts', 'manifest.json', 'runtime.json'], dependencies),
+    ).rejects.toMatchObject({ code: 'source-binding-invalid' })
+    expect(revalidationCount).toBe(1)
+    expect(fixture.processes).toEqual([])
+    expect(fixture.receipts.map(({ status }) => status)).toEqual(['reserved', 'failed'])
+  })
+
+  test('burns the attempt when the reviewed binding changes after the child exits', async () => {
+    const fixture = dependenciesFor()
+    let revalidationCount = 0
+    const dependencies: CandidateDevelopmentLocalDependencies = {
+      ...fixture.dependencies,
+      revalidateSourceBinding: async () => {
+        revalidationCount += 1
+        if (revalidationCount === 2)
+          throw new CandidateDevelopmentLocalError('source-binding-invalid', 'source changed')
+      },
+    }
+
+    await expect(
+      runCandidateDevelopmentLocally(['module.ts', 'manifest.json', 'runtime.json'], dependencies),
+    ).rejects.toMatchObject({ code: 'source-binding-invalid' })
+    expect(revalidationCount).toBe(2)
+    expect(fixture.processes).toHaveLength(1)
+    expect(fixture.receipts.map(({ status, exitCode }) => [status, exitCode])).toEqual([
+      ['reserved', undefined],
+      ['failed', 0],
+    ])
   })
 
   test('consumes the one-shot receipt when the child exits nonzero', async () => {

--- a/packages/scripts/src/bayn/candidate-development-local/command.ts
+++ b/packages/scripts/src/bayn/candidate-development-local/command.ts
@@ -1,0 +1,391 @@
+import { execFile } from 'node:child_process'
+import { createHash, randomUUID } from 'node:crypto'
+import { link, realpath, rename, unlink, writeFile } from 'node:fs/promises'
+import { relative, resolve, sep } from 'node:path'
+import process from 'node:process'
+import { promisify } from 'node:util'
+
+import {
+  makeCandidateDevelopmentLocalAttemptReceipt,
+  parseCandidateDevelopmentLocalArguments,
+  serializeCandidateDevelopmentLocalReceipt,
+  validateCandidateDevelopmentLocalSourceBinding,
+  type CandidateDevelopmentLocalArguments,
+  type CandidateDevelopmentLocalAttemptReceipt,
+  type CandidateDevelopmentLocalSourceBinding,
+  type CandidateDevelopmentLocalSourceBindingInput,
+} from './contract'
+
+const execFileAsync = promisify(execFile)
+const maximumGitOutputBytes = 8 * 1024 * 1024
+const candidateDevelopmentCommandPath = 'services/bayn/src/candidate-development-command.ts'
+const localReceiptName = 'bayn-candidate-development-local-receipt.json'
+
+export type CandidateDevelopmentLocalErrorCode =
+  | 'invalid-arguments'
+  | 'source-binding-invalid'
+  | 'git-command-failed'
+  | 'source-path-invalid'
+  | 'source-working-tree-dirty'
+  | 'source-manifest-invalid'
+  | 'receipt-already-consumed'
+  | 'receipt-reservation-failed'
+  | 'receipt-finalization-failed'
+  | 'candidate-process-failed'
+  | 'candidate-exited'
+
+export class CandidateDevelopmentLocalError extends Error {
+  readonly code: CandidateDevelopmentLocalErrorCode
+
+  constructor(code: CandidateDevelopmentLocalErrorCode, message: string) {
+    super(message)
+    this.name = 'CandidateDevelopmentLocalError'
+    this.code = code
+  }
+}
+
+export interface CandidateDevelopmentLocalSourceResolution {
+  readonly repositoryRoot: string
+  readonly modulePath: string
+  readonly sourceManifestPath: string
+  readonly runtimeMarketDataPath: string
+  readonly receiptPath: string
+  readonly source: CandidateDevelopmentLocalSourceBinding
+}
+
+export interface CandidateDevelopmentLocalProcessRequest {
+  readonly repositoryRoot: string
+  readonly argv: readonly string[]
+}
+
+export interface CandidateDevelopmentLocalDependencies {
+  readonly resolveSourceBinding: (
+    args: CandidateDevelopmentLocalArguments,
+  ) => Promise<CandidateDevelopmentLocalSourceResolution>
+  readonly reserveReceipt: (path: string, receipt: CandidateDevelopmentLocalAttemptReceipt) => Promise<void>
+  readonly finalizeReceipt: (path: string, receipt: CandidateDevelopmentLocalAttemptReceipt) => Promise<void>
+  readonly runCandidateDevelopment: (request: CandidateDevelopmentLocalProcessRequest) => Promise<number>
+}
+
+export interface CandidateDevelopmentLocalRunResult {
+  readonly receiptPath: string
+  readonly receipt: CandidateDevelopmentLocalAttemptReceipt
+}
+
+const isFileSystemError = (cause: unknown, code: string): boolean =>
+  typeof cause === 'object' && cause !== null && 'code' in cause && cause.code === code
+
+const gitCommandFailure = (): CandidateDevelopmentLocalError =>
+  new CandidateDevelopmentLocalError('git-command-failed', 'Git could not verify the reviewed source binding')
+
+const gitText = async (repositoryRoot: string, args: readonly string[]): Promise<string> => {
+  try {
+    const result = await execFileAsync('git', [...args], {
+      cwd: repositoryRoot,
+      encoding: 'utf8',
+      maxBuffer: maximumGitOutputBytes,
+    })
+    return String(result.stdout)
+  } catch {
+    throw gitCommandFailure()
+  }
+}
+
+const gitToken = async (repositoryRoot: string, args: readonly string[]): Promise<string> => {
+  const output = (await gitText(repositoryRoot, args)).trim()
+  if (output.length === 0) throw gitCommandFailure()
+  return output
+}
+
+const gitDiffIsClean = async (repositoryRoot: string, paths: readonly string[]): Promise<boolean> => {
+  try {
+    await execFileAsync('git', ['diff', '--quiet', 'HEAD', '--', ...paths], {
+      cwd: repositoryRoot,
+      encoding: 'utf8',
+      maxBuffer: maximumGitOutputBytes,
+    })
+    return true
+  } catch (cause) {
+    if (typeof cause === 'object' && cause !== null && 'code' in cause && (cause.code === 1 || cause.code === '1')) {
+      return false
+    }
+    throw gitCommandFailure()
+  }
+}
+
+const repositoryRelativePath = (repositoryRoot: string, absolutePath: string, label: string): string => {
+  const path = relative(repositoryRoot, absolutePath)
+  if (path.length === 0 || path === '..' || path.startsWith(`..${sep}`) || path.startsWith(sep)) {
+    throw new CandidateDevelopmentLocalError('source-path-invalid', `${label} must be inside the repository`)
+  }
+  return path.split(sep).join('/')
+}
+
+const sourceManifestRecord = (value: unknown): Record<string, unknown> => {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    throw new CandidateDevelopmentLocalError('source-manifest-invalid', 'source manifest must be a JSON object')
+  }
+  return value as Record<string, unknown>
+}
+
+const verifySourceManifest = (value: unknown, modulePath: string, moduleSha256: string): void => {
+  const manifest = sourceManifestRecord(value)
+  if (manifest.schemaVersion !== 'bayn.candidate-development-source-manifest.v1') {
+    throw new CandidateDevelopmentLocalError('source-manifest-invalid', 'source manifest schema is unsupported')
+  }
+  if (manifest.modulePath !== modulePath) {
+    throw new CandidateDevelopmentLocalError('source-manifest-invalid', 'source manifest module path is not exact')
+  }
+  if (manifest.moduleSha256 !== undefined && manifest.moduleSha256 !== moduleSha256) {
+    throw new CandidateDevelopmentLocalError('source-manifest-invalid', 'source manifest module hash is not exact')
+  }
+}
+
+const sourceSha256 = (value: string): string => createHash('sha256').update(value, 'utf8').digest('hex')
+
+const gitPath = async (repositoryRoot: string): Promise<string> => {
+  const path = await gitToken(repositoryRoot, ['rev-parse', '--git-path', localReceiptName])
+  return resolve(repositoryRoot, path)
+}
+
+export const resolveCandidateDevelopmentLocalSource = async (
+  args: CandidateDevelopmentLocalArguments,
+): Promise<CandidateDevelopmentLocalSourceResolution> => {
+  const repositoryRoot = await realpath(await gitText(process.cwd(), ['rev-parse', '--show-toplevel']))
+  let absoluteModulePath: string
+  let absoluteSourceManifestPath: string
+  try {
+    absoluteModulePath = await realpath(resolve(repositoryRoot, args.modulePath))
+    absoluteSourceManifestPath = await realpath(resolve(repositoryRoot, args.sourceManifestPath))
+  } catch {
+    throw new CandidateDevelopmentLocalError('source-path-invalid', 'module and source manifest must be readable files')
+  }
+
+  const modulePath = repositoryRelativePath(repositoryRoot, absoluteModulePath, 'module')
+  const sourceManifestPath = repositoryRelativePath(repositoryRoot, absoluteSourceManifestPath, 'source manifest')
+  if (!(await gitDiffIsClean(repositoryRoot, [modulePath, sourceManifestPath]))) {
+    throw new CandidateDevelopmentLocalError(
+      'source-working-tree-dirty',
+      'module and source manifest must match their exact reviewed HEAD blobs',
+    )
+  }
+  for (const path of [modulePath, sourceManifestPath]) {
+    const trackedPath = (await gitText(repositoryRoot, ['ls-files', '--error-unmatch', '--', path])).trim()
+    if (trackedPath !== path)
+      throw new CandidateDevelopmentLocalError('source-path-invalid', 'source path is not tracked')
+  }
+
+  const sourceRevision = await gitToken(repositoryRoot, ['rev-parse', 'HEAD'])
+  const moduleSpec = `HEAD:${modulePath}`
+  const sourceManifestSpec = `HEAD:${sourceManifestPath}`
+  const [moduleBlobOid, sourceManifestBlobOid, moduleSource, sourceManifestSource] = await Promise.all([
+    gitToken(repositoryRoot, ['rev-parse', moduleSpec]),
+    gitToken(repositoryRoot, ['rev-parse', sourceManifestSpec]),
+    gitText(repositoryRoot, ['cat-file', 'blob', moduleSpec]),
+    gitText(repositoryRoot, ['cat-file', 'blob', sourceManifestSpec]),
+  ])
+  const moduleSha256 = sourceSha256(moduleSource)
+  const sourceManifestSha256 = sourceSha256(sourceManifestSource)
+  let parsedManifest: unknown
+  try {
+    parsedManifest = JSON.parse(sourceManifestSource) as unknown
+  } catch {
+    throw new CandidateDevelopmentLocalError('source-manifest-invalid', 'source manifest is not valid JSON')
+  }
+  verifySourceManifest(parsedManifest, modulePath, moduleSha256)
+
+  const sourceInput: CandidateDevelopmentLocalSourceBindingInput = {
+    sourceRevision,
+    modulePath,
+    moduleBlobOid,
+    moduleSha256,
+    sourceManifestPath,
+    sourceManifestBlobOid,
+    sourceManifestSha256,
+  }
+  const source = validateCandidateDevelopmentLocalSourceBinding(sourceInput)
+  if (!source.ok) throw new CandidateDevelopmentLocalError(source.code, source.message)
+  return {
+    repositoryRoot,
+    modulePath,
+    sourceManifestPath,
+    runtimeMarketDataPath: resolve(repositoryRoot, args.runtimeMarketDataPath),
+    receiptPath: await gitPath(repositoryRoot),
+    source: source.value,
+  }
+}
+
+const temporaryReceiptPath = (path: string): string => `${path}.tmp-${process.pid}-${randomUUID()}`
+
+export const reserveCandidateDevelopmentLocalReceipt = async (
+  path: string,
+  receipt: CandidateDevelopmentLocalAttemptReceipt,
+): Promise<void> => {
+  const temporaryPath = temporaryReceiptPath(path)
+  try {
+    await writeFile(temporaryPath, serializeCandidateDevelopmentLocalReceipt(receipt), {
+      encoding: 'utf8',
+      flag: 'wx',
+      mode: 0o600,
+    })
+    try {
+      await link(temporaryPath, path)
+    } catch (cause) {
+      if (isFileSystemError(cause, 'EEXIST')) {
+        throw new CandidateDevelopmentLocalError(
+          'receipt-already-consumed',
+          'the local candidate-development attempt has already been consumed',
+        )
+      }
+      throw new CandidateDevelopmentLocalError(
+        'receipt-reservation-failed',
+        'the local attempt receipt was not reserved',
+      )
+    }
+  } catch (cause) {
+    if (cause instanceof CandidateDevelopmentLocalError) throw cause
+    throw new CandidateDevelopmentLocalError('receipt-reservation-failed', 'the local attempt receipt was not reserved')
+  } finally {
+    await unlink(temporaryPath).catch(() => undefined)
+  }
+}
+
+export const finalizeCandidateDevelopmentLocalReceipt = async (
+  path: string,
+  receipt: CandidateDevelopmentLocalAttemptReceipt,
+): Promise<void> => {
+  const temporaryPath = temporaryReceiptPath(path)
+  try {
+    await writeFile(temporaryPath, serializeCandidateDevelopmentLocalReceipt(receipt), {
+      encoding: 'utf8',
+      flag: 'wx',
+      mode: 0o600,
+    })
+    await rename(temporaryPath, path)
+  } catch {
+    throw new CandidateDevelopmentLocalError(
+      'receipt-finalization-failed',
+      'the local attempt receipt could not be finalized; do not retry',
+    )
+  } finally {
+    await unlink(temporaryPath).catch(() => undefined)
+  }
+}
+
+export const runCandidateDevelopmentProcess = async (
+  request: CandidateDevelopmentLocalProcessRequest,
+): Promise<number> => {
+  const child = Bun.spawn([process.execPath, candidateDevelopmentCommandPath, ...request.argv], {
+    cwd: request.repositoryRoot,
+    stdin: 'inherit',
+    stdout: 'inherit',
+    stderr: 'inherit',
+  })
+  return child.exited
+}
+
+const defaultDependencies: CandidateDevelopmentLocalDependencies = {
+  resolveSourceBinding: resolveCandidateDevelopmentLocalSource,
+  reserveReceipt: reserveCandidateDevelopmentLocalReceipt,
+  finalizeReceipt: finalizeCandidateDevelopmentLocalReceipt,
+  runCandidateDevelopment: runCandidateDevelopmentProcess,
+}
+
+const finalizeFailedAttempt = async (
+  dependencies: CandidateDevelopmentLocalDependencies,
+  receiptPath: string,
+  source: CandidateDevelopmentLocalSourceBinding,
+  exitCode?: number,
+): Promise<void> => {
+  await dependencies.finalizeReceipt(
+    receiptPath,
+    makeCandidateDevelopmentLocalAttemptReceipt(source, 'failed', exitCode),
+  )
+}
+
+export const runCandidateDevelopmentLocally = async (
+  argv: readonly string[],
+  dependencies: CandidateDevelopmentLocalDependencies = defaultDependencies,
+): Promise<CandidateDevelopmentLocalRunResult> => {
+  const parsed = parseCandidateDevelopmentLocalArguments(argv)
+  if (!parsed.ok) throw new CandidateDevelopmentLocalError(parsed.code, parsed.message)
+  const resolved = await dependencies.resolveSourceBinding(parsed.value)
+  const reserved = makeCandidateDevelopmentLocalAttemptReceipt(resolved.source, 'reserved')
+  await dependencies.reserveReceipt(resolved.receiptPath, reserved)
+
+  let exitCode: number
+  try {
+    exitCode = await dependencies.runCandidateDevelopment({
+      repositoryRoot: resolved.repositoryRoot,
+      argv: [resolved.modulePath, resolved.sourceManifestPath, resolved.runtimeMarketDataPath],
+    })
+  } catch {
+    try {
+      await finalizeFailedAttempt(dependencies, resolved.receiptPath, resolved.source)
+    } catch {
+      throw new CandidateDevelopmentLocalError(
+        'receipt-finalization-failed',
+        'the local attempt receipt could not be finalized; do not retry',
+      )
+    }
+    throw new CandidateDevelopmentLocalError('candidate-process-failed', 'the candidate-development command failed')
+  }
+
+  if (!Number.isSafeInteger(exitCode) || exitCode < 0) {
+    try {
+      await finalizeFailedAttempt(dependencies, resolved.receiptPath, resolved.source)
+    } catch {
+      throw new CandidateDevelopmentLocalError(
+        'receipt-finalization-failed',
+        'the local attempt receipt could not be finalized; do not retry',
+      )
+    }
+    throw new CandidateDevelopmentLocalError(
+      'candidate-process-failed',
+      'the candidate-development command exit was invalid',
+    )
+  }
+  if (exitCode !== 0) {
+    try {
+      await finalizeFailedAttempt(dependencies, resolved.receiptPath, resolved.source, exitCode)
+    } catch {
+      throw new CandidateDevelopmentLocalError(
+        'receipt-finalization-failed',
+        'the local attempt receipt could not be finalized; do not retry',
+      )
+    }
+    throw new CandidateDevelopmentLocalError(
+      'candidate-exited',
+      `the candidate-development command exited with ${exitCode}`,
+    )
+  }
+
+  const completed = makeCandidateDevelopmentLocalAttemptReceipt(resolved.source, 'completed', exitCode)
+  await dependencies.finalizeReceipt(resolved.receiptPath, completed)
+  return { receiptPath: resolved.receiptPath, receipt: completed }
+}
+
+const renderLocalError = (cause: unknown): string => {
+  const error =
+    cause instanceof CandidateDevelopmentLocalError
+      ? cause
+      : new CandidateDevelopmentLocalError('candidate-process-failed', 'local candidate development failed')
+  return `${JSON.stringify({
+    schemaVersion: 'bayn.candidate-development-local-error.v1',
+    code: error.code,
+    message: error.message,
+  })}\n`
+}
+
+if (import.meta.main) {
+  runCandidateDevelopmentLocally(process.argv.slice(2))
+    .then(({ receipt }) => {
+      process.stderr.write(
+        `BAYN_CANDIDATE_DEVELOPMENT_LOCAL_RECEIPT=${serializeCandidateDevelopmentLocalReceipt(receipt)}`,
+      )
+    })
+    .catch((cause) => {
+      process.stderr.write(`BAYN_CANDIDATE_DEVELOPMENT_LOCAL_ERROR=${renderLocalError(cause)}`)
+      process.exitCode = 1
+    })
+}

--- a/packages/scripts/src/bayn/candidate-development-local/command.ts
+++ b/packages/scripts/src/bayn/candidate-development-local/command.ts
@@ -56,6 +56,7 @@ export interface CandidateDevelopmentLocalSourceResolution {
 export interface CandidateDevelopmentLocalProcessRequest {
   readonly repositoryRoot: string
   readonly argv: readonly string[]
+  readonly sourceRevision: string
 }
 
 export interface CandidateDevelopmentLocalDependencies {
@@ -327,6 +328,10 @@ export const runCandidateDevelopmentProcess = async (
     stdin: 'inherit',
     stdout: 'inherit',
     stderr: 'inherit',
+    env: {
+      ...process.env,
+      BAYN_CANDIDATE_DEVELOPMENT_EXPECTED_SOURCE_REVISION: request.sourceRevision,
+    },
   })
   return child.exited
 }
@@ -380,6 +385,7 @@ export const runCandidateDevelopmentLocally = async (
     exitCode = await dependencies.runCandidateDevelopment({
       repositoryRoot: resolved.repositoryRoot,
       argv: [resolved.modulePath, resolved.sourceManifestPath, resolved.runtimeMarketDataPath],
+      sourceRevision: resolved.source.sourceRevision,
     })
   } catch {
     try {

--- a/packages/scripts/src/bayn/candidate-development-local/command.ts
+++ b/packages/scripts/src/bayn/candidate-development-local/command.ts
@@ -151,7 +151,7 @@ const gitPath = async (repositoryRoot: string): Promise<string> => {
 export const resolveCandidateDevelopmentLocalSource = async (
   args: CandidateDevelopmentLocalArguments,
 ): Promise<CandidateDevelopmentLocalSourceResolution> => {
-  const repositoryRoot = await realpath(await gitText(process.cwd(), ['rev-parse', '--show-toplevel']))
+  const repositoryRoot = await realpath(await gitToken(process.cwd(), ['rev-parse', '--show-toplevel']))
   let absoluteModulePath: string
   let absoluteSourceManifestPath: string
   try {

--- a/packages/scripts/src/bayn/candidate-development-local/command.ts
+++ b/packages/scripts/src/bayn/candidate-development-local/command.ts
@@ -79,11 +79,18 @@ const isFileSystemError = (cause: unknown, code: string): boolean =>
 const gitCommandFailure = (): CandidateDevelopmentLocalError =>
   new CandidateDevelopmentLocalError('git-command-failed', 'Git could not verify the reviewed source binding')
 
+export const candidateDevelopmentGitCommand = (args: readonly string[]) => ({
+  args: ['--no-replace-objects', ...args],
+  env: Object.fromEntries(Object.entries(process.env).filter(([name]) => !name.startsWith('GIT_'))),
+})
+
 const gitText = async (repositoryRoot: string, args: readonly string[]): Promise<string> => {
   try {
-    const result = await execFileAsync('git', [...args], {
+    const command = candidateDevelopmentGitCommand(args)
+    const result = await execFileAsync('git', command.args, {
       cwd: repositoryRoot,
       encoding: 'utf8',
+      env: command.env,
       maxBuffer: maximumGitOutputBytes,
     })
     return String(result.stdout)
@@ -100,9 +107,11 @@ const gitToken = async (repositoryRoot: string, args: readonly string[]): Promis
 
 const gitDiffIsClean = async (repositoryRoot: string, paths: readonly string[]): Promise<boolean> => {
   try {
-    await execFileAsync('git', ['diff', '--quiet', 'HEAD', '--', ...paths], {
+    const command = candidateDevelopmentGitCommand(['diff', '--quiet', 'HEAD', '--', ...paths])
+    await execFileAsync('git', command.args, {
       cwd: repositoryRoot,
       encoding: 'utf8',
+      env: command.env,
       maxBuffer: maximumGitOutputBytes,
     })
     return true

--- a/packages/scripts/src/bayn/candidate-development-local/command.ts
+++ b/packages/scripts/src/bayn/candidate-development-local/command.ts
@@ -62,6 +62,7 @@ export interface CandidateDevelopmentLocalDependencies {
   readonly resolveSourceBinding: (
     args: CandidateDevelopmentLocalArguments,
   ) => Promise<CandidateDevelopmentLocalSourceResolution>
+  readonly revalidateSourceBinding: (resolution: CandidateDevelopmentLocalSourceResolution) => Promise<void>
   readonly reserveReceipt: (path: string, receipt: CandidateDevelopmentLocalAttemptReceipt) => Promise<void>
   readonly finalizeReceipt: (path: string, receipt: CandidateDevelopmentLocalAttemptReceipt) => Promise<void>
   readonly runCandidateDevelopment: (request: CandidateDevelopmentLocalProcessRequest) => Promise<number>
@@ -176,8 +177,8 @@ export const resolveCandidateDevelopmentLocalSource = async (
   }
 
   const sourceRevision = await gitToken(repositoryRoot, ['rev-parse', 'HEAD'])
-  const moduleSpec = `HEAD:${modulePath}`
-  const sourceManifestSpec = `HEAD:${sourceManifestPath}`
+  const moduleSpec = `${sourceRevision}:${modulePath}`
+  const sourceManifestSpec = `${sourceRevision}:${sourceManifestPath}`
   const [moduleBlobOid, sourceManifestBlobOid, moduleSource, sourceManifestSource] = await Promise.all([
     gitToken(repositoryRoot, ['rev-parse', moduleSpec]),
     gitToken(repositoryRoot, ['rev-parse', sourceManifestSpec]),
@@ -212,6 +213,43 @@ export const resolveCandidateDevelopmentLocalSource = async (
     runtimeMarketDataPath: resolve(repositoryRoot, args.runtimeMarketDataPath),
     receiptPath: await gitPath(repositoryRoot),
     source: source.value,
+  }
+}
+
+export const revalidateCandidateDevelopmentLocalSource = async (
+  resolution: CandidateDevelopmentLocalSourceResolution,
+): Promise<void> => {
+  const currentRevision = await gitToken(resolution.repositoryRoot, ['rev-parse', 'HEAD'])
+  if (currentRevision !== resolution.source.sourceRevision) {
+    throw new CandidateDevelopmentLocalError(
+      'source-binding-invalid',
+      'the reviewed source revision changed during local candidate development',
+    )
+  }
+  if (!(await gitDiffIsClean(resolution.repositoryRoot, [resolution.modulePath, resolution.sourceManifestPath]))) {
+    throw new CandidateDevelopmentLocalError(
+      'source-working-tree-dirty',
+      'module and source manifest changed during local candidate development',
+    )
+  }
+  const [moduleBlobOid, sourceManifestBlobOid] = await Promise.all([
+    gitToken(resolution.repositoryRoot, [
+      'rev-parse',
+      `${resolution.source.sourceRevision}:${resolution.source.modulePath}`,
+    ]),
+    gitToken(resolution.repositoryRoot, [
+      'rev-parse',
+      `${resolution.source.sourceRevision}:${resolution.source.sourceManifestPath}`,
+    ]),
+  ])
+  if (
+    moduleBlobOid !== resolution.source.moduleBlobOid ||
+    sourceManifestBlobOid !== resolution.source.sourceManifestBlobOid
+  ) {
+    throw new CandidateDevelopmentLocalError(
+      'source-binding-invalid',
+      'the reviewed source blobs changed during local candidate development',
+    )
   }
 }
 
@@ -286,6 +324,7 @@ export const runCandidateDevelopmentProcess = async (
 
 const defaultDependencies: CandidateDevelopmentLocalDependencies = {
   resolveSourceBinding: resolveCandidateDevelopmentLocalSource,
+  revalidateSourceBinding: revalidateCandidateDevelopmentLocalSource,
   reserveReceipt: reserveCandidateDevelopmentLocalReceipt,
   finalizeReceipt: finalizeCandidateDevelopmentLocalReceipt,
   runCandidateDevelopment: runCandidateDevelopmentProcess,
@@ -313,6 +352,20 @@ export const runCandidateDevelopmentLocally = async (
   const reserved = makeCandidateDevelopmentLocalAttemptReceipt(resolved.source, 'reserved')
   await dependencies.reserveReceipt(resolved.receiptPath, reserved)
 
+  try {
+    await dependencies.revalidateSourceBinding(resolved)
+  } catch (cause) {
+    try {
+      await finalizeFailedAttempt(dependencies, resolved.receiptPath, resolved.source)
+    } catch {
+      throw new CandidateDevelopmentLocalError(
+        'receipt-finalization-failed',
+        'the local attempt receipt could not be finalized; do not retry',
+      )
+    }
+    throw cause
+  }
+
   let exitCode: number
   try {
     exitCode = await dependencies.runCandidateDevelopment({
@@ -329,6 +382,20 @@ export const runCandidateDevelopmentLocally = async (
       )
     }
     throw new CandidateDevelopmentLocalError('candidate-process-failed', 'the candidate-development command failed')
+  }
+
+  try {
+    await dependencies.revalidateSourceBinding(resolved)
+  } catch (cause) {
+    try {
+      await finalizeFailedAttempt(dependencies, resolved.receiptPath, resolved.source, exitCode)
+    } catch {
+      throw new CandidateDevelopmentLocalError(
+        'receipt-finalization-failed',
+        'the local attempt receipt could not be finalized; do not retry',
+      )
+    }
+    throw cause
   }
 
   if (!Number.isSafeInteger(exitCode) || exitCode < 0) {

--- a/packages/scripts/src/bayn/candidate-development-local/contract.ts
+++ b/packages/scripts/src/bayn/candidate-development-local/contract.ts
@@ -1,0 +1,147 @@
+import { createHash } from 'node:crypto'
+
+const sourceRevisionPattern = /^[0-9a-f]{40}$/
+const blobOidPattern = /^[0-9a-f]{40}$/
+const sha256Pattern = /^[0-9a-f]{64}$/
+
+export const candidateDevelopmentLocalReceiptSchemaVersion = 'bayn.candidate-development-local-attempt.v1' as const
+
+export type CandidateDevelopmentLocalReceiptStatus = 'reserved' | 'completed' | 'failed'
+
+export interface CandidateDevelopmentLocalArguments {
+  readonly modulePath: string
+  readonly sourceManifestPath: string
+  readonly runtimeMarketDataPath: string
+}
+
+export interface CandidateDevelopmentLocalSourceBindingInput {
+  readonly sourceRevision: string
+  readonly modulePath: string
+  readonly moduleBlobOid: string
+  readonly moduleSha256: string
+  readonly sourceManifestPath: string
+  readonly sourceManifestBlobOid: string
+  readonly sourceManifestSha256: string
+}
+
+export interface CandidateDevelopmentLocalSourceBinding extends CandidateDevelopmentLocalSourceBindingInput {
+  readonly bindingHash: string
+}
+
+export interface CandidateDevelopmentLocalAttemptReceipt {
+  readonly schemaVersion: typeof candidateDevelopmentLocalReceiptSchemaVersion
+  readonly attempt: 1
+  readonly status: CandidateDevelopmentLocalReceiptStatus
+  readonly source: CandidateDevelopmentLocalSourceBinding
+  readonly exitCode?: number
+}
+
+export type CandidateDevelopmentLocalValidation<T> =
+  | { readonly ok: true; readonly value: T }
+  | { readonly ok: false; readonly code: 'invalid-arguments' | 'source-binding-invalid'; readonly message: string }
+
+const success = <T>(value: T): CandidateDevelopmentLocalValidation<T> => ({ ok: true, value })
+
+const failure = (
+  code: 'invalid-arguments' | 'source-binding-invalid',
+  message: string,
+): CandidateDevelopmentLocalValidation<never> => ({ ok: false, code, message })
+
+const pathArgument = (value: unknown): string | undefined => {
+  if (typeof value !== 'string' || value.length === 0 || value.includes('\u0000')) return undefined
+  if (value.includes('\n') || value.includes('\r')) return undefined
+  return value
+}
+
+const repositoryPath = (value: unknown): string | undefined => {
+  const path = pathArgument(value)
+  if (path === undefined || path.startsWith('/') || path.split('/').some((part) => part === '..' || part === '')) {
+    return undefined
+  }
+  return path
+}
+
+const hash = (value: unknown, pattern: RegExp): string | undefined => {
+  if (typeof value !== 'string' || !pattern.test(value)) return undefined
+  return value
+}
+
+export const parseCandidateDevelopmentLocalArguments = (
+  argv: readonly string[],
+): CandidateDevelopmentLocalValidation<CandidateDevelopmentLocalArguments> => {
+  if (argv.length !== 3) {
+    return failure('invalid-arguments', 'expected exactly <module> <source-manifest> <typed-runtime-market-data.json>')
+  }
+  const [modulePath, sourceManifestPath, runtimeMarketDataPath] = argv
+  if (
+    pathArgument(modulePath) === undefined ||
+    pathArgument(sourceManifestPath) === undefined ||
+    pathArgument(runtimeMarketDataPath) === undefined
+  ) {
+    return failure('invalid-arguments', 'module, source manifest, and runtime market-data paths must be valid paths')
+  }
+  return success({ modulePath, sourceManifestPath, runtimeMarketDataPath })
+}
+
+const sourceBindingCanonicalBytes = (binding: CandidateDevelopmentLocalSourceBindingInput): string =>
+  JSON.stringify([
+    'bayn.candidate-development-local-source-binding.v1',
+    binding.sourceRevision,
+    binding.modulePath,
+    binding.moduleBlobOid,
+    binding.moduleSha256,
+    binding.sourceManifestPath,
+    binding.sourceManifestBlobOid,
+    binding.sourceManifestSha256,
+  ])
+
+export const validateCandidateDevelopmentLocalSourceBinding = (
+  input: CandidateDevelopmentLocalSourceBindingInput,
+): CandidateDevelopmentLocalValidation<CandidateDevelopmentLocalSourceBinding> => {
+  const sourceRevision = hash(input.sourceRevision, sourceRevisionPattern)
+  const modulePath = repositoryPath(input.modulePath)
+  const moduleBlobOid = hash(input.moduleBlobOid, blobOidPattern)
+  const moduleSha256 = hash(input.moduleSha256, sha256Pattern)
+  const sourceManifestPath = repositoryPath(input.sourceManifestPath)
+  const sourceManifestBlobOid = hash(input.sourceManifestBlobOid, blobOidPattern)
+  const sourceManifestSha256 = hash(input.sourceManifestSha256, sha256Pattern)
+  if (
+    sourceRevision === undefined ||
+    modulePath === undefined ||
+    moduleBlobOid === undefined ||
+    moduleSha256 === undefined ||
+    sourceManifestPath === undefined ||
+    sourceManifestBlobOid === undefined ||
+    sourceManifestSha256 === undefined
+  ) {
+    return failure('source-binding-invalid', 'reviewed source binding contains an invalid Git identity or path')
+  }
+  const binding = {
+    sourceRevision,
+    modulePath,
+    moduleBlobOid,
+    moduleSha256,
+    sourceManifestPath,
+    sourceManifestBlobOid,
+    sourceManifestSha256,
+  } satisfies CandidateDevelopmentLocalSourceBindingInput
+  return success({
+    ...binding,
+    bindingHash: createHash('sha256').update(sourceBindingCanonicalBytes(binding), 'utf8').digest('hex'),
+  })
+}
+
+export const makeCandidateDevelopmentLocalAttemptReceipt = (
+  source: CandidateDevelopmentLocalSourceBinding,
+  status: CandidateDevelopmentLocalReceiptStatus,
+  exitCode?: number,
+): CandidateDevelopmentLocalAttemptReceipt => ({
+  schemaVersion: candidateDevelopmentLocalReceiptSchemaVersion,
+  attempt: 1,
+  status,
+  source,
+  ...(exitCode === undefined ? {} : { exitCode }),
+})
+
+export const serializeCandidateDevelopmentLocalReceipt = (receipt: CandidateDevelopmentLocalAttemptReceipt): string =>
+  `${JSON.stringify(receipt)}\n`

--- a/packages/scripts/src/bayn/verify-promotion-eligibility.test.ts
+++ b/packages/scripts/src/bayn/verify-promotion-eligibility.test.ts
@@ -46,7 +46,7 @@ const currentMainSha = '1'.repeat(40)
 
 const buildWorkflowPath = new URL('../../../../.github/workflows/bayn-build-push.yml', import.meta.url)
 const buildWorkflow = parse(readFileSync(buildWorkflowPath, 'utf8')) as {
-  readonly on: { readonly push: { readonly paths: readonly string[] } }
+  readonly on: { readonly push: { readonly paths?: readonly string[] } }
 }
 
 const representativeBuildTriggerPath = (pattern: string): string => {
@@ -749,7 +749,8 @@ describe('Bayn promotion eligibility', () => {
   })
 
   test('matches the release lane Bayn build-input freshness boundary', () => {
-    for (const pattern of buildWorkflow.on.push.paths) {
+    expect(buildWorkflow.on.push.paths).toBeUndefined()
+    for (const pattern of buildWorkflow.on.push.paths ?? []) {
       const path = representativeBuildTriggerPath(pattern)
       expect(isBaynPromotionSourceAffectingPath(path)).toBeTrue()
     }

--- a/packages/scripts/src/bayn/verify-release-review.test.ts
+++ b/packages/scripts/src/bayn/verify-release-review.test.ts
@@ -5080,6 +5080,42 @@ describe('Bayn publication-range eligibility', () => {
     })
   })
 
+  test('publishes an exact image for a clean non-Bayn main commit', () => {
+    const result = evaluateBaynReleaseEligibility({
+      mainCommitSha,
+      baseRefName: 'main',
+      snapshot: eligibilitySnapshot({
+        comparison: {
+          status: 'ahead',
+          baseSha: lastPublishedSha,
+          headSha: mainCommitSha,
+          mergeBaseSha: lastPublishedSha,
+          aheadBy: 1,
+          totalCommits: 1,
+          commits: [
+            {
+              sha: mainCommitSha,
+              parents: [pushBeforeSha],
+              files: ['README.md'],
+              reviewSnapshot: null,
+            },
+          ],
+          truncated: false,
+        },
+      }),
+      nowMs: evaluationNowMs,
+      pushBeforeSha,
+    })
+
+    expect(result).toMatchObject({
+      status: 'eligible',
+      lastPublishedRevision: lastPublishedSha,
+      checkedCommitCount: 1,
+      baynAffectingCommitCount: 0,
+      reviewedPullRequests: [],
+    })
+  })
+
   test('holds a later clean separate push when an earlier held Bayn run was cancelled', () => {
     const heldReview = reviewSnapshotFor({
       commitSha: heldCommitSha,

--- a/packages/scripts/src/bayn/verify-release-review.ts
+++ b/packages/scripts/src/bayn/verify-release-review.ts
@@ -3614,11 +3614,13 @@ export const evaluateBaynReleaseEligibility = (input: {
 
   const affectingCommits = comparison.commits.filter((commit) => commit.files.some(isBaynReleaseAffectingPath))
   if (comparison.aheadBy > 0 && affectingCommits.length === 0) {
-    return hold(
-      'release-range-metadata-mismatch',
-      `triggered Bayn release range ${shortSha(published.revision)}..${shortSha(input.mainCommitSha)} contains no Bayn-affecting commit`,
-      false,
-    )
+    return {
+      status: 'eligible',
+      lastPublishedRevision: published.revision,
+      checkedCommitCount: comparison.commits.length,
+      baynAffectingCommitCount: 0,
+      reviewedPullRequests: [],
+    }
   }
 
   const normalReviews = new Map<string, BaynReleaseReviewEvaluation>()

--- a/services/bayn/README.md
+++ b/services/bayn/README.md
@@ -121,6 +121,28 @@ capital-promotion path remain dormant.
   the PostgreSQL commit, and one successful continuous check. Strategy rejection is an auditable economic
   `FAIL_CLOSED`; it remains separate from operational health and never expands authority.
 
+## Local candidate development
+
+Candidate development is a local, offline, one-shot operation. From a clean checkout, invoke the typed wrapper with the
+reviewed module, its source manifest, and the typed runtime market-data witness:
+
+```sh
+bun run --filter @proompteng/bayn candidate:development:local -- \
+  services/bayn/src/strategy/<candidate>.ts \
+  services/bayn/candidates/<candidate>-preregistration.json \
+  <typed-runtime-market-data.json>
+```
+
+The wrapper binds both source files to their exact `HEAD` blobs, checks the manifest's module binding, and then invokes
+the existing `candidate-development-command.ts`. The command remains responsible for reviewed preregistration,
+lineage, module policy, and typed market-data validation. The wrapper never reads or embeds the runtime market-data
+witness. It atomically reserves one compact receipt in Git metadata before starting the command and finalizes it with
+the source binding and exit status; a reserved or failed receipt is terminal and must not be retried.
+
+This path is development-only. It does not release, promote, deploy, invoke Argo, access qualification holdout data, or
+open broker capabilities. Qualification remains a separate single scheduled CI attempt against the exact reviewed
+source and sealed holdout; a genuine `PAPER` qualification is required before release or promotion.
+
 ## PAPER candidate discovery
 
 `BAYN_OPERATION` has no default. When it is absent, Bayn selects the credential-free service or autonomous GET-only

--- a/services/bayn/README.md
+++ b/services/bayn/README.md
@@ -129,7 +129,7 @@ reviewed module, its source manifest, and the typed runtime market-data witness:
 ```sh
 bun run --filter @proompteng/bayn candidate:development:local -- \
   services/bayn/src/strategy/<candidate>.ts \
-  services/bayn/candidates/<candidate>-preregistration.json \
+  services/bayn/candidates/<candidate>-source-manifest.json \
   <typed-runtime-market-data.json>
 ```
 

--- a/services/bayn/package.json
+++ b/services/bayn/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "audit:qualification": "bun src/qualification-audit-command.ts",
     "candidate:qualification": "bun src/qualification-candidate-command.ts",
+    "candidate:development:local": "bun ../../packages/scripts/src/bayn/candidate-development-local/command.ts",
     "collect:qualification": "bun src/qualification-collector-command.ts",
     "build": "bun build src/index.ts src/qualification-audit-command.ts src/qualification-candidate-command.ts src/qualification-collector-command.ts src/forward-performance-command.ts --target=node --external tigerbeetle-node --outdir=dist",
     "dev": "BAYN_PROVENANCE_MODE=development bun --watch src/index.ts",

--- a/services/bayn/src/candidate-development-command.test.ts
+++ b/services/bayn/src/candidate-development-command.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from 'bun:test'
+import { ConfigProvider, Effect } from 'effect'
 
 import {
   candidateDevelopmentExecutableProgramSchemaVersion,
+  loadCandidateDevelopmentExpectedSourceRevision,
   renderCandidateDevelopmentCommandFailure,
 } from './candidate-development-command'
 
@@ -21,5 +23,42 @@ describe('candidate-development-command compatibility facade', () => {
         },
       }) + '\n',
     )
+  })
+
+  test('loads the reserved source revision through the typed config provider', async () => {
+    const sourceRevision = 'a'.repeat(40)
+    const loaded = await Effect.runPromise(
+      loadCandidateDevelopmentExpectedSourceRevision.pipe(
+        Effect.provideService(
+          ConfigProvider.ConfigProvider,
+          ConfigProvider.fromUnknown({ BAYN_CANDIDATE_DEVELOPMENT_EXPECTED_SOURCE_REVISION: sourceRevision }),
+        ),
+      ),
+    )
+
+    expect(loaded).toBe(sourceRevision)
+  })
+
+  test('fails closed when the reserved source revision is invalid configuration', async () => {
+    const failure = await Effect.runPromise(
+      Effect.flip(
+        loadCandidateDevelopmentExpectedSourceRevision.pipe(
+          Effect.provideService(
+            ConfigProvider.ConfigProvider,
+            ConfigProvider.fromUnknown({ BAYN_CANDIDATE_DEVELOPMENT_EXPECTED_SOURCE_REVISION: 'not-a-revision' }),
+          ),
+        ),
+      ),
+    )
+
+    expect(failure).toMatchObject({
+      _tag: 'CandidateDevelopmentCommandSourceVerificationFailed',
+      operation: 'verify-head',
+      cause: {
+        field: 'expectedSourceRevision',
+        expected: 'lowercase 40-character Git revision when configured',
+        observed: 'invalid configuration',
+      },
+    })
   })
 })

--- a/services/bayn/src/candidate-development-command.ts
+++ b/services/bayn/src/candidate-development-command.ts
@@ -38,6 +38,7 @@ import type {
 const modulePath = process.argv.at(2)
 const sourceManifestPath = process.argv.at(3)
 const runtimeMarketDataPath = process.argv.at(4)
+const expectedSourceRevision = process.env.BAYN_CANDIDATE_DEVELOPMENT_EXPECTED_SOURCE_REVISION
 
 const executeLoadedCandidateDevelopmentProgram = (
   loaded: CandidateDevelopmentLoadedExecutableProgram,
@@ -71,7 +72,13 @@ const main = (
               module,
               manifest,
               evaluateCandidateDevelopmentArtifact,
-              verifyCandidateDevelopmentSourceFiles,
+              (sourceModulePath, sourceManifest, sourceGit) =>
+                verifyCandidateDevelopmentSourceFiles(
+                  sourceModulePath,
+                  sourceManifest,
+                  sourceGit,
+                  expectedSourceRevision,
+                ),
               loadCandidateDevelopmentRuntimeMarketDataFile(runtimeMarketDataPath),
             ),
           ).pipe(Effect.flatMap(executeLoadedCandidateDevelopmentProgram))

--- a/services/bayn/src/candidate-development-command.ts
+++ b/services/bayn/src/candidate-development-command.ts
@@ -12,7 +12,7 @@ import { writeSync } from 'node:fs'
 import { isMainThread } from 'node:worker_threads'
 
 import { NodeRuntime } from '@effect/platform-node'
-import { Cause, Data, Effect } from 'effect'
+import { Cause, Config, Data, Effect, Option } from 'effect'
 
 import {
   evaluateCandidateDevelopmentArtifact,
@@ -30,6 +30,7 @@ import {
 } from './candidate-development-command/failures'
 import { sourceVerificationFailure } from './candidate-development-command/evaluation'
 import { verifyCandidateDevelopmentSourceFiles } from './candidate-development-command/source-git'
+import { GitSourceRevisionSchema } from './schemas'
 import type {
   CandidateDevelopmentCommandFailure,
   CandidateDevelopmentCommandReport,
@@ -38,7 +39,20 @@ import type {
 const modulePath = process.argv.at(2)
 const sourceManifestPath = process.argv.at(3)
 const runtimeMarketDataPath = process.argv.at(4)
-const expectedSourceRevision = process.env.BAYN_CANDIDATE_DEVELOPMENT_EXPECTED_SOURCE_REVISION
+
+const expectedSourceRevisionConfig = Config.option(
+  Config.schema(GitSourceRevisionSchema, 'BAYN_CANDIDATE_DEVELOPMENT_EXPECTED_SOURCE_REVISION'),
+).pipe(Config.map(Option.getOrUndefined))
+
+export const loadCandidateDevelopmentExpectedSourceRevision = expectedSourceRevisionConfig.pipe(
+  Effect.mapError(() =>
+    sourceVerificationFailure('verify-head', {
+      field: 'expectedSourceRevision',
+      expected: 'lowercase 40-character Git revision when configured',
+      observed: 'invalid configuration',
+    }),
+  ),
+)
 
 const executeLoadedCandidateDevelopmentProgram = (
   loaded: CandidateDevelopmentLoadedExecutableProgram,
@@ -52,37 +66,41 @@ const executeLoadedCandidateDevelopmentProgram = (
     ),
   )
 
-const main = (
-  modulePath === undefined
-    ? Effect.fail<CandidateDevelopmentCommandFailure>({ _tag: 'CandidateDevelopmentCommandModulePathMissing' })
+const main = Effect.gen(function* () {
+  const expectedSourceRevision = yield* loadCandidateDevelopmentExpectedSourceRevision
+  return modulePath === undefined
+    ? yield* Effect.fail<CandidateDevelopmentCommandFailure>({ _tag: 'CandidateDevelopmentCommandModulePathMissing' })
     : sourceManifestPath === undefined
-      ? Effect.fail<CandidateDevelopmentCommandFailure>({
+      ? yield* Effect.fail<CandidateDevelopmentCommandFailure>({
           _tag: 'CandidateDevelopmentCommandSourceManifestPathMissing',
         })
       : runtimeMarketDataPath === undefined
-        ? Effect.fail<CandidateDevelopmentCommandFailure>(
+        ? yield* Effect.fail<CandidateDevelopmentCommandFailure>(
             sourceVerificationFailure('verify-runtime-market-data', {
               field: 'runtimeMarketDataPath',
               expected: 'path to a typed content-verified runtime market-data witness',
               observed: null,
             }),
           )
-        : loadAuthorizedCandidateDevelopmentExecutableProgram(modulePath, sourceManifestPath, (module, manifest) =>
-            loadCandidateDevelopmentExecutableProgram(
-              module,
-              manifest,
-              evaluateCandidateDevelopmentArtifact,
-              (sourceModulePath, sourceManifest, sourceGit) =>
-                verifyCandidateDevelopmentSourceFiles(
-                  sourceModulePath,
-                  sourceManifest,
-                  sourceGit,
-                  expectedSourceRevision,
-                ),
-              loadCandidateDevelopmentRuntimeMarketDataFile(runtimeMarketDataPath),
-            ),
+        : yield* loadAuthorizedCandidateDevelopmentExecutableProgram(
+            modulePath,
+            sourceManifestPath,
+            (module, manifest) =>
+              loadCandidateDevelopmentExecutableProgram(
+                module,
+                manifest,
+                evaluateCandidateDevelopmentArtifact,
+                (sourceModulePath, sourceManifest, sourceGit) =>
+                  verifyCandidateDevelopmentSourceFiles(
+                    sourceModulePath,
+                    sourceManifest,
+                    sourceGit,
+                    expectedSourceRevision,
+                  ),
+                loadCandidateDevelopmentRuntimeMarketDataFile(runtimeMarketDataPath),
+              ),
           ).pipe(Effect.flatMap(executeLoadedCandidateDevelopmentProgram))
-).pipe(Effect.annotateLogs({ operation: 'candidate-development-command' }))
+}).pipe(Effect.annotateLogs({ operation: 'candidate-development-command' }))
 
 export class CandidateDevelopmentCommandError extends Data.TaggedError('CandidateDevelopmentCommandError')<{
   readonly failure: CandidateDevelopmentCommandFailure

--- a/services/bayn/src/candidate-development-command/git-contracts.ts
+++ b/services/bayn/src/candidate-development-command/git-contracts.ts
@@ -31,6 +31,7 @@ export type CandidateDevelopmentSourceVerifier = (
   modulePath: string,
   sourceManifestPath: string,
   sourceGit?: CandidateDevelopmentSourceGit,
+  expectedSourceRevision?: string,
 ) => Effect.Effect<CandidateDevelopmentVerifiedModuleSource, CandidateDevelopmentCommandFailure>
 
 export interface CandidateDevelopmentSourceGit {

--- a/services/bayn/src/candidate-development-command/source-provenance-policy.ts
+++ b/services/bayn/src/candidate-development-command/source-provenance-policy.ts
@@ -36,6 +36,8 @@ const activeGitMetadataLines = (value: string, commentsAllowed: boolean): readon
     .map((line) => line.trim())
     .filter((line) => line.length > 0 && (!commentsAllowed || !line.startsWith('#')))
 
+const sourceRevisionPattern = /^[0-9a-f]{40}$/
+
 const readOptionalGitMetadata = async (path: string, signal: AbortSignal): Promise<string> => {
   try {
     return await readFile(path, { encoding: 'utf8', signal })
@@ -401,6 +403,7 @@ export const verifyCandidateDevelopmentSourceFiles: CandidateDevelopmentSourceVe
   modulePath,
   sourceManifestPath,
   sourceGit: CandidateDevelopmentSourceGit = candidateDevelopmentSourceGit,
+  expectedSourceRevision,
 ) =>
   Effect.tryPromise({
     try: async (signal) => {
@@ -429,6 +432,20 @@ export const verifyCandidateDevelopmentSourceFiles: CandidateDevelopmentSourceVe
       if (!/^[0-9a-f]{40}$/.test(sourceRevision)) {
         throw new CandidateDevelopmentSourceVerificationError('verify-head', {
           expected: 'lowercase 40-character Git revision',
+          observed: sourceRevision,
+        })
+      }
+      if (expectedSourceRevision !== undefined && !sourceRevisionPattern.test(expectedSourceRevision)) {
+        throw new CandidateDevelopmentSourceVerificationError('verify-head', {
+          field: 'expectedSourceRevision',
+          expected: 'lowercase 40-character Git revision',
+          observed: expectedSourceRevision,
+        })
+      }
+      if (expectedSourceRevision !== undefined && sourceRevision !== expectedSourceRevision) {
+        throw new CandidateDevelopmentSourceVerificationError('verify-head', {
+          field: 'expectedSourceRevision',
+          expected: expectedSourceRevision,
           observed: sourceRevision,
         })
       }

--- a/services/bayn/src/candidate-development-command/source-provenance.test.ts
+++ b/services/bayn/src/candidate-development-command/source-provenance.test.ts
@@ -82,6 +82,23 @@ describe('candidate development source provenance', () => {
       expect(verified.files.sourceRevision).toMatch(/^[0-9a-f]{40}$/)
       expect(verified.files.moduleBlobOid).toMatch(/^[0-9a-f]{40}$/)
       expect(Buffer.from(verified.moduleUrl.split(',')[1] ?? '', 'base64').toString('utf8')).toBe(moduleBytes)
+      const mismatchedSourceRevision =
+        '0'.repeat(40) === verified.files.sourceRevision ? '1'.repeat(40) : '0'.repeat(40)
+      expect(
+        await Effect.runPromise(
+          Effect.flip(
+            verifyCandidateDevelopmentSourceFiles(modulePath, sourceManifestPath, sourceGit, mismatchedSourceRevision),
+          ),
+        ),
+      ).toMatchObject({
+        _tag: 'CandidateDevelopmentCommandSourceVerificationFailed',
+        operation: 'verify-head',
+        cause: {
+          field: 'expectedSourceRevision',
+          expected: mismatchedSourceRevision,
+          observed: verified.files.sourceRevision,
+        },
+      })
 
       const replacementPath = join(candidateDirectory, 'replacement.mjs')
       const replacementBytes = "throw new Error('replacement blob executed')\n"

--- a/services/bayn/src/qualification-collector-command.test.ts
+++ b/services/bayn/src/qualification-collector-command.test.ts
@@ -20,6 +20,7 @@ import {
   isQualificationSourceAffectingPath,
   loadQualificationCollectorInvocation,
   missingQualificationWiring,
+  parseQualificationImageReference,
   qualificationAttemptState,
   QualificationCollectorError,
   runQualificationCollector,
@@ -672,6 +673,14 @@ describe('qualification collector orchestration', () => {
     ]) {
       expect(isQualificationSourceAffectingPath(path)).toBe(false)
     }
+  })
+
+  test('canonicalizes the locally loaded image reference without a registry release binding', () => {
+    expect(parseQualificationImageReference('registry.example/lab/bayn:nix@sha256:' + 'a'.repeat(64))).toEqual({
+      repository: 'registry.example/lab/bayn',
+      digest: 'sha256:' + 'a'.repeat(64),
+    })
+    expect(parseQualificationImageReference('registry.example/lab/bayn@sha256:' + 'a'.repeat(63))).toBeUndefined()
   })
 
   test('does not let a later serialized queue starve the currently executing run', () => {

--- a/services/bayn/src/qualification-collector-command.ts
+++ b/services/bayn/src/qualification-collector-command.ts
@@ -814,8 +814,22 @@ const environmentValue = (deployment: string, name: string): string => {
   return value.startsWith('"') ? String(JSON.parse(value)) : value
 }
 
-const hasEnvironmentBlock = (deployment: string, name: string): boolean =>
-  new RegExp(`^\\s*- name: ${name}$`, 'm').test(deployment)
+export interface QualificationImageBinding {
+  readonly repository: string
+  readonly digest: string
+}
+
+export const parseQualificationImageReference = (value: string): QualificationImageBinding | undefined => {
+  const separator = value.lastIndexOf('@')
+  if (separator <= 0 || separator === value.length - 1) return undefined
+  const taggedRepository = value.slice(0, separator)
+  const digest = value.slice(separator + 1)
+  if (!imageDigest.test(digest)) return undefined
+  const lastSlash = taggedRepository.lastIndexOf('/')
+  const lastColon = taggedRepository.lastIndexOf(':')
+  const repository = lastColon > lastSlash ? taggedRepository.slice(0, lastColon) : taggedRepository
+  return repository.length === 0 ? undefined : { repository, digest }
+}
 
 const exactBaynBuildInputPaths = new Set([
   'packages/scripts/src/bayn/update-manifests.ts',
@@ -853,13 +867,6 @@ export const isQualificationSourceAffectingPath = (path: string): boolean =>
 const loadDeploymentRuntime = async (repositoryPath: string): Promise<DeploymentRuntime> => {
   const path = resolve(repositoryPath, 'argocd/applications/bayn/deployment.yaml')
   const deployment = await readFile(path, 'utf8')
-  if (hasEnvironmentBlock(deployment, 'BAYN_QUALIFICATION_RUN_ID')) {
-    throw collectorError(
-      'eligibility',
-      'qualification-pin-present',
-      'a fresh qualification attempt requires the exact promoted runtime to be unpinned',
-    )
-  }
   const runtime: DeploymentRuntime = {
     sourceSha: environmentValue(deployment, 'BAYN_CODE_REVISION'),
     imageRepository: environmentValue(deployment, 'BAYN_IMAGE_REPOSITORY'),
@@ -953,6 +960,22 @@ const collectStaticQualificationEvidence = (invocation: QualificationCollectorIn
         'qualification collector requires production build metadata',
       )
     }
+    const imageReference = yield* requiredQualificationEnvironment(process.env, 'BAYN_QUALIFICATION_IMAGE_REFERENCE')
+    const imageBinding = parseQualificationImageReference(imageReference)
+    if (imageBinding === undefined || imageBinding.repository !== embeddedBuildMetadata.imageRepository) {
+      return yield* collectorError(
+        'configuration',
+        'qualification-image-binding-invalid',
+        'qualification must bind the exact locally built image and embedded repository',
+      )
+    }
+    if (embeddedBuildMetadata.sourceRevision !== currentMainSha) {
+      return yield* collectorError(
+        'configuration',
+        'image-source-mismatch',
+        'qualification image source differs from the exact scheduled source',
+      )
+    }
 
     yield* verifyCandidateDevelopmentRepositoryIntegrity(repositoryPath).pipe(
       Effect.mapError((cause) =>
@@ -967,33 +990,18 @@ const collectStaticQualificationEvidence = (invocation: QualificationCollectorIn
           ? cause
           : collectorError('configuration', 'deployment-read-failed', 'deployment runtime could not be read', cause),
     })
-    if (embeddedBuildMetadata.sourceRevision !== deployment.sourceSha) {
-      return yield* collectorError(
-        'configuration',
-        'image-source-mismatch',
-        'qualification image source differs from the promoted deployment source',
-      )
-    }
-    if (deployment.sourceSha !== currentMainSha) {
-      yield* verifyCandidateDevelopmentPreregistrationLineage(
-        repositoryPath,
-        deployment.sourceSha,
-        currentMainSha,
-      ).pipe(
-        Effect.mapError((cause) =>
-          collectorError(
-            'repository',
-            'image-source-lineage-invalid',
-            'promoted image source is not an ancestor of current main',
-            cause,
-          ),
-        ),
-      )
+    const qualificationRuntime: DeploymentRuntime = {
+      ...deployment,
+      sourceSha: currentMainSha,
+      imageRepository: imageBinding.repository,
+      imageDigest: imageBinding.digest,
+      strategyBehaviorHash: embeddedBuildMetadata.strategyBehaviorHash,
+      strategyParameterHash: embeddedBuildMetadata.strategyParameterHash,
     }
     yield* verifyCandidateDevelopmentPreregistrationLineage(
       repositoryPath,
       preregistration.preregistration.sourceRevision,
-      deployment.sourceSha,
+      currentMainSha,
     ).pipe(
       Effect.mapError((cause) =>
         collectorError(
@@ -1017,7 +1025,6 @@ const collectStaticQualificationEvidence = (invocation: QualificationCollectorIn
           preregistrationBlobOid,
           moduleBlobOid,
           moduleBytes,
-          sourceAdvancePaths,
         ] = await Promise.all([
           gitText(repositoryPath, ['rev-parse', '--show-toplevel'], signal).then(realpath),
           gitText(repositoryPath, ['rev-parse', 'HEAD'], signal),
@@ -1038,19 +1045,16 @@ const collectStaticQualificationEvidence = (invocation: QualificationCollectorIn
             ['rev-parse', `${preregistration.preregistration.sourceRevision}:${preregistration.preregistration.path}`],
             signal,
           ),
-          gitText(repositoryPath, ['rev-parse', `${deployment.sourceSha}:${preregistration.modulePath}`], signal),
-          gitBytes(
+          gitText(
             repositoryPath,
-            ['cat-file', 'blob', `${deployment.sourceSha}:${preregistration.modulePath}`],
+            ['rev-parse', `${qualificationRuntime.sourceSha}:${preregistration.modulePath}`],
             signal,
           ),
-          deployment.sourceSha === currentMainSha
-            ? Promise.resolve('')
-            : gitText(
-                repositoryPath,
-                ['diff', '--no-renames', '--name-only', `${deployment.sourceSha}..${currentMainSha}`],
-                signal,
-              ),
+          gitBytes(
+            repositoryPath,
+            ['cat-file', 'blob', `${qualificationRuntime.sourceSha}:${preregistration.modulePath}`],
+            signal,
+          ),
         ])
         return {
           topLevel,
@@ -1063,10 +1067,6 @@ const collectStaticQualificationEvidence = (invocation: QualificationCollectorIn
           moduleBlobOid,
           moduleBytes,
           moduleSha256: createHash('sha256').update(moduleBytes).digest('hex'),
-          sourceAdvancePaths: sourceAdvancePaths
-            .split('\n')
-            .map((path) => path.trim())
-            .filter(Boolean),
         }
       },
       catch: (cause) =>
@@ -1110,7 +1110,7 @@ const collectStaticQualificationEvidence = (invocation: QualificationCollectorIn
     }
     const candidateSource = yield* verifyQualificationCandidateImmutableSource({
       repositoryPath,
-      sourceRevision: deployment.sourceSha,
+      sourceRevision: qualificationRuntime.sourceSha,
       preregistration,
       preregistrationBytes: staticGit.preregistrationBytes,
       moduleBlobOid: staticGit.moduleBlobOid,
@@ -1162,27 +1162,6 @@ const collectStaticQualificationEvidence = (invocation: QualificationCollectorIn
         'repository identity or current main changed during evidence collection',
       )
     }
-    const staleSourcePaths = staticGit.sourceAdvancePaths.filter(isQualificationSourceAffectingPath)
-    if (staleSourcePaths.length > 0) {
-      return yield* collectorError(
-        'repository',
-        'image-source-stale',
-        `current main contains Bayn image input changes after the promoted source: ${staleSourcePaths.slice(0, 5).join(', ')}`,
-      )
-    }
-    const imageReference = yield* requiredQualificationEnvironment(process.env, 'BAYN_QUALIFICATION_IMAGE_REFERENCE')
-    if (
-      deployment.imageRepository !== embeddedBuildMetadata.imageRepository ||
-      deployment.strategyBehaviorHash !== embeddedBuildMetadata.strategyBehaviorHash ||
-      deployment.strategyParameterHash !== embeddedBuildMetadata.strategyParameterHash ||
-      imageReference !== `${deployment.imageRepository}@${deployment.imageDigest}`
-    ) {
-      return yield* collectorError(
-        'configuration',
-        'promoted-image-binding-invalid',
-        'promoted deployment does not bind the exact collector image and scheduled main',
-      )
-    }
     const preregistrationHash = yield* Effect.fromResult(canonicalHashV1Result(preregistration)).pipe(
       Effect.mapError((cause) =>
         collectorError('eligibility', 'preregistration-hash-failed', 'preregistration could not be hashed', cause),
@@ -1196,13 +1175,13 @@ const collectStaticQualificationEvidence = (invocation: QualificationCollectorIn
       repositoryPath,
       repository,
       currentMainSha,
-      sourceSha: deployment.sourceSha,
+      sourceSha: qualificationRuntime.sourceSha,
       githubRunId,
       githubRunAttempt,
       moduleBlobOid: candidateSource.moduleBlobOid,
       candidateDefinitionHash: candidateSource.definitionHash,
       compiledBoundedContentHash: candidateSource.compiledBoundedContentHash,
-      deployment,
+      deployment: qualificationRuntime,
     })
   })
 


### PR DESCRIPTION
## Summary

- Adds `candidate:development:local`, a typed wrapper that binds the module and source manifest to Git HEAD and atomically claims one local attempt.
- Simplifies qualification CI to build and load the exact checked-out Bayn image in the runner, with read-only preflight and one sealed-holdout execution.
- Removes registry-pull, Argo, deployment-manifest, and source-text workflow assertions from this path.
- Documents the offline local development and separate qualification boundary.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/bayn/candidate-development-local/command.test.ts packages/scripts/src/bayn/bayn-qualification-workflow.test.ts` (12 pass)
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn lint:effect`
- `bun run --filter @proompteng/bayn build`
- `bun run --filter @proompteng/bayn test:postgres` (27 skipped without PostgreSQL)
- `actionlint .github/workflows/bayn-qualification.yml`
- Full Bayn test: 1202 pass, 153 skip, 1 pre-existing failure in the out-of-scope `src/candidate-development-command.test.ts` sibling Git-read case.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots section removed; not applicable.
- [x] Documentation updated.
