### PR TITLE
chore(headlamp): promote nix image sha-3c06c10afdc80418be2b7d6417dec2ad5f07f494

### DIFF
--- a/argocd/applications/headlamp/values.yaml
+++ b/argocd/applications/headlamp/values.yaml
@@ -5,7 +5,7 @@ deploymentAnnotations:
 image:
   registry: registry.ide-newton.ts.net
   repository: lab/headlamp@sha256
-  tag: c1c9c59aba9b118c36c36baed3bd90b977fcec6c255408b955be3650c1a84af3
+  tag: a771dbc4d27935fd3f9fa20cd55c35f6cbb0b363fd475ea5744ef4e34761c0ff
 persistentVolumeClaim:
   enabled: false
 podSecurityContext:


### PR DESCRIPTION
## Summary

- Promote Headlamp to `registry.ide-newton.ts.net/lab/headlamp@sha256:a771dbc4d27935fd3f9fa20cd55c35f6cbb0b363fd475ea5744ef4e34761c0ff`.
- Source commit: `3c06c10afdc80418be2b7d6417dec2ad5f07f494`.
- Built by the shared Nix OCI workflow.

## Related Issues

N/A

## Testing

- `nix run .#assert-oci-platforms -- "registry.ide-newton.ts.net/lab/headlamp@sha256:a771dbc4d27935fd3f9fa20cd55c35f6cbb0b363fd475ea5744ef4e34761c0ff" linux/amd64 linux/arm64`

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.