### PR TITLE
fix(headlamp): materialize runtime image assets

### DIFF
--- a/.github/workflows/headlamp-ci.yml
+++ b/.github/workflows/headlamp-ci.yml
@@ -6,12 +6,18 @@ permissions:
 on:
   pull_request:
     paths:
+      - '.github/workflows/headlamp-ci.yml'
+      - '.github/workflows/nix-oci-build-common.yml'
+      - 'nix/verify-headlamp-image-assets.sh'
       - 'services/headlamp/**'
       - 'nix/images/headlamp.nix'
   push:
     branches:
       - main
     paths:
+      - '.github/workflows/headlamp-ci.yml'
+      - '.github/workflows/nix-oci-build-common.yml'
+      - 'nix/verify-headlamp-image-assets.sh'
       - 'services/headlamp/**'
       - 'nix/images/headlamp.nix'
   workflow_dispatch:
@@ -48,6 +54,7 @@ jobs:
   nix-image:
     if: >-
       ${{
+        github.event_name == 'pull_request' ||
         github.event_name == 'workflow_dispatch' ||
         (
           github.event_name == 'push' &&

--- a/.github/workflows/headlamp-ci.yml
+++ b/.github/workflows/headlamp-ci.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Set up Nix toolchain
         uses: ./.github/actions/setup-nix-toolchain
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ github.token }}
           require-preinstalled: 'true'
           install-ci-toolchain: 'true'
           extra-nix-config: |
@@ -51,10 +51,18 @@ jobs:
       - name: Run upstream multiplexer regression tests
         run: sh services/headlamp/scripts/test-upstream.sh
 
+  nix-image-pr:
+    if: github.event_name == 'pull_request'
+    uses: ./.github/workflows/nix-oci-build-common.yml
+    with:
+      image_name: headlamp
+      package_attr: headlamp-image
+      tag: sha-${{ github.sha }}
+      image_build_timeout: 20m
+
   nix-image:
     if: >-
       ${{
-        github.event_name == 'pull_request' ||
         github.event_name == 'workflow_dispatch' ||
         (
           github.event_name == 'push' &&
@@ -70,4 +78,5 @@ jobs:
       latest: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main' }}
       release_artifact_name: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main' && 'headlamp-release-contract' || '' }}
       image_build_timeout: 20m
-    secrets: inherit
+    secrets:
+      ATTIC_TOKEN: ${{ secrets.ATTIC_TOKEN }}

--- a/.github/workflows/headlamp-ci.yml
+++ b/.github/workflows/headlamp-ci.yml
@@ -67,7 +67,6 @@ jobs:
       image_name: headlamp
       package_attr: headlamp-image
       tag: sha-${{ github.sha }}
-      pr_number: ${{ github.event.pull_request.number || '' }}
       latest: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main' }}
       release_artifact_name: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main' && 'headlamp-release-contract' || '' }}
       image_build_timeout: 20m

--- a/.github/workflows/nix-oci-build-common.yml
+++ b/.github/workflows/nix-oci-build-common.yml
@@ -189,6 +189,16 @@ jobs:
           bash nix/ci-run-timed.sh "verify-bayn-command-${ARCH}" "${NIX_OCI_LOG_DIR}/verify-bayn-command-${ARCH}.log" \
             bash nix/verify-bayn-image-command.sh "${IMAGE_TAR}"
 
+      - name: Verify Headlamp frontend assets from image
+        if: inputs.image_name == 'headlamp'
+        env:
+          IMAGE_TAR: ${{ steps.build.outputs.image_tar }}
+          ARCH: ${{ matrix.arch }}
+        run: |
+          set -euo pipefail
+          bash nix/ci-run-timed.sh "verify-headlamp-assets-${ARCH}" "${NIX_OCI_LOG_DIR}/verify-headlamp-assets-${ARCH}.log" \
+            bash nix/verify-headlamp-image-assets.sh "${IMAGE_TAR}"
+
       - name: Push platform image without Docker
         if: >-
           ${{

--- a/.github/workflows/nix-oci-build-common.yml
+++ b/.github/workflows/nix-oci-build-common.yml
@@ -5,6 +5,9 @@ permissions:
 
 on:
   workflow_call:
+    secrets:
+      ATTIC_TOKEN:
+        required: false
     inputs:
       image_name:
         required: true
@@ -108,7 +111,7 @@ jobs:
       - name: Set up Nix toolchain
         uses: ./.github/actions/setup-nix-toolchain
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ github.token }}
           require-preinstalled: 'true'
           install-ci-toolchain: 'false'
           extra-nix-config: |
@@ -343,7 +346,7 @@ jobs:
       - name: Set up Nix toolchain
         uses: ./.github/actions/setup-nix-toolchain
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ github.token }}
           require-preinstalled: 'true'
           install-ci-toolchain: 'false'
           extra-nix-config: |

--- a/nix/images/headlamp.nix
+++ b/nix/images/headlamp.nix
@@ -144,12 +144,20 @@ pkgs.dockerTools.buildLayeredImage {
   tag = "nix";
   maxLayers = 16;
   contents = [
-    runtimeRoot
     pkgs.busybox
     pkgs.cacert
   ];
   extraCommands = ''
-    mkdir -p tmp var/tmp etc/ssl/certs
+    mkdir -p headlamp tmp var/tmp etc/ssl/certs
+    # dockerTools materializes `contents` as store-backed symlinks. Headlamp
+    # 0.44 serves static files through os.OpenRoot, which rejects symlinks that
+    # escape the frontend root. Copy with dereferencing into this image layer.
+    cp -RL ${runtimeRoot}/headlamp/. headlamp/
+    remaining_headlamp_link="$(find headlamp -type l -print -quit)"
+    if [ -n "$remaining_headlamp_link" ]; then
+      echo "Headlamp runtime contains an unresolved symlink: $remaining_headlamp_link" >&2
+      exit 1
+    fi
     chmod 1777 tmp var/tmp
     ln -s ${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt etc/ssl/certs/ca-certificates.crt
   '';

--- a/nix/verify-headlamp-image-assets.sh
+++ b/nix/verify-headlamp-image-assets.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$#" -ne 1 ]]; then
+  echo "Usage: verify-headlamp-image-assets <nix-image-tar>" >&2
+  exit 2
+fi
+
+image_tar="$1"
+if [[ ! -f "$image_tar" ]]; then
+  echo "Headlamp image archive does not exist: $image_tar" >&2
+  exit 1
+fi
+
+verification_dir="$(mktemp -d)"
+cleanup() {
+  chmod -R u+w "$verification_dir" 2>/dev/null || true
+  rm -rf "$verification_dir"
+}
+trap cleanup EXIT
+archive_dir="$verification_dir/archive"
+rootfs_dir="$verification_dir/rootfs"
+mkdir -p "$archive_dir" "$rootfs_dir"
+
+tar -xf "$image_tar" -C "$archive_dir"
+manifest_path="$archive_dir/manifest.json"
+if [[ ! -f "$manifest_path" ]]; then
+  echo "Headlamp image archive is missing manifest.json" >&2
+  exit 1
+fi
+
+image_layers=()
+while IFS= read -r image_layer; do
+  image_layers+=("$image_layer")
+done < <(jq -r '.[0].Layers[]' "$manifest_path")
+if [[ "${#image_layers[@]}" -eq 0 ]]; then
+  echo "Headlamp image archive contains no layers" >&2
+  exit 1
+fi
+
+for image_layer in "${image_layers[@]}"; do
+  layer_path="$archive_dir/$image_layer"
+  if [[ ! -f "$layer_path" ]]; then
+    echo "Headlamp image layer is missing: $image_layer" >&2
+    exit 1
+  fi
+  tar -xf "$layer_path" -C "$rootfs_dir"
+done
+
+headlamp_root="$rootfs_dir/headlamp"
+frontend_root="$headlamp_root/frontend"
+index_path="$frontend_root/index.html"
+if [[ -L "$headlamp_root" || -L "$frontend_root" || -L "$index_path" ]]; then
+  echo "Headlamp runtime root, frontend root, and index must be materialized files and directories" >&2
+  exit 1
+fi
+if [[ ! -f "$index_path" ]]; then
+  echo "Headlamp image is missing /headlamp/frontend/index.html" >&2
+  exit 1
+fi
+
+remaining_link="$(find "$headlamp_root" -type l -print -quit)"
+if [[ -n "$remaining_link" ]]; then
+  echo "Headlamp image contains a store-backed runtime symlink: ${remaining_link#"$rootfs_dir"}" >&2
+  exit 1
+fi
+
+asset_refs=()
+while IFS= read -r asset_ref; do
+  asset_refs+=("$asset_ref")
+done < <(
+  grep -Eo '(src|href)="/assets/[^"]+"' "$index_path" \
+    | sed -E 's/^(src|href)="([^"]+)"$/\2/' \
+    | sort -u
+)
+if [[ "${#asset_refs[@]}" -eq 0 ]]; then
+  echo "Headlamp index does not reference any /assets files" >&2
+  exit 1
+fi
+
+javascript_assets=0
+stylesheet_assets=0
+for asset_ref in "${asset_refs[@]}"; do
+  asset_path="${asset_ref%%[?#]*}"
+  materialized_asset="$frontend_root/${asset_path#/}"
+  if [[ -L "$materialized_asset" || ! -f "$materialized_asset" || ! -r "$materialized_asset" ]]; then
+    echo "Headlamp index references a missing, unreadable, or symlinked asset: $asset_ref" >&2
+    exit 1
+  fi
+  case "$asset_path" in
+    *.js) javascript_assets=$((javascript_assets + 1)) ;;
+    *.css) stylesheet_assets=$((stylesheet_assets + 1)) ;;
+  esac
+done
+
+if [[ "$javascript_assets" -eq 0 || "$stylesheet_assets" -eq 0 ]]; then
+  echo "Headlamp index must reference materialized JavaScript and stylesheet assets" >&2
+  exit 1
+fi
+
+printf 'Verified %d Headlamp frontend assets (%d JavaScript, %d stylesheet) with no runtime symlinks.\n' \
+  "${#asset_refs[@]}" "$javascript_assets" "$stylesheet_assets"

--- a/nix/verify-headlamp-image-assets.sh
+++ b/nix/verify-headlamp-image-assets.sh
@@ -69,12 +69,12 @@ asset_refs=()
 while IFS= read -r asset_ref; do
   asset_refs+=("$asset_ref")
 done < <(
-  grep -Eo '(src|href)="/assets/[^"]+"' "$index_path" \
+  grep -Eo '(src|href)="(\./|/)?assets/[^"]+"' "$index_path" \
     | sed -E 's/^(src|href)="([^"]+)"$/\2/' \
     | sort -u
 )
 if [[ "${#asset_refs[@]}" -eq 0 ]]; then
-  echo "Headlamp index does not reference any /assets files" >&2
+  echo "Headlamp index does not reference any frontend assets" >&2
   exit 1
 fi
 
@@ -82,7 +82,9 @@ javascript_assets=0
 stylesheet_assets=0
 for asset_ref in "${asset_refs[@]}"; do
   asset_path="${asset_ref%%[?#]*}"
-  materialized_asset="$frontend_root/${asset_path#/}"
+  asset_relative_path="${asset_path#./}"
+  asset_relative_path="${asset_relative_path#/}"
+  materialized_asset="$frontend_root/$asset_relative_path"
   if [[ -L "$materialized_asset" || ! -f "$materialized_asset" || ! -r "$materialized_asset" ]]; then
     echo "Headlamp index references a missing, unreadable, or symlinked asset: $asset_ref" >&2
     exit 1


### PR DESCRIPTION
## Summary

- Materialize the Headlamp runtime into the OCI layer so Go `os.OpenRoot` can serve frontend assets without escaping through Nix store symlinks.
- Verify both built architectures contain no Headlamp runtime symlinks and every JavaScript and stylesheet referenced by `index.html` is readable.
- Run image construction on pull requests without inherited repository secrets; pass only the named `ATTIC_TOKEN` to trusted main/dispatch release builds.

## Related Issues

None

## Testing

- `actionlint .github/workflows/headlamp-ci.yml .github/workflows/nix-oci-build-common.yml`
- `shellcheck nix/verify-headlamp-image-assets.sh`
- `git diff --check`
- The verifier rejects published broken digest `sha256:6750048b052613e073b32e33029fc88a12e88b3c1761d478355987110f29059a` with the materialization error.
- The verifier accepts the materialized Headlamp 0.44 runtime reconstructed from that image: 7 assets, 5 JavaScript and 2 stylesheet files, with no runtime symlinks.
- `nix flake check`
- `nix run .#render-headlamp`
- `sh services/headlamp/scripts/test-upstream.sh`
- Evaluated `packages.aarch64-linux.headlamp-image` and `packages.x86_64-linux.headlamp-image` derivations.
- Exact-head GitHub CI built and verified the real amd64 and arm64 image archives; all required checks passed.

## Review

- Automatic GitHub Codex review was unavailable because the review quota was exhausted.
- Independent ChatGPT Pro audit of exact head `1ead7342b95c550f2c272869aafeec67f84ec412` used archive SHA256 `9103d0064a669218698c0da345f510a8b18d59ec3de18ea7f66358273a3fd630` and returned `MERGE` with no blockers.
- Audit thread: https://chatgpt.com/c/6a762a37-4bc8-83e8-aa77-b65b39fea624

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked; immutable digest promotion and live non-root HTTP/browser acceptance remain separate GitOps steps.