### PR TITLE
chore(headlamp): promote 0.44.0

### DIFF
--- a/argocd/applications/headlamp/kustomization.yaml
+++ b/argocd/applications/headlamp/kustomization.yaml
@@ -39,7 +39,7 @@ patches:
 helmCharts:
   - name: headlamp
     repo: https://kubernetes-sigs.github.io/headlamp
-    version: 0.43.0
+    version: 0.44.0
     releaseName: headlamp
     namespace: headlamp
     valuesFile: values.yaml

--- a/argocd/applications/headlamp/values.yaml
+++ b/argocd/applications/headlamp/values.yaml
@@ -5,7 +5,7 @@ deploymentAnnotations:
 image:
   registry: registry.ide-newton.ts.net
   repository: lab/headlamp@sha256
-  tag: c1c9c59aba9b118c36c36baed3bd90b977fcec6c255408b955be3650c1a84af3
+  tag: 6750048b052613e073b32e33029fc88a12e88b3c1761d478355987110f29059a
 persistentVolumeClaim:
   enabled: false
 podSecurityContext:

--- a/argocd/applications/headlamp/values.yaml
+++ b/argocd/applications/headlamp/values.yaml
@@ -17,6 +17,8 @@ volumes:
   - name: headlamp-tmp
     emptyDir: {}
 config:
+  staticPlugins:
+    enabled: true
   oidc:
     secret:
       create: false


### PR DESCRIPTION
## Summary

- Promote Headlamp `v0.44.0` with fixed OCI index `sha256:6750048b052613e073b32e33029fc88a12e88b3c1761d478355987110f29059a` built from source merge `a84126839be8541466a52d89cff3580e5454242e`.
- Upgrade the Headlamp Helm chart from `0.43.0` to `0.44.0` and keep static plugins explicit so Prometheus plugin `0.9.1` remains enabled.
- Include #13591, which keeps the auth cookie for the configured session TTL and proves an already-expired access token can refresh after an idle session.

## Related Issues

Supersedes #13590.

## Testing

- Source fix: `sh services/headlamp/scripts/test-upstream.sh`, all patched backend tests, and `go test -race ./pkg/auth`.
- Main image run `31204843108`: successful `linux/amd64`, `linux/arm64`, OCI index verification, and release contract.
- `nix run .#assert-oci-platforms -- "registry.ide-newton.ts.net/lab/headlamp@sha256:6750048b052613e073b32e33029fc88a12e88b3c1761d478355987110f29059a" linux/amd64 linux/arm64`
- `nix run .#render-headlamp`
- `bun run lint:argocd`
- `bun test ./packages/scripts/src/shared/__tests__/enabled-apps.test.ts ./packages/scripts/src/shared/__tests__/enabled-apps-baseline.test.ts` (39 passed)
- `git diff --check`
- Helm `0.43.0` versus `0.44.0`: identical resource identities and no semantic Deployment, Service, or RBAC delta after chart metadata normalization.
- Live preflight: Argo `Synced/Healthy`, one ready pod with zero restarts, public root and `/healthz` HTTP 200, OIDC redirect to Keycloak, authenticated Kubernetes REST response, and `/wsMultiplexer` HTTP 101 upgrade.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.