### PR TITLE
refactor(bayn): split paper proof operation programs

### DIFF
--- a/services/bayn/src/paper-proof-command.ts
+++ b/services/bayn/src/paper-proof-command.ts
@@ -44,7 +44,7 @@ export const runPaperProofCommand = (
     const operation = malformedOperation(input)
     return !hasPaperProofMutationAuthority(dependencies.runtime)
       ? Effect.fail(failure)
-      : containMalformedPaperProofCommand(operation ?? 'GATE', dependencies, failure)
+      : containMalformedPaperProofCommand(operation ?? 'GATE', dependencies.containment, failure)
   }
   const envelope: PaperProofCliEnvelope = decoded.success
   return runPaperProof(envelope.command, {

--- a/services/bayn/src/paper-proof-command.ts
+++ b/services/bayn/src/paper-proof-command.ts
@@ -44,7 +44,12 @@ export const runPaperProofCommand = (
     const operation = malformedOperation(input)
     return !hasPaperProofMutationAuthority(dependencies.runtime)
       ? Effect.fail(failure)
-      : containMalformedPaperProofCommand(operation ?? 'GATE', dependencies.containment, failure)
+      : containMalformedPaperProofCommand(
+          operation ?? 'GATE',
+          dependencies.sourcePlan.accountId,
+          dependencies.containment,
+          failure,
+        )
   }
   const envelope: PaperProofCliEnvelope = decoded.success
   return runPaperProof(envelope.command, {

--- a/services/bayn/src/paper-proof/gates.ts
+++ b/services/bayn/src/paper-proof/gates.ts
@@ -6,7 +6,7 @@ import { BrokerAccess, CapitalAuthorityKind } from '../execution/authority'
 import type { PaperProofCommand, PaperProofRuntimeBinding, PaperProofSourcePlan } from './model'
 import { PaperProofError, protectedEntryToken } from './model'
 
-const containmentIoCount = 3
+export const paperProofContainmentIoCount = 3
 
 const mismatch = (message: string): Result.Result<never, PaperProofError> =>
   Result.fail(
@@ -32,7 +32,7 @@ export const validatePaperProofEntry = (
   runtime: PaperProofRuntimeBinding,
   entryToken: string,
 ): Result.Result<void, PaperProofError> => {
-  const containmentReservationMs = command.containmentIoTimeoutMs * containmentIoCount
+  const containmentReservationMs = command.containmentIoTimeoutMs * paperProofContainmentIoCount
   if (command.timeoutMs <= containmentReservationMs) {
     return mismatch('paper proof timeout must reserve three separately bounded containment I/O windows')
   }

--- a/services/bayn/src/paper-proof/index.ts
+++ b/services/bayn/src/paper-proof/index.ts
@@ -1,4 +1,18 @@
-export { hasPaperProofMutationAuthority, validatePaperProofEntry } from './gates'
+export { hasPaperProofMutationAuthority, paperProofContainmentIoCount, validatePaperProofEntry } from './gates'
+export {
+  runPaperProofCancel,
+  runPaperProofSubmit,
+  type PaperProofCancelDependencies,
+  type PaperProofSubmitDependencies,
+} from './mutations'
+export { runPaperProofPrepare, type PaperProofPrepareDependencies } from './prepare'
+export { runPaperProofRecover, type PaperProofRecoverDependencies } from './recovery'
+export {
+  type PaperProofContainmentDependencies,
+  type PaperProofCommandFor,
+  type PaperProofOperationContext,
+  type PaperProofRestrictionDependencies,
+} from './operations'
 export {
   decodePaperProofCliEnvelopeResult,
   decodePaperProofCommandResult,

--- a/services/bayn/src/paper-proof/index.ts
+++ b/services/bayn/src/paper-proof/index.ts
@@ -1,12 +1,7 @@
 export { hasPaperProofMutationAuthority, paperProofContainmentIoCount, validatePaperProofEntry } from './gates'
-export {
-  runPaperProofCancel,
-  runPaperProofSubmit,
-  type PaperProofCancelDependencies,
-  type PaperProofSubmitDependencies,
-} from './mutations'
-export { runPaperProofPrepare, type PaperProofPrepareDependencies } from './prepare'
-export { runPaperProofRecover, type PaperProofRecoverDependencies } from './recovery'
+export { type PaperProofCancelDependencies, type PaperProofSubmitDependencies } from './mutations'
+export { type PaperProofPrepareDependencies } from './prepare'
+export { type PaperProofRecoverDependencies } from './recovery'
 export {
   type PaperProofContainmentDependencies,
   type PaperProofCommandFor,

--- a/services/bayn/src/paper-proof/mutations.ts
+++ b/services/bayn/src/paper-proof/mutations.ts
@@ -1,0 +1,323 @@
+import { Effect } from 'effect'
+
+import { MutationOperation } from '../broker/alpaca-mutations'
+import type { CapitalGrantProofBinding } from '../execution/contracts'
+import type { MutationEvent } from '../execution/mutations'
+import {
+  completePaperProofReceipt,
+  decideCancellationAdmission,
+  decideSubmitAdmission,
+  ensureRecoveryMarkerCompatible,
+  isCancellationSettled,
+  isRecoveredCancellation,
+  isSuccessfulSubmit,
+  isTerminalSubmit,
+  lift,
+  markRecoveryRequired,
+  observeReconciliation,
+  paperProofFailure,
+  persistRecoveryCompletion,
+  readPaperProofIntent,
+  readPaperProofMutation,
+  recoverMutationLookup,
+  reconcileExact,
+  restrictPaperProof,
+  validateExactReconciliation,
+  type PaperProofExecutionHook,
+  type PaperProofMutationRecoveryStore,
+  type PaperProofMutationStore,
+  type PaperProofOperationContext,
+  type PaperProofReceiptFields,
+  type PaperProofRestrictionDependencies,
+} from './operations'
+import { proofBinding } from './model'
+import type {
+  PaperProofError,
+  PaperProofIntentSnapshot,
+  PaperProofReceipt,
+  PaperProofReconciliation,
+  PaperProofRecoveryRequired,
+  PreparedPaperProofIntent,
+} from './model'
+
+export interface PaperProofSubmitDependencies extends PaperProofRestrictionDependencies {
+  readonly activateCapitalGrant: (proof: CapitalGrantProofBinding) => Effect.Effect<void, Error>
+  readonly recovery: PaperProofMutationRecoveryStore
+  readonly mutations: PaperProofMutationStore
+  readonly execution: {
+    /** Lookup-only recovery for a previously started SUBMIT. It never issues another POST. */
+    readonly recover: (intentId: string) => Effect.Effect<MutationEvent, Error>
+    /** The adapter must run the containment hook exactly once immediately before the broker POST. */
+    readonly submit: (
+      intentId: string,
+      consistencyDelayMs: number,
+      beforeBrokerMutation: PaperProofExecutionHook,
+    ) => Effect.Effect<MutationEvent, Error>
+  }
+  readonly prepareIntent: () => Effect.Effect<PreparedPaperProofIntent, Error>
+  readonly reconcile: () => Effect.Effect<PaperProofReconciliation, Error>
+}
+
+export interface PaperProofCancelDependencies extends PaperProofRestrictionDependencies {
+  readonly recovery: PaperProofMutationRecoveryStore
+  readonly mutations: PaperProofMutationStore
+  readonly execution: {
+    /** Lookup-only recovery for a previously started CANCEL. It never issues another DELETE. */
+    readonly recover: (intentId: string) => Effect.Effect<MutationEvent, Error>
+    /** The adapter must run the containment hook exactly once immediately before the broker DELETE. */
+    readonly cancel: (
+      intentId: string,
+      consistencyDelayMs: number,
+      beforeBrokerMutation: PaperProofExecutionHook,
+    ) => Effect.Effect<MutationEvent, Error>
+  }
+  readonly readIntent: (intentId: string) => Effect.Effect<PaperProofIntentSnapshot | undefined, Error>
+  readonly reconcile: () => Effect.Effect<PaperProofReconciliation, Error>
+}
+
+const prepareSubmitIntent = (
+  context: PaperProofOperationContext,
+  dependencies: PaperProofSubmitDependencies,
+): Effect.Effect<PreparedPaperProofIntent, PaperProofError> =>
+  lift('SUBMIT', 'paper proof intent preparation failed', dependencies.prepareIntent()).pipe(
+    Effect.flatMap((prepared) =>
+      prepared.intentId === context.sourcePlan.intentId
+        ? Effect.succeed(prepared)
+        : Effect.fail(
+            paperProofFailure(
+              'SUBMIT',
+              'prepared PAPER intent identity does not match the source-controlled proof plan',
+              prepared,
+              'invariant',
+            ),
+          ),
+    ),
+  )
+
+const prepareCancellation = (
+  context: PaperProofOperationContext,
+  dependencies: PaperProofCancelDependencies,
+): Effect.Effect<{ readonly existing?: MutationEvent }, PaperProofError> =>
+  Effect.gen(function* () {
+    const existing = yield* readPaperProofMutation(context, 'CANCEL', dependencies.mutations, MutationOperation.Cancel)
+    if (existing !== undefined) return { existing }
+
+    const submitted = yield* readPaperProofMutation(context, 'CANCEL', dependencies.mutations, MutationOperation.Submit)
+    if (submitted === undefined || !isSuccessfulSubmit(submitted) || submitted.brokerOrderId === undefined) {
+      return yield* Effect.fromResult(decideCancellationAdmission(existing, submitted, undefined)).pipe(
+        Effect.map(() => ({})),
+      )
+    }
+    const intent = yield* readPaperProofIntent(context, 'CANCEL', dependencies.readIntent)
+    return yield* Effect.fromResult(decideCancellationAdmission(existing, submitted, intent)).pipe(
+      Effect.map(() => ({})),
+    )
+  })
+
+const settleSubmitReceipt = (
+  context: PaperProofOperationContext,
+  dependencies: PaperProofSubmitDependencies,
+  input: PaperProofReceiptFields,
+): Effect.Effect<PaperProofReceipt, PaperProofError> =>
+  Effect.gen(function* () {
+    const receipt = yield* completePaperProofReceipt(context, dependencies.currentUtcInstant, input)
+    if (!receipt.recoveryRequired) {
+      yield* persistRecoveryCompletion(
+        context,
+        {
+          recovery: dependencies.recovery,
+          latestCancellation: () =>
+            readPaperProofMutation(context, 'RECOVERY_STATE', dependencies.mutations, MutationOperation.Cancel),
+        },
+        'SUBMIT',
+        receipt,
+      )
+    }
+    return receipt
+  })
+
+const runExistingSubmit = (
+  context: PaperProofOperationContext<'SUBMIT'>,
+  dependencies: PaperProofSubmitDependencies,
+  prepared: PreparedPaperProofIntent,
+  before: PaperProofReconciliation,
+  existing: MutationEvent,
+  existingMarker: PaperProofRecoveryRequired | undefined,
+): Effect.Effect<PaperProofReceipt, PaperProofError> =>
+  Effect.gen(function* () {
+    if (!isTerminalSubmit(existing)) {
+      yield* markRecoveryRequired(context, dependencies, 'SUBMIT', 'paper-proof-existing-submit')
+    }
+    const event = isTerminalSubmit(existing)
+      ? existing
+      : yield* recoverMutationLookup(context, MutationOperation.Submit, () =>
+          dependencies.execution.recover(context.sourcePlan.intentId),
+        )
+    let restricted = false
+    if (!isSuccessfulSubmit(event)) {
+      yield* restrictPaperProof(dependencies, `paper-proof-submit-${event.eventType.toLowerCase()}`)
+      restricted = true
+    }
+    const finalReconciliation = isTerminalSubmit(event)
+      ? yield* reconcileExact(context.sourcePlan.accountId, dependencies.reconcile)
+      : yield* observeReconciliation(context.sourcePlan.accountId, dependencies.reconcile)
+    const input: PaperProofReceiptFields = {
+      clientOrderId: prepared.clientOrderId,
+      mutation: event,
+      reconciliations: [before, finalReconciliation],
+      restricted,
+      recoveryRequired: !isTerminalSubmit(event),
+    }
+    return isTerminalSubmit(existing) && existingMarker === undefined
+      ? yield* completePaperProofReceipt(context, dependencies.currentUtcInstant, input)
+      : yield* settleSubmitReceipt(context, dependencies, input)
+  })
+
+const runNewSubmit = (
+  context: PaperProofOperationContext<'SUBMIT'>,
+  dependencies: PaperProofSubmitDependencies,
+  prepared: PreparedPaperProofIntent,
+  before: PaperProofReconciliation,
+): Effect.Effect<PaperProofReceipt, PaperProofError> =>
+  Effect.gen(function* () {
+    yield* Effect.fromResult(
+      // The preflight reconciliation is also checked after activation so the broker hook cannot run on stale state.
+      validateExactReconciliation(before),
+    )
+    yield* lift(
+      'SUBMIT',
+      'paper proof generation activation failed',
+      dependencies.activateCapitalGrant(proofBinding(context.command)),
+    )
+    const afterActivation = yield* reconcileExact(context.sourcePlan.accountId, dependencies.reconcile)
+    const event = yield* lift(
+      'SUBMIT',
+      'paper proof guarded submit failed',
+      dependencies.execution.submit(prepared.intentId, context.command.consistencyDelayMs, () =>
+        markRecoveryRequired(context, dependencies, 'SUBMIT', 'paper-proof-new-submit'),
+      ),
+    )
+    let restricted = false
+    if (!isSuccessfulSubmit(event)) {
+      yield* restrictPaperProof(dependencies, `paper-proof-submit-${event.eventType.toLowerCase()}`)
+      restricted = true
+    }
+    const finalReconciliation = isTerminalSubmit(event)
+      ? yield* reconcileExact(context.sourcePlan.accountId, dependencies.reconcile)
+      : yield* observeReconciliation(context.sourcePlan.accountId, dependencies.reconcile)
+    return yield* settleSubmitReceipt(context, dependencies, {
+      clientOrderId: prepared.clientOrderId,
+      mutation: event,
+      reconciliations: [before, afterActivation, finalReconciliation],
+      restricted,
+      recoveryRequired: !isTerminalSubmit(event),
+    })
+  })
+
+const runExistingCancel = (
+  context: PaperProofOperationContext<'CANCEL'>,
+  dependencies: PaperProofCancelDependencies,
+  before: PaperProofReconciliation,
+  existing: MutationEvent,
+): Effect.Effect<PaperProofReceipt, PaperProofError> =>
+  Effect.gen(function* () {
+    yield* markRecoveryRequired(context, dependencies, 'CANCEL', 'paper-proof-existing-cancel')
+    const event = isRecoveredCancellation(existing)
+      ? existing
+      : yield* recoverMutationLookup(context, MutationOperation.Cancel, () =>
+          dependencies.execution.recover(context.sourcePlan.intentId),
+        )
+    yield* restrictPaperProof(dependencies, `paper-proof-cancel-${event.eventType.toLowerCase()}`)
+    const settled = isRecoveredCancellation(event)
+      ? yield* readPaperProofIntent(context, 'CANCEL', dependencies.readIntent).pipe(
+          Effect.map((intent) => isCancellationSettled(event, intent)),
+        )
+      : false
+    const after = settled
+      ? yield* reconcileExact(context.sourcePlan.accountId, dependencies.reconcile)
+      : yield* observeReconciliation(context.sourcePlan.accountId, dependencies.reconcile)
+    const receipt = yield* completePaperProofReceipt(context, dependencies.currentUtcInstant, {
+      mutation: event,
+      reconciliations: [before, after],
+      restricted: true,
+      recoveryRequired: !settled,
+    })
+    if (settled) {
+      yield* persistRecoveryCompletion(context, { recovery: dependencies.recovery }, 'CANCEL', receipt)
+    }
+    return receipt
+  })
+
+export const runPaperProofSubmit = (
+  context: PaperProofOperationContext<'SUBMIT'>,
+  dependencies: PaperProofSubmitDependencies,
+): Effect.Effect<PaperProofReceipt, PaperProofError> =>
+  Effect.gen(function* () {
+    const existingMarker = yield* ensureRecoveryMarkerCompatible(context, dependencies, 'SUBMIT')
+    const before = yield* observeReconciliation(context.sourcePlan.accountId, dependencies.reconcile)
+    const prepared = yield* prepareSubmitIntent(context, dependencies)
+    const cancellation = yield* readPaperProofMutation(
+      context,
+      'SUBMIT',
+      dependencies.mutations,
+      MutationOperation.Cancel,
+    )
+    if (cancellation !== undefined) {
+      return yield* Effect.fail(
+        paperProofFailure(
+          'SUBMIT',
+          'paper proof submit is superseded by a durable cancellation mutation',
+          cancellation,
+          'mutation-unresolved',
+        ),
+      )
+    }
+    const existing = yield* readPaperProofMutation(context, 'SUBMIT', dependencies.mutations, MutationOperation.Submit)
+    const admission = yield* Effect.fromResult(decideSubmitAdmission(cancellation, existing))
+    return admission._tag === 'New'
+      ? yield* runNewSubmit(context, dependencies, prepared, before)
+      : yield* runExistingSubmit(context, dependencies, prepared, before, admission.event, existingMarker)
+  })
+
+export const runPaperProofCancel = (
+  context: PaperProofOperationContext<'CANCEL'>,
+  dependencies: PaperProofCancelDependencies,
+): Effect.Effect<PaperProofReceipt, PaperProofError> =>
+  Effect.gen(function* () {
+    const before = yield* observeReconciliation(context.sourcePlan.accountId, dependencies.reconcile)
+    const prepared = yield* prepareCancellation(context, dependencies)
+    if (prepared.existing !== undefined)
+      return yield* runExistingCancel(context, dependencies, before, prepared.existing)
+
+    const event = yield* lift(
+      'CANCEL',
+      'paper proof identified cancellation failed',
+      dependencies.execution.cancel(context.sourcePlan.intentId, context.command.consistencyDelayMs, () =>
+        markRecoveryRequired(context, dependencies, 'CANCEL', 'paper-proof-cancel'),
+      ),
+    )
+    const recovered = isRecoveredCancellation(event)
+      ? event
+      : yield* recoverMutationLookup(context, MutationOperation.Cancel, () =>
+          dependencies.execution.recover(context.sourcePlan.intentId),
+        )
+    yield* restrictPaperProof(dependencies, `paper-proof-cancel-${recovered.eventType.toLowerCase()}`)
+    const settled = isRecoveredCancellation(recovered)
+      ? yield* readPaperProofIntent(context, 'CANCEL', dependencies.readIntent).pipe(
+          Effect.map((intent) => isCancellationSettled(recovered, intent)),
+        )
+      : false
+    const after = settled
+      ? yield* reconcileExact(context.sourcePlan.accountId, dependencies.reconcile)
+      : yield* observeReconciliation(context.sourcePlan.accountId, dependencies.reconcile)
+    const receipt = yield* completePaperProofReceipt(context, dependencies.currentUtcInstant, {
+      mutation: recovered,
+      reconciliations: [before, after],
+      restricted: true,
+      recoveryRequired: !settled,
+    })
+    if (settled) {
+      yield* persistRecoveryCompletion(context, { recovery: dependencies.recovery }, 'CANCEL', receipt)
+    }
+    return receipt
+  })

--- a/services/bayn/src/paper-proof/operations.ts
+++ b/services/bayn/src/paper-proof/operations.ts
@@ -1,0 +1,651 @@
+import { Duration, Effect, Result } from 'effect'
+
+import { MutationOperation } from '../broker/alpaca-mutations'
+import { IntentState } from '../execution/contracts'
+import { MutationEventType, type MutationEvent, type MutationStoreShape } from '../execution/mutations'
+import {
+  PaperProofError,
+  paperProofReceiptSchemaVersion,
+  paperProofRecoveryCompletionSchemaVersion,
+  paperProofRecoveryRequiredSchemaVersion,
+  type PaperProofCommand,
+  type PaperProofIntentSnapshot,
+  type PaperProofMutationOperation,
+  type PaperProofOperation,
+  type PaperProofReceipt,
+  type PaperProofReconciliation,
+  type PaperProofRecoveryCompletion,
+  type PaperProofRecoveryRequired,
+  type PaperProofRecoveryStore,
+  type PaperProofSourcePlan,
+} from './model'
+
+export type PaperProofCommandFor<Operation extends PaperProofOperation> = Omit<PaperProofCommand, 'operation'> & {
+  readonly operation: Operation
+}
+
+export interface PaperProofOperationContext<Operation extends PaperProofOperation = PaperProofOperation> {
+  readonly command: PaperProofCommandFor<Operation>
+  readonly sourcePlan: PaperProofSourcePlan
+}
+
+export interface PaperProofContainmentDependencies {
+  readonly accountId: string
+  readonly restrictAuthority: (reason: string, updatedAt: string) => Effect.Effect<void, Error>
+  readonly reconcile: () => Effect.Effect<PaperProofReconciliation, Error>
+  readonly currentUtcInstant: Effect.Effect<string, Error>
+}
+
+export interface PaperProofRestrictionDependencies {
+  readonly restrictAuthority: (reason: string, updatedAt: string) => Effect.Effect<void, Error>
+  readonly currentUtcInstant: Effect.Effect<string, Error>
+}
+
+export type PaperProofMutationStore = Pick<MutationStoreShape, 'latest'>
+export type PaperProofMutationRecoveryStore = Pick<PaperProofRecoveryStore, 'load' | 'markRequired' | 'complete'>
+
+export type PaperProofReceiptFields = Omit<
+  PaperProofReceipt,
+  'schemaVersion' | 'operation' | 'proofPlanHash' | 'qualificationRunId' | 'intentId' | 'completedAt'
+>
+
+export type PaperProofExecutionHook = () => Effect.Effect<void, PaperProofError>
+
+export const paperProofFailure = (
+  operation: PaperProofError['operation'],
+  message: string,
+  cause: unknown,
+  failure: PaperProofError['failure'] = 'operational',
+): PaperProofError =>
+  new PaperProofError({
+    operation,
+    failure,
+    message,
+    cause,
+  })
+
+export const timeoutFailure = (operation: PaperProofError['operation'], message: string): PaperProofError =>
+  new PaperProofError({
+    operation,
+    failure: 'timeout',
+    message,
+  })
+
+export const lift = <A>(
+  operation: PaperProofError['operation'],
+  message: string,
+  effect: Effect.Effect<A, Error>,
+): Effect.Effect<A, PaperProofError> =>
+  effect.pipe(Effect.mapError((cause) => paperProofFailure(operation, message, cause)))
+
+export const liftBounded = <A>(
+  operation: PaperProofError['operation'],
+  message: string,
+  effect: Effect.Effect<A, Error>,
+  timeoutMs: number,
+): Effect.Effect<A, PaperProofError> =>
+  lift(operation, message, effect).pipe(
+    Effect.timeoutOrElse({
+      duration: Duration.millis(timeoutMs),
+      orElse: () =>
+        Effect.fail(
+          timeoutFailure(operation, `${message} exceeded its ${timeoutMs.toString()}ms containment I/O bound`),
+        ),
+    }),
+  )
+
+export const validateReconciliationAccount = (
+  expectedAccountId: string,
+  reconciliation: PaperProofReconciliation,
+): Result.Result<PaperProofReconciliation, PaperProofError> =>
+  reconciliation.accountId === expectedAccountId
+    ? Result.succeed(reconciliation)
+    : Result.fail(
+        paperProofFailure(
+          'RECONCILE',
+          'paper proof reconciliation account does not match the source-controlled account',
+          reconciliation,
+          'invariant',
+        ),
+      )
+
+export const validateExactReconciliation = (
+  reconciliation: PaperProofReconciliation,
+): Result.Result<PaperProofReconciliation, PaperProofError> =>
+  reconciliation.status === 'EXACT' && reconciliation.unknownMutationCount === 0
+    ? Result.succeed(reconciliation)
+    : Result.fail(
+        paperProofFailure(
+          'RECONCILE',
+          'paper proof requires exact reconciliation with zero unknown mutations',
+          reconciliation,
+          'invariant',
+        ),
+      )
+
+export const observeReconciliation = (
+  accountId: string,
+  reconcile: () => Effect.Effect<PaperProofReconciliation, Error>,
+): Effect.Effect<PaperProofReconciliation, PaperProofError> =>
+  lift('RECONCILE', 'paper proof reconciliation failed', reconcile()).pipe(
+    Effect.flatMap((result) => Effect.fromResult(validateReconciliationAccount(accountId, result))),
+  )
+
+export const reconcileExact = (
+  accountId: string,
+  reconcile: () => Effect.Effect<PaperProofReconciliation, Error>,
+): Effect.Effect<PaperProofReconciliation, PaperProofError> =>
+  observeReconciliation(accountId, reconcile).pipe(
+    Effect.flatMap((result) => Effect.fromResult(validateExactReconciliation(result))),
+  )
+
+export const restrictPaperProof = (
+  dependencies: PaperProofRestrictionDependencies,
+  reason: string,
+): Effect.Effect<void, PaperProofError> =>
+  lift('RESTRICT', 'paper proof failed to read the restriction clock', dependencies.currentUtcInstant).pipe(
+    Effect.flatMap((updatedAt) =>
+      lift(
+        'RESTRICT',
+        'paper proof failed to restrict mutation authority',
+        dependencies.restrictAuthority(reason.slice(0, 240), updatedAt),
+      ),
+    ),
+  )
+
+export const makePaperProofReceipt = (
+  context: PaperProofOperationContext,
+  completedAt: string,
+  input: PaperProofReceiptFields,
+): PaperProofReceipt => ({
+  schemaVersion: paperProofReceiptSchemaVersion,
+  operation: context.command.operation,
+  proofPlanHash: context.command.proofPlanHash,
+  qualificationRunId: context.command.qualificationRunId,
+  intentId: context.sourcePlan.intentId,
+  completedAt,
+  ...input,
+})
+
+export const completePaperProofReceipt = (
+  context: PaperProofOperationContext,
+  currentUtcInstant: Effect.Effect<string, Error>,
+  input: PaperProofReceiptFields,
+): Effect.Effect<PaperProofReceipt, PaperProofError> =>
+  lift(context.command.operation, 'paper proof completion clock failed', currentUtcInstant).pipe(
+    Effect.map((completedAt) => makePaperProofReceipt(context, completedAt, input)),
+  )
+
+export const isSuccessfulSubmit = (event: MutationEvent): boolean =>
+  event.operation === MutationOperation.Submit &&
+  (event.eventType === MutationEventType.SubmitAccepted || event.eventType === MutationEventType.RecoveryFound)
+
+export const isTerminalSubmit = (event: MutationEvent): boolean =>
+  event.operation === MutationOperation.Submit &&
+  (isSuccessfulSubmit(event) ||
+    event.eventType === MutationEventType.SubmitRejected ||
+    event.eventType === MutationEventType.SubmitDenied)
+
+export const isRecoveredCancellation = (event: MutationEvent): boolean =>
+  event.operation === MutationOperation.Cancel && event.eventType === MutationEventType.RecoveryFound
+
+export const isCancellationSettled = (event: MutationEvent, intent: PaperProofIntentSnapshot): boolean =>
+  isRecoveredCancellation(event) && intent.state === IntentState.Terminal && intent.terminalOutcome !== undefined
+
+export type SubmitAdmission =
+  | {
+      readonly _tag: 'New'
+    }
+  | {
+      readonly _tag: 'Existing'
+      readonly event: MutationEvent
+    }
+
+export const decideSubmitAdmission = (
+  cancellation: MutationEvent | undefined,
+  existing: MutationEvent | undefined,
+): Result.Result<SubmitAdmission, PaperProofError> => {
+  if (cancellation !== undefined) {
+    return Result.fail(
+      paperProofFailure(
+        'SUBMIT',
+        'paper proof submit is superseded by a durable cancellation mutation',
+        cancellation,
+        'mutation-unresolved',
+      ),
+    )
+  }
+  return existing === undefined
+    ? Result.succeed({ _tag: 'New' })
+    : Result.succeed({ _tag: 'Existing', event: existing })
+}
+
+export type CancellationAdmission =
+  | {
+      readonly _tag: 'Existing'
+      readonly event: MutationEvent
+    }
+  | {
+      readonly _tag: 'New'
+    }
+
+export const decideCancellationAdmission = (
+  existing: MutationEvent | undefined,
+  submitted: MutationEvent | undefined,
+  intent: PaperProofIntentSnapshot | undefined,
+): Result.Result<CancellationAdmission, PaperProofError> => {
+  if (existing !== undefined) return Result.succeed({ _tag: 'Existing', event: existing })
+  if (submitted === undefined || !isSuccessfulSubmit(submitted) || submitted.brokerOrderId === undefined) {
+    return Result.fail(
+      paperProofFailure(
+        'CANCEL',
+        'paper proof cancellation requires an exact durable submitted broker order',
+        submitted,
+        'mutation-unresolved',
+      ),
+    )
+  }
+  if (intent === undefined) {
+    return Result.fail(paperProofFailure('CANCEL', 'paper proof durable intent does not exist', intent, 'invariant'))
+  }
+  if (intent.state !== IntentState.Acknowledged) {
+    return Result.fail(
+      paperProofFailure(
+        'CANCEL',
+        'paper proof cancellation requires an acknowledged durable intent',
+        intent,
+        'mutation-unresolved',
+      ),
+    )
+  }
+  return Result.succeed({ _tag: 'New' })
+}
+
+export const sameMutationEvent = (left: MutationEvent, right: MutationEvent): boolean =>
+  left.schemaVersion === right.schemaVersion &&
+  left.eventId === right.eventId &&
+  left.mutationId === right.mutationId &&
+  left.intentId === right.intentId &&
+  left.sequence === right.sequence &&
+  left.operation === right.operation &&
+  left.eventType === right.eventType &&
+  left.requestHash === right.requestHash &&
+  left.consistencyDelayMs === right.consistencyDelayMs &&
+  left.brokerOrderId === right.brokerOrderId &&
+  left.requestId === right.requestId &&
+  left.responseStatus === right.responseStatus &&
+  left.responseContentHash === right.responseContentHash &&
+  left.occurredAt === right.occurredAt
+
+export interface DurableMutationState {
+  readonly submit?: MutationEvent
+  readonly cancel?: MutationEvent
+}
+
+export const markerMutationOperation = (operation: PaperProofMutationOperation): MutationOperation =>
+  operation === 'CANCEL' ? MutationOperation.Cancel : MutationOperation.Submit
+
+export const mutationForOperation = (
+  state: DurableMutationState,
+  operation: PaperProofMutationOperation,
+): MutationEvent | undefined => (operation === 'CANCEL' ? state.cancel : state.submit)
+
+export const selectRecoveryOperation = (
+  state: DurableMutationState,
+  required: PaperProofRecoveryRequired | undefined,
+): PaperProofMutationOperation | undefined => {
+  if (state.cancel !== undefined) return 'CANCEL'
+  if (required !== undefined) return required.operation
+  return state.submit === undefined ? undefined : 'SUBMIT'
+}
+
+export const decideRecoverySelection = (
+  state: DurableMutationState,
+  required: PaperProofRecoveryRequired | undefined,
+): Result.Result<
+  { readonly operation: PaperProofMutationOperation; readonly recorded: MutationEvent },
+  PaperProofError
+> => {
+  const operation = selectRecoveryOperation(state, required)
+  if (operation === undefined) {
+    return Result.fail(
+      paperProofFailure(
+        'RECOVERY_STATE',
+        'paper proof RECOVER requires a durable marker, completion, or mutation evidence',
+        { required, mutations: state },
+        'mutation-unresolved',
+      ),
+    )
+  }
+  const recorded = mutationForOperation(state, operation)
+  return recorded === undefined
+    ? Result.fail(
+        paperProofFailure(
+          'RECOVERY_STATE',
+          'paper proof recovery marker does not have a durable mutation to recover',
+          { operation, required, mutations: state },
+          'mutation-unresolved',
+        ),
+      )
+    : Result.succeed({ operation, recorded })
+}
+
+export const completionMatchesAuthoritativeMutation = (
+  state: DurableMutationState,
+  completion: PaperProofRecoveryCompletion,
+): boolean => {
+  if (completion.operation === 'SUBMIT' && state.cancel !== undefined) return false
+  const latest = mutationForOperation(state, completion.operation)
+  return latest !== undefined && sameMutationEvent(latest, completion.mutation)
+}
+
+export const validateCompletionMutationIdentity = (
+  context: PaperProofOperationContext,
+  completion: PaperProofRecoveryCompletion,
+): Result.Result<void, PaperProofError> => {
+  const expectedOperation = markerMutationOperation(completion.operation)
+  return completion.mutation.intentId === context.sourcePlan.intentId &&
+    completion.mutation.operation === expectedOperation
+    ? Result.succeed(undefined)
+    : Result.fail(
+        paperProofFailure(
+          'RECOVERY_STATE',
+          'paper proof durable recovery completion mutation identity is invalid',
+          completion,
+          'invariant',
+        ),
+      )
+}
+
+export const recoveryIdentityMatches = (
+  context: PaperProofOperationContext,
+  value: Pick<PaperProofRecoveryRequired, 'intentId' | 'proofPlanHash' | 'qualificationRunId'>,
+): boolean =>
+  value.intentId === context.sourcePlan.intentId &&
+  value.proofPlanHash === context.command.proofPlanHash &&
+  value.qualificationRunId === context.command.qualificationRunId
+
+export interface PaperProofRecoveryMarkerDependencies {
+  readonly recovery: Pick<PaperProofRecoveryStore, 'load' | 'markRequired'>
+  readonly currentUtcInstant: Effect.Effect<string, Error>
+}
+
+export const ensureRecoveryMarkerCompatible = (
+  context: PaperProofOperationContext,
+  dependencies: PaperProofRecoveryMarkerDependencies,
+  operation: PaperProofMutationOperation,
+): Effect.Effect<PaperProofRecoveryRequired | undefined, PaperProofError> =>
+  liftBounded(
+    'RECOVERY_STATE',
+    'paper proof failed to load the existing durable recovery marker',
+    dependencies.recovery.load(context.sourcePlan.intentId),
+    context.command.containmentIoTimeoutMs,
+  ).pipe(
+    Effect.flatMap((existing) => {
+      if (existing === undefined) return Effect.succeed(undefined)
+      if (!recoveryIdentityMatches(context, existing)) {
+        return Effect.fail(
+          paperProofFailure(
+            'RECOVERY_STATE',
+            'paper proof durable recovery marker does not match the pinned proof identity',
+            existing,
+            'invariant',
+          ),
+        )
+      }
+      if (existing.operation === 'CANCEL' && operation === 'SUBMIT') {
+        return Effect.fail(
+          paperProofFailure(
+            'RECOVERY_STATE',
+            'paper proof cannot replace an unresolved cancellation marker with submit recovery',
+            existing,
+            'mutation-unresolved',
+          ),
+        )
+      }
+      return Effect.succeed(existing)
+    }),
+  )
+
+export const makeRecoveryRequired = (
+  context: PaperProofOperationContext,
+  operation: PaperProofMutationOperation,
+  reason: string,
+  requiredAt: string,
+): PaperProofRecoveryRequired => ({
+  schemaVersion: paperProofRecoveryRequiredSchemaVersion,
+  intentId: context.sourcePlan.intentId,
+  proofPlanHash: context.command.proofPlanHash,
+  qualificationRunId: context.command.qualificationRunId,
+  operation,
+  reason: reason.slice(0, 240),
+  requiredAt,
+})
+
+export const markRecoveryRequired = (
+  context: PaperProofOperationContext,
+  dependencies: PaperProofRecoveryMarkerDependencies,
+  operation: PaperProofMutationOperation,
+  reason: string,
+): Effect.Effect<void, PaperProofError> =>
+  ensureRecoveryMarkerCompatible(context, dependencies, operation).pipe(
+    Effect.flatMap((existing) => {
+      if (existing?.operation === operation) return Effect.void
+      return liftBounded(
+        'RECOVERY_STATE',
+        'paper proof failed to read the recovery marker clock',
+        dependencies.currentUtcInstant,
+        context.command.containmentIoTimeoutMs,
+      ).pipe(
+        Effect.flatMap((requiredAt) =>
+          liftBounded(
+            'RECOVERY_STATE',
+            'paper proof failed to durably mark recovery required',
+            dependencies.recovery.markRequired(makeRecoveryRequired(context, operation, reason, requiredAt)),
+            context.command.containmentIoTimeoutMs,
+          ),
+        ),
+      )
+    }),
+  )
+
+export const loadRecoveryRequired = (
+  context: PaperProofOperationContext,
+  recovery: Pick<PaperProofRecoveryStore, 'load'>,
+): Effect.Effect<PaperProofRecoveryRequired | undefined, PaperProofError> =>
+  liftBounded(
+    'RECOVERY_STATE',
+    'paper proof failed to load the durable recovery marker',
+    recovery.load(context.sourcePlan.intentId),
+    context.command.containmentIoTimeoutMs,
+  ).pipe(
+    Effect.flatMap((required) =>
+      required === undefined || recoveryIdentityMatches(context, required)
+        ? Effect.succeed(required)
+        : Effect.fail(
+            paperProofFailure(
+              'RECOVERY_STATE',
+              'paper proof durable recovery marker does not match the pinned proof identity',
+              required,
+              'invariant',
+            ),
+          ),
+    ),
+  )
+
+export const loadRecoveryCompletion = (
+  context: PaperProofOperationContext,
+  recovery: Pick<PaperProofRecoveryStore, 'loadCompletion'>,
+): Effect.Effect<PaperProofRecoveryCompletion | undefined, PaperProofError> =>
+  liftBounded(
+    'RECOVERY_STATE',
+    'paper proof failed to load durable recovery completion',
+    recovery.loadCompletion(context.sourcePlan.intentId),
+    context.command.containmentIoTimeoutMs,
+  ).pipe(
+    Effect.flatMap((completion) => {
+      if (completion !== undefined && !recoveryIdentityMatches(context, completion)) {
+        return Effect.fail(
+          paperProofFailure(
+            'RECOVERY_STATE',
+            'paper proof durable recovery completion does not match the pinned proof identity',
+            completion,
+            'invariant',
+          ),
+        )
+      }
+      return Effect.succeed(completion)
+    }),
+  )
+
+export const readPaperProofIntent = (
+  context: PaperProofOperationContext,
+  operation: PaperProofError['operation'],
+  readIntent: (intentId: string) => Effect.Effect<PaperProofIntentSnapshot | undefined, Error>,
+): Effect.Effect<PaperProofIntentSnapshot, PaperProofError> =>
+  lift(operation, 'paper proof durable intent read failed', readIntent(context.sourcePlan.intentId)).pipe(
+    Effect.flatMap((snapshot) =>
+      snapshot === undefined
+        ? Effect.fail(paperProofFailure(operation, 'paper proof durable intent does not exist', snapshot, 'invariant'))
+        : Effect.succeed(snapshot),
+    ),
+  )
+
+export const readPaperProofMutation = (
+  context: PaperProofOperationContext,
+  operation: PaperProofError['operation'],
+  mutations: PaperProofMutationStore,
+  mutationOperation: MutationOperation,
+): Effect.Effect<MutationEvent | undefined, PaperProofError> =>
+  lift(
+    operation,
+    `paper proof durable ${mutationOperation.toLowerCase()} read failed`,
+    mutations.latest(context.sourcePlan.intentId, mutationOperation),
+  )
+
+export const readDurableMutationState = (
+  context: PaperProofOperationContext,
+  operation: PaperProofError['operation'],
+  mutations: PaperProofMutationStore,
+): Effect.Effect<DurableMutationState, PaperProofError> =>
+  Effect.gen(function* () {
+    const submit = yield* readPaperProofMutation(context, operation, mutations, MutationOperation.Submit)
+    const cancel = yield* readPaperProofMutation(context, operation, mutations, MutationOperation.Cancel)
+    return {
+      ...(submit === undefined ? {} : { submit }),
+      ...(cancel === undefined ? {} : { cancel }),
+    }
+  })
+
+export const recoverMutationLookup = (
+  context: PaperProofOperationContext,
+  operation: MutationOperation,
+  recover: () => Effect.Effect<MutationEvent, Error>,
+): Effect.Effect<MutationEvent, PaperProofError> =>
+  Effect.sleep(Duration.millis(context.command.consistencyDelayMs)).pipe(
+    Effect.andThen(lift('RECOVER', `paper proof lookup-only ${operation.toLowerCase()} recovery failed`, recover())),
+  )
+
+export const makeRecoveryCompletion = (
+  context: PaperProofOperationContext,
+  operation: PaperProofMutationOperation,
+  receipt: PaperProofReceipt,
+): Result.Result<PaperProofRecoveryCompletion, PaperProofError> =>
+  receipt.mutation === undefined
+    ? Result.fail(
+        paperProofFailure(
+          'RECOVERY_STATE',
+          'paper proof recovery completion requires durable mutation evidence',
+          receipt,
+          'invariant',
+        ),
+      )
+    : Result.succeed({
+        schemaVersion: paperProofRecoveryCompletionSchemaVersion,
+        intentId: context.sourcePlan.intentId,
+        proofPlanHash: context.command.proofPlanHash,
+        qualificationRunId: context.command.qualificationRunId,
+        operation,
+        ...(receipt.clientOrderId === undefined ? {} : { clientOrderId: receipt.clientOrderId }),
+        mutation: receipt.mutation,
+        reconciliations: receipt.reconciliations,
+        restricted: receipt.restricted,
+        completedAt: receipt.completedAt,
+      })
+
+export const completeRecovery = (
+  context: PaperProofOperationContext,
+  recovery: Pick<PaperProofRecoveryStore, 'complete'>,
+  latestCancellation: (() => Effect.Effect<MutationEvent | undefined, Error>) | undefined,
+  completion: PaperProofRecoveryCompletion,
+): Effect.Effect<void, PaperProofError> =>
+  Effect.gen(function* () {
+    if (completion.operation === 'SUBMIT') {
+      if (latestCancellation === undefined) {
+        return yield* Effect.fail(
+          paperProofFailure(
+            'RECOVERY_STATE',
+            'paper proof submit completion is missing its cancellation-state reader',
+            completion,
+            'invariant',
+          ),
+        )
+      }
+      const cancellation = yield* lift(
+        'RECOVERY_STATE',
+        'paper proof failed to verify submit completion against durable cancellation state',
+        latestCancellation(),
+      )
+      if (cancellation !== undefined) {
+        return yield* Effect.fail(
+          paperProofFailure(
+            'RECOVERY_STATE',
+            'paper proof submit completion is superseded by a durable cancellation mutation',
+            cancellation,
+            'mutation-unresolved',
+          ),
+        )
+      }
+    }
+    yield* liftBounded(
+      'RECOVERY_STATE',
+      'paper proof failed to atomically persist recovery completion',
+      recovery.complete(completion, {
+        expectedLatestMutation: completion.mutation,
+        rejectAnyCancellation: completion.operation === 'SUBMIT',
+      }),
+      context.command.containmentIoTimeoutMs,
+    )
+  })
+
+export const persistRecoveryCompletion = (
+  context: PaperProofOperationContext,
+  dependencies: {
+    readonly recovery: Pick<PaperProofRecoveryStore, 'complete'>
+    readonly latestCancellation?: () => Effect.Effect<MutationEvent | undefined, Error>
+  },
+  operation: PaperProofMutationOperation,
+  receipt: PaperProofReceipt,
+): Effect.Effect<void, PaperProofError> =>
+  Effect.fromResult(makeRecoveryCompletion(context, operation, receipt)).pipe(
+    Effect.flatMap((completion) =>
+      completeRecovery(context, dependencies.recovery, dependencies.latestCancellation, completion),
+    ),
+  )
+
+export const makeReceiptFromCompletion = (
+  context: PaperProofOperationContext,
+  completion: PaperProofRecoveryCompletion,
+): PaperProofReceipt => ({
+  schemaVersion: paperProofReceiptSchemaVersion,
+  operation: context.command.operation,
+  proofPlanHash: context.command.proofPlanHash,
+  qualificationRunId: context.command.qualificationRunId,
+  intentId: context.sourcePlan.intentId,
+  ...(completion.clientOrderId === undefined ? {} : { clientOrderId: completion.clientOrderId }),
+  mutation: completion.mutation,
+  reconciliations: completion.reconciliations,
+  restricted: completion.restricted,
+  recoveryRequired: false,
+  completedAt: completion.completedAt,
+})

--- a/services/bayn/src/paper-proof/operations.ts
+++ b/services/bayn/src/paper-proof/operations.ts
@@ -30,7 +30,6 @@ export interface PaperProofOperationContext<Operation extends PaperProofOperatio
 }
 
 export interface PaperProofContainmentDependencies {
-  readonly accountId: string
   readonly restrictAuthority: (reason: string, updatedAt: string) => Effect.Effect<void, Error>
   readonly reconcile: () => Effect.Effect<PaperProofReconciliation, Error>
   readonly currentUtcInstant: Effect.Effect<string, Error>

--- a/services/bayn/src/paper-proof/prepare.ts
+++ b/services/bayn/src/paper-proof/prepare.ts
@@ -1,0 +1,38 @@
+import { Effect } from 'effect'
+
+import type { CapitalGrantGeneration, CapitalGrantProofBinding } from '../execution/contracts'
+import {
+  completePaperProofReceipt,
+  lift,
+  reconcileExact,
+  type PaperProofOperationContext,
+  type PaperProofReceiptFields,
+} from './operations'
+import { proofBinding } from './model'
+import type { PaperProofError, PaperProofReceipt, PaperProofReconciliation } from './model'
+
+export interface PaperProofPrepareDependencies {
+  readonly prepareCapitalGrant: (proof: CapitalGrantProofBinding) => Effect.Effect<CapitalGrantGeneration, Error>
+  readonly reconcile: () => Effect.Effect<PaperProofReconciliation, Error>
+  readonly currentUtcInstant: Effect.Effect<string, Error>
+}
+
+export const runPaperProofPrepare = (
+  context: PaperProofOperationContext<'PREPARE'>,
+  dependencies: PaperProofPrepareDependencies,
+): Effect.Effect<PaperProofReceipt, PaperProofError> =>
+  Effect.gen(function* () {
+    const reconciliation = yield* reconcileExact(context.sourcePlan.accountId, dependencies.reconcile)
+    const generation = yield* lift(
+      'PREPARE',
+      'paper proof generation PREPARE failed',
+      dependencies.prepareCapitalGrant(proofBinding(context.command)),
+    )
+    const input: PaperProofReceiptFields = {
+      generation,
+      reconciliations: [reconciliation],
+      restricted: false,
+      recoveryRequired: false,
+    }
+    return yield* completePaperProofReceipt(context, dependencies.currentUtcInstant, input)
+  })

--- a/services/bayn/src/paper-proof/program.test.ts
+++ b/services/bayn/src/paper-proof/program.test.ts
@@ -13,8 +13,13 @@ import { paperProofCommandEntryGate, runPaperProofCommand } from '../paper-proof
 import {
   protectedEntryToken,
   runPaperProof,
+  runPaperProofPrepare,
   type PaperProofCommand,
+  type PaperProofCancelDependencies,
   type PaperProofDependencies,
+  type PaperProofPrepareDependencies,
+  type PaperProofRecoverDependencies,
+  type PaperProofSubmitDependencies,
   type PaperProofIntentSnapshot,
   type PaperProofRecoveryCompletion,
   type PaperProofRecoveryRequired,
@@ -63,7 +68,9 @@ const runtime = (mutation: boolean): PaperProofRuntimeBinding => ({
   strategy,
 })
 
-const command = (operation: PaperProofCommand['operation']): PaperProofCommand => ({
+const command = <Operation extends PaperProofCommand['operation']>(
+  operation: Operation,
+): Omit<PaperProofCommand, 'operation'> & { readonly operation: Operation } => ({
   schemaVersion: 'bayn.paper-proof-command.v1',
   operation,
   timeoutMs: 1_000,
@@ -232,6 +239,23 @@ const sameMutationEvent = (left: MutationEvent, right: MutationEvent): boolean =
   left.responseContentHash === right.responseContentHash &&
   left.occurredAt === right.occurredAt
 
+type PaperProofFixtureCapabilities = Pick<PaperProofDependencies, 'sourcePlan' | 'runtime' | 'protectedEntryToken'> & {
+  readonly prepareCapitalGrant: PaperProofDependencies['prepare']['prepareCapitalGrant']
+  readonly activateCapitalGrant: PaperProofDependencies['submit']['activateCapitalGrant']
+  readonly restrictAuthority: PaperProofDependencies['containment']['restrictAuthority']
+  readonly recovery: PaperProofDependencies['recover']['recovery']
+  readonly mutations: PaperProofDependencies['recover']['mutations']
+  readonly execution: {
+    readonly submit: PaperProofDependencies['submit']['execution']['submit']
+    readonly cancel: PaperProofDependencies['cancel']['execution']['cancel']
+    readonly recover: (intentId: string, operation: MutationOperation) => Effect.Effect<MutationEvent, Error>
+  }
+  readonly prepareIntent: PaperProofDependencies['submit']['prepareIntent']
+  readonly readIntent: PaperProofDependencies['cancel']['readIntent']
+  readonly reconcile: PaperProofDependencies['containment']['reconcile']
+  readonly currentUtcInstant: PaperProofDependencies['containment']['currentUtcInstant']
+}
+
 const fixture = (options: FixtureOptions) => {
   const sequence: string[] = []
   const recoveryState = options.recoveryState ?? {}
@@ -259,7 +283,7 @@ const fixture = (options: FixtureOptions) => {
     recoveryComplete: 0,
     clock: 0,
   }
-  const dependencies: PaperProofDependencies = {
+  const capabilities: PaperProofFixtureCapabilities = {
     sourcePlan,
     runtime: runtime(options.operation !== 'PREPARE'),
     protectedEntryToken: protectedEntryToken(sourcePlan),
@@ -436,6 +460,59 @@ const fixture = (options: FixtureOptions) => {
         : Effect.succeed('2026-07-31T08:00:01.000Z')
     }),
   }
+  const dependencies: PaperProofDependencies = {
+    sourcePlan: capabilities.sourcePlan,
+    runtime: capabilities.runtime,
+    protectedEntryToken: capabilities.protectedEntryToken,
+    containment: {
+      accountId,
+      restrictAuthority: capabilities.restrictAuthority,
+      reconcile: capabilities.reconcile,
+      currentUtcInstant: capabilities.currentUtcInstant,
+    },
+    prepare: {
+      prepareCapitalGrant: capabilities.prepareCapitalGrant,
+      reconcile: capabilities.reconcile,
+      currentUtcInstant: capabilities.currentUtcInstant,
+    },
+    submit: {
+      activateCapitalGrant: capabilities.activateCapitalGrant,
+      recovery: capabilities.recovery,
+      mutations: capabilities.mutations,
+      execution: {
+        submit: capabilities.execution.submit,
+        recover: (value) => capabilities.execution.recover(value, MutationOperation.Submit),
+      },
+      prepareIntent: capabilities.prepareIntent,
+      reconcile: capabilities.reconcile,
+      restrictAuthority: capabilities.restrictAuthority,
+      currentUtcInstant: capabilities.currentUtcInstant,
+    },
+    cancel: {
+      recovery: capabilities.recovery,
+      mutations: capabilities.mutations,
+      execution: {
+        cancel: capabilities.execution.cancel,
+        recover: (value) => capabilities.execution.recover(value, MutationOperation.Cancel),
+      },
+      readIntent: capabilities.readIntent,
+      reconcile: capabilities.reconcile,
+      restrictAuthority: capabilities.restrictAuthority,
+      currentUtcInstant: capabilities.currentUtcInstant,
+    },
+    recover: {
+      recovery: capabilities.recovery,
+      mutations: capabilities.mutations,
+      execution: {
+        recoverSubmit: (value) => capabilities.execution.recover(value, MutationOperation.Submit),
+        recoverCancel: (value) => capabilities.execution.recover(value, MutationOperation.Cancel),
+      },
+      readIntent: capabilities.readIntent,
+      reconcile: capabilities.reconcile,
+      restrictAuthority: capabilities.restrictAuthority,
+      currentUtcInstant: capabilities.currentUtcInstant,
+    },
+  }
   return { calls, dependencies, mutationState, recoveryState, sequence }
 }
 
@@ -456,6 +533,55 @@ const runWithTestClock = <A, E>(effect: Effect.Effect<A, E>, advanceMs: number):
   )
 
 describe('bounded PAPER proof command', () => {
+  test('operation programs expose only their permitted capabilities', async () => {
+    const { dependencies } = fixture({ operation: 'PREPARE' })
+    const prepare: PaperProofPrepareDependencies = dependencies.prepare
+    const submit: PaperProofSubmitDependencies = dependencies.submit
+    const cancel: PaperProofCancelDependencies = dependencies.cancel
+    const recover: PaperProofRecoverDependencies = dependencies.recover
+
+    // @ts-expect-error PREPARE cannot activate capital or access mutation execution.
+    void prepare.activateCapitalGrant
+    // @ts-expect-error PREPARE cannot read or write recovery state.
+    void prepare.recovery
+    // @ts-expect-error SUBMIT cannot issue cancellation broker I/O.
+    void submit.execution.cancel
+    // @ts-expect-error SUBMIT cannot read durable intent state.
+    void submit.readIntent
+    // @ts-expect-error CANCEL cannot activate capital.
+    void cancel.activateCapitalGrant
+    // @ts-expect-error CANCEL cannot issue submission broker I/O.
+    void cancel.execution.submit
+    // @ts-expect-error RECOVER cannot issue a broker POST.
+    void recover.execution.submit
+    // @ts-expect-error RECOVER cannot issue a broker DELETE.
+    void recover.execution.cancel
+    // @ts-expect-error RECOVER cannot prepare a new intent.
+    void recover.prepareIntent
+    // @ts-expect-error PREPARE cannot be invoked with a mutation command.
+    void runPaperProofPrepare({ command: command('SUBMIT'), sourcePlan }, prepare)
+
+    const receipt = await Effect.runPromise(runPaperProofPrepare({ command: command('PREPARE'), sourcePlan }, prepare))
+    expect(receipt.operation).toBe('PREPARE')
+  })
+
+  test('mutation program failures remain contained at the composition boundary', async () => {
+    const cases = [
+      { operation: 'SUBMIT' as const, options: { failRecoveryLoad: true } },
+      { operation: 'CANCEL' as const, options: {} },
+      { operation: 'RECOVER' as const, options: { recoveryState: { required: recoveryRequired('SUBMIT') } } },
+    ]
+
+    for (const entryCase of cases) {
+      const { calls, dependencies } = fixture({ operation: entryCase.operation, ...entryCase.options })
+      const exit = await Effect.runPromiseExit(runPaperProof(command(entryCase.operation), dependencies))
+
+      expect(Exit.isFailure(exit)).toBe(true)
+      expect(calls.restrict).toBeGreaterThanOrEqual(1)
+      expect(calls.reconcile).toBeGreaterThanOrEqual(1)
+    }
+  })
+
   test('PREPARE reconciles and derives a generation without mutation services', async () => {
     const { calls, dependencies } = fixture({ operation: 'PREPARE' })
     const receipt = await Effect.runPromise(runPaperProof(command('PREPARE'), dependencies))

--- a/services/bayn/src/paper-proof/program.test.ts
+++ b/services/bayn/src/paper-proof/program.test.ts
@@ -475,8 +475,6 @@ const fixture = (options: FixtureOptions) => {
     },
     prepare: {
       prepareCapitalGrant: capabilities.prepareCapitalGrant,
-      reconcile: capabilities.reconcile,
-      currentUtcInstant: capabilities.currentUtcInstant,
     },
     submit: {
       activateCapitalGrant: capabilities.activateCapitalGrant,
@@ -485,9 +483,6 @@ const fixture = (options: FixtureOptions) => {
         recover: (value) => capabilities.execution.recover(value, MutationOperation.Submit),
       },
       prepareIntent: capabilities.prepareIntent,
-      reconcile: capabilities.reconcile,
-      restrictAuthority: capabilities.restrictAuthority,
-      currentUtcInstant: capabilities.currentUtcInstant,
     },
     cancel: {
       execution: {
@@ -495,9 +490,6 @@ const fixture = (options: FixtureOptions) => {
         recover: (value) => capabilities.execution.recover(value, MutationOperation.Cancel),
       },
       readIntent: capabilities.readIntent,
-      reconcile: capabilities.reconcile,
-      restrictAuthority: capabilities.restrictAuthority,
-      currentUtcInstant: capabilities.currentUtcInstant,
     },
     recover: {
       execution: {
@@ -505,9 +497,6 @@ const fixture = (options: FixtureOptions) => {
         recoverCancel: (value) => capabilities.execution.recover(value, MutationOperation.Cancel),
       },
       readIntent: capabilities.readIntent,
-      reconcile: capabilities.reconcile,
-      restrictAuthority: capabilities.restrictAuthority,
-      currentUtcInstant: capabilities.currentUtcInstant,
     },
   }
   return { calls, dependencies, mutationState, recoveryState, sequence }
@@ -532,19 +521,22 @@ const runWithTestClock = <A, E>(effect: Effect.Effect<A, E>, advanceMs: number):
 describe('bounded PAPER proof command', () => {
   test('operation programs expose only their permitted capabilities', async () => {
     const { dependencies } = fixture({ operation: 'PREPARE' })
-    const prepare: PaperProofPrepareDependencies = dependencies.prepare
+    const prepare: PaperProofPrepareDependencies = { ...dependencies.prepare, ...dependencies.containment }
     const submit: PaperProofSubmitDependencies = {
       ...dependencies.submit,
+      ...dependencies.containment,
       mutations: dependencies.mutations,
       recovery: dependencies.recovery,
     }
     const cancel: PaperProofCancelDependencies = {
       ...dependencies.cancel,
+      ...dependencies.containment,
       mutations: dependencies.mutations,
       recovery: dependencies.recovery,
     }
     const recover: PaperProofRecoverDependencies = {
       ...dependencies.recover,
+      ...dependencies.containment,
       mutations: dependencies.mutations,
       recovery: dependencies.recovery,
     }

--- a/services/bayn/src/paper-proof/program.test.ts
+++ b/services/bayn/src/paper-proof/program.test.ts
@@ -13,7 +13,6 @@ import { paperProofCommandEntryGate, runPaperProofCommand } from '../paper-proof
 import {
   protectedEntryToken,
   runPaperProof,
-  runPaperProofPrepare,
   type PaperProofCommand,
   type PaperProofCancelDependencies,
   type PaperProofDependencies,
@@ -26,6 +25,9 @@ import {
   type PaperProofRuntimeBinding,
   type PaperProofSourcePlan,
 } from './index'
+import { runPaperProofPrepare } from './prepare'
+
+type PaperProofPublicExports = typeof import('./index')
 
 const hash = (character: string): string => character.repeat(64)
 const accountId = 'paper-account'
@@ -465,7 +467,6 @@ const fixture = (options: FixtureOptions) => {
     runtime: capabilities.runtime,
     protectedEntryToken: capabilities.protectedEntryToken,
     containment: {
-      accountId,
       restrictAuthority: capabilities.restrictAuthority,
       reconcile: capabilities.reconcile,
       currentUtcInstant: capabilities.currentUtcInstant,
@@ -540,6 +541,12 @@ describe('bounded PAPER proof command', () => {
     const cancel: PaperProofCancelDependencies = dependencies.cancel
     const recover: PaperProofRecoverDependencies = dependencies.recover
 
+    // @ts-expect-error mutation runners stay behind the validated composition boundary.
+    void ({} as PaperProofPublicExports).runPaperProofSubmit
+    // @ts-expect-error mutation runners stay behind the validated composition boundary.
+    void ({} as PaperProofPublicExports).runPaperProofCancel
+    // @ts-expect-error containment must derive the expected account from the source plan.
+    void dependencies.containment.accountId
     // @ts-expect-error PREPARE cannot activate capital or access mutation execution.
     void prepare.activateCapitalGrant
     // @ts-expect-error PREPARE cannot read or write recovery state.

--- a/services/bayn/src/paper-proof/program.test.ts
+++ b/services/bayn/src/paper-proof/program.test.ts
@@ -253,7 +253,7 @@ type PaperProofFixtureCapabilities = Pick<PaperProofDependencies, 'sourcePlan' |
     readonly recover: (intentId: string, operation: MutationOperation) => Effect.Effect<MutationEvent, Error>
   }
   readonly prepareIntent: PaperProofDependencies['submit']['prepareIntent']
-  readonly readIntent: PaperProofDependencies['cancel']['readIntent']
+  readonly readIntent: PaperProofDependencies['readIntent']
   readonly reconcile: PaperProofDependencies['containment']['reconcile']
   readonly currentUtcInstant: PaperProofDependencies['containment']['currentUtcInstant']
 }
@@ -468,6 +468,7 @@ const fixture = (options: FixtureOptions) => {
     protectedEntryToken: capabilities.protectedEntryToken,
     mutations: capabilities.mutations,
     recovery: capabilities.recovery,
+    readIntent: capabilities.readIntent,
     containment: {
       restrictAuthority: capabilities.restrictAuthority,
       reconcile: capabilities.reconcile,
@@ -489,14 +490,12 @@ const fixture = (options: FixtureOptions) => {
         cancel: capabilities.execution.cancel,
         recover: (value) => capabilities.execution.recover(value, MutationOperation.Cancel),
       },
-      readIntent: capabilities.readIntent,
     },
     recover: {
       execution: {
         recoverSubmit: (value) => capabilities.execution.recover(value, MutationOperation.Submit),
         recoverCancel: (value) => capabilities.execution.recover(value, MutationOperation.Cancel),
       },
-      readIntent: capabilities.readIntent,
     },
   }
   return { calls, dependencies, mutationState, recoveryState, sequence }
@@ -533,12 +532,14 @@ describe('bounded PAPER proof command', () => {
       ...dependencies.containment,
       mutations: dependencies.mutations,
       recovery: dependencies.recovery,
+      readIntent: dependencies.readIntent,
     }
     const recover: PaperProofRecoverDependencies = {
       ...dependencies.recover,
       ...dependencies.containment,
       mutations: dependencies.mutations,
       recovery: dependencies.recovery,
+      readIntent: dependencies.readIntent,
     }
 
     // @ts-expect-error mutation runners stay behind the validated composition boundary.
@@ -555,6 +556,10 @@ describe('bounded PAPER proof command', () => {
     void submit.execution.cancel
     // @ts-expect-error SUBMIT cannot read durable intent state.
     void submit.readIntent
+    // @ts-expect-error the root CANCEL view cannot replace the canonical durable intent reader.
+    void dependencies.cancel.readIntent
+    // @ts-expect-error the root RECOVER view cannot replace the canonical durable intent reader.
+    void dependencies.recover.readIntent
     // @ts-expect-error CANCEL cannot activate capital.
     void cancel.activateCapitalGrant
     // @ts-expect-error CANCEL cannot issue submission broker I/O.

--- a/services/bayn/src/paper-proof/program.test.ts
+++ b/services/bayn/src/paper-proof/program.test.ts
@@ -245,8 +245,8 @@ type PaperProofFixtureCapabilities = Pick<PaperProofDependencies, 'sourcePlan' |
   readonly prepareCapitalGrant: PaperProofDependencies['prepare']['prepareCapitalGrant']
   readonly activateCapitalGrant: PaperProofDependencies['submit']['activateCapitalGrant']
   readonly restrictAuthority: PaperProofDependencies['containment']['restrictAuthority']
-  readonly recovery: PaperProofDependencies['recover']['recovery']
-  readonly mutations: PaperProofDependencies['recover']['mutations']
+  readonly recovery: PaperProofDependencies['recovery']
+  readonly mutations: PaperProofDependencies['mutations']
   readonly execution: {
     readonly submit: PaperProofDependencies['submit']['execution']['submit']
     readonly cancel: PaperProofDependencies['cancel']['execution']['cancel']
@@ -466,6 +466,8 @@ const fixture = (options: FixtureOptions) => {
     sourcePlan: capabilities.sourcePlan,
     runtime: capabilities.runtime,
     protectedEntryToken: capabilities.protectedEntryToken,
+    mutations: capabilities.mutations,
+    recovery: capabilities.recovery,
     containment: {
       restrictAuthority: capabilities.restrictAuthority,
       reconcile: capabilities.reconcile,
@@ -478,8 +480,6 @@ const fixture = (options: FixtureOptions) => {
     },
     submit: {
       activateCapitalGrant: capabilities.activateCapitalGrant,
-      recovery: capabilities.recovery,
-      mutations: capabilities.mutations,
       execution: {
         submit: capabilities.execution.submit,
         recover: (value) => capabilities.execution.recover(value, MutationOperation.Submit),
@@ -490,8 +490,6 @@ const fixture = (options: FixtureOptions) => {
       currentUtcInstant: capabilities.currentUtcInstant,
     },
     cancel: {
-      recovery: capabilities.recovery,
-      mutations: capabilities.mutations,
       execution: {
         cancel: capabilities.execution.cancel,
         recover: (value) => capabilities.execution.recover(value, MutationOperation.Cancel),
@@ -502,8 +500,6 @@ const fixture = (options: FixtureOptions) => {
       currentUtcInstant: capabilities.currentUtcInstant,
     },
     recover: {
-      recovery: capabilities.recovery,
-      mutations: capabilities.mutations,
       execution: {
         recoverSubmit: (value) => capabilities.execution.recover(value, MutationOperation.Submit),
         recoverCancel: (value) => capabilities.execution.recover(value, MutationOperation.Cancel),
@@ -537,9 +533,21 @@ describe('bounded PAPER proof command', () => {
   test('operation programs expose only their permitted capabilities', async () => {
     const { dependencies } = fixture({ operation: 'PREPARE' })
     const prepare: PaperProofPrepareDependencies = dependencies.prepare
-    const submit: PaperProofSubmitDependencies = dependencies.submit
-    const cancel: PaperProofCancelDependencies = dependencies.cancel
-    const recover: PaperProofRecoverDependencies = dependencies.recover
+    const submit: PaperProofSubmitDependencies = {
+      ...dependencies.submit,
+      mutations: dependencies.mutations,
+      recovery: dependencies.recovery,
+    }
+    const cancel: PaperProofCancelDependencies = {
+      ...dependencies.cancel,
+      mutations: dependencies.mutations,
+      recovery: dependencies.recovery,
+    }
+    const recover: PaperProofRecoverDependencies = {
+      ...dependencies.recover,
+      mutations: dependencies.mutations,
+      recovery: dependencies.recovery,
+    }
 
     // @ts-expect-error mutation runners stay behind the validated composition boundary.
     void ({} as PaperProofPublicExports).runPaperProofSubmit

--- a/services/bayn/src/paper-proof/program.test.ts
+++ b/services/bayn/src/paper-proof/program.test.ts
@@ -469,6 +469,7 @@ const fixture = (options: FixtureOptions) => {
     mutations: capabilities.mutations,
     recovery: capabilities.recovery,
     readIntent: capabilities.readIntent,
+    recoverMutation: capabilities.execution.recover,
     containment: {
       restrictAuthority: capabilities.restrictAuthority,
       reconcile: capabilities.reconcile,
@@ -481,22 +482,15 @@ const fixture = (options: FixtureOptions) => {
       activateCapitalGrant: capabilities.activateCapitalGrant,
       execution: {
         submit: capabilities.execution.submit,
-        recover: (value) => capabilities.execution.recover(value, MutationOperation.Submit),
       },
       prepareIntent: capabilities.prepareIntent,
     },
     cancel: {
       execution: {
         cancel: capabilities.execution.cancel,
-        recover: (value) => capabilities.execution.recover(value, MutationOperation.Cancel),
       },
     },
-    recover: {
-      execution: {
-        recoverSubmit: (value) => capabilities.execution.recover(value, MutationOperation.Submit),
-        recoverCancel: (value) => capabilities.execution.recover(value, MutationOperation.Cancel),
-      },
-    },
+    recover: {},
   }
   return { calls, dependencies, mutationState, recoveryState, sequence }
 }
@@ -526,6 +520,10 @@ describe('bounded PAPER proof command', () => {
       ...dependencies.containment,
       mutations: dependencies.mutations,
       recovery: dependencies.recovery,
+      execution: {
+        ...dependencies.submit.execution,
+        recover: (value) => dependencies.recoverMutation(value, MutationOperation.Submit),
+      },
     }
     const cancel: PaperProofCancelDependencies = {
       ...dependencies.cancel,
@@ -533,6 +531,10 @@ describe('bounded PAPER proof command', () => {
       mutations: dependencies.mutations,
       recovery: dependencies.recovery,
       readIntent: dependencies.readIntent,
+      execution: {
+        ...dependencies.cancel.execution,
+        recover: (value) => dependencies.recoverMutation(value, MutationOperation.Cancel),
+      },
     }
     const recover: PaperProofRecoverDependencies = {
       ...dependencies.recover,
@@ -540,6 +542,10 @@ describe('bounded PAPER proof command', () => {
       mutations: dependencies.mutations,
       recovery: dependencies.recovery,
       readIntent: dependencies.readIntent,
+      execution: {
+        recoverSubmit: (value) => dependencies.recoverMutation(value, MutationOperation.Submit),
+        recoverCancel: (value) => dependencies.recoverMutation(value, MutationOperation.Cancel),
+      },
     }
 
     // @ts-expect-error mutation runners stay behind the validated composition boundary.
@@ -560,6 +566,12 @@ describe('bounded PAPER proof command', () => {
     void dependencies.cancel.readIntent
     // @ts-expect-error the root RECOVER view cannot replace the canonical durable intent reader.
     void dependencies.recover.readIntent
+    // @ts-expect-error the root SUBMIT view cannot replace the canonical broker recovery lookup.
+    void dependencies.submit.execution.recover
+    // @ts-expect-error the root CANCEL view cannot replace the canonical broker recovery lookup.
+    void dependencies.cancel.execution.recover
+    // @ts-expect-error the root RECOVER view receives canonical lookup adapters at dispatch time.
+    void dependencies.recover.execution
     // @ts-expect-error CANCEL cannot activate capital.
     void cancel.activateCapitalGrant
     // @ts-expect-error CANCEL cannot issue submission broker I/O.

--- a/services/bayn/src/paper-proof/program.ts
+++ b/services/bayn/src/paper-proof/program.ts
@@ -46,6 +46,8 @@ export interface PaperProofDependencies {
   readonly mutations: PaperProofMutationStore
   /** Stateful recovery markers are canonical and shared by every mutation operation view. */
   readonly recovery: PaperProofRecoveryStore
+  /** Durable intent state is canonical and shared by cancellation and recovery views. */
+  readonly readIntent: PaperProofCancelDependencies['readIntent']
   readonly prepare: Omit<PaperProofPrepareDependencies, 'currentUtcInstant' | 'reconcile'>
   readonly submit: Omit<
     PaperProofSubmitDependencies,
@@ -53,11 +55,11 @@ export interface PaperProofDependencies {
   >
   readonly cancel: Omit<
     PaperProofCancelDependencies,
-    'currentUtcInstant' | 'mutations' | 'reconcile' | 'recovery' | 'restrictAuthority'
+    'currentUtcInstant' | 'mutations' | 'readIntent' | 'reconcile' | 'recovery' | 'restrictAuthority'
   >
   readonly recover: Omit<
     PaperProofRecoverDependencies,
-    'currentUtcInstant' | 'mutations' | 'reconcile' | 'recovery' | 'restrictAuthority'
+    'currentUtcInstant' | 'mutations' | 'readIntent' | 'reconcile' | 'recovery' | 'restrictAuthority'
   >
 }
 
@@ -211,6 +213,7 @@ const runValidatedPaperProof = (
             ...dependencies.cancel,
             currentUtcInstant: dependencies.containment.currentUtcInstant,
             mutations: dependencies.mutations,
+            readIntent: dependencies.readIntent,
             reconcile: dependencies.containment.reconcile,
             recovery: dependencies.recovery,
             restrictAuthority: dependencies.containment.restrictAuthority,
@@ -229,6 +232,7 @@ const runValidatedPaperProof = (
             ...dependencies.recover,
             currentUtcInstant: dependencies.containment.currentUtcInstant,
             mutations: dependencies.mutations,
+            readIntent: dependencies.readIntent,
             reconcile: dependencies.containment.reconcile,
             recovery: dependencies.recovery,
             restrictAuthority: dependencies.containment.restrictAuthority,

--- a/services/bayn/src/paper-proof/program.ts
+++ b/services/bayn/src/paper-proof/program.ts
@@ -1,31 +1,24 @@
 import { Clock, Duration, Effect, Exit } from 'effect'
 
-import { MutationOperation } from '../broker/alpaca-mutations'
-import { IntentState } from '../execution/contracts'
-import type { CapitalGrantGeneration, CapitalGrantProofBinding } from '../execution/contracts'
-import { MutationEventType, type MutationEvent, type MutationStoreShape } from '../execution/mutations'
 import { utcInstantFromEpochMillis } from '../time'
-import { hasPaperProofMutationAuthority, validatePaperProofEntry } from './gates'
+import {
+  runPaperProofCancel,
+  runPaperProofSubmit,
+  type PaperProofCancelDependencies,
+  type PaperProofSubmitDependencies,
+} from './mutations'
+import { runPaperProofPrepare, type PaperProofPrepareDependencies } from './prepare'
+import { runPaperProofRecover, type PaperProofRecoverDependencies } from './recovery'
+import { hasPaperProofMutationAuthority, paperProofContainmentIoCount, validatePaperProofEntry } from './gates'
+import { liftBounded, validateReconciliationAccount, type PaperProofContainmentDependencies } from './operations'
 import {
   PaperProofError,
-  paperProofReceiptSchemaVersion,
-  paperProofRecoveryCompletionSchemaVersion,
-  paperProofRecoveryRequiredSchemaVersion,
-  proofBinding,
   type PaperProofCommand,
-  type PaperProofIntentSnapshot,
-  type PaperProofMutationOperation,
   type PaperProofReceipt,
-  type PaperProofReconciliation,
-  type PaperProofRecoveryCompletion,
-  type PaperProofRecoveryRequired,
-  type PaperProofRecoveryStore,
   type PaperProofRuntimeBinding,
   type PaperProofSourcePlan,
-  type PreparedPaperProofIntent,
 } from './model'
 
-const containmentIoCount = 3
 const malformedCommandContainmentIoTimeoutMs = 5_000
 const malformedCommandContainmentTotalTimeoutMs = 20_000
 
@@ -34,435 +27,19 @@ interface PaperProofContainmentContext {
   readonly containmentIoTimeoutMs: number
 }
 
+/**
+ * Composition owns all live capabilities, but each operation receives only its nested capability surface. The
+ * operation programs never receive runtime authority, the protected token, or another operation's broker adapter.
+ */
 export interface PaperProofDependencies {
   readonly sourcePlan: PaperProofSourcePlan
   readonly runtime: PaperProofRuntimeBinding
   readonly protectedEntryToken: string
-  readonly prepareCapitalGrant: (proof: CapitalGrantProofBinding) => Effect.Effect<CapitalGrantGeneration, Error>
-  readonly activateCapitalGrant: (proof: CapitalGrantProofBinding) => Effect.Effect<void, Error>
-  readonly restrictAuthority: (reason: string, updatedAt: string) => Effect.Effect<void, Error>
-  readonly recovery: PaperProofRecoveryStore
-  readonly mutations: Pick<MutationStoreShape, 'latest'>
-  readonly execution: {
-    /**
-     * The adapter must invoke `beforeBrokerMutation` exactly once after every local and durable submit prerequisite
-     * passes and the durable submit mutation has started, immediately before the broker POST. If the hook fails, the
-     * adapter must not issue broker I/O.
-     */
-    readonly submit: (
-      intentId: string,
-      consistencyDelayMs: number,
-      beforeBrokerMutation: () => Effect.Effect<void, PaperProofError>,
-    ) => Effect.Effect<MutationEvent, Error>
-    /**
-     * The adapter must invoke `beforeBrokerMutation` exactly once after every local and durable cancellation
-     * prerequisite passes and the durable cancellation mutation has started, immediately before the broker DELETE.
-     * If the hook fails, the adapter must not issue broker I/O.
-     */
-    readonly cancel: (
-      intentId: string,
-      consistencyDelayMs: number,
-      beforeBrokerMutation: () => Effect.Effect<void, PaperProofError>,
-    ) => Effect.Effect<MutationEvent, Error>
-    readonly recover: (intentId: string, operation: MutationOperation) => Effect.Effect<MutationEvent, Error>
-  }
-  readonly prepareIntent: () => Effect.Effect<PreparedPaperProofIntent, Error>
-  readonly readIntent: (intentId: string) => Effect.Effect<PaperProofIntentSnapshot | undefined, Error>
-  readonly reconcile: () => Effect.Effect<PaperProofReconciliation, Error>
-  readonly currentUtcInstant: Effect.Effect<string, Error>
-}
-
-const paperProofFailure = (
-  operation: PaperProofError['operation'],
-  message: string,
-  cause: unknown,
-  failure: PaperProofError['failure'] = 'operational',
-): PaperProofError =>
-  new PaperProofError({
-    operation,
-    failure,
-    message,
-    cause,
-  })
-
-const timeoutFailure = (operation: PaperProofError['operation'], message: string): PaperProofError =>
-  new PaperProofError({
-    operation,
-    failure: 'timeout',
-    message,
-  })
-
-const lift = <A>(
-  operation: PaperProofError['operation'],
-  message: string,
-  effect: Effect.Effect<A, Error>,
-): Effect.Effect<A, PaperProofError> =>
-  effect.pipe(Effect.mapError((cause) => paperProofFailure(operation, message, cause)))
-
-const liftBounded = <A>(
-  operation: PaperProofError['operation'],
-  message: string,
-  effect: Effect.Effect<A, Error>,
-  timeoutMs: number,
-): Effect.Effect<A, PaperProofError> =>
-  lift(operation, message, effect).pipe(
-    Effect.timeoutOrElse({
-      duration: Duration.millis(timeoutMs),
-      orElse: () =>
-        Effect.fail(
-          timeoutFailure(operation, `${message} exceeded its ${timeoutMs.toString()}ms containment I/O bound`),
-        ),
-    }),
-  )
-
-const requireSameAccountReconciliation = (
-  expectedAccountId: string,
-  reconciliation: PaperProofReconciliation,
-): Effect.Effect<PaperProofReconciliation, PaperProofError> =>
-  reconciliation.accountId === expectedAccountId
-    ? Effect.succeed(reconciliation)
-    : Effect.fail(
-        paperProofFailure(
-          'RECONCILE',
-          'paper proof reconciliation account does not match the source-controlled account',
-          reconciliation,
-          'invariant',
-        ),
-      )
-
-const requireExactReconciliation = (
-  reconciliation: PaperProofReconciliation,
-): Effect.Effect<PaperProofReconciliation, PaperProofError> => {
-  if (reconciliation.status !== 'EXACT' || reconciliation.unknownMutationCount !== 0) {
-    return Effect.fail(
-      paperProofFailure(
-        'RECONCILE',
-        'paper proof requires exact reconciliation with zero unknown mutations',
-        reconciliation,
-        'invariant',
-      ),
-    )
-  }
-  return Effect.succeed(reconciliation)
-}
-
-const observeReconciliation = (
-  dependencies: PaperProofDependencies,
-): Effect.Effect<PaperProofReconciliation, PaperProofError> =>
-  lift('RECONCILE', 'paper proof reconciliation failed', dependencies.reconcile()).pipe(
-    Effect.flatMap((result) => requireSameAccountReconciliation(dependencies.sourcePlan.accountId, result)),
-  )
-
-const reconcileExact = (
-  dependencies: PaperProofDependencies,
-): Effect.Effect<PaperProofReconciliation, PaperProofError> =>
-  observeReconciliation(dependencies).pipe(Effect.flatMap(requireExactReconciliation))
-
-const restrict = (dependencies: PaperProofDependencies, reason: string): Effect.Effect<void, PaperProofError> =>
-  lift('RESTRICT', 'paper proof failed to read the restriction clock', dependencies.currentUtcInstant).pipe(
-    Effect.flatMap((updatedAt) =>
-      lift(
-        'RESTRICT',
-        'paper proof failed to restrict mutation authority',
-        dependencies.restrictAuthority(reason.slice(0, 240), updatedAt),
-      ),
-    ),
-  )
-
-const recoveryIdentityMatches = (
-  command: PaperProofCommand,
-  dependencies: PaperProofDependencies,
-  value: Pick<PaperProofRecoveryRequired, 'intentId' | 'proofPlanHash' | 'qualificationRunId'>,
-): boolean =>
-  value.intentId === dependencies.sourcePlan.intentId &&
-  value.proofPlanHash === command.proofPlanHash &&
-  value.qualificationRunId === command.qualificationRunId
-
-const ensureRecoveryMarkerCompatible = (
-  command: PaperProofCommand,
-  dependencies: PaperProofDependencies,
-  operation: PaperProofMutationOperation,
-): Effect.Effect<PaperProofRecoveryRequired | undefined, PaperProofError> =>
-  liftBounded(
-    'RECOVERY_STATE',
-    'paper proof failed to load the existing durable recovery marker',
-    dependencies.recovery.load(dependencies.sourcePlan.intentId),
-    command.containmentIoTimeoutMs,
-  ).pipe(
-    Effect.flatMap((existing) => {
-      if (existing === undefined) return Effect.succeed(undefined)
-      if (!recoveryIdentityMatches(command, dependencies, existing)) {
-        return Effect.fail(
-          paperProofFailure(
-            'RECOVERY_STATE',
-            'paper proof durable recovery marker does not match the pinned proof identity',
-            existing,
-            'invariant',
-          ),
-        )
-      }
-      if (existing.operation === 'CANCEL' && operation === 'SUBMIT') {
-        return Effect.fail(
-          paperProofFailure(
-            'RECOVERY_STATE',
-            'paper proof cannot replace an unresolved cancellation marker with submit recovery',
-            existing,
-            'mutation-unresolved',
-          ),
-        )
-      }
-      return Effect.succeed(existing)
-    }),
-  )
-
-const markRecoveryRequired = (
-  command: PaperProofCommand,
-  dependencies: PaperProofDependencies,
-  operation: PaperProofMutationOperation,
-  reason: string,
-): Effect.Effect<void, PaperProofError> =>
-  ensureRecoveryMarkerCompatible(command, dependencies, operation).pipe(
-    Effect.flatMap((existing) => {
-      if (existing?.operation === operation) return Effect.void
-      return liftBounded(
-        'RECOVERY_STATE',
-        'paper proof failed to read the recovery marker clock',
-        dependencies.currentUtcInstant,
-        command.containmentIoTimeoutMs,
-      ).pipe(
-        Effect.flatMap((requiredAt) =>
-          liftBounded(
-            'RECOVERY_STATE',
-            'paper proof failed to durably mark recovery required',
-            dependencies.recovery.markRequired({
-              schemaVersion: paperProofRecoveryRequiredSchemaVersion,
-              intentId: dependencies.sourcePlan.intentId,
-              proofPlanHash: command.proofPlanHash,
-              qualificationRunId: command.qualificationRunId,
-              operation,
-              reason: reason.slice(0, 240),
-              requiredAt,
-            }),
-            command.containmentIoTimeoutMs,
-          ),
-        ),
-      )
-    }),
-  )
-
-const loadRecoveryRequired = (
-  command: PaperProofCommand,
-  dependencies: PaperProofDependencies,
-): Effect.Effect<PaperProofRecoveryRequired | undefined, PaperProofError> =>
-  liftBounded(
-    'RECOVERY_STATE',
-    'paper proof failed to load the durable recovery marker',
-    dependencies.recovery.load(dependencies.sourcePlan.intentId),
-    command.containmentIoTimeoutMs,
-  ).pipe(
-    Effect.flatMap((required) =>
-      required === undefined || recoveryIdentityMatches(command, dependencies, required)
-        ? Effect.succeed(required)
-        : Effect.fail(
-            paperProofFailure(
-              'RECOVERY_STATE',
-              'paper proof durable recovery marker does not match the pinned proof identity',
-              required,
-              'invariant',
-            ),
-          ),
-    ),
-  )
-
-const loadRecoveryCompletion = (
-  command: PaperProofCommand,
-  dependencies: PaperProofDependencies,
-): Effect.Effect<PaperProofRecoveryCompletion | undefined, PaperProofError> =>
-  liftBounded(
-    'RECOVERY_STATE',
-    'paper proof failed to load durable recovery completion',
-    dependencies.recovery.loadCompletion(dependencies.sourcePlan.intentId),
-    command.containmentIoTimeoutMs,
-  ).pipe(
-    Effect.flatMap((completion) => {
-      if (completion !== undefined && !recoveryIdentityMatches(command, dependencies, completion)) {
-        return Effect.fail(
-          paperProofFailure(
-            'RECOVERY_STATE',
-            'paper proof durable recovery completion does not match the pinned proof identity',
-            completion,
-            'invariant',
-          ),
-        )
-      }
-      return Effect.succeed(completion)
-    }),
-  )
-
-const completeRecovery = (
-  command: PaperProofCommand,
-  dependencies: PaperProofDependencies,
-  completion: PaperProofRecoveryCompletion,
-): Effect.Effect<void, PaperProofError> =>
-  Effect.gen(function* () {
-    if (completion.operation === 'SUBMIT') {
-      const cancellation = yield* lift(
-        'RECOVERY_STATE',
-        'paper proof failed to verify submit completion against durable cancellation state',
-        dependencies.mutations.latest(dependencies.sourcePlan.intentId, MutationOperation.Cancel),
-      )
-      if (cancellation !== undefined) {
-        return yield* Effect.fail(
-          paperProofFailure(
-            'RECOVERY_STATE',
-            'paper proof submit completion is superseded by a durable cancellation mutation',
-            cancellation,
-            'mutation-unresolved',
-          ),
-        )
-      }
-    }
-    yield* liftBounded(
-      'RECOVERY_STATE',
-      'paper proof failed to atomically persist recovery completion',
-      dependencies.recovery.complete(completion, {
-        expectedLatestMutation: completion.mutation,
-        rejectAnyCancellation: completion.operation === 'SUBMIT',
-      }),
-      command.containmentIoTimeoutMs,
-    )
-  })
-
-const persistRecoveryCompletion = (
-  command: PaperProofCommand,
-  dependencies: PaperProofDependencies,
-  operation: PaperProofMutationOperation,
-  receipt: PaperProofReceipt,
-): Effect.Effect<void, PaperProofError> => {
-  if (receipt.mutation === undefined) {
-    return Effect.fail(
-      paperProofFailure(
-        'RECOVERY_STATE',
-        'paper proof recovery completion requires durable mutation evidence',
-        receipt,
-        'invariant',
-      ),
-    )
-  }
-  return completeRecovery(command, dependencies, {
-    schemaVersion: paperProofRecoveryCompletionSchemaVersion,
-    intentId: dependencies.sourcePlan.intentId,
-    proofPlanHash: command.proofPlanHash,
-    qualificationRunId: command.qualificationRunId,
-    operation,
-    ...(receipt.clientOrderId === undefined ? {} : { clientOrderId: receipt.clientOrderId }),
-    mutation: receipt.mutation,
-    reconciliations: receipt.reconciliations,
-    restricted: receipt.restricted,
-    completedAt: receipt.completedAt,
-  })
-}
-
-const receiptFromCompletion = (
-  command: PaperProofCommand,
-  dependencies: PaperProofDependencies,
-  completion: PaperProofRecoveryCompletion,
-): PaperProofReceipt => ({
-  schemaVersion: paperProofReceiptSchemaVersion,
-  operation: command.operation,
-  proofPlanHash: command.proofPlanHash,
-  qualificationRunId: command.qualificationRunId,
-  intentId: dependencies.sourcePlan.intentId,
-  ...(completion.clientOrderId === undefined ? {} : { clientOrderId: completion.clientOrderId }),
-  mutation: completion.mutation,
-  reconciliations: completion.reconciliations,
-  restricted: completion.restricted,
-  recoveryRequired: false,
-  completedAt: completion.completedAt,
-})
-
-interface DurableMutationState {
-  readonly submit?: MutationEvent
-  readonly cancel?: MutationEvent
-}
-
-const readDurableMutationState = (
-  operation: PaperProofError['operation'],
-  dependencies: PaperProofDependencies,
-): Effect.Effect<DurableMutationState, PaperProofError> =>
-  Effect.gen(function* () {
-    const submit = yield* readMutation(operation, dependencies, MutationOperation.Submit)
-    const cancel = yield* readMutation(operation, dependencies, MutationOperation.Cancel)
-    return {
-      ...(submit === undefined ? {} : { submit }),
-      ...(cancel === undefined ? {} : { cancel }),
-    }
-  })
-
-const mutationForOperation = (
-  state: DurableMutationState,
-  operation: PaperProofMutationOperation,
-): MutationEvent | undefined => (operation === 'CANCEL' ? state.cancel : state.submit)
-
-const validateCompletionMutationIdentity = (
-  dependencies: PaperProofDependencies,
-  completion: PaperProofRecoveryCompletion,
-): Effect.Effect<void, PaperProofError> => {
-  const expectedOperation = markerMutationOperation(completion.operation)
-  return completion.mutation.intentId === dependencies.sourcePlan.intentId &&
-    completion.mutation.operation === expectedOperation
-    ? Effect.void
-    : Effect.fail(
-        paperProofFailure(
-          'RECOVERY_STATE',
-          'paper proof durable recovery completion mutation identity is invalid',
-          completion,
-          'invariant',
-        ),
-      )
-}
-
-const sameMutationEvent = (left: MutationEvent, right: MutationEvent): boolean =>
-  left.schemaVersion === right.schemaVersion &&
-  left.eventId === right.eventId &&
-  left.mutationId === right.mutationId &&
-  left.intentId === right.intentId &&
-  left.sequence === right.sequence &&
-  left.operation === right.operation &&
-  left.eventType === right.eventType &&
-  left.requestHash === right.requestHash &&
-  left.consistencyDelayMs === right.consistencyDelayMs &&
-  left.brokerOrderId === right.brokerOrderId &&
-  left.requestId === right.requestId &&
-  left.responseStatus === right.responseStatus &&
-  left.responseContentHash === right.responseContentHash &&
-  left.occurredAt === right.occurredAt
-
-const completionMatchesAuthoritativeMutation = (
-  state: DurableMutationState,
-  completion: PaperProofRecoveryCompletion,
-): boolean => {
-  if (completion.operation === 'SUBMIT' && state.cancel !== undefined) return false
-  const latest = mutationForOperation(state, completion.operation)
-  return latest !== undefined && sameMutationEvent(latest, completion.mutation)
-}
-
-const refreshCompletionAfterContainment = (
-  command: PaperProofCommand,
-  dependencies: PaperProofDependencies,
-  completion: PaperProofRecoveryCompletion,
-): Effect.Effect<PaperProofRecoveryCompletion, PaperProofError> => {
-  if (completion.restricted) return Effect.succeed(completion)
-  return Effect.gen(function* () {
-    const reconciliation = yield* reconcileExact(dependencies)
-    const refreshed: PaperProofRecoveryCompletion = {
-      ...completion,
-      reconciliations: [...completion.reconciliations, reconciliation],
-      restricted: true,
-    }
-    yield* completeRecovery(command, dependencies, refreshed)
-    return refreshed
-  })
+  readonly containment: PaperProofContainmentDependencies
+  readonly prepare: PaperProofPrepareDependencies
+  readonly submit: PaperProofSubmitDependencies
+  readonly cancel: PaperProofCancelDependencies
+  readonly recover: PaperProofRecoverDependencies
 }
 
 const logContainmentFailure = <A>(
@@ -481,7 +58,7 @@ const logContainmentFailure = <A>(
 
 const containFailure = (
   context: PaperProofContainmentContext,
-  dependencies: PaperProofDependencies,
+  dependencies: PaperProofContainmentDependencies,
   reason: string,
 ): Effect.Effect<void> =>
   Effect.gen(function* () {
@@ -496,7 +73,7 @@ const containFailure = (
     yield* logContainmentFailure(context.operation, 'restriction-clock', clockExit)
 
     const restrictionTimestamp = Exit.isFailure(clockExit)
-      ? yield* Clock.currentTimeMillis.pipe(Effect.map(utcInstantFromEpochMillis))
+      ? yield* Clock.currentTimeMillis.pipe(Effect.map((millis) => utcInstantFromEpochMillis(millis)))
       : clockExit.value
     const restrictionExit = yield* Effect.exit(
       liftBounded(
@@ -514,14 +91,16 @@ const containFailure = (
         'paper proof containment reconciliation failed',
         dependencies.reconcile(),
         context.containmentIoTimeoutMs,
-      ).pipe(Effect.flatMap((result) => requireSameAccountReconciliation(dependencies.sourcePlan.accountId, result))),
+      ).pipe(
+        Effect.flatMap((result) => Effect.fromResult(validateReconciliationAccount(dependencies.accountId, result))),
+      ),
     )
     yield* logContainmentFailure(context.operation, 'reconcile', reconciliationExit)
   })
 
 const withRecoveryFinalizer = <A>(
   command: PaperProofContainmentContext,
-  dependencies: PaperProofDependencies,
+  dependencies: PaperProofContainmentDependencies,
   reason: string,
   effect: Effect.Effect<A, PaperProofError>,
 ): Effect.Effect<A, PaperProofError> =>
@@ -531,7 +110,7 @@ const withRecoveryFinalizer = <A>(
 
 export const containMalformedPaperProofCommand = (
   operation: PaperProofCommand['operation'] | 'GATE',
-  dependencies: PaperProofDependencies,
+  dependencies: PaperProofContainmentDependencies,
   failure: PaperProofError,
 ): Effect.Effect<never, PaperProofError> =>
   withRecoveryFinalizer(
@@ -546,463 +125,15 @@ export const containMalformedPaperProofCommand = (
     Effect.timeoutOrElse({
       duration: Duration.millis(malformedCommandContainmentTotalTimeoutMs),
       orElse: () =>
-        commandTimeout(
-          `paper proof malformed-command containment exceeded its ${malformedCommandContainmentTotalTimeoutMs.toString()}ms total bound`,
+        Effect.fail(
+          new PaperProofError({
+            operation: 'TIMEOUT',
+            failure: 'timeout',
+            message: `paper proof malformed-command containment exceeded its ${malformedCommandContainmentTotalTimeoutMs.toString()}ms total bound`,
+          }),
         ),
     }),
   )
-
-const successfulSubmit = (event: MutationEvent): boolean =>
-  event.operation === MutationOperation.Submit &&
-  (event.eventType === MutationEventType.SubmitAccepted || event.eventType === MutationEventType.RecoveryFound)
-
-const terminalSubmit = (event: MutationEvent): boolean =>
-  event.operation === MutationOperation.Submit &&
-  (successfulSubmit(event) ||
-    event.eventType === MutationEventType.SubmitRejected ||
-    event.eventType === MutationEventType.SubmitDenied)
-
-const recoveredCancellation = (event: MutationEvent): boolean =>
-  event.operation === MutationOperation.Cancel && event.eventType === MutationEventType.RecoveryFound
-
-const readIntentSnapshot = (
-  operation: PaperProofError['operation'],
-  dependencies: PaperProofDependencies,
-): Effect.Effect<PaperProofIntentSnapshot, PaperProofError> =>
-  lift(
-    operation,
-    'paper proof durable intent read failed',
-    dependencies.readIntent(dependencies.sourcePlan.intentId),
-  ).pipe(
-    Effect.flatMap((snapshot) =>
-      snapshot === undefined
-        ? Effect.fail(paperProofFailure(operation, 'paper proof durable intent does not exist', snapshot, 'invariant'))
-        : Effect.succeed(snapshot),
-    ),
-  )
-
-const cancellationTerminal = (
-  operation: Extract<PaperProofCommand['operation'], 'CANCEL' | 'RECOVER'>,
-  dependencies: PaperProofDependencies,
-  event: MutationEvent,
-): Effect.Effect<boolean, PaperProofError> =>
-  recoveredCancellation(event)
-    ? readIntentSnapshot(operation, dependencies).pipe(
-        Effect.map((snapshot) => snapshot.state === IntentState.Terminal && snapshot.terminalOutcome !== undefined),
-      )
-    : Effect.succeed(false)
-
-const prepareSubmitIntent = (
-  dependencies: PaperProofDependencies,
-): Effect.Effect<PreparedPaperProofIntent, PaperProofError> =>
-  lift('SUBMIT', 'paper proof intent preparation failed', dependencies.prepareIntent()).pipe(
-    Effect.flatMap((prepared) =>
-      prepared.intentId === dependencies.sourcePlan.intentId
-        ? Effect.succeed(prepared)
-        : Effect.fail(
-            paperProofFailure(
-              'SUBMIT',
-              'prepared PAPER intent identity does not match the source-controlled proof plan',
-              prepared,
-              'invariant',
-            ),
-          ),
-    ),
-  )
-
-const readMutation = (
-  operation: PaperProofError['operation'],
-  dependencies: PaperProofDependencies,
-  mutationOperation: MutationOperation,
-): Effect.Effect<MutationEvent | undefined, PaperProofError> =>
-  lift(
-    operation,
-    `paper proof durable ${mutationOperation.toLowerCase()} read failed`,
-    dependencies.mutations.latest(dependencies.sourcePlan.intentId, mutationOperation),
-  )
-
-const waitForRecovery = (command: PaperProofCommand): Effect.Effect<void> =>
-  Effect.sleep(Duration.millis(command.consistencyDelayMs))
-
-const recoverMutation = (
-  command: PaperProofCommand,
-  dependencies: PaperProofDependencies,
-  operation: MutationOperation,
-): Effect.Effect<MutationEvent, PaperProofError> =>
-  waitForRecovery(command).pipe(
-    Effect.andThen(
-      lift(
-        'RECOVER',
-        `paper proof lookup-only ${operation.toLowerCase()} recovery failed`,
-        dependencies.execution.recover(dependencies.sourcePlan.intentId, operation),
-      ),
-    ),
-  )
-
-interface PreparedCancellation {
-  readonly existing?: MutationEvent
-}
-
-const prepareCancellation = (
-  dependencies: PaperProofDependencies,
-): Effect.Effect<PreparedCancellation, PaperProofError> =>
-  Effect.gen(function* () {
-    const existing = yield* readMutation('CANCEL', dependencies, MutationOperation.Cancel)
-    if (existing !== undefined) return { existing }
-
-    const submitted = yield* readMutation('CANCEL', dependencies, MutationOperation.Submit)
-    if (submitted === undefined || !successfulSubmit(submitted) || submitted.brokerOrderId === undefined) {
-      return yield* Effect.fail(
-        paperProofFailure(
-          'CANCEL',
-          'paper proof cancellation requires an exact durable submitted broker order',
-          submitted,
-          'mutation-unresolved',
-        ),
-      )
-    }
-    const intent = yield* readIntentSnapshot('CANCEL', dependencies)
-    if (intent.state !== IntentState.Acknowledged) {
-      return yield* Effect.fail(
-        paperProofFailure(
-          'CANCEL',
-          'paper proof cancellation requires an acknowledged durable intent',
-          intent,
-          'mutation-unresolved',
-        ),
-      )
-    }
-    return {}
-  })
-
-const cancelOrRecover = (
-  command: PaperProofCommand,
-  dependencies: PaperProofDependencies,
-  prepared: PreparedCancellation,
-): Effect.Effect<MutationEvent, PaperProofError> =>
-  Effect.gen(function* () {
-    const event =
-      prepared.existing ??
-      (yield* lift(
-        'CANCEL',
-        'paper proof identified cancellation failed',
-        dependencies.execution.cancel(dependencies.sourcePlan.intentId, command.consistencyDelayMs, () =>
-          markRecoveryRequired(command, dependencies, 'CANCEL', 'paper-proof-cancel'),
-        ),
-      ))
-    return recoveredCancellation(event)
-      ? event
-      : yield* recoverMutation(command, dependencies, MutationOperation.Cancel)
-  })
-
-const markerMutationOperation = (operation: PaperProofMutationOperation): MutationOperation =>
-  operation === 'CANCEL' ? MutationOperation.Cancel : MutationOperation.Submit
-
-const completeReceipt = (
-  command: PaperProofCommand,
-  dependencies: PaperProofDependencies,
-  input: Omit<
-    PaperProofReceipt,
-    'schemaVersion' | 'operation' | 'proofPlanHash' | 'qualificationRunId' | 'intentId' | 'completedAt'
-  >,
-): Effect.Effect<PaperProofReceipt, PaperProofError> =>
-  lift(command.operation, 'paper proof completion clock failed', dependencies.currentUtcInstant).pipe(
-    Effect.map((completedAt) => ({
-      schemaVersion: paperProofReceiptSchemaVersion,
-      operation: command.operation,
-      proofPlanHash: command.proofPlanHash,
-      qualificationRunId: command.qualificationRunId,
-      intentId: dependencies.sourcePlan.intentId,
-      completedAt,
-      ...input,
-    })),
-  )
-
-const runPrepare = (
-  command: PaperProofCommand,
-  dependencies: PaperProofDependencies,
-): Effect.Effect<PaperProofReceipt, PaperProofError> =>
-  Effect.gen(function* () {
-    const reconciliation = yield* reconcileExact(dependencies)
-    const generation = yield* lift(
-      'PREPARE',
-      'paper proof generation PREPARE failed',
-      dependencies.prepareCapitalGrant(proofBinding(command)),
-    )
-    return yield* completeReceipt(command, dependencies, {
-      generation,
-      reconciliations: [reconciliation],
-      restricted: false,
-      recoveryRequired: false,
-    })
-  })
-
-const settleSubmitReceipt = (
-  command: PaperProofCommand,
-  dependencies: PaperProofDependencies,
-  operation: PaperProofMutationOperation,
-  input: Parameters<typeof completeReceipt>[2],
-): Effect.Effect<PaperProofReceipt, PaperProofError> =>
-  Effect.gen(function* () {
-    const receipt = yield* completeReceipt(command, dependencies, input)
-    if (!receipt.recoveryRequired) {
-      yield* persistRecoveryCompletion(command, dependencies, operation, receipt)
-    }
-    return receipt
-  })
-
-const runExistingSubmit = (
-  command: PaperProofCommand,
-  dependencies: PaperProofDependencies,
-  prepared: PreparedPaperProofIntent,
-  before: PaperProofReconciliation,
-  existing: MutationEvent,
-  existingMarker: PaperProofRecoveryRequired | undefined,
-): Effect.Effect<PaperProofReceipt, PaperProofError> =>
-  Effect.gen(function* () {
-    if (!terminalSubmit(existing)) {
-      yield* markRecoveryRequired(command, dependencies, 'SUBMIT', 'paper-proof-existing-submit')
-    }
-    const event = terminalSubmit(existing)
-      ? existing
-      : yield* recoverMutation(command, dependencies, MutationOperation.Submit)
-    let restricted = false
-    if (!successfulSubmit(event)) {
-      yield* restrict(dependencies, `paper-proof-submit-${event.eventType.toLowerCase()}`)
-      restricted = true
-    }
-    const finalReconciliation = terminalSubmit(event)
-      ? yield* reconcileExact(dependencies)
-      : yield* observeReconciliation(dependencies)
-    const input = {
-      clientOrderId: prepared.clientOrderId,
-      mutation: event,
-      reconciliations: [before, finalReconciliation],
-      restricted,
-      recoveryRequired: !terminalSubmit(event),
-    } as const
-    return terminalSubmit(existing) && existingMarker === undefined
-      ? yield* completeReceipt(command, dependencies, input)
-      : yield* settleSubmitReceipt(command, dependencies, 'SUBMIT', input)
-  })
-
-const runNewSubmit = (
-  command: PaperProofCommand,
-  dependencies: PaperProofDependencies,
-  prepared: PreparedPaperProofIntent,
-  before: PaperProofReconciliation,
-): Effect.Effect<PaperProofReceipt, PaperProofError> =>
-  Effect.gen(function* () {
-    yield* requireExactReconciliation(before)
-    yield* lift(
-      'SUBMIT',
-      'paper proof generation activation failed',
-      dependencies.activateCapitalGrant(proofBinding(command)),
-    )
-    const afterActivation = yield* reconcileExact(dependencies)
-    const event = yield* lift(
-      'SUBMIT',
-      'paper proof guarded submit failed',
-      dependencies.execution.submit(prepared.intentId, command.consistencyDelayMs, () =>
-        markRecoveryRequired(command, dependencies, 'SUBMIT', 'paper-proof-new-submit'),
-      ),
-    )
-    let restricted = false
-    if (!successfulSubmit(event)) {
-      yield* restrict(dependencies, `paper-proof-submit-${event.eventType.toLowerCase()}`)
-      restricted = true
-    }
-    const finalReconciliation = terminalSubmit(event)
-      ? yield* reconcileExact(dependencies)
-      : yield* observeReconciliation(dependencies)
-    return yield* settleSubmitReceipt(command, dependencies, 'SUBMIT', {
-      clientOrderId: prepared.clientOrderId,
-      mutation: event,
-      reconciliations: [before, afterActivation, finalReconciliation],
-      restricted,
-      recoveryRequired: !terminalSubmit(event),
-    })
-  })
-
-const runSubmit = (
-  command: PaperProofCommand,
-  dependencies: PaperProofDependencies,
-): Effect.Effect<PaperProofReceipt, PaperProofError> =>
-  withRecoveryFinalizer(
-    command,
-    dependencies,
-    'paper-proof-submit-failure',
-    Effect.gen(function* () {
-      const existingMarker = yield* ensureRecoveryMarkerCompatible(command, dependencies, 'SUBMIT')
-      const before = yield* observeReconciliation(dependencies)
-      const prepared = yield* prepareSubmitIntent(dependencies)
-      const cancellation = yield* readMutation('SUBMIT', dependencies, MutationOperation.Cancel)
-      if (cancellation !== undefined) {
-        return yield* Effect.fail(
-          paperProofFailure(
-            'SUBMIT',
-            'paper proof submit is superseded by a durable cancellation mutation',
-            cancellation,
-            'mutation-unresolved',
-          ),
-        )
-      }
-      const existing = yield* readMutation('SUBMIT', dependencies, MutationOperation.Submit)
-      return yield* existing === undefined
-        ? runNewSubmit(command, dependencies, prepared, before)
-        : runExistingSubmit(command, dependencies, prepared, before, existing, existingMarker)
-    }),
-  )
-
-const runCancel = (
-  command: PaperProofCommand,
-  dependencies: PaperProofDependencies,
-): Effect.Effect<PaperProofReceipt, PaperProofError> =>
-  withRecoveryFinalizer(
-    command,
-    dependencies,
-    'paper-proof-cancel-failure',
-    Effect.gen(function* () {
-      const before = yield* observeReconciliation(dependencies)
-      const prepared = yield* prepareCancellation(dependencies)
-      if (prepared.existing !== undefined) {
-        yield* markRecoveryRequired(command, dependencies, 'CANCEL', 'paper-proof-existing-cancel')
-      }
-      const event = yield* cancelOrRecover(command, dependencies, prepared)
-      yield* restrict(dependencies, `paper-proof-cancel-${event.eventType.toLowerCase()}`)
-      const settled = yield* cancellationTerminal('CANCEL', dependencies, event)
-      const after = settled ? yield* reconcileExact(dependencies) : yield* observeReconciliation(dependencies)
-      const receipt = yield* completeReceipt(command, dependencies, {
-        mutation: event,
-        reconciliations: [before, after],
-        restricted: true,
-        recoveryRequired: !settled,
-      })
-      if (settled) {
-        yield* persistRecoveryCompletion(command, dependencies, 'CANCEL', receipt)
-      }
-      return receipt
-    }),
-  )
-
-const selectRecoveryOperation = (
-  state: DurableMutationState,
-  required: PaperProofRecoveryRequired | undefined,
-): PaperProofMutationOperation | undefined => {
-  if (state.cancel !== undefined) return 'CANCEL'
-  if (required !== undefined) return required.operation
-  return state.submit === undefined ? undefined : 'SUBMIT'
-}
-
-const recoverAuthoritativeMutation = (
-  command: PaperProofCommand,
-  dependencies: PaperProofDependencies,
-  operation: PaperProofMutationOperation,
-  recorded: MutationEvent,
-): Effect.Effect<PaperProofReceipt, PaperProofError> =>
-  Effect.gen(function* () {
-    const alreadySettled =
-      operation === 'CANCEL' ? yield* cancellationTerminal('RECOVER', dependencies, recorded) : terminalSubmit(recorded)
-    if (alreadySettled) {
-      const reconciliation = yield* reconcileExact(dependencies)
-      const receipt = yield* completeReceipt(command, dependencies, {
-        mutation: recorded,
-        reconciliations: [reconciliation],
-        restricted: true,
-        recoveryRequired: false,
-      })
-      yield* persistRecoveryCompletion(command, dependencies, operation, receipt)
-      return receipt
-    }
-
-    const before = yield* observeReconciliation(dependencies)
-    const event = yield* recoverMutation(command, dependencies, markerMutationOperation(operation))
-    const settled =
-      operation === 'CANCEL' ? yield* cancellationTerminal('RECOVER', dependencies, event) : terminalSubmit(event)
-    const after = settled ? yield* reconcileExact(dependencies) : yield* observeReconciliation(dependencies)
-    const receipt = yield* completeReceipt(command, dependencies, {
-      mutation: event,
-      reconciliations: [before, after],
-      restricted: true,
-      recoveryRequired: !settled,
-    })
-    if (settled) {
-      yield* persistRecoveryCompletion(command, dependencies, operation, receipt)
-    }
-    return receipt
-  })
-
-const runRecover = (
-  command: PaperProofCommand,
-  dependencies: PaperProofDependencies,
-): Effect.Effect<PaperProofReceipt, PaperProofError> =>
-  withRecoveryFinalizer(
-    command,
-    dependencies,
-    'paper-proof-recover-load-or-execution-failure',
-    Effect.gen(function* () {
-      yield* restrict(dependencies, 'paper-proof-recover-before-state-load')
-      const completed = yield* loadRecoveryCompletion(command, dependencies)
-      const required = yield* loadRecoveryRequired(command, dependencies)
-      const mutations = yield* readDurableMutationState('RECOVER', dependencies)
-      if (completed !== undefined && required === undefined) {
-        yield* validateCompletionMutationIdentity(dependencies, completed)
-        if (completionMatchesAuthoritativeMutation(mutations, completed)) {
-          const settled =
-            completed.operation === 'CANCEL'
-              ? yield* cancellationTerminal('RECOVER', dependencies, completed.mutation)
-              : terminalSubmit(completed.mutation)
-          if (settled) {
-            const refreshed = yield* refreshCompletionAfterContainment(command, dependencies, completed)
-            return receiptFromCompletion(command, dependencies, refreshed)
-          }
-        }
-      }
-
-      const operation = selectRecoveryOperation(mutations, required)
-      if (operation === undefined) {
-        return yield* Effect.fail(
-          paperProofFailure(
-            'RECOVERY_STATE',
-            'paper proof RECOVER requires a durable marker, completion, or mutation evidence',
-            { completed, required, mutations },
-            'mutation-unresolved',
-          ),
-        )
-      }
-      const recorded = mutationForOperation(mutations, operation)
-      if (recorded === undefined) {
-        return yield* Effect.fail(
-          paperProofFailure(
-            'RECOVERY_STATE',
-            'paper proof recovery marker does not have a durable mutation to recover',
-            { operation, required, mutations },
-            'mutation-unresolved',
-          ),
-        )
-      }
-      if (required?.operation !== operation) {
-        yield* markRecoveryRequired(command, dependencies, operation, 'paper-proof-reconstructed-recovery')
-      }
-      return yield* recoverAuthoritativeMutation(command, dependencies, operation, recorded)
-    }),
-  )
-
-const runValidatedPaperProof = (
-  command: PaperProofCommand,
-  dependencies: PaperProofDependencies,
-): Effect.Effect<PaperProofReceipt, PaperProofError> => {
-  switch (command.operation) {
-    case 'PREPARE':
-      return runPrepare(command, dependencies)
-    case 'SUBMIT':
-      return runSubmit(command, dependencies)
-    case 'CANCEL':
-      return runCancel(command, dependencies)
-    case 'RECOVER':
-      return runRecover(command, dependencies)
-  }
-}
 
 const commandTimeout = (message: string): Effect.Effect<never, PaperProofError> =>
   Effect.fail(
@@ -1013,19 +144,62 @@ const commandTimeout = (message: string): Effect.Effect<never, PaperProofError> 
     }),
   )
 
+const runValidatedPaperProof = (
+  command: PaperProofCommand,
+  dependencies: PaperProofDependencies,
+): Effect.Effect<PaperProofReceipt, PaperProofError> => {
+  switch (command.operation) {
+    case 'PREPARE':
+      return runPaperProofPrepare(
+        { command: { ...command, operation: 'PREPARE' }, sourcePlan: dependencies.sourcePlan },
+        dependencies.prepare,
+      )
+    case 'SUBMIT':
+      return withRecoveryFinalizer(
+        command,
+        dependencies.containment,
+        'paper-proof-submit-failure',
+        runPaperProofSubmit(
+          { command: { ...command, operation: 'SUBMIT' }, sourcePlan: dependencies.sourcePlan },
+          dependencies.submit,
+        ),
+      )
+    case 'CANCEL':
+      return withRecoveryFinalizer(
+        command,
+        dependencies.containment,
+        'paper-proof-cancel-failure',
+        runPaperProofCancel(
+          { command: { ...command, operation: 'CANCEL' }, sourcePlan: dependencies.sourcePlan },
+          dependencies.cancel,
+        ),
+      )
+    case 'RECOVER':
+      return withRecoveryFinalizer(
+        command,
+        dependencies.containment,
+        'paper-proof-recover-load-or-execution-failure',
+        runPaperProofRecover(
+          { command: { ...command, operation: 'RECOVER' }, sourcePlan: dependencies.sourcePlan },
+          dependencies.recover,
+        ),
+      )
+  }
+}
+
 export const runPaperProof = (
   command: PaperProofCommand,
   dependencies: PaperProofDependencies,
 ): Effect.Effect<PaperProofReceipt, PaperProofError> => {
   const requiresContainment = hasPaperProofMutationAuthority(dependencies.runtime)
   const executionTimeoutMs = requiresContainment
-    ? command.timeoutMs - command.containmentIoTimeoutMs * containmentIoCount
+    ? command.timeoutMs - command.containmentIoTimeoutMs * paperProofContainmentIoCount
     : command.timeoutMs
   const entry = Effect.fromResult(
     validatePaperProofEntry(command, dependencies.sourcePlan, dependencies.runtime, dependencies.protectedEntryToken),
   )
   const containedEntry = requiresContainment
-    ? withRecoveryFinalizer(command, dependencies, 'paper-proof-entry-gate-failure', entry)
+    ? withRecoveryFinalizer(command, dependencies.containment, 'paper-proof-entry-gate-failure', entry)
     : entry
   const execution = containedEntry.pipe(
     Effect.andThen(runValidatedPaperProof(command, dependencies)),

--- a/services/bayn/src/paper-proof/program.ts
+++ b/services/bayn/src/paper-proof/program.ts
@@ -10,11 +10,17 @@ import {
 import { runPaperProofPrepare, type PaperProofPrepareDependencies } from './prepare'
 import { runPaperProofRecover, type PaperProofRecoverDependencies } from './recovery'
 import { hasPaperProofMutationAuthority, paperProofContainmentIoCount, validatePaperProofEntry } from './gates'
-import { liftBounded, validateReconciliationAccount, type PaperProofContainmentDependencies } from './operations'
+import {
+  liftBounded,
+  validateReconciliationAccount,
+  type PaperProofContainmentDependencies,
+  type PaperProofMutationStore,
+} from './operations'
 import {
   PaperProofError,
   type PaperProofCommand,
   type PaperProofReceipt,
+  type PaperProofRecoveryStore,
   type PaperProofRuntimeBinding,
   type PaperProofSourcePlan,
 } from './model'
@@ -36,10 +42,14 @@ export interface PaperProofDependencies {
   readonly runtime: PaperProofRuntimeBinding
   readonly protectedEntryToken: string
   readonly containment: PaperProofContainmentDependencies
+  /** Stateful mutation evidence is canonical and shared by every mutation operation view. */
+  readonly mutations: PaperProofMutationStore
+  /** Stateful recovery markers are canonical and shared by every mutation operation view. */
+  readonly recovery: PaperProofRecoveryStore
   readonly prepare: PaperProofPrepareDependencies
-  readonly submit: PaperProofSubmitDependencies
-  readonly cancel: PaperProofCancelDependencies
-  readonly recover: PaperProofRecoverDependencies
+  readonly submit: Omit<PaperProofSubmitDependencies, 'mutations' | 'recovery'>
+  readonly cancel: Omit<PaperProofCancelDependencies, 'mutations' | 'recovery'>
+  readonly recover: Omit<PaperProofRecoverDependencies, 'mutations' | 'recovery'>
 }
 
 const logContainmentFailure = <A>(
@@ -166,7 +176,7 @@ const runValidatedPaperProof = (
         'paper-proof-submit-failure',
         runPaperProofSubmit(
           { command: { ...command, operation: 'SUBMIT' }, sourcePlan: dependencies.sourcePlan },
-          dependencies.submit,
+          { ...dependencies.submit, mutations: dependencies.mutations, recovery: dependencies.recovery },
         ),
       )
     case 'CANCEL':
@@ -177,7 +187,7 @@ const runValidatedPaperProof = (
         'paper-proof-cancel-failure',
         runPaperProofCancel(
           { command: { ...command, operation: 'CANCEL' }, sourcePlan: dependencies.sourcePlan },
-          dependencies.cancel,
+          { ...dependencies.cancel, mutations: dependencies.mutations, recovery: dependencies.recovery },
         ),
       )
     case 'RECOVER':
@@ -188,7 +198,7 @@ const runValidatedPaperProof = (
         'paper-proof-recover-load-or-execution-failure',
         runPaperProofRecover(
           { command: { ...command, operation: 'RECOVER' }, sourcePlan: dependencies.sourcePlan },
-          dependencies.recover,
+          { ...dependencies.recover, mutations: dependencies.mutations, recovery: dependencies.recovery },
         ),
       )
   }

--- a/services/bayn/src/paper-proof/program.ts
+++ b/services/bayn/src/paper-proof/program.ts
@@ -58,6 +58,7 @@ const logContainmentFailure = <A>(
 
 const containFailure = (
   context: PaperProofContainmentContext,
+  accountId: string,
   dependencies: PaperProofContainmentDependencies,
   reason: string,
 ): Effect.Effect<void> =>
@@ -91,25 +92,27 @@ const containFailure = (
         'paper proof containment reconciliation failed',
         dependencies.reconcile(),
         context.containmentIoTimeoutMs,
-      ).pipe(
-        Effect.flatMap((result) => Effect.fromResult(validateReconciliationAccount(dependencies.accountId, result))),
-      ),
+      ).pipe(Effect.flatMap((result) => Effect.fromResult(validateReconciliationAccount(accountId, result)))),
     )
     yield* logContainmentFailure(context.operation, 'reconcile', reconciliationExit)
   })
 
 const withRecoveryFinalizer = <A>(
   command: PaperProofContainmentContext,
+  accountId: string,
   dependencies: PaperProofContainmentDependencies,
   reason: string,
   effect: Effect.Effect<A, PaperProofError>,
 ): Effect.Effect<A, PaperProofError> =>
   effect.pipe(
-    Effect.onExit((exit) => (Exit.isFailure(exit) ? containFailure(command, dependencies, reason) : Effect.void)),
+    Effect.onExit((exit) =>
+      Exit.isFailure(exit) ? containFailure(command, accountId, dependencies, reason) : Effect.void,
+    ),
   )
 
 export const containMalformedPaperProofCommand = (
   operation: PaperProofCommand['operation'] | 'GATE',
+  accountId: string,
   dependencies: PaperProofContainmentDependencies,
   failure: PaperProofError,
 ): Effect.Effect<never, PaperProofError> =>
@@ -118,6 +121,7 @@ export const containMalformedPaperProofCommand = (
       operation,
       containmentIoTimeoutMs: malformedCommandContainmentIoTimeoutMs,
     },
+    accountId,
     dependencies,
     'paper-proof-malformed-command-envelope',
     Effect.fail(failure),
@@ -157,6 +161,7 @@ const runValidatedPaperProof = (
     case 'SUBMIT':
       return withRecoveryFinalizer(
         command,
+        dependencies.sourcePlan.accountId,
         dependencies.containment,
         'paper-proof-submit-failure',
         runPaperProofSubmit(
@@ -167,6 +172,7 @@ const runValidatedPaperProof = (
     case 'CANCEL':
       return withRecoveryFinalizer(
         command,
+        dependencies.sourcePlan.accountId,
         dependencies.containment,
         'paper-proof-cancel-failure',
         runPaperProofCancel(
@@ -177,6 +183,7 @@ const runValidatedPaperProof = (
     case 'RECOVER':
       return withRecoveryFinalizer(
         command,
+        dependencies.sourcePlan.accountId,
         dependencies.containment,
         'paper-proof-recover-load-or-execution-failure',
         runPaperProofRecover(
@@ -199,7 +206,13 @@ export const runPaperProof = (
     validatePaperProofEntry(command, dependencies.sourcePlan, dependencies.runtime, dependencies.protectedEntryToken),
   )
   const containedEntry = requiresContainment
-    ? withRecoveryFinalizer(command, dependencies.containment, 'paper-proof-entry-gate-failure', entry)
+    ? withRecoveryFinalizer(
+        command,
+        dependencies.sourcePlan.accountId,
+        dependencies.containment,
+        'paper-proof-entry-gate-failure',
+        entry,
+      )
     : entry
   const execution = containedEntry.pipe(
     Effect.andThen(runValidatedPaperProof(command, dependencies)),

--- a/services/bayn/src/paper-proof/program.ts
+++ b/services/bayn/src/paper-proof/program.ts
@@ -46,10 +46,19 @@ export interface PaperProofDependencies {
   readonly mutations: PaperProofMutationStore
   /** Stateful recovery markers are canonical and shared by every mutation operation view. */
   readonly recovery: PaperProofRecoveryStore
-  readonly prepare: PaperProofPrepareDependencies
-  readonly submit: Omit<PaperProofSubmitDependencies, 'mutations' | 'recovery'>
-  readonly cancel: Omit<PaperProofCancelDependencies, 'mutations' | 'recovery'>
-  readonly recover: Omit<PaperProofRecoverDependencies, 'mutations' | 'recovery'>
+  readonly prepare: Omit<PaperProofPrepareDependencies, 'currentUtcInstant' | 'reconcile'>
+  readonly submit: Omit<
+    PaperProofSubmitDependencies,
+    'currentUtcInstant' | 'mutations' | 'reconcile' | 'recovery' | 'restrictAuthority'
+  >
+  readonly cancel: Omit<
+    PaperProofCancelDependencies,
+    'currentUtcInstant' | 'mutations' | 'reconcile' | 'recovery' | 'restrictAuthority'
+  >
+  readonly recover: Omit<
+    PaperProofRecoverDependencies,
+    'currentUtcInstant' | 'mutations' | 'reconcile' | 'recovery' | 'restrictAuthority'
+  >
 }
 
 const logContainmentFailure = <A>(
@@ -166,7 +175,11 @@ const runValidatedPaperProof = (
     case 'PREPARE':
       return runPaperProofPrepare(
         { command: { ...command, operation: 'PREPARE' }, sourcePlan: dependencies.sourcePlan },
-        dependencies.prepare,
+        {
+          ...dependencies.prepare,
+          currentUtcInstant: dependencies.containment.currentUtcInstant,
+          reconcile: dependencies.containment.reconcile,
+        },
       )
     case 'SUBMIT':
       return withRecoveryFinalizer(
@@ -176,7 +189,14 @@ const runValidatedPaperProof = (
         'paper-proof-submit-failure',
         runPaperProofSubmit(
           { command: { ...command, operation: 'SUBMIT' }, sourcePlan: dependencies.sourcePlan },
-          { ...dependencies.submit, mutations: dependencies.mutations, recovery: dependencies.recovery },
+          {
+            ...dependencies.submit,
+            currentUtcInstant: dependencies.containment.currentUtcInstant,
+            mutations: dependencies.mutations,
+            reconcile: dependencies.containment.reconcile,
+            recovery: dependencies.recovery,
+            restrictAuthority: dependencies.containment.restrictAuthority,
+          },
         ),
       )
     case 'CANCEL':
@@ -187,7 +207,14 @@ const runValidatedPaperProof = (
         'paper-proof-cancel-failure',
         runPaperProofCancel(
           { command: { ...command, operation: 'CANCEL' }, sourcePlan: dependencies.sourcePlan },
-          { ...dependencies.cancel, mutations: dependencies.mutations, recovery: dependencies.recovery },
+          {
+            ...dependencies.cancel,
+            currentUtcInstant: dependencies.containment.currentUtcInstant,
+            mutations: dependencies.mutations,
+            reconcile: dependencies.containment.reconcile,
+            recovery: dependencies.recovery,
+            restrictAuthority: dependencies.containment.restrictAuthority,
+          },
         ),
       )
     case 'RECOVER':
@@ -198,7 +225,14 @@ const runValidatedPaperProof = (
         'paper-proof-recover-load-or-execution-failure',
         runPaperProofRecover(
           { command: { ...command, operation: 'RECOVER' }, sourcePlan: dependencies.sourcePlan },
-          { ...dependencies.recover, mutations: dependencies.mutations, recovery: dependencies.recovery },
+          {
+            ...dependencies.recover,
+            currentUtcInstant: dependencies.containment.currentUtcInstant,
+            mutations: dependencies.mutations,
+            reconcile: dependencies.containment.reconcile,
+            recovery: dependencies.recovery,
+            restrictAuthority: dependencies.containment.restrictAuthority,
+          },
         ),
       )
   }

--- a/services/bayn/src/paper-proof/program.ts
+++ b/services/bayn/src/paper-proof/program.ts
@@ -1,5 +1,7 @@
 import { Clock, Duration, Effect, Exit } from 'effect'
 
+import { MutationOperation } from '../broker/alpaca-mutations'
+import type { MutationEvent } from '../execution/mutations'
 import { utcInstantFromEpochMillis } from '../time'
 import {
   runPaperProofCancel,
@@ -33,6 +35,25 @@ interface PaperProofContainmentContext {
   readonly containmentIoTimeoutMs: number
 }
 
+type PaperProofSubmitCompositionDependencies = Omit<
+  PaperProofSubmitDependencies,
+  'currentUtcInstant' | 'execution' | 'mutations' | 'reconcile' | 'recovery' | 'restrictAuthority'
+> & {
+  readonly execution: Omit<PaperProofSubmitDependencies['execution'], 'recover'>
+}
+
+type PaperProofCancelCompositionDependencies = Omit<
+  PaperProofCancelDependencies,
+  'currentUtcInstant' | 'execution' | 'mutations' | 'readIntent' | 'reconcile' | 'recovery' | 'restrictAuthority'
+> & {
+  readonly execution: Omit<PaperProofCancelDependencies['execution'], 'recover'>
+}
+
+type PaperProofRecoverCompositionDependencies = Omit<
+  PaperProofRecoverDependencies,
+  'currentUtcInstant' | 'execution' | 'mutations' | 'readIntent' | 'reconcile' | 'recovery' | 'restrictAuthority'
+>
+
 /**
  * Composition owns all live capabilities, but each operation receives only its nested capability surface. The
  * operation programs never receive runtime authority, the protected token, or another operation's broker adapter.
@@ -48,19 +69,12 @@ export interface PaperProofDependencies {
   readonly recovery: PaperProofRecoveryStore
   /** Durable intent state is canonical and shared by cancellation and recovery views. */
   readonly readIntent: PaperProofCancelDependencies['readIntent']
+  /** Broker recovery lookup is canonical and shared by the original mutation and RECOVER views. */
+  readonly recoverMutation: (intentId: string, operation: MutationOperation) => Effect.Effect<MutationEvent, Error>
   readonly prepare: Omit<PaperProofPrepareDependencies, 'currentUtcInstant' | 'reconcile'>
-  readonly submit: Omit<
-    PaperProofSubmitDependencies,
-    'currentUtcInstant' | 'mutations' | 'reconcile' | 'recovery' | 'restrictAuthority'
-  >
-  readonly cancel: Omit<
-    PaperProofCancelDependencies,
-    'currentUtcInstant' | 'mutations' | 'readIntent' | 'reconcile' | 'recovery' | 'restrictAuthority'
-  >
-  readonly recover: Omit<
-    PaperProofRecoverDependencies,
-    'currentUtcInstant' | 'mutations' | 'readIntent' | 'reconcile' | 'recovery' | 'restrictAuthority'
-  >
+  readonly submit: PaperProofSubmitCompositionDependencies
+  readonly cancel: PaperProofCancelCompositionDependencies
+  readonly recover: PaperProofRecoverCompositionDependencies
 }
 
 const logContainmentFailure = <A>(
@@ -195,6 +209,10 @@ const runValidatedPaperProof = (
             ...dependencies.submit,
             currentUtcInstant: dependencies.containment.currentUtcInstant,
             mutations: dependencies.mutations,
+            execution: {
+              ...dependencies.submit.execution,
+              recover: (intentId) => dependencies.recoverMutation(intentId, MutationOperation.Submit),
+            },
             reconcile: dependencies.containment.reconcile,
             recovery: dependencies.recovery,
             restrictAuthority: dependencies.containment.restrictAuthority,
@@ -213,6 +231,10 @@ const runValidatedPaperProof = (
             ...dependencies.cancel,
             currentUtcInstant: dependencies.containment.currentUtcInstant,
             mutations: dependencies.mutations,
+            execution: {
+              ...dependencies.cancel.execution,
+              recover: (intentId) => dependencies.recoverMutation(intentId, MutationOperation.Cancel),
+            },
             readIntent: dependencies.readIntent,
             reconcile: dependencies.containment.reconcile,
             recovery: dependencies.recovery,
@@ -232,6 +254,10 @@ const runValidatedPaperProof = (
             ...dependencies.recover,
             currentUtcInstant: dependencies.containment.currentUtcInstant,
             mutations: dependencies.mutations,
+            execution: {
+              recoverSubmit: (intentId) => dependencies.recoverMutation(intentId, MutationOperation.Submit),
+              recoverCancel: (intentId) => dependencies.recoverMutation(intentId, MutationOperation.Cancel),
+            },
             readIntent: dependencies.readIntent,
             reconcile: dependencies.containment.reconcile,
             recovery: dependencies.recovery,

--- a/services/bayn/src/paper-proof/recovery.ts
+++ b/services/bayn/src/paper-proof/recovery.ts
@@ -1,0 +1,189 @@
+import { Effect } from 'effect'
+
+import { MutationOperation } from '../broker/alpaca-mutations'
+import type { MutationEvent } from '../execution/mutations'
+import {
+  completePaperProofReceipt,
+  completeRecovery,
+  completionMatchesAuthoritativeMutation,
+  decideRecoverySelection,
+  isCancellationSettled,
+  isRecoveredCancellation,
+  isTerminalSubmit,
+  loadRecoveryCompletion,
+  loadRecoveryRequired,
+  makeReceiptFromCompletion,
+  markRecoveryRequired,
+  observeReconciliation,
+  persistRecoveryCompletion,
+  readDurableMutationState,
+  readPaperProofIntent,
+  readPaperProofMutation,
+  recoverMutationLookup,
+  reconcileExact,
+  restrictPaperProof,
+  validateCompletionMutationIdentity,
+  type DurableMutationState,
+  type PaperProofMutationStore,
+  type PaperProofOperationContext,
+  type PaperProofRestrictionDependencies,
+} from './operations'
+import type {
+  PaperProofError,
+  PaperProofIntentSnapshot,
+  PaperProofReceipt,
+  PaperProofReconciliation,
+  PaperProofRecoveryCompletion,
+  PaperProofRecoveryStore,
+} from './model'
+
+export interface PaperProofRecoverDependencies extends PaperProofRestrictionDependencies {
+  readonly recovery: PaperProofRecoveryStore
+  readonly mutations: PaperProofMutationStore
+  readonly execution: {
+    /** Lookup-only recovery for a previously started SUBMIT. It never issues another POST. */
+    readonly recoverSubmit: (intentId: string) => Effect.Effect<MutationEvent, Error>
+    /** Lookup-only recovery for a previously started CANCEL. It never issues another DELETE. */
+    readonly recoverCancel: (intentId: string) => Effect.Effect<MutationEvent, Error>
+  }
+  readonly readIntent: (intentId: string) => Effect.Effect<PaperProofIntentSnapshot | undefined, Error>
+  readonly reconcile: () => Effect.Effect<PaperProofReconciliation, Error>
+}
+
+const cancellationTerminal = (
+  context: PaperProofOperationContext<'RECOVER'>,
+  dependencies: PaperProofRecoverDependencies,
+  event: MutationEvent,
+): Effect.Effect<boolean, PaperProofError> =>
+  isRecoveredCancellation(event)
+    ? readPaperProofIntent(context, 'RECOVER', dependencies.readIntent).pipe(
+        Effect.map((intent) => isCancellationSettled(event, intent)),
+      )
+    : Effect.succeed(false)
+
+const latestCancellation =
+  (
+    context: PaperProofOperationContext<'RECOVER'>,
+    dependencies: PaperProofRecoverDependencies,
+  ): (() => Effect.Effect<MutationEvent | undefined, PaperProofError>) =>
+  () =>
+    readPaperProofMutation(context, 'RECOVERY_STATE', dependencies.mutations, MutationOperation.Cancel)
+
+const recoverAuthoritativeMutation = (
+  context: PaperProofOperationContext<'RECOVER'>,
+  dependencies: PaperProofRecoverDependencies,
+  operation: 'SUBMIT' | 'CANCEL',
+  recorded: MutationEvent,
+): Effect.Effect<PaperProofReceipt, PaperProofError> =>
+  Effect.gen(function* () {
+    const alreadySettled =
+      operation === 'CANCEL' ? yield* cancellationTerminal(context, dependencies, recorded) : isTerminalSubmit(recorded)
+    if (alreadySettled) {
+      const reconciliation = yield* reconcileExact(context.sourcePlan.accountId, dependencies.reconcile)
+      const receipt = yield* completePaperProofReceipt(context, dependencies.currentUtcInstant, {
+        mutation: recorded,
+        reconciliations: [reconciliation],
+        restricted: true,
+        recoveryRequired: false,
+      })
+      yield* persistRecoveryCompletion(
+        context,
+        {
+          recovery: dependencies.recovery,
+          ...(operation === 'SUBMIT' ? { latestCancellation: latestCancellation(context, dependencies) } : {}),
+        },
+        operation,
+        receipt,
+      )
+      return receipt
+    }
+
+    const before = yield* observeReconciliation(context.sourcePlan.accountId, dependencies.reconcile)
+    const event =
+      operation === 'SUBMIT'
+        ? yield* recoverMutationLookup(context, MutationOperation.Submit, () =>
+            dependencies.execution.recoverSubmit(context.sourcePlan.intentId),
+          )
+        : yield* recoverMutationLookup(context, MutationOperation.Cancel, () =>
+            dependencies.execution.recoverCancel(context.sourcePlan.intentId),
+          )
+    const settled =
+      operation === 'CANCEL' ? yield* cancellationTerminal(context, dependencies, event) : isTerminalSubmit(event)
+    const after = settled
+      ? yield* reconcileExact(context.sourcePlan.accountId, dependencies.reconcile)
+      : yield* observeReconciliation(context.sourcePlan.accountId, dependencies.reconcile)
+    const receipt = yield* completePaperProofReceipt(context, dependencies.currentUtcInstant, {
+      mutation: event,
+      reconciliations: [before, after],
+      restricted: true,
+      recoveryRequired: !settled,
+    })
+    if (settled) {
+      yield* persistRecoveryCompletion(
+        context,
+        {
+          recovery: dependencies.recovery,
+          ...(operation === 'SUBMIT' ? { latestCancellation: latestCancellation(context, dependencies) } : {}),
+        },
+        operation,
+        receipt,
+      )
+    }
+    return receipt
+  })
+
+const refreshCompletionAfterContainment = (
+  context: PaperProofOperationContext<'RECOVER'>,
+  dependencies: PaperProofRecoverDependencies,
+  completion: PaperProofRecoveryCompletion,
+): Effect.Effect<PaperProofRecoveryCompletion, PaperProofError> => {
+  if (completion.restricted) return Effect.succeed(completion)
+  return Effect.gen(function* () {
+    const reconciliation = yield* reconcileExact(context.sourcePlan.accountId, dependencies.reconcile)
+    const refreshed: PaperProofRecoveryCompletion = {
+      ...completion,
+      reconciliations: [...completion.reconciliations, reconciliation],
+      restricted: true,
+    }
+    yield* completeRecovery(
+      context,
+      dependencies.recovery,
+      completion.operation === 'SUBMIT' ? latestCancellation(context, dependencies) : undefined,
+      refreshed,
+    )
+    return refreshed
+  })
+}
+
+export const runPaperProofRecover = (
+  context: PaperProofOperationContext<'RECOVER'>,
+  dependencies: PaperProofRecoverDependencies,
+): Effect.Effect<PaperProofReceipt, PaperProofError> =>
+  Effect.gen(function* () {
+    yield* restrictPaperProof(dependencies, 'paper-proof-recover-before-state-load')
+    const completed = yield* loadRecoveryCompletion(context, dependencies.recovery)
+    const required = yield* loadRecoveryRequired(context, dependencies.recovery)
+    const mutations: DurableMutationState = yield* readDurableMutationState(context, 'RECOVER', dependencies.mutations)
+    if (completed !== undefined && required === undefined) {
+      yield* Effect.fromResult(
+        // Completion is advisory until its mutation and authority facts are read again in this same pass.
+        validateCompletionMutationIdentity(context, completed),
+      )
+      if (completionMatchesAuthoritativeMutation(mutations, completed)) {
+        const settled =
+          completed.operation === 'CANCEL'
+            ? yield* cancellationTerminal(context, dependencies, completed.mutation)
+            : isTerminalSubmit(completed.mutation)
+        if (settled) {
+          const refreshed = yield* refreshCompletionAfterContainment(context, dependencies, completed)
+          return makeReceiptFromCompletion(context, refreshed)
+        }
+      }
+    }
+
+    const selection = yield* Effect.fromResult(decideRecoverySelection(mutations, required))
+    if (required?.operation !== selection.operation) {
+      yield* markRecoveryRequired(context, dependencies, selection.operation, 'paper-proof-reconstructed-recovery')
+    }
+    return yield* recoverAuthoritativeMutation(context, dependencies, selection.operation, selection.recorded)
+  })


### PR DESCRIPTION
## Summary

- Split PAPER PREPARE, SUBMIT, CANCEL, and RECOVER into operation-specific programs with narrow capability interfaces.
- Move reconciliation, admission, receipt, marker, completion, and recovery decisions into total domain helpers with bounded Effect interpreters at I/O boundaries.
- Preserve source-entry gates, mutation containment, durable recovery markers, crash/timeout recovery, exactly-once broker hooks, reconciliation, and error/log contracts.
- Add compile-time capability restrictions and containment behavior coverage.

## Related Issues

None.

## Testing

- `bun test src/paper-proof/program.test.ts` — 50 pass, 0 fail.
- `bun run --filter @proompteng/bayn test` — 1196 pass, 153 skip, 0 fail.
- `bun run --filter @proompteng/bayn test:postgres` — 0 fail; PostgreSQL integration cases skipped because the local PostgreSQL gate is unavailable.
- `bun run --filter @proompteng/bayn tsc` — pass.
- `bun run --filter @proompteng/bayn lint` — pass.
- `bun run --filter @proompteng/bayn lint:effect` — pass.
- `bun run --filter @proompteng/bayn lint:oxlint` — 0 errors; one pre-existing warning in forbidden `candidate-development-domain/preflight.ts`.
- `bun run --filter @proompteng/bayn lint:oxlint:type` — 0 errors; same pre-existing warning.
- `bunx oxfmt --check services/bayn/src/paper-proof services/bayn/src/paper-proof-command.ts` — pass.
- `bun run --filter @proompteng/bayn build` — pass.

## Breaking Changes

`PaperProofDependencies` now exposes nested operation-specific capability groups; all in-repository callers are updated. No runtime or broker behavior changes.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable.
- [x] No documentation or release-note update is required for this internal composition refactor.