### PR TITLE
fix(bayn): promote research paper service images

### DIFF
--- a/.github/workflows/bayn-release.yml
+++ b/.github/workflows/bayn-release.yml
@@ -144,7 +144,7 @@ jobs:
               --strategy-parameter-hash "$strategy_parameter_hash" \
               --rollout-timestamp "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           )"
-          jq -e '(.promotionAction == "promote" or .promotionAction == "hold") and (.qualificationMode == "preserve" or .qualificationMode == "replace" or .qualificationMode == "install")' <<< "$promotion"
+          jq -e '(.promotionAction == "promote" or .promotionAction == "hold") and (.qualificationMode == "preserve" or .qualificationMode == "replace" or .qualificationMode == "install" or .qualificationMode == "research")' <<< "$promotion"
           {
             echo "promotion_action=$(jq -r '.promotionAction' <<< "$promotion")"
             echo "promotion_reason=$(jq -r '.promotionReason' <<< "$promotion")"
@@ -235,7 +235,9 @@ jobs:
             there is no schema fallback or automatic rename. `preserve` keeps the terminal run only when compiled
             behavior, protocol parameters, Signal inputs, TigerBeetle cluster ID, and TigerBeetle ledger all match.
             Replica addresses are transport and an explicit candidate may change them without relabeling qualification
-            evidence. `replace` removes an existing incompatible pin only for a fresh Signal snapshot. `install` is
+            evidence. `replace` removes an existing incompatible pin only for a fresh Signal snapshot. `research`
+            keeps qualification state absent while advancing an unchanged-strategy, unchanged-runtime research PAPER
+            service image; its build-bound activation request must be refreshed separately. `install` is
             available only to a controlled invocation that supplies the complete reviewed candidate runtime and exact
             independently accepted terminal run ID; automatic image promotion supplies neither and therefore never
             creates a pin. Installation can pin only the exact source, image digest, compiled strategy, and runtime

--- a/.github/workflows/bayn-release.yml
+++ b/.github/workflows/bayn-release.yml
@@ -236,8 +236,8 @@ jobs:
             behavior, protocol parameters, Signal inputs, TigerBeetle cluster ID, and TigerBeetle ledger all match.
             Replica addresses are transport and an explicit candidate may change them without relabeling qualification
             evidence. `replace` removes an existing incompatible pin only for a fresh Signal snapshot. `research`
-            keeps qualification state absent while advancing an unchanged-strategy, unchanged-runtime research PAPER
-            service image; its build-bound activation request must be refreshed separately. `install` is
+            keeps qualification state absent and holds a different source or image until the build-bound activation
+            request and image are refreshed together in a reviewed GitOps change. `install` is
             available only to a controlled invocation that supplies the complete reviewed candidate runtime and exact
             independently accepted terminal run ID; automatic image promotion supplies neither and therefore never
             creates a pin. Installation can pin only the exact source, image digest, compiled strategy, and runtime

--- a/packages/scripts/src/bayn/update-manifests.test.ts
+++ b/packages/scripts/src/bayn/update-manifests.test.ts
@@ -37,6 +37,7 @@ interface FixtureOptions {
   readonly behaviorHash?: string
   readonly parameterHash?: string
   readonly qualificationRunId?: string | null
+  readonly paperActivationRequest?: boolean
 }
 
 interface FixturePaths {
@@ -77,6 +78,9 @@ const makeFixture = (options: FixtureOptions = {}): FixturePaths => {
     environmentBlock('BAYN_STRATEGY_BEHAVIOR_HASH', options.behaviorHash ?? strategyBehaviorHash),
     environmentBlock('BAYN_STRATEGY_PARAMETER_HASH', options.parameterHash ?? strategyParameterHash),
     pin === null ? '' : environmentBlock('BAYN_QUALIFICATION_RUN_ID', pin),
+    options.paperActivationRequest === true
+      ? '            - name: BAYN_PAPER_ACTIVATION_REQUEST\n              valueFrom:\n                secretKeyRef:\n                  name: bayn-alpaca-auth\n                  key: paper-activation-request\n'
+      : '',
     ...Object.entries(bindings).map(([name, value]) => environmentBlock(name, value)),
   ].join('')
 
@@ -318,6 +322,62 @@ describe('Bayn manifest promotion', () => {
     )
     expect(Object.values(paths).map((path) => readFileSync(path, 'utf8'))).toEqual(before)
     expect(readFileSync(paths.deploymentPath, 'utf8')).not.toContain('BAYN_QUALIFICATION_RUN_ID')
+  })
+
+  test('promotes source-only changes for a research PAPER activation without weakening candidate immutability', () => {
+    const paths = makeFixture({ qualificationRunId: null, paperActivationRequest: true })
+
+    expect(promote(paths)).toMatchObject({
+      promotionAction: 'promote',
+      promotionReason: 'eligible',
+      qualificationMode: 'research',
+      hadQualificationPin: false,
+      qualificationBindingsMatch: true,
+      snapshotChanged: false,
+    })
+    expect(readFileSync(paths.deploymentPath, 'utf8')).toContain(
+      `- name: BAYN_CODE_REVISION\n              value: ${'a'.repeat(40)}`,
+    )
+    expect(readFileSync(paths.deploymentPath, 'utf8')).toContain(
+      `- name: BAYN_IMAGE_DIGEST\n              value: sha256:${'b'.repeat(64)}`,
+    )
+    expect(readFileSync(paths.deploymentPath, 'utf8')).toContain('BAYN_PAPER_ACTIVATION_REQUEST')
+    expect(readFileSync(paths.deploymentPath, 'utf8')).not.toContain('BAYN_QUALIFICATION_RUN_ID')
+  })
+
+  test('keeps research PAPER strategy and runtime identity immutable across a service release', () => {
+    const paths = makeFixture({ qualificationRunId: null, paperActivationRequest: true })
+    const before = Object.values(paths).map((path) => readFileSync(path, 'utf8'))
+
+    expect(() => promote(paths, { strategyParameterHash: '6'.repeat(64) })).toThrow(
+      'a research PAPER release cannot change strategy or runtime identity',
+    )
+    expect(() =>
+      promote(paths, {
+        candidateRuntime: {
+          ...currentBindings,
+          BAYN_SIGNAL_SNAPSHOT_ID: '5'.repeat(64),
+        },
+      }),
+    ).toThrow('a research PAPER release cannot change strategy or runtime identity')
+    expect(Object.values(paths).map((path) => readFileSync(path, 'utf8'))).toEqual(before)
+  })
+
+  test('does not install a qualification pin through an existing PAPER activation request', () => {
+    const paths = makeFixture({ qualificationRunId: null, paperActivationRequest: true })
+    const before = Object.values(paths).map((path) => readFileSync(path, 'utf8'))
+
+    expect(() =>
+      promote(
+        paths,
+        {
+          acceptedQualificationRunId: '8'.repeat(64),
+          digest: `sha256:${'0'.repeat(64)}`,
+        },
+        '0'.repeat(40),
+      ),
+    ).toThrow('qualification installation cannot reuse a configured PAPER activation request')
+    expect(Object.values(paths).map((path) => readFileSync(path, 'utf8'))).toEqual(before)
   })
 
   test('rejects installing an accepted run while replacing a pinned runtime', () => {

--- a/packages/scripts/src/bayn/update-manifests.test.ts
+++ b/packages/scripts/src/bayn/update-manifests.test.ts
@@ -324,25 +324,32 @@ describe('Bayn manifest promotion', () => {
     expect(readFileSync(paths.deploymentPath, 'utf8')).not.toContain('BAYN_QUALIFICATION_RUN_ID')
   })
 
-  test('promotes source-only changes for a research PAPER activation without weakening candidate immutability', () => {
+  test('holds source-only research PAPER changes until the build-bound activation request is refreshed', () => {
     const paths = makeFixture({ qualificationRunId: null, paperActivationRequest: true })
+    const before = Object.values(paths).map((path) => readFileSync(path, 'utf8'))
 
     expect(promote(paths)).toMatchObject({
-      promotionAction: 'promote',
-      promotionReason: 'eligible',
+      promotionAction: 'hold',
+      promotionReason: 'research-paper-activation-refresh-required',
       qualificationMode: 'research',
       hadQualificationPin: false,
       qualificationBindingsMatch: true,
       snapshotChanged: false,
     })
-    expect(readFileSync(paths.deploymentPath, 'utf8')).toContain(
-      `- name: BAYN_CODE_REVISION\n              value: ${'a'.repeat(40)}`,
-    )
-    expect(readFileSync(paths.deploymentPath, 'utf8')).toContain(
-      `- name: BAYN_IMAGE_DIGEST\n              value: sha256:${'b'.repeat(64)}`,
-    )
-    expect(readFileSync(paths.deploymentPath, 'utf8')).toContain('BAYN_PAPER_ACTIVATION_REQUEST')
-    expect(readFileSync(paths.deploymentPath, 'utf8')).not.toContain('BAYN_QUALIFICATION_RUN_ID')
+    expect(Object.values(paths).map((path) => readFileSync(path, 'utf8'))).toEqual(before)
+  })
+
+  test('makes an exact research PAPER release replay a no-op', () => {
+    const paths = makeFixture({ qualificationRunId: null, paperActivationRequest: true })
+    const before = Object.values(paths).map((path) => readFileSync(path, 'utf8'))
+
+    expect(promote(paths, { digest: `sha256:${'0'.repeat(64)}` }, '0'.repeat(40))).toMatchObject({
+      promotionAction: 'promote',
+      promotionReason: 'eligible',
+      qualificationMode: 'research',
+      hadQualificationPin: false,
+    })
+    expect(Object.values(paths).map((path) => readFileSync(path, 'utf8'))).toEqual(before)
   })
 
   test('keeps research PAPER strategy and runtime identity immutable across a service release', () => {

--- a/packages/scripts/src/bayn/update-manifests.ts
+++ b/packages/scripts/src/bayn/update-manifests.ts
@@ -43,7 +43,10 @@ export interface UpdateBaynManifestOptions {
 
 export interface BaynManifestUpdate {
   readonly promotionAction: 'promote' | 'hold'
-  readonly promotionReason: 'eligible' | 'strategy-identity-change-requires-fresh-snapshot'
+  readonly promotionReason:
+    | 'eligible'
+    | 'strategy-identity-change-requires-fresh-snapshot'
+    | 'research-paper-activation-refresh-required'
   readonly qualificationMode: 'preserve' | 'replace' | 'install' | 'research'
   readonly hadQualificationPin: boolean
   readonly qualificationBindingsMatch: boolean
@@ -238,6 +241,7 @@ export const updateBaynManifests = (options: UpdateBaynManifestOptions): BaynMan
   )
   const strategyIdentityMatches =
     deployedBehaviorHash === options.strategyBehaviorHash && deployedParameterHash === options.strategyParameterHash
+  const activationBuildMatches = deployedSourceSha === options.sourceSha && deployedImageDigest === options.digest
   const acceptedQualificationRunId = options.acceptedQualificationRunId
   const acceptedRunAlreadyPinned =
     acceptedQualificationRunId !== undefined && deployedQualificationRunId === acceptedQualificationRunId
@@ -272,10 +276,7 @@ export const updateBaynManifests = (options: UpdateBaynManifestOptions): BaynMan
     !hadQualificationPin && !hasPaperActivationRequest && acceptedQualificationRunId === undefined
   if (
     unpinnedCandidateReplay &&
-    (deployedSourceSha !== options.sourceSha ||
-      deployedImageDigest !== options.digest ||
-      !strategyIdentityMatches ||
-      !candidateRuntimeMatchesDeployment)
+    (!activationBuildMatches || !strategyIdentityMatches || !candidateRuntimeMatchesDeployment)
   ) {
     throw new Error('an unpinned qualification candidate is immutable until its terminal run is pinned')
   }
@@ -318,10 +319,17 @@ export const updateBaynManifests = (options: UpdateBaynManifestOptions): BaynMan
       ...updateDetails,
     }
   }
+  if (researchPaperRelease && !activationBuildMatches) {
+    return {
+      promotionAction: 'hold',
+      promotionReason: 'research-paper-activation-refresh-required',
+      ...updateDetails,
+    }
+  }
   if (qualificationMode === 'replace' && hadQualificationPin && !snapshotChanged) {
     throw new Error('qualification replacement requires a fresh BAYN_SIGNAL_SNAPSHOT_ID')
   }
-  if (unpinnedCandidateReplay) {
+  if (researchPaperRelease || unpinnedCandidateReplay) {
     return {
       promotionAction: 'promote',
       promotionReason: 'eligible',

--- a/packages/scripts/src/bayn/update-manifests.ts
+++ b/packages/scripts/src/bayn/update-manifests.ts
@@ -44,7 +44,7 @@ export interface UpdateBaynManifestOptions {
 export interface BaynManifestUpdate {
   readonly promotionAction: 'promote' | 'hold'
   readonly promotionReason: 'eligible' | 'strategy-identity-change-requires-fresh-snapshot'
-  readonly qualificationMode: 'preserve' | 'replace' | 'install'
+  readonly qualificationMode: 'preserve' | 'replace' | 'install' | 'research'
   readonly hadQualificationPin: boolean
   readonly qualificationBindingsMatch: boolean
   readonly snapshotChanged: boolean
@@ -75,6 +75,7 @@ const environmentValue = (deployment: string, name: string): string => {
 }
 
 const qualificationPin = /            - name: BAYN_QUALIFICATION_RUN_ID\n              value: [^\n]+\n/
+const paperActivationRequest = /            - name: BAYN_PAPER_ACTIVATION_REQUEST\n/
 const qualificationIdentityNames = [
   'BAYN_SIGNAL_SNAPSHOT_ID',
   'BAYN_SIGNAL_PUBLICATION_ASOF',
@@ -157,7 +158,7 @@ const validateCandidateRuntime = (runtime: BaynCandidateRuntime): void => {
 
 const transitionQualificationPin = (
   deployment: string,
-  mode: 'preserve' | 'replace' | 'install',
+  mode: BaynManifestUpdate['qualificationMode'],
   hadQualificationPin: boolean,
   acceptedQualificationRunId: string | undefined,
 ): string => {
@@ -166,6 +167,12 @@ const transitionQualificationPin = (
     return deployment
   }
   if (mode === 'replace') return hadQualificationPin ? deployment.replace(qualificationPin, '') : deployment
+  if (mode === 'research') {
+    if (hadQualificationPin || acceptedQualificationRunId !== undefined) {
+      throw new Error('research PAPER release cannot carry qualification state')
+    }
+    return deployment
+  }
   if (acceptedQualificationRunId === undefined) {
     throw new Error('cannot install a missing accepted qualification run ID')
   }
@@ -204,6 +211,9 @@ export const updateBaynManifests = (options: UpdateBaynManifestOptions): BaynMan
   const qualificationPins = [...deployment.matchAll(new RegExp(qualificationPin.source, 'g'))]
   if (qualificationPins.length > 1) throw new Error('expected at most one BAYN_QUALIFICATION_RUN_ID block')
   const hadQualificationPin = qualificationPins.length === 1
+  const paperActivationRequests = [...deployment.matchAll(new RegExp(paperActivationRequest.source, 'g'))]
+  if (paperActivationRequests.length > 1) throw new Error('expected at most one BAYN_PAPER_ACTIVATION_REQUEST block')
+  const hasPaperActivationRequest = paperActivationRequests.length === 1
   const deployedQualificationRunId = hadQualificationPin
     ? environmentValue(deployment, 'BAYN_QUALIFICATION_RUN_ID')
     : null
@@ -238,6 +248,9 @@ export const updateBaynManifests = (options: UpdateBaynManifestOptions): BaynMan
     throw new Error('an accepted qualification pin cannot be rebound to different strategy or runtime identity')
   }
   if (acceptedQualificationRunId !== undefined && !acceptedRunAlreadyPinned) {
+    if (hasPaperActivationRequest) {
+      throw new Error('qualification installation cannot reuse a configured PAPER activation request')
+    }
     if (hadQualificationPin) {
       throw new Error('qualification installation requires an already-deployed unpinned runtime')
     }
@@ -250,7 +263,13 @@ export const updateBaynManifests = (options: UpdateBaynManifestOptions): BaynMan
       throw new Error('qualification installation must pin the exact deployed source, image, strategy, and runtime')
     }
   }
-  const unpinnedCandidateReplay = !hadQualificationPin && acceptedQualificationRunId === undefined
+  const researchPaperRelease =
+    !hadQualificationPin && hasPaperActivationRequest && acceptedQualificationRunId === undefined
+  if (researchPaperRelease && (!strategyIdentityMatches || !candidateRuntimeMatchesDeployment)) {
+    throw new Error('a research PAPER release cannot change strategy or runtime identity')
+  }
+  const unpinnedCandidateReplay =
+    !hadQualificationPin && !hasPaperActivationRequest && acceptedQualificationRunId === undefined
   if (
     unpinnedCandidateReplay &&
     (deployedSourceSha !== options.sourceSha ||
@@ -261,7 +280,9 @@ export const updateBaynManifests = (options: UpdateBaynManifestOptions): BaynMan
     throw new Error('an unpinned qualification candidate is immutable until its terminal run is pinned')
   }
   let qualificationMode: BaynManifestUpdate['qualificationMode']
-  if (acceptedQualificationRunId !== undefined && !acceptedRunAlreadyPinned) {
+  if (researchPaperRelease) {
+    qualificationMode = 'research'
+  } else if (acceptedQualificationRunId !== undefined && !acceptedRunAlreadyPinned) {
     qualificationMode = 'install'
   } else if (hadQualificationPin && strategyIdentityMatches && qualificationBindingsMatch) {
     qualificationMode = 'preserve'


### PR DESCRIPTION
## Summary

- distinguish an active research PAPER deployment from an unpinned qualification candidate during image promotion
- hold any different research source/image until its build-bound activation request is refreshed in the same reviewed GitOps change
- retain the qualification-candidate freeze, reject mixed research/qualification installation, and make exact research release replays no-ops

## Related Issues

PROOMPT-405

## Testing

- `bun test packages/scripts/src/bayn` (146 passed)
- `bun run --filter @proompteng/scripts lint` (passed; three pre-existing warnings outside this change)
- `bunx oxlint --config .oxlintrc.json --type-aware --tsconfig packages/scripts/tsconfig.json packages/scripts/src/bayn/update-manifests.ts packages/scripts/src/bayn/update-manifests.test.ts`
- `actionlint .github/workflows/bayn-release.yml`
- reproduced release run 31011587900 inputs against temporary copies of the current manifests; result was `promotionAction=hold`, `promotionReason=research-paper-activation-refresh-required`, `qualificationMode=research`, with all three GitOps files byte-identical

## Breaking Changes

None. The internal release-decision output adds `qualificationMode=research`; the sole workflow consumer accepts and documents it. A different research build is deliberately held until a separately reviewed activation PR updates the image and build-bound activation request together.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] The release workflow documents the research hold and activation-refresh boundary.