### PR TITLE
feat(bayn): preregister Candidate 23

### DIFF
--- a/services/bayn/candidates/ordinal-23-long-horizon-trend-consensus-preregistration.json
+++ b/services/bayn/candidates/ordinal-23-long-horizon-trend-consensus-preregistration.json
@@ -1,0 +1,18 @@
+{
+  "schemaVersion": "bayn.candidate-development-next-preregistration.v1",
+  "candidateOrdinal": 23,
+  "priorTrialCount": 22,
+  "strategyProtocolHash": "4c872d202736df67a1884165ff7dcff5d4c0786661acbb1c52f1da4d954e7c71",
+  "candidateDevelopmentProtocolHash": "67df3759bf447907a8252563e3b6e4b5cfec1b6b75d34e235857581377b81099",
+  "calendarHash": "4b2f519f336e4e730c1f0d69e860f25a8d4d0cfbd8e93c6b333ea83623d87237",
+  "priorTrialsHash": "3f274a01dfc943d6648044eb9530dce3a0dc5d31b9b55ff5271c671f5639821e",
+  "modulePath": "services/bayn/src/strategy/candidate-23.ts",
+  "moduleSha256": "94f3a5d098cbfab2cf6dd2cc5282be352a9b283d1117c674817921019a708197",
+  "marketData": {
+    "schemaVersion": "bayn.candidate-development-market-data-source.v1",
+    "snapshotId": "2a91f0177684f7022f746207333e510c8268f9b77a04b778a04220a33ccf79e0",
+    "finalizedSnapshotContentHash": "8e376546f6a6cc1dbe2e910db3d68f584fc0bd9c4858166042ce32aa077eed0d",
+    "inputManifestHash": "1e5377336f2e6feb751000114b81cc89aee5be7542e213c320f2cfbb4185bb2b",
+    "boundedContentHash": "b6052c8ebdca855973adf4e41efafb5028fd8dbbaa70809331f6017519b1c995"
+  }
+}


### PR DESCRIPTION
## Summary

- preregister Candidate 23 as a result-blind long-horizon trend-consensus hypothesis
- bind the exact future module bytes, Candidate 22-terminal ledger hash, protocol identity, calendar, and frozen development snapshot
- keep executable source and all metric-bearing development output outside this preregistration commit

## Related Issues

PROOMPT-448

## Testing

- Schema.decodeUnknownSync(CandidateDevelopmentNextPreregistrationDocumentSchema) against the exact JSON
- bunx oxfmt --check services/bayn/candidates/ordinal-23-long-horizon-trend-consensus-preregistration.json services/bayn/src/strategy/candidate-23.ts
- mechanically recomputed module, parameter, strategy-protocol, prior-ledger, and candidate-development-protocol hashes from current main

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots section removed because it is not applicable; Breaking Changes is filled in.
- [x] Follow-up source review, single development attempt, and honest terminalization are tracked in PROOMPT-448.