### PR TITLE
feat(bayn): bind Candidate 25 source

### DIFF
--- a/packages/scripts/src/bayn/verify-qualification-dormancy.test.ts
+++ b/packages/scripts/src/bayn/verify-qualification-dormancy.test.ts
@@ -25,8 +25,8 @@ describe('qualification dormancy command', () => {
     const decision = await verifyQualificationDormancy(repositoryRoot)
     expect(decision).toEqual({
       status: 'dormant',
-      reason: 'development-rejected',
-      candidateOrdinal: 24,
+      reason: 'development-not-approved',
+      candidateOrdinal: 25,
     })
   })
 
@@ -84,7 +84,7 @@ describe('qualification dormancy command', () => {
       expect(stderr).toBe('')
       expect(stdout).toContain('"status":"dormant"')
       expect(await readFile(githubOutput, 'utf8')).toBe(
-        'eligible=false\ndormant=true\nreason=development-rejected\ncandidate_ordinal=24\n',
+        'eligible=false\ndormant=true\nreason=development-not-approved\ncandidate_ordinal=25\n',
       )
     } finally {
       await rm(directory, { recursive: true, force: true })

--- a/services/bayn/candidates/ordinal-25-source-manifest.json
+++ b/services/bayn/candidates/ordinal-25-source-manifest.json
@@ -1,0 +1,17 @@
+{
+  "schemaVersion": "bayn.candidate-development-source-manifest.v2",
+  "candidateOrdinal": 25,
+  "priorTrialCount": 24,
+  "trialHistoryHash": "8f9082e34c6d48d8496e79e53d0209f24112bdb950b6ebb11d3d39063b47ff14",
+  "strategyName": "candidate-25-top-two-momentum-consensus",
+  "strategyProtocolHash": "b38c8a135a34e571470e28f16e2f0f75a8dbaefee25d276c7afae39f2793b136",
+  "modulePath": "services/bayn/src/strategy/candidate-25.ts",
+  "moduleSha256": "bb70b8e8851a3fb390dd5c0b51876122d05a08401b4ad42ac831d5c616e39835",
+  "moduleFormat": "typescript-strategy-application-v1",
+  "marketData": {
+    "schemaVersion": "bayn.candidate-development-market-data-source.v2",
+    "snapshotId": "2a91f0177684f7022f746207333e510c8268f9b77a04b778a04220a33ccf79e0",
+    "inputManifestHash": "1e5377336f2e6feb751000114b81cc89aee5be7542e213c320f2cfbb4185bb2b",
+    "boundedContentHash": "b6052c8ebdca855973adf4e41efafb5028fd8dbbaa70809331f6017519b1c995"
+  }
+}

--- a/services/bayn/src/candidate-development-trials/ledger.ts
+++ b/services/bayn/src/candidate-development-trials/ledger.ts
@@ -366,6 +366,40 @@ const historicalLedger = [
       qualificationAnalysisHash: 'eb73fe8520833eac7b06a138d4d496ea07a36fb4ae6140399709d047dee69d6d',
     },
   },
+  {
+    _tag: 'DEVELOPMENT_PENDING' as const,
+    candidateOrdinal: 25,
+    priorTrialCount: 24,
+    strategyName: 'candidate-25-top-two-momentum-consensus',
+    preregistration: {
+      schemaVersion: 'bayn.candidate-development-next-preregistration.v1' as const,
+      candidateOrdinal: 25,
+      priorTrialCount: 24,
+      strategyProtocolHash: 'b38c8a135a34e571470e28f16e2f0f75a8dbaefee25d276c7afae39f2793b136',
+      candidateDevelopmentProtocolHash: 'f0a34cd42a6d4657890a7164d9ffc2242822333539eb80465f570ba82766c9ad',
+      calendarHash: '4b2f519f336e4e730c1f0d69e860f25a8d4d0cfbd8e93c6b333ea83623d87237',
+      priorTrialsHash: '8f9082e34c6d48d8496e79e53d0209f24112bdb950b6ebb11d3d39063b47ff14',
+      modulePath: 'services/bayn/src/strategy/candidate-25.ts',
+      moduleSha256: 'bb70b8e8851a3fb390dd5c0b51876122d05a08401b4ad42ac831d5c616e39835',
+      marketData: {
+        schemaVersion: 'bayn.candidate-development-market-data-source.v1' as const,
+        snapshotId: '2a91f0177684f7022f746207333e510c8268f9b77a04b778a04220a33ccf79e0',
+        finalizedSnapshotContentHash: '8e376546f6a6cc1dbe2e910db3d68f584fc0bd9c4858166042ce32aa077eed0d',
+        inputManifestHash: '1e5377336f2e6feb751000114b81cc89aee5be7542e213c320f2cfbb4185bb2b',
+        boundedContentHash: 'b6052c8ebdca855973adf4e41efafb5028fd8dbbaa70809331f6017519b1c995',
+      },
+      preregistration: {
+        sourceRevision: '9dff32d40405c9149ca0e5e72cc918011765f09d',
+        path: 'services/bayn/candidates/ordinal-25-top-two-momentum-consensus-preregistration.json',
+        blobOid: '83667dda9a986510a33ac9508dce0da386be5620',
+      },
+    },
+    sourceManifest: {
+      path: 'services/bayn/candidates/ordinal-25-source-manifest.json',
+      blobOid: '5cb836429e8a019317ecb7302969b23aaec4587c',
+      sha256: '39bc07487cea9a00190a133ff5faa3b240b04c1a7083041eaa791006106dd79b',
+    },
+  },
 ] as const
 
 /** One append-only source-controlled ledger. Candidate 20 is represented once as the terminal tombstone entry. */

--- a/services/bayn/src/strategy/candidate-25.ts
+++ b/services/bayn/src/strategy/candidate-25.ts
@@ -1,0 +1,154 @@
+import { Result, pipe } from 'effect'
+
+import { decodeProtocol, defaultProtocolDocument } from '../protocol'
+import type { RiskBalancedTrendFailure } from '../risk-balanced-trend/model'
+import type { DecisionPlan, Protocol } from '../types'
+import {
+  makeRiskBalancedTrendApplication,
+  type RiskBalancedTrendMarketContext,
+  type RiskBalancedTrendStrategyDefinition,
+} from './risk-balanced-trend'
+import { makeRiskBalancedTrendDecision } from './risk-balanced-trend/decision'
+import { annualizedPortfolioVolatility } from './risk-balanced-trend/risk'
+import { dailyReturns, fail, WEIGHT_SCALE } from './risk-balanced-trend/shared'
+
+const selectionCount = 2
+
+const protocol = Result.getOrThrow(
+  decodeProtocol({
+    ...defaultProtocolDocument,
+    horizons: [63, 126, 252],
+    maximumSymbolWeight: 1 / selectionCount,
+    signal: {
+      ...defaultProtocolDocument.signal,
+      minimumPositiveHorizons: 2,
+    },
+  }),
+)
+
+const selectedSymbols = (decision: DecisionPlan): ReadonlySet<string> =>
+  new Set(
+    decision.signals
+      .filter(({ eligible }) => eligible)
+      .sort(
+        (left, right) =>
+          right.compositeScore - left.compositeScore ||
+          (left.symbol < right.symbol ? -1 : left.symbol > right.symbol ? 1 : 0),
+      )
+      .slice(0, selectionCount)
+      .map(({ symbol }) => symbol),
+  )
+
+const recentReturns = (
+  context: RiskBalancedTrendMarketContext,
+  candidateProtocol: Protocol,
+): Result.Result<Readonly<Record<string, readonly number[]>>, RiskBalancedTrendFailure> =>
+  pipe(
+    Result.all(
+      candidateProtocol.universe.map((symbol) => {
+        const closes = context.closes[symbol]
+        return closes === undefined
+          ? fail({
+              _tag: 'RiskBalancedTrendCloseHistoryMismatch',
+              symbol,
+              expectedCount: context.sessionDates.length,
+              observedCount: 0,
+            })
+          : pipe(
+              dailyReturns(closes, candidateProtocol.volatilityWindow, symbol),
+              Result.map((returns) => [symbol, returns] as const),
+            )
+      }),
+    ),
+    Result.map(Object.fromEntries),
+  )
+
+const scaleToRiskLimit = (
+  requestedWeights: Readonly<Record<string, number>>,
+  returnSeries: Readonly<Record<string, readonly number[]>>,
+  candidateProtocol: Protocol,
+): Result.Result<
+  {
+    readonly estimatedAnnualizedPortfolioVolatility: number
+    readonly exposureScale: number
+    readonly targetWeights: Readonly<Record<string, number>>
+  },
+  RiskBalancedTrendFailure
+> =>
+  pipe(
+    annualizedPortfolioVolatility(requestedWeights, returnSeries),
+    Result.flatMap((estimatedAnnualizedPortfolioVolatility) => {
+      const exposureScale =
+        estimatedAnnualizedPortfolioVolatility === 0
+          ? 1
+          : Math.min(1, candidateProtocol.maximumPortfolioVolatility / estimatedAnnualizedPortfolioVolatility)
+      const targetWeights = Object.fromEntries(
+        Object.entries(requestedWeights).map(([symbol, weight]) => [
+          symbol,
+          Math.floor(weight * exposureScale * WEIGHT_SCALE) / WEIGHT_SCALE,
+        ]),
+      )
+      return pipe(
+        annualizedPortfolioVolatility(targetWeights, returnSeries),
+        Result.flatMap((observedPortfolioVolatility) => {
+          const totalWeight = Object.values(targetWeights).reduce((total, weight) => total + weight, 0)
+          return totalWeight > 1 + 1e-12 ||
+            Object.values(targetWeights).some(
+              (weight) => weight < 0 || weight > candidateProtocol.maximumSymbolWeight + 1e-12,
+            ) ||
+            observedPortfolioVolatility > candidateProtocol.maximumPortfolioVolatility + 1e-12
+            ? fail({
+                _tag: 'UnboundedRiskBalancedTrendWeights',
+                totalWeight,
+                maximumSymbolWeight: candidateProtocol.maximumSymbolWeight,
+                maximumPortfolioVolatility: candidateProtocol.maximumPortfolioVolatility,
+                observedPortfolioVolatility,
+              })
+            : Result.succeed({ estimatedAnnualizedPortfolioVolatility, exposureScale, targetWeights })
+        }),
+      )
+    }),
+  )
+
+const decide = (
+  context: RiskBalancedTrendMarketContext,
+  candidateProtocol: Protocol,
+): Result.Result<DecisionPlan, RiskBalancedTrendFailure> =>
+  pipe(
+    Result.all({
+      base: makeRiskBalancedTrendDecision(context.signalDate, context.sessionDates, context.closes, candidateProtocol),
+      returnSeries: recentReturns(context, candidateProtocol),
+    }),
+    Result.flatMap(({ base, returnSeries }) => {
+      const selected = selectedSymbols(base)
+      const requestedWeights = Object.fromEntries(
+        candidateProtocol.universe.map((symbol) => [symbol, selected.has(symbol) ? 1 / selectionCount : 0]),
+      )
+      return pipe(
+        scaleToRiskLimit(requestedWeights, returnSeries, candidateProtocol),
+        Result.map(({ estimatedAnnualizedPortfolioVolatility, exposureScale, targetWeights }) => ({
+          ...base,
+          estimatedAnnualizedPortfolioVolatility,
+          exposureScale,
+          targetWeights,
+          signals: base.signals.map((signal) => ({
+            ...signal,
+            positiveScore: selected.has(signal.symbol) ? signal.positiveScore : 0,
+            eligible: selected.has(signal.symbol),
+            uncappedWeight: requestedWeights[signal.symbol] ?? 0,
+            cappedWeight: requestedWeights[signal.symbol] ?? 0,
+            targetWeight: targetWeights[signal.symbol] ?? 0,
+          })),
+        })),
+      )
+    }),
+  )
+
+const definition: RiskBalancedTrendStrategyDefinition = {
+  name: 'candidate-25-top-two-momentum-consensus',
+  parameters: protocol,
+  decide: ({ market }) => decide(market, protocol),
+}
+
+/** Result-blind top-two momentum consensus with fixed concentration and portfolio-risk bounds. */
+export const strategyApplication = makeRiskBalancedTrendApplication(protocol, definition)


### PR DESCRIPTION
## Summary

- bind the independently preregistered Candidate 25 source and immutable source manifest to the append-only development ledger
- implement a small, result-blind top-two momentum consensus strategy using the shared risk-balanced trend functional core
- keep qualification dormant until Candidate 25 has an immutable terminal development result

## Related Issues

PROOMPT-448

## Testing

- `bun test services/bayn/src/candidate-development-trials/ledger.test.ts services/bayn/src/candidate-development-trials/qualification-dormancy.test.ts packages/scripts/src/bayn/verify-qualification-dormancy.test.ts services/bayn/src/candidate-development-local/command.test.ts` (33 pass, 0 fail)
- `bun run --filter @proompteng/bayn test` (1,114 pass, 154 PostgreSQL-gated skips, 0 fail)
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn build`

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] No documentation, release-note, or follow-up change is required for this source-binding commit.