### PR TITLE
feat(bayn): preregister Candidate 21

### DIFF
--- a/services/bayn/candidates/ordinal-21-six-month-rotation-preregistration.json
+++ b/services/bayn/candidates/ordinal-21-six-month-rotation-preregistration.json
@@ -4,7 +4,7 @@
   "priorTrialCount": 20,
   "strategyProtocolHash": "9f03db47df47cb133b922c795b9cbd5c5b78e3d6d3411ec74e303d7f193f81fe",
   "candidateDevelopmentProtocolHash": "41fb58503e94222ea98d5e929f431a31ad6a1720ff7eb88a5f7935396a254769",
-  "calendarHash": "a6df7a68249842fa35814f282b3df63db19c52f6ea0697899979d3a8c970d9b1",
+  "calendarHash": "4b2f519f336e4e730c1f0d69e860f25a8d4d0cfbd8e93c6b333ea83623d87237",
   "priorTrialsHash": "295eff4120c4d3deb33e09e3948bc5a670b55a836dc6be6849b2eea979e60008",
   "modulePath": "services/bayn/src/strategy/candidate-21.ts",
   "moduleSha256": "929ce699203425b95a06597c98fbbff3d124dda5da68e187ebb1f289d9ded5b1",

--- a/services/bayn/candidates/ordinal-21-six-month-rotation-preregistration.json
+++ b/services/bayn/candidates/ordinal-21-six-month-rotation-preregistration.json
@@ -1,0 +1,18 @@
+{
+  "schemaVersion": "bayn.candidate-development-next-preregistration.v1",
+  "candidateOrdinal": 21,
+  "priorTrialCount": 20,
+  "strategyProtocolHash": "9f03db47df47cb133b922c795b9cbd5c5b78e3d6d3411ec74e303d7f193f81fe",
+  "candidateDevelopmentProtocolHash": "41fb58503e94222ea98d5e929f431a31ad6a1720ff7eb88a5f7935396a254769",
+  "calendarHash": "a6df7a68249842fa35814f282b3df63db19c52f6ea0697899979d3a8c970d9b1",
+  "priorTrialsHash": "295eff4120c4d3deb33e09e3948bc5a670b55a836dc6be6849b2eea979e60008",
+  "modulePath": "services/bayn/src/strategy/candidate-21.ts",
+  "moduleSha256": "929ce699203425b95a06597c98fbbff3d124dda5da68e187ebb1f289d9ded5b1",
+  "marketData": {
+    "schemaVersion": "bayn.candidate-development-market-data-source.v1",
+    "snapshotId": "2a91f0177684f7022f746207333e510c8268f9b77a04b778a04220a33ccf79e0",
+    "finalizedSnapshotContentHash": "8e376546f6a6cc1dbe2e910db3d68f584fc0bd9c4858166042ce32aa077eed0d",
+    "inputManifestHash": "1e5377336f2e6feb751000114b81cc89aee5be7542e213c320f2cfbb4185bb2b",
+    "boundedContentHash": "b6052c8ebdca855973adf4e41efafb5028fd8dbbaa70809331f6017519b1c995"
+  }
+}


### PR DESCRIPTION
## Summary

- Preregister Candidate 21 as one result-blind six-month DBC/VNQ rotation with IEF fallback.
- Bind the candidate to the current five-symbol protocol, trial ledger hash, and independently recomputed frozen snapshot witness hashes.
- Preserve Candidate 20 as the immutable zero-attempt tombstone; no active registration or evaluator execution is enabled by this change.

## Related Issues

None

## Testing

- `bunx oxfmt --check services/bayn/candidates/ordinal-21-six-month-rotation-preregistration.json`
- JSON schema/hash and module SHA-256 binding checked with Bun.
- Live ClickHouse snapshot identity and bounded witness rows verified read-only; no metrics were run.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled.
- [x] Documentation, release notes, and follow-ups are updated or tracked; the source/consumer merge is the follow-up PR.