### PR TITLE
fix(kafka): retain Karapace schemas

### DIFF
--- a/argocd/applications/kafka/karapace.yaml
+++ b/argocd/applications/kafka/karapace.yaml
@@ -3,6 +3,8 @@ kind: KafkaTopic
 metadata:
   name: karapace-schemas
   namespace: kafka
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false
   labels:
     strimzi.io/cluster: kafka
 spec:

--- a/argocd/applications/kafka/karapace.yaml
+++ b/argocd/applications/kafka/karapace.yaml
@@ -1,3 +1,17 @@
+apiVersion: kafka.strimzi.io/v1
+kind: KafkaTopic
+metadata:
+  name: karapace-schemas
+  namespace: kafka
+  labels:
+    strimzi.io/cluster: kafka
+spec:
+  topicName: _schemas
+  partitions: 1
+  replicas: 3
+  config:
+    cleanup.policy: compact
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/docs/runbooks/cluster-application-upgrades-2026-08.md
+++ b/docs/runbooks/cluster-application-upgrades-2026-08.md
@@ -1025,3 +1025,20 @@ restarts. Require Karapace to report 6.2.2, preserve the exact sorted subject ha
 Require cloudflared to report 2026.7.3, return HTTP 200 with at least one ready connection, and show no recurring tunnel
 errors after convergence. Each Application must be `Synced/Healthy` at the exact merge revision. Roll back through a
 reviewed revert only; never delete the Flipt PVC or Kafka `_schemas` topic.
+
+Wave 5b merged as `305f732b9e15ca3252526e4c4e6040ea1699094b`. Flipt and cloudflared passed their runtime gates, and all
+five resource UIDs plus the Flipt volume binding were preserved. Karapace 6.2.2 started healthy and replayed through
+offset 248, but returned zero subjects, so the wave remains unaccepted.
+
+The failed Karapace gate exposed pre-existing topic retention loss rather than a 6.2.2 reader regression. An
+independent consumer reported `_schemas` watermarks `low=249, high=249`; all three broker replicas contained only the
+empty segment beginning at offset 249. The topic was not represented by a `KafkaTopic`, so it retained the broker
+defaults `cleanup.policy=delete` and `retention.ms=604800000`. The previous long-running Karapace process continued to
+serve four subjects from memory after Kafka deleted their records, masking the loss until the upgrade restarted it.
+
+The corrective gate is a managed `KafkaTopic/karapace-schemas` targeting `_schemas`, with one partition, three replicas,
+and `cleanup.policy=compact`. Do not restore registry records until that resource is `Ready` and an independent Kafka
+admin read confirms the effective compact-only policy. Recovery must preserve the current IDs observed in retained
+payloads (`7`, `8`, and `9`) and the legacy IDs still present in retained TA payloads (`1` and `4`), restore exactly the
+four pre-upgrade active subjects, and prove that each ID serves a schema capable of decoding its corresponding retained
+payload without exposing payload contents. Keep Wave 5b open until those checks and a fresh Karapace restart both pass.

--- a/docs/runbooks/cluster-application-upgrades-2026-08.md
+++ b/docs/runbooks/cluster-application-upgrades-2026-08.md
@@ -1037,8 +1037,10 @@ defaults `cleanup.policy=delete` and `retention.ms=604800000`. The previous long
 serve four subjects from memory after Kafka deleted their records, masking the loss until the upgrade restarted it.
 
 The corrective gate is a managed `KafkaTopic/karapace-schemas` targeting `_schemas`, with one partition, three replicas,
-and `cleanup.policy=compact`. Do not restore registry records until that resource is `Ready` and an independent Kafka
-admin read confirms the effective compact-only policy. Recovery must preserve the current IDs observed in retained
-payloads (`7`, `8`, and `9`) and the legacy IDs still present in retained TA payloads (`1` and `4`), restore exactly the
-four pre-upgrade active subjects, and prove that each ID serves a schema capable of decoding its corresponding retained
-payload without exposing payload contents. Keep Wave 5b open until those checks and a fresh Karapace restart both pass.
+and `cleanup.policy=compact`. It carries Argo's `Prune=false` sync option so deleting or renaming the manifest cannot
+cause Strimzi to delete the data-bearing Kafka topic. Do not restore registry records until that resource is `Ready` and
+an independent Kafka admin read confirms the effective compact-only policy. Recovery must preserve the current IDs
+observed in retained payloads (`7`, `8`, and `9`) and the legacy IDs still present in retained TA payloads (`1` and `4`),
+restore exactly the four pre-upgrade active subjects, and prove that each ID serves a schema capable of decoding its
+corresponding retained payload without exposing payload contents. Keep Wave 5b open until those checks and a fresh
+Karapace restart both pass.

--- a/packages/scripts/src/shared/__tests__/enabled-apps.test.ts
+++ b/packages/scripts/src/shared/__tests__/enabled-apps.test.ts
@@ -42,7 +42,12 @@ const karapaceManifest = readFileSync('argocd/applications/kafka/karapace.yaml',
 const karapaceResources = YAML.parseAllDocuments(karapaceManifest).map((document) => document.toJSON()) as Array<{
   apiVersion?: string
   kind?: string
-  metadata?: { name?: string; namespace?: string; labels?: Record<string, string> }
+  metadata?: {
+    name?: string
+    namespace?: string
+    annotations?: Record<string, string>
+    labels?: Record<string, string>
+  }
   spec?: {
     topicName?: string
     partitions?: number
@@ -212,6 +217,7 @@ describe('enabled app inventory', () => {
       metadata: {
         name: 'karapace-schemas',
         namespace: 'kafka',
+        annotations: { 'argocd.argoproj.io/sync-options': 'Prune=false' },
         labels: { 'strimzi.io/cluster': 'kafka' },
       },
       spec: {

--- a/packages/scripts/src/shared/__tests__/enabled-apps.test.ts
+++ b/packages/scripts/src/shared/__tests__/enabled-apps.test.ts
@@ -38,7 +38,18 @@ const natsKustomization = readFileSync('argocd/applications/nats/kustomization.y
 const observabilityKustomization = readFileSync('argocd/applications/observability/kustomization.yaml', 'utf8')
 const featureFlagsKustomization = readFileSync('argocd/applications/feature-flags/kustomization.yaml', 'utf8')
 const cloudflaredDeployment = readFileSync('argocd/applications/cloudflare/deployment.yaml', 'utf8')
-const karapaceDeployment = readFileSync('argocd/applications/kafka/karapace.yaml', 'utf8')
+const karapaceManifest = readFileSync('argocd/applications/kafka/karapace.yaml', 'utf8')
+const karapaceResources = YAML.parseAllDocuments(karapaceManifest).map((document) => document.toJSON()) as Array<{
+  apiVersion?: string
+  kind?: string
+  metadata?: { name?: string; namespace?: string; labels?: Record<string, string> }
+  spec?: {
+    topicName?: string
+    partitions?: number
+    replicas?: number
+    config?: Record<string, string | number>
+  }
+}>
 const productApplicationSet = YAML.parse(readFileSync('argocd/applicationsets/product.yaml', 'utf8')) as {
   spec?: {
     syncPolicy?: { preserveResourcesOnDeletion?: boolean }
@@ -187,9 +198,29 @@ describe('enabled app inventory', () => {
     expect(cloudflaredDeployment).toContain(
       'cloudflare/cloudflared:2026.7.3@sha256:e39ee8da81ad5e05d77f38d2f51c60ca51bf2a8450ac3abab50c17fdb91d91bf',
     )
-    expect(karapaceDeployment).toContain(
+    expect(karapaceManifest).toContain(
       'ghcr.io/aiven-open/karapace:6.2.2@sha256:3c202789067f1bc3aa68d9dbb22d6298d254380a9e69c2705120c7434277238c',
     )
+  })
+
+  it('retains Karapace schemas in a managed compacted topic', () => {
+    const schemasTopic = karapaceResources.find(
+      (resource) => resource.apiVersion === 'kafka.strimzi.io/v1' && resource.kind === 'KafkaTopic',
+    )
+
+    expect(schemasTopic).toMatchObject({
+      metadata: {
+        name: 'karapace-schemas',
+        namespace: 'kafka',
+        labels: { 'strimzi.io/cluster': 'kafka' },
+      },
+      spec: {
+        topicName: '_schemas',
+        partitions: 1,
+        replicas: 3,
+        config: { 'cleanup.policy': 'compact' },
+      },
+    })
   })
 
   it('keeps chart-only apps out of Nix image migration state', () => {


### PR DESCRIPTION
## Summary

- Adopt the existing Karapace `_schemas` topic with a Strimzi `KafkaTopic` and enforce compact-only cleanup.
- Add an enabled-app regression test for the topic name, partition count, replica count, and cleanup policy.
- Record the Wave 5b acceptance failure, verified retention-loss root cause, and guarded recovery criteria.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/shared/__tests__/enabled-apps.test.ts` (27 pass)
- `kubectl -n kafka apply --dry-run=server -f argocd/applications/kafka/karapace.yaml`
- `nix develop -c bun run lint:argocd` (all rendered sets: 0 invalid, 0 errors)
- `nix develop -c sh -c 'kustomize build --enable-helm argocd/applications/kafka | yq eval-all "select(.kind == \\"KafkaTopic\\" and .spec.topicName == \\"_schemas\\")" -'`
- `bunx oxfmt --check packages/scripts/src/shared/__tests__/enabled-apps.test.ts`
- `git diff --check`

## Breaking Changes

None. The existing `_schemas` topic is adopted in place; this PR changes its cleanup policy from the broker default `delete` to `compact` and does not recreate the topic or restore records.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.