### PR TITLE
refactor(bayn): enforce exact TypeScript semantics

### DIFF
--- a/services/bayn/src/audit/reference/replay.ts
+++ b/services/bayn/src/audit/reference/replay.ts
@@ -421,14 +421,12 @@ export const replay = (
     const terminalSession = closeAtEnd && index === sessions.length - 1
     const replaceScheduledTarget = terminalSession && scheduledTarget !== undefined && !isFlatTarget(scheduledTarget)
     const terminalTargetFor = (source: Target | undefined): Target => ({
-      ...(source ?? {
-        signalIndex: Math.max(0, index - 1),
-        executionIndex: index,
-        weights: Object.fromEntries(protocol.universe.map((symbol) => [symbol, 0])),
-      }),
+      signalIndex: source?.signalIndex ?? Math.max(0, index - 1),
       executionIndex: index,
       weights: Object.fromEntries(protocol.universe.map((symbol) => [symbol, 0])),
-      plan: undefined,
+      ...(source?.requireDecisionEvidence === undefined
+        ? {}
+        : { requireDecisionEvidence: source.requireDecisionEvidence }),
       terminalClose: true,
     })
     const target = replaceScheduledTarget ? terminalTargetFor(scheduledTarget) : scheduledTarget
@@ -444,23 +442,7 @@ export const replay = (
 
     const mustCloseAtEnd = terminalSession && !replaceScheduledTarget && hasOpenPosition(positions)
     const closeSource = scheduledTarget ?? lastTarget
-    const terminalTarget =
-      mustCloseAtEnd && closeSource !== undefined
-        ? {
-            ...closeSource,
-            executionIndex: index,
-            weights: Object.fromEntries(protocol.universe.map((symbol) => [symbol, 0])),
-            plan: undefined,
-            terminalClose: true,
-          }
-        : mustCloseAtEnd
-          ? {
-              signalIndex: Math.max(0, index - 1),
-              executionIndex: index,
-              weights: Object.fromEntries(protocol.universe.map((symbol) => [symbol, 0])),
-              terminalClose: true,
-            }
-          : undefined
+    const terminalTarget = mustCloseAtEnd ? terminalTargetFor(closeSource) : undefined
     if (terminalTarget !== undefined) {
       const terminalResult = runTarget(terminalTarget)
       if (Result.isFailure(terminalResult)) return Result.fail(terminalResult.failure)

--- a/services/bayn/src/broker/alpaca-mutations.test.ts
+++ b/services/bayn/src/broker/alpaca-mutations.test.ts
@@ -217,7 +217,9 @@ const withMutation = <A, E>(
   use: (mutation: BrokerMutationShape) => Effect.Effect<A, E>,
   options: MutationHarnessOptions = {},
 ): Effect.Effect<A, BrokerMutationError | E> => {
-  const session = options.session ?? verifiedSession({ operationTimeoutMs: options.operationTimeoutMs })
+  const session =
+    options.session ??
+    verifiedSession(options.operationTimeoutMs === undefined ? {} : { operationTimeoutMs: options.operationTimeoutMs })
   return makeMutation(session, options.authority ?? submitAuthority, client).pipe(Effect.flatMap(use))
 }
 

--- a/services/bayn/src/broker/alpaca-mutations.ts
+++ b/services/bayn/src/broker/alpaca-mutations.ts
@@ -7,6 +7,7 @@ export {
   invalidRequest,
   type BrokerMutationShape,
   type MutationEvidence,
+  type PartialMutationEvidence,
 } from './alpaca-mutations/model'
 export {
   OrderRequestError,

--- a/services/bayn/src/broker/alpaca-mutations/interpreter.ts
+++ b/services/bayn/src/broker/alpaca-mutations/interpreter.ts
@@ -175,7 +175,7 @@ export const makeMutation = (
                 ...prepared,
                 status: response.status,
                 requestId: headers['x-request-id'],
-                body,
+                ...(body === undefined ? {} : { body }),
                 observedAt,
               }),
             )

--- a/services/bayn/src/broker/alpaca-mutations/model.ts
+++ b/services/bayn/src/broker/alpaca-mutations/model.ts
@@ -26,6 +26,9 @@ export const MutationEvidenceSchema = Schema.Struct({
   observedAt: UtcInstant,
 })
 export type MutationEvidence = typeof MutationEvidenceSchema.Type
+export type PartialMutationEvidence = {
+  readonly [K in keyof MutationEvidence]?: MutationEvidence[K] | undefined
+}
 
 export class BrokerMutationError extends Data.TaggedError('BrokerMutationError')<{
   readonly operation: MutationOperation
@@ -33,7 +36,7 @@ export class BrokerMutationError extends Data.TaggedError('BrokerMutationError')
   readonly outcome: MutationOutcome
   readonly message: string
   readonly requestHash?: string
-  readonly evidence?: Partial<MutationEvidence>
+  readonly evidence?: PartialMutationEvidence
   readonly brokerOrderId?: string
   readonly brokerCode?: string
   readonly cause?: Readonly<Record<string, string>>
@@ -93,7 +96,7 @@ export const configurationError = (message: string, cause?: unknown) =>
     failure: MutationFailure.Configuration,
     outcome: MutationOutcome.Known,
     message,
-    cause: cause === undefined ? undefined : causeSummary(cause),
+    ...(cause === undefined ? {} : { cause: causeSummary(cause) }),
   })
 
 export const invalidRequest = (operation: MutationOperation, message: string, cause?: unknown) =>
@@ -102,14 +105,14 @@ export const invalidRequest = (operation: MutationOperation, message: string, ca
     failure: MutationFailure.InvalidRequest,
     outcome: MutationOutcome.Known,
     message,
-    cause: cause === undefined ? undefined : causeSummary(cause),
+    ...(cause === undefined ? {} : { cause: causeSummary(cause) }),
   })
 
 export const unknownOutcome = (
   operation: MutationOperation,
   message: string,
   requestHash?: string,
-  evidence?: Partial<MutationEvidence>,
+  evidence?: PartialMutationEvidence,
   cause?: unknown,
 ) =>
   new BrokerMutationError({
@@ -117,9 +120,9 @@ export const unknownOutcome = (
     failure: MutationFailure.Unknown,
     outcome: MutationOutcome.Unknown,
     message,
-    requestHash,
-    evidence,
-    cause: cause === undefined ? undefined : causeSummary(cause),
+    ...(requestHash === undefined ? {} : { requestHash }),
+    ...(evidence === undefined ? {} : { evidence }),
+    ...(cause === undefined ? {} : { cause: causeSummary(cause) }),
   })
 
 export const knownRejection = (

--- a/services/bayn/src/broker/alpaca/failures.ts
+++ b/services/bayn/src/broker/alpaca/failures.ts
@@ -165,11 +165,11 @@ export const invalidResponse = (
     kind: BrokerReadErrorKind.InvalidResponse,
     message,
     retryable: false,
-    status: evidence?.status,
-    requestId: evidence?.requestId,
-    contentHash: evidence?.contentHash,
-    observedAt: evidence?.observedAt,
-    cause: cause === undefined ? undefined : safeCause(cause),
+    ...(evidence?.status === undefined ? {} : { status: evidence.status }),
+    ...(evidence?.requestId === undefined ? {} : { requestId: evidence.requestId }),
+    ...(evidence?.contentHash === undefined ? {} : { contentHash: evidence.contentHash }),
+    ...(evidence?.observedAt === undefined ? {} : { observedAt: evidence.observedAt }),
+    ...(cause === undefined ? {} : { cause: safeCause(cause) }),
   })
 
 export const invalidRequest = (operation: BrokerReadOperation, message: string, cause: unknown): BrokerReadError =>

--- a/services/bayn/src/broker/alpaca/http.ts
+++ b/services/bayn/src/broker/alpaca/http.ts
@@ -557,8 +557,9 @@ export const make = (connection: BrokerConnection): Effect.Effect<BrokerReadShap
             Effect.map((items) => ({
               value: {
                 items,
-                nextPageToken:
-                  items.length === pageSize && items.length > 0 ? items[items.length - 1]?.activityId : undefined,
+                ...(items.length === pageSize && items.length > 0
+                  ? { nextPageToken: items[items.length - 1]?.activityId }
+                  : {}),
               },
               evidence: result.evidence,
             })),

--- a/services/bayn/src/broker/alpaca/model.ts
+++ b/services/bayn/src/broker/alpaca/model.ts
@@ -203,10 +203,10 @@ export interface ProxyDispatcherDependencies {
 }
 
 export interface RateLimitEvidence {
-  readonly limit?: string
-  readonly remaining?: string
-  readonly reset?: string
-  readonly retryAfter?: string
+  readonly limit?: string | undefined
+  readonly remaining?: string | undefined
+  readonly reset?: string | undefined
+  readonly retryAfter?: string | undefined
 }
 
 export interface ReadEvidence {
@@ -214,7 +214,7 @@ export interface ReadEvidence {
   readonly status: number
   readonly contentHash: string
   readonly observedAt: string
-  readonly rateLimit?: RateLimitEvidence
+  readonly rateLimit?: RateLimitEvidence | undefined
 }
 
 export interface ReadResult<A> {

--- a/services/bayn/src/broker/alpaca/requests.ts
+++ b/services/bayn/src/broker/alpaca/requests.ts
@@ -117,16 +117,16 @@ export const responseEvidenceResult = (
     headers['retry-after'] === undefined
       ? undefined
       : {
-          limit,
-          remaining,
-          reset: headers['x-ratelimit-reset'],
-          retryAfter: headers['retry-after'],
+          ...(limit === undefined ? {} : { limit }),
+          ...(remaining === undefined ? {} : { remaining }),
+          ...(headers['x-ratelimit-reset'] === undefined ? {} : { reset: headers['x-ratelimit-reset'] }),
+          ...(headers['retry-after'] === undefined ? {} : { retryAfter: headers['retry-after'] }),
         }
   return Result.succeed({
     requestId: headers['x-request-id'],
     status,
     contentHash,
     observedAt,
-    rateLimit,
+    ...(rateLimit === undefined ? {} : { rateLimit }),
   })
 }

--- a/services/bayn/src/broker/alpaca/session.ts
+++ b/services/bayn/src/broker/alpaca/session.ts
@@ -56,8 +56,6 @@ const acquisitionStage = (cause: BrokerReadError | BrokerAccountPreflightError):
     case 'market-calendar':
       return BrokerSessionAcquisitionStage.ReadSurface
   }
-  const exhaustive: never = cause.operation
-  return exhaustive
 }
 
 const acquisitionError = (

--- a/services/bayn/src/broker/connection.ts
+++ b/services/bayn/src/broker/connection.ts
@@ -237,6 +237,4 @@ export const renderBrokerConnectionDecodeFailure = (failure: BrokerConnectionDec
     case 'InvalidBrokerProxyUrl':
       return `invalid broker proxy URL: ${failure.reason}`
   }
-  const exhaustive: never = failure
-  return exhaustive
 }

--- a/services/bayn/src/broker/observations.test.ts
+++ b/services/bayn/src/broker/observations.test.ts
@@ -186,7 +186,8 @@ describe('paper broker observations', () => {
       _tag: 'ExtendedHoursUnsupported',
       brokerOrderId: order.brokerOrderId,
     })
-    expect(failure(orderObservation({ ...order, updatedAt: undefined }, evidence))).toEqual({
+    const { updatedAt: _omittedUpdatedAt, ...orderWithoutUpdatedAt } = order
+    expect(failure(orderObservation(orderWithoutUpdatedAt, evidence))).toEqual({
       _tag: 'OrderUpdatedAtMissing',
       brokerOrderId: order.brokerOrderId,
     })

--- a/services/bayn/src/broker/observations.ts
+++ b/services/bayn/src/broker/observations.ts
@@ -394,7 +394,7 @@ export const positionSnapshot = (
         )
 }
 
-type QuantityOrder = AlpacaOrder & {
+type QuantityOrder = Omit<AlpacaOrder, 'notionalMicros' | 'quantityMicros' | 'updatedAt'> & {
   readonly quantityMicros: string
   readonly notionalMicros?: undefined
   readonly updatedAt: string
@@ -415,12 +415,12 @@ const validateOrderShape = (
   if (updatedAt === undefined) {
     return fail({ _tag: 'OrderUpdatedAtMissing', brokerOrderId: value.brokerOrderId })
   }
+  const { notionalMicros: _omittedNotionalMicros, ...order } = value
   return pipe(
     validateObservationTime(value.observedAt, evidence),
     Result.map(() => ({
-      ...value,
+      ...order,
       quantityMicros,
-      notionalMicros: undefined,
       updatedAt,
     })),
   )

--- a/services/bayn/src/config/load.ts
+++ b/services/bayn/src/config/load.ts
@@ -109,8 +109,6 @@ const presentRuntimeConfigFailure = (failure: RuntimeConfigResolutionFailure): R
         message: 'invalid build provenance: configured strategy parameter hash does not match embedded build metadata',
       }
   }
-  const exhaustive: never = failure
-  return exhaustive
 }
 
 const resolutionFailureToOperationalError = (failure: RuntimeConfigResolutionFailure): OperationalError => {

--- a/services/bayn/src/config/model.ts
+++ b/services/bayn/src/config/model.ts
@@ -20,8 +20,8 @@ export interface RuntimeBuildMetadata extends EmbeddedBuildMetadata {
 export interface RuntimeConfig {
   readonly host: string
   readonly port: number
-  readonly qualificationRunId?: string
-  readonly paperActivationRequestJson?: string
+  readonly qualificationRunId?: string | undefined
+  readonly paperActivationRequestJson?: string | undefined
   readonly execution: ExecutionPolicy
   readonly build: RuntimeBuildMetadata
   readonly healthIntervalMs: number
@@ -29,10 +29,12 @@ export interface RuntimeConfig {
   readonly cycleStallThresholdMs: number
   readonly reconciliationStaleThresholdMs: number
   readonly unknownMutationThresholdMs: number
-  readonly alpaca?: BrokerConnection & {
-    readonly authorityGenerationHash: string
-    readonly reconciliationIntervalMs: number
-  }
+  readonly alpaca?:
+    | (BrokerConnection & {
+        readonly authorityGenerationHash: string
+        readonly reconciliationIntervalMs: number
+      })
+    | undefined
   readonly clickhouse: {
     readonly url: string
     readonly username: string
@@ -68,13 +70,13 @@ export type LoadedRuntimeConfig = LoadedRuntimeConfigBase &
   (
     | {
         readonly runtimeMode: 'BrokerlessService'
-        readonly qualificationRunId?: string
+        readonly qualificationRunId?: string | undefined
         readonly execution: Extract<ExecutionPolicy, { readonly brokerIdentity?: undefined }>
         readonly alpaca?: undefined
       }
     | {
         readonly runtimeMode: 'AutonomousService'
-        readonly qualificationRunId?: string
+        readonly qualificationRunId?: string | undefined
         readonly execution: Exclude<ExecutionPolicy, { readonly brokerIdentity?: undefined }>
         readonly alpaca: AlpacaRuntimeConfig
       }
@@ -105,7 +107,7 @@ export interface ParsedRuntimeConfig {
   readonly host: string
   readonly port: number
   readonly qualificationRunId: string | undefined
-  readonly paperActivationRequestJson?: string
+  readonly paperActivationRequestJson?: string | undefined
   readonly configuredOperation: RuntimeOperation | undefined
   readonly executionPrepareRequest: ExecutionPrepareRequest | undefined
   readonly legacyMaximumAuthority: LegacyAuthorityToken | undefined

--- a/services/bayn/src/cycle-observability.ts
+++ b/services/bayn/src/cycle-observability.ts
@@ -131,12 +131,12 @@ const isRecord = (value: unknown): value is Readonly<Record<string, unknown>> =>
 
 export const retainedAutonomousCycleCadenceDecision = (observation: unknown): MonthEndCadenceDecision | undefined => {
   if (!isRecord(observation) || !Object.hasOwn(observation, 'cadenceDecision')) return undefined
-  const retained = observation.cadenceDecision
+  const retained = observation['cadenceDecision']
   if (!isRecord(retained)) return decideMonthEndCadenceEligibility({})
   return decideMonthEndCadenceEligibility({
-    ...(typeof retained.signalSessionDate === 'string' ? { signalSessionDate: retained.signalSessionDate } : {}),
-    ...(typeof retained.executionSessionDate === 'string'
-      ? { executionSessionDate: retained.executionSessionDate }
+    ...(typeof retained['signalSessionDate'] === 'string' ? { signalSessionDate: retained['signalSessionDate'] } : {}),
+    ...(typeof retained['executionSessionDate'] === 'string'
+      ? { executionSessionDate: retained['executionSessionDate'] }
       : {}),
   })
 }
@@ -372,8 +372,6 @@ export const renderCycleOperationsStatusFailure = (failure: CycleOperationsStatu
     case 'UtcEpochMillisOutOfRange':
       return `cycle operations clock is outside the supported UTC range: observed=${failure.nowMs}`
   }
-  const exhaustive: never = failure.cause
-  return exhaustive
 }
 
 const ageAt = (instant: string | null, nowMs: number): number | null =>

--- a/services/bayn/src/cycle-runner.test.ts
+++ b/services/bayn/src/cycle-runner.test.ts
@@ -1396,7 +1396,7 @@ describe('autonomous cycle runner', () => {
     expect(facts.map((fact) => fact.message)).toEqual(
       Array.from({ length: results.length }, () => 'Bayn autonomous cycle pass completed'),
     )
-    expect(facts.map((fact) => [fact.annotations.outcome, fact.annotations.persistenceDeduplicated])).toEqual([
+    expect(facts.map((fact) => [fact.annotations['outcome'], fact.annotations['persistenceDeduplicated']])).toEqual([
       ['NO_PUBLICATION', undefined],
       ['ALREADY_ACQUIRED', undefined],
       ['ALREADY_TERMINAL', undefined],
@@ -3527,8 +3527,8 @@ describe('autonomous cycle runner', () => {
         (entry) =>
           Array.isArray(entry.message) &&
           entry.message.includes('Bayn autonomous cycle pass failed') &&
-          entry.annotations.operation === 'load-context' &&
-          entry.annotations.failure === 'context',
+          entry.annotations['operation'] === 'load-context' &&
+          entry.annotations['failure'] === 'context',
       ),
     ).toBe(true)
     expect(observations).toHaveLength(2)

--- a/services/bayn/src/db/cycle-observability.integration.test.ts
+++ b/services/bayn/src/db/cycle-observability.integration.test.ts
@@ -23,7 +23,7 @@ import { PostgresClientLive } from './evidence-store'
 import { migrationLoader } from './migrations'
 import { readForwardPerformancePostgres } from '../forward-performance/postgres'
 
-const postgresUrl = process.env.BAYN_TEST_POSTGRES_URL
+const postgresUrl = process.env['BAYN_TEST_POSTGRES_URL']
 const testUrl = postgresUrl ?? 'postgresql://bayn:bayn@127.0.0.1:5432/bayn_test'
 const describePostgres = postgresUrl === undefined ? describe.skip : describe
 const qualificationRunId = 'a'.repeat(64)

--- a/services/bayn/src/db/cycle-store/integration.test.ts
+++ b/services/bayn/src/db/cycle-store/integration.test.ts
@@ -93,7 +93,7 @@ import { PostgresClientLive } from '../evidence-store'
 import { migrationLoader } from '../migrations'
 import { CycleStore, CycleStoreLive, type CycleStoreShape } from '.'
 
-const postgresUrl = process.env.BAYN_TEST_POSTGRES_URL
+const postgresUrl = process.env['BAYN_TEST_POSTGRES_URL']
 const testUrl = postgresUrl ?? 'postgresql://bayn:bayn@127.0.0.1:5432/bayn_test'
 const describePostgres = postgresUrl === undefined ? describe.skip : describe
 const signalCalendarVersion = 'signal-XNYS-2026-v1'
@@ -144,7 +144,7 @@ interface PostgresProcessRestartEvidence {
 }
 
 const restartGithubPostgres18Process = async (): Promise<PostgresProcessRestartEvidence | undefined> => {
-  if (process.env.GITHUB_ACTIONS !== 'true') return undefined
+  if (process.env['GITHUB_ACTIONS'] !== 'true') return undefined
 
   const url = new URL(testUrl)
   const port = url.port.length === 0 ? '5432' : url.port
@@ -4570,7 +4570,7 @@ describePostgres('PostgreSQL autonomous cycle store', () => {
       await firstRuntime.dispose()
 
       const processRestart = await restartGithubPostgres18Process()
-      if (process.env.GITHUB_ACTIONS === 'true') {
+      if (process.env['GITHUB_ACTIONS'] === 'true') {
         expect(processRestart).toMatchObject({
           containerId: expect.any(String),
           image: expect.stringMatching(/^postgres:18(?:-|$)/),

--- a/services/bayn/src/db/evidence-store.integration.test.ts
+++ b/services/bayn/src/db/evidence-store.integration.test.ts
@@ -123,7 +123,7 @@ const ExecutionStore = Effect.gen(function* () {
   }
 })
 
-const postgresUrl = process.env.BAYN_TEST_POSTGRES_URL
+const postgresUrl = process.env['BAYN_TEST_POSTGRES_URL']
 const testUrl = postgresUrl ?? 'postgresql://bayn:bayn@127.0.0.1:5432/bayn_test'
 const describePostgres = postgresUrl === undefined ? describe.skip : describe
 const orderId = '61e69015-8549-4bfd-b9c3-01e75843f47d'

--- a/services/bayn/src/db/execution-store.ts
+++ b/services/bayn/src/db/execution-store.ts
@@ -1,6 +1,5 @@
 import { Context, Effect, Layer } from 'effect'
 
-import type { RuntimeConfig } from '../config'
 import {
   BrokerEventStore,
   AuthorityGenerationStore,
@@ -9,6 +8,7 @@ import {
   FillAccountingStore,
   ReconciliationStore,
   ValuationStore,
+  type ExecutionStoreRuntimeConfig,
 } from './execution-store/contract'
 import { makeExecutionPersistence } from './execution-store/postgres'
 
@@ -35,7 +35,7 @@ export {
   type ValuationStoreShape,
 } from './execution-store/contract'
 
-export const ExecutionStoreLive = (config: RuntimeConfig) =>
+export const ExecutionStoreLive = (config: ExecutionStoreRuntimeConfig) =>
   Layer.effectContext(
     makeExecutionPersistence(config).pipe(
       Effect.map((persistence) =>

--- a/services/bayn/src/db/execution-store/contract.ts
+++ b/services/bayn/src/db/execution-store/contract.ts
@@ -165,5 +165,7 @@ export type ExecutionStoreRuntimeConfig = Pick<
   RuntimeConfig,
   'build' | 'execution' | 'qualificationRunId' | 'reconciliationStaleThresholdMs' | 'tigerBeetle'
 > & {
-  readonly alpaca?: Pick<NonNullable<RuntimeConfig['alpaca']>, 'expectedAccountId' | 'authorityGenerationHash'>
+  readonly alpaca?:
+    | Pick<NonNullable<RuntimeConfig['alpaca']>, 'expectedAccountId' | 'authorityGenerationHash'>
+    | undefined
 }

--- a/services/bayn/src/db/paper-store.integration.test.ts
+++ b/services/bayn/src/db/paper-store.integration.test.ts
@@ -90,7 +90,7 @@ const ExecutionStore = Effect.gen(function* () {
   }
 })
 
-const postgresUrl = process.env.BAYN_TEST_POSTGRES_URL
+const postgresUrl = process.env['BAYN_TEST_POSTGRES_URL']
 const testUrl = postgresUrl ?? 'postgresql://bayn:bayn@127.0.0.1:5432/bayn_test'
 const describePostgres = postgresUrl === undefined ? describe.skip : describe
 const accountId = 'paper-account-1'
@@ -2902,8 +2902,8 @@ describePostgres('paper accounting persistence', () => {
         }),
       )
 
-      expect(result.before.authority?.[0]?.row.version).toBe(Number.MAX_SAFE_INTEGER)
-      expect(result.before.history?.[0]?.row.authority_version).toBe(Number.MAX_SAFE_INTEGER)
+      expect(result.before.authority?.[0]?.row['version']).toBe(Number.MAX_SAFE_INTEGER)
+      expect(result.before.history?.[0]?.row['authority_version']).toBe(Number.MAX_SAFE_INTEGER)
       expect(result.failure).toMatchObject({
         operation: 'authority',
         failure: 'invariant',

--- a/services/bayn/src/db/reconciliation-algebra.test.ts
+++ b/services/bayn/src/db/reconciliation-algebra.test.ts
@@ -78,7 +78,7 @@ const prepared = preparedResult.success
 const postedMicros = prepared.ledger.transfers.reduce((sum, transfer) => sum + transfer.amount, 0n).toString()
 const receiptMaterial = {
   schemaVersion: 'bayn.paper-accounting-receipt.v1' as const,
-  intentId: fill.intentId,
+  ...(fill.intentId === undefined ? {} : { intentId: fill.intentId }),
   brokerEventId: prepared.transaction.brokerEventId,
   tigerBeetleClusterId: tigerBeetle.clusterId.toString(),
   tigerBeetleLedger: tigerBeetle.ledger,
@@ -122,7 +122,7 @@ const order: Order = {
   accountId,
   brokerOrderId: fill.brokerOrderId,
   clientOrderId: fill.clientOrderId,
-  intentId: fill.intentId,
+  ...(fill.intentId === undefined ? {} : { intentId: fill.intentId }),
   symbol: fill.symbol,
   side: fill.side,
   orderType: OrderType.Limit,

--- a/services/bayn/src/execution-candidate-discovery.test.ts
+++ b/services/bayn/src/execution-candidate-discovery.test.ts
@@ -1145,7 +1145,7 @@ describe('paper candidate discovery', () => {
   })
 })
 
-const postgresUrl = process.env.BAYN_TEST_POSTGRES_URL
+const postgresUrl = process.env['BAYN_TEST_POSTGRES_URL']
 const describePostgres = postgresUrl === undefined ? describe.skip : describe
 
 describePostgres('paper candidate discovery PostgreSQL transaction', () => {

--- a/services/bayn/src/execution-prepare/execution-prepare.integration.test.ts
+++ b/services/bayn/src/execution-prepare/execution-prepare.integration.test.ts
@@ -38,7 +38,7 @@ import { makeExecutionPrepareDiscoveryReceiptFixture } from './test-fixture'
 
 type ExecutionPrepareRequest = ExecutionPrepareProofPlanRequest
 
-const postgresUrl = process.env.BAYN_TEST_POSTGRES_URL
+const postgresUrl = process.env['BAYN_TEST_POSTGRES_URL']
 const testUrl = postgresUrl ?? 'postgresql://bayn:bayn@127.0.0.1:5432/bayn_test'
 const describePostgres = postgresUrl === undefined ? describe.skip : describe
 const accountId = 'execution-prepare-account'

--- a/services/bayn/src/execution/configuration.ts
+++ b/services/bayn/src/execution/configuration.ts
@@ -471,6 +471,4 @@ export const renderExecutionPolicyFailure = (failure: ExecutionPolicyResolutionF
     case 'UnexpectedLiveCapitalGrantHash':
       return `live capital grant hash is not valid for ${failure.capitalAuthority}`
   }
-  const exhaustive: never = failure
-  return exhaustive
 }

--- a/services/bayn/src/execution/coordinator.test.ts
+++ b/services/bayn/src/execution/coordinator.test.ts
@@ -12,6 +12,7 @@ import {
   orderRequestBody,
   type BrokerMutationShape,
   type MutationEvidence,
+  type PartialMutationEvidence,
 } from '../broker/alpaca-mutations'
 import {
   AssetClass,
@@ -730,6 +731,7 @@ describe('MutationStore decision algebra', () => {
         expect(state).toBeUndefined()
       }
       if ('terminalOutcome' in decision.transition) {
+        if (terminalOutcome === undefined) throw new Error('expected a terminal outcome')
         expect(decision.transition.terminalOutcome).toBe(terminalOutcome)
       } else {
         expect(terminalOutcome).toBeUndefined()
@@ -1240,7 +1242,7 @@ describe('MutationStore decision algebra', () => {
   })
 })
 
-const completeEvidence = (response: Partial<MutationEvidence> | undefined): MutationEvidence | undefined =>
+const completeEvidence = (response: PartialMutationEvidence | undefined): MutationEvidence | undefined =>
   response?.requestId !== undefined &&
   response.status !== undefined &&
   response.contentHash !== undefined &&
@@ -1285,6 +1287,7 @@ const makeHarness = (options: HarnessOptions = {}) => {
   ): MutationEvent => {
     const previous = latest.get(operation)
     const sequence = (previous?.sequence ?? 0) + 1
+    const effectiveBrokerOrderId = brokerOrderId ?? previous?.brokerOrderId
     const value: MutationEvent = {
       schemaVersion: 'bayn.paper-mutation-event.v1',
       eventId: canonicalHashV1({ operation, sequence, eventType, occurredAt }),
@@ -1295,9 +1298,7 @@ const makeHarness = (options: HarnessOptions = {}) => {
       eventType,
       requestHash,
       consistencyDelayMs,
-      ...((brokerOrderId ?? previous?.brokerOrderId)
-        ? { brokerOrderId: brokerOrderId ?? previous?.brokerOrderId }
-        : {}),
+      ...(effectiveBrokerOrderId === undefined ? {} : { brokerOrderId: effectiveBrokerOrderId }),
       ...(response === undefined
         ? {}
         : {

--- a/services/bayn/src/execution/mutation-authority.test.ts
+++ b/services/bayn/src/execution/mutation-authority.test.ts
@@ -91,27 +91,38 @@ const position = (overrides: Partial<Position> = {}): Position => ({
   ...overrides,
 })
 
-const order = (overrides: Partial<Order> = {}): Order => ({
-  accountId,
-  brokerOrderId: '61e69015-8549-4bfd-b9c3-01e75843f47d',
-  clientOrderId: 'open-order-1',
-  createdAt: activeAt,
-  submittedAt: activeAt,
-  assetId: 'b0b6dd9d-8b9b-48a9-ba46-b9d54906e415',
-  symbol: 'AMD',
-  assetClass: AssetClass.UsEquity,
-  quantityMicros: '1000000',
-  notionalMicros: '100000000',
-  filledQuantityMicros: '0',
-  orderClass: OrderClass.Simple,
-  orderType: BrokerOrderType.Market,
-  side: BrokerOrderSide.Buy,
-  timeInForce: BrokerTimeInForce.Day,
-  status: OrderStatus.New,
-  extendedHours: false,
-  observedAt: activeAt,
-  ...overrides,
-})
+type OmittedOrderField =
+  | 'filledAveragePriceMicros'
+  | 'limitPriceMicros'
+  | 'notionalMicros'
+  | 'quantityMicros'
+  | 'stopPriceMicros'
+
+const order = (overrides: Partial<Order> = {}, omitted: readonly OmittedOrderField[] = []): Order => {
+  const value: Order = {
+    accountId,
+    brokerOrderId: '61e69015-8549-4bfd-b9c3-01e75843f47d',
+    clientOrderId: 'open-order-1',
+    createdAt: activeAt,
+    submittedAt: activeAt,
+    assetId: 'b0b6dd9d-8b9b-48a9-ba46-b9d54906e415',
+    symbol: 'AMD',
+    assetClass: AssetClass.UsEquity,
+    quantityMicros: '1000000',
+    notionalMicros: '100000000',
+    filledQuantityMicros: '0',
+    orderClass: OrderClass.Simple,
+    orderType: BrokerOrderType.Market,
+    side: BrokerOrderSide.Buy,
+    timeInForce: BrokerTimeInForce.Day,
+    status: OrderStatus.New,
+    extendedHours: false,
+    observedAt: activeAt,
+    ...overrides,
+  }
+  for (const field of omitted) Reflect.deleteProperty(value, field)
+  return value
+}
 
 const intent = (overrides: Partial<Intent> = {}): Intent => ({
   schemaVersion: 'bayn.paper-intent.v3',
@@ -306,7 +317,7 @@ const runLiveSubmit = async (input: ScenarioInput = {}) => {
 const failureTag = (exit: Awaited<ReturnType<typeof runLiveSubmit>>['exit']): string | undefined => {
   if (exit._tag !== 'Failure') return undefined
   const failure = exit.cause.reasons.find(Cause.isFailReason)?.error
-  return failure?.cause?.tag
+  return failure?.cause?.['tag']
 }
 
 describe('final broker mutation authority', () => {
@@ -426,7 +437,7 @@ describe('final broker mutation authority', () => {
     expect(rejected._tag).toBe('Failure')
     if (rejected._tag === 'Failure') {
       const failure = rejected.cause.reasons.find(Cause.isFailReason)?.error
-      expect(failure?.cause?.tag).toBe('LiveOpenOrderLimitExceeded')
+      expect(failure?.cause?.['tag']).toBe('LiveOpenOrderLimitExceeded')
     }
   })
 
@@ -526,7 +537,7 @@ describe('final broker mutation authority', () => {
 
   test('fails closed when an open order has no defensible notional', async () => {
     const observed = await runLiveSubmit({
-      openOrders: [order({ notionalMicros: undefined, quantityMicros: undefined })],
+      openOrders: [order({}, ['notionalMicros', 'quantityMicros'])],
     })
 
     expect(failureTag(observed.exit)).toBe('OpenOrderNotionalUnavailable')
@@ -536,14 +547,14 @@ describe('final broker mutation authority', () => {
   test('rejects a queued stop order whose triggered market fill has no enforceable price bound', async () => {
     const observed = await runLiveSubmit({
       openOrders: [
-        order({
-          orderType: BrokerOrderType.Stop,
-          notionalMicros: undefined,
-          quantityMicros: '1000000',
-          limitPriceMicros: undefined,
-          stopPriceMicros: '100000000',
-          filledAveragePriceMicros: undefined,
-        }),
+        order(
+          {
+            orderType: BrokerOrderType.Stop,
+            quantityMicros: '1000000',
+            stopPriceMicros: '100000000',
+          },
+          ['notionalMicros', 'limitPriceMicros', 'filledAveragePriceMicros'],
+        ),
       ],
     })
 
@@ -553,15 +564,14 @@ describe('final broker mutation authority', () => {
   })
 
   test('rejects a queued quantity market order whose future fill has no enforceable ceiling', async () => {
-    const queued = order({
-      brokerOrderId: 'c14cb7fb-0890-47dd-bbca-7778cfc61ec6',
-      symbol: 'NVDA',
-      notionalMicros: undefined,
-      quantityMicros: '1000000',
-      limitPriceMicros: undefined,
-      stopPriceMicros: undefined,
-      filledAveragePriceMicros: undefined,
-    })
+    const queued = order(
+      {
+        brokerOrderId: 'c14cb7fb-0890-47dd-bbca-7778cfc61ec6',
+        symbol: 'NVDA',
+        quantityMicros: '1000000',
+      },
+      ['notionalMicros', 'limitPriceMicros', 'stopPriceMicros', 'filledAveragePriceMicros'],
+    )
     const observed = await runLiveSubmit({
       openOrders: [queued],
       freshPricesBySymbol: {
@@ -660,14 +670,16 @@ describe('final broker mutation authority', () => {
   })
 
   test('rejects an uncovered pending sell on another symbol before authorizing a candidate buy', async () => {
-    const uncoveredSell = order({
-      brokerOrderId: 'c87ed037-a814-4e28-aef4-57f23831a54b',
-      symbol: 'NVDA',
-      side: BrokerOrderSide.Sell,
-      quantityMicros: '1000000',
-      notionalMicros: undefined,
-      limitPriceMicros: '1000000',
-    })
+    const uncoveredSell = order(
+      {
+        brokerOrderId: 'c87ed037-a814-4e28-aef4-57f23831a54b',
+        symbol: 'NVDA',
+        side: BrokerOrderSide.Sell,
+        quantityMicros: '1000000',
+        limitPriceMicros: '1000000',
+      },
+      ['notionalMicros'],
+    )
     const observed = await runLiveSubmit({
       openOrders: [uncoveredSell],
       freshPricesBySymbol: {
@@ -682,15 +694,17 @@ describe('final broker mutation authority', () => {
 
   test('prices only the unfilled remainder of a partially filled queued buy', async () => {
     const grant = liveGrant({ ...defaultLimits, maxPositionNotionalMicros: '120000000' })
-    const partialBuy = order({
-      brokerOrderId: '2a9722db-503f-47ad-82ef-6ba5a444be52',
-      side: BrokerOrderSide.Buy,
-      quantityMicros: '1000000',
-      filledQuantityMicros: '500000',
-      notionalMicros: undefined,
-      limitPriceMicros: '100000000',
-      status: OrderStatus.PartiallyFilled,
-    })
+    const partialBuy = order(
+      {
+        brokerOrderId: '2a9722db-503f-47ad-82ef-6ba5a444be52',
+        side: BrokerOrderSide.Buy,
+        quantityMicros: '1000000',
+        filledQuantityMicros: '500000',
+        limitPriceMicros: '100000000',
+        status: OrderStatus.PartiallyFilled,
+      },
+      ['notionalMicros'],
+    )
     const observed = await runLiveSubmit({
       grant,
       positions: [position({ quantityMicros: '500000', marketValueMicros: '50000000' })],
@@ -704,18 +718,18 @@ describe('final broker mutation authority', () => {
 
   test('rejects a partially filled market-order remainder whose future fill remains unbounded', async () => {
     const grant = liveGrant({ ...defaultLimits, maxPositionNotionalMicros: '150000000' })
-    const partialMarketBuy = order({
-      brokerOrderId: 'baf250d8-f7ac-48e8-b54b-1ed2fc870bf0',
-      side: BrokerOrderSide.Buy,
-      orderType: BrokerOrderType.Market,
-      quantityMicros: '1000000',
-      filledQuantityMicros: '500000',
-      notionalMicros: undefined,
-      limitPriceMicros: undefined,
-      stopPriceMicros: undefined,
-      filledAveragePriceMicros: '100000000',
-      status: OrderStatus.PartiallyFilled,
-    })
+    const partialMarketBuy = order(
+      {
+        brokerOrderId: 'baf250d8-f7ac-48e8-b54b-1ed2fc870bf0',
+        side: BrokerOrderSide.Buy,
+        orderType: BrokerOrderType.Market,
+        quantityMicros: '1000000',
+        filledQuantityMicros: '500000',
+        filledAveragePriceMicros: '100000000',
+        status: OrderStatus.PartiallyFilled,
+      },
+      ['notionalMicros', 'limitPriceMicros', 'stopPriceMicros'],
+    )
     const observed = await runLiveSubmit({
       grant,
       positions: [position({ quantityMicros: '500000', marketValueMicros: '50000000' })],
@@ -731,15 +745,17 @@ describe('final broker mutation authority', () => {
   })
 
   test('uses only the unfilled remainder of a partially filled queued sell for overshort protection', async () => {
-    const partialSell = order({
-      brokerOrderId: '318a5a2b-b976-4df3-9fbd-1030ab46e937',
-      side: BrokerOrderSide.Sell,
-      quantityMicros: '1000000',
-      filledQuantityMicros: '500000',
-      notionalMicros: undefined,
-      limitPriceMicros: '100000000',
-      status: OrderStatus.PartiallyFilled,
-    })
+    const partialSell = order(
+      {
+        brokerOrderId: '318a5a2b-b976-4df3-9fbd-1030ab46e937',
+        side: BrokerOrderSide.Sell,
+        quantityMicros: '1000000',
+        filledQuantityMicros: '500000',
+        limitPriceMicros: '100000000',
+        status: OrderStatus.PartiallyFilled,
+      },
+      ['notionalMicros'],
+    )
     const observed = await runLiveSubmit({
       positions: [position()],
       openOrders: [partialSell],

--- a/services/bayn/src/execution/mutations/decisions.ts
+++ b/services/bayn/src/execution/mutations/decisions.ts
@@ -1,6 +1,6 @@
 import { Result, Schema } from 'effect'
 
-import { MutationOperation, type MutationEvidence } from '../../broker/alpaca-mutations'
+import { MutationOperation, type MutationEvidence, type PartialMutationEvidence } from '../../broker/alpaca-mutations'
 import { canonicalHashV1Result } from '../../hash'
 import { Authority, IntentState, KillState, OrderSide, TerminalOutcome } from '../contracts'
 import { strictParseOptions } from '../../schemas'
@@ -34,7 +34,7 @@ import { MutationStoreError as MutationStoreErrorValue } from './model'
 
 const decodeStartInputResult = Schema.decodeUnknownResult(StartInputSchema, strictParseOptions)
 const decodeOutcomeInputResult = Schema.decodeUnknownResult(OutcomeInputSchema, strictParseOptions)
-const hasCompleteEvidence = (evidence: Partial<MutationEvidence>): evidence is MutationEvidence =>
+const hasCompleteEvidence = (evidence: PartialMutationEvidence): evidence is MutationEvidence =>
   evidence.requestId !== undefined &&
   evidence.status !== undefined &&
   evidence.contentHash !== undefined &&
@@ -42,9 +42,9 @@ const hasCompleteEvidence = (evidence: Partial<MutationEvidence>): evidence is M
 
 type MutationEvidenceDecision =
   | { readonly _tag: 'OmitIncompleteEvidence' }
-  | { readonly _tag: 'RetainCompleteEvidence'; readonly evidence: Partial<MutationEvidence> }
+  | { readonly _tag: 'RetainCompleteEvidence'; readonly evidence: PartialMutationEvidence }
 
-const decideMutationEvidence = (evidence: Partial<MutationEvidence> | undefined): MutationEvidenceDecision =>
+const decideMutationEvidence = (evidence: PartialMutationEvidence | undefined): MutationEvidenceDecision =>
   evidence !== undefined && hasCompleteEvidence(evidence)
     ? { _tag: 'RetainCompleteEvidence', evidence }
     : { _tag: 'OmitIncompleteEvidence' }
@@ -827,7 +827,7 @@ export const decodeOutcomeInput = (
     readonly requestHash: string
     readonly occurredAt: string
     readonly brokerOrderId?: string
-    readonly evidence?: Partial<MutationEvidence>
+    readonly evidence?: PartialMutationEvidence
   },
 ): Result.Result<MutationOutcomeInput, MutationStoreError> => {
   const evidence = decideMutationEvidence(input.evidence)

--- a/services/bayn/src/execution/mutations/model.ts
+++ b/services/bayn/src/execution/mutations/model.ts
@@ -1,6 +1,11 @@
 import { Context, Data, Effect, Schema } from 'effect'
 
-import { MutationEvidenceSchema, MutationOperation, type MutationEvidence } from '../../broker/alpaca-mutations'
+import {
+  MutationEvidenceSchema,
+  MutationOperation,
+  type MutationEvidence,
+  type PartialMutationEvidence,
+} from '../../broker/alpaca-mutations'
 import type { CanonicalHashFailure } from '../../hash'
 import { Authority, IntentState, KillState, OrderSide, TerminalOutcome } from '../contracts'
 import {
@@ -134,7 +139,7 @@ export interface MutationStoreShape {
     intentId: string,
     requestHash: string,
     occurredAt: string,
-    evidence?: Partial<MutationEvidence>,
+    evidence?: PartialMutationEvidence,
     brokerOrderId?: string,
   ) => Effect.Effect<MutationEvent, MutationStoreError | WriterFenceError>
   readonly beginCancel: (
@@ -155,7 +160,7 @@ export interface MutationStoreShape {
     requestHash: string,
     brokerOrderId: string,
     occurredAt: string,
-    evidence?: Partial<MutationEvidence>,
+    evidence?: PartialMutationEvidence,
   ) => Effect.Effect<MutationEvent, MutationStoreError | WriterFenceError>
   readonly recoveryFound: (
     intentId: string,
@@ -176,7 +181,7 @@ export interface MutationStoreShape {
     operation: MutationOperation,
     requestHash: string,
     occurredAt: string,
-    evidence?: Partial<MutationEvidence>,
+    evidence?: PartialMutationEvidence,
   ) => Effect.Effect<MutationEvent, MutationStoreError | WriterFenceError>
   readonly latest: (
     intentId: string,

--- a/services/bayn/src/execution/mutations/postgres/outcome.ts
+++ b/services/bayn/src/execution/mutations/postgres/outcome.ts
@@ -2,7 +2,7 @@ import { PgClient } from '@effect/sql-pg'
 import { Effect, Result } from 'effect'
 import type { SqlError } from 'effect/unstable/sql/SqlError'
 
-import { MutationOperation, type MutationEvidence } from '../../../broker/alpaca-mutations'
+import { MutationOperation, type PartialMutationEvidence } from '../../../broker/alpaca-mutations'
 import { IntentState } from '../../contracts'
 import {
   decideAcknowledgedRecovery,
@@ -35,7 +35,7 @@ export interface MutationOutcomePostgres {
     intentId: string,
     requestHash: string,
     occurredAt: string,
-    evidence?: Partial<MutationEvidence>,
+    evidence?: PartialMutationEvidence,
     brokerOrderId?: string,
   ) => Effect.Effect<MutationEvent, MutationStoreError | SqlError | WriterFenceError>
 }
@@ -266,7 +266,7 @@ export const makeMutationOutcomePostgres = (
     intentId: string,
     requestHash: string,
     occurredAt: string,
-    evidence?: Partial<MutationEvidence>,
+    evidence?: PartialMutationEvidence,
     brokerOrderId?: string,
   ) => {
     const operation = outcomeStoreOperation(definition)

--- a/services/bayn/src/execution/runtime-program.test.ts
+++ b/services/bayn/src/execution/runtime-program.test.ts
@@ -185,7 +185,7 @@ const finalLiveFixture = () => {
 const finalAuthorizationFailureTag = <A, E>(exit: Exit.Exit<A, E>): string | undefined => {
   if (Exit.isSuccess(exit)) return undefined
   const failure: unknown = exit.cause.reasons.find(Cause.isFailReason)?.error
-  if (failure instanceof BrokerMutationError) return failure.cause?.tag
+  if (failure instanceof BrokerMutationError) return failure.cause?.['tag']
   return typeof failure === 'object' && failure !== null && '_tag' in failure
     ? String((failure as { readonly _tag: unknown })._tag)
     : undefined

--- a/services/bayn/src/forward-performance/domain.test.ts
+++ b/services/bayn/src/forward-performance/domain.test.ts
@@ -1084,7 +1084,9 @@ describe('forward performance domain', () => {
   })
 
   test('missing starting capital is an evidence gap rather than malformed micros', () => {
-    const receipt = success(makeForwardPerformanceReceipt(input({ startingCapitalMicros: undefined })))
+    const evidence = input()
+    Reflect.deleteProperty(evidence, 'startingCapitalMicros')
+    const receipt = success(makeForwardPerformanceReceipt(evidence))
 
     expect(receipt.evidence.reasonCodes).toContain('STARTING_CAPITAL_GAP')
     expect(receipt.evidence.reasonCodes).not.toContain('INVALID_MICROS')

--- a/services/bayn/src/forward-performance/program.ts
+++ b/services/bayn/src/forward-performance/program.ts
@@ -485,7 +485,8 @@ const programError = (
   operation: ForwardPerformanceProgramError['operation'],
   message: string,
   cause?: ForwardPerformanceProgramCause,
-): ForwardPerformanceProgramError => new ForwardPerformanceProgramError({ operation, message, cause })
+): ForwardPerformanceProgramError =>
+  new ForwardPerformanceProgramError({ operation, message, ...(cause === undefined ? {} : { cause }) })
 
 const requireBrokerIdentity = (
   config: LoadedRuntimeConfig,

--- a/services/bayn/src/hash.test.ts
+++ b/services/bayn/src/hash.test.ts
@@ -88,7 +88,7 @@ describe('canonical hashing', () => {
 
   test('rejects cycles while accepting repeated non-cyclic references', () => {
     const cyclicObject: Record<string, unknown> = {}
-    cyclicObject.self = cyclicObject
+    cyclicObject['self'] = cyclicObject
     expect(failureOf(canonicalJsonV1Result(cyclicObject))).toEqual({
       _tag: 'CanonicalJsonFailure',
       path: '$.self',

--- a/services/bayn/src/health.test.ts
+++ b/services/bayn/src/health.test.ts
@@ -192,8 +192,6 @@ const brokerReadOperation = (name: BrokerHealthReadName): BrokerReadOperation =>
     case 'recent-fills':
       return 'fill-activities'
   }
-  const exhaustive: never = name
-  return exhaustive
 }
 
 const controlledBrokerRead = <A>(

--- a/services/bayn/src/health/decisions.ts
+++ b/services/bayn/src/health/decisions.ts
@@ -71,8 +71,6 @@ export const renderSignalIdentityFailure = (failure: SignalIdentityFailure): str
     case 'PublicationMismatch':
       return `configured Signal publication ${failure.observedPublicationId} differs from active run publication ${failure.expectedPublicationId}`
   }
-  const exhaustive: never = failure
-  return exhaustive
 }
 
 const durableMaterial = (evidence: RuntimeEvidence | RecoveredEvaluationEvidence) => ({
@@ -169,8 +167,6 @@ export const renderDurableEvidenceFailure = (failure: DurableEvidenceFailure): s
     case 'CanonicalizationFailed':
       return `canonicalization of ${failure.material} for run ${failure.runId} failed: ${renderCanonicalJsonFailure(failure.cause)}`
   }
-  const exhaustive: never = failure
-  return exhaustive
 }
 
 const dependencyHealth = <A>(result: ProbeResult<A>, checkedAt: string | null): DependencyHealth => ({

--- a/services/bayn/src/health/program.ts
+++ b/services/bayn/src/health/program.ts
@@ -65,8 +65,6 @@ const renderBrokerPermissionFailure = (failure: BrokerAccountPreflightFailure): 
     case 'BrokerFractionalTradingDisabled':
       return 'fractional trading is disabled'
   }
-  const exhaustive: never = failure
-  return exhaustive
 }
 
 const namedBrokerRead = <A, E, R>(

--- a/services/bayn/src/ledger-plan/input.ts
+++ b/services/bayn/src/ledger-plan/input.ts
@@ -128,9 +128,12 @@ const snapshotEvent = (
       access.field = 'event.kind'
       access.eventIndex = eventIndex
       const source = event as Record<PropertyKey, unknown>
-      const kind = source.kind
-      access.eventKind =
-        kind === 'decision' || kind === 'fill' || kind === 'fee' || kind === 'cash-yield' ? kind : undefined
+      const kind = source['kind']
+      if (kind === 'decision' || kind === 'fill' || kind === 'fee' || kind === 'cash-yield') {
+        access.eventKind = kind
+      } else {
+        delete access.eventKind
+      }
 
       return { source, kind, prototype: Object.getPrototypeOf(source), properties: Reflect.ownKeys(source) }
     }),

--- a/services/bayn/src/observe-composition.test.ts
+++ b/services/bayn/src/observe-composition.test.ts
@@ -1038,7 +1038,13 @@ describe('OBSERVE runtime composition', () => {
     expect(
       decidePaperCycleCompletion(
         evaluatedAt,
-        [{ ...filled, state: IntentState.Acknowledged, terminalOutcome: undefined }],
+        [
+          {
+            state: IntentState.Acknowledged,
+            updatedAt: filled.updatedAt,
+            latestMutationAt: filled.latestMutationAt,
+          },
+        ],
         laterReconciliation,
       ),
     ).toEqual({ _tag: 'Wait', reason: 'intent-nonterminal' })
@@ -1209,11 +1215,11 @@ describe('OBSERVE runtime composition', () => {
       brokerOrderId: 'accepted-broker-order',
       occurredAt: evaluatedAt,
     }
+    const { brokerOrderId: _acceptedBrokerOrderId, ...acceptedWithoutBrokerOrderId } = accepted
     const unknownEvent: MutationEvent = {
-      ...accepted,
+      ...acceptedWithoutBrokerOrderId,
       eventId: '2'.repeat(64),
       eventType: MutationEventType.SubmitUnknown,
-      brokerOrderId: undefined,
     }
     const cancelAccepted: MutationEvent = {
       ...accepted,
@@ -1711,12 +1717,12 @@ describe('OBSERVE runtime composition', () => {
       brokerOrderId: 'superseded-accepted-order',
       occurredAt,
     }
+    const { brokerOrderId: _supersededBrokerOrderId, ...acceptedWithoutBrokerOrderId } = accepted
     const unknown: MutationEvent = {
-      ...accepted,
+      ...acceptedWithoutBrokerOrderId,
       eventId: '4'.repeat(64),
       mutationId: '5'.repeat(64),
       eventType: MutationEventType.SubmitUnknown,
-      brokerOrderId: undefined,
     }
     const cancelAccepted: MutationEvent = {
       ...accepted,

--- a/services/bayn/src/observe-composition.ts
+++ b/services/bayn/src/observe-composition.ts
@@ -767,10 +767,8 @@ function buildCycleDecision<R>(
         input,
         facts,
         compiled,
-        authorityRequirement === Authority.Paper
-          ? {
-              allocationCapitalMicros: allocationCapitalMicros?.toString(),
-            }
+        authorityRequirement === Authority.Paper && allocationCapitalMicros !== undefined
+          ? { allocationCapitalMicros: allocationCapitalMicros.toString() }
           : {},
       ),
     )
@@ -1510,8 +1508,10 @@ const executeBoundPaperCycle = (
       paperMutationSubmissionAllowed({
         capability: capability._tag,
         closeOnly,
-        paperEpisodeCutoffAt: input.paperEpisodeCutoffAt,
-        paperEpisodeCloseSubmitCutoffAt: input.paperEpisodeCloseSubmitCutoffAt,
+        ...(input.paperEpisodeCutoffAt === undefined ? {} : { paperEpisodeCutoffAt: input.paperEpisodeCutoffAt }),
+        ...(input.paperEpisodeCloseSubmitCutoffAt === undefined
+          ? {}
+          : { paperEpisodeCloseSubmitCutoffAt: input.paperEpisodeCloseSubmitCutoffAt }),
         observedAt,
       }),
     )

--- a/services/bayn/src/observe-composition/mutation-intent-interpreter.ts
+++ b/services/bayn/src/observe-composition/mutation-intent-interpreter.ts
@@ -488,7 +488,7 @@ export const prepareMutationIntent = <R, E, I extends MutationIntentInput, P ext
         case 'SkipTerminal':
           terminalEvidence.push({
             state: record.intent.state,
-            terminalOutcome: record.intent.terminalOutcome,
+            ...(record.intent.terminalOutcome === undefined ? {} : { terminalOutcome: record.intent.terminalOutcome }),
             updatedAt: record.updatedAt,
             ...(latest === undefined ? {} : { latestMutationAt: latest.occurredAt }),
           })

--- a/services/bayn/src/protocol.test.ts
+++ b/services/bayn/src/protocol.test.ts
@@ -175,7 +175,7 @@ describe('strategy protocol', () => {
 
     for (const path of requiredPaths) {
       const document: Record<string, unknown> = structuredClone(defaultProtocolDocument)
-      let parent = document.executionModel as Record<string, unknown>
+      let parent = document['executionModel'] as Record<string, unknown>
       for (const segment of path.slice(0, -1)) parent = parent[segment] as Record<string, unknown>
       const key = path.at(-1)
       if (key === undefined) throw new Error('execution path cannot be empty')

--- a/services/bayn/src/qualification-audit.test.ts
+++ b/services/bayn/src/qualification-audit.test.ts
@@ -346,10 +346,10 @@ const replaceFirstItem = (
   payload: Readonly<Record<string, unknown>>,
   patch: Readonly<Record<string, unknown>>,
 ): unknown => {
-  if (!Array.isArray(payload.items) || typeof payload.items[0] !== 'object' || payload.items[0] === null) {
+  if (!Array.isArray(payload['items']) || typeof payload['items'][0] !== 'object' || payload['items'][0] === null) {
     throw new Error('fixture artifact has no object item')
   }
-  return { ...payload, items: [{ ...payload.items[0], ...patch }, ...payload.items.slice(1)] }
+  return { ...payload, items: [{ ...payload['items'][0], ...patch }, ...payload['items'].slice(1)] }
 }
 
 describe('qualification audit', () => {

--- a/services/bayn/src/qualification-statistics/policy.ts
+++ b/services/bayn/src/qualification-statistics/policy.ts
@@ -100,7 +100,10 @@ export const makeQualificationStatisticsPolicy = ({
   walkForward,
 }: QualificationStatisticsPolicyOptions): QualificationStatisticsPolicyResult =>
   Result.map(
-    validateQualificationStatisticsPolicyOptions({ maximumCandidateOrdinal, walkForward }),
+    validateQualificationStatisticsPolicyOptions({
+      maximumCandidateOrdinal,
+      ...(walkForward === undefined ? {} : { walkForward }),
+    }),
     ({ testSessions, minimumFolds }) => ({
       schemaVersion: qualificationStatisticsPolicySchemaVersion,
       annualizationSessions: 252,

--- a/services/bayn/src/reconciler.test.ts
+++ b/services/bayn/src/reconciler.test.ts
@@ -289,7 +289,10 @@ describe('reconciliation pure decisions', () => {
         observedAt: undefined,
       },
       500,
-      { value: [{ ...firstOrder, submittedAt: undefined }], evidence: orderPageEvidence },
+      {
+        value: [(({ submittedAt: _submittedAt, ...orderWithoutSubmittedAt }) => orderWithoutSubmittedAt)(firstOrder)],
+        evidence: orderPageEvidence,
+      },
     )
     expect(missingTimestamp).toMatchObject({
       _tag: 'Failure',
@@ -490,7 +493,9 @@ describe('paper reconciliation loop', () => {
   })
 
   test('fails closed before persistence when an order omits submitted_at', async () => {
-    const pendingOrder = { ...order(0), submittedAt: undefined }
+    const pendingOrder = (({ submittedAt: _submittedAt, ...orderWithoutSubmittedAt }) => orderWithoutSubmittedAt)(
+      order(0),
+    )
     const read: BrokerReadShape = {
       ...emptyRead(),
       orders: () => Effect.succeed({ value: [pendingOrder], evidence: evidence('orders') }),

--- a/services/bayn/src/reconciliation.test.ts
+++ b/services/bayn/src/reconciliation.test.ts
@@ -81,7 +81,7 @@ const fill: Fill = {
   fillId: 'fill-1',
   brokerOrderId: order.brokerOrderId,
   clientOrderId: order.clientOrderId,
-  intentId: order.intentId,
+  ...(order.intentId === undefined ? {} : { intentId: order.intentId }),
   symbol: order.symbol,
   side: order.side,
   quantityMicros: order.quantityMicros,
@@ -117,7 +117,7 @@ const snapshot = (overrides: Partial<ReconciliationSnapshot> = {}): Reconciliati
       side: order.side,
       orderType: OrderType.Market,
       submittedOrderType: OrderType.Limit,
-      submittedLimitPriceMicros: order.limitPriceMicros,
+      ...(order.limitPriceMicros === undefined ? {} : { submittedLimitPriceMicros: order.limitPriceMicros }),
       timeInForce: order.timeInForce,
       quantityMicros: order.quantityMicros,
       state: IntentState.Terminal,
@@ -184,7 +184,7 @@ describe('paper reconciliation', () => {
           side: order.side,
           orderType: OrderType.Market,
           submittedOrderType: OrderType.Limit,
-          submittedLimitPriceMicros: order.limitPriceMicros,
+          ...(order.limitPriceMicros === undefined ? {} : { submittedLimitPriceMicros: order.limitPriceMicros }),
           timeInForce: order.timeInForce,
           quantityMicros: order.quantityMicros,
           state: IntentState.Terminal,
@@ -366,7 +366,12 @@ describe('paper reconciliation', () => {
     const result = successOf(
       compareReconciliation({
         ...input,
-        orders: [{ ...order, orderType: OrderType.Market, limitPriceMicros: undefined }],
+        orders: [
+          (({ limitPriceMicros: _limitPriceMicros, ...marketOrder }) => ({
+            ...marketOrder,
+            orderType: OrderType.Market,
+          }))(order),
+        ],
         intents: input.intents.map(({ submittedLimitPriceMicros: _limit, ...intent }) => ({
           ...intent,
           submittedOrderType: OrderType.Market,

--- a/services/bayn/src/risk.test.ts
+++ b/services/bayn/src/risk.test.ts
@@ -392,7 +392,7 @@ describe('bounded paper risk', () => {
 
     const rawPolicy = { ...makePolicy() }
     const missingPolicy: Record<string, unknown> = { ...rawPolicy }
-    delete missingPolicy.maxOrderNotionalMicros
+    delete missingPolicy['maxOrderNotionalMicros']
     expect(() => decodePolicy(missingPolicy)).toThrow()
     expect(() => decodePolicy({ ...rawPolicy, brokerMode: 'LIVE' })).toThrow()
     expect(() => decodePolicy({ ...rawPolicy, allowedSymbols: ['NVDA', 'AMD'] })).toThrow()
@@ -1016,7 +1016,7 @@ describe('bounded paper risk', () => {
           operation: 'decode-input',
           reason: 'positions',
         })
-        expect(result.failure.facts.issues).toBeArray()
+        expect(result.failure.facts['issues']).toBeArray()
       }
     }
   })
@@ -1037,7 +1037,7 @@ describe('bounded paper risk', () => {
         operation: 'decode-input',
         reason: 'positions',
       })
-      expect(result.failure.facts.issues).toContainEqual({
+      expect(result.failure.facts['issues']).toContainEqual({
         path: ['positions', 0, 'marketValueMicros'],
         issue: 'must have the quantity sign',
       })

--- a/services/bayn/src/shadow-decision.test.ts
+++ b/services/bayn/src/shadow-decision.test.ts
@@ -374,7 +374,7 @@ const makeInput = (
     NVDA: '5000000',
   }
   const riskInputs: ShadowDeltaRiskInput[] =
-    targetWeights.AMD === 0.4 && targetWeights.NVDA === 0.6
+    targetWeights['AMD'] === 0.4 && targetWeights['NVDA'] === 0.6
       ? ['AMD', 'NVDA'].map((symbol) => ({
           symbol,
           notionalLimitMicros: (
@@ -747,7 +747,7 @@ describe('OBSERVE shadow decision', () => {
     expect(failures.every((failure) => failure._tag === 'ShadowDecisionError')).toBe(true)
 
     const cyclic: Record<string, unknown> = {}
-    cyclic.self = cyclic
+    cyclic['self'] = cyclic
     const constructorFailures = [
       makeObserveShadowDecisionDocument(null),
       makeObserveShadowDecisionDocument({}),

--- a/services/bayn/src/shadow-decision.ts
+++ b/services/bayn/src/shadow-decision.ts
@@ -495,9 +495,11 @@ const decodeShadowDecisionContext = (
   if (Result.isFailure(decoded)) return Result.fail(decoded.failure)
   const compiledDecision = compiledDecisionOf(decoded.success.compiledDecision)
   if (Result.isFailure(compiledDecision)) return Result.fail(compiledDecision.failure)
+  const { submissionCutoffAt, ...decodedInput } = decoded.success
   const input: ObserveShadowDecisionInput = {
-    ...decoded.success,
+    ...decodedInput,
     compiledDecision: compiledDecision.success,
+    ...(submissionCutoffAt === undefined ? {} : { submissionCutoffAt }),
   }
   const strategyDecisionHash = hashValue(
     input.compiledDecision,
@@ -607,8 +609,8 @@ const reduceShadowRisk = (
               riskInputs: prepared.riskInputs,
               targetsBySymbol: prepared.targetsBySymbol,
               authority,
-              authorityGenerationHash,
-              replanGenerationHash,
+              ...(authorityGenerationHash === undefined ? {} : { authorityGenerationHash }),
+              ...(replanGenerationHash === undefined ? {} : { replanGenerationHash }),
             }),
       ),
     Result.succeed({

--- a/services/bayn/src/simulation-causality.test.ts
+++ b/services/bayn/src/simulation-causality.test.ts
@@ -151,10 +151,9 @@ describe('live-causal simulation', () => {
       decision: plan('2026-01-02', { AAA: 1, BBB: 0 }),
     }
     const close = (target: SimulationTarget, executionIndex: number): SimulationTarget => ({
-      ...target,
+      signalIndex: target.signalIndex,
       executionIndex,
       weights: { AAA: 0, BBB: 0 },
-      decision: undefined,
       requireDecisionEvidence: false,
       terminalClose: true,
     })
@@ -167,10 +166,9 @@ describe('live-causal simulation', () => {
 
   test('replaces a final non-flat target with the terminal close instead of a same-session round trip', () => {
     const close = (target: SimulationTarget, executionIndex: number): SimulationTarget => ({
-      ...target,
+      signalIndex: target.signalIndex,
       executionIndex,
       weights: { AAA: 0, BBB: 0 },
-      decision: undefined,
       requireDecisionEvidence: false,
       terminalClose: true,
     })

--- a/services/bayn/src/simulation-reconciliation/broker-normalization.ts
+++ b/services/bayn/src/simulation-reconciliation/broker-normalization.ts
@@ -113,9 +113,15 @@ const normalizeFills = (
       return mapObservationFailure(
         'fill',
         observed.value.activityId,
-        fillObservation(observed.value, order, observed.evidence, {
-          intentId: Option.getOrUndefined(HashMap.get(intentByClient, order.clientOrderId)),
-        }),
+        fillObservation(
+          observed.value,
+          order,
+          observed.evidence,
+          Option.match(HashMap.get(intentByClient, order.clientOrderId), {
+            onNone: () => ({}),
+            onSome: (intentId) => ({ intentId }),
+          }),
+        ),
       )
     }),
   )

--- a/services/bayn/src/simulation/simulate.ts
+++ b/services/bayn/src/simulation/simulate.ts
@@ -270,7 +270,7 @@ export const simulate = (
   const input = {
     sessions,
     targets,
-    terminalCloseTarget,
+    ...(terminalCloseTarget === undefined ? {} : { terminalCloseTarget }),
     startIndex,
     protocol,
     costMultiplierMicros,

--- a/services/bayn/src/startup/decisions.ts
+++ b/services/bayn/src/startup/decisions.ts
@@ -520,7 +520,6 @@ export const qualifyEvaluation = (
 }
 
 export const evaluatedCompletion = (
-  strategy: StrategyRuntimeInput,
   provenance: RuntimeProvenance,
   evidence: EvaluationEvidence,
   persistence: PersistenceReceipt,

--- a/services/bayn/src/startup/program.ts
+++ b/services/bayn/src/startup/program.ts
@@ -214,11 +214,7 @@ const persistEvaluation = (
     workflow.config.operationTimeoutMs,
     'database',
     'persist-evaluation',
-  ).pipe(
-    Effect.map((persistence) =>
-      evaluatedCompletion(workflow.strategy, workflow.strategy.provenance, evidence, persistence),
-    ),
-  )
+  ).pipe(Effect.map((persistence) => evaluatedCompletion(workflow.strategy.provenance, evidence, persistence)))
 
 const evaluateAcquiredQualification = (
   workflow: EvaluationWorkflow,

--- a/services/bayn/src/strategy/evaluation-runner.ts
+++ b/services/bayn/src/strategy/evaluation-runner.ts
@@ -72,15 +72,15 @@ const strategyTargets = <TMarket, TFailure extends StrategyDecisionFailure, TTar
       pipe(
         application.contextAtSignal(sessions, signalIndex),
         Result.flatMap((context) => application.definition.decide(context)),
-        Result.map(
-          (target): SimulationTarget => ({
+        Result.map((target): SimulationTarget => {
+          const decision = decisionPlanFromTarget(target)
+          return {
             signalIndex,
             executionIndex: signalIndex + 1,
             weights: target.targetWeights,
-            decision: decisionPlanFromTarget(target),
-            requireDecisionEvidence: decisionPlanFromTarget(target) === undefined ? false : undefined,
-          }),
-        ),
+            ...(decision === undefined ? { requireDecisionEvidence: false } : { decision }),
+          }
+        }),
       ),
     ),
   )
@@ -94,9 +94,9 @@ const closeStrategyTarget = <TMarket, TFailure extends StrategyDecisionFailure, 
       ? Object.fromEntries(Object.keys(target.weights).map((symbol) => [symbol, 0]))
       : application.closeTarget(target.decision as unknown as TTarget).targetWeights
   return {
-    ...target,
+    signalIndex: target.signalIndex,
+    executionIndex: target.executionIndex,
     weights: closedWeights,
-    decision: undefined,
     requireDecisionEvidence: false,
     terminalClose: true,
   }

--- a/services/bayn/tsconfig.json
+++ b/services/bayn/tsconfig.json
@@ -3,6 +3,19 @@
   "compilerOptions": {
     "noEmit": true,
     "strict": true,
+    "allowUnreachableCode": false,
+    "allowUnusedLabels": false,
+    "exactOptionalPropertyTypes": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noUncheckedSideEffectImports": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "verbatimModuleSyntax": true,
     "types": ["bun", "node"],
     "plugins": [
       {


### PR DESCRIPTION
## Summary

- enables the strict TypeScript compiler options that were still missing from Bayn, including exact optional properties, isolated modules, exhaustive returns, override checks, and side-effect import checks
- updates existing domain objects and test fixtures to preserve their exact runtime shapes under the stricter contracts
- keeps this as the first focused refactor layer above the Effect TSGo toolchain PR

## Related Issues

None

## Testing

- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn test`
- `bun run --filter @proompteng/bayn build`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
