### PR TITLE
feat(bayn): preregister Candidate 24

### DIFF
--- a/services/bayn/candidates/ordinal-24-twelve-month-time-series-momentum-preregistration.json
+++ b/services/bayn/candidates/ordinal-24-twelve-month-time-series-momentum-preregistration.json
@@ -1,0 +1,18 @@
+{
+  "schemaVersion": "bayn.candidate-development-next-preregistration.v1",
+  "candidateOrdinal": 24,
+  "priorTrialCount": 23,
+  "strategyProtocolHash": "e5984cde401715e654a61b268bf3c70ebf600b9e303efb348c0e6c3d9eacd7c1",
+  "candidateDevelopmentProtocolHash": "3336e3e5dcd0251bf3bbdc468ed7a9179d4890c055f3e636ec2b16bc4ad87829",
+  "calendarHash": "4b2f519f336e4e730c1f0d69e860f25a8d4d0cfbd8e93c6b333ea83623d87237",
+  "priorTrialsHash": "1e34949870418ab15c4120e9a45de1d41d0ed4a07fdbcc31d4a22cd22e5f42b3",
+  "modulePath": "services/bayn/src/strategy/candidate-24.ts",
+  "moduleSha256": "dc9132bc2332f1878dd7f698f426f875d6370c354da38d38055c5ea32849d24c",
+  "marketData": {
+    "schemaVersion": "bayn.candidate-development-market-data-source.v1",
+    "snapshotId": "2a91f0177684f7022f746207333e510c8268f9b77a04b778a04220a33ccf79e0",
+    "finalizedSnapshotContentHash": "8e376546f6a6cc1dbe2e910db3d68f584fc0bd9c4858166042ce32aa077eed0d",
+    "inputManifestHash": "1e5377336f2e6feb751000114b81cc89aee5be7542e213c320f2cfbb4185bb2b",
+    "boundedContentHash": "b6052c8ebdca855973adf4e41efafb5028fd8dbbaa70809331f6017519b1c995"
+  }
+}


### PR DESCRIPTION
## Summary

- preregister Candidate 24 as a result-blind canonical 12-month time-series-momentum hypothesis
- bind the exact future 27-line module bytes, Candidate 23-terminal ledger hash, protocol identity, calendar, and frozen development snapshot
- keep executable source and all result-bearing development output outside this preregistration commit

## Related Issues

PROOMPT-448

## Testing

- decoded the exact JSON with CandidateDevelopmentNextPreregistrationDocumentSchema
- mechanically recomputed module, parameter, strategy-protocol, full prior-ledger, calendar, and candidate-development-protocol hashes from exact main
- bunx oxfmt --check services/bayn/candidates/ordinal-24-twelve-month-time-series-momentum-preregistration.json services/bayn/src/strategy/candidate-24.ts

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots section removed because it is not applicable; Breaking Changes is filled in.
- [x] Follow-up source review, single development attempt, and honest terminalization are tracked in PROOMPT-448.