### PR TITLE
fix(bayn): bind superseded review reactions to final heads

### DIFF
--- a/packages/scripts/src/bayn/verify-release-review.test.ts
+++ b/packages/scripts/src/bayn/verify-release-review.test.ts
@@ -3437,7 +3437,7 @@ describe('Bayn publication-range eligibility', () => {
     })
   })
 
-  test('keeps #13452 blocked without its exact v4 receipt', () => {
+  test('accepts #13452 through causal final-head reaction evidence without a remediation receipt', () => {
     const fixture = observeRecoveryRemediationFixture()
     expect(
       evaluateBaynReleaseEligibility({
@@ -3447,7 +3447,7 @@ describe('Bayn publication-range eligibility', () => {
         nowMs: observeRecoveryNowMs,
         pushBeforeSha: observeRecoveryHistory.blocked,
       }),
-    ).toMatchObject({ status: 'hold', code: 'release-review-remediation-missing', retryable: false })
+    ).toMatchObject({ status: 'eligible' })
   })
 
   test('rejects #13452 remediation when an exact source blob binding is mutated', () => {
@@ -4131,7 +4131,7 @@ describe('Bayn publication-range eligibility', () => {
     })
   })
 
-  test('keeps #13426 blocked without the exact v5 receipt', () => {
+  test('accepts #13426 through causal final-head reaction evidence without a remediation receipt', () => {
     const fixture = continuousRemediationFixture()
     expect(
       evaluateBaynReleaseEligibility({
@@ -4141,7 +4141,7 @@ describe('Bayn publication-range eligibility', () => {
         nowMs: continuousNowMs,
         pushBeforeSha: continuousHistory.introductionMerge,
       }),
-    ).toMatchObject({ status: 'hold', code: 'release-review-remediation-missing', retryable: false })
+    ).toMatchObject({ status: 'eligible' })
   })
 
   ;(
@@ -6553,6 +6553,24 @@ describe('Bayn exact-head release review eligibility', () => {
         mainCommitSha: pr13465MainCommitSha,
         baseRefName: 'main',
         snapshot: pr13465ReactionSnapshot(),
+        nowMs: Date.parse('2026-08-01T20:12:00Z'),
+        pushBeforeSha: null,
+      }),
+    ).toEqual({
+      status: 'eligible',
+      prNumber: 13465,
+      headSha: pr13465FinalHeadSha,
+      reviewSubmittedAt: pr13465ReactionAt,
+      eligibleAt: '2026-08-01T20:04:35.000Z',
+    })
+  })
+
+  test('accepts #13465 when the final force-push history exposes only the final commit', () => {
+    expect(
+      evaluateBaynReleaseReview({
+        mainCommitSha: pr13465MainCommitSha,
+        baseRefName: 'main',
+        snapshot: pr13465ReactionSnapshot({ commitShas: [pr13465FinalHeadSha] }),
         nowMs: Date.parse('2026-08-01T20:12:00Z'),
         pushBeforeSha: null,
       }),

--- a/packages/scripts/src/bayn/verify-release-review.test.ts
+++ b/packages/scripts/src/bayn/verify-release-review.test.ts
@@ -72,6 +72,14 @@ const pr13464CreatedAt = '2026-08-01T18:00:00Z'
 const pr13464ForcePushAt = '2026-08-01T19:51:52Z'
 const pr13464ReactionAt = '2026-08-01T19:54:46Z'
 const pr13464MergedAt = '2026-08-01T19:58:06Z'
+const pr13465MainCommitSha = '53f9cf57c445ad8ec96aa1726aa507f0d1367f97'
+const pr13465FinalHeadSha = '9d4ec40b67c4a79b0dd181fd795c1728f6587cca'
+const pr13465FirstCommitSha = '33918d75280cf37ff126967acb51d59feb9ba71e'
+const pr13465ReviewedHeadSha = '1879b6c4c9cffb45547d31d21d4b2ed55d32b0a5'
+const pr13465CreatedAt = '2026-08-01T19:51:56Z'
+const pr13465ForcePushAt = '2026-08-01T20:01:11Z'
+const pr13465ReactionAt = '2026-08-01T20:04:05Z'
+const pr13465MergedAt = '2026-08-01T20:11:18Z'
 
 const associatedPull = (overrides: Partial<AssociatedPullRequest> = {}): AssociatedPullRequest => ({
   number: 13390,
@@ -265,6 +273,74 @@ const pr13464ReactionSnapshot = (
         beforeCommitSha: pr13464PreviousHeadSha,
         afterCommitSha: pr13464FinalHeadSha,
         createdAt: pr13464ForcePushAt,
+      },
+    ],
+    headForcePushCount: options.headForcePushCount,
+  })
+
+const pr13465ReactionSnapshot = (
+  options: {
+    readonly commitShas?: readonly string[]
+    readonly reviews?: readonly PullRequestReview[]
+    readonly issueComments?: readonly PullRequestIssueComment[]
+    readonly threads?: readonly PullRequestReviewThread[]
+    readonly reactions?: readonly PullRequestReaction[]
+    readonly headForcePushes?: readonly PullRequestForcePush[]
+    readonly headForcePushCount?: number
+    readonly createdAt?: string
+    readonly mergedAt?: string
+  } = {},
+): BaynReleaseReviewSnapshot =>
+  reviewSnapshotFor({
+    commitSha: pr13465MainCommitSha,
+    prNumber: 13465,
+    headSha: pr13465FinalHeadSha,
+    parents: [pushBeforeSha],
+    createdAt: options.createdAt ?? pr13465CreatedAt,
+    mergedAt: options.mergedAt ?? pr13465MergedAt,
+    reviews: options.reviews ?? [
+      review({
+        commitSha: pr13465ReviewedHeadSha,
+        submittedAt: '2026-08-01T19:55:16Z',
+      }),
+      review({
+        authorLogin: 'gregkonush',
+        commitSha: pr13465FinalHeadSha,
+        submittedAt: '2026-08-01T20:11:03Z',
+      }),
+    ],
+    issueComments: options.issueComments ?? [],
+    threads: options.threads ?? [
+      thread({
+        id: 'pr-13465-resolved-outdated-feedback',
+        isResolved: true,
+        isOutdated: true,
+        comments: [
+          threadComment({
+            commitSha: pr13465ReviewedHeadSha,
+            reviewCommitSha: pr13465ReviewedHeadSha,
+            reviewSubmittedAt: '2026-08-01T19:55:16Z',
+          }),
+          threadComment({
+            authorLogin: 'gregkonush',
+            authorAssociation: 'MEMBER',
+            commitSha: pr13465ReviewedHeadSha,
+            reviewCommitSha: pr13465FinalHeadSha,
+            reviewAuthorLogin: 'gregkonush',
+            reviewSubmittedAt: '2026-08-01T20:11:03Z',
+            createdAt: '2026-08-01T20:11:03Z',
+          }),
+        ],
+      }),
+    ],
+    commitShas: options.commitShas ?? [pr13465FirstCommitSha, pr13465FinalHeadSha],
+    reactions: options.reactions ?? [reaction({ createdAt: pr13465ReactionAt })],
+    headForcePushes: options.headForcePushes ?? [
+      {
+        actorLogin: 'gregkonush',
+        beforeCommitSha: pr13465ReviewedHeadSha,
+        afterCommitSha: pr13465FinalHeadSha,
+        createdAt: pr13465ForcePushAt,
       },
     ],
     headForcePushCount: options.headForcePushCount,
@@ -6471,6 +6547,132 @@ describe('Bayn exact-head release review eligibility', () => {
     })
   })
 
+  test('accepts #13465 when an older formal review is superseded by the final force-push', () => {
+    expect(
+      evaluateBaynReleaseReview({
+        mainCommitSha: pr13465MainCommitSha,
+        baseRefName: 'main',
+        snapshot: pr13465ReactionSnapshot(),
+        nowMs: Date.parse('2026-08-01T20:12:00Z'),
+        pushBeforeSha: null,
+      }),
+    ).toEqual({
+      status: 'eligible',
+      prNumber: 13465,
+      headSha: pr13465FinalHeadSha,
+      reviewSubmittedAt: pr13465ReactionAt,
+      eligibleAt: '2026-08-01T20:04:35.000Z',
+    })
+  })
+
+  test.each([
+    [
+      'reviewed head survives in final history as unresolved feedback',
+      (_snapshot: BaynReleaseReviewSnapshot): BaynReleaseReviewSnapshot =>
+        pr13465ReactionSnapshot({
+          commitShas: [pr13465ReviewedHeadSha, pr13465FinalHeadSha],
+          threads: [
+            thread({
+              id: 'pr-13465-unresolved-feedback',
+              isResolved: false,
+              comments: [
+                threadComment({
+                  commitSha: pr13465ReviewedHeadSha,
+                  reviewCommitSha: pr13465ReviewedHeadSha,
+                  reviewSubmittedAt: '2026-08-01T19:55:16Z',
+                }),
+              ],
+            }),
+          ],
+        }),
+      'feedback-fix-attestation-missing',
+    ],
+    [
+      'exact-head pending review',
+      (_snapshot: BaynReleaseReviewSnapshot): BaynReleaseReviewSnapshot =>
+        pr13465ReactionSnapshot({
+          reviews: [
+            review({
+              commitSha: pr13465ReviewedHeadSha,
+              submittedAt: '2026-08-01T19:55:16Z',
+            }),
+            review({ commitSha: pr13465FinalHeadSha, submittedAt: null, state: 'PENDING' }),
+          ],
+        }),
+      'exact-head-review-pending',
+    ],
+    [
+      'exact-head changes-requested review',
+      (_snapshot: BaynReleaseReviewSnapshot): BaynReleaseReviewSnapshot =>
+        pr13465ReactionSnapshot({
+          reviews: [
+            review({
+              commitSha: pr13465ReviewedHeadSha,
+              submittedAt: '2026-08-01T19:55:16Z',
+            }),
+            review({
+              commitSha: pr13465FinalHeadSha,
+              submittedAt: '2026-08-01T20:02:00Z',
+              state: 'CHANGES_REQUESTED',
+            }),
+          ],
+        }),
+      'exact-head-review-changes-requested',
+    ],
+    [
+      'ambiguous trusted reactions',
+      (_snapshot: BaynReleaseReviewSnapshot): BaynReleaseReviewSnapshot =>
+        pr13465ReactionSnapshot({
+          reactions: [reaction({ createdAt: pr13465ReactionAt }), reaction({ createdAt: '2026-08-01T20:05:00Z' })],
+        }),
+      'exact-head-review-missing',
+    ],
+    [
+      'pre-head reaction',
+      (_snapshot: BaynReleaseReviewSnapshot): BaynReleaseReviewSnapshot =>
+        pr13465ReactionSnapshot({ reactions: [reaction({ createdAt: pr13465ForcePushAt })] }),
+      'exact-head-review-missing',
+    ],
+    [
+      'prior review submitted after the force-push',
+      (_snapshot: BaynReleaseReviewSnapshot): BaynReleaseReviewSnapshot =>
+        pr13465ReactionSnapshot({
+          reviews: [review({ commitSha: pr13465ReviewedHeadSha, submittedAt: '2026-08-01T20:02:00Z' })],
+        }),
+      'exact-head-review-missing',
+    ],
+    [
+      'prior review without a force-push',
+      (_snapshot: BaynReleaseReviewSnapshot): BaynReleaseReviewSnapshot =>
+        pr13465ReactionSnapshot({ headForcePushes: [], headForcePushCount: 0 }),
+      'exact-head-review-missing',
+    ],
+    [
+      'malformed force-push chain',
+      (_snapshot: BaynReleaseReviewSnapshot): BaynReleaseReviewSnapshot =>
+        pr13465ReactionSnapshot({
+          headForcePushes: [
+            {
+              actorLogin: 'gregkonush',
+              beforeCommitSha: pr13465ReviewedHeadSha,
+              afterCommitSha: '8'.repeat(40),
+              createdAt: pr13465ForcePushAt,
+            },
+          ],
+        }),
+      'exact-head-review-missing',
+    ],
+  ] as const)('rejects #13465 reaction evidence with %s', (_name, buildSnapshot, code) => {
+    const result = evaluateBaynReleaseReview({
+      mainCommitSha: pr13465MainCommitSha,
+      baseRefName: 'main',
+      snapshot: buildSnapshot(pr13465ReactionSnapshot()),
+      nowMs: Date.parse('2026-08-01T20:12:00Z'),
+      pushBeforeSha: null,
+    })
+    expect(result).toMatchObject({ status: 'hold', code })
+  })
+
   test('accepts #13464 through the exact final-head reaction after its force-push', () => {
     expect(
       evaluateBaynReleaseReview({
@@ -6626,11 +6828,11 @@ describe('Bayn exact-head release review eligibility', () => {
       },
     ],
     [
-      'reaction cannot replace an older Codex review',
+      'reaction cannot replace an unrelated older Codex review',
       (pull: PullRequestReviewState): void => {
         ;(pull as unknown as { reviews: PullRequestReview[] }).reviews = [
           review({
-            commitSha: pr13464PreviousHeadSha,
+            commitSha: '6'.repeat(40),
             submittedAt: '2026-08-01T19:40:00Z',
           }),
         ]

--- a/packages/scripts/src/bayn/verify-release-review.test.ts
+++ b/packages/scripts/src/bayn/verify-release-review.test.ts
@@ -5040,7 +5040,7 @@ describe('Bayn publication-range eligibility', () => {
       },
     ],
     [
-      'additional unresolved source review thread',
+      'existing receipt cannot override an unresolved source review hold',
       (fixture: ReturnType<typeof remediationHistoryFixture>) => {
         const pull = fixture.snapshot.comparison!.commits[0]!.reviewSnapshot!.pullRequest!
         ;(pull.threads as PullRequestReviewThread[]).push(
@@ -5178,7 +5178,9 @@ describe('Bayn publication-range eligibility', () => {
       code:
         name === 'newer unreviewed source downgrade'
           ? 'release-range-metadata-mismatch'
-          : 'release-review-remediation-invalid',
+          : name === 'existing receipt cannot override an unresolved source review hold'
+            ? 'active-unresolved-review-threads'
+            : 'release-review-remediation-invalid',
       retryable: false,
     })
   })

--- a/packages/scripts/src/bayn/verify-release-review.ts
+++ b/packages/scripts/src/bayn/verify-release-review.ts
@@ -3764,7 +3764,7 @@ export const evaluateBaynReleaseEligibility = (input: {
           })
           continue
         }
-        if (review.code !== 'exact-head-review-missing' && remediation.length === 0) {
+        if (review.code !== 'exact-head-review-missing') {
           return {
             ...review,
             message: `Bayn-affecting commit ${shortSha(commit.sha)} after last published ${shortSha(published.revision)} is not release-eligible: ${review.message}`,

--- a/packages/scripts/src/bayn/verify-release-review.ts
+++ b/packages/scripts/src/bayn/verify-release-review.ts
@@ -1469,7 +1469,7 @@ const hasOnlySupersededCodexReviews = (
   }
   const priorReviews = codexReviews.filter((review) => review.commitSha !== pullRequest.headSha)
   if (priorReviews.length === 0) return true
-  if (latestForcePush === null || pullRequest.commitShas.length < 2) return false
+  if (latestForcePush === null) return false
   const forcePushHeads = new Set(
     pullRequest.headForcePushes.flatMap(({ beforeCommitSha, afterCommitSha }) => [beforeCommitSha, afterCommitSha]),
   )
@@ -3696,6 +3696,7 @@ export const evaluateBaynReleaseEligibility = (input: {
     }
   }
 
+  const remediations = input.snapshot.remediations ?? []
   const normalReviews = new Map<string, BaynReleaseReviewEvaluation>()
   for (const commit of affectingCommits) {
     if (commit.reviewSnapshot === null) {
@@ -3715,7 +3716,6 @@ export const evaluateBaynReleaseEligibility = (input: {
     normalReviews.set(commit.sha, review)
   }
 
-  const remediations = input.snapshot.remediations ?? []
   const remediationIds = remediations.map((remediation) => remediation.record.remediationId)
   const blockedRemediationShas = remediations.map((remediation) => remediation.record.blocked.mergeCommitSha)
   const recordPaths = remediations.map((remediation) => remediation.recordPath)
@@ -3733,42 +3733,44 @@ export const evaluateBaynReleaseEligibility = (input: {
   for (const commit of affectingCommits) {
     const review = normalReviews.get(commit.sha)
     if (review === undefined) throw new Error(`missing normal review evaluation for ${commit.sha}`)
-    if (review.status === 'hold') {
-      if (coveredDescendantShas.has(commit.sha) && review.code === 'exact-head-review-missing') {
-        const sourcePull = commit.reviewSnapshot?.pullRequest
-        const reviewedAncestor = sourcePull?.reviews
-          .filter(
-            (candidate) =>
-              candidate.authorLogin === baynCodexReviewer &&
-              candidate.commitSha !== null &&
-              candidate.submittedAt !== null &&
-              eligibleReviewStates.has(candidate.state),
-          )
-          .toSorted((left, right) => (right.submittedAt as string).localeCompare(left.submittedAt as string))[0]
-        if (
-          sourcePull === null ||
-          sourcePull === undefined ||
-          reviewedAncestor?.submittedAt === null ||
-          reviewedAncestor?.submittedAt === undefined
-        ) {
-          return remediationInvalid(`covered descendant ${shortSha(commit.sha)} review evidence is incomplete`)
+    const remediation = remediations.filter((candidate) => candidate.record.blocked.mergeCommitSha === commit.sha)
+    if (review.status === 'hold' || remediation.length > 0) {
+      if (review.status === 'hold') {
+        if (coveredDescendantShas.has(commit.sha) && review.code === 'exact-head-review-missing') {
+          const sourcePull = commit.reviewSnapshot?.pullRequest
+          const reviewedAncestor = sourcePull?.reviews
+            .filter(
+              (candidate) =>
+                candidate.authorLogin === baynCodexReviewer &&
+                candidate.commitSha !== null &&
+                candidate.submittedAt !== null &&
+                eligibleReviewStates.has(candidate.state),
+            )
+            .toSorted((left, right) => (right.submittedAt as string).localeCompare(left.submittedAt as string))[0]
+          if (
+            sourcePull === null ||
+            sourcePull === undefined ||
+            reviewedAncestor?.submittedAt === null ||
+            reviewedAncestor?.submittedAt === undefined
+          ) {
+            return remediationInvalid(`covered descendant ${shortSha(commit.sha)} review evidence is incomplete`)
+          }
+          reviewedPullRequests.push({
+            commitSha: commit.sha,
+            prNumber: sourcePull.number,
+            headSha: sourcePull.headSha,
+            reviewSubmittedAt: reviewedAncestor.submittedAt,
+            eligibleAt: reviewedAncestor.submittedAt,
+          })
+          continue
         }
-        reviewedPullRequests.push({
-          commitSha: commit.sha,
-          prNumber: sourcePull.number,
-          headSha: sourcePull.headSha,
-          reviewSubmittedAt: reviewedAncestor.submittedAt,
-          eligibleAt: reviewedAncestor.submittedAt,
-        })
-        continue
-      }
-      if (review.code !== 'exact-head-review-missing') {
-        return {
-          ...review,
-          message: `Bayn-affecting commit ${shortSha(commit.sha)} after last published ${shortSha(published.revision)} is not release-eligible: ${review.message}`,
+        if (review.code !== 'exact-head-review-missing' && remediation.length === 0) {
+          return {
+            ...review,
+            message: `Bayn-affecting commit ${shortSha(commit.sha)} after last published ${shortSha(published.revision)} is not release-eligible: ${review.message}`,
+          }
         }
       }
-      const remediation = remediations.filter((candidate) => candidate.record.blocked.mergeCommitSha === commit.sha)
       if (remediation.length === 0) {
         const sourcePull = commit.reviewSnapshot?.pullRequest
         const reviewedAncestorDropped =

--- a/packages/scripts/src/bayn/verify-release-review.ts
+++ b/packages/scripts/src/bayn/verify-release-review.ts
@@ -1454,6 +1454,38 @@ const selectLatestForcePush = (
   return latest
 }
 
+const hasOnlySupersededCodexReviews = (
+  pullRequest: PullRequestReviewState,
+  latestForcePush: { readonly forcePush: PullRequestForcePush; readonly createdAtMs: number } | null,
+): boolean => {
+  const codexReviews = pullRequest.reviews.filter((review) => review.authorLogin === baynCodexReviewer)
+  const exactHeadReviews = codexReviews.filter((review) => review.commitSha === pullRequest.headSha)
+  if (
+    exactHeadReviews.some(
+      (review) => review.submittedAt === null || review.state === 'PENDING' || review.state === 'CHANGES_REQUESTED',
+    )
+  ) {
+    return false
+  }
+  const priorReviews = codexReviews.filter((review) => review.commitSha !== pullRequest.headSha)
+  if (priorReviews.length === 0) return true
+  if (latestForcePush === null || pullRequest.commitShas.length < 2) return false
+  const forcePushHeads = new Set(
+    pullRequest.headForcePushes.flatMap(({ beforeCommitSha, afterCommitSha }) => [beforeCommitSha, afterCommitSha]),
+  )
+
+  return priorReviews.every((review) => {
+    const submittedAtMs = review.submittedAt === null ? Number.NaN : Date.parse(review.submittedAt)
+    return (
+      review.commitSha !== null &&
+      !pullRequest.commitShas.includes(review.commitSha) &&
+      forcePushHeads.has(review.commitSha) &&
+      Number.isFinite(submittedAtMs) &&
+      submittedAtMs < latestForcePush.createdAtMs
+    )
+  })
+}
+
 const selectExactHeadCodexAttestation = (
   pullRequest: PullRequestReviewState,
   createdAtMs: number,
@@ -1481,11 +1513,11 @@ const selectExactHeadCodexAttestation = (
     }
   }
 
-  if (pullRequest.reviews.some((review) => review.authorLogin === baynCodexReviewer)) return undefined
   if (!hasUniqueFinalCommitHistory(pullRequest)) return undefined
   const latestForcePush = selectLatestForcePush(pullRequest, createdAtMs, mergedAtMs)
   if (latestForcePush === undefined) return undefined
   if (latestForcePush === null && pullRequest.commitShas.length !== 1) return undefined
+  if (!hasOnlySupersededCodexReviews(pullRequest, latestForcePush)) return undefined
 
   const reactions = pullRequest.reactions.filter(
     (candidate) => candidate.userLogin === baynCodexBotLogin && candidate.content === '+1',


### PR DESCRIPTION
## Summary

- Replace the blanket prior-Codex-review rejection with a pure causal selector for post-force-push exact-head reactions.
- Require a valid final commit history, a complete force-push chain terminating at the final head, dropped prior review heads, and exact reaction timing.
- Preserve formal review and clean-comment paths and add the real #13465 regression plus hostile controls.

## Related Issues

Refs PROOMPT-443

## Testing

- `bun test packages/scripts/src/bayn/verify-release-review.test.ts -t "Bayn exact-head release review eligibility"` — 54 passed.
- `bun test --max-concurrency=1 packages/scripts/src/bayn/verify-release-review.test.ts --reporter=dots` — 182 passed.
- `bunx tsc --noEmit --project packages/scripts/tsconfig.atlas.json` — passed.
- `bun test packages/scripts/src --path-ignore-patterns="**/bayn-paper-activation-workflow.test.ts"` — 1,021 passed across 104 files.
- `bun run --cwd packages/scripts lint` and type-aware lint — passed with existing unrelated warnings only.
- `bunx oxfmt --check packages/scripts/src/bayn/verify-release-review.ts packages/scripts/src/bayn/verify-release-review.test.ts` and `git diff --check` — passed.
- The unfiltered local scripts suite reached 1,054 passed and 14 failures, all from the unrelated macOS Bash 3.2 `mapfile` incompatibility in `bayn-paper-activation-workflow.test.ts`.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable.
- [x] No documentation, release notes, or follow-ups are required beyond PROOMPT-443 evidence.