### PR TITLE
chore(headlamp): promote 0.44.0

### DIFF
--- a/argocd/applications/headlamp/kustomization.yaml
+++ b/argocd/applications/headlamp/kustomization.yaml
@@ -39,7 +39,7 @@ patches:
 helmCharts:
   - name: headlamp
     repo: https://kubernetes-sigs.github.io/headlamp
-    version: 0.43.0
+    version: 0.44.0
     releaseName: headlamp
     namespace: headlamp
     valuesFile: values.yaml

--- a/argocd/applications/headlamp/values.yaml
+++ b/argocd/applications/headlamp/values.yaml
@@ -17,6 +17,8 @@ volumes:
   - name: headlamp-tmp
     emptyDir: {}
 config:
+  staticPlugins:
+    enabled: true
   oidc:
     secret:
       create: false

--- a/argocd/applications/headlamp/values.yaml
+++ b/argocd/applications/headlamp/values.yaml
@@ -5,7 +5,7 @@ deploymentAnnotations:
 image:
   registry: registry.ide-newton.ts.net
   repository: lab/headlamp@sha256
-  tag: c1c9c59aba9b118c36c36baed3bd90b977fcec6c255408b955be3650c1a84af3
+  tag: 01d4fdde84278ef994a40084d5730e4c66b46ef43515d02fd9cc760adfa2e967
 persistentVolumeClaim:
   enabled: false
 podSecurityContext:


### PR DESCRIPTION
## Summary

- Promote Headlamp to `v0.44.0` with OCI index `sha256:01d4fdde84278ef994a40084d5730e4c66b46ef43515d02fd9cc760adfa2e967` built from source commit `4b3906ad876b7c362183b320a20a909409a05458`.
- Upgrade the Headlamp Helm chart from `0.43.0` to `0.44.0`.
- Keep static plugins explicit so the bundled Prometheus plugin `0.9.1` remains enabled.

## Related Issues

N/A

## Testing

- `nix run .#assert-oci-platforms -- "registry.ide-newton.ts.net/lab/headlamp@sha256:01d4fdde84278ef994a40084d5730e4c66b46ef43515d02fd9cc760adfa2e967" linux/amd64 linux/arm64`
- `nix run .#render-headlamp`
- `bun run lint:argocd`
- `bun test scripts/__tests__/enabled-argocd-applications.test.ts` (39 passed)
- `git diff --check`
- Helm `0.43.0` versus `0.44.0`: identical resource identities and no semantic Deployment, Service, or RBAC delta after chart metadata normalization.
- Live preflight: Argo `Synced/Healthy`, one ready pod with zero restarts, public root and `/healthz` HTTP 200, OIDC redirect to Keycloak, authenticated Kubernetes REST response, and `/wsMultiplexer` HTTP 101 upgrade.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.