### PR TITLE
fix(knative): keep managed namespace untracked

### DIFF
--- a/argocd/applicationsets/platform.yaml
+++ b/argocd/applicationsets/platform.yaml
@@ -301,9 +301,8 @@ spec:
                 annotations:
                   argocd.argoproj.io/sync-wave: "1"
                 managedNamespaceMetadata:
-                  annotations:
-                    # Protect the namespace while ownership moves from the upstream manifest to ApplicationSet.
-                    argocd.argoproj.io/sync-options: Prune=false
+                  labels:
+                    app.kubernetes.io/managed-by: argocd
                 automation: auto
                 enabled: "true"
               - name: knative-serving

--- a/docs/runbooks/cluster-application-upgrades-2026-08.md
+++ b/docs/runbooks/cluster-application-upgrades-2026-08.md
@@ -684,11 +684,15 @@ three handlers, no other error recurred after startup, all handlers were ready w
 `Available=True`, `Progressing=False`, and `Degraded=False`. Treat only that exact legacy watcher message as an accepted
 upstream diagnostic until KubeVirt removes the unused manager.
 
-## Wave 4 namespace ownership handoff
+## Wave 4 namespace management handoff
 
-The Wave 4a source and live namespace now both carry `argocd.argoproj.io/sync-options=Prune=false`. Remove the upstream
-`Namespace` from rendered output while retaining ApplicationSet-managed namespace metadata. This is an ownership-only
-change: no Knative workload or custom resource should roll.
+Wave 4a first placed `argocd.argoproj.io/sync-options=Prune=false` on both the source and live namespace. The handoff then
+removes the upstream `Namespace` from rendered output and retains ApplicationSet-managed namespace metadata. Argo CD
+3.4's managed-namespace implementation always replaces that annotation value with `ServerSideApply=true`; it cannot
+combine a caller-provided `Prune=false` value. The generated namespace remains safe because Argo does not resource-track
+it unless a tracking annotation is explicitly added. Keep `argocd.argoproj.io/tracking-id` absent, assert that the
+Application has no Namespace in `status.resources`, and use the standard managed-by label as the metadata-management
+receipt. This change must not roll a Knative workload or custom resource.
 
 ```bash
 set -euo pipefail
@@ -704,12 +708,19 @@ argocd app get knative --hard-refresh >/dev/null
 argocd app wait knative --sync --health --timeout 900
 test "$(kubectl -n argocd get application knative \
   -o jsonpath='{.status.operationState.syncResult.revision}')" = "$upgrade_revision"
-test "$(kubectl get namespace knative \
-  -o jsonpath='{.metadata.annotations.argocd\.argoproj\.io/sync-options}')" = Prune=false
 test "$(kubectl get namespace knative -o jsonpath='{.metadata.uid}')" = b45355e7-34c7-483b-9e0f-1431571ae7f7
+test "$(kubectl get namespace knative \
+  -o jsonpath='{.metadata.labels.app\.kubernetes\.io/managed-by}')" = argocd
+test "$(kubectl get namespace knative \
+  -o jsonpath='{.metadata.annotations.argocd\.argoproj\.io/sync-options}')" = ServerSideApply=true
+test -z "$(kubectl get namespace knative \
+  -o jsonpath='{.metadata.annotations.argocd\.argoproj\.io/tracking-id}')"
+test "$(kubectl -n argocd get application knative -o json |
+  jq '[.status.resources[] | select(.kind == "Namespace")] | length')" = 0
 ```
 
 Acceptance requires the Knative Application to be `Synced/Healthy` at the exact merge revision, the rendered target to
-contain no `Namespace`, the live namespace UID and protection annotation to remain unchanged, and all Knative operator,
-Serving, Eventing, and Service identities and readiness states to remain unchanged. Roll back by restoring the protected
-source Namespace; never delete or recreate the live namespace.
+contain no `Namespace`, the live namespace UID to remain unchanged, the managed-by and server-side-apply metadata to be
+present without a tracking annotation, and all Knative operator, Serving, Eventing, and Service identities and readiness
+states to remain unchanged. Roll back by restoring the protected source Namespace; never delete or recreate the live
+namespace.

--- a/packages/scripts/src/shared/__tests__/enabled-apps.test.ts
+++ b/packages/scripts/src/shared/__tests__/enabled-apps.test.ts
@@ -136,7 +136,9 @@ describe('enabled app inventory', () => {
     expect(knativeKustomization).toContain('knative/operator/releases/download/knative-v1.23.0/operator.yaml')
     expect(knativeKustomization).toContain('$patch: delete')
     expect(knativeKustomization).not.toContain('argocd.argoproj.io/sync-options: Prune=false')
-    expect(knativeEntry).toContain('argocd.argoproj.io/sync-options: Prune=false')
+    expect(knativeEntry).toContain('app.kubernetes.io/managed-by: argocd')
+    expect(knativeEntry).not.toContain('argocd.argoproj.io/sync-options: Prune=false')
+    expect(knativeEntry).not.toContain('argocd.argoproj.io/tracking-id')
   })
 
   it('keeps chart-only apps out of Nix image migration state', () => {


### PR DESCRIPTION
## Summary

- replace the ineffective managed-namespace `Prune=false` value that Argo CD 3.4 unconditionally overwrites with `ServerSideApply=true`
- add a standard managed-by label while deliberately keeping the generated Namespace free of Argo resource-tracking metadata
- update the Wave 4 handoff acceptance to assert the preserved UID, untracked status, and actual managed-namespace behavior

## Related Issues

None

## Testing

- `bun test packages/scripts/src/shared/__tests__/enabled-apps.test.ts` (24 pass)
- `bunx oxfmt --check argocd/applicationsets/platform.yaml packages/scripts/src/shared/__tests__/enabled-apps.test.ts docs/runbooks/cluster-application-upgrades-2026-08.md`
- `kubectl -n argocd apply --dry-run=server --server-side --field-manager=argocd-controller --force-conflicts -f argocd/applicationsets/platform.yaml`
- `bun run lint:argocd`
- live diagnosis confirmed Namespace UID preservation, `ServerSideApply=true`, no tracking annotation, and no Namespace in Application `status.resources`

## Breaking Changes

None. This corrects namespace metadata without tracking, pruning, deleting, or recreating the namespace.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.