### PR TITLE
fix(bayn): replay reviewed qualification strategy

### DIFF
--- a/services/bayn/README.md
+++ b/services/bayn/README.md
@@ -208,9 +208,13 @@ BAYN_AUDIT_SIGNAL_PASSWORD=<readonly-bayn-password> \
 BAYN_AUDIT_CLICKHOUSE_URLS=<replica-0-audit-url>,<replica-1-audit-url> \
 BAYN_AUDIT_CLICKHOUSE_USERNAME=<query-log-audit-user> \
 BAYN_AUDIT_CLICKHOUSE_PASSWORD=<query-log-audit-password> \
-BAYN_AUDIT_REPOSITORY_PATH=<lab-checkout> \
+BAYN_AUDIT_REPOSITORY_PATH=<clean-lab-checkout-at-the-run-source-revision> \
   bun run --filter @proompteng/bayn audit:qualification
 ```
+
+The audit checkout must be clean and its `HEAD` must equal the persisted run source revision. This binds the reviewed
+candidate module and every local dependency it imports to the same source tree; the command fails closed for a newer,
+dirty, or otherwise different checkout.
 
 The audit command is not part of the deployed runtime and never calls TigerBeetle or a broker. Its privileged
 ClickHouse credential is operator-supplied only to read `system.query_log`; the service keeps its normal Signal

--- a/services/bayn/src/audit/audit.ts
+++ b/services/bayn/src/audit/audit.ts
@@ -12,6 +12,7 @@ import {
   type Protocol,
 } from '../types'
 import type { ReferenceEvaluationFailure } from './reference'
+import type { StrategyApplication } from '../strategy/core'
 
 export const auditContract = {
   name: 'risk-balanced-trend',
@@ -146,6 +147,8 @@ export interface QualificationAuditInput {
   readonly bars: readonly DailyBar[]
   readonly manifest: InputManifest
   readonly protocol: Protocol
+  /** The reviewed pure application that produced the qualification attempt. */
+  readonly application: StrategyApplication<any, any, any>
   readonly database: AuditDatabaseSnapshot
   readonly signalReplicas: readonly string[]
   readonly signalAccess: readonly SignalAccessRecord[]
@@ -241,7 +244,7 @@ export type QualificationAuditFailure =
       readonly _tag: 'UnsupportedAuditStrategyContract'
       readonly protocolStrategyName: string
       readonly runStrategyName: string
-      readonly requiredStrategyName: typeof auditContract.name
+      readonly requiredStrategyName: string
     }
   | {
       readonly _tag: 'UnsupportedAuditProtocolVersion'

--- a/services/bayn/src/audit/core.ts
+++ b/services/bayn/src/audit/core.ts
@@ -171,12 +171,13 @@ export const makeAuditFacts = (
   input: QualificationAuditInput,
 ): Result.Result<QualificationAuditFacts, QualificationAuditFailure> => {
   const database = input.database
-  if (database.protocol.strategyName !== auditContract.name || database.run.strategyName !== auditContract.name) {
+  const strategyName = input.application.definition.name
+  if (database.protocol.strategyName !== strategyName || database.run.strategyName !== strategyName) {
     return Result.fail({
       _tag: 'UnsupportedAuditStrategyContract',
       protocolStrategyName: database.protocol.strategyName,
       runStrategyName: database.run.strategyName,
-      requiredStrategyName: auditContract.name,
+      requiredStrategyName: strategyName,
     })
   }
   const supportedSchemaVersions = [
@@ -208,13 +209,14 @@ export const makeAuditFacts = (
   // Terminal liquidation was added after the v6 evaluation contract was already persisted.
   // The persisted v4 behavior identity is the durable marker even when a flat strategy emits no
   // terminal-close decision; the event marker preserves legacy v6 evidence semantics.
-  const closeAtEnd = usesTerminalReplaySemantics(database)
+  const closeAtEnd = strategyName !== auditContract.name || usesTerminalReplaySemantics(database)
   const referenceResult = evaluateReference(
     input.bars,
     input.manifest,
     input.protocol,
     provenanceResult.success,
     closeAtEnd,
+    input.application,
   )
   if (Result.isFailure(referenceResult)) return Result.fail(referenceResult.failure)
   const reference = referenceResult.success

--- a/services/bayn/src/audit/core.ts
+++ b/services/bayn/src/audit/core.ts
@@ -209,7 +209,10 @@ export const makeAuditFacts = (
   // Terminal liquidation was added after the v6 evaluation contract was already persisted.
   // The persisted v4 behavior identity is the durable marker even when a flat strategy emits no
   // terminal-close decision; the event marker preserves legacy v6 evidence semantics.
-  const closeAtEnd = strategyName !== auditContract.name || usesTerminalReplaySemantics(database)
+  const closeAtEnd =
+    input.application.reviewedSource !== undefined ||
+    strategyName !== auditContract.name ||
+    usesTerminalReplaySemantics(database)
   const referenceResult = evaluateReference(
     input.bars,
     input.manifest,

--- a/services/bayn/src/audit/reference.ts
+++ b/services/bayn/src/audit/reference.ts
@@ -231,7 +231,8 @@ const evaluateReferenceWithWork = (
   const runId = runIdentityResult.success.runId
   const protocolHash = protocolHashResult.success
   const candidateTargetsResult =
-    application !== undefined && application.definition.name !== 'risk-balanced-trend'
+    application !== undefined &&
+    (application.reviewedSource !== undefined || application.definition.name !== 'risk-balanced-trend')
       ? strategyTargetsFromApplication(sessions, eligibleSignals, application)
       : Result.all(
           eligibleSignals.map((signalIndex) =>

--- a/services/bayn/src/audit/reference.ts
+++ b/services/bayn/src/audit/reference.ts
@@ -132,18 +132,12 @@ const strategyTargetsFromApplication = (
         ),
         Result.flatMap((target) => {
           const decision = Schema.decodeUnknownResult(DecisionPlanSchema, strictParseOptions)(target)
-          return Result.isFailure(decision)
-            ? Result.fail<ReferenceEvaluationFailure>({
-                _tag: 'ReferenceMissingDecisionPlan',
-                signalIndex,
-                executionIndex: signalIndex + 1,
-              })
-            : Result.succeed({
-                signalIndex,
-                executionIndex: signalIndex + 1,
-                weights: target.targetWeights,
-                plan: decision.success,
-              })
+          return Result.succeed({
+            signalIndex,
+            executionIndex: signalIndex + 1,
+            weights: target.targetWeights,
+            ...(Result.isSuccess(decision) ? { plan: decision.success } : { requireDecisionEvidence: false as const }),
+          })
         }),
       ),
     ),

--- a/services/bayn/src/audit/reference.ts
+++ b/services/bayn/src/audit/reference.ts
@@ -1,4 +1,4 @@
-import { pipe, Result } from 'effect'
+import { pipe, Result, Schema } from 'effect'
 
 import { makeRunIdentityResult, makeStrategyProtocolHashResult, type RuntimeProvenance } from '../contracts'
 import { MICROS } from '../execution-model'
@@ -11,6 +11,9 @@ import type {
   Protocol,
   SimulationProtocol,
 } from '../types'
+import { DecisionPlanSchema } from '../evidence-contracts'
+import { strictParseOptions } from '../schemas'
+import type { StrategyApplication } from '../strategy/core'
 import {
   align,
   directVolatilityTarget,
@@ -23,10 +26,12 @@ import { hashReferenceMaterial } from './reference/replay/identities'
 import type {
   ReferenceComputation,
   ReferenceEvaluation,
+  ReferenceEvaluationFailure,
   ReferenceEvaluationWithWork,
   ReferenceEvaluationWork,
   Replay,
   ReplayWithWork,
+  Session,
   Target,
 } from './reference/model'
 import { replay } from './reference/replay'
@@ -92,12 +97,65 @@ const makeVerdict = (
   return { status: gates.every((gate) => gate.passed) ? 'PASS' : 'FAIL_CLOSED', gates }
 }
 
+/**
+ * Candidate qualification must replay the exact reviewed application that produced the stored
+ * decisions. The reference still owns the independent session selection, benchmark construction,
+ * and accounting replay; only the strategy decision is supplied by the reviewed application.
+ */
+const strategyTargetsFromApplication = (
+  sessions: readonly Session[],
+  signalIndices: readonly number[],
+  application: StrategyApplication<any, any, any>,
+): ReferenceComputation<readonly Target[]> =>
+  Result.all(
+    signalIndices.map((signalIndex) =>
+      pipe(
+        application.contextAtSignal(sessions, signalIndex),
+        Result.mapError(
+          (cause): ReferenceEvaluationFailure => ({
+            _tag: 'ReferenceStrategyDecisionFailed',
+            signalIndex,
+            cause,
+          }),
+        ),
+        Result.flatMap((context) =>
+          pipe(
+            application.definition.decide(context),
+            Result.mapError(
+              (cause): ReferenceEvaluationFailure => ({
+                _tag: 'ReferenceStrategyDecisionFailed',
+                signalIndex,
+                cause,
+              }),
+            ),
+          ),
+        ),
+        Result.flatMap((target) => {
+          const decision = Schema.decodeUnknownResult(DecisionPlanSchema, strictParseOptions)(target)
+          return Result.isFailure(decision)
+            ? Result.fail<ReferenceEvaluationFailure>({
+                _tag: 'ReferenceMissingDecisionPlan',
+                signalIndex,
+                executionIndex: signalIndex + 1,
+              })
+            : Result.succeed({
+                signalIndex,
+                executionIndex: signalIndex + 1,
+                weights: target.targetWeights,
+                plan: decision.success,
+              })
+        }),
+      ),
+    ),
+  )
+
 const evaluateReferenceWithWork = (
   bars: readonly DailyBar[],
   manifest: InputManifest,
   protocol: Protocol,
   provenance: RuntimeProvenance,
   closeAtEnd: boolean,
+  application?: StrategyApplication<any, any, any>,
 ): ReferenceComputation<ReferenceEvaluationWithWork> => {
   const sessionsResult = align(bars, manifest, protocol.universe)
   if (Result.isFailure(sessionsResult)) return Result.fail(sessionsResult.failure)
@@ -145,10 +203,10 @@ const evaluateReferenceWithWork = (
     parameterHash,
     parameterSchemaVersion: protocol.schemaVersion,
   }
-  if (parameterHash !== provenance.strategy.parameterHash || provenance.strategy.name !== 'risk-balanced-trend') {
+  if (parameterHash !== provenance.strategy.parameterHash) {
     return Result.fail({
       _tag: 'ReferenceProvenanceMismatch',
-      requiredStrategyName: 'risk-balanced-trend',
+      requiredStrategyName: provenance.strategy.name,
       actualStrategyName: provenance.strategy.name,
       expectedParameterHash: parameterHash,
       actualParameterHash: provenance.strategy.parameterHash,
@@ -172,16 +230,24 @@ const evaluateReferenceWithWork = (
   if (Result.isFailure(protocolHashResult)) return Result.fail(protocolHashResult.failure)
   const runId = runIdentityResult.success.runId
   const protocolHash = protocolHashResult.success
-  const candidateTargetsResult = Result.all(
-    eligibleSignals.map((signalIndex) =>
-      pipe(
-        riskBalancedDecisionPlan(signalIndex, sessions, protocol),
-        Result.map(
-          (plan): Target => ({ signalIndex, executionIndex: signalIndex + 1, weights: plan.targetWeights, plan }),
-        ),
-      ),
-    ),
-  )
+  const candidateTargetsResult =
+    application !== undefined && application.definition.name !== 'risk-balanced-trend'
+      ? strategyTargetsFromApplication(sessions, eligibleSignals, application)
+      : Result.all(
+          eligibleSignals.map((signalIndex) =>
+            pipe(
+              riskBalancedDecisionPlan(signalIndex, sessions, protocol),
+              Result.map(
+                (plan): Target => ({
+                  signalIndex,
+                  executionIndex: signalIndex + 1,
+                  weights: plan.targetWeights,
+                  plan,
+                }),
+              ),
+            ),
+          ),
+        )
   if (Result.isFailure(candidateTargetsResult)) return Result.fail(candidateTargetsResult.failure)
   const candidateTargets = candidateTargetsResult.success
   const equalWeight = roundWeight(1 / protocol.universe.length)
@@ -266,9 +332,10 @@ export const evaluateReference = (
   protocol: Protocol,
   provenance: RuntimeProvenance,
   closeAtEnd = true,
+  application?: StrategyApplication<any, any, any>,
 ): ReferenceComputation<ReferenceEvaluation> =>
   pipe(
-    evaluateReferenceWithWork(bars, manifest, protocol, provenance, closeAtEnd),
+    evaluateReferenceWithWork(bars, manifest, protocol, provenance, closeAtEnd, application),
     Result.map((reference) => ({
       runId: reference.runId,
       protocolHash: reference.protocolHash,
@@ -286,9 +353,10 @@ export const measureReferenceEvaluationWork = (
   protocol: Protocol,
   provenance: RuntimeProvenance,
   closeAtEnd = true,
+  application?: StrategyApplication<any, any, any>,
 ): ReferenceComputation<ReferenceEvaluationWork> =>
   pipe(
-    evaluateReferenceWithWork(bars, manifest, protocol, provenance, closeAtEnd),
+    evaluateReferenceWithWork(bars, manifest, protocol, provenance, closeAtEnd, application),
     Result.map((reference) => ({
       strategy: reference.strategy.work,
       buyAndHold: reference.buyAndHold.work,

--- a/services/bayn/src/audit/reference/model.ts
+++ b/services/bayn/src/audit/reference/model.ts
@@ -254,10 +254,15 @@ export type ReferenceEvaluationFailure =
     }
   | {
       readonly _tag: 'ReferenceProvenanceMismatch'
-      readonly requiredStrategyName: 'risk-balanced-trend'
+      readonly requiredStrategyName: string
       readonly actualStrategyName: string
       readonly expectedParameterHash: string
       readonly actualParameterHash: string
+    }
+  | {
+      readonly _tag: 'ReferenceStrategyDecisionFailed'
+      readonly signalIndex: number
+      readonly cause: unknown
     }
 
 export type ReferenceCanonicalizationSubject =

--- a/services/bayn/src/audit/reference/model.ts
+++ b/services/bayn/src/audit/reference/model.ts
@@ -25,6 +25,7 @@ export interface Target {
   readonly executionIndex: number
   readonly weights: Readonly<Record<string, number>>
   readonly plan?: DecisionPlan
+  readonly requireDecisionEvidence?: boolean
   readonly terminalClose?: boolean
 }
 

--- a/services/bayn/src/audit/reference/replay.ts
+++ b/services/bayn/src/audit/reference/replay.ts
@@ -175,7 +175,7 @@ export const replay = (
       const decision: DecisionEvent = decisionResult.success
       if (retainTrace) {
         const plan = 'plan' in target ? target.plan : undefined
-        if (plan === undefined && !terminalClose) {
+        if (plan === undefined && !terminalClose && target.requireDecisionEvidence !== false) {
           return Result.fail({
             _tag: 'ReferenceMissingDecisionPlan',
             signalIndex: target.signalIndex,

--- a/services/bayn/src/candidate-development-local/source-module.ts
+++ b/services/bayn/src/candidate-development-local/source-module.ts
@@ -26,6 +26,31 @@ const isStrategyApplication = (value: unknown): value is StrategyApplication<any
   )
 }
 
+const importReviewedModule = (moduleUrl: string, signal: AbortSignal): Promise<unknown> =>
+  new Promise((resolve, reject) => {
+    let settled = false
+    const abort = () => fail(signal.reason ?? new Error('reviewed strategy module import interrupted'))
+    const cleanup = () => signal.removeEventListener('abort', abort)
+    const succeed = (value: unknown) => {
+      if (settled) return
+      settled = true
+      cleanup()
+      resolve(value)
+    }
+    const fail = (cause: unknown) => {
+      if (settled) return
+      settled = true
+      cleanup()
+      reject(cause)
+    }
+    if (signal.aborted) {
+      abort()
+      return
+    }
+    signal.addEventListener('abort', abort, { once: true })
+    import(moduleUrl).then(succeed, fail)
+  })
+
 /**
  * Load the executable application from the reviewed checkout rather than using a separately composed substitute.
  * The revision query keeps Bun from reusing a module cached from another checked-out source revision.
@@ -35,17 +60,18 @@ export const loadReviewedStrategyApplication = (
   sourceRevision: string,
 ): Effect.Effect<StrategyApplication<any, any, any>, CandidateDevelopmentSourceModuleError> =>
   Effect.tryPromise({
-    try: async () => {
+    try: (signal) => {
       const moduleUrl = `${pathToFileURL(absoluteModulePath).href}?bayn-source-revision=${sourceRevision}`
-      const loaded: unknown = await import(moduleUrl)
-      const application =
-        typeof loaded === 'object' && loaded !== null
-          ? (loaded as Record<string, unknown>).strategyApplication
-          : undefined
-      if (!isStrategyApplication(application)) {
-        throw new Error('reviewed candidate module must export strategyApplication')
-      }
-      return application
+      return importReviewedModule(moduleUrl, signal).then((loaded: unknown) => {
+        const application =
+          typeof loaded === 'object' && loaded !== null
+            ? (loaded as Record<string, unknown>).strategyApplication
+            : undefined
+        if (!isStrategyApplication(application)) {
+          throw new Error('reviewed candidate module must export strategyApplication')
+        }
+        return application
+      })
     },
     catch: (cause) =>
       new CandidateDevelopmentSourceModuleError({

--- a/services/bayn/src/db/evidence-store.integration.test.ts
+++ b/services/bayn/src/db/evidence-store.integration.test.ts
@@ -4960,6 +4960,8 @@ describePostgres('PostgreSQL evaluation evidence', () => {
       auditClickhouseUsername: 'bayn-audit-query-log',
       auditClickhousePassword: Redacted.make('unused'),
       repositoryPath: '.',
+      candidateModulePath: '',
+      candidateModuleSha256: '',
       operationTimeoutMs: 5_000,
     }
     const snapshot = await Effect.runPromise(

--- a/services/bayn/src/qualification-audit-command.test.ts
+++ b/services/bayn/src/qualification-audit-command.test.ts
@@ -140,6 +140,41 @@ describe('qualification audit command', () => {
     expect(acquisitions).toEqual({ database: 1, repository: 0, signal: 0, signalReplica: 0 })
   })
 
+  test('verifies the persisted source checkout before loading an audited strategy', async () => {
+    const sourceRevision = 'c'.repeat(40)
+    const repositoryFailure = new QualificationAuditCommandError({
+      operation: 'repository',
+      message: 'audit repository must be a clean checkout at the persisted source revision',
+    })
+    const database = {
+      ...opaqueDatabase,
+      run: { ...opaqueDatabase.run, sourceRevision },
+      artifacts: [
+        {
+          name: 'input-manifest',
+          schemaVersion: signalSnapshot.manifest.schemaVersion,
+          contentHash: 'd'.repeat(64),
+          payload: signalSnapshot.manifest,
+        },
+      ],
+    } as unknown as AuditDatabaseSnapshot
+    const input = auditConfig()
+    const readers = makeQualificationAuditReaders(input, {
+      database: () => Effect.succeed({ read: () => Effect.succeed(database) }),
+      signal: () => Effect.die('signal must not be acquired before source verification'),
+      signalReplica: () => Effect.die('signal replica must not be acquired before source verification'),
+      repository: () =>
+        Effect.succeed({
+          verifySourceCheckout: () => Effect.fail(repositoryFailure),
+          audit: () => Effect.fail(repositoryFailure),
+        }),
+    })
+
+    const failure = await Effect.runPromise(Effect.flip(runQualificationAudit(input, readers)))
+
+    expect(failure).toBe(repositoryFailure)
+  })
+
   test('acquires, uses, and releases the PostgreSQL audit client exactly once', async () => {
     let acquisitions = 0
     let releases = 0

--- a/services/bayn/src/qualification-audit-command.test.ts
+++ b/services/bayn/src/qualification-audit-command.test.ts
@@ -64,6 +64,8 @@ const auditConfig = (overrides: Partial<AuditConfig> = {}): AuditConfig => ({
   auditClickhouseUsername: 'bayn-audit-query-log',
   auditClickhousePassword: Redacted.make('audit-password'),
   repositoryPath: import.meta.dir,
+  candidateModulePath: '',
+  candidateModuleSha256: '',
   operationTimeoutMs: 5_000,
   ...overrides,
 })

--- a/services/bayn/src/qualification-audit.test.ts
+++ b/services/bayn/src/qualification-audit.test.ts
@@ -24,7 +24,7 @@ import {
   prepareQualificationSeries,
 } from './qualification-statistics'
 import { evaluateRiskBalancedTrend, parseMatchingManifest, summarizeEvaluation } from './risk-balanced-trend'
-import { makeRiskBalancedTrendDefinition } from './strategy'
+import { makeRiskBalancedTrendApplication, makeRiskBalancedTrendDefinition } from './strategy'
 import { prepareRiskBalancedTrendQualificationLock } from './strategy/risk-balanced-trend/qualification'
 import { fixtureProtocol, makeSnapshot, makeTestProvenance } from './test-fixtures'
 
@@ -269,6 +269,7 @@ const fixture = (priorTrialRunIds: readonly string[] = []): QualificationAuditIn
     bars: snapshot.bars,
     manifest: snapshot.manifest,
     protocol,
+    application: makeRiskBalancedTrendApplication(protocol, definition),
     database,
     signalReplicas: ['replica-0', 'replica-1'],
     signalAccess: [

--- a/services/bayn/src/qualification-collector-command.ts
+++ b/services/bayn/src/qualification-collector-command.ts
@@ -1695,6 +1695,8 @@ const configureRuntimeEnvironment = (
     BAYN_AUDIT_CLICKHOUSE_USERNAME: wiring.auditClickhouseUsername,
     BAYN_AUDIT_CLICKHOUSE_PASSWORD: wiring.auditClickhousePassword,
     BAYN_AUDIT_REPOSITORY_PATH: staticEvidence.repositoryPath,
+    BAYN_AUDIT_CANDIDATE_MODULE_PATH: resolve(staticEvidence.repositoryPath, staticEvidence.preregistration.modulePath),
+    BAYN_AUDIT_CANDIDATE_MODULE_SHA256: staticEvidence.moduleSha256,
     BAYN_AUDIT_OPERATION_TIMEOUT_MS: operationTimeout,
   })
   delete process.env.BAYN_QUALIFICATION_RUN_ID

--- a/services/bayn/src/qualification-collector-command.ts
+++ b/services/bayn/src/qualification-collector-command.ts
@@ -54,6 +54,7 @@ const imageDigest = /^sha256:[0-9a-f]{64}$/
 const maximumGitOutputBytes = 16 * 1024 * 1024
 const defaultOperationTimeoutMs = 60_000
 const candidateDevelopmentTrialLedgerPath = 'services/bayn/src/candidate-development-trials/ledger.ts'
+const candidateDevelopmentDormancyTestPath = 'packages/scripts/src/bayn/verify-qualification-dormancy.test.ts'
 const defaultAuditReplicaUrls = [
   'http://chi-torghut-clickhouse-default-0-0.torghut.svc.cluster.local:8123',
   'http://chi-torghut-clickhouse-default-0-1.torghut.svc.cluster.local:8123',
@@ -1414,6 +1415,7 @@ const collectStaticQualificationEvidence = (invocation: QualificationCollectorIn
         preregistration.preregistration.path,
         activeCandidate.sourceManifest.path,
         candidateDevelopmentTrialLedgerPath,
+        candidateDevelopmentDormancyTestPath,
       ],
       preregistration,
       preregistrationBytes: staticGit.preregistrationBytes,

--- a/services/bayn/src/qualification-reference.test.ts
+++ b/services/bayn/src/qualification-reference.test.ts
@@ -15,6 +15,7 @@ import { MICROS } from './execution-model'
 import { hashParameters } from './protocol'
 import { evaluateRiskBalancedTrend } from './risk-balanced-trend'
 import { evaluateStrategyApplication } from './strategy/evaluation-runner'
+import { bindReviewedStrategySource } from './strategy'
 import { makeRiskBalancedTrendApplication, makeRiskBalancedTrendDefinition } from './strategy/risk-balanced-trend'
 import { fixtureProtocol, makeSnapshot, makeTestProvenance } from './test-fixtures'
 
@@ -53,10 +54,14 @@ describe('independent qualification reference', () => {
     expect(reference.doubleCostStrategy.daily).toEqual(actual.benchmarkSeries.doubleCostStrategy)
   })
 
-  test('replays a reviewed non-legacy application instead of substituting the legacy planner', () => {
+  test('replays a reviewed application even when its display name matches the legacy planner', () => {
     const snapshot = makeSnapshot(900)
-    const definition = { ...makeRiskBalancedTrendDefinition(fixtureProtocol), name: 'candidate-test-rotation' }
-    const application = makeRiskBalancedTrendApplication(fixtureProtocol, definition)
+    const definition = makeRiskBalancedTrendDefinition(fixtureProtocol)
+    const application = bindReviewedStrategySource(makeRiskBalancedTrendApplication(fixtureProtocol, definition), {
+      sourceRevision: 'a'.repeat(40),
+      modulePath: 'services/bayn/src/strategy/candidate.ts',
+      moduleSha256: 'd'.repeat(64),
+    })
     const provenance = makeRuntimeProvenance({
       sourceRevision: 'a'.repeat(40),
       image: {

--- a/services/bayn/src/qualification-reference.test.ts
+++ b/services/bayn/src/qualification-reference.test.ts
@@ -15,7 +15,7 @@ import { MICROS } from './execution-model'
 import { hashParameters } from './protocol'
 import { evaluateRiskBalancedTrend } from './risk-balanced-trend'
 import { evaluateStrategyApplication } from './strategy/evaluation-runner'
-import { bindReviewedStrategySource } from './strategy'
+import { bindReviewedStrategySource, type StrategyApplication, type TargetPortfolio } from './strategy'
 import { makeRiskBalancedTrendApplication, makeRiskBalancedTrendDefinition } from './strategy/risk-balanced-trend'
 import { fixtureProtocol, makeSnapshot, makeTestProvenance } from './test-fixtures'
 
@@ -92,6 +92,62 @@ describe('independent qualification reference', () => {
     expect(reference.strategy.metrics).toEqual(actual.strategy)
     expect(reference.strategy.events).toEqual(actual.events)
     expect(reference.strategy.decisions).toEqual(actual.signalDecisions)
+    expect(reference.strategy.trace).toEqual(actual.simulation)
+    expect(reference.verdict).toEqual(actual.verdict)
+  })
+
+  test('replays a reviewed generic target without requiring risk-specific decision evidence', () => {
+    const snapshot = makeSnapshot(900)
+    const baseApplication = makeRiskBalancedTrendApplication(
+      fixtureProtocol,
+      makeRiskBalancedTrendDefinition(fixtureProtocol),
+    )
+    const application = bindReviewedStrategySource(
+      {
+        ...baseApplication,
+        closeTarget: (target) => ({ targetWeights: target.targetWeights }),
+        definition: {
+          ...baseApplication.definition,
+          decide: (context) =>
+            Result.map(baseApplication.definition.decide(context), (target) => ({
+              targetWeights: target.targetWeights,
+            })),
+        },
+      } as StrategyApplication<any, any, TargetPortfolio>,
+      {
+        sourceRevision: 'a'.repeat(40),
+        modulePath: 'services/bayn/src/strategy/candidate.ts',
+        moduleSha256: 'd'.repeat(64),
+      },
+    )
+    const provenance = makeRuntimeProvenance({
+      sourceRevision: 'a'.repeat(40),
+      image: {
+        repository: 'registry.ide-newton.ts.net/lab/bayn',
+        digest: `sha256:${'b'.repeat(64)}`,
+      },
+      strategy: {
+        name: application.definition.name,
+        behaviorHash: 'd'.repeat(64),
+        parameterHash: hashParameters(fixtureProtocol),
+        parameterSchemaVersion: fixtureProtocol.schemaVersion,
+      },
+    })
+    const actual = assertSuccess(
+      evaluateStrategyApplication({
+        application,
+        provenance,
+        bars: snapshot.bars,
+        inputManifest: snapshot.manifest,
+      }),
+    )
+    const reference = assertSuccess(
+      evaluateReference(snapshot.bars, snapshot.manifest, fixtureProtocol, provenance, true, application),
+    )
+
+    expect(reference.strategy.metrics).toEqual(actual.strategy)
+    expect(reference.strategy.events).toEqual(actual.events)
+    expect(reference.strategy.decisions).toEqual([])
     expect(reference.strategy.trace).toEqual(actual.simulation)
     expect(reference.verdict).toEqual(actual.verdict)
   })

--- a/services/bayn/src/qualification-reference.test.ts
+++ b/services/bayn/src/qualification-reference.test.ts
@@ -7,11 +7,15 @@ import { describe, expect, test } from 'bun:test'
 import { Result } from 'effect'
 
 import { canonicalHashV1 } from './hash'
+import { makeRuntimeProvenance } from './contracts'
 import { align } from './audit/reference/decisions'
 import { replay } from './audit/reference/replay'
 import { evaluateReference, measureReferenceEvaluationWork, restrictReferenceBuyFill } from './audit/reference'
 import { MICROS } from './execution-model'
+import { hashParameters } from './protocol'
 import { evaluateRiskBalancedTrend } from './risk-balanced-trend'
+import { evaluateStrategyApplication } from './strategy/evaluation-runner'
+import { makeRiskBalancedTrendApplication, makeRiskBalancedTrendDefinition } from './strategy/risk-balanced-trend'
 import { fixtureProtocol, makeSnapshot, makeTestProvenance } from './test-fixtures'
 
 const assertSuccess = <A, E>(result: Result.Result<A, E>): A => {
@@ -47,6 +51,44 @@ describe('independent qualification reference', () => {
     expect(reference.buyAndHold.daily).toEqual(actual.benchmarkSeries.buyAndHold)
     expect(reference.directVolTiming.daily).toEqual(actual.benchmarkSeries.directVolTiming)
     expect(reference.doubleCostStrategy.daily).toEqual(actual.benchmarkSeries.doubleCostStrategy)
+  })
+
+  test('replays a reviewed non-legacy application instead of substituting the legacy planner', () => {
+    const snapshot = makeSnapshot(900)
+    const definition = { ...makeRiskBalancedTrendDefinition(fixtureProtocol), name: 'candidate-test-rotation' }
+    const application = makeRiskBalancedTrendApplication(fixtureProtocol, definition)
+    const provenance = makeRuntimeProvenance({
+      sourceRevision: 'a'.repeat(40),
+      image: {
+        repository: 'registry.ide-newton.ts.net/lab/bayn',
+        digest: `sha256:${'b'.repeat(64)}`,
+      },
+      strategy: {
+        name: definition.name,
+        behaviorHash: 'd'.repeat(64),
+        parameterHash: hashParameters(fixtureProtocol),
+        parameterSchemaVersion: fixtureProtocol.schemaVersion,
+      },
+    })
+    const actual = assertSuccess(
+      evaluateStrategyApplication({
+        application,
+        provenance,
+        bars: snapshot.bars,
+        inputManifest: snapshot.manifest,
+      }),
+    )
+    const reference = assertSuccess(
+      evaluateReference(snapshot.bars, snapshot.manifest, fixtureProtocol, provenance, true, application),
+    )
+
+    expect(reference.runId).toBe(actual.runId)
+    expect(reference.protocolHash).toBe(actual.protocolHash)
+    expect(reference.strategy.metrics).toEqual(actual.strategy)
+    expect(reference.strategy.events).toEqual(actual.events)
+    expect(reference.strategy.decisions).toEqual(actual.signalDecisions)
+    expect(reference.strategy.trace).toEqual(actual.simulation)
+    expect(reference.verdict).toEqual(actual.verdict)
   })
 
   test('preserves legacy replay semantics without a durable terminal-close marker', () => {

--- a/services/bayn/src/qualification/audit-command/model.ts
+++ b/services/bayn/src/qualification/audit-command/model.ts
@@ -86,6 +86,7 @@ export type AcquireAuditSignalReplicaClient<R> = (
 ) => Effect.Effect<AuditSignalReplicaClient, QualificationAuditCommandError, Scope.Scope | R>
 
 export interface AuditRepositoryClient {
+  readonly verifySourceCheckout: (sourceRevision: string) => Effect.Effect<void, QualificationAuditCommandError>
   readonly audit: (
     sourceRevision: string,
     lockCreatedAt: string,
@@ -117,6 +118,7 @@ export interface QualificationAuditReaders<R = never> {
     lockCreatedAt: string,
     resultIdentity: readonly string[],
   ) => Effect.Effect<RepositoryAudit, QualificationAuditCommandError, R>
+  readonly verifySourceCheckout: (sourceRevision: string) => Effect.Effect<void, QualificationAuditCommandError, R>
 }
 
 export interface QualificationAuditAcquirers<R> {

--- a/services/bayn/src/qualification/audit-command/model.ts
+++ b/services/bayn/src/qualification/audit-command/model.ts
@@ -86,7 +86,10 @@ export type AcquireAuditSignalReplicaClient<R> = (
 ) => Effect.Effect<AuditSignalReplicaClient, QualificationAuditCommandError, Scope.Scope | R>
 
 export interface AuditRepositoryClient {
-  readonly verifySourceCheckout: (sourceRevision: string) => Effect.Effect<void, QualificationAuditCommandError>
+  readonly verifySourceCheckout: (
+    sourceRevision: string,
+    candidateModulePath?: string,
+  ) => Effect.Effect<void, QualificationAuditCommandError>
   readonly audit: (
     sourceRevision: string,
     lockCreatedAt: string,
@@ -118,7 +121,10 @@ export interface QualificationAuditReaders<R = never> {
     lockCreatedAt: string,
     resultIdentity: readonly string[],
   ) => Effect.Effect<RepositoryAudit, QualificationAuditCommandError, R>
-  readonly verifySourceCheckout: (sourceRevision: string) => Effect.Effect<void, QualificationAuditCommandError, R>
+  readonly verifySourceCheckout: (
+    sourceRevision: string,
+    candidateModulePath?: string,
+  ) => Effect.Effect<void, QualificationAuditCommandError, R>
 }
 
 export interface QualificationAuditAcquirers<R> {

--- a/services/bayn/src/qualification/audit-command/model.ts
+++ b/services/bayn/src/qualification/audit-command/model.ts
@@ -25,6 +25,8 @@ export const qualificationAuditConfig = Config.all({
   auditClickhouseUsername: Config.string('BAYN_AUDIT_CLICKHOUSE_USERNAME'),
   auditClickhousePassword: Config.redacted('BAYN_AUDIT_CLICKHOUSE_PASSWORD'),
   repositoryPath: Config.string('BAYN_AUDIT_REPOSITORY_PATH').pipe(Config.withDefault('.')),
+  candidateModulePath: Config.string('BAYN_AUDIT_CANDIDATE_MODULE_PATH').pipe(Config.withDefault('')),
+  candidateModuleSha256: Config.string('BAYN_AUDIT_CANDIDATE_MODULE_SHA256').pipe(Config.withDefault('')),
   operationTimeoutMs: Config.schema(PositiveInteger, 'BAYN_AUDIT_OPERATION_TIMEOUT_MS').pipe(
     Config.withDefault(60_000),
   ),

--- a/services/bayn/src/qualification/audit-command/program.ts
+++ b/services/bayn/src/qualification/audit-command/program.ts
@@ -31,6 +31,7 @@ const loadAuditStrategyApplication = (
   input: AuditConfig,
   sourceRevision: string,
   protocol: Parameters<typeof makeActiveStrategyApplication>[0],
+  expectedBehaviorHash: string,
 ): Effect.Effect<StrategyApplication<any, any, any>, QualificationAuditCommandError> => {
   if (input.candidateModulePath.trim().length === 0) return Effect.succeed(makeActiveStrategyApplication(protocol))
   if (!sha256Pattern.test(input.candidateModuleSha256)) {
@@ -43,7 +44,7 @@ const loadAuditStrategyApplication = (
   }
   return Effect.gen(function* () {
     const moduleBytes = yield* Effect.tryPromise({
-      try: () => readFile(input.candidateModulePath),
+      try: (signal) => readFile(input.candidateModulePath, { signal }),
       catch: (cause) =>
         qualificationAuditCommandError('repository', 'candidate strategy module could not be read', cause),
     })
@@ -53,6 +54,14 @@ const loadAuditStrategyApplication = (
         qualificationAuditCommandError(
           'repository',
           'candidate strategy module bytes do not match the qualification provenance',
+        ),
+      )
+    }
+    if (observedModuleSha256 !== expectedBehaviorHash) {
+      return yield* Effect.fail(
+        qualificationAuditCommandError(
+          'repository',
+          'candidate strategy module bytes do not match the persisted behavior identity',
         ),
       )
     }
@@ -109,7 +118,12 @@ export const runQualificationAudit = <R>(input: AuditConfig, readers: Qualificat
     }
     const manifest = yield* decodeInputManifestArtifact(inputManifestArtifact.payload)
     const protocol = database.protocol.parameters
-    const application = yield* loadAuditStrategyApplication(input, database.run.sourceRevision, protocol)
+    const application = yield* loadAuditStrategyApplication(
+      input,
+      database.run.sourceRevision,
+      protocol,
+      database.protocol.behaviorHash,
+    )
     const signal = yield* readers.loadSignal(manifest, protocol)
     const signalAccess = yield* readers.readSignalAccess(
       database,

--- a/services/bayn/src/qualification/audit-command/program.ts
+++ b/services/bayn/src/qualification/audit-command/program.ts
@@ -157,8 +157,10 @@ export const makeQualificationAuditReaders = <R>(
     acquirers
       .repository(input)
       .pipe(Effect.flatMap((repository) => repository.audit(sourceRevision, lockCreatedAt, resultIdentity))),
-  verifySourceCheckout: (sourceRevision) =>
-    acquirers.repository(input).pipe(Effect.flatMap((repository) => repository.verifySourceCheckout(sourceRevision))),
+  verifySourceCheckout: (sourceRevision, candidateModulePath) =>
+    acquirers
+      .repository(input)
+      .pipe(Effect.flatMap((repository) => repository.verifySourceCheckout(sourceRevision, candidateModulePath))),
 })
 
 export const runQualificationAudit = <R>(input: AuditConfig, readers: QualificationAuditReaders<R>) =>

--- a/services/bayn/src/qualification/audit-command/program.ts
+++ b/services/bayn/src/qualification/audit-command/program.ts
@@ -1,5 +1,6 @@
 import { createHash } from 'node:crypto'
-import { readFile } from 'node:fs/promises'
+import { readFile, realpath } from 'node:fs/promises'
+import { isAbsolute, relative, resolve, sep } from 'node:path'
 
 import { Effect } from 'effect'
 import { ChildProcessSpawner } from 'effect/unstable/process'
@@ -27,6 +28,35 @@ import { hashParameters } from '../../protocol'
 
 const sha256Pattern = /^[0-9a-f]{64}$/
 
+const verifiedCandidateModulePath = (input: AuditConfig): Effect.Effect<string, QualificationAuditCommandError> =>
+  Effect.gen(function* () {
+    const repositoryRoot = yield* Effect.tryPromise({
+      try: () => realpath(resolve(input.repositoryPath)),
+      catch: (cause) =>
+        qualificationAuditCommandError('repository', 'audit repository path could not be resolved', cause),
+    })
+    const modulePath = yield* Effect.tryPromise({
+      try: () => realpath(resolve(input.candidateModulePath)),
+      catch: (cause) =>
+        qualificationAuditCommandError('repository', 'candidate strategy module path could not be resolved', cause),
+    })
+    const relativeModulePath = relative(repositoryRoot, modulePath)
+    if (
+      relativeModulePath.length === 0 ||
+      relativeModulePath === '..' ||
+      relativeModulePath.startsWith(`..${sep}`) ||
+      isAbsolute(relativeModulePath)
+    ) {
+      return yield* Effect.fail(
+        qualificationAuditCommandError(
+          'repository',
+          'candidate strategy module must resolve inside the audit repository',
+        ),
+      )
+    }
+    return modulePath
+  })
+
 const loadAuditStrategyApplication = (
   input: AuditConfig,
   sourceRevision: string,
@@ -52,8 +82,9 @@ const loadAuditStrategyApplication = (
     )
   }
   return Effect.gen(function* () {
+    const modulePath = yield* verifiedCandidateModulePath(input)
     const moduleBytes = yield* Effect.tryPromise({
-      try: (signal) => readFile(input.candidateModulePath, { signal }),
+      try: (signal) => readFile(modulePath, { signal }),
       catch: (cause) =>
         qualificationAuditCommandError('repository', 'candidate strategy module could not be read', cause),
     })
@@ -74,7 +105,17 @@ const loadAuditStrategyApplication = (
         ),
       )
     }
-    const application = yield* loadReviewedStrategyApplication(input.candidateModulePath, sourceRevision).pipe(
+    const application = yield* loadReviewedStrategyApplication(modulePath, sourceRevision).pipe(
+      Effect.timeoutOrElse({
+        duration: input.operationTimeoutMs,
+        orElse: () =>
+          Effect.fail(
+            qualificationAuditCommandError(
+              'repository',
+              'candidate strategy application load exceeded the configured audit timeout',
+            ),
+          ),
+      }),
       Effect.mapError((cause) =>
         qualificationAuditCommandError('repository', 'candidate strategy application could not be loaded', cause),
       ),
@@ -89,7 +130,7 @@ const loadAuditStrategyApplication = (
     }
     return bindReviewedStrategySource(application, {
       sourceRevision,
-      modulePath: input.candidateModulePath,
+      modulePath,
       moduleSha256: input.candidateModuleSha256,
     })
   })
@@ -128,7 +169,11 @@ export const runQualificationAudit = <R>(input: AuditConfig, readers: Qualificat
       return yield* qualificationAuditCommandError('audit', 'input-manifest artifact is missing')
     }
     const manifest = yield* decodeInputManifestArtifact(inputManifestArtifact.payload)
-    yield* readers.verifySourceCheckout(database.run.sourceRevision)
+    const candidateModulePath = input.candidateModulePath.trim()
+    yield* readers.verifySourceCheckout(
+      database.run.sourceRevision,
+      candidateModulePath.length === 0 ? undefined : resolve(candidateModulePath),
+    )
     const protocol = database.protocol.parameters
     const application = yield* loadAuditStrategyApplication(
       input,

--- a/services/bayn/src/qualification/audit-command/program.ts
+++ b/services/bayn/src/qualification/audit-command/program.ts
@@ -116,6 +116,8 @@ export const makeQualificationAuditReaders = <R>(
     acquirers
       .repository(input)
       .pipe(Effect.flatMap((repository) => repository.audit(sourceRevision, lockCreatedAt, resultIdentity))),
+  verifySourceCheckout: (sourceRevision) =>
+    acquirers.repository(input).pipe(Effect.flatMap((repository) => repository.verifySourceCheckout(sourceRevision))),
 })
 
 export const runQualificationAudit = <R>(input: AuditConfig, readers: QualificationAuditReaders<R>) =>
@@ -126,6 +128,7 @@ export const runQualificationAudit = <R>(input: AuditConfig, readers: Qualificat
       return yield* qualificationAuditCommandError('audit', 'input-manifest artifact is missing')
     }
     const manifest = yield* decodeInputManifestArtifact(inputManifestArtifact.payload)
+    yield* readers.verifySourceCheckout(database.run.sourceRevision)
     const protocol = database.protocol.parameters
     const application = yield* loadAuditStrategyApplication(
       input,

--- a/services/bayn/src/qualification/audit-command/program.ts
+++ b/services/bayn/src/qualification/audit-command/program.ts
@@ -1,3 +1,6 @@
+import { createHash } from 'node:crypto'
+import { readFile } from 'node:fs/promises'
+
 import { Effect } from 'effect'
 import { ChildProcessSpawner } from 'effect/unstable/process'
 import * as Reactivity from 'effect/unstable/reactivity/Reactivity'
@@ -11,11 +14,68 @@ import {
   qualificationAuditCommandError,
   type AuditConfig,
   type QualificationAuditAcquirers,
+  type QualificationAuditCommandError,
   type QualificationAuditReaders,
 } from './model'
 import { acquireAuditRepositoryClient } from './repository'
 import { acquireAuditSignalClient, loadAuditSignal } from './signal'
 import { acquireAuditSignalReplicaClient, readAuditSignalAccess } from './signal-access'
+import { bindReviewedStrategySource, makeActiveStrategyApplication } from '../../strategy'
+import { loadReviewedStrategyApplication } from '../../candidate-development-local/source-module'
+import type { StrategyApplication } from '../../strategy/core'
+import { hashParameters } from '../../protocol'
+
+const sha256Pattern = /^[0-9a-f]{64}$/
+
+const loadAuditStrategyApplication = (
+  input: AuditConfig,
+  sourceRevision: string,
+  protocol: Parameters<typeof makeActiveStrategyApplication>[0],
+): Effect.Effect<StrategyApplication<any, any, any>, QualificationAuditCommandError> => {
+  if (input.candidateModulePath.trim().length === 0) return Effect.succeed(makeActiveStrategyApplication(protocol))
+  if (!sha256Pattern.test(input.candidateModuleSha256)) {
+    return Effect.fail(
+      qualificationAuditCommandError(
+        'configuration',
+        'BAYN_AUDIT_CANDIDATE_MODULE_SHA256 must be a lowercase SHA-256 digest',
+      ),
+    )
+  }
+  return Effect.gen(function* () {
+    const moduleBytes = yield* Effect.tryPromise({
+      try: () => readFile(input.candidateModulePath),
+      catch: (cause) =>
+        qualificationAuditCommandError('repository', 'candidate strategy module could not be read', cause),
+    })
+    const observedModuleSha256 = createHash('sha256').update(moduleBytes).digest('hex')
+    if (observedModuleSha256 !== input.candidateModuleSha256) {
+      return yield* Effect.fail(
+        qualificationAuditCommandError(
+          'repository',
+          'candidate strategy module bytes do not match the qualification provenance',
+        ),
+      )
+    }
+    const application = yield* loadReviewedStrategyApplication(input.candidateModulePath, sourceRevision).pipe(
+      Effect.mapError((cause) =>
+        qualificationAuditCommandError('repository', 'candidate strategy application could not be loaded', cause),
+      ),
+    )
+    if (hashParameters(application.definition.parameters) !== hashParameters(protocol)) {
+      return yield* Effect.fail(
+        qualificationAuditCommandError(
+          'repository',
+          'candidate strategy parameters do not match the persisted qualification protocol',
+        ),
+      )
+    }
+    return bindReviewedStrategySource(application, {
+      sourceRevision,
+      modulePath: input.candidateModulePath,
+      moduleSha256: input.candidateModuleSha256,
+    })
+  })
+}
 
 export const liveQualificationAuditAcquirers: QualificationAuditAcquirers<
   FileSystem.FileSystem | Reactivity.Reactivity | ChildProcessSpawner.ChildProcessSpawner
@@ -49,6 +109,7 @@ export const runQualificationAudit = <R>(input: AuditConfig, readers: Qualificat
     }
     const manifest = yield* decodeInputManifestArtifact(inputManifestArtifact.payload)
     const protocol = database.protocol.parameters
+    const application = yield* loadAuditStrategyApplication(input, database.run.sourceRevision, protocol)
     const signal = yield* readers.loadSignal(manifest, protocol)
     const signalAccess = yield* readers.readSignalAccess(
       database,
@@ -65,6 +126,7 @@ export const runQualificationAudit = <R>(input: AuditConfig, readers: Qualificat
       bars: signal.bars,
       manifest: signal.manifest,
       protocol,
+      application,
       database,
       signalReplicas: signalAccess.replicas,
       signalAccess: signalAccess.access,

--- a/services/bayn/src/qualification/audit-command/program.ts
+++ b/services/bayn/src/qualification/audit-command/program.ts
@@ -20,7 +20,7 @@ import {
 import { acquireAuditRepositoryClient } from './repository'
 import { acquireAuditSignalClient, loadAuditSignal } from './signal'
 import { acquireAuditSignalReplicaClient, readAuditSignalAccess } from './signal-access'
-import { bindReviewedStrategySource, makeActiveStrategyApplication } from '../../strategy'
+import { activeStrategyBehaviorHash, bindReviewedStrategySource, makeActiveStrategyApplication } from '../../strategy'
 import { loadReviewedStrategyApplication } from '../../candidate-development-local/source-module'
 import type { StrategyApplication } from '../../strategy/core'
 import { hashParameters } from '../../protocol'
@@ -33,7 +33,16 @@ const loadAuditStrategyApplication = (
   protocol: Parameters<typeof makeActiveStrategyApplication>[0],
   expectedBehaviorHash: string,
 ): Effect.Effect<StrategyApplication<any, any, any>, QualificationAuditCommandError> => {
-  if (input.candidateModulePath.trim().length === 0) return Effect.succeed(makeActiveStrategyApplication(protocol))
+  if (input.candidateModulePath.trim().length === 0) {
+    return expectedBehaviorHash === activeStrategyBehaviorHash
+      ? Effect.succeed(makeActiveStrategyApplication(protocol))
+      : Effect.fail(
+          qualificationAuditCommandError(
+            'configuration',
+            'BAYN_AUDIT_CANDIDATE_MODULE_PATH and BAYN_AUDIT_CANDIDATE_MODULE_SHA256 are required for the persisted strategy behavior',
+          ),
+        )
+  }
   if (!sha256Pattern.test(input.candidateModuleSha256)) {
     return Effect.fail(
       qualificationAuditCommandError(

--- a/services/bayn/src/qualification/audit-command/repository.ts
+++ b/services/bayn/src/qualification/audit-command/repository.ts
@@ -3,10 +3,10 @@ import { ChildProcess, ChildProcessSpawner } from 'effect/unstable/process'
 
 import type { RepositoryAudit } from '../../audit/audit'
 import {
+  QualificationAuditCommandError,
   qualificationAuditCommandError,
   type AcquireAuditRepositoryClient,
   type AuditRepositoryClient,
-  type QualificationAuditCommandError,
 } from './model'
 
 const repositoryAuditWithClient = (
@@ -47,12 +47,49 @@ const repositoryAuditWithClient = (
     ),
   )
 
+const verifySourceCheckoutWithClient = (
+  processes: ChildProcessSpawner.ChildProcessSpawner['Service'],
+  repositoryPath: string,
+  sourceRevision: string,
+): Effect.Effect<void, QualificationAuditCommandError> =>
+  Effect.gen(function* () {
+    const headLines = yield* processes.lines(
+      ChildProcess.make('git', ['-C', repositoryPath, '--no-optional-locks', 'rev-parse', '--verify', 'HEAD']),
+    )
+    const statusLines = yield* processes.lines(
+      ChildProcess.make('git', [
+        '-C',
+        repositoryPath,
+        '--no-optional-locks',
+        'status',
+        '--porcelain=v1',
+        '--untracked-files=all',
+      ]),
+    )
+    if (headLines[0] !== sourceRevision || statusLines.length > 0) {
+      return yield* Effect.fail(
+        qualificationAuditCommandError(
+          'repository',
+          'audit repository must be a clean checkout at the persisted source revision',
+        ),
+      )
+    }
+  }).pipe(
+    Effect.mapError((cause) =>
+      cause instanceof QualificationAuditCommandError
+        ? cause
+        : qualificationAuditCommandError('repository', 'audit source checkout could not be verified', cause),
+    ),
+  )
+
 export const acquireAuditRepositoryClient: AcquireAuditRepositoryClient<ChildProcessSpawner.ChildProcessSpawner> = (
   input,
 ) =>
   ChildProcessSpawner.ChildProcessSpawner.pipe(
     Effect.map(
       (processes): AuditRepositoryClient => ({
+        verifySourceCheckout: (sourceRevision) =>
+          verifySourceCheckoutWithClient(processes, input.repositoryPath, sourceRevision),
         audit: (sourceRevision, lockCreatedAt, resultIdentity) =>
           repositoryAuditWithClient(processes, input.repositoryPath, sourceRevision, lockCreatedAt, resultIdentity),
       }),

--- a/services/bayn/src/qualification/audit-command/repository.ts
+++ b/services/bayn/src/qualification/audit-command/repository.ts
@@ -51,6 +51,7 @@ const verifySourceCheckoutWithClient = (
   processes: ChildProcessSpawner.ChildProcessSpawner['Service'],
   repositoryPath: string,
   sourceRevision: string,
+  candidateModulePath?: string,
 ): Effect.Effect<void, QualificationAuditCommandError> =>
   Effect.gen(function* () {
     const headLines = yield* processes.lines(
@@ -66,7 +67,25 @@ const verifySourceCheckoutWithClient = (
         '--untracked-files=all',
       ]),
     )
-    if (headLines[0] !== sourceRevision || statusLines.length > 0) {
+    const trackedModuleLines =
+      candidateModulePath === undefined
+        ? []
+        : yield* processes.lines(
+            ChildProcess.make('git', [
+              '-C',
+              repositoryPath,
+              '--no-optional-locks',
+              'ls-files',
+              '--error-unmatch',
+              '--',
+              candidateModulePath,
+            ]),
+          )
+    if (
+      headLines[0] !== sourceRevision ||
+      statusLines.length > 0 ||
+      (candidateModulePath !== undefined && (trackedModuleLines.length !== 1 || trackedModuleLines[0] === undefined))
+    ) {
       return yield* Effect.fail(
         qualificationAuditCommandError(
           'repository',
@@ -88,8 +107,8 @@ export const acquireAuditRepositoryClient: AcquireAuditRepositoryClient<ChildPro
   ChildProcessSpawner.ChildProcessSpawner.pipe(
     Effect.map(
       (processes): AuditRepositoryClient => ({
-        verifySourceCheckout: (sourceRevision) =>
-          verifySourceCheckoutWithClient(processes, input.repositoryPath, sourceRevision),
+        verifySourceCheckout: (sourceRevision, candidateModulePath) =>
+          verifySourceCheckoutWithClient(processes, input.repositoryPath, sourceRevision, candidateModulePath),
         audit: (sourceRevision, lockCreatedAt, resultIdentity) =>
           repositoryAuditWithClient(processes, input.repositoryPath, sourceRevision, lockCreatedAt, resultIdentity),
       }),


### PR DESCRIPTION
## Summary

- Pass the reviewed pure strategy application into qualification audit replay.
- Load and SHA-256-bind the candidate module from the exact checked-out source before auditing.
- Preserve legacy risk-balanced-trend replay while adding candidate-aware replay and terminal close semantics.

## Related Issues

None

## Testing

- `bun run --cwd services/bayn tsc`
- `bun run --filter @proompteng/bayn lint:effect`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun test services/bayn/src/qualification-reference.test.ts services/bayn/src/qualification-audit.test.ts services/bayn/src/qualification-audit-command.test.ts`
- `bun run --cwd services/bayn test` (1109 pass, 154 skip, 0 fail)
- `bun test packages/scripts/src/bayn` (141 pass, 0 fail)
- `bun run --cwd services/bayn build`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled.
- [x] Documentation, release notes, and follow-ups are updated or tracked.