### PR TITLE
build(bayn): make Effect TSGo the typecheck

### DIFF
--- a/.github/workflows/bayn-ci.yml
+++ b/.github/workflows/bayn-ci.yml
@@ -111,7 +111,7 @@ jobs:
       lint-command: bunx oxfmt --check services/bayn argocd/applications/bayn argocd/applications/torghut/clickhouse/bayn-sealed-secret.yaml argocd/applications/torghut/clickhouse/clickhouse-cluster.yaml
       oxlint-command: bun run --cwd services/bayn lint:oxlint
       oxlint-type-command: bun run --cwd services/bayn lint:oxlint:type
-      test-command: bun run --cwd services/bayn tsc && bun run --cwd services/bayn lint:effect && bun run --cwd services/bayn test && bun test packages/scripts/src/bayn
+      test-command: bun run --cwd services/bayn tsc && bun run --cwd services/bayn test && bun test packages/scripts/src/bayn
       build-command: bun run --cwd services/bayn build
     secrets: inherit
 

--- a/nix/images/bayn.nix
+++ b/nix/images/bayn.nix
@@ -21,8 +21,8 @@ let
   buildDefine = name: value: "--define ${name}=${lib.escapeShellArg (builtins.toJSON value)}";
   dependencySource = import ./bun-workspace-deps-source.nix { inherit lib repoRoot; };
   depsHash = {
-    x86_64-linux = "sha256-ScfYBRqXqLq2oXmpPqAYcB+uJOQsFN5gQ9cdf4Gtlzo=";
-    aarch64-linux = "sha256-QaszirC/VC17YOcUYIaQnXaxdpCz7rijSZTnL9YtY8M=";
+    x86_64-linux = "sha256-jaeixE6zSL/K3OhIM9lo4FljP+ANiCI1LFkfTkSTr3E=";
+    aarch64-linux = "sha256-pnehq1SsO8bj40GoJJ5sDIgYTXwDTL4Qtnu9aIbnLdE=";
   };
   buildCommands = [
     "bun --cwd=services/bayn run tsc"

--- a/packages/scripts/src/bayn/bayn-release-workflow.test.ts
+++ b/packages/scripts/src/bayn/bayn-release-workflow.test.ts
@@ -35,7 +35,7 @@ test('keeps the existing Bayn PR gate aggregation', () => {
     expect(baynCiWorkflow).toContain(check)
   }
   expect(baynCiWorkflow).toContain(
-    'test-command: bun run --cwd services/bayn tsc && bun run --cwd services/bayn lint:effect && bun run --cwd services/bayn test && bun test packages/scripts/src/bayn',
+    'test-command: bun run --cwd services/bayn tsc && bun run --cwd services/bayn test && bun test packages/scripts/src/bayn',
   )
   expect(baynCiWorkflow).not.toContain('verify-release-review')
 })

--- a/services/bayn/README.md
+++ b/services/bayn/README.md
@@ -161,6 +161,9 @@ credentials and writes no dossier. Later PREPARE/SUBMIT/CANCEL/RECOVER work rema
 
 ## Validation
 
+`tsc` invokes the pinned Effect TSGo compiler directly, so TypeScript and configured Effect diagnostics run once and
+share one failing exit boundary.
+
 ```sh
 bun run --filter @proompteng/bayn test
 bun run --filter @proompteng/bayn tsc

--- a/services/bayn/package.json
+++ b/services/bayn/package.json
@@ -9,14 +9,13 @@
     "forward:performance": "BAYN_PROVENANCE_MODE=development node dist/forward-performance-command.js",
     "start": "BAYN_PROVENANCE_MODE=development node dist/index.js",
     "lint": "bun ../../node_modules/oxfmt/bin/oxfmt --check src",
-    "lint:effect": "find ../../node_modules/.bun -path '*/@effect/tsgo-*/lib/tsc*' -type f ! -name '*.json' -exec chmod +x {} + 2>/dev/null || true; bun node_modules/@effect/tsgo/dist/effect-tsgo.js diagnostics --project tsconfig.json --format text --severity error",
     "lint:oxlint": "bun ../../node_modules/oxlint/bin/oxlint --config ../../.oxlintrc.json .",
     "lint:oxlint:type": "bun ../../node_modules/oxlint/bin/oxlint --config ../../.oxlintrc.json --type-aware --tsconfig ./tsconfig.json .",
     "test": "bun test",
     "test:broker-sandbox": "bun test src/broker-sandbox-contract.test.ts",
     "test:effect-runtime": "bun test src/clickhouse-patch.test.ts src/effect-runtime-compatibility.test.ts",
     "test:postgres": "bun test src/db/cycle-observability.integration.test.ts && bun test src/db/evidence-store.integration.test.ts && bun test src/db/paper-store.integration.test.ts && bun test src/db/cycle-store/integration.test.ts",
-    "tsc": "bun node_modules/typescript/bin/tsc --noEmit"
+    "tsc": "find ../../node_modules/.bun -path '*/@effect/tsgo-*/lib/tsc*' -type f ! -name '*.json' -exec chmod +x {} + 2>/dev/null || true; \"$(bun node_modules/@effect/tsgo/dist/effect-tsgo.js get-exe-path)\" --noEmit --project tsconfig.json"
   },
   "dependencies": {
     "@clickhouse/client": "1.23.1",

--- a/services/bayn/src/composition.test.ts
+++ b/services/bayn/src/composition.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, test } from 'bun:test'
 
-import { Deferred, Effect, Fiber, Ref, Result } from 'effect'
+import { Context, Deferred, Effect, Fiber, FileSystem, Layer, Ref, Result } from 'effect'
 import { TestClock } from 'effect/testing'
 
 import {
+  ApplicationPlatformLive,
   closedCycleReceiptEmissionAllowed,
   finalizePaperEpisode,
   paperReceiptFinalizationWindowOpen,
@@ -54,6 +55,14 @@ const researchRequest = Result.getOrThrow(
     ...researchPlanFields,
   }),
 )
+
+describe('Bayn application platform', () => {
+  test('provides filesystem access for TLS-backed PostgreSQL acquisition', async () => {
+    const context = await Effect.runPromise(Effect.scoped(Layer.build(ApplicationPlatformLive)))
+
+    expect(Context.get(context, FileSystem.FileSystem)).toBeDefined()
+  })
+})
 
 describe('Bayn PAPER receipt retry boundary', () => {
   test('does not bind a generation receipt before its PAPER entry cutoff', () => {

--- a/services/bayn/src/composition.ts
+++ b/services/bayn/src/composition.ts
@@ -167,6 +167,9 @@ export const BrokerSessionResourceLive = (config: Extract<LoadedRuntimeConfig, {
 
 export const ApplicationPlatformLive = Layer.merge(NodeServices.layer, NodeHttpClient.layerNodeHttp)
 
+const HttpApplicationPlatformLive = (config: LoadedRuntimeConfig) =>
+  Layer.merge(HttpServerLive(config), NodeHttpClient.layerNodeHttp)
+
 const SignalMarketDataLive = (plan: ApplicationIdentity) => {
   const clickHouse = sqlResource(ClickHouseClientResourceLive(plan.config))
   return MarketDataResourceLive(plan).pipe(Layer.provide(clickHouse))
@@ -178,24 +181,22 @@ const PostgresAuthorityLive = (config: LoadedRuntimeConfig) =>
 export const BrokerlessApplicationResourcesLive = (plan: ApplicationPlanFor<'BrokerlessService'>) => {
   const postgres = PostgresAuthorityLive(plan.config)
   return Layer.mergeAll(
-    HttpServerLive(plan.config),
     SignalMarketDataLive(plan),
     postgres,
     JournalResourceLive(plan.config),
     CycleObservabilityResourceLive.pipe(Layer.provide(postgres)),
-  ).pipe(Layer.provideMerge(ApplicationPlatformLive))
+  ).pipe(Layer.provideMerge(HttpApplicationPlatformLive(plan.config)))
 }
 
 export const AutonomousApplicationResourcesLive = (plan: ApplicationPlanFor<'AutonomousService'>) => {
   const postgres = PostgresAuthorityLive(plan.config)
   const journal = JournalResourceLive(plan.config)
   return Layer.mergeAll(
-    HttpServerLive(plan.config),
     SignalMarketDataLive(plan),
     postgres,
     journal,
     CycleObservabilityResourceLive.pipe(Layer.provide(postgres)),
-  ).pipe(Layer.provideMerge(ApplicationPlatformLive))
+  ).pipe(Layer.provideMerge(HttpApplicationPlatformLive(plan.config)))
 }
 
 export const AutonomousRuntimeResourcesLive = (plan: ApplicationPlanFor<'AutonomousService'>) => {

--- a/services/bayn/src/composition.ts
+++ b/services/bayn/src/composition.ts
@@ -168,7 +168,7 @@ export const BrokerSessionResourceLive = (config: Extract<LoadedRuntimeConfig, {
 export const ApplicationPlatformLive = Layer.merge(NodeServices.layer, NodeHttpClient.layerNodeHttp)
 
 const HttpApplicationPlatformLive = (config: LoadedRuntimeConfig) =>
-  Layer.merge(HttpServerLive(config), NodeHttpClient.layerNodeHttp)
+  Layer.merge(HttpServerLive(config), ApplicationPlatformLive)
 
 const SignalMarketDataLive = (plan: ApplicationIdentity) => {
   const clickHouse = sqlResource(ClickHouseClientResourceLive(plan.config))

--- a/services/bayn/src/observe-composition.test.ts
+++ b/services/bayn/src/observe-composition.test.ts
@@ -4693,16 +4693,21 @@ describe('OBSERVE runtime composition', () => {
         executionProgram,
       })
 
-      const failure = await Effect.runPromise(
-        Effect.flip(
+      const exit = await Effect.runPromise(
+        Effect.exit(
           startup({
             qualificationRunId: 'c'.repeat(64),
             recordPass: () => Effect.void,
           }),
         ),
       )
+      expect(Exit.isFailure(exit)).toBe(true)
+      if (Exit.isSuccess(exit)) throw new Error('mismatched mutation startup unexpectedly succeeded')
+      const failure = Cause.findErrorOption(exit.cause)
+      expect(Option.isSome(failure)).toBe(true)
+      if (Option.isNone(failure)) throw new Error('mismatched mutation startup failed without a typed cause')
 
-      expect(failure).toMatchObject({
+      expect(failure.value).toMatchObject({
         _tag: 'OperationalError',
         component: 'config',
         operation: 'cycle-loop',

--- a/services/bayn/tsconfig.json
+++ b/services/bayn/tsconfig.json
@@ -9,6 +9,8 @@
         "name": "@effect/language-service",
         "diagnostics": true,
         "includeSuggestionsInTsc": false,
+        "ignoreEffectErrorsInTscExitCode": false,
+        "ignoreEffectWarningsInTscExitCode": false,
         "diagnosticSeverity": {
           "anyUnknownInErrorContext": "error",
           "globalDateInEffect": "error",


### PR DESCRIPTION
## Summary

- make the existing pinned `@effect/tsgo` 0.24.3 compiler the normal Bayn `tsc` path instead of running TypeScript and Effect diagnostics twice
- fail the single compiler boundary on configured Effect warnings and errors and simplify the Bayn PR workflow accordingly
- sequence HTTP/platform dependencies correctly and retain `NodeServices.layer` for TLS-backed PostgreSQL certificate reads
- inspect startup failure through `Exit` so an autonomous-loop Effect never enters an Effect error channel
- bind the exact amd64 and arm64 dependency closures produced by the TSGo package contract

Stacked on #13612.

## Related Issues

None

## Testing

- `bun run --filter @proompteng/bayn tsc` — Effect TSGo checked 464 files with 0 errors, 0 warnings, and 0 messages, including after restoring the unpatched native TypeScript binary
- focused composition/startup/release tests — 125 passed, 0 failed
- `bun run --filter @proompteng/bayn test` — 1054 passed, 160 PostgreSQL-environment skips, 0 failed
- `bun test packages/scripts/src/bayn` — 126 passed, 0 failed
- `bun run --filter @proompteng/bayn build`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `nix eval --raw .#packages.x86_64-linux.bayn-image.drvPath`
- `nix eval --raw .#packages.aarch64-linux.bayn-image.drvPath`
- `git diff --check`
- hosted full Bayn, PostgreSQL, amd64/arm64 image, dependency, broker, Effect runtime, release, and repository gates are green

## Breaking Changes

None. `bun run --filter @proompteng/bayn tsc` remains the public validation command and now includes Effect diagnostics in the same compiler pass.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes are documented.
- [x] Documentation and CI contract tests are updated.
