### PR TITLE
fix(bayn): size paper risk budget to sandbox equity

### DIFF
--- a/services/bayn/src/observe-composition.test.ts
+++ b/services/bayn/src/observe-composition.test.ts
@@ -2666,8 +2666,13 @@ describe('OBSERVE runtime composition', () => {
     expect(policy).toMatchObject({
       accountId,
       allowedSymbols: fixtureProtocol.universe,
-      maxOrderNotionalMicros: '600000000',
-      maxGrossExposureMicros: '1000000000',
+      maxOrderNotionalMicros: '40000000000',
+      maxSymbolExposureMicros: '40000000000',
+      maxGrossExposureMicros: '100000000000',
+      maxNetExposureMicros: '100000000000',
+      maxDailyTradedNotionalMicros: '200000000000',
+      maxDailyLossMicros: '5000000000',
+      maxDrawdownMicros: '5000000000',
       maxUnresolvedOrders: 0,
     })
   })
@@ -2864,7 +2869,8 @@ describe('OBSERVE runtime composition', () => {
     const document = await Effect.runPromise(program)
     const plannedNotional = BigInt(document.targetPlan.requiredReferenceBuyNotionalMicros)
 
-    expect(plannedNotional).toBeGreaterThan(0n)
+    expect(plannedNotional).toBeGreaterThan(99_000_000_000n)
+    expect(plannedNotional).toBeLessThanOrEqual(BigInt(policy.maxGrossExposureMicros))
     expect(plannedNotional).toBeLessThan(BigInt(policy.maxDailyTradedNotionalMicros))
     expect(document.riskBlock).toBeUndefined()
     expect(document).toMatchObject({ mode: 'PAPER', dispatchable: true })

--- a/services/bayn/src/observe-composition.ts
+++ b/services/bayn/src/observe-composition.ts
@@ -162,14 +162,16 @@ export type {
   PreparedMutationRecoveryDecision,
 }
 
+const dollarsToMicros = (dollars: bigint): string => (dollars * 1_000_000n).toString()
+
 const observeRiskLimits = {
-  maxOrderNotionalMicros: '600000000',
-  maxSymbolExposureMicros: '600000000',
-  maxGrossExposureMicros: '1000000000',
-  maxNetExposureMicros: '1000000000',
-  maxDailyTradedNotionalMicros: '1000000000',
-  maxDailyLossMicros: '100000000',
-  maxDrawdownMicros: '100000000',
+  maxOrderNotionalMicros: dollarsToMicros(40_000n),
+  maxSymbolExposureMicros: dollarsToMicros(40_000n),
+  maxGrossExposureMicros: dollarsToMicros(100_000n),
+  maxNetExposureMicros: dollarsToMicros(100_000n),
+  maxDailyTradedNotionalMicros: dollarsToMicros(200_000n),
+  maxDailyLossMicros: dollarsToMicros(5_000n),
+  maxDrawdownMicros: dollarsToMicros(5_000n),
   maxIntentAgeMs: 300_000,
   maxBrokerStateAgeMs: 300_000,
   maxMarketDataAgeMs: 300_000,

--- a/services/bayn/src/risk.test.ts
+++ b/services/bayn/src/risk.test.ts
@@ -497,6 +497,64 @@ describe('bounded paper risk', () => {
     expectBlocked(Reason.KillActive, makeIntent(), closeOnlyState)
   })
 
+  test('lets only a strictly exposure-reducing close liquidate gains beyond entry limits', () => {
+    const positions = baseState().positions.map((position) =>
+      position.symbol === 'NVDA'
+        ? {
+            ...position,
+            marketPriceMicros: '150000000',
+            marketValueMicros: '150000000',
+            unrealizedPnlMicros: '60000000',
+          }
+        : position,
+    )
+    const sharedState = {
+      account: {
+        ...baseState().account,
+        cashMicros: '550000000',
+        equityMicros: '800000000',
+        buyingPowerMicros: '0',
+      },
+      positions,
+      referencePriceMicros: '150000000',
+      expectedExecutionPriceMicros: '150000000',
+      dailyTradedNotionalMicros: '100000000',
+    } satisfies Partial<State>
+    const intent = makeIntent({
+      side: OrderSide.Sell,
+      quantityMicros: '1000000',
+      notionalLimitMicros: '150000000',
+    })
+    const closeOnlyState = makeState({
+      ...sharedState,
+      closeOnly: true,
+      closeOnlyExpiresAt: '2026-07-21T21:01:00.000Z',
+    })
+    const close = evaluateSuccess(intent, closeOnlyState, makePolicy())
+
+    expect(close.decision.outcome).toBe(RiskOutcome.Approved)
+    expect(close.metrics.orderNotionalMicros).toBe('150000000')
+    expect(close.decision.reasonCodes).toEqual([])
+
+    const ordinary = evaluateSuccess(intent, makeState(sharedState), makePolicy())
+    expect(ordinary.decision.reasonCodes).toEqual(
+      expect.arrayContaining([
+        Reason.OrderNotionalExceeded,
+        Reason.DailyTradedNotionalExceeded,
+        Reason.DailyLossExceeded,
+        Reason.DrawdownExceeded,
+      ]),
+    )
+
+    const oversell = evaluateSuccess(
+      makeIntent({ side: OrderSide.Sell, quantityMicros: '2000000', notionalLimitMicros: '300000000' }),
+      closeOnlyState,
+      makePolicy({ maxDailyTradedNotionalMicros: '400000000' }),
+    )
+    expect(oversell.decision.reasonCodes).toContain(Reason.ShortPositionNotAllowed)
+    expect(oversell.decision.reasonCodes).toContain(Reason.OrderNotionalExceeded)
+  })
+
   test('approves at submission open and blocks immediately before it and exactly at cutoff', () => {
     const state = makeState()
     const atOpen = makeState({

--- a/services/bayn/src/risk.ts
+++ b/services/bayn/src/risk.ts
@@ -605,6 +605,9 @@ interface RiskFacts {
 interface DerivedRiskMetrics {
   readonly orderNotionalMicros: bigint
   readonly currentSymbolQuantityMicros: bigint
+  readonly currentSymbolExposureMagnitudeMicros: bigint
+  readonly currentGrossExposureMicros: bigint
+  readonly currentNetExposureMagnitudeMicros: bigint
   readonly postTradeSymbolQuantityMicros: bigint
   readonly postTradeSymbolExposureMicros: bigint
   readonly postTradeSymbolExposureMagnitudeMicros: bigint
@@ -680,6 +683,8 @@ const deriveRiskMetrics = (facts: RiskFacts): Result.Result<DerivedRiskMetrics, 
     .filter((position) => position.symbol === facts.intent.symbol)
     .reduce((total, position) => total + position.quantityMicros, 0n)
   const postTradeSymbolQuantityMicros = currentSymbolQuantityMicros + direction * facts.intentQuantityMicros
+  const currentSymbolExposureNumerator = currentSymbolQuantityMicros * facts.referencePriceMicros
+  const currentSymbolExposureMagnitudeMicros = divideUp(absolute(currentSymbolExposureNumerator), QUANTITY_SCALE)
   const postTradeSymbolExposureNumerator = postTradeSymbolQuantityMicros * facts.referencePriceMicros
   const postTradeSymbolExposureMicros = divideAwayFromZero(postTradeSymbolExposureNumerator, QUANTITY_SCALE)
   const postTradeSymbolExposureMagnitudeMicros = divideUp(absolute(postTradeSymbolExposureNumerator), QUANTITY_SCALE)
@@ -689,6 +694,9 @@ const deriveRiskMetrics = (facts: RiskFacts): Result.Result<DerivedRiskMetrics, 
   const otherNetExposureMicros = facts.positions
     .filter((position) => position.symbol !== facts.intent.symbol)
     .reduce((total, position) => total + position.marketValueMicros, 0n)
+  const currentGrossExposureMicros = otherGrossExposureMicros + currentSymbolExposureMagnitudeMicros
+  const currentNetExposureNumerator = otherNetExposureMicros * QUANTITY_SCALE + currentSymbolExposureNumerator
+  const currentNetExposureMagnitudeMicros = divideUp(absolute(currentNetExposureNumerator), QUANTITY_SCALE)
   const postTradeGrossExposureMicros = otherGrossExposureMicros + postTradeSymbolExposureMagnitudeMicros
   const postTradeNetExposureNumerator = otherNetExposureMicros * QUANTITY_SCALE + postTradeSymbolExposureNumerator
   const postTradeNetExposureMicros = divideAwayFromZero(postTradeNetExposureNumerator, QUANTITY_SCALE)
@@ -716,6 +724,9 @@ const deriveRiskMetrics = (facts: RiskFacts): Result.Result<DerivedRiskMetrics, 
   return Result.succeed({
     orderNotionalMicros,
     currentSymbolQuantityMicros,
+    currentSymbolExposureMagnitudeMicros,
+    currentGrossExposureMicros,
+    currentNetExposureMagnitudeMicros,
     postTradeSymbolQuantityMicros,
     postTradeSymbolExposureMicros,
     postTradeSymbolExposureMagnitudeMicros,
@@ -733,6 +744,17 @@ const deriveRiskMetrics = (facts: RiskFacts): Result.Result<DerivedRiskMetrics, 
     marketFreshUntil: facts.marketDataObservedAt + facts.policy.maxMarketDataAgeMs,
   })
 }
+
+const isStrictlyExposureReducingClose = (facts: RiskFacts, metrics: DerivedRiskMetrics): boolean =>
+  facts.state.closeOnly === true &&
+  facts.intent.side === OrderSide.Sell &&
+  facts.positions.every((position) => position.quantityMicros >= 0n) &&
+  metrics.currentSymbolQuantityMicros > 0n &&
+  metrics.postTradeSymbolQuantityMicros >= 0n &&
+  metrics.postTradeSymbolQuantityMicros < metrics.currentSymbolQuantityMicros &&
+  metrics.postTradeSymbolExposureMagnitudeMicros < metrics.currentSymbolExposureMagnitudeMicros &&
+  metrics.postTradeGrossExposureMicros <= metrics.currentGrossExposureMicros &&
+  metrics.postTradeNetExposureMagnitudeMicros <= metrics.currentNetExposureMagnitudeMicros
 
 const deriveReconciledHash = (facts: RiskFacts): Result.Result<string, RiskEvaluationFailure> =>
   pipe(
@@ -868,6 +890,7 @@ const buildAuthorityAndStateGates = (
 
 const buildOrderLimitGates = (facts: RiskFacts, metrics: DerivedRiskMetrics): readonly GateResult[] => {
   const { intent, policy, state } = facts
+  const exposureReducingClose = isStrictlyExposureReducingClose(facts, metrics)
   return [
     makeGate(
       Gate.IntentNotional,
@@ -877,9 +900,11 @@ const buildOrderLimitGates = (facts: RiskFacts, metrics: DerivedRiskMetrics): re
     ),
     makeGate(
       Gate.OrderNotional,
-      metrics.orderNotionalMicros <= facts.maxOrderNotionalMicros,
+      exposureReducingClose || metrics.orderNotionalMicros <= facts.maxOrderNotionalMicros,
       metrics.orderNotionalMicros,
-      `<=${policy.maxOrderNotionalMicros}`,
+      facts.state.closeOnly === true
+        ? `<=${policy.maxOrderNotionalMicros}|STRICTLY_EXPOSURE_REDUCING_CLOSE`
+        : `<=${policy.maxOrderNotionalMicros}`,
     ),
     makeGate(
       Gate.BuyingPower,
@@ -898,6 +923,7 @@ const buildOrderLimitGates = (facts: RiskFacts, metrics: DerivedRiskMetrics): re
 
 const buildExposureGates = (facts: RiskFacts, metrics: DerivedRiskMetrics): readonly GateResult[] => {
   const { policy } = facts
+  const exposureReducingClose = isStrictlyExposureReducingClose(facts, metrics)
   return [
     makeGate(
       Gate.LongOnly,
@@ -907,45 +933,58 @@ const buildExposureGates = (facts: RiskFacts, metrics: DerivedRiskMetrics): read
     ),
     makeGate(
       Gate.SymbolExposure,
-      metrics.postTradeSymbolExposureMagnitudeMicros <= facts.maxSymbolExposureMicros,
+      exposureReducingClose || metrics.postTradeSymbolExposureMagnitudeMicros <= facts.maxSymbolExposureMicros,
       metrics.postTradeSymbolExposureMagnitudeMicros,
-      `<=${policy.maxSymbolExposureMicros}`,
+      facts.state.closeOnly === true
+        ? `<=${policy.maxSymbolExposureMicros}|STRICTLY_EXPOSURE_REDUCING_CLOSE`
+        : `<=${policy.maxSymbolExposureMicros}`,
     ),
     makeGate(
       Gate.GrossExposure,
-      metrics.postTradeGrossExposureMicros <= facts.maxGrossExposureMicros,
+      exposureReducingClose || metrics.postTradeGrossExposureMicros <= facts.maxGrossExposureMicros,
       metrics.postTradeGrossExposureMicros,
-      `<=${policy.maxGrossExposureMicros}`,
+      facts.state.closeOnly === true
+        ? `<=${policy.maxGrossExposureMicros}|STRICTLY_EXPOSURE_REDUCING_CLOSE`
+        : `<=${policy.maxGrossExposureMicros}`,
     ),
     makeGate(
       Gate.NetExposure,
-      metrics.postTradeNetExposureMagnitudeMicros <= facts.maxNetExposureMicros,
+      exposureReducingClose || metrics.postTradeNetExposureMagnitudeMicros <= facts.maxNetExposureMicros,
       metrics.postTradeNetExposureMagnitudeMicros,
-      `<=${policy.maxNetExposureMicros}`,
+      facts.state.closeOnly === true
+        ? `<=${policy.maxNetExposureMicros}|STRICTLY_EXPOSURE_REDUCING_CLOSE`
+        : `<=${policy.maxNetExposureMicros}`,
     ),
   ]
 }
 
 const buildCumulativeRiskGates = (facts: RiskFacts, metrics: DerivedRiskMetrics): readonly GateResult[] => {
   const { policy } = facts
+  const exposureReducingClose = isStrictlyExposureReducingClose(facts, metrics)
   return [
     makeGate(
       Gate.DailyTradedNotional,
-      metrics.dailyTradedNotionalMicros <= facts.maxDailyTradedNotionalMicros,
+      exposureReducingClose || metrics.dailyTradedNotionalMicros <= facts.maxDailyTradedNotionalMicros,
       metrics.dailyTradedNotionalMicros,
-      `<=${policy.maxDailyTradedNotionalMicros}`,
+      facts.state.closeOnly === true
+        ? `<=${policy.maxDailyTradedNotionalMicros}|STRICTLY_EXPOSURE_REDUCING_CLOSE`
+        : `<=${policy.maxDailyTradedNotionalMicros}`,
     ),
     makeGate(
       Gate.DailyLoss,
-      metrics.dailyLossMicros <= facts.maxDailyLossMicros,
+      exposureReducingClose || metrics.dailyLossMicros <= facts.maxDailyLossMicros,
       metrics.dailyLossMicros,
-      `<=${policy.maxDailyLossMicros}`,
+      facts.state.closeOnly === true
+        ? `<=${policy.maxDailyLossMicros}|STRICTLY_EXPOSURE_REDUCING_CLOSE`
+        : `<=${policy.maxDailyLossMicros}`,
     ),
     makeGate(
       Gate.Drawdown,
-      metrics.drawdownMicros <= facts.maxDrawdownMicros,
+      exposureReducingClose || metrics.drawdownMicros <= facts.maxDrawdownMicros,
       metrics.drawdownMicros,
-      `<=${policy.maxDrawdownMicros}`,
+      facts.state.closeOnly === true
+        ? `<=${policy.maxDrawdownMicros}|STRICTLY_EXPOSURE_REDUCING_CLOSE`
+        : `<=${policy.maxDrawdownMicros}`,
     ),
   ]
 }


### PR DESCRIPTION
## Summary

- replace the $1,000 bootstrap exposure cap with a $100,000 no-leverage sandbox budget
- allow up to $40,000 per entry order and symbol and $200,000 daily turnover
- permit only strictly exposure-reducing close-only sells to flatten appreciated positions beyond entry/cumulative caps
- retain long-only DAY execution, a $5,000 loss/drawdown stop, exact reconciliation, and zero-unresolved-mutation admission

## Related Issues

None

## Testing

- `bun test services/bayn/src/observe-composition.test.ts -t "decodes the bounded source policy|binds a high-balance PAPER account"`
- `bun test services/bayn/src/risk.test.ts services/bayn/src/observe-composition.test.ts` (70 passed, 0 failed)
- `bun run --filter @proompteng/bayn test` (1,154 passed, 159 PostgreSQL-gated skipped, 0 failed)
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn lint:effect`
- `bun run --filter @proompteng/bayn build`

## Breaking Changes

None. The changed canonical risk-policy hash requires the normal reviewed activation refresh and GitOps rollout before the new budget becomes effective.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.