### PR TITLE
chore(headlamp): upgrade chart to 0.44.0

### DIFF
--- a/argocd/applications/headlamp/kustomization.yaml
+++ b/argocd/applications/headlamp/kustomization.yaml
@@ -39,7 +39,7 @@ patches:
 helmCharts:
   - name: headlamp
     repo: https://kubernetes-sigs.github.io/headlamp
-    version: 0.43.0
+    version: 0.44.0
     releaseName: headlamp
     namespace: headlamp
     valuesFile: values.yaml

--- a/argocd/applications/headlamp/values.yaml
+++ b/argocd/applications/headlamp/values.yaml
@@ -17,6 +17,8 @@ volumes:
   - name: headlamp-tmp
     emptyDir: {}
 config:
+  staticPlugins:
+    enabled: true
   oidc:
     secret:
       create: false


### PR DESCRIPTION
## Summary

- Upgrade the enabled Headlamp Helm chart from 0.43.0 to 0.44.0.
- Enable the chart's static-plugin wiring so the bundled Prometheus plugin is discovered at runtime.
- Keep the already-promoted, multi-arch, materialized Headlamp 0.44 image pinned by digest.

## Related Issues

None

## Testing

- `nix run .#render-headlamp`
- `bun run lint:argocd`
- `bun test ./packages/scripts/src/shared/__tests__/enabled-apps.test.ts ./packages/scripts/src/shared/__tests__/enabled-apps-baseline.test.ts` (39 pass)
- `nix run .#assert-oci-platforms -- registry.ide-newton.ts.net/lab/headlamp@sha256:a771dbc4d27935fd3f9fa20cd55c35f6cbb0b363fd475ea5744ef4e34761c0ff linux/amd64 linux/arm64`
- Live pre-merge digest proof: Argo `Synced/Healthy` at `68cb8e0e9c545eef2e75904d0c69680592af3b90`; Deployment UID preserved; pod ready with zero restarts; root HTML and all seven emitted JS/CSS assets returned HTTP 200 with the expected MIME types.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
