### PR TITLE
fix(bayn): preserve historical rejection integrity

### DIFF
--- a/services/bayn/src/candidate-development-trials/ledger.test.ts
+++ b/services/bayn/src/candidate-development-trials/ledger.test.ts
@@ -96,9 +96,11 @@ describe('Bayn candidate development trial ledger', () => {
 
   test('binds the terminal rejection to its report hash, status, and source revision', () => {
     const rejection = candidateDevelopmentTrialLedgerState.entries.at(-1)
+    const pending = candidateDevelopmentTrialLedgerState.entries.at(-2)
     if (rejection?._tag !== 'DEVELOPMENT_REJECTED' || rejection.terminalReport === undefined) {
       throw new Error('expected the terminal Candidate 21 rejection')
     }
+    if (pending?._tag !== 'DEVELOPMENT_PENDING') throw new Error('expected the pending Candidate 21 registration')
     const withRejection = (replacement: typeof rejection) =>
       qualificationDormancyDecisionFromLedgerState({
         ...candidateDevelopmentTrialLedgerState,
@@ -124,6 +126,83 @@ describe('Bayn candidate development trial ledger', () => {
     }
     expect(
       withRejection({
+        ...rejection,
+        terminalReport: alteredReport,
+        terminalReportHash: canonicalHashV1(alteredReport),
+      }),
+    ).toEqual({
+      ok: false,
+      issue: { path: 'entries.DEVELOPMENT_REJECTED.terminalReport.source.bindingHash', reason: 'INVALID_STATE' },
+    })
+
+    const successorPreregistration = {
+      ...pending.preregistration,
+      candidateOrdinal: 22,
+      priorTrialCount: 21,
+      modulePath: 'services/bayn/src/strategy/candidate-22.ts',
+      preregistration: {
+        sourceRevision: 'b'.repeat(40),
+        path: 'services/bayn/candidates/ordinal-22-preregistration.json',
+        blobOid: 'c'.repeat(40),
+      },
+    }
+    const successorSourceManifest = {
+      path: 'services/bayn/candidates/ordinal-22-source-manifest.json',
+      blobOid: 'd'.repeat(40),
+      sha256: 'e'.repeat(64),
+    }
+    const successorPending = {
+      _tag: 'DEVELOPMENT_PENDING' as const,
+      candidateOrdinal: 22,
+      priorTrialCount: 21,
+      strategyName: 'candidate-22',
+      preregistration: successorPreregistration,
+      sourceManifest: successorSourceManifest,
+    }
+    const withSuccessor = (replacement: typeof rejection) =>
+      qualificationDormancyDecisionFromLedgerState({
+        ...candidateDevelopmentTrialLedgerState,
+        entries: [...candidateDevelopmentTrialLedgerState.entries.slice(0, -1), replacement, successorPending],
+        activeCandidate: {
+          preregistration: successorPreregistration,
+          strategyName: successorPending.strategyName,
+          sourceManifest: successorSourceManifest,
+        },
+      })
+
+    expect(withSuccessor(rejection)).toEqual({
+      ok: true,
+      decision: { status: 'dormant', reason: 'development-not-approved', candidateOrdinal: 22 },
+    })
+    expect(
+      qualificationDormancyDecisionFromLedgerState({
+        ...candidateDevelopmentTrialLedgerState,
+        entries: [...candidateDevelopmentTrialLedgerState.entries.slice(0, -2), rejection, successorPending],
+        activeCandidate: {
+          preregistration: successorPreregistration,
+          strategyName: successorPending.strategyName,
+          sourceManifest: successorSourceManifest,
+        },
+      }),
+    ).toEqual({
+      ok: false,
+      issue: { path: 'entries.DEVELOPMENT_REJECTED.binding', reason: 'INVALID_STATE' },
+    })
+    expect(withSuccessor({ ...rejection, terminalReportHash: '0'.repeat(64) })).toEqual({
+      ok: false,
+      issue: { path: 'entries.DEVELOPMENT_REJECTED.terminalReportHash', reason: 'INVALID_STATE' },
+    })
+    expect(
+      withSuccessor({
+        ...rejection,
+        terminalReport: { ...rejection.terminalReport, status: 'PASS' },
+      }),
+    ).toEqual({
+      ok: false,
+      issue: { path: 'entries.DEVELOPMENT_REJECTED.terminalReport.status', reason: 'INVALID_STATE' },
+    })
+    expect(
+      withSuccessor({
         ...rejection,
         terminalReport: alteredReport,
         terminalReportHash: canonicalHashV1(alteredReport),

--- a/services/bayn/src/candidate-development-trials/qualification-dormancy.ts
+++ b/services/bayn/src/candidate-development-trials/qualification-dormancy.ts
@@ -291,7 +291,16 @@ const validateLedger = (
       previous._tag === 'DEVELOPMENT_PENDING' &&
       entry._tag === 'DEVELOPMENT_REJECTED' &&
       previous.candidateOrdinal === entry.candidateOrdinal
-    if (isDevelopmentRejectionAfterPending) continue
+    if (entry._tag === 'DEVELOPMENT_REJECTED' && entry.candidateOrdinal >= 20 && !isDevelopmentRejectionAfterPending) {
+      return { ok: false, result: invalidLedger('entries.DEVELOPMENT_REJECTED.binding') }
+    }
+    if (isDevelopmentRejectionAfterPending) {
+      if (entry.candidateOrdinal >= 20) {
+        const rejectionIssue = validateDevelopmentRejectionEvidence(entry, previous)
+        if (rejectionIssue !== undefined) return { ok: false, result: rejectionIssue }
+      }
+      continue
+    }
 
     if (entry.candidateOrdinal !== previous.candidateOrdinal + 1) {
       return {
@@ -369,14 +378,6 @@ export const qualificationDormancyDecisionFromLedgerState = (
       }
     }
     if (last?._tag === 'DEVELOPMENT_REJECTED') {
-      if (last.candidateOrdinal >= 20) {
-        const pending = entries.at(-2)
-        if (pending?._tag !== 'DEVELOPMENT_PENDING' || pending.candidateOrdinal !== last.candidateOrdinal) {
-          return invalidLedger('entries.DEVELOPMENT_REJECTED.binding')
-        }
-        const rejectionIssue = validateDevelopmentRejectionEvidence(last, pending)
-        if (rejectionIssue !== undefined) return rejectionIssue
-      }
       return {
         ok: true,
         decision: { status: 'dormant', reason: 'development-rejected', candidateOrdinal: last.candidateOrdinal },


### PR DESCRIPTION
## Summary

- Validate every modern development rejection while traversing the append-only trial ledger, including rejections that become historical after a successor is registered.
- Keep legacy Candidate 17-19 receipt-less entries compatible while preserving strict Candidate 20+ evidence integrity.
- Add a real Candidate 22 successor regression proving Candidate 21 hash, status, and source-binding tampering still fail closed.

## Related Issues

None

## Testing

- `bun test services/bayn/src/candidate-development-trials/ledger.test.ts services/bayn/src/candidate-development-trials/qualification-dormancy.test.ts packages/scripts/src/bayn/verify-qualification-dormancy.test.ts` (20 pass, 0 fail)
- `bun run --filter @proompteng/bayn test` (1,113 pass, 154 PostgreSQL-only skips, 0 fail)
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint:effect`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn build`
- `bunx oxfmt --check services/bayn/src/candidate-development-trials/qualification-dormancy.ts services/bayn/src/candidate-development-trials/ledger.test.ts`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] No documentation or release note change is required for this internal integrity correction; Candidate 21 was not rerun and no qualification or PAPER action occurred.