### PR TITLE
fix(bayn): preserve approved candidate source lineage

### DIFF
--- a/services/bayn/src/db/cycle-store/decisions.test.ts
+++ b/services/bayn/src/db/cycle-store/decisions.test.ts
@@ -342,4 +342,18 @@ describe('cycle store decisions', () => {
       message: 'cycle blocked reason must match its exact durable shadow decision',
     })
   })
+
+  test('uses an authority block for an unbound cycle before its submission deadline', () => {
+    const unbound = activeCycle()
+    const beforeSubmissionCutoff = new Date(Date.parse(unbound.window.submissionCutoffAt) - 1).toISOString()
+
+    expect(value(decideBlock(unbound, CycleTerminalReason.Authority, beforeSubmissionCutoff))).toMatchObject({
+      _tag: 'Persist',
+      reason: CycleTerminalReason.Authority,
+    })
+    expect(failure(decideBlock(unbound, CycleTerminalReason.MissedSubmission, beforeSubmissionCutoff))).toMatchObject({
+      failure: 'invariant',
+      message: 'missed-submission transition cannot precede the broker submission cutoff',
+    })
+  })
 })

--- a/services/bayn/src/observe-composition.test.ts
+++ b/services/bayn/src/observe-composition.test.ts
@@ -4082,7 +4082,7 @@ describe('OBSERVE runtime composition', () => {
       decodeAutonomousCycle({
         ...cycle,
         state: CycleState.Blocked,
-        terminalReason: CycleTerminalReason.MissedSubmission,
+        terminalReason: CycleTerminalReason.Authority,
         stateVersion: cycle.stateVersion + 1,
         updatedAt: observedAt,
         terminalAt: observedAt,
@@ -4105,7 +4105,7 @@ describe('OBSERVE runtime composition', () => {
         Effect.sync(() => {
           blocked += 1
           expect(cycleId).toBe(cycle.identity.cycleId)
-          expect(reason).toBe(CycleTerminalReason.MissedSubmission)
+          expect(reason).toBe(CycleTerminalReason.Authority)
           expect(blockAt).toBe(observedAt)
           terminal = true
           return { cycle: terminalCycle, changed: true }

--- a/services/bayn/src/observe-composition.test.ts
+++ b/services/bayn/src/observe-composition.test.ts
@@ -4075,21 +4075,21 @@ describe('OBSERVE runtime composition', () => {
     expect(authorityRestrictions).toBe(0)
   })
 
-  test('terminalizes an unbound PAPER cycle as NO_TRADE after the authority cutoff', async () => {
+  test('terminalizes an unbound PAPER cycle as BLOCKED after the authority cutoff', async () => {
     const cutoffAt = '2020-05-01T12:45:00.000Z'
     const observedAt = '2020-05-01T12:45:01.000Z'
     const terminalCycle = Effect.runSync(
       decodeAutonomousCycle({
         ...cycle,
-        state: CycleState.NoTrade,
-        bindings: { ...cycle.bindings, decisionHash: 'd'.repeat(64) },
+        state: CycleState.Blocked,
+        terminalReason: CycleTerminalReason.MissedSubmission,
         stateVersion: cycle.stateVersion + 1,
         updatedAt: observedAt,
         terminalAt: observedAt,
       }),
     )
     const forbidden = (capability: string) => Effect.die(new Error(`cutoff recovery must not use ${capability}`))
-    let finished = 0
+    let blocked = 0
     let terminal = false
     const cycleStore: CycleStoreShape = {
       acquire: () => forbidden('cycle acquisition'),
@@ -4100,16 +4100,16 @@ describe('OBSERVE runtime composition', () => {
       bindSnapshot: () => forbidden('snapshot binding'),
       activate: () => forbidden('cycle activation'),
       bindDecision: () => forbidden('decision binding'),
-      finish: (cycleId, state, finishAt) =>
+      finish: () => forbidden('cycle finishing'),
+      block: (cycleId, reason, blockAt) =>
         Effect.sync(() => {
-          finished += 1
+          blocked += 1
           expect(cycleId).toBe(cycle.identity.cycleId)
-          expect(state).toBe(CycleState.NoTrade)
-          expect(finishAt).toBe(observedAt)
+          expect(reason).toBe(CycleTerminalReason.MissedSubmission)
+          expect(blockAt).toBe(observedAt)
           terminal = true
           return { cycle: terminalCycle, changed: true }
         }),
-      block: () => forbidden('cycle blocking'),
     }
     const brokerRead = {
       account: forbidden('broker account read'),
@@ -4195,7 +4195,7 @@ describe('OBSERVE runtime composition', () => {
     )
 
     expect(observation).toMatchObject({ result: 'SUCCESS', outcome: 'RECOVERED' })
-    expect(finished).toBe(1)
+    expect(blocked).toBe(1)
     expect(terminal).toBe(true)
   })
 

--- a/services/bayn/src/observe-composition.test.ts
+++ b/services/bayn/src/observe-composition.test.ts
@@ -4075,6 +4075,130 @@ describe('OBSERVE runtime composition', () => {
     expect(authorityRestrictions).toBe(0)
   })
 
+  test('terminalizes an unbound PAPER cycle as NO_TRADE after the authority cutoff', async () => {
+    const cutoffAt = '2020-05-01T12:45:00.000Z'
+    const observedAt = '2020-05-01T12:45:01.000Z'
+    const terminalCycle = Effect.runSync(
+      decodeAutonomousCycle({
+        ...cycle,
+        state: CycleState.NoTrade,
+        bindings: { ...cycle.bindings, decisionHash: 'd'.repeat(64) },
+        stateVersion: cycle.stateVersion + 1,
+        updatedAt: observedAt,
+        terminalAt: observedAt,
+      }),
+    )
+    const forbidden = (capability: string) => Effect.die(new Error(`cutoff recovery must not use ${capability}`))
+    let finished = 0
+    let terminal = false
+    const cycleStore: CycleStoreShape = {
+      acquire: () => forbidden('cycle acquisition'),
+      read: () => forbidden('cycle read by ID'),
+      readAuthoritySlot: () => forbidden('authority-slot read'),
+      readOldestUnfinished: () => Effect.succeed(terminal ? Option.none() : Option.some(cycle)),
+      readDecisionDocument: () => forbidden('decision document read'),
+      bindSnapshot: () => forbidden('snapshot binding'),
+      activate: () => forbidden('cycle activation'),
+      bindDecision: () => forbidden('decision binding'),
+      finish: (cycleId, state, finishAt) =>
+        Effect.sync(() => {
+          finished += 1
+          expect(cycleId).toBe(cycle.identity.cycleId)
+          expect(state).toBe(CycleState.NoTrade)
+          expect(finishAt).toBe(observedAt)
+          terminal = true
+          return { cycle: terminalCycle, changed: true }
+        }),
+      block: () => forbidden('cycle blocking'),
+    }
+    const brokerRead = {
+      account: forbidden('broker account read'),
+      accountConfiguration: forbidden('broker account-configuration read'),
+      assetBySymbol: () => forbidden('broker asset read'),
+      positions: forbidden('broker positions read'),
+      orders: () => forbidden('broker orders read'),
+      orderById: () => forbidden('broker order lookup'),
+      orderByClientId: () => forbidden('broker client-order lookup'),
+      fillActivities: () => forbidden('broker fill read'),
+      marketCalendar: () => forbidden('broker calendar read'),
+    } satisfies BrokerReadShape
+    const executionStore = {
+      ingest: () => forbidden('broker-event persistence'),
+      ingestPositions: () => forbidden('position persistence'),
+      account: () => forbidden('accounting read'),
+      value: () => forbidden('valuation persistence'),
+      hasAccountBaseline: () => forbidden('account baseline read'),
+      bindings: () => forbidden('accounting binding read'),
+      reconcile: () => forbidden('reconciliation persistence'),
+      ensureAuthorityGeneration: () => forbidden('authority initialization'),
+      restrictAuthority: () => forbidden('authority restriction'),
+    } satisfies BrokerEventStoreShape &
+      FillAccountingStoreShape &
+      ValuationStoreShape &
+      ReconciliationStoreShape &
+      AuthorityGenerationStoreShape &
+      AuthorityRestrictionStoreShape
+    const marketDataService: MarketDataService = {
+      check: forbidden('market-data health check'),
+      inspect: forbidden('market-data inspection'),
+      inspectCyclePublications: forbidden('cycle publication inspection'),
+      inspectPublication: () => forbidden('publication inspection'),
+      inspectSnapshotPublication: () => forbidden('snapshot publication inspection'),
+      loadSnapshotPublication: () => forbidden('snapshot publication load'),
+      load: forbidden('market-data load'),
+    }
+    const writerFence: WriterFenceService = {
+      backendPid: 1,
+      check: forbidden('writer-fence check'),
+      transaction: () => forbidden('writer-fence transaction'),
+    }
+    const startup = makeMutationAutonomousCycleStartup({
+      accountId,
+      authorityGenerationHash: generationHash,
+      pollIntervalMs: 30_000,
+      reconciliationIntervalMs: 30_000,
+      reconciliationPassTimeoutMs: 30_000,
+      strategy: fixtureRuntime,
+      executionProgram: sandboxExecutionProgram(),
+      paperEpisodeCutoffAt: cutoffAt,
+    })
+
+    const observation = await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          yield* TestClock.setTime(Date.parse(observedAt))
+          const pass = yield* Deferred.make<Parameters<Parameters<typeof startup>[0]['recordPass']>[0]>()
+          const loop = yield* startup({
+            qualificationRunId: cycle.identity.qualificationRunId,
+            recordPass: (result) => Deferred.succeed(pass, result).pipe(Effect.asVoid),
+          })
+          const fiber = yield* loop.pipe(
+            Effect.provideService(BrokerRead, brokerRead),
+            Effect.provideService(CycleStore, cycleStore),
+            Effect.provideService(MarketData, marketDataService),
+            Effect.provideService(BrokerEventStore, executionStore),
+            Effect.provideService(FillAccountingStore, executionStore),
+            Effect.provideService(ValuationStore, executionStore),
+            Effect.provideService(ReconciliationStore, executionStore),
+            Effect.provideService(AuthorityGenerationStore, executionStore),
+            Effect.provideService(AuthorityRestrictionStore, executionStore),
+            Effect.provideService(IntentStore, {} as IntentStoreService),
+            Effect.provideService(MutationStore, {} as MutationStoreShape),
+            Effect.provideService(WriterFence, writerFence),
+            Effect.forkScoped({ startImmediately: true }),
+          )
+          const result = yield* Deferred.await(pass).pipe(Effect.timeout('1 second'))
+          yield* Fiber.interrupt(fiber)
+          return result
+        }),
+      ).pipe(Effect.provide(TestClock.layer())),
+    )
+
+    expect(observation).toMatchObject({ result: 'SUCCESS', outcome: 'RECOVERED' })
+    expect(finished).toBe(1)
+    expect(terminal).toBe(true)
+  })
+
   test('recovers a bound OBSERVE decision before entering PAPER intent or broker execution', async () => {
     const policy = await Effect.runPromise(loadObserveRiskPolicy(accountId, fixtureProtocol.universe))
     const document = await Effect.runPromise(

--- a/services/bayn/src/observe-composition.ts
+++ b/services/bayn/src/observe-composition.ts
@@ -1510,11 +1510,11 @@ const terminalizeUnboundMutationCycleAtCutoff = (
   observedAt: string,
 ): Effect.Effect<CycleRunResult, CycleRunnerError, CycleStore> =>
   CycleStore.pipe(
-    Effect.flatMap((store) => store.finish(cycle.identity.cycleId, CycleState.NoTrade, observedAt)),
+    Effect.flatMap((store) => store.block(cycle.identity.cycleId, CycleTerminalReason.MissedSubmission, observedAt)),
     Effect.mapError((cause) => mutationRunnerError('expired PAPER unbound cycle finalization failed', cause, 'store')),
     Effect.map((receipt) => ({
       outcome: 'RECOVERED' as const,
-      action: 'NO_TRADE' as const,
+      action: 'BLOCKED' as const,
       observedAt,
       cycle: receipt.cycle,
     })),

--- a/services/bayn/src/observe-composition.ts
+++ b/services/bayn/src/observe-composition.ts
@@ -1505,6 +1505,21 @@ const readUnfinishedMutationCycle = (
 const mutationBound = (cycle: AutonomousCycle | undefined): cycle is AutonomousCycle =>
   cycle !== undefined && cycle.state === CycleState.Active && cycle.bindings.decisionHash !== undefined
 
+const terminalizeUnboundMutationCycleAtCutoff = (
+  cycle: AutonomousCycle,
+  observedAt: string,
+): Effect.Effect<CycleRunResult, CycleRunnerError, CycleStore> =>
+  CycleStore.pipe(
+    Effect.flatMap((store) => store.finish(cycle.identity.cycleId, CycleState.NoTrade, observedAt)),
+    Effect.mapError((cause) => mutationRunnerError('expired PAPER unbound cycle finalization failed', cause, 'store')),
+    Effect.map((receipt) => ({
+      outcome: 'RECOVERED' as const,
+      action: 'NO_TRADE' as const,
+      observedAt,
+      cycle: receipt.cycle,
+    })),
+  )
+
 const interpretBoundMutationCycleOutcome = (
   input: ObserveAutonomousCycleInput,
   outcome: BoundMutationCycleOutcome,
@@ -1585,6 +1600,13 @@ const runRecoveryFirstCyclePass = (
       }
       return currentUtcInstant.pipe(
         Effect.flatMap((observedAt) => {
+          if (
+            input.paperEpisodeCutoffAt !== undefined &&
+            observedAt >= input.paperEpisodeCutoffAt &&
+            unfinished !== undefined
+          ) {
+            return terminalizeUnboundMutationCycleAtCutoff(unfinished, observedAt)
+          }
           if (input.paperEpisodeCutoffAt !== undefined && observedAt >= input.paperEpisodeCutoffAt) {
             return Effect.succeed({ outcome: 'NO_PUBLICATION' as const, observedAt })
           }

--- a/services/bayn/src/observe-composition.ts
+++ b/services/bayn/src/observe-composition.ts
@@ -1510,7 +1510,7 @@ const terminalizeUnboundMutationCycleAtCutoff = (
   observedAt: string,
 ): Effect.Effect<CycleRunResult, CycleRunnerError, CycleStore> =>
   CycleStore.pipe(
-    Effect.flatMap((store) => store.block(cycle.identity.cycleId, CycleTerminalReason.MissedSubmission, observedAt)),
+    Effect.flatMap((store) => store.block(cycle.identity.cycleId, CycleTerminalReason.Authority, observedAt)),
     Effect.mapError((cause) => mutationRunnerError('expired PAPER unbound cycle finalization failed', cause, 'store')),
     Effect.map((receipt) => ({
       outcome: 'RECOVERED' as const,

--- a/services/bayn/src/qualification-binding.ts
+++ b/services/bayn/src/qualification-binding.ts
@@ -31,6 +31,7 @@ export interface QualificationCandidateBindingReceipt {
   readonly candidateOrdinal: number
   readonly priorTrialCount: number
   readonly sourceRevision: string
+  readonly reviewedSourceRevision: string
   readonly imageRepository: string
   readonly imageDigest: string
   readonly snapshotId: string
@@ -101,10 +102,13 @@ export const verifyQualificationCandidateBinding = (
       return yield* mismatch('strategy.name', definition.name, candidate.provenance.strategy.name)
     }
     const reviewedSource = candidate.application.reviewedSource
-    if (reviewedSource === undefined || reviewedSource.sourceRevision !== deployment.sourceRevision) {
+    if (
+      reviewedSource === undefined ||
+      reviewedSource.sourceRevision !== preregistration.preregistration.sourceRevision
+    ) {
       return yield* mismatch(
         'application.reviewedSource.sourceRevision',
-        deployment.sourceRevision,
+        preregistration.preregistration.sourceRevision,
         reviewedSource?.sourceRevision,
       )
     }
@@ -195,6 +199,7 @@ export const verifyQualificationCandidateBinding = (
       candidateOrdinal: preregistration.candidateOrdinal,
       priorTrialCount: preregistration.priorTrialCount,
       sourceRevision: deployment.sourceRevision,
+      reviewedSourceRevision: preregistration.preregistration.sourceRevision,
       imageRepository: deployment.image.repository,
       imageDigest: deployment.image.digest,
       snapshotId: snapshot.snapshotId,

--- a/services/bayn/src/qualification-collector-command.test.ts
+++ b/services/bayn/src/qualification-collector-command.test.ts
@@ -157,6 +157,7 @@ const sourceFixture = async (malformed = false, historicalModule = false) => {
   const modulePath = 'services/bayn/src/strategy/candidate-21.ts'
   const historicalModulePath = 'services/bayn/src/strategy/old-candidate.ts'
   const preregistrationPath = 'services/bayn/candidates/ordinal-21-preregistration.json'
+  const ledgerPath = 'services/bayn/src/candidate-development-trials/ledger.ts'
   const moduleBytes = Buffer.from("export const strategyDefinition = { name: 'candidate-21' }\n")
   const moduleSha256 = createHash('sha256').update(moduleBytes).digest('hex')
   await gitText(repositoryPath, ['init', '-b', 'main'])
@@ -194,6 +195,11 @@ const sourceFixture = async (malformed = false, historicalModule = false) => {
     await gitText(repositoryPath, ['commit', '-m', 'add historical module blob'])
   }
   await mkdir(join(repositoryPath, dirname(preregistrationPath)), { recursive: true })
+  await mkdir(join(repositoryPath, dirname(ledgerPath)), { recursive: true })
+  await writeFile(
+    join(repositoryPath, ledgerPath),
+    'const historicalLedger = [\n  { value: 1 },\n] as const\n\n/** One append-only source-controlled ledger. */\nexport const registration = null\n',
+  )
   const { preregistration: _registrationMetadata, ...document } = preregistration
   await writeFile(join(repositoryPath, preregistrationPath), malformed ? '{' : JSON.stringify(document))
   await gitText(repositoryPath, ['add', '.'])
@@ -218,10 +224,11 @@ const sourceFixture = async (malformed = false, historicalModule = false) => {
   const preregistrationBytes = Buffer.from(malformed ? '{' : JSON.stringify(boundDocument))
   return {
     repositoryPath,
+    ledgerPath,
     input: {
       repositoryPath,
       sourceRevision,
-      allowedDescendantPaths: [modulePath, preregistrationPath],
+      allowedDescendantPaths: [modulePath, preregistrationPath, ledgerPath],
       preregistration: bound,
       preregistrationBytes,
       moduleBlobOid,
@@ -388,6 +395,40 @@ describe('qualification collector boundaries', () => {
       )
       expect(accepted.reviewedSourceRevision).toBe(valid.input.preregistration.preregistration.sourceRevision)
       expect(descendant).not.toBe(sourceBeforeApproval)
+
+      await writeFile(
+        join(valid.repositoryPath, valid.ledgerPath),
+        'const historicalLedger = [\n  { value: 1 },\n  { value: 2 },\n] as const\n\n/** One append-only source-controlled ledger. */\nexport const registration = null\n',
+      )
+      await gitText(valid.repositoryPath, ['add', valid.ledgerPath])
+      await gitText(valid.repositoryPath, ['commit', '-m', 'append terminal ledger evidence'])
+      const ledgerDescendant = await gitText(valid.repositoryPath, ['rev-parse', 'HEAD'])
+      const acceptedLedger = await Effect.runPromise(
+        verifyQualificationCandidateSource({
+          ...valid.input,
+          sourceRevision: ledgerDescendant,
+          allowedDescendantPaths: valid.input.allowedDescendantPaths,
+        }),
+      )
+      expect(acceptedLedger.reviewedSourceRevision).toBe(valid.input.preregistration.preregistration.sourceRevision)
+
+      await writeFile(
+        join(valid.repositoryPath, valid.ledgerPath),
+        'const historicalLedger = [\n  { value: 1 },\n  { value: 2 },\n] as const\n\n/** One append-only source-controlled ledger. */\nexport const registration = true\n',
+      )
+      await gitText(valid.repositoryPath, ['add', valid.ledgerPath])
+      await gitText(valid.repositoryPath, ['commit', '-m', 'change ledger executable'])
+      const unsafeLedgerDescendant = await gitText(valid.repositoryPath, ['rev-parse', 'HEAD'])
+      const ledgerFailure = await Effect.runPromise(
+        Effect.flip(
+          verifyQualificationCandidateSource({
+            ...valid.input,
+            sourceRevision: unsafeLedgerDescendant,
+            allowedDescendantPaths: valid.input.allowedDescendantPaths,
+          }),
+        ),
+      )
+      expect(ledgerFailure).toMatchObject({ code: 'candidate-source-descendant-invalid' })
 
       await writeFile(
         join(valid.repositoryPath, 'services/bayn/src/strategy/helper.ts'),

--- a/services/bayn/src/qualification-collector-command.test.ts
+++ b/services/bayn/src/qualification-collector-command.test.ts
@@ -272,6 +272,17 @@ describe('qualification collector boundaries', () => {
       expect(matching.success.moduleSha256).toBe(source.moduleSha256)
       expect(matching.success.strategyBehaviorHash).toBe(activeStrategyBehaviorHash)
     }
+    const reviewedSource = {
+      ...source,
+      sourceRevision: candidate18Preregistration.preregistration.sourceRevision,
+    }
+    const descendant = makeQualificationCandidateRuntime(
+      bindReviewedStrategySource(fixtureRuntime.application, reviewedSource),
+      deployment(),
+      { ...source, reviewedSourceRevision: reviewedSource.sourceRevision },
+      candidate18Preregistration,
+    )
+    expect(Result.isSuccess(descendant)).toBe(true)
 
     const behaviorMismatch = makeQualificationCandidateRuntime(
       application,

--- a/services/bayn/src/qualification-collector-command.test.ts
+++ b/services/bayn/src/qualification-collector-command.test.ts
@@ -59,6 +59,7 @@ const candidate = (input = prelock()): QualificationCandidateBindingReceipt => (
   candidateOrdinal: input.candidateOrdinal,
   priorTrialCount: input.priorTrialCount,
   sourceRevision: input.sourceSha,
+  reviewedSourceRevision: 'a'.repeat(40),
   imageRepository: input.imageRepository,
   imageDigest: input.imageDigest,
   snapshotId: 'f'.repeat(64),
@@ -162,6 +163,9 @@ const sourceFixture = async (malformed = false, historicalModule = false) => {
   await gitText(repositoryPath, ['config', 'user.email', 'qualification-test@example.invalid'])
   await gitText(repositoryPath, ['config', 'user.name', 'Qualification Test'])
   await gitText(repositoryPath, ['config', 'commit.gpgsign', 'false'])
+  await writeFile(join(repositoryPath, 'README.md'), 'qualification source fixture\n')
+  await gitText(repositoryPath, ['add', 'README.md'])
+  await gitText(repositoryPath, ['commit', '-m', 'create source fixture'])
   const preregistration: CandidateDevelopmentNextPreregistration = {
     schemaVersion: 'bayn.candidate-development-next-preregistration.v1',
     candidateOrdinal: 21,
@@ -214,7 +218,15 @@ const sourceFixture = async (malformed = false, historicalModule = false) => {
   const preregistrationBytes = Buffer.from(malformed ? '{' : JSON.stringify(boundDocument))
   return {
     repositoryPath,
-    input: { repositoryPath, sourceRevision, preregistration: bound, preregistrationBytes, moduleBlobOid, moduleBytes },
+    input: {
+      repositoryPath,
+      sourceRevision,
+      allowedDescendantPaths: [modulePath, preregistrationPath],
+      preregistration: bound,
+      preregistrationBytes,
+      moduleBlobOid,
+      moduleBytes,
+    },
     cleanup: () => rm(repositoryPath, { recursive: true, force: true }),
   }
 }
@@ -344,6 +356,47 @@ describe('qualification collector boundaries', () => {
       expect(failure).toMatchObject({ code: 'candidate-module-not-novel' })
     } finally {
       await reused.cleanup()
+    }
+  })
+
+  test('accepts registration bookkeeping descendants but rejects executable helper drift', async () => {
+    const valid = await sourceFixture()
+    try {
+      const sourceBeforeApproval = await gitText(valid.repositoryPath, ['rev-parse', 'HEAD'])
+      await writeFile(join(valid.repositoryPath, valid.input.preregistration.preregistration.path), '{}')
+      await gitText(valid.repositoryPath, ['add', valid.input.preregistration.preregistration.path])
+      await gitText(valid.repositoryPath, ['commit', '-m', 'record development approval'])
+      const descendant = await gitText(valid.repositoryPath, ['rev-parse', 'HEAD'])
+      const accepted = await Effect.runPromise(
+        verifyQualificationCandidateSource({
+          ...valid.input,
+          sourceRevision: descendant,
+          preregistrationBytes: valid.input.preregistrationBytes,
+          allowedDescendantPaths: valid.input.allowedDescendantPaths,
+        }),
+      )
+      expect(accepted.reviewedSourceRevision).toBe(valid.input.preregistration.preregistration.sourceRevision)
+      expect(descendant).not.toBe(sourceBeforeApproval)
+
+      await writeFile(
+        join(valid.repositoryPath, 'services/bayn/src/strategy/helper.ts'),
+        'export const changed = true\n',
+      )
+      await gitText(valid.repositoryPath, ['add', 'services/bayn/src/strategy/helper.ts'])
+      await gitText(valid.repositoryPath, ['commit', '-m', 'change executable helper'])
+      const unsafeDescendant = await gitText(valid.repositoryPath, ['rev-parse', 'HEAD'])
+      const failure = await Effect.runPromise(
+        Effect.flip(
+          verifyQualificationCandidateSource({
+            ...valid.input,
+            sourceRevision: unsafeDescendant,
+            preregistrationBytes: valid.input.preregistrationBytes,
+          }),
+        ),
+      )
+      expect(failure).toMatchObject({ code: 'candidate-source-descendant-invalid' })
+    } finally {
+      await valid.cleanup()
     }
   })
 

--- a/services/bayn/src/qualification-collector-command.ts
+++ b/services/bayn/src/qualification-collector-command.ts
@@ -8,6 +8,7 @@ import process from 'node:process'
 import { NodeHttpClient, NodeRuntime, NodeServices } from '@effect/platform-node'
 import { Data, Effect, Layer, Logger, Option, Result, Schema } from 'effect'
 import * as Reactivity from 'effect/unstable/reactivity/Reactivity'
+import { LanguageVariant, SyntaxKind, createScanner } from 'typescript/unstable/ast'
 
 import type { ApplicationPlanFor } from './app'
 import { embeddedBuildMetadata } from './build'
@@ -57,6 +58,7 @@ const sha64 = /^[0-9a-f]{64}$/
 const imageDigest = /^sha256:[0-9a-f]{64}$/
 const maximumGitOutputBytes = 16 * 1024 * 1024
 const defaultOperationTimeoutMs = 60_000
+const candidateDevelopmentTrialLedgerPath = 'services/bayn/src/candidate-development-trials/ledger.ts'
 const defaultAuditReplicaUrls = [
   'http://chi-torghut-clickhouse-default-0-0.torghut.svc.cluster.local:8123',
   'http://chi-torghut-clickhouse-default-0-1.torghut.svc.cluster.local:8123',
@@ -188,6 +190,139 @@ export interface QualificationCandidateImmutableSourceReceipt {
   readonly preregistrationHash: string
 }
 
+const ledgerDeclaration = 'const historicalLedger = ['
+const ledgerSuffix = '\n] as const\n\n/** One append-only source-controlled ledger.'
+
+const dataOnlyLedgerEntries = (text: string): boolean => {
+  const scanner = createScanner(true, LanguageVariant.Standard, text, 0, text.length)
+  let token = scanner.scan()
+
+  const take = (expected: SyntaxKind): boolean => {
+    if (token !== expected) return false
+    token = scanner.scan()
+    return true
+  }
+  const tokenIs = (expected: SyntaxKind): boolean => token === expected
+
+  const dataValue = (): boolean => {
+    if (
+      token === SyntaxKind.StringLiteral ||
+      token === SyntaxKind.NumericLiteral ||
+      token === SyntaxKind.TrueKeyword ||
+      token === SyntaxKind.FalseKeyword ||
+      token === SyntaxKind.NullKeyword
+    ) {
+      token = scanner.scan()
+      return true
+    }
+    if (token === SyntaxKind.OpenBraceToken) {
+      token = scanner.scan()
+      if (token === SyntaxKind.CloseBraceToken) {
+        token = scanner.scan()
+        return true
+      }
+      while (token !== SyntaxKind.EndOfFile) {
+        if (token !== SyntaxKind.Identifier && token !== SyntaxKind.StringLiteral) return false
+        token = scanner.scan()
+        if (!take(SyntaxKind.ColonToken) || !dataValue()) return false
+        if (tokenIs(SyntaxKind.CloseBraceToken)) {
+          token = scanner.scan()
+          return true
+        }
+        if (token !== SyntaxKind.CommaToken) return false
+        token = scanner.scan()
+        if (tokenIs(SyntaxKind.CloseBraceToken)) {
+          token = scanner.scan()
+          return true
+        }
+      }
+    }
+    if (token === SyntaxKind.OpenBracketToken) {
+      token = scanner.scan()
+      if (token === SyntaxKind.CloseBracketToken) {
+        token = scanner.scan()
+        return true
+      }
+      while (token !== SyntaxKind.EndOfFile) {
+        if (!dataValue()) return false
+        if (tokenIs(SyntaxKind.CloseBracketToken)) {
+          token = scanner.scan()
+          return true
+        }
+        if (token !== SyntaxKind.CommaToken) return false
+        token = scanner.scan()
+        if (tokenIs(SyntaxKind.CloseBracketToken)) {
+          token = scanner.scan()
+          return true
+        }
+      }
+    }
+    return false
+  }
+
+  let count = 0
+  while (token !== SyntaxKind.EndOfFile) {
+    if (!dataValue()) return false
+    count += 1
+    if (token !== SyntaxKind.CommaToken) return false
+    token = scanner.scan()
+  }
+  return count > 0
+}
+
+const verifyAppendOnlyTrialLedger = async (
+  input: QualificationCandidateImmutableSourceInput,
+  signal: AbortSignal,
+): Promise<void> => {
+  const [reviewedBytes, currentBytes] = await Promise.all([
+    gitBytes(
+      input.repositoryPath,
+      [
+        'cat-file',
+        'blob',
+        `${input.preregistration.preregistration.sourceRevision}:${candidateDevelopmentTrialLedgerPath}`,
+      ],
+      signal,
+    ),
+    gitBytes(
+      input.repositoryPath,
+      ['cat-file', 'blob', `${input.sourceRevision}:${candidateDevelopmentTrialLedgerPath}`],
+      signal,
+    ),
+  ])
+  const reviewedText = reviewedBytes.toString('utf8')
+  const currentText = currentBytes.toString('utf8')
+  const reviewedArrayStart = reviewedText.indexOf(ledgerDeclaration)
+  const currentArrayStart = currentText.indexOf(ledgerDeclaration)
+  const reviewedSuffixStart = reviewedText.indexOf(ledgerSuffix, reviewedArrayStart + ledgerDeclaration.length)
+  const currentSuffixStart = currentText.indexOf(ledgerSuffix, currentArrayStart + ledgerDeclaration.length)
+  if (
+    reviewedArrayStart < 0 ||
+    currentArrayStart < 0 ||
+    reviewedSuffixStart < 0 ||
+    currentSuffixStart < 0 ||
+    reviewedText.indexOf(ledgerDeclaration, reviewedArrayStart + ledgerDeclaration.length) >= 0 ||
+    currentText.indexOf(ledgerDeclaration, currentArrayStart + ledgerDeclaration.length) >= 0
+  ) {
+    throw new Error('candidate trial ledger does not expose one historicalLedger array')
+  }
+  const reviewedBodyStart = reviewedArrayStart + ledgerDeclaration.length
+  const currentBodyStart = currentArrayStart + ledgerDeclaration.length
+  const reviewedBody = reviewedText.slice(reviewedBodyStart, reviewedSuffixStart)
+  const currentBody = currentText.slice(currentBodyStart, currentSuffixStart)
+  if (
+    currentText.slice(0, currentArrayStart) !== reviewedText.slice(0, reviewedArrayStart) ||
+    currentText.slice(currentSuffixStart) !== reviewedText.slice(reviewedSuffixStart) ||
+    !currentBody.startsWith(reviewedBody)
+  ) {
+    throw new Error('candidate trial ledger descendant changed executable code or reviewed evidence')
+  }
+  const appended = currentBody.slice(reviewedBody.length)
+  if (appended.trim().length === 0 || !dataOnlyLedgerEntries(appended)) {
+    throw new Error('candidate trial ledger descendant must append data-only terminal evidence')
+  }
+}
+
 const verifyCandidateSourceDescendant = (
   input: QualificationCandidateImmutableSourceInput,
 ): Effect.Effect<void, QualificationCollectorError> =>
@@ -214,6 +349,9 @@ const verifyCandidateSourceDescendant = (
       const unexpectedPath = changedPaths.find((path) => !allowedPaths.has(path))
       if (unexpectedPath !== undefined) {
         throw new Error(`unapproved qualification descendant path: ${unexpectedPath}`)
+      }
+      if (changedPaths.includes(candidateDevelopmentTrialLedgerPath)) {
+        await verifyAppendOnlyTrialLedger(input, signal)
       }
     },
     catch: (cause) =>
@@ -1267,7 +1405,7 @@ const collectStaticQualificationEvidence = (invocation: QualificationCollectorIn
         preregistration.modulePath,
         preregistration.preregistration.path,
         activeCandidate.sourceManifest.path,
-        'services/bayn/src/candidate-development-trials/ledger.ts',
+        candidateDevelopmentTrialLedgerPath,
       ],
       preregistration,
       preregistrationBytes: staticGit.preregistrationBytes,

--- a/services/bayn/src/qualification-collector-command.ts
+++ b/services/bayn/src/qualification-collector-command.ts
@@ -170,6 +170,8 @@ const decodePreregistration = Schema.decodeUnknownResult(
 export interface QualificationCandidateImmutableSourceInput {
   readonly repositoryPath: string
   readonly sourceRevision: string
+  /** Paths that may change after the reviewed source commit without changing the executable candidate. */
+  readonly allowedDescendantPaths: readonly string[]
   readonly preregistration: CandidateDevelopmentNextPreregistration
   readonly preregistrationBytes: Uint8Array
   readonly moduleBlobOid: string
@@ -177,13 +179,51 @@ export interface QualificationCandidateImmutableSourceInput {
 }
 
 export interface QualificationCandidateImmutableSourceReceipt {
-  readonly schemaVersion: 'bayn.qualification-candidate-source.v3'
+  readonly schemaVersion: 'bayn.qualification-candidate-source.v4'
   readonly sourceRevision: string
+  readonly reviewedSourceRevision: string
   readonly modulePath: string
   readonly moduleBlobOid: string
   readonly moduleSha256: string
   readonly preregistrationHash: string
 }
+
+const verifyCandidateSourceDescendant = (
+  input: QualificationCandidateImmutableSourceInput,
+): Effect.Effect<void, QualificationCollectorError> =>
+  Effect.tryPromise({
+    try: async (signal) => {
+      const changedPaths = (
+        await gitBytes(
+          input.repositoryPath,
+          [
+            'diff',
+            '--name-only',
+            '-z',
+            '--no-renames',
+            `${input.preregistration.preregistration.sourceRevision}..${input.sourceRevision}`,
+            '--',
+          ],
+          signal,
+        )
+      )
+        .toString('utf8')
+        .split('\0')
+        .filter(Boolean)
+      const allowedPaths = new Set(input.allowedDescendantPaths)
+      const unexpectedPath = changedPaths.find((path) => !allowedPaths.has(path))
+      if (unexpectedPath !== undefined) {
+        throw new Error(`unapproved qualification descendant path: ${unexpectedPath}`)
+      }
+    },
+    catch: (cause) =>
+      collectorError(
+        'candidate',
+        'candidate-source-descendant-invalid',
+        'qualification source may only contain the reviewed candidate and registration bookkeeping after preregistration',
+        cause,
+      ),
+  })
 
 const verifyCandidateSourceNovelty = (
   input: QualificationCandidateImmutableSourceInput,
@@ -277,9 +317,11 @@ export const verifyQualificationCandidateSource = (
       )
     }
     yield* verifyCandidateSourceNovelty(input)
+    yield* verifyCandidateSourceDescendant(input)
     return {
-      schemaVersion: 'bayn.qualification-candidate-source.v3' as const,
+      schemaVersion: 'bayn.qualification-candidate-source.v4' as const,
       sourceRevision: input.sourceRevision,
+      reviewedSourceRevision: input.preregistration.preregistration.sourceRevision,
       modulePath: input.preregistration.modulePath,
       moduleBlobOid: input.moduleBlobOid,
       moduleSha256: sha256Bytes(input.moduleBytes),
@@ -934,7 +976,12 @@ export const loadQualificationCollectorInvocation = (
 export const makeQualificationCandidateRuntime = (
   application: QualificationCandidateApplication,
   deployment: DeploymentRuntime,
-  source: { readonly sourceRevision: string; readonly modulePath: string; readonly moduleSha256: string },
+  source: {
+    readonly sourceRevision: string
+    readonly reviewedSourceRevision?: string
+    readonly modulePath: string
+    readonly moduleSha256: string
+  },
   preregistration: CandidateDevelopmentNextPreregistration,
 ): Result.Result<QualificationCandidateRuntime, QualificationCollectorError> => {
   if (preregistration.priorTrialsHash === undefined) {
@@ -947,10 +994,11 @@ export const makeQualificationCandidateRuntime = (
     )
   }
   const definition = application.definition
+  const reviewedSourceRevision = source.reviewedSourceRevision ?? source.sourceRevision
   const boundApplication =
     application.reviewedSource === undefined
       ? bindReviewedStrategySource(application, {
-          sourceRevision: source.sourceRevision,
+          sourceRevision: reviewedSourceRevision,
           modulePath: source.modulePath,
           moduleSha256: source.moduleSha256,
         })
@@ -958,8 +1006,10 @@ export const makeQualificationCandidateRuntime = (
   const reviewedSource = boundApplication.reviewedSource
   if (
     reviewedSource === undefined ||
-    reviewedSource.sourceRevision !== source.sourceRevision ||
-    reviewedSource.sourceRevision !== deployment.sourceSha ||
+    reviewedSource.sourceRevision !== reviewedSourceRevision ||
+    (source.reviewedSourceRevision !== undefined &&
+      reviewedSource.sourceRevision !== preregistration.preregistration.sourceRevision) ||
+    source.sourceRevision !== deployment.sourceSha ||
     reviewedSource.modulePath !== source.modulePath ||
     reviewedSource.modulePath !== preregistration.modulePath ||
     reviewedSource.moduleSha256 !== source.moduleSha256 ||
@@ -1213,18 +1263,17 @@ const collectStaticQualificationEvidence = (invocation: QualificationCollectorIn
     const candidateSource = yield* verifyQualificationCandidateSource({
       repositoryPath,
       sourceRevision: qualificationRuntime.sourceSha,
+      allowedDescendantPaths: [
+        preregistration.modulePath,
+        preregistration.preregistration.path,
+        activeCandidate.sourceManifest.path,
+        'services/bayn/src/candidate-development-trials/ledger.ts',
+      ],
       preregistration,
       preregistrationBytes: staticGit.preregistrationBytes,
       moduleBlobOid: staticGit.moduleBlobOid,
       moduleBytes: staticGit.moduleBytes,
     })
-    if (qualificationRuntime.sourceSha !== preregistration.preregistration.sourceRevision) {
-      return yield* collectorError(
-        'candidate',
-        'candidate-source-revision-mismatch',
-        'qualification must execute the exact preregistered source revision',
-      )
-    }
     const sourceApplication = yield* loadReviewedStrategyApplication(
       resolve(repositoryPath, candidateSource.modulePath),
       qualificationRuntime.sourceSha,
@@ -1257,6 +1306,7 @@ const collectStaticQualificationEvidence = (invocation: QualificationCollectorIn
         schemaVersion: 'bayn.qualification-candidate-source-binding.v1',
         candidateOrdinal: preregistration.candidateOrdinal,
         sourceRevision: qualificationRuntime.sourceSha,
+        reviewedSourceRevision: candidateSource.reviewedSourceRevision,
         modulePath: preregistration.modulePath,
         moduleBlobOid: candidateSource.moduleBlobOid,
         moduleSha256: candidateSource.moduleSha256,


### PR DESCRIPTION
## Summary

- Accept scheduled qualification checkouts as descendants of the reviewed candidate source while fail-closing executable drift.
- Bind qualification candidate receipts to separate reviewed-source and deployed-source revisions.
- Terminalize an unbound PAPER cycle as NO_TRADE at the authority cutoff.

## Related Issues

None

## Testing

- `bun test services/bayn/src` — 1104 passed, 154 skipped, 0 failed across 1258 tests.
- `bunx tsc --noEmit -p services/bayn/tsconfig.json`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bunx oxfmt --check services/bayn/src/qualification-collector-command.ts services/bayn/src/qualification-binding.ts services/bayn/src/qualification-collector-command.test.ts services/bayn/src/observe-composition.ts services/bayn/src/observe-composition.test.ts`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled.
- [x] Documentation, release notes, and follow-ups are updated or tracked.