### PR TITLE
chore(coder): start 2.35.3

### DIFF
--- a/argocd/applications/coder/values.yaml
+++ b/argocd/applications/coder/values.yaml
@@ -1,8 +1,6 @@
 coder:
   coder:
-    # Stage the forward-only schema upgrade with the 2.32.1 server fully stopped.
-    # Restore this to one replica only after Argo proves the drain at this revision.
-    replicaCount: 0
+    replicaCount: 1
     image:
       tag: v2.35.3@sha256:8e34e774ebde1813f03294498374cd955264eee6cd2b61a72baf7634a0ca7de4
     env:

--- a/docs/runbooks/cluster-application-upgrades-2026-08.md
+++ b/docs/runbooks/cluster-application-upgrades-2026-08.md
@@ -1379,3 +1379,11 @@ and exact projection hashes except for documented migration-owned changes. Prese
 prove both existing workspace agents reconnect, require a clean bounded log window, and finish with Argo
 `Synced/Healthy` at the exact start revision. Rollback requires draining Coder, restoring the logical dump or snapshot,
 and only then reverting both Git revisions; never start 2.32.1 against schema 535.
+
+The drain revision was accepted at merge `a4165fb4d5532932f6595a022389ec1865ab3c7e`. Argo finished
+`Synced/Healthy` at that exact revision with `Deployment/coder` at zero replicas and no control-plane Pod. Schema
+version 462 remained clean, database size and all five record counts and projection hashes remained exact, and there
+were zero remaining Coder database connections. Both workspace Deployments remained ready with their exact UIDs, both
+workspace-home PVCs retained their UIDs and bindings, and the two-node CNPG cluster stayed healthy with negligible
+replication lag. The public `/healthz` returned the expected 503 during the controlled outage. The start revision may
+now restore one replica at the already-reconciled 2.35.3 image and chart.

--- a/packages/scripts/src/shared/__tests__/enabled-apps.test.ts
+++ b/packages/scripts/src/shared/__tests__/enabled-apps.test.ts
@@ -338,14 +338,14 @@ describe('enabled app inventory', () => {
     )
   })
 
-  it('stages the Coder schema upgrade at zero replicas with an immutable image', () => {
+  it('pins Coder to the immutable multi-architecture stable release', () => {
     expect(coderChart).toMatchObject({
       appVersion: '2.35.3',
       version: '2.35.3',
     })
     expect(coderChart.dependencies?.find((dependency) => dependency.name === 'coder')?.version).toBe('2.35.3')
     expect(coderValues.coder?.coder).toMatchObject({
-      replicaCount: 0,
+      replicaCount: 1,
       image: {
         tag: 'v2.35.3@sha256:8e34e774ebde1813f03294498374cd955264eee6cd2b61a72baf7634a0ca7de4',
       },


### PR DESCRIPTION
## Summary

- restore the drained Coder control plane to one replica at the already-reconciled 2.35.3 chart and immutable image
- record exact drain acceptance: schema 462 remained clean, state hashes were exact, and workspace/storage identities were preserved
- convert the enabled-application regression gate from staging state to the final one-replica state

## Related Issues

None

## Testing

- `bun test packages/scripts/src/shared/__tests__/enabled-apps.test.ts` (33 passed)
- exact Helm render comparison against merged drain revision (only `spec.replicas: 0` to `1`)
- `kubeconform -strict -summary -ignore-missing-schemas` on the start Helm and Kustomize renders (8 valid, 0 invalid, 0 errors, 3 CRDs skipped)
- `kubectl -n coder apply --dry-run=server` on the start Helm and Kustomize renders
- `bun run lint:argocd` (all seven shards passed with zero invalid resources and zero errors)
- `bunx oxfmt --check packages/scripts/src/shared/__tests__/enabled-apps.test.ts docs/runbooks/cluster-application-upgrades-2026-08.md argocd/applications/coder/values.yaml`
- live drain acceptance: zero control-plane Pods/connections, schema `462/false`, exact counts/hashes/UIDs/bindings, both workspace Deployments ready, CNPG 2/2 healthy, snapshot ready

## Breaking Changes

This revision starts Coder 2.35.3 and executes forward-only PostgreSQL migrations 463-535. Rollback requires first draining Coder and restoring `/tmp/coder-v2-32-1-20260807T143239Z.dump` or `VolumeSnapshot/coder-cluster-pre-v2-35-3-20260807t143239z`; 2.32.1 must never start against schema 535.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
