### PR TITLE
chore(argocd): upgrade control plane to 3.4.6

### DIFF
--- a/argocd/applications/argocd/kustomization.yaml
+++ b/argocd/applications/argocd/kustomization.yaml
@@ -3,10 +3,10 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: argocd
 resources:
-  - https://raw.githubusercontent.com/argoproj/argo-cd/v3.3.9/manifests/ha/install.yaml
+  - https://raw.githubusercontent.com/argoproj/argo-cd/v3.4.6/manifests/ha/install.yaml
   - base/ingressroute.yaml
   - base/ingressroute-private.yaml
-  - https://raw.githubusercontent.com/argoproj-labs/argocd-image-updater/v1.2.0/config/install.yaml
+  - https://raw.githubusercontent.com/argoproj-labs/argocd-image-updater/v1.2.2/config/install.yaml
   - base/secrets.yaml
   - base/argo-workflows-sso-sealedsecret.yaml
   - base/tsag-repo-sealedsecret.yaml

--- a/argocd/applications/argocd/overlays/argocd-applicationset-crd.yaml
+++ b/argocd/applications/argocd/overlays/argocd-applicationset-crd.yaml
@@ -3,4 +3,4 @@ kind: CustomResourceDefinition
 metadata:
   name: applicationsets.argoproj.io
   annotations:
-    argocd.argoproj.io/sync-options: Replace=true
+    argocd.argoproj.io/sync-options: ServerSideApply=true

--- a/argocd/applications/argocd/overlays/argocd-lovely-plugin.yaml
+++ b/argocd/applications/argocd/overlays/argocd-lovely-plugin.yaml
@@ -8,7 +8,7 @@ spec:
       containers:
         - name: lovely-plugin
           # Choose your image here - see https://github.com/crumbhole/argocd-lovely-plugin/blob/main/doc/variations.md
-          image: ghcr.io/crumbhole/lovely:1.2.2
+          image: ghcr.io/crumbhole/lovely:1.2.5
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/argocd/applicationsets/README.md
+++ b/argocd/applicationsets/README.md
@@ -61,13 +61,13 @@ The upstream `applicationsets.argoproj.io` CRD can be large enough that `kubectl
 Recommended (server-side apply):
 
 ```bash
-kubectl apply --server-side -f https://raw.githubusercontent.com/argoproj/argo-cd/v3.3.9/manifests/crds/applicationset-crd.yaml
+kubectl apply --server-side --force-conflicts -f https://raw.githubusercontent.com/argoproj/argo-cd/v3.4.6/manifests/crds/applicationset-crd.yaml
 ```
 
 Fallback (create-only):
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/argoproj/argo-cd/v3.3.9/manifests/crds/applicationset-crd.yaml | kubectl create -f -
+curl -fsSL https://raw.githubusercontent.com/argoproj/argo-cd/v3.4.6/manifests/crds/applicationset-crd.yaml | kubectl create -f -
 ```
 
 Verify:

--- a/argocd/applicationsets/bootstrap.yaml
+++ b/argocd/applicationsets/bootstrap.yaml
@@ -168,7 +168,6 @@ spec:
           - RespectIgnoreDifferences=true
           - ApplyOutOfSyncOnly=true
           - PruneLast=true
-          - ClientSideApplyMigration=false
   templatePatch: |
     {{- if .annotations }}
     metadata:

--- a/devices/galactic/docs/bootstrap-argocd.md
+++ b/devices/galactic/docs/bootstrap-argocd.md
@@ -29,13 +29,13 @@ This is typically caused by `kubectl apply` trying to store the full object in t
 Recommended (server-side apply, avoids last-applied annotation):
 
 ```bash
-kubectl apply --server-side -f https://raw.githubusercontent.com/argoproj/argo-cd/v3.3.0/manifests/crds/applicationset-crd.yaml
+kubectl apply --server-side --force-conflicts -f https://raw.githubusercontent.com/argoproj/argo-cd/v3.4.6/manifests/crds/applicationset-crd.yaml
 ```
 
 Fallback (create-only, avoids last-applied annotation):
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/argoproj/argo-cd/v3.3.0/manifests/crds/applicationset-crd.yaml | kubectl create -f -
+curl -fsSL https://raw.githubusercontent.com/argoproj/argo-cd/v3.4.6/manifests/crds/applicationset-crd.yaml | kubectl create -f -
 ```
 
 Verify:
@@ -55,7 +55,7 @@ On a fresh cluster, applying `argocd/applications/argocd` will fail until the Tr
 Install the CRDs (pinned to the chart version we deploy):
 
 ```bash
-kubectl apply --server-side --force-conflicts -k https://github.com/traefik/traefik-helm-chart/traefik/crds/?ref=v39.0.1
+kubectl apply --server-side --force-conflicts -k https://github.com/traefik/traefik-helm-chart/traefik/crds/?ref=v39.0.9
 ```
 
 Verify:
@@ -69,7 +69,7 @@ kubectl get crd ingressroutes.traefik.io
 Apply the repo-managed Argo CD manifests:
 
 ```bash
-kubectl apply -k argocd/applications/argocd
+kubectl apply --server-side --force-conflicts -k argocd/applications/argocd
 ```
 
 Wait for Argo CD control plane to be up:

--- a/docs/runbooks/cluster-application-upgrades-2026-08.md
+++ b/docs/runbooks/cluster-application-upgrades-2026-08.md
@@ -427,8 +427,9 @@ annotation size limit. Before syncing the control plane:
 
 ### Promotion
 
-After merge, require root drift to contain only `ApplicationSet/bootstrap`, then update the generated Argo Application
-before touching the control plane:
+After merge, allow only two root states: either the reviewed `ApplicationSet/bootstrap` drift is still pending, or root
+already auto-synced the exact merge revision. In both cases, require the generated Argo Application to carry the new
+policy before touching the control plane:
 
 ```bash
 set -euo pipefail
@@ -437,10 +438,20 @@ upgrade_revision="$(git rev-parse origin/main)"
 argocd app get root --hard-refresh >/dev/null
 root_drift=$(kubectl -n argocd get application root -o json |
   jq -r '.status.resources[] | select(.status != "Synced") | [.group,.kind,.namespace,.name] | @tsv')
-test "$root_drift" = $'argoproj.io\tApplicationSet\targocd\tbootstrap'
-
-argocd app sync root --revision "$upgrade_revision" --prune=false --timeout 600
-argocd app wait root --sync --health --timeout 600
+if [[ -n "$root_drift" ]]; then
+  test "$root_drift" = $'argoproj.io\tApplicationSet\targocd\tbootstrap'
+  argocd app sync root --revision "$upgrade_revision" --prune=false --timeout 600
+  argocd app wait root --sync --health --timeout 600
+else
+  test "$(kubectl -n argocd get application root -o jsonpath='{.status.sync.status}')" = Synced
+  test "$(kubectl -n argocd get application root -o jsonpath='{.status.sync.revision}')" = "$upgrade_revision"
+fi
+for _ in {1..30}; do
+  migration_disabled=$(kubectl -n argocd get application argocd -o json |
+    jq -r '.spec.syncPolicy.syncOptions | index("ClientSideApplyMigration=false")')
+  [[ "$migration_disabled" == null ]] && break
+  sleep 2
+done
 test "$(kubectl -n argocd get application argocd -o json |
   jq -r '.spec.syncPolicy.syncOptions | index("ClientSideApplyMigration=false")')" = null
 

--- a/docs/runbooks/cluster-application-upgrades-2026-08.md
+++ b/docs/runbooks/cluster-application-upgrades-2026-08.md
@@ -381,10 +381,11 @@ The Argo CD, Dex, and Image Updater target image indexes resolve to
 - The only Argo-specific alert uses the stable `argocd_app_info` metric, not changed OpenTelemetry semantic attributes.
 - The fully rendered target contains 100 non-Namespace resources, exactly matching the 100 currently tracked resource
   identities. It renders no `Namespace` object and passes a server-side API dry-run with the Argo field manager.
-- Representative pre-upgrade Lovely output hashes were: Buzz
-  `e4cffe0f974f5c1024acd495ed63ba353168e69aef0d042571b9070afd1a882e`, cert-manager
-  `a686b77d4c7105c0e422004add91c3ad8e682ea76575fbd7280a388e35efb45a`, and Torghut
-  `a42e2a65ba9064dfb6eb56bd235273d9beb0c20bc954ccd333e3ceab73457c34`.
+- Representative pre-upgrade Lovely outputs were canonicalized as sorted JSON before hashing. The hashes were: Buzz
+  `a00a13a28043cb40849b2373b0553765cbbf40295b2de78e6da76dcb6e90d921`, cert-manager
+  `8103d2bf7294a7b28865b90b07af521c4753772713bb2545bb6e921ca4710348`, and Torghut
+  `493015e412d88e903b152305fb5f7a7fec3744d2a657b2bc35529403f465de4d`. Raw YAML hashes are not an acceptance
+  signal because serialization can differ without a manifest change.
 
 Live identity baseline:
 
@@ -464,8 +465,8 @@ syncing and re-review the exact additions and removals.
   Redis secret, or ImageUpdater target is recreated.
 - Image Updater reports `Ready=True` and `Error=False`. Public health and Dex discovery return HTTP 200, the Argo
   service has a ready endpoint, and a fresh core-mode manifest request succeeds.
-- Buzz, cert-manager, and Torghut Lovely output hashes remain equal to the recorded baseline. The Argo manifest hash is
-  expected to change because this wave changes its desired control-plane manifests.
+- Buzz, cert-manager, and Torghut canonical Lovely output hashes remain equal to the recorded baseline. The Argo
+  manifest hash is expected to change because this wave changes its desired control-plane manifests.
 - Application and workload health contains no new exception beyond the explicitly recorded baseline, all nodes remain
   ready, and controller/repo-server/Image Updater logs contain no new render, cache, authentication, or reconciliation
   errors.

--- a/docs/runbooks/cluster-application-upgrades-2026-08.md
+++ b/docs/runbooks/cluster-application-upgrades-2026-08.md
@@ -343,3 +343,133 @@ Rollback controller versions through a reviewed revert PR. Keep the newer CRDs u
 requires a separate CRD migration; never delete certificate keys or generated Secrets. Revert Metrics Server to
 `v0.8.1` only after proving the HA manifest still serves the Metrics API. The Buzz one-shot manifest must remain
 removed during rollback.
+
+Wave 2 completed on 2026-08-07 at merge `4813a91f8b1f4e5ac00c7562746c4651949e529b`. All three controller
+applications reached `Synced/Healthy`; certificate, external-secret, generated-secret, APIService, CNPG, and PVC UIDs
+were preserved. Metrics queries and the Buzz endpoint succeeded. Argo pruned only the completed one-shot `Backup`
+request; the `14d` object-store retention policy and all scheduled backups remained intact.
+
+## Wave 3: Argo control plane
+
+Upgrade the self-managed control plane as one coordinated unit:
+
+- Argo CD `v3.3.9` -> `v3.4.6`
+- Argo CD Image Updater `v1.2.0` -> `v1.2.2`
+- Lovely CMP `1.2.2` -> `1.2.5`
+- Dex `v2.43.0` -> `v2.45.0`, inherited from the Argo CD HA manifest
+
+Verified lightweight release refs:
+
+| Release                | Commit                                     | Manifest or image evidence                                                                            |
+| ---------------------- | ------------------------------------------ | ----------------------------------------------------------------------------------------------------- |
+| Argo CD `v3.4.6`       | `e1becb74c728a992804d39c3ceb2e9e6ae58f0ae` | HA manifest SHA-256 `67d1513b1ec6f5265bf48bc7509f251a1ba791b22d0a40f3586fa1ce07d60465`                |
+| Image Updater `v1.2.2` | `0e7ba4e51d2f8e64934f738db9f2b57274a401d3` | install manifest SHA-256 `9551f4135c714c57b0637260e2bef1b47fb081dd66c3baea5db8bd491f8af22b`           |
+| Lovely `1.2.5`         | `29742c0fe861c619f7d8c1ebbbf1043478d1ce55` | multi-platform image digest `sha256:6cf1db338edda01018a623504bccb7c96e9e3b611a361a0e3942e9e2100e867b` |
+
+The Argo CD, Dex, and Image Updater target image indexes resolve to
+`sha256:6e9f4f1d646d9056c8e285495d0c8043b5f553c784181b3522ef324dcefdcc82`,
+`sha256:b8469881d3cb3a73001506f0d3aaefecb9c45d2311c1e0f405d8ac538316c59d`, and
+`sha256:6a61e42794105cfd0ca029068f0cfc27bc29b9882d23df7bded7fcd1e14203da`, respectively.
+
+### Compatibility and recorded baseline
+
+- Argo CD 3.4 is tested with Kubernetes 1.35, which matches all three nodes.
+- No ApplicationSet uses the Kubernetes-version auto-label or a version selector. The 3.4 cluster-version formatting
+  change therefore has no repository consumer, and the Lovely `$KUBE_VERSION` contract is unchanged upstream.
+- The repository does not configure Dex preprocessing or gRPC DNS TXT service configuration. The Dex 2.45 and new
+  default `GRPC_ENABLE_TXT_SERVICE_CONFIG=false` behavior require no override.
+- The only Argo-specific alert uses the stable `argocd_app_info` metric, not changed OpenTelemetry semantic attributes.
+- The fully rendered target contains 100 non-Namespace resources, exactly matching the 100 currently tracked resource
+  identities. It renders no `Namespace` object and passes a server-side API dry-run with the Argo field manager.
+- Representative pre-upgrade Lovely output hashes were: Buzz
+  `e4cffe0f974f5c1024acd495ed63ba353168e69aef0d042571b9070afd1a882e`, cert-manager
+  `a686b77d4c7105c0e422004add91c3ad8e682ea76575fbd7280a388e35efb45a`, and Torghut
+  `a42e2a65ba9064dfb6eb56bd235273d9beb0c20bc954ccd333e3ceab73457c34`.
+
+Live identity baseline:
+
+| Resource                             | UID                                    |
+| ------------------------------------ | -------------------------------------- |
+| `Application/argocd`                 | `25a2d122-ba0f-453b-b6d3-de23489bb5c6` |
+| `CRD/applicationsets.argoproj.io`    | `aca1cb44-7d0d-44bd-932a-377651c53513` |
+| `ApplicationSet/appset-helm`         | `e61413d8-fa0f-49b0-b00f-683d3920a9d4` |
+| `ApplicationSet/bootstrap`           | `d4a4325b-37d8-4199-9c6e-4f0952ebba8f` |
+| `ApplicationSet/platform`            | `df00b5f6-5927-4296-a4a0-7168e4470792` |
+| `ApplicationSet/product`             | `54b89646-4a76-453d-8d36-2b2a0c0ecc9e` |
+| `Secret/argocd-secret`               | `4f2bf4ad-56da-4b66-ae29-e2d1da18c8d1` |
+| `Secret/argocd-notifications-secret` | `7ca5d751-9ba6-4e1f-be44-5c80ffdf4549` |
+| `Secret/argocd-redis`                | `49dcecf6-65f6-4865-9543-8d41340506a2` |
+| `ImageUpdater/product-image-updater` | `0a81a6c6-0653-4f91-9af5-562bb33a88e0` |
+
+Before the upgrade, 76 of 79 Applications were synced and 77 were healthy. The exact pre-existing exceptions were:
+
+- `agents`, `froussard`, and `oirat`: `OutOfSync/Healthy`
+- `torghut`: `Synced/Degraded`
+- the two previously recorded failed Synthesis Jobs
+
+Do not attribute those conditions to this wave or sync those applications as part of the Argo rollout. The public
+Argo health and Dex discovery endpoints returned HTTP 200; the in-cluster Argo server EndpointSlice had one ready
+endpoint. The workstation could not resolve the private Tailscale hostname, so use in-cluster endpoint readiness as
+the private-path acceptance signal.
+
+### ApplicationSet CRD apply migration
+
+The live ApplicationSet CRD was originally created by `kubectl-create` and subsequently updated through
+`Replace=true`. Argo CD 3.3 and later require server-side apply for this CRD because client-side apply can exceed the
+annotation size limit. Before syncing the control plane:
+
+1. Replace the CRD's `Replace=true` annotation with `ServerSideApply=true`.
+2. Remove the obsolete `ClientSideApplyMigration=false` workaround from the bootstrap ApplicationSet template.
+3. Sync `root` first so `Application/argocd` has server-side apply enabled without the migration disablement.
+4. Sync the Argo application without prune. The server-side apply must preserve the CRD UID and move field ownership
+   to the Argo field manager; never delete and recreate the CRD.
+
+### Promotion
+
+After merge, require root drift to contain only `ApplicationSet/bootstrap`, then update the generated Argo Application
+before touching the control plane:
+
+```bash
+set -euo pipefail
+upgrade_revision="$(git rev-parse origin/main)"
+
+argocd app get root --hard-refresh >/dev/null
+root_drift=$(kubectl -n argocd get application root -o json |
+  jq -r '.status.resources[] | select(.status != "Synced") | [.group,.kind,.namespace,.name] | @tsv')
+test "$root_drift" = $'argoproj.io\tApplicationSet\targocd\tbootstrap'
+
+argocd app sync root --revision "$upgrade_revision" --prune=false --timeout 600
+argocd app wait root --sync --health --timeout 600
+test "$(kubectl -n argocd get application argocd -o json |
+  jq -r '.spec.syncPolicy.syncOptions | index("ClientSideApplyMigration=false")')" = null
+
+argocd app get argocd --hard-refresh >/dev/null
+test "$(kubectl -n argocd get application argocd -o json |
+  jq -r '.spec.syncPolicy.automated // "manual"')" = manual
+argocd app sync argocd --revision "$upgrade_revision" --prune=false --timeout 900
+argocd app wait argocd --sync --health --timeout 900
+```
+
+The Argo sync must not report a prune. If the reviewed resource-identity comparison changes after merge, stop before
+syncing and re-review the exact additions and removals.
+
+### Acceptance and rollback
+
+- `argocd` is `Synced/Healthy` at the exact merge revision, with a successful operation revision.
+- All Argo Deployments and StatefulSets complete rollout. New Argo CD containers run `v3.4.6`, Dex runs `v2.45.0`,
+  Image Updater runs `v1.2.2`, and both repo-server Pods run Lovely `1.2.5` with no new restarts.
+- The Application, CRD, ApplicationSet, Secret, and ImageUpdater UIDs in the baseline remain unchanged. The
+  ApplicationSet CRD has `ServerSideApply=true`, no `Replace=true`, and an Argo server-side-apply managed-field entry.
+- All four ApplicationSets retain their generated-resource counts. No Application, repository credential, SSO secret,
+  Redis secret, or ImageUpdater target is recreated.
+- Image Updater reports `Ready=True` and `Error=False`. Public health and Dex discovery return HTTP 200, the Argo
+  service has a ready endpoint, and a fresh core-mode manifest request succeeds.
+- Buzz, cert-manager, and Torghut Lovely output hashes remain equal to the recorded baseline. The Argo manifest hash is
+  expected to change because this wave changes its desired control-plane manifests.
+- Application and workload health contains no new exception beyond the explicitly recorded baseline, all nodes remain
+  ready, and controller/repo-server/Image Updater logs contain no new render, cache, authentication, or reconciliation
+  errors.
+
+Rollback through a reviewed revert PR and the same root-first GitOps sequence. Preserve the newer CRDs during workload
+rollback unless a separate compatibility review proves a schema rollback is required. Keep server-side apply enabled;
+do not restore `Replace=true` or `ClientSideApplyMigration=false`.

--- a/packages/scripts/src/shared/__tests__/enabled-apps.test.ts
+++ b/packages/scripts/src/shared/__tests__/enabled-apps.test.ts
@@ -7,6 +7,13 @@ import { assertEnabledAppBuildPolicy, loadEnabledAppInventory } from '../enabled
 
 const inventory = loadEnabledAppInventory()
 const platformApplicationSet = readFileSync('argocd/applicationsets/platform.yaml', 'utf8')
+const bootstrapApplicationSet = readFileSync('argocd/applicationsets/bootstrap.yaml', 'utf8')
+const argoCdKustomization = readFileSync('argocd/applications/argocd/kustomization.yaml', 'utf8')
+const argoCdApplicationSetCrdOverlay = readFileSync(
+  'argocd/applications/argocd/overlays/argocd-applicationset-crd.yaml',
+  'utf8',
+)
+const argoCdLovelyPluginOverlay = readFileSync('argocd/applications/argocd/overlays/argocd-lovely-plugin.yaml', 'utf8')
 const certManagerKustomization = readFileSync('argocd/applications/cert-manager/kustomization.yaml', 'utf8')
 const externalSecretsKustomization = readFileSync('argocd/applications/external-secrets/kustomization.yaml', 'utf8')
 const productApplicationSet = YAML.parse(readFileSync('argocd/applicationsets/product.yaml', 'utf8')) as {
@@ -101,6 +108,16 @@ describe('enabled app inventory', () => {
     expect(certManagerKustomization).toContain('version: v1.21.1')
     expect(externalSecretsKustomization).toContain('version: 2.8.0')
     expect(platformApplicationSet).toContain('targetRevision: v0.9.0')
+  })
+
+  it('pins the Argo control-plane upgrade wave and applies its large CRD server-side', () => {
+    expect(argoCdKustomization).toContain('argo-cd/v3.4.6/manifests/ha/install.yaml')
+    expect(argoCdKustomization).toContain('argocd-image-updater/v1.2.2/config/install.yaml')
+    expect(argoCdLovelyPluginOverlay).toContain('ghcr.io/crumbhole/lovely:1.2.5')
+    expect(argoCdApplicationSetCrdOverlay).toContain('argocd.argoproj.io/sync-options: ServerSideApply=true')
+    expect(argoCdApplicationSetCrdOverlay).not.toContain('Replace=true')
+    expect(bootstrapApplicationSet).toContain('ServerSideApply=true')
+    expect(bootstrapApplicationSet).not.toContain('ClientSideApplyMigration=false')
   })
 
   it('keeps chart-only apps out of Nix image migration state', () => {


### PR DESCRIPTION
## Summary

- upgrade Argo CD to v3.4.6, Image Updater to v1.2.2, Lovely to 1.2.5, and inherited Dex to v2.45.0
- migrate the oversized ApplicationSet CRD from Replace to server-side apply and remove the obsolete bootstrap migration workaround
- record release provenance, live identity/drift baselines, root-first promotion gates, acceptance checks, and rollback constraints

## Related Issues

None

## Testing

- bun test packages/scripts/src/shared/__tests__/enabled-apps.test.ts packages/scripts/src/shared/__tests__/argocd-dex-sso.test.ts packages/scripts/src/shared/__tests__/enabled-apps-baseline.test.ts
- bun run lint:argocd
- bunx oxfmt --check on all eight changed files
- kustomize build --enable-helm argocd/applications/argocd rendered 100 resources and zero Namespace objects
- rendered target passed kubectl server-side API dry-run with force-conflicts and field-manager=argocd-controller
- rendered target and the live Argo Application each contain the same 100 non-Namespace resource identities
- target image tags and lightweight release refs were resolved against their upstream registries and repositories

## Breaking Changes

The rollout requires the documented root-first manual GitOps sequence so Application/argocd receives the corrected server-side-apply policy before the self-managed control plane sync. No resource identity is added or removed, and prune is prohibited.

## Checklist

- [x] Testing section documents the exact validation performed (or N/A with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (screenshots are not applicable to this manifest-only change).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
