### PR TITLE
refactor(bayn): model candidate development trial state machine

### DIFF
--- a/services/bayn/src/candidate-development-decision.ts
+++ b/services/bayn/src/candidate-development-decision.ts
@@ -12,6 +12,7 @@ export type {
   CandidateDevelopmentImmutableInvalidation,
   CandidateDevelopmentNextAction,
   CandidateDevelopmentQualificationTerminalEvidence,
+  CandidateDevelopmentSuccessorKind,
   CandidateDevelopmentTrialState,
   CandidateDevelopmentTrialStateIssue,
   CandidateDevelopmentTrialStateIssueReason,

--- a/services/bayn/src/candidate-development-decision.ts
+++ b/services/bayn/src/candidate-development-decision.ts
@@ -1,30 +1,29 @@
 import { candidateDevelopmentComparisonSemantics, candidateDevelopmentStatisticsPolicy } from './candidate-development'
 import type { QualificationSelectedBenchmarkComparisonAnalysis } from './qualification-statistics'
 
-export interface CandidateDevelopmentNextPreregistration {
-  readonly schemaVersion: 'bayn.candidate-development-next-preregistration.v1'
-  readonly candidateOrdinal: number
-  readonly priorTrialCount: number
-  readonly strategyProtocolHash: string
-  readonly strategyIdentityHash?: string
-  readonly candidateDevelopmentProtocolHash?: string
-  readonly calendarHash?: string
-  readonly priorTrialsHash?: string
-  readonly modulePath: string
-  readonly moduleSha256: string
-  readonly marketData: {
-    readonly schemaVersion: 'bayn.candidate-development-market-data-source.v1'
-    readonly snapshotId: string
-    readonly finalizedSnapshotContentHash: string
-    readonly inputManifestHash: string
-    readonly boundedContentHash: string
-  }
-  readonly preregistration: {
-    readonly sourceRevision: string
-    readonly path: string
-    readonly blobOid: string
-  }
-}
+export type { CandidateDevelopmentNextPreregistration } from './candidate-development-trials/state-machine'
+
+export type {
+  CandidateDevelopmentAttemptConsumption,
+  CandidateDevelopmentCurrentSuccessor,
+  CandidateDevelopmentDevelopmentOnlyTrial,
+  CandidateDevelopmentDevelopmentTerminalEvidence,
+  CandidateDevelopmentHistoricalQualificationTrial,
+  CandidateDevelopmentImmutableInvalidation,
+  CandidateDevelopmentNextAction,
+  CandidateDevelopmentQualificationTerminalEvidence,
+  CandidateDevelopmentTrialState,
+  CandidateDevelopmentTrialStateIssue,
+  CandidateDevelopmentTrialStateIssueReason,
+  CandidateDevelopmentTrialTransition,
+  CandidateDevelopmentTrialTransitionDecision,
+} from './candidate-development-trials/state-machine'
+export {
+  deriveCandidateDevelopmentNextAction,
+  nextCandidateDevelopmentOrdinal,
+  reduceCandidateDevelopmentTrialState,
+  validateCandidateDevelopmentTrialState,
+} from './candidate-development-trials/state-machine'
 
 export type CandidateDevelopmentGateName =
   | (typeof candidateDevelopmentComparisonSemantics.gates)[keyof typeof candidateDevelopmentComparisonSemantics.gates]['name']

--- a/services/bayn/src/candidate-development-trial-history.ts
+++ b/services/bayn/src/candidate-development-trial-history.ts
@@ -14,6 +14,7 @@ export type {
   CandidateDevelopmentQualificationEvidence,
   CandidateDevelopmentQualificationPreregistration,
   CandidateDevelopmentQualificationTerminalEvidence,
+  CandidateDevelopmentSuccessorKind,
   CandidateDevelopmentTrialHistory,
   CandidateDevelopmentTrialState,
   CandidateDevelopmentTrialStateIssue,

--- a/services/bayn/src/candidate-development-trials/frozen-lineage.ts
+++ b/services/bayn/src/candidate-development-trials/frozen-lineage.ts
@@ -100,6 +100,13 @@ export const candidate19DevelopmentFailureEvidenceExpectation = {
   developmentMetricsObserved: true,
 } as const
 
+/** The frozen archive records these metric-bearing observations for normalized historical trials. */
+export const frozenDevelopmentMetricObservations: Readonly<Partial<Record<number, boolean>>> = Object.freeze({
+  17: true,
+  18: candidate18DevelopmentFailureEvidenceExpectation.developmentMetricsObserved,
+  19: candidate19DevelopmentFailureEvidenceExpectation.developmentMetricsObserved,
+})
+
 export const candidate19DevelopmentEligibility = {
   status: 'DEVELOPMENT_REJECTED',
   evidenceContentHash: candidate19DevelopmentFailureEvidenceExpectation.evidenceContentHash,

--- a/services/bayn/src/candidate-development-trials/frozen-lineage.ts
+++ b/services/bayn/src/candidate-development-trials/frozen-lineage.ts
@@ -1,0 +1,300 @@
+import { candidateDevelopmentCalendarContract } from '../candidate-development'
+import type {
+  CandidateDevelopmentInvalidPrecommit,
+  CandidateDevelopmentLegacyPriorTrialsMaterial,
+  CandidateDevelopmentNextPreregistration,
+  CandidateDevelopmentPriorTrialsMaterial,
+  CandidateDevelopmentQualificationEvidence,
+  CandidateDevelopmentQualificationPreregistration,
+  CandidateDevelopmentTrialHistory,
+} from './model'
+import { canonicalHashV1Result } from '../hash'
+
+export const candidate16TerminalEvidence: CandidateDevelopmentQualificationEvidence = {
+  candidateOrdinal: 16,
+  priorTrialCount: 15,
+  terminalStatus: 'HOLD_REJECT',
+  sourceRevision: '60a48a2e52fbafdd67a404a33a3cb22e82a98493',
+}
+
+export const candidate16Preregistration: CandidateDevelopmentQualificationPreregistration = {
+  candidateOrdinal: 16,
+  priorTrialCount: 15,
+  sourceRevision: 'a0dadcd2f6346968bd9df582e4673608afc04592',
+  path: 'services/bayn/candidates/ordinal-16-macro-breadth-regime-preregistration.md',
+  blobOid: 'f602e3c8fd1b85768404d5fbc439775cdcd2570b',
+}
+
+export const candidate17Preregistration: CandidateDevelopmentNextPreregistration = {
+  schemaVersion: 'bayn.candidate-development-next-preregistration.v1',
+  candidateOrdinal: 17,
+  priorTrialCount: 16,
+  strategyProtocolHash: 'fa25d8c16bc4f4fde3bab99409ae60a6fd23332d295b3557231796cebb911390',
+  modulePath: 'services/bayn/src/strategy/volatility-managed-trend-overlay/candidate-17.ts',
+  moduleSha256: '2e98bc55eae1901ccdde41978b7b32d746dc2ef6afcebbff1de0ed54574065da',
+  marketData: {
+    schemaVersion: 'bayn.candidate-development-market-data-source.v1',
+    snapshotId: '2a91f0177684f7022f746207333e510c8268f9b77a04b778a04220a33ccf79e0',
+    finalizedSnapshotContentHash: '8e376546f6a6cc1dbe2e910db3d68f584fc0bd9c4858166042ce32aa077eed0d',
+    inputManifestHash: 'b606cf57fb076f5bd2875206973e7c512817430d5cfbbeac8a99396f9983cab4',
+    boundedContentHash: 'e0e7b283de187d8ccaf8a449dacc538f00049cfe446dcf153b558e92bf0e17ed',
+  },
+  preregistration: {
+    sourceRevision: '890d8f5801cf7c7576ed7a0cee387a4e79b98877',
+    path: 'services/bayn/candidates/ordinal-17-volatility-managed-trend-overlay-preregistration.json',
+    blobOid: 'c1d07233df53cc0379b1dfae9f1caffbd6b7abd6',
+  },
+}
+
+export const candidate17DevelopmentEvidenceExpectation = {
+  bindings: {
+    schemaVersion: 'bayn.candidate-development-evidence-bindings.v1',
+    candidateOrdinal: 17,
+    priorTrialCount: 16,
+    preregistration: candidate17Preregistration.preregistration,
+    reviewedSourceRevision: '9a293a7a8f7cb4ed5c8ddf41d7dbf9abecb12510',
+    mergedSourceRevision: '4f39bb8ad168c3a459afdfdb30feccd49aba22d8',
+    module: {
+      path: candidate17Preregistration.modulePath,
+      blobOid: '8d1ccbfc6bef2c1707ac85f51d1647a7a8bfd98b',
+      sha256: candidate17Preregistration.moduleSha256,
+    },
+    sourceManifest: {
+      path: 'services/bayn/candidates/ordinal-17-volatility-managed-trend-overlay-source-manifest.json',
+      blobOid: '23521cd435a97045adf18d1f075599fe5d22d750',
+      sha256: 'ffc4d8cb6e473d660096dc18fe786d0b498adbab70bce9a3814c8bf3fdaeb954',
+    },
+    strategyProtocolHash: candidate17Preregistration.strategyProtocolHash,
+    candidateDevelopmentProtocolHash: '72754b1178308c721a43aa1b295a374ccb82cb6c0a790187bdfc4f4ed066302a',
+    marketData: candidate17Preregistration.marketData,
+    calendar: candidateDevelopmentCalendarContract,
+  },
+  evidenceContentHash: '97b9c2d6dc1d59d9b60686065bc4d595b8d1f22cdff9930b6131427b90e13f26',
+  independentlyReproducedEvaluationHash: 'c7e551fc6352c4294f38e083b8743b882f2874ec4d614f46a04539d2a72d79a1',
+  independentlyReproducedDecisionOutputHash: '9d76278fa34c18d38110b42980e65dd7941267968420e10fa0c0515b5075ed14',
+} as const
+
+export const candidate17DevelopmentEligibility = {
+  status: 'DEVELOPMENT_REJECTED',
+  evidenceContentHash: candidate17DevelopmentEvidenceExpectation.evidenceContentHash,
+  nextCandidatePreregistration: null,
+} as const
+
+export const candidate18DevelopmentFailureEvidenceExpectation = {
+  evidenceContentHash: '65d6f044f3f323aa87ff26a3dca011053aa3172c8a4ce422841497ccf370a5b6',
+  evaluatedSourceRevision: '24465ada2b5e1e04c5058ad812b1eedd9f58b0dd',
+  failureStage: 'buildEvaluation-preflight',
+  developmentMetricsObserved: false,
+} as const
+
+export const candidate18DevelopmentEligibility = {
+  status: 'DEVELOPMENT_REJECTED',
+  evidenceContentHash: candidate18DevelopmentFailureEvidenceExpectation.evidenceContentHash,
+  nextCandidatePreregistration: null,
+} as const
+
+export const candidate19DevelopmentFailureEvidenceExpectation = {
+  evidenceContentHash: '6170af41ddc14c04412a1929a60c88f35062ec2440f6e4b3beb0539bd411f364',
+  evaluatedSourceRevision: '276805b77d783db907dcb86cba934d7a4f6a0147',
+  failureStage: 'development-evaluation',
+  developmentMetricsObserved: true,
+} as const
+
+export const candidate19DevelopmentEligibility = {
+  status: 'DEVELOPMENT_REJECTED',
+  evidenceContentHash: candidate19DevelopmentFailureEvidenceExpectation.evidenceContentHash,
+  nextCandidatePreregistration: null,
+} as const
+
+export const candidate18Preregistration: CandidateDevelopmentNextPreregistration = {
+  schemaVersion: 'bayn.candidate-development-next-preregistration.v1',
+  candidateOrdinal: 18,
+  priorTrialCount: 17,
+  strategyProtocolHash: '7e27320b47cd170c1bc9c60ec3692593f2182af44bb48cef4d4a403b09601d75',
+  strategyIdentityHash: 'ff762a985c129055670224dca5827a65c689f6f50e1e3765e7b521a05417b1f0',
+  candidateDevelopmentProtocolHash: '46657425873b4f766b5f49d0ebbe2ac3aa9cf53682a8508635be708406271877',
+  calendarHash: '4b2f519f336e4e730c1f0d69e860f25a8d4d0cfbd8e93c6b333ea83623d87237',
+  priorTrialsHash: '58f4e801380f35f483f998e00c82889e0cb6257e85542764e2dc8eaa4f3fd419',
+  modulePath: 'services/bayn/src/strategy/dual-momentum-global-equity/candidate-18.ts',
+  moduleSha256: '27466a8c9a9acba475db9cd0d2916532208540a53bd1f0ece307df299e5e34e8',
+  marketData: candidate17Preregistration.marketData,
+  preregistration: {
+    sourceRevision: '30614640c5dfa7a7d50bf053df153062ff0bbca4',
+    path: 'services/bayn/candidates/ordinal-18-global-equity-dual-momentum-preregistration.json',
+    blobOid: '920a4afb8a7e5c1f6ef0875683ddc96a91008079',
+  },
+}
+
+export const candidate19Preregistration: CandidateDevelopmentNextPreregistration = {
+  schemaVersion: 'bayn.candidate-development-next-preregistration.v1',
+  candidateOrdinal: 19,
+  priorTrialCount: 18,
+  strategyProtocolHash: 'b4a2a6c65a7fa5973f7cbc1fd5031e77d529f4884562e5cc8a105fc870ced78f',
+  strategyIdentityHash: 'ccf8f03db1f0f9eb54f7ad42194c938e5a53e11573488fd31e7af871967af25a',
+  candidateDevelopmentProtocolHash: '663b59d6c570bbe3373d6e160609e0ad6294a687f435416f2a0956888d960738',
+  calendarHash: '4b2f519f336e4e730c1f0d69e860f25a8d4d0cfbd8e93c6b333ea83623d87237',
+  priorTrialsHash: '1dfc9b6832d4841093becd2c276141110afdfce28a0a88b301cfe9959b900d62',
+  modulePath: 'services/bayn/src/strategy/inverse-volatility-risk-diversification/candidate-19.ts',
+  moduleSha256: '90813ab3a3d3cb000bb894309694f94588f98730a6f78b8e1418a5c38d8cb45f',
+  marketData: candidate18Preregistration.marketData,
+  preregistration: {
+    sourceRevision: 'bb24ec2ab4225b13920a2b50fb137c4134d2d75f',
+    path: 'services/bayn/candidates/ordinal-19-inverse-volatility-risk-diversification-preregistration.json',
+    blobOid: '02d9150a1f0007a644a084b3fca4cd543131374e',
+  },
+}
+
+export const candidate20Preregistration: CandidateDevelopmentNextPreregistration = {
+  schemaVersion: 'bayn.candidate-development-next-preregistration.v1',
+  candidateOrdinal: 20,
+  priorTrialCount: 19,
+  strategyProtocolHash: '18b61d027e2235c7fc8ba718313ae8863650c2cb7c497dc4a7a5028829d19e0f',
+  strategyIdentityHash: '8c99589120d8f3ed36c5286ce119d20490d42becd014e7fc2cc97b1420600278',
+  candidateDevelopmentProtocolHash: 'f7d4d78e70401c01c141fc7b63c4c1cfe9e7350b973c40ffbd7d8fe9832b332f',
+  calendarHash: '4b2f519f336e4e730c1f0d69e860f25a8d4d0cfbd8e93c6b333ea83623d87237',
+  priorTrialsHash: 'dfda4c7706cdd7b2999a863ac63714c5d46894027442253f031b69bcdeaefde0',
+  modulePath: 'services/bayn/src/strategy/cross-sectional-short-term-reversal/candidate-20.ts',
+  moduleSha256: '15570022245f8bba1c121c6657369d66085d6c3659aa326b50048be1ab050441',
+  marketData: candidate19Preregistration.marketData,
+  preregistration: {
+    sourceRevision: '0b0a951465e1c4644bc3fd04b7b448b8701dc609',
+    path: 'services/bayn/candidates/ordinal-20-cross-sectional-short-term-reversal-preregistration.json',
+    blobOid: '066a4d44cd41b871cad95474eb00e411af532c76',
+  },
+}
+
+export const candidate20PrecommitInvalidation: CandidateDevelopmentInvalidPrecommit = {
+  schemaVersion: 'bayn.candidate-development-precommit-invalidation.v1',
+  candidateOrdinal: 20,
+  priorTrialCount: 19,
+  status: 'PRECOMMIT_INVALID',
+  attemptStatus: 'UNATTEMPTED',
+  metricBearingAttemptsConsumed: 0,
+  qualificationAttemptConsumed: false,
+  reviewedHeadRevision: '82f58dd6bd6fc9849e779665873f934841b47ea7',
+  mergedSourceRevision: '69d803040c8866e7703df50a645a096c54e7eca5',
+  preregistration: {
+    sourceRevision: candidate20Preregistration.preregistration.sourceRevision,
+    path: candidate20Preregistration.preregistration.path,
+    blobOid: candidate20Preregistration.preregistration.blobOid,
+    sha256: 'e392888970d3c510e3ad20d6e982b81bf6234cd17260c8c5203013b5ce979409',
+  },
+  sourceManifest: {
+    path: 'services/bayn/candidates/ordinal-20-cross-sectional-short-term-reversal-source-manifest.json',
+    blobOid: 'def5faba5a301b8fe4daa8f0557e8d53efb4b697',
+    sha256: 'b5d9c4da95f59d4d4483fa80665de5327f4ed0b04c3afa8a94a3316b91f9e1fe',
+  },
+  invalidatedModule: {
+    path: candidate20Preregistration.modulePath,
+    blobOid: '71ae99e9303e7b79a640f185e70faa68a3048910',
+    sha256: candidate20Preregistration.moduleSha256,
+    lineCount: 123_194,
+    byteCount: 2_963_738,
+    findings: [
+      'TYPE_CHECK_DISABLED',
+      'DOWNCOMPILED_BUNDLE',
+      'EMBEDDED_OFFICIAL_SESSIONS',
+      'EMBEDDED_MARKET_BARS',
+      'RUNTIME_INPUT_IGNORED',
+    ],
+  },
+  naturalBuild: {
+    runId: '30657379582',
+    imagePublished: true,
+    imageDigest: 'sha256:28f59fb44bdb3008eecd17cf3c053098f214f3d982f26673a44a98d53f767fba',
+    deploymentAllowed: false,
+  },
+  release: {
+    runId: '30657658256',
+    conclusion: 'CANCELLED',
+    promotionCompleted: false,
+    rerunAllowed: false,
+  },
+  nextCandidatePreregistration: null,
+}
+
+export const candidate18LegacyPriorTrialsMaterial: CandidateDevelopmentLegacyPriorTrialsMaterial = {
+  schemaVersion: 'bayn.candidate-development-prior-trials.v1',
+  qualificationCandidateOrdinals: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
+  developmentCandidateOrdinals: [17],
+  latestDevelopmentEvidence: {
+    candidateOrdinal: 17,
+    priorTrialCount: 16,
+    status: 'DEVELOPMENT_REJECTED',
+    evidenceContentHash: candidate17DevelopmentEvidenceExpectation.evidenceContentHash,
+    qualificationAttemptConsumed: false,
+  },
+  latestReviewedPreregistration: candidate17Preregistration,
+}
+
+export const candidate18PriorTrialsMaterial: CandidateDevelopmentPriorTrialsMaterial = {
+  schemaVersion: 'bayn.candidate-development-prior-trials.v2',
+  qualificationCandidateOrdinals: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
+  latestQualificationEvidence: candidate16TerminalEvidence,
+  latestQualificationPreregistration: candidate16Preregistration,
+  developmentCandidateOrdinals: candidate18LegacyPriorTrialsMaterial.developmentCandidateOrdinals,
+  latestDevelopmentEvidence: candidate18LegacyPriorTrialsMaterial.latestDevelopmentEvidence,
+  latestReviewedPreregistration: candidate18LegacyPriorTrialsMaterial.latestReviewedPreregistration,
+}
+
+export const candidate19PriorTrialsMaterial: CandidateDevelopmentPriorTrialsMaterial = {
+  schemaVersion: 'bayn.candidate-development-prior-trials.v2',
+  qualificationCandidateOrdinals: candidate18PriorTrialsMaterial.qualificationCandidateOrdinals,
+  latestQualificationEvidence: candidate16TerminalEvidence,
+  latestQualificationPreregistration: candidate16Preregistration,
+  developmentCandidateOrdinals: [17, 18],
+  latestDevelopmentEvidence: {
+    candidateOrdinal: 18,
+    priorTrialCount: 17,
+    status: 'DEVELOPMENT_REJECTED',
+    evidenceContentHash: candidate18DevelopmentFailureEvidenceExpectation.evidenceContentHash,
+    qualificationAttemptConsumed: false,
+  },
+  latestReviewedPreregistration: candidate18Preregistration,
+}
+
+export const candidate20PriorTrialsMaterial: CandidateDevelopmentPriorTrialsMaterial = {
+  schemaVersion: 'bayn.candidate-development-prior-trials.v2',
+  qualificationCandidateOrdinals: candidate19PriorTrialsMaterial.qualificationCandidateOrdinals,
+  latestQualificationEvidence: candidate16TerminalEvidence,
+  latestQualificationPreregistration: candidate16Preregistration,
+  developmentCandidateOrdinals: [17, 18, 19],
+  latestDevelopmentEvidence: {
+    candidateOrdinal: 19,
+    priorTrialCount: 18,
+    status: 'DEVELOPMENT_REJECTED',
+    evidenceContentHash: candidate19DevelopmentFailureEvidenceExpectation.evidenceContentHash,
+    qualificationAttemptConsumed: false,
+  },
+  latestReviewedPreregistration: candidate19Preregistration,
+}
+
+export const deriveCandidateDevelopmentLegacyPriorTrialsHash = (
+  material: CandidateDevelopmentLegacyPriorTrialsMaterial,
+) => canonicalHashV1Result(material)
+
+export const deriveCandidateDevelopmentPriorTrialsHash = (material: CandidateDevelopmentPriorTrialsMaterial) =>
+  canonicalHashV1Result(material)
+
+export const frozenCandidateDevelopmentTrialHistory: CandidateDevelopmentTrialHistory = {
+  schemaVersion: 'bayn.candidate-development-trial-history.v2',
+  completedCandidateOrdinals: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
+  developmentCandidateOrdinals: [17, 18, 19],
+  latestReviewedCandidateLegacyPriorTrials: candidate18LegacyPriorTrialsMaterial,
+  latestReviewedCandidatePriorTrials: candidate20PriorTrialsMaterial,
+  latestTerminalEvidence: candidate16TerminalEvidence,
+  candidatePreregistration: candidate16Preregistration,
+  latestReviewedCandidatePreregistration: candidate20Preregistration,
+  latestDevelopmentEvidence: {
+    candidateOrdinal: 19,
+    priorTrialCount: 18,
+    status: 'DEVELOPMENT_REJECTED',
+    evidenceContentHash: candidate19DevelopmentFailureEvidenceExpectation.evidenceContentHash,
+    evaluatedSourceRevision: candidate19DevelopmentFailureEvidenceExpectation.evaluatedSourceRevision,
+    failureStage: candidate19DevelopmentFailureEvidenceExpectation.failureStage,
+    developmentMetricsObserved: candidate19DevelopmentFailureEvidenceExpectation.developmentMetricsObserved,
+    qualificationAttemptConsumed: false,
+  },
+  latestInvalidPrecommit: candidate20PrecommitInvalidation,
+  nextCandidatePreregistration: null,
+}

--- a/services/bayn/src/candidate-development-trials/lineage.ts
+++ b/services/bayn/src/candidate-development-trials/lineage.ts
@@ -9,6 +9,7 @@ import type {
   CandidateDevelopmentTrialState,
   CandidateDevelopmentTrialStateIssue,
 } from './model'
+import { frozenDevelopmentMetricObservations } from './frozen-lineage'
 import { validateCandidateDevelopmentTrialHistory } from './validation'
 
 const unattempted: Extract<CandidateDevelopmentAttemptConsumption, { readonly _tag: 'UNATTEMPTED' }> = Object.freeze({
@@ -31,23 +32,28 @@ export const cloneAndFreeze = <T>(value: T): T => {
 const normalizedDevelopmentTrial = (
   ordinal: number,
   latest: CandidateDevelopmentTrialHistory['latestDevelopmentEvidence'],
-): CandidateDevelopmentDevelopmentOnlyTrial => ({
-  _tag: 'DEVELOPMENT_ONLY',
-  candidateOrdinal: ordinal,
-  priorTrialCount: ordinal - 1,
-  status: 'DEVELOPMENT_REJECTED',
-  evidenceContentHash: ordinal === latest.candidateOrdinal ? latest.evidenceContentHash : null,
-  evaluatedSourceRevision: ordinal === latest.candidateOrdinal ? latest.evaluatedSourceRevision : null,
-  failureStage: ordinal === latest.candidateOrdinal ? (latest.failureStage ?? null) : null,
-  developmentMetricsObserved: ordinal === latest.candidateOrdinal ? (latest.developmentMetricsObserved ?? null) : null,
-  attempt: {
-    _tag: 'DEVELOPMENT_ONLY_ATTEMPT',
-    attemptCount: 1,
-    metricBearingAttemptsConsumed:
-      ordinal === latest.candidateOrdinal && latest.developmentMetricsObserved === true ? 1 : 0,
-    qualificationAttemptConsumed: false,
-  },
-})
+): CandidateDevelopmentDevelopmentOnlyTrial => {
+  const developmentMetricsObserved =
+    ordinal === latest.candidateOrdinal
+      ? (latest.developmentMetricsObserved ?? null)
+      : (frozenDevelopmentMetricObservations[ordinal] ?? null)
+  return {
+    _tag: 'DEVELOPMENT_ONLY',
+    candidateOrdinal: ordinal,
+    priorTrialCount: ordinal - 1,
+    status: 'DEVELOPMENT_REJECTED',
+    evidenceContentHash: ordinal === latest.candidateOrdinal ? latest.evidenceContentHash : null,
+    evaluatedSourceRevision: ordinal === latest.candidateOrdinal ? latest.evaluatedSourceRevision : null,
+    failureStage: ordinal === latest.candidateOrdinal ? (latest.failureStage ?? null) : null,
+    developmentMetricsObserved,
+    attempt: {
+      _tag: 'DEVELOPMENT_ONLY_ATTEMPT',
+      attemptCount: 1,
+      metricBearingAttemptsConsumed: developmentMetricsObserved === null ? null : developmentMetricsObserved ? 1 : 0,
+      qualificationAttemptConsumed: false,
+    },
+  }
+}
 
 const historicalQualificationTrial = (
   candidateOrdinal: number,

--- a/services/bayn/src/candidate-development-trials/lineage.ts
+++ b/services/bayn/src/candidate-development-trials/lineage.ts
@@ -1,0 +1,129 @@
+import { Result } from 'effect'
+
+import type {
+  CandidateDevelopmentAttemptConsumption,
+  CandidateDevelopmentDevelopmentOnlyTrial,
+  CandidateDevelopmentHistoricalQualificationTrial,
+  CandidateDevelopmentImmutableInvalidation,
+  CandidateDevelopmentTrialHistory,
+  CandidateDevelopmentTrialState,
+  CandidateDevelopmentTrialStateIssue,
+} from './model'
+import { validateCandidateDevelopmentTrialHistory } from './validation'
+
+const unattempted: Extract<CandidateDevelopmentAttemptConsumption, { readonly _tag: 'UNATTEMPTED' }> = Object.freeze({
+  _tag: 'UNATTEMPTED',
+  attemptCount: 0,
+  metricBearingAttemptsConsumed: 0,
+  qualificationAttemptConsumed: false,
+})
+
+const isObject = (value: unknown): value is Record<string, unknown> => typeof value === 'object' && value !== null
+
+export const cloneAndFreeze = <T>(value: T): T => {
+  if (!isObject(value) && !Array.isArray(value)) return value
+  const cloned = Array.isArray(value)
+    ? value.map((item) => cloneAndFreeze(item))
+    : Object.fromEntries(Object.entries(value).map(([key, item]) => [key, cloneAndFreeze(item)]))
+  return Object.freeze(cloned) as T
+}
+
+const normalizedDevelopmentTrial = (
+  ordinal: number,
+  latest: CandidateDevelopmentTrialHistory['latestDevelopmentEvidence'],
+): CandidateDevelopmentDevelopmentOnlyTrial => ({
+  _tag: 'DEVELOPMENT_ONLY',
+  candidateOrdinal: ordinal,
+  priorTrialCount: ordinal - 1,
+  status: 'DEVELOPMENT_REJECTED',
+  evidenceContentHash: ordinal === latest.candidateOrdinal ? latest.evidenceContentHash : null,
+  evaluatedSourceRevision: ordinal === latest.candidateOrdinal ? latest.evaluatedSourceRevision : null,
+  failureStage: ordinal === latest.candidateOrdinal ? (latest.failureStage ?? null) : null,
+  developmentMetricsObserved: ordinal === latest.candidateOrdinal ? (latest.developmentMetricsObserved ?? null) : null,
+  attempt: {
+    _tag: 'DEVELOPMENT_ONLY_ATTEMPT',
+    attemptCount: 1,
+    metricBearingAttemptsConsumed:
+      ordinal === latest.candidateOrdinal && latest.developmentMetricsObserved === true ? 1 : 0,
+    qualificationAttemptConsumed: false,
+  },
+})
+
+const historicalQualificationTrial = (candidateOrdinal: number): CandidateDevelopmentHistoricalQualificationTrial => ({
+  _tag: 'HISTORICAL_QUALIFICATION',
+  candidateOrdinal,
+  priorTrialCount: candidateOrdinal - 1,
+  terminalStatus: 'HOLD_REJECT',
+  attempt: {
+    _tag: 'QUALIFICATION_ATTEMPT',
+    attemptCount: 1,
+    metricBearingAttemptsConsumed: 1,
+    qualificationAttemptConsumed: true,
+  },
+})
+
+const invalidatedPrecommit = (
+  invalidation: CandidateDevelopmentTrialHistory['latestInvalidPrecommit'],
+): readonly CandidateDevelopmentImmutableInvalidation[] =>
+  invalidation === null
+    ? []
+    : [
+        {
+          _tag: 'IMMUTABLE_INVALIDATION' as const,
+          invalidation: cloneAndFreeze(invalidation),
+          attempt: unattempted,
+        },
+      ]
+
+const currentSuccessor = (preregistration: CandidateDevelopmentTrialHistory['nextCandidatePreregistration']) =>
+  preregistration === null
+    ? null
+    : {
+        _tag: 'CURRENT_SUCCESSOR' as const,
+        preregistration: cloneAndFreeze(preregistration),
+        attempt: unattempted,
+      }
+
+const nextOrdinal = (
+  history: CandidateDevelopmentTrialHistory,
+  successor: ReturnType<typeof currentSuccessor>,
+): number =>
+  successor === null
+    ? Math.max(
+        history.completedCandidateOrdinals.at(-1) ?? 0,
+        history.developmentCandidateOrdinals.at(-1) ?? 0,
+        history.latestInvalidPrecommit?.candidateOrdinal ?? 0,
+      ) + 1
+    : successor.preregistration.candidateOrdinal
+
+export const buildCandidateDevelopmentTrialState = (
+  history: CandidateDevelopmentTrialHistory,
+): Result.Result<CandidateDevelopmentTrialState, CandidateDevelopmentTrialStateIssue> => {
+  const validated = validateCandidateDevelopmentTrialHistory(history)
+  if (Result.isFailure(validated)) return Result.fail(validated.failure)
+  const successor = currentSuccessor(history.nextCandidatePreregistration)
+  const state: CandidateDevelopmentTrialState = {
+    schemaVersion: 'bayn.candidate-development-trial-state.v1',
+    historicalQualificationTrials: cloneAndFreeze(history.completedCandidateOrdinals.map(historicalQualificationTrial)),
+    developmentOnlyTrials: cloneAndFreeze(
+      history.developmentCandidateOrdinals.map((candidateOrdinal) =>
+        normalizedDevelopmentTrial(candidateOrdinal, history.latestDevelopmentEvidence),
+      ),
+    ),
+    invalidatedPrecommits: cloneAndFreeze(invalidatedPrecommit(history.latestInvalidPrecommit)),
+    currentSuccessor: cloneAndFreeze(successor),
+    nextOrdinal: nextOrdinal(history, successor),
+  }
+  return Result.succeed(state)
+}
+
+export const candidateDevelopmentTrialStateFromHistory = buildCandidateDevelopmentTrialState
+
+export const emptyCandidateDevelopmentTrialState = (): CandidateDevelopmentTrialState => ({
+  schemaVersion: 'bayn.candidate-development-trial-state.v1',
+  historicalQualificationTrials: [],
+  developmentOnlyTrials: [],
+  invalidatedPrecommits: [],
+  currentSuccessor: null,
+  nextOrdinal: 1,
+})

--- a/services/bayn/src/candidate-development-trials/lineage.ts
+++ b/services/bayn/src/candidate-development-trials/lineage.ts
@@ -49,11 +49,15 @@ const normalizedDevelopmentTrial = (
   },
 })
 
-const historicalQualificationTrial = (candidateOrdinal: number): CandidateDevelopmentHistoricalQualificationTrial => ({
+const historicalQualificationTrial = (
+  candidateOrdinal: number,
+  sourceRevision: string | null,
+): CandidateDevelopmentHistoricalQualificationTrial => ({
   _tag: 'HISTORICAL_QUALIFICATION',
   candidateOrdinal,
   priorTrialCount: candidateOrdinal - 1,
   terminalStatus: 'HOLD_REJECT',
+  sourceRevision,
   attempt: {
     _tag: 'QUALIFICATION_ATTEMPT',
     attemptCount: 1,
@@ -80,6 +84,7 @@ const currentSuccessor = (preregistration: CandidateDevelopmentTrialHistory['nex
     ? null
     : {
         _tag: 'CURRENT_SUCCESSOR' as const,
+        kind: 'DEVELOPMENT_ONLY' as const,
         preregistration: cloneAndFreeze(preregistration),
         attempt: unattempted,
       }
@@ -102,9 +107,17 @@ export const buildCandidateDevelopmentTrialState = (
   const validated = validateCandidateDevelopmentTrialHistory(history)
   if (Result.isFailure(validated)) return Result.fail(validated.failure)
   const successor = currentSuccessor(history.nextCandidatePreregistration)
+  const latestQualificationOrdinal = history.completedCandidateOrdinals.at(-1)
   const state: CandidateDevelopmentTrialState = {
     schemaVersion: 'bayn.candidate-development-trial-state.v1',
-    historicalQualificationTrials: cloneAndFreeze(history.completedCandidateOrdinals.map(historicalQualificationTrial)),
+    historicalQualificationTrials: cloneAndFreeze(
+      history.completedCandidateOrdinals.map((candidateOrdinal) =>
+        historicalQualificationTrial(
+          candidateOrdinal,
+          candidateOrdinal === latestQualificationOrdinal ? history.latestTerminalEvidence.sourceRevision : null,
+        ),
+      ),
+    ),
     developmentOnlyTrials: cloneAndFreeze(
       history.developmentCandidateOrdinals.map((candidateOrdinal) =>
         normalizedDevelopmentTrial(candidateOrdinal, history.latestDevelopmentEvidence),

--- a/services/bayn/src/candidate-development-trials/model.ts
+++ b/services/bayn/src/candidate-development-trials/model.ts
@@ -160,11 +160,14 @@ export type CandidateDevelopmentAttemptConsumption =
       readonly qualificationAttemptConsumed: true
     }
 
+export type CandidateDevelopmentSuccessorKind = 'DEVELOPMENT_ONLY' | 'QUALIFICATION'
+
 export interface CandidateDevelopmentHistoricalQualificationTrial {
   readonly _tag: 'HISTORICAL_QUALIFICATION'
   readonly candidateOrdinal: number
   readonly priorTrialCount: number
   readonly terminalStatus: 'HOLD_REJECT'
+  readonly sourceRevision: string | null
   readonly attempt: Extract<CandidateDevelopmentAttemptConsumption, { readonly _tag: 'QUALIFICATION_ATTEMPT' }>
 }
 
@@ -182,6 +185,7 @@ export interface CandidateDevelopmentDevelopmentOnlyTrial {
 
 export interface CandidateDevelopmentCurrentSuccessor {
   readonly _tag: 'CURRENT_SUCCESSOR'
+  readonly kind: CandidateDevelopmentSuccessorKind
   readonly preregistration: CandidateDevelopmentNextPreregistration
   readonly attempt: CandidateDevelopmentAttemptConsumption
 }
@@ -217,6 +221,7 @@ export type CandidateDevelopmentTrialTransition =
   | {
       readonly _tag: 'REVIEW_SUCCESSOR'
       readonly preregistration: CandidateDevelopmentNextPreregistration
+      readonly kind?: CandidateDevelopmentSuccessorKind
     }
   | {
       readonly _tag: 'CONSUME_DEVELOPMENT_ATTEMPT'

--- a/services/bayn/src/candidate-development-trials/model.ts
+++ b/services/bayn/src/candidate-development-trials/model.ts
@@ -150,7 +150,7 @@ export type CandidateDevelopmentAttemptConsumption =
   | {
       readonly _tag: 'DEVELOPMENT_ONLY_ATTEMPT'
       readonly attemptCount: 1
-      readonly metricBearingAttemptsConsumed: 0 | 1
+      readonly metricBearingAttemptsConsumed: 0 | 1 | null
       readonly qualificationAttemptConsumed: false
     }
   | {

--- a/services/bayn/src/candidate-development-trials/model.ts
+++ b/services/bayn/src/candidate-development-trials/model.ts
@@ -1,0 +1,296 @@
+export interface CandidateDevelopmentNextPreregistration {
+  readonly schemaVersion: 'bayn.candidate-development-next-preregistration.v1'
+  readonly candidateOrdinal: number
+  readonly priorTrialCount: number
+  readonly strategyProtocolHash: string
+  readonly strategyIdentityHash?: string
+  readonly candidateDevelopmentProtocolHash?: string
+  readonly calendarHash?: string
+  readonly priorTrialsHash?: string
+  readonly modulePath: string
+  readonly moduleSha256: string
+  readonly marketData: {
+    readonly schemaVersion: 'bayn.candidate-development-market-data-source.v1'
+    readonly snapshotId: string
+    readonly finalizedSnapshotContentHash: string
+    readonly inputManifestHash: string
+    readonly boundedContentHash: string
+  }
+  readonly preregistration: {
+    readonly sourceRevision: string
+    readonly path: string
+    readonly blobOid: string
+  }
+}
+
+export interface CandidateDevelopmentQualificationEvidence {
+  readonly candidateOrdinal: number
+  readonly priorTrialCount: number
+  readonly terminalStatus: 'HOLD_REJECT'
+  readonly sourceRevision: string
+}
+
+export interface CandidateDevelopmentQualificationPreregistration {
+  readonly candidateOrdinal: number
+  readonly priorTrialCount: number
+  readonly sourceRevision: string
+  readonly path: string
+  readonly blobOid: string
+}
+
+export interface CandidateDevelopmentPriorDevelopmentEvidence {
+  readonly candidateOrdinal: number
+  readonly priorTrialCount: number
+  readonly status: 'DEVELOPMENT_REJECTED'
+  readonly evidenceContentHash: string
+  readonly qualificationAttemptConsumed: false
+}
+
+export interface CandidateDevelopmentInvalidPrecommit {
+  readonly schemaVersion: 'bayn.candidate-development-precommit-invalidation.v1'
+  readonly candidateOrdinal: number
+  readonly priorTrialCount: number
+  readonly status: 'PRECOMMIT_INVALID'
+  readonly attemptStatus: 'UNATTEMPTED'
+  readonly metricBearingAttemptsConsumed: 0
+  readonly qualificationAttemptConsumed: false
+  readonly reviewedHeadRevision: string
+  readonly mergedSourceRevision: string
+  readonly preregistration: {
+    readonly sourceRevision: string
+    readonly path: string
+    readonly blobOid: string
+    readonly sha256: string
+  }
+  readonly sourceManifest: {
+    readonly path: string
+    readonly blobOid: string
+    readonly sha256: string
+  }
+  readonly invalidatedModule: {
+    readonly path: string
+    readonly blobOid: string
+    readonly sha256: string
+    readonly lineCount: number
+    readonly byteCount: number
+    readonly findings: readonly [
+      'TYPE_CHECK_DISABLED',
+      'DOWNCOMPILED_BUNDLE',
+      'EMBEDDED_OFFICIAL_SESSIONS',
+      'EMBEDDED_MARKET_BARS',
+      'RUNTIME_INPUT_IGNORED',
+    ]
+  }
+  readonly naturalBuild: {
+    readonly runId: string
+    readonly imagePublished: true
+    readonly imageDigest: `sha256:${string}`
+    readonly deploymentAllowed: false
+  }
+  readonly release: {
+    readonly runId: string
+    readonly conclusion: 'CANCELLED'
+    readonly promotionCompleted: false
+    readonly rerunAllowed: false
+  }
+  readonly nextCandidatePreregistration: null
+}
+
+export interface CandidateDevelopmentLegacyPriorTrialsMaterial {
+  readonly schemaVersion: 'bayn.candidate-development-prior-trials.v1'
+  readonly qualificationCandidateOrdinals: readonly number[]
+  readonly developmentCandidateOrdinals: readonly number[]
+  readonly latestDevelopmentEvidence: CandidateDevelopmentPriorDevelopmentEvidence
+  readonly latestReviewedPreregistration: CandidateDevelopmentNextPreregistration
+}
+
+export interface CandidateDevelopmentPriorTrialsMaterial {
+  readonly schemaVersion: 'bayn.candidate-development-prior-trials.v2'
+  readonly qualificationCandidateOrdinals: readonly number[]
+  readonly latestQualificationEvidence: CandidateDevelopmentQualificationEvidence
+  readonly latestQualificationPreregistration: CandidateDevelopmentQualificationPreregistration
+  readonly developmentCandidateOrdinals: readonly number[]
+  readonly latestDevelopmentEvidence: CandidateDevelopmentPriorDevelopmentEvidence
+  readonly latestReviewedPreregistration: CandidateDevelopmentNextPreregistration
+}
+
+/** The v2 history remains the wire-compatible facade consumed by Bayn. */
+export interface CandidateDevelopmentTrialHistory {
+  readonly schemaVersion: 'bayn.candidate-development-trial-history.v2'
+  readonly completedCandidateOrdinals: readonly number[]
+  readonly developmentCandidateOrdinals: readonly number[]
+  readonly latestReviewedCandidateLegacyPriorTrials: CandidateDevelopmentLegacyPriorTrialsMaterial
+  readonly latestReviewedCandidatePriorTrials: CandidateDevelopmentPriorTrialsMaterial
+  readonly latestTerminalEvidence: CandidateDevelopmentQualificationEvidence
+  readonly candidatePreregistration: CandidateDevelopmentQualificationPreregistration
+  readonly latestReviewedCandidatePreregistration: CandidateDevelopmentNextPreregistration
+  readonly latestDevelopmentEvidence: {
+    readonly candidateOrdinal: number
+    readonly priorTrialCount: number
+    readonly status: 'DEVELOPMENT_REJECTED'
+    readonly evidenceContentHash: string
+    readonly evaluatedSourceRevision: string
+    readonly reviewedSourceRevision?: string
+    readonly mergedSourceRevision?: string
+    readonly failureStage?: 'buildEvaluation-preflight' | 'development-evaluation'
+    readonly developmentMetricsObserved?: boolean
+    readonly qualificationAttemptConsumed: false
+  }
+  readonly latestInvalidPrecommit: CandidateDevelopmentInvalidPrecommit | null
+  readonly nextCandidatePreregistration: CandidateDevelopmentNextPreregistration | null
+}
+
+export type CandidateDevelopmentAttemptConsumption =
+  | {
+      readonly _tag: 'UNATTEMPTED'
+      readonly attemptCount: 0
+      readonly metricBearingAttemptsConsumed: 0
+      readonly qualificationAttemptConsumed: false
+    }
+  | {
+      readonly _tag: 'DEVELOPMENT_ONLY_ATTEMPT'
+      readonly attemptCount: 1
+      readonly metricBearingAttemptsConsumed: 0 | 1
+      readonly qualificationAttemptConsumed: false
+    }
+  | {
+      readonly _tag: 'QUALIFICATION_ATTEMPT'
+      readonly attemptCount: 1
+      readonly metricBearingAttemptsConsumed: 1
+      readonly qualificationAttemptConsumed: true
+    }
+
+export interface CandidateDevelopmentHistoricalQualificationTrial {
+  readonly _tag: 'HISTORICAL_QUALIFICATION'
+  readonly candidateOrdinal: number
+  readonly priorTrialCount: number
+  readonly terminalStatus: 'HOLD_REJECT'
+  readonly attempt: Extract<CandidateDevelopmentAttemptConsumption, { readonly _tag: 'QUALIFICATION_ATTEMPT' }>
+}
+
+export interface CandidateDevelopmentDevelopmentOnlyTrial {
+  readonly _tag: 'DEVELOPMENT_ONLY'
+  readonly candidateOrdinal: number
+  readonly priorTrialCount: number
+  readonly status: 'DEVELOPMENT_REJECTED'
+  readonly evidenceContentHash: string | null
+  readonly evaluatedSourceRevision: string | null
+  readonly failureStage: 'buildEvaluation-preflight' | 'development-evaluation' | null
+  readonly developmentMetricsObserved: boolean | null
+  readonly attempt: Extract<CandidateDevelopmentAttemptConsumption, { readonly _tag: 'DEVELOPMENT_ONLY_ATTEMPT' }>
+}
+
+export interface CandidateDevelopmentCurrentSuccessor {
+  readonly _tag: 'CURRENT_SUCCESSOR'
+  readonly preregistration: CandidateDevelopmentNextPreregistration
+  readonly attempt: CandidateDevelopmentAttemptConsumption
+}
+
+export interface CandidateDevelopmentImmutableInvalidation {
+  readonly _tag: 'IMMUTABLE_INVALIDATION'
+  readonly invalidation: CandidateDevelopmentInvalidPrecommit
+  readonly attempt: Extract<CandidateDevelopmentAttemptConsumption, { readonly _tag: 'UNATTEMPTED' }>
+}
+
+export interface CandidateDevelopmentTrialState {
+  readonly schemaVersion: 'bayn.candidate-development-trial-state.v1'
+  readonly historicalQualificationTrials: readonly CandidateDevelopmentHistoricalQualificationTrial[]
+  readonly developmentOnlyTrials: readonly CandidateDevelopmentDevelopmentOnlyTrial[]
+  readonly invalidatedPrecommits: readonly CandidateDevelopmentImmutableInvalidation[]
+  readonly currentSuccessor: CandidateDevelopmentCurrentSuccessor | null
+  readonly nextOrdinal: number
+}
+
+export interface CandidateDevelopmentDevelopmentTerminalEvidence {
+  readonly evidenceContentHash: string
+  readonly evaluatedSourceRevision?: string
+  readonly failureStage?: 'buildEvaluation-preflight' | 'development-evaluation'
+  readonly developmentMetricsObserved?: boolean
+}
+
+export interface CandidateDevelopmentQualificationTerminalEvidence {
+  readonly terminalStatus: 'HOLD_REJECT'
+  readonly sourceRevision: string
+}
+
+export type CandidateDevelopmentTrialTransition =
+  | {
+      readonly _tag: 'REVIEW_SUCCESSOR'
+      readonly preregistration: CandidateDevelopmentNextPreregistration
+    }
+  | {
+      readonly _tag: 'CONSUME_DEVELOPMENT_ATTEMPT'
+      readonly metricBearing: boolean
+    }
+  | { readonly _tag: 'CONSUME_QUALIFICATION_ATTEMPT' }
+  | {
+      readonly _tag: 'TERMINALIZE_DEVELOPMENT_ONLY'
+      readonly evidence: CandidateDevelopmentDevelopmentTerminalEvidence
+    }
+  | {
+      readonly _tag: 'TERMINALIZE_QUALIFICATION'
+      readonly evidence: CandidateDevelopmentQualificationTerminalEvidence
+    }
+  | {
+      readonly _tag: 'INVALIDATE_PRECOMMIT'
+      readonly invalidation: CandidateDevelopmentInvalidPrecommit
+    }
+
+export type CandidateDevelopmentTrialStateIssueReason =
+  | 'MALFORMED_HISTORY'
+  | 'SCHEMA_VERSION_MISMATCH'
+  | 'ORDINAL_NOT_POSITIVE'
+  | 'PRIOR_TRIAL_COUNT_MISMATCH'
+  | 'ORDINAL_SEQUENCE_GAP'
+  | 'ORDINAL_OVERLAP'
+  | 'LATEST_EVIDENCE_MISMATCH'
+  | 'INVALIDATION_NOT_IMMUTABLE'
+  | 'INVALIDATION_BINDING_MISMATCH'
+  | 'SUCCESSOR_BINDING_MISMATCH'
+  | 'SUCCESSOR_REQUIRED'
+  | 'SUCCESSOR_ALREADY_PRESENT'
+  | 'ATTEMPT_ALREADY_CONSUMED'
+  | 'ATTEMPT_KIND_MISMATCH'
+  | 'TERMINAL_STATE_MISMATCH'
+  | 'NEXT_ORDINAL_MISMATCH'
+
+export interface CandidateDevelopmentTrialStateIssue {
+  readonly _tag: 'CandidateDevelopmentTrialStateInvalid'
+  readonly reason: CandidateDevelopmentTrialStateIssueReason
+  readonly path: string
+  readonly expected?: unknown
+  readonly observed?: unknown
+}
+
+export type CandidateDevelopmentTrialTransitionDecision =
+  | { readonly _tag: 'APPLIED'; readonly state: CandidateDevelopmentTrialState }
+  | { readonly _tag: 'BLOCKED'; readonly issue: CandidateDevelopmentTrialStateIssue }
+
+export type CandidateDevelopmentNextAction =
+  | {
+      readonly _tag: 'AWAIT_REVIEWED_PRECOMMIT'
+      readonly candidateOrdinal: number
+      readonly priorTrialCount: number
+      readonly reason: 'NO_SUCCESSOR' | 'PRECOMMIT_INVALIDATED'
+    }
+  | {
+      readonly _tag: 'CONSUME_DEVELOPMENT_ATTEMPT'
+      readonly candidateOrdinal: number
+      readonly preregistration: CandidateDevelopmentNextPreregistration
+    }
+  | {
+      readonly _tag: 'TERMINALIZE_DEVELOPMENT_ONLY'
+      readonly candidateOrdinal: number
+      readonly preregistration: CandidateDevelopmentNextPreregistration
+    }
+  | {
+      readonly _tag: 'CONSUME_QUALIFICATION_ATTEMPT'
+      readonly candidateOrdinal: number
+      readonly preregistration: CandidateDevelopmentNextPreregistration
+    }
+  | {
+      readonly _tag: 'TERMINALIZE_QUALIFICATION'
+      readonly candidateOrdinal: number
+      readonly preregistration: CandidateDevelopmentNextPreregistration
+    }
+  | { readonly _tag: 'BLOCKED'; readonly issue: CandidateDevelopmentTrialStateIssue }

--- a/services/bayn/src/candidate-development-trials/next-action.ts
+++ b/services/bayn/src/candidate-development-trials/next-action.ts
@@ -7,11 +7,14 @@ import type {
 } from './model'
 import { validateCandidateDevelopmentTrialState } from './validation'
 
+const immediatelyPrecedingOrdinalWasInvalidated = (state: CandidateDevelopmentTrialState): boolean =>
+  state.invalidatedPrecommits.some(({ invalidation }) => invalidation.candidateOrdinal === state.nextOrdinal - 1)
+
 const awaitReviewedPrecommit = (state: CandidateDevelopmentTrialState): CandidateDevelopmentNextAction => ({
   _tag: 'AWAIT_REVIEWED_PRECOMMIT',
   candidateOrdinal: state.nextOrdinal,
   priorTrialCount: state.nextOrdinal - 1,
-  reason: state.invalidatedPrecommits.length === 0 ? 'NO_SUCCESSOR' : 'PRECOMMIT_INVALIDATED',
+  reason: immediatelyPrecedingOrdinalWasInvalidated(state) ? 'PRECOMMIT_INVALIDATED' : 'NO_SUCCESSOR',
 })
 
 const actionForSuccessor = (successor: CandidateDevelopmentCurrentSuccessor): CandidateDevelopmentNextAction => {

--- a/services/bayn/src/candidate-development-trials/next-action.ts
+++ b/services/bayn/src/candidate-development-trials/next-action.ts
@@ -1,0 +1,49 @@
+import { Result } from 'effect'
+
+import type {
+  CandidateDevelopmentCurrentSuccessor,
+  CandidateDevelopmentNextAction,
+  CandidateDevelopmentTrialState,
+} from './model'
+import { validateCandidateDevelopmentTrialState } from './validation'
+
+const awaitReviewedPrecommit = (state: CandidateDevelopmentTrialState): CandidateDevelopmentNextAction => ({
+  _tag: 'AWAIT_REVIEWED_PRECOMMIT',
+  candidateOrdinal: state.nextOrdinal,
+  priorTrialCount: state.nextOrdinal - 1,
+  reason: state.invalidatedPrecommits.length === 0 ? 'NO_SUCCESSOR' : 'PRECOMMIT_INVALIDATED',
+})
+
+const actionForSuccessor = (successor: CandidateDevelopmentCurrentSuccessor): CandidateDevelopmentNextAction => {
+  const { candidateOrdinal } = successor.preregistration
+  switch (successor.attempt._tag) {
+    case 'UNATTEMPTED':
+      return {
+        _tag: 'CONSUME_DEVELOPMENT_ATTEMPT',
+        candidateOrdinal,
+        preregistration: successor.preregistration,
+      }
+    case 'DEVELOPMENT_ONLY_ATTEMPT':
+      return {
+        _tag: 'TERMINALIZE_DEVELOPMENT_ONLY',
+        candidateOrdinal,
+        preregistration: successor.preregistration,
+      }
+    case 'QUALIFICATION_ATTEMPT':
+      return {
+        _tag: 'TERMINALIZE_QUALIFICATION',
+        candidateOrdinal,
+        preregistration: successor.preregistration,
+      }
+  }
+}
+
+export const deriveCandidateDevelopmentNextAction = (
+  state: CandidateDevelopmentTrialState,
+): CandidateDevelopmentNextAction => {
+  const validation = validateCandidateDevelopmentTrialState(state)
+  if (Result.isFailure(validation)) return { _tag: 'BLOCKED', issue: validation.failure }
+  return state.currentSuccessor === null ? awaitReviewedPrecommit(state) : actionForSuccessor(state.currentSuccessor)
+}
+
+export const nextCandidateDevelopmentOrdinal = (state: CandidateDevelopmentTrialState): number => state.nextOrdinal

--- a/services/bayn/src/candidate-development-trials/next-action.ts
+++ b/services/bayn/src/candidate-development-trials/next-action.ts
@@ -18,11 +18,17 @@ const actionForSuccessor = (successor: CandidateDevelopmentCurrentSuccessor): Ca
   const { candidateOrdinal } = successor.preregistration
   switch (successor.attempt._tag) {
     case 'UNATTEMPTED':
-      return {
-        _tag: 'CONSUME_DEVELOPMENT_ATTEMPT',
-        candidateOrdinal,
-        preregistration: successor.preregistration,
-      }
+      return successor.kind === 'QUALIFICATION'
+        ? {
+            _tag: 'CONSUME_QUALIFICATION_ATTEMPT',
+            candidateOrdinal,
+            preregistration: successor.preregistration,
+          }
+        : {
+            _tag: 'CONSUME_DEVELOPMENT_ATTEMPT',
+            candidateOrdinal,
+            preregistration: successor.preregistration,
+          }
     case 'DEVELOPMENT_ONLY_ATTEMPT':
       return {
         _tag: 'TERMINALIZE_DEVELOPMENT_ONLY',

--- a/services/bayn/src/candidate-development-trials/state-machine.test.ts
+++ b/services/bayn/src/candidate-development-trials/state-machine.test.ts
@@ -92,16 +92,19 @@ describe('candidate development trial state machine', () => {
   })
 
   test('consumes and terminalizes a qualification attempt independently from development trials', () => {
-    const state = stateFrom(
-      buildCandidateDevelopmentTrialHistory({
-        nextCandidatePreregistration: buildCandidateDevelopmentPreregistration(4),
-      }),
-    )
-    expect(deriveCandidateDevelopmentNextAction(state)).toMatchObject({
-      _tag: 'CONSUME_DEVELOPMENT_ATTEMPT',
+    const state = stateFrom(buildCandidateDevelopmentTrialHistory())
+    const reviewed = reduceCandidateDevelopmentTrialState(state, {
+      _tag: 'REVIEW_SUCCESSOR',
+      kind: 'QUALIFICATION',
+      preregistration: buildCandidateDevelopmentPreregistration(4),
+    })
+    expect(reviewed._tag).toBe('APPLIED')
+    if (reviewed._tag === 'BLOCKED') throw new Error('expected qualification review to apply')
+    expect(deriveCandidateDevelopmentNextAction(reviewed.state)).toMatchObject({
+      _tag: 'CONSUME_QUALIFICATION_ATTEMPT',
       candidateOrdinal: 4,
     })
-    const consumed = reduceCandidateDevelopmentTrialState(state, { _tag: 'CONSUME_QUALIFICATION_ATTEMPT' })
+    const consumed = reduceCandidateDevelopmentTrialState(reviewed.state, { _tag: 'CONSUME_QUALIFICATION_ATTEMPT' })
     expect(consumed._tag).toBe('APPLIED')
     if (consumed._tag === 'BLOCKED') throw new Error('expected qualification attempt to apply')
     expect(deriveCandidateDevelopmentNextAction(consumed.state)).toMatchObject({
@@ -115,8 +118,10 @@ describe('candidate development trial state machine', () => {
     expect(terminalized._tag).toBe('APPLIED')
     if (terminalized._tag === 'BLOCKED') throw new Error('expected qualification terminalization to apply')
     expect(terminalized.state.historicalQualificationTrials.map((trial) => trial.candidateOrdinal)).toEqual([1, 2, 4])
+    expect(terminalized.state.historicalQualificationTrials.at(-1)?.sourceRevision).toBe('qualification-source-4')
     expect(terminalized.state.developmentOnlyTrials.map((trial) => trial.candidateOrdinal)).toEqual([3])
     expect(terminalized.state.nextOrdinal).toBe(5)
+    expect(validateCandidateDevelopmentTrialState(terminalized.state)).toEqual(Result.succeed(undefined))
   })
 
   test('keeps an invalidated precommit immutable and waits for a new reviewed successor', () => {
@@ -167,6 +172,12 @@ describe('candidate development trial state machine', () => {
     })
     if (consumed._tag === 'BLOCKED') throw new Error('expected development attempt to apply')
     expect(
+      reduceCandidateDevelopmentTrialState(consumed.state, {
+        _tag: 'TERMINALIZE_DEVELOPMENT_ONLY',
+        evidence: { evidenceContentHash: 'contradictory-metrics', developmentMetricsObserved: true },
+      }),
+    ).toMatchObject({ _tag: 'BLOCKED', issue: { reason: 'TERMINAL_STATE_MISMATCH' } })
+    expect(
       reduceCandidateDevelopmentTrialState(consumed.state, { _tag: 'CONSUME_QUALIFICATION_ATTEMPT' }),
     ).toMatchObject({ _tag: 'BLOCKED', issue: { reason: 'ATTEMPT_ALREADY_CONSUMED' } })
     expect(
@@ -198,6 +209,11 @@ describe('candidate development trial state machine', () => {
       },
       (history: Record<string, unknown>) => {
         history.completedCandidateOrdinals = [1, 1]
+      },
+      (history: Record<string, unknown>) => {
+        const current = history.latestInvalidPrecommit as Record<string, unknown>
+        const naturalBuild = current.naturalBuild as Record<string, unknown>
+        naturalBuild.imageDigest = `legacy:${'a'.repeat(64)}`
       },
     ] as const
     for (const mutate of mutations) {

--- a/services/bayn/src/candidate-development-trials/state-machine.test.ts
+++ b/services/bayn/src/candidate-development-trials/state-machine.test.ts
@@ -36,6 +36,17 @@ describe('candidate development trial state machine', () => {
 
     expect(state.historicalQualificationTrials).toHaveLength(16)
     expect(state.developmentOnlyTrials.map((trial) => trial.candidateOrdinal)).toEqual([17, 18, 19])
+    expect(
+      state.developmentOnlyTrials.map((trial) => [
+        trial.candidateOrdinal,
+        trial.developmentMetricsObserved,
+        trial.attempt.metricBearingAttemptsConsumed,
+      ]),
+    ).toEqual([
+      [17, true, 1],
+      [18, false, 0],
+      [19, true, 1],
+    ])
     expect(state.invalidatedPrecommits).toHaveLength(1)
     expect(state.invalidatedPrecommits[0]?.invalidation).toEqual(candidate20PrecommitInvalidation)
     expect(state.invalidatedPrecommits[0] && Object.isFrozen(state.invalidatedPrecommits[0].invalidation)).toBe(true)
@@ -83,6 +94,11 @@ describe('candidate development trial state machine', () => {
     if (terminalized21._tag === 'BLOCKED') throw new Error('expected candidate 21 terminalization to apply')
     expect(terminalized21.state.developmentOnlyTrials.map((trial) => trial.candidateOrdinal)).toEqual([17, 18, 19, 21])
     expect(terminalized21.state.nextOrdinal).toBe(22)
+    expect(deriveCandidateDevelopmentNextAction(terminalized21.state)).toMatchObject({
+      _tag: 'AWAIT_REVIEWED_PRECOMMIT',
+      candidateOrdinal: 22,
+      reason: 'NO_SUCCESSOR',
+    })
 
     const reviewed22 = reduceCandidateDevelopmentTrialState(terminalized21.state, {
       _tag: 'REVIEW_SUCCESSOR',
@@ -237,6 +253,18 @@ describe('candidate development trial state machine', () => {
     expect(
       reduceCandidateDevelopmentTrialState(consumed.state, { _tag: 'CONSUME_QUALIFICATION_ATTEMPT' }),
     ).toMatchObject({ _tag: 'BLOCKED', issue: { reason: 'ATTEMPT_ALREADY_CONSUMED' } })
+    expect(
+      reduceCandidateDevelopmentTrialState(reviewed.state, {
+        _tag: 'CONSUME_DEVELOPMENT_ATTEMPT',
+        metricBearing: 'true' as never,
+      }),
+    ).toMatchObject({ _tag: 'BLOCKED', issue: { reason: 'MALFORMED_HISTORY' } })
+    expect(
+      reduceCandidateDevelopmentTrialState(reviewed.state, {
+        _tag: 'CONSUME_DEVELOPMENT_ATTEMPT',
+        metricBearing: undefined as never,
+      }),
+    ).toMatchObject({ _tag: 'BLOCKED', issue: { reason: 'MALFORMED_HISTORY' } })
     expect(
       reduceCandidateDevelopmentTrialState(reviewed.state, {
         _tag: 'TERMINALIZE_QUALIFICATION',

--- a/services/bayn/src/candidate-development-trials/state-machine.test.ts
+++ b/services/bayn/src/candidate-development-trials/state-machine.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, test } from 'bun:test'
+import { Result } from 'effect'
+
+import {
+  candidate20PrecommitInvalidation,
+  frozenCandidateDevelopmentTrialHistory,
+} from '../candidate-development-trial-history'
+import {
+  buildCandidateDevelopmentInvalidPrecommit,
+  buildCandidateDevelopmentPreregistration,
+  buildCandidateDevelopmentTrialHistory,
+} from './test-builders'
+import {
+  buildCandidateDevelopmentTrialState,
+  deriveCandidateDevelopmentNextAction,
+  reduceCandidateDevelopmentTrialState,
+  validateCandidateDevelopmentTrialHistory,
+  validateCandidateDevelopmentTrialState,
+  type CandidateDevelopmentTrialHistory,
+  type CandidateDevelopmentTrialState,
+} from './state-machine'
+
+const successOf = <A, E>(result: Result.Result<A, E>): A => {
+  expect(Result.isSuccess(result)).toBe(true)
+  if (Result.isFailure(result)) throw new Error('expected state-machine fixture to validate')
+  return result.success
+}
+
+const stateFrom = (history: CandidateDevelopmentTrialHistory): CandidateDevelopmentTrialState =>
+  successOf(buildCandidateDevelopmentTrialState(history))
+
+describe('candidate development trial state machine', () => {
+  test('normalizes the current history without changing the compatibility facade', () => {
+    const state = stateFrom(frozenCandidateDevelopmentTrialHistory)
+
+    expect(state.historicalQualificationTrials).toHaveLength(16)
+    expect(state.developmentOnlyTrials.map((trial) => trial.candidateOrdinal)).toEqual([17, 18, 19])
+    expect(state.invalidatedPrecommits).toHaveLength(1)
+    expect(state.invalidatedPrecommits[0]?.invalidation).toEqual(candidate20PrecommitInvalidation)
+    expect(state.invalidatedPrecommits[0] && Object.isFrozen(state.invalidatedPrecommits[0].invalidation)).toBe(true)
+    expect(state.currentSuccessor).toBeNull()
+    expect(state.nextOrdinal).toBe(21)
+    expect(deriveCandidateDevelopmentNextAction(state)).toEqual({
+      _tag: 'AWAIT_REVIEWED_PRECOMMIT',
+      candidateOrdinal: 21,
+      priorTrialCount: 20,
+      reason: 'PRECOMMIT_INVALIDATED',
+    })
+    expect(validateCandidateDevelopmentTrialState(state)).toEqual(Result.succeed(undefined))
+  })
+
+  test('reviews, consumes, and terminalizes a development-only successor exactly once', () => {
+    const state = stateFrom(buildCandidateDevelopmentTrialHistory())
+    const successorPreregistration = buildCandidateDevelopmentPreregistration(4)
+    const reviewed = reduceCandidateDevelopmentTrialState(state, {
+      _tag: 'REVIEW_SUCCESSOR',
+      preregistration: successorPreregistration,
+    })
+    expect(reviewed._tag).toBe('APPLIED')
+    if (reviewed._tag === 'BLOCKED') throw new Error('expected successor review to apply')
+    expect(deriveCandidateDevelopmentNextAction(reviewed.state)).toMatchObject({
+      _tag: 'CONSUME_DEVELOPMENT_ATTEMPT',
+      candidateOrdinal: 4,
+    })
+
+    const consumed = reduceCandidateDevelopmentTrialState(reviewed.state, {
+      _tag: 'CONSUME_DEVELOPMENT_ATTEMPT',
+      metricBearing: true,
+    })
+    expect(consumed._tag).toBe('APPLIED')
+    if (consumed._tag === 'BLOCKED') throw new Error('expected development attempt to apply')
+    expect(deriveCandidateDevelopmentNextAction(consumed.state)).toMatchObject({
+      _tag: 'TERMINALIZE_DEVELOPMENT_ONLY',
+      candidateOrdinal: 4,
+    })
+
+    const terminalized = reduceCandidateDevelopmentTrialState(consumed.state, {
+      _tag: 'TERMINALIZE_DEVELOPMENT_ONLY',
+      evidence: {
+        evidenceContentHash: 'development-evidence-4',
+        evaluatedSourceRevision: 'development-source-4',
+        failureStage: 'development-evaluation',
+        developmentMetricsObserved: true,
+      },
+    })
+    expect(terminalized._tag).toBe('APPLIED')
+    if (terminalized._tag === 'BLOCKED') throw new Error('expected development terminalization to apply')
+    expect(terminalized.state.currentSuccessor).toBeNull()
+    expect(terminalized.state.developmentOnlyTrials.map((trial) => trial.candidateOrdinal)).toEqual([3, 4])
+    expect(terminalized.state.nextOrdinal).toBe(5)
+    expect(validateCandidateDevelopmentTrialState(terminalized.state)).toEqual(Result.succeed(undefined))
+  })
+
+  test('consumes and terminalizes a qualification attempt independently from development trials', () => {
+    const state = stateFrom(
+      buildCandidateDevelopmentTrialHistory({
+        nextCandidatePreregistration: buildCandidateDevelopmentPreregistration(4),
+      }),
+    )
+    expect(deriveCandidateDevelopmentNextAction(state)).toMatchObject({
+      _tag: 'CONSUME_DEVELOPMENT_ATTEMPT',
+      candidateOrdinal: 4,
+    })
+    const consumed = reduceCandidateDevelopmentTrialState(state, { _tag: 'CONSUME_QUALIFICATION_ATTEMPT' })
+    expect(consumed._tag).toBe('APPLIED')
+    if (consumed._tag === 'BLOCKED') throw new Error('expected qualification attempt to apply')
+    expect(deriveCandidateDevelopmentNextAction(consumed.state)).toMatchObject({
+      _tag: 'TERMINALIZE_QUALIFICATION',
+      candidateOrdinal: 4,
+    })
+    const terminalized = reduceCandidateDevelopmentTrialState(consumed.state, {
+      _tag: 'TERMINALIZE_QUALIFICATION',
+      evidence: { terminalStatus: 'HOLD_REJECT', sourceRevision: 'qualification-source-4' },
+    })
+    expect(terminalized._tag).toBe('APPLIED')
+    if (terminalized._tag === 'BLOCKED') throw new Error('expected qualification terminalization to apply')
+    expect(terminalized.state.historicalQualificationTrials.map((trial) => trial.candidateOrdinal)).toEqual([1, 2, 4])
+    expect(terminalized.state.developmentOnlyTrials.map((trial) => trial.candidateOrdinal)).toEqual([3])
+    expect(terminalized.state.nextOrdinal).toBe(5)
+  })
+
+  test('keeps an invalidated precommit immutable and waits for a new reviewed successor', () => {
+    const preregistration = buildCandidateDevelopmentPreregistration(4)
+    const state = stateFrom(buildCandidateDevelopmentTrialHistory())
+    const reviewed = reduceCandidateDevelopmentTrialState(state, {
+      _tag: 'REVIEW_SUCCESSOR',
+      preregistration,
+    })
+    if (reviewed._tag === 'BLOCKED') throw new Error('expected successor review to apply')
+    const invalidated = reduceCandidateDevelopmentTrialState(reviewed.state, {
+      _tag: 'INVALIDATE_PRECOMMIT',
+      invalidation: buildCandidateDevelopmentInvalidPrecommit(preregistration),
+    })
+    expect(invalidated._tag).toBe('APPLIED')
+    if (invalidated._tag === 'BLOCKED') throw new Error('expected invalidation to apply')
+    expect(invalidated.state.currentSuccessor).toBeNull()
+    expect(invalidated.state.invalidatedPrecommits).toHaveLength(1)
+    expect(invalidated.state.nextOrdinal).toBe(5)
+    expect(deriveCandidateDevelopmentNextAction(invalidated.state)).toMatchObject({
+      _tag: 'AWAIT_REVIEWED_PRECOMMIT',
+      candidateOrdinal: 5,
+      reason: 'PRECOMMIT_INVALIDATED',
+    })
+
+    const replay = reduceCandidateDevelopmentTrialState(invalidated.state, {
+      _tag: 'INVALIDATE_PRECOMMIT',
+      invalidation: buildCandidateDevelopmentInvalidPrecommit(preregistration),
+    })
+    expect(replay).toMatchObject({ _tag: 'BLOCKED', issue: { reason: 'SUCCESSOR_REQUIRED' } })
+    const oldOrdinal = reduceCandidateDevelopmentTrialState(invalidated.state, {
+      _tag: 'REVIEW_SUCCESSOR',
+      preregistration,
+    })
+    expect(oldOrdinal).toMatchObject({ _tag: 'BLOCKED', issue: { reason: 'NEXT_ORDINAL_MISMATCH' } })
+  })
+
+  test('blocks repeated attempts, wrong terminalization, and ambiguous histories', () => {
+    const preregistration = buildCandidateDevelopmentPreregistration(4)
+    const reviewed = reduceCandidateDevelopmentTrialState(stateFrom(buildCandidateDevelopmentTrialHistory()), {
+      _tag: 'REVIEW_SUCCESSOR',
+      preregistration,
+    })
+    if (reviewed._tag === 'BLOCKED') throw new Error('expected successor review to apply')
+    const consumed = reduceCandidateDevelopmentTrialState(reviewed.state, {
+      _tag: 'CONSUME_DEVELOPMENT_ATTEMPT',
+      metricBearing: false,
+    })
+    if (consumed._tag === 'BLOCKED') throw new Error('expected development attempt to apply')
+    expect(
+      reduceCandidateDevelopmentTrialState(consumed.state, { _tag: 'CONSUME_QUALIFICATION_ATTEMPT' }),
+    ).toMatchObject({ _tag: 'BLOCKED', issue: { reason: 'ATTEMPT_ALREADY_CONSUMED' } })
+    expect(
+      reduceCandidateDevelopmentTrialState(reviewed.state, {
+        _tag: 'TERMINALIZE_QUALIFICATION',
+        evidence: { terminalStatus: 'HOLD_REJECT', sourceRevision: 'wrong-kind' },
+      }),
+    ).toMatchObject({ _tag: 'BLOCKED', issue: { reason: 'ATTEMPT_KIND_MISMATCH' } })
+
+    const invalidation = buildCandidateDevelopmentInvalidPrecommit(preregistration)
+    const invalidHistory = buildCandidateDevelopmentTrialHistory({ latestInvalidPrecommit: invalidation })
+    expect(validateCandidateDevelopmentTrialHistory(invalidHistory)).toEqual(Result.succeed(undefined))
+    const mutations = [
+      (history: Record<string, unknown>) => {
+        const current = history.latestInvalidPrecommit as Record<string, unknown>
+        current.metricBearingAttemptsConsumed = 1
+      },
+      (history: Record<string, unknown>) => {
+        history.developmentCandidateOrdinals = [3, 4]
+      },
+      (history: Record<string, unknown>) => {
+        const prior = history.latestReviewedCandidatePriorTrials as Record<string, unknown>
+        prior.developmentCandidateOrdinals = [3, 5]
+      },
+      (history: Record<string, unknown>) => {
+        history.nextCandidatePreregistration = {
+          ...buildCandidateDevelopmentPreregistration(6),
+        }
+      },
+      (history: Record<string, unknown>) => {
+        history.completedCandidateOrdinals = [1, 1]
+      },
+    ] as const
+    for (const mutate of mutations) {
+      const mutated = structuredClone(invalidHistory) as unknown as Record<string, unknown>
+      mutate(mutated)
+      expect(Result.isFailure(validateCandidateDevelopmentTrialHistory(mutated))).toBe(true)
+    }
+
+    const tamperedState = {
+      ...stateFrom(invalidHistory),
+      nextOrdinal: 99,
+    }
+    expect(deriveCandidateDevelopmentNextAction(tamperedState)).toMatchObject({
+      _tag: 'BLOCKED',
+      issue: { reason: 'NEXT_ORDINAL_MISMATCH' },
+    })
+  })
+
+  test('fails closed on missing lineage and malformed normalized records', () => {
+    const history = frozenCandidateDevelopmentTrialHistory as unknown as Record<string, unknown>
+    const missingInvalidation = { ...history }
+    delete missingInvalidation.latestInvalidPrecommit
+    expect(Result.isFailure(validateCandidateDevelopmentTrialHistory(missingInvalidation))).toBe(true)
+
+    const state = stateFrom(frozenCandidateDevelopmentTrialHistory)
+    const malformedStates: readonly unknown[] = [
+      { ...state, historicalQualificationTrials: [null] },
+      { ...state, developmentOnlyTrials: [null] },
+      { ...state, invalidatedPrecommits: [null] },
+    ]
+    for (const malformed of malformedStates) {
+      expect(() => validateCandidateDevelopmentTrialState(malformed)).not.toThrow()
+      expect(Result.isFailure(validateCandidateDevelopmentTrialState(malformed))).toBe(true)
+      expect(deriveCandidateDevelopmentNextAction(malformed as CandidateDevelopmentTrialState)).toMatchObject({
+        _tag: 'BLOCKED',
+      })
+    }
+  })
+})

--- a/services/bayn/src/candidate-development-trials/state-machine.test.ts
+++ b/services/bayn/src/candidate-development-trials/state-machine.test.ts
@@ -9,6 +9,7 @@ import {
   buildCandidateDevelopmentInvalidPrecommit,
   buildCandidateDevelopmentPreregistration,
   buildCandidateDevelopmentTrialHistory,
+  buildCandidateDevelopmentTrialHistoryAfterInvalidation,
 } from './test-builders'
 import {
   buildCandidateDevelopmentTrialState,
@@ -47,6 +48,50 @@ describe('candidate development trial state machine', () => {
       reason: 'PRECOMMIT_INVALIDATED',
     })
     expect(validateCandidateDevelopmentTrialState(state)).toEqual(Result.succeed(undefined))
+  })
+
+  test('preserves an invalidation gap and advances candidate 20 to successors 21 and 22', () => {
+    const historyWithGap = buildCandidateDevelopmentTrialHistoryAfterInvalidation()
+    expect(validateCandidateDevelopmentTrialHistory(historyWithGap)).toEqual(Result.succeed(undefined))
+    const normalizedGap = stateFrom(historyWithGap)
+    expect(normalizedGap.developmentOnlyTrials.map((trial) => trial.candidateOrdinal)).toEqual([3, 5])
+    expect(normalizedGap.invalidatedPrecommits.map((trial) => trial.invalidation.candidateOrdinal)).toEqual([4])
+    expect(normalizedGap.nextOrdinal).toBe(6)
+
+    const reviewed21 = reduceCandidateDevelopmentTrialState(stateFrom(frozenCandidateDevelopmentTrialHistory), {
+      _tag: 'REVIEW_SUCCESSOR',
+      preregistration: buildCandidateDevelopmentPreregistration(21),
+    })
+    expect(reviewed21._tag).toBe('APPLIED')
+    if (reviewed21._tag === 'BLOCKED') throw new Error('expected candidate 21 review to apply')
+    const consumed21 = reduceCandidateDevelopmentTrialState(reviewed21.state, {
+      _tag: 'CONSUME_DEVELOPMENT_ATTEMPT',
+      metricBearing: false,
+    })
+    expect(consumed21._tag).toBe('APPLIED')
+    if (consumed21._tag === 'BLOCKED') throw new Error('expected candidate 21 attempt to apply')
+    const terminalized21 = reduceCandidateDevelopmentTrialState(consumed21.state, {
+      _tag: 'TERMINALIZE_DEVELOPMENT_ONLY',
+      evidence: {
+        evidenceContentHash: 'development-evidence-21',
+        evaluatedSourceRevision: 'development-source-21',
+        failureStage: 'development-evaluation',
+        developmentMetricsObserved: false,
+      },
+    })
+    expect(terminalized21._tag).toBe('APPLIED')
+    if (terminalized21._tag === 'BLOCKED') throw new Error('expected candidate 21 terminalization to apply')
+    expect(terminalized21.state.developmentOnlyTrials.map((trial) => trial.candidateOrdinal)).toEqual([17, 18, 19, 21])
+    expect(terminalized21.state.nextOrdinal).toBe(22)
+
+    const reviewed22 = reduceCandidateDevelopmentTrialState(terminalized21.state, {
+      _tag: 'REVIEW_SUCCESSOR',
+      preregistration: buildCandidateDevelopmentPreregistration(22),
+    })
+    expect(reviewed22._tag).toBe('APPLIED')
+    if (reviewed22._tag === 'BLOCKED') throw new Error('expected candidate 22 review to apply')
+    expect(reviewed22.state.nextOrdinal).toBe(22)
+    expect(validateCandidateDevelopmentTrialState(reviewed22.state)).toEqual(Result.succeed(undefined))
   })
 
   test('reviews, consumes, and terminalizes a development-only successor exactly once', () => {
@@ -111,6 +156,12 @@ describe('candidate development trial state machine', () => {
       _tag: 'TERMINALIZE_QUALIFICATION',
       candidateOrdinal: 4,
     })
+    expect(
+      reduceCandidateDevelopmentTrialState(consumed.state, {
+        _tag: 'TERMINALIZE_QUALIFICATION',
+        evidence: { terminalStatus: 'HOLD_REJECT', sourceRevision: '' },
+      }),
+    ).toMatchObject({ _tag: 'BLOCKED', issue: { reason: 'TERMINAL_STATE_MISMATCH' } })
     const terminalized = reduceCandidateDevelopmentTrialState(consumed.state, {
       _tag: 'TERMINALIZE_QUALIFICATION',
       evidence: { terminalStatus: 'HOLD_REJECT', sourceRevision: 'qualification-source-4' },
@@ -178,6 +229,12 @@ describe('candidate development trial state machine', () => {
       }),
     ).toMatchObject({ _tag: 'BLOCKED', issue: { reason: 'TERMINAL_STATE_MISMATCH' } })
     expect(
+      reduceCandidateDevelopmentTrialState(consumed.state, {
+        _tag: 'TERMINALIZE_DEVELOPMENT_ONLY',
+        evidence: { evidenceContentHash: '' },
+      }),
+    ).toMatchObject({ _tag: 'BLOCKED', issue: { reason: 'TERMINAL_STATE_MISMATCH' } })
+    expect(
       reduceCandidateDevelopmentTrialState(consumed.state, { _tag: 'CONSUME_QUALIFICATION_ATTEMPT' }),
     ).toMatchObject({ _tag: 'BLOCKED', issue: { reason: 'ATTEMPT_ALREADY_CONSUMED' } })
     expect(
@@ -222,11 +279,39 @@ describe('candidate development trial state machine', () => {
       expect(Result.isFailure(validateCandidateDevelopmentTrialHistory(mutated))).toBe(true)
     }
 
+    const successorHistory = buildCandidateDevelopmentTrialHistory({
+      nextCandidatePreregistration: buildCandidateDevelopmentPreregistration(4),
+    })
+    const mismatchedSuccessor = structuredClone(successorHistory) as unknown as Record<string, unknown>
+    const nextSuccessor = mismatchedSuccessor.nextCandidatePreregistration as Record<string, unknown>
+    mismatchedSuccessor.nextCandidatePreregistration = {
+      ...nextSuccessor,
+      moduleSha256: 'a'.repeat(64),
+    }
+    expect(Result.isFailure(validateCandidateDevelopmentTrialHistory(mismatchedSuccessor))).toBe(true)
+
     const tamperedState = {
       ...stateFrom(invalidHistory),
       nextOrdinal: 99,
     }
     expect(deriveCandidateDevelopmentNextAction(tamperedState)).toMatchObject({
+      _tag: 'BLOCKED',
+      issue: { reason: 'NEXT_ORDINAL_MISMATCH' },
+    })
+    const successorState = stateFrom(successorHistory)
+    const missingLineageState = {
+      ...successorState,
+      nextOrdinal: 99,
+      currentSuccessor: {
+        ...successorState.currentSuccessor!,
+        preregistration: {
+          ...successorState.currentSuccessor!.preregistration,
+          candidateOrdinal: 99,
+          priorTrialCount: 98,
+        },
+      },
+    }
+    expect(deriveCandidateDevelopmentNextAction(missingLineageState)).toMatchObject({
       _tag: 'BLOCKED',
       issue: { reason: 'NEXT_ORDINAL_MISMATCH' },
     })

--- a/services/bayn/src/candidate-development-trials/state-machine.ts
+++ b/services/bayn/src/candidate-development-trials/state-machine.ts
@@ -14,6 +14,7 @@ export type {
   CandidateDevelopmentQualificationEvidence,
   CandidateDevelopmentQualificationPreregistration,
   CandidateDevelopmentQualificationTerminalEvidence,
+  CandidateDevelopmentSuccessorKind,
   CandidateDevelopmentTrialHistory,
   CandidateDevelopmentTrialState,
   CandidateDevelopmentTrialStateIssue,

--- a/services/bayn/src/candidate-development-trials/state-machine.ts
+++ b/services/bayn/src/candidate-development-trials/state-machine.ts
@@ -20,17 +20,13 @@ export type {
   CandidateDevelopmentTrialStateIssueReason,
   CandidateDevelopmentTrialTransition,
   CandidateDevelopmentTrialTransitionDecision,
-} from './candidate-development-trials/model'
+} from './model'
 
 export {
   buildCandidateDevelopmentTrialState,
   candidateDevelopmentTrialStateFromHistory,
-  deriveCandidateDevelopmentNextAction,
   emptyCandidateDevelopmentTrialState,
-  nextCandidateDevelopmentOrdinal,
-  reduceCandidateDevelopmentTrialState,
-  validateCandidateDevelopmentTrialHistory,
-  validateCandidateDevelopmentTrialState,
-} from './candidate-development-trials/state-machine'
-
-export * from './candidate-development-trials/frozen-lineage'
+} from './lineage'
+export { deriveCandidateDevelopmentNextAction, nextCandidateDevelopmentOrdinal } from './next-action'
+export { reduceCandidateDevelopmentTrialState } from './transitions'
+export { validateCandidateDevelopmentTrialHistory, validateCandidateDevelopmentTrialState } from './validation'

--- a/services/bayn/src/candidate-development-trials/test-builders.ts
+++ b/services/bayn/src/candidate-development-trials/test-builders.ts
@@ -174,3 +174,40 @@ export const buildCandidateDevelopmentTrialHistory = (
     nextCandidatePreregistration,
   }
 }
+
+export const buildCandidateDevelopmentTrialHistoryAfterInvalidation = (): CandidateDevelopmentTrialHistory => {
+  const invalidation = buildCandidateDevelopmentInvalidPrecommit(buildCandidateDevelopmentPreregistration(4))
+  const history = buildCandidateDevelopmentTrialHistory({ latestInvalidPrecommit: invalidation })
+  const latestDevelopmentPreregistration = buildCandidateDevelopmentPreregistration(5)
+  const latestDevelopmentEvidence = {
+    ...history.latestDevelopmentEvidence,
+    candidateOrdinal: 5,
+    priorTrialCount: 4,
+    evidenceContentHash: 'development-evidence-5',
+    evaluatedSourceRevision: 'development-source-5',
+  }
+  const latestPriorTrials = {
+    ...history.latestReviewedCandidatePriorTrials,
+    developmentCandidateOrdinals: [3, 5],
+    latestDevelopmentEvidence: {
+      ...history.latestReviewedCandidatePriorTrials.latestDevelopmentEvidence,
+      candidateOrdinal: 5,
+      priorTrialCount: 4,
+      evidenceContentHash: latestDevelopmentEvidence.evidenceContentHash,
+    },
+    latestReviewedPreregistration: latestDevelopmentPreregistration,
+  }
+  return {
+    ...history,
+    developmentCandidateOrdinals: [3, 5],
+    latestReviewedCandidateLegacyPriorTrials: {
+      ...history.latestReviewedCandidateLegacyPriorTrials,
+      developmentCandidateOrdinals: [3, 5],
+      latestDevelopmentEvidence: latestPriorTrials.latestDevelopmentEvidence,
+      latestReviewedPreregistration: latestDevelopmentPreregistration,
+    },
+    latestReviewedCandidatePriorTrials: latestPriorTrials,
+    latestReviewedCandidatePreregistration: latestDevelopmentPreregistration,
+    latestDevelopmentEvidence,
+  }
+}

--- a/services/bayn/src/candidate-development-trials/test-builders.ts
+++ b/services/bayn/src/candidate-development-trials/test-builders.ts
@@ -1,0 +1,176 @@
+import type {
+  CandidateDevelopmentInvalidPrecommit,
+  CandidateDevelopmentNextPreregistration,
+  CandidateDevelopmentTrialHistory,
+} from './state-machine'
+
+const hex = (seed: string, length: number): string =>
+  Array.from({ length }, (_, index) => '0123456789abcdef'[(seed.charCodeAt(index % seed.length) + index) % 16]).join('')
+
+const marketData = {
+  schemaVersion: 'bayn.candidate-development-market-data-source.v1' as const,
+  snapshotId: hex('snapshot-1', 64),
+  finalizedSnapshotContentHash: hex('finalized-content-1', 64),
+  inputManifestHash: hex('manifest-1', 64),
+  boundedContentHash: hex('bounded-content-1', 64),
+}
+
+export const buildCandidateDevelopmentPreregistration = (
+  candidateOrdinal: number,
+): CandidateDevelopmentNextPreregistration => ({
+  schemaVersion: 'bayn.candidate-development-next-preregistration.v1',
+  candidateOrdinal,
+  priorTrialCount: candidateOrdinal - 1,
+  strategyProtocolHash: hex(`strategy-${candidateOrdinal}`, 64),
+  strategyIdentityHash: hex(`identity-${candidateOrdinal}`, 64),
+  candidateDevelopmentProtocolHash: hex(`development-${candidateOrdinal}`, 64),
+  calendarHash: hex('calendar-1', 64),
+  priorTrialsHash: hex(`prior-trials-${candidateOrdinal}`, 64),
+  modulePath: `services/bayn/src/strategy/test/candidate-${candidateOrdinal}.ts`,
+  moduleSha256: hex(`module-${candidateOrdinal}`, 64),
+  marketData,
+  preregistration: {
+    sourceRevision: hex(`source-${candidateOrdinal}`, 40),
+    path: `services/bayn/candidates/ordinal-${candidateOrdinal}-preregistration.json`,
+    blobOid: hex(`blob-${candidateOrdinal}`, 40),
+  },
+})
+
+export const buildCandidateDevelopmentInvalidPrecommit = (
+  preregistration: CandidateDevelopmentNextPreregistration,
+): CandidateDevelopmentInvalidPrecommit => ({
+  schemaVersion: 'bayn.candidate-development-precommit-invalidation.v1',
+  candidateOrdinal: preregistration.candidateOrdinal,
+  priorTrialCount: preregistration.priorTrialCount,
+  status: 'PRECOMMIT_INVALID',
+  attemptStatus: 'UNATTEMPTED',
+  metricBearingAttemptsConsumed: 0,
+  qualificationAttemptConsumed: false,
+  reviewedHeadRevision: hex('reviewed-head', 40),
+  mergedSourceRevision: hex('merged-source', 40),
+  preregistration: {
+    ...preregistration.preregistration,
+    sha256: hex(`preregistration-${preregistration.candidateOrdinal}`, 64),
+  },
+  sourceManifest: {
+    path: `services/bayn/candidates/ordinal-${preregistration.candidateOrdinal}-source-manifest.json`,
+    blobOid: hex(`manifest-blob-${preregistration.candidateOrdinal}`, 40),
+    sha256: hex(`manifest-${preregistration.candidateOrdinal}`, 64),
+  },
+  invalidatedModule: {
+    path: preregistration.modulePath,
+    blobOid: hex(`module-blob-${preregistration.candidateOrdinal}`, 40),
+    sha256: preregistration.moduleSha256,
+    lineCount: 10,
+    byteCount: 100,
+    findings: [
+      'TYPE_CHECK_DISABLED',
+      'DOWNCOMPILED_BUNDLE',
+      'EMBEDDED_OFFICIAL_SESSIONS',
+      'EMBEDDED_MARKET_BARS',
+      'RUNTIME_INPUT_IGNORED',
+    ],
+  },
+  naturalBuild: {
+    runId: 'natural-build',
+    imagePublished: true,
+    imageDigest: `sha256:${hex('natural-build', 64)}`,
+    deploymentAllowed: false,
+  },
+  release: {
+    runId: 'release',
+    conclusion: 'CANCELLED',
+    promotionCompleted: false,
+    rerunAllowed: false,
+  },
+  nextCandidatePreregistration: null,
+})
+
+export const buildCandidateDevelopmentTrialHistory = (
+  options: {
+    readonly nextCandidatePreregistration?: CandidateDevelopmentNextPreregistration | null
+    readonly latestInvalidPrecommit?: CandidateDevelopmentInvalidPrecommit | null
+  } = {},
+): CandidateDevelopmentTrialHistory => {
+  const latestDevelopmentPreregistration = buildCandidateDevelopmentPreregistration(3)
+  const latestInvalidPrecommit = options.latestInvalidPrecommit ?? null
+  const nextCandidatePreregistration = options.nextCandidatePreregistration ?? null
+  const latestReviewed =
+    nextCandidatePreregistration ??
+    (latestInvalidPrecommit === null
+      ? latestDevelopmentPreregistration
+      : {
+          ...latestDevelopmentPreregistration,
+          candidateOrdinal: latestInvalidPrecommit.candidateOrdinal,
+          priorTrialCount: latestInvalidPrecommit.priorTrialCount,
+          modulePath: latestInvalidPrecommit.invalidatedModule.path,
+          moduleSha256: latestInvalidPrecommit.invalidatedModule.sha256,
+          preregistration: {
+            sourceRevision: latestInvalidPrecommit.preregistration.sourceRevision,
+            path: latestInvalidPrecommit.preregistration.path,
+            blobOid: latestInvalidPrecommit.preregistration.blobOid,
+          },
+        })
+  const latestTerminalEvidence = {
+    candidateOrdinal: 2,
+    priorTrialCount: 1,
+    terminalStatus: 'HOLD_REJECT' as const,
+    sourceRevision: 'qualification-source',
+  }
+  const latestDevelopmentEvidence = {
+    candidateOrdinal: 3,
+    priorTrialCount: 2,
+    status: 'DEVELOPMENT_REJECTED' as const,
+    evidenceContentHash: 'development-evidence-3',
+    evaluatedSourceRevision: 'development-source-3',
+    failureStage: 'development-evaluation' as const,
+    developmentMetricsObserved: true,
+    qualificationAttemptConsumed: false as const,
+  }
+  const latestReviewedCandidatePriorTrials = {
+    schemaVersion: 'bayn.candidate-development-prior-trials.v2' as const,
+    qualificationCandidateOrdinals: [1, 2],
+    latestQualificationEvidence: latestTerminalEvidence,
+    latestQualificationPreregistration: {
+      candidateOrdinal: 2,
+      priorTrialCount: 1,
+      sourceRevision: 'qualification-preregistration',
+      path: 'candidate-2-preregistration.json',
+      blobOid: 'candidate-2-blob',
+    },
+    developmentCandidateOrdinals: [3],
+    latestDevelopmentEvidence: {
+      candidateOrdinal: 3,
+      priorTrialCount: 2,
+      status: 'DEVELOPMENT_REJECTED' as const,
+      evidenceContentHash: latestDevelopmentEvidence.evidenceContentHash,
+      qualificationAttemptConsumed: false as const,
+    },
+    latestReviewedPreregistration: latestDevelopmentPreregistration,
+  }
+  return {
+    schemaVersion: 'bayn.candidate-development-trial-history.v2',
+    completedCandidateOrdinals: [1, 2],
+    developmentCandidateOrdinals: [3],
+    latestReviewedCandidateLegacyPriorTrials: {
+      schemaVersion: 'bayn.candidate-development-prior-trials.v1',
+      qualificationCandidateOrdinals: [1, 2],
+      developmentCandidateOrdinals: [3],
+      latestDevelopmentEvidence: latestReviewedCandidatePriorTrials.latestDevelopmentEvidence,
+      latestReviewedPreregistration: latestDevelopmentPreregistration,
+    },
+    latestReviewedCandidatePriorTrials,
+    latestTerminalEvidence,
+    candidatePreregistration: {
+      candidateOrdinal: 2,
+      priorTrialCount: 1,
+      sourceRevision: 'qualification-preregistration',
+      path: 'candidate-2-preregistration.json',
+      blobOid: 'candidate-2-blob',
+    },
+    latestReviewedCandidatePreregistration: latestReviewed,
+    latestDevelopmentEvidence,
+    latestInvalidPrecommit,
+    nextCandidatePreregistration,
+  }
+}

--- a/services/bayn/src/candidate-development-trials/transitions.ts
+++ b/services/bayn/src/candidate-development-trials/transitions.ts
@@ -1,0 +1,245 @@
+import { Result } from 'effect'
+
+import type {
+  CandidateDevelopmentAttemptConsumption,
+  CandidateDevelopmentCurrentSuccessor,
+  CandidateDevelopmentDevelopmentOnlyTrial,
+  CandidateDevelopmentHistoricalQualificationTrial,
+  CandidateDevelopmentImmutableInvalidation,
+  CandidateDevelopmentTrialState,
+  CandidateDevelopmentTrialStateIssue,
+  CandidateDevelopmentTrialTransition,
+  CandidateDevelopmentTrialTransitionDecision,
+} from './model'
+import { cloneAndFreeze } from './lineage'
+import {
+  isRecord,
+  stateIssue,
+  validateCandidateDevelopmentTrialState,
+  validateInvalidation,
+  validateNextPreregistration,
+} from './validation'
+
+type ReviewSuccessorTransition = Extract<CandidateDevelopmentTrialTransition, { readonly _tag: 'REVIEW_SUCCESSOR' }>
+type InvalidatePrecommitTransition = Extract<
+  CandidateDevelopmentTrialTransition,
+  { readonly _tag: 'INVALIDATE_PRECOMMIT' }
+>
+type TerminalizeDevelopmentTransition = Extract<
+  CandidateDevelopmentTrialTransition,
+  { readonly _tag: 'TERMINALIZE_DEVELOPMENT_ONLY' }
+>
+type TerminalizeQualificationTransition = Extract<
+  CandidateDevelopmentTrialTransition,
+  { readonly _tag: 'TERMINALIZE_QUALIFICATION' }
+>
+
+const unattempted: Extract<CandidateDevelopmentAttemptConsumption, { readonly _tag: 'UNATTEMPTED' }> = Object.freeze({
+  _tag: 'UNATTEMPTED',
+  attemptCount: 0,
+  metricBearingAttemptsConsumed: 0,
+  qualificationAttemptConsumed: false,
+})
+
+const applied = (state: CandidateDevelopmentTrialState): CandidateDevelopmentTrialTransitionDecision => ({
+  _tag: 'APPLIED',
+  state,
+})
+
+const blocked = (issue: CandidateDevelopmentTrialStateIssue): CandidateDevelopmentTrialTransitionDecision => ({
+  _tag: 'BLOCKED',
+  issue,
+})
+
+const isIssue = (
+  value: CandidateDevelopmentCurrentSuccessor | CandidateDevelopmentTrialStateIssue,
+): value is CandidateDevelopmentTrialStateIssue => value._tag === 'CandidateDevelopmentTrialStateInvalid'
+
+const requireSuccessor = (
+  state: CandidateDevelopmentTrialState,
+): CandidateDevelopmentCurrentSuccessor | CandidateDevelopmentTrialStateIssue =>
+  state.currentSuccessor ?? stateIssue('state.currentSuccessor', 'SUCCESSOR_REQUIRED')
+
+const requireUnattemptedSuccessor = (
+  state: CandidateDevelopmentTrialState,
+): CandidateDevelopmentCurrentSuccessor | CandidateDevelopmentTrialStateIssue => {
+  const successor = requireSuccessor(state)
+  if (isIssue(successor)) return successor
+  return successor.attempt._tag === 'UNATTEMPTED'
+    ? successor
+    : stateIssue('state.currentSuccessor.attempt', 'ATTEMPT_ALREADY_CONSUMED', successor.attempt)
+}
+
+const reviewSuccessor = (
+  state: CandidateDevelopmentTrialState,
+  preregistration: ReviewSuccessorTransition['preregistration'],
+): CandidateDevelopmentTrialTransitionDecision => {
+  if (state.currentSuccessor !== null) {
+    return blocked(stateIssue('state.currentSuccessor', 'SUCCESSOR_ALREADY_PRESENT', state.currentSuccessor))
+  }
+  const preregistrationIssue = validateNextPreregistration(preregistration, 'transition.preregistration')
+  if (preregistrationIssue !== undefined) return blocked(preregistrationIssue)
+  if (
+    preregistration.candidateOrdinal !== state.nextOrdinal ||
+    preregistration.priorTrialCount !== state.nextOrdinal - 1
+  ) {
+    return blocked(
+      stateIssue('transition.preregistration', 'NEXT_ORDINAL_MISMATCH', preregistration, {
+        candidateOrdinal: state.nextOrdinal,
+        priorTrialCount: state.nextOrdinal - 1,
+      }),
+    )
+  }
+  const successor: CandidateDevelopmentCurrentSuccessor = {
+    _tag: 'CURRENT_SUCCESSOR',
+    preregistration: cloneAndFreeze(preregistration),
+    attempt: unattempted,
+  }
+  return applied({ ...state, currentSuccessor: cloneAndFreeze(successor) })
+}
+
+const consumeAttempt = (
+  state: CandidateDevelopmentTrialState,
+  attempt: Exclude<CandidateDevelopmentAttemptConsumption, { readonly _tag: 'UNATTEMPTED' }>,
+): CandidateDevelopmentTrialTransitionDecision => {
+  const successor = requireUnattemptedSuccessor(state)
+  if (isIssue(successor)) return blocked(successor)
+  return applied({
+    ...state,
+    currentSuccessor: cloneAndFreeze({ ...successor, attempt }),
+  })
+}
+
+const matchesInvalidationBinding = (
+  successor: CandidateDevelopmentCurrentSuccessor,
+  invalidation: InvalidatePrecommitTransition['invalidation'],
+): boolean =>
+  invalidation.candidateOrdinal === successor.preregistration.candidateOrdinal &&
+  invalidation.priorTrialCount === successor.preregistration.priorTrialCount &&
+  invalidation.invalidatedModule.path === successor.preregistration.modulePath &&
+  invalidation.invalidatedModule.sha256 === successor.preregistration.moduleSha256 &&
+  invalidation.preregistration.sourceRevision === successor.preregistration.preregistration.sourceRevision &&
+  invalidation.preregistration.path === successor.preregistration.preregistration.path &&
+  invalidation.preregistration.blobOid === successor.preregistration.preregistration.blobOid
+
+const invalidateSuccessor = (
+  state: CandidateDevelopmentTrialState,
+  invalidation: InvalidatePrecommitTransition['invalidation'],
+): CandidateDevelopmentTrialTransitionDecision => {
+  const successor = requireUnattemptedSuccessor(state)
+  if (isIssue(successor)) return blocked(successor)
+  const invalidationIssue = validateInvalidation(invalidation, 'transition.invalidation')
+  if (invalidationIssue !== undefined) return blocked(invalidationIssue)
+  if (!matchesInvalidationBinding(successor, invalidation)) {
+    return blocked(
+      stateIssue('transition.invalidation', 'INVALIDATION_BINDING_MISMATCH', invalidation, successor.preregistration),
+    )
+  }
+  const invalidated: CandidateDevelopmentImmutableInvalidation = {
+    _tag: 'IMMUTABLE_INVALIDATION',
+    invalidation: cloneAndFreeze(invalidation),
+    attempt: unattempted,
+  }
+  return applied({
+    ...state,
+    invalidatedPrecommits: [...state.invalidatedPrecommits, cloneAndFreeze(invalidated)],
+    currentSuccessor: null,
+    nextOrdinal: invalidation.candidateOrdinal + 1,
+  })
+}
+
+const terminalizeDevelopmentOnly = (
+  state: CandidateDevelopmentTrialState,
+  evidence: TerminalizeDevelopmentTransition['evidence'],
+): CandidateDevelopmentTrialTransitionDecision => {
+  const successor = requireSuccessor(state)
+  if (isIssue(successor)) return blocked(successor)
+  if (successor.attempt._tag !== 'DEVELOPMENT_ONLY_ATTEMPT') {
+    return blocked(
+      stateIssue(
+        'state.currentSuccessor.attempt',
+        'ATTEMPT_KIND_MISMATCH',
+        successor.attempt,
+        'DEVELOPMENT_ONLY_ATTEMPT',
+      ),
+    )
+  }
+  const trial: CandidateDevelopmentDevelopmentOnlyTrial = {
+    _tag: 'DEVELOPMENT_ONLY',
+    candidateOrdinal: successor.preregistration.candidateOrdinal,
+    priorTrialCount: successor.preregistration.priorTrialCount,
+    status: 'DEVELOPMENT_REJECTED',
+    evidenceContentHash: evidence.evidenceContentHash,
+    evaluatedSourceRevision: evidence.evaluatedSourceRevision ?? null,
+    failureStage: evidence.failureStage ?? null,
+    developmentMetricsObserved: evidence.developmentMetricsObserved ?? null,
+    attempt: successor.attempt,
+  }
+  return applied({
+    ...state,
+    developmentOnlyTrials: [...state.developmentOnlyTrials, cloneAndFreeze(trial)],
+    currentSuccessor: null,
+    nextOrdinal: successor.preregistration.candidateOrdinal + 1,
+  })
+}
+
+const terminalizeQualification = (
+  state: CandidateDevelopmentTrialState,
+  evidence: TerminalizeQualificationTransition['evidence'],
+): CandidateDevelopmentTrialTransitionDecision => {
+  const successor = requireSuccessor(state)
+  if (isIssue(successor)) return blocked(successor)
+  if (successor.attempt._tag !== 'QUALIFICATION_ATTEMPT') {
+    return blocked(
+      stateIssue('state.currentSuccessor.attempt', 'ATTEMPT_KIND_MISMATCH', successor.attempt, 'QUALIFICATION_ATTEMPT'),
+    )
+  }
+  const trial: CandidateDevelopmentHistoricalQualificationTrial = {
+    _tag: 'HISTORICAL_QUALIFICATION',
+    candidateOrdinal: successor.preregistration.candidateOrdinal,
+    priorTrialCount: successor.preregistration.priorTrialCount,
+    terminalStatus: evidence.terminalStatus,
+    attempt: successor.attempt,
+  }
+  return applied({
+    ...state,
+    historicalQualificationTrials: [...state.historicalQualificationTrials, cloneAndFreeze(trial)],
+    currentSuccessor: null,
+    nextOrdinal: successor.preregistration.candidateOrdinal + 1,
+  })
+}
+
+export const reduceCandidateDevelopmentTrialState = (
+  state: CandidateDevelopmentTrialState,
+  transition: CandidateDevelopmentTrialTransition,
+): CandidateDevelopmentTrialTransitionDecision => {
+  const stateValidation = validateCandidateDevelopmentTrialState(state)
+  if (Result.isFailure(stateValidation)) return blocked(stateValidation.failure)
+  if (!isRecord(transition)) return blocked(stateIssue('transition', 'MALFORMED_HISTORY', transition))
+  switch (transition._tag) {
+    case 'REVIEW_SUCCESSOR':
+      return reviewSuccessor(state, transition.preregistration)
+    case 'INVALIDATE_PRECOMMIT':
+      return invalidateSuccessor(state, transition.invalidation)
+    case 'CONSUME_DEVELOPMENT_ATTEMPT':
+      return consumeAttempt(state, {
+        _tag: 'DEVELOPMENT_ONLY_ATTEMPT',
+        attemptCount: 1,
+        metricBearingAttemptsConsumed: transition.metricBearing ? 1 : 0,
+        qualificationAttemptConsumed: false,
+      })
+    case 'CONSUME_QUALIFICATION_ATTEMPT':
+      return consumeAttempt(state, {
+        _tag: 'QUALIFICATION_ATTEMPT',
+        attemptCount: 1,
+        metricBearingAttemptsConsumed: 1,
+        qualificationAttemptConsumed: true,
+      })
+    case 'TERMINALIZE_DEVELOPMENT_ONLY':
+      return terminalizeDevelopmentOnly(state, transition.evidence)
+    case 'TERMINALIZE_QUALIFICATION':
+      return terminalizeQualification(state, transition.evidence)
+    default:
+      return blocked(stateIssue('transition', 'MALFORMED_HISTORY', transition))
+  }
+}

--- a/services/bayn/src/candidate-development-trials/transitions.ts
+++ b/services/bayn/src/candidate-development-trials/transitions.ts
@@ -24,6 +24,10 @@ import {
 } from './validation'
 
 type ReviewSuccessorTransition = Extract<CandidateDevelopmentTrialTransition, { readonly _tag: 'REVIEW_SUCCESSOR' }>
+type ConsumeDevelopmentTransition = Extract<
+  CandidateDevelopmentTrialTransition,
+  { readonly _tag: 'CONSUME_DEVELOPMENT_ATTEMPT' }
+>
 type InvalidatePrecommitTransition = Extract<
   CandidateDevelopmentTrialTransition,
   { readonly _tag: 'INVALIDATE_PRECOMMIT' }
@@ -121,6 +125,25 @@ const consumeAttempt = (
     ...state,
     currentSuccessor: cloneAndFreeze({ ...successor, attempt }),
   })
+}
+
+const consumeDevelopmentOnlyAttempt = (
+  state: CandidateDevelopmentTrialState,
+  transition: ConsumeDevelopmentTransition,
+): CandidateDevelopmentTrialTransitionDecision => {
+  if (typeof transition.metricBearing !== 'boolean') {
+    return blocked(stateIssue('transition.metricBearing', 'MALFORMED_HISTORY', transition.metricBearing, 'boolean'))
+  }
+  return consumeAttempt(
+    state,
+    {
+      _tag: 'DEVELOPMENT_ONLY_ATTEMPT',
+      attemptCount: 1,
+      metricBearingAttemptsConsumed: transition.metricBearing ? 1 : 0,
+      qualificationAttemptConsumed: false,
+    },
+    'DEVELOPMENT_ONLY',
+  )
 }
 
 const matchesInvalidationBinding = (
@@ -260,16 +283,7 @@ export const reduceCandidateDevelopmentTrialState = (
     case 'INVALIDATE_PRECOMMIT':
       return invalidateSuccessor(state, transition.invalidation)
     case 'CONSUME_DEVELOPMENT_ATTEMPT':
-      return consumeAttempt(
-        state,
-        {
-          _tag: 'DEVELOPMENT_ONLY_ATTEMPT',
-          attemptCount: 1,
-          metricBearingAttemptsConsumed: transition.metricBearing ? 1 : 0,
-          qualificationAttemptConsumed: false,
-        },
-        'DEVELOPMENT_ONLY',
-      )
+      return consumeDevelopmentOnlyAttempt(state, transition)
     case 'CONSUME_QUALIFICATION_ATTEMPT':
       return consumeAttempt(
         state,

--- a/services/bayn/src/candidate-development-trials/transitions.ts
+++ b/services/bayn/src/candidate-development-trials/transitions.ts
@@ -6,6 +6,7 @@ import type {
   CandidateDevelopmentDevelopmentOnlyTrial,
   CandidateDevelopmentHistoricalQualificationTrial,
   CandidateDevelopmentImmutableInvalidation,
+  CandidateDevelopmentSuccessorKind,
   CandidateDevelopmentTrialState,
   CandidateDevelopmentTrialStateIssue,
   CandidateDevelopmentTrialTransition,
@@ -72,8 +73,9 @@ const requireUnattemptedSuccessor = (
 
 const reviewSuccessor = (
   state: CandidateDevelopmentTrialState,
-  preregistration: ReviewSuccessorTransition['preregistration'],
+  transition: ReviewSuccessorTransition,
 ): CandidateDevelopmentTrialTransitionDecision => {
+  const { preregistration } = transition
   if (state.currentSuccessor !== null) {
     return blocked(stateIssue('state.currentSuccessor', 'SUCCESSOR_ALREADY_PRESENT', state.currentSuccessor))
   }
@@ -90,8 +92,13 @@ const reviewSuccessor = (
       }),
     )
   }
+  const kind: CandidateDevelopmentSuccessorKind = transition.kind ?? 'DEVELOPMENT_ONLY'
+  if (kind !== 'DEVELOPMENT_ONLY' && kind !== 'QUALIFICATION') {
+    return blocked(stateIssue('transition.kind', 'ATTEMPT_KIND_MISMATCH', kind, ['DEVELOPMENT_ONLY', 'QUALIFICATION']))
+  }
   const successor: CandidateDevelopmentCurrentSuccessor = {
     _tag: 'CURRENT_SUCCESSOR',
+    kind,
     preregistration: cloneAndFreeze(preregistration),
     attempt: unattempted,
   }
@@ -101,9 +108,13 @@ const reviewSuccessor = (
 const consumeAttempt = (
   state: CandidateDevelopmentTrialState,
   attempt: Exclude<CandidateDevelopmentAttemptConsumption, { readonly _tag: 'UNATTEMPTED' }>,
+  expectedKind: CandidateDevelopmentSuccessorKind,
 ): CandidateDevelopmentTrialTransitionDecision => {
   const successor = requireUnattemptedSuccessor(state)
   if (isIssue(successor)) return blocked(successor)
+  if (successor.kind !== expectedKind) {
+    return blocked(stateIssue('state.currentSuccessor.kind', 'ATTEMPT_KIND_MISMATCH', successor.kind, expectedKind))
+  }
   return applied({
     ...state,
     currentSuccessor: cloneAndFreeze({ ...successor, attempt }),
@@ -154,6 +165,11 @@ const terminalizeDevelopmentOnly = (
 ): CandidateDevelopmentTrialTransitionDecision => {
   const successor = requireSuccessor(state)
   if (isIssue(successor)) return blocked(successor)
+  if (successor.kind !== 'DEVELOPMENT_ONLY') {
+    return blocked(
+      stateIssue('state.currentSuccessor.kind', 'ATTEMPT_KIND_MISMATCH', successor.kind, 'DEVELOPMENT_ONLY'),
+    )
+  }
   if (successor.attempt._tag !== 'DEVELOPMENT_ONLY_ATTEMPT') {
     return blocked(
       stateIssue(
@@ -161,6 +177,18 @@ const terminalizeDevelopmentOnly = (
         'ATTEMPT_KIND_MISMATCH',
         successor.attempt,
         'DEVELOPMENT_ONLY_ATTEMPT',
+      ),
+    )
+  }
+  const developmentMetricsObserved = evidence.developmentMetricsObserved ?? null
+  const attemptMetricsObserved = successor.attempt.metricBearingAttemptsConsumed === 1
+  if (developmentMetricsObserved !== null && developmentMetricsObserved !== attemptMetricsObserved) {
+    return blocked(
+      stateIssue(
+        'transition.evidence.developmentMetricsObserved',
+        'TERMINAL_STATE_MISMATCH',
+        developmentMetricsObserved,
+        attemptMetricsObserved,
       ),
     )
   }
@@ -172,7 +200,7 @@ const terminalizeDevelopmentOnly = (
     evidenceContentHash: evidence.evidenceContentHash,
     evaluatedSourceRevision: evidence.evaluatedSourceRevision ?? null,
     failureStage: evidence.failureStage ?? null,
-    developmentMetricsObserved: evidence.developmentMetricsObserved ?? null,
+    developmentMetricsObserved,
     attempt: successor.attempt,
   }
   return applied({
@@ -189,6 +217,9 @@ const terminalizeQualification = (
 ): CandidateDevelopmentTrialTransitionDecision => {
   const successor = requireSuccessor(state)
   if (isIssue(successor)) return blocked(successor)
+  if (successor.kind !== 'QUALIFICATION') {
+    return blocked(stateIssue('state.currentSuccessor.kind', 'ATTEMPT_KIND_MISMATCH', successor.kind, 'QUALIFICATION'))
+  }
   if (successor.attempt._tag !== 'QUALIFICATION_ATTEMPT') {
     return blocked(
       stateIssue('state.currentSuccessor.attempt', 'ATTEMPT_KIND_MISMATCH', successor.attempt, 'QUALIFICATION_ATTEMPT'),
@@ -199,6 +230,7 @@ const terminalizeQualification = (
     candidateOrdinal: successor.preregistration.candidateOrdinal,
     priorTrialCount: successor.preregistration.priorTrialCount,
     terminalStatus: evidence.terminalStatus,
+    sourceRevision: evidence.sourceRevision,
     attempt: successor.attempt,
   }
   return applied({
@@ -218,23 +250,31 @@ export const reduceCandidateDevelopmentTrialState = (
   if (!isRecord(transition)) return blocked(stateIssue('transition', 'MALFORMED_HISTORY', transition))
   switch (transition._tag) {
     case 'REVIEW_SUCCESSOR':
-      return reviewSuccessor(state, transition.preregistration)
+      return reviewSuccessor(state, transition)
     case 'INVALIDATE_PRECOMMIT':
       return invalidateSuccessor(state, transition.invalidation)
     case 'CONSUME_DEVELOPMENT_ATTEMPT':
-      return consumeAttempt(state, {
-        _tag: 'DEVELOPMENT_ONLY_ATTEMPT',
-        attemptCount: 1,
-        metricBearingAttemptsConsumed: transition.metricBearing ? 1 : 0,
-        qualificationAttemptConsumed: false,
-      })
+      return consumeAttempt(
+        state,
+        {
+          _tag: 'DEVELOPMENT_ONLY_ATTEMPT',
+          attemptCount: 1,
+          metricBearingAttemptsConsumed: transition.metricBearing ? 1 : 0,
+          qualificationAttemptConsumed: false,
+        },
+        'DEVELOPMENT_ONLY',
+      )
     case 'CONSUME_QUALIFICATION_ATTEMPT':
-      return consumeAttempt(state, {
-        _tag: 'QUALIFICATION_ATTEMPT',
-        attemptCount: 1,
-        metricBearingAttemptsConsumed: 1,
-        qualificationAttemptConsumed: true,
-      })
+      return consumeAttempt(
+        state,
+        {
+          _tag: 'QUALIFICATION_ATTEMPT',
+          attemptCount: 1,
+          metricBearingAttemptsConsumed: 1,
+          qualificationAttemptConsumed: true,
+        },
+        'QUALIFICATION',
+      )
     case 'TERMINALIZE_DEVELOPMENT_ONLY':
       return terminalizeDevelopmentOnly(state, transition.evidence)
     case 'TERMINALIZE_QUALIFICATION':

--- a/services/bayn/src/candidate-development-trials/transitions.ts
+++ b/services/bayn/src/candidate-development-trials/transitions.ts
@@ -17,8 +17,10 @@ import {
   isRecord,
   stateIssue,
   validateCandidateDevelopmentTrialState,
+  validateDevelopmentTerminalEvidence,
   validateInvalidation,
   validateNextPreregistration,
+  validateQualificationTerminalEvidence,
 } from './validation'
 
 type ReviewSuccessorTransition = Extract<CandidateDevelopmentTrialTransition, { readonly _tag: 'REVIEW_SUCCESSOR' }>
@@ -180,6 +182,8 @@ const terminalizeDevelopmentOnly = (
       ),
     )
   }
+  const evidenceIssue = validateDevelopmentTerminalEvidence(evidence, 'transition.evidence')
+  if (evidenceIssue !== undefined) return blocked(evidenceIssue)
   const developmentMetricsObserved = evidence.developmentMetricsObserved ?? null
   const attemptMetricsObserved = successor.attempt.metricBearingAttemptsConsumed === 1
   if (developmentMetricsObserved !== null && developmentMetricsObserved !== attemptMetricsObserved) {
@@ -225,6 +229,8 @@ const terminalizeQualification = (
       stateIssue('state.currentSuccessor.attempt', 'ATTEMPT_KIND_MISMATCH', successor.attempt, 'QUALIFICATION_ATTEMPT'),
     )
   }
+  const evidenceIssue = validateQualificationTerminalEvidence(evidence, 'transition.evidence')
+  if (evidenceIssue !== undefined) return blocked(evidenceIssue)
   const trial: CandidateDevelopmentHistoricalQualificationTrial = {
     _tag: 'HISTORICAL_QUALIFICATION',
     candidateOrdinal: successor.preregistration.candidateOrdinal,

--- a/services/bayn/src/candidate-development-trials/validation.ts
+++ b/services/bayn/src/candidate-development-trials/validation.ts
@@ -233,10 +233,9 @@ const validateInvalidationOutcomes = (
     naturalBuild.imagePublished !== true ||
     naturalBuild.deploymentAllowed !== false ||
     !isNonEmptyString(naturalBuild.runId) ||
-    !isHex(
-      typeof naturalBuild.imageDigest === 'string' ? naturalBuild.imageDigest.slice('sha256:'.length) : undefined,
-      64,
-    ) ||
+    typeof naturalBuild.imageDigest !== 'string' ||
+    !naturalBuild.imageDigest.startsWith('sha256:') ||
+    !isHex(naturalBuild.imageDigest.slice('sha256:'.length), 64) ||
     !isNonNegativeInteger(invalidatedModule.lineCount) ||
     !isNonNegativeInteger(invalidatedModule.byteCount) ||
     !hasInvalidationFindings(invalidatedModule.findings) ||
@@ -607,6 +606,9 @@ const expectedDevelopmentOrdinals = (
 const sameOrdinals = (left: readonly number[], right: readonly number[]): boolean =>
   left.length === right.length && left.every((ordinal, index) => ordinal === right[index])
 
+const isStrictlyIncreasing = (ordinals: readonly number[]): boolean =>
+  ordinals.every((ordinal, index) => index === 0 || ordinal > ordinals[index - 1]!)
+
 const validateClosedOrdinals = (
   history: CandidateDevelopmentTrialHistory,
   invalidOrdinal: number | null,
@@ -736,17 +738,17 @@ const validateHistoricalQualificationTrials = (
   for (const [index, trial] of state.historicalQualificationTrials.entries()) {
     if (!isRecord(trial)) return stateIssue(`state.historicalQualificationTrials[${index}]`, 'MALFORMED_HISTORY', trial)
   }
-  const sequenceIssue = equalOrdinalSequence(
-    state.historicalQualificationTrials.map((trial) => trial.candidateOrdinal),
-    1,
-  )
-  if (sequenceIssue !== null) return stateIssue('state.historicalQualificationTrials', 'ORDINAL_SEQUENCE_GAP')
+  const qualificationOrdinals = state.historicalQualificationTrials.map((trial) => trial.candidateOrdinal)
+  if (!isStrictlyIncreasing(qualificationOrdinals)) {
+    return stateIssue('state.historicalQualificationTrials', 'ORDINAL_OVERLAP', qualificationOrdinals)
+  }
   for (const [index, trial] of state.historicalQualificationTrials.entries()) {
     if (
       trial._tag !== 'HISTORICAL_QUALIFICATION' ||
       !isPositiveInteger(trial.candidateOrdinal) ||
       trial.priorTrialCount !== trial.candidateOrdinal - 1 ||
       trial.terminalStatus !== 'HOLD_REJECT' ||
+      (trial.sourceRevision !== null && !isNonEmptyString(trial.sourceRevision)) ||
       !isRecord(trial.attempt) ||
       trial.attempt._tag !== 'QUALIFICATION_ATTEMPT'
     ) {
@@ -776,6 +778,17 @@ const validateDevelopmentOnlyTrials = (
     }
     const attemptIssue = validateAttempt(trial.attempt, `state.developmentOnlyTrials[${index}].attempt`)
     if (attemptIssue !== undefined) return attemptIssue
+    if (
+      trial.developmentMetricsObserved !== null &&
+      trial.developmentMetricsObserved !== (trial.attempt.metricBearingAttemptsConsumed === 1)
+    ) {
+      return stateIssue(
+        `state.developmentOnlyTrials[${index}].developmentMetricsObserved`,
+        'TERMINAL_STATE_MISMATCH',
+        trial.developmentMetricsObserved,
+        trial.attempt.metricBearingAttemptsConsumed === 1,
+      )
+    }
   }
   return undefined
 }
@@ -813,6 +826,12 @@ const validateCurrentSuccessor = (
   if (!isRecord(successor) || successor._tag !== 'CURRENT_SUCCESSOR' || !isRecord(successor.attempt)) {
     return stateIssue('state.currentSuccessor', 'MALFORMED_HISTORY', successor)
   }
+  if (successor.kind !== 'DEVELOPMENT_ONLY' && successor.kind !== 'QUALIFICATION') {
+    return stateIssue('state.currentSuccessor.kind', 'ATTEMPT_KIND_MISMATCH', successor.kind, [
+      'DEVELOPMENT_ONLY',
+      'QUALIFICATION',
+    ])
+  }
   const preregistrationIssue = validateNextPreregistration(
     successor.preregistration,
     'state.currentSuccessor.preregistration',
@@ -826,7 +845,21 @@ const validateCurrentSuccessor = (
       state.nextOrdinal,
     )
   }
-  return validateAttempt(successor.attempt, 'state.currentSuccessor.attempt')
+  const attemptIssue = validateAttempt(successor.attempt, 'state.currentSuccessor.attempt')
+  if (attemptIssue !== undefined) return attemptIssue
+  if (
+    successor.attempt._tag !== 'UNATTEMPTED' &&
+    successor.attempt._tag !==
+      (successor.kind === 'QUALIFICATION' ? 'QUALIFICATION_ATTEMPT' : 'DEVELOPMENT_ONLY_ATTEMPT')
+  ) {
+    return stateIssue(
+      'state.currentSuccessor.attempt',
+      'ATTEMPT_KIND_MISMATCH',
+      successor.attempt,
+      successor.kind === 'QUALIFICATION' ? 'QUALIFICATION_ATTEMPT' : 'DEVELOPMENT_ONLY_ATTEMPT',
+    )
+  }
+  return undefined
 }
 
 const validateStateOrdinals = (

--- a/services/bayn/src/candidate-development-trials/validation.ts
+++ b/services/bayn/src/candidate-development-trials/validation.ts
@@ -2,6 +2,7 @@ import { Result } from 'effect'
 
 import type {
   CandidateDevelopmentAttemptConsumption,
+  CandidateDevelopmentNextPreregistration,
   CandidateDevelopmentTrialHistory,
   CandidateDevelopmentTrialState,
   CandidateDevelopmentTrialStateIssue,
@@ -284,6 +285,34 @@ export const validateAttempt = (value: unknown, path: string): CandidateDevelopm
   }
 }
 
+export const validateDevelopmentTerminalEvidence = (
+  value: unknown,
+  path: string,
+): CandidateDevelopmentTrialStateIssue | undefined => {
+  if (!isRecord(value)) return stateIssue(path, 'TERMINAL_STATE_MISMATCH', value)
+  if (
+    !isNonEmptyString(value.evidenceContentHash) ||
+    (value.evaluatedSourceRevision !== undefined && !isNonEmptyString(value.evaluatedSourceRevision)) ||
+    (value.failureStage !== undefined &&
+      value.failureStage !== 'buildEvaluation-preflight' &&
+      value.failureStage !== 'development-evaluation') ||
+    (value.developmentMetricsObserved !== undefined && typeof value.developmentMetricsObserved !== 'boolean')
+  ) {
+    return stateIssue(path, 'TERMINAL_STATE_MISMATCH', value)
+  }
+  return undefined
+}
+
+export const validateQualificationTerminalEvidence = (
+  value: unknown,
+  path: string,
+): CandidateDevelopmentTrialStateIssue | undefined => {
+  if (!isRecord(value) || value.terminalStatus !== 'HOLD_REJECT' || !isNonEmptyString(value.sourceRevision)) {
+    return stateIssue(path, 'TERMINAL_STATE_MISMATCH', value)
+  }
+  return undefined
+}
+
 const validateLegacyHistoryShape = (value: unknown): CandidateDevelopmentTrialStateIssue | undefined => {
   if (!isRecord(value)) return stateIssue('history', 'MALFORMED_HISTORY', value)
   if (value.schemaVersion !== 'bayn.candidate-development-trial-history.v2') {
@@ -473,9 +502,17 @@ const validatePriorTrialOrdinals = (
   if (!qualification.every(isPositiveInteger) || equalOrdinalSequence(qualification as number[], 1) !== null) {
     return stateIssue(`${path}.qualificationCandidateOrdinals`, 'ORDINAL_SEQUENCE_GAP', qualification, '1..n')
   }
-  const expectedDevelopment = development.map((_, index) => qualification.length + index + 1)
-  if (!development.every(isPositiveInteger) || !sameOrdinals(development as number[], expectedDevelopment)) {
-    return stateIssue(`${path}.developmentCandidateOrdinals`, 'ORDINAL_SEQUENCE_GAP', development, expectedDevelopment)
+  if (
+    !development.every(isPositiveInteger) ||
+    !isStrictlyIncreasing(development as number[]) ||
+    development.some((ordinal) => (qualification as number[]).includes(ordinal))
+  ) {
+    return stateIssue(
+      `${path}.developmentCandidateOrdinals`,
+      'ORDINAL_SEQUENCE_GAP',
+      development,
+      'strictly increasing',
+    )
   }
   return undefined
 }
@@ -561,9 +598,7 @@ const validateHistoryPriorMaterialRelations = (
   const legacy = history.latestReviewedCandidateLegacyPriorTrials
   if (
     !sameOrdinals(legacy.qualificationCandidateOrdinals, history.completedCandidateOrdinals) ||
-    legacy.developmentCandidateOrdinals.some(
-      (ordinal, index) => ordinal !== history.developmentCandidateOrdinals[index],
-    ) ||
+    !isOrdinalPrefix(legacy.developmentCandidateOrdinals, history.developmentCandidateOrdinals) ||
     legacy.developmentCandidateOrdinals.at(-1) !== legacy.latestDevelopmentEvidence.candidateOrdinal ||
     legacy.latestReviewedPreregistration.candidateOrdinal !== legacy.latestDevelopmentEvidence.candidateOrdinal
   ) {
@@ -606,6 +641,9 @@ const expectedDevelopmentOrdinals = (
 const sameOrdinals = (left: readonly number[], right: readonly number[]): boolean =>
   left.length === right.length && left.every((ordinal, index) => ordinal === right[index])
 
+const isOrdinalPrefix = (prefix: readonly number[], values: readonly number[]): boolean =>
+  prefix.length <= values.length && prefix.every((ordinal, index) => ordinal === values[index])
+
 const isStrictlyIncreasing = (ordinals: readonly number[]): boolean =>
   ordinals.every((ordinal, index) => index === 0 || ordinal > ordinals[index - 1]!)
 
@@ -620,6 +658,9 @@ const validateClosedOrdinals = (
     if (seen.has(ordinal)) return stateIssue('history.ordinals', 'ORDINAL_OVERLAP', allClosed)
     seen.add(ordinal)
   }
+  const sorted = allClosed.sort((left, right) => left - right)
+  const sequenceIssue = equalOrdinalSequence(sorted, 1)
+  if (sequenceIssue !== null) return stateIssue('history.ordinals', 'ORDINAL_SEQUENCE_GAP', sorted, '1..n')
   return undefined
 }
 
@@ -642,16 +683,18 @@ const validateHistoryInvalidationBinding = (
 ): CandidateDevelopmentTrialStateIssue | undefined => {
   const invalidation = history.latestInvalidPrecommit
   if (invalidation === null) return undefined
-  if (invalidation.candidateOrdinal <= latestDevelopment) {
+  if (history.developmentCandidateOrdinals.includes(invalidation.candidateOrdinal)) {
     return stateIssue(
       'history.latestInvalidPrecommit.candidateOrdinal',
       'ORDINAL_OVERLAP',
       invalidation.candidateOrdinal,
     )
   }
+  const latestClosedOrdinal = Math.max(latestDevelopment, invalidation.candidateOrdinal)
   const reviewed = history.latestReviewedCandidatePreregistration
   if (
     history.nextCandidatePreregistration === null &&
+    invalidation.candidateOrdinal === latestClosedOrdinal &&
     (reviewed.candidateOrdinal !== invalidation.candidateOrdinal ||
       reviewed.priorTrialCount !== invalidation.priorTrialCount ||
       reviewed.modulePath !== invalidation.invalidatedModule.path ||
@@ -673,8 +716,8 @@ const validateHistorySuccessorBinding = (
   const latestClosedOrdinal = Math.max(latestDevelopment, invalidOrdinal ?? latestDevelopment)
   if (history.nextCandidatePreregistration === null) {
     if (
-      invalidOrdinal === null &&
-      history.latestReviewedCandidatePreregistration.candidateOrdinal !== latestClosedOrdinal
+      history.latestReviewedCandidatePreregistration.candidateOrdinal !== latestClosedOrdinal ||
+      history.latestReviewedCandidatePreregistration.priorTrialCount !== latestClosedOrdinal - 1
     ) {
       return stateIssue('history.latestReviewedCandidatePreregistration', 'SUCCESSOR_BINDING_MISMATCH')
     }
@@ -691,8 +734,39 @@ const validateHistorySuccessorBinding = (
       { candidateOrdinal: latestClosedOrdinal + 1, priorTrialCount: latestClosedOrdinal },
     )
   }
+  if (!sameNextPreregistration(history.nextCandidatePreregistration, history.latestReviewedCandidatePreregistration)) {
+    return stateIssue(
+      'history.nextCandidatePreregistration',
+      'SUCCESSOR_BINDING_MISMATCH',
+      history.nextCandidatePreregistration,
+      history.latestReviewedCandidatePreregistration,
+    )
+  }
   return undefined
 }
+
+const sameNextPreregistration = (
+  left: CandidateDevelopmentNextPreregistration,
+  right: CandidateDevelopmentNextPreregistration,
+): boolean =>
+  left.schemaVersion === right.schemaVersion &&
+  left.candidateOrdinal === right.candidateOrdinal &&
+  left.priorTrialCount === right.priorTrialCount &&
+  left.strategyProtocolHash === right.strategyProtocolHash &&
+  left.strategyIdentityHash === right.strategyIdentityHash &&
+  left.candidateDevelopmentProtocolHash === right.candidateDevelopmentProtocolHash &&
+  left.calendarHash === right.calendarHash &&
+  left.priorTrialsHash === right.priorTrialsHash &&
+  left.modulePath === right.modulePath &&
+  left.moduleSha256 === right.moduleSha256 &&
+  left.marketData.schemaVersion === right.marketData.schemaVersion &&
+  left.marketData.snapshotId === right.marketData.snapshotId &&
+  left.marketData.finalizedSnapshotContentHash === right.marketData.finalizedSnapshotContentHash &&
+  left.marketData.inputManifestHash === right.marketData.inputManifestHash &&
+  left.marketData.boundedContentHash === right.marketData.boundedContentHash &&
+  left.preregistration.sourceRevision === right.preregistration.sourceRevision &&
+  left.preregistration.path === right.preregistration.path &&
+  left.preregistration.blobOid === right.preregistration.blobOid
 
 export const validateCandidateDevelopmentTrialHistory = (
   value: unknown,
@@ -710,7 +784,7 @@ export const expectedNextOrdinal = (state: CandidateDevelopmentTrialState): numb
     ...state.invalidatedPrecommits.map((trial) => trial.invalidation.candidateOrdinal),
   ]
   const highestClosed = closedOrdinals.length === 0 ? 0 : Math.max(...closedOrdinals)
-  return state.currentSuccessor === null ? highestClosed + 1 : state.currentSuccessor.preregistration.candidateOrdinal
+  return highestClosed + 1
 }
 
 const validateStateEnvelope = (
@@ -770,6 +844,12 @@ const validateDevelopmentOnlyTrials = (
       !isPositiveInteger(trial.candidateOrdinal) ||
       trial.priorTrialCount !== trial.candidateOrdinal - 1 ||
       trial.status !== 'DEVELOPMENT_REJECTED' ||
+      (trial.evidenceContentHash !== null && !isNonEmptyString(trial.evidenceContentHash)) ||
+      (trial.evaluatedSourceRevision !== null && !isNonEmptyString(trial.evaluatedSourceRevision)) ||
+      (trial.failureStage !== null &&
+        trial.failureStage !== 'buildEvaluation-preflight' &&
+        trial.failureStage !== 'development-evaluation') ||
+      (trial.developmentMetricsObserved !== null && typeof trial.developmentMetricsObserved !== 'boolean') ||
       !isRecord(trial.attempt) ||
       trial.attempt._tag !== 'DEVELOPMENT_ONLY_ATTEMPT' ||
       trial.attempt.qualificationAttemptConsumed !== false

--- a/services/bayn/src/candidate-development-trials/validation.ts
+++ b/services/bayn/src/candidate-development-trials/validation.ts
@@ -270,7 +270,9 @@ export const validateAttempt = (value: unknown, path: string): CandidateDevelopm
         : stateIssue(path, 'ATTEMPT_ALREADY_CONSUMED', value)
     case 'DEVELOPMENT_ONLY_ATTEMPT':
       return value.attemptCount === 1 &&
-        (value.metricBearingAttemptsConsumed === 0 || value.metricBearingAttemptsConsumed === 1) &&
+        (value.metricBearingAttemptsConsumed === null ||
+          value.metricBearingAttemptsConsumed === 0 ||
+          value.metricBearingAttemptsConsumed === 1) &&
         value.qualificationAttemptConsumed === false
         ? undefined
         : stateIssue(path, 'ATTEMPT_ALREADY_CONSUMED', value)
@@ -284,6 +286,11 @@ export const validateAttempt = (value: unknown, path: string): CandidateDevelopm
       return stateIssue(path, 'MALFORMED_HISTORY', value)
   }
 }
+
+const metricBearingObservation = (
+  attempt: Extract<CandidateDevelopmentAttemptConsumption, { readonly _tag: 'DEVELOPMENT_ONLY_ATTEMPT' }>,
+): boolean | null =>
+  attempt.metricBearingAttemptsConsumed === null ? null : attempt.metricBearingAttemptsConsumed === 1
 
 export const validateDevelopmentTerminalEvidence = (
   value: unknown,
@@ -858,15 +865,16 @@ const validateDevelopmentOnlyTrials = (
     }
     const attemptIssue = validateAttempt(trial.attempt, `state.developmentOnlyTrials[${index}].attempt`)
     if (attemptIssue !== undefined) return attemptIssue
+    const metricBearing = metricBearingObservation(trial.attempt)
     if (
       trial.developmentMetricsObserved !== null &&
-      trial.developmentMetricsObserved !== (trial.attempt.metricBearingAttemptsConsumed === 1)
+      (metricBearing === null || trial.developmentMetricsObserved !== metricBearing)
     ) {
       return stateIssue(
         `state.developmentOnlyTrials[${index}].developmentMetricsObserved`,
         'TERMINAL_STATE_MISMATCH',
         trial.developmentMetricsObserved,
-        trial.attempt.metricBearingAttemptsConsumed === 1,
+        metricBearing,
       )
     }
   }
@@ -927,6 +935,12 @@ const validateCurrentSuccessor = (
   }
   const attemptIssue = validateAttempt(successor.attempt, 'state.currentSuccessor.attempt')
   if (attemptIssue !== undefined) return attemptIssue
+  if (
+    successor.attempt._tag === 'DEVELOPMENT_ONLY_ATTEMPT' &&
+    successor.attempt.metricBearingAttemptsConsumed === null
+  ) {
+    return stateIssue('state.currentSuccessor.attempt.metricBearingAttemptsConsumed', 'TERMINAL_STATE_MISMATCH')
+  }
   if (
     successor.attempt._tag !== 'UNATTEMPTED' &&
     successor.attempt._tag !==

--- a/services/bayn/src/candidate-development-trials/validation.ts
+++ b/services/bayn/src/candidate-development-trials/validation.ts
@@ -1,0 +1,878 @@
+import { Result } from 'effect'
+
+import type {
+  CandidateDevelopmentAttemptConsumption,
+  CandidateDevelopmentTrialHistory,
+  CandidateDevelopmentTrialState,
+  CandidateDevelopmentTrialStateIssue,
+  CandidateDevelopmentTrialStateIssueReason,
+} from './model'
+
+export const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null
+
+const isNonEmptyString = (value: unknown): value is string => typeof value === 'string' && value.length > 0
+
+const isHex = (value: unknown, length: number): value is string =>
+  typeof value === 'string' && new RegExp(`^[0-9a-f]{${length}}$`).test(value)
+
+const isPositiveInteger = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isInteger(value) && value > 0
+
+const isNonNegativeInteger = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isInteger(value) && value >= 0
+
+export const stateIssue = (
+  path: string,
+  reason: CandidateDevelopmentTrialStateIssueReason,
+  observed?: unknown,
+  expected?: unknown,
+): CandidateDevelopmentTrialStateIssue => ({
+  _tag: 'CandidateDevelopmentTrialStateInvalid',
+  reason,
+  path,
+  ...(expected === undefined ? {} : { expected }),
+  ...(observed === undefined ? {} : { observed }),
+})
+
+const failure = (
+  path: string,
+  reason: CandidateDevelopmentTrialStateIssueReason,
+  observed?: unknown,
+  expected?: unknown,
+): Result.Result<never, CandidateDevelopmentTrialStateIssue> =>
+  Result.fail(stateIssue(path, reason, observed, expected))
+
+export const equalOrdinalSequence = (observed: readonly number[], start: number): number | null => {
+  for (let index = 0; index < observed.length; index += 1) {
+    if (observed[index] !== start + index) return start + index
+  }
+  return null
+}
+
+const validateOrdinalAndPriorCount = (
+  value: Record<string, unknown>,
+  path: string,
+): CandidateDevelopmentTrialStateIssue | undefined => {
+  if (!isPositiveInteger(value.candidateOrdinal)) return stateIssue(`${path}.candidateOrdinal`, 'ORDINAL_NOT_POSITIVE')
+  if (
+    typeof value.priorTrialCount !== 'number' ||
+    !Number.isInteger(value.priorTrialCount) ||
+    value.priorTrialCount !== value.candidateOrdinal - 1
+  ) {
+    return stateIssue(
+      `${path}.priorTrialCount`,
+      'PRIOR_TRIAL_COUNT_MISMATCH',
+      value.priorTrialCount,
+      value.candidateOrdinal - 1,
+    )
+  }
+  return undefined
+}
+
+export const validateNextPreregistration = (
+  value: unknown,
+  path: string,
+): CandidateDevelopmentTrialStateIssue | undefined => {
+  if (!isRecord(value)) return stateIssue(path, 'MALFORMED_HISTORY', value)
+  if (value.schemaVersion !== 'bayn.candidate-development-next-preregistration.v1') {
+    return stateIssue(
+      `${path}.schemaVersion`,
+      'SCHEMA_VERSION_MISMATCH',
+      value.schemaVersion,
+      'bayn.candidate-development-next-preregistration.v1',
+    )
+  }
+  const ordinalIssue = validateOrdinalAndPriorCount(value, path)
+  if (ordinalIssue !== undefined) return ordinalIssue
+  if (!isHex(value.strategyProtocolHash, 64) || !isNonEmptyString(value.modulePath) || !isHex(value.moduleSha256, 64)) {
+    return stateIssue(path, 'MALFORMED_HISTORY', value)
+  }
+  const optionalHashIssue = validateOptionalHashes(value, path)
+  if (optionalHashIssue !== undefined) return optionalHashIssue
+  if (!isRecord(value.marketData) || !isRecord(value.preregistration)) {
+    return stateIssue(path, 'MALFORMED_HISTORY', value)
+  }
+  const marketDataIssue = validateMarketData(value.marketData, `${path}.marketData`)
+  if (marketDataIssue !== undefined) return marketDataIssue
+  return validatePreregistrationSource(value.preregistration, `${path}.preregistration`)
+}
+
+const validateOptionalHashes = (
+  value: Record<string, unknown>,
+  path: string,
+): CandidateDevelopmentTrialStateIssue | undefined => {
+  for (const [field, observed] of [
+    ['strategyIdentityHash', value.strategyIdentityHash],
+    ['candidateDevelopmentProtocolHash', value.candidateDevelopmentProtocolHash],
+    ['calendarHash', value.calendarHash],
+    ['priorTrialsHash', value.priorTrialsHash],
+  ] as const) {
+    if (observed !== undefined && !isHex(observed, 64))
+      return stateIssue(`${path}.${field}`, 'MALFORMED_HISTORY', observed)
+  }
+  return undefined
+}
+
+const validateMarketData = (
+  value: Record<string, unknown>,
+  path: string,
+): CandidateDevelopmentTrialStateIssue | undefined => {
+  if (
+    value.schemaVersion !== 'bayn.candidate-development-market-data-source.v1' ||
+    !isHex(value.snapshotId, 64) ||
+    !isHex(value.finalizedSnapshotContentHash, 64) ||
+    !isHex(value.inputManifestHash, 64) ||
+    !isHex(value.boundedContentHash, 64)
+  ) {
+    return stateIssue(path, 'MALFORMED_HISTORY', value)
+  }
+  return undefined
+}
+
+const validatePreregistrationSource = (
+  value: Record<string, unknown>,
+  path: string,
+): CandidateDevelopmentTrialStateIssue | undefined => {
+  if (!isHex(value.sourceRevision, 40) || !isNonEmptyString(value.path) || !isHex(value.blobOid, 40)) {
+    return stateIssue(path, 'MALFORMED_HISTORY', value)
+  }
+  return undefined
+}
+
+export const validateInvalidation = (value: unknown, path: string): CandidateDevelopmentTrialStateIssue | undefined => {
+  if (!isRecord(value)) return stateIssue(path, 'MALFORMED_HISTORY', value)
+  if (value.schemaVersion !== 'bayn.candidate-development-precommit-invalidation.v1') {
+    return stateIssue(`${path}.schemaVersion`, 'SCHEMA_VERSION_MISMATCH', value.schemaVersion)
+  }
+  const immutableIssue = validateImmutableFlags(value, path)
+  if (immutableIssue !== undefined) return immutableIssue
+  const identityIssue = validateOrdinalAndPriorCount(value, path)
+  if (identityIssue !== undefined) return identityIssue
+  if (!isNonEmptyString(value.reviewedHeadRevision) || !isNonEmptyString(value.mergedSourceRevision)) {
+    return stateIssue(path, 'MALFORMED_HISTORY', value)
+  }
+  const nested = readInvalidationParts(value)
+  if (nested === undefined) return stateIssue(path, 'MALFORMED_HISTORY', value)
+  const sourceIssue = validateInvalidationSources(nested, path)
+  if (sourceIssue !== undefined) return sourceIssue
+  return validateInvalidationOutcomes(value, nested, path)
+}
+
+const validateImmutableFlags = (
+  value: Record<string, unknown>,
+  path: string,
+): CandidateDevelopmentTrialStateIssue | undefined => {
+  if (
+    value.status !== 'PRECOMMIT_INVALID' ||
+    value.attemptStatus !== 'UNATTEMPTED' ||
+    value.metricBearingAttemptsConsumed !== 0 ||
+    value.qualificationAttemptConsumed !== false ||
+    value.nextCandidatePreregistration !== null
+  ) {
+    return stateIssue(path, 'INVALIDATION_NOT_IMMUTABLE', value)
+  }
+  return undefined
+}
+
+type InvalidationParts = {
+  readonly preregistration: Record<string, unknown>
+  readonly sourceManifest: Record<string, unknown>
+  readonly invalidatedModule: Record<string, unknown>
+  readonly naturalBuild: Record<string, unknown>
+  readonly release: Record<string, unknown>
+}
+
+const readInvalidationParts = (value: Record<string, unknown>): InvalidationParts | undefined => {
+  const preregistration = isRecord(value.preregistration) ? value.preregistration : undefined
+  const sourceManifest = isRecord(value.sourceManifest) ? value.sourceManifest : undefined
+  const invalidatedModule = isRecord(value.invalidatedModule) ? value.invalidatedModule : undefined
+  const naturalBuild = isRecord(value.naturalBuild) ? value.naturalBuild : undefined
+  const release = isRecord(value.release) ? value.release : undefined
+  if (
+    preregistration === undefined ||
+    sourceManifest === undefined ||
+    invalidatedModule === undefined ||
+    naturalBuild === undefined ||
+    release === undefined
+  ) {
+    return undefined
+  }
+  return { preregistration, sourceManifest, invalidatedModule, naturalBuild, release }
+}
+
+const validateInvalidationSources = (
+  parts: InvalidationParts,
+  path: string,
+): CandidateDevelopmentTrialStateIssue | undefined => {
+  const { preregistration, sourceManifest, invalidatedModule } = parts
+  if (
+    !isHex(preregistration.sourceRevision, 40) ||
+    !isNonEmptyString(preregistration.path) ||
+    !isHex(preregistration.blobOid, 40) ||
+    !isHex(preregistration.sha256, 64) ||
+    !isNonEmptyString(sourceManifest.path) ||
+    !isHex(sourceManifest.blobOid, 40) ||
+    !isHex(sourceManifest.sha256, 64) ||
+    !isNonEmptyString(invalidatedModule.path) ||
+    !isHex(invalidatedModule.blobOid, 40) ||
+    !isHex(invalidatedModule.sha256, 64)
+  ) {
+    return stateIssue(path, 'MALFORMED_HISTORY', parts)
+  }
+  return undefined
+}
+
+const validateInvalidationOutcomes = (
+  value: Record<string, unknown>,
+  parts: InvalidationParts,
+  path: string,
+): CandidateDevelopmentTrialStateIssue | undefined => {
+  const { invalidatedModule, naturalBuild, release } = parts
+  if (
+    naturalBuild.imagePublished !== true ||
+    naturalBuild.deploymentAllowed !== false ||
+    !isNonEmptyString(naturalBuild.runId) ||
+    !isHex(
+      typeof naturalBuild.imageDigest === 'string' ? naturalBuild.imageDigest.slice('sha256:'.length) : undefined,
+      64,
+    ) ||
+    !isNonNegativeInteger(invalidatedModule.lineCount) ||
+    !isNonNegativeInteger(invalidatedModule.byteCount) ||
+    !hasInvalidationFindings(invalidatedModule.findings) ||
+    release.conclusion !== 'CANCELLED' ||
+    release.promotionCompleted !== false ||
+    release.rerunAllowed !== false ||
+    !isNonEmptyString(release.runId)
+  ) {
+    return stateIssue(path, 'INVALIDATION_NOT_IMMUTABLE', value)
+  }
+  return undefined
+}
+
+const hasInvalidationFindings = (value: unknown): boolean =>
+  Array.isArray(value) &&
+  value.length === 5 &&
+  value[0] === 'TYPE_CHECK_DISABLED' &&
+  value[1] === 'DOWNCOMPILED_BUNDLE' &&
+  value[2] === 'EMBEDDED_OFFICIAL_SESSIONS' &&
+  value[3] === 'EMBEDDED_MARKET_BARS' &&
+  value[4] === 'RUNTIME_INPUT_IGNORED'
+
+export const validateAttempt = (value: unknown, path: string): CandidateDevelopmentTrialStateIssue | undefined => {
+  if (!isRecord(value)) return stateIssue(path, 'MALFORMED_HISTORY', value)
+  switch (value._tag) {
+    case 'UNATTEMPTED':
+      return value.attemptCount === 0 &&
+        value.metricBearingAttemptsConsumed === 0 &&
+        value.qualificationAttemptConsumed === false
+        ? undefined
+        : stateIssue(path, 'ATTEMPT_ALREADY_CONSUMED', value)
+    case 'DEVELOPMENT_ONLY_ATTEMPT':
+      return value.attemptCount === 1 &&
+        (value.metricBearingAttemptsConsumed === 0 || value.metricBearingAttemptsConsumed === 1) &&
+        value.qualificationAttemptConsumed === false
+        ? undefined
+        : stateIssue(path, 'ATTEMPT_ALREADY_CONSUMED', value)
+    case 'QUALIFICATION_ATTEMPT':
+      return value.attemptCount === 1 &&
+        value.metricBearingAttemptsConsumed === 1 &&
+        value.qualificationAttemptConsumed === true
+        ? undefined
+        : stateIssue(path, 'ATTEMPT_ALREADY_CONSUMED', value)
+    default:
+      return stateIssue(path, 'MALFORMED_HISTORY', value)
+  }
+}
+
+const validateLegacyHistoryShape = (value: unknown): CandidateDevelopmentTrialStateIssue | undefined => {
+  if (!isRecord(value)) return stateIssue('history', 'MALFORMED_HISTORY', value)
+  if (value.schemaVersion !== 'bayn.candidate-development-trial-history.v2') {
+    return stateIssue('history.schemaVersion', 'SCHEMA_VERSION_MISMATCH', value.schemaVersion)
+  }
+  if (!Array.isArray(value.completedCandidateOrdinals) || !Array.isArray(value.developmentCandidateOrdinals)) {
+    return stateIssue('history.ordinals', 'MALFORMED_HISTORY', value)
+  }
+  if (
+    !isRecord(value.latestTerminalEvidence) ||
+    !isRecord(value.candidatePreregistration) ||
+    !isRecord(value.latestDevelopmentEvidence) ||
+    !isRecord(value.latestReviewedCandidatePriorTrials) ||
+    !isRecord(value.latestReviewedCandidateLegacyPriorTrials)
+  ) {
+    return stateIssue('history.evidence', 'MALFORMED_HISTORY', value)
+  }
+  const terminalEvidenceIssue = validateQualificationEvidence(
+    value.latestTerminalEvidence,
+    'history.latestTerminalEvidence',
+  )
+  if (terminalEvidenceIssue !== undefined) return terminalEvidenceIssue
+  const candidatePreregistrationIssue = validateQualificationPreregistration(
+    value.candidatePreregistration,
+    'history.candidatePreregistration',
+  )
+  if (candidatePreregistrationIssue !== undefined) return candidatePreregistrationIssue
+  const developmentEvidenceIssue = validateDevelopmentEvidence(
+    value.latestDevelopmentEvidence,
+    'history.latestDevelopmentEvidence',
+  )
+  if (developmentEvidenceIssue !== undefined) return developmentEvidenceIssue
+  const legacyMaterialIssue = validateLegacyPriorTrialsMaterial(
+    value.latestReviewedCandidateLegacyPriorTrials,
+    'history.latestReviewedCandidateLegacyPriorTrials',
+  )
+  if (legacyMaterialIssue !== undefined) return legacyMaterialIssue
+  const priorMaterialIssue = validatePriorTrialsMaterial(
+    value.latestReviewedCandidatePriorTrials,
+    'history.latestReviewedCandidatePriorTrials',
+  )
+  if (priorMaterialIssue !== undefined) return priorMaterialIssue
+  const reviewedIssue = validateNextPreregistration(
+    value.latestReviewedCandidatePreregistration,
+    'history.latestReviewedCandidatePreregistration',
+  )
+  if (reviewedIssue !== undefined) return reviewedIssue
+  const nextIssue =
+    value.nextCandidatePreregistration === null
+      ? undefined
+      : validateNextPreregistration(value.nextCandidatePreregistration, 'history.nextCandidatePreregistration')
+  if (nextIssue !== undefined) return nextIssue
+  return value.latestInvalidPrecommit === null
+    ? undefined
+    : validateInvalidation(value.latestInvalidPrecommit, 'history.latestInvalidPrecommit')
+}
+
+const validateQualificationEvidence = (
+  value: Record<string, unknown>,
+  path: string,
+): CandidateDevelopmentTrialStateIssue | undefined => {
+  if (
+    !isPositiveInteger(value.candidateOrdinal) ||
+    value.priorTrialCount !== value.candidateOrdinal - 1 ||
+    value.terminalStatus !== 'HOLD_REJECT' ||
+    !isNonEmptyString(value.sourceRevision)
+  ) {
+    return stateIssue(path, 'LATEST_EVIDENCE_MISMATCH', value)
+  }
+  return undefined
+}
+
+const validateQualificationPreregistration = (
+  value: Record<string, unknown>,
+  path: string,
+): CandidateDevelopmentTrialStateIssue | undefined => {
+  if (
+    !isPositiveInteger(value.candidateOrdinal) ||
+    value.priorTrialCount !== value.candidateOrdinal - 1 ||
+    !isNonEmptyString(value.sourceRevision) ||
+    !isNonEmptyString(value.path) ||
+    !isNonEmptyString(value.blobOid)
+  ) {
+    return stateIssue(path, 'MALFORMED_HISTORY', value)
+  }
+  return undefined
+}
+
+const validateDevelopmentEvidence = (
+  value: Record<string, unknown>,
+  path: string,
+): CandidateDevelopmentTrialStateIssue | undefined => {
+  if (
+    !isPositiveInteger(value.candidateOrdinal) ||
+    value.priorTrialCount !== value.candidateOrdinal - 1 ||
+    value.status !== 'DEVELOPMENT_REJECTED' ||
+    !isNonEmptyString(value.evidenceContentHash) ||
+    !isNonEmptyString(value.evaluatedSourceRevision) ||
+    (value.reviewedSourceRevision !== undefined && !isNonEmptyString(value.reviewedSourceRevision)) ||
+    (value.mergedSourceRevision !== undefined && !isNonEmptyString(value.mergedSourceRevision)) ||
+    (value.failureStage !== undefined &&
+      value.failureStage !== 'buildEvaluation-preflight' &&
+      value.failureStage !== 'development-evaluation') ||
+    (value.developmentMetricsObserved !== undefined && typeof value.developmentMetricsObserved !== 'boolean') ||
+    value.qualificationAttemptConsumed !== false
+  ) {
+    return stateIssue(path, 'LATEST_EVIDENCE_MISMATCH', value)
+  }
+  return undefined
+}
+
+const validateLegacyPriorTrialsMaterial = (
+  value: Record<string, unknown>,
+  path: string,
+): CandidateDevelopmentTrialStateIssue | undefined => {
+  if (value.schemaVersion !== 'bayn.candidate-development-prior-trials.v1') {
+    return stateIssue(`${path}.schemaVersion`, 'SCHEMA_VERSION_MISMATCH', value.schemaVersion)
+  }
+  const ordinalsIssue = validatePriorTrialOrdinals(value, path)
+  if (ordinalsIssue !== undefined) return ordinalsIssue
+  const latestEvidence = isRecord(value.latestDevelopmentEvidence) ? value.latestDevelopmentEvidence : undefined
+  const latestPreregistration = isRecord(value.latestReviewedPreregistration)
+    ? value.latestReviewedPreregistration
+    : undefined
+  if (latestEvidence === undefined || latestPreregistration === undefined) {
+    return stateIssue(path, 'MALFORMED_HISTORY', value)
+  }
+  return validatePriorDevelopmentMaterialRelations(latestEvidence, latestPreregistration, path)
+}
+
+const validatePriorTrialsMaterial = (
+  value: Record<string, unknown>,
+  path: string,
+): CandidateDevelopmentTrialStateIssue | undefined => {
+  if (value.schemaVersion !== 'bayn.candidate-development-prior-trials.v2') {
+    return stateIssue(`${path}.schemaVersion`, 'SCHEMA_VERSION_MISMATCH', value.schemaVersion)
+  }
+  const ordinalsIssue = validatePriorTrialOrdinals(value, path)
+  if (ordinalsIssue !== undefined) return ordinalsIssue
+  const qualificationEvidence = isRecord(value.latestQualificationEvidence)
+    ? value.latestQualificationEvidence
+    : undefined
+  const qualificationPreregistration = isRecord(value.latestQualificationPreregistration)
+    ? value.latestQualificationPreregistration
+    : undefined
+  const latestEvidence = isRecord(value.latestDevelopmentEvidence) ? value.latestDevelopmentEvidence : undefined
+  const latestPreregistration = isRecord(value.latestReviewedPreregistration)
+    ? value.latestReviewedPreregistration
+    : undefined
+  if (
+    qualificationEvidence === undefined ||
+    qualificationPreregistration === undefined ||
+    latestEvidence === undefined ||
+    latestPreregistration === undefined
+  ) {
+    return stateIssue(path, 'MALFORMED_HISTORY', value)
+  }
+  if (
+    !isPositiveInteger(qualificationEvidence.candidateOrdinal) ||
+    qualificationEvidence.priorTrialCount !== qualificationEvidence.candidateOrdinal - 1 ||
+    !isNonEmptyString(qualificationEvidence.sourceRevision) ||
+    !isPositiveInteger(qualificationPreregistration.candidateOrdinal) ||
+    qualificationPreregistration.priorTrialCount !== qualificationPreregistration.candidateOrdinal - 1 ||
+    !isNonEmptyString(qualificationPreregistration.sourceRevision) ||
+    !isNonEmptyString(qualificationPreregistration.path) ||
+    !isNonEmptyString(qualificationPreregistration.blobOid) ||
+    qualificationEvidence.candidateOrdinal !== qualificationPreregistration.candidateOrdinal ||
+    qualificationEvidence.priorTrialCount !== qualificationPreregistration.priorTrialCount ||
+    qualificationEvidence.terminalStatus !== 'HOLD_REJECT'
+  ) {
+    return stateIssue(`${path}.latestQualificationEvidence`, 'LATEST_EVIDENCE_MISMATCH', qualificationEvidence)
+  }
+  const developmentIssue = validatePriorDevelopmentMaterialRelations(latestEvidence, latestPreregistration, path)
+  if (developmentIssue !== undefined) return developmentIssue
+  return undefined
+}
+
+const validatePriorTrialOrdinals = (
+  value: Record<string, unknown>,
+  path: string,
+): CandidateDevelopmentTrialStateIssue | undefined => {
+  const qualification = value.qualificationCandidateOrdinals
+  const development = value.developmentCandidateOrdinals
+  if (!Array.isArray(qualification) || !Array.isArray(development)) {
+    return stateIssue(`${path}.ordinals`, 'MALFORMED_HISTORY', value)
+  }
+  if (!qualification.every(isPositiveInteger) || equalOrdinalSequence(qualification as number[], 1) !== null) {
+    return stateIssue(`${path}.qualificationCandidateOrdinals`, 'ORDINAL_SEQUENCE_GAP', qualification, '1..n')
+  }
+  const expectedDevelopment = development.map((_, index) => qualification.length + index + 1)
+  if (!development.every(isPositiveInteger) || !sameOrdinals(development as number[], expectedDevelopment)) {
+    return stateIssue(`${path}.developmentCandidateOrdinals`, 'ORDINAL_SEQUENCE_GAP', development, expectedDevelopment)
+  }
+  return undefined
+}
+
+const validatePriorDevelopmentMaterialRelations = (
+  evidence: Record<string, unknown>,
+  preregistration: Record<string, unknown>,
+  path: string,
+): CandidateDevelopmentTrialStateIssue | undefined => {
+  const evidenceOrdinal = evidence.candidateOrdinal
+  if (
+    !isPositiveInteger(evidenceOrdinal) ||
+    evidence.priorTrialCount !== evidenceOrdinal - 1 ||
+    evidence.status !== 'DEVELOPMENT_REJECTED' ||
+    !isNonEmptyString(evidence.evidenceContentHash) ||
+    evidence.qualificationAttemptConsumed !== false
+  ) {
+    return stateIssue(`${path}.latestDevelopmentEvidence`, 'LATEST_EVIDENCE_MISMATCH', evidence)
+  }
+  const preregistrationIssue = validateNextPreregistration(preregistration, `${path}.latestReviewedPreregistration`)
+  if (preregistrationIssue !== undefined) return preregistrationIssue
+  if (preregistration.candidateOrdinal !== evidenceOrdinal || preregistration.priorTrialCount !== evidenceOrdinal - 1) {
+    return stateIssue(`${path}.latestReviewedPreregistration`, 'LATEST_EVIDENCE_MISMATCH', preregistration, {
+      candidateOrdinal: evidenceOrdinal,
+      priorTrialCount: evidenceOrdinal - 1,
+    })
+  }
+  return undefined
+}
+
+const validateLegacyHistoryRelations = (
+  history: CandidateDevelopmentTrialHistory,
+): CandidateDevelopmentTrialStateIssue | undefined => {
+  const completedIssue = equalOrdinalSequence(history.completedCandidateOrdinals, 1)
+  if (completedIssue !== null) {
+    return stateIssue(
+      'history.completedCandidateOrdinals',
+      'ORDINAL_SEQUENCE_GAP',
+      history.completedCandidateOrdinals,
+      '1..n',
+    )
+  }
+  const completedCount = history.completedCandidateOrdinals.length
+  const invalidOrdinal = history.latestInvalidPrecommit?.candidateOrdinal ?? null
+  const expectedDevelopment = expectedDevelopmentOrdinals(
+    history.developmentCandidateOrdinals.length,
+    completedCount,
+    invalidOrdinal,
+  )
+  if (!sameOrdinals(history.developmentCandidateOrdinals, expectedDevelopment)) {
+    return stateIssue(
+      'history.developmentCandidateOrdinals',
+      'ORDINAL_SEQUENCE_GAP',
+      history.developmentCandidateOrdinals,
+      expectedDevelopment,
+    )
+  }
+  const ordinalIssue = validateClosedOrdinals(history, invalidOrdinal)
+  if (ordinalIssue !== undefined) return ordinalIssue
+  const latestCompleted = history.completedCandidateOrdinals.at(-1)
+  if (!latestCompleted || !matchesLatestQualification(history, latestCompleted)) {
+    return stateIssue('history.latestTerminalEvidence', 'LATEST_EVIDENCE_MISMATCH', history.latestTerminalEvidence)
+  }
+  const latestDevelopment = history.developmentCandidateOrdinals.at(-1)
+  if (!latestDevelopment || !matchesLatestDevelopment(history, latestDevelopment)) {
+    return stateIssue(
+      'history.latestDevelopmentEvidence',
+      'LATEST_EVIDENCE_MISMATCH',
+      history.latestDevelopmentEvidence,
+    )
+  }
+  const materialIssue = validateHistoryPriorMaterialRelations(history, latestDevelopment)
+  if (materialIssue !== undefined) return materialIssue
+  const invalidationIssue = validateHistoryInvalidationBinding(history, latestDevelopment)
+  if (invalidationIssue !== undefined) return invalidationIssue
+  return validateHistorySuccessorBinding(history, latestDevelopment, invalidOrdinal)
+}
+
+const validateHistoryPriorMaterialRelations = (
+  history: CandidateDevelopmentTrialHistory,
+  latestDevelopment: number,
+): CandidateDevelopmentTrialStateIssue | undefined => {
+  const legacy = history.latestReviewedCandidateLegacyPriorTrials
+  if (
+    !sameOrdinals(legacy.qualificationCandidateOrdinals, history.completedCandidateOrdinals) ||
+    legacy.developmentCandidateOrdinals.some(
+      (ordinal, index) => ordinal !== history.developmentCandidateOrdinals[index],
+    ) ||
+    legacy.developmentCandidateOrdinals.at(-1) !== legacy.latestDevelopmentEvidence.candidateOrdinal ||
+    legacy.latestReviewedPreregistration.candidateOrdinal !== legacy.latestDevelopmentEvidence.candidateOrdinal
+  ) {
+    return stateIssue('history.latestReviewedCandidateLegacyPriorTrials', 'LATEST_EVIDENCE_MISMATCH', legacy)
+  }
+  const prior = history.latestReviewedCandidatePriorTrials
+  if (
+    !sameOrdinals(prior.qualificationCandidateOrdinals, history.completedCandidateOrdinals) ||
+    !sameOrdinals(prior.developmentCandidateOrdinals, history.developmentCandidateOrdinals) ||
+    prior.latestQualificationEvidence.candidateOrdinal !== history.latestTerminalEvidence.candidateOrdinal ||
+    prior.latestQualificationEvidence.sourceRevision !== history.latestTerminalEvidence.sourceRevision ||
+    prior.latestQualificationPreregistration.candidateOrdinal !== history.candidatePreregistration.candidateOrdinal ||
+    prior.latestQualificationPreregistration.sourceRevision !== history.candidatePreregistration.sourceRevision ||
+    prior.latestQualificationPreregistration.path !== history.candidatePreregistration.path ||
+    prior.latestQualificationPreregistration.blobOid !== history.candidatePreregistration.blobOid ||
+    prior.latestDevelopmentEvidence.candidateOrdinal !== latestDevelopment ||
+    prior.latestDevelopmentEvidence.evidenceContentHash !== history.latestDevelopmentEvidence.evidenceContentHash ||
+    prior.latestReviewedPreregistration.candidateOrdinal !== latestDevelopment
+  ) {
+    return stateIssue('history.latestReviewedCandidatePriorTrials', 'LATEST_EVIDENCE_MISMATCH', prior)
+  }
+  return undefined
+}
+
+const expectedDevelopmentOrdinals = (
+  count: number,
+  completedCount: number,
+  invalidOrdinal: number | null,
+): number[] => {
+  const expected: number[] = []
+  let nextOrdinal = completedCount + 1
+  for (let index = 0; index < count; index += 1) {
+    if (nextOrdinal === invalidOrdinal) nextOrdinal += 1
+    expected.push(nextOrdinal)
+    nextOrdinal += 1
+  }
+  return expected
+}
+
+const sameOrdinals = (left: readonly number[], right: readonly number[]): boolean =>
+  left.length === right.length && left.every((ordinal, index) => ordinal === right[index])
+
+const validateClosedOrdinals = (
+  history: CandidateDevelopmentTrialHistory,
+  invalidOrdinal: number | null,
+): CandidateDevelopmentTrialStateIssue | undefined => {
+  const allClosed = [...history.completedCandidateOrdinals, ...history.developmentCandidateOrdinals]
+  if (invalidOrdinal !== null) allClosed.push(invalidOrdinal)
+  const seen = new Set<number>()
+  for (const ordinal of allClosed) {
+    if (seen.has(ordinal)) return stateIssue('history.ordinals', 'ORDINAL_OVERLAP', allClosed)
+    seen.add(ordinal)
+  }
+  return undefined
+}
+
+const matchesLatestQualification = (history: CandidateDevelopmentTrialHistory, ordinal: number): boolean =>
+  history.latestTerminalEvidence.candidateOrdinal === ordinal &&
+  history.latestTerminalEvidence.priorTrialCount === ordinal - 1 &&
+  history.latestTerminalEvidence.terminalStatus === 'HOLD_REJECT' &&
+  history.candidatePreregistration.candidateOrdinal === ordinal &&
+  history.candidatePreregistration.priorTrialCount === ordinal - 1
+
+const matchesLatestDevelopment = (history: CandidateDevelopmentTrialHistory, ordinal: number): boolean =>
+  history.latestDevelopmentEvidence.candidateOrdinal === ordinal &&
+  history.latestDevelopmentEvidence.priorTrialCount === ordinal - 1 &&
+  history.latestDevelopmentEvidence.status === 'DEVELOPMENT_REJECTED' &&
+  history.latestDevelopmentEvidence.qualificationAttemptConsumed === false
+
+const validateHistoryInvalidationBinding = (
+  history: CandidateDevelopmentTrialHistory,
+  latestDevelopment: number,
+): CandidateDevelopmentTrialStateIssue | undefined => {
+  const invalidation = history.latestInvalidPrecommit
+  if (invalidation === null) return undefined
+  if (invalidation.candidateOrdinal <= latestDevelopment) {
+    return stateIssue(
+      'history.latestInvalidPrecommit.candidateOrdinal',
+      'ORDINAL_OVERLAP',
+      invalidation.candidateOrdinal,
+    )
+  }
+  const reviewed = history.latestReviewedCandidatePreregistration
+  if (
+    history.nextCandidatePreregistration === null &&
+    (reviewed.candidateOrdinal !== invalidation.candidateOrdinal ||
+      reviewed.priorTrialCount !== invalidation.priorTrialCount ||
+      reviewed.modulePath !== invalidation.invalidatedModule.path ||
+      reviewed.moduleSha256 !== invalidation.invalidatedModule.sha256 ||
+      reviewed.preregistration.sourceRevision !== invalidation.preregistration.sourceRevision ||
+      reviewed.preregistration.path !== invalidation.preregistration.path ||
+      reviewed.preregistration.blobOid !== invalidation.preregistration.blobOid)
+  ) {
+    return stateIssue('history.latestReviewedCandidatePreregistration', 'INVALIDATION_BINDING_MISMATCH', reviewed)
+  }
+  return undefined
+}
+
+const validateHistorySuccessorBinding = (
+  history: CandidateDevelopmentTrialHistory,
+  latestDevelopment: number,
+  invalidOrdinal: number | null,
+): CandidateDevelopmentTrialStateIssue | undefined => {
+  const latestClosedOrdinal = Math.max(latestDevelopment, invalidOrdinal ?? latestDevelopment)
+  if (history.nextCandidatePreregistration === null) {
+    if (
+      invalidOrdinal === null &&
+      history.latestReviewedCandidatePreregistration.candidateOrdinal !== latestClosedOrdinal
+    ) {
+      return stateIssue('history.latestReviewedCandidatePreregistration', 'SUCCESSOR_BINDING_MISMATCH')
+    }
+    return undefined
+  }
+  if (
+    history.nextCandidatePreregistration.candidateOrdinal !== latestClosedOrdinal + 1 ||
+    history.nextCandidatePreregistration.priorTrialCount !== latestClosedOrdinal
+  ) {
+    return stateIssue(
+      'history.nextCandidatePreregistration',
+      'NEXT_ORDINAL_MISMATCH',
+      history.nextCandidatePreregistration,
+      { candidateOrdinal: latestClosedOrdinal + 1, priorTrialCount: latestClosedOrdinal },
+    )
+  }
+  return undefined
+}
+
+export const validateCandidateDevelopmentTrialHistory = (
+  value: unknown,
+): Result.Result<void, CandidateDevelopmentTrialStateIssue> => {
+  const shapeIssue = validateLegacyHistoryShape(value)
+  if (shapeIssue !== undefined) return Result.fail(shapeIssue)
+  const relationIssue = validateLegacyHistoryRelations(value as CandidateDevelopmentTrialHistory)
+  return relationIssue === undefined ? Result.succeed(undefined) : Result.fail(relationIssue)
+}
+
+export const expectedNextOrdinal = (state: CandidateDevelopmentTrialState): number => {
+  const closedOrdinals = [
+    ...state.historicalQualificationTrials.map((trial) => trial.candidateOrdinal),
+    ...state.developmentOnlyTrials.map((trial) => trial.candidateOrdinal),
+    ...state.invalidatedPrecommits.map((trial) => trial.invalidation.candidateOrdinal),
+  ]
+  const highestClosed = closedOrdinals.length === 0 ? 0 : Math.max(...closedOrdinals)
+  return state.currentSuccessor === null ? highestClosed + 1 : state.currentSuccessor.preregistration.candidateOrdinal
+}
+
+const validateStateEnvelope = (
+  value: unknown,
+): Result.Result<CandidateDevelopmentTrialState, CandidateDevelopmentTrialStateIssue> => {
+  if (!isRecord(value)) return failure('state', 'MALFORMED_HISTORY', value)
+  if (value.schemaVersion !== 'bayn.candidate-development-trial-state.v1') {
+    return failure('state.schemaVersion', 'SCHEMA_VERSION_MISMATCH', value.schemaVersion)
+  }
+  if (
+    !Array.isArray(value.historicalQualificationTrials) ||
+    !Array.isArray(value.developmentOnlyTrials) ||
+    !Array.isArray(value.invalidatedPrecommits) ||
+    (value.currentSuccessor !== null && !isRecord(value.currentSuccessor)) ||
+    !isPositiveInteger(value.nextOrdinal)
+  ) {
+    return failure('state', 'MALFORMED_HISTORY', value)
+  }
+  return Result.succeed(value as unknown as CandidateDevelopmentTrialState)
+}
+
+const validateHistoricalQualificationTrials = (
+  state: CandidateDevelopmentTrialState,
+): CandidateDevelopmentTrialStateIssue | undefined => {
+  for (const [index, trial] of state.historicalQualificationTrials.entries()) {
+    if (!isRecord(trial)) return stateIssue(`state.historicalQualificationTrials[${index}]`, 'MALFORMED_HISTORY', trial)
+  }
+  const sequenceIssue = equalOrdinalSequence(
+    state.historicalQualificationTrials.map((trial) => trial.candidateOrdinal),
+    1,
+  )
+  if (sequenceIssue !== null) return stateIssue('state.historicalQualificationTrials', 'ORDINAL_SEQUENCE_GAP')
+  for (const [index, trial] of state.historicalQualificationTrials.entries()) {
+    if (
+      trial._tag !== 'HISTORICAL_QUALIFICATION' ||
+      !isPositiveInteger(trial.candidateOrdinal) ||
+      trial.priorTrialCount !== trial.candidateOrdinal - 1 ||
+      trial.terminalStatus !== 'HOLD_REJECT' ||
+      !isRecord(trial.attempt) ||
+      trial.attempt._tag !== 'QUALIFICATION_ATTEMPT'
+    ) {
+      return stateIssue(`state.historicalQualificationTrials[${index}]`, 'TERMINAL_STATE_MISMATCH', trial)
+    }
+    const attemptIssue = validateAttempt(trial.attempt, `state.historicalQualificationTrials[${index}].attempt`)
+    if (attemptIssue !== undefined) return attemptIssue
+  }
+  return undefined
+}
+
+const validateDevelopmentOnlyTrials = (
+  state: CandidateDevelopmentTrialState,
+): CandidateDevelopmentTrialStateIssue | undefined => {
+  for (const [index, trial] of state.developmentOnlyTrials.entries()) {
+    if (!isRecord(trial)) return stateIssue(`state.developmentOnlyTrials[${index}]`, 'MALFORMED_HISTORY', trial)
+    if (
+      trial._tag !== 'DEVELOPMENT_ONLY' ||
+      !isPositiveInteger(trial.candidateOrdinal) ||
+      trial.priorTrialCount !== trial.candidateOrdinal - 1 ||
+      trial.status !== 'DEVELOPMENT_REJECTED' ||
+      !isRecord(trial.attempt) ||
+      trial.attempt._tag !== 'DEVELOPMENT_ONLY_ATTEMPT' ||
+      trial.attempt.qualificationAttemptConsumed !== false
+    ) {
+      return stateIssue(`state.developmentOnlyTrials[${index}]`, 'TERMINAL_STATE_MISMATCH', trial)
+    }
+    const attemptIssue = validateAttempt(trial.attempt, `state.developmentOnlyTrials[${index}].attempt`)
+    if (attemptIssue !== undefined) return attemptIssue
+  }
+  return undefined
+}
+
+const validateInvalidatedPrecommits = (
+  state: CandidateDevelopmentTrialState,
+): CandidateDevelopmentTrialStateIssue | undefined => {
+  for (const [index, invalidated] of state.invalidatedPrecommits.entries()) {
+    if (!isRecord(invalidated) || invalidated._tag !== 'IMMUTABLE_INVALIDATION' || !isRecord(invalidated.attempt)) {
+      return stateIssue(`state.invalidatedPrecommits[${index}]`, 'INVALIDATION_NOT_IMMUTABLE', invalidated)
+    }
+    const invalidationIssue = validateInvalidation(
+      invalidated.invalidation,
+      `state.invalidatedPrecommits[${index}].invalidation`,
+    )
+    if (invalidationIssue !== undefined) return invalidationIssue
+    if (invalidated.attempt._tag !== 'UNATTEMPTED') {
+      return stateIssue(
+        `state.invalidatedPrecommits[${index}].attempt`,
+        'INVALIDATION_NOT_IMMUTABLE',
+        invalidated.attempt,
+      )
+    }
+    const attemptIssue = validateAttempt(invalidated.attempt, `state.invalidatedPrecommits[${index}].attempt`)
+    if (attemptIssue !== undefined) return attemptIssue
+  }
+  return undefined
+}
+
+const validateCurrentSuccessor = (
+  state: CandidateDevelopmentTrialState,
+): CandidateDevelopmentTrialStateIssue | undefined => {
+  const successor = state.currentSuccessor
+  if (successor === null) return undefined
+  if (!isRecord(successor) || successor._tag !== 'CURRENT_SUCCESSOR' || !isRecord(successor.attempt)) {
+    return stateIssue('state.currentSuccessor', 'MALFORMED_HISTORY', successor)
+  }
+  const preregistrationIssue = validateNextPreregistration(
+    successor.preregistration,
+    'state.currentSuccessor.preregistration',
+  )
+  if (preregistrationIssue !== undefined) return preregistrationIssue
+  if (successor.preregistration.candidateOrdinal !== state.nextOrdinal) {
+    return stateIssue(
+      'state.currentSuccessor.preregistration.candidateOrdinal',
+      'NEXT_ORDINAL_MISMATCH',
+      successor.preregistration.candidateOrdinal,
+      state.nextOrdinal,
+    )
+  }
+  return validateAttempt(successor.attempt, 'state.currentSuccessor.attempt')
+}
+
+const validateStateOrdinals = (
+  state: CandidateDevelopmentTrialState,
+): CandidateDevelopmentTrialStateIssue | undefined => {
+  if (state.nextOrdinal !== expectedNextOrdinal(state)) {
+    return stateIssue('state.nextOrdinal', 'NEXT_ORDINAL_MISMATCH', state.nextOrdinal, expectedNextOrdinal(state))
+  }
+  const allOrdinals = [
+    ...state.historicalQualificationTrials.map((trial) => trial.candidateOrdinal),
+    ...state.developmentOnlyTrials.map((trial) => trial.candidateOrdinal),
+    ...state.invalidatedPrecommits.map((trial) => trial.invalidation.candidateOrdinal),
+  ].sort((left, right) => left - right)
+  for (let index = 0; index < allOrdinals.length; index += 1) {
+    if (allOrdinals[index] !== index + 1) return stateIssue('state.trials', 'ORDINAL_SEQUENCE_GAP', allOrdinals, '1..n')
+  }
+  if (
+    state.currentSuccessor !== null &&
+    allOrdinals.includes(state.currentSuccessor.preregistration.candidateOrdinal)
+  ) {
+    return stateIssue(
+      'state.currentSuccessor',
+      'ORDINAL_OVERLAP',
+      state.currentSuccessor.preregistration.candidateOrdinal,
+    )
+  }
+  return undefined
+}
+
+export const validateCandidateDevelopmentTrialState = (
+  value: unknown,
+): Result.Result<void, CandidateDevelopmentTrialStateIssue> => {
+  const envelope = validateStateEnvelope(value)
+  if (Result.isFailure(envelope)) return Result.fail(envelope.failure)
+  const checks = [
+    validateHistoricalQualificationTrials,
+    validateDevelopmentOnlyTrials,
+    validateInvalidatedPrecommits,
+    validateCurrentSuccessor,
+    validateStateOrdinals,
+  ] as const
+  for (const check of checks) {
+    const checkIssue = check(envelope.success)
+    if (checkIssue !== undefined) return Result.fail(checkIssue)
+  }
+  return Result.succeed(undefined)
+}
+
+export type { CandidateDevelopmentAttemptConsumption }


### PR DESCRIPTION
## Summary

- Split candidate trial history into explicit normalized model, validation, transition, next-action, and lineage modules behind the existing facades.
- Preserve the serialized history and frozen Candidate 16–20 lineage values while keeping Candidate 20 PRECOMMIT_INVALID, UNATTEMPTED, zero-attempt, and null-successor.
- Add compact typed builders and causal state-machine tests for one-attempt consumption, terminalization, immutable invalidation, successor binding, next ordinal, and fail-closed malformed histories.

## Related Issues

None.

## Testing

- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint:oxlint` (0 errors; existing generated-candidate warnings remain)
- `bun run --filter @proompteng/bayn lint:oxlint:type` (0 errors; existing generated-candidate warnings remain)
- `bun run --filter @proompteng/bayn build`
- `bun run --filter @proompteng/bayn test`
- `bun test services/bayn/src/candidate-development-trials/state-machine.test.ts services/bayn/src/candidate-development-candidate-20.test.ts services/bayn/src/candidate-development-candidate-19.test.ts services/bayn/src/candidate-development-candidate-18.test.ts services/bayn/src/candidate-development-candidate-17.test.ts services/bayn/src/candidate-development-evidence.test.ts` (37 passed)
- `bun run --filter @proompteng/bayn test:postgres` (0 failed; 145 integration tests skipped because no PostgreSQL fixture is configured)
- `git diff --check`

## Screenshots (if applicable)

N/A.

## Breaking Changes

None; existing history and decision facade exports remain compatible.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled.
- [x] Documentation, release notes, and follow-ups are not required for this internal pure-domain refactor.
