### PR TITLE
refactor(bayn): remove duplicate paper episode lifecycle

### DIFF
--- a/services/bayn/src/paper-episode.test.ts
+++ b/services/bayn/src/paper-episode.test.ts
@@ -2,38 +2,13 @@ import { describe, expect, test } from 'bun:test'
 import { Result } from 'effect'
 
 import {
-  decidePaperEpisode,
   decidePaperEpisodeAuthority,
   decidePaperEpisodeCycleTerminalization,
-  failedPaperEpisode,
   paperEpisodeAllocationCapitalMicros,
   paperGrantFromGeneration,
   paperGrantKey,
   validatePaperEpisodeCloseWindow,
-  type PaperEpisodeFacts,
-  type PaperEpisodeFailure,
-  type PaperEpisodeState,
 } from './paper-episode'
-
-const safeFacts = (overrides: Partial<PaperEpisodeFacts> = {}): PaperEpisodeFacts => ({
-  observedAt: '2026-08-04T14:00:00.000Z',
-  entryCutoffAt: '2026-09-01T13:00:00.000Z',
-  maximumCloseSessions: 3,
-  finalizedSnapshotAvailable: true,
-  nonzeroTargetAvailable: true,
-  entryFilled: false,
-  hasOpenPosition: false,
-  closeSessionAdvanced: false,
-  safety: {
-    brokerRejected: false,
-    dataFresh: true,
-    identityMatches: true,
-    reconciliationExact: true,
-    restartUnambiguous: true,
-    unresolvedMutationCount: 0,
-  },
-  ...overrides,
-})
 
 describe('paperEpisodeAllocationCapitalMicros', () => {
   test('selects the smallest account, exposure, and remaining-turnover bound', () => {
@@ -95,13 +70,7 @@ describe('paperEpisodeAllocationCapitalMicros', () => {
   })
 })
 
-const success = (state: PaperEpisodeState, facts: PaperEpisodeFacts) => {
-  const result = decidePaperEpisode(state, facts)
-  expect(Result.isSuccess(result)).toBe(true)
-  return Result.getOrThrow(result)
-}
-
-describe('decidePaperEpisode', () => {
+describe('paper episode decisions', () => {
   test('adapts legacy qualification history and research history to one grant boundary', () => {
     const qualified = paperGrantFromGeneration({
       schemaVersion: 'bayn.paper-authority-generation.v2',
@@ -124,86 +93,6 @@ describe('decidePaperEpisode', () => {
     })
     expect(paperGrantKey(qualified)).toBe('a'.repeat(64))
     expect(paperGrantKey(research)).toBe('d'.repeat(64))
-  })
-
-  test('starts only when a finalized snapshot has a nonzero target', () => {
-    expect(success({ _tag: 'Pending' }, safeFacts())).toEqual({ _tag: 'StartEntry', state: { _tag: 'Pending' } })
-    expect(success({ _tag: 'Pending' }, safeFacts({ nonzeroTargetAvailable: false }))).toEqual({
-      _tag: 'WaitForEntry',
-      state: { _tag: 'Pending' },
-    })
-  })
-
-  test('adopts one durable entry cycle and replays it idempotently after restart', () => {
-    const entering = success({ _tag: 'Pending' }, safeFacts({ cycleId: 'entry-cycle' }))
-    expect(entering).toEqual({ _tag: 'Enter', state: { _tag: 'Entering', cycleId: 'entry-cycle' } })
-    expect(success(entering.state, safeFacts({ cycleId: 'entry-cycle' }))).toEqual({
-      _tag: 'ContinueEntry',
-      state: { _tag: 'Entering', cycleId: 'entry-cycle' },
-    })
-  })
-
-  test('holds a broker-confirmed entry until the monthly cutoff', () => {
-    const holding = success(
-      { _tag: 'Entering', cycleId: 'entry-cycle' },
-      safeFacts({ cycleId: 'entry-cycle', entryFilled: true, hasOpenPosition: true }),
-    )
-    expect(holding).toEqual({ _tag: 'Hold', state: { _tag: 'Holding', entryCycleId: 'entry-cycle' } })
-    expect(success(holding.state, safeFacts({ cycleId: 'entry-cycle', hasOpenPosition: true }))).toEqual(holding)
-  })
-
-  test('enters close-only mode at the cutoff and consumes at most three advanced sessions', () => {
-    const closing = success(
-      { _tag: 'Holding', entryCycleId: 'entry-cycle' },
-      safeFacts({
-        cycleId: 'entry-cycle',
-        observedAt: '2026-09-01T13:00:00.000Z',
-        hasOpenPosition: true,
-      }),
-    )
-    expect(closing).toEqual({ _tag: 'Close', state: { _tag: 'Closing', remainingSessions: 3 } })
-    expect(
-      success(closing.state, safeFacts({ cycleId: 'entry-cycle', hasOpenPosition: true, closeSessionAdvanced: true })),
-    ).toEqual({ _tag: 'Close', state: { _tag: 'Closing', remainingSessions: 2 } })
-  })
-
-  test('finalizes only when flat and completes only with the bound receipt', () => {
-    const state = { _tag: 'Closing', remainingSessions: 2 } as const
-    expect(success(state, safeFacts())).toEqual({ _tag: 'Finalize', state })
-    expect(success(state, safeFacts({ receiptHash: 'a'.repeat(64) }))).toEqual({
-      _tag: 'Complete',
-      state: { _tag: 'Completed', receiptHash: 'a'.repeat(64) },
-    })
-    expect(
-      success({ _tag: 'Completed', receiptHash: 'a'.repeat(64) }, safeFacts({ receiptHash: 'a'.repeat(64) })),
-    ).toEqual({ _tag: 'Complete', state: { _tag: 'Completed', receiptHash: 'a'.repeat(64) } })
-  })
-
-  test('fails closed on every unsafe broker and recovery fact', () => {
-    const failures: ReadonlyArray<[Partial<PaperEpisodeFacts['safety']>, PaperEpisodeFailure['_tag']]> = [
-      [{ identityMatches: false }, 'IdentityDrift'],
-      [{ restartUnambiguous: false }, 'RestartAmbiguous'],
-      [{ unresolvedMutationCount: 1 }, 'UnknownMutation'],
-      [{ reconciliationExact: false }, 'ReconciliationDiscrepancy'],
-      [{ dataFresh: false }, 'StaleData'],
-      [{ brokerRejected: true }, 'BrokerRejected'],
-    ]
-    for (const [safety, tag] of failures) {
-      const result = decidePaperEpisode(
-        { _tag: 'Pending' },
-        safeFacts({ safety: { ...safeFacts().safety, ...safety } }),
-      )
-      expect(Result.isFailure(result)).toBe(true)
-      if (Result.isFailure(result)) expect(result.failure._tag).toBe(tag)
-    }
-  })
-
-  test('fails rather than opening a fourth close session', () => {
-    const result = decidePaperEpisode(
-      { _tag: 'Closing', remainingSessions: 1 },
-      safeFacts({ cycleId: 'entry-cycle', hasOpenPosition: true, closeSessionAdvanced: true }),
-    )
-    expect(result).toEqual(Result.fail({ _tag: 'CloseWindowExhausted', cycleId: 'entry-cycle' }))
   })
 
   test('keeps the entry cycle active through holding and terminalizes only after close evidence', () => {
@@ -240,11 +129,6 @@ describe('decidePaperEpisode', () => {
         entryHasUnsuccessfulIntent: true,
       }),
     ).toEqual({ _tag: 'Block' })
-  })
-
-  test('keeps a terminal failure stable across restart', () => {
-    const state = failedPaperEpisode({ _tag: 'BrokerRejected' })
-    expect(success(state, safeFacts())).toEqual({ _tag: 'RemainFailed', state })
   })
 
   test('activates, rearms, and resumes only from their exact durable authority states', () => {

--- a/services/bayn/src/paper-episode.ts
+++ b/services/bayn/src/paper-episode.ts
@@ -135,47 +135,8 @@ export const paperGrantFromGeneration = (generation: PersistedPaperGrantBinding)
       }
 
 export type PaperEpisodeFailure =
-  | { readonly _tag: 'BrokerRejected' }
-  | { readonly _tag: 'CloseWindowExhausted'; readonly cycleId: string }
   | { readonly _tag: 'IdentityDrift' }
   | { readonly _tag: 'InvalidCloseWindow'; readonly reason: string }
-  | { readonly _tag: 'InvalidTransition'; readonly state: PaperEpisodeState['_tag']; readonly reason: string }
-  | { readonly _tag: 'MissedEntryCutoff' }
-  | { readonly _tag: 'ReconciliationDiscrepancy' }
-  | { readonly _tag: 'RestartAmbiguous' }
-  | { readonly _tag: 'StaleData' }
-  | { readonly _tag: 'UnknownMutation'; readonly count: number }
-
-export type PaperEpisodeState =
-  | { readonly _tag: 'Pending' }
-  | { readonly _tag: 'Entering'; readonly cycleId: string }
-  | { readonly _tag: 'Holding'; readonly entryCycleId: string }
-  | { readonly _tag: 'Closing'; readonly remainingSessions: number }
-  | { readonly _tag: 'Completed'; readonly receiptHash: string }
-  | { readonly _tag: 'Failed'; readonly reason: PaperEpisodeFailure }
-
-export interface PaperEpisodeSafetyFacts {
-  readonly brokerRejected: boolean
-  readonly dataFresh: boolean
-  readonly identityMatches: boolean
-  readonly reconciliationExact: boolean
-  readonly restartUnambiguous: boolean
-  readonly unresolvedMutationCount: number
-}
-
-export interface PaperEpisodeFacts {
-  readonly observedAt: string
-  readonly entryCutoffAt: string
-  readonly maximumCloseSessions: number
-  readonly cycleId?: string
-  readonly finalizedSnapshotAvailable: boolean
-  readonly nonzeroTargetAvailable: boolean
-  readonly entryFilled: boolean
-  readonly hasOpenPosition: boolean
-  readonly closeSessionAdvanced: boolean
-  readonly receiptHash?: string
-  readonly safety: PaperEpisodeSafetyFacts
-}
 
 export interface PaperEpisodeMarketSession {
   readonly date: string
@@ -281,17 +242,6 @@ export const validatePaperEpisodeCloseWindow = (input: {
   return Result.succeed(closeSessions)
 }
 
-export type PaperEpisodeDecision =
-  | { readonly _tag: 'WaitForEntry'; readonly state: Extract<PaperEpisodeState, { readonly _tag: 'Pending' }> }
-  | { readonly _tag: 'StartEntry'; readonly state: Extract<PaperEpisodeState, { readonly _tag: 'Pending' }> }
-  | { readonly _tag: 'Enter'; readonly state: Extract<PaperEpisodeState, { readonly _tag: 'Entering' }> }
-  | { readonly _tag: 'ContinueEntry'; readonly state: Extract<PaperEpisodeState, { readonly _tag: 'Entering' }> }
-  | { readonly _tag: 'Hold'; readonly state: Extract<PaperEpisodeState, { readonly _tag: 'Holding' }> }
-  | { readonly _tag: 'Close'; readonly state: Extract<PaperEpisodeState, { readonly _tag: 'Closing' }> }
-  | { readonly _tag: 'Finalize'; readonly state: Extract<PaperEpisodeState, { readonly _tag: 'Closing' }> }
-  | { readonly _tag: 'Complete'; readonly state: Extract<PaperEpisodeState, { readonly _tag: 'Completed' }> }
-  | { readonly _tag: 'RemainFailed'; readonly state: Extract<PaperEpisodeState, { readonly _tag: 'Failed' }> }
-
 export type PaperEpisodeCycleTerminalizationDecision =
   | { readonly _tag: 'WaitForClose' }
   | { readonly _tag: 'Block' }
@@ -311,104 +261,3 @@ export const decidePaperEpisodeCycleTerminalization = (input: {
   }
   return { _tag: 'Complete' }
 }
-
-const invalid = (state: PaperEpisodeState, reason: string): Result.Result<never, PaperEpisodeFailure> =>
-  Result.fail({ _tag: 'InvalidTransition', state: state._tag, reason })
-
-const safetyFailure = (facts: PaperEpisodeSafetyFacts): PaperEpisodeFailure | undefined => {
-  if (!facts.identityMatches) return { _tag: 'IdentityDrift' }
-  if (!facts.restartUnambiguous) return { _tag: 'RestartAmbiguous' }
-  if (facts.unresolvedMutationCount !== 0) {
-    return { _tag: 'UnknownMutation', count: facts.unresolvedMutationCount }
-  }
-  if (!facts.reconciliationExact) return { _tag: 'ReconciliationDiscrepancy' }
-  if (!facts.dataFresh) return { _tag: 'StaleData' }
-  if (facts.brokerRejected) return { _tag: 'BrokerRejected' }
-  return undefined
-}
-
-const closeDecision = (
-  state: Extract<PaperEpisodeState, { readonly _tag: 'Closing' }>,
-  facts: PaperEpisodeFacts,
-): Result.Result<PaperEpisodeDecision, PaperEpisodeFailure> => {
-  if (facts.receiptHash !== undefined) {
-    return facts.hasOpenPosition
-      ? invalid(state, 'a completed receipt cannot coexist with an open position')
-      : Result.succeed({ _tag: 'Complete', state: { _tag: 'Completed', receiptHash: facts.receiptHash } })
-  }
-  if (!facts.hasOpenPosition) return Result.succeed({ _tag: 'Finalize', state })
-  const remainingSessions = state.remainingSessions - (facts.closeSessionAdvanced ? 1 : 0)
-  return remainingSessions <= 0
-    ? Result.fail({ _tag: 'CloseWindowExhausted', cycleId: facts.cycleId ?? 'unknown' })
-    : Result.succeed({ _tag: 'Close', state: { _tag: 'Closing', remainingSessions } })
-}
-
-/**
- * Total, I/O-free decision for one bounded sandbox PAPER episode. The caller derives facts from durable generation,
- * cycle, intent, broker, reconciliation, and receipt records, then interprets the returned action through existing
- * ports. No state is hidden in this module.
- */
-export const decidePaperEpisode = (
-  state: PaperEpisodeState,
-  facts: PaperEpisodeFacts,
-): Result.Result<PaperEpisodeDecision, PaperEpisodeFailure> => {
-  if (!Number.isSafeInteger(facts.maximumCloseSessions) || facts.maximumCloseSessions < 1) {
-    return invalid(state, 'maximumCloseSessions must be a positive safe integer')
-  }
-  const safety = safetyFailure(facts.safety)
-  if (safety !== undefined) return Result.fail(safety)
-
-  switch (state._tag) {
-    case 'Pending':
-      if (facts.receiptHash !== undefined) return invalid(state, 'a pending episode cannot already have a receipt')
-      if (facts.cycleId !== undefined) {
-        return Result.succeed({ _tag: 'Enter', state: { _tag: 'Entering', cycleId: facts.cycleId } })
-      }
-      if (facts.observedAt >= facts.entryCutoffAt) return Result.fail({ _tag: 'MissedEntryCutoff' })
-      return facts.finalizedSnapshotAvailable && facts.nonzeroTargetAvailable
-        ? Result.succeed({ _tag: 'StartEntry', state })
-        : Result.succeed({ _tag: 'WaitForEntry', state })
-
-    case 'Entering':
-      if (facts.cycleId !== undefined && facts.cycleId !== state.cycleId) {
-        return invalid(state, 'the durable entry cycle identity changed')
-      }
-      if (facts.entryFilled || facts.hasOpenPosition) {
-        return Result.succeed({ _tag: 'Hold', state: { _tag: 'Holding', entryCycleId: state.cycleId } })
-      }
-      return facts.observedAt >= facts.entryCutoffAt
-        ? Result.fail({ _tag: 'MissedEntryCutoff' })
-        : Result.succeed({ _tag: 'ContinueEntry', state })
-
-    case 'Holding':
-      if (facts.cycleId !== undefined && facts.cycleId !== state.entryCycleId) {
-        return invalid(state, 'the durable holding cycle identity changed')
-      }
-      if (!facts.hasOpenPosition) {
-        return facts.receiptHash === undefined
-          ? invalid(state, 'a held position disappeared before a terminal receipt')
-          : Result.succeed({ _tag: 'Complete', state: { _tag: 'Completed', receiptHash: facts.receiptHash } })
-      }
-      return facts.observedAt < facts.entryCutoffAt
-        ? Result.succeed({ _tag: 'Hold', state })
-        : Result.succeed({
-            _tag: 'Close',
-            state: { _tag: 'Closing', remainingSessions: facts.maximumCloseSessions },
-          })
-
-    case 'Closing':
-      return closeDecision(state, facts)
-
-    case 'Completed':
-      return facts.receiptHash === state.receiptHash && !facts.hasOpenPosition
-        ? Result.succeed({ _tag: 'Complete', state })
-        : invalid(state, 'completed episode evidence changed')
-
-    case 'Failed':
-      return Result.succeed({ _tag: 'RemainFailed', state })
-  }
-}
-
-export const failedPaperEpisode = (
-  reason: PaperEpisodeFailure,
-): Extract<PaperEpisodeState, { readonly _tag: 'Failed' }> => ({ _tag: 'Failed', reason })


### PR DESCRIPTION
## Summary

- remove the unused in-memory `PaperEpisodeState` reducer that never controlled production execution
- retain the pure grant, allocation, authority, close-window, and durable-cycle terminalization decisions used by Bayn
- remove tests for the parallel lifecycle while preserving behavioral coverage of the canonical durable lifecycle

## Related Issues

None

## Testing

- `bun test services/bayn/src/paper-episode.test.ts services/bayn/src/composition.test.ts services/bayn/src/observe-composition.test.ts` (69 passed)
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint:effect`
- `git diff --check`

## Breaking Changes

None. The removed symbols had no production consumers.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.