### PR TITLE
fix(bayn): skip qualification startup for research paper

### DIFF
--- a/services/bayn/src/app.test.ts
+++ b/services/bayn/src/app.test.ts
@@ -393,6 +393,8 @@ describe('Bayn application composition', () => {
     const researchPlanHash = 'b'.repeat(64)
     let startedBindingId: string | undefined
     let observedBindingId: string | undefined
+    let startupMarketDataLoads = 0
+    let startupQualificationOpens = 0
 
     await Effect.runPromise(
       Effect.scoped(
@@ -414,13 +416,26 @@ describe('Bayn application composition', () => {
             autonomousConfig(config),
             fixtureRuntime,
             {
-              marketData: marketDataService(Effect.succeed(makeSnapshot())),
+              marketData: marketDataService(
+                Effect.sync(() => {
+                  startupMarketDataLoads += 1
+                  return makeSnapshot()
+                }),
+              ),
               journal: successfulJournal,
-              evidenceStore: successfulEvidenceStore,
+              evidenceStore: {
+                ...successfulEvidenceStore,
+                openQualification: (request) =>
+                  Effect.sync(() => {
+                    startupQualificationOpens += 1
+                    return { state: 'ACQUIRED' as const, lock: request.lock }
+                  }),
+              },
               cycleObservability: researchCycleObservability,
             },
             {
               _tag: 'AutonomousRead',
+              startupEvidenceMode: 'Research',
               broker,
               cycleBindingId: researchPlanHash,
               cycleObservationId: researchPlanHash,
@@ -436,6 +451,8 @@ describe('Bayn application composition', () => {
 
     expect(startedBindingId).toBe(researchPlanHash)
     expect(observedBindingId).toBe(researchPlanHash)
+    expect(startupMarketDataLoads).toBe(0)
+    expect(startupQualificationOpens).toBe(0)
   })
 
   test('explicitly suppresses a pending research cycle despite recovered qualification evidence', async () => {

--- a/services/bayn/src/app.ts
+++ b/services/bayn/src/app.ts
@@ -92,6 +92,7 @@ export type ApplicationRuntime<StartupR, LoopR> =
   | { readonly _tag: 'Brokerless' }
   | {
       readonly _tag: 'AutonomousRead'
+      readonly startupEvidenceMode?: 'Qualification' | 'Research'
       readonly broker?: BrokerProbe
       readonly brokerConfiguration?: BrokerConfiguration
       /** null explicitly suppresses cycles even when startup recovered historical qualification evidence. */
@@ -103,6 +104,7 @@ export type ApplicationRuntime<StartupR, LoopR> =
     }
   | {
       readonly _tag: 'AutonomousMutation'
+      readonly startupEvidenceMode?: 'Qualification' | 'Research'
       readonly broker: BrokerProbe
       readonly cycleBindingId?: string | null
       readonly cycleObservationId?: string
@@ -158,6 +160,9 @@ const applyAutonomousCyclePass = (current: RuntimeState, observation: Autonomous
 
 const brokerProbe = <StartupR, LoopR>(runtime: ApplicationRuntime<StartupR, LoopR>): BrokerProbe | undefined =>
   runtime._tag === 'Brokerless' ? undefined : runtime.broker
+
+const qualificationEvidenceRequired = <StartupR, LoopR>(runtime: ApplicationRuntime<StartupR, LoopR>): boolean =>
+  runtime._tag === 'Brokerless' || runtime.startupEvidenceMode !== 'Research'
 
 const initialRuntimeState = <StartupR, LoopR>(runtime: ApplicationRuntime<StartupR, LoopR>): RuntimeState =>
   runtime._tag === 'Brokerless'
@@ -247,7 +252,9 @@ export const runApplication = <StartupR, LoopR>(
     Effect.tap(({ state }) =>
       serveHttp(config, state, strategy.provenance, config.build.verification, dependencies.evidenceStore.read),
     ),
-    Effect.tap(({ state }) => runStartup(config, state, strategy, dependencies)),
+    Effect.tap(({ state }) =>
+      qualificationEvidenceRequired(runtime) ? runStartup(config, state, strategy, dependencies) : Effect.void,
+    ),
     Effect.bind('resolvedRuntime', ({ state }) => resolveRuntimeAfterStartup(runtime, state)),
     Effect.bind('autonomousCycleFiber', ({ state, resolvedRuntime }) => startAutonomousCycle(resolvedRuntime, state)),
     Effect.tap(({ autonomousCycleFiber, resolvedRuntime, state }) =>
@@ -261,6 +268,7 @@ export const runApplication = <StartupR, LoopR>(
           resolvedRuntime._tag === 'Brokerless'
             ? undefined
             : (resolvedRuntime.cycleObservationId ?? resolvedRuntime.cycleBindingId ?? undefined),
+          qualificationEvidenceRequired(resolvedRuntime),
         ),
         Effect.forkScoped({ startImmediately: true }),
       ),

--- a/services/bayn/src/composition.ts
+++ b/services/bayn/src/composition.ts
@@ -1143,11 +1143,20 @@ const runAutonomousService = (plan: ApplicationPlanFor<'AutonomousService'>) =>
       strategyProtocolHash: plan.strategyProtocolHash,
     }) as ApplicationPlanFor<'AutonomousService'>
     const serializedRequest = observePlan.config.paperActivationRequestJson
+    const decodedRequest: Result.Result<PaperActivationRequest | null, string> =
+      serializedRequest === undefined ? Result.succeed(null) : decodeConfiguredPaperActivationRequest(serializedRequest)
+    const startupEvidenceMode =
+      Result.isSuccess(decodedRequest) &&
+      decodedRequest.success !== null &&
+      isResearchPaperActivationRequest(decodedRequest.success)
+        ? ('Research' as const)
+        : ('Qualification' as const)
     const noCycle = (
       _startup: AutonomousCycleStartupInput,
     ): Effect.Effect<Effect.Effect<void, never, never>, OperationalError, never> => Effect.succeed(Effect.never)
     const pendingRuntime = () => ({
       _tag: 'AutonomousRead' as const,
+      startupEvidenceMode,
       cycleBindingId: null,
       brokerConfiguration: {
         expectedAccountId: observePlan.config.alpaca.expectedAccountId,
@@ -1157,10 +1166,6 @@ const runAutonomousService = (plan: ApplicationPlanFor<'AutonomousService'>) =>
       startCycle: noCycle,
     })
     const resolveAfterStartup: AutonomousRuntimeResolver<never, never> = (state) => {
-      const decodedRequest: Result.Result<PaperActivationRequest | null, string> =
-        serializedRequest === undefined
-          ? Result.succeed(null)
-          : decodeConfiguredPaperActivationRequest(serializedRequest)
       const validateStaticRequest: Effect.Effect<
         Result.Result<
           { readonly request: PaperActivationRequest | null; readonly evidence: RuntimeEvidence | null },
@@ -1238,6 +1243,10 @@ const runAutonomousService = (plan: ApplicationPlanFor<'AutonomousService'>) =>
                           )
                         const readRuntime = () => ({
                           _tag: 'AutonomousRead' as const,
+                          startupEvidenceMode:
+                            request !== null && isResearchPaperActivationRequest(request)
+                              ? ('Research' as const)
+                              : ('Qualification' as const),
                           broker: runtimeBroker(observePlan, runtimeServices.session.read, false),
                           ...(request !== null && isResearchPaperActivationRequest(request)
                             ? { cycleBindingId: null, cycleObservationId: request.grant.planHash }
@@ -1497,6 +1506,9 @@ const runAutonomousService = (plan: ApplicationPlanFor<'AutonomousService'>) =>
                                     ),
                                     Effect.map((executionProgram) => ({
                                       _tag: 'AutonomousMutation' as const,
+                                      startupEvidenceMode: isResearchPaperActivationRequest(request)
+                                        ? ('Research' as const)
+                                        : ('Qualification' as const),
                                       broker: runtimeBroker(realizedPlan, runtimeServices.session.read, true),
                                       cycleBindingId,
                                       cycleObservationId: cycleBindingId,

--- a/services/bayn/src/health.test.ts
+++ b/services/bayn/src/health.test.ts
@@ -42,7 +42,7 @@ import {
 import { readinessResponseDecision, statusFacts } from './http'
 import { Journal, type JournalService } from './ledger'
 import { MarketData, type MarketDataService } from './market-data'
-import { initialState, type RuntimeState } from './runtime-state'
+import { initialState, isReady, type RuntimeState } from './runtime-state'
 import { makeSnapshot } from './test-fixtures'
 
 const testHealthDependencies = Effect.all({
@@ -852,11 +852,42 @@ describe('Bayn continuous health', () => {
 
   test('observes a research cycle binding when startup evidence is unavailable', async () => {
     const researchPlanHash = 'b'.repeat(64)
-    const initial = initialState()
+    const checkedAt = '2026-07-20T00:00:00.000Z'
+    const generationHash = 'd'.repeat(64)
+    const initial: RuntimeState = {
+      ...initialState(),
+      paperActivation: {
+        _tag: 'Realized',
+        requestHash: 'c'.repeat(64),
+        generationHash,
+        grant: 'Research',
+        cutoffAt: '2026-09-01T20:00:00.000Z',
+        expiresAt: '2026-09-03T20:00:00.000Z',
+        maximumCloseSessions: 3,
+      },
+    }
     const observedBindings: string[] = []
-    const projection = emptyCycleProjection()
+    const projection: CycleOperationsProjection = {
+      ...emptyCycleProjection(),
+      authority: {
+        generationHash,
+        maximum: Authority.Paper,
+        effective: Authority.Paper,
+        kill: KillState.Clear,
+        reason: null,
+        updatedAt: checkedAt,
+      },
+      reconciliation: {
+        accountId: brokerAccountId,
+        reconciliationId: 'e'.repeat(64),
+        status: ReconciliationStatus.Exact,
+        discrepancyCount: 0,
+        reconciledAt: checkedAt,
+        coversLatestMutation: true,
+      },
+    }
     const program = Effect.gen(function* () {
-      yield* TestClock.setTime(Date.parse('2026-07-20T00:00:00.000Z'))
+      yield* TestClock.setTime(Date.parse(checkedAt))
       const state = yield* Ref.make(initial)
       yield* probe(config, state, undefined, undefined, researchPlanHash, false).pipe(
         Effect.provideService(MarketData, {
@@ -885,7 +916,8 @@ describe('Bayn continuous health', () => {
       )
 
       expect(observedBindings).toEqual([researchPlanHash])
-      expect(yield* Ref.get(state)).toMatchObject({
+      const observed = yield* Ref.get(state)
+      expect(observed).toMatchObject({
         status: 'READY',
         health: {
           dependencies: {
@@ -896,6 +928,7 @@ describe('Bayn continuous health', () => {
         },
         cycle: { condition: CycleOperationsCondition.Waiting, unfinishedCycleCount: 0 },
       })
+      expect(isReady(observed)).toBe(true)
     }).pipe(Effect.provide(TestClock.layer()))
 
     await Effect.runPromise(program)

--- a/services/bayn/src/health.test.ts
+++ b/services/bayn/src/health.test.ts
@@ -58,10 +58,19 @@ const probe = (
   broker?: BrokerProbe,
   cycleFiber?: Fiber.Fiber<void, never>,
   cycleObservationId?: string,
+  qualificationEvidenceRequired = true,
 ) =>
   testHealthDependencies.pipe(
     Effect.flatMap((dependencies) =>
-      checkHealth(runtimeConfig, state, dependencies, broker, cycleFiber, cycleObservationId),
+      checkHealth(
+        runtimeConfig,
+        state,
+        dependencies,
+        broker,
+        cycleFiber,
+        cycleObservationId,
+        qualificationEvidenceRequired,
+      ),
     ),
   )
 
@@ -843,17 +852,13 @@ describe('Bayn continuous health', () => {
 
   test('observes a research cycle binding when startup evidence is unavailable', async () => {
     const researchPlanHash = 'b'.repeat(64)
-    const initial: RuntimeState = { ...readyState(), evidence: null }
+    const initial = initialState()
     const observedBindings: string[] = []
-    const projection = {
-      ...emptyCycleProjection(),
-      current: pendingCycle('2026-07-20T00:00:00.000Z'),
-      unfinishedCycleCount: 1,
-    }
+    const projection = emptyCycleProjection()
     const program = Effect.gen(function* () {
       yield* TestClock.setTime(Date.parse('2026-07-20T00:00:00.000Z'))
       const state = yield* Ref.make(initial)
-      yield* probe(config, state, undefined, undefined, researchPlanHash).pipe(
+      yield* probe(config, state, undefined, undefined, researchPlanHash, false).pipe(
         Effect.provideService(MarketData, {
           check: Effect.succeed(makeSnapshot().manifest.finalizedSnapshot),
           inspect: Effect.die(new Error('health probes must not inspect sessions')),
@@ -881,8 +886,15 @@ describe('Bayn continuous health', () => {
 
       expect(observedBindings).toEqual([researchPlanHash])
       expect(yield* Ref.get(state)).toMatchObject({
-        health: { dependencies: { cycle: { status: 'AVAILABLE', error: null } } },
-        cycle: { current: { cycleId: projection.current.cycleId }, unfinishedCycleCount: 1 },
+        status: 'READY',
+        health: {
+          dependencies: {
+            signal: { status: 'AVAILABLE', error: null },
+            evidence: { status: 'AVAILABLE', error: null },
+            cycle: { status: 'AVAILABLE', error: null },
+          },
+        },
+        cycle: { condition: CycleOperationsCondition.Waiting, unfinishedCycleCount: 0 },
       })
     }).pipe(Effect.provide(TestClock.layer()))
 

--- a/services/bayn/src/health/program.ts
+++ b/services/bayn/src/health/program.ts
@@ -12,7 +12,12 @@ import type { FinalizedSnapshotProvenance } from '../contracts'
 import type { QualificationRecord, RecoveredEvaluationEvidence } from '../db/evidence-store'
 import { OperationalError, operationalError } from '../errors'
 import { databaseOperation, withinDeadline } from '../operations'
-import type { BrokerConfiguration, RuntimeEvidence, RuntimeState } from '../runtime-state'
+import {
+  qualificationEvidenceSatisfied,
+  type BrokerConfiguration,
+  type RuntimeEvidence,
+  type RuntimeState,
+} from '../runtime-state'
 import { utcInstantFromEpochMillisResult } from '../time'
 import {
   deriveHealthLogDecisions,
@@ -322,7 +327,7 @@ export const checkHealth = (
     const transition = yield* Ref.modify(state, (current) => {
       const decision = deriveHealthTransition(current, {
         config,
-        evidenceAvailable: initial.evidence !== null || !qualificationEvidenceRequired,
+        evidenceAvailable: qualificationEvidenceSatisfied(initial),
         results,
         broker: brokerConfiguration(broker),
         cycleFiber,

--- a/services/bayn/src/health/program.ts
+++ b/services/bayn/src/health/program.ts
@@ -208,6 +208,7 @@ const collectHealthProbeResults = (
   cycleObservability: HealthDependencies['cycleObservability'],
   broker: BrokerProbe | undefined,
   cycleObservationId: string | undefined,
+  qualificationEvidenceRequired: boolean,
 ): Effect.Effect<HealthProbeResults, never> => {
   const cycleBindingId = cycleObservationId ?? evidence?.evaluation.runId
   return Effect.map(
@@ -223,7 +224,9 @@ const collectHealthProbeResults = (
         ),
         observe(
           withinDeadline(marketData.check, config.operationTimeoutMs, 'market-data', 'continuous-health').pipe(
-            Effect.flatMap((snapshot) => ensureSignalIdentity(snapshot, evidence)),
+            Effect.flatMap((snapshot) =>
+              qualificationEvidenceRequired ? ensureSignalIdentity(snapshot, evidence) : Effect.void,
+            ),
           ),
         ),
         observe(
@@ -235,27 +238,29 @@ const collectHealthProbeResults = (
           ),
         ),
         observe(
-          evidence === null
-            ? Effect.fail(operationalError('database', 'verify-evidence', 'startup evidence is unavailable'))
-            : withinDeadline(
-                Effect.all([
-                  databaseOperation(
-                    evidenceStore.recover(evidence.evaluation.runId, evidence.provenance),
-                    'continuous-recovery',
+          !qualificationEvidenceRequired
+            ? Effect.void
+            : evidence === null
+              ? Effect.fail(operationalError('database', 'verify-evidence', 'startup evidence is unavailable'))
+              : withinDeadline(
+                  Effect.all([
+                    databaseOperation(
+                      evidenceStore.recover(evidence.evaluation.runId, evidence.provenance),
+                      'continuous-recovery',
+                    ),
+                    databaseOperation(
+                      evidenceStore.readQualification(evidence.evaluation.runId),
+                      'continuous-qualification',
+                    ),
+                  ]),
+                  config.operationTimeoutMs,
+                  'database',
+                  'continuous-recovery',
+                ).pipe(
+                  Effect.flatMap(([recovered, qualification]) =>
+                    ensureDurableEvidence(Option.getOrNull(recovered), Option.getOrNull(qualification), evidence),
                   ),
-                  databaseOperation(
-                    evidenceStore.readQualification(evidence.evaluation.runId),
-                    'continuous-qualification',
-                  ),
-                ]),
-                config.operationTimeoutMs,
-                'database',
-                'continuous-recovery',
-              ).pipe(
-                Effect.flatMap(([recovered, qualification]) =>
-                  ensureDurableEvidence(Option.getOrNull(recovered), Option.getOrNull(qualification), evidence),
                 ),
-              ),
         ),
         observe(
           cycleBindingId === undefined
@@ -292,6 +297,7 @@ export const checkHealth = (
   broker?: BrokerProbe,
   autonomousCycleFiber?: Fiber.Fiber<void, never>,
   cycleObservationId?: string,
+  qualificationEvidenceRequired = true,
 ): Effect.Effect<void> =>
   Effect.gen(function* () {
     const initial = yield* Ref.get(state)
@@ -304,6 +310,7 @@ export const checkHealth = (
       dependencies.cycleObservability,
       broker,
       cycleObservationId,
+      qualificationEvidenceRequired,
     )
     const checkedAtMs = yield* Clock.currentTimeMillis
     const checkedAtResult = utcInstantFromEpochMillisResult(checkedAtMs)
@@ -315,7 +322,7 @@ export const checkHealth = (
     const transition = yield* Ref.modify(state, (current) => {
       const decision = deriveHealthTransition(current, {
         config,
-        evidenceAvailable: initial.evidence !== null,
+        evidenceAvailable: initial.evidence !== null || !qualificationEvidenceRequired,
         results,
         broker: brokerConfiguration(broker),
         cycleFiber,
@@ -333,8 +340,14 @@ export const runHealthMonitor = (
   broker?: BrokerProbe,
   autonomousCycleFiber?: Fiber.Fiber<void, never>,
   cycleObservationId?: string,
+  qualificationEvidenceRequired = true,
 ): Effect.Effect<void> =>
-  checkHealth(config, state, dependencies, broker, autonomousCycleFiber, cycleObservationId).pipe(
-    Effect.repeat(Schedule.spaced(Duration.millis(config.healthIntervalMs))),
-    Effect.asVoid,
-  )
+  checkHealth(
+    config,
+    state,
+    dependencies,
+    broker,
+    autonomousCycleFiber,
+    cycleObservationId,
+    qualificationEvidenceRequired,
+  ).pipe(Effect.repeat(Schedule.spaced(Duration.millis(config.healthIntervalMs))), Effect.asVoid)

--- a/services/bayn/src/http.test.ts
+++ b/services/bayn/src/http.test.ts
@@ -1173,6 +1173,42 @@ describe('Bayn HTTP probes', () => {
     )
   })
 
+  test('reports an evidence-free realized research PAPER runtime as ready', async () => {
+    const researchState: RuntimeState = {
+      ...readyState(),
+      evidence: null,
+      paperActivation: {
+        _tag: 'Realized',
+        requestHash: 'a'.repeat(64),
+        generationHash: 'b'.repeat(64),
+        grant: 'Research',
+        cutoffAt: '2026-09-01T20:00:00.000Z',
+        expiresAt: '2026-09-03T20:00:00.000Z',
+        maximumCloseSessions: 3,
+      },
+    }
+
+    await withHttpServer({ state: researchState }, ({ port }) =>
+      Effect.all([request(port, '/readyz'), request(port, '/v1/status'), request(port, '/metrics')]).pipe(
+        Effect.tap(([ready, status, metrics]) =>
+          Effect.sync(() => {
+            expect(ready).toMatchObject({ status: 200, body: { ready: true, status: 'READY' } })
+            expect(status).toMatchObject({
+              status: 200,
+              body: {
+                operational: { ready: true },
+                evidence: { status: 'UNKNOWN', runId: null },
+                paperActivation: { _tag: 'Realized', grant: 'Research' },
+              },
+            })
+            expect(metrics.body).toContain('bayn_runtime_ready 1')
+          }),
+        ),
+        Effect.asVoid,
+      ),
+    )
+  })
+
   test('keeps a typed latest loop failure visible and makes readiness and metrics fail closed', async () => {
     const failedAt = '2026-07-20T00:00:00.000Z'
     const failedState: RuntimeState = {

--- a/services/bayn/src/runtime-state.ts
+++ b/services/bayn/src/runtime-state.ts
@@ -155,9 +155,14 @@ export const initialState = (broker?: BrokerConfiguration, autonomousCycleLoopCo
   error: null,
 })
 
+export const qualificationEvidenceSatisfied = (state: RuntimeState): boolean =>
+  state.evidence !== null ||
+  ((state.paperActivation?._tag === 'Realized' || state.paperActivation?._tag === 'Completed') &&
+    state.paperActivation.grant === 'Research')
+
 export const isReady = (state: RuntimeState): boolean =>
   state.status === 'READY' &&
-  state.evidence !== null &&
+  qualificationEvidenceSatisfied(state) &&
   state.cycle.condition !== CycleOperationsCondition.Unknown &&
   state.cycle.condition !== CycleOperationsCondition.Stalled &&
   state.cycle.condition !== CycleOperationsCondition.Failed &&


### PR DESCRIPTION
## Summary

- Distinguish explicit research PAPER runtimes from qualification-bound runtimes at the composition boundary.
- Skip legacy qualification startup and evidence recovery only for a successfully decoded research activation request.
- Keep market-data availability, autonomous cycle, broker, authority, and reconciliation health probes active in research mode.
- Add regressions proving research mode performs no qualification startup I/O and can become ready without fabricated qualification evidence.

## Related Issues

PROOMPT-405

## Testing

- `bun test services/bayn/src/app.test.ts services/bayn/src/health.test.ts services/bayn/src/composition.test.ts` (48 pass, 0 fail)
- `bun run --filter @proompteng/bayn test` (1137 pass, 157 PostgreSQL-gated skips, 0 fail)
- `BAYN_TEST_POSTGRES_URL=postgresql://bayn:***@127.0.0.1:<ephemeral>/bayn_test bun run --cwd services/bayn test:postgres` (all four canonical suites passed)
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn build`

## Breaking Changes

None. Qualification-bound and brokerless startup behavior remains unchanged.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable and Breaking Changes is handled.
- [x] Follow-up live proof remains tracked in PROOMPT-405 and the Bayn project.