### PR TITLE
refactor(bayn): make strategy APIs pipeable

### DIFF
--- a/services/bayn/src/forward-performance/program.ts
+++ b/services/bayn/src/forward-performance/program.ts
@@ -32,6 +32,7 @@ import type {
   ForwardPerformanceMarketVolumeRequest,
   ForwardPerformanceReceipt,
 } from './model'
+import { Pipeable } from '../pipeable'
 
 export type ForwardPerformanceProgramCause =
   | CanonicalJsonFailure
@@ -229,7 +230,7 @@ const projectForwardPerformanceMarketVolumeEvidence = (
   )
 }
 
-export const makeForwardPerformanceMarketVolumeEvidence = (
+const makeForwardPerformanceMarketVolumeEvidenceDataFirst = (
   request: ForwardPerformanceMarketVolumeRequest,
   rows: ForwardPerformanceMarketSnapshotRows,
   evaluationStart: IsoDate,
@@ -239,6 +240,11 @@ export const makeForwardPerformanceMarketVolumeEvidence = (
     ? Result.succeed(undefined)
     : projectForwardPerformanceMarketVolumeEvidence(request, verified, evaluationStart)
 }
+
+export const makeForwardPerformanceMarketVolumeEvidence = Pipeable.dual(
+  3,
+  makeForwardPerformanceMarketVolumeEvidenceDataFirst,
+)
 
 const requestGroupKey = (request: ForwardPerformanceMarketVolumeRequest): string =>
   JSON.stringify([
@@ -271,7 +277,7 @@ const groupMarketVolumeRequests = (
     .map(([, group]) => group)
 }
 
-export const readForwardPerformanceMarketVolumeWithClient = (
+const readForwardPerformanceMarketVolumeWithClientDataFirst = (
   config: Pick<LoadedRuntimeConfig, 'clickhouse' | 'operationTimeoutMs'>,
   requests: readonly ForwardPerformanceMarketVolumeRequest[],
 ): Effect.Effect<
@@ -397,6 +403,11 @@ export const readForwardPerformanceMarketVolumeWithClient = (
   )
 }
 
+export const readForwardPerformanceMarketVolumeWithClient = Pipeable.dual(
+  2,
+  readForwardPerformanceMarketVolumeWithClientDataFirst,
+)
+
 export function readForwardPerformanceMarketVolume(
   config: Pick<LoadedRuntimeConfig, 'clickhouse' | 'operationTimeoutMs'>,
   requests: readonly ForwardPerformanceMarketVolumeRequest[],
@@ -423,7 +434,7 @@ export function readForwardPerformanceMarketVolume(
 const canonicalUnsigned = (value: string): bigint | undefined =>
   /^(?:0|[1-9][0-9]*)$/.test(value) ? BigInt(value) : undefined
 
-export const bindForwardPerformanceTerminalReferencePrices = (
+const bindForwardPerformanceTerminalReferencePricesDataFirst = (
   executionEvidence: readonly ForwardPerformanceExecutionEvidence[],
   marketVolumeEvidence: readonly ForwardPerformanceMarketVolumeEvidence[],
 ): Result.Result<readonly ForwardPerformanceExecutionEvidence[], CanonicalJsonFailure> => {
@@ -481,6 +492,11 @@ export const bindForwardPerformanceTerminalReferencePrices = (
     }),
   )
 }
+
+export const bindForwardPerformanceTerminalReferencePrices = Pipeable.dual(
+  2,
+  bindForwardPerformanceTerminalReferencePricesDataFirst,
+)
 
 const programError = (
   operation: ForwardPerformanceProgramError['operation'],

--- a/services/bayn/src/health/decisions.ts
+++ b/services/bayn/src/health/decisions.ts
@@ -37,8 +37,9 @@ import type {
   ProbeResult,
   SignalIdentityFailure,
 } from './model'
+import { Pipeable } from '../pipeable'
 
-export const validateSignalIdentity = (
+const validateSignalIdentityDataFirst = (
   snapshot: FinalizedSnapshotProvenance,
   evidence: RuntimeEvidence | null,
 ): Result.Result<void, SignalIdentityFailure> => {
@@ -61,6 +62,8 @@ export const validateSignalIdentity = (
   }
   return Result.succeed(undefined)
 }
+
+export const validateSignalIdentity = Pipeable.dual(2, validateSignalIdentityDataFirst)
 
 export const renderSignalIdentityFailure = (failure: SignalIdentityFailure): string => {
   switch (failure._tag) {
@@ -94,7 +97,7 @@ const canonicalHashResult = (
     (cause): DurableEvidenceFailure => ({ _tag: 'CanonicalizationFailed', runId, material, cause }),
   )
 
-export const validateDurableEvidence = (
+const validateDurableEvidenceDataFirst = (
   recovered: RecoveredEvaluationEvidence | null,
   qualification: QualificationRecord | null,
   evidence: RuntimeEvidence | null,
@@ -149,6 +152,8 @@ export const validateDurableEvidence = (
   }
   return Result.succeed(undefined)
 }
+
+export const validateDurableEvidence = Pipeable.dual(3, validateDurableEvidenceDataFirst)
 
 export const renderDurableEvidenceFailure = (failure: DurableEvidenceFailure): string => {
   switch (failure._tag) {
@@ -363,7 +368,7 @@ const deriveNextRuntimeState = (
   return { ...current, status: 'DEGRADED', health, cycle, broker, error: failures.messages.join('; ') }
 }
 
-export const deriveHealthTransition = (current: RuntimeState, input: HealthTransitionInput): HealthTransition => {
+const deriveHealthTransitionDataFirst = (current: RuntimeState, input: HealthTransitionInput): HealthTransition => {
   const checkedAt = input.clock._tag === 'Available' ? input.clock.checkedAt : null
   const clockFailure = input.clock._tag === 'Unavailable' ? input.clock.failure : null
   const clockError =
@@ -397,6 +402,8 @@ export const deriveHealthTransition = (current: RuntimeState, input: HealthTrans
     clockFailure,
   }
 }
+
+export const deriveHealthTransition = Pipeable.dual(2, deriveHealthTransitionDataFirst)
 
 const runtimeStatusLogDecision = (transition: HealthTransition): HealthLogDecision | null => {
   if (transition.next.status === transition.current.status) return null

--- a/services/bayn/src/health/program.ts
+++ b/services/bayn/src/health/program.ts
@@ -36,6 +36,7 @@ import type {
   HealthProbeResults,
   ProbeResult,
 } from './model'
+import { Pipeable } from '../pipeable'
 
 const probeFailureMessage = <E>(cause: Cause.Cause<E>, fallback: string): string => {
   const errors = Cause.prettyErrors(cause).map((error) => error.message)
@@ -139,7 +140,7 @@ const observeBroker = (read: BrokerReadShape, timeoutMs: number): Effect.Effect<
     }),
   )
 
-export const ensureSignalIdentity = (
+const ensureSignalIdentityDataFirst = (
   snapshot: FinalizedSnapshotProvenance,
   evidence: RuntimeEvidence | null,
 ): Effect.Effect<void, OperationalError> =>
@@ -155,7 +156,9 @@ export const ensureSignalIdentity = (
       }),
   )
 
-export const ensureDurableEvidence = (
+export const ensureSignalIdentity = Pipeable.dual(2, ensureSignalIdentityDataFirst)
+
+const ensureDurableEvidenceDataFirst = (
   recovered: RecoveredEvaluationEvidence | null,
   qualification: QualificationRecord | null,
   evidence: RuntimeEvidence | null,
@@ -171,6 +174,8 @@ export const ensureDurableEvidence = (
         cause: failure,
       }),
   )
+
+export const ensureDurableEvidence = Pipeable.dual(3, ensureDurableEvidenceDataFirst)
 
 const sampleAutonomousCycleFiber = (fiber: Fiber.Fiber<void, never> | undefined): AutonomousCycleFiberObservation => {
   if (fiber === undefined) return { _tag: 'NotProvided' }

--- a/services/bayn/src/ledger-plan/build.ts
+++ b/services/bayn/src/ledger-plan/build.ts
@@ -15,6 +15,7 @@ import {
   type LedgerPlanFailureDetail,
   type LedgerTransferRecord,
 } from './model'
+import { Pipeable } from '../pipeable'
 
 const makeAccount = (
   runId: string,
@@ -89,7 +90,7 @@ const requireNonNegative = (
 ): Result.Result<bigint, LedgerPlanFailureDetail> =>
   value < 0n ? failLedgerPlan({ kind: 'negative-amount', field, value, eventId }) : Result.succeed(value)
 
-export const planDecodedLedgerInput = (
+const planDecodedLedgerInputDataFirst = (
   input: DecodedLedgerInput,
   ledger: number,
 ): Result.Result<EvaluationLedgerPlan, LedgerPlanFailureDetail> =>
@@ -298,3 +299,5 @@ export const planDecodedLedgerInput = (
       transfers: transfers.sort((left, right) => (left.id < right.id ? -1 : 1)),
     }
   })
+
+export const planDecodedLedgerInput = Pipeable.dual(2, planDecodedLedgerInputDataFirst)

--- a/services/bayn/src/ledger-plan/model.ts
+++ b/services/bayn/src/ledger-plan/model.ts
@@ -2,6 +2,7 @@ import { Data, Result } from 'effect'
 
 import { renderCanonicalJsonFailure, type CanonicalJsonFailure } from '../hash'
 import type { EvaluationEvent, ReconciliationResult } from '../types'
+import { Pipeable } from '../pipeable'
 
 export const LEDGER_SCHEMA_VERSION = 2
 export const LEDGER_BATCH_MAX = 8_189
@@ -299,7 +300,7 @@ const ledgerPlanCause = (failure: LedgerPlanFailureDetail): unknown => {
   }
 }
 
-export const makeLedgerPlanFailure = (ledger: number, detail: LedgerPlanFailureDetail): LedgerPlanFailure =>
+const makeLedgerPlanFailureDataFirst = (ledger: number, detail: LedgerPlanFailureDetail): LedgerPlanFailure =>
   Object.assign(
     ledgerValidationError(
       'build-plan',
@@ -310,6 +311,8 @@ export const makeLedgerPlanFailure = (ledger: number, detail: LedgerPlanFailureD
     ),
     { kind: detail.kind, detail },
   ) as LedgerPlanFailure
+
+export const makeLedgerPlanFailure = Pipeable.dual(2, makeLedgerPlanFailureDataFirst)
 
 export const failLedgerPlan = (failure: LedgerPlanFailureDetail): Result.Result<never, LedgerPlanFailureDetail> =>
   Result.fail(failure)

--- a/services/bayn/src/ledger-plan/verification.ts
+++ b/services/bayn/src/ledger-plan/verification.ts
@@ -8,8 +8,9 @@ import {
   type LedgerValidationError,
   type LedgerValidationOperation,
 } from './model'
+import { Pipeable } from '../pipeable'
 
-export const accountMetadataMatches = (actual: LedgerAccountRecord, expected: LedgerAccountRecord): boolean =>
+const accountMetadataMatchesDataFirst = (actual: LedgerAccountRecord, expected: LedgerAccountRecord): boolean =>
   actual.id === expected.id &&
   actual.user_data_128 === expected.user_data_128 &&
   actual.user_data_64 === expected.user_data_64 &&
@@ -19,7 +20,9 @@ export const accountMetadataMatches = (actual: LedgerAccountRecord, expected: Le
   actual.code === expected.code &&
   actual.flags === expected.flags
 
-export const transferMetadataMatches = (actual: LedgerTransferRecord, expected: LedgerTransferRecord): boolean =>
+export const accountMetadataMatches = Pipeable.dual(2, accountMetadataMatchesDataFirst)
+
+const transferMetadataMatchesDataFirst = (actual: LedgerTransferRecord, expected: LedgerTransferRecord): boolean =>
   actual.id === expected.id &&
   actual.debit_account_id === expected.debit_account_id &&
   actual.credit_account_id === expected.credit_account_id &&
@@ -32,6 +35,8 @@ export const transferMetadataMatches = (actual: LedgerTransferRecord, expected: 
   actual.ledger === expected.ledger &&
   actual.code === expected.code &&
   actual.flags === expected.flags
+
+export const transferMetadataMatches = Pipeable.dual(2, transferMetadataMatchesDataFirst)
 
 const duplicateRecordId = <Record extends { readonly id: bigint }>(records: readonly Record[]): bigint | undefined => {
   const ids = new Set<bigint>()
@@ -81,7 +86,7 @@ const verifyUniqueExact = <Record extends { readonly id: bigint }>(
   return Result.succeed(undefined)
 }
 
-export const verifyExactAccounts = (
+const verifyExactAccountsDataFirst = (
   operation: LedgerValidationOperation,
   kind: string,
   actual: readonly LedgerAccountRecord[],
@@ -89,7 +94,9 @@ export const verifyExactAccounts = (
 ): Result.Result<void, LedgerValidationError> =>
   verifyUniqueExact(operation, kind, actual, expected, accountMetadataMatches)
 
-export const verifyExactTransfers = (
+export const verifyExactAccounts = Pipeable.dual(4, verifyExactAccountsDataFirst)
+
+const verifyExactTransfersDataFirst = (
   operation: LedgerValidationOperation,
   kind: string,
   actual: readonly LedgerTransferRecord[],
@@ -97,7 +104,9 @@ export const verifyExactTransfers = (
 ): Result.Result<void, LedgerValidationError> =>
   verifyUniqueExact(operation, kind, actual, expected, transferMetadataMatches)
 
-export const verifyLedgerPlanRecords = (
+export const verifyExactTransfers = Pipeable.dual(4, verifyExactTransfersDataFirst)
+
+const verifyLedgerPlanRecordsDataFirst = (
   operation: LedgerValidationOperation,
   accountKind: string,
   transferKind: string,
@@ -110,7 +119,9 @@ export const verifyLedgerPlanRecords = (
     yield* verifyExactTransfers(operation, transferKind, actualTransfers, plan.transfers)
   })
 
-export const preflightTransfers = (
+export const verifyLedgerPlanRecords = Pipeable.dual(6, verifyLedgerPlanRecordsDataFirst)
+
+const preflightTransfersDataFirst = (
   expected: readonly LedgerTransferRecord[],
   existing: readonly LedgerTransferRecord[],
 ): Result.Result<readonly LedgerTransferRecord[], LedgerValidationError> => {
@@ -151,6 +162,8 @@ export const preflightTransfers = (
   }
   return Result.succeed(expected.filter((transfer) => !existingIds.has(transfer.id)))
 }
+
+export const preflightTransfers = Pipeable.dual(2, preflightTransfersDataFirst)
 
 export interface LedgerBalances {
   readonly accountsById: ReadonlyMap<bigint, LedgerAccountRecord>

--- a/services/bayn/src/ledger/decisions.ts
+++ b/services/bayn/src/ledger/decisions.ts
@@ -14,6 +14,7 @@ import {
   type LedgerValidationError,
 } from '../ledger-plan'
 import type { ReconciliationResult } from '../types'
+import { Pipeable } from '../pipeable'
 
 const classifyCreateBatch = <Record extends { readonly id: bigint }>(
   kind: 'account' | 'transfer',
@@ -56,17 +57,21 @@ const classifyCreateBatch = <Record extends { readonly id: bigint }>(
   return Result.succeed(existing)
 }
 
-export const classifyAccountCreateBatch = (
+const classifyAccountCreateBatchDataFirst = (
   accounts: readonly LedgerAccountRecord[],
   results: readonly LedgerCreateResult[],
 ): Result.Result<readonly LedgerAccountRecord[], LedgerValidationError> =>
   classifyCreateBatch('account', 'verify-account-results', accounts, results)
 
-export const classifyTransferCreateBatch = (
+export const classifyAccountCreateBatch = Pipeable.dual(2, classifyAccountCreateBatchDataFirst)
+
+const classifyTransferCreateBatchDataFirst = (
   transfers: readonly LedgerTransferRecord[],
   results: readonly LedgerCreateResult[],
 ): Result.Result<readonly LedgerTransferRecord[], LedgerValidationError> =>
   classifyCreateBatch('transfer', 'verify-transfer-results', transfers, results)
+
+export const classifyTransferCreateBatch = Pipeable.dual(2, classifyTransferCreateBatchDataFirst)
 
 const queryFilter = (ledger: number): LedgerQueryFilter => ({
   user_data_128: 0n,
@@ -132,7 +137,7 @@ export interface LedgerQueries {
   readonly transfers: LedgerQueryFilter
 }
 
-export const persistedRunQueries = (
+const persistedRunQueriesDataFirst = (
   result: ReconciliationResult,
   ledger: number,
 ): Result.Result<LedgerQueries, LedgerValidationError> => {
@@ -159,7 +164,9 @@ export const persistedRunQueries = (
   })
 }
 
-export const accountReconciliationQueries = (
+export const persistedRunQueries = Pipeable.dual(2, persistedRunQueriesDataFirst)
+
+const accountReconciliationQueriesDataFirst = (
   plan: LedgerPlan,
   ledger: number,
 ): Result.Result<LedgerQueries, LedgerValidationError> => {
@@ -186,12 +193,16 @@ export const accountReconciliationQueries = (
   })
 }
 
-export const runPlanQueries = (plan: LedgerPlan, ledger: number): LedgerQueries => ({
+export const accountReconciliationQueries = Pipeable.dual(2, accountReconciliationQueriesDataFirst)
+
+const runPlanQueriesDataFirst = (plan: LedgerPlan, ledger: number): LedgerQueries => ({
   accounts: { ...queryFilter(ledger), user_data_128: plan.runKey, limit: plan.accounts.length + 1 },
   transfers: { ...queryFilter(ledger), user_data_64: plan.runTag, limit: plan.transfers.length + 1 },
 })
 
-export const assembleAccountPlan = (
+export const runPlanQueries = Pipeable.dual(2, runPlanQueriesDataFirst)
+
+const assembleAccountPlanDataFirst = (
   accountId: string,
   plans: readonly LedgerPlan[],
 ): Result.Result<LedgerPlan, LedgerValidationError> => {
@@ -239,3 +250,5 @@ export const assembleAccountPlan = (
     transfers: [...transfers.values()].sort((left, right) => (left.id < right.id ? -1 : 1)),
   })
 }
+
+export const assembleAccountPlan = Pipeable.dual(2, assembleAccountPlanDataFirst)

--- a/services/bayn/src/market-data/errors.ts
+++ b/services/bayn/src/market-data/errors.ts
@@ -2,8 +2,9 @@ import { isSqlError } from 'effect/unstable/sql/SqlError'
 
 import { OperationalError, operationalError, retryableOperationalError } from '../errors'
 import { isMarketDataVerificationError, renderMarketDataVerificationError } from '../market-data-verification'
+import { Pipeable } from '../pipeable'
 
-export const marketDataOperationError = (
+const marketDataOperationErrorDataFirst = (
   operation: 'check' | 'inspect' | 'inspect-publication' | 'load',
   message: string,
   cause: unknown,
@@ -24,3 +25,5 @@ export const marketDataOperationError = (
   }
   return retryableOperationalError('market-data', operation, message, cause)
 }
+
+export const marketDataOperationError = Pipeable.dual(3, marketDataOperationErrorDataFirst)

--- a/services/bayn/src/market-data/program.ts
+++ b/services/bayn/src/market-data/program.ts
@@ -27,8 +27,9 @@ import {
 } from './model'
 import { cyclePublicationCandidateLimit, makeMarketDataQueries } from './queries'
 import { decodeSnapshotRows, type SignalManifestRow } from './rows'
+import { Pipeable } from '../pipeable'
 
-export const makeMarketData = (
+const makeMarketDataDataFirst = (
   config: Pick<RuntimeConfig, 'clickhouse' | 'operationTimeoutMs'>,
   contract: MarketDataContract,
 ): Effect.Effect<MarketDataService, never, ClickhouseClient.ClickhouseClient> =>
@@ -318,8 +319,12 @@ export const makeMarketData = (
     }),
   )
 
-export const MarketDataLive = (
+export const makeMarketData = Pipeable.dual(2, makeMarketDataDataFirst)
+
+const MarketDataLiveDataFirst = (
   config: Pick<RuntimeConfig, 'clickhouse' | 'operationTimeoutMs'>,
   contract: MarketDataContract,
 ): Layer.Layer<MarketData, never, ClickhouseClient.ClickhouseClient> =>
   Layer.effect(MarketData, makeMarketData(config, contract))
+
+export const MarketDataLive = Pipeable.dual(2, MarketDataLiveDataFirst)

--- a/services/bayn/src/market-data/queries.ts
+++ b/services/bayn/src/market-data/queries.ts
@@ -2,12 +2,13 @@ import type { ClickhouseClient } from '@effect/sql-clickhouse'
 
 import type { RuntimeConfig } from '../config'
 import type { FinalizedPublicationRequest, MarketDataContract, SnapshotPublicationRequest } from './model'
+import { Pipeable } from '../pipeable'
 
 // A 21-calendar-day catch-up interval contains at most 15 weekday publications. One extra bounded row keeps the
 // MarketData seam complete while the runner clamps by calendar date before its single broker-calendar read.
 export const cyclePublicationCandidateLimit = 16
 
-export const makeMarketDataQueries = (
+const makeMarketDataQueriesDataFirst = (
   sql: ClickhouseClient.ClickhouseClient,
   config: Pick<RuntimeConfig, 'clickhouse'>,
   contract: MarketDataContract,
@@ -240,3 +241,5 @@ export const makeMarketDataQueries = (
     loadSnapshotPublicationManifest,
   }
 }
+
+export const makeMarketDataQueries = Pipeable.dual(3, makeMarketDataQueriesDataFirst)

--- a/services/bayn/src/market-data/rows.ts
+++ b/services/bayn/src/market-data/rows.ts
@@ -14,6 +14,7 @@ import {
   strictParseOptions as StrictParseOptions,
 } from '../schemas'
 import { DataFeed, DataSource, PriceAdjustment, PublicationSchema } from '../types'
+import { Pipeable } from '../pipeable'
 
 const calendarTimeZone = 'America/New_York' as const
 const SnapshotIdSchema = HashSchema
@@ -150,7 +151,7 @@ export const decodeManifests = (
     ),
   )
 
-export const decodeSnapshotRows = (
+const decodeSnapshotRowsDataFirst = (
   bars: readonly unknown[],
   sessions: readonly unknown[],
   manifests: readonly unknown[],
@@ -160,3 +161,5 @@ export const decodeSnapshotRows = (
     sessions: decodeSessions(sessions),
     manifests: decodeManifests(manifests),
   })
+
+export const decodeSnapshotRows = Pipeable.dual(3, decodeSnapshotRowsDataFirst)

--- a/services/bayn/src/market-data/verification/calendar.ts
+++ b/services/bayn/src/market-data/verification/calendar.ts
@@ -16,6 +16,7 @@ import {
   validateBoundSessions,
   withoutSnapshot,
 } from './shared'
+import { Pipeable } from '../../pipeable'
 
 export interface VerifiedCalendar {
   readonly verifiedManifest: VerifiedManifest
@@ -72,7 +73,7 @@ const validateSession = (
     }),
   ])
 
-export const verifyCalendar = (
+const verifyCalendarDataFirst = (
   sessions: readonly SignalSessionRow[],
   manifests: readonly SignalManifestRow[],
   request: SnapshotRequest,
@@ -186,7 +187,9 @@ export const verifyCalendar = (
     }),
   )
 
-export const verifyFinalizedCalendar = (
+export const verifyCalendar = Pipeable.dual(3, verifyCalendarDataFirst)
+
+const verifyFinalizedCalendarDataFirst = (
   rows: Pick<SnapshotRows, 'sessions' | 'manifests'>,
   request: SnapshotRequest,
 ): Result.Result<MarketDataInspection, MarketDataVerificationError> =>
@@ -209,7 +212,9 @@ export const verifyFinalizedCalendar = (
     }),
   )
 
-export const publicationSnapshotRequest = (
+export const verifyFinalizedCalendar = Pipeable.dual(2, verifyFinalizedCalendarDataFirst)
+
+const publicationSnapshotRequestDataFirst = (
   manifest: SignalManifestRow,
   input: FinalizedPublicationRequest,
   contract: MarketDataContract,
@@ -233,3 +238,5 @@ export const publicationSnapshotRequest = (
   historyStart: contract.historyStart,
   evaluationStart: contract.evaluationStart,
 })
+
+export const publicationSnapshotRequest = Pipeable.dual(4, publicationSnapshotRequestDataFirst)

--- a/services/bayn/src/market-data/verification/manifest.ts
+++ b/services/bayn/src/market-data/verification/manifest.ts
@@ -14,6 +14,7 @@ import {
   validateAll,
   withoutManifestHash,
 } from './shared'
+import { Pipeable } from '../../pipeable'
 
 export interface VerifiedManifest {
   readonly manifest: SignalManifestRow
@@ -46,7 +47,7 @@ const manifestMismatch = (
   snapshotId,
 })
 
-export const verifyManifest = (
+const verifyManifestDataFirst = (
   manifests: readonly SignalManifestRow[],
   request: SnapshotRequest,
 ): Result.Result<VerifiedManifest, MarketDataVerificationError> =>
@@ -244,8 +245,12 @@ export const verifyManifest = (
     }),
   )
 
-export const verifyFinalizedManifest = (
+export const verifyManifest = Pipeable.dual(2, verifyManifestDataFirst)
+
+const verifyFinalizedManifestDataFirst = (
   manifests: readonly SignalManifestRow[],
   request: SnapshotRequest,
 ): Result.Result<FinalizedSnapshotProvenance, MarketDataVerificationError> =>
   Result.map(verifyManifest(manifests, request), ({ finalizedSnapshot }) => finalizedSnapshot)
+
+export const verifyFinalizedManifest = Pipeable.dual(2, verifyFinalizedManifestDataFirst)

--- a/services/bayn/src/market-data/verification/publications.ts
+++ b/services/bayn/src/market-data/verification/publications.ts
@@ -5,8 +5,9 @@ import type { SignalManifestRow, SignalSessionRow, SnapshotRows } from '../rows'
 import { publicationSnapshotRequest, verifyFinalizedCalendar } from './calendar'
 import type { MarketDataVerificationError } from './errors'
 import { fail } from './shared'
+import { Pipeable } from '../../pipeable'
 
-export const verifyFinalizedPublication = (
+const verifyFinalizedPublicationDataFirst = (
   rows: Pick<SnapshotRows, 'sessions' | 'manifests'>,
   input: FinalizedPublicationRequest,
   contract: MarketDataContract,
@@ -26,6 +27,8 @@ export const verifyFinalizedPublication = (
         publicationSnapshotRequest(manifests[0], input, contract, observedAt),
       )
 }
+
+export const verifyFinalizedPublication = Pipeable.dual(4, verifyFinalizedPublicationDataFirst)
 
 export const selectPublicationManifest = (
   manifests: readonly SignalManifestRow[],
@@ -70,7 +73,7 @@ export const verifyBoundFinalizedPublication = (
     ),
   )
 
-export const selectCyclePublicationManifests = (
+const selectCyclePublicationManifestsDataFirst = (
   manifests: readonly SignalManifestRow[],
   maximum: number,
 ): Result.Result<readonly SignalManifestRow[], MarketDataVerificationError> => {
@@ -97,7 +100,9 @@ export const selectCyclePublicationManifests = (
       : Result.succeed(ordered)
 }
 
-export const verifyCyclePublications = (
+export const selectCyclePublicationManifests = Pipeable.dual(2, selectCyclePublicationManifestsDataFirst)
+
+const verifyCyclePublicationsDataFirst = (
   manifests: readonly SignalManifestRow[],
   sessions: readonly SignalSessionRow[],
   contract: MarketDataContract,
@@ -134,3 +139,5 @@ export const verifyCyclePublications = (
         ),
       )
 }
+
+export const verifyCyclePublications = Pipeable.dual(4, verifyCyclePublicationsDataFirst)

--- a/services/bayn/src/market-data/verification/shared.ts
+++ b/services/bayn/src/market-data/verification/shared.ts
@@ -3,6 +3,7 @@ import { Result } from 'effect'
 import type { EvaluationBounds } from '../../contracts'
 import { canonicalHashV1Result } from '../../hash'
 import type { BoundField, MarketDataVerificationError } from './errors'
+import { Pipeable } from '../../pipeable'
 
 export const database = 'signal' as const
 export const tables = {
@@ -14,10 +15,12 @@ export const tables = {
 export const fail = <A>(error: MarketDataVerificationError): Result.Result<A, MarketDataVerificationError> =>
   Result.fail(error)
 
-export const requireCondition = (
+const requireConditionDataFirst = (
   condition: boolean,
   error: MarketDataVerificationError,
 ): Result.Result<void, MarketDataVerificationError> => (condition ? Result.succeed(undefined) : fail(error))
+
+export const requireCondition = Pipeable.dual(2, requireConditionDataFirst)
 
 export const requireValue = <A>(
   value: A | null | undefined,
@@ -29,7 +32,7 @@ export const validateAll = (
   validations: ReadonlyArray<Result.Result<void, MarketDataVerificationError>>,
 ): Result.Result<void, MarketDataVerificationError> => Result.map(Result.all(validations), () => undefined)
 
-export const canonicalHashResult = (
+const canonicalHashResultDataFirst = (
   target: Extract<MarketDataVerificationError, { readonly _tag: 'CanonicalizationFailed' }>['target'],
   snapshotId: string,
   value: unknown,
@@ -44,7 +47,9 @@ export const canonicalHashResult = (
     }),
   )
 
-export const decodeSignalCount = (
+export const canonicalHashResult = Pipeable.dual(3, canonicalHashResultDataFirst)
+
+const decodeSignalCountDataFirst = (
   value: string | number,
   field: Extract<MarketDataVerificationError, { readonly _tag: 'CountInvalid' }>['field'],
 ): Result.Result<number, MarketDataVerificationError> => {
@@ -53,6 +58,8 @@ export const decodeSignalCount = (
     ? Result.succeed(parsed)
     : fail({ _tag: 'CountInvalid', field, value })
 }
+
+export const decodeSignalCount = Pipeable.dual(2, decodeSignalCountDataFirst)
 
 export const canonicalUniverse = (
   universe: readonly string[],
@@ -75,7 +82,7 @@ export const toUtcInstant = (value: string): string => `${value.replace(' ', 'T'
 
 const boundFields: readonly BoundField[] = ['dataStart', 'dataEnd', 'lookbackStart', 'evaluationStart', 'evaluationEnd']
 
-export const validateBoundSessions = (
+const validateBoundSessionsDataFirst = (
   sessions: ReadonlySet<string>,
   bounds: EvaluationBounds,
 ): Result.Result<void, MarketDataVerificationError> =>
@@ -88,3 +95,5 @@ export const validateBoundSessions = (
       }),
     ),
   )
+
+export const validateBoundSessions = Pipeable.dual(2, validateBoundSessionsDataFirst)

--- a/services/bayn/src/market-data/verification/snapshot.ts
+++ b/services/bayn/src/market-data/verification/snapshot.ts
@@ -6,6 +6,7 @@ import { PublicationSchema, type DailyBar } from '../../types'
 import { verifyCalendar } from './calendar'
 import type { BarField, MarketDataVerificationError } from './errors'
 import { canonicalHashResult, fail, requireCondition, validateAll, withoutSnapshot } from './shared'
+import { Pipeable } from '../../pipeable'
 
 const decimalNumber = (
   row: SignalBarRow,
@@ -128,7 +129,7 @@ const validateBar = (
     }),
   ])
 
-export const verifyFinalizedSnapshot = (
+const verifyFinalizedSnapshotDataFirst = (
   rows: SnapshotRows,
   request: SnapshotRequest,
 ): Result.Result<MarketDataSnapshot, MarketDataVerificationError> =>
@@ -211,3 +212,5 @@ export const verifyFinalizedSnapshot = (
       )
     }),
   )
+
+export const verifyFinalizedSnapshot = Pipeable.dual(2, verifyFinalizedSnapshotDataFirst)

--- a/services/bayn/src/observe-composition/mutation-decisions.ts
+++ b/services/bayn/src/observe-composition/mutation-decisions.ts
@@ -14,6 +14,7 @@ import {
 } from '../execution/contracts'
 import { MutationEventType, type MutationEvent } from '../execution/mutations'
 import type { PlannedTargetQuantity } from '../target-planner'
+import { Pipeable } from '../pipeable'
 
 const quantityScale = 1_000_000n
 
@@ -78,7 +79,7 @@ const projectMutationPosition = (
   return [...retained, projected].sort(comparePositionSymbol)
 }
 
-export const projectWorstCasePendingMutationPosition = (
+const projectWorstCasePendingMutationPositionDataFirst = (
   positions: readonly Position[],
   target: PlannedTargetQuantity,
   accountId: string,
@@ -91,6 +92,11 @@ export const projectWorstCasePendingMutationPosition = (
     ? positions
     : projectMutationPosition(positions, target, accountId, observedAt)
 }
+
+export const projectWorstCasePendingMutationPosition = Pipeable.dual(
+  4,
+  projectWorstCasePendingMutationPositionDataFirst,
+)
 
 export type PreparedMutationIntentDecision =
   | { readonly _tag: 'Submit' }
@@ -105,7 +111,7 @@ export type PreparedMutationIntentDecisionFailure = {
   readonly eventType?: MutationEventType
 }
 
-export const decidePreparedMutationIntent = (
+const decidePreparedMutationIntentDataFirst = (
   intent: Intent,
   latest: MutationEvent | undefined,
 ): Result.Result<PreparedMutationIntentDecision, PreparedMutationIntentDecisionFailure> => {
@@ -157,6 +163,8 @@ export const decidePreparedMutationIntent = (
       return Result.succeed({ _tag: 'Recover', eventType: latest.eventType })
   }
 }
+
+export const decidePreparedMutationIntent = Pipeable.dual(2, decidePreparedMutationIntentDataFirst)
 
 export type PreparedMutationIntentAdmissionFailure = {
   readonly _tag: 'PreparedMutationIntentAdmissionFailure'
@@ -282,10 +290,12 @@ export const decidePreparedCloseIntentAdmission = (
   return Result.succeed(undefined)
 }
 
-export const appendPendingMutationOrder = (orders: readonly Order[], pending: Order): readonly Order[] =>
+const appendPendingMutationOrderDataFirst = (orders: readonly Order[], pending: Order): readonly Order[] =>
   orders.some((order) => order.brokerOrderId === pending.brokerOrderId || order.clientOrderId === pending.clientOrderId)
     ? orders
     : [...orders, pending]
+
+export const appendPendingMutationOrder = Pipeable.dual(2, appendPendingMutationOrderDataFirst)
 
 export interface PaperCycleIntentTerminalEvidence {
   readonly state: IntentState
@@ -318,7 +328,7 @@ export type PaperCycleCompletionDecision =
         | 'open-position'
     }
 
-export const decidePaperCycleCompletion = (
+const decidePaperCycleCompletionDataFirst = (
   documentCreatedAt: string,
   intents: readonly PaperCycleIntentTerminalEvidence[],
   reconciliation: PaperCycleReconciliationEvidence,
@@ -349,6 +359,8 @@ export const decidePaperCycleCompletion = (
   return { _tag: 'Complete' }
 }
 
+export const decidePaperCycleCompletion = Pipeable.dual(3, decidePaperCycleCompletionDataFirst)
+
 export type PreparedMutationRecoveryDecision =
   | { readonly _tag: 'NoRecovery' }
   | {
@@ -357,7 +369,7 @@ export type PreparedMutationRecoveryDecision =
       readonly event: MutationEvent
     }
 
-export const decidePreparedMutationRecovery = (
+const decidePreparedMutationRecoveryDataFirst = (
   intent: Intent,
   latestSubmit: MutationEvent | undefined,
   latestCancel: MutationEvent | undefined,
@@ -408,6 +420,8 @@ export const decidePreparedMutationRecovery = (
   return Result.succeed({ _tag: 'Recover', operation: MutationOperation.Submit, event: latestSubmit })
 }
 
+export const decidePreparedMutationRecovery = Pipeable.dual(3, decidePreparedMutationRecoveryDataFirst)
+
 export type PreparedMutationCycleStep =
   | { readonly _tag: 'RunCycle' }
   | {
@@ -436,13 +450,17 @@ export type PreparedMutationCycleStep =
 
 export type BoundMutationCycleOutcome = Exclude<PreparedMutationCycleStep, { readonly _tag: 'Execute' }>
 
-export const mutationRecoveryIsDue = (event: MutationEvent, observedAt: string): boolean =>
+const mutationRecoveryIsDueDataFirst = (event: MutationEvent, observedAt: string): boolean =>
   Date.parse(observedAt) >= Date.parse(event.occurredAt) + event.consistencyDelayMs
 
-export const paperSubmitExpiresAt = (documentExpiresAt: string, riskDecisionExpiresAt: string): string =>
+export const mutationRecoveryIsDue = Pipeable.dual(2, mutationRecoveryIsDueDataFirst)
+
+const paperSubmitExpiresAtDataFirst = (documentExpiresAt: string, riskDecisionExpiresAt: string): string =>
   riskDecisionExpiresAt < documentExpiresAt ? riskDecisionExpiresAt : documentExpiresAt
 
-export const expiredPaperPlanTerminalReason = (
+export const paperSubmitExpiresAt = Pipeable.dual(2, paperSubmitExpiresAtDataFirst)
+
+const expiredPaperPlanTerminalReasonDataFirst = (
   observedAt: string,
   submitExpiresAt: string,
   submissionCutoffAt: string,
@@ -452,6 +470,8 @@ export const expiredPaperPlanTerminalReason = (
     : observedAt >= submissionCutoffAt
       ? CycleTerminalReason.MissedSubmission
       : CycleTerminalReason.Risk
+
+export const expiredPaperPlanTerminalReason = Pipeable.dual(3, expiredPaperPlanTerminalReasonDataFirst)
 
 export type MutationIntentSettlementDecision =
   | {

--- a/services/bayn/src/observe-composition/mutation-interpreter.ts
+++ b/services/bayn/src/observe-composition/mutation-interpreter.ts
@@ -8,6 +8,7 @@ import { WriterFence } from '../execution/writer-fence'
 import { CycleRunnerError } from '../cycle-runner'
 import { currentUtcInstant } from '../time'
 import { decideMutationIntentSettlement, type MutationIntentExecutionResult } from './mutation-decisions'
+import { Pipeable } from '../pipeable'
 
 export type PaperMutationExecutor<E, R> = {
   readonly submit?: (intentId: string, consistencyDelayMs: number) => Effect.Effect<MutationEvent, E, R>
@@ -28,7 +29,7 @@ export const mutationRunnerError = (
     cause,
   })
 
-export const restrictMutationAuthority = (
+const restrictMutationAuthorityDataFirst = (
   subject: string,
   reason: string,
 ): Effect.Effect<void, CycleRunnerError, AuthorityRestrictionStore | WriterFence> =>
@@ -48,6 +49,8 @@ export const restrictMutationAuthority = (
         ),
       )
   })
+
+export const restrictMutationAuthority = Pipeable.dual(2, restrictMutationAuthorityDataFirst)
 
 export const restrictMutationLoopFailure = (
   error: CycleRunnerError,

--- a/services/bayn/src/paper-proof/gates.ts
+++ b/services/bayn/src/paper-proof/gates.ts
@@ -5,6 +5,7 @@ import { BrokerEnvironment } from '../broker/identity'
 import { BrokerAccess, CapitalAuthorityKind } from '../execution/authority'
 import type { PaperProofCommand, PaperProofRuntimeBinding, PaperProofSourcePlan } from './model'
 import { PaperProofError, protectedEntryToken } from './model'
+import { Pipeable } from '../pipeable'
 
 export const paperProofContainmentIoCount = 3
 
@@ -26,7 +27,7 @@ const sameStrategy = (left: PaperProofSourcePlan['strategy'], right: PaperProofR
 export const hasPaperProofMutationAuthority = (runtime: PaperProofRuntimeBinding): boolean =>
   runtime.brokerAccess === BrokerAccess.Mutation || runtime.capitalAuthority === CapitalAuthorityKind.Sandbox
 
-export const validatePaperProofEntry = (
+const validatePaperProofEntryDataFirst = (
   command: PaperProofCommand,
   source: PaperProofSourcePlan,
   runtime: PaperProofRuntimeBinding,
@@ -92,3 +93,5 @@ export const validatePaperProofEntry = (
   }
   return mismatch('SUBMIT, CANCEL, and RECOVER require explicit sandbox mutation authority')
 }
+
+export const validatePaperProofEntry = Pipeable.dual(4, validatePaperProofEntryDataFirst)

--- a/services/bayn/src/paper-proof/mutations.ts
+++ b/services/bayn/src/paper-proof/mutations.ts
@@ -39,6 +39,7 @@ import type {
   PaperProofRecoveryRequired,
   PreparedPaperProofIntent,
 } from './model'
+import { Pipeable } from '../pipeable'
 
 export interface PaperProofSubmitDependencies extends PaperProofRestrictionDependencies {
   readonly activateCapitalGrant: (proof: CapitalGrantProofBinding) => Effect.Effect<void, Error>
@@ -248,7 +249,7 @@ const runExistingCancel = (
     return receipt
   })
 
-export const runPaperProofSubmit = (
+const runPaperProofSubmitDataFirst = (
   context: PaperProofOperationContext<'SUBMIT'>,
   dependencies: PaperProofSubmitDependencies,
 ): Effect.Effect<PaperProofReceipt, PaperProofError> =>
@@ -277,7 +278,9 @@ export const runPaperProofSubmit = (
       : yield* runExistingSubmit(context, dependencies, prepared, before, admission.event, existingMarker)
   })
 
-export const runPaperProofCancel = (
+export const runPaperProofSubmit = Pipeable.dual(2, runPaperProofSubmitDataFirst)
+
+const runPaperProofCancelDataFirst = (
   context: PaperProofOperationContext<'CANCEL'>,
   dependencies: PaperProofCancelDependencies,
 ): Effect.Effect<PaperProofReceipt, PaperProofError> =>
@@ -319,3 +322,5 @@ export const runPaperProofCancel = (
     }
     return receipt
   })
+
+export const runPaperProofCancel = Pipeable.dual(2, runPaperProofCancelDataFirst)

--- a/services/bayn/src/paper-proof/operations.ts
+++ b/services/bayn/src/paper-proof/operations.ts
@@ -19,6 +19,7 @@ import {
   type PaperProofRecoveryStore,
   type PaperProofSourcePlan,
 } from './model'
+import { Pipeable } from '../pipeable'
 
 export type PaperProofCommandFor<Operation extends PaperProofOperation> = Omit<PaperProofCommand, 'operation'> & {
   readonly operation: Operation
@@ -63,12 +64,14 @@ export const paperProofFailure = (
     cause,
   })
 
-export const timeoutFailure = (operation: PaperProofError['operation'], message: string): PaperProofError =>
+const timeoutFailureDataFirst = (operation: PaperProofError['operation'], message: string): PaperProofError =>
   new PaperProofError({
     operation,
     failure: 'timeout',
     message,
   })
+
+export const timeoutFailure = Pipeable.dual(2, timeoutFailureDataFirst)
 
 export const lift = <A>(
   operation: PaperProofError['operation'],
@@ -93,7 +96,7 @@ export const liftBounded = <A>(
     }),
   )
 
-export const validateReconciliationAccount = (
+const validateReconciliationAccountDataFirst = (
   expectedAccountId: string,
   reconciliation: PaperProofReconciliation,
 ): Result.Result<PaperProofReconciliation, PaperProofError> =>
@@ -107,6 +110,8 @@ export const validateReconciliationAccount = (
           'invariant',
         ),
       )
+
+export const validateReconciliationAccount = Pipeable.dual(2, validateReconciliationAccountDataFirst)
 
 export const validateExactReconciliation = (
   reconciliation: PaperProofReconciliation,
@@ -122,7 +127,7 @@ export const validateExactReconciliation = (
         ),
       )
 
-export const observeReconciliation = (
+const observeReconciliationDataFirst = (
   accountId: string,
   reconcile: Effect.Effect<PaperProofReconciliation, Error>,
 ): Effect.Effect<PaperProofReconciliation, PaperProofError> =>
@@ -130,7 +135,9 @@ export const observeReconciliation = (
     Effect.flatMap((result) => Effect.fromResult(validateReconciliationAccount(accountId, result))),
   )
 
-export const reconcileExact = (
+export const observeReconciliation = Pipeable.dual(2, observeReconciliationDataFirst)
+
+const reconcileExactDataFirst = (
   accountId: string,
   reconcile: Effect.Effect<PaperProofReconciliation, Error>,
 ): Effect.Effect<PaperProofReconciliation, PaperProofError> =>
@@ -138,7 +145,9 @@ export const reconcileExact = (
     Effect.flatMap((result) => Effect.fromResult(validateExactReconciliation(result))),
   )
 
-export const restrictPaperProof = (
+export const reconcileExact = Pipeable.dual(2, reconcileExactDataFirst)
+
+const restrictPaperProofDataFirst = (
   dependencies: PaperProofRestrictionDependencies,
   reason: string,
 ): Effect.Effect<void, PaperProofError> =>
@@ -152,7 +161,9 @@ export const restrictPaperProof = (
     ),
   )
 
-export const makePaperProofReceipt = (
+export const restrictPaperProof = Pipeable.dual(2, restrictPaperProofDataFirst)
+
+const makePaperProofReceiptDataFirst = (
   context: PaperProofOperationContext,
   completedAt: string,
   input: PaperProofReceiptFields,
@@ -166,7 +177,9 @@ export const makePaperProofReceipt = (
   ...input,
 })
 
-export const completePaperProofReceipt = (
+export const makePaperProofReceipt = Pipeable.dual(3, makePaperProofReceiptDataFirst)
+
+const completePaperProofReceiptDataFirst = (
   context: PaperProofOperationContext,
   currentUtcInstant: Effect.Effect<string, Error>,
   input: PaperProofReceiptFields,
@@ -174,6 +187,8 @@ export const completePaperProofReceipt = (
   lift(context.command.operation, 'paper proof completion clock failed', currentUtcInstant).pipe(
     Effect.map((completedAt) => makePaperProofReceipt(context, completedAt, input)),
   )
+
+export const completePaperProofReceipt = Pipeable.dual(3, completePaperProofReceiptDataFirst)
 
 export const isSuccessfulSubmit = (event: MutationEvent): boolean =>
   event.operation === MutationOperation.Submit &&
@@ -188,8 +203,10 @@ export const isTerminalSubmit = (event: MutationEvent): boolean =>
 export const isRecoveredCancellation = (event: MutationEvent): boolean =>
   event.operation === MutationOperation.Cancel && event.eventType === MutationEventType.RecoveryFound
 
-export const isCancellationSettled = (event: MutationEvent, intent: PaperProofIntentSnapshot): boolean =>
+const isCancellationSettledDataFirst = (event: MutationEvent, intent: PaperProofIntentSnapshot): boolean =>
   isRecoveredCancellation(event) && intent.state === IntentState.Terminal && intent.terminalOutcome !== undefined
+
+export const isCancellationSettled = Pipeable.dual(2, isCancellationSettledDataFirst)
 
 export type SubmitAdmission =
   | {
@@ -200,7 +217,7 @@ export type SubmitAdmission =
       readonly event: MutationEvent
     }
 
-export const decideSubmitAdmission = (
+const decideSubmitAdmissionDataFirst = (
   cancellation: MutationEvent | undefined,
   existing: MutationEvent | undefined,
 ): Result.Result<SubmitAdmission, PaperProofError> => {
@@ -219,6 +236,8 @@ export const decideSubmitAdmission = (
     : Result.succeed({ _tag: 'Existing', event: existing })
 }
 
+export const decideSubmitAdmission = Pipeable.dual(2, decideSubmitAdmissionDataFirst)
+
 export type CancellationAdmission =
   | {
       readonly _tag: 'Existing'
@@ -228,7 +247,7 @@ export type CancellationAdmission =
       readonly _tag: 'New'
     }
 
-export const decideCancellationAdmission = (
+const decideCancellationAdmissionDataFirst = (
   existing: MutationEvent | undefined,
   submitted: MutationEvent | undefined,
   intent: PaperProofIntentSnapshot | undefined,
@@ -260,7 +279,9 @@ export const decideCancellationAdmission = (
   return Result.succeed({ _tag: 'New' })
 }
 
-export const sameMutationEvent = (left: MutationEvent, right: MutationEvent): boolean =>
+export const decideCancellationAdmission = Pipeable.dual(3, decideCancellationAdmissionDataFirst)
+
+const sameMutationEventDataFirst = (left: MutationEvent, right: MutationEvent): boolean =>
   left.schemaVersion === right.schemaVersion &&
   left.eventId === right.eventId &&
   left.mutationId === right.mutationId &&
@@ -276,6 +297,8 @@ export const sameMutationEvent = (left: MutationEvent, right: MutationEvent): bo
   left.responseContentHash === right.responseContentHash &&
   left.occurredAt === right.occurredAt
 
+export const sameMutationEvent = Pipeable.dual(2, sameMutationEventDataFirst)
+
 export interface DurableMutationState {
   readonly submit?: MutationEvent
   readonly cancel?: MutationEvent
@@ -284,12 +307,14 @@ export interface DurableMutationState {
 export const markerMutationOperation = (operation: PaperProofMutationOperation): MutationOperation =>
   operation === 'CANCEL' ? MutationOperation.Cancel : MutationOperation.Submit
 
-export const mutationForOperation = (
+const mutationForOperationDataFirst = (
   state: DurableMutationState,
   operation: PaperProofMutationOperation,
 ): MutationEvent | undefined => (operation === 'CANCEL' ? state.cancel : state.submit)
 
-export const selectRecoveryOperation = (
+export const mutationForOperation = Pipeable.dual(2, mutationForOperationDataFirst)
+
+const selectRecoveryOperationDataFirst = (
   state: DurableMutationState,
   required: PaperProofRecoveryRequired | undefined,
 ): PaperProofMutationOperation | undefined => {
@@ -298,7 +323,9 @@ export const selectRecoveryOperation = (
   return state.submit === undefined ? undefined : 'SUBMIT'
 }
 
-export const decideRecoverySelection = (
+export const selectRecoveryOperation = Pipeable.dual(2, selectRecoveryOperationDataFirst)
+
+const decideRecoverySelectionDataFirst = (
   state: DurableMutationState,
   required: PaperProofRecoveryRequired | undefined,
 ): Result.Result<
@@ -329,7 +356,9 @@ export const decideRecoverySelection = (
     : Result.succeed({ operation, recorded })
 }
 
-export const completionMatchesAuthoritativeMutation = (
+export const decideRecoverySelection = Pipeable.dual(2, decideRecoverySelectionDataFirst)
+
+const completionMatchesAuthoritativeMutationDataFirst = (
   state: DurableMutationState,
   completion: PaperProofRecoveryCompletion,
 ): boolean => {
@@ -338,7 +367,9 @@ export const completionMatchesAuthoritativeMutation = (
   return latest !== undefined && sameMutationEvent(latest, completion.mutation)
 }
 
-export const validateCompletionMutationIdentity = (
+export const completionMatchesAuthoritativeMutation = Pipeable.dual(2, completionMatchesAuthoritativeMutationDataFirst)
+
+const validateCompletionMutationIdentityDataFirst = (
   context: PaperProofOperationContext,
   completion: PaperProofRecoveryCompletion,
 ): Result.Result<void, PaperProofError> => {
@@ -356,7 +387,9 @@ export const validateCompletionMutationIdentity = (
       )
 }
 
-export const recoveryIdentityMatches = (
+export const validateCompletionMutationIdentity = Pipeable.dual(2, validateCompletionMutationIdentityDataFirst)
+
+const recoveryIdentityMatchesDataFirst = (
   context: PaperProofOperationContext,
   value: Pick<PaperProofRecoveryRequired, 'intentId' | 'proofPlanHash' | 'qualificationRunId'>,
 ): boolean =>
@@ -364,12 +397,14 @@ export const recoveryIdentityMatches = (
   value.proofPlanHash === context.command.proofPlanHash &&
   value.qualificationRunId === context.command.qualificationRunId
 
+export const recoveryIdentityMatches = Pipeable.dual(2, recoveryIdentityMatchesDataFirst)
+
 export interface PaperProofRecoveryMarkerDependencies {
   readonly recovery: Pick<PaperProofRecoveryStore, 'load' | 'markRequired'>
   readonly currentUtcInstant: Effect.Effect<string, Error>
 }
 
-export const ensureRecoveryMarkerCompatible = (
+const ensureRecoveryMarkerCompatibleDataFirst = (
   context: PaperProofOperationContext,
   dependencies: PaperProofRecoveryMarkerDependencies,
   operation: PaperProofMutationOperation,
@@ -406,7 +441,9 @@ export const ensureRecoveryMarkerCompatible = (
     }),
   )
 
-export const makeRecoveryRequired = (
+export const ensureRecoveryMarkerCompatible = Pipeable.dual(3, ensureRecoveryMarkerCompatibleDataFirst)
+
+const makeRecoveryRequiredDataFirst = (
   context: PaperProofOperationContext,
   operation: PaperProofMutationOperation,
   reason: string,
@@ -421,7 +458,9 @@ export const makeRecoveryRequired = (
   requiredAt,
 })
 
-export const markRecoveryRequired = (
+export const makeRecoveryRequired = Pipeable.dual(4, makeRecoveryRequiredDataFirst)
+
+const markRecoveryRequiredDataFirst = (
   context: PaperProofOperationContext,
   dependencies: PaperProofRecoveryMarkerDependencies,
   operation: PaperProofMutationOperation,
@@ -448,7 +487,9 @@ export const markRecoveryRequired = (
     }),
   )
 
-export const loadRecoveryRequired = (
+export const markRecoveryRequired = Pipeable.dual(4, markRecoveryRequiredDataFirst)
+
+const loadRecoveryRequiredDataFirst = (
   context: PaperProofOperationContext,
   recovery: Pick<PaperProofRecoveryStore, 'load'>,
 ): Effect.Effect<PaperProofRecoveryRequired | undefined, PaperProofError> =>
@@ -472,7 +513,9 @@ export const loadRecoveryRequired = (
     ),
   )
 
-export const loadRecoveryCompletion = (
+export const loadRecoveryRequired = Pipeable.dual(2, loadRecoveryRequiredDataFirst)
+
+const loadRecoveryCompletionDataFirst = (
   context: PaperProofOperationContext,
   recovery: Pick<PaperProofRecoveryStore, 'loadCompletion'>,
 ): Effect.Effect<PaperProofRecoveryCompletion | undefined, PaperProofError> =>
@@ -497,7 +540,9 @@ export const loadRecoveryCompletion = (
     }),
   )
 
-export const readPaperProofIntent = (
+export const loadRecoveryCompletion = Pipeable.dual(2, loadRecoveryCompletionDataFirst)
+
+const readPaperProofIntentDataFirst = (
   context: PaperProofOperationContext,
   operation: PaperProofError['operation'],
   readIntent: (intentId: string) => Effect.Effect<PaperProofIntentSnapshot | undefined, Error>,
@@ -510,7 +555,9 @@ export const readPaperProofIntent = (
     ),
   )
 
-export const readPaperProofMutation = (
+export const readPaperProofIntent = Pipeable.dual(3, readPaperProofIntentDataFirst)
+
+const readPaperProofMutationDataFirst = (
   context: PaperProofOperationContext,
   operation: PaperProofError['operation'],
   mutations: PaperProofMutationStore,
@@ -522,7 +569,9 @@ export const readPaperProofMutation = (
     mutations.latest(context.sourcePlan.intentId, mutationOperation),
   )
 
-export const readDurableMutationState = (
+export const readPaperProofMutation = Pipeable.dual(4, readPaperProofMutationDataFirst)
+
+const readDurableMutationStateDataFirst = (
   context: PaperProofOperationContext,
   operation: PaperProofError['operation'],
   mutations: PaperProofMutationStore,
@@ -536,7 +585,9 @@ export const readDurableMutationState = (
     }
   })
 
-export const recoverMutationLookup = (
+export const readDurableMutationState = Pipeable.dual(3, readDurableMutationStateDataFirst)
+
+const recoverMutationLookupDataFirst = (
   context: PaperProofOperationContext,
   operation: MutationOperation,
   recover: () => Effect.Effect<MutationEvent, Error>,
@@ -545,7 +596,9 @@ export const recoverMutationLookup = (
     Effect.andThen(lift('RECOVER', `paper proof lookup-only ${operation.toLowerCase()} recovery failed`, recover())),
   )
 
-export const makeRecoveryCompletion = (
+export const recoverMutationLookup = Pipeable.dual(3, recoverMutationLookupDataFirst)
+
+const makeRecoveryCompletionDataFirst = (
   context: PaperProofOperationContext,
   operation: PaperProofMutationOperation,
   receipt: PaperProofReceipt,
@@ -572,7 +625,9 @@ export const makeRecoveryCompletion = (
         completedAt: receipt.completedAt,
       })
 
-export const completeRecovery = (
+export const makeRecoveryCompletion = Pipeable.dual(3, makeRecoveryCompletionDataFirst)
+
+const completeRecoveryDataFirst = (
   context: PaperProofOperationContext,
   recovery: Pick<PaperProofRecoveryStore, 'complete'>,
   latestCancellation: (() => Effect.Effect<MutationEvent | undefined, Error>) | undefined,
@@ -613,7 +668,9 @@ export const completeRecovery = (
     )
   })
 
-export const persistRecoveryCompletion = (
+export const completeRecovery = Pipeable.dual(4, completeRecoveryDataFirst)
+
+const persistRecoveryCompletionDataFirst = (
   context: PaperProofOperationContext,
   dependencies: {
     readonly recovery: Pick<PaperProofRecoveryStore, 'complete'>
@@ -628,7 +685,9 @@ export const persistRecoveryCompletion = (
     ),
   )
 
-export const makeReceiptFromCompletion = (
+export const persistRecoveryCompletion = Pipeable.dual(4, persistRecoveryCompletionDataFirst)
+
+const makeReceiptFromCompletionDataFirst = (
   context: PaperProofOperationContext,
   completion: PaperProofRecoveryCompletion,
 ): PaperProofReceipt => ({
@@ -644,3 +703,5 @@ export const makeReceiptFromCompletion = (
   recoveryRequired: false,
   completedAt: completion.completedAt,
 })
+
+export const makeReceiptFromCompletion = Pipeable.dual(2, makeReceiptFromCompletionDataFirst)

--- a/services/bayn/src/paper-proof/prepare.ts
+++ b/services/bayn/src/paper-proof/prepare.ts
@@ -10,6 +10,7 @@ import {
 } from './operations'
 import { proofBinding } from './model'
 import type { PaperProofError, PaperProofReceipt, PaperProofReconciliation } from './model'
+import { Pipeable } from '../pipeable'
 
 export interface PaperProofPrepareDependencies {
   readonly prepareCapitalGrant: (proof: CapitalGrantProofBinding) => Effect.Effect<CapitalGrantGeneration, Error>
@@ -17,7 +18,7 @@ export interface PaperProofPrepareDependencies {
   readonly currentUtcInstant: Effect.Effect<string, Error>
 }
 
-export const runPaperProofPrepare = (
+const runPaperProofPrepareDataFirst = (
   context: PaperProofOperationContext<'PREPARE'>,
   dependencies: PaperProofPrepareDependencies,
 ): Effect.Effect<PaperProofReceipt, PaperProofError> =>
@@ -36,3 +37,5 @@ export const runPaperProofPrepare = (
     }
     return yield* completePaperProofReceipt(context, dependencies.currentUtcInstant, input)
   })
+
+export const runPaperProofPrepare = Pipeable.dual(2, runPaperProofPrepareDataFirst)

--- a/services/bayn/src/paper-proof/program.ts
+++ b/services/bayn/src/paper-proof/program.ts
@@ -26,6 +26,7 @@ import {
   type PaperProofRuntimeBinding,
   type PaperProofSourcePlan,
 } from './model'
+import { Pipeable } from '../pipeable'
 
 const malformedCommandContainmentIoTimeoutMs = 5_000
 const malformedCommandContainmentTotalTimeoutMs = 20_000
@@ -145,7 +146,7 @@ const withRecoveryFinalizer = <A>(
     ),
   )
 
-export const containMalformedPaperProofCommand = (
+const containMalformedPaperProofCommandDataFirst = (
   operation: PaperProofCommand['operation'] | 'GATE',
   accountId: string,
   dependencies: PaperProofContainmentDependencies,
@@ -173,6 +174,8 @@ export const containMalformedPaperProofCommand = (
         ),
     }),
   )
+
+export const containMalformedPaperProofCommand = Pipeable.dual(4, containMalformedPaperProofCommandDataFirst)
 
 const commandTimeout = (message: string): Effect.Effect<never, PaperProofError> =>
   Effect.fail(
@@ -268,7 +271,7 @@ const runValidatedPaperProof = (
   }
 }
 
-export const runPaperProof = (
+const runPaperProofDataFirst = (
   command: PaperProofCommand,
   dependencies: PaperProofDependencies,
 ): Effect.Effect<PaperProofReceipt, PaperProofError> => {
@@ -314,3 +317,5 @@ export const runPaperProof = (
     ),
   )
 }
+
+export const runPaperProof = Pipeable.dual(2, runPaperProofDataFirst)

--- a/services/bayn/src/paper-proof/recovery.ts
+++ b/services/bayn/src/paper-proof/recovery.ts
@@ -36,6 +36,7 @@ import type {
   PaperProofRecoveryCompletion,
   PaperProofRecoveryStore,
 } from './model'
+import { Pipeable } from '../pipeable'
 
 export interface PaperProofRecoverDependencies extends PaperProofRestrictionDependencies {
   readonly recovery: PaperProofRecoveryStore
@@ -155,7 +156,7 @@ const refreshCompletionAfterContainment = (
   })
 }
 
-export const runPaperProofRecover = (
+const runPaperProofRecoverDataFirst = (
   context: PaperProofOperationContext<'RECOVER'>,
   dependencies: PaperProofRecoverDependencies,
 ): Effect.Effect<PaperProofReceipt, PaperProofError> =>
@@ -187,3 +188,5 @@ export const runPaperProofRecover = (
     }
     return yield* recoverAuthoritativeMutation(context, dependencies, selection.operation, selection.recorded)
   })
+
+export const runPaperProofRecover = Pipeable.dual(2, runPaperProofRecoverDataFirst)

--- a/services/bayn/src/qualification-statistics/analysis.ts
+++ b/services/bayn/src/qualification-statistics/analysis.ts
@@ -21,6 +21,7 @@ import { isCanonicalOrder } from './ordering'
 import { calculateQualificationPower } from './power'
 import { buildCompleteBlocks } from './series'
 import { calculateWalkForward } from './walk-forward'
+import { Pipeable } from '../pipeable'
 
 export interface QualificationBoundTrialHistory {
   readonly candidateOrdinal: number
@@ -120,7 +121,7 @@ export const analyzeQualificationInput = (
     ),
   )
 
-export const analyzeQualificationAtOrdinal = (
+const analyzeQualificationAtOrdinalDataFirst = (
   series: QualificationSeries,
   policy: QualificationStatisticsPolicy,
   history: QualificationBoundTrialHistory,
@@ -142,9 +143,13 @@ export const analyzeQualificationAtOrdinal = (
   })
 }
 
-export const analyzeQualification = (
+export const analyzeQualificationAtOrdinal = Pipeable.dual(3, analyzeQualificationAtOrdinalDataFirst)
+
+const analyzeQualificationDataFirst = (
   series: QualificationSeries,
   policy: QualificationStatisticsPolicy,
   priorTrialRunIds: readonly string[],
 ): Result.Result<QualificationAnalysis, QualificationStatisticsFailure> =>
   analyzeQualificationInput({ series, policy, priorTrialRunIds })
+
+export const analyzeQualification = Pipeable.dual(3, analyzeQualificationDataFirst)

--- a/services/bayn/src/qualification-statistics/bootstrap.ts
+++ b/services/bayn/src/qualification-statistics/bootstrap.ts
@@ -11,6 +11,7 @@ import type {
 import { annualizedSharpe, mean, nearestRankLowerQuantile, roundStatistic } from './numerical-methods'
 import { qualificationTailCapacityForOrdinal } from './policy'
 import type { CompleteBlockWork } from './series'
+import { Pipeable } from '../pipeable'
 
 export const qualificationSelectedBenchmarkRule = {
   schemaVersion: 'bayn.qualification-selected-benchmark-rule.v1',
@@ -39,7 +40,7 @@ export const selectQualificationBenchmarkFromCashAdjustedSharpes = (
     ? { name: 'direct-volatility-timing', sharpe: sharpes.directVolatilityTiming }
     : { name: qualificationSelectedBenchmarkRule.tieBreak, sharpe: sharpes.buyAndHold }
 
-export const selectQualificationBenchmark = (
+const selectQualificationBenchmarkDataFirst = (
   observations: readonly QualificationObservation[],
   annualizationSessions: number,
 ): QualificationSelectedBenchmarkDecision => {
@@ -56,6 +57,8 @@ export const selectQualificationBenchmark = (
     directVolatilityTiming: directVolatility,
   })
 }
+
+export const selectQualificationBenchmark = Pipeable.dual(2, selectQualificationBenchmarkDataFirst)
 
 export interface QualificationSelectedBenchmarkBootstrapComparison {
   readonly schemaVersion: 'bayn.selected-benchmark-bootstrap-comparison.v1'
@@ -161,7 +164,7 @@ const sampleBlocks = (
       })),
     )
 
-export const runQualificationBootstrap = (
+const runQualificationBootstrapDataFirst = (
   series: QualificationSeries,
   blocks: readonly CompleteBlockWork[],
   policy: QualificationStatisticsPolicy,
@@ -277,7 +280,9 @@ export const runQualificationBootstrap = (
   )
 }
 
-export const runSelectedBenchmarkBootstrapComparison = (
+export const runQualificationBootstrap = Pipeable.dual(4, runQualificationBootstrapDataFirst)
+
+const runSelectedBenchmarkBootstrapComparisonDataFirst = (
   series: QualificationSeries,
   blocks: readonly CompleteBlockWork[],
   policy: QualificationStatisticsPolicy,
@@ -392,3 +397,8 @@ export const runSelectedBenchmarkBootstrapComparison = (
     }),
   )
 }
+
+export const runSelectedBenchmarkBootstrapComparison = Pipeable.dual(
+  4,
+  runSelectedBenchmarkBootstrapComparisonDataFirst,
+)

--- a/services/bayn/src/qualification-statistics/comparison.ts
+++ b/services/bayn/src/qualification-statistics/comparison.ts
@@ -14,6 +14,7 @@ import {
   calculateSelectedBenchmarkWalkForwardComparison,
   type QualificationSelectedBenchmarkWalkForwardComparison,
 } from './walk-forward'
+import { Pipeable } from '../pipeable'
 
 export interface QualificationSelectedBenchmarkComparisonAnalysis {
   readonly schemaVersion: 'bayn.selected-benchmark-comparison-analysis.v1'
@@ -26,7 +27,7 @@ export interface QualificationSelectedBenchmarkComparisonAnalysis {
   readonly analysisHash: string
 }
 
-export const analyzeSelectedBenchmarkComparison = (
+const analyzeSelectedBenchmarkComparisonDataFirst = (
   series: QualificationSeries,
   policy: QualificationStatisticsPolicy,
   priorTrialCount: number,
@@ -65,7 +66,9 @@ export const analyzeSelectedBenchmarkComparison = (
     ),
   )
 
-export const analyzeSelectedBenchmarkComparisonInput = (
+export const analyzeSelectedBenchmarkComparison = Pipeable.dual(3, analyzeSelectedBenchmarkComparisonDataFirst)
+
+const analyzeSelectedBenchmarkComparisonInputDataFirst = (
   series: unknown,
   policy: QualificationStatisticsPolicy,
   priorTrialCount: number,
@@ -75,3 +78,8 @@ export const analyzeSelectedBenchmarkComparisonInput = (
     Result.mapError(qualificationStatisticsSchemaFailure('series')),
     Result.flatMap((decoded) => analyzeSelectedBenchmarkComparison(decoded, policy, priorTrialCount)),
   )
+
+export const analyzeSelectedBenchmarkComparisonInput = Pipeable.dual(
+  3,
+  analyzeSelectedBenchmarkComparisonInputDataFirst,
+)

--- a/services/bayn/src/qualification-statistics/hashing.ts
+++ b/services/bayn/src/qualification-statistics/hashing.ts
@@ -2,13 +2,14 @@ import { pipe, Result } from 'effect'
 
 import { canonicalHashV1Result } from '../hash'
 import type { QualificationStatisticsFailure } from './failure'
+import { Pipeable } from '../pipeable'
 
 export type QualificationStatisticsHashOperation = Extract<
   QualificationStatisticsFailure,
   { readonly _tag: 'QualificationStatisticsCanonicalizationFailed' }
 >['operation']
 
-export const hashQualificationEvidence = (
+const hashQualificationEvidenceDataFirst = (
   operation: QualificationStatisticsHashOperation,
   value: unknown,
 ): Result.Result<string, QualificationStatisticsFailure> =>
@@ -22,3 +23,5 @@ export const hashQualificationEvidence = (
       }),
     ),
   )
+
+export const hashQualificationEvidence = Pipeable.dual(2, hashQualificationEvidenceDataFirst)

--- a/services/bayn/src/qualification-statistics/numerical-methods.ts
+++ b/services/bayn/src/qualification-statistics/numerical-methods.ts
@@ -1,6 +1,7 @@
 import { pipe, Result } from 'effect'
 
 import { statisticsFailure, type QualificationStatisticsFailure } from './failure'
+import { Pipeable } from '../pipeable'
 
 export const roundStatistic = (value: number): Result.Result<number, QualificationStatisticsFailure> =>
   Number.isFinite(value)
@@ -17,17 +18,21 @@ export const sampleStandardDeviation = (values: readonly number[]): number => {
   return Math.sqrt(Math.max(0, variance))
 }
 
-export const annualizedSharpe = (returns: readonly number[], annualizationSessions: number): number => {
+const annualizedSharpeDataFirst = (returns: readonly number[], annualizationSessions: number): number => {
   const volatility = sampleStandardDeviation(returns)
   return volatility === 0 ? 0 : (mean(returns) / volatility) * Math.sqrt(annualizationSessions)
 }
 
-export const nearestRankLowerQuantile = (values: readonly number[], probability: number): number => {
+export const annualizedSharpe = Pipeable.dual(2, annualizedSharpeDataFirst)
+
+const nearestRankLowerQuantileDataFirst = (values: readonly number[], probability: number): number => {
   if (values.length === 0) return 0
   const sorted = [...values].sort((left, right) => left - right)
   const rank = Math.max(1, Math.ceil(probability * sorted.length))
   return sorted.at(rank - 1) ?? 0
 }
+
+export const nearestRankLowerQuantile = Pipeable.dual(2, nearestRankLowerQuantileDataFirst)
 
 export const compoundedReturn = (returns: readonly number[]): number =>
   returns.reduce((growth, value) => growth * (1 + value), 1) - 1

--- a/services/bayn/src/qualification-statistics/ordering.ts
+++ b/services/bayn/src/qualification-statistics/ordering.ts
@@ -1,6 +1,7 @@
 import type { Schema } from 'effect'
+import { Pipeable } from '../pipeable'
 
-export const canonicalOrderIssues = (path: string, values: readonly string[]): readonly Schema.FilterIssue[] => {
+const canonicalOrderIssuesDataFirst = (path: string, values: readonly string[]): readonly Schema.FilterIssue[] => {
   const canonical = [...new Set(values)].sort()
   if (canonical.length !== values.length) return [{ path: [path], issue: 'must not contain duplicates' }]
   if (canonical.some((value, index) => value !== values.at(index))) {
@@ -8,6 +9,8 @@ export const canonicalOrderIssues = (path: string, values: readonly string[]): r
   }
   return []
 }
+
+export const canonicalOrderIssues = Pipeable.dual(2, canonicalOrderIssuesDataFirst)
 
 export const isCanonicalOrder = (values: readonly string[]): boolean =>
   canonicalOrderIssues('values', values).length === 0

--- a/services/bayn/src/qualification-statistics/policy.ts
+++ b/services/bayn/src/qualification-statistics/policy.ts
@@ -5,6 +5,7 @@ import {
   qualificationStatisticsMinimumBootstrapSamples,
   type QualificationStatisticsPolicy,
 } from './model'
+import { Pipeable } from '../pipeable'
 
 export const qualificationStatisticsPolicySchemaVersion = 'bayn.qualification-statistics-policy.v1' as const
 export const qualificationPolicyMaximumCandidateOrdinal = 25
@@ -153,7 +154,7 @@ export interface QualificationOrdinalTailCapacity {
   readonly minimumTailSamples: number
 }
 
-export const qualificationTailCapacityForOrdinal = (
+const qualificationTailCapacityForOrdinalDataFirst = (
   policy: QualificationStatisticsPolicy,
   candidateOrdinal: number,
 ): QualificationOrdinalTailCapacity => {
@@ -165,3 +166,5 @@ export const qualificationTailCapacityForOrdinal = (
     minimumTailSamples: policy.confidence.minimumTailSamples,
   }
 }
+
+export const qualificationTailCapacityForOrdinal = Pipeable.dual(2, qualificationTailCapacityForOrdinalDataFirst)

--- a/services/bayn/src/qualification-statistics/power.ts
+++ b/services/bayn/src/qualification-statistics/power.ts
@@ -8,6 +8,7 @@ import {
 import { statisticsFailure, type QualificationStatisticsFailure } from './failure'
 import type { PowerAnalysis, QualificationStatisticsPolicy } from './model'
 import { roundStatistic } from './numerical-methods'
+import { Pipeable } from '../pipeable'
 
 const Z_ONE_SIDED_95 = 1.6448536269514722
 const Z_POWER_80 = 0.8416212335729143
@@ -17,7 +18,7 @@ const finitePowerStatistic = (value: number): Result.Result<number, Qualificatio
     ? Result.succeed(value)
     : statisticsFailure({ _tag: 'QualificationStatisticNotFinite', operation: 'power', value })
 
-export const calculateQualificationPower = (
+const calculateQualificationPowerDataFirst = (
   policy: QualificationStatisticsPolicy,
   availableCompleteRebalanceBlocks: number,
   availableCompleteSessions: number,
@@ -67,3 +68,5 @@ export const calculateQualificationPower = (
       )
     }),
   )
+
+export const calculateQualificationPower = Pipeable.dual(3, calculateQualificationPowerDataFirst)

--- a/services/bayn/src/qualification-statistics/walk-forward.ts
+++ b/services/bayn/src/qualification-statistics/walk-forward.ts
@@ -5,6 +5,7 @@ import { statisticsFailure, type QualificationStatisticsFailure } from './failur
 import { hashQualificationEvidence } from './hashing'
 import type { QualificationSeries, QualificationStatisticsPolicy, WalkForwardAnalysis } from './model'
 import { compoundedReturn, maximumDrawdown, roundStatistic } from './numerical-methods'
+import { Pipeable } from '../pipeable'
 
 export interface QualificationSelectedBenchmarkWalkForwardFold {
   readonly schemaVersion: 'bayn.selected-benchmark-walk-forward-fold.v1'
@@ -37,7 +38,7 @@ export interface QualificationSelectedBenchmarkWalkForwardComparison {
   readonly sufficient: boolean
 }
 
-export const calculateWalkForward = (
+const calculateWalkForwardDataFirst = (
   series: QualificationSeries,
   policy: QualificationStatisticsPolicy,
 ): Result.Result<WalkForwardAnalysis, QualificationStatisticsFailure> => {
@@ -124,7 +125,9 @@ export const calculateWalkForward = (
   )
 }
 
-export const calculateSelectedBenchmarkWalkForwardComparison = (
+export const calculateWalkForward = Pipeable.dual(2, calculateWalkForwardDataFirst)
+
+const calculateSelectedBenchmarkWalkForwardComparisonDataFirst = (
   series: QualificationSeries,
   policy: QualificationStatisticsPolicy,
 ): Result.Result<QualificationSelectedBenchmarkWalkForwardComparison, QualificationStatisticsFailure> => {
@@ -214,3 +217,8 @@ export const calculateSelectedBenchmarkWalkForwardComparison = (
     }),
   )
 }
+
+export const calculateSelectedBenchmarkWalkForwardComparison = Pipeable.dual(
+  2,
+  calculateSelectedBenchmarkWalkForwardComparisonDataFirst,
+)

--- a/services/bayn/src/qualification/hashing.ts
+++ b/services/bayn/src/qualification/hashing.ts
@@ -2,13 +2,16 @@ import { pipe, Result } from 'effect'
 
 import { canonicalHashV1Result } from '../hash'
 import type { QualificationConstructionFailure } from './failure'
+import { Pipeable } from '../pipeable'
 
-export const canonicalHashMatches = (expected: string, value: unknown): boolean => {
+const canonicalHashMatchesDataFirst = (expected: string, value: unknown): boolean => {
   const result = canonicalHashV1Result(value)
   return Result.isSuccess(result) && result.success === expected
 }
 
-export const hashQualificationMaterial = (
+export const canonicalHashMatches = Pipeable.dual(2, canonicalHashMatchesDataFirst)
+
+const hashQualificationMaterialDataFirst = (
   operation: Extract<
     QualificationConstructionFailure,
     { readonly _tag: 'QualificationCanonicalizationFailed' }
@@ -25,3 +28,5 @@ export const hashQualificationMaterial = (
       }),
     ),
   )
+
+export const hashQualificationMaterial = Pipeable.dual(2, hashQualificationMaterialDataFirst)

--- a/services/bayn/src/qualification/policy.ts
+++ b/services/bayn/src/qualification/policy.ts
@@ -5,13 +5,14 @@ import { strictParseOptions } from '../schemas'
 import type { QualificationConstructionFailure } from './failure'
 import { hashQualificationMaterial } from './hashing'
 import { QualificationPolicyDocumentSchema, type QualificationPolicyDocument } from './model'
+import { Pipeable } from '../pipeable'
 
 const decodeQualificationPolicyDocument = Schema.decodeUnknownResult(
   QualificationPolicyDocumentSchema,
   strictParseOptions,
 )
 
-export const makeQualificationPolicyDocument = (
+const makeQualificationPolicyDocumentDataFirst = (
   schemaVersion: string,
   content: unknown,
 ): Result.Result<QualificationPolicyDocument, QualificationConstructionFailure> =>
@@ -30,6 +31,8 @@ export const makeQualificationPolicyDocument = (
       ),
     ),
   )
+
+export const makeQualificationPolicyDocument = Pipeable.dual(2, makeQualificationPolicyDocumentDataFirst)
 
 export const defaultQualificationStatisticsPolicyDocument = makeQualificationPolicyDocument(
   defaultQualificationStatisticsPolicy.schemaVersion,

--- a/services/bayn/src/qualification/result.ts
+++ b/services/bayn/src/qualification/result.ts
@@ -11,6 +11,7 @@ import {
   type QualificationLock,
   type QualificationResult,
 } from './model'
+import { Pipeable } from '../pipeable'
 
 const decodeQualificationResult = Schema.decodeUnknownResult(QualificationResultSchema, strictParseOptions)
 const QualificationPolicyBindingSchema = Schema.Struct({
@@ -102,9 +103,11 @@ const constructQualificationResult = (
   )
 }
 
-export const makeQualificationResult = (
+const makeQualificationResultDataFirst = (
   lock: QualificationLock,
   evaluationVerdict: EconomicVerdict,
   analysis: QualificationAnalysis,
 ): Result.Result<QualificationResult, QualificationConstructionFailure> =>
   constructQualificationResult({ lock, evaluationVerdict, analysis })
+
+export const makeQualificationResult = Pipeable.dual(3, makeQualificationResultDataFirst)

--- a/services/bayn/src/qualification/terminal.ts
+++ b/services/bayn/src/qualification/terminal.ts
@@ -1,6 +1,7 @@
 import { Result } from 'effect'
 
 import type { QualificationLock, QualificationResult } from './model'
+import { Pipeable } from '../pipeable'
 
 export type QualificationTerminalState =
   | { readonly state: 'PREREGISTERED'; readonly lock: QualificationLock }
@@ -27,7 +28,7 @@ export type QualificationTerminalConflict =
       readonly attemptedResultHash: string
     }
 
-export const decideQualificationTerminal = (
+const decideQualificationTerminalDataFirst = (
   current: QualificationTerminalState,
   attempted: QualificationResult,
 ): Result.Result<QualificationTerminalDecision, QualificationTerminalConflict> => {
@@ -56,3 +57,5 @@ export const decideQualificationTerminal = (
         attemptedResultHash: attempted.resultHash,
       })
 }
+
+export const decideQualificationTerminal = Pipeable.dual(2, decideQualificationTerminalDataFirst)

--- a/services/bayn/src/risk-balanced-trend/schema.ts
+++ b/services/bayn/src/risk-balanced-trend/schema.ts
@@ -5,6 +5,7 @@ import { ExecutionSessionBindingSchema, type ExecutionSessionBinding } from '../
 import { strictParseOptions } from '../schemas'
 import type { InputManifest, Protocol } from '../types'
 import type { RiskBalancedTrendFailure } from './model'
+import { Pipeable } from '../pipeable'
 
 const decodeManifestResult = Schema.decodeUnknownResult(InputManifestArtifactSchema, strictParseOptions)
 const decodeCycleBindingResult = Schema.decodeUnknownResult(ExecutionSessionBindingSchema, strictParseOptions)
@@ -18,7 +19,7 @@ export const decodeCurrentDecisionCycleBinding = (
     : Result.succeed(decoded.success)
 }
 
-export const parseMatchingManifest = (
+const parseMatchingManifestDataFirst = (
   input: unknown,
   protocol: Protocol,
 ): Result.Result<InputManifest, RiskBalancedTrendFailure> => {
@@ -64,3 +65,5 @@ export const parseMatchingManifest = (
   }
   return Result.succeed(manifest)
 }
+
+export const parseMatchingManifest = Pipeable.dual(2, parseMatchingManifestDataFirst)

--- a/services/bayn/src/simulation-reconciliation/broker-history.ts
+++ b/services/bayn/src/simulation-reconciliation/broker-history.ts
@@ -25,6 +25,7 @@ import {
   type ReconciliationError,
   type StableBrokerSnapshot,
 } from './broker-reconciler-model'
+import { Pipeable } from '../pipeable'
 
 interface OrderPaginationState {
   readonly rows: readonly Observed<BrokerOrder>[]
@@ -68,7 +69,7 @@ const initialOrderPaginationState = (): OrderPaginationState => ({
 
 const initialFillPaginationState = (): FillPaginationState => ({ rows: [], ids: HashSet.empty(), cursor: undefined })
 
-export const decideOrderPage = (
+const decideOrderPageDataFirst = (
   state: OrderPaginationState,
   limit: number,
   page: ReadResult<readonly BrokerOrder[]>,
@@ -161,7 +162,9 @@ export const decideOrderPage = (
   })
 }
 
-export const decideFillPage = (
+export const decideOrderPage = Pipeable.dual(3, decideOrderPageDataFirst)
+
+const decideFillPageDataFirst = (
   state: FillPaginationState,
   pageSize: number,
   page: ReadResult<{ readonly items: readonly FillActivity[]; readonly nextPageToken?: string }>,
@@ -196,6 +199,8 @@ export const decideFillPage = (
     state: { rows, ids: pageResult.success.ids, cursor: next },
   })
 }
+
+export const decideFillPage = Pipeable.dual(3, decideFillPageDataFirst)
 
 const readOrderPages = (
   read: BrokerReadShape,
@@ -277,7 +282,7 @@ const historyHashResult = (history: BrokerHistory): Result.Result<string, Histor
     ),
   )
 
-export const decideStableHistory = (
+const decideStableHistoryDataFirst = (
   before: BrokerHistory,
   after: BrokerHistory,
 ): Result.Result<BrokerHistory, ReconciliationError> =>
@@ -295,7 +300,9 @@ export const decideStableHistory = (
       : yield* Result.fail(snapshotFailure('HistoryChanged', 'broker history changed during reconciliation'))
   })
 
-export const readStableBrokerSnapshot = (
+export const decideStableHistory = Pipeable.dual(2, decideStableHistoryDataFirst)
+
+const readStableBrokerSnapshotDataFirst = (
   read: BrokerReadShape,
   now: Effect.Effect<string>,
 ): Effect.Effect<StableBrokerSnapshot, BrokerReadError | ReconciliationError> =>
@@ -308,3 +315,5 @@ export const readStableBrokerSnapshot = (
     const history = yield* Effect.fromResult(decideStableHistory(before, after))
     return { account, positions, history }
   })
+
+export const readStableBrokerSnapshot = Pipeable.dual(2, readStableBrokerSnapshotDataFirst)

--- a/services/bayn/src/simulation-reconciliation/broker-model.ts
+++ b/services/bayn/src/simulation-reconciliation/broker-model.ts
@@ -15,6 +15,7 @@ import {
 import { canonicalHashV1Result, type CanonicalHashFailure } from '../hash'
 import type { IsoDate } from '../schemas'
 import { roundUnsignedHalfUp } from '../unsigned-round-half-up'
+import { Pipeable } from '../pipeable'
 
 export interface IntentExpectation {
   readonly intentId: string
@@ -238,7 +239,7 @@ export const canonicalHash = (
 export const absolute = (value: bigint): bigint => (value < 0n ? -value : value)
 const canonicalIntegerPattern = /^(?:0|-?[1-9][0-9]*)$/
 
-export const integer = (
+const integerDataFirst = (
   source: ReconciliationIntegerSource,
   identity: string,
   value: string,
@@ -247,7 +248,9 @@ export const integer = (
     ? Result.succeed(BigInt(value))
     : fail({ _tag: 'InvalidInteger', source, identity, value })
 
-export const roundMicrosProduct = (
+export const integer = Pipeable.dual(3, integerDataFirst)
+
+const roundMicrosProductDataFirst = (
   symbol: string,
   quantityMicros: string,
   averageEntryPriceMicros: string,
@@ -273,6 +276,8 @@ export const roundMicrosProduct = (
     ),
   )
 
+export const roundMicrosProduct = Pipeable.dual(3, roundMicrosProductDataFirst)
+
 export const reconciledStateHash = (state: ReconciledStateMaterial): ReconciliationDecision<string> =>
   pipe(
     canonicalHash('broker-state-hash', {
@@ -292,7 +297,7 @@ export const reconciledStateHash = (state: ReconciledStateMaterial): Reconciliat
     ),
   )
 
-export const instant = (
+const instantDataFirst = (
   field: ReconciliationInstantField,
   identity: string,
   value: string,
@@ -302,6 +307,8 @@ export const instant = (
     ? Result.succeed(milliseconds)
     : fail({ _tag: 'InvalidInstant', field, identity, value })
 }
+
+export const instant = Pipeable.dual(3, instantDataFirst)
 
 export const indexUnique = <A>(
   values: readonly A[],
@@ -349,7 +356,7 @@ const discrepancy = (
         ),
       )
 
-export const compareValue = (
+const compareValueDataFirst = (
   accountId: string,
   kind: DiscrepancyKind,
   identity: string,
@@ -362,6 +369,8 @@ export const compareValue = (
         discrepancy(accountId, kind, identity, expected, observed),
         Result.map((value) => [value]),
       )
+
+export const compareValue = Pipeable.dual(5, compareValueDataFirst)
 
 export const renderReconciliationDecisionError = (error: ReconciliationDecisionError): string => {
   switch (error._tag) {

--- a/services/bayn/src/simulation-reconciliation/broker-normalization.ts
+++ b/services/bayn/src/simulation-reconciliation/broker-normalization.ts
@@ -23,6 +23,7 @@ import {
   type ReconciliationError,
   type StableBrokerSnapshot,
 } from './broker-reconciler-model'
+import { Pipeable } from '../pipeable'
 
 const indexBindings = (
   bindings: readonly IntentBinding[],
@@ -143,7 +144,7 @@ const normalizePositions = (
 ): Result.Result<PositionSnapshotInput, ReconciliationError> =>
   mapObservationFailure('positions', accountId, positionSnapshot(accountId, positions))
 
-export const normalizeSnapshot = (
+const normalizeSnapshotDataFirst = (
   snapshot: StableBrokerSnapshot,
   bindings: readonly IntentBinding[],
 ): Result.Result<NormalizedBrokerSnapshot, ReconciliationError> =>
@@ -156,6 +157,8 @@ export const normalizeSnapshot = (
     return { account, positions, orderEvents: Chunk.toReadonlyArray(orders.events), fillEvents }
   })
 
+export const normalizeSnapshot = Pipeable.dual(2, normalizeSnapshotDataFirst)
+
 export const decideAccountBaseline = (hasAccountBaseline: boolean): Result.Result<void, ReconciliationError> =>
   hasAccountBaseline
     ? Result.succeed(undefined)
@@ -166,7 +169,7 @@ export const decideAccountBaseline = (hasAccountBaseline: boolean): Result.Resul
         ),
       )
 
-export const prepareNormalizedSnapshot = (store: ReconciliationPersistence, snapshot: StableBrokerSnapshot) =>
+const prepareNormalizedSnapshotDataFirst = (store: ReconciliationPersistence, snapshot: StableBrokerSnapshot) =>
   Effect.gen(function* () {
     const bindings = yield* store.reconciliation.bindings(snapshot.account.value.id)
     if (snapshot.history.fills.length > 0) {
@@ -175,3 +178,5 @@ export const prepareNormalizedSnapshot = (store: ReconciliationPersistence, snap
     }
     return yield* Effect.fromResult(normalizeSnapshot(snapshot, bindings))
   })
+
+export const prepareNormalizedSnapshot = Pipeable.dual(2, prepareNormalizedSnapshotDataFirst)

--- a/services/bayn/src/simulation-reconciliation/broker-persistence.ts
+++ b/services/bayn/src/simulation-reconciliation/broker-persistence.ts
@@ -11,6 +11,7 @@ import {
   type StableBrokerSnapshot,
 } from './broker-reconciler-model'
 import { prepareNormalizedSnapshot } from './broker-normalization'
+import { Pipeable } from '../pipeable'
 
 const ingestBrokerEvents = (store: ReconciliationPersistence, normalized: NormalizedBrokerSnapshot) =>
   Effect.gen(function* () {
@@ -109,7 +110,7 @@ const writeReconciliation = (
     return result
   })
 
-export const persistStableSnapshot = (
+const persistStableSnapshotDataFirst = (
   store: ReconciliationPersistence,
   fence: WriterFenceService,
   snapshot: StableBrokerSnapshot,
@@ -120,3 +121,5 @@ export const persistStableSnapshot = (
       Effect.flatMap((normalized) => writeReconciliation(store, normalized, snapshot.history.orders.observedAt, now)),
     ),
   )
+
+export const persistStableSnapshot = Pipeable.dual(4, persistStableSnapshotDataFirst)

--- a/services/bayn/src/simulation-reconciliation/broker-reconciler-model.ts
+++ b/services/bayn/src/simulation-reconciliation/broker-reconciler-model.ts
@@ -22,6 +22,7 @@ import type { BrokerSnapshot, ReconciliationReport } from '../db/reconciliation'
 import type { WriterFenceError } from '../execution/writer-fence'
 import type { CanonicalHashFailure } from '../hash'
 import type { ReconciledBrokerState, ReconciliationRiskContext } from '../reconciliation'
+import { Pipeable } from '../pipeable'
 
 export const maximumRows = 10_000
 export const ordersPageSize = 500
@@ -126,13 +127,17 @@ export class ReconciliationError extends Data.TaggedError('ReconciliationError')
 
 export type ReconciliationPassError = BrokerReadError | ExecutionStoreError | ReconciliationError | WriterFenceError
 
-export const paginationFailure = (reason: PaginationFailureReason, message: string): ReconciliationError =>
+const paginationFailureDataFirst = (reason: PaginationFailureReason, message: string): ReconciliationError =>
   new ReconciliationError({ operation: 'pagination', message, failure: { _tag: 'Pagination', reason } })
 
-export const snapshotFailure = (reason: SnapshotFailureReason, message: string): ReconciliationError =>
+export const paginationFailure = Pipeable.dual(2, paginationFailureDataFirst)
+
+const snapshotFailureDataFirst = (reason: SnapshotFailureReason, message: string): ReconciliationError =>
   new ReconciliationError({ operation: 'snapshot', message, failure: { _tag: 'Snapshot', reason } })
 
-export const historyHashFailure = (side: HistorySnapshotSide, error: HistoryHashFailure): ReconciliationError =>
+export const snapshotFailure = Pipeable.dual(2, snapshotFailureDataFirst)
+
+const historyHashFailureDataFirst = (side: HistorySnapshotSide, error: HistoryHashFailure): ReconciliationError =>
   new ReconciliationError({
     operation: 'snapshot',
     message:
@@ -143,12 +148,16 @@ export const historyHashFailure = (side: HistorySnapshotSide, error: HistoryHash
     failure: { _tag: 'HistoryHash', side, error },
   })
 
-export const validationFailure = (reason: ValidationFailureReason, detail: string): ReconciliationError =>
+export const historyHashFailure = Pipeable.dual(2, historyHashFailureDataFirst)
+
+const validationFailureDataFirst = (reason: ValidationFailureReason, detail: string): ReconciliationError =>
   new ReconciliationError({
     operation: 'normalization',
     message: detail,
     failure: { _tag: 'Validation', reason, detail },
   })
+
+export const validationFailure = Pipeable.dual(2, validationFailureDataFirst)
 
 const normalizationFailure = (
   stage: NormalizationStage,
@@ -177,10 +186,14 @@ export const mapObservationFailure = <A>(
     Result.mapError((error) => normalizationFailure(stage, identity, error)),
   )
 
-export const normalizeTimestamp = (
+const normalizeTimestampDataFirst = (
   stage: Extract<NormalizationStage, 'order-timestamp' | 'fill-ordering'>,
   identity: string,
   value: string,
 ): Result.Result<string, ReconciliationError> => mapObservationFailure(stage, identity, sourceTimestamp(value))
 
-export const compareText = (left: string, right: string): number => (left < right ? -1 : left > right ? 1 : 0)
+export const normalizeTimestamp = Pipeable.dual(3, normalizeTimestampDataFirst)
+
+const compareTextDataFirst = (left: string, right: string): number => (left < right ? -1 : left > right ? 1 : 0)
+
+export const compareText = Pipeable.dual(2, compareTextDataFirst)

--- a/services/bayn/src/simulation-reconciliation/fee-validation.ts
+++ b/services/bayn/src/simulation-reconciliation/fee-validation.ts
@@ -4,6 +4,7 @@ import { calculateSessionFees, type FeeBreakdown, type FeeInput } from '../execu
 import type { FeeEvent, SimulationTrace } from '../types'
 import type { EvidenceMismatchProblem, FailedComputation, SimulationReconciliationIssue, Validation } from './model'
 import { fail, failIssues, unsigned, validateCanonicalIdentity, type ValidatedFill } from './validation'
+import { Pipeable } from '../pipeable'
 
 export interface ValidatedFee {
   readonly kind: 'fee'
@@ -32,7 +33,7 @@ const feeSchedule = (
   )
 }
 
-export const validateFee = (
+const validateFeeDataFirst = (
   runId: string,
   fee: FeeEvent,
   sessionFills: readonly ValidatedFill[],
@@ -105,3 +106,5 @@ export const validateFee = (
     ? failIssues(identity.failure)
     : Result.succeed({ kind: 'fee', event: fee, totalMicros: total.success })
 }
+
+export const validateFee = Pipeable.dual(5, validateFeeDataFirst)

--- a/services/bayn/src/simulation-reconciliation/mark-validation.ts
+++ b/services/bayn/src/simulation-reconciliation/mark-validation.ts
@@ -3,8 +3,9 @@ import { pipe, Result } from 'effect'
 import type { CashChange, CashYieldEvent, DailyPositionMark, FeeEvent, FillEvent } from '../types'
 import type { EvidenceMismatchProblem, SimulationReconciliationIssue, Validation } from './model'
 import { fail, failIssues, signed, validateCanonicalIdentity } from './validation'
+import { Pipeable } from '../pipeable'
 
-export const validateCashChange = (
+const validateCashChangeDataFirst = (
   runId: string,
   change: CashChange,
   event: FillEvent | FeeEvent | CashYieldEvent,
@@ -57,6 +58,8 @@ export const validateCashChange = (
     { runId, kind: 'cash-change', ...payload },
   )
 }
+
+export const validateCashChange = Pipeable.dual(5, validateCashChangeDataFirst)
 
 const validateMark = (mark: DailyPositionMark, previous: DailyPositionMark | undefined): Validation<void> => {
   if (previous !== undefined && previous.sessionDate >= mark.sessionDate) {

--- a/services/bayn/src/simulation-reconciliation/reconstruction-events.ts
+++ b/services/bayn/src/simulation-reconciliation/reconstruction-events.ts
@@ -6,6 +6,7 @@ import { validateCashChange } from './mark-validation'
 import type { FailedComputation, SimulationReconciliationIssue, Validation } from './model'
 import type { PreparedFee, PreparedFill, PreparedMonetaryEvent, PreparedReconciliation } from './preparation'
 import { fail, failIssues, unsigned, validateCanonicalIdentity } from './validation'
+import { Pipeable } from '../pipeable'
 
 export interface ReconstructionState {
   readonly cashMicros: bigint
@@ -157,7 +158,7 @@ const updateQuantities = (
   )
 }
 
-export const applyEvent = (
+const applyEventDataFirst = (
   prepared: PreparedReconciliation,
   state: ReconstructionState,
   preparedEvent: PreparedMonetaryEvent,
@@ -197,3 +198,5 @@ export const applyEvent = (
     cumulativeCashYieldMicros: state.cumulativeCashYieldMicros + transition.success.cashYieldMicros,
   })
 }
+
+export const applyEvent = Pipeable.dual(3, applyEventDataFirst)

--- a/services/bayn/src/simulation-reconciliation/reconstruction-marks.ts
+++ b/services/bayn/src/simulation-reconciliation/reconstruction-marks.ts
@@ -6,6 +6,7 @@ import type { EvidenceMismatchProblem, SimulationReconciliationIssue, Validation
 import type { PreparedReconciliation } from './preparation'
 import { applyEvent, type ReconstructionState } from './reconstruction-events'
 import { absolute, fail, failIssues, markUnsigned, positionUnsigned } from './validation'
+import { Pipeable } from '../pipeable'
 
 interface MarkBaselines {
   readonly turnoverMicros: bigint
@@ -271,7 +272,7 @@ const reconcileDailyMark = (
   })
 }
 
-export const reconcileAllMarks = (
+const reconcileAllMarksDataFirst = (
   prepared: PreparedReconciliation,
   initial: ReconstructionState,
 ): Validation<ReconstructionState> =>
@@ -283,3 +284,5 @@ export const reconcileAllMarks = (
       ),
     Result.succeed(initial),
   )
+
+export const reconcileAllMarks = Pipeable.dual(2, reconcileAllMarksDataFirst)

--- a/services/bayn/src/simulation-reconciliation/validation.ts
+++ b/services/bayn/src/simulation-reconciliation/validation.ts
@@ -16,6 +16,7 @@ import {
   type UnsignedIntegerEvidence,
   type Validation,
 } from './model'
+import { Pipeable } from '../pipeable'
 
 export const failIssues = <A = never>(issues: readonly SimulationReconciliationIssue[]): Validation<A> =>
   Result.fail(issues)
@@ -60,15 +61,19 @@ const orderUnsigned = (order: SimulatedOrder, field: OrderIntegerField): Validat
 const fillUnsigned = (fill: FillEvent, field: FillIntegerField): Validation<bigint> =>
   unsigned({ kind: 'fill', fillId: fill.id, field, value: fill[field] })
 
-export const markUnsigned = (mark: DailyPositionMark, field: MarkIntegerField): Validation<bigint> =>
+const markUnsignedDataFirst = (mark: DailyPositionMark, field: MarkIntegerField): Validation<bigint> =>
   unsigned({ kind: 'daily-mark', sessionDate: mark.sessionDate, field, value: mark[field] })
 
-export const positionUnsigned = (
+export const markUnsigned = Pipeable.dual(2, markUnsignedDataFirst)
+
+const positionUnsignedDataFirst = (
   mark: DailyPositionMark,
   position: DailyPositionMark['positions'][number],
   field: PositionIntegerField,
 ): Validation<bigint> =>
   unsigned({ kind: 'position', sessionDate: mark.sessionDate, symbol: position.symbol, field, value: position[field] })
+
+export const positionUnsigned = Pipeable.dual(3, positionUnsignedDataFirst)
 
 export const absolute = (value: bigint): bigint => (value < 0n ? -value : value)
 
@@ -100,7 +105,10 @@ const invalidCanonicalIdentity = (
 const validateIdentityFormat = (evidence: IdentityEvidence): Validation<void> =>
   /^[0-9a-f]{64}$/.test(evidence.id) ? Result.succeed(undefined) : invalidIdentityFormat(evidence)
 
-export const validateCanonicalIdentity = (evidence: CanonicalIdentityEvidence, material: unknown): Validation<void> => {
+const validateCanonicalIdentityDataFirst = (
+  evidence: CanonicalIdentityEvidence,
+  material: unknown,
+): Validation<void> => {
   const expectedResult = Result.mapError(
     canonicalHashV1Result(material),
     (cause): readonly SimulationReconciliationIssue[] => [
@@ -119,6 +127,8 @@ export const validateCanonicalIdentity = (evidence: CanonicalIdentityEvidence, m
         expected: expectedResult.success,
       })
 }
+
+export const validateCanonicalIdentity = Pipeable.dual(2, validateCanonicalIdentityDataFirst)
 
 type IndexedIdentity = CanonicalIdentityEvidence
 
@@ -166,13 +176,15 @@ export const groupValuesBy = <A>(
   return grouped
 }
 
-export const validateDecisionIdentity = (runId: string, decision: DecisionEvent): Validation<void> => {
+const validateDecisionIdentityDataFirst = (runId: string, decision: DecisionEvent): Validation<void> => {
   const { id: _, kind: __, ...payload } = decision
   return validateCanonicalIdentity(
     { kind: 'decision', id: decision.id, signalDate: decision.signalDate },
     { runId, kind: 'decision', ...payload },
   )
 }
+
+export const validateDecisionIdentity = Pipeable.dual(2, validateDecisionIdentityDataFirst)
 
 const fillBindingIssue = (
   fill: FillEvent,
@@ -335,7 +347,7 @@ const invalidOrder = (
     },
   })
 
-export const validateOrder = (
+const validateOrderDataFirst = (
   runId: string,
   order: SimulatedOrder,
   fill: FillEvent | undefined,
@@ -401,3 +413,5 @@ export const validateOrder = (
     ? Result.succeed(undefined)
     : validateFill(runId, fill, order, filled.success, simulation, costMultiplierMicros)
 }
+
+export const validateOrder = Pipeable.dual(6, validateOrderDataFirst)

--- a/services/bayn/src/simulation/evidence.ts
+++ b/services/bayn/src/simulation/evidence.ts
@@ -20,16 +20,19 @@ import {
 import type { AlignedSession, PreparedOrder, SimulationFailure, SimulationInput, SimulationTarget } from './model'
 import { canonicalHashResult } from './inputs'
 import type { PreparedFill, SimulationState } from './state'
+import { Pipeable } from '../pipeable'
 
 const fail = <A = never>(failure: SimulationFailure): Result.Result<A, SimulationFailure> => Result.fail(failure)
 
-export const parseMicros = (
+const parseMicrosDataFirst = (
   value: string,
   field: Extract<SimulationFailure, { readonly _tag: 'InvalidMicrosString' }>['field'],
 ): Result.Result<bigint, SimulationFailure> =>
   /^[0-9]+$/.test(value) ? Result.succeed(BigInt(value)) : fail({ _tag: 'InvalidMicrosString', field, value })
 
-export const makeDecision = (
+export const parseMicros = Pipeable.dual(2, parseMicrosDataFirst)
+
+const makeDecisionDataFirst = (
   runId: string,
   target: SimulationTarget,
   signalDate: IsoDate,
@@ -46,6 +49,8 @@ export const makeDecision = (
     Result.map((id) => ({ kind: 'decision' as const, id, ...payload })),
   )
 }
+
+export const makeDecision = Pipeable.dual(4, makeDecisionDataFirst)
 
 export const makeOrder = (
   runId: string,
@@ -96,7 +101,7 @@ export const makeOrder = (
     }),
   )
 
-export const limitOrderFillToBuyingPower = (
+const limitOrderFillToBuyingPowerDataFirst = (
   runId: string,
   order: PreparedOrder,
   filledQuantityMicros: bigint,
@@ -128,7 +133,9 @@ export const limitOrderFillToBuyingPower = (
   )
 }
 
-export const makeFill = (
+export const limitOrderFillToBuyingPower = Pipeable.dual(3, limitOrderFillToBuyingPowerDataFirst)
+
+const makeFillDataFirst = (
   runId: string,
   decision: DecisionEvent,
   order: PreparedOrder,
@@ -159,7 +166,9 @@ export const makeFill = (
   )
 }
 
-export const makeCashChange = (
+export const makeFill = Pipeable.dual(5, makeFillDataFirst)
+
+const makeCashChangeDataFirst = (
   runId: string,
   source:
     | Pick<FillEvent | FeeEvent, 'kind' | 'id' | 'sessionDate'>
@@ -180,7 +189,9 @@ export const makeCashChange = (
   )
 }
 
-export const makeFeeEvent = (
+export const makeCashChange = Pipeable.dual(4, makeCashChangeDataFirst)
+
+const makeFeeEventDataFirst = (
   runId: string,
   sessionDate: IsoDate,
   fees: FeeBreakdown,
@@ -199,6 +210,8 @@ export const makeFeeEvent = (
   )
 }
 
+export const makeFeeEvent = Pipeable.dual(3, makeFeeEventDataFirst)
+
 const makeCashYieldEvent = (
   runId: string,
   sessionDate: IsoDate,
@@ -213,7 +226,7 @@ const makeCashYieldEvent = (
   )
 }
 
-export const appendFillEvidence = (
+const appendFillEvidenceDataFirst = (
   state: SimulationState,
   fill: PreparedFill,
   amountMicros: bigint,
@@ -231,10 +244,14 @@ export const appendFillEvidence = (
       )
     : Result.succeed(state)
 
-export const appendOrder = (state: SimulationState, order: PreparedOrder, recordEvents: boolean): SimulationState =>
+export const appendFillEvidence = Pipeable.dual(5, appendFillEvidenceDataFirst)
+
+const appendOrderDataFirst = (state: SimulationState, order: PreparedOrder, recordEvents: boolean): SimulationState =>
   recordEvents ? { ...state, orders: Chunk.append(state.orders, order.event) } : state
 
-export const recordDecision = (
+export const appendOrder = Pipeable.dual(3, appendOrderDataFirst)
+
+const recordDecisionDataFirst = (
   state: SimulationState,
   target: SimulationTarget,
   decision: DecisionEvent,
@@ -276,7 +293,9 @@ export const recordDecision = (
   )
 }
 
-export const accrueSessionCash = (
+export const recordDecision = Pipeable.dual(4, recordDecisionDataFirst)
+
+const accrueSessionCashDataFirst = (
   state: SimulationState,
   session: AlignedSession,
   input: SimulationInput,
@@ -324,3 +343,5 @@ export const accrueSessionCash = (
     ),
   )
 }
+
+export const accrueSessionCash = Pipeable.dual(3, accrueSessionCashDataFirst)

--- a/services/bayn/src/simulation/inputs.ts
+++ b/services/bayn/src/simulation/inputs.ts
@@ -5,6 +5,7 @@ import { canonicalHashV1Result } from '../hash'
 import { ContractVersion, type DailyBar, type InputManifest, type IsoDate, type Protocol } from '../types'
 import type { AlignedSession, EvaluationIdentity, EvaluationWindow, SimulationFailure } from './model'
 import { optionalRecordValue } from './record'
+import { Pipeable } from '../pipeable'
 
 const fail = <A = never>(failure: SimulationFailure): Result.Result<A, SimulationFailure> => Result.fail(failure)
 
@@ -53,7 +54,7 @@ const groupedBars = (bars: readonly DailyBar[]): readonly (readonly DailyBar[])[
   return Chunk.toReadonlyArray(groups).map(Chunk.toReadonlyArray)
 }
 
-export const canonicalHashResult = (
+const canonicalHashResultDataFirst = (
   operation: CanonicalOperation,
   material: unknown,
 ): Result.Result<string, SimulationFailure> =>
@@ -62,7 +63,9 @@ export const canonicalHashResult = (
     Result.mapError((cause): SimulationFailure => ({ _tag: 'CanonicalizationFailed', operation, cause })),
   )
 
-export const requiredSession = (
+export const canonicalHashResult = Pipeable.dual(2, canonicalHashResultDataFirst)
+
+const requiredSessionDataFirst = (
   sessions: readonly AlignedSession[],
   index: number,
   operation: SessionOperation,
@@ -72,6 +75,8 @@ export const requiredSession = (
     ? fail({ _tag: 'MissingSession', operation, index, sessionCount: sessions.length })
     : Result.succeed(session)
 }
+
+export const requiredSession = Pipeable.dual(3, requiredSessionDataFirst)
 
 export const requiredRecordValue = <A>(
   values: Readonly<Record<string, A>>,
@@ -121,7 +126,7 @@ const buildAlignedSession = (
   })
 }
 
-export const alignBars = (
+const alignBarsDataFirst = (
   bars: readonly DailyBar[],
   universe: readonly string[],
   inputManifest: InputManifest,
@@ -181,7 +186,9 @@ export const alignBars = (
   return sessions
 }
 
-export const isMonthEnd = (
+export const alignBars = Pipeable.dual(3, alignBarsDataFirst)
+
+const isMonthEndDataFirst = (
   sessionDates: readonly IsoDate[],
   index: number,
 ): Result.Result<boolean, SimulationFailure> => {
@@ -198,6 +205,8 @@ export const isMonthEnd = (
   return Result.succeed(next !== undefined && current.slice(0, 7) !== next.slice(0, 7))
 }
 
+export const isMonthEnd = Pipeable.dual(2, isMonthEndDataFirst)
+
 const qualificationCalendarFailure = (
   sessionDates: readonly IsoDate[],
   inputManifest: InputManifest,
@@ -211,7 +220,7 @@ const qualificationCalendarFailure = (
   observedLast: sessionDates.at(-1) ?? null,
 })
 
-export const selectEvaluationWindow = (
+const selectEvaluationWindowDataFirst = (
   sessionDates: readonly IsoDate[],
   inputManifest: InputManifest,
   requiredHistorySessions: number,
@@ -283,6 +292,8 @@ export const selectEvaluationWindow = (
   }
   return Result.succeed({ signalIndices, startIndex, evaluationEndExclusive: boundedEnd })
 }
+
+export const selectEvaluationWindow = Pipeable.dual(4, selectEvaluationWindowDataFirst)
 
 export const makeEvaluationIdentity = (
   inputManifest: InputManifest,

--- a/services/bayn/src/simulation/metrics.ts
+++ b/services/bayn/src/simulation/metrics.ts
@@ -5,6 +5,7 @@ import { DIRECT_VOLATILITY_WINDOW } from '../protocol'
 import type { EconomicVerdict, GateResult, PerformanceMetrics, SimulationProtocol } from '../types'
 import { requiredRecordValue, requiredSession } from './inputs'
 import type { AlignedSession, SimulationFailure } from './model'
+import { Pipeable } from '../pipeable'
 
 const fail = <A = never>(failure: SimulationFailure): Result.Result<A, SimulationFailure> => Result.fail(failure)
 
@@ -100,7 +101,7 @@ const directVolatilityReturn = (
     ),
   )
 
-export const directVolatilityWeights = (
+const directVolatilityWeightsDataFirst = (
   sessions: readonly AlignedSession[],
   signalIndex: number,
   protocol: SimulationProtocol,
@@ -125,7 +126,9 @@ export const directVolatilityWeights = (
   )
 }
 
-export const calculatePerformanceMetrics = (
+export const directVolatilityWeights = Pipeable.dual(3, directVolatilityWeightsDataFirst)
+
+const calculatePerformanceMetricsDataFirst = (
   equity: readonly number[],
   turnover: number,
   totalFees: number,
@@ -238,7 +241,9 @@ export const calculatePerformanceMetrics = (
   )
 }
 
-export const calculateExactPerformanceMetrics = (
+export const calculatePerformanceMetrics = Pipeable.dual(4, calculatePerformanceMetricsDataFirst)
+
+const calculateExactPerformanceMetricsDataFirst = (
   equityMicros: readonly bigint[],
   turnoverMicros: bigint,
   totalFeesMicros: bigint,
@@ -274,7 +279,9 @@ export const calculateExactPerformanceMetrics = (
   )
 }
 
-export const buildVerdict = (
+export const calculateExactPerformanceMetrics = Pipeable.dual(7, calculateExactPerformanceMetricsDataFirst)
+
+const buildVerdictDataFirst = (
   strategy: PerformanceMetrics,
   buyAndHold: PerformanceMetrics,
   directVolTiming: PerformanceMetrics,
@@ -331,3 +338,5 @@ export const buildVerdict = (
   ]
   return { status: gates.every((gate) => gate.passed) ? 'PASS' : 'FAIL_CLOSED', gates }
 }
+
+export const buildVerdict = Pipeable.dual(5, buildVerdictDataFirst)

--- a/services/bayn/src/simulation/rebalance.ts
+++ b/services/bayn/src/simulation/rebalance.ts
@@ -35,6 +35,7 @@ import {
   type TradeCandidate,
 } from './state'
 import { positionValueMicros, referencePricesFor } from './valuation'
+import { Pipeable } from '../pipeable'
 
 const fail = <A = never>(failure: SimulationFailure): Result.Result<A, SimulationFailure> => Result.fail(failure)
 
@@ -624,7 +625,7 @@ const executeRebalanceOrders = (context: RebalanceOrders): Result.Result<Simulat
   )
 }
 
-export const rebalanceSession = (
+const rebalanceSessionDataFirst = (
   state: SimulationState,
   session: AlignedSession,
   target: SimulationTarget,
@@ -637,3 +638,5 @@ export const rebalanceSession = (
     Result.flatMap(planRebalanceOrders),
     Result.flatMap(executeRebalanceOrders),
   )
+
+export const rebalanceSession = Pipeable.dual(5, rebalanceSessionDataFirst)

--- a/services/bayn/src/simulation/state.ts
+++ b/services/bayn/src/simulation/state.ts
@@ -13,6 +13,7 @@ import type {
 } from '../types'
 import type { SimulationFailure } from './model'
 import { optionalRecordValue } from './record'
+import { Pipeable } from '../pipeable'
 
 export interface Position {
   readonly quantityMicros: bigint
@@ -69,7 +70,7 @@ export interface TradeCandidate {
 
 const zeroPosition: Position = { quantityMicros: 0n, costBasisMicros: 0n }
 
-export const positionFor = (
+const positionForDataFirst = (
   positions: Readonly<Record<string, Position>>,
   symbol: string,
 ): Result.Result<Position, SimulationFailure> =>
@@ -78,11 +79,15 @@ export const positionFor = (
     Result.map(Option.getOrElse(() => zeroPosition)),
   )
 
-export const updatePosition = (
+export const positionFor = Pipeable.dual(2, positionForDataFirst)
+
+const updatePositionDataFirst = (
   positions: Readonly<Record<string, Position>>,
   symbol: string,
   position: Position,
 ): Readonly<Record<string, Position>> => ({ ...positions, [symbol]: position })
+
+export const updatePosition = Pipeable.dual(3, updatePositionDataFirst)
 
 export const initialState = (initialCapitalMicros: bigint): SimulationState => ({
   initialCapitalMicros,

--- a/services/bayn/src/simulation/valuation.ts
+++ b/services/bayn/src/simulation/valuation.ts
@@ -5,10 +5,11 @@ import type { DailyBar, DailyPerformancePoint, DailyPositionMark, SimulationProt
 import type { AlignedSession, SimulationFailure, SimulationInput } from './model'
 import { requiredRecordValue } from './inputs'
 import { positionFor, type Position, type SessionOpeningSnapshot, type SimulationState } from './state'
+import { Pipeable } from '../pipeable'
 
 const fail = <A = never>(failure: SimulationFailure): Result.Result<A, SimulationFailure> => Result.fail(failure)
 
-export const referencePricesFor = (
+const referencePricesForDataFirst = (
   bars: Readonly<Record<string, DailyBar>>,
   protocol: SimulationProtocol,
   price: (bar: DailyBar) => number,
@@ -25,7 +26,9 @@ export const referencePricesFor = (
     Result.map((entries) => Object.fromEntries(entries)),
   )
 
-export const positionValueMicros = (
+export const referencePricesFor = Pipeable.dual(3, referencePricesForDataFirst)
+
+const positionValueMicrosDataFirst = (
   prices: Readonly<Record<string, bigint>>,
   positions: Readonly<Record<string, Position>>,
 ): Result.Result<bigint, SimulationFailure> =>
@@ -47,6 +50,8 @@ export const positionValueMicros = (
       ),
     Result.succeed(0n),
   )
+
+export const positionValueMicros = Pipeable.dual(2, positionValueMicrosDataFirst)
 
 const markedPositions = (
   session: AlignedSession,
@@ -78,7 +83,7 @@ const markedPositions = (
       }),
   )
 
-export const closeSession = (
+const closeSessionDataFirst = (
   state: SimulationState,
   session: AlignedSession,
   opening: SessionOpeningSnapshot,
@@ -143,3 +148,5 @@ export const closeSession = (
       ),
     ),
   )
+
+export const closeSession = Pipeable.dual(4, closeSessionDataFirst)

--- a/services/bayn/src/startup/decisions.ts
+++ b/services/bayn/src/startup/decisions.ts
@@ -30,6 +30,7 @@ import type {
   StartupCompletion,
   StartupDecisionFailure,
 } from './model'
+import { Pipeable } from '../pipeable'
 
 const canonicalStartupHash = (
   context: StartupCanonicalizationContext,
@@ -130,7 +131,7 @@ const provenanceFromStored = (
   return Result.succeed(provenance)
 }
 
-export const decidePinnedQualification = (
+const decidePinnedQualificationDataFirst = (
   config: RuntimeConfig,
   runId: string,
   facts: PinnedQualificationFacts,
@@ -216,7 +217,9 @@ export const decidePinnedQualification = (
   })
 }
 
-export const decidePinnedRecovery = (
+export const decidePinnedQualification = Pipeable.dual(3, decidePinnedQualificationDataFirst)
+
+const decidePinnedRecoveryDataFirst = (
   decision: PinnedQualificationDecision,
   recovered: Option.Option<RecoveredEvaluationEvidence>,
 ): Result.Result<StartupCompletion, StartupDecisionFailure> => {
@@ -245,7 +248,9 @@ export const decidePinnedRecovery = (
   })
 }
 
-export const prepareQualificationLock = (
+export const decidePinnedRecovery = Pipeable.dual(2, decidePinnedRecoveryDataFirst)
+
+const prepareQualificationLockDataFirst = (
   strategy: StrategyRuntimeInput,
   provenance: RuntimeProvenance,
   inspection: MarketDataInspection,
@@ -261,7 +266,9 @@ export const prepareQualificationLock = (
     }),
   )
 
-export const decideQualificationPath = (
+export const prepareQualificationLock = Pipeable.dual(4, prepareQualificationLockDataFirst)
+
+const decideQualificationPathDataFirst = (
   expectedLock: QualificationLock,
   opened: QualificationOpen,
 ): Result.Result<QualificationPath, StartupDecisionFailure> => {
@@ -301,6 +308,8 @@ export const decideQualificationPath = (
     result: opened.result,
   })
 }
+
+export const decideQualificationPath = Pipeable.dual(2, decideQualificationPathDataFirst)
 
 interface RecoveryExpectation {
   readonly phase: 'pinned' | 'terminal'
@@ -364,7 +373,7 @@ const validateRecoveredEvaluation = (
   return Result.isFailure(verdictBinding) ? Result.fail(verdictBinding.failure) : Result.succeed(evidence)
 }
 
-export const decideTerminalRecovery = (
+const decideTerminalRecoveryDataFirst = (
   provenance: RuntimeProvenance,
   path: Extract<QualificationPath, { readonly _tag: 'RecoverTerminal' }>,
   recovered: Option.Option<RecoveredEvaluationEvidence>,
@@ -404,7 +413,9 @@ export const decideTerminalRecovery = (
   })
 }
 
-export const evaluateLockedSnapshot = (
+export const decideTerminalRecovery = Pipeable.dual(3, decideTerminalRecoveryDataFirst)
+
+const evaluateLockedSnapshotDataFirst = (
   strategy: StrategyRuntimeInput,
   provenance: RuntimeProvenance,
   inspection: MarketDataInspection,
@@ -463,6 +474,8 @@ export const evaluateLockedSnapshot = (
   return Result.succeed(evaluationResult.success)
 }
 
+export const evaluateLockedSnapshot = Pipeable.dual(5, evaluateLockedSnapshotDataFirst)
+
 const qualificationPipelineFailure = (
   strategyName: string,
   cause: QualificationPipelineFailure,
@@ -488,7 +501,7 @@ const qualificationPipelineFailure = (
   }
 }
 
-export const qualifyEvaluation = (
+const qualifyEvaluationDataFirst = (
   strategy: StrategyRuntimeInput,
   lock: QualificationLock,
   evaluation: EvaluationResult,
@@ -519,7 +532,9 @@ export const qualifyEvaluation = (
     : Result.succeed({ evaluation, reconciliation, qualification: qualification.success.result })
 }
 
-export const evaluatedCompletion = (
+export const qualifyEvaluation = Pipeable.dual(4, qualifyEvaluationDataFirst)
+
+const evaluatedCompletionDataFirst = (
   provenance: RuntimeProvenance,
   evidence: EvaluationEvidence,
   persistence: PersistenceReceipt,
@@ -535,3 +550,5 @@ export const evaluatedCompletion = (
   },
   markedEquityDifferenceMicros: evidence.evaluation.markedEquityReconciliation.differenceMicros,
 })
+
+export const evaluatedCompletion = Pipeable.dual(3, evaluatedCompletionDataFirst)

--- a/services/bayn/src/startup/program.ts
+++ b/services/bayn/src/startup/program.ts
@@ -29,6 +29,7 @@ import type {
   StartupDecisionFailure,
 } from './model'
 import { renderStartupDecisionFailure } from './presentation'
+import { Pipeable } from '../pipeable'
 
 const failStartupState = (current: RuntimeState, error: OperationalError): RuntimeState => ({
   ...current,
@@ -359,7 +360,7 @@ const evaluateAndJournal = (
     Effect.withLogSpan('startup'),
   )
 
-export const runStartup = (
+const runStartupDataFirst = (
   config: RuntimeConfig,
   state: Ref.Ref<RuntimeState>,
   strategy: StrategyRuntime,
@@ -369,3 +370,5 @@ export const runStartup = (
     ? evaluateAndJournal(config, state, strategy, dependencies)
     : recoverPinnedQualification(config, config.qualificationRunId, state, dependencies.evidenceStore)
   ).pipe(Effect.catch((error) => (error.retryable ? Effect.fail(error) : failStartup(state, error))))
+
+export const runStartup = Pipeable.dual(4, runStartupDataFirst)

--- a/services/bayn/src/strategy/execution-model/cash.ts
+++ b/services/bayn/src/strategy/execution-model/cash.ts
@@ -4,8 +4,9 @@ import type { ExecutionModel } from '../../execution-model-contract'
 import type { IsoDate } from '../../schemas'
 import { ensureUnsigned, fail, quantizeDown, roundDiv, scaledNumber, type ExecutionResult } from './fixed-point'
 import { BPS, MICROS, PPM } from './model'
+import { Pipeable } from '../../pipeable'
 
-export const accrueCashYield = (
+const accrueCashYieldDataFirst = (
   cashMicros: bigint,
   elapsedDays: number,
   model: ExecutionModel,
@@ -22,7 +23,9 @@ export const accrueCashYield = (
   )
 }
 
-export const elapsedCalendarDays = (from: IsoDate, to: IsoDate): ExecutionResult<number> => {
+export const accrueCashYield = Pipeable.dual(3, accrueCashYieldDataFirst)
+
+const elapsedCalendarDaysDataFirst = (from: IsoDate, to: IsoDate): ExecutionResult<number> => {
   const fromTime = Date.parse(`${from}T00:00:00Z`)
   const toTime = Date.parse(`${to}T00:00:00Z`)
   return !Number.isFinite(fromTime) || !Number.isFinite(toTime) || toTime < fromTime
@@ -30,7 +33,9 @@ export const elapsedCalendarDays = (from: IsoDate, to: IsoDate): ExecutionResult
     : Result.succeed((toTime - fromTime) / 86_400_000)
 }
 
-export const saleCostBasisMicros = (
+export const elapsedCalendarDays = Pipeable.dual(2, elapsedCalendarDaysDataFirst)
+
+const saleCostBasisMicrosDataFirst = (
   positionCostBasisMicros: bigint,
   soldQuantityMicros: bigint,
   positionQuantityMicros: bigint,
@@ -56,7 +61,9 @@ export const saleCostBasisMicros = (
   return roundDiv(positionCostBasisMicros * soldQuantityMicros, positionQuantityMicros)
 }
 
-export const scaleQuantityMicros = (
+export const saleCostBasisMicros = Pipeable.dual(3, saleCostBasisMicrosDataFirst)
+
+const scaleQuantityMicrosDataFirst = (
   quantityMicros: bigint,
   scalePpm: bigint,
   model: ExecutionModel,
@@ -75,3 +82,5 @@ export const scaleQuantityMicros = (
     Result.flatMap((increment) => quantizeDown((quantityMicros * scalePpm) / PPM, increment)),
   )
 }
+
+export const scaleQuantityMicros = Pipeable.dual(3, scaleQuantityMicrosDataFirst)

--- a/services/bayn/src/strategy/execution-model/fees.ts
+++ b/services/bayn/src/strategy/execution-model/fees.ts
@@ -3,6 +3,7 @@ import { Result, pipe } from 'effect'
 import type { ExecutionModel } from '../../execution-model-contract'
 import { ceilDiv, ensureUnsigned, fail, scaledNumber, type ExecutionResult } from './fixed-point'
 import { BPS, MICROS } from './model'
+import { Pipeable } from '../../pipeable'
 
 export interface FeeInput {
   readonly side: 'buy' | 'sell'
@@ -26,7 +27,7 @@ const roundedFee = (numerator: bigint, denominator: bigint, increment: bigint): 
         Result.map((quotient) => quotient * increment),
       )
 
-export const calculateSessionFees = (
+const calculateSessionFeesDataFirst = (
   fills: readonly FeeInput[],
   model: ExecutionModel,
   costMultiplierMicros: bigint,
@@ -79,3 +80,5 @@ export const calculateSessionFees = (
     }),
   )
 }
+
+export const calculateSessionFees = Pipeable.dual(3, calculateSessionFeesDataFirst)

--- a/services/bayn/src/strategy/execution-model/fills.ts
+++ b/services/bayn/src/strategy/execution-model/fills.ts
@@ -15,6 +15,7 @@ import {
   type ExecutionResult,
 } from './fixed-point'
 import { BPS, MICROS, PPM, type ExecutionModelFailure } from './model'
+import { Pipeable } from '../../pipeable'
 
 const impactedDelta = (
   referencePriceMicros: bigint,
@@ -36,7 +37,7 @@ export interface FillTerms {
   readonly slippageCostMicros: bigint
 }
 
-export const makeFillTerms = (
+const makeFillTermsDataFirst = (
   side: 'buy' | 'sell',
   quantityMicros: bigint,
   referencePrice: bigint,
@@ -118,6 +119,8 @@ export const makeFillTerms = (
     }),
   )
 }
+
+export const makeFillTerms = Pipeable.dual(5, makeFillTermsDataFirst)
 
 export interface OrderOutcome {
   readonly requestedQuantityMicros: bigint

--- a/services/bayn/src/strategy/execution-model/fixed-point.ts
+++ b/services/bayn/src/strategy/execution-model/fixed-point.ts
@@ -3,6 +3,7 @@ import { Result, pipe } from 'effect'
 import type { ExecutionModel } from '../../execution-model-contract'
 import { roundUnsignedHalfUp } from '../../unsigned-round-half-up'
 import { MICROS, WEIGHT_SCALE, type ExecutionModelFailure } from './model'
+import { Pipeable } from '../../pipeable'
 
 export type ExecutionResult<A> = Result.Result<A, ExecutionModelFailure>
 
@@ -31,7 +32,7 @@ export const scaledNumber = (value: number, field: string, scale = Number(MICROS
     : Result.succeed(BigInt(rounded))
 }
 
-export const integerNumber = (
+const integerNumberDataFirst = (
   value: number,
   field: string,
   minimum: number,
@@ -41,7 +42,9 @@ export const integerNumber = (
     ? Result.succeed(BigInt(value))
     : fail({ _tag: 'InvalidIntegerNumber', field, value, minimum, maximum })
 
-export const ceilDiv = (numerator: bigint, denominator: bigint): ExecutionResult<bigint> => {
+export const integerNumber = Pipeable.dual(4, integerNumberDataFirst)
+
+const ceilDivDataFirst = (numerator: bigint, denominator: bigint): ExecutionResult<bigint> => {
   if (numerator < 0n || denominator <= 0n) {
     return fail({
       _tag: 'InvalidCeilingDivision',
@@ -54,10 +57,14 @@ export const ceilDiv = (numerator: bigint, denominator: bigint): ExecutionResult
   return Result.succeed(numerator === 0n ? 0n : (numerator - 1n) / denominator + 1n)
 }
 
-export const roundDiv = (numerator: bigint, denominator: bigint): ExecutionResult<bigint> =>
+export const ceilDiv = Pipeable.dual(2, ceilDivDataFirst)
+
+const roundDivDataFirst = (numerator: bigint, denominator: bigint): ExecutionResult<bigint> =>
   roundUnsignedHalfUp(numerator, denominator)
 
-export const quantizeDown = (value: bigint, increment: bigint): ExecutionResult<bigint> =>
+export const roundDiv = Pipeable.dual(2, roundDivDataFirst)
+
+const quantizeDownDataFirst = (value: bigint, increment: bigint): ExecutionResult<bigint> =>
   value < 0n || increment <= 0n
     ? fail({
         _tag: 'InvalidQuantization',
@@ -69,17 +76,23 @@ export const quantizeDown = (value: bigint, increment: bigint): ExecutionResult<
       })
     : Result.succeed((value / increment) * increment)
 
-export const quantizeUp = (value: bigint, increment: bigint): ExecutionResult<bigint> =>
+export const quantizeDown = Pipeable.dual(2, quantizeDownDataFirst)
+
+const quantizeUpDataFirst = (value: bigint, increment: bigint): ExecutionResult<bigint> =>
   pipe(
     ceilDiv(value, increment),
     Result.map((quotient) => quotient * increment),
   )
 
-export const quantizeNearest = (value: bigint, increment: bigint): ExecutionResult<bigint> =>
+export const quantizeUp = Pipeable.dual(2, quantizeUpDataFirst)
+
+const quantizeNearestDataFirst = (value: bigint, increment: bigint): ExecutionResult<bigint> =>
   pipe(
     roundDiv(value, increment),
     Result.map((quotient) => quotient * increment),
   )
+
+export const quantizeNearest = Pipeable.dual(2, quantizeNearestDataFirst)
 
 export const numberToMicros = (value: number, field = 'value'): ExecutionResult<bigint> => {
   const scale = Number(MICROS)
@@ -97,7 +110,7 @@ export const numberToMicros = (value: number, field = 'value'): ExecutionResult<
 
 export const microsToNumber = (value: bigint): number => Number(value) / Number(MICROS)
 
-export const referencePriceMicros = (price: number, model: ExecutionModel): ExecutionResult<bigint> => {
+const referencePriceMicrosDataFirst = (price: number, model: ExecutionModel): ExecutionResult<bigint> => {
   if (!Number.isFinite(price) || price <= 0) {
     return fail({ _tag: 'InvalidReferencePrice', price, reason: 'not-positive' })
   }
@@ -115,10 +128,14 @@ export const referencePriceMicros = (price: number, model: ExecutionModel): Exec
   )
 }
 
-export const notionalMicros = (quantityMicros: bigint, priceMicros: bigint): ExecutionResult<bigint> =>
+export const referencePriceMicros = Pipeable.dual(2, referencePriceMicrosDataFirst)
+
+const notionalMicrosDataFirst = (quantityMicros: bigint, priceMicros: bigint): ExecutionResult<bigint> =>
   roundDiv(quantityMicros * priceMicros, MICROS)
 
-export const desiredQuantityMicros = (
+export const notionalMicros = Pipeable.dual(2, notionalMicrosDataFirst)
+
+const desiredQuantityMicrosDataFirst = (
   equityMicros: bigint,
   weight: number,
   priceMicros: bigint,
@@ -155,3 +172,5 @@ export const desiredQuantityMicros = (
     }),
   )
 }
+
+export const desiredQuantityMicros = Pipeable.dual(4, desiredQuantityMicrosDataFirst)

--- a/services/bayn/src/strategy/risk-balanced-trend/allocation.ts
+++ b/services/bayn/src/strategy/risk-balanced-trend/allocation.ts
@@ -2,6 +2,7 @@ import { Result, pipe } from 'effect'
 
 import type { RiskBalancedTrendFailure } from '../../risk-balanced-trend/model'
 import { compareKeys, fail, WEIGHT_SCALE } from './shared'
+import { Pipeable } from '../../pipeable'
 
 interface ScoredSymbol {
   readonly symbol: string
@@ -50,7 +51,7 @@ const allocateWeights = (
   })
 }
 
-export const redistributeWithCap = (
+const redistributeWithCapDataFirst = (
   scores: Readonly<Record<string, number>>,
   maximumWeight: number,
 ): Result.Result<Readonly<Record<string, number>>, RiskBalancedTrendFailure> => {
@@ -63,6 +64,8 @@ export const redistributeWithCap = (
     remaining: candidates.filter(({ score }) => score > 0),
   })
 }
+
+export const redistributeWithCap = Pipeable.dual(2, redistributeWithCapDataFirst)
 
 interface QuantizedUnits {
   readonly units: Readonly<Record<string, number>>
@@ -129,7 +132,7 @@ const removeExcessUnits = (
       })
 }
 
-export const quantizeWeights = (
+const quantizeWeightsDataFirst = (
   weights: Readonly<Record<string, number>>,
   maximumSymbolWeight: number,
 ): Result.Result<Readonly<Record<string, number>>, RiskBalancedTrendFailure> =>
@@ -137,3 +140,5 @@ export const quantizeWeights = (
     quantizedUnits(weights, Math.floor(maximumSymbolWeight * WEIGHT_SCALE + Number.EPSILON)),
     Result.flatMap(removeExcessUnits),
   )
+
+export const quantizeWeights = Pipeable.dual(2, quantizeWeightsDataFirst)

--- a/services/bayn/src/strategy/risk-balanced-trend/decision.ts
+++ b/services/bayn/src/strategy/risk-balanced-trend/decision.ts
@@ -8,6 +8,7 @@ import { quantizeWeights, redistributeWithCap } from './allocation'
 import { annualizedPortfolioVolatility } from './risk'
 import { finalizeSignals, prepareSignal, type PreparedSignal } from './signals'
 import { fail, requiredHistory, WEIGHT_SCALE } from './shared'
+import { Pipeable } from '../../pipeable'
 
 const assembleDecision = (
   signalDate: IsoDate,
@@ -123,7 +124,7 @@ const assembleDecision = (
   )
 }
 
-export const makeRiskBalancedTrendDecision = (
+const makeRiskBalancedTrendDecisionDataFirst = (
   signalDate: IsoDate,
   sessionDates: readonly IsoDate[],
   closes: Readonly<Record<string, readonly number[]>>,
@@ -159,6 +160,8 @@ export const makeRiskBalancedTrendDecision = (
   )
 }
 
+export const makeRiskBalancedTrendDecision = Pipeable.dual(4, makeRiskBalancedTrendDecisionDataFirst)
+
 export interface RiskBalancedTrendMarketContext {
   readonly signalDate: IsoDate
   readonly sessionDates: readonly IsoDate[]
@@ -180,7 +183,7 @@ export const makeRiskBalancedTrendDefinition = (protocol: Protocol): RiskBalance
     makeRiskBalancedTrendDecision(market.signalDate, market.sessionDates, market.closes, protocol),
 })
 
-export const riskBalancedTrendContextAtSignal = (
+const riskBalancedTrendContextAtSignalDataFirst = (
   sessions: readonly AlignedSession[],
   signalIndex: number,
   protocol: Protocol,
@@ -209,6 +212,8 @@ export const riskBalancedTrendContextAtSignal = (
       )
     }),
   )
+
+export const riskBalancedTrendContextAtSignal = Pipeable.dual(3, riskBalancedTrendContextAtSignalDataFirst)
 
 export const decisionFromAlignedSessions = (
   sessions: readonly AlignedSession[],

--- a/services/bayn/src/strategy/risk-balanced-trend/qualification-precommit.ts
+++ b/services/bayn/src/strategy/risk-balanced-trend/qualification-precommit.ts
@@ -5,11 +5,12 @@ import { makeEvaluationIdentity, selectEvaluationWindow } from '../../simulation
 import type { InputManifest, IsoDate, Protocol } from '../../types'
 import type { QualificationPrecommit, RiskBalancedTrendFailure } from '../../risk-balanced-trend/model'
 import { requiredHistory } from './shared'
+import { Pipeable } from '../../pipeable'
 
 const fail = <A = never>(failure: RiskBalancedTrendFailure): Result.Result<A, RiskBalancedTrendFailure> =>
   Result.fail(failure)
 
-export const prepareRiskBalancedTrendQualification = (
+const prepareRiskBalancedTrendQualificationDataFirst = (
   sessionDates: readonly IsoDate[],
   inputManifest: InputManifest,
   protocol: Protocol,
@@ -66,3 +67,5 @@ export const prepareRiskBalancedTrendQualification = (
       ),
     ),
   )
+
+export const prepareRiskBalancedTrendQualification = Pipeable.dual(4, prepareRiskBalancedTrendQualificationDataFirst)

--- a/services/bayn/src/strategy/risk-balanced-trend/qualification.ts
+++ b/services/bayn/src/strategy/risk-balanced-trend/qualification.ts
@@ -18,6 +18,7 @@ import {
 import { prepareRiskBalancedTrendQualification } from './qualification-precommit'
 import type { RiskBalancedTrendFailure } from '../../risk-balanced-trend/model'
 import type { EvaluationResult, InputManifest, IsoDate, Protocol } from '../../types'
+import { Pipeable } from '../../pipeable'
 
 export type RiskBalancedTrendStrategyPrepareLockFailure = RiskBalancedTrendFailure | QualificationConstructionFailure
 
@@ -26,7 +27,7 @@ export type RiskBalancedTrendQualificationFailure = QualificationConstructionFai
 const universeRationale =
   'The precommitted five-sleeve cross-asset universe uses broad commodities (DBC), developed ex-US equities (EFA), intermediate US Treasuries (IEF), US equities (SPY), and US real estate (VNQ); symbols were fixed without inspecting candidate prices or returns.'
 
-export const prepareRiskBalancedTrendQualificationLock = (
+const prepareRiskBalancedTrendQualificationLockDataFirst = (
   manifest: InputManifest,
   sessionDates: readonly IsoDate[],
   priorTrialRunIds: readonly string[],
@@ -89,7 +90,12 @@ export const prepareRiskBalancedTrendQualificationLock = (
     }),
   )
 
-export const analyzeRiskBalancedTrendEvaluation = (
+export const prepareRiskBalancedTrendQualificationLock = Pipeable.dual(
+  5,
+  prepareRiskBalancedTrendQualificationLockDataFirst,
+)
+
+const analyzeRiskBalancedTrendEvaluationDataFirst = (
   evaluation: EvaluationResult,
   priorTrialRunIds: readonly string[],
 ): Result.Result<QualificationAnalysis, QualificationStatisticsFailure> =>
@@ -97,3 +103,5 @@ export const analyzeRiskBalancedTrendEvaluation = (
     prepareQualificationSeries(evaluation),
     Result.flatMap((series) => analyzeQualification(series, defaultQualificationStatisticsPolicy, priorTrialRunIds)),
   )
+
+export const analyzeRiskBalancedTrendEvaluation = Pipeable.dual(2, analyzeRiskBalancedTrendEvaluationDataFirst)

--- a/services/bayn/src/strategy/risk-balanced-trend/risk.ts
+++ b/services/bayn/src/strategy/risk-balanced-trend/risk.ts
@@ -3,6 +3,7 @@ import { Result, pipe } from 'effect'
 import { TRADING_DAYS, mean, requiredRecordValue } from '../../simulation'
 import type { RiskBalancedTrendFailure } from '../../risk-balanced-trend/model'
 import { fail, finite } from './shared'
+import { Pipeable } from '../../pipeable'
 
 const covariance = (
   left: readonly number[],
@@ -73,7 +74,7 @@ const portfolioVarianceRow = (
     ),
   )
 
-export const annualizedPortfolioVolatility = (
+const annualizedPortfolioVolatilityDataFirst = (
   weights: Readonly<Record<string, number>>,
   returns: Readonly<Record<string, readonly number[]>>,
 ): Result.Result<number, RiskBalancedTrendFailure> => {
@@ -95,3 +96,5 @@ export const annualizedPortfolioVolatility = (
     }),
   )
 }
+
+export const annualizedPortfolioVolatility = Pipeable.dual(2, annualizedPortfolioVolatilityDataFirst)

--- a/services/bayn/src/strategy/risk-balanced-trend/shared.ts
+++ b/services/bayn/src/strategy/risk-balanced-trend/shared.ts
@@ -2,11 +2,14 @@ import { Result } from 'effect'
 
 import type { Protocol } from '../../types'
 import type { RiskBalancedTrendFailure } from '../../risk-balanced-trend/model'
+import { Pipeable } from '../../pipeable'
 
 export const WEIGHT_SCALE = 1_000_000_000_000
 
-export const compareKeys = ([left]: readonly [string, unknown], [right]: readonly [string, unknown]): number =>
+const compareKeysDataFirst = ([left]: readonly [string, unknown], [right]: readonly [string, unknown]): number =>
   left < right ? -1 : left > right ? 1 : 0
+
+export const compareKeys = Pipeable.dual(2, compareKeysDataFirst)
 
 export const fail = <A = never>(failure: RiskBalancedTrendFailure): Result.Result<A, RiskBalancedTrendFailure> =>
   Result.fail(failure)
@@ -24,7 +27,7 @@ export const finite = (
       ? fail({ _tag: 'InvalidRiskBalancedTrendNumber', operation, value, symbol, reason: 'negative' })
       : Result.succeed(value)
 
-export const dailyReturns = (
+const dailyReturnsDataFirst = (
   closes: readonly number[],
   count: number,
   symbol: string,
@@ -52,3 +55,5 @@ export const dailyReturns = (
     }),
   )
 }
+
+export const dailyReturns = Pipeable.dual(3, dailyReturnsDataFirst)

--- a/services/bayn/src/strategy/risk-balanced-trend/signals.ts
+++ b/services/bayn/src/strategy/risk-balanced-trend/signals.ts
@@ -4,6 +4,7 @@ import { TRADING_DAYS, requiredRecordValue, roundWeight, sampleStandardDeviation
 import type { Protocol, SymbolSignal } from '../../types'
 import type { RiskBalancedTrendFailure } from '../../risk-balanced-trend/model'
 import { dailyReturns, fail, finite } from './shared'
+import { Pipeable } from '../../pipeable'
 
 export interface PreparedSignal {
   readonly signal: Omit<SymbolSignal, 'uncappedWeight' | 'cappedWeight' | 'targetWeight'>
@@ -67,7 +68,7 @@ const scoreSignal = (
   )
 }
 
-export const prepareSignal = (
+const prepareSignalDataFirst = (
   symbol: string,
   closes: Readonly<Record<string, readonly number[]>>,
   historyLength: number,
@@ -156,7 +157,9 @@ export const prepareSignal = (
   )
 }
 
-export const finalizeSignals = (
+export const prepareSignal = Pipeable.dual(4, prepareSignalDataFirst)
+
+const finalizeSignalsDataFirst = (
   prepared: readonly PreparedSignal[],
   uncappedWeights: Readonly<Record<string, number>>,
   cappedWeights: Readonly<Record<string, number>>,
@@ -177,3 +180,5 @@ export const finalizeSignals = (
       ),
     ),
   )
+
+export const finalizeSignals = Pipeable.dual(4, finalizeSignalsDataFirst)

--- a/services/bayn/src/target-planner/facts.ts
+++ b/services/bayn/src/target-planner/facts.ts
@@ -14,10 +14,13 @@ import {
   type TargetPlannerFailure,
   type TargetPlannerInput,
 } from './model'
+import { Pipeable } from '../pipeable'
 
 const WEIGHT_SUM_TOLERANCE = 1e-12
 
-export const compareText = (left: string, right: string): number => (left < right ? -1 : left > right ? 1 : 0)
+const compareTextDataFirst = (left: string, right: string): number => (left < right ? -1 : left > right ? 1 : 0)
+
+export const compareText = Pipeable.dual(2, compareTextDataFirst)
 
 const isStrictlySorted = (values: readonly string[]): boolean =>
   values.every((value, index) => {
@@ -109,7 +112,10 @@ export const deriveTargetPlannerHashes = (
     ),
   })
 
-export const parseTargetPlannerFacts = (input: TargetPlannerInput, hashes: TargetPlannerHashes): TargetPlannerFacts => {
+const parseTargetPlannerFactsDataFirst = (
+  input: TargetPlannerInput,
+  hashes: TargetPlannerHashes,
+): TargetPlannerFacts => {
   const targetSymbols = Object.keys(input.targetWeights).sort(compareText)
   const priceSymbols = Object.keys(input.referencePrices.priceMicros).sort(compareText)
   const prices = new Map(
@@ -150,6 +156,8 @@ export const parseTargetPlannerFacts = (input: TargetPlannerInput, hashes: Targe
     availableBuyingPower: BigInt(input.brokerState.account.buyingPowerMicros),
   }
 }
+
+export const parseTargetPlannerFacts = Pipeable.dual(2, parseTargetPlannerFactsDataFirst)
 
 const identityAndSessionMatch = (facts: TargetPlannerFacts): boolean => {
   const { input, priceSymbols, targetSymbols } = facts
@@ -222,8 +230,10 @@ const brokerStateIsCurrent = (facts: TargetPlannerFacts): boolean => {
   )
 }
 
-export const referenceNotional = (quantityMicros: bigint, priceMicros: bigint): bigint =>
+const referenceNotionalDataFirst = (quantityMicros: bigint, priceMicros: bigint): bigint =>
   (quantityMicros * priceMicros + 1_000_000n - 1n) / 1_000_000n
+
+export const referenceNotional = Pipeable.dual(2, referenceNotionalDataFirst)
 
 export const derivePlannedTargetFacts = (
   facts: TargetPlannerFacts,


### PR DESCRIPTION
## Summary

- Makes strategy, simulation, and qualification APIs pipeable with their existing typed inputs and outputs.
- Keeps this native stack layer independently reviewable at 886 changed lines.
- Bases directly on codex/bayn-effect-tsgo-pipeable-persistence so GitHub shows only this layer.

## Related Issues

None

## Testing

- bunx tsc --noEmit --project services/bayn/tsconfig.json
- bun run lint
- bun run lint:oxlint
- bun run lint:oxlint:type
- bun run build
- Focused tests for the touched subsystem were run while constructing the layer.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable and Breaking Changes is filled in.
- [x] Documentation and follow-ups are unchanged or represented by later stack layers.