### PR TITLE
feat(bayn): register Candidate 21 capped source

### DIFF
--- a/packages/scripts/src/bayn/verify-qualification-dormancy.test.ts
+++ b/packages/scripts/src/bayn/verify-qualification-dormancy.test.ts
@@ -25,8 +25,8 @@ describe('qualification dormancy command', () => {
     const decision = await verifyQualificationDormancy(repositoryRoot)
     expect(decision).toEqual({
       status: 'dormant',
-      reason: 'precommit-invalid-unattempted',
-      candidateOrdinal: 20,
+      reason: 'development-not-approved',
+      candidateOrdinal: 21,
     })
   })
 
@@ -84,7 +84,7 @@ describe('qualification dormancy command', () => {
       expect(stderr).toBe('')
       expect(stdout).toContain('"status":"dormant"')
       expect(await readFile(githubOutput, 'utf8')).toBe(
-        'eligible=false\ndormant=true\nreason=precommit-invalid-unattempted\ncandidate_ordinal=20\n',
+        'eligible=false\ndormant=true\nreason=development-not-approved\ncandidate_ordinal=21\n',
       )
     } finally {
       await rm(directory, { recursive: true, force: true })

--- a/services/bayn/candidates/ordinal-21-source-manifest.json
+++ b/services/bayn/candidates/ordinal-21-source-manifest.json
@@ -1,0 +1,17 @@
+{
+  "schemaVersion": "bayn.candidate-development-source-manifest.v2",
+  "candidateOrdinal": 21,
+  "priorTrialCount": 20,
+  "trialHistoryHash": "295eff4120c4d3deb33e09e3948bc5a670b55a836dc6be6849b2eea979e60008",
+  "strategyName": "candidate-21-six-month-rotation",
+  "strategyProtocolHash": "fd0a271c22691770246e16ca5aa38ba5b9c546d4070ae5382e8a79f40d5c2bd5",
+  "modulePath": "services/bayn/src/strategy/candidate-21.ts",
+  "moduleSha256": "e77081c2c6904a67b293334b6e051d76dd634974ec0055dd099e5c4d84985b06",
+  "moduleFormat": "typescript-strategy-application-v1",
+  "marketData": {
+    "schemaVersion": "bayn.candidate-development-market-data-source.v2",
+    "snapshotId": "2a91f0177684f7022f746207333e510c8268f9b77a04b778a04220a33ccf79e0",
+    "inputManifestHash": "1e5377336f2e6feb751000114b81cc89aee5be7542e213c320f2cfbb4185bb2b",
+    "boundedContentHash": "b6052c8ebdca855973adf4e41efafb5028fd8dbbaa70809331f6017519b1c995"
+  }
+}

--- a/services/bayn/src/candidate-development-trials/ledger.ts
+++ b/services/bayn/src/candidate-development-trials/ledger.ts
@@ -100,6 +100,40 @@ const historicalLedger = [
     metricBearingAttemptsConsumed: 0 as const,
     qualificationAttemptConsumed: false as const,
   },
+  {
+    _tag: 'DEVELOPMENT_PENDING' as const,
+    candidateOrdinal: 21,
+    priorTrialCount: 20,
+    strategyName: 'candidate-21-six-month-rotation',
+    preregistration: {
+      schemaVersion: 'bayn.candidate-development-next-preregistration.v1' as const,
+      candidateOrdinal: 21,
+      priorTrialCount: 20,
+      strategyProtocolHash: 'fd0a271c22691770246e16ca5aa38ba5b9c546d4070ae5382e8a79f40d5c2bd5',
+      candidateDevelopmentProtocolHash: '05c4f3247252d4c3d724593b5c2f654c5b9a11974f865f5d68dac44a792b1b61',
+      calendarHash: '4b2f519f336e4e730c1f0d69e860f25a8d4d0cfbd8e93c6b333ea83623d87237',
+      priorTrialsHash: '295eff4120c4d3deb33e09e3948bc5a670b55a836dc6be6849b2eea979e60008',
+      modulePath: 'services/bayn/src/strategy/candidate-21.ts',
+      moduleSha256: 'e77081c2c6904a67b293334b6e051d76dd634974ec0055dd099e5c4d84985b06',
+      marketData: {
+        schemaVersion: 'bayn.candidate-development-market-data-source.v1' as const,
+        snapshotId: '2a91f0177684f7022f746207333e510c8268f9b77a04b778a04220a33ccf79e0',
+        finalizedSnapshotContentHash: '8e376546f6a6cc1dbe2e910db3d68f584fc0bd9c4858166042ce32aa077eed0d',
+        inputManifestHash: '1e5377336f2e6feb751000114b81cc89aee5be7542e213c320f2cfbb4185bb2b',
+        boundedContentHash: 'b6052c8ebdca855973adf4e41efafb5028fd8dbbaa70809331f6017519b1c995',
+      },
+      preregistration: {
+        sourceRevision: 'fd16d1523a74e282846dcf465d375c77e2d40e77',
+        path: 'services/bayn/candidates/ordinal-21-six-month-rotation-preregistration.json',
+        blobOid: 'f61534e914c854aec0c19c28cfd24490e59f36c7',
+      },
+    },
+    sourceManifest: {
+      path: 'services/bayn/candidates/ordinal-21-source-manifest.json',
+      blobOid: '623a59e183a6700fbde8600629f87ea2b14b59fd',
+      sha256: '0613547be32377af4431b87476b7cee15af107f7860fbc5cff346763c5b9150c',
+    },
+  },
 ] as const
 
 /** One append-only source-controlled ledger. Candidate 20 is represented once as the terminal tombstone entry. */

--- a/services/bayn/src/candidate-development-trials/ledger.ts
+++ b/services/bayn/src/candidate-development-trials/ledger.ts
@@ -123,7 +123,7 @@ const historicalLedger = [
         boundedContentHash: 'b6052c8ebdca855973adf4e41efafb5028fd8dbbaa70809331f6017519b1c995',
       },
       preregistration: {
-        sourceRevision: '3c42ea0b783fcc6cb3fe6693bf82330bf42b9734',
+        sourceRevision: 'f9c90e5158212d862ca4b64cf9624fe424f09ba6',
         path: 'services/bayn/candidates/ordinal-21-six-month-rotation-preregistration.json',
         blobOid: 'f61534e914c854aec0c19c28cfd24490e59f36c7',
       },

--- a/services/bayn/src/candidate-development-trials/ledger.ts
+++ b/services/bayn/src/candidate-development-trials/ledger.ts
@@ -123,7 +123,7 @@ const historicalLedger = [
         boundedContentHash: 'b6052c8ebdca855973adf4e41efafb5028fd8dbbaa70809331f6017519b1c995',
       },
       preregistration: {
-        sourceRevision: 'fd16d1523a74e282846dcf465d375c77e2d40e77',
+        sourceRevision: '3c42ea0b783fcc6cb3fe6693bf82330bf42b9734',
         path: 'services/bayn/candidates/ordinal-21-six-month-rotation-preregistration.json',
         blobOid: 'f61534e914c854aec0c19c28cfd24490e59f36c7',
       },

--- a/services/bayn/src/strategy/candidate-21.ts
+++ b/services/bayn/src/strategy/candidate-21.ts
@@ -1,0 +1,188 @@
+import { Result, pipe } from 'effect'
+
+import { decodeDefaultProtocol } from '../protocol'
+import type { DecisionPlan, Protocol } from '../types'
+import { annualizedPortfolioVolatility } from './risk-balanced-trend/risk'
+import {
+  makeRiskBalancedTrendApplication,
+  type RiskBalancedTrendMarketContext,
+  type RiskBalancedTrendStrategyDefinition,
+} from './risk-balanced-trend'
+import { makeRiskBalancedTrendDecision } from './risk-balanced-trend/decision'
+import { dailyReturns, WEIGHT_SCALE } from './risk-balanced-trend/shared'
+import type { RiskBalancedTrendFailure } from '../risk-balanced-trend/model'
+
+const protocol = Result.getOrThrow(decodeDefaultProtocol())
+
+const sixMonthHorizon = 126
+const rotationSymbols = ['DBC', 'VNQ'] as const
+const defensiveSymbol = 'IEF' as const
+
+const fail = <A = never>(failure: RiskBalancedTrendFailure): Result.Result<A, RiskBalancedTrendFailure> =>
+  Result.fail(failure)
+
+const invalidClose = (symbol: string, index: number, value: number): Result.Result<never, RiskBalancedTrendFailure> =>
+  fail({
+    _tag: 'InvalidRiskBalancedTrendClose',
+    symbol,
+    index,
+    value,
+  })
+
+const closeHistory = (
+  context: RiskBalancedTrendMarketContext,
+  symbol: string,
+): Result.Result<readonly number[], RiskBalancedTrendFailure> => {
+  const closes = context.closes[symbol]
+  if (closes === undefined || closes.length !== context.sessionDates.length) {
+    return fail({
+      _tag: 'RiskBalancedTrendCloseHistoryMismatch',
+      symbol,
+      expectedCount: context.sessionDates.length,
+      observedCount: closes?.length ?? 0,
+    })
+  }
+  const invalidIndex = closes.findIndex((close) => !Number.isFinite(close) || close <= 0)
+  return invalidIndex < 0
+    ? Result.succeed(closes)
+    : invalidClose(symbol, invalidIndex, closes.at(invalidIndex) ?? Number.NaN)
+}
+
+const sixMonthReturn = (
+  context: RiskBalancedTrendMarketContext,
+  symbol: string,
+): Result.Result<number, RiskBalancedTrendFailure> =>
+  pipe(
+    closeHistory(context, symbol),
+    Result.flatMap((closes) => {
+      const current = closes.at(-1)
+      const prior = closes.at(-1 - sixMonthHorizon)
+      if (current === undefined || prior === undefined) {
+        return fail({
+          _tag: 'MissingRiskBalancedTrendClose',
+          symbol,
+          horizonSessions: sixMonthHorizon,
+        })
+      }
+      const value = current / prior - 1
+      return Number.isFinite(value)
+        ? Result.succeed(value)
+        : fail({
+            _tag: 'InvalidRiskBalancedTrendNumber',
+            operation: 'horizon-return',
+            value,
+            symbol,
+            reason: 'not-finite',
+          })
+    }),
+  )
+
+const selectedRotationSymbol = (returns: Readonly<Record<string, number>>): string | null => {
+  const winner = [...rotationSymbols]
+    .map((symbol) => ({ symbol, value: returns[symbol] ?? Number.NEGATIVE_INFINITY }))
+    .sort((left, right) => right.value - left.value || left.symbol.localeCompare(right.symbol))
+    .find(({ value }) => value > 0)
+  return winner?.symbol ?? ((returns[defensiveSymbol] ?? Number.NEGATIVE_INFINITY) > 0 ? defensiveSymbol : null)
+}
+
+const candidate21Decision = (
+  context: RiskBalancedTrendMarketContext,
+  candidateProtocol: Protocol,
+): Result.Result<DecisionPlan, RiskBalancedTrendFailure> =>
+  pipe(
+    makeRiskBalancedTrendDecision(context.signalDate, context.sessionDates, context.closes, candidateProtocol),
+    Result.flatMap((baseDecision) =>
+      pipe(
+        Result.all(
+          candidateProtocol.universe.map((symbol) =>
+            pipe(
+              sixMonthReturn(context, symbol),
+              Result.map((value) => [symbol, value] as const),
+            ),
+          ),
+        ),
+        Result.flatMap((returnEntries) => {
+          const returns = Object.fromEntries(returnEntries)
+          const selected = selectedRotationSymbol(returns)
+          const requestedTargetWeights = Object.fromEntries(
+            candidateProtocol.universe.map((symbol) => [
+              symbol,
+              symbol === selected ? candidateProtocol.maximumSymbolWeight : 0,
+            ]),
+          )
+          return pipe(
+            Result.all(
+              candidateProtocol.universe.map((symbol) =>
+                pipe(
+                  closeHistory(context, symbol),
+                  Result.flatMap((closes) => dailyReturns(closes, candidateProtocol.volatilityWindow, symbol)),
+                  Result.map((values) => [symbol, values] as const),
+                ),
+              ),
+            ),
+            Result.flatMap((returnSeries) =>
+              pipe(
+                annualizedPortfolioVolatility(requestedTargetWeights, Object.fromEntries(returnSeries)),
+                Result.flatMap((estimatedAnnualizedPortfolioVolatility) => {
+                  const exposureScale =
+                    estimatedAnnualizedPortfolioVolatility === 0
+                      ? 1
+                      : Math.min(
+                          1,
+                          candidateProtocol.maximumPortfolioVolatility / estimatedAnnualizedPortfolioVolatility,
+                        )
+                  const targetWeights = Object.fromEntries(
+                    Object.entries(requestedTargetWeights).map(([symbol, weight]) => [
+                      symbol,
+                      Math.floor(weight * exposureScale * WEIGHT_SCALE) / WEIGHT_SCALE,
+                    ]),
+                  )
+                  return pipe(
+                    annualizedPortfolioVolatility(targetWeights, Object.fromEntries(returnSeries)),
+                    Result.flatMap((observedAnnualizedPortfolioVolatility) =>
+                      observedAnnualizedPortfolioVolatility > candidateProtocol.maximumPortfolioVolatility + 1e-12
+                        ? fail({
+                            _tag: 'UnboundedRiskBalancedTrendWeights',
+                            totalWeight: Object.values(targetWeights).reduce((total, weight) => total + weight, 0),
+                            maximumSymbolWeight: candidateProtocol.maximumSymbolWeight,
+                            maximumPortfolioVolatility: candidateProtocol.maximumPortfolioVolatility,
+                            observedPortfolioVolatility: observedAnnualizedPortfolioVolatility,
+                          })
+                        : Result.succeed({
+                            ...baseDecision,
+                            estimatedAnnualizedPortfolioVolatility,
+                            exposureScale,
+                            targetWeights,
+                            signals: baseDecision.signals.map((signal) => {
+                              const score = returns[signal.symbol] ?? 0
+                              const targetWeight = targetWeights[signal.symbol] ?? 0
+                              return {
+                                ...signal,
+                                compositeScore: score,
+                                positiveScore: Math.max(0, score),
+                                eligible: signal.symbol === selected,
+                                uncappedWeight: targetWeight,
+                                cappedWeight: targetWeight,
+                                targetWeight,
+                              }
+                            }),
+                          }),
+                    ),
+                  )
+                }),
+              ),
+            ),
+          )
+        }),
+      ),
+    ),
+  )
+
+const definition: RiskBalancedTrendStrategyDefinition = {
+  name: 'candidate-21-six-month-rotation',
+  parameters: protocol,
+  decide: ({ market }) => candidate21Decision(market, protocol),
+}
+
+/** Candidate 21 is a result-blind, source-controlled application; its witness is supplied only by the adapter. */
+export const strategyApplication = makeRiskBalancedTrendApplication(protocol, definition)


### PR DESCRIPTION
## Summary

- Add the result-blind Candidate 21 six-month rotation application with protocol volatility scaling and synchronized signal weights.
- Add the exact source manifest and one append-only `DEVELOPMENT_PENDING` registration.
- Update the reviewed dormancy fixture to represent registered-but-not-approved Candidate 21 while preserving Candidate 20 as the immutable tombstone.
- Bind the registration to the corrected preregistration blob, source-manifest blob, module SHA, market witness hashes, and exact reviewed main ancestor.

## Related Issues

None.

## Testing

- `bun test services/bayn/src/candidate-development.test.ts services/bayn/src/candidate-development-candidate-20.test.ts services/bayn/src/candidate-development-local/command.test.ts services/bayn/src/candidate-development-trials/ledger.test.ts packages/scripts/src/bayn/verify-qualification-dormancy.test.ts` — 56 passed, 0 failed, 347 assertions.
- `bun run --cwd services/bayn tsc`
- `bun run --filter @proompteng/bayn lint:effect`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bunx oxfmt --check services/bayn/src/strategy/candidate-21.ts services/bayn/src/candidate-development-trials/ledger.ts packages/scripts/src/bayn/verify-qualification-dormancy.test.ts`
- Exact descendant diff from `f9c90e5158212d862ca4b64cf9624fe424f09ba6` contains only the four reviewed candidate paths: module, source manifest, ledger, and dormancy fixture.
- Candidate 21 metrics, witness evaluation, and development attempt have not been run.

## Screenshots (if applicable)

N/A.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
