### PR TITLE
fix(bayn): rotate paper authority generation

### DIFF
--- a/argocd/applications/bayn/deployment.yaml
+++ b/argocd/applications/bayn/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         app.kubernetes.io/name: bayn
         app.kubernetes.io/part-of: bayn
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-08-06T03:11:14Z"
+        kubectl.kubernetes.io/restartedAt: "2026-08-06T03:22:09Z"
     spec:
       serviceAccountName: bayn
       automountServiceAccountToken: false
@@ -63,9 +63,9 @@ spec:
                   key: paper-activation-request
             - name: BAYN_MAXIMUM_AUTHORITY
               value: OBSERVE
-            # sha256("bayn/authority-generation/autonomous-observe-v6")
+            # sha256("bayn/authority-generation/autonomous-observe-v7")
             - name: BAYN_AUTHORITY_GENERATION_HASH
-              value: "8c36d4fe9956e2b73de40e47b5cb7a21d764acf3e0422bd4caaa88e594d6c94b"
+              value: "e26fd8bb80aea84d7da04b0a57bddf132031bf27badc8d3f12d7b9bc5ce7a519"
             - name: BAYN_CYCLE_POLL_INTERVAL_MS
               value: "30000"
             - name: BAYN_BROKER_PROVIDER


### PR DESCRIPTION
## Summary

- Rotate the immutable OBSERVE authority lineage from v6 to fresh v7 after the reviewed readiness source rollout.
- Restart the exact reviewed `a893d455` / `sha256:06e7330c` image so the existing guarded PAPER rearm can create a build-bound successor generation.
- Preserve the live activation request, strategy, risk, broker, source/image, and cycle bindings.

## Related Issues

PROOMPT-405

## Testing

- `kustomize build argocd/applications/bayn`
- Exact rendered authority-generation/source/image assertions with `yq`
- `bunx prettier --check argocd/applications/bayn/deployment.yaml`
- `bun run lint:argocd`
- `git diff --check`
- Read-only live diagnosis on exact source `a893d455`: activation failed closed with `research PAPER source authority rearm failed`, durable authority remained PAPER/PAPER/CLEAR, and mutation/unresolved counts remained zero.
- Verified the generated Secret still carries request hash `eb9b3e31e79fa31b942bebd7987e31ac9b88d51bcef3ac214e0fda20e105ce21` bound to the exact deployed source/digest.

## Rollout

Argo applies this normally. No direct sync or broker action is performed. Live acceptance requires successful research grant realization, HTTP 200 READY, recovery of the current cycle, PAPER authority, exact reconciliation, and zero premature mutations.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.