### PR TITLE
refactor(bayn): make core domain APIs pipeable

### DIFF
--- a/services/bayn/src/accounting/domain.ts
+++ b/services/bayn/src/accounting/domain.ts
@@ -16,6 +16,7 @@ import { roundUnsignedHalfUp } from '../unsigned-round-half-up'
 import { type AccountingFailure, type AccountingHashOperation, type AccountingMicrosField } from './failure'
 import type { PositionCost, PreparedAccounting } from './model'
 import { decodeAccountingTransaction, type AccountingTransaction } from './schema'
+import { Pipeable } from '../pipeable'
 
 const MICROS = 1_000_000n
 type AccountCodeValue = (typeof AccountCode)[keyof typeof AccountCode]
@@ -367,7 +368,10 @@ const requireLedgerPlanHash = (
     ),
   )
 
-export const rebuildAccountingLedger = (input: unknown, ledger: number): Result.Result<LedgerPlan, AccountingFailure> =>
+const rebuildAccountingLedgerDataFirst = (
+  input: unknown,
+  ledger: number,
+): Result.Result<LedgerPlan, AccountingFailure> =>
   pipe(
     decodeAccountingTransaction(input),
     Result.mapError((cause): AccountingFailure => ({ _tag: 'AccountingTransactionDecodeFailed', cause })),
@@ -398,7 +402,9 @@ export const rebuildAccountingLedger = (input: unknown, ledger: number): Result.
     ),
   )
 
-export const prepareAccounting = (
+export const rebuildAccountingLedger = Pipeable.dual(2, rebuildAccountingLedgerDataFirst)
+
+const prepareAccountingDataFirst = (
   brokerEventId: string,
   fill: Fill,
   prior: PositionCost,
@@ -455,3 +461,5 @@ export const prepareAccounting = (
       ),
     ),
   )
+
+export const prepareAccounting = Pipeable.dual(4, prepareAccountingDataFirst)

--- a/services/bayn/src/audit/audit.ts
+++ b/services/bayn/src/audit/audit.ts
@@ -13,6 +13,7 @@ import {
 } from '../types'
 import type { ReferenceEvaluationFailure } from './reference'
 import type { StrategyApplication } from '../strategy/core'
+import { Pipeable } from '../pipeable'
 
 export const auditContract = {
   name: 'risk-balanced-trend',
@@ -118,7 +119,7 @@ export type SignalTableClassificationFailure = {
   readonly expectedTables: readonly string[]
 }
 
-export const classifySignalTableAccess = (
+const classifySignalTableAccessDataFirst = (
   observedTables: readonly string[],
   signalTables: InputManifest['tables'],
 ): Result.Result<SignalAccessRecord['kind'], SignalTableClassificationFailure> => {
@@ -136,6 +137,8 @@ export const classifySignalTableAccess = (
     ].sort(),
   })
 }
+
+export const classifySignalTableAccess = Pipeable.dual(2, classifySignalTableAccessDataFirst)
 
 export interface RepositoryAudit {
   readonly sourceCommitExists: boolean

--- a/services/bayn/src/audit/core.ts
+++ b/services/bayn/src/audit/core.ts
@@ -20,10 +20,11 @@ import type {
 } from './audit'
 import { evaluateReference, type ReferenceEvaluation } from './reference'
 import { auditContract } from './audit'
+import { Pipeable } from '../pipeable'
 
 export const MICROS_STRING = '1000000'
 
-export const hashAuditMaterial = (
+const hashAuditMaterialDataFirst = (
   subject: AuditCanonicalizationSubject,
   value: unknown,
 ): Result.Result<string, QualificationAuditFailure> =>
@@ -32,7 +33,9 @@ export const hashAuditMaterial = (
     (cause): QualificationAuditFailure => ({ _tag: 'AuditCanonicalizationFailed', subject, cause }),
   )
 
-export const sameAuditMaterial = (
+export const hashAuditMaterial = Pipeable.dual(2, hashAuditMaterialDataFirst)
+
+const sameAuditMaterialDataFirst = (
   subject: AuditCanonicalizationSubject,
   left: unknown,
   right: unknown,
@@ -43,12 +46,16 @@ export const sameAuditMaterial = (
     return leftHash === rightHash
   })
 
-export const auditHashMatches = (
+export const sameAuditMaterial = Pipeable.dual(3, sameAuditMaterialDataFirst)
+
+const auditHashMatchesDataFirst = (
   subject: AuditCanonicalizationSubject,
   value: unknown,
   expectedHash: string,
 ): Result.Result<boolean, QualificationAuditFailure> =>
   Result.map(hashAuditMaterial(subject, value), (actualHash) => actualHash === expectedHash)
+
+export const auditHashMatches = Pipeable.dual(3, auditHashMatchesDataFirst)
 
 export const expectedResultReason = (gateName: string): string =>
   `EVALUATION_${gateName
@@ -56,11 +63,13 @@ export const expectedResultReason = (gateName: string): string =>
     .replace(/[^A-Z0-9]+/g, '_')
     .replace(/^_+|_+$/g, '')}_FAILED`
 
-export const makeAuditCheck = (name: string, passed: boolean, evidence: string): AuditCheck => ({
+const makeAuditCheckDataFirst = (name: string, passed: boolean, evidence: string): AuditCheck => ({
   name,
   passed,
   evidence,
 })
+
+export const makeAuditCheck = Pipeable.dual(3, makeAuditCheckDataFirst)
 
 export const makePolicyDocuments = (lock: QualificationLock) =>
   (
@@ -72,7 +81,7 @@ export const makePolicyDocuments = (lock: QualificationLock) =>
     ] as const
   ).map(([name, policy]) => ({ name, ...policy }))
 
-export const makeEvaluationSummary = (
+const makeEvaluationSummaryDataFirst = (
   input: QualificationAuditInput,
   reference: ReferenceEvaluation,
   trace: SimulationTrace,
@@ -110,6 +119,8 @@ export const makeEvaluationSummary = (
   },
   markedEquityReconciliation: markedEquity,
 })
+
+export const makeEvaluationSummary = Pipeable.dual(4, makeEvaluationSummaryDataFirst)
 
 const hasTerminalCloseEvent = (database: AuditDatabaseSnapshot): boolean =>
   database.events.some(({ payload }) => payload.kind === 'decision' && payload.terminalClose === true)

--- a/services/bayn/src/audit/qualification-checks.ts
+++ b/services/bayn/src/audit/qualification-checks.ts
@@ -9,6 +9,7 @@ import {
   sameAuditMaterial,
   type QualificationAuditFacts,
 } from './core'
+import { Pipeable } from '../pipeable'
 
 export const auditQualificationBindings = (
   facts: QualificationAuditFacts,
@@ -145,7 +146,7 @@ export const auditQualificationBindings = (
     ]
   })
 
-export const makeAuditReport = (
+const makeAuditReportDataFirst = (
   facts: QualificationAuditFacts,
   checks: readonly AuditCheck[],
 ): Result.Result<QualificationAuditReport, QualificationAuditFailure> =>
@@ -187,3 +188,5 @@ export const makeAuditReport = (
     const auditHash = yield* hashAuditMaterial({ scope: 'audit', name: 'report' }, material)
     return { ...material, auditHash }
   })
+
+export const makeAuditReport = Pipeable.dual(2, makeAuditReportDataFirst)

--- a/services/bayn/src/audit/reference/decisions.ts
+++ b/services/bayn/src/audit/reference/decisions.ts
@@ -3,6 +3,7 @@ import { Result } from 'effect'
 import type { DailyBar, DecisionPlan, InputManifest, IsoDate, Protocol, SimulationProtocol } from '../../types'
 import { hashReferenceMaterial } from './replay/identities'
 import type { ReferenceComputation, Session } from './model'
+import { Pipeable } from '../../pipeable'
 
 export const tradingDays = 252
 
@@ -27,7 +28,7 @@ export const sampleDeviation = (values: readonly number[]): number => {
   return Math.sqrt(variance)
 }
 
-export const align = (
+const alignDataFirst = (
   bars: readonly DailyBar[],
   manifest: InputManifest,
   universe: readonly string[],
@@ -104,6 +105,8 @@ export const align = (
   }
   return Result.succeed(sessions)
 }
+
+export const align = Pipeable.dual(3, alignDataFirst)
 
 export const monthEnds = (dates: readonly IsoDate[]): readonly number[] => {
   const result: number[] = []
@@ -253,7 +256,7 @@ const portfolioVolatility = (
   return Result.succeed(annualized)
 }
 
-export const riskBalancedDecisionPlan = (
+const riskBalancedDecisionPlanDataFirst = (
   signalIndex: number,
   sessions: readonly Session[],
   protocol: Protocol,
@@ -481,7 +484,9 @@ export const riskBalancedDecisionPlan = (
   })
 }
 
-export const directVolatilityTarget = (
+export const riskBalancedDecisionPlan = Pipeable.dual(3, riskBalancedDecisionPlanDataFirst)
+
+const directVolatilityTargetDataFirst = (
   sessions: readonly Session[],
   signalIndex: number,
   protocol: SimulationProtocol,
@@ -532,3 +537,5 @@ export const directVolatilityTarget = (
   const weight = roundWeight(exposure / protocol.universe.length)
   return Result.succeed(Object.fromEntries(protocol.universe.map((symbol) => [symbol, weight])))
 }
+
+export const directVolatilityTarget = Pipeable.dual(3, directVolatilityTargetDataFirst)

--- a/services/bayn/src/audit/reference/replay-calculations.ts
+++ b/services/bayn/src/audit/reference/replay-calculations.ts
@@ -30,8 +30,9 @@ import {
   makeReferenceOrderIdentity,
 } from './replay/identities'
 import type { Position, ReferenceComputation, Session } from './model'
+import { Pipeable } from '../../pipeable'
 
-export const calculateReplayMetrics = (
+const calculateReplayMetricsDataFirst = (
   equityMicros: readonly bigint[],
   turnoverMicros: bigint,
   feeMicros: bigint,
@@ -94,6 +95,8 @@ export const calculateReplayMetrics = (
   })
 }
 
+export const calculateReplayMetrics = Pipeable.dual(7, calculateReplayMetricsDataFirst)
+
 export const makeReferenceOrder = (
   runId: string,
   decision: DecisionEvent,
@@ -137,7 +140,7 @@ export const makeReferenceOrder = (
     }),
   )
 
-export const restrictReferenceBuyFill = (
+const restrictReferenceBuyFillDataFirst = (
   runId: string,
   simulatedOrder: SimulatedOrder,
   permittedQuantity: bigint,
@@ -166,7 +169,9 @@ export const restrictReferenceBuyFill = (
   return makeReferenceOrderIdentity(runId, material)
 }
 
-export const makeReferenceFill = (
+export const restrictReferenceBuyFill = Pipeable.dual(3, restrictReferenceBuyFillDataFirst)
+
+const makeReferenceFillDataFirst = (
   runId: string,
   decision: DecisionEvent,
   simulatedOrder: SimulatedOrder,
@@ -190,7 +195,9 @@ export const makeReferenceFill = (
   return makeReferenceFillIdentity(runId, material)
 }
 
-export const makeCashChange = (
+export const makeReferenceFill = Pipeable.dual(5, makeReferenceFillDataFirst)
+
+const makeCashChangeDataFirst = (
   runId: string,
   source:
     | Pick<FillEvent | FeeEvent, 'kind' | 'id' | 'sessionDate'>
@@ -199,7 +206,9 @@ export const makeCashChange = (
   cashAfterMicros: bigint,
 ): ReferenceComputation<CashChange> => makeReferenceCashChangeIdentity(runId, source, amountMicros, cashAfterMicros)
 
-export const replayPrices = (
+export const makeCashChange = Pipeable.dual(4, makeCashChangeDataFirst)
+
+const replayPricesDataFirst = (
   session: Session,
   protocol: SimulationProtocol,
   price: (bar: DailyBar) => number,
@@ -226,7 +235,9 @@ export const replayPrices = (
     Result.map((entries) => Object.fromEntries(entries)),
   )
 
-export const replayPositionValue = (
+export const replayPrices = Pipeable.dual(3, replayPricesDataFirst)
+
+const replayPositionValueDataFirst = (
   prices: Readonly<Record<string, bigint>>,
   positions: ReadonlyMap<string, Position>,
   protocol: SimulationProtocol,
@@ -242,7 +253,9 @@ export const replayPositionValue = (
   return Result.succeed(total)
 }
 
-export const replayPriceFor = (
+export const replayPositionValue = Pipeable.dual(3, replayPositionValueDataFirst)
+
+const replayPriceForDataFirst = (
   prices: Readonly<Record<string, bigint>>,
   symbol: string,
 ): ReferenceComputation<bigint> => {
@@ -252,7 +265,9 @@ export const replayPriceFor = (
     : Result.succeed(priceMicros)
 }
 
-export const replayQuantityFor = (
+export const replayPriceFor = Pipeable.dual(2, replayPriceForDataFirst)
+
+const replayQuantityForDataFirst = (
   quantities: Readonly<Record<string, bigint>>,
   symbol: string,
 ): ReferenceComputation<bigint> => {
@@ -262,7 +277,9 @@ export const replayQuantityFor = (
     : Result.succeed(quantityMicros)
 }
 
-export const replayDesiredQuantities = (
+export const replayQuantityFor = Pipeable.dual(2, replayQuantityForDataFirst)
+
+const replayDesiredQuantitiesDataFirst = (
   equityMicros: bigint,
   weights: Readonly<Record<string, number>>,
   prices: Readonly<Record<string, bigint>>,
@@ -283,6 +300,8 @@ export const replayDesiredQuantities = (
     ),
     Result.map((entries) => Object.fromEntries(entries)),
   )
+
+export const replayDesiredQuantities = Pipeable.dual(4, replayDesiredQuantitiesDataFirst)
 
 interface ReferenceBuyCandidate {
   readonly symbol: string

--- a/services/bayn/src/audit/reference/replay/identities.ts
+++ b/services/bayn/src/audit/reference/replay/identities.ts
@@ -11,8 +11,9 @@ import type {
   SimulatedOrder,
 } from '../../../types'
 import type { ReferenceCanonicalizationSubject, ReferenceComputation } from '../model'
+import { Pipeable } from '../../../pipeable'
 
-export const hashReferenceMaterial = (
+const hashReferenceMaterialDataFirst = (
   subject: ReferenceCanonicalizationSubject,
   value: unknown,
 ): ReferenceComputation<string> =>
@@ -22,7 +23,9 @@ export const hashReferenceMaterial = (
     cause,
   }))
 
-export const makeReferenceDecisionEvent = (
+export const hashReferenceMaterial = Pipeable.dual(2, hashReferenceMaterialDataFirst)
+
+const makeReferenceDecisionEventDataFirst = (
   runId: string,
   material: Omit<DecisionEvent, 'id' | 'kind'>,
 ): ReferenceComputation<DecisionEvent> =>
@@ -32,7 +35,9 @@ export const makeReferenceDecisionEvent = (
     ...material,
   }))
 
-export const makeReferenceCashYieldEvent = (
+export const makeReferenceDecisionEvent = Pipeable.dual(2, makeReferenceDecisionEventDataFirst)
+
+const makeReferenceCashYieldEventDataFirst = (
   runId: string,
   material: Omit<CashYieldEvent, 'id' | 'kind'>,
 ): ReferenceComputation<CashYieldEvent> =>
@@ -42,7 +47,9 @@ export const makeReferenceCashYieldEvent = (
     ...material,
   }))
 
-export const makeReferenceFeeEvent = (
+export const makeReferenceCashYieldEvent = Pipeable.dual(2, makeReferenceCashYieldEventDataFirst)
+
+const makeReferenceFeeEventDataFirst = (
   runId: string,
   material: Omit<FeeEvent, 'id' | 'kind'>,
 ): ReferenceComputation<FeeEvent> =>
@@ -52,7 +59,9 @@ export const makeReferenceFeeEvent = (
     ...material,
   }))
 
-export const makeReferenceOrderIdentity = (
+export const makeReferenceFeeEvent = Pipeable.dual(2, makeReferenceFeeEventDataFirst)
+
+const makeReferenceOrderIdentityDataFirst = (
   runId: string,
   material: Omit<SimulatedOrder, 'id'>,
 ): ReferenceComputation<SimulatedOrder> =>
@@ -61,7 +70,9 @@ export const makeReferenceOrderIdentity = (
     ...material,
   }))
 
-export const makeReferenceFillIdentity = (
+export const makeReferenceOrderIdentity = Pipeable.dual(2, makeReferenceOrderIdentityDataFirst)
+
+const makeReferenceFillIdentityDataFirst = (
   runId: string,
   material: Omit<FillEvent, 'id' | 'kind'>,
 ): ReferenceComputation<FillEvent> =>
@@ -71,7 +82,9 @@ export const makeReferenceFillIdentity = (
     ...material,
   }))
 
-export const makeReferenceCashChangeIdentity = (
+export const makeReferenceFillIdentity = Pipeable.dual(2, makeReferenceFillIdentityDataFirst)
+
+const makeReferenceCashChangeIdentityDataFirst = (
   runId: string,
   source:
     | Pick<FillEvent | FeeEvent, 'kind' | 'id' | 'sessionDate'>
@@ -95,3 +108,5 @@ export const makeReferenceCashChangeIdentity = (
     ...material,
   }))
 }
+
+export const makeReferenceCashChangeIdentity = Pipeable.dual(4, makeReferenceCashChangeIdentityDataFirst)

--- a/services/bayn/src/broker/alpaca-mutations/decisions.ts
+++ b/services/bayn/src/broker/alpaca-mutations/decisions.ts
@@ -26,6 +26,7 @@ import {
   type MutationEvidence,
   type SubmitReceipt,
 } from './model'
+import { Pipeable } from '../../pipeable'
 
 const inputParseOptions = { onExcessProperty: 'error' } as const
 
@@ -194,7 +195,7 @@ export const authorizeMutationAccess = (
   return Result.succeed(BrokerAccess.Mutation)
 }
 
-export const resolveMutationCapability = (
+const resolveMutationCapabilityDataFirst = (
   session: BrokerSessionShape,
   authority: ExecutionAuthority,
 ): Result.Result<ResolvedMutationCapability, BrokerMutationError> => {
@@ -240,6 +241,8 @@ export const resolveMutationCapability = (
     }
   })
 }
+
+export const resolveMutationCapability = Pipeable.dual(2, resolveMutationCapabilityDataFirst)
 
 export const historicalMarketOrderRequestBody = (
   intent: OrderRequestIntent,
@@ -328,7 +331,7 @@ const submitRequestHash = (body: OrderRequestBody): Result.Result<string, Broker
     invalidRequest(MutationOperation.Submit, 'order request cannot be canonically hashed', cause),
   )
 
-export const prepareSubmit = (
+const prepareSubmitDataFirst = (
   input: unknown,
   expectedAccountId: string,
 ): Result.Result<PreparedSubmit, BrokerMutationError> => {
@@ -352,6 +355,8 @@ export const prepareSubmit = (
     requestHash,
   }))
 }
+
+export const prepareSubmit = Pipeable.dual(2, prepareSubmitDataFirst)
 
 export const cancelRequestHash = (brokerOrderId: string): string =>
   canonicalHashV1OrThrow({ operation: MutationOperation.Cancel, brokerOrderId })

--- a/services/bayn/src/broker/alpaca-mutations/interpreter.ts
+++ b/services/bayn/src/broker/alpaca-mutations/interpreter.ts
@@ -21,6 +21,7 @@ import {
   unknownOutcome,
   type BrokerMutationShape,
 } from './model'
+import { Pipeable } from '../../pipeable'
 
 const decodeHeaders = HttpClientResponse.schemaHeaders(ResponseHeadersSchema, responseParseOptions)
 
@@ -105,7 +106,7 @@ const readCancelBody = (
         ),
       )
 
-export const makeMutation = (
+const makeMutationDataFirst = (
   session: BrokerSessionShape,
   authority: ExecutionAuthority,
   client: HttpClient.HttpClient,
@@ -192,3 +193,5 @@ export const makeMutation = (
       orderByClientId: session.read.orderByClientId,
     }
   })
+
+export const makeMutation = Pipeable.dual(3, makeMutationDataFirst)

--- a/services/bayn/src/broker/alpaca-mutations/model.ts
+++ b/services/bayn/src/broker/alpaca-mutations/model.ts
@@ -4,6 +4,7 @@ import { MutationOutcome } from '../../paper'
 import { StrictNonEmptyStringSchema as NonEmptyString, UtcInstantSchema as UtcInstant } from '../../schemas'
 import type { Intent } from '../../paper'
 import type { BrokerReadError, Order, ReadResult } from '../alpaca'
+import { Pipeable } from '../../pipeable'
 
 const RequestId = NonEmptyString.check(Schema.isMaxLength(256))
 
@@ -125,7 +126,7 @@ export const unknownOutcome = (
     ...(cause === undefined ? {} : { cause: causeSummary(cause) }),
   })
 
-export const knownRejection = (
+const knownRejectionDataFirst = (
   requestHash: string,
   evidence: MutationEvidence,
   code: string | number,
@@ -141,7 +142,9 @@ export const knownRejection = (
     brokerCode: String(code),
   })
 
-export const mismatchedAcceptedOrder = (requestHash: string, evidence: MutationEvidence, brokerOrderId: string) =>
+export const knownRejection = Pipeable.dual(4, knownRejectionDataFirst)
+
+const mismatchedAcceptedOrderDataFirst = (requestHash: string, evidence: MutationEvidence, brokerOrderId: string) =>
   new BrokerMutationError({
     operation: MutationOperation.Submit,
     failure: MutationFailure.Unknown,
@@ -151,3 +154,5 @@ export const mismatchedAcceptedOrder = (requestHash: string, evidence: MutationE
     evidence,
     brokerOrderId,
   })
+
+export const mismatchedAcceptedOrder = Pipeable.dual(3, mismatchedAcceptedOrderDataFirst)

--- a/services/bayn/src/broker/alpaca/failures.ts
+++ b/services/bayn/src/broker/alpaca/failures.ts
@@ -1,5 +1,6 @@
 import { Data, Schema } from 'effect'
 import { HttpClientError } from 'effect/unstable/http'
+import { Pipeable } from '../../pipeable'
 
 export enum BrokerReadErrorKind {
   Configuration = 'CONFIGURATION',
@@ -172,7 +173,7 @@ export const invalidResponse = (
     ...(cause === undefined ? {} : { cause: safeCause(cause) }),
   })
 
-export const invalidRequest = (operation: BrokerReadOperation, message: string, cause: unknown): BrokerReadError =>
+const invalidRequestDataFirst = (operation: BrokerReadOperation, message: string, cause: unknown): BrokerReadError =>
   new BrokerReadError({
     operation,
     kind: BrokerReadErrorKind.InvalidRequest,
@@ -181,7 +182,9 @@ export const invalidRequest = (operation: BrokerReadOperation, message: string, 
     cause: safeCause(cause),
   })
 
-export const transportError = (
+export const invalidRequest = Pipeable.dual(3, invalidRequestDataFirst)
+
+const transportErrorDataFirst = (
   operation: BrokerReadOperation,
   cause: unknown,
   sensitiveValues: readonly string[],
@@ -194,7 +197,9 @@ export const transportError = (
     cause: safeCause(cause, sensitiveValues),
   })
 
-export const statusError = (
+export const transportError = Pipeable.dual(3, transportErrorDataFirst)
+
+const statusErrorDataFirst = (
   operation: BrokerReadOperation,
   status: number,
   requestId: string,
@@ -227,7 +232,9 @@ export const statusError = (
   })
 }
 
-export const timeoutError = (
+export const statusError = Pipeable.dual(7, statusErrorDataFirst)
+
+const timeoutErrorDataFirst = (
   operation: BrokerReadOperation,
   timeoutMs: number,
   cause: unknown,
@@ -240,3 +247,5 @@ export const timeoutError = (
     retryable: true,
     cause: safeCause(cause, sensitiveValues),
   })
+
+export const timeoutError = Pipeable.dual(4, timeoutErrorDataFirst)

--- a/services/bayn/src/broker/alpaca/http.ts
+++ b/services/bayn/src/broker/alpaca/http.ts
@@ -69,6 +69,7 @@ import {
   positionsUrl,
   responseEvidenceResult,
 } from './requests'
+import { Pipeable } from '../../pipeable'
 
 const decodeResponseHeaders = HttpClientResponse.schemaHeaders(ResponseHeadersSchema, responseParseOptions)
 
@@ -186,7 +187,7 @@ export interface AlpacaFreshBrokerQuote {
   readonly observedAt: string
 }
 
-export const decodeFreshBrokerPrice = (
+const decodeFreshBrokerPriceDataFirst = (
   requestedSymbol: string,
   raw: unknown,
   observedAt: string,
@@ -235,13 +236,15 @@ export const decodeFreshBrokerPrice = (
   })
 }
 
+export const decodeFreshBrokerPrice = Pipeable.dual(3, decodeFreshBrokerPriceDataFirst)
+
 export const latestQuoteUrl = (symbol: string): URL => {
   const url = new URL(`/v2/stocks/${encodeURIComponent(symbol)}/quotes/latest`, 'https://data.alpaca.markets')
   url.searchParams.set('feed', 'sip')
   return url
 }
 
-export const makeFreshBrokerPriceReader = (
+const makeFreshBrokerPriceReaderDataFirst = (
   connection: BrokerConnection,
   client: HttpClient.HttpClient,
 ): ((symbol: string) => Effect.Effect<AlpacaFreshBrokerQuote, ReturnType<typeof operationalError>>) => {
@@ -300,6 +303,8 @@ export const makeFreshBrokerPriceReader = (
       }),
     )
 }
+
+export const makeFreshBrokerPriceReader = Pipeable.dual(2, makeFreshBrokerPriceReaderDataFirst)
 
 export const make = (connection: BrokerConnection): Effect.Effect<BrokerReadShape, never, HttpClient.HttpClient> =>
   Effect.gen(function* () {

--- a/services/bayn/src/broker/alpaca/normalizers.ts
+++ b/services/bayn/src/broker/alpaca/normalizers.ts
@@ -36,6 +36,7 @@ import {
   type Position,
 } from './model'
 import { accountConfigurationRequestMaterial, assetRequestMaterial } from './requests'
+import { Pipeable } from '../../pipeable'
 
 const decimalPattern = /^(?:0|[1-9][0-9]*)(?:\.[0-9]+)?$|^-[1-9][0-9]*(?:\.[0-9]+)?$/
 
@@ -47,7 +48,7 @@ const hashResult = (value: unknown, field: string): Result.Result<string, Broker
     }),
   )
 
-export const decimalToMicrosResult = (
+const decimalToMicrosResultDataFirst = (
   value: string,
   signed: boolean,
   name: string,
@@ -86,6 +87,8 @@ export const decimalToMicrosResult = (
   return Result.succeed(result.toString())
 }
 
+export const decimalToMicrosResult = Pipeable.dual(3, decimalToMicrosResultDataFirst)
+
 const positiveMicrosResult = (value: string, name: string): Result.Result<string, BrokerReadContractFailure> =>
   Result.flatMap(decimalToMicrosResult(value, false, name), (micros) =>
     micros === '0'
@@ -122,7 +125,7 @@ const positionMicrosResult = (
       : Result.succeed(normalized.toString())
   })
 
-export const normalizeAccountResult = (
+const normalizeAccountResultDataFirst = (
   raw: typeof AccountResponseSchema.Type,
   expectedAccountId: string,
   observedAt: string,
@@ -157,7 +160,9 @@ export const normalizeAccountResult = (
   })
 }
 
-export const normalizeAccountConfigurationResult = (
+export const normalizeAccountResult = Pipeable.dual(3, normalizeAccountResultDataFirst)
+
+const normalizeAccountConfigurationResultDataFirst = (
   raw: typeof AccountConfigurationResponseSchema.Type,
   observedAt: string,
 ): Result.Result<AccountConfigurationObservation, BrokerReadContractFailure> =>
@@ -173,7 +178,9 @@ export const normalizeAccountConfigurationResult = (
     return { ...normalized, observedAt, normalizedResponseHash }
   })
 
-export const normalizePositionResult = (
+export const normalizeAccountConfigurationResult = Pipeable.dual(2, normalizeAccountConfigurationResultDataFirst)
+
+const normalizePositionResultDataFirst = (
   raw: typeof PositionResponseSchema.Type,
   accountId: string,
   observedAt: string,
@@ -211,14 +218,18 @@ export const normalizePositionResult = (
   })
 }
 
-export const normalizePositionsResult = (
+export const normalizePositionResult = Pipeable.dual(3, normalizePositionResultDataFirst)
+
+const normalizePositionsResultDataFirst = (
   raw: readonly (typeof PositionResponseSchema.Type)[],
   accountId: string,
   observedAt: string,
 ): Result.Result<readonly Position[], BrokerReadContractFailure> =>
   Result.all(raw.map((position) => normalizePositionResult(position, accountId, observedAt)))
 
-export const normalizeAssetResult = (
+export const normalizePositionsResult = Pipeable.dual(3, normalizePositionsResultDataFirst)
+
+const normalizeAssetResultDataFirst = (
   raw: typeof AssetResponseSchema.Type,
   requestedSymbol: string,
   observedAt: string,
@@ -253,7 +264,9 @@ export const normalizeAssetResult = (
   })
 }
 
-export const normalizeOrderResult = (
+export const normalizeAssetResult = Pipeable.dual(3, normalizeAssetResultDataFirst)
+
+const normalizeOrderResultDataFirst = (
   raw: typeof OrderResponseSchema.Type,
   accountId: string,
   observedAt: string,
@@ -342,14 +355,18 @@ export const normalizeOrderResult = (
   })
 }
 
-export const normalizeOrdersResult = (
+export const normalizeOrderResult = Pipeable.dual(3, normalizeOrderResultDataFirst)
+
+const normalizeOrdersResultDataFirst = (
   raw: readonly (typeof OrderResponseSchema.Type)[],
   accountId: string,
   observedAt: string,
 ): Result.Result<readonly Order[], BrokerReadContractFailure> =>
   Result.all(raw.map((order) => normalizeOrderResult(order, accountId, observedAt)))
 
-export const normalizeFillActivityResult = (
+export const normalizeOrdersResult = Pipeable.dual(3, normalizeOrdersResultDataFirst)
+
+const normalizeFillActivityResultDataFirst = (
   raw: typeof FillActivityResponseSchema.Type,
   accountId: string,
 ): Result.Result<FillActivity, BrokerReadContractFailure> => {
@@ -397,11 +414,15 @@ export const normalizeFillActivityResult = (
   })
 }
 
-export const normalizeFillActivitiesResult = (
+export const normalizeFillActivityResult = Pipeable.dual(2, normalizeFillActivityResultDataFirst)
+
+const normalizeFillActivitiesResultDataFirst = (
   raw: readonly (typeof FillActivityResponseSchema.Type)[],
   accountId: string,
 ): Result.Result<readonly FillActivity[], BrokerReadContractFailure> =>
   Result.all(raw.map((activity) => normalizeFillActivityResult(activity, accountId)))
+
+export const normalizeFillActivitiesResult = Pipeable.dual(2, normalizeFillActivitiesResultDataFirst)
 
 const marketCalendarInstantResult = (
   date: string,
@@ -435,7 +456,7 @@ const marketCalendarInstantResult = (
     : Result.succeed(DateTime.formatIso(zoned.value))
 }
 
-export const normalizeMarketCalendarResult = (
+const normalizeMarketCalendarResultDataFirst = (
   raw: typeof MarketCalendarResponseSchema.Type,
   query: typeof MarketCalendarQueryBase.Type,
 ): Result.Result<MarketCalendarObservation, BrokerReadContractFailure> =>
@@ -484,3 +505,5 @@ export const normalizeMarketCalendarResult = (
     const normalizedResponseHash = yield* hashResult(normalized, 'market calendar response')
     return { ...normalized, normalizedResponseHash }
   })
+
+export const normalizeMarketCalendarResult = Pipeable.dual(2, normalizeMarketCalendarResultDataFirst)

--- a/services/bayn/src/broker/alpaca/preflight.ts
+++ b/services/bayn/src/broker/alpaca/preflight.ts
@@ -24,6 +24,7 @@ import {
   type ReadPreflight,
   type ReadResult,
 } from './model'
+import { Pipeable } from '../../pipeable'
 
 const missingOrderId = '00000000-0000-4000-8000-000000000000'
 const missingClientOrderId = 'bayn-observe-read-proof-does-not-exist'
@@ -62,7 +63,7 @@ export class BrokerAccountPreflightError extends Data.TaggedError('BrokerAccount
   readonly failure: BrokerAccountPreflightFailure
 }> {}
 
-export const verifyBrokerAccountPermissions = (
+const verifyBrokerAccountPermissionsDataFirst = (
   account: Account,
   configuration: AccountConfigurationObservation,
 ): Result.Result<VerifiedBrokerAccountPermissions, BrokerAccountPreflightFailure> => {
@@ -81,6 +82,8 @@ export const verifyBrokerAccountPermissions = (
     fractionalTrading: true,
   })
 }
+
+export const verifyBrokerAccountPermissions = Pipeable.dual(2, verifyBrokerAccountPermissionsDataFirst)
 
 const permissionFailure = (
   connection: BrokerConnection,
@@ -142,7 +145,7 @@ const verifyOrderLookup = (
     ),
   )
 
-export const verifyReadAccess = (
+const verifyReadAccessDataFirst = (
   connection: BrokerConnection,
   read: BrokerReadShape,
 ): Effect.Effect<ReadPreflight, BrokerReadError | BrokerAccountPreflightError> =>
@@ -265,3 +268,5 @@ export const verifyReadAccess = (
     }),
     Effect.withLogSpan('broker.read.preflight'),
   )
+
+export const verifyReadAccess = Pipeable.dual(2, verifyReadAccessDataFirst)

--- a/services/bayn/src/broker/alpaca/requests.ts
+++ b/services/bayn/src/broker/alpaca/requests.ts
@@ -14,6 +14,7 @@ import {
   type OrdersQuery,
   type ReadEvidence,
 } from './model'
+import { Pipeable } from '../../pipeable'
 
 export const accountConfigurationRequestMaterial = {
   schemaVersion: accountConfigurationObservationSchemaVersion,
@@ -37,10 +38,12 @@ export const accountConfigurationUrl = (connection: BrokerConnection): URL =>
 
 export const positionsUrl = (connection: BrokerConnection): URL => new URL('/v2/positions', connection.baseUrl)
 
-export const assetBySymbolUrl = (connection: BrokerConnection, requestedSymbol: string): URL =>
+const assetBySymbolUrlDataFirst = (connection: BrokerConnection, requestedSymbol: string): URL =>
   new URL(assetRequestMaterial(requestedSymbol).path, connection.baseUrl)
 
-export const marketCalendarUrl = (connection: BrokerConnection, query: MarketCalendarQuery): URL => {
+export const assetBySymbolUrl = Pipeable.dual(2, assetBySymbolUrlDataFirst)
+
+const marketCalendarUrlDataFirst = (connection: BrokerConnection, query: MarketCalendarQuery): URL => {
   const url = new URL('/v2/calendar', connection.baseUrl)
   url.searchParams.set('start', query.start)
   url.searchParams.set('end', query.end)
@@ -48,7 +51,9 @@ export const marketCalendarUrl = (connection: BrokerConnection, query: MarketCal
   return url
 }
 
-export const ordersUrl = (connection: BrokerConnection, query: OrdersQuery): URL => {
+export const marketCalendarUrl = Pipeable.dual(2, marketCalendarUrlDataFirst)
+
+const ordersUrlDataFirst = (connection: BrokerConnection, query: OrdersQuery): URL => {
   const url = new URL('/v2/orders', connection.baseUrl)
   if (query.status !== undefined) url.searchParams.set('status', query.status)
   if (query.limit !== undefined) url.searchParams.set('limit', String(query.limit))
@@ -60,25 +65,34 @@ export const ordersUrl = (connection: BrokerConnection, query: OrdersQuery): URL
   return url
 }
 
+export const ordersUrl = Pipeable.dual(2, ordersUrlDataFirst)
+
 export const submitOrderUrl = (connection: BrokerConnection): URL => new URL('/v2/orders', connection.baseUrl)
 
-export const orderByIdUrl = (connection: BrokerConnection, orderId: string): URL =>
+const orderByIdUrlDataFirst = (connection: BrokerConnection, orderId: string): URL =>
   new URL(`/v2/orders/${encodeURIComponent(orderId)}`, connection.baseUrl)
 
-export const cancelOrderUrl = (connection: BrokerConnection, orderId: string): URL => orderByIdUrl(connection, orderId)
+export const orderByIdUrl = Pipeable.dual(2, orderByIdUrlDataFirst)
 
-export const orderByClientIdUrl = (connection: BrokerConnection, clientOrderId: string): URL => {
+const cancelOrderUrlDataFirst = (connection: BrokerConnection, orderId: string): URL =>
+  orderByIdUrl(connection, orderId)
+
+export const cancelOrderUrl = Pipeable.dual(2, cancelOrderUrlDataFirst)
+
+const orderByClientIdUrlDataFirst = (connection: BrokerConnection, clientOrderId: string): URL => {
   const url = new URL('/v2/orders:by_client_order_id', connection.baseUrl)
   url.searchParams.set('client_order_id', clientOrderId)
   return url
 }
+
+export const orderByClientIdUrl = Pipeable.dual(2, orderByClientIdUrlDataFirst)
 
 export interface FillActivitiesRequest {
   readonly url: URL
   readonly pageSize: number
 }
 
-export const fillActivitiesRequest = (
+const fillActivitiesRequestDataFirst = (
   connection: BrokerConnection,
   query: FillActivitiesQuery,
 ): FillActivitiesRequest => {
@@ -93,7 +107,9 @@ export const fillActivitiesRequest = (
   return { url, pageSize }
 }
 
-export const responseEvidenceResult = (
+export const fillActivitiesRequest = Pipeable.dual(2, fillActivitiesRequestDataFirst)
+
+const responseEvidenceResultDataFirst = (
   headers: typeof ResponseHeadersSchema.Type,
   status: number,
   contentHash: string,
@@ -130,3 +146,5 @@ export const responseEvidenceResult = (
     ...(rateLimit === undefined ? {} : { rateLimit }),
   })
 }
+
+export const responseEvidenceResult = Pipeable.dual(4, responseEvidenceResultDataFirst)

--- a/services/bayn/src/broker/alpaca/session.ts
+++ b/services/bayn/src/broker/alpaca/session.ts
@@ -7,6 +7,7 @@ import { alpacaHttpLayer, make } from './http'
 import { BrokerRead, type BrokerReadShape, type ReadPreflight } from './model'
 import { BrokerAccountPreflightError, verifyReadAccess } from './preflight'
 import { mapLayerAcquisitionError } from '../../resource-boundary'
+import { Pipeable } from '../../pipeable'
 
 export enum BrokerSessionAcquisitionStage {
   Connection = 'CONNECTION',
@@ -131,11 +132,13 @@ export const layer = (
   ).pipe(Layer.provideMerge(session))
 }
 
-export const mapHttpAcquisitionError = (
+const mapHttpAcquisitionErrorDataFirst = (
   connection: BrokerConnection,
   http: Layer.Layer<HttpClient.HttpClient, BrokerReadError>,
 ): Layer.Layer<HttpClient.HttpClient, BrokerSessionAcquisitionError> =>
   mapLayerAcquisitionError(http, (cause) => acquisitionError(connection, cause))
+
+export const mapHttpAcquisitionError = Pipeable.dual(2, mapHttpAcquisitionErrorDataFirst)
 
 export const live = (
   connection: BrokerConnection,

--- a/services/bayn/src/broker/observations.ts
+++ b/services/bayn/src/broker/observations.ts
@@ -33,6 +33,7 @@ import {
   type ReadEvidence,
   type ReadResult,
 } from './alpaca'
+import { Pipeable } from '../pipeable'
 
 const CommonEventInput = {
   broker: Schema.Literal(Broker.Alpaca),
@@ -367,7 +368,7 @@ const duplicatePosition = (positions: readonly AlpacaPosition[]): BrokerObservat
   return duplicateSymbol === undefined ? undefined : { _tag: 'DuplicatePositionSymbol', symbol: duplicateSymbol.symbol }
 }
 
-export const positionSnapshot = (
+const positionSnapshotDataFirst = (
   accountId: string,
   result: ReadResult<readonly AlpacaPosition[]>,
 ): Result.Result<PositionSnapshotInput, BrokerObservationError> => {
@@ -391,6 +392,8 @@ export const positionSnapshot = (
           ),
         )
 }
+
+export const positionSnapshot = Pipeable.dual(2, positionSnapshotDataFirst)
 
 type QuantityOrder = Omit<AlpacaOrder, 'notionalMicros' | 'quantityMicros' | 'updatedAt'> & {
   readonly quantityMicros: string

--- a/services/bayn/src/build.ts
+++ b/services/bayn/src/build.ts
@@ -6,6 +6,7 @@ import {
   ImageRepositorySchema as ImageRepository,
   Sha256Schema as Sha256,
 } from './schemas'
+import { Pipeable } from './pipeable'
 
 declare const __BAYN_BUILD_SOURCE_REVISION__: string
 declare const __BAYN_BUILD_IMAGE_REPOSITORY__: string
@@ -44,7 +45,7 @@ export const embeddedBuildMetadata: EmbeddedBuildMetadata | undefined = hasNoEmb
       strategyParameterHash: strategyParameterHash ?? 'incomplete',
     }
 
-export const verifyParameterHash = (
+const verifyParameterHashDataFirst = (
   metadata: EmbeddedBuildMetadata,
   actualParameterHash: string,
 ): Effect.Effect<void, OperationalError> =>
@@ -52,10 +53,14 @@ export const verifyParameterHash = (
     ? Effect.void
     : Effect.fail(operationalError('config', 'provenance', 'compiled strategy parameters do not match build metadata'))
 
-export const verifyBehaviorHash = (
+export const verifyParameterHash = Pipeable.dual(2, verifyParameterHashDataFirst)
+
+const verifyBehaviorHashDataFirst = (
   metadata: EmbeddedBuildMetadata,
   actualBehaviorHash: string,
 ): Effect.Effect<void, OperationalError> =>
   metadata.strategyBehaviorHash === actualBehaviorHash
     ? Effect.void
     : Effect.fail(operationalError('config', 'provenance', 'compiled strategy behavior does not match build metadata'))
+
+export const verifyBehaviorHash = Pipeable.dual(2, verifyBehaviorHashDataFirst)

--- a/services/bayn/src/composition.ts
+++ b/services/bayn/src/composition.ts
@@ -135,6 +135,7 @@ import { currentUtcInstant } from './time'
 import type { RuntimeEvidence, RuntimeState } from './runtime-state'
 import { scopedAcquisition } from './resource-boundary'
 import { strategyApplication } from './strategy'
+import { Pipeable } from './pipeable'
 
 export const ClickHouseClientResourceLive = (config: LoadedRuntimeConfig) =>
   ClickhouseClient.layer({
@@ -964,7 +965,7 @@ const completedPaperActivation = (
     error: null,
   }))
 
-export const restrictExpiredPaperActivation = (
+const restrictExpiredPaperActivationDataFirst = (
   authorityRestrictionStore: AuthorityRestrictionStoreShape,
   writerFence: WriterFenceService,
 ): Effect.Effect<void, OperationalError> =>
@@ -973,6 +974,8 @@ export const restrictExpiredPaperActivation = (
     Effect.provideService(WriterFence, writerFence),
     Effect.mapError((cause) => paperActivationOperationalError('expired PAPER activation restriction failed', cause)),
   )
+
+export const restrictExpiredPaperActivation = Pipeable.dual(2, restrictExpiredPaperActivationDataFirst)
 
 const restrictPaperAtExpiry = (
   expiresAt: string,
@@ -1096,7 +1099,7 @@ const makeClosedCycleReceiptEmitter =
       ),
     )
 
-export const finalizePaperEpisode = (
+const finalizePaperEpisodeDataFirst = (
   state: Ref.Ref<RuntimeState>,
   request: PaperActivationRequest,
   generationHash: string,
@@ -1130,7 +1133,9 @@ export const finalizePaperEpisode = (
     ),
   )
 
-export const retryClosedCycleReceipts = (
+export const finalizePaperEpisode = Pipeable.dual(8, finalizePaperEpisodeDataFirst)
+
+const retryClosedCycleReceiptsDataFirst = (
   emit: (cycleId: string | undefined, observedAt: string) => Effect.Effect<boolean>,
   cutoffAt: string,
   retryUntilAt: string,
@@ -1155,15 +1160,21 @@ export const retryClosedCycleReceipts = (
     }
   })
 
-export const closedCycleReceiptEmissionAllowed = (cutoffAt: string, observedAt: string): boolean =>
+export const retryClosedCycleReceipts = Pipeable.dual(4, retryClosedCycleReceiptsDataFirst)
+
+const closedCycleReceiptEmissionAllowedDataFirst = (cutoffAt: string, observedAt: string): boolean =>
   Date.parse(observedAt) >= Date.parse(cutoffAt)
 
-export const paperReceiptFinalizationWindowOpen = (authorityExpiresAt: string, observedAt: string): boolean => {
+export const closedCycleReceiptEmissionAllowed = Pipeable.dual(2, closedCycleReceiptEmissionAllowedDataFirst)
+
+const paperReceiptFinalizationWindowOpenDataFirst = (authorityExpiresAt: string, observedAt: string): boolean => {
   const observedMs = Date.parse(observedAt)
   const closeExpiresMs = Date.parse(paperEpisodeCloseExpiresAt(authorityExpiresAt))
   const finalizationExpiresMs = Date.parse(paperEpisodeReceiptFinalizationExpiresAt(authorityExpiresAt))
   return Number.isFinite(observedMs) && observedMs >= closeExpiresMs && observedMs < finalizationExpiresMs
 }
+
+export const paperReceiptFinalizationWindowOpen = Pipeable.dual(2, paperReceiptFinalizationWindowOpenDataFirst)
 
 const runAutonomousService = (plan: ApplicationPlanFor<'AutonomousService'>) =>
   Effect.gen(function* () {

--- a/services/bayn/src/cycle-observability.ts
+++ b/services/bayn/src/cycle-observability.ts
@@ -3,6 +3,7 @@ import { Result } from 'effect'
 import { Authority, KillState, ReconciliationStatus } from './execution/contracts'
 import { CycleState, type CycleTerminalReason } from './cycle'
 import { utcInstantFromEpochMillisResult, type UtcEpochMillisFailure } from './time'
+import { Pipeable } from './pipeable'
 
 export interface CycleOperationsThresholds {
   readonly cycleStallThresholdMs: number
@@ -547,7 +548,7 @@ const deriveCycleOperationsStatusWithCheckedAt = (
   }
 }
 
-export const deriveCycleOperationsStatusResult = (
+const deriveCycleOperationsStatusResultDataFirst = (
   projection: CycleOperationsProjection,
   nowMs: number,
   maximumAuthority: Authority,
@@ -561,10 +562,14 @@ export const deriveCycleOperationsStatusResult = (
     (checkedAt) => deriveCycleOperationsStatusWithCheckedAt(projection, nowMs, maximumAuthority, thresholds, checkedAt),
   )
 
-export const deriveCycleOperationsStatus = (
+export const deriveCycleOperationsStatusResult = Pipeable.dual(4, deriveCycleOperationsStatusResultDataFirst)
+
+const deriveCycleOperationsStatusDataFirst = (
   projection: CycleOperationsProjection,
   nowMs: number,
   maximumAuthority: Authority,
   thresholds: CycleOperationsThresholds,
 ): CycleOperationsStatus =>
   Result.getOrThrow(deriveCycleOperationsStatusResult(projection, nowMs, maximumAuthority, thresholds))
+
+export const deriveCycleOperationsStatus = Pipeable.dual(4, deriveCycleOperationsStatusDataFirst)

--- a/services/bayn/src/cycle-readiness.ts
+++ b/services/bayn/src/cycle-readiness.ts
@@ -15,6 +15,7 @@ import { CycleStore, type CycleMutationReceipt, type CycleStoreError, type Cycle
 import type { OperationalError } from './errors'
 import { MarketData, type MarketDataInspection, type MarketDataService } from './market-data'
 import { currentUtcInstant } from './time'
+import { Pipeable } from './pipeable'
 
 export type {
   CyclePublicationReadiness,
@@ -167,12 +168,14 @@ const bindFinalizedCyclePublicationWith = (
     )
   })
 
-export const bindFinalizedCyclePublication = (
+const bindFinalizedCyclePublicationDataFirst = (
   cycle: AutonomousCycle,
   inspection: MarketDataInspection,
   observedAt: string,
 ): Effect.Effect<CyclePublicationReadiness, CycleReadinessError, CycleStore> =>
   Effect.flatMap(CycleStore, (store) => bindFinalizedCyclePublicationWith(store, cycle, inspection, observedAt))
+
+export const bindFinalizedCyclePublication = Pipeable.dual(3, bindFinalizedCyclePublicationDataFirst)
 
 const inspectBoundPublication = (
   cycle: AutonomousCycle,

--- a/services/bayn/src/cycle-runner/authority-decisions.ts
+++ b/services/bayn/src/cycle-runner/authority-decisions.ts
@@ -1,6 +1,7 @@
 import { CycleState, CycleTerminalReason, isTerminalCycleState, type AutonomousCycle } from '../cycle'
 import type { MarketDataInspection } from '../market-data'
 import type { NonEmptyPublications } from './calendar-decisions'
+import { Pipeable } from '../pipeable'
 
 type CycleAuthoritySlotDecision =
   | { readonly _tag: 'UNCLAIMED'; readonly publication: MarketDataInspection }
@@ -59,7 +60,7 @@ export const beginCycleAuthoritySelection = (slot: CycleAuthoritySlot): CycleAut
   }
 }
 
-export const reduceCycleAuthoritySelection = (
+const reduceCycleAuthoritySelectionDataFirst = (
   state: CycleAuthoritySelectionState,
   slot: CycleAuthoritySlot,
 ): CycleAuthoritySelectionReduction => {
@@ -86,6 +87,8 @@ export const reduceCycleAuthoritySelection = (
       return decision
   }
 }
+
+export const reduceCycleAuthoritySelection = Pipeable.dual(2, reduceCycleAuthoritySelectionDataFirst)
 
 export const completeCycleAuthoritySelection = (
   state: CycleAuthoritySelectionState,

--- a/services/bayn/src/cycle-runner/calendar-decisions.ts
+++ b/services/bayn/src/cycle-runner/calendar-decisions.ts
@@ -11,6 +11,7 @@ import {
 } from '../cycle'
 import type { MarketDataInspection } from '../market-data'
 import type { CycleCandidate } from './model'
+import { Pipeable } from '../pipeable'
 
 const calendarRangeDays = 31
 const publicationCatchUpRangeDays = 21
@@ -188,7 +189,7 @@ export const boundedCyclePublications = <Publication extends CyclePublicationDat
   )
 }
 
-export const selectNextExecutionSession = (
+const selectNextExecutionSessionDataFirst = (
   signalSessionDate: string,
   observation: MarketCalendarObservation,
 ): MarketCalendarSession | undefined =>
@@ -198,10 +199,14 @@ export const selectNextExecutionSession = (
     undefined,
   )
 
-export const isMonthEndCycleDue = (signalSessionDate: string, executionSessionDate: string): boolean =>
+export const selectNextExecutionSession = Pipeable.dual(2, selectNextExecutionSessionDataFirst)
+
+const isMonthEndCycleDueDataFirst = (signalSessionDate: string, executionSessionDate: string): boolean =>
   signalSessionDate.slice(0, 7) !== executionSessionDate.slice(0, 7)
 
-export const makeDueCycleDraft = (
+export const isMonthEndCycleDue = Pipeable.dual(2, isMonthEndCycleDueDataFirst)
+
+const makeDueCycleDraftDataFirst = (
   candidate: CycleCandidate,
   observation: MarketCalendarObservation,
   executionSession: MarketCalendarSession,
@@ -238,3 +243,5 @@ export const makeDueCycleDraft = (
               ),
           ),
       )
+
+export const makeDueCycleDraft = Pipeable.dual(3, makeDueCycleDraftDataFirst)

--- a/services/bayn/src/cycle-runner/cycle-construction.ts
+++ b/services/bayn/src/cycle-runner/cycle-construction.ts
@@ -25,6 +25,7 @@ import {
   type ExecutionCalendarObservation,
   type SignalCycleSession,
 } from './cycle-model'
+import { Pipeable } from '../pipeable'
 
 const autonomousCycleSubmissionWindowMs = 30 * 60_000
 const decodeSelectedExecutionCalendarSessionResult = Schema.decodeUnknownResult(
@@ -375,7 +376,7 @@ const assembleCycleWindow = (
     (cause) => failure('cycle-window', 'decode', 'derived cycle window is invalid', {}, cause),
   )
 
-export const makeCycleWindow = (
+const makeCycleWindowDataFirst = (
   signalSession: unknown,
   executionCalendar: unknown,
   executionPolicy: unknown,
@@ -386,7 +387,9 @@ export const makeCycleWindow = (
     ),
   )
 
-export const makeCycleDraft = (
+export const makeCycleWindow = Pipeable.dual(3, makeCycleWindowDataFirst)
+
+const makeCycleDraftDataFirst = (
   identity: unknown,
   window: unknown,
 ): Result.Result<CycleDraft, CycleConstructionFailure> =>
@@ -421,3 +424,5 @@ export const makeCycleDraft = (
           ),
       ),
   )
+
+export const makeCycleDraft = Pipeable.dual(2, makeCycleDraftDataFirst)

--- a/services/bayn/src/cycle-runner/cycle-transitions.ts
+++ b/services/bayn/src/cycle-runner/cycle-transitions.ts
@@ -2,11 +2,12 @@ import { Result } from 'effect'
 
 import { canonicalHashV1Result } from '../hash'
 import { CycleState, type AutonomousCycle, type CycleDraft } from './cycle-model'
+import { Pipeable } from '../pipeable'
 
 export const isTerminalCycleState = (state: CycleState): boolean =>
   state === CycleState.Completed || state === CycleState.NoTrade || state === CycleState.Blocked
 
-export const isCycleStateTransitionAllowed = (from: CycleState, to: CycleState): boolean => {
+const isCycleStateTransitionAllowedDataFirst = (from: CycleState, to: CycleState): boolean => {
   if (from === CycleState.Pending) return to === CycleState.Active || to === CycleState.Blocked
   if (from === CycleState.Active) {
     return to === CycleState.Completed || to === CycleState.NoTrade || to === CycleState.Blocked
@@ -14,15 +15,19 @@ export const isCycleStateTransitionAllowed = (from: CycleState, to: CycleState):
   return false
 }
 
+export const isCycleStateTransitionAllowed = Pipeable.dual(2, isCycleStateTransitionAllowedDataFirst)
+
 export const cycleDraftOf = (cycle: AutonomousCycle): CycleDraft => ({
   schemaVersion: cycle.schemaVersion,
   identity: cycle.identity,
   window: cycle.window,
 })
 
-export const cycleDraftMatches = (left: CycleDraft, right: CycleDraft): boolean => {
+const cycleDraftMatchesDataFirst = (left: CycleDraft, right: CycleDraft): boolean => {
   const leftHash = canonicalHashV1Result(left)
   if (Result.isFailure(leftHash)) return false
   const rightHash = canonicalHashV1Result(right)
   return Result.isSuccess(rightHash) && leftHash.success === rightHash.success
 }
+
+export const cycleDraftMatches = Pipeable.dual(2, cycleDraftMatchesDataFirst)

--- a/services/bayn/src/cycle-runner/pass-decisions.ts
+++ b/services/bayn/src/cycle-runner/pass-decisions.ts
@@ -5,6 +5,7 @@ import { CycleState, type AutonomousCycle } from '../cycle'
 import type { CycleReadinessError } from '../cycle-readiness'
 import type { CycleRecoverySelection } from '../cycle-recovery'
 import { runnerError, type CyclePassObservation, type CycleRunnerError, type CycleRunResult } from './model'
+import { Pipeable } from '../pipeable'
 
 export const readinessFailure = (cause: CycleReadinessError): CycleRunnerError['failure'] => {
   switch (cause.failure) {
@@ -17,7 +18,7 @@ export const readinessFailure = (cause: CycleReadinessError): CycleRunnerError['
   }
 }
 
-export const finishRecoveryResult = (
+const finishRecoveryResultDataFirst = (
   selection: Extract<CycleRecoverySelection, { readonly action: 'FINISH' }>,
   cycle: AutonomousCycle,
 ): Result.Result<CycleRunResult, CycleRunnerError> => {
@@ -36,6 +37,8 @@ export const finishRecoveryResult = (
       return Result.fail(runnerError('recover-cycle', 'contract', 'cycle finish did not produce a terminal state'))
   }
 }
+
+export const finishRecoveryResult = Pipeable.dual(2, finishRecoveryResultDataFirst)
 
 export interface CyclePassLogFacts {
   readonly level: 'INFO' | 'ERROR'

--- a/services/bayn/src/cycle-runner/publication-decisions.ts
+++ b/services/bayn/src/cycle-runner/publication-decisions.ts
@@ -1,4 +1,5 @@
 import { CycleState, type AutonomousCycle } from '../cycle'
+import { Pipeable } from '../pipeable'
 
 export type CyclePublicationAdmission =
   | { readonly _tag: 'RETURN_BLOCKED' }
@@ -8,7 +9,7 @@ export type CyclePublicationAdmission =
   | { readonly _tag: 'WAIT_SIGNAL' }
   | { readonly _tag: 'INSPECT_PUBLICATION' }
 
-export const decideCyclePublicationAdmission = (
+const decideCyclePublicationAdmissionDataFirst = (
   cycle: AutonomousCycle,
   observedAt: string,
 ): CyclePublicationAdmission => {
@@ -20,6 +21,8 @@ export const decideCyclePublicationAdmission = (
   return { _tag: 'INSPECT_PUBLICATION' }
 }
 
+export const decideCyclePublicationAdmission = Pipeable.dual(2, decideCyclePublicationAdmissionDataFirst)
+
 export type FinalizedPublicationBindingDecision =
   | { readonly _tag: 'RETURN_BLOCKED' }
   | { readonly _tag: 'REJECT_IMMUTABLE_BINDING' }
@@ -29,7 +32,7 @@ export type FinalizedPublicationBindingDecision =
   | { readonly _tag: 'REJECT_BEFORE_SIGNAL_CLOSE' }
   | { readonly _tag: 'BIND' }
 
-export const decideFinalizedPublicationBinding = (
+const decideFinalizedPublicationBindingDataFirst = (
   cycle: AutonomousCycle,
   snapshotId: string,
   observedAt: string,
@@ -46,12 +49,14 @@ export const decideFinalizedPublicationBinding = (
   return { _tag: 'BIND' }
 }
 
+export const decideFinalizedPublicationBinding = Pipeable.dual(3, decideFinalizedPublicationBindingDataFirst)
+
 export type PublicationInspectionDecision =
   | { readonly _tag: 'BLOCK_MISSED' }
   | { readonly _tag: 'WAIT_MISSING' }
   | { readonly _tag: 'BIND_FINALIZED' }
 
-export const decidePublicationInspection = (
+const decidePublicationInspectionDataFirst = (
   publicationFound: boolean,
   observedAt: string,
   publicationDeadlineAt: string,
@@ -59,3 +64,5 @@ export const decidePublicationInspection = (
   if (observedAt >= publicationDeadlineAt) return { _tag: 'BLOCK_MISSED' }
   return publicationFound ? { _tag: 'BIND_FINALIZED' } : { _tag: 'WAIT_MISSING' }
 }
+
+export const decidePublicationInspection = Pipeable.dual(3, decidePublicationInspectionDataFirst)

--- a/services/bayn/src/cycle-runner/reconciliation-cadence.ts
+++ b/services/bayn/src/cycle-runner/reconciliation-cadence.ts
@@ -6,6 +6,7 @@ import {
   type IdleReconciliationCadenceDecision,
   type ReconciliationCadenceState,
 } from './model'
+import { Pipeable } from '../pipeable'
 
 const nanosPerMillisecond = 1_000_000n
 
@@ -16,7 +17,7 @@ export const validateReconciliationInterval = (
     ? Result.succeed(reconciliationIntervalMs)
     : Result.fail(runnerError('configure', 'invalid-config', 'reconciliation interval must be a positive safe integer'))
 
-export const validateCyclePassTimeout = (
+const validateCyclePassTimeoutDataFirst = (
   cyclePassTimeoutMs: number,
   reconciliationIntervalMs: number,
 ): Result.Result<number, CycleRunnerError> =>
@@ -29,6 +30,8 @@ export const validateCyclePassTimeout = (
           'cycle pass timeout must be a positive safe integer no longer than the reconciliation interval',
         ),
       )
+
+export const validateCyclePassTimeout = Pipeable.dual(2, validateCyclePassTimeoutDataFirst)
 
 export const shouldDeferCyclePollForReconciliation = (input: {
   readonly lastAttemptAtNanos: bigint | undefined
@@ -46,7 +49,7 @@ export const shouldDeferCyclePollForReconciliation = (input: {
   )
 }
 
-export const decideIdleReconciliationCadence = (
+const decideIdleReconciliationCadenceDataFirst = (
   state: ReconciliationCadenceState,
   nowNanos: bigint,
   reconciliationIntervalMs: number,
@@ -59,3 +62,5 @@ export const decideIdleReconciliationCadence = (
     ? { _tag: 'RECONCILE' }
     : { _tag: 'WAIT', remainingNanos: intervalNanos - elapsedNanos }
 }
+
+export const decideIdleReconciliationCadence = Pipeable.dual(3, decideIdleReconciliationCadenceDataFirst)

--- a/services/bayn/src/cycle-runner/recovery-decision-binding.ts
+++ b/services/bayn/src/cycle-runner/recovery-decision-binding.ts
@@ -10,6 +10,7 @@ import {
   type CycleRecoverySelection,
 } from './recovery-model'
 import { cycleCompletionStateForTargetPlan, cycleTerminalReasonForBlockedTargetPlan } from './recovery-decisions'
+import { Pipeable } from '../pipeable'
 
 export { cycleCompletionStateForTargetPlan, cycleTerminalReasonForBlockedTargetPlan } from './recovery-decisions'
 
@@ -61,7 +62,7 @@ const validateDecisionBinding = (
     : Result.succeed(undefined)
 }
 
-export const selectBoundDecision = (
+const selectBoundDecisionDataFirst = (
   cycle: AutonomousCycle,
   document: CycleDecisionDocument | null | undefined,
   observedAt: string,
@@ -105,3 +106,5 @@ export const selectBoundDecision = (
     },
   )
 }
+
+export const selectBoundDecision = Pipeable.dual(3, selectBoundDecisionDataFirst)

--- a/services/bayn/src/cycle-runner/recovery-readiness-model.ts
+++ b/services/bayn/src/cycle-runner/recovery-readiness-model.ts
@@ -2,6 +2,7 @@ import { Result } from 'effect'
 
 import { signalSessionCloseAt, type AutonomousCycle, type CycleConstructionFailure } from '../cycle'
 import type { MarketDataInspection } from '../market-data'
+import { Pipeable } from '../pipeable'
 
 export interface PublicationFreshness {
   readonly dataAgeMs: number
@@ -75,7 +76,7 @@ const elapsed = (
     : Result.succeed(milliseconds)
 }
 
-export const measurePublicationFreshness = (
+const measurePublicationFreshnessDataFirst = (
   cycle: AutonomousCycle,
   inspection: MarketDataInspection,
   observedAt: string,
@@ -131,3 +132,5 @@ export const measurePublicationFreshness = (
           ),
   )
 }
+
+export const measurePublicationFreshness = Pipeable.dual(3, measurePublicationFreshnessDataFirst)

--- a/services/bayn/src/cycle-runner/recovery-readiness.ts
+++ b/services/bayn/src/cycle-runner/recovery-readiness.ts
@@ -12,6 +12,7 @@ import {
   type DecodedCycleRecoveryState,
   type WaitingReadiness,
 } from './recovery-model'
+import { Pipeable } from '../pipeable'
 
 const readinessBindingFacts = (
   cycle: AutonomousCycle,
@@ -134,7 +135,7 @@ const readinessOutcomeMatches = (cycle: AutonomousCycle, readiness: CyclePublica
   }
 }
 
-export const readinessIsCorrelated = (
+const readinessIsCorrelatedDataFirst = (
   cycle: AutonomousCycle,
   recoveryObservedAt: string,
   readiness: CyclePublicationReadiness,
@@ -143,7 +144,9 @@ export const readinessIsCorrelated = (
   readinessCommonMatches(cycle, readiness) &&
   readinessOutcomeMatches(cycle, readiness)
 
-export const validateReadiness = (
+export const readinessIsCorrelated = Pipeable.dual(3, readinessIsCorrelatedDataFirst)
+
+const validateReadinessDataFirst = (
   cycle: AutonomousCycle,
   recoveryObservedAt: string,
   readiness: CyclePublicationReadiness,
@@ -158,7 +161,9 @@ export const validateReadiness = (
         ),
       )
 
-export const correlatedReadinessOf = (
+export const validateReadiness = Pipeable.dual(3, validateReadinessDataFirst)
+
+const correlatedReadinessOfDataFirst = (
   state: DecodedCycleRecoveryState,
   cycle: AutonomousCycle,
 ): AlreadyBoundReadiness | undefined => {
@@ -169,3 +174,5 @@ export const correlatedReadinessOf = (
     ? readiness
     : undefined
 }
+
+export const correlatedReadinessOf = Pipeable.dual(2, correlatedReadinessOfDataFirst)

--- a/services/bayn/src/http.ts
+++ b/services/bayn/src/http.ts
@@ -24,6 +24,7 @@ import { databaseOperation, withinDeadline } from './operations'
 import { Authority } from './execution/contracts'
 import { makeQualificationDiagnosis } from './qualification-diagnosis'
 import { isReady, type DependencyHealth, type RuntimeState } from './runtime-state'
+import { Pipeable } from './pipeable'
 
 type ReadEvidence = EvidenceStoreService['read']
 
@@ -289,7 +290,7 @@ const publicCycleState = (state: RuntimeState) =>
         error: cyclePresentationReason(state.cycle.error),
       }
 
-export const statusFacts = (
+const statusFactsDataFirst = (
   state: RuntimeState,
   execution: ExecutionPolicy,
   provenance: RuntimeProvenance,
@@ -385,12 +386,16 @@ export const statusFacts = (
   } as const
 }
 
-export const statusResponseDecision = (
+export const statusFacts = Pipeable.dual(4, statusFactsDataFirst)
+
+const statusResponseDecisionDataFirst = (
   state: RuntimeState,
   execution: ExecutionPolicy,
   provenance: RuntimeProvenance,
   provenanceVerification: RuntimeBuildMetadata['verification'],
 ): HttpResponseDecision => jsonDecision(statusFacts(state, execution, provenance, provenanceVerification))
+
+export const statusResponseDecision = Pipeable.dual(4, statusResponseDecisionDataFirst)
 
 const appendFailure = (failures: readonly string[], name: string, failed: boolean): readonly string[] =>
   failed && !failures.includes(name) ? [...failures, name] : failures
@@ -440,7 +445,7 @@ export const historicalEvidenceResponseDecision = (stored: Option.Option<unknown
     onSome: (evidence) => jsonDecision(evidence),
   })
 
-export const historicalReadFailureDecision = (runId: string, error: OperationalError) =>
+const historicalReadFailureDecisionDataFirst = (runId: string, error: OperationalError) =>
   ({
     response: jsonDecision({ error: 'evidence_unavailable' }, 503),
     log: {
@@ -456,6 +461,8 @@ export const historicalReadFailureDecision = (runId: string, error: OperationalE
       },
     },
   }) as const
+
+export const historicalReadFailureDecision = Pipeable.dual(2, historicalReadFailureDecisionDataFirst)
 
 export const readHistoricalEvidence = <A, R>(
   read: Effect.Effect<Option.Option<A>, DatabaseError, R>,
@@ -478,7 +485,7 @@ const epochSeconds = (instant: string | null | undefined): number =>
 
 const booleanMetric = (value: boolean | null): number => (value === true ? 1 : 0)
 
-export const renderPrometheusMetrics = (
+const renderPrometheusMetricsDataFirst = (
   state: RuntimeState,
   config: Pick<
     RuntimeConfig,
@@ -710,6 +717,8 @@ export const renderPrometheusMetrics = (
   return `${lines.join('\n')}\n`
 }
 
+export const renderPrometheusMetrics = Pipeable.dual(4, renderPrometheusMetricsDataFirst)
+
 const interpretResponseDecision = (
   decision: HttpResponseDecision,
 ): Effect.Effect<HttpServerResponse.HttpServerResponse> =>
@@ -835,7 +844,7 @@ const registerHttpRoutes = (
   })
 }
 
-export const serveHttp = (
+const serveHttpDataFirst = (
   config: HttpConfig,
   state: Ref.Ref<RuntimeState>,
   provenance: RuntimeProvenance,
@@ -850,3 +859,5 @@ export const serveHttp = (
     const handler = router.asHttpEffect().pipe(Effect.orDie)
     yield* HttpServer.serveEffect(handler)
   })
+
+export const serveHttp = Pipeable.dual(5, serveHttpDataFirst)

--- a/services/bayn/src/ledger-plan.ts
+++ b/services/bayn/src/ledger-plan.ts
@@ -40,8 +40,9 @@ import {
   verifyExactTransfers,
   verifyLedgerPlanRecords,
 } from './ledger-plan/verification'
+import { Pipeable } from './pipeable'
 
-export const buildLedgerPlan = (
+const buildLedgerPlanDataFirst = (
   input: unknown,
   ledger: number,
 ): Result.Result<EvaluationLedgerPlan, LedgerPlanFailure> =>
@@ -49,6 +50,8 @@ export const buildLedgerPlan = (
     Result.flatMap(decodeLedgerInput(input), (decoded) => planDecodedLedgerInput(decoded, ledger)),
     (failure) => makeLedgerPlanFailure(ledger, failure),
   )
+
+export const buildLedgerPlan = Pipeable.dual(2, buildLedgerPlanDataFirst)
 
 export {
   AccountCode,

--- a/services/bayn/src/observe-composition.ts
+++ b/services/bayn/src/observe-composition.ts
@@ -132,6 +132,7 @@ import {
   type MutationPreparationFacts,
   type MutationPreparationFactsRequest,
 } from './observe-composition/mutation-intent-interpreter'
+import { Pipeable } from './pipeable'
 
 export {
   appendPendingMutationOrder,
@@ -180,7 +181,7 @@ const observeRiskLimits = {
   decisionTtlMs: 300_000,
 } as const
 
-export const loadObserveRiskPolicy = (accountId: string, allowedSymbols: readonly string[]) =>
+const loadObserveRiskPolicyDataFirst = (accountId: string, allowedSymbols: readonly string[]) =>
   decodePolicy({
     schemaVersion: 'bayn.paper-risk-policy.v1',
     accountId,
@@ -190,6 +191,8 @@ export const loadObserveRiskPolicy = (accountId: string, allowedSymbols: readonl
     allowedTimeInForce: [TimeInForce.Day],
     ...observeRiskLimits,
   })
+
+export const loadObserveRiskPolicy = Pipeable.dual(2, loadObserveRiskPolicyDataFirst)
 
 type ObserveStrategy = StrategyRuntime
 
@@ -1599,7 +1602,7 @@ const terminalizeUnboundMutationCycleAtCutoff = (
     })),
   )
 
-export const terminalizeBlockedPaperCycle = (
+const terminalizeBlockedPaperCycleDataFirst = (
   cycle: AutonomousCycle,
   outcome: Extract<BoundMutationCycleOutcome, { readonly _tag: 'Block' }>,
 ): Effect.Effect<CycleRunResult, CycleRunnerError, CycleStore | AuthorityRestrictionStore | WriterFence> =>
@@ -1620,6 +1623,8 @@ export const terminalizeBlockedPaperCycle = (
       cycle: receipt.cycle,
     })),
   )
+
+export const terminalizeBlockedPaperCycle = Pipeable.dual(2, terminalizeBlockedPaperCycleDataFirst)
 
 const interpretBoundMutationCycleOutcome = (
   input: ObserveAutonomousCycleInput,

--- a/services/bayn/src/paper-proof-command.ts
+++ b/services/bayn/src/paper-proof-command.ts
@@ -11,6 +11,7 @@ import {
   type PaperProofDependencies,
   type PaperProofReceipt,
 } from './paper-proof'
+import { Pipeable } from './pipeable'
 
 const ownDataProperty = (value: unknown, property: string): unknown => {
   if (typeof value !== 'object' || value === null || Array.isArray(value)) return undefined
@@ -29,7 +30,7 @@ const malformedOperation = (input: unknown): PaperProofCliEnvelope['command']['o
     : undefined
 }
 
-export const runPaperProofCommand = (
+const runPaperProofCommandDataFirst = (
   input: unknown,
   dependencies: PaperProofDependencies,
 ): Effect.Effect<PaperProofReceipt, PaperProofError> => {
@@ -57,6 +58,8 @@ export const runPaperProofCommand = (
     protectedEntryToken: envelope.protectedEntryToken,
   })
 }
+
+export const runPaperProofCommand = Pipeable.dual(2, runPaperProofCommandDataFirst)
 
 export const paperProofCommandEntryGate = Effect.fail(
   new PaperProofError({

--- a/services/bayn/src/pipeable.ts
+++ b/services/bayn/src/pipeable.ts
@@ -1,0 +1,17 @@
+import { Function } from 'effect'
+
+type AnyFunction = (...arguments_: ReadonlyArray<never>) => unknown
+type Tail<Values extends ReadonlyArray<unknown>> = Values extends readonly [unknown, ...infer Rest] ? Rest : never
+
+interface PipeableFunction<Self, Arguments extends ReadonlyArray<unknown>, Return> {
+  (...arguments_: Arguments): (self: Self) => Return
+  (self: Self, ...arguments_: Arguments): Return
+}
+
+const dual = <DataFirst extends AnyFunction>(
+  arity: Parameters<DataFirst>['length'],
+  body: DataFirst,
+): PipeableFunction<Parameters<DataFirst>[0], Tail<Parameters<DataFirst>>, ReturnType<DataFirst>> =>
+  Function.dual(arity, body)
+
+export const Pipeable = { dual } as const

--- a/services/bayn/src/qualification-diagnosis.ts
+++ b/services/bayn/src/qualification-diagnosis.ts
@@ -1,6 +1,7 @@
 import { canonicalHashV1 } from './hash'
 import type { QualificationResult } from './qualification'
 import type { EvaluationSummary, PerformanceMetrics } from './types'
+import { Pipeable } from './pipeable'
 
 const round = (value: number): number => Number.parseFloat(value.toFixed(12))
 
@@ -46,7 +47,7 @@ const metricFacts = (metrics: PerformanceMetrics) => ({
   totalCashYieldMicros: metrics.totalCashYieldMicros,
 })
 
-export const makeQualificationDiagnosis = (evaluation: EvaluationSummary, result: QualificationResult) => {
+const makeQualificationDiagnosisDataFirst = (evaluation: EvaluationSummary, result: QualificationResult) => {
   const bootstrap = result.analysis.bootstrap
   const benchmarkMetrics =
     bootstrap.selectedBenchmark === 'buy-and-hold' ? evaluation.buyAndHold : evaluation.directVolTiming
@@ -93,5 +94,7 @@ export const makeQualificationDiagnosis = (evaluation: EvaluationSummary, result
   }
   return { ...material, diagnosisHash: canonicalHashV1(material) }
 }
+
+export const makeQualificationDiagnosis = Pipeable.dual(2, makeQualificationDiagnosisDataFirst)
 
 export type QualificationDiagnosis = ReturnType<typeof makeQualificationDiagnosis>

--- a/services/bayn/src/tigerbeetle-client.ts
+++ b/services/bayn/src/tigerbeetle-client.ts
@@ -20,6 +20,7 @@ import type {
   LedgerQueryFilter,
   LedgerTransferRecord,
 } from './ledger-plan/model'
+import { Pipeable } from './pipeable'
 
 type ResolveHostname = (hostname: string) => Effect.Effect<readonly string[], OperationalError>
 
@@ -187,7 +188,7 @@ export const parseReplicaEndpoints = (
       })
     : Result.all(configuredAddresses.map(parseReplicaEndpoint))
 
-export const validateResolvedReplicaEndpoint = (
+const validateResolvedReplicaEndpointDataFirst = (
   endpoint: ReplicaEndpoint,
   resolvedAddresses: readonly string[],
 ): Result.Result<string, ReplicaAddressValidationError> => {
@@ -210,6 +211,8 @@ export const validateResolvedReplicaEndpoint = (
   }
   return Result.succeed(`${ipv4Addresses[0]}:${endpoint.port}`)
 }
+
+export const validateResolvedReplicaEndpoint = Pipeable.dual(2, validateResolvedReplicaEndpointDataFirst)
 
 export const validateResolvedReplicaAddresses = (
   addresses: readonly string[],

--- a/services/bayn/src/time.ts
+++ b/services/bayn/src/time.ts
@@ -1,4 +1,5 @@
 import { Clock, DateTime, Effect, Option, pipe, Result } from 'effect'
+import { Pipeable } from './pipeable'
 
 export type UtcEpochMillisFailure =
   | {
@@ -26,8 +27,10 @@ export const utcInstantFromEpochMillis = (epochMillis: number): string =>
 export const utcDateFromEpochMillis = (epochMillis: number): string =>
   DateTime.formatIsoDate(DateTime.makeUnsafe(epochMillis))
 
-export const addUtcDays = (date: string, days: number): string =>
+const addUtcDaysDataFirst = (date: string, days: number): string =>
   pipe(DateTime.makeUnsafe(`${date}T00:00:00.000Z`), DateTime.add({ days }), DateTime.formatIsoDate)
+
+export const addUtcDays = Pipeable.dual(2, addUtcDaysDataFirst)
 
 export const currentUtcInstant = Clock.currentTimeMillis.pipe(Effect.map(utcInstantFromEpochMillis))
 

--- a/services/bayn/src/unsigned-round-half-up.ts
+++ b/services/bayn/src/unsigned-round-half-up.ts
@@ -1,5 +1,7 @@
 import { Result } from 'effect'
 
+import { Pipeable } from './pipeable'
+
 export type UnsignedRoundHalfUpFailure =
   | {
       readonly _tag: 'NegativeUnsignedRoundHalfUpNumerator'
@@ -14,7 +16,7 @@ export type UnsignedRoundHalfUpFailure =
       readonly minimumDenominator: 1n
     }
 
-export const roundUnsignedHalfUp = (
+const roundUnsignedHalfUpDataFirst = (
   numerator: bigint,
   denominator: bigint,
 ): Result.Result<bigint, UnsignedRoundHalfUpFailure> => {
@@ -36,3 +38,5 @@ export const roundUnsignedHalfUp = (
   }
   return Result.succeed((numerator + denominator / 2n) / denominator)
 }
+
+export const roundUnsignedHalfUp = Pipeable.dual(2, roundUnsignedHalfUpDataFirst)


### PR DESCRIPTION
## Summary

- Makes core domain functions support idiomatic Effect pipe composition without changing their decisions.
- Keeps this native stack layer independently reviewable at 477 changed lines.
- Bases directly on codex/bayn-effect-tsgo-strict-diagnostics so GitHub shows only this layer.

## Related Issues

None

## Testing

- bunx tsc --noEmit --project services/bayn/tsconfig.json
- bun run lint
- bun run lint:oxlint
- bun run lint:oxlint:type
- bun run build
- Focused tests for the touched subsystem were run while constructing the layer.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable and Breaking Changes is filled in.
- [x] Documentation and follow-ups are unchanged or represented by later stack layers.