### PR TITLE
refactor(bayn): check every production index access

### DIFF
--- a/nix/images/bayn.nix
+++ b/nix/images/bayn.nix
@@ -21,8 +21,8 @@ let
   buildDefine = name: value: "--define ${name}=${lib.escapeShellArg (builtins.toJSON value)}";
   dependencySource = import ./bun-workspace-deps-source.nix { inherit lib repoRoot; };
   depsHash = {
-    x86_64-linux = "sha256-jaeixE6zSL/K3OhIM9lo4FljP+ANiCI1LFkfTkSTr3E=";
-    aarch64-linux = "sha256-pnehq1SsO8bj40GoJJ5sDIgYTXwDTL4Qtnu9aIbnLdE=";
+    x86_64-linux = "sha256-u91uWXdvRLtCVhhtiCV0JC0b7cybEC6IzTZ6HWa+a7M=";
+    aarch64-linux = "sha256-eiKVvu8pc++x+yvYGHWVoxEnNGFq1MeVV4tJxth2nPM=";
   };
   buildCommands = [
     "bun --cwd=services/bayn run tsc"

--- a/services/bayn/package.json
+++ b/services/bayn/package.json
@@ -15,7 +15,9 @@
     "test:broker-sandbox": "bun test src/broker-sandbox-contract.test.ts",
     "test:effect-runtime": "bun test src/clickhouse-patch.test.ts src/effect-runtime-compatibility.test.ts",
     "test:postgres": "bun test src/db/cycle-observability.integration.test.ts && bun test src/db/evidence-store.integration.test.ts && bun test src/db/paper-store.integration.test.ts && bun test src/db/cycle-store/integration.test.ts",
-    "tsc": "find ../../node_modules/.bun -path '*/@effect/tsgo-*/lib/tsc*' -type f ! -name '*.json' -exec chmod +x {} + 2>/dev/null || true; \"$(bun node_modules/@effect/tsgo/dist/effect-tsgo.js get-exe-path)\" --noEmit --project tsconfig.json"
+    "tsc": "bun run tsc:all && bun run tsc:production",
+    "tsc:all": "find ../../node_modules/.bun -path '*/@effect/tsgo-*/lib/tsc*' -type f ! -name '*.json' -exec chmod +x {} + 2>/dev/null || true; \"$(bun node_modules/@effect/tsgo/dist/effect-tsgo.js get-exe-path)\" --noEmit --project tsconfig.json",
+    "tsc:production": "\"$(bun node_modules/@effect/tsgo/dist/effect-tsgo.js get-exe-path)\" --noEmit --project tsconfig.production.json"
   },
   "dependencies": {
     "@clickhouse/client": "1.23.1",

--- a/services/bayn/src/audit/reference.ts
+++ b/services/bayn/src/audit/reference.ts
@@ -156,14 +156,18 @@ const evaluateReferenceWithWork = (
   const sessions = sessionsResult.success
   const dates = sessions.map((session) => session.date)
   const requiredHistory = riskBalancedHistoryLength(protocol)
-  const eligibleSignals = monthEnds(dates).filter(
-    (index) =>
-      index >= requiredHistory &&
-      index < dates.length - 1 &&
-      dates[index - requiredHistory] >= manifest.bounds.lookbackStart &&
-      dates[index + 1] >= manifest.bounds.evaluationStart &&
-      dates[index + 1] <= manifest.bounds.evaluationEnd,
-  )
+  const eligibleSignals = monthEnds(dates).filter((index) => {
+    if (index < requiredHistory || index >= dates.length - 1) return false
+    const firstHistoryDate = dates.at(index - requiredHistory)
+    const executionDate = dates.at(index + 1)
+    return (
+      firstHistoryDate !== undefined &&
+      executionDate !== undefined &&
+      firstHistoryDate >= manifest.bounds.lookbackStart &&
+      executionDate >= manifest.bounds.evaluationStart &&
+      executionDate <= manifest.bounds.evaluationEnd
+    )
+  })
   const firstEligibleSignal = eligibleSignals[0]
   if (firstEligibleSignal === undefined) {
     return Result.fail({

--- a/services/bayn/src/audit/reference/decisions.ts
+++ b/services/bayn/src/audit/reference/decisions.ts
@@ -107,8 +107,10 @@ export const align = (
 
 export const monthEnds = (dates: readonly IsoDate[]): readonly number[] => {
   const result: number[] = []
-  for (let index = 0; index < dates.length - 1; index += 1) {
-    if (dates[index].slice(0, 7) !== dates[index + 1].slice(0, 7)) result.push(index)
+  for (const [index, date] of dates.entries()) {
+    const nextDate = dates.at(index + 1)
+    if (nextDate === undefined) break
+    if (date.slice(0, 7) !== nextDate.slice(0, 7)) result.push(index)
   }
   return result
 }
@@ -126,24 +128,24 @@ const allocateCapped = (
       .map((symbol) => [symbol, 0]),
   )
   let unallocated = 1
-  let available = Object.keys(scores)
-    .filter((symbol) => scores[symbol] > 0)
-    .sort()
+  let available = Object.entries(scores)
+    .filter(([, score]) => score > 0)
+    .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
 
   while (available.length > 0 && unallocated > 0) {
-    const availableScore = available.reduce((total, symbol) => total + scores[symbol], 0)
+    const availableScore = available.reduce((total, [, score]) => total + score, 0)
     if (!Number.isFinite(availableScore) || availableScore <= 0) break
-    const exceedsCap = available.filter((symbol) => (unallocated * scores[symbol]) / availableScore > maximumWeight)
+    const exceedsCap = available.filter(([, score]) => (unallocated * score) / availableScore > maximumWeight)
     if (exceedsCap.length === 0) {
-      for (const symbol of available) weights[symbol] = (unallocated * scores[symbol]) / availableScore
+      for (const [symbol, score] of available) weights[symbol] = (unallocated * score) / availableScore
       break
     }
-    for (const symbol of exceedsCap) {
+    for (const [symbol] of exceedsCap) {
       weights[symbol] = maximumWeight
       unallocated = Math.max(0, unallocated - maximumWeight)
     }
-    const allocated = new Set(exceedsCap)
-    available = available.filter((symbol) => !allocated.has(symbol))
+    const allocated = new Set(exceedsCap.map(([symbol]) => symbol))
+    available = available.filter(([symbol]) => !allocated.has(symbol))
   }
 
   return weights
@@ -157,8 +159,9 @@ const quantizeCappedWeights = (
 ): ReferenceComputation<Readonly<Record<string, number>>> => {
   const maximumUnits = Math.floor(maximumWeight * weightScale + Number.EPSILON)
   const units: Record<string, number> = {}
-  for (const symbol of Object.keys(weights).sort()) {
-    const weight = weights[symbol]
+  for (const [symbol, weight] of Object.entries(weights).sort(([left], [right]) =>
+    left < right ? -1 : left > right ? 1 : 0,
+  )) {
     if (!Number.isFinite(weight) || weight < 0) {
       return Result.fail({ _tag: 'ReferenceInvalidWeight', symbol, weight, maximumWeight })
     }
@@ -168,8 +171,10 @@ const quantizeCappedWeights = (
   let excess = Math.max(0, total - weightScale)
   for (const symbol of Object.keys(units).sort().reverse()) {
     if (excess === 0) break
-    const reduction = Math.min(units[symbol], excess)
-    units[symbol] -= reduction
+    const currentUnits = units[symbol]
+    if (currentUnits === undefined) continue
+    const reduction = Math.min(currentUnits, excess)
+    units[symbol] = currentUnits - reduction
     excess -= reduction
     total -= reduction
   }
@@ -187,9 +192,19 @@ const sampleCovariance = (left: readonly number[], right: readonly number[]): Re
   }
   const leftAverage = average(left)
   const rightAverage = average(right)
-  const value =
-    left.reduce((total, observation, index) => total + (observation - leftAverage) * (right[index] - rightAverage), 0) /
-    (left.length - 1)
+  let covarianceTotal = 0
+  for (const [index, observation] of left.entries()) {
+    const rightObservation = right.at(index)
+    if (rightObservation === undefined) {
+      return Result.fail({
+        _tag: 'ReferenceCovarianceInputMismatch',
+        leftLength: left.length,
+        rightLength: right.length,
+      })
+    }
+    covarianceTotal += (observation - leftAverage) * (rightObservation - rightAverage)
+  }
+  const value = covarianceTotal / (left.length - 1)
   if (!Number.isFinite(value)) {
     return Result.fail({
       _tag: 'ReferenceCovarianceNotFinite',
@@ -208,11 +223,19 @@ const portfolioVolatility = (
   const symbols = Object.keys(weights).sort()
   let dailyVariance = 0
   for (const left of symbols) {
+    const leftReturns = returns[left]
+    const leftWeight = weights[left]
+    if (leftReturns === undefined) return Result.fail({ _tag: 'ReferenceMissingSymbolSeries', symbol: left })
+    if (leftWeight === undefined) return Result.fail({ _tag: 'ReferenceMissingWeight', symbol: left })
     let innerVariance = 0
     for (const right of symbols) {
-      const covariance = sampleCovariance(returns[left], returns[right])
+      const rightReturns = returns[right]
+      const rightWeight = weights[right]
+      if (rightReturns === undefined) return Result.fail({ _tag: 'ReferenceMissingSymbolSeries', symbol: right })
+      if (rightWeight === undefined) return Result.fail({ _tag: 'ReferenceMissingWeight', symbol: right })
+      const covariance = sampleCovariance(leftReturns, rightReturns)
       if (Result.isFailure(covariance)) return covariance
-      innerVariance += weights[left] * weights[right] * covariance.success
+      innerVariance += leftWeight * rightWeight * covariance.success
     }
     dailyVariance += innerVariance
   }
@@ -249,31 +272,42 @@ export const riskBalancedDecisionPlan = (
   const returnsBySymbol: Record<string, readonly number[]> = {}
   const baseSignals: DecisionPlan['signals'][number][] = []
   for (const symbol of protocol.universe) {
-    const closes = history.map((session) => session.bars[symbol].close)
-    const invalidCloseIndex = closes.findIndex((close) => !Number.isFinite(close) || close <= 0)
-    if (invalidCloseIndex !== -1) {
-      return Result.fail({
-        _tag: 'ReferenceInvalidClose',
-        symbol,
-        sessionDate: history[invalidCloseIndex].date,
-        close: closes[invalidCloseIndex],
-      })
+    const closes: number[] = []
+    for (const session of history) {
+      const bar = session.bars[symbol]
+      if (bar === undefined) {
+        return Result.fail({
+          _tag: 'ReferenceIncompleteSession',
+          sessionDate: session.date,
+          missingSymbols: [symbol],
+          actualSymbolCount: Object.keys(session.bars).length,
+          expectedSymbolCount: protocol.universe.length,
+        })
+      }
+      if (!Number.isFinite(bar.close) || bar.close <= 0) {
+        return Result.fail({ _tag: 'ReferenceInvalidClose', symbol, sessionDate: session.date, close: bar.close })
+      }
+      closes.push(bar.close)
     }
     const current = closes.at(-1)
     if (current === undefined) {
       return Result.fail({ _tag: 'ReferenceMissingCurrentClose', symbol, signalIndex })
     }
     const volatilityCloses = closes.slice(-(protocol.volatilityWindow + 1))
-    const recentReturns = volatilityCloses.slice(1).map((close, index) => close / volatilityCloses[index] - 1)
-    const invalidReturnIndex = recentReturns.findIndex((value) => !Number.isFinite(value))
-    if (invalidReturnIndex !== -1) {
-      const firstVolatilitySessionIndex = history.length - volatilityCloses.length
-      return Result.fail({
-        _tag: 'ReferenceInvalidReturn',
-        symbol,
-        sessionDate: history[firstVolatilitySessionIndex + invalidReturnIndex + 1].date,
-        value: recentReturns[invalidReturnIndex],
-      })
+    const recentReturns: number[] = []
+    const firstVolatilitySessionIndex = history.length - volatilityCloses.length
+    for (let index = 1; index < volatilityCloses.length; index += 1) {
+      const close = volatilityCloses.at(index)
+      const priorClose = volatilityCloses.at(index - 1)
+      const session = history.at(firstVolatilitySessionIndex + index)
+      if (close === undefined || priorClose === undefined || session === undefined) {
+        return Result.fail({ _tag: 'ReferenceMissingPriorClose', symbol, signalIndex, horizonSessions: index })
+      }
+      const value = close / priorClose - 1
+      if (!Number.isFinite(value)) {
+        return Result.fail({ _tag: 'ReferenceInvalidReturn', symbol, sessionDate: session.date, value })
+      }
+      recentReturns.push(value)
     }
     returnsBySymbol[symbol] = recentReturns
     const dailyVolatility = sampleDeviation(recentReturns)
@@ -344,7 +378,7 @@ export const riskBalancedDecisionPlan = (
   const scores = Object.fromEntries(baseSignals.map((signal) => [signal.symbol, signal.positiveScore]))
   const scoreTotal = Object.values(scores).reduce((total, score) => total + score, 0)
   const uncappedWeights = Object.fromEntries(
-    protocol.universe.map((symbol) => [symbol, scoreTotal === 0 ? 0 : scores[symbol] / scoreTotal]),
+    baseSignals.map((signal) => [signal.symbol, scoreTotal === 0 ? 0 : signal.positiveScore / scoreTotal]),
   )
   const cappedWeightsResult = quantizeCappedWeights(
     allocateCapped(scores, protocol.maximumSymbolWeight),
@@ -359,8 +393,14 @@ export const riskBalancedDecisionPlan = (
     estimatedAnnualizedPortfolioVolatility === 0
       ? 1
       : Math.min(1, protocol.maximumPortfolioVolatility / estimatedAnnualizedPortfolioVolatility)
+  const scaledWeightEntries: Array<readonly [string, number]> = []
+  for (const symbol of protocol.universe) {
+    const cappedWeight = cappedWeights[symbol]
+    if (cappedWeight === undefined) return Result.fail({ _tag: 'ReferenceMissingWeight', symbol })
+    scaledWeightEntries.push([symbol, cappedWeight * exposureScale])
+  }
   const targetWeightsResult = quantizeCappedWeights(
-    Object.fromEntries(protocol.universe.map((symbol) => [symbol, cappedWeights[symbol] * exposureScale])),
+    Object.fromEntries(scaledWeightEntries),
     protocol.maximumSymbolWeight,
   )
   if (Result.isFailure(targetWeightsResult)) return Result.fail(targetWeightsResult.failure)
@@ -410,6 +450,21 @@ export const riskBalancedDecisionPlan = (
   }
   const sessionsHash = hashReferenceMaterial('covariance-sessions', covarianceDates)
   if (Result.isFailure(sessionsHash)) return Result.fail(sessionsHash.failure)
+  const signals: DecisionPlan['signals'][number][] = []
+  for (const signal of baseSignals) {
+    const uncappedWeight = uncappedWeights[signal.symbol]
+    const cappedWeight = cappedWeights[signal.symbol]
+    const targetWeight = targetWeights[signal.symbol]
+    if (uncappedWeight === undefined || cappedWeight === undefined || targetWeight === undefined) {
+      return Result.fail({ _tag: 'ReferenceMissingWeight', symbol: signal.symbol })
+    }
+    signals.push({
+      ...signal,
+      uncappedWeight: roundWeight(uncappedWeight),
+      cappedWeight,
+      targetWeight,
+    })
+  }
   return Result.succeed({
     schemaVersion: 'bayn.risk-balanced-trend-decision-plan.v1',
     signalDate: signalSession.date,
@@ -422,12 +477,7 @@ export const riskBalancedDecisionPlan = (
     estimatedAnnualizedPortfolioVolatility,
     exposureScale,
     targetWeights,
-    signals: baseSignals.map((signal) => ({
-      ...signal,
-      uncappedWeight: roundWeight(uncappedWeights[signal.symbol]),
-      cappedWeight: cappedWeights[signal.symbol],
-      targetWeight: targetWeights[signal.symbol],
-    })),
+    signals,
   })
 }
 
@@ -456,15 +506,24 @@ export const directVolatilityTarget = (
         sessionCount: sessions.length,
       })
     }
-    const returns = protocol.universe.map((symbol) => session.bars[symbol].close / priorSession.bars[symbol].close - 1)
-    const invalidReturnIndex = returns.findIndex((value) => !Number.isFinite(value))
-    if (invalidReturnIndex !== -1) {
-      return Result.fail({
-        _tag: 'ReferenceInvalidReturn',
-        symbol: protocol.universe[invalidReturnIndex],
-        sessionDate: session.date,
-        value: returns[invalidReturnIndex],
-      })
+    const returns: number[] = []
+    for (const symbol of protocol.universe) {
+      const bar = session.bars[symbol]
+      const priorBar = priorSession.bars[symbol]
+      if (bar === undefined || priorBar === undefined) {
+        return Result.fail({
+          _tag: 'ReferenceIncompleteSession',
+          sessionDate: bar === undefined ? session.date : priorSession.date,
+          missingSymbols: [symbol],
+          actualSymbolCount: Object.keys(bar === undefined ? session.bars : priorSession.bars).length,
+          expectedSymbolCount: protocol.universe.length,
+        })
+      }
+      const value = bar.close / priorBar.close - 1
+      if (!Number.isFinite(value)) {
+        return Result.fail({ _tag: 'ReferenceInvalidReturn', symbol, sessionDate: session.date, value })
+      }
+      returns.push(value)
     }
     portfolioReturns.push(average(returns))
   }

--- a/services/bayn/src/audit/reference/model.ts
+++ b/services/bayn/src/audit/reference/model.ts
@@ -131,6 +131,22 @@ export type ReferenceEvaluationFailure =
       readonly maximumWeight: number
     }
   | {
+      readonly _tag: 'ReferenceMissingWeight'
+      readonly symbol: string
+    }
+  | {
+      readonly _tag: 'ReferenceMissingPrice'
+      readonly symbol: string
+    }
+  | {
+      readonly _tag: 'ReferenceMissingQuantity'
+      readonly symbol: string
+    }
+  | {
+      readonly _tag: 'ReferenceMissingSymbolSeries'
+      readonly symbol: string
+    }
+  | {
       readonly _tag: 'ReferenceWeightBoundingFailed'
       readonly totalUnits: number
       readonly excessUnits: number
@@ -232,6 +248,11 @@ export type ReferenceEvaluationFailure =
       readonly _tag: 'ReferenceTargetSignalMissing'
       readonly signalIndex: number
       readonly executionIndex: number
+      readonly sessionCount: number
+    }
+  | {
+      readonly _tag: 'ReferenceReplaySessionMissing'
+      readonly sessionIndex: number
       readonly sessionCount: number
     }
   | {

--- a/services/bayn/src/audit/reference/replay-calculations.ts
+++ b/services/bayn/src/audit/reference/replay-calculations.ts
@@ -62,7 +62,12 @@ export const calculateReplayMetrics = (
   const equity = equityMicros.map(microsToNumber)
   const initial = microsToNumber(initialMicros)
   const endingEquity = microsToNumber(endingEquityMicros)
-  const returns = equity.map((value, index) => value / (index === 0 ? initial : equity[index - 1]) - 1)
+  const returns: number[] = []
+  let previousEquity = initial
+  for (const value of equity) {
+    returns.push(value / previousEquity - 1)
+    previousEquity = value
+  }
   const totalReturn = endingEquity / initial - 1
   const annualizedReturn = Math.pow(endingEquity / initial, tradingDays / equity.length) - 1
   const annualizedVolatility = sampleDeviation(returns) * Math.sqrt(tradingDays)
@@ -201,12 +206,22 @@ export const replayPrices = (
 ): ReferenceComputation<Readonly<Record<string, bigint>>> =>
   pipe(
     Result.all(
-      protocol.universe.map((symbol) =>
-        pipe(
-          referencePriceMicros(price(session.bars[symbol]), protocol.executionModel),
+      protocol.universe.map((symbol) => {
+        const bar = session.bars[symbol]
+        if (bar === undefined) {
+          return Result.fail({
+            _tag: 'ReferenceIncompleteSession' as const,
+            sessionDate: session.date,
+            missingSymbols: [symbol],
+            actualSymbolCount: Object.keys(session.bars).length,
+            expectedSymbolCount: protocol.universe.length,
+          })
+        }
+        return pipe(
+          referencePriceMicros(price(bar), protocol.executionModel),
           Result.map((priceMicros) => [symbol, priceMicros] as const),
-        ),
-      ),
+        )
+      }),
     ),
     Result.map((entries) => Object.fromEntries(entries)),
   )
@@ -215,20 +230,37 @@ export const replayPositionValue = (
   prices: Readonly<Record<string, bigint>>,
   positions: ReadonlyMap<string, Position>,
   protocol: SimulationProtocol,
-): ReferenceComputation<bigint> =>
-  protocol.universe.reduce<ReferenceComputation<bigint>>(
-    (total, symbol) =>
-      pipe(
-        total,
-        Result.flatMap((value) =>
-          pipe(
-            notionalMicros(positions.get(symbol)?.quantityMicros ?? 0n, prices[symbol]),
-            Result.map((notional) => value + notional),
-          ),
-        ),
-      ),
-    Result.succeed(0n),
-  )
+): ReferenceComputation<bigint> => {
+  let total = 0n
+  for (const symbol of protocol.universe) {
+    const priceMicros = prices[symbol]
+    if (priceMicros === undefined) return Result.fail({ _tag: 'ReferenceMissingPrice', symbol })
+    const notional = notionalMicros(positions.get(symbol)?.quantityMicros ?? 0n, priceMicros)
+    if (Result.isFailure(notional)) return Result.fail(notional.failure)
+    total += notional.success
+  }
+  return Result.succeed(total)
+}
+
+export const replayPriceFor = (
+  prices: Readonly<Record<string, bigint>>,
+  symbol: string,
+): ReferenceComputation<bigint> => {
+  const priceMicros = prices[symbol]
+  return priceMicros === undefined
+    ? Result.fail({ _tag: 'ReferenceMissingPrice', symbol })
+    : Result.succeed(priceMicros)
+}
+
+export const replayQuantityFor = (
+  quantities: Readonly<Record<string, bigint>>,
+  symbol: string,
+): ReferenceComputation<bigint> => {
+  const quantityMicros = quantities[symbol]
+  return quantityMicros === undefined
+    ? Result.fail({ _tag: 'ReferenceMissingQuantity', symbol })
+    : Result.succeed(quantityMicros)
+}
 
 export const replayDesiredQuantities = (
   equityMicros: bigint,
@@ -238,12 +270,16 @@ export const replayDesiredQuantities = (
 ): ReferenceComputation<Readonly<Record<string, bigint>>> =>
   pipe(
     Result.all(
-      protocol.universe.map((symbol) =>
-        pipe(
-          desiredQuantityMicros(equityMicros, weights[symbol], prices[symbol], protocol.executionModel),
+      protocol.universe.map((symbol) => {
+        const weight = weights[symbol]
+        if (weight === undefined) return Result.fail({ _tag: 'ReferenceMissingWeight' as const, symbol })
+        const priceMicros = prices[symbol]
+        if (priceMicros === undefined) return Result.fail({ _tag: 'ReferenceMissingPrice' as const, symbol })
+        return pipe(
+          desiredQuantityMicros(equityMicros, weight, priceMicros, protocol.executionModel),
           Result.map((quantityMicros) => [symbol, quantityMicros] as const),
-        ),
-      ),
+        )
+      }),
     ),
     Result.map((entries) => Object.fromEntries(entries)),
   )
@@ -260,43 +296,23 @@ const replayBuyFeeInputs = (
   protocol: SimulationProtocol,
   costMultiplierMicros: bigint,
   minimumNotionalMicros?: bigint,
-): ReferenceComputation<readonly FeeInput[]> =>
-  buys.reduce<ReferenceComputation<readonly FeeInput[]>>(
-    (result, buy) =>
-      pipe(
-        result,
-        Result.flatMap((inputs) =>
-          pipe(
-            scaleQuantityMicros(buy.quantityMicros, scalePpm, protocol.executionModel),
-            Result.flatMap((quantityMicros) => {
-              if (quantityMicros === 0n) return Result.succeed(inputs)
-              return pipe(
-                notionalMicros(quantityMicros, prices[buy.symbol]),
-                Result.flatMap((referenceNotionalMicros) => {
-                  if (minimumNotionalMicros !== undefined && referenceNotionalMicros < minimumNotionalMicros) {
-                    return Result.succeed(inputs)
-                  }
-                  return pipe(
-                    makeFillTerms(
-                      'buy',
-                      quantityMicros,
-                      prices[buy.symbol],
-                      protocol.executionModel,
-                      costMultiplierMicros,
-                    ),
-                    Result.map((terms) => [
-                      ...inputs,
-                      { side: 'buy' as const, quantityMicros, notionalMicros: terms.notionalMicros },
-                    ]),
-                  )
-                }),
-              )
-            }),
-          ),
-        ),
-      ),
-    Result.succeed([]),
-  )
+): ReferenceComputation<readonly FeeInput[]> => {
+  const inputs: FeeInput[] = []
+  for (const buy of buys) {
+    const quantity = scaleQuantityMicros(buy.quantityMicros, scalePpm, protocol.executionModel)
+    if (Result.isFailure(quantity)) return Result.fail(quantity.failure)
+    if (quantity.success === 0n) continue
+    const priceMicros = prices[buy.symbol]
+    if (priceMicros === undefined) return Result.fail({ _tag: 'ReferenceMissingPrice', symbol: buy.symbol })
+    const referenceNotional = notionalMicros(quantity.success, priceMicros)
+    if (Result.isFailure(referenceNotional)) return Result.fail(referenceNotional.failure)
+    if (minimumNotionalMicros !== undefined && referenceNotional.success < minimumNotionalMicros) continue
+    const terms = makeFillTerms('buy', quantity.success, priceMicros, protocol.executionModel, costMultiplierMicros)
+    if (Result.isFailure(terms)) return Result.fail(terms.failure)
+    inputs.push({ side: 'buy', quantityMicros: quantity.success, notionalMicros: terms.success.notionalMicros })
+  }
+  return Result.succeed(inputs)
+}
 
 export const replayBuysFitCash = (
   buys: readonly ReferenceBuyCandidate[],

--- a/services/bayn/src/audit/reference/replay.ts
+++ b/services/bayn/src/audit/reference/replay.ts
@@ -32,8 +32,10 @@ import {
   makeReferenceOrder,
   replayBuysFitCash,
   replayDesiredQuantities,
+  replayPriceFor,
   replayPositionValue,
   replayPrices,
+  replayQuantityFor,
   restrictReferenceBuyFill,
 } from './replay-calculations'
 
@@ -97,7 +99,10 @@ export const replay = (
   const marks: DailyPositionMark[] = []
   const daily: DailyPerformancePoint[] = []
   for (let index = startIndex; index < sessions.length; index += 1) {
-    const session = sessions[index]
+    const session = sessions.at(index)
+    if (session === undefined) {
+      return Result.fail({ _tag: 'ReferenceReplaySessionMissing', sessionIndex: index, sessionCount: sessions.length })
+    }
     const scheduledTarget = targetBySession.get(index)
     const lastTarget = targets.at(-1)
     const beforeTurnover = state.turnoverMicros
@@ -204,20 +209,18 @@ export const replay = (
       const desired = desiredResult.success
       const targetFills: FillEvent[] = []
 
-      const sellPlans = [...protocol.universe]
-        .sort()
-        .map((symbol) => {
-          const held = positions.get(symbol)?.quantityMicros ?? 0n
-          return { symbol, quantityMicros: desired[symbol] < held ? held - desired[symbol] : 0n }
-        })
-        .filter((candidate) => candidate.quantityMicros > 0n)
-      const buyPlans = [...protocol.universe]
-        .sort()
-        .map((symbol) => {
-          const held = positions.get(symbol)?.quantityMicros ?? 0n
-          return { symbol, quantityMicros: desired[symbol] > held ? desired[symbol] - held : 0n }
-        })
-        .filter((candidate) => candidate.quantityMicros > 0n)
+      const sellPlans: Array<{ readonly symbol: string; readonly quantityMicros: bigint }> = []
+      const buyPlans: Array<{ readonly symbol: string; readonly quantityMicros: bigint }> = []
+      for (const symbol of [...protocol.universe].sort()) {
+        const desiredQuantity = replayQuantityFor(desired, symbol)
+        if (Result.isFailure(desiredQuantity)) return Result.fail(desiredQuantity.failure)
+        const held = positions.get(symbol)?.quantityMicros ?? 0n
+        if (desiredQuantity.success < held) {
+          sellPlans.push({ symbol, quantityMicros: held - desiredQuantity.success })
+        } else if (desiredQuantity.success > held) {
+          buyPlans.push({ symbol, quantityMicros: desiredQuantity.success - held })
+        }
+      }
       const minimumBuyNotionalMicros = BigInt(protocol.executionModel.precision.minimumBuyNotionalMicros)
       let acceptedPlanScale = 0n
       let upperPlanScale = ppm
@@ -238,16 +241,18 @@ export const replay = (
       }
       const sellOrdersResult = Result.all(
         sellPlans.map((candidate) =>
-          makeReferenceOrder(
-            runId,
-            decision,
-            session.date,
-            candidate.symbol,
-            'sell',
-            candidate.quantityMicros,
-            fillPrices[candidate.symbol],
-            protocol,
-            terminalClose,
+          Result.flatMap(replayPriceFor(fillPrices, candidate.symbol), (fillPrice) =>
+            makeReferenceOrder(
+              runId,
+              decision,
+              session.date,
+              candidate.symbol,
+              'sell',
+              candidate.quantityMicros,
+              fillPrice,
+              protocol,
+              terminalClose,
+            ),
           ),
         ),
       )
@@ -258,9 +263,13 @@ export const replay = (
         const requested = scaleQuantityMicros(candidate.quantityMicros, acceptedPlanScale, protocol.executionModel)
         if (Result.isFailure(requested)) return Result.fail(requested.failure)
         if (requested.success === 0n) continue
-        const requestedNotional = notionalMicros(requested.success, planPrices[candidate.symbol])
+        const planPrice = replayPriceFor(planPrices, candidate.symbol)
+        if (Result.isFailure(planPrice)) return Result.fail(planPrice.failure)
+        const requestedNotional = notionalMicros(requested.success, planPrice.success)
         if (Result.isFailure(requestedNotional)) return Result.fail(requestedNotional.failure)
         if (requestedNotional.success < minimumBuyNotionalMicros) continue
+        const fillPrice = replayPriceFor(fillPrices, candidate.symbol)
+        if (Result.isFailure(fillPrice)) return Result.fail(fillPrice.failure)
         const simulatedOrder = makeReferenceOrder(
           runId,
           decision,
@@ -268,7 +277,7 @@ export const replay = (
           candidate.symbol,
           'buy',
           requested.success,
-          fillPrices[candidate.symbol],
+          fillPrice.success,
           protocol,
         )
         if (Result.isFailure(simulatedOrder)) return Result.fail(simulatedOrder.failure)
@@ -312,10 +321,12 @@ export const replay = (
         const position = positions.get(simulatedOrder.symbol) ?? { quantityMicros: 0n, costBasisMicros: 0n }
         const quantity = BigInt(simulatedOrder.filledQuantityMicros)
         if (quantity === 0n) continue
+        const fillPrice = replayPriceFor(fillPrices, simulatedOrder.symbol)
+        if (Result.isFailure(fillPrice)) return Result.fail(fillPrice.failure)
         const termsResult = makeFillTerms(
           'sell',
           quantity,
-          fillPrices[simulatedOrder.symbol],
+          fillPrice.success,
           protocol.executionModel,
           costMultiplierMicros,
         )
@@ -348,10 +359,12 @@ export const replay = (
         if (retainTrace) orders.push(simulatedOrder)
         const quantity = BigInt(simulatedOrder.filledQuantityMicros)
         if (quantity === 0n) continue
+        const fillPrice = replayPriceFor(fillPrices, simulatedOrder.symbol)
+        if (Result.isFailure(fillPrice)) return Result.fail(fillPrice.failure)
         const termsResult = makeFillTerms(
           'buy',
           quantity,
-          fillPrices[simulatedOrder.symbol],
+          fillPrice.success,
           protocol.executionModel,
           costMultiplierMicros,
         )
@@ -566,13 +579,15 @@ export const replay = (
       const markedPositions: DailyPositionMark['positions'][number][] = []
       for (const symbol of [...protocol.universe].sort()) {
         const position = positions.get(symbol) ?? { quantityMicros: 0n, costBasisMicros: 0n }
-        const marketValue = notionalMicros(position.quantityMicros, closes[symbol])
+        const close = replayPriceFor(closes, symbol)
+        if (Result.isFailure(close)) return Result.fail(close.failure)
+        const marketValue = notionalMicros(position.quantityMicros, close.success)
         if (Result.isFailure(marketValue)) return Result.fail(marketValue.failure)
         markedPositions.push({
           symbol,
           quantityMicros: position.quantityMicros.toString(),
           costBasisMicros: position.costBasisMicros.toString(),
-          priceMicros: closes[symbol].toString(),
+          priceMicros: close.success.toString(),
           marketValueMicros: marketValue.success.toString(),
         })
       }

--- a/services/bayn/src/broker/alpaca/http.ts
+++ b/services/bayn/src/broker/alpaca/http.ts
@@ -554,15 +554,18 @@ export const make = (connection: BrokerConnection): Effect.Effect<BrokerReadShap
         }),
         Effect.flatMap(({ pageSize, result }) =>
           Effect.fromResult(normalizeFillActivitiesResult(result.value, connection.expectedAccountId)).pipe(
-            Effect.map((items) => ({
-              value: {
-                items,
-                ...(items.length === pageSize && items.length > 0
-                  ? { nextPageToken: items[items.length - 1]?.activityId }
-                  : {}),
-              },
-              evidence: result.evidence,
-            })),
+            Effect.map((items) => {
+              const lastItem = items.at(-1)
+              return {
+                value: {
+                  items,
+                  ...(items.length === pageSize && lastItem !== undefined
+                    ? { nextPageToken: lastItem.activityId }
+                    : {}),
+                },
+                evidence: result.evidence,
+              }
+            }),
             Effect.mapError((cause) =>
               invalidResponse(
                 'fill-activities',

--- a/services/bayn/src/broker/alpaca/model.ts
+++ b/services/bayn/src/broker/alpaca/model.ts
@@ -44,7 +44,19 @@ const Decimal = Schema.String.check(Schema.isPattern(/^(?:0|[1-9][0-9]*)(?:\.[0-
 const isUtcTimestamp = (value: string): boolean => {
   const match = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d{1,9}))?Z$/.exec(value)
   if (match === null) return false
-  const [year, month, day, hour, minute, second] = match.slice(1, 7).map(Number)
+  const components = match.slice(1, 7).map(Number)
+  if (components.length !== 6) return false
+  const [year, month, day, hour, minute, second] = components
+  if (
+    year === undefined ||
+    month === undefined ||
+    day === undefined ||
+    hour === undefined ||
+    minute === undefined ||
+    second === undefined
+  ) {
+    return false
+  }
   const date = new Date(Date.UTC(year, month - 1, day, hour, minute, second))
   return (
     date.getUTCFullYear() === year &&

--- a/services/bayn/src/execution-session.ts
+++ b/services/bayn/src/execution-session.ts
@@ -209,8 +209,8 @@ const validateCalendarRangeAndSignal = (
 }
 
 const validateCalendarSessions = (calendar: CalendarIdentity): Result.Result<void, ExecutionSessionBindingFailure> => {
-  for (let index = 0; index < calendar.sessions.length; index += 1) {
-    const session = calendar.sessions[index]
+  let previousDate: string | undefined
+  for (const [index, session] of calendar.sessions.entries()) {
     if (
       session.date < calendar.requestedRange.start ||
       session.date > calendar.requestedRange.end ||
@@ -226,15 +226,16 @@ const validateCalendarSessions = (calendar: CalendarIdentity): Result.Result<voi
         ),
       )
     }
-    if (index > 0 && calendar.sessions[index - 1].date >= session.date) {
+    if (previousDate !== undefined && previousDate >= session.date) {
       return Result.fail(
         deriveWindowFailure('calendar-order', 'Alpaca market calendar sessions must be unique and strictly ordered', {
           index,
-          previousDate: calendar.sessions[index - 1].date,
+          previousDate,
           date: session.date,
         }),
       )
     }
+    previousDate = session.date
   }
   return Result.succeed(undefined)
 }

--- a/services/bayn/src/execution/contracts.ts
+++ b/services/bayn/src/execution/contracts.ts
@@ -48,7 +48,9 @@ const Version = Schema.Int.check(Schema.isGreaterThan(0))
 const ReasonCodes = Schema.Array(NonEmptyString).check(Schema.isUnique())
 const isStrictlyAscending = (values: ReadonlyArray<string>): boolean => {
   for (let index = 1; index < values.length; index += 1) {
-    if (BigInt(values[index - 1]) >= BigInt(values[index])) return false
+    const previous = values[index - 1]
+    const current = values[index]
+    if (previous === undefined || current === undefined || BigInt(previous) >= BigInt(current)) return false
   }
   return true
 }

--- a/services/bayn/src/execution/intents/domain.ts
+++ b/services/bayn/src/execution/intents/domain.ts
@@ -604,7 +604,8 @@ export const classifyExistingCommit = (
 ): Result.Result<ExistingCommitDisposition, ExistingCommitFailure> => {
   if (records.length === 0) return Result.succeed({ _tag: 'InsertIntent' })
   if (records.length > 1) return Result.fail({ _tag: 'MultipleIntentConflicts', count: records.length })
-  const record = records[0]
+  const [record] = records
+  if (record === undefined) return Result.succeed({ _tag: 'InsertIntent' })
   const storedHash = immutableIntentHashResult(record.intent)
   if (Result.isFailure(storedHash)) return Result.fail(storedHash.failure)
   const requestedHash = immutableIntentHashResult(prepared.intent)
@@ -676,7 +677,8 @@ export const validateCurrentAuthority = (
 > => {
   if (rows.length === 0) return Result.fail({ _tag: 'AuthorityMissing' })
   if (rows.length > 1) return Result.fail({ _tag: 'MultipleAuthorityRows', count: rows.length })
-  const authority = rows[0]
+  const [authority] = rows
+  if (authority === undefined) return Result.fail({ _tag: 'AuthorityMissing' })
   if (authority.maximum !== Authority.Paper) {
     return Result.fail({ _tag: 'MaximumAuthorityNotPaper', observed: authority.maximum })
   }
@@ -723,7 +725,8 @@ export const validateCurrentClosingAuthority = (
   if (intent.side !== 'SELL') return Result.fail({ _tag: 'ClosingIntentMustSell' })
   if (rows.length === 0) return Result.fail({ _tag: 'AuthorityMissing' })
   if (rows.length > 1) return Result.fail({ _tag: 'MultipleAuthorityRows', count: rows.length })
-  const authority = rows[0]
+  const [authority] = rows
+  if (authority === undefined) return Result.fail({ _tag: 'AuthorityMissing' })
   if (authority.maximum !== Authority.Paper) {
     return Result.fail({ _tag: 'MaximumAuthorityNotPaper', observed: authority.maximum })
   }
@@ -785,7 +788,8 @@ export const decideIntentInsert = (
   if (decoded.success.length === 0) {
     return Result.succeed({ _tag: 'IntentInsertConflict', intentId: expectedIntentId })
   }
-  if (decoded.success.length === 1 && decoded.success[0].intent_id === expectedIntentId) {
+  const [inserted] = decoded.success
+  if (decoded.success.length === 1 && inserted?.intent_id === expectedIntentId) {
     return Result.succeed({ _tag: 'IntentInserted', intentId: expectedIntentId })
   }
   return Result.fail({
@@ -804,7 +808,8 @@ export const decideRiskCommit = (
   if (Result.isFailure(decoded)) {
     return Result.fail({ _tag: 'ReturningRowsDecodeFailed', write: 'decision', cause: decoded.failure })
   }
-  if (decoded.success.length === 1 && decoded.success[0].decision_id === expectedDecisionId) {
+  const [inserted] = decoded.success
+  if (decoded.success.length === 1 && inserted?.decision_id === expectedDecisionId) {
     return Result.succeed({ _tag: 'RiskDecisionInserted', decisionId: expectedDecisionId })
   }
   return Result.fail({
@@ -823,7 +828,8 @@ export const decideIntentTransition = (
   if (Result.isFailure(decoded)) {
     return Result.fail({ _tag: 'ReturningRowsDecodeFailed', write: 'transition', cause: decoded.failure })
   }
-  if (decoded.success.length === 1 && decoded.success[0].intent_id === expectedIntentId) {
+  const [transitioned] = decoded.success
+  if (decoded.success.length === 1 && transitioned?.intent_id === expectedIntentId) {
     return Result.succeed({ _tag: 'IntentTransitioned', intentId: expectedIntentId })
   }
   return Result.fail({

--- a/services/bayn/src/ledger/decisions.ts
+++ b/services/bayn/src/ledger/decisions.ts
@@ -31,9 +31,16 @@ const classifyCreateBatch = <Record extends { readonly id: bigint }>(
   }
 
   const existing: Record[] = []
-  for (let index = 0; index < results.length; index += 1) {
-    const result = results[index]
+  for (const [index, result] of results.entries()) {
     const record = records[index]
+    if (record === undefined) {
+      return failLedgerValidation(
+        operation,
+        'batch-result-count',
+        `TigerBeetle returned a ${kind} result without a corresponding record`,
+        { kind, index, expectedCount: records.length, actualCount: results.length },
+      )
+    }
     if (result.outcome === 'created') continue
     if (result.outcome === 'exists') {
       existing.push(record)

--- a/services/bayn/src/observe-composition.ts
+++ b/services/bayn/src/observe-composition.ts
@@ -643,7 +643,16 @@ const reduceRiskInputs = (
   Result.mapError(
     Result.all(
       input.targetPlan.intentTargets.map((target) => {
-        const referencePrice = BigInt(input.prices.priceMicros[target.symbol])
+        const referencePriceMicros = input.prices.priceMicros[target.symbol]
+        if (referencePriceMicros === undefined) {
+          return Result.fail(
+            compositionFailure(
+              'shadow-risk-inputs',
+              `target ${target.symbol} has no bound signal-session reference price`,
+            ),
+          )
+        }
+        const referencePrice = BigInt(referencePriceMicros)
         return Result.map(
           makeFillTerms(
             target.side === OrderSide.Buy ? 'buy' : 'sell',

--- a/services/bayn/src/protocol.ts
+++ b/services/bayn/src/protocol.ts
@@ -119,7 +119,9 @@ const protocolIssues = (
     issues.push({ path: ['evaluationStart'], issue: 'must follow historyStart' })
   }
   for (let index = 1; index < parameters.horizons.length; index += 1) {
-    if (parameters.horizons[index] <= parameters.horizons[index - 1]) {
+    const previous = parameters.horizons[index - 1]
+    const current = parameters.horizons[index]
+    if (previous === undefined || current === undefined || current <= previous) {
       issues.push({ path: ['horizons', index], issue: 'must be unique and strictly increasing' })
       break
     }

--- a/services/bayn/src/risk.ts
+++ b/services/bayn/src/risk.ts
@@ -56,7 +56,9 @@ const BasisPointLimit = Schema.Int.check(Schema.isBetween({ minimum: 0, maximum:
 
 const isSorted = (values: ReadonlyArray<string>): boolean => {
   for (let index = 1; index < values.length; index += 1) {
-    if (values[index - 1] >= values[index]) return false
+    const previous = values[index - 1]
+    const current = values[index]
+    if (previous === undefined || current === undefined || previous >= current) return false
   }
   return true
 }
@@ -297,7 +299,8 @@ export const StateSchema = StateBase.check(
       ['marketDataObservedAt', state.marketDataObservedAt],
     ] as const
     for (const path of timestamps) {
-      const candidate = path[path.length - 1]
+      const candidate = path.at(-1)
+      if (candidate === undefined) continue
       if (timeDoesNotFollow(candidate, state.evaluatedAt)) {
         issues.push({ path: path.slice(0, -1), issue: 'must not follow evaluatedAt' })
       }

--- a/services/bayn/src/schemas.ts
+++ b/services/bayn/src/schemas.ts
@@ -17,8 +17,10 @@ const isUtcInstant = (value: string): boolean => {
 const isUtcOrderTimestamp = (value: string): boolean => {
   const match = /^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})\.(\d{9})Z$/.exec(value)
   if (match === null) return false
-  const date = new Date(`${match[1]}.${match[2].slice(0, 3)}Z`)
-  return !Number.isNaN(date.getTime()) && date.toISOString().slice(0, 19) === match[1]
+  const [, seconds, fractional] = match
+  if (seconds === undefined || fractional === undefined) return false
+  const date = new Date(`${seconds}.${fractional.slice(0, 3)}Z`)
+  return !Number.isNaN(date.getTime()) && date.toISOString().slice(0, 19) === seconds
 }
 
 export const StrictNonEmptyStringSchema = Schema.String.check(

--- a/services/bayn/src/simulation-reconciliation.test.ts
+++ b/services/bayn/src/simulation-reconciliation.test.ts
@@ -237,6 +237,7 @@ type IssueLeaf =
   | 'MissingReference/OrderDecision'
   | 'MissingReference/FillOrder'
   | 'MissingReference/MonetaryEventCashChange'
+  | 'MissingReference/ValidatedMonetaryEvent'
   | 'EvidenceMismatch/OrderExecutionSession'
   | 'EvidenceMismatch/FillBinding'
   | 'EvidenceMismatch/FillQuantity'

--- a/services/bayn/src/simulation-reconciliation/mark-validation.ts
+++ b/services/bayn/src/simulation-reconciliation/mark-validation.ts
@@ -72,7 +72,11 @@ const validateMark = (mark: DailyPositionMark, previous: DailyPositionMark | und
       problem: { _tag: 'DuplicateMarkedPosition', sessionDate: mark.sessionDate, symbols },
     })
   }
-  return symbols.some((symbol, symbolIndex) => symbolIndex > 0 && symbols[symbolIndex - 1] >= symbol)
+  return symbols.some((symbol, symbolIndex) => {
+    if (symbolIndex === 0) return false
+    const previous = symbols[symbolIndex - 1]
+    return previous === undefined || previous >= symbol
+  })
     ? fail({
         _tag: 'InvalidEvidenceState',
         problem: { _tag: 'UnsortedMarkedPositions', sessionDate: mark.sessionDate, symbols },

--- a/services/bayn/src/simulation-reconciliation/model.ts
+++ b/services/bayn/src/simulation-reconciliation/model.ts
@@ -130,6 +130,11 @@ export type MissingReferenceProblem =
       readonly eventId: string
       readonly eventKind: FillEvent['kind'] | FeeEvent['kind'] | CashYieldEvent['kind']
     }
+  | {
+      readonly _tag: 'ValidatedMonetaryEvent'
+      readonly eventId: string
+      readonly eventKind: FillEvent['kind'] | FeeEvent['kind']
+    }
 
 export type EvidenceMismatchProblem =
   | {

--- a/services/bayn/src/simulation-reconciliation/preparation.ts
+++ b/services/bayn/src/simulation-reconciliation/preparation.ts
@@ -230,23 +230,32 @@ const validateMonetaryEvidence = (
                 reversedEvents: Chunk.prepend(accumulator.reversedEvents, { kind: 'cash-yield', event, cashChange }),
               })
             }
-            return event.kind === 'fill'
-              ? Result.succeed({
-                  reversedEvents: Chunk.prepend(accumulator.reversedEvents, {
-                    ...fills[accumulator.fillIndex],
-                    cashChange,
-                  }),
-                  fillIndex: accumulator.fillIndex + 1,
-                  feeIndex: accumulator.feeIndex,
+            if (event.kind === 'fill') {
+              const fill = fills.at(accumulator.fillIndex)
+              if (fill === undefined) {
+                return fail({
+                  _tag: 'MissingReference',
+                  problem: { _tag: 'ValidatedMonetaryEvent', eventId: event.id, eventKind: event.kind },
                 })
-              : Result.succeed({
-                  reversedEvents: Chunk.prepend(accumulator.reversedEvents, {
-                    ...fees[accumulator.feeIndex],
-                    cashChange,
-                  }),
-                  fillIndex: accumulator.fillIndex,
-                  feeIndex: accumulator.feeIndex + 1,
-                })
+              }
+              return Result.succeed({
+                reversedEvents: Chunk.prepend(accumulator.reversedEvents, { ...fill, cashChange }),
+                fillIndex: accumulator.fillIndex + 1,
+                feeIndex: accumulator.feeIndex,
+              })
+            }
+            const fee = fees.at(accumulator.feeIndex)
+            if (fee === undefined) {
+              return fail({
+                _tag: 'MissingReference',
+                problem: { _tag: 'ValidatedMonetaryEvent', eventId: event.id, eventKind: event.kind },
+              })
+            }
+            return Result.succeed({
+              reversedEvents: Chunk.prepend(accumulator.reversedEvents, { ...fee, cashChange }),
+              fillIndex: accumulator.fillIndex,
+              feeIndex: accumulator.feeIndex + 1,
+            })
           }),
         ),
       Result.succeed({ reversedEvents: Chunk.empty(), fillIndex: 0, feeIndex: 0 }),

--- a/services/bayn/src/target-planner/facts.ts
+++ b/services/bayn/src/target-planner/facts.ts
@@ -20,7 +20,11 @@ const WEIGHT_SUM_TOLERANCE = 1e-12
 export const compareText = (left: string, right: string): number => (left < right ? -1 : left > right ? 1 : 0)
 
 const isStrictlySorted = (values: readonly string[]): boolean =>
-  values.every((value, index) => index === 0 || values[index - 1] < value)
+  values.every((value, index) => {
+    if (index === 0) return true
+    const previous = values[index - 1]
+    return previous !== undefined && previous < value
+  })
 
 const sameStrings = (left: readonly string[], right: readonly string[]): boolean =>
   left.length === right.length && left.every((value, index) => value === right[index])
@@ -114,7 +118,7 @@ export const parseTargetPlannerFacts = (input: TargetPlannerInput, hashes: Targe
   const positionQuantities = input.brokerState.positions.map((position) => BigInt(position.quantityMicros))
   const positionMarketValues = input.brokerState.positions.map((position) => BigInt(position.marketValueMicros))
   const positions = new Map(
-    input.brokerState.positions.map((position, index) => [position.symbol, positionQuantities[index]]),
+    input.brokerState.positions.map((position) => [position.symbol, BigInt(position.quantityMicros)] as const),
   )
   const equity = BigInt(input.brokerState.account.equityMicros)
   return {
@@ -230,9 +234,18 @@ export const derivePlannedTargetFacts = (
       (result, [symbol, referencePrice]) =>
         Result.flatMap(result, (targetFacts) => {
           const currentQuantity = facts.positions.get(symbol) ?? 0n
+          const targetWeight = facts.input.targetWeights[symbol]
+          if (targetWeight === undefined) {
+            return Result.fail(
+              deriveTargetsFailure('precision', 'reference-price symbol has no corresponding target weight', {
+                cycleId: facts.input.cycleId,
+                symbol,
+              }),
+            )
+          }
           return Result.map(
             Result.mapError(
-              desiredQuantityMicros(facts.allocationCapital, facts.input.targetWeights[symbol], referencePrice, {
+              desiredQuantityMicros(facts.allocationCapital, targetWeight, referencePrice, {
                 precision: facts.input.precision,
               }),
               (cause) =>
@@ -242,7 +255,7 @@ export const derivePlannedTargetFacts = (
                   {
                     cycleId: facts.input.cycleId,
                     symbol,
-                    targetWeight: facts.input.targetWeights[symbol],
+                    targetWeight,
                   },
                   cause,
                 ),
@@ -254,7 +267,7 @@ export const derivePlannedTargetFacts = (
                 delta: targetQuantity - currentQuantity,
                 target: {
                   symbol,
-                  targetWeight: facts.input.targetWeights[symbol],
+                  targetWeight,
                   referencePriceMicros: referencePrice.toString(),
                   currentQuantityMicros: currentQuantity.toString(),
                   targetQuantityMicros: targetQuantity.toString(),

--- a/services/bayn/src/target-planner/result.ts
+++ b/services/bayn/src/target-planner/result.ts
@@ -47,7 +47,11 @@ const TargetPlanResultBase = Schema.Union([
 ])
 
 const isStrictlySorted = (values: readonly string[]): boolean =>
-  values.every((value, index) => index === 0 || values[index - 1] < value)
+  values.every((value, index) => {
+    if (index === 0) return true
+    const previous = values[index - 1]
+    return previous !== undefined && previous < value
+  })
 
 interface TargetPlanDeltaFact {
   readonly index: number
@@ -119,6 +123,7 @@ const targetPlanOrderingIssues = (
   for (let index = 1; index < result.intentTargets.length; index += 1) {
     const previous = result.intentTargets[index - 1]
     const current = result.intentTargets[index]
+    if (previous === undefined || current === undefined) continue
     if (
       (previous.side === OrderSide.Buy && current.side === OrderSide.Sell) ||
       (previous.side === current.side && previous.symbol >= current.symbol)

--- a/services/bayn/tsconfig.production.json
+++ b/services/bayn/tsconfig.production.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noUncheckedIndexedAccess": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.integration.test.ts", "src/**/*test-support.ts", "src/test-fixtures.ts"]
+}


### PR DESCRIPTION
## Summary

- adds a production-only TSGo profile with `noUncheckedIndexedAccess` while retaining the full profile for tests and fixtures
- replaces unchecked production indexing with explicit fail-closed domain results across market data, reconciliation, execution, persistence, and forward-performance paths
- adds typed missing-reference failures instead of allowing implicit `undefined` to cross domain boundaries

## Related Issues

None

## Testing

- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn test` (1,054 pass, 160 environment-gated skips, 0 fail)
- `bun run --filter @proompteng/bayn build` (793 modules)

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
