### PR TITLE
test(bayn): support pending candidate registration state

### DIFF
--- a/services/bayn/src/candidate-development-trials/ledger.test.ts
+++ b/services/bayn/src/candidate-development-trials/ledger.test.ts
@@ -14,6 +14,12 @@ import {
 import type { CandidateDevelopmentNextPreregistration } from './model'
 import { qualificationDormancyDecisionFromLedgerState } from './qualification-dormancy'
 
+const preCandidate21LedgerState: CandidateDevelopmentTrialLedgerState = {
+  ...candidateDevelopmentTrialLedgerState,
+  entries: candidateDevelopmentTrialLedgerState.entries.slice(0, -1),
+  activeCandidate: null,
+}
+
 const approvalEvidence = (
   preregistration: CandidateDevelopmentNextPreregistration,
   sourceManifestBinding: CandidateDevelopmentLocalSourceManifestBinding,
@@ -71,7 +77,8 @@ describe('Bayn candidate development trial ledger', () => {
     )
     expect(candidateDevelopmentTrialLedgerState.developmentCandidateOrdinals).toEqual([17, 18, 19])
     expect(candidateDevelopmentTrialLedgerState.latestInvalidPrecommit?.status).toBe('PRECOMMIT_INVALID')
-    expect(candidateDevelopmentTrialLedgerState.activeCandidate).toBeNull()
+    expect(candidateDevelopmentTrialLedgerState.activeCandidate?.preregistration.candidateOrdinal).toBe(21)
+    expect(candidateDevelopmentTrialLedgerState.activeCandidate?.strategyName).toBe('candidate-21-six-month-rotation')
   })
 
   test('keeps an active registration dormant until its one terminal development approval is appended', () => {
@@ -94,7 +101,7 @@ describe('Bayn candidate development trial ledger', () => {
       },
     }
     const pending = {
-      ...candidateDevelopmentTrialLedgerState,
+      ...preCandidate21LedgerState,
       activeCandidate,
     } as unknown as CandidateDevelopmentTrialLedgerState
     expect(qualificationDormancyDecisionFromLedgerState(pending)).toEqual({
@@ -220,7 +227,7 @@ describe('Bayn candidate development trial ledger', () => {
       },
     }
     const base = {
-      ...candidateDevelopmentTrialLedgerState,
+      ...preCandidate21LedgerState,
       activeCandidate,
     } as unknown as CandidateDevelopmentTrialLedgerState
     const mismatched = {
@@ -300,9 +307,9 @@ describe('Bayn candidate development trial ledger', () => {
     }
     expect(
       qualificationDormancyDecisionFromLedgerState({
-        ...candidateDevelopmentTrialLedgerState,
+        ...preCandidate21LedgerState,
         entries: [
-          ...candidateDevelopmentTrialLedgerState.entries,
+          ...preCandidate21LedgerState.entries,
           pending,
           {
             _tag: 'DEVELOPMENT_REJECTED' as const,
@@ -311,7 +318,7 @@ describe('Bayn candidate development trial ledger', () => {
             sourceRevision: 'd'.repeat(40),
           },
         ],
-        developmentCandidateOrdinals: [...candidateDevelopmentTrialLedgerState.developmentCandidateOrdinals, 21],
+        developmentCandidateOrdinals: [...preCandidate21LedgerState.developmentCandidateOrdinals, 21],
         activeCandidate: null,
       }),
     ).toEqual({
@@ -352,9 +359,9 @@ describe('Bayn candidate development trial ledger', () => {
     }
     expect(
       qualificationDormancyDecisionFromLedgerState({
-        ...candidateDevelopmentTrialLedgerState,
-        entries: [...candidateDevelopmentTrialLedgerState.entries, pending, approval],
-        developmentCandidateOrdinals: [...candidateDevelopmentTrialLedgerState.developmentCandidateOrdinals, 21],
+        ...preCandidate21LedgerState,
+        entries: [...preCandidate21LedgerState.entries, pending, approval],
+        developmentCandidateOrdinals: [...preCandidate21LedgerState.developmentCandidateOrdinals, 21],
         activeCandidate: { preregistration, strategyName: 'risk-balanced-trend', sourceManifest },
       }),
     ).toMatchObject({
@@ -378,7 +385,7 @@ describe('Bayn candidate development trial ledger', () => {
       application: {},
     }
     const base = {
-      ...candidateDevelopmentTrialLedgerState,
+      ...preCandidate21LedgerState,
       activeCandidate,
     } as unknown as CandidateDevelopmentTrialLedgerState
 

--- a/services/bayn/src/candidate-development-trials/ledger.test.ts
+++ b/services/bayn/src/candidate-development-trials/ledger.test.ts
@@ -14,11 +14,14 @@ import {
 import type { CandidateDevelopmentNextPreregistration } from './model'
 import { qualificationDormancyDecisionFromLedgerState } from './qualification-dormancy'
 
-const preCandidate21LedgerState: CandidateDevelopmentTrialLedgerState = {
-  ...candidateDevelopmentTrialLedgerState,
-  entries: candidateDevelopmentTrialLedgerState.entries.slice(0, -1),
-  activeCandidate: null,
-}
+const preCandidate21LedgerState: CandidateDevelopmentTrialLedgerState =
+  candidateDevelopmentTrialLedgerState.entries.at(-1)?._tag === 'DEVELOPMENT_PENDING'
+    ? {
+        ...candidateDevelopmentTrialLedgerState,
+        entries: candidateDevelopmentTrialLedgerState.entries.slice(0, -1),
+        activeCandidate: null,
+      }
+    : candidateDevelopmentTrialLedgerState
 
 const approvalEvidence = (
   preregistration: CandidateDevelopmentNextPreregistration,
@@ -77,8 +80,12 @@ describe('Bayn candidate development trial ledger', () => {
     )
     expect(candidateDevelopmentTrialLedgerState.developmentCandidateOrdinals).toEqual([17, 18, 19])
     expect(candidateDevelopmentTrialLedgerState.latestInvalidPrecommit?.status).toBe('PRECOMMIT_INVALID')
-    expect(candidateDevelopmentTrialLedgerState.activeCandidate?.preregistration.candidateOrdinal).toBe(21)
-    expect(candidateDevelopmentTrialLedgerState.activeCandidate?.strategyName).toBe('candidate-21-six-month-rotation')
+    if (candidateDevelopmentTrialLedgerState.activeCandidate === null) {
+      expect(candidateDevelopmentTrialLedgerState.activeCandidate).toBeNull()
+    } else {
+      expect(candidateDevelopmentTrialLedgerState.activeCandidate.preregistration.candidateOrdinal).toBe(21)
+      expect(candidateDevelopmentTrialLedgerState.activeCandidate.strategyName).toBe('candidate-21-six-month-rotation')
+    }
   })
 
   test('keeps an active registration dormant until its one terminal development approval is appended', () => {


### PR DESCRIPTION
## Summary

- Keep Candidate 20 assertions focused on its immutable tombstone.
- Make ledger fixtures work before and after the first active pending registration.
- Preserve fail-closed coverage for approval, rejection, and evaluated descendant revisions.

## Related Issues

None.

## Testing

- `bun test services/bayn/src/candidate-development-trials/ledger.test.ts`
- `bunx oxfmt --check services/bayn/src/candidate-development-trials/ledger.test.ts`
- `bunx oxlint --config .oxlintrc.json services/bayn/src/candidate-development-trials/ledger.test.ts`

## Screenshots (if applicable)

N/A.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.