### PR TITLE
fix(bayn): bind qualification bootstrap policy to ordinal horizon

### DIFF
--- a/services/bayn/src/candidate-development-domain/attempt.ts
+++ b/services/bayn/src/candidate-development-domain/attempt.ts
@@ -1,6 +1,7 @@
 import { Result } from 'effect'
 
 import { canonicalHashV1Result, type CanonicalHashFailure } from '../hash'
+import { qualificationTailCapacityForOrdinal } from '../qualification-statistics'
 import {
   candidateDevelopmentAttemptHorizon,
   candidateDevelopmentProtocol,
@@ -65,20 +66,19 @@ export const bindCandidateDevelopmentAttempt = (
     })
   }
 
-  const adjustedOneSidedAlpha = candidateDevelopmentStatisticsPolicy.confidence.familyOneSidedAlpha / candidateOrdinal
-  const tailSampleCount = Math.floor(candidateDevelopmentStatisticsPolicy.bootstrap.samples * adjustedOneSidedAlpha)
+  const tailCapacity = qualificationTailCapacityForOrdinal(candidateDevelopmentStatisticsPolicy, candidateOrdinal)
   const capacity = {
     candidateOrdinal,
     priorTrialCount,
     bootstrapSamples: candidateDevelopmentStatisticsPolicy.bootstrap.samples,
-    adjustedOneSidedAlpha,
-    tailSampleCount,
-    minimumTailSamples: candidateDevelopmentStatisticsPolicy.confidence.minimumTailSamples,
+    adjustedOneSidedAlpha: tailCapacity.adjustedOneSidedAlpha,
+    tailSampleCount: tailCapacity.tailSampleCount,
+    minimumTailSamples: tailCapacity.minimumTailSamples,
     maximumCandidateOrdinal: candidateDevelopmentAttemptHorizon.maximumCandidateOrdinal,
   }
 
   return candidateOrdinal <= candidateDevelopmentAttemptHorizon.maximumCandidateOrdinal &&
-    tailSampleCount >= candidateDevelopmentStatisticsPolicy.confidence.minimumTailSamples
+    tailCapacity.tailSampleCount >= candidateDevelopmentStatisticsPolicy.confidence.minimumTailSamples
     ? Result.succeed(capacity)
     : Result.fail({ _tag: 'CandidateDevelopmentBootstrapTailInfeasible', ...capacity })
 }

--- a/services/bayn/src/candidate-development-domain/protocol.ts
+++ b/services/bayn/src/candidate-development-domain/protocol.ts
@@ -1,3 +1,5 @@
+import { Result } from 'effect'
+
 import {
   makeQualificationStatisticsPolicy,
   qualificationPolicyMaximumCandidateOrdinal,
@@ -63,13 +65,15 @@ export const candidateDevelopmentDoubledCostContract = {
   invariants: ['signal-decisions', 'ordered-order-quantity-path'],
 } as const
 
-export const candidateDevelopmentStatisticsPolicy = makeQualificationStatisticsPolicy({
-  maximumCandidateOrdinal: candidateDevelopmentAttemptHorizon.maximumCandidateOrdinal,
-  walkForward: {
-    testSessions: candidateDevelopmentWalkForwardProtocol.testSessions,
-    minimumFolds: candidateDevelopmentWalkForwardProtocol.requiredFolds,
-  },
-}) satisfies QualificationStatisticsPolicy
+export const candidateDevelopmentStatisticsPolicy = Result.getOrThrow(
+  makeQualificationStatisticsPolicy({
+    maximumCandidateOrdinal: candidateDevelopmentAttemptHorizon.maximumCandidateOrdinal,
+    walkForward: {
+      testSessions: candidateDevelopmentWalkForwardProtocol.testSessions,
+      minimumFolds: candidateDevelopmentWalkForwardProtocol.requiredFolds,
+    },
+  }),
+) satisfies QualificationStatisticsPolicy
 
 export const candidateDevelopmentComparisonSemantics = {
   schemaVersion: 'bayn.candidate-development-comparison-semantics.v2',

--- a/services/bayn/src/candidate-development-domain/protocol.ts
+++ b/services/bayn/src/candidate-development-domain/protocol.ts
@@ -1,5 +1,6 @@
 import {
-  defaultQualificationStatisticsPolicy,
+  makeQualificationStatisticsPolicy,
+  qualificationPolicyMaximumCandidateOrdinal,
   qualificationSelectedBenchmarkRule,
   type QualificationStatisticsPolicy,
 } from '../qualification-statistics'
@@ -20,9 +21,9 @@ export const candidateDevelopmentCalendarContract = {
  * 252-session causal lookback and next-session execution inside the frozen 1,762-session development calendar.
  * Latest-contiguous selection maximizes recency while deriving every boundary only from the frozen calendar and
  * preregistered geometry, never from realized returns.
- * Terminal qualification continues to use defaultQualificationStatisticsPolicy unchanged. Its paired complete-block
- * bootstrap also remains unchanged and samples only observed, non-wrapping rebalance blocks, following the dependent
- * block-resampling principle of Künsch (1989, doi:10.1214/aos/1176347265).
+ * Development and terminal qualification share one ordinal-bound statistics policy. Its paired complete-block bootstrap
+ * samples only observed, non-wrapping rebalance blocks, following the dependent block-resampling principle of Künsch
+ * (1989, doi:10.1214/aos/1176347265).
  */
 export const candidateDevelopmentWalkForwardProtocol = {
   method: 'expanding-origin',
@@ -36,7 +37,7 @@ export const candidateDevelopmentWalkForwardProtocol = {
 
 export const candidateDevelopmentAttemptHorizon = {
   schemaVersion: 'bayn.candidate-development-attempt-horizon.v1',
-  maximumCandidateOrdinal: 25,
+  maximumCandidateOrdinal: qualificationPolicyMaximumCandidateOrdinal,
   ordinalBinding: 'candidate-ordinal-equals-prior-trial-count-plus-one',
 } as const
 
@@ -62,23 +63,13 @@ export const candidateDevelopmentDoubledCostContract = {
   invariants: ['signal-decisions', 'ordered-order-quantity-path'],
 } as const
 
-export const candidateDevelopmentBootstrapSamples = 10_000
-
-export const candidateDevelopmentStatisticsPolicy = {
-  ...defaultQualificationStatisticsPolicy,
-  confidence: { ...defaultQualificationStatisticsPolicy.confidence },
-  bootstrap: {
-    ...defaultQualificationStatisticsPolicy.bootstrap,
-    samples: candidateDevelopmentBootstrapSamples,
-  },
-  power: { ...defaultQualificationStatisticsPolicy.power },
+export const candidateDevelopmentStatisticsPolicy = makeQualificationStatisticsPolicy({
+  maximumCandidateOrdinal: candidateDevelopmentAttemptHorizon.maximumCandidateOrdinal,
   walkForward: {
-    ...defaultQualificationStatisticsPolicy.walkForward,
     testSessions: candidateDevelopmentWalkForwardProtocol.testSessions,
     minimumFolds: candidateDevelopmentWalkForwardProtocol.requiredFolds,
   },
-  cashReturn: { ...defaultQualificationStatisticsPolicy.cashReturn },
-} as const satisfies QualificationStatisticsPolicy
+}) satisfies QualificationStatisticsPolicy
 
 export const candidateDevelopmentComparisonSemantics = {
   schemaVersion: 'bayn.candidate-development-comparison-semantics.v2',

--- a/services/bayn/src/candidate-development.test.ts
+++ b/services/bayn/src/candidate-development.test.ts
@@ -5,7 +5,6 @@ import {
   bindCandidateDevelopmentAttempt,
   buildCandidateDevelopmentComparisonSemanticsEvidence,
   candidateDevelopmentAttemptHorizon,
-  candidateDevelopmentBootstrapSamples,
   candidateDevelopmentCalendarContract,
   candidateDevelopmentComparisonSemantics,
   candidateDevelopmentDoubledCostContract,
@@ -30,6 +29,7 @@ import { canonicalHashV1Result } from './hash'
 import { makeEvaluationIdentity } from './simulation'
 import {
   defaultQualificationStatisticsPolicy,
+  qualificationTailCapacityForOrdinal,
   prepareQualificationSeries,
   type QualificationSeries,
 } from './qualification-statistics'
@@ -552,13 +552,30 @@ describe('candidate development walk-forward protocol', () => {
     }
   })
 
-  test('binds Candidate 13 and the deterministic bootstrap horizon before any effects', () => {
+  test('binds every declared ordinal to the shared deterministic bootstrap horizon before any effects', () => {
     const candidate13 = successOf(bindCandidateDevelopmentAttempt(13, 12))
+    const candidate21 = successOf(bindCandidateDevelopmentAttempt(21, 20))
     const horizon = successOf(bindCandidateDevelopmentAttempt(25, 24))
 
-    expect(candidateDevelopmentBootstrapSamples).toBe(10_000)
     expect(candidateDevelopmentStatisticsPolicy.bootstrap.samples).toBe(10_000)
-    expect(defaultQualificationStatisticsPolicy.bootstrap.samples).toBe(5_000)
+    expect(defaultQualificationStatisticsPolicy.bootstrap.samples).toBe(10_000)
+    expect(candidateDevelopmentStatisticsPolicy.confidence).toEqual(defaultQualificationStatisticsPolicy.confidence)
+    expect(candidateDevelopmentStatisticsPolicy.bootstrap).toEqual(defaultQualificationStatisticsPolicy.bootstrap)
+    for (
+      let candidateOrdinal = 1;
+      candidateOrdinal <= candidateDevelopmentAttemptHorizon.maximumCandidateOrdinal;
+      candidateOrdinal += 1
+    ) {
+      const attempt = successOf(bindCandidateDevelopmentAttempt(candidateOrdinal, candidateOrdinal - 1))
+      const terminalCapacity = qualificationTailCapacityForOrdinal(
+        defaultQualificationStatisticsPolicy,
+        candidateOrdinal,
+      )
+      expect(attempt.tailSampleCount).toBe(terminalCapacity.tailSampleCount)
+      expect(attempt.tailSampleCount).toBeGreaterThanOrEqual(
+        defaultQualificationStatisticsPolicy.confidence.minimumTailSamples,
+      )
+    }
     expect(bindCandidateDevelopmentAttempt(13, 11)).toEqual(
       Result.fail({
         _tag: 'CandidateDevelopmentAttemptLineageMismatch',
@@ -575,8 +592,8 @@ describe('candidate development walk-forward protocol', () => {
       minimumTailSamples: 20,
       maximumCandidateOrdinal: 25,
     })
+    expect(candidate21.tailSampleCount).toBe(23)
     expect(horizon.tailSampleCount).toBe(20)
-    expect(Math.floor((candidateDevelopmentBootstrapSamples - 1) * (0.05 / 25))).toBe(19)
     expect(bindCandidateDevelopmentAttempt(26, 25)).toMatchObject(
       Result.fail({
         _tag: 'CandidateDevelopmentBootstrapTailInfeasible',
@@ -1223,7 +1240,7 @@ describe('candidate development walk-forward protocol', () => {
       },
       bootstrap: {
         method: 'paired-complete-rebalance-blocks',
-        samples: 5_000,
+        samples: 10_000,
         seedNamespace: 'bayn-risk-balanced-trend-qualification-v1',
         lowerQuantile: 'nearest-rank',
       },
@@ -1237,7 +1254,7 @@ describe('candidate development walk-forward protocol', () => {
       },
     })
     expect(successOf(canonicalHashV1Result(defaultQualificationStatisticsPolicy))).toBe(
-      '8090c35a5e76e02bde5c74f7a71b5d0b005c3e0409165fde96f2748e827e88de',
+      '79a2e1048e51c90f5fd61e6fde0e052847c61570556838c06a718ce0dbd5839e',
     )
   })
 

--- a/services/bayn/src/qualification-audit.test.ts
+++ b/services/bayn/src/qualification-audit.test.ts
@@ -353,7 +353,7 @@ describe('qualification audit', () => {
     ])
     expect(first.policies.policySetHash).toBe(canonicalHashV1(first.policies.documents))
     expect(second.auditHash).toBe(first.auditHash)
-    expect(first.auditHash).toBe('864443531b3431094e3750f21436e79b1d6447043608e88192b4749a976268b3')
+    expect(first.auditHash).toBe('b95f97dfe898fff9fd248d2ef44b66509cde232b56903d77ac9a3c8fe840ba2c')
   })
 
   test('passes for a later candidate when prior terminal result lineage is complete', () => {

--- a/services/bayn/src/qualification-statistics.test.ts
+++ b/services/bayn/src/qualification-statistics.test.ts
@@ -96,9 +96,11 @@ const policy = (overrides: Partial<QualificationStatisticsPolicy> = {}): Qualifi
 
 describe('qualification statistics policy and power', () => {
   test('derives one exact policy for the declared ordinal horizon and preserves historical v1 decoding', () => {
-    const policyFromHorizon = makeQualificationStatisticsPolicy({
-      maximumCandidateOrdinal: qualificationPolicyMaximumCandidateOrdinal,
-    })
+    const policyFromHorizon = successOf(
+      makeQualificationStatisticsPolicy({
+        maximumCandidateOrdinal: qualificationPolicyMaximumCandidateOrdinal,
+      }),
+    )
 
     expect(policyFromHorizon).toEqual(defaultQualificationStatisticsPolicy)
     expect(defaultQualificationStatisticsPolicy).toMatchObject({
@@ -132,6 +134,28 @@ describe('qualification statistics policy and power', () => {
     }
     const decode = Schema.decodeUnknownSync(QualificationStatisticsPolicySchema, { onExcessProperty: 'error' })
     expect(decode(historicalPolicy)).toEqual(historicalPolicy)
+  })
+
+  test('rejects policy options that cannot produce schema-valid policies', () => {
+    expect(Result.isFailure(makeQualificationStatisticsPolicy({ maximumCandidateOrdinal: 0 }))).toBe(true)
+    expect(Result.isFailure(makeQualificationStatisticsPolicy({ maximumCandidateOrdinal: 1.5 }))).toBe(true)
+    expect(Result.isFailure(makeQualificationStatisticsPolicy({ maximumCandidateOrdinal: 251 }))).toBe(true)
+    expect(
+      Result.isFailure(
+        makeQualificationStatisticsPolicy({
+          maximumCandidateOrdinal: qualificationPolicyMaximumCandidateOrdinal,
+          walkForward: { testSessions: 0 },
+        }),
+      ),
+    ).toBe(true)
+    expect(
+      Result.isFailure(
+        makeQualificationStatisticsPolicy({
+          maximumCandidateOrdinal: qualificationPolicyMaximumCandidateOrdinal,
+          walkForward: { minimumFolds: 1.5 },
+        }),
+      ),
+    ).toBe(true)
   })
 
   test('strictly decodes the precommit and rejects invalid or unknown fields', () => {

--- a/services/bayn/src/qualification-statistics.test.ts
+++ b/services/bayn/src/qualification-statistics.test.ts
@@ -12,7 +12,10 @@ import {
   analyzeSelectedBenchmarkComparison,
   calculateQualificationPower,
   defaultQualificationStatisticsPolicy,
+  makeQualificationStatisticsPolicy,
   prepareQualificationSeries,
+  qualificationPolicyMaximumCandidateOrdinal,
+  qualificationTailCapacityForOrdinal,
   qualificationSelectedBenchmarkRule,
   selectQualificationBenchmarkFromCashAdjustedSharpes,
   type QualificationSeries,
@@ -92,6 +95,45 @@ const policy = (overrides: Partial<QualificationStatisticsPolicy> = {}): Qualifi
 })
 
 describe('qualification statistics policy and power', () => {
+  test('derives one exact policy for the declared ordinal horizon and preserves historical v1 decoding', () => {
+    const policyFromHorizon = makeQualificationStatisticsPolicy({
+      maximumCandidateOrdinal: qualificationPolicyMaximumCandidateOrdinal,
+    })
+
+    expect(policyFromHorizon).toEqual(defaultQualificationStatisticsPolicy)
+    expect(defaultQualificationStatisticsPolicy).toMatchObject({
+      schemaVersion: 'bayn.qualification-statistics-policy.v1',
+      confidence: {
+        familyOneSidedAlpha: 0.05,
+        multiplicityAdjustment: 'bonferroni',
+        minimumTailSamples: 20,
+      },
+      bootstrap: { samples: 10_000 },
+    })
+    for (
+      let candidateOrdinal = 1;
+      candidateOrdinal <= qualificationPolicyMaximumCandidateOrdinal;
+      candidateOrdinal += 1
+    ) {
+      const capacity = qualificationTailCapacityForOrdinal(defaultQualificationStatisticsPolicy, candidateOrdinal)
+      expect(capacity.candidateOrdinal).toBe(candidateOrdinal)
+      expect(capacity.tailSampleCount).toBeGreaterThanOrEqual(20)
+      expect(capacity.minimumTailSamples).toBe(20)
+    }
+    expect(qualificationTailCapacityForOrdinal(defaultQualificationStatisticsPolicy, 21)).toMatchObject({
+      candidateOrdinal: 21,
+      adjustedOneSidedAlpha: 0.05 / 21,
+      tailSampleCount: 23,
+    })
+
+    const historicalPolicy: QualificationStatisticsPolicy = {
+      ...defaultQualificationStatisticsPolicy,
+      bootstrap: { ...defaultQualificationStatisticsPolicy.bootstrap, samples: 5_000 },
+    }
+    const decode = Schema.decodeUnknownSync(QualificationStatisticsPolicySchema, { onExcessProperty: 'error' })
+    expect(decode(historicalPolicy)).toEqual(historicalPolicy)
+  })
+
   test('strictly decodes the precommit and rejects invalid or unknown fields', () => {
     const decode = Schema.decodeUnknownSync(QualificationStatisticsPolicySchema, {
       onExcessProperty: 'error',

--- a/services/bayn/src/qualification-statistics.ts
+++ b/services/bayn/src/qualification-statistics.ts
@@ -16,7 +16,6 @@ export {
   QualificationAnalysisSchema,
   QualificationSeriesSchema,
   QualificationStatisticsPolicySchema,
-  defaultQualificationStatisticsPolicy,
   type PowerAnalysis,
   type QualificationAnalysis,
   type QualificationAnalysisInput,
@@ -24,6 +23,15 @@ export {
   type QualificationSeries,
   type QualificationStatisticsPolicy,
 } from './qualification-statistics/model'
+export {
+  defaultQualificationStatisticsPolicy,
+  makeQualificationStatisticsPolicy,
+  qualificationPolicyMaximumCandidateOrdinal,
+  qualificationStatisticsPolicySchemaVersion,
+  qualificationTailCapacityForOrdinal,
+  type QualificationOrdinalTailCapacity,
+  type QualificationStatisticsPolicyOptions,
+} from './qualification-statistics/policy'
 export {
   renderQualificationStatisticsFailure,
   type QualificationStatisticsFailure,

--- a/services/bayn/src/qualification-statistics.ts
+++ b/services/bayn/src/qualification-statistics.ts
@@ -29,8 +29,10 @@ export {
   qualificationPolicyMaximumCandidateOrdinal,
   qualificationStatisticsPolicySchemaVersion,
   qualificationTailCapacityForOrdinal,
+  type QualificationStatisticsPolicyConstructionFailure,
   type QualificationOrdinalTailCapacity,
   type QualificationStatisticsPolicyOptions,
+  type QualificationStatisticsPolicyResult,
 } from './qualification-statistics/policy'
 export {
   renderQualificationStatisticsFailure,

--- a/services/bayn/src/qualification-statistics/bootstrap.ts
+++ b/services/bayn/src/qualification-statistics/bootstrap.ts
@@ -9,6 +9,7 @@ import type {
   QualificationStatisticsPolicy,
 } from './model'
 import { annualizedSharpe, mean, nearestRankLowerQuantile, roundStatistic } from './numerical-methods'
+import { qualificationTailCapacityForOrdinal } from './policy'
 import type { CompleteBlockWork } from './series'
 
 export const qualificationSelectedBenchmarkRule = {
@@ -166,9 +167,9 @@ export const runQualificationBootstrap = (
   policy: QualificationStatisticsPolicy,
   priorTrialCount: number,
 ): Result.Result<BootstrapAnalysis, QualificationStatisticsFailure> => {
+  const candidateOrdinal = priorTrialCount + 1
   const benchmark = selectQualificationBenchmark(series.observations, policy.annualizationSessions)
-  const adjustedOneSidedAlpha = policy.confidence.familyOneSidedAlpha / (priorTrialCount + 1)
-  const tailSampleCount = Math.floor(policy.bootstrap.samples * adjustedOneSidedAlpha)
+  const { adjustedOneSidedAlpha, tailSampleCount } = qualificationTailCapacityForOrdinal(policy, candidateOrdinal)
   return pipe(
     hashQualificationEvidence('bootstrap-seed', {
       schemaVersion: 'bayn.qualification-bootstrap-seed.v1',
@@ -282,9 +283,9 @@ export const runSelectedBenchmarkBootstrapComparison = (
   policy: QualificationStatisticsPolicy,
   priorTrialCount: number,
 ): Result.Result<QualificationSelectedBenchmarkBootstrapComparison, QualificationStatisticsFailure> => {
+  const candidateOrdinal = priorTrialCount + 1
   const benchmark = selectQualificationBenchmark(series.observations, policy.annualizationSessions)
-  const adjustedOneSidedAlpha = policy.confidence.familyOneSidedAlpha / (priorTrialCount + 1)
-  const tailSampleCount = Math.floor(policy.bootstrap.samples * adjustedOneSidedAlpha)
+  const { adjustedOneSidedAlpha, tailSampleCount } = qualificationTailCapacityForOrdinal(policy, candidateOrdinal)
   return pipe(
     hashQualificationEvidence('bootstrap-seed', {
       schemaVersion: 'bayn.qualification-bootstrap-seed.v1',

--- a/services/bayn/src/qualification-statistics/model.ts
+++ b/services/bayn/src/qualification-statistics/model.ts
@@ -15,8 +15,7 @@ const PositiveUnitInterval = Schema.Finite.check(Schema.isGreaterThan(0), Schema
 const SimpleReturn = Schema.Finite.check(Schema.isGreaterThanOrEqualTo(-1))
 const Scalar = Schema.Union([Schema.Finite, Schema.Boolean, Schema.String])
 
-export const QualificationStatisticsPolicySchema = Schema.Struct({
-  schemaVersion: Schema.Literal('bayn.qualification-statistics-policy.v1'),
+const QualificationStatisticsPolicyFields = {
   annualizationSessions: Schema.Literal(252),
   confidence: Schema.Struct({
     familyOneSidedAlpha: Schema.Literal(0.05),
@@ -50,43 +49,13 @@ export const QualificationStatisticsPolicySchema = Schema.Struct({
   cashReturn: Schema.Struct({
     method: Schema.Literal('actual-365-simple'),
   }),
+} as const
+
+export const QualificationStatisticsPolicySchema = Schema.Struct({
+  schemaVersion: Schema.Literal('bayn.qualification-statistics-policy.v1'),
+  ...QualificationStatisticsPolicyFields,
 })
 export type QualificationStatisticsPolicy = typeof QualificationStatisticsPolicySchema.Type
-
-export const defaultQualificationStatisticsPolicy = {
-  schemaVersion: 'bayn.qualification-statistics-policy.v1',
-  annualizationSessions: 252,
-  confidence: {
-    familyOneSidedAlpha: 0.05,
-    multiplicityAdjustment: 'bonferroni',
-    minimumTailSamples: 20,
-  },
-  bootstrap: {
-    method: 'paired-complete-rebalance-blocks',
-    samples: 5_000,
-    seedNamespace: 'bayn-risk-balanced-trend-qualification-v1',
-    lowerQuantile: 'nearest-rank',
-  },
-  power: {
-    method: 'normal-approximation-independent-rebalance-blocks',
-    oneSidedAlpha: 0.05,
-    targetPower: 0.8,
-    minimumDetectableAnnualizedExcessReturn: 0.03,
-    assumedAnnualizedTrackingVolatility: 0.1,
-    assumedSessionsPerRebalanceBlock: 21,
-    absoluteMinimumSessions: 504,
-    absoluteMinimumRebalanceBlocks: 24,
-  },
-  walkForward: {
-    method: 'expanding-origin',
-    minimumTrainingSessions: 504,
-    testSessions: 252,
-    minimumFolds: 5,
-    minimumPositiveFoldFraction: 0.6,
-    maximumFoldDrawdown: 0.35,
-  },
-  cashReturn: { method: 'actual-365-simple' },
-} as const satisfies QualificationStatisticsPolicy
 
 export const QualificationObservationSchema = Schema.Struct({
   sessionDate: IsoDateSchema,

--- a/services/bayn/src/qualification-statistics/model.ts
+++ b/services/bayn/src/qualification-statistics/model.ts
@@ -15,6 +15,9 @@ const PositiveUnitInterval = Schema.Finite.check(Schema.isGreaterThan(0), Schema
 const SimpleReturn = Schema.Finite.check(Schema.isGreaterThanOrEqualTo(-1))
 const Scalar = Schema.Union([Schema.Finite, Schema.Boolean, Schema.String])
 
+export const qualificationStatisticsMinimumBootstrapSamples = 1_000
+export const qualificationStatisticsMaximumBootstrapSamples = 100_000
+
 const QualificationStatisticsPolicyFields = {
   annualizationSessions: Schema.Literal(252),
   confidence: Schema.Struct({
@@ -24,7 +27,12 @@ const QualificationStatisticsPolicyFields = {
   }),
   bootstrap: Schema.Struct({
     method: Schema.Literal('paired-complete-rebalance-blocks'),
-    samples: Schema.Int.check(Schema.isBetween({ minimum: 1_000, maximum: 100_000 })),
+    samples: Schema.Int.check(
+      Schema.isBetween({
+        minimum: qualificationStatisticsMinimumBootstrapSamples,
+        maximum: qualificationStatisticsMaximumBootstrapSamples,
+      }),
+    ),
     seedNamespace: NonEmptyString,
     lowerQuantile: Schema.Literal('nearest-rank'),
   }),

--- a/services/bayn/src/qualification-statistics/policy.ts
+++ b/services/bayn/src/qualification-statistics/policy.ts
@@ -1,0 +1,81 @@
+import type { QualificationStatisticsPolicy } from './model'
+
+export const qualificationStatisticsPolicySchemaVersion = 'bayn.qualification-statistics-policy.v1' as const
+export const qualificationPolicyMaximumCandidateOrdinal = 25
+
+const minimumBootstrapSamples = 1_000
+const familyOneSidedAlpha = 0.05
+const minimumTailSamples = 20
+
+export interface QualificationStatisticsPolicyOptions {
+  readonly maximumCandidateOrdinal: number
+  readonly walkForward?: {
+    readonly testSessions?: number
+    readonly minimumFolds?: number
+  }
+}
+
+const bootstrapSamplesForOrdinalHorizon = (maximumCandidateOrdinal: number): number =>
+  Math.max(minimumBootstrapSamples, Math.ceil((minimumTailSamples * maximumCandidateOrdinal) / familyOneSidedAlpha))
+
+export const makeQualificationStatisticsPolicy = ({
+  maximumCandidateOrdinal,
+  walkForward,
+}: QualificationStatisticsPolicyOptions): QualificationStatisticsPolicy => ({
+  schemaVersion: qualificationStatisticsPolicySchemaVersion,
+  annualizationSessions: 252,
+  confidence: {
+    familyOneSidedAlpha,
+    multiplicityAdjustment: 'bonferroni',
+    minimumTailSamples,
+  },
+  bootstrap: {
+    method: 'paired-complete-rebalance-blocks',
+    samples: bootstrapSamplesForOrdinalHorizon(maximumCandidateOrdinal),
+    seedNamespace: 'bayn-risk-balanced-trend-qualification-v1',
+    lowerQuantile: 'nearest-rank',
+  },
+  power: {
+    method: 'normal-approximation-independent-rebalance-blocks',
+    oneSidedAlpha: 0.05,
+    targetPower: 0.8,
+    minimumDetectableAnnualizedExcessReturn: 0.03,
+    assumedAnnualizedTrackingVolatility: 0.1,
+    assumedSessionsPerRebalanceBlock: 21,
+    absoluteMinimumSessions: 504,
+    absoluteMinimumRebalanceBlocks: 24,
+  },
+  walkForward: {
+    method: 'expanding-origin',
+    minimumTrainingSessions: 504,
+    testSessions: walkForward?.testSessions ?? 252,
+    minimumFolds: walkForward?.minimumFolds ?? 5,
+    minimumPositiveFoldFraction: 0.6,
+    maximumFoldDrawdown: 0.35,
+  },
+  cashReturn: { method: 'actual-365-simple' },
+})
+
+export const defaultQualificationStatisticsPolicy = makeQualificationStatisticsPolicy({
+  maximumCandidateOrdinal: qualificationPolicyMaximumCandidateOrdinal,
+})
+
+export interface QualificationOrdinalTailCapacity {
+  readonly candidateOrdinal: number
+  readonly adjustedOneSidedAlpha: number
+  readonly tailSampleCount: number
+  readonly minimumTailSamples: number
+}
+
+export const qualificationTailCapacityForOrdinal = (
+  policy: QualificationStatisticsPolicy,
+  candidateOrdinal: number,
+): QualificationOrdinalTailCapacity => {
+  const adjustedOneSidedAlpha = policy.confidence.familyOneSidedAlpha / candidateOrdinal
+  return {
+    candidateOrdinal,
+    adjustedOneSidedAlpha,
+    tailSampleCount: Math.floor(policy.bootstrap.samples * adjustedOneSidedAlpha),
+    minimumTailSamples: policy.confidence.minimumTailSamples,
+  }
+}

--- a/services/bayn/src/qualification-statistics/policy.ts
+++ b/services/bayn/src/qualification-statistics/policy.ts
@@ -1,11 +1,21 @@
-import type { QualificationStatisticsPolicy } from './model'
+import { Result } from 'effect'
+
+import {
+  qualificationStatisticsMaximumBootstrapSamples,
+  qualificationStatisticsMinimumBootstrapSamples,
+  type QualificationStatisticsPolicy,
+} from './model'
 
 export const qualificationStatisticsPolicySchemaVersion = 'bayn.qualification-statistics-policy.v1' as const
 export const qualificationPolicyMaximumCandidateOrdinal = 25
 
-const minimumBootstrapSamples = 1_000
 const familyOneSidedAlpha = 0.05
 const minimumTailSamples = 20
+const defaultWalkForwardTestSessions = 252
+const defaultWalkForwardMinimumFolds = 5
+const maximumCandidateOrdinalSupportedByBootstrapSchema = Math.floor(
+  (qualificationStatisticsMaximumBootstrapSamples * familyOneSidedAlpha) / minimumTailSamples,
+)
 
 export interface QualificationStatisticsPolicyOptions {
   readonly maximumCandidateOrdinal: number
@@ -15,50 +25,123 @@ export interface QualificationStatisticsPolicyOptions {
   }
 }
 
+export type QualificationStatisticsPolicyConstructionFailure = {
+  readonly _tag: 'QualificationStatisticsPolicyOptionInvalid'
+  readonly field: 'maximumCandidateOrdinal' | 'walkForward.testSessions' | 'walkForward.minimumFolds'
+  readonly value: number
+  readonly reason: 'must-be-positive-safe-integer' | 'exceeds-bootstrap-schema-cap'
+  readonly maximum?: number
+}
+
+export type QualificationStatisticsPolicyResult = Result.Result<
+  QualificationStatisticsPolicy,
+  QualificationStatisticsPolicyConstructionFailure
+>
+
 const bootstrapSamplesForOrdinalHorizon = (maximumCandidateOrdinal: number): number =>
-  Math.max(minimumBootstrapSamples, Math.ceil((minimumTailSamples * maximumCandidateOrdinal) / familyOneSidedAlpha))
+  Math.max(
+    qualificationStatisticsMinimumBootstrapSamples,
+    Math.ceil((minimumTailSamples * maximumCandidateOrdinal) / familyOneSidedAlpha),
+  )
+
+const positiveSafeIntegerOption = (
+  field: Extract<QualificationStatisticsPolicyConstructionFailure['field'], `walkForward.${string}`>,
+  value: number,
+): Result.Result<number, QualificationStatisticsPolicyConstructionFailure> =>
+  Number.isSafeInteger(value) && value > 0
+    ? Result.succeed(value)
+    : Result.fail({
+        _tag: 'QualificationStatisticsPolicyOptionInvalid',
+        field,
+        value,
+        reason: 'must-be-positive-safe-integer',
+      })
+
+const validateQualificationStatisticsPolicyOptions = ({
+  maximumCandidateOrdinal,
+  walkForward,
+}: QualificationStatisticsPolicyOptions): Result.Result<
+  {
+    readonly maximumCandidateOrdinal: number
+    readonly testSessions: number
+    readonly minimumFolds: number
+  },
+  QualificationStatisticsPolicyConstructionFailure
+> => {
+  if (!Number.isSafeInteger(maximumCandidateOrdinal) || maximumCandidateOrdinal <= 0) {
+    return Result.fail({
+      _tag: 'QualificationStatisticsPolicyOptionInvalid',
+      field: 'maximumCandidateOrdinal',
+      value: maximumCandidateOrdinal,
+      reason: 'must-be-positive-safe-integer',
+    })
+  }
+  if (maximumCandidateOrdinal > maximumCandidateOrdinalSupportedByBootstrapSchema) {
+    return Result.fail({
+      _tag: 'QualificationStatisticsPolicyOptionInvalid',
+      field: 'maximumCandidateOrdinal',
+      value: maximumCandidateOrdinal,
+      reason: 'exceeds-bootstrap-schema-cap',
+      maximum: maximumCandidateOrdinalSupportedByBootstrapSchema,
+    })
+  }
+
+  const testSessions = walkForward?.testSessions ?? defaultWalkForwardTestSessions
+  const minimumFolds = walkForward?.minimumFolds ?? defaultWalkForwardMinimumFolds
+  return Result.all({
+    maximumCandidateOrdinal: Result.succeed(maximumCandidateOrdinal),
+    testSessions: positiveSafeIntegerOption('walkForward.testSessions', testSessions),
+    minimumFolds: positiveSafeIntegerOption('walkForward.minimumFolds', minimumFolds),
+  })
+}
 
 export const makeQualificationStatisticsPolicy = ({
   maximumCandidateOrdinal,
   walkForward,
-}: QualificationStatisticsPolicyOptions): QualificationStatisticsPolicy => ({
-  schemaVersion: qualificationStatisticsPolicySchemaVersion,
-  annualizationSessions: 252,
-  confidence: {
-    familyOneSidedAlpha,
-    multiplicityAdjustment: 'bonferroni',
-    minimumTailSamples,
-  },
-  bootstrap: {
-    method: 'paired-complete-rebalance-blocks',
-    samples: bootstrapSamplesForOrdinalHorizon(maximumCandidateOrdinal),
-    seedNamespace: 'bayn-risk-balanced-trend-qualification-v1',
-    lowerQuantile: 'nearest-rank',
-  },
-  power: {
-    method: 'normal-approximation-independent-rebalance-blocks',
-    oneSidedAlpha: 0.05,
-    targetPower: 0.8,
-    minimumDetectableAnnualizedExcessReturn: 0.03,
-    assumedAnnualizedTrackingVolatility: 0.1,
-    assumedSessionsPerRebalanceBlock: 21,
-    absoluteMinimumSessions: 504,
-    absoluteMinimumRebalanceBlocks: 24,
-  },
-  walkForward: {
-    method: 'expanding-origin',
-    minimumTrainingSessions: 504,
-    testSessions: walkForward?.testSessions ?? 252,
-    minimumFolds: walkForward?.minimumFolds ?? 5,
-    minimumPositiveFoldFraction: 0.6,
-    maximumFoldDrawdown: 0.35,
-  },
-  cashReturn: { method: 'actual-365-simple' },
-})
+}: QualificationStatisticsPolicyOptions): QualificationStatisticsPolicyResult =>
+  Result.map(
+    validateQualificationStatisticsPolicyOptions({ maximumCandidateOrdinal, walkForward }),
+    ({ testSessions, minimumFolds }) => ({
+      schemaVersion: qualificationStatisticsPolicySchemaVersion,
+      annualizationSessions: 252,
+      confidence: {
+        familyOneSidedAlpha,
+        multiplicityAdjustment: 'bonferroni',
+        minimumTailSamples,
+      },
+      bootstrap: {
+        method: 'paired-complete-rebalance-blocks',
+        samples: bootstrapSamplesForOrdinalHorizon(maximumCandidateOrdinal),
+        seedNamespace: 'bayn-risk-balanced-trend-qualification-v1',
+        lowerQuantile: 'nearest-rank',
+      },
+      power: {
+        method: 'normal-approximation-independent-rebalance-blocks',
+        oneSidedAlpha: 0.05,
+        targetPower: 0.8,
+        minimumDetectableAnnualizedExcessReturn: 0.03,
+        assumedAnnualizedTrackingVolatility: 0.1,
+        assumedSessionsPerRebalanceBlock: 21,
+        absoluteMinimumSessions: 504,
+        absoluteMinimumRebalanceBlocks: 24,
+      },
+      walkForward: {
+        method: 'expanding-origin',
+        minimumTrainingSessions: 504,
+        testSessions,
+        minimumFolds,
+        minimumPositiveFoldFraction: 0.6,
+        maximumFoldDrawdown: 0.35,
+      },
+      cashReturn: { method: 'actual-365-simple' },
+    }),
+  )
 
-export const defaultQualificationStatisticsPolicy = makeQualificationStatisticsPolicy({
-  maximumCandidateOrdinal: qualificationPolicyMaximumCandidateOrdinal,
-})
+export const defaultQualificationStatisticsPolicy = Result.getOrThrow(
+  makeQualificationStatisticsPolicy({
+    maximumCandidateOrdinal: qualificationPolicyMaximumCandidateOrdinal,
+  }),
+)
 
 export interface QualificationOrdinalTailCapacity {
   readonly candidateOrdinal: number

--- a/services/bayn/src/qualification.test.ts
+++ b/services/bayn/src/qualification.test.ts
@@ -74,7 +74,7 @@ describe('qualification lock', () => {
       schemaVersion: 'bayn.qualification-statistics-policy.v1',
       content: {
         schemaVersion: 'bayn.qualification-statistics-policy.v1',
-        bootstrap: { method: 'paired-complete-rebalance-blocks', samples: 5_000 },
+        bootstrap: { method: 'paired-complete-rebalance-blocks', samples: 10_000 },
       },
     })
   })

--- a/services/bayn/src/qualification/policy.ts
+++ b/services/bayn/src/qualification/policy.ts
@@ -1,6 +1,6 @@
 import { pipe, Result, Schema } from 'effect'
 
-import { defaultQualificationStatisticsPolicy } from '../qualification-statistics/model'
+import { defaultQualificationStatisticsPolicy } from '../qualification-statistics/policy'
 import { strictParseOptions } from '../schemas'
 import type { QualificationConstructionFailure } from './failure'
 import { hashQualificationMaterial } from './hashing'


### PR DESCRIPTION
## Summary

- Add one pure ordinal-bound qualification policy constructor for terminal and candidate-development statistics.
- Derive 10,000 bootstrap samples for the declared horizon of 25, preserving Bonferroni correction and the 20-sample minimum tail; Candidate 21 has exactly 23 tail samples.
- Centralize tail-capacity calculation, reject Candidate 26 before preregistration/data/evaluation, and preserve decoding of immutable historical v1 policies with 5,000 samples.

## Related Issues

Fixes PROOMPT-366 (follow-up statistical-feasibility hardening).

## Testing

- Focused qualification, candidate-development, and terminal integration tests: passed.
- `bun run --filter @proompteng/bayn test`: 1,244 passed, 153 skipped, 0 failed.
- `bun run --filter @proompteng/bayn test:postgres`: 0 failed; PostgreSQL integration cases are environment-skipped.
- `bun run --filter @proompteng/bayn tsc`: passed.
- `bun run --filter @proompteng/bayn lint`: passed.
- Effect lint and both Oxlint modes: passed; one pre-existing unused-import warning in `candidate-development-domain/preflight.ts`.
- `bun run --filter @proompteng/bayn build`: passed.
- `bun test packages/scripts/src/bayn`: 389 passed; 14 macOS Bash 3 environment failures because `mapfile` is unavailable, unrelated to this diff.
- Linux Bayn image build was evaluated but cannot run on the local aarch64-darwin host; the CI image job remains applicable.

## Breaking Changes

None. The policy remains schema v1 for historical receipt decoding; the default policy content hash intentionally changes with the precommitted sample count. Candidate 21 remains unattempted.