### PR TITLE
chore(metallb): upgrade to 0.16.1

### DIFF
--- a/argocd/applications/metallb-system/kustomization.yaml
+++ b/argocd/applications/metallb-system/kustomization.yaml
@@ -2,10 +2,28 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: metallb-system
 resources:
-  - github.com/metallb/metallb//config/native?ref=v0.15.3
+  - github.com/metallb/metallb//config/native?ref=v0.16.1
   - ipaddresspool.yaml
   - l2advertisement.yaml
+images:
+  - name: quay.io/metallb/controller
+    newName: quay.io/metallb/controller
+    newTag: v0.16.1
+    digest: sha256:f51ab515de9ccd20dc3dccb093e48df8adddac019326c456f449e55ba91b6420
+  - name: quay.io/metallb/speaker
+    newName: quay.io/metallb/speaker
+    newTag: v0.16.1
+    digest: sha256:16561e96531e1852d5c229ad7fae6e994dcfa983ff7f4de6b6208b34a4e2ddbc
 patches:
+  - target:
+      kind: Namespace
+      name: metallb-system
+    patch: |-
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: metallb-system
+      $patch: delete
   - target:
       group: apps
       version: v1

--- a/argocd/applicationsets/bootstrap.yaml
+++ b/argocd/applicationsets/bootstrap.yaml
@@ -112,6 +112,14 @@ spec:
                     argocd.argoproj.io/sync-wave: "0"
                   automation: manual
                   enabled: "true"
+                  managedNamespaceMetadata:
+                    labels:
+                      pod-security.kubernetes.io/enforce: privileged
+                      pod-security.kubernetes.io/audit: privileged
+                      pod-security.kubernetes.io/warn: privileged
+                    annotations:
+                      # Prevent accidental namespace deletion when the upstream Namespace leaves rendered output.
+                      argocd.argoproj.io/sync-options: Prune=false
                 - name: traefik
                   path: argocd/applications/traefik
                   namespace: traefik

--- a/docs/runbooks/cluster-application-upgrades-2026-08.md
+++ b/docs/runbooks/cluster-application-upgrades-2026-08.md
@@ -1537,3 +1537,41 @@ advertisement valid, and the four MetalLB-backed Services retaining `100.100.244
 After merge, require the generated Application to report no automated sync policy, no application-resource diff, and
 no operation or Pod replacement. Recheck every listed UID, VIP assignment, endpoint, and reachability probe, then
 require Argo `Synced/Healthy` at the exact gate merge. Rollback is a reviewed Git revert of the policy-only revision.
+
+Wave 7c was accepted at merge `01434e5516a29f8c5fd9a8eecabf59fd4e2292f0`. The root Application diff contained
+only the MetalLB `automation: auto` to `manual` field and was reconciled without pruning. The generated MetalLB
+Application then reported no automated sync policy and no resource diff. The controller and all three speaker Pod
+UIDs, readiness, and zero restart counts remained exact. Both pool UIDs, the L2Advertisement UID, all four service
+UIDs, and VIP assignments `.180`, `.181`, and `.182` remained exact. HTTP probes through both ingress VIPs returned
+404 as expected, Plex `/identity` returned 200 through `.180`, and Forgejo SSH remained reachable through `.181`.
+Both root and MetalLB finished `Synced/Healthy` at the exact gate merge.
+
+## Wave 7d: MetalLB 0.16.1
+
+| Application | From     | To       | Reconciliation | Expected impact                                                  |
+| ----------- | -------- | -------- | -------------- | ---------------------------------------------------------------- |
+| MetalLB     | `0.15.3` | `0.16.1` | Manual         | One controller and three speakers roll; VIPs must remain stable. |
+
+MetalLB 0.16.0 changes the default BGP backend to FRR-K8s, introduces HTTPS-only metrics, improves endpoint health
+handling during KubeVirt migrations, and fixes L2 election with service selectors. This cluster explicitly consumes
+the upstream `config/native` overlay and defines only L2 advertisements, so the BGP default change does not alter its
+data plane. Version 0.16.1 fixes the controller health probes and bind address, the BGPPeer `localASN` schema, and HTTPS
+scrape configuration. Pin the controller and speaker multi-architecture indexes to
+`sha256:f51ab515de9ccd20dc3dccb093e48df8adddac019326c456f449e55ba91b6420` and
+`sha256:16561e96531e1852d5c229ad7fae6e994dcfa983ff7f4de6b6208b34a4e2ddbc`.
+
+Delete the upstream `Namespace` from rendered output and hand ownership to the bootstrap ApplicationSet with the
+existing privileged Pod Security labels and `Prune=false` namespace annotation. Reconcile root first, without pruning,
+and require the namespace UID `e4450219-b1e5-4a54-833e-361d2e40bb4f` and metadata to remain exact before touching the
+MetalLB Application. Preserve every resource and Service UID listed in Wave 7c.
+
+Before merge, require both pools valid, the L2Advertisement valid, all four MetalLB-backed Services assigned their
+exact VIPs, controller and speakers ready with zero restarts, and reachability through `.180`, `.181`, and `.182`.
+After the root namespace handoff, require the reviewed MetalLB diff to contain only upstream 0.16.1 CRD, RBAC,
+NetworkPolicy, probe, metrics, argument, and image changes plus removal of the rendered Namespace; do not permit pool,
+advertisement, or Service deletion. Sync without pruning. Require exact controller, speaker, pool, advertisement,
+namespace, and Service UIDs; one ready controller and three ready speakers at the pinned image indexes with zero
+restarts; unchanged VIPs and endpoints; valid configuration status; and successful reachability probes throughout the
+roll. Finish with bounded clean logs and both root and MetalLB `Synced/Healthy` at the exact merge. Rollback is a
+reviewed Git revert and manual no-prune sync; stop immediately on VIP reassignment, endpoint loss, or failed L2
+advertisement.

--- a/packages/scripts/src/shared/__tests__/enabled-apps.test.ts
+++ b/packages/scripts/src/shared/__tests__/enabled-apps.test.ts
@@ -47,6 +47,12 @@ const localPathKustomization = YAML.parse(
   images?: Array<{ name?: string; newName?: string; newTag?: string; digest?: string }>
 }
 const localPathConfigPatch = readFileSync('argocd/applications/local-path/patches/local-path-config.patch.yaml', 'utf8')
+const metallbKustomizationSource = readFileSync('argocd/applications/metallb-system/kustomization.yaml', 'utf8')
+const metallbKustomization = YAML.parse(metallbKustomizationSource) as {
+  resources?: string[]
+  images?: Array<{ name?: string; newName?: string; newTag?: string; digest?: string }>
+  patches?: Array<{ target?: { kind?: string; name?: string }; patch?: string }>
+}
 const nvidiaDevicePluginManifests = [
   readFileSync('argocd/applications/nvidia-gpu-operator/altra-nvidia-device-plugin.yaml', 'utf8'),
   readFileSync('argocd/applications/nvidia-gpu-operator/turin-nvidia-device-plugin.yaml', 'utf8'),
@@ -211,6 +217,30 @@ describe('enabled app inventory', () => {
 
     expect(metallbEntry).toContain('automation: manual')
     expect(metallbEntry).not.toContain('automation: auto')
+    expect(metallbEntry).toContain('argocd.argoproj.io/sync-options: Prune=false')
+  })
+
+  it('pins MetalLB to immutable 0.16.1 images without rendering its Namespace', () => {
+    expect(metallbKustomization.resources).toContain('github.com/metallb/metallb//config/native?ref=v0.16.1')
+    expect(metallbKustomization.images).toEqual([
+      {
+        name: 'quay.io/metallb/controller',
+        newName: 'quay.io/metallb/controller',
+        newTag: 'v0.16.1',
+        digest: 'sha256:f51ab515de9ccd20dc3dccb093e48df8adddac019326c456f449e55ba91b6420',
+      },
+      {
+        name: 'quay.io/metallb/speaker',
+        newName: 'quay.io/metallb/speaker',
+        newTag: 'v0.16.1',
+        digest: 'sha256:16561e96531e1852d5c229ad7fae6e994dcfa983ff7f4de6b6208b34a4e2ddbc',
+      },
+    ])
+    expect(
+      metallbKustomization.patches?.find(
+        (patch) => patch.target?.kind === 'Namespace' && patch.target.name === 'metallb-system',
+      )?.patch,
+    ).toContain('$patch: delete')
   })
 
   it('pins the Argo control-plane upgrade wave and applies its large CRD server-side', () => {


### PR DESCRIPTION
## Summary

- Upgrade the MetalLB native manifest from 0.15.3 to 0.16.1 with immutable controller and speaker image indexes.
- Remove the upstream Namespace from rendered output and hand namespace metadata to the bootstrap ApplicationSet with prune protection.
- Add invariants for the manual gate, image pins, and namespace deletion; record the gate acceptance and rollout contract.

## Related Issues

None

## Testing

- bun test packages/scripts/src/shared/__tests__/enabled-apps.test.ts (37 pass)
- kustomize render comparison (28 target resources; only the upstream Namespace leaves the resource set)
- kubeconform strict validation (28 resources, 16 valid, 12 skipped, 0 invalid or errors)
- kubectl server dry-run for all 28 rendered MetalLB resources
- kubectl server dry-run for the bootstrap ApplicationSet
- bunx oxfmt --check on all changed files
- bun run lint:argocd

## Breaking Changes

None. MetalLB remains manual and requires a reviewed root namespace handoff followed by a no-prune MetalLB sync.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots section removed and Breaking Changes handled.
- [x] Documentation, release notes, and follow-ups are updated or tracked.