### PR TITLE
refactor(bayn): add pure strategy composition boundary

### DIFF
--- a/services/bayn/src/application-plan.ts
+++ b/services/bayn/src/application-plan.ts
@@ -13,7 +13,8 @@ import {
 import { operationalError } from './errors'
 import { canonicalHashV1Result, type CanonicalJsonFailure } from './hash'
 import { loadDefaultProtocol, type CausalProtocol } from './protocol'
-import { makeStrategy, type Strategy } from './strategy'
+import { type Strategy } from './strategy'
+import { makeRiskBalancedTrendStrategy } from './strategy/risk-balanced-trend/strategy'
 
 type RuntimeIdentityFailure =
   | {
@@ -37,6 +38,9 @@ type RuntimeSeed = {
 type ParameterizedRuntime = RuntimeSeed & { readonly parameterHash: string }
 type ProvenanceRuntime = ParameterizedRuntime & { readonly provenance: RuntimeProvenance }
 type StrategyRuntime = ProvenanceRuntime & { readonly strategy: Strategy }
+
+const selectStrategy = (runtime: ProvenanceRuntime): Strategy =>
+  makeRiskBalancedTrendStrategy(runtime.protocol, runtime.provenance)
 
 const hashRuntimeParameters = (seed: RuntimeSeed): Result.Result<ParameterizedRuntime, RuntimeIdentityFailure> =>
   pipe(
@@ -71,10 +75,7 @@ const addRuntimeProvenance = (
     Result.map((provenance) => ({ ...parameterized, provenance })),
   )
 
-const addStrategy = (runtime: ProvenanceRuntime): StrategyRuntime => ({
-  ...runtime,
-  strategy: makeStrategy(runtime.protocol, runtime.provenance),
-})
+const addStrategy = (runtime: ProvenanceRuntime): StrategyRuntime => ({ ...runtime, strategy: selectStrategy(runtime) })
 
 const addStrategyProtocolHash = (
   runtime: StrategyRuntime,

--- a/services/bayn/src/risk-balanced-trend.test.ts
+++ b/services/bayn/src/risk-balanced-trend.test.ts
@@ -13,7 +13,7 @@ import {
   prepareRiskBalancedTrendQualification,
   type CurrentDecisionCycleBinding,
 } from './risk-balanced-trend'
-import { makeStrategy } from './strategy'
+import { makeRiskBalancedTrendDefinition, makeRiskBalancedTrendStrategy, makeStrategy } from './strategy'
 import { makeSnapshot, makeTestProvenance, fixtureProtocol } from './test-fixtures'
 import type { CausalProtocol, IsoDate, Protocol } from './types'
 
@@ -138,6 +138,32 @@ describe('risk-balanced trend candidate', () => {
     expect(efa.compositeScore).toBeCloseTo(-Math.sqrt(8), 12)
     expect(efa.positiveScore).toBe(0)
     expect(decision.targetWeights).toEqual({ DBC: 0.666666666667, EEM: 0.333333333333, EFA: 0 })
+  })
+
+  test('uses the generic verified-context definition without changing the target portfolio or hash', () => {
+    const protocol = shortProtocol({
+      horizons: [1],
+      volatilityWindow: 2,
+      maximumSymbolWeight: 1,
+      maximumPortfolioVolatility: 1,
+    })
+    const sessionDates = ['2026-07-15', '2026-07-16', '2026-07-17'] as const satisfies readonly IsoDate[]
+    const closes = {
+      DBC: [100, 101, 103.02],
+      EEM: [100, 102, 103.02],
+      EFA: [100, 99, 97.02],
+    } as const
+    const direct = assertSuccess(makeRiskBalancedTrendDecision(sessionDates[2], sessionDates, closes, protocol))
+    const viaDefinition = assertSuccess(
+      makeRiskBalancedTrendDefinition(protocol).decide({
+        market: { signalDate: sessionDates[2], sessionDates, closes },
+        portfolio: { positions: {} },
+      }),
+    )
+
+    expect(viaDefinition).toEqual(direct)
+    expect(viaDefinition.targetWeights).toEqual(direct.targetWeights)
+    expect(canonicalHashV1(viaDefinition)).toBe(canonicalHashV1(direct))
   })
 
   test('requires three positive horizons and allocates by conviction per unit volatility in protocol v4', () => {
@@ -338,7 +364,7 @@ describe('risk-balanced trend candidate', () => {
 
   test('compiles one current decision with exact quantized terminal-session prices', () => {
     const snapshot = makeSnapshot(1_129)
-    const strategy = makeStrategy(fixtureProtocol, makeTestProvenance())
+    const strategy = makeRiskBalancedTrendStrategy(fixtureProtocol, makeTestProvenance())
     const bars = snapshot.bars.map((bar) =>
       bar.sessionDate === snapshot.manifest.lastSession && bar.symbol === fixtureProtocol.universe[0]
         ? { ...bar, close: 100.123456 }
@@ -573,9 +599,13 @@ describe('risk-balanced trend candidate', () => {
     const { decisionId: _, executionDate: __, ...retainedPlan } = retained
     expect(retainedPlan).toEqual(expectedDecision)
     const priorTrialRunIds = Array.from({ length: 8 }, (_, index) => index.toString(16).repeat(64))
-    const strategy = makeStrategy(fixtureProtocol, provenance)
+    const strategy = makeRiskBalancedTrendStrategy(fixtureProtocol, provenance)
+    const adapted = assertSuccess(strategy.evaluate(snapshot.bars, snapshot.manifest))
     const lock = assertSuccess(strategy.prepareLock(snapshot.manifest, sessionDates, priorTrialRunIds))
     const analysis = assertSuccess(strategy.analyze(first, priorTrialRunIds))
+    expect(adapted).toEqual(first)
+    expect(canonicalHashV1(adapted)).toBe(canonicalHashV1(first))
+    expect(strategy.provenance).toEqual(provenance)
     expect(lock.priorTrialRunIds).toEqual(priorTrialRunIds)
     expect(lock).toMatchObject({
       schemaVersion: 'bayn.qualification-lock.v3',

--- a/services/bayn/src/strategy.ts
+++ b/services/bayn/src/strategy.ts
@@ -1,152 +1,35 @@
-import { pipe, Result } from 'effect'
+import { makeRiskBalancedTrendStrategy } from './strategy/risk-balanced-trend/strategy'
+import type {
+  RiskBalancedTrendStrategy,
+  RiskBalancedTrendStrategyPrepareLockFailure,
+} from './strategy/risk-balanced-trend/strategy'
+import type { CurrentDecisionCycleBinding, CurrentRiskBalancedTrendDecision } from './risk-balanced-trend'
+import type { RiskBalancedTrendFailure } from './risk-balanced-trend'
 
-import type { RuntimeProvenance } from './contracts'
-import {
-  defaultQualificationStatisticsPolicyDocument,
-  makeQualificationLock,
-  makeQualificationPolicyDocument,
-  type QualificationConstructionFailure,
-  type QualificationLock,
-} from './qualification'
-import {
-  analyzeQualification,
-  defaultQualificationStatisticsPolicy,
-  prepareQualificationSeries,
-  type QualificationAnalysis,
-  type QualificationStatisticsFailure,
-} from './qualification-statistics'
-import {
-  compileCurrentRiskBalancedTrendDecision,
-  evaluateRiskBalancedTrend,
-  parseMatchingManifest,
-  prepareRiskBalancedTrendQualification,
-  type CurrentDecisionCycleBinding,
-  type CurrentRiskBalancedTrendDecision,
-  type RiskBalancedTrendEvaluationIssue,
-  type RiskBalancedTrendFailure,
-} from './risk-balanced-trend'
-import type { DailyBar, EvaluationResult, InputManifest, IsoDate, Protocol } from './types'
+export type {
+  StrategyDecisionFailure,
+  StrategyDefinition,
+  StrategyTargetPortfolio,
+  VerifiedStrategyContext,
+} from './strategy/core'
+export { makeRiskBalancedTrendDefinition, makeRiskBalancedTrendStrategy } from './strategy/risk-balanced-trend'
+export type {
+  RiskBalancedTrendMarketContext,
+  RiskBalancedTrendPortfolioContext,
+  RiskBalancedTrendStrategyDefinition,
+  RiskBalancedTrendTargetPortfolio,
+} from './strategy/risk-balanced-trend'
+
+/**
+ * Runtime callers still consume the full evaluation facade until their own migrations land.
+ * New strategy consumers should depend on StrategyDefinition instead.
+ */
+export type Strategy = RiskBalancedTrendStrategy
 
 export type CurrentStrategyDecision = CurrentRiskBalancedTrendDecision
 export type CurrentStrategyDecisionCycleBinding = CurrentDecisionCycleBinding
 export type CurrentStrategyDecisionFailure = RiskBalancedTrendFailure
-export type StrategyPrepareLockFailure = RiskBalancedTrendFailure | QualificationConstructionFailure
+export type StrategyPrepareLockFailure = RiskBalancedTrendStrategyPrepareLockFailure
 
-export interface Strategy {
-  readonly name: string
-  readonly parameters: Protocol
-  readonly provenance: RuntimeProvenance
-  readonly evaluate: (
-    bars: readonly DailyBar[],
-    manifest: InputManifest,
-  ) => Result.Result<EvaluationResult, readonly RiskBalancedTrendEvaluationIssue[]>
-  readonly currentDecision: (
-    bars: readonly DailyBar[],
-    manifest: InputManifest,
-    cycleBinding: CurrentStrategyDecisionCycleBinding,
-  ) => Result.Result<CurrentStrategyDecision, CurrentStrategyDecisionFailure>
-  readonly prepareLock: (
-    manifest: InputManifest,
-    sessionDates: readonly IsoDate[],
-    priorTrialRunIds: readonly string[],
-  ) => Result.Result<QualificationLock, StrategyPrepareLockFailure>
-  readonly analyze: (
-    evaluation: EvaluationResult,
-    priorTrialRunIds: readonly string[],
-  ) => Result.Result<QualificationAnalysis, QualificationStatisticsFailure>
-}
-
-const universeRationale =
-  'The precommitted five-sleeve cross-asset universe uses broad commodities (DBC), developed ex-US equities (EFA), intermediate US Treasuries (IEF), US equities (SPY), and US real estate (VNQ); symbols were fixed without inspecting candidate prices or returns.'
-
-export const makeStrategy = (protocol: Protocol, provenance: RuntimeProvenance): Strategy => {
-  return {
-    name: 'risk-balanced-trend',
-    parameters: protocol,
-    provenance,
-    evaluate: (bars, manifest) =>
-      pipe(
-        parseMatchingManifest(manifest, protocol),
-        Result.mapError((failure): readonly RiskBalancedTrendEvaluationIssue[] => [failure]),
-        Result.flatMap((inputManifest) => evaluateRiskBalancedTrend(bars, inputManifest, protocol, provenance)),
-      ),
-    currentDecision: (bars, manifest, cycleBinding) =>
-      pipe(
-        parseMatchingManifest(manifest, protocol),
-        Result.flatMap((inputManifest) =>
-          compileCurrentRiskBalancedTrendDecision(bars, inputManifest, protocol, cycleBinding),
-        ),
-      ),
-    prepareLock: (manifest, sessionDates, priorTrialRunIds) =>
-      pipe(
-        parseMatchingManifest(manifest, protocol),
-        Result.flatMap((inputManifest) =>
-          pipe(
-            Result.all({
-              precommit: prepareRiskBalancedTrendQualification(sessionDates, inputManifest, protocol, provenance),
-              benchmarkPolicy: makeQualificationPolicyDocument('bayn.risk-balanced-trend-benchmark-policy.v1', {
-                schemaVersion: 'bayn.risk-balanced-trend-benchmark-policy.v1',
-                comparison: 'stronger-of-buy-and-hold-or-direct-volatility-timing',
-                excessReturnBasis: 'after-cost-over-cash',
-                sharpeBasis: 'daily-excess-over-cash',
-                alignment: 'candidate-sessions-and-exposure-rules',
-              }),
-              thresholdPolicy: makeQualificationPolicyDocument('bayn.risk-balanced-trend-threshold-policy.v1', {
-                schemaVersion: 'bayn.risk-balanced-trend-threshold-policy.v1',
-                thresholds: protocol.thresholds,
-              }),
-              uncertaintyPolicy: defaultQualificationStatisticsPolicyDocument,
-              executionPolicy: makeQualificationPolicyDocument(
-                protocol.executionModel.schemaVersion,
-                protocol.executionModel,
-              ),
-            }),
-            Result.flatMap(({ benchmarkPolicy, executionPolicy, precommit, thresholdPolicy, uncertaintyPolicy }) => {
-              const snapshot = inputManifest.finalizedSnapshot
-              return makeQualificationLock({
-                schemaVersion: 'bayn.qualification-lock.v3',
-                candidateRunId: precommit.candidateRunId,
-                protocolHash: precommit.protocolHash,
-                sourceRevision: provenance.sourceRevision,
-                image: provenance.image,
-                universeId: protocol.universeId,
-                universeSymbolHash: protocol.universeSymbolHash,
-                universe: protocol.universe,
-                universeRationale,
-                data: {
-                  snapshotId: snapshot.snapshotId,
-                  publicationId: snapshot.publicationId,
-                  inputManifestHash: inputManifest.hash,
-                  contentHash: snapshot.contentHash,
-                  sessionsContentHash: snapshot.sessionsContentHash,
-                  provider: snapshot.source,
-                  sourceFeed: snapshot.sourceFeed,
-                  adjustment: snapshot.adjustment,
-                  calendarVersion: snapshot.calendarVersion,
-                  firstSession: snapshot.firstSession,
-                  lastSession: snapshot.lastSession,
-                  selectedSessionCount: precommit.selectedSessionCount,
-                  selectedRebalanceCount: precommit.selectedRebalanceCount,
-                  bounds: inputManifest.bounds,
-                },
-                policies: {
-                  benchmark: benchmarkPolicy,
-                  thresholds: thresholdPolicy,
-                  uncertainty: uncertaintyPolicy,
-                  execution: executionPolicy,
-                },
-                priorTrialRunIds,
-              })
-            }),
-          ),
-        ),
-      ),
-    analyze: (evaluation, priorTrialRunIds) =>
-      pipe(
-        prepareQualificationSeries(evaluation),
-        Result.flatMap((series) =>
-          analyzeQualification(series, defaultQualificationStatisticsPolicy, priorTrialRunIds),
-        ),
-      ),
-  }
-}
+/** Compatibility entry point retained for the unowned runtime callers. */
+export const makeStrategy = makeRiskBalancedTrendStrategy

--- a/services/bayn/src/strategy/core.ts
+++ b/services/bayn/src/strategy/core.ts
@@ -1,0 +1,30 @@
+import type { Result } from 'effect'
+
+/** A concrete strategy closes this to its finite tagged decision-failure union. */
+export interface StrategyDecisionFailure {
+  readonly _tag: string
+}
+
+/** The common output consumed by later portfolio planning stages. */
+export interface StrategyTargetPortfolio {
+  readonly targetWeights: Readonly<Record<string, number>>
+}
+
+/** Inputs verified by the caller before a pure strategy decision is requested. */
+export interface VerifiedStrategyContext<TMarket, TPortfolio> {
+  readonly market: TMarket
+  readonly portfolio: TPortfolio
+}
+
+/** Pure strategy identity and decision boundary shared by development and runtimes. */
+export interface StrategyDefinition<
+  TParameters,
+  TMarket,
+  TPortfolio,
+  TTargetPortfolio extends StrategyTargetPortfolio,
+  TFailure extends StrategyDecisionFailure,
+> {
+  readonly name: string
+  readonly parameters: TParameters
+  readonly decide: (context: VerifiedStrategyContext<TMarket, TPortfolio>) => Result.Result<TTargetPortfolio, TFailure>
+}

--- a/services/bayn/src/strategy/risk-balanced-trend/decision.ts
+++ b/services/bayn/src/strategy/risk-balanced-trend/decision.ts
@@ -1,8 +1,9 @@
 import { Result, pipe } from 'effect'
 
 import { canonicalHashResult, requiredRecordValue, requiredSession, type AlignedSession } from '../../simulation'
-import { ContractVersion, type IsoDate, type Protocol } from '../../types'
-import type { RiskBalancedTrendDecision } from '../../risk-balanced-trend/model'
+import { ContractVersion, type DecisionPlan, type IsoDate, type Protocol } from '../../types'
+import type { RiskBalancedTrendDecision, RiskBalancedTrendFailure } from '../../risk-balanced-trend/model'
+import type { StrategyDefinition, StrategyTargetPortfolio, VerifiedStrategyContext } from '../core'
 import { quantizeWeights, redistributeWithCap } from './allocation'
 import { annualizedPortfolioVolatility } from './risk'
 import { finalizeSignals, prepareSignal, type PreparedSignal } from './signals'
@@ -158,6 +159,35 @@ export const makeRiskBalancedTrendDecision = (
   )
 }
 
+export interface RiskBalancedTrendMarketContext {
+  readonly signalDate: IsoDate
+  readonly sessionDates: readonly IsoDate[]
+  readonly closes: Readonly<Record<string, readonly number[]>>
+}
+
+export interface RiskBalancedTrendPortfolioContext {
+  readonly positions: Readonly<Record<string, number>>
+}
+
+export type RiskBalancedTrendTargetPortfolio = DecisionPlan & StrategyTargetPortfolio
+
+export type RiskBalancedTrendStrategyDefinition = StrategyDefinition<
+  Protocol,
+  RiskBalancedTrendMarketContext,
+  RiskBalancedTrendPortfolioContext,
+  RiskBalancedTrendTargetPortfolio,
+  RiskBalancedTrendFailure
+>
+
+export const makeRiskBalancedTrendDefinition = (protocol: Protocol): RiskBalancedTrendStrategyDefinition => ({
+  name: 'risk-balanced-trend',
+  parameters: protocol,
+  decide: ({ market }: VerifiedStrategyContext<RiskBalancedTrendMarketContext, RiskBalancedTrendPortfolioContext>) =>
+    makeRiskBalancedTrendDecision(market.signalDate, market.sessionDates, market.closes, protocol),
+})
+
+const emptyPortfolioContext: RiskBalancedTrendPortfolioContext = { positions: {} }
+
 export const decisionFromAlignedSessions = (
   sessions: readonly AlignedSession[],
   signalIndex: number,
@@ -178,12 +208,14 @@ export const decisionFromAlignedSessions = (
           ),
         ),
         Result.flatMap((closes) =>
-          makeRiskBalancedTrendDecision(
-            signalSession.date,
-            history.map((session) => session.date),
-            Object.fromEntries(closes),
-            protocol,
-          ),
+          makeRiskBalancedTrendDefinition(protocol).decide({
+            market: {
+              signalDate: signalSession.date,
+              sessionDates: history.map((session) => session.date),
+              closes: Object.fromEntries(closes),
+            },
+            portfolio: emptyPortfolioContext,
+          }),
         ),
       )
     }),

--- a/services/bayn/src/strategy/risk-balanced-trend/index.ts
+++ b/services/bayn/src/strategy/risk-balanced-trend/index.ts
@@ -1,0 +1,9 @@
+export { makeRiskBalancedTrendDefinition } from './decision'
+export type {
+  RiskBalancedTrendMarketContext,
+  RiskBalancedTrendPortfolioContext,
+  RiskBalancedTrendStrategyDefinition,
+  RiskBalancedTrendTargetPortfolio,
+} from './decision'
+export { makeRiskBalancedTrendStrategy } from './strategy'
+export type { RiskBalancedTrendStrategy, RiskBalancedTrendStrategyPrepareLockFailure } from './strategy'

--- a/services/bayn/src/strategy/risk-balanced-trend/strategy.ts
+++ b/services/bayn/src/strategy/risk-balanced-trend/strategy.ts
@@ -1,0 +1,155 @@
+import { pipe, Result } from 'effect'
+
+import type { RuntimeProvenance } from '../../contracts'
+import {
+  defaultQualificationStatisticsPolicyDocument,
+  makeQualificationLock,
+  makeQualificationPolicyDocument,
+  type QualificationConstructionFailure,
+  type QualificationLock,
+} from '../../qualification'
+import {
+  analyzeQualification,
+  defaultQualificationStatisticsPolicy,
+  prepareQualificationSeries,
+  type QualificationAnalysis,
+  type QualificationStatisticsFailure,
+} from '../../qualification-statistics'
+import {
+  compileCurrentRiskBalancedTrendDecision,
+  evaluateRiskBalancedTrend,
+  parseMatchingManifest,
+  prepareRiskBalancedTrendQualification,
+  type CurrentDecisionCycleBinding,
+  type CurrentRiskBalancedTrendDecision,
+  type RiskBalancedTrendEvaluationIssue,
+  type RiskBalancedTrendFailure,
+} from '../../risk-balanced-trend'
+import type { DailyBar, EvaluationResult, InputManifest, IsoDate, Protocol } from '../../types'
+import { makeRiskBalancedTrendDefinition } from './decision'
+
+export type RiskBalancedTrendStrategyPrepareLockFailure = RiskBalancedTrendFailure | QualificationConstructionFailure
+
+export interface RiskBalancedTrendStrategy {
+  readonly name: string
+  readonly parameters: Protocol
+  readonly provenance: RuntimeProvenance
+  readonly evaluate: (
+    bars: readonly DailyBar[],
+    manifest: InputManifest,
+  ) => Result.Result<EvaluationResult, readonly RiskBalancedTrendEvaluationIssue[]>
+  readonly currentDecision: (
+    bars: readonly DailyBar[],
+    manifest: InputManifest,
+    cycleBinding: CurrentDecisionCycleBinding,
+  ) => Result.Result<CurrentRiskBalancedTrendDecision, RiskBalancedTrendFailure>
+  readonly prepareLock: (
+    manifest: InputManifest,
+    sessionDates: readonly IsoDate[],
+    priorTrialRunIds: readonly string[],
+  ) => Result.Result<QualificationLock, RiskBalancedTrendStrategyPrepareLockFailure>
+  readonly analyze: (
+    evaluation: EvaluationResult,
+    priorTrialRunIds: readonly string[],
+  ) => Result.Result<QualificationAnalysis, QualificationStatisticsFailure>
+}
+
+const universeRationale =
+  'The precommitted five-sleeve cross-asset universe uses broad commodities (DBC), developed ex-US equities (EFA), intermediate US Treasuries (IEF), US equities (SPY), and US real estate (VNQ); symbols were fixed without inspecting candidate prices or returns.'
+
+export const makeRiskBalancedTrendStrategy = (
+  protocol: Protocol,
+  provenance: RuntimeProvenance,
+): RiskBalancedTrendStrategy => {
+  const definition = makeRiskBalancedTrendDefinition(protocol)
+
+  return {
+    name: definition.name,
+    parameters: definition.parameters,
+    provenance,
+    evaluate: (bars, manifest) =>
+      pipe(
+        parseMatchingManifest(manifest, protocol),
+        Result.mapError((failure): readonly RiskBalancedTrendEvaluationIssue[] => [failure]),
+        Result.flatMap((inputManifest) => evaluateRiskBalancedTrend(bars, inputManifest, protocol, provenance)),
+      ),
+    currentDecision: (bars, manifest, cycleBinding) =>
+      pipe(
+        parseMatchingManifest(manifest, protocol),
+        Result.flatMap((inputManifest) =>
+          compileCurrentRiskBalancedTrendDecision(bars, inputManifest, protocol, cycleBinding),
+        ),
+      ),
+    prepareLock: (manifest, sessionDates, priorTrialRunIds) =>
+      pipe(
+        parseMatchingManifest(manifest, protocol),
+        Result.flatMap((inputManifest) =>
+          pipe(
+            Result.all({
+              precommit: prepareRiskBalancedTrendQualification(sessionDates, inputManifest, protocol, provenance),
+              benchmarkPolicy: makeQualificationPolicyDocument('bayn.risk-balanced-trend-benchmark-policy.v1', {
+                schemaVersion: 'bayn.risk-balanced-trend-benchmark-policy.v1',
+                comparison: 'stronger-of-buy-and-hold-or-direct-volatility-timing',
+                excessReturnBasis: 'after-cost-over-cash',
+                sharpeBasis: 'daily-excess-over-cash',
+                alignment: 'candidate-sessions-and-exposure-rules',
+              }),
+              thresholdPolicy: makeQualificationPolicyDocument('bayn.risk-balanced-trend-threshold-policy.v1', {
+                schemaVersion: 'bayn.risk-balanced-trend-threshold-policy.v1',
+                thresholds: protocol.thresholds,
+              }),
+              uncertaintyPolicy: defaultQualificationStatisticsPolicyDocument,
+              executionPolicy: makeQualificationPolicyDocument(
+                protocol.executionModel.schemaVersion,
+                protocol.executionModel,
+              ),
+            }),
+            Result.flatMap(({ benchmarkPolicy, executionPolicy, precommit, thresholdPolicy, uncertaintyPolicy }) => {
+              const snapshot = inputManifest.finalizedSnapshot
+              return makeQualificationLock({
+                schemaVersion: 'bayn.qualification-lock.v3',
+                candidateRunId: precommit.candidateRunId,
+                protocolHash: precommit.protocolHash,
+                sourceRevision: provenance.sourceRevision,
+                image: provenance.image,
+                universeId: protocol.universeId,
+                universeSymbolHash: protocol.universeSymbolHash,
+                universe: protocol.universe,
+                universeRationale,
+                data: {
+                  snapshotId: snapshot.snapshotId,
+                  publicationId: snapshot.publicationId,
+                  inputManifestHash: inputManifest.hash,
+                  contentHash: snapshot.contentHash,
+                  sessionsContentHash: snapshot.sessionsContentHash,
+                  provider: snapshot.source,
+                  sourceFeed: snapshot.sourceFeed,
+                  adjustment: snapshot.adjustment,
+                  calendarVersion: snapshot.calendarVersion,
+                  firstSession: snapshot.firstSession,
+                  lastSession: snapshot.lastSession,
+                  selectedSessionCount: precommit.selectedSessionCount,
+                  selectedRebalanceCount: precommit.selectedRebalanceCount,
+                  bounds: inputManifest.bounds,
+                },
+                policies: {
+                  benchmark: benchmarkPolicy,
+                  thresholds: thresholdPolicy,
+                  uncertainty: uncertaintyPolicy,
+                  execution: executionPolicy,
+                },
+                priorTrialRunIds,
+              })
+            }),
+          ),
+        ),
+      ),
+    analyze: (evaluation, priorTrialRunIds) =>
+      pipe(
+        prepareQualificationSeries(evaluation),
+        Result.flatMap((series) =>
+          analyzeQualification(series, defaultQualificationStatisticsPolicy, priorTrialRunIds),
+        ),
+      ),
+  }
+}


### PR DESCRIPTION
## Summary

- Introduce a small pure `StrategyDefinition` contract over verified market and portfolio context with typed Result failures.
- Move the risk-balanced trend runtime facade behind an explicit concrete adapter and preserve its existing evaluation, qualification, provenance, and decision behavior.
- Route aligned-session decisions through the generic definition and add target/hash causal-equivalence coverage.
- Make application-plan composition select the single explicit risk-balanced trend strategy at the composition root.

## Related Issues

None

## Testing

- `bun test services/bayn/src/risk-balanced-trend.test.ts services/bayn/src/app.test.ts`
- `bun run --filter @proompteng/bayn test`
- `bun run --filter @proompteng/bayn test:postgres` (all PostgreSQL tests skipped because no database was configured)
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:effect`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn build`

## Breaking Changes

None. Existing runtime callers retain the compatibility facade; future strategy consumers can use `StrategyDefinition`.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
