### PR TITLE
refactor(bayn): enforce strict Effect diagnostics

### DIFF
--- a/services/bayn/src/app.test.ts
+++ b/services/bayn/src/app.test.ts
@@ -670,7 +670,7 @@ describe('Bayn application composition', () => {
         Effect.gen(function* () {
           const parentScope = yield* Scope.Scope
           const partialLayer = Layer.effectDiscard(
-            Effect.acquireRelease(Effect.succeed(undefined), () => Effect.sync(() => void (finalizations += 1))).pipe(
+            Effect.acquireRelease(Effect.void, () => Effect.sync(() => void (finalizations += 1))).pipe(
               Effect.andThen(Effect.fail(acquisitionFailure)),
             ),
           )

--- a/services/bayn/src/app.ts
+++ b/services/bayn/src/app.ts
@@ -227,7 +227,7 @@ const startAutonomousCycle = <StartupR, LoopR>(
   state: Ref.Ref<RuntimeState>,
 ): Effect.Effect<Fiber.Fiber<void, never> | undefined, OperationalError, StartupR | LoopR | Scope.Scope> =>
   runtime._tag === 'Brokerless'
-    ? Effect.succeed(undefined)
+    ? Effect.as(Effect.void, undefined)
     : Ref.get(state).pipe(
         Effect.flatMap((initialized) => {
           const cycleBindingId =
@@ -235,7 +235,7 @@ const startAutonomousCycle = <StartupR, LoopR>(
               ? undefined
               : (runtime.cycleBindingId ?? initialized.evidence?.evaluation.runId)
           return cycleBindingId === undefined
-            ? Effect.succeed(undefined)
+            ? Effect.as(Effect.void, undefined)
             : forkAutonomousCycle(runtime, state, cycleBindingId)
         }),
       )

--- a/services/bayn/src/broker/alpaca-mutations/interpreter.ts
+++ b/services/bayn/src/broker/alpaca-mutations/interpreter.ts
@@ -92,7 +92,7 @@ const readCancelBody = (
   headers: { readonly 'x-request-id': string },
 ): Effect.Effect<string | undefined, BrokerMutationError> =>
   response.status === 204
-    ? Effect.succeed(undefined)
+    ? Effect.as(Effect.void, undefined)
     : response.text.pipe(
         Effect.mapError((cause) =>
           unknownOutcome(

--- a/services/bayn/src/broker/alpaca.test.ts
+++ b/services/bayn/src/broker/alpaca.test.ts
@@ -1528,13 +1528,7 @@ describe('Alpaca paper reads', () => {
       Effect.succeed(jsonResponse(request, { ...accountResponse, id: wrongAccount })),
     )
     const testLayer = layer(options).pipe(Layer.provide(Layer.succeed(HttpClient.HttpClient, client)))
-    const failure = await Effect.runPromise(
-      Effect.flip(
-        Effect.gen(function* () {
-          yield* BrokerRead
-        }).pipe(Effect.provide(testLayer)),
-      ),
-    )
+    const failure = await Effect.runPromise(Effect.flip(BrokerRead.pipe(Effect.provide(testLayer))))
     expect(failure).toBeInstanceOf(BrokerSessionAcquisitionError)
     expect(failure).toMatchObject({
       stage: BrokerSessionAcquisitionStage.Account,

--- a/services/bayn/src/broker/alpaca/http.ts
+++ b/services/bayn/src/broker/alpaca/http.ts
@@ -265,12 +265,10 @@ export const makeFreshBrokerPriceReader = (
           ),
         )
       if (response.status < 200 || response.status >= 300) {
-        return yield* Effect.fail(
-          operationalError(
-            'http',
-            'alpaca-latest-quote',
-            `Alpaca latest quote returned HTTP ${response.status.toString()}`,
-          ),
+        return yield* operationalError(
+          'http',
+          'alpaca-latest-quote',
+          `Alpaca latest quote returned HTTP ${response.status.toString()}`,
         )
       }
       const raw = yield* response.json.pipe(
@@ -385,16 +383,14 @@ export const make = (connection: BrokerConnection): Effect.Effect<BrokerReadShap
               invalidResponse(operation, `Alpaca ${operation} error response is invalid`, evidence, cause),
             ),
           )
-          return yield* Effect.fail(
-            statusError(
-              operation,
-              response.status,
-              evidence.requestId,
-              contentHash,
-              evidence.observedAt,
-              failure.code,
-              failure.message,
-            ),
+          return yield* statusError(
+            operation,
+            response.status,
+            evidence.requestId,
+            contentHash,
+            evidence.observedAt,
+            failure.code,
+            failure.message,
           )
         }
 

--- a/services/bayn/src/broker/alpaca/session.test.ts
+++ b/services/bayn/src/broker/alpaca/session.test.ts
@@ -298,7 +298,7 @@ describe('Alpaca broker session acquisition retry', () => {
       currentTimeMillis: Effect.sync(readTime),
       currentTimeNanosUnsafe: () => BigInt(currentTime()) * 1_000_000n,
       currentTimeNanos: Effect.sync(() => BigInt(currentTime()) * 1_000_000n),
-      sleep: () => Effect.succeed(undefined),
+      sleep: () => Effect.void,
     }
     const cause = new BrokerReadError({
       operation: 'account',

--- a/services/bayn/src/broker/alpaca/session.ts
+++ b/services/bayn/src/broker/alpaca/session.ts
@@ -106,16 +106,14 @@ export const acquireBrokerSession = (
   connection: BrokerConnection,
 ): Effect.Effect<BrokerSessionShape, BrokerSessionAcquisitionError, HttpClient.HttpClient> =>
   pipe(
-    pipe(
-      make(connection),
-      Effect.flatMap((read) =>
-        pipe(
-          verifyReadAccess(connection, read),
-          Effect.map((preflight) => Object.freeze({ connection, read, preflight })),
-        ),
+    make(connection),
+    Effect.flatMap((read) =>
+      pipe(
+        verifyReadAccess(connection, read),
+        Effect.map((preflight) => Object.freeze({ connection, read, preflight })),
       ),
-      Effect.mapError((cause) => acquisitionError(connection, cause)),
     ),
+    Effect.mapError((cause) => acquisitionError(connection, cause)),
     (acquisition) => retryRecoverableBrokerSessionAcquisition(connection, acquisition),
     Effect.withLogSpan('broker.session.acquire'),
   )

--- a/services/bayn/src/broker/observations.ts
+++ b/services/bayn/src/broker/observations.ts
@@ -51,16 +51,14 @@ export const BrokerEventInputSchema = Schema.TaggedUnion({
 })
 export type BrokerEventInput = typeof BrokerEventInputSchema.Type
 
-export const FillEventInputSchema = Schema.Struct({
-  _tag: Schema.Literal('Fill'),
+export const FillEventInputSchema = Schema.TaggedStruct('Fill', {
   ...CommonEventInput,
   sourceTimestamp: UtcOrderTimestamp,
   fill: FillSchema,
 })
 export type FillEventInput = typeof FillEventInputSchema.Type
 
-export const PositionEventInputSchema = Schema.Struct({
-  _tag: Schema.Literal('Position'),
+export const PositionEventInputSchema = Schema.TaggedStruct('Position', {
   ...CommonEventInput,
   position: PositionSchema,
 })

--- a/services/bayn/src/composition.ts
+++ b/services/bayn/src/composition.ts
@@ -237,7 +237,10 @@ export const ExecutionPrepareValidationResourcesLive = (plan: ApplicationPlanFor
 export const ExecutionPrepareExecutionResourcesLive = (plan: ApplicationPlanFor<'ExecutionPrepare'>) => {
   const postgres = sqlResource(PostgresClientResourceLive(plan.config))
   const writerFence = WriterFenceResourceLive.pipe(Layer.provide(postgres))
-  const executionPrepareStore = ExecutionPrepareStoreLive(plan.config).pipe(Layer.provide(postgres))
+  const executionPrepareStore = ExecutionPrepareStoreLive(plan.config).pipe(
+    Layer.provide(writerFence),
+    Layer.provide(postgres),
+  )
   return Layer.mergeAll(postgres, writerFence, executionPrepareStore, BrokerSessionResourceLive(plan.config)).pipe(
     Layer.provideMerge(ApplicationPlatformLive),
   )
@@ -520,32 +523,28 @@ const readBoundPaperActivationGeneration = (
 ): Effect.Effect<PaperAuthorityGeneration, OperationalError> =>
   Effect.gen(function* () {
     if (authorityStore.readAuthorityState === undefined) {
-      return yield* Effect.fail(
-        paperActivationOperationalError('durable PAPER recovery requires authority history read capabilities'),
+      return yield* paperActivationOperationalError(
+        'durable PAPER recovery requires authority history read capabilities',
       )
     }
-    const authority = yield* authorityStore
-      .readAuthorityState()
-      .pipe(Effect.mapError((cause) => paperActivationOperationalError('durable PAPER authority read failed', cause)))
+    const authority = yield* authorityStore.readAuthorityState.pipe(
+      Effect.mapError((cause) => paperActivationOperationalError('durable PAPER authority read failed', cause)),
+    )
     if (authority.maximum !== Authority.Paper) {
-      return yield* Effect.fail(
-        paperActivationOperationalError('durable PAPER recovery requires PAPER maximum authority'),
-      )
+      return yield* paperActivationOperationalError('durable PAPER recovery requires PAPER maximum authority')
     }
     const closeAuthorityIsBound =
       (authority.effective === Authority.Paper && authority.kill === KillState.Clear) ||
       (authority.effective === Authority.Observe && authority.kill === KillState.Active)
     if (!closeAuthorityIsBound) {
-      return yield* Effect.fail(
-        paperActivationOperationalError(
-          'durable PAPER recovery requires clear PAPER or active OBSERVE close authority',
-        ),
+      return yield* paperActivationOperationalError(
+        'durable PAPER recovery requires clear PAPER or active OBSERVE close authority',
       )
     }
     if (isResearchPaperActivationRequest(request)) {
       if (authorityStore.readResearchAuthorityGeneration === undefined) {
-        return yield* Effect.fail(
-          paperActivationOperationalError('durable research PAPER recovery requires v3 authority history reads'),
+        return yield* paperActivationOperationalError(
+          'durable research PAPER recovery requires v3 authority history reads',
         )
       }
       const generation = yield* authorityStore
@@ -554,7 +553,7 @@ const readBoundPaperActivationGeneration = (
           Effect.mapError((cause) => paperActivationOperationalError('durable PAPER generation read failed', cause)),
         )
       if (generation === undefined) {
-        return yield* Effect.fail(paperActivationOperationalError('durable research PAPER history is missing'))
+        return yield* paperActivationOperationalError('durable research PAPER history is missing')
       }
       yield* Effect.fromResult(
         researchPaperGenerationIsBoundToRequest(request, plan.config.alpaca.authorityGenerationHash, generation),
@@ -562,15 +561,15 @@ const readBoundPaperActivationGeneration = (
       return generation
     }
     if (authorityStore.readAuthorityGeneration === undefined) {
-      return yield* Effect.fail(
-        paperActivationOperationalError('durable qualified PAPER recovery requires v2 authority history reads'),
+      return yield* paperActivationOperationalError(
+        'durable qualified PAPER recovery requires v2 authority history reads',
       )
     }
     const generation = yield* authorityStore
       .readAuthorityGeneration(authority.generationHash)
       .pipe(Effect.mapError((cause) => paperActivationOperationalError('durable PAPER generation read failed', cause)))
     if (generation === undefined) {
-      return yield* Effect.fail(paperActivationOperationalError('durable qualified PAPER history is missing'))
+      return yield* paperActivationOperationalError('durable qualified PAPER history is missing')
     }
     yield* Effect.fromResult(paperGenerationIsBoundToRequest(request, plan, generation)).pipe(
       Effect.mapError((message) => paperActivationOperationalError(message)),
@@ -594,14 +593,10 @@ const recoverPaperActivationGeneration = (
     const closeExpiresAt = paperEpisodeCloseExpiresAt(request.expiresAt)
     if (observedAt >= closeExpiresAt) {
       yield* restrictExpiredPaperActivation(authorityRestrictionStore, writerFence)
-      return yield* Effect.fail(
-        paperActivationOperationalError('durable PAPER close recovery is outside its immutable close lease'),
-      )
+      return yield* paperActivationOperationalError('durable PAPER close recovery is outside its immutable close lease')
     }
     if (observedAt < request.cutoffAt) {
-      return yield* Effect.fail(
-        paperActivationOperationalError('durable PAPER close recovery is outside its immutable close lease'),
-      )
+      return yield* paperActivationOperationalError('durable PAPER close recovery is outside its immutable close lease')
     }
     return yield* readBoundPaperActivationGeneration(plan, request, authorityStore)
   })
@@ -620,9 +615,7 @@ const recoverPaperReceiptFinalizationGeneration = (
       Effect.mapError((message) => paperActivationOperationalError(message)),
     )
     if (observedAt < paperEpisodeCloseExpiresAt(request.expiresAt)) {
-      return yield* Effect.fail(
-        paperActivationOperationalError('durable PAPER receipt finalization is outside its bounded lease'),
-      )
+      return yield* paperActivationOperationalError('durable PAPER receipt finalization is outside its bounded lease')
     }
     yield* restrictExpiredPaperActivation(authorityRestrictionStore, writerFence)
     return yield* readBoundPaperActivationGeneration(plan, request, authorityStore)
@@ -663,6 +656,7 @@ const preparePaperActivation = (
       discoveryConfig as ApplicationPlanFor<'ExecutionCandidateDiscovery'>,
       riskPolicyHash,
     ).pipe(
+      // @effect-diagnostics-next-line strictEffectProvide:off -- dynamic discovery subprogram boundary owns this layer
       Effect.provide(
         ExecutionCandidateDiscoveryResourcesLive(discoveryConfig as ApplicationPlanFor<'ExecutionCandidateDiscovery'>),
       ),
@@ -681,10 +675,12 @@ const preparePaperActivation = (
       prepareRequest,
     )
     const validated = yield* validateExecutionPreparePlan(prepareConfig as ApplicationPlanFor<'ExecutionPrepare'>).pipe(
+      // @effect-diagnostics-next-line strictEffectProvide:off -- dynamic PREPARE validation boundary owns this layer
       Effect.provide(ExecutionPrepareValidationResourcesLive(prepareConfig as ApplicationPlanFor<'ExecutionPrepare'>)),
       Effect.mapError((cause) => paperActivationOperationalError('execution PREPARE validation failed', cause)),
     )
     const prepared = yield* prepareExecutionPrepareOutput(validated).pipe(
+      // @effect-diagnostics-next-line strictEffectProvide:off -- dynamic PREPARE execution boundary owns this layer
       Effect.provide(ExecutionPrepareExecutionResourcesLive(prepareConfig as ApplicationPlanFor<'ExecutionPrepare'>)),
       Effect.mapError((cause) => paperActivationOperationalError('execution PREPARE resource failed', cause)),
     )
@@ -767,7 +763,7 @@ const readCurrentResearchPaperGeneration = (
   authority: AuthorityState,
   authorityStore: AuthorityGenerationStoreShape,
 ): Effect.Effect<ResearchCapitalGrantGeneration | undefined, OperationalError> => {
-  if (authority.maximum !== Authority.Paper) return Effect.succeed(undefined)
+  if (authority.maximum !== Authority.Paper) return Effect.as(Effect.void, undefined)
   if (authorityStore.readResearchAuthorityGeneration === undefined) {
     return Effect.fail(paperActivationOperationalError('research PAPER startup requires v3 authority history reads'))
   }
@@ -787,7 +783,6 @@ const prepareResearchPaperActivation = (
   session: BrokerSessionShape,
   authorityStore: AuthorityGenerationStoreShape,
   lifecycle: CapitalGrantLifecycleStoreShape,
-  writerFence: WriterFenceService,
 ): Effect.Effect<ResearchCapitalGrantGeneration, OperationalError> =>
   Effect.gen(function* () {
     const observedAt = yield* currentUtcInstant
@@ -801,10 +796,13 @@ const prepareResearchPaperActivation = (
     yield* validateResearchPaperCloseLease(request, session)
 
     const proof = researchCapitalGrantProof(request)
-    const authority = yield* lifecycle.activateResearchCapitalGrant(proof).pipe(
-      Effect.provideService(WriterFence, writerFence),
-      Effect.mapError((cause) => paperActivationOperationalError('research PAPER generation activation failed', cause)),
-    )
+    const authority = yield* lifecycle
+      .activateResearchCapitalGrant(proof)
+      .pipe(
+        Effect.mapError((cause) =>
+          paperActivationOperationalError('research PAPER generation activation failed', cause),
+        ),
+      )
     yield* Effect.fromResult(validateActivatedResearchAuthority(authority)).pipe(
       Effect.mapError((message) => paperActivationOperationalError(message)),
     )
@@ -839,19 +837,16 @@ const prepareOrRecoverResearchPaperActivation = (
   session: BrokerSessionShape,
   authorityStore: AuthorityGenerationStoreShape,
   lifecycle: CapitalGrantLifecycleStoreShape,
-  writerFence: WriterFenceService,
   reconcile: Effect.Effect<unknown, ReconciliationPassError | OperationalError>,
   operationTimeoutMs: number,
 ): Effect.Effect<ResearchCapitalGrantGeneration, OperationalError> =>
   Effect.gen(function* () {
     if (authorityStore.readAuthorityState === undefined) {
-      return yield* Effect.fail(
-        paperActivationOperationalError('research PAPER startup requires durable authority state reads'),
-      )
+      return yield* paperActivationOperationalError('research PAPER startup requires durable authority state reads')
     }
-    const authority = yield* authorityStore
-      .readAuthorityState()
-      .pipe(Effect.mapError((cause) => paperActivationOperationalError('research PAPER authority read failed', cause)))
+    const authority = yield* authorityStore.readAuthorityState.pipe(
+      Effect.mapError((cause) => paperActivationOperationalError('research PAPER authority read failed', cause)),
+    )
     const currentGeneration = yield* readCurrentResearchPaperGeneration(authority, authorityStore)
     const currentGenerationMatchesRequest =
       currentGeneration !== undefined &&
@@ -890,19 +885,16 @@ const prepareOrRecoverResearchPaperActivation = (
         rearmed.effective !== Authority.Observe ||
         rearmed.kill !== KillState.Clear
       ) {
-        return yield* Effect.fail(
-          paperActivationOperationalError('research PAPER source authority rearm did not return clear OBSERVE'),
+        return yield* paperActivationOperationalError(
+          'research PAPER source authority rearm did not return clear OBSERVE',
         )
       }
     }
     if (decision._tag !== 'Resume') {
       yield* refreshResearchPaperActivationReconciliation(reconcile, operationTimeoutMs)
-      return yield* prepareResearchPaperActivation(plan, request, session, authorityStore, lifecycle, writerFence)
+      return yield* prepareResearchPaperActivation(plan, request, session, authorityStore, lifecycle)
     }
-    return (
-      currentGeneration ??
-      (yield* Effect.fail(paperActivationOperationalError('research PAPER recovery lost durable history')))
-    )
+    return currentGeneration ?? (yield* paperActivationOperationalError('research PAPER recovery lost durable history'))
   })
 
 const pendingPaperActivation = (
@@ -1092,16 +1084,15 @@ const makeClosedCycleReceiptEmitter =
       return stored.receiptHash
     }).pipe(
       Effect.catch((cause) =>
-        Effect.logError('Bayn forward-performance receipt emission failed')
-          .pipe(
-            Effect.annotateLogs({
-              service: 'bayn',
-              cycleId,
-              observedAt,
-              reason: cause instanceof Error ? cause.message : String(cause),
-            }),
-          )
-          .pipe(Effect.as(undefined)),
+        Effect.logError('Bayn forward-performance receipt emission failed').pipe(
+          Effect.annotateLogs({
+            service: 'bayn',
+            cycleId,
+            observedAt,
+            reason: cause instanceof Error ? cause.message : String(cause),
+          }),
+          Effect.as(undefined),
+        ),
       ),
     )
 
@@ -1284,8 +1275,14 @@ const runAutonomousService = (plan: ApplicationPlanFor<'AutonomousService'>) =>
                         )
                         const readStartCycle = (startup: AutonomousCycleStartupInput) =>
                           observeCycle(observePlan)(startup).pipe(
+                            // @effect-diagnostics-next-line strictEffectProvide:off -- value-only cycle services have no resource lifetime
                             Effect.provide(cycleResources),
-                            Effect.map((loop) => loop.pipe(Effect.provide(cycleResources))),
+                            Effect.map((loop) =>
+                              loop.pipe(
+                                // @effect-diagnostics-next-line strictEffectProvide:off -- value-only cycle services have no resource lifetime
+                                Effect.provide(cycleResources),
+                              ),
+                            ),
                           )
                         const readRuntime = () => ({
                           _tag: 'AutonomousRead' as const,
@@ -1340,8 +1337,10 @@ const runAutonomousService = (plan: ApplicationPlanFor<'AutonomousService'>) =>
                                           runtimeServices.session,
                                           runtimeServices.authorityGenerationStore,
                                           runtimeServices.capitalGrantLifecycleStore,
-                                          runtimeServices.writerFence,
-                                          runOnce.pipe(Effect.provide(cycleResources)),
+                                          runOnce.pipe(
+                                            // @effect-diagnostics-next-line strictEffectProvide:off -- value-only cycle services have no resource lifetime
+                                            Effect.provide(cycleResources),
+                                          ),
                                           observePlan.config.operationTimeoutMs,
                                         ).pipe(Effect.map((generation) => ({ _tag: 'Mutation' as const, generation })))
                                       : evidence === null
@@ -1516,7 +1515,7 @@ const runAutonomousService = (plan: ApplicationPlanFor<'AutonomousService'>) =>
                                           isPaperEpisodeCloseIntent: (intentId) =>
                                             runtimeServices.paperCycleClosureStore
                                               .containsIntent(intentId)
-                                              .pipe(Effect.catch(() => Effect.succeed(false))),
+                                              .pipe(Effect.orElseSucceed(() => false)),
                                           intentStore: runtimeServices.intentStore,
                                           mutationStore: runtimeServices.mutationStore,
                                           writerFence: runtimeServices.writerFence,
@@ -1569,8 +1568,14 @@ const runAutonomousService = (plan: ApplicationPlanFor<'AutonomousService'>) =>
                                           runtimeServices.paperCycleClosureStore,
                                           onClosedCycle,
                                         )(startup).pipe(
+                                          // @effect-diagnostics-next-line strictEffectProvide:off -- value-only cycle services have no resource lifetime
                                           Effect.provide(cycleResources),
-                                          Effect.map((loop) => loop.pipe(Effect.provide(cycleResources))),
+                                          Effect.map((loop) =>
+                                            loop.pipe(
+                                              // @effect-diagnostics-next-line strictEffectProvide:off -- value-only cycle services have no resource lifetime
+                                              Effect.provide(cycleResources),
+                                            ),
+                                          ),
                                         ),
                                     })),
                                   )
@@ -1783,15 +1788,13 @@ export const validateExecutionPreparePlan = (plan: ApplicationPlanFor<'Execution
       configuredStrategy.name !== application.definition.name ||
       configuredStrategy.parameterSchemaVersion !== application.definition.parameters.schemaVersion
     ) {
-      return yield* Effect.fail(
-        new OperationalError({
-          component: 'strategy',
-          operation: 'execution-prepare',
-          message: 'EXECUTION_PREPARE strategy identity does not match the composed application',
-          retryable: false,
-          cause: { _tag: 'StrategyProtocolVersionMismatch' },
-        }),
-      )
+      return yield* new OperationalError({
+        component: 'strategy',
+        operation: 'execution-prepare',
+        message: 'EXECUTION_PREPARE strategy identity does not match the composed application',
+        retryable: false,
+        cause: { _tag: 'StrategyProtocolVersionMismatch' },
+      })
     }
     const strategy: ExecutionPrepareRuntimeBinding['strategy'] = {
       name: configuredStrategy.name,
@@ -1804,15 +1807,13 @@ export const validateExecutionPreparePlan = (plan: ApplicationPlanFor<'Execution
       plan.config.executionPrepareRequest.qualification.runId,
     )
     if (Option.isNone(qualification)) {
-      return yield* Effect.fail(
-        new OperationalError({
-          component: 'strategy',
-          operation: 'execution-prepare',
-          message: 'EXECUTION_PREPARE qualification evidence is unavailable',
-          retryable: false,
-          cause: { _tag: 'QualificationEvidenceUnavailable' },
-        }),
-      )
+      return yield* new OperationalError({
+        component: 'strategy',
+        operation: 'execution-prepare',
+        message: 'EXECUTION_PREPARE qualification evidence is unavailable',
+        retryable: false,
+        cause: { _tag: 'QualificationEvidenceUnavailable' },
+      })
     }
     const runtime = executionPrepareRuntimeBinding(plan, riskPolicyHash, strategy)
     const proofPlanRequest = yield* Effect.fromResult(
@@ -1848,11 +1849,14 @@ export const prepareExecutionPreparePlan = (plan: ApplicationPlanFor<'ExecutionP
 
 export const runExecutionPreparePlan = (plan: ApplicationPlanFor<'ExecutionPrepare'>) =>
   validateExecutionPreparePlan(plan).pipe(
+    // @effect-diagnostics-next-line strictEffectProvide:off -- ExecutionPrepare plan boundary owns validation resources
     Effect.provide(ExecutionPrepareValidationResourcesLive(plan)),
     Effect.flatMap((prevalidated) =>
       prepareExecutionPrepareOutput(prevalidated).pipe(
+        // @effect-diagnostics-next-line strictEffectProvide:off -- ExecutionPrepare plan boundary owns execution resources
         Effect.provide(ExecutionPrepareExecutionResourcesLive(plan)),
         Effect.flatMap(writeExecutionPrepareOutput),
+        // @effect-diagnostics-next-line strictEffectProvide:off -- ExecutionPrepare plan boundary owns platform resources
         Effect.provide(ApplicationPlatformLive),
       ),
     ),
@@ -1876,12 +1880,15 @@ export const executionPrepareBoundaryError = (cause: unknown): OperationalError 
 export const runApplicationPlan = pipe(
   Match.type<ApplicationPlan>(),
   Match.tag('BrokerlessService', (plan) =>
+    // @effect-diagnostics-next-line strictEffectProvide:off -- application plan dispatch is the resource entry point
     runBrokerlessService(plan).pipe(Effect.provide(BrokerlessApplicationResourcesLive(plan))),
   ),
   Match.tag('AutonomousService', (plan) =>
+    // @effect-diagnostics-next-line strictEffectProvide:off -- application plan dispatch is the resource entry point
     runAutonomousService(plan).pipe(Effect.provide(AutonomousApplicationResourcesLive(plan))),
   ),
   Match.tag('ExecutionCandidateDiscovery', (plan) =>
+    // @effect-diagnostics-next-line strictEffectProvide:off -- application plan dispatch is the resource entry point
     runExecutionCandidateDiscovery(plan).pipe(Effect.provide(ExecutionCandidateDiscoveryResourcesLive(plan))),
   ),
   Match.tag('ExecutionPrepare', runExecutionPreparePlan),

--- a/services/bayn/src/cycle-readiness.ts
+++ b/services/bayn/src/cycle-readiness.ts
@@ -101,13 +101,12 @@ const bindFinalizedCyclePublicationWith = (
       case 'RETURN_BLOCKED':
         return { outcome: 'BLOCKED', observedAt, cycle }
       case 'REJECT_IMMUTABLE_BINDING':
-        return yield* Effect.fail(
-          readinessError(
-            'bind-publication',
-            'contract',
-            'finalized Signal publication differs from the immutable cycle binding',
-          ),
+        return yield* readinessError(
+          'bind-publication',
+          'contract',
+          'finalized Signal publication differs from the immutable cycle binding',
         )
+
       case 'RETURN_ALREADY_BOUND': {
         const freshness = yield* measureFreshness(
           cycle,
@@ -118,19 +117,21 @@ const bindFinalizedCyclePublicationWith = (
         return { outcome: 'ALREADY_BOUND', observedAt, cycle, snapshotId, freshness }
       }
       case 'REJECT_UNBOUND_STATE':
-        return yield* Effect.fail(
-          readinessError('bind-publication', 'contract', `unbound cycle ${cycle.identity.cycleId} is not pending`),
+        return yield* readinessError(
+          'bind-publication',
+          'contract',
+          `unbound cycle ${cycle.identity.cycleId} is not pending`,
         )
+
       case 'BLOCK_MISSED':
         return yield* blockMissedPublication(store, cycle.identity.cycleId, observedAt)
       case 'REJECT_BEFORE_SIGNAL_CLOSE':
-        return yield* Effect.fail(
-          readinessError(
-            'bind-publication',
-            'contract',
-            'finalized Signal publication cannot bind before the cycle signal close',
-          ),
+        return yield* readinessError(
+          'bind-publication',
+          'contract',
+          'finalized Signal publication cannot bind before the cycle signal close',
         )
+
       case 'BIND':
         break
     }
@@ -200,21 +201,17 @@ const inspectBoundPublication = (
       Effect.flatMap((publication) =>
         Effect.gen(function* () {
           if (publication.outcome === 'MISSING') {
-            return yield* Effect.fail(
-              readinessError(
-                'inspect-publication',
-                'contract',
-                'bound finalized Signal publication is missing from its durable source',
-              ),
+            return yield* readinessError(
+              'inspect-publication',
+              'contract',
+              'bound finalized Signal publication is missing from its durable source',
             )
           }
           if (publication.inspection.manifest.finalizedSnapshot.snapshotId !== boundSnapshotId) {
-            return yield* Effect.fail(
-              readinessError(
-                'inspect-publication',
-                'contract',
-                'finalized Signal publication does not match the immutable cycle binding',
-              ),
+            return yield* readinessError(
+              'inspect-publication',
+              'contract',
+              'finalized Signal publication does not match the immutable cycle binding',
             )
           }
           const observedAt = yield* now
@@ -248,9 +245,12 @@ const runCyclePublicationReadinessWith = (
       case 'INSPECT_BOUND':
         return yield* inspectBoundPublication(cycle, dependencies.marketData, dependencies.now)
       case 'REJECT_UNBOUND_STATE':
-        return yield* Effect.fail(
-          readinessError('inspect-publication', 'contract', `unbound cycle ${cycle.identity.cycleId} is not pending`),
+        return yield* readinessError(
+          'inspect-publication',
+          'contract',
+          `unbound cycle ${cycle.identity.cycleId} is not pending`,
         )
+
       case 'BLOCK_MISSED':
         return yield* blockMissedPublication(dependencies.store, cycle.identity.cycleId, initialObservedAt)
       case 'WAIT_SIGNAL':
@@ -271,13 +271,11 @@ const runCyclePublicationReadinessWith = (
             if (observedAt >= cycle.window.publicationDeadlineAt) {
               return yield* blockMissedPublication(dependencies.store, cycle.identity.cycleId, observedAt)
             }
-            return yield* Effect.fail(
-              readinessError(
-                'inspect-publication',
-                'market-data',
-                'finalized Signal publication inspection failed before its deadline',
-                cause,
-              ),
+            return yield* readinessError(
+              'inspect-publication',
+              'market-data',
+              'finalized Signal publication inspection failed before its deadline',
+              cause,
             )
           }),
         onSuccess: (publication) =>
@@ -296,8 +294,10 @@ const runCyclePublicationReadinessWith = (
                 return { outcome: 'WAITING', reason: 'PUBLICATION_MISSING', observedAt, cycle } as const
               case 'BIND_FINALIZED':
                 if (publication.outcome === 'MISSING') {
-                  return yield* Effect.fail(
-                    readinessError('inspect-publication', 'contract', 'publication decision lost finalized evidence'),
+                  return yield* readinessError(
+                    'inspect-publication',
+                    'contract',
+                    'publication decision lost finalized evidence',
                   )
                 }
                 return yield* bindFinalizedCyclePublicationWith(

--- a/services/bayn/src/cycle-runner/loop.ts
+++ b/services/bayn/src/cycle-runner/loop.ts
@@ -81,7 +81,7 @@ const reconcileNotDuePass = <DecisionR>(
     const state = yield* Ref.get(cadence)
     const decision = decideIdleReconciliationCadence(state, nowNanos, reconciliationIntervalMs)
     if (decision._tag === 'WAIT') {
-      if (state.lastFailure !== undefined) return yield* Effect.fail(state.lastFailure)
+      if (state.lastFailure !== undefined) return yield* state.lastFailure
       return result
     }
     yield* attemptIdleReconciliation(reconcileNotDue, cadence)

--- a/services/bayn/src/db/cycle-observability.ts
+++ b/services/bayn/src/db/cycle-observability.ts
@@ -264,7 +264,7 @@ const makeCycleObservability = Effect.gen(function* () {
         Effect.mapError((cause) => readError('decode', 'invalid qualification run identity', cause)),
       ),
       accountId === undefined
-        ? Effect.succeed(undefined)
+        ? Effect.void
         : decodeAccountId(accountId).pipe(
             Effect.mapError((cause) => readError('decode', 'invalid cycle observability account identity', cause)),
           ),

--- a/services/bayn/src/db/evidence-store.integration.test.ts
+++ b/services/bayn/src/db/evidence-store.integration.test.ts
@@ -2484,11 +2484,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
     const execution = makeExecutionRuntime()
     const intent = await Effect.runPromise(plan(intentPlan({ cycleId: '1'.repeat(64) })))
     const decision = await Effect.runPromise(riskDecision(intent, RiskOutcome.Approved))
-    await execution.runPromise(
-      Effect.gen(function* () {
-        yield* Effect.flatMap(IntentStore, (store) => store.commit(intent, decision))
-      }),
-    )
+    await execution.runPromise(Effect.flatMap(IntentStore, (store) => store.commit(intent, decision)))
     await execution.dispose()
     const mutation = makeMutationRuntime()
     const startedAt = new Date(Date.now() + 100).toISOString()
@@ -2727,11 +2723,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
     const execution = makeExecutionRuntime()
     const intent = await Effect.runPromise(plan(intentPlan({ cycleId: '6'.repeat(64) })))
     const decision = await Effect.runPromise(riskDecision(intent, RiskOutcome.Approved))
-    await execution.runPromise(
-      Effect.gen(function* () {
-        yield* Effect.flatMap(IntentStore, (store) => store.commit(intent, decision))
-      }),
-    )
+    await execution.runPromise(Effect.flatMap(IntentStore, (store) => store.commit(intent, decision)))
     await execution.dispose()
     const mutation = makeMutationRuntime()
     const requestHash = '5'.repeat(64)
@@ -2852,11 +2844,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
     const execution = makeExecutionRuntime()
     const intent = await Effect.runPromise(plan(intentPlan({ cycleId: '8'.repeat(64) })))
     const decision = await Effect.runPromise(riskDecision(intent, RiskOutcome.Approved))
-    await execution.runPromise(
-      Effect.gen(function* () {
-        yield* Effect.flatMap(IntentStore, (store) => store.commit(intent, decision))
-      }),
-    )
+    await execution.runPromise(Effect.flatMap(IntentStore, (store) => store.commit(intent, decision)))
     await execution.dispose()
     const mutation = makeMutationRuntime()
     const requestHash = 'b'.repeat(64)
@@ -2935,11 +2923,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
     const execution = makeExecutionRuntime()
     const intent = await Effect.runPromise(plan(intentPlan({ cycleId: '9'.repeat(64) })))
     const decision = await Effect.runPromise(riskDecision(intent, RiskOutcome.Approved))
-    await execution.runPromise(
-      Effect.gen(function* () {
-        yield* Effect.flatMap(IntentStore, (store) => store.commit(intent, decision))
-      }),
-    )
+    await execution.runPromise(Effect.flatMap(IntentStore, (store) => store.commit(intent, decision)))
     await execution.dispose()
 
     const mutation = makeMutationRuntime()
@@ -3073,11 +3057,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
     const execution = makeExecutionRuntime()
     const intent = await Effect.runPromise(plan(intentPlan({ cycleId: '7'.repeat(64) })))
     const decision = await Effect.runPromise(riskDecision(intent, RiskOutcome.Approved))
-    await execution.runPromise(
-      Effect.gen(function* () {
-        yield* Effect.flatMap(IntentStore, (store) => store.commit(intent, decision))
-      }),
-    )
+    await execution.runPromise(Effect.flatMap(IntentStore, (store) => store.commit(intent, decision)))
     await execution.dispose()
 
     const mutation = makeMutationRuntime()
@@ -3328,11 +3308,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
     const decision = await Effect.runPromise(
       riskDecision(intent, RiskOutcome.Approved, { expiresAt: new Date(expiresAtMillis).toISOString() }),
     )
-    await execution.runPromise(
-      Effect.gen(function* () {
-        yield* Effect.flatMap(IntentStore, (store) => store.commit(intent, decision))
-      }),
-    )
+    await execution.runPromise(Effect.flatMap(IntentStore, (store) => store.commit(intent, decision)))
     await execution.dispose()
     await Bun.sleep(Math.max(0, expiresAtMillis - Date.now() + 50))
 
@@ -3368,11 +3344,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
     const execution = makeExecutionRuntime()
     const intent = await Effect.runPromise(plan(intentPlan({ cycleId: '2'.repeat(64) })))
     const decision = await Effect.runPromise(riskDecision(intent, RiskOutcome.Approved))
-    await execution.runPromise(
-      Effect.gen(function* () {
-        yield* Effect.flatMap(IntentStore, (store) => store.commit(intent, decision))
-      }),
-    )
+    await execution.runPromise(Effect.flatMap(IntentStore, (store) => store.commit(intent, decision)))
     await execution.dispose()
 
     const mutation = makeMutationRuntime()
@@ -3958,11 +3930,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
     const execution = makeExecutionRuntime()
     const intent = await Effect.runPromise(plan(intentPlan({ cycleId: 'e'.repeat(64) })))
     const decision = await Effect.runPromise(riskDecision(intent, RiskOutcome.Approved))
-    await execution.runPromise(
-      Effect.gen(function* () {
-        yield* Effect.flatMap(IntentStore, (store) => store.commit(intent, decision))
-      }),
-    )
+    await execution.runPromise(Effect.flatMap(IntentStore, (store) => store.commit(intent, decision)))
     await execution.dispose()
 
     const mutation = makeMutationRuntime()

--- a/services/bayn/src/db/evidence-store/bootstrap.ts
+++ b/services/bayn/src/db/evidence-store/bootstrap.ts
@@ -57,9 +57,7 @@ const migrate = Effect.gen(function* () {
     `,
   )
   if (boundary.legacy_exists) {
-    return yield* Effect.fail(
-      databaseError('migration', 'migrate', 'legacy migration tracker is unsupported after the hard cut'),
-    )
+    return yield* databaseError('migration', 'migrate', 'legacy migration tracker is unsupported after the hard cut')
   }
   if (boundary.current_exists) {
     const identities = yield* decodeMigrationIdentities(
@@ -67,9 +65,7 @@ const migrate = Effect.gen(function* () {
     )
     const [initial] = identities
     if (identities.length !== 1 || initial?.name !== 'initial_schema') {
-      return yield* Effect.fail(
-        databaseError('migration', 'migrate', 'legacy migration history is unsupported after the hard cut'),
-      )
+      return yield* databaseError('migration', 'migrate', 'legacy migration history is unsupported after the hard cut')
     }
   }
   yield* PgMigrator.run({ loader: migrationLoader, table: 'schema_migrations' })

--- a/services/bayn/src/db/evidence-store/persist-program.ts
+++ b/services/bayn/src/db/evidence-store/persist-program.ts
@@ -44,9 +44,7 @@ export const makeEvidencePersistenceProgram = (
             )
             if (plan.qualification !== undefined) {
               if (Option.isNone(storedQualification)) {
-                return yield* Effect.fail(
-                  databaseError('invariant', 'persist-qualification', 'qualification lock was not opened'),
-                )
+                return yield* databaseError('invariant', 'persist-qualification', 'qualification lock was not opened')
               }
               yield* ensure(
                 storedQualification.value.state === 'OPENED_INCOMPLETE',
@@ -87,12 +85,10 @@ export const makeEvidencePersistenceProgram = (
             })
             if (inserted.length === 0) {
               if (plan.qualification !== undefined) {
-                return yield* Effect.fail(
-                  databaseError(
-                    'invariant',
-                    'persist-qualification',
-                    'locked qualification candidate was already evaluated without a terminal result',
-                  ),
+                return yield* databaseError(
+                  'invariant',
+                  'persist-qualification',
+                  'locked qualification candidate was already evaluated without a terminal result',
                 )
               }
               return yield* references.readReceipt(plan, true)

--- a/services/bayn/src/db/evidence-store/qualification-program.ts
+++ b/services/bayn/src/db/evidence-store/qualification-program.ts
@@ -121,8 +121,10 @@ export const makeQualificationPrograms = (
               Effect.mapError((failure) => storedQualificationDatabaseError('open-qualification', failure)),
             )
             if (Option.isNone(stored)) {
-              return yield* Effect.fail(
-                databaseError('invariant', 'open-qualification', 'conflicting qualification lock is missing'),
+              return yield* databaseError(
+                'invariant',
+                'open-qualification',
+                'conflicting qualification lock is missing',
               )
             }
             yield* Effect.fromResult(validateQualificationLockMatch(stored.value.lock, lock)).pipe(

--- a/services/bayn/src/db/evidence-store/read-program.ts
+++ b/services/bayn/src/db/evidence-store/read-program.ts
@@ -68,9 +68,7 @@ export const makeEvidenceReadPrograms = (
             yield* ensure(metadata.length === 1, 'read-artifact-items', 'artifact series metadata is duplicated')
             const [series] = metadata
             if (series === undefined) {
-              return yield* Effect.fail(
-                databaseError('invariant', 'read-artifact-items', 'artifact series metadata disappeared'),
-              )
+              return yield* databaseError('invariant', 'read-artifact-items', 'artifact series metadata disappeared')
             }
             const rows = yield* statements.getArtifactItems({ runId, artifactName, afterOrdinal, limit })
             yield* ensure(

--- a/services/bayn/src/db/execution-store/capital-grant.ts
+++ b/services/bayn/src/db/execution-store/capital-grant.ts
@@ -2,7 +2,7 @@ import { PgClient } from '@effect/sql-pg'
 import { Effect } from 'effect'
 
 import { BrokerEnvironment } from '../../broker/identity'
-import { WriterFence } from '../../execution/writer-fence'
+import type { WriterFenceService } from '../../execution/writer-fence'
 import { historicalSandboxAuthority } from '../../execution/legacy-authority'
 import {
   Authority,
@@ -56,13 +56,11 @@ import {
 export interface CapitalGrantInterpreter {
   readonly prepareCapitalGrant: (
     proof: CapitalGrantProofBinding,
-  ) => Effect.Effect<CapitalGrantGeneration, ExecutionStoreError, WriterFence>
-  readonly activateCapitalGrant: (
-    proof: CapitalGrantProofBinding,
-  ) => Effect.Effect<AuthorityState, ExecutionStoreError, WriterFence>
+  ) => Effect.Effect<CapitalGrantGeneration, ExecutionStoreError>
+  readonly activateCapitalGrant: (proof: CapitalGrantProofBinding) => Effect.Effect<AuthorityState, ExecutionStoreError>
   readonly activateResearchCapitalGrant: (
     proof: ResearchCapitalGrantProofBinding,
-  ) => Effect.Effect<AuthorityState, ExecutionStoreError, WriterFence>
+  ) => Effect.Effect<AuthorityState, ExecutionStoreError>
 }
 
 interface ResearchPaperRuntimeBinding {
@@ -75,6 +73,7 @@ export const makeCapitalGrantInterpreter = (
   sql: PgClient.PgClient,
   authority: AuthorityPostgres,
   config: ExecutionStoreRuntimeConfig,
+  writerFence: WriterFenceService,
 ): CapitalGrantInterpreter => {
   const requirePaperGenerationRuntime = (
     expectedMaximum: Authority,
@@ -352,8 +351,7 @@ export const makeCapitalGrantInterpreter = (
       Effect.gen(function* () {
         const proof = yield* decodeCapitalGrantProofBinding(candidate)
         const binding = yield* requirePaperGenerationRuntime(Authority.Observe, 'PREPARE')
-        const fence = yield* WriterFence
-        return yield* fence.transaction(prepareCapitalGrantTransaction(proof, binding))
+        return yield* writerFence.transaction(prepareCapitalGrantTransaction(proof, binding))
       }),
     )
 
@@ -484,8 +482,7 @@ export const makeCapitalGrantInterpreter = (
       Effect.gen(function* () {
         const proof = yield* decodeCapitalGrantProofBinding(candidate)
         const binding = yield* requirePaperGenerationRuntime(Authority.Paper, 'activation')
-        const fence = yield* WriterFence
-        return yield* fence.transaction(activatePaperGenerationTransaction(proof, binding))
+        return yield* writerFence.transaction(activatePaperGenerationTransaction(proof, binding))
       }),
     )
 
@@ -615,8 +612,7 @@ export const makeCapitalGrantInterpreter = (
             build: config.build,
           }),
         )
-        const fence = yield* WriterFence
-        return yield* fence.transaction(activateResearchPaperGenerationTransaction(proof, binding))
+        return yield* writerFence.transaction(activateResearchPaperGenerationTransaction(proof, binding))
       }),
     )
 

--- a/services/bayn/src/db/execution-store/contract.ts
+++ b/services/bayn/src/db/execution-store/contract.ts
@@ -2,7 +2,6 @@ import { Context, Data, Effect } from 'effect'
 
 import type { BrokerEventInput, FillEventInput, PositionSnapshotInput, ValuationInput } from '../../broker/observations'
 import type { RuntimeConfig } from '../../config'
-import type { WriterFence } from '../../execution/writer-fence'
 import type {
   AccountingReceipt,
   Authority,
@@ -50,13 +49,6 @@ export class ExecutionStoreError extends Data.TaggedError('ExecutionStoreError')
   readonly cause?: unknown
 }> {}
 
-/**
- * The capital-grant lifecycle is the execution store's writer-fenced interpreter boundary. Its operations acquire the
- * process-wide WriterFence at invocation time; all other execution-store capabilities remain fence-free because they
- * do not own the authority-generation transaction.
- */
-export type WriterFencedExecutionStoreOperation<A> = Effect.Effect<A, ExecutionStoreError, WriterFence>
-
 export interface BrokerEventStoreShape {
   readonly ingest: (input: BrokerEventInput) => Effect.Effect<EventReceipt, ExecutionStoreError>
   readonly ingestPositions: (
@@ -83,7 +75,7 @@ export interface AuthorityGenerationStoreShape {
     input: EnsureAuthorityGenerationInput,
   ) => Effect.Effect<AuthorityState, ExecutionStoreError>
   /** Read-only recovery view used to resume a durable PAPER close lease after process restart. */
-  readonly readAuthorityState?: () => Effect.Effect<AuthorityState, ExecutionStoreError>
+  readonly readAuthorityState?: Effect.Effect<AuthorityState, ExecutionStoreError>
   readonly readAuthorityGeneration?: (
     generationHash: string,
   ) => Effect.Effect<CapitalGrantGeneration | undefined, ExecutionStoreError>
@@ -92,6 +84,7 @@ export interface AuthorityGenerationStoreShape {
   ) => Effect.Effect<ResearchCapitalGrantGeneration | undefined, ExecutionStoreError>
 }
 
+/** Domain operations; the live Layer captures the process-wide writer fence. */
 export interface CapitalGrantLifecycleStoreShape {
   /**
    * PREPARE operation: transactionally derives the stable canonical capital-grant generation identity plus current
@@ -100,7 +93,7 @@ export interface CapitalGrantLifecycleStoreShape {
    */
   readonly prepareCapitalGrant: (
     proof: CapitalGrantProofBinding,
-  ) => WriterFencedExecutionStoreOperation<CapitalGrantGeneration>
+  ) => Effect.Effect<CapitalGrantGeneration, ExecutionStoreError>
   /**
    * SUBMIT activation operation: transactionally re-derives the stable generation identity
    * from the same proof binding, requires its hash to equal the configured generationHash, and records the latest
@@ -108,9 +101,7 @@ export interface CapitalGrantLifecycleStoreShape {
    * writer; application code and operators must not issue direct DML against authority_state or
    * authority_generations.
    */
-  readonly activateCapitalGrant: (
-    proof: CapitalGrantProofBinding,
-  ) => WriterFencedExecutionStoreOperation<AuthorityState>
+  readonly activateCapitalGrant: (proof: CapitalGrantProofBinding) => Effect.Effect<AuthorityState, ExecutionStoreError>
   /**
    * Atomically derives a reconciliation-bound research generation, records it, and activates PAPER authority. The
    * static request intentionally cannot predict this generation hash because reconciliation continues until the
@@ -118,7 +109,7 @@ export interface CapitalGrantLifecycleStoreShape {
    */
   readonly activateResearchCapitalGrant: (
     proof: ResearchCapitalGrantProofBinding,
-  ) => WriterFencedExecutionStoreOperation<AuthorityState>
+  ) => Effect.Effect<AuthorityState, ExecutionStoreError>
 }
 
 export interface AuthorityRestrictionStoreShape {

--- a/services/bayn/src/db/execution-store/observe-authority.ts
+++ b/services/bayn/src/db/execution-store/observe-authority.ts
@@ -117,7 +117,7 @@ export interface ObserveAuthorityInterpreter {
   readonly ensureAuthorityGeneration: (
     input: EnsureAuthorityGenerationInput,
   ) => Effect.Effect<AuthorityState, ExecutionStoreError>
-  readonly readAuthorityState: () => Effect.Effect<AuthorityState, ExecutionStoreError>
+  readonly readAuthorityState: Effect.Effect<AuthorityState, ExecutionStoreError>
   readonly readAuthorityGeneration: (
     generationHash: string,
   ) => Effect.Effect<CapitalGrantGeneration | undefined, ExecutionStoreError>
@@ -422,23 +422,22 @@ export const makeObserveAuthorityInterpreter = (
       ),
     )
 
-  const readAuthorityState = () =>
-    runExecutionOperation(
-      'authority',
-      sql<Record<string, unknown>>`
+  const readAuthorityState = runExecutionOperation(
+    'authority',
+    sql<Record<string, unknown>>`
         SELECT schema_version, generation_hash, maximum, effective, kill_state, reason,
           version::text AS version, updated_at
         FROM authority_state
         WHERE singleton
       `.pipe(
-        Effect.flatMap(decodeAuthorityStateRows),
-        Effect.flatMap((rows) =>
-          rows[0] === undefined
-            ? failExecutionStore('authority', 'invariant', 'durable authority state is missing')
-            : authorityStateFromRow(rows[0]),
-        ),
+      Effect.flatMap(decodeAuthorityStateRows),
+      Effect.flatMap((rows) =>
+        rows[0] === undefined
+          ? failExecutionStore('authority', 'invariant', 'durable authority state is missing')
+          : authorityStateFromRow(rows[0]),
       ),
-    )
+    ),
+  )
 
   const readAuthorityGeneration = (generationHash: string) =>
     runExecutionOperation(
@@ -451,7 +450,7 @@ export const makeObserveAuthorityInterpreter = (
             row.maximum !== Authority.Paper ||
             row.activation_schema_version !== 'bayn.paper-authority-generation.v2'
           ) {
-            return Effect.succeed(undefined)
+            return Effect.as(Effect.void, undefined)
           }
           return paperGenerationFromRow(row).pipe(Effect.map((generation) => generation))
         }),
@@ -469,7 +468,7 @@ export const makeObserveAuthorityInterpreter = (
             row.maximum !== Authority.Paper ||
             row.activation_schema_version !== 'bayn.paper-authority-generation.v3'
           ) {
-            return Effect.succeed(undefined)
+            return Effect.as(Effect.void, undefined)
           }
           return researchPaperGenerationFromRow(row).pipe(Effect.map((generation) => generation))
         }),

--- a/services/bayn/src/db/execution-store/postgres.ts
+++ b/services/bayn/src/db/execution-store/postgres.ts
@@ -1,6 +1,7 @@
 import { PgClient } from '@effect/sql-pg'
 import { Effect } from 'effect'
 
+import { WriterFence } from '../../execution/writer-fence'
 import { Journal } from '../../ledger'
 import { makeReconciliation, restrictAuthority } from '../reconciliation'
 import { makeAccountingInterpreter } from './accounting'
@@ -17,13 +18,14 @@ export const makeExecutionPersistence = (config: ExecutionStoreRuntimeConfig) =>
   Effect.gen(function* () {
     const sql = yield* PgClient.PgClient
     const journal = yield* Journal
+    const writerFence = yield* WriterFence
     const events = makeBrokerEventInterpreter(sql)
     const accounting = makeAccountingInterpreter(sql, journal, config, events)
     const valuation = makeValuationInterpreter(sql)
     const reconciliation = makeReconciliation(sql, journal, config)
     const authorityPostgres = makeAuthorityPostgres(sql)
     const observeAuthority = makeObserveAuthorityInterpreter(sql, authorityPostgres, config.execution.brokerIdentity)
-    const capitalGrant = makeCapitalGrantInterpreter(sql, authorityPostgres, config)
+    const capitalGrant = makeCapitalGrantInterpreter(sql, authorityPostgres, config, writerFence)
 
     return {
       events,

--- a/services/bayn/src/db/forward-performance-receipt-postgres.ts
+++ b/services/bayn/src/db/forward-performance-receipt-postgres.ts
@@ -80,17 +80,17 @@ const makeStore = Effect.gen(function* () {
           `
             const stored = yield* readByGeneration(sql, envelope.authorityGenerationHash)
             if (Option.isNone(stored)) {
-              return yield* Effect.fail(
-                storeError('bind', 'invariant', 'forward-performance receipt disappeared after its immutable bind'),
+              return yield* storeError(
+                'bind',
+                'invariant',
+                'forward-performance receipt disappeared after its immutable bind',
               )
             }
             if (stored.value.contentHash !== envelope.contentHash) {
-              return yield* Effect.fail(
-                storeError(
-                  'bind',
-                  'conflict',
-                  'forward-performance receipt generation was reused with different immutable content',
-                ),
+              return yield* storeError(
+                'bind',
+                'conflict',
+                'forward-performance receipt generation was reused with different immutable content',
               )
             }
             return stored.value

--- a/services/bayn/src/db/live-capital-grant.ts
+++ b/services/bayn/src/db/live-capital-grant.ts
@@ -354,7 +354,7 @@ const makeStore = Effect.gen(function* () {
           : storeError('read', 'decode', 'live capital grant row decoding failed', cause),
       ),
       Effect.flatMap((rows) => {
-        if (rows.length === 0) return Effect.succeed(undefined)
+        if (rows.length === 0) return Effect.as(Effect.void, undefined)
         if (rows.length !== 1) {
           return Effect.fail(storeError('read', 'invariant', 'live capital grant query returned duplicate rows'))
         }
@@ -370,7 +370,7 @@ const makeStore = Effect.gen(function* () {
       Effect.mapError((cause) => storeError('lock-submit', 'decode', 'invalid live capital grant hash', cause)),
       Effect.flatMap((grantHash) =>
         lockGrant('lock-submit', grantHash).pipe(
-          Effect.flatMap((exists) => (exists ? read(grantHash) : Effect.succeed(undefined))),
+          Effect.flatMap((exists) => (exists ? read(grantHash) : Effect.as(Effect.void, undefined))),
         ),
       ),
     )

--- a/services/bayn/src/db/paper-cycle-closure-postgres.ts
+++ b/services/bayn/src/db/paper-cycle-closure-postgres.ts
@@ -165,13 +165,17 @@ const makeStore = Effect.gen(function* () {
           `
             const stored = yield* readReplanByHash(sql, closure.cycleId, closure.contentHash)
             if (Option.isNone(stored)) {
-              return yield* Effect.fail(
-                storeError('bind-replan', 'invariant', 'paper close replan disappeared after its immutable bind'),
+              return yield* storeError(
+                'bind-replan',
+                'invariant',
+                'paper close replan disappeared after its immutable bind',
               )
             }
             if (stored.value.contentHash !== closure.contentHash) {
-              return yield* Effect.fail(
-                storeError('bind-replan', 'conflict', 'paper close replan identity was reused with different content'),
+              return yield* storeError(
+                'bind-replan',
+                'conflict',
+                'paper close replan identity was reused with different content',
               )
             }
             return stored.value
@@ -204,13 +208,13 @@ const makeStore = Effect.gen(function* () {
           `
             const stored = yield* readByCycleId(sql, closure.cycleId)
             if (Option.isNone(stored)) {
-              return yield* Effect.fail(
-                storeError('bind', 'invariant', 'paper closure disappeared after its immutable bind'),
-              )
+              return yield* storeError('bind', 'invariant', 'paper closure disappeared after its immutable bind')
             }
             if (stored.value.contentHash !== closure.contentHash) {
-              return yield* Effect.fail(
-                storeError('bind', 'conflict', 'paper closure identity was reused with different immutable content'),
+              return yield* storeError(
+                'bind',
+                'conflict',
+                'paper closure identity was reused with different immutable content',
               )
             }
             return stored.value

--- a/services/bayn/src/execution-prepare/execution-prepare.test.ts
+++ b/services/bayn/src/execution-prepare/execution-prepare.test.ts
@@ -12,7 +12,6 @@ import {
 import { validateDerivedPaperGeneration } from '../db/capital-grant-algebra'
 import { BrokerAccess, CapitalAuthorityKind } from '../execution/authority'
 import { Authority, makeCapitalGrantGenerationResult, type CapitalGrantGeneration } from '../execution/contracts'
-import { WriterFence, type WriterFenceService } from '../execution/writer-fence'
 import { canonicalHashV1OrThrow, sha256 } from '../hash'
 import { renderExecutionPrepareFailure } from './failure'
 import type { ExecutionPrepareGenerationField } from './failure'
@@ -707,12 +706,6 @@ describe('EXECUTION_PREPARE pure validation', () => {
   })
 })
 
-const writerFence: WriterFenceService = {
-  backendPid: 1,
-  check: Effect.void,
-  transaction: (effect) => effect,
-}
-
 const unusedResearchCapitalGrantLifecycle = {
   activateResearchCapitalGrant: () => Effect.die(new Error('research activation must remain unreachable')),
 } satisfies Pick<CapitalGrantLifecycleStoreShape, 'activateResearchCapitalGrant'>
@@ -724,7 +717,6 @@ const runProgram = (
 ) =>
   prepareExecution(candidateRequest, runtime, trustedReceipt).pipe(
     Effect.provideService(CapitalGrantLifecycleStore, lifecycle),
-    Effect.provideService(WriterFence, writerFence),
   )
 
 describe('EXECUTION_PREPARE program boundary', () => {
@@ -761,7 +753,6 @@ describe('EXECUTION_PREPARE program boundary', () => {
     const output = await Effect.runPromise(
       prepareValidatedExecutionWithGeneration(validated()).pipe(
         Effect.provideService(CapitalGrantLifecycleStore, lifecycle),
-        Effect.provideService(WriterFence, writerFence),
       ),
     )
 

--- a/services/bayn/src/execution-prepare/live.ts
+++ b/services/bayn/src/execution-prepare/live.ts
@@ -5,12 +5,14 @@ import type { RuntimeConfig } from '../config'
 import { CapitalGrantLifecycleStore } from '../db/execution-store'
 import { makeAuthorityPostgres } from '../db/execution-store/authority-shared'
 import { makeCapitalGrantInterpreter } from '../db/execution-store/capital-grant'
+import { WriterFence } from '../execution/writer-fence'
 
 export const ExecutionPrepareStoreLive = (config: RuntimeConfig) =>
   Layer.effect(
     CapitalGrantLifecycleStore,
     Effect.gen(function* () {
       const sql = yield* PgClient.PgClient
-      return makeCapitalGrantInterpreter(sql, makeAuthorityPostgres(sql), config)
+      const writerFence = yield* WriterFence
+      return makeCapitalGrantInterpreter(sql, makeAuthorityPostgres(sql), config, writerFence)
     }),
   )

--- a/services/bayn/src/execution-prepare/program.ts
+++ b/services/bayn/src/execution-prepare/program.ts
@@ -5,7 +5,6 @@ import { CapitalGrantLifecycleStore } from '../db/execution-store'
 import type { ExecutionCandidateDiscoveryReceipt } from '../execution-candidate-discovery'
 import { canonicalHashV1Result } from '../hash'
 import type { CapitalGrantGeneration } from '../execution/contracts'
-import type { WriterFence } from '../execution/writer-fence'
 import type { ExecutionPrepareFailure } from './failure'
 import type {
   ExecutionPrepareProofPlanRequest,
@@ -159,7 +158,7 @@ export const prepareValidatedExecutionWithGeneration = (
     readonly receipt: ExecutionPrepareReceipt
   },
   ExecutionPrepareFailure,
-  CapitalGrantLifecycleStore | WriterFence
+  CapitalGrantLifecycleStore
 > =>
   Effect.gen(function* () {
     const lifecycle = yield* CapitalGrantLifecycleStore
@@ -180,14 +179,14 @@ export const prepareValidatedExecutionWithGeneration = (
 
 export const prepareValidatedExecution = (
   validated: ValidatedExecutionPrepareInput,
-): Effect.Effect<ExecutionPrepareReceipt, ExecutionPrepareFailure, CapitalGrantLifecycleStore | WriterFence> =>
+): Effect.Effect<ExecutionPrepareReceipt, ExecutionPrepareFailure, CapitalGrantLifecycleStore> =>
   prepareValidatedExecutionWithGeneration(validated).pipe(Effect.map(({ receipt }) => receipt))
 
 export const prepareExecution = (
   request: unknown,
   runtime: unknown,
   trustedDiscoveryReceipt: ExecutionCandidateDiscoveryReceipt,
-): Effect.Effect<ExecutionPrepareReceipt, ExecutionPrepareFailure, CapitalGrantLifecycleStore | WriterFence> =>
+): Effect.Effect<ExecutionPrepareReceipt, ExecutionPrepareFailure, CapitalGrantLifecycleStore> =>
   Effect.gen(function* () {
     const prevalidated = yield* Effect.fromResult(validateExecutionPrepareInput(request, runtime))
     const validated = yield* Effect.fromResult(

--- a/services/bayn/src/execution/coordinator.test.ts
+++ b/services/bayn/src/execution/coordinator.test.ts
@@ -1498,29 +1498,25 @@ const makeHarness = (options: HarnessOptions = {}) => {
       lookupClientOrderId = clientOrderId
       if (options.lookupFailureOnceAfterMs !== undefined && lookupCalls === 1) {
         yield* Effect.sleep(Duration.millis(options.lookupFailureOnceAfterMs))
-        return yield* Effect.fail(
-          new BrokerReadError({
-            operation: 'order-by-client-id',
-            kind: BrokerReadErrorKind.Timeout,
-            message: 'injected delayed lookup timeout',
-            retryable: false,
-          }),
-        )
+        return yield* new BrokerReadError({
+          operation: 'order-by-client-id',
+          kind: BrokerReadErrorKind.Timeout,
+          message: 'injected delayed lookup timeout',
+          retryable: false,
+        })
       }
       const observedAt = new Date(yield* Clock.currentTimeMillis).toISOString()
       if (options.notFoundOnce && lookupCalls === 1) {
-        return yield* Effect.fail(
-          new BrokerReadError({
-            operation: 'order-by-client-id',
-            kind: BrokerReadErrorKind.NotFound,
-            message: 'injected delayed visibility',
-            retryable: false,
-            status: 404,
-            requestId: 'lookup-not-found',
-            contentHash: canonicalHashV1({ code: 404, message: 'order not found' }),
-            observedAt,
-          }),
-        )
+        return yield* new BrokerReadError({
+          operation: 'order-by-client-id',
+          kind: BrokerReadErrorKind.NotFound,
+          message: 'injected delayed visibility',
+          retryable: false,
+          status: 404,
+          requestId: 'lookup-not-found',
+          contentHash: canonicalHashV1({ code: 404, message: 'order not found' }),
+          observedAt,
+        })
       }
       const selected =
         options.lookupOrders?.[Math.min(lookupCalls - 1, options.lookupOrders.length - 1)] ??

--- a/services/bayn/src/execution/coordinator.ts
+++ b/services/bayn/src/execution/coordinator.ts
@@ -433,7 +433,7 @@ const continueRecovery = (
 ) =>
   (operation === MutationOperation.Submit
     ? services.mutations.latest(stored.intent.intentId, MutationOperation.Cancel)
-    : Effect.succeed(undefined)
+    : Effect.as(Effect.void, undefined)
   ).pipe(
     Effect.flatMap((cancellation) => liftDecision(validateRecovery(stored.intent, event, cancellation))),
     Effect.andThen(Clock.currentTimeMillis),

--- a/services/bayn/src/execution/intents/postgres.ts
+++ b/services/bayn/src/execution/intents/postgres.ts
@@ -453,13 +453,13 @@ const persistDecision = (
     )
     const stored = yield* readById(sql, 'commit', prepared.intent.intentId)
     if (Option.isNone(stored)) {
-      return yield* Effect.fail(storeError('invariant', 'commit', 'committed intent cannot be read back'))
+      return yield* storeError('invariant', 'commit', 'committed intent cannot be read back')
     }
     const verified = yield* Effect.fromResult(classifyExistingCommit([stored.value], prepared)).pipe(
       Effect.mapError(existingCommitError),
     )
     if (verified._tag !== 'ExactReplay') {
-      return yield* Effect.fail(storeError('invariant', 'commit', 'committed intent readback is incomplete'))
+      return yield* storeError('invariant', 'commit', 'committed intent readback is incomplete')
     }
     return { record: verified.receipt.record, deduplicated: false }
   })

--- a/services/bayn/src/execution/mutation-authority.test.ts
+++ b/services/bayn/src/execution/mutation-authority.test.ts
@@ -863,7 +863,7 @@ describe('final broker mutation authority', () => {
         liveCapitalGrants: {
           read: () => {
             grantReads += 1
-            return Effect.succeed(undefined)
+            return Effect.as(Effect.void, undefined)
           },
         },
         freshBrokerPrice: () => Effect.die(new Error('sandbox must not read a live broker price')),

--- a/services/bayn/src/execution/mutation-authority.ts
+++ b/services/bayn/src/execution/mutation-authority.ts
@@ -801,11 +801,9 @@ export const refreshLiveBrokerSubmitSnapshot = (
     )
     const stablePositions = validateStableLivePositionSnapshot(positionsBefore.value, positionsAfter.value)
     if (Result.isFailure(stablePositions)) {
-      return yield* Effect.fail(
-        mutationAuthorizationError(
-          'live broker position snapshot changed during exposure refresh',
-          stablePositions.failure,
-        ),
+      return yield* mutationAuthorizationError(
+        'live broker position snapshot changed during exposure refresh',
+        stablePositions.failure,
       )
     }
     const quoteSymbols = quoteSymbolsForLiveExposure(intent, openOrders.value)
@@ -955,8 +953,9 @@ export const makeAuthorityGuardedBrokerMutation = (
         const observedAt = yield* dependencies.currentUtcInstant
         const validation = validateLiveBrokerSubmitSnapshot(liveAuthority, persisted, intent, snapshot, observedAt)
         if (Result.isFailure(validation)) {
-          return yield* Effect.fail(
-            mutationAuthorizationError('live broker submit preflight rejected the broker submit', validation.failure),
+          return yield* mutationAuthorizationError(
+            'live broker submit preflight rejected the broker submit',
+            validation.failure,
           )
         }
         return yield* transmit(intent)

--- a/services/bayn/src/execution/runtime-program.ts
+++ b/services/bayn/src/execution/runtime-program.ts
@@ -55,7 +55,7 @@ const finalLiveGrantAuthorization = (
   dependencies: ExecutionProgramDependencies,
 ): Effect.Effect<LiveCapitalAuthority | undefined, FinalSubmitAuthorizationFailure> => {
   const capital = authority.capitalAuthority
-  if (capital._tag !== CapitalAuthorityKind.LiveGrant) return Effect.succeed(undefined)
+  if (capital._tag !== CapitalAuthorityKind.LiveGrant) return Effect.as(Effect.void, undefined)
   const grantHash = capital.grant.grantHash
   return Effect.gen(function* () {
     const persisted = yield* dependencies.liveCapitalGrants.lockForSubmit(grantHash)
@@ -113,7 +113,9 @@ const validatePaperEpisodeLease = (
     }
     const isCloseIntent =
       closeIntent ??
-      (dependencies.isPaperEpisodeCloseIntent ? yield* dependencies.isPaperEpisodeCloseIntent(intentId) : false)
+      (dependencies.isPaperEpisodeCloseIntent !== undefined
+        ? yield* dependencies.isPaperEpisodeCloseIntent(intentId)
+        : false)
     const expiresAt = isCloseIntent ? dependencies.paperEpisodeCloseExpiresAt : dependencies.paperEpisodeEntryExpiresAt
     if (expiresAt === undefined) return
     const observedAt = yield* dependencies.currentUtcInstant
@@ -131,9 +133,10 @@ export const authorizeFinalBrokerSubmit = <A, E, R>(
   return dependencies.writerFence
     .transaction(
       Effect.gen(function* () {
-        const closeOnly = dependencies.isPaperEpisodeCloseIntent
-          ? yield* dependencies.isPaperEpisodeCloseIntent(intent.intentId)
-          : false
+        const closeOnly =
+          dependencies.isPaperEpisodeCloseIntent !== undefined
+            ? yield* dependencies.isPaperEpisodeCloseIntent(intent.intentId)
+            : false
         yield* dependencies.mutationStore.authorizeSubmit(intent.intentId, closeOnly)
         yield* validateFinalSubmitRisk(intent.intentId, dependencies)
         const persisted = yield* finalLiveGrantAuthorization(authority, dependencies)

--- a/services/bayn/src/execution/writer-fence.ts
+++ b/services/bayn/src/execution/writer-fence.ts
@@ -63,13 +63,11 @@ const acquire = Effect.gen(function* () {
     Effect.mapError((cause) => decodeFailure('acquire', cause)),
   )
   if (!acquired) {
-    return yield* Effect.fail(
-      new WriterFenceError({
-        failure: 'busy',
-        operation: 'acquire',
-        message: 'another PostgreSQL session owns the paper writer fence',
-      }),
-    )
+    return yield* new WriterFenceError({
+      failure: 'busy',
+      operation: 'acquire',
+      message: 'another PostgreSQL session owns the paper writer fence',
+    })
   }
 
   yield* Effect.addFinalizer(() =>
@@ -100,13 +98,11 @@ const acquire = Effect.gen(function* () {
       Effect.mapError((cause) => decodeFailure('check', cause)),
     )
     if (!held) {
-      return yield* Effect.fail(
-        new WriterFenceError({
-          failure: 'unavailable',
-          operation: 'check',
-          message: 'PostgreSQL paper writer fence is no longer held',
-        }),
-      )
+      return yield* new WriterFenceError({
+        failure: 'unavailable',
+        operation: 'check',
+        message: 'PostgreSQL paper writer fence is no longer held',
+      })
     }
   })
   const check = transactionPermit.withPermit(checkHeld)

--- a/services/bayn/src/forward-performance-command.ts
+++ b/services/bayn/src/forward-performance-command.ts
@@ -18,6 +18,7 @@ const printUsage = Effect.gen(function* () {
 const runProof = Effect.scoped(
   Effect.gen(function* () {
     const config = yield* loadConfig()
+    // @effect-diagnostics-next-line strictEffectProvide:off -- command subprogram owns its scoped PostgreSQL layer
     const receipt = yield* runForwardPerformance(config).pipe(Effect.provide(PostgresClientLive(config)))
     const output = yield* Effect.fromResult(canonicalJsonV1Result(receipt)).pipe(
       Effect.mapError(
@@ -36,6 +37,7 @@ const runProof = Effect.scoped(
 
 const runtime = Layer.mergeAll(Logger.layer([Logger.consoleJson]), NodeServices.layer)
 const main = process.argv.slice(2).includes('--help') ? printUsage : runProof
+// @effect-diagnostics-next-line strictEffectProvide:off -- command entry point owns the runtime layer
 const program = main.pipe(Effect.annotateLogs({ service: 'bayn-forward-performance' }), Effect.provide(runtime))
 
 if (import.meta.main) NodeRuntime.runMain(program)

--- a/services/bayn/src/forward-performance/program.ts
+++ b/services/bayn/src/forward-performance/program.ts
@@ -411,6 +411,7 @@ export function readForwardPerformanceMarketVolume(
     request_timeout: config.operationTimeoutMs,
   })
   return Effect.scoped(
+    // @effect-diagnostics-next-line strictEffectProvide:off -- scoped ClickHouse query boundary owns the client layer
     readForwardPerformanceMarketVolumeWithClient(config, requests).pipe(Effect.provide(client)),
   ).pipe(
     Effect.mapError((cause) =>

--- a/services/bayn/src/forward-performance/tigerbeetle.ts
+++ b/services/bayn/src/forward-performance/tigerbeetle.ts
@@ -202,18 +202,16 @@ export const readForwardPerformanceLedger = (
     ).pipe(Effect.mapError(ledgerError))
 
     if (accounts.length >= LEDGER_BATCH_MAX || transfers.length >= LEDGER_BATCH_MAX) {
-      return yield* Effect.fail(
-        ledgerError(
-          ledgerValidationError(
-            'verify-account',
-            'batch-limit',
-            'paper account reached the exact TigerBeetle reconciliation limit',
-            {
-              accountCount: accounts.length,
-              transferCount: transfers.length,
-              limit: LEDGER_BATCH_MAX,
-            },
-          ),
+      return yield* ledgerError(
+        ledgerValidationError(
+          'verify-account',
+          'batch-limit',
+          'paper account reached the exact TigerBeetle reconciliation limit',
+          {
+            accountCount: accounts.length,
+            transferCount: transfers.length,
+            limit: LEDGER_BATCH_MAX,
+          },
         ),
       )
     }

--- a/services/bayn/src/index.ts
+++ b/services/bayn/src/index.ts
@@ -4,5 +4,6 @@ import { Effect, Logger, pipe } from 'effect'
 import { program } from './entrypoint'
 
 NodeRuntime.runMain(
+  // @effect-diagnostics-next-line strictEffectProvide:off -- process entry point owns the logger layer
   pipe(program, Effect.annotateLogs({ service: 'bayn' }), Effect.provide(Logger.layer([Logger.consoleJson]))),
 )

--- a/services/bayn/src/observe-composition.test.ts
+++ b/services/bayn/src/observe-composition.test.ts
@@ -986,7 +986,7 @@ describe('OBSERVE runtime composition', () => {
       read: () => Effect.succeed(Option.none()),
     }
     const mutationStore = {
-      latest: () => Effect.succeed(undefined),
+      latest: () => Effect.void,
     } as unknown as MutationStoreShape
     const waiting = await Effect.runPromise(
       Effect.gen(function* () {
@@ -1298,7 +1298,7 @@ describe('OBSERVE runtime composition', () => {
     ])
 
     const missingStore = {
-      latest: () => Effect.succeed(undefined),
+      latest: () => Effect.void,
     } as unknown as MutationStoreShape
     const failure = await Effect.runPromise(
       Effect.flip(
@@ -1393,7 +1393,7 @@ describe('OBSERVE runtime composition', () => {
         }),
     }
     const store = {
-      latest: () => Effect.succeed(undefined),
+      latest: () => Effect.void,
     } as unknown as MutationStoreShape
     const failure = await Effect.runPromise(
       Effect.flip(
@@ -1584,7 +1584,7 @@ describe('OBSERVE runtime composition', () => {
         }),
     }
     const mutationStore = {
-      latest: () => Effect.succeed(undefined),
+      latest: () => Effect.void,
     } as unknown as MutationStoreShape
     const authorityRestrictionStore: AuthorityRestrictionStoreShape = {
       restrictAuthority: () =>
@@ -1910,7 +1910,7 @@ describe('OBSERVE runtime composition', () => {
       read: () => Effect.succeed(Option.some(plannedRecord)),
     }
     const mutationStore = {
-      latest: () => Effect.succeed(undefined),
+      latest: () => Effect.void,
     } as unknown as MutationStoreShape
     const freshFailure = await Effect.runPromise(
       Effect.gen(function* () {
@@ -2023,7 +2023,7 @@ describe('OBSERVE runtime composition', () => {
       read: () => Effect.succeed(Option.some(plannedRecord)),
     }
     const mutationStore = {
-      latest: () => Effect.succeed(undefined),
+      latest: () => Effect.void,
     } as unknown as MutationStoreShape
     const freshFailure = await Effect.runPromise(
       Effect.gen(function* () {
@@ -2228,7 +2228,7 @@ describe('OBSERVE runtime composition', () => {
       },
     }
     const closeMutationStore = {
-      latest: () => Effect.succeed(undefined),
+      latest: () => Effect.void,
     } as unknown as MutationStoreShape
     const admission = await Effect.runPromise(
       Effect.gen(function* () {

--- a/services/bayn/src/observe-composition.ts
+++ b/services/bayn/src/observe-composition.ts
@@ -1299,12 +1299,10 @@ const ensurePaperCycleClosure = (
     const existing = yield* readPaperCycleClosure(cycle.identity.cycleId, store)
     const entryDecisionHash = cycle.bindings.decisionHash
     if (entryDecisionHash === undefined) {
-      return yield* Effect.fail(
-        mutationRunnerError(
-          'active PAPER cycle has no immutable entry decision hash for its close plan',
-          undefined,
-          'contract',
-        ),
+      return yield* mutationRunnerError(
+        'active PAPER cycle has no immutable entry decision hash for its close plan',
+        undefined,
+        'contract',
       )
     }
     if (existing === undefined) {
@@ -1785,7 +1783,7 @@ const reconcileMutationNotDuePass = (
     const state = yield* Ref.get(cadence)
     const decision = decideIdleReconciliationCadence(state, nowNanos, input.reconciliationIntervalMs)
     if (decision._tag === 'WAIT') {
-      if (state.lastFailure !== undefined) return yield* Effect.fail(state.lastFailure)
+      if (state.lastFailure !== undefined) return yield* state.lastFailure
       return result
     }
     yield* attemptMutationIdleReconciliation(cadence, reconcile)

--- a/services/bayn/src/observe-composition/mutation-intent-interpreter.ts
+++ b/services/bayn/src/observe-composition/mutation-intent-interpreter.ts
@@ -267,12 +267,10 @@ export const prepareMutationIntent = <R, E, I extends MutationIntentInput, P ext
       const target = targets.get(targetIntent.symbol)
       const intentId = document.orderedIntentIds[index]
       if (riskBinding === undefined || target === undefined || intentId === undefined) {
-        return yield* Effect.fail(
-          mutationRunnerError(
-            'durable mutation target is missing its intent, risk, or final-position binding',
-            undefined,
-            'contract',
-          ),
+        return yield* mutationRunnerError(
+          'durable mutation target is missing its intent, risk, or final-position binding',
+          undefined,
+          'contract',
         )
       }
       const stored = yield* intentStore
@@ -288,21 +286,17 @@ export const prepareMutationIntent = <R, E, I extends MutationIntentInput, P ext
         .latest(intentId, MutationOperation.Cancel)
         .pipe(Effect.mapError((cause) => mutationRunnerError('durable cancel state read failed', cause, 'store')))
       if (existing === undefined && (latestSubmit !== undefined || latestCancel !== undefined)) {
-        return yield* Effect.fail(
-          mutationRunnerError(
-            'durable mutation exists without its authority-bound intent',
-            { latestSubmit, latestCancel },
-            'contract',
-          ),
+        return yield* mutationRunnerError(
+          'durable mutation exists without its authority-bound intent',
+          { latestSubmit, latestCancel },
+          'contract',
         )
       }
       if (existing !== undefined && existing.intent.intentId !== intentId) {
-        return yield* Effect.fail(
-          mutationRunnerError(
-            'durable PAPER intent recovery returned a different intent identity',
-            undefined,
-            'contract',
-          ),
+        return yield* mutationRunnerError(
+          'durable PAPER intent recovery returned a different intent identity',
+          undefined,
+          'contract',
         )
       }
       recoveryLookups.push({
@@ -335,17 +329,17 @@ export const prepareMutationIntent = <R, E, I extends MutationIntentInput, P ext
         ),
       )
       if (lookup.intentId !== intent.intentId) {
-        return yield* Effect.fail(
-          mutationRunnerError(
-            'durable PAPER intent identity or order changed after decision binding',
-            undefined,
-            'contract',
-          ),
+        return yield* mutationRunnerError(
+          'durable PAPER intent identity or order changed after decision binding',
+          undefined,
+          'contract',
         )
       }
       if (lookup.stored !== undefined && !immutableIntentBindingMatches(lookup.stored.intent, intent)) {
-        return yield* Effect.fail(
-          mutationRunnerError('stored PAPER intent changed from its durable decision binding', undefined, 'contract'),
+        return yield* mutationRunnerError(
+          'stored PAPER intent changed from its durable decision binding',
+          undefined,
+          'contract',
         )
       }
       preparedIntents.push({ ...lookup, intent })
@@ -420,23 +414,19 @@ export const prepareMutationIntent = <R, E, I extends MutationIntentInput, P ext
       if (
         preparedIntents.some((prepared) => prepared.latestSubmit !== undefined || prepared.latestCancel !== undefined)
       ) {
-        return yield* Effect.fail(
-          mutationRunnerError(
-            'broker mutation evidence exists before the complete immutable intent set was committed',
-            undefined,
-            'contract',
-          ),
+        return yield* mutationRunnerError(
+          'broker mutation evidence exists before the complete immutable intent set was committed',
+          undefined,
+          'contract',
         )
       }
     }
 
     if (input.mutationPhase === 'CLOSE' && intentStore.commitClosing === undefined) {
-      return yield* Effect.fail(
-        mutationRunnerError(
-          'PAPER close intent store does not expose the close-only authority port',
-          undefined,
-          'store',
-        ),
+      return yield* mutationRunnerError(
+        'PAPER close intent store does not expose the close-only authority port',
+        undefined,
+        'store',
       )
     }
     yield* Effect.forEach(
@@ -456,8 +446,10 @@ export const prepareMutationIntent = <R, E, I extends MutationIntentInput, P ext
       document.bindings.snapshotContentHash !== facts.snapshot.contentHash ||
       document.bindings.snapshotFinalizedAt !== facts.snapshot.finalizedAt
     ) {
-      return yield* Effect.fail(
-        mutationRunnerError('bound mutation cycle snapshot publication changed after planning', undefined, 'contract'),
+      return yield* mutationRunnerError(
+        'bound mutation cycle snapshot publication changed after planning',
+        undefined,
+        'contract',
       )
     }
 
@@ -474,8 +466,10 @@ export const prepareMutationIntent = <R, E, I extends MutationIntentInput, P ext
         .pipe(Effect.mapError((cause) => mutationRunnerError('committed PAPER intent readback failed', cause, 'store')))
       const record = Option.getOrUndefined(stored)
       if (record === undefined) {
-        return yield* Effect.fail(
-          mutationRunnerError('committed PAPER intent disappeared before execution selection', undefined, 'contract'),
+        return yield* mutationRunnerError(
+          'committed PAPER intent disappeared before execution selection',
+          undefined,
+          'contract',
         )
       }
       const latest = yield* mutationStore

--- a/services/bayn/src/observe-composition/mutation-interpreter.ts
+++ b/services/bayn/src/observe-composition/mutation-interpreter.ts
@@ -77,36 +77,32 @@ export const executeMutationIntentWithExecutor = <E, R>(
     let event: MutationEvent
     if (existing === undefined) {
       if (action !== 'SUBMIT') {
-        return yield* Effect.fail(
-          mutationRunnerError(
-            `lookup-only PAPER recovery lost its durable ${operation.toLowerCase()} evidence`,
-            { intentId, action, operation },
-            'contract',
-          ),
+        return yield* mutationRunnerError(
+          `lookup-only PAPER recovery lost its durable ${operation.toLowerCase()} evidence`,
+          { intentId, action, operation },
+          'contract',
         )
       }
       if (submitExpiresAt === undefined) {
-        return yield* Effect.fail(
-          mutationRunnerError('fresh PAPER submit is missing its immutable submission cutoff', undefined, 'contract'),
+        return yield* mutationRunnerError(
+          'fresh PAPER submit is missing its immutable submission cutoff',
+          undefined,
+          'contract',
         )
       }
       const submitObservedAt = yield* now
       if (submitObservedAt >= submitExpiresAt) {
-        return yield* Effect.fail(
-          mutationRunnerError(
-            'fresh PAPER submit crossed its immutable submission cutoff before broker I/O',
-            { intentId, submitObservedAt, submitExpiresAt },
-            'contract',
-          ),
+        return yield* mutationRunnerError(
+          'fresh PAPER submit crossed its immutable submission cutoff before broker I/O',
+          { intentId, submitObservedAt, submitExpiresAt },
+          'contract',
         )
       }
       if (executor.submit === undefined) {
-        return yield* Effect.fail(
-          mutationRunnerError(
-            'fresh PAPER submit is unavailable under OBSERVE recovery-only authority',
-            undefined,
-            'contract',
-          ),
+        return yield* mutationRunnerError(
+          'fresh PAPER submit is unavailable under OBSERVE recovery-only authority',
+          undefined,
+          'contract',
         )
       }
       event = yield* executor
@@ -125,8 +121,10 @@ export const executeMutationIntentWithExecutor = <E, R>(
     }
     const settlement = decideMutationIntentSettlement(event.eventType)
     if (settlement._tag === 'Unresolved') {
-      return yield* Effect.fail(
-        mutationRunnerError(`guarded PAPER submit remains unresolved at ${settlement.eventType}`, event, 'operational'),
+      return yield* mutationRunnerError(
+        `guarded PAPER submit remains unresolved at ${settlement.eventType}`,
+        event,
+        'operational',
       )
     }
     return { settlement, consistencyDelayMs: event.consistencyDelayMs, operation }

--- a/services/bayn/src/paper-episode.ts
+++ b/services/bayn/src/paper-episode.ts
@@ -10,12 +10,10 @@ export const QualificationBindingSchema = Schema.Struct({
 })
 export type QualificationBinding = typeof QualificationBindingSchema.Type
 
-export const QualifiedPaperGrantSchema = Schema.Struct({
-  _tag: Schema.Literal('Qualified'),
+export const QualifiedPaperGrantSchema = Schema.TaggedStruct('Qualified', {
   qualification: QualificationBindingSchema,
 })
-export const ResearchPaperGrantSchema = Schema.Struct({
-  _tag: Schema.Literal('Research'),
+export const ResearchPaperGrantSchema = Schema.TaggedStruct('Research', {
   planHash: Sha256Schema,
 })
 export const PaperGrantSchema = Schema.Union([QualifiedPaperGrantSchema, ResearchPaperGrantSchema])

--- a/services/bayn/src/paper-proof/mutations.ts
+++ b/services/bayn/src/paper-proof/mutations.ts
@@ -54,8 +54,8 @@ export interface PaperProofSubmitDependencies extends PaperProofRestrictionDepen
       beforeBrokerMutation: PaperProofExecutionHook,
     ) => Effect.Effect<MutationEvent, Error>
   }
-  readonly prepareIntent: () => Effect.Effect<PreparedPaperProofIntent, Error>
-  readonly reconcile: () => Effect.Effect<PaperProofReconciliation, Error>
+  readonly prepareIntent: Effect.Effect<PreparedPaperProofIntent, Error>
+  readonly reconcile: Effect.Effect<PaperProofReconciliation, Error>
 }
 
 export interface PaperProofCancelDependencies extends PaperProofRestrictionDependencies {
@@ -72,14 +72,14 @@ export interface PaperProofCancelDependencies extends PaperProofRestrictionDepen
     ) => Effect.Effect<MutationEvent, Error>
   }
   readonly readIntent: (intentId: string) => Effect.Effect<PaperProofIntentSnapshot | undefined, Error>
-  readonly reconcile: () => Effect.Effect<PaperProofReconciliation, Error>
+  readonly reconcile: Effect.Effect<PaperProofReconciliation, Error>
 }
 
 const prepareSubmitIntent = (
   context: PaperProofOperationContext,
   dependencies: PaperProofSubmitDependencies,
 ): Effect.Effect<PreparedPaperProofIntent, PaperProofError> =>
-  lift('SUBMIT', 'paper proof intent preparation failed', dependencies.prepareIntent()).pipe(
+  lift('SUBMIT', 'paper proof intent preparation failed', dependencies.prepareIntent).pipe(
     Effect.flatMap((prepared) =>
       prepared.intentId === context.sourcePlan.intentId
         ? Effect.succeed(prepared)
@@ -263,13 +263,11 @@ export const runPaperProofSubmit = (
       MutationOperation.Cancel,
     )
     if (cancellation !== undefined) {
-      return yield* Effect.fail(
-        paperProofFailure(
-          'SUBMIT',
-          'paper proof submit is superseded by a durable cancellation mutation',
-          cancellation,
-          'mutation-unresolved',
-        ),
+      return yield* paperProofFailure(
+        'SUBMIT',
+        'paper proof submit is superseded by a durable cancellation mutation',
+        cancellation,
+        'mutation-unresolved',
       )
     }
     const existing = yield* readPaperProofMutation(context, 'SUBMIT', dependencies.mutations, MutationOperation.Submit)

--- a/services/bayn/src/paper-proof/operations.ts
+++ b/services/bayn/src/paper-proof/operations.ts
@@ -31,7 +31,7 @@ export interface PaperProofOperationContext<Operation extends PaperProofOperatio
 
 export interface PaperProofContainmentDependencies {
   readonly restrictAuthority: (reason: string, updatedAt: string) => Effect.Effect<void, Error>
-  readonly reconcile: () => Effect.Effect<PaperProofReconciliation, Error>
+  readonly reconcile: Effect.Effect<PaperProofReconciliation, Error>
   readonly currentUtcInstant: Effect.Effect<string, Error>
 }
 
@@ -124,15 +124,15 @@ export const validateExactReconciliation = (
 
 export const observeReconciliation = (
   accountId: string,
-  reconcile: () => Effect.Effect<PaperProofReconciliation, Error>,
+  reconcile: Effect.Effect<PaperProofReconciliation, Error>,
 ): Effect.Effect<PaperProofReconciliation, PaperProofError> =>
-  lift('RECONCILE', 'paper proof reconciliation failed', reconcile()).pipe(
+  lift('RECONCILE', 'paper proof reconciliation failed', reconcile).pipe(
     Effect.flatMap((result) => Effect.fromResult(validateReconciliationAccount(accountId, result))),
   )
 
 export const reconcileExact = (
   accountId: string,
-  reconcile: () => Effect.Effect<PaperProofReconciliation, Error>,
+  reconcile: Effect.Effect<PaperProofReconciliation, Error>,
 ): Effect.Effect<PaperProofReconciliation, PaperProofError> =>
   observeReconciliation(accountId, reconcile).pipe(
     Effect.flatMap((result) => Effect.fromResult(validateExactReconciliation(result))),
@@ -381,7 +381,7 @@ export const ensureRecoveryMarkerCompatible = (
     context.command.containmentIoTimeoutMs,
   ).pipe(
     Effect.flatMap((existing) => {
-      if (existing === undefined) return Effect.succeed(undefined)
+      if (existing === undefined) return Effect.as(Effect.void, undefined)
       if (!recoveryIdentityMatches(context, existing)) {
         return Effect.fail(
           paperProofFailure(
@@ -581,13 +581,11 @@ export const completeRecovery = (
   Effect.gen(function* () {
     if (completion.operation === 'SUBMIT') {
       if (latestCancellation === undefined) {
-        return yield* Effect.fail(
-          paperProofFailure(
-            'RECOVERY_STATE',
-            'paper proof submit completion is missing its cancellation-state reader',
-            completion,
-            'invariant',
-          ),
+        return yield* paperProofFailure(
+          'RECOVERY_STATE',
+          'paper proof submit completion is missing its cancellation-state reader',
+          completion,
+          'invariant',
         )
       }
       const cancellation = yield* lift(
@@ -596,13 +594,11 @@ export const completeRecovery = (
         latestCancellation(),
       )
       if (cancellation !== undefined) {
-        return yield* Effect.fail(
-          paperProofFailure(
-            'RECOVERY_STATE',
-            'paper proof submit completion is superseded by a durable cancellation mutation',
-            cancellation,
-            'mutation-unresolved',
-          ),
+        return yield* paperProofFailure(
+          'RECOVERY_STATE',
+          'paper proof submit completion is superseded by a durable cancellation mutation',
+          cancellation,
+          'mutation-unresolved',
         )
       }
     }

--- a/services/bayn/src/paper-proof/prepare.ts
+++ b/services/bayn/src/paper-proof/prepare.ts
@@ -13,7 +13,7 @@ import type { PaperProofError, PaperProofReceipt, PaperProofReconciliation } fro
 
 export interface PaperProofPrepareDependencies {
   readonly prepareCapitalGrant: (proof: CapitalGrantProofBinding) => Effect.Effect<CapitalGrantGeneration, Error>
-  readonly reconcile: () => Effect.Effect<PaperProofReconciliation, Error>
+  readonly reconcile: Effect.Effect<PaperProofReconciliation, Error>
   readonly currentUtcInstant: Effect.Effect<string, Error>
 }
 

--- a/services/bayn/src/paper-proof/program.test.ts
+++ b/services/bayn/src/paper-proof/program.test.ts
@@ -298,7 +298,7 @@ const fixture = (options: FixtureOptions) => {
       calls.activate += 1
       sequence.push('activate')
       if (options.neverActivation === true) return Effect.never
-      return options.failActivation === true ? Effect.fail(new Error('activation failed')) : Effect.succeed(undefined)
+      return options.failActivation === true ? Effect.fail(new Error('activation failed')) : Effect.void
     },
     restrictAuthority: () => {
       calls.restrict += 1
@@ -420,25 +420,24 @@ const fixture = (options: FixtureOptions) => {
         return Effect.succeed(recovered)
       },
     },
-    prepareIntent: () =>
-      Effect.suspend(() => {
-        calls.prepareIntent += 1
-        sequence.push('intent:prepare')
-        if (options.neverPrepareIntent === true) return Effect.never
-        if (options.failPrepareIntent === true) return Effect.fail(new Error('intent preparation failed'))
-        return Effect.succeed({
-          intentId,
-          clientOrderId: `b1_${'A'.repeat(43)}`,
-          deduplicated: false,
-        })
-      }),
+    prepareIntent: Effect.suspend(() => {
+      calls.prepareIntent += 1
+      sequence.push('intent:prepare')
+      if (options.neverPrepareIntent === true) return Effect.never
+      if (options.failPrepareIntent === true) return Effect.fail(new Error('intent preparation failed'))
+      return Effect.succeed({
+        intentId,
+        clientOrderId: `b1_${'A'.repeat(43)}`,
+        deduplicated: false,
+      })
+    }),
     readIntent: () => {
       calls.readIntent += 1
       sequence.push(`intent:read:${calls.readIntent.toString()}`)
       const index = Math.min(calls.readIntent - 1, intentSnapshots.length - 1)
       return Effect.succeed(intentSnapshots[index])
     },
-    reconcile: () => {
+    reconcile: Effect.suspend(() => {
       calls.reconcile += 1
       sequence.push(`reconcile:${calls.reconcile.toString()}`)
       if (options.neverReconcileCalls?.includes(calls.reconcile) === true) return Effect.never
@@ -453,7 +452,7 @@ const fixture = (options: FixtureOptions) => {
         unknownMutationCount: options.reconciliationUnknownCounts?.[calls.reconcile - 1] ?? 0,
         reconciledAt: '2026-07-31T08:00:00.000Z',
       })
-    },
+    }),
     currentUtcInstant: Effect.suspend(() => {
       calls.clock += 1
       if (options.neverClockCalls?.includes(calls.clock) === true) return Effect.never

--- a/services/bayn/src/paper-proof/program.ts
+++ b/services/bayn/src/paper-proof/program.ts
@@ -125,7 +125,7 @@ const containFailure = (
       liftBounded(
         'RECONCILE',
         'paper proof containment reconciliation failed',
-        dependencies.reconcile(),
+        dependencies.reconcile,
         context.containmentIoTimeoutMs,
       ).pipe(Effect.flatMap((result) => Effect.fromResult(validateReconciliationAccount(accountId, result)))),
     )

--- a/services/bayn/src/paper-proof/recovery.ts
+++ b/services/bayn/src/paper-proof/recovery.ts
@@ -47,7 +47,7 @@ export interface PaperProofRecoverDependencies extends PaperProofRestrictionDepe
     readonly recoverCancel: (intentId: string) => Effect.Effect<MutationEvent, Error>
   }
   readonly readIntent: (intentId: string) => Effect.Effect<PaperProofIntentSnapshot | undefined, Error>
-  readonly reconcile: () => Effect.Effect<PaperProofReconciliation, Error>
+  readonly reconcile: Effect.Effect<PaperProofReconciliation, Error>
 }
 
 const cancellationTerminal = (

--- a/services/bayn/src/resources.test.ts
+++ b/services/bayn/src/resources.test.ts
@@ -406,9 +406,7 @@ describe('Bayn resource lifecycle', () => {
 
     await Effect.runPromise(
       Effect.scoped(
-        Effect.gen(function* () {
-          yield* Journal
-        }).pipe(
+        Journal.pipe(
           Effect.provide(
             JournalLive(config, {
               createClient: () => tigerBeetleClient,

--- a/services/bayn/tsconfig.json
+++ b/services/bayn/tsconfig.json
@@ -21,7 +21,8 @@
       {
         "name": "@effect/language-service",
         "diagnostics": true,
-        "includeSuggestionsInTsc": false,
+        "includeSuggestionsInTsc": true,
+        "ignoreEffectSuggestionsInTscExitCode": false,
         "ignoreEffectErrorsInTscExitCode": false,
         "ignoreEffectWarningsInTscExitCode": false,
         "diagnosticSeverity": {
@@ -32,6 +33,9 @@
           "multipleEffectProvide": "error",
           "schemaNumber": "error",
           "scopeInLayerEffect": "error",
+          "strictBooleanExpressions": "error",
+          "strictEffectProvide": "error",
+          "unsafeEffectTypeAssertion": "error",
           "unknownInEffectCatch": "error"
         },
         "overrides": [
@@ -46,6 +50,9 @@
                 "multipleEffectProvide": "off",
                 "schemaNumber": "off",
                 "scopeInLayerEffect": "off",
+                "strictBooleanExpressions": "off",
+                "strictEffectProvide": "off",
+                "unsafeEffectTypeAssertion": "off",
                 "unknownInEffectCatch": "off"
               }
             }

--- a/services/bayn/tsconfig.production.json
+++ b/services/bayn/tsconfig.production.json
@@ -1,7 +1,30 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "noUncheckedIndexedAccess": true
+    "noUncheckedIndexedAccess": true,
+    "plugins": [
+      {
+        "name": "@effect/language-service",
+        "diagnostics": true,
+        "includeSuggestionsInTsc": true,
+        "ignoreEffectSuggestionsInTscExitCode": false,
+        "ignoreEffectErrorsInTscExitCode": false,
+        "ignoreEffectWarningsInTscExitCode": false,
+        "diagnosticSeverity": {
+          "anyUnknownInErrorContext": "error",
+          "globalDateInEffect": "error",
+          "globalErrorInEffectCatch": "error",
+          "globalErrorInEffectFailure": "error",
+          "multipleEffectProvide": "error",
+          "schemaNumber": "error",
+          "scopeInLayerEffect": "error",
+          "strictBooleanExpressions": "error",
+          "strictEffectProvide": "error",
+          "unsafeEffectTypeAssertion": "error",
+          "unknownInEffectCatch": "error"
+        }
+      }
+    ]
   },
   "include": ["src/**/*.ts"],
   "exclude": ["src/**/*.test.ts", "src/**/*.integration.test.ts", "src/**/*test-support.ts", "src/test-fixtures.ts"]


### PR DESCRIPTION
## Summary

- makes every default Effect TSGo error, warning, and suggestion blocking in both the full and production profiles, with a dedicated clean `diagnostics --strict` result
- enables the off-by-default production safety rules for strict boolean conditions, unsafe Effect channel assertions, and Layer provisioning outside explicit boundaries
- applies the documented Effect refactors: yieldable errors, tagged structs, direct Effects instead of zero-argument Effect wrappers, and simplified pipelines
- captures `WriterFence` when lifecycle Layers are built so the public capital-grant service exposes only domain operations and no interpreter requirement
- documents only real dynamic subprogram and application Layer boundaries; value-only Layers are identified explicitly rather than hidden behind another DI abstraction
- retains narrow documented suppressions only where replacing typed `undefined` with `Effect.void` would change the public success type

## Related Issues

None

## Testing

- `bun --cwd=services/bayn run tsc`
- `services/bayn/node_modules/@effect/tsgo/dist/effect-tsgo.js diagnostics --strict --project services/bayn/tsconfig.production.json --format text` (341 files, 0 findings)
- `bun --cwd=services/bayn run lint`
- `bun --cwd=services/bayn run lint:oxlint:type` (465 files, 0 findings)
- `bun --cwd=services/bayn test` (1,054 pass, 160 environment-gated PostgreSQL skips, 0 fail)
- `bun test services/bayn/src/execution/runtime-program.test.ts services/bayn/src/composition.test.ts services/bayn/src/forward-performance/program.test.ts services/bayn/src/observe-composition.test.ts` (77 pass, 0 fail)
- `bun --cwd=services/bayn run test:postgres` (0 fail; integration cases skipped locally because no test database URL is configured)
- `bun --cwd=services/bayn run build` (793 modules)

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.