### PR TITLE
refactor(bayn): decompose observe mutation orchestration

### DIFF
--- a/services/bayn/src/observe-composition.test.ts
+++ b/services/bayn/src/observe-composition.test.ts
@@ -790,6 +790,31 @@ describe('OBSERVE runtime composition', () => {
     ).toBe('unknown-order')
   })
 
+  test('chooses cancellation recovery before submit recovery and fresh-policy gates', async () => {
+    const fixture = await paperLifecycleFixture()
+    const event = (operation: MutationOperation, eventType: MutationEventType): MutationEvent => ({
+      schemaVersion: 'bayn.paper-mutation-event.v1',
+      eventId: canonicalHashV1({ operation, eventType, intentId: fixture.intent.intentId }),
+      mutationId: canonicalHashV1({ operation, intentId: fixture.intent.intentId }),
+      intentId: fixture.intent.intentId,
+      sequence: 2,
+      operation,
+      eventType,
+      requestHash: '1'.repeat(64),
+      consistencyDelayMs: 1_000,
+      occurredAt: fixture.document.createdAt,
+    })
+
+    const submit = event(MutationOperation.Submit, MutationEventType.SubmitAccepted)
+    const cancel = event(MutationOperation.Cancel, MutationEventType.CancelUnknown)
+
+    expect(Result.getOrThrow(decidePreparedMutationRecovery(fixture.intent, submit, cancel))).toEqual({
+      _tag: 'Recover',
+      operation: MutationOperation.Cancel,
+      event: cancel,
+    })
+  })
+
   test('keeps OBSERVE recovery-only execution lookup-capable while fresh submit remains structurally unavailable', async () => {
     const fixture = await paperLifecycleFixture()
     const occurredAt = fixture.document.createdAt

--- a/services/bayn/src/observe-composition.ts
+++ b/services/bayn/src/observe-composition.ts
@@ -2,13 +2,7 @@ import { Clock, Data, Duration, Effect, Option, Ref, Result } from 'effect'
 
 import type { AutonomousCycleLoop, AutonomousCycleStartup } from './app'
 import { BrokerRead, type BrokerReadShape, type MarketCalendarQuery } from './broker/alpaca'
-import {
-  CycleState,
-  CycleTerminalReason,
-  makeCycleExecutionPolicyFromModel,
-  type AutonomousCycle,
-  type CycleExecutionPolicy,
-} from './cycle'
+import { CycleState, makeCycleExecutionPolicyFromModel, type AutonomousCycle, type CycleExecutionPolicy } from './cycle'
 import {
   CycleDecisionBuildError,
   CycleRunnerError,
@@ -39,8 +33,8 @@ import { WriterFence } from './execution/writer-fence'
 import { MutationOperation } from './broker/alpaca-mutations'
 import { recover as recoverMutation } from './execution/coordinator'
 import { BrokerAccess, CapitalAuthorityKind } from './execution/authority'
-import { IntentStore, planPaperIntent, type StoredIntent } from './execution/intents'
-import { MutationEventType, MutationStore, type MutationEvent } from './execution/mutations'
+import { IntentStore } from './execution/intents'
+import { MutationStore } from './execution/mutations'
 import type { ExecutionProgram } from './execution/runtime-program'
 import {
   bindCycleExecutionSession,
@@ -52,21 +46,7 @@ import { makeStrategyProtocolHash } from './contracts'
 import { OperationalError, operationalError } from './errors'
 import { canonicalHashV1Result } from './hash'
 import { MarketData, type MarketDataService } from './market-data'
-import {
-  Authority,
-  IntentState,
-  KillState,
-  OrderSide,
-  OrderStatus,
-  OrderType,
-  ReconciliationStatus,
-  TerminalOutcome,
-  TimeInForce,
-  type AuthorityState,
-  type Intent,
-  type Order,
-  type Position,
-} from './execution/contracts'
+import { Authority, OrderSide, OrderType, TimeInForce, type AuthorityState } from './execution/contracts'
 import type { CausalProtocol } from './protocol'
 import { runOnce, type ReconciliationPassResult } from './reconciler'
 import { reconciledStateHash } from './reconciliation'
@@ -85,14 +65,74 @@ import type {
 import { currentUtcInstant } from './time'
 import {
   planTargets,
-  TargetPlanStatus,
-  type PlannedTargetQuantity,
   type SignalSessionReferencePrices,
   type TargetPlannerInput,
   type TargetPlannerFailure,
   type TargetPlanResult,
 } from './target-planner'
 import type { CurrentStrategyDecision, Strategy } from './strategy'
+import {
+  appendPendingMutationOrder,
+  decideMutationIntentSettlement,
+  decidePaperCycleCompletion,
+  decidePreparedMutationIntent,
+  decidePreparedMutationIntentAdmission,
+  decidePreparedMutationRecovery,
+  expiredPaperPlanTerminalReason,
+  mutationIntentReconciliationDelayMs,
+  mutationRecoveryIsDue,
+  paperSubmitExpiresAt,
+  projectWorstCasePendingMutationPosition,
+  type BoundMutationCycleOutcome,
+  type MutationIntentExecutionResult,
+  type PaperCycleIntentTerminalEvidence,
+  type PaperCycleReconciliationEvidence,
+  type PaperCycleCompletionDecision,
+  type PreparedMutationCycleStep,
+  type PreparedMutationIntentAdmissionFailure,
+  type PreparedMutationIntentDecision,
+  type PreparedMutationIntentDecisionFailure,
+  type PreparedMutationRecoveryDecision,
+  type MutationIntentSettlementDecision,
+} from './observe-composition/mutation-decisions'
+import {
+  executeMutationIntent,
+  executeMutationIntentWithExecutor,
+  mutationRunnerError,
+  restrictMutationAuthority,
+  restrictMutationLoopFailure,
+} from './observe-composition/mutation-interpreter'
+import {
+  prepareMutationIntent,
+  type MutationPreparationFacts,
+  type MutationPreparationFactsRequest,
+} from './observe-composition/mutation-intent-interpreter'
+
+export {
+  appendPendingMutationOrder,
+  decideMutationIntentSettlement,
+  decidePaperCycleCompletion,
+  decidePreparedMutationIntent,
+  decidePreparedMutationIntentAdmission,
+  decidePreparedMutationRecovery,
+  executeMutationIntent,
+  expiredPaperPlanTerminalReason,
+  mutationIntentReconciliationDelayMs,
+  mutationRecoveryIsDue,
+  paperSubmitExpiresAt,
+  projectWorstCasePendingMutationPosition,
+}
+export type {
+  MutationIntentExecutionResult,
+  MutationIntentSettlementDecision,
+  PaperCycleCompletionDecision,
+  PaperCycleIntentTerminalEvidence,
+  PaperCycleReconciliationEvidence,
+  PreparedMutationIntentAdmissionFailure,
+  PreparedMutationIntentDecision,
+  PreparedMutationIntentDecisionFailure,
+  PreparedMutationRecoveryDecision,
+}
 
 const observeRiskLimits = {
   maxOrderNotionalMicros: '600000000',
@@ -128,7 +168,7 @@ class ReconciliationPassTimeoutError extends Data.TaggedError('ReconciliationPas
   readonly message: string
 }> {}
 
-type ReconciliationPassError = Effect.Error<typeof runOnce> | ReconciliationPassTimeoutError
+export type ReconciliationPassError = Effect.Error<typeof runOnce> | ReconciliationPassTimeoutError
 
 const boundedReconciliationPass = (
   timeoutMs: number,
@@ -710,9 +750,6 @@ const initializeObserveAuthority = (
     Effect.flatMap((authority) => Effect.fromResult(validateObserveAuthorityInitialization(authority, input))),
   )
 
-const mutationConsistencyDelayMs = 1_000
-const quantityScale = 1_000_000n
-
 export type MutationAutonomousCycleInput = ObserveAutonomousCycleInput & {
   readonly executionProgram: ExecutionProgram
 }
@@ -721,27 +758,10 @@ type PaperExecutionCapability =
   | { readonly _tag: 'RecoveryOnly' }
   | { readonly _tag: 'Mutation'; readonly executionProgram: ExecutionProgram }
 
-type PaperMutationExecutor<E, R> = {
-  readonly submit?: (intentId: string, consistencyDelayMs: number) => Effect.Effect<MutationEvent, E, R>
-  readonly recover: (intentId: string, operation: MutationOperation) => Effect.Effect<MutationEvent, E, R>
-}
-
 type RecoveryFirstDecisionBuilder = (
   cycle: AutonomousCycle,
   reconcile: Effect.Effect<ReconciliationPassResult, ReconciliationPassError, ObserveDecisionRuntime>,
 ) => Effect.Effect<CycleDecisionDocument, CycleDecisionBuildError, ObserveDecisionRuntime>
-
-const mutationRunnerError = (
-  message: string,
-  cause?: unknown,
-  failure: CycleRunnerError['failure'] = 'operational',
-): CycleRunnerError =>
-  new CycleRunnerError({
-    operation: 'recover-cycle',
-    failure,
-    message,
-    cause,
-  })
 
 const configuredMutationGeneration = (input: MutationAutonomousCycleInput): string | undefined => {
   const capital = input.executionProgram.authority.capitalAuthority
@@ -772,97 +792,6 @@ const validateMutationExecutionProgram = (
           'config',
           'cycle-loop',
           'mutation cycle execution program does not match its account, authority generation, and strategy',
-        ),
-      )
-    : Result.succeed(undefined)
-}
-
-const comparePositionSymbol = (left: Position, right: Position): number =>
-  left.symbol < right.symbol ? -1 : left.symbol > right.symbol ? 1 : 0
-
-const divideAwayFromZero = (numerator: bigint): bigint => {
-  const magnitude = numerator < 0n ? -numerator : numerator
-  const rounded = magnitude === 0n ? 0n : (magnitude + quantityScale - 1n) / quantityScale
-  return numerator < 0n ? -rounded : rounded
-}
-
-const projectMutationPosition = (
-  positions: readonly Position[],
-  target: PlannedTargetQuantity,
-  accountId: string,
-  observedAt: string,
-): readonly Position[] => {
-  const retained = positions.filter((position) => position.symbol !== target.symbol)
-  const quantity = BigInt(target.targetQuantityMicros)
-  if (quantity === 0n) return retained
-  const previous = positions.find((position) => position.symbol === target.symbol)
-  const referencePrice = BigInt(target.referencePriceMicros)
-  const averageEntryPrice = BigInt(previous?.averageEntryPriceMicros ?? target.referencePriceMicros)
-  const projected: Position = {
-    schemaVersion: 'bayn.paper-position.v1',
-    accountId: previous?.accountId ?? accountId,
-    symbol: target.symbol,
-    quantityMicros: target.targetQuantityMicros,
-    averageEntryPriceMicros: averageEntryPrice.toString(),
-    marketPriceMicros: target.referencePriceMicros,
-    marketValueMicros: divideAwayFromZero(quantity * referencePrice).toString(),
-    unrealizedPnlMicros: divideAwayFromZero(quantity * (referencePrice - averageEntryPrice)).toString(),
-    observedAt: previous?.observedAt ?? observedAt,
-  }
-  return [...retained, projected].sort(comparePositionSymbol)
-}
-
-export const projectWorstCasePendingMutationPosition = (
-  positions: readonly Position[],
-  target: PlannedTargetQuantity,
-  accountId: string,
-  observedAt: string,
-): readonly Position[] => {
-  const current = positions.find((position) => position.symbol === target.symbol)
-  const currentQuantity = current === undefined ? 0n : BigInt(current.quantityMicros)
-  const targetQuantity = BigInt(target.targetQuantityMicros)
-  return targetQuantity <= currentQuantity
-    ? positions
-    : projectMutationPosition(positions, target, accountId, observedAt)
-}
-
-const validateBoundMutationDocument = (
-  input: ObserveAutonomousCycleInput,
-  cycle: AutonomousCycle,
-  document: PaperDecisionDocument,
-): Result.Result<void, CycleRunnerError> => {
-  return cycle.state !== CycleState.Active ||
-    cycle.bindings.decisionHash !== document.contentHash ||
-    cycle.bindings.snapshotId !== document.bindings.snapshotId ||
-    cycle.identity.cycleId !== document.bindings.cycleId ||
-    cycle.identity.qualificationRunId !== document.bindings.qualificationRunId ||
-    cycle.identity.accountId !== document.bindings.accountId ||
-    cycle.identity.strategyProtocolHash !== document.bindings.strategyProtocolHash ||
-    input.accountId !== document.bindings.accountId
-    ? Result.fail(
-        mutationRunnerError(
-          'durable shadow plan does not match the mutation cycle account, protocol, and decision binding',
-          undefined,
-          'contract',
-        ),
-      )
-    : Result.succeed(undefined)
-}
-
-const validateCurrentMutationPolicy = (
-  policy: Policy,
-  document: PaperDecisionDocument,
-): Result.Result<void, CycleRunnerError> => {
-  const policyHash = canonicalHashV1Result(policy)
-  if (Result.isFailure(policyHash)) {
-    return Result.fail(mutationRunnerError('mutation cycle risk policy is not canonicalizable', policyHash.failure))
-  }
-  return policyHash.success !== document.bindings.policyHash
-    ? Result.fail(
-        mutationRunnerError(
-          'current source-controlled PAPER risk policy changed from the durable decision binding',
-          undefined,
-          'contract',
         ),
       )
     : Result.succeed(undefined)
@@ -900,599 +829,22 @@ const mutationDecisionInput = (
   strategy: input.strategy,
 })
 
-export type PreparedMutationIntentDecision =
-  | { readonly _tag: 'Submit' }
-  | { readonly _tag: 'Recover'; readonly eventType: MutationEventType }
-  | { readonly _tag: 'Pending'; readonly order: Order }
-  | { readonly _tag: 'SkipTerminal' }
-
-export type PreparedMutationIntentDecisionFailure = {
-  readonly _tag: 'PreparedMutationIntentDecisionFailure'
-  readonly intentId: string
-  readonly message: string
-  readonly eventType?: MutationEventType
-}
-
-export const decidePreparedMutationIntent = (
-  intent: Intent,
-  latest: MutationEvent | undefined,
-): Result.Result<PreparedMutationIntentDecision, PreparedMutationIntentDecisionFailure> => {
-  if (intent.state === IntentState.Terminal) return Result.succeed({ _tag: 'SkipTerminal' })
-  if (latest === undefined) return Result.succeed({ _tag: 'Submit' })
-  switch (latest.eventType) {
-    case MutationEventType.SubmitAccepted:
-    case MutationEventType.RecoveryFound:
-      return latest.brokerOrderId === undefined
-        ? Result.fail({
-            _tag: 'PreparedMutationIntentDecisionFailure',
-            intentId: intent.intentId,
-            eventType: latest.eventType,
-            message: 'accepted nonterminal submit lacks a durable broker order identity',
-          })
-        : Result.succeed({
-            _tag: 'Pending',
-            order: {
-              schemaVersion: 'bayn.paper-order.v1',
-              accountId: intent.accountId,
-              brokerOrderId: latest.brokerOrderId,
-              clientOrderId: intent.clientOrderId,
-              intentId: intent.intentId,
-              symbol: intent.symbol,
-              side: intent.side,
-              orderType: intent.orderType,
-              timeInForce: intent.timeInForce,
-              quantityMicros: intent.quantityMicros,
-              filledQuantityMicros: '0',
-              status: OrderStatus.New,
-              observedAt: latest.occurredAt,
-            },
-          })
-    case MutationEventType.SubmitRejected:
-    case MutationEventType.SubmitDenied:
-      return Result.fail({
-        _tag: 'PreparedMutationIntentDecisionFailure',
-        intentId: intent.intentId,
-        eventType: latest.eventType,
-        message: 'terminal submit event does not match the nonterminal durable intent state',
-      })
-    case MutationEventType.SubmitStarted:
-    case MutationEventType.SubmitUnknown:
-    case MutationEventType.RecoveryNotFound:
-    case MutationEventType.RecoveryUnknown:
-    case MutationEventType.CancelStarted:
-    case MutationEventType.CancelAccepted:
-    case MutationEventType.CancelUnknown:
-      return Result.succeed({ _tag: 'Recover', eventType: latest.eventType })
-  }
-}
-
-export type PreparedMutationIntentAdmissionFailure = {
-  readonly _tag: 'PreparedMutationIntentAdmissionFailure'
-  readonly reason:
-    | 'accounting-inexact'
-    | 'authority'
-    | 'expiry'
-    | 'reconciliation-not-exact'
-    | 'unknown-mutation'
-    | 'unknown-order'
-  readonly message: string
-}
-
-export const decidePreparedMutationIntentAdmission = (
-  prepared: PreparedMutationIntentDecision,
-  effectiveAuthority: Authority,
-  observedAt: string,
-  expiresAt: string,
-  unknownMutationCount: number,
-  reconciliationStatus: ReconciliationStatus = ReconciliationStatus.Exact,
-  accountingExact = true,
-  unknownOrderCount = 0,
-): Result.Result<void, PreparedMutationIntentAdmissionFailure> => {
-  if (prepared._tag !== 'Submit') return Result.succeed(undefined)
-  if (effectiveAuthority !== Authority.Paper) {
-    return Result.fail({
-      _tag: 'PreparedMutationIntentAdmissionFailure',
-      reason: 'authority',
-      message: 'fresh PAPER submit requires current effective PAPER authority',
-    })
-  }
-  if (observedAt >= expiresAt) {
-    return Result.fail({
-      _tag: 'PreparedMutationIntentAdmissionFailure',
-      reason: 'expiry',
-      message: 'fresh PAPER submit is forbidden at or after decision expiry',
-    })
-  }
-  if (reconciliationStatus !== ReconciliationStatus.Exact) {
-    return Result.fail({
-      _tag: 'PreparedMutationIntentAdmissionFailure',
-      reason: 'reconciliation-not-exact',
-      message: 'fresh PAPER submit requires exact same-pass reconciliation',
-    })
-  }
-  if (!accountingExact) {
-    return Result.fail({
-      _tag: 'PreparedMutationIntentAdmissionFailure',
-      reason: 'accounting-inexact',
-      message: 'fresh PAPER submit requires exact same-pass accounting',
-    })
-  }
-  if (unknownMutationCount !== 0) {
-    return Result.fail({
-      _tag: 'PreparedMutationIntentAdmissionFailure',
-      reason: 'unknown-mutation',
-      message: 'fresh PAPER submit is forbidden while a mutation outcome is unknown',
-    })
-  }
-  if (unknownOrderCount !== 0) {
-    return Result.fail({
-      _tag: 'PreparedMutationIntentAdmissionFailure',
-      reason: 'unknown-order',
-      message: 'fresh PAPER submit is forbidden while a broker order is unknown',
-    })
-  }
-  return Result.succeed(undefined)
-}
-
-export const appendPendingMutationOrder = (orders: readonly Order[], pending: Order): readonly Order[] =>
-  orders.some((order) => order.brokerOrderId === pending.brokerOrderId || order.clientOrderId === pending.clientOrderId)
-    ? orders
-    : [...orders, pending]
-
-export interface PaperCycleIntentTerminalEvidence {
-  readonly state: IntentState
-  readonly terminalOutcome?: TerminalOutcome
-  readonly updatedAt: string
-  readonly latestMutationAt?: string
-}
-
-export interface PaperCycleReconciliationEvidence {
-  readonly status: ReconciliationStatus
-  readonly reconciledAt: string
-  readonly accountingExact: boolean
-  readonly unknownMutationCount: number
-  readonly unknownOrderCount: number
-}
-
-export type PaperCycleCompletionDecision =
-  | { readonly _tag: 'Complete' }
-  | {
-      readonly _tag: 'Wait'
-      readonly reason:
-        | 'accounting-inexact'
-        | 'intent-nonterminal'
-        | 'intent-unsuccessful'
-        | 'reconciliation-not-later'
-        | 'reconciliation-not-exact'
-        | 'unknown-mutation'
-        | 'unknown-order'
-    }
-
-export const decidePaperCycleCompletion = (
-  documentCreatedAt: string,
-  intents: readonly PaperCycleIntentTerminalEvidence[],
-  reconciliation: PaperCycleReconciliationEvidence,
-): PaperCycleCompletionDecision => {
-  if (intents.some((intent) => intent.state !== IntentState.Terminal)) {
-    return { _tag: 'Wait', reason: 'intent-nonterminal' }
-  }
-  if (intents.some((intent) => intent.terminalOutcome !== TerminalOutcome.Filled)) {
-    return { _tag: 'Wait', reason: 'intent-unsuccessful' }
-  }
-  if (reconciliation.status !== ReconciliationStatus.Exact) {
-    return { _tag: 'Wait', reason: 'reconciliation-not-exact' }
-  }
-  if (!reconciliation.accountingExact) return { _tag: 'Wait', reason: 'accounting-inexact' }
-  if (reconciliation.unknownMutationCount !== 0) return { _tag: 'Wait', reason: 'unknown-mutation' }
-  if (reconciliation.unknownOrderCount !== 0) return { _tag: 'Wait', reason: 'unknown-order' }
-  const latestEvidenceAt = Math.max(
-    Date.parse(documentCreatedAt),
-    ...intents.flatMap((intent) => [
-      Date.parse(intent.updatedAt),
-      Date.parse(intent.latestMutationAt ?? intent.updatedAt),
-    ]),
-  )
-  if (Date.parse(reconciliation.reconciledAt) <= latestEvidenceAt) {
-    return { _tag: 'Wait', reason: 'reconciliation-not-later' }
-  }
-  return { _tag: 'Complete' }
-}
-
-type PreparedPaperIntent = {
-  readonly intent: Intent
-  readonly targetIntent: PaperDecisionDocument['targetPlan']['intentTargets'][number]
-  readonly target: PlannedTargetQuantity
-  readonly riskBinding: PaperDecisionDocument['deltaRisk'][number]
-  readonly stored: StoredIntent | undefined
-  readonly latestSubmit: MutationEvent | undefined
-  readonly latestCancel: MutationEvent | undefined
-}
-
-type PaperIntentRecoveryLookup = Omit<PreparedPaperIntent, 'intent'> & {
-  readonly intentId: string
-}
-
-export type PreparedMutationRecoveryDecision =
-  | { readonly _tag: 'NoRecovery' }
-  | {
-      readonly _tag: 'Recover'
-      readonly operation: MutationOperation
-      readonly event: MutationEvent
-    }
-
-export const decidePreparedMutationRecovery = (
-  intent: Intent,
-  latestSubmit: MutationEvent | undefined,
-  latestCancel: MutationEvent | undefined,
-): Result.Result<PreparedMutationRecoveryDecision, PreparedMutationIntentDecisionFailure> => {
-  if (latestCancel !== undefined) {
-    if (latestCancel.operation !== MutationOperation.Cancel) {
-      return Result.fail({
-        _tag: 'PreparedMutationIntentDecisionFailure',
-        intentId: intent.intentId,
-        eventType: latestCancel.eventType,
-        message: 'durable cancellation recovery read returned a non-cancel mutation',
-      })
-    }
-    return intent.state === IntentState.Terminal && latestCancel.eventType === MutationEventType.RecoveryFound
-      ? Result.succeed({ _tag: 'NoRecovery' })
-      : Result.succeed({ _tag: 'Recover', operation: MutationOperation.Cancel, event: latestCancel })
-  }
-  if (latestSubmit === undefined) return Result.succeed({ _tag: 'NoRecovery' })
-  if (latestSubmit.operation !== MutationOperation.Submit) {
-    return Result.fail({
-      _tag: 'PreparedMutationIntentDecisionFailure',
-      intentId: intent.intentId,
-      eventType: latestSubmit.eventType,
-      message: 'durable submit recovery read returned a non-submit mutation',
-    })
-  }
-  if (
-    intent.state === IntentState.Terminal &&
-    (latestSubmit.eventType === MutationEventType.SubmitAccepted ||
-      latestSubmit.eventType === MutationEventType.SubmitRejected ||
-      latestSubmit.eventType === MutationEventType.SubmitDenied ||
-      latestSubmit.eventType === MutationEventType.RecoveryFound)
-  ) {
-    return Result.succeed({ _tag: 'NoRecovery' })
-  }
-  if (
-    intent.state !== IntentState.Terminal &&
-    (latestSubmit.eventType === MutationEventType.SubmitRejected ||
-      latestSubmit.eventType === MutationEventType.SubmitDenied)
-  ) {
-    return Result.fail({
-      _tag: 'PreparedMutationIntentDecisionFailure',
-      intentId: intent.intentId,
-      eventType: latestSubmit.eventType,
-      message: 'terminal submit event does not match the nonterminal durable intent state',
-    })
-  }
-  return Result.succeed({ _tag: 'Recover', operation: MutationOperation.Submit, event: latestSubmit })
-}
-
-type PreparedMutationCycleStep =
-  | { readonly _tag: 'RunCycle' }
-  | {
-      readonly _tag: 'Execute'
-      readonly action: 'RECOVER_SUBMIT' | 'RECOVER_CANCEL'
-      readonly intentId: string
-      readonly observedAt: string
-    }
-  | {
-      readonly _tag: 'Execute'
-      readonly action: 'SUBMIT'
-      readonly intentId: string
-      readonly observedAt: string
-      readonly submitExpiresAt: string
-    }
-  | {
-      readonly _tag: 'Block'
-      readonly reason:
-        | CycleTerminalReason.MissedSubmission
-        | CycleTerminalReason.ProvenanceMismatch
-        | CycleTerminalReason.Risk
-      readonly observedAt: string
-    }
-  | { readonly _tag: 'Wait'; readonly observedAt: string }
-  | { readonly _tag: 'Complete'; readonly observedAt: string }
-
-type BoundMutationCycleOutcome = Exclude<PreparedMutationCycleStep, { readonly _tag: 'Execute' }>
-
-export const mutationRecoveryIsDue = (event: MutationEvent, observedAt: string): boolean =>
-  Date.parse(observedAt) >= Date.parse(event.occurredAt) + event.consistencyDelayMs
-
-export const paperSubmitExpiresAt = (documentExpiresAt: string, riskDecisionExpiresAt: string): string =>
-  riskDecisionExpiresAt < documentExpiresAt ? riskDecisionExpiresAt : documentExpiresAt
-
-export const expiredPaperPlanTerminalReason = (
-  observedAt: string,
-  submitExpiresAt: string,
-  submissionCutoffAt: string,
-): CycleTerminalReason.MissedSubmission | CycleTerminalReason.Risk | undefined =>
-  observedAt < submitExpiresAt
-    ? undefined
-    : observedAt >= submissionCutoffAt
-      ? CycleTerminalReason.MissedSubmission
-      : CycleTerminalReason.Risk
-
-const boundPaperSubmissionCutoff = (
-  cycle: AutonomousCycle,
-  document: PaperDecisionDocument,
-): Result.Result<string, CycleRunnerError> => {
-  if (
-    document.submissionCutoffAt !== cycle.window.submissionCutoffAt ||
-    document.expiresAt !== cycle.window.submissionCutoffAt
-  ) {
-    return Result.fail(
-      mutationRunnerError(
-        'durable PAPER decision changed from its immutable cycle submission window',
-        undefined,
-        'contract',
-      ),
-    )
-  }
-  return Result.succeed(cycle.window.submissionCutoffAt)
-}
-
-const immutableIntentBindingMatches = (stored: Intent, expected: Intent): boolean =>
-  stored.schemaVersion === expected.schemaVersion &&
-  stored.intentId === expected.intentId &&
-  stored.authorityGenerationHash === expected.authorityGenerationHash &&
-  stored.strategyName === expected.strategyName &&
-  stored.cycleId === expected.cycleId &&
-  stored.decisionHash === expected.decisionHash &&
-  stored.policyHash === expected.policyHash &&
-  stored.accountId === expected.accountId &&
-  stored.clientOrderId === expected.clientOrderId &&
-  stored.symbol === expected.symbol &&
-  stored.side === expected.side &&
-  stored.orderType === expected.orderType &&
-  stored.timeInForce === expected.timeInForce &&
-  stored.quantityMicros === expected.quantityMicros &&
-  stored.notionalLimitMicros === expected.notionalLimitMicros &&
-  stored.createdAt === expected.createdAt
-
-const validateCurrentMutationExecutionTerms = (
-  preparation: ObserveStartupPreparation,
-  targetIntent: PaperDecisionDocument['targetPlan']['intentTargets'][number],
-  target: PlannedTargetQuantity,
-  riskBinding: PaperDecisionDocument['deltaRisk'][number],
-): Result.Result<void, CycleRunnerError> => {
-  const fillTerms = makeFillTerms(
-    targetIntent.side === OrderSide.Buy ? 'buy' : 'sell',
-    BigInt(targetIntent.quantityMicros),
-    BigInt(target.referencePriceMicros),
-    preparation.executionModel,
-    MICROS,
-  )
-  if (Result.isFailure(fillTerms)) {
-    return Result.fail(mutationRunnerError('mutation execution terms are invalid', fillTerms.failure, 'contract'))
-  }
-  return fillTerms.success.notionalMicros.toString() === riskBinding.notionalLimitMicros
-    ? Result.succeed(undefined)
-    : Result.fail(
-        mutationRunnerError(
-          'durable mutation notional changed from the current execution model',
-          undefined,
-          'contract',
-        ),
-      )
-}
-
-export const prepareNextMutationIntent = (
-  input: ObserveAutonomousCycleInput,
-  preparation: ObserveStartupPreparation,
-  policy: Policy,
-  cycle: AutonomousCycle,
-  document: PaperDecisionDocument,
-  reconcile: Effect.Effect<ReconciliationPassResult, ReconciliationPassError, ObserveDecisionRuntime>,
-  allowSubmit = true,
-): Effect.Effect<PreparedMutationCycleStep, CycleRunnerError, ObserveDecisionRuntime | IntentStore | MutationStore> =>
+const readMutationPreparationFacts = (
+  request: MutationPreparationFactsRequest<
+    ObserveDecisionRuntime,
+    ReconciliationPassError,
+    ObserveAutonomousCycleInput,
+    ObserveStartupPreparation
+  >,
+): Effect.Effect<MutationPreparationFacts, CycleRunnerError, ObserveDecisionRuntime> =>
   Effect.gen(function* () {
-    yield* Effect.fromResult(validateBoundMutationDocument(input, cycle, document))
-    const submissionCutoffAt = yield* Effect.fromResult(boundPaperSubmissionCutoff(cycle, document))
-    const generationIsSuperseded = input.authorityGenerationHash !== document.bindings.authorityGenerationHash
-    if (document.riskBlock !== undefined) {
-      return {
-        _tag: 'Block',
-        reason: CycleTerminalReason.Risk,
-        observedAt: yield* currentUtcInstant,
-      }
-    }
-    if (document.targetPlan.status !== TargetPlanStatus.Planned) return { _tag: 'RunCycle' }
-
-    const intentStore = yield* IntentStore
-    const mutationStore = yield* MutationStore
-    const targets = new Map(document.targetPlan.targets.map((target) => [target.symbol, target]))
-    const documentAuthority: AuthorityState = {
-      schemaVersion: 'bayn.paper-authority.v1',
-      generationHash: document.bindings.authorityGenerationHash,
-      maximum: Authority.Paper,
-      effective: Authority.Paper,
-      kill: KillState.Clear,
-      version: 1,
-      updatedAt: document.createdAt,
-    }
-    const recoveryLookups: PaperIntentRecoveryLookup[] = []
-
-    for (const [index, targetIntent] of document.targetPlan.intentTargets.entries()) {
-      const riskBinding = document.deltaRisk[index]
-      const target = targets.get(targetIntent.symbol)
-      const intentId = document.orderedIntentIds[index]
-      if (riskBinding === undefined || target === undefined || intentId === undefined) {
-        return yield* Effect.fail(
-          mutationRunnerError(
-            'durable mutation target is missing its intent, risk, or final-position binding',
-            undefined,
-            'contract',
-          ),
-        )
-      }
-      const stored = yield* intentStore
-        .read(intentId)
-        .pipe(
-          Effect.mapError((cause) => mutationRunnerError('durable PAPER intent recovery read failed', cause, 'store')),
-        )
-      const existing = Option.getOrUndefined(stored)
-      const latestSubmit = yield* mutationStore
-        .latest(intentId, MutationOperation.Submit)
-        .pipe(Effect.mapError((cause) => mutationRunnerError('durable submit state read failed', cause, 'store')))
-      const latestCancel = yield* mutationStore
-        .latest(intentId, MutationOperation.Cancel)
-        .pipe(Effect.mapError((cause) => mutationRunnerError('durable cancel state read failed', cause, 'store')))
-      if (existing === undefined && (latestSubmit !== undefined || latestCancel !== undefined)) {
-        return yield* Effect.fail(
-          mutationRunnerError(
-            'durable mutation exists without its authority-bound intent',
-            { latestSubmit, latestCancel },
-            'contract',
-          ),
-        )
-      }
-      if (existing !== undefined && existing.intent.intentId !== intentId) {
-        return yield* Effect.fail(
-          mutationRunnerError(
-            'durable PAPER intent recovery returned a different intent identity',
-            undefined,
-            'contract',
-          ),
-        )
-      }
-      recoveryLookups.push({
-        intentId,
-        targetIntent,
-        target,
-        riskBinding,
-        stored: existing,
-        latestSubmit,
-        latestCancel,
-      })
-    }
-
-    const preparedIntents: PreparedPaperIntent[] = []
-    for (const lookup of recoveryLookups) {
-      const intent = yield* planPaperIntent(
-        {
-          schemaVersion: 'bayn.paper-intent-plan.v1',
-          ...lookup.targetIntent,
-          notionalLimitMicros: lookup.riskBinding.notionalLimitMicros,
-          createdAt: document.createdAt,
-        },
-        { authority: documentAuthority },
-      ).pipe(
-        Effect.mapError((cause) =>
-          mutationRunnerError('durable PAPER intent reconstruction failed', cause, 'contract'),
-        ),
-      )
-      if (lookup.intentId !== intent.intentId) {
-        return yield* Effect.fail(
-          mutationRunnerError(
-            'durable PAPER intent identity or order changed after decision binding',
-            undefined,
-            'contract',
-          ),
-        )
-      }
-      if (lookup.stored !== undefined && !immutableIntentBindingMatches(lookup.stored.intent, intent)) {
-        return yield* Effect.fail(
-          mutationRunnerError('stored PAPER intent changed from its durable decision binding', undefined, 'contract'),
-        )
-      }
-      preparedIntents.push({ ...lookup, intent })
-    }
-
-    const recoveryObservedAt = yield* currentUtcInstant
-    for (const prepared of preparedIntents) {
-      const existing = prepared.stored
-      if (existing === undefined) continue
-      const recovery = yield* Effect.fromResult(
-        decidePreparedMutationRecovery(existing.intent, prepared.latestSubmit, prepared.latestCancel),
-      ).pipe(Effect.mapError((cause) => mutationRunnerError(cause.message, cause, 'contract')))
-      if (recovery._tag === 'Recover') {
-        return mutationRecoveryIsDue(recovery.event, recoveryObservedAt)
-          ? {
-              _tag: 'Execute',
-              action:
-                recovery.operation === MutationOperation.Submit
-                  ? ('RECOVER_SUBMIT' as const)
-                  : ('RECOVER_CANCEL' as const),
-              intentId: prepared.intent.intentId,
-              observedAt: recoveryObservedAt,
-            }
-          : { _tag: 'Wait', observedAt: recoveryObservedAt }
-      }
-    }
-
-    if (generationIsSuperseded) {
-      return {
-        _tag: 'Block',
-        reason: CycleTerminalReason.ProvenanceMismatch,
-        observedAt: recoveryObservedAt,
-      }
-    }
-
-    yield* Effect.fromResult(validateCurrentMutationPolicy(policy, document))
-
-    const uncommittedIntents = preparedIntents.filter((prepared) => prepared.stored === undefined)
-    if (!allowSubmit && uncommittedIntents.length > 0) {
-      return { _tag: 'Wait', observedAt: recoveryObservedAt }
-    }
-    if (allowSubmit) {
-      for (const prepared of preparedIntents) {
-        const requiresFreshSubmission =
-          prepared.stored === undefined ||
-          (prepared.stored.intent.state !== IntentState.Terminal && prepared.latestSubmit === undefined)
-        if (!requiresFreshSubmission) continue
-        yield* Effect.fromResult(
-          validateCurrentMutationExecutionTerms(
-            preparation,
-            prepared.targetIntent,
-            prepared.target,
-            prepared.riskBinding,
-          ),
-        )
-      }
-    }
-    if (uncommittedIntents.length > 0) {
-      const commitObservedAt = yield* currentUtcInstant
-      const commitExpiresAt = uncommittedIntents.reduce(
-        (expiresAt, prepared) => paperSubmitExpiresAt(expiresAt, prepared.riskBinding.evaluation.decision.expiresAt),
-        document.expiresAt,
-      )
-      const expirationReason = expiredPaperPlanTerminalReason(commitObservedAt, commitExpiresAt, submissionCutoffAt)
-      if (expirationReason !== undefined) {
-        return {
-          _tag: 'Block',
-          reason: expirationReason,
-          observedAt: commitObservedAt,
-        }
-      }
-      if (
-        preparedIntents.some((prepared) => prepared.latestSubmit !== undefined || prepared.latestCancel !== undefined)
-      ) {
-        return yield* Effect.fail(
-          mutationRunnerError(
-            'broker mutation evidence exists before the complete immutable intent set was committed',
-            undefined,
-            'contract',
-          ),
-        )
-      }
-    }
-
-    yield* Effect.forEach(
-      preparedIntents,
-      (prepared) =>
-        intentStore
-          .commit(prepared.intent, prepared.riskBinding.evaluation.decision)
-          .pipe(
-            Effect.mapError((cause) => mutationRunnerError('durable PAPER intent-set commit failed', cause, 'store')),
-          ),
-      { concurrency: 1, discard: true },
+    const decisionInput = mutationDecisionInput(
+      request.input,
+      request.preparation,
+      request.policy,
+      request.cycle,
+      request.reconcile,
     )
-
-    const decisionInput = mutationDecisionInput(input, preparation, policy, cycle, reconcile)
     const reads = yield* Effect.fromResult(prepareObserveDecisionReads(decisionInput)).pipe(
       Effect.mapError((cause) => mutationRunnerError('mutation cycle decision reads are invalid', cause, 'contract')),
     )
@@ -1503,275 +855,30 @@ export const prepareNextMutationIntent = (
       }),
     )
     const authority = yield* Effect.fromResult(
-      requireMutationAuthorityGeneration(facts.reconciliation, policy, input.authorityGenerationHash),
+      requireMutationAuthorityGeneration(facts.reconciliation, request.policy, request.input.authorityGenerationHash),
     ).pipe(Effect.mapError((cause) => mutationRunnerError(cause.message, cause, 'contract')))
-    if (
-      document.bindings.snapshotContentHash !== facts.snapshot.manifest.finalizedSnapshot.contentHash ||
-      document.bindings.snapshotFinalizedAt !== facts.snapshot.manifest.finalizedSnapshot.finalizedAt
-    ) {
-      return yield* Effect.fail(
-        mutationRunnerError('bound mutation cycle snapshot publication changed after planning', undefined, 'contract'),
-      )
+    return {
+      snapshot: facts.snapshot.manifest.finalizedSnapshot,
+      reconciliation: facts.reconciliation,
+      authority: authority.authority,
+      evaluatedAt: facts.evaluatedAt,
     }
-
-    const terminalEvidence: PaperCycleIntentTerminalEvidence[] = []
-    for (const prepared of preparedIntents) {
-      const stored = yield* intentStore
-        .read(prepared.intent.intentId)
-        .pipe(Effect.mapError((cause) => mutationRunnerError('committed PAPER intent readback failed', cause, 'store')))
-      const record = Option.getOrUndefined(stored)
-      if (record === undefined) {
-        return yield* Effect.fail(
-          mutationRunnerError('committed PAPER intent disappeared before execution selection', undefined, 'contract'),
-        )
-      }
-      const latest = yield* mutationStore
-        .latest(prepared.intent.intentId, MutationOperation.Submit)
-        .pipe(Effect.mapError((cause) => mutationRunnerError('durable submit state refresh failed', cause, 'store')))
-      const decision = yield* Effect.fromResult(decidePreparedMutationIntent(record.intent, latest)).pipe(
-        Effect.mapError((cause) => mutationRunnerError(cause.message, cause, 'contract')),
-      )
-      switch (decision._tag) {
-        case 'SkipTerminal':
-          terminalEvidence.push({
-            state: record.intent.state,
-            terminalOutcome: record.intent.terminalOutcome,
-            updatedAt: record.updatedAt,
-            ...(latest === undefined ? {} : { latestMutationAt: latest.occurredAt }),
-          })
-          if (record.intent.terminalOutcome !== TerminalOutcome.Filled) {
-            yield* restrictMutationAuthority(
-              `bound PAPER cycle ${cycle.identity.cycleId}`,
-              `intent ${prepared.intent.intentId} ended ${record.intent.terminalOutcome ?? 'without outcome'}`,
-            )
-            return {
-              _tag: 'Block',
-              reason: CycleTerminalReason.Risk,
-              observedAt: facts.evaluatedAt,
-            }
-          }
-          break
-        case 'Pending':
-          return latest !== undefined && mutationRecoveryIsDue(latest, facts.evaluatedAt)
-            ? {
-                _tag: 'Execute',
-                action: 'RECOVER_SUBMIT',
-                intentId: prepared.intent.intentId,
-                observedAt: facts.evaluatedAt,
-              }
-            : { _tag: 'Wait', observedAt: facts.evaluatedAt }
-        case 'Recover':
-          return latest !== undefined && mutationRecoveryIsDue(latest, facts.evaluatedAt)
-            ? {
-                _tag: 'Execute',
-                action: 'RECOVER_SUBMIT',
-                intentId: prepared.intent.intentId,
-                observedAt: facts.evaluatedAt,
-              }
-            : { _tag: 'Wait', observedAt: facts.evaluatedAt }
-        case 'Submit':
-          if (!allowSubmit) return { _tag: 'Wait', observedAt: facts.evaluatedAt }
-          const submitExpiresAt = paperSubmitExpiresAt(
-            submissionCutoffAt,
-            prepared.riskBinding.evaluation.decision.expiresAt,
-          )
-          const expirationReason = expiredPaperPlanTerminalReason(
-            facts.evaluatedAt,
-            submitExpiresAt,
-            submissionCutoffAt,
-          )
-          if (expirationReason !== undefined) {
-            return {
-              _tag: 'Block',
-              reason: expirationReason,
-              observedAt: facts.evaluatedAt,
-            }
-          }
-          yield* Effect.fromResult(
-            decidePreparedMutationIntentAdmission(
-              decision,
-              authority.authority.effective,
-              facts.evaluatedAt,
-              submitExpiresAt,
-              facts.reconciliation.riskContext.unknownMutationCount,
-              facts.reconciliation.brokerState.reconciliation.status,
-              facts.reconciliation.report.metrics.accountingExact,
-              facts.reconciliation.brokerState.unknownOrderCount,
-            ),
-          ).pipe(Effect.mapError((cause) => mutationRunnerError(cause.message, cause, 'contract')))
-          return {
-            _tag: 'Execute',
-            action: 'SUBMIT',
-            intentId: prepared.intent.intentId,
-            observedAt: facts.evaluatedAt,
-            submitExpiresAt,
-          }
-      }
-    }
-
-    const completion = decidePaperCycleCompletion(document.createdAt, terminalEvidence, {
-      status: facts.reconciliation.brokerState.reconciliation.status,
-      reconciledAt: facts.reconciliation.brokerState.reconciliation.reconciledAt,
-      accountingExact: facts.reconciliation.report.metrics.accountingExact,
-      unknownMutationCount: facts.reconciliation.riskContext.unknownMutationCount,
-      unknownOrderCount: facts.reconciliation.brokerState.unknownOrderCount,
-    })
-    return completion._tag === 'Complete'
-      ? { _tag: 'Complete', observedAt: facts.evaluatedAt }
-      : { _tag: 'Wait', observedAt: facts.evaluatedAt }
   })
 
-const submitDoesNotRequireRecovery = (eventType: MutationEventType): boolean =>
-  eventType === MutationEventType.SubmitRejected || eventType === MutationEventType.SubmitDenied
-
-export type MutationIntentSettlementDecision =
-  | {
-      readonly _tag: 'Settled'
-      readonly outcome: 'accepted' | 'rejected' | 'denied'
-    }
-  | {
-      readonly _tag: 'Unresolved'
-      readonly eventType: MutationEventType
-    }
-
-export const decideMutationIntentSettlement = (eventType: MutationEventType): MutationIntentSettlementDecision => {
-  switch (eventType) {
-    case MutationEventType.SubmitAccepted:
-    case MutationEventType.RecoveryFound:
-      return { _tag: 'Settled', outcome: 'accepted' }
-    case MutationEventType.SubmitRejected:
-      return { _tag: 'Settled', outcome: 'rejected' }
-    case MutationEventType.SubmitDenied:
-      return { _tag: 'Settled', outcome: 'denied' }
-    default:
-      return { _tag: 'Unresolved', eventType }
-  }
-}
-
-export interface MutationIntentExecutionResult {
-  readonly settlement: Extract<MutationIntentSettlementDecision, { readonly _tag: 'Settled' }>
-  readonly consistencyDelayMs: number
-  readonly operation: MutationOperation
-}
-
-export const mutationIntentReconciliationDelayMs = (result: MutationIntentExecutionResult): number =>
-  result.settlement.outcome === 'accepted' ? result.consistencyDelayMs : 0
-
-const restrictMutationAuthority = (
-  subject: string,
-  reason: string,
-): Effect.Effect<void, CycleRunnerError, AuthorityRestrictionStore | WriterFence> =>
-  Effect.gen(function* () {
-    const store = yield* AuthorityRestrictionStore
-    const fence = yield* WriterFence
-    const updatedAt = yield* currentUtcInstant
-    yield* fence
-      .transaction(store.restrictAuthority(`${subject} restricted effective authority: ${reason}`, updatedAt))
-      .pipe(
-        Effect.mapError((cause) =>
-          mutationRunnerError(
-            'authority restriction failed after a bound PAPER cycle failure',
-            { subject, reason, cause },
-            'store',
-          ),
-        ),
-      )
+export const prepareNextMutationIntent = (
+  input: ObserveAutonomousCycleInput,
+  preparation: ObserveStartupPreparation,
+  policy: Policy,
+  cycle: AutonomousCycle,
+  document: PaperDecisionDocument,
+  reconcile: Effect.Effect<ReconciliationPassResult, ReconciliationPassError, ObserveDecisionRuntime>,
+  allowSubmit = true,
+): Effect.Effect<PreparedMutationCycleStep, CycleRunnerError, ObserveDecisionRuntime | IntentStore | MutationStore> =>
+  prepareMutationIntent(input, preparation, policy, cycle, document, reconcile, allowSubmit, {
+    now: currentUtcInstant,
+    readFacts: readMutationPreparationFacts,
+    restrictAuthority: restrictMutationAuthority,
   })
-
-const restrictMutationLoopFailure = (
-  error: CycleRunnerError,
-): Effect.Effect<void, CycleRunnerError, AuthorityRestrictionStore | WriterFence> =>
-  restrictMutationAuthority('PAPER autonomous cycle loop', `${error.operation}: ${error.message}`)
-
-const executeMutationIntentWithExecutor = <E, R>(
-  executor: PaperMutationExecutor<E, R>,
-  intentId: string,
-  action: 'RECOVER_SUBMIT' | 'RECOVER_CANCEL' | 'SUBMIT',
-  submitExpiresAt?: string,
-): Effect.Effect<MutationIntentExecutionResult, CycleRunnerError, MutationStore | R> =>
-  Effect.gen(function* () {
-    const store = yield* MutationStore
-    const operation = action === 'RECOVER_CANCEL' ? MutationOperation.Cancel : MutationOperation.Submit
-    const existing = yield* store
-      .latest(intentId, operation)
-      .pipe(
-        Effect.mapError((cause) =>
-          mutationRunnerError(`durable ${operation.toLowerCase()} recovery read failed`, cause, 'store'),
-        ),
-      )
-    let event: MutationEvent
-    if (existing === undefined) {
-      if (action !== 'SUBMIT') {
-        return yield* Effect.fail(
-          mutationRunnerError(
-            `lookup-only PAPER recovery lost its durable ${operation.toLowerCase()} evidence`,
-            { intentId, action, operation },
-            'contract',
-          ),
-        )
-      }
-      if (submitExpiresAt === undefined) {
-        return yield* Effect.fail(
-          mutationRunnerError('fresh PAPER submit is missing its immutable submission cutoff', undefined, 'contract'),
-        )
-      }
-      const submitObservedAt = yield* currentUtcInstant
-      if (submitObservedAt >= submitExpiresAt) {
-        return yield* Effect.fail(
-          mutationRunnerError(
-            'fresh PAPER submit crossed its immutable submission cutoff before broker I/O',
-            { intentId, submitObservedAt, submitExpiresAt },
-            'contract',
-          ),
-        )
-      }
-      if (executor.submit === undefined) {
-        return yield* Effect.fail(
-          mutationRunnerError(
-            'fresh PAPER submit is unavailable under OBSERVE recovery-only authority',
-            undefined,
-            'contract',
-          ),
-        )
-      }
-      event = yield* executor
-        .submit(intentId, mutationConsistencyDelayMs)
-        .pipe(Effect.mapError((cause) => mutationRunnerError('guarded PAPER submit failed', cause)))
-    } else if (operation === MutationOperation.Submit && submitDoesNotRequireRecovery(existing.eventType)) {
-      event = existing
-    } else {
-      event = yield* executor
-        .recover(intentId, operation)
-        .pipe(
-          Effect.mapError((cause) =>
-            mutationRunnerError(`lookup-only PAPER ${operation.toLowerCase()} recovery failed`, cause),
-          ),
-        )
-    }
-    const settlement = decideMutationIntentSettlement(event.eventType)
-    if (settlement._tag === 'Unresolved') {
-      return yield* Effect.fail(
-        mutationRunnerError(`guarded PAPER submit remains unresolved at ${settlement.eventType}`, event, 'operational'),
-      )
-    }
-    return { settlement, consistencyDelayMs: event.consistencyDelayMs, operation }
-  })
-
-export const executeMutationIntent = (
-  executionProgram: ExecutionProgram,
-  intentId: string,
-  action: 'RECOVER_SUBMIT' | 'RECOVER_CANCEL' | 'SUBMIT',
-  submitExpiresAt?: string,
-): Effect.Effect<MutationIntentExecutionResult, CycleRunnerError, MutationStore> =>
-  executeMutationIntentWithExecutor(
-    {
-      submit: executionProgram.submit,
-      recover: executionProgram.recover,
-    },
-    intentId,
-    action,
-    submitExpiresAt,
-  )
 
 const executeBoundPaperCycle = (
   input: ObserveAutonomousCycleInput,

--- a/services/bayn/src/observe-composition/mutation-decisions.ts
+++ b/services/bayn/src/observe-composition/mutation-decisions.ts
@@ -1,0 +1,402 @@
+import { Result } from 'effect'
+
+import { MutationOperation } from '../broker/alpaca-mutations'
+import { CycleTerminalReason } from '../cycle'
+import {
+  Authority,
+  IntentState,
+  OrderStatus,
+  ReconciliationStatus,
+  TerminalOutcome,
+  type Intent,
+  type Order,
+  type Position,
+} from '../execution/contracts'
+import { MutationEventType, type MutationEvent } from '../execution/mutations'
+import type { PlannedTargetQuantity } from '../target-planner'
+
+const quantityScale = 1_000_000n
+
+const comparePositionSymbol = (left: Position, right: Position): number =>
+  left.symbol < right.symbol ? -1 : left.symbol > right.symbol ? 1 : 0
+
+const divideAwayFromZero = (numerator: bigint): bigint => {
+  const magnitude = numerator < 0n ? -numerator : numerator
+  const rounded = magnitude === 0n ? 0n : (magnitude + quantityScale - 1n) / quantityScale
+  return numerator < 0n ? -rounded : rounded
+}
+
+const projectMutationPosition = (
+  positions: readonly Position[],
+  target: PlannedTargetQuantity,
+  accountId: string,
+  observedAt: string,
+): readonly Position[] => {
+  const retained = positions.filter((position) => position.symbol !== target.symbol)
+  const quantity = BigInt(target.targetQuantityMicros)
+  if (quantity === 0n) return retained
+  const previous = positions.find((position) => position.symbol === target.symbol)
+  const referencePrice = BigInt(target.referencePriceMicros)
+  const averageEntryPrice = BigInt(previous?.averageEntryPriceMicros ?? target.referencePriceMicros)
+  const projected: Position = {
+    schemaVersion: 'bayn.paper-position.v1',
+    accountId: previous?.accountId ?? accountId,
+    symbol: target.symbol,
+    quantityMicros: target.targetQuantityMicros,
+    averageEntryPriceMicros: averageEntryPrice.toString(),
+    marketPriceMicros: target.referencePriceMicros,
+    marketValueMicros: divideAwayFromZero(quantity * referencePrice).toString(),
+    unrealizedPnlMicros: divideAwayFromZero(quantity * (referencePrice - averageEntryPrice)).toString(),
+    observedAt: previous?.observedAt ?? observedAt,
+  }
+  return [...retained, projected].sort(comparePositionSymbol)
+}
+
+export const projectWorstCasePendingMutationPosition = (
+  positions: readonly Position[],
+  target: PlannedTargetQuantity,
+  accountId: string,
+  observedAt: string,
+): readonly Position[] => {
+  const current = positions.find((position) => position.symbol === target.symbol)
+  const currentQuantity = current === undefined ? 0n : BigInt(current.quantityMicros)
+  const targetQuantity = BigInt(target.targetQuantityMicros)
+  return targetQuantity <= currentQuantity
+    ? positions
+    : projectMutationPosition(positions, target, accountId, observedAt)
+}
+
+export type PreparedMutationIntentDecision =
+  | { readonly _tag: 'Submit' }
+  | { readonly _tag: 'Recover'; readonly eventType: MutationEventType }
+  | { readonly _tag: 'Pending'; readonly order: Order }
+  | { readonly _tag: 'SkipTerminal' }
+
+export type PreparedMutationIntentDecisionFailure = {
+  readonly _tag: 'PreparedMutationIntentDecisionFailure'
+  readonly intentId: string
+  readonly message: string
+  readonly eventType?: MutationEventType
+}
+
+export const decidePreparedMutationIntent = (
+  intent: Intent,
+  latest: MutationEvent | undefined,
+): Result.Result<PreparedMutationIntentDecision, PreparedMutationIntentDecisionFailure> => {
+  if (intent.state === IntentState.Terminal) return Result.succeed({ _tag: 'SkipTerminal' })
+  if (latest === undefined) return Result.succeed({ _tag: 'Submit' })
+  switch (latest.eventType) {
+    case MutationEventType.SubmitAccepted:
+    case MutationEventType.RecoveryFound:
+      return latest.brokerOrderId === undefined
+        ? Result.fail({
+            _tag: 'PreparedMutationIntentDecisionFailure',
+            intentId: intent.intentId,
+            eventType: latest.eventType,
+            message: 'accepted nonterminal submit lacks a durable broker order identity',
+          })
+        : Result.succeed({
+            _tag: 'Pending',
+            order: {
+              schemaVersion: 'bayn.paper-order.v1',
+              accountId: intent.accountId,
+              brokerOrderId: latest.brokerOrderId,
+              clientOrderId: intent.clientOrderId,
+              intentId: intent.intentId,
+              symbol: intent.symbol,
+              side: intent.side,
+              orderType: intent.orderType,
+              timeInForce: intent.timeInForce,
+              quantityMicros: intent.quantityMicros,
+              filledQuantityMicros: '0',
+              status: OrderStatus.New,
+              observedAt: latest.occurredAt,
+            },
+          })
+    case MutationEventType.SubmitRejected:
+    case MutationEventType.SubmitDenied:
+      return Result.fail({
+        _tag: 'PreparedMutationIntentDecisionFailure',
+        intentId: intent.intentId,
+        eventType: latest.eventType,
+        message: 'terminal submit event does not match the nonterminal durable intent state',
+      })
+    case MutationEventType.SubmitStarted:
+    case MutationEventType.SubmitUnknown:
+    case MutationEventType.RecoveryNotFound:
+    case MutationEventType.RecoveryUnknown:
+    case MutationEventType.CancelStarted:
+    case MutationEventType.CancelAccepted:
+    case MutationEventType.CancelUnknown:
+      return Result.succeed({ _tag: 'Recover', eventType: latest.eventType })
+  }
+}
+
+export type PreparedMutationIntentAdmissionFailure = {
+  readonly _tag: 'PreparedMutationIntentAdmissionFailure'
+  readonly reason:
+    | 'accounting-inexact'
+    | 'authority'
+    | 'expiry'
+    | 'reconciliation-not-exact'
+    | 'unknown-mutation'
+    | 'unknown-order'
+  readonly message: string
+}
+
+export const decidePreparedMutationIntentAdmission = (
+  prepared: PreparedMutationIntentDecision,
+  effectiveAuthority: Authority,
+  observedAt: string,
+  expiresAt: string,
+  unknownMutationCount: number,
+  reconciliationStatus: ReconciliationStatus = ReconciliationStatus.Exact,
+  accountingExact = true,
+  unknownOrderCount = 0,
+): Result.Result<void, PreparedMutationIntentAdmissionFailure> => {
+  if (prepared._tag !== 'Submit') return Result.succeed(undefined)
+  if (effectiveAuthority !== Authority.Paper) {
+    return Result.fail({
+      _tag: 'PreparedMutationIntentAdmissionFailure',
+      reason: 'authority',
+      message: 'fresh PAPER submit requires current effective PAPER authority',
+    })
+  }
+  if (observedAt >= expiresAt) {
+    return Result.fail({
+      _tag: 'PreparedMutationIntentAdmissionFailure',
+      reason: 'expiry',
+      message: 'fresh PAPER submit is forbidden at or after decision expiry',
+    })
+  }
+  if (reconciliationStatus !== ReconciliationStatus.Exact) {
+    return Result.fail({
+      _tag: 'PreparedMutationIntentAdmissionFailure',
+      reason: 'reconciliation-not-exact',
+      message: 'fresh PAPER submit requires exact same-pass reconciliation',
+    })
+  }
+  if (!accountingExact) {
+    return Result.fail({
+      _tag: 'PreparedMutationIntentAdmissionFailure',
+      reason: 'accounting-inexact',
+      message: 'fresh PAPER submit requires exact same-pass accounting',
+    })
+  }
+  if (unknownMutationCount !== 0) {
+    return Result.fail({
+      _tag: 'PreparedMutationIntentAdmissionFailure',
+      reason: 'unknown-mutation',
+      message: 'fresh PAPER submit is forbidden while a mutation outcome is unknown',
+    })
+  }
+  if (unknownOrderCount !== 0) {
+    return Result.fail({
+      _tag: 'PreparedMutationIntentAdmissionFailure',
+      reason: 'unknown-order',
+      message: 'fresh PAPER submit is forbidden while a broker order is unknown',
+    })
+  }
+  return Result.succeed(undefined)
+}
+
+export const appendPendingMutationOrder = (orders: readonly Order[], pending: Order): readonly Order[] =>
+  orders.some((order) => order.brokerOrderId === pending.brokerOrderId || order.clientOrderId === pending.clientOrderId)
+    ? orders
+    : [...orders, pending]
+
+export interface PaperCycleIntentTerminalEvidence {
+  readonly state: IntentState
+  readonly terminalOutcome?: TerminalOutcome
+  readonly updatedAt: string
+  readonly latestMutationAt?: string
+}
+
+export interface PaperCycleReconciliationEvidence {
+  readonly status: ReconciliationStatus
+  readonly reconciledAt: string
+  readonly accountingExact: boolean
+  readonly unknownMutationCount: number
+  readonly unknownOrderCount: number
+}
+
+export type PaperCycleCompletionDecision =
+  | { readonly _tag: 'Complete' }
+  | {
+      readonly _tag: 'Wait'
+      readonly reason:
+        | 'accounting-inexact'
+        | 'intent-nonterminal'
+        | 'intent-unsuccessful'
+        | 'reconciliation-not-later'
+        | 'reconciliation-not-exact'
+        | 'unknown-mutation'
+        | 'unknown-order'
+    }
+
+export const decidePaperCycleCompletion = (
+  documentCreatedAt: string,
+  intents: readonly PaperCycleIntentTerminalEvidence[],
+  reconciliation: PaperCycleReconciliationEvidence,
+): PaperCycleCompletionDecision => {
+  if (intents.some((intent) => intent.state !== IntentState.Terminal)) {
+    return { _tag: 'Wait', reason: 'intent-nonterminal' }
+  }
+  if (intents.some((intent) => intent.terminalOutcome !== TerminalOutcome.Filled)) {
+    return { _tag: 'Wait', reason: 'intent-unsuccessful' }
+  }
+  if (reconciliation.status !== ReconciliationStatus.Exact) {
+    return { _tag: 'Wait', reason: 'reconciliation-not-exact' }
+  }
+  if (!reconciliation.accountingExact) return { _tag: 'Wait', reason: 'accounting-inexact' }
+  if (reconciliation.unknownMutationCount !== 0) return { _tag: 'Wait', reason: 'unknown-mutation' }
+  if (reconciliation.unknownOrderCount !== 0) return { _tag: 'Wait', reason: 'unknown-order' }
+  const latestEvidenceAt = Math.max(
+    Date.parse(documentCreatedAt),
+    ...intents.flatMap((intent) => [
+      Date.parse(intent.updatedAt),
+      Date.parse(intent.latestMutationAt ?? intent.updatedAt),
+    ]),
+  )
+  if (Date.parse(reconciliation.reconciledAt) <= latestEvidenceAt) {
+    return { _tag: 'Wait', reason: 'reconciliation-not-later' }
+  }
+  return { _tag: 'Complete' }
+}
+
+export type PreparedMutationRecoveryDecision =
+  | { readonly _tag: 'NoRecovery' }
+  | {
+      readonly _tag: 'Recover'
+      readonly operation: MutationOperation
+      readonly event: MutationEvent
+    }
+
+export const decidePreparedMutationRecovery = (
+  intent: Intent,
+  latestSubmit: MutationEvent | undefined,
+  latestCancel: MutationEvent | undefined,
+): Result.Result<PreparedMutationRecoveryDecision, PreparedMutationIntentDecisionFailure> => {
+  if (latestCancel !== undefined) {
+    if (latestCancel.operation !== MutationOperation.Cancel) {
+      return Result.fail({
+        _tag: 'PreparedMutationIntentDecisionFailure',
+        intentId: intent.intentId,
+        eventType: latestCancel.eventType,
+        message: 'durable cancellation recovery read returned a non-cancel mutation',
+      })
+    }
+    return intent.state === IntentState.Terminal && latestCancel.eventType === MutationEventType.RecoveryFound
+      ? Result.succeed({ _tag: 'NoRecovery' })
+      : Result.succeed({ _tag: 'Recover', operation: MutationOperation.Cancel, event: latestCancel })
+  }
+  if (latestSubmit === undefined) return Result.succeed({ _tag: 'NoRecovery' })
+  if (latestSubmit.operation !== MutationOperation.Submit) {
+    return Result.fail({
+      _tag: 'PreparedMutationIntentDecisionFailure',
+      intentId: intent.intentId,
+      eventType: latestSubmit.eventType,
+      message: 'durable submit recovery read returned a non-submit mutation',
+    })
+  }
+  if (
+    intent.state === IntentState.Terminal &&
+    (latestSubmit.eventType === MutationEventType.SubmitAccepted ||
+      latestSubmit.eventType === MutationEventType.SubmitRejected ||
+      latestSubmit.eventType === MutationEventType.SubmitDenied ||
+      latestSubmit.eventType === MutationEventType.RecoveryFound)
+  ) {
+    return Result.succeed({ _tag: 'NoRecovery' })
+  }
+  if (
+    intent.state !== IntentState.Terminal &&
+    (latestSubmit.eventType === MutationEventType.SubmitRejected ||
+      latestSubmit.eventType === MutationEventType.SubmitDenied)
+  ) {
+    return Result.fail({
+      _tag: 'PreparedMutationIntentDecisionFailure',
+      intentId: intent.intentId,
+      eventType: latestSubmit.eventType,
+      message: 'terminal submit event does not match the nonterminal durable intent state',
+    })
+  }
+  return Result.succeed({ _tag: 'Recover', operation: MutationOperation.Submit, event: latestSubmit })
+}
+
+export type PreparedMutationCycleStep =
+  | { readonly _tag: 'RunCycle' }
+  | {
+      readonly _tag: 'Execute'
+      readonly action: 'RECOVER_SUBMIT' | 'RECOVER_CANCEL'
+      readonly intentId: string
+      readonly observedAt: string
+    }
+  | {
+      readonly _tag: 'Execute'
+      readonly action: 'SUBMIT'
+      readonly intentId: string
+      readonly observedAt: string
+      readonly submitExpiresAt: string
+    }
+  | {
+      readonly _tag: 'Block'
+      readonly reason:
+        | CycleTerminalReason.MissedSubmission
+        | CycleTerminalReason.ProvenanceMismatch
+        | CycleTerminalReason.Risk
+      readonly observedAt: string
+    }
+  | { readonly _tag: 'Wait'; readonly observedAt: string }
+  | { readonly _tag: 'Complete'; readonly observedAt: string }
+
+export type BoundMutationCycleOutcome = Exclude<PreparedMutationCycleStep, { readonly _tag: 'Execute' }>
+
+export const mutationRecoveryIsDue = (event: MutationEvent, observedAt: string): boolean =>
+  Date.parse(observedAt) >= Date.parse(event.occurredAt) + event.consistencyDelayMs
+
+export const paperSubmitExpiresAt = (documentExpiresAt: string, riskDecisionExpiresAt: string): string =>
+  riskDecisionExpiresAt < documentExpiresAt ? riskDecisionExpiresAt : documentExpiresAt
+
+export const expiredPaperPlanTerminalReason = (
+  observedAt: string,
+  submitExpiresAt: string,
+  submissionCutoffAt: string,
+): CycleTerminalReason.MissedSubmission | CycleTerminalReason.Risk | undefined =>
+  observedAt < submitExpiresAt
+    ? undefined
+    : observedAt >= submissionCutoffAt
+      ? CycleTerminalReason.MissedSubmission
+      : CycleTerminalReason.Risk
+
+export type MutationIntentSettlementDecision =
+  | {
+      readonly _tag: 'Settled'
+      readonly outcome: 'accepted' | 'rejected' | 'denied'
+    }
+  | {
+      readonly _tag: 'Unresolved'
+      readonly eventType: MutationEventType
+    }
+
+export const decideMutationIntentSettlement = (eventType: MutationEventType): MutationIntentSettlementDecision => {
+  switch (eventType) {
+    case MutationEventType.SubmitAccepted:
+    case MutationEventType.RecoveryFound:
+      return { _tag: 'Settled', outcome: 'accepted' }
+    case MutationEventType.SubmitRejected:
+      return { _tag: 'Settled', outcome: 'rejected' }
+    case MutationEventType.SubmitDenied:
+      return { _tag: 'Settled', outcome: 'denied' }
+    default:
+      return { _tag: 'Unresolved', eventType }
+  }
+}
+
+export interface MutationIntentExecutionResult {
+  readonly settlement: Extract<MutationIntentSettlementDecision, { readonly _tag: 'Settled' }>
+  readonly consistencyDelayMs: number
+  readonly operation: MutationOperation
+}
+
+export const mutationIntentReconciliationDelayMs = (result: MutationIntentExecutionResult): number =>
+  result.settlement.outcome === 'accepted' ? result.consistencyDelayMs : 0

--- a/services/bayn/src/observe-composition/mutation-intent-interpreter.ts
+++ b/services/bayn/src/observe-composition/mutation-intent-interpreter.ts
@@ -1,0 +1,530 @@
+import { Effect, Option, Result } from 'effect'
+
+import { MutationOperation } from '../broker/alpaca-mutations'
+import { CycleState, CycleTerminalReason, type AutonomousCycle } from '../cycle'
+import { CycleRunnerError } from '../cycle-runner'
+import { IntentStore, planPaperIntent, type StoredIntent } from '../execution/intents'
+import {
+  Authority,
+  IntentState,
+  KillState,
+  OrderSide,
+  TerminalOutcome,
+  type AuthorityState,
+  type Intent,
+} from '../execution/contracts'
+import { MutationStore, type MutationEvent } from '../execution/mutations'
+import { makeFillTerms, MICROS } from '../execution-model'
+import { canonicalHashV1Result } from '../hash'
+import type { ReconciliationPassResult } from '../reconciler'
+import type { Policy } from '../risk'
+import type { PaperDecisionDocument } from '../shadow-decision-contract'
+import { TargetPlanStatus } from '../target-planner'
+import type { CausalProtocol } from '../protocol'
+import {
+  decidePaperCycleCompletion,
+  decidePreparedMutationIntent,
+  decidePreparedMutationIntentAdmission,
+  decidePreparedMutationRecovery,
+  expiredPaperPlanTerminalReason,
+  mutationRecoveryIsDue,
+  paperSubmitExpiresAt,
+  type PaperCycleIntentTerminalEvidence,
+  type PreparedMutationCycleStep,
+} from './mutation-decisions'
+import { mutationRunnerError } from './mutation-interpreter'
+
+export type MutationPreparationFacts = {
+  readonly snapshot: {
+    readonly contentHash: string
+    readonly finalizedAt: string
+  }
+  readonly reconciliation: ReconciliationPassResult
+  readonly authority: AuthorityState
+  readonly evaluatedAt: string
+}
+
+export type MutationIntentInput = {
+  readonly accountId: string
+  readonly authorityGenerationHash: string
+}
+
+export type MutationPreparation = {
+  readonly executionModel: CausalProtocol['executionModel']
+}
+
+export type MutationPreparationFactsRequest<
+  R,
+  E,
+  I extends MutationIntentInput = MutationIntentInput,
+  P extends MutationPreparation = MutationPreparation,
+> = {
+  readonly input: I
+  readonly preparation: P
+  readonly policy: Policy
+  readonly cycle: AutonomousCycle
+  readonly reconcile: Effect.Effect<ReconciliationPassResult, E, R>
+}
+
+export type MutationPreparationDependencies<
+  R,
+  E,
+  I extends MutationIntentInput = MutationIntentInput,
+  P extends MutationPreparation = MutationPreparation,
+> = {
+  readonly now: Effect.Effect<string, never, R>
+  readonly readFacts: (
+    request: MutationPreparationFactsRequest<R, E, I, P>,
+  ) => Effect.Effect<MutationPreparationFacts, CycleRunnerError, R>
+  readonly restrictAuthority: (subject: string, reason: string) => Effect.Effect<void, CycleRunnerError, R>
+}
+
+const validateBoundMutationDocument = (
+  input: MutationIntentInput,
+  cycle: AutonomousCycle,
+  document: PaperDecisionDocument,
+): Result.Result<void, CycleRunnerError> =>
+  cycle.state !== CycleState.Active ||
+  cycle.bindings.decisionHash !== document.contentHash ||
+  cycle.bindings.snapshotId !== document.bindings.snapshotId ||
+  cycle.identity.cycleId !== document.bindings.cycleId ||
+  cycle.identity.qualificationRunId !== document.bindings.qualificationRunId ||
+  cycle.identity.accountId !== document.bindings.accountId ||
+  cycle.identity.strategyProtocolHash !== document.bindings.strategyProtocolHash ||
+  input.accountId !== document.bindings.accountId
+    ? Result.fail(
+        mutationRunnerError(
+          'durable shadow plan does not match the mutation cycle account, protocol, and decision binding',
+          undefined,
+          'contract',
+        ),
+      )
+    : Result.succeed(undefined)
+
+const validateCurrentMutationPolicy = (
+  policy: Policy,
+  document: PaperDecisionDocument,
+): Result.Result<void, CycleRunnerError> => {
+  const policyHash = canonicalHashV1Result(policy)
+  if (Result.isFailure(policyHash)) {
+    return Result.fail(mutationRunnerError('mutation cycle risk policy is not canonicalizable', policyHash.failure))
+  }
+  return policyHash.success !== document.bindings.policyHash
+    ? Result.fail(
+        mutationRunnerError(
+          'current source-controlled PAPER risk policy changed from the durable decision binding',
+          undefined,
+          'contract',
+        ),
+      )
+    : Result.succeed(undefined)
+}
+
+const boundPaperSubmissionCutoff = (
+  cycle: AutonomousCycle,
+  document: PaperDecisionDocument,
+): Result.Result<string, CycleRunnerError> => {
+  if (
+    document.submissionCutoffAt !== cycle.window.submissionCutoffAt ||
+    document.expiresAt !== cycle.window.submissionCutoffAt
+  ) {
+    return Result.fail(
+      mutationRunnerError(
+        'durable PAPER decision changed from its immutable cycle submission window',
+        undefined,
+        'contract',
+      ),
+    )
+  }
+  return Result.succeed(cycle.window.submissionCutoffAt)
+}
+
+const immutableIntentBindingMatches = (stored: Intent, expected: Intent): boolean =>
+  stored.schemaVersion === expected.schemaVersion &&
+  stored.intentId === expected.intentId &&
+  stored.authorityGenerationHash === expected.authorityGenerationHash &&
+  stored.strategyName === expected.strategyName &&
+  stored.cycleId === expected.cycleId &&
+  stored.decisionHash === expected.decisionHash &&
+  stored.policyHash === expected.policyHash &&
+  stored.accountId === expected.accountId &&
+  stored.clientOrderId === expected.clientOrderId &&
+  stored.symbol === expected.symbol &&
+  stored.side === expected.side &&
+  stored.orderType === expected.orderType &&
+  stored.timeInForce === expected.timeInForce &&
+  stored.quantityMicros === expected.quantityMicros &&
+  stored.notionalLimitMicros === expected.notionalLimitMicros &&
+  stored.createdAt === expected.createdAt
+
+const validateCurrentMutationExecutionTerms = (
+  preparation: MutationPreparation,
+  targetIntent: PaperDecisionDocument['targetPlan']['intentTargets'][number],
+  target: PaperDecisionDocument['targetPlan']['targets'][number],
+  riskBinding: PaperDecisionDocument['deltaRisk'][number],
+): Result.Result<void, CycleRunnerError> => {
+  const fillTerms = makeFillTerms(
+    targetIntent.side === OrderSide.Buy ? 'buy' : 'sell',
+    BigInt(targetIntent.quantityMicros),
+    BigInt(target.referencePriceMicros),
+    preparation.executionModel,
+    MICROS,
+  )
+  if (Result.isFailure(fillTerms)) {
+    return Result.fail(mutationRunnerError('mutation execution terms are invalid', fillTerms.failure, 'contract'))
+  }
+  return fillTerms.success.notionalMicros.toString() === riskBinding.notionalLimitMicros
+    ? Result.succeed(undefined)
+    : Result.fail(
+        mutationRunnerError(
+          'durable mutation notional changed from the current execution model',
+          undefined,
+          'contract',
+        ),
+      )
+}
+
+type PreparedPaperIntent = {
+  readonly intent: Intent
+  readonly targetIntent: PaperDecisionDocument['targetPlan']['intentTargets'][number]
+  readonly target: PaperDecisionDocument['targetPlan']['targets'][number]
+  readonly riskBinding: PaperDecisionDocument['deltaRisk'][number]
+  readonly stored: StoredIntent | undefined
+  readonly latestSubmit: MutationEvent | undefined
+  readonly latestCancel: MutationEvent | undefined
+}
+
+type PaperIntentRecoveryLookup = Omit<PreparedPaperIntent, 'intent'> & {
+  readonly intentId: string
+}
+
+export const prepareMutationIntent = <R, E, I extends MutationIntentInput, P extends MutationPreparation>(
+  input: I,
+  preparation: P,
+  policy: Policy,
+  cycle: AutonomousCycle,
+  document: PaperDecisionDocument,
+  reconcile: Effect.Effect<ReconciliationPassResult, E, R>,
+  allowSubmit: boolean,
+  dependencies: MutationPreparationDependencies<R, E, I, P>,
+): Effect.Effect<PreparedMutationCycleStep, CycleRunnerError, R | IntentStore | MutationStore> =>
+  Effect.gen(function* () {
+    yield* Effect.fromResult(validateBoundMutationDocument(input, cycle, document))
+    const submissionCutoffAt = yield* Effect.fromResult(boundPaperSubmissionCutoff(cycle, document))
+    const generationIsSuperseded = input.authorityGenerationHash !== document.bindings.authorityGenerationHash
+    if (document.riskBlock !== undefined) {
+      return {
+        _tag: 'Block',
+        reason: CycleTerminalReason.Risk,
+        observedAt: yield* dependencies.now,
+      }
+    }
+    if (document.targetPlan.status !== TargetPlanStatus.Planned) return { _tag: 'RunCycle' }
+
+    const intentStore = yield* IntentStore
+    const mutationStore = yield* MutationStore
+    const targets = new Map(document.targetPlan.targets.map((target) => [target.symbol, target]))
+    const documentAuthority: AuthorityState = {
+      schemaVersion: 'bayn.paper-authority.v1',
+      generationHash: document.bindings.authorityGenerationHash,
+      maximum: Authority.Paper,
+      effective: Authority.Paper,
+      kill: KillState.Clear,
+      version: 1,
+      updatedAt: document.createdAt,
+    }
+    const recoveryLookups: PaperIntentRecoveryLookup[] = []
+
+    for (const [index, targetIntent] of document.targetPlan.intentTargets.entries()) {
+      const riskBinding = document.deltaRisk[index]
+      const target = targets.get(targetIntent.symbol)
+      const intentId = document.orderedIntentIds[index]
+      if (riskBinding === undefined || target === undefined || intentId === undefined) {
+        return yield* Effect.fail(
+          mutationRunnerError(
+            'durable mutation target is missing its intent, risk, or final-position binding',
+            undefined,
+            'contract',
+          ),
+        )
+      }
+      const stored = yield* intentStore
+        .read(intentId)
+        .pipe(
+          Effect.mapError((cause) => mutationRunnerError('durable PAPER intent recovery read failed', cause, 'store')),
+        )
+      const existing = Option.getOrUndefined(stored)
+      const latestSubmit = yield* mutationStore
+        .latest(intentId, MutationOperation.Submit)
+        .pipe(Effect.mapError((cause) => mutationRunnerError('durable submit state read failed', cause, 'store')))
+      const latestCancel = yield* mutationStore
+        .latest(intentId, MutationOperation.Cancel)
+        .pipe(Effect.mapError((cause) => mutationRunnerError('durable cancel state read failed', cause, 'store')))
+      if (existing === undefined && (latestSubmit !== undefined || latestCancel !== undefined)) {
+        return yield* Effect.fail(
+          mutationRunnerError(
+            'durable mutation exists without its authority-bound intent',
+            { latestSubmit, latestCancel },
+            'contract',
+          ),
+        )
+      }
+      if (existing !== undefined && existing.intent.intentId !== intentId) {
+        return yield* Effect.fail(
+          mutationRunnerError(
+            'durable PAPER intent recovery returned a different intent identity',
+            undefined,
+            'contract',
+          ),
+        )
+      }
+      recoveryLookups.push({
+        intentId,
+        targetIntent,
+        target,
+        riskBinding,
+        stored: existing,
+        latestSubmit,
+        latestCancel,
+      })
+    }
+
+    const preparedIntents: PreparedPaperIntent[] = []
+    for (const lookup of recoveryLookups) {
+      const intent = yield* planPaperIntent(
+        {
+          schemaVersion: 'bayn.paper-intent-plan.v1',
+          ...lookup.targetIntent,
+          notionalLimitMicros: lookup.riskBinding.notionalLimitMicros,
+          createdAt: document.createdAt,
+        },
+        { authority: documentAuthority },
+      ).pipe(
+        Effect.mapError((cause) =>
+          mutationRunnerError('durable PAPER intent reconstruction failed', cause, 'contract'),
+        ),
+      )
+      if (lookup.intentId !== intent.intentId) {
+        return yield* Effect.fail(
+          mutationRunnerError(
+            'durable PAPER intent identity or order changed after decision binding',
+            undefined,
+            'contract',
+          ),
+        )
+      }
+      if (lookup.stored !== undefined && !immutableIntentBindingMatches(lookup.stored.intent, intent)) {
+        return yield* Effect.fail(
+          mutationRunnerError('stored PAPER intent changed from its durable decision binding', undefined, 'contract'),
+        )
+      }
+      preparedIntents.push({ ...lookup, intent })
+    }
+
+    const recoveryObservedAt = yield* dependencies.now
+    for (const prepared of preparedIntents) {
+      const existing = prepared.stored
+      if (existing === undefined) continue
+      const recovery = yield* Effect.fromResult(
+        decidePreparedMutationRecovery(existing.intent, prepared.latestSubmit, prepared.latestCancel),
+      ).pipe(Effect.mapError((cause) => mutationRunnerError(cause.message, cause, 'contract')))
+      if (recovery._tag === 'Recover') {
+        return mutationRecoveryIsDue(recovery.event, recoveryObservedAt)
+          ? {
+              _tag: 'Execute',
+              action:
+                recovery.operation === MutationOperation.Submit
+                  ? ('RECOVER_SUBMIT' as const)
+                  : ('RECOVER_CANCEL' as const),
+              intentId: prepared.intent.intentId,
+              observedAt: recoveryObservedAt,
+            }
+          : { _tag: 'Wait', observedAt: recoveryObservedAt }
+      }
+    }
+
+    if (generationIsSuperseded) {
+      return {
+        _tag: 'Block',
+        reason: CycleTerminalReason.ProvenanceMismatch,
+        observedAt: recoveryObservedAt,
+      }
+    }
+
+    yield* Effect.fromResult(validateCurrentMutationPolicy(policy, document))
+
+    const uncommittedIntents = preparedIntents.filter((prepared) => prepared.stored === undefined)
+    if (!allowSubmit && uncommittedIntents.length > 0) {
+      return { _tag: 'Wait', observedAt: recoveryObservedAt }
+    }
+    if (allowSubmit) {
+      for (const prepared of preparedIntents) {
+        const requiresFreshSubmission =
+          prepared.stored === undefined ||
+          (prepared.stored.intent.state !== IntentState.Terminal && prepared.latestSubmit === undefined)
+        if (!requiresFreshSubmission) continue
+        yield* Effect.fromResult(
+          validateCurrentMutationExecutionTerms(
+            preparation,
+            prepared.targetIntent,
+            prepared.target,
+            prepared.riskBinding,
+          ),
+        )
+      }
+    }
+    if (uncommittedIntents.length > 0) {
+      const commitObservedAt = yield* dependencies.now
+      const commitExpiresAt = uncommittedIntents.reduce(
+        (expiresAt, prepared) => paperSubmitExpiresAt(expiresAt, prepared.riskBinding.evaluation.decision.expiresAt),
+        document.expiresAt,
+      )
+      const expirationReason = expiredPaperPlanTerminalReason(commitObservedAt, commitExpiresAt, submissionCutoffAt)
+      if (expirationReason !== undefined) {
+        return {
+          _tag: 'Block',
+          reason: expirationReason,
+          observedAt: commitObservedAt,
+        }
+      }
+      if (
+        preparedIntents.some((prepared) => prepared.latestSubmit !== undefined || prepared.latestCancel !== undefined)
+      ) {
+        return yield* Effect.fail(
+          mutationRunnerError(
+            'broker mutation evidence exists before the complete immutable intent set was committed',
+            undefined,
+            'contract',
+          ),
+        )
+      }
+    }
+
+    yield* Effect.forEach(
+      preparedIntents,
+      (prepared) =>
+        intentStore
+          .commit(prepared.intent, prepared.riskBinding.evaluation.decision)
+          .pipe(
+            Effect.mapError((cause) => mutationRunnerError('durable PAPER intent-set commit failed', cause, 'store')),
+          ),
+      { concurrency: 1, discard: true },
+    )
+
+    const facts = yield* dependencies.readFacts({ input, preparation, policy, cycle, reconcile })
+    if (
+      document.bindings.snapshotContentHash !== facts.snapshot.contentHash ||
+      document.bindings.snapshotFinalizedAt !== facts.snapshot.finalizedAt
+    ) {
+      return yield* Effect.fail(
+        mutationRunnerError('bound mutation cycle snapshot publication changed after planning', undefined, 'contract'),
+      )
+    }
+
+    const terminalEvidence: PaperCycleIntentTerminalEvidence[] = []
+    for (const prepared of preparedIntents) {
+      const stored = yield* intentStore
+        .read(prepared.intent.intentId)
+        .pipe(Effect.mapError((cause) => mutationRunnerError('committed PAPER intent readback failed', cause, 'store')))
+      const record = Option.getOrUndefined(stored)
+      if (record === undefined) {
+        return yield* Effect.fail(
+          mutationRunnerError('committed PAPER intent disappeared before execution selection', undefined, 'contract'),
+        )
+      }
+      const latest = yield* mutationStore
+        .latest(prepared.intent.intentId, MutationOperation.Submit)
+        .pipe(Effect.mapError((cause) => mutationRunnerError('durable submit state refresh failed', cause, 'store')))
+      const decision = yield* Effect.fromResult(decidePreparedMutationIntent(record.intent, latest)).pipe(
+        Effect.mapError((cause) => mutationRunnerError(cause.message, cause, 'contract')),
+      )
+      switch (decision._tag) {
+        case 'SkipTerminal':
+          terminalEvidence.push({
+            state: record.intent.state,
+            terminalOutcome: record.intent.terminalOutcome,
+            updatedAt: record.updatedAt,
+            ...(latest === undefined ? {} : { latestMutationAt: latest.occurredAt }),
+          })
+          if (record.intent.terminalOutcome !== TerminalOutcome.Filled) {
+            yield* dependencies.restrictAuthority(
+              `bound PAPER cycle ${cycle.identity.cycleId}`,
+              `intent ${prepared.intent.intentId} ended ${record.intent.terminalOutcome ?? 'without outcome'}`,
+            )
+            return {
+              _tag: 'Block',
+              reason: CycleTerminalReason.Risk,
+              observedAt: facts.evaluatedAt,
+            }
+          }
+          break
+        case 'Pending':
+          return latest !== undefined && mutationRecoveryIsDue(latest, facts.evaluatedAt)
+            ? {
+                _tag: 'Execute',
+                action: 'RECOVER_SUBMIT',
+                intentId: prepared.intent.intentId,
+                observedAt: facts.evaluatedAt,
+              }
+            : { _tag: 'Wait', observedAt: facts.evaluatedAt }
+        case 'Recover':
+          return latest !== undefined && mutationRecoveryIsDue(latest, facts.evaluatedAt)
+            ? {
+                _tag: 'Execute',
+                action: 'RECOVER_SUBMIT',
+                intentId: prepared.intent.intentId,
+                observedAt: facts.evaluatedAt,
+              }
+            : { _tag: 'Wait', observedAt: facts.evaluatedAt }
+        case 'Submit': {
+          if (!allowSubmit) return { _tag: 'Wait', observedAt: facts.evaluatedAt }
+          const submitExpiresAt = paperSubmitExpiresAt(
+            submissionCutoffAt,
+            prepared.riskBinding.evaluation.decision.expiresAt,
+          )
+          const expirationReason = expiredPaperPlanTerminalReason(
+            facts.evaluatedAt,
+            submitExpiresAt,
+            submissionCutoffAt,
+          )
+          if (expirationReason !== undefined) {
+            return {
+              _tag: 'Block',
+              reason: expirationReason,
+              observedAt: facts.evaluatedAt,
+            }
+          }
+          yield* Effect.fromResult(
+            decidePreparedMutationIntentAdmission(
+              decision,
+              facts.authority.effective,
+              facts.evaluatedAt,
+              submitExpiresAt,
+              facts.reconciliation.riskContext.unknownMutationCount,
+              facts.reconciliation.brokerState.reconciliation.status,
+              facts.reconciliation.report.metrics.accountingExact,
+              facts.reconciliation.brokerState.unknownOrderCount,
+            ),
+          ).pipe(Effect.mapError((cause) => mutationRunnerError(cause.message, cause, 'contract')))
+          return {
+            _tag: 'Execute',
+            action: 'SUBMIT',
+            intentId: prepared.intent.intentId,
+            observedAt: facts.evaluatedAt,
+            submitExpiresAt,
+          }
+        }
+      }
+    }
+
+    const completion = decidePaperCycleCompletion(document.createdAt, terminalEvidence, {
+      status: facts.reconciliation.brokerState.reconciliation.status,
+      reconciledAt: facts.reconciliation.brokerState.reconciliation.reconciledAt,
+      accountingExact: facts.reconciliation.report.metrics.accountingExact,
+      unknownMutationCount: facts.reconciliation.riskContext.unknownMutationCount,
+      unknownOrderCount: facts.reconciliation.brokerState.unknownOrderCount,
+    })
+    return completion._tag === 'Complete'
+      ? { _tag: 'Complete', observedAt: facts.evaluatedAt }
+      : { _tag: 'Wait', observedAt: facts.evaluatedAt }
+  })

--- a/services/bayn/src/observe-composition/mutation-interpreter.ts
+++ b/services/bayn/src/observe-composition/mutation-interpreter.ts
@@ -1,0 +1,150 @@
+import { Effect } from 'effect'
+
+import { MutationOperation } from '../broker/alpaca-mutations'
+import { AuthorityRestrictionStore } from '../db/execution-store'
+import { MutationEventType, MutationStore, type MutationEvent } from '../execution/mutations'
+import type { ExecutionProgram } from '../execution/runtime-program'
+import { WriterFence } from '../execution/writer-fence'
+import { CycleRunnerError } from '../cycle-runner'
+import { currentUtcInstant } from '../time'
+import { decideMutationIntentSettlement, type MutationIntentExecutionResult } from './mutation-decisions'
+
+export type PaperMutationExecutor<E, R> = {
+  readonly submit?: (intentId: string, consistencyDelayMs: number) => Effect.Effect<MutationEvent, E, R>
+  readonly recover: (intentId: string, operation: MutationOperation) => Effect.Effect<MutationEvent, E, R>
+}
+
+export const mutationConsistencyDelayMs = 1_000
+
+export const mutationRunnerError = (
+  message: string,
+  cause?: unknown,
+  failure: CycleRunnerError['failure'] = 'operational',
+): CycleRunnerError =>
+  new CycleRunnerError({
+    operation: 'recover-cycle',
+    failure,
+    message,
+    cause,
+  })
+
+export const restrictMutationAuthority = (
+  subject: string,
+  reason: string,
+): Effect.Effect<void, CycleRunnerError, AuthorityRestrictionStore | WriterFence> =>
+  Effect.gen(function* () {
+    const store = yield* AuthorityRestrictionStore
+    const fence = yield* WriterFence
+    const updatedAt = yield* currentUtcInstant
+    yield* fence
+      .transaction(store.restrictAuthority(`${subject} restricted effective authority: ${reason}`, updatedAt))
+      .pipe(
+        Effect.mapError((cause) =>
+          mutationRunnerError(
+            'authority restriction failed after a bound PAPER cycle failure',
+            { subject, reason, cause },
+            'store',
+          ),
+        ),
+      )
+  })
+
+export const restrictMutationLoopFailure = (
+  error: CycleRunnerError,
+): Effect.Effect<void, CycleRunnerError, AuthorityRestrictionStore | WriterFence> =>
+  restrictMutationAuthority('PAPER autonomous cycle loop', `${error.operation}: ${error.message}`)
+
+const submitDoesNotRequireRecovery = (eventType: MutationEvent['eventType']): boolean =>
+  eventType === MutationEventType.SubmitRejected || eventType === MutationEventType.SubmitDenied
+
+export const executeMutationIntentWithExecutor = <E, R>(
+  executor: PaperMutationExecutor<E, R>,
+  intentId: string,
+  action: 'RECOVER_SUBMIT' | 'RECOVER_CANCEL' | 'SUBMIT',
+  submitExpiresAt?: string,
+  now: Effect.Effect<string, never, R> = currentUtcInstant,
+): Effect.Effect<MutationIntentExecutionResult, CycleRunnerError, MutationStore | R> =>
+  Effect.gen(function* () {
+    const store = yield* MutationStore
+    const operation = action === 'RECOVER_CANCEL' ? MutationOperation.Cancel : MutationOperation.Submit
+    const existing = yield* store
+      .latest(intentId, operation)
+      .pipe(
+        Effect.mapError((cause) =>
+          mutationRunnerError(`durable ${operation.toLowerCase()} recovery read failed`, cause, 'store'),
+        ),
+      )
+    let event: MutationEvent
+    if (existing === undefined) {
+      if (action !== 'SUBMIT') {
+        return yield* Effect.fail(
+          mutationRunnerError(
+            `lookup-only PAPER recovery lost its durable ${operation.toLowerCase()} evidence`,
+            { intentId, action, operation },
+            'contract',
+          ),
+        )
+      }
+      if (submitExpiresAt === undefined) {
+        return yield* Effect.fail(
+          mutationRunnerError('fresh PAPER submit is missing its immutable submission cutoff', undefined, 'contract'),
+        )
+      }
+      const submitObservedAt = yield* now
+      if (submitObservedAt >= submitExpiresAt) {
+        return yield* Effect.fail(
+          mutationRunnerError(
+            'fresh PAPER submit crossed its immutable submission cutoff before broker I/O',
+            { intentId, submitObservedAt, submitExpiresAt },
+            'contract',
+          ),
+        )
+      }
+      if (executor.submit === undefined) {
+        return yield* Effect.fail(
+          mutationRunnerError(
+            'fresh PAPER submit is unavailable under OBSERVE recovery-only authority',
+            undefined,
+            'contract',
+          ),
+        )
+      }
+      event = yield* executor
+        .submit(intentId, mutationConsistencyDelayMs)
+        .pipe(Effect.mapError((cause) => mutationRunnerError('guarded PAPER submit failed', cause)))
+    } else if (operation === MutationOperation.Submit && submitDoesNotRequireRecovery(existing.eventType)) {
+      event = existing
+    } else {
+      event = yield* executor
+        .recover(intentId, operation)
+        .pipe(
+          Effect.mapError((cause) =>
+            mutationRunnerError(`lookup-only PAPER ${operation.toLowerCase()} recovery failed`, cause),
+          ),
+        )
+    }
+    const settlement = decideMutationIntentSettlement(event.eventType)
+    if (settlement._tag === 'Unresolved') {
+      return yield* Effect.fail(
+        mutationRunnerError(`guarded PAPER submit remains unresolved at ${settlement.eventType}`, event, 'operational'),
+      )
+    }
+    return { settlement, consistencyDelayMs: event.consistencyDelayMs, operation }
+  })
+
+export const executeMutationIntent = (
+  executionProgram: ExecutionProgram,
+  intentId: string,
+  action: 'RECOVER_SUBMIT' | 'RECOVER_CANCEL' | 'SUBMIT',
+  submitExpiresAt?: string,
+): Effect.Effect<MutationIntentExecutionResult, CycleRunnerError, MutationStore> =>
+  executeMutationIntentWithExecutor(
+    {
+      submit: executionProgram.submit,
+      recover: executionProgram.recover,
+    },
+    intentId,
+    action,
+    submitExpiresAt,
+    currentUtcInstant,
+  )


### PR DESCRIPTION
## Summary

- Extract pure mutation selection, admission, recovery ordering, settlement, completion, expiry, and position-projection decisions from `observe-composition.ts`.
- Add cohesive Effect interpreters for durable intent preparation, broker/recovery execution, authority restriction, and explicit preparation facts.
- Preserve recovery-first behavior, immutable cutoff and policy checks, authority semantics, exact reconciliation, and existing public exports; add an explicit cancellation-first regression.

## Related Issues

None.

## Testing

- `bun test services/bayn/src/observe-composition.test.ts` — 38 passed.
- `bun run --filter @proompteng/bayn tsc` — passed.
- `bun run --filter @proompteng/bayn lint` — passed.
- `bun run --filter @proompteng/bayn lint:effect` — passed.
- `bun run --filter @proompteng/bayn lint:oxlint` — passed with one pre-existing warning in the out-of-scope candidate-development path.
- `bun run --filter @proompteng/bayn lint:oxlint:type` — passed with the same pre-existing warning.
- `bun run --filter @proompteng/bayn build` — passed.
- `BAYN_TEST_POSTGRES_URL=postgresql://bayn:bayn@127.0.0.1:5432/bayn_test bun run --filter @proompteng/bayn test:postgres` — 25 passed.
- Full `bun run --filter @proompteng/bayn test` — 1,193 passed, 153 skipped, 1 pre-existing failure in the out-of-scope candidate-development Git-read test; the exact test also fails in isolation on this macOS environment.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] Documentation, release notes, and follow-ups are not required for this internal refactor.
