### PR TITLE
refactor(bayn): make schema decoders pipeable

### DIFF
--- a/services/bayn/src/accounting/schema.ts
+++ b/services/bayn/src/accounting/schema.ts
@@ -13,6 +13,7 @@ import {
   UtcInstantSchema as UtcInstant,
   strictParseOptions,
 } from '../schemas'
+import { Pipeable } from '../pipeable'
 
 export const AccountingTransactionSchema = Schema.Struct({
   schemaVersion: Schema.Literal('bayn.paper-accounting-transaction.v1'),
@@ -38,4 +39,8 @@ export const AccountingTransactionSchema = Schema.Struct({
 
 export type AccountingTransaction = typeof AccountingTransactionSchema.Type
 
-export const decodeAccountingTransaction = Schema.decodeUnknownResult(AccountingTransactionSchema, strictParseOptions)
+const decodeAccountingTransactionDataFirst = Schema.decodeUnknownResult(AccountingTransactionSchema, strictParseOptions)
+
+export const decodeAccountingTransaction = Pipeable.dual(1, (input: unknown) =>
+  decodeAccountingTransactionDataFirst(input),
+)

--- a/services/bayn/src/broker/alpaca/model.ts
+++ b/services/bayn/src/broker/alpaca/model.ts
@@ -9,6 +9,7 @@ import {
 } from '../../schemas'
 import type { BrokerProvider } from '../connection'
 import { BrokerReadError } from './failures'
+import { Pipeable } from '../../pipeable'
 
 export const defaultFillActivitiesPageSize = 100
 const maxMarketCalendarRangeDays = 31
@@ -603,24 +604,58 @@ const MarketCalendarQuerySchema = MarketCalendarQueryBase.check(
 
 export type Decoder<A> = (input: unknown) => Result.Result<A, Schema.SchemaError>
 
-export const decodeAccount = Schema.decodeUnknownResult(AccountResponseSchema, responseParseOptions)
-export const decodeAccountConfiguration = Schema.decodeUnknownResult(
+const decodeAccountDataFirst = Schema.decodeUnknownResult(AccountResponseSchema, responseParseOptions)
+
+export const decodeAccount = Pipeable.dual(1, (input: unknown) => decodeAccountDataFirst(input))
+const decodeAccountConfigurationDataFirst = Schema.decodeUnknownResult(
   AccountConfigurationResponseSchema,
   responseParseOptions,
 )
-export const decodeAsset = Schema.decodeUnknownResult(AssetResponseSchema, responseParseOptions)
-export const decodePositions = Schema.decodeUnknownResult(Schema.Array(PositionResponseSchema), responseParseOptions)
-export const decodeOrders = Schema.decodeUnknownResult(Schema.Array(OrderResponseSchema), responseParseOptions)
-export const decodeOrder = Schema.decodeUnknownResult(OrderResponseSchema, responseParseOptions)
-export const decodeFillActivities = Schema.decodeUnknownResult(
+
+export const decodeAccountConfiguration = Pipeable.dual(1, (input: unknown) =>
+  decodeAccountConfigurationDataFirst(input),
+)
+const decodeAssetDataFirst = Schema.decodeUnknownResult(AssetResponseSchema, responseParseOptions)
+
+export const decodeAsset = Pipeable.dual(1, (input: unknown) => decodeAssetDataFirst(input))
+const decodePositionsDataFirst = Schema.decodeUnknownResult(Schema.Array(PositionResponseSchema), responseParseOptions)
+
+export const decodePositions = Pipeable.dual(1, (input: unknown) => decodePositionsDataFirst(input))
+const decodeOrdersDataFirst = Schema.decodeUnknownResult(Schema.Array(OrderResponseSchema), responseParseOptions)
+
+export const decodeOrders = Pipeable.dual(1, (input: unknown) => decodeOrdersDataFirst(input))
+const decodeOrderDataFirst = Schema.decodeUnknownResult(OrderResponseSchema, responseParseOptions)
+
+export const decodeOrder = Pipeable.dual(1, (input: unknown) => decodeOrderDataFirst(input))
+const decodeFillActivitiesDataFirst = Schema.decodeUnknownResult(
   Schema.Array(FillActivityResponseSchema),
   responseParseOptions,
 )
-export const decodeMarketCalendar = Schema.decodeUnknownResult(MarketCalendarResponseSchema, responseParseOptions)
-export const decodeErrorResponse = Schema.decodeUnknownResult(ErrorResponseSchema, responseParseOptions)
-export const decodeOrdersQuery = Schema.decodeUnknownResult(OrdersQuerySchema, inputParseOptions)
-export const decodeFillActivitiesQuery = Schema.decodeUnknownResult(FillActivitiesQuerySchema, inputParseOptions)
-export const decodeMarketCalendarQuery = Schema.decodeUnknownResult(MarketCalendarQuerySchema, inputParseOptions)
-export const decodeAssetSymbol = Schema.decodeUnknownResult(SymbolName)
-export const decodeOrderId = Schema.decodeUnknownResult(Uuid)
-export const decodeExternalClientOrderId = Schema.decodeUnknownResult(ExternalClientOrderId)
+
+export const decodeFillActivities = Pipeable.dual(1, (input: unknown) => decodeFillActivitiesDataFirst(input))
+const decodeMarketCalendarDataFirst = Schema.decodeUnknownResult(MarketCalendarResponseSchema, responseParseOptions)
+
+export const decodeMarketCalendar = Pipeable.dual(1, (input: unknown) => decodeMarketCalendarDataFirst(input))
+const decodeErrorResponseDataFirst = Schema.decodeUnknownResult(ErrorResponseSchema, responseParseOptions)
+
+export const decodeErrorResponse = Pipeable.dual(1, (input: unknown) => decodeErrorResponseDataFirst(input))
+const decodeOrdersQueryDataFirst = Schema.decodeUnknownResult(OrdersQuerySchema, inputParseOptions)
+
+export const decodeOrdersQuery = Pipeable.dual(1, (input: unknown) => decodeOrdersQueryDataFirst(input))
+const decodeFillActivitiesQueryDataFirst = Schema.decodeUnknownResult(FillActivitiesQuerySchema, inputParseOptions)
+
+export const decodeFillActivitiesQuery = Pipeable.dual(1, (input: unknown) => decodeFillActivitiesQueryDataFirst(input))
+const decodeMarketCalendarQueryDataFirst = Schema.decodeUnknownResult(MarketCalendarQuerySchema, inputParseOptions)
+
+export const decodeMarketCalendarQuery = Pipeable.dual(1, (input: unknown) => decodeMarketCalendarQueryDataFirst(input))
+const decodeAssetSymbolDataFirst = Schema.decodeUnknownResult(SymbolName)
+
+export const decodeAssetSymbol = Pipeable.dual(1, (input: unknown) => decodeAssetSymbolDataFirst(input))
+const decodeOrderIdDataFirst = Schema.decodeUnknownResult(Uuid)
+
+export const decodeOrderId = Pipeable.dual(1, (input: unknown) => decodeOrderIdDataFirst(input))
+const decodeExternalClientOrderIdDataFirst = Schema.decodeUnknownResult(ExternalClientOrderId)
+
+export const decodeExternalClientOrderId = Pipeable.dual(1, (input: unknown) =>
+  decodeExternalClientOrderIdDataFirst(input),
+)

--- a/services/bayn/src/config/source.ts
+++ b/services/bayn/src/config/source.ts
@@ -14,6 +14,7 @@ import {
   TrimmedNonEmptyStringSchema as NonEmptyString,
 } from '../schemas'
 import type { ParsedRuntimeConfig, RuntimeOperation } from './model'
+import { Pipeable } from '../pipeable'
 
 const ProvenanceMode = Schema.Literals(['production', 'development'])
 const RetryAttempts = Schema.Int.check(Schema.isBetween({ minimum: 0, maximum: 3 }))
@@ -185,4 +186,6 @@ export const runtimeConfigSource = Config.all({
   ),
 )
 
-export const evaluationBoundsDecoder = Schema.decodeUnknownResult(EvaluationBoundsSchema)
+const evaluationBoundsDecoderDataFirst = Schema.decodeUnknownResult(EvaluationBoundsSchema)
+
+export const evaluationBoundsDecoder = Pipeable.dual(1, (input: unknown) => evaluationBoundsDecoderDataFirst(input))

--- a/services/bayn/src/contracts.ts
+++ b/services/bayn/src/contracts.ts
@@ -13,6 +13,7 @@ import {
   UtcInstantSchema as UtcInstant,
   strictParseOptions as StrictParseOptions,
 } from './schemas'
+import { Pipeable } from './pipeable'
 export enum DataSource {
   Alpaca = 'alpaca',
 }
@@ -248,10 +249,21 @@ export const makeStrategyProtocolHashResult = (
     ),
   )
 
-export const decodeFinalizedSnapshot = Schema.decodeUnknownEffect(FinalizedSnapshotProvenanceSchema, StrictParseOptions)
-export const decodeEvaluationBounds = Schema.decodeUnknownEffect(EvaluationBoundsSchema, StrictParseOptions)
-export const decodeRunIdentity = Schema.decodeUnknownEffect(RunIdentitySchema, StrictParseOptions)
-export const decodeRuntimeProvenance = Schema.decodeUnknownEffect(RuntimeProvenanceSchema, StrictParseOptions)
+const decodeFinalizedSnapshotDataFirst = Schema.decodeUnknownEffect(
+  FinalizedSnapshotProvenanceSchema,
+  StrictParseOptions,
+)
+
+export const decodeFinalizedSnapshot = Pipeable.dual(1, (input: unknown) => decodeFinalizedSnapshotDataFirst(input))
+const decodeEvaluationBoundsDataFirst = Schema.decodeUnknownEffect(EvaluationBoundsSchema, StrictParseOptions)
+
+export const decodeEvaluationBounds = Pipeable.dual(1, (input: unknown) => decodeEvaluationBoundsDataFirst(input))
+const decodeRunIdentityDataFirst = Schema.decodeUnknownEffect(RunIdentitySchema, StrictParseOptions)
+
+export const decodeRunIdentity = Pipeable.dual(1, (input: unknown) => decodeRunIdentityDataFirst(input))
+const decodeRuntimeProvenanceDataFirst = Schema.decodeUnknownEffect(RuntimeProvenanceSchema, StrictParseOptions)
+
+export const decodeRuntimeProvenance = Pipeable.dual(1, (input: unknown) => decodeRuntimeProvenanceDataFirst(input))
 
 const decodeRunIdentityMaterialSync = Schema.decodeUnknownSync(RunIdentityMaterialSchema, StrictParseOptions)
 const decodeRunIdentitySync = Schema.decodeUnknownSync(RunIdentitySchema, StrictParseOptions)

--- a/services/bayn/src/cycle-runner/cycle-model.ts
+++ b/services/bayn/src/cycle-runner/cycle-model.ts
@@ -10,6 +10,7 @@ import {
   UtcInstantSchema,
   strictParseOptions,
 } from '../schemas'
+import { Pipeable } from '../pipeable'
 
 export const cycleTimeZone = 'America/New_York' as const
 export const maximumSubmissionDurationMs = 86_400_000
@@ -396,40 +397,86 @@ export const CycleWindowPolicyInputSchema = Schema.Union([
 export type SignalCycleSession = typeof SignalCycleSessionSchema.Type
 export type CycleWindowPolicyInput = typeof CycleWindowPolicyInputSchema.Type
 
-export const decodeExecutionCalendarMaterialResult = Schema.decodeUnknownResult(
+const decodeExecutionCalendarMaterialResultDataFirst = Schema.decodeUnknownResult(
   ExecutionCalendarObservationMaterialSchema,
   strictParseOptions,
 )
-export const decodeExecutionCalendarObservationResult = Schema.decodeUnknownResult(
+
+export const decodeExecutionCalendarMaterialResult = Pipeable.dual(1, (input: unknown) =>
+  decodeExecutionCalendarMaterialResultDataFirst(input),
+)
+const decodeExecutionCalendarObservationResultDataFirst = Schema.decodeUnknownResult(
   ExecutionCalendarObservationSchema,
   strictParseOptions,
 )
-export const decodeCycleWindowPolicyInputResult = Schema.decodeUnknownResult(
+
+export const decodeExecutionCalendarObservationResult = Pipeable.dual(1, (input: unknown) =>
+  decodeExecutionCalendarObservationResultDataFirst(input),
+)
+const decodeCycleWindowPolicyInputResultDataFirst = Schema.decodeUnknownResult(
   CycleWindowPolicyInputSchema,
   strictParseOptions,
 )
-export const decodeCycleExecutionPolicyMaterialResult = Schema.decodeUnknownResult(
+
+export const decodeCycleWindowPolicyInputResult = Pipeable.dual(1, (input: unknown) =>
+  decodeCycleWindowPolicyInputResultDataFirst(input),
+)
+const decodeCycleExecutionPolicyMaterialResultDataFirst = Schema.decodeUnknownResult(
   CycleExecutionPolicyMaterialSchema,
   strictParseOptions,
 )
-export const decodeCycleExecutionPolicyResult = Schema.decodeUnknownResult(
+
+export const decodeCycleExecutionPolicyMaterialResult = Pipeable.dual(1, (input: unknown) =>
+  decodeCycleExecutionPolicyMaterialResultDataFirst(input),
+)
+const decodeCycleExecutionPolicyResultDataFirst = Schema.decodeUnknownResult(
   CycleExecutionPolicySchema,
   strictParseOptions,
 )
-export const decodeCycleIdentityMaterialResult = Schema.decodeUnknownResult(
+
+export const decodeCycleExecutionPolicyResult = Pipeable.dual(1, (input: unknown) =>
+  decodeCycleExecutionPolicyResultDataFirst(input),
+)
+const decodeCycleIdentityMaterialResultDataFirst = Schema.decodeUnknownResult(
   CycleIdentityMaterialSchema,
   strictParseOptions,
 )
-export const decodeCycleIdentityResult = Schema.decodeUnknownResult(CycleIdentitySchema, strictParseOptions)
-export const decodeCycleWindowResult = Schema.decodeUnknownResult(CycleWindowSchema, strictParseOptions)
-export const decodeCycleDraftResult = Schema.decodeUnknownResult(CycleDraftSchema, strictParseOptions)
 
-export const decodeExecutionCalendarObservation = Schema.decodeUnknownEffect(
+export const decodeCycleIdentityMaterialResult = Pipeable.dual(1, (input: unknown) =>
+  decodeCycleIdentityMaterialResultDataFirst(input),
+)
+const decodeCycleIdentityResultDataFirst = Schema.decodeUnknownResult(CycleIdentitySchema, strictParseOptions)
+
+export const decodeCycleIdentityResult = Pipeable.dual(1, (input: unknown) => decodeCycleIdentityResultDataFirst(input))
+const decodeCycleWindowResultDataFirst = Schema.decodeUnknownResult(CycleWindowSchema, strictParseOptions)
+
+export const decodeCycleWindowResult = Pipeable.dual(1, (input: unknown) => decodeCycleWindowResultDataFirst(input))
+const decodeCycleDraftResultDataFirst = Schema.decodeUnknownResult(CycleDraftSchema, strictParseOptions)
+
+export const decodeCycleDraftResult = Pipeable.dual(1, (input: unknown) => decodeCycleDraftResultDataFirst(input))
+
+const decodeExecutionCalendarObservationDataFirst = Schema.decodeUnknownEffect(
   ExecutionCalendarObservationSchema,
   strictParseOptions,
 )
-export const decodeCycleExecutionPolicy = Schema.decodeUnknownEffect(CycleExecutionPolicySchema, strictParseOptions)
-export const decodeCycleIdentity = Schema.decodeUnknownEffect(CycleIdentitySchema, strictParseOptions)
-export const decodeCycleWindow = Schema.decodeUnknownEffect(CycleWindowSchema, strictParseOptions)
-export const decodeCycleDraft = Schema.decodeUnknownEffect(CycleDraftSchema, strictParseOptions)
-export const decodeAutonomousCycle = Schema.decodeUnknownEffect(AutonomousCycleSchema, strictParseOptions)
+
+export const decodeExecutionCalendarObservation = Pipeable.dual(1, (input: unknown) =>
+  decodeExecutionCalendarObservationDataFirst(input),
+)
+const decodeCycleExecutionPolicyDataFirst = Schema.decodeUnknownEffect(CycleExecutionPolicySchema, strictParseOptions)
+
+export const decodeCycleExecutionPolicy = Pipeable.dual(1, (input: unknown) =>
+  decodeCycleExecutionPolicyDataFirst(input),
+)
+const decodeCycleIdentityDataFirst = Schema.decodeUnknownEffect(CycleIdentitySchema, strictParseOptions)
+
+export const decodeCycleIdentity = Pipeable.dual(1, (input: unknown) => decodeCycleIdentityDataFirst(input))
+const decodeCycleWindowDataFirst = Schema.decodeUnknownEffect(CycleWindowSchema, strictParseOptions)
+
+export const decodeCycleWindow = Pipeable.dual(1, (input: unknown) => decodeCycleWindowDataFirst(input))
+const decodeCycleDraftDataFirst = Schema.decodeUnknownEffect(CycleDraftSchema, strictParseOptions)
+
+export const decodeCycleDraft = Pipeable.dual(1, (input: unknown) => decodeCycleDraftDataFirst(input))
+const decodeAutonomousCycleDataFirst = Schema.decodeUnknownEffect(AutonomousCycleSchema, strictParseOptions)
+
+export const decodeAutonomousCycle = Pipeable.dual(1, (input: unknown) => decodeAutonomousCycleDataFirst(input))

--- a/services/bayn/src/db/cycle-store/rows.ts
+++ b/services/bayn/src/db/cycle-store/rows.ts
@@ -16,6 +16,7 @@ import {
   strictParseOptions,
 } from '../../schemas'
 import { CycleDecisionDocumentSchema } from '../../shadow-decision-contract'
+import { Pipeable } from '../../pipeable'
 
 const StoredCycleRowSchema = Schema.Struct({
   cycle_id: Sha256Schema,
@@ -89,21 +90,51 @@ const StoredDecisionDocumentRowsSchema = Schema.Array(
   }),
 )
 
-export const decodeCycleId = Schema.decodeUnknownEffect(Sha256Schema, strictParseOptions)
-export const decodeCycleIdInput = Schema.decodeUnknownEffect(CycleIdInputSchema, strictParseOptions)
-export const decodeCycleAuthoritySlot = Schema.decodeUnknownEffect(CycleAuthoritySlotSchema, strictParseOptions)
-export const decodeCycleRecoveryScope = Schema.decodeUnknownEffect(CycleRecoveryScopeSchema, strictParseOptions)
-export const decodeSnapshotInput = Schema.decodeUnknownEffect(SnapshotInputSchema, strictParseOptions)
-export const decodeDecisionInput = Schema.decodeUnknownEffect(DecisionInputSchema, strictParseOptions)
-export const decodeBlockInput = Schema.decodeUnknownEffect(BlockInputSchema, strictParseOptions)
-export const decodeFinishInput = Schema.decodeUnknownEffect(FinishInputSchema, strictParseOptions)
-export const decodeCycleDraft = Schema.decodeUnknownEffect(CycleDraftSchema, strictParseOptions)
-export const decodeObservedAt = Schema.decodeUnknownEffect(UtcInstantSchema, strictParseOptions)
-export const decodeMutationRows = Schema.decodeUnknownEffect(MutationRowsSchema, strictParseOptions)
-export const decodeDecisionEvidenceMatch = Schema.decodeUnknownEffect(DecisionEvidenceMatchSchema, strictParseOptions)
-export const decodeStoredDecisionDocumentRows = Schema.decodeUnknownEffect(
+const decodeCycleIdDataFirst = Schema.decodeUnknownEffect(Sha256Schema, strictParseOptions)
+
+export const decodeCycleId = Pipeable.dual(1, (input: unknown) => decodeCycleIdDataFirst(input))
+const decodeCycleIdInputDataFirst = Schema.decodeUnknownEffect(CycleIdInputSchema, strictParseOptions)
+
+export const decodeCycleIdInput = Pipeable.dual(1, (input: unknown) => decodeCycleIdInputDataFirst(input))
+const decodeCycleAuthoritySlotDataFirst = Schema.decodeUnknownEffect(CycleAuthoritySlotSchema, strictParseOptions)
+
+export const decodeCycleAuthoritySlot = Pipeable.dual(1, (input: unknown) => decodeCycleAuthoritySlotDataFirst(input))
+const decodeCycleRecoveryScopeDataFirst = Schema.decodeUnknownEffect(CycleRecoveryScopeSchema, strictParseOptions)
+
+export const decodeCycleRecoveryScope = Pipeable.dual(1, (input: unknown) => decodeCycleRecoveryScopeDataFirst(input))
+const decodeSnapshotInputDataFirst = Schema.decodeUnknownEffect(SnapshotInputSchema, strictParseOptions)
+
+export const decodeSnapshotInput = Pipeable.dual(1, (input: unknown) => decodeSnapshotInputDataFirst(input))
+const decodeDecisionInputDataFirst = Schema.decodeUnknownEffect(DecisionInputSchema, strictParseOptions)
+
+export const decodeDecisionInput = Pipeable.dual(1, (input: unknown) => decodeDecisionInputDataFirst(input))
+const decodeBlockInputDataFirst = Schema.decodeUnknownEffect(BlockInputSchema, strictParseOptions)
+
+export const decodeBlockInput = Pipeable.dual(1, (input: unknown) => decodeBlockInputDataFirst(input))
+const decodeFinishInputDataFirst = Schema.decodeUnknownEffect(FinishInputSchema, strictParseOptions)
+
+export const decodeFinishInput = Pipeable.dual(1, (input: unknown) => decodeFinishInputDataFirst(input))
+const decodeCycleDraftDataFirst = Schema.decodeUnknownEffect(CycleDraftSchema, strictParseOptions)
+
+export const decodeCycleDraft = Pipeable.dual(1, (input: unknown) => decodeCycleDraftDataFirst(input))
+const decodeObservedAtDataFirst = Schema.decodeUnknownEffect(UtcInstantSchema, strictParseOptions)
+
+export const decodeObservedAt = Pipeable.dual(1, (input: unknown) => decodeObservedAtDataFirst(input))
+const decodeMutationRowsDataFirst = Schema.decodeUnknownEffect(MutationRowsSchema, strictParseOptions)
+
+export const decodeMutationRows = Pipeable.dual(1, (input: unknown) => decodeMutationRowsDataFirst(input))
+const decodeDecisionEvidenceMatchDataFirst = Schema.decodeUnknownEffect(DecisionEvidenceMatchSchema, strictParseOptions)
+
+export const decodeDecisionEvidenceMatch = Pipeable.dual(1, (input: unknown) =>
+  decodeDecisionEvidenceMatchDataFirst(input),
+)
+const decodeStoredDecisionDocumentRowsDataFirst = Schema.decodeUnknownEffect(
   StoredDecisionDocumentRowsSchema,
   strictParseOptions,
+)
+
+export const decodeStoredDecisionDocumentRows = Pipeable.dual(1, (input: unknown) =>
+  decodeStoredDecisionDocumentRowsDataFirst(input),
 )
 
 const decodeAutonomousCycleResult = Schema.decodeUnknownEffect(AutonomousCycleSchema, strictParseOptions)

--- a/services/bayn/src/db/evidence-recovery/decoders.ts
+++ b/services/bayn/src/db/evidence-recovery/decoders.ts
@@ -15,34 +15,77 @@ import {
   SimulatedOrdersArtifactSchema,
 } from '../../evidence-contracts'
 import { strictParseOptions } from '../../schemas'
+import { Pipeable } from '../../pipeable'
 
-export const decodeEvaluationSummary = Schema.decodeUnknownResult(EvaluationSummarySchema, strictParseOptions)
-export const decodeReconciliationResult = Schema.decodeUnknownResult(ReconciliationResultSchema, strictParseOptions)
-export const decodeMarkedEquityReconciliation = Schema.decodeUnknownResult(
+const decodeEvaluationSummaryDataFirst = Schema.decodeUnknownResult(EvaluationSummarySchema, strictParseOptions)
+
+export const decodeEvaluationSummary = Pipeable.dual(1, (input: unknown) => decodeEvaluationSummaryDataFirst(input))
+const decodeReconciliationResultDataFirst = Schema.decodeUnknownResult(ReconciliationResultSchema, strictParseOptions)
+
+export const decodeReconciliationResult = Pipeable.dual(1, (input: unknown) =>
+  decodeReconciliationResultDataFirst(input),
+)
+const decodeMarkedEquityReconciliationDataFirst = Schema.decodeUnknownResult(
   MarkedEquityReconciliationSchema,
   strictParseOptions,
 )
-export const decodeEquitySeriesArtifact = Schema.decodeUnknownResult(EquitySeriesArtifactSchema, strictParseOptions)
-export const decodeEvaluationEvents = Schema.decodeUnknownResult(EvaluationEventsSchema, strictParseOptions)
-export const decodeSimulatedOrdersArtifact = Schema.decodeUnknownResult(
+
+export const decodeMarkedEquityReconciliation = Pipeable.dual(1, (input: unknown) =>
+  decodeMarkedEquityReconciliationDataFirst(input),
+)
+const decodeEquitySeriesArtifactDataFirst = Schema.decodeUnknownResult(EquitySeriesArtifactSchema, strictParseOptions)
+
+export const decodeEquitySeriesArtifact = Pipeable.dual(1, (input: unknown) =>
+  decodeEquitySeriesArtifactDataFirst(input),
+)
+const decodeEvaluationEventsDataFirst = Schema.decodeUnknownResult(EvaluationEventsSchema, strictParseOptions)
+
+export const decodeEvaluationEvents = Pipeable.dual(1, (input: unknown) => decodeEvaluationEventsDataFirst(input))
+const decodeSimulatedOrdersArtifactDataFirst = Schema.decodeUnknownResult(
   SimulatedOrdersArtifactSchema,
   strictParseOptions,
 )
-export const decodeSignalDecisionsArtifact = Schema.decodeUnknownResult(
+
+export const decodeSimulatedOrdersArtifact = Pipeable.dual(1, (input: unknown) =>
+  decodeSimulatedOrdersArtifactDataFirst(input),
+)
+const decodeSignalDecisionsArtifactDataFirst = Schema.decodeUnknownResult(
   RiskBalancedTrendSignalDecisionsArtifactSchema,
   strictParseOptions,
 )
-export const decodeDailyPerformanceSeriesArtifact = Schema.decodeUnknownResult(
+
+export const decodeSignalDecisionsArtifact = Pipeable.dual(1, (input: unknown) =>
+  decodeSignalDecisionsArtifactDataFirst(input),
+)
+const decodeDailyPerformanceSeriesArtifactDataFirst = Schema.decodeUnknownResult(
   DailyPerformanceSeriesArtifactSchema,
   strictParseOptions,
 )
-export const decodeQualificationArtifactManifest = Schema.decodeUnknownResult(
+
+export const decodeDailyPerformanceSeriesArtifact = Pipeable.dual(1, (input: unknown) =>
+  decodeDailyPerformanceSeriesArtifactDataFirst(input),
+)
+const decodeQualificationArtifactManifestDataFirst = Schema.decodeUnknownResult(
   QualificationArtifactManifestSchema,
   strictParseOptions,
 )
-export const decodeCashChangesArtifact = Schema.decodeUnknownResult(CashChangesArtifactSchema, strictParseOptions)
-export const decodeDailyPositionMarksArtifact = Schema.decodeUnknownResult(
+
+export const decodeQualificationArtifactManifest = Pipeable.dual(1, (input: unknown) =>
+  decodeQualificationArtifactManifestDataFirst(input),
+)
+const decodeCashChangesArtifactDataFirst = Schema.decodeUnknownResult(CashChangesArtifactSchema, strictParseOptions)
+
+export const decodeCashChangesArtifact = Pipeable.dual(1, (input: unknown) => decodeCashChangesArtifactDataFirst(input))
+const decodeDailyPositionMarksArtifactDataFirst = Schema.decodeUnknownResult(
   DailyPositionMarksArtifactSchema,
   strictParseOptions,
 )
-export const decodeInputManifestArtifact = Schema.decodeUnknownResult(InputManifestArtifactSchema, strictParseOptions)
+
+export const decodeDailyPositionMarksArtifact = Pipeable.dual(1, (input: unknown) =>
+  decodeDailyPositionMarksArtifactDataFirst(input),
+)
+const decodeInputManifestArtifactDataFirst = Schema.decodeUnknownResult(InputManifestArtifactSchema, strictParseOptions)
+
+export const decodeInputManifestArtifact = Pipeable.dual(1, (input: unknown) =>
+  decodeInputManifestArtifactDataFirst(input),
+)

--- a/services/bayn/src/db/execution-store/rows.ts
+++ b/services/bayn/src/db/execution-store/rows.ts
@@ -24,6 +24,7 @@ import {
   strictParseOptions,
 } from '../../schemas'
 import { AccountingReceiptRowSchema, AccountingTransactionRowSchema } from '../accounting-rows'
+import { Pipeable } from '../../pipeable'
 
 export const EventKind = Schema.Literals(['ACCOUNT', 'POSITION', 'ORDER', 'FILL'])
 export const EventRow = Schema.Struct({
@@ -200,52 +201,132 @@ export const MutationBaselineRow = Schema.Tuple([
 export const DatabaseInstantRow = Schema.Tuple([Schema.Struct({ activated_at: Schema.Date })])
 export const AuthorityRestrictionInput = Schema.Struct({ reason: NonEmptyString, updatedAt: UtcInstant })
 
-export const decodeEventInput = Schema.decodeUnknownEffect(BrokerEventInputSchema, strictParseOptions)
-export const decodeFillInput = Schema.decodeUnknownEffect(FillEventInputSchema, strictParseOptions)
-export const decodePositionSnapshotInput = Schema.decodeUnknownEffect(PositionSnapshotInputSchema, strictParseOptions)
-export const decodeValuationInput = Schema.decodeUnknownEffect(ValuationInputSchema, strictParseOptions)
-export const decodeEventRows = Schema.decodeUnknownEffect(Schema.Array(EventRow), strictParseOptions)
-export const decodeLastSequence = Schema.decodeUnknownEffect(LastSequenceRow, strictParseOptions)
-export const decodePositionCost = Schema.decodeUnknownEffect(PositionCostRow, strictParseOptions)
-export const decodeUnresolvedPredecessor = Schema.decodeUnknownEffect(UnresolvedPredecessorRow, strictParseOptions)
-export const decodeAccountBaseline = Schema.decodeUnknownEffect(AccountBaselineRow, strictParseOptions)
-export const decodeAccountId = Schema.decodeUnknownEffect(NonEmptyString, strictParseOptions)
-export const decodeTransactionRows = Schema.decodeUnknownEffect(
+const decodeEventInputDataFirst = Schema.decodeUnknownEffect(BrokerEventInputSchema, strictParseOptions)
+
+export const decodeEventInput = Pipeable.dual(1, (input: unknown) => decodeEventInputDataFirst(input))
+const decodeFillInputDataFirst = Schema.decodeUnknownEffect(FillEventInputSchema, strictParseOptions)
+
+export const decodeFillInput = Pipeable.dual(1, (input: unknown) => decodeFillInputDataFirst(input))
+const decodePositionSnapshotInputDataFirst = Schema.decodeUnknownEffect(PositionSnapshotInputSchema, strictParseOptions)
+
+export const decodePositionSnapshotInput = Pipeable.dual(1, (input: unknown) =>
+  decodePositionSnapshotInputDataFirst(input),
+)
+const decodeValuationInputDataFirst = Schema.decodeUnknownEffect(ValuationInputSchema, strictParseOptions)
+
+export const decodeValuationInput = Pipeable.dual(1, (input: unknown) => decodeValuationInputDataFirst(input))
+const decodeEventRowsDataFirst = Schema.decodeUnknownEffect(Schema.Array(EventRow), strictParseOptions)
+
+export const decodeEventRows = Pipeable.dual(1, (input: unknown) => decodeEventRowsDataFirst(input))
+const decodeLastSequenceDataFirst = Schema.decodeUnknownEffect(LastSequenceRow, strictParseOptions)
+
+export const decodeLastSequence = Pipeable.dual(1, (input: unknown) => decodeLastSequenceDataFirst(input))
+const decodePositionCostDataFirst = Schema.decodeUnknownEffect(PositionCostRow, strictParseOptions)
+
+export const decodePositionCost = Pipeable.dual(1, (input: unknown) => decodePositionCostDataFirst(input))
+const decodeUnresolvedPredecessorDataFirst = Schema.decodeUnknownEffect(UnresolvedPredecessorRow, strictParseOptions)
+
+export const decodeUnresolvedPredecessor = Pipeable.dual(1, (input: unknown) =>
+  decodeUnresolvedPredecessorDataFirst(input),
+)
+const decodeAccountBaselineDataFirst = Schema.decodeUnknownEffect(AccountBaselineRow, strictParseOptions)
+
+export const decodeAccountBaseline = Pipeable.dual(1, (input: unknown) => decodeAccountBaselineDataFirst(input))
+const decodeAccountIdDataFirst = Schema.decodeUnknownEffect(NonEmptyString, strictParseOptions)
+
+export const decodeAccountId = Pipeable.dual(1, (input: unknown) => decodeAccountIdDataFirst(input))
+const decodeTransactionRowsDataFirst = Schema.decodeUnknownEffect(
   Schema.Array(AccountingTransactionRowSchema),
   strictParseOptions,
 )
-export const decodeReceiptRows = Schema.decodeUnknownEffect(
+
+export const decodeTransactionRows = Pipeable.dual(1, (input: unknown) => decodeTransactionRowsDataFirst(input))
+const decodeReceiptRowsDataFirst = Schema.decodeUnknownEffect(
   Schema.Array(AccountingReceiptRowSchema),
   strictParseOptions,
 )
-export const decodeAccountRows = Schema.decodeUnknownEffect(AccountRow, strictParseOptions)
-export const decodePositionRows = Schema.decodeUnknownEffect(Schema.Array(PositionRow), strictParseOptions)
-export const decodePositionSnapshotRows = Schema.decodeUnknownEffect(
+
+export const decodeReceiptRows = Pipeable.dual(1, (input: unknown) => decodeReceiptRowsDataFirst(input))
+const decodeAccountRowsDataFirst = Schema.decodeUnknownEffect(AccountRow, strictParseOptions)
+
+export const decodeAccountRows = Pipeable.dual(1, (input: unknown) => decodeAccountRowsDataFirst(input))
+const decodePositionRowsDataFirst = Schema.decodeUnknownEffect(Schema.Array(PositionRow), strictParseOptions)
+
+export const decodePositionRows = Pipeable.dual(1, (input: unknown) => decodePositionRowsDataFirst(input))
+const decodePositionSnapshotRowsDataFirst = Schema.decodeUnknownEffect(
   Schema.Array(PositionSnapshotRow),
   strictParseOptions,
 )
-export const decodeEventIdRows = Schema.decodeUnknownEffect(Schema.Array(EventIdRow), strictParseOptions)
-export const decodeSnapshotIdRows = Schema.decodeUnknownEffect(Schema.Array(SnapshotIdRow), strictParseOptions)
-export const decodeValuationRows = Schema.decodeUnknownEffect(Schema.Array(ValuationRow), strictParseOptions)
-export const decodeEnsureAuthorityGenerationInput = Schema.decodeUnknownEffect(
+
+export const decodePositionSnapshotRows = Pipeable.dual(1, (input: unknown) =>
+  decodePositionSnapshotRowsDataFirst(input),
+)
+const decodeEventIdRowsDataFirst = Schema.decodeUnknownEffect(Schema.Array(EventIdRow), strictParseOptions)
+
+export const decodeEventIdRows = Pipeable.dual(1, (input: unknown) => decodeEventIdRowsDataFirst(input))
+const decodeSnapshotIdRowsDataFirst = Schema.decodeUnknownEffect(Schema.Array(SnapshotIdRow), strictParseOptions)
+
+export const decodeSnapshotIdRows = Pipeable.dual(1, (input: unknown) => decodeSnapshotIdRowsDataFirst(input))
+const decodeValuationRowsDataFirst = Schema.decodeUnknownEffect(Schema.Array(ValuationRow), strictParseOptions)
+
+export const decodeValuationRows = Pipeable.dual(1, (input: unknown) => decodeValuationRowsDataFirst(input))
+const decodeEnsureAuthorityGenerationInputDataFirst = Schema.decodeUnknownEffect(
   EnsureAuthorityGenerationInputSchema,
   strictParseOptions,
 )
-export const decodeAuthorityStateRows = Schema.decodeUnknownEffect(AuthorityStateRows, strictParseOptions)
-export const decodeAuthorityStateObservationRows = Schema.decodeUnknownEffect(
+
+export const decodeEnsureAuthorityGenerationInput = Pipeable.dual(1, (input: unknown) =>
+  decodeEnsureAuthorityGenerationInputDataFirst(input),
+)
+const decodeAuthorityStateRowsDataFirst = Schema.decodeUnknownEffect(AuthorityStateRows, strictParseOptions)
+
+export const decodeAuthorityStateRows = Pipeable.dual(1, (input: unknown) => decodeAuthorityStateRowsDataFirst(input))
+const decodeAuthorityStateObservationRowsDataFirst = Schema.decodeUnknownEffect(
   AuthorityStateObservationRows,
   strictParseOptions,
 )
-export const decodeAuthorityGenerationRows = Schema.decodeUnknownEffect(AuthorityGenerationRows, strictParseOptions)
-export const decodeActivationEvidenceRows = Schema.decodeUnknownEffect(ActivationEvidenceRows, strictParseOptions)
-export const decodeActivationReconciliationRows = Schema.decodeUnknownEffect(
+
+export const decodeAuthorityStateObservationRows = Pipeable.dual(1, (input: unknown) =>
+  decodeAuthorityStateObservationRowsDataFirst(input),
+)
+const decodeAuthorityGenerationRowsDataFirst = Schema.decodeUnknownEffect(AuthorityGenerationRows, strictParseOptions)
+
+export const decodeAuthorityGenerationRows = Pipeable.dual(1, (input: unknown) =>
+  decodeAuthorityGenerationRowsDataFirst(input),
+)
+const decodeActivationEvidenceRowsDataFirst = Schema.decodeUnknownEffect(ActivationEvidenceRows, strictParseOptions)
+
+export const decodeActivationEvidenceRows = Pipeable.dual(1, (input: unknown) =>
+  decodeActivationEvidenceRowsDataFirst(input),
+)
+const decodeActivationReconciliationRowsDataFirst = Schema.decodeUnknownEffect(
   ActivationReconciliationRows,
   strictParseOptions,
 )
-export const decodeMutationBaseline = Schema.decodeUnknownEffect(MutationBaselineRow, strictParseOptions)
-export const decodeDatabaseInstant = Schema.decodeUnknownEffect(DatabaseInstantRow, strictParseOptions)
-export const decodeBrokerEvent = Schema.decodeUnknownEffect(BrokerEventSchema, strictParseOptions)
-export const decodeReceipt = Schema.decodeUnknownEffect(AccountingReceiptSchema, strictParseOptions)
-export const decodeValuation = Schema.decodeUnknownEffect(ValuationSchema, strictParseOptions)
-export const decodeTransaction = Schema.decodeUnknownEffect(AccountingTransactionSchema, strictParseOptions)
-export const decodeAuthorityRestriction = Schema.decodeUnknownEffect(AuthorityRestrictionInput, strictParseOptions)
+
+export const decodeActivationReconciliationRows = Pipeable.dual(1, (input: unknown) =>
+  decodeActivationReconciliationRowsDataFirst(input),
+)
+const decodeMutationBaselineDataFirst = Schema.decodeUnknownEffect(MutationBaselineRow, strictParseOptions)
+
+export const decodeMutationBaseline = Pipeable.dual(1, (input: unknown) => decodeMutationBaselineDataFirst(input))
+const decodeDatabaseInstantDataFirst = Schema.decodeUnknownEffect(DatabaseInstantRow, strictParseOptions)
+
+export const decodeDatabaseInstant = Pipeable.dual(1, (input: unknown) => decodeDatabaseInstantDataFirst(input))
+const decodeBrokerEventDataFirst = Schema.decodeUnknownEffect(BrokerEventSchema, strictParseOptions)
+
+export const decodeBrokerEvent = Pipeable.dual(1, (input: unknown) => decodeBrokerEventDataFirst(input))
+const decodeReceiptDataFirst = Schema.decodeUnknownEffect(AccountingReceiptSchema, strictParseOptions)
+
+export const decodeReceipt = Pipeable.dual(1, (input: unknown) => decodeReceiptDataFirst(input))
+const decodeValuationDataFirst = Schema.decodeUnknownEffect(ValuationSchema, strictParseOptions)
+
+export const decodeValuation = Pipeable.dual(1, (input: unknown) => decodeValuationDataFirst(input))
+const decodeTransactionDataFirst = Schema.decodeUnknownEffect(AccountingTransactionSchema, strictParseOptions)
+
+export const decodeTransaction = Pipeable.dual(1, (input: unknown) => decodeTransactionDataFirst(input))
+const decodeAuthorityRestrictionDataFirst = Schema.decodeUnknownEffect(AuthorityRestrictionInput, strictParseOptions)
+
+export const decodeAuthorityRestriction = Pipeable.dual(1, (input: unknown) =>
+  decodeAuthorityRestrictionDataFirst(input),
+)

--- a/services/bayn/src/db/paper-cycle-closure.ts
+++ b/services/bayn/src/db/paper-cycle-closure.ts
@@ -3,6 +3,7 @@ import { Context, Data, Effect, Option, Result, Schema } from 'effect'
 import { canonicalHashV1Result } from '../hash'
 import { PaperDecisionDocumentSchema } from '../shadow-decision-contract'
 import { Sha256Schema, UtcInstantSchema, strictParseOptions } from '../schemas'
+import { Pipeable } from '../pipeable'
 
 const PaperCycleClosureMaterialSchema = Schema.Struct({
   schemaVersion: Schema.Literal('bayn.paper-cycle-closure.v1'),
@@ -66,9 +67,17 @@ export class PaperCycleClosureStore extends Context.Service<PaperCycleClosureSto
   'bayn/PaperCycleClosureStore',
 ) {}
 
-export const decodePaperCycleClosureResult = Schema.decodeUnknownResult(PaperCycleClosureSchema, strictParseOptions)
+const decodePaperCycleClosureResultDataFirst = Schema.decodeUnknownResult(PaperCycleClosureSchema, strictParseOptions)
 
-export const decodePaperCycleClosureMaterialResult = Schema.decodeUnknownResult(
+export const decodePaperCycleClosureResult = Pipeable.dual(1, (input: unknown) =>
+  decodePaperCycleClosureResultDataFirst(input),
+)
+
+const decodePaperCycleClosureMaterialResultDataFirst = Schema.decodeUnknownResult(
   PaperCycleClosureMaterialSchema,
   strictParseOptions,
+)
+
+export const decodePaperCycleClosureMaterialResult = Pipeable.dual(1, (input: unknown) =>
+  decodePaperCycleClosureMaterialResultDataFirst(input),
 )

--- a/services/bayn/src/evidence-contracts.ts
+++ b/services/bayn/src/evidence-contracts.ts
@@ -16,6 +16,7 @@ import {
   strictParseOptions as StrictParseOptions,
 } from './schemas'
 import { MARKED_EQUITY_TOLERANCE_MICROS } from './simulation-reconciliation/constants'
+import { Pipeable } from './pipeable'
 
 const Scalar = Schema.Union([Schema.Finite, Schema.Boolean, Schema.String])
 
@@ -422,35 +423,77 @@ export const EquitySeriesArtifactSchema = Schema.Struct({
   ).check(Schema.isMinLength(1)),
 })
 
-export const decodeEvaluationSummary = Schema.decodeUnknownEffect(EvaluationSummarySchema, StrictParseOptions)
-export const decodeReconciliationResult = Schema.decodeUnknownEffect(ReconciliationResultSchema, StrictParseOptions)
-export const decodeMarkedEquityReconciliation = Schema.decodeUnknownEffect(
+const decodeEvaluationSummaryDataFirst = Schema.decodeUnknownEffect(EvaluationSummarySchema, StrictParseOptions)
+
+export const decodeEvaluationSummary = Pipeable.dual(1, (input: unknown) => decodeEvaluationSummaryDataFirst(input))
+const decodeReconciliationResultDataFirst = Schema.decodeUnknownEffect(ReconciliationResultSchema, StrictParseOptions)
+
+export const decodeReconciliationResult = Pipeable.dual(1, (input: unknown) =>
+  decodeReconciliationResultDataFirst(input),
+)
+const decodeMarkedEquityReconciliationDataFirst = Schema.decodeUnknownEffect(
   MarkedEquityReconciliationSchema,
   StrictParseOptions,
 )
-export const decodeInputManifestArtifact = Schema.decodeUnknownEffect(InputManifestArtifactSchema, StrictParseOptions)
-export const decodeEquitySeriesArtifact = Schema.decodeUnknownEffect(EquitySeriesArtifactSchema, StrictParseOptions)
-export const decodeEvaluationEvents = Schema.decodeUnknownEffect(EvaluationEventsSchema, StrictParseOptions)
-export const decodeSimulatedOrdersArtifact = Schema.decodeUnknownEffect(
+
+export const decodeMarkedEquityReconciliation = Pipeable.dual(1, (input: unknown) =>
+  decodeMarkedEquityReconciliationDataFirst(input),
+)
+const decodeInputManifestArtifactDataFirst = Schema.decodeUnknownEffect(InputManifestArtifactSchema, StrictParseOptions)
+
+export const decodeInputManifestArtifact = Pipeable.dual(1, (input: unknown) =>
+  decodeInputManifestArtifactDataFirst(input),
+)
+const decodeEquitySeriesArtifactDataFirst = Schema.decodeUnknownEffect(EquitySeriesArtifactSchema, StrictParseOptions)
+
+export const decodeEquitySeriesArtifact = Pipeable.dual(1, (input: unknown) =>
+  decodeEquitySeriesArtifactDataFirst(input),
+)
+const decodeEvaluationEventsDataFirst = Schema.decodeUnknownEffect(EvaluationEventsSchema, StrictParseOptions)
+
+export const decodeEvaluationEvents = Pipeable.dual(1, (input: unknown) => decodeEvaluationEventsDataFirst(input))
+const decodeSimulatedOrdersArtifactDataFirst = Schema.decodeUnknownEffect(
   SimulatedOrdersArtifactSchema,
   StrictParseOptions,
 )
-export const decodeCashChangesArtifact = Schema.decodeUnknownEffect(CashChangesArtifactSchema, StrictParseOptions)
-export const decodeDailyPositionMarksArtifact = Schema.decodeUnknownEffect(
+
+export const decodeSimulatedOrdersArtifact = Pipeable.dual(1, (input: unknown) =>
+  decodeSimulatedOrdersArtifactDataFirst(input),
+)
+const decodeCashChangesArtifactDataFirst = Schema.decodeUnknownEffect(CashChangesArtifactSchema, StrictParseOptions)
+
+export const decodeCashChangesArtifact = Pipeable.dual(1, (input: unknown) => decodeCashChangesArtifactDataFirst(input))
+const decodeDailyPositionMarksArtifactDataFirst = Schema.decodeUnknownEffect(
   DailyPositionMarksArtifactSchema,
   StrictParseOptions,
 )
-export const decodeRiskBalancedTrendSignalDecisionsArtifact = Schema.decodeUnknownEffect(
+
+export const decodeDailyPositionMarksArtifact = Pipeable.dual(1, (input: unknown) =>
+  decodeDailyPositionMarksArtifactDataFirst(input),
+)
+const decodeRiskBalancedTrendSignalDecisionsArtifactDataFirst = Schema.decodeUnknownEffect(
   RiskBalancedTrendSignalDecisionsArtifactSchema,
   StrictParseOptions,
 )
-export const decodeDailyPerformanceSeriesArtifact = Schema.decodeUnknownEffect(
+
+export const decodeRiskBalancedTrendSignalDecisionsArtifact = Pipeable.dual(1, (input: unknown) =>
+  decodeRiskBalancedTrendSignalDecisionsArtifactDataFirst(input),
+)
+const decodeDailyPerformanceSeriesArtifactDataFirst = Schema.decodeUnknownEffect(
   DailyPerformanceSeriesArtifactSchema,
   StrictParseOptions,
 )
-export const decodeQualificationArtifactManifest = Schema.decodeUnknownEffect(
+
+export const decodeDailyPerformanceSeriesArtifact = Pipeable.dual(1, (input: unknown) =>
+  decodeDailyPerformanceSeriesArtifactDataFirst(input),
+)
+const decodeQualificationArtifactManifestDataFirst = Schema.decodeUnknownEffect(
   QualificationArtifactManifestSchema,
   StrictParseOptions,
+)
+
+export const decodeQualificationArtifactManifest = Pipeable.dual(1, (input: unknown) =>
+  decodeQualificationArtifactManifestDataFirst(input),
 )
 
 export const makeEquitySeriesArtifact = (items: (typeof EquitySeriesArtifactSchema.Type)['items']) => ({

--- a/services/bayn/src/execution-prepare/model.ts
+++ b/services/bayn/src/execution-prepare/model.ts
@@ -17,6 +17,7 @@ import {
   StrictNonEmptyStringSchema,
   strictParseOptions,
 } from '../schemas'
+import { Pipeable } from '../pipeable'
 
 export const executionPrepareRequestSchemaVersion = 'bayn.execution-prepare-request.v1' as const
 export const executionPrepareProofPlanSchemaVersion = 'bayn.execution-prepare-proof-plan.v1' as const
@@ -74,9 +75,13 @@ export const ExecutionPrepareRequestSchema = Schema.Struct({
 })
 export type ExecutionPrepareRequest = typeof ExecutionPrepareRequestSchema.Type
 
-export const decodeExecutionPrepareRequestResult = Schema.decodeUnknownResult(
+const decodeExecutionPrepareRequestResultDataFirst = Schema.decodeUnknownResult(
   ExecutionPrepareRequestSchema,
   strictParseOptions,
+)
+
+export const decodeExecutionPrepareRequestResult = Pipeable.dual(1, (input: unknown) =>
+  decodeExecutionPrepareRequestResultDataFirst(input),
 )
 
 export const ExecutionPrepareProofPlanRequestSchema = Schema.Struct({
@@ -87,9 +92,13 @@ export const ExecutionPrepareProofPlanRequestSchema = Schema.Struct({
 })
 export type ExecutionPrepareProofPlanRequest = typeof ExecutionPrepareProofPlanRequestSchema.Type
 
-export const decodeExecutionPrepareProofPlanRequestResult = Schema.decodeUnknownResult(
+const decodeExecutionPrepareProofPlanRequestResultDataFirst = Schema.decodeUnknownResult(
   ExecutionPrepareProofPlanRequestSchema,
   strictParseOptions,
+)
+
+export const decodeExecutionPrepareProofPlanRequestResult = Pipeable.dual(1, (input: unknown) =>
+  decodeExecutionPrepareProofPlanRequestResultDataFirst(input),
 )
 
 export const ExecutionPrepareRuntimeBindingSchema = Schema.Struct({
@@ -167,9 +176,13 @@ export const ExecutionPrepareReceiptSchema = ExecutionPrepareReceiptBase.check(
 )
 export type ExecutionPrepareReceipt = typeof ExecutionPrepareReceiptSchema.Type
 
-export const decodeExecutionPrepareReceiptResult = Schema.decodeUnknownResult(
+const decodeExecutionPrepareReceiptResultDataFirst = Schema.decodeUnknownResult(
   ExecutionPrepareReceiptSchema,
   strictParseOptions,
+)
+
+export const decodeExecutionPrepareReceiptResult = Pipeable.dual(1, (input: unknown) =>
+  decodeExecutionPrepareReceiptResultDataFirst(input),
 )
 
 export interface ExecutionPrepareOutput {

--- a/services/bayn/src/execution/authority.ts
+++ b/services/bayn/src/execution/authority.ts
@@ -14,6 +14,7 @@ import {
   UtcInstantSchema as UtcInstant,
   strictParseOptions as StrictParseOptions,
 } from '../schemas'
+import { Pipeable } from '../pipeable'
 
 export { BrokerEnvironment, BrokerEnvironmentSchema }
 
@@ -362,7 +363,11 @@ export const makeLiveCapitalGrant = (
   )
 
 export const decodeLiveCapitalGrant = (input: unknown) => decodeLiveGrant(input)
-export const decodeLiveCapitalGrantRevocation = Schema.decodeUnknownResult(
+const decodeLiveCapitalGrantRevocationDataFirst = Schema.decodeUnknownResult(
   LiveCapitalGrantRevocationSchema,
   StrictParseOptions,
+)
+
+export const decodeLiveCapitalGrantRevocation = Pipeable.dual(1, (input: unknown) =>
+  decodeLiveCapitalGrantRevocationDataFirst(input),
 )

--- a/services/bayn/src/execution/configuration.ts
+++ b/services/bayn/src/execution/configuration.ts
@@ -262,9 +262,13 @@ export const makeResearchPaperActivationRequest = (
   )
 }
 
-export const decodePaperActivationRequestResult = Schema.decodeUnknownResult(
+const decodePaperActivationRequestResultDataFirst = Schema.decodeUnknownResult(
   PaperActivationRequestSchema,
   strictParseOptions,
+)
+
+export const decodePaperActivationRequestResult = Pipeable.dual(1, (input: unknown) =>
+  decodePaperActivationRequestResultDataFirst(input),
 )
 
 export type CapitalAuthorityRequest = NoCapitalRequest | SandboxCapitalRequest | LiveCapitalGrantRequest

--- a/services/bayn/src/execution/contracts.ts
+++ b/services/bayn/src/execution/contracts.ts
@@ -12,6 +12,7 @@ import {
   UtcOrderTimestampSchema as UtcOrderTimestamp,
   strictParseOptions as StrictParseOptions,
 } from '../schemas'
+import { Pipeable } from '../pipeable'
 
 const U32_MAX = 4_294_967_295
 const U64_MAX = 18_446_744_073_709_551_615n
@@ -874,31 +875,80 @@ export const AuthorityStateSchema = AuthorityStateBase.check(
 )
 export type AuthorityState = typeof AuthorityStateSchema.Type
 
-export const decodeBrokerEvent = Schema.decodeUnknownEffect(BrokerEventSchema, StrictParseOptions)
-export const decodeAccountSnapshot = Schema.decodeUnknownEffect(AccountSnapshotSchema, StrictParseOptions)
-export const decodePosition = Schema.decodeUnknownEffect(PositionSchema, StrictParseOptions)
-export const decodeOrder = Schema.decodeUnknownEffect(OrderSchema, StrictParseOptions)
-export const decodeFill = Schema.decodeUnknownEffect(FillSchema, StrictParseOptions)
-export const decodeBrokerError = Schema.decodeUnknownEffect(BrokerErrorSchema, StrictParseOptions)
-export const decodeRateLimit = Schema.decodeUnknownEffect(RateLimitSchema, StrictParseOptions)
-export const decodeReferenceIntent = Schema.decodeUnknownEffect(ReferenceIntentSchema, StrictParseOptions)
-export const decodeIntent = Schema.decodeUnknownEffect(IntentSchema, StrictParseOptions)
-export const decodeRiskInput = Schema.decodeUnknownEffect(RiskInputSchema, StrictParseOptions)
-export const decodeRiskDecision = Schema.decodeUnknownEffect(RiskDecisionSchema, StrictParseOptions)
-export const decodeAccountingReceipt = Schema.decodeUnknownEffect(AccountingReceiptSchema, StrictParseOptions)
-export const decodeValuation = Schema.decodeUnknownEffect(ValuationSchema, StrictParseOptions)
-export const decodeReconciliation = Schema.decodeUnknownEffect(ReconciliationSchema, StrictParseOptions)
-export const decodeCapitalGrantProofBinding = Schema.decodeUnknownEffect(
+const decodeBrokerEventDataFirst = Schema.decodeUnknownEffect(BrokerEventSchema, StrictParseOptions)
+
+export const decodeBrokerEvent = Pipeable.dual(1, (input: unknown) => decodeBrokerEventDataFirst(input))
+const decodeAccountSnapshotDataFirst = Schema.decodeUnknownEffect(AccountSnapshotSchema, StrictParseOptions)
+
+export const decodeAccountSnapshot = Pipeable.dual(1, (input: unknown) => decodeAccountSnapshotDataFirst(input))
+const decodePositionDataFirst = Schema.decodeUnknownEffect(PositionSchema, StrictParseOptions)
+
+export const decodePosition = Pipeable.dual(1, (input: unknown) => decodePositionDataFirst(input))
+const decodeOrderDataFirst = Schema.decodeUnknownEffect(OrderSchema, StrictParseOptions)
+
+export const decodeOrder = Pipeable.dual(1, (input: unknown) => decodeOrderDataFirst(input))
+const decodeFillDataFirst = Schema.decodeUnknownEffect(FillSchema, StrictParseOptions)
+
+export const decodeFill = Pipeable.dual(1, (input: unknown) => decodeFillDataFirst(input))
+const decodeBrokerErrorDataFirst = Schema.decodeUnknownEffect(BrokerErrorSchema, StrictParseOptions)
+
+export const decodeBrokerError = Pipeable.dual(1, (input: unknown) => decodeBrokerErrorDataFirst(input))
+const decodeRateLimitDataFirst = Schema.decodeUnknownEffect(RateLimitSchema, StrictParseOptions)
+
+export const decodeRateLimit = Pipeable.dual(1, (input: unknown) => decodeRateLimitDataFirst(input))
+const decodeReferenceIntentDataFirst = Schema.decodeUnknownEffect(ReferenceIntentSchema, StrictParseOptions)
+
+export const decodeReferenceIntent = Pipeable.dual(1, (input: unknown) => decodeReferenceIntentDataFirst(input))
+const decodeIntentDataFirst = Schema.decodeUnknownEffect(IntentSchema, StrictParseOptions)
+
+export const decodeIntent = Pipeable.dual(1, (input: unknown) => decodeIntentDataFirst(input))
+const decodeRiskInputDataFirst = Schema.decodeUnknownEffect(RiskInputSchema, StrictParseOptions)
+
+export const decodeRiskInput = Pipeable.dual(1, (input: unknown) => decodeRiskInputDataFirst(input))
+const decodeRiskDecisionDataFirst = Schema.decodeUnknownEffect(RiskDecisionSchema, StrictParseOptions)
+
+export const decodeRiskDecision = Pipeable.dual(1, (input: unknown) => decodeRiskDecisionDataFirst(input))
+const decodeAccountingReceiptDataFirst = Schema.decodeUnknownEffect(AccountingReceiptSchema, StrictParseOptions)
+
+export const decodeAccountingReceipt = Pipeable.dual(1, (input: unknown) => decodeAccountingReceiptDataFirst(input))
+const decodeValuationDataFirst = Schema.decodeUnknownEffect(ValuationSchema, StrictParseOptions)
+
+export const decodeValuation = Pipeable.dual(1, (input: unknown) => decodeValuationDataFirst(input))
+const decodeReconciliationDataFirst = Schema.decodeUnknownEffect(ReconciliationSchema, StrictParseOptions)
+
+export const decodeReconciliation = Pipeable.dual(1, (input: unknown) => decodeReconciliationDataFirst(input))
+const decodeCapitalGrantProofBindingDataFirst = Schema.decodeUnknownEffect(
   CapitalGrantProofBindingSchema,
   StrictParseOptions,
 )
-export const decodeResearchCapitalGrantProofBinding = Schema.decodeUnknownEffect(
+
+export const decodeCapitalGrantProofBinding = Pipeable.dual(1, (input: unknown) =>
+  decodeCapitalGrantProofBindingDataFirst(input),
+)
+const decodeResearchCapitalGrantProofBindingDataFirst = Schema.decodeUnknownEffect(
   ResearchCapitalGrantProofBindingSchema,
   StrictParseOptions,
 )
-export const decodeCapitalGrantGeneration = Schema.decodeUnknownEffect(CapitalGrantGenerationSchema, StrictParseOptions)
-export const decodeResearchCapitalGrantGeneration = Schema.decodeUnknownEffect(
+
+export const decodeResearchCapitalGrantProofBinding = Pipeable.dual(1, (input: unknown) =>
+  decodeResearchCapitalGrantProofBindingDataFirst(input),
+)
+const decodeCapitalGrantGenerationDataFirst = Schema.decodeUnknownEffect(
+  CapitalGrantGenerationSchema,
+  StrictParseOptions,
+)
+
+export const decodeCapitalGrantGeneration = Pipeable.dual(1, (input: unknown) =>
+  decodeCapitalGrantGenerationDataFirst(input),
+)
+const decodeResearchCapitalGrantGenerationDataFirst = Schema.decodeUnknownEffect(
   ResearchCapitalGrantGenerationSchema,
   StrictParseOptions,
 )
-export const decodeAuthorityState = Schema.decodeUnknownEffect(AuthorityStateSchema, StrictParseOptions)
+
+export const decodeResearchCapitalGrantGeneration = Pipeable.dual(1, (input: unknown) =>
+  decodeResearchCapitalGrantGenerationDataFirst(input),
+)
+const decodeAuthorityStateDataFirst = Schema.decodeUnknownEffect(AuthorityStateSchema, StrictParseOptions)
+
+export const decodeAuthorityState = Pipeable.dual(1, (input: unknown) => decodeAuthorityStateDataFirst(input))

--- a/services/bayn/src/paper-proof/model.ts
+++ b/services/bayn/src/paper-proof/model.ts
@@ -19,6 +19,7 @@ import {
   StrictNonEmptyStringSchema,
   strictParseOptions,
 } from '../schemas'
+import { Pipeable } from '../pipeable'
 
 export const paperProofCommandSchemaVersion = 'bayn.paper-proof-command.v1' as const
 export const paperProofReceiptSchemaVersion = 'bayn.paper-proof-receipt.v1' as const
@@ -44,7 +45,11 @@ export const PaperProofCommandSchema = Schema.Struct({
 })
 export type PaperProofCommand = typeof PaperProofCommandSchema.Type
 
-export const decodePaperProofCommandResult = Schema.decodeUnknownResult(PaperProofCommandSchema, strictParseOptions)
+const decodePaperProofCommandResultDataFirst = Schema.decodeUnknownResult(PaperProofCommandSchema, strictParseOptions)
+
+export const decodePaperProofCommandResult = Pipeable.dual(1, (input: unknown) =>
+  decodePaperProofCommandResultDataFirst(input),
+)
 
 export interface PaperProofSourcePlan {
   readonly schemaVersion: 'bayn.paper-proof-plan.v1'
@@ -182,7 +187,11 @@ export const PaperProofCliEnvelopeSchema = Schema.Struct({
   protectedEntryToken: StrictNonEmptyStringSchema,
 })
 export type PaperProofCliEnvelope = typeof PaperProofCliEnvelopeSchema.Type
-export const decodePaperProofCliEnvelopeResult = Schema.decodeUnknownResult(
+const decodePaperProofCliEnvelopeResultDataFirst = Schema.decodeUnknownResult(
   PaperProofCliEnvelopeSchema,
   strictParseOptions,
+)
+
+export const decodePaperProofCliEnvelopeResult = Pipeable.dual(1, (input: unknown) =>
+  decodePaperProofCliEnvelopeResultDataFirst(input),
 )

--- a/services/bayn/src/pipeable.test.ts
+++ b/services/bayn/src/pipeable.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from 'bun:test'
+
+import { Pipeable } from './pipeable'
+
+describe('pipeable functions', () => {
+  test('supports unary data-first and data-last calls', () => {
+    const length = Pipeable.dual(1, (value: string) => value.length)
+
+    expect(length('bayn')).toBe(4)
+    expect(length()('bayn')).toBe(4)
+  })
+
+  test('delegates multi-argument calls to Effect dual', () => {
+    const append = Pipeable.dual(2, (self: string, suffix: string) => `${self}${suffix}`)
+
+    expect(append('bayn', '-paper')).toBe('bayn-paper')
+    expect(append('-paper')('bayn')).toBe('bayn-paper')
+  })
+})

--- a/services/bayn/src/pipeable.ts
+++ b/services/bayn/src/pipeable.ts
@@ -11,7 +11,16 @@ interface PipeableFunction<Self, Arguments extends ReadonlyArray<unknown>, Retur
 const dual = <DataFirst extends AnyFunction>(
   arity: Parameters<DataFirst>['length'],
   body: DataFirst,
-): PipeableFunction<Parameters<DataFirst>[0], Tail<Parameters<DataFirst>>, ReturnType<DataFirst>> =>
-  Function.dual(arity, body)
+): PipeableFunction<Parameters<DataFirst>[0], Tail<Parameters<DataFirst>>, ReturnType<DataFirst>> => {
+  if (arity !== 1) return Function.dual(arity, body)
+
+  const unaryBody = body as unknown as (self: Parameters<DataFirst>[0]) => ReturnType<DataFirst>
+  return ((...arguments_: ReadonlyArray<Parameters<DataFirst>[0]>) =>
+    arguments_.length === 0 ? unaryBody : unaryBody(arguments_[0])) as PipeableFunction<
+    Parameters<DataFirst>[0],
+    Tail<Parameters<DataFirst>>,
+    ReturnType<DataFirst>
+  >
+}
 
 export const Pipeable = { dual } as const

--- a/services/bayn/src/qualification-statistics/decoding.ts
+++ b/services/bayn/src/qualification-statistics/decoding.ts
@@ -9,15 +9,30 @@ import {
   QualificationSeriesSchema,
   QualificationStatisticsPolicySchema,
 } from './model'
+import { Pipeable } from '../pipeable'
 
-export const decodeQualificationSeries = Schema.decodeUnknownResult(QualificationSeriesSchema, strictParseOptions)
-export const decodeQualificationStatisticsPolicy = Schema.decodeUnknownResult(
+const decodeQualificationSeriesDataFirst = Schema.decodeUnknownResult(QualificationSeriesSchema, strictParseOptions)
+
+export const decodeQualificationSeries = Pipeable.dual(1, (input: unknown) => decodeQualificationSeriesDataFirst(input))
+const decodeQualificationStatisticsPolicyDataFirst = Schema.decodeUnknownResult(
   QualificationStatisticsPolicySchema,
   strictParseOptions,
 )
-export const decodeQualificationPower = Schema.decodeUnknownResult(PowerAnalysisSchema, strictParseOptions)
-export const decodeQualificationAnalysis = Schema.decodeUnknownResult(QualificationAnalysisSchema, strictParseOptions)
-export const decodePriorTrialRunIds = Schema.decodeUnknownResult(Schema.Array(Sha256Schema), strictParseOptions)
+
+export const decodeQualificationStatisticsPolicy = Pipeable.dual(1, (input: unknown) =>
+  decodeQualificationStatisticsPolicyDataFirst(input),
+)
+const decodeQualificationPowerDataFirst = Schema.decodeUnknownResult(PowerAnalysisSchema, strictParseOptions)
+
+export const decodeQualificationPower = Pipeable.dual(1, (input: unknown) => decodeQualificationPowerDataFirst(input))
+const decodeQualificationAnalysisDataFirst = Schema.decodeUnknownResult(QualificationAnalysisSchema, strictParseOptions)
+
+export const decodeQualificationAnalysis = Pipeable.dual(1, (input: unknown) =>
+  decodeQualificationAnalysisDataFirst(input),
+)
+const decodePriorTrialRunIdsDataFirst = Schema.decodeUnknownResult(Schema.Array(Sha256Schema), strictParseOptions)
+
+export const decodePriorTrialRunIds = Pipeable.dual(1, (input: unknown) => decodePriorTrialRunIdsDataFirst(input))
 
 export const qualificationStatisticsSchemaFailure =
   (

--- a/services/bayn/src/risk.ts
+++ b/services/bayn/src/risk.ts
@@ -38,6 +38,7 @@ import {
   UtcInstantSchema as UtcInstant,
   strictParseOptions as StrictParseOptions,
 } from './schemas'
+import { Pipeable } from './pipeable'
 
 const MAX_POLICY_MICROS = 9_223_372_036_854_775_807n
 const MAX_AGE_MS = 86_400_000
@@ -1291,5 +1292,9 @@ export const evaluate = (
   return evaluateDecoded(intent.success, state.success, policy.success, proposedPositions.success)
 }
 
-export const decodePolicy = Schema.decodeUnknownEffect(PolicySchema, StrictParseOptions)
-export const decodeState = Schema.decodeUnknownEffect(StateSchema, StrictParseOptions)
+const decodePolicyDataFirst = Schema.decodeUnknownEffect(PolicySchema, StrictParseOptions)
+
+export const decodePolicy = Pipeable.dual(1, (input: unknown) => decodePolicyDataFirst(input))
+const decodeStateDataFirst = Schema.decodeUnknownEffect(StateSchema, StrictParseOptions)
+
+export const decodeState = Pipeable.dual(1, (input: unknown) => decodeStateDataFirst(input))


### PR DESCRIPTION
## Summary

- Makes schema decoder factories pipeable and preserves typed decode failures at boundaries.
- Keeps this native stack layer independently reviewable at 720 changed lines.
- Bases directly on codex/bayn-effect-tsgo-pipeable-strategy so GitHub shows only this layer.

## Related Issues

None

## Testing

- bunx tsc --noEmit --project services/bayn/tsconfig.json
- bun run lint
- bun run lint:oxlint
- bun run lint:oxlint:type
- bun run build
- Focused tests for the touched subsystem were run while constructing the layer.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable and Breaking Changes is filled in.
- [x] Documentation and follow-ups are unchanged or represented by later stack layers.