### PR TITLE
chore(bayn): terminalize Candidate 25 rejection

### DIFF
--- a/packages/scripts/src/bayn/verify-qualification-dormancy.test.ts
+++ b/packages/scripts/src/bayn/verify-qualification-dormancy.test.ts
@@ -25,7 +25,7 @@ describe('qualification dormancy command', () => {
     const decision = await verifyQualificationDormancy(repositoryRoot)
     expect(decision).toEqual({
       status: 'dormant',
-      reason: 'development-not-approved',
+      reason: 'development-rejected',
       candidateOrdinal: 25,
     })
   })
@@ -84,7 +84,7 @@ describe('qualification dormancy command', () => {
       expect(stderr).toBe('')
       expect(stdout).toContain('"status":"dormant"')
       expect(await readFile(githubOutput, 'utf8')).toBe(
-        'eligible=false\ndormant=true\nreason=development-not-approved\ncandidate_ordinal=25\n',
+        'eligible=false\ndormant=true\nreason=development-rejected\ncandidate_ordinal=25\n',
       )
     } finally {
       await rm(directory, { recursive: true, force: true })

--- a/services/bayn/src/candidate-development-trials/ledger.ts
+++ b/services/bayn/src/candidate-development-trials/ledger.ts
@@ -400,6 +400,38 @@ const historicalLedger = [
       sha256: '39bc07487cea9a00190a133ff5faa3b240b04c1a7083041eaa791006106dd79b',
     },
   },
+  {
+    _tag: 'DEVELOPMENT_REJECTED' as const,
+    candidateOrdinal: 25,
+    priorTrialCount: 24,
+    sourceRevision: 'aad1803306ddb6b8ee61fbbcd0e40a25b4143c8b',
+    terminalReportHash: 'c26b1ed91e9467f7dc3c2018f9a96f7b3672c291cf427ceaaf8da4a18050eaee',
+    terminalReport: {
+      schemaVersion: 'bayn.candidate-development-local-terminal.v1' as const,
+      source: {
+        candidateOrdinal: 25,
+        priorTrialCount: 24,
+        trialHistoryHash: '8f9082e34c6d48d8496e79e53d0209f24112bdb950b6ebb11d3d39063b47ff14',
+        strategyName: 'candidate-25-top-two-momentum-consensus',
+        strategyProtocolHash: 'b38c8a135a34e571470e28f16e2f0f75a8dbaefee25d276c7afae39f2793b136',
+        snapshotId: '2a91f0177684f7022f746207333e510c8268f9b77a04b778a04220a33ccf79e0',
+        inputManifestHash: '1e5377336f2e6feb751000114b81cc89aee5be7542e213c320f2cfbb4185bb2b',
+        boundedContentHash: 'b6052c8ebdca855973adf4e41efafb5028fd8dbbaa70809331f6017519b1c995',
+        sourceRevision: 'aad1803306ddb6b8ee61fbbcd0e40a25b4143c8b',
+        modulePath: 'services/bayn/src/strategy/candidate-25.ts',
+        moduleBlobOid: '4953248b045f9f85fb0441dbe0b0d5b14da3558a',
+        moduleSha256: 'bb70b8e8851a3fb390dd5c0b51876122d05a08401b4ad42ac831d5c616e39835',
+        sourceManifestPath: 'services/bayn/candidates/ordinal-25-source-manifest.json',
+        sourceManifestBlobOid: '5cb836429e8a019317ecb7302969b23aaec4587c',
+        sourceManifestSha256: '39bc07487cea9a00190a133ff5faa3b240b04c1a7083041eaa791006106dd79b',
+        bindingHash: 'dc8e691bf2cd9efbf6e64b57dc385f4fe6a69c909d84d91d29ef02da06f1a564',
+      },
+      status: 'HOLD_REJECT',
+      evaluationHash: 'ac07f6d7f55f2fd6258e99d30b00aee679513a4e2b59afcbd5e3a37920a8c4a7',
+      targetHash: 'abdb35449efae707768c9a010cf0e62f5e9ade9572b4ec0151a982a10005596a',
+      qualificationAnalysisHash: '9019a1dfd764518f9b4543c2920511cb91398c45d7109f5bccaae4b18e43804c',
+    },
+  },
 ] as const
 
 /** One append-only source-controlled ledger. Candidate 20 is represented once as the terminal tombstone entry. */


### PR DESCRIPTION
## Summary

- append the exact digest-bound terminal report from Candidate 25s single reviewed local development attempt
- record the honest `HOLD_REJECT` outcome without tuning, rerun, qualification, or successor creation
- keep scheduled qualification dormant at Candidate 25 with `development-rejected`

## Related Issues

PROOMPT-448

## Testing

- exact durable receipt-to-ledger equality check (`receipt-match=true`)
- `bun test services/bayn/src/candidate-development-trials/ledger.test.ts services/bayn/src/candidate-development-trials/qualification-dormancy.test.ts packages/scripts/src/bayn/verify-qualification-dormancy.test.ts services/bayn/src/candidate-development-local/command.test.ts` (33 pass, 0 fail)
- `bun run --filter @proompteng/bayn test` (1,114 pass, 154 PostgreSQL-gated skips, 0 fail)
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn build`

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] No documentation, release-note, or follow-up change is required for this terminal ledger update.