### PR TITLE
fix(bayn): retain runtime resources through application lifecycle

### DIFF
--- a/services/bayn/src/app.test.ts
+++ b/services/bayn/src/app.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 
-import { Clock, Deferred, Effect, Fiber, Layer, Option, pipe, Redacted, Ref, Result } from 'effect'
+import { Clock, Context, Deferred, Effect, Fiber, Layer, Option, pipe, Redacted, Ref, Result, Scope } from 'effect'
 
 import {
   config,
@@ -431,6 +431,110 @@ describe('Bayn application composition', () => {
     )
 
     expect(events).toEqual(['resolved', 'cycle'])
+  })
+
+  test('keeps resolver-owned runtime resources open through cycle and health until application interruption', async () => {
+    const events: string[] = []
+    let finalizations = 0
+
+    await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const cycleUsed = yield* Deferred.make<void>()
+          const healthUsed = yield* Deferred.make<void>()
+          type RuntimeResource = {
+            readonly close: () => void
+            readonly use: (consumer: 'cycle' | 'health') => Effect.Effect<void>
+          }
+          const RuntimeResource = Context.Service<RuntimeResource>('BaynApplicationTest/RuntimeResource')
+          const runtimeResourceLayer = Layer.effect(
+            RuntimeResource,
+            Effect.acquireRelease(
+              Effect.sync(() => {
+                let open = true
+                const resource: RuntimeResource = {
+                  close: () => void (open = false),
+                  use: (consumer) =>
+                    Effect.sync(() => {
+                      if (!open) throw new Error(`runtime resource was finalized before ${consumer} use`)
+                      events.push(consumer)
+                    }).pipe(
+                      Effect.andThen(
+                        consumer === 'cycle'
+                          ? Deferred.succeed(cycleUsed, undefined)
+                          : Deferred.succeed(healthUsed, undefined),
+                      ),
+                    ),
+                }
+                return resource
+              }),
+              (resource) =>
+                Effect.sync(() => {
+                  resource.close()
+                  finalizations += 1
+                }),
+            ),
+          )
+          const fiber = yield* runApplication<never, never>(
+            autonomousConfig(config),
+            fixtureStrategy,
+            {
+              marketData: marketDataService(Effect.succeed(makeSnapshot())),
+              journal: successfulJournal,
+              evidenceStore: successfulEvidenceStore,
+              cycleObservability,
+            },
+            {
+              _tag: 'AutonomousRead',
+              brokerConfiguration: {
+                expectedAccountId: brokerAccountId,
+                executionEligible: false,
+                executionDisabledReason: 'BROKER_ACCESS_READ_ONLY',
+              },
+              startCycle: () => Effect.succeed(Effect.never),
+              resolveAfterStartup: () =>
+                Effect.flatMap(Scope.Scope, (scope) =>
+                  Layer.buildWithMemoMap(Layer.fresh(runtimeResourceLayer), Layer.makeMemoMapUnsafe(), scope).pipe(
+                    Effect.map((context) => {
+                      const resource = Context.get(context, RuntimeResource)
+                      const runtimeBroker = {
+                        ...broker,
+                        read: {
+                          ...broker.read,
+                          account: resource.use('health').pipe(Effect.andThen(broker.read.account)),
+                        },
+                      }
+                      return {
+                        _tag: 'AutonomousRead' as const,
+                        broker: runtimeBroker,
+                        startCycle: ({ recordPass }: AutonomousCycleStartupInput) =>
+                          resource.use('cycle').pipe(
+                            Effect.andThen(Clock.currentTimeMillis),
+                            Effect.map((millis) => new Date(millis).toISOString()),
+                            Effect.flatMap((observedAt) =>
+                              recordPass({ result: 'SUCCESS', observedAt, outcome: 'NO_PUBLICATION' }),
+                            ),
+                            Effect.as(Effect.never),
+                          ),
+                      }
+                    }),
+                  ),
+                ),
+            },
+          ).pipe(Effect.provide(HttpServerLive(config)), Effect.forkScoped)
+
+          yield* Deferred.await(cycleUsed).pipe(Effect.timeout('1 second'))
+          expect(finalizations).toBe(0)
+          yield* Deferred.await(healthUsed).pipe(Effect.timeout('1 second'))
+          expect(finalizations).toBe(0)
+          yield* Fiber.interrupt(fiber)
+        }),
+      ),
+    )
+
+    expect(events).toContain('cycle')
+    expect(events).toContain('health')
+    expect(finalizations).toBe(1)
   })
 
   test('starts the same scoped autonomous cycle for mutation runtime readiness', async () => {

--- a/services/bayn/src/app.test.ts
+++ b/services/bayn/src/app.test.ts
@@ -47,6 +47,7 @@ import { HttpServerLive } from './http'
 import { loadObserveRiskPolicy } from './observe-composition'
 import { makeStrategy } from './strategy'
 import { fixtureProtocol, makeSnapshot, makeTestProvenance } from './test-fixtures'
+import { scopedAcquisition } from './resource-boundary'
 
 const cycleObservability = {
   read: () =>
@@ -494,30 +495,38 @@ describe('Bayn application composition', () => {
               startCycle: () => Effect.succeed(Effect.never),
               resolveAfterStartup: () =>
                 Effect.flatMap(Scope.Scope, (scope) =>
-                  Layer.buildWithMemoMap(Layer.fresh(runtimeResourceLayer), Layer.makeMemoMapUnsafe(), scope).pipe(
-                    Effect.map((context) => {
-                      const resource = Context.get(context, RuntimeResource)
-                      const runtimeBroker = {
-                        ...broker,
-                        read: {
-                          ...broker.read,
-                          account: resource.use('health').pipe(Effect.andThen(broker.read.account)),
-                        },
-                      }
-                      return {
-                        _tag: 'AutonomousRead' as const,
-                        broker: runtimeBroker,
-                        startCycle: ({ recordPass }: AutonomousCycleStartupInput) =>
-                          resource.use('cycle').pipe(
-                            Effect.andThen(Clock.currentTimeMillis),
-                            Effect.map((millis) => new Date(millis).toISOString()),
-                            Effect.flatMap((observedAt) =>
-                              recordPass({ result: 'SUCCESS', observedAt, outcome: 'NO_PUBLICATION' }),
-                            ),
-                            Effect.as(Effect.never),
-                          ),
-                      }
-                    }),
+                  scopedAcquisition(
+                    (attemptScope) =>
+                      Layer.buildWithMemoMap(
+                        Layer.fresh(runtimeResourceLayer),
+                        Layer.makeMemoMapUnsafe(),
+                        attemptScope,
+                      ).pipe(
+                        Effect.map((context) => {
+                          const resource = Context.get(context, RuntimeResource)
+                          const runtimeBroker = {
+                            ...broker,
+                            read: {
+                              ...broker.read,
+                              account: resource.use('health').pipe(Effect.andThen(broker.read.account)),
+                            },
+                          }
+                          return {
+                            _tag: 'AutonomousRead' as const,
+                            broker: runtimeBroker,
+                            startCycle: ({ recordPass }: AutonomousCycleStartupInput) =>
+                              resource.use('cycle').pipe(
+                                Effect.andThen(Clock.currentTimeMillis),
+                                Effect.map((millis) => new Date(millis).toISOString()),
+                                Effect.flatMap((observedAt) =>
+                                  recordPass({ result: 'SUCCESS', observedAt, outcome: 'NO_PUBLICATION' }),
+                                ),
+                                Effect.as(Effect.never),
+                              ),
+                          }
+                        }),
+                      ),
+                    scope,
                   ),
                 ),
             },
@@ -534,6 +543,36 @@ describe('Bayn application composition', () => {
 
     expect(events).toContain('cycle')
     expect(events).toContain('health')
+    expect(finalizations).toBe(1)
+  })
+
+  test('closes partial runtime acquisition before pending recovery', async () => {
+    const acquisitionFailure = new Error('runtime resource acquisition failed')
+    let finalizations = 0
+
+    await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const parentScope = yield* Scope.Scope
+          const partialLayer = Layer.effectDiscard(
+            Effect.acquireRelease(Effect.succeed(undefined), () => Effect.sync(() => void (finalizations += 1))).pipe(
+              Effect.andThen(Effect.fail(acquisitionFailure)),
+            ),
+          )
+          const failure = yield* Effect.flip(
+            scopedAcquisition(
+              (attemptScope) =>
+                Layer.buildWithMemoMap(Layer.fresh(partialLayer), Layer.makeMemoMapUnsafe(), attemptScope),
+              parentScope,
+            ),
+          )
+
+          expect(failure).toBe(acquisitionFailure)
+          expect(finalizations).toBe(1)
+        }),
+      ),
+    )
+
     expect(finalizations).toBe(1)
   })
 

--- a/services/bayn/src/app.ts
+++ b/services/bayn/src/app.ts
@@ -111,7 +111,7 @@ export type AutonomousRuntime<StartupR, LoopR> = Extract<
 
 export type AutonomousRuntimeResolver<StartupR, LoopR> = (
   state: Ref.Ref<RuntimeState>,
-) => Effect.Effect<AutonomousRuntime<StartupR, LoopR>, never, StartupR | LoopR>
+) => Effect.Effect<AutonomousRuntime<StartupR, LoopR>, never, StartupR | LoopR | Scope.Scope>
 
 const cyclePassError = (observation: Extract<AutonomousCyclePassObservation, { readonly result: 'FAILURE' }>): string =>
   `cycleRunner: ${observation.operation}/${observation.failure}: ${observation.message}`
@@ -164,7 +164,11 @@ const initialRuntimeState = <StartupR, LoopR>(runtime: ApplicationRuntime<Startu
 const resolveRuntimeAfterStartup = <StartupR, LoopR>(
   runtime: ApplicationRuntime<StartupR, LoopR>,
   state: Ref.Ref<RuntimeState>,
-): Effect.Effect<AutonomousRuntime<StartupR, LoopR> | ApplicationRuntime<StartupR, LoopR>, never, StartupR | LoopR> =>
+): Effect.Effect<
+  AutonomousRuntime<StartupR, LoopR> | ApplicationRuntime<StartupR, LoopR>,
+  never,
+  StartupR | LoopR | Scope.Scope
+> =>
   runtime._tag === 'AutonomousRead' && runtime.resolveAfterStartup !== undefined
     ? runtime.resolveAfterStartup(state)
     : Effect.succeed(runtime)

--- a/services/bayn/src/composition.ts
+++ b/services/bayn/src/composition.ts
@@ -1,6 +1,6 @@
 import { NodeHttpClient, NodeServices } from '@effect/platform-node'
 import { ClickhouseClient } from '@effect/sql-clickhouse'
-import { Effect, Layer, Match, Option, pipe, Redacted, Ref, Result, Schema, Stdio, Stream } from 'effect'
+import { Effect, Layer, Match, Option, pipe, Redacted, Ref, Result, Schema, Scope, Stdio, Stream } from 'effect'
 
 import {
   makeApplicationPlan,
@@ -565,10 +565,10 @@ const runAutonomousService = (plan: ApplicationPlanFor<'AutonomousService'>) =>
         return Result.succeed({ request, evidence: current.evidence })
       })
       return validateStaticRequest.pipe(
-        Effect.flatMap((validated): Effect.Effect<AutonomousRuntime<never, never>, never> => {
+        Effect.flatMap((validated): Effect.Effect<AutonomousRuntime<never, never>, never, Scope.Scope> => {
           if (Result.isFailure(validated)) return Effect.succeed(pendingRuntime())
           const request = validated.success.request
-          return Effect.scopedWith((scope) =>
+          return Effect.flatMap(Scope.Scope, (scope) =>
             Layer.buildWithMemoMap(
               Layer.fresh(AutonomousRuntimeResourcesLive(observePlan)),
               Layer.makeMemoMapUnsafe(),

--- a/services/bayn/src/composition.ts
+++ b/services/bayn/src/composition.ts
@@ -76,6 +76,7 @@ import {
 } from './execution-prepare'
 import { currentUtcInstant } from './time'
 import type { RuntimeEvidence, RuntimeState } from './runtime-state'
+import { scopedAcquisition } from './resource-boundary'
 
 export const ClickHouseClientResourceLive = (config: LoadedRuntimeConfig) =>
   ClickhouseClient.layer({
@@ -569,168 +570,177 @@ const runAutonomousService = (plan: ApplicationPlanFor<'AutonomousService'>) =>
           if (Result.isFailure(validated)) return Effect.succeed(pendingRuntime())
           const request = validated.success.request
           return Effect.flatMap(Scope.Scope, (scope) =>
-            Layer.buildWithMemoMap(
-              Layer.fresh(AutonomousRuntimeResourcesLive(observePlan)),
-              Layer.makeMemoMapUnsafe(),
-              scope,
-            ).pipe(
-              Effect.flatMap((runtimeContext) =>
-                Effect.all({
-                  session: BrokerSession,
-                  alpacaHttpClient: AlpacaHttpClient,
-                  liveCapitalGrants: LiveCapitalGrantStore,
-                  intentStore: IntentStore,
-                  mutationStore: MutationStore,
-                  writerFence: WriterFence,
-                  cycleStore: CycleStore,
-                  brokerEventStore: BrokerEventStore,
-                  fillAccountingStore: FillAccountingStore,
-                  valuationStore: ValuationStore,
-                  reconciliationStore: ReconciliationStore,
-                  authorityGenerationStore: AuthorityGenerationStore,
-                  authorityRestrictionStore: AuthorityRestrictionStore,
-                }).pipe(
-                  Effect.flatMap((runtimeServices) => {
-                    const cycleResources = Layer.mergeAll(
-                      Layer.succeed(BrokerRead, runtimeServices.session.read),
-                      Layer.succeed(MarketData, dependencies.marketData),
-                      Layer.succeed(CycleStore, runtimeServices.cycleStore),
-                      Layer.succeed(BrokerEventStore, runtimeServices.brokerEventStore),
-                      Layer.succeed(FillAccountingStore, runtimeServices.fillAccountingStore),
-                      Layer.succeed(ValuationStore, runtimeServices.valuationStore),
-                      Layer.succeed(ReconciliationStore, runtimeServices.reconciliationStore),
-                      Layer.succeed(AuthorityGenerationStore, runtimeServices.authorityGenerationStore),
-                      Layer.succeed(AuthorityRestrictionStore, runtimeServices.authorityRestrictionStore),
-                      Layer.succeed(WriterFence, runtimeServices.writerFence),
-                      Layer.succeed(IntentStore, runtimeServices.intentStore),
-                      Layer.succeed(MutationStore, runtimeServices.mutationStore),
-                    )
-                    const readStartCycle = (startup: AutonomousCycleStartupInput) =>
-                      observeCycle(observePlan)(startup).pipe(
-                        Effect.provide(cycleResources),
-                        Effect.map((loop) => loop.pipe(Effect.provide(cycleResources))),
-                      )
-                    const readRuntime = () => ({
-                      _tag: 'AutonomousRead' as const,
-                      broker: runtimeBroker(observePlan, runtimeServices.session.read, false),
-                      startCycle: readStartCycle,
-                    })
-                    if (request === null) return Effect.succeed(readRuntime())
-                    const evidence = validated.success.evidence
-                    if (evidence === null) {
-                      return pendingPaperActivation(state, request, 'STARTUP_EVIDENCE_UNAVAILABLE').pipe(
-                        Effect.as(readRuntime()),
-                      )
-                    }
-                    return preparePaperActivation(observePlan, evidence, request).pipe(
-                      Effect.flatMap((prepared) => {
-                        if (observePlan.config.alpaca.identity.environment !== BrokerEnvironment.Sandbox) {
-                          return Effect.fail(
-                            paperActivationOperationalError('paper activation requires a sandbox broker'),
+            scopedAcquisition(
+              (attemptScope) =>
+                Layer.buildWithMemoMap(
+                  Layer.fresh(AutonomousRuntimeResourcesLive(observePlan)),
+                  Layer.makeMemoMapUnsafe(),
+                  attemptScope,
+                ).pipe(
+                  Effect.flatMap((runtimeContext) =>
+                    Effect.all({
+                      session: BrokerSession,
+                      alpacaHttpClient: AlpacaHttpClient,
+                      liveCapitalGrants: LiveCapitalGrantStore,
+                      intentStore: IntentStore,
+                      mutationStore: MutationStore,
+                      writerFence: WriterFence,
+                      cycleStore: CycleStore,
+                      brokerEventStore: BrokerEventStore,
+                      fillAccountingStore: FillAccountingStore,
+                      valuationStore: ValuationStore,
+                      reconciliationStore: ReconciliationStore,
+                      authorityGenerationStore: AuthorityGenerationStore,
+                      authorityRestrictionStore: AuthorityRestrictionStore,
+                    }).pipe(
+                      Effect.flatMap((runtimeServices) => {
+                        const cycleResources = Layer.mergeAll(
+                          Layer.succeed(BrokerRead, runtimeServices.session.read),
+                          Layer.succeed(MarketData, dependencies.marketData),
+                          Layer.succeed(CycleStore, runtimeServices.cycleStore),
+                          Layer.succeed(BrokerEventStore, runtimeServices.brokerEventStore),
+                          Layer.succeed(FillAccountingStore, runtimeServices.fillAccountingStore),
+                          Layer.succeed(ValuationStore, runtimeServices.valuationStore),
+                          Layer.succeed(ReconciliationStore, runtimeServices.reconciliationStore),
+                          Layer.succeed(AuthorityGenerationStore, runtimeServices.authorityGenerationStore),
+                          Layer.succeed(AuthorityRestrictionStore, runtimeServices.authorityRestrictionStore),
+                          Layer.succeed(WriterFence, runtimeServices.writerFence),
+                          Layer.succeed(IntentStore, runtimeServices.intentStore),
+                          Layer.succeed(MutationStore, runtimeServices.mutationStore),
+                        )
+                        const readStartCycle = (startup: AutonomousCycleStartupInput) =>
+                          observeCycle(observePlan)(startup).pipe(
+                            Effect.provide(cycleResources),
+                            Effect.map((loop) => loop.pipe(Effect.provide(cycleResources))),
+                          )
+                        const readRuntime = () => ({
+                          _tag: 'AutonomousRead' as const,
+                          broker: runtimeBroker(observePlan, runtimeServices.session.read, false),
+                          startCycle: readStartCycle,
+                        })
+                        if (request === null) return Effect.succeed(readRuntime())
+                        const evidence = validated.success.evidence
+                        if (evidence === null) {
+                          return pendingPaperActivation(state, request, 'STARTUP_EVIDENCE_UNAVAILABLE').pipe(
+                            Effect.as(readRuntime()),
                           )
                         }
-                        return currentUtcInstant.pipe(
-                          Effect.flatMap((observedAt) =>
-                            resolvePreparedSandboxAuthority({
-                              brokerIdentity: observePlan.config.alpaca.identity as Extract<
-                                typeof observePlan.config.alpaca.identity,
-                                { readonly environment: BrokerEnvironment.Sandbox }
-                              >,
-                              strategy: observePlan.strategy.provenance.strategy,
-                              generationHash: prepared.generation.generationHash,
-                              observedAt,
-                            }),
-                          ),
-                          Effect.mapError((cause) =>
-                            paperActivationOperationalError('prepared sandbox execution authority is invalid', cause),
-                          ),
-                          Effect.flatMap((authority) => {
-                            const realizedPolicy = resolveExecutionPolicy({
-                              brokerIdentity: observePlan.config.alpaca.identity,
-                              brokerAccess: BrokerAccess.Mutation,
-                              capitalAuthority: CapitalAuthoritySelection.Sandbox,
-                              authorityGenerationHash: prepared.generation.generationHash,
-                              liveCapitalGrantHash: undefined,
-                            })
-                            if (Result.isFailure(realizedPolicy)) {
+                        return preparePaperActivation(observePlan, evidence, request).pipe(
+                          Effect.flatMap((prepared) => {
+                            if (observePlan.config.alpaca.identity.environment !== BrokerEnvironment.Sandbox) {
                               return Effect.fail(
-                                paperActivationOperationalError(
-                                  'prepared sandbox execution policy is invalid',
-                                  realizedPolicy.failure,
-                                ),
+                                paperActivationOperationalError('paper activation requires a sandbox broker'),
                               )
                             }
-                            const realizedConfig = {
-                              ...observePlan.config,
-                              execution: realizedPolicy.success,
-                            } as Extract<LoadedRuntimeConfig, { readonly runtimeMode: 'AutonomousService' }>
-                            const realizedPlan = makeApplicationPlan({
-                              config: realizedConfig,
-                              protocol: observePlan.protocol,
-                              parameterHash: observePlan.parameterHash,
-                              strategy: observePlan.strategy,
-                              strategyProtocolHash: observePlan.strategyProtocolHash,
-                            }) as ApplicationPlanFor<'AutonomousService'>
-                            return makeMutation(
-                              runtimeServices.session,
-                              authority,
-                              runtimeServices.alpacaHttpClient,
-                            ).pipe(
-                              Effect.flatMap((brokerMutation) =>
-                                Effect.fromResult(
-                                  makeExecutionProgram(authority, {
-                                    brokerRead: runtimeServices.session.read,
-                                    liveCapitalGrants: runtimeServices.liveCapitalGrants,
-                                    freshBrokerPrice: makeFreshBrokerPriceReader(
-                                      runtimeServices.session.connection,
-                                      runtimeServices.alpacaHttpClient,
-                                    ),
-                                    currentUtcInstant,
-                                    intentStore: runtimeServices.intentStore,
-                                    mutationStore: runtimeServices.mutationStore,
-                                    writerFence: runtimeServices.writerFence,
-                                    brokerMutation,
-                                  }),
+                            return currentUtcInstant.pipe(
+                              Effect.flatMap((observedAt) =>
+                                resolvePreparedSandboxAuthority({
+                                  brokerIdentity: observePlan.config.alpaca.identity as Extract<
+                                    typeof observePlan.config.alpaca.identity,
+                                    { readonly environment: BrokerEnvironment.Sandbox }
+                                  >,
+                                  strategy: observePlan.strategy.provenance.strategy,
+                                  generationHash: prepared.generation.generationHash,
+                                  observedAt,
+                                }),
+                              ),
+                              Effect.mapError((cause) =>
+                                paperActivationOperationalError(
+                                  'prepared sandbox execution authority is invalid',
+                                  cause,
                                 ),
                               ),
-                              Effect.mapError(executionProgramError),
-                              Effect.tap(() =>
-                                realizedPaperActivation(state, request, prepared.generation.generationHash),
-                              ),
-                              Effect.map((executionProgram) => ({
-                                _tag: 'AutonomousMutation' as const,
-                                broker: runtimeBroker(realizedPlan, runtimeServices.session.read, true),
-                                executionProgram,
-                                startCycle: (startup: AutonomousCycleStartupInput) =>
-                                  mutationCycle(
-                                    realizedPlan,
-                                    executionProgram,
-                                  )(startup).pipe(
-                                    Effect.provide(cycleResources),
-                                    Effect.map((loop) => loop.pipe(Effect.provide(cycleResources))),
+                              Effect.flatMap((authority) => {
+                                const realizedPolicy = resolveExecutionPolicy({
+                                  brokerIdentity: observePlan.config.alpaca.identity,
+                                  brokerAccess: BrokerAccess.Mutation,
+                                  capitalAuthority: CapitalAuthoritySelection.Sandbox,
+                                  authorityGenerationHash: prepared.generation.generationHash,
+                                  liveCapitalGrantHash: undefined,
+                                })
+                                if (Result.isFailure(realizedPolicy)) {
+                                  return Effect.fail(
+                                    paperActivationOperationalError(
+                                      'prepared sandbox execution policy is invalid',
+                                      realizedPolicy.failure,
+                                    ),
+                                  )
+                                }
+                                const realizedConfig = {
+                                  ...observePlan.config,
+                                  execution: realizedPolicy.success,
+                                } as Extract<LoadedRuntimeConfig, { readonly runtimeMode: 'AutonomousService' }>
+                                const realizedPlan = makeApplicationPlan({
+                                  config: realizedConfig,
+                                  protocol: observePlan.protocol,
+                                  parameterHash: observePlan.parameterHash,
+                                  strategy: observePlan.strategy,
+                                  strategyProtocolHash: observePlan.strategyProtocolHash,
+                                }) as ApplicationPlanFor<'AutonomousService'>
+                                return makeMutation(
+                                  runtimeServices.session,
+                                  authority,
+                                  runtimeServices.alpacaHttpClient,
+                                ).pipe(
+                                  Effect.flatMap((brokerMutation) =>
+                                    Effect.fromResult(
+                                      makeExecutionProgram(authority, {
+                                        brokerRead: runtimeServices.session.read,
+                                        liveCapitalGrants: runtimeServices.liveCapitalGrants,
+                                        freshBrokerPrice: makeFreshBrokerPriceReader(
+                                          runtimeServices.session.connection,
+                                          runtimeServices.alpacaHttpClient,
+                                        ),
+                                        currentUtcInstant,
+                                        intentStore: runtimeServices.intentStore,
+                                        mutationStore: runtimeServices.mutationStore,
+                                        writerFence: runtimeServices.writerFence,
+                                        brokerMutation,
+                                      }),
+                                    ),
                                   ),
-                              })),
+                                  Effect.mapError(executionProgramError),
+                                  Effect.tap(() =>
+                                    realizedPaperActivation(state, request, prepared.generation.generationHash),
+                                  ),
+                                  Effect.map((executionProgram) => ({
+                                    _tag: 'AutonomousMutation' as const,
+                                    broker: runtimeBroker(realizedPlan, runtimeServices.session.read, true),
+                                    executionProgram,
+                                    startCycle: (startup: AutonomousCycleStartupInput) =>
+                                      mutationCycle(
+                                        realizedPlan,
+                                        executionProgram,
+                                      )(startup).pipe(
+                                        Effect.provide(cycleResources),
+                                        Effect.map((loop) => loop.pipe(Effect.provide(cycleResources))),
+                                      ),
+                                  })),
+                                )
+                              }),
                             )
                           }),
+                          Effect.catch((cause) =>
+                            Effect.logWarning('Bayn PAPER activation remains in OBSERVE').pipe(
+                              Effect.annotateLogs({
+                                service: 'bayn',
+                                activation: 'PENDING',
+                                reason: cause instanceof Error ? cause.message : String(cause),
+                              }),
+                              Effect.andThen(
+                                pendingPaperActivation(state, request, 'PREPARATION_FAILED').pipe(
+                                  Effect.as(readRuntime()),
+                                ),
+                              ),
+                            ),
+                          ),
                         )
                       }),
-                      Effect.catch((cause) =>
-                        Effect.logWarning('Bayn PAPER activation remains in OBSERVE').pipe(
-                          Effect.annotateLogs({
-                            service: 'bayn',
-                            activation: 'PENDING',
-                            reason: cause instanceof Error ? cause.message : String(cause),
-                          }),
-                          Effect.andThen(
-                            pendingPaperActivation(state, request, 'PREPARATION_FAILED').pipe(Effect.as(readRuntime())),
-                          ),
-                        ),
-                      ),
-                    )
-                  }),
-                  Effect.provide(runtimeContext),
+                      Effect.provide(runtimeContext),
+                    ),
+                  ),
                 ),
-              ),
+              scope,
             ),
           ).pipe(
             Effect.catch((cause) =>


### PR DESCRIPTION
## Summary

- Reuse the application-owned `Scope.Scope` when the post-startup autonomous resolver builds runtime resources.
- Keep BrokerSession/PostgreSQL resources alive through cycle startup and health monitoring; finalize them with application interruption.
- Add a regression covering cycle use, health use, and exactly-once finalization.

## Related Issues

PROOMPT-445

## Testing

- `bun test services/bayn/src/app.test.ts`
- `bun run --filter @proompteng/bayn test`
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint:effect`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn build`
- `bunx oxfmt --check services/bayn/src/app.ts services/bayn/src/composition.ts services/bayn/src/app.test.ts`
- `git diff --check`

## Screenshots

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.