### PR TITLE
feat(bayn): preregister Candidate 25

### DIFF
--- a/services/bayn/candidates/ordinal-25-top-two-momentum-consensus-preregistration.json
+++ b/services/bayn/candidates/ordinal-25-top-two-momentum-consensus-preregistration.json
@@ -1,0 +1,18 @@
+{
+  "schemaVersion": "bayn.candidate-development-next-preregistration.v1",
+  "candidateOrdinal": 25,
+  "priorTrialCount": 24,
+  "strategyProtocolHash": "b38c8a135a34e571470e28f16e2f0f75a8dbaefee25d276c7afae39f2793b136",
+  "candidateDevelopmentProtocolHash": "f0a34cd42a6d4657890a7164d9ffc2242822333539eb80465f570ba82766c9ad",
+  "calendarHash": "4b2f519f336e4e730c1f0d69e860f25a8d4d0cfbd8e93c6b333ea83623d87237",
+  "priorTrialsHash": "8f9082e34c6d48d8496e79e53d0209f24112bdb950b6ebb11d3d39063b47ff14",
+  "modulePath": "services/bayn/src/strategy/candidate-25.ts",
+  "moduleSha256": "bb70b8e8851a3fb390dd5c0b51876122d05a08401b4ad42ac831d5c616e39835",
+  "marketData": {
+    "schemaVersion": "bayn.candidate-development-market-data-source.v1",
+    "snapshotId": "2a91f0177684f7022f746207333e510c8268f9b77a04b778a04220a33ccf79e0",
+    "finalizedSnapshotContentHash": "8e376546f6a6cc1dbe2e910db3d68f584fc0bd9c4858166042ce32aa077eed0d",
+    "inputManifestHash": "1e5377336f2e6feb751000114b81cc89aee5be7542e213c320f2cfbb4185bb2b",
+    "boundedContentHash": "b6052c8ebdca855973adf4e41efafb5028fd8dbbaa70809331f6017519b1c995"
+  }
+}


### PR DESCRIPTION
## Summary

- freeze Candidate 25 as a result-blind top-two cross-asset momentum-consensus hypothesis
- bind ordinal 25 to all 24 prior trials, the frozen development witness, and the exact future module SHA-256
- keep the executable source absent from this preregistration commit and authorize no development or qualification attempt

## Related Issues

None

## Testing

- decoded the JSON with CandidateDevelopmentNextPreregistrationDocumentSchema under strict parse options
- recomputed and matched the future module SHA-256, strategy protocol hash, ordinal-bound development protocol hash, calendar hash, and canonical prior-ledger hash
- bun run --filter @proompteng/bayn tsc
- bun run --filter @proompteng/bayn lint:oxlint:type
- synthetic-only strategy checks for top-two selection, cash fallback, gross exposure, and sleeve caps; no frozen market witness was opened

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable and Breaking Changes is filled in.
- [x] No documentation, release notes, or follow-up changes are required for this immutable preregistration.
