### PR TITLE
refactor(bayn): normalize scoped resource acquisition

### DIFF
--- a/services/bayn/src/broker/alpaca/session.test.ts
+++ b/services/bayn/src/broker/alpaca/session.test.ts
@@ -14,6 +14,7 @@ import {
   BrokerSessionAcquisitionStage,
   acquireBrokerSession,
   layer,
+  mapHttpAcquisitionError,
   retryRecoverableBrokerSessionAcquisition,
 } from './session'
 
@@ -354,6 +355,42 @@ describe('Alpaca broker session acquisition retry', () => {
     )
 
     expect(requests).toBe(1)
+    expect(finalizations).toBe(1)
+  })
+
+  test('maps HTTP resource acquisition once and finalizes a failed resource exactly once', async () => {
+    const options = connection(0)
+    const cause = new BrokerReadError({
+      operation: 'proxy',
+      kind: BrokerReadErrorKind.Configuration,
+      message: 'proxy dispatcher acquisition failed',
+      retryable: false,
+    })
+    let finalizations = 0
+    const client = HttpClient.make(() => Effect.die('unused HTTP client'))
+    const http = Layer.effect(
+      HttpClient.HttpClient,
+      Effect.acquireRelease(Effect.succeed(client), () =>
+        Effect.sync(() => {
+          finalizations += 1
+        }),
+      ).pipe(Effect.andThen(Effect.fail(cause))),
+    )
+
+    const failure = await Effect.runPromise(
+      Effect.flip(Effect.scoped(Layer.build(mapHttpAcquisitionError(options, http)))),
+    )
+
+    expect(failure).toMatchObject({
+      stage: BrokerSessionAcquisitionStage.Connection,
+      provider: BrokerProvider.Alpaca,
+      environment: BrokerEnvironment.Sandbox,
+      baseUrl: alpacaSandboxBaseUrl,
+      expectedAccountId: accountId,
+      cause,
+    })
+    expect(JSON.stringify(failure)).not.toContain(key)
+    expect(JSON.stringify(failure)).not.toContain(secret)
     expect(finalizations).toBe(1)
   })
 })

--- a/services/bayn/src/broker/alpaca/session.ts
+++ b/services/bayn/src/broker/alpaca/session.ts
@@ -6,6 +6,7 @@ import { BrokerReadError } from './failures'
 import { alpacaHttpLayer, make } from './http'
 import { BrokerRead, type BrokerReadShape, type ReadPreflight } from './model'
 import { BrokerAccountPreflightError, verifyReadAccess } from './preflight'
+import { mapLayerAcquisitionError } from '../../resource-boundary'
 
 export enum BrokerSessionAcquisitionStage {
   Connection = 'CONNECTION',
@@ -134,17 +135,11 @@ export const layer = (
   ).pipe(Layer.provideMerge(session))
 }
 
-const mapHttpAcquisitionError = (
+export const mapHttpAcquisitionError = (
   connection: BrokerConnection,
   http: Layer.Layer<HttpClient.HttpClient, BrokerReadError>,
 ): Layer.Layer<HttpClient.HttpClient, BrokerSessionAcquisitionError> =>
-  Layer.unwrap(
-    pipe(
-      Layer.build(http),
-      Effect.mapError((cause) => acquisitionError(connection, cause)),
-      Effect.map(Layer.succeedContext),
-    ),
-  )
+  mapLayerAcquisitionError(http, (cause) => acquisitionError(connection, cause))
 
 export const live = (
   connection: BrokerConnection,

--- a/services/bayn/src/db/execution-store/contract.ts
+++ b/services/bayn/src/db/execution-store/contract.ts
@@ -48,6 +48,13 @@ export class ExecutionStoreError extends Data.TaggedError('ExecutionStoreError')
   readonly cause?: unknown
 }> {}
 
+/**
+ * The capital-grant lifecycle is the execution store's writer-fenced interpreter boundary. Its operations acquire the
+ * process-wide WriterFence at invocation time; all other execution-store capabilities remain fence-free because they
+ * do not own the authority-generation transaction.
+ */
+export type WriterFencedExecutionStoreOperation<A> = Effect.Effect<A, ExecutionStoreError, WriterFence>
+
 export interface BrokerEventStoreShape {
   readonly ingest: (input: BrokerEventInput) => Effect.Effect<EventReceipt, ExecutionStoreError>
   readonly ingestPositions: (
@@ -83,7 +90,7 @@ export interface CapitalGrantLifecycleStoreShape {
    */
   readonly prepareCapitalGrant: (
     proof: CapitalGrantProofBinding,
-  ) => Effect.Effect<CapitalGrantGeneration, ExecutionStoreError, WriterFence>
+  ) => WriterFencedExecutionStoreOperation<CapitalGrantGeneration>
   /**
    * SUBMIT activation operation: transactionally re-derives the stable generation identity
    * from the same proof binding, requires its hash to equal the configured generationHash, and records the latest
@@ -93,7 +100,7 @@ export interface CapitalGrantLifecycleStoreShape {
    */
   readonly activateCapitalGrant: (
     proof: CapitalGrantProofBinding,
-  ) => Effect.Effect<AuthorityState, ExecutionStoreError, WriterFence>
+  ) => WriterFencedExecutionStoreOperation<AuthorityState>
 }
 
 export interface AuthorityRestrictionStoreShape {

--- a/services/bayn/src/execution/writer-fence.test.ts
+++ b/services/bayn/src/execution/writer-fence.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from 'bun:test'
+
+import { Deferred, Effect, Exit, Fiber } from 'effect'
+
+import { WriterFence, type WriterFenceService, withWriterFence } from './writer-fence'
+
+const service = (transaction: WriterFenceService['transaction']): WriterFenceService => ({
+  backendPid: 42,
+  check: Effect.void,
+  transaction,
+})
+
+describe('WriterFence interpreter boundary', () => {
+  test('requires and delegates through one explicit fence service', async () => {
+    let transactions = 0
+    const fence = service((effect) =>
+      Effect.sync(() => {
+        transactions += 1
+      }).pipe(Effect.andThen(effect)),
+    )
+
+    const value = await Effect.runPromise(
+      withWriterFence(Effect.succeed('committed')).pipe(Effect.provideService(WriterFence, fence)),
+    )
+
+    expect(value).toBe('committed')
+    expect(transactions).toBe(1)
+  })
+
+  test('preserves interruption at the explicit transaction boundary', async () => {
+    const started = await Effect.runPromise(Deferred.make<void>())
+    let transactions = 0
+    const fence = service((effect) =>
+      Effect.sync(() => {
+        transactions += 1
+      }).pipe(Effect.andThen(Deferred.succeed(started, undefined)), Effect.andThen(effect)),
+    )
+
+    const exit = await Effect.runPromise(
+      Effect.gen(function* () {
+        const fiber = yield* withWriterFence(Effect.never).pipe(
+          Effect.provideService(WriterFence, fence),
+          Effect.forkChild({ startImmediately: true }),
+        )
+        yield* Deferred.await(started)
+        yield* Fiber.interrupt(fiber)
+        return yield* Fiber.await(fiber)
+      }),
+    )
+
+    expect(Exit.isFailure(exit)).toBe(true)
+    expect(transactions).toBe(1)
+  })
+})

--- a/services/bayn/src/execution/writer-fence.ts
+++ b/services/bayn/src/execution/writer-fence.ts
@@ -17,10 +17,22 @@ export class WriterFenceError extends Data.TaggedError('WriterFenceError')<{
 export interface WriterFenceService {
   readonly backendPid: number
   readonly check: Effect.Effect<void, WriterFenceError>
-  readonly transaction: <A, E, R>(effect: Effect.Effect<A, E, R>) => Effect.Effect<A, E | WriterFenceError, R>
+  readonly transaction: WriterFenceTransaction
 }
 
+export type WriterFenceTransaction = <A, E, R>(
+  effect: Effect.Effect<A, E, R>,
+) => Effect.Effect<A, E | WriterFenceError, R>
+
 export class WriterFence extends Context.Service<WriterFence, WriterFenceService>()('bayn/WriterFence') {}
+
+/**
+ * Explicitly crosses the WriterFence interpreter boundary for callers that do not already hold the service value.
+ */
+export const withWriterFence = <A, E, R>(
+  effect: Effect.Effect<A, E, R>,
+): Effect.Effect<A, E | WriterFenceError, R | WriterFence> =>
+  Effect.flatMap(WriterFence, (fence) => fence.transaction(effect))
 
 const unavailable = (operation: 'acquire' | 'check' | 'transaction', cause: unknown) =>
   new WriterFenceError({

--- a/services/bayn/src/operations.ts
+++ b/services/bayn/src/operations.ts
@@ -4,6 +4,7 @@ import { isSqlError } from 'effect/unstable/sql/SqlError'
 import { CycleObservabilityError } from './db/cycle-observability'
 import { DatabaseError } from './db/evidence-store'
 import { operationalError, retryableOperationalError, type Component, type OperationalError } from './errors'
+import { retryLayerAcquisition } from './resource-boundary'
 
 type DatabaseOperationFailure = DatabaseError | CycleObservabilityError
 
@@ -23,8 +24,8 @@ const isRetryableSqlAcquisition = (error: unknown): boolean => {
 }
 
 export const sqlResource = <A, E, R>(layer: Layer.Layer<A, E, R>): Layer.Layer<A, E, R> =>
-  Layer.effectContext(
-    Layer.build(layer).pipe(
+  retryLayerAcquisition(layer, (acquisition) =>
+    acquisition.pipe(
       Effect.retry({
         times: 2,
         schedule: Schedule.spaced(Duration.seconds(1)),

--- a/services/bayn/src/resource-boundary.test.ts
+++ b/services/bayn/src/resource-boundary.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from 'bun:test'
+
+import { Deferred, Effect, Exit, Fiber, Layer, Ref } from 'effect'
+
+import { mapLayerAcquisitionError, retryLayerAcquisition } from './resource-boundary'
+
+describe('scoped resource boundaries', () => {
+  test('retries fresh acquisitions and finalizes every failed and successful attempt exactly once', async () => {
+    let attempts = 0
+    let finalizations = 0
+    const retryable = new Error('transient acquisition failure')
+    const dependency = Layer.effectDiscard(
+      Effect.suspend(() => {
+        attempts += 1
+        const attempt = attempts
+        if (attempt > 1) {
+          expect(finalizations).toBe(attempt - 1)
+        }
+        return Effect.acquireRelease(Effect.void, () =>
+          Effect.sync(() => {
+            finalizations += 1
+          }),
+        ).pipe(Effect.andThen(attempt < 3 ? Effect.fail(retryable) : Effect.void))
+      }),
+    )
+    const resource = retryLayerAcquisition(dependency, (acquisition) =>
+      acquisition.pipe(Effect.retry({ times: 2, while: (cause) => cause === retryable })),
+    )
+
+    await Effect.runPromise(Effect.scoped(Layer.build(resource)))
+
+    expect(attempts).toBe(3)
+    expect(finalizations).toBe(3)
+  })
+
+  test('closes an interrupted in-flight acquisition once without starting another attempt', async () => {
+    let attempts = 0
+    const started = await Effect.runPromise(Deferred.make<void>())
+    const finalizations = await Effect.runPromise(Ref.make(0))
+    const dependency = Layer.effectDiscard(
+      Effect.suspend(() => {
+        attempts += 1
+        return Effect.acquireRelease(Deferred.succeed(started, undefined), () =>
+          Ref.update(finalizations, (count) => count + 1),
+        ).pipe(Effect.andThen(Effect.never))
+      }),
+    )
+    const resource = retryLayerAcquisition(dependency, (acquisition) => acquisition)
+
+    await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const fiber = yield* Layer.build(resource).pipe(Effect.forkChild({ startImmediately: true }))
+          yield* Deferred.await(started)
+          yield* Fiber.interrupt(fiber)
+          const exit = yield* Fiber.await(fiber)
+          expect(Exit.isFailure(exit)).toBe(true)
+        }),
+      ),
+    )
+
+    expect(attempts).toBe(1)
+    expect(await Effect.runPromise(Ref.get(finalizations))).toBe(1)
+  })
+
+  test('maps acquisition errors at the resource boundary and releases the failed resource once', async () => {
+    let finalizations = 0
+    const cause = new Error('proxy acquisition failed')
+    const dependency = Layer.effectDiscard(
+      Effect.acquireRelease(Effect.void, () =>
+        Effect.sync(() => {
+          finalizations += 1
+        }),
+      ).pipe(Effect.andThen(Effect.fail(cause))),
+    )
+    const resource = mapLayerAcquisitionError(dependency, (error) => `mapped: ${error.message}`)
+
+    const failure = await Effect.runPromise(Effect.flip(Effect.scoped(Layer.build(resource))))
+
+    expect(failure).toBe('mapped: proxy acquisition failed')
+    expect(finalizations).toBe(1)
+  })
+})

--- a/services/bayn/src/resource-boundary.test.ts
+++ b/services/bayn/src/resource-boundary.test.ts
@@ -93,7 +93,7 @@ describe('scoped resource boundaries', () => {
       Effect.scoped(
         Effect.gen(function* () {
           const parentScope = yield* Scope.Scope
-          yield* scopedAcquisition(
+          return yield* scopedAcquisition(
             (attemptScope) =>
               Scope.provide(
                 Effect.acquireRelease(Effect.void, () =>

--- a/services/bayn/src/resource-boundary.test.ts
+++ b/services/bayn/src/resource-boundary.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from 'bun:test'
 
-import { Cause, Deferred, Effect, Exit, Fiber, Layer, Ref } from 'effect'
+import { Cause, Deferred, Effect, Exit, Fiber, Layer, Option, Ref, Result, Scope } from 'effect'
 
-import { mapLayerAcquisitionError, retryLayerAcquisition } from './resource-boundary'
+import { mapLayerAcquisitionError, retryLayerAcquisition, scopedAcquisition } from './resource-boundary'
 
 describe('scoped resource boundaries', () => {
   test('retries fresh acquisitions and finalizes every failed and successful attempt exactly once', async () => {
@@ -80,6 +80,47 @@ describe('scoped resource boundaries', () => {
     expect(Exit.isFailure(exit)).toBe(true)
     if (Exit.isFailure(exit)) {
       expect(Cause.squash(exit.cause)).toBe(defect)
+    }
+    expect(finalizations).toBe(1)
+  })
+
+  test('retains an acquisition failure when its finalizer defects', async () => {
+    let finalizations = 0
+    const acquisitionFailure = new Error('acquisition failure')
+    const cleanupDefect = new Error('cleanup defect')
+
+    const exit = await Effect.runPromiseExit(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const parentScope = yield* Scope.Scope
+          yield* scopedAcquisition(
+            (attemptScope) =>
+              Scope.provide(
+                Effect.acquireRelease(Effect.void, () =>
+                  Effect.sync(() => {
+                    finalizations += 1
+                  }).pipe(Effect.andThen(Effect.die(cleanupDefect))),
+                ).pipe(Effect.andThen(Effect.fail(acquisitionFailure))),
+                attemptScope,
+              ),
+            parentScope,
+          )
+        }),
+      ),
+    )
+
+    expect(Exit.isFailure(exit)).toBe(true)
+    if (Exit.isFailure(exit)) {
+      const failure = Cause.findErrorOption(exit.cause)
+      expect(Option.isSome(failure)).toBe(true)
+      if (Option.isSome(failure)) {
+        expect(failure.value).toBe(acquisitionFailure)
+      }
+      const defect = Cause.findDie(exit.cause)
+      expect(Result.isSuccess(defect)).toBe(true)
+      if (Result.isSuccess(defect)) {
+        expect(defect.success.defect).toBe(cleanupDefect)
+      }
     }
     expect(finalizations).toBe(1)
   })

--- a/services/bayn/src/resource-boundary.test.ts
+++ b/services/bayn/src/resource-boundary.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 
-import { Deferred, Effect, Exit, Fiber, Layer, Ref } from 'effect'
+import { Cause, Deferred, Effect, Exit, Fiber, Layer, Ref } from 'effect'
 
 import { mapLayerAcquisitionError, retryLayerAcquisition } from './resource-boundary'
 
@@ -61,6 +61,27 @@ describe('scoped resource boundaries', () => {
 
     expect(attempts).toBe(1)
     expect(await Effect.runPromise(Ref.get(finalizations))).toBe(1)
+  })
+
+  test('preserves acquisition defects and finalizes the failed attempt once', async () => {
+    let finalizations = 0
+    const defect = new Error('defective acquisition')
+    const dependency = Layer.effectDiscard(
+      Effect.acquireRelease(Effect.void, () =>
+        Effect.sync(() => {
+          finalizations += 1
+        }),
+      ).pipe(Effect.andThen(Effect.die(defect))),
+    )
+    const resource = retryLayerAcquisition(dependency, (acquisition) => acquisition)
+
+    const exit = await Effect.runPromiseExit(Effect.scoped(Layer.build(resource)))
+
+    expect(Exit.isFailure(exit)).toBe(true)
+    if (Exit.isFailure(exit)) {
+      expect(Cause.squash(exit.cause)).toBe(defect)
+    }
+    expect(finalizations).toBe(1)
   })
 
   test('maps acquisition errors at the resource boundary and releases the failed resource once', async () => {

--- a/services/bayn/src/resource-boundary.ts
+++ b/services/bayn/src/resource-boundary.ts
@@ -1,0 +1,54 @@
+import { Context, Effect, Exit, Layer, Scope } from 'effect'
+
+/**
+ * Builds a fresh layer attempt in a child scope owned by the caller-owned scope.
+ *
+ * A fresh memo map is intentional: a failed acquisition must not be memoized as the result of a later retry. A
+ * failed or interrupted attempt closes its child scope immediately; a successful attempt remains attached to the
+ * caller-owned scope and is closed by the outer layer boundary.
+ */
+const acquireFreshLayer = <A, E, R>(
+  layer: Layer.Layer<A, E, R>,
+  scope: Scope.Scope,
+): Effect.Effect<Context.Context<A>, E, R> =>
+  Effect.uninterruptibleMask((restore) =>
+    Effect.gen(function* () {
+      const attemptScope = yield* Scope.fork(scope)
+      const result = yield* Effect.exit(
+        restore(Layer.buildWithMemoMap(Layer.fresh(layer), Layer.makeMemoMapUnsafe(), attemptScope)),
+      )
+
+      if (Exit.isSuccess(result)) {
+        return result.value
+      }
+
+      yield* Scope.close(attemptScope, result)
+      return yield* Effect.failCause(result.cause)
+    }),
+  )
+
+/**
+ * Owns the scope used by a resource boundary while keeping acquisition as an ordinary Effect.
+ */
+const scopedLayer = <A, E, R>(
+  acquire: (scope: Scope.Scope) => Effect.Effect<Context.Context<A>, E, R>,
+): Layer.Layer<A, E, R> => Layer.fromBuildMemo((_, scope) => acquire(scope))
+
+/**
+ * Applies a retry policy to fresh, scoped layer acquisition. The retry callback receives an Effect rather than a
+ * Layer, so retrying cannot accidentally rebuild a layer through a nested `Layer.build` conversion.
+ */
+export const retryLayerAcquisition = <A, E, R>(
+  layer: Layer.Layer<A, E, R>,
+  retry: (acquisition: Effect.Effect<Context.Context<A>, E, R>) => Effect.Effect<Context.Context<A>, E, R>,
+): Layer.Layer<A, E, R> => scopedLayer((scope) => retry(Effect.suspend(() => acquireFreshLayer(layer, scope))))
+
+/**
+ * Maps errors from a scoped dependency layer at the resource boundary. The dependency is built once for the
+ * boundary and its finalizers remain owned by the same scope as the layer that consumes it.
+ */
+export const mapLayerAcquisitionError = <A, E, E2, R>(
+  layer: Layer.Layer<A, E, R>,
+  mapError: (cause: E) => E2,
+): Layer.Layer<A, E2, R> =>
+  scopedLayer((scope) => Effect.suspend(() => acquireFreshLayer(layer, scope)).pipe(Effect.mapError(mapError)))

--- a/services/bayn/src/resource-boundary.ts
+++ b/services/bayn/src/resource-boundary.ts
@@ -1,30 +1,37 @@
-import { Context, Effect, Exit, Layer, Scope } from 'effect'
+import { Cause, Context, Effect, Exit, Layer, Scope } from 'effect'
 
 /**
- * Builds a fresh layer attempt in a child scope owned by the caller-owned scope.
- *
- * A fresh memo map is intentional: a failed acquisition must not be memoized as the result of a later retry. A
- * failed or interrupted attempt closes its child scope immediately; a successful attempt remains attached to the
- * caller-owned scope and is closed by the outer layer boundary.
+ * Runs one acquisition in a child scope. Failed or interrupted attempts close immediately and retain both the
+ * acquisition and cleanup causes; successful attempts leave the child scope attached to `scope` for the caller to own.
  */
-const acquireFreshLayer = <A, E, R>(
-  layer: Layer.Layer<A, E, R>,
+export const scopedAcquisition = <A, E, R>(
+  acquire: (scope: Scope.Scope) => Effect.Effect<A, E, R>,
   scope: Scope.Scope,
-): Effect.Effect<Context.Context<A>, E, R> =>
+): Effect.Effect<A, E, R> =>
   Effect.uninterruptibleMask((restore) =>
     Effect.gen(function* () {
       const attemptScope = yield* Scope.fork(scope)
-      const result = yield* Effect.exit(
-        restore(Layer.buildWithMemoMap(Layer.fresh(layer), Layer.makeMemoMapUnsafe(), attemptScope)),
-      )
+      const result = yield* Effect.exit(restore(acquire(attemptScope)))
 
       if (Exit.isSuccess(result)) {
         return result.value
       }
 
-      yield* Scope.close(attemptScope, result)
+      const closeExit = yield* Effect.exit(Scope.close(attemptScope, result))
+      if (Exit.isFailure(closeExit)) {
+        return yield* Effect.failCause(Cause.combine(result.cause, closeExit.cause))
+      }
       return yield* Effect.failCause(result.cause)
     }),
+  )
+
+const acquireFreshLayer = <A, E, R>(
+  layer: Layer.Layer<A, E, R>,
+  scope: Scope.Scope,
+): Effect.Effect<Context.Context<A>, E, R> =>
+  scopedAcquisition(
+    (attemptScope) => Layer.buildWithMemoMap(Layer.fresh(layer), Layer.makeMemoMapUnsafe(), attemptScope),
+    scope,
   )
 
 /**


### PR DESCRIPTION
## Summary

- Replace retry-time `Layer.build` with a dedicated scoped resource boundary that retries ordinary acquisition effects.
- Close failed and interrupted layer attempts immediately while retaining the successful attempt under the caller scope.
- Map Alpaca HTTP acquisition failures at the same resource boundary, preserving typed redacted session errors and identity.
- Name the capital-grant execution-store WriterFence interpreter boundary and add lifecycle, interruption, mapping, and delegation regressions.
- Scope is limited to the eight requested files under `services/bayn/src`.

## Related Issues

None.

## Testing

- `bun install --frozen-lockfile`
- `bun test src/resource-boundary.test.ts src/execution/writer-fence.test.ts src/broker/alpaca/session.test.ts src/operations.test.ts` — 22 passed, 0 failed.
- `bun run test` — 1,200 passed, 153 skipped, 0 failed.
- `bun run test:postgres` — 0 passed, 145 skipped, 0 failed; PostgreSQL integration cases were skipped because no test database URL is configured.
- `bun run lint`
- `bun run lint:effect`
- `bun run lint:oxlint` — 0 errors; one pre-existing warning in excluded candidate-development code.
- `bun run lint:oxlint:type` — 0 errors; one pre-existing warning in excluded candidate-development code.
- `bun run tsc`
- `bun run build`

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; this is a backend resource/contract refactor.
- [x] No documentation, release notes, or follow-ups are required for this internal refactor.
