### PR TITLE
fix(bayn): rotate paper authority generation

### DIFF
--- a/argocd/applications/bayn/deployment.yaml
+++ b/argocd/applications/bayn/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         app.kubernetes.io/name: bayn
         app.kubernetes.io/part-of: bayn
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-08-05T18:20:04Z"
+        kubectl.kubernetes.io/restartedAt: "2026-08-05T18:39:15Z"
     spec:
       serviceAccountName: bayn
       automountServiceAccountToken: false
@@ -63,9 +63,9 @@ spec:
                   key: paper-activation-request
             - name: BAYN_MAXIMUM_AUTHORITY
               value: OBSERVE
-            # sha256("bayn/authority-generation/autonomous-observe-v5")
+            # sha256("bayn/authority-generation/autonomous-observe-v6")
             - name: BAYN_AUTHORITY_GENERATION_HASH
-              value: "dbb4d330aeb81b55715aff4cca8ad658ff3af0bf6394158609069ab8d1c0ebe9"
+              value: "8c36d4fe9956e2b73de40e47b5cb7a21d764acf3e0422bd4caaa88e594d6c94b"
             - name: BAYN_CYCLE_POLL_INTERVAL_MS
               value: "30000"
             - name: BAYN_BROKER_PROVIDER


### PR DESCRIPTION
## Summary

- rotate the immutable OBSERVE authority lineage from v5 to fresh v6 before recovering the reviewed research PAPER episode
- restart the exact reviewed `716d38b6` / `sha256:c3e81bc0` image so the existing guarded PAPER-to-OBSERVE rollover can run
- preserve the staged activation request, source/image, strategy, risk, and broker bindings without direct deployment or broker mutation

## Related Issues

Linear PROOMPT-405

## Testing

- `git diff --check`
- `kustomize build argocd/applications/bayn`
- `bunx prettier --check argocd/applications/bayn/deployment.yaml`
- `bun run lint:argocd`
- live read-only diagnosis: old PAPER generation is terminal, exact-reconciled after authority update, and has zero intents/mutations; v5 OBSERVE hash is already immutable history

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.