### PR TITLE
chore(bayn): roll staged research paper activation

### DIFF
--- a/argocd/applications/bayn/deployment.yaml
+++ b/argocd/applications/bayn/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         app.kubernetes.io/name: bayn
         app.kubernetes.io/part-of: bayn
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-08-03T03:48:41Z"
+        kubectl.kubernetes.io/restartedAt: "2026-08-05T17:13:45Z"
     spec:
       serviceAccountName: bayn
       automountServiceAccountToken: false
@@ -47,11 +47,11 @@ spec:
               protocol: TCP
           env:
             - name: BAYN_CODE_REVISION
-              value: 56453573fd0618c2488f8b1c339e9abca3883e61
+              value: 78d5b3ae0f8286ab54b2349f6bb8ef79d2752cd1
             - name: BAYN_IMAGE_REPOSITORY
               value: registry.ide-newton.ts.net/lab/bayn
             - name: BAYN_IMAGE_DIGEST
-              value: sha256:2bffdbed6891d5d689809e0dae961625a1505342137805760da18bd66f022c70
+              value: sha256:79ea78c09ce29ece97fb4c5c0070d568504a9f9695e5a1c74295415c987ff269
             - name: BAYN_STRATEGY_BEHAVIOR_HASH
               value: "dde55f6292080b185554148cbfe4380e729626df1d11cbb47392645a80ce6c46"
             - name: BAYN_STRATEGY_PARAMETER_HASH

--- a/argocd/applications/bayn/kustomization.yaml
+++ b/argocd/applications/bayn/kustomization.yaml
@@ -22,5 +22,5 @@ configMapGenerator:
 images:
   - name: registry.ide-newton.ts.net/lab/bayn
     newName: registry.ide-newton.ts.net/lab/bayn
-    newTag: "sha-56453573fd0618c2488f8b1c339e9abca3883e61"
-    digest: sha256:2bffdbed6891d5d689809e0dae961625a1505342137805760da18bd66f022c70
+    newTag: "sha-78d5b3ae0f8286ab54b2349f6bb8ef79d2752cd1"
+    digest: sha256:79ea78c09ce29ece97fb4c5c0070d568504a9f9695e5a1c74295415c987ff269


### PR DESCRIPTION
## Summary

- Roll the reviewed Bayn image built from `78d5b3ae0f8286ab54b2349f6bb8ef79d2752cd1`.
- Consume the research PAPER activation Secret that was reconciled separately in phase one.
- Keep the existing sandbox strategy identity, runtime snapshot, broker binding, and bounded risk policy unchanged.

## Related Issues

PROOMPT-405

## Testing

- `kustomize build --enable-helm argocd/applications/bayn`
- `bun run lint:argocd`
- `bun test packages/scripts/src/bayn/verify-paper-activation.test.ts packages/scripts/src/bayn/bayn-paper-activation-workflow.test.ts packages/scripts/src/bayn/verify-promotion-eligibility.test.ts packages/scripts/src/bayn/verify-promotion-automerge.test.ts` (86 pass, 0 fail)
- `git diff --check`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled.
- [x] Documentation, release notes, and follow-ups are updated or tracked in PROOMPT-405.
