### PR TITLE
feat(bayn): register Candidate 22 source

### DIFF
--- a/packages/scripts/src/bayn/verify-qualification-dormancy.test.ts
+++ b/packages/scripts/src/bayn/verify-qualification-dormancy.test.ts
@@ -25,8 +25,8 @@ describe('qualification dormancy command', () => {
     const decision = await verifyQualificationDormancy(repositoryRoot)
     expect(decision).toEqual({
       status: 'dormant',
-      reason: 'development-rejected',
-      candidateOrdinal: 21,
+      reason: 'development-not-approved',
+      candidateOrdinal: 22,
     })
   })
 
@@ -84,7 +84,7 @@ describe('qualification dormancy command', () => {
       expect(stderr).toBe('')
       expect(stdout).toContain('"status":"dormant"')
       expect(await readFile(githubOutput, 'utf8')).toBe(
-        'eligible=false\ndormant=true\nreason=development-rejected\ncandidate_ordinal=21\n',
+        'eligible=false\ndormant=true\nreason=development-not-approved\ncandidate_ordinal=22\n',
       )
     } finally {
       await rm(directory, { recursive: true, force: true })

--- a/services/bayn/candidates/ordinal-22-source-manifest.json
+++ b/services/bayn/candidates/ordinal-22-source-manifest.json
@@ -1,0 +1,17 @@
+{
+  "schemaVersion": "bayn.candidate-development-source-manifest.v2",
+  "candidateOrdinal": 22,
+  "priorTrialCount": 21,
+  "trialHistoryHash": "d0ea5dc985522a99ce93f530218d52a42eb846bea73b5c2a56640bfd2d59ff96",
+  "strategyName": "candidate-22-low-dispersion-momentum-tilt",
+  "strategyProtocolHash": "7439fb7aa6838f77fd936b3332851981bb8c1c8a713653107a8baa43e6eb53ab",
+  "modulePath": "services/bayn/src/strategy/candidate-22.ts",
+  "moduleSha256": "938a2f83f11c81f10325365f4b0456097c7038eee84e3fc08687f1d4d08d7177",
+  "moduleFormat": "typescript-strategy-application-v1",
+  "marketData": {
+    "schemaVersion": "bayn.candidate-development-market-data-source.v2",
+    "snapshotId": "2a91f0177684f7022f746207333e510c8268f9b77a04b778a04220a33ccf79e0",
+    "inputManifestHash": "1e5377336f2e6feb751000114b81cc89aee5be7542e213c320f2cfbb4185bb2b",
+    "boundedContentHash": "b6052c8ebdca855973adf4e41efafb5028fd8dbbaa70809331f6017519b1c995"
+  }
+}

--- a/services/bayn/src/candidate-development-trials/ledger.ts
+++ b/services/bayn/src/candidate-development-trials/ledger.ts
@@ -168,6 +168,40 @@ const historicalLedger = [
       qualificationAnalysisHash: '4a47fa4c5a77ecf162427cba22d101f6f1b0e482c5ca222f58cc6fdeb93f3852',
     },
   },
+  {
+    _tag: 'DEVELOPMENT_PENDING' as const,
+    candidateOrdinal: 22,
+    priorTrialCount: 21,
+    strategyName: 'candidate-22-low-dispersion-momentum-tilt',
+    preregistration: {
+      schemaVersion: 'bayn.candidate-development-next-preregistration.v1' as const,
+      candidateOrdinal: 22,
+      priorTrialCount: 21,
+      strategyProtocolHash: '7439fb7aa6838f77fd936b3332851981bb8c1c8a713653107a8baa43e6eb53ab',
+      candidateDevelopmentProtocolHash: '0fbd4067a7421ff8f575dc876e94fae2893457b8a33add847f5e26dfde8091a9',
+      calendarHash: '4b2f519f336e4e730c1f0d69e860f25a8d4d0cfbd8e93c6b333ea83623d87237',
+      priorTrialsHash: 'd0ea5dc985522a99ce93f530218d52a42eb846bea73b5c2a56640bfd2d59ff96',
+      modulePath: 'services/bayn/src/strategy/candidate-22.ts',
+      moduleSha256: '938a2f83f11c81f10325365f4b0456097c7038eee84e3fc08687f1d4d08d7177',
+      marketData: {
+        schemaVersion: 'bayn.candidate-development-market-data-source.v1' as const,
+        snapshotId: '2a91f0177684f7022f746207333e510c8268f9b77a04b778a04220a33ccf79e0',
+        finalizedSnapshotContentHash: '8e376546f6a6cc1dbe2e910db3d68f584fc0bd9c4858166042ce32aa077eed0d',
+        inputManifestHash: '1e5377336f2e6feb751000114b81cc89aee5be7542e213c320f2cfbb4185bb2b',
+        boundedContentHash: 'b6052c8ebdca855973adf4e41efafb5028fd8dbbaa70809331f6017519b1c995',
+      },
+      preregistration: {
+        sourceRevision: 'eaa0f5d9b1a9ba72d1c4eda705187013c290a40a',
+        path: 'services/bayn/candidates/ordinal-22-low-dispersion-momentum-tilt-preregistration.json',
+        blobOid: 'b5833a1ef8ccb27a20c8b434881f90c75cc953fb',
+      },
+    },
+    sourceManifest: {
+      path: 'services/bayn/candidates/ordinal-22-source-manifest.json',
+      blobOid: '19f1104b1bb508027175409a3dbedab77fcc0a32',
+      sha256: '7ec1c6b5dd9147f4a810cfa2353e5607ddc39d6b4ffb0bdb3354af1af1ddb11c',
+    },
+  },
 ] as const
 
 /** One append-only source-controlled ledger. Candidate 20 is represented once as the terminal tombstone entry. */

--- a/services/bayn/src/strategy/candidate-22.ts
+++ b/services/bayn/src/strategy/candidate-22.ts
@@ -1,0 +1,262 @@
+import { Result, pipe } from 'effect'
+
+import { annualizedPortfolioVolatility } from './risk-balanced-trend/risk'
+import {
+  makeRiskBalancedTrendApplication,
+  type RiskBalancedTrendMarketContext,
+  type RiskBalancedTrendStrategyDefinition,
+} from './risk-balanced-trend'
+import { makeRiskBalancedTrendDecision } from './risk-balanced-trend/decision'
+import { dailyReturns, WEIGHT_SCALE } from './risk-balanced-trend/shared'
+import { decodeDefaultProtocol } from '../protocol'
+import type { RiskBalancedTrendFailure } from '../risk-balanced-trend/model'
+import type { DecisionPlan, Protocol } from '../types'
+
+const protocol = Result.getOrThrow(decodeDefaultProtocol())
+
+const momentumHorizon = 252
+const momentumSkip = 21
+const dispersionHorizon = 21
+const dispersionObservationCount = 12
+const activeWeight = 0.35
+const baselineWeight = 0.1
+const neutralWeight = 0.2
+
+/**
+ * Frozen hypothesis: recent cross-sectional dispersion is a negative state variable for momentum, so the strategy
+ * adds a bounded 12-minus-1 tilt only below its trailing dispersion median. See Stivers and Sun (2010),
+ * doi:10.1017/S0022109010000384, and Asness, Moskowitz, and Pedersen (2013), doi:10.1111/jofi.12021.
+ */
+
+const fail = <A = never>(failure: RiskBalancedTrendFailure): Result.Result<A, RiskBalancedTrendFailure> =>
+  Result.fail(failure)
+
+const closeHistory = (
+  context: RiskBalancedTrendMarketContext,
+  symbol: string,
+): Result.Result<readonly number[], RiskBalancedTrendFailure> => {
+  const closes = context.closes[symbol]
+  if (closes === undefined || closes.length !== context.sessionDates.length) {
+    return fail({
+      _tag: 'RiskBalancedTrendCloseHistoryMismatch',
+      symbol,
+      expectedCount: context.sessionDates.length,
+      observedCount: closes?.length ?? 0,
+    })
+  }
+  const invalidIndex = closes.findIndex((close) => !Number.isFinite(close) || close <= 0)
+  return invalidIndex < 0
+    ? Result.succeed(closes)
+    : fail({
+        _tag: 'InvalidRiskBalancedTrendClose',
+        symbol,
+        index: invalidIndex,
+        value: closes.at(invalidIndex) ?? Number.NaN,
+      })
+}
+
+const returnEndingAt = (
+  closes: readonly number[],
+  symbol: string,
+  endIndex: number,
+  horizon: number,
+): Result.Result<number, RiskBalancedTrendFailure> => {
+  const current = closes.at(endIndex)
+  const prior = closes.at(endIndex - horizon)
+  if (current === undefined || prior === undefined) {
+    return fail({ _tag: 'MissingRiskBalancedTrendClose', symbol, horizonSessions: horizon })
+  }
+  const value = current / prior - 1
+  return Number.isFinite(value)
+    ? Result.succeed(value)
+    : fail({
+        _tag: 'InvalidRiskBalancedTrendNumber',
+        operation: 'horizon-return',
+        value,
+        symbol,
+        reason: 'not-finite',
+      })
+}
+
+const sampleDispersion = (values: readonly number[]): number => {
+  const mean = values.reduce((total, value) => total + value, 0) / values.length
+  return Math.sqrt(values.reduce((total, value) => total + (value - mean) ** 2, 0) / (values.length - 1))
+}
+
+const dispersionEndingAt = (
+  context: RiskBalancedTrendMarketContext,
+  endIndex: number,
+  candidateProtocol: Protocol,
+): Result.Result<number, RiskBalancedTrendFailure> =>
+  pipe(
+    Result.all(
+      candidateProtocol.universe.map((symbol) =>
+        pipe(
+          closeHistory(context, symbol),
+          Result.flatMap((closes) => returnEndingAt(closes, symbol, endIndex, dispersionHorizon)),
+        ),
+      ),
+    ),
+    Result.map(sampleDispersion),
+  )
+
+const median = (values: readonly number[]): number => {
+  const ordered = [...values].sort((left, right) => left - right)
+  return ordered[Math.floor(ordered.length / 2)] ?? Number.NaN
+}
+
+const lowDispersionRegime = (
+  context: RiskBalancedTrendMarketContext,
+  candidateProtocol: Protocol,
+): Result.Result<boolean, RiskBalancedTrendFailure> => {
+  const lastIndex = context.sessionDates.length - 1
+  return pipe(
+    Result.all(
+      Array.from({ length: dispersionObservationCount }, (_, offset) =>
+        dispersionEndingAt(context, lastIndex - offset * dispersionHorizon, candidateProtocol),
+      ),
+    ),
+    Result.map(([current, ...history]) => current !== undefined && current < median(history)),
+  )
+}
+
+const momentumScores = (
+  context: RiskBalancedTrendMarketContext,
+  candidateProtocol: Protocol,
+): Result.Result<Readonly<Record<string, number>>, RiskBalancedTrendFailure> => {
+  const endIndex = context.sessionDates.length - 1 - momentumSkip
+  return pipe(
+    Result.all(
+      candidateProtocol.universe.map((symbol) =>
+        pipe(
+          closeHistory(context, symbol),
+          Result.flatMap((closes) => returnEndingAt(closes, symbol, endIndex, momentumHorizon - momentumSkip)),
+          Result.map((score) => [symbol, score] as const),
+        ),
+      ),
+    ),
+    Result.map(Object.fromEntries),
+  )
+}
+
+const requestedWeights = (
+  scores: Readonly<Record<string, number>>,
+  tiltMomentum: boolean,
+  candidateProtocol: Protocol,
+): Readonly<Record<string, number>> => {
+  if (!tiltMomentum) return Object.fromEntries(candidateProtocol.universe.map((symbol) => [symbol, neutralWeight]))
+  const leaders = new Set(
+    [...candidateProtocol.universe]
+      .sort(
+        (left, right) =>
+          (scores[right] ?? Number.NEGATIVE_INFINITY) - (scores[left] ?? Number.NEGATIVE_INFINITY) ||
+          left.localeCompare(right),
+      )
+      .slice(0, 2),
+  )
+  return Object.fromEntries(
+    candidateProtocol.universe.map((symbol) => [symbol, leaders.has(symbol) ? activeWeight : baselineWeight]),
+  )
+}
+
+const volatilityScaledWeights = (
+  context: RiskBalancedTrendMarketContext,
+  weights: Readonly<Record<string, number>>,
+  candidateProtocol: Protocol,
+): Result.Result<
+  {
+    readonly estimatedAnnualizedPortfolioVolatility: number
+    readonly exposureScale: number
+    readonly targetWeights: Readonly<Record<string, number>>
+  },
+  RiskBalancedTrendFailure
+> =>
+  pipe(
+    Result.all(
+      candidateProtocol.universe.map((symbol) =>
+        pipe(
+          closeHistory(context, symbol),
+          Result.flatMap((closes) => dailyReturns(closes, candidateProtocol.volatilityWindow, symbol)),
+          Result.map((returns) => [symbol, returns] as const),
+        ),
+      ),
+    ),
+    Result.flatMap((returnEntries) => {
+      const returnSeries = Object.fromEntries(returnEntries)
+      return pipe(
+        annualizedPortfolioVolatility(weights, returnSeries),
+        Result.flatMap((estimatedAnnualizedPortfolioVolatility) => {
+          const exposureScale =
+            estimatedAnnualizedPortfolioVolatility === 0
+              ? 1
+              : Math.min(1, candidateProtocol.maximumPortfolioVolatility / estimatedAnnualizedPortfolioVolatility)
+          const targetWeights = Object.fromEntries(
+            Object.entries(weights).map(([symbol, weight]) => [
+              symbol,
+              Math.floor(weight * exposureScale * WEIGHT_SCALE) / WEIGHT_SCALE,
+            ]),
+          )
+          return pipe(
+            annualizedPortfolioVolatility(targetWeights, returnSeries),
+            Result.flatMap((observedAnnualizedPortfolioVolatility) =>
+              observedAnnualizedPortfolioVolatility > candidateProtocol.maximumPortfolioVolatility + 1e-12
+                ? fail({
+                    _tag: 'UnboundedRiskBalancedTrendWeights',
+                    totalWeight: Object.values(targetWeights).reduce((total, weight) => total + weight, 0),
+                    maximumSymbolWeight: candidateProtocol.maximumSymbolWeight,
+                    maximumPortfolioVolatility: candidateProtocol.maximumPortfolioVolatility,
+                    observedPortfolioVolatility: observedAnnualizedPortfolioVolatility,
+                  })
+                : Result.succeed({ estimatedAnnualizedPortfolioVolatility, exposureScale, targetWeights }),
+            ),
+          )
+        }),
+      )
+    }),
+  )
+
+const candidate22Decision = (
+  context: RiskBalancedTrendMarketContext,
+  candidateProtocol: Protocol,
+): Result.Result<DecisionPlan, RiskBalancedTrendFailure> =>
+  pipe(
+    Result.all({
+      base: makeRiskBalancedTrendDecision(context.signalDate, context.sessionDates, context.closes, candidateProtocol),
+      lowDispersion: lowDispersionRegime(context, candidateProtocol),
+      scores: momentumScores(context, candidateProtocol),
+    }),
+    Result.flatMap(({ base, lowDispersion, scores }) => {
+      const weights = requestedWeights(scores, lowDispersion, candidateProtocol)
+      return pipe(
+        volatilityScaledWeights(context, weights, candidateProtocol),
+        Result.map(({ estimatedAnnualizedPortfolioVolatility, exposureScale, targetWeights }) => ({
+          ...base,
+          estimatedAnnualizedPortfolioVolatility,
+          exposureScale,
+          targetWeights,
+          signals: base.signals.map((signal) => {
+            const score = scores[signal.symbol] ?? 0
+            const targetWeight = targetWeights[signal.symbol] ?? 0
+            return {
+              ...signal,
+              compositeScore: score,
+              positiveScore: Math.max(0, score),
+              eligible: true,
+              uncappedWeight: weights[signal.symbol] ?? 0,
+              cappedWeight: weights[signal.symbol] ?? 0,
+              targetWeight,
+            }
+          }),
+        })),
+      )
+    }),
+  )
+
+const definition: RiskBalancedTrendStrategyDefinition = {
+  name: 'candidate-22-low-dispersion-momentum-tilt',
+  parameters: protocol,
+  decide: ({ market }) => candidate22Decision(market, protocol),
+}
+
+/** Result-blind low-dispersion momentum tilt; the adapter supplies only reviewed, verified market context. */
+export const strategyApplication = makeRiskBalancedTrendApplication(protocol, definition)


### PR DESCRIPTION
## Summary

- Publishes the preregistered Candidate 22 low-dispersion momentum-tilt module and exact source manifest from reviewed source revision `eaa0f5d9b1a9ba72d1c4eda705187013c290a40a`.
- Appends one `DEVELOPMENT_PENDING` ledger entry bound to the canonical 22-entry history, immutable preregistration blob, module SHA-256, and source-manifest blob/SHA-256.
- Keeps qualification dormant as `development-not-approved`; this PR neither evaluates the frozen witness nor consumes Candidate 22's single development attempt.
- Changes exactly the four paths permitted by the one-shot source-descendant contract; it does not release or deploy the candidate.

The strategy is a pure, long-only monthly decision: it keeps the existing volatility-scaled equal-weight five-ETF benchmark unless current 21-session cross-sectional dispersion is below its previous 11-block median; in that regime it assigns 35% each to the two 12-minus-1 momentum leaders and 10% to the remaining symbols, then uniformly scales down to the existing portfolio-volatility cap.

## Related Issues

PROOMPT-448

## Testing

- Focused lifecycle, source-boundary, and local strategy checks: 30 pass, 0 fail.
- `bun run test`: 1,118 pass, 154 PostgreSQL-only skips, 0 fail across 99 files.
- `bun run tsc`: clean.
- `bun run lint:effect`: 509 files checked, 0 errors.
- `bun run lint:oxlint:type`: 510 files checked, 0 warnings or errors.
- `bun run build`: four Bayn entrypoints bundled successfully.
- Independently verified the exact descendant path set, module SHA-256 `938a2f83f11c81f10325365f4b0456097c7038eee84e3fc08687f1d4d08d7177`, manifest blob `19f1104b1bb508027175409a3dbedab77fcc0a32`, manifest SHA-256 `7ec1c6b5dd9147f4a810cfa2353e5607ddc39d6b4ffb0bdb3354af1af1ddb11c`, and preregistration blob `b5833a1ef8ccb27a20c8b434881f90c75cc953fb`.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] The one allowed local development attempt and conditional qualification/PAPER follow-up remain tracked in PROOMPT-448.
