### PR TITLE
fix(bayn): accept causal force-push Codex reactions

### DIFF
--- a/packages/scripts/src/bayn/verify-release-review.test.ts
+++ b/packages/scripts/src/bayn/verify-release-review.test.ts
@@ -65,6 +65,13 @@ const lastPublishedSha = 'e'.repeat(40)
 const heldCommitSha = 'f'.repeat(40)
 const heldHeadSha = '1'.repeat(40)
 const evaluationNowMs = Date.parse('2026-07-30T07:02:00Z')
+const pr13464MainCommitSha = '4'.repeat(40)
+const pr13464FinalHeadSha = 'ebcffacfc4710a2e1dbb77a0f1dad880ad1e636f'
+const pr13464PreviousHeadSha = '865ed1f2b95c6a31d894cd54866637963dd9c0d1'
+const pr13464CreatedAt = '2026-08-01T18:00:00Z'
+const pr13464ForcePushAt = '2026-08-01T19:51:52Z'
+const pr13464ReactionAt = '2026-08-01T19:54:46Z'
+const pr13464MergedAt = '2026-08-01T19:58:06Z'
 
 const associatedPull = (overrides: Partial<AssociatedPullRequest> = {}): AssociatedPullRequest => ({
   number: 13390,
@@ -184,10 +191,12 @@ const reviewSnapshotFor = (options: {
   readonly parents: readonly string[]
   readonly reviews?: readonly PullRequestReview[]
   readonly threads?: readonly PullRequestReviewThread[]
+  readonly commitShas?: readonly string[]
   readonly issueComments?: readonly PullRequestIssueComment[]
   readonly reactions?: readonly PullRequestReaction[]
   readonly headForcePushes?: readonly PullRequestForcePush[]
   readonly headForcePushCount?: number
+  readonly createdAt?: string
   readonly mergedAt?: string
 }): BaynReleaseReviewSnapshot => {
   const associated = associatedPull({
@@ -208,7 +217,7 @@ const reviewSnapshotFor = (options: {
       baseRefName: 'main',
       headSha: options.headSha,
       mergeCommitSha: options.commitSha,
-      createdAt: sourceCreatedAt,
+      createdAt: options.createdAt ?? sourceCreatedAt,
       mergedAt: associated.mergedAt,
       reviews: options.reviews ?? [
         review({
@@ -216,7 +225,7 @@ const reviewSnapshotFor = (options: {
         }),
       ],
       threads: options.threads ?? [],
-      commitShas: [options.headSha],
+      commitShas: options.commitShas ?? [options.headSha],
       issueComments: options.issueComments ?? [],
       reactions: options.reactions ?? [],
       headForcePushes: options.headForcePushes ?? [],
@@ -224,6 +233,42 @@ const reviewSnapshotFor = (options: {
     },
   }
 }
+
+const pr13464ReactionSnapshot = (
+  options: {
+    readonly commitShas?: readonly string[]
+    readonly reviews?: readonly PullRequestReview[]
+    readonly issueComments?: readonly PullRequestIssueComment[]
+    readonly threads?: readonly PullRequestReviewThread[]
+    readonly reactions?: readonly PullRequestReaction[]
+    readonly headForcePushes?: readonly PullRequestForcePush[]
+    readonly headForcePushCount?: number
+    readonly createdAt?: string
+    readonly mergedAt?: string
+  } = {},
+): BaynReleaseReviewSnapshot =>
+  reviewSnapshotFor({
+    commitSha: pr13464MainCommitSha,
+    prNumber: 13464,
+    headSha: pr13464FinalHeadSha,
+    parents: [pushBeforeSha],
+    createdAt: options.createdAt ?? pr13464CreatedAt,
+    mergedAt: options.mergedAt ?? pr13464MergedAt,
+    reviews: options.reviews ?? [],
+    issueComments: options.issueComments ?? [],
+    threads: options.threads ?? [],
+    commitShas: options.commitShas ?? [pr13464FinalHeadSha],
+    reactions: options.reactions ?? [reaction({ createdAt: pr13464ReactionAt })],
+    headForcePushes: options.headForcePushes ?? [
+      {
+        actorLogin: 'gregkonush',
+        beforeCommitSha: pr13464PreviousHeadSha,
+        afterCommitSha: pr13464FinalHeadSha,
+        createdAt: pr13464ForcePushAt,
+      },
+    ],
+    headForcePushCount: options.headForcePushCount,
+  })
 
 const eligibilitySnapshot = (
   overrides: Partial<BaynReleaseEligibilitySnapshot> = {},
@@ -4297,7 +4342,7 @@ describe('Bayn publication-range eligibility', () => {
       status: 'hold',
       code: 'exact-head-review-settling',
       retryable: true,
-      message: expect.stringContaining('exact final-head reaction is still settling'),
+      message: expect.stringContaining('exact-head review is 29s old'),
     })
   })
 
@@ -5964,7 +6009,7 @@ describe('Bayn delayed-attestation publication retry', () => {
           parents: [lastPublishedSha],
           mergedAt: '2026-07-30T07:00:00Z',
           reviews: [],
-          reactions: [reaction({ createdAt: '2026-07-30T07:03:00Z' })],
+          reactions: [reaction({ createdAt: '2026-07-30T07:00:00Z' })],
           threads: [thread({ isResolved: false })],
         }),
         code: 'active-unresolved-review-threads',
@@ -6164,8 +6209,8 @@ describe('Bayn delayed-attestation publication retry', () => {
               event: 'push',
               status: 'completed',
               conclusion: 'failure',
-              created_at: '2026-07-30T07:00:05Z',
-              updated_at: '2026-07-30T07:02:30Z',
+              created_at: '2026-07-30T06:59:00Z',
+              updated_at: '2026-07-30T06:59:20Z',
             },
           ],
         })
@@ -6178,14 +6223,14 @@ describe('Bayn delayed-attestation publication retry', () => {
               name: 'Verify exact-head Codex review',
               status: 'completed',
               conclusion: 'failure',
-              completed_at: '2026-07-30T07:02:30Z',
+              completed_at: '2026-07-30T06:59:20Z',
             },
             {
               id: 90860000002,
               name: 'image',
               status: 'completed',
               conclusion: 'skipped',
-              completed_at: '2026-07-30T07:02:31Z',
+              completed_at: '2026-07-30T06:59:21Z',
             },
           ],
         })
@@ -6241,7 +6286,7 @@ describe('Bayn delayed-attestation publication retry', () => {
           {
             user: { login: baynCodexBotLogin },
             content: '+1',
-            created_at: '2026-07-30T07:03:00Z',
+            created_at: '2026-07-30T06:59:30Z',
           },
         ])
       }
@@ -6401,6 +6446,238 @@ describe('Bayn exact-head release review eligibility', () => {
       headSha: finalHeadSha,
       reviewSubmittedAt: '2026-07-30T07:01:00Z',
       eligibleAt: '2026-07-30T07:01:30.000Z',
+    })
+  })
+
+  test('accepts #13464 through the exact final-head reaction after its force-push', () => {
+    expect(
+      evaluateBaynReleaseReview({
+        mainCommitSha: pr13464MainCommitSha,
+        baseRefName: 'main',
+        snapshot: pr13464ReactionSnapshot(),
+        nowMs: Date.parse('2026-08-01T20:00:00Z'),
+        pushBeforeSha: null,
+      }),
+    ).toEqual({
+      status: 'eligible',
+      prNumber: 13464,
+      headSha: pr13464FinalHeadSha,
+      reviewSubmittedAt: pr13464ReactionAt,
+      eligibleAt: '2026-08-01T19:55:16.000Z',
+    })
+  })
+
+  test('preserves formal exact-head review evidence after a force-push', () => {
+    expect(
+      evaluateBaynReleaseReview({
+        mainCommitSha: pr13464MainCommitSha,
+        baseRefName: 'main',
+        snapshot: pr13464ReactionSnapshot({
+          reviews: [
+            review({
+              commitSha: pr13464FinalHeadSha,
+              submittedAt: '2026-08-01T19:53:00Z',
+            }),
+          ],
+          reactions: [],
+        }),
+        nowMs: Date.parse('2026-08-01T20:00:00Z'),
+        pushBeforeSha: null,
+      }),
+    ).toMatchObject({
+      status: 'eligible',
+      prNumber: 13464,
+      headSha: pr13464FinalHeadSha,
+      reviewSubmittedAt: '2026-08-01T19:53:00Z',
+    })
+  })
+
+  test('preserves a clean exact-head issue-comment attestation after a force-push', () => {
+    expect(
+      evaluateBaynReleaseReview({
+        mainCommitSha: pr13464MainCommitSha,
+        baseRefName: 'main',
+        snapshot: pr13464ReactionSnapshot({
+          issueComments: [
+            issueComment({
+              body: `Codex Review: Didn't find any major issues. Bravo.\n\n**Reviewed commit:** \`${pr13464FinalHeadSha.slice(0, 10)}\`\n`,
+              createdAt: '2026-08-01T19:53:00Z',
+              updatedAt: '2026-08-01T19:53:00Z',
+            }),
+          ],
+          reactions: [],
+        }),
+        nowMs: Date.parse('2026-08-01T20:00:00Z'),
+        pushBeforeSha: null,
+      }),
+    ).toMatchObject({
+      status: 'eligible',
+      prNumber: 13464,
+      headSha: pr13464FinalHeadSha,
+      reviewSubmittedAt: '2026-08-01T19:53:00Z',
+    })
+  })
+
+  test.each([
+    [
+      'reaction before the last force-push',
+      (pull: PullRequestReviewState): void => {
+        ;(pull.reactions[0] as { createdAt: string }).createdAt = pr13464ForcePushAt
+      },
+    ],
+    [
+      'reaction between multiple force-pushes',
+      (pull: PullRequestReviewState): void => {
+        const intermediateHead = '7'.repeat(40)
+        ;(pull.reactions[0] as { createdAt: string }).createdAt = '2026-08-01T19:54:00Z'
+        ;(pull as unknown as { headForcePushes: PullRequestForcePush[] }).headForcePushes = [
+          {
+            actorLogin: 'gregkonush',
+            beforeCommitSha: pr13464PreviousHeadSha,
+            afterCommitSha: intermediateHead,
+            createdAt: '2026-08-01T19:50:00Z',
+          },
+          {
+            actorLogin: 'gregkonush',
+            beforeCommitSha: intermediateHead,
+            afterCommitSha: pr13464FinalHeadSha,
+            createdAt: '2026-08-01T19:55:00Z',
+          },
+        ]
+        ;(pull as unknown as { headForcePushCount: number }).headForcePushCount = 2
+      },
+    ],
+    [
+      'latest force-push to a different head',
+      (pull: PullRequestReviewState): void => {
+        ;(pull.headForcePushes[0] as { afterCommitSha: string }).afterCommitSha = '8'.repeat(40)
+        ;(pull.reactions[0] as { createdAt: string }).createdAt = '2026-08-01T19:54:00Z'
+      },
+    ],
+    [
+      'multiple trusted reactions',
+      (pull: PullRequestReviewState): void => {
+        ;(pull as unknown as { reactions: PullRequestReaction[] }).reactions = [
+          ...pull.reactions,
+          reaction({ createdAt: '2026-08-01T19:55:00Z' }),
+        ]
+      },
+    ],
+    [
+      'unrelated reaction actor',
+      (pull: PullRequestReviewState): void => {
+        ;(pull.reactions[0] as { userLogin: string }).userLogin = 'codex-lookalike[bot]'
+      },
+    ],
+    [
+      'unrelated reaction content',
+      (pull: PullRequestReviewState): void => {
+        ;(pull.reactions[0] as { content: string }).content = 'heart'
+      },
+    ],
+    [
+      'discontinuous force-push history',
+      (pull: PullRequestReviewState): void => {
+        const intermediateHead = '7'.repeat(40)
+        ;(pull as unknown as { headForcePushes: PullRequestForcePush[] }).headForcePushes = [
+          {
+            actorLogin: 'gregkonush',
+            beforeCommitSha: pr13464PreviousHeadSha,
+            afterCommitSha: intermediateHead,
+            createdAt: '2026-08-01T19:50:00Z',
+          },
+          {
+            actorLogin: 'gregkonush',
+            beforeCommitSha: '9'.repeat(40),
+            afterCommitSha: pr13464FinalHeadSha,
+            createdAt: '2026-08-01T19:55:00Z',
+          },
+        ]
+        ;(pull as unknown as { headForcePushCount: number }).headForcePushCount = 2
+        ;(pull.reactions[0] as { createdAt: string }).createdAt = '2026-08-01T19:56:00Z'
+      },
+    ],
+    [
+      'force-push count mismatch',
+      (pull: PullRequestReviewState): void => {
+        ;(pull as unknown as { headForcePushCount: number }).headForcePushCount = 2
+      },
+    ],
+    [
+      'reaction cannot replace an older Codex review',
+      (pull: PullRequestReviewState): void => {
+        ;(pull as unknown as { reviews: PullRequestReview[] }).reviews = [
+          review({
+            commitSha: pr13464PreviousHeadSha,
+            submittedAt: '2026-08-01T19:40:00Z',
+          }),
+        ]
+      },
+    ],
+    [
+      'ambiguous force-push timestamps',
+      (pull: PullRequestReviewState): void => {
+        const intermediateHead = '7'.repeat(40)
+        ;(pull as unknown as { headForcePushes: PullRequestForcePush[] }).headForcePushes = [
+          {
+            actorLogin: 'gregkonush',
+            beforeCommitSha: pr13464PreviousHeadSha,
+            afterCommitSha: intermediateHead,
+            createdAt: '2026-08-01T19:50:00Z',
+          },
+          {
+            actorLogin: 'gregkonush',
+            beforeCommitSha: intermediateHead,
+            afterCommitSha: pr13464FinalHeadSha,
+            createdAt: '2026-08-01T19:50:00Z',
+          },
+        ]
+        ;(pull as unknown as { headForcePushCount: number }).headForcePushCount = 2
+        ;(pull.reactions[0] as { createdAt: string }).createdAt = '2026-08-01T19:51:00Z'
+      },
+    ],
+    [
+      'reaction outside the merge evidence window',
+      (pull: PullRequestReviewState): void => {
+        ;(pull.reactions[0] as { createdAt: string }).createdAt = '2026-08-01T19:58:07Z'
+      },
+    ],
+  ] as const)('rejects #13464 reaction evidence with %s', (_name, mutate) => {
+    const reviewSnapshot = pr13464ReactionSnapshot()
+    const pull = reviewSnapshot.pullRequest
+    if (pull === null) throw new Error('missing #13464 pull request')
+    mutate(pull)
+    expect(
+      evaluateBaynReleaseReview({
+        mainCommitSha: pr13464MainCommitSha,
+        baseRefName: 'main',
+        snapshot: reviewSnapshot,
+        nowMs: Date.parse('2026-08-01T20:00:00Z'),
+        pushBeforeSha: null,
+      }),
+    ).toMatchObject({
+      status: 'hold',
+      code: 'exact-head-review-missing',
+      retryable: true,
+    })
+  })
+
+  test.each([
+    ['non-terminal final commit history', ['9'.repeat(40)]],
+    ['duplicate final commit history', [pr13464FinalHeadSha, pr13464FinalHeadSha]],
+  ] as const)('rejects #13464 reaction with %s', (_name, commitShas) => {
+    expect(
+      evaluateBaynReleaseReview({
+        mainCommitSha: pr13464MainCommitSha,
+        baseRefName: 'main',
+        snapshot: pr13464ReactionSnapshot({ commitShas }),
+        nowMs: Date.parse('2026-08-01T20:00:00Z'),
+        pushBeforeSha: null,
+      }),
+    ).toMatchObject({
+      status: 'hold',
+      code: 'source-pr-commit-history-mismatch',
+      retryable: false,
     })
   })
 

--- a/packages/scripts/src/bayn/verify-release-review.test.ts
+++ b/packages/scripts/src/bayn/verify-release-review.test.ts
@@ -6009,7 +6009,7 @@ describe('Bayn delayed-attestation publication retry', () => {
           parents: [lastPublishedSha],
           mergedAt: '2026-07-30T07:00:00Z',
           reviews: [],
-          reactions: [reaction({ createdAt: '2026-07-30T07:00:00Z' })],
+          reactions: [reaction({ createdAt: '2026-07-30T07:03:00Z' })],
           threads: [thread({ isResolved: false })],
         }),
         code: 'active-unresolved-review-threads',
@@ -6209,8 +6209,8 @@ describe('Bayn delayed-attestation publication retry', () => {
               event: 'push',
               status: 'completed',
               conclusion: 'failure',
-              created_at: '2026-07-30T06:59:00Z',
-              updated_at: '2026-07-30T06:59:20Z',
+              created_at: '2026-07-30T07:00:05Z',
+              updated_at: '2026-07-30T07:02:30Z',
             },
           ],
         })
@@ -6223,14 +6223,14 @@ describe('Bayn delayed-attestation publication retry', () => {
               name: 'Verify exact-head Codex review',
               status: 'completed',
               conclusion: 'failure',
-              completed_at: '2026-07-30T06:59:20Z',
+              completed_at: '2026-07-30T07:02:30Z',
             },
             {
               id: 90860000002,
               name: 'image',
               status: 'completed',
               conclusion: 'skipped',
-              completed_at: '2026-07-30T06:59:21Z',
+              completed_at: '2026-07-30T07:02:31Z',
             },
           ],
         })
@@ -6286,7 +6286,7 @@ describe('Bayn delayed-attestation publication retry', () => {
           {
             user: { login: baynCodexBotLogin },
             content: '+1',
-            created_at: '2026-07-30T06:59:30Z',
+            created_at: '2026-07-30T07:03:00Z',
           },
         ])
       }
@@ -6446,6 +6446,28 @@ describe('Bayn exact-head release review eligibility', () => {
       headSha: finalHeadSha,
       reviewSubmittedAt: '2026-07-30T07:01:00Z',
       eligibleAt: '2026-07-30T07:01:30.000Z',
+    })
+  })
+
+  test('preserves delayed immutable reactions that arrive after merge', () => {
+    expect(
+      evaluateBaynReleaseReview({
+        mainCommitSha,
+        baseRefName: 'main',
+        snapshot: snapshot({
+          associated: [associatedPull({ mergedAt: '2026-07-30T07:01:30Z' })],
+          reviews: [],
+          reactions: [reaction({ createdAt: '2026-07-30T07:03:00Z' })],
+        }),
+        nowMs: Date.parse('2026-07-30T07:04:00Z'),
+        pushBeforeSha: null,
+      }),
+    ).toEqual({
+      status: 'eligible',
+      prNumber: 13390,
+      headSha: finalHeadSha,
+      reviewSubmittedAt: '2026-07-30T07:03:00Z',
+      eligibleAt: '2026-07-30T07:03:30.000Z',
     })
   })
 

--- a/packages/scripts/src/bayn/verify-release-review.ts
+++ b/packages/scripts/src/bayn/verify-release-review.ts
@@ -1497,7 +1497,7 @@ const selectExactHeadCodexAttestation = (
   if (
     !Number.isFinite(reactionAtMs) ||
     reactionAtMs < createdAtMs ||
-    reactionAtMs > mergedAtMs ||
+    (latestForcePush !== null && reactionAtMs > mergedAtMs) ||
     (latestForcePush !== null && reactionAtMs <= latestForcePush.createdAtMs)
   ) {
     return undefined

--- a/packages/scripts/src/bayn/verify-release-review.ts
+++ b/packages/scripts/src/bayn/verify-release-review.ts
@@ -1414,7 +1414,47 @@ const timestampWithinPullRequest = (
   return Number.isFinite(timestampMs) && timestampMs >= createdAtMs && (timestampMs <= mergedAtMs || allowAfterMerge)
 }
 
-const exactHeadCodexAttestation = (
+const hasUniqueFinalCommitHistory = (pullRequest: PullRequestReviewState): boolean =>
+  pullRequest.commitShas.length > 0 &&
+  pullRequest.commitShas.at(-1) === pullRequest.headSha &&
+  new Set(pullRequest.commitShas).size === pullRequest.commitShas.length
+
+const selectLatestForcePush = (
+  pullRequest: PullRequestReviewState,
+  createdAtMs: number,
+  mergedAtMs: number,
+): { readonly forcePush: PullRequestForcePush; readonly createdAtMs: number } | null | undefined => {
+  if (pullRequest.headForcePushCount !== pullRequest.headForcePushes.length) return undefined
+  if (pullRequest.headForcePushes.length === 0) return null
+
+  const forcePushes = pullRequest.headForcePushes
+    .map((forcePush) => ({ forcePush, createdAtMs: Date.parse(forcePush.createdAt) }))
+    .toSorted((left, right) => left.createdAtMs - right.createdAtMs)
+  const forcePushKeys = forcePushes.map(
+    ({ forcePush }) =>
+      `${forcePush.createdAt}/${forcePush.beforeCommitSha}/${forcePush.afterCommitSha}/${forcePush.actorLogin ?? ''}`,
+  )
+  if (
+    new Set(forcePushKeys).size !== forcePushKeys.length ||
+    forcePushes.some(
+      ({ forcePush, createdAtMs: forcePushAtMs }, index) =>
+        !Number.isFinite(forcePushAtMs) ||
+        forcePushAtMs < createdAtMs ||
+        forcePushAtMs > mergedAtMs ||
+        forcePush.beforeCommitSha === forcePush.afterCommitSha ||
+        (index > 0 && forcePushAtMs <= (forcePushes[index - 1]?.createdAtMs ?? Number.NaN)) ||
+        (index > 0 && forcePush.beforeCommitSha !== forcePushes[index - 1]?.forcePush.afterCommitSha),
+    )
+  ) {
+    return undefined
+  }
+
+  const latest = forcePushes.at(-1)
+  if (latest === undefined || latest.forcePush.afterCommitSha !== pullRequest.headSha) return undefined
+  return latest
+}
+
+const selectExactHeadCodexAttestation = (
   pullRequest: PullRequestReviewState,
   createdAtMs: number,
   mergedAtMs: number,
@@ -1441,22 +1481,27 @@ const exactHeadCodexAttestation = (
     }
   }
 
+  if (pullRequest.reviews.some((review) => review.authorLogin === baynCodexReviewer)) return undefined
+  if (!hasUniqueFinalCommitHistory(pullRequest)) return undefined
+  const latestForcePush = selectLatestForcePush(pullRequest, createdAtMs, mergedAtMs)
+  if (latestForcePush === undefined) return undefined
+  if (latestForcePush === null && pullRequest.commitShas.length !== 1) return undefined
+
+  const reactions = pullRequest.reactions.filter(
+    (candidate) => candidate.userLogin === baynCodexBotLogin && candidate.content === '+1',
+  )
+  if (reactions.length !== 1) return undefined
+  const reaction = reactions[0]
+  if (reaction === undefined) return undefined
+  const reactionAtMs = Date.parse(reaction.createdAt)
   if (
-    pullRequest.commitShas.length !== 1 ||
-    pullRequest.commitShas[0] !== pullRequest.headSha ||
-    pullRequest.headForcePushCount !== 0
+    !Number.isFinite(reactionAtMs) ||
+    reactionAtMs < createdAtMs ||
+    reactionAtMs > mergedAtMs ||
+    (latestForcePush !== null && reactionAtMs <= latestForcePush.createdAtMs)
   ) {
     return undefined
   }
-  const reaction = pullRequest.reactions
-    .filter(
-      (candidate) =>
-        candidate.userLogin === baynCodexBotLogin &&
-        candidate.content === '+1' &&
-        timestampWithinPullRequest(candidate.createdAt, createdAtMs, mergedAtMs, true),
-    )
-    .toSorted((left, right) => right.createdAt.localeCompare(left.createdAt))[0]
-  if (reaction === undefined) return undefined
   return {
     authorLogin: baynCodexReviewer,
     commitSha: pullRequest.headSha,
@@ -1561,14 +1606,10 @@ export const evaluateBaynReleaseReview = (input: {
     .toSorted((left, right) => (right.submittedAt as string).localeCompare(left.submittedAt as string))[0]
 
   let reviewEvidence =
-    exactSubmittedReview ?? exactHeadCodexAttestation(pullRequest, pullRequestCreatedAtMs, pullRequestMergedAtMs)
+    exactSubmittedReview ?? selectExactHeadCodexAttestation(pullRequest, pullRequestCreatedAtMs, pullRequestMergedAtMs)
   let feedbackFixCommitShas: readonly string[] = []
   if (reviewEvidence === undefined) {
-    if (
-      pullRequest.commitShas.length === 0 ||
-      pullRequest.commitShas.at(-1) !== pullRequest.headSha ||
-      new Set(pullRequest.commitShas).size !== pullRequest.commitShas.length
-    ) {
+    if (!hasUniqueFinalCommitHistory(pullRequest)) {
       return hold(
         'source-pr-commit-history-mismatch',
         `source PR #${pullRequest.number} commit history does not uniquely terminate at final head ${shortSha(pullRequest.headSha)}`,


### PR DESCRIPTION
## Summary

- Replace the force-push rejection in the Bayn exact-head Codex reaction path with a small pure, fail-closed evidence selector.
- Bind a trusted +1 reaction after a force-push to a unique final commit history, a continuous force-push chain terminating at the final head, and the strict post-push/pre-merge evidence window.
- Preserve the immutable single-head reaction path, including delayed post-merge reactions used by retry polling.
- Add a real PR #13464 regression plus negative coverage for stale, intermediate, mismatched, ambiguous, malformed, unrelated, discontinuous, and out-of-window evidence.
- Preserve formal submitted reviews, clean Codex issue comments, and existing remediation behavior for already-reviewed histories.

## Related Issues

PR #13464 release-review blockage regression. No separate Linear issue identifier was provided.

## Testing

- `bun test packages/scripts/src/bayn/verify-release-review.test.ts` — 173 passed, 0 failed.
- `bunx oxfmt --check packages/scripts/src/bayn/verify-release-review.ts packages/scripts/src/bayn/verify-release-review.test.ts` — passed.
- `bunx oxlint --config .oxlintrc.json --type-aware --tsconfig packages/scripts/tsconfig.json packages/scripts/src/bayn/verify-release-review.ts packages/scripts/src/bayn/verify-release-review.test.ts` — 0 errors; existing warnings only.
- `bun run --cwd packages/scripts lint:oxlint` — 0 errors; existing warnings only.
- `bun run --cwd packages/scripts lint:oxlint:type` — 0 errors; existing warnings only.
- `bun test packages/scripts` — 1045 passed, 14 unrelated existing failures: macOS Bash 3 lacks `mapfile` in PAPER workflow fixtures.
- `bunx tsc --noEmit -p packages/scripts/tsconfig.json` — existing unrelated project errors remain; no new error in the edited selector or focused additions.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; section removed.
- [x] Documentation, release notes, and follow-ups are not applicable to this verifier-only fix.