### PR TITLE
feat(bayn): run one bounded research paper episode

### DIFF
--- a/services/bayn/migrations/0028_research_paper_grants.ts
+++ b/services/bayn/migrations/0028_research_paper_grants.ts
@@ -1,0 +1,124 @@
+import { Effect } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient
+
+  yield* sql`
+    ALTER TABLE authority_generations
+      ADD COLUMN research_plan_hash text
+        CHECK (research_plan_hash IS NULL OR research_plan_hash ~ '^[0-9a-f]{64}$'),
+      ADD COLUMN strategy_protocol_hash text
+        CHECK (strategy_protocol_hash IS NULL OR strategy_protocol_hash ~ '^[0-9a-f]{64}$')
+  `
+
+  yield* sql`
+    ALTER TABLE authority_generations
+      DROP CONSTRAINT authority_generations_activation_schema_version_check,
+      ADD CONSTRAINT authority_generations_activation_schema_version_check CHECK (
+        activation_schema_version IN (
+          'bayn.paper-authority-generation.v2',
+          'bayn.paper-authority-generation.v3'
+        )
+      )
+  `
+
+  yield* sql`
+    ALTER TABLE authority_generations
+      DROP CONSTRAINT authority_generations_check,
+      ADD CONSTRAINT authority_generations_check CHECK (
+        (
+          maximum = 'OBSERVE'
+          AND activation_schema_version IS NULL
+          AND qualification_run_id IS NULL
+          AND qualification_lock_id IS NULL
+          AND qualification_result_hash IS NULL
+          AND protocol_hash IS NULL
+          AND qualification_execution_policy_hash IS NULL
+          AND qualification_source_revision IS NULL
+          AND qualification_image_repository IS NULL
+          AND qualification_image_digest IS NULL
+          AND activation_source_revision IS NULL
+          AND activation_image_repository IS NULL
+          AND activation_image_digest IS NULL
+          AND strategy_name IS NULL
+          AND strategy_behavior_hash IS NULL
+          AND strategy_parameter_hash IS NULL
+          AND strategy_parameter_schema_version IS NULL
+          AND risk_policy_hash IS NULL
+          AND proof_plan_hash IS NULL
+          AND reconciliation_id IS NULL
+          AND reconciliation_content_hash IS NULL
+          AND research_plan_hash IS NULL
+          AND strategy_protocol_hash IS NULL
+          AND (
+            account_id IS NULL
+            OR (
+              broker_identity_schema_version = 'bayn.broker-identity.v2'
+              AND broker_identity_hash IS NOT NULL
+              AND broker_provider = 'alpaca'
+              AND broker_environment IN ('sandbox', 'live')
+            )
+          )
+        )
+        OR (
+          maximum = 'PAPER'
+          AND previous_generation_hash IS NOT NULL
+          AND activation_schema_version = 'bayn.paper-authority-generation.v2'
+          AND qualification_run_id IS NOT NULL
+          AND qualification_lock_id IS NOT NULL
+          AND qualification_result_hash IS NOT NULL
+          AND protocol_hash IS NOT NULL
+          AND qualification_execution_policy_hash IS NOT NULL
+          AND qualification_source_revision IS NOT NULL
+          AND qualification_image_repository IS NOT NULL
+          AND qualification_image_digest IS NOT NULL
+          AND activation_source_revision IS NOT NULL
+          AND activation_image_repository IS NOT NULL
+          AND activation_image_digest IS NOT NULL
+          AND strategy_name IS NOT NULL
+          AND strategy_behavior_hash IS NOT NULL
+          AND strategy_parameter_hash IS NOT NULL
+          AND strategy_parameter_schema_version IS NOT NULL
+          AND account_id IS NOT NULL
+          AND risk_policy_hash IS NOT NULL
+          AND proof_plan_hash IS NOT NULL
+          AND reconciliation_id IS NOT NULL
+          AND reconciliation_content_hash IS NOT NULL
+          AND research_plan_hash IS NULL
+          AND strategy_protocol_hash IS NULL
+        )
+        OR (
+          maximum = 'PAPER'
+          AND previous_generation_hash IS NOT NULL
+          AND activation_schema_version = 'bayn.paper-authority-generation.v3'
+          AND qualification_run_id IS NULL
+          AND qualification_lock_id IS NULL
+          AND qualification_result_hash IS NULL
+          AND protocol_hash IS NULL
+          AND qualification_execution_policy_hash IS NULL
+          AND qualification_source_revision IS NULL
+          AND qualification_image_repository IS NULL
+          AND qualification_image_digest IS NULL
+          AND activation_source_revision IS NOT NULL
+          AND activation_image_repository IS NOT NULL
+          AND activation_image_digest IS NOT NULL
+          AND strategy_name IS NOT NULL
+          AND strategy_behavior_hash IS NOT NULL
+          AND strategy_parameter_hash IS NOT NULL
+          AND strategy_parameter_schema_version IS NOT NULL
+          AND account_id IS NOT NULL
+          AND broker_identity_schema_version = 'bayn.broker-identity.v2'
+          AND broker_identity_hash IS NOT NULL
+          AND broker_provider = 'alpaca'
+          AND broker_environment = 'sandbox'
+          AND risk_policy_hash IS NOT NULL
+          AND proof_plan_hash IS NOT NULL
+          AND reconciliation_id IS NOT NULL
+          AND reconciliation_content_hash IS NOT NULL
+          AND research_plan_hash IS NOT NULL
+          AND strategy_protocol_hash IS NOT NULL
+        )
+      )
+  `
+})

--- a/services/bayn/src/app.test.ts
+++ b/services/bayn/src/app.test.ts
@@ -389,6 +389,85 @@ describe('Bayn application composition', () => {
     expect(backgroundInterrupted).toBe(true)
   })
 
+  test('starts a research-bound autonomous cycle without qualification evidence', async () => {
+    const researchPlanHash = 'b'.repeat(64)
+    let startedBindingId: string | undefined
+
+    await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const started = yield* Deferred.make<void>()
+          const startCycle = ({ qualificationRunId }: AutonomousCycleStartupInput) =>
+            Effect.sync(() => void (startedBindingId = qualificationRunId)).pipe(
+              Effect.as(Deferred.succeed(started, undefined).pipe(Effect.andThen(Effect.never))),
+            )
+          const fiber = yield* runApplication(
+            { ...autonomousConfig(config), qualificationRunId: 'c'.repeat(64) },
+            fixtureRuntime,
+            {
+              marketData: marketDataService(Effect.succeed(makeSnapshot())),
+              journal: successfulJournal,
+              evidenceStore: successfulEvidenceStore,
+              cycleObservability,
+            },
+            { _tag: 'AutonomousRead', broker, cycleBindingId: researchPlanHash, startCycle },
+          ).pipe(Effect.provide(HttpServerLive(config)), Effect.forkScoped)
+          yield* Deferred.await(started).pipe(Effect.timeout('1 second'))
+          yield* Fiber.interrupt(fiber)
+        }),
+      ),
+    )
+
+    expect(startedBindingId).toBe(researchPlanHash)
+  })
+
+  test('explicitly suppresses a pending research cycle despite recovered qualification evidence', async () => {
+    let cycleStarted = false
+
+    await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const resolved = yield* Deferred.make<void>()
+          const fiber = yield* runApplication(
+            autonomousConfig(config),
+            fixtureRuntime,
+            {
+              marketData: marketDataService(Effect.succeed(makeSnapshot())),
+              journal: successfulJournal,
+              evidenceStore: successfulEvidenceStore,
+              cycleObservability,
+            },
+            {
+              _tag: 'AutonomousRead',
+              cycleBindingId: null,
+              broker,
+              startCycle: () =>
+                Effect.sync(() => {
+                  cycleStarted = true
+                }).pipe(Effect.as(Effect.never)),
+              resolveAfterStartup: () =>
+                Deferred.succeed(resolved, undefined).pipe(
+                  Effect.as({
+                    _tag: 'AutonomousRead' as const,
+                    cycleBindingId: null,
+                    broker,
+                    startCycle: () =>
+                      Effect.sync(() => {
+                        cycleStarted = true
+                      }).pipe(Effect.as(Effect.never)),
+                  }),
+                ),
+            },
+          ).pipe(Effect.provide(HttpServerLive(config)), Effect.forkScoped)
+          yield* Deferred.await(resolved).pipe(Effect.timeout('1 second'))
+          yield* Effect.yieldNow
+          expect(cycleStarted).toBe(false)
+          yield* Fiber.interrupt(fiber)
+        }),
+      ),
+    )
+  })
+
   test('resolves the autonomous broker runtime before starting its cycle', async () => {
     const events: string[] = []
     await Effect.runPromise(

--- a/services/bayn/src/app.ts
+++ b/services/bayn/src/app.ts
@@ -94,12 +94,15 @@ export type ApplicationRuntime<StartupR, LoopR> =
       readonly _tag: 'AutonomousRead'
       readonly broker?: BrokerProbe
       readonly brokerConfiguration?: BrokerConfiguration
+      /** null explicitly suppresses cycles even when startup recovered historical qualification evidence. */
+      readonly cycleBindingId?: string | null
       readonly startCycle: AutonomousCycleStartup<StartupR, LoopR>
       readonly resolveAfterStartup?: AutonomousRuntimeResolver<StartupR, LoopR>
     }
   | {
       readonly _tag: 'AutonomousMutation'
       readonly broker: BrokerProbe
+      readonly cycleBindingId?: string | null
       readonly executionProgram: ExecutionProgram
       readonly startCycle: AutonomousCycleStartup<StartupR, LoopR>
     }
@@ -197,14 +200,14 @@ const markAutonomousCycleStarted = (state: Ref.Ref<RuntimeState>, startedAt: str
 const forkAutonomousCycle = <StartupR, LoopR>(
   runtime: AutonomousRuntime<StartupR, LoopR>,
   state: Ref.Ref<RuntimeState>,
-  qualificationRunId: string,
+  cycleBindingId: string,
 ): Effect.Effect<Fiber.Fiber<void, never>, OperationalError, StartupR | LoopR | Scope.Scope> =>
   pipe(
     currentUtcInstant,
     Effect.tap((startedAt) => markAutonomousCycleStarted(state, startedAt)),
     Effect.flatMap(() =>
       runtime.startCycle({
-        qualificationRunId,
+        qualificationRunId: cycleBindingId,
         recordPass: (observation) => recordAutonomousCyclePass(state, observation),
       }),
     ),
@@ -218,11 +221,15 @@ const startAutonomousCycle = <StartupR, LoopR>(
   runtime._tag === 'Brokerless'
     ? Effect.succeed(undefined)
     : Ref.get(state).pipe(
-        Effect.flatMap((initialized) =>
-          initialized.evidence === null
+        Effect.flatMap((initialized) => {
+          const cycleBindingId =
+            runtime.cycleBindingId === null
+              ? undefined
+              : (runtime.cycleBindingId ?? initialized.evidence?.evaluation.runId)
+          return cycleBindingId === undefined
             ? Effect.succeed(undefined)
-            : forkAutonomousCycle(runtime, state, initialized.evidence.evaluation.runId),
-        ),
+            : forkAutonomousCycle(runtime, state, cycleBindingId)
+        }),
       )
 
 export const runApplication = <StartupR, LoopR>(

--- a/services/bayn/src/composition.test.ts
+++ b/services/bayn/src/composition.test.ts
@@ -1,17 +1,58 @@
 import { describe, expect, test } from 'bun:test'
 
-import { Effect, Fiber } from 'effect'
+import { Effect, Fiber, Ref, Result } from 'effect'
 import { TestClock } from 'effect/testing'
 
 import {
   closedCycleReceiptEmissionAllowed,
+  finalizePaperEpisode,
   paperReceiptFinalizationWindowOpen,
   restrictExpiredPaperActivation,
   retryClosedCycleReceipts,
 } from './composition'
+import { BrokerEnvironment } from './broker/identity'
 import type { AuthorityRestrictionStoreShape } from './db/execution-store'
+import { makeResearchPaperActivationRequest, makeResearchPaperPlanHash } from './execution/configuration'
 import type { WriterFenceService } from './execution/writer-fence'
 import { paperEpisodeReceiptFinalizationExpiresAt } from './observe-composition'
+import { initialState } from './runtime-state'
+
+const hash = (value: string) => value.repeat(64).slice(0, 64)
+
+const researchPlan = {
+  schemaVersion: 'bayn.paper-research-plan.v1' as const,
+  activation: {
+    sourceRevision: '3'.repeat(40),
+    imageRepository: 'registry.example.test/bayn',
+    imageDigest: `sha256:${hash('4')}`,
+  },
+  strategy: {
+    name: 'risk-balanced-trend',
+    behaviorHash: hash('5'),
+    parameterHash: hash('6'),
+    parameterSchemaVersion: 'bayn.robust-trend-parameters.v2',
+    protocolHash: hash('7'),
+  },
+  broker: {
+    environment: BrokerEnvironment.Sandbox,
+    accountId: 'paper-account',
+    identityHash: hash('8'),
+  },
+  riskPolicyHash: hash('9'),
+  limits: { maxOpenOrders: 0 as const, maxPositions: 0 as const },
+  cutoffAt: '2026-09-01T13:30:00.000Z',
+  expiresAt: '2026-09-03T20:00:00.000Z',
+  maximumCloseSessions: 3 as const,
+} as const
+const { schemaVersion: _researchPlanSchemaVersion, ...researchPlanFields } = researchPlan
+
+const researchRequest = Result.getOrThrow(
+  makeResearchPaperActivationRequest({
+    schemaVersion: 'bayn.paper-research-activation-request.v1',
+    grant: { _tag: 'Research', planHash: Result.getOrThrow(makeResearchPaperPlanHash(researchPlan)) },
+    ...researchPlanFields,
+  }),
+)
 
 describe('Bayn PAPER receipt retry boundary', () => {
   test('does not bind a generation receipt before its PAPER entry cutoff', () => {
@@ -146,5 +187,56 @@ describe('Bayn PAPER startup recovery boundary', () => {
         updatedAt: '2026-08-03T12:00:00.000Z',
       },
     ])
+  })
+
+  test('returns to OBSERVE presentation only after the exact flat receipt is durable', async () => {
+    const restrictions: string[] = []
+    const authorityRestrictionStore: AuthorityRestrictionStoreShape = {
+      restrictAuthority: (reason) =>
+        Effect.sync(() => {
+          restrictions.push(reason)
+        }),
+    }
+    const writerFence: WriterFenceService = {
+      backendPid: 1,
+      check: Effect.void,
+      transaction: <A, E, R>(effect: Effect.Effect<A, E, R>) => effect,
+    }
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const state = yield* Ref.make(
+          initialState(
+            { expectedAccountId: 'paper-account', executionEligible: true, executionDisabledReason: null },
+            true,
+          ),
+        )
+        const finalized = yield* finalizePaperEpisode(
+          state,
+          researchRequest,
+          hash('2'),
+          authorityRestrictionStore,
+          writerFence,
+          () => Effect.succeed(hash('a')),
+          'cycle-1',
+          '2026-09-03T20:01:00.000Z',
+        )
+        return { finalized, state: yield* Ref.get(state) }
+      }),
+    )
+
+    expect(result.finalized).toBe(true)
+    expect(restrictions).toEqual(['PAPER episode restricted effective authority: flat exact receipt finalized'])
+    expect(result.state.paperActivation).toEqual({
+      _tag: 'Completed',
+      requestHash: researchRequest.requestHash,
+      generationHash: hash('2'),
+      grant: 'Research',
+      receiptHash: hash('a'),
+    })
+    expect(result.state.broker).toMatchObject({
+      executionEligible: false,
+      executionDisabledReason: 'PAPER_EPISODE_COMPLETED',
+    })
   })
 })

--- a/services/bayn/src/composition.ts
+++ b/services/bayn/src/composition.ts
@@ -30,7 +30,13 @@ import {
   type AutonomousRuntimeResolver,
 } from './app'
 import { AlpacaBrokerResourcesLive } from './broker/alpaca/composition'
-import { BrokerRead, BrokerSession, type BrokerReadShape } from './broker/alpaca'
+import {
+  BrokerRead,
+  BrokerSession,
+  type BrokerReadShape,
+  type BrokerSessionShape,
+  type ReadPreflight,
+} from './broker/alpaca'
 import { AlpacaHttpClient, makeFreshBrokerPriceReader } from './broker/alpaca/http'
 import { BrokerMutationError, makeMutation } from './broker/alpaca-mutations'
 import { BrokerEnvironment } from './broker/identity'
@@ -50,22 +56,35 @@ import {
   AuthorityGenerationStore,
   AuthorityRestrictionStore,
   BrokerEventStore,
+  CapitalGrantLifecycleStore,
   ExecutionStoreLive,
   FillAccountingStore,
   ReconciliationStore,
   ValuationStore,
   type AuthorityGenerationStoreShape,
   type AuthorityRestrictionStoreShape,
+  type CapitalGrantLifecycleStoreShape,
 } from './db/execution-store'
 import { LiveCapitalGrantStore, LiveCapitalGrantStoreLive } from './db/live-capital-grant'
 import { BrokerAccess, CapitalAuthorityKind, noCapitalAuthority } from './execution/authority'
-import { Authority, KillState, type CapitalGrantGeneration } from './execution/contracts'
+import {
+  Authority,
+  KillState,
+  type AuthorityState,
+  type CapitalGrantGeneration,
+  type ResearchCapitalGrantGeneration,
+} from './execution/contracts'
 import {
   CapitalAuthoritySelection,
   decodePaperActivationRequestResult,
+  isResearchPaperActivationRequest,
+  researchCapitalGrantProof,
+  researchPaperGenerationIsBoundToRequest,
   resolveExecutionPolicy,
   type ExecutionPolicy,
   type PaperActivationRequest,
+  type QualifiedPaperActivationRequest,
+  type ResearchPaperActivationRequest,
 } from './execution/configuration'
 import { IntentStore, IntentStoreLive } from './execution/intents'
 import { MutationStore, MutationStoreLive } from './execution/mutations'
@@ -78,6 +97,12 @@ import { runForwardPerformance } from './forward-performance'
 import { HttpServerLive } from './http'
 import { Journal, JournalLive } from './ledger'
 import { MarketData, MarketDataLive } from './market-data'
+import {
+  decidePaperEpisodeAuthority,
+  paperGrantFromGeneration,
+  paperGrantKey,
+  validatePaperEpisodeCloseWindow,
+} from './paper-episode'
 import {
   loadObserveRiskPolicy,
   makeMutationAutonomousCycleStartup,
@@ -261,7 +286,7 @@ const observeCycle = (plan: ApplicationPlanFor<'AutonomousService'>) =>
 const mutationCycle = (
   plan: ApplicationPlanFor<'AutonomousService'>,
   executionProgram: ExecutionProgram,
-  paperEpisode: Pick<PaperActivationRequest, 'cutoffAt' | 'expiresAt'>,
+  paperEpisode: PaperActivationRequest,
   paperCycleClosureStore: PaperCycleClosureStoreShape,
   onClosedCycle: (cycleId: string, observedAt: string) => Effect.Effect<void>,
 ) =>
@@ -275,10 +300,12 @@ const mutationCycle = (
     reconciliationIntervalMs: plan.config.alpaca.reconciliationIntervalMs,
     reconciliationPassTimeoutMs: plan.config.operationTimeoutMs,
     strategy: plan.strategy,
+    ...(isResearchPaperActivationRequest(paperEpisode) ? { cycleCadence: 'PAPER_BOOTSTRAP' as const } : {}),
     executionProgram,
     paperCycleClosureStore,
     onClosedCycle,
     paperEpisodeCutoffAt: paperEpisode.cutoffAt,
+    paperEpisodeCloseSubmitCutoffAt: paperEpisode.expiresAt,
     paperEpisodeExpiresAt: paperEpisodeCloseExpiresAt(paperEpisode.expiresAt),
   })
 
@@ -326,7 +353,6 @@ const paperActivationRequestIsCurrent = (
   observedAt: string,
   allowCloseRecovery = false,
 ): Result.Result<void, string> => {
-  if (evidence === null) return Result.fail('pinned qualification evidence was not published by startup')
   if (!allowCloseRecovery && (request.expiresAt <= observedAt || request.cutoffAt <= observedAt)) {
     return Result.fail('paper activation request is expired or past its immutable cutoff')
   }
@@ -349,6 +375,17 @@ const paperActivationRequestIsCurrent = (
   ) {
     return Result.fail('paper activation request is not bound to the current activation build')
   }
+  if (isResearchPaperActivationRequest(request)) {
+    if (
+      request.broker.environment !== BrokerEnvironment.Sandbox ||
+      request.broker.accountId !== plan.config.alpaca.expectedAccountId ||
+      request.broker.identityHash !== plan.config.alpaca.identity.identityHash
+    ) {
+      return Result.fail('research PAPER request broker identity does not match the configured sandbox account')
+    }
+    return Result.succeed(undefined)
+  }
+  if (evidence === null) return Result.fail('pinned qualification evidence was not published by startup')
   if (
     evidence.evaluation.runId !== request.qualification.runId ||
     evidence.qualification.runId !== request.qualification.runId ||
@@ -373,7 +410,7 @@ const paperActivationRequestIsCurrent = (
 const internalExecutionPlan = (
   plan: ApplicationPlanFor<'AutonomousService'>,
   mode: 'ExecutionCandidateDiscovery' | 'ExecutionPrepare',
-  request: PaperActivationRequest,
+  request: QualifiedPaperActivationRequest,
   execution: ReadOnlyExecutionPolicy,
   executionPrepareRequest?: ExecutionPrepareRequest,
 ) => {
@@ -394,7 +431,7 @@ const internalExecutionPlan = (
 }
 
 const buildPaperActivationPrepareRequest = (
-  request: PaperActivationRequest,
+  request: QualifiedPaperActivationRequest,
   evidence: RuntimeEvidence,
   discoveryReceipt: ExecutionCandidateDiscoveryReceipt,
 ): Result.Result<ExecutionPrepareRequest, string> => {
@@ -418,7 +455,7 @@ const buildPaperActivationPrepareRequest = (
 }
 
 const paperGenerationIsBoundToRequest = (
-  request: PaperActivationRequest,
+  request: QualifiedPaperActivationRequest,
   plan: ApplicationPlanFor<'AutonomousService'>,
   generation: CapitalGrantGeneration,
 ): Result.Result<void, string> => {
@@ -451,8 +488,10 @@ const paperGenerationIsBoundToRequest = (
   return Result.succeed(undefined)
 }
 
+type PaperAuthorityGeneration = CapitalGrantGeneration | ResearchCapitalGrantGeneration
+
 const preparedPaperActivationIsBound = (
-  request: PaperActivationRequest,
+  request: QualifiedPaperActivationRequest,
   plan: ApplicationPlanFor<'AutonomousService'>,
   prepared: ExecutionPrepareOutput,
 ): Result.Result<void, string> => {
@@ -476,9 +515,9 @@ const readBoundPaperActivationGeneration = (
   plan: ApplicationPlanFor<'AutonomousService'>,
   request: PaperActivationRequest,
   authorityStore: AuthorityGenerationStoreShape,
-): Effect.Effect<CapitalGrantGeneration, OperationalError> =>
+): Effect.Effect<PaperAuthorityGeneration, OperationalError> =>
   Effect.gen(function* () {
-    if (authorityStore.readAuthorityState === undefined || authorityStore.readAuthorityGeneration === undefined) {
+    if (authorityStore.readAuthorityState === undefined) {
       return yield* Effect.fail(
         paperActivationOperationalError('durable PAPER recovery requires authority history read capabilities'),
       )
@@ -501,11 +540,35 @@ const readBoundPaperActivationGeneration = (
         ),
       )
     }
+    if (isResearchPaperActivationRequest(request)) {
+      if (authorityStore.readResearchAuthorityGeneration === undefined) {
+        return yield* Effect.fail(
+          paperActivationOperationalError('durable research PAPER recovery requires v3 authority history reads'),
+        )
+      }
+      const generation = yield* authorityStore
+        .readResearchAuthorityGeneration(authority.generationHash)
+        .pipe(
+          Effect.mapError((cause) => paperActivationOperationalError('durable PAPER generation read failed', cause)),
+        )
+      if (generation === undefined) {
+        return yield* Effect.fail(paperActivationOperationalError('durable research PAPER history is missing'))
+      }
+      yield* Effect.fromResult(
+        researchPaperGenerationIsBoundToRequest(request, plan.config.alpaca.authorityGenerationHash, generation),
+      ).pipe(Effect.mapError((message) => paperActivationOperationalError(message)))
+      return generation
+    }
+    if (authorityStore.readAuthorityGeneration === undefined) {
+      return yield* Effect.fail(
+        paperActivationOperationalError('durable qualified PAPER recovery requires v2 authority history reads'),
+      )
+    }
     const generation = yield* authorityStore
       .readAuthorityGeneration(authority.generationHash)
       .pipe(Effect.mapError((cause) => paperActivationOperationalError('durable PAPER generation read failed', cause)))
     if (generation === undefined) {
-      return yield* Effect.fail(paperActivationOperationalError('durable PAPER generation history is missing'))
+      return yield* Effect.fail(paperActivationOperationalError('durable qualified PAPER history is missing'))
     }
     yield* Effect.fromResult(paperGenerationIsBoundToRequest(request, plan, generation)).pipe(
       Effect.mapError((message) => paperActivationOperationalError(message)),
@@ -516,11 +579,11 @@ const readBoundPaperActivationGeneration = (
 const recoverPaperActivationGeneration = (
   plan: ApplicationPlanFor<'AutonomousService'>,
   request: PaperActivationRequest,
-  evidence: RuntimeEvidence,
+  evidence: RuntimeEvidence | null,
   authorityStore: AuthorityGenerationStoreShape,
   authorityRestrictionStore: AuthorityRestrictionStoreShape,
   writerFence: WriterFenceService,
-): Effect.Effect<CapitalGrantGeneration, OperationalError> =>
+): Effect.Effect<PaperAuthorityGeneration, OperationalError> =>
   Effect.gen(function* () {
     const observedAt = yield* currentUtcInstant
     yield* Effect.fromResult(paperActivationRequestIsCurrent(request, plan, evidence, observedAt, true)).pipe(
@@ -544,11 +607,11 @@ const recoverPaperActivationGeneration = (
 const recoverPaperReceiptFinalizationGeneration = (
   plan: ApplicationPlanFor<'AutonomousService'>,
   request: PaperActivationRequest,
-  evidence: RuntimeEvidence,
+  evidence: RuntimeEvidence | null,
   authorityStore: AuthorityGenerationStoreShape,
   authorityRestrictionStore: AuthorityRestrictionStoreShape,
   writerFence: WriterFenceService,
-): Effect.Effect<CapitalGrantGeneration, OperationalError> =>
+): Effect.Effect<PaperAuthorityGeneration, OperationalError> =>
   Effect.gen(function* () {
     const observedAt = yield* currentUtcInstant
     yield* Effect.fromResult(paperActivationRequestIsCurrent(request, plan, evidence, observedAt, true)).pipe(
@@ -560,22 +623,17 @@ const recoverPaperReceiptFinalizationGeneration = (
       )
     }
     yield* restrictExpiredPaperActivation(authorityRestrictionStore, writerFence)
-    if (!paperReceiptFinalizationWindowOpen(request.expiresAt, observedAt)) {
-      return yield* Effect.fail(
-        paperActivationOperationalError('durable PAPER receipt finalization is outside its bounded lease'),
-      )
-    }
     return yield* readBoundPaperActivationGeneration(plan, request, authorityStore)
   })
 
 type PaperActivationStartupResolution =
-  | { readonly _tag: 'ReceiptFinalization'; readonly generation: CapitalGrantGeneration }
-  | { readonly _tag: 'Mutation'; readonly generation: CapitalGrantGeneration }
+  | { readonly _tag: 'ReceiptFinalization'; readonly generation: PaperAuthorityGeneration }
+  | { readonly _tag: 'Mutation'; readonly generation: PaperAuthorityGeneration }
 
 const preparePaperActivation = (
   plan: ApplicationPlanFor<'AutonomousService'>,
   evidence: RuntimeEvidence,
-  request: PaperActivationRequest,
+  request: QualifiedPaperActivationRequest,
 ): Effect.Effect<ExecutionPrepareOutput, OperationalError> =>
   Effect.gen(function* () {
     const observedAt = yield* currentUtcInstant
@@ -634,6 +692,150 @@ const preparePaperActivation = (
     return prepared
   })
 
+const validateResearchPaperPreflight = (
+  request: ResearchPaperActivationRequest,
+  preflight: ReadPreflight,
+): Result.Result<void, string> =>
+  preflight.environment === BrokerEnvironment.Sandbox &&
+  preflight.accountId === request.broker.accountId &&
+  preflight.openOrderCount === request.limits.maxOpenOrders &&
+  preflight.positionCount === request.limits.maxPositions
+    ? Result.succeed(undefined)
+    : Result.fail('research PAPER preflight requires the exact empty sandbox account')
+
+const validateResearchPaperRiskPolicy = (
+  plan: ApplicationPlanFor<'AutonomousService'>,
+  request: ResearchPaperActivationRequest,
+): Effect.Effect<void, OperationalError> =>
+  loadObserveRiskPolicy(request.broker.accountId, plan.strategy.definition.parameters.universe).pipe(
+    Effect.mapError((cause) =>
+      paperActivationOperationalError('source-controlled PAPER risk policy is invalid', cause),
+    ),
+    Effect.flatMap((riskPolicy) => policyHash(riskPolicy, 'paper-candidate-policy')),
+    Effect.mapError((cause) => paperActivationOperationalError(cause.message, cause)),
+    Effect.flatMap((currentRiskPolicyHash) =>
+      currentRiskPolicyHash === request.riskPolicyHash
+        ? Effect.void
+        : Effect.fail(
+            paperActivationOperationalError('research PAPER request is not bound to the current risk policy'),
+          ),
+    ),
+  )
+
+const validateResearchPaperCloseLease = (
+  request: ResearchPaperActivationRequest,
+  session: BrokerSessionShape,
+): Effect.Effect<void, OperationalError> => {
+  const requestedRange = { start: request.cutoffAt.slice(0, 10), end: request.expiresAt.slice(0, 10) }
+  return session.read.marketCalendar(requestedRange).pipe(
+    Effect.mapError((cause) => paperActivationOperationalError('research PAPER close calendar read failed', cause)),
+    Effect.flatMap((calendar) =>
+      calendar.value.requestedRange.start === requestedRange.start &&
+      calendar.value.requestedRange.end === requestedRange.end
+        ? Effect.succeed(calendar.value.sessions)
+        : Effect.fail(
+            paperActivationOperationalError('research PAPER close calendar did not cover the requested lease'),
+          ),
+    ),
+    Effect.flatMap((sessions) =>
+      Effect.fromResult(
+        validatePaperEpisodeCloseWindow({
+          cutoffAt: request.cutoffAt,
+          expiresAt: request.expiresAt,
+          maximumCloseSessions: request.maximumCloseSessions,
+          sessions,
+        }),
+      ),
+    ),
+    Effect.mapError((cause) =>
+      cause instanceof OperationalError
+        ? cause
+        : paperActivationOperationalError(`research PAPER close lease is invalid: ${cause._tag}`, cause),
+    ),
+    Effect.asVoid,
+  )
+}
+
+const validateActivatedResearchAuthority = (authority: AuthorityState): Result.Result<void, string> =>
+  authority.maximum === Authority.Paper && authority.effective === Authority.Paper && authority.kill === KillState.Clear
+    ? Result.succeed(undefined)
+    : Result.fail('research PAPER activation did not return clear effective PAPER authority')
+
+const prepareResearchPaperActivation = (
+  plan: ApplicationPlanFor<'AutonomousService'>,
+  request: ResearchPaperActivationRequest,
+  session: BrokerSessionShape,
+  authorityStore: AuthorityGenerationStoreShape,
+  lifecycle: CapitalGrantLifecycleStoreShape,
+  writerFence: WriterFenceService,
+): Effect.Effect<ResearchCapitalGrantGeneration, OperationalError> =>
+  Effect.gen(function* () {
+    const observedAt = yield* currentUtcInstant
+    yield* Effect.fromResult(paperActivationRequestIsCurrent(request, plan, null, observedAt)).pipe(
+      Effect.mapError((message) => paperActivationOperationalError(message)),
+    )
+    yield* Effect.fromResult(validateResearchPaperPreflight(request, session.preflight)).pipe(
+      Effect.mapError((message) => paperActivationOperationalError(message)),
+    )
+    yield* validateResearchPaperRiskPolicy(plan, request)
+    yield* validateResearchPaperCloseLease(request, session)
+
+    const proof = researchCapitalGrantProof(request)
+    const authority = yield* lifecycle.activateResearchCapitalGrant(proof).pipe(
+      Effect.provideService(WriterFence, writerFence),
+      Effect.mapError((cause) => paperActivationOperationalError('research PAPER generation activation failed', cause)),
+    )
+    yield* Effect.fromResult(validateActivatedResearchAuthority(authority)).pipe(
+      Effect.mapError((message) => paperActivationOperationalError(message)),
+    )
+    return yield* readBoundPaperActivationGeneration(plan, request, authorityStore).pipe(
+      Effect.flatMap((generation) =>
+        generation.schemaVersion === 'bayn.paper-authority-generation.v3'
+          ? Effect.succeed(generation)
+          : Effect.fail(paperActivationOperationalError('research PAPER activation loaded qualified history')),
+      ),
+    )
+  })
+
+const prepareOrRecoverResearchPaperActivation = (
+  plan: ApplicationPlanFor<'AutonomousService'>,
+  request: ResearchPaperActivationRequest,
+  session: BrokerSessionShape,
+  authorityStore: AuthorityGenerationStoreShape,
+  lifecycle: CapitalGrantLifecycleStoreShape,
+  writerFence: WriterFenceService,
+): Effect.Effect<ResearchCapitalGrantGeneration, OperationalError> =>
+  Effect.gen(function* () {
+    if (authorityStore.readAuthorityState === undefined) {
+      return yield* Effect.fail(
+        paperActivationOperationalError('research PAPER startup requires durable authority state reads'),
+      )
+    }
+    const authority = yield* authorityStore
+      .readAuthorityState()
+      .pipe(Effect.mapError((cause) => paperActivationOperationalError('research PAPER authority read failed', cause)))
+    const decision = yield* Effect.fromResult(
+      decidePaperEpisodeAuthority({
+        generationHash: authority.generationHash,
+        sourceGenerationHash: plan.config.alpaca.authorityGenerationHash,
+        maximum: authority.maximum,
+        effective: authority.effective,
+        kill: authority.kill,
+      }),
+    ).pipe(
+      Effect.mapError((cause) =>
+        paperActivationOperationalError('research PAPER durable authority does not match this episode', cause),
+      ),
+    )
+    if (decision._tag === 'Activate') {
+      return yield* prepareResearchPaperActivation(plan, request, session, authorityStore, lifecycle, writerFence)
+    }
+    const generation = yield* readBoundPaperActivationGeneration(plan, request, authorityStore)
+    return generation.schemaVersion === 'bayn.paper-authority-generation.v3'
+      ? generation
+      : yield* Effect.fail(paperActivationOperationalError('research PAPER recovery loaded qualified history'))
+  })
+
 const pendingPaperActivation = (
   state: Ref.Ref<RuntimeState>,
   request: PaperActivationRequest | null,
@@ -657,12 +859,47 @@ const realizedPaperActivation = (
   state: Ref.Ref<RuntimeState>,
   request: PaperActivationRequest,
   generationHash: string,
+  grant: 'Qualified' | 'Research',
 ): Effect.Effect<void> =>
   Ref.update(state, (current) => ({
     ...current,
-    paperActivation: { _tag: 'Realized' as const, requestHash: request.requestHash, generationHash },
+    paperActivation: {
+      _tag: 'Realized' as const,
+      requestHash: request.requestHash,
+      generationHash,
+      grant,
+      cutoffAt: request.cutoffAt,
+      expiresAt: request.expiresAt,
+      maximumCloseSessions: isResearchPaperActivationRequest(request) ? request.maximumCloseSessions : null,
+    },
     broker:
       current.broker === null ? null : { ...current.broker, executionEligible: true, executionDisabledReason: null },
+    error: null,
+  }))
+
+const completedPaperActivation = (
+  state: Ref.Ref<RuntimeState>,
+  request: PaperActivationRequest,
+  generationHash: string,
+  receiptHash: string,
+): Effect.Effect<void> =>
+  Ref.update(state, (current) => ({
+    ...current,
+    paperActivation: {
+      _tag: 'Completed' as const,
+      requestHash: request.requestHash,
+      generationHash,
+      grant: isResearchPaperActivationRequest(request) ? ('Research' as const) : ('Qualified' as const),
+      receiptHash,
+    },
+    broker:
+      current.broker === null
+        ? null
+        : {
+            ...current.broker,
+            executionEligible: false,
+            executionDisabledReason: 'PAPER_EPISODE_COMPLETED',
+          },
     error: null,
   }))
 
@@ -708,11 +945,11 @@ const makeClosedCycleReceiptEmitter =
     sql: PgClient.PgClient,
     authorityGenerationHash: string,
     receiptStore: ForwardPerformanceReceiptStoreShape,
-  ): ((cycleId: string | undefined, observedAt: string) => Effect.Effect<boolean>) =>
+  ): ((cycleId: string | undefined, observedAt: string) => Effect.Effect<string | undefined>) =>
   (cycleId, observedAt) =>
     Effect.gen(function* () {
       const existing = yield* receiptStore.read(authorityGenerationHash)
-      if (Option.isSome(existing)) return true
+      if (Option.isSome(existing)) return existing.value.receiptHash
       const receipt = yield* Effect.scoped(
         runForwardPerformance(config, undefined, { authorityGenerationHash }).pipe(
           Effect.provideService(PgClient.PgClient, sql),
@@ -747,20 +984,20 @@ const makeClosedCycleReceiptEmitter =
             openPositionCount: receipt.reconciliationProof.openPositionCount,
           }),
         )
-        return false
+        return undefined
       }
       if (receipt.profitability === 'PROFITABLE' && netRealizedPnl <= 0n) {
         yield* Effect.logError('Bayn forward-performance receipt rejected an unsupported positive claim').pipe(
           Effect.annotateLogs({ service: 'bayn', cycleId, receiptHash: receipt.receiptHash }),
         )
-        return false
+        return undefined
       }
       const receiptCycleId = cycleId ?? receipt.window.lastCycleId
       if (receiptCycleId === null || receiptCycleId === undefined) {
         yield* Effect.logWarning(
           'Bayn forward-performance receipt withheld: no closed cycle identity was observed',
         ).pipe(Effect.annotateLogs({ service: 'bayn', observedAt }))
-        return false
+        return undefined
       }
       const envelope = yield* Effect.fromResult(
         makeForwardPerformanceReceiptEnvelope({
@@ -783,7 +1020,7 @@ const makeClosedCycleReceiptEmitter =
           netRealizedPnlAfterCostsMicros: stored.receipt.totals.netRealizedPnlAfterCostsMicros,
         }),
       )
-      return true
+      return stored.receiptHash
     }).pipe(
       Effect.catch((cause) =>
         Effect.logError('Bayn forward-performance receipt emission failed')
@@ -795,9 +1032,43 @@ const makeClosedCycleReceiptEmitter =
               reason: cause instanceof Error ? cause.message : String(cause),
             }),
           )
-          .pipe(Effect.as(false)),
+          .pipe(Effect.as(undefined)),
       ),
     )
+
+export const finalizePaperEpisode = (
+  state: Ref.Ref<RuntimeState>,
+  request: PaperActivationRequest,
+  generationHash: string,
+  authorityRestrictionStore: AuthorityRestrictionStoreShape,
+  writerFence: WriterFenceService,
+  emit: (cycleId: string | undefined, observedAt: string) => Effect.Effect<string | undefined>,
+  cycleId: string | undefined,
+  observedAt: string,
+): Effect.Effect<boolean> =>
+  emit(cycleId, observedAt).pipe(
+    Effect.flatMap((receiptHash) =>
+      receiptHash === undefined
+        ? Effect.succeed(false)
+        : restrictMutationAuthority('PAPER episode', 'flat exact receipt finalized').pipe(
+            Effect.provideService(AuthorityRestrictionStore, authorityRestrictionStore),
+            Effect.provideService(WriterFence, writerFence),
+            Effect.andThen(completedPaperActivation(state, request, generationHash, receiptHash)),
+            Effect.as(true),
+          ),
+    ),
+    Effect.catch((cause) =>
+      Effect.logError('Bayn PAPER episode finalization failed').pipe(
+        Effect.annotateLogs({
+          service: 'bayn',
+          cycleId,
+          observedAt,
+          reason: cause instanceof Error ? cause.message : String(cause),
+        }),
+        Effect.as(false),
+      ),
+    ),
+  )
 
 export const retryClosedCycleReceipts = (
   emit: (cycleId: string | undefined, observedAt: string) => Effect.Effect<boolean>,
@@ -854,6 +1125,7 @@ const runAutonomousService = (plan: ApplicationPlanFor<'AutonomousService'>) =>
     ): Effect.Effect<Effect.Effect<void, never, never>, OperationalError, never> => Effect.succeed(Effect.never)
     const pendingRuntime = () => ({
       _tag: 'AutonomousRead' as const,
+      cycleBindingId: null,
       brokerConfiguration: {
         expectedAccountId: observePlan.config.alpaca.expectedAccountId,
         executionEligible: false,
@@ -915,6 +1187,7 @@ const runAutonomousService = (plan: ApplicationPlanFor<'AutonomousService'>) =>
                       valuationStore: ValuationStore,
                       reconciliationStore: ReconciliationStore,
                       authorityGenerationStore: AuthorityGenerationStore,
+                      capitalGrantLifecycleStore: CapitalGrantLifecycleStore,
                       authorityRestrictionStore: AuthorityRestrictionStore,
                       paperCycleClosureStore: PaperCycleClosureStore,
                       forwardPerformanceReceiptStore: ForwardPerformanceReceiptStore,
@@ -943,11 +1216,14 @@ const runAutonomousService = (plan: ApplicationPlanFor<'AutonomousService'>) =>
                         const readRuntime = () => ({
                           _tag: 'AutonomousRead' as const,
                           broker: runtimeBroker(observePlan, runtimeServices.session.read, false),
+                          ...(request !== null && isResearchPaperActivationRequest(request)
+                            ? { cycleBindingId: null }
+                            : {}),
                           startCycle: readStartCycle,
                         })
                         if (request === null) return Effect.succeed(readRuntime())
                         const evidence = validated.success.evidence
-                        if (evidence === null) {
+                        if (evidence === null && !isResearchPaperActivationRequest(request)) {
                           return pendingPaperActivation(state, request, 'STARTUP_EVIDENCE_UNAVAILABLE').pipe(
                             Effect.as(readRuntime()),
                           )
@@ -979,9 +1255,24 @@ const runAutonomousService = (plan: ApplicationPlanFor<'AutonomousService'>) =>
                                         runtimeServices.authorityRestrictionStore,
                                         runtimeServices.writerFence,
                                       ).pipe(Effect.map((generation) => ({ _tag: 'Mutation' as const, generation })))
-                                    : preparePaperActivation(observePlan, evidence, request).pipe(
-                                        Effect.map(({ generation }) => ({ _tag: 'Mutation' as const, generation })),
-                                      ),
+                                    : isResearchPaperActivationRequest(request)
+                                      ? prepareOrRecoverResearchPaperActivation(
+                                          observePlan,
+                                          request,
+                                          runtimeServices.session,
+                                          runtimeServices.authorityGenerationStore,
+                                          runtimeServices.capitalGrantLifecycleStore,
+                                          runtimeServices.writerFence,
+                                        ).pipe(Effect.map((generation) => ({ _tag: 'Mutation' as const, generation })))
+                                      : evidence === null
+                                        ? Effect.fail(
+                                            paperActivationOperationalError(
+                                              'qualified PAPER activation evidence is unavailable',
+                                            ),
+                                          )
+                                        : preparePaperActivation(observePlan, evidence, request).pipe(
+                                            Effect.map(({ generation }) => ({ _tag: 'Mutation' as const, generation })),
+                                          ),
                             ),
                           )
                         return prepareOrRecover.pipe(
@@ -996,16 +1287,53 @@ const runAutonomousService = (plan: ApplicationPlanFor<'AutonomousService'>) =>
                                   prepared.generation.generationHash,
                                   runtimeServices.forwardPerformanceReceiptStore,
                                 )
+                                const finalizeClosedCycleReceipt = (cycleId: string | undefined, observedAt: string) =>
+                                  finalizePaperEpisode(
+                                    state,
+                                    request,
+                                    prepared.generation.generationHash,
+                                    runtimeServices.authorityRestrictionStore,
+                                    runtimeServices.writerFence,
+                                    emitClosedCycleReceipt,
+                                    cycleId,
+                                    observedAt,
+                                  )
                                 return Effect.gen(function* () {
+                                  yield* pendingPaperActivation(state, request, 'REQUEST_EXPIRED')
+                                  const observedAt = yield* currentUtcInstant
+                                  if (!paperReceiptFinalizationWindowOpen(request.expiresAt, observedAt)) {
+                                    const existing = yield* runtimeServices.forwardPerformanceReceiptStore
+                                      .read(prepared.generation.generationHash)
+                                      .pipe(
+                                        Effect.mapError((cause) =>
+                                          paperActivationOperationalError(
+                                            'durable PAPER receipt recovery read failed',
+                                            cause,
+                                          ),
+                                        ),
+                                      )
+                                    if (Option.isSome(existing)) {
+                                      yield* finalizePaperEpisode(
+                                        state,
+                                        request,
+                                        prepared.generation.generationHash,
+                                        runtimeServices.authorityRestrictionStore,
+                                        runtimeServices.writerFence,
+                                        () => Effect.succeed(existing.value.receiptHash),
+                                        existing.value.cycleId,
+                                        observedAt,
+                                      )
+                                    }
+                                    return readRuntime()
+                                  }
                                   yield* Effect.forkScoped(
                                     retryClosedCycleReceipts(
-                                      emitClosedCycleReceipt,
+                                      finalizeClosedCycleReceipt,
                                       request.cutoffAt,
                                       paperEpisodeReceiptFinalizationExpiresAt(request.expiresAt),
                                       observePlan.config.alpaca.reconciliationIntervalMs,
                                     ),
                                   )
-                                  yield* pendingPaperActivation(state, request, 'REQUEST_EXPIRED')
                                   return readRuntime()
                                 })
                               }
@@ -1051,6 +1379,9 @@ const runAutonomousService = (plan: ApplicationPlanFor<'AutonomousService'>) =>
                                   const realizedConfig = {
                                     ...observePlan.config,
                                     execution: realizedPolicy.success,
+                                    ...(isResearchPaperActivationRequest(request)
+                                      ? { qualificationRunId: request.grant.planHash }
+                                      : {}),
                                   } as Extract<LoadedRuntimeConfig, { readonly runtimeMode: 'AutonomousService' }>
                                   const realizedPlan = makeApplicationPlan({
                                     config: realizedConfig,
@@ -1065,9 +1396,23 @@ const runAutonomousService = (plan: ApplicationPlanFor<'AutonomousService'>) =>
                                     prepared.generation.generationHash,
                                     runtimeServices.forwardPerformanceReceiptStore,
                                   )
+                                  const finalizeClosedCycleReceipt = (
+                                    cycleId: string | undefined,
+                                    observedAt: string,
+                                  ) =>
+                                    finalizePaperEpisode(
+                                      state,
+                                      request,
+                                      prepared.generation.generationHash,
+                                      runtimeServices.authorityRestrictionStore,
+                                      runtimeServices.writerFence,
+                                      emitClosedCycleReceipt,
+                                      cycleId,
+                                      observedAt,
+                                    )
                                   const onClosedCycle = (cycleId: string, observedAt: string) =>
                                     closedCycleReceiptEmissionAllowed(request.cutoffAt, observedAt)
-                                      ? emitClosedCycleReceipt(cycleId, observedAt).pipe(Effect.asVoid)
+                                      ? finalizeClosedCycleReceipt(cycleId, observedAt).pipe(Effect.asVoid)
                                       : Effect.void
                                   return makeMutation(
                                     runtimeServices.session,
@@ -1099,12 +1444,17 @@ const runAutonomousService = (plan: ApplicationPlanFor<'AutonomousService'>) =>
                                     ),
                                     Effect.mapError(executionProgramError),
                                     Effect.tap(() =>
-                                      realizedPaperActivation(state, request, prepared.generation.generationHash),
+                                      realizedPaperActivation(
+                                        state,
+                                        request,
+                                        prepared.generation.generationHash,
+                                        paperGrantFromGeneration(prepared.generation)._tag,
+                                      ),
                                     ),
                                     Effect.tap(() =>
                                       Effect.forkScoped(
                                         retryClosedCycleReceipts(
-                                          emitClosedCycleReceipt,
+                                          finalizeClosedCycleReceipt,
                                           request.cutoffAt,
                                           paperEpisodeReceiptFinalizationExpiresAt(request.expiresAt),
                                           realizedPlan.config.alpaca.reconciliationIntervalMs,
@@ -1123,6 +1473,7 @@ const runAutonomousService = (plan: ApplicationPlanFor<'AutonomousService'>) =>
                                     Effect.map((executionProgram) => ({
                                       _tag: 'AutonomousMutation' as const,
                                       broker: runtimeBroker(realizedPlan, runtimeServices.session.read, true),
+                                      cycleBindingId: paperGrantKey(paperGrantFromGeneration(prepared.generation)),
                                       executionProgram,
                                       startCycle: (startup: AutonomousCycleStartupInput) =>
                                         mutationCycle(

--- a/services/bayn/src/cycle-runner.test.ts
+++ b/services/bayn/src/cycle-runner.test.ts
@@ -49,6 +49,7 @@ import {
   type CycleRunResult,
 } from './cycle-runner'
 import { CycleNotDueReconciliationError } from './cycle-runner/model'
+import { completeCycleAuthoritySelection } from './cycle-runner/decisions'
 import { runAutonomousCycleUntilSettled } from './cycle-runner/program'
 import { selectBoundDecision } from './cycle-runner/recovery-decision-binding'
 import { selectCycleRecovery, type CycleRecoveryState } from './cycle-recovery'
@@ -1107,6 +1108,26 @@ describe('autonomous cycle runner', () => {
       })
     }
     expect(
+      completeCycleAuthoritySelection(
+        { _tag: 'UNCLAIMED', publications: [publication], latestTerminal: terminal },
+        'PAPER_BOOTSTRAP',
+      ),
+    ).toEqual({ _tag: 'ALREADY_TERMINAL', cycle: terminal })
+    const noTrade = { ...terminal, state: CycleState.NoTrade }
+    expect(
+      completeCycleAuthoritySelection(
+        { _tag: 'UNCLAIMED', publications: [publication], latestTerminal: noTrade },
+        'PAPER_BOOTSTRAP',
+      ),
+    ).toEqual({ _tag: 'READ_CALENDAR', publications: [publication] })
+    const blocked = { ...terminal, state: CycleState.Blocked }
+    expect(
+      completeCycleAuthoritySelection(
+        { _tag: 'UNCLAIMED', publications: [publication], latestTerminal: blocked },
+        'PAPER_BOOTSTRAP',
+      ),
+    ).toEqual({ _tag: 'ALREADY_TERMINAL', cycle: blocked })
+    expect(
       selectCycleAuthoritySlots([
         { publication, existing: terminal },
         { publication: olderPublication, existing: olderTerminal },
@@ -1444,6 +1465,20 @@ describe('autonomous cycle runner', () => {
       executionOpenAt: '2026-02-02T14:30:00.000Z',
       executionCloseAt: '2026-02-02T20:00:00.000Z',
     })
+  })
+
+  test('admits a PAPER bootstrap publication without weakening the default monthly cadence', () => {
+    const executionSession = selectNextExecutionSession('2026-01-29', ordinaryNotDueCalendar)
+    if (executionSession === undefined) throw new Error('bootstrap fixture must have an execution session')
+    const monthly = makeDueCycleDraft(candidate('2026-01-29'), ordinaryNotDueCalendar, executionSession)
+    const bootstrap = makeDueCycleDraft(
+      { ...candidate('2026-01-29'), cadence: 'PAPER_BOOTSTRAP' },
+      ordinaryNotDueCalendar,
+      executionSession,
+    )
+    expect(monthly).toEqual(Result.succeed(undefined))
+    expect(Result.isSuccess(bootstrap)).toBe(true)
+    if (Result.isSuccess(bootstrap)) expect(bootstrap.success?.identity.signalSessionDate).toBe('2026-01-29')
   })
 
   test('does nothing when no finalized publication exists and never reads the broker', async () => {

--- a/services/bayn/src/cycle-runner/admission-decisions.ts
+++ b/services/bayn/src/cycle-runner/admission-decisions.ts
@@ -51,6 +51,7 @@ const selectCycleCalendarPublication = <R>(
 ): Result.Result<CycleCalendarCandidateDecision, CycleCalendarCandidateFailure> => {
   const candidate: CycleCandidate = {
     qualificationRunId: context.qualificationRunId,
+    ...(context.cadence === undefined ? {} : { cadence: context.cadence }),
     strategyProtocolHash: context.strategyProtocolHash,
     accountId: context.accountId,
     signalSession: publication.signalSession,

--- a/services/bayn/src/cycle-runner/authority-decisions.ts
+++ b/services/bayn/src/cycle-runner/authority-decisions.ts
@@ -1,4 +1,4 @@
-import { isTerminalCycleState, type AutonomousCycle } from '../cycle'
+import { CycleState, isTerminalCycleState, type AutonomousCycle } from '../cycle'
 import type { MarketDataInspection } from '../market-data'
 import type { NonEmptyPublications } from './calendar-decisions'
 
@@ -87,10 +87,20 @@ export const reduceCycleAuthoritySelection = (
   }
 }
 
-export const completeCycleAuthoritySelection = (state: CycleAuthoritySelectionState): CycleAuthoritySelection =>
-  state._tag === 'UNCLAIMED'
-    ? { _tag: 'READ_CALENDAR', publications: state.publications }
-    : { _tag: 'ALREADY_TERMINAL', cycle: state.latestTerminal }
+export const completeCycleAuthoritySelection = (
+  state: CycleAuthoritySelectionState,
+  cadence?: 'MONTHLY' | 'PAPER_BOOTSTRAP',
+): CycleAuthoritySelection => {
+  if (state._tag === 'TERMINAL') return { _tag: 'ALREADY_TERMINAL', cycle: state.latestTerminal }
+  if (
+    cadence === 'PAPER_BOOTSTRAP' &&
+    state.latestTerminal !== undefined &&
+    state.latestTerminal.state !== CycleState.NoTrade
+  ) {
+    return { _tag: 'ALREADY_TERMINAL', cycle: state.latestTerminal }
+  }
+  return { _tag: 'READ_CALENDAR', publications: state.publications }
+}
 
 export const selectCycleAuthoritySlots = (slots: NonEmptyAuthoritySlots): CycleAuthoritySelection => {
   const [first, ...remaining] = slots

--- a/services/bayn/src/cycle-runner/calendar-decisions.ts
+++ b/services/bayn/src/cycle-runner/calendar-decisions.ts
@@ -206,6 +206,7 @@ export const makeDueCycleDraft = (
   observation: MarketCalendarObservation,
   executionSession: MarketCalendarSession,
 ): Result.Result<CycleDraft | undefined, CycleConstructionFailure> =>
+  candidate.cadence !== 'PAPER_BOOTSTRAP' &&
   !isMonthEndCycleDue(candidate.signalSession.session_date, executionSession.date)
     ? Result.succeed(undefined)
     : Result.flatMap(

--- a/services/bayn/src/cycle-runner/model.ts
+++ b/services/bayn/src/cycle-runner/model.ts
@@ -22,6 +22,7 @@ export class CycleNotDueReconciliationError extends Data.TaggedError('CycleNotDu
 
 export interface CycleRunContext<R = never> {
   readonly qualificationRunId: string
+  readonly cadence?: 'MONTHLY' | 'PAPER_BOOTSTRAP'
   readonly strategyProtocolHash: string
   readonly accountId: string
   readonly executionPolicy: CycleExecutionPolicy
@@ -33,6 +34,7 @@ export interface CycleRunContext<R = never> {
 
 export interface CycleCandidate {
   readonly qualificationRunId: string
+  readonly cadence?: 'MONTHLY' | 'PAPER_BOOTSTRAP'
   readonly strategyProtocolHash: string
   readonly accountId: string
   readonly signalSession: SignalCycleSession

--- a/services/bayn/src/cycle-runner/program.ts
+++ b/services/bayn/src/cycle-runner/program.ts
@@ -95,7 +95,7 @@ const continueCycleAuthorityReads = <R>(
 ): Effect.Effect<CycleAuthoritySelection, CycleRunnerError> => {
   const [publication, ...remaining] = publications
   if (publication === undefined) {
-    return Effect.succeed(completeCycleAuthoritySelection(state))
+    return Effect.succeed(completeCycleAuthoritySelection(state, context.cadence))
   }
   return pipe(
     readCycleAuthoritySlot(store, context, publication),

--- a/services/bayn/src/db/capital-grant-algebra.test.ts
+++ b/services/bayn/src/db/capital-grant-algebra.test.ts
@@ -10,6 +10,8 @@ import {
   ReconciliationStatus,
   type AuthorityState,
   type CapitalGrantProofBinding,
+  type ResearchCapitalGrantGenerationMaterial,
+  type ResearchCapitalGrantProofBinding,
 } from '../execution/contracts'
 import { makeQualificationResult } from '../qualification'
 import {
@@ -23,6 +25,7 @@ import {
   decideObserveGeneration,
   decidePaperActivation,
   deriveCapitalGrantGeneration,
+  deriveResearchCapitalGrantGeneration,
   nextAuthorityVersion,
   paperActivationEffectiveAuthority,
   capitalGrantFailureDetails,
@@ -38,6 +41,8 @@ import {
   validatePaperGenerationReplay,
   validatePaperPrepareGeneration,
   validatePaperSourceAuthority,
+  validateResearchCapitalGrantProof,
+  validateResearchPaperGenerationReplay,
   type ExactReconciliationFacts,
   type CapitalGrantAlgebraFailure,
   type PaperGenerationEvidenceFacts,
@@ -97,6 +102,45 @@ const reconciliation: ExactReconciliationFacts = {
   contentHash: hash('reconciliation-content'),
   status: ReconciliationStatus.Exact,
   reconciledAt: new Date('2026-07-25T20:00:00.500Z'),
+}
+
+const researchProof = (): ResearchCapitalGrantProofBinding => {
+  const material: ResearchCapitalGrantGenerationMaterial = {
+    schemaVersion: 'bayn.paper-authority-generation.v3' as const,
+    maximum: Authority.Paper,
+    previousGenerationHash: observeGenerationHash,
+    grant: { _tag: 'Research' as const, planHash: hash('research-plan') },
+    activationSourceRevision: config.build.sourceRevision,
+    activationImageRepository: config.build.imageRepository,
+    activationImageDigest: config.build.imageDigest,
+    strategyName: 'risk-balanced-trend',
+    strategyBehaviorHash: config.build.strategyBehaviorHash,
+    strategyParameterHash: config.build.strategyParameterHash,
+    strategyParameterSchemaVersion: 'bayn.risk-balanced-trend.protocol.v4',
+    strategyProtocolHash: hash('strategy-protocol'),
+    accountId,
+    brokerIdentityHash: hash('broker-identity'),
+    riskPolicyHash: hash('risk-policy'),
+    proofPlanHash: hash('research-plan'),
+    reconciliationId: reconciliation.reconciliationId,
+    reconciliationContentHash: reconciliation.contentHash,
+  }
+  return {
+    schemaVersion: 'bayn.research-paper-grant-proof.v1',
+    grant: material.grant,
+    activationSourceRevision: material.activationSourceRevision,
+    activationImageRepository: material.activationImageRepository,
+    activationImageDigest: material.activationImageDigest,
+    strategyName: material.strategyName,
+    strategyBehaviorHash: material.strategyBehaviorHash,
+    strategyParameterHash: material.strategyParameterHash,
+    strategyParameterSchemaVersion: material.strategyParameterSchemaVersion,
+    strategyProtocolHash: material.strategyProtocolHash,
+    accountId: material.accountId,
+    brokerIdentityHash: material.brokerIdentityHash,
+    riskPolicyHash: material.riskPolicyHash,
+    proofPlanHash: material.proofPlanHash,
+  }
 }
 
 const qualificationSeries = (runId: string): QualificationSeries => {
@@ -596,5 +640,42 @@ describe('PAPER authority algebra', () => {
     })
     expect(paperActivationEffectiveAuthority(KillState.Clear)).toBe(Authority.Paper)
     expect(paperActivationEffectiveAuthority(KillState.Active)).toBe(Authority.Observe)
+  })
+
+  test('derives and replays a research PAPER generation without qualification evidence', () => {
+    const research = researchProof()
+    expect(
+      successOf(
+        validateResearchCapitalGrantProof({
+          proof: research,
+          configuredSourceGenerationHash: observeGenerationHash,
+          accountId,
+          brokerIdentityHash: research.brokerIdentityHash,
+          build: config.build,
+        }),
+      ),
+    ).toBeUndefined()
+    const derived = successOf(
+      deriveResearchCapitalGrantGeneration({ current: observeAuthority, proof: research, reconciliation }),
+    )
+    expect(derived.generation).toMatchObject({
+      schemaVersion: 'bayn.paper-authority-generation.v3',
+      previousGenerationHash: observeGenerationHash,
+      grant: research.grant,
+      accountId,
+    })
+    expect(derived.generation.generationHash).toMatch(/^[0-9a-f]{64}$/)
+    expect(
+      successOf(validateResearchPaperGenerationReplay(derived.generation, research, observeGenerationHash)),
+    ).toBeUndefined()
+    expect(
+      failureOf(
+        validateResearchPaperGenerationReplay(
+          derived.generation,
+          { ...research, riskPolicyHash: hash('changed-risk-policy') },
+          observeGenerationHash,
+        ),
+      ),
+    ).toMatchObject({ _tag: 'ResearchPaperGenerationReplayMismatch' })
   })
 })

--- a/services/bayn/src/db/capital-grant-algebra.ts
+++ b/services/bayn/src/db/capital-grant-algebra.ts
@@ -8,11 +8,16 @@ import {
   KillState,
   ReconciliationStatus,
   makeCapitalGrantGenerationResult,
+  makeResearchCapitalGrantGenerationResult,
   type AuthorityState,
   type CapitalGrantGeneration,
   type CapitalGrantGenerationConstructionFailure,
   type CapitalGrantGenerationMaterial,
   type CapitalGrantProofBinding,
+  type ResearchCapitalGrantGeneration,
+  type ResearchCapitalGrantGenerationConstructionFailure,
+  type ResearchCapitalGrantGenerationMaterial,
+  type ResearchCapitalGrantProofBinding,
 } from '../execution/contracts'
 import type { QualificationLock, QualificationResult } from '../qualification'
 
@@ -78,6 +83,12 @@ export interface MutationBaselineFacts {
 export interface DerivedPaperGeneration {
   readonly current: AuthorityState
   readonly generation: CapitalGrantGeneration
+  readonly reconciliation: ExactReconciliationFacts
+}
+
+export interface DerivedResearchPaperGeneration {
+  readonly current: AuthorityState
+  readonly generation: ResearchCapitalGrantGeneration
   readonly reconciliation: ExactReconciliationFacts
 }
 
@@ -252,6 +263,7 @@ export type CapitalGrantAlgebraFailure =
       readonly reconciledAt: Date
     }
   | { readonly _tag: 'PaperGenerationDerivationFailed'; readonly cause: unknown }
+  | { readonly _tag: 'ResearchPaperGenerationDerivationFailed'; readonly cause: unknown }
   | {
       readonly _tag: 'ReconciliationNotFresh'
       readonly reconciledAt: Date
@@ -273,6 +285,22 @@ export type CapitalGrantAlgebraFailure =
       readonly _tag: 'DerivedPaperGenerationMismatch'
       readonly derivedGenerationHash: string
       readonly configuredGenerationHash: string
+    }
+  | {
+      readonly _tag: 'ResearchPaperGenerationReplayMismatch'
+      readonly generationHash: string
+      readonly expectedPreviousGenerationHash: string
+    }
+  | {
+      readonly _tag: 'ResearchPaperGenerationRuntimeMismatch'
+      readonly field:
+        | 'accountId'
+        | 'activationBuild'
+        | 'brokerIdentityHash'
+        | 'generationHash'
+        | 'proofPlanHash'
+        | 'riskPolicyHash'
+        | 'strategy'
     }
 
 export interface CapitalGrantFailureDetails {
@@ -680,6 +708,107 @@ export const deriveCapitalGrantGeneration = (input: {
     Result.map((generation) => ({ current: input.current, generation, reconciliation: input.reconciliation })),
   )
 
+const researchRuntimeMismatch = (
+  field: Extract<CapitalGrantAlgebraFailure, { readonly _tag: 'ResearchPaperGenerationRuntimeMismatch' }>['field'],
+): Result.Result<never, CapitalGrantAlgebraFailure> =>
+  Result.fail({ _tag: 'ResearchPaperGenerationRuntimeMismatch', field })
+
+export const validateResearchCapitalGrantProof = (input: {
+  readonly proof: ResearchCapitalGrantProofBinding
+  readonly configuredSourceGenerationHash: string
+  readonly accountId: string
+  readonly brokerIdentityHash: string
+  readonly build: AuthorityBuildFacts
+}): Result.Result<void, CapitalGrantAlgebraFailure> => {
+  const { proof, build } = input
+  if (proof.accountId !== input.accountId) return researchRuntimeMismatch('accountId')
+  if (proof.brokerIdentityHash !== input.brokerIdentityHash) return researchRuntimeMismatch('brokerIdentityHash')
+  if (proof.proofPlanHash !== proof.grant.planHash) return researchRuntimeMismatch('proofPlanHash')
+  if (
+    proof.activationSourceRevision !== build.sourceRevision ||
+    proof.activationImageRepository !== build.imageRepository ||
+    proof.activationImageDigest !== build.imageDigest
+  ) {
+    return researchRuntimeMismatch('activationBuild')
+  }
+  if (
+    proof.strategyBehaviorHash !== build.strategyBehaviorHash ||
+    proof.strategyParameterHash !== build.strategyParameterHash
+  ) {
+    return researchRuntimeMismatch('strategy')
+  }
+  return /^[0-9a-f]{64}$/.test(input.configuredSourceGenerationHash)
+    ? Result.succeed(undefined)
+    : researchRuntimeMismatch('generationHash')
+}
+
+const researchCapitalGrantGenerationMaterial = (input: {
+  readonly current: AuthorityState
+  readonly proof: ResearchCapitalGrantProofBinding
+  readonly reconciliation: ExactReconciliationFacts
+}): ResearchCapitalGrantGenerationMaterial => ({
+  schemaVersion: 'bayn.paper-authority-generation.v3',
+  maximum: Authority.Paper,
+  previousGenerationHash: input.current.generationHash,
+  grant: input.proof.grant,
+  activationSourceRevision: input.proof.activationSourceRevision,
+  activationImageRepository: input.proof.activationImageRepository,
+  activationImageDigest: input.proof.activationImageDigest,
+  strategyName: input.proof.strategyName,
+  strategyBehaviorHash: input.proof.strategyBehaviorHash,
+  strategyParameterHash: input.proof.strategyParameterHash,
+  strategyParameterSchemaVersion: input.proof.strategyParameterSchemaVersion,
+  strategyProtocolHash: input.proof.strategyProtocolHash,
+  accountId: input.proof.accountId,
+  brokerIdentityHash: input.proof.brokerIdentityHash,
+  riskPolicyHash: input.proof.riskPolicyHash,
+  proofPlanHash: input.proof.proofPlanHash,
+  reconciliationId: input.reconciliation.reconciliationId,
+  reconciliationContentHash: input.reconciliation.contentHash,
+})
+
+export const deriveResearchCapitalGrantGeneration = (input: {
+  readonly current: AuthorityState
+  readonly proof: ResearchCapitalGrantProofBinding
+  readonly reconciliation: ExactReconciliationFacts
+}): Result.Result<DerivedResearchPaperGeneration, CapitalGrantAlgebraFailure> =>
+  pipe(
+    makeResearchCapitalGrantGenerationResult(researchCapitalGrantGenerationMaterial(input)),
+    Result.mapError(
+      (cause: ResearchCapitalGrantGenerationConstructionFailure): CapitalGrantAlgebraFailure => ({
+        _tag: 'ResearchPaperGenerationDerivationFailed',
+        cause,
+      }),
+    ),
+    Result.map((generation) => ({ current: input.current, generation, reconciliation: input.reconciliation })),
+  )
+
+export const validateResearchPaperGenerationReplay = (
+  stored: ResearchCapitalGrantGeneration,
+  proof: ResearchCapitalGrantProofBinding,
+  expectedPreviousGenerationHash: string,
+): Result.Result<void, CapitalGrantAlgebraFailure> =>
+  stored.previousGenerationHash === expectedPreviousGenerationHash &&
+  stored.grant.planHash === proof.grant.planHash &&
+  stored.activationSourceRevision === proof.activationSourceRevision &&
+  stored.activationImageRepository === proof.activationImageRepository &&
+  stored.activationImageDigest === proof.activationImageDigest &&
+  stored.strategyName === proof.strategyName &&
+  stored.strategyBehaviorHash === proof.strategyBehaviorHash &&
+  stored.strategyParameterHash === proof.strategyParameterHash &&
+  stored.strategyParameterSchemaVersion === proof.strategyParameterSchemaVersion &&
+  stored.strategyProtocolHash === proof.strategyProtocolHash &&
+  stored.accountId === proof.accountId &&
+  stored.brokerIdentityHash === proof.brokerIdentityHash &&
+  stored.riskPolicyHash === proof.riskPolicyHash &&
+  stored.proofPlanHash === proof.proofPlanHash
+    ? Result.succeed(undefined)
+    : fail({
+        _tag: 'ResearchPaperGenerationReplayMismatch',
+        generationHash: stored.generationHash,
+        expectedPreviousGenerationHash,
+      })
+
 export const validatePaperGenerationFreshness = (
   reconciliation: ExactReconciliationFacts,
   observedAt: Date,
@@ -697,7 +826,7 @@ export const validatePaperGenerationFreshness = (
 
 export const decidePaperActivation = (
   current: AuthorityState,
-  binding: PaperGenerationRuntimeBinding,
+  binding: Pick<PaperGenerationRuntimeBinding, 'configuredGenerationHash'>,
 ): Result.Result<PaperActivationDecision, CapitalGrantAlgebraFailure> => {
   if (current.maximum !== Authority.Paper) {
     return Result.map(
@@ -837,11 +966,24 @@ export const capitalGrantFailureDetails = (failure: CapitalGrantAlgebraFailure):
         message: 'derived PAPER generation is invalid',
         cause: failure.cause,
       }
+    case 'ResearchPaperGenerationDerivationFailed':
+      return {
+        failure: 'decode',
+        message: 'derived research PAPER generation is invalid',
+        cause: failure.cause,
+      }
     case 'DurablePaperGenerationMismatch':
       return { failure: 'conflict', message: 'durable PAPER generation differs from the configured generation' }
     case 'PaperGenerationReplayMismatch':
       return { failure: 'conflict', message: 'PAPER generation history differs from deterministic replay' }
     case 'DerivedPaperGenerationMismatch':
       return { failure: 'invariant', message: 'derived PAPER generation differs from the configured generation' }
+    case 'ResearchPaperGenerationReplayMismatch':
+      return { failure: 'conflict', message: 'research PAPER generation history differs from deterministic replay' }
+    case 'ResearchPaperGenerationRuntimeMismatch':
+      return {
+        failure: 'invariant',
+        message: `research PAPER generation ${failure.field} binding differs from the current runtime`,
+      }
   }
 }

--- a/services/bayn/src/db/cycle-store/integration.test.ts
+++ b/services/bayn/src/db/cycle-store/integration.test.ts
@@ -60,6 +60,7 @@ import {
   Authority,
   IntentState,
   KillState,
+  makeResearchCapitalGrantGenerationResult,
   ReconciliationStatus,
   RiskOutcome,
 } from '../../execution/contracts'
@@ -67,6 +68,7 @@ import { BrokerAccess, noCapitalAuthority } from '../../execution/authority'
 import { planPaperIntent } from '../../execution/intents'
 import { runOnce, type ReconciliationPassResult } from '../../reconciler'
 import { reconciledStateHash } from '../../reconciliation'
+import { readForwardPerformancePostgres } from '../../forward-performance/postgres'
 import { Reason, type Policy } from '../../risk'
 import {
   makeObserveShadowDecisionDocument,
@@ -1095,7 +1097,11 @@ const makeShadowDecision = (
   return result.success
 }
 
-const makePaperNoTradeDecision = (draft: CycleDraft, boundSnapshotId: string) => {
+const makePaperNoTradeDecision = (
+  draft: CycleDraft,
+  boundSnapshotId: string,
+  authorityGenerationHash = 'a'.repeat(64),
+) => {
   const observe = makeShadowDecision(draft, boundSnapshotId)
   const result = makePaperDecisionDocument({
     schemaVersion: 'bayn.paper-cycle-decision.v1',
@@ -1104,7 +1110,7 @@ const makePaperNoTradeDecision = (draft: CycleDraft, boundSnapshotId: string) =>
     bindings: {
       ...observe.bindings,
       qualificationRunId: draft.identity.qualificationRunId,
-      authorityGenerationHash: 'a'.repeat(64),
+      authorityGenerationHash,
     },
     targetPlan: observe.targetPlan,
     deltaRisk: [],
@@ -3113,6 +3119,118 @@ describePostgres('PostgreSQL autonomous cycle store', () => {
       bindings: { authorityGenerationHash: 'a'.repeat(64) },
       orderedIntentIds: [],
     })
+  })
+
+  test('projects a research PAPER generation into exact forward-performance strategy evidence', async () => {
+    const researchPlanHash = '7'.repeat(64)
+    const parentGenerationHash = '6'.repeat(64)
+    const accountId = 'paper-account-research-forward-performance'
+    const draft = makeDraft(accountId, { qualificationRunId: researchPlanHash })
+    const reconciliation = shadowReconciliation(draft)
+    const sourceRevision = '1'.repeat(40)
+    const imageRepository = 'registry.example.com/lab/bayn'
+    const imageDigest = `sha256:${'2'.repeat(64)}`
+    const strategyBehaviorHash = '3'.repeat(64)
+    const strategyParameterHash = '4'.repeat(64)
+    const riskPolicyHash = '2'.repeat(64)
+    const brokerIdentity = Result.getOrThrow(
+      makeBrokerIdentity({
+        schemaVersion: 'bayn.broker-identity.v2',
+        provider: BrokerProvider.Alpaca,
+        environment: BrokerEnvironment.Sandbox,
+        accountId,
+      }),
+    )
+    const generation = Result.getOrThrow(
+      makeResearchCapitalGrantGenerationResult({
+        schemaVersion: 'bayn.paper-authority-generation.v3',
+        maximum: Authority.Paper,
+        previousGenerationHash: parentGenerationHash,
+        grant: { _tag: 'Research', planHash: researchPlanHash },
+        activationSourceRevision: sourceRevision,
+        activationImageRepository: imageRepository,
+        activationImageDigest: imageDigest,
+        strategyName: draft.identity.strategyName,
+        strategyBehaviorHash,
+        strategyParameterHash,
+        strategyParameterSchemaVersion: 'bayn.risk-balanced-trend.protocol.v3',
+        strategyProtocolHash: draft.identity.strategyProtocolHash,
+        accountId,
+        brokerIdentityHash: brokerIdentity.identityHash,
+        riskPolicyHash,
+        proofPlanHash: researchPlanHash,
+        reconciliationId: reconciliation.reconciliationId,
+        reconciliationContentHash: reconciliation.contentHash,
+      }),
+    )
+    const document = makePaperNoTradeDecision(draft, snapshotA, generation.generationHash)
+
+    const evidence = await runtime.runPromise(
+      Effect.gen(function* () {
+        const store = yield* CycleStore
+        const sql = yield* PgClient.PgClient
+        yield* insertShadowReconciliation(draft)
+        yield* sql`
+          INSERT INTO authority_generations (
+            generation_hash, schema_version, previous_generation_hash, maximum,
+            authority_version, activated_at
+          ) VALUES (
+            ${parentGenerationHash}, 'bayn.authority-generation-history.v1', NULL,
+            'OBSERVE', 1, '2026-03-06T21:00:00.000Z'
+          )
+        `
+        yield* sql`
+          INSERT INTO authority_generations (
+            generation_hash, schema_version, activation_schema_version,
+            previous_generation_hash, maximum, authority_version,
+            activation_source_revision, activation_image_repository, activation_image_digest,
+            strategy_name, strategy_behavior_hash, strategy_parameter_hash,
+            strategy_parameter_schema_version, strategy_protocol_hash, account_id,
+            broker_identity_schema_version, broker_identity_hash, broker_provider, broker_environment,
+            risk_policy_hash, proof_plan_hash, reconciliation_id, reconciliation_content_hash,
+            research_plan_hash, activated_at
+          ) VALUES (
+            ${generation.generationHash}, 'bayn.authority-generation-history.v1', ${generation.schemaVersion},
+            ${generation.previousGenerationHash}, 'PAPER', 2,
+            ${generation.activationSourceRevision}, ${generation.activationImageRepository},
+            ${generation.activationImageDigest}, ${generation.strategyName}, ${generation.strategyBehaviorHash},
+            ${generation.strategyParameterHash}, ${generation.strategyParameterSchemaVersion},
+            ${generation.strategyProtocolHash}, ${generation.accountId}, ${brokerIdentity.schemaVersion},
+            ${brokerIdentity.identityHash}, ${brokerIdentity.provider}, ${brokerIdentity.environment},
+            ${generation.riskPolicyHash}, ${generation.proofPlanHash}, ${generation.reconciliationId},
+            ${generation.reconciliationContentHash}, ${generation.grant.planHash},
+            '2026-03-06T21:02:30.000Z'
+          )
+        `
+        yield* store.acquire(draft, '2026-03-06T21:03:00.000Z')
+        yield* store.bindSnapshot(draft.identity.cycleId, makeInputManifest(snapshotA), '2026-03-06T21:04:00.000Z')
+        yield* store.activate(draft.identity.cycleId, '2026-03-06T21:05:00.000Z')
+        yield* store.bindDecision(draft.identity.cycleId, document, decisionAt)
+        yield* store.finish(draft.identity.cycleId, CycleState.NoTrade, terminalAt)
+        return yield* readForwardPerformancePostgres(sql, accountId, generation.generationHash)
+      }),
+    )
+
+    expect(evidence.cycles).toEqual([
+      expect.objectContaining({
+        cycleId: draft.identity.cycleId,
+        qualificationRunId: researchPlanHash,
+        strategyProtocolHash: draft.identity.strategyProtocolHash,
+        state: CycleState.NoTrade,
+      }),
+    ])
+    expect(evidence.strategy).toEqual({
+      qualificationRunId: researchPlanHash,
+      strategyName: draft.identity.strategyName,
+      strategyProtocolHash: draft.identity.strategyProtocolHash,
+      strategyBehaviorHash,
+      strategyParameterHash,
+      strategyParameterSchemaVersion: generation.strategyParameterSchemaVersion,
+      sourceRevision,
+      imageRepository,
+      imageDigest,
+    })
+    expect(evidence.unclosedCycleCount).toBe(0)
   })
 
   test('terminalizes an expired untouched PAPER plan and releases oldest-unfinished selection', async () => {

--- a/services/bayn/src/db/evidence-store.integration.test.ts
+++ b/services/bayn/src/db/evidence-store.integration.test.ts
@@ -1195,6 +1195,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
       { migration_id: 25, name: 'forward_performance_receipts' },
       { migration_id: 26, name: 'paper_cycle_close_replans' },
       { migration_id: 27, name: 'distinct_close_replan_intents' },
+      { migration_id: 28, name: 'research_paper_grants' },
     ])
   })
 

--- a/services/bayn/src/db/execution-store/authority-shared.ts
+++ b/services/bayn/src/db/execution-store/authority-shared.ts
@@ -4,8 +4,10 @@ import { Effect, Schema } from 'effect'
 import {
   decodeAuthorityState,
   decodeCapitalGrantGeneration,
+  decodeResearchCapitalGrantGeneration,
   type AuthorityState,
   type CapitalGrantGeneration,
+  type ResearchCapitalGrantGeneration,
 } from '../../execution/contracts'
 import {
   requireUnusedAuthorityGeneration,
@@ -46,7 +48,7 @@ export const paperGenerationFromRow = (
   row: AuthorityGenerationRow,
 ): Effect.Effect<CapitalGrantGeneration, ExecutionStoreError | Schema.SchemaError> => {
   if (
-    row.activation_schema_version === null ||
+    row.activation_schema_version !== 'bayn.paper-authority-generation.v2' ||
     row.previous_generation_hash === null ||
     row.qualification_run_id === null ||
     row.qualification_lock_id === null ||
@@ -99,6 +101,53 @@ export const paperGenerationFromRow = (
   })
 }
 
+export const researchPaperGenerationFromRow = (
+  row: AuthorityGenerationRow,
+): Effect.Effect<ResearchCapitalGrantGeneration, ExecutionStoreError | Schema.SchemaError> => {
+  if (
+    row.activation_schema_version !== 'bayn.paper-authority-generation.v3' ||
+    row.previous_generation_hash === null ||
+    row.research_plan_hash === null ||
+    row.activation_source_revision === null ||
+    row.activation_image_repository === null ||
+    row.activation_image_digest === null ||
+    row.strategy_name === null ||
+    row.strategy_behavior_hash === null ||
+    row.strategy_parameter_hash === null ||
+    row.strategy_parameter_schema_version === null ||
+    row.strategy_protocol_hash === null ||
+    row.account_id === null ||
+    row.broker_identity_hash === null ||
+    row.risk_policy_hash === null ||
+    row.proof_plan_hash === null ||
+    row.reconciliation_id === null ||
+    row.reconciliation_content_hash === null
+  ) {
+    return failExecutionStore('authority', 'invariant', 'research PAPER authority generation history is incomplete')
+  }
+  return decodeResearchCapitalGrantGeneration({
+    schemaVersion: row.activation_schema_version,
+    generationHash: row.generation_hash,
+    maximum: row.maximum,
+    previousGenerationHash: row.previous_generation_hash,
+    grant: { _tag: 'Research', planHash: row.research_plan_hash },
+    activationSourceRevision: row.activation_source_revision,
+    activationImageRepository: row.activation_image_repository,
+    activationImageDigest: row.activation_image_digest,
+    strategyName: row.strategy_name,
+    strategyBehaviorHash: row.strategy_behavior_hash,
+    strategyParameterHash: row.strategy_parameter_hash,
+    strategyParameterSchemaVersion: row.strategy_parameter_schema_version,
+    strategyProtocolHash: row.strategy_protocol_hash,
+    accountId: row.account_id,
+    brokerIdentityHash: row.broker_identity_hash,
+    riskPolicyHash: row.risk_policy_hash,
+    proofPlanHash: row.proof_plan_hash,
+    reconciliationId: row.reconciliation_id,
+    reconciliationContentHash: row.reconciliation_content_hash,
+  })
+}
+
 const generationHistoryFacts = (
   history: AuthorityGenerationRow,
 ): AuthorityGenerationHistoryFacts & { readonly row: AuthorityGenerationRow } => ({
@@ -137,7 +186,7 @@ export const makeAuthorityPostgres = (sql: PgClient.PgClient) => {
         activation_source_revision, activation_image_repository, activation_image_digest,
         strategy_name, strategy_behavior_hash, strategy_parameter_hash,
         strategy_parameter_schema_version, account_id, risk_policy_hash, proof_plan_hash,
-        reconciliation_id, reconciliation_content_hash, activated_at
+        reconciliation_id, reconciliation_content_hash, research_plan_hash, strategy_protocol_hash, activated_at
       FROM authority_generations
       WHERE generation_hash = ${generationHash}
     `.pipe(Effect.flatMap(decodeAuthorityGenerationRows))

--- a/services/bayn/src/db/execution-store/capital-grant.ts
+++ b/services/bayn/src/db/execution-store/capital-grant.ts
@@ -1,19 +1,23 @@
 import { PgClient } from '@effect/sql-pg'
 import { Effect } from 'effect'
 
+import { BrokerEnvironment } from '../../broker/identity'
 import { WriterFence } from '../../execution/writer-fence'
 import { historicalSandboxAuthority } from '../../execution/legacy-authority'
 import {
   Authority,
   decodeCapitalGrantProofBinding,
+  decodeResearchCapitalGrantProofBinding,
   type AuthorityState,
   type CapitalGrantGeneration,
   type CapitalGrantProofBinding,
+  type ResearchCapitalGrantProofBinding,
 } from '../../execution/contracts'
 import {
   bindPaperGenerationRuntime,
   decidePaperActivation,
   deriveCapitalGrantGeneration,
+  deriveResearchCapitalGrantGeneration,
   paperActivationEffectiveAuthority,
   validateDerivedPaperGeneration,
   validateLatestExactReconciliation,
@@ -23,13 +27,21 @@ import {
   validatePaperGenerationReplay,
   validatePaperPrepareGeneration,
   validatePaperSourceAuthority,
+  validateResearchCapitalGrantProof,
+  validateResearchPaperGenerationReplay,
   type DerivedPaperGeneration,
+  type DerivedResearchPaperGeneration,
   type ExactReconciliationFacts,
   type PaperActivationDecision,
   type PaperGenerationEvidenceFacts,
   type PaperGenerationRuntimeBinding,
 } from '../capital-grant-algebra'
-import { authorityStateFromRow, paperGenerationFromRow, type AuthorityPostgres } from './authority-shared'
+import {
+  authorityStateFromRow,
+  paperGenerationFromRow,
+  researchPaperGenerationFromRow,
+  type AuthorityPostgres,
+} from './authority-shared'
 import type { ExecutionStoreError, ExecutionStoreRuntimeConfig } from './contract'
 import { failExecutionStore, liftAuthorityDecision, runExecutionOperation } from './errors'
 import {
@@ -48,6 +60,15 @@ export interface CapitalGrantInterpreter {
   readonly activateCapitalGrant: (
     proof: CapitalGrantProofBinding,
   ) => Effect.Effect<AuthorityState, ExecutionStoreError, WriterFence>
+  readonly activateResearchCapitalGrant: (
+    proof: ResearchCapitalGrantProofBinding,
+  ) => Effect.Effect<AuthorityState, ExecutionStoreError, WriterFence>
+}
+
+interface ResearchPaperRuntimeBinding {
+  readonly accountId: string
+  readonly brokerIdentityHash: string
+  readonly configuredSourceGenerationHash: string
 }
 
 export const makeCapitalGrantInterpreter = (
@@ -76,6 +97,28 @@ export const makeCapitalGrantInterpreter = (
         operation,
       ),
     )
+
+  const requireResearchPaperRuntime = (): Effect.Effect<ResearchPaperRuntimeBinding, ExecutionStoreError> => {
+    const identity = config.execution.brokerIdentity
+    const alpaca = config.alpaca
+    if (
+      identity === undefined ||
+      alpaca === undefined ||
+      identity.environment !== BrokerEnvironment.Sandbox ||
+      identity.accountId !== alpaca.expectedAccountId
+    ) {
+      return failExecutionStore(
+        'authority',
+        'invariant',
+        'research PAPER generation requires the exact configured sandbox broker identity and OBSERVE generation',
+      )
+    }
+    return Effect.succeed({
+      accountId: identity.accountId,
+      brokerIdentityHash: identity.identityHash,
+      configuredSourceGenerationHash: alpaca.authorityGenerationHash,
+    })
+  }
 
   const evidenceFacts = (row: ActivationEvidenceRow): PaperGenerationEvidenceFacts => ({
     lock: row.lock_payload,
@@ -194,7 +237,7 @@ export const makeCapitalGrantInterpreter = (
     reconciledAt: row.reconciled_at,
   })
 
-  const readLatestExactReconciliation = (binding: PaperGenerationRuntimeBinding) =>
+  const readLatestExactReconciliation = (binding: Pick<PaperGenerationRuntimeBinding, 'accountId'>) =>
     sql<Record<string, unknown>>`
       SELECT
         reconciliation_id, account_id, content_hash, status, reconciled_at
@@ -211,7 +254,10 @@ export const makeCapitalGrantInterpreter = (
       ),
     )
 
-  const verifyMutationCoverage = (binding: PaperGenerationRuntimeBinding, reconciliation: ExactReconciliationFacts) =>
+  const verifyMutationCoverage = (
+    binding: Pick<PaperGenerationRuntimeBinding, 'accountId'>,
+    reconciliation: ExactReconciliationFacts,
+  ) =>
     sql<Record<string, unknown>>`
       WITH latest AS (
         SELECT DISTINCT ON (event.mutation_id)
@@ -282,7 +328,7 @@ export const makeCapitalGrantInterpreter = (
       )
     })
 
-  const requireFreshPaperGeneration = (derived: DerivedPaperGeneration) =>
+  const requireFreshPaperGeneration = (derived: Pick<DerivedPaperGeneration, 'reconciliation'>) =>
     authority.nextAuthorityInstant.pipe(
       Effect.flatMap((observedAt) =>
         liftAuthorityDecision(
@@ -323,6 +369,36 @@ export const makeCapitalGrantInterpreter = (
       ),
       Effect.as(current),
     )
+
+  const activateAuthorityState = (
+    generationHash: string,
+    authorityVersion: number,
+    kill: AuthorityState['kill'],
+    activatedAt: Date,
+  ) => {
+    const effective = paperActivationEffectiveAuthority(kill)
+    return sql<Record<string, unknown>>`
+      UPDATE authority_state
+      SET
+        generation_hash = ${generationHash},
+        maximum = 'PAPER',
+        effective = ${effective},
+        version = ${authorityVersion},
+        updated_at = ${activatedAt}
+      WHERE singleton
+      RETURNING
+        schema_version, generation_hash, maximum, effective, kill_state, reason,
+        version::text AS version, updated_at
+    `.pipe(
+      Effect.flatMap(decodeAuthorityStateRows),
+      Effect.flatMap((rows) => {
+        const row = rows[0]
+        return row === undefined
+          ? failExecutionStore('authority', 'invariant', 'PAPER authority was not activated')
+          : authorityStateFromRow(row)
+      }),
+    )
+  }
 
   const writePaperGenerationActivation = (
     decision: Extract<PaperActivationDecision, { readonly _tag: 'ActivatePaperGeneration' }>,
@@ -376,25 +452,12 @@ export const makeCapitalGrantInterpreter = (
           ${input.reconciliationContentHash}, ${activatedAt}
         )
       `
-      const effective = paperActivationEffectiveAuthority(derived.current.kill)
-      const activatedRows = yield* sql<Record<string, unknown>>`
-        UPDATE authority_state
-        SET
-          generation_hash = ${input.generationHash},
-          maximum = 'PAPER',
-          effective = ${effective},
-          version = ${decision.authorityVersion},
-          updated_at = ${activatedAt}
-        WHERE singleton
-        RETURNING
-          schema_version, generation_hash, maximum, effective, kill_state, reason,
-          version::text AS version, updated_at
-      `.pipe(Effect.flatMap(decodeAuthorityStateRows))
-      const activatedRow = activatedRows[0]
-      if (activatedRow === undefined) {
-        return yield* failExecutionStore('authority', 'invariant', 'PAPER authority was not activated')
-      }
-      return yield* authorityStateFromRow(activatedRow)
+      return yield* activateAuthorityState(
+        input.generationHash,
+        decision.authorityVersion,
+        derived.current.kill,
+        activatedAt,
+      )
     })
 
   const activatePaperGenerationTransaction = (
@@ -426,5 +489,136 @@ export const makeCapitalGrantInterpreter = (
       }),
     )
 
-  return { prepareCapitalGrant, activateCapitalGrant }
+  const deriveResearchPaperGeneration = (
+    proof: ResearchCapitalGrantProofBinding,
+    binding: ResearchPaperRuntimeBinding,
+    current: AuthorityState,
+  ) =>
+    Effect.gen(function* () {
+      yield* liftAuthorityDecision(validatePaperSourceAuthority(current))
+      yield* liftAuthorityDecision(
+        validatePaperPrepareGeneration(current, {
+          accountId: binding.accountId,
+          configuredGenerationHash: binding.configuredSourceGenerationHash,
+          qualificationRunId: proof.grant.planHash,
+        }),
+      )
+      yield* liftAuthorityDecision(
+        validateResearchCapitalGrantProof({
+          proof,
+          configuredSourceGenerationHash: binding.configuredSourceGenerationHash,
+          accountId: binding.accountId,
+          brokerIdentityHash: binding.brokerIdentityHash,
+          build: config.build,
+        }),
+      )
+      const reconciliation = yield* readLatestExactReconciliation(binding)
+      yield* verifyMutationCoverage(binding, reconciliation)
+      return yield* liftAuthorityDecision(deriveResearchCapitalGrantGeneration({ current, proof, reconciliation }))
+    })
+
+  const replayResearchPaperGeneration = (
+    current: AuthorityState,
+    history: Parameters<typeof researchPaperGenerationFromRow>[0],
+    proof: ResearchCapitalGrantProofBinding,
+    binding: ResearchPaperRuntimeBinding,
+  ) =>
+    researchPaperGenerationFromRow(history).pipe(
+      Effect.flatMap((stored) =>
+        liftAuthorityDecision(
+          validateResearchPaperGenerationReplay(stored, proof, binding.configuredSourceGenerationHash),
+        ),
+      ),
+      Effect.as(current),
+    )
+
+  const writeResearchPaperGenerationActivation = (
+    decision: Extract<PaperActivationDecision, { readonly _tag: 'ActivatePaperGeneration' }>,
+    derived: DerivedResearchPaperGeneration,
+    activatedAt: Date,
+  ) =>
+    Effect.gen(function* () {
+      const input = derived.generation
+      const identity = config.execution.brokerIdentity
+      if (
+        identity === undefined ||
+        identity.environment !== BrokerEnvironment.Sandbox ||
+        identity.accountId !== input.accountId ||
+        identity.identityHash !== input.brokerIdentityHash
+      ) {
+        return yield* failExecutionStore(
+          'authority',
+          'invariant',
+          'research PAPER generation broker identity does not match the configured sandbox account',
+        )
+      }
+      yield* sql`
+        INSERT INTO authority_generations (
+          generation_hash, schema_version, activation_schema_version,
+          previous_generation_hash, maximum, authority_version,
+          activation_source_revision, activation_image_repository, activation_image_digest,
+          strategy_name, strategy_behavior_hash, strategy_parameter_hash,
+          strategy_parameter_schema_version, strategy_protocol_hash, account_id,
+          broker_identity_schema_version, broker_identity_hash, broker_provider, broker_environment,
+          risk_policy_hash, proof_plan_hash, reconciliation_id, reconciliation_content_hash,
+          research_plan_hash, activated_at
+        ) VALUES (
+          ${input.generationHash}, 'bayn.authority-generation-history.v1', ${input.schemaVersion},
+          ${input.previousGenerationHash}, 'PAPER', ${decision.authorityVersion},
+          ${input.activationSourceRevision}, ${input.activationImageRepository}, ${input.activationImageDigest},
+          ${input.strategyName}, ${input.strategyBehaviorHash}, ${input.strategyParameterHash},
+          ${input.strategyParameterSchemaVersion}, ${input.strategyProtocolHash}, ${input.accountId},
+          ${identity.schemaVersion}, ${identity.identityHash}, ${identity.provider}, ${identity.environment},
+          ${input.riskPolicyHash}, ${input.proofPlanHash}, ${input.reconciliationId},
+          ${input.reconciliationContentHash}, ${input.grant.planHash}, ${activatedAt}
+        )
+      `
+      return yield* activateAuthorityState(
+        input.generationHash,
+        decision.authorityVersion,
+        derived.current.kill,
+        activatedAt,
+      )
+    })
+
+  const activateResearchPaperGenerationTransaction = (
+    proof: ResearchCapitalGrantProofBinding,
+    binding: ResearchPaperRuntimeBinding,
+  ) =>
+    Effect.gen(function* () {
+      const locked = yield* authority.lockCapitalGrant(binding.accountId)
+      const decision = yield* liftAuthorityDecision(
+        decidePaperActivation(locked.current, { configuredGenerationHash: locked.current.generationHash }),
+      )
+      if (decision._tag === 'ReplayPaperGeneration') {
+        return yield* replayResearchPaperGeneration(decision.current, locked.history, proof, binding)
+      }
+      const derived = yield* deriveResearchPaperGeneration(proof, binding, decision.current)
+      const [existing] = yield* authority.readGeneration(derived.generation.generationHash)
+      yield* authority.requireUnusedGeneration(derived.generation.generationHash, existing)
+      const activatedAt = yield* requireFreshPaperGeneration(derived)
+      return yield* writeResearchPaperGenerationActivation(decision, derived, activatedAt)
+    })
+
+  const activateResearchCapitalGrant = (candidate: ResearchCapitalGrantProofBinding) =>
+    runExecutionOperation(
+      'authority',
+      Effect.gen(function* () {
+        const proof = yield* decodeResearchCapitalGrantProofBinding(candidate)
+        const binding = yield* requireResearchPaperRuntime()
+        yield* liftAuthorityDecision(
+          validateResearchCapitalGrantProof({
+            proof,
+            configuredSourceGenerationHash: binding.configuredSourceGenerationHash,
+            accountId: binding.accountId,
+            brokerIdentityHash: binding.brokerIdentityHash,
+            build: config.build,
+          }),
+        )
+        const fence = yield* WriterFence
+        return yield* fence.transaction(activateResearchPaperGenerationTransaction(proof, binding))
+      }),
+    )
+
+  return { prepareCapitalGrant, activateCapitalGrant, activateResearchCapitalGrant }
 }

--- a/services/bayn/src/db/execution-store/contract.ts
+++ b/services/bayn/src/db/execution-store/contract.ts
@@ -9,6 +9,8 @@ import type {
   AuthorityState,
   CapitalGrantGeneration,
   CapitalGrantProofBinding,
+  ResearchCapitalGrantGeneration,
+  ResearchCapitalGrantProofBinding,
   Valuation,
 } from '../../execution/contracts'
 import type { BrokerSnapshot, IntentBinding, ReconciliationWriteResult } from '../reconciliation'
@@ -85,6 +87,9 @@ export interface AuthorityGenerationStoreShape {
   readonly readAuthorityGeneration?: (
     generationHash: string,
   ) => Effect.Effect<CapitalGrantGeneration | undefined, ExecutionStoreError>
+  readonly readResearchAuthorityGeneration?: (
+    generationHash: string,
+  ) => Effect.Effect<ResearchCapitalGrantGeneration | undefined, ExecutionStoreError>
 }
 
 export interface CapitalGrantLifecycleStoreShape {
@@ -105,6 +110,14 @@ export interface CapitalGrantLifecycleStoreShape {
    */
   readonly activateCapitalGrant: (
     proof: CapitalGrantProofBinding,
+  ) => WriterFencedExecutionStoreOperation<AuthorityState>
+  /**
+   * Atomically derives a reconciliation-bound research generation, records it, and activates PAPER authority. The
+   * static request intentionally cannot predict this generation hash because reconciliation continues until the
+   * activation transaction acquires its fence.
+   */
+  readonly activateResearchCapitalGrant: (
+    proof: ResearchCapitalGrantProofBinding,
   ) => WriterFencedExecutionStoreOperation<AuthorityState>
 }
 

--- a/services/bayn/src/db/execution-store/observe-authority.ts
+++ b/services/bayn/src/db/execution-store/observe-authority.ts
@@ -7,7 +7,12 @@ import {
   decodePersistedBrokerIdentity,
   type BrokerIdentity,
 } from '../../broker/identity'
-import { Authority, type AuthorityState, type CapitalGrantGeneration } from '../../execution/contracts'
+import {
+  Authority,
+  type AuthorityState,
+  type CapitalGrantGeneration,
+  type ResearchCapitalGrantGeneration,
+} from '../../execution/contracts'
 import { incompletePassReason } from '../../simulation-reconciliation/broker-reconciler-model'
 import {
   decideObserveGeneration,
@@ -16,7 +21,12 @@ import {
   type ObserveGenerationDecision,
   type ObserveGenerationRequest,
 } from '../capital-grant-algebra'
-import { authorityStateFromRow, paperGenerationFromRow, type AuthorityPostgres } from './authority-shared'
+import {
+  authorityStateFromRow,
+  paperGenerationFromRow,
+  researchPaperGenerationFromRow,
+  type AuthorityPostgres,
+} from './authority-shared'
 import type { EnsureAuthorityGenerationInput, ExecutionStoreError } from './contract'
 import { failExecutionStore, liftAuthorityDecision, runExecutionOperation } from './errors'
 import {
@@ -111,6 +121,9 @@ export interface ObserveAuthorityInterpreter {
   readonly readAuthorityGeneration: (
     generationHash: string,
   ) => Effect.Effect<CapitalGrantGeneration | undefined, ExecutionStoreError>
+  readonly readResearchAuthorityGeneration: (
+    generationHash: string,
+  ) => Effect.Effect<ResearchCapitalGrantGeneration | undefined, ExecutionStoreError>
 }
 
 export const makeObserveAuthorityInterpreter = (
@@ -347,11 +360,35 @@ export const makeObserveAuthorityInterpreter = (
       authority.readGeneration(generationHash).pipe(
         Effect.flatMap((rows) => {
           const row = rows[0]
-          if (row === undefined || row.maximum !== Authority.Paper) return Effect.succeed(undefined)
+          if (
+            row === undefined ||
+            row.maximum !== Authority.Paper ||
+            row.activation_schema_version !== 'bayn.paper-authority-generation.v2'
+          ) {
+            return Effect.succeed(undefined)
+          }
           return paperGenerationFromRow(row).pipe(Effect.map((generation) => generation))
         }),
       ),
     )
 
-  return { ensureAuthorityGeneration, readAuthorityState, readAuthorityGeneration }
+  const readResearchAuthorityGeneration = (generationHash: string) =>
+    runExecutionOperation(
+      'authority',
+      authority.readGeneration(generationHash).pipe(
+        Effect.flatMap((rows) => {
+          const row = rows[0]
+          if (
+            row === undefined ||
+            row.maximum !== Authority.Paper ||
+            row.activation_schema_version !== 'bayn.paper-authority-generation.v3'
+          ) {
+            return Effect.succeed(undefined)
+          }
+          return researchPaperGenerationFromRow(row).pipe(Effect.map((generation) => generation))
+        }),
+      ),
+    )
+
+  return { ensureAuthorityGeneration, readAuthorityState, readAuthorityGeneration, readResearchAuthorityGeneration }
 }

--- a/services/bayn/src/db/execution-store/postgres.ts
+++ b/services/bayn/src/db/execution-store/postgres.ts
@@ -37,10 +37,12 @@ export const makeExecutionPersistence = (config: ExecutionStoreRuntimeConfig) =>
         ensureAuthorityGeneration: observeAuthority.ensureAuthorityGeneration,
         readAuthorityState: observeAuthority.readAuthorityState,
         readAuthorityGeneration: observeAuthority.readAuthorityGeneration,
+        readResearchAuthorityGeneration: observeAuthority.readResearchAuthorityGeneration,
       },
       capitalGrantLifecycle: {
         prepareCapitalGrant: capitalGrant.prepareCapitalGrant,
         activateCapitalGrant: capitalGrant.activateCapitalGrant,
+        activateResearchCapitalGrant: capitalGrant.activateResearchCapitalGrant,
       },
       authorityRestriction: {
         restrictAuthority: (reason, updatedAt) =>

--- a/services/bayn/src/db/execution-store/rows.ts
+++ b/services/bayn/src/db/execution-store/rows.ts
@@ -114,7 +114,9 @@ export const AuthorityStateRows = Schema.Array(AuthorityStateRow).check(Schema.i
 export const AuthorityStateObservationRows = Schema.Array(AuthorityStateObservationRow).check(Schema.isMaxLength(1))
 export const AuthorityGenerationRow = Schema.Struct({
   generation_hash: Sha256,
-  activation_schema_version: Schema.NullOr(Schema.Literal('bayn.paper-authority-generation.v2')),
+  activation_schema_version: Schema.NullOr(
+    Schema.Literals(['bayn.paper-authority-generation.v2', 'bayn.paper-authority-generation.v3']),
+  ),
   previous_generation_hash: Schema.NullOr(Sha256),
   maximum: Schema.Enum(Authority),
   authority_version: Schema.String,
@@ -144,6 +146,8 @@ export const AuthorityGenerationRow = Schema.Struct({
   proof_plan_hash: Schema.NullOr(Sha256),
   reconciliation_id: Schema.NullOr(Sha256),
   reconciliation_content_hash: Schema.NullOr(Sha256),
+  research_plan_hash: Schema.NullOr(Sha256),
+  strategy_protocol_hash: Schema.NullOr(Sha256),
   activated_at: Schema.Date,
 })
 export type AuthorityGenerationRow = typeof AuthorityGenerationRow.Type

--- a/services/bayn/src/db/migrations.ts
+++ b/services/bayn/src/db/migrations.ts
@@ -27,6 +27,7 @@ import paperCycleClosures from '../../migrations/0024_paper_cycle_closures'
 import forwardPerformanceReceipts from '../../migrations/0025_forward_performance_receipts'
 import paperCycleCloseReplans from '../../migrations/0026_paper_cycle_close_replans'
 import distinctCloseReplanIntents from '../../migrations/0027_distinct_close_replan_intents'
+import researchPaperGrants from '../../migrations/0028_research_paper_grants'
 
 export const migrationLoader = PgMigrator.fromRecord({
   '1_initial_schema': initialSchema,
@@ -56,4 +57,5 @@ export const migrationLoader = PgMigrator.fromRecord({
   '25_forward_performance_receipts': forwardPerformanceReceipts,
   '26_paper_cycle_close_replans': paperCycleCloseReplans,
   '27_distinct_close_replan_intents': distinctCloseReplanIntents,
+  '28_research_paper_grants': researchPaperGrants,
 })

--- a/services/bayn/src/db/paper-store.integration.test.ts
+++ b/services/bayn/src/db/paper-store.integration.test.ts
@@ -27,7 +27,9 @@ import {
   ReconciliationStatus,
   TimeInForce,
   makeCapitalGrantGenerationResult,
+  makeResearchCapitalGrantGenerationResult,
   type CapitalGrantGeneration,
+  type ResearchCapitalGrantGeneration,
 } from '../execution/contracts'
 import {
   defaultQualificationStatisticsPolicyDocument,
@@ -98,6 +100,8 @@ const successOfResult = <A, E>(result: Result.Result<A, E>): A => {
 }
 const makeCapitalGrantGeneration = (input: Parameters<typeof makeCapitalGrantGenerationResult>[0]) =>
   successOfResult(makeCapitalGrantGenerationResult(input))
+const makeResearchCapitalGrantGeneration = (input: Parameters<typeof makeResearchCapitalGrantGenerationResult>[0]) =>
+  successOfResult(makeResearchCapitalGrantGenerationResult(input))
 const observedAt = '2026-07-22T15:30:01.000Z'
 const occurredAt = '2026-07-22T15:30:00.000Z'
 const hash = (value: string): string => canonicalHashV1({ value })
@@ -718,6 +722,53 @@ const proofBinding = (activation: CapitalGrantGeneration) => ({
   proofPlanHash: activation.proofPlanHash,
 })
 
+const makeResearchActivation = (
+  previousGenerationHash: string,
+  reconciliation: Pick<ReconciliationFixture, 'contentHash' | 'reconciliationId'>,
+): ResearchCapitalGrantGeneration =>
+  makeResearchCapitalGrantGeneration({
+    schemaVersion: 'bayn.paper-authority-generation.v3',
+    maximum: Authority.Paper,
+    previousGenerationHash,
+    grant: { _tag: 'Research', planHash: hash('bounded-research-paper-plan') },
+    activationSourceRevision: config.build.sourceRevision,
+    activationImageRepository: config.build.imageRepository,
+    activationImageDigest: config.build.imageDigest,
+    strategyName: 'risk-balanced-trend',
+    strategyBehaviorHash: config.build.strategyBehaviorHash,
+    strategyParameterHash: config.build.strategyParameterHash,
+    strategyParameterSchemaVersion: fixtureProtocol.schemaVersion,
+    strategyProtocolHash: makeStrategyProtocolHash({
+      name: 'risk-balanced-trend',
+      behaviorHash: config.build.strategyBehaviorHash,
+      parameterHash: config.build.strategyParameterHash,
+      parameterSchemaVersion: fixtureProtocol.schemaVersion,
+    }),
+    accountId,
+    brokerIdentityHash: sandboxBrokerIdentity(accountId).identityHash,
+    riskPolicyHash: hash('bounded-research-risk-policy'),
+    proofPlanHash: hash('bounded-research-paper-plan'),
+    reconciliationId: reconciliation.reconciliationId,
+    reconciliationContentHash: reconciliation.contentHash,
+  })
+
+const researchProofBinding = (activation: ResearchCapitalGrantGeneration) => ({
+  schemaVersion: 'bayn.research-paper-grant-proof.v1' as const,
+  grant: activation.grant,
+  activationSourceRevision: activation.activationSourceRevision,
+  activationImageRepository: activation.activationImageRepository,
+  activationImageDigest: activation.activationImageDigest,
+  strategyName: activation.strategyName,
+  strategyBehaviorHash: activation.strategyBehaviorHash,
+  strategyParameterHash: activation.strategyParameterHash,
+  strategyParameterSchemaVersion: activation.strategyParameterSchemaVersion,
+  strategyProtocolHash: activation.strategyProtocolHash,
+  accountId: activation.accountId,
+  brokerIdentityHash: activation.brokerIdentityHash,
+  riskPolicyHash: activation.riskPolicyHash,
+  proofPlanHash: activation.proofPlanHash,
+})
+
 const paperRuntimeConfig = (
   activation: CapitalGrantGeneration,
   overrides: Partial<RuntimeConfig> = {},
@@ -767,6 +818,32 @@ const prepareRuntimeConfig = (activation: CapitalGrantGeneration): RuntimeConfig
     alpaca: {
       ...alpaca,
       authorityGenerationHash: activation.previousGenerationHash,
+    },
+  }
+}
+
+const researchRuntimeConfig = (sourceGenerationHash: string): RuntimeConfig => {
+  const identity = sandboxBrokerIdentity(accountId)
+  return {
+    ...config,
+    execution: {
+      brokerIdentity: identity,
+      brokerAccess: BrokerAccess.ReadOnly,
+      capitalAuthority: noCapitalAuthority,
+    },
+    alpaca: {
+      provider: BrokerProvider.Alpaca,
+      environment: BrokerEnvironment.Sandbox,
+      identity,
+      baseUrl: alpacaSandboxBaseUrl,
+      expectedAccountId: accountId,
+      authorityGenerationHash: sourceGenerationHash,
+      key: Redacted.make('unused'),
+      secret: Redacted.make('unused'),
+      proxyUrl: 'http://bayn-egress-proxy.invalid',
+      operationTimeoutMs: config.operationTimeoutMs,
+      retryAttempts: 0,
+      reconciliationIntervalMs: 30_000,
     },
   }
 }
@@ -1834,6 +1911,84 @@ describePostgres('paper accounting persistence', () => {
       })
     } finally {
       await activationRuntime.dispose()
+    }
+  }, 15_000)
+
+  test('atomically activates, reads, and exactly replays one reconciliation-bound research PAPER generation', async () => {
+    const initialGenerationHash = hash('research-paper-observe-generation')
+    const reconciliation = exactReconciliation('research-paper')
+    const expected = makeResearchActivation(initialGenerationHash, reconciliation)
+    const staticRequest = makeResearchActivation(initialGenerationHash, exactReconciliation('static-request'))
+    expect(staticRequest.generationHash).toBe(expected.generationHash)
+    expect(staticRequest.reconciliationId).not.toBe(expected.reconciliationId)
+    expect(staticRequest.reconciliationContentHash).not.toBe(expected.reconciliationContentHash)
+    const runtime = makeStoreRuntime({ fail: false, planHashes: [] }, researchRuntimeConfig(initialGenerationHash))
+    try {
+      const result = await runtime.runPromise(
+        Effect.gen(function* () {
+          const store = yield* ExecutionStore
+          const sql = yield* PgClient.PgClient
+          const activateResearch = store.activateResearchCapitalGrant
+          const readResearch = store.readResearchAuthorityGeneration
+          const readQualified = store.readAuthorityGeneration
+          assert(activateResearch !== undefined, 'research PAPER activation must be implemented')
+          assert(readResearch !== undefined, 'research PAPER history read must be implemented')
+          assert(readQualified !== undefined, 'qualified PAPER history read must be implemented')
+          yield* seedExactReconciliation(reconciliation)
+          yield* store.ensureAuthorityGeneration({
+            generationHash: initialGenerationHash,
+            maximum: Authority.Observe,
+          })
+          const activated = yield* activateResearch(researchProofBinding(staticRequest))
+          const beforeReplay = yield* readAuthorityTupleEvidence
+          const replay = yield* activateResearch(researchProofBinding(staticRequest))
+          const afterReplay = yield* readAuthorityTupleEvidence
+          const research = yield* readResearch(expected.generationHash)
+          const qualified = yield* readQualified(expected.generationHash)
+          const [history] = yield* sql<{
+            activation_schema_version: string
+            history_count: number
+            research_plan_hash: string
+            strategy_protocol_hash: string
+          }>`
+            SELECT
+              count(*)::integer AS history_count,
+              min(activation_schema_version) AS activation_schema_version,
+              min(research_plan_hash) AS research_plan_hash,
+              min(strategy_protocol_hash) AS strategy_protocol_hash
+            FROM authority_generations
+            WHERE generation_hash = ${expected.generationHash}
+          `
+          return {
+            activated,
+            afterReplay,
+            beforeReplay,
+            history,
+            qualified,
+            replay,
+            research,
+          }
+        }),
+      )
+
+      expect(result.activated).toMatchObject({
+        generationHash: expected.generationHash,
+        maximum: Authority.Paper,
+        effective: Authority.Paper,
+        version: 2,
+      })
+      expect(result.replay).toEqual(result.activated)
+      expect(result.afterReplay).toEqual(result.beforeReplay)
+      expect(result.research).toEqual(expected)
+      expect(result.qualified).toBeUndefined()
+      expect(result.history).toEqual({
+        activation_schema_version: 'bayn.paper-authority-generation.v3',
+        history_count: 1,
+        research_plan_hash: expected.grant.planHash,
+        strategy_protocol_hash: expected.strategyProtocolHash,
+      })
+    } finally {
+      await runtime.dispose()
     }
   }, 15_000)
 

--- a/services/bayn/src/execution-prepare/execution-prepare.test.ts
+++ b/services/bayn/src/execution-prepare/execution-prepare.test.ts
@@ -713,6 +713,10 @@ const writerFence: WriterFenceService = {
   transaction: (effect) => effect,
 }
 
+const unusedResearchCapitalGrantLifecycle = {
+  activateResearchCapitalGrant: () => Effect.die(new Error('research activation must remain unreachable')),
+} satisfies Pick<CapitalGrantLifecycleStoreShape, 'activateResearchCapitalGrant'>
+
 const runProgram = (
   lifecycle: CapitalGrantLifecycleStoreShape,
   candidateRequest: ExecutionPrepareRequest = request,
@@ -728,6 +732,7 @@ describe('EXECUTION_PREPARE program boundary', () => {
     let prepareCalls = 0
     let activateCalls = 0
     const lifecycle: CapitalGrantLifecycleStoreShape = {
+      ...unusedResearchCapitalGrantLifecycle,
       prepareCapitalGrant: () =>
         Effect.sync(() => {
           prepareCalls += 1
@@ -749,6 +754,7 @@ describe('EXECUTION_PREPARE program boundary', () => {
   test('carries the store-derived v2 generation through the PREPARE output and runtime binding', async () => {
     const preparedGeneration = generation()
     const lifecycle: CapitalGrantLifecycleStoreShape = {
+      ...unusedResearchCapitalGrantLifecycle,
       prepareCapitalGrant: () => Effect.succeed(preparedGeneration),
       activateCapitalGrant: () => Effect.die(new Error('activation must remain unreachable')),
     }
@@ -786,6 +792,7 @@ describe('EXECUTION_PREPARE program boundary', () => {
       observedPlanIntentId: hash('fabricated-program-intent'),
     })
     const lifecycle: CapitalGrantLifecycleStoreShape = {
+      ...unusedResearchCapitalGrantLifecycle,
       prepareCapitalGrant: () =>
         Effect.sync(() => {
           prepareCalls += 1
@@ -812,6 +819,7 @@ describe('EXECUTION_PREPARE program boundary', () => {
       cause: new Error('underlying schema failure'),
     })
     const lifecycle: CapitalGrantLifecycleStoreShape = {
+      ...unusedResearchCapitalGrantLifecycle,
       prepareCapitalGrant: () => Effect.fail(lifecycleFailure),
       activateCapitalGrant: () => Effect.die(new Error('activation must remain unreachable')),
     }

--- a/services/bayn/src/execution/configuration.test.ts
+++ b/services/bayn/src/execution/configuration.test.ts
@@ -4,10 +4,15 @@ import { Result } from 'effect'
 
 import { BrokerEnvironment, BrokerProvider, makeBrokerIdentity } from '../broker/identity'
 import { BrokerAccess, CapitalAuthorityKind } from './authority'
+import { Authority, makeResearchCapitalGrantGenerationResult } from './contracts'
 import {
   CapitalAuthoritySelection,
   decodePaperActivationRequestResult,
   makePaperActivationRequest,
+  makeResearchPaperActivationRequest,
+  makeResearchPaperPlanHash,
+  researchCapitalGrantProof,
+  researchPaperGenerationIsBoundToRequest,
   resolveExecutionPolicy,
 } from './configuration'
 
@@ -170,5 +175,90 @@ describe('execution policy configuration', () => {
       _tag: 'Failure',
     })
     expect(decodePaperActivationRequestResult({ ...request, unexpected: true })).toMatchObject({ _tag: 'Failure' })
+  })
+
+  test('decodes a canonical research grant without qualification aliases', () => {
+    const sourceGenerationHash = '0'.repeat(64)
+    const plan = {
+      schemaVersion: 'bayn.paper-research-plan.v1' as const,
+      activation: {
+        sourceRevision: 'a'.repeat(40),
+        imageRepository: 'ghcr.io/proompteng/bayn',
+        imageDigest: `sha256:${'3'.repeat(64)}`,
+      },
+      strategy: {
+        name: 'risk-balanced-trend',
+        behaviorHash: '4'.repeat(64),
+        parameterHash: '5'.repeat(64),
+        parameterSchemaVersion: 'bayn.risk-balanced-trend.protocol.v4',
+        protocolHash: '6'.repeat(64),
+      },
+      broker: {
+        environment: BrokerEnvironment.Sandbox,
+        accountId,
+        identityHash: '7'.repeat(64),
+      },
+      riskPolicyHash: '8'.repeat(64),
+      limits: { maxOpenOrders: 0 as const, maxPositions: 0 as const },
+      cutoffAt: '2026-09-01T13:00:00.000Z',
+      expiresAt: '2026-09-03T20:00:00.000Z',
+      maximumCloseSessions: 3 as const,
+    } as const
+    const planHash = Result.getOrThrow(makeResearchPaperPlanHash(plan))
+    const { schemaVersion: _planSchemaVersion, ...planFields } = plan
+    const generation = Result.getOrThrow(
+      makeResearchCapitalGrantGenerationResult({
+        schemaVersion: 'bayn.paper-authority-generation.v3',
+        maximum: Authority.Paper,
+        previousGenerationHash: sourceGenerationHash,
+        grant: { _tag: 'Research', planHash },
+        activationSourceRevision: 'a'.repeat(40),
+        activationImageRepository: 'ghcr.io/proompteng/bayn',
+        activationImageDigest: `sha256:${'3'.repeat(64)}`,
+        strategyName: 'risk-balanced-trend',
+        strategyBehaviorHash: '4'.repeat(64),
+        strategyParameterHash: '5'.repeat(64),
+        strategyParameterSchemaVersion: 'bayn.risk-balanced-trend.protocol.v4',
+        strategyProtocolHash: '6'.repeat(64),
+        accountId,
+        brokerIdentityHash: '7'.repeat(64),
+        riskPolicyHash: '8'.repeat(64),
+        proofPlanHash: planHash,
+        reconciliationId: '9'.repeat(64),
+        reconciliationContentHash: 'a'.repeat(64),
+      }),
+    )
+    const request = Result.getOrThrow(
+      makeResearchPaperActivationRequest({
+        schemaVersion: 'bayn.paper-research-activation-request.v1',
+        grant: { _tag: 'Research', planHash },
+        ...planFields,
+      }),
+    )
+    expect(decodePaperActivationRequestResult(request)).toMatchObject({ _tag: 'Success', success: request })
+    expect(decodePaperActivationRequestResult({ ...request, grant: { _tag: 'Qualified' } })).toMatchObject({
+      _tag: 'Failure',
+    })
+    expect(decodePaperActivationRequestResult({ ...request, maximumCloseSessions: 4 })).toMatchObject({
+      _tag: 'Failure',
+    })
+    expect(
+      makeResearchPaperActivationRequest({
+        schemaVersion: 'bayn.paper-research-activation-request.v1',
+        grant: { _tag: 'Research', planHash },
+        ...planFields,
+        cutoffAt: '2026-09-02T13:00:00.000Z',
+      }),
+    ).toEqual(Result.fail('ResearchPaperPlanHashMismatch'))
+    expect(researchCapitalGrantProof(request)).toMatchObject({
+      grant: request.grant,
+      proofPlanHash: request.grant.planHash,
+    })
+    expect(researchPaperGenerationIsBoundToRequest(request, sourceGenerationHash, generation)).toEqual(
+      Result.succeed(undefined),
+    )
+    expect(researchPaperGenerationIsBoundToRequest(request, 'f'.repeat(64), generation)).toMatchObject({
+      _tag: 'Failure',
+    })
   })
 })

--- a/services/bayn/src/execution/configuration.ts
+++ b/services/bayn/src/execution/configuration.ts
@@ -3,6 +3,8 @@ import { pipe, Result, Schema } from 'effect'
 import type { BrokerIdentity } from '../broker/identity'
 import { BrokerEnvironment } from '../broker/identity'
 import { canonicalHashV1Result } from '../hash'
+import { ResearchPaperGrantSchema } from '../paper-episode'
+import { Authority, type ResearchCapitalGrantGeneration, type ResearchCapitalGrantProofBinding } from './contracts'
 import {
   GitSourceRevisionSchema,
   ImageDigestSchema,
@@ -36,6 +38,8 @@ export interface LiveCapitalGrantRequest {
 }
 
 export const paperActivationRequestSchemaVersion = 'bayn.paper-activation-request.v1' as const
+export const researchPaperActivationRequestSchemaVersion = 'bayn.paper-research-activation-request.v1' as const
+export const researchPaperPlanSchemaVersion = 'bayn.paper-research-plan.v1' as const
 
 const PaperActivationStrategySchema = Schema.Struct({
   name: StrictNonEmptyStringSchema,
@@ -71,7 +75,7 @@ const PaperActivationRequestMaterialSchema = Schema.Struct({
   expiresAt: UtcInstantSchema,
 })
 
-export const PaperActivationRequestSchema = Schema.Struct({
+export const QualifiedPaperActivationRequestSchema = Schema.Struct({
   ...PaperActivationRequestMaterialSchema.fields,
   requestHash: Sha256Schema,
 }).check(
@@ -82,11 +86,144 @@ export const PaperActivationRequestSchema = Schema.Struct({
   }),
 )
 
+export type QualifiedPaperActivationRequest = typeof QualifiedPaperActivationRequestSchema.Type
+
+const ResearchPaperPlanFields = {
+  activation: PaperActivationRevisionBindingSchema,
+  strategy: PaperActivationStrategySchema,
+  broker: Schema.Struct({
+    environment: Schema.Literal(BrokerEnvironment.Sandbox),
+    accountId: StrictNonEmptyStringSchema,
+    identityHash: Sha256Schema,
+  }),
+  riskPolicyHash: Sha256Schema,
+  limits: Schema.Struct({
+    maxOpenOrders: Schema.Literal(0),
+    maxPositions: Schema.Literal(0),
+  }),
+  cutoffAt: UtcInstantSchema,
+  expiresAt: UtcInstantSchema,
+  maximumCloseSessions: Schema.Literal(3),
+} as const
+
+const ResearchPaperPlanMaterialSchema = Schema.Struct({
+  schemaVersion: Schema.Literal(researchPaperPlanSchemaVersion),
+  ...ResearchPaperPlanFields,
+})
+export type ResearchPaperPlanMaterial = typeof ResearchPaperPlanMaterialSchema.Type
+
+export const makeResearchPaperPlanHash = (
+  material: ResearchPaperPlanMaterial,
+): Result.Result<string, 'ResearchPaperPlanCanonicalizationFailed'> =>
+  pipe(
+    canonicalHashV1Result(material),
+    Result.mapError(() => 'ResearchPaperPlanCanonicalizationFailed' as const),
+  )
+
+const ResearchPaperActivationRequestMaterialSchema = Schema.Struct({
+  schemaVersion: Schema.Literal(researchPaperActivationRequestSchemaVersion),
+  grant: ResearchPaperGrantSchema,
+  ...ResearchPaperPlanFields,
+})
+
+const researchPlanMaterial = (
+  request: typeof ResearchPaperActivationRequestMaterialSchema.Type,
+): ResearchPaperPlanMaterial => ({
+  schemaVersion: researchPaperPlanSchemaVersion,
+  activation: request.activation,
+  strategy: request.strategy,
+  broker: request.broker,
+  riskPolicyHash: request.riskPolicyHash,
+  limits: request.limits,
+  cutoffAt: request.cutoffAt,
+  expiresAt: request.expiresAt,
+  maximumCloseSessions: request.maximumCloseSessions,
+})
+
+export const ResearchPaperActivationRequestSchema = Schema.Struct({
+  ...ResearchPaperActivationRequestMaterialSchema.fields,
+  requestHash: Sha256Schema,
+}).check(
+  Schema.makeFilter(
+    (request: typeof ResearchPaperActivationRequestMaterialSchema.Type & { readonly requestHash: string }) => {
+      if (request.expiresAt <= request.cutoffAt) return false
+      const planHash = makeResearchPaperPlanHash(researchPlanMaterial(request))
+      if (Result.isFailure(planHash) || request.grant.planHash !== planHash.success) return false
+      const expected = canonicalHashV1Result(requestWithoutHash(request))
+      return Result.isSuccess(expected) && request.requestHash === expected.success
+    },
+  ),
+)
+export type ResearchPaperActivationRequest = typeof ResearchPaperActivationRequestSchema.Type
+
+export const isResearchPaperActivationRequest = (
+  request: PaperActivationRequest,
+): request is ResearchPaperActivationRequest => request.schemaVersion === researchPaperActivationRequestSchemaVersion
+
+export const researchCapitalGrantProof = (
+  request: ResearchPaperActivationRequest,
+): ResearchCapitalGrantProofBinding => ({
+  schemaVersion: 'bayn.research-paper-grant-proof.v1',
+  grant: request.grant,
+  activationSourceRevision: request.activation.sourceRevision,
+  activationImageRepository: request.activation.imageRepository,
+  activationImageDigest: request.activation.imageDigest,
+  strategyName: request.strategy.name,
+  strategyBehaviorHash: request.strategy.behaviorHash,
+  strategyParameterHash: request.strategy.parameterHash,
+  strategyParameterSchemaVersion: request.strategy.parameterSchemaVersion,
+  strategyProtocolHash: request.strategy.protocolHash,
+  accountId: request.broker.accountId,
+  brokerIdentityHash: request.broker.identityHash,
+  riskPolicyHash: request.riskPolicyHash,
+  proofPlanHash: request.grant.planHash,
+})
+
+export const researchPaperGenerationIsBoundToRequest = (
+  request: ResearchPaperActivationRequest,
+  sourceGenerationHash: string,
+  generation: ResearchCapitalGrantGeneration,
+): Result.Result<void, string> => {
+  if (
+    generation.maximum !== Authority.Paper ||
+    generation.previousGenerationHash !== sourceGenerationHash ||
+    generation.grant.planHash !== request.grant.planHash
+  ) {
+    return Result.fail('research PAPER generation identity is not bound to the activation request')
+  }
+  if (
+    generation.activationSourceRevision !== request.activation.sourceRevision ||
+    generation.activationImageRepository !== request.activation.imageRepository ||
+    generation.activationImageDigest !== request.activation.imageDigest ||
+    generation.strategyName !== request.strategy.name ||
+    generation.strategyBehaviorHash !== request.strategy.behaviorHash ||
+    generation.strategyParameterHash !== request.strategy.parameterHash ||
+    generation.strategyParameterSchemaVersion !== request.strategy.parameterSchemaVersion ||
+    generation.strategyProtocolHash !== request.strategy.protocolHash
+  ) {
+    return Result.fail('research PAPER generation is not bound to the requested current strategy and build')
+  }
+  if (
+    generation.accountId !== request.broker.accountId ||
+    generation.brokerIdentityHash !== request.broker.identityHash ||
+    generation.riskPolicyHash !== request.riskPolicyHash ||
+    generation.proofPlanHash !== request.grant.planHash
+  ) {
+    return Result.fail('research PAPER generation is not bound to the requested broker and risk controls')
+  }
+  return Result.succeed(undefined)
+}
+
+export const PaperActivationRequestSchema = Schema.Union([
+  QualifiedPaperActivationRequestSchema,
+  ResearchPaperActivationRequestSchema,
+])
 export type PaperActivationRequest = typeof PaperActivationRequestSchema.Type
 
 const requestWithoutHash = (
   request:
-    | PaperActivationRequest
+    | QualifiedPaperActivationRequest
+    | ResearchPaperActivationRequest
     | (typeof PaperActivationRequestMaterialSchema.Type & { readonly requestHash: string }),
 ) => {
   const { requestHash: _requestHash, ...material } = request
@@ -95,12 +232,29 @@ const requestWithoutHash = (
 
 export const makePaperActivationRequest = (
   material: typeof PaperActivationRequestMaterialSchema.Type,
-): Result.Result<PaperActivationRequest, 'PaperActivationRequestCanonicalizationFailed'> =>
+): Result.Result<QualifiedPaperActivationRequest, 'PaperActivationRequestCanonicalizationFailed'> =>
   pipe(
     canonicalHashV1Result(material),
     Result.mapError(() => 'PaperActivationRequestCanonicalizationFailed' as const),
-    Result.flatMap((requestHash) => Result.succeed({ ...material, requestHash } as PaperActivationRequest)),
+    Result.flatMap((requestHash) => Result.succeed({ ...material, requestHash } as QualifiedPaperActivationRequest)),
   )
+
+export const makeResearchPaperActivationRequest = (
+  material: typeof ResearchPaperActivationRequestMaterialSchema.Type,
+): Result.Result<
+  ResearchPaperActivationRequest,
+  'PaperActivationRequestCanonicalizationFailed' | 'ResearchPaperCloseWindowInvalid' | 'ResearchPaperPlanHashMismatch'
+> => {
+  if (material.expiresAt <= material.cutoffAt) return Result.fail('ResearchPaperCloseWindowInvalid')
+  const planHash = makeResearchPaperPlanHash(researchPlanMaterial(material))
+  if (Result.isFailure(planHash)) return Result.fail('PaperActivationRequestCanonicalizationFailed')
+  if (material.grant.planHash !== planHash.success) return Result.fail('ResearchPaperPlanHashMismatch')
+  return pipe(
+    canonicalHashV1Result(material),
+    Result.mapError(() => 'PaperActivationRequestCanonicalizationFailed' as const),
+    Result.map((requestHash) => ({ ...material, requestHash }) as ResearchPaperActivationRequest),
+  )
+}
 
 export const decodePaperActivationRequestResult = Schema.decodeUnknownResult(
   PaperActivationRequestSchema,

--- a/services/bayn/src/execution/contracts.ts
+++ b/services/bayn/src/execution/contracts.ts
@@ -1,6 +1,7 @@
 import { pipe, Result, Schema } from 'effect'
 
 import { canonicalHashV1Result, type CanonicalHashFailure } from '../hash'
+import { ResearchPaperGrantSchema } from '../paper-episode'
 import {
   ImageDigestSchema as ImageDigest,
   Sha256Schema as Sha256,
@@ -602,6 +603,24 @@ export const CapitalGrantProofBindingSchema = Schema.Struct({
 })
 export type CapitalGrantProofBinding = typeof CapitalGrantProofBindingSchema.Type
 
+export const ResearchCapitalGrantProofBindingSchema = Schema.Struct({
+  schemaVersion: Schema.Literal('bayn.research-paper-grant-proof.v1'),
+  grant: ResearchPaperGrantSchema,
+  activationSourceRevision: SourceRevision,
+  activationImageRepository: NonEmptyString,
+  activationImageDigest: ImageDigest,
+  strategyName: NonEmptyString,
+  strategyBehaviorHash: Sha256,
+  strategyParameterHash: Sha256,
+  strategyParameterSchemaVersion: NonEmptyString,
+  strategyProtocolHash: Sha256,
+  accountId: NonEmptyString,
+  brokerIdentityHash: Sha256,
+  riskPolicyHash: Sha256,
+  proofPlanHash: Sha256,
+})
+export type ResearchCapitalGrantProofBinding = typeof ResearchCapitalGrantProofBindingSchema.Type
+
 const CapitalGrantGenerationIdentityMaterialSchema = Schema.Struct({
   schemaVersion: Schema.Literal('bayn.paper-authority-generation.v2'),
   maximum: Schema.Literal(Authority.Paper),
@@ -713,6 +732,115 @@ export const makeCapitalGrantGenerationResult = (
     ),
   )
 
+const ResearchCapitalGrantGenerationIdentityMaterialSchema = Schema.Struct({
+  schemaVersion: Schema.Literal('bayn.paper-authority-generation.v3'),
+  maximum: Schema.Literal(Authority.Paper),
+  previousGenerationHash: Sha256,
+  grant: ResearchPaperGrantSchema,
+  activationSourceRevision: SourceRevision,
+  activationImageRepository: NonEmptyString,
+  activationImageDigest: ImageDigest,
+  strategyName: NonEmptyString,
+  strategyBehaviorHash: Sha256,
+  strategyParameterHash: Sha256,
+  strategyParameterSchemaVersion: NonEmptyString,
+  strategyProtocolHash: Sha256,
+  accountId: NonEmptyString,
+  brokerIdentityHash: Sha256,
+  riskPolicyHash: Sha256,
+  proofPlanHash: Sha256,
+})
+
+export const ResearchCapitalGrantGenerationMaterialSchema = Schema.Struct({
+  ...ResearchCapitalGrantGenerationIdentityMaterialSchema.fields,
+  reconciliationId: Sha256,
+  reconciliationContentHash: Sha256,
+})
+export type ResearchCapitalGrantGenerationMaterial = typeof ResearchCapitalGrantGenerationMaterialSchema.Type
+
+const researchCapitalGrantGenerationIdentity = (material: ResearchCapitalGrantGenerationMaterial) => {
+  const {
+    reconciliationContentHash: _reconciliationContentHash,
+    reconciliationId: _reconciliationId,
+    ...identity
+  } = material
+  return identity
+}
+
+const ResearchCapitalGrantGenerationBase = Schema.Struct({
+  ...ResearchCapitalGrantGenerationMaterialSchema.fields,
+  generationHash: Sha256,
+})
+
+export const ResearchCapitalGrantGenerationSchema = ResearchCapitalGrantGenerationBase.check(
+  Schema.makeFilter(
+    (generation: typeof ResearchCapitalGrantGenerationBase.Type) => {
+      const { generationHash, ...material } = generation
+      const expectedHash = canonicalHashV1Result(researchCapitalGrantGenerationIdentity(material))
+      return Result.isSuccess(expectedHash) && generationHash === expectedHash.success
+    },
+    { expected: 'a generation hash matching the stable research PAPER authority identity' },
+  ),
+)
+export type ResearchCapitalGrantGeneration = typeof ResearchCapitalGrantGenerationSchema.Type
+
+export type ResearchCapitalGrantGenerationConstructionFailure =
+  | {
+      readonly _tag: 'ResearchCapitalGrantGenerationSchemaInvalid'
+      readonly operation: 'material' | 'generation'
+      readonly cause: Schema.SchemaError
+    }
+  | {
+      readonly _tag: 'ResearchCapitalGrantGenerationCanonicalizationFailed'
+      readonly cause: CanonicalHashFailure
+    }
+
+const decodeResearchCapitalGrantGenerationMaterialResult = Schema.decodeUnknownResult(
+  ResearchCapitalGrantGenerationMaterialSchema,
+  StrictParseOptions,
+)
+const decodeResearchCapitalGrantGenerationResult = Schema.decodeUnknownResult(
+  ResearchCapitalGrantGenerationSchema,
+  StrictParseOptions,
+)
+
+export const makeResearchCapitalGrantGenerationResult = (
+  input: ResearchCapitalGrantGenerationMaterial,
+): Result.Result<ResearchCapitalGrantGeneration, ResearchCapitalGrantGenerationConstructionFailure> =>
+  pipe(
+    decodeResearchCapitalGrantGenerationMaterialResult(input),
+    Result.mapError(
+      (cause): ResearchCapitalGrantGenerationConstructionFailure => ({
+        _tag: 'ResearchCapitalGrantGenerationSchemaInvalid',
+        operation: 'material',
+        cause,
+      }),
+    ),
+    Result.flatMap((material) =>
+      pipe(
+        canonicalHashV1Result(researchCapitalGrantGenerationIdentity(material)),
+        Result.mapError(
+          (cause): ResearchCapitalGrantGenerationConstructionFailure => ({
+            _tag: 'ResearchCapitalGrantGenerationCanonicalizationFailed',
+            cause,
+          }),
+        ),
+        Result.flatMap((generationHash) =>
+          pipe(
+            decodeResearchCapitalGrantGenerationResult({ ...material, generationHash }),
+            Result.mapError(
+              (cause): ResearchCapitalGrantGenerationConstructionFailure => ({
+                _tag: 'ResearchCapitalGrantGenerationSchemaInvalid',
+                operation: 'generation',
+                cause,
+              }),
+            ),
+          ),
+        ),
+      ),
+    ),
+  )
+
 const AuthorityStateBase = Schema.Struct({
   schemaVersion: Schema.Literal('bayn.paper-authority.v1'),
   generationHash: Sha256,
@@ -762,5 +890,13 @@ export const decodeCapitalGrantProofBinding = Schema.decodeUnknownEffect(
   CapitalGrantProofBindingSchema,
   StrictParseOptions,
 )
+export const decodeResearchCapitalGrantProofBinding = Schema.decodeUnknownEffect(
+  ResearchCapitalGrantProofBindingSchema,
+  StrictParseOptions,
+)
 export const decodeCapitalGrantGeneration = Schema.decodeUnknownEffect(CapitalGrantGenerationSchema, StrictParseOptions)
+export const decodeResearchCapitalGrantGeneration = Schema.decodeUnknownEffect(
+  ResearchCapitalGrantGenerationSchema,
+  StrictParseOptions,
+)
 export const decodeAuthorityState = Schema.decodeUnknownEffect(AuthorityStateSchema, StrictParseOptions)

--- a/services/bayn/src/forward-performance/postgres.ts
+++ b/services/bayn/src/forward-performance/postgres.ts
@@ -284,7 +284,8 @@ const generationScope = (
         WHERE scope_generation.generation_hash = ${authorityGenerationHash}
           AND scope_generation.maximum = 'PAPER'
           AND scope_generation.account_id = ${accountId}
-          AND scope_generation.qualification_run_id = cycle.qualification_run_id
+          AND COALESCE(scope_generation.qualification_run_id, scope_generation.research_plan_hash)
+            = cycle.qualification_run_id
           AND cycle.account_id = scope_generation.account_id
           AND (
             EXISTS (
@@ -326,7 +327,8 @@ const generationScope = (
         WHERE scope_generation.generation_hash = ${authorityGenerationHash}
           AND scope_generation.maximum = 'PAPER'
           AND scope_generation.account_id = ${accountId}
-          AND scope_generation.qualification_run_id = cycle.qualification_run_id
+          AND COALESCE(scope_generation.qualification_run_id, scope_generation.research_plan_hash)
+            = cycle.qualification_run_id
           AND cycle.account_id = scope_generation.account_id
           AND cycle.created_at >= scope_generation.activated_at
           AND (
@@ -1007,38 +1009,72 @@ export const readForwardPerformancePostgres = (
 
         const strategyRows = yield* sql<Record<string, unknown>>`
           WITH first_cycle AS (
-            SELECT qualification_run_id, strategy_protocol_hash
+            SELECT qualification_run_id, strategy_protocol_hash, created_at
             FROM autonomous_cycles AS cycle
             WHERE cycle.account_id = ${accountId}
               AND cycle.state IN ('COMPLETED', 'NO_TRADE')
               AND ${generationScope(sql, accountId, authorityGenerationHash, 'cycle')}
             ORDER BY cycle.submission_open_at, cycle.cycle_id COLLATE "C"
             LIMIT 1
+          ), qualified_strategy AS (
+            SELECT
+              evaluation.run_id AS qualification_run_id,
+              evaluation.strategy_name,
+              protocol.protocol_hash AS strategy_protocol_hash,
+              protocol.behavior_hash AS strategy_behavior_hash,
+              protocol.parameter_hash AS strategy_parameter_hash,
+              protocol.schema_version AS strategy_parameter_schema_version,
+              evaluation.source_revision,
+              evaluation.image_repository,
+              evaluation.image_digest
+            FROM first_cycle
+            JOIN qualification_results AS result
+              ON result.run_id = first_cycle.qualification_run_id
+              AND result.verdict = 'QUALIFIED'
+            JOIN qualification_locks AS qualification_lock ON qualification_lock.lock_id = result.lock_id
+            JOIN evaluation_runs AS evaluation ON evaluation.run_id = result.run_id
+            JOIN protocol_locks AS protocol
+              ON protocol.protocol_hash = first_cycle.strategy_protocol_hash
+              AND protocol.protocol_hash = qualification_lock.protocol_hash
+              AND protocol.protocol_hash = evaluation.protocol_hash
+            WHERE evaluation.status = 'COMPLETE'
+              AND qualification_lock.source_revision = evaluation.source_revision
+              AND qualification_lock.image_repository = evaluation.image_repository
+              AND qualification_lock.image_digest = evaluation.image_digest
+          ), research_strategy AS (
+            SELECT
+              generation.research_plan_hash AS qualification_run_id,
+              generation.strategy_name,
+              generation.strategy_protocol_hash,
+              generation.strategy_behavior_hash,
+              generation.strategy_parameter_hash,
+              generation.strategy_parameter_schema_version,
+              generation.activation_source_revision AS source_revision,
+              generation.activation_image_repository AS image_repository,
+              generation.activation_image_digest AS image_digest
+            FROM first_cycle
+            JOIN authority_generations AS generation
+              ON generation.activation_schema_version = 'bayn.paper-authority-generation.v3'
+              AND generation.maximum = 'PAPER'
+              AND generation.account_id = ${accountId}
+              AND generation.research_plan_hash = first_cycle.qualification_run_id
+              AND generation.strategy_protocol_hash = first_cycle.strategy_protocol_hash
+              AND first_cycle.created_at >= generation.activated_at
+            WHERE ${
+              authorityGenerationHash === undefined
+                ? true
+                : sql`generation.generation_hash = ${authorityGenerationHash}`
+            }
+              AND NOT EXISTS (
+                SELECT 1
+                FROM authority_generations AS next_generation
+                WHERE next_generation.previous_generation_hash = generation.generation_hash
+                  AND first_cycle.created_at >= next_generation.activated_at
+              )
           )
-          SELECT
-            evaluation.run_id AS qualification_run_id,
-            evaluation.strategy_name,
-            protocol.protocol_hash AS strategy_protocol_hash,
-            protocol.behavior_hash AS strategy_behavior_hash,
-            protocol.parameter_hash AS strategy_parameter_hash,
-            protocol.schema_version AS strategy_parameter_schema_version,
-            evaluation.source_revision,
-            evaluation.image_repository,
-            evaluation.image_digest
-          FROM first_cycle
-          JOIN qualification_results AS result
-            ON result.run_id = first_cycle.qualification_run_id
-            AND result.verdict = 'QUALIFIED'
-          JOIN qualification_locks AS qualification_lock ON qualification_lock.lock_id = result.lock_id
-          JOIN evaluation_runs AS evaluation ON evaluation.run_id = result.run_id
-          JOIN protocol_locks AS protocol
-            ON protocol.protocol_hash = first_cycle.strategy_protocol_hash
-            AND protocol.protocol_hash = qualification_lock.protocol_hash
-            AND protocol.protocol_hash = evaluation.protocol_hash
-          WHERE evaluation.status = 'COMPLETE'
-            AND qualification_lock.source_revision = evaluation.source_revision
-            AND qualification_lock.image_repository = evaluation.image_repository
-            AND qualification_lock.image_digest = evaluation.image_digest
+          SELECT * FROM qualified_strategy
+          UNION ALL
+          SELECT * FROM research_strategy
         `.pipe(Effect.flatMap(decodeStrategy))
 
         const reconciliationRows = yield* sql<Record<string, unknown>>`
@@ -1416,20 +1452,27 @@ export const readForwardPerformancePostgres = (
             generation.broker_identity_hash,
             generation.broker_provider,
             generation.broker_environment,
-            generation.qualification_run_id,
+            COALESCE(generation.qualification_run_id, generation.research_plan_hash) AS qualification_run_id,
             generation.strategy_name,
-            generation.protocol_hash,
+            COALESCE(generation.protocol_hash, generation.strategy_protocol_hash) AS protocol_hash,
             generation.strategy_behavior_hash,
             generation.strategy_parameter_hash,
             generation.strategy_parameter_schema_version,
-            generation.qualification_execution_policy_hash,
-            generation.qualification_source_revision,
-            generation.qualification_image_repository,
-            generation.qualification_image_digest
+            COALESCE(generation.qualification_execution_policy_hash, cycle.execution_policy_hash)
+              AS qualification_execution_policy_hash,
+            COALESCE(generation.qualification_source_revision, generation.activation_source_revision)
+              AS qualification_source_revision,
+            COALESCE(generation.qualification_image_repository, generation.activation_image_repository)
+              AS qualification_image_repository,
+            COALESCE(generation.qualification_image_digest, generation.activation_image_digest)
+              AS qualification_image_digest
           FROM accounting_transactions AS transaction
           CROSS JOIN latest_reconciliation
           CROSS JOIN opening_snapshot
           JOIN intents AS intent ON intent.intent_id = transaction.intent_id
+          JOIN autonomous_cycles AS cycle
+            ON cycle.cycle_id = intent.cycle_id
+            AND cycle.account_id = intent.account_id
           JOIN authority_generations AS generation
             ON generation.generation_hash = intent.authority_generation_hash
           WHERE transaction.account_id = ${accountId}
@@ -1441,16 +1484,16 @@ export const readForwardPerformancePostgres = (
             generation.broker_identity_hash,
             generation.broker_provider,
             generation.broker_environment,
-            generation.qualification_run_id,
+            COALESCE(generation.qualification_run_id, generation.research_plan_hash),
             generation.strategy_name,
-            generation.protocol_hash,
+            COALESCE(generation.protocol_hash, generation.strategy_protocol_hash),
             generation.strategy_behavior_hash,
             generation.strategy_parameter_hash,
             generation.strategy_parameter_schema_version,
-            generation.qualification_execution_policy_hash,
-            generation.qualification_source_revision,
-            generation.qualification_image_repository,
-            generation.qualification_image_digest
+            COALESCE(generation.qualification_execution_policy_hash, cycle.execution_policy_hash),
+            COALESCE(generation.qualification_source_revision, generation.activation_source_revision),
+            COALESCE(generation.qualification_image_repository, generation.activation_image_repository),
+            COALESCE(generation.qualification_image_digest, generation.activation_image_digest)
         `.pipe(Effect.flatMap(decodeDurableExecutions))
 
         const [unclosedCycles] = yield* sql<Record<string, unknown>>`

--- a/services/bayn/src/forward-performance/program.test.ts
+++ b/services/bayn/src/forward-performance/program.test.ts
@@ -730,6 +730,23 @@ describe('forward performance read program', () => {
     expect(
       observation.statements.some(
         (statement) =>
+          statement.includes('COALESCE(scope_generation.qualification_run_id, scope_generation.research_plan_hash)') &&
+          statement.includes('= cycle.qualification_run_id'),
+      ),
+    ).toBe(true)
+    expect(
+      observation.statements.some(
+        (statement) =>
+          statement.includes('COALESCE(generation.qualification_run_id, generation.research_plan_hash)') &&
+          statement.includes('COALESCE(generation.protocol_hash, generation.strategy_protocol_hash)') &&
+          statement.includes(
+            'COALESCE(generation.qualification_source_revision, generation.activation_source_revision)',
+          ),
+      ),
+    ).toBe(true)
+    expect(
+      observation.statements.some(
+        (statement) =>
           statement.includes("cycle.state IN ('PENDING', 'ACTIVE', 'BLOCKED')") &&
           statement.includes('cycle.account_id = scope_generation.account_id') &&
           statement.includes('cycle.created_at >= scope_generation.activated_at') &&

--- a/services/bayn/src/http.test.ts
+++ b/services/bayn/src/http.test.ts
@@ -299,6 +299,10 @@ describe('Bayn HTTP pure decisions', () => {
         _tag: 'Realized' as const,
         requestHash: 'a'.repeat(64),
         generationHash: 'b'.repeat(64),
+        grant: 'Research' as const,
+        cutoffAt: '2026-09-01T13:30:00.000Z',
+        expiresAt: '2026-09-03T20:00:00.000Z',
+        maximumCloseSessions: 3,
       },
     }
     const facts = statusFacts(realized, readOnlyExecution, provenance, 'embedded')

--- a/services/bayn/src/observe-composition.test.ts
+++ b/services/bayn/src/observe-composition.test.ts
@@ -118,7 +118,7 @@ const accountingHash = 'b'.repeat(64)
 const reconciledAt = '2020-05-01T12:45:01.000Z'
 const evaluatedAt = '2020-05-01T12:45:02.000Z'
 
-test('PAPER entry submission is allowed before cutoff and denied afterward', () => {
+test('PAPER submissions obey separate entry and final close-session cutoffs', () => {
   expect(
     paperMutationSubmissionAllowed({
       capability: 'Mutation',
@@ -140,9 +140,19 @@ test('PAPER entry submission is allowed before cutoff and denied afterward', () 
       capability: 'Mutation',
       closeOnly: true,
       paperEpisodeCutoffAt: '2020-05-01T13:00:00.000Z',
+      paperEpisodeCloseSubmitCutoffAt: '2020-05-03T20:00:00.000Z',
       observedAt: '2020-05-01T13:05:00.000Z',
     }),
   ).toBe(true)
+  expect(
+    paperMutationSubmissionAllowed({
+      capability: 'Mutation',
+      closeOnly: true,
+      paperEpisodeCutoffAt: '2020-05-01T13:00:00.000Z',
+      paperEpisodeCloseSubmitCutoffAt: '2020-05-03T20:00:00.000Z',
+      observedAt: '2020-05-03T20:00:00.000Z',
+    }),
+  ).toBe(false)
 })
 
 test('requires a bounded residual close replan after a settled close leaves a position open', () => {

--- a/services/bayn/src/observe-composition.ts
+++ b/services/bayn/src/observe-composition.ts
@@ -57,6 +57,7 @@ import { makeStrategyProtocolHash } from './contracts'
 import { OperationalError, operationalError } from './errors'
 import { canonicalHashV1Result } from './hash'
 import { MarketData, type MarketDataService } from './market-data'
+import { decidePaperEpisodeCycleTerminalization } from './paper-episode'
 import {
   Authority,
   IntentState,
@@ -1005,9 +1006,11 @@ export type ObserveAutonomousCycleInput = {
   readonly reconciliationIntervalMs: number
   readonly reconciliationPassTimeoutMs: number
   readonly strategy: StrategyRuntime
+  readonly cycleCadence?: 'MONTHLY' | 'PAPER_BOOTSTRAP'
   readonly mutationPhase?: 'ENTRY' | 'CLOSE'
   readonly paperCycleClosureStore?: PaperCycleClosureStoreShape
   readonly paperEpisodeCutoffAt?: string
+  readonly paperEpisodeCloseSubmitCutoffAt?: string
   readonly paperEpisodeExpiresAt?: string
   readonly onClosedCycle?: (cycleId: string, observedAt: string) => Effect.Effect<void>
 }
@@ -1105,10 +1108,13 @@ export const paperMutationSubmissionAllowed = (input: {
   readonly capability: PaperExecutionCapability['_tag']
   readonly closeOnly: boolean
   readonly paperEpisodeCutoffAt?: string
+  readonly paperEpisodeCloseSubmitCutoffAt?: string
   readonly observedAt: string
 }): boolean =>
   input.capability === 'Mutation' &&
-  (input.closeOnly || input.paperEpisodeCutoffAt === undefined || input.observedAt < input.paperEpisodeCutoffAt)
+  (input.closeOnly
+    ? input.paperEpisodeCloseSubmitCutoffAt === undefined || input.observedAt < input.paperEpisodeCloseSubmitCutoffAt
+    : input.paperEpisodeCutoffAt === undefined || input.observedAt < input.paperEpisodeCutoffAt)
 
 type RecoveryFirstDecisionBuilder = (
   cycle: AutonomousCycle,
@@ -1455,14 +1461,30 @@ const executeBoundPaperCycle = (
         capability: capability._tag,
         closeOnly,
         paperEpisodeCutoffAt: input.paperEpisodeCutoffAt,
+        paperEpisodeCloseSubmitCutoffAt: input.paperEpisodeCloseSubmitCutoffAt,
         observedAt,
       }),
     )
     if (step._tag !== 'Execute') {
-      if (step._tag === 'Complete' && closeOnly && (yield* entryPaperCycleHasUnsuccessfulIntent(document))) {
-        return { _tag: 'Block', reason: CycleTerminalReason.Risk, observedAt: step.observedAt }
+      if (step._tag !== 'Complete') return step
+      const entryHasUnsuccessfulIntent =
+        closeOnly || (input.paperEpisodeCutoffAt !== undefined && observedAt >= input.paperEpisodeCutoffAt)
+          ? yield* entryPaperCycleHasUnsuccessfulIntent(document)
+          : false
+      const terminalization = decidePaperEpisodeCycleTerminalization({
+        closeOnly,
+        observedAt,
+        ...(input.paperEpisodeCutoffAt === undefined ? {} : { entryCutoffAt: input.paperEpisodeCutoffAt }),
+        entryHasUnsuccessfulIntent,
+      })
+      switch (terminalization._tag) {
+        case 'WaitForClose':
+          return { _tag: 'Wait', observedAt: step.observedAt }
+        case 'Block':
+          return { _tag: 'Block', reason: CycleTerminalReason.Risk, observedAt: step.observedAt }
+        case 'Complete':
+          return step
       }
-      return step
     }
     const executed = yield* capability._tag === 'Mutation'
       ? executeMutationIntent(
@@ -1860,6 +1882,7 @@ const recoveryFirstCycleLoop = (
         Effect.gen(function* () {
           const context: CycleRunContext<ObserveDecisionRuntime> = {
             qualificationRunId: startup.qualificationRunId,
+            ...(input.cycleCadence === undefined ? {} : { cadence: input.cycleCadence }),
             strategyProtocolHash: preparation.strategyProtocolHash,
             accountId: input.accountId,
             executionPolicy: preparation.executionPolicy,

--- a/services/bayn/src/paper-episode.test.ts
+++ b/services/bayn/src/paper-episode.test.ts
@@ -1,0 +1,282 @@
+import { describe, expect, test } from 'bun:test'
+import { Result } from 'effect'
+
+import {
+  decidePaperEpisode,
+  decidePaperEpisodeAuthority,
+  decidePaperEpisodeCycleTerminalization,
+  failedPaperEpisode,
+  paperGrantFromGeneration,
+  paperGrantKey,
+  validatePaperEpisodeCloseWindow,
+  type PaperEpisodeFacts,
+  type PaperEpisodeFailure,
+  type PaperEpisodeState,
+} from './paper-episode'
+
+const safeFacts = (overrides: Partial<PaperEpisodeFacts> = {}): PaperEpisodeFacts => ({
+  observedAt: '2026-08-04T14:00:00.000Z',
+  entryCutoffAt: '2026-09-01T13:00:00.000Z',
+  maximumCloseSessions: 3,
+  finalizedSnapshotAvailable: true,
+  nonzeroTargetAvailable: true,
+  entryFilled: false,
+  hasOpenPosition: false,
+  closeSessionAdvanced: false,
+  safety: {
+    brokerRejected: false,
+    dataFresh: true,
+    identityMatches: true,
+    reconciliationExact: true,
+    restartUnambiguous: true,
+    unresolvedMutationCount: 0,
+  },
+  ...overrides,
+})
+
+const success = (state: PaperEpisodeState, facts: PaperEpisodeFacts) => {
+  const result = decidePaperEpisode(state, facts)
+  expect(Result.isSuccess(result)).toBe(true)
+  return Result.getOrThrow(result)
+}
+
+describe('decidePaperEpisode', () => {
+  test('adapts legacy qualification history and research history to one grant boundary', () => {
+    const qualified = paperGrantFromGeneration({
+      schemaVersion: 'bayn.paper-authority-generation.v2',
+      qualificationRunId: 'a'.repeat(64),
+      qualificationLockId: 'b'.repeat(64),
+      qualificationResultHash: 'c'.repeat(64),
+    })
+    const research = paperGrantFromGeneration({
+      schemaVersion: 'bayn.paper-authority-generation.v3',
+      grant: { _tag: 'Research', planHash: 'd'.repeat(64) },
+    })
+
+    expect(qualified).toEqual({
+      _tag: 'Qualified',
+      qualification: {
+        runId: 'a'.repeat(64),
+        lockId: 'b'.repeat(64),
+        resultHash: 'c'.repeat(64),
+      },
+    })
+    expect(paperGrantKey(qualified)).toBe('a'.repeat(64))
+    expect(paperGrantKey(research)).toBe('d'.repeat(64))
+  })
+
+  test('starts only when a finalized snapshot has a nonzero target', () => {
+    expect(success({ _tag: 'Pending' }, safeFacts())).toEqual({ _tag: 'StartEntry', state: { _tag: 'Pending' } })
+    expect(success({ _tag: 'Pending' }, safeFacts({ nonzeroTargetAvailable: false }))).toEqual({
+      _tag: 'WaitForEntry',
+      state: { _tag: 'Pending' },
+    })
+  })
+
+  test('adopts one durable entry cycle and replays it idempotently after restart', () => {
+    const entering = success({ _tag: 'Pending' }, safeFacts({ cycleId: 'entry-cycle' }))
+    expect(entering).toEqual({ _tag: 'Enter', state: { _tag: 'Entering', cycleId: 'entry-cycle' } })
+    expect(success(entering.state, safeFacts({ cycleId: 'entry-cycle' }))).toEqual({
+      _tag: 'ContinueEntry',
+      state: { _tag: 'Entering', cycleId: 'entry-cycle' },
+    })
+  })
+
+  test('holds a broker-confirmed entry until the monthly cutoff', () => {
+    const holding = success(
+      { _tag: 'Entering', cycleId: 'entry-cycle' },
+      safeFacts({ cycleId: 'entry-cycle', entryFilled: true, hasOpenPosition: true }),
+    )
+    expect(holding).toEqual({ _tag: 'Hold', state: { _tag: 'Holding', entryCycleId: 'entry-cycle' } })
+    expect(success(holding.state, safeFacts({ cycleId: 'entry-cycle', hasOpenPosition: true }))).toEqual(holding)
+  })
+
+  test('enters close-only mode at the cutoff and consumes at most three advanced sessions', () => {
+    const closing = success(
+      { _tag: 'Holding', entryCycleId: 'entry-cycle' },
+      safeFacts({
+        cycleId: 'entry-cycle',
+        observedAt: '2026-09-01T13:00:00.000Z',
+        hasOpenPosition: true,
+      }),
+    )
+    expect(closing).toEqual({ _tag: 'Close', state: { _tag: 'Closing', remainingSessions: 3 } })
+    expect(
+      success(closing.state, safeFacts({ cycleId: 'entry-cycle', hasOpenPosition: true, closeSessionAdvanced: true })),
+    ).toEqual({ _tag: 'Close', state: { _tag: 'Closing', remainingSessions: 2 } })
+  })
+
+  test('finalizes only when flat and completes only with the bound receipt', () => {
+    const state = { _tag: 'Closing', remainingSessions: 2 } as const
+    expect(success(state, safeFacts())).toEqual({ _tag: 'Finalize', state })
+    expect(success(state, safeFacts({ receiptHash: 'a'.repeat(64) }))).toEqual({
+      _tag: 'Complete',
+      state: { _tag: 'Completed', receiptHash: 'a'.repeat(64) },
+    })
+    expect(
+      success({ _tag: 'Completed', receiptHash: 'a'.repeat(64) }, safeFacts({ receiptHash: 'a'.repeat(64) })),
+    ).toEqual({ _tag: 'Complete', state: { _tag: 'Completed', receiptHash: 'a'.repeat(64) } })
+  })
+
+  test('fails closed on every unsafe broker and recovery fact', () => {
+    const failures: ReadonlyArray<[Partial<PaperEpisodeFacts['safety']>, PaperEpisodeFailure['_tag']]> = [
+      [{ identityMatches: false }, 'IdentityDrift'],
+      [{ restartUnambiguous: false }, 'RestartAmbiguous'],
+      [{ unresolvedMutationCount: 1 }, 'UnknownMutation'],
+      [{ reconciliationExact: false }, 'ReconciliationDiscrepancy'],
+      [{ dataFresh: false }, 'StaleData'],
+      [{ brokerRejected: true }, 'BrokerRejected'],
+    ]
+    for (const [safety, tag] of failures) {
+      const result = decidePaperEpisode(
+        { _tag: 'Pending' },
+        safeFacts({ safety: { ...safeFacts().safety, ...safety } }),
+      )
+      expect(Result.isFailure(result)).toBe(true)
+      if (Result.isFailure(result)) expect(result.failure._tag).toBe(tag)
+    }
+  })
+
+  test('fails rather than opening a fourth close session', () => {
+    const result = decidePaperEpisode(
+      { _tag: 'Closing', remainingSessions: 1 },
+      safeFacts({ cycleId: 'entry-cycle', hasOpenPosition: true, closeSessionAdvanced: true }),
+    )
+    expect(result).toEqual(Result.fail({ _tag: 'CloseWindowExhausted', cycleId: 'entry-cycle' }))
+  })
+
+  test('keeps the entry cycle active through holding and terminalizes only after close evidence', () => {
+    const cutoff = '2026-09-01T13:00:00.000Z'
+    expect(
+      decidePaperEpisodeCycleTerminalization({
+        closeOnly: false,
+        observedAt: '2026-08-31T20:00:00.000Z',
+        entryCutoffAt: cutoff,
+        entryHasUnsuccessfulIntent: false,
+      }),
+    ).toEqual({ _tag: 'WaitForClose' })
+    expect(
+      decidePaperEpisodeCycleTerminalization({
+        closeOnly: true,
+        observedAt: cutoff,
+        entryCutoffAt: cutoff,
+        entryHasUnsuccessfulIntent: false,
+      }),
+    ).toEqual({ _tag: 'Complete' })
+    expect(
+      decidePaperEpisodeCycleTerminalization({
+        closeOnly: true,
+        observedAt: cutoff,
+        entryCutoffAt: cutoff,
+        entryHasUnsuccessfulIntent: true,
+      }),
+    ).toEqual({ _tag: 'Complete' })
+    expect(
+      decidePaperEpisodeCycleTerminalization({
+        closeOnly: false,
+        observedAt: cutoff,
+        entryCutoffAt: cutoff,
+        entryHasUnsuccessfulIntent: true,
+      }),
+    ).toEqual({ _tag: 'Block' })
+  })
+
+  test('keeps a terminal failure stable across restart', () => {
+    const state = failedPaperEpisode({ _tag: 'BrokerRejected' })
+    expect(success(state, safeFacts())).toEqual({ _tag: 'RemainFailed', state })
+  })
+
+  test('activates only from the exact OBSERVE source and resumes only the exact durable PAPER generation', () => {
+    const common = {
+      sourceGenerationHash: 'a'.repeat(64),
+    }
+    expect(
+      decidePaperEpisodeAuthority({
+        ...common,
+        generationHash: common.sourceGenerationHash,
+        maximum: 'OBSERVE',
+        effective: 'OBSERVE',
+        kill: 'CLEAR',
+      }),
+    ).toEqual(Result.succeed({ _tag: 'Activate' }))
+    expect(
+      decidePaperEpisodeAuthority({
+        ...common,
+        generationHash: 'b'.repeat(64),
+        maximum: 'PAPER',
+        effective: 'PAPER',
+        kill: 'CLEAR',
+      }),
+    ).toEqual(Result.succeed({ _tag: 'Resume' }))
+    expect(
+      decidePaperEpisodeAuthority({
+        ...common,
+        generationHash: 'b'.repeat(64),
+        maximum: 'PAPER',
+        effective: 'OBSERVE',
+        kill: 'ACTIVE',
+      }),
+    ).toEqual(Result.succeed({ _tag: 'Resume' }))
+  })
+
+  test('rejects source-generation drift instead of activating over unknown OBSERVE history', () => {
+    const result = decidePaperEpisodeAuthority({
+      generationHash: 'c'.repeat(64),
+      sourceGenerationHash: 'a'.repeat(64),
+      maximum: 'OBSERVE',
+      effective: 'OBSERVE',
+      kill: 'CLEAR',
+    })
+    expect(result).toEqual(Result.fail({ _tag: 'IdentityDrift' }))
+  })
+
+  test('accepts a close lease containing at most three complete market sessions', () => {
+    const sessions = [
+      { date: '2026-09-01', openAt: '2026-09-01T13:30:00.000Z', closeAt: '2026-09-01T20:00:00.000Z' },
+      { date: '2026-09-02', openAt: '2026-09-02T13:30:00.000Z', closeAt: '2026-09-02T20:00:00.000Z' },
+      { date: '2026-09-03', openAt: '2026-09-03T13:30:00.000Z', closeAt: '2026-09-03T20:00:00.000Z' },
+    ]
+    expect(
+      validatePaperEpisodeCloseWindow({
+        cutoffAt: sessions[0].openAt,
+        expiresAt: sessions[2].closeAt,
+        maximumCloseSessions: 3,
+        sessions: [...sessions].reverse(),
+      }),
+    ).toEqual(Result.succeed(sessions))
+  })
+
+  test('rejects a partial, late-starting, or fourth-session close lease', () => {
+    const sessions = [
+      { date: '2026-09-01', openAt: '2026-09-01T13:30:00.000Z', closeAt: '2026-09-01T20:00:00.000Z' },
+      { date: '2026-09-02', openAt: '2026-09-02T13:30:00.000Z', closeAt: '2026-09-02T20:00:00.000Z' },
+      { date: '2026-09-03', openAt: '2026-09-03T13:30:00.000Z', closeAt: '2026-09-03T20:00:00.000Z' },
+      { date: '2026-09-04', openAt: '2026-09-04T13:30:00.000Z', closeAt: '2026-09-04T20:00:00.000Z' },
+    ]
+    const invalid = [
+      {
+        cutoffAt: '2026-09-01T14:00:00.000Z',
+        expiresAt: sessions[2].closeAt,
+        maximumCloseSessions: 3,
+        sessions,
+      },
+      {
+        cutoffAt: sessions[0].openAt,
+        expiresAt: '2026-09-03T19:00:00.000Z',
+        maximumCloseSessions: 3,
+        sessions,
+      },
+      {
+        cutoffAt: sessions[0].openAt,
+        expiresAt: sessions[3].closeAt,
+        maximumCloseSessions: 3,
+        sessions,
+      },
+    ]
+    for (const input of invalid) {
+      const result = validatePaperEpisodeCloseWindow(input)
+      expect(Result.isFailure(result)).toBe(true)
+      if (Result.isFailure(result)) expect(result.failure._tag).toBe('InvalidCloseWindow')
+    }
+  })
+})

--- a/services/bayn/src/paper-episode.test.ts
+++ b/services/bayn/src/paper-episode.test.ts
@@ -186,7 +186,7 @@ describe('decidePaperEpisode', () => {
     expect(success(state, safeFacts())).toEqual({ _tag: 'RemainFailed', state })
   })
 
-  test('activates only from the exact OBSERVE source and resumes only the exact durable PAPER generation', () => {
+  test('activates only from the exact OBSERVE source and resumes only clear effective PAPER authority', () => {
     const common = {
       sourceGenerationHash: 'a'.repeat(64),
     }
@@ -216,7 +216,7 @@ describe('decidePaperEpisode', () => {
         effective: 'OBSERVE',
         kill: 'ACTIVE',
       }),
-    ).toEqual(Result.succeed({ _tag: 'Resume' }))
+    ).toEqual(Result.fail({ _tag: 'IdentityDrift' }))
   })
 
   test('rejects source-generation drift instead of activating over unknown OBSERVE history', () => {

--- a/services/bayn/src/paper-episode.ts
+++ b/services/bayn/src/paper-episode.ts
@@ -118,11 +118,7 @@ export const decidePaperEpisodeAuthority = (
   ) {
     return Result.succeed({ _tag: 'Activate' })
   }
-  if (
-    facts.maximum === 'PAPER' &&
-    ((facts.effective === 'PAPER' && facts.kill === 'CLEAR') ||
-      (facts.effective === 'OBSERVE' && facts.kill === 'ACTIVE'))
-  ) {
+  if (facts.maximum === 'PAPER' && facts.effective === 'PAPER' && facts.kill === 'CLEAR') {
     return Result.succeed({ _tag: 'Resume' })
   }
   return Result.fail({ _tag: 'IdentityDrift' })

--- a/services/bayn/src/paper-episode.ts
+++ b/services/bayn/src/paper-episode.ts
@@ -1,0 +1,302 @@
+import { Result, Schema } from 'effect'
+
+import { Sha256Schema } from './schemas'
+
+export const QualificationBindingSchema = Schema.Struct({
+  runId: Sha256Schema,
+  lockId: Sha256Schema,
+  resultHash: Sha256Schema,
+})
+export type QualificationBinding = typeof QualificationBindingSchema.Type
+
+export const QualifiedPaperGrantSchema = Schema.Struct({
+  _tag: Schema.Literal('Qualified'),
+  qualification: QualificationBindingSchema,
+})
+export const ResearchPaperGrantSchema = Schema.Struct({
+  _tag: Schema.Literal('Research'),
+  planHash: Sha256Schema,
+})
+export const PaperGrantSchema = Schema.Union([QualifiedPaperGrantSchema, ResearchPaperGrantSchema])
+export type PaperGrant = typeof PaperGrantSchema.Type
+
+export const paperGrantKey = (grant: PaperGrant): string =>
+  grant._tag === 'Qualified' ? grant.qualification.runId : grant.planHash
+
+export type PersistedPaperGrantBinding =
+  | {
+      readonly schemaVersion: 'bayn.paper-authority-generation.v2'
+      readonly qualificationRunId: string
+      readonly qualificationLockId: string
+      readonly qualificationResultHash: string
+    }
+  | {
+      readonly schemaVersion: 'bayn.paper-authority-generation.v3'
+      readonly grant: Extract<PaperGrant, { readonly _tag: 'Research' }>
+    }
+
+/** Projects legacy qualification-bound history into the episode grant without rewriting durable rows. */
+export const paperGrantFromGeneration = (generation: PersistedPaperGrantBinding): PaperGrant =>
+  generation.schemaVersion === 'bayn.paper-authority-generation.v3'
+    ? generation.grant
+    : {
+        _tag: 'Qualified',
+        qualification: {
+          runId: generation.qualificationRunId,
+          lockId: generation.qualificationLockId,
+          resultHash: generation.qualificationResultHash,
+        },
+      }
+
+export type PaperEpisodeFailure =
+  | { readonly _tag: 'BrokerRejected' }
+  | { readonly _tag: 'CloseWindowExhausted'; readonly cycleId: string }
+  | { readonly _tag: 'IdentityDrift' }
+  | { readonly _tag: 'InvalidCloseWindow'; readonly reason: string }
+  | { readonly _tag: 'InvalidTransition'; readonly state: PaperEpisodeState['_tag']; readonly reason: string }
+  | { readonly _tag: 'MissedEntryCutoff' }
+  | { readonly _tag: 'ReconciliationDiscrepancy' }
+  | { readonly _tag: 'RestartAmbiguous' }
+  | { readonly _tag: 'StaleData' }
+  | { readonly _tag: 'UnknownMutation'; readonly count: number }
+
+export type PaperEpisodeState =
+  | { readonly _tag: 'Pending' }
+  | { readonly _tag: 'Entering'; readonly cycleId: string }
+  | { readonly _tag: 'Holding'; readonly entryCycleId: string }
+  | { readonly _tag: 'Closing'; readonly remainingSessions: number }
+  | { readonly _tag: 'Completed'; readonly receiptHash: string }
+  | { readonly _tag: 'Failed'; readonly reason: PaperEpisodeFailure }
+
+export interface PaperEpisodeSafetyFacts {
+  readonly brokerRejected: boolean
+  readonly dataFresh: boolean
+  readonly identityMatches: boolean
+  readonly reconciliationExact: boolean
+  readonly restartUnambiguous: boolean
+  readonly unresolvedMutationCount: number
+}
+
+export interface PaperEpisodeFacts {
+  readonly observedAt: string
+  readonly entryCutoffAt: string
+  readonly maximumCloseSessions: number
+  readonly cycleId?: string
+  readonly finalizedSnapshotAvailable: boolean
+  readonly nonzeroTargetAvailable: boolean
+  readonly entryFilled: boolean
+  readonly hasOpenPosition: boolean
+  readonly closeSessionAdvanced: boolean
+  readonly receiptHash?: string
+  readonly safety: PaperEpisodeSafetyFacts
+}
+
+export interface PaperEpisodeMarketSession {
+  readonly date: string
+  readonly openAt: string
+  readonly closeAt: string
+}
+
+export interface PaperEpisodeAuthorityFacts {
+  readonly generationHash: string
+  readonly sourceGenerationHash: string
+  readonly maximum: 'OBSERVE' | 'PAPER'
+  readonly effective: 'OBSERVE' | 'PAPER'
+  readonly kill: 'CLEAR' | 'ACTIVE'
+}
+
+export type PaperEpisodeAuthorityDecision = { readonly _tag: 'Activate' } | { readonly _tag: 'Resume' }
+
+export const decidePaperEpisodeAuthority = (
+  facts: PaperEpisodeAuthorityFacts,
+): Result.Result<PaperEpisodeAuthorityDecision, PaperEpisodeFailure> => {
+  if (
+    facts.maximum === 'OBSERVE' &&
+    facts.effective === 'OBSERVE' &&
+    facts.kill === 'CLEAR' &&
+    facts.generationHash === facts.sourceGenerationHash
+  ) {
+    return Result.succeed({ _tag: 'Activate' })
+  }
+  if (
+    facts.maximum === 'PAPER' &&
+    ((facts.effective === 'PAPER' && facts.kill === 'CLEAR') ||
+      (facts.effective === 'OBSERVE' && facts.kill === 'ACTIVE'))
+  ) {
+    return Result.succeed({ _tag: 'Resume' })
+  }
+  return Result.fail({ _tag: 'IdentityDrift' })
+}
+
+export const validatePaperEpisodeCloseWindow = (input: {
+  readonly cutoffAt: string
+  readonly expiresAt: string
+  readonly maximumCloseSessions: number
+  readonly sessions: readonly PaperEpisodeMarketSession[]
+}): Result.Result<readonly PaperEpisodeMarketSession[], PaperEpisodeFailure> => {
+  if (!Number.isSafeInteger(input.maximumCloseSessions) || input.maximumCloseSessions < 1) {
+    return Result.fail({ _tag: 'InvalidCloseWindow', reason: 'maximum close sessions must be positive' })
+  }
+  if (input.cutoffAt >= input.expiresAt) {
+    return Result.fail({ _tag: 'InvalidCloseWindow', reason: 'close expiry must follow the cutoff' })
+  }
+  const ordered = [...input.sessions].sort((left, right) => left.openAt.localeCompare(right.openAt))
+  for (let index = 0; index < ordered.length; index += 1) {
+    const session = ordered[index]
+    const previous = ordered[index - 1]
+    if (session === undefined || session.openAt >= session.closeAt) {
+      return Result.fail({ _tag: 'InvalidCloseWindow', reason: 'market session interval is invalid' })
+    }
+    if (previous !== undefined && (session.date === previous.date || session.openAt <= previous.openAt)) {
+      return Result.fail({ _tag: 'InvalidCloseWindow', reason: 'market sessions are not unique and ordered' })
+    }
+  }
+  const closeSessions = ordered.filter(
+    (session) => session.closeAt > input.cutoffAt && session.openAt < input.expiresAt,
+  )
+  if (closeSessions.length === 0) {
+    return Result.fail({ _tag: 'InvalidCloseWindow', reason: 'close window contains no market session' })
+  }
+  if (closeSessions.length > input.maximumCloseSessions) {
+    return Result.fail({ _tag: 'InvalidCloseWindow', reason: 'close window exceeds its market-session limit' })
+  }
+  if (closeSessions[0]?.openAt !== input.cutoffAt) {
+    return Result.fail({ _tag: 'InvalidCloseWindow', reason: 'close cutoff must equal the first session open' })
+  }
+  if (closeSessions.some((session) => session.closeAt > input.expiresAt)) {
+    return Result.fail({ _tag: 'InvalidCloseWindow', reason: 'close expiry truncates a market session' })
+  }
+  return Result.succeed(closeSessions)
+}
+
+export type PaperEpisodeDecision =
+  | { readonly _tag: 'WaitForEntry'; readonly state: Extract<PaperEpisodeState, { readonly _tag: 'Pending' }> }
+  | { readonly _tag: 'StartEntry'; readonly state: Extract<PaperEpisodeState, { readonly _tag: 'Pending' }> }
+  | { readonly _tag: 'Enter'; readonly state: Extract<PaperEpisodeState, { readonly _tag: 'Entering' }> }
+  | { readonly _tag: 'ContinueEntry'; readonly state: Extract<PaperEpisodeState, { readonly _tag: 'Entering' }> }
+  | { readonly _tag: 'Hold'; readonly state: Extract<PaperEpisodeState, { readonly _tag: 'Holding' }> }
+  | { readonly _tag: 'Close'; readonly state: Extract<PaperEpisodeState, { readonly _tag: 'Closing' }> }
+  | { readonly _tag: 'Finalize'; readonly state: Extract<PaperEpisodeState, { readonly _tag: 'Closing' }> }
+  | { readonly _tag: 'Complete'; readonly state: Extract<PaperEpisodeState, { readonly _tag: 'Completed' }> }
+  | { readonly _tag: 'RemainFailed'; readonly state: Extract<PaperEpisodeState, { readonly _tag: 'Failed' }> }
+
+export type PaperEpisodeCycleTerminalizationDecision =
+  | { readonly _tag: 'WaitForClose' }
+  | { readonly _tag: 'Block' }
+  | { readonly _tag: 'Complete' }
+
+export const decidePaperEpisodeCycleTerminalization = (input: {
+  readonly closeOnly: boolean
+  readonly observedAt: string
+  readonly entryCutoffAt?: string
+  readonly entryHasUnsuccessfulIntent: boolean
+}): PaperEpisodeCycleTerminalizationDecision => {
+  if (!input.closeOnly && input.entryCutoffAt !== undefined && input.observedAt < input.entryCutoffAt) {
+    return { _tag: 'WaitForClose' }
+  }
+  if (!input.closeOnly && input.entryCutoffAt !== undefined && input.entryHasUnsuccessfulIntent) {
+    return { _tag: 'Block' }
+  }
+  return { _tag: 'Complete' }
+}
+
+const invalid = (state: PaperEpisodeState, reason: string): Result.Result<never, PaperEpisodeFailure> =>
+  Result.fail({ _tag: 'InvalidTransition', state: state._tag, reason })
+
+const safetyFailure = (facts: PaperEpisodeSafetyFacts): PaperEpisodeFailure | undefined => {
+  if (!facts.identityMatches) return { _tag: 'IdentityDrift' }
+  if (!facts.restartUnambiguous) return { _tag: 'RestartAmbiguous' }
+  if (facts.unresolvedMutationCount !== 0) {
+    return { _tag: 'UnknownMutation', count: facts.unresolvedMutationCount }
+  }
+  if (!facts.reconciliationExact) return { _tag: 'ReconciliationDiscrepancy' }
+  if (!facts.dataFresh) return { _tag: 'StaleData' }
+  if (facts.brokerRejected) return { _tag: 'BrokerRejected' }
+  return undefined
+}
+
+const closeDecision = (
+  state: Extract<PaperEpisodeState, { readonly _tag: 'Closing' }>,
+  facts: PaperEpisodeFacts,
+): Result.Result<PaperEpisodeDecision, PaperEpisodeFailure> => {
+  if (facts.receiptHash !== undefined) {
+    return facts.hasOpenPosition
+      ? invalid(state, 'a completed receipt cannot coexist with an open position')
+      : Result.succeed({ _tag: 'Complete', state: { _tag: 'Completed', receiptHash: facts.receiptHash } })
+  }
+  if (!facts.hasOpenPosition) return Result.succeed({ _tag: 'Finalize', state })
+  const remainingSessions = state.remainingSessions - (facts.closeSessionAdvanced ? 1 : 0)
+  return remainingSessions <= 0
+    ? Result.fail({ _tag: 'CloseWindowExhausted', cycleId: facts.cycleId ?? 'unknown' })
+    : Result.succeed({ _tag: 'Close', state: { _tag: 'Closing', remainingSessions } })
+}
+
+/**
+ * Total, I/O-free decision for one bounded sandbox PAPER episode. The caller derives facts from durable generation,
+ * cycle, intent, broker, reconciliation, and receipt records, then interprets the returned action through existing
+ * ports. No state is hidden in this module.
+ */
+export const decidePaperEpisode = (
+  state: PaperEpisodeState,
+  facts: PaperEpisodeFacts,
+): Result.Result<PaperEpisodeDecision, PaperEpisodeFailure> => {
+  if (!Number.isSafeInteger(facts.maximumCloseSessions) || facts.maximumCloseSessions < 1) {
+    return invalid(state, 'maximumCloseSessions must be a positive safe integer')
+  }
+  const safety = safetyFailure(facts.safety)
+  if (safety !== undefined) return Result.fail(safety)
+
+  switch (state._tag) {
+    case 'Pending':
+      if (facts.receiptHash !== undefined) return invalid(state, 'a pending episode cannot already have a receipt')
+      if (facts.cycleId !== undefined) {
+        return Result.succeed({ _tag: 'Enter', state: { _tag: 'Entering', cycleId: facts.cycleId } })
+      }
+      if (facts.observedAt >= facts.entryCutoffAt) return Result.fail({ _tag: 'MissedEntryCutoff' })
+      return facts.finalizedSnapshotAvailable && facts.nonzeroTargetAvailable
+        ? Result.succeed({ _tag: 'StartEntry', state })
+        : Result.succeed({ _tag: 'WaitForEntry', state })
+
+    case 'Entering':
+      if (facts.cycleId !== undefined && facts.cycleId !== state.cycleId) {
+        return invalid(state, 'the durable entry cycle identity changed')
+      }
+      if (facts.entryFilled || facts.hasOpenPosition) {
+        return Result.succeed({ _tag: 'Hold', state: { _tag: 'Holding', entryCycleId: state.cycleId } })
+      }
+      return facts.observedAt >= facts.entryCutoffAt
+        ? Result.fail({ _tag: 'MissedEntryCutoff' })
+        : Result.succeed({ _tag: 'ContinueEntry', state })
+
+    case 'Holding':
+      if (facts.cycleId !== undefined && facts.cycleId !== state.entryCycleId) {
+        return invalid(state, 'the durable holding cycle identity changed')
+      }
+      if (!facts.hasOpenPosition) {
+        return facts.receiptHash === undefined
+          ? invalid(state, 'a held position disappeared before a terminal receipt')
+          : Result.succeed({ _tag: 'Complete', state: { _tag: 'Completed', receiptHash: facts.receiptHash } })
+      }
+      return facts.observedAt < facts.entryCutoffAt
+        ? Result.succeed({ _tag: 'Hold', state })
+        : Result.succeed({
+            _tag: 'Close',
+            state: { _tag: 'Closing', remainingSessions: facts.maximumCloseSessions },
+          })
+
+    case 'Closing':
+      return closeDecision(state, facts)
+
+    case 'Completed':
+      return facts.receiptHash === state.receiptHash && !facts.hasOpenPosition
+        ? Result.succeed({ _tag: 'Complete', state })
+        : invalid(state, 'completed episode evidence changed')
+
+    case 'Failed':
+      return Result.succeed({ _tag: 'RemainFailed', state })
+  }
+}
+
+export const failedPaperEpisode = (
+  reason: PaperEpisodeFailure,
+): Extract<PaperEpisodeState, { readonly _tag: 'Failed' }> => ({ _tag: 'Failed', reason })

--- a/services/bayn/src/runtime-state.ts
+++ b/services/bayn/src/runtime-state.ts
@@ -90,6 +90,17 @@ export type PaperActivationRuntimeState =
       readonly _tag: 'Realized'
       readonly requestHash: string
       readonly generationHash: string
+      readonly grant: 'Qualified' | 'Research'
+      readonly cutoffAt: string
+      readonly expiresAt: string
+      readonly maximumCloseSessions: number | null
+    }
+  | {
+      readonly _tag: 'Completed'
+      readonly requestHash: string
+      readonly generationHash: string
+      readonly grant: 'Qualified' | 'Research'
+      readonly receiptHash: string
     }
 
 export interface RuntimeState {


### PR DESCRIPTION
## Summary

- add a pure `PaperEpisode` state machine and a normalized `PaperGrant` seam for legacy qualified and new research-bound generations
- persist research activation, cycle binding, broker intents, bounded close-only recovery, and forward-performance completion through existing PostgreSQL and Effect boundaries
- keep sandbox risk limits and fail-closed reconciliation intact while supporting restart-safe entry, holding, three-session flattening, durable completion, and automatic OBSERVE restriction
- add migration, pure transition coverage, runtime/restart tests, and PostgreSQL integration coverage without adding a deployment or broker activation

## Related Issues

None

## Testing

- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn lint:effect`
- `bun run --filter @proompteng/bayn build`
- `bun test services/bayn/src/paper-episode.test.ts services/bayn/src/composition.test.ts` (22 passed)
- `bun run --filter @proompteng/bayn test` (1,133 passed, 156 skipped)
- `bun run --filter @proompteng/bayn test:scripts` (141 passed)
- `bun run --filter @proompteng/bayn test:effect-runtime` (4 passed)
- `bun run --filter @proompteng/bayn test:broker-sandbox-contract` (3 passed)
- `BAYN_DATABASE_URL=postgresql://bayn:bayn@127.0.0.1:5432/bayn_e39e_test bun run --filter @proompteng/bayn test:postgres` (141 passed)
- `git diff --check`

## Breaking Changes

None. Migration 0028 adds backward-compatible research grant columns and generation schema v3; persisted v2 qualified generations are decoded through a compatibility adapter without rewriting history.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
