### PR TITLE
refactor(bayn): isolate candidate evidence from command facade

### DIFF
--- a/services/bayn/src/candidate-development-command.ts
+++ b/services/bayn/src/candidate-development-command.ts
@@ -1,12 +1,61 @@
-export * from './candidate-development-command/contracts'
-export * from './candidate-development-command/failures'
-export * from './candidate-development-command/evaluation'
-export * from './candidate-development-command/runtime-policy'
-export * from './candidate-development-command/source-git'
-export * from './candidate-development-command/artifact-policy'
-export * from './candidate-development-command/plan-evaluation'
-export * from './candidate-development-command/sandbox'
-export * from './candidate-development-command/orchestration'
+// Keep this module as the application/CLI boundary. Internal policies and contracts are
+// re-exported only for the compatibility consumers that still import this historical path.
+export {
+  candidateDevelopmentExecutableProgramSchemaVersion,
+  CandidateDevelopmentSourceManifestSchema,
+} from './candidate-development-command/contracts'
+export type {
+  CandidateDevelopmentCommandEvaluation,
+  CandidateDevelopmentExecutableProgram,
+  CandidateDevelopmentSourceManifest,
+  CandidateDevelopmentStrategyPlan,
+  CandidateDevelopmentStrategyProtocol,
+  CandidateDevelopmentVerifiedSource,
+  CandidateDevelopmentVerifiedSourceFiles,
+} from './candidate-development-command/contracts'
+export type {
+  CandidateDevelopmentSourceGit,
+  CandidateDevelopmentSourceVerifier,
+  CandidateDevelopmentVerifiedModuleSource,
+} from './candidate-development-command/git-contracts'
+export { candidateDevelopmentCommandFailureOutputMaxBytes } from './candidate-development-command/failure-core'
+export { renderCandidateDevelopmentCommandFailure } from './candidate-development-command/failure-dispatch'
+export {
+  authorizeCandidateDevelopmentAttempt,
+  bindCandidateDevelopmentVerifiedSource,
+  preregisterCandidateDevelopmentAttempt,
+  validateCandidateDevelopmentPreregisteredMarketData,
+  validateCandidateDevelopmentTrialHistoryClosure,
+} from './candidate-development-command/evaluation-authority'
+export { buildCandidateDevelopmentCommandReport } from './candidate-development-command/report-policy'
+export { validateCandidateDevelopmentAccountingReplay } from './candidate-development-command/accounting-replay'
+export {
+  validateCandidateDevelopmentCommandEvaluation,
+  validateCandidateDevelopmentExecutableProgram,
+  validateCandidateDevelopmentPreregistrationDocument,
+  validateCandidateDevelopmentRuntimeMarketData,
+} from './candidate-development-command/runtime-policy'
+export { validateCandidateDevelopmentModuleSource } from './candidate-development-command/artifact-public-policy'
+export { buildCandidateDevelopmentPlanEvaluation } from './candidate-development-command/plan-builder'
+export {
+  evaluateCandidateDevelopmentArtifact,
+  executeCandidateDevelopmentArtifactRuntime,
+  loadCandidateDevelopmentRuntimeMarketDataFile,
+} from './candidate-development-command/sandbox'
+export {
+  executeCandidateDevelopmentProgram,
+  loadCandidateDevelopmentExecutableProgram,
+  makeCandidateDevelopmentCommandReportWriter,
+  renderCandidateDevelopmentCommandReport,
+  writeCandidateDevelopmentCommandReport,
+} from './candidate-development-command/orchestration'
+export { openCandidateDevelopmentGitBatchObjectReader } from './candidate-development-command/git-interpreter'
+export {
+  verifyCandidateDevelopmentPreregistrationLineage,
+  verifyCandidateDevelopmentPreregistrationModuleNovelty,
+  verifyCandidateDevelopmentRepositoryIntegrity,
+  verifyCandidateDevelopmentSourceFiles,
+} from './candidate-development-command/source-provenance-policy'
 
 import { writeSync } from 'node:fs'
 import { isMainThread } from 'node:worker_threads'
@@ -27,9 +76,9 @@ import {
 import {
   renderCandidateDevelopmentCommandDefect,
   renderCandidateDevelopmentCommandFailure,
-} from './candidate-development-command/failures'
-import { sourceVerificationFailure } from './candidate-development-command/evaluation'
-import { verifyCandidateDevelopmentSourceFiles } from './candidate-development-command/source-git'
+} from './candidate-development-command/failure-dispatch'
+import { sourceVerificationFailure } from './candidate-development-command/evaluation-metrics'
+import { verifyCandidateDevelopmentSourceFiles } from './candidate-development-command/source-provenance-policy'
 import { GitSourceRevisionSchema } from './schemas'
 import type {
   CandidateDevelopmentCommandFailure,

--- a/services/bayn/src/candidate-development-evidence/accounting.ts
+++ b/services/bayn/src/candidate-development-evidence/accounting.ts
@@ -10,10 +10,8 @@ import {
   type CandidateDevelopmentPreflightPass,
   type CandidateDevelopmentReport,
 } from '../candidate-development'
-import {
-  validateCandidateDevelopmentCommandEvaluation,
-  type CandidateDevelopmentCommandEvaluation,
-} from '../candidate-development-command'
+import { validateCandidateDevelopmentCommandEvaluation } from '../candidate-development-command/runtime-policy'
+import type { CandidateDevelopmentCommandEvaluation } from '../candidate-development-command/contracts'
 import { deriveCandidateDevelopmentDecision } from '../candidate-development-decision'
 import { canonicalHashV1Result } from '../hash'
 import { prepareQualificationSeries } from '../qualification-statistics'

--- a/services/bayn/src/candidate-development-evidence/hashing.ts
+++ b/services/bayn/src/candidate-development-evidence/hashing.ts
@@ -1,6 +1,10 @@
 import { Result } from 'effect'
 
-import { validateCandidateDevelopmentCommandEvaluation } from '../candidate-development-command'
+import { validateCandidateDevelopmentCommandEvaluation } from '../candidate-development-command/runtime-policy'
+import type {
+  CandidateDevelopmentCommandEvaluation,
+  CandidateDevelopmentVerifiedSource,
+} from '../candidate-development-command/contracts'
 import { canonicalHashV1Result, type CanonicalHashFailure } from '../hash'
 import { collectCanonicalBinding, collectCanonicalBindings } from './bindings'
 import type {
@@ -9,10 +13,6 @@ import type {
   CandidateDevelopmentImmutableEvidence,
   CandidateDevelopmentIndependentReproduction,
 } from './model'
-import type {
-  CandidateDevelopmentCommandEvaluation,
-  CandidateDevelopmentVerifiedSource,
-} from '../candidate-development-command'
 
 export const candidateDevelopmentEvidenceMaterial = (
   evidence: CandidateDevelopmentImmutableEvidence,

--- a/services/bayn/src/candidate-development-evidence/model.ts
+++ b/services/bayn/src/candidate-development-evidence/model.ts
@@ -8,7 +8,7 @@ import type {
   CandidateDevelopmentCommandEvaluation,
   CandidateDevelopmentStrategyProtocol,
   CandidateDevelopmentVerifiedSource,
-} from '../candidate-development-command'
+} from '../candidate-development-command/contracts'
 import type {
   CandidateDevelopmentDecision,
   CandidateDevelopmentNextPreregistration,

--- a/services/bayn/src/candidate-development-evidence/receipt.ts
+++ b/services/bayn/src/candidate-development-evidence/receipt.ts
@@ -1,6 +1,6 @@
 import { Result } from 'effect'
 
-import { buildCandidateDevelopmentCommandReport } from '../candidate-development-command'
+import { buildCandidateDevelopmentCommandReport } from '../candidate-development-command/report-policy'
 import type { CandidateDevelopmentNextPreregistration } from '../candidate-development-decision'
 import { collectCandidateDevelopmentEligibilityBindings, collectCanonicalBinding } from './bindings'
 import { validateCandidateDevelopmentCompleteEvidence } from './accounting'

--- a/services/bayn/src/candidate-development-evidence/wire.ts
+++ b/services/bayn/src/candidate-development-evidence/wire.ts
@@ -5,8 +5,8 @@ import {
   CandidateDevelopmentPreflightInputSchema,
   CandidateDevelopmentSourceManifestSchema,
   CandidateDevelopmentStrategyProtocolSchema,
-  validateCandidateDevelopmentCommandEvaluation,
-} from '../candidate-development-command'
+} from '../candidate-development-command/contracts'
+import { validateCandidateDevelopmentCommandEvaluation } from '../candidate-development-command/runtime-policy'
 import {
   GitSourceRevisionSchema,
   NonNegativeIntegerSchema,


### PR DESCRIPTION
## Summary

- Make `services/bayn/src/candidate-development-command.ts` an explicit application/CLI boundary with named compatibility re-exports only.
- Point candidate-development evidence directly at concrete contracts, runtime validation, and report policy modules instead of the facade.
- Keep candidate evaluation decisions, canonical evidence, and hashes unchanged; retain the existing typed config and CLI behavior.
- Change only the owned command facade and candidate-development evidence files.

## Related Issues

None.

## Testing

- `bun test src/candidate-development-command.test.ts src/candidate-development-command/command-flow.test.ts src/candidate-development-command/report-policy.test.ts src/candidate-development-evidence.test.ts` — 36 passed, 0 failed.
- `bun run --filter @proompteng/bayn test` — 1,218 passed, 153 skipped, 0 failed; 1,371 tests across 114 files.
- `bun run --filter @proompteng/bayn tsc` — passed.
- `bun run --filter @proompteng/bayn build` — passed.
- `bun run --filter @proompteng/bayn lint` — passed.
- `bun run --filter @proompteng/bayn lint:oxlint` — passed with one pre-existing warning in `src/candidate-development-domain/preflight.ts`.
- `bun run --filter @proompteng/bayn lint:oxlint:type` — passed with the same pre-existing warning.
- `bunx oxfmt --check services/bayn/src/candidate-development-command.ts services/bayn/src/candidate-development-evidence/accounting.ts services/bayn/src/candidate-development-evidence/hashing.ts services/bayn/src/candidate-development-evidence/model.ts services/bayn/src/candidate-development-evidence/receipt.ts services/bayn/src/candidate-development-evidence/wire.ts` — passed.
- Repository-wide `bun run format:check` remains blocked by an unrelated pre-existing duplicate `controllers` key in `charts/agents/values-ci-ha.yaml`; no out-of-scope files were changed.
- Real PostgreSQL validation: N/A; this change touches no database code or runtime paths, and PostgreSQL integration tests are skipped without the integration environment.
- No candidates, holdout data, broker mutations, or deployments were run.

## Screenshots (if applicable)

Removed; not applicable to a TypeScript layering refactor.

## Breaking Changes

None. The historical facade retains the compatibility exports used by current production callers and tests; internal evidence imports no longer depend on it.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
