### PR TITLE
refactor(bayn): restore one-way cycle layering

### DIFF
--- a/services/bayn/src/cycle-readiness.ts
+++ b/services/bayn/src/cycle-readiness.ts
@@ -1,40 +1,27 @@
 import { Data, Effect, Result } from 'effect'
 
-import { CycleTerminalReason, signalSessionCloseAt, type AutonomousCycle, type CycleConstructionFailure } from './cycle'
+import { CycleTerminalReason, type AutonomousCycle } from './cycle'
 import {
   decideCyclePublicationAdmission,
   decideFinalizedPublicationBinding,
   decidePublicationInspection,
 } from './cycle-runner/publication-decisions'
+import {
+  measurePublicationFreshness,
+  type CyclePublicationReadiness,
+  type PublicationFreshness,
+} from './cycle-runner/recovery-readiness-model'
 import { CycleStore, type CycleMutationReceipt, type CycleStoreError, type CycleStoreShape } from './db/cycle-store'
 import type { OperationalError } from './errors'
 import { MarketData, type MarketDataInspection, type MarketDataService } from './market-data'
 import { currentUtcInstant } from './time'
 
-export interface PublicationFreshness {
-  readonly dataAgeMs: number
-  readonly publicationDelayMs: number
-}
-
-export type CyclePublicationReadiness =
-  | {
-      readonly outcome: 'WAITING'
-      readonly reason: 'SIGNAL_SESSION_OPEN' | 'PUBLICATION_MISSING'
-      readonly observedAt: string
-      readonly cycle: AutonomousCycle
-    }
-  | {
-      readonly outcome: 'BOUND' | 'ALREADY_BOUND'
-      readonly observedAt: string
-      readonly cycle: AutonomousCycle
-      readonly snapshotId: string
-      readonly freshness?: PublicationFreshness
-    }
-  | {
-      readonly outcome: 'BLOCKED'
-      readonly observedAt: string
-      readonly cycle: AutonomousCycle
-    }
+export type {
+  CyclePublicationReadiness,
+  PublicationFreshness,
+  PublicationFreshnessFailure,
+} from './cycle-runner/recovery-readiness-model'
+export { measurePublicationFreshness } from './cycle-runner/recovery-readiness-model'
 
 export class CycleReadinessError extends Data.TaggedError('CycleReadinessError')<{
   readonly operation: 'bind-publication' | 'inspect-publication' | 'measure-freshness' | 'missed-publication'
@@ -56,113 +43,9 @@ interface CyclePublicationDependencies {
   readonly now: Effect.Effect<string>
 }
 
-export type PublicationFreshnessFailure =
-  | {
-      readonly _tag: 'PublicationSessionMismatch'
-      readonly expectedSessionDate: string
-      readonly observedAsOfSession: string
-      readonly observedLastSession: string
-    }
-  | {
-      readonly _tag: 'PublicationCalendarMismatch'
-      readonly expectedCalendarVersion: string
-      readonly observedCalendarVersion: string
-    }
-  | {
-      readonly _tag: 'PublicationSignalSessionMismatch'
-      readonly expectedSessionDate: string
-      readonly expectedCalendarVersion: string
-      readonly observedSessionDate: string
-      readonly observedCalendarVersion: string
-    }
-  | {
-      readonly _tag: 'PublicationSignalCloseInvalid'
-      readonly cause: CycleConstructionFailure
-    }
-  | {
-      readonly _tag: 'PublicationSignalCloseMismatch'
-      readonly expectedSignalCloseAt: string
-      readonly observedSignalCloseAt: string
-    }
-  | {
-      readonly _tag: 'PublicationElapsedInvalid'
-      readonly measurement: 'data-age' | 'publication-delay'
-      readonly later: string
-      readonly earlier: string
-      readonly milliseconds: number
-    }
-
 type BoundPublicationFailure = {
   readonly _tag: 'BoundPublicationSnapshotMissing'
   readonly cycleId: string
-}
-
-const elapsed = (
-  later: string,
-  earlier: string,
-  measurement: Extract<PublicationFreshnessFailure, { readonly _tag: 'PublicationElapsedInvalid' }>['measurement'],
-): Result.Result<number, PublicationFreshnessFailure> => {
-  const milliseconds = Date.parse(later) - Date.parse(earlier)
-  return !Number.isSafeInteger(milliseconds) || milliseconds < 0
-    ? Result.fail({ _tag: 'PublicationElapsedInvalid', measurement, later, earlier, milliseconds })
-    : Result.succeed(milliseconds)
-}
-
-export const measurePublicationFreshness = (
-  cycle: AutonomousCycle,
-  inspection: MarketDataInspection,
-  observedAt: string,
-): Result.Result<PublicationFreshness, PublicationFreshnessFailure> => {
-  const snapshot = inspection.manifest.finalizedSnapshot
-  if (
-    snapshot.asOfSession !== cycle.identity.signalSessionDate ||
-    snapshot.lastSession !== cycle.identity.signalSessionDate
-  ) {
-    return Result.fail({
-      _tag: 'PublicationSessionMismatch',
-      expectedSessionDate: cycle.identity.signalSessionDate,
-      observedAsOfSession: snapshot.asOfSession,
-      observedLastSession: snapshot.lastSession,
-    })
-  }
-  if (snapshot.calendarVersion !== cycle.identity.signalCalendarVersion) {
-    return Result.fail({
-      _tag: 'PublicationCalendarMismatch',
-      expectedCalendarVersion: cycle.identity.signalCalendarVersion,
-      observedCalendarVersion: snapshot.calendarVersion,
-    })
-  }
-  if (
-    inspection.signalSession.session_date !== cycle.identity.signalSessionDate ||
-    inspection.signalSession.calendar_version !== cycle.identity.signalCalendarVersion
-  ) {
-    return Result.fail({
-      _tag: 'PublicationSignalSessionMismatch',
-      expectedSessionDate: cycle.identity.signalSessionDate,
-      expectedCalendarVersion: cycle.identity.signalCalendarVersion,
-      observedSessionDate: inspection.signalSession.session_date,
-      observedCalendarVersion: inspection.signalSession.calendar_version,
-    })
-  }
-  return Result.flatMap(
-    Result.mapError(
-      signalSessionCloseAt(inspection.signalSession),
-      (cause): PublicationFreshnessFailure => ({ _tag: 'PublicationSignalCloseInvalid', cause }),
-    ),
-    (observedSignalCloseAt) =>
-      observedSignalCloseAt !== cycle.window.signalCloseAt
-        ? Result.fail({
-            _tag: 'PublicationSignalCloseMismatch',
-            expectedSignalCloseAt: cycle.window.signalCloseAt,
-            observedSignalCloseAt,
-          })
-        : Result.flatMap(elapsed(observedAt, snapshot.finalizedAt, 'data-age'), (dataAgeMs) =>
-            Result.map(
-              elapsed(snapshot.finalizedAt, cycle.window.signalCloseAt, 'publication-delay'),
-              (publicationDelayMs) => ({ dataAgeMs, publicationDelayMs }),
-            ),
-          ),
-  )
 }
 
 const boundResult = (

--- a/services/bayn/src/cycle-recovery.ts
+++ b/services/bayn/src/cycle-recovery.ts
@@ -1,7 +1,7 @@
 export {
   cycleCompletionStateForTargetPlan,
   cycleTerminalReasonForBlockedTargetPlan,
-} from './cycle-runner/recovery-decision-binding'
+} from './cycle-runner/recovery-decisions'
 export { selectCycleRecovery } from './cycle-runner/recovery-selection'
 export {
   type CorrelatedCycleRecoveryState,

--- a/services/bayn/src/cycle-runner/recovery-decision-binding.ts
+++ b/services/bayn/src/cycle-runner/recovery-decision-binding.ts
@@ -1,14 +1,17 @@
 import { Result } from 'effect'
 
-import { CycleState, CycleTerminalReason, type AutonomousCycle, type CycleCompletionState } from '../cycle'
+import type { AutonomousCycle } from '../cycle'
 import type { CycleDecisionDocument } from '../shadow-decision-contract'
-import { TargetPlanReason, TargetPlanStatus, type BlockedTargetPlanReason } from '../target-planner'
+import { TargetPlanStatus } from '../target-planner'
 import {
   selectRecoveryFailure,
   validateDecisionFailure,
   type CycleRecoveryFailure,
   type CycleRecoverySelection,
 } from './recovery-model'
+import { cycleCompletionStateForTargetPlan, cycleTerminalReasonForBlockedTargetPlan } from './recovery-decisions'
+
+export { cycleCompletionStateForTargetPlan, cycleTerminalReasonForBlockedTargetPlan } from './recovery-decisions'
 
 const validateDecisionBinding = (
   cycle: AutonomousCycle,
@@ -56,42 +59,6 @@ const validateDecisionBinding = (
         ),
       )
     : Result.succeed(undefined)
-}
-
-export const cycleTerminalReasonForBlockedTargetPlan = (reason: BlockedTargetPlanReason): CycleTerminalReason => {
-  switch (reason) {
-    case TargetPlanReason.SubmissionCutoffReached:
-      return CycleTerminalReason.MissedSubmission
-    case TargetPlanReason.IdentityMismatch:
-      return CycleTerminalReason.ProvenanceMismatch
-    case TargetPlanReason.InputMismatch:
-      return CycleTerminalReason.DataInvalid
-    case TargetPlanReason.InputStale:
-      return CycleTerminalReason.DataStale
-    case TargetPlanReason.ReconciliationNotExact:
-      return CycleTerminalReason.Reconciliation
-    case TargetPlanReason.AccountNotActive:
-      return CycleTerminalReason.BrokerDisabled
-    case TargetPlanReason.UnknownOrder:
-    case TargetPlanReason.UnresolvedOrder:
-      return CycleTerminalReason.UnresolvedMutation
-    case TargetPlanReason.BelowMinimumBuyNotional:
-    case TargetPlanReason.InsufficientBuyingPower:
-    case TargetPlanReason.NonPositiveEquity:
-    case TargetPlanReason.ShortPositionNotAllowed:
-      return CycleTerminalReason.Risk
-  }
-}
-
-export const cycleCompletionStateForTargetPlan = (
-  status: TargetPlanStatus.Planned | TargetPlanStatus.NoTrade,
-): CycleCompletionState => {
-  switch (status) {
-    case TargetPlanStatus.Planned:
-      return CycleState.Completed
-    case TargetPlanStatus.NoTrade:
-      return CycleState.NoTrade
-  }
 }
 
 export const selectBoundDecision = (

--- a/services/bayn/src/cycle-runner/recovery-decisions.ts
+++ b/services/bayn/src/cycle-runner/recovery-decisions.ts
@@ -1,0 +1,38 @@
+import { CycleState, CycleTerminalReason, type CycleCompletionState } from '../cycle'
+import { TargetPlanReason, TargetPlanStatus, type BlockedTargetPlanReason } from '../target-planner'
+
+export const cycleTerminalReasonForBlockedTargetPlan = (reason: BlockedTargetPlanReason): CycleTerminalReason => {
+  switch (reason) {
+    case TargetPlanReason.SubmissionCutoffReached:
+      return CycleTerminalReason.MissedSubmission
+    case TargetPlanReason.IdentityMismatch:
+      return CycleTerminalReason.ProvenanceMismatch
+    case TargetPlanReason.InputMismatch:
+      return CycleTerminalReason.DataInvalid
+    case TargetPlanReason.InputStale:
+      return CycleTerminalReason.DataStale
+    case TargetPlanReason.ReconciliationNotExact:
+      return CycleTerminalReason.Reconciliation
+    case TargetPlanReason.AccountNotActive:
+      return CycleTerminalReason.BrokerDisabled
+    case TargetPlanReason.UnknownOrder:
+    case TargetPlanReason.UnresolvedOrder:
+      return CycleTerminalReason.UnresolvedMutation
+    case TargetPlanReason.BelowMinimumBuyNotional:
+    case TargetPlanReason.InsufficientBuyingPower:
+    case TargetPlanReason.NonPositiveEquity:
+    case TargetPlanReason.ShortPositionNotAllowed:
+      return CycleTerminalReason.Risk
+  }
+}
+
+export const cycleCompletionStateForTargetPlan = (
+  status: TargetPlanStatus.Planned | TargetPlanStatus.NoTrade,
+): CycleCompletionState => {
+  switch (status) {
+    case TargetPlanStatus.Planned:
+      return CycleState.Completed
+    case TargetPlanStatus.NoTrade:
+      return CycleState.NoTrade
+  }
+}

--- a/services/bayn/src/cycle-runner/recovery-model.ts
+++ b/services/bayn/src/cycle-runner/recovery-model.ts
@@ -9,7 +9,7 @@ import {
   type CycleCompletionState,
   type PendingCycle,
 } from '../cycle'
-import type { CyclePublicationReadiness } from '../cycle-readiness'
+import type { CyclePublicationReadiness } from './recovery-readiness-model'
 import { CycleDecisionDocumentSchema, type CycleDecisionDocument } from '../shadow-decision-contract'
 import {
   NonNegativeFiniteSchema,

--- a/services/bayn/src/cycle-runner/recovery-readiness-model.ts
+++ b/services/bayn/src/cycle-runner/recovery-readiness-model.ts
@@ -1,0 +1,133 @@
+import { Result } from 'effect'
+
+import { signalSessionCloseAt, type AutonomousCycle, type CycleConstructionFailure } from '../cycle'
+import type { MarketDataInspection } from '../market-data'
+
+export interface PublicationFreshness {
+  readonly dataAgeMs: number
+  readonly publicationDelayMs: number
+}
+
+export type CyclePublicationReadiness =
+  | {
+      readonly outcome: 'WAITING'
+      readonly reason: 'SIGNAL_SESSION_OPEN' | 'PUBLICATION_MISSING'
+      readonly observedAt: string
+      readonly cycle: AutonomousCycle
+    }
+  | {
+      readonly outcome: 'BOUND' | 'ALREADY_BOUND'
+      readonly observedAt: string
+      readonly cycle: AutonomousCycle
+      readonly snapshotId: string
+      readonly freshness?: PublicationFreshness
+    }
+  | {
+      readonly outcome: 'BLOCKED'
+      readonly observedAt: string
+      readonly cycle: AutonomousCycle
+    }
+
+export type PublicationFreshnessFailure =
+  | {
+      readonly _tag: 'PublicationSessionMismatch'
+      readonly expectedSessionDate: string
+      readonly observedAsOfSession: string
+      readonly observedLastSession: string
+    }
+  | {
+      readonly _tag: 'PublicationCalendarMismatch'
+      readonly expectedCalendarVersion: string
+      readonly observedCalendarVersion: string
+    }
+  | {
+      readonly _tag: 'PublicationSignalSessionMismatch'
+      readonly expectedSessionDate: string
+      readonly expectedCalendarVersion: string
+      readonly observedSessionDate: string
+      readonly observedCalendarVersion: string
+    }
+  | {
+      readonly _tag: 'PublicationSignalCloseInvalid'
+      readonly cause: CycleConstructionFailure
+    }
+  | {
+      readonly _tag: 'PublicationSignalCloseMismatch'
+      readonly expectedSignalCloseAt: string
+      readonly observedSignalCloseAt: string
+    }
+  | {
+      readonly _tag: 'PublicationElapsedInvalid'
+      readonly measurement: 'data-age' | 'publication-delay'
+      readonly later: string
+      readonly earlier: string
+      readonly milliseconds: number
+    }
+
+const elapsed = (
+  later: string,
+  earlier: string,
+  measurement: Extract<PublicationFreshnessFailure, { readonly _tag: 'PublicationElapsedInvalid' }>['measurement'],
+): Result.Result<number, PublicationFreshnessFailure> => {
+  const milliseconds = Date.parse(later) - Date.parse(earlier)
+  return !Number.isSafeInteger(milliseconds) || milliseconds < 0
+    ? Result.fail({ _tag: 'PublicationElapsedInvalid', measurement, later, earlier, milliseconds })
+    : Result.succeed(milliseconds)
+}
+
+export const measurePublicationFreshness = (
+  cycle: AutonomousCycle,
+  inspection: MarketDataInspection,
+  observedAt: string,
+): Result.Result<PublicationFreshness, PublicationFreshnessFailure> => {
+  const snapshot = inspection.manifest.finalizedSnapshot
+  if (
+    snapshot.asOfSession !== cycle.identity.signalSessionDate ||
+    snapshot.lastSession !== cycle.identity.signalSessionDate
+  ) {
+    return Result.fail({
+      _tag: 'PublicationSessionMismatch',
+      expectedSessionDate: cycle.identity.signalSessionDate,
+      observedAsOfSession: snapshot.asOfSession,
+      observedLastSession: snapshot.lastSession,
+    })
+  }
+  if (snapshot.calendarVersion !== cycle.identity.signalCalendarVersion) {
+    return Result.fail({
+      _tag: 'PublicationCalendarMismatch',
+      expectedCalendarVersion: cycle.identity.signalCalendarVersion,
+      observedCalendarVersion: snapshot.calendarVersion,
+    })
+  }
+  if (
+    inspection.signalSession.session_date !== cycle.identity.signalSessionDate ||
+    inspection.signalSession.calendar_version !== cycle.identity.signalCalendarVersion
+  ) {
+    return Result.fail({
+      _tag: 'PublicationSignalSessionMismatch',
+      expectedSessionDate: cycle.identity.signalSessionDate,
+      expectedCalendarVersion: cycle.identity.signalCalendarVersion,
+      observedSessionDate: inspection.signalSession.session_date,
+      observedCalendarVersion: inspection.signalSession.calendar_version,
+    })
+  }
+  return Result.flatMap(
+    Result.mapError(
+      signalSessionCloseAt(inspection.signalSession),
+      (cause): PublicationFreshnessFailure => ({ _tag: 'PublicationSignalCloseInvalid', cause }),
+    ),
+    (observedSignalCloseAt) =>
+      observedSignalCloseAt !== cycle.window.signalCloseAt
+        ? Result.fail({
+            _tag: 'PublicationSignalCloseMismatch',
+            expectedSignalCloseAt: cycle.window.signalCloseAt,
+            observedSignalCloseAt,
+          })
+        : Result.flatMap(elapsed(observedAt, snapshot.finalizedAt, 'data-age'), (dataAgeMs) =>
+            Result.map(
+              elapsed(snapshot.finalizedAt, cycle.window.signalCloseAt, 'publication-delay'),
+              (publicationDelayMs) => ({ dataAgeMs, publicationDelayMs }),
+            ),
+          ),
+  )
+}

--- a/services/bayn/src/cycle-runner/recovery-readiness.ts
+++ b/services/bayn/src/cycle-runner/recovery-readiness.ts
@@ -1,7 +1,7 @@
 import { Result } from 'effect'
 
 import { CycleState, CycleTerminalReason, cycleDraftMatches, cycleDraftOf, type AutonomousCycle } from '../cycle'
-import type { CyclePublicationReadiness } from '../cycle-readiness'
+import type { CyclePublicationReadiness } from './recovery-readiness-model'
 import {
   isAlreadyBoundReadiness,
   selectRecoveryFailure,

--- a/services/bayn/src/db/cycle-store/architecture-lint.mjs
+++ b/services/bayn/src/db/cycle-store/architecture-lint.mjs
@@ -1,0 +1,136 @@
+import { dirname, relative, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { API } from 'typescript/unstable/sync'
+
+const lintDirectory = dirname(fileURLToPath(import.meta.url))
+const serviceRoot = resolve(lintDirectory, '../../..')
+const sourceRoot = resolve(serviceRoot, 'src')
+const configFile = resolve(serviceRoot, 'tsconfig.json')
+
+const normalizePath = (file) => resolve(file).replaceAll('\\', '/')
+const sourceRootPrefix = `${normalizePath(sourceRoot)}/`
+const sourceFiles = (program) =>
+  new Set(
+    program
+      .getSourceFileNames()
+      .map(normalizePath)
+      .filter((file) => file.startsWith(sourceRootPrefix) && file.endsWith('.ts') && !file.endsWith('.test.ts')),
+  )
+
+const resolveSourceDependency = (file, specifier, files) => {
+  if (typeof specifier !== 'string' || !specifier.startsWith('.')) return undefined
+
+  const base = normalizePath(resolve(dirname(file), specifier))
+  const extensionlessBase = base.endsWith('.js') ? base.slice(0, -3) : base
+  return [
+    base,
+    `${base}.ts`,
+    `${base}.tsx`,
+    `${base}.mts`,
+    `${base}.cts`,
+    `${extensionlessBase}.ts`,
+    `${extensionlessBase}.tsx`,
+    `${extensionlessBase}.mts`,
+    `${extensionlessBase}.cts`,
+    `${base}/index.ts`,
+    `${base}/index.tsx`,
+    `${base}/index.mts`,
+    `${base}/index.cts`,
+  ].find((candidate) => files.has(candidate))
+}
+
+const sourceDependencyGraph = (program) => {
+  const files = sourceFiles(program)
+  return new Map(
+    [...files].map((file) => [
+      file,
+      [
+        ...new Set(
+          (program.getSourceFile(file)?.imports ?? [])
+            .map((specifier) => resolveSourceDependency(file, specifier.text, files))
+            .filter((dependency) => dependency !== undefined),
+        ),
+      ],
+    ]),
+  )
+}
+
+const stronglyConnectedComponents = (graph) => {
+  let nextIndex = 0
+  const stack = []
+  const onStack = new Set()
+  const indices = new Map()
+  const lowLinks = new Map()
+  const components = []
+
+  const visit = (file) => {
+    indices.set(file, nextIndex)
+    lowLinks.set(file, nextIndex)
+    nextIndex += 1
+    stack.push(file)
+    onStack.add(file)
+
+    for (const dependency of graph.get(file) ?? []) {
+      if (!indices.has(dependency)) {
+        visit(dependency)
+        lowLinks.set(file, Math.min(lowLinks.get(file), lowLinks.get(dependency)))
+      } else if (onStack.has(dependency)) {
+        lowLinks.set(file, Math.min(lowLinks.get(file), indices.get(dependency)))
+      }
+    }
+
+    if (lowLinks.get(file) !== indices.get(file)) return
+    const component = []
+    let current
+    do {
+      current = stack.pop()
+      if (current === undefined) return
+      onStack.delete(current)
+      component.push(current)
+    } while (current !== file)
+    if (component.length > 1 || graph.get(file)?.includes(file) === true) components.push(component)
+  }
+
+  for (const file of graph.keys()) {
+    if (!indices.has(file)) visit(file)
+  }
+  return components
+}
+
+const isCycleBoundary = (file) => {
+  const name = relative(sourceRoot, file).replaceAll('\\', '/')
+  return (
+    name.startsWith('db/cycle-store/') ||
+    name === 'cycle-readiness.ts' ||
+    name === 'cycle-recovery.ts' ||
+    name.startsWith('cycle-runner/recovery-')
+  )
+}
+
+const api = new API({ cwd: serviceRoot })
+try {
+  const snapshot = api.updateSnapshot({ openProjects: [configFile] })
+  try {
+    const project = snapshot
+      .getProjects()
+      .find((candidate) => normalizePath(candidate.configFileName) === normalizePath(configFile))
+    if (project === undefined) throw new Error(`TypeScript project was not loaded from ${configFile}`)
+
+    const cycles = stronglyConnectedComponents(sourceDependencyGraph(project.program))
+      .filter((component) => component.some(isCycleBoundary))
+      .map((component) => component.map((file) => relative(sourceRoot, file).replaceAll('\\', '/')).sort())
+
+    const result = { cycles }
+    if (cycles.length > 0) {
+      console.error(JSON.stringify(result, null, 2))
+      process.exitCode = 1
+    } else {
+      console.log(JSON.stringify(result))
+    }
+  } finally {
+    snapshot.dispose()
+  }
+} finally {
+  api.close()
+}

--- a/services/bayn/src/db/cycle-store/architecture.test.ts
+++ b/services/bayn/src/db/cycle-store/architecture.test.ts
@@ -1,42 +1,60 @@
 import { describe, expect, test } from 'bun:test'
-import { readdirSync, readFileSync } from 'node:fs'
-import { dirname, join, relative, resolve } from 'node:path'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, relative, resolve } from 'node:path'
 
 type DependencyGraph = ReadonlyMap<string, readonly string[]>
 
-const sourceRoot = resolve(import.meta.dir, '../..')
+const serviceRoot = resolve(import.meta.dir, '../../..')
+const sourceRoot = resolve(serviceRoot, 'src')
+const productionEntrypoints = [
+  resolve(sourceRoot, 'cycle-readiness.ts'),
+  resolve(sourceRoot, 'cycle-recovery.ts'),
+  resolve(sourceRoot, 'cycle-runner/recovery-decision-binding.ts'),
+  resolve(sourceRoot, 'cycle-runner/recovery-decisions.ts'),
+  resolve(sourceRoot, 'cycle-runner/recovery-model.ts'),
+  resolve(sourceRoot, 'cycle-runner/recovery-readiness-model.ts'),
+  resolve(sourceRoot, 'cycle-runner/recovery-readiness.ts'),
+  resolve(sourceRoot, 'cycle-runner/recovery-selection.ts'),
+  resolve(sourceRoot, 'db/cycle-store/index.ts'),
+]
 
-const sourceFilesUnder = (directory: string): readonly string[] =>
-  readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
-    const file = join(directory, entry.name)
-    if (entry.isDirectory()) return sourceFilesUnder(file)
-    return entry.name.endsWith('.ts') && !entry.name.endsWith('.test.ts') ? [file] : []
-  })
+const normalizePath = (file: string): string => file.replaceAll('\\', '/')
 
-const resolveSourceImport = (from: string, specifier: string, sourceFiles: ReadonlySet<string>): string | undefined => {
-  if (!specifier.startsWith('.')) return undefined
-  const base = resolve(dirname(from), specifier)
-  for (const candidate of [base, `${base}.ts`, join(base, 'index.ts')]) {
-    if (sourceFiles.has(candidate)) return candidate
-  }
-  return undefined
+const sourcePath = (file: string): string => normalizePath(resolve(file))
+
+const sourceDependencies = (
+  file: string,
+  imports: Readonly<Record<string, { imports: readonly { path: string }[] }>>,
+  sourceFiles: ReadonlySet<string>,
+): readonly string[] => {
+  const dependencies = imports[file]?.imports ?? []
+  return [
+    ...new Set(
+      dependencies.flatMap(({ path }) => {
+        const base = path.startsWith('.')
+          ? sourcePath(resolve(dirname(file), path))
+          : path.startsWith('/')
+            ? sourcePath(path)
+            : undefined
+        if (base === undefined) return []
+        return [base, `${base}.ts`, `${base}/index.ts`].filter((candidate) => sourceFiles.has(candidate))
+      }),
+    ),
+  ]
 }
 
-const sourceDependencies = (file: string, sourceFiles: ReadonlySet<string>): readonly string[] => {
-  const source = readFileSync(file, 'utf8')
-  const specifiers = [
-    ...source.matchAll(/\bfrom\s+["'](\.[^"']+)["']/g),
-    ...source.matchAll(/\bimport\s+["'](\.[^"']+)["']/g),
-  ].map((match) => match[1])
-  return [...new Set(specifiers.flatMap((specifier) => (specifier === undefined ? [] : [specifier])))]
-    .map((specifier) => resolveSourceImport(file, specifier, sourceFiles))
-    .filter((dependency): dependency is string => dependency !== undefined)
-}
+const sourceDependencyGraph = (metafile: Bun.BuildMetafile): DependencyGraph => {
+  const sourceFiles = new Set(
+    Object.keys(metafile.inputs)
+      .map((file) => sourcePath(resolve(serviceRoot, file)))
+      .filter((file) => file.startsWith(`${normalizePath(sourceRoot)}/`)),
+  )
+  const imports = Object.fromEntries(
+    Object.entries(metafile.inputs).map(([file, input]) => [sourcePath(resolve(serviceRoot, file)), input]),
+  )
 
-const sourceDependencyGraph = (): DependencyGraph => {
-  const sourceFiles = sourceFilesUnder(sourceRoot)
-  const sourceFileSet = new Set(sourceFiles)
-  return new Map(sourceFiles.map((file) => [file, sourceDependencies(file, sourceFileSet)]))
+  return new Map([...sourceFiles].map((file) => [file, sourceDependencies(file, imports, sourceFiles)]))
 }
 
 const stronglyConnectedComponents = (graph: DependencyGraph): readonly (readonly string[])[] => {
@@ -72,7 +90,7 @@ const stronglyConnectedComponents = (graph: DependencyGraph): readonly (readonly
       onStack.delete(current)
       component.push(current)
     } while (current !== file)
-    if (component.length > 1) components.push(component)
+    if (component.length > 1 || graph.get(file)?.includes(file) === true) components.push(component)
   }
 
   for (const file of graph.keys()) {
@@ -92,11 +110,41 @@ const isCycleBoundary = (file: string): boolean => {
 }
 
 describe('cycle-store architecture', () => {
-  test('keeps cycle-store, readiness, and recovery modules outside import cycles', () => {
-    const cycles = stronglyConnectedComponents(sourceDependencyGraph())
-      .filter((component) => component.some(isCycleBoundary))
-      .map((component) => component.map((file) => relative(sourceRoot, file)).sort())
+  test('keeps cycle-store, readiness, and recovery modules outside import cycles', async () => {
+    const outputDirectory = await mkdtemp(resolve(tmpdir(), 'bayn-cycle-architecture-'))
+    try {
+      const metafilePath = resolve(outputDirectory, 'metafile.json')
+      const build = Bun.spawn(
+        [
+          process.execPath,
+          'build',
+          '--external=tigerbeetle-node',
+          `--metafile=${metafilePath}`,
+          `--outdir=${outputDirectory}`,
+          '--target=node',
+          ...productionEntrypoints,
+        ],
+        { stderr: 'pipe', stdout: 'pipe' },
+      )
+      const [exitCode, stdout, stderr] = await Promise.all([
+        build.exited,
+        new Response(build.stdout).text(),
+        new Response(build.stderr).text(),
+      ])
 
-    expect(cycles).toEqual([])
+      expect(exitCode).toBe(0)
+      if (exitCode !== 0) {
+        throw new Error([stdout, stderr].filter((output) => output.length > 0).join('\n'))
+      }
+
+      const metafile = (await Bun.file(metafilePath).json()) as Bun.BuildMetafile
+      const cycles = stronglyConnectedComponents(sourceDependencyGraph(metafile))
+        .filter((component) => component.some(isCycleBoundary))
+        .map((component) => component.map((file) => relative(sourceRoot, file)).sort())
+
+      expect(cycles).toEqual([])
+    } finally {
+      await rm(outputDirectory, { force: true, recursive: true })
+    }
   })
 })

--- a/services/bayn/src/db/cycle-store/architecture.test.ts
+++ b/services/bayn/src/db/cycle-store/architecture.test.ts
@@ -17,10 +17,10 @@ describe('cycle-store architecture', () => {
       new Response(lint.stderr).text(),
     ])
 
-    expect(exitCode).toBe(0)
     if (exitCode !== 0) {
       throw new Error([stdout, stderr].filter((output) => output.length > 0).join('\n'))
     }
+    expect(exitCode).toBe(0)
 
     expect(JSON.parse(stdout)).toEqual({ cycles: [] })
   })

--- a/services/bayn/src/db/cycle-store/architecture.test.ts
+++ b/services/bayn/src/db/cycle-store/architecture.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from 'bun:test'
+import { readdirSync, readFileSync } from 'node:fs'
+import { dirname, join, relative, resolve } from 'node:path'
+
+type DependencyGraph = ReadonlyMap<string, readonly string[]>
+
+const sourceRoot = resolve(import.meta.dir, '../..')
+
+const sourceFilesUnder = (directory: string): readonly string[] =>
+  readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const file = join(directory, entry.name)
+    if (entry.isDirectory()) return sourceFilesUnder(file)
+    return entry.name.endsWith('.ts') && !entry.name.endsWith('.test.ts') ? [file] : []
+  })
+
+const resolveSourceImport = (from: string, specifier: string, sourceFiles: ReadonlySet<string>): string | undefined => {
+  if (!specifier.startsWith('.')) return undefined
+  const base = resolve(dirname(from), specifier)
+  for (const candidate of [base, `${base}.ts`, join(base, 'index.ts')]) {
+    if (sourceFiles.has(candidate)) return candidate
+  }
+  return undefined
+}
+
+const sourceDependencies = (file: string, sourceFiles: ReadonlySet<string>): readonly string[] => {
+  const source = readFileSync(file, 'utf8')
+  const specifiers = [
+    ...source.matchAll(/\bfrom\s+["'](\.[^"']+)["']/g),
+    ...source.matchAll(/\bimport\s+["'](\.[^"']+)["']/g),
+  ].map((match) => match[1])
+  return [...new Set(specifiers.flatMap((specifier) => (specifier === undefined ? [] : [specifier])))]
+    .map((specifier) => resolveSourceImport(file, specifier, sourceFiles))
+    .filter((dependency): dependency is string => dependency !== undefined)
+}
+
+const sourceDependencyGraph = (): DependencyGraph => {
+  const sourceFiles = sourceFilesUnder(sourceRoot)
+  const sourceFileSet = new Set(sourceFiles)
+  return new Map(sourceFiles.map((file) => [file, sourceDependencies(file, sourceFileSet)]))
+}
+
+const stronglyConnectedComponents = (graph: DependencyGraph): readonly (readonly string[])[] => {
+  let nextIndex = 0
+  const stack: string[] = []
+  const onStack = new Set<string>()
+  const indices = new Map<string, number>()
+  const lowLinks = new Map<string, number>()
+  const components: string[][] = []
+
+  const visit = (file: string): void => {
+    indices.set(file, nextIndex)
+    lowLinks.set(file, nextIndex)
+    nextIndex += 1
+    stack.push(file)
+    onStack.add(file)
+
+    for (const dependency of graph.get(file) ?? []) {
+      if (!indices.has(dependency)) {
+        visit(dependency)
+        lowLinks.set(file, Math.min(lowLinks.get(file) ?? 0, lowLinks.get(dependency) ?? 0))
+      } else if (onStack.has(dependency)) {
+        lowLinks.set(file, Math.min(lowLinks.get(file) ?? 0, indices.get(dependency) ?? 0))
+      }
+    }
+
+    if (lowLinks.get(file) !== indices.get(file)) return
+    const component: string[] = []
+    let current: string | undefined
+    do {
+      current = stack.pop()
+      if (current === undefined) return
+      onStack.delete(current)
+      component.push(current)
+    } while (current !== file)
+    if (component.length > 1) components.push(component)
+  }
+
+  for (const file of graph.keys()) {
+    if (!indices.has(file)) visit(file)
+  }
+  return components
+}
+
+const isCycleBoundary = (file: string): boolean => {
+  const name = relative(sourceRoot, file)
+  return (
+    name.startsWith('db/cycle-store/') ||
+    name === 'cycle-readiness.ts' ||
+    name === 'cycle-recovery.ts' ||
+    name.startsWith('cycle-runner/recovery-')
+  )
+}
+
+describe('cycle-store architecture', () => {
+  test('keeps cycle-store, readiness, and recovery modules outside import cycles', () => {
+    const cycles = stronglyConnectedComponents(sourceDependencyGraph())
+      .filter((component) => component.some(isCycleBoundary))
+      .map((component) => component.map((file) => relative(sourceRoot, file)).sort())
+
+    expect(cycles).toEqual([])
+  })
+})

--- a/services/bayn/src/db/cycle-store/architecture.test.ts
+++ b/services/bayn/src/db/cycle-store/architecture.test.ts
@@ -1,150 +1,27 @@
 import { describe, expect, test } from 'bun:test'
-import { mkdtemp, rm } from 'node:fs/promises'
-import { tmpdir } from 'node:os'
-import { dirname, relative, resolve } from 'node:path'
-
-type DependencyGraph = ReadonlyMap<string, readonly string[]>
+import { resolve } from 'node:path'
 
 const serviceRoot = resolve(import.meta.dir, '../../..')
-const sourceRoot = resolve(serviceRoot, 'src')
-const productionEntrypoints = [
-  resolve(sourceRoot, 'cycle-readiness.ts'),
-  resolve(sourceRoot, 'cycle-recovery.ts'),
-  resolve(sourceRoot, 'cycle-runner/recovery-decision-binding.ts'),
-  resolve(sourceRoot, 'cycle-runner/recovery-decisions.ts'),
-  resolve(sourceRoot, 'cycle-runner/recovery-model.ts'),
-  resolve(sourceRoot, 'cycle-runner/recovery-readiness-model.ts'),
-  resolve(sourceRoot, 'cycle-runner/recovery-readiness.ts'),
-  resolve(sourceRoot, 'cycle-runner/recovery-selection.ts'),
-  resolve(sourceRoot, 'db/cycle-store/index.ts'),
-]
-
-const normalizePath = (file: string): string => file.replaceAll('\\', '/')
-
-const sourcePath = (file: string): string => normalizePath(resolve(file))
-
-const sourceDependencies = (
-  file: string,
-  imports: Readonly<Record<string, { imports: readonly { path: string }[] }>>,
-  sourceFiles: ReadonlySet<string>,
-): readonly string[] => {
-  const dependencies = imports[file]?.imports ?? []
-  return [
-    ...new Set(
-      dependencies.flatMap(({ path }) => {
-        const base = path.startsWith('.')
-          ? sourcePath(resolve(dirname(file), path))
-          : path.startsWith('/')
-            ? sourcePath(path)
-            : undefined
-        if (base === undefined) return []
-        return [base, `${base}.ts`, `${base}/index.ts`].filter((candidate) => sourceFiles.has(candidate))
-      }),
-    ),
-  ]
-}
-
-const sourceDependencyGraph = (metafile: Bun.BuildMetafile): DependencyGraph => {
-  const sourceFiles = new Set(
-    Object.keys(metafile.inputs)
-      .map((file) => sourcePath(resolve(serviceRoot, file)))
-      .filter((file) => file.startsWith(`${normalizePath(sourceRoot)}/`)),
-  )
-  const imports = Object.fromEntries(
-    Object.entries(metafile.inputs).map(([file, input]) => [sourcePath(resolve(serviceRoot, file)), input]),
-  )
-
-  return new Map([...sourceFiles].map((file) => [file, sourceDependencies(file, imports, sourceFiles)]))
-}
-
-const stronglyConnectedComponents = (graph: DependencyGraph): readonly (readonly string[])[] => {
-  let nextIndex = 0
-  const stack: string[] = []
-  const onStack = new Set<string>()
-  const indices = new Map<string, number>()
-  const lowLinks = new Map<string, number>()
-  const components: string[][] = []
-
-  const visit = (file: string): void => {
-    indices.set(file, nextIndex)
-    lowLinks.set(file, nextIndex)
-    nextIndex += 1
-    stack.push(file)
-    onStack.add(file)
-
-    for (const dependency of graph.get(file) ?? []) {
-      if (!indices.has(dependency)) {
-        visit(dependency)
-        lowLinks.set(file, Math.min(lowLinks.get(file) ?? 0, lowLinks.get(dependency) ?? 0))
-      } else if (onStack.has(dependency)) {
-        lowLinks.set(file, Math.min(lowLinks.get(file) ?? 0, indices.get(dependency) ?? 0))
-      }
-    }
-
-    if (lowLinks.get(file) !== indices.get(file)) return
-    const component: string[] = []
-    let current: string | undefined
-    do {
-      current = stack.pop()
-      if (current === undefined) return
-      onStack.delete(current)
-      component.push(current)
-    } while (current !== file)
-    if (component.length > 1 || graph.get(file)?.includes(file) === true) components.push(component)
-  }
-
-  for (const file of graph.keys()) {
-    if (!indices.has(file)) visit(file)
-  }
-  return components
-}
-
-const isCycleBoundary = (file: string): boolean => {
-  const name = relative(sourceRoot, file)
-  return (
-    name.startsWith('db/cycle-store/') ||
-    name === 'cycle-readiness.ts' ||
-    name === 'cycle-recovery.ts' ||
-    name.startsWith('cycle-runner/recovery-')
-  )
-}
+const architectureLint = resolve(import.meta.dir, 'architecture-lint.mjs')
 
 describe('cycle-store architecture', () => {
   test('keeps cycle-store, readiness, and recovery modules outside import cycles', async () => {
-    const outputDirectory = await mkdtemp(resolve(tmpdir(), 'bayn-cycle-architecture-'))
-    try {
-      const metafilePath = resolve(outputDirectory, 'metafile.json')
-      const build = Bun.spawn(
-        [
-          process.execPath,
-          'build',
-          '--external=tigerbeetle-node',
-          `--metafile=${metafilePath}`,
-          `--outdir=${outputDirectory}`,
-          '--target=node',
-          ...productionEntrypoints,
-        ],
-        { stderr: 'pipe', stdout: 'pipe' },
-      )
-      const [exitCode, stdout, stderr] = await Promise.all([
-        build.exited,
-        new Response(build.stdout).text(),
-        new Response(build.stderr).text(),
-      ])
+    const lint = Bun.spawn(['node', architectureLint], {
+      cwd: serviceRoot,
+      stderr: 'pipe',
+      stdout: 'pipe',
+    })
+    const [exitCode, stdout, stderr] = await Promise.all([
+      lint.exited,
+      new Response(lint.stdout).text(),
+      new Response(lint.stderr).text(),
+    ])
 
-      expect(exitCode).toBe(0)
-      if (exitCode !== 0) {
-        throw new Error([stdout, stderr].filter((output) => output.length > 0).join('\n'))
-      }
-
-      const metafile = (await Bun.file(metafilePath).json()) as Bun.BuildMetafile
-      const cycles = stronglyConnectedComponents(sourceDependencyGraph(metafile))
-        .filter((component) => component.some(isCycleBoundary))
-        .map((component) => component.map((file) => relative(sourceRoot, file)).sort())
-
-      expect(cycles).toEqual([])
-    } finally {
-      await rm(outputDirectory, { force: true, recursive: true })
+    expect(exitCode).toBe(0)
+    if (exitCode !== 0) {
+      throw new Error([stdout, stderr].filter((output) => output.length > 0).join('\n'))
     }
+
+    expect(JSON.parse(stdout)).toEqual({ cycles: [] })
   })
 })

--- a/services/bayn/src/db/cycle-store/decision-contract.ts
+++ b/services/bayn/src/db/cycle-store/decision-contract.ts
@@ -1,0 +1,25 @@
+import type { CycleDecisionDocument } from '../../shadow-decision-contract'
+
+export interface CycleStoreDecisionFailure {
+  readonly failure: 'conflict' | 'invariant' | 'not-found'
+  readonly message: string
+}
+
+export interface CycleDecisionStoreEvidence {
+  readonly paperCompletionEvidenceMatches: boolean
+  readonly paperGenerationIsSuperseded: boolean
+}
+
+const decisionStoreEvidence = new WeakMap<object, CycleDecisionStoreEvidence>()
+
+export const attachCycleDecisionStoreEvidence = (
+  document: CycleDecisionDocument,
+  evidence: CycleDecisionStoreEvidence,
+): CycleDecisionDocument => {
+  const attached = { ...document } satisfies CycleDecisionDocument
+  decisionStoreEvidence.set(attached, evidence)
+  return attached
+}
+
+export const cycleDecisionStoreEvidence = (document: CycleDecisionDocument): CycleDecisionStoreEvidence | undefined =>
+  decisionStoreEvidence.get(document)

--- a/services/bayn/src/db/cycle-store/decisions.test.ts
+++ b/services/bayn/src/db/cycle-store/decisions.test.ts
@@ -27,8 +27,8 @@ import {
   makeInitialCycle,
   validateBlockedDecision,
   validateCompletionDocument,
-  type CycleStoreDecisionFailure,
 } from './decisions'
+import type { CycleStoreDecisionFailure } from './decision-contract'
 
 const hash = (character: string): string => character.repeat(64)
 const accountId = 'paper-account-1'

--- a/services/bayn/src/db/cycle-store/decisions.ts
+++ b/services/bayn/src/db/cycle-store/decisions.ts
@@ -10,16 +10,14 @@ import {
   type CycleCompletionState,
   type CycleDraft,
 } from '../../cycle'
-import { cycleTerminalReasonForBlockedTargetPlan } from '../../cycle-recovery'
+import { cycleTerminalReasonForBlockedTargetPlan } from '../../cycle-runner/recovery-decisions'
 import { CycleDecisionDocumentSchema, type CycleDecisionDocument } from '../../shadow-decision-contract'
 import { TargetPlanStatus } from '../../target-planner'
 import type { InputManifest } from '../../types'
-import { cycleDecisionStoreEvidence } from './model'
+import { cycleDecisionStoreEvidence } from './decision-contract'
+import type { CycleStoreDecisionFailure } from './decision-contract'
 
-export interface CycleStoreDecisionFailure {
-  readonly failure: 'conflict' | 'invariant' | 'not-found'
-  readonly message: string
-}
+export type { CycleStoreDecisionFailure } from './decision-contract'
 
 export type AcquireDecision =
   | {

--- a/services/bayn/src/db/cycle-store/model.ts
+++ b/services/bayn/src/db/cycle-store/model.ts
@@ -4,26 +4,13 @@ import { isSqlError, type SqlError } from 'effect/unstable/sql/SqlError'
 import type { AutonomousCycle, CycleCompletionState, CycleDraft, CycleTerminalReason } from '../../cycle'
 import type { CycleDecisionDocument } from '../../shadow-decision-contract'
 import type { InputManifest, IsoDate } from '../../types'
-import type { CycleStoreDecisionFailure } from './decisions'
+import type { CycleStoreDecisionFailure } from './decision-contract'
 
-export interface CycleDecisionStoreEvidence {
-  readonly paperCompletionEvidenceMatches: boolean
-  readonly paperGenerationIsSuperseded: boolean
-}
-
-const decisionStoreEvidence = new WeakMap<object, CycleDecisionStoreEvidence>()
-
-export const attachCycleDecisionStoreEvidence = (
-  document: CycleDecisionDocument,
-  evidence: CycleDecisionStoreEvidence,
-): CycleDecisionDocument => {
-  const attached = { ...document } satisfies CycleDecisionDocument
-  decisionStoreEvidence.set(attached, evidence)
-  return attached
-}
-
-export const cycleDecisionStoreEvidence = (document: CycleDecisionDocument): CycleDecisionStoreEvidence | undefined =>
-  decisionStoreEvidence.get(document)
+export {
+  attachCycleDecisionStoreEvidence,
+  cycleDecisionStoreEvidence,
+  type CycleDecisionStoreEvidence,
+} from './decision-contract'
 
 export interface CycleAcquireReceipt {
   readonly cycle: AutonomousCycle

--- a/services/bayn/src/db/cycle-store/queries.ts
+++ b/services/bayn/src/db/cycle-store/queries.ts
@@ -3,12 +3,8 @@ import { Effect } from 'effect'
 
 import { CycleState, type AutonomousCycle } from '../../cycle'
 import type { CycleDecisionDocument, PaperDecisionDocument } from '../../shadow-decision-contract'
-import {
-  attachCycleDecisionStoreEvidence,
-  type CycleAuthoritySlot,
-  type CycleRecoveryScope,
-  type CycleStoreInternalError,
-} from './model'
+import { attachCycleDecisionStoreEvidence } from './decision-contract'
+import type { CycleAuthoritySlot, CycleRecoveryScope, CycleStoreInternalError } from './model'
 import { decodeDecisionEvidenceMatch, decodeStoredCycles, decodeStoredDecisionDocumentRows } from './rows'
 
 export interface CycleQueries {


### PR DESCRIPTION
## Summary

- Extracted cycle-store decision failures and decision evidence into a dependency-free contract while preserving the existing model and decisions exports.
- Moved publication readiness data and freshness validation into the pure recovery-readiness model, leaving the readiness module as the I/O interpreter over the stable CycleStore facade.
- Moved target-plan-to-terminal mappings into pure recovery decisions and removed the public recovery/store import cycle.
- Added a bounded SCC regression test covering the cycle-store, readiness, and recovery boundary.

## Related Issues

None

## Testing

- `bun test src/db/cycle-store/decisions.test.ts src/db/cycle-store/rows.test.ts src/db/cycle-store/architecture.test.ts src/cycle-readiness.test.ts src/cycle-recovery.test.ts` — 23 passed, 0 failed.
- `bun run test` — 1,195 passed, 153 skipped, 0 failed.
- `bun run test:postgres` — 0 passed, 64 skipped, 0 failed; PostgreSQL integration tests were unavailable in this environment.
- `bun run tsc` — passed.
- `bun run lint:effect` — passed.
- `bun run lint`, `bun run lint:oxlint`, and `bun run lint:oxlint:type` — passed; the latter two retain one pre-existing warning in `src/candidate-development-domain/preflight.ts`.
- `bun run build` — passed.
- Pre-commit hooks (lint-staged Oxlint/Oxfmt and commitlint) — passed.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled.
- [x] Documentation, release notes, and follow-ups are updated or tracked.