### PR TITLE
chore(argocd): upgrade observability collectors

### DIFF
--- a/argocd/applications/agents/alloy-deployment.yaml
+++ b/argocd/applications/agents/alloy-deployment.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: agents-alloy
       containers:
         - name: alloy
-          image: grafana/alloy:v1.11.2
+          image: grafana/alloy:v1.18.1
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/argocd/applications/argo-workflows/alloy-deployment.yaml
+++ b/argocd/applications/argo-workflows/alloy-deployment.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: argo-workflows-alloy
       containers:
         - name: alloy
-          image: grafana/alloy:v1.11.2
+          image: grafana/alloy:v1.18.1
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/argocd/applications/argocd/alloy-deployment.yaml
+++ b/argocd/applications/argocd/alloy-deployment.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: argocd-alloy
       containers:
         - name: alloy
-          image: grafana/alloy:v1.11.2
+          image: grafana/alloy:v1.18.1
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/argocd/applications/bilig/alloy-deployment.yaml
+++ b/argocd/applications/bilig/alloy-deployment.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: bilig-alloy
       containers:
         - name: alloy
-          image: grafana/alloy:v1.11.2
+          image: grafana/alloy:v1.18.1
           args:
             - run
             - /etc/alloy/config.river

--- a/argocd/applications/buzz/alloy-deployment.yaml
+++ b/argocd/applications/buzz/alloy-deployment.yaml
@@ -27,7 +27,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: alloy
-          image: grafana/alloy:v1.11.2@sha256:6ab34b8201f0e8b0c4346be4934c9965723af3f7f21dd9a65fd73f270f69b451
+          image: grafana/alloy:v1.18.1@sha256:0f4434c92b3e6cdac38bb129b344e1790c246f7b6e2eaffcc16a5fa363240e33
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/argocd/applications/jangar/alloy-deployment.yaml
+++ b/argocd/applications/jangar/alloy-deployment.yaml
@@ -22,7 +22,7 @@ spec:
       serviceAccountName: jangar-alloy
       containers:
         - name: alloy
-          image: grafana/alloy:v1.11.2
+          image: grafana/alloy:v1.18.1
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/argocd/applications/nats/alloy-deployment.yaml
+++ b/argocd/applications/nats/alloy-deployment.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: nats-alloy
       containers:
         - name: alloy
-          image: grafana/alloy:v1.11.2
+          image: grafana/alloy:v1.18.1
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/argocd/applications/nats/kustomization.yaml
+++ b/argocd/applications/nats/kustomization.yaml
@@ -32,4 +32,4 @@ images:
     newTag: 0.18.0
   - name: grafana/alloy
     newName: mirror.gcr.io/grafana/alloy
-    newTag: v1.11.2
+    newTag: v1.18.1

--- a/argocd/applications/observability/cluster-metrics-alloy-deployment.yaml
+++ b/argocd/applications/observability/cluster-metrics-alloy-deployment.yaml
@@ -30,7 +30,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: alloy
-          image: grafana/alloy:v1.11.2
+          image: grafana/alloy:v1.18.1
           args:
             - run
             - /etc/alloy/config.river

--- a/argocd/applications/observability/kustomization.yaml
+++ b/argocd/applications/observability/kustomization.yaml
@@ -29,7 +29,7 @@ resources:
 helmCharts:
   - name: kube-state-metrics
     repo: https://prometheus-community.github.io/helm-charts
-    version: 7.3.0
+    version: 8.2.0
     releaseName: observability-kube-state-metrics
     namespace: observability
     includeCRDs: true

--- a/argocd/applications/oirat/alloy-deployment.yaml
+++ b/argocd/applications/oirat/alloy-deployment.yaml
@@ -22,7 +22,7 @@ spec:
         fsGroup: 65534
       containers:
         - name: alloy
-          image: grafana/alloy:v1.11.2
+          image: grafana/alloy:v1.18.1
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/argocd/applications/torghut/alloy-deployment.yaml
+++ b/argocd/applications/torghut/alloy-deployment.yaml
@@ -24,7 +24,7 @@ spec:
       serviceAccountName: torghut-alloy
       containers:
         - name: alloy
-          image: grafana/alloy:v1.11.2
+          image: grafana/alloy:v1.18.1
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/docs/alloy-ingester-macos.md
+++ b/docs/alloy-ingester-macos.md
@@ -4,7 +4,9 @@ This guide covers installing and running Grafana Alloy locally on macOS so you c
 
 ## Version alignment
 
-Match the local binary to the cluster version. Current deployments use `grafana/alloy:v1.11.2` (see `argocd/applications/*/alloy-deployment.yaml`). If Homebrew is ahead, install the pinned tarball instead or upgrade the cluster manifests in sync.
+Match the local binary to the cluster version. Current enabled deployments use `grafana/alloy:v1.18.1` (see
+`argocd/applications/*/alloy-deployment.yaml`). If Homebrew is on a different version, install the pinned release archive
+instead or upgrade the cluster manifests in sync.
 
 ## Install
 
@@ -21,13 +23,14 @@ Homebrew stores configuration in `/opt/homebrew/etc/grafana-alloy` and data in
 `/opt/homebrew/var/lib/grafana-alloy/data`. The service runs `alloy run /opt/homebrew/etc/grafana-alloy`,
 so only `*.alloy` files in that directory are loaded.
 
-### Option B: Download the macOS release tarball
+### Option B: Download the macOS release archive
 
-Download the Grafana Alloy v1.11.2 macOS tarball from the official release page, then unpack and place the `alloy` binary on your PATH:
+Download the Grafana Alloy v1.18.1 macOS ZIP archive for your architecture from the official release page, then unpack
+and place the `alloy` binary on your PATH:
 
 ```bash
-tar -xzf alloy-darwin-*.tar.gz
-sudo install -m 0755 alloy /usr/local/bin/alloy
+unzip alloy-darwin-*.zip
+sudo install -m 0755 alloy-darwin-* /usr/local/bin/alloy
 alloy --version
 ```
 

--- a/docs/alloy-ingester-macos.md
+++ b/docs/alloy-ingester-macos.md
@@ -29,8 +29,15 @@ Download the Grafana Alloy v1.18.1 macOS ZIP archive for your architecture from 
 and place the `alloy` binary on your PATH:
 
 ```bash
-unzip alloy-darwin-*.zip
-sudo install -m 0755 alloy-darwin-* /usr/local/bin/alloy
+alloy_arch="$(uname -m)"
+case "$alloy_arch" in
+  arm64) alloy_arch="arm64" ;;
+  x86_64) alloy_arch="amd64" ;;
+  *) echo "unsupported architecture: $alloy_arch" >&2; exit 1 ;;
+esac
+alloy_archive="alloy-darwin-${alloy_arch}.zip"
+unzip "$alloy_archive"
+sudo install -m 0755 "${alloy_archive%.zip}" /usr/local/bin/alloy
 alloy --version
 ```
 

--- a/docs/runbooks/cluster-application-upgrades-2026-08.md
+++ b/docs/runbooks/cluster-application-upgrades-2026-08.md
@@ -869,3 +869,94 @@ migration Jobs. The KafkaSource, ConsumerGroup, and Consumer must retain their U
 source dispatcher must remain ready, the patched mutating webhook must stay scoped to `knative-eventing`, and no new
 recurring controller error may remain after startup. Roll back the version and release URLs only through a reviewed
 revert; preserve newer CRDs and all Eventing objects during rollback.
+
+Wave 4c completed on 2026-08-07 at merge `0abc1164f89b15abf9be3b738b1234cd95b262b3`. The Eventing CR, all 13
+Deployment and StatefulSet identities, all 23 CRD UIDs and stored versions, and the KafkaSource, ConsumerGroup, and
+Consumer UIDs were preserved. All desired 1.23 Pods became ready with zero restarts and the storage-version migration
+Job succeeded. The Kafka controller continues to report absent `kafka-broker-dispatcher` and
+`kafka-channel-dispatcher` StatefulSets because this cluster intentionally installs only the Kafka source plane; the
+same upstream scheduler code and log behavior exist in 1.22 and 1.23. The source dispatcher also continues to receive
+HTTP 422 for unsupported event types on the shared GitHub webhook topic. The Agents handler's only 422 path deliberately
+rejects unsupported event types and predates this upgrade; the Ready source continues to advance offsets. Neither
+recurring message is a 1.23 regression or a reason to install unused broker/channel operands.
+
+## Wave 5a: Alloy and kube-state-metrics
+
+| Application                                 | From               | To                 | Reconciliation | Expected impact                                                                        |
+| ------------------------------------------- | ------------------ | ------------------ | -------------- | -------------------------------------------------------------------------------------- |
+| Alloy collectors in 10 enabled applications | `1.11.2`           | `1.18.1`           | Mixed          | Collector Pods roll independently; application workloads do not roll.                  |
+| Observability kube-state-metrics chart      | `7.3.0` / `2.18.0` | `8.2.0` / `2.19.1` | Automatic      | One metrics Pod rolls in place; metric objects and custom state configuration persist. |
+
+Alloy 1.18.1 is the current upstream release and includes backported fixes for GO-2026-6061 and GO-2026-5970. Its
+multi-architecture image index digest is `sha256:0f4434c92b3e6cdac38bb129b344e1790c246f7b6e2eaffcc16a5fa363240e33`
+and contains both `linux/amd64` and `linux/arm64`, matching the cluster nodes. Every enabled River configuration validates
+with the target 1.18.1 binary. The documented 1.12 exporter label change does not apply because none of these configs
+uses the blackbox, SNMP, or StatsD exporters. The disabled `facteur` and `graf` applications remain untouched.
+
+Kube-state-metrics chart 8.2.0 packages app 2.19.1. Rendering 7.3.0 and 8.2.0 with the repository values produces the
+same six resource identities, with canonical identity hash
+`40556a2d2f8da5bc60acee4c791bbbc2d317797425a3b45758dbc6efce91bb81`, and the Deployment selector is unchanged.
+The configured collector list and custom Argo CD and CloudNativePG state metrics remain explicit and unchanged.
+
+Preserve these pre-merge Deployment identities:
+
+| Deployment                                          | UID                                    |
+| --------------------------------------------------- | -------------------------------------- |
+| `agents/agents-alloy`                               | `a3ba02f7-cd9c-40a1-b441-e95915e1186b` |
+| `argo-workflows/argo-workflows-alloy`               | `bdb9460b-a043-4f9a-b1e3-abc4a9855f93` |
+| `argocd/argocd-alloy`                               | `1ec0c154-b891-4df8-8a80-e05845d4de46` |
+| `bilig/bilig-alloy`                                 | `936b4cd8-f601-4de0-b5a7-f96f497154a1` |
+| `buzz/buzz-alloy`                                   | `081cfbd5-3483-44ab-a4d5-80844614678c` |
+| `jangar/jangar-alloy`                               | `a4d52115-fcd4-4744-a65d-d7e707293043` |
+| `nats/nats-alloy`                                   | `e1eba73d-67a7-416c-af2c-ff0d3f3e6d47` |
+| `observability/observability-cluster-metrics-alloy` | `b02148f1-7308-4e34-82ec-bc606e6a99e1` |
+| `observability/observability-kube-state-metrics`    | `e244832b-9bac-47c6-aa29-1a6da041a481` |
+| `oirat/oirat-alloy`                                 | `c8d9cdec-e4aa-4bea-9368-a2e4b7e665a1` |
+| `torghut/torghut-alloy`                             | `ebd469eb-065d-4ad3-a46c-27b052e77d19` |
+
+```bash
+set -euo pipefail
+git fetch --quiet origin main
+upgrade_revision=$(gh pr view codex/cluster-app-upgrades-wave5-observability -R proompteng/lab \
+  --json state,mergeCommit --jq 'select(.state == "MERGED") | .mergeCommit.oid')
+test -n "$upgrade_revision"
+test "$(git rev-parse origin/main)" = "$upgrade_revision"
+
+for app in bilig jangar nats observability torghut; do
+  argocd app get "$app" --hard-refresh >/dev/null
+done
+for app in agents argo-workflows argocd buzz oirat; do
+  argocd app get "$app" --hard-refresh >/dev/null
+done
+
+argocd app sync agents --resource apps:Deployment:agents-alloy
+argocd app sync argo-workflows --resource apps:Deployment:argo-workflows-alloy
+argocd app sync argocd --resource apps:Deployment:argocd-alloy
+argocd app sync buzz --resource apps:Deployment:buzz-alloy
+argocd app sync oirat --resource apps:Deployment:oirat-alloy
+
+for pair in \
+  agents/agents-alloy \
+  argo-workflows/argo-workflows-alloy \
+  argocd/argocd-alloy \
+  bilig/bilig-alloy \
+  buzz/buzz-alloy \
+  jangar/jangar-alloy \
+  nats/nats-alloy \
+  observability/observability-cluster-metrics-alloy \
+  observability/observability-kube-state-metrics \
+  oirat/oirat-alloy \
+  torghut/torghut-alloy; do
+  namespace=${pair%/*}
+  deployment=${pair#*/}
+  kubectl -n "$namespace" rollout status "deployment/$deployment" --timeout=15m
+done
+```
+
+Acceptance requires every Deployment UID above to remain unchanged, every replacement Pod to be ready with zero
+restarts, all Alloy containers to run 1.18.1, and kube-state-metrics to report chart 8.2.0/app 2.19.1. Validate each
+Alloy readiness endpoint and require no recurring post-startup errors. Query the kube-state-metrics service through the
+API proxy and require representative `kube_pod_info`, `kube_argocd_application_deployment_history_info`, and
+`kube_cnpg_*` metrics. Preserve and explicitly recheck the pre-existing `agents` and `oirat` OutOfSync states and the
+pre-existing `torghut` Degraded state so the targeted manual syncs do not reconcile unrelated resources. Roll back by
+reviewed revert; the metrics collectors are stateless and no persisted application data is changed.

--- a/packages/scripts/src/shared/__tests__/enabled-apps.test.ts
+++ b/packages/scripts/src/shared/__tests__/enabled-apps.test.ts
@@ -22,6 +22,20 @@ const knativeKustomization = readFileSync('argocd/applications/knative/kustomiza
 const knativeServingManifest = readFileSync('argocd/applications/knative-serving/knative-serving.yaml', 'utf8')
 const knativeEventingKustomization = readFileSync('argocd/applications/knative-eventing/kustomization.yaml', 'utf8')
 const knativeEventingManifest = readFileSync('argocd/applications/knative-eventing/knative-eventing.yaml', 'utf8')
+const enabledAlloyDeploymentPaths = [
+  'argocd/applications/agents/alloy-deployment.yaml',
+  'argocd/applications/argo-workflows/alloy-deployment.yaml',
+  'argocd/applications/argocd/alloy-deployment.yaml',
+  'argocd/applications/bilig/alloy-deployment.yaml',
+  'argocd/applications/buzz/alloy-deployment.yaml',
+  'argocd/applications/jangar/alloy-deployment.yaml',
+  'argocd/applications/nats/alloy-deployment.yaml',
+  'argocd/applications/observability/cluster-metrics-alloy-deployment.yaml',
+  'argocd/applications/oirat/alloy-deployment.yaml',
+  'argocd/applications/torghut/alloy-deployment.yaml',
+]
+const natsKustomization = readFileSync('argocd/applications/nats/kustomization.yaml', 'utf8')
+const observabilityKustomization = readFileSync('argocd/applications/observability/kustomization.yaml', 'utf8')
 const productApplicationSet = YAML.parse(readFileSync('argocd/applicationsets/product.yaml', 'utf8')) as {
   spec?: {
     syncPolicy?: { preserveResourcesOnDeletion?: boolean }
@@ -148,6 +162,17 @@ describe('enabled app inventory', () => {
     expect(knativeEntry).toContain('app.kubernetes.io/managed-by: argocd')
     expect(knativeEntry).not.toContain('argocd.argoproj.io/sync-options: Prune=false')
     expect(knativeEntry).not.toContain('argocd.argoproj.io/tracking-id')
+  })
+
+  it('pins the enabled observability collector upgrade wave', () => {
+    for (const deploymentPath of enabledAlloyDeploymentPaths) {
+      expect(readFileSync(deploymentPath, 'utf8')).toContain('grafana/alloy:v1.18.1')
+    }
+    expect(readFileSync('argocd/applications/buzz/alloy-deployment.yaml', 'utf8')).toContain(
+      'sha256:0f4434c92b3e6cdac38bb129b344e1790c246f7b6e2eaffcc16a5fa363240e33',
+    )
+    expect(natsKustomization).toContain('newTag: v1.18.1')
+    expect(observabilityKustomization).toContain('version: 8.2.0')
   })
 
   it('keeps chart-only apps out of Nix image migration state', () => {


### PR DESCRIPTION
## Summary

- upgrade Grafana Alloy from 1.11.2 to 1.18.1 across all ten enabled collector deployments while preserving the disabled Facteur and Graf manifests
- upgrade the observability kube-state-metrics chart from 7.3.0/app 2.18.0 to 8.2.0/app 2.19.1 with unchanged object identities and selector
- record pre-rollout identities, scoped reconciliation, rollback, and live acceptance requirements in the cluster application upgrade runbook

## Related Issues

None

## Testing

- `bun test packages/scripts/src/shared/__tests__/enabled-apps.test.ts packages/scripts/src/shared/__tests__/storage-observability-contract.test.ts packages/scripts/src/shared/__tests__/bayn-cnpg-contract.test.ts packages/scripts/src/shared/__tests__/bayn-cycle-observability-contract.test.ts packages/scripts/src/shared/__tests__/flink-observability-contract.test.ts packages/scripts/src/shared/__tests__/buzz-production-contract.test.ts` (45 passed before adding the wave pin; focused enabled-app rerun then passed 25 tests)
- Grafana Alloy 1.18.1 `alloy validate` against all ten enabled River configurations
- Helm-rendered kube-state-metrics 7.3.0 versus 8.2.0 identity and Deployment-selector comparison
- `nix develop -c kustomize build --enable-helm` plus targeted `kubectl apply --dry-run=server` for all eleven changed Deployments; no rendered Namespace objects
- `nix develop -c bun run lint:argocd`
- `bunx oxfmt --check` on every changed source, test, and runbook file
- `git diff --check`

## Breaking Changes

None. The collectors are stateless; enabled Alloy configs validate unchanged, and kube-state-metrics retains the same six object identities and Deployment selector.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
