### PR TITLE
fix(bayn): admit paper bootstrap successor

### DIFF
--- a/services/bayn/src/cycle-runner.test.ts
+++ b/services/bayn/src/cycle-runner.test.ts
@@ -1127,6 +1127,20 @@ describe('autonomous cycle runner', () => {
         'PAPER_BOOTSTRAP',
       ),
     ).toEqual({ _tag: 'ALREADY_TERMINAL', cycle: blocked })
+    const newerPublication = finalizedPublicationInspection('2026-02-02')
+    expect(
+      completeCycleAuthoritySelection(
+        { _tag: 'UNCLAIMED', publications: [newerPublication, publication], latestTerminal: terminal },
+        'PAPER_BOOTSTRAP',
+      ),
+    ).toEqual({ _tag: 'READ_CALENDAR', publications: [newerPublication] })
+    const riskBlocked = { ...terminal, terminalReason: CycleTerminalReason.Risk }
+    expect(
+      completeCycleAuthoritySelection(
+        { _tag: 'UNCLAIMED', publications: [newerPublication], latestTerminal: riskBlocked },
+        'PAPER_BOOTSTRAP',
+      ),
+    ).toEqual({ _tag: 'ALREADY_TERMINAL', cycle: riskBlocked })
     expect(
       selectCycleAuthoritySlots([
         { publication, existing: terminal },
@@ -2477,6 +2491,63 @@ describe('autonomous cycle runner', () => {
     })
     expect(calendarReads).toBe(1)
     expect(control.binds).toBe(0)
+  })
+
+  test('admits only a newer PAPER bootstrap publication after a missed publication deadline', async () => {
+    const control: StoreControl = { acquisitions: [], binds: 0 }
+    const store = cycleStore(control)
+    let calendarReads = 0
+    const read = brokerRead(() => {
+      calendarReads += 1
+      return Effect.succeed({ value: monthEndCalendar, evidence })
+    })
+    const paperContext = { ...context(), cadence: 'PAPER_BOOTSTRAP' as const }
+    const missedPublication = finalizedPublicationInspection('2026-01-29', '2026-01-29T21:15:00.000Z')
+    const newerPublication = finalizedPublicationInspection('2026-01-30', '2026-01-30T21:15:00.000Z')
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        yield* TestClock.setTime(Date.parse('2026-01-30T14:30:00.000Z'))
+        const missed = yield* provide(
+          runAutonomousCyclePass(paperContext),
+          read,
+          store,
+          marketDataService(Effect.succeed(finalizedPublications([missedPublication]))),
+        )
+        yield* TestClock.setTime(Date.parse('2026-01-30T21:20:00.000Z'))
+        const successor = yield* provide(
+          runAutonomousCyclePass(paperContext),
+          read,
+          store,
+          marketDataService(
+            Effect.succeed(finalizedPublications([newerPublication, missedPublication])),
+            newerPublication,
+          ),
+        )
+        return { missed, successor }
+      }).pipe(Effect.provide(TestClock.layer())),
+    )
+
+    expect(result.missed).toMatchObject({
+      outcome: 'ACQUIRED',
+      signalSessionDate: '2026-01-29',
+      readiness: {
+        outcome: 'BLOCKED',
+        cycle: { state: CycleState.Blocked, terminalReason: CycleTerminalReason.MissedPublication },
+      },
+    })
+    expect(result.successor).toMatchObject({
+      outcome: 'ACQUIRED',
+      signalSessionDate: '2026-01-30',
+      executionSessionDate: '2026-02-02',
+      readiness: {
+        outcome: 'BOUND',
+        cycle: { state: CycleState.Pending, bindings: { snapshotId } },
+      },
+    })
+    expect(calendarReads).toBe(2)
+    expect(control.acquisitions).toHaveLength(2)
+    expect(control.binds).toBe(1)
   })
 
   test('reinspects and activates a bound cycle on restart before any new discovery', async () => {

--- a/services/bayn/src/cycle-runner/authority-decisions.ts
+++ b/services/bayn/src/cycle-runner/authority-decisions.ts
@@ -1,4 +1,4 @@
-import { CycleState, isTerminalCycleState, type AutonomousCycle } from '../cycle'
+import { CycleState, CycleTerminalReason, isTerminalCycleState, type AutonomousCycle } from '../cycle'
 import type { MarketDataInspection } from '../market-data'
 import type { NonEmptyPublications } from './calendar-decisions'
 
@@ -92,12 +92,20 @@ export const completeCycleAuthoritySelection = (
   cadence?: 'MONTHLY' | 'PAPER_BOOTSTRAP',
 ): CycleAuthoritySelection => {
   if (state._tag === 'TERMINAL') return { _tag: 'ALREADY_TERMINAL', cycle: state.latestTerminal }
-  if (
-    cadence === 'PAPER_BOOTSTRAP' &&
-    state.latestTerminal !== undefined &&
-    state.latestTerminal.state !== CycleState.NoTrade
-  ) {
-    return { _tag: 'ALREADY_TERMINAL', cycle: state.latestTerminal }
+  const latestTerminal = state.latestTerminal
+  if (cadence === 'PAPER_BOOTSTRAP' && latestTerminal !== undefined && latestTerminal.state !== CycleState.NoTrade) {
+    const newerPublications = state.publications.filter(
+      (publication) => publication.signalSession.session_date > latestTerminal.identity.signalSessionDate,
+    )
+    const [firstNewerPublication, ...remainingNewerPublications] = newerPublications
+    if (
+      latestTerminal.state === CycleState.Blocked &&
+      latestTerminal.terminalReason === CycleTerminalReason.MissedPublication &&
+      firstNewerPublication !== undefined
+    ) {
+      return { _tag: 'READ_CALENDAR', publications: [firstNewerPublication, ...remainingNewerPublications] }
+    }
+    return { _tag: 'ALREADY_TERMINAL', cycle: latestTerminal }
   }
   return { _tag: 'READ_CALENDAR', publications: state.publications }
 }


### PR DESCRIPTION
## Summary

- allow a research PAPER bootstrap cycle blocked only by a missed publication deadline to consider strictly newer finalized publications
- keep same-session, older, and every non-publication block terminal so risk, data, identity, and reconciliation failures cannot retry
- add pure selection coverage and an end-to-end restart regression proving the newer publication is acquired and snapshot-bound exactly once

## Related Issues

Linear PROOMPT-405

## Testing

- `bun test services/bayn/src/cycle-runner.test.ts` — 46 pass, 0 fail
- `bun run --filter @proompteng/bayn test` — 1,142 pass, 159 skip, 0 fail
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn lint:effect`
- `bun run --filter @proompteng/bayn build`
- `bunx oxfmt --check services/bayn/src/cycle-runner/authority-decisions.ts services/bayn/src/cycle-runner.test.ts`
- `git diff --check`
- `bun run --filter @proompteng/bayn test:postgres` — local PostgreSQL integration cases skipped because no test database is configured; hosted PostgreSQL is a required merge gate

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked in Linear PROOMPT-405.
