### PR TITLE
refactor(bayn): make persistence APIs pipeable

### DIFF
--- a/services/bayn/src/db/capital-grant-algebra.ts
+++ b/services/bayn/src/db/capital-grant-algebra.ts
@@ -20,6 +20,7 @@ import {
   type ResearchCapitalGrantProofBinding,
 } from '../execution/contracts'
 import type { QualificationLock, QualificationResult } from '../qualification'
+import { Pipeable } from '../pipeable'
 
 export interface AuthorityGenerationHistoryFacts {
   readonly generationHash: string
@@ -334,7 +335,7 @@ export const nextAuthorityVersion = (current: {
       })
 }
 
-export const decideObserveGeneration = (
+const decideObserveGenerationDataFirst = (
   input: ObserveGenerationRequest,
   current: AuthorityState | undefined,
 ): Result.Result<ObserveGenerationDecision, CapitalGrantAlgebraFailure> => {
@@ -368,7 +369,9 @@ export const decideObserveGeneration = (
   )
 }
 
-export const validateAuthorityObservation = (
+export const decideObserveGeneration = Pipeable.dual(2, decideObserveGenerationDataFirst)
+
+const validateAuthorityObservationDataFirst = (
   current: AuthorityState,
   observedAt: Date,
 ): Result.Result<void, CapitalGrantAlgebraFailure> => {
@@ -382,6 +385,8 @@ export const validateAuthorityObservation = (
         observedAt,
       })
 }
+
+export const validateAuthorityObservation = Pipeable.dual(2, validateAuthorityObservationDataFirst)
 
 export const validateCurrentGenerationHistory = <History extends AuthorityGenerationHistoryFacts>(
   current: AuthorityState,
@@ -429,13 +434,15 @@ export const validateCurrentGenerationHistory = <History extends AuthorityGenera
   return Result.succeed(history)
 }
 
-export const requireUnusedAuthorityGeneration = (
+const requireUnusedAuthorityGenerationDataFirst = (
   generationHash: string,
   existing: AuthorityGenerationHistoryFacts | undefined,
 ): Result.Result<void, CapitalGrantAlgebraFailure> =>
   existing === undefined ? Result.succeed(undefined) : fail({ _tag: 'AuthorityGenerationAlreadyUsed', generationHash })
 
-export const bindPaperGenerationRuntime = (
+export const requireUnusedAuthorityGeneration = Pipeable.dual(2, requireUnusedAuthorityGenerationDataFirst)
+
+const bindPaperGenerationRuntimeDataFirst = (
   facts: PaperGenerationRuntimeFacts,
   expectedMaximum: Authority,
   operation: 'PREPARE' | 'activation',
@@ -461,6 +468,8 @@ export const bindPaperGenerationRuntime = (
   })
 }
 
+export const bindPaperGenerationRuntime = Pipeable.dual(3, bindPaperGenerationRuntimeDataFirst)
+
 export const validatePaperSourceAuthority = (
   current: AuthorityState,
 ): Result.Result<void, CapitalGrantAlgebraFailure> =>
@@ -473,7 +482,7 @@ export const validatePaperSourceAuthority = (
         effective: current.effective,
       })
 
-export const validatePaperPrepareGeneration = (
+const validatePaperPrepareGenerationDataFirst = (
   current: AuthorityState,
   binding: PaperGenerationRuntimeBinding,
 ): Result.Result<void, CapitalGrantAlgebraFailure> =>
@@ -484,6 +493,8 @@ export const validatePaperPrepareGeneration = (
         currentGenerationHash: current.generationHash,
         configuredGenerationHash: binding.configuredGenerationHash,
       })
+
+export const validatePaperPrepareGeneration = Pipeable.dual(2, validatePaperPrepareGenerationDataFirst)
 
 const readQualificationEvidenceVerificationFacts = (
   evidence: PaperGenerationEvidenceFacts,
@@ -541,7 +552,7 @@ const qualificationEvidenceHash = (
     }),
   )
 
-export const validatePaperGenerationEvidence = (
+const validatePaperGenerationEvidenceDataFirst = (
   evidence: PaperGenerationEvidenceFacts | undefined,
   binding: PaperGenerationRuntimeBinding,
   build: AuthorityBuildFacts,
@@ -613,7 +624,9 @@ export const validatePaperGenerationEvidence = (
   })
 }
 
-export const validateLatestExactReconciliation = (
+export const validatePaperGenerationEvidence = Pipeable.dual(3, validatePaperGenerationEvidenceDataFirst)
+
+const validateLatestExactReconciliationDataFirst = (
   reconciliation: ExactReconciliationFacts | undefined,
   accountId: string,
 ): Result.Result<ExactReconciliationFacts, CapitalGrantAlgebraFailure> => {
@@ -633,7 +646,9 @@ export const validateLatestExactReconciliation = (
   return Result.succeed(reconciliation)
 }
 
-export const validateMutationCoverage = (
+export const validateLatestExactReconciliation = Pipeable.dual(2, validateLatestExactReconciliationDataFirst)
+
+const validateMutationCoverageDataFirst = (
   baseline: MutationBaselineFacts,
   reconciliation: ExactReconciliationFacts,
 ): Result.Result<void, CapitalGrantAlgebraFailure> =>
@@ -646,6 +661,8 @@ export const validateMutationCoverage = (
         latestMutationAt: baseline.latestMutationAt,
         reconciledAt: reconciliation.reconciledAt,
       })
+
+export const validateMutationCoverage = Pipeable.dual(2, validateMutationCoverageDataFirst)
 
 const readCapitalGrantGenerationMaterial = (input: {
   readonly current: AuthorityState
@@ -783,7 +800,7 @@ export const deriveResearchCapitalGrantGeneration = (input: {
     Result.map((generation) => ({ current: input.current, generation, reconciliation: input.reconciliation })),
   )
 
-export const validateResearchPaperGenerationReplay = (
+const validateResearchPaperGenerationReplayDataFirst = (
   stored: ResearchCapitalGrantGeneration,
   proof: ResearchCapitalGrantProofBinding,
   expectedPreviousGenerationHash: string,
@@ -809,7 +826,9 @@ export const validateResearchPaperGenerationReplay = (
         expectedPreviousGenerationHash,
       })
 
-export const validatePaperGenerationFreshness = (
+export const validateResearchPaperGenerationReplay = Pipeable.dual(3, validateResearchPaperGenerationReplayDataFirst)
+
+const validatePaperGenerationFreshnessDataFirst = (
   reconciliation: ExactReconciliationFacts,
   observedAt: Date,
   staleThresholdMs: number,
@@ -824,7 +843,9 @@ export const validatePaperGenerationFreshness = (
         staleThresholdMs,
       })
 
-export const decidePaperActivation = (
+export const validatePaperGenerationFreshness = Pipeable.dual(3, validatePaperGenerationFreshnessDataFirst)
+
+const decidePaperActivationDataFirst = (
   current: AuthorityState,
   binding: Pick<PaperGenerationRuntimeBinding, 'configuredGenerationHash'>,
 ): Result.Result<PaperActivationDecision, CapitalGrantAlgebraFailure> => {
@@ -847,7 +868,9 @@ export const decidePaperActivation = (
       })
 }
 
-export const validatePaperGenerationReplay = (
+export const decidePaperActivation = Pipeable.dual(2, decidePaperActivationDataFirst)
+
+const validatePaperGenerationReplayDataFirst = (
   stored: CapitalGrantGeneration,
   binding: PaperGenerationRuntimeBinding,
   proof: CapitalGrantProofBinding,
@@ -870,7 +893,9 @@ export const validatePaperGenerationReplay = (
         qualificationRunId: binding.qualificationRunId,
       })
 
-export const validateDerivedPaperGeneration = (
+export const validatePaperGenerationReplay = Pipeable.dual(4, validatePaperGenerationReplayDataFirst)
+
+const validateDerivedPaperGenerationDataFirst = (
   generation: CapitalGrantGeneration,
   binding: PaperGenerationRuntimeBinding,
 ): Result.Result<void, CapitalGrantAlgebraFailure> =>
@@ -881,6 +906,8 @@ export const validateDerivedPaperGeneration = (
         derivedGenerationHash: generation.generationHash,
         configuredGenerationHash: binding.configuredGenerationHash,
       })
+
+export const validateDerivedPaperGeneration = Pipeable.dual(2, validateDerivedPaperGenerationDataFirst)
 
 export const paperActivationEffectiveAuthority = (kill: KillState): Authority =>
   kill === KillState.Active ? Authority.Observe : Authority.Paper

--- a/services/bayn/src/db/cycle-store/binding-program.ts
+++ b/services/bayn/src/db/cycle-store/binding-program.ts
@@ -28,6 +28,7 @@ import {
 import type { CycleMutationPrimitives } from './mutations'
 import type { CycleQueries } from './queries'
 import { decodeDecisionInput, decodeSnapshotInput } from './rows'
+import { Pipeable } from '../../pipeable'
 
 export interface CycleBindingPrograms {
   readonly bindSnapshot: CycleStoreShape['bindSnapshot']
@@ -104,7 +105,7 @@ const upgradeDecisionDocumentConstraints = (sql: PgClient.PgClient): Effect.Effe
     $migration$
   `.pipe(Effect.asVoid)
 
-export const makeCycleBindingPrograms = (
+const makeCycleBindingProgramsDataFirst = (
   sql: PgClient.PgClient,
   queries: CycleQueries,
   mutations: CycleMutationPrimitives,
@@ -270,3 +271,5 @@ export const makeCycleBindingPrograms = (
 
   return { bindSnapshot, bindDecision }
 }
+
+export const makeCycleBindingPrograms = Pipeable.dual(3, makeCycleBindingProgramsDataFirst)

--- a/services/bayn/src/db/cycle-store/decision-contract.ts
+++ b/services/bayn/src/db/cycle-store/decision-contract.ts
@@ -1,4 +1,5 @@
 import type { CycleDecisionDocument } from '../../shadow-decision-contract'
+import { Pipeable } from '../../pipeable'
 
 export interface CycleStoreDecisionFailure {
   readonly failure: 'conflict' | 'invariant' | 'not-found'
@@ -12,7 +13,7 @@ export interface CycleDecisionStoreEvidence {
 
 const decisionStoreEvidence = new WeakMap<object, CycleDecisionStoreEvidence>()
 
-export const attachCycleDecisionStoreEvidence = (
+const attachCycleDecisionStoreEvidenceDataFirst = (
   document: CycleDecisionDocument,
   evidence: CycleDecisionStoreEvidence,
 ): CycleDecisionDocument => {
@@ -20,6 +21,8 @@ export const attachCycleDecisionStoreEvidence = (
   decisionStoreEvidence.set(attached, evidence)
   return attached
 }
+
+export const attachCycleDecisionStoreEvidence = Pipeable.dual(2, attachCycleDecisionStoreEvidenceDataFirst)
 
 export const cycleDecisionStoreEvidence = (document: CycleDecisionDocument): CycleDecisionStoreEvidence | undefined =>
   decisionStoreEvidence.get(document)

--- a/services/bayn/src/db/cycle-store/decisions.ts
+++ b/services/bayn/src/db/cycle-store/decisions.ts
@@ -16,6 +16,7 @@ import { TargetPlanStatus } from '../../target-planner'
 import type { InputManifest } from '../../types'
 import { cycleDecisionStoreEvidence } from './decision-contract'
 import type { CycleStoreDecisionFailure } from './decision-contract'
+import { Pipeable } from '../../pipeable'
 
 export type { CycleStoreDecisionFailure } from './decision-contract'
 
@@ -116,7 +117,7 @@ const fail = (
 
 const shadowDecisionEquivalent = Schema.toEquivalence(CycleDecisionDocumentSchema)
 
-export const makeInitialCycle = (draft: CycleDraft, observedAt: string): AutonomousCycle => {
+const makeInitialCycleDataFirst = (draft: CycleDraft, observedAt: string): AutonomousCycle => {
   const missedPublication = observedAt >= draft.window.publicationDeadlineAt
   return {
     ...draft,
@@ -134,7 +135,9 @@ export const makeInitialCycle = (draft: CycleDraft, observedAt: string): Autonom
   }
 }
 
-export const decideAcquire = (
+export const makeInitialCycle = Pipeable.dual(2, makeInitialCycleDataFirst)
+
+const decideAcquireDataFirst = (
   stored: AutonomousCycle,
   draft: CycleDraft,
   observedAt: string,
@@ -155,7 +158,9 @@ export const decideAcquire = (
   )
 }
 
-export const decideSnapshotBinding = (
+export const decideAcquire = Pipeable.dual(4, decideAcquireDataFirst)
+
+const decideSnapshotBindingDataFirst = (
   cycle: AutonomousCycle,
   snapshot: InputManifest['finalizedSnapshot'],
   observedAt: string,
@@ -190,7 +195,9 @@ export const decideSnapshotBinding = (
     : Result.succeed({ _tag: 'Persist', cycle, snapshotId: snapshot.snapshotId })
 }
 
-export const decideActivation = (
+export const decideSnapshotBinding = Pipeable.dual(3, decideSnapshotBindingDataFirst)
+
+const decideActivationDataFirst = (
   cycle: AutonomousCycle,
   observedAt: string,
 ): Result.Result<ActivationDecision, CycleStoreDecisionFailure> => {
@@ -213,7 +220,9 @@ export const decideActivation = (
     : Result.succeed({ _tag: 'Persist', cycle })
 }
 
-export const decideDecisionBinding = (
+export const decideActivation = Pipeable.dual(2, decideActivationDataFirst)
+
+const decideDecisionBindingDataFirst = (
   cycle: AutonomousCycle,
   document: CycleDecisionDocument,
   observedAt: string,
@@ -256,7 +265,9 @@ export const decideDecisionBinding = (
     : Result.succeed({ _tag: 'Persist', cycle, document })
 }
 
-export const decideCompletion = (
+export const decideDecisionBinding = Pipeable.dual(4, decideDecisionBindingDataFirst)
+
+const decideCompletionDataFirst = (
   cycle: AutonomousCycle,
   state: CycleCompletionState,
   observedAt: string,
@@ -271,6 +282,8 @@ export const decideCompletion = (
     ? fail('invariant', 'cycle completion requires a bound shadow decision')
     : Result.succeed({ _tag: 'VerifyDecision', cycle, decisionHash, state })
 }
+
+export const decideCompletion = Pipeable.dual(3, decideCompletionDataFirst)
 
 export const validateCompletionDocument = (
   decision: Extract<CompletionDecision, { readonly _tag: 'VerifyDecision' }>,
@@ -294,7 +307,7 @@ export const validateCompletionDocument = (
     : fail('invariant', 'cycle terminal state must match its exact durable shadow decision')
 }
 
-export const decideBlock = (
+const decideBlockDataFirst = (
   cycle: AutonomousCycle,
   reason: CycleTerminalReason,
   observedAt: string,
@@ -325,6 +338,8 @@ export const decideBlock = (
     ? Result.succeed({ _tag: 'VerifyDecision', cycle, reason, decisionHash, observedAt })
     : Result.succeed({ _tag: 'Persist', cycle, reason })
 }
+
+export const decideBlock = Pipeable.dual(3, decideBlockDataFirst)
 
 export const validateBlockedDecision = (
   decision: Extract<BlockDecision, { readonly _tag: 'VerifyDecision' }>,

--- a/services/bayn/src/db/cycle-store/lifecycle-program.ts
+++ b/services/bayn/src/db/cycle-store/lifecycle-program.ts
@@ -23,6 +23,7 @@ import {
 import type { CycleMutationPrimitives } from './mutations'
 import type { CycleQueries } from './queries'
 import { decodeBlockInput, decodeCycleDraft, decodeCycleIdInput, decodeFinishInput, decodeObservedAt } from './rows'
+import { Pipeable } from '../../pipeable'
 
 export interface CycleLifecyclePrograms {
   readonly acquire: CycleStoreShape['acquire']
@@ -31,7 +32,7 @@ export interface CycleLifecyclePrograms {
   readonly block: CycleStoreShape['block']
 }
 
-export const makeCycleLifecyclePrograms = (
+const makeCycleLifecycleProgramsDataFirst = (
   sql: PgClient.PgClient,
   queries: CycleQueries,
   mutations: CycleMutationPrimitives,
@@ -205,3 +206,5 @@ export const makeCycleLifecyclePrograms = (
 
   return { acquire, activate, finish, block }
 }
+
+export const makeCycleLifecyclePrograms = Pipeable.dual(3, makeCycleLifecycleProgramsDataFirst)

--- a/services/bayn/src/db/cycle-store/model.ts
+++ b/services/bayn/src/db/cycle-store/model.ts
@@ -5,6 +5,7 @@ import type { AutonomousCycle, CycleCompletionState, CycleDraft, CycleTerminalRe
 import type { CycleDecisionDocument } from '../../shadow-decision-contract'
 import type { InputManifest, IsoDate } from '../../types'
 import type { CycleStoreDecisionFailure } from './decision-contract'
+import { Pipeable } from '../../pipeable'
 
 export {
   attachCycleDecisionStoreEvidence,
@@ -167,11 +168,13 @@ export const runCycleStore = <A, E, R>(
     }),
   )
 
-export const failCycleStore = (
+const failCycleStoreDataFirst = (
   operation: CycleStoreError['operation'],
   failure: CycleStoreError['failure'],
   message: string,
 ): Effect.Effect<never, CycleStoreError> => Effect.fail(cycleStoreError(operation, failure, message))
+
+export const failCycleStore = Pipeable.dual(3, failCycleStoreDataFirst)
 
 export const liftCycleDecision = <A>(
   operation: CycleStoreError['operation'],
@@ -181,7 +184,7 @@ export const liftCycleDecision = <A>(
     Effect.mapError(({ failure, message }) => cycleStoreError(operation, failure, message)),
   )
 
-export const exactlyOneCycle = (
+const exactlyOneCycleDataFirst = (
   operation: CycleStoreError['operation'],
   rows: readonly AutonomousCycle[],
 ): Effect.Effect<AutonomousCycle, CycleStoreError> => {
@@ -195,3 +198,5 @@ export const exactlyOneCycle = (
   }
   return Effect.succeed(cycle)
 }
+
+export const exactlyOneCycle = Pipeable.dual(2, exactlyOneCycleDataFirst)

--- a/services/bayn/src/db/cycle-store/mutations.ts
+++ b/services/bayn/src/db/cycle-store/mutations.ts
@@ -13,6 +13,7 @@ import {
 } from './model'
 import type { CycleQueries } from './queries'
 import { decodeMutationRows } from './rows'
+import { Pipeable } from '../../pipeable'
 
 export interface CycleMutationPrimitives {
   readonly readLocked: (
@@ -35,7 +36,10 @@ export interface CycleMutationPrimitives {
   readonly lockAuthoritySlot: (candidate: AutonomousCycle) => Effect.Effect<string, CycleStoreInternalError>
 }
 
-export const makeCycleMutationPrimitives = (sql: PgClient.PgClient, queries: CycleQueries): CycleMutationPrimitives => {
+const makeCycleMutationPrimitivesDataFirst = (
+  sql: PgClient.PgClient,
+  queries: CycleQueries,
+): CycleMutationPrimitives => {
   const readLocked: CycleMutationPrimitives['readLocked'] = (operation, cycleId) =>
     queries.selectCycle(cycleId, true).pipe(Effect.flatMap((rows) => exactlyOneCycle(operation, rows)))
 
@@ -154,3 +158,5 @@ export const makeCycleMutationPrimitives = (sql: PgClient.PgClient, queries: Cyc
 
   return { readLocked, requireApplied, blockCycle, insertCycle, lockAuthoritySlot }
 }
+
+export const makeCycleMutationPrimitives = Pipeable.dual(2, makeCycleMutationPrimitivesDataFirst)

--- a/services/bayn/src/db/evidence-recovery/artifacts.ts
+++ b/services/bayn/src/db/evidence-recovery/artifacts.ts
@@ -2,8 +2,9 @@ import { Result } from 'effect'
 
 import { evidenceRecoveryContract, type ArtifactIndex, type EvidenceRecoveryIssue, type StoredArtifact } from './model'
 import { recoveryFailure } from './shared'
+import { Pipeable } from '../../pipeable'
 
-export const requiredArtifact = (
+const requiredArtifactDataFirst = (
   artifacts: ArtifactIndex,
   name: string,
 ): Result.Result<StoredArtifact, EvidenceRecoveryIssue> => {
@@ -19,3 +20,5 @@ export const requiredArtifact = (
     },
   })
 }
+
+export const requiredArtifact = Pipeable.dual(2, requiredArtifactDataFirst)

--- a/services/bayn/src/db/evidence-recovery/complete.ts
+++ b/services/bayn/src/db/evidence-recovery/complete.ts
@@ -22,6 +22,7 @@ import {
   validateRecoveredSnapshotReference,
 } from './reconciliation-proof'
 import { canonicalHash, mismatch } from './shared'
+import { Pipeable } from '../../pipeable'
 
 const componentMismatch = (
   path: RecoveryPath,
@@ -387,7 +388,7 @@ const validateTerminalStatus = (
   return Result.void
 }
 
-export const completeEvidenceRecovery = (
+const completeEvidenceRecoveryDataFirst = (
   prepared: PreparedEvidenceRecovery,
   snapshot: StoredSnapshotRow,
 ): Result.Result<RecoveredEvaluationEvidence, EvidenceRecoveryIssue> =>
@@ -416,3 +417,5 @@ export const completeEvidenceRecovery = (
       },
     }
   })
+
+export const completeEvidenceRecovery = Pipeable.dual(2, completeEvidenceRecoveryDataFirst)

--- a/services/bayn/src/db/evidence-recovery/reconciliation-proof.ts
+++ b/services/bayn/src/db/evidence-recovery/reconciliation-proof.ts
@@ -10,8 +10,9 @@ import {
   type StoredSnapshotRow,
 } from './model'
 import { canonicalHash, mismatch } from './shared'
+import { Pipeable } from '../../pipeable'
 
-export const validateRecoveredSnapshotReference = (
+const validateRecoveredSnapshotReferenceDataFirst = (
   row: StoredSnapshotRow,
   inputManifest: InputManifest,
 ): Result.Result<void, EvidenceRecoveryIssue> =>
@@ -40,6 +41,8 @@ export const validateRecoveredSnapshotReference = (
       return yield* mismatch('snapshot', ['manifestHash'], observedManifestHash, expectedManifestHash)
     }
   })
+
+export const validateRecoveredSnapshotReference = Pipeable.dual(2, validateRecoveredSnapshotReferenceDataFirst)
 
 export const reconcileRecoveredEvidence = (
   prepared: PreparedEvidenceRecovery,

--- a/services/bayn/src/db/evidence-recovery/shared.ts
+++ b/services/bayn/src/db/evidence-recovery/shared.ts
@@ -7,17 +7,20 @@ import type {
   RecoveryMismatchStage,
   RecoveryPath,
 } from './model'
+import { Pipeable } from '../../pipeable'
 
 export const recoveryFailure = (issue: EvidenceRecoveryIssue): Result.Result<never, EvidenceRecoveryIssue> =>
   Result.fail(issue)
 
-export const mismatch = (
+const mismatchDataFirst = (
   stage: RecoveryMismatchStage,
   path: RecoveryPath,
   observed: unknown,
   expected: unknown,
 ): Result.Result<never, EvidenceRecoveryIssue> =>
   recoveryFailure({ _tag: 'RecoveryMismatch', stage, path, observed, expected })
+
+export const mismatch = Pipeable.dual(4, mismatchDataFirst)
 
 export const canonicalHash = (
   operation: RecoveryCanonicalizationOperation,

--- a/services/bayn/src/db/evidence-recovery/stored.ts
+++ b/services/bayn/src/db/evidence-recovery/stored.ts
@@ -8,6 +8,7 @@ import type {
   ValidatedStoredGraph,
 } from './model'
 import { canonicalHash, mismatch } from './shared'
+import { Pipeable } from '../../pipeable'
 
 const validateStoredReceipt = (
   runId: string,
@@ -158,7 +159,7 @@ const validateStoredStatuses = (
     }
   })
 
-export const validateStoredGraph = (
+const validateStoredGraphDataFirst = (
   runId: string,
   rows: StoredEvidenceRows,
 ): Result.Result<ValidatedStoredGraph, EvidenceRecoveryIssue> =>
@@ -172,6 +173,8 @@ export const validateStoredGraph = (
     yield* validateStoredStatuses(runId, rows, receipt)
     return { receipt, rows }
   })
+
+export const validateStoredGraph = Pipeable.dual(2, validateStoredGraphDataFirst)
 
 export const toStoredEvidence = (graph: ValidatedStoredGraph): StoredEvaluationEvidence => {
   const { receipt, rows } = graph
@@ -223,8 +226,10 @@ export const toStoredEvidence = (graph: ValidatedStoredGraph): StoredEvaluationE
   }
 }
 
-export const validateStoredEvidence = (
+const validateStoredEvidenceDataFirst = (
   runId: string,
   rows: StoredEvidenceRows,
 ): Result.Result<StoredEvaluationEvidence, EvidenceRecoveryIssue> =>
   Result.andThen(validateStoredGraph(runId, rows), toStoredEvidence)
+
+export const validateStoredEvidence = Pipeable.dual(2, validateStoredEvidenceDataFirst)

--- a/services/bayn/src/db/evidence-store/errors.ts
+++ b/services/bayn/src/db/evidence-store/errors.ts
@@ -11,6 +11,7 @@ import {
   type QualificationDecisionFailure,
   type StoredQualificationFailure,
 } from './qualification'
+import { Pipeable } from '../../pipeable'
 
 export { DatabaseError, type DatabaseFailure, type PersistenceFailure } from './error-contract'
 
@@ -73,7 +74,7 @@ export const databaseError = (
     cause,
   })
 
-export const classifyDatabaseError = (operation: string, cause: unknown): DatabaseError => {
+const classifyDatabaseErrorDataFirst = (operation: string, cause: unknown): DatabaseError => {
   if (cause instanceof DatabaseError) return cause
   if (Schema.isSchemaError(cause)) return databaseError('decode', operation, 'database row decoding failed', cause)
   if (isSqlError(cause)) {
@@ -89,16 +90,20 @@ export const classifyDatabaseError = (operation: string, cause: unknown): Databa
   return databaseError('invariant', operation, 'unexpected database result', cause)
 }
 
+export const classifyDatabaseError = Pipeable.dual(2, classifyDatabaseErrorDataFirst)
+
 export const runDatabase = <A, E, R>(
   operation: string,
   effect: Effect.Effect<A, E, R>,
 ): Effect.Effect<A, DatabaseError, R> =>
   effect.pipe(Effect.mapError((cause) => classifyDatabaseError(operation, cause)))
 
-export const ensure = (condition: boolean, operation: string, message: string): Effect.Effect<void, DatabaseError> =>
+const ensureDataFirst = (condition: boolean, operation: string, message: string): Effect.Effect<void, DatabaseError> =>
   condition ? Effect.void : Effect.fail(databaseError('invariant', operation, message))
 
-export const persistencePlanDatabaseError = (operation: string, failure: PersistencePlanFailure): DatabaseError =>
+export const ensure = Pipeable.dual(3, ensureDataFirst)
+
+const persistencePlanDatabaseErrorDataFirst = (operation: string, failure: PersistencePlanFailure): DatabaseError =>
   databaseError(
     'invariant',
     operation,
@@ -106,20 +111,28 @@ export const persistencePlanDatabaseError = (operation: string, failure: Persist
     failure._tag === 'SimulationReconciliationFailed' ? failure.issues : failure,
   )
 
-export const qualificationDecisionDatabaseError = (
+export const persistencePlanDatabaseError = Pipeable.dual(2, persistencePlanDatabaseErrorDataFirst)
+
+const qualificationDecisionDatabaseErrorDataFirst = (
   operation: string,
   failure: QualificationDecisionFailure,
 ): DatabaseError => databaseError('invariant', operation, renderQualificationDecisionFailure(failure), failure)
 
-export const storedQualificationDatabaseError = (
+export const qualificationDecisionDatabaseError = Pipeable.dual(2, qualificationDecisionDatabaseErrorDataFirst)
+
+const storedQualificationDatabaseErrorDataFirst = (
   operation: string,
   failure: StoredQualificationFailure,
 ): DatabaseError => databaseError('invariant', operation, renderStoredQualificationFailure(failure), failure)
 
-export const evidenceRecoveryDatabaseError = (operation: string, issue: EvidenceRecoveryIssue): DatabaseError =>
+export const storedQualificationDatabaseError = Pipeable.dual(2, storedQualificationDatabaseErrorDataFirst)
+
+const evidenceRecoveryDatabaseErrorDataFirst = (operation: string, issue: EvidenceRecoveryIssue): DatabaseError =>
   databaseError(
     issue._tag === 'DecodeFailure' ? 'decode' : 'invariant',
     operation,
     renderEvidenceRecoveryIssue(issue),
     issue._tag === 'SimulationFailure' ? issue.issues : issue,
   )
+
+export const evidenceRecoveryDatabaseError = Pipeable.dual(2, evidenceRecoveryDatabaseErrorDataFirst)

--- a/services/bayn/src/db/evidence-store/persist-program.ts
+++ b/services/bayn/src/db/evidence-store/persist-program.ts
@@ -15,10 +15,11 @@ import { makePersistencePlan } from './persistence-plan'
 import { decodeQualificationRows, validateQualificationLockMatch } from './qualification'
 import type { QualificationStatements } from './qualification-statements'
 import type { EvidenceReferencePrograms } from './reference-programs'
+import { Pipeable } from '../../pipeable'
 
 const encodeJson = Schema.encodeSync(Schema.fromJsonString(Schema.Json))
 
-export const makeEvidencePersistenceProgram = (
+const makeEvidencePersistenceProgramDataFirst = (
   sql: PgClient.PgClient,
   statements: EvidenceStatements,
   qualificationStatements: QualificationStatements,
@@ -208,3 +209,5 @@ export const makeEvidencePersistenceProgram = (
       }),
     )
 }
+
+export const makeEvidencePersistenceProgram = Pipeable.dual(4, makeEvidencePersistenceProgramDataFirst)

--- a/services/bayn/src/db/evidence-store/persistence-evaluation.ts
+++ b/services/bayn/src/db/evidence-store/persistence-evaluation.ts
@@ -6,6 +6,7 @@ import type { DecisionEvent } from '../../types'
 import type { PersistEvaluationInput } from './model'
 import { persistenceCanonicalHash, persistenceMismatch } from './persistence-failures'
 import type { PersistencePlanFailure, ValidatedPersistenceEvaluation } from './persistence-model'
+import { Pipeable } from '../../pipeable'
 
 const makeProtocolHash = (input: PersistEvaluationInput): Result.Result<string, PersistencePlanFailure> =>
   Result.mapError(
@@ -42,7 +43,7 @@ const makeExpectedRunId = (input: PersistEvaluationInput): Result.Result<string,
     (identity) => identity.runId,
   )
 
-export const validatePersistenceEvaluation = (
+const validatePersistenceEvaluationDataFirst = (
   input: PersistEvaluationInput,
   inputManifestSchemaVersion: string,
 ): Result.Result<ValidatedPersistenceEvaluation, PersistencePlanFailure> =>
@@ -281,3 +282,5 @@ export const validatePersistenceEvaluation = (
 
     return { protocolHash, snapshotId }
   })
+
+export const validatePersistenceEvaluation = Pipeable.dual(2, validatePersistenceEvaluationDataFirst)

--- a/services/bayn/src/db/evidence-store/persistence-failures.ts
+++ b/services/bayn/src/db/evidence-store/persistence-failures.ts
@@ -11,14 +11,17 @@ import {
   type PersistencePlanFailure,
   type PersistencePlanInvariant,
 } from './persistence-model'
+import { Pipeable } from '../../pipeable'
 
-export const persistenceMismatch = (
+const persistenceMismatchDataFirst = (
   invariant: PersistencePlanInvariant,
   path: PersistencePath,
   observed: unknown,
   expected: unknown,
 ): Result.Result<never, PersistencePlanFailure> =>
   Result.fail({ _tag: 'PersistenceMismatch', invariant, path, observed, expected })
+
+export const persistenceMismatch = Pipeable.dual(4, persistenceMismatchDataFirst)
 
 export const persistenceCanonicalHash = (
   operation: PersistenceCanonicalizationOperation,

--- a/services/bayn/src/db/evidence-store/persistence-receipt.ts
+++ b/services/bayn/src/db/evidence-store/persistence-receipt.ts
@@ -10,8 +10,9 @@ import type {
   StoredPersistenceReferences,
   StoredProtocolReference,
 } from './persistence-model'
+import { Pipeable } from '../../pipeable'
 
-export const validateProtocolReference = (
+const validateProtocolReferenceDataFirst = (
   input: {
     readonly protocolHash: string
     readonly provenance: RuntimeProvenance
@@ -57,7 +58,9 @@ export const validateProtocolReference = (
     }
   })
 
-export const validatePersistenceReceipt = (
+export const validateProtocolReference = Pipeable.dual(2, validateProtocolReferenceDataFirst)
+
+const validatePersistenceReceiptDataFirst = (
   plan: PersistencePlan,
   references: StoredPersistenceReferences,
   deduplicated: boolean,
@@ -251,3 +254,5 @@ export const validatePersistenceReceipt = (
       gateCount: row.gate_count,
     }
   })
+
+export const validatePersistenceReceipt = Pipeable.dual(3, validatePersistenceReceiptDataFirst)

--- a/services/bayn/src/db/evidence-store/qualification-program.ts
+++ b/services/bayn/src/db/evidence-store/qualification-program.ts
@@ -18,6 +18,7 @@ import {
 } from './qualification'
 import type { QualificationStatements } from './qualification-statements'
 import type { EvidenceReferencePrograms } from './reference-programs'
+import { Pipeable } from '../../pipeable'
 
 export interface QualificationPrograms {
   readonly listPriorTrials: EvidenceStoreService['listPriorTrials']
@@ -25,7 +26,7 @@ export interface QualificationPrograms {
   readonly readQualification: EvidenceStoreService['readQualification']
 }
 
-export const makeQualificationPrograms = (
+const makeQualificationProgramsDataFirst = (
   sql: PgClient.PgClient,
   statements: QualificationStatements,
   references: EvidenceReferencePrograms,
@@ -138,3 +139,5 @@ export const makeQualificationPrograms = (
 
   return { listPriorTrials, openQualification, readQualification }
 }
+
+export const makeQualificationPrograms = Pipeable.dual(3, makeQualificationProgramsDataFirst)

--- a/services/bayn/src/db/evidence-store/qualification.ts
+++ b/services/bayn/src/db/evidence-store/qualification.ts
@@ -9,6 +9,7 @@ import { canonicalHashV1Result, renderCanonicalJsonFailure, type CanonicalJsonFa
 import { QualificationLockSchema, type QualificationLock, type QualificationResult } from '../../qualification'
 import { strictParseOptions } from '../../schemas'
 import type { OpenQualificationInput, QualificationRecord } from './model'
+import { Pipeable } from '../../pipeable'
 
 type QualificationDecisionStage = 'lineage' | 'lock-match' | 'open-input' | 'stored-record'
 type QualificationPath = readonly [string, ...(number | string)[]]
@@ -264,7 +265,7 @@ export const decodeQualificationRows = (
   return Result.map(decodeQualificationRecord(row), Option.some)
 }
 
-export const validateQualificationLockMatch = (
+const validateQualificationLockMatchDataFirst = (
   observed: QualificationLock,
   expected: QualificationLock,
 ): Result.Result<void, QualificationDecisionFailure> =>
@@ -279,7 +280,9 @@ export const validateQualificationLockMatch = (
     }
   })
 
-export const validateQualificationLineage = (
+export const validateQualificationLockMatch = Pipeable.dual(2, validateQualificationLockMatchDataFirst)
+
+const validateQualificationLineageDataFirst = (
   observed: readonly string[],
   expected: readonly string[],
 ): Result.Result<void, QualificationDecisionFailure> => {
@@ -293,6 +296,8 @@ export const validateQualificationLineage = (
   }
   return Result.void
 }
+
+export const validateQualificationLineage = Pipeable.dual(2, validateQualificationLineageDataFirst)
 
 const renderFact = (value: unknown): string => {
   if (value === null) return 'null'

--- a/services/bayn/src/db/evidence-store/read-program.ts
+++ b/services/bayn/src/db/evidence-store/read-program.ts
@@ -18,6 +18,7 @@ import {
   type EvidenceReadInputFailure,
 } from './read-decisions'
 import type { EvidenceReferencePrograms } from './reference-programs'
+import { Pipeable } from '../../pipeable'
 
 const readInputDatabaseError = (operation: string, cause: EvidenceReadInputFailure) =>
   databaseError(
@@ -33,7 +34,7 @@ export interface EvidenceReadPrograms {
   readonly recover: EvidenceStoreService['recover']
 }
 
-export const makeEvidenceReadPrograms = (
+const makeEvidenceReadProgramsDataFirst = (
   statements: EvidenceStatements,
   references: EvidenceReferencePrograms,
 ): EvidenceReadPrograms => {
@@ -115,3 +116,5 @@ export const makeEvidenceReadPrograms = (
 
   return { read, readArtifactItems, recover }
 }
+
+export const makeEvidenceReadPrograms = Pipeable.dual(2, makeEvidenceReadProgramsDataFirst)

--- a/services/bayn/src/db/evidence-store/reference-programs.ts
+++ b/services/bayn/src/db/evidence-store/reference-programs.ts
@@ -14,6 +14,7 @@ import { databaseError, persistencePlanDatabaseError, type DatabaseError } from 
 import type { EvidenceStatements } from './evidence-statements'
 import type { PersistencePlan } from './persistence-model'
 import { validatePersistenceReceipt, validateProtocolReference } from './persistence-receipt'
+import { Pipeable } from '../../pipeable'
 
 export interface EvidenceReferencePrograms {
   readonly ensureProtocolReference: (input: {
@@ -33,7 +34,7 @@ export interface EvidenceReferencePrograms {
   ) => Effect.Effect<Option.Option<StoredEvidenceRows>, Cause.NoSuchElementError | Schema.SchemaError | SqlError>
 }
 
-export const makeEvidenceReferencePrograms = (
+const makeEvidenceReferenceProgramsDataFirst = (
   sql: PgClient.PgClient,
   statements: EvidenceStatements,
 ): EvidenceReferencePrograms => {
@@ -99,3 +100,5 @@ export const makeEvidenceReferencePrograms = (
 
   return { ensureProtocolReference, ensureSnapshotReference, readReceipt, loadStoredRows }
 }
+
+export const makeEvidenceReferencePrograms = Pipeable.dual(2, makeEvidenceReferenceProgramsDataFirst)

--- a/services/bayn/src/db/execution-store/accounting.ts
+++ b/services/bayn/src/db/execution-store/accounting.ts
@@ -31,12 +31,13 @@ import {
   decodeTransactionRows,
   decodeUnresolvedPredecessor,
 } from './rows'
+import { Pipeable } from '../../pipeable'
 
 export interface AccountingInterpreter {
   readonly account: (input: FillEventInput) => Effect.Effect<AccountingReceipt, ExecutionStoreError>
 }
 
-export const makeAccountingInterpreter = (
+const makeAccountingInterpreterDataFirst = (
   sql: PgClient.PgClient,
   journal: JournalService,
   config: ExecutionStoreRuntimeConfig,
@@ -277,3 +278,5 @@ export const makeAccountingInterpreter = (
 
   return { account }
 }
+
+export const makeAccountingInterpreter = Pipeable.dual(4, makeAccountingInterpreterDataFirst)

--- a/services/bayn/src/db/execution-store/capital-grant.ts
+++ b/services/bayn/src/db/execution-store/capital-grant.ts
@@ -52,6 +52,7 @@ import {
   type ActivationEvidenceRow,
   type ActivationReconciliationRow,
 } from './rows'
+import { Pipeable } from '../../pipeable'
 
 export interface CapitalGrantInterpreter {
   readonly prepareCapitalGrant: (
@@ -69,7 +70,7 @@ interface ResearchPaperRuntimeBinding {
   readonly configuredSourceGenerationHash: string
 }
 
-export const makeCapitalGrantInterpreter = (
+const makeCapitalGrantInterpreterDataFirst = (
   sql: PgClient.PgClient,
   authority: AuthorityPostgres,
   config: ExecutionStoreRuntimeConfig,
@@ -618,3 +619,5 @@ export const makeCapitalGrantInterpreter = (
 
   return { prepareCapitalGrant, activateCapitalGrant, activateResearchCapitalGrant }
 }
+
+export const makeCapitalGrantInterpreter = Pipeable.dual(4, makeCapitalGrantInterpreterDataFirst)

--- a/services/bayn/src/db/execution-store/decisions.ts
+++ b/services/bayn/src/db/execution-store/decisions.ts
@@ -8,6 +8,7 @@ import type { AccountingReceipt, Valuation } from '../../execution/contracts'
 import type { EventReceipt, PositionSnapshotReceipt } from './contract'
 import type { AccountRow, EventIdRow, EventRow, PositionRow, PositionSnapshotRow } from './rows'
 import { EventKind } from './rows'
+import { Pipeable } from '../../pipeable'
 
 export interface ExecutionStoreDecisionFailure {
   readonly failure: 'conflict' | 'invariant'
@@ -152,7 +153,7 @@ export type BrokerEventAppendDecision =
       readonly eventKind: typeof EventKind.Type
     }
 
-export const decideBrokerEventAppend = (
+const decideBrokerEventAppendDataFirst = (
   input: BrokerEventInput,
   existing: readonly EventRow[],
 ): Result.Result<BrokerEventAppendDecision, ExecutionStoreDecisionFailure> => {
@@ -174,6 +175,8 @@ export const decideBrokerEventAppend = (
     },
   })
 }
+
+export const decideBrokerEventAppend = Pipeable.dual(2, decideBrokerEventAppendDataFirst)
 
 export const decideNextSourceSequence = (lastSequence: string): Result.Result<string, ExecutionStoreDecisionFailure> =>
   Result.map(
@@ -248,7 +251,7 @@ export const decidePositionSnapshotInsert = (
     ? fail('invariant', 'position snapshot insert returned multiple rows')
     : Result.succeed(insertedSnapshotIds.length === 0)
 
-export const validateStoredPositionSnapshot = (
+const validateStoredPositionSnapshotDataFirst = (
   input: PositionSnapshotInput,
   plan: PositionSnapshotPlan,
   snapshots: readonly PositionSnapshotRow[],
@@ -276,7 +279,9 @@ export const validateStoredPositionSnapshot = (
     return undefined
   })
 
-export const finishPositionSnapshot = (
+export const validateStoredPositionSnapshot = Pipeable.dual(3, validateStoredPositionSnapshotDataFirst)
+
+const finishPositionSnapshotDataFirst = (
   plan: PositionSnapshotPlan,
   storedEvents: readonly EventIdRow[],
   deduplicated: boolean,
@@ -290,6 +295,8 @@ export const finishPositionSnapshot = (
   }
   return Result.succeed({ snapshotId: plan.snapshotId, eventIds: plan.eventIds, deduplicated })
 }
+
+export const finishPositionSnapshot = Pipeable.dual(3, finishPositionSnapshotDataFirst)
 
 export const decidePredecessorCoverage = (unresolved: boolean): Result.Result<void, ExecutionStoreDecisionFailure> =>
   unresolved ? fail('conflict', 'an earlier fill has not been posted to TigerBeetle') : Result.succeed(undefined)
@@ -306,7 +313,7 @@ export const decidePreparedTransaction = (
   return Result.succeed(transactions[0])
 }
 
-export const decidePreparedAccountingReplay = (
+const decidePreparedAccountingReplayDataFirst = (
   stored: AccountingTransaction | undefined,
   expected: PreparedAccounting,
 ): Result.Result<PreparedAccounting, ExecutionStoreDecisionFailure> =>
@@ -328,6 +335,8 @@ export const decidePreparedAccountingReplay = (
           : yield* fail('conflict', 'stored accounting plan differs from deterministic replay')
       })
 
+export const decidePreparedAccountingReplay = Pipeable.dual(2, decidePreparedAccountingReplayDataFirst)
+
 export const decideAccountingReceipt = (
   receipts: readonly AccountingReceipt[],
 ): Result.Result<AccountingReceipt | undefined, ExecutionStoreDecisionFailure> => {
@@ -337,7 +346,7 @@ export const decideAccountingReceipt = (
 
 export type AccountingReceiptPlan = Omit<AccountingReceipt, 'recordedAt'>
 
-export const planAccountingReceipt = (
+const planAccountingReceiptDataFirst = (
   prepared: PreparedAccounting,
   tigerBeetleClusterId: string,
   tigerBeetleLedger: number,
@@ -375,6 +384,8 @@ export const planAccountingReceipt = (
     return { ...stable, receiptId, contentHash }
   })
 
+export const planAccountingReceipt = Pipeable.dual(3, planAccountingReceiptDataFirst)
+
 export const stableAccountingReceipt = (receipt: AccountingReceipt) => ({
   schemaVersion: receipt.schemaVersion,
   receiptId: receipt.receiptId,
@@ -389,7 +400,7 @@ export const stableAccountingReceipt = (receipt: AccountingReceipt) => ({
   contentHash: receipt.contentHash,
 })
 
-export const decideAccountingReceiptReplay = (
+const decideAccountingReceiptReplayDataFirst = (
   stored: AccountingReceipt | undefined,
   candidate: AccountingReceipt,
 ): Result.Result<AccountingReceipt, ExecutionStoreDecisionFailure> => {
@@ -411,7 +422,9 @@ export const decideAccountingReceiptReplay = (
   })
 }
 
-export const planValuation = (
+export const decideAccountingReceiptReplay = Pipeable.dual(2, decideAccountingReceiptReplayDataFirst)
+
+const planValuationDataFirst = (
   input: ValuationInput,
   accountSnapshot: AccountRow,
   positionSnapshot: PositionSnapshotRow,
@@ -501,6 +514,8 @@ export const planValuation = (
     }
   })
 
+export const planValuation = Pipeable.dual(5, planValuationDataFirst)
+
 export const requireValuationPositionSnapshot = (
   positionSnapshots: readonly PositionSnapshotRow[],
 ): Result.Result<PositionSnapshotRow, ExecutionStoreDecisionFailure> => {
@@ -510,7 +525,7 @@ export const requireValuationPositionSnapshot = (
     : fail('conflict', 'valuation position snapshot does not exist')
 }
 
-export const decideStoredValuation = (
+const decideStoredValuationDataFirst = (
   storedValuations: readonly Valuation[],
   candidate: Valuation,
 ): Result.Result<Valuation, ExecutionStoreDecisionFailure> => {
@@ -529,3 +544,5 @@ export const decideStoredValuation = (
       : yield* fail('conflict', 'stored valuation differs from deterministic replay')
   })
 }
+
+export const decideStoredValuation = Pipeable.dual(2, decideStoredValuationDataFirst)

--- a/services/bayn/src/db/execution-store/errors.ts
+++ b/services/bayn/src/db/execution-store/errors.ts
@@ -5,6 +5,7 @@ import { capitalGrantFailureDetails, type CapitalGrantAlgebraFailure } from '../
 import { ReconciliationStoreError } from '../reconciliation'
 import { ExecutionStoreError } from './contract'
 import type { ExecutionStoreDecisionFailure } from './decisions'
+import { Pipeable } from '../../pipeable'
 
 const messageOf = (cause: unknown): string => (cause instanceof Error ? cause.message : String(cause))
 
@@ -21,11 +22,13 @@ export const executionStoreError = (
     cause,
   })
 
-export const failExecutionStore = (
+const failExecutionStoreDataFirst = (
   operation: ExecutionStoreError['operation'],
   failure: ExecutionStoreError['failure'],
   message: string,
 ): Effect.Effect<never, ExecutionStoreError> => Effect.fail(executionStoreError(operation, failure, message))
+
+export const failExecutionStore = Pipeable.dual(3, failExecutionStoreDataFirst)
 
 export const runExecutionOperation = <A, E, R>(
   operation: ExecutionStoreError['operation'],

--- a/services/bayn/src/db/execution-store/observe-authority.ts
+++ b/services/bayn/src/db/execution-store/observe-authority.ts
@@ -36,6 +36,7 @@ import {
   decodeEnsureAuthorityGenerationInput,
   type AuthorityGenerationRow,
 } from './rows'
+import { Pipeable } from '../../pipeable'
 
 export const LEGACY_AUTONOMOUS_OBSERVE_GENERATION_HASH =
   'd290539ec85334d8ce267f98919c139cb382068101042d69b5433832136dc063'
@@ -62,7 +63,7 @@ const legacyAutonomousObserveCompatible = (history: AuthorityGenerationRow, conf
   configured.provider === BrokerProvider.Alpaca &&
   configured.environment === BrokerEnvironment.Sandbox
 
-export const validateObserveGenerationBrokerIdentityReplay = (
+const validateObserveGenerationBrokerIdentityReplayDataFirst = (
   history: AuthorityGenerationRow,
   configured: BrokerIdentity | undefined,
 ): Result.Result<void, ObserveGenerationBrokerIdentityFailure> => {
@@ -113,6 +114,11 @@ export const validateObserveGenerationBrokerIdentityReplay = (
       })
 }
 
+export const validateObserveGenerationBrokerIdentityReplay = Pipeable.dual(
+  2,
+  validateObserveGenerationBrokerIdentityReplayDataFirst,
+)
+
 export interface ObserveAuthorityInterpreter {
   readonly ensureAuthorityGeneration: (
     input: EnsureAuthorityGenerationInput,
@@ -126,7 +132,7 @@ export interface ObserveAuthorityInterpreter {
   ) => Effect.Effect<ResearchCapitalGrantGeneration | undefined, ExecutionStoreError>
 }
 
-export const makeObserveAuthorityInterpreter = (
+const makeObserveAuthorityInterpreterDataFirst = (
   sql: PgClient.PgClient,
   authority: AuthorityPostgres,
   brokerIdentity: BrokerIdentity | undefined,
@@ -477,3 +483,5 @@ export const makeObserveAuthorityInterpreter = (
 
   return { ensureAuthorityGeneration, readAuthorityState, readAuthorityGeneration, readResearchAuthorityGeneration }
 }
+
+export const makeObserveAuthorityInterpreter = Pipeable.dual(3, makeObserveAuthorityInterpreterDataFirst)

--- a/services/bayn/src/db/live-capital-grant.ts
+++ b/services/bayn/src/db/live-capital-grant.ts
@@ -18,6 +18,7 @@ import {
 } from '../execution/authority'
 import { Authority } from '../execution/contracts'
 import { NonNegativeIntegerSchema, Sha256Schema, StrictNonEmptyStringSchema, strictParseOptions } from '../schemas'
+import { Pipeable } from '../pipeable'
 
 export class LiveCapitalGrantStoreError extends Data.TaggedError('LiveCapitalGrantStoreError')<{
   readonly operation: 'read' | 'record' | 'revoke' | 'lock-submit'
@@ -113,7 +114,7 @@ export interface LiveGrantGenerationBindingFailure {
   readonly observed: string | null
 }
 
-export const validateLiveGrantGenerationBinding = (
+const validateLiveGrantGenerationBindingDataFirst = (
   grant: Pick<LiveCapitalGrant, 'strategy'>,
   generation: LiveGrantGenerationBindingFacts,
 ): Result.Result<void, LiveGrantGenerationBindingFailure> => {
@@ -150,6 +151,8 @@ export const validateLiveGrantGenerationBinding = (
         observed: mismatch.observed,
       })
 }
+
+export const validateLiveGrantGenerationBinding = Pipeable.dual(2, validateLiveGrantGenerationBindingDataFirst)
 
 const sameRevocation = (left: LiveCapitalGrantRevocation | undefined, right: LiveCapitalGrantRevocation): boolean =>
   left?.schemaVersion === right.schemaVersion &&

--- a/services/bayn/src/db/reconciliation-algebra.ts
+++ b/services/bayn/src/db/reconciliation-algebra.ts
@@ -45,6 +45,7 @@ import {
   type ReconciliationRiskContext,
 } from '../reconciliation'
 import { strictParseOptions, type IsoDate } from '../schemas'
+import { Pipeable } from '../pipeable'
 
 export interface IntentProjectionRow {
   readonly intent_id: string
@@ -406,7 +407,7 @@ const accountingHash = (value: unknown): Result.Result<string, ReconciliationAlg
     }),
   )
 
-export const verifyAccountingReceipts = (
+const verifyAccountingReceiptsDataFirst = (
   transactions: readonly AccountingTransaction[],
   receipts: readonly AccountingReceipt[],
   config: AccountingLedgerIdentity,
@@ -448,6 +449,8 @@ export const verifyAccountingReceipts = (
     }
     return { exactReceipts, plans: planned.map(({ plan }) => plan) }
   })
+
+export const verifyAccountingReceipts = Pipeable.dual(3, verifyAccountingReceiptsDataFirst)
 
 export const compareOpeningCash = (input: {
   readonly accountId: string
@@ -520,7 +523,7 @@ export const compareOpeningCash = (input: {
     return { accountingHash: accountingHashValue, comparison }
   })
 
-export const ageDiscrepancies = (
+const ageDiscrepanciesDataFirst = (
   comparison: ReconciliationComparison,
   previous: readonly Discrepancy[],
   reconciledAt: string,
@@ -559,6 +562,8 @@ export const ageDiscrepancies = (
     status: discrepancies.length === 0 ? ReconciliationStatus.Exact : ReconciliationStatus.Discrepancy,
   })
 }
+
+export const ageDiscrepancies = Pipeable.dual(3, ageDiscrepanciesDataFirst)
 
 export const makeReconciliationIdentity = (input: {
   readonly accountId: string
@@ -617,7 +622,7 @@ export const decideReconciliation = (input: {
     return yield* makeReconciliationIdentity({ ...input, aged })
   })
 
-export const validateReconciliationReadback = (
+const validateReconciliationReadbackDataFirst = (
   reconciliation: Reconciliation,
   storedContentHash: string,
 ): Result.Result<void, ReconciliationAlgebraFailure> =>
@@ -629,6 +634,8 @@ export const validateReconciliationReadback = (
         expectedContentHash: reconciliation.contentHash,
         storedContentHash,
       })
+
+export const validateReconciliationReadback = Pipeable.dual(2, validateReconciliationReadbackDataFirst)
 
 const timestamp = (
   field: 'authority_observed_at' | 'authority_updated_at',
@@ -646,7 +653,7 @@ const riskMaterial = (row: RiskContextRow, unknownMutationCount: number) => ({
   peakEquityMicros: row.peak_equity_micros,
 })
 
-export const riskContextFromRow = (
+const riskContextFromRowDataFirst = (
   row: RiskContextRow,
   unknownMutationCount: number,
 ): Result.Result<ReconciliationRiskContext, ReconciliationAlgebraFailure> =>
@@ -736,6 +743,8 @@ export const riskContextFromRow = (
       authorityObservedAt,
     }
   })
+
+export const riskContextFromRow = Pipeable.dual(2, riskContextFromRowDataFirst)
 
 interface ReconciliationAlgebraFailureDetails {
   readonly failure: 'decode' | 'invariant'

--- a/services/bayn/src/db/reconciliation.ts
+++ b/services/bayn/src/db/reconciliation.ts
@@ -55,6 +55,7 @@ import {
   verifyAccountingReceipts,
   type ReconciliationAlgebraFailure,
 } from './reconciliation-algebra'
+import { Pipeable } from '../pipeable'
 
 export interface IntentBinding {
   readonly intentId: string
@@ -211,7 +212,7 @@ const fromDecision = <A>(
     }),
   )
 
-export const restrictAuthority = (
+const restrictAuthorityDataFirst = (
   sql: PgClient.PgClient,
   reason: string,
   updatedAt: string,
@@ -232,7 +233,9 @@ export const restrictAuthority = (
     `.pipe(Effect.asVoid),
   )
 
-export const makeReconciliation = (
+export const restrictAuthority = Pipeable.dual(3, restrictAuthorityDataFirst)
+
+const makeReconciliationDataFirst = (
   sql: PgClient.PgClient,
   journal: JournalService,
   config: Pick<RuntimeConfig, 'tigerBeetle'>,
@@ -560,3 +563,5 @@ export const makeReconciliation = (
 
   return { bindings, reconcile }
 }
+
+export const makeReconciliation = Pipeable.dual(3, makeReconciliationDataFirst)

--- a/services/bayn/src/db/snapshot-reference.ts
+++ b/services/bayn/src/db/snapshot-reference.ts
@@ -5,6 +5,7 @@ import type { SqlError } from 'effect/unstable/sql/SqlError'
 import { canonicalHashV1Result, renderCanonicalJsonFailure, type CanonicalJsonFailure } from '../hash'
 import { strictParseOptions } from '../schemas'
 import type { InputManifest } from '../types'
+import { Pipeable } from '../pipeable'
 
 const PositiveInteger = Schema.Int.check(Schema.isGreaterThan(0))
 const SnapshotReferenceRowSchema = Schema.Struct({
@@ -81,7 +82,7 @@ const manifestHash = (
     }),
   )
 
-export const validateSnapshotReference = (
+const validateSnapshotReferenceDataFirst = (
   inputManifest: InputManifest,
   rows: readonly SnapshotReferenceRow[],
 ): Result.Result<void, SnapshotReferenceIssue> =>
@@ -128,6 +129,8 @@ export const validateSnapshotReference = (
     }
   })
 
+export const validateSnapshotReference = Pipeable.dual(2, validateSnapshotReferenceDataFirst)
+
 const renderFact = (value: unknown): string => {
   if (value === null) return 'null'
   switch (typeof value) {
@@ -159,7 +162,7 @@ export const renderSnapshotReferenceIssue = (issue: SnapshotReferenceIssue): str
   }
 }
 
-export const ensureSnapshotReference = (
+const ensureSnapshotReferenceDataFirst = (
   sql: PgClient.PgClient,
   inputManifest: InputManifest,
 ): Effect.Effect<void, SnapshotReferenceIssue | SqlError | Schema.SchemaError> =>
@@ -218,3 +221,5 @@ export const ensureSnapshotReference = (
     const rows = yield* Effect.fromResult(decodeSnapshotReferenceRows(rawRows))
     yield* Effect.fromResult(validateSnapshotReference(inputManifest, rows))
   })
+
+export const ensureSnapshotReference = Pipeable.dual(2, ensureSnapshotReferenceDataFirst)

--- a/services/bayn/src/execution-candidate-discovery/broker-observation-validation.ts
+++ b/services/bayn/src/execution-candidate-discovery/broker-observation-validation.ts
@@ -26,6 +26,7 @@ import {
   type ValidatedPaperCandidateSnapshot,
 } from './model'
 import { requireCondition, requireValue, type ExecutionCandidateDiscoveryError } from './failure'
+import { Pipeable } from '../pipeable'
 
 const assetEligibilityRules = [
   [PaperCandidateIneligibility.AssetClass, (asset: AssetObservation) => asset.assetClass !== AssetClass.UsEquity],
@@ -86,7 +87,7 @@ export const normalizedReadEvidence = (evidence: ReadEvidence): typeof ReadEvide
   }
 }
 
-export const validateAccountObservation = (
+const validateAccountObservationDataFirst = (
   identity: ExecutionCandidateDiscoveryIdentity,
   account: ReadResult<Account>,
 ): Result.Result<ValidatedAccount, ExecutionCandidateDiscoveryError> =>
@@ -103,7 +104,9 @@ export const validateAccountObservation = (
     Result.map(() => ({ [ValidatedAccountTypeId]: true as const, read: account })),
   )
 
-export const validateAccountConfiguration = (
+export const validateAccountObservation = Pipeable.dual(2, validateAccountObservationDataFirst)
+
+const validateAccountConfigurationDataFirst = (
   account: ValidatedAccount,
   configuration: ReadResult<AccountConfigurationObservation>,
 ): Result.Result<ValidatedAccountConfiguration, ExecutionCandidateDiscoveryError> =>
@@ -125,6 +128,8 @@ export const validateAccountConfiguration = (
       read: configuration,
     })),
   )
+
+export const validateAccountConfiguration = Pipeable.dual(2, validateAccountConfigurationDataFirst)
 
 const validateAssetObservation = (
   symbol: string,
@@ -161,7 +166,7 @@ const validateAssetObservation = (
     ),
   )
 
-export const validateAssetObservations = (
+const validateAssetObservationsDataFirst = (
   snapshot: ExecutionCandidateDiscoverySnapshot,
   configuration: ValidatedAccountConfiguration,
   assets: ReadonlyArray<ReadResult<AssetObservation>>,
@@ -184,7 +189,9 @@ export const validateAssetObservations = (
     Result.map((reads) => ({ [ValidatedAssetsTypeId]: true as const, reads })),
   )
 
-export const assembleValidatedObservations = (
+export const validateAssetObservations = Pipeable.dual(3, validateAssetObservationsDataFirst)
+
+const assembleValidatedObservationsDataFirst = (
   validatedSnapshot: ValidatedPaperCandidateSnapshot,
   account: ValidatedAccount,
   accountConfiguration: ValidatedAccountConfiguration,
@@ -242,7 +249,9 @@ export const assembleValidatedObservations = (
   )
 }
 
-export const validateExecutionCandidateDiscoveryObservations = (
+export const assembleValidatedObservations = Pipeable.dual(5, assembleValidatedObservationsDataFirst)
+
+const validateExecutionCandidateDiscoveryObservationsDataFirst = (
   validatedSnapshot: ValidatedPaperCandidateSnapshot,
   input: {
     readonly account: ReadResult<Account>
@@ -264,3 +273,8 @@ export const validateExecutionCandidateDiscoveryObservations = (
       assembleValidatedObservations(validatedSnapshot, account, accountConfiguration, assets, input.capturedAtMs),
     ),
   )
+
+export const validateExecutionCandidateDiscoveryObservations = Pipeable.dual(
+  2,
+  validateExecutionCandidateDiscoveryObservationsDataFirst,
+)

--- a/services/bayn/src/execution-candidate-discovery/failure.ts
+++ b/services/bayn/src/execution-candidate-discovery/failure.ts
@@ -2,6 +2,7 @@ import { Result } from 'effect'
 
 import { canonicalHashV1Result, type CanonicalHashFailure } from '../hash'
 import { Authority, RiskOutcome } from '../execution/contracts'
+import { Pipeable } from '../pipeable'
 
 export type ExecutionCandidateDiscoveryError =
   | { readonly _tag: 'IdentityDecodeFailed'; readonly failure: 'invalid-input'; readonly cause: unknown }
@@ -489,10 +490,12 @@ export const renderExecutionCandidateDiscoveryError = (error: ExecutionCandidate
   }
 }
 
-export const requireCondition = (
+const requireConditionDataFirst = (
   condition: boolean,
   error: ExecutionCandidateDiscoveryError,
 ): Result.Result<void, ExecutionCandidateDiscoveryError> => (condition ? Result.succeed(undefined) : Result.fail(error))
+
+export const requireCondition = Pipeable.dual(2, requireConditionDataFirst)
 
 export const requireValue = <A>(
   value: A | null | undefined,
@@ -500,7 +503,9 @@ export const requireValue = <A>(
 ): Result.Result<A, ExecutionCandidateDiscoveryError> =>
   value === null || value === undefined ? Result.fail(error) : Result.succeed(value)
 
-export const canonicalHashResult = (
+const canonicalHashResultDataFirst = (
   value: unknown,
   onFailure: (cause: CanonicalHashFailure) => ExecutionCandidateDiscoveryError,
 ): Result.Result<string, ExecutionCandidateDiscoveryError> => Result.mapError(canonicalHashV1Result(value), onFailure)
+
+export const canonicalHashResult = Pipeable.dual(2, canonicalHashResultDataFirst)

--- a/services/bayn/src/execution-candidate-discovery/receipt-construction.ts
+++ b/services/bayn/src/execution-candidate-discovery/receipt-construction.ts
@@ -23,6 +23,7 @@ import {
 } from './model'
 import { assetEligibility, normalizedReadEvidence } from './broker-observation-validation'
 import { canonicalHashResult, requireValue, type ExecutionCandidateDiscoveryError } from './failure'
+import { Pipeable } from '../pipeable'
 
 const accountFacts = (account: Account): typeof AccountFactsSchema.Type => ({
   id: account.id,
@@ -183,7 +184,7 @@ const decodeReceipt = (
     ),
   )
 
-export const makeExecutionCandidateDiscoveryReceipt = (
+const makeExecutionCandidateDiscoveryReceiptDataFirst = (
   validatedSnapshot: ValidatedPaperCandidateSnapshot,
   observations: ValidatedPaperCandidateObservations,
 ): Result.Result<ExecutionCandidateDiscoveryReceipt, ExecutionCandidateDiscoveryError> => {
@@ -268,3 +269,5 @@ export const makeExecutionCandidateDiscoveryReceipt = (
     ),
   )
 }
+
+export const makeExecutionCandidateDiscoveryReceipt = Pipeable.dual(2, makeExecutionCandidateDiscoveryReceiptDataFirst)

--- a/services/bayn/src/execution-candidate-discovery/snapshot-validation.ts
+++ b/services/bayn/src/execution-candidate-discovery/snapshot-validation.ts
@@ -18,6 +18,7 @@ import {
   type ValidatedPaperCandidateSnapshot,
 } from './model'
 import { requireCondition, requireValue, type ExecutionCandidateDiscoveryError } from './failure'
+import { Pipeable } from '../pipeable'
 
 export const validateIdentity = (
   input: ExecutionCandidateDiscoveryIdentity,
@@ -347,7 +348,7 @@ const assembleBinding = (
   },
 })
 
-export const validateSnapshotForIdentity = (
+const validateSnapshotForIdentityDataFirst = (
   identity: ExecutionCandidateDiscoveryIdentity,
   snapshot: ExecutionCandidateDiscoverySnapshot,
   now: number,
@@ -411,7 +412,9 @@ export const validateSnapshotForIdentity = (
     ),
   )
 
-export const validateExecutionCandidateDiscoverySnapshot = (
+export const validateSnapshotForIdentity = Pipeable.dual(3, validateSnapshotForIdentityDataFirst)
+
+const validateExecutionCandidateDiscoverySnapshotDataFirst = (
   identity: ExecutionCandidateDiscoveryIdentity,
   snapshot: ExecutionCandidateDiscoverySnapshot,
   now: number,
@@ -420,3 +423,8 @@ export const validateExecutionCandidateDiscoverySnapshot = (
     validateIdentity(identity),
     Result.flatMap((validatedIdentity) => validateSnapshotForIdentity(validatedIdentity, snapshot, now)),
   )
+
+export const validateExecutionCandidateDiscoverySnapshot = Pipeable.dual(
+  3,
+  validateExecutionCandidateDiscoverySnapshotDataFirst,
+)

--- a/services/bayn/src/execution-prepare/program.ts
+++ b/services/bayn/src/execution-prepare/program.ts
@@ -20,6 +20,7 @@ import {
   type PrevalidatedExecutionPrepareInput,
   type ValidatedExecutionPrepareInput,
 } from './validation'
+import { Pipeable } from '../pipeable'
 
 const fail = <A>(failure: ExecutionPrepareFailure): Result.Result<A, ExecutionPrepareFailure> => Result.fail(failure)
 
@@ -182,7 +183,7 @@ export const prepareValidatedExecution = (
 ): Effect.Effect<ExecutionPrepareReceipt, ExecutionPrepareFailure, CapitalGrantLifecycleStore> =>
   prepareValidatedExecutionWithGeneration(validated).pipe(Effect.map(({ receipt }) => receipt))
 
-export const prepareExecution = (
+const prepareExecutionDataFirst = (
   request: unknown,
   runtime: unknown,
   trustedDiscoveryReceipt: ExecutionCandidateDiscoveryReceipt,
@@ -195,8 +196,12 @@ export const prepareExecution = (
     return yield* prepareValidatedExecution(validated)
   })
 
-export const authenticateValidatedExecutionPrepare = (
+export const prepareExecution = Pipeable.dual(3, prepareExecutionDataFirst)
+
+const authenticateValidatedExecutionPrepareDataFirst = (
   prevalidated: PrevalidatedExecutionPrepareInput,
   trustedDiscoveryReceipt: ExecutionCandidateDiscoveryReceipt,
 ): Effect.Effect<ValidatedExecutionPrepareInput, ExecutionPrepareFailure> =>
   Effect.fromResult(authenticateExecutionPrepareDiscovery(prevalidated, trustedDiscoveryReceipt))
+
+export const authenticateValidatedExecutionPrepare = Pipeable.dual(2, authenticateValidatedExecutionPrepareDataFirst)

--- a/services/bayn/src/execution-prepare/validation.ts
+++ b/services/bayn/src/execution-prepare/validation.ts
@@ -21,6 +21,7 @@ import type {
   ExecutionPrepareGenerationField,
   ExecutionPrepareRuntimeField,
 } from './failure'
+import { Pipeable } from '../pipeable'
 
 export interface PrevalidatedExecutionPrepareInput {
   readonly request: ExecutionPrepareProofPlanRequest
@@ -203,7 +204,7 @@ const validateRuntimeAgainstProof = (
     : runtimeMismatch('riskPolicyHash')
 }
 
-export const validateExecutionPrepareInput = (
+const validateExecutionPrepareInputDataFirst = (
   candidate: unknown,
   runtimeCandidate: unknown,
 ): Result.Result<PrevalidatedExecutionPrepareInput, ExecutionPrepareFailure> => {
@@ -233,7 +234,9 @@ export const validateExecutionPrepareInput = (
   return Result.succeed({ request, runtime })
 }
 
-export const authenticateExecutionPrepareDiscovery = (
+export const validateExecutionPrepareInput = Pipeable.dual(2, validateExecutionPrepareInputDataFirst)
+
+const authenticateExecutionPrepareDiscoveryDataFirst = (
   input: PrevalidatedExecutionPrepareInput,
   trustedReceipt: ExecutionCandidateDiscoveryReceipt,
 ): Result.Result<ValidatedExecutionPrepareInput, ExecutionPrepareFailure> => {
@@ -263,6 +266,8 @@ export const authenticateExecutionPrepareDiscovery = (
     },
   })
 }
+
+export const authenticateExecutionPrepareDiscovery = Pipeable.dual(2, authenticateExecutionPrepareDiscoveryDataFirst)
 
 const equalGenerationBinding = (
   generation: CapitalGrantGeneration,
@@ -319,7 +324,7 @@ const equalGenerationBinding = (
     : generationMismatch('reconciliationContentHash')
 }
 
-export const makeExecutionPrepareReceipt = (
+const makeExecutionPrepareReceiptDataFirst = (
   input: ValidatedExecutionPrepareInput,
   generation: CapitalGrantGeneration,
 ): Result.Result<ExecutionPrepareReceipt, ExecutionPrepareFailure> => {
@@ -367,3 +372,5 @@ export const makeExecutionPrepareReceipt = (
     Result.mapError((cause): ExecutionPrepareFailure => ({ _tag: 'ExecutionPrepareReceiptInvalid', cause })),
   )
 }
+
+export const makeExecutionPrepareReceipt = Pipeable.dual(2, makeExecutionPrepareReceiptDataFirst)

--- a/services/bayn/src/execution/configuration.ts
+++ b/services/bayn/src/execution/configuration.ts
@@ -15,6 +15,7 @@ import {
   strictParseOptions,
 } from '../schemas'
 import { BrokerAccess, CapitalAuthorityKind } from './authority'
+import { Pipeable } from '../pipeable'
 
 export enum CapitalAuthoritySelection {
   None = 'none',
@@ -179,7 +180,7 @@ export const researchCapitalGrantProof = (
   proofPlanHash: request.grant.planHash,
 })
 
-export const researchPaperGenerationIsBoundToRequest = (
+const researchPaperGenerationIsBoundToRequestDataFirst = (
   request: ResearchPaperActivationRequest,
   sourceGenerationHash: string,
   generation: ResearchCapitalGrantGeneration,
@@ -213,6 +214,11 @@ export const researchPaperGenerationIsBoundToRequest = (
   }
   return Result.succeed(undefined)
 }
+
+export const researchPaperGenerationIsBoundToRequest = Pipeable.dual(
+  3,
+  researchPaperGenerationIsBoundToRequestDataFirst,
+)
 
 export const PaperActivationRequestSchema = Schema.Union([
   QualifiedPaperActivationRequestSchema,

--- a/services/bayn/src/execution/coordinator-decisions.ts
+++ b/services/bayn/src/execution/coordinator-decisions.ts
@@ -30,6 +30,7 @@ import { UtcInstantSchema } from '../schemas'
 import { utcInstantFromEpochMillisResult } from '../time'
 import type { StoredIntent } from './intents/domain'
 import { MutationEventType, type MutationEvent } from './mutations'
+import { Pipeable } from '../pipeable'
 
 // Pure decisions for the effectful coordinator interpreter.
 export type ExecutionDecisionFailure =
@@ -141,7 +142,7 @@ interface CancelReceipt {
 const completeMutationEvidence = Schema.is(MutationEvidenceSchema)
 const isUtcInstant = Schema.is(UtcInstantSchema)
 
-export const selectStoredIntent = (
+const selectStoredIntentDataFirst = (
   operation: MutationOperation,
   intentId: string,
   stored: Option.Option<StoredIntent>,
@@ -150,6 +151,8 @@ export const selectStoredIntent = (
     onNone: () => Result.fail({ _tag: 'IntentMissing', operation, intentId }),
     onSome: Result.succeed,
   })
+
+export const selectStoredIntent = Pipeable.dual(3, selectStoredIntentDataFirst)
 
 const parseInstant = (
   operation: MutationOperation,
@@ -184,7 +187,7 @@ const validateCurrentTime = (
 ): Result.Result<number, ExecutionDecisionFailure> =>
   Result.map(formatInstant(operation, 'current-time', currentTimeMillis), () => currentTimeMillis)
 
-export const nextInstant = (
+const nextInstantDataFirst = (
   operation: MutationOperation,
   instant: string,
   current: string,
@@ -196,6 +199,8 @@ export const nextInstant = (
         : formatInstant(operation, 'stored-updated-at', instantMillis + 1),
     ),
   )
+
+export const nextInstant = Pipeable.dual(3, nextInstantDataFirst)
 
 export const encodeOrder = (
   operation: MutationOperation,
@@ -251,13 +256,15 @@ export const validateActiveSubmitRiskDecision = (
 ): Result.Result<StoredIntent, ExecutionDecisionFailure> =>
   validateSubmitRiskDecision(stored, currentTimeMillis, operationLabel, IntentState.Approved)
 
-export const validateStartedSubmitRiskDecision = (
+const validateStartedSubmitRiskDecisionDataFirst = (
   stored: StoredIntent,
   currentTimeMillis: number,
 ): Result.Result<StoredIntent, ExecutionDecisionFailure> =>
   validateSubmitRiskDecision(stored, currentTimeMillis, 'final submission', IntentState.IoStarted)
 
-export const makeDryRunSubmit = (
+export const validateStartedSubmitRiskDecision = Pipeable.dual(2, validateStartedSubmitRiskDecisionDataFirst)
+
+const makeDryRunSubmitDataFirst = (
   stored: StoredIntent,
   currentTimeMillis: number,
 ): Result.Result<DryRunSubmitDecision, ExecutionDecisionFailure> =>
@@ -279,6 +286,8 @@ export const makeDryRunSubmit = (
     ),
   )
 
+export const makeDryRunSubmit = Pipeable.dual(2, makeDryRunSubmitDataFirst)
+
 export const terminalOutcome = (status: OrderStatus): TerminalOutcome | undefined => {
   switch (status) {
     case OrderStatus.Filled:
@@ -294,7 +303,7 @@ export const terminalOutcome = (status: OrderStatus): TerminalOutcome | undefine
   }
 }
 
-export const exactOrder = (intent: Intent, request: EncodedOrder['request'], order: Order): boolean =>
+const exactOrderDataFirst = (intent: Intent, request: EncodedOrder['request'], order: Order): boolean =>
   Result.match(orderPriceBoundaryMicros(intent), {
     onFailure: () => false,
     onSuccess: (limitPriceMicros) =>
@@ -309,6 +318,8 @@ export const exactOrder = (intent: Intent, request: EncodedOrder['request'], ord
       (order.status !== OrderStatus.Filled || order.filledQuantityMicros === intent.quantityMicros) &&
       order.extendedHours === false,
   })
+
+export const exactOrder = Pipeable.dual(3, exactOrderDataFirst)
 
 export const completeEvidence = (value: unknown): MutationEvidence | undefined =>
   completeMutationEvidence(value) ? value : undefined
@@ -328,7 +339,7 @@ export const readErrorEvidence = (error: BrokerReadError): MutationEvidence | un
     observedAt: error.observedAt,
   })
 
-export const decideSubmitFailure = (
+const decideSubmitFailureDataFirst = (
   expectedRequestHash: string,
   error: BrokerMutationError,
 ): SubmitPersistenceDecision => {
@@ -349,7 +360,9 @@ export const decideSubmitFailure = (
         }
 }
 
-export const decideSubmitSuccess = (
+export const decideSubmitFailure = Pipeable.dual(2, decideSubmitFailureDataFirst)
+
+const decideSubmitSuccessDataFirst = (
   intent: Intent,
   encoded: EncodedOrder,
   receipt: SubmitReceipt,
@@ -370,6 +383,8 @@ export const decideSubmitSuccess = (
   }
 }
 
+export const decideSubmitSuccess = Pipeable.dual(3, decideSubmitSuccessDataFirst)
+
 export const cancellationIdentity = (
   submitEvent: MutationEvent | undefined,
 ): Result.Result<{ readonly brokerOrderId: string; readonly requestHash: string }, ExecutionDecisionFailure> =>
@@ -388,7 +403,7 @@ export const decideCancelFailure = (error: BrokerMutationError): CancelPersisten
   }
 }
 
-export const decideCancelSuccess = (
+const decideCancelSuccessDataFirst = (
   brokerOrderId: string,
   requestHash: string,
   receipt: CancelReceipt,
@@ -397,6 +412,8 @@ export const decideCancelSuccess = (
     ? { _tag: 'CancelAccepted', evidence: receipt.evidence }
     : { _tag: 'CancelUnknown', evidence: receipt.evidence }
 
+export const decideCancelSuccess = Pipeable.dual(3, decideCancelSuccessDataFirst)
+
 const submitResolved = (intent: Intent, event: MutationEvent): boolean =>
   intent.state === IntentState.Terminal &&
   (event.eventType === MutationEventType.SubmitAccepted ||
@@ -404,7 +421,7 @@ const submitResolved = (intent: Intent, event: MutationEvent): boolean =>
     event.eventType === MutationEventType.SubmitDenied ||
     event.eventType === MutationEventType.RecoveryFound)
 
-export const selectRecovery = (
+const selectRecoveryDataFirst = (
   operation: MutationOperation,
   intent: Intent,
   event: MutationEvent | undefined,
@@ -418,6 +435,8 @@ export const selectRecovery = (
   return Result.succeed(complete ? { _tag: 'RecoveryComplete', event } : { _tag: 'RecoveryRequired', event })
 }
 
+export const selectRecovery = Pipeable.dual(3, selectRecoveryDataFirst)
+
 const recoveryRequestHash = (
   intent: Intent,
   event: MutationEvent,
@@ -426,7 +445,7 @@ const recoveryRequestHash = (
     ? encodeOrder(event.operation, intent).pipe(Result.map(({ requestHash }) => requestHash))
     : Result.succeed(event.brokerOrderId === undefined ? undefined : cancelRequestHash(event.brokerOrderId))
 
-export const validateRecovery = (
+const validateRecoveryDataFirst = (
   intent: Intent,
   event: MutationEvent,
   cancellation: MutationEvent | undefined,
@@ -450,7 +469,9 @@ export const validateRecovery = (
   )
 }
 
-export const ensureRecoveryDelay = (
+export const validateRecovery = Pipeable.dual(3, validateRecoveryDataFirst)
+
+const ensureRecoveryDelayDataFirst = (
   operation: MutationOperation,
   event: MutationEvent,
   currentMillis: number,
@@ -471,7 +492,9 @@ export const ensureRecoveryDelay = (
   )
 }
 
-export const decideInterruptedStart = (event: MutationEvent, occurredAt: string): InterruptedStartDecision => {
+export const ensureRecoveryDelay = Pipeable.dual(3, ensureRecoveryDelayDataFirst)
+
+const decideInterruptedStartDataFirst = (event: MutationEvent, occurredAt: string): InterruptedStartDecision => {
   if (event.eventType === MutationEventType.SubmitStarted) {
     return { _tag: 'MarkSubmitUnknown', event, occurredAt }
   }
@@ -479,6 +502,8 @@ export const decideInterruptedStart = (event: MutationEvent, occurredAt: string)
     ? { _tag: 'MarkCancelUnknown', event, brokerOrderId: event.brokerOrderId, occurredAt }
     : { _tag: 'KeepMutation', event }
 }
+
+export const decideInterruptedStart = Pipeable.dual(2, decideInterruptedStartDataFirst)
 
 export const decideRecoveryFailure = (error: BrokerReadError): RecoveryPersistenceDecision => {
   const evidence = readErrorEvidence(error)
@@ -490,7 +515,7 @@ export const decideRecoveryFailure = (error: BrokerReadError): RecoveryPersisten
       }
 }
 
-export const decideRecoverySuccess = (
+const decideRecoverySuccessDataFirst = (
   intent: Intent,
   operation: MutationOperation,
   interrupted: MutationEvent,
@@ -518,3 +543,5 @@ export const decideRecoverySuccess = (
         ...(outcome === undefined ? {} : { terminalOutcome: outcome }),
       }
 }
+
+export const decideRecoverySuccess = Pipeable.dual(4, decideRecoverySuccessDataFirst)

--- a/services/bayn/src/execution/coordinator.ts
+++ b/services/bayn/src/execution/coordinator.ts
@@ -30,6 +30,7 @@ import { IntentStore, type IntentStoreError, type StoredIntent } from './intents
 import { MutationStore, type MutationEvent } from './mutations'
 import { WriterFence } from './writer-fence'
 import { currentUtcInstant, utcInstantFromEpochMillis } from '../time'
+import { Pipeable } from '../pipeable'
 
 export enum ExecutionFailure {
   IntentNotFound = 'INTENT_NOT_FOUND',
@@ -357,12 +358,14 @@ const runCancel = (services: MutationServices, intentId: string, consistencyDela
       ),
     )
 
-export const cancel = (intentId: string, consistencyDelayMs: number) =>
+const cancelDataFirst = (intentId: string, consistencyDelayMs: number) =>
   Effect.all({
     mutations: MutationStore,
     broker: BrokerMutation,
     fence: WriterFence,
   }).pipe(Effect.flatMap((services) => runCancel(services, intentId, consistencyDelayMs)))
+
+export const cancel = Pipeable.dual(2, cancelDataFirst)
 
 const markInterruptedStart = (mutations: MutationStore['Service'], event: MutationEvent, occurredAt: string) =>
   Match.value(decideInterruptedStart(event, occurredAt)).pipe(
@@ -464,8 +467,10 @@ const runRecovery = (services: RecoveryServices, intentId: string, operation: Mu
     ),
   )
 
-export const recover = (intentId: string, operation: MutationOperation) =>
+const recoverDataFirst = (intentId: string, operation: MutationOperation) =>
   Effect.all({
     mutations: MutationStore,
     broker: BrokerRead,
   }).pipe(Effect.flatMap((services) => runRecovery(services, intentId, operation)))
+
+export const recover = Pipeable.dual(2, recoverDataFirst)

--- a/services/bayn/src/execution/intents/domain.ts
+++ b/services/bayn/src/execution/intents/domain.ts
@@ -27,6 +27,7 @@ import {
   strictParseOptions,
 } from '../../schemas'
 import { WriterFenceError } from '../writer-fence'
+import { Pipeable } from '../../pipeable'
 
 export const IntentPlanSchema = Schema.Struct({
   schemaVersion: Schema.Literal('bayn.paper-intent-plan.v1'),
@@ -262,7 +263,7 @@ export const plan = (input: unknown): Effect.Effect<ReferenceIntent, IntentPlann
   return Effect.fromResult(Result.flatMap(decoded, makeReferenceIntentResult))
 }
 
-export const paperIntentIdForPlan = (
+const paperIntentIdForPlanDataFirst = (
   input: unknown,
   authorityGenerationHash: string,
 ): Effect.Effect<string, IntentPlanningFailure> => {
@@ -278,11 +279,13 @@ export const paperIntentIdForPlan = (
   )
 }
 
+export const paperIntentIdForPlan = Pipeable.dual(2, paperIntentIdForPlanDataFirst)
+
 export class PaperIntentBindingError extends Data.TaggedError('PaperIntentBindingError')<{
   readonly message: string
 }> {}
 
-export const planPaperIntent = (
+const planPaperIntentDataFirst = (
   input: unknown,
   state: Pick<State, 'authority'>,
 ): Effect.Effect<Intent, IntentPlanningFailure | PaperIntentBindingError> => {
@@ -299,6 +302,8 @@ export const planPaperIntent = (
     ),
   )
 }
+
+export const planPaperIntent = Pipeable.dual(2, planPaperIntentDataFirst)
 
 export class IntentStoreError extends Data.TaggedError('IntentStoreError')<{
   readonly failure: 'conflict' | 'decode' | 'invariant' | 'query'
@@ -511,7 +516,7 @@ const planFromIntent = (intent: Intent): IntentPlan => ({
   createdAt: intent.createdAt,
 })
 
-export const validateCommitIdentity = (
+const validateCommitIdentityDataFirst = (
   inputIntent: unknown,
   inputDecision: unknown,
 ): Result.Result<PreparedCommit, CommitMaterialFailure> => {
@@ -552,6 +557,8 @@ export const validateCommitIdentity = (
   }
   return Result.succeed({ _tag: 'PreparedCommit', intent: intent.success, decision: decision.success })
 }
+
+export const validateCommitIdentity = Pipeable.dual(2, validateCommitIdentityDataFirst)
 
 const immutableIntentMaterial = (intent: Intent) => ({
   schemaVersion: intent.schemaVersion,
@@ -598,7 +605,7 @@ const decisionStateMatches = (record: StoredIntent, decision: RiskDecision): boo
     ? record.intent.state !== IntentState.Planned
     : record.intent.state === IntentState.Terminal && record.intent.terminalOutcome === TerminalOutcome.Blocked
 
-export const classifyExistingCommit = (
+const classifyExistingCommitDataFirst = (
   records: readonly StoredIntent[],
   prepared: PreparedCommit,
 ): Result.Result<ExistingCommitDisposition, ExistingCommitFailure> => {
@@ -641,6 +648,8 @@ export const classifyExistingCommit = (
   return Result.succeed({ _tag: 'CompleteIntent', record })
 }
 
+export const classifyExistingCommit = Pipeable.dual(2, classifyExistingCommitDataFirst)
+
 export type AuthorityBindingFailure =
   | { readonly _tag: 'AuthorityMissing' }
   | { readonly _tag: 'MultipleAuthorityRows'; readonly count: number }
@@ -668,7 +677,7 @@ export const decodeAuthorityBindingRows = (
     cause,
   }))
 
-export const validateCurrentAuthority = (
+const validateCurrentAuthorityDataFirst = (
   rows: readonly AuthorityBindingRow[],
   intent: Intent,
 ): Result.Result<
@@ -715,7 +724,9 @@ export const validateCurrentAuthority = (
   return Result.succeed({ _tag: 'CurrentCapitalGrant', binding: authority })
 }
 
-export const validateCurrentClosingAuthority = (
+export const validateCurrentAuthority = Pipeable.dual(2, validateCurrentAuthorityDataFirst)
+
+const validateCurrentClosingAuthorityDataFirst = (
   rows: readonly AuthorityBindingRow[],
   intent: Intent,
 ): Result.Result<
@@ -760,6 +771,8 @@ export const validateCurrentClosingAuthority = (
   return Result.succeed({ _tag: 'CurrentCapitalGrant', binding: authority })
 }
 
+export const validateCurrentClosingAuthority = Pipeable.dual(2, validateCurrentClosingAuthorityDataFirst)
+
 export type WriteDispositionFailure =
   | {
       readonly _tag: 'ReturningRowsDecodeFailed'
@@ -777,7 +790,7 @@ export type IntentInsertDisposition =
   | { readonly _tag: 'IntentInserted'; readonly intentId: string }
   | { readonly _tag: 'IntentInsertConflict'; readonly intentId: string }
 
-export const decideIntentInsert = (
+const decideIntentInsertDataFirst = (
   rows: unknown,
   expectedIntentId: string,
 ): Result.Result<IntentInsertDisposition, WriteDispositionFailure> => {
@@ -800,7 +813,9 @@ export const decideIntentInsert = (
   })
 }
 
-export const decideRiskCommit = (
+export const decideIntentInsert = Pipeable.dual(2, decideIntentInsertDataFirst)
+
+const decideRiskCommitDataFirst = (
   rows: unknown,
   expectedDecisionId: string,
 ): Result.Result<{ readonly _tag: 'RiskDecisionInserted'; readonly decisionId: string }, WriteDispositionFailure> => {
@@ -820,7 +835,9 @@ export const decideRiskCommit = (
   })
 }
 
-export const decideIntentTransition = (
+export const decideRiskCommit = Pipeable.dual(2, decideRiskCommitDataFirst)
+
+const decideIntentTransitionDataFirst = (
   rows: unknown,
   expectedIntentId: string,
 ): Result.Result<{ readonly _tag: 'IntentTransitioned'; readonly intentId: string }, WriteDispositionFailure> => {
@@ -839,3 +856,5 @@ export const decideIntentTransition = (
     observedIds: decoded.success.map((row) => row.intent_id),
   })
 }
+
+export const decideIntentTransition = Pipeable.dual(2, decideIntentTransitionDataFirst)

--- a/services/bayn/src/execution/mutation-authority.ts
+++ b/services/bayn/src/execution/mutation-authority.ts
@@ -31,6 +31,7 @@ import {
   type LiveCapitalAuthority,
   type MutationExecutionAuthority,
 } from './authority'
+import { Pipeable } from '../pipeable'
 
 export type LiveMutationExecutionAuthority = Extract<
   ExecutionAuthority,
@@ -237,7 +238,7 @@ const positionExposureIdentity = (positions: readonly Position[]) =>
       left.assetId < right.assetId ? -1 : left.assetId > right.assetId ? 1 : left.symbol.localeCompare(right.symbol),
     )
 
-export const validateStableLivePositionSnapshot = (
+const validateStableLivePositionSnapshotDataFirst = (
   before: readonly Position[],
   after: readonly Position[],
 ): Result.Result<readonly Position[], LiveCapitalLimitFailure> => {
@@ -258,12 +259,14 @@ export const validateStableLivePositionSnapshot = (
       })
 }
 
+export const validateStableLivePositionSnapshot = Pipeable.dual(2, validateStableLivePositionSnapshotDataFirst)
+
 const expectedAuthorityGeneration = (authority: MutationExecutionAuthority): string =>
   authority.capitalAuthority._tag === CapitalAuthorityKind.Sandbox
     ? authority.capitalAuthority.authorityGenerationHash
     : authority.capitalAuthority.grant.authorityGenerationHash
 
-export const validateIntentAuthorityBinding = (
+const validateIntentAuthorityBindingDataFirst = (
   authority: MutationExecutionAuthority,
   intent: Intent,
 ): Result.Result<void, IntentAuthorityBindingFailure> => {
@@ -291,6 +294,8 @@ export const validateIntentAuthorityBinding = (
   }
   return Result.succeed(undefined)
 }
+
+export const validateIntentAuthorityBinding = Pipeable.dual(2, validateIntentAuthorityBindingDataFirst)
 
 const signedIntentNotional = (intent: Intent, notional: bigint): bigint =>
   intent.side === IntentOrderSide.Buy ? notional : -notional
@@ -351,7 +356,7 @@ export const boundedBrokerOrderNotional = (intent: Intent): Result.Result<bigint
   return Result.succeed((quantityMicros * priceBoundary.success + microsPerUnit - 1n) / microsPerUnit)
 }
 
-export const liveOrderCapNotional = (
+const liveOrderCapNotionalDataFirst = (
   intent: Intent,
   quote: FreshBrokerQuote,
   observedAt: string,
@@ -370,7 +375,9 @@ export const liveOrderCapNotional = (
   return Result.succeed((quantityMicros * freshBid.success + microsPerUnit - 1n) / microsPerUnit)
 }
 
-export const validateBrokerPriceBoundary = (
+export const liveOrderCapNotional = Pipeable.dual(3, liveOrderCapNotionalDataFirst)
+
+const validateBrokerPriceBoundaryDataFirst = (
   intent: Intent,
   quote: FreshBrokerQuote,
   observedAt: string,
@@ -399,15 +406,19 @@ export const validateBrokerPriceBoundary = (
       })
 }
 
+export const validateBrokerPriceBoundary = Pipeable.dual(3, validateBrokerPriceBoundaryDataFirst)
+
 const orderHasUnboundedExecutionPrice = (order: Order): boolean =>
   order.notionalMicros === undefined &&
   order.quantityMicros !== undefined &&
   order.limitPriceMicros === undefined &&
   (order.orderType === BrokerOrderType.Stop || order.orderType === BrokerOrderType.TrailingStop)
 
-export const quoteSymbolsForLiveExposure = (intent: Intent, _openOrders: readonly Order[]): readonly string[] => [
+const quoteSymbolsForLiveExposureDataFirst = (intent: Intent, _openOrders: readonly Order[]): readonly string[] => [
   intent.symbol,
 ]
+
+export const quoteSymbolsForLiveExposure = Pipeable.dual(2, quoteSymbolsForLiveExposureDataFirst)
 
 const signedOrderNotional = (order: Order): Result.Result<bigint, LiveCapitalLimitFailure> => {
   const remainingQuantity = unfilledOrderQuantity(order)
@@ -581,7 +592,7 @@ interface PendingSymbolExposure {
 
 const emptyPendingSymbolExposure: PendingSymbolExposure = { buyMicros: 0n, sellMicros: 0n }
 
-export const maximumAbsoluteExposureAcrossPendingFills = (
+const maximumAbsoluteExposureAcrossPendingFillsDataFirst = (
   currentMicros: bigint,
   pending: PendingSymbolExposure,
   proposedMicros: bigint,
@@ -590,6 +601,11 @@ export const maximumAbsoluteExposureAcrossPendingFills = (
   const upperBound = currentMicros + proposedMicros + pending.buyMicros
   return absolute(lowerBound) > absolute(upperBound) ? absolute(lowerBound) : absolute(upperBound)
 }
+
+export const maximumAbsoluteExposureAcrossPendingFills = Pipeable.dual(
+  3,
+  maximumAbsoluteExposureAcrossPendingFillsDataFirst,
+)
 
 const validateSnapshotBindings = (
   authority: LiveMutationExecutionAuthority,
@@ -640,7 +656,7 @@ const validateSnapshotBindings = (
   return Result.succeed(undefined)
 }
 
-export const validateLiveCapitalLimits = (
+const validateLiveCapitalLimitsDataFirst = (
   authority: LiveMutationExecutionAuthority,
   intent: Intent,
   snapshot: LiveCapitalSnapshot,
@@ -765,10 +781,12 @@ export const validateLiveCapitalLimits = (
   return Result.succeed(undefined)
 }
 
+export const validateLiveCapitalLimits = Pipeable.dual(6, validateLiveCapitalLimitsDataFirst)
+
 const mutationAuthorizationError = (message: string, cause: unknown) =>
   invalidRequest(MutationOperation.Submit, message, cause)
 
-export const refreshLiveBrokerSubmitSnapshot = (
+const refreshLiveBrokerSubmitSnapshotDataFirst = (
   authority: LiveMutationExecutionAuthority,
   intent: Intent,
   dependencies: LiveBrokerSubmitRefreshDependencies,
@@ -823,6 +841,8 @@ export const refreshLiveBrokerSubmitSnapshot = (
     }
   })
 
+export const refreshLiveBrokerSubmitSnapshot = Pipeable.dual(3, refreshLiveBrokerSubmitSnapshotDataFirst)
+
 export type LiveGrantRefreshFailure =
   | ExecutionAuthorityConstructionFailure
   | {
@@ -834,7 +854,7 @@ export type LiveGrantRefreshFailure =
       readonly _tag: 'FreshAuthorityCapabilityMismatch'
     }
 
-export const validateLiveGrantForSubmit = (
+const validateLiveGrantForSubmitDataFirst = (
   captured: MutationExecutionAuthority,
   persisted: LiveCapitalAuthority,
   observedAt: string,
@@ -862,6 +882,8 @@ export const validateLiveGrantForSubmit = (
     : Result.fail({ _tag: 'FreshAuthorityCapabilityMismatch' })
 }
 
+export const validateLiveGrantForSubmit = Pipeable.dual(3, validateLiveGrantForSubmitDataFirst)
+
 export type LiveBrokerSubmitValidationFailure =
   | LiveGrantRefreshFailure
   | LiveCapitalLimitFailure
@@ -870,7 +892,7 @@ export type LiveBrokerSubmitValidationFailure =
       readonly symbol: string
     }
 
-export const validateLiveBrokerSubmitSnapshot = (
+const validateLiveBrokerSubmitSnapshotDataFirst = (
   captured: LiveMutationExecutionAuthority,
   persisted: LiveCapitalAuthority,
   intent: Intent,
@@ -904,7 +926,9 @@ export const validateLiveBrokerSubmitSnapshot = (
   )
 }
 
-export const makeAuthorityGuardedBrokerMutation = (
+export const validateLiveBrokerSubmitSnapshot = Pipeable.dual(5, validateLiveBrokerSubmitSnapshotDataFirst)
+
+const makeAuthorityGuardedBrokerMutationDataFirst = (
   authority: MutationExecutionAuthority,
   dependencies: MutationAuthorityDependencies,
 ): BrokerMutationShape => {
@@ -974,3 +998,5 @@ export const makeAuthorityGuardedBrokerMutation = (
       : { orderByClientId: dependencies.brokerMutation.orderByClientId }),
   }
 }
+
+export const makeAuthorityGuardedBrokerMutation = Pipeable.dual(2, makeAuthorityGuardedBrokerMutationDataFirst)

--- a/services/bayn/src/execution/mutations/decisions.ts
+++ b/services/bayn/src/execution/mutations/decisions.ts
@@ -31,6 +31,7 @@ import {
   type SubmitRecoveryWriteDecision,
 } from './model'
 import { MutationStoreError as MutationStoreErrorValue } from './model'
+import { Pipeable } from '../../pipeable'
 
 const decodeStartInputResult = Schema.decodeUnknownResult(StartInputSchema, strictParseOptions)
 const decodeOutcomeInputResult = Schema.decodeUnknownResult(OutcomeInputSchema, strictParseOptions)
@@ -78,7 +79,7 @@ const canonicalHashResult = (
     }),
   )
 
-export const mutationIdResult = (
+const mutationIdResultDataFirst = (
   intentId: string,
   operation: MutationOperation,
 ): Result.Result<string, MutationCanonicalizationFailure> =>
@@ -86,6 +87,8 @@ export const mutationIdResult = (
     { _tag: 'MutationIdentity', intentId, operation },
     { schemaVersion: 'bayn.paper-mutation.v1', intentId, operation },
   )
+
+export const mutationIdResult = Pipeable.dual(2, mutationIdResultDataFirst)
 
 const mutationEventResult = (
   event: Omit<MutationEvent, 'eventId' | 'schemaVersion'>,
@@ -143,7 +146,7 @@ export const storeError = (
 export const startStoreOperationFor = (operation: MutationOperation): StartStoreOperation =>
   operation === MutationOperation.Submit ? 'begin-submit' : 'begin-cancel'
 
-export const canonicalizationStoreError = (
+const canonicalizationStoreErrorDataFirst = (
   operation: MutationStoreError['operation'],
   failure: MutationCanonicalizationFailure,
 ): MutationStoreError =>
@@ -158,7 +161,9 @@ export const canonicalizationStoreError = (
     canonicalizationFailure: failure,
   })
 
-export const canonicalMutationId = (
+export const canonicalizationStoreError = Pipeable.dual(2, canonicalizationStoreErrorDataFirst)
+
+const canonicalMutationIdDataFirst = (
   storeOperation: MutationStoreError['operation'],
   intentId: string,
   operation: MutationOperation,
@@ -167,13 +172,17 @@ export const canonicalMutationId = (
     canonicalizationStoreError(storeOperation, failure),
   )
 
-export const makeEventResult = (
+export const canonicalMutationId = Pipeable.dual(3, canonicalMutationIdDataFirst)
+
+const makeEventResultDataFirst = (
   storeOperation: MutationStoreError['operation'],
   event: Omit<MutationEvent, 'eventId' | 'schemaVersion'>,
 ): Result.Result<MutationEvent, MutationStoreError> =>
   Result.mapError(mutationEventResult(event), (failure) => canonicalizationStoreError(storeOperation, failure))
 
-export const decideMutationStartReplay = (
+export const makeEventResult = Pipeable.dual(2, makeEventResultDataFirst)
+
+const decideMutationStartReplayDataFirst = (
   operation: MutationOperation,
   input: MutationStartInput,
   existing: MutationEvent | undefined,
@@ -197,6 +206,8 @@ export const decideMutationStartReplay = (
     receipt: { event: existing, started: false },
   })
 }
+
+export const decideMutationStartReplay = Pipeable.dual(3, decideMutationStartReplayDataFirst)
 
 export const decideMutationAuthority = (
   operation: MutationOperation,
@@ -275,7 +286,7 @@ export const decideMutationContainment = (unresolved: boolean | undefined): Resu
     ? Result.succeed(undefined)
     : Result.fail(storeError('begin-submit', 'invariant', 'another broker mutation has an unresolved outcome'))
 
-export const decideMutationStart = (
+const decideMutationStartDataFirst = (
   operation: MutationOperation,
   input: MutationStartInput,
   authority: MutationAuthorityBinding,
@@ -368,6 +379,8 @@ export const decideMutationStart = (
     }),
   )
 }
+
+export const decideMutationStart = Pipeable.dual(5, decideMutationStartDataFirst)
 
 export const decideMutationOutcomeDefinition = (definition: MutationOutcomeDefinition): MutationOutcomeFacts => {
   switch (definition._tag) {
@@ -642,7 +655,7 @@ const decideMutationEventContract = (
       )
 }
 
-export const decideMutationOutcome = (
+const decideMutationOutcomeDataFirst = (
   input: MutationOutcomeInput,
   definition: MutationOutcomeDefinition,
   previous: MutationEvent | undefined,
@@ -720,7 +733,9 @@ export const decideMutationOutcome = (
   })
 }
 
-export const decideCancelFirst = (
+export const decideMutationOutcome = Pipeable.dual(4, decideMutationOutcomeDataFirst)
+
+const decideCancelFirstDataFirst = (
   decision: MutationCancelFirstDecision,
   cancellation: MutationEvent | undefined,
 ): Result.Result<void, MutationStoreError> =>
@@ -730,7 +745,9 @@ export const decideCancelFirst = (
       )
     : Result.succeed(undefined)
 
-export const decideMutationAppend = (
+export const decideCancelFirst = Pipeable.dual(2, decideCancelFirstDataFirst)
+
+const decideMutationAppendDataFirst = (
   storeOperation: MutationStoreError['operation'],
   event: MutationEvent,
   appendedEventIds: readonly string[],
@@ -748,6 +765,8 @@ export const decideMutationAppend = (
         ),
       )
 
+export const decideMutationAppend = Pipeable.dual(4, decideMutationAppendDataFirst)
+
 export const decideSubmitStartWrite = (
   transitionedIntentIds: readonly string[],
 ): Result.Result<void, MutationStoreError> =>
@@ -755,7 +774,7 @@ export const decideSubmitStartWrite = (
     ? Result.succeed(undefined)
     : Result.fail(storeError('begin-submit', 'conflict', 'approved intent transition lost its race'))
 
-export const decideMutationOutcomeWrite = (
+const decideMutationOutcomeWriteDataFirst = (
   storeOperation: OutcomeStoreOperation,
   transitionedIntentIds: readonly string[],
 ): Result.Result<void, MutationStoreError> =>
@@ -763,7 +782,9 @@ export const decideMutationOutcomeWrite = (
     ? Result.succeed(undefined)
     : Result.fail(storeError(storeOperation, 'conflict', 'intent mutation outcome lost its race'))
 
-export const decideSubmitRecoveryWrite = (
+export const decideMutationOutcomeWrite = Pipeable.dual(2, decideMutationOutcomeWriteDataFirst)
+
+const decideSubmitRecoveryWriteDataFirst = (
   storeOperation: OutcomeStoreOperation,
   recoveredIntentIds: readonly string[],
   transition: Extract<MutationIntentTransition, { readonly _tag: 'RecoverSubmit' }>,
@@ -778,7 +799,9 @@ export const decideSubmitRecoveryWrite = (
   return Result.fail(storeError(storeOperation, 'conflict', 'unknown intent recovery lost its race'))
 }
 
-export const decideAcknowledgedRecovery = (
+export const decideSubmitRecoveryWrite = Pipeable.dual(3, decideSubmitRecoveryWriteDataFirst)
+
+const decideAcknowledgedRecoveryDataFirst = (
   storeOperation: OutcomeStoreOperation,
   acknowledged: boolean | undefined,
 ): Result.Result<void, MutationStoreError> =>
@@ -786,7 +809,9 @@ export const decideAcknowledgedRecovery = (
     ? Result.succeed(undefined)
     : Result.fail(storeError(storeOperation, 'conflict', 'submit recovery requires an unresolved durable intent'))
 
-export const decideRecoveredOutcomeWrite = (
+export const decideAcknowledgedRecovery = Pipeable.dual(2, decideAcknowledgedRecoveryDataFirst)
+
+const decideRecoveredOutcomeWriteDataFirst = (
   storeOperation: OutcomeStoreOperation,
   transitionedIntentIds: readonly string[],
   acknowledgedTerminal: boolean,
@@ -803,7 +828,9 @@ export const decideRecoveredOutcomeWrite = (
         ),
       )
 
-export const decideCancelRecoveryState = (
+export const decideRecoveredOutcomeWrite = Pipeable.dual(3, decideRecoveredOutcomeWriteDataFirst)
+
+const decideCancelRecoveryStateDataFirst = (
   storeOperation: OutcomeStoreOperation,
   recoveredIntentIds: readonly string[],
 ): Result.Result<IntentState.Acknowledged | IntentState.Recovered, MutationStoreError> => {
@@ -812,7 +839,9 @@ export const decideCancelRecoveryState = (
   return Result.fail(storeError(storeOperation, 'conflict', 'intent mutation outcome lost its race'))
 }
 
-export const decodeStartInput = (
+export const decideCancelRecoveryState = Pipeable.dual(2, decideCancelRecoveryStateDataFirst)
+
+const decodeStartInputDataFirst = (
   operation: MutationOperation,
   input: unknown,
 ): Result.Result<MutationStartInput, MutationStoreError> =>
@@ -820,7 +849,9 @@ export const decodeStartInput = (
     storeError(startStoreOperationFor(operation), 'decode', 'invalid mutation start', cause),
   )
 
-export const decodeOutcomeInput = (
+export const decodeStartInput = Pipeable.dual(2, decodeStartInputDataFirst)
+
+const decodeOutcomeInputDataFirst = (
   storeOperation: OutcomeStoreOperation,
   input: {
     readonly intentId: string
@@ -842,3 +873,5 @@ export const decodeOutcomeInput = (
     (cause) => storeError(storeOperation, 'decode', 'invalid mutation outcome', cause),
   )
 }
+
+export const decodeOutcomeInput = Pipeable.dual(2, decodeOutcomeInputDataFirst)

--- a/services/bayn/src/execution/mutations/postgres/outcome.ts
+++ b/services/bayn/src/execution/mutations/postgres/outcome.ts
@@ -28,6 +28,7 @@ import { decodeAcknowledged, decodeIntentIds, decodeOutcomeIntentSnapshot } from
 import type { MutationEventPostgres } from './events'
 import { fromDecision } from './shared'
 import type { WriterFenceError, WriterFenceService } from '../../writer-fence'
+import { Pipeable } from '../../../pipeable'
 
 export interface MutationOutcomePostgres {
   readonly appendOutcome: (
@@ -40,7 +41,7 @@ export interface MutationOutcomePostgres {
   ) => Effect.Effect<MutationEvent, MutationStoreError | SqlError | WriterFenceError>
 }
 
-export const makeMutationOutcomePostgres = (
+const makeMutationOutcomePostgresDataFirst = (
   sql: PgClient.PgClient,
   fence: WriterFenceService,
   events: MutationEventPostgres,
@@ -288,3 +289,5 @@ export const makeMutationOutcomePostgres = (
 
   return { appendOutcome }
 }
+
+export const makeMutationOutcomePostgres = Pipeable.dual(3, makeMutationOutcomePostgresDataFirst)

--- a/services/bayn/src/execution/mutations/postgres/start.ts
+++ b/services/bayn/src/execution/mutations/postgres/start.ts
@@ -19,6 +19,7 @@ import { decodeAuthoritySnapshot, decodeIntentIds, decodeIntentSnapshot, decodeU
 import type { MutationEventPostgres } from './events'
 import { fromDecision } from './shared'
 import type { WriterFenceError, WriterFenceService } from '../../writer-fence'
+import { Pipeable } from '../../../pipeable'
 
 export interface MutationStartPostgres {
   readonly authorizeSubmit: (
@@ -36,7 +37,7 @@ export interface MutationStartPostgres {
   ) => Effect.Effect<StartReceipt, MutationStoreError | SqlError | WriterFenceError>
 }
 
-export const makeMutationStartPostgres = (
+const makeMutationStartPostgresDataFirst = (
   sql: PgClient.PgClient,
   fence: WriterFenceService,
   events: MutationEventPostgres,
@@ -210,3 +211,5 @@ export const makeMutationStartPostgres = (
 
   return { authorizeSubmit, begin }
 }
+
+export const makeMutationStartPostgres = Pipeable.dual(3, makeMutationStartPostgresDataFirst)

--- a/services/bayn/src/execution/mutations/rows.ts
+++ b/services/bayn/src/execution/mutations/rows.ts
@@ -21,6 +21,7 @@ import {
   type MutationStoreError,
   type OutcomeStoreOperation,
 } from './model'
+import { Pipeable } from '../../pipeable'
 
 const StoredEventRows = Schema.Array(
   Schema.Struct({
@@ -117,7 +118,7 @@ export const decodeStoredEvents = (rows: unknown): Result.Result<readonly Mutati
 export const decodeIntentId = (intentId: string): Result.Result<string, MutationStoreError> =>
   Result.mapError(decodeIntentIdResult(intentId), (cause) => storeError('read', 'decode', 'invalid intent ID', cause))
 
-export const decodeAuthoritySnapshot = (
+const decodeAuthoritySnapshotDataFirst = (
   operation: MutationOperation,
   rows: unknown,
 ): Result.Result<MutationAuthoritySnapshot | undefined, MutationStoreError> =>
@@ -140,7 +141,9 @@ export const decodeAuthoritySnapshot = (
     },
   )
 
-export const decodeIntentSnapshot = (
+export const decodeAuthoritySnapshot = Pipeable.dual(2, decodeAuthoritySnapshotDataFirst)
+
+const decodeIntentSnapshotDataFirst = (
   operation: MutationOperation,
   rows: unknown,
 ): Result.Result<MutationIntentSnapshot | undefined, MutationStoreError> =>
@@ -168,6 +171,8 @@ export const decodeIntentSnapshot = (
     },
   )
 
+export const decodeIntentSnapshot = Pipeable.dual(2, decodeIntentSnapshotDataFirst)
+
 export const decodeUnresolved = (rows: unknown): Result.Result<boolean | undefined, MutationStoreError> =>
   Result.map(
     Result.mapError(decodeUnresolvedRows(rows), (cause) =>
@@ -176,7 +181,7 @@ export const decodeUnresolved = (rows: unknown): Result.Result<boolean | undefin
     (decoded) => decoded[0]?.unresolved,
   )
 
-export const decodeEventIds = (
+const decodeEventIdsDataFirst = (
   operation: MutationStoreError['operation'],
   rows: unknown,
 ): Result.Result<readonly string[], MutationStoreError> =>
@@ -187,7 +192,9 @@ export const decodeEventIds = (
     (decoded) => decoded.map((row) => row.event_id),
   )
 
-export const decodeIntentIds = (
+export const decodeEventIds = Pipeable.dual(2, decodeEventIdsDataFirst)
+
+const decodeIntentIdsDataFirst = (
   operation: OutcomeStoreOperation | 'begin-submit',
   message: string,
   rows: unknown,
@@ -197,7 +204,9 @@ export const decodeIntentIds = (
     (decoded) => decoded.map((row) => row.intent_id),
   )
 
-export const decodeOutcomeIntentSnapshot = (
+export const decodeIntentIds = Pipeable.dual(3, decodeIntentIdsDataFirst)
+
+const decodeOutcomeIntentSnapshotDataFirst = (
   operation: OutcomeStoreOperation,
   rows: unknown,
 ): Result.Result<MutationReplayIntentSnapshot | undefined, MutationStoreError> =>
@@ -216,7 +225,9 @@ export const decodeOutcomeIntentSnapshot = (
     },
   )
 
-export const decodeAcknowledged = (
+export const decodeOutcomeIntentSnapshot = Pipeable.dual(2, decodeOutcomeIntentSnapshotDataFirst)
+
+const decodeAcknowledgedDataFirst = (
   operation: OutcomeStoreOperation,
   rows: unknown,
 ): Result.Result<boolean | undefined, MutationStoreError> =>
@@ -226,3 +237,5 @@ export const decodeAcknowledged = (
     ),
     (decoded) => decoded[0]?.acknowledged,
   )
+
+export const decodeAcknowledged = Pipeable.dual(2, decodeAcknowledgedDataFirst)

--- a/services/bayn/src/execution/runtime-program.ts
+++ b/services/bayn/src/execution/runtime-program.ts
@@ -28,6 +28,7 @@ import {
   type FreshBrokerQuote,
 } from './mutation-authority'
 import { WriterFence, WriterFenceError, type WriterFenceService } from './writer-fence'
+import { Pipeable } from '../pipeable'
 
 export interface ExecutionProgramDependencies {
   readonly brokerRead: BrokerReadShape
@@ -177,7 +178,7 @@ const provideCoordinatorDependencies = <A, E, R>(
     Effect.provideService(WriterFence, dependencies.writerFence),
   )
 
-export const makeExecutionProgram = (authority: ExecutionAuthority, dependencies: ExecutionProgramDependencies) => {
+const makeExecutionProgramDataFirst = (authority: ExecutionAuthority, dependencies: ExecutionProgramDependencies) => {
   if (authority.brokerAccess !== BrokerAccess.Mutation) {
     return Result.fail({
       _tag: 'ExecutionProgramRequiresMutationAuthority' as const,
@@ -214,5 +215,7 @@ export const makeExecutionProgram = (authority: ExecutionAuthority, dependencies
       provideCoordinatorDependencies(recover(intentId, operation), coordinatorDependencies),
   })
 }
+
+export const makeExecutionProgram = Pipeable.dual(2, makeExecutionProgramDataFirst)
 
 export type ExecutionProgram = Result.Result.Success<ReturnType<typeof makeExecutionProgram>>


### PR DESCRIPTION
## Summary

- Makes persistence decision and adapter APIs pipeable while preserving existing replay and failure contracts.
- Keeps this native stack layer independently reviewable at 648 changed lines.
- Bases directly on codex/bayn-effect-tsgo-pipeable-domain so GitHub shows only this layer.

## Related Issues

None

## Testing

- bunx tsc --noEmit --project services/bayn/tsconfig.json
- bun run lint
- bun run lint:oxlint
- bun run lint:oxlint:type
- bun run build
- Focused tests for the touched subsystem were run while constructing the layer.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable and Breaking Changes is filled in.
- [x] Documentation and follow-ups are unchanged or represented by later stack layers.