### PR TITLE
feat(bayn): bind Candidate 24 source

### DIFF
--- a/packages/scripts/src/bayn/verify-qualification-dormancy.test.ts
+++ b/packages/scripts/src/bayn/verify-qualification-dormancy.test.ts
@@ -25,8 +25,8 @@ describe('qualification dormancy command', () => {
     const decision = await verifyQualificationDormancy(repositoryRoot)
     expect(decision).toEqual({
       status: 'dormant',
-      reason: 'development-rejected',
-      candidateOrdinal: 23,
+      reason: 'development-not-approved',
+      candidateOrdinal: 24,
     })
   })
 
@@ -84,7 +84,7 @@ describe('qualification dormancy command', () => {
       expect(stderr).toBe('')
       expect(stdout).toContain('"status":"dormant"')
       expect(await readFile(githubOutput, 'utf8')).toBe(
-        'eligible=false\ndormant=true\nreason=development-rejected\ncandidate_ordinal=23\n',
+        'eligible=false\ndormant=true\nreason=development-not-approved\ncandidate_ordinal=24\n',
       )
     } finally {
       await rm(directory, { recursive: true, force: true })

--- a/services/bayn/candidates/ordinal-24-source-manifest.json
+++ b/services/bayn/candidates/ordinal-24-source-manifest.json
@@ -1,0 +1,17 @@
+{
+  "schemaVersion": "bayn.candidate-development-source-manifest.v2",
+  "candidateOrdinal": 24,
+  "priorTrialCount": 23,
+  "trialHistoryHash": "1e34949870418ab15c4120e9a45de1d41d0ed4a07fdbcc31d4a22cd22e5f42b3",
+  "strategyName": "candidate-24-twelve-month-time-series-momentum",
+  "strategyProtocolHash": "e5984cde401715e654a61b268bf3c70ebf600b9e303efb348c0e6c3d9eacd7c1",
+  "modulePath": "services/bayn/src/strategy/candidate-24.ts",
+  "moduleSha256": "dc9132bc2332f1878dd7f698f426f875d6370c354da38d38055c5ea32849d24c",
+  "moduleFormat": "typescript-strategy-application-v1",
+  "marketData": {
+    "schemaVersion": "bayn.candidate-development-market-data-source.v2",
+    "snapshotId": "2a91f0177684f7022f746207333e510c8268f9b77a04b778a04220a33ccf79e0",
+    "inputManifestHash": "1e5377336f2e6feb751000114b81cc89aee5be7542e213c320f2cfbb4185bb2b",
+    "boundedContentHash": "b6052c8ebdca855973adf4e41efafb5028fd8dbbaa70809331f6017519b1c995"
+  }
+}

--- a/services/bayn/src/candidate-development-trials/ledger.ts
+++ b/services/bayn/src/candidate-development-trials/ledger.ts
@@ -300,6 +300,40 @@ const historicalLedger = [
       qualificationAnalysisHash: '9bc11fc3026a938f4109c96298050a713b7ad14379c76181f12835cccda65784',
     },
   },
+  {
+    _tag: 'DEVELOPMENT_PENDING' as const,
+    candidateOrdinal: 24,
+    priorTrialCount: 23,
+    strategyName: 'candidate-24-twelve-month-time-series-momentum',
+    preregistration: {
+      schemaVersion: 'bayn.candidate-development-next-preregistration.v1' as const,
+      candidateOrdinal: 24,
+      priorTrialCount: 23,
+      strategyProtocolHash: 'e5984cde401715e654a61b268bf3c70ebf600b9e303efb348c0e6c3d9eacd7c1',
+      candidateDevelopmentProtocolHash: '3336e3e5dcd0251bf3bbdc468ed7a9179d4890c055f3e636ec2b16bc4ad87829',
+      calendarHash: '4b2f519f336e4e730c1f0d69e860f25a8d4d0cfbd8e93c6b333ea83623d87237',
+      priorTrialsHash: '1e34949870418ab15c4120e9a45de1d41d0ed4a07fdbcc31d4a22cd22e5f42b3',
+      modulePath: 'services/bayn/src/strategy/candidate-24.ts',
+      moduleSha256: 'dc9132bc2332f1878dd7f698f426f875d6370c354da38d38055c5ea32849d24c',
+      marketData: {
+        schemaVersion: 'bayn.candidate-development-market-data-source.v1' as const,
+        snapshotId: '2a91f0177684f7022f746207333e510c8268f9b77a04b778a04220a33ccf79e0',
+        finalizedSnapshotContentHash: '8e376546f6a6cc1dbe2e910db3d68f584fc0bd9c4858166042ce32aa077eed0d',
+        inputManifestHash: '1e5377336f2e6feb751000114b81cc89aee5be7542e213c320f2cfbb4185bb2b',
+        boundedContentHash: 'b6052c8ebdca855973adf4e41efafb5028fd8dbbaa70809331f6017519b1c995',
+      },
+      preregistration: {
+        sourceRevision: 'f7529b676225bcdd8f084feed81efffd99a745ef',
+        path: 'services/bayn/candidates/ordinal-24-twelve-month-time-series-momentum-preregistration.json',
+        blobOid: '3ad2152e4cebc48c85c82c4ecaeed45458460f63',
+      },
+    },
+    sourceManifest: {
+      path: 'services/bayn/candidates/ordinal-24-source-manifest.json',
+      blobOid: '877de3583c2e8998ad265a5e6a11b540b37895f5',
+      sha256: 'af366df1ec0633232ab4ca798ec68cfbe4485368a6624cb4a7379eca18e34ec0',
+    },
+  },
 ] as const
 
 /** One append-only source-controlled ledger. Candidate 20 is represented once as the terminal tombstone entry. */

--- a/services/bayn/src/strategy/candidate-24.ts
+++ b/services/bayn/src/strategy/candidate-24.ts
@@ -1,0 +1,27 @@
+import { Result } from 'effect'
+
+import { decodeProtocol, defaultProtocolDocument } from '../protocol'
+import {
+  makeRiskBalancedTrendApplication,
+  makeRiskBalancedTrendDefinition,
+  type RiskBalancedTrendStrategyDefinition,
+} from './risk-balanced-trend'
+
+const protocol = Result.getOrThrow(
+  decodeProtocol({
+    ...defaultProtocolDocument,
+    horizons: [252],
+    signal: {
+      ...defaultProtocolDocument.signal,
+      minimumPositiveHorizons: 1,
+    },
+  }),
+)
+
+const definition: RiskBalancedTrendStrategyDefinition = {
+  ...makeRiskBalancedTrendDefinition(protocol),
+  name: 'candidate-24-twelve-month-time-series-momentum',
+}
+
+/** Result-blind 12-month time-series momentum using the verified strategy core and unchanged risk bounds. */
+export const strategyApplication = makeRiskBalancedTrendApplication(protocol, definition)


### PR DESCRIPTION
## Summary

- adds a 27-line result-blind 12-month time-series momentum strategy using the existing pure risk-balanced trend application
- binds the exact reviewed strategy bytes and frozen development witness identities in a compact source manifest
- appends Candidate 24 as development-pending and keeps qualification dormant until the one allowed development attempt passes

## Related Issues

PROOMPT-448

## Testing

- `bun test services/bayn/src/candidate-development-trials/ledger.test.ts services/bayn/src/candidate-development-local/command.test.ts packages/scripts/src/bayn/verify-qualification-dormancy.test.ts` (26 pass, 0 fail)
- `bun run --filter @proompteng/bayn test` (1,114 pass, 154 PostgreSQL-gated skips, 0 fail)
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn lint:effect`
- `bun run --filter @proompteng/bayn build`
- `bunx oxfmt --check packages/scripts/src/bayn/verify-qualification-dormancy.test.ts services/bayn/candidates/ordinal-24-source-manifest.json services/bayn/src/candidate-development-trials/ledger.ts services/bayn/src/strategy/candidate-24.ts`

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
