### PR TITLE
fix(bilig): configure explicit demo authentication

### DIFF
--- a/argocd/applications/bilig/README.md
+++ b/argocd/applications/bilig/README.md
@@ -28,4 +28,5 @@ This app is registered as `auto` automation in the product ApplicationSet.
 ## Notes
 
 - Argo CD Image Updater writes new published `bilig-app` image tags back into this app, and Argo CD auto-sync applies them.
+- The public product shell runs in explicit `demo` authentication mode and signs anonymous sessions with the `bilig-app-auth` SealedSecret.
 - Redis has been removed from the product runtime path; collaboration correctness now depends only on the monolith, Zero, and Postgres.

--- a/argocd/applications/bilig/README.md
+++ b/argocd/applications/bilig/README.md
@@ -30,3 +30,10 @@ This app is registered as `auto` automation in the product ApplicationSet.
 - Argo CD Image Updater writes new published `bilig-app` image tags back into this app, and Argo CD auto-sync applies them.
 - The public product shell runs in explicit `demo` authentication mode and signs anonymous sessions with the `bilig-app-auth` SealedSecret.
 - Redis has been removed from the product runtime path; collaboration correctness now depends only on the monolith, Zero, and Postgres.
+
+## Authentication rollout
+
+- Cutover impact: client-supplied identity headers stop being trusted. On their next request, existing visitors receive a newly signed anonymous session, so their anonymous identity changes once at cutover. The shared demo workbook remains available.
+- Secret readiness: validate the manifest with `kubeseal --validate --controller-name sealed-secrets --controller-namespace sealed-secrets`, then after sync require `kubectl -n bilig wait --for=condition=Synced sealedsecret/bilig-app-auth --timeout=120s` and confirm `secret/bilig-app-auth` exists before accepting the rollout.
+- Pod safety: `BILIG_SESSION_SECRET` uses a required `secretKeyRef`; a replacement container cannot start until the Secret exists. The deployment's `maxUnavailable: 0`, `maxSurge: 1`, and readiness probe keep the previous replicas serving until each replacement is healthy.
+- Rollback: revert this auth configuration together with the image-promotion commit to the last known-good pre-cutover image, let Argo CD sync, and wait for `deployment/bilig-app` to complete. Removing the signing Secret invalidates cookies issued during the cutover, which is expected.

--- a/argocd/applications/bilig/app-auth-sealedsecret.yaml
+++ b/argocd/applications/bilig/app-auth-sealedsecret.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: bitnami.com/v1alpha1
+kind: SealedSecret
+metadata:
+  name: bilig-app-auth
+  namespace: bilig
+spec:
+  encryptedData:
+    session-secret: AgBFyR5BLFayQiTCvCs4fDAfT+QhKy9AUCWVT03mlUMHrjemFT7fc//XIkY1C2c90A5Hhj4MGDR+ZGSlCIWT/rYCldooQdKZ9XHTu+tPIw3pdHWVxR1iYPQdQuT8ee5rxbvX6uqQcANSBFm4lX+37LVmvz/SjYHgAYC2im9rrBy3HeWE1Alvv297zz55GaRmLgMl1spcthV3QdJOSQzCeEv0s72tM6+r6IlSgPjAxN2iY8paYYZyC9U4E8QqkXnrAQCcJ7cPaw7xJLFoH5z65vAWCxozlHMoRO3FZs+yw30Y7RxThn2jxgi0gQrogyaoR7Mpori+y9DgNrcZa+bnd5Ghtei/iq/KbYRNkvoeM0io9IpOSc7xjC2oT73dM023cU3KCUiM6C2afGnleScBZwcdDFsmt0SgCzcZAczmxaMqm8869TetcUCOxB2ooCGvqT4HUm3cvk8dsrQKGk3ztMy/EwHqFrpNk7UTWD5Pp/JRWHBAouT4OmC7Fz6Naxt7kfw6z12PzbLtDDoRXvtzMrC5o/uVl6cBkCHKmY+FMS0B1oCPHSp3tTqvbQKZj1mcQtXuYJSyk8Uyso78qTbcdgtGOHlK4aRWJZaACDtxybdgeiZWlWQsy7mAecxx3R6ujnxBA7ykI6elYsaFsn/Vj4JdHgekxwIRPp3lDvskgJdLuLQ8ON9aniM1OVwn6GTlLaFaSpiAW9JPeB//PCAMcK/ivtIn7WR0TOG995swe1c+Pj0T+am7nuHyrjM2Qh42POAkvwdrH5lofcJaZwBfOztp
+  template:
+    metadata:
+      name: bilig-app-auth
+      namespace: bilig

--- a/argocd/applications/bilig/app-deployment.yaml
+++ b/argocd/applications/bilig/app-deployment.yaml
@@ -50,6 +50,15 @@ spec:
           env:
             - name: NODE_ENV
               value: "production"
+            - name: BILIG_AUTH_MODE
+              value: demo
+            - name: BILIG_SESSION_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: bilig-app-auth
+                  key: session-secret
+            - name: BILIG_REMOTE_MCP_ALLOW_LOCAL_ORIGINS
+              value: "false"
             - name: PORT
               value: "4321"
             - name: BILIG_PUBLIC_SERVER_URL

--- a/argocd/applications/bilig/kustomization.yaml
+++ b/argocd/applications/bilig/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - bilig-cert-tls.yaml
+  - app-auth-sealedsecret.yaml
   - zero-admin-sealedsecret.yaml
   - zero-strip-prefix-middleware.yaml
   - zero-client-mutation-id-repair-job.yaml


### PR DESCRIPTION
## Summary

- configure the public Bilig deployment with explicit demo authentication
- source the anonymous-session signing key from a namespace-scoped SealedSecret
- disable local-origin MCP CORS allowances in production and document the boundary

## Related Issues

None

## Testing

- `kubeseal --validate --controller-name sealed-secrets --controller-namespace sealed-secrets < argocd/applications/bilig/app-auth-sealedsecret.yaml`
- `kubectl kustomize argocd/applications/bilig > /dev/null`
- `bun run lint:argocd`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.