### PR TITLE
feat(bayn): roll health readiness fix

### DIFF
--- a/argocd/applications/bayn/deployment.yaml
+++ b/argocd/applications/bayn/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         app.kubernetes.io/name: bayn
         app.kubernetes.io/part-of: bayn
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-08-05T18:39:15Z"
+        kubectl.kubernetes.io/restartedAt: "2026-08-06T03:11:14Z"
     spec:
       serviceAccountName: bayn
       automountServiceAccountToken: false
@@ -47,11 +47,11 @@ spec:
               protocol: TCP
           env:
             - name: BAYN_CODE_REVISION
-              value: 716d38b69e86e083dadc413d7ab880c536e0fac0
+              value: a893d4550983e6edf4a95bd404698dca454bfacf
             - name: BAYN_IMAGE_REPOSITORY
               value: registry.ide-newton.ts.net/lab/bayn
             - name: BAYN_IMAGE_DIGEST
-              value: sha256:c3e81bc00b0a4601d932c311876ba1a59c7c83557c0cd56ad53ac12fae76ad33
+              value: sha256:06e7330ca10d3913c16593a52a22e78215c4b4e5bd38267ee62aa66b7fd60983
             - name: BAYN_STRATEGY_BEHAVIOR_HASH
               value: "dde55f6292080b185554148cbfe4380e729626df1d11cbb47392645a80ce6c46"
             - name: BAYN_STRATEGY_PARAMETER_HASH

--- a/argocd/applications/bayn/kustomization.yaml
+++ b/argocd/applications/bayn/kustomization.yaml
@@ -22,5 +22,5 @@ configMapGenerator:
 images:
   - name: registry.ide-newton.ts.net/lab/bayn
     newName: registry.ide-newton.ts.net/lab/bayn
-    newTag: "sha-716d38b69e86e083dadc413d7ab880c536e0fac0"
-    digest: sha256:c3e81bc00b0a4601d932c311876ba1a59c7c83557c0cd56ad53ac12fae76ad33
+    newTag: "sha-a893d4550983e6edf4a95bd404698dca454bfacf"
+    digest: sha256:06e7330ca10d3913c16593a52a22e78215c4b4e5bd38267ee62aa66b7fd60983


### PR DESCRIPTION
## Summary

- Roll Bayn to reviewed source `a893d4550983e6edf4a95bd404698dca454bfacf`, which fixes historical blocked-cycle precedence in readiness.
- Pin the exact published multi-architecture digest `sha256:06e7330ca10d3913c16593a52a22e78215c4b4e5bd38267ee62aa66b7fd60983`.
- Restart the single sandbox replica only after phase-one verification proved the live generated Secret contains matching research request hash `eb9b3e31e79fa31b942bebd7987e31ac9b88d51bcef3ac214e0fda20e105ce21`.
- Leave credentials, strategy, risk limits, authority lineage, signal snapshot, and all other workload settings unchanged.

## Related Issues

PROOMPT-405

## Testing

- `kustomize build argocd/applications/bayn`
- Exact rendered image/source/digest assertions with `yq`
- `bunx prettier --check argocd/applications/bayn/deployment.yaml argocd/applications/bayn/kustomization.yaml`
- `bun run lint:argocd`
- `git diff --check`
- Read-only live verification confirmed Argo applied phase one `a0bfaf3adeae8fb8ec30b4b836a6d4018bb9cffe`, SealedSecret generation 8 is synced, and the generated Secret carries the exact matching request hash.

## Rollout

Argo applies this normally. There is no direct sync or broker action. Live acceptance requires the exact source/image, HTTP 200 READY, the current ACTIVE cycle retained, PAPER authority, exact reconciliation, and zero premature mutations.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.