### PR TITLE
fix(bayn): preserve local candidate decision status

### DIFF
--- a/packages/scripts/src/bayn/candidate-development-local/command.test.ts
+++ b/packages/scripts/src/bayn/candidate-development-local/command.test.ts
@@ -44,6 +44,7 @@ const resolved: CandidateDevelopmentLocalSourceResolution = {
   sourceManifestPath: 'services/bayn/candidates/example.json',
   runtimeMarketDataPath: '/sealed/typed-runtime-market-data.json',
   receiptPath: '/repo/.git/bayn-candidate-development-local-receipt.json',
+  candidateOrdinal: 20,
   source: source.value,
 }
 
@@ -319,6 +320,24 @@ describe('candidate development local command', () => {
       })
       await finalizeCandidateDevelopmentLocalReceipt(receiptPath, completed)
       expect(JSON.parse(await readFile(receiptPath, 'utf8'))).toMatchObject({ status: 'completed', exitCode: 0 })
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+
+  test('claims the v3 ordinal path before the legacy path for upgrade coordination', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'bayn-candidate-development-local-'))
+    const legacyReceiptPath = join(directory, 'bayn-candidate-development-local-receipt.json')
+    const reserved = makeCandidateDevelopmentLocalAttemptReceipt(source.value, 'reserved')
+    try {
+      await reserveCandidateDevelopmentLocalReceipt(legacyReceiptPath, reserved, 20)
+
+      expect(
+        JSON.parse(
+          await readFile(join(directory, 'bayn', 'candidate-development-attempts', 'ordinal-20.json'), 'utf8'),
+        ),
+      ).toMatchObject({ status: 'reserved', attempt: 1 })
+      expect(JSON.parse(await readFile(legacyReceiptPath, 'utf8'))).toMatchObject({ status: 'reserved', attempt: 1 })
     } finally {
       await rm(directory, { recursive: true, force: true })
     }

--- a/packages/scripts/src/bayn/candidate-development-local/command.test.ts
+++ b/packages/scripts/src/bayn/candidate-development-local/command.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'bun:test'
 import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { execFile } from 'node:child_process'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 import { promisify } from 'node:util'
 
 import {
@@ -44,6 +44,7 @@ const resolved: CandidateDevelopmentLocalSourceResolution = {
   sourceManifestPath: 'services/bayn/candidates/example.json',
   runtimeMarketDataPath: '/sealed/typed-runtime-market-data.json',
   receiptPath: '/repo/.git/bayn-candidate-development-local-receipt.json',
+  attemptReceiptPath: '/repo/.git/bayn/candidate-development-attempts/ordinal-20.json',
   candidateOrdinal: 20,
   source: source.value,
 }
@@ -327,16 +328,21 @@ describe('candidate development local command', () => {
 
   test('claims the v3 ordinal path before the legacy path for upgrade coordination', async () => {
     const directory = await mkdtemp(join(tmpdir(), 'bayn-candidate-development-local-'))
-    const legacyReceiptPath = join(directory, 'bayn-candidate-development-local-receipt.json')
+    const legacyReceiptPath = join(directory, 'worktree-git', 'bayn-candidate-development-local-receipt.json')
+    const attemptReceiptPath = join(
+      directory,
+      'common-git',
+      'bayn',
+      'candidate-development-attempts',
+      'ordinal-20.json',
+    )
     const reserved = makeCandidateDevelopmentLocalAttemptReceipt(source.value, 'reserved')
     try {
-      await reserveCandidateDevelopmentLocalReceipt(legacyReceiptPath, reserved, 20)
+      await mkdir(join(directory, 'worktree-git'), { recursive: true })
+      await mkdir(dirname(attemptReceiptPath), { recursive: true })
+      await reserveCandidateDevelopmentLocalReceipt(legacyReceiptPath, reserved, 20, attemptReceiptPath)
 
-      expect(
-        JSON.parse(
-          await readFile(join(directory, 'bayn', 'candidate-development-attempts', 'ordinal-20.json'), 'utf8'),
-        ),
-      ).toMatchObject({ status: 'reserved', attempt: 1 })
+      expect(JSON.parse(await readFile(attemptReceiptPath, 'utf8'))).toMatchObject({ status: 'reserved', attempt: 1 })
       expect(JSON.parse(await readFile(legacyReceiptPath, 'utf8'))).toMatchObject({ status: 'reserved', attempt: 1 })
     } finally {
       await rm(directory, { recursive: true, force: true })

--- a/packages/scripts/src/bayn/candidate-development-local/command.ts
+++ b/packages/scripts/src/bayn/candidate-development-local/command.ts
@@ -482,27 +482,8 @@ export const runCandidateDevelopmentLocally = async (
   return { receiptPath: resolved.receiptPath, receipt: completed }
 }
 
-const renderLocalError = (cause: unknown): string => {
-  const error =
-    cause instanceof CandidateDevelopmentLocalError
-      ? cause
-      : new CandidateDevelopmentLocalError('candidate-process-failed', 'local candidate development failed')
-  return `${JSON.stringify({
-    schemaVersion: 'bayn.candidate-development-local-error.v1',
-    code: error.code,
-    message: error.message,
-  })}\n`
-}
-
 if (import.meta.main) {
-  runCandidateDevelopmentLocally(process.argv.slice(2))
-    .then(({ receipt }) => {
-      process.stderr.write(
-        `BAYN_CANDIDATE_DEVELOPMENT_LOCAL_RECEIPT=${serializeCandidateDevelopmentLocalReceipt(receipt)}`,
-      )
-    })
-    .catch((cause) => {
-      process.stderr.write(`BAYN_CANDIDATE_DEVELOPMENT_LOCAL_ERROR=${renderLocalError(cause)}`)
-      process.exitCode = 1
-    })
+  const { runCandidateDevelopmentLocalMain } =
+    await import('../../../../../services/bayn/src/candidate-development-local/command.ts')
+  runCandidateDevelopmentLocalMain(process.argv.slice(2))
 }

--- a/packages/scripts/src/bayn/candidate-development-local/command.ts
+++ b/packages/scripts/src/bayn/candidate-development-local/command.ts
@@ -51,6 +51,7 @@ export interface CandidateDevelopmentLocalSourceResolution {
   readonly sourceManifestPath: string
   readonly runtimeMarketDataPath: string
   readonly receiptPath: string
+  readonly attemptReceiptPath: string
   readonly candidateOrdinal: number
   readonly source: CandidateDevelopmentLocalSourceBinding
 }
@@ -70,6 +71,7 @@ export interface CandidateDevelopmentLocalDependencies {
     path: string,
     receipt: CandidateDevelopmentLocalAttemptReceipt,
     candidateOrdinal?: number,
+    attemptReceiptPath?: string,
   ) => Promise<void>
   readonly finalizeReceipt: (path: string, receipt: CandidateDevelopmentLocalAttemptReceipt) => Promise<void>
   readonly runCandidateDevelopment: (request: CandidateDevelopmentLocalProcessRequest) => Promise<number>
@@ -195,6 +197,11 @@ const gitPath = async (repositoryRoot: string): Promise<string> => {
   return resolve(repositoryRoot, path)
 }
 
+const gitCommonPath = async (repositoryRoot: string): Promise<string> => {
+  const path = await gitToken(repositoryRoot, ['rev-parse', '--git-common-dir'])
+  return realpath(resolve(repositoryRoot, path))
+}
+
 export const resolveCandidateDevelopmentLocalSource = async (
   args: CandidateDevelopmentLocalArguments,
 ): Promise<CandidateDevelopmentLocalSourceResolution> => {
@@ -258,12 +265,19 @@ export const resolveCandidateDevelopmentLocalSource = async (
   }
   const source = validateCandidateDevelopmentLocalSourceBinding(sourceInput)
   if (!source.ok) throw new CandidateDevelopmentLocalError(source.code, source.message)
+  const commonDirectory = await gitCommonPath(repositoryRoot)
   return {
     repositoryRoot,
     modulePath,
     sourceManifestPath,
     runtimeMarketDataPath: resolve(repositoryRoot, args.runtimeMarketDataPath),
     receiptPath: await gitPath(repositoryRoot),
+    attemptReceiptPath: join(
+      commonDirectory,
+      'bayn',
+      'candidate-development-attempts',
+      `ordinal-${candidateOrdinal}.json`,
+    ),
     candidateOrdinal,
     source: source.value,
   }
@@ -351,9 +365,10 @@ export const reserveCandidateDevelopmentLocalReceipt = async (
   path: string,
   receipt: CandidateDevelopmentLocalAttemptReceipt,
   candidateOrdinal?: number,
+  attemptReceiptPath?: string,
 ): Promise<void> => {
   if (candidateOrdinal !== undefined) {
-    const attemptPath = candidateDevelopmentAttemptReceiptPath(path, candidateOrdinal)
+    const attemptPath = attemptReceiptPath ?? candidateDevelopmentAttemptReceiptPath(path, candidateOrdinal)
     await mkdir(dirname(attemptPath), { recursive: true, mode: 0o700 })
     await reserveReceiptAtPath(attemptPath, receipt)
   }
@@ -426,7 +441,12 @@ export const runCandidateDevelopmentLocally = async (
   if (!parsed.ok) throw new CandidateDevelopmentLocalError(parsed.code, parsed.message)
   const resolved = await dependencies.resolveSourceBinding(parsed.value)
   const reserved = makeCandidateDevelopmentLocalAttemptReceipt(resolved.source, 'reserved')
-  await dependencies.reserveReceipt(resolved.receiptPath, reserved, resolved.candidateOrdinal)
+  await dependencies.reserveReceipt(
+    resolved.receiptPath,
+    reserved,
+    resolved.candidateOrdinal,
+    resolved.attemptReceiptPath,
+  )
 
   try {
     await dependencies.revalidateSourceBinding(resolved)
@@ -511,6 +531,6 @@ export const runCandidateDevelopmentLocally = async (
 
 if (import.meta.main) {
   const { runCandidateDevelopmentLocalMain } =
-    await import('../../../../../services/bayn/src/candidate-development-local/command.ts')
+    await import('../../../../../services/bayn/src/candidate-development-local/command')
   runCandidateDevelopmentLocalMain(process.argv.slice(2))
 }

--- a/packages/scripts/src/bayn/candidate-development-local/command.ts
+++ b/packages/scripts/src/bayn/candidate-development-local/command.ts
@@ -1,7 +1,7 @@
 import { execFile } from 'node:child_process'
 import { createHash, randomUUID } from 'node:crypto'
-import { link, realpath, rename, unlink, writeFile } from 'node:fs/promises'
-import { relative, resolve, sep } from 'node:path'
+import { link, mkdir, realpath, rename, unlink, writeFile } from 'node:fs/promises'
+import { dirname, join, relative, resolve, sep } from 'node:path'
 import process from 'node:process'
 import { promisify } from 'node:util'
 
@@ -51,6 +51,7 @@ export interface CandidateDevelopmentLocalSourceResolution {
   readonly sourceManifestPath: string
   readonly runtimeMarketDataPath: string
   readonly receiptPath: string
+  readonly candidateOrdinal: number
   readonly source: CandidateDevelopmentLocalSourceBinding
 }
 
@@ -65,7 +66,11 @@ export interface CandidateDevelopmentLocalDependencies {
     args: CandidateDevelopmentLocalArguments,
   ) => Promise<CandidateDevelopmentLocalSourceResolution>
   readonly revalidateSourceBinding: (resolution: CandidateDevelopmentLocalSourceResolution) => Promise<void>
-  readonly reserveReceipt: (path: string, receipt: CandidateDevelopmentLocalAttemptReceipt) => Promise<void>
+  readonly reserveReceipt: (
+    path: string,
+    receipt: CandidateDevelopmentLocalAttemptReceipt,
+    candidateOrdinal?: number,
+  ) => Promise<void>
   readonly finalizeReceipt: (path: string, receipt: CandidateDevelopmentLocalAttemptReceipt) => Promise<void>
   readonly runCandidateDevelopment: (request: CandidateDevelopmentLocalProcessRequest) => Promise<number>
 }
@@ -162,7 +167,7 @@ const sourceManifestRecord = (value: unknown): Record<string, unknown> => {
   return value as Record<string, unknown>
 }
 
-const verifySourceManifest = (value: unknown, modulePath: string, moduleSha256: string): void => {
+const verifySourceManifest = (value: unknown, modulePath: string, moduleSha256: string): number => {
   const manifest = sourceManifestRecord(value)
   if (manifest.schemaVersion !== 'bayn.candidate-development-source-manifest.v1') {
     throw new CandidateDevelopmentLocalError('source-manifest-invalid', 'source manifest schema is unsupported')
@@ -173,6 +178,14 @@ const verifySourceManifest = (value: unknown, modulePath: string, moduleSha256: 
   if (manifest.moduleSha256 !== undefined && manifest.moduleSha256 !== moduleSha256) {
     throw new CandidateDevelopmentLocalError('source-manifest-invalid', 'source manifest module hash is not exact')
   }
+  if (
+    typeof manifest.candidateOrdinal !== 'number' ||
+    !Number.isSafeInteger(manifest.candidateOrdinal) ||
+    manifest.candidateOrdinal < 1
+  ) {
+    throw new CandidateDevelopmentLocalError('source-manifest-invalid', 'source manifest candidate ordinal is invalid')
+  }
+  return manifest.candidateOrdinal
 }
 
 const sourceSha256 = (value: string): string => createHash('sha256').update(value, 'utf8').digest('hex')
@@ -232,7 +245,7 @@ export const resolveCandidateDevelopmentLocalSource = async (
   } catch {
     throw new CandidateDevelopmentLocalError('source-manifest-invalid', 'source manifest is not valid JSON')
   }
-  verifySourceManifest(parsedManifest, modulePath, moduleSha256)
+  const candidateOrdinal = verifySourceManifest(parsedManifest, modulePath, moduleSha256)
 
   const sourceInput: CandidateDevelopmentLocalSourceBindingInput = {
     sourceRevision,
@@ -251,6 +264,7 @@ export const resolveCandidateDevelopmentLocalSource = async (
     sourceManifestPath,
     runtimeMarketDataPath: resolve(repositoryRoot, args.runtimeMarketDataPath),
     receiptPath: await gitPath(repositoryRoot),
+    candidateOrdinal,
     source: source.value,
   }
 }
@@ -300,10 +314,7 @@ export const revalidateCandidateDevelopmentLocalSource = async (
 
 const temporaryReceiptPath = (path: string): string => `${path}.tmp-${process.pid}-${randomUUID()}`
 
-export const reserveCandidateDevelopmentLocalReceipt = async (
-  path: string,
-  receipt: CandidateDevelopmentLocalAttemptReceipt,
-): Promise<void> => {
+const reserveReceiptAtPath = async (path: string, receipt: CandidateDevelopmentLocalAttemptReceipt): Promise<void> => {
   const temporaryPath = temporaryReceiptPath(path)
   try {
     await writeFile(temporaryPath, serializeCandidateDevelopmentLocalReceipt(receipt), {
@@ -331,6 +342,22 @@ export const reserveCandidateDevelopmentLocalReceipt = async (
   } finally {
     await unlink(temporaryPath).catch(() => undefined)
   }
+}
+
+const candidateDevelopmentAttemptReceiptPath = (legacyReceiptPath: string, candidateOrdinal: number): string =>
+  join(dirname(legacyReceiptPath), 'bayn', 'candidate-development-attempts', `ordinal-${candidateOrdinal}.json`)
+
+export const reserveCandidateDevelopmentLocalReceipt = async (
+  path: string,
+  receipt: CandidateDevelopmentLocalAttemptReceipt,
+  candidateOrdinal?: number,
+): Promise<void> => {
+  if (candidateOrdinal !== undefined) {
+    const attemptPath = candidateDevelopmentAttemptReceiptPath(path, candidateOrdinal)
+    await mkdir(dirname(attemptPath), { recursive: true, mode: 0o700 })
+    await reserveReceiptAtPath(attemptPath, receipt)
+  }
+  await reserveReceiptAtPath(path, receipt)
 }
 
 export const finalizeCandidateDevelopmentLocalReceipt = async (
@@ -399,7 +426,7 @@ export const runCandidateDevelopmentLocally = async (
   if (!parsed.ok) throw new CandidateDevelopmentLocalError(parsed.code, parsed.message)
   const resolved = await dependencies.resolveSourceBinding(parsed.value)
   const reserved = makeCandidateDevelopmentLocalAttemptReceipt(resolved.source, 'reserved')
-  await dependencies.reserveReceipt(resolved.receiptPath, reserved)
+  await dependencies.reserveReceipt(resolved.receiptPath, reserved, resolved.candidateOrdinal)
 
   try {
     await dependencies.revalidateSourceBinding(resolved)

--- a/services/bayn/src/candidate-development-local/command.test.ts
+++ b/services/bayn/src/candidate-development-local/command.test.ts
@@ -60,9 +60,9 @@ const fileExists = async (path: string): Promise<boolean> => {
   }
 }
 
-const legacyReceiptFor = (source: typeof boundSource.success) => {
+const legacyReceiptFor = (source: typeof boundSource.success, overrides: { readonly sourceRevision?: string } = {}) => {
   const legacySource = {
-    sourceRevision: source.sourceRevision,
+    sourceRevision: overrides.sourceRevision ?? source.sourceRevision,
     modulePath: source.modulePath,
     moduleBlobOid: source.moduleBlobOid,
     moduleSha256: source.moduleSha256,
@@ -92,6 +92,14 @@ const legacyReceiptFor = (source: typeof boundSource.success) => {
     source: { ...legacySource, bindingHash },
   }
 }
+
+const legacyReceiptContext = (candidateOrdinal: number, manifestBlobOid: string) => ({
+  repositoryRoot: '/repo',
+  sourceGit: {
+    text: async () => manifestBlobOid,
+    bytes: async () => Buffer.from(JSON.stringify({ candidateOrdinal }), 'utf8'),
+  },
+})
 
 const dependencies = (
   execute: CandidateDevelopmentLocalAttemptPort['execute'] = () => Effect.succeed(reportFor('PASS')),
@@ -347,9 +355,18 @@ describe('candidate development local program', () => {
     const reserved = makeCandidateDevelopmentLocalReceipt(boundSource.success, 'RESERVED')
     try {
       await mkdir(join(directory, 'bayn', 'candidate-development-attempts'), { recursive: true })
-      await writeFile(legacyReceiptPath, `${JSON.stringify(legacyReceiptFor(boundSource.success))}\n`, 'utf8')
+      await writeFile(
+        legacyReceiptPath,
+        `${JSON.stringify(legacyReceiptFor(boundSource.success, { sourceRevision: '1'.repeat(40) }))}\n`,
+        'utf8',
+      )
       const exit = await Effect.runPromiseExit(
-        reserveCandidateDevelopmentLocalReceipt(receiptPath, reserved, legacyReceiptPath),
+        reserveCandidateDevelopmentLocalReceipt(
+          receiptPath,
+          reserved,
+          legacyReceiptPath,
+          legacyReceiptContext(20, '5'.repeat(40)),
+        ),
       )
 
       expect(Exit.isFailure(exit)).toBe(true)
@@ -363,13 +380,29 @@ describe('candidate development local program', () => {
     const directory = await mkdtemp(join(tmpdir(), 'bayn-candidate-development-local-'))
     const receiptPath = join(directory, 'bayn', 'candidate-development-attempts', 'ordinal-20.json')
     const legacyReceiptPath = join(directory, 'bayn-candidate-development-local-receipt.json')
-    const differentSource = { ...boundSource.success, modulePath: 'services/bayn/src/strategy/other-candidate.ts' }
+    const differentSource = {
+      ...boundSource.success,
+      sourceRevision: '3'.repeat(40),
+      modulePath: 'services/bayn/src/strategy/other-candidate.ts',
+      moduleBlobOid: '7'.repeat(40),
+      moduleSha256: '8'.repeat(64),
+      sourceManifestPath: 'services/bayn/candidates/ordinal-21.json',
+      sourceManifestBlobOid: '9'.repeat(40),
+      sourceManifestSha256: 'a'.repeat(64),
+    }
     const reserved = makeCandidateDevelopmentLocalReceipt(boundSource.success, 'RESERVED')
     try {
       await mkdir(join(directory, 'bayn', 'candidate-development-attempts'), { recursive: true })
       await writeFile(legacyReceiptPath, `${JSON.stringify(legacyReceiptFor(differentSource))}\n`, 'utf8')
 
-      await Effect.runPromise(reserveCandidateDevelopmentLocalReceipt(receiptPath, reserved, legacyReceiptPath))
+      await Effect.runPromise(
+        reserveCandidateDevelopmentLocalReceipt(
+          receiptPath,
+          reserved,
+          legacyReceiptPath,
+          legacyReceiptContext(21, differentSource.sourceManifestBlobOid),
+        ),
+      )
 
       expect(JSON.parse(await readFile(receiptPath, 'utf8'))).toMatchObject({ status: 'RESERVED' })
     } finally {

--- a/services/bayn/src/candidate-development-local/command.test.ts
+++ b/services/bayn/src/candidate-development-local/command.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'bun:test'
 import { createHash } from 'node:crypto'
 import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 
 import { Deferred, Effect, Exit, Fiber, Result } from 'effect'
 
@@ -41,6 +41,7 @@ const prepared: PreparedCandidateDevelopmentLocalAttempt = {
   },
   receiptPath: '/repo/.git/bayn/candidate-development-attempts/ordinal-20.json',
   legacyReceiptPath: '/repo/.git/bayn-candidate-development-local-receipt.json',
+  legacyReceiptPaths: ['/repo/.git/bayn-candidate-development-local-receipt.json'],
   source: boundSource.success,
 }
 
@@ -405,6 +406,42 @@ describe('candidate development local program', () => {
       )
 
       expect(JSON.parse(await readFile(receiptPath, 'utf8'))).toMatchObject({ status: 'RESERVED' })
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+
+  test('rejects a matching legacy receipt from a registered linked worktree', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'bayn-candidate-development-local-'))
+    const receiptPath = join(directory, 'bayn', 'candidate-development-attempts', 'ordinal-20.json')
+    const currentLegacyReceiptPath = join(
+      directory,
+      'current-worktree',
+      'bayn-candidate-development-local-receipt.json',
+    )
+    const linkedWorktreeLegacyReceiptPath = join(
+      directory,
+      'linked-worktree-git',
+      'bayn-candidate-development-local-receipt.json',
+    )
+    const reserved = makeCandidateDevelopmentLocalReceipt(boundSource.success, 'RESERVED')
+    try {
+      await mkdir(dirname(receiptPath), { recursive: true })
+      await mkdir(dirname(linkedWorktreeLegacyReceiptPath), { recursive: true })
+      await writeFile(
+        linkedWorktreeLegacyReceiptPath,
+        `${JSON.stringify(legacyReceiptFor(boundSource.success, { sourceRevision: '1'.repeat(40) }))}\n`,
+        'utf8',
+      )
+      const exit = await Effect.runPromiseExit(
+        reserveCandidateDevelopmentLocalReceipt(receiptPath, reserved, currentLegacyReceiptPath, {
+          ...legacyReceiptContext(20, '5'.repeat(40)),
+          legacyReceiptPaths: [linkedWorktreeLegacyReceiptPath],
+        }),
+      )
+
+      expect(Exit.isFailure(exit)).toBe(true)
+      expect(await fileExists(receiptPath)).toBe(false)
     } finally {
       await rm(directory, { recursive: true, force: true })
     }

--- a/services/bayn/src/candidate-development-local/command.test.ts
+++ b/services/bayn/src/candidate-development-local/command.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'bun:test'
+import { createHash } from 'node:crypto'
 import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -56,6 +57,39 @@ const fileExists = async (path: string): Promise<boolean> => {
   } catch (cause) {
     if (typeof cause === 'object' && cause !== null && 'code' in cause && cause.code === 'ENOENT') return false
     throw cause
+  }
+}
+
+const legacyReceiptFor = (source: typeof boundSource.success) => {
+  const legacySource = {
+    sourceRevision: source.sourceRevision,
+    modulePath: source.modulePath,
+    moduleBlobOid: source.moduleBlobOid,
+    moduleSha256: source.moduleSha256,
+    sourceManifestPath: source.sourceManifestPath,
+    sourceManifestBlobOid: source.sourceManifestBlobOid,
+    sourceManifestSha256: source.sourceManifestSha256,
+  }
+  const bindingHash = createHash('sha256')
+    .update(
+      JSON.stringify([
+        'bayn.candidate-development-local-source-binding.v1',
+        legacySource.sourceRevision,
+        legacySource.modulePath,
+        legacySource.moduleBlobOid,
+        legacySource.moduleSha256,
+        legacySource.sourceManifestPath,
+        legacySource.sourceManifestBlobOid,
+        legacySource.sourceManifestSha256,
+      ]),
+      'utf8',
+    )
+    .digest('hex')
+  return {
+    schemaVersion: 'bayn.candidate-development-local-attempt.v1',
+    attempt: 1,
+    status: 'completed',
+    source: { ...legacySource, bindingHash },
   }
 }
 
@@ -149,6 +183,24 @@ describe('candidate development local domain', () => {
     }
     const exit = await Effect.runPromiseExit(
       verifyCandidateDevelopmentLocalSourceTree('/repo', ['services/bayn/src'], sourceGit),
+    )
+
+    expect(Exit.isFailure(exit)).toBe(true)
+  })
+
+  test('rejects a changed HEAD even when the evaluator tree is otherwise clean', async () => {
+    const sourceGit = {
+      text: async (_repositoryRoot: string, args: readonly string[]) => {
+        if (args[0] === 'rev-parse') return 'a'.repeat(40)
+        if (args[0] === 'ls-files') return 'H services/bayn/src/evaluator.ts'
+        if (args[0] === 'diff') return ''
+        if (args[0] === 'status') return ''
+        throw new Error(`unexpected Git command: ${args.join(' ')}`)
+      },
+      bytes: async () => Buffer.alloc(0),
+    }
+    const exit = await Effect.runPromiseExit(
+      verifyCandidateDevelopmentLocalSourceTree('/repo', ['services/bayn/src'], sourceGit, 'b'.repeat(40)),
     )
 
     expect(Exit.isFailure(exit)).toBe(true)
@@ -295,13 +347,31 @@ describe('candidate development local program', () => {
     const reserved = makeCandidateDevelopmentLocalReceipt(boundSource.success, 'RESERVED')
     try {
       await mkdir(join(directory, 'bayn', 'candidate-development-attempts'), { recursive: true })
-      await writeFile(legacyReceiptPath, '{}\n', 'utf8')
+      await writeFile(legacyReceiptPath, `${JSON.stringify(legacyReceiptFor(boundSource.success))}\n`, 'utf8')
       const exit = await Effect.runPromiseExit(
         reserveCandidateDevelopmentLocalReceipt(receiptPath, reserved, legacyReceiptPath),
       )
 
       expect(Exit.isFailure(exit)).toBe(true)
       expect(await fileExists(receiptPath)).toBe(false)
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+
+  test('allows a valid legacy receipt for a different source binding', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'bayn-candidate-development-local-'))
+    const receiptPath = join(directory, 'bayn', 'candidate-development-attempts', 'ordinal-20.json')
+    const legacyReceiptPath = join(directory, 'bayn-candidate-development-local-receipt.json')
+    const differentSource = { ...boundSource.success, modulePath: 'services/bayn/src/strategy/other-candidate.ts' }
+    const reserved = makeCandidateDevelopmentLocalReceipt(boundSource.success, 'RESERVED')
+    try {
+      await mkdir(join(directory, 'bayn', 'candidate-development-attempts'), { recursive: true })
+      await writeFile(legacyReceiptPath, `${JSON.stringify(legacyReceiptFor(differentSource))}\n`, 'utf8')
+
+      await Effect.runPromise(reserveCandidateDevelopmentLocalReceipt(receiptPath, reserved, legacyReceiptPath))
+
+      expect(JSON.parse(await readFile(receiptPath, 'utf8'))).toMatchObject({ status: 'RESERVED' })
     } finally {
       await rm(directory, { recursive: true, force: true })
     }

--- a/services/bayn/src/candidate-development-local/command.test.ts
+++ b/services/bayn/src/candidate-development-local/command.test.ts
@@ -1,0 +1,324 @@
+import { describe, expect, test } from 'bun:test'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { Deferred, Effect, Exit, Fiber, Result } from 'effect'
+
+import type { CandidateDevelopmentCommandReport } from '../candidate-development-command/contracts'
+import { frozenSourceVerifiedSourceFiles } from '../candidate-development-command/test-support/provenance-fixtures'
+import {
+  finalizeCandidateDevelopmentLocalReceipt,
+  makeCandidateDevelopmentLocalAttempt,
+  reserveCandidateDevelopmentLocalReceipt,
+  resolveCandidateDevelopmentLocalArguments,
+  runCandidateDevelopmentLocally,
+  verifyCandidateDevelopmentLocalSourceTree,
+  type CandidateDevelopmentLocalAttemptPort,
+  type CandidateDevelopmentLocalDependencies,
+  type PreparedCandidateDevelopmentLocalAttempt,
+} from './command'
+import {
+  bindCandidateDevelopmentLocalSource,
+  CandidateDevelopmentLocalError,
+  makeCandidateDevelopmentLocalReceipt,
+  parseCandidateDevelopmentLocalArguments,
+  serializeCandidateDevelopmentLocalReceipt,
+  type CandidateDevelopmentLocalDecisionStatus,
+  type CandidateDevelopmentLocalAttemptReceipt,
+} from './domain'
+
+const boundSource = bindCandidateDevelopmentLocalSource(frozenSourceVerifiedSourceFiles)
+if (Result.isFailure(boundSource)) throw new Error('candidate local source fixture must be valid')
+
+const prepared: PreparedCandidateDevelopmentLocalAttempt = {
+  repositoryRoot: '/repo',
+  args: {
+    modulePath: 'services/bayn/src/strategy/candidate-20.ts',
+    sourceManifestPath: 'services/bayn/candidates/candidate-20.json',
+    runtimeMarketDataPath: '/sealed/runtime-market-data.json',
+  },
+  receiptPath: '/repo/.git/bayn/candidate-development-attempts/ordinal-20.json',
+  legacyReceiptPath: '/repo/.git/bayn-candidate-development-local-receipt.json',
+  source: boundSource.success,
+}
+
+const reportFor = (status: CandidateDevelopmentLocalDecisionStatus): CandidateDevelopmentCommandReport =>
+  ({
+    contentHash: status === 'PASS' ? 'f'.repeat(64) : 'e'.repeat(64),
+    decision: { status },
+  }) as CandidateDevelopmentCommandReport
+
+const fileExists = async (path: string): Promise<boolean> => {
+  try {
+    await readFile(path, 'utf8')
+    return true
+  } catch (cause) {
+    if (typeof cause === 'object' && cause !== null && 'code' in cause && cause.code === 'ENOENT') return false
+    throw cause
+  }
+}
+
+const dependencies = (
+  execute: CandidateDevelopmentLocalAttemptPort['execute'] = () => Effect.succeed(reportFor('PASS')),
+): {
+  readonly value: CandidateDevelopmentLocalDependencies
+  readonly events: string[]
+  readonly finalized: CandidateDevelopmentLocalAttemptReceipt[]
+} => {
+  const events: string[] = []
+  const finalized: CandidateDevelopmentLocalAttemptReceipt[] = []
+  const port: CandidateDevelopmentLocalAttemptPort = {
+    reserve: (_path, receipt) =>
+      Effect.sync(() => {
+        events.push(`reserve:${receipt.status}`)
+      }),
+    execute: (preparedAttempt) =>
+      Effect.sync(() =>
+        events.push(`execute:${preparedAttempt.source.sourceRevision}:${preparedAttempt.args.runtimeMarketDataPath}`),
+      ).pipe(Effect.andThen(execute(preparedAttempt))),
+    finalize: (_path, receipt) =>
+      Effect.sync(() => {
+        finalized.push(receipt)
+        events.push(`finalize:${receipt.status}`)
+      }),
+  }
+  return {
+    events,
+    finalized,
+    value: {
+      prepare: () => Effect.sync(() => (events.push('prepare'), prepared)),
+      attempt: makeCandidateDevelopmentLocalAttempt(port),
+    },
+  }
+}
+
+const runWithDependencies = (fixture: { readonly value: CandidateDevelopmentLocalDependencies }) =>
+  runCandidateDevelopmentLocally(
+    [prepared.args.modulePath, prepared.args.sourceManifestPath, prepared.args.runtimeMarketDataPath],
+    fixture.value,
+  )
+
+describe('candidate development local domain', () => {
+  test('requires exactly three opaque paths', () => {
+    expect(
+      Result.isSuccess(parseCandidateDevelopmentLocalArguments(['module.ts', 'manifest.json', 'runtime.json'])),
+    ).toBe(true)
+    expect(Result.isFailure(parseCandidateDevelopmentLocalArguments(['module.ts', 'manifest.json']))).toBe(true)
+  })
+
+  test('binds reviewed source identity without recording the runtime witness path or contents', () => {
+    const receipt = makeCandidateDevelopmentLocalReceipt(boundSource.success, 'PASS', reportFor('PASS').contentHash)
+    const serialized = serializeCandidateDevelopmentLocalReceipt(receipt)
+    expect(receipt.source).toMatchObject({
+      sourceRevision: frozenSourceVerifiedSourceFiles.sourceRevision,
+      moduleBlobOid: frozenSourceVerifiedSourceFiles.moduleBlobOid,
+      moduleSha256: frozenSourceVerifiedSourceFiles.moduleSha256,
+      sourceManifestBlobOid: frozenSourceVerifiedSourceFiles.sourceManifestBlobOid,
+      sourceManifestSha256: frozenSourceVerifiedSourceFiles.sourceManifestSha256,
+    })
+    expect(receipt.source.bindingHash).toMatch(/^[0-9a-f]{64}$/)
+    expect(serialized).not.toContain('/sealed/runtime-market-data.json')
+    expect(serialized).not.toContain('bars')
+    expect(serialized).not.toContain('strategyProtocol')
+  })
+
+  test('resolves documented repository-relative paths from the repository root', () => {
+    expect(
+      resolveCandidateDevelopmentLocalArguments('/repo', {
+        modulePath: 'services/bayn/src/strategy/candidate-20.ts',
+        sourceManifestPath: 'services/bayn/candidates/candidate-20.json',
+        runtimeMarketDataPath: 'sealed/runtime-market-data.json',
+      }),
+    ).toEqual({
+      modulePath: '/repo/services/bayn/src/strategy/candidate-20.ts',
+      sourceManifestPath: '/repo/services/bayn/candidates/candidate-20.json',
+      runtimeMarketDataPath: '/repo/sealed/runtime-market-data.json',
+    })
+  })
+
+  test('rejects evaluator source drift before executing a reviewed module', async () => {
+    const sourceGit = {
+      text: async (_repositoryRoot: string, args: readonly string[]) => {
+        if (args[0] === 'ls-files') return 'H services/bayn/src/evaluator.ts'
+        if (args[0] === 'diff') return ''
+        if (args[0] === 'status') return ' M services/bayn/src/evaluator.ts'
+        throw new Error(`unexpected Git command: ${args.join(' ')}`)
+      },
+      bytes: async () => Buffer.alloc(0),
+    }
+    const exit = await Effect.runPromiseExit(
+      verifyCandidateDevelopmentLocalSourceTree('/repo', ['services/bayn/src'], sourceGit),
+    )
+
+    expect(Exit.isFailure(exit)).toBe(true)
+  })
+})
+
+describe('candidate development local program', () => {
+  test('reserves before evaluation and finalizes PASS exactly once', async () => {
+    const fixture = dependencies()
+    const receipt = await Effect.runPromise(runWithDependencies(fixture))
+
+    expect(fixture.events).toEqual([
+      'prepare',
+      'reserve:RESERVED',
+      `execute:${prepared.source.sourceRevision}:${prepared.args.runtimeMarketDataPath}`,
+      'finalize:PASS',
+    ])
+    expect(fixture.finalized).toHaveLength(1)
+    expect(receipt).toMatchObject({ status: 'PASS', terminalReportHash: reportFor('PASS').contentHash })
+  })
+
+  test('records HOLD_REJECT separately from PASS while retaining the report hash', async () => {
+    const fixture = dependencies(() => Effect.succeed(reportFor('HOLD_REJECT')))
+    const receipt = await Effect.runPromise(runWithDependencies(fixture))
+
+    expect(fixture.finalized).toHaveLength(1)
+    expect(fixture.finalized[0]).toMatchObject({
+      status: 'HOLD_REJECT',
+      terminalReportHash: reportFor('HOLD_REJECT').contentHash,
+    })
+    expect(receipt).toMatchObject({
+      status: 'HOLD_REJECT',
+      terminalReportHash: reportFor('HOLD_REJECT').contentHash,
+    })
+  })
+
+  test('burns and finalizes the reservation as FAILED when evaluation fails', async () => {
+    const fixture = dependencies(() => Effect.fail({ _tag: 'CandidateDevelopmentCommandModulePathMissing' } as const))
+    const exit = await Effect.runPromiseExit(runWithDependencies(fixture))
+
+    expect(Exit.isFailure(exit)).toBe(true)
+    expect(fixture.events.at(-1)).toBe('finalize:FAILED')
+    expect(fixture.finalized).toHaveLength(1)
+    expect(fixture.finalized[0]).toMatchObject({ status: 'FAILED', terminalReportHash: null })
+  })
+
+  test('finalizes FAILED on interruption exactly once', async () => {
+    const started = await Effect.runPromise(Deferred.make<void>())
+    const fixture = dependencies(() => Deferred.succeed(started, undefined).pipe(Effect.andThen(Effect.never)))
+    const fiber = Effect.runFork(runWithDependencies(fixture))
+
+    await Effect.runPromise(Deferred.await(started))
+    await Effect.runPromise(Fiber.interrupt(fiber))
+    const exit = await Effect.runPromise(Fiber.await(fiber))
+
+    expect(Exit.isFailure(exit)).toBe(true)
+    expect(fixture.finalized).toHaveLength(1)
+    expect(fixture.finalized[0]).toMatchObject({ status: 'FAILED', terminalReportHash: null })
+  })
+
+  test('never starts evaluation when the atomic reservation already exists', async () => {
+    const fixture = dependencies()
+    const blocked: CandidateDevelopmentLocalDependencies = {
+      ...fixture.value,
+      attempt: makeCandidateDevelopmentLocalAttempt({
+        reserve: () =>
+          Effect.fail(
+            new CandidateDevelopmentLocalError({
+              code: 'RECEIPT_ALREADY_CONSUMED',
+              message: 'already consumed',
+            }),
+          ),
+        execute: () => Effect.fail({ _tag: 'CandidateDevelopmentCommandModulePathMissing' } as const),
+        finalize: () => Effect.void,
+      }),
+    }
+    const exit = await Effect.runPromiseExit(runWithDependencies({ value: blocked }))
+
+    expect(Exit.isFailure(exit)).toBe(true)
+    expect(fixture.events.some((event) => event.startsWith('execute:'))).toBe(false)
+  })
+
+  test('an existing RESERVED receipt burns the ordinal across a crash and blocks retry', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'bayn-candidate-development-local-'))
+    const receiptPath = join(directory, 'receipt.json')
+    const reserved = makeCandidateDevelopmentLocalReceipt(boundSource.success, 'RESERVED')
+    let executeCount = 0
+    try {
+      await Effect.runPromise(reserveCandidateDevelopmentLocalReceipt(receiptPath, reserved))
+      const exit = await Effect.runPromiseExit(
+        runCandidateDevelopmentLocally(
+          [prepared.args.modulePath, prepared.args.sourceManifestPath, prepared.args.runtimeMarketDataPath],
+          {
+            prepare: () => Effect.succeed({ ...prepared, receiptPath }),
+            attempt: makeCandidateDevelopmentLocalAttempt({
+              reserve: reserveCandidateDevelopmentLocalReceipt,
+              execute: () =>
+                Effect.sync(() => {
+                  executeCount += 1
+                  return reportFor('PASS')
+                }),
+              finalize: finalizeCandidateDevelopmentLocalReceipt,
+            }),
+          },
+        ),
+      )
+
+      expect(Exit.isFailure(exit)).toBe(true)
+      expect(executeCount).toBe(0)
+      expect(JSON.parse(await readFile(receiptPath, 'utf8'))).toMatchObject({
+        attempt: 1,
+        status: 'RESERVED',
+        terminalReportHash: null,
+      })
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+
+  test('claims and replaces one compact receipt atomically', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'bayn-candidate-development-local-'))
+    const receiptPath = join(directory, 'receipt.json')
+    const reserved = makeCandidateDevelopmentLocalReceipt(boundSource.success, 'RESERVED')
+    const completed = makeCandidateDevelopmentLocalReceipt(boundSource.success, 'PASS', reportFor('PASS').contentHash)
+    try {
+      await Effect.runPromise(reserveCandidateDevelopmentLocalReceipt(receiptPath, reserved))
+      const duplicate = await Effect.runPromiseExit(reserveCandidateDevelopmentLocalReceipt(receiptPath, reserved))
+      expect(Exit.isFailure(duplicate)).toBe(true)
+      await Effect.runPromise(finalizeCandidateDevelopmentLocalReceipt(receiptPath, completed))
+      expect(JSON.parse(await readFile(receiptPath, 'utf8'))).toMatchObject({
+        schemaVersion: 'bayn.candidate-development-local-attempt.v3',
+        status: 'PASS',
+        terminalReportHash: reportFor('PASS').contentHash,
+      })
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+
+  test('rejects a legacy receipt before creating the v3 reservation', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'bayn-candidate-development-local-'))
+    const receiptPath = join(directory, 'bayn', 'candidate-development-attempts', 'ordinal-20.json')
+    const legacyReceiptPath = join(directory, 'bayn-candidate-development-local-receipt.json')
+    const reserved = makeCandidateDevelopmentLocalReceipt(boundSource.success, 'RESERVED')
+    try {
+      await mkdir(join(directory, 'bayn', 'candidate-development-attempts'), { recursive: true })
+      await writeFile(legacyReceiptPath, '{}\n', 'utf8')
+      const exit = await Effect.runPromiseExit(
+        reserveCandidateDevelopmentLocalReceipt(receiptPath, reserved, legacyReceiptPath),
+      )
+
+      expect(Exit.isFailure(exit)).toBe(true)
+      expect(await fileExists(receiptPath)).toBe(false)
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+
+  test('leaves a crash marker as the consumed reservation without publishing a partial receipt', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'bayn-candidate-development-local-'))
+    const receiptPath = join(directory, 'receipt.json')
+    const reserved = makeCandidateDevelopmentLocalReceipt(boundSource.success, 'RESERVED')
+    try {
+      await writeFile(`${receiptPath}.reservation`, '', 'utf8')
+      const exit = await Effect.runPromiseExit(reserveCandidateDevelopmentLocalReceipt(receiptPath, reserved))
+
+      expect(Exit.isFailure(exit)).toBe(true)
+      expect(await fileExists(receiptPath)).toBe(false)
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+})

--- a/services/bayn/src/candidate-development-local/command.ts
+++ b/services/bayn/src/candidate-development-local/command.ts
@@ -1,0 +1,450 @@
+import { constants } from 'node:fs'
+import { link, lstat, mkdir, open, realpath, rename, unlink } from 'node:fs/promises'
+import { dirname, join, relative, resolve, sep } from 'node:path'
+import process from 'node:process'
+import { randomUUID } from 'node:crypto'
+
+import { NodeRuntime } from '@effect/platform-node'
+import { Cause, Data, Effect, Exit } from 'effect'
+
+import type {
+  CandidateDevelopmentCommandFailure,
+  CandidateDevelopmentCommandReport,
+} from '../candidate-development-command/contracts'
+import {
+  evaluateCandidateDevelopmentArtifact,
+  loadCandidateDevelopmentRuntimeMarketDataFile,
+} from '../candidate-development-command/sandbox'
+import {
+  loadAuthorizedCandidateDevelopmentExecutableProgram,
+  loadCandidateDevelopmentExecutableProgram,
+  runCandidateDevelopmentCommand,
+  type CandidateDevelopmentLoadedExecutableProgram,
+} from '../candidate-development-command/orchestration'
+import {
+  renderCandidateDevelopmentCommandDefect,
+  renderCandidateDevelopmentCommandFailure,
+} from '../candidate-development-command/failures'
+import { candidateDevelopmentSourceGit } from '../candidate-development-command/git-interpreter'
+import { verifyCandidateDevelopmentSourceFiles } from '../candidate-development-command/source-provenance-policy'
+import {
+  bindCandidateDevelopmentLocalSource,
+  CandidateDevelopmentLocalError,
+  makeCandidateDevelopmentLocalReceipt,
+  makeCandidateDevelopmentLocalTerminalReceipt,
+  parseCandidateDevelopmentLocalArguments,
+  serializeCandidateDevelopmentLocalReceipt,
+  type CandidateDevelopmentLocalArguments,
+  type CandidateDevelopmentLocalAttemptReceipt,
+  type CandidateDevelopmentLocalSourceBinding,
+  type CandidateDevelopmentLocalTerminalOutcome,
+} from './domain'
+
+const candidateDevelopmentEvaluatorSourcePath = 'services/bayn/src'
+const legacyCandidateDevelopmentLocalReceiptName = 'bayn-candidate-development-local-receipt.json'
+
+export interface PreparedCandidateDevelopmentLocalAttempt {
+  readonly repositoryRoot: string
+  readonly args: CandidateDevelopmentLocalArguments
+  readonly receiptPath: string
+  readonly legacyReceiptPath: string
+  readonly source: CandidateDevelopmentLocalSourceBinding
+}
+
+export interface CandidateDevelopmentLocalAttemptPort {
+  reserve: (
+    path: string,
+    receipt: CandidateDevelopmentLocalAttemptReceipt,
+    legacyReceiptPath?: string,
+  ) => Effect.Effect<void, CandidateDevelopmentLocalError>
+  execute: (
+    prepared: PreparedCandidateDevelopmentLocalAttempt,
+  ) => Effect.Effect<
+    CandidateDevelopmentCommandReport,
+    CandidateDevelopmentLocalError | CandidateDevelopmentCommandFailure
+  >
+  finalize: (
+    path: string,
+    receipt: CandidateDevelopmentLocalAttemptReceipt,
+  ) => Effect.Effect<void, CandidateDevelopmentLocalError>
+}
+
+export type CandidateDevelopmentLocalAttempt = (
+  prepared: PreparedCandidateDevelopmentLocalAttempt,
+) => Effect.Effect<
+  CandidateDevelopmentLocalAttemptReceipt,
+  CandidateDevelopmentLocalError | CandidateDevelopmentCommandFailure
+>
+
+export interface CandidateDevelopmentLocalDependencies {
+  readonly prepare: (
+    args: CandidateDevelopmentLocalArguments,
+  ) => Effect.Effect<PreparedCandidateDevelopmentLocalAttempt, CandidateDevelopmentLocalError>
+  readonly attempt: CandidateDevelopmentLocalAttempt
+}
+
+const localError = (
+  code: ConstructorParameters<typeof CandidateDevelopmentLocalError>[0]['code'],
+  message: string,
+  cause?: unknown,
+): CandidateDevelopmentLocalError =>
+  new CandidateDevelopmentLocalError({ code, message, ...(cause === undefined ? {} : { cause }) })
+
+const isFileSystemError = (cause: unknown, code: string): boolean =>
+  typeof cause === 'object' && cause !== null && 'code' in cause && cause.code === code
+
+export const resolveCandidateDevelopmentLocalArguments = (
+  repositoryRoot: string,
+  args: CandidateDevelopmentLocalArguments,
+): CandidateDevelopmentLocalArguments => ({
+  modulePath: resolve(repositoryRoot, args.modulePath),
+  sourceManifestPath: resolve(repositoryRoot, args.sourceManifestPath),
+  runtimeMarketDataPath: resolve(repositoryRoot, args.runtimeMarketDataPath),
+})
+
+const repositoryRelativePath = (repositoryRoot: string, absolutePath: string, label: string): string => {
+  const path = relative(repositoryRoot, absolutePath)
+  if (path.length === 0 || path === '..' || path.startsWith(`..${sep}`) || path.startsWith(sep)) {
+    throw localError('SOURCE_BINDING_INVALID', `${label} must be inside the repository`)
+  }
+  return path.split(sep).join('/')
+}
+
+export const verifyCandidateDevelopmentLocalSourceTree = (
+  repositoryRoot: string,
+  paths: readonly string[],
+  sourceGit = candidateDevelopmentSourceGit,
+): Effect.Effect<void, CandidateDevelopmentLocalError> =>
+  Effect.tryPromise({
+    try: async (signal) => {
+      const tracked = await sourceGit.text(repositoryRoot, ['ls-files', '-v', '--', ...paths], signal)
+      if (
+        tracked
+          .split('\n')
+          .filter((entry) => entry.length > 0)
+          .some((entry) => !entry.startsWith('H '))
+      ) {
+        throw new Error('tracked source has an index override')
+      }
+      const diff = await sourceGit.text(repositoryRoot, ['diff', '--name-only', 'HEAD', '--', ...paths], signal)
+      if (diff.length > 0) throw new Error('source differs from reviewed HEAD')
+      const status = await sourceGit.text(
+        repositoryRoot,
+        ['status', '--porcelain=v1', '--untracked-files=all', '--ignored=matching', '--', ...paths],
+        signal,
+      )
+      if (status.length > 0) throw new Error('source working tree is not clean')
+    },
+    catch: (cause) =>
+      localError(
+        'SOURCE_BINDING_INVALID',
+        'candidate module, source manifest, and evaluator source must match their exact reviewed HEAD blobs',
+        cause,
+      ),
+  })
+
+const executeLoadedCandidateDevelopmentProgram = (
+  loaded: CandidateDevelopmentLoadedExecutableProgram,
+): Effect.Effect<CandidateDevelopmentCommandReport, CandidateDevelopmentCommandFailure> =>
+  runCandidateDevelopmentCommand(loaded.program, loaded.verifiedSource).pipe(
+    Effect.mapError(
+      (cause): CandidateDevelopmentCommandFailure => ({
+        _tag: 'CandidateDevelopmentCommandProgramExecutionFailed',
+        cause,
+      }),
+    ),
+  )
+
+const executeCandidateDevelopmentCommand = (
+  prepared: PreparedCandidateDevelopmentLocalAttempt,
+): Effect.Effect<
+  CandidateDevelopmentCommandReport,
+  CandidateDevelopmentLocalError | CandidateDevelopmentCommandFailure
+> => {
+  const sourcePaths = [
+    prepared.source.modulePath,
+    prepared.source.sourceManifestPath,
+    candidateDevelopmentEvaluatorSourcePath,
+  ]
+  const verifySourceTree = verifyCandidateDevelopmentLocalSourceTree(prepared.repositoryRoot, sourcePaths)
+  return verifySourceTree.pipe(
+    Effect.flatMap(() =>
+      loadAuthorizedCandidateDevelopmentExecutableProgram(
+        prepared.args.modulePath,
+        prepared.args.sourceManifestPath,
+        (module, manifest) =>
+          loadCandidateDevelopmentExecutableProgram(
+            module,
+            manifest,
+            evaluateCandidateDevelopmentArtifact,
+            (sourceModulePath, sourceManifest, sourceGit) =>
+              verifyCandidateDevelopmentSourceFiles(
+                sourceModulePath,
+                sourceManifest,
+                sourceGit,
+                prepared.source.sourceRevision,
+              ),
+            loadCandidateDevelopmentRuntimeMarketDataFile(prepared.args.runtimeMarketDataPath),
+          ),
+      ),
+    ),
+    Effect.tap(() => verifyCandidateDevelopmentLocalSourceTree(prepared.repositoryRoot, sourcePaths)),
+    Effect.flatMap(executeLoadedCandidateDevelopmentProgram),
+    Effect.tap(() => verifyCandidateDevelopmentLocalSourceTree(prepared.repositoryRoot, sourcePaths)),
+  )
+}
+
+const prepareCandidateDevelopmentLocalAttempt = (
+  args: CandidateDevelopmentLocalArguments,
+): Effect.Effect<PreparedCandidateDevelopmentLocalAttempt, CandidateDevelopmentLocalError> =>
+  Effect.gen(function* () {
+    const repositoryRoot = yield* Effect.tryPromise({
+      try: async (signal) =>
+        realpath(await candidateDevelopmentSourceGit.text(process.cwd(), ['rev-parse', '--show-toplevel'], signal)),
+      catch: (cause) => localError('SOURCE_BINDING_INVALID', 'candidate repository root is unavailable', cause),
+    })
+    const normalizedArgs = resolveCandidateDevelopmentLocalArguments(repositoryRoot, args)
+    const sourcePaths = yield* Effect.try({
+      try: () => [
+        repositoryRelativePath(repositoryRoot, normalizedArgs.modulePath, 'module'),
+        repositoryRelativePath(repositoryRoot, normalizedArgs.sourceManifestPath, 'source manifest'),
+        candidateDevelopmentEvaluatorSourcePath,
+      ],
+      catch: (cause) =>
+        cause instanceof CandidateDevelopmentLocalError
+          ? cause
+          : localError('SOURCE_BINDING_INVALID', 'candidate source paths are invalid', cause),
+    })
+    yield* verifyCandidateDevelopmentLocalSourceTree(repositoryRoot, sourcePaths)
+    const verified = yield* verifyCandidateDevelopmentSourceFiles(
+      normalizedArgs.modulePath,
+      normalizedArgs.sourceManifestPath,
+    ).pipe(
+      Effect.mapError((cause) => localError('SOURCE_BINDING_INVALID', 'candidate source binding is invalid', cause)),
+    )
+    const source = yield* Effect.fromResult(bindCandidateDevelopmentLocalSource(verified.files)).pipe(
+      Effect.mapError((cause) => localError('SOURCE_BINDING_INVALID', 'candidate source binding is invalid', cause)),
+    )
+    const receiptPaths = yield* Effect.tryPromise({
+      try: async (signal) => {
+        const commonDirectoryValue = await candidateDevelopmentSourceGit.text(
+          repositoryRoot,
+          ['rev-parse', '--git-common-dir'],
+          signal,
+        )
+        const commonDirectory = await realpath(resolve(repositoryRoot, commonDirectoryValue))
+        const receiptDirectory = join(commonDirectory, 'bayn', 'candidate-development-attempts')
+        await mkdir(receiptDirectory, { recursive: true, mode: 0o700 })
+        if ((await realpath(receiptDirectory)) !== receiptDirectory) {
+          throw new Error('candidate receipt directory is not canonical')
+        }
+        const legacyReceiptPath = resolve(
+          repositoryRoot,
+          await candidateDevelopmentSourceGit.text(
+            repositoryRoot,
+            ['rev-parse', '--git-path', legacyCandidateDevelopmentLocalReceiptName],
+            signal,
+          ),
+        )
+        return {
+          attempt: join(receiptDirectory, `ordinal-${source.candidateOrdinal}.json`),
+          legacy: legacyReceiptPath,
+        }
+      },
+      catch: (cause) => localError('RECEIPT_RESERVATION_FAILED', 'candidate receipt path is unavailable', cause),
+    })
+    return {
+      repositoryRoot,
+      args: normalizedArgs,
+      receiptPath: receiptPaths.attempt,
+      legacyReceiptPath: receiptPaths.legacy,
+      source,
+    }
+  })
+
+export const makeCandidateDevelopmentLocalAttempt =
+  (port: CandidateDevelopmentLocalAttemptPort): CandidateDevelopmentLocalAttempt =>
+  (prepared) => {
+    return Effect.gen(function* () {
+      yield* port.reserve(
+        prepared.receiptPath,
+        makeCandidateDevelopmentLocalReceipt(prepared.source, 'RESERVED'),
+        prepared.legacyReceiptPath,
+      )
+      return yield* port.execute(prepared).pipe(
+        Effect.onExit((exit) =>
+          port.finalize(
+            prepared.receiptPath,
+            makeCandidateDevelopmentLocalTerminalReceipt(
+              prepared.source,
+              Exit.isSuccess(exit)
+                ? {
+                    status: exit.value.decision.status,
+                    terminalReportHash: exit.value.contentHash,
+                  }
+                : ({ status: 'FAILED', terminalReportHash: null } satisfies CandidateDevelopmentLocalTerminalOutcome),
+            ),
+          ),
+        ),
+        Effect.map((report) =>
+          makeCandidateDevelopmentLocalTerminalReceipt(prepared.source, {
+            status: report.decision.status,
+            terminalReportHash: report.contentHash,
+          }),
+        ),
+      )
+    })
+  }
+
+const writeSynchronizedExclusiveFile = async (temporaryPath: string, content: string): Promise<void> => {
+  const handle = await open(
+    temporaryPath,
+    constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY | constants.O_NOFOLLOW,
+    0o600,
+  )
+  try {
+    await handle.writeFile(content, 'utf8')
+    await handle.sync()
+  } finally {
+    await handle.close()
+  }
+}
+
+const defaultLegacyReceiptPath = (path: string): string =>
+  join(dirname(dirname(path)), legacyCandidateDevelopmentLocalReceiptName)
+
+const pathExists = async (path: string): Promise<boolean> => {
+  try {
+    await lstat(path)
+    return true
+  } catch (cause) {
+    if (isFileSystemError(cause, 'ENOENT')) return false
+    throw cause
+  }
+}
+
+export const reserveCandidateDevelopmentLocalReceipt = (
+  path: string,
+  receipt: CandidateDevelopmentLocalAttemptReceipt,
+  legacyReceiptPath = defaultLegacyReceiptPath(path),
+): Effect.Effect<void, CandidateDevelopmentLocalError> =>
+  Effect.tryPromise({
+    try: async () => {
+      if (await pathExists(legacyReceiptPath)) {
+        throw localError(
+          'RECEIPT_ALREADY_CONSUMED',
+          'candidate development attempt was already consumed by the legacy local receipt',
+        )
+      }
+      const markerPath = `${path}.reservation`
+      try {
+        await writeSynchronizedExclusiveFile(markerPath, serializeCandidateDevelopmentLocalReceipt(receipt))
+      } catch (cause) {
+        if (isFileSystemError(cause, 'EEXIST')) {
+          throw localError('RECEIPT_ALREADY_CONSUMED', 'candidate development attempt was already consumed', cause)
+        }
+        throw cause
+      }
+      try {
+        await link(markerPath, path)
+      } catch (cause) {
+        if (isFileSystemError(cause, 'EEXIST')) {
+          await unlink(markerPath).catch(() => undefined)
+          throw localError('RECEIPT_ALREADY_CONSUMED', 'candidate development attempt was already consumed', cause)
+        }
+        throw cause
+      }
+      await unlink(markerPath).catch(() => undefined)
+    },
+    catch: (cause) =>
+      cause instanceof CandidateDevelopmentLocalError
+        ? cause
+        : localError('RECEIPT_RESERVATION_FAILED', 'candidate development attempt could not be reserved', cause),
+  })
+
+export const finalizeCandidateDevelopmentLocalReceipt = (
+  path: string,
+  receipt: CandidateDevelopmentLocalAttemptReceipt,
+): Effect.Effect<void, CandidateDevelopmentLocalError> =>
+  Effect.tryPromise({
+    try: async () => {
+      const temporaryPath = join(dirname(path), `.${receipt.candidateOrdinal}-${process.pid}-${randomUUID()}.tmp`)
+      try {
+        await writeSynchronizedExclusiveFile(temporaryPath, serializeCandidateDevelopmentLocalReceipt(receipt))
+        await rename(temporaryPath, path)
+      } catch (cause) {
+        await unlink(temporaryPath).catch(() => undefined)
+        throw cause
+      }
+    },
+    catch: (cause) =>
+      localError(
+        'RECEIPT_FINALIZATION_FAILED',
+        'candidate development receipt could not be finalized; do not retry',
+        cause,
+      ),
+  })
+
+const liveDependencies: CandidateDevelopmentLocalDependencies = {
+  prepare: prepareCandidateDevelopmentLocalAttempt,
+  attempt: makeCandidateDevelopmentLocalAttempt({
+    reserve: reserveCandidateDevelopmentLocalReceipt,
+    execute: executeCandidateDevelopmentCommand,
+    finalize: finalizeCandidateDevelopmentLocalReceipt,
+  }),
+}
+
+export const runCandidateDevelopmentLocally = (
+  argv: readonly string[],
+  dependencies: CandidateDevelopmentLocalDependencies = liveDependencies,
+): Effect.Effect<
+  CandidateDevelopmentLocalAttemptReceipt,
+  CandidateDevelopmentLocalError | CandidateDevelopmentCommandFailure
+> =>
+  Effect.gen(function* () {
+    const args = yield* Effect.fromResult(parseCandidateDevelopmentLocalArguments(argv))
+    const prepared = yield* dependencies.prepare(args)
+    return yield* dependencies.attempt(prepared)
+  }).pipe(Effect.annotateLogs({ operation: 'candidate-development-local' }))
+
+const renderLocalFailure = (failure: CandidateDevelopmentLocalError | CandidateDevelopmentCommandFailure): string =>
+  failure instanceof CandidateDevelopmentLocalError
+    ? `${JSON.stringify({
+        schemaVersion: 'bayn.candidate-development-local-error.v1',
+        code: failure.code,
+        message: failure.message,
+      })}\n`
+    : renderCandidateDevelopmentCommandFailure(failure)
+
+const reportCause = (
+  cause: Cause.Cause<CandidateDevelopmentLocalError | CandidateDevelopmentCommandFailure>,
+): Effect.Effect<void> => {
+  if (Cause.hasInterruptsOnly(cause)) return Effect.void
+  const [reason] = cause.reasons
+  const rendered =
+    cause.reasons.length === 1 && reason !== undefined && Cause.isFailReason(reason)
+      ? renderLocalFailure(reason.error)
+      : renderCandidateDevelopmentCommandDefect()
+  return Effect.sync(() => process.stderr.write(rendered))
+}
+
+class CandidateDevelopmentLocalCommandError extends Data.TaggedError('CandidateDevelopmentLocalCommandError')<{
+  readonly cause: CandidateDevelopmentLocalError | CandidateDevelopmentCommandFailure
+}> {}
+
+export const runCandidateDevelopmentLocalMain = (argv: readonly string[]): void => {
+  NodeRuntime.runMain(
+    runCandidateDevelopmentLocally(argv).pipe(
+      Effect.tap((receipt) =>
+        Effect.sync(() => {
+          process.stderr.write(`BAYN_CANDIDATE_DEVELOPMENT_LOCAL_RECEIPT=${JSON.stringify(receipt)}\n`)
+        }),
+      ),
+      Effect.tapCause(reportCause),
+      Effect.mapError((cause) => new CandidateDevelopmentLocalCommandError({ cause })),
+    ),
+    { disableErrorReporting: true },
+  )
+}
+
+if (import.meta.main) runCandidateDevelopmentLocalMain(process.argv.slice(2))

--- a/services/bayn/src/candidate-development-local/command.ts
+++ b/services/bayn/src/candidate-development-local/command.ts
@@ -42,12 +42,14 @@ export interface PreparedCandidateDevelopmentLocalAttempt {
   readonly args: CandidateDevelopmentLocalArguments
   readonly receiptPath: string
   readonly legacyReceiptPath: string
+  readonly legacyReceiptPaths: readonly string[]
   readonly source: CandidateDevelopmentLocalSourceBinding
 }
 
 export interface CandidateDevelopmentLocalReceiptReservationContext {
   readonly repositoryRoot: string
   readonly sourceGit?: CandidateDevelopmentSourceGit
+  readonly legacyReceiptPaths?: readonly string[]
 }
 
 export interface CandidateDevelopmentLocalAttemptPort {
@@ -308,9 +310,38 @@ const prepareCandidateDevelopmentLocalAttempt = (
             signal,
           ),
         )
+        const worktreeList = await candidateDevelopmentSourceGit.text(
+          repositoryRoot,
+          ['worktree', 'list', '--porcelain'],
+          signal,
+        )
+        const worktreeRoots = worktreeList
+          .split('\n\n')
+          .map((record) =>
+            record
+              .split('\n')
+              .find((line) => line.startsWith('worktree '))
+              ?.slice('worktree '.length),
+          )
+          .filter((worktreeRoot): worktreeRoot is string => worktreeRoot !== undefined && worktreeRoot.length > 0)
+        if (worktreeRoots.length === 0) throw new Error('candidate worktree list is empty')
+        const legacyReceiptPaths = await Promise.all(
+          worktreeRoots.map(async (worktreeRoot) => {
+            const canonicalWorktreeRoot = await realpath(resolve(repositoryRoot, worktreeRoot))
+            return resolve(
+              canonicalWorktreeRoot,
+              await candidateDevelopmentSourceGit.text(
+                canonicalWorktreeRoot,
+                ['rev-parse', '--git-path', legacyCandidateDevelopmentLocalReceiptName],
+                signal,
+              ),
+            )
+          }),
+        )
         return {
           attempt: join(receiptDirectory, `ordinal-${source.candidateOrdinal}.json`),
           legacy: legacyReceiptPath,
+          legacyPaths: [...new Set([legacyReceiptPath, ...legacyReceiptPaths])],
         }
       },
       catch: (cause) => localError('RECEIPT_RESERVATION_FAILED', 'candidate receipt path is unavailable', cause),
@@ -320,6 +351,7 @@ const prepareCandidateDevelopmentLocalAttempt = (
       args: normalizedArgs,
       receiptPath: receiptPaths.attempt,
       legacyReceiptPath: receiptPaths.legacy,
+      legacyReceiptPaths: receiptPaths.legacyPaths,
       source,
     }
   })
@@ -332,7 +364,10 @@ export const makeCandidateDevelopmentLocalAttempt =
         prepared.receiptPath,
         makeCandidateDevelopmentLocalReceipt(prepared.source, 'RESERVED'),
         prepared.legacyReceiptPath,
-        { repositoryRoot: prepared.repositoryRoot },
+        {
+          repositoryRoot: prepared.repositoryRoot,
+          legacyReceiptPaths: prepared.legacyReceiptPaths,
+        },
       )
       return yield* port.execute(prepared).pipe(
         Effect.onExit((exit) =>
@@ -384,6 +419,15 @@ const writeFinalizationTemporary = async (temporaryPath: string, content: string
     await temporary.sync()
   } finally {
     await temporary.close()
+  }
+}
+
+const syncReceiptDirectory = async (path: string): Promise<void> => {
+  const directory = await open(path, constants.O_RDONLY | constants.O_DIRECTORY)
+  try {
+    await directory.sync()
+  } finally {
+    await directory.close()
   }
 }
 
@@ -528,12 +572,13 @@ export const reserveCandidateDevelopmentLocalReceipt = (
 ): Effect.Effect<void, CandidateDevelopmentLocalError> =>
   Effect.tryPromise({
     try: async () => {
-      const legacyReceipt = await inspectLegacyCandidateDevelopmentLocalReceipt(
-        legacyReceiptPath,
-        receipt.candidateOrdinal,
-        context,
+      const legacyReceiptPaths = [...new Set([legacyReceiptPath, ...(context?.legacyReceiptPaths ?? [])])]
+      const legacyReceipts = await Promise.all(
+        legacyReceiptPaths.map((candidateLegacyReceiptPath) =>
+          inspectLegacyCandidateDevelopmentLocalReceipt(candidateLegacyReceiptPath, receipt.candidateOrdinal, context),
+        ),
       )
-      if (legacyReceipt === 'MATCHING_SOURCE') {
+      if (legacyReceipts.some((legacyReceipt) => legacyReceipt === 'MATCHING_SOURCE')) {
         throw localError(
           'RECEIPT_ALREADY_CONSUMED',
           'candidate development attempt was already consumed by the legacy local receipt',
@@ -557,7 +602,9 @@ export const reserveCandidateDevelopmentLocalReceipt = (
         }
         throw cause
       }
-      await unlink(markerPath).catch(() => undefined)
+      await syncReceiptDirectory(dirname(path))
+      await unlink(markerPath)
+      await syncReceiptDirectory(dirname(path))
     },
     catch: (cause) =>
       cause instanceof CandidateDevelopmentLocalError
@@ -575,6 +622,7 @@ export const finalizeCandidateDevelopmentLocalReceipt = (
       try {
         await writeFinalizationTemporary(temporaryPath, serializeCandidateDevelopmentLocalReceipt(receipt))
         await rename(temporaryPath, path)
+        await syncReceiptDirectory(dirname(path))
       } catch (cause) {
         await unlink(temporaryPath).catch(() => undefined)
         throw cause

--- a/services/bayn/src/candidate-development-local/command.ts
+++ b/services/bayn/src/candidate-development-local/command.ts
@@ -1,8 +1,8 @@
 import { constants } from 'node:fs'
-import { link, lstat, mkdir, open, realpath, rename, unlink } from 'node:fs/promises'
+import { link, mkdir, open, readFile, realpath, rename, unlink } from 'node:fs/promises'
 import { dirname, join, relative, resolve, sep } from 'node:path'
+import { createHash, randomUUID } from 'node:crypto'
 import process from 'node:process'
-import { randomUUID } from 'node:crypto'
 
 import { NodeRuntime } from '@effect/platform-node'
 import { Cause, Data, Effect, Exit } from 'effect'
@@ -11,22 +11,15 @@ import type {
   CandidateDevelopmentCommandFailure,
   CandidateDevelopmentCommandReport,
 } from '../candidate-development-command/contracts'
-import {
-  evaluateCandidateDevelopmentArtifact,
-  loadCandidateDevelopmentRuntimeMarketDataFile,
-} from '../candidate-development-command/sandbox'
-import {
-  loadAuthorizedCandidateDevelopmentExecutableProgram,
-  loadCandidateDevelopmentExecutableProgram,
-  runCandidateDevelopmentCommand,
-  type CandidateDevelopmentLoadedExecutableProgram,
+import type {
+  CandidateDevelopmentLoadedExecutableProgram,
+  runCandidateDevelopmentCommand as runCandidateDevelopmentCommandType,
 } from '../candidate-development-command/orchestration'
 import {
   renderCandidateDevelopmentCommandDefect,
   renderCandidateDevelopmentCommandFailure,
 } from '../candidate-development-command/failures'
 import { candidateDevelopmentSourceGit } from '../candidate-development-command/git-interpreter'
-import { verifyCandidateDevelopmentSourceFiles } from '../candidate-development-command/source-provenance-policy'
 import {
   bindCandidateDevelopmentLocalSource,
   CandidateDevelopmentLocalError,
@@ -93,6 +86,8 @@ const localError = (
 const isFileSystemError = (cause: unknown, code: string): boolean =>
   typeof cause === 'object' && cause !== null && 'code' in cause && cause.code === code
 
+type CandidateDevelopmentCommandRunner = typeof runCandidateDevelopmentCommandType
+
 export const resolveCandidateDevelopmentLocalArguments = (
   repositoryRoot: string,
   args: CandidateDevelopmentLocalArguments,
@@ -114,9 +109,14 @@ export const verifyCandidateDevelopmentLocalSourceTree = (
   repositoryRoot: string,
   paths: readonly string[],
   sourceGit = candidateDevelopmentSourceGit,
+  expectedSourceRevision?: string,
 ): Effect.Effect<void, CandidateDevelopmentLocalError> =>
   Effect.tryPromise({
     try: async (signal) => {
+      if (expectedSourceRevision !== undefined) {
+        const sourceRevision = await sourceGit.text(repositoryRoot, ['rev-parse', 'HEAD'], signal)
+        if (sourceRevision !== expectedSourceRevision) throw new Error('source revision changed during the attempt')
+      }
       const tracked = await sourceGit.text(repositoryRoot, ['ls-files', '-v', '--', ...paths], signal)
       if (
         tracked
@@ -144,9 +144,10 @@ export const verifyCandidateDevelopmentLocalSourceTree = (
   })
 
 const executeLoadedCandidateDevelopmentProgram = (
+  runCommand: CandidateDevelopmentCommandRunner,
   loaded: CandidateDevelopmentLoadedExecutableProgram,
 ): Effect.Effect<CandidateDevelopmentCommandReport, CandidateDevelopmentCommandFailure> =>
-  runCandidateDevelopmentCommand(loaded.program, loaded.verifiedSource).pipe(
+  runCommand(loaded.program, loaded.verifiedSource).pipe(
     Effect.mapError(
       (cause): CandidateDevelopmentCommandFailure => ({
         _tag: 'CandidateDevelopmentCommandProgramExecutionFailed',
@@ -166,31 +167,64 @@ const executeCandidateDevelopmentCommand = (
     prepared.source.sourceManifestPath,
     candidateDevelopmentEvaluatorSourcePath,
   ]
-  const verifySourceTree = verifyCandidateDevelopmentLocalSourceTree(prepared.repositoryRoot, sourcePaths)
+  const verifySourceTree = verifyCandidateDevelopmentLocalSourceTree(
+    prepared.repositoryRoot,
+    sourcePaths,
+    candidateDevelopmentSourceGit,
+    prepared.source.sourceRevision,
+  )
+  const loadInterpreter = Effect.tryPromise({
+    try: async () => {
+      const [sandbox, orchestration, sourceProvenance] = await Promise.all([
+        import('../candidate-development-command/sandbox'),
+        import('../candidate-development-command/orchestration'),
+        import('../candidate-development-command/source-provenance-policy'),
+      ])
+      return { sandbox, orchestration, sourceProvenance }
+    },
+    catch: (cause) => localError('SOURCE_BINDING_INVALID', 'candidate development interpreter is unavailable', cause),
+  })
   return verifySourceTree.pipe(
-    Effect.flatMap(() =>
-      loadAuthorizedCandidateDevelopmentExecutableProgram(
-        prepared.args.modulePath,
-        prepared.args.sourceManifestPath,
-        (module, manifest) =>
-          loadCandidateDevelopmentExecutableProgram(
-            module,
-            manifest,
-            evaluateCandidateDevelopmentArtifact,
-            (sourceModulePath, sourceManifest, sourceGit) =>
-              verifyCandidateDevelopmentSourceFiles(
-                sourceModulePath,
-                sourceManifest,
-                sourceGit,
-                prepared.source.sourceRevision,
-              ),
-            loadCandidateDevelopmentRuntimeMarketDataFile(prepared.args.runtimeMarketDataPath),
-          ),
+    Effect.flatMap(() => loadInterpreter),
+    Effect.flatMap(({ sandbox, orchestration, sourceProvenance }) =>
+      orchestration
+        .loadAuthorizedCandidateDevelopmentExecutableProgram(
+          prepared.args.modulePath,
+          prepared.args.sourceManifestPath,
+          (module, manifest) =>
+            orchestration.loadCandidateDevelopmentExecutableProgram(
+              module,
+              manifest,
+              sandbox.evaluateCandidateDevelopmentArtifact,
+              (sourceModulePath, sourceManifest, sourceGit) =>
+                sourceProvenance.verifyCandidateDevelopmentSourceFiles(
+                  sourceModulePath,
+                  sourceManifest,
+                  sourceGit,
+                  prepared.source.sourceRevision,
+                ),
+              sandbox.loadCandidateDevelopmentRuntimeMarketDataFile(prepared.args.runtimeMarketDataPath),
+            ),
+        )
+        .pipe(Effect.map((loaded) => ({ loaded, runCommand: orchestration.runCandidateDevelopmentCommand }))),
+    ),
+    Effect.tap(() =>
+      verifyCandidateDevelopmentLocalSourceTree(
+        prepared.repositoryRoot,
+        sourcePaths,
+        candidateDevelopmentSourceGit,
+        prepared.source.sourceRevision,
       ),
     ),
-    Effect.tap(() => verifyCandidateDevelopmentLocalSourceTree(prepared.repositoryRoot, sourcePaths)),
-    Effect.flatMap(executeLoadedCandidateDevelopmentProgram),
-    Effect.tap(() => verifyCandidateDevelopmentLocalSourceTree(prepared.repositoryRoot, sourcePaths)),
+    Effect.flatMap(({ loaded, runCommand }) => executeLoadedCandidateDevelopmentProgram(runCommand, loaded)),
+    Effect.tap(() =>
+      verifyCandidateDevelopmentLocalSourceTree(
+        prepared.repositoryRoot,
+        sourcePaths,
+        candidateDevelopmentSourceGit,
+        prepared.source.sourceRevision,
+      ),
+    ),
   )
 }
 
@@ -202,6 +236,14 @@ const prepareCandidateDevelopmentLocalAttempt = (
       try: async (signal) =>
         realpath(await candidateDevelopmentSourceGit.text(process.cwd(), ['rev-parse', '--show-toplevel'], signal)),
       catch: (cause) => localError('SOURCE_BINDING_INVALID', 'candidate repository root is unavailable', cause),
+    })
+    const sourceRevision = yield* Effect.tryPromise({
+      try: async (signal) => {
+        const revision = await candidateDevelopmentSourceGit.text(repositoryRoot, ['rev-parse', 'HEAD'], signal)
+        if (!/^[0-9a-f]{40}$/.test(revision)) throw new Error('candidate source revision is invalid')
+        return revision
+      },
+      catch: (cause) => localError('SOURCE_BINDING_INVALID', 'candidate source revision is unavailable', cause),
     })
     const normalizedArgs = resolveCandidateDevelopmentLocalArguments(repositoryRoot, args)
     const sourcePaths = yield* Effect.try({
@@ -215,10 +257,23 @@ const prepareCandidateDevelopmentLocalAttempt = (
           ? cause
           : localError('SOURCE_BINDING_INVALID', 'candidate source paths are invalid', cause),
     })
-    yield* verifyCandidateDevelopmentLocalSourceTree(repositoryRoot, sourcePaths)
-    const verified = yield* verifyCandidateDevelopmentSourceFiles(
+    yield* verifyCandidateDevelopmentLocalSourceTree(
+      repositoryRoot,
+      sourcePaths,
+      candidateDevelopmentSourceGit,
+      sourceRevision,
+    )
+    const verifySourceFiles = yield* Effect.tryPromise({
+      try: async () =>
+        (await import('../candidate-development-command/source-provenance-policy'))
+          .verifyCandidateDevelopmentSourceFiles,
+      catch: (cause) => localError('SOURCE_BINDING_INVALID', 'candidate source verifier is unavailable', cause),
+    })
+    const verified = yield* verifySourceFiles(
       normalizedArgs.modulePath,
       normalizedArgs.sourceManifestPath,
+      candidateDevelopmentSourceGit,
+      sourceRevision,
     ).pipe(
       Effect.mapError((cause) => localError('SOURCE_BINDING_INVALID', 'candidate source binding is invalid', cause)),
     )
@@ -296,31 +351,145 @@ export const makeCandidateDevelopmentLocalAttempt =
     })
   }
 
-const writeSynchronizedExclusiveFile = async (temporaryPath: string, content: string): Promise<void> => {
-  const handle = await open(
+const writeReservationMarker = async (markerPath: string, content: string): Promise<void> => {
+  const marker = await open(
+    markerPath,
+    constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY | constants.O_NOFOLLOW,
+    0o600,
+  )
+  try {
+    await marker.writeFile(content, 'utf8')
+    await marker.sync()
+  } finally {
+    await marker.close()
+  }
+}
+
+const writeFinalizationTemporary = async (temporaryPath: string, content: string): Promise<void> => {
+  const temporary = await open(
     temporaryPath,
     constants.O_CREAT | constants.O_EXCL | constants.O_WRONLY | constants.O_NOFOLLOW,
     0o600,
   )
   try {
-    await handle.writeFile(content, 'utf8')
-    await handle.sync()
+    await temporary.writeFile(content, 'utf8')
+    await temporary.sync()
   } finally {
-    await handle.close()
+    await temporary.close()
   }
 }
 
 const defaultLegacyReceiptPath = (path: string): string =>
   join(dirname(dirname(path)), legacyCandidateDevelopmentLocalReceiptName)
 
-const pathExists = async (path: string): Promise<boolean> => {
+const legacyReceiptSourceFields = [
+  'sourceRevision',
+  'modulePath',
+  'moduleBlobOid',
+  'moduleSha256',
+  'sourceManifestPath',
+  'sourceManifestBlobOid',
+  'sourceManifestSha256',
+  'bindingHash',
+] as const
+
+const legacyReceiptSourceIdentityFields = legacyReceiptSourceFields.filter(
+  (field): field is Exclude<(typeof legacyReceiptSourceFields)[number], 'bindingHash'> => field !== 'bindingHash',
+)
+
+type LegacyReceiptInspection = 'ABSENT' | 'MATCHING_SOURCE' | 'DIFFERENT_SOURCE'
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+const inspectLegacyCandidateDevelopmentLocalReceipt = async (
+  path: string,
+  source: CandidateDevelopmentLocalSourceBinding,
+): Promise<LegacyReceiptInspection> => {
+  let serialized: string
   try {
-    await lstat(path)
-    return true
+    serialized = await readFile(path, 'utf8')
   } catch (cause) {
-    if (isFileSystemError(cause, 'ENOENT')) return false
-    throw cause
+    if (isFileSystemError(cause, 'ENOENT')) return 'ABSENT'
+    throw localError('RECEIPT_ALREADY_CONSUMED', 'legacy local receipt could not be inspected')
   }
+
+  let value: unknown
+  try {
+    value = JSON.parse(serialized) as unknown
+  } catch {
+    throw localError('RECEIPT_ALREADY_CONSUMED', 'legacy local receipt is invalid')
+  }
+  if (!isRecord(value) || value.schemaVersion !== 'bayn.candidate-development-local-attempt.v1') {
+    throw localError('RECEIPT_ALREADY_CONSUMED', 'legacy local receipt is invalid')
+  }
+  const exitCode = value.exitCode
+  if (
+    value.attempt !== 1 ||
+    (value.status !== 'reserved' && value.status !== 'completed' && value.status !== 'failed') ||
+    (exitCode !== undefined && (typeof exitCode !== 'number' || !Number.isInteger(exitCode) || exitCode < 0))
+  ) {
+    throw localError('RECEIPT_ALREADY_CONSUMED', 'legacy local receipt is invalid')
+  }
+  const legacySourceValue = value.source
+  if (
+    !isRecord(legacySourceValue) ||
+    legacyReceiptSourceFields.some((field) => typeof legacySourceValue[field] !== 'string')
+  ) {
+    throw localError('RECEIPT_ALREADY_CONSUMED', 'legacy local receipt is invalid')
+  }
+  const legacySource = {
+    sourceRevision: legacySourceValue.sourceRevision as string,
+    modulePath: legacySourceValue.modulePath as string,
+    moduleBlobOid: legacySourceValue.moduleBlobOid as string,
+    moduleSha256: legacySourceValue.moduleSha256 as string,
+    sourceManifestPath: legacySourceValue.sourceManifestPath as string,
+    sourceManifestBlobOid: legacySourceValue.sourceManifestBlobOid as string,
+    sourceManifestSha256: legacySourceValue.sourceManifestSha256 as string,
+  }
+  if (
+    !/^[0-9a-f]{40}$/.test(legacySource.sourceRevision) ||
+    !/^[0-9a-f]{40}$/.test(legacySource.moduleBlobOid) ||
+    !/^[0-9a-f]{64}$/.test(legacySource.moduleSha256) ||
+    !/^[0-9a-f]{40}$/.test(legacySource.sourceManifestBlobOid) ||
+    !/^[0-9a-f]{64}$/.test(legacySource.sourceManifestSha256) ||
+    legacySource.modulePath.length === 0 ||
+    legacySource.sourceManifestPath.length === 0 ||
+    legacySource.modulePath.includes('\u0000') ||
+    legacySource.sourceManifestPath.includes('\u0000') ||
+    legacySource.modulePath.includes('\n') ||
+    legacySource.modulePath.includes('\r') ||
+    legacySource.sourceManifestPath.includes('\n') ||
+    legacySource.sourceManifestPath.includes('\r') ||
+    legacySource.modulePath.startsWith('/') ||
+    legacySource.sourceManifestPath.startsWith('/') ||
+    legacySource.modulePath.split('/').some((part) => part === '' || part === '..') ||
+    legacySource.sourceManifestPath.split('/').some((part) => part === '' || part === '..') ||
+    !/^[0-9a-f]{64}$/.test(legacySourceValue.bindingHash as string)
+  ) {
+    throw localError('RECEIPT_ALREADY_CONSUMED', 'legacy local receipt is invalid')
+  }
+  const expectedBindingHash = createHash('sha256')
+    .update(
+      JSON.stringify([
+        'bayn.candidate-development-local-source-binding.v1',
+        legacySource.sourceRevision,
+        legacySource.modulePath,
+        legacySource.moduleBlobOid,
+        legacySource.moduleSha256,
+        legacySource.sourceManifestPath,
+        legacySource.sourceManifestBlobOid,
+        legacySource.sourceManifestSha256,
+      ]),
+      'utf8',
+    )
+    .digest('hex')
+  if (legacySourceValue.bindingHash !== expectedBindingHash) {
+    throw localError('RECEIPT_ALREADY_CONSUMED', 'legacy local receipt is invalid')
+  }
+  return legacyReceiptSourceIdentityFields.every((field) => legacySourceValue[field] === source[field])
+    ? 'MATCHING_SOURCE'
+    : 'DIFFERENT_SOURCE'
 }
 
 export const reserveCandidateDevelopmentLocalReceipt = (
@@ -330,7 +499,8 @@ export const reserveCandidateDevelopmentLocalReceipt = (
 ): Effect.Effect<void, CandidateDevelopmentLocalError> =>
   Effect.tryPromise({
     try: async () => {
-      if (await pathExists(legacyReceiptPath)) {
+      const legacyReceipt = await inspectLegacyCandidateDevelopmentLocalReceipt(legacyReceiptPath, receipt.source)
+      if (legacyReceipt === 'MATCHING_SOURCE') {
         throw localError(
           'RECEIPT_ALREADY_CONSUMED',
           'candidate development attempt was already consumed by the legacy local receipt',
@@ -338,7 +508,7 @@ export const reserveCandidateDevelopmentLocalReceipt = (
       }
       const markerPath = `${path}.reservation`
       try {
-        await writeSynchronizedExclusiveFile(markerPath, serializeCandidateDevelopmentLocalReceipt(receipt))
+        await writeReservationMarker(markerPath, serializeCandidateDevelopmentLocalReceipt(receipt))
       } catch (cause) {
         if (isFileSystemError(cause, 'EEXIST')) {
           throw localError('RECEIPT_ALREADY_CONSUMED', 'candidate development attempt was already consumed', cause)
@@ -370,7 +540,7 @@ export const finalizeCandidateDevelopmentLocalReceipt = (
     try: async () => {
       const temporaryPath = join(dirname(path), `.${receipt.candidateOrdinal}-${process.pid}-${randomUUID()}.tmp`)
       try {
-        await writeSynchronizedExclusiveFile(temporaryPath, serializeCandidateDevelopmentLocalReceipt(receipt))
+        await writeFinalizationTemporary(temporaryPath, serializeCandidateDevelopmentLocalReceipt(receipt))
         await rename(temporaryPath, path)
       } catch (cause) {
         await unlink(temporaryPath).catch(() => undefined)

--- a/services/bayn/src/candidate-development-local/command.ts
+++ b/services/bayn/src/candidate-development-local/command.ts
@@ -1,5 +1,6 @@
 import { constants } from 'node:fs'
-import { link, mkdir, open, readFile, realpath, rename, unlink } from 'node:fs/promises'
+import type { Dirent } from 'node:fs'
+import { link, mkdir, open, readFile, readdir, realpath, rename, unlink } from 'node:fs/promises'
 import { dirname, join, relative, resolve, sep } from 'node:path'
 import { createHash, randomUUID } from 'node:crypto'
 import process from 'node:process'
@@ -310,33 +311,22 @@ const prepareCandidateDevelopmentLocalAttempt = (
             signal,
           ),
         )
-        const worktreeList = await candidateDevelopmentSourceGit.text(
-          repositoryRoot,
-          ['worktree', 'list', '--porcelain'],
-          signal,
-        )
-        const worktreeRoots = worktreeList
-          .split('\n\n')
-          .map((record) =>
-            record
-              .split('\n')
-              .find((line) => line.startsWith('worktree '))
-              ?.slice('worktree '.length),
-          )
-          .filter((worktreeRoot): worktreeRoot is string => worktreeRoot !== undefined && worktreeRoot.length > 0)
-        if (worktreeRoots.length === 0) throw new Error('candidate worktree list is empty')
+        let worktreeAdministrativeEntries: Dirent[]
+        try {
+          worktreeAdministrativeEntries = await readdir(join(commonDirectory, 'worktrees'), { withFileTypes: true })
+        } catch (cause) {
+          if (!isFileSystemError(cause, 'ENOENT')) throw cause
+          worktreeAdministrativeEntries = []
+        }
         const legacyReceiptPaths = await Promise.all(
-          worktreeRoots.map(async (worktreeRoot) => {
-            const canonicalWorktreeRoot = await realpath(resolve(repositoryRoot, worktreeRoot))
-            return resolve(
-              canonicalWorktreeRoot,
-              await candidateDevelopmentSourceGit.text(
-                canonicalWorktreeRoot,
-                ['rev-parse', '--git-path', legacyCandidateDevelopmentLocalReceiptName],
-                signal,
-              ),
-            )
-          }),
+          worktreeAdministrativeEntries
+            .filter((entry) => entry.isDirectory())
+            .map(async (entry) => {
+              const administrativeDirectory = join(commonDirectory, 'worktrees', entry.name)
+              const gitDirectoryReference = (await readFile(join(administrativeDirectory, 'gitdir'), 'utf8')).trim()
+              if (gitDirectoryReference.length === 0) throw new Error('candidate worktree gitdir is empty')
+              return join(administrativeDirectory, legacyCandidateDevelopmentLocalReceiptName)
+            }),
         )
         return {
           attempt: join(receiptDirectory, `ordinal-${source.candidateOrdinal}.json`),

--- a/services/bayn/src/candidate-development-local/command.ts
+++ b/services/bayn/src/candidate-development-local/command.ts
@@ -331,7 +331,13 @@ const prepareCandidateDevelopmentLocalAttempt = (
         return {
           attempt: join(receiptDirectory, `ordinal-${source.candidateOrdinal}.json`),
           legacy: legacyReceiptPath,
-          legacyPaths: [...new Set([legacyReceiptPath, ...legacyReceiptPaths])],
+          legacyPaths: [
+            ...new Set([
+              join(commonDirectory, legacyCandidateDevelopmentLocalReceiptName),
+              legacyReceiptPath,
+              ...legacyReceiptPaths,
+            ]),
+          ],
         }
       },
       catch: (cause) => localError('RECEIPT_RESERVATION_FAILED', 'candidate receipt path is unavailable', cause),

--- a/services/bayn/src/candidate-development-local/command.ts
+++ b/services/bayn/src/candidate-development-local/command.ts
@@ -15,6 +15,7 @@ import type {
   CandidateDevelopmentLoadedExecutableProgram,
   runCandidateDevelopmentCommand as runCandidateDevelopmentCommandType,
 } from '../candidate-development-command/orchestration'
+import type { CandidateDevelopmentSourceGit } from '../candidate-development-command/git-contracts'
 import {
   renderCandidateDevelopmentCommandDefect,
   renderCandidateDevelopmentCommandFailure,
@@ -44,11 +45,17 @@ export interface PreparedCandidateDevelopmentLocalAttempt {
   readonly source: CandidateDevelopmentLocalSourceBinding
 }
 
+export interface CandidateDevelopmentLocalReceiptReservationContext {
+  readonly repositoryRoot: string
+  readonly sourceGit?: CandidateDevelopmentSourceGit
+}
+
 export interface CandidateDevelopmentLocalAttemptPort {
   reserve: (
     path: string,
     receipt: CandidateDevelopmentLocalAttemptReceipt,
     legacyReceiptPath?: string,
+    context?: CandidateDevelopmentLocalReceiptReservationContext,
   ) => Effect.Effect<void, CandidateDevelopmentLocalError>
   execute: (
     prepared: PreparedCandidateDevelopmentLocalAttempt,
@@ -325,6 +332,7 @@ export const makeCandidateDevelopmentLocalAttempt =
         prepared.receiptPath,
         makeCandidateDevelopmentLocalReceipt(prepared.source, 'RESERVED'),
         prepared.legacyReceiptPath,
+        { repositoryRoot: prepared.repositoryRoot },
       )
       return yield* port.execute(prepared).pipe(
         Effect.onExit((exit) =>
@@ -393,10 +401,6 @@ const legacyReceiptSourceFields = [
   'bindingHash',
 ] as const
 
-const legacyReceiptSourceIdentityFields = legacyReceiptSourceFields.filter(
-  (field): field is Exclude<(typeof legacyReceiptSourceFields)[number], 'bindingHash'> => field !== 'bindingHash',
-)
-
 type LegacyReceiptInspection = 'ABSENT' | 'MATCHING_SOURCE' | 'DIFFERENT_SOURCE'
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
@@ -404,7 +408,8 @@ const isRecord = (value: unknown): value is Record<string, unknown> =>
 
 const inspectLegacyCandidateDevelopmentLocalReceipt = async (
   path: string,
-  source: CandidateDevelopmentLocalSourceBinding,
+  candidateOrdinal: number,
+  context: CandidateDevelopmentLocalReceiptReservationContext | undefined,
 ): Promise<LegacyReceiptInspection> => {
   let serialized: string
   try {
@@ -487,19 +492,47 @@ const inspectLegacyCandidateDevelopmentLocalReceipt = async (
   if (legacySourceValue.bindingHash !== expectedBindingHash) {
     throw localError('RECEIPT_ALREADY_CONSUMED', 'legacy local receipt is invalid')
   }
-  return legacyReceiptSourceIdentityFields.every((field) => legacySourceValue[field] === source[field])
-    ? 'MATCHING_SOURCE'
-    : 'DIFFERENT_SOURCE'
+  if (context === undefined) {
+    throw localError('RECEIPT_ALREADY_CONSUMED', 'legacy local receipt cannot be verified')
+  }
+  try {
+    const sourceGit = context.sourceGit ?? candidateDevelopmentSourceGit
+    const manifestSpec = `${legacySource.sourceRevision}:${legacySource.sourceManifestPath}`
+    const manifestBlobOid = await sourceGit.text(context.repositoryRoot, ['rev-parse', manifestSpec])
+    if (manifestBlobOid !== legacySource.sourceManifestBlobOid) {
+      throw new Error('legacy source manifest blob changed')
+    }
+    const manifestSource = await sourceGit.bytes(context.repositoryRoot, ['cat-file', 'blob', manifestSpec])
+    const manifest = JSON.parse(manifestSource.toString('utf8')) as unknown
+    if (!isRecord(manifest)) throw new Error('legacy source manifest is invalid')
+    const manifestCandidateOrdinal = manifest.candidateOrdinal
+    if (
+      typeof manifestCandidateOrdinal !== 'number' ||
+      !Number.isSafeInteger(manifestCandidateOrdinal) ||
+      manifestCandidateOrdinal < 1
+    ) {
+      throw new Error('legacy source manifest ordinal is invalid')
+    }
+    return manifestCandidateOrdinal === candidateOrdinal ? 'MATCHING_SOURCE' : 'DIFFERENT_SOURCE'
+  } catch (cause) {
+    if (cause instanceof CandidateDevelopmentLocalError) throw cause
+    throw localError('RECEIPT_ALREADY_CONSUMED', 'legacy local receipt could not be verified', cause)
+  }
 }
 
 export const reserveCandidateDevelopmentLocalReceipt = (
   path: string,
   receipt: CandidateDevelopmentLocalAttemptReceipt,
   legacyReceiptPath = defaultLegacyReceiptPath(path),
+  context?: CandidateDevelopmentLocalReceiptReservationContext,
 ): Effect.Effect<void, CandidateDevelopmentLocalError> =>
   Effect.tryPromise({
     try: async () => {
-      const legacyReceipt = await inspectLegacyCandidateDevelopmentLocalReceipt(legacyReceiptPath, receipt.source)
+      const legacyReceipt = await inspectLegacyCandidateDevelopmentLocalReceipt(
+        legacyReceiptPath,
+        receipt.candidateOrdinal,
+        context,
+      )
       if (legacyReceipt === 'MATCHING_SOURCE') {
         throw localError(
           'RECEIPT_ALREADY_CONSUMED',

--- a/services/bayn/src/candidate-development-local/domain.ts
+++ b/services/bayn/src/candidate-development-local/domain.ts
@@ -1,0 +1,134 @@
+import { Data, Result } from 'effect'
+
+import { canonicalHashV1Result, type CanonicalHashFailure } from '../hash'
+import type { CandidateDevelopmentVerifiedSourceFiles } from '../candidate-development-command/contracts'
+
+export const candidateDevelopmentLocalReceiptSchemaVersion = 'bayn.candidate-development-local-attempt.v3' as const
+
+export type CandidateDevelopmentLocalErrorCode =
+  | 'INVALID_ARGUMENTS'
+  | 'SOURCE_BINDING_INVALID'
+  | 'RECEIPT_ALREADY_CONSUMED'
+  | 'RECEIPT_RESERVATION_FAILED'
+  | 'RECEIPT_FINALIZATION_FAILED'
+
+export class CandidateDevelopmentLocalError extends Data.TaggedError('CandidateDevelopmentLocalError')<{
+  readonly code: CandidateDevelopmentLocalErrorCode
+  readonly message: string
+  readonly cause?: unknown
+}> {}
+
+export interface CandidateDevelopmentLocalArguments {
+  readonly modulePath: string
+  readonly sourceManifestPath: string
+  readonly runtimeMarketDataPath: string
+}
+
+export interface CandidateDevelopmentLocalSourceBinding {
+  readonly candidateOrdinal: number
+  readonly sourceRevision: string
+  readonly modulePath: string
+  readonly moduleBlobOid: string
+  readonly moduleSha256: string
+  readonly sourceManifestPath: string
+  readonly sourceManifestBlobOid: string
+  readonly sourceManifestSha256: string
+  readonly bindingHash: string
+}
+
+export type CandidateDevelopmentLocalDecisionStatus = 'PASS' | 'HOLD_REJECT'
+
+export type CandidateDevelopmentLocalTerminalStatus = CandidateDevelopmentLocalDecisionStatus | 'FAILED'
+
+export interface CandidateDevelopmentLocalAttemptReceipt {
+  readonly schemaVersion: typeof candidateDevelopmentLocalReceiptSchemaVersion
+  readonly candidateOrdinal: number
+  readonly attempt: 1
+  readonly status: 'RESERVED' | CandidateDevelopmentLocalTerminalStatus
+  readonly source: CandidateDevelopmentLocalSourceBinding
+  readonly terminalReportHash: string | null
+}
+
+export type CandidateDevelopmentLocalTerminalOutcome =
+  | {
+      readonly status: CandidateDevelopmentLocalDecisionStatus
+      readonly terminalReportHash: string
+    }
+  | {
+      readonly status: 'FAILED'
+      readonly terminalReportHash: null
+    }
+
+const pathArgument = (value: unknown): value is string =>
+  typeof value === 'string' &&
+  value.length > 0 &&
+  !value.includes('\u0000') &&
+  !value.includes('\n') &&
+  !value.includes('\r')
+
+export const parseCandidateDevelopmentLocalArguments = (
+  argv: readonly string[],
+): Result.Result<CandidateDevelopmentLocalArguments, CandidateDevelopmentLocalError> => {
+  if (argv.length !== 3 || !argv.every(pathArgument)) {
+    return Result.fail(
+      new CandidateDevelopmentLocalError({
+        code: 'INVALID_ARGUMENTS',
+        message: 'expected exactly <module> <source-manifest> <typed-runtime-market-data.json>',
+      }),
+    )
+  }
+  const [modulePath, sourceManifestPath, runtimeMarketDataPath] = argv as readonly [string, string, string]
+  return Result.succeed({ modulePath, sourceManifestPath, runtimeMarketDataPath })
+}
+
+type SourceBindingResult = Result.Result<
+  CandidateDevelopmentLocalSourceBinding,
+  CandidateDevelopmentLocalError | CanonicalHashFailure
+>
+
+export const bindCandidateDevelopmentLocalSource = (
+  files: CandidateDevelopmentVerifiedSourceFiles,
+): SourceBindingResult => {
+  const candidateOrdinal = files.sourceManifest.candidateOrdinal
+  if (!Number.isSafeInteger(candidateOrdinal) || candidateOrdinal < 1) {
+    return Result.fail(
+      new CandidateDevelopmentLocalError({
+        code: 'SOURCE_BINDING_INVALID',
+        message: 'candidate source manifest has an invalid ordinal',
+      }),
+    )
+  }
+  const source = {
+    candidateOrdinal,
+    sourceRevision: files.sourceRevision,
+    modulePath: files.modulePath,
+    moduleBlobOid: files.moduleBlobOid,
+    moduleSha256: files.moduleSha256,
+    sourceManifestPath: files.sourceManifestPath,
+    sourceManifestBlobOid: files.sourceManifestBlobOid,
+    sourceManifestSha256: files.sourceManifestSha256,
+  }
+  return Result.map(canonicalHashV1Result(source), (bindingHash) => ({ ...source, bindingHash }))
+}
+
+export const makeCandidateDevelopmentLocalReceipt = (
+  source: CandidateDevelopmentLocalSourceBinding,
+  status: CandidateDevelopmentLocalAttemptReceipt['status'],
+  terminalReportHash: string | null = null,
+): CandidateDevelopmentLocalAttemptReceipt => ({
+  schemaVersion: candidateDevelopmentLocalReceiptSchemaVersion,
+  candidateOrdinal: source.candidateOrdinal,
+  attempt: 1,
+  status,
+  source,
+  terminalReportHash,
+})
+
+export const makeCandidateDevelopmentLocalTerminalReceipt = (
+  source: CandidateDevelopmentLocalSourceBinding,
+  outcome: CandidateDevelopmentLocalTerminalOutcome,
+): CandidateDevelopmentLocalAttemptReceipt =>
+  makeCandidateDevelopmentLocalReceipt(source, outcome.status, outcome.terminalReportHash)
+
+export const serializeCandidateDevelopmentLocalReceipt = (receipt: CandidateDevelopmentLocalAttemptReceipt): string =>
+  `${JSON.stringify(receipt)}\n`


### PR DESCRIPTION
## Summary

- Add a compact v3 local-development receipt domain that binds reviewed source revision, blobs, hashes, attempt ordinal, terminal PASS/HOLD_REJECT/FAILED status, and terminal report hash.
- Keep runtime market-data path/content and full metric output out of the receipt.
- Keep the Effect interpreter cohesive with explicit dependency injection, reserve-before-execute ordering, one finalization, O_EXCL crash burning, interruption failure finalization, source-scoped legacy-receipt compatibility across the main worktree and registered linked-worktree admin records (including prunable records), evaluator-source revalidation, directory-sync durability, and shared legacy/v3 ordinal claim coordination.
- Keep the documented package script contract and route its existing wrapper entrypoint in-process to the service-owned interpreter.

## Related Issues

None

## Testing

- Focused service receipt tests: 16 passed, 37 assertions.
- Focused scripts-wrapper compatibility tests: 14 passed, 36 assertions; existing qualification contract tests: 17 passed, 90 assertions.
- Full local Bayn suite at the final local head: 1,242 passed, 153 skipped, 0 failed across 116 files; 8,809 assertions.
- Final-head CI is required after this final review-fix head: full PR checks, real PostgreSQL integration, both Bayn image builds, dependency invariant, broker sandbox, Effect compatibility, and release gate.
- Service typecheck, Effect diagnostics, lint, Oxlint, format, and build passed; one pre-existing Bayn Oxlint warning remains outside this change in `src/candidate-development-domain/preflight.ts`.
- Package-wide TypeScript checking still reports unrelated existing errors outside this lane; the changed local command has no remaining package-tsc diagnostic.
- No candidate, holdout, broker, or access-data execution occurred; full-suite evidence uses repository test fixtures only.

## Breaking Changes

None

## Checklist

- [x] Testing section documents exact validation performed.
- [x] Screenshots and Breaking Changes handled.
- [x] Documentation, release notes, follow-ups updated/tracked.