### PR TITLE
fix(bayn): bound paper targets to episode risk

### DIFF
--- a/services/bayn/src/observe-composition.test.ts
+++ b/services/bayn/src/observe-composition.test.ts
@@ -2877,6 +2877,58 @@ describe('OBSERVE runtime composition', () => {
     ).toBe(true)
   })
 
+  test('rejects a PAPER entry before planning when existing exposure cannot fit remaining turnover', async () => {
+    const policy = await Effect.runPromise(loadObserveRiskPolicy(accountId, fixtureProtocol.universe))
+    const highBalanceAccount: AccountSnapshot = {
+      ...account,
+      cashMicros: '100000000000',
+      equityMicros: '100000000000',
+      buyingPowerMicros: '400000000000',
+    }
+    const existingPosition: Position = {
+      schemaVersion: 'bayn.paper-position.v1',
+      accountId,
+      symbol: 'SPY',
+      quantityMicros: '10000000000',
+      averageEntryPriceMicros: '100000000',
+      marketPriceMicros: '100000000',
+      marketValueMicros: '1000000000000',
+      unrealizedPnlMicros: '0',
+      observedAt: reconciledAt,
+    }
+    const reconciled = reconciliationResult(generationHash, Authority.Paper, [existingPosition], [], highBalanceAccount)
+    const failure = await Effect.runPromise(
+      Effect.flip(
+        Effect.gen(function* () {
+          yield* TestClock.setTime(Date.parse(evaluatedAt))
+          return yield* buildMutationShadowCycleDecision({
+            authorityGenerationHash: generationHash,
+            cycle,
+            executionModel: fixtureProtocol.executionModel,
+            policy,
+            reconcile: Effect.succeed({
+              ...reconciled,
+              riskContext: {
+                ...reconciled.riskContext,
+                dailyTradedNotionalMicros: '750000000',
+              },
+            }),
+            strategy: runtimeWithDecision(() => Result.succeed(decision)),
+          })
+        }).pipe(
+          (effect) => provideDecisionServices(effect, marketData([]), calendarRead([])),
+          Effect.provide(TestClock.layer()),
+        ),
+      ),
+    )
+
+    expect(failure).toMatchObject({
+      _tag: 'ObserveDecisionCompositionFailure',
+      operation: 'paper-episode-allocation',
+      cause: { _tag: 'CurrentExposureExceedsRemainingTurnover' },
+    })
+  })
+
   test('fails closed when same-pass reconciliation observes another authority generation', async () => {
     const policy = await Effect.runPromise(loadObserveRiskPolicy(accountId, fixtureProtocol.universe))
     let strategyCalls = 0

--- a/services/bayn/src/observe-composition.test.ts
+++ b/services/bayn/src/observe-composition.test.ts
@@ -82,6 +82,7 @@ import {
   makeMutationAutonomousCycleStartup,
   makeObserveAutonomousCycleStartup,
   prepareObserveStartup,
+  terminalizeBlockedPaperCycle,
 } from './observe-composition'
 import {
   AccountStatus,
@@ -282,10 +283,14 @@ const account: AccountSnapshot = {
   observedAt: reconciledAt,
 }
 
-const reconciliation = (positions: readonly Position[] = [], orders: readonly Order[] = []): Reconciliation => {
+const reconciliation = (
+  positions: readonly Position[] = [],
+  orders: readonly Order[] = [],
+  brokerAccount: AccountSnapshot = account,
+): Reconciliation => {
   const stateHash = Result.getOrThrow(
     reconciledStateHash({
-      account,
+      account: brokerAccount,
       positions,
       positionsObservedAt: reconciledAt,
       orders,
@@ -318,8 +323,9 @@ const reconciliationResult = (
   maximum: Authority = Authority.Observe,
   positions: readonly Position[] = [],
   orders: readonly Order[] = [],
+  brokerAccount: AccountSnapshot = account,
 ): ReconciliationPassResult => {
-  const exact = reconciliation(positions, orders)
+  const exact = reconciliation(positions, orders, brokerAccount)
   return {
     report: {
       reconciliation: exact,
@@ -334,7 +340,7 @@ const reconciliationResult = (
       },
     },
     brokerState: {
-      account,
+      account: brokerAccount,
       positions,
       positionsObservedAt: reconciledAt,
       orders,
@@ -357,8 +363,8 @@ const reconciliationResult = (
       authorityObservedAt: reconciledAt,
       unknownMutationCount: 0,
       dailyTradedNotionalMicros: '0',
-      dayStartEquityMicros: account.equityMicros,
-      peakEquityMicros: account.equityMicros,
+      dayStartEquityMicros: brokerAccount.equityMicros,
+      peakEquityMicros: brokerAccount.equityMicros,
     },
   }
 }
@@ -1451,6 +1457,82 @@ describe('OBSERVE runtime composition', () => {
     const completion = Result.getOrThrow(decideCompletion(fixture.boundCycle, CycleState.Completed, observedAt))
     if (completion._tag !== 'VerifyDecision') return expect.unreachable('risk-blocked PAPER completion must verify')
     expect(Result.isFailure(validateCompletionDocument(completion, [fixture.document]))).toBe(true)
+  })
+
+  test('revokes PAPER authority before persisting a risk-blocked cycle terminal', async () => {
+    const fixture = await paperLifecycleFixture((policy) => ({
+      ...policy,
+      maxOrderNotionalMicros: '1',
+    }))
+    const observedAt = new Date(Date.parse(fixture.document.createdAt) + 1).toISOString()
+    const blockedCycle = Effect.runSync(
+      decodeAutonomousCycle({
+        ...fixture.boundCycle,
+        state: CycleState.Blocked,
+        terminalReason: CycleTerminalReason.Risk,
+        stateVersion: fixture.boundCycle.stateVersion + 1,
+        updatedAt: observedAt,
+        terminalAt: observedAt,
+      }),
+    )
+    const events: string[] = []
+    const unused = Effect.die(new Error('blocked PAPER terminalization used an unrelated cycle-store operation'))
+    const cycleStore: CycleStoreShape = {
+      acquire: () => unused,
+      read: () => unused,
+      readAuthoritySlot: () => unused,
+      readDecisionDocument: () => unused,
+      readOldestUnfinished: () => unused,
+      bindSnapshot: () => unused,
+      activate: () => unused,
+      bindDecision: () => unused,
+      finish: () => unused,
+      block: (cycleId, reason, terminalAt) =>
+        Effect.sync(() => {
+          events.push('block')
+          expect(cycleId).toBe(fixture.boundCycle.identity.cycleId)
+          expect(reason).toBe(CycleTerminalReason.Risk)
+          expect(terminalAt).toBe(observedAt)
+          return { cycle: blockedCycle, changed: true }
+        }),
+    }
+    const authorityRestrictionStore: AuthorityRestrictionStoreShape = {
+      restrictAuthority: (reason, updatedAt) =>
+        Effect.sync(() => {
+          events.push('restrict')
+          expect(reason).toBe(
+            `PAPER autonomous cycle loop restricted effective authority: bound cycle ${fixture.boundCycle.identity.cycleId} blocked: BLOCKED_RISK`,
+          )
+          expect(updatedAt).toBe(observedAt)
+        }),
+    }
+    const writerFence: WriterFenceService = {
+      backendPid: 1,
+      check: unused,
+      transaction: (effect) =>
+        Effect.sync(() => {
+          events.push('fence')
+        }).pipe(Effect.andThen(effect)),
+    }
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        yield* TestClock.setTime(Date.parse(observedAt))
+        return yield* terminalizeBlockedPaperCycle(fixture.boundCycle, {
+          _tag: 'Block',
+          reason: CycleTerminalReason.Risk,
+          observedAt,
+        })
+      }).pipe(
+        Effect.provideService(CycleStore, cycleStore),
+        Effect.provideService(AuthorityRestrictionStore, authorityRestrictionStore),
+        Effect.provideService(WriterFence, writerFence),
+        Effect.provide(TestClock.layer()),
+      ),
+    )
+
+    expect(events).toEqual(['fence', 'restrict', 'block'])
+    expect(result).toMatchObject({ action: 'BLOCKED', cycle: { state: CycleState.Blocked } })
   })
 
   test('terminalizes an untouched PAPER remainder when its durable approval expires', async () => {
@@ -2744,6 +2826,55 @@ describe('OBSERVE runtime composition', () => {
     for (const altered of [alteredGeneration, alteredTarget, alteredOrder, alteredCumulativeRisk, alteredExpiry]) {
       expect(Result.isFailure(altered)).toBe(true)
     }
+  })
+
+  test('binds a high-balance PAPER account to the episode capital budget before risk evaluation', async () => {
+    const policy = await Effect.runPromise(loadObserveRiskPolicy(accountId, fixtureProtocol.universe))
+    const highBalanceAccount: AccountSnapshot = {
+      ...account,
+      cashMicros: '100000000000',
+      equityMicros: '100000000000',
+      buyingPowerMicros: '400000000000',
+    }
+    const fullyAllocatedDecision: DecisionPlan = {
+      ...decision,
+      targetWeights: {
+        DBC: 0.1946,
+        EFA: 0.2151,
+        IEF: 0,
+        SPY: 0.35,
+        VNQ: 0.2403,
+      },
+    }
+    const program = Effect.gen(function* () {
+      yield* TestClock.setTime(Date.parse(evaluatedAt))
+      return yield* buildMutationShadowCycleDecision({
+        authorityGenerationHash: generationHash,
+        cycle,
+        executionModel: fixtureProtocol.executionModel,
+        policy,
+        reconcile: Effect.succeed(reconciliationResult(generationHash, Authority.Paper, [], [], highBalanceAccount)),
+        strategy: runtimeWithDecision(() => Result.succeed(fullyAllocatedDecision)),
+      })
+    }).pipe(
+      (effect) => provideDecisionServices(effect, marketData([]), calendarRead([])),
+      Effect.provide(TestClock.layer()),
+    )
+
+    const document = await Effect.runPromise(program)
+    const plannedNotional = BigInt(document.targetPlan.requiredReferenceBuyNotionalMicros)
+
+    expect(plannedNotional).toBeGreaterThan(0n)
+    expect(plannedNotional).toBeLessThan(BigInt(policy.maxDailyTradedNotionalMicros))
+    expect(document.riskBlock).toBeUndefined()
+    expect(document).toMatchObject({ mode: 'PAPER', dispatchable: true })
+    expect(document.deltaRisk).toHaveLength(4)
+    expect(
+      document.deltaRisk.every(
+        ({ evaluation }) =>
+          evaluation.decision.outcome === RiskOutcome.Approved && evaluation.decision.reasonCodes.length === 0,
+      ),
+    ).toBe(true)
   })
 
   test('fails closed when same-pass reconciliation observes another authority generation', async () => {

--- a/services/bayn/src/observe-composition.ts
+++ b/services/bayn/src/observe-composition.ts
@@ -632,17 +632,15 @@ const reduceRiskInputs = (
     Result.all(
       input.targetPlan.intentTargets.map((target) => {
         const referencePrice = BigInt(input.prices.priceMicros[target.symbol])
-        const quantity = BigInt(target.quantityMicros)
         return Result.map(
           makeFillTerms(
             target.side === OrderSide.Buy ? 'buy' : 'sell',
-            quantity,
+            BigInt(target.quantityMicros),
             referencePrice,
             input.executionModel,
             MICROS,
           ),
           (fillTerms): ShadowDeltaRiskInput => {
-            const orderNotionalLimit = (quantity * fillTerms.fillPriceMicros + MICROS - 1n) / MICROS
             const state: State = {
               schemaVersion: 'bayn.paper-risk-state.v2',
               brokerMode: BrokerMode.Paper,
@@ -673,7 +671,7 @@ const reduceRiskInputs = (
             }
             return {
               symbol: target.symbol,
-              notionalLimitMicros: orderNotionalLimit.toString(),
+              notionalLimitMicros: fillTerms.notionalMicros.toString(),
               state,
             }
           },

--- a/services/bayn/src/observe-composition.ts
+++ b/services/bayn/src/observe-composition.ts
@@ -251,6 +251,7 @@ type ObserveDecisionCompositionFailure = {
     | 'compiled-decision-hash'
     | 'cycle-binding'
     | 'observe-authority'
+    | 'paper-episode-allocation'
     | 'reconciled-state-hash'
     | 'reference-prices'
     | 'risk-policy-hash'
@@ -736,6 +737,29 @@ function buildCycleDecision<R>(
     )
     const executionSession = yield* Effect.fromResult(prepareExecutionSessionBinding(input, facts))
     const compiled = yield* compileObserveStrategyDecision(input, facts, executionSession)
+    const allocationCapitalMicros =
+      authorityRequirement === Authority.Paper
+        ? yield* Effect.fromResult(
+            paperEpisodeAllocationCapitalMicros({
+              accountEquityMicros: BigInt(facts.reconciliation.brokerState.account.equityMicros),
+              dailyTradedNotionalMicros: BigInt(facts.reconciliation.riskContext.dailyTradedNotionalMicros),
+              maxGrossExposureMicros: BigInt(input.policy.maxGrossExposureMicros),
+              maxNetExposureMicros: BigInt(input.policy.maxNetExposureMicros),
+              maxDailyTradedNotionalMicros: BigInt(input.policy.maxDailyTradedNotionalMicros),
+              maxAdverseSlippageBps: BigInt(input.policy.maxAdverseSlippageBps),
+              positions: facts.reconciliation.brokerState.positions,
+              referencePriceMicros: compiled.priceMicros,
+            }),
+          ).pipe(
+            Effect.mapError((cause) =>
+              compositionFailure(
+                'paper-episode-allocation',
+                'PAPER entry cannot fit its complete sell-plus-buy plan inside the remaining turnover budget',
+                cause,
+              ),
+            ),
+          )
+        : undefined
     const plannerPreparation = yield* Effect.fromResult(
       prepareObservePlanner(
         input,
@@ -743,14 +767,7 @@ function buildCycleDecision<R>(
         compiled,
         authorityRequirement === Authority.Paper
           ? {
-              allocationCapitalMicros: paperEpisodeAllocationCapitalMicros({
-                accountEquityMicros: BigInt(facts.reconciliation.brokerState.account.equityMicros),
-                dailyTradedNotionalMicros: BigInt(facts.reconciliation.riskContext.dailyTradedNotionalMicros),
-                maxGrossExposureMicros: BigInt(input.policy.maxGrossExposureMicros),
-                maxNetExposureMicros: BigInt(input.policy.maxNetExposureMicros),
-                maxDailyTradedNotionalMicros: BigInt(input.policy.maxDailyTradedNotionalMicros),
-                maxAdverseSlippageBps: BigInt(input.policy.maxAdverseSlippageBps),
-              }).toString(),
+              allocationCapitalMicros: allocationCapitalMicros?.toString(),
             }
           : {},
       ),

--- a/services/bayn/src/observe-composition.ts
+++ b/services/bayn/src/observe-composition.ts
@@ -57,7 +57,7 @@ import { makeStrategyProtocolHash } from './contracts'
 import { OperationalError, operationalError } from './errors'
 import { canonicalHashV1Result } from './hash'
 import { MarketData, type MarketDataService } from './market-data'
-import { decidePaperEpisodeCycleTerminalization } from './paper-episode'
+import { decidePaperEpisodeCycleTerminalization, paperEpisodeAllocationCapitalMicros } from './paper-episode'
 import {
   Authority,
   IntentState,
@@ -290,6 +290,7 @@ type ObservePlannerPreparation = {
 }
 
 type ObservePlannerOverrides = {
+  readonly allocationCapitalMicros?: string
   readonly targetWeights?: DecisionPlan['targetWeights']
   readonly submissionCutoffAt?: string
 }
@@ -597,6 +598,9 @@ const prepareObservePlanner = <R>(
               accountId: input.cycle.identity.accountId,
               signalDate: input.cycle.identity.signalSessionDate,
               targetWeights: overrides.targetWeights ?? compiled.decision.targetWeights,
+              ...(overrides.allocationCapitalMicros === undefined
+                ? {}
+                : { allocationCapitalMicros: overrides.allocationCapitalMicros }),
               referencePrices: prices,
               brokerState: facts.reconciliation.brokerState,
               precision: input.executionModel.precision,
@@ -628,15 +632,17 @@ const reduceRiskInputs = (
     Result.all(
       input.targetPlan.intentTargets.map((target) => {
         const referencePrice = BigInt(input.prices.priceMicros[target.symbol])
+        const quantity = BigInt(target.quantityMicros)
         return Result.map(
           makeFillTerms(
             target.side === OrderSide.Buy ? 'buy' : 'sell',
-            BigInt(target.quantityMicros),
+            quantity,
             referencePrice,
             input.executionModel,
             MICROS,
           ),
           (fillTerms): ShadowDeltaRiskInput => {
+            const orderNotionalLimit = (quantity * fillTerms.fillPriceMicros + MICROS - 1n) / MICROS
             const state: State = {
               schemaVersion: 'bayn.paper-risk-state.v2',
               brokerMode: BrokerMode.Paper,
@@ -667,7 +673,7 @@ const reduceRiskInputs = (
             }
             return {
               symbol: target.symbol,
-              notionalLimitMicros: fillTerms.notionalMicros.toString(),
+              notionalLimitMicros: orderNotionalLimit.toString(),
               state,
             }
           },
@@ -723,7 +729,25 @@ function buildCycleDecision<R>(
     )
     const executionSession = yield* Effect.fromResult(prepareExecutionSessionBinding(input, facts))
     const compiled = yield* compileObserveStrategyDecision(input, facts, executionSession)
-    const plannerPreparation = yield* Effect.fromResult(prepareObservePlanner(input, facts, compiled))
+    const plannerPreparation = yield* Effect.fromResult(
+      prepareObservePlanner(
+        input,
+        facts,
+        compiled,
+        authorityRequirement === Authority.Paper
+          ? {
+              allocationCapitalMicros: paperEpisodeAllocationCapitalMicros({
+                accountEquityMicros: BigInt(facts.reconciliation.brokerState.account.equityMicros),
+                dailyTradedNotionalMicros: BigInt(facts.reconciliation.riskContext.dailyTradedNotionalMicros),
+                maxGrossExposureMicros: BigInt(input.policy.maxGrossExposureMicros),
+                maxNetExposureMicros: BigInt(input.policy.maxNetExposureMicros),
+                maxDailyTradedNotionalMicros: BigInt(input.policy.maxDailyTradedNotionalMicros),
+                maxAdverseSlippageBps: BigInt(input.policy.maxAdverseSlippageBps),
+              }).toString(),
+            }
+          : {},
+      ),
+    )
     const targetPlan = yield* Effect.fromResult(planTargets(plannerPreparation.plannerInput))
     const riskInputs = yield* Effect.fromResult(
       reduceObserveRiskInputs(
@@ -1542,6 +1566,28 @@ const terminalizeUnboundMutationCycleAtCutoff = (
     })),
   )
 
+export const terminalizeBlockedPaperCycle = (
+  cycle: AutonomousCycle,
+  outcome: Extract<BoundMutationCycleOutcome, { readonly _tag: 'Block' }>,
+): Effect.Effect<CycleRunResult, CycleRunnerError, CycleStore | AuthorityRestrictionStore | WriterFence> =>
+  restrictMutationAuthority(
+    'PAPER autonomous cycle loop',
+    `bound cycle ${cycle.identity.cycleId} blocked: ${outcome.reason}`,
+  ).pipe(
+    Effect.andThen(
+      CycleStore.pipe(
+        Effect.flatMap((store) => store.block(cycle.identity.cycleId, outcome.reason, outcome.observedAt)),
+        Effect.mapError((cause) => mutationRunnerError('blocked PAPER cycle finalization failed', cause, 'store')),
+      ),
+    ),
+    Effect.map((receipt) => ({
+      outcome: 'RECOVERED' as const,
+      action: 'BLOCKED' as const,
+      observedAt: outcome.observedAt,
+      cycle: receipt.cycle,
+    })),
+  )
+
 const interpretBoundMutationCycleOutcome = (
   input: ObserveAutonomousCycleInput,
   outcome: BoundMutationCycleOutcome,
@@ -1559,16 +1605,7 @@ const interpretBoundMutationCycleOutcome = (
         cycle,
       })
     case 'Block':
-      return CycleStore.pipe(
-        Effect.flatMap((store) => store.block(cycle.identity.cycleId, outcome.reason, outcome.observedAt)),
-        Effect.mapError((cause) => mutationRunnerError('expired PAPER cycle finalization failed', cause, 'store')),
-        Effect.map((receipt) => ({
-          outcome: 'RECOVERED' as const,
-          action: 'BLOCKED' as const,
-          observedAt: outcome.observedAt,
-          cycle: receipt.cycle,
-        })),
-      )
+      return terminalizeBlockedPaperCycle(cycle, outcome)
     case 'Complete':
       return CycleStore.pipe(
         Effect.flatMap((store) => store.finish(cycle.identity.cycleId, CycleState.Completed, outcome.observedAt)),

--- a/services/bayn/src/observe-composition.ts
+++ b/services/bayn/src/observe-composition.ts
@@ -587,10 +587,8 @@ const prepareObservePlanner = <R>(
             'current strategy decision is not canonicalizable',
             compiled.decision,
           ),
-          (decisionHash) => ({
-            prices,
-            plannerInput: {
-              schemaVersion: 'bayn.paper-target-planner-input.v1',
+          (decisionHash) => {
+            const commonPlannerInput = {
               strategyName: input.cycle.identity.strategyName,
               cycleId: input.cycle.identity.cycleId,
               decisionHash,
@@ -598,17 +596,28 @@ const prepareObservePlanner = <R>(
               accountId: input.cycle.identity.accountId,
               signalDate: input.cycle.identity.signalSessionDate,
               targetWeights: overrides.targetWeights ?? compiled.decision.targetWeights,
-              ...(overrides.allocationCapitalMicros === undefined
-                ? {}
-                : { allocationCapitalMicros: overrides.allocationCapitalMicros }),
               referencePrices: prices,
               brokerState: facts.reconciliation.brokerState,
               precision: input.executionModel.precision,
               maximumInputAgeMs: Math.min(input.policy.maxBrokerStateAgeMs, input.policy.maxMarketDataAgeMs),
               submissionCutoffAt: overrides.submissionCutoffAt ?? input.cycle.window.submissionCutoffAt,
               observedAt: facts.evaluatedAt,
-            },
-          }),
+            }
+            return {
+              prices,
+              plannerInput:
+                overrides.allocationCapitalMicros === undefined
+                  ? {
+                      schemaVersion: 'bayn.paper-target-planner-input.v1' as const,
+                      ...commonPlannerInput,
+                    }
+                  : {
+                      schemaVersion: 'bayn.paper-target-planner-input.v2' as const,
+                      ...commonPlannerInput,
+                      allocationCapitalMicros: overrides.allocationCapitalMicros,
+                    },
+            }
+          },
         ),
     ),
   )

--- a/services/bayn/src/paper-episode.test.ts
+++ b/services/bayn/src/paper-episode.test.ts
@@ -44,15 +44,54 @@ describe('paperEpisodeAllocationCapitalMicros', () => {
       maxNetExposureMicros: 1_000_000_000n,
       maxDailyTradedNotionalMicros: 1_000_000_000n,
       maxAdverseSlippageBps: 0n,
+      positions: [],
+      referencePriceMicros: {},
     }
 
-    expect(paperEpisodeAllocationCapitalMicros(common)).toBe(1_000_000_000n)
-    expect(paperEpisodeAllocationCapitalMicros({ ...common, dailyTradedNotionalMicros: 750_000_000n })).toBe(
-      250_000_000n,
+    expect(Result.getOrThrow(paperEpisodeAllocationCapitalMicros(common))).toBe(1_000_000_000n)
+    expect(
+      Result.getOrThrow(paperEpisodeAllocationCapitalMicros({ ...common, dailyTradedNotionalMicros: 750_000_000n })),
+    ).toBe(250_000_000n)
+    expect(
+      Result.getOrThrow(paperEpisodeAllocationCapitalMicros({ ...common, accountEquityMicros: 200_000_000n })),
+    ).toBe(200_000_000n)
+    expect(
+      Result.getOrThrow(paperEpisodeAllocationCapitalMicros({ ...common, dailyTradedNotionalMicros: 1_000_000_001n })),
+    ).toBe(0n)
+    expect(Result.getOrThrow(paperEpisodeAllocationCapitalMicros({ ...common, maxAdverseSlippageBps: 10n }))).toBe(
+      999_000_999n,
     )
-    expect(paperEpisodeAllocationCapitalMicros({ ...common, accountEquityMicros: 200_000_000n })).toBe(200_000_000n)
-    expect(paperEpisodeAllocationCapitalMicros({ ...common, dailyTradedNotionalMicros: 1_000_000_001n })).toBe(0n)
-    expect(paperEpisodeAllocationCapitalMicros({ ...common, maxAdverseSlippageBps: 10n })).toBe(999_000_999n)
+  })
+
+  test('bounds both sides of a rebalance and rejects exposure that cannot fit the remaining turnover', () => {
+    const common = {
+      accountEquityMicros: 100_000_000_000n,
+      dailyTradedNotionalMicros: 750_000_000n,
+      maxGrossExposureMicros: 1_000_000_000n,
+      maxNetExposureMicros: 1_000_000_000n,
+      maxDailyTradedNotionalMicros: 1_000_000_000n,
+      maxAdverseSlippageBps: 0n,
+      referencePriceMicros: { SPY: '100000000' },
+    }
+    const scalable = Result.getOrThrow(
+      paperEpisodeAllocationCapitalMicros({
+        ...common,
+        positions: [{ symbol: 'SPY', quantityMicros: '1000000' }],
+      }),
+    )
+    const rejected = paperEpisodeAllocationCapitalMicros({
+      ...common,
+      positions: [{ symbol: 'SPY', quantityMicros: '10000000' }],
+    })
+
+    expect(scalable).toBe(150_000_000n)
+    expect(rejected).toEqual(
+      Result.fail({
+        _tag: 'CurrentExposureExceedsRemainingTurnover',
+        currentReferenceGrossExposureMicros: 1_000_000_000n,
+        remainingReferenceTurnoverMicros: 250_000_000n,
+      }),
+    )
   })
 })
 

--- a/services/bayn/src/paper-episode.test.ts
+++ b/services/bayn/src/paper-episode.test.ts
@@ -6,6 +6,7 @@ import {
   decidePaperEpisodeAuthority,
   decidePaperEpisodeCycleTerminalization,
   failedPaperEpisode,
+  paperEpisodeAllocationCapitalMicros,
   paperGrantFromGeneration,
   paperGrantKey,
   validatePaperEpisodeCloseWindow,
@@ -32,6 +33,27 @@ const safeFacts = (overrides: Partial<PaperEpisodeFacts> = {}): PaperEpisodeFact
     unresolvedMutationCount: 0,
   },
   ...overrides,
+})
+
+describe('paperEpisodeAllocationCapitalMicros', () => {
+  test('selects the smallest account, exposure, and remaining-turnover bound', () => {
+    const common = {
+      accountEquityMicros: 100_000_000_000n,
+      dailyTradedNotionalMicros: 0n,
+      maxGrossExposureMicros: 1_000_000_000n,
+      maxNetExposureMicros: 1_000_000_000n,
+      maxDailyTradedNotionalMicros: 1_000_000_000n,
+      maxAdverseSlippageBps: 0n,
+    }
+
+    expect(paperEpisodeAllocationCapitalMicros(common)).toBe(1_000_000_000n)
+    expect(paperEpisodeAllocationCapitalMicros({ ...common, dailyTradedNotionalMicros: 750_000_000n })).toBe(
+      250_000_000n,
+    )
+    expect(paperEpisodeAllocationCapitalMicros({ ...common, accountEquityMicros: 200_000_000n })).toBe(200_000_000n)
+    expect(paperEpisodeAllocationCapitalMicros({ ...common, dailyTradedNotionalMicros: 1_000_000_001n })).toBe(0n)
+    expect(paperEpisodeAllocationCapitalMicros({ ...common, maxAdverseSlippageBps: 10n })).toBe(999_000_999n)
+  })
 })
 
 const success = (state: PaperEpisodeState, facts: PaperEpisodeFacts) => {

--- a/services/bayn/src/paper-episode.ts
+++ b/services/bayn/src/paper-episode.ts
@@ -1,5 +1,6 @@
 import { Result, Schema } from 'effect'
 
+import { notionalMicros } from './execution-model'
 import { Sha256Schema } from './schemas'
 
 export const QualificationBindingSchema = Schema.Struct({
@@ -27,24 +28,82 @@ export interface PaperEpisodeAllocationFacts {
   readonly maxNetExposureMicros: bigint
   readonly maxDailyTradedNotionalMicros: bigint
   readonly maxAdverseSlippageBps: bigint
+  readonly positions: readonly {
+    readonly quantityMicros: string
+    readonly symbol: string
+  }[]
+  readonly referencePriceMicros: Readonly<Record<string, string>>
 }
 
+export type PaperEpisodeAllocationFailure =
+  | {
+      readonly _tag: 'CurrentExposureExceedsRemainingTurnover'
+      readonly currentReferenceGrossExposureMicros: bigint
+      readonly remainingReferenceTurnoverMicros: bigint
+    }
+  | { readonly _tag: 'InvalidPositionReferenceNotional'; readonly cause: unknown; readonly symbol: string }
+  | { readonly _tag: 'MissingPositionReferencePrice'; readonly symbol: string }
+
 const nonNegative = (value: bigint): bigint => (value < 0n ? 0n : value)
+const absolute = (value: bigint): bigint => (value < 0n ? -value : value)
 const BASIS_POINTS = 10_000n
 
-/** Bounds target construction to the capital that this episode may actually put at risk. */
-export const paperEpisodeAllocationCapitalMicros = (facts: PaperEpisodeAllocationFacts): bigint => {
+const currentReferenceGrossExposureMicros = (
+  facts: PaperEpisodeAllocationFacts,
+): Result.Result<bigint, PaperEpisodeAllocationFailure> =>
+  facts.positions.reduce<Result.Result<bigint, PaperEpisodeAllocationFailure>>(
+    (total, position) =>
+      Result.flatMap(total, (current) => {
+        const price = facts.referencePriceMicros[position.symbol]
+        if (price === undefined) {
+          return Result.fail({ _tag: 'MissingPositionReferencePrice', symbol: position.symbol })
+        }
+        return Result.mapError(
+          Result.map(
+            notionalMicros(absolute(BigInt(position.quantityMicros)), BigInt(price)),
+            (notional) => current + notional,
+          ),
+          (cause): PaperEpisodeAllocationFailure => ({
+            _tag: 'InvalidPositionReferenceNotional',
+            cause,
+            symbol: position.symbol,
+          }),
+        )
+      }),
+    Result.succeed(0n),
+  )
+
+/**
+ * Bounds entry target construction by a sell-plus-buy turnover upper bound. Current reference gross exposure plus
+ * target gross capital bounds every absolute target delta, including rotations; an infeasible current portfolio is
+ * rejected before target planning instead of producing a risk-blocked authority transition.
+ */
+export const paperEpisodeAllocationCapitalMicros = (
+  facts: PaperEpisodeAllocationFacts,
+): Result.Result<bigint, PaperEpisodeAllocationFailure> => {
   const remainingDailyTurnover = nonNegative(facts.maxDailyTradedNotionalMicros - facts.dailyTradedNotionalMicros)
-  const referenceCapitalWithinTurnover =
+  const remainingReferenceTurnover =
     (remainingDailyTurnover * BASIS_POINTS) / (BASIS_POINTS + nonNegative(facts.maxAdverseSlippageBps))
-  return [
-    facts.accountEquityMicros,
-    facts.maxGrossExposureMicros,
-    facts.maxNetExposureMicros,
-    referenceCapitalWithinTurnover,
-  ]
-    .map(nonNegative)
-    .reduce((minimum, value) => (value < minimum ? value : minimum))
+  return Result.flatMap(currentReferenceGrossExposureMicros(facts), (currentReferenceGrossExposure) => {
+    if (currentReferenceGrossExposure > remainingReferenceTurnover) {
+      return Result.fail({
+        _tag: 'CurrentExposureExceedsRemainingTurnover',
+        currentReferenceGrossExposureMicros: currentReferenceGrossExposure,
+        remainingReferenceTurnoverMicros: remainingReferenceTurnover,
+      })
+    }
+    const referenceCapitalWithinTurnover = remainingReferenceTurnover - currentReferenceGrossExposure
+    return Result.succeed(
+      [
+        facts.accountEquityMicros,
+        facts.maxGrossExposureMicros,
+        facts.maxNetExposureMicros,
+        referenceCapitalWithinTurnover,
+      ]
+        .map(nonNegative)
+        .reduce((minimum, value) => (value < minimum ? value : minimum)),
+    )
+  })
 }
 
 export const paperGrantKey = (grant: PaperGrant): string =>

--- a/services/bayn/src/paper-episode.ts
+++ b/services/bayn/src/paper-episode.ts
@@ -20,6 +20,33 @@ export const ResearchPaperGrantSchema = Schema.Struct({
 export const PaperGrantSchema = Schema.Union([QualifiedPaperGrantSchema, ResearchPaperGrantSchema])
 export type PaperGrant = typeof PaperGrantSchema.Type
 
+export interface PaperEpisodeAllocationFacts {
+  readonly accountEquityMicros: bigint
+  readonly dailyTradedNotionalMicros: bigint
+  readonly maxGrossExposureMicros: bigint
+  readonly maxNetExposureMicros: bigint
+  readonly maxDailyTradedNotionalMicros: bigint
+  readonly maxAdverseSlippageBps: bigint
+}
+
+const nonNegative = (value: bigint): bigint => (value < 0n ? 0n : value)
+const BASIS_POINTS = 10_000n
+
+/** Bounds target construction to the capital that this episode may actually put at risk. */
+export const paperEpisodeAllocationCapitalMicros = (facts: PaperEpisodeAllocationFacts): bigint => {
+  const remainingDailyTurnover = nonNegative(facts.maxDailyTradedNotionalMicros - facts.dailyTradedNotionalMicros)
+  const referenceCapitalWithinTurnover =
+    (remainingDailyTurnover * BASIS_POINTS) / (BASIS_POINTS + nonNegative(facts.maxAdverseSlippageBps))
+  return [
+    facts.accountEquityMicros,
+    facts.maxGrossExposureMicros,
+    facts.maxNetExposureMicros,
+    referenceCapitalWithinTurnover,
+  ]
+    .map(nonNegative)
+    .reduce((minimum, value) => (value < minimum ? value : minimum))
+}
+
 export const paperGrantKey = (grant: PaperGrant): string =>
   grant._tag === 'Qualified' ? grant.qualification.runId : grant.planHash
 

--- a/services/bayn/src/risk.test.ts
+++ b/services/bayn/src/risk.test.ts
@@ -61,6 +61,7 @@ const riskFailurePairs = [
   { operation: 'bind-authority', reason: 'authority-maximum' },
   { operation: 'canonicalize-input', reason: 'evidence' },
   { operation: 'canonicalize-input', reason: 'reconciliation' },
+  { operation: 'compute-metrics', reason: 'order-notional' },
   { operation: 'decode-input', reason: 'intent' },
   { operation: 'decode-input', reason: 'policy' },
   { operation: 'decode-input', reason: 'positions' },
@@ -373,6 +374,18 @@ const openOrder = (brokerOrderId: string) => ({
 })
 
 describe('bounded paper risk', () => {
+  test('uses the execution-model half-up notional at the intent and mutation boundary', () => {
+    const intent = makeIntent({ quantityMicros: '1', notionalLimitMicros: '100' })
+    const state = makeState({
+      expectedExecutionPriceMicros: '100000001',
+      referencePriceMicros: '100000000',
+    })
+    const result = evaluateSuccess(intent, state, makePolicy())
+
+    expect(result.metrics.orderNotionalMicros).toBe('100')
+    expect(result.decision.reasonCodes).not.toContain(Reason.IntentNotionalExceeded)
+  })
+
   test('strictly decodes complete policy and coherent state', () => {
     expect(makePolicy().schemaVersion).toBe('bayn.paper-risk-policy.v1')
     expect(makeState().schemaVersion).toBe('bayn.paper-risk-state.v2')

--- a/services/bayn/src/risk.ts
+++ b/services/bayn/src/risk.ts
@@ -1,6 +1,7 @@
 import { Data, Result, Schema, pipe } from 'effect'
 
 import { canonicalHashV1Result } from './hash'
+import { notionalMicros } from './execution-model'
 import { ExecutionSessionBindingSchema } from './execution-session'
 import {
   AccountSnapshotSchema,
@@ -465,9 +466,15 @@ interface DecodeRiskOutputIssue {
   readonly reason: 'decision' | 'evaluation' | 'input'
 }
 
+interface ComputeRiskMetricsIssue {
+  readonly operation: 'compute-metrics'
+  readonly reason: 'order-notional'
+}
+
 type RiskEvaluationIssue =
   | BindRiskAuthorityIssue
   | CanonicalizeRiskInputIssue
+  | ComputeRiskMetricsIssue
   | DecodeRiskInputIssue
   | DecodeRiskOutputIssue
 
@@ -515,6 +522,13 @@ const decodeRiskOutputFailure = (
   facts: Readonly<Record<string, unknown>> = {},
   cause?: unknown,
 ): RiskEvaluationFailure => new RiskEvaluationFailure({ operation: 'decode-output', reason, message, facts, cause })
+
+const computeRiskMetricsFailure = (
+  reason: RiskEvaluationReason<'compute-metrics'>,
+  message: string,
+  facts: Readonly<Record<string, unknown>> = {},
+  cause?: unknown,
+): RiskEvaluationFailure => new RiskEvaluationFailure({ operation: 'compute-metrics', reason, message, facts, cause })
 
 const RiskIntentSchema = Schema.Union([IntentSchema, ReferenceIntentSchema])
 const ProposedPositionsSchema = Schema.Array(PositionSchema)
@@ -648,8 +662,19 @@ const parseRiskFacts = (
   maxAdverseSlippageBps: BigInt(policy.maxAdverseSlippageBps),
 })
 
-const deriveRiskMetrics = (facts: RiskFacts): DerivedRiskMetrics => {
-  const orderNotionalMicros = divideUp(facts.intentQuantityMicros * facts.expectedExecutionPriceMicros, QUANTITY_SCALE)
+const deriveRiskMetrics = (facts: RiskFacts): Result.Result<DerivedRiskMetrics, RiskEvaluationFailure> => {
+  const orderNotional = notionalMicros(facts.intentQuantityMicros, facts.expectedExecutionPriceMicros)
+  if (Result.isFailure(orderNotional)) {
+    return Result.fail(
+      computeRiskMetricsFailure(
+        'order-notional',
+        'risk order notional could not be computed from decoded execution terms',
+        { intentId: facts.intent.intentId },
+        orderNotional.failure,
+      ),
+    )
+  }
+  const orderNotionalMicros = orderNotional.success
   const direction = facts.intent.side === OrderSide.Buy ? 1n : -1n
   const currentSymbolQuantityMicros = facts.positions
     .filter((position) => position.symbol === facts.intent.symbol)
@@ -688,7 +713,7 @@ const deriveRiskMetrics = (facts: RiskFacts): DerivedRiskMetrics => {
     instant(facts.state.authorityObservedAt),
   )
 
-  return {
+  return Result.succeed({
     orderNotionalMicros,
     currentSymbolQuantityMicros,
     postTradeSymbolQuantityMicros,
@@ -706,7 +731,7 @@ const deriveRiskMetrics = (facts: RiskFacts): DerivedRiskMetrics => {
     oldestBrokerStateAt,
     brokerFreshUntil: oldestBrokerStateAt + facts.policy.maxBrokerStateAgeMs,
     marketFreshUntil: facts.marketDataObservedAt + facts.policy.maxMarketDataAgeMs,
-  }
+  })
 }
 
 const deriveReconciledHash = (facts: RiskFacts): Result.Result<string, RiskEvaluationFailure> =>
@@ -1168,18 +1193,19 @@ const evaluateDecoded = (
   Result.flatMap(validateAuthorityBinding(intent, state), () => {
     const facts = parseRiskFacts(intent, state, policy, proposedPositions)
     return Result.flatMap(deriveReconciledHash(facts), (reconciledHash) => {
-      const metrics = deriveRiskMetrics(facts)
-      const gates = buildRiskGates(facts, metrics, reconciledHash)
-      const reasonCodes = gates.filter((gate) => !gate.passed).map((gate) => gate.reason)
-      const outcome = reasonCodes.length === 0 ? RiskOutcome.Approved : RiskOutcome.Blocked
-      const expiresAt = deriveRiskExpiry(facts, metrics, outcome)
-      return Result.flatMap(deriveRiskBindingHashes(facts), (hashes) =>
-        Result.flatMap(makeRiskInput(facts, hashes, expiresAt), (input) =>
-          Result.flatMap(makeRiskDecision(facts, hashes, input, outcome, reasonCodes, expiresAt), (decision) =>
-            makeRiskEvaluation(hashes, input, decision, gates, metrics),
+      return Result.flatMap(deriveRiskMetrics(facts), (metrics) => {
+        const gates = buildRiskGates(facts, metrics, reconciledHash)
+        const reasonCodes = gates.filter((gate) => !gate.passed).map((gate) => gate.reason)
+        const outcome = reasonCodes.length === 0 ? RiskOutcome.Approved : RiskOutcome.Blocked
+        const expiresAt = deriveRiskExpiry(facts, metrics, outcome)
+        return Result.flatMap(deriveRiskBindingHashes(facts), (hashes) =>
+          Result.flatMap(makeRiskInput(facts, hashes, expiresAt), (input) =>
+            Result.flatMap(makeRiskDecision(facts, hashes, input, outcome, reasonCodes, expiresAt), (decision) =>
+              makeRiskEvaluation(hashes, input, decision, gates, metrics),
+            ),
           ),
-        ),
-      )
+        )
+      })
     })
   })
 

--- a/services/bayn/src/target-planner.test.ts
+++ b/services/bayn/src/target-planner.test.ts
@@ -25,6 +25,7 @@ import {
   type SignalSessionReferencePrices,
   type TargetPlanResult,
   type TargetPlannerInput,
+  type TargetPlannerInputV1,
 } from './target-planner'
 
 const hash = (digit: string): string => digit.repeat(64)
@@ -169,8 +170,7 @@ const fixture = (options: FixtureOptions = {}): TargetPlannerInput => {
     observedAt: options.accountObservedAt ?? brokerObservedAt,
   }
   const prices = options.priceMicros ?? { AMD: '50000000', NVDA: '100000000' }
-  return {
-    schemaVersion: 'bayn.paper-target-planner-input.v1',
+  const common: Omit<TargetPlannerInputV1, 'schemaVersion'> = {
     strategyName: 'risk-balanced-trend',
     cycleId: hash('1'),
     decisionHash: options.decisionHash ?? hash('2'),
@@ -181,9 +181,6 @@ const fixture = (options: FixtureOptions = {}): TargetPlannerInput => {
       AMD: 0.5,
       NVDA: 0.5,
     },
-    ...(options.allocationCapitalMicros === undefined
-      ? {}
-      : { allocationCapitalMicros: options.allocationCapitalMicros }),
     referencePrices: referencePrices(
       prices,
       options.pricesObservedAt ?? pricesObservedAt,
@@ -208,6 +205,13 @@ const fixture = (options: FixtureOptions = {}): TargetPlannerInput => {
     submissionCutoffAt: options.submissionCutoffAt ?? submissionCutoffAt,
     observedAt: options.observedAt ?? observedAt,
   }
+  return options.allocationCapitalMicros === undefined
+    ? { schemaVersion: 'bayn.paper-target-planner-input.v1', ...common }
+    : {
+        schemaVersion: 'bayn.paper-target-planner-input.v2',
+        ...common,
+        allocationCapitalMicros: options.allocationCapitalMicros,
+      }
 }
 
 const planSuccess = (input: TargetPlannerInput): TargetPlanResult => {
@@ -248,6 +252,18 @@ describe('causal target planner', () => {
       { symbol: 'NVDA', targetQuantityMicros: '50000000' },
     ])
     expect(excessive).toMatchObject({ status: TargetPlanStatus.Blocked, reason: TargetPlanReason.InputMismatch })
+  })
+
+  test('versions bounded allocation separately from strict legacy planner evidence', () => {
+    const legacy = fixture({ positions: [] })
+    const bounded = fixture({ allocationCapitalMicros: '1000000000', positions: [] })
+
+    expect(legacy.schemaVersion).toBe('bayn.paper-target-planner-input.v1')
+    expect(bounded.schemaVersion).toBe('bayn.paper-target-planner-input.v2')
+    expect(Result.isFailure(planTargets({ ...legacy, allocationCapitalMicros: '1000000000' }))).toBe(true)
+    if (bounded.schemaVersion !== 'bayn.paper-target-planner-input.v2') throw new Error('expected v2 planner input')
+    const { allocationCapitalMicros: _allocationCapitalMicros, ...boundedWithoutAllocation } = bounded
+    expect(Result.isFailure(planTargets(boundedWithoutAllocation))).toBe(true)
   })
 
   test('turns an exhausted allocation into a deterministic flat no-trade target', () => {

--- a/services/bayn/src/target-planner.test.ts
+++ b/services/bayn/src/target-planner.test.ts
@@ -41,6 +41,7 @@ interface FixtureOptions {
   readonly accountId?: string
   readonly accountStatus?: AccountStatus
   readonly accountObservedAt?: string
+  readonly allocationCapitalMicros?: string
   readonly buyingPowerMicros?: string
   readonly decisionHash?: string
   readonly equityMicros?: string
@@ -180,6 +181,9 @@ const fixture = (options: FixtureOptions = {}): TargetPlannerInput => {
       AMD: 0.5,
       NVDA: 0.5,
     },
+    ...(options.allocationCapitalMicros === undefined
+      ? {}
+      : { allocationCapitalMicros: options.allocationCapitalMicros }),
     referencePrices: referencePrices(
       prices,
       options.pricesObservedAt ?? pricesObservedAt,
@@ -213,6 +217,48 @@ const planSuccess = (input: TargetPlannerInput): TargetPlanResult => {
 }
 
 describe('causal target planner', () => {
+  test('sizes an immutable PAPER target against its bounded allocation instead of full account equity', () => {
+    const bounded = planSuccess(
+      fixture({
+        allocationCapitalMicros: '1000000000',
+        buyingPowerMicros: '400000000000',
+        equityMicros: '100000000000',
+        positions: [],
+      }),
+    )
+
+    expect(bounded).toMatchObject({
+      status: TargetPlanStatus.Planned,
+      requiredReferenceBuyNotionalMicros: '1000000000',
+      targets: [
+        { symbol: 'AMD', targetQuantityMicros: '10000000' },
+        { symbol: 'NVDA', targetQuantityMicros: '5000000' },
+      ],
+    })
+  })
+
+  test('preserves legacy full-equity planning and rejects allocation above current equity', () => {
+    const legacy = planSuccess(fixture({ positions: [] }))
+    const excessive = planSuccess(
+      fixture({ allocationCapitalMicros: '10000000001', equityMicros: '10000000000', positions: [] }),
+    )
+
+    expect(legacy.targets).toMatchObject([
+      { symbol: 'AMD', targetQuantityMicros: '100000000' },
+      { symbol: 'NVDA', targetQuantityMicros: '50000000' },
+    ])
+    expect(excessive).toMatchObject({ status: TargetPlanStatus.Blocked, reason: TargetPlanReason.InputMismatch })
+  })
+
+  test('turns an exhausted allocation into a deterministic flat no-trade target', () => {
+    expect(planSuccess(fixture({ allocationCapitalMicros: '0', positions: [] }))).toMatchObject({
+      status: TargetPlanStatus.NoTrade,
+      reason: TargetPlanReason.TargetsSatisfied,
+      requiredReferenceBuyNotionalMicros: '0',
+      intentTargets: [],
+    })
+  })
+
   test('produces exact target deltas in stable sell-then-buy order without crediting the sell', () => {
     const result = planSuccess(fixture())
 

--- a/services/bayn/src/target-planner/facts.ts
+++ b/services/bayn/src/target-planner/facts.ts
@@ -59,6 +59,7 @@ export interface TargetPlannerFacts {
   readonly quantityIncrement: bigint
   readonly minimumBuyNotional: bigint
   readonly equity: bigint
+  readonly allocationCapital: bigint
   readonly availableBuyingPower: bigint
 }
 
@@ -115,6 +116,7 @@ export const parseTargetPlannerFacts = (input: TargetPlannerInput, hashes: Targe
   const positions = new Map(
     input.brokerState.positions.map((position, index) => [position.symbol, positionQuantities[index]]),
   )
+  const equity = BigInt(input.brokerState.account.equityMicros)
   return {
     input,
     ...hashes,
@@ -138,7 +140,8 @@ export const parseTargetPlannerFacts = (input: TargetPlannerInput, hashes: Targe
     priceIncrement: BigInt(input.precision.priceIncrementMicros),
     quantityIncrement: BigInt(input.precision.quantityIncrementMicros),
     minimumBuyNotional: BigInt(input.precision.minimumBuyNotionalMicros),
-    equity: BigInt(input.brokerState.account.equityMicros),
+    equity,
+    allocationCapital: input.allocationCapitalMicros === undefined ? equity : BigInt(input.allocationCapitalMicros),
     availableBuyingPower: BigInt(input.brokerState.account.buyingPowerMicros),
   }
 }
@@ -190,6 +193,7 @@ const brokerStateIsCoherent = (facts: TargetPlannerFacts): boolean => {
     state.orders.every((order) => order.observedAt <= state.ordersObservedAt) &&
     (state.orders.length === 0 || latestOrderObservation === state.ordersObservedAt) &&
     state.unknownOrderCount === unknownOrderCount &&
+    facts.allocationCapital <= facts.equity &&
     input.referencePrices.contentHash === facts.referencePriceHash &&
     Object.values(input.targetWeights).reduce((total, weight) => total + weight, 0) <= 1 + WEIGHT_SUM_TOLERANCE &&
     [...prices.values()].every((price) => price % priceIncrement === 0n) &&
@@ -227,7 +231,7 @@ export const derivePlannedTargetFacts = (
           const currentQuantity = facts.positions.get(symbol) ?? 0n
           return Result.map(
             Result.mapError(
-              desiredQuantityMicros(facts.equity, facts.input.targetWeights[symbol], referencePrice, {
+              desiredQuantityMicros(facts.allocationCapital, facts.input.targetWeights[symbol], referencePrice, {
                 precision: facts.input.precision,
               }),
               (cause) =>

--- a/services/bayn/src/target-planner/facts.ts
+++ b/services/bayn/src/target-planner/facts.ts
@@ -141,7 +141,8 @@ export const parseTargetPlannerFacts = (input: TargetPlannerInput, hashes: Targe
     quantityIncrement: BigInt(input.precision.quantityIncrementMicros),
     minimumBuyNotional: BigInt(input.precision.minimumBuyNotionalMicros),
     equity,
-    allocationCapital: input.allocationCapitalMicros === undefined ? equity : BigInt(input.allocationCapitalMicros),
+    allocationCapital:
+      input.schemaVersion === 'bayn.paper-target-planner-input.v1' ? equity : BigInt(input.allocationCapitalMicros),
     availableBuyingPower: BigInt(input.brokerState.account.buyingPowerMicros),
   }
 }

--- a/services/bayn/src/target-planner/model.ts
+++ b/services/bayn/src/target-planner/model.ts
@@ -51,8 +51,7 @@ export const TargetPlannerBrokerStateSchema = Schema.Struct({
   unknownOrderCount: NonNegativeIntegerSchema,
 })
 
-export const TargetPlannerInputSchema = Schema.Struct({
-  schemaVersion: Schema.Literal('bayn.paper-target-planner-input.v1'),
+const TargetPlannerInputFields = {
   strategyName: StrictNonEmptyStringSchema,
   cycleId: Sha256Schema,
   decisionHash: Sha256Schema,
@@ -60,7 +59,6 @@ export const TargetPlannerInputSchema = Schema.Struct({
   accountId: StrictNonEmptyStringSchema,
   signalDate: SignalSessionReferencePricesSchema.fields.signalDate,
   targetWeights: Schema.Record(SymbolSchema, UnitIntervalSchema),
-  allocationCapitalMicros: Schema.optionalKey(UnsignedMicrosSchema),
   referencePrices: SignalSessionReferencePricesSchema,
   brokerState: TargetPlannerBrokerStateSchema,
   precision: Schema.Struct({
@@ -71,10 +69,25 @@ export const TargetPlannerInputSchema = Schema.Struct({
   maximumInputAgeMs: PositiveIntegerSchema,
   submissionCutoffAt: UtcInstantSchema,
   observedAt: UtcInstantSchema,
+} as const
+
+export const TargetPlannerInputV1Schema = Schema.Struct({
+  schemaVersion: Schema.Literal('bayn.paper-target-planner-input.v1'),
+  ...TargetPlannerInputFields,
 })
+
+export const TargetPlannerInputV2Schema = Schema.Struct({
+  schemaVersion: Schema.Literal('bayn.paper-target-planner-input.v2'),
+  ...TargetPlannerInputFields,
+  allocationCapitalMicros: UnsignedMicrosSchema,
+})
+
+export const TargetPlannerInputSchema = Schema.Union([TargetPlannerInputV1Schema, TargetPlannerInputV2Schema])
 
 export type SignalSessionReferencePrices = typeof SignalSessionReferencePricesSchema.Type
 export type TargetPlannerBrokerState = typeof TargetPlannerBrokerStateSchema.Type
+export type TargetPlannerInputV1 = typeof TargetPlannerInputV1Schema.Type
+export type TargetPlannerInputV2 = typeof TargetPlannerInputV2Schema.Type
 export type TargetPlannerInput = typeof TargetPlannerInputSchema.Type
 
 export interface PlannedTargetQuantity {

--- a/services/bayn/src/target-planner/model.ts
+++ b/services/bayn/src/target-planner/model.ts
@@ -60,6 +60,7 @@ export const TargetPlannerInputSchema = Schema.Struct({
   accountId: StrictNonEmptyStringSchema,
   signalDate: SignalSessionReferencePricesSchema.fields.signalDate,
   targetWeights: Schema.Record(SymbolSchema, UnitIntervalSchema),
+  allocationCapitalMicros: Schema.optionalKey(UnsignedMicrosSchema),
   referencePrices: SignalSessionReferencePricesSchema,
   brokerState: TargetPlannerBrokerStateSchema,
   precision: Schema.Struct({


### PR DESCRIPTION
## Summary

- Size PAPER target construction from the episode risk budget instead of the full broker account equity.
- Reserve adverse-slippage headroom while enforcing gross, net, and complete sell-plus-buy daily-turnover caps.
- Preserve legacy planner replay when bounded allocation is absent and reject allocations above account equity.
- Restrict PAPER authority through the writer fence before persisting a blocked cycle, and align intent notional rounding with risk evaluation.

## Related Issues

None

## Testing

- `bun run test` — 1,153 passed, 159 PostgreSQL-gated skips, 0 failed.
- `BAYN_TEST_POSTGRES_URL=<redacted-local-postgres-url> bun run test:postgres` — 144 passed, 0 failed against PostgreSQL.
- `bun run tsc && bun run lint:effect` — clean.
- `bun run lint && bun run lint:oxlint && bun run lint:oxlint:type` — clean.
- `bun run build` — clean.
- `bun run test:effect-runtime` — 4 passed.
- Broker credentials unset: `bun run test:broker-sandbox` — 3 passed.
- `bun test packages/scripts/src/bayn` — 146 passed.
- Linux-only Nix image and dependency-boundary validation remains delegated to the required hosted multi-architecture jobs because the local host is aarch64-darwin.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.


