### PR TITLE
feat(bayn): hand off qualified PAPER activation evidence

### DIFF
--- a/.github/workflows/bayn-paper-activation.yml
+++ b/.github/workflows/bayn-paper-activation.yml
@@ -84,6 +84,10 @@ jobs:
         with:
           bun-version: 1.3.14
 
+      - name: Install activation verifier dependencies
+        shell: bash
+        run: bun install --frozen-lockfile --ignore-scripts --filter @proompteng/scripts
+
       - name: Authenticate activation identity and evidence producer
         id: identity
         env:
@@ -845,7 +849,8 @@ jobs:
             echo 'BAYN_PAPER_ACTIVATION_HOLD rollback-precommit-changed: rollback branch differs from the workflow-produced commit' >&2
             exit 1
           }
-          mapfile -t metadata_lines < <(
+          metadata_lines=()
+          while IFS= read -r metadata_line_value; do metadata_lines+=("$metadata_line_value"); done < <(
             git show -s --format=%B "${old_rollback_sha}" | sed -n 's/^BAYN_PAPER_ROLLBACK_METADATA=//p'
           )
           [[ "${#metadata_lines[@]}" == 1 ]] || {
@@ -1591,7 +1596,8 @@ jobs:
             echo 'BAYN_PAPER_ACTIVATION_HOLD watchdog-artifact-list-invalid: repository artifact discovery is incomplete or duplicated' >&2
             exit 1
           }
-          mapfile -t attestation_artifacts < <(
+          attestation_artifacts=()
+          while IFS= read -r attestation_line; do attestation_artifacts+=("$attestation_line"); done < <(
             jq -c --arg cutoff "${retention_cutoff}" '
               .[] | .artifacts[] |
               select(.expired == false and .created_at >= $cutoff) |
@@ -1599,7 +1605,8 @@ jobs:
               select((.workflow_run.id | tostring) == $identity.runId)
             ' <<< "${artifact_pages}"
           )
-          for artifact in "${attestation_artifacts[@]}"; do
+          if [[ ${#attestation_artifacts[@]} -gt 0 ]]; then
+            for artifact in "${attestation_artifacts[@]}"; do
             artifact_id="$(jq -r '.id' <<< "${artifact}")"
             artifact_name="$(jq -r '.name' <<< "${artifact}")"
             artifact_workflow_run_id="$(jq -r '.workflow_run.id' <<< "${artifact}")"
@@ -1849,7 +1856,10 @@ jobs:
                   git commit-tree "${tree}" -p "${current_main_sha}"
             )"
             rm -f "${index}"
-            mapfile -t rollback_remote_refs < <(git ls-remote --heads origin "refs/heads/${rollback_branch}")
+            rollback_remote_refs=()
+            while IFS= read -r rollback_remote_ref; do rollback_remote_refs+=("$rollback_remote_ref"); done < <(
+              git ls-remote --heads origin "refs/heads/${rollback_branch}"
+            )
             [[ "${#rollback_remote_refs[@]}" -le 1 ]] || {
               echo "Rollback branch ${rollback_branch} resolved to multiple remote refs." >&2
               exit 1
@@ -1989,4 +1999,5 @@ jobs:
               echo "Rollback PR #${rollback_pr} did not reach a clean exact-head reviewed state." >&2
               exit 1
             }
-          done
+            done
+          fi

--- a/.github/workflows/bayn-qualification.yml
+++ b/.github/workflows/bayn-qualification.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Install local Bayn lifecycle dependencies
         shell: bash
-        run: bun install --frozen-lockfile --ignore-scripts --filter @proompteng/bayn
+        run: bun install --frozen-lockfile --ignore-scripts --filter @proompteng/bayn --filter @proompteng/scripts
 
       - name: Verify candidate lifecycle before any image or credential access
         id: lifecycle
@@ -153,26 +153,40 @@ jobs:
             --entrypoint bayn-qualification-collector \
             "$IMAGE_REFERENCE" >"$log" 2>&1
 
-          mapfile -t terminal_lines < <(grep '^BAYN_QUALIFICATION_TERMINAL=' "$log")
+          terminal_lines=()
+          while IFS= read -r terminal_line; do terminal_lines+=("$terminal_line"); done < <(grep '^BAYN_QUALIFICATION_TERMINAL=' "$log")
           test "${#terminal_lines[@]}" -eq 1
           printf '%s\n' "${terminal_lines[0]#BAYN_QUALIFICATION_TERMINAL=}" > "$terminal"
-          jq -e '
-            .schemaVersion == "bayn.qualification-collector-terminal.v1"
-            and (.sourceSha | test("^[0-9a-f]{40}$"))
-            and (.eligibilityHash | test("^[0-9a-f]{64}$"))
-            and (.candidateBindingHash | test("^[0-9a-f]{64}$"))
-            and (.terminal.schemaVersion == "bayn.qualification-execution.v1")
-            and (.terminal.runId | test("^[0-9a-f]{64}$"))
-            and (.terminal.lockId | test("^[0-9a-f]{64}$"))
-            and (.terminal.resultHash | test("^[0-9a-f]{64}$"))
-            and (.audit.schemaVersion == "bayn.qualification-audit.v2")
-            and (.audit.status == "PASS")
-            and (.audit.runId == .terminal.runId)
-            and (.audit.evidence.lockId == .terminal.lockId)
-            and (.audit.evidence.resultHash == .terminal.resultHash)
-            and (.evidenceHash | test("^[0-9a-f]{64}$"))
-          ' "$terminal" >/dev/null
           echo "terminal=${terminal}" >> "$GITHUB_OUTPUT"
+
+      - name: Build typed PAPER activation evidence
+        id: activation-evidence
+        if: steps.lifecycle.outputs.eligible == 'true' && steps.qualify.outcome == 'success'
+        shell: bash
+        env:
+          TERMINAL: ${{ steps.qualify.outputs.terminal }}
+          REVIEWED_PINS_JSON: ${{ vars.BAYN_PAPER_ACTIVATION_REVIEWED_PINS_JSON }}
+        run: |
+          set -euo pipefail
+          set +x
+          umask 077
+
+          output_directory="${RUNNER_TEMP}/bayn-paper-activation-evidence"
+          rm -rf -- "$output_directory"
+          if [[ -z "${REVIEWED_PINS_JSON:-}" ]]; then
+            echo 'Reviewed PAPER activation pins are not configured; activation evidence remains dormant.'
+            echo 'emit=false' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          reviewed_pins="${RUNNER_TEMP}/bayn-paper-activation-reviewed-pins.json"
+          printf '%s' "$REVIEWED_PINS_JSON" > "$reviewed_pins"
+          bun packages/scripts/src/bayn/verify-paper-activation.ts \
+            --mode build-evidence \
+            --terminal "$TERMINAL" \
+            --reviewed-pins "$reviewed_pins" \
+            --output-dir "$output_directory" \
+            --github-output "$GITHUB_OUTPUT"
 
       - name: Upload immutable terminal qualification evidence
         if: steps.lifecycle.outputs.eligible == 'true' && steps.qualify.outcome == 'success'
@@ -181,6 +195,18 @@ jobs:
           name: bayn-qualification-terminal-${{ github.sha }}-${{ github.run_id }}
           path: ${{ steps.qualify.outputs.terminal }}
           if-no-files-found: error
+          retention-days: 90
+
+      - name: Upload immutable PAPER activation evidence
+        if: steps.lifecycle.outputs.eligible == 'true' && steps.activation-evidence.outcome == 'success' && steps.activation-evidence.outputs.emit == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: bayn-paper-activation-evidence-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            ${{ runner.temp }}/bayn-paper-activation-evidence/evidence.json
+            ${{ runner.temp }}/bayn-paper-activation-evidence/pins.json
+          if-no-files-found: error
+          overwrite: false
           retention-days: 90
 
       - name: Summarize terminal qualification evidence

--- a/packages/scripts/src/bayn/bayn-paper-activation-workflow.test.ts
+++ b/packages/scripts/src/bayn/bayn-paper-activation-workflow.test.ts
@@ -5,7 +5,19 @@ import { dirname, join } from 'node:path'
 import { describe, expect, test } from 'bun:test'
 import { parse } from 'yaml'
 
+import {
+  buildPaperActivationArtifact,
+  canonicalHashV1,
+  deriveObserveRollbackGeneration,
+  evaluatePaperActivation,
+  extractPaperActivationManifestPins,
+  renderPaperActivationTransition,
+  type QualificationTerminalEvidence,
+} from './verify-paper-activation'
+
 const path = new URL('../../../../.github/workflows/bayn-paper-activation.yml', import.meta.url)
+const deploymentPath = new URL('../../../../argocd/applications/bayn/deployment.yaml', import.meta.url)
+const kustomizationPath = new URL('../../../../argocd/applications/bayn/kustomization.yaml', import.meta.url)
 const workflow = readFileSync(path, 'utf8')
 const parsed = parse(workflow) as {
   readonly name: string
@@ -48,6 +60,83 @@ const stepFor = (jobName: string, stepName: string) => {
   const step = parsed.jobs[jobName]?.steps.find((candidate) => candidate.name === stepName)
   if (step === undefined) throw new Error(`workflow step ${jobName}/${stepName} is missing`)
   return step
+}
+
+const syntheticTerminal = (
+  sourceSha: string,
+  imageRepository: string,
+  imageDigest: string,
+  verdict: 'QUALIFIED' | 'REJECTED',
+): QualificationTerminalEvidence => {
+  const runId = 'a'.repeat(64)
+  const lockId = 'b'.repeat(64)
+  const resultHash = 'c'.repeat(64)
+  const auditMaterial = {
+    schemaVersion: 'bayn.qualification-audit.v2' as const,
+    runId,
+    status: 'PASS' as const,
+    reference: { economicStatus: 'PASS' as const, observations: 1, rebalanceCount: 0 },
+    evidence: { artifactCount: 1, eventCount: 2, gateCount: 3, lockId, resultHash },
+    policies: {
+      declaredAt: '2026-08-01T06:00:00Z',
+      lockId,
+      policySetHash: 'd'.repeat(64),
+      documents: [
+        {
+          name: 'execution',
+          schemaVersion: 'bayn.policy.v1',
+          contentHash: 'e'.repeat(64),
+          content: { maximum: 'PAPER' },
+        },
+      ],
+    },
+    contamination: {
+      lockCreatedAt: '2026-08-01T06:00:00Z',
+      resultCommittedAt: '2026-08-01T07:00:00Z',
+      replicas: ['signal-1'],
+      principals: { candidate: 'candidate', publishers: ['publisher'] },
+      access: [
+        {
+          replica: 'signal-1',
+          queryId: 'query-1',
+          queryStartTime: '2026-08-01T06:30:00Z',
+          user: 'candidate',
+          kind: 'bars' as const,
+        },
+      ],
+    },
+    repository: {
+      sourceCommitExists: true,
+      sourceCommitAncestorOfMain: true,
+      preLockResultReferences: [],
+      sourceRevision: sourceSha,
+    },
+    checks: [{ name: 'terminal-result-binding', passed: true, evidence: `verdict=${verdict}` }],
+  }
+  const audit = { ...auditMaterial, auditHash: canonicalHashV1(auditMaterial) }
+  const terminalMaterial = {
+    schemaVersion: 'bayn.qualification-collector-terminal.v1' as const,
+    repository: 'proompteng/lab',
+    currentMainSha: sourceSha,
+    sourceSha,
+    image: { repository: imageRepository, digest: imageDigest },
+    candidateOrdinal: 1,
+    githubRunId: '9001',
+    githubRunAttempt: 1,
+    preregistrationHash: 'f'.repeat(64),
+    eligibilityHash: '1'.repeat(64),
+    candidateBindingHash: '2'.repeat(64),
+    terminal: {
+      schemaVersion: 'bayn.qualification-execution.v1' as const,
+      runId,
+      lockId,
+      resultHash,
+      verdict,
+      persistence: { artifactCount: 1, eventCount: 2, gateCount: 3 },
+    },
+    audit,
+  }
+  return { ...terminalMaterial, evidenceHash: canonicalHashV1(terminalMaterial) }
 }
 
 const writeExecutable = (directory: string, name: string, contents: string): void => {
@@ -587,6 +676,102 @@ esac
       expect(result.githubOutput).toContain('live=false')
     } finally {
       result.dispose()
+    }
+  })
+
+  test('proves the synthetic QUALIFIED handoff and emits no artifact for REJECTED', () => {
+    const deployment = readFileSync(deploymentPath, 'utf8')
+    const kustomization = readFileSync(kustomizationPath, 'utf8')
+    const checkedOutPins = extractPaperActivationManifestPins(deployment, kustomization)
+    const terminal = syntheticTerminal(
+      checkedOutPins.sourceSha,
+      checkedOutPins.kustomizeImageRepository,
+      checkedOutPins.kustomizeImageDigest,
+      'QUALIFIED',
+    )
+    const reviewedPins = {
+      schemaVersion: 'bayn.paper-activation-reviewed-pins.v1' as const,
+      sourceSha: checkedOutPins.sourceSha,
+      imageRepository: checkedOutPins.kustomizeImageRepository,
+      imageDigest: checkedOutPins.kustomizeImageDigest,
+      protocolHash: '3'.repeat(64),
+      strategyBehaviorHash: checkedOutPins.strategyBehaviorHash,
+      strategyParameterHash: checkedOutPins.strategyParameterHash,
+      strategyParameterSchemaVersion: 'bayn.risk-balanced-trend.protocol.v4' as const,
+      qualificationExecutionPolicyHash: '4'.repeat(64),
+      previousGenerationHash: checkedOutPins.currentAuthorityGenerationHash,
+      accountId: 'paper-account-1',
+      riskPolicyHash: '5'.repeat(64),
+      proofPlanHash: '6'.repeat(64),
+      reconciliationId: '7'.repeat(64),
+      reconciliationContentHash: '8'.repeat(64),
+      qualificationExpiresAt: '2026-08-01T10:00:00Z',
+      accountBindingHash: '9'.repeat(64),
+      brokerEnvironment: 'sandbox' as const,
+      brokerBaseUrl: 'https://paper-api.alpaca.markets',
+      maximumAuthority: 'PAPER' as const,
+      authorityExpiresAt: '2026-08-01T09:00:00Z',
+      unresolvedMutationCount: 0,
+      unknownMutationCount: 0,
+      openOrderCount: 0,
+      discrepancyCount: 0,
+      reconciliation: 'EXACT' as const,
+      killSwitchActive: false,
+      identityGap: false,
+      activationState: 'PRECOMMITTED' as const,
+    }
+    const artifact = buildPaperActivationArtifact({ terminal, reviewedPins })
+    expect(artifact).not.toBeNull()
+    if (artifact === null) return
+    const manifestPins = {
+      ...checkedOutPins,
+      qualificationRunId: artifact.evidence.qualificationRunId,
+    }
+    const decision = evaluatePaperActivation({
+      evidence: artifact.evidence,
+      pins: artifact.pins,
+      manifestPins,
+      now: '2026-08-01T08:00:00Z',
+      expectedRepository: 'proompteng/lab',
+      expectedActivationId: artifact.evidence.activationId,
+      trustedCurrentMainSha: checkedOutPins.sourceSha,
+    })
+    expect(decision).toMatchObject({ status: 'eligible' })
+    if (decision.status !== 'eligible') return
+    const rollback = deriveObserveRollbackGeneration({
+      repository: 'proompteng/lab',
+      activationId: artifact.evidence.activationId,
+      sourceMainSha: checkedOutPins.sourceSha,
+      previousObserveGenerationHash: checkedOutPins.currentAuthorityGenerationHash,
+      paperAuthorityGenerationHash: decision.authorityGenerationHash,
+    })
+    const proposal = renderPaperActivationTransition(
+      deployment,
+      decision.authorityGenerationHash,
+      rollback.generationHash,
+      artifact.evidence.authorityExpiresAt,
+    )
+    expect(proposal.paperDeployment).toContain('value: PAPER')
+    expect(proposal.paperDeployment).toContain('value: mutation')
+    expect(proposal.observeDeployment).toContain('value: OBSERVE')
+    expect(proposal.observeDeployment).toContain('value: read-only')
+
+    const rejected = syntheticTerminal(
+      checkedOutPins.sourceSha,
+      checkedOutPins.kustomizeImageRepository,
+      checkedOutPins.kustomizeImageDigest,
+      'REJECTED',
+    )
+    const rejectedArtifact = buildPaperActivationArtifact({ terminal: rejected, reviewedPins })
+    expect(rejectedArtifact).toBeNull()
+    const outputDirectory = mkdtempSync(join(tmpdir(), 'bayn-paper-rejected-'))
+    try {
+      if (rejectedArtifact !== null)
+        writeFileSync(join(outputDirectory, 'evidence.json'), JSON.stringify(rejectedArtifact))
+      expect(existsSync(join(outputDirectory, 'evidence.json'))).toBe(false)
+      expect(existsSync(join(outputDirectory, 'pins.json'))).toBe(false)
+    } finally {
+      rmSync(outputDirectory, { recursive: true, force: true })
     }
   })
 

--- a/packages/scripts/src/bayn/bayn-qualification-workflow.test.ts
+++ b/packages/scripts/src/bayn/bayn-qualification-workflow.test.ts
@@ -68,6 +68,8 @@ describe('Bayn qualification workflow contract', () => {
       'Build and load the exact checked-out source image locally',
       'Run exactly one isolated read-only qualification',
       'Upload immutable terminal qualification evidence',
+      'Build typed PAPER activation evidence',
+      'Upload immutable PAPER activation evidence',
       'Summarize terminal qualification evidence',
     ]) {
       expect(step(name).if).toContain("steps.lifecycle.outputs.eligible == 'true'")
@@ -145,6 +147,30 @@ describe('Bayn qualification workflow contract', () => {
       .join('\n')
     expect((orchestrationText.match(/BAYN_QUALIFICATION_MODE=execute/g) ?? []).length).toBe(1)
     expect((orchestrationText.match(/docker run --rm/g) ?? []).length).toBe(1)
+  })
+
+  test('builds and uploads one exact immutable activation artifact through the typed verifier', () => {
+    const producer = step('Build typed PAPER activation evidence')
+    const upload = step('Upload immutable PAPER activation evidence')
+    expect(producer.id).toBe('activation-evidence')
+    expect(producer.if).toBe("steps.lifecycle.outputs.eligible == 'true' && steps.qualify.outcome == 'success'")
+    expect(producer.env).toMatchObject({
+      REVIEWED_PINS_JSON: '${{ vars.BAYN_PAPER_ACTIVATION_REVIEWED_PINS_JSON }}',
+    })
+    expect(producer.run).toContain('--mode build-evidence')
+    expect(producer.run).toContain('--terminal "$TERMINAL"')
+    expect(producer.run).toContain('--reviewed-pins "$reviewed_pins"')
+    expect(producer.run).toContain('--output-dir "$output_directory"')
+    expect(producer.run).not.toContain('jq')
+    expect(upload.uses).toBe('actions/upload-artifact@v4')
+    expect(upload.if).toContain("steps.activation-evidence.outputs.emit == 'true'")
+    expect(upload.with).toMatchObject({
+      name: 'bayn-paper-activation-evidence-${{ github.run_id }}-${{ github.run_attempt }}',
+      path: '${{ runner.temp }}/bayn-paper-activation-evidence/evidence.json\n${{ runner.temp }}/bayn-paper-activation-evidence/pins.json\n',
+      'if-no-files-found': 'error',
+      overwrite: false,
+      'retention-days': 90,
+    })
   })
 
   test('keeps the qualification boundary read-only and wires credentials only at execution', () => {

--- a/packages/scripts/src/bayn/verify-paper-activation.test.ts
+++ b/packages/scripts/src/bayn/verify-paper-activation.test.ts
@@ -1,4 +1,5 @@
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
+import { execFileSync } from 'node:child_process'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -6,6 +7,8 @@ import { describe, expect, test } from 'bun:test'
 import { parse } from 'yaml'
 
 import {
+  buildPaperActivationArtifact,
+  canonicalHashV1,
   deriveObserveRollbackGeneration,
   evaluatePaperActivation,
   extractDeploymentAuthorityState,
@@ -14,7 +17,9 @@ import {
   renderObserveRollback,
   renderPaperActivationTransition,
   type PaperActivationEvidence,
+  type PaperActivationReviewedPins,
   type PaperAuthorityGenerationMaterial,
+  type QualificationTerminalEvidence,
 } from './verify-paper-activation'
 
 const hash = 'a'.repeat(64)
@@ -54,26 +59,99 @@ const authorityGeneration = (overrides: Partial<PaperAuthorityGenerationMaterial
   const material = generationMaterial(overrides)
   return { ...material, generationHash: paperAuthorityGenerationHash(material) }
 }
-const evidence = (overrides: Partial<PaperActivationEvidence> = {}): PaperActivationEvidence => ({
-  schemaVersion: 1,
+const qualificationAuditMaterial = {
+  schemaVersion: 'bayn.qualification-audit.v2' as const,
+  runId: hash,
+  status: 'PASS' as const,
+  reference: { economicStatus: 'PASS' as const, observations: 1, rebalanceCount: 0 },
+  evidence: { artifactCount: 1, eventCount: 2, gateCount: 3, lockId: '1'.repeat(64), resultHash: '2'.repeat(64) },
+  policies: {
+    declaredAt: '2026-07-31T06:00:00Z',
+    lockId: '1'.repeat(64),
+    policySetHash: '3'.repeat(64),
+    documents: [
+      {
+        name: 'execution',
+        schemaVersion: 'bayn.policy.v1',
+        contentHash: '4'.repeat(64),
+        content: { maximum: 'PAPER' },
+      },
+    ],
+  },
+  contamination: {
+    lockCreatedAt: '2026-07-31T06:00:00Z',
+    resultCommittedAt: '2026-07-31T07:00:00Z',
+    replicas: ['signal-1'],
+    principals: { candidate: 'candidate', publishers: ['publisher'] },
+    access: [
+      {
+        replica: 'signal-1',
+        queryId: 'query-1',
+        queryStartTime: '2026-07-31T06:30:00Z',
+        user: 'candidate',
+        kind: 'bars' as const,
+      },
+    ],
+  },
+  repository: {
+    sourceCommitExists: true,
+    sourceCommitAncestorOfMain: true,
+    preLockResultReferences: [],
+    sourceRevision: sourceSha,
+  },
+  checks: [{ name: 'terminal-result-binding', passed: true, evidence: 'verdict=QUALIFIED' }],
+}
+const qualificationAudit = {
+  ...qualificationAuditMaterial,
+  auditHash: canonicalHashV1(qualificationAuditMaterial),
+}
+const qualificationTerminalMaterial = {
+  schemaVersion: 'bayn.qualification-collector-terminal.v1' as const,
   repository: 'proompteng/lab',
-  mainSha: sourceSha,
   currentMainSha: sourceSha,
+  sourceSha,
+  image: { repository: 'registry.ide-newton.ts.net/lab/bayn', digest: `sha256:${'c'.repeat(64)}` },
+  candidateOrdinal: 1,
+  githubRunId: '77',
+  githubRunAttempt: 1,
+  preregistrationHash: '8'.repeat(64),
+  eligibilityHash: '9'.repeat(64),
+  candidateBindingHash: 'a'.repeat(64),
+  terminal: {
+    schemaVersion: 'bayn.qualification-execution.v1' as const,
+    runId: hash,
+    lockId: '1'.repeat(64),
+    resultHash: '2'.repeat(64),
+    verdict: 'QUALIFIED' as const,
+    persistence: { artifactCount: 1, eventCount: 2, gateCount: 3 },
+  },
+  audit: qualificationAudit,
+}
+const qualificationTerminal: QualificationTerminalEvidence = {
+  ...qualificationTerminalMaterial,
+  evidenceHash: canonicalHashV1(qualificationTerminalMaterial),
+}
+const reviewedPins = (): PaperActivationReviewedPins => ({
+  schemaVersion: 'bayn.paper-activation-reviewed-pins.v1',
   sourceSha,
   imageRepository: 'registry.ide-newton.ts.net/lab/bayn',
   imageDigest: `sha256:${'c'.repeat(64)}`,
   protocolHash: hash,
   strategyBehaviorHash: hash,
   strategyParameterHash: hash,
-  qualificationRunId: hash,
-  qualificationDecision: 'QUALIFIED',
-  qualificationObservedAt: '2026-07-31T07:00:00Z',
+  strategyParameterSchemaVersion: 'bayn.risk-balanced-trend.protocol.v4',
+  qualificationExecutionPolicyHash: '3'.repeat(64),
+  previousGenerationHash: '0'.repeat(64),
+  accountId: 'paper-account-1',
+  riskPolicyHash: '4'.repeat(64),
+  proofPlanHash: '5'.repeat(64),
+  reconciliationId: '6'.repeat(64),
+  reconciliationContentHash: '7'.repeat(64),
   qualificationExpiresAt: '2026-08-01T07:00:00Z',
   accountBindingHash: hash,
   brokerEnvironment: 'sandbox',
   brokerBaseUrl: 'https://paper-api.alpaca.markets',
   maximumAuthority: 'PAPER',
-  authorityGeneration: authorityGeneration(),
   authorityExpiresAt: '2026-07-31T09:00:00Z',
   unresolvedMutationCount: 0,
   unknownMutationCount: 0,
@@ -83,9 +161,66 @@ const evidence = (overrides: Partial<PaperActivationEvidence> = {}): PaperActiva
   killSwitchActive: false,
   identityGap: false,
   activationState: 'PRECOMMITTED',
-  activationId: 'proompt-405-paper-proof-1',
-  ...overrides,
 })
+const evidence = (overrides: Partial<PaperActivationEvidence> = {}): PaperActivationEvidence => {
+  const base: PaperActivationEvidence = {
+    schemaVersion: 2,
+    repository: 'proompteng/lab',
+    mainSha: sourceSha,
+    currentMainSha: sourceSha,
+    sourceSha,
+    imageRepository: 'registry.ide-newton.ts.net/lab/bayn',
+    imageDigest: `sha256:${'c'.repeat(64)}`,
+    protocolHash: hash,
+    strategyBehaviorHash: hash,
+    strategyParameterHash: hash,
+    qualificationRunId: hash,
+    qualificationDecision: 'QUALIFIED',
+    qualificationObservedAt: '2026-07-31T07:00:00Z',
+    qualificationExpiresAt: '2026-08-01T07:00:00Z',
+    accountBindingHash: hash,
+    brokerEnvironment: 'sandbox',
+    brokerBaseUrl: 'https://paper-api.alpaca.markets',
+    maximumAuthority: 'PAPER',
+    authorityGeneration: authorityGeneration(),
+    authorityExpiresAt: '2026-07-31T09:00:00Z',
+    unresolvedMutationCount: 0,
+    unknownMutationCount: 0,
+    openOrderCount: 0,
+    discrepancyCount: 0,
+    reconciliation: 'EXACT',
+    killSwitchActive: false,
+    identityGap: false,
+    activationState: 'PRECOMMITTED',
+    activationId: 'qualification-77-1',
+    qualificationTerminal,
+  }
+  const value = { ...base, ...overrides }
+  const auditMaterial = {
+    ...qualificationAuditMaterial,
+    runId: value.qualificationRunId,
+    evidence: { ...qualificationAuditMaterial.evidence, lockId: value.qualificationTerminal.terminal.lockId },
+    policies: { ...qualificationAuditMaterial.policies, lockId: value.qualificationTerminal.terminal.lockId },
+    repository: { ...qualificationAuditMaterial.repository, sourceRevision: value.sourceSha },
+  }
+  const audit = { ...auditMaterial, auditHash: canonicalHashV1(auditMaterial) }
+  const terminalMaterial = {
+    ...qualificationTerminalMaterial,
+    currentMainSha: value.mainSha,
+    sourceSha: value.sourceSha,
+    image: { repository: value.imageRepository, digest: value.imageDigest },
+    terminal: {
+      ...qualificationTerminalMaterial.terminal,
+      runId: value.qualificationRunId,
+      verdict: value.qualificationDecision,
+    },
+    audit,
+  }
+  return {
+    ...value,
+    qualificationTerminal: { ...terminalMaterial, evidenceHash: canonicalHashV1(terminalMaterial) },
+  }
+}
 const manifestPins = (value: PaperActivationEvidence) => ({
   sourceSha: value.sourceSha,
   strategyBehaviorHash: value.strategyBehaviorHash,
@@ -114,11 +249,92 @@ const evaluate = (value = evidence()) =>
     manifestPins: manifestPins(value),
     now,
     expectedRepository: 'proompteng/lab',
-    expectedActivationId: 'proompt-405-paper-proof-1',
+    expectedActivationId: 'qualification-77-1',
     trustedCurrentMainSha: sourceSha,
   })
 
 describe('Bayn PAPER activation verifier', () => {
+  test('builds one authenticated activation artifact from a qualified terminal and reviewed pins', () => {
+    const artifact = buildPaperActivationArtifact({ terminal: qualificationTerminal, reviewedPins: reviewedPins() })
+    expect(artifact).not.toBeNull()
+    if (artifact === null) return
+    expect(artifact.evidence.qualificationDecision).toBe('QUALIFIED')
+    expect(artifact.evidence.qualificationTerminal).toEqual(qualificationTerminal)
+    expect(artifact.evidence.activationId).toBe('qualification-77-1')
+    expect(
+      evaluatePaperActivation({
+        evidence: artifact.evidence,
+        pins: artifact.pins,
+        manifestPins: manifestPins(artifact.evidence),
+        now,
+        expectedRepository: artifact.evidence.repository,
+        expectedActivationId: artifact.evidence.activationId,
+        trustedCurrentMainSha: sourceSha,
+      }),
+    ).toMatchObject({ status: 'eligible' })
+  })
+
+  test('does not build an activation artifact for a rejected terminal verdict', () => {
+    const rejectedMaterial = {
+      ...qualificationTerminalMaterial,
+      terminal: { ...qualificationTerminalMaterial.terminal, verdict: 'REJECTED' as const },
+    }
+    const rejected: QualificationTerminalEvidence = {
+      ...rejectedMaterial,
+      evidenceHash: canonicalHashV1(rejectedMaterial),
+    }
+    expect(buildPaperActivationArtifact({ terminal: rejected, reviewedPins: reviewedPins() })).toBeNull()
+  })
+
+  test('CLI materializes exactly evidence.json and pins.json for a qualified terminal', () => {
+    const root = mkdtempSync(join(tmpdir(), 'bayn-paper-evidence-cli-'))
+    const terminalPath = join(root, 'terminal.json')
+    const reviewedPinsPath = join(root, 'reviewed-pins.json')
+    const outputDirectory = join(root, 'artifact')
+    const githubOutput = join(root, 'github-output')
+    writeFileSync(terminalPath, `${JSON.stringify(qualificationTerminal)}\n`)
+    writeFileSync(reviewedPinsPath, `${JSON.stringify(reviewedPins())}\n`)
+    try {
+      execFileSync(
+        process.execPath,
+        [
+          join(process.cwd(), 'packages/scripts/src/bayn/verify-paper-activation.ts'),
+          '--mode',
+          'build-evidence',
+          '--terminal',
+          terminalPath,
+          '--reviewed-pins',
+          reviewedPinsPath,
+          '--output-dir',
+          outputDirectory,
+          '--github-output',
+          githubOutput,
+        ],
+        { cwd: process.cwd(), encoding: 'utf8' },
+      )
+      expect(JSON.parse(readFileSync(join(outputDirectory, 'evidence.json'), 'utf8'))).toMatchObject({
+        schemaVersion: 2,
+        qualificationDecision: 'QUALIFIED',
+      })
+      expect(JSON.parse(readFileSync(join(outputDirectory, 'pins.json'), 'utf8'))).toEqual(
+        buildPaperActivationArtifact({ terminal: qualificationTerminal, reviewedPins: reviewedPins() })?.pins,
+      )
+      expect(readFileSync(githubOutput, 'utf8')).toBe('emit=true\n')
+      expect(readdirSync(outputDirectory).sort()).toEqual(['evidence.json', 'pins.json'])
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test('rejects a terminal artifact whose authenticated evidence hash was changed', () => {
+    expect(() =>
+      buildPaperActivationArtifact({
+        terminal: { ...qualificationTerminal, sourceSha: 'd'.repeat(40) },
+        reviewedPins: reviewedPins(),
+      }),
+    ).toThrow('invalid or unauthenticated')
+  })
+
   test('accepts one exact current-main precommitted sandbox PAPER tuple', () =>
     expect(evaluate()).toMatchObject({ status: 'eligible' }))
   const holds: Array<[string, Partial<PaperActivationEvidence>, string]> = [

--- a/packages/scripts/src/bayn/verify-paper-activation.ts
+++ b/packages/scripts/src/bayn/verify-paper-activation.ts
@@ -1,4 +1,4 @@
-import { readFileSync, writeFileSync } from 'node:fs'
+import { appendFileSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { createHash } from 'node:crypto'
 
 import { parse } from 'yaml'
@@ -52,8 +52,82 @@ export type DeploymentAuthorityState = {
   readonly authorityGenerationHash: string
 }
 
+export type QualificationAuditEvidence = {
+  readonly schemaVersion: 'bayn.qualification-audit.v2'
+  readonly runId: string
+  readonly status: 'PASS' | 'FAIL'
+  readonly reference: {
+    readonly economicStatus: 'PASS' | 'FAIL_CLOSED'
+    readonly observations: number
+    readonly rebalanceCount: number
+  }
+  readonly evidence: {
+    readonly artifactCount: number
+    readonly eventCount: number
+    readonly gateCount: number
+    readonly lockId: string
+    readonly resultHash: string
+  }
+  readonly policies: {
+    readonly declaredAt: string
+    readonly lockId: string
+    readonly policySetHash: string
+    readonly documents: readonly {
+      readonly name: string
+      readonly schemaVersion: string
+      readonly contentHash: string
+      readonly content: unknown
+    }[]
+  }
+  readonly contamination: {
+    readonly lockCreatedAt: string
+    readonly resultCommittedAt: string
+    readonly replicas: readonly string[]
+    readonly principals: { readonly candidate: string; readonly publishers: readonly string[] }
+    readonly access: readonly {
+      readonly replica: string
+      readonly queryId: string
+      readonly queryStartTime: string
+      readonly user: string
+      readonly kind: 'manifest' | 'sessions' | 'bars'
+    }[]
+  }
+  readonly repository: {
+    readonly sourceCommitExists: boolean
+    readonly sourceCommitAncestorOfMain: boolean
+    readonly preLockResultReferences: readonly string[]
+    readonly sourceRevision: string
+  }
+  readonly checks: readonly { readonly name: string; readonly passed: boolean; readonly evidence: string }[]
+  readonly auditHash: string
+}
+
+export type QualificationTerminalEvidence = {
+  readonly schemaVersion: 'bayn.qualification-collector-terminal.v1'
+  readonly repository: string
+  readonly currentMainSha: string
+  readonly sourceSha: string
+  readonly image: { readonly repository: string; readonly digest: string }
+  readonly candidateOrdinal: number
+  readonly githubRunId: string
+  readonly githubRunAttempt: number
+  readonly preregistrationHash: string
+  readonly eligibilityHash: string
+  readonly candidateBindingHash: string
+  readonly terminal: {
+    readonly schemaVersion: 'bayn.qualification-execution.v1'
+    readonly runId: string
+    readonly lockId: string
+    readonly resultHash: string
+    readonly verdict: 'QUALIFIED' | 'REJECTED'
+    readonly persistence: { readonly artifactCount: number; readonly eventCount: number; readonly gateCount: number }
+  }
+  readonly audit: QualificationAuditEvidence
+  readonly evidenceHash: string
+}
+
 export type PaperActivationEvidence = {
-  readonly schemaVersion: 1
+  readonly schemaVersion: 2
   readonly repository: string
   readonly mainSha: string
   readonly currentMainSha: string
@@ -82,6 +156,46 @@ export type PaperActivationEvidence = {
   readonly identityGap: boolean
   readonly activationState: 'PRECOMMITTED' | 'IN_FLIGHT' | 'CONSUMED' | 'CANCELLED'
   readonly activationId: string
+  readonly qualificationTerminal: QualificationTerminalEvidence
+}
+
+export type PaperActivationReviewedPins = {
+  readonly schemaVersion: 'bayn.paper-activation-reviewed-pins.v1'
+  readonly sourceSha: string
+  readonly imageRepository: string
+  readonly imageDigest: string
+  readonly protocolHash: string
+  readonly strategyBehaviorHash: string
+  readonly strategyParameterHash: string
+  readonly strategyParameterSchemaVersion:
+    | 'bayn.risk-balanced-trend.protocol.v3'
+    | 'bayn.risk-balanced-trend.protocol.v4'
+  readonly qualificationExecutionPolicyHash: string
+  readonly previousGenerationHash: string
+  readonly accountId: string
+  readonly riskPolicyHash: string
+  readonly proofPlanHash: string
+  readonly reconciliationId: string
+  readonly reconciliationContentHash: string
+  readonly qualificationExpiresAt: string
+  readonly accountBindingHash: string
+  readonly brokerEnvironment: 'sandbox' | 'live'
+  readonly brokerBaseUrl: string
+  readonly maximumAuthority: 'OBSERVE' | 'PAPER' | 'LIVE'
+  readonly authorityExpiresAt: string
+  readonly unresolvedMutationCount: number
+  readonly unknownMutationCount: number
+  readonly openOrderCount: number
+  readonly discrepancyCount: number
+  readonly reconciliation: 'EXACT' | 'NON_EXACT' | 'UNKNOWN'
+  readonly killSwitchActive: boolean
+  readonly identityGap: boolean
+  readonly activationState: 'PRECOMMITTED' | 'IN_FLIGHT' | 'CONSUMED' | 'CANCELLED'
+}
+
+export type PaperActivationArtifact = {
+  readonly evidence: PaperActivationEvidence
+  readonly pins: PaperActivationPins
 }
 
 export type PaperActivationPins = Pick<
@@ -153,6 +267,7 @@ const evidenceKeys = [
   'identityGap',
   'activationState',
   'activationId',
+  'qualificationTerminal',
 ] as const satisfies readonly (keyof PaperActivationEvidence)[]
 const pinKeys = [
   'sourceSha',
@@ -203,6 +318,88 @@ const paperGenerationKeys = [
   'reconciliationContentHash',
   'generationHash',
 ] as const satisfies readonly (keyof PaperAuthorityGeneration)[]
+
+const qualificationTerminalKeys = [
+  'schemaVersion',
+  'repository',
+  'currentMainSha',
+  'sourceSha',
+  'image',
+  'candidateOrdinal',
+  'githubRunId',
+  'githubRunAttempt',
+  'preregistrationHash',
+  'eligibilityHash',
+  'candidateBindingHash',
+  'terminal',
+  'audit',
+  'evidenceHash',
+] as const satisfies readonly (keyof QualificationTerminalEvidence)[]
+const qualificationExecutionKeys = ['schemaVersion', 'runId', 'lockId', 'resultHash', 'verdict', 'persistence'] as const
+const qualificationPersistenceKeys = ['artifactCount', 'eventCount', 'gateCount'] as const
+const qualificationAuditKeys = [
+  'schemaVersion',
+  'runId',
+  'status',
+  'reference',
+  'evidence',
+  'policies',
+  'contamination',
+  'repository',
+  'checks',
+  'auditHash',
+] as const
+const qualificationAuditReferenceKeys = ['economicStatus', 'observations', 'rebalanceCount'] as const
+const qualificationAuditEvidenceKeys = ['artifactCount', 'eventCount', 'gateCount', 'lockId', 'resultHash'] as const
+const qualificationAuditPoliciesKeys = ['declaredAt', 'lockId', 'policySetHash', 'documents'] as const
+const qualificationAuditDocumentKeys = ['name', 'schemaVersion', 'contentHash', 'content'] as const
+const qualificationAuditContaminationKeys = [
+  'lockCreatedAt',
+  'resultCommittedAt',
+  'replicas',
+  'principals',
+  'access',
+] as const
+const qualificationAuditPrincipalsKeys = ['candidate', 'publishers'] as const
+const qualificationAuditAccessKeys = ['replica', 'queryId', 'queryStartTime', 'user', 'kind'] as const
+const qualificationAuditRepositoryKeys = [
+  'sourceCommitExists',
+  'sourceCommitAncestorOfMain',
+  'preLockResultReferences',
+  'sourceRevision',
+] as const
+const qualificationAuditCheckKeys = ['name', 'passed', 'evidence'] as const
+const reviewedPinKeys = [
+  'schemaVersion',
+  'sourceSha',
+  'imageRepository',
+  'imageDigest',
+  'protocolHash',
+  'strategyBehaviorHash',
+  'strategyParameterHash',
+  'strategyParameterSchemaVersion',
+  'qualificationExecutionPolicyHash',
+  'previousGenerationHash',
+  'accountId',
+  'riskPolicyHash',
+  'proofPlanHash',
+  'reconciliationId',
+  'reconciliationContentHash',
+  'qualificationExpiresAt',
+  'accountBindingHash',
+  'brokerEnvironment',
+  'brokerBaseUrl',
+  'maximumAuthority',
+  'authorityExpiresAt',
+  'unresolvedMutationCount',
+  'unknownMutationCount',
+  'openOrderCount',
+  'discrepancyCount',
+  'reconciliation',
+  'killSwitchActive',
+  'identityGap',
+  'activationState',
+] as const satisfies readonly (keyof PaperActivationReviewedPins)[]
 
 const requirePins = <Key extends string>(value: unknown, keys: readonly Key[]): Record<Key, string> | null => {
   if (typeof value !== 'object' || value === null || Array.isArray(value)) return null
@@ -274,7 +471,289 @@ const canonicalJsonV1 = (value: unknown, ancestors: readonly object[] = []): str
   return `{${entries.join(',')}}`
 }
 
-const canonicalHashV1 = (value: unknown): string => sha256(canonicalJsonV1(value))
+export const canonicalHashV1 = (value: unknown): string => sha256(canonicalJsonV1(value))
+
+const isNonNegativeSafeInteger = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isSafeInteger(value) && value >= 0
+
+const nonEmptyStringArray = (value: unknown): value is readonly string[] =>
+  Array.isArray(value) && value.every((entry) => typeof entry === 'string' && entry.length > 0)
+
+const exactObject = (value: unknown, keys: readonly string[]): Record<string, unknown> | null => {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return null
+  const record = value as Record<string, unknown>
+  return hasExactKeys(record, keys) ? record : null
+}
+
+const requireQualificationAudit = (value: unknown): QualificationAuditEvidence | null => {
+  const record = exactObject(value, qualificationAuditKeys)
+  if (record === null) return null
+  if (record.schemaVersion !== 'bayn.qualification-audit.v2') return null
+  if (typeof record.runId !== 'string' || !isHash(record.runId)) return null
+  if (record.status !== 'PASS' && record.status !== 'FAIL') return null
+
+  const reference = exactObject(record.reference, qualificationAuditReferenceKeys)
+  if (reference === null) return null
+  if (reference.economicStatus !== 'PASS' && reference.economicStatus !== 'FAIL_CLOSED') return null
+  if (!isNonNegativeSafeInteger(reference.observations) || !isNonNegativeSafeInteger(reference.rebalanceCount))
+    return null
+
+  const evidence = exactObject(record.evidence, qualificationAuditEvidenceKeys)
+  if (evidence === null) return null
+  if (
+    !isNonNegativeSafeInteger(evidence.artifactCount) ||
+    !isNonNegativeSafeInteger(evidence.eventCount) ||
+    !isNonNegativeSafeInteger(evidence.gateCount) ||
+    typeof evidence.lockId !== 'string' ||
+    !isHash(evidence.lockId) ||
+    typeof evidence.resultHash !== 'string' ||
+    !isHash(evidence.resultHash)
+  )
+    return null
+
+  const policies = exactObject(record.policies, qualificationAuditPoliciesKeys)
+  if (policies === null) return null
+  if (
+    typeof policies.declaredAt !== 'string' ||
+    policies.declaredAt.length === 0 ||
+    typeof policies.lockId !== 'string' ||
+    !isHash(policies.lockId) ||
+    typeof policies.policySetHash !== 'string' ||
+    !isHash(policies.policySetHash) ||
+    !Array.isArray(policies.documents)
+  )
+    return null
+  for (const document of policies.documents) {
+    const documentRecord = exactObject(document, qualificationAuditDocumentKeys)
+    if (
+      documentRecord === null ||
+      typeof documentRecord.name !== 'string' ||
+      documentRecord.name.length === 0 ||
+      typeof documentRecord.schemaVersion !== 'string' ||
+      documentRecord.schemaVersion.length === 0 ||
+      typeof documentRecord.contentHash !== 'string' ||
+      !isHash(documentRecord.contentHash)
+    )
+      return null
+  }
+
+  const contamination = exactObject(record.contamination, qualificationAuditContaminationKeys)
+  if (contamination === null) return null
+  if (
+    typeof contamination.lockCreatedAt !== 'string' ||
+    contamination.lockCreatedAt.length === 0 ||
+    typeof contamination.resultCommittedAt !== 'string' ||
+    contamination.resultCommittedAt.length === 0 ||
+    !nonEmptyStringArray(contamination.replicas)
+  )
+    return null
+  const principals = exactObject(contamination.principals, qualificationAuditPrincipalsKeys)
+  if (
+    principals === null ||
+    typeof principals.candidate !== 'string' ||
+    principals.candidate.length === 0 ||
+    !nonEmptyStringArray(principals.publishers) ||
+    !Array.isArray(contamination.access)
+  )
+    return null
+  for (const access of contamination.access) {
+    const accessRecord = exactObject(access, qualificationAuditAccessKeys)
+    if (
+      accessRecord === null ||
+      typeof accessRecord.replica !== 'string' ||
+      accessRecord.replica.length === 0 ||
+      typeof accessRecord.queryId !== 'string' ||
+      accessRecord.queryId.length === 0 ||
+      typeof accessRecord.queryStartTime !== 'string' ||
+      accessRecord.queryStartTime.length === 0 ||
+      typeof accessRecord.user !== 'string' ||
+      accessRecord.user.length === 0 ||
+      (accessRecord.kind !== 'manifest' && accessRecord.kind !== 'sessions' && accessRecord.kind !== 'bars')
+    )
+      return null
+  }
+
+  const repository = exactObject(record.repository, qualificationAuditRepositoryKeys)
+  if (
+    repository === null ||
+    repository.sourceCommitExists !== true ||
+    repository.sourceCommitAncestorOfMain !== true ||
+    !Array.isArray(repository.preLockResultReferences) ||
+    !repository.preLockResultReferences.every((entry) => typeof entry === 'string') ||
+    typeof repository.sourceRevision !== 'string' ||
+    !isSha(repository.sourceRevision)
+  )
+    return null
+
+  if (!Array.isArray(record.checks)) return null
+  for (const check of record.checks) {
+    const checkRecord = exactObject(check, qualificationAuditCheckKeys)
+    if (
+      checkRecord === null ||
+      typeof checkRecord.name !== 'string' ||
+      checkRecord.name.length === 0 ||
+      typeof checkRecord.passed !== 'boolean' ||
+      typeof checkRecord.evidence !== 'string' ||
+      checkRecord.evidence.length === 0
+    )
+      return null
+  }
+  if (typeof record.auditHash !== 'string' || !isHash(record.auditHash)) return null
+
+  try {
+    const { auditHash: _auditHash, ...auditMaterial } = record
+    if (canonicalHashV1(auditMaterial) !== record.auditHash) return null
+  } catch {
+    return null
+  }
+  return record as unknown as QualificationAuditEvidence
+}
+
+const requireQualificationTerminal = (value: unknown): QualificationTerminalEvidence | null => {
+  const record = exactObject(value, qualificationTerminalKeys)
+  if (record === null || record.schemaVersion !== 'bayn.qualification-collector-terminal.v1') return null
+  if (
+    typeof record.repository !== 'string' ||
+    record.repository.length === 0 ||
+    typeof record.currentMainSha !== 'string' ||
+    !isSha(record.currentMainSha) ||
+    typeof record.sourceSha !== 'string' ||
+    !isSha(record.sourceSha) ||
+    typeof record.candidateOrdinal !== 'number' ||
+    !Number.isSafeInteger(record.candidateOrdinal) ||
+    record.candidateOrdinal < 1 ||
+    typeof record.githubRunId !== 'string' ||
+    !/^\d+$/.test(record.githubRunId) ||
+    typeof record.githubRunAttempt !== 'number' ||
+    !Number.isSafeInteger(record.githubRunAttempt) ||
+    record.githubRunAttempt < 1
+  )
+    return null
+  const image = exactObject(record.image, ['repository', 'digest'])
+  if (
+    image === null ||
+    typeof image.repository !== 'string' ||
+    image.repository.length === 0 ||
+    typeof image.digest !== 'string' ||
+    !isDigest(image.digest)
+  )
+    return null
+  for (const key of ['preregistrationHash', 'eligibilityHash', 'candidateBindingHash', 'evidenceHash'] as const) {
+    if (typeof record[key] !== 'string' || !isHash(record[key])) return null
+  }
+
+  const execution = exactObject(record.terminal, qualificationExecutionKeys)
+  if (execution === null || execution.schemaVersion !== 'bayn.qualification-execution.v1') return null
+  if (
+    typeof execution.runId !== 'string' ||
+    !isHash(execution.runId) ||
+    typeof execution.lockId !== 'string' ||
+    !isHash(execution.lockId) ||
+    typeof execution.resultHash !== 'string' ||
+    !isHash(execution.resultHash) ||
+    (execution.verdict !== 'QUALIFIED' && execution.verdict !== 'REJECTED')
+  )
+    return null
+  const persistence = exactObject(execution.persistence, qualificationPersistenceKeys)
+  if (
+    persistence === null ||
+    !isNonNegativeSafeInteger(persistence.artifactCount) ||
+    !isNonNegativeSafeInteger(persistence.eventCount) ||
+    !isNonNegativeSafeInteger(persistence.gateCount)
+  )
+    return null
+
+  const audit = requireQualificationAudit(record.audit)
+  if (audit === null || audit.status !== 'PASS') return null
+  if (
+    audit.runId !== execution.runId ||
+    audit.evidence.lockId !== execution.lockId ||
+    audit.evidence.resultHash !== execution.resultHash ||
+    audit.policies.lockId !== execution.lockId ||
+    audit.repository.sourceRevision !== record.sourceSha ||
+    audit.evidence.artifactCount !== persistence.artifactCount ||
+    audit.evidence.eventCount !== persistence.eventCount ||
+    audit.evidence.gateCount !== persistence.gateCount
+  )
+    return null
+
+  try {
+    const { evidenceHash: _evidenceHash, ...terminalMaterial } = record
+    if (canonicalHashV1(terminalMaterial) !== record.evidenceHash) return null
+  } catch {
+    return null
+  }
+  return {
+    ...(record as unknown as Omit<QualificationTerminalEvidence, 'image' | 'terminal' | 'audit'>),
+    image: image as QualificationTerminalEvidence['image'],
+    terminal: execution as QualificationTerminalEvidence['terminal'],
+    audit,
+  }
+}
+
+const requireReviewedPins = (value: unknown): PaperActivationReviewedPins | null => {
+  const record = exactObject(value, reviewedPinKeys)
+  if (record === null || record.schemaVersion !== 'bayn.paper-activation-reviewed-pins.v1') return null
+  const stringKeys = [
+    'imageRepository',
+    'protocolHash',
+    'strategyBehaviorHash',
+    'strategyParameterHash',
+    'qualificationExecutionPolicyHash',
+    'previousGenerationHash',
+    'accountId',
+    'riskPolicyHash',
+    'proofPlanHash',
+    'reconciliationId',
+    'reconciliationContentHash',
+    'qualificationExpiresAt',
+    'accountBindingHash',
+    'brokerBaseUrl',
+    'authorityExpiresAt',
+  ] as const
+  if (stringKeys.some((key) => typeof record[key] !== 'string' || record[key].length === 0)) return null
+  if (typeof record.sourceSha !== 'string' || !isSha(record.sourceSha)) return null
+  if (typeof record.imageDigest !== 'string' || !isDigest(record.imageDigest)) return null
+  for (const key of [
+    'protocolHash',
+    'strategyBehaviorHash',
+    'strategyParameterHash',
+    'qualificationExecutionPolicyHash',
+    'previousGenerationHash',
+    'riskPolicyHash',
+    'proofPlanHash',
+    'reconciliationId',
+    'reconciliationContentHash',
+    'accountBindingHash',
+  ] as const) {
+    if (typeof record[key] !== 'string' || !isHash(record[key])) return null
+  }
+  if (
+    record.strategyParameterSchemaVersion !== 'bayn.risk-balanced-trend.protocol.v3' &&
+    record.strategyParameterSchemaVersion !== 'bayn.risk-balanced-trend.protocol.v4'
+  )
+    return null
+  if (record.brokerEnvironment !== 'sandbox' && record.brokerEnvironment !== 'live') return null
+  if (
+    record.maximumAuthority !== 'OBSERVE' &&
+    record.maximumAuthority !== 'PAPER' &&
+    record.maximumAuthority !== 'LIVE'
+  )
+    return null
+  const countKeys = ['unresolvedMutationCount', 'unknownMutationCount', 'openOrderCount', 'discrepancyCount'] as const
+  if (countKeys.some((key) => !isNonNegativeSafeInteger(record[key]))) return null
+  if (record.reconciliation !== 'EXACT' && record.reconciliation !== 'NON_EXACT' && record.reconciliation !== 'UNKNOWN')
+    return null
+  if (
+    record.activationState !== 'PRECOMMITTED' &&
+    record.activationState !== 'IN_FLIGHT' &&
+    record.activationState !== 'CONSUMED' &&
+    record.activationState !== 'CANCELLED'
+  )
+    return null
+  if (typeof record.killSwitchActive !== 'boolean' || typeof record.identityGap !== 'boolean') return null
+  return record as unknown as PaperActivationReviewedPins
+}
 
 const requirePaperAuthorityGeneration = (value: unknown): PaperAuthorityGeneration | null => {
   if (typeof value !== 'object' || value === null || Array.isArray(value)) return null
@@ -343,7 +822,7 @@ const requireEvidence = (value: unknown): PaperActivationEvidence | null => {
     })
   )
     return null
-  if (record.schemaVersion !== 1) return null
+  if (record.schemaVersion !== 2) return null
   if (record.qualificationDecision !== 'QUALIFIED' && record.qualificationDecision !== 'REJECTED') return null
   if (record.brokerEnvironment !== 'sandbox' && record.brokerEnvironment !== 'live') return null
   if (
@@ -364,7 +843,24 @@ const requireEvidence = (value: unknown): PaperActivationEvidence | null => {
   if (typeof record.killSwitchActive !== 'boolean' || typeof record.identityGap !== 'boolean') return null
   const authorityGeneration = requirePaperAuthorityGeneration(record.authorityGeneration)
   if (authorityGeneration === null) return null
-  return { ...(record as unknown as Omit<PaperActivationEvidence, 'authorityGeneration'>), authorityGeneration }
+  const qualificationTerminal = requireQualificationTerminal(record.qualificationTerminal)
+  if (qualificationTerminal === null) return null
+  if (
+    qualificationTerminal.repository !== record.repository ||
+    qualificationTerminal.currentMainSha !== record.mainSha ||
+    qualificationTerminal.sourceSha !== record.sourceSha ||
+    qualificationTerminal.image.repository !== record.imageRepository ||
+    qualificationTerminal.image.digest !== record.imageDigest ||
+    qualificationTerminal.terminal.runId !== record.qualificationRunId ||
+    qualificationTerminal.terminal.verdict !== record.qualificationDecision ||
+    qualificationTerminal.audit.contamination.resultCommittedAt !== record.qualificationObservedAt
+  )
+    return null
+  return {
+    ...(record as unknown as Omit<PaperActivationEvidence, 'authorityGeneration' | 'qualificationTerminal'>),
+    authorityGeneration,
+    qualificationTerminal,
+  }
 }
 
 const expectRecord = (value: unknown, label: string): Record<string, unknown> => {
@@ -642,6 +1138,98 @@ export const paperAuthorityGenerationHash = (
   generation: PaperAuthorityGenerationMaterial | PaperAuthorityGeneration,
 ): string => canonicalHashV1(paperAuthorityGenerationIdentity(generation))
 
+export const buildPaperActivationArtifact = (input: {
+  readonly terminal: unknown
+  readonly reviewedPins: unknown
+}): PaperActivationArtifact | null => {
+  const terminal = requireQualificationTerminal(input.terminal)
+  if (terminal === null) throw new Error('qualification terminal evidence is invalid or unauthenticated')
+  if (terminal.terminal.verdict === 'REJECTED') return null
+
+  const reviewed = requireReviewedPins(input.reviewedPins)
+  if (reviewed === null) throw new Error('reviewed PAPER activation pins are invalid or incomplete')
+  if (reviewed.sourceSha !== terminal.sourceSha)
+    throw new Error('reviewed source SHA does not match qualification terminal')
+  if (reviewed.imageRepository !== terminal.image.repository || reviewed.imageDigest !== terminal.image.digest)
+    throw new Error('reviewed image pin does not match qualification terminal')
+
+  const activationId = `qualification-${terminal.githubRunId}-${terminal.githubRunAttempt}`
+  const generationMaterial: PaperAuthorityGenerationMaterial = {
+    schemaVersion: 'bayn.paper-authority-generation.v2',
+    maximum: 'PAPER',
+    previousGenerationHash: reviewed.previousGenerationHash,
+    qualificationRunId: terminal.terminal.runId,
+    qualificationLockId: terminal.terminal.lockId,
+    qualificationResultHash: terminal.terminal.resultHash,
+    protocolHash: reviewed.protocolHash,
+    qualificationExecutionPolicyHash: reviewed.qualificationExecutionPolicyHash,
+    qualificationSourceRevision: terminal.sourceSha,
+    qualificationImageRepository: terminal.image.repository,
+    qualificationImageDigest: terminal.image.digest,
+    activationSourceRevision: terminal.sourceSha,
+    activationImageRepository: terminal.image.repository,
+    activationImageDigest: terminal.image.digest,
+    strategyName: 'risk-balanced-trend',
+    strategyBehaviorHash: reviewed.strategyBehaviorHash,
+    strategyParameterHash: reviewed.strategyParameterHash,
+    strategyParameterSchemaVersion: reviewed.strategyParameterSchemaVersion,
+    accountId: reviewed.accountId,
+    riskPolicyHash: reviewed.riskPolicyHash,
+    proofPlanHash: reviewed.proofPlanHash,
+    reconciliationId: reviewed.reconciliationId,
+    reconciliationContentHash: reviewed.reconciliationContentHash,
+  }
+  const authorityGeneration: PaperAuthorityGeneration = {
+    ...generationMaterial,
+    generationHash: paperAuthorityGenerationHash(generationMaterial),
+  }
+  const evidence: PaperActivationEvidence = {
+    schemaVersion: 2,
+    repository: terminal.repository,
+    mainSha: terminal.currentMainSha,
+    currentMainSha: terminal.currentMainSha,
+    sourceSha: terminal.sourceSha,
+    imageRepository: terminal.image.repository,
+    imageDigest: terminal.image.digest,
+    protocolHash: reviewed.protocolHash,
+    strategyBehaviorHash: reviewed.strategyBehaviorHash,
+    strategyParameterHash: reviewed.strategyParameterHash,
+    qualificationRunId: terminal.terminal.runId,
+    qualificationDecision: 'QUALIFIED',
+    qualificationObservedAt: terminal.audit.contamination.resultCommittedAt,
+    qualificationExpiresAt: reviewed.qualificationExpiresAt,
+    accountBindingHash: reviewed.accountBindingHash,
+    brokerEnvironment: reviewed.brokerEnvironment,
+    brokerBaseUrl: reviewed.brokerBaseUrl,
+    maximumAuthority: reviewed.maximumAuthority,
+    authorityGeneration,
+    authorityExpiresAt: reviewed.authorityExpiresAt,
+    unresolvedMutationCount: reviewed.unresolvedMutationCount,
+    unknownMutationCount: reviewed.unknownMutationCount,
+    openOrderCount: reviewed.openOrderCount,
+    discrepancyCount: reviewed.discrepancyCount,
+    reconciliation: reviewed.reconciliation,
+    killSwitchActive: reviewed.killSwitchActive,
+    identityGap: reviewed.identityGap,
+    activationState: reviewed.activationState,
+    activationId,
+    qualificationTerminal: terminal,
+  }
+  return {
+    evidence,
+    pins: {
+      sourceSha: evidence.sourceSha,
+      imageRepository: evidence.imageRepository,
+      imageDigest: evidence.imageDigest,
+      protocolHash: evidence.protocolHash,
+      strategyBehaviorHash: evidence.strategyBehaviorHash,
+      strategyParameterHash: evidence.strategyParameterHash,
+      qualificationRunId: evidence.qualificationRunId,
+      accountBindingHash: evidence.accountBindingHash,
+    },
+  }
+}
+
 export const deriveObserveRollbackGeneration = (input: {
   readonly repository: string
   readonly activationId: string
@@ -684,11 +1272,16 @@ export const evaluatePaperActivation = (input: {
   const manifestPins = requirePins(input.manifestPins, manifestPinKeys)
   if (manifestPins === null)
     return hold('invalid-manifest-pins', 'manifest pins must contain the complete exact schema')
-  if (evidence.schemaVersion !== 1) return hold('unsupported-schema', 'activation evidence schema is unsupported')
+  if (evidence.schemaVersion !== 2) return hold('unsupported-schema', 'activation evidence schema is unsupported')
   if (evidence.repository !== input.expectedRepository)
     return hold('repository-mismatch', 'evidence belongs to another repository')
   if (evidence.activationId !== input.expectedActivationId)
     return hold('activation-id-mismatch', 'activation id does not match the precommit')
+  if (
+    evidence.activationId !==
+    `qualification-${evidence.qualificationTerminal.githubRunId}-${evidence.qualificationTerminal.githubRunAttempt}`
+  )
+    return hold('activation-id-mismatch', 'activation id does not match the authenticated qualification run')
   if (
     !isSha(input.trustedCurrentMainSha) ||
     !isSha(evidence.mainSha) ||
@@ -798,6 +1391,24 @@ const parseArguments = (arguments_: readonly string[]): Record<string, string> =
 if (import.meta.main) {
   try {
     const args = parseArguments(process.argv.slice(2))
+    if (args.mode === 'build-evidence') {
+      const artifact = buildPaperActivationArtifact({
+        terminal: JSON.parse(readFileSync(args.terminal ?? '', 'utf8')) as unknown,
+        reviewedPins: JSON.parse(readFileSync(args['reviewed-pins'] ?? '', 'utf8')) as unknown,
+      })
+      if (artifact === null) {
+        if (args['github-output'] !== undefined) appendFileSync(args['github-output'], 'emit=false\n')
+        console.log('BAYN_PAPER_ACTIVATION_EVIDENCE_NOT_EMITTED verdict=REJECTED')
+        process.exit(0)
+      }
+      const outputDirectory = args['output-dir'] ?? ''
+      mkdirSync(outputDirectory, { recursive: true })
+      writeFileSync(`${outputDirectory}/evidence.json`, `${JSON.stringify(artifact.evidence, null, 2)}\n`)
+      writeFileSync(`${outputDirectory}/pins.json`, `${JSON.stringify(artifact.pins, null, 2)}\n`)
+      if (args['github-output'] !== undefined) appendFileSync(args['github-output'], 'emit=true\n')
+      console.log('BAYN_PAPER_ACTIVATION_EVIDENCE_EMITTED')
+      process.exit(0)
+    }
     if (args.mode === 'extract-manifest-pins') {
       const manifestPins = extractPaperActivationManifestPins(
         readFileSync(args.deployment ?? '', 'utf8'),

--- a/services/bayn/src/paper-proof-command.ts
+++ b/services/bayn/src/paper-proof-command.ts
@@ -1,4 +1,3 @@
-import { NodeRuntime } from '@effect/platform-node'
 import { Effect, Result } from 'effect'
 
 import {
@@ -56,17 +55,4 @@ export const runPaperProofCommand = (
     ...dependencies,
     protectedEntryToken: envelope.protectedEntryToken,
   })
-}
-
-export const paperProofCommandEntryGate = Effect.fail(
-  new PaperProofError({
-    operation: 'GATE',
-    failure: 'gate-closed',
-    message:
-      'PAPER proof CLI is source-ready but intentionally disabled: no reviewed source plan and protected sandbox entry binding are pinned',
-  }),
-)
-
-if (import.meta.main) {
-  NodeRuntime.runMain(paperProofCommandEntryGate)
 }

--- a/services/bayn/src/paper-proof/program.test.ts
+++ b/services/bayn/src/paper-proof/program.test.ts
@@ -9,7 +9,7 @@ import { BrokerEnvironment } from '../broker/identity'
 import { BrokerAccess, CapitalAuthorityKind } from '../execution/authority'
 import { Authority, IntentState, TerminalOutcome } from '../execution/contracts'
 import { MutationEventType, MutationStoreError, type MutationEvent } from '../execution/mutations'
-import { paperProofCommandEntryGate, runPaperProofCommand } from '../paper-proof-command'
+import { runPaperProofCommand } from '../paper-proof-command'
 import {
   protectedEntryToken,
   runPaperProof,
@@ -1551,12 +1551,5 @@ describe('bounded PAPER proof command', () => {
       expect(calls.cancel).toBe(0)
       expect(calls.recover).toBe(0)
     }
-  })
-
-  test('executable default entry remains fail-closed without a pinned plan', async () => {
-    const exit = await Effect.runPromiseExit(paperProofCommandEntryGate)
-
-    expect(Exit.isFailure(exit)).toBe(true)
-    if (Exit.isFailure(exit)) expect(String(exit.cause)).toContain('intentionally disabled')
   })
 })


### PR DESCRIPTION
## Summary

- Produce exactly one immutable `bayn-paper-activation-evidence-<run>-<attempt>` artifact from a typed verifier only for authenticated QUALIFIED terminal evidence and reviewed runtime pins.
- Bind `evidence.json` and `pins.json` to the terminal audit/hash, exact source/image, qualification run, and canonical PAPER authority generation.
- Keep activation fail-closed for missing, ambiguous, stale, wrong-producer, malformed, or non-QUALIFIED evidence, with synthetic QUALIFIED-to-proposal and REJECTED-no-artifact coverage.
- Remove the dead standalone proof executable entrypoint while preserving the directly tested source-level fail-closed proof command.

## Related Issues

PROOMPT-405

## Testing

- `bun test packages/scripts/src/bayn/verify-paper-activation.test.ts packages/scripts/src/bayn/bayn-qualification-workflow.test.ts packages/scripts/src/bayn/bayn-paper-activation-workflow.test.ts --reporter dots` — passed.
- `bun test --reporter dots` in `services/bayn` — passed: 1,241 passed, 153 skipped, 0 failed.
- Bayn `tsc`, build, Effect lint, formatting, both Oxlint modes, and scripts Oxlint/type-aware Oxlint — passed.
- `bun run --filter @proompteng/bayn test:postgres` — 145 tests skipped because no PostgreSQL service is configured locally.
- `actionlint -shellcheck "" -pyflakes "" .github/workflows/bayn-qualification.yml .github/workflows/bayn-paper-activation.yml` — passed.
- Nix Bayn image evaluation was attempted; this Apple Silicon host cannot build the x86_64-linux image locally, so the Linux image check remains CI-owned.
- No live PAPER activation, broker order, credential access, or deployment was performed.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
