### PR TITLE
fix(bayn): advance durable intent transition time

### DIFF
--- a/services/bayn/src/db/evidence-store.integration.test.ts
+++ b/services/bayn/src/db/evidence-store.integration.test.ts
@@ -1793,6 +1793,50 @@ describePostgres('PostgreSQL evaluation evidence', () => {
     }
   })
 
+  test('rejects a risk decision that predates its intent even when the decision remains current', async () => {
+    await activateAuditedCapitalGrant()
+    const execution = makeExecutionRuntime()
+    const createdAt = new Date(Date.now() - 1_000).toISOString()
+    const intent = await Effect.runPromise(
+      plan(
+        intentPlan({
+          cycleId: fixtureHash('predated-risk-decision-cycle'),
+          createdAt,
+        }),
+      ),
+    )
+    const decision = await Effect.runPromise(
+      riskDecision(intent, RiskOutcome.Approved, {
+        decidedAt: new Date(Date.parse(createdAt) - 1).toISOString(),
+        expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      }),
+    )
+
+    try {
+      const commit = await execution.runPromiseExit(
+        Effect.flatMap(IntentStore, (store) => store.commit(intent, decision)),
+      )
+      const [counts] = await runtime.runPromise(
+        Effect.gen(function* () {
+          const sql = yield* PgClient.PgClient
+          return yield* sql<{ decisions: number; intents: number }>`
+            SELECT
+              (SELECT count(*)::integer FROM intents) AS intents,
+              (SELECT count(*)::integer FROM risk_decisions) AS decisions
+          `
+        }),
+      )
+
+      expect(Exit.isFailure(commit)).toBe(true)
+      if (Exit.isFailure(commit)) {
+        expect(Cause.pretty(commit.cause)).toContain('intent state version and time must advance')
+      }
+      expect(counts).toEqual({ decisions: 0, intents: 0 })
+    } finally {
+      await execution.dispose()
+    }
+  })
+
   test('commits a residual close generation beside its predecessor with a distinct identity binding', async () => {
     await activateAuditedCapitalGrant()
     const execution = makeExecutionRuntime()

--- a/services/bayn/src/db/evidence-store.integration.test.ts
+++ b/services/bayn/src/db/evidence-store.integration.test.ts
@@ -1746,6 +1746,53 @@ describePostgres('PostgreSQL evaluation evidence', () => {
     })
   })
 
+  test('commits an approved intent when planning and risk evaluation share one timestamp', async () => {
+    await activateAuditedCapitalGrant()
+    const execution = makeExecutionRuntime()
+    const decidedAt = new Date(Date.now() - 1_000).toISOString()
+    const intent = await Effect.runPromise(
+      plan(
+        intentPlan({
+          cycleId: fixtureHash('equal-planning-risk-clock-cycle'),
+          createdAt: decidedAt,
+        }),
+      ),
+    )
+    const decision = await Effect.runPromise(
+      riskDecision(intent, RiskOutcome.Approved, {
+        decidedAt,
+        expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      }),
+    )
+
+    try {
+      const receipt = await execution.runPromise(Effect.flatMap(IntentStore, (store) => store.commit(intent, decision)))
+      const [stored] = await runtime.runPromise(
+        Effect.gen(function* () {
+          const sql = yield* PgClient.PgClient
+          return yield* sql<{ created_at: Date; updated_at: Date }>`
+            SELECT created_at, updated_at
+            FROM intents
+            WHERE intent_id = ${intent.intentId}
+          `
+        }),
+      )
+
+      expect(receipt).toMatchObject({
+        deduplicated: false,
+        record: {
+          decision: { decidedAt },
+          intent: { createdAt: decidedAt, state: IntentState.Approved },
+          stateVersion: 2,
+        },
+      })
+      assert(stored !== undefined, 'committed intent must be readable')
+      expect(stored.updated_at.getTime()).toBeGreaterThan(stored.created_at.getTime())
+    } finally {
+      await execution.dispose()
+    }
+  })
+
   test('commits a residual close generation beside its predecessor with a distinct identity binding', async () => {
     await activateAuditedCapitalGrant()
     const execution = makeExecutionRuntime()

--- a/services/bayn/src/execution/intents/postgres.ts
+++ b/services/bayn/src/execution/intents/postgres.ts
@@ -370,7 +370,10 @@ const transitionIntent = (sql: PgClient.PgClient, intent: Intent, decision: Risk
       state = ${approved ? IntentState.Approved : IntentState.Terminal},
       terminal_outcome = ${approved ? null : TerminalOutcome.Blocked},
       state_version = state_version + 1,
-      updated_at = ${decision.decidedAt}
+      updated_at = greatest(
+        ${decision.decidedAt}::timestamptz,
+        created_at + interval '1 millisecond'
+      )
     WHERE intent_id = ${intent.intentId} AND state = ${IntentState.Planned}
     RETURNING intent_id
   `.pipe(Effect.mapError((cause) => classifyIntentCause('commit', cause)))

--- a/services/bayn/src/execution/intents/postgres.ts
+++ b/services/bayn/src/execution/intents/postgres.ts
@@ -370,10 +370,11 @@ const transitionIntent = (sql: PgClient.PgClient, intent: Intent, decision: Risk
       state = ${approved ? IntentState.Approved : IntentState.Terminal},
       terminal_outcome = ${approved ? null : TerminalOutcome.Blocked},
       state_version = state_version + 1,
-      updated_at = greatest(
-        ${decision.decidedAt}::timestamptz,
-        created_at + interval '1 millisecond'
-      )
+      updated_at = CASE
+        WHEN ${decision.decidedAt}::timestamptz = created_at
+          THEN created_at + interval '1 millisecond'
+        ELSE ${decision.decidedAt}::timestamptz
+      END
     WHERE intent_id = ${intent.intentId} AND state = ${IntentState.Planned}
     RETURNING intent_id
   `.pipe(Effect.mapError((cause) => classifyIntentCause('commit', cause)))


### PR DESCRIPTION
## Summary

- advance the durable intent transition timestamp when planning and risk evaluation share the same instant
- retain the original risk-decision evidence and the strict PostgreSQL state/version/time trigger
- cover the Friday failure through the real writer-fenced PostgreSQL commit path

## Related Issues

None

## Testing

- `bun test services/bayn/src/execution/intents.test.ts services/bayn/src/execution/writer-fence.test.ts` (19 pass, 0 fail)
- `BAYN_TEST_POSTGRES_URL=<local-test-postgres> bun run --filter @proompteng/bayn test:postgres` (145 pass, 0 fail)
- `bun run --filter @proompteng/bayn test` (1,154 pass, 160 skip, 0 fail)
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn build`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable and Breaking Changes is filled in.
- [x] Documentation and release notes are not required for this internal persistence correction; the regression test records the durable contract.
