### PR TITLE
fix(bayn): allow Candidate 21 dormancy fixture descendant

### DIFF
--- a/services/bayn/src/candidate-development-local/command.test.ts
+++ b/services/bayn/src/candidate-development-local/command.test.ts
@@ -16,6 +16,7 @@ import {
   reserveCandidateDevelopmentLocalReceipt,
   runCandidateDevelopmentLocally,
   verifyCandidateDevelopmentSourceManifestBinding,
+  verifyCandidateDevelopmentLocalSourceDescendant,
   verifyCandidateDevelopmentLocalSourceTree,
   verifyCandidateDevelopmentSourceManifest,
   type CandidateDevelopmentLocalAttemptPort,
@@ -258,6 +259,43 @@ describe('candidate-development-local source and attempt lifecycle', () => {
       verifyCandidateDevelopmentLocalSourceTree('/repo', [sourceModulePath], sourceGit, sourceRevision),
     )
     expect(Exit.isFailure(exit)).toBe(true)
+  })
+
+  test('allows only the reviewed Candidate 21 dormancy fixture in a source descendant', async () => {
+    const allowedPaths = [
+      sourceModulePath,
+      sourceManifestPath,
+      'services/bayn/src/candidate-development-trials/ledger.ts',
+      'packages/scripts/src/bayn/verify-qualification-dormancy.test.ts',
+    ]
+    const sourceGit = (changedPaths: readonly string[]) => ({
+      text: async (_root: string, args: readonly string[]) => (args[0] === 'diff' ? changedPaths.join('\n') : ''),
+      bytes: async () => Buffer.alloc(0),
+    })
+
+    const accepted = await Effect.runPromiseExit(
+      verifyCandidateDevelopmentLocalSourceDescendant(
+        '/repo',
+        sourceRevision,
+        'f'.repeat(40),
+        sourceModulePath,
+        sourceManifestPath,
+        sourceGit(allowedPaths),
+      ),
+    )
+    expect(Exit.isSuccess(accepted)).toBe(true)
+
+    const rejected = await Effect.runPromiseExit(
+      verifyCandidateDevelopmentLocalSourceDescendant(
+        '/repo',
+        sourceRevision,
+        'f'.repeat(40),
+        sourceModulePath,
+        sourceManifestPath,
+        sourceGit([...allowedPaths, 'services/bayn/src/unrelated.ts']),
+      ),
+    )
+    expect(Exit.isFailure(rejected)).toBe(true)
   })
 
   test('reserves an attempt once and rejects replay', async () => {

--- a/services/bayn/src/candidate-development-local/command.ts
+++ b/services/bayn/src/candidate-development-local/command.ts
@@ -209,7 +209,7 @@ export const verifyCandidateDevelopmentLocalSourceTree = (
       ),
   })
 
-const verifyCandidateDevelopmentLocalSourceDescendant = (
+export const verifyCandidateDevelopmentLocalSourceDescendant = (
   repositoryRoot: string,
   reviewedSourceRevision: string,
   sourceRevision: string,

--- a/services/bayn/src/candidate-development-local/command.ts
+++ b/services/bayn/src/candidate-development-local/command.ts
@@ -57,6 +57,7 @@ import { loadReviewedStrategyApplication } from './source-module'
 
 const candidateDevelopmentEvaluatorSourcePath = 'services/bayn/src'
 const candidateDevelopmentTrialLedgerSourcePath = 'services/bayn/src/candidate-development-trials/ledger.ts'
+const candidateDevelopmentDormancyTestSourcePath = 'packages/scripts/src/bayn/verify-qualification-dormancy.test.ts'
 
 export interface CandidateDevelopmentSourceGit {
   readonly text: (repositoryRoot: string, args: readonly string[], signal?: AbortSignal) => Promise<string>
@@ -227,7 +228,12 @@ const verifyCandidateDevelopmentLocalSourceDescendant = (
       )
         .split('\n')
         .filter(Boolean)
-      const allowedPaths = new Set([modulePath, sourceManifestPath, candidateDevelopmentTrialLedgerSourcePath])
+      const allowedPaths = new Set([
+        modulePath,
+        sourceManifestPath,
+        candidateDevelopmentTrialLedgerSourcePath,
+        candidateDevelopmentDormancyTestSourcePath,
+      ])
       const unexpectedPath = changedPaths.find((path) => !allowedPaths.has(path))
       if (unexpectedPath !== undefined)
         throw new Error(`unapproved candidate source descendant path: ${unexpectedPath}`)
@@ -235,7 +241,7 @@ const verifyCandidateDevelopmentLocalSourceDescendant = (
     catch: (cause) =>
       localError(
         'SOURCE_BINDING_INVALID',
-        'candidate source descendants may only add the reviewed module, manifest, and terminal ledger data',
+        'candidate source descendants may only add the reviewed module, manifest, terminal ledger, and dormancy fixture',
         cause,
       ),
   })


### PR DESCRIPTION
## Summary

- Allow the exact Candidate 21 source-descendant check to include its reviewed dormancy fixture.
- Keep the local development boundary fail-closed for every other changed path.

## Root Cause

The pending Candidate 21 registration changes the dormancy fixture from the immutable Candidate 20 tombstone to the registered-but-not-approved Candidate 21 state. The exact descendant allowlist did not include that source-controlled fixture, so the one-shot development adapter would reject the valid reviewed source descendant before evaluation.

## Related Issues

None.

## Testing

- `bun test services/bayn/src/candidate-development-local/command.test.ts services/bayn/src/candidate-development-trials/ledger.test.ts` — 17 passed, 0 failed.
- `bun run --cwd services/bayn tsc`
- `bun run --filter @proompteng/bayn lint:effect`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bunx oxfmt --check services/bayn/src/candidate-development-local/command.ts`

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; no UI behavior changed.
- [x] No documentation or release-note changes are required.
