### PR TITLE
chore(bayn): record Candidate 22 rejection

### DIFF
--- a/packages/scripts/src/bayn/verify-qualification-dormancy.test.ts
+++ b/packages/scripts/src/bayn/verify-qualification-dormancy.test.ts
@@ -25,7 +25,7 @@ describe('qualification dormancy command', () => {
     const decision = await verifyQualificationDormancy(repositoryRoot)
     expect(decision).toEqual({
       status: 'dormant',
-      reason: 'development-not-approved',
+      reason: 'development-rejected',
       candidateOrdinal: 22,
     })
   })
@@ -84,7 +84,7 @@ describe('qualification dormancy command', () => {
       expect(stderr).toBe('')
       expect(stdout).toContain('"status":"dormant"')
       expect(await readFile(githubOutput, 'utf8')).toBe(
-        'eligible=false\ndormant=true\nreason=development-not-approved\ncandidate_ordinal=22\n',
+        'eligible=false\ndormant=true\nreason=development-rejected\ncandidate_ordinal=22\n',
       )
     } finally {
       await rm(directory, { recursive: true, force: true })

--- a/services/bayn/src/candidate-development-trials/ledger.test.ts
+++ b/services/bayn/src/candidate-development-trials/ledger.test.ts
@@ -85,37 +85,25 @@ describe('Bayn candidate development trial ledger', () => {
     expect(candidateDevelopmentTrialLedgerState.completedCandidateOrdinals).toEqual(
       Array.from({ length: 16 }, (_, index) => index + 1),
     )
-    expect(candidateDevelopmentTrialLedgerState.developmentCandidateOrdinals).toEqual([17, 18, 19, 21])
+    expect(candidateDevelopmentTrialLedgerState.developmentCandidateOrdinals).toEqual([17, 18, 19, 21, 22])
     expect(candidateDevelopmentTrialLedgerState.latestInvalidPrecommit?.status).toBe('PRECOMMIT_INVALID')
-    const active = candidateDevelopmentTrialLedgerState.activeCandidate
-    if (active === null) {
-      expect(qualificationDormancyDecisionFromLedgerState(candidateDevelopmentTrialLedgerState)).toEqual({
-        ok: true,
-        decision: { status: 'dormant', reason: 'development-rejected', candidateOrdinal: 21 },
-      })
-    } else {
-      expect(active).toMatchObject({
-        strategyName: 'candidate-22-low-dispersion-momentum-tilt',
-        preregistration: { candidateOrdinal: 22, priorTrialCount: 21 },
-        sourceManifest: { path: 'services/bayn/candidates/ordinal-22-source-manifest.json' },
-      })
-      expect(qualificationDormancyDecisionFromLedgerState(candidateDevelopmentTrialLedgerState)).toEqual({
-        ok: true,
-        decision: { status: 'dormant', reason: 'development-not-approved', candidateOrdinal: 22 },
-      })
-    }
+    expect(candidateDevelopmentTrialLedgerState.activeCandidate).toBeNull()
+    expect(qualificationDormancyDecisionFromLedgerState(candidateDevelopmentTrialLedgerState)).toEqual({
+      ok: true,
+      decision: { status: 'dormant', reason: 'development-rejected', candidateOrdinal: 22 },
+    })
   })
 
   test('binds the terminal rejection to its report hash, status, and source revision', () => {
     const rejectionIndex = candidateDevelopmentTrialLedgerState.entries.findIndex(
-      (entry) => entry._tag === 'DEVELOPMENT_REJECTED' && entry.candidateOrdinal === 21,
+      (entry) => entry._tag === 'DEVELOPMENT_REJECTED' && entry.candidateOrdinal === 22,
     )
     const rejection = candidateDevelopmentTrialLedgerState.entries.at(rejectionIndex)
     const pending = candidateDevelopmentTrialLedgerState.entries.at(rejectionIndex - 1)
     if (rejection?._tag !== 'DEVELOPMENT_REJECTED' || rejection.terminalReport === undefined) {
-      throw new Error('expected the terminal Candidate 21 rejection')
+      throw new Error('expected the terminal Candidate 22 rejection')
     }
-    if (pending?._tag !== 'DEVELOPMENT_PENDING') throw new Error('expected the pending Candidate 21 registration')
+    if (pending?._tag !== 'DEVELOPMENT_PENDING') throw new Error('expected the pending Candidate 22 registration')
     const withRejection = (replacement: typeof rejection) =>
       qualificationDormancyDecisionFromLedgerState({
         ...candidateDevelopmentTrialLedgerState,
@@ -152,17 +140,20 @@ describe('Bayn candidate development trial ledger', () => {
       issue: { path: 'entries.DEVELOPMENT_REJECTED.terminalReport.source.bindingHash', reason: 'INVALID_STATE' },
     })
 
-    expect(withRejection(rejection)).toEqual(
-      candidateDevelopmentTrialLedgerState.activeCandidate === null
-        ? {
-            ok: true,
-            decision: { status: 'dormant', reason: 'development-rejected', candidateOrdinal: 21 },
-          }
-        : {
-            ok: true,
-            decision: { status: 'dormant', reason: 'development-not-approved', candidateOrdinal: 22 },
-          },
-    )
+    expect(rejection).toMatchObject({
+      sourceRevision: '85677b0f4b8396bceba7bf33d6d2fca4e81c6d0c',
+      terminalReportHash: '56d845e58845106a54569278eb5c265437dbe288ac93a1d97de2dc886169af24',
+      terminalReport: {
+        status: 'HOLD_REJECT',
+        evaluationHash: 'bd98ee2294dd48caecf682419e0b094f92cac1972be7af7aff8363a60188fa00',
+        targetHash: 'e9e46ab3cecfaa95cd88cb65a83a571edfbc05909b9940057e2bea5277f78acf',
+        qualificationAnalysisHash: 'fdb003763930de38e74d0c3ab00d9fa6480ad35a973b8ca884fd8987750e7533',
+      },
+    })
+    expect(withRejection(rejection)).toEqual({
+      ok: true,
+      decision: { status: 'dormant', reason: 'development-rejected', candidateOrdinal: 22 },
+    })
     expect(
       qualificationDormancyDecisionFromLedgerState({
         ...candidateDevelopmentTrialLedgerState,

--- a/services/bayn/src/candidate-development-trials/ledger.ts
+++ b/services/bayn/src/candidate-development-trials/ledger.ts
@@ -202,6 +202,38 @@ const historicalLedger = [
       sha256: '7ec1c6b5dd9147f4a810cfa2353e5607ddc39d6b4ffb0bdb3354af1af1ddb11c',
     },
   },
+  {
+    _tag: 'DEVELOPMENT_REJECTED' as const,
+    candidateOrdinal: 22,
+    priorTrialCount: 21,
+    sourceRevision: '85677b0f4b8396bceba7bf33d6d2fca4e81c6d0c',
+    terminalReportHash: '56d845e58845106a54569278eb5c265437dbe288ac93a1d97de2dc886169af24',
+    terminalReport: {
+      schemaVersion: 'bayn.candidate-development-local-terminal.v1' as const,
+      source: {
+        candidateOrdinal: 22,
+        priorTrialCount: 21,
+        trialHistoryHash: 'd0ea5dc985522a99ce93f530218d52a42eb846bea73b5c2a56640bfd2d59ff96',
+        strategyName: 'candidate-22-low-dispersion-momentum-tilt',
+        strategyProtocolHash: '7439fb7aa6838f77fd936b3332851981bb8c1c8a713653107a8baa43e6eb53ab',
+        snapshotId: '2a91f0177684f7022f746207333e510c8268f9b77a04b778a04220a33ccf79e0',
+        inputManifestHash: '1e5377336f2e6feb751000114b81cc89aee5be7542e213c320f2cfbb4185bb2b',
+        boundedContentHash: 'b6052c8ebdca855973adf4e41efafb5028fd8dbbaa70809331f6017519b1c995',
+        sourceRevision: '85677b0f4b8396bceba7bf33d6d2fca4e81c6d0c',
+        modulePath: 'services/bayn/src/strategy/candidate-22.ts',
+        moduleBlobOid: '98f632c5b6ac5022221089a8646387008456c316',
+        moduleSha256: '938a2f83f11c81f10325365f4b0456097c7038eee84e3fc08687f1d4d08d7177',
+        sourceManifestPath: 'services/bayn/candidates/ordinal-22-source-manifest.json',
+        sourceManifestBlobOid: '19f1104b1bb508027175409a3dbedab77fcc0a32',
+        sourceManifestSha256: '7ec1c6b5dd9147f4a810cfa2353e5607ddc39d6b4ffb0bdb3354af1af1ddb11c',
+        bindingHash: '82326feb8cbb26a854b6ea0cb922ec5e199713562057079fdbf2bdcc3e851654',
+      },
+      status: 'HOLD_REJECT',
+      evaluationHash: 'bd98ee2294dd48caecf682419e0b094f92cac1972be7af7aff8363a60188fa00',
+      targetHash: 'e9e46ab3cecfaa95cd88cb65a83a571edfbc05909b9940057e2bea5277f78acf',
+      qualificationAnalysisHash: 'fdb003763930de38e74d0c3ab00d9fa6480ad35a973b8ca884fd8987750e7533',
+    },
+  },
 ] as const
 
 /** One append-only source-controlled ledger. Candidate 20 is represented once as the terminal tombstone entry. */


### PR DESCRIPTION
## Summary

- Append the exact digest-bound Candidate 22 HOLD_REJECT receipt produced by its single allowed development attempt.
- Close the active registration and make qualification remain dormant with the explicit development-rejected reason.
- Add exact source/report hash regressions while preserving Candidate 20 as PRECOMMIT_INVALID/UNATTEMPTED with zero attempts.
- Do not read qualification holdout, qualify, deploy, enable PAPER, or mutate the broker.

## Related Issues

PROOMPT-448

## Testing

- `bun test services/bayn/src/candidate-development-trials/ledger.test.ts packages/scripts/src/bayn/verify-qualification-dormancy.test.ts` (14 pass, 0 fail)
- `bun run --filter @proompteng/bayn test` (1,114 pass, 154 PostgreSQL-only skips, 0 fail)
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint:effect` (508 files, 0 errors)
- `bun run --filter @proompteng/bayn lint:oxlint:type` (509 files, 0 errors)
- `bun run --filter @proompteng/bayn build`
- `bunx oxfmt --check services/bayn/src/candidate-development-trials/ledger.ts services/bayn/src/candidate-development-trials/ledger.test.ts packages/scripts/src/bayn/verify-qualification-dormancy.test.ts`
- `bun packages/scripts/src/bayn/verify-qualification-dormancy.ts --repository-root . --github-output <temporary-path>` verified `eligible=false`, `dormant=true`, `reason=development-rejected`, and Candidate 22.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable and Breaking Changes is filled in.
- [x] Documentation and durable follow-up evidence are tracked in PROOMPT-448.