### PR TITLE
chore(rook): upgrade operator and CSI to 1.20.3

### DIFF
--- a/argocd/applications/rook-ceph/csi-driver-values.yaml
+++ b/argocd/applications/rook-ceph/csi-driver-values.yaml
@@ -11,7 +11,8 @@ operatorConfig:
     clusterName: rook-ceph
     enableMetadata: false
     enableFencing: false
-    grpcTimeout: 30
+    # Preserve the live Rook v1.19 sidecar timeout during ownership transfer.
+    grpcTimeout: 150
     snapshotPolicy: volumeSnapshot
     generateOMapInfo: false
     fsGroupPolicy: File
@@ -54,7 +55,7 @@ drivers:
     clusterName: rook-ceph
     enableMetadata: false
     enableFencing: false
-    grpcTimeout: 30
+    grpcTimeout: 150
     snapshotPolicy: volumeSnapshot
     generateOMapInfo: false
     fsGroupPolicy: File
@@ -141,7 +142,7 @@ drivers:
     clusterName: rook-ceph
     enableMetadata: false
     enableFencing: false
-    grpcTimeout: 30
+    grpcTimeout: 150
     snapshotPolicy: volumeGroupSnapshot
     generateOMapInfo: false
     fsGroupPolicy: File

--- a/argocd/applications/rook-ceph/csi-driver-values.yaml
+++ b/argocd/applications/rook-ceph/csi-driver-values.yaml
@@ -1,0 +1,222 @@
+# Rook-compatible Ceph-CSI values preserving the existing live driver behavior.
+operatorConfig:
+  name: ceph-csi-operator-config
+  namespace: rook-ceph
+  create: true
+  log: null
+  driverSpecDefaults:
+    log: null
+    imageSet:
+      name: rook-csi-operator-image-set-configmap
+    clusterName: rook-ceph
+    enableMetadata: false
+    enableFencing: false
+    grpcTimeout: 30
+    snapshotPolicy: volumeSnapshot
+    generateOMapInfo: false
+    fsGroupPolicy: File
+    attachRequired: true
+    deployCsiAddons: false
+    cephFsClientType: autodetect
+    kernelMountOptions: {}
+    fuseMountOptions: {}
+    nodePlugin:
+      priorityClassName: system-node-critical
+      kubeletDirPath: /var/lib/kubelet
+      enableSeLinuxHostMount: false
+      affinity:
+        nodeAffinity: {}
+      # Turin is intentionally a control-plane node and needs CSI node plugins
+      # so GPU workloads pinned there can mount rook-ceph-block PVCs.
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
+      imagePullPolicy: IfNotPresent
+    controllerPlugin:
+      hostNetwork: true
+      replicas: 2
+      deploymentStrategy:
+        type: Recreate
+      priorityClassName: system-cluster-critical
+      affinity:
+        nodeAffinity: {}
+      tolerations: []
+      imagePullPolicy: IfNotPresent
+
+drivers:
+  rbd:
+    name: rook-ceph.rbd.csi.ceph.com
+    enabled: true
+    log: null
+    imageSet:
+      name: rook-csi-operator-image-set-configmap
+    clusterName: rook-ceph
+    enableMetadata: false
+    enableFencing: false
+    grpcTimeout: 30
+    snapshotPolicy: volumeSnapshot
+    generateOMapInfo: false
+    fsGroupPolicy: File
+    attachRequired: true
+    deployCsiAddons: false
+    cephFsClientType: autodetect
+    kernelMountOptions: {}
+    fuseMountOptions: {}
+    nodePlugin:
+      # Node pods contain the mount processes, so roll them one node at a time.
+      updateStrategy:
+        type: OnDelete
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
+      # Leave driver-level ownership unchanged during adoption. The effective
+      # IfNotPresent default continues to come from OperatorConfig.
+      imagePullPolicy: ""
+      topology:
+        domainLabels:
+          - kubernetes.io/hostname
+      resources:
+        registrar:
+          limits:
+            memory: 256Mi
+          requests:
+            cpu: 50m
+            memory: 128Mi
+        plugin:
+          limits:
+            memory: 1Gi
+          requests:
+            cpu: 250m
+            memory: 512Mi
+    controllerPlugin:
+      hostNetwork: true
+      replicas: 2
+      tolerations: []
+      imagePullPolicy: ""
+      resources:
+        attacher:
+          limits:
+            memory: 256Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        snapshotter:
+          limits:
+            memory: 256Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        resizer:
+          limits:
+            memory: 256Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        provisioner:
+          limits:
+            memory: 256Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        omapGenerator:
+          limits:
+            memory: 1Gi
+          requests:
+            cpu: 250m
+            memory: 512Mi
+        plugin:
+          limits:
+            memory: 1Gi
+          requests:
+            memory: 512Mi
+
+  cephfs:
+    name: rook-ceph.cephfs.csi.ceph.com
+    enabled: true
+    log: null
+    imageSet:
+      name: rook-csi-operator-image-set-configmap
+    clusterName: rook-ceph
+    enableMetadata: false
+    enableFencing: false
+    grpcTimeout: 30
+    snapshotPolicy: volumeGroupSnapshot
+    generateOMapInfo: false
+    fsGroupPolicy: File
+    attachRequired: true
+    deployCsiAddons: false
+    cephFsClientType: autodetect
+    kernelMountOptions: {}
+    fuseMountOptions: {}
+    nodePlugin:
+      # FUSE mount processes live inside this pod. Preserve OnDelete even though
+      # current consumers use the kernel client, and roll nodes explicitly.
+      updateStrategy:
+        type: OnDelete
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
+      imagePullPolicy: ""
+      topology:
+        domainLabels:
+          - kubernetes.io/hostname
+      resources:
+        registrar:
+          limits:
+            memory: 256Mi
+          requests:
+            cpu: 50m
+            memory: 128Mi
+        plugin:
+          limits:
+            memory: 4Gi
+          requests:
+            cpu: 250m
+            memory: 1Gi
+    controllerPlugin:
+      hostNetwork: true
+      replicas: 2
+      tolerations: []
+      imagePullPolicy: ""
+      resources:
+        attacher:
+          limits:
+            memory: 256Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        snapshotter:
+          limits:
+            memory: 256Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        resizer:
+          limits:
+            memory: 256Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        provisioner:
+          limits:
+            memory: 256Mi
+          requests:
+            cpu: 100m
+            memory: 128Mi
+        plugin:
+          limits:
+            memory: 1Gi
+          requests:
+            cpu: 250m
+            memory: 512Mi
+
+  nfs:
+    name: rook-ceph.nfs.csi.ceph.com
+    enabled: false
+
+  nvmeof:
+    name: rook-ceph.nvmeof.csi.ceph.com
+    enabled: false

--- a/argocd/applications/rook-ceph/csi-driver-values.yaml
+++ b/argocd/applications/rook-ceph/csi-driver-values.yaml
@@ -85,6 +85,12 @@ drivers:
           requests:
             cpu: 50m
             memory: 128Mi
+        liveness:
+          limits:
+            memory: 256Mi
+          requests:
+            cpu: 50m
+            memory: 128Mi
         plugin:
           limits:
             memory: 1Gi
@@ -102,6 +108,12 @@ drivers:
             memory: 256Mi
           requests:
             cpu: 100m
+            memory: 128Mi
+        liveness:
+          limits:
+            memory: 256Mi
+          requests:
+            cpu: 50m
             memory: 128Mi
         snapshotter:
           limits:
@@ -171,6 +183,12 @@ drivers:
           requests:
             cpu: 50m
             memory: 128Mi
+        liveness:
+          limits:
+            memory: 256Mi
+          requests:
+            cpu: 50m
+            memory: 128Mi
         plugin:
           limits:
             memory: 4Gi
@@ -188,6 +206,12 @@ drivers:
             memory: 256Mi
           requests:
             cpu: 100m
+            memory: 128Mi
+        liveness:
+          limits:
+            memory: 256Mi
+          requests:
+            cpu: 50m
             memory: 128Mi
         snapshotter:
           limits:

--- a/argocd/applications/rook-ceph/csi-legacy-service-account-bridge.yaml
+++ b/argocd/applications/rook-ceph/csi-legacy-service-account-bridge.yaml
@@ -1,0 +1,158 @@
+# Keep the ceph-csi-operator v0.6 identities authorized while the v1.0.4
+# operator adopts the controllers and OnDelete node plugins. Remove this bridge
+# only after every CSI pod runs with the normalized v1.0.4 service accounts.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ceph-csi-cephfs-ctrlplugin-sa
+  namespace: rook-ceph
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ceph-csi-cephfs-nodeplugin-sa
+  namespace: rook-ceph
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ceph-csi-rbd-ctrlplugin-sa
+  namespace: rook-ceph
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ceph-csi-rbd-nodeplugin-sa
+  namespace: rook-ceph
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: rook-ceph-csi-legacy-cephfs-ctrlplugin-rb
+  namespace: rook-ceph
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rook-ceph-cephfs-csi-ceph-com-ctrlplugin-r
+subjects:
+  - kind: ServiceAccount
+    name: ceph-csi-cephfs-ctrlplugin-sa
+    namespace: rook-ceph
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: rook-ceph-csi-legacy-cephfs-nodeplugin-rb
+  namespace: rook-ceph
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rook-ceph-cephfs-csi-ceph-com-nodeplugin-r
+subjects:
+  - kind: ServiceAccount
+    name: ceph-csi-cephfs-nodeplugin-sa
+    namespace: rook-ceph
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: rook-ceph-csi-legacy-rbd-ctrlplugin-rb
+  namespace: rook-ceph
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rook-ceph-rbd-csi-ceph-com-ctrlplugin-r
+subjects:
+  - kind: ServiceAccount
+    name: ceph-csi-rbd-ctrlplugin-sa
+    namespace: rook-ceph
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: rook-ceph-csi-legacy-rbd-nodeplugin-rb
+  namespace: rook-ceph
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: rook-ceph-rbd-csi-ceph-com-nodeplugin-r
+subjects:
+  - kind: ServiceAccount
+    name: ceph-csi-rbd-nodeplugin-sa
+    namespace: rook-ceph
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rook-ceph-csi-legacy-cephfs-ctrlplugin-crb
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rook-ceph-cephfs-csi-ceph-com-ctrlplugin-cr
+subjects:
+  - kind: ServiceAccount
+    name: ceph-csi-cephfs-ctrlplugin-sa
+    namespace: rook-ceph
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rook-ceph-csi-legacy-cephfs-nodeplugin-crb
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rook-ceph-cephfs-csi-ceph-com-nodeplugin-cr
+subjects:
+  - kind: ServiceAccount
+    name: ceph-csi-cephfs-nodeplugin-sa
+    namespace: rook-ceph
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rook-ceph-csi-legacy-rbd-ctrlplugin-crb
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rook-ceph-rbd-csi-ceph-com-ctrlplugin-cr
+subjects:
+  - kind: ServiceAccount
+    name: ceph-csi-rbd-ctrlplugin-sa
+    namespace: rook-ceph
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: rook-ceph-csi-legacy-rbd-nodeplugin-crb
+  annotations:
+    argocd.argoproj.io/sync-wave: "1"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rook-ceph-rbd-csi-ceph-com-nodeplugin-cr
+subjects:
+  - kind: ServiceAccount
+    name: ceph-csi-rbd-nodeplugin-sa
+    namespace: rook-ceph

--- a/argocd/applications/rook-ceph/csi-legacy-service-account-bridge.yaml
+++ b/argocd/applications/rook-ceph/csi-legacy-service-account-bridge.yaml
@@ -1,13 +1,14 @@
 # Keep the ceph-csi-operator v0.6 identities authorized while the v1.0.4
-# operator adopts the controllers and OnDelete node plugins. Remove this bridge
-# only after every CSI pod runs with the normalized v1.0.4 service accounts.
+# operator adopts the controllers and OnDelete node plugins. Apply the bridge
+# with the new RBAC before operator reconciliation, and remove it only after
+# every CSI pod runs with the normalized v1.0.4 service accounts.
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: ceph-csi-cephfs-ctrlplugin-sa
   namespace: rook-ceph
   annotations:
-    argocd.argoproj.io/sync-wave: "1"
+    argocd.argoproj.io/sync-wave: "-1"
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -15,7 +16,7 @@ metadata:
   name: ceph-csi-cephfs-nodeplugin-sa
   namespace: rook-ceph
   annotations:
-    argocd.argoproj.io/sync-wave: "1"
+    argocd.argoproj.io/sync-wave: "-1"
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -23,7 +24,7 @@ metadata:
   name: ceph-csi-rbd-ctrlplugin-sa
   namespace: rook-ceph
   annotations:
-    argocd.argoproj.io/sync-wave: "1"
+    argocd.argoproj.io/sync-wave: "-1"
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -31,7 +32,7 @@ metadata:
   name: ceph-csi-rbd-nodeplugin-sa
   namespace: rook-ceph
   annotations:
-    argocd.argoproj.io/sync-wave: "1"
+    argocd.argoproj.io/sync-wave: "-1"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -39,7 +40,7 @@ metadata:
   name: rook-ceph-csi-legacy-cephfs-ctrlplugin-rb
   namespace: rook-ceph
   annotations:
-    argocd.argoproj.io/sync-wave: "1"
+    argocd.argoproj.io/sync-wave: "-1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -55,7 +56,7 @@ metadata:
   name: rook-ceph-csi-legacy-cephfs-nodeplugin-rb
   namespace: rook-ceph
   annotations:
-    argocd.argoproj.io/sync-wave: "1"
+    argocd.argoproj.io/sync-wave: "-1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -71,7 +72,7 @@ metadata:
   name: rook-ceph-csi-legacy-rbd-ctrlplugin-rb
   namespace: rook-ceph
   annotations:
-    argocd.argoproj.io/sync-wave: "1"
+    argocd.argoproj.io/sync-wave: "-1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -87,7 +88,7 @@ metadata:
   name: rook-ceph-csi-legacy-rbd-nodeplugin-rb
   namespace: rook-ceph
   annotations:
-    argocd.argoproj.io/sync-wave: "1"
+    argocd.argoproj.io/sync-wave: "-1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -102,7 +103,7 @@ kind: ClusterRoleBinding
 metadata:
   name: rook-ceph-csi-legacy-cephfs-ctrlplugin-crb
   annotations:
-    argocd.argoproj.io/sync-wave: "1"
+    argocd.argoproj.io/sync-wave: "-1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -117,7 +118,7 @@ kind: ClusterRoleBinding
 metadata:
   name: rook-ceph-csi-legacy-cephfs-nodeplugin-crb
   annotations:
-    argocd.argoproj.io/sync-wave: "1"
+    argocd.argoproj.io/sync-wave: "-1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -132,7 +133,7 @@ kind: ClusterRoleBinding
 metadata:
   name: rook-ceph-csi-legacy-rbd-ctrlplugin-crb
   annotations:
-    argocd.argoproj.io/sync-wave: "1"
+    argocd.argoproj.io/sync-wave: "-1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -147,7 +148,7 @@ kind: ClusterRoleBinding
 metadata:
   name: rook-ceph-csi-legacy-rbd-nodeplugin-crb
   annotations:
-    argocd.argoproj.io/sync-wave: "1"
+    argocd.argoproj.io/sync-wave: "-1"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/argocd/applications/rook-ceph/kustomization.yaml
+++ b/argocd/applications/rook-ceph/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - ingressroute-ceph-k8s-private.yaml
   - rook-ceph-objectstore-loki-user.yaml
   - rook-ceph-object-user-objectstore-loki-reflector-source.yaml
+  - csi-legacy-service-account-bridge.yaml
 
 helmCharts:
   - name: rook-ceph
@@ -33,7 +34,8 @@ helmCharts:
 
 patches:
   # Install the v1.20 CSI operator, CRDs, RBAC, and service accounts before
-  # transferring the existing Driver and OperatorConfig resources to GitOps.
+  # bridging the legacy identities (wave 1) and transferring the existing
+  # Driver and OperatorConfig resources to GitOps (wave 2).
   - target:
       group: csi.ceph.io
       version: v1
@@ -42,7 +44,7 @@ patches:
       - op: add
         path: /metadata/annotations
         value:
-          argocd.argoproj.io/sync-wave: "1"
+          argocd.argoproj.io/sync-wave: "2"
   - target:
       group: csi.ceph.io
       version: v1
@@ -51,7 +53,7 @@ patches:
       - op: add
         path: /metadata/annotations
         value:
-          argocd.argoproj.io/sync-wave: "1"
+          argocd.argoproj.io/sync-wave: "2"
   - path: cephcluster-osd-config-rollout.yaml
     target:
       group: ceph.rook.io

--- a/argocd/applications/rook-ceph/kustomization.yaml
+++ b/argocd/applications/rook-ceph/kustomization.yaml
@@ -12,11 +12,17 @@ resources:
 helmCharts:
   - name: rook-ceph
     repo: https://charts.rook.io/release
-    version: v1.19.8
+    version: v1.20.3
     releaseName: rook-ceph
     namespace: rook-ceph
     includeCRDs: true
     valuesFile: operator-values.yaml
+  - name: ceph-csi-drivers
+    repo: https://ceph.github.io/ceph-csi-operator
+    version: 1.0.4
+    releaseName: ceph-csi-drivers
+    namespace: rook-ceph
+    valuesFile: csi-driver-values.yaml
   - name: rook-ceph-cluster
     repo: https://charts.rook.io/release
     version: v1.19.8
@@ -26,6 +32,26 @@ helmCharts:
     valuesFile: cluster-values.yaml
 
 patches:
+  # Install the v1.20 CSI operator, CRDs, RBAC, and service accounts before
+  # transferring the existing Driver and OperatorConfig resources to GitOps.
+  - target:
+      group: csi.ceph.io
+      version: v1
+      kind: Driver
+    patch: |-
+      - op: add
+        path: /metadata/annotations
+        value:
+          argocd.argoproj.io/sync-wave: "1"
+  - target:
+      group: csi.ceph.io
+      version: v1
+      kind: OperatorConfig
+    patch: |-
+      - op: add
+        path: /metadata/annotations
+        value:
+          argocd.argoproj.io/sync-wave: "1"
   - path: cephcluster-osd-config-rollout.yaml
     target:
       group: ceph.rook.io

--- a/argocd/applications/rook-ceph/kustomization.yaml
+++ b/argocd/applications/rook-ceph/kustomization.yaml
@@ -33,9 +33,59 @@ helmCharts:
     valuesFile: cluster-values.yaml
 
 patches:
-  # Install the v1.20 CSI operator, CRDs, RBAC, and service accounts before
-  # bridging the legacy identities (wave 1) and transferring the existing
-  # Driver and OperatorConfig resources to GitOps (wave 2).
+  # Authorize both the normalized and legacy CSI identities before the v1.20
+  # operator can reconcile the existing Driver resources.
+  - target:
+      version: v1
+      kind: ServiceAccount
+      name: rook-ceph-(cephfs|rbd)-csi-ceph-com-(ctrlplugin|nodeplugin)-sa
+    patch: |-
+      - op: add
+        path: /metadata/annotations
+        value:
+          argocd.argoproj.io/sync-wave: "-1"
+  - target:
+      group: rbac.authorization.k8s.io
+      version: v1
+      kind: Role
+      name: rook-ceph-(cephfs|rbd)-csi-ceph-com-(ctrlplugin|nodeplugin)-r
+    patch: |-
+      - op: add
+        path: /metadata/annotations
+        value:
+          argocd.argoproj.io/sync-wave: "-1"
+  - target:
+      group: rbac.authorization.k8s.io
+      version: v1
+      kind: RoleBinding
+      name: rook-ceph-(cephfs|rbd)-csi-ceph-com-(ctrlplugin|nodeplugin)-rb
+    patch: |-
+      - op: add
+        path: /metadata/annotations
+        value:
+          argocd.argoproj.io/sync-wave: "-1"
+  - target:
+      group: rbac.authorization.k8s.io
+      version: v1
+      kind: ClusterRole
+      name: rook-ceph-(cephfs|rbd)-csi-ceph-com-(ctrlplugin|nodeplugin)-cr
+    patch: |-
+      - op: add
+        path: /metadata/annotations
+        value:
+          argocd.argoproj.io/sync-wave: "-1"
+  - target:
+      group: rbac.authorization.k8s.io
+      version: v1
+      kind: ClusterRoleBinding
+      name: rook-ceph-(cephfs|rbd)-csi-ceph-com-(ctrlplugin|nodeplugin)-crb
+    patch: |-
+      - op: add
+        path: /metadata/annotations
+        value:
+          argocd.argoproj.io/sync-wave: "-1"
+  # Transfer the existing Driver and OperatorConfig resources to GitOps only
+  # after the pre-operator identity and RBAC wave is healthy.
   - target:
       group: csi.ceph.io
       version: v1

--- a/argocd/applications/rook-ceph/operator-values.yaml
+++ b/argocd/applications/rook-ceph/operator-values.yaml
@@ -1,6 +1,6 @@
 image:
   repository: docker.io/rook/ceph
-  tag: v1.19.8
+  tag: v1.20.3
   pullPolicy: IfNotPresent
 
 crds:
@@ -35,56 +35,7 @@ allowLoopDevices: false
 cephCommandsTimeoutSeconds: "120"
 
 csi:
-  rookUseCsiOperator: true
-  enableRbdDriver: true
-  enableCephfsDriver: true
-  enableRBDSnapshotter: true
-  enableCephfsSnapshotter: true
-  enableCSIHostNetwork: true
-  # The Talos kernel client requires explicit v2 CRC negotiation with this Ceph cluster.
-  cephFSKernelMountOptions: ms_mode=crc
-  # Render `CSI_FORCE_CEPHFS_KERNEL_CLIENT: "false"` (Helm `with` blocks skip boolean false).
-  forceCephFSKernelClient: "false"
-  # FUSE mount processes live inside this pod. Roll nodes only after inventorying
-  # and restarting the node's FUSE consumers through a controlled operation.
-  cephFSPluginUpdateStrategy: OnDelete
-  # Rook v1.19.7's CSI-operator path reads the RBD strategy when constructing the
-  # CephFS Driver CR. Keep both OnDelete until that upstream mapping bug is fixed.
-  rbdPluginUpdateStrategy: OnDelete
-  # A 1 GiB limit OOM-killed ceph-fuse and invalidated every FUSE mount on the node.
-  # Media workloads use the kernel client, while this headroom protects compatibility clients.
-  csiCephFSPluginResource: |
-    - name : driver-registrar
-      resource:
-        requests:
-          memory: 128Mi
-          cpu: 50m
-        limits:
-          memory: 256Mi
-    - name : csi-cephfsplugin
-      resource:
-        requests:
-          memory: 1Gi
-          cpu: 250m
-        limits:
-          memory: 4Gi
-    - name : liveness-prometheus
-      resource:
-        requests:
-          memory: 128Mi
-          cpu: 50m
-        limits:
-          memory: 256Mi
-  topology:
-    enabled: true
-    domainLabels:
-      - kubernetes.io/hostname
-  provisionerReplicas: 2
-  pluginPriorityClassName: system-node-critical
-  provisionerPriorityClassName: system-cluster-critical
-  # Turin is intentionally a control-plane node and needs CSI nodeplugins so
-  # GPU workloads pinned there can mount rook-ceph-block PVCs.
-  pluginTolerations:
-    - key: node-role.kubernetes.io/control-plane
-      operator: Exists
-      effect: NoSchedule
+  installCsiOperator: true
+
+# Rook v1.20 transfers CSI configuration ownership to the ceph-csi-drivers chart.
+# The existing live Driver and OperatorConfig behavior is preserved in csi-driver-values.yaml.

--- a/argocd/applications/rook-ceph/operator-values.yaml
+++ b/argocd/applications/rook-ceph/operator-values.yaml
@@ -37,5 +37,14 @@ cephCommandsTimeoutSeconds: "120"
 csi:
   installCsiOperator: true
 
+# Before the wave-2 Driver update, ceph-csi-operator must reconcile the live
+# Drivers against their existing legacy service accounts. The wave-1 bridge
+# keeps those identities authorized until every OnDelete node pod is replaced.
+ceph-csi-operator:
+  controllerManager:
+    manager:
+      env:
+        csiServiceAccountPrefix: ceph-csi-
+
 # Rook v1.20 transfers CSI configuration ownership to the ceph-csi-drivers chart.
 # The existing live Driver and OperatorConfig behavior is preserved in csi-driver-values.yaml.

--- a/packages/scripts/src/shared/__tests__/rook-upgrade-contract.test.ts
+++ b/packages/scripts/src/shared/__tests__/rook-upgrade-contract.test.ts
@@ -19,11 +19,17 @@ type Kustomization = {
   patches: Array<{
     patch?: string
     target: {
-      group: string
+      group?: string
       version: string
       kind: string
+      name?: string
     }
   }>
+}
+
+type ResourceRequirements = {
+  limits: { memory: string }
+  requests: { cpu: string; memory: string }
 }
 
 type Driver = {
@@ -36,12 +42,16 @@ type Driver = {
     imagePullPolicy: string
     updateStrategy: { type: string }
     topology: { domainLabels: string[] }
-    resources: { plugin: { limits: { memory: string } } }
+    resources: {
+      liveness: ResourceRequirements
+      plugin: { limits: { memory: string } }
+    }
   }
   controllerPlugin: {
     hostNetwork: boolean
     replicas: number
     imagePullPolicy: string
+    resources: { liveness: ResourceRequirements }
   }
 }
 
@@ -65,6 +75,26 @@ test('orders the Rook v1.20 CSI ownership migration before the unchanged cluster
         op: 'add',
         path: '/metadata/annotations',
         value: { 'argocd.argoproj.io/sync-wave': '2' },
+      },
+    ])
+  }
+
+  const preOperatorIdentityPatches = kustomization.patches.filter(({ target }) =>
+    target.name?.startsWith('rook-ceph-(cephfs|rbd)-csi-ceph-com-'),
+  )
+  expect(preOperatorIdentityPatches.map(({ target }) => target.kind).sort()).toEqual([
+    'ClusterRole',
+    'ClusterRoleBinding',
+    'Role',
+    'RoleBinding',
+    'ServiceAccount',
+  ])
+  for (const { patch } of preOperatorIdentityPatches) {
+    expect(YAML.parse(patch ?? '')).toEqual([
+      {
+        op: 'add',
+        path: '/metadata/annotations',
+        value: { 'argocd.argoproj.io/sync-wave': '-1' },
       },
     ])
   }
@@ -115,6 +145,12 @@ test('preserves the Ceph data plane and live CSI behavior during the v1.20 migra
     expect(driver.nodePlugin.imagePullPolicy).toBe('')
     expect(driver.nodePlugin.topology.domainLabels).toEqual(['kubernetes.io/hostname'])
     expect(driver.controllerPlugin).toMatchObject({ hostNetwork: true, replicas: 2, imagePullPolicy: '' })
+    const expectedLivenessResources = {
+      limits: { memory: '256Mi' },
+      requests: { cpu: '50m', memory: '128Mi' },
+    }
+    expect(driver.nodePlugin.resources.liveness).toEqual(expectedLivenessResources)
+    expect(driver.controllerPlugin.resources.liveness).toEqual(expectedLivenessResources)
   }
 
   expect(driverValues.drivers.rbd).toMatchObject({
@@ -141,7 +177,7 @@ test('bridges the legacy CSI identities until every OnDelete pod is rolled', () 
 
   expect(resources).toHaveLength(12)
   for (const resource of resources) {
-    expect(resource.metadata.annotations['argocd.argoproj.io/sync-wave']).toBe('1')
+    expect(resource.metadata.annotations['argocd.argoproj.io/sync-wave']).toBe('-1')
   }
 
   expect(

--- a/packages/scripts/src/shared/__tests__/rook-upgrade-contract.test.ts
+++ b/packages/scripts/src/shared/__tests__/rook-upgrade-contract.test.ts
@@ -5,6 +5,8 @@ import YAML from 'yaml'
 
 const repoRoot = new URL('../../../../../', import.meta.url)
 const readYaml = <T>(path: string): T => YAML.parse(readFileSync(new URL(path, repoRoot), 'utf8')) as T
+const readYamlDocuments = <T>(path: string): T[] =>
+  YAML.parseAllDocuments(readFileSync(new URL(path, repoRoot), 'utf8')).map((document) => document.toJS() as T)
 
 type HelmChart = {
   name: string
@@ -12,6 +14,7 @@ type HelmChart = {
 }
 
 type Kustomization = {
+  resources: string[]
   helmCharts: HelmChart[]
   patches: Array<{
     patch?: string
@@ -26,6 +29,7 @@ type Kustomization = {
 type Driver = {
   name: string
   enabled: boolean
+  grpcTimeout: number
   snapshotPolicy: string
   cephFsClientType: string
   nodePlugin: {
@@ -49,6 +53,7 @@ test('orders the Rook v1.20 CSI ownership migration before the unchanged cluster
     { name: 'ceph-csi-drivers', version: '1.0.4' },
     { name: 'rook-ceph-cluster', version: 'v1.19.8' },
   ])
+  expect(kustomization.resources).toContain('csi-legacy-service-account-bridge.yaml')
 
   const csiOwnershipPatches = kustomization.patches.filter(
     ({ target }) => target.group === 'csi.ceph.io' && target.version === 'v1',
@@ -59,7 +64,7 @@ test('orders the Rook v1.20 CSI ownership migration before the unchanged cluster
       {
         op: 'add',
         path: '/metadata/annotations',
-        value: { 'argocd.argoproj.io/sync-wave': '1' },
+        value: { 'argocd.argoproj.io/sync-wave': '2' },
       },
     ])
   }
@@ -79,6 +84,7 @@ test('preserves the Ceph data plane and live CSI behavior during the v1.20 migra
       driverSpecDefaults: {
         clusterName: string
         cephFsClientType: string
+        grpcTimeout: number
         controllerPlugin: { hostNetwork: boolean; replicas: number }
       }
     }
@@ -97,11 +103,13 @@ test('preserves the Ceph data plane and live CSI behavior during the v1.20 migra
   expect(driverValues.operatorConfig.driverSpecDefaults).toMatchObject({
     clusterName: 'rook-ceph',
     cephFsClientType: 'autodetect',
+    grpcTimeout: 150,
     controllerPlugin: { hostNetwork: true, replicas: 2 },
   })
 
   for (const driver of [driverValues.drivers.rbd, driverValues.drivers.cephfs]) {
     expect(driver.enabled).toBe(true)
+    expect(driver.grpcTimeout).toBe(150)
     expect(driver.cephFsClientType).toBe('autodetect')
     expect(driver.nodePlugin.updateStrategy.type).toBe('OnDelete')
     expect(driver.nodePlugin.imagePullPolicy).toBe('')
@@ -121,4 +129,46 @@ test('preserves the Ceph data plane and live CSI behavior during the v1.20 migra
   expect(driverValues.drivers.cephfs.nodePlugin.resources.plugin.limits.memory).toBe('4Gi')
   expect(driverValues.drivers.nfs.enabled).toBe(false)
   expect(driverValues.drivers.nvmeof.enabled).toBe(false)
+})
+
+test('bridges the legacy CSI identities until every OnDelete pod is rolled', () => {
+  const resources = readYamlDocuments<{
+    kind: string
+    metadata: { name: string; annotations: Record<string, string> }
+    roleRef?: { kind: string; name: string }
+    subjects?: Array<{ kind: string; name: string; namespace: string }>
+  }>('argocd/applications/rook-ceph/csi-legacy-service-account-bridge.yaml')
+
+  expect(resources).toHaveLength(12)
+  for (const resource of resources) {
+    expect(resource.metadata.annotations['argocd.argoproj.io/sync-wave']).toBe('1')
+  }
+
+  expect(
+    resources
+      .filter(({ kind }) => kind === 'ServiceAccount')
+      .map(({ metadata }) => metadata.name)
+      .sort(),
+  ).toEqual([
+    'ceph-csi-cephfs-ctrlplugin-sa',
+    'ceph-csi-cephfs-nodeplugin-sa',
+    'ceph-csi-rbd-ctrlplugin-sa',
+    'ceph-csi-rbd-nodeplugin-sa',
+  ])
+
+  expect(
+    resources
+      .filter(({ kind }) => kind === 'RoleBinding' || kind === 'ClusterRoleBinding')
+      .map(({ kind, roleRef, subjects }) => `${kind}:${subjects?.[0]?.name}->${roleRef?.kind}:${roleRef?.name}`)
+      .sort(),
+  ).toEqual([
+    'ClusterRoleBinding:ceph-csi-cephfs-ctrlplugin-sa->ClusterRole:rook-ceph-cephfs-csi-ceph-com-ctrlplugin-cr',
+    'ClusterRoleBinding:ceph-csi-cephfs-nodeplugin-sa->ClusterRole:rook-ceph-cephfs-csi-ceph-com-nodeplugin-cr',
+    'ClusterRoleBinding:ceph-csi-rbd-ctrlplugin-sa->ClusterRole:rook-ceph-rbd-csi-ceph-com-ctrlplugin-cr',
+    'ClusterRoleBinding:ceph-csi-rbd-nodeplugin-sa->ClusterRole:rook-ceph-rbd-csi-ceph-com-nodeplugin-cr',
+    'RoleBinding:ceph-csi-cephfs-ctrlplugin-sa->Role:rook-ceph-cephfs-csi-ceph-com-ctrlplugin-r',
+    'RoleBinding:ceph-csi-cephfs-nodeplugin-sa->Role:rook-ceph-cephfs-csi-ceph-com-nodeplugin-r',
+    'RoleBinding:ceph-csi-rbd-ctrlplugin-sa->Role:rook-ceph-rbd-csi-ceph-com-ctrlplugin-r',
+    'RoleBinding:ceph-csi-rbd-nodeplugin-sa->Role:rook-ceph-rbd-csi-ceph-com-nodeplugin-r',
+  ])
 })

--- a/packages/scripts/src/shared/__tests__/rook-upgrade-contract.test.ts
+++ b/packages/scripts/src/shared/__tests__/rook-upgrade-contract.test.ts
@@ -1,0 +1,124 @@
+import { readFileSync } from 'node:fs'
+
+import { expect, test } from 'bun:test'
+import YAML from 'yaml'
+
+const repoRoot = new URL('../../../../../', import.meta.url)
+const readYaml = <T>(path: string): T => YAML.parse(readFileSync(new URL(path, repoRoot), 'utf8')) as T
+
+type HelmChart = {
+  name: string
+  version: string
+}
+
+type Kustomization = {
+  helmCharts: HelmChart[]
+  patches: Array<{
+    patch?: string
+    target: {
+      group: string
+      version: string
+      kind: string
+    }
+  }>
+}
+
+type Driver = {
+  name: string
+  enabled: boolean
+  snapshotPolicy: string
+  cephFsClientType: string
+  nodePlugin: {
+    imagePullPolicy: string
+    updateStrategy: { type: string }
+    topology: { domainLabels: string[] }
+    resources: { plugin: { limits: { memory: string } } }
+  }
+  controllerPlugin: {
+    hostNetwork: boolean
+    replicas: number
+    imagePullPolicy: string
+  }
+}
+
+test('orders the Rook v1.20 CSI ownership migration before the unchanged cluster chart', () => {
+  const kustomization = readYaml<Kustomization>('argocd/applications/rook-ceph/kustomization.yaml')
+
+  expect(kustomization.helmCharts).toMatchObject([
+    { name: 'rook-ceph', version: 'v1.20.3' },
+    { name: 'ceph-csi-drivers', version: '1.0.4' },
+    { name: 'rook-ceph-cluster', version: 'v1.19.8' },
+  ])
+
+  const csiOwnershipPatches = kustomization.patches.filter(
+    ({ target }) => target.group === 'csi.ceph.io' && target.version === 'v1',
+  )
+  expect(csiOwnershipPatches.map(({ target }) => target.kind).sort()).toEqual(['Driver', 'OperatorConfig'])
+  for (const { patch } of csiOwnershipPatches) {
+    expect(YAML.parse(patch ?? '')).toEqual([
+      {
+        op: 'add',
+        path: '/metadata/annotations',
+        value: { 'argocd.argoproj.io/sync-wave': '1' },
+      },
+    ])
+  }
+})
+
+test('preserves the Ceph data plane and live CSI behavior during the v1.20 migration', () => {
+  const operatorValues = readYaml<{
+    image: { repository: string; tag: string }
+    csi: Record<string, unknown>
+  }>('argocd/applications/rook-ceph/operator-values.yaml')
+  const clusterValues = readYaml<{
+    cephImage: { repository: string; tag: string }
+    cephClusterSpec: { csi: { cephfs: { kernelMountOptions: string } } }
+  }>('argocd/applications/rook-ceph/cluster-values.yaml')
+  const driverValues = readYaml<{
+    operatorConfig: {
+      driverSpecDefaults: {
+        clusterName: string
+        cephFsClientType: string
+        controllerPlugin: { hostNetwork: boolean; replicas: number }
+      }
+    }
+    drivers: {
+      rbd: Driver
+      cephfs: Driver
+      nfs: { enabled: boolean }
+      nvmeof: { enabled: boolean }
+    }
+  }>('argocd/applications/rook-ceph/csi-driver-values.yaml')
+
+  expect(operatorValues.image).toMatchObject({ repository: 'docker.io/rook/ceph', tag: 'v1.20.3' })
+  expect(operatorValues.csi).toEqual({ installCsiOperator: true })
+  expect(clusterValues.cephImage).toMatchObject({ repository: 'quay.io/ceph/ceph', tag: 'v19.2.4' })
+  expect(clusterValues.cephClusterSpec.csi.cephfs.kernelMountOptions).toBe('ms_mode=crc')
+  expect(driverValues.operatorConfig.driverSpecDefaults).toMatchObject({
+    clusterName: 'rook-ceph',
+    cephFsClientType: 'autodetect',
+    controllerPlugin: { hostNetwork: true, replicas: 2 },
+  })
+
+  for (const driver of [driverValues.drivers.rbd, driverValues.drivers.cephfs]) {
+    expect(driver.enabled).toBe(true)
+    expect(driver.cephFsClientType).toBe('autodetect')
+    expect(driver.nodePlugin.updateStrategy.type).toBe('OnDelete')
+    expect(driver.nodePlugin.imagePullPolicy).toBe('')
+    expect(driver.nodePlugin.topology.domainLabels).toEqual(['kubernetes.io/hostname'])
+    expect(driver.controllerPlugin).toMatchObject({ hostNetwork: true, replicas: 2, imagePullPolicy: '' })
+  }
+
+  expect(driverValues.drivers.rbd).toMatchObject({
+    name: 'rook-ceph.rbd.csi.ceph.com',
+    snapshotPolicy: 'volumeSnapshot',
+  })
+  expect(driverValues.drivers.rbd.nodePlugin.resources.plugin.limits.memory).toBe('1Gi')
+  expect(driverValues.drivers.cephfs).toMatchObject({
+    name: 'rook-ceph.cephfs.csi.ceph.com',
+    snapshotPolicy: 'volumeGroupSnapshot',
+  })
+  expect(driverValues.drivers.cephfs.nodePlugin.resources.plugin.limits.memory).toBe('4Gi')
+  expect(driverValues.drivers.nfs.enabled).toBe(false)
+  expect(driverValues.drivers.nvmeof.enabled).toBe(false)
+})

--- a/packages/scripts/src/shared/__tests__/rook-upgrade-contract.test.ts
+++ b/packages/scripts/src/shared/__tests__/rook-upgrade-contract.test.ts
@@ -104,6 +104,9 @@ test('preserves the Ceph data plane and live CSI behavior during the v1.20 migra
   const operatorValues = readYaml<{
     image: { repository: string; tag: string }
     csi: Record<string, unknown>
+    'ceph-csi-operator': {
+      controllerManager: { manager: { env: { csiServiceAccountPrefix: string } } }
+    }
   }>('argocd/applications/rook-ceph/operator-values.yaml')
   const clusterValues = readYaml<{
     cephImage: { repository: string; tag: string }
@@ -128,6 +131,7 @@ test('preserves the Ceph data plane and live CSI behavior during the v1.20 migra
 
   expect(operatorValues.image).toMatchObject({ repository: 'docker.io/rook/ceph', tag: 'v1.20.3' })
   expect(operatorValues.csi).toEqual({ installCsiOperator: true })
+  expect(operatorValues['ceph-csi-operator'].controllerManager.manager.env.csiServiceAccountPrefix).toBe('ceph-csi-')
   expect(clusterValues.cephImage).toMatchObject({ repository: 'quay.io/ceph/ceph', tag: 'v19.2.4' })
   expect(clusterValues.cephClusterSpec.csi.cephfs.kernelMountOptions).toBe('ms_mode=crc')
   expect(driverValues.operatorConfig.driverSpecDefaults).toMatchObject({


### PR DESCRIPTION
## Summary

- Upgrade the Rook operator from v1.19.8 to v1.20.3 and install the embedded ceph-csi-operator 1.0.4.
- Install ceph-csi-drivers 1.0.4 and transfer the existing Driver and OperatorConfig resources to GitOps in wave 2.
- Apply all normalized CSI identities/RBAC and the temporary legacy-identity bridge in wave -1, before the new operator can reconcile existing Drivers.
- Keep the wave-0 operator's fallback service-account prefix at `ceph-csi-`, so its pre-adoption reconciliation continues using the authorized live identities until wave 2 writes the normalized names.
- Preserve the live 150-second CSI timeout, driver names, topology, all node/controller resources including liveness reservations, and OnDelete node-plugin strategy.
- Hold rook-ceph-cluster at v1.19.8 and Ceph at v19.2.4 so the data-plane chart upgrade remains a separate wave.

## Related Issues

None

## Testing

- `bun test packages/scripts/src/shared/__tests__/enabled-apps.test.ts packages/scripts/src/shared/__tests__/enabled-apps-baseline.test.ts packages/scripts/src/shared/__tests__/rook-upgrade-contract.test.ts` (42 passed, 356 assertions)
- `bun run lint:argocd` (all rendered ApplicationSet groups valid)
- `kustomize build --enable-helm argocd/applications/rook-ceph` (134 resources; no Namespace)
- Render assertions: exactly 32 wave -1 identity/RBAC resources, both Drivers and OperatorConfig in wave 2, all four liveness resource blocks present, and `CSI_SERVICE_ACCOUNT_PREFIX=ceph-csi-` on the wave-0 operator
- `kubeconform -strict -ignore-missing-schemas` against the rendered output (134 resources; 99 valid, 35 intentionally skipped, 0 invalid/errors)
- Production-equivalent server-side dry-run of all 134 resources with `--force-conflicts --field-manager=argocd-controller` (134 passed)
- Force-conflicts dry-run preserves both Driver UIDs, the OperatorConfig UID, the ceph-csi-operator Deployment UID, and the CephCluster UID; the live and dry-run CephCluster spec hashes match exactly and remain on Ceph v19.2.4
- Live CRD preflight confirms Driver and OperatorConfig `storedVersions` contain only `v1`, so removal of served `v1alpha1` is accepted
- Live pre-merge check: Ceph `HEALTH_OK`, 3-mon quorum, 6/6 OSDs up/in, and all 601 placement groups clean or actively scrubbing

## Breaking Changes

None. CSI service-account names migrate to the upstream v1.0.4 convention. The temporary identity bridge remains through the explicit one-node-at-a-time OnDelete rollout and will be removed only after every CSI pod uses its new identity.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
