### PR TITLE
fix(bayn): allow research paper bootstrap decisions

### DIFF
--- a/services/bayn/src/risk-balanced-trend.test.ts
+++ b/services/bayn/src/risk-balanced-trend.test.ts
@@ -484,19 +484,19 @@ describe('risk-balanced trend candidate', () => {
     })
   })
 
-  test('rejects a current decision outside the bound month-end cycle', () => {
+  test('compiles a same-month PAPER bootstrap decision while preserving binding validation', () => {
     const snapshot = makeSnapshot()
     const definition = makeRiskBalancedTrendDefinition(fixtureProtocol)
 
-    const notMonthEnd = compileCurrentRiskBalancedTrendDecision(
+    const bootstrap = compileCurrentRiskBalancedTrendDecision(
       snapshot.bars,
       snapshot.manifest,
       fixtureProtocol,
       currentDecisionBinding(snapshot.manifest.lastSession, ['2020-04-21', '2020-04-22', '2020-05-01']),
       definition,
     )
-    assert(Result.isFailure(notMonthEnd), 'same-month execution must fail')
-    expect(notMonthEnd.failure).toMatchObject({ _tag: 'CurrentDecisionNotMonthEnd' })
+    assert(Result.isSuccess(bootstrap), 'cycle admission, not strategy evaluation, owns cadence enforcement')
+    expect(bootstrap.success.decision.signalDate).toBe(snapshot.manifest.lastSession)
     const invalidBinding = compileCurrentRiskBalancedTrendDecision(
       snapshot.bars,
       snapshot.manifest,

--- a/services/bayn/src/risk-balanced-trend/model.ts
+++ b/services/bayn/src/risk-balanced-trend/model.ts
@@ -80,11 +80,6 @@ export type RiskBalancedTrendDomainFailure =
       readonly observedSession: IsoDate | null
     }
   | {
-      readonly _tag: 'CurrentDecisionNotMonthEnd'
-      readonly signalSession: IsoDate
-      readonly executionSession: IsoDate
-    }
-  | {
       readonly _tag: 'CurrentDecisionCoverageMismatch'
       readonly signalDate: IsoDate
       readonly expectedSymbols: readonly string[]
@@ -136,7 +131,6 @@ const domainFailureTags = new Set<RiskBalancedTrendDomainFailure['_tag']>([
   'SignalSessionMissing',
   'CurrentDecisionBindingDecodeFailed',
   'CurrentDecisionSessionMismatch',
-  'CurrentDecisionNotMonthEnd',
   'CurrentDecisionCoverageMismatch',
   'DecisionSchemaMismatch',
   'ManifestDecodeFailed',
@@ -184,8 +178,6 @@ const renderDomainFailure = (failure: RiskBalancedTrendDomainFailure): string =>
       return `current decision binding is invalid: ${failure.cause.message}`
     case 'CurrentDecisionSessionMismatch':
       return `current decision session ${failure.observedSession ?? 'missing'} does not match manifest/snapshot/binding ${failure.manifestSession}/${failure.snapshotSession}/${failure.bindingSession}`
-    case 'CurrentDecisionNotMonthEnd':
-      return `current decision signal ${failure.signalSession} and execution ${failure.executionSession} are in the same month`
     case 'CurrentDecisionCoverageMismatch':
       return `current decision covers ${failure.observedSymbols.join(',')}; expected ${failure.expectedSymbols.join(',')}`
     case 'DecisionSchemaMismatch':

--- a/services/bayn/src/strategy/risk-balanced-trend/current-decision.ts
+++ b/services/bayn/src/strategy/risk-balanced-trend/current-decision.ts
@@ -64,16 +64,6 @@ export const compileCurrentRiskBalancedTrendDecision = (
                   observedSession: terminalSession.date,
                 })
               }
-              if (
-                protocol.rebalance === 'month-end' &&
-                binding.signal.sessionDate.slice(0, 7) === binding.executionSession.date.slice(0, 7)
-              ) {
-                return fail({
-                  _tag: 'CurrentDecisionNotMonthEnd',
-                  signalSession: binding.signal.sessionDate,
-                  executionSession: binding.executionSession.date,
-                })
-              }
               return pipe(
                 Result.all({
                   decision: decisionFromAlignedSessions(sessions, sessions.length - 1, protocol, definition),


### PR DESCRIPTION
## Summary

- remove the strategy-level month-end rejection that contradicted the explicitly admitted PAPER bootstrap cadence
- keep monthly cadence enforcement at the cycle-admission boundary, where ordinary same-month publications remain not due
- add a regression proving a same-month bootstrap decision compiles while malformed and snapshot-divergent bindings still fail

## Related Issues

Relates to PROOMPT-405

## Testing

- `bun test services/bayn/src/risk-balanced-trend.test.ts services/bayn/src/cycle-runner.test.ts`
- `bun run --filter @proompteng/bayn test` (1136 pass, 156 skip, 0 fail)
- `bun run --filter @proompteng/bayn lint:effect`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bunx oxfmt --check services/bayn/src/strategy/risk-balanced-trend/current-decision.ts services/bayn/src/risk-balanced-trend/model.ts services/bayn/src/risk-balanced-trend.test.ts`
- `bun run --filter @proompteng/bayn build`

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.
