### PR TITLE
fix(bayn): bind research paper health to active cycle

### DIFF
--- a/services/bayn/src/app.test.ts
+++ b/services/bayn/src/app.test.ts
@@ -392,33 +392,50 @@ describe('Bayn application composition', () => {
   test('starts a research-bound autonomous cycle without qualification evidence', async () => {
     const researchPlanHash = 'b'.repeat(64)
     let startedBindingId: string | undefined
+    let observedBindingId: string | undefined
 
     await Effect.runPromise(
       Effect.scoped(
         Effect.gen(function* () {
           const started = yield* Deferred.make<void>()
+          const observed = yield* Deferred.make<void>()
           const startCycle = ({ qualificationRunId }: AutonomousCycleStartupInput) =>
             Effect.sync(() => void (startedBindingId = qualificationRunId)).pipe(
               Effect.as(Deferred.succeed(started, undefined).pipe(Effect.andThen(Effect.never))),
             )
+          const researchCycleObservability = {
+            read: (bindingId: string) =>
+              Effect.sync(() => void (observedBindingId = bindingId)).pipe(
+                Effect.andThen(Deferred.succeed(observed, undefined)),
+                Effect.andThen(cycleObservability.read()),
+              ),
+          }
           const fiber = yield* runApplication(
-            { ...autonomousConfig(config), qualificationRunId: 'c'.repeat(64) },
+            autonomousConfig(config),
             fixtureRuntime,
             {
               marketData: marketDataService(Effect.succeed(makeSnapshot())),
               journal: successfulJournal,
               evidenceStore: successfulEvidenceStore,
-              cycleObservability,
+              cycleObservability: researchCycleObservability,
             },
-            { _tag: 'AutonomousRead', broker, cycleBindingId: researchPlanHash, startCycle },
+            {
+              _tag: 'AutonomousRead',
+              broker,
+              cycleBindingId: researchPlanHash,
+              cycleObservationId: researchPlanHash,
+              startCycle,
+            },
           ).pipe(Effect.provide(HttpServerLive(config)), Effect.forkScoped)
           yield* Deferred.await(started).pipe(Effect.timeout('1 second'))
+          yield* Deferred.await(observed).pipe(Effect.timeout('1 second'))
           yield* Fiber.interrupt(fiber)
         }),
       ),
     )
 
     expect(startedBindingId).toBe(researchPlanHash)
+    expect(observedBindingId).toBe(researchPlanHash)
   })
 
   test('explicitly suppresses a pending research cycle despite recovered qualification evidence', async () => {

--- a/services/bayn/src/app.ts
+++ b/services/bayn/src/app.ts
@@ -96,6 +96,8 @@ export type ApplicationRuntime<StartupR, LoopR> =
       readonly brokerConfiguration?: BrokerConfiguration
       /** null explicitly suppresses cycles even when startup recovered historical qualification evidence. */
       readonly cycleBindingId?: string | null
+      /** Overrides startup qualification evidence when health observes a separately bound research cycle. */
+      readonly cycleObservationId?: string
       readonly startCycle: AutonomousCycleStartup<StartupR, LoopR>
       readonly resolveAfterStartup?: AutonomousRuntimeResolver<StartupR, LoopR>
     }
@@ -103,6 +105,7 @@ export type ApplicationRuntime<StartupR, LoopR> =
       readonly _tag: 'AutonomousMutation'
       readonly broker: BrokerProbe
       readonly cycleBindingId?: string | null
+      readonly cycleObservationId?: string
       readonly executionProgram: ExecutionProgram
       readonly startCycle: AutonomousCycleStartup<StartupR, LoopR>
     }
@@ -249,7 +252,16 @@ export const runApplication = <StartupR, LoopR>(
     Effect.bind('autonomousCycleFiber', ({ state, resolvedRuntime }) => startAutonomousCycle(resolvedRuntime, state)),
     Effect.tap(({ autonomousCycleFiber, resolvedRuntime, state }) =>
       pipe(
-        runHealthMonitor(config, state, dependencies, brokerProbe(resolvedRuntime), autonomousCycleFiber),
+        runHealthMonitor(
+          config,
+          state,
+          dependencies,
+          brokerProbe(resolvedRuntime),
+          autonomousCycleFiber,
+          resolvedRuntime._tag === 'Brokerless'
+            ? undefined
+            : (resolvedRuntime.cycleObservationId ?? resolvedRuntime.cycleBindingId ?? undefined),
+        ),
         Effect.forkScoped({ startImmediately: true }),
       ),
     ),

--- a/services/bayn/src/composition.ts
+++ b/services/bayn/src/composition.ts
@@ -1217,7 +1217,7 @@ const runAutonomousService = (plan: ApplicationPlanFor<'AutonomousService'>) =>
                           _tag: 'AutonomousRead' as const,
                           broker: runtimeBroker(observePlan, runtimeServices.session.read, false),
                           ...(request !== null && isResearchPaperActivationRequest(request)
-                            ? { cycleBindingId: null }
+                            ? { cycleBindingId: null, cycleObservationId: request.grant.planHash }
                             : {}),
                           startCycle: readStartCycle,
                         })
@@ -1390,6 +1390,8 @@ const runAutonomousService = (plan: ApplicationPlanFor<'AutonomousService'>) =>
                                     strategy: observePlan.strategy,
                                     strategyProtocolHash: observePlan.strategyProtocolHash,
                                   }) as ApplicationPlanFor<'AutonomousService'>
+                                  const paperGrant = paperGrantFromGeneration(prepared.generation)
+                                  const cycleBindingId = paperGrantKey(paperGrant)
                                   const emitClosedCycleReceipt = makeClosedCycleReceiptEmitter(
                                     realizedPlan.config,
                                     runtimeServices.pgClient,
@@ -1448,7 +1450,7 @@ const runAutonomousService = (plan: ApplicationPlanFor<'AutonomousService'>) =>
                                         state,
                                         request,
                                         prepared.generation.generationHash,
-                                        paperGrantFromGeneration(prepared.generation)._tag,
+                                        paperGrant._tag,
                                       ),
                                     ),
                                     Effect.tap(() =>
@@ -1473,7 +1475,8 @@ const runAutonomousService = (plan: ApplicationPlanFor<'AutonomousService'>) =>
                                     Effect.map((executionProgram) => ({
                                       _tag: 'AutonomousMutation' as const,
                                       broker: runtimeBroker(realizedPlan, runtimeServices.session.read, true),
-                                      cycleBindingId: paperGrantKey(paperGrantFromGeneration(prepared.generation)),
+                                      cycleBindingId,
+                                      cycleObservationId: cycleBindingId,
                                       executionProgram,
                                       startCycle: (startup: AutonomousCycleStartupInput) =>
                                         mutationCycle(

--- a/services/bayn/src/health.test.ts
+++ b/services/bayn/src/health.test.ts
@@ -57,9 +57,12 @@ const probe = (
   state: Ref.Ref<RuntimeState>,
   broker?: BrokerProbe,
   cycleFiber?: Fiber.Fiber<void, never>,
+  cycleObservationId?: string,
 ) =>
   testHealthDependencies.pipe(
-    Effect.flatMap((dependencies) => checkHealth(runtimeConfig, state, dependencies, broker, cycleFiber)),
+    Effect.flatMap((dependencies) =>
+      checkHealth(runtimeConfig, state, dependencies, broker, cycleFiber, cycleObservationId),
+    ),
   )
 
 const monitor = (
@@ -836,6 +839,54 @@ describe('Bayn continuous health', () => {
 
     expect(transition.next.cycle.reason).not.toBe(CycleOperationsReason.AuthorityMaximumMismatch)
     expect(transition.next.cycle.alerts.authorityIncoherent).toBe(false)
+  })
+
+  test('observes a research cycle binding when startup evidence is unavailable', async () => {
+    const researchPlanHash = 'b'.repeat(64)
+    const initial: RuntimeState = { ...readyState(), evidence: null }
+    const observedBindings: string[] = []
+    const projection = {
+      ...emptyCycleProjection(),
+      current: pendingCycle('2026-07-20T00:00:00.000Z'),
+      unfinishedCycleCount: 1,
+    }
+    const program = Effect.gen(function* () {
+      yield* TestClock.setTime(Date.parse('2026-07-20T00:00:00.000Z'))
+      const state = yield* Ref.make(initial)
+      yield* probe(config, state, undefined, undefined, researchPlanHash).pipe(
+        Effect.provideService(MarketData, {
+          check: Effect.succeed(makeSnapshot().manifest.finalizedSnapshot),
+          inspect: Effect.die(new Error('health probes must not inspect sessions')),
+          inspectCyclePublications: Effect.die(
+            new Error('health probes must not inspect cycle publication candidates'),
+          ),
+          inspectPublication: () => Effect.die(new Error('health probes must not inspect cycle publications')),
+          inspectSnapshotPublication: () =>
+            Effect.die(new Error('health probes must not inspect bound cycle publications')),
+          loadSnapshotPublication: () => Effect.die(new Error('health probes must not load bound cycle bars')),
+          load: Effect.die(new Error('health probes must not load bars')),
+        }),
+        Effect.provideService(Journal, successfulJournal),
+        Effect.provideService(EvidenceStore, recoveringStore(readyState())),
+        Effect.provideService(
+          CycleObservability,
+          cycleObservability((bindingId) =>
+            Effect.sync(() => {
+              observedBindings.push(bindingId)
+              return projection
+            }),
+          ),
+        ),
+      )
+
+      expect(observedBindings).toEqual([researchPlanHash])
+      expect(yield* Ref.get(state)).toMatchObject({
+        health: { dependencies: { cycle: { status: 'AVAILABLE', error: null } } },
+        cycle: { current: { cycleId: projection.current.cycleId }, unfinishedCycleCount: 1 },
+      })
+    }).pipe(Effect.provide(TestClock.layer()))
+
+    await Effect.runPromise(program)
   })
 
   test('does not manufacture a cycle-runner stall from a rejected finite clock', () => {

--- a/services/bayn/src/health.test.ts
+++ b/services/bayn/src/health.test.ts
@@ -783,6 +783,61 @@ describe('Bayn continuous health', () => {
     expect(transition.next.cycle.alerts.authorityIncoherent).toBe(false)
   })
 
+  test('projects a realized research PAPER episode through its read-only bootstrap config', () => {
+    const checkedAt = '2026-08-05T12:00:00.000Z'
+    const current: RuntimeState = {
+      ...readyState(),
+      paperActivation: {
+        _tag: 'Realized',
+        requestHash: 'a'.repeat(64),
+        generationHash: 'b'.repeat(64),
+        grant: 'Research',
+        cutoffAt: '2026-09-01T13:30:00.000Z',
+        expiresAt: '2026-09-03T20:00:00.000Z',
+        maximumCloseSessions: 3,
+      },
+    }
+    const transition = deriveHealthTransition(current, {
+      config,
+      evidenceAvailable: true,
+      results: {
+        postgresql: { _tag: 'Available', value: undefined },
+        signal: { _tag: 'Available', value: undefined },
+        tigerBeetle: { _tag: 'Available', value: undefined },
+        durableEvidence: { _tag: 'Available', value: undefined },
+        cycle: {
+          _tag: 'Available',
+          value: {
+            ...emptyCycleProjection(),
+            authority: {
+              generationHash: 'b'.repeat(64),
+              maximum: Authority.Paper,
+              effective: Authority.Paper,
+              kill: KillState.Clear,
+              reason: null,
+              updatedAt: checkedAt,
+            },
+            reconciliation: {
+              accountId: brokerAccountId,
+              reconciliationId: 'c'.repeat(64),
+              status: ReconciliationStatus.Exact,
+              discrepancyCount: 0,
+              reconciledAt: checkedAt,
+              coversLatestMutation: true,
+            },
+          },
+        },
+        broker: null,
+      },
+      broker: undefined,
+      cycleFiber: { _tag: 'NotProvided' },
+      clock: availableClock(checkedAt),
+    })
+
+    expect(transition.next.cycle.reason).not.toBe(CycleOperationsReason.AuthorityMaximumMismatch)
+    expect(transition.next.cycle.alerts.authorityIncoherent).toBe(false)
+  })
+
   test('does not manufacture a cycle-runner stall from a rejected finite clock', () => {
     const progressAt = '2026-07-20T00:00:00.000Z'
     const current: RuntimeState = {

--- a/services/bayn/src/health/decisions.ts
+++ b/services/bayn/src/health/decisions.ts
@@ -11,6 +11,7 @@ import {
   type CycleOperationsStatus,
   unknownCycleOperationsStatus,
 } from '../cycle-observability'
+import { Authority } from '../execution/contracts'
 import type { QualificationRecord, RecoveredEvaluationEvidence } from '../db/evidence-store'
 import { canonicalHashV1Result, renderCanonicalJsonFailure } from '../hash'
 import type {
@@ -258,6 +259,7 @@ const deriveBrokerStatus = (
 const deriveCycleStatus = (
   result: ProbeResult<CycleOperationsProjection>,
   config: RuntimeConfig,
+  runtime: RuntimeState,
   clock: HealthProbeClock,
 ): CycleOperationsStatus => {
   const clockError =
@@ -274,7 +276,9 @@ const deriveCycleStatus = (
       deriveCycleOperationsStatusResult(
         result.value,
         clock.checkedAtMs,
-        historicalSandboxAuthority(config.execution),
+        runtime.paperActivation?._tag === 'Realized' || runtime.paperActivation?._tag === 'Completed'
+          ? Authority.Paper
+          : historicalSandboxAuthority(config.execution),
         config,
       ),
       {
@@ -383,7 +387,7 @@ export const deriveHealthTransition = (current: RuntimeState, input: HealthTrans
     input.broker !== undefined,
   )
   const cycleObservation = publicCycleObservation(input.results.cycle)
-  const cycle = deriveCycleStatus(cycleObservation, input.config, input.clock)
+  const cycle = deriveCycleStatus(cycleObservation, input.config, current, input.clock)
   const broker = deriveBrokerStatus(current.broker, input.broker, input.results.broker, checkedAt)
   const health = deriveRuntimeHealth(current, { ...input.results, cycle: cycleObservation }, cycleRunner, checkedAt)
   const failures = summarizeHealthFailures(health, broker, cycle, clockError)

--- a/services/bayn/src/health/program.ts
+++ b/services/bayn/src/health/program.ts
@@ -207,6 +207,7 @@ const collectHealthProbeResults = (
   evidenceStore: HealthDependencies['evidenceStore'],
   cycleObservability: HealthDependencies['cycleObservability'],
   broker: BrokerProbe | undefined,
+  cycleObservationId: string | undefined,
 ): Effect.Effect<HealthProbeResults, never> =>
   Effect.map(
     Effect.all(
@@ -260,7 +261,7 @@ const collectHealthProbeResults = (
             ? Effect.fail(operationalError('database', 'cycle-observability', 'startup evidence is unavailable'))
             : withinDeadline(
                 databaseOperation(
-                  cycleObservability.read(evidence.evaluation.runId, broker?.expectedAccountId),
+                  cycleObservability.read(cycleObservationId ?? evidence.evaluation.runId, broker?.expectedAccountId),
                   'cycle-observability',
                 ),
                 config.operationTimeoutMs,
@@ -288,6 +289,7 @@ export const checkHealth = (
   dependencies: HealthDependencies,
   broker?: BrokerProbe,
   autonomousCycleFiber?: Fiber.Fiber<void, never>,
+  cycleObservationId?: string,
 ): Effect.Effect<void> =>
   Effect.gen(function* () {
     const initial = yield* Ref.get(state)
@@ -299,6 +301,7 @@ export const checkHealth = (
       dependencies.evidenceStore,
       dependencies.cycleObservability,
       broker,
+      cycleObservationId,
     )
     const checkedAtMs = yield* Clock.currentTimeMillis
     const checkedAtResult = utcInstantFromEpochMillisResult(checkedAtMs)
@@ -327,8 +330,9 @@ export const runHealthMonitor = (
   dependencies: HealthDependencies,
   broker?: BrokerProbe,
   autonomousCycleFiber?: Fiber.Fiber<void, never>,
+  cycleObservationId?: string,
 ): Effect.Effect<void> =>
-  checkHealth(config, state, dependencies, broker, autonomousCycleFiber).pipe(
+  checkHealth(config, state, dependencies, broker, autonomousCycleFiber, cycleObservationId).pipe(
     Effect.repeat(Schedule.spaced(Duration.millis(config.healthIntervalMs))),
     Effect.asVoid,
   )

--- a/services/bayn/src/health/program.ts
+++ b/services/bayn/src/health/program.ts
@@ -208,8 +208,9 @@ const collectHealthProbeResults = (
   cycleObservability: HealthDependencies['cycleObservability'],
   broker: BrokerProbe | undefined,
   cycleObservationId: string | undefined,
-): Effect.Effect<HealthProbeResults, never> =>
-  Effect.map(
+): Effect.Effect<HealthProbeResults, never> => {
+  const cycleBindingId = cycleObservationId ?? evidence?.evaluation.runId
+  return Effect.map(
     Effect.all(
       [
         observe(
@@ -257,11 +258,11 @@ const collectHealthProbeResults = (
               ),
         ),
         observe(
-          evidence === null
+          cycleBindingId === undefined
             ? Effect.fail(operationalError('database', 'cycle-observability', 'startup evidence is unavailable'))
             : withinDeadline(
                 databaseOperation(
-                  cycleObservability.read(cycleObservationId ?? evidence.evaluation.runId, broker?.expectedAccountId),
+                  cycleObservability.read(cycleBindingId, broker?.expectedAccountId),
                   'cycle-observability',
                 ),
                 config.operationTimeoutMs,
@@ -282,6 +283,7 @@ const collectHealthProbeResults = (
       broker: brokerResult,
     }),
   )
+}
 
 export const checkHealth = (
   config: RuntimeConfig,


### PR DESCRIPTION
## Summary

- scope continuous cycle health to the resolved research-plan binding instead of unrelated startup qualification evidence
- project a realized or completed research PAPER episode against durable PAPER maximum authority while retaining read-only bootstrap configuration
- preserve explicit cycle-start suppression during receipt recovery while continuing to observe the bound episode
- add regressions for research cycle startup/health identity and OBSERVE-bootstrap/PAPER-authority coherence

## Related Issues

PROOMPT-405

## Testing

- `bun test services/bayn/src/app.test.ts services/bayn/src/health.test.ts services/bayn/src/composition.test.ts` (47 pass, 0 fail)
- `bun run --cwd services/bayn test` (1135 pass, 156 PostgreSQL-gated skips, 0 fail)
- `bun run --cwd services/bayn lint:effect` (0 errors)
- `bun run --cwd services/bayn lint:oxlint:type` (0 errors)
- `bun run --cwd services/bayn build`
- `bunx oxfmt --check services/bayn/src/app.ts services/bayn/src/app.test.ts services/bayn/src/composition.ts services/bayn/src/health/program.ts services/bayn/src/health/decisions.ts services/bayn/src/health.test.ts`
- Live reproduction on source `a322125791b5cd4cb485885c71117b0a978fa617`: research generation is durable PAPER/PAPER with exact reconciliation and zero mutations, while `/v1/status` incorrectly reports `AUTHORITY_MAXIMUM_MISMATCH` and omits the active research cycle.

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots section removed; no UI change. Breaking Changes is filled in.
- [x] Operational follow-up and live proof remain tracked in PROOMPT-405.
