### PR TITLE
fix(bayn): bind evaluator source closure locally

### DIFF
--- a/packages/scripts/src/bayn/candidate-development-local/command.test.ts
+++ b/packages/scripts/src/bayn/candidate-development-local/command.test.ts
@@ -153,6 +153,47 @@ describe('candidate development local command', () => {
     }
   })
 
+  test('rejects an index-hidden evaluator modification during source revalidation', async () => {
+    const repository = await mkdtemp(join(tmpdir(), 'bayn-candidate-development-index-source-'))
+    const modulePath = 'services/bayn/src/strategy/example.ts'
+    const sourceManifestPath = 'services/bayn/candidates/example.json'
+    const evaluatorPath = 'services/bayn/src/evaluator.ts'
+    try {
+      await mkdir(join(repository, 'services/bayn/src/strategy'), { recursive: true })
+      await mkdir(join(repository, 'services/bayn/candidates'), { recursive: true })
+      await writeFile(join(repository, modulePath), 'export const candidateDevelopmentProgram = {}\n')
+      await writeFile(join(repository, sourceManifestPath), '{}\n')
+      await writeFile(join(repository, evaluatorPath), 'export const evaluator = 1\n')
+      await execFileAsync('git', ['init', '-q'], { cwd: repository })
+      await execFileAsync('git', ['config', 'user.email', 'test@example.com'], { cwd: repository })
+      await execFileAsync('git', ['config', 'user.name', 'Bayn Test'], { cwd: repository })
+      await execFileAsync('git', ['add', '.'], { cwd: repository })
+      await execFileAsync('git', ['commit', '-qm', 'test: bind evaluator source'], { cwd: repository })
+      const { stdout } = await execFileAsync('git', ['rev-parse', 'HEAD'], { cwd: repository })
+      const sourceRevision = String(stdout).trim()
+      const sourceBinding = validateCandidateDevelopmentLocalSourceBinding({
+        ...source.value,
+        sourceRevision,
+      })
+      if (!sourceBinding.ok) throw new Error(sourceBinding.message)
+      const resolution: CandidateDevelopmentLocalSourceResolution = {
+        ...resolved,
+        repositoryRoot: repository,
+        modulePath,
+        sourceManifestPath,
+        source: sourceBinding.value,
+      }
+      await execFileAsync('git', ['update-index', '--assume-unchanged', '--', evaluatorPath], { cwd: repository })
+      await writeFile(join(repository, evaluatorPath), 'export const evaluator = 2\n')
+
+      await expect(revalidateCandidateDevelopmentLocalSource(resolution)).rejects.toMatchObject({
+        code: 'source-working-tree-dirty',
+      })
+    } finally {
+      await rm(repository, { recursive: true, force: true })
+    }
+  })
+
   test('rejects invalid arguments before source resolution or process execution', async () => {
     const fixture = dependenciesFor()
     let resolvedCount = 0

--- a/packages/scripts/src/bayn/candidate-development-local/command.test.ts
+++ b/packages/scripts/src/bayn/candidate-development-local/command.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, test } from 'bun:test'
-import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { execFile } from 'node:child_process'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { promisify } from 'node:util'
 
 import {
   makeCandidateDevelopmentLocalAttemptReceipt,
@@ -13,6 +15,7 @@ import {
 import {
   CandidateDevelopmentLocalError,
   candidateDevelopmentGitCommand,
+  revalidateCandidateDevelopmentLocalSource,
   runCandidateDevelopmentLocally,
   finalizeCandidateDevelopmentLocalReceipt,
   reserveCandidateDevelopmentLocalReceipt,
@@ -20,6 +23,8 @@ import {
   type CandidateDevelopmentLocalProcessRequest,
   type CandidateDevelopmentLocalSourceResolution,
 } from './command'
+
+const execFileAsync = promisify(execFile)
 
 const source = validateCandidateDevelopmentLocalSourceBinding({
   sourceRevision: 'a'.repeat(40),
@@ -107,6 +112,44 @@ describe('candidate development local command', () => {
     } finally {
       if (previousReplacementRef === undefined) delete process.env.GIT_REPLACE_REF_BASE
       else process.env.GIT_REPLACE_REF_BASE = previousReplacementRef
+    }
+  })
+
+  test('rejects an untracked evaluator source file during source revalidation', async () => {
+    const repository = await mkdtemp(join(tmpdir(), 'bayn-candidate-development-evaluator-source-'))
+    const modulePath = 'services/bayn/src/strategy/example.ts'
+    const sourceManifestPath = 'services/bayn/candidates/example.json'
+    try {
+      await mkdir(join(repository, 'services/bayn/src/strategy'), { recursive: true })
+      await mkdir(join(repository, 'services/bayn/candidates'), { recursive: true })
+      await writeFile(join(repository, modulePath), 'export const candidateDevelopmentProgram = {}\n')
+      await writeFile(join(repository, sourceManifestPath), '{}\n')
+      await execFileAsync('git', ['init', '-q'], { cwd: repository })
+      await execFileAsync('git', ['config', 'user.email', 'test@example.com'], { cwd: repository })
+      await execFileAsync('git', ['config', 'user.name', 'Bayn Test'], { cwd: repository })
+      await execFileAsync('git', ['add', '.'], { cwd: repository })
+      await execFileAsync('git', ['commit', '-qm', 'test: bind evaluator source'], { cwd: repository })
+      const { stdout } = await execFileAsync('git', ['rev-parse', 'HEAD'], { cwd: repository })
+      const sourceRevision = String(stdout).trim()
+      const sourceBinding = validateCandidateDevelopmentLocalSourceBinding({
+        ...source.value,
+        sourceRevision,
+      })
+      if (!sourceBinding.ok) throw new Error(sourceBinding.message)
+      const resolution: CandidateDevelopmentLocalSourceResolution = {
+        ...resolved,
+        repositoryRoot: repository,
+        modulePath,
+        sourceManifestPath,
+        source: sourceBinding.value,
+      }
+      await writeFile(join(repository, 'services/bayn/src/untracked-evaluator-helper.ts'), 'export const value = 1\n')
+
+      await expect(revalidateCandidateDevelopmentLocalSource(resolution)).rejects.toMatchObject({
+        code: 'source-working-tree-dirty',
+      })
+    } finally {
+      await rm(repository, { recursive: true, force: true })
     }
   })
 

--- a/packages/scripts/src/bayn/candidate-development-local/command.ts
+++ b/packages/scripts/src/bayn/candidate-development-local/command.ts
@@ -19,6 +19,7 @@ import {
 const execFileAsync = promisify(execFile)
 const maximumGitOutputBytes = 8 * 1024 * 1024
 const candidateDevelopmentCommandPath = 'services/bayn/src/candidate-development-command.ts'
+const candidateDevelopmentEvaluatorSourcePath = 'services/bayn/src'
 const localReceiptName = 'bayn-candidate-development-local-receipt.json'
 
 export type CandidateDevelopmentLocalErrorCode =
@@ -124,6 +125,19 @@ const gitDiffIsClean = async (repositoryRoot: string, paths: readonly string[]):
   }
 }
 
+const gitWorkingTreeIsClean = async (repositoryRoot: string, paths: readonly string[]): Promise<boolean> => {
+  if (!(await gitDiffIsClean(repositoryRoot, paths))) return false
+  const status = await gitText(repositoryRoot, [
+    'status',
+    '--porcelain=v1',
+    '--untracked-files=all',
+    '--ignored=matching',
+    '--',
+    ...paths,
+  ])
+  return status.length === 0
+}
+
 const repositoryRelativePath = (repositoryRoot: string, absolutePath: string, label: string): string => {
   const path = relative(repositoryRoot, absolutePath)
   if (path.length === 0 || path === '..' || path.startsWith(`..${sep}`) || path.startsWith(sep)) {
@@ -174,10 +188,16 @@ export const resolveCandidateDevelopmentLocalSource = async (
 
   const modulePath = repositoryRelativePath(repositoryRoot, absoluteModulePath, 'module')
   const sourceManifestPath = repositoryRelativePath(repositoryRoot, absoluteSourceManifestPath, 'source manifest')
-  if (!(await gitDiffIsClean(repositoryRoot, [modulePath, sourceManifestPath]))) {
+  if (
+    !(await gitWorkingTreeIsClean(repositoryRoot, [
+      modulePath,
+      sourceManifestPath,
+      candidateDevelopmentEvaluatorSourcePath,
+    ]))
+  ) {
     throw new CandidateDevelopmentLocalError(
       'source-working-tree-dirty',
-      'module and source manifest must match their exact reviewed HEAD blobs',
+      'candidate module, source manifest, and evaluator source must match their exact reviewed HEAD blobs',
     )
   }
   for (const path of [modulePath, sourceManifestPath]) {
@@ -236,10 +256,16 @@ export const revalidateCandidateDevelopmentLocalSource = async (
       'the reviewed source revision changed during local candidate development',
     )
   }
-  if (!(await gitDiffIsClean(resolution.repositoryRoot, [resolution.modulePath, resolution.sourceManifestPath]))) {
+  if (
+    !(await gitWorkingTreeIsClean(resolution.repositoryRoot, [
+      resolution.modulePath,
+      resolution.sourceManifestPath,
+      candidateDevelopmentEvaluatorSourcePath,
+    ]))
+  ) {
     throw new CandidateDevelopmentLocalError(
       'source-working-tree-dirty',
-      'module and source manifest changed during local candidate development',
+      'candidate module, source manifest, or evaluator source changed during local candidate development',
     )
   }
   const [moduleBlobOid, sourceManifestBlobOid] = await Promise.all([

--- a/packages/scripts/src/bayn/candidate-development-local/command.ts
+++ b/packages/scripts/src/bayn/candidate-development-local/command.ts
@@ -126,6 +126,15 @@ const gitDiffIsClean = async (repositoryRoot: string, paths: readonly string[]):
 }
 
 const gitWorkingTreeIsClean = async (repositoryRoot: string, paths: readonly string[]): Promise<boolean> => {
+  const indexEntries = await gitText(repositoryRoot, ['ls-files', '-v', '--', ...paths])
+  if (
+    indexEntries
+      .split('\n')
+      .filter((entry) => entry.length > 0)
+      .some((entry) => !entry.startsWith('H '))
+  ) {
+    return false
+  }
   if (!(await gitDiffIsClean(repositoryRoot, paths))) return false
   const status = await gitText(repositoryRoot, [
     'status',


### PR DESCRIPTION
## Summary

- Require the complete `services/bayn/src` evaluator source tree to match the reserved `HEAD` before and after local candidate execution.
- Reject tracked, untracked, and ignored evaluator-source changes with the existing fail-closed source-working-tree error.
- Add a temporary Git repository regression test proving an untracked evaluator file is rejected during revalidation.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/bayn/candidate-development-local/command.test.ts` — 12 pass, 0 fail.
- `bun run --filter @proompteng/scripts lint` — pass; 3 pre-existing warnings.
- `bun run --filter @proompteng/scripts lint:oxlint:type` — pass; 3 pre-existing warnings.
- `git diff --check` — pass.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; section removed.
- [x] Breaking Changes section is handled.
- [x] Documentation and follow-ups are not required for this internal wrapper hardening.