### PR TITLE
fix(bayn): rearm unused research paper episode

### DIFF
--- a/services/bayn/migrations/0029_unused_research_paper_rearm.ts
+++ b/services/bayn/migrations/0029_unused_research_paper_rearm.ts
@@ -1,0 +1,236 @@
+import { Effect } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient
+
+  yield* sql`
+    CREATE FUNCTION research_paper_rearm_eligible(
+      candidate_generation_hash text,
+      candidate_authority_version bigint,
+      candidate_activated_at timestamptz
+    )
+    RETURNS boolean
+    LANGUAGE sql
+    STABLE
+    AS $function$
+      SELECT EXISTS (
+        SELECT 1
+        FROM authority_state AS state
+        JOIN authority_generations AS previous_generation
+          ON previous_generation.generation_hash = state.generation_hash
+        JOIN authority_generations AS candidate_generation
+          ON candidate_generation.generation_hash = candidate_generation_hash
+        JOIN LATERAL (
+          SELECT reconciliation.*
+          FROM reconciliations AS reconciliation
+          WHERE reconciliation.account_id = previous_generation.account_id
+          ORDER BY reconciliation.reconciled_at DESC, reconciliation.reconciliation_id COLLATE "C" DESC
+          LIMIT 1
+        ) AS reconciliation ON true
+        WHERE state.singleton
+          AND state.maximum = 'PAPER'
+          AND state.effective = 'OBSERVE'
+          AND state.kill_state = 'ACTIVE'
+          AND state.reason LIKE 'PAPER autonomous cycle loop restricted effective authority:%'
+          AND state.version + 1 = candidate_authority_version
+          AND previous_generation.maximum = 'PAPER'
+          AND previous_generation.activation_schema_version = 'bayn.paper-authority-generation.v3'
+          AND previous_generation.proof_plan_hash IS NOT NULL
+          AND candidate_generation.previous_generation_hash = previous_generation.generation_hash
+          AND candidate_generation.maximum = 'OBSERVE'
+          AND candidate_generation.activation_schema_version IS NULL
+          AND candidate_generation.authority_version = candidate_authority_version
+          AND candidate_generation.activated_at = candidate_activated_at
+          AND candidate_generation.broker_identity_schema_version = previous_generation.broker_identity_schema_version
+          AND candidate_generation.broker_identity_hash = previous_generation.broker_identity_hash
+          AND candidate_generation.broker_provider = previous_generation.broker_provider
+          AND candidate_generation.broker_environment = 'sandbox'
+          AND candidate_generation.broker_environment = previous_generation.broker_environment
+          AND candidate_generation.account_id = previous_generation.account_id
+          AND reconciliation.status = 'EXACT'
+          AND reconciliation.expected_hash = reconciliation.observed_hash
+          AND jsonb_array_length(reconciliation.discrepancies) = 0
+          AND reconciliation.reconciled_at > state.updated_at
+          AND reconciliation.reconciled_at < candidate_activated_at
+          AND NOT EXISTS (
+            SELECT 1
+            FROM autonomous_cycles AS cycle
+            WHERE cycle.qualification_run_id = previous_generation.proof_plan_hash
+              AND cycle.account_id = previous_generation.account_id
+              AND cycle.state IN ('PENDING', 'ACTIVE')
+          )
+          AND NOT EXISTS (
+            SELECT 1
+            FROM intents AS intent
+            WHERE intent.authority_generation_hash = previous_generation.generation_hash
+          )
+      )
+    $function$
+  `
+
+  yield* sql`
+    CREATE OR REPLACE FUNCTION enforce_authority_transition()
+    RETURNS trigger
+    LANGUAGE plpgsql
+    AS $function$
+    BEGIN
+      IF TG_OP = 'DELETE' THEN
+        RAISE EXCEPTION 'authority state cannot be deleted' USING ERRCODE = '55000';
+      END IF;
+
+      IF TG_OP = 'INSERT' THEN
+        IF NEW.version <> 1
+          OR NEW.maximum <> 'OBSERVE'
+          OR NEW.effective <> 'OBSERVE'
+          OR NEW.kill_state <> 'CLEAR'
+          OR NEW.reason IS NOT NULL
+        THEN
+          RAISE EXCEPTION 'authority state must begin as clear OBSERVE at version 1'
+            USING ERRCODE = '23514';
+        END IF;
+        IF NOT EXISTS (
+          SELECT 1
+          FROM authority_generations AS generation
+          WHERE generation.generation_hash = NEW.generation_hash
+            AND generation.previous_generation_hash IS NULL
+            AND generation.maximum = 'OBSERVE'
+            AND generation.authority_version = 1
+            AND generation.activated_at = NEW.updated_at
+        ) THEN
+          RAISE EXCEPTION 'initial authority state lacks matching immutable OBSERVE history'
+            USING ERRCODE = '23514';
+        END IF;
+        RETURN NEW;
+      END IF;
+
+      IF NEW.singleton <> OLD.singleton
+        OR NEW.schema_version <> OLD.schema_version
+        OR NEW.version <> OLD.version + 1
+        OR NEW.updated_at <= OLD.updated_at
+      THEN
+        RAISE EXCEPTION 'invalid authority state version' USING ERRCODE = '23514';
+      END IF;
+
+      IF NEW.generation_hash = OLD.generation_hash THEN
+        IF NEW.maximum <> OLD.maximum
+          OR (OLD.effective = 'OBSERVE' AND NEW.effective = 'PAPER')
+          OR (OLD.kill_state = 'ACTIVE' AND NEW.kill_state = 'CLEAR')
+        THEN
+          RAISE EXCEPTION 'authority can only decrease within a GitOps generation' USING ERRCODE = '23514';
+        END IF;
+        RETURN NEW;
+      END IF;
+
+      IF NEW.kill_state IS DISTINCT FROM OLD.kill_state
+        OR NEW.reason IS DISTINCT FROM OLD.reason
+      THEN
+        IF NOT (
+          (
+            OLD.maximum = 'OBSERVE'
+            AND OLD.effective = 'OBSERVE'
+            AND OLD.kill_state = 'ACTIVE'
+            AND OLD.reason = 'reconciliation pass incomplete'
+            AND NEW.maximum = 'OBSERVE'
+            AND NEW.effective = 'OBSERVE'
+            AND NEW.kill_state = 'CLEAR'
+            AND NEW.reason IS NULL
+            AND EXISTS (
+              SELECT 1
+              FROM authority_generations AS generation
+              JOIN authority_generations AS previous_generation
+                ON previous_generation.generation_hash = OLD.generation_hash
+              JOIN LATERAL (
+                SELECT reconciliation.*
+                FROM reconciliations AS reconciliation
+                WHERE reconciliation.account_id = generation.account_id
+                ORDER BY reconciliation.reconciled_at DESC, reconciliation.reconciliation_id COLLATE "C" DESC
+                LIMIT 1
+              ) AS reconciliation ON true
+              WHERE generation.generation_hash = NEW.generation_hash
+                AND generation.previous_generation_hash = OLD.generation_hash
+                AND generation.maximum = 'OBSERVE'
+                AND generation.authority_version = NEW.version
+                AND generation.activated_at = NEW.updated_at
+                AND generation.broker_identity_schema_version = 'bayn.broker-identity.v2'
+                AND generation.broker_identity_hash IS NOT NULL
+                AND generation.account_id IS NOT NULL
+                AND (
+                  (
+                    previous_generation.broker_identity_schema_version = generation.broker_identity_schema_version
+                    AND previous_generation.broker_identity_hash = generation.broker_identity_hash
+                    AND previous_generation.broker_provider = generation.broker_provider
+                    AND previous_generation.broker_environment = generation.broker_environment
+                    AND previous_generation.account_id = generation.account_id
+                  )
+                  OR (
+                    generation.broker_provider = 'alpaca'
+                    AND generation.broker_environment = 'sandbox'
+                    AND previous_generation.generation_hash =
+                      'd290539ec85334d8ce267f98919c139cb382068101042d69b5433832136dc063'
+                    AND previous_generation.previous_generation_hash IS NULL
+                    AND previous_generation.maximum = 'OBSERVE'
+                    AND previous_generation.authority_version = 1
+                    AND previous_generation.broker_identity_schema_version IS NULL
+                    AND previous_generation.broker_identity_hash IS NULL
+                    AND previous_generation.broker_provider IS NULL
+                    AND previous_generation.broker_environment IS NULL
+                    AND previous_generation.account_id IS NULL
+                  )
+                )
+                AND reconciliation.status = 'EXACT'
+                AND reconciliation.expected_hash = reconciliation.observed_hash
+                AND jsonb_array_length(reconciliation.discrepancies) = 0
+                AND reconciliation.reconciled_at > OLD.updated_at
+                AND reconciliation.reconciled_at < NEW.updated_at
+                AND NOT EXISTS (
+                  SELECT 1
+                  FROM mutation_events AS mutation
+                  JOIN intents AS intent ON intent.intent_id = mutation.intent_id
+                  WHERE intent.account_id = generation.account_id
+                )
+            )
+          )
+          OR (
+            NEW.maximum = 'OBSERVE'
+            AND NEW.effective = 'OBSERVE'
+            AND NEW.kill_state = 'CLEAR'
+            AND NEW.reason IS NULL
+            AND research_paper_rearm_eligible(NEW.generation_hash, NEW.version, NEW.updated_at)
+          )
+        ) THEN
+          RAISE EXCEPTION 'authority generation changes must preserve kill state exactly'
+            USING ERRCODE = '23514';
+        END IF;
+      END IF;
+
+      IF NOT EXISTS (
+        SELECT 1
+        FROM authority_generations AS generation
+        WHERE generation.generation_hash = NEW.generation_hash
+          AND generation.previous_generation_hash = OLD.generation_hash
+          AND generation.maximum = NEW.maximum
+          AND generation.authority_version = NEW.version
+          AND generation.activated_at = NEW.updated_at
+      ) THEN
+        RAISE EXCEPTION 'authority generation change lacks matching immutable history'
+          USING ERRCODE = '23514';
+      END IF;
+
+      IF NEW.maximum = 'PAPER' THEN
+        IF OLD.maximum <> 'OBSERVE'
+          OR NEW.effective <> (
+            CASE WHEN NEW.kill_state = 'ACTIVE' THEN 'OBSERVE' ELSE 'PAPER' END
+          )
+        THEN
+          RAISE EXCEPTION 'invalid PAPER authority generation transition' USING ERRCODE = '23514';
+        END IF;
+      ELSIF NEW.effective <> 'OBSERVE' THEN
+        RAISE EXCEPTION 'OBSERVE generation must remain effectively OBSERVE' USING ERRCODE = '23514';
+      END IF;
+
+      RETURN NEW;
+    END
+    $function$
+  `
+})

--- a/services/bayn/src/composition.ts
+++ b/services/bayn/src/composition.ts
@@ -821,13 +821,36 @@ const prepareOrRecoverResearchPaperActivation = (
         maximum: authority.maximum,
         effective: authority.effective,
         kill: authority.kill,
+        ...(authority.reason === undefined ? {} : { reason: authority.reason }),
       }),
     ).pipe(
       Effect.mapError((cause) =>
         paperActivationOperationalError('research PAPER durable authority does not match this episode', cause),
       ),
     )
-    if (decision._tag === 'Activate') {
+    if (decision._tag === 'Rearm') {
+      const rearmed = yield* authorityStore
+        .ensureAuthorityGeneration({
+          generationHash: plan.config.alpaca.authorityGenerationHash,
+          maximum: Authority.Observe,
+        })
+        .pipe(
+          Effect.mapError((cause) =>
+            paperActivationOperationalError('research PAPER source authority rearm failed', cause),
+          ),
+        )
+      if (
+        rearmed.generationHash !== plan.config.alpaca.authorityGenerationHash ||
+        rearmed.maximum !== Authority.Observe ||
+        rearmed.effective !== Authority.Observe ||
+        rearmed.kill !== KillState.Clear
+      ) {
+        return yield* Effect.fail(
+          paperActivationOperationalError('research PAPER source authority rearm did not return clear OBSERVE'),
+        )
+      }
+    }
+    if (decision._tag !== 'Resume') {
       return yield* prepareResearchPaperActivation(plan, request, session, authorityStore, lifecycle, writerFence)
     }
     const generation = yield* readBoundPaperActivationGeneration(plan, request, authorityStore)

--- a/services/bayn/src/db/evidence-store.integration.test.ts
+++ b/services/bayn/src/db/evidence-store.integration.test.ts
@@ -1196,6 +1196,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
       { migration_id: 26, name: 'paper_cycle_close_replans' },
       { migration_id: 27, name: 'distinct_close_replan_intents' },
       { migration_id: 28, name: 'research_paper_grants' },
+      { migration_id: 29, name: 'unused_research_paper_rearm' },
     ])
   })
 

--- a/services/bayn/src/db/execution-store/observe-authority.ts
+++ b/services/bayn/src/db/execution-store/observe-authority.ts
@@ -274,18 +274,41 @@ export const makeObserveAuthorityInterpreter = (
             ON previous_generation.generation_hash = state.generation_hash
           LEFT JOIN latest_reconciliation AS reconciliation ON true
           WHERE state.singleton
+        ), research_rearm AS (
+          SELECT
+            state.maximum = 'PAPER'
+            AND state.effective = 'OBSERVE'
+            AND state.kill_state = 'ACTIVE'
+            AND state.reason LIKE 'PAPER autonomous cycle loop restricted effective authority:%'
+            AND previous_generation.activation_schema_version = 'bayn.paper-authority-generation.v3' AS candidate,
+            research_paper_rearm_eligible(
+              ${decision.generationHash},
+              ${decision.authorityVersion},
+              ${activatedAt}
+            ) AS eligible
+          FROM authority_state AS state
+          JOIN authority_generations AS previous_generation
+            ON previous_generation.generation_hash = state.generation_hash
+          WHERE state.singleton
         )
         UPDATE authority_state AS state
         SET
           generation_hash = ${decision.generationHash},
           maximum = ${decision.maximum},
           effective = 'OBSERVE',
-          kill_state = CASE WHEN recovery.eligible THEN 'CLEAR' ELSE state.kill_state END,
-          reason = CASE WHEN recovery.eligible THEN NULL ELSE state.reason END,
+          kill_state = CASE
+            WHEN recovery.eligible OR research_rearm.eligible THEN 'CLEAR'
+            ELSE state.kill_state
+          END,
+          reason = CASE
+            WHEN recovery.eligible OR research_rearm.eligible THEN NULL
+            ELSE state.reason
+          END,
           version = ${decision.authorityVersion},
           updated_at = ${activatedAt}
-        FROM recovery
+        FROM recovery, research_rearm
         WHERE state.singleton
+          AND (NOT research_rearm.candidate OR research_rearm.eligible)
         RETURNING
           state.schema_version, state.generation_hash, state.maximum, state.effective, state.kill_state, state.reason,
           state.version::text AS version, state.updated_at

--- a/services/bayn/src/db/migrations.ts
+++ b/services/bayn/src/db/migrations.ts
@@ -28,6 +28,7 @@ import forwardPerformanceReceipts from '../../migrations/0025_forward_performanc
 import paperCycleCloseReplans from '../../migrations/0026_paper_cycle_close_replans'
 import distinctCloseReplanIntents from '../../migrations/0027_distinct_close_replan_intents'
 import researchPaperGrants from '../../migrations/0028_research_paper_grants'
+import unusedResearchPaperRearm from '../../migrations/0029_unused_research_paper_rearm'
 
 export const migrationLoader = PgMigrator.fromRecord({
   '1_initial_schema': initialSchema,
@@ -58,4 +59,5 @@ export const migrationLoader = PgMigrator.fromRecord({
   '26_paper_cycle_close_replans': paperCycleCloseReplans,
   '27_distinct_close_replan_intents': distinctCloseReplanIntents,
   '28_research_paper_grants': researchPaperGrants,
+  '29_unused_research_paper_rearm': unusedResearchPaperRearm,
 })

--- a/services/bayn/src/db/paper-store.integration.test.ts
+++ b/services/bayn/src/db/paper-store.integration.test.ts
@@ -56,6 +56,7 @@ import {
 import { BrokerProvider, alpacaSandboxBaseUrl } from '../broker/alpaca'
 import { makeBrokerIdentity, type BrokerIdentity } from '../broker/identity'
 import { incompletePassReason } from '../simulation-reconciliation/broker-reconciler-model'
+import { paperEpisodeFailureRestrictionPrefix } from '../paper-episode'
 import { EvidenceStore, EvidenceStoreFromPostgres, PostgresClientLive } from './evidence-store'
 import {
   BrokerEventStore,
@@ -1986,6 +1987,136 @@ describePostgres('paper accounting persistence', () => {
         history_count: 1,
         research_plan_hash: expected.grant.planHash,
         strategy_protocol_hash: expected.strategyProtocolHash,
+      })
+    } finally {
+      await runtime.dispose()
+    }
+  }, 15_000)
+
+  test('rearms an unused failed research PAPER episode only after its cycle is terminal and reconciled', async () => {
+    const sourceGenerationHash = hash('research-paper-rearm-source')
+    const nextSourceGenerationHash = hash('research-paper-rearm-next-source')
+    const activationReconciliation = exactReconciliation('research-paper-rearm-activation')
+    const activation = makeResearchActivation(sourceGenerationHash, activationReconciliation)
+    const cycleId = hash('research-paper-rearm-cycle')
+    const runtime = makeStoreRuntime({ fail: false, planHashes: [] }, researchRuntimeConfig(sourceGenerationHash))
+    try {
+      const result = await runtime.runPromise(
+        Effect.gen(function* () {
+          const store = yield* ExecutionStore
+          const sql = yield* PgClient.PgClient
+          const activateResearch = store.activateResearchCapitalGrant
+          assert(activateResearch !== undefined, 'research PAPER activation must be implemented')
+
+          yield* seedExactReconciliation(activationReconciliation)
+          yield* store.ensureAuthorityGeneration({
+            generationHash: sourceGenerationHash,
+            maximum: Authority.Observe,
+          })
+          const activated = yield* activateResearch(researchProofBinding(activation))
+          const [restrictionTime] = yield* sql<{ updated_at: Date }>`
+            SELECT greatest(clock_timestamp(), updated_at + interval '1 millisecond') AS updated_at
+            FROM authority_state
+            WHERE singleton
+          `
+          if (restrictionTime === undefined) return yield* Effect.die(new Error('restriction time is unavailable'))
+          yield* store.restrictAuthority(
+            `${paperEpisodeFailureRestrictionPrefix} build-decision failed`,
+            restrictionTime.updated_at.toISOString(),
+          )
+
+          yield* sql`
+            WITH timing AS (
+              SELECT clock_timestamp() AS created_at, date_trunc('day', clock_timestamp()) AS day_start
+            )
+            INSERT INTO autonomous_cycles (
+              cycle_id, schema_version, identity_schema_version, strategy_name,
+              qualification_run_id, strategy_protocol_hash, account_id,
+              signal_session_date, signal_calendar_version,
+              execution_policy_schema_version, execution_policy_hash,
+              strategy_execution_model_hash, submission_window_ms,
+              submission_cutoff_before_open_ms, window_schema_version,
+              execution_calendar_schema_version, execution_calendar_source,
+              execution_calendar_hash, execution_session_date, signal_close_at,
+              publication_deadline_at, submission_open_at, execution_open_at,
+              execution_close_at, submission_cutoff_at, state, snapshot_id,
+              decision_hash, terminal_reason, state_version, created_at, updated_at, terminal_at
+            )
+            SELECT
+              ${cycleId}, 'bayn.autonomous-cycle.v1', 'bayn.autonomous-cycle-identity.v1',
+              'risk-balanced-trend', ${activation.grant.planHash}, ${activation.strategyProtocolHash}, ${accountId},
+              day_start::date, 'test-calendar-v1',
+              'bayn.autonomous-cycle-execution-policy.v1', ${hash('research-paper-rearm-policy')},
+              ${hash('research-paper-rearm-execution-model')}, 1800000, 1800000,
+              'bayn.autonomous-cycle-window.v1', 'bayn.alpaca-market-calendar-observation.v1',
+              'alpaca-v2-calendar', ${hash('research-paper-rearm-calendar')}, (day_start + interval '1 day')::date,
+              day_start + interval '20 hours', day_start + interval '1 day 12 hours 30 minutes',
+              day_start + interval '1 day 12 hours 30 minutes', day_start + interval '1 day 13 hours 30 minutes',
+              day_start + interval '1 day 15 hours', day_start + interval '1 day 13 hours',
+              'PENDING', NULL, NULL, NULL, 1, created_at, created_at, NULL
+            FROM timing
+          `
+          yield* seedExactReconciliation(exactReconciliation('research-paper-rearm-before-terminal'))
+          const beforePremature = yield* readAuthorityTupleEvidence
+          const premature = yield* Effect.flip(
+            store.ensureAuthorityGeneration({
+              generationHash: nextSourceGenerationHash,
+              maximum: Authority.Observe,
+            }),
+          )
+          const afterPremature = yield* readAuthorityTupleEvidence
+
+          yield* sql`
+            WITH timing AS (
+              SELECT greatest(clock_timestamp(), updated_at + interval '1 millisecond') AS terminal_at
+              FROM autonomous_cycles
+              WHERE cycle_id = ${cycleId}
+            )
+            UPDATE autonomous_cycles AS cycle
+            SET
+              state = 'BLOCKED',
+              terminal_reason = 'BLOCKED_AUTHORITY',
+              state_version = 2,
+              updated_at = timing.terminal_at,
+              terminal_at = timing.terminal_at
+            FROM timing
+            WHERE cycle.cycle_id = ${cycleId}
+          `
+          yield* seedExactReconciliation(exactReconciliation('research-paper-rearm-after-terminal'))
+          const rearmed = yield* store.ensureAuthorityGeneration({
+            generationHash: nextSourceGenerationHash,
+            maximum: Authority.Observe,
+          })
+          const [history] = yield* sql<{
+            maximum: Authority
+            previous_generation_hash: string | null
+          }>`
+            SELECT maximum, previous_generation_hash
+            FROM authority_generations
+            WHERE generation_hash = ${nextSourceGenerationHash}
+          `
+          return { activated, afterPremature, beforePremature, history, premature, rearmed }
+        }),
+      )
+
+      expect(result.activated).toMatchObject({
+        generationHash: activation.generationHash,
+        maximum: Authority.Paper,
+        effective: Authority.Paper,
+        kill: KillState.Clear,
+      })
+      expect(result.premature).toMatchObject({ operation: 'authority', failure: 'invariant' })
+      expect(result.afterPremature).toEqual(result.beforePremature)
+      expect(result.rearmed).toMatchObject({
+        generationHash: nextSourceGenerationHash,
+        maximum: Authority.Observe,
+        effective: Authority.Observe,
+        kill: KillState.Clear,
+      })
+      expect(result.rearmed.reason).toBeUndefined()
+      expect(result.history).toEqual({
+        maximum: Authority.Observe,
+        previous_generation_hash: activation.generationHash,
       })
     } finally {
       await runtime.dispose()

--- a/services/bayn/src/paper-episode.test.ts
+++ b/services/bayn/src/paper-episode.test.ts
@@ -186,7 +186,7 @@ describe('decidePaperEpisode', () => {
     expect(success(state, safeFacts())).toEqual({ _tag: 'RemainFailed', state })
   })
 
-  test('activates only from the exact OBSERVE source and resumes only clear effective PAPER authority', () => {
+  test('activates, rearms, and resumes only from their exact durable authority states', () => {
     const common = {
       sourceGenerationHash: 'a'.repeat(64),
     }
@@ -215,8 +215,30 @@ describe('decidePaperEpisode', () => {
         maximum: 'PAPER',
         effective: 'OBSERVE',
         kill: 'ACTIVE',
+        reason: 'PAPER autonomous cycle loop restricted effective authority: build-decision failed',
+      }),
+    ).toEqual(Result.succeed({ _tag: 'Rearm' }))
+  })
+
+  test('does not rearm an operator kill, an unchanged source generation, or unknown authority state', () => {
+    const common = {
+      generationHash: 'b'.repeat(64),
+      sourceGenerationHash: 'a'.repeat(64),
+      maximum: 'PAPER' as const,
+      effective: 'OBSERVE' as const,
+      kill: 'ACTIVE' as const,
+    }
+    expect(decidePaperEpisodeAuthority({ ...common, reason: 'operator kill' })).toEqual(
+      Result.fail({ _tag: 'IdentityDrift' }),
+    )
+    expect(
+      decidePaperEpisodeAuthority({
+        ...common,
+        sourceGenerationHash: common.generationHash,
+        reason: 'PAPER autonomous cycle loop restricted effective authority: build-decision failed',
       }),
     ).toEqual(Result.fail({ _tag: 'IdentityDrift' }))
+    expect(decidePaperEpisodeAuthority(common)).toEqual(Result.fail({ _tag: 'IdentityDrift' }))
   })
 
   test('rejects source-generation drift instead of activating over unknown OBSERVE history', () => {

--- a/services/bayn/src/paper-episode.ts
+++ b/services/bayn/src/paper-episode.ts
@@ -103,9 +103,15 @@ export interface PaperEpisodeAuthorityFacts {
   readonly maximum: 'OBSERVE' | 'PAPER'
   readonly effective: 'OBSERVE' | 'PAPER'
   readonly kill: 'CLEAR' | 'ACTIVE'
+  readonly reason?: string
 }
 
-export type PaperEpisodeAuthorityDecision = { readonly _tag: 'Activate' } | { readonly _tag: 'Resume' }
+export const paperEpisodeFailureRestrictionPrefix = 'PAPER autonomous cycle loop restricted effective authority:'
+
+export type PaperEpisodeAuthorityDecision =
+  | { readonly _tag: 'Activate' }
+  | { readonly _tag: 'Rearm' }
+  | { readonly _tag: 'Resume' }
 
 export const decidePaperEpisodeAuthority = (
   facts: PaperEpisodeAuthorityFacts,
@@ -120,6 +126,15 @@ export const decidePaperEpisodeAuthority = (
   }
   if (facts.maximum === 'PAPER' && facts.effective === 'PAPER' && facts.kill === 'CLEAR') {
     return Result.succeed({ _tag: 'Resume' })
+  }
+  if (
+    facts.maximum === 'PAPER' &&
+    facts.effective === 'OBSERVE' &&
+    facts.kill === 'ACTIVE' &&
+    facts.generationHash !== facts.sourceGenerationHash &&
+    facts.reason?.startsWith(paperEpisodeFailureRestrictionPrefix) === true
+  ) {
+    return Result.succeed({ _tag: 'Rearm' })
   }
   return Result.fail({ _tag: 'IdentityDrift' })
 }


### PR DESCRIPTION
## Summary

- Add one explicit `Rearm` decision for a failed, unused research PAPER episode when a different reviewed source generation is configured.
- Clear the fail-closed kill only when immutable research history, unchanged sandbox identity, zero generation-bound intents, no unfinished cycle, and fresh exact reconciliation all agree.
- Keep operator kills and every other authority restriction unchanged; a premature rearm rolls back the candidate generation and leaves authority/history byte-stable.

## Related Issues

PROOMPT-405

## Testing

- `bun test services/bayn/src/paper-episode.test.ts services/bayn/src/composition.test.ts` (23 pass, 0 fail)
- `env -u BAYN_TEST_POSTGRES_URL bun run --filter @proompteng/bayn test` (1,137 pass, 157 expected PostgreSQL skips, 0 fail)
- `BAYN_TEST_POSTGRES_URL=postgresql://bayn:bayn@127.0.0.1:5432/bayn_test bun run --filter @proompteng/bayn test:postgres` (all four PostgreSQL suites pass)
- `bun run --filter @proompteng/bayn lint:effect` (0 errors)
- `bun run --filter @proompteng/bayn lint:oxlint` (0 warnings, 0 errors)
- `bun run --filter @proompteng/bayn lint:oxlint:type` (0 warnings, 0 errors)
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn build`
- `bunx oxfmt --check` on all eight changed files

## Breaking Changes

None. Migration 29 preserves existing authority history and transition behavior, adding only the evidence-bound unused research PAPER rearm.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
