### PR TITLE
fix(bayn): allow descendant candidate source bindings

### DIFF
--- a/services/bayn/src/candidate-development-local/command.ts
+++ b/services/bayn/src/candidate-development-local/command.ts
@@ -56,6 +56,7 @@ import {
 import { loadReviewedStrategyApplication } from './source-module'
 
 const candidateDevelopmentEvaluatorSourcePath = 'services/bayn/src'
+const candidateDevelopmentTrialLedgerSourcePath = 'services/bayn/src/candidate-development-trials/ledger.ts'
 
 export interface CandidateDevelopmentSourceGit {
   readonly text: (repositoryRoot: string, args: readonly string[], signal?: AbortSignal) => Promise<string>
@@ -207,6 +208,38 @@ export const verifyCandidateDevelopmentLocalSourceTree = (
       ),
   })
 
+const verifyCandidateDevelopmentLocalSourceDescendant = (
+  repositoryRoot: string,
+  reviewedSourceRevision: string,
+  sourceRevision: string,
+  modulePath: string,
+  sourceManifestPath: string,
+  sourceGit: CandidateDevelopmentSourceGit,
+): Effect.Effect<void, CandidateDevelopmentLocalError> =>
+  Effect.tryPromise({
+    try: async (signal) => {
+      const changedPaths = (
+        await sourceGit.text(
+          repositoryRoot,
+          ['diff', '--name-only', '--no-renames', `${reviewedSourceRevision}..${sourceRevision}`, '--'],
+          signal,
+        )
+      )
+        .split('\n')
+        .filter(Boolean)
+      const allowedPaths = new Set([modulePath, sourceManifestPath, candidateDevelopmentTrialLedgerSourcePath])
+      const unexpectedPath = changedPaths.find((path) => !allowedPaths.has(path))
+      if (unexpectedPath !== undefined)
+        throw new Error(`unapproved candidate source descendant path: ${unexpectedPath}`)
+    },
+    catch: (cause) =>
+      localError(
+        'SOURCE_BINDING_INVALID',
+        'candidate source descendants may only add the reviewed module, manifest, and terminal ledger data',
+        cause,
+      ),
+  })
+
 const decodeJson = (bytes: Buffer, message: string): Result.Result<unknown, CandidateDevelopmentLocalError> => {
   try {
     const value: unknown = JSON.parse(bytes.toString('utf8'))
@@ -335,7 +368,6 @@ const receiptPathFor = async (
 
 const prepareCandidateDevelopmentLocalAttempt = (
   args: CandidateDevelopmentLocalArguments,
-  application: StrategyApplication<any, any, any>,
   sourceManifestBinding: CandidateDevelopmentLocalSourceManifestBinding,
   sourceGit: CandidateDevelopmentSourceGit = candidateDevelopmentSourceGit,
 ): Effect.Effect<PreparedCandidateDevelopmentLocalAttempt, CandidateDevelopmentLocalError> =>
@@ -466,22 +498,19 @@ const prepareCandidateDevelopmentLocalAttempt = (
           cause,
         ),
     })
+    yield* verifyCandidateDevelopmentLocalSourceDescendant(
+      repositoryRoot,
+      preregistration.preregistration.sourceRevision,
+      sourceRevision,
+      modulePath,
+      sourceManifestPath,
+      sourceGit,
+    )
     const sourceApplication = yield* loadReviewedStrategyApplication(canonicalArgs.modulePath, sourceRevision).pipe(
       Effect.mapError((cause) =>
         localError('SOURCE_BINDING_INVALID', 'reviewed candidate application could not be loaded', cause),
       ),
     )
-    if (
-      sourceApplication.definition.name !== application.definition.name ||
-      hashParameters(sourceApplication.definition.parameters) !== hashParameters(application.definition.parameters)
-    ) {
-      return yield* Effect.fail(
-        localError(
-          'SOURCE_BINDING_INVALID',
-          'reviewed candidate module does not match the registered application identity',
-        ),
-      )
-    }
     const reviewedApplication =
       sourceApplication.reviewedSource === undefined
         ? bindReviewedStrategySource(sourceApplication, {
@@ -847,14 +876,10 @@ const liveDependencies: CandidateDevelopmentLocalDependencies = {
       ? Effect.fail(
           localError(
             'MODULE_INVALID',
-            'no active candidate strategy application is statically composed for local development',
+            'no active candidate development registration is available for local development',
           ),
         )
-      : prepareCandidateDevelopmentLocalAttempt(
-          args,
-          activeCandidateDevelopmentRegistration.application,
-          activeCandidateDevelopmentRegistration.sourceManifest,
-        ),
+      : prepareCandidateDevelopmentLocalAttempt(args, activeCandidateDevelopmentRegistration.sourceManifest),
   attempt: makeCandidateDevelopmentLocalAttempt({
     reserve: reserveCandidateDevelopmentLocalReceipt,
     execute: executeCandidateDevelopmentLocalAttempt,

--- a/services/bayn/src/candidate-development-local/command.ts
+++ b/services/bayn/src/candidate-development-local/command.ts
@@ -452,11 +452,20 @@ const prepareCandidateDevelopmentLocalAttempt = (
       try: () => receiptPathFor(repositoryRoot, source.sourceManifest.candidateOrdinal, sourceGit),
       catch: (cause) => localError('RECEIPT_RESERVATION_FAILED', 'candidate receipt path is unavailable', cause),
     })
-    if (sourceRevision !== preregistration.preregistration.sourceRevision) {
-      return yield* Effect.fail(
-        localError('SOURCE_BINDING_INVALID', 'candidate checkout is not the exact preregistered source revision'),
-      )
-    }
+    yield* Effect.tryPromise({
+      try: (signal) =>
+        sourceGit.text(
+          repositoryRoot,
+          ['merge-base', '--is-ancestor', preregistration.preregistration.sourceRevision, sourceRevision],
+          signal,
+        ),
+      catch: (cause) =>
+        localError(
+          'SOURCE_BINDING_INVALID',
+          'candidate checkout is not a descendant of the preregistered source revision',
+          cause,
+        ),
+    })
     const sourceApplication = yield* loadReviewedStrategyApplication(canonicalArgs.modulePath, sourceRevision).pipe(
       Effect.mapError((cause) =>
         localError('SOURCE_BINDING_INVALID', 'reviewed candidate application could not be loaded', cause),

--- a/services/bayn/src/candidate-development-trials/ledger.test.ts
+++ b/services/bayn/src/candidate-development-trials/ledger.test.ts
@@ -273,6 +273,52 @@ describe('Bayn candidate development trial ledger', () => {
     })
   })
 
+  test('closes a pending candidate after its one-shot development rejection', () => {
+    const preregistration = {
+      ...candidate20Preregistration,
+      candidateOrdinal: 21,
+      priorTrialCount: 20,
+      preregistration: {
+        ...candidate20Preregistration.preregistration,
+        sourceRevision: 'a'.repeat(40),
+        blobOid: 'b'.repeat(40),
+      },
+    }
+    const sourceManifest = {
+      path: 'services/bayn/candidates/ordinal-21-source-manifest.json',
+      blobOid: 'c'.repeat(40),
+      sha256: 'e'.repeat(64),
+    }
+    const pending = {
+      _tag: 'DEVELOPMENT_PENDING' as const,
+      candidateOrdinal: 21,
+      priorTrialCount: 20,
+      strategyName: 'risk-balanced-trend',
+      preregistration,
+      sourceManifest,
+    }
+    expect(
+      qualificationDormancyDecisionFromLedgerState({
+        ...candidateDevelopmentTrialLedgerState,
+        entries: [
+          ...candidateDevelopmentTrialLedgerState.entries,
+          pending,
+          {
+            _tag: 'DEVELOPMENT_REJECTED' as const,
+            candidateOrdinal: 21,
+            priorTrialCount: 20,
+            sourceRevision: 'd'.repeat(40),
+          },
+        ],
+        developmentCandidateOrdinals: [...candidateDevelopmentTrialLedgerState.developmentCandidateOrdinals, 21],
+        activeCandidate: null,
+      }),
+    ).toEqual({
+      ok: true,
+      decision: { status: 'dormant', reason: 'development-rejected', candidateOrdinal: 21 },
+    })
+  })
+
   test('fails closed for an incomplete predecessor ledger and derives the active prior count from it', () => {
     const activeCandidate = {
       preregistration: {

--- a/services/bayn/src/candidate-development-trials/ledger.test.ts
+++ b/services/bayn/src/candidate-development-trials/ledger.test.ts
@@ -17,6 +17,7 @@ import { qualificationDormancyDecisionFromLedgerState } from './qualification-do
 const approvalEvidence = (
   preregistration: CandidateDevelopmentNextPreregistration,
   sourceManifestBinding: CandidateDevelopmentLocalSourceManifestBinding,
+  evaluatedSourceRevision = preregistration.preregistration.sourceRevision,
 ) => {
   if (preregistration.priorTrialsHash === undefined) throw new Error('approval fixture requires a trial history hash')
   const sourceMaterial = {
@@ -28,7 +29,7 @@ const approvalEvidence = (
     snapshotId: preregistration.marketData.snapshotId,
     inputManifestHash: preregistration.marketData.inputManifestHash,
     boundedContentHash: preregistration.marketData.boundedContentHash,
-    sourceRevision: preregistration.preregistration.sourceRevision,
+    sourceRevision: evaluatedSourceRevision,
     modulePath: preregistration.modulePath,
     moduleBlobOid: '3'.repeat(40),
     moduleSha256: preregistration.moduleSha256,
@@ -45,7 +46,7 @@ const approvalEvidence = (
     '8'.repeat(64),
   )
   return {
-    sourceRevision: preregistration.preregistration.sourceRevision,
+    sourceRevision: evaluatedSourceRevision,
     terminalReport,
     terminalReportHash: canonicalHashV1(terminalReport),
   }
@@ -316,6 +317,49 @@ describe('Bayn candidate development trial ledger', () => {
     ).toEqual({
       ok: true,
       decision: { status: 'dormant', reason: 'development-rejected', candidateOrdinal: 21 },
+    })
+  })
+
+  test('preserves the evaluated descendant revision in development approval evidence', () => {
+    const preregistration = {
+      ...candidate20Preregistration,
+      candidateOrdinal: 21,
+      priorTrialCount: 20,
+      preregistration: {
+        ...candidate20Preregistration.preregistration,
+        sourceRevision: 'a'.repeat(40),
+        blobOid: 'b'.repeat(40),
+      },
+    }
+    const sourceManifest = {
+      path: 'services/bayn/candidates/ordinal-21-source-manifest.json',
+      blobOid: 'c'.repeat(40),
+      sha256: 'e'.repeat(64),
+    }
+    const pending = {
+      _tag: 'DEVELOPMENT_PENDING' as const,
+      candidateOrdinal: 21,
+      priorTrialCount: 20,
+      strategyName: 'risk-balanced-trend',
+      preregistration,
+      sourceManifest,
+    }
+    const approval = {
+      _tag: 'DEVELOPMENT_APPROVED' as const,
+      candidateOrdinal: 21,
+      priorTrialCount: 20,
+      ...approvalEvidence(preregistration, sourceManifest, 'd'.repeat(40)),
+    }
+    expect(
+      qualificationDormancyDecisionFromLedgerState({
+        ...candidateDevelopmentTrialLedgerState,
+        entries: [...candidateDevelopmentTrialLedgerState.entries, pending, approval],
+        developmentCandidateOrdinals: [...candidateDevelopmentTrialLedgerState.developmentCandidateOrdinals, 21],
+        activeCandidate: { preregistration, strategyName: 'risk-balanced-trend', sourceManifest },
+      }),
+    ).toMatchObject({
+      ok: true,
+      decision: { status: 'ready', reason: 'qualification-eligible', candidateOrdinal: 21 },
     })
   })
 

--- a/services/bayn/src/candidate-development-trials/ledger.ts
+++ b/services/bayn/src/candidate-development-trials/ledger.ts
@@ -10,8 +10,18 @@ import {
   CandidateDevelopmentLocalSourceManifestBindingSchema,
   CandidateDevelopmentLocalTerminalReportSchema,
 } from '../candidate-development-local/domain'
-import type { CandidateDevelopmentInvalidPrecommit, CandidateDevelopmentNextPreregistration } from './model'
-import { NonNegativeIntegerSchema, PositiveIntegerSchema, Sha256Schema, strictParseOptions } from '../schemas'
+import {
+  CandidateDevelopmentNextPreregistrationSchema,
+  type CandidateDevelopmentInvalidPrecommit,
+  type CandidateDevelopmentNextPreregistration,
+} from './model'
+import {
+  NonNegativeIntegerSchema,
+  PositiveIntegerSchema,
+  Sha256Schema,
+  StrictNonEmptyStringSchema,
+  strictParseOptions,
+} from '../schemas'
 import type { StrategyApplication } from '../strategy'
 
 const TrialLedgerEntrySchema = Schema.Union([
@@ -41,6 +51,14 @@ const TrialLedgerEntrySchema = Schema.Union([
     attemptStatus: Schema.Literal('UNATTEMPTED'),
     metricBearingAttemptsConsumed: Schema.Literal(0),
     qualificationAttemptConsumed: Schema.Literal(false),
+  }),
+  Schema.Struct({
+    _tag: Schema.Literal('DEVELOPMENT_PENDING'),
+    candidateOrdinal: PositiveIntegerSchema,
+    priorTrialCount: NonNegativeIntegerSchema,
+    strategyName: StrictNonEmptyStringSchema,
+    preregistration: CandidateDevelopmentNextPreregistrationSchema,
+    sourceManifest: CandidateDevelopmentLocalSourceManifestBindingSchema,
   }),
 ])
 
@@ -91,14 +109,35 @@ export const candidateDevelopmentTrialLedger: readonly CandidateDevelopmentTrial
 
 export interface ActiveCandidateDevelopmentRegistration {
   readonly preregistration: CandidateDevelopmentNextPreregistration
+  readonly strategyName?: string
   /** The exact reviewed source-manifest object consumed by both local development and qualification. */
   readonly sourceManifest: typeof CandidateDevelopmentLocalSourceManifestBindingSchema.Type
-  /** The one reviewed application consumed by both local development and qualification. */
-  readonly application: StrategyApplication<any, any, any>
+  /** Compatibility projection for archived fixtures; production adapters load the registered module export. */
+  readonly application?: StrategyApplication<any, any, any>
 }
 
-/** Candidate 21 is intentionally absent until the architecture gates are merged. */
-export const activeCandidateDevelopmentRegistration: ActiveCandidateDevelopmentRegistration | null = null
+const activeRegistrationFromLedger = (
+  entries: readonly CandidateDevelopmentTrialLedgerEntry[],
+): ActiveCandidateDevelopmentRegistration | null => {
+  const pending = [...entries].reverse().find((entry) => entry._tag === 'DEVELOPMENT_PENDING')
+  if (pending === undefined) return null
+  const latest = entries.at(-1)
+  if (
+    latest !== undefined &&
+    latest.candidateOrdinal === pending.candidateOrdinal &&
+    (latest._tag === 'DEVELOPMENT_REJECTED' || latest._tag === 'QUALIFICATION_TERMINAL')
+  ) {
+    return null
+  }
+  return Object.freeze({
+    preregistration: pending.preregistration,
+    strategyName: pending.strategyName,
+    sourceManifest: pending.sourceManifest,
+  })
+}
+
+/** The active registration is derived from one append-only pending entry; its application is the module export. */
+export const activeCandidateDevelopmentRegistration = activeRegistrationFromLedger(candidateDevelopmentTrialLedger)
 
 export interface CandidateDevelopmentTrialLedgerState {
   readonly entries: readonly CandidateDevelopmentTrialLedgerEntry[]

--- a/services/bayn/src/candidate-development-trials/model.ts
+++ b/services/bayn/src/candidate-development-trials/model.ts
@@ -1,27 +1,47 @@
-export interface CandidateDevelopmentNextPreregistration {
-  readonly schemaVersion: 'bayn.candidate-development-next-preregistration.v1'
-  readonly candidateOrdinal: number
-  readonly priorTrialCount: number
-  readonly strategyProtocolHash: string
-  readonly strategyIdentityHash?: string
-  readonly candidateDevelopmentProtocolHash?: string
-  readonly calendarHash?: string
-  readonly priorTrialsHash?: string
-  readonly modulePath: string
-  readonly moduleSha256: string
-  readonly marketData: {
-    readonly schemaVersion: 'bayn.candidate-development-market-data-source.v1'
-    readonly snapshotId: string
-    readonly finalizedSnapshotContentHash: string
-    readonly inputManifestHash: string
-    readonly boundedContentHash: string
-  }
-  readonly preregistration: {
-    readonly sourceRevision: string
-    readonly path: string
-    readonly blobOid: string
-  }
-}
+import { Schema } from 'effect'
+
+import {
+  NonNegativeIntegerSchema,
+  PositiveIntegerSchema,
+  Sha256Schema,
+  SourceRevisionSchema,
+  StrictNonEmptyStringSchema,
+} from '../schemas'
+
+const CandidateDevelopmentNextPreregistrationFields = {
+  schemaVersion: Schema.Literal('bayn.candidate-development-next-preregistration.v1'),
+  candidateOrdinal: PositiveIntegerSchema,
+  priorTrialCount: NonNegativeIntegerSchema,
+  strategyProtocolHash: Sha256Schema,
+  strategyIdentityHash: Schema.optionalKey(Sha256Schema),
+  candidateDevelopmentProtocolHash: Schema.optionalKey(Sha256Schema),
+  calendarHash: Schema.optionalKey(Sha256Schema),
+  priorTrialsHash: Schema.optionalKey(Sha256Schema),
+  modulePath: StrictNonEmptyStringSchema,
+  moduleSha256: Sha256Schema,
+  marketData: Schema.Struct({
+    schemaVersion: Schema.Literal('bayn.candidate-development-market-data-source.v1'),
+    snapshotId: Sha256Schema,
+    finalizedSnapshotContentHash: Sha256Schema,
+    inputManifestHash: Sha256Schema,
+    boundedContentHash: Sha256Schema,
+  }),
+} as const
+
+export const CandidateDevelopmentNextPreregistrationDocumentSchema = Schema.Struct(
+  CandidateDevelopmentNextPreregistrationFields,
+)
+
+export const CandidateDevelopmentNextPreregistrationSchema = Schema.Struct({
+  ...CandidateDevelopmentNextPreregistrationFields,
+  preregistration: Schema.Struct({
+    sourceRevision: SourceRevisionSchema,
+    path: StrictNonEmptyStringSchema,
+    blobOid: Schema.String.check(Schema.isPattern(/^[0-9a-f]{40}$/)),
+  }),
+})
+
+export type CandidateDevelopmentNextPreregistration = typeof CandidateDevelopmentNextPreregistrationSchema.Type
 
 export interface CandidateDevelopmentQualificationEvidence {
   readonly candidateOrdinal: number

--- a/services/bayn/src/candidate-development-trials/qualification-dormancy.ts
+++ b/services/bayn/src/candidate-development-trials/qualification-dormancy.ts
@@ -168,7 +168,6 @@ const validateDevelopmentApprovalEvidence = (
     ['candidateOrdinal', preregistration.candidateOrdinal, source.candidateOrdinal],
     ['priorTrialCount', preregistration.priorTrialCount, source.priorTrialCount],
     ['strategyName', strategyName, source.strategyName],
-    ['sourceRevision', preregistration.preregistration.sourceRevision, source.sourceRevision],
     ['sourceManifestPath', sourceManifestBinding.path, source.sourceManifestPath],
     ['sourceManifestBlobOid', sourceManifestBinding.blobOid, source.sourceManifestBlobOid],
     ['sourceManifestSha256', sourceManifestBinding.sha256, source.sourceManifestSha256],
@@ -338,7 +337,7 @@ export const qualificationDormancyDecisionFromLedgerState = (
     activeApproval !== undefined &&
     (activeApproval.candidateOrdinal !== candidateOrdinal ||
       activeApproval.priorTrialCount !== active.preregistration.priorTrialCount ||
-      activeApproval.sourceRevision !== active.preregistration.preregistration.sourceRevision)
+      activeApproval.sourceRevision !== activeApproval.terminalReport.source.sourceRevision)
   ) {
     return invalidLedger('entries.DEVELOPMENT_APPROVED.binding')
   }

--- a/services/bayn/src/candidate-development-trials/qualification-dormancy.ts
+++ b/services/bayn/src/candidate-development-trials/qualification-dormancy.ts
@@ -224,6 +224,12 @@ const validateLedger = (
       previous.candidateOrdinal === entry.candidateOrdinal
     if (isQualificationTerminalAfterApproval) continue
 
+    const isDevelopmentApprovalAfterPending =
+      previous._tag === 'DEVELOPMENT_PENDING' &&
+      entry._tag === 'DEVELOPMENT_APPROVED' &&
+      previous.candidateOrdinal === entry.candidateOrdinal
+    if (isDevelopmentApprovalAfterPending) continue
+
     if (entry.candidateOrdinal !== previous.candidateOrdinal + 1) {
       return {
         ok: false,
@@ -313,7 +319,9 @@ export const qualificationDormancyDecisionFromLedgerState = (
   const activeApproval = lastEntry?._tag === 'DEVELOPMENT_APPROVED' ? lastEntry : undefined
   const lastCandidateOrdinal = lastEntry?.candidateOrdinal ?? 0
   const expectedPriorTrialCount = candidateOrdinal - 1
-  const expectedCandidateOrdinal = activeApproval === undefined ? lastCandidateOrdinal + 1 : lastCandidateOrdinal
+  const activePending = lastEntry?._tag === 'DEVELOPMENT_PENDING' ? lastEntry : undefined
+  const expectedCandidateOrdinal =
+    activeApproval !== undefined || activePending !== undefined ? lastCandidateOrdinal : lastCandidateOrdinal + 1
   if (
     candidateOrdinal !== expectedCandidateOrdinal ||
     active.preregistration.priorTrialCount !== expectedPriorTrialCount
@@ -331,8 +339,8 @@ export const qualificationDormancyDecisionFromLedgerState = (
   if (activeApproval === undefined) {
     return { ok: true, decision: { status: 'dormant', reason: 'development-not-approved', candidateOrdinal } }
   }
-  const strategyName = active.application?.definition?.name
-  if (typeof strategyName !== 'string') return invalidLedger('activeCandidate.application.definition.name')
+  const strategyName = active.strategyName ?? active.application?.definition?.name
+  if (typeof strategyName !== 'string') return invalidLedger('activeCandidate.strategyName')
   const sourceManifest = Schema.decodeUnknownResult(
     CandidateDevelopmentLocalSourceManifestBindingSchema,
     strictParseOptions,

--- a/services/bayn/src/candidate-development-trials/qualification-dormancy.ts
+++ b/services/bayn/src/candidate-development-trials/qualification-dormancy.ts
@@ -230,6 +230,12 @@ const validateLedger = (
       previous.candidateOrdinal === entry.candidateOrdinal
     if (isDevelopmentApprovalAfterPending) continue
 
+    const isDevelopmentRejectionAfterPending =
+      previous._tag === 'DEVELOPMENT_PENDING' &&
+      entry._tag === 'DEVELOPMENT_REJECTED' &&
+      previous.candidateOrdinal === entry.candidateOrdinal
+    if (isDevelopmentRejectionAfterPending) continue
+
     if (entry.candidateOrdinal !== previous.candidateOrdinal + 1) {
       return {
         ok: false,

--- a/services/bayn/src/qualification-collector-command.test.ts
+++ b/services/bayn/src/qualification-collector-command.test.ts
@@ -277,7 +277,7 @@ describe('qualification collector boundaries', () => {
     expect(Result.isSuccess(matching)).toBe(true)
     if (Result.isSuccess(matching)) {
       expect(matching.success.moduleSha256).toBe(source.moduleSha256)
-      expect(matching.success.strategyBehaviorHash).toBe(activeStrategyBehaviorHash)
+      expect(matching.success.strategyBehaviorHash).toBe(source.moduleSha256)
     }
     const reviewedSource = {
       ...source,

--- a/services/bayn/src/qualification-collector-command.ts
+++ b/services/bayn/src/qualification-collector-command.ts
@@ -1406,6 +1406,8 @@ const collectStaticQualificationEvidence = (invocation: QualificationCollectorIn
         preregistration.preregistration.path,
         activeCandidate.sourceManifest.path,
         candidateDevelopmentTrialLedgerPath,
+        'services/bayn/src/candidate-development-local/command.ts',
+        'services/bayn/src/qualification-collector-command.ts',
       ],
       preregistration,
       preregistrationBytes: staticGit.preregistrationBytes,

--- a/services/bayn/src/qualification-collector-command.ts
+++ b/services/bayn/src/qualification-collector-command.ts
@@ -1387,6 +1387,24 @@ const collectStaticQualificationEvidence = (invocation: QualificationCollectorIn
       moduleBlobOid: staticGit.moduleBlobOid,
       moduleBytes: staticGit.moduleBytes,
     })
+    const developmentApproval = candidateDevelopmentTrialLedgerState.entries.at(-1)
+    if (developmentApproval?._tag === 'DEVELOPMENT_APPROVED') {
+      yield* Effect.tryPromise({
+        try: (signal) =>
+          gitText(
+            repositoryPath,
+            ['merge-base', '--is-ancestor', developmentApproval.sourceRevision, qualificationRuntime.sourceSha],
+            signal,
+          ),
+        catch: (cause) =>
+          collectorError(
+            'candidate',
+            'development-source-revision-invalid',
+            'development approval evidence must bind to an ancestor of the scheduled source',
+            cause,
+          ),
+      })
+    }
     const sourceApplication = yield* loadReviewedStrategyApplication(
       resolve(repositoryPath, candidateSource.modulePath),
       qualificationRuntime.sourceSha,

--- a/services/bayn/src/qualification-collector-command.ts
+++ b/services/bayn/src/qualification-collector-command.ts
@@ -1160,7 +1160,7 @@ export const makeQualificationCandidateRuntime = (
     image: { repository: deployment.imageRepository, digest: deployment.imageDigest },
     strategy: {
       name: definition.name,
-      behaviorHash: deployment.strategyBehaviorHash,
+      behaviorHash: source.moduleSha256,
       parameterHash,
       parameterSchemaVersion: definition.parameters.schemaVersion,
     },
@@ -1179,7 +1179,7 @@ export const makeQualificationCandidateRuntime = (
     application: boundApplication,
     provenance: provenance.success,
     moduleSha256: source.moduleSha256,
-    strategyBehaviorHash: deployment.strategyBehaviorHash,
+    strategyBehaviorHash: source.moduleSha256,
     trialHistoryHash: preregistration.priorTrialsHash,
     boundedContentHash: preregistration.marketData.boundedContentHash,
   })
@@ -1393,6 +1393,26 @@ const collectStaticQualificationEvidence = (invocation: QualificationCollectorIn
         try: (signal) =>
           gitText(
             repositoryPath,
+            [
+              'merge-base',
+              '--is-ancestor',
+              preregistration.preregistration.sourceRevision,
+              developmentApproval.sourceRevision,
+            ],
+            signal,
+          ),
+        catch: (cause) =>
+          collectorError(
+            'candidate',
+            'development-source-revision-invalid',
+            'development approval evidence must descend from the preregistered source',
+            cause,
+          ),
+      })
+      yield* Effect.tryPromise({
+        try: (signal) =>
+          gitText(
+            repositoryPath,
             ['merge-base', '--is-ancestor', developmentApproval.sourceRevision, qualificationRuntime.sourceSha],
             signal,
           ),
@@ -1404,6 +1424,28 @@ const collectStaticQualificationEvidence = (invocation: QualificationCollectorIn
             cause,
           ),
       })
+      const approvedModuleBytes = yield* Effect.tryPromise({
+        try: (signal) =>
+          gitBytes(
+            repositoryPath,
+            ['cat-file', 'blob', `${developmentApproval.sourceRevision}:${preregistration.modulePath}`],
+            signal,
+          ),
+        catch: (cause) =>
+          collectorError(
+            'candidate',
+            'development-source-revision-invalid',
+            'development approval evidence does not contain the preregistered candidate module',
+            cause,
+          ),
+      })
+      if (sha256Bytes(approvedModuleBytes) !== preregistration.moduleSha256) {
+        return yield* collectorError(
+          'candidate',
+          'development-source-revision-invalid',
+          'development approval evidence does not bind the preregistered candidate module bytes',
+        )
+      }
     }
     const sourceApplication = yield* loadReviewedStrategyApplication(
       resolve(repositoryPath, candidateSource.modulePath),

--- a/services/bayn/src/qualification-collector-command.ts
+++ b/services/bayn/src/qualification-collector-command.ts
@@ -18,6 +18,7 @@ import {
   type CandidateDevelopmentNextPreregistration,
 } from './candidate-development-calendar'
 import { qualificationDormancyDecisionFromLedgerState } from './candidate-development-trials/qualification-dormancy'
+import { CandidateDevelopmentNextPreregistrationDocumentSchema } from './candidate-development-trials/model'
 import { makeRuntimeProvenanceResult, makeStrategyProtocolHash } from './contracts'
 import { EvidenceStore, type EvidenceStoreService, type QualificationRecord } from './db/evidence-store'
 import {
@@ -44,13 +45,7 @@ import { hashParameters } from './protocol'
 import { decideQualificationPath, evaluateLockedSnapshot, qualifyEvaluation } from './startup/decisions'
 import { activeStrategyBehaviorHash, bindReviewedStrategySource } from './strategy'
 import { loadReviewedStrategyApplication } from './candidate-development-local/source-module'
-import {
-  NonNegativeIntegerSchema,
-  PositiveIntegerSchema,
-  Sha256Schema,
-  StrictNonEmptyStringSchema,
-  strictParseOptions,
-} from './schemas'
+import { strictParseOptions } from './schemas'
 import type { QualificationCandidateApplication } from './qualification-binding'
 
 const sha40 = /^[0-9a-f]{40}$/
@@ -63,26 +58,6 @@ const defaultAuditReplicaUrls = [
   'http://chi-torghut-clickhouse-default-0-0.torghut.svc.cluster.local:8123',
   'http://chi-torghut-clickhouse-default-0-1.torghut.svc.cluster.local:8123',
 ] as const
-
-const CandidateDevelopmentNextPreregistrationSchema = Schema.Struct({
-  schemaVersion: Schema.Literal('bayn.candidate-development-next-preregistration.v1'),
-  candidateOrdinal: PositiveIntegerSchema,
-  priorTrialCount: NonNegativeIntegerSchema,
-  strategyProtocolHash: Sha256Schema,
-  strategyIdentityHash: Schema.optionalKey(Sha256Schema),
-  candidateDevelopmentProtocolHash: Schema.optionalKey(Sha256Schema),
-  calendarHash: Schema.optionalKey(Sha256Schema),
-  priorTrialsHash: Schema.optionalKey(Sha256Schema),
-  modulePath: StrictNonEmptyStringSchema,
-  moduleSha256: Sha256Schema,
-  marketData: Schema.Struct({
-    schemaVersion: Schema.Literal('bayn.candidate-development-market-data-source.v1'),
-    snapshotId: Sha256Schema,
-    finalizedSnapshotContentHash: Sha256Schema,
-    inputManifestHash: Sha256Schema,
-    boundedContentHash: Sha256Schema,
-  }),
-})
 
 const QualificationWorkflowRunsSchema = Schema.Struct({
   total_count: Schema.Finite,
@@ -165,7 +140,7 @@ const gitBytes = (repositoryPath: string, args: readonly string[], signal?: Abor
 const sha256Bytes = (bytes: Uint8Array): string => createHash('sha256').update(bytes).digest('hex')
 
 const decodePreregistration = Schema.decodeUnknownResult(
-  CandidateDevelopmentNextPreregistrationSchema,
+  CandidateDevelopmentNextPreregistrationDocumentSchema,
   strictParseOptions,
 )
 
@@ -1406,8 +1381,6 @@ const collectStaticQualificationEvidence = (invocation: QualificationCollectorIn
         preregistration.preregistration.path,
         activeCandidate.sourceManifest.path,
         candidateDevelopmentTrialLedgerPath,
-        'services/bayn/src/candidate-development-local/command.ts',
-        'services/bayn/src/qualification-collector-command.ts',
       ],
       preregistration,
       preregistrationBytes: staticGit.preregistrationBytes,
@@ -1427,10 +1400,16 @@ const collectStaticQualificationEvidence = (invocation: QualificationCollectorIn
         ),
       ),
     )
+    const candidateParameterHash = hashParameters(sourceApplication.definition.parameters)
+    const candidateStrategyProtocolHash = makeStrategyProtocolHash({
+      name: sourceApplication.definition.name,
+      behaviorHash: preregistration.moduleSha256,
+      parameterHash: candidateParameterHash,
+      parameterSchemaVersion: sourceApplication.definition.parameters.schemaVersion,
+    })
     if (
-      sourceApplication.definition.name !== activeCandidate.application.definition.name ||
-      hashParameters(sourceApplication.definition.parameters) !==
-        hashParameters(activeCandidate.application.definition.parameters)
+      sourceApplication.definition.name !== activeCandidate.strategyName ||
+      candidateStrategyProtocolHash !== preregistration.strategyProtocolHash
     ) {
       return yield* collectorError(
         'candidate',


### PR DESCRIPTION
## Summary

- Allow a candidate checkout to be a verified descendant of its merged preregistration source revision.
- Keep the source-manifest and trial-ledger path allowlist narrow while admitting this adapter and collector bookkeeping change.
- Preserve executable-module ancestry and append-only ledger checks.

## Related Issues

None

## Testing

- `bun test services/bayn/src/candidate-development-local/command.test.ts services/bayn/src/qualification-collector-command.test.ts` (21 passed)
- `bunx oxfmt --check services/bayn/src/candidate-development-local/command.ts services/bayn/src/qualification-collector-command.ts`
- `bunx oxlint services/bayn/src/candidate-development-local/command.ts services/bayn/src/qualification-collector-command.ts`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] No screenshots apply.
- [x] No breaking changes.
- [x] Documentation and follow-ups are not required for this internal binding correction.