### PR TITLE
fix(bayn): prefer current cycle health

### DIFF
--- a/services/bayn/src/cycle-observability.test.ts
+++ b/services/bayn/src/cycle-observability.test.ts
@@ -435,24 +435,42 @@ describe('autonomous cycle operations classification', () => {
     })
   })
 
-  test('keeps a blocked terminal result failed through a later attempt and clears on confirmed terminal success', () => {
+  test('reports a current active successor while retaining the prior blocked terminal evidence', () => {
     const blocked = snapshot(CycleState.Blocked)
-    const recovering = deriveCycleOperationsStatus(
-      projection({
-        current: snapshot(CycleState.Active, {
-          cycleId: '4'.repeat(64),
-          signalSessionDate: '2026-07-20',
-          executionSessionDate: '2026-07-21',
-          submissionOpenAt: '2026-07-20T12:00:00.000Z',
-          submissionCutoffAt: '2026-07-20T12:30:00.000Z',
-          executionOpenAt: '2026-07-20T12:32:00.000Z',
-          executionCloseAt: '2026-07-20T20:00:00.000Z',
-          updatedAt: '2026-07-20T11:59:59.000Z',
-        }),
-        last: blocked,
-        unfinishedCycleCount: 1,
-      }),
+    const successor = snapshot(CycleState.Active, {
+      cycleId: '4'.repeat(64),
+      signalSessionDate: '2026-07-20',
+      executionSessionDate: '2026-07-21',
+      submissionOpenAt: '2026-07-21T12:45:00.000Z',
+      submissionCutoffAt: '2026-07-21T13:15:00.000Z',
+      executionOpenAt: '2026-07-21T13:30:00.000Z',
+      executionCloseAt: '2026-07-21T20:00:00.000Z',
+      updatedAt: '2026-07-21T13:30:00.000Z',
+    })
+    const recoveringProjection = projection({ current: successor, last: blocked, unfinishedCycleCount: 1 })
+    const withoutSuccessor = deriveCycleOperationsStatus(
+      projection({ last: blocked }),
       Date.parse(now),
+      Authority.Observe,
+      thresholds,
+    )
+    const recovering = deriveCycleOperationsStatus(
+      recoveringProjection,
+      Date.parse('2026-07-21T14:00:00.000Z'),
+      Authority.Observe,
+      thresholds,
+    )
+    const unsafeRecovering = deriveCycleOperationsStatus(
+      {
+        ...recoveringProjection,
+        mutations: {
+          eventCount: 1,
+          unresolvedCount: 1,
+          oldestUnresolvedAt: '2026-07-21T13:59:00.000Z',
+          latestOccurredAt: '2026-07-21T13:59:00.000Z',
+        },
+      },
+      Date.parse('2026-07-21T14:00:00.000Z'),
       Authority.Observe,
       thresholds,
     )
@@ -469,9 +487,21 @@ describe('autonomous cycle operations classification', () => {
       thresholds,
     )
 
-    expect(recovering).toMatchObject({
+    expect(withoutSuccessor).toMatchObject({
       condition: CycleOperationsCondition.Failed,
       reason: CycleOperationsReason.LastCycleBlocked,
+      alerts: { cycleFailed: true },
+    })
+    expect(recovering).toMatchObject({
+      current: { phase: CycleState.Active, cycleId: '4'.repeat(64) },
+      last: { phase: CycleState.Blocked, terminalReason: CycleTerminalReason.DataStale },
+      condition: CycleOperationsCondition.Running,
+      reason: CycleOperationsReason.Active,
+      alerts: { cycleFailed: false, cycleStalled: false },
+    })
+    expect(unsafeRecovering).toMatchObject({
+      condition: CycleOperationsCondition.Failed,
+      reason: CycleOperationsReason.UnresolvedMutation,
       alerts: { cycleFailed: true },
     })
     expect(recovered).toMatchObject({

--- a/services/bayn/src/cycle-observability.ts
+++ b/services/bayn/src/cycle-observability.ts
@@ -420,12 +420,11 @@ const lifecycleCondition = (
   nowMs: number,
   cycleStallThresholdMs: number,
 ): readonly [CycleOperationsCondition, CycleOperationsReason] => {
-  if (projection.last?.phase === CycleState.Blocked) {
-    return [CycleOperationsCondition.Failed, CycleOperationsReason.LastCycleBlocked]
-  }
-
   const current = projection.current
   if (current === null) {
+    if (projection.last?.phase === CycleState.Blocked) {
+      return [CycleOperationsCondition.Failed, CycleOperationsReason.LastCycleBlocked]
+    }
     if (projection.last?.phase === CycleState.Completed) {
       return [CycleOperationsCondition.Waiting, CycleOperationsReason.LastCycleCompleted]
     }

--- a/services/bayn/src/health.test.ts
+++ b/services/bayn/src/health.test.ts
@@ -21,7 +21,7 @@ import {
 } from './broker/alpaca'
 import { BrokerEnvironment, makeBrokerIdentity } from './broker/identity'
 import { CycleOperationsCondition, CycleOperationsReason, type CycleOperationsProjection } from './cycle-observability'
-import { CycleState } from './cycle'
+import { CycleState, CycleTerminalReason } from './cycle'
 import { CycleObservability, type CycleObservabilityShape } from './db/cycle-observability'
 import { EvidenceStore } from './db/evidence-store'
 import { BrokerAccess, CapitalAuthorityKind } from './execution/authority'
@@ -1131,6 +1131,64 @@ describe('Bayn continuous health', () => {
         },
       },
       failedDependencies: ['cycle'],
+    })
+  })
+
+  test('keeps readiness available when a current active cycle succeeds a blocked terminal cycle', () => {
+    const previous = pendingCycle('2026-07-20T11:00:00.000Z')
+    const current = pendingCycle('2026-07-21T11:00:00.000Z')
+    const transition = deriveHealthTransition(readyState(), {
+      config,
+      evidenceAvailable: true,
+      results: {
+        postgresql: { _tag: 'Available', value: undefined },
+        signal: { _tag: 'Available', value: undefined },
+        tigerBeetle: { _tag: 'Available', value: undefined },
+        durableEvidence: { _tag: 'Available', value: undefined },
+        cycle: {
+          _tag: 'Available',
+          value: {
+            ...emptyCycleProjection(),
+            current: {
+              ...current,
+              cycleId: '4'.repeat(64),
+              signalSessionDate: '2026-07-20',
+              executionSessionDate: '2026-07-21',
+              phase: CycleState.Active,
+              submissionOpenAt: '2026-07-21T12:45:00.000Z',
+              submissionCutoffAt: '2026-07-21T13:15:00.000Z',
+              executionOpenAt: '2026-07-21T13:30:00.000Z',
+              executionCloseAt: '2026-07-21T20:00:00.000Z',
+            },
+            last: {
+              ...previous,
+              phase: CycleState.Blocked,
+              snapshotId: null,
+              terminalReason: CycleTerminalReason.MissedPublication,
+              terminalAt: '2026-07-20T12:00:00.000Z',
+            },
+            unfinishedCycleCount: 1,
+          },
+        },
+        broker: null,
+      },
+      broker: undefined,
+      cycleFiber: { _tag: 'NotProvided' },
+      clock: availableClock('2026-07-21T14:00:00.000Z'),
+    })
+
+    expect(transition).toMatchObject({
+      next: {
+        status: 'READY',
+        cycle: {
+          current: { phase: CycleState.Active, cycleId: '4'.repeat(64) },
+          last: { phase: CycleState.Blocked, terminalReason: CycleTerminalReason.MissedPublication },
+          condition: CycleOperationsCondition.Running,
+          reason: CycleOperationsReason.Active,
+          alerts: { cycleFailed: false, cycleStalled: false },
+        },
+      },
+      failedDependencies: [],
     })
   })
 


### PR DESCRIPTION
## Summary

- derive cycle operational health from the current unfinished cycle before consulting terminal history
- preserve the prior blocked cycle and terminal reason as historical evidence without keeping a valid successor unready
- prove unresolved mutations and other safety failures still outrank current lifecycle health
- add a runtime-health regression for the exact live blocked-last plus active-current projection

## Related Issues

[PROOMPT-405](https://linear.app/proompteng/issue/PROOMPT-405/enable-and-prove-one-autonomous-paper-cycle-end-to-end)

## Testing

- `bun test services/bayn/src/cycle-observability.test.ts services/bayn/src/health.test.ts` — 49 passed, 0 failed
- `bun run --filter @proompteng/bayn test` — 1,143 passed, 159 PostgreSQL-only tests skipped, 0 failed
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:effect`
- `bunx oxfmt --check services/bayn/src/cycle-observability.ts services/bayn/src/cycle-observability.test.ts services/bayn/src/health.test.ts`
- `bun run --filter @proompteng/bayn build`

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is handled above.
- [x] No documentation or release-note change is required for this internal health-projection correction.