### PR TITLE
fix(bayn): reconcile before research paper activation

### DIFF
--- a/services/bayn/src/composition.test.ts
+++ b/services/bayn/src/composition.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 
-import { Effect, Fiber, Ref, Result } from 'effect'
+import { Deferred, Effect, Fiber, Ref, Result } from 'effect'
 import { TestClock } from 'effect/testing'
 
 import {
@@ -169,6 +169,7 @@ describe('Bayn PAPER startup recovery boundary', () => {
         Effect.sync(() => {
           operations.push('reconcile')
         }),
+        1_000,
       ).pipe(
         Effect.andThen(
           Effect.sync(() => {
@@ -187,7 +188,7 @@ describe('Bayn PAPER startup recovery boundary', () => {
 
     const failure = await Effect.runPromise(
       Effect.flip(
-        refreshResearchPaperActivationReconciliation(Effect.fail(reconciliationFailure)).pipe(
+        refreshResearchPaperActivationReconciliation(Effect.fail(reconciliationFailure), 1_000).pipe(
           Effect.andThen(
             Effect.sync(() => {
               operations.push('activate')
@@ -200,6 +201,46 @@ describe('Bayn PAPER startup recovery boundary', () => {
     expect(operations).toEqual([])
     expect(failure.message).toBe('research PAPER pre-activation reconciliation failed')
     expect(failure.cause).toBe(reconciliationFailure)
+  })
+
+  test('times out and interrupts pre-activation reconciliation before activation', async () => {
+    const operations: string[] = []
+    const timeoutFailure = await Effect.runPromise(
+      Effect.gen(function* () {
+        const started = yield* Deferred.make<void>()
+        const finalizations = yield* Ref.make(0)
+        const activation = yield* refreshResearchPaperActivationReconciliation(
+          Deferred.succeed(started, undefined).pipe(
+            Effect.andThen(Effect.never),
+            Effect.ensuring(Ref.update(finalizations, (count) => count + 1)),
+          ),
+          1_000,
+        ).pipe(
+          Effect.andThen(
+            Effect.sync(() => {
+              operations.push('activate')
+            }),
+          ),
+          Effect.flip,
+          Effect.forkChild({ startImmediately: true }),
+        )
+
+        yield* Deferred.await(started)
+        yield* TestClock.adjust(999)
+        expect(yield* Ref.get(finalizations)).toBe(0)
+        yield* TestClock.adjust(1)
+
+        const failure = yield* Fiber.join(activation)
+        expect(yield* Ref.get(finalizations)).toBe(1)
+        return failure
+      }).pipe(Effect.provide(TestClock.layer())),
+    )
+
+    expect(operations).toEqual([])
+    expect(timeoutFailure.message).toBe('research PAPER pre-activation reconciliation failed')
+    expect(timeoutFailure.cause).toMatchObject({
+      message: 'research PAPER pre-activation reconciliation timed out',
+    })
   })
 
   test('restricts durable authority before an expired close recovery is rejected', async () => {

--- a/services/bayn/src/composition.test.ts
+++ b/services/bayn/src/composition.test.ts
@@ -7,6 +7,7 @@ import {
   closedCycleReceiptEmissionAllowed,
   finalizePaperEpisode,
   paperReceiptFinalizationWindowOpen,
+  refreshResearchPaperActivationReconciliation,
   restrictExpiredPaperActivation,
   retryClosedCycleReceipts,
 } from './composition'
@@ -160,6 +161,47 @@ describe('Bayn PAPER receipt retry boundary', () => {
 })
 
 describe('Bayn PAPER startup recovery boundary', () => {
+  test('persists one fresh reconciliation before activating a new research PAPER generation', async () => {
+    const operations: string[] = []
+
+    await Effect.runPromise(
+      refreshResearchPaperActivationReconciliation(
+        Effect.sync(() => {
+          operations.push('reconcile')
+        }),
+      ).pipe(
+        Effect.andThen(
+          Effect.sync(() => {
+            operations.push('activate')
+          }),
+        ),
+      ),
+    )
+
+    expect(operations).toEqual(['reconcile', 'activate'])
+  })
+
+  test('keeps activation disabled when the fresh reconciliation fails', async () => {
+    const operations: string[] = []
+    const reconciliationFailure = new Error('read-only reconciliation failed')
+
+    const failure = await Effect.runPromise(
+      Effect.flip(
+        refreshResearchPaperActivationReconciliation(Effect.fail(reconciliationFailure)).pipe(
+          Effect.andThen(
+            Effect.sync(() => {
+              operations.push('activate')
+            }),
+          ),
+        ),
+      ),
+    )
+
+    expect(operations).toEqual([])
+    expect(failure.message).toBe('research PAPER pre-activation reconciliation failed')
+    expect(failure.cause).toBe(reconciliationFailure)
+  })
+
   test('restricts durable authority before an expired close recovery is rejected', async () => {
     const restrictions: Array<{ readonly reason: string; readonly updatedAt: string }> = []
     const authorityRestrictionStore: AuthorityRestrictionStoreShape = {

--- a/services/bayn/src/composition.ts
+++ b/services/bayn/src/composition.ts
@@ -818,8 +818,14 @@ const prepareResearchPaperActivation = (
 
 export const refreshResearchPaperActivationReconciliation = <E, R>(
   reconcile: Effect.Effect<unknown, E, R>,
+  operationTimeoutMs: number,
 ): Effect.Effect<void, OperationalError, R> =>
   reconcile.pipe(
+    Effect.timeoutOrElse({
+      duration: operationTimeoutMs,
+      orElse: () =>
+        Effect.fail(paperActivationOperationalError('research PAPER pre-activation reconciliation timed out')),
+    }),
     Effect.mapError((cause) =>
       paperActivationOperationalError('research PAPER pre-activation reconciliation failed', cause),
     ),
@@ -834,6 +840,7 @@ const prepareOrRecoverResearchPaperActivation = (
   lifecycle: CapitalGrantLifecycleStoreShape,
   writerFence: WriterFenceService,
   reconcile: Effect.Effect<unknown, ReconciliationPassError | OperationalError>,
+  operationTimeoutMs: number,
 ): Effect.Effect<ResearchCapitalGrantGeneration, OperationalError> =>
   Effect.gen(function* () {
     if (authorityStore.readAuthorityState === undefined) {
@@ -888,7 +895,7 @@ const prepareOrRecoverResearchPaperActivation = (
       }
     }
     if (decision._tag !== 'Resume') {
-      yield* refreshResearchPaperActivationReconciliation(reconcile)
+      yield* refreshResearchPaperActivationReconciliation(reconcile, operationTimeoutMs)
       return yield* prepareResearchPaperActivation(plan, request, session, authorityStore, lifecycle, writerFence)
     }
     return (
@@ -1333,18 +1340,8 @@ const runAutonomousService = (plan: ApplicationPlanFor<'AutonomousService'>) =>
                                           runtimeServices.authorityGenerationStore,
                                           runtimeServices.capitalGrantLifecycleStore,
                                           runtimeServices.writerFence,
-                                          runOnce.pipe(
-                                            Effect.timeoutOrElse({
-                                              duration: observePlan.config.operationTimeoutMs,
-                                              orElse: () =>
-                                                Effect.fail(
-                                                  paperActivationOperationalError(
-                                                    'research PAPER pre-activation reconciliation timed out',
-                                                  ),
-                                                ),
-                                            }),
-                                            Effect.provide(cycleResources),
-                                          ),
+                                          runOnce.pipe(Effect.provide(cycleResources)),
+                                          observePlan.config.operationTimeoutMs,
                                         ).pipe(Effect.map((generation) => ({ _tag: 'Mutation' as const, generation })))
                                       : evidence === null
                                         ? Effect.fail(

--- a/services/bayn/src/composition.ts
+++ b/services/bayn/src/composition.ts
@@ -112,6 +112,7 @@ import {
 } from './observe-composition'
 import { restrictMutationAuthority } from './observe-composition/mutation-interpreter'
 import { sqlResource } from './operations'
+import { runOnce, type ReconciliationPassError } from './reconciler'
 import {
   discoverPaperCandidates as discoverExecutionCandidatesHistoricalCodec,
   renderExecutionCandidateDiscoveryError,
@@ -815,6 +816,16 @@ const prepareResearchPaperActivation = (
     )
   })
 
+export const refreshResearchPaperActivationReconciliation = <E, R>(
+  reconcile: Effect.Effect<unknown, E, R>,
+): Effect.Effect<void, OperationalError, R> =>
+  reconcile.pipe(
+    Effect.mapError((cause) =>
+      paperActivationOperationalError('research PAPER pre-activation reconciliation failed', cause),
+    ),
+    Effect.asVoid,
+  )
+
 const prepareOrRecoverResearchPaperActivation = (
   plan: ApplicationPlanFor<'AutonomousService'>,
   request: ResearchPaperActivationRequest,
@@ -822,6 +833,7 @@ const prepareOrRecoverResearchPaperActivation = (
   authorityStore: AuthorityGenerationStoreShape,
   lifecycle: CapitalGrantLifecycleStoreShape,
   writerFence: WriterFenceService,
+  reconcile: Effect.Effect<unknown, ReconciliationPassError | OperationalError>,
 ): Effect.Effect<ResearchCapitalGrantGeneration, OperationalError> =>
   Effect.gen(function* () {
     if (authorityStore.readAuthorityState === undefined) {
@@ -876,6 +888,7 @@ const prepareOrRecoverResearchPaperActivation = (
       }
     }
     if (decision._tag !== 'Resume') {
+      yield* refreshResearchPaperActivationReconciliation(reconcile)
       return yield* prepareResearchPaperActivation(plan, request, session, authorityStore, lifecycle, writerFence)
     }
     return (
@@ -1320,6 +1333,18 @@ const runAutonomousService = (plan: ApplicationPlanFor<'AutonomousService'>) =>
                                           runtimeServices.authorityGenerationStore,
                                           runtimeServices.capitalGrantLifecycleStore,
                                           runtimeServices.writerFence,
+                                          runOnce.pipe(
+                                            Effect.timeoutOrElse({
+                                              duration: observePlan.config.operationTimeoutMs,
+                                              orElse: () =>
+                                                Effect.fail(
+                                                  paperActivationOperationalError(
+                                                    'research PAPER pre-activation reconciliation timed out',
+                                                  ),
+                                                ),
+                                            }),
+                                            Effect.provide(cycleResources),
+                                          ),
                                         ).pipe(Effect.map((generation) => ({ _tag: 'Mutation' as const, generation })))
                                       : evidence === null
                                         ? Effect.fail(


### PR DESCRIPTION
## Summary

- run one bounded, read-only broker reconciliation after OBSERVE rearm and immediately before a new research PAPER activation
- reuse the existing reconciler, persistence, writer fence, and operation timeout instead of adding another state path
- keep activation fail-closed when reconciliation fails or times out
- add focused ordering and failure regressions

## Related Issues

Linear PROOMPT-405

## Testing

- `bun test services/bayn/src/composition.test.ts` (10 pass, 0 fail)
- `bun run --filter @proompteng/bayn test` (1,140 pass, 159 PostgreSQL-only skips, 0 fail)
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:effect`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn build`

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] No documentation or release-note change is required for this internal startup-order fix; PROOMPT-405 tracks live proof.