### PR TITLE
feat(restate): expose admin ui over tailscale

### DIFF
--- a/argocd/applications/restate/README.md
+++ b/argocd/applications/restate/README.md
@@ -1,0 +1,74 @@
+# Restate GitOps rollout notes
+
+This application deploys the self-hosted Restate server and its private admin UI exposure.
+
+## Admin UI exposure
+
+`restate-admin-tailscale` exposes the Restate admin/UI port only through the Tailscale Kubernetes operator:
+
+- Tailscale hostname: `restate-admin`
+- Kubernetes Service: `restate-admin-tailscale`
+- External port: `80`
+- Restate target port: `admin` / `9070`
+
+The Service intentionally carries `argocd.argoproj.io/ignore-healthcheck: "true"` because the Tailscale operator owns LoadBalancer readiness and the Argo health check should not block on tailnet endpoint allocation.
+
+## Post-sync verification
+
+After Argo reconciles this app from `main`, verify the core application and generated Tailscale resources:
+
+```sh
+kubectl get application -n argocd restate -o wide
+kubectl get svc -n restate restate restate-admin-tailscale -o wide
+kubectl get pods -n tailscale -l tailscale.com/parent-resource-ns=restate,tailscale.com/parent-resource=restate-admin-tailscale -o wide
+```
+
+Expected:
+
+- the `restate` Argo Application is `Synced` and `Healthy`;
+- `restate-admin-tailscale` exists with `loadBalancerClass: tailscale`;
+- one Tailscale proxy pod exists in the `tailscale` namespace with parent labels for `restate-admin-tailscale`;
+- opening `http://restate-admin` from an authorized tailnet client reaches the Restate admin UI.
+
+Verify the NetworkPolicy still blocks ordinary cluster workloads from admin port `9070`:
+
+```sh
+kubectl run restate-admin-deny-check \
+  -n default \
+  --rm \
+  -i \
+  --restart=Never \
+  --image=curlimages/curl:8.17.0 \
+  --image-pull-policy=IfNotPresent \
+  --command -- sh -ec '
+    if curl -sS --connect-timeout 2 --max-time 5 http://restate.restate.svc.cluster.local:9070/services >/tmp/out 2>/tmp/err; then
+      echo unexpected_admin_access
+      cat /tmp/out
+      exit 1
+    fi
+    echo admin_access_blocked
+    cat /tmp/err
+  '
+```
+
+Expected result: `admin_access_blocked`.
+
+## Recovery
+
+If `http://restate-admin` is unreachable after Argo sync:
+
+1. Inspect the Service and Tailscale proxy pod:
+   ```sh
+   kubectl describe svc -n restate restate-admin-tailscale
+   kubectl get pods -n tailscale -l tailscale.com/parent-resource-ns=restate,tailscale.com/parent-resource=restate-admin-tailscale -o wide
+   kubectl logs -n tailscale -l tailscale.com/parent-resource-ns=restate,tailscale.com/parent-resource=restate-admin-tailscale --tail=200
+   ```
+2. Verify Restate itself is healthy inside the cluster:
+   ```sh
+   kubectl -n restate port-forward svc/restate 9070:9070
+   curl -sSf http://127.0.0.1:9070/services
+   ```
+3. Confirm the NetworkPolicy has the Tailscale parent-resource allow rule for `restate-admin-tailscale`.
+4. If the Tailscale endpoint must be removed, revert the commit that added `admin-tailscale-service.yaml` and the matching NetworkPolicy rule, merge through GitOps, and sync the root Argo application.
+
+Do not expose Restate admin port `9070` through a public Ingress or unrestricted LoadBalancer. The admin port allows state-changing deployment registration.

--- a/argocd/applications/restate/admin-tailscale-service.yaml
+++ b/argocd/applications/restate/admin-tailscale-service.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: restate-admin-tailscale
+  labels:
+    app: restate
+    app.kubernetes.io/name: restate
+    app.kubernetes.io/component: admin-ui
+  annotations:
+    tailscale.com/hostname: restate-admin
+    # Tailscale LB readiness is managed by the operator; don't hold the Argo app in Progressing.
+    argocd.argoproj.io/ignore-healthcheck: "true"
+spec:
+  type: LoadBalancer
+  loadBalancerClass: tailscale
+  selector:
+    app: restate
+  ports:
+    - name: http-admin
+      port: 80
+      targetPort: admin
+      protocol: TCP

--- a/argocd/applications/restate/kustomization.yaml
+++ b/argocd/applications/restate/kustomization.yaml
@@ -5,5 +5,6 @@ resources:
   - serviceaccount.yaml
   - service-cluster.yaml
   - service.yaml
+  - admin-tailscale-service.yaml
   - statefulset.yaml
   - networkpolicy.yaml

--- a/argocd/applications/restate/networkpolicy.yaml
+++ b/argocd/applications/restate/networkpolicy.yaml
@@ -28,6 +28,19 @@ spec:
         - port: admin
           protocol: TCP
     - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: tailscale
+          podSelector:
+            matchLabels:
+              tailscale.com/managed: "true"
+              tailscale.com/parent-resource-ns: restate
+              tailscale.com/parent-resource-type: svc
+              tailscale.com/parent-resource: restate-admin-tailscale
+      ports:
+        - port: admin
+          protocol: TCP
+    - from:
         - namespaceSelector: {}
       ports:
         - port: ingress


### PR DESCRIPTION
## Summary

- Adds a Tailscale-only `restate-admin-tailscale` LoadBalancer Service for the Restate admin UI on hostname `restate-admin`.
- Keeps the admin surface off public ingress and exposes only port 9070 via Tailscale port 80.
- Narrows Restate admin ingress policy to allow only the dedicated Tailscale proxy pod for this Service, plus existing in-namespace/admin-access paths.

## Related Issues

None

## Testing

- `kubectl kustomize argocd/applications/restate > /tmp/restate-tailscale-render.yaml`
- `kubectl apply --dry-run=client -n restate -f /tmp/restate-tailscale-render.yaml`
- `kubectl apply --dry-run=server -n restate -f /tmp/restate-tailscale-render.yaml`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
