### PR TITLE
fix(bayn): rearm unused research paper generation

### DIFF
--- a/services/bayn/migrations/0030_clear_unused_research_paper_rearm.ts
+++ b/services/bayn/migrations/0030_clear_unused_research_paper_rearm.ts
@@ -1,0 +1,81 @@
+import { Effect } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient
+
+  yield* sql`
+    CREATE OR REPLACE FUNCTION research_paper_rearm_eligible(
+      candidate_generation_hash text,
+      candidate_authority_version bigint,
+      candidate_activated_at timestamptz
+    )
+    RETURNS boolean
+    LANGUAGE sql
+    STABLE
+    AS $function$
+      SELECT EXISTS (
+        SELECT 1
+        FROM authority_state AS state
+        JOIN authority_generations AS previous_generation
+          ON previous_generation.generation_hash = state.generation_hash
+        JOIN authority_generations AS candidate_generation
+          ON candidate_generation.generation_hash = candidate_generation_hash
+        JOIN LATERAL (
+          SELECT reconciliation.*
+          FROM reconciliations AS reconciliation
+          WHERE reconciliation.account_id = previous_generation.account_id
+          ORDER BY reconciliation.reconciled_at DESC, reconciliation.reconciliation_id COLLATE "C" DESC
+          LIMIT 1
+        ) AS reconciliation ON true
+        WHERE state.singleton
+          AND (
+            (
+              state.maximum = 'PAPER'
+              AND state.effective = 'OBSERVE'
+              AND state.kill_state = 'ACTIVE'
+              AND state.reason LIKE 'PAPER autonomous cycle loop restricted effective authority:%'
+            )
+            OR (
+              state.maximum = 'PAPER'
+              AND state.effective = 'PAPER'
+              AND state.kill_state = 'CLEAR'
+              AND state.reason IS NULL
+            )
+          )
+          AND state.version + 1 = candidate_authority_version
+          AND previous_generation.maximum = 'PAPER'
+          AND previous_generation.activation_schema_version = 'bayn.paper-authority-generation.v3'
+          AND previous_generation.proof_plan_hash IS NOT NULL
+          AND candidate_generation.previous_generation_hash = previous_generation.generation_hash
+          AND candidate_generation.maximum = 'OBSERVE'
+          AND candidate_generation.activation_schema_version IS NULL
+          AND candidate_generation.authority_version = candidate_authority_version
+          AND candidate_generation.activated_at = candidate_activated_at
+          AND candidate_generation.broker_identity_schema_version = previous_generation.broker_identity_schema_version
+          AND candidate_generation.broker_identity_hash = previous_generation.broker_identity_hash
+          AND candidate_generation.broker_provider = previous_generation.broker_provider
+          AND candidate_generation.broker_environment = 'sandbox'
+          AND candidate_generation.broker_environment = previous_generation.broker_environment
+          AND candidate_generation.account_id = previous_generation.account_id
+          AND reconciliation.status = 'EXACT'
+          AND reconciliation.expected_hash = reconciliation.observed_hash
+          AND jsonb_array_length(reconciliation.discrepancies) = 0
+          AND reconciliation.reconciled_at > state.updated_at
+          AND reconciliation.reconciled_at < candidate_activated_at
+          AND NOT EXISTS (
+            SELECT 1
+            FROM autonomous_cycles AS cycle
+            WHERE cycle.qualification_run_id = previous_generation.proof_plan_hash
+              AND cycle.account_id = previous_generation.account_id
+              AND cycle.state IN ('PENDING', 'ACTIVE')
+          )
+          AND NOT EXISTS (
+            SELECT 1
+            FROM intents AS intent
+            WHERE intent.authority_generation_hash = previous_generation.generation_hash
+          )
+      )
+    $function$
+  `
+})

--- a/services/bayn/src/composition.ts
+++ b/services/bayn/src/composition.ts
@@ -761,6 +761,24 @@ const validateActivatedResearchAuthority = (authority: AuthorityState): Result.R
     ? Result.succeed(undefined)
     : Result.fail('research PAPER activation did not return clear effective PAPER authority')
 
+const readCurrentResearchPaperGeneration = (
+  authority: AuthorityState,
+  authorityStore: AuthorityGenerationStoreShape,
+): Effect.Effect<ResearchCapitalGrantGeneration | undefined, OperationalError> => {
+  if (authority.maximum !== Authority.Paper) return Effect.succeed(undefined)
+  if (authorityStore.readResearchAuthorityGeneration === undefined) {
+    return Effect.fail(paperActivationOperationalError('research PAPER startup requires v3 authority history reads'))
+  }
+  return authorityStore.readResearchAuthorityGeneration(authority.generationHash).pipe(
+    Effect.mapError((cause) => paperActivationOperationalError('research PAPER generation read failed', cause)),
+    Effect.flatMap((generation) =>
+      generation === undefined
+        ? Effect.fail(paperActivationOperationalError('durable research PAPER history is missing'))
+        : Effect.succeed(generation),
+    ),
+  )
+}
+
 const prepareResearchPaperActivation = (
   plan: ApplicationPlanFor<'AutonomousService'>,
   request: ResearchPaperActivationRequest,
@@ -814,10 +832,17 @@ const prepareOrRecoverResearchPaperActivation = (
     const authority = yield* authorityStore
       .readAuthorityState()
       .pipe(Effect.mapError((cause) => paperActivationOperationalError('research PAPER authority read failed', cause)))
+    const currentGeneration = yield* readCurrentResearchPaperGeneration(authority, authorityStore)
+    const currentGenerationMatchesRequest =
+      currentGeneration !== undefined &&
+      Result.isSuccess(
+        researchPaperGenerationIsBoundToRequest(request, plan.config.alpaca.authorityGenerationHash, currentGeneration),
+      )
     const decision = yield* Effect.fromResult(
       decidePaperEpisodeAuthority({
         generationHash: authority.generationHash,
         sourceGenerationHash: plan.config.alpaca.authorityGenerationHash,
+        currentGenerationMatchesRequest,
         maximum: authority.maximum,
         effective: authority.effective,
         kill: authority.kill,
@@ -853,10 +878,10 @@ const prepareOrRecoverResearchPaperActivation = (
     if (decision._tag !== 'Resume') {
       return yield* prepareResearchPaperActivation(plan, request, session, authorityStore, lifecycle, writerFence)
     }
-    const generation = yield* readBoundPaperActivationGeneration(plan, request, authorityStore)
-    return generation.schemaVersion === 'bayn.paper-authority-generation.v3'
-      ? generation
-      : yield* Effect.fail(paperActivationOperationalError('research PAPER recovery loaded qualified history'))
+    return (
+      currentGeneration ??
+      (yield* Effect.fail(paperActivationOperationalError('research PAPER recovery lost durable history')))
+    )
   })
 
 const pendingPaperActivation = (

--- a/services/bayn/src/db/evidence-store.integration.test.ts
+++ b/services/bayn/src/db/evidence-store.integration.test.ts
@@ -1197,6 +1197,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
       { migration_id: 27, name: 'distinct_close_replan_intents' },
       { migration_id: 28, name: 'research_paper_grants' },
       { migration_id: 29, name: 'unused_research_paper_rearm' },
+      { migration_id: 30, name: 'clear_unused_research_paper_rearm' },
     ])
   })
 

--- a/services/bayn/src/db/execution-store/observe-authority.ts
+++ b/services/bayn/src/db/execution-store/observe-authority.ts
@@ -277,9 +277,6 @@ export const makeObserveAuthorityInterpreter = (
         ), research_rearm AS (
           SELECT
             state.maximum = 'PAPER'
-            AND state.effective = 'OBSERVE'
-            AND state.kill_state = 'ACTIVE'
-            AND state.reason LIKE 'PAPER autonomous cycle loop restricted effective authority:%'
             AND previous_generation.activation_schema_version = 'bayn.paper-authority-generation.v3' AS candidate,
             research_paper_rearm_eligible(
               ${decision.generationHash},

--- a/services/bayn/src/db/execution-store/observe-authority.ts
+++ b/services/bayn/src/db/execution-store/observe-authority.ts
@@ -277,7 +277,19 @@ export const makeObserveAuthorityInterpreter = (
         ), research_rearm AS (
           SELECT
             state.maximum = 'PAPER'
-            AND previous_generation.activation_schema_version = 'bayn.paper-authority-generation.v3' AS candidate,
+            AND previous_generation.activation_schema_version = 'bayn.paper-authority-generation.v3'
+            AND (
+              (
+                state.effective = 'OBSERVE'
+                AND state.kill_state = 'ACTIVE'
+                AND state.reason LIKE 'PAPER autonomous cycle loop restricted effective authority:%'
+              )
+              OR (
+                state.effective = 'PAPER'
+                AND state.kill_state = 'CLEAR'
+                AND state.reason IS NULL
+              )
+            ) AS candidate,
             research_paper_rearm_eligible(
               ${decision.generationHash},
               ${decision.authorityVersion},

--- a/services/bayn/src/db/migrations.ts
+++ b/services/bayn/src/db/migrations.ts
@@ -29,6 +29,7 @@ import paperCycleCloseReplans from '../../migrations/0026_paper_cycle_close_repl
 import distinctCloseReplanIntents from '../../migrations/0027_distinct_close_replan_intents'
 import researchPaperGrants from '../../migrations/0028_research_paper_grants'
 import unusedResearchPaperRearm from '../../migrations/0029_unused_research_paper_rearm'
+import clearUnusedResearchPaperRearm from '../../migrations/0030_clear_unused_research_paper_rearm'
 
 export const migrationLoader = PgMigrator.fromRecord({
   '1_initial_schema': initialSchema,
@@ -60,4 +61,5 @@ export const migrationLoader = PgMigrator.fromRecord({
   '27_distinct_close_replan_intents': distinctCloseReplanIntents,
   '28_research_paper_grants': researchPaperGrants,
   '29_unused_research_paper_rearm': unusedResearchPaperRearm,
+  '30_clear_unused_research_paper_rearm': clearUnusedResearchPaperRearm,
 })

--- a/services/bayn/src/db/paper-store.integration.test.ts
+++ b/services/bayn/src/db/paper-store.integration.test.ts
@@ -2241,6 +2241,53 @@ describePostgres('paper accounting persistence', () => {
     }
   }, 15_000)
 
+  test('rotates a non-rearm research PAPER kill to OBSERVE without clearing it', async () => {
+    const sourceGenerationHash = hash('operator-killed-research-paper-source')
+    const nextSourceGenerationHash = hash('operator-killed-research-paper-next-source')
+    const activationReconciliation = exactReconciliation('operator-killed-research-paper-activation')
+    const activation = makeResearchActivation(sourceGenerationHash, activationReconciliation)
+    const runtime = makeStoreRuntime({ fail: false, planHashes: [] }, researchRuntimeConfig(sourceGenerationHash))
+    try {
+      const result = await runtime.runPromise(
+        Effect.gen(function* () {
+          const store = yield* ExecutionStore
+          const sql = yield* PgClient.PgClient
+          const activateResearch = store.activateResearchCapitalGrant
+          assert(activateResearch !== undefined, 'research PAPER activation must be implemented')
+
+          yield* seedExactReconciliation(activationReconciliation)
+          yield* store.ensureAuthorityGeneration({
+            generationHash: sourceGenerationHash,
+            maximum: Authority.Observe,
+          })
+          yield* activateResearch(researchProofBinding(activation))
+          const [restrictionTime] = yield* sql<{ updated_at: Date }>`
+            SELECT greatest(clock_timestamp(), updated_at + interval '1 millisecond') AS updated_at
+            FROM authority_state
+            WHERE singleton
+          `
+          if (restrictionTime === undefined) return yield* Effect.die(new Error('restriction time is unavailable'))
+          yield* store.restrictAuthority('operator requested PAPER stop', restrictionTime.updated_at.toISOString())
+
+          return yield* store.ensureAuthorityGeneration({
+            generationHash: nextSourceGenerationHash,
+            maximum: Authority.Observe,
+          })
+        }),
+      )
+
+      expect(result).toMatchObject({
+        generationHash: nextSourceGenerationHash,
+        maximum: Authority.Observe,
+        effective: Authority.Observe,
+        kill: KillState.Active,
+        reason: 'operator requested PAPER stop',
+      })
+    } finally {
+      await runtime.dispose()
+    }
+  }, 15_000)
+
   test('activates PAPER after fresh exact reconciliation covers terminal cancel mutation history', async () => {
     const initialGenerationHash = hash('terminal-canceled-observe-generation')
     const reconciliation = exactReconciliation('terminal-canceled-paper')

--- a/services/bayn/src/db/paper-store.integration.test.ts
+++ b/services/bayn/src/db/paper-store.integration.test.ts
@@ -2123,6 +2123,124 @@ describePostgres('paper accounting persistence', () => {
     }
   }, 15_000)
 
+  test('rearms a clear research PAPER generation with no intent only after its cycle is terminal', async () => {
+    const sourceGenerationHash = hash('clear-research-paper-rearm-source')
+    const nextSourceGenerationHash = hash('clear-research-paper-rearm-next-source')
+    const activationReconciliation = exactReconciliation('clear-research-paper-rearm-activation')
+    const activation = makeResearchActivation(sourceGenerationHash, activationReconciliation)
+    const cycleId = hash('clear-research-paper-rearm-cycle')
+    const runtime = makeStoreRuntime({ fail: false, planHashes: [] }, researchRuntimeConfig(sourceGenerationHash))
+    try {
+      const result = await runtime.runPromise(
+        Effect.gen(function* () {
+          const store = yield* ExecutionStore
+          const sql = yield* PgClient.PgClient
+          const activateResearch = store.activateResearchCapitalGrant
+          assert(activateResearch !== undefined, 'research PAPER activation must be implemented')
+
+          yield* seedExactReconciliation(activationReconciliation)
+          yield* store.ensureAuthorityGeneration({
+            generationHash: sourceGenerationHash,
+            maximum: Authority.Observe,
+          })
+          const activated = yield* activateResearch(researchProofBinding(activation))
+          yield* sql`
+            WITH timing AS (
+              SELECT clock_timestamp() AS created_at, date_trunc('day', clock_timestamp()) AS day_start
+            )
+            INSERT INTO autonomous_cycles (
+              cycle_id, schema_version, identity_schema_version, strategy_name,
+              qualification_run_id, strategy_protocol_hash, account_id,
+              signal_session_date, signal_calendar_version,
+              execution_policy_schema_version, execution_policy_hash,
+              strategy_execution_model_hash, submission_window_ms,
+              submission_cutoff_before_open_ms, window_schema_version,
+              execution_calendar_schema_version, execution_calendar_source,
+              execution_calendar_hash, execution_session_date, signal_close_at,
+              publication_deadline_at, submission_open_at, execution_open_at,
+              execution_close_at, submission_cutoff_at, state, snapshot_id,
+              decision_hash, terminal_reason, state_version, created_at, updated_at, terminal_at
+            )
+            SELECT
+              ${cycleId}, 'bayn.autonomous-cycle.v1', 'bayn.autonomous-cycle-identity.v1',
+              'risk-balanced-trend', ${activation.grant.planHash}, ${activation.strategyProtocolHash}, ${accountId},
+              day_start::date, 'test-calendar-v1',
+              'bayn.autonomous-cycle-execution-policy.v1', ${hash('clear-rearm-policy')},
+              ${hash('clear-rearm-execution-model')}, 1800000, 1800000,
+              'bayn.autonomous-cycle-window.v1', 'bayn.alpaca-market-calendar-observation.v1',
+              'alpaca-v2-calendar', ${hash('clear-rearm-calendar')}, (day_start + interval '1 day')::date,
+              day_start + interval '20 hours', day_start + interval '1 day 12 hours 30 minutes',
+              day_start + interval '1 day 12 hours 30 minutes', day_start + interval '1 day 13 hours 30 minutes',
+              day_start + interval '1 day 15 hours', day_start + interval '1 day 13 hours',
+              'PENDING', NULL, NULL, NULL, 1, created_at, created_at, NULL
+            FROM timing
+          `
+          yield* seedExactReconciliation(exactReconciliation('clear-research-paper-rearm-before-terminal'))
+          const beforePremature = yield* readAuthorityTupleEvidence
+          const premature = yield* Effect.flip(
+            store.ensureAuthorityGeneration({
+              generationHash: nextSourceGenerationHash,
+              maximum: Authority.Observe,
+            }),
+          )
+          const afterPremature = yield* readAuthorityTupleEvidence
+          yield* sql`
+            WITH timing AS (
+              SELECT greatest(clock_timestamp(), updated_at + interval '1 millisecond') AS terminal_at
+              FROM autonomous_cycles
+              WHERE cycle_id = ${cycleId}
+            )
+            UPDATE autonomous_cycles AS cycle
+            SET
+              state = 'BLOCKED',
+              terminal_reason = 'BLOCKED_AUTHORITY',
+              state_version = 2,
+              updated_at = timing.terminal_at,
+              terminal_at = timing.terminal_at
+            FROM timing
+            WHERE cycle.cycle_id = ${cycleId}
+          `
+          yield* seedExactReconciliation(exactReconciliation('clear-research-paper-rearm-after-terminal'))
+          const rearmed = yield* store.ensureAuthorityGeneration({
+            generationHash: nextSourceGenerationHash,
+            maximum: Authority.Observe,
+          })
+          const [history] = yield* sql<{
+            maximum: Authority
+            previous_generation_hash: string | null
+          }>`
+            SELECT maximum, previous_generation_hash
+            FROM authority_generations
+            WHERE generation_hash = ${nextSourceGenerationHash}
+          `
+          return { activated, afterPremature, beforePremature, history, premature, rearmed }
+        }),
+      )
+
+      expect(result.activated).toMatchObject({
+        generationHash: activation.generationHash,
+        maximum: Authority.Paper,
+        effective: Authority.Paper,
+        kill: KillState.Clear,
+      })
+      expect(result.premature).toMatchObject({ operation: 'authority', failure: 'invariant' })
+      expect(result.afterPremature).toEqual(result.beforePremature)
+      expect(result.rearmed).toMatchObject({
+        generationHash: nextSourceGenerationHash,
+        maximum: Authority.Observe,
+        effective: Authority.Observe,
+        kill: KillState.Clear,
+      })
+      expect(result.rearmed.reason).toBeUndefined()
+      expect(result.history).toEqual({
+        maximum: Authority.Observe,
+        previous_generation_hash: activation.generationHash,
+      })
+    } finally {
+      await runtime.dispose()
+    }
+  }, 15_000)
+
   test('activates PAPER after fresh exact reconciliation covers terminal cancel mutation history', async () => {
     const initialGenerationHash = hash('terminal-canceled-observe-generation')
     const reconciliation = exactReconciliation('terminal-canceled-paper')

--- a/services/bayn/src/paper-episode.test.ts
+++ b/services/bayn/src/paper-episode.test.ts
@@ -189,6 +189,7 @@ describe('decidePaperEpisode', () => {
   test('activates, rearms, and resumes only from their exact durable authority states', () => {
     const common = {
       sourceGenerationHash: 'a'.repeat(64),
+      currentGenerationMatchesRequest: false,
     }
     expect(
       decidePaperEpisodeAuthority({
@@ -206,6 +207,7 @@ describe('decidePaperEpisode', () => {
         maximum: 'PAPER',
         effective: 'PAPER',
         kill: 'CLEAR',
+        currentGenerationMatchesRequest: true,
       }),
     ).toEqual(Result.succeed({ _tag: 'Resume' }))
     expect(
@@ -218,6 +220,15 @@ describe('decidePaperEpisode', () => {
         reason: 'PAPER autonomous cycle loop restricted effective authority: build-decision failed',
       }),
     ).toEqual(Result.succeed({ _tag: 'Rearm' }))
+    expect(
+      decidePaperEpisodeAuthority({
+        ...common,
+        generationHash: 'c'.repeat(64),
+        maximum: 'PAPER',
+        effective: 'PAPER',
+        kill: 'CLEAR',
+      }),
+    ).toEqual(Result.succeed({ _tag: 'Rearm' }))
   })
 
   test('does not rearm an operator kill, an unchanged source generation, or unknown authority state', () => {
@@ -227,6 +238,7 @@ describe('decidePaperEpisode', () => {
       maximum: 'PAPER' as const,
       effective: 'OBSERVE' as const,
       kill: 'ACTIVE' as const,
+      currentGenerationMatchesRequest: false,
     }
     expect(decidePaperEpisodeAuthority({ ...common, reason: 'operator kill' })).toEqual(
       Result.fail({ _tag: 'IdentityDrift' }),
@@ -236,6 +248,15 @@ describe('decidePaperEpisode', () => {
         ...common,
         sourceGenerationHash: common.generationHash,
         reason: 'PAPER autonomous cycle loop restricted effective authority: build-decision failed',
+      }),
+    ).toEqual(Result.fail({ _tag: 'IdentityDrift' }))
+    expect(
+      decidePaperEpisodeAuthority({
+        ...common,
+        sourceGenerationHash: common.generationHash,
+        maximum: 'PAPER',
+        effective: 'PAPER',
+        kill: 'CLEAR',
       }),
     ).toEqual(Result.fail({ _tag: 'IdentityDrift' }))
     expect(decidePaperEpisodeAuthority(common)).toEqual(Result.fail({ _tag: 'IdentityDrift' }))
@@ -248,6 +269,7 @@ describe('decidePaperEpisode', () => {
       maximum: 'OBSERVE',
       effective: 'OBSERVE',
       kill: 'CLEAR',
+      currentGenerationMatchesRequest: false,
     })
     expect(result).toEqual(Result.fail({ _tag: 'IdentityDrift' }))
   })

--- a/services/bayn/src/paper-episode.ts
+++ b/services/bayn/src/paper-episode.ts
@@ -100,6 +100,7 @@ export interface PaperEpisodeMarketSession {
 export interface PaperEpisodeAuthorityFacts {
   readonly generationHash: string
   readonly sourceGenerationHash: string
+  readonly currentGenerationMatchesRequest: boolean
   readonly maximum: 'OBSERVE' | 'PAPER'
   readonly effective: 'OBSERVE' | 'PAPER'
   readonly kill: 'CLEAR' | 'ACTIVE'
@@ -124,8 +125,22 @@ export const decidePaperEpisodeAuthority = (
   ) {
     return Result.succeed({ _tag: 'Activate' })
   }
-  if (facts.maximum === 'PAPER' && facts.effective === 'PAPER' && facts.kill === 'CLEAR') {
+  if (
+    facts.maximum === 'PAPER' &&
+    facts.effective === 'PAPER' &&
+    facts.kill === 'CLEAR' &&
+    facts.currentGenerationMatchesRequest
+  ) {
     return Result.succeed({ _tag: 'Resume' })
+  }
+  if (
+    facts.maximum === 'PAPER' &&
+    facts.effective === 'PAPER' &&
+    facts.kill === 'CLEAR' &&
+    !facts.currentGenerationMatchesRequest &&
+    facts.generationHash !== facts.sourceGenerationHash
+  ) {
+    return Result.succeed({ _tag: 'Rearm' })
   }
   if (
     facts.maximum === 'PAPER' &&


### PR DESCRIPTION
## Summary

- distinguish an exact research PAPER replay from a stale build-bound generation in the pure episode authority decision
- rotate an unused stale research PAPER generation back through the source OBSERVE generation only after terminal cycles, zero intents, and a newer exact reconciliation
- preserve immutable authority lineage and every existing restricted-rearm safety condition while adding clear-state PostgreSQL coverage

## Related Issues

PROOMPT-405

## Testing

- bun test services/bayn/src/paper-episode.test.ts services/bayn/src/composition.test.ts
- bun test --only-failures services/bayn/src (1138 pass, 158 skip, 0 fail)
- BAYN_TEST_POSTGRES_URL=redacted bun run --cwd services/bayn test:postgres (143 pass, 0 fail)
- bun run --cwd services/bayn tsc
- bun run --cwd services/bayn lint:effect
- bun run --cwd services/bayn lint:oxlint:type
- bun run --cwd services/bayn lint
- bun run --cwd services/bayn lint:oxlint
- bun run --cwd services/bayn build

## Breaking Changes

None. Migration 30 only broadens the existing atomic unused-research rearm predicate to the clear, intent-free state while retaining all cycle, reconciliation, identity, and lineage requirements.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots section removed and Breaking Changes handled.
- [x] Operational follow-up and live acceptance remain tracked in PROOMPT-405.