### PR TITLE
fix(rook): force normalized CSI identity cutover

### DIFF
--- a/argocd/applications/rook-ceph/kustomization.yaml
+++ b/argocd/applications/rook-ceph/kustomization.yaml
@@ -83,6 +83,23 @@ patches:
         path: /metadata/annotations
         value:
           argocd.argoproj.io/sync-wave: "-1"
+  # Advance the manager pod generation so Argo applies the explicit empty CSI
+  # identity prefix instead of treating the chart default as an equal empty value.
+  - target:
+      group: apps
+      version: v1
+      kind: Deployment
+      name: ceph-csi-controller-manager
+    patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: ceph-csi-controller-manager
+      spec:
+        template:
+          metadata:
+            annotations:
+              storage.proompteng.ai/csi-service-account-generation: normalized-v1
   # Transfer the existing Driver and OperatorConfig resources to GitOps only
   # after the pre-operator identity and RBAC wave is healthy.
   - target:

--- a/packages/scripts/src/shared/__tests__/rook-upgrade-contract.test.ts
+++ b/packages/scripts/src/shared/__tests__/rook-upgrade-contract.test.ts
@@ -95,6 +95,20 @@ test('keeps the Rook v1.20 operator, CSI, and cluster charts aligned', () => {
       },
     ])
   }
+
+  const managerCutoverPatch = kustomization.patches.find(
+    ({ target }) =>
+      target.group === 'apps' && target.kind === 'Deployment' && target.name === 'ceph-csi-controller-manager',
+  )
+  expect(YAML.parse(managerCutoverPatch?.patch ?? '')).toMatchObject({
+    spec: {
+      template: {
+        metadata: {
+          annotations: { 'storage.proompteng.ai/csi-service-account-generation': 'normalized-v1' },
+        },
+      },
+    },
+  })
 })
 
 test('preserves the Ceph data plane and live CSI behavior after the v1.20 migration', () => {


### PR DESCRIPTION
## Summary

- Force one CSI controller-manager pod-template generation after PR #13600 exposed that Argo normalized the chart's empty prefix and skipped the live field transition.
- Keep the chart-default empty `CSI_SERVICE_ACCOUNT_PREFIX` while adding a durable `normalized-v1` generation marker so GitOps replaces the old `ceph-csi-` live value.
- Extend the Rook upgrade contract test to require the cutover marker.

## Related Issues

Follow-up to #13600.

## Testing

- `bun test packages/scripts/src/shared/__tests__/enabled-apps-baseline.test.ts packages/scripts/src/shared/__tests__/enabled-apps.test.ts packages/scripts/src/shared/__tests__/rook-upgrade-contract.test.ts` — 42 passed, 344 expectations.
- `bun run lint:argocd` — all seven groups passed with 0 invalid resources and 0 errors.
- `bunx oxfmt --check packages/scripts/src/shared/__tests__/rook-upgrade-contract.test.ts argocd/applications/rook-ceph/kustomization.yaml` — passed.
- `git diff --check` — passed.
- Nix-shell render: 122 resources, 0 Namespace resources, one controller-manager generation marker, and an empty `CSI_SERVICE_ACCOUNT_PREFIX`.
- Server-side dry-run with Argo's field manager and force-conflicts: Deployment UID remains `71a4ab45-be10-4988-a5e5-9c0033b94a10`, generation advances 11 to 12, the marker is `normalized-v1`, and the prefix is empty.
- Live discovery after #13600: Argo reported Synced/Healthy at `cef13c2c0d72c12ec3598e41a821a4c1780bda94`, but the manager remained at generation 11 with `CSI_SERVICE_ACCOUNT_PREFIX=ceph-csi-`; the 12 temporary bridge resources were absent and Ceph remained HEALTH_OK.

## Breaking Changes

None. This deliberately rolls only the stateless Ceph-CSI controller-manager and preserves its Deployment UID.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
