### PR TITLE
revert(headlamp): restore working frontend assets

### DIFF
--- a/argocd/applications/headlamp/kustomization.yaml
+++ b/argocd/applications/headlamp/kustomization.yaml
@@ -39,7 +39,7 @@ patches:
 helmCharts:
   - name: headlamp
     repo: https://kubernetes-sigs.github.io/headlamp
-    version: 0.44.0
+    version: 0.43.0
     releaseName: headlamp
     namespace: headlamp
     valuesFile: values.yaml

--- a/argocd/applications/headlamp/values.yaml
+++ b/argocd/applications/headlamp/values.yaml
@@ -5,7 +5,7 @@ deploymentAnnotations:
 image:
   registry: registry.ide-newton.ts.net
   repository: lab/headlamp@sha256
-  tag: 6750048b052613e073b32e33029fc88a12e88b3c1761d478355987110f29059a
+  tag: c1c9c59aba9b118c36c36baed3bd90b977fcec6c255408b955be3650c1a84af3
 persistentVolumeClaim:
   enabled: false
 podSecurityContext:
@@ -17,8 +17,6 @@ volumes:
   - name: headlamp-tmp
     emptyDir: {}
 config:
-  staticPlugins:
-    enabled: true
   oidc:
     secret:
       create: false


### PR DESCRIPTION
## Summary

- Roll back the Headlamp `0.44.0` chart and fixed-image promotion from #13592.
- Restore the previously healthy `0.43.0` chart and image digest `sha256:c1c9c59aba9b118c36c36baed3bd90b977fcec6c255408b955be3650c1a84af3`.
- Keep the source-level OIDC refresh fix from #13591 on main while the Nix runtime layout is corrected.

## Related Issues

Reverts the deployment portion of #13592.

## Testing

- Fresh browser load of the promoted image remains stuck at `Loading`.
- Every referenced `0.44.0` frontend asset returns HTTP 400 `Invalid file path`.
- In-pod inspection confirms the assets are symlinks into the Nix store, outside the frontend root accepted by Headlamp `0.44.0`.
- `nix run .#render-headlamp`
- `bun run lint:argocd`
- `git diff --cached --check`
- The rollback exactly restores the pre-rollout chart and digest that were `Synced/Healthy`, browser-functional, 1/1, and zero-restart immediately before #13592.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.