### PR TITLE
feat(bayn): register Candidate 23 source

### DIFF
--- a/packages/scripts/src/bayn/verify-qualification-dormancy.test.ts
+++ b/packages/scripts/src/bayn/verify-qualification-dormancy.test.ts
@@ -25,8 +25,8 @@ describe('qualification dormancy command', () => {
     const decision = await verifyQualificationDormancy(repositoryRoot)
     expect(decision).toEqual({
       status: 'dormant',
-      reason: 'development-rejected',
-      candidateOrdinal: 22,
+      reason: 'development-not-approved',
+      candidateOrdinal: 23,
     })
   })
 
@@ -84,7 +84,7 @@ describe('qualification dormancy command', () => {
       expect(stderr).toBe('')
       expect(stdout).toContain('"status":"dormant"')
       expect(await readFile(githubOutput, 'utf8')).toBe(
-        'eligible=false\ndormant=true\nreason=development-rejected\ncandidate_ordinal=22\n',
+        'eligible=false\ndormant=true\nreason=development-not-approved\ncandidate_ordinal=23\n',
       )
     } finally {
       await rm(directory, { recursive: true, force: true })

--- a/services/bayn/candidates/ordinal-23-source-manifest.json
+++ b/services/bayn/candidates/ordinal-23-source-manifest.json
@@ -1,0 +1,17 @@
+{
+  "schemaVersion": "bayn.candidate-development-source-manifest.v2",
+  "candidateOrdinal": 23,
+  "priorTrialCount": 22,
+  "trialHistoryHash": "3f274a01dfc943d6648044eb9530dce3a0dc5d31b9b55ff5271c671f5639821e",
+  "strategyName": "candidate-23-long-horizon-trend-consensus",
+  "strategyProtocolHash": "4c872d202736df67a1884165ff7dcff5d4c0786661acbb1c52f1da4d954e7c71",
+  "modulePath": "services/bayn/src/strategy/candidate-23.ts",
+  "moduleSha256": "94f3a5d098cbfab2cf6dd2cc5282be352a9b283d1117c674817921019a708197",
+  "moduleFormat": "typescript-strategy-application-v1",
+  "marketData": {
+    "schemaVersion": "bayn.candidate-development-market-data-source.v2",
+    "snapshotId": "2a91f0177684f7022f746207333e510c8268f9b77a04b778a04220a33ccf79e0",
+    "inputManifestHash": "1e5377336f2e6feb751000114b81cc89aee5be7542e213c320f2cfbb4185bb2b",
+    "boundedContentHash": "b6052c8ebdca855973adf4e41efafb5028fd8dbbaa70809331f6017519b1c995"
+  }
+}

--- a/services/bayn/src/candidate-development-trials/ledger.test.ts
+++ b/services/bayn/src/candidate-development-trials/ledger.test.ts
@@ -87,10 +87,18 @@ describe('Bayn candidate development trial ledger', () => {
     )
     expect(candidateDevelopmentTrialLedgerState.developmentCandidateOrdinals).toEqual([17, 18, 19, 21, 22])
     expect(candidateDevelopmentTrialLedgerState.latestInvalidPrecommit?.status).toBe('PRECOMMIT_INVALID')
-    expect(candidateDevelopmentTrialLedgerState.activeCandidate).toBeNull()
+    expect(candidateDevelopmentTrialLedgerState.activeCandidate).toMatchObject({
+      preregistration: {
+        candidateOrdinal: 23,
+        priorTrialCount: 22,
+        modulePath: 'services/bayn/src/strategy/candidate-23.ts',
+      },
+      strategyName: 'candidate-23-long-horizon-trend-consensus',
+      sourceManifest: { path: 'services/bayn/candidates/ordinal-23-source-manifest.json' },
+    })
     expect(qualificationDormancyDecisionFromLedgerState(candidateDevelopmentTrialLedgerState)).toEqual({
       ok: true,
-      decision: { status: 'dormant', reason: 'development-rejected', candidateOrdinal: 22 },
+      decision: { status: 'dormant', reason: 'development-not-approved', candidateOrdinal: 23 },
     })
   })
 
@@ -152,7 +160,7 @@ describe('Bayn candidate development trial ledger', () => {
     })
     expect(withRejection(rejection)).toEqual({
       ok: true,
-      decision: { status: 'dormant', reason: 'development-rejected', candidateOrdinal: 22 },
+      decision: { status: 'dormant', reason: 'development-not-approved', candidateOrdinal: 23 },
     })
     expect(
       qualificationDormancyDecisionFromLedgerState({

--- a/services/bayn/src/candidate-development-trials/ledger.ts
+++ b/services/bayn/src/candidate-development-trials/ledger.ts
@@ -234,6 +234,40 @@ const historicalLedger = [
       qualificationAnalysisHash: 'fdb003763930de38e74d0c3ab00d9fa6480ad35a973b8ca884fd8987750e7533',
     },
   },
+  {
+    _tag: 'DEVELOPMENT_PENDING' as const,
+    candidateOrdinal: 23,
+    priorTrialCount: 22,
+    strategyName: 'candidate-23-long-horizon-trend-consensus',
+    preregistration: {
+      schemaVersion: 'bayn.candidate-development-next-preregistration.v1' as const,
+      candidateOrdinal: 23,
+      priorTrialCount: 22,
+      strategyProtocolHash: '4c872d202736df67a1884165ff7dcff5d4c0786661acbb1c52f1da4d954e7c71',
+      candidateDevelopmentProtocolHash: '67df3759bf447907a8252563e3b6e4b5cfec1b6b75d34e235857581377b81099',
+      calendarHash: '4b2f519f336e4e730c1f0d69e860f25a8d4d0cfbd8e93c6b333ea83623d87237',
+      priorTrialsHash: '3f274a01dfc943d6648044eb9530dce3a0dc5d31b9b55ff5271c671f5639821e',
+      modulePath: 'services/bayn/src/strategy/candidate-23.ts',
+      moduleSha256: '94f3a5d098cbfab2cf6dd2cc5282be352a9b283d1117c674817921019a708197',
+      marketData: {
+        schemaVersion: 'bayn.candidate-development-market-data-source.v1' as const,
+        snapshotId: '2a91f0177684f7022f746207333e510c8268f9b77a04b778a04220a33ccf79e0',
+        finalizedSnapshotContentHash: '8e376546f6a6cc1dbe2e910db3d68f584fc0bd9c4858166042ce32aa077eed0d',
+        inputManifestHash: '1e5377336f2e6feb751000114b81cc89aee5be7542e213c320f2cfbb4185bb2b',
+        boundedContentHash: 'b6052c8ebdca855973adf4e41efafb5028fd8dbbaa70809331f6017519b1c995',
+      },
+      preregistration: {
+        sourceRevision: 'bee48b55268061cf0059dbd79b78405c875f199f',
+        path: 'services/bayn/candidates/ordinal-23-long-horizon-trend-consensus-preregistration.json',
+        blobOid: '6288eaa3ce74daff10ec5a7374c54666f02b163d',
+      },
+    },
+    sourceManifest: {
+      path: 'services/bayn/candidates/ordinal-23-source-manifest.json',
+      blobOid: '918abb4e5d66bc069267de999f103c280d11d321',
+      sha256: '571cef9990c7e28ba24327b428df0f4c98af71bb882d10281b1a624cdf5aeb7b',
+    },
+  },
 ] as const
 
 /** One append-only source-controlled ledger. Candidate 20 is represented once as the terminal tombstone entry. */

--- a/services/bayn/src/strategy/candidate-23.ts
+++ b/services/bayn/src/strategy/candidate-23.ts
@@ -1,0 +1,27 @@
+import { Result } from 'effect'
+
+import { decodeProtocol, defaultProtocolDocument } from '../protocol'
+import {
+  makeRiskBalancedTrendApplication,
+  makeRiskBalancedTrendDefinition,
+  type RiskBalancedTrendStrategyDefinition,
+} from './risk-balanced-trend'
+
+const protocol = Result.getOrThrow(
+  decodeProtocol({
+    ...defaultProtocolDocument,
+    horizons: [126, 252],
+    signal: {
+      ...defaultProtocolDocument.signal,
+      minimumPositiveHorizons: 2,
+    },
+  }),
+)
+
+const definition: RiskBalancedTrendStrategyDefinition = {
+  ...makeRiskBalancedTrendDefinition(protocol),
+  name: 'candidate-23-long-horizon-trend-consensus',
+}
+
+/** Result-blind long-horizon consensus using the existing verified strategy core and risk bounds. */
+export const strategyApplication = makeRiskBalancedTrendApplication(protocol, definition)


### PR DESCRIPTION
## Summary

- publish the exact preregistered Candidate 23 module as a 27-line pure adapter over the existing risk-balanced-trend core
- bind the source manifest and append-only pending ledger entry to the merged preregistration, Candidate 22 terminal lineage, frozen development snapshot, and compatibility base 3aeb2b6567c7d09cc4b79deffcac952e4b020357
- keep the candidate descendant to the four reviewed source paths and qualification fail-closed as development-not-approved until the one allowed local attempt is terminalized

## Related Issues

PROOMPT-448

## Testing

- bun test services/bayn/src/candidate-development-trials/ledger.test.ts packages/scripts/src/bayn/verify-qualification-dormancy.test.ts: 14 pass, 0 fail
- bun run --filter @proompteng/bayn test: 1114 pass, 154 PostgreSQL-only skips, 0 fail
- bun run --filter @proompteng/bayn tsc
- bun run --filter @proompteng/bayn lint:effect
- bun run --filter @proompteng/bayn lint:oxlint:type
- bun run --filter @proompteng/bayn build
- bunx oxfmt --check on all four changed files
- exact four-path source-descendant diff plus mechanical Git blob and SHA-256 binding verification

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots section removed because it is not applicable; Breaking Changes is filled in.
- [x] The one local development attempt has not been executed by this PR.