### PR TITLE
feat(bayn): roll risk-budget paper source

### DIFF
--- a/argocd/applications/bayn/deployment.yaml
+++ b/argocd/applications/bayn/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         app.kubernetes.io/name: bayn
         app.kubernetes.io/part-of: bayn
       annotations:
-        kubectl.kubernetes.io/restartedAt: "2026-08-06T09:27:24Z"
+        kubectl.kubernetes.io/restartedAt: "2026-08-07T00:07:46Z"
     spec:
       serviceAccountName: bayn
       automountServiceAccountToken: false
@@ -47,11 +47,11 @@ spec:
               protocol: TCP
           env:
             - name: BAYN_CODE_REVISION
-              value: 5b3eabfc4d55671d10322b47cda641b7d0161bcf
+              value: 835d84597b11b8c85b0a93a7af55e1932a0769c7
             - name: BAYN_IMAGE_REPOSITORY
               value: registry.ide-newton.ts.net/lab/bayn
             - name: BAYN_IMAGE_DIGEST
-              value: sha256:15649e3ad02f83eae913b66dc4545d1dc587c9c692b9d6335e5d76e282f272f7
+              value: sha256:b706b4b335b08f84a581d2aedd6f203b443fd8092feacc546dc53504a3b93106
             - name: BAYN_STRATEGY_BEHAVIOR_HASH
               value: "dde55f6292080b185554148cbfe4380e729626df1d11cbb47392645a80ce6c46"
             - name: BAYN_STRATEGY_PARAMETER_HASH
@@ -63,9 +63,9 @@ spec:
                   key: paper-activation-request
             - name: BAYN_MAXIMUM_AUTHORITY
               value: OBSERVE
-            # sha256("bayn/authority-generation/autonomous-observe-v7")
+            # sha256("bayn/authority-generation/autonomous-observe-v8")
             - name: BAYN_AUTHORITY_GENERATION_HASH
-              value: "e26fd8bb80aea84d7da04b0a57bddf132031bf27badc8d3f12d7b9bc5ce7a519"
+              value: "1cb62f0a1965e7ea427bf00848e902650536a4017bb35786e4ef0e3b4532269b"
             - name: BAYN_CYCLE_POLL_INTERVAL_MS
               value: "30000"
             - name: BAYN_BROKER_PROVIDER

--- a/argocd/applications/bayn/kustomization.yaml
+++ b/argocd/applications/bayn/kustomization.yaml
@@ -22,5 +22,5 @@ configMapGenerator:
 images:
   - name: registry.ide-newton.ts.net/lab/bayn
     newName: registry.ide-newton.ts.net/lab/bayn
-    newTag: "sha-5b3eabfc4d55671d10322b47cda641b7d0161bcf"
-    digest: sha256:15649e3ad02f83eae913b66dc4545d1dc587c9c692b9d6335e5d76e282f272f7
+    newTag: "sha-835d84597b11b8c85b0a93a7af55e1932a0769c7"
+    digest: sha256:b706b4b335b08f84a581d2aedd6f203b443fd8092feacc546dc53504a3b93106


### PR DESCRIPTION
## Summary

- Roll the exact reviewed Bayn source 835d84597b11b8c85b0a93a7af55e1932a0769c7 at multi-arch digest sha256:b706b4b335b08f84a581d2aedd6f203b443fd8092feacc546dc53504a3b93106.
- Preserve the reviewed risk-balanced-trend identity and existing bounded sandbox risk policy.
- Rotate to fresh, database-unused OBSERVE generation 1cb62f0a1965e7ea427bf00848e902650536a4017bb35786e4ef0e3b4532269b; the separately merged and applied sealed request performs the bounded research PAPER activation at runtime.
- Use only normal Argo reconciliation; this PR performs no direct deployment or broker mutation.

## Related Issues

PROOMPT-405

## Testing

- bun test packages/scripts/src/bayn/update-manifests.test.ts packages/scripts/src/bayn/bayn-paper-activation-workflow.test.ts (26 pass, 0 fail)
- nix develop --command kustomize build --enable-helm argocd/applications/bayn; rendered source, digest, image and generation pins verified
- bun run lint:argocd
- New authority generation queried against live PostgreSQL authority_generations: zero prior rows
- Published image labels verified for source and strategy hashes on linux/arm64
- Applied sealed activation request verified redacted against the exact source and digest
- git diff --check

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots section removed and Breaking Changes handled.
- [x] Documentation, release notes, and follow-ups are updated or tracked.