### PR TITLE
chore(rook): upgrade to 1.19.8

### DIFF
--- a/argocd/applications/rook-ceph/kustomization.yaml
+++ b/argocd/applications/rook-ceph/kustomization.yaml
@@ -12,14 +12,14 @@ resources:
 helmCharts:
   - name: rook-ceph
     repo: https://charts.rook.io/release
-    version: v1.19.7
+    version: v1.19.8
     releaseName: rook-ceph
     namespace: rook-ceph
     includeCRDs: true
     valuesFile: operator-values.yaml
   - name: rook-ceph-cluster
     repo: https://charts.rook.io/release
-    version: v1.19.7
+    version: v1.19.8
     releaseName: rook-ceph-cluster
     namespace: rook-ceph
     includeCRDs: true

--- a/argocd/applications/rook-ceph/operator-values.yaml
+++ b/argocd/applications/rook-ceph/operator-values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: docker.io/rook/ceph
-  tag: v1.19.7
+  tag: v1.19.8
   pullPolicy: IfNotPresent
 
 crds:


### PR DESCRIPTION
## Summary

- Upgrade the Rook operator and cluster Helm charts from `v1.19.7` to `v1.19.8`.
- Align the Rook operator image tag with the chart patch release.
- Preserve the Ceph `v19.2.4` data plane and all existing CSI/operator configuration.

## Related Issues

None.

## Testing

- `nix develop --command kustomize build --enable-helm argocd/applications/rook-ceph`
- `nix develop --command kubeconform -strict -ignore-missing-schemas /tmp/rook-1.19.8-render.yaml`
- `bun run lint:argocd`
- `bun test packages/scripts/src/shared/__tests__/enabled-apps.test.ts packages/scripts/src/shared/__tests__/enabled-apps-baseline.test.ts` (39 pass, 0 fail)
- `kubectl apply -n rook-ceph --server-side --dry-run=server --force-conflicts --field-manager=argocd-application-controller -f /tmp/rook-1.19.8-render.yaml -o name` (149 resources accepted)
- Normalized chart render comparison: operator and cluster outputs are byte-identical between `v1.19.7` and `v1.19.8` after version-label/image-tag normalization.
- `git diff --check`

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked. No documentation change is required for this version-only patch wave; the coordinated `v1.20.3` CSI adoption remains a separate follow-up.
