### PR TITLE
fix(bayn): accept resolved final-head feedback fixes

### DIFF
--- a/packages/scripts/src/bayn/verify-release-review.test.ts
+++ b/packages/scripts/src/bayn/verify-release-review.test.ts
@@ -32,6 +32,7 @@ import {
   type BaynReleaseReviewRemediationEvidence,
   type BaynReleaseReviewRemediationRecord,
   type PullRequestReview,
+  type PullRequestFinalHeadCommitDetail,
   type PullRequestReviewState,
   type PullRequestIssueComment,
   type PullRequestForcePush,
@@ -113,6 +114,20 @@ const pr13475FinalCommitShas = [
   pr13475ReviewedHeadSha,
   pr13475FinalHeadSha,
 ] as const
+const pr13475ReviewedPath = 'services/bayn/src/candidate-development-local/command.ts'
+const pr13475FinalHeadCommit: PullRequestFinalHeadCommitDetail = {
+  sha: pr13475FinalHeadSha,
+  parents: [pr13475ReviewedHeadSha],
+  files: [pr13475ReviewedPath],
+  fileChanges: [
+    {
+      path: pr13475ReviewedPath,
+      previousPath: null,
+      status: 'modified',
+      blobSha: null,
+    },
+  ],
+}
 const pr13473EarlierForcePush: PullRequestForcePush = {
   actorLogin: 'gregkonush',
   beforeCommitSha: pr13473EarlierForcePushBeforeSha,
@@ -280,6 +295,7 @@ const reviewSnapshotFor = (options: {
   readonly reviews?: readonly PullRequestReview[]
   readonly threads?: readonly PullRequestReviewThread[]
   readonly commitShas?: readonly string[]
+  readonly finalHeadCommit?: PullRequestFinalHeadCommitDetail | null
   readonly issueComments?: readonly PullRequestIssueComment[]
   readonly reactions?: readonly PullRequestReaction[]
   readonly headForcePushes?: readonly PullRequestForcePush[]
@@ -314,6 +330,7 @@ const reviewSnapshotFor = (options: {
       ],
       threads: options.threads ?? [],
       commitShas: options.commitShas ?? [options.headSha],
+      finalHeadCommit: options.finalHeadCommit,
       issueComments: options.issueComments ?? [],
       reactions: options.reactions ?? [],
       headForcePushes: options.headForcePushes ?? [],
@@ -325,6 +342,7 @@ const reviewSnapshotFor = (options: {
 const pr13464ReactionSnapshot = (
   options: {
     readonly commitShas?: readonly string[]
+    readonly finalHeadCommit?: PullRequestFinalHeadCommitDetail | null
     readonly reviews?: readonly PullRequestReview[]
     readonly issueComments?: readonly PullRequestIssueComment[]
     readonly threads?: readonly PullRequestReviewThread[]
@@ -460,7 +478,7 @@ const pr13475FeedbackThread = (overrides: Partial<PullRequestReviewThread> = {})
     id: 'PRRT_kwDOLkRLus6VwJXZ',
     isResolved: true,
     isOutdated: true,
-    path: 'services/bayn/src/candidate-development-local/command.ts',
+    path: pr13475ReviewedPath,
     url: 'https://github.com/proompteng/lab/pull/13475#discussion_r3698708781',
     comments: [
       threadComment({
@@ -479,6 +497,7 @@ const pr13475FeedbackThread = (overrides: Partial<PullRequestReviewThread> = {})
 const pr13475ReviewSnapshot = (
   options: {
     readonly commitShas?: readonly string[]
+    readonly finalHeadCommit?: PullRequestFinalHeadCommitDetail | null
     readonly reviews?: readonly PullRequestReview[]
     readonly threads?: readonly PullRequestReviewThread[]
   } = {},
@@ -493,6 +512,7 @@ const pr13475ReviewSnapshot = (
     reviews: options.reviews ?? pr13475Reviews,
     threads: options.threads ?? [pr13475FeedbackThread()],
     commitShas: options.commitShas ?? pr13475FinalCommitShas,
+    finalHeadCommit: options.finalHeadCommit === undefined ? pr13475FinalHeadCommit : options.finalHeadCommit,
   })
 
 const eligibilitySnapshot = (
@@ -5574,6 +5594,13 @@ describe('Bayn publication-range eligibility', () => {
           ],
         })
       }
+      if (url.includes('/commits/') && !url.includes('/pulls?')) {
+        return Response.json({
+          sha: finalHeadSha,
+          parents: [{ sha: olderHeadSha }],
+          files: [{ filename: 'services/bayn/src/example.ts' }],
+        })
+      }
       if (url.includes('/issues/13390/comments?') || url.includes('/issues/13390/reactions?')) {
         return Response.json([])
       }
@@ -6511,6 +6538,13 @@ describe('Bayn delayed-attestation publication retry', () => {
           files: [{ filename: 'packages/scripts/src/bayn/verify-release-review.ts' }],
         })
       }
+      if (url.includes('/commits/') && !url.includes('/pulls?')) {
+        return Response.json({
+          sha: finalHeadSha,
+          parents: [{ sha: olderHeadSha }],
+          files: [{ filename: 'packages/scripts/src/bayn/verify-release-review.ts' }],
+        })
+      }
       if (url.includes('/issues/13401/comments?')) return Response.json([])
       if (url.includes('/issues/13401/reactions?')) {
         return Response.json([
@@ -7058,6 +7092,35 @@ describe('Bayn exact-head release review eligibility', () => {
           }),
         ],
       }),
+      'feedback-fix-attestation-missing',
+    ],
+    [
+      'direct child fixes reviewed file but also changes a second Bayn path',
+      pr13475ReviewSnapshot({
+        finalHeadCommit: {
+          ...pr13475FinalHeadCommit,
+          files: [pr13475ReviewedPath, 'services/bayn/src/unreviewed.ts'],
+          fileChanges: [
+            ...pr13475FinalHeadCommit.fileChanges,
+            {
+              path: 'services/bayn/src/unreviewed.ts',
+              previousPath: null,
+              status: 'modified',
+              blobSha: null,
+            },
+          ],
+        },
+      }),
+      'feedback-fix-attestation-missing',
+    ],
+    [
+      'missing final-head commit detail',
+      pr13475ReviewSnapshot({ finalHeadCommit: null }),
+      'feedback-fix-attestation-missing',
+    ],
+    [
+      'malformed final-head commit detail',
+      pr13475ReviewSnapshot({ finalHeadCommit: { ...pr13475FinalHeadCommit, parents: [pushBeforeSha] } }),
       'feedback-fix-attestation-missing',
     ],
     ['missing feedback thread', pr13475ReviewSnapshot({ threads: [] }), 'feedback-fix-attestation-missing'],
@@ -7929,9 +7992,10 @@ describe('Bayn exact-head release review eligibility', () => {
       const url = String(input)
       if (url.includes('/commits/')) {
         if (!url.includes('/pulls?')) {
+          const isFinalHeadDetail = url.includes(`/commits/${finalHeadSha}?`)
           return Response.json({
-            sha: mainCommitSha,
-            parents: [{ sha: pushBeforeSha }],
+            sha: isFinalHeadDetail ? finalHeadSha : mainCommitSha,
+            parents: [{ sha: isFinalHeadDetail ? olderHeadSha : pushBeforeSha }],
             files: [{ filename: 'services/bayn/src/example.ts' }],
           })
         }

--- a/packages/scripts/src/bayn/verify-release-review.test.ts
+++ b/packages/scripts/src/bayn/verify-release-review.test.ts
@@ -7280,6 +7280,39 @@ describe('Bayn exact-head release review eligibility', () => {
     ).toMatchObject({ status: 'hold', code })
   })
 
+  test('ignores an earlier review thread on the same predecessor head', () => {
+    expect(
+      evaluateBaynReleaseReview({
+        mainCommitSha: pr13475MainCommitSha,
+        baseRefName: 'main',
+        snapshot: pr13475ReviewSnapshot({
+          reviews: [
+            review({ commitSha: pr13475ReviewedHeadSha, submittedAt: '2026-08-02T10:31:00Z' }),
+            review({ commitSha: pr13475ReviewedHeadSha, submittedAt: pr13475ReviewSubmittedAt }),
+          ],
+          threads: [
+            thread({
+              id: 'pr-13475-earlier-review-thread',
+              isResolved: true,
+              isOutdated: true,
+              path: 'services/bayn/src/older-reviewed-path.ts',
+              comments: [
+                threadComment({
+                  commitSha: pr13475ReviewedHeadSha,
+                  reviewCommitSha: pr13475ReviewedHeadSha,
+                  reviewSubmittedAt: '2026-08-02T10:31:00Z',
+                }),
+              ],
+            }),
+            pr13475FeedbackThread(),
+          ],
+        }),
+        nowMs: Date.parse('2026-08-02T11:00:00Z'),
+        pushBeforeSha: null,
+      }),
+    ).toMatchObject({ status: 'eligible', eligibleAt: '2026-08-02T10:32:46.000Z' })
+  })
+
   test('accepts #13464 through the exact final-head reaction after its force-push', () => {
     expect(
       evaluateBaynReleaseReview({

--- a/packages/scripts/src/bayn/verify-release-review.test.ts
+++ b/packages/scripts/src/bayn/verify-release-review.test.ts
@@ -6056,6 +6056,84 @@ describe('Bayn delayed-attestation publication retry', () => {
     })
   })
 
+  test('uses the latest per-thread reply when feedback attestations straddle the failed review gate', () => {
+    const firstReplyAt = '2026-07-30T07:01:00Z'
+    const finalReplyAt = '2026-07-30T07:03:00Z'
+    const feedbackReview = snapshot({
+      commitShas: [olderHeadSha, finalHeadSha],
+      reviews: [review({ commitSha: olderHeadSha, submittedAt: '2026-07-30T07:00:00Z' })],
+      threads: [
+        thread({
+          id: 'first-feedback-thread',
+          isResolved: true,
+          comments: [
+            threadComment({ reviewSubmittedAt: '2026-07-30T07:00:00Z' }),
+            threadComment({
+              authorLogin: 'gregkonush',
+              authorAssociation: 'MEMBER',
+              body: 'Fixed the first reviewed path.',
+              createdAt: firstReplyAt,
+              commitSha: finalHeadSha,
+              reviewCommitSha: finalHeadSha,
+              reviewAuthorLogin: 'gregkonush',
+              reviewSubmittedAt: firstReplyAt,
+            }),
+          ],
+        }),
+        thread({
+          id: 'second-feedback-thread',
+          path: 'services/bayn/src/second.ts',
+          isResolved: true,
+          comments: [
+            threadComment({ reviewSubmittedAt: '2026-07-30T07:00:00Z' }),
+            threadComment({
+              authorLogin: 'gregkonush',
+              authorAssociation: 'MEMBER',
+              body: 'Fixed the second reviewed path.',
+              createdAt: finalReplyAt,
+              commitSha: finalHeadSha,
+              reviewCommitSha: finalHeadSha,
+              reviewAuthorLogin: 'gregkonush',
+              reviewSubmittedAt: finalReplyAt,
+            }),
+          ],
+        }),
+      ],
+    })
+
+    expect(
+      evaluateBaynReleaseReview({
+        mainCommitSha,
+        baseRefName: 'main',
+        snapshot: feedbackReview,
+        nowMs: Date.parse('2026-07-30T07:02:30Z'),
+        pushBeforeSha: null,
+      }),
+    ).toMatchObject({
+      status: 'eligible',
+      eligibleAt: '2026-07-30T07:03:00.000Z',
+    })
+
+    expect(
+      evaluateBaynReleaseRetry({
+        mainCommitSha,
+        baseRefName: 'main',
+        snapshot: retrySnapshot({
+          reviewSnapshot: feedbackReview,
+          failedRun: failedBuildRun({ updatedAt: '2026-07-30T07:02:30Z' }),
+          failedReviewJobCompletedAt: '2026-07-30T07:02:30Z',
+        }),
+        trigger: { type: 'schedule' },
+        nowMs: retryNowMs,
+      }),
+    ).toMatchObject({
+      status: 'dispatch',
+      sourceCommitSha: mainCommitSha,
+      prNumber: 13390,
+      headSha: finalHeadSha,
+    })
+  })
+
   test('binds a retry to the earlier range commit whose attestation arrived after the failed current-main push', () => {
     const earlierCommitSha = heldCommitSha
     const earlierHeadSha = heldHeadSha

--- a/packages/scripts/src/bayn/verify-release-review.test.ts
+++ b/packages/scripts/src/bayn/verify-release-review.test.ts
@@ -98,6 +98,21 @@ const pr13473FinalCommitShas = [
   '49d772ff13fd17c6f1068d71aaeb10c46da6d5f4',
   pr13473FinalHeadSha,
 ] as const
+const pr13475MainCommitSha = '8bafccc0bd689a90b20c359cf77e852546056026'
+const pr13475FinalHeadSha = '22dd9788538add020d8b113f3319c77db2f3a71d'
+const pr13475ReviewedHeadSha = 'feffd9f2ee697252e032dc36bf871675848f1ca2'
+const pr13475CreatedAt = '2026-08-02T08:33:25Z'
+const pr13475ReviewSubmittedAt = '2026-08-02T10:32:16Z'
+const pr13475MergedAt = '2026-08-02T10:46:55Z'
+const pr13475FinalCommitShas = [
+  '69f6ee223a0c04d04319f3ddd095964e49bbb055',
+  '051746efa174fb84a8699aebaa3d700a4ee7cb43',
+  '8b92f7e23b21ebb539466e429bed87e59defab47',
+  'f0b6ddf9ba9e76cb9b39cc3fe3107a0973657bd3',
+  'ecad4b74bdfa83dc88941c8ffa8af4685f815d4d',
+  pr13475ReviewedHeadSha,
+  pr13475FinalHeadSha,
+] as const
 const pr13473EarlierForcePush: PullRequestForcePush = {
   actorLogin: 'gregkonush',
   beforeCommitSha: pr13473EarlierForcePushBeforeSha,
@@ -149,6 +164,18 @@ const pr13473SupersededReviews: readonly PullRequestReview[] = [
     commitSha: '9c4dee691b971f8d745324345d64e6a010135cce',
     submittedAt: '2026-08-01T21:25:46Z',
   }),
+]
+
+const pr13475Reviews: readonly PullRequestReview[] = [
+  review({ commitSha: '01ba3227241175d35a5c06025d6e700626849124', submittedAt: '2026-08-02T08:36:25Z' }),
+  review({ commitSha: '80085b78a765128300a9aa92c9054b2c21a7073b', submittedAt: '2026-08-02T08:45:07Z' }),
+  review({ commitSha: '7346dbef6dde37a7ea09dc7040f3084a59600245', submittedAt: '2026-08-02T08:53:43Z' }),
+  review({ commitSha: '69f6ee223a0c04d04319f3ddd095964e49bbb055', submittedAt: '2026-08-02T09:31:34Z' }),
+  review({ commitSha: '051746efa174fb84a8699aebaa3d700a4ee7cb43', submittedAt: '2026-08-02T09:53:41Z' }),
+  review({ commitSha: '8b92f7e23b21ebb539466e429bed87e59defab47', submittedAt: '2026-08-02T10:02:20Z' }),
+  review({ commitSha: 'f0b6ddf9ba9e76cb9b39cc3fe3107a0973657bd3', submittedAt: '2026-08-02T10:12:24Z' }),
+  review({ commitSha: 'ecad4b74bdfa83dc88941c8ffa8af4685f815d4d', submittedAt: '2026-08-02T10:24:44Z' }),
+  review({ commitSha: pr13475ReviewedHeadSha, submittedAt: pr13475ReviewSubmittedAt }),
 ]
 
 const issueComment = (overrides: Partial<PullRequestIssueComment> = {}): PullRequestIssueComment => ({
@@ -426,6 +453,46 @@ const pr13473ReactionSnapshot = (
     reactions: options.reactions ?? [reaction({ createdAt: pr13473ReactionAt })],
     headForcePushes: options.headForcePushes ?? [pr13473EarlierForcePush, pr13473FinalForcePush],
     headForcePushCount: options.headForcePushCount,
+  })
+
+const pr13475FeedbackThread = (overrides: Partial<PullRequestReviewThread> = {}): PullRequestReviewThread =>
+  thread({
+    id: 'PRRT_kwDOLkRLus6VwJXZ',
+    isResolved: true,
+    isOutdated: true,
+    path: 'services/bayn/src/candidate-development-local/command.ts',
+    url: 'https://github.com/proompteng/lab/pull/13475#discussion_r3698708781',
+    comments: [
+      threadComment({
+        body: 'Include the main-worktree legacy receipt in linked checks.',
+        commitSha: pr13475FinalHeadSha,
+        reviewCommitSha: pr13475ReviewedHeadSha,
+        reviewAuthorLogin: baynCodexReviewer,
+        reviewSubmittedAt: pr13475ReviewSubmittedAt,
+        createdAt: '2026-08-02T10:32:17Z',
+        url: 'https://github.com/proompteng/lab/pull/13475#discussion_r3698708781',
+      }),
+    ],
+    ...overrides,
+  })
+
+const pr13475ReviewSnapshot = (
+  options: {
+    readonly commitShas?: readonly string[]
+    readonly reviews?: readonly PullRequestReview[]
+    readonly threads?: readonly PullRequestReviewThread[]
+  } = {},
+): BaynReleaseReviewSnapshot =>
+  reviewSnapshotFor({
+    commitSha: pr13475MainCommitSha,
+    prNumber: 13475,
+    headSha: pr13475FinalHeadSha,
+    parents: [pushBeforeSha],
+    createdAt: pr13475CreatedAt,
+    mergedAt: pr13475MergedAt,
+    reviews: options.reviews ?? pr13475Reviews,
+    threads: options.threads ?? [pr13475FeedbackThread()],
+    commitShas: options.commitShas ?? pr13475FinalCommitShas,
   })
 
 const eligibilitySnapshot = (
@@ -6286,7 +6353,7 @@ describe('Bayn delayed-attestation publication retry', () => {
     ).toEqual({ commitShaPrefix: mainCommitSha.slice(0, 12), prNumber: 13401 })
     expect(
       parseFailedReviewThreadBlock(
-        `2026-07-30T07:02:30Z BAYN_RELEASE_REVIEW_HOLD feedback-fix-attestation-missing: Bayn-affecting commit ${mainCommitSha.slice(0, 12)} after last published ${lastPublishedSha.slice(0, 12)} is not release-eligible: source PR #13401 final head ${finalHeadSha.slice(0, 12)} carries review from ${olderHeadSha.slice(0, 12)}, but post-review commit ${finalHeadSha.slice(0, 12)} lacks a trusted member reply on a resolved Codex thread from that review\n`,
+        `2026-07-30T07:02:30Z BAYN_RELEASE_REVIEW_HOLD feedback-fix-attestation-missing: Bayn-affecting commit ${mainCommitSha.slice(0, 12)} after last published ${lastPublishedSha.slice(0, 12)} is not release-eligible: source PR #13401 final head ${finalHeadSha.slice(0, 12)} carries review from ${olderHeadSha.slice(0, 12)}, but post-review feedback threads are not a resolved, final-head-safe causal fix from that review\n`,
       ),
     ).toEqual({ commitShaPrefix: mainCommitSha.slice(0, 12), prNumber: 13401 })
     expect(
@@ -6932,6 +6999,144 @@ describe('Bayn exact-head release review eligibility', () => {
     })
   })
 
+  test('accepts the real #13475 final feedback-fix head without a member reply ceremony', () => {
+    expect(
+      evaluateBaynReleaseReview({
+        mainCommitSha: pr13475MainCommitSha,
+        baseRefName: 'main',
+        snapshot: pr13475ReviewSnapshot(),
+        nowMs: Date.parse('2026-08-02T11:00:00Z'),
+        pushBeforeSha: null,
+      }),
+    ).toEqual({
+      status: 'eligible',
+      prNumber: 13475,
+      headSha: pr13475FinalHeadSha,
+      reviewSubmittedAt: pr13475ReviewSubmittedAt,
+      eligibleAt: '2026-08-02T10:32:46.000Z',
+    })
+  })
+
+  test.each([
+    [
+      'unresolved actionable thread',
+      pr13475ReviewSnapshot({ threads: [pr13475FeedbackThread({ isResolved: false })] }),
+      'feedback-fix-attestation-missing',
+    ],
+    [
+      'unchanged reviewed path',
+      pr13475ReviewSnapshot({
+        threads: [
+          pr13475FeedbackThread({
+            isOutdated: false,
+            comments: [
+              threadComment({
+                commitSha: pr13475ReviewedHeadSha,
+                reviewCommitSha: pr13475ReviewedHeadSha,
+                reviewSubmittedAt: pr13475ReviewSubmittedAt,
+              }),
+            ],
+          }),
+        ],
+      }),
+      'feedback-fix-attestation-missing',
+    ],
+    [
+      'intermediate fix later reverted before final head',
+      pr13475ReviewSnapshot({
+        commitShas: [...pr13475FinalCommitShas.slice(0, -1), 'a'.repeat(40), pr13475FinalHeadSha],
+        threads: [
+          pr13475FeedbackThread({
+            comments: [
+              threadComment({
+                commitSha: 'a'.repeat(40),
+                reviewCommitSha: pr13475ReviewedHeadSha,
+                reviewSubmittedAt: pr13475ReviewSubmittedAt,
+              }),
+            ],
+          }),
+        ],
+      }),
+      'feedback-fix-attestation-missing',
+    ],
+    [
+      'reviewed head absent from final history',
+      pr13475ReviewSnapshot({
+        commitShas: [pr13475FinalCommitShas[0]!, pr13475FinalHeadSha],
+        reviews: [review({ commitSha: pr13475ReviewedHeadSha, submittedAt: pr13475ReviewSubmittedAt })],
+      }),
+      'exact-head-review-missing',
+    ],
+    [
+      'final head not later than reviewed head',
+      pr13475ReviewSnapshot({ commitShas: [pr13475ReviewedHeadSha] }),
+      'source-pr-commit-history-mismatch',
+    ],
+    [
+      'ambiguous latest applicable review',
+      pr13475ReviewSnapshot({
+        reviews: [
+          review({ commitSha: 'ecad4b74bdfa83dc88941c8ffa8af4685f815d4d', submittedAt: pr13475ReviewSubmittedAt }),
+          review({ commitSha: pr13475ReviewedHeadSha, submittedAt: pr13475ReviewSubmittedAt }),
+        ],
+      }),
+      'exact-head-review-missing',
+    ],
+    [
+      'stale unrelated trusted reply',
+      pr13475ReviewSnapshot({
+        threads: [
+          pr13475FeedbackThread({
+            isOutdated: false,
+            comments: [
+              threadComment({
+                commitSha: pr13475ReviewedHeadSha,
+                reviewCommitSha: pr13475ReviewedHeadSha,
+                reviewSubmittedAt: pr13475ReviewSubmittedAt,
+              }),
+              threadComment({
+                authorLogin: 'gregkonush',
+                authorAssociation: 'MEMBER',
+                commitSha: pr13475ReviewedHeadSha,
+                reviewCommitSha: 'a'.repeat(40),
+                reviewAuthorLogin: 'gregkonush',
+                reviewSubmittedAt: '2026-08-02T10:40:00Z',
+              }),
+            ],
+          }),
+        ],
+      }),
+      'feedback-fix-attestation-missing',
+    ],
+    [
+      'malformed review comment binding',
+      pr13475ReviewSnapshot({
+        threads: [
+          pr13475FeedbackThread({
+            comments: [
+              threadComment({
+                commitSha: pr13475FinalHeadSha,
+                reviewCommitSha: pr13475ReviewedHeadSha,
+                reviewSubmittedAt: null,
+              }),
+            ],
+          }),
+        ],
+      }),
+      'feedback-fix-attestation-missing',
+    ],
+  ] as const)('rejects #13475 feedback-fix evidence with %s', (_name, reviewSnapshot, code) => {
+    expect(
+      evaluateBaynReleaseReview({
+        mainCommitSha: pr13475MainCommitSha,
+        baseRefName: 'main',
+        snapshot: reviewSnapshot,
+        nowMs: Date.parse('2026-08-02T11:00:00Z'),
+        pushBeforeSha: null,
+      }),
+    ).toMatchObject({ status: 'hold', code })
+  })
+
   test('accepts #13464 through the exact final-head reaction after its force-push', () => {
     expect(
       evaluateBaynReleaseReview({
@@ -7383,7 +7588,7 @@ describe('Bayn exact-head release review eligibility', () => {
     })
   })
 
-  test('requires an attestation for every commit after the reviewed head', () => {
+  test('accepts a final trusted feedback reply without per-commit attestations', () => {
     const intermediateFixSha = '4'.repeat(40)
     expect(
       evaluateBaynReleaseReview({
@@ -7410,10 +7615,12 @@ describe('Bayn exact-head release review eligibility', () => {
         nowMs: evaluationNowMs,
         pushBeforeSha: null,
       }),
-    ).toMatchObject({
-      status: 'hold',
-      code: 'feedback-fix-attestation-missing',
-      retryable: true,
+    ).toEqual({
+      status: 'eligible',
+      prNumber: 13390,
+      headSha: finalHeadSha,
+      reviewSubmittedAt: '2026-07-30T07:01:00Z',
+      eligibleAt: '2026-07-30T07:01:30.000Z',
     })
   })
 

--- a/packages/scripts/src/bayn/verify-release-review.test.ts
+++ b/packages/scripts/src/bayn/verify-release-review.test.ts
@@ -128,6 +128,19 @@ const pr13475FinalHeadCommit: PullRequestFinalHeadCommitDetail = {
     },
   ],
 }
+const genericFeedbackFixFinalHeadCommit: PullRequestFinalHeadCommitDetail = {
+  sha: finalHeadSha,
+  parents: [olderHeadSha],
+  files: ['packages/scripts/src/bayn/verify-release-review.ts'],
+  fileChanges: [
+    {
+      path: 'packages/scripts/src/bayn/verify-release-review.ts',
+      previousPath: null,
+      status: 'modified',
+      blobSha: null,
+    },
+  ],
+}
 const pr13473EarlierForcePush: PullRequestForcePush = {
   actorLogin: 'gregkonush',
   beforeCommitSha: pr13473EarlierForcePushBeforeSha,
@@ -239,6 +252,7 @@ const snapshot = (
     readonly threads?: readonly PullRequestReviewThread[]
     readonly mainCommitParents?: readonly string[]
     readonly commitShas?: readonly string[]
+    readonly finalHeadCommit?: PullRequestFinalHeadCommitDetail | null
     readonly issueComments?: readonly PullRequestIssueComment[]
     readonly reactions?: readonly PullRequestReaction[]
     readonly headForcePushes?: readonly PullRequestForcePush[]
@@ -267,6 +281,7 @@ const snapshot = (
             reviews: options.reviews ?? [review()],
             threads: options.threads ?? [],
             commitShas: options.commitShas ?? [source.headSha],
+            finalHeadCommit: options.finalHeadCommit,
             issueComments: options.issueComments ?? [],
             reactions: options.reactions ?? [],
             headForcePushes: options.headForcePushes ?? [],
@@ -5980,7 +5995,8 @@ describe('Bayn delayed-attestation publication retry', () => {
     const resolvedFeedback = snapshot({
       commitShas: [olderHeadSha, finalHeadSha],
       reviews: [review({ commitSha: olderHeadSha, submittedAt: '2026-07-30T07:00:00Z' })],
-      threads: [thread({ isResolved: true, comments: feedbackComments })],
+      finalHeadCommit: genericFeedbackFixFinalHeadCommit,
+      threads: [thread({ isResolved: true, isOutdated: true, comments: feedbackComments })],
     })
     expect(
       evaluateBaynReleaseRetry({
@@ -6002,12 +6018,14 @@ describe('Bayn delayed-attestation publication retry', () => {
     })
   })
 
-  test('dispatches when the final required feedback attestation arrives after the failed push', () => {
+  test('does not use a trusted feedback reply as delayed retry evidence', () => {
     const feedbackReview = snapshot({
       commitShas: [olderHeadSha, finalHeadSha],
       reviews: [review({ commitSha: olderHeadSha, submittedAt: '2026-07-30T07:00:00Z' })],
+      finalHeadCommit: genericFeedbackFixFinalHeadCommit,
       threads: [
         thread({
+          isOutdated: true,
           comments: [
             threadComment({
               createdAt: '2026-07-30T07:00:00Z',
@@ -6038,7 +6056,7 @@ describe('Bayn delayed-attestation publication retry', () => {
     ).toMatchObject({
       status: 'eligible',
       reviewSubmittedAt: '2026-07-30T07:00:00Z',
-      eligibleAt: '2026-07-30T07:03:00.000Z',
+      eligibleAt: '2026-07-30T07:00:30.000Z',
     })
     expect(
       evaluateBaynReleaseRetry({
@@ -6049,18 +6067,18 @@ describe('Bayn delayed-attestation publication retry', () => {
         nowMs: retryNowMs,
       }),
     ).toMatchObject({
-      status: 'dispatch',
-      sourceCommitSha: mainCommitSha,
-      prNumber: 13390,
-      headSha: finalHeadSha,
+      status: 'hold',
+      code: 'retry-attestation-not-delayed',
+      retryable: true,
     })
   })
 
-  test('uses the latest per-thread reply when feedback attestations straddle the failed review gate', () => {
+  test('rejects a multi-commit feedback fix even when every thread has a trusted final-head reply', () => {
     const firstReplyAt = '2026-07-30T07:01:00Z'
     const finalReplyAt = '2026-07-30T07:03:00Z'
+    const intermediateFixSha = '4'.repeat(40)
     const feedbackReview = snapshot({
-      commitShas: [olderHeadSha, finalHeadSha],
+      commitShas: [olderHeadSha, intermediateFixSha, finalHeadSha],
       reviews: [review({ commitSha: olderHeadSha, submittedAt: '2026-07-30T07:00:00Z' })],
       threads: [
         thread({
@@ -6110,27 +6128,9 @@ describe('Bayn delayed-attestation publication retry', () => {
         pushBeforeSha: null,
       }),
     ).toMatchObject({
-      status: 'eligible',
-      eligibleAt: '2026-07-30T07:03:00.000Z',
-    })
-
-    expect(
-      evaluateBaynReleaseRetry({
-        mainCommitSha,
-        baseRefName: 'main',
-        snapshot: retrySnapshot({
-          reviewSnapshot: feedbackReview,
-          failedRun: failedBuildRun({ updatedAt: '2026-07-30T07:02:30Z' }),
-          failedReviewJobCompletedAt: '2026-07-30T07:02:30Z',
-        }),
-        trigger: { type: 'schedule' },
-        nowMs: retryNowMs,
-      }),
-    ).toMatchObject({
-      status: 'dispatch',
-      sourceCommitSha: mainCommitSha,
-      prNumber: 13390,
-      headSha: finalHeadSha,
+      status: 'hold',
+      code: 'feedback-fix-attestation-missing',
+      retryable: true,
     })
   })
 
@@ -7129,6 +7129,34 @@ describe('Bayn exact-head release review eligibility', () => {
     })
   })
 
+  test('accepts a direct-child feedback fix with no release-affecting Bayn path', () => {
+    const reviewedTestPath = 'packages/scripts/src/bayn/verify-release-review.test.ts'
+    expect(
+      evaluateBaynReleaseReview({
+        mainCommitSha: pr13475MainCommitSha,
+        baseRefName: 'main',
+        snapshot: pr13475ReviewSnapshot({
+          finalHeadCommit: {
+            sha: pr13475FinalHeadSha,
+            parents: [pr13475ReviewedHeadSha],
+            files: [reviewedTestPath],
+            fileChanges: [
+              {
+                path: reviewedTestPath,
+                previousPath: null,
+                status: 'modified',
+                blobSha: null,
+              },
+            ],
+          },
+          threads: [pr13475FeedbackThread({ path: reviewedTestPath })],
+        }),
+        nowMs: Date.parse('2026-08-02T11:00:00Z'),
+        pushBeforeSha: null,
+      }),
+    ).toMatchObject({ status: 'eligible', prNumber: 13475, headSha: pr13475FinalHeadSha })
+  })
+
   test.each([
     [
       'unresolved actionable thread',
@@ -7639,8 +7667,10 @@ describe('Bayn exact-head release review eligibility', () => {
         snapshot: snapshot({
           commitShas: [olderHeadSha, finalHeadSha],
           reviews: [review({ commitSha: olderHeadSha })],
+          finalHeadCommit: genericFeedbackFixFinalHeadCommit,
           threads: [
             thread({
+              isOutdated: true,
               comments: [
                 threadComment(),
                 threadComment({
@@ -7668,7 +7698,7 @@ describe('Bayn exact-head release review eligibility', () => {
     })
   })
 
-  test('retries a stale feedback-attestation read and then accepts the indexed reply', async () => {
+  test('retries a stale final-head detail read and then accepts the indexed commit', async () => {
     let calls = 0
     const sleeps: number[] = []
     const result = await pollBaynReleaseReview({
@@ -7681,8 +7711,10 @@ describe('Bayn exact-head release review eligibility', () => {
         return snapshot({
           commitShas: [olderHeadSha, finalHeadSha],
           reviews: [review({ commitSha: olderHeadSha })],
+          finalHeadCommit: calls === 1 ? null : genericFeedbackFixFinalHeadCommit,
           threads: [
             thread({
+              isOutdated: true,
               comments: [
                 threadComment(),
                 ...(calls === 1
@@ -7764,7 +7796,7 @@ describe('Bayn exact-head release review eligibility', () => {
     })
   })
 
-  test('accepts a final trusted feedback reply without per-commit attestations', () => {
+  test('rejects a final trusted feedback reply across multiple commits', () => {
     const intermediateFixSha = '4'.repeat(40)
     expect(
       evaluateBaynReleaseReview({
@@ -7791,12 +7823,10 @@ describe('Bayn exact-head release review eligibility', () => {
         nowMs: evaluationNowMs,
         pushBeforeSha: null,
       }),
-    ).toEqual({
-      status: 'eligible',
-      prNumber: 13390,
-      headSha: finalHeadSha,
-      reviewSubmittedAt: '2026-07-30T07:01:00Z',
-      eligibleAt: '2026-07-30T07:01:30.000Z',
+    ).toMatchObject({
+      status: 'hold',
+      code: 'feedback-fix-attestation-missing',
+      retryable: true,
     })
   })
 
@@ -8388,5 +8418,204 @@ describe('Bayn exact-head release review eligibility', () => {
 
     await expect(loader()).rejects.toMatchObject({ code: 'github-api-pagination-limit' })
     expect(finalHeadDetailRequests).toBe(1)
+  })
+
+  test('requires final-head detail for all-replied and mixed feedback threads', async () => {
+    const fallbackReviewSubmittedAt = '2026-07-30T07:00:00Z'
+    const trustedReplyAt = '2026-07-30T07:00:30Z'
+    const fallbackPath = 'services/bayn/src/example.ts'
+    const makeFetchFn = (finalFilePaths: readonly string[], includeNoReplyThread = true) => {
+      let finalHeadDetailRequests = 0
+      const fetchFn = (async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input)
+        if (url.includes('/commits/')) {
+          if (!url.includes('/pulls?')) {
+            if (url.includes(`/commits/${finalHeadSha}?`)) {
+              finalHeadDetailRequests += 1
+              return Response.json({
+                sha: finalHeadSha,
+                parents: [{ sha: olderHeadSha }],
+                files: finalFilePaths.map((filename) => ({ filename, status: 'modified' })),
+              })
+            }
+            return Response.json({
+              sha: mainCommitSha,
+              parents: [{ sha: pushBeforeSha }],
+              files: [{ filename: fallbackPath }],
+            })
+          }
+          return Response.json([
+            {
+              number: 13390,
+              base: { ref: 'main' },
+              head: { sha: finalHeadSha },
+              merge_commit_sha: mainCommitSha,
+              merged_at: '2026-07-30T07:01:30Z',
+            },
+          ])
+        }
+        if (url.includes('/issues/13390/comments?') || url.includes('/issues/13390/reactions?')) {
+          return Response.json([])
+        }
+
+        const request = JSON.parse(String(init?.body)) as { readonly query: string }
+        if (request.query.includes('BaynReleasePullRequestMetadata')) {
+          return Response.json({
+            data: {
+              repository: {
+                pullRequest: {
+                  number: 13390,
+                  baseRefName: 'main',
+                  headRefOid: finalHeadSha,
+                  createdAt: '2026-07-30T06:59:00Z',
+                  mergedAt: '2026-07-30T07:01:30Z',
+                  mergeCommit: { oid: mainCommitSha },
+                  timelineItems: { nodes: [], pageInfo: { hasNextPage: false, endCursor: null } },
+                },
+              },
+            },
+          })
+        }
+        if (request.query.includes('BaynReleasePullRequestReviews')) {
+          return Response.json({
+            data: {
+              repository: {
+                pullRequest: {
+                  reviews: {
+                    nodes: [
+                      {
+                        author: { login: baynCodexReviewer },
+                        commit: { oid: olderHeadSha },
+                        submittedAt: fallbackReviewSubmittedAt,
+                        state: 'COMMENTED',
+                      },
+                    ],
+                    pageInfo: { hasNextPage: false, endCursor: null },
+                  },
+                },
+              },
+            },
+          })
+        }
+        if (request.query.includes('BaynReleasePullRequestThreads')) {
+          const reviewedComment = {
+            author: { login: baynCodexReviewer },
+            authorAssociation: 'NONE',
+            body: 'Review finding',
+            createdAt: fallbackReviewSubmittedAt,
+            commit: { oid: olderHeadSha },
+            pullRequestReview: {
+              author: { login: baynCodexReviewer },
+              commit: { oid: olderHeadSha },
+              submittedAt: fallbackReviewSubmittedAt,
+              state: 'COMMENTED',
+            },
+            url: 'https://github.com/proompteng/lab/pull/13390#discussion_reviewed',
+          }
+          const trustedReply = {
+            author: { login: 'gregkonush' },
+            authorAssociation: 'MEMBER',
+            body: 'Fixed in the final head.',
+            createdAt: trustedReplyAt,
+            commit: { oid: finalHeadSha },
+            pullRequestReview: {
+              author: { login: 'gregkonush' },
+              commit: { oid: finalHeadSha },
+              submittedAt: trustedReplyAt,
+              state: 'COMMENTED',
+            },
+            url: 'https://github.com/proompteng/lab/pull/13390#discussion_reply',
+          }
+          return Response.json({
+            data: {
+              repository: {
+                pullRequest: {
+                  reviewThreads: {
+                    nodes: [
+                      {
+                        id: 'mixed-replied-thread',
+                        isResolved: true,
+                        isOutdated: true,
+                        path: fallbackPath,
+                        comments: {
+                          nodes: [reviewedComment, trustedReply],
+                          pageInfo: { hasNextPage: false, endCursor: null },
+                        },
+                      },
+                      ...(includeNoReplyThread
+                        ? [
+                            {
+                              id: 'mixed-no-reply-thread',
+                              isResolved: true,
+                              isOutdated: true,
+                              path: fallbackPath,
+                              comments: {
+                                nodes: [reviewedComment],
+                                pageInfo: { hasNextPage: false, endCursor: null },
+                              },
+                            },
+                          ]
+                        : []),
+                    ],
+                    pageInfo: { hasNextPage: false, endCursor: null },
+                  },
+                },
+              },
+            },
+          })
+        }
+        if (request.query.includes('BaynReleasePullRequestCommits')) {
+          return Response.json({
+            data: {
+              repository: {
+                pullRequest: {
+                  commits: {
+                    nodes: [{ commit: { oid: olderHeadSha } }, { commit: { oid: finalHeadSha } }],
+                    pageInfo: { hasNextPage: false, endCursor: null },
+                  },
+                },
+              },
+            },
+          })
+        }
+        throw new Error('unexpected mixed fixture request')
+      }) as typeof fetch
+      return { fetchFn, getFinalHeadDetailRequests: () => finalHeadDetailRequests }
+    }
+
+    const evaluateLoaded = async (finalFilePaths: readonly string[], includeNoReplyThread = true) => {
+      const fixture = makeFetchFn(finalFilePaths, includeNoReplyThread)
+      const loader = createGitHubReleaseReviewLoader({
+        repository: 'proompteng/lab',
+        token: 'fixture-token',
+        mainCommitSha,
+        baseRefName: 'main',
+        requestTimeoutMs: 1_000,
+        fetchFn: fixture.fetchFn,
+      })
+      const result = evaluateBaynReleaseReview({
+        mainCommitSha,
+        baseRefName: 'main',
+        snapshot: await loader(),
+        nowMs: evaluationNowMs,
+        pushBeforeSha: null,
+      })
+      expect(fixture.getFinalHeadDetailRequests()).toBe(1)
+      return result
+    }
+
+    expect(await evaluateLoaded([fallbackPath, 'services/bayn/src/unreviewed.ts'])).toMatchObject({
+      status: 'hold',
+      code: 'feedback-fix-attestation-missing',
+    })
+    expect(await evaluateLoaded([fallbackPath, 'services/bayn/src/unreviewed.ts'], false)).toMatchObject({
+      status: 'hold',
+      code: 'feedback-fix-attestation-missing',
+    })
+    expect(await evaluateLoaded([fallbackPath])).toMatchObject({
+      status: 'eligible',
+      prNumber: 13390,
+      headSha: finalHeadSha,
+    })
   })
 })

--- a/packages/scripts/src/bayn/verify-release-review.test.ts
+++ b/packages/scripts/src/bayn/verify-release-review.test.ts
@@ -465,7 +465,7 @@ const pr13475FeedbackThread = (overrides: Partial<PullRequestReviewThread> = {})
     comments: [
       threadComment({
         body: 'Include the main-worktree legacy receipt in linked checks.',
-        commitSha: pr13475FinalHeadSha,
+        commitSha: pr13475ReviewedHeadSha,
         reviewCommitSha: pr13475ReviewedHeadSha,
         reviewAuthorLogin: baynCodexReviewer,
         reviewSubmittedAt: pr13475ReviewSubmittedAt,
@@ -7024,7 +7024,7 @@ describe('Bayn exact-head release review eligibility', () => {
       'feedback-fix-attestation-missing',
     ],
     [
-      'unchanged reviewed path',
+      'direct final child but thread not outdated',
       pr13475ReviewSnapshot({
         threads: [
           pr13475FeedbackThread({
@@ -7042,14 +7042,15 @@ describe('Bayn exact-head release review eligibility', () => {
       'feedback-fix-attestation-missing',
     ],
     [
-      'intermediate fix later reverted before final head',
+      'two post-review commits with first outdating and second revert',
       pr13475ReviewSnapshot({
         commitShas: [...pr13475FinalCommitShas.slice(0, -1), 'a'.repeat(40), pr13475FinalHeadSha],
         threads: [
           pr13475FeedbackThread({
+            isOutdated: true,
             comments: [
               threadComment({
-                commitSha: 'a'.repeat(40),
+                commitSha: pr13475ReviewedHeadSha,
                 reviewCommitSha: pr13475ReviewedHeadSha,
                 reviewSubmittedAt: pr13475ReviewSubmittedAt,
               }),
@@ -7059,6 +7060,7 @@ describe('Bayn exact-head release review eligibility', () => {
       }),
       'feedback-fix-attestation-missing',
     ],
+    ['missing feedback thread', pr13475ReviewSnapshot({ threads: [] }), 'feedback-fix-attestation-missing'],
     [
       'reviewed head absent from final history',
       pr13475ReviewSnapshot({

--- a/packages/scripts/src/bayn/verify-release-review.test.ts
+++ b/packages/scripts/src/bayn/verify-release-review.test.ts
@@ -8098,15 +8098,34 @@ describe('Bayn exact-head release review eligibility', () => {
     expect(requireHold(result).message).toContain('bounded wait exhausted')
   })
 
-  test('decodes a complete deterministic GitHub API fixture', async () => {
+  test('does not request paginated final-head detail for exact-head evidence', async () => {
+    let finalHeadDetailRequests = 0
     const fetchFn = (async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = String(input)
       if (url.includes('/commits/')) {
         if (!url.includes('/pulls?')) {
           const isFinalHeadDetail = url.includes(`/commits/${finalHeadSha}?`)
+          if (isFinalHeadDetail) {
+            finalHeadDetailRequests += 1
+            return new Response(
+              JSON.stringify({
+                sha: finalHeadSha,
+                parents: [{ sha: olderHeadSha }],
+                files: Array.from({ length: 101 }, (_, index) => ({
+                  filename: `services/bayn/src/generated-${index}.ts`,
+                })),
+              }),
+              {
+                headers: {
+                  'content-type': 'application/json',
+                  link: '<https://api.github.com/next>; rel="next"',
+                },
+              },
+            )
+          }
           return Response.json({
-            sha: isFinalHeadDetail ? finalHeadSha : mainCommitSha,
-            parents: [{ sha: isFinalHeadDetail ? olderHeadSha : pushBeforeSha }],
+            sha: mainCommitSha,
+            parents: [{ sha: pushBeforeSha }],
             files: [{ filename: 'services/bayn/src/example.ts' }],
           })
         }
@@ -8215,5 +8234,159 @@ describe('Bayn exact-head release review eligibility', () => {
         pushBeforeSha: null,
       }),
     ).toMatchObject({ status: 'eligible', prNumber: 13390, headSha: finalHeadSha })
+    expect(finalHeadDetailRequests).toBe(0)
+  })
+
+  test('requests paginated final-head detail for no-reply feedback-fix evidence and fails closed', async () => {
+    const fallbackReviewSubmittedAt = '2026-07-30T07:00:00Z'
+    const fallbackPath = 'services/bayn/src/example.ts'
+    let finalHeadDetailRequests = 0
+    const fetchFn = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url.includes('/commits/')) {
+        if (!url.includes('/pulls?')) {
+          if (url.includes(`/commits/${finalHeadSha}?`)) {
+            finalHeadDetailRequests += 1
+            return new Response(
+              JSON.stringify({
+                sha: finalHeadSha,
+                parents: [{ sha: olderHeadSha }],
+                files: Array.from({ length: 101 }, (_, index) => ({ filename: `${fallbackPath}-${index}` })),
+              }),
+              {
+                headers: {
+                  'content-type': 'application/json',
+                  link: '<https://api.github.com/next>; rel="next"',
+                },
+              },
+            )
+          }
+          return Response.json({
+            sha: mainCommitSha,
+            parents: [{ sha: pushBeforeSha }],
+            files: [{ filename: fallbackPath }],
+          })
+        }
+        return Response.json([
+          {
+            number: 13390,
+            base: { ref: 'main' },
+            head: { sha: finalHeadSha },
+            merge_commit_sha: mainCommitSha,
+            merged_at: '2026-07-30T07:01:30Z',
+          },
+        ])
+      }
+      if (url.includes('/issues/13390/comments?') || url.includes('/issues/13390/reactions?')) {
+        return Response.json([])
+      }
+
+      const request = JSON.parse(String(init?.body)) as { readonly query: string }
+      if (request.query.includes('BaynReleasePullRequestMetadata')) {
+        return Response.json({
+          data: {
+            repository: {
+              pullRequest: {
+                number: 13390,
+                baseRefName: 'main',
+                headRefOid: finalHeadSha,
+                createdAt: '2026-07-30T06:59:00Z',
+                mergedAt: '2026-07-30T07:01:30Z',
+                mergeCommit: { oid: mainCommitSha },
+                timelineItems: { nodes: [], pageInfo: { hasNextPage: false, endCursor: null } },
+              },
+            },
+          },
+        })
+      }
+      if (request.query.includes('BaynReleasePullRequestReviews')) {
+        return Response.json({
+          data: {
+            repository: {
+              pullRequest: {
+                reviews: {
+                  nodes: [
+                    {
+                      author: { login: baynCodexReviewer },
+                      commit: { oid: olderHeadSha },
+                      submittedAt: fallbackReviewSubmittedAt,
+                      state: 'COMMENTED',
+                    },
+                  ],
+                  pageInfo: { hasNextPage: false, endCursor: null },
+                },
+              },
+            },
+          },
+        })
+      }
+      if (request.query.includes('BaynReleasePullRequestThreads')) {
+        return Response.json({
+          data: {
+            repository: {
+              pullRequest: {
+                reviewThreads: {
+                  nodes: [
+                    {
+                      id: 'fallback-thread',
+                      isResolved: true,
+                      isOutdated: true,
+                      path: fallbackPath,
+                      comments: {
+                        nodes: [
+                          {
+                            author: { login: baynCodexReviewer },
+                            authorAssociation: 'NONE',
+                            body: 'Review finding',
+                            createdAt: fallbackReviewSubmittedAt,
+                            commit: { oid: olderHeadSha },
+                            pullRequestReview: {
+                              author: { login: baynCodexReviewer },
+                              commit: { oid: olderHeadSha },
+                              submittedAt: fallbackReviewSubmittedAt,
+                              state: 'COMMENTED',
+                            },
+                            url: 'https://github.com/proompteng/lab/pull/13390#discussion_fallback',
+                          },
+                        ],
+                        pageInfo: { hasNextPage: false, endCursor: null },
+                      },
+                    },
+                  ],
+                  pageInfo: { hasNextPage: false, endCursor: null },
+                },
+              },
+            },
+          },
+        })
+      }
+      if (request.query.includes('BaynReleasePullRequestCommits')) {
+        return Response.json({
+          data: {
+            repository: {
+              pullRequest: {
+                commits: {
+                  nodes: [{ commit: { oid: olderHeadSha } }, { commit: { oid: finalHeadSha } }],
+                  pageInfo: { hasNextPage: false, endCursor: null },
+                },
+              },
+            },
+          },
+        })
+      }
+      throw new Error('unexpected fallback fixture request')
+    }) as typeof fetch
+
+    const loader = createGitHubReleaseReviewLoader({
+      repository: 'proompteng/lab',
+      token: 'fixture-token',
+      mainCommitSha,
+      baseRefName: 'main',
+      requestTimeoutMs: 1_000,
+      fetchFn,
+    })
+
+    await expect(loader()).rejects.toMatchObject({ code: 'github-api-pagination-limit' })
+    expect(finalHeadDetailRequests).toBe(1)
   })
 })

--- a/packages/scripts/src/bayn/verify-release-review.ts
+++ b/packages/scripts/src/bayn/verify-release-review.ts
@@ -51,6 +51,13 @@ export interface PullRequestForcePush {
   readonly createdAt: string
 }
 
+export interface PullRequestFinalHeadCommitDetail {
+  readonly sha: string
+  readonly parents: readonly string[]
+  readonly files: readonly string[]
+  readonly fileChanges: readonly BaynReleaseCommitFileChange[]
+}
+
 export interface PullRequestReviewThreadComment {
   readonly authorLogin: string | null
   readonly authorAssociation: string
@@ -83,6 +90,7 @@ export interface PullRequestReviewState {
   readonly reviews: readonly PullRequestReview[]
   readonly threads: readonly PullRequestReviewThread[]
   readonly commitShas: readonly string[]
+  readonly finalHeadCommit?: PullRequestFinalHeadCommitDetail | null
   readonly issueComments: readonly PullRequestIssueComment[]
   readonly reactions: readonly PullRequestReaction[]
   readonly headForcePushes: readonly PullRequestForcePush[]
@@ -1514,25 +1522,17 @@ const selectFeedbackFixEvidence = (
   const finalCommitIndex = pullRequest.commitShas.length - 1
   if (reviewedCommitIndex < 0 || reviewedCommitIndex >= finalCommitIndex) return undefined
   const isDirectFinalChild = reviewedCommitIndex + 1 === finalCommitIndex
+  const belongsToReview = (comment: PullRequestReviewThreadComment): boolean =>
+    comment.reviewAuthorLogin === baynCodexReviewer &&
+    (comment.reviewCommitSha === reviewEvidence.commitSha || comment.reviewSubmittedAt === reviewEvidence.submittedAt)
 
-  const reviewedThreads = pullRequest.threads.filter((thread) =>
-    thread.comments.some(
-      (comment) =>
-        comment.reviewAuthorLogin === baynCodexReviewer &&
-        (comment.reviewCommitSha === reviewEvidence.commitSha ||
-          comment.reviewSubmittedAt === reviewEvidence.submittedAt),
-    ),
-  )
+  const reviewedThreads = pullRequest.threads.filter((thread) => thread.comments.some(belongsToReview))
   if (reviewedThreads.length === 0) return undefined
 
   const trustedAttestationTimes: number[] = []
+  const reviewedPaths = new Set<string>()
   for (const thread of reviewedThreads) {
-    const reviewedComments = thread.comments.filter(
-      (comment) =>
-        comment.reviewAuthorLogin === baynCodexReviewer &&
-        (comment.reviewCommitSha === reviewEvidence.commitSha ||
-          comment.reviewSubmittedAt === reviewEvidence.submittedAt),
-    )
+    const reviewedComments = thread.comments.filter(belongsToReview)
     if (
       thread.path === null ||
       thread.path.length === 0 ||
@@ -1547,6 +1547,7 @@ const selectFeedbackFixEvidence = (
     ) {
       return undefined
     }
+    reviewedPaths.add(thread.path)
 
     const trustedReplies = thread.comments.flatMap((comment) => {
       if (
@@ -1569,6 +1570,42 @@ const selectFeedbackFixEvidence = (
       return undefined
     }
     trustedAttestationTimes.push(...trustedReplies)
+  }
+
+  if (trustedAttestationTimes.length === 0) {
+    const finalHeadCommit = pullRequest.finalHeadCommit
+    const changedFilePaths = finalHeadCommit?.fileChanges.flatMap((change) =>
+      change.previousPath === null ? [change.path] : [change.path, change.previousPath],
+    )
+    const finalFilePaths = finalHeadCommit?.files
+    const finalFilePathSet = finalFilePaths === undefined ? null : new Set(finalFilePaths)
+    const changedFilePathSet = changedFilePaths === undefined ? null : new Set(changedFilePaths)
+    const finalBaynPaths = finalHeadCommit?.fileChanges
+      .filter((change) => isBaynReleaseAffectingPath(change.path))
+      .map((change) => change.path)
+    if (
+      finalHeadCommit === undefined ||
+      finalHeadCommit === null ||
+      finalHeadCommit.sha !== pullRequest.headSha ||
+      finalHeadCommit.parents.length !== 1 ||
+      finalHeadCommit.parents[0] !== reviewEvidence.commitSha ||
+      finalFilePaths === undefined ||
+      changedFilePaths === undefined ||
+      finalFilePaths.length !== changedFilePaths.length ||
+      finalFilePathSet === null ||
+      changedFilePathSet === null ||
+      finalFilePathSet.size !== finalFilePaths.length ||
+      changedFilePathSet.size !== changedFilePaths.length ||
+      finalFilePaths.some((path) => !changedFilePathSet.has(path)) ||
+      changedFilePaths.some((path) => !finalFilePathSet.has(path)) ||
+      finalHeadCommit.fileChanges.some((change) => change.path.length === 0 || change.previousPath !== null) ||
+      finalBaynPaths === undefined ||
+      finalBaynPaths.length === 0 ||
+      new Set(finalBaynPaths).size !== finalBaynPaths.length ||
+      finalBaynPaths.some((path) => !reviewedPaths.has(path))
+    ) {
+      return undefined
+    }
   }
 
   return {
@@ -4803,12 +4840,8 @@ const parseComparison = (value: unknown): ParsedComparison => {
   }
 }
 
-interface CommitDetail {
-  readonly sha: string
-  readonly parents: readonly string[]
+interface CommitDetail extends PullRequestFinalHeadCommitDetail {
   readonly treeSha: string
-  readonly files: readonly string[]
-  readonly fileChanges: readonly BaynReleaseCommitFileChange[]
 }
 
 const parseCommitDetail = (value: unknown, expectedSha: string): CommitDetail => {
@@ -5467,18 +5500,19 @@ const loadCommitReviewSnapshot = async (
 
   const candidate = candidates[0]
   if (candidate === undefined) throw new Error('source pull selection was unexpectedly empty')
-  const [metadata, reviews, threads, commitShas, issueComments, reactions] = await Promise.all([
+  const [metadata, reviews, threads, commitShas, issueComments, reactions, finalHeadCommit] = await Promise.all([
     fetchPullRequestMetadata(options, candidate.number),
     fetchPullRequestReviews(options, candidate.number),
     fetchPullRequestThreads(options, candidate.number),
     fetchPullRequestCommitShas(options, candidate.number),
     fetchPullRequestIssueComments(options, candidate.number),
     fetchPullRequestReactions(options, candidate.number),
+    fetchCommitDetail(options, candidate.headSha),
   ])
   return {
     mainCommitParents: commit.parents,
     associatedPullRequests,
-    pullRequest: { ...metadata, reviews, threads, commitShas, issueComments, reactions },
+    pullRequest: { ...metadata, reviews, threads, commitShas, finalHeadCommit, issueComments, reactions },
   }
 }
 

--- a/packages/scripts/src/bayn/verify-release-review.ts
+++ b/packages/scripts/src/bayn/verify-release-review.ts
@@ -1513,11 +1513,14 @@ const selectFeedbackFixEvidence = (
   const reviewedCommitIndex = pullRequest.commitShas.indexOf(reviewEvidence.commitSha)
   const finalCommitIndex = pullRequest.commitShas.length - 1
   if (reviewedCommitIndex < 0 || reviewedCommitIndex >= finalCommitIndex) return undefined
+  const isDirectFinalChild = reviewedCommitIndex + 1 === finalCommitIndex
 
   const reviewedThreads = pullRequest.threads.filter((thread) =>
     thread.comments.some(
       (comment) =>
-        comment.reviewAuthorLogin === baynCodexReviewer && comment.reviewCommitSha === reviewEvidence.commitSha,
+        comment.reviewAuthorLogin === baynCodexReviewer &&
+        (comment.reviewCommitSha === reviewEvidence.commitSha ||
+          comment.reviewSubmittedAt === reviewEvidence.submittedAt),
     ),
   )
   if (reviewedThreads.length === 0) return undefined
@@ -1526,7 +1529,9 @@ const selectFeedbackFixEvidence = (
   for (const thread of reviewedThreads) {
     const reviewedComments = thread.comments.filter(
       (comment) =>
-        comment.reviewAuthorLogin === baynCodexReviewer && comment.reviewCommitSha === reviewEvidence.commitSha,
+        comment.reviewAuthorLogin === baynCodexReviewer &&
+        (comment.reviewCommitSha === reviewEvidence.commitSha ||
+          comment.reviewSubmittedAt === reviewEvidence.submittedAt),
     )
     if (
       thread.path === null ||
@@ -1536,13 +1541,13 @@ const selectFeedbackFixEvidence = (
         (comment) =>
           comment.reviewSubmittedAt !== reviewEvidence.submittedAt ||
           comment.reviewState !== reviewEvidence.state ||
-          comment.commitSha === null,
+          comment.commitSha !== reviewEvidence.commitSha ||
+          comment.reviewCommitSha !== reviewEvidence.commitSha,
       )
     ) {
       return undefined
     }
 
-    const changedReviewedPath = reviewedComments.some((comment) => comment.commitSha === pullRequest.headSha)
     const trustedReplies = thread.comments.flatMap((comment) => {
       if (
         comment.authorLogin === null ||
@@ -1558,7 +1563,7 @@ const selectFeedbackFixEvidence = (
     })
     if (
       !thread.isResolved ||
-      (!changedReviewedPath && trustedReplies.length === 0) ||
+      (!isDirectFinalChild && trustedReplies.length === 0) ||
       (!thread.isOutdated && trustedReplies.length === 0)
     ) {
       return undefined

--- a/packages/scripts/src/bayn/verify-release-review.ts
+++ b/packages/scripts/src/bayn/verify-release-review.ts
@@ -1524,7 +1524,8 @@ const selectFeedbackFixEvidence = (
   const isDirectFinalChild = reviewedCommitIndex + 1 === finalCommitIndex
   const belongsToReview = (comment: PullRequestReviewThreadComment): boolean =>
     comment.reviewAuthorLogin === baynCodexReviewer &&
-    (comment.reviewCommitSha === reviewEvidence.commitSha || comment.reviewSubmittedAt === reviewEvidence.submittedAt)
+    comment.reviewCommitSha === reviewEvidence.commitSha &&
+    comment.reviewSubmittedAt === reviewEvidence.submittedAt
 
   const reviewedThreads = pullRequest.threads.filter((thread) => thread.comments.some(belongsToReview))
   if (reviewedThreads.length === 0) return undefined

--- a/packages/scripts/src/bayn/verify-release-review.ts
+++ b/packages/scripts/src/bayn/verify-release-review.ts
@@ -1512,6 +1512,38 @@ const selectLatestApplicableCodexReview = (
   return latest.length === 1 ? latest[0]?.review : undefined
 }
 
+const reviewCommentBelongsTo = (comment: PullRequestReviewThreadComment, reviewEvidence: PullRequestReview): boolean =>
+  comment.reviewAuthorLogin === baynCodexReviewer &&
+  comment.reviewCommitSha === reviewEvidence.commitSha &&
+  comment.reviewSubmittedAt === reviewEvidence.submittedAt
+
+const selectReviewThreads = (
+  pullRequest: PullRequestReviewState,
+  reviewEvidence: PullRequestReview,
+): readonly PullRequestReviewThread[] =>
+  pullRequest.threads.filter((thread) =>
+    thread.comments.some((comment) => reviewCommentBelongsTo(comment, reviewEvidence)),
+  )
+
+const selectTrustedFinalHeadReplyTimes = (
+  pullRequest: PullRequestReviewState,
+  thread: PullRequestReviewThread,
+  reviewSubmittedAtMs: number,
+): readonly number[] =>
+  thread.comments.flatMap((comment) => {
+    if (
+      comment.authorLogin === null ||
+      comment.authorLogin === baynCodexReviewer ||
+      !trustedFeedbackAssociations.has(comment.authorAssociation) ||
+      comment.reviewCommitSha !== pullRequest.headSha ||
+      comment.reviewSubmittedAt === null
+    ) {
+      return []
+    }
+    const attestationTime = Date.parse(comment.reviewSubmittedAt)
+    return Number.isFinite(attestationTime) && attestationTime >= reviewSubmittedAtMs ? [attestationTime] : []
+  })
+
 const selectFeedbackFixEvidence = (
   pullRequest: PullRequestReviewState,
   reviewEvidence: PullRequestReview,
@@ -1522,18 +1554,13 @@ const selectFeedbackFixEvidence = (
   const finalCommitIndex = pullRequest.commitShas.length - 1
   if (reviewedCommitIndex < 0 || reviewedCommitIndex >= finalCommitIndex) return undefined
   const isDirectFinalChild = reviewedCommitIndex + 1 === finalCommitIndex
-  const belongsToReview = (comment: PullRequestReviewThreadComment): boolean =>
-    comment.reviewAuthorLogin === baynCodexReviewer &&
-    comment.reviewCommitSha === reviewEvidence.commitSha &&
-    comment.reviewSubmittedAt === reviewEvidence.submittedAt
-
-  const reviewedThreads = pullRequest.threads.filter((thread) => thread.comments.some(belongsToReview))
+  const reviewedThreads = selectReviewThreads(pullRequest, reviewEvidence)
   if (reviewedThreads.length === 0) return undefined
 
   const threadAttestationTimes: number[] = []
   const reviewedPaths = new Set<string>()
   for (const thread of reviewedThreads) {
-    const reviewedComments = thread.comments.filter(belongsToReview)
+    const reviewedComments = thread.comments.filter((comment) => reviewCommentBelongsTo(comment, reviewEvidence))
     if (
       thread.path === null ||
       thread.path.length === 0 ||
@@ -1550,19 +1577,7 @@ const selectFeedbackFixEvidence = (
     }
     reviewedPaths.add(thread.path)
 
-    const trustedReplies = thread.comments.flatMap((comment) => {
-      if (
-        comment.authorLogin === null ||
-        comment.authorLogin === baynCodexReviewer ||
-        !trustedFeedbackAssociations.has(comment.authorAssociation) ||
-        comment.reviewCommitSha !== pullRequest.headSha ||
-        comment.reviewSubmittedAt === null
-      ) {
-        return []
-      }
-      const attestationTime = Date.parse(comment.reviewSubmittedAt)
-      return Number.isFinite(attestationTime) && attestationTime >= reviewSubmittedAtMs ? [attestationTime] : []
-    })
+    const trustedReplies = selectTrustedFinalHeadReplyTimes(pullRequest, thread, reviewSubmittedAtMs)
     const earliestTrustedReplyAtMs = trustedReplies.length === 0 ? undefined : Math.min(...trustedReplies)
     if (
       !thread.isResolved ||
@@ -1672,6 +1687,38 @@ const selectExactHeadCodexAttestation = (
     submittedAt: reaction.createdAt,
     state: 'COMMENTED',
   }
+}
+
+const shouldFetchFinalHeadCommitDetail = (pullRequest: PullRequestReviewState): boolean => {
+  const createdAtMs = Date.parse(pullRequest.createdAt)
+  const mergedAtMs = pullRequest.mergedAt === null ? Number.NaN : Date.parse(pullRequest.mergedAt)
+  if (!Number.isFinite(createdAtMs) || !Number.isFinite(mergedAtMs) || createdAtMs > mergedAtMs) return false
+
+  const codexReviews = pullRequest.reviews.filter((review) => review.authorLogin === baynCodexReviewer)
+  const exactHeadReviews = codexReviews.filter((review) => review.commitSha === pullRequest.headSha)
+  if (exactHeadReviews.some((review) => review.submittedAt === null || review.state === 'PENDING')) return false
+  if (exactHeadReviews.some((review) => review.submittedAt !== null)) return false
+  if (selectExactHeadCodexAttestation(pullRequest, createdAtMs, mergedAtMs) !== undefined) return false
+  if (!hasUniqueFinalCommitHistory(pullRequest)) return false
+
+  const feedbackFixReview = selectLatestApplicableCodexReview(pullRequest, codexReviews)
+  if (
+    feedbackFixReview === undefined ||
+    !eligibleReviewStates.has(feedbackFixReview.state) ||
+    feedbackFixReview.submittedAt === null ||
+    !Number.isFinite(Date.parse(feedbackFixReview.submittedAt))
+  ) {
+    return false
+  }
+
+  const reviewSubmittedAtMs = Date.parse(feedbackFixReview.submittedAt)
+  const reviewedThreads = selectReviewThreads(pullRequest, feedbackFixReview)
+  return (
+    reviewedThreads.length > 0 &&
+    reviewedThreads.every(
+      (thread) => selectTrustedFinalHeadReplyTimes(pullRequest, thread, reviewSubmittedAtMs).length === 0,
+    )
+  )
 }
 
 export const evaluateBaynReleaseReview = (input: {
@@ -5502,19 +5549,22 @@ const loadCommitReviewSnapshot = async (
 
   const candidate = candidates[0]
   if (candidate === undefined) throw new Error('source pull selection was unexpectedly empty')
-  const [metadata, reviews, threads, commitShas, issueComments, reactions, finalHeadCommit] = await Promise.all([
+  const [metadata, reviews, threads, commitShas, issueComments, reactions] = await Promise.all([
     fetchPullRequestMetadata(options, candidate.number),
     fetchPullRequestReviews(options, candidate.number),
     fetchPullRequestThreads(options, candidate.number),
     fetchPullRequestCommitShas(options, candidate.number),
     fetchPullRequestIssueComments(options, candidate.number),
     fetchPullRequestReactions(options, candidate.number),
-    fetchCommitDetail(options, candidate.headSha),
   ])
+  const pullRequest = { ...metadata, reviews, threads, commitShas, issueComments, reactions }
+  const finalHeadCommit = shouldFetchFinalHeadCommitDetail(pullRequest)
+    ? await fetchCommitDetail(options, candidate.headSha)
+    : undefined
   return {
     mainCommitParents: commit.parents,
     associatedPullRequests,
-    pullRequest: { ...metadata, reviews, threads, commitShas, finalHeadCommit, issueComments, reactions },
+    pullRequest: { ...pullRequest, finalHeadCommit },
   }
 }
 

--- a/packages/scripts/src/bayn/verify-release-review.ts
+++ b/packages/scripts/src/bayn/verify-release-review.ts
@@ -1525,25 +1525,6 @@ const selectReviewThreads = (
     thread.comments.some((comment) => reviewCommentBelongsTo(comment, reviewEvidence)),
   )
 
-const selectTrustedFinalHeadReplyTimes = (
-  pullRequest: PullRequestReviewState,
-  thread: PullRequestReviewThread,
-  reviewSubmittedAtMs: number,
-): readonly number[] =>
-  thread.comments.flatMap((comment) => {
-    if (
-      comment.authorLogin === null ||
-      comment.authorLogin === baynCodexReviewer ||
-      !trustedFeedbackAssociations.has(comment.authorAssociation) ||
-      comment.reviewCommitSha !== pullRequest.headSha ||
-      comment.reviewSubmittedAt === null
-    ) {
-      return []
-    }
-    const attestationTime = Date.parse(comment.reviewSubmittedAt)
-    return Number.isFinite(attestationTime) && attestationTime >= reviewSubmittedAtMs ? [attestationTime] : []
-  })
-
 const selectFeedbackFixEvidence = (
   pullRequest: PullRequestReviewState,
   reviewEvidence: PullRequestReview,
@@ -1552,12 +1533,10 @@ const selectFeedbackFixEvidence = (
   if (reviewEvidence.commitSha === null || reviewEvidence.submittedAt === null) return undefined
   const reviewedCommitIndex = pullRequest.commitShas.indexOf(reviewEvidence.commitSha)
   const finalCommitIndex = pullRequest.commitShas.length - 1
-  if (reviewedCommitIndex < 0 || reviewedCommitIndex >= finalCommitIndex) return undefined
-  const isDirectFinalChild = reviewedCommitIndex + 1 === finalCommitIndex
+  if (reviewedCommitIndex < 0 || reviewedCommitIndex + 1 !== finalCommitIndex) return undefined
   const reviewedThreads = selectReviewThreads(pullRequest, reviewEvidence)
   if (reviewedThreads.length === 0) return undefined
 
-  const threadAttestationTimes: number[] = []
   const reviewedPaths = new Set<string>()
   for (const thread of reviewedThreads) {
     const reviewedComments = thread.comments.filter((comment) => reviewCommentBelongsTo(comment, reviewEvidence))
@@ -1576,60 +1555,44 @@ const selectFeedbackFixEvidence = (
       return undefined
     }
     reviewedPaths.add(thread.path)
-
-    const trustedReplies = selectTrustedFinalHeadReplyTimes(pullRequest, thread, reviewSubmittedAtMs)
-    const earliestTrustedReplyAtMs = trustedReplies.length === 0 ? undefined : Math.min(...trustedReplies)
-    if (
-      !thread.isResolved ||
-      (!isDirectFinalChild && trustedReplies.length === 0) ||
-      (!thread.isOutdated && trustedReplies.length === 0)
-    ) {
-      return undefined
-    }
-    if (earliestTrustedReplyAtMs !== undefined) threadAttestationTimes.push(earliestTrustedReplyAtMs)
+    if (!thread.isResolved || !thread.isOutdated) return undefined
   }
 
-  if (threadAttestationTimes.length === 0) {
-    const finalHeadCommit = pullRequest.finalHeadCommit
-    const changedFilePaths = finalHeadCommit?.fileChanges.flatMap((change) =>
-      change.previousPath === null ? [change.path] : [change.path, change.previousPath],
-    )
-    const finalFilePaths = finalHeadCommit?.files
-    const finalFilePathSet = finalFilePaths === undefined ? null : new Set(finalFilePaths)
-    const changedFilePathSet = changedFilePaths === undefined ? null : new Set(changedFilePaths)
-    const finalBaynPaths = finalHeadCommit?.fileChanges
-      .filter((change) => isBaynReleaseAffectingPath(change.path))
-      .map((change) => change.path)
-    if (
-      finalHeadCommit === undefined ||
-      finalHeadCommit === null ||
-      finalHeadCommit.sha !== pullRequest.headSha ||
-      finalHeadCommit.parents.length !== 1 ||
-      finalHeadCommit.parents[0] !== reviewEvidence.commitSha ||
-      finalFilePaths === undefined ||
-      changedFilePaths === undefined ||
-      finalFilePaths.length !== changedFilePaths.length ||
-      finalFilePathSet === null ||
-      changedFilePathSet === null ||
-      finalFilePathSet.size !== finalFilePaths.length ||
-      changedFilePathSet.size !== changedFilePaths.length ||
-      finalFilePaths.some((path) => !changedFilePathSet.has(path)) ||
-      changedFilePaths.some((path) => !finalFilePathSet.has(path)) ||
-      finalHeadCommit.fileChanges.some((change) => change.path.length === 0 || change.previousPath !== null) ||
-      finalBaynPaths === undefined ||
-      finalBaynPaths.length === 0 ||
-      new Set(finalBaynPaths).size !== finalBaynPaths.length ||
-      finalBaynPaths.some((path) => !reviewedPaths.has(path))
-    ) {
-      return undefined
-    }
+  const finalHeadCommit = pullRequest.finalHeadCommit
+  const changedFilePaths = finalHeadCommit?.fileChanges.flatMap((change) =>
+    change.previousPath === null ? [change.path] : [change.path, change.previousPath],
+  )
+  const finalFilePaths = finalHeadCommit?.files
+  const finalFilePathSet = finalFilePaths === undefined ? null : new Set(finalFilePaths)
+  const changedFilePathSet = changedFilePaths === undefined ? null : new Set(changedFilePaths)
+  const finalBaynPaths = finalHeadCommit?.fileChanges
+    .filter((change) => isBaynReleaseAffectingPath(change.path))
+    .map((change) => change.path)
+  if (
+    finalHeadCommit === undefined ||
+    finalHeadCommit === null ||
+    finalHeadCommit.sha !== pullRequest.headSha ||
+    finalHeadCommit.parents.length !== 1 ||
+    finalHeadCommit.parents[0] !== reviewEvidence.commitSha ||
+    finalFilePaths === undefined ||
+    changedFilePaths === undefined ||
+    finalFilePaths.length !== changedFilePaths.length ||
+    finalFilePathSet === null ||
+    changedFilePathSet === null ||
+    finalFilePathSet.size !== finalFilePaths.length ||
+    changedFilePathSet.size !== changedFilePaths.length ||
+    finalFilePaths.some((path) => !changedFilePathSet.has(path)) ||
+    changedFilePaths.some((path) => !finalFilePathSet.has(path)) ||
+    finalHeadCommit.fileChanges.some((change) => change.path.length === 0 || change.previousPath !== null) ||
+    finalBaynPaths === undefined ||
+    new Set(finalBaynPaths).size !== finalBaynPaths.length ||
+    finalBaynPaths.some((path) => !reviewedPaths.has(path))
+  ) {
+    return undefined
   }
 
   return {
-    eligibleAtMs:
-      threadAttestationTimes.length === 0
-        ? reviewSubmittedAtMs + minimumExactReviewAgeMs
-        : Math.max(reviewSubmittedAtMs + minimumExactReviewAgeMs, Math.max(...threadAttestationTimes)),
+    eligibleAtMs: reviewSubmittedAtMs + minimumExactReviewAgeMs,
   }
 }
 
@@ -1711,14 +1674,8 @@ const shouldFetchFinalHeadCommitDetail = (pullRequest: PullRequestReviewState): 
     return false
   }
 
-  const reviewSubmittedAtMs = Date.parse(feedbackFixReview.submittedAt)
-  const reviewedThreads = selectReviewThreads(pullRequest, feedbackFixReview)
-  return (
-    reviewedThreads.length > 0 &&
-    reviewedThreads.every(
-      (thread) => selectTrustedFinalHeadReplyTimes(pullRequest, thread, reviewSubmittedAtMs).length === 0,
-    )
-  )
+  const reviewedCommitIndex = pullRequest.commitShas.indexOf(feedbackFixReview.commitSha as string)
+  return reviewedCommitIndex + 1 === pullRequest.commitShas.length - 1
 }
 
 export const evaluateBaynReleaseReview = (input: {

--- a/packages/scripts/src/bayn/verify-release-review.ts
+++ b/packages/scripts/src/bayn/verify-release-review.ts
@@ -1481,6 +1481,99 @@ const hasOnlySupersededCodexReviews = (
   })
 }
 
+const selectLatestApplicableCodexReview = (
+  pullRequest: PullRequestReviewState,
+  codexReviews: readonly PullRequestReview[],
+): PullRequestReview | undefined => {
+  const candidates = codexReviews
+    .filter(
+      (review) =>
+        review.commitSha !== null &&
+        review.commitSha !== pullRequest.headSha &&
+        review.submittedAt !== null &&
+        pullRequest.commitShas.includes(review.commitSha),
+    )
+    .map((review) => ({ review, submittedAtMs: Date.parse(review.submittedAt as string) }))
+  if (candidates.some(({ submittedAtMs }) => !Number.isFinite(submittedAtMs))) return undefined
+
+  const latestSubmittedAtMs = Math.max(
+    ...candidates.map(({ submittedAtMs }) => submittedAtMs),
+    Number.NEGATIVE_INFINITY,
+  )
+  const latest = candidates.filter(({ submittedAtMs }) => submittedAtMs === latestSubmittedAtMs)
+  return latest.length === 1 ? latest[0]?.review : undefined
+}
+
+const selectFeedbackFixEvidence = (
+  pullRequest: PullRequestReviewState,
+  reviewEvidence: PullRequestReview,
+  reviewSubmittedAtMs: number,
+): { readonly eligibleAtMs: number } | undefined => {
+  if (reviewEvidence.commitSha === null || reviewEvidence.submittedAt === null) return undefined
+  const reviewedCommitIndex = pullRequest.commitShas.indexOf(reviewEvidence.commitSha)
+  const finalCommitIndex = pullRequest.commitShas.length - 1
+  if (reviewedCommitIndex < 0 || reviewedCommitIndex >= finalCommitIndex) return undefined
+
+  const reviewedThreads = pullRequest.threads.filter((thread) =>
+    thread.comments.some(
+      (comment) =>
+        comment.reviewAuthorLogin === baynCodexReviewer && comment.reviewCommitSha === reviewEvidence.commitSha,
+    ),
+  )
+  if (reviewedThreads.length === 0) return undefined
+
+  const trustedAttestationTimes: number[] = []
+  for (const thread of reviewedThreads) {
+    const reviewedComments = thread.comments.filter(
+      (comment) =>
+        comment.reviewAuthorLogin === baynCodexReviewer && comment.reviewCommitSha === reviewEvidence.commitSha,
+    )
+    if (
+      thread.path === null ||
+      thread.path.length === 0 ||
+      reviewedComments.length === 0 ||
+      reviewedComments.some(
+        (comment) =>
+          comment.reviewSubmittedAt !== reviewEvidence.submittedAt ||
+          comment.reviewState !== reviewEvidence.state ||
+          comment.commitSha === null,
+      )
+    ) {
+      return undefined
+    }
+
+    const changedReviewedPath = reviewedComments.some((comment) => comment.commitSha === pullRequest.headSha)
+    const trustedReplies = thread.comments.flatMap((comment) => {
+      if (
+        comment.authorLogin === null ||
+        comment.authorLogin === baynCodexReviewer ||
+        !trustedFeedbackAssociations.has(comment.authorAssociation) ||
+        comment.reviewCommitSha !== pullRequest.headSha ||
+        comment.reviewSubmittedAt === null
+      ) {
+        return []
+      }
+      const attestationTime = Date.parse(comment.reviewSubmittedAt)
+      return Number.isFinite(attestationTime) && attestationTime >= reviewSubmittedAtMs ? [attestationTime] : []
+    })
+    if (
+      !thread.isResolved ||
+      (!changedReviewedPath && trustedReplies.length === 0) ||
+      (!thread.isOutdated && trustedReplies.length === 0)
+    ) {
+      return undefined
+    }
+    trustedAttestationTimes.push(...trustedReplies)
+  }
+
+  return {
+    eligibleAtMs:
+      trustedAttestationTimes.length === 0
+        ? reviewSubmittedAtMs + minimumExactReviewAgeMs
+        : Math.max(reviewSubmittedAtMs + minimumExactReviewAgeMs, Math.min(...trustedAttestationTimes)),
+  }
+}
+
 const selectExactHeadCodexAttestation = (
   pullRequest: PullRequestReviewState,
   createdAtMs: number,
@@ -1634,7 +1727,7 @@ export const evaluateBaynReleaseReview = (input: {
 
   let reviewEvidence =
     exactSubmittedReview ?? selectExactHeadCodexAttestation(pullRequest, pullRequestCreatedAtMs, pullRequestMergedAtMs)
-  let feedbackFixCommitShas: readonly string[] = []
+  let feedbackFixReview: PullRequestReview | null = null
   if (reviewEvidence === undefined) {
     if (!hasUniqueFinalCommitHistory(pullRequest)) {
       return hold(
@@ -1644,16 +1737,7 @@ export const evaluateBaynReleaseReview = (input: {
       )
     }
 
-    const priorSubmittedReviews = codexReviews
-      .filter(
-        (review) =>
-          review.commitSha !== null &&
-          review.commitSha !== pullRequest.headSha &&
-          review.submittedAt !== null &&
-          pullRequest.commitShas.includes(review.commitSha),
-      )
-      .toSorted((left, right) => (right.submittedAt as string).localeCompare(left.submittedAt as string))
-    reviewEvidence = priorSubmittedReviews[0]
+    reviewEvidence = selectLatestApplicableCodexReview(pullRequest, codexReviews)
     if (reviewEvidence === undefined) {
       const olderReviewedHeads = [
         ...new Set(
@@ -1681,7 +1765,7 @@ export const evaluateBaynReleaseReview = (input: {
         false,
       )
     }
-    feedbackFixCommitShas = pullRequest.commitShas.slice(reviewedCommitIndex + 1)
+    feedbackFixReview = reviewEvidence
   }
 
   if (reviewEvidence.state === 'CHANGES_REQUESTED') {
@@ -1717,41 +1801,16 @@ export const evaluateBaynReleaseReview = (input: {
   }
   let eligibleAtMs = reviewSubmittedAtMs + minimumExactReviewAgeMs
 
-  if (feedbackFixCommitShas.length > 0) {
-    const reviewedHeadSha = reviewEvidence.commitSha as string
-    for (const fixCommitSha of feedbackFixCommitShas) {
-      const trustedAttestationTimes = pullRequest.threads.flatMap((thread) => {
-        if (!thread.isResolved) return []
-        const belongsToReviewedHead = thread.comments.some(
-          (comment) =>
-            comment.reviewAuthorLogin === baynCodexReviewer &&
-            comment.reviewCommitSha === reviewedHeadSha &&
-            comment.reviewSubmittedAt === reviewEvidence.submittedAt,
-        )
-        if (!belongsToReviewedHead) return []
-        return thread.comments.flatMap((comment) => {
-          if (
-            comment.authorLogin === null ||
-            comment.authorLogin === baynCodexReviewer ||
-            !trustedFeedbackAssociations.has(comment.authorAssociation) ||
-            comment.reviewCommitSha !== fixCommitSha ||
-            comment.reviewSubmittedAt === null
-          ) {
-            return []
-          }
-          const attestationTime = Date.parse(comment.reviewSubmittedAt)
-          return Number.isFinite(attestationTime) && attestationTime >= reviewSubmittedAtMs ? [attestationTime] : []
-        })
-      })
-      if (trustedAttestationTimes.length === 0) {
-        return hold(
-          'feedback-fix-attestation-missing',
-          `source PR #${pullRequest.number} final head ${shortSha(pullRequest.headSha)} carries review from ${shortSha(reviewedHeadSha)}, but post-review commit ${shortSha(fixCommitSha)} lacks a trusted member reply on a resolved Codex thread from that review`,
-          true,
-        )
-      }
-      eligibleAtMs = Math.max(eligibleAtMs, Math.min(...trustedAttestationTimes))
+  if (feedbackFixReview !== null) {
+    const feedbackFixEvidence = selectFeedbackFixEvidence(pullRequest, feedbackFixReview, reviewSubmittedAtMs)
+    if (feedbackFixEvidence === undefined) {
+      return hold(
+        'feedback-fix-attestation-missing',
+        `source PR #${pullRequest.number} final head ${shortSha(pullRequest.headSha)} carries review from ${shortSha(feedbackFixReview.commitSha as string)}, but post-review feedback threads are not a resolved, final-head-safe causal fix from that review`,
+        true,
+      )
     }
+    eligibleAtMs = Math.max(eligibleAtMs, feedbackFixEvidence.eligibleAtMs)
   }
 
   const unresolvedThreads = pullRequest.threads.filter((thread) => !thread.isResolved)
@@ -4680,7 +4739,7 @@ const parseBaynBuildWorkflowJobs = (value: unknown): readonly BaynBuildWorkflowJ
 export const parseFailedReviewThreadBlock = (log: string): FailedReviewThreadBlock | null => {
   const patterns = [
     /BAYN_RELEASE_REVIEW_HOLD active-unresolved-review-threads: Bayn-affecting commit ([0-9a-f]{12}) .*? source PR #(\d+) has \d+ unresolved review thread\(s\):/g,
-    /BAYN_RELEASE_REVIEW_HOLD feedback-fix-attestation-missing: Bayn-affecting commit ([0-9a-f]{12}) .*? source PR #(\d+) final head [0-9a-f]{12} carries review from [0-9a-f]{12}, but post-review commit [0-9a-f]{12} lacks a trusted member reply on a resolved Codex thread from that review/g,
+    /BAYN_RELEASE_REVIEW_HOLD feedback-fix-attestation-missing: Bayn-affecting commit ([0-9a-f]{12}) .*? source PR #(\d+) final head [0-9a-f]{12} carries review from [0-9a-f]{12}, but post-review feedback threads are not a resolved, final-head-safe causal fix from that review/g,
   ]
   const matches = patterns.flatMap((pattern) =>
     [...log.matchAll(pattern)].map((match) => ({

--- a/packages/scripts/src/bayn/verify-release-review.ts
+++ b/packages/scripts/src/bayn/verify-release-review.ts
@@ -1529,7 +1529,7 @@ const selectFeedbackFixEvidence = (
   const reviewedThreads = pullRequest.threads.filter((thread) => thread.comments.some(belongsToReview))
   if (reviewedThreads.length === 0) return undefined
 
-  const trustedAttestationTimes: number[] = []
+  const threadAttestationTimes: number[] = []
   const reviewedPaths = new Set<string>()
   for (const thread of reviewedThreads) {
     const reviewedComments = thread.comments.filter(belongsToReview)
@@ -1562,6 +1562,7 @@ const selectFeedbackFixEvidence = (
       const attestationTime = Date.parse(comment.reviewSubmittedAt)
       return Number.isFinite(attestationTime) && attestationTime >= reviewSubmittedAtMs ? [attestationTime] : []
     })
+    const earliestTrustedReplyAtMs = trustedReplies.length === 0 ? undefined : Math.min(...trustedReplies)
     if (
       !thread.isResolved ||
       (!isDirectFinalChild && trustedReplies.length === 0) ||
@@ -1569,10 +1570,10 @@ const selectFeedbackFixEvidence = (
     ) {
       return undefined
     }
-    trustedAttestationTimes.push(...trustedReplies)
+    if (earliestTrustedReplyAtMs !== undefined) threadAttestationTimes.push(earliestTrustedReplyAtMs)
   }
 
-  if (trustedAttestationTimes.length === 0) {
+  if (threadAttestationTimes.length === 0) {
     const finalHeadCommit = pullRequest.finalHeadCommit
     const changedFilePaths = finalHeadCommit?.fileChanges.flatMap((change) =>
       change.previousPath === null ? [change.path] : [change.path, change.previousPath],
@@ -1610,9 +1611,9 @@ const selectFeedbackFixEvidence = (
 
   return {
     eligibleAtMs:
-      trustedAttestationTimes.length === 0
+      threadAttestationTimes.length === 0
         ? reviewSubmittedAtMs + minimumExactReviewAgeMs
-        : Math.max(reviewSubmittedAtMs + minimumExactReviewAgeMs, Math.min(...trustedAttestationTimes)),
+        : Math.max(reviewSubmittedAtMs + minimumExactReviewAgeMs, Math.max(...threadAttestationTimes)),
   }
 }
 


### PR DESCRIPTION
## Summary

- Keep exact-head formal review, exact Codex comment, and causal exact-head reaction paths independent of final-commit detail, so valid large/paginated final commits do not block them.
- Make the no-exact-head feedback-fix fallback fail closed unless the reviewed head is the direct parent of the final head.
- Always fetch and validate authoritative final-head commit detail in that fallback: exact SHA, one reviewed parent, complete non-rename file set, and every nonempty release-affecting Bayn path covered by a reviewed feedback path.
- Require every selected feedback thread to be resolved and outdated; an empty release-affecting Bayn path set remains valid for a reviewed non-release/test-only fix.
- Remove the trusted-member-reply bypass for multi-commit or incomplete fallback histories.
- Add real #13475 evidence plus hostile controls for all-replied and mixed-reply unrelated paths, multi-commit histories, missing/malformed/paginated detail, and valid empty-Bayn direct-child evidence.

## Related Issues

None.

## Testing

- `bun test packages/scripts/src/bayn/verify-release-review.test.ts` — 212 pass.
- `bunx oxfmt --check packages/scripts/src/bayn/verify-release-review.ts packages/scripts/src/bayn/verify-release-review.test.ts && git diff --check` — pass.
- `bun run --cwd packages/scripts lint` and `bun run --cwd packages/scripts lint:oxlint:type` — pass with pre-existing warnings only.
- `bunx tsc --noEmit --project packages/scripts/tsconfig.atlas.json` — pass.
- Commit hook — Oxlint, Oxfmt, and commitlint pass.

## Screenshots (if applicable)

Not applicable.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.