### PR TITLE
fix(bayn): verify registered source manifest bytes

### DIFF
--- a/services/bayn/src/qualification-collector-command.test.ts
+++ b/services/bayn/src/qualification-collector-command.test.ts
@@ -17,6 +17,7 @@ import {
   qualificationAttemptState,
   QualificationCollectorError,
   runQualificationCollector,
+  sourceManifestBindingMatches,
   verifyQualificationCandidateSource,
   type QualificationCollectorExecutionReceipt,
   type QualificationCollectorPrelockEvidence,
@@ -339,6 +340,17 @@ describe('qualification collector boundaries', () => {
   test('reports missing wiring without exposing secret values', () => {
     expect(missingQualificationWiring({})).toContain('GITHUB_TOKEN')
     expect(missingQualificationWiring({ GITHUB_TOKEN: 'secret' })).not.toContain('GITHUB_TOKEN')
+  })
+
+  test('requires the scheduled source manifest to match its registered blob and bytes', () => {
+    const bytes = Buffer.from('{"candidateOrdinal":21}\n')
+    const binding = {
+      blobOid: 'a'.repeat(40),
+      sha256: createHash('sha256').update(bytes).digest('hex'),
+    }
+    expect(sourceManifestBindingMatches(binding, binding.blobOid, bytes)).toBe(true)
+    expect(sourceManifestBindingMatches(binding, 'b'.repeat(40), bytes)).toBe(false)
+    expect(sourceManifestBindingMatches(binding, binding.blobOid, Buffer.from('changed\n'))).toBe(false)
   })
 
   test('rejects malformed or source-mismatched preregistration bytes before any evaluation', async () => {

--- a/services/bayn/src/qualification-collector-command.ts
+++ b/services/bayn/src/qualification-collector-command.ts
@@ -139,6 +139,12 @@ const gitBytes = (repositoryPath: string, args: readonly string[], signal?: Abor
 
 const sha256Bytes = (bytes: Uint8Array): string => createHash('sha256').update(bytes).digest('hex')
 
+export const sourceManifestBindingMatches = (
+  binding: { readonly blobOid: string; readonly sha256: string },
+  observedBlobOid: string,
+  observedBytes: Uint8Array,
+): boolean => binding.blobOid === observedBlobOid && binding.sha256 === sha256Bytes(observedBytes)
+
 const decodePreregistration = Schema.decodeUnknownResult(
   CandidateDevelopmentNextPreregistrationDocumentSchema,
   strictParseOptions,
@@ -1292,6 +1298,8 @@ const collectStaticQualificationEvidence = (invocation: QualificationCollectorIn
           preregistrationBlobOid,
           moduleBlobOid,
           moduleBytes,
+          sourceManifestBlobOid,
+          sourceManifestBytes,
         ] = await Promise.all([
           gitText(repositoryPath, ['rev-parse', '--show-toplevel'], signal).then(realpath),
           gitText(repositoryPath, ['rev-parse', 'HEAD'], signal),
@@ -1322,6 +1330,16 @@ const collectStaticQualificationEvidence = (invocation: QualificationCollectorIn
             ['cat-file', 'blob', `${qualificationRuntime.sourceSha}:${preregistration.modulePath}`],
             signal,
           ),
+          gitText(
+            repositoryPath,
+            ['rev-parse', `${qualificationRuntime.sourceSha}:${activeCandidate.sourceManifest.path}`],
+            signal,
+          ),
+          gitBytes(
+            repositoryPath,
+            ['cat-file', 'blob', `${qualificationRuntime.sourceSha}:${activeCandidate.sourceManifest.path}`],
+            signal,
+          ),
         ])
         return {
           topLevel,
@@ -1333,6 +1351,8 @@ const collectStaticQualificationEvidence = (invocation: QualificationCollectorIn
           preregistrationBlobOid,
           moduleBlobOid,
           moduleBytes,
+          sourceManifestBlobOid,
+          sourceManifestBytes,
         }
       },
       catch: (cause) =>
@@ -1371,6 +1391,19 @@ const collectStaticQualificationEvidence = (invocation: QualificationCollectorIn
         'repository',
         'preregistration-source-mismatch',
         'preregistration document or candidate module differs from the reviewed immutable source',
+      )
+    }
+    if (
+      !sourceManifestBindingMatches(
+        activeCandidate.sourceManifest,
+        staticGit.sourceManifestBlobOid,
+        staticGit.sourceManifestBytes,
+      )
+    ) {
+      return yield* collectorError(
+        'repository',
+        'source-manifest-mismatch',
+        'source manifest differs from the active candidate registration',
       )
     }
     const candidateSource = yield* verifyQualificationCandidateSource({


### PR DESCRIPTION
## Summary

- Verify the active candidate source-manifest blob ID and SHA-256 at the exact scheduled main revision.
- Fail closed when manifest bytes drift from the append-only registration.
- Add focused coverage for matching and mismatching manifest identity.

## Related Issues

None.

## Testing

- `bun test services/bayn/src/qualification-collector-command.test.ts services/bayn/src/candidate-development-trials/ledger.test.ts`
- `bun run --filter @proompteng/bayn lint:effect`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bunx oxfmt --check services/bayn/src/qualification-collector-command.ts services/bayn/src/qualification-collector-command.test.ts`
- `bunx oxlint --config .oxlintrc.json services/bayn/src/qualification-collector-command.ts services/bayn/src/qualification-collector-command.test.ts`

## Screenshots (if applicable)

N/A.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.