### PR TITLE
fix(kafka): restart Karapace after recovery

### DIFF
--- a/argocd/applications/kafka/karapace.yaml
+++ b/argocd/applications/kafka/karapace.yaml
@@ -28,6 +28,8 @@ spec:
       app.kubernetes.io/name: karapace
   template:
     metadata:
+      annotations:
+        app.proompteng.ai/schema-storage-generation: compact-v1
       labels:
         app.kubernetes.io/name: karapace
     spec:

--- a/packages/scripts/src/shared/__tests__/enabled-apps.test.ts
+++ b/packages/scripts/src/shared/__tests__/enabled-apps.test.ts
@@ -206,6 +206,7 @@ describe('enabled app inventory', () => {
     expect(karapaceManifest).toContain(
       'ghcr.io/aiven-open/karapace:6.2.2@sha256:3c202789067f1bc3aa68d9dbb22d6298d254380a9e69c2705120c7434277238c',
     )
+    expect(karapaceManifest).toContain('app.proompteng.ai/schema-storage-generation: compact-v1')
   })
 
   it('retains Karapace schemas in a managed compacted topic', () => {


### PR DESCRIPTION
## Summary

- Mark the Karapace Pod template with the durable `compact-v1` schema-storage generation.
- Force one GitOps-managed Karapace restart so the restored `_schemas` records are replayed from Kafka instead of process memory.
- Assert the storage-generation marker in the enabled-app regression test.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/shared/__tests__/enabled-apps.test.ts` (27 pass)
- `kubectl -n kafka apply --dry-run=server -f argocd/applications/kafka/karapace.yaml`
- `nix develop -c bun run lint:argocd` (all rendered sets: 0 invalid, 0 errors)
- `bunx oxfmt --check packages/scripts/src/shared/__tests__/enabled-apps.test.ts`
- `git diff --check`
- Pre-restart recovery verification: active-subject hash `c372679b92ee2057a19827dce2cd941419df54363187b0d708c66594b7da1e11`; schema IDs `1`, `4`, `7`, `8`, and `9` resolve; retained legacy/current bar, signal, and status payloads decode completely with the restored registry schemas.

## Breaking Changes

None. The Deployment UID and image are unchanged; the template annotation intentionally rolls the single Karapace Pod once.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.