### PR TITLE
feat(bayn): roll paper scheduler fix

### DIFF
--- a/argocd/applications/bayn/deployment.yaml
+++ b/argocd/applications/bayn/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         app.kubernetes.io/name: bayn
         app.kubernetes.io/part-of: bayn
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-08-05T17:13:45Z"
+        kubectl.kubernetes.io/restartedAt: "2026-08-05T18:20:04Z"
     spec:
       serviceAccountName: bayn
       automountServiceAccountToken: false
@@ -47,11 +47,11 @@ spec:
               protocol: TCP
           env:
             - name: BAYN_CODE_REVISION
-              value: 78d5b3ae0f8286ab54b2349f6bb8ef79d2752cd1
+              value: 716d38b69e86e083dadc413d7ab880c536e0fac0
             - name: BAYN_IMAGE_REPOSITORY
               value: registry.ide-newton.ts.net/lab/bayn
             - name: BAYN_IMAGE_DIGEST
-              value: sha256:79ea78c09ce29ece97fb4c5c0070d568504a9f9695e5a1c74295415c987ff269
+              value: sha256:c3e81bc00b0a4601d932c311876ba1a59c7c83557c0cd56ad53ac12fae76ad33
             - name: BAYN_STRATEGY_BEHAVIOR_HASH
               value: "dde55f6292080b185554148cbfe4380e729626df1d11cbb47392645a80ce6c46"
             - name: BAYN_STRATEGY_PARAMETER_HASH

--- a/argocd/applications/bayn/kustomization.yaml
+++ b/argocd/applications/bayn/kustomization.yaml
@@ -22,5 +22,5 @@ configMapGenerator:
 images:
   - name: registry.ide-newton.ts.net/lab/bayn
     newName: registry.ide-newton.ts.net/lab/bayn
-    newTag: "sha-78d5b3ae0f8286ab54b2349f6bb8ef79d2752cd1"
-    digest: sha256:79ea78c09ce29ece97fb4c5c0070d568504a9f9695e5a1c74295415c987ff269
+    newTag: "sha-716d38b69e86e083dadc413d7ab880c536e0fac0"
+    digest: sha256:c3e81bc00b0a4601d932c311876ba1a59c7c83557c0cd56ad53ac12fae76ad33


### PR DESCRIPTION
## Summary

- roll Bayn to reviewed source `716d38b69e86e083dadc413d7ab880c536e0fac0`
- pin the exact published multi-architecture digest `sha256:c3e81bc00b0a4601d932c311876ba1a59c7c83557c0cd56ad53ac12fae76ad33`
- restart the single sandbox replica only after phase-one verification proved the controller-generated activation request hash is current
- leave credentials, authority, risk limits, strategy bindings, signal snapshot, and every other workload setting unchanged

## Related Issues

PROOMPT-405

## Testing

- `kustomize build argocd/applications/bayn >/dev/null`
- `bunx prettier --check argocd/applications/bayn/deployment.yaml argocd/applications/bayn/kustomization.yaml`
- `bun run lint:argocd`
- `git diff --check`
- mechanically verified the rendered source SHA, digest, tagged image, and restart annotation
- read-only live verification before this PR confirmed Argo applied phase-one main `1fd79bf9b4422ac208dd68098642e142fa3212d3`, SealedSecret generation 7 is synced, and the generated Secret carries request hash `c78ad441f389c31dd1daa15ffe4c941dc0a66b88c700f60259cc462ac9d2dc83`

## Rollout

Argo applies this normally. No direct sync or broker action is performed. The service must fail closed unless the deployed source/digest and already-verified activation request match; live acceptance requires exact source/image proof, PAPER authority, exact reconciliation, and zero unresolved mutations.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.