### PR TITLE
feat(bayn): register Candidate 21 executable source

### DIFF
--- a/services/bayn/candidates/ordinal-21-source-manifest.json
+++ b/services/bayn/candidates/ordinal-21-source-manifest.json
@@ -1,0 +1,17 @@
+{
+  "schemaVersion": "bayn.candidate-development-source-manifest.v2",
+  "candidateOrdinal": 21,
+  "priorTrialCount": 20,
+  "trialHistoryHash": "295eff4120c4d3deb33e09e3948bc5a670b55a836dc6be6849b2eea979e60008",
+  "strategyName": "candidate-21-six-month-rotation",
+  "strategyProtocolHash": "9f03db47df47cb133b922c795b9cbd5c5b78e3d6d3411ec74e303d7f193f81fe",
+  "modulePath": "services/bayn/src/strategy/candidate-21.ts",
+  "moduleSha256": "929ce699203425b95a06597c98fbbff3d124dda5da68e187ebb1f289d9ded5b1",
+  "moduleFormat": "typescript-strategy-application-v1",
+  "marketData": {
+    "schemaVersion": "bayn.candidate-development-market-data-source.v2",
+    "snapshotId": "2a91f0177684f7022f746207333e510c8268f9b77a04b778a04220a33ccf79e0",
+    "inputManifestHash": "1e5377336f2e6feb751000114b81cc89aee5be7542e213c320f2cfbb4185bb2b",
+    "boundedContentHash": "b6052c8ebdca855973adf4e41efafb5028fd8dbbaa70809331f6017519b1c995"
+  }
+}

--- a/services/bayn/src/candidate-development-trials/ledger.ts
+++ b/services/bayn/src/candidate-development-trials/ledger.ts
@@ -100,6 +100,40 @@ const historicalLedger = [
     metricBearingAttemptsConsumed: 0 as const,
     qualificationAttemptConsumed: false as const,
   },
+  {
+    _tag: 'DEVELOPMENT_PENDING' as const,
+    candidateOrdinal: 21,
+    priorTrialCount: 20,
+    strategyName: 'candidate-21-six-month-rotation',
+    preregistration: {
+      schemaVersion: 'bayn.candidate-development-next-preregistration.v1' as const,
+      candidateOrdinal: 21,
+      priorTrialCount: 20,
+      strategyProtocolHash: '9f03db47df47cb133b922c795b9cbd5c5b78e3d6d3411ec74e303d7f193f81fe',
+      candidateDevelopmentProtocolHash: '41fb58503e94222ea98d5e929f431a31ad6a1720ff7eb88a5f7935396a254769',
+      calendarHash: '4b2f519f336e4e730c1f0d69e860f25a8d4d0cfbd8e93c6b333ea83623d87237',
+      priorTrialsHash: '295eff4120c4d3deb33e09e3948bc5a670b55a836dc6be6849b2eea979e60008',
+      modulePath: 'services/bayn/src/strategy/candidate-21.ts',
+      moduleSha256: '929ce699203425b95a06597c98fbbff3d124dda5da68e187ebb1f289d9ded5b1',
+      marketData: {
+        schemaVersion: 'bayn.candidate-development-market-data-source.v1' as const,
+        snapshotId: '2a91f0177684f7022f746207333e510c8268f9b77a04b778a04220a33ccf79e0',
+        finalizedSnapshotContentHash: '8e376546f6a6cc1dbe2e910db3d68f584fc0bd9c4858166042ce32aa077eed0d',
+        inputManifestHash: '1e5377336f2e6feb751000114b81cc89aee5be7542e213c320f2cfbb4185bb2b',
+        boundedContentHash: 'b6052c8ebdca855973adf4e41efafb5028fd8dbbaa70809331f6017519b1c995',
+      },
+      preregistration: {
+        sourceRevision: '90e7bd810923d31fef75caaab95ddebf89fe7bfc',
+        path: 'services/bayn/candidates/ordinal-21-six-month-rotation-preregistration.json',
+        blobOid: 'bba3ffb476aa763a31cc69f545f8fbf9a3eda11d',
+      },
+    },
+    sourceManifest: {
+      path: 'services/bayn/candidates/ordinal-21-source-manifest.json',
+      blobOid: '0e19efebffc2f060aa1be894be0a24b60605c184',
+      sha256: 'b6cf022eba56430c6418dc8a9bdbfd00e78dddcb4825f1e0a7853c8e3dbdcd98',
+    },
+  },
 ] as const
 
 /** One append-only source-controlled ledger. Candidate 20 is represented once as the terminal tombstone entry. */

--- a/services/bayn/src/strategy/candidate-21.ts
+++ b/services/bayn/src/strategy/candidate-21.ts
@@ -1,0 +1,160 @@
+import { Result, pipe } from 'effect'
+
+import { decodeDefaultProtocol } from '../protocol'
+import type { DecisionPlan, Protocol } from '../types'
+import { annualizedPortfolioVolatility } from './risk-balanced-trend/risk'
+import {
+  makeRiskBalancedTrendApplication,
+  type RiskBalancedTrendMarketContext,
+  type RiskBalancedTrendStrategyDefinition,
+} from './risk-balanced-trend'
+import { makeRiskBalancedTrendDecision } from './risk-balanced-trend/decision'
+import { dailyReturns } from './risk-balanced-trend/shared'
+import type { RiskBalancedTrendFailure } from '../risk-balanced-trend/model'
+
+const protocol = Result.getOrThrow(decodeDefaultProtocol())
+
+const sixMonthHorizon = 126
+const rotationSymbols = ['DBC', 'VNQ'] as const
+const defensiveSymbol = 'IEF' as const
+
+const fail = <A = never>(failure: RiskBalancedTrendFailure): Result.Result<A, RiskBalancedTrendFailure> =>
+  Result.fail(failure)
+
+const invalidClose = (symbol: string, index: number, value: number): Result.Result<never, RiskBalancedTrendFailure> =>
+  fail({
+    _tag: 'InvalidRiskBalancedTrendClose',
+    symbol,
+    index,
+    value,
+  })
+
+const closeHistory = (
+  context: RiskBalancedTrendMarketContext,
+  symbol: string,
+): Result.Result<readonly number[], RiskBalancedTrendFailure> => {
+  const closes = context.closes[symbol]
+  if (closes === undefined || closes.length !== context.sessionDates.length) {
+    return fail({
+      _tag: 'RiskBalancedTrendCloseHistoryMismatch',
+      symbol,
+      expectedCount: context.sessionDates.length,
+      observedCount: closes?.length ?? 0,
+    })
+  }
+  const invalidIndex = closes.findIndex((close) => !Number.isFinite(close) || close <= 0)
+  return invalidIndex < 0
+    ? Result.succeed(closes)
+    : invalidClose(symbol, invalidIndex, closes.at(invalidIndex) ?? Number.NaN)
+}
+
+const sixMonthReturn = (
+  context: RiskBalancedTrendMarketContext,
+  symbol: string,
+): Result.Result<number, RiskBalancedTrendFailure> =>
+  pipe(
+    closeHistory(context, symbol),
+    Result.flatMap((closes) => {
+      const current = closes.at(-1)
+      const prior = closes.at(-1 - sixMonthHorizon)
+      if (current === undefined || prior === undefined) {
+        return fail({
+          _tag: 'MissingRiskBalancedTrendClose',
+          symbol,
+          horizonSessions: sixMonthHorizon,
+        })
+      }
+      const value = current / prior - 1
+      return Number.isFinite(value)
+        ? Result.succeed(value)
+        : fail({
+            _tag: 'InvalidRiskBalancedTrendNumber',
+            operation: 'horizon-return',
+            value,
+            symbol,
+            reason: 'not-finite',
+          })
+    }),
+  )
+
+const selectedRotationSymbol = (returns: Readonly<Record<string, number>>): string | null => {
+  const winner = [...rotationSymbols]
+    .map((symbol) => ({ symbol, value: returns[symbol] ?? Number.NEGATIVE_INFINITY }))
+    .sort((left, right) => right.value - left.value || left.symbol.localeCompare(right.symbol))
+    .find(({ value }) => value > 0)
+  return winner?.symbol ?? ((returns[defensiveSymbol] ?? Number.NEGATIVE_INFINITY) > 0 ? defensiveSymbol : null)
+}
+
+const candidate21Decision = (
+  context: RiskBalancedTrendMarketContext,
+  candidateProtocol: Protocol,
+): Result.Result<DecisionPlan, RiskBalancedTrendFailure> =>
+  pipe(
+    makeRiskBalancedTrendDecision(context.signalDate, context.sessionDates, context.closes, candidateProtocol),
+    Result.flatMap((baseDecision) =>
+      pipe(
+        Result.all(
+          candidateProtocol.universe.map((symbol) =>
+            pipe(
+              sixMonthReturn(context, symbol),
+              Result.map((value) => [symbol, value] as const),
+            ),
+          ),
+        ),
+        Result.flatMap((returnEntries) => {
+          const returns = Object.fromEntries(returnEntries)
+          const selected = selectedRotationSymbol(returns)
+          const targetWeights = Object.fromEntries(
+            candidateProtocol.universe.map((symbol) => [
+              symbol,
+              symbol === selected ? candidateProtocol.maximumSymbolWeight : 0,
+            ]),
+          )
+          return pipe(
+            Result.all(
+              candidateProtocol.universe.map((symbol) =>
+                pipe(
+                  closeHistory(context, symbol),
+                  Result.flatMap((closes) => dailyReturns(closes, candidateProtocol.volatilityWindow, symbol)),
+                  Result.map((values) => [symbol, values] as const),
+                ),
+              ),
+            ),
+            Result.flatMap((returnSeries) =>
+              pipe(
+                annualizedPortfolioVolatility(targetWeights, Object.fromEntries(returnSeries)),
+                Result.map((estimatedAnnualizedPortfolioVolatility) => ({
+                  ...baseDecision,
+                  estimatedAnnualizedPortfolioVolatility,
+                  exposureScale: 1,
+                  targetWeights,
+                  signals: baseDecision.signals.map((signal) => {
+                    const score = returns[signal.symbol] ?? 0
+                    const targetWeight = targetWeights[signal.symbol] ?? 0
+                    return {
+                      ...signal,
+                      compositeScore: score,
+                      positiveScore: Math.max(0, score),
+                      eligible: signal.symbol === selected,
+                      uncappedWeight: targetWeight,
+                      cappedWeight: targetWeight,
+                      targetWeight,
+                    }
+                  }),
+                })),
+              ),
+            ),
+          )
+        }),
+      ),
+    ),
+  )
+
+const definition: RiskBalancedTrendStrategyDefinition = {
+  name: 'candidate-21-six-month-rotation',
+  parameters: protocol,
+  decide: ({ market }) => candidate21Decision(market, protocol),
+}
+
+/** Candidate 21 is a result-blind, source-controlled application; its witness is supplied only by the adapter. */
+export const strategyApplication = makeRiskBalancedTrendApplication(protocol, definition)


### PR DESCRIPTION
## Summary

- Add the result-blind Candidate 21 strategy application and exact source manifest.
- Append one `DEVELOPMENT_PENDING` ledger registration bound to the preregistration, module, manifest, market witness, and current reviewed main ancestor.
- Keep the candidate descendant limited to the module, manifest, and append-only ledger data.

## Related Issues

None.

## Testing

- `bun test services/bayn/src/candidate-development-trials/ledger.test.ts services/bayn/src/candidate-development-local/command.test.ts services/bayn/src/qualification-collector-command.test.ts`
- `bun run --filter @proompteng/bayn lint:effect`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bunx oxfmt --check services/bayn/src/candidate-development-trials/ledger.ts services/bayn/src/strategy/candidate-21.ts services/bayn/candidates/ordinal-21-source-manifest.json`
- `bunx oxlint --config .oxlintrc.json services/bayn/src/candidate-development-trials/ledger.ts services/bayn/src/strategy/candidate-21.ts`
- Exact descendant audit: `git diff --name-only 90e7bd810923d31fef75caaab95ddebf89fe7bfc..HEAD` returns only the three approved paths.

## Screenshots (if applicable)

N/A.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.