### PR TITLE
refactor(bayn): make optional APIs pipeable

### DIFF
--- a/services/bayn/src/app.ts
+++ b/services/bayn/src/app.ts
@@ -20,6 +20,7 @@ import { runStartup, type StartupDependencies } from './startup'
 import type { StrategyRuntime } from './strategy'
 import { utcInstantFromEpochMillis } from './time'
 import type { ExecutionProgram } from './execution/runtime-program'
+import { Pipeable } from './pipeable'
 
 export type RecordAutonomousCyclePass = (observation: AutonomousCyclePassObservation) => Effect.Effect<void>
 
@@ -240,7 +241,7 @@ const startAutonomousCycle = <StartupR, LoopR>(
         }),
       )
 
-export const runApplication = <StartupR, LoopR>(
+const runApplicationDataFirst = <StartupR, LoopR>(
   config: RuntimeConfig,
   strategy: StrategyRuntime,
   dependencies: ApplicationDependencies,
@@ -276,3 +277,12 @@ export const runApplication = <StartupR, LoopR>(
     Effect.andThen(Effect.never),
     Effect.scoped,
   )
+
+export const runApplication = Pipeable.generic<
+  <StartupR, LoopR>(
+    strategy: StrategyRuntime,
+    dependencies: ApplicationDependencies,
+    runtime: ApplicationRuntime<StartupR, LoopR>,
+  ) => (config: RuntimeConfig) => Effect.Effect<never, OperationalError, HttpServer.HttpServer | StartupR | LoopR>,
+  typeof runApplicationDataFirst
+>(4, runApplicationDataFirst)

--- a/services/bayn/src/audit/reference.ts
+++ b/services/bayn/src/audit/reference.ts
@@ -35,6 +35,7 @@ import type {
   Target,
 } from './reference/model'
 import { replay } from './reference/replay'
+import { Pipeable } from '../pipeable'
 
 export type { ReferenceEvaluation, ReferenceEvaluationFailure } from './reference/model'
 export { restrictReferenceBuyFill } from './reference/replay'
@@ -325,7 +326,7 @@ const stripReplayWork = (replay: ReplayWithWork): Replay => ({
   trace: replay.trace,
 })
 
-export const evaluateReference = (
+const evaluateReferenceDataFirst = (
   bars: readonly DailyBar[],
   manifest: InputManifest,
   protocol: Protocol,
@@ -346,7 +347,18 @@ export const evaluateReference = (
     })),
   )
 
-export const measureReferenceEvaluationWork = (
+export const evaluateReference = Pipeable.by<
+  (
+    manifest: InputManifest,
+    protocol: Protocol,
+    provenance: RuntimeProvenance,
+    closeAtEnd?: boolean,
+    application?: StrategyApplication<any, any, any>,
+  ) => (bars: readonly DailyBar[]) => ReturnType<typeof evaluateReferenceDataFirst>,
+  typeof evaluateReferenceDataFirst
+>((arguments_) => Array.isArray(arguments_[0]), evaluateReferenceDataFirst)
+
+const measureReferenceEvaluationWorkDataFirst = (
   bars: readonly DailyBar[],
   manifest: InputManifest,
   protocol: Protocol,
@@ -363,3 +375,14 @@ export const measureReferenceEvaluationWork = (
       doubleCostStrategy: reference.doubleCostStrategy.work,
     })),
   )
+
+export const measureReferenceEvaluationWork = Pipeable.by<
+  (
+    manifest: InputManifest,
+    protocol: Protocol,
+    provenance: RuntimeProvenance,
+    closeAtEnd?: boolean,
+    application?: StrategyApplication<any, any, any>,
+  ) => (bars: readonly DailyBar[]) => ReturnType<typeof measureReferenceEvaluationWorkDataFirst>,
+  typeof measureReferenceEvaluationWorkDataFirst
+>((arguments_) => Array.isArray(arguments_[0]), measureReferenceEvaluationWorkDataFirst)

--- a/services/bayn/src/audit/reference/replay-calculations.ts
+++ b/services/bayn/src/audit/reference/replay-calculations.ts
@@ -97,7 +97,7 @@ const calculateReplayMetricsDataFirst = (
 
 export const calculateReplayMetrics = Pipeable.dual(7, calculateReplayMetricsDataFirst)
 
-export const makeReferenceOrder = (
+const makeReferenceOrderDataFirst = (
   runId: string,
   decision: DecisionEvent,
   sessionDate: IsoDate,
@@ -139,6 +139,20 @@ export const makeReferenceOrder = (
       return makeReferenceOrderIdentity(runId, material)
     }),
   )
+
+export const makeReferenceOrder = Pipeable.by<
+  (
+    decision: DecisionEvent,
+    sessionDate: IsoDate,
+    symbol: string,
+    side: 'buy' | 'sell',
+    requestedQuantityMicros: bigint,
+    referencePrice: bigint,
+    protocol: SimulationProtocol,
+    forceFullFill?: boolean,
+  ) => (runId: string) => ReturnType<typeof makeReferenceOrderDataFirst>,
+  typeof makeReferenceOrderDataFirst
+>((arguments_) => typeof arguments_[0] === 'string', makeReferenceOrderDataFirst)
 
 const restrictReferenceBuyFillDataFirst = (
   runId: string,
@@ -333,7 +347,7 @@ const replayBuyFeeInputs = (
   return Result.succeed(inputs)
 }
 
-export const replayBuysFitCash = (
+const replayBuysFitCashDataFirst = (
   buys: readonly ReferenceBuyCandidate[],
   scalePpm: bigint,
   prices: Readonly<Record<string, bigint>>,
@@ -355,3 +369,15 @@ export const replayBuysFitCash = (
       ),
     ),
   )
+
+export const replayBuysFitCash = Pipeable.by<
+  (
+    scalePpm: bigint,
+    prices: Readonly<Record<string, bigint>>,
+    protocol: SimulationProtocol,
+    costMultiplierMicros: bigint,
+    availableCashMicros: bigint,
+    minimumNotionalMicros?: bigint,
+  ) => (buys: readonly ReferenceBuyCandidate[]) => ReturnType<typeof replayBuysFitCashDataFirst>,
+  typeof replayBuysFitCashDataFirst
+>((arguments_) => Array.isArray(arguments_[0]), replayBuysFitCashDataFirst)

--- a/services/bayn/src/audit/reference/replay.ts
+++ b/services/bayn/src/audit/reference/replay.ts
@@ -38,6 +38,7 @@ import {
   replayQuantityFor,
   restrictReferenceBuyFill,
 } from './replay-calculations'
+import { Pipeable } from '../../pipeable'
 
 export { restrictReferenceBuyFill } from './replay-calculations'
 
@@ -59,7 +60,7 @@ const hasOpenPosition = (positions: ReadonlyMap<string, Position>): boolean =>
 
 const isFlatTarget = (target: Target): boolean => Object.values(target.weights).every((weight) => weight === 0)
 
-export const replay = (
+const replayDataFirst = (
   sessions: readonly Session[],
   targets: readonly Target[],
   startIndex: number,
@@ -635,3 +636,16 @@ export const replay = (
     work: { sessionsProcessed: daily.length, positionStateCopies, positionWrites },
   })
 }
+
+export const replay = Pipeable.by<
+  (
+    targets: readonly Target[],
+    startIndex: number,
+    protocol: SimulationProtocol,
+    costMultiplierMicros: bigint,
+    runId: string,
+    retainTrace: boolean,
+    closeAtEnd?: boolean,
+  ) => (sessions: readonly Session[]) => ReturnType<typeof replayDataFirst>,
+  typeof replayDataFirst
+>((arguments_) => Array.isArray(arguments_[1]), replayDataFirst)

--- a/services/bayn/src/broker/alpaca/composition.ts
+++ b/services/bayn/src/broker/alpaca/composition.ts
@@ -11,6 +11,7 @@ import {
   layer as brokerSessionLayer,
 } from './session'
 import { BrokerRead } from './model'
+import { Pipeable } from '../../pipeable'
 
 const brokerSessionAcquisitionError = (
   connection: BrokerConnection,
@@ -35,7 +36,7 @@ const mapHttpAcquisitionError = (
     ),
   )
 
-export const AlpacaBrokerResourcesLive = (
+const AlpacaBrokerResourcesLiveDataFirst = (
   connection: BrokerConnection,
   http: Layer.Layer<HttpClient.HttpClient, BrokerReadError> = alpacaHttpLayer(connection),
 ): Layer.Layer<BrokerSession | BrokerRead | AlpacaHttpClient, BrokerSessionAcquisitionError> => {
@@ -44,3 +45,13 @@ export const AlpacaBrokerResourcesLive = (
   const client = Layer.effect(AlpacaHttpClient, HttpClient.HttpClient).pipe(Layer.provide(sharedHttp))
   return Layer.merge(session, client)
 }
+
+export const AlpacaBrokerResourcesLive = Pipeable.by<
+  (
+    http?: Layer.Layer<HttpClient.HttpClient, BrokerReadError>,
+  ) => (connection: BrokerConnection) => ReturnType<typeof AlpacaBrokerResourcesLiveDataFirst>,
+  typeof AlpacaBrokerResourcesLiveDataFirst
+>(
+  (arguments_) => typeof arguments_[0] === 'object' && arguments_[0] !== null && 'baseUrl' in arguments_[0],
+  AlpacaBrokerResourcesLiveDataFirst,
+)

--- a/services/bayn/src/broker/alpaca/http.ts
+++ b/services/bayn/src/broker/alpaca/http.ts
@@ -97,7 +97,7 @@ const normalizeRead = <A>(
     ),
   )
 
-export const makeProxyDispatcher = (
+const makeProxyDispatcherDataFirst = (
   proxyUrl: string,
   dependencies: ProxyDispatcherDependencies = {
     create: (url) => new Undici.ProxyAgent({ uri: url.toString() }),
@@ -116,6 +116,11 @@ export const makeProxyDispatcher = (
     ),
     (dispatcher) => Effect.promise(() => dependencies.destroy(dispatcher)),
   )
+
+export const makeProxyDispatcher = Pipeable.by<
+  (dependencies?: ProxyDispatcherDependencies) => (proxyUrl: string) => ReturnType<typeof makeProxyDispatcherDataFirst>,
+  typeof makeProxyDispatcherDataFirst
+>((arguments_) => typeof arguments_[0] === 'string', makeProxyDispatcherDataFirst)
 
 export const parseProxyUrl = (proxyUrl: string): Result.Result<URL, BrokerReadError> =>
   pipe(
@@ -157,11 +162,21 @@ const proxyLayer = (
 ): Layer.Layer<NodeHttpClient.Dispatcher, BrokerReadError> =>
   Layer.effect(NodeHttpClient.Dispatcher, makeVerifiedProxyDispatcher(connection.proxyUrl, dependencies))
 
-export const alpacaHttpLayer = (
+const alpacaHttpLayerDataFirst = (
   connection: BrokerConnection,
   dependencies: ProxyDispatcherDependencies = defaultProxyDispatcherDependencies,
 ): Layer.Layer<HttpClient.HttpClient, BrokerReadError> =>
   NodeHttpClient.layerUndiciNoDispatcher.pipe(Layer.provide(proxyLayer(connection, dependencies)))
+
+export const alpacaHttpLayer = Pipeable.by<
+  (
+    dependencies?: ProxyDispatcherDependencies,
+  ) => (connection: BrokerConnection) => ReturnType<typeof alpacaHttpLayerDataFirst>,
+  typeof alpacaHttpLayerDataFirst
+>(
+  (arguments_) => typeof arguments_[0] === 'object' && arguments_[0] !== null && 'baseUrl' in arguments_[0],
+  alpacaHttpLayerDataFirst,
+)
 
 const LatestQuoteResponseSchema = Schema.Struct({
   symbol: Schema.String,

--- a/services/bayn/src/broker/alpaca/session.ts
+++ b/services/bayn/src/broker/alpaca/session.ts
@@ -75,7 +75,7 @@ const acquisitionError = (
 const isRetryableBrokerSessionAcquisition = (error: BrokerSessionAcquisitionError): boolean =>
   error.cause instanceof BrokerReadError && error.cause.retryable
 
-export const retryRecoverableBrokerSessionAcquisition = <A, R>(
+const retryRecoverableBrokerSessionAcquisitionDataFirst = <A, R>(
   connection: BrokerConnection,
   effect: Effect.Effect<A, BrokerSessionAcquisitionError, R>,
 ): Effect.Effect<A, BrokerSessionAcquisitionError, R> =>
@@ -102,6 +102,13 @@ export const retryRecoverableBrokerSessionAcquisition = <A, R>(
       )
     return yield* attempt(connection.retryAttempts)
   })
+
+export const retryRecoverableBrokerSessionAcquisition = Pipeable.generic<
+  <A, R>(
+    effect: Effect.Effect<A, BrokerSessionAcquisitionError, R>,
+  ) => (connection: BrokerConnection) => Effect.Effect<A, BrokerSessionAcquisitionError, R>,
+  typeof retryRecoverableBrokerSessionAcquisitionDataFirst
+>(2, retryRecoverableBrokerSessionAcquisitionDataFirst)
 
 export const acquireBrokerSession = (
   connection: BrokerConnection,

--- a/services/bayn/src/broker/observations.ts
+++ b/services/bayn/src/broker/observations.ts
@@ -427,7 +427,7 @@ const validateOrderShape = (
   )
 }
 
-export const orderObservation = (
+const orderObservationDataFirst = (
   value: AlpacaOrder,
   evidence: ReadEvidence,
   intentId?: string,
@@ -483,7 +483,15 @@ export const orderObservation = (
     ),
   )
 
-export const fillObservation = (
+export const orderObservation = Pipeable.by<
+  (evidence: ReadEvidence, intentId?: string) => (value: AlpacaOrder) => ReturnType<typeof orderObservationDataFirst>,
+  typeof orderObservationDataFirst
+>(
+  (arguments_) => typeof arguments_[0] === 'object' && arguments_[0] !== null && 'brokerOrderId' in arguments_[0],
+  orderObservationDataFirst,
+)
+
+const fillObservationDataFirst = (
   activity: FillActivity,
   order: AlpacaOrder,
   evidence: ReadEvidence,
@@ -543,6 +551,18 @@ export const fillObservation = (
         brokerOrderId: order.brokerOrderId,
       })
 }
+
+export const fillObservation = Pipeable.by<
+  (
+    order: AlpacaOrder,
+    evidence: ReadEvidence,
+    options?: { readonly intentId?: string; readonly feeMicros?: string },
+  ) => (activity: FillActivity) => ReturnType<typeof fillObservationDataFirst>,
+  typeof fillObservationDataFirst
+>(
+  (arguments_) => typeof arguments_[0] === 'object' && arguments_[0] !== null && 'activityId' in arguments_[0],
+  fillObservationDataFirst,
+)
 
 export const renderBrokerObservationError = (error: BrokerObservationError): string => {
   switch (error._tag) {

--- a/services/bayn/src/composition.ts
+++ b/services/bayn/src/composition.ts
@@ -816,7 +816,7 @@ const prepareResearchPaperActivation = (
     )
   })
 
-export const refreshResearchPaperActivationReconciliation = <E, R>(
+const refreshResearchPaperActivationReconciliationDataFirst = <E, R>(
   reconcile: Effect.Effect<unknown, E, R>,
   operationTimeoutMs: number,
 ): Effect.Effect<void, OperationalError, R> =>
@@ -831,6 +831,13 @@ export const refreshResearchPaperActivationReconciliation = <E, R>(
     ),
     Effect.asVoid,
   )
+
+export const refreshResearchPaperActivationReconciliation = Pipeable.generic<
+  <E, R>(
+    operationTimeoutMs: number,
+  ) => (reconcile: Effect.Effect<unknown, E, R>) => Effect.Effect<void, OperationalError, R>,
+  typeof refreshResearchPaperActivationReconciliationDataFirst
+>(2, refreshResearchPaperActivationReconciliationDataFirst)
 
 const prepareOrRecoverResearchPaperActivation = (
   plan: ApplicationPlanFor<'AutonomousService'>,

--- a/services/bayn/src/cycle-runner/admission-decisions.ts
+++ b/services/bayn/src/cycle-runner/admission-decisions.ts
@@ -18,6 +18,7 @@ import {
   type CycleRunnerError,
   type CycleRunResult,
 } from './model'
+import { Pipeable } from '../pipeable'
 
 type CycleNotDueResult = Extract<CycleRunResult, { readonly outcome: 'NOT_DUE' }>
 
@@ -80,7 +81,7 @@ const selectCycleCalendarPublication = <R>(
   )
 }
 
-export const selectCycleCalendarCandidate = <R>(
+const selectCycleCalendarCandidateDataFirst = <R>(
   context: CycleRunContext<R>,
   publications: NonEmptyPublications,
   observation: MarketCalendarObservation,
@@ -104,6 +105,16 @@ export const selectCycleCalendarCandidate = <R>(
     selectCycleCalendarPublication(context, first, observation, calendarReadContentHash, observedAt),
   )
 }
+
+export const selectCycleCalendarCandidate = Pipeable.generic<
+  <R>(
+    publications: NonEmptyPublications,
+    observation: MarketCalendarObservation,
+    calendarReadContentHash: string,
+    observedAt: string,
+  ) => (context: CycleRunContext<R>) => Result.Result<CycleCalendarCandidateDecision, CycleCalendarCandidateFailure>,
+  typeof selectCycleCalendarCandidateDataFirst
+>(5, selectCycleCalendarCandidateDataFirst)
 
 export const publicationFailureError = (cause: CyclePublicationFailure): CycleRunnerError =>
   runnerError('inspect-publication', 'contract', 'bounded cycle publication discovery is invalid', cause)

--- a/services/bayn/src/cycle-runner/authority-decisions.ts
+++ b/services/bayn/src/cycle-runner/authority-decisions.ts
@@ -90,7 +90,7 @@ const reduceCycleAuthoritySelectionDataFirst = (
 
 export const reduceCycleAuthoritySelection = Pipeable.dual(2, reduceCycleAuthoritySelectionDataFirst)
 
-export const completeCycleAuthoritySelection = (
+const completeCycleAuthoritySelectionDataFirst = (
   state: CycleAuthoritySelectionState,
   cadence?: 'MONTHLY' | 'PAPER_BOOTSTRAP',
 ): CycleAuthoritySelection => {
@@ -112,6 +112,13 @@ export const completeCycleAuthoritySelection = (
   }
   return { _tag: 'READ_CALENDAR', publications: state.publications }
 }
+
+export const completeCycleAuthoritySelection = Pipeable.by<
+  (
+    cadence?: 'MONTHLY' | 'PAPER_BOOTSTRAP',
+  ) => (state: CycleAuthoritySelectionState) => ReturnType<typeof completeCycleAuthoritySelectionDataFirst>,
+  typeof completeCycleAuthoritySelectionDataFirst
+>((arguments_) => typeof arguments_[0] === 'object' && arguments_[0] !== null, completeCycleAuthoritySelectionDataFirst)
 
 export const selectCycleAuthoritySlots = (slots: NonEmptyAuthoritySlots): CycleAuthoritySelection => {
   const [first, ...remaining] = slots

--- a/services/bayn/src/db/capital-grant-algebra.ts
+++ b/services/bayn/src/db/capital-grant-algebra.ts
@@ -388,7 +388,7 @@ const validateAuthorityObservationDataFirst = (
 
 export const validateAuthorityObservation = Pipeable.dual(2, validateAuthorityObservationDataFirst)
 
-export const validateCurrentGenerationHistory = <History extends AuthorityGenerationHistoryFacts>(
+const validateCurrentGenerationHistoryDataFirst = <History extends AuthorityGenerationHistoryFacts>(
   current: AuthorityState,
   history: History | undefined,
 ): Result.Result<History, CapitalGrantAlgebraFailure> => {
@@ -433,6 +433,13 @@ export const validateCurrentGenerationHistory = <History extends AuthorityGenera
   }
   return Result.succeed(history)
 }
+
+export const validateCurrentGenerationHistory = Pipeable.generic<
+  <History extends AuthorityGenerationHistoryFacts>(
+    history: History | undefined,
+  ) => (current: AuthorityState) => Result.Result<History, CapitalGrantAlgebraFailure>,
+  typeof validateCurrentGenerationHistoryDataFirst
+>(2, validateCurrentGenerationHistoryDataFirst)
 
 const requireUnusedAuthorityGenerationDataFirst = (
   generationHash: string,

--- a/services/bayn/src/db/cycle-store/decisions.ts
+++ b/services/bayn/src/db/cycle-store/decisions.ts
@@ -285,7 +285,7 @@ const decideCompletionDataFirst = (
 
 export const decideCompletion = Pipeable.dual(3, decideCompletionDataFirst)
 
-export const validateCompletionDocument = (
+const validateCompletionDocumentDataFirst = (
   decision: Extract<CompletionDecision, { readonly _tag: 'VerifyDecision' }>,
   storedDocuments: readonly CycleDecisionDocument[],
   paperCompletionEvidenceMatches?: boolean,
@@ -306,6 +306,16 @@ export const validateCompletionDocument = (
     ? Result.succeed(undefined)
     : fail('invariant', 'cycle terminal state must match its exact durable shadow decision')
 }
+
+export const validateCompletionDocument = Pipeable.by<
+  (
+    storedDocuments: readonly CycleDecisionDocument[],
+    paperCompletionEvidenceMatches?: boolean,
+  ) => (
+    decision: Extract<CompletionDecision, { readonly _tag: 'VerifyDecision' }>,
+  ) => ReturnType<typeof validateCompletionDocumentDataFirst>,
+  typeof validateCompletionDocumentDataFirst
+>((arguments_) => !Array.isArray(arguments_[0]), validateCompletionDocumentDataFirst)
 
 const decideBlockDataFirst = (
   cycle: AutonomousCycle,
@@ -341,7 +351,7 @@ const decideBlockDataFirst = (
 
 export const decideBlock = Pipeable.dual(3, decideBlockDataFirst)
 
-export const validateBlockedDecision = (
+const validateBlockedDecisionDataFirst = (
   decision: Extract<BlockDecision, { readonly _tag: 'VerifyDecision' }>,
   storedDocuments: readonly CycleDecisionDocument[],
   paperGenerationIsSuperseded?: boolean,
@@ -384,3 +394,13 @@ export const validateBlockedDecision = (
   }
   return fail('invariant', 'decision-bound cycle may block only from its exact blocked or expired PAPER decision')
 }
+
+export const validateBlockedDecision = Pipeable.by<
+  (
+    storedDocuments: readonly CycleDecisionDocument[],
+    paperGenerationIsSuperseded?: boolean,
+  ) => (
+    decision: Extract<BlockDecision, { readonly _tag: 'VerifyDecision' }>,
+  ) => ReturnType<typeof validateBlockedDecisionDataFirst>,
+  typeof validateBlockedDecisionDataFirst
+>((arguments_) => !Array.isArray(arguments_[0]), validateBlockedDecisionDataFirst)

--- a/services/bayn/src/db/cycle-store/model.ts
+++ b/services/bayn/src/db/cycle-store/model.ts
@@ -124,7 +124,7 @@ export const cycleStoreError = (
     cause,
   })
 
-export const runCycleStore = <A, E, R>(
+const runCycleStoreDataFirst = <A, E, R>(
   operation: CycleStoreError['operation'],
   effect: Effect.Effect<A, E, R>,
 ): Effect.Effect<A, CycleStoreError, R> =>
@@ -168,6 +168,13 @@ export const runCycleStore = <A, E, R>(
     }),
   )
 
+export const runCycleStore = Pipeable.generic<
+  <A, E, R>(
+    effect: Effect.Effect<A, E, R>,
+  ) => (operation: CycleStoreError['operation']) => Effect.Effect<A, CycleStoreError, R>,
+  typeof runCycleStoreDataFirst
+>(2, runCycleStoreDataFirst)
+
 const failCycleStoreDataFirst = (
   operation: CycleStoreError['operation'],
   failure: CycleStoreError['failure'],
@@ -176,13 +183,20 @@ const failCycleStoreDataFirst = (
 
 export const failCycleStore = Pipeable.dual(3, failCycleStoreDataFirst)
 
-export const liftCycleDecision = <A>(
+const liftCycleDecisionDataFirst = <A>(
   operation: CycleStoreError['operation'],
   decision: Result.Result<A, CycleStoreDecisionFailure>,
 ): Effect.Effect<A, CycleStoreError> =>
   Effect.fromResult(decision).pipe(
     Effect.mapError(({ failure, message }) => cycleStoreError(operation, failure, message)),
   )
+
+export const liftCycleDecision = Pipeable.generic<
+  <A>(
+    decision: Result.Result<A, CycleStoreDecisionFailure>,
+  ) => (operation: CycleStoreError['operation']) => Effect.Effect<A, CycleStoreError>,
+  typeof liftCycleDecisionDataFirst
+>(2, liftCycleDecisionDataFirst)
 
 const exactlyOneCycleDataFirst = (
   operation: CycleStoreError['operation'],

--- a/services/bayn/src/db/evidence-store/errors.ts
+++ b/services/bayn/src/db/evidence-store/errors.ts
@@ -92,11 +92,16 @@ const classifyDatabaseErrorDataFirst = (operation: string, cause: unknown): Data
 
 export const classifyDatabaseError = Pipeable.dual(2, classifyDatabaseErrorDataFirst)
 
-export const runDatabase = <A, E, R>(
+const runDatabaseDataFirst = <A, E, R>(
   operation: string,
   effect: Effect.Effect<A, E, R>,
 ): Effect.Effect<A, DatabaseError, R> =>
   effect.pipe(Effect.mapError((cause) => classifyDatabaseError(operation, cause)))
+
+export const runDatabase = Pipeable.generic<
+  <A, E, R>(effect: Effect.Effect<A, E, R>) => (operation: string) => Effect.Effect<A, DatabaseError, R>,
+  typeof runDatabaseDataFirst
+>(2, runDatabaseDataFirst)
 
 const ensureDataFirst = (condition: boolean, operation: string, message: string): Effect.Effect<void, DatabaseError> =>
   condition ? Effect.void : Effect.fail(databaseError('invariant', operation, message))

--- a/services/bayn/src/db/execution-store/errors.ts
+++ b/services/bayn/src/db/execution-store/errors.ts
@@ -30,7 +30,7 @@ const failExecutionStoreDataFirst = (
 
 export const failExecutionStore = Pipeable.dual(3, failExecutionStoreDataFirst)
 
-export const runExecutionOperation = <A, E, R>(
+const runExecutionOperationDataFirst = <A, E, R>(
   operation: ExecutionStoreError['operation'],
   effect: Effect.Effect<A, E, R>,
 ): Effect.Effect<A, ExecutionStoreError, R> =>
@@ -63,13 +63,27 @@ export const runExecutionOperation = <A, E, R>(
     }),
   )
 
-export const liftStoreDecision = <A>(
+export const runExecutionOperation = Pipeable.generic<
+  <A, E, R>(
+    effect: Effect.Effect<A, E, R>,
+  ) => (operation: ExecutionStoreError['operation']) => Effect.Effect<A, ExecutionStoreError, R>,
+  typeof runExecutionOperationDataFirst
+>(2, runExecutionOperationDataFirst)
+
+const liftStoreDecisionDataFirst = <A>(
   operation: ExecutionStoreError['operation'],
   decision: Result.Result<A, ExecutionStoreDecisionFailure>,
 ): Effect.Effect<A, ExecutionStoreError> =>
   Effect.fromResult(decision).pipe(
     Effect.mapError((failure) => executionStoreError(operation, failure.failure, failure.message, failure.cause)),
   )
+
+export const liftStoreDecision = Pipeable.generic<
+  <A>(
+    decision: Result.Result<A, ExecutionStoreDecisionFailure>,
+  ) => (operation: ExecutionStoreError['operation']) => Effect.Effect<A, ExecutionStoreError>,
+  typeof liftStoreDecisionDataFirst
+>(2, liftStoreDecisionDataFirst)
 
 export const liftAuthorityDecision = <A>(
   decision: Result.Result<A, CapitalGrantAlgebraFailure>,

--- a/services/bayn/src/execution-candidate-discovery/failure.ts
+++ b/services/bayn/src/execution-candidate-discovery/failure.ts
@@ -497,11 +497,18 @@ const requireConditionDataFirst = (
 
 export const requireCondition = Pipeable.dual(2, requireConditionDataFirst)
 
-export const requireValue = <A>(
+const requireValueDataFirst = <A>(
   value: A | null | undefined,
   error: ExecutionCandidateDiscoveryError,
 ): Result.Result<A, ExecutionCandidateDiscoveryError> =>
   value === null || value === undefined ? Result.fail(error) : Result.succeed(value)
+
+export const requireValue = Pipeable.generic<
+  <A>(
+    error: ExecutionCandidateDiscoveryError,
+  ) => (value: A | null | undefined) => Result.Result<A, ExecutionCandidateDiscoveryError>,
+  typeof requireValueDataFirst
+>(2, requireValueDataFirst)
 
 const canonicalHashResultDataFirst = (
   value: unknown,

--- a/services/bayn/src/execution/authority.ts
+++ b/services/bayn/src/execution/authority.ts
@@ -133,7 +133,7 @@ export const sandboxCapitalAuthority = (authorityGenerationHash: string): Sandbo
   authorityGenerationHash,
 })
 
-export const liveCapitalAuthority = (
+const liveCapitalAuthorityDataFirst = (
   grant: LiveCapitalGrant,
   revocation?: LiveCapitalGrantRevocation,
 ): LiveCapitalAuthority => ({
@@ -141,6 +141,19 @@ export const liveCapitalAuthority = (
   grant,
   ...(revocation === undefined ? {} : { revocation }),
 })
+
+export const liveCapitalAuthority = Pipeable.by<
+  (
+    revocation?: LiveCapitalGrantRevocation,
+  ) => (grant: LiveCapitalGrant) => ReturnType<typeof liveCapitalAuthorityDataFirst>,
+  typeof liveCapitalAuthorityDataFirst
+>(
+  (arguments_) =>
+    typeof arguments_[0] === 'object' &&
+    arguments_[0] !== null &&
+    arguments_[0].schemaVersion === 'bayn.live-capital-grant.v1',
+  liveCapitalAuthorityDataFirst,
+)
 
 export type ExecutionAuthority =
   | {

--- a/services/bayn/src/execution/coordinator-decisions.ts
+++ b/services/bayn/src/execution/coordinator-decisions.ts
@@ -202,7 +202,7 @@ const nextInstantDataFirst = (
 
 export const nextInstant = Pipeable.dual(3, nextInstantDataFirst)
 
-export const encodeOrder = (
+const encodeOrderDataFirst = (
   operation: MutationOperation,
   intent: Intent,
   message = 'intent cannot be represented as an Alpaca paper order',
@@ -225,6 +225,11 @@ export const encodeOrder = (
       ),
     ),
   )
+
+export const encodeOrder = Pipeable.by<
+  (intent: Intent, message?: string) => (operation: MutationOperation) => ReturnType<typeof encodeOrderDataFirst>,
+  typeof encodeOrderDataFirst
+>((arguments_) => typeof arguments_[0] === 'string', encodeOrderDataFirst)
 
 const validateSubmitRiskDecision = (
   stored: StoredIntent,
@@ -249,12 +254,23 @@ const validateSubmitRiskDecision = (
   )
 }
 
-export const validateActiveSubmitRiskDecision = (
+const validateActiveSubmitRiskDecisionDataFirst = (
   stored: StoredIntent,
   currentTimeMillis: number,
   operationLabel = 'submission',
 ): Result.Result<StoredIntent, ExecutionDecisionFailure> =>
   validateSubmitRiskDecision(stored, currentTimeMillis, operationLabel, IntentState.Approved)
+
+export const validateActiveSubmitRiskDecision = Pipeable.by<
+  (
+    currentTimeMillis: number,
+    operationLabel?: string,
+  ) => (stored: StoredIntent) => ReturnType<typeof validateActiveSubmitRiskDecisionDataFirst>,
+  typeof validateActiveSubmitRiskDecisionDataFirst
+>(
+  (arguments_) => typeof arguments_[0] === 'object' && arguments_[0] !== null,
+  validateActiveSubmitRiskDecisionDataFirst,
+)
 
 const validateStartedSubmitRiskDecisionDataFirst = (
   stored: StoredIntent,

--- a/services/bayn/src/execution/coordinator.ts
+++ b/services/bayn/src/execution/coordinator.ts
@@ -259,12 +259,17 @@ const runSubmit = (services: MutationServices, intentId: string, consistencyDela
       ),
     )
 
-export const submit = (intentId: string, consistencyDelayMs: number, closeOnly = false) =>
+const submitDataFirst = (intentId: string, consistencyDelayMs: number, closeOnly = false) =>
   Effect.all({
     mutations: MutationStore,
     broker: BrokerMutation,
     fence: WriterFence,
   }).pipe(Effect.flatMap((services) => runSubmit(services, intentId, consistencyDelayMs, closeOnly)))
+
+export const submit = Pipeable.by<
+  (consistencyDelayMs: number, closeOnly?: boolean) => (intentId: string) => ReturnType<typeof submitDataFirst>,
+  typeof submitDataFirst
+>((arguments_) => typeof arguments_[0] === 'string', submitDataFirst)
 
 const persistCancelDecision = (
   services: MutationServices,

--- a/services/bayn/src/execution/mutations/decisions.ts
+++ b/services/bayn/src/execution/mutations/decisions.ts
@@ -209,7 +209,7 @@ const decideMutationStartReplayDataFirst = (
 
 export const decideMutationStartReplay = Pipeable.dual(3, decideMutationStartReplayDataFirst)
 
-export const decideMutationAuthority = (
+const decideMutationAuthorityDataFirst = (
   operation: MutationOperation,
   authority: MutationAuthoritySnapshot | undefined,
   closeOnly = false,
@@ -248,6 +248,14 @@ export const decideMutationAuthority = (
     generationHash: authority.generationHash,
   })
 }
+
+export const decideMutationAuthority = Pipeable.by<
+  (
+    authority: MutationAuthoritySnapshot | undefined,
+    closeOnly?: boolean,
+  ) => (operation: MutationOperation) => ReturnType<typeof decideMutationAuthorityDataFirst>,
+  typeof decideMutationAuthorityDataFirst
+>((arguments_) => typeof arguments_[0] === 'string', decideMutationAuthorityDataFirst)
 
 export const decideFinalSubmitAuthorization = (
   authority: MutationAuthorityBinding,

--- a/services/bayn/src/execution/runtime-program.ts
+++ b/services/bayn/src/execution/runtime-program.ts
@@ -124,7 +124,7 @@ const validatePaperEpisodeLease = (
     return yield* Effect.fail({ _tag: 'PaperEpisodeExpired' as const, expiresAt, observedAt })
   })
 
-export const authorizeFinalBrokerSubmit = <A, E, R>(
+const authorizeFinalBrokerSubmitDataFirst = <A, E, R>(
   authority: MutationExecutionAuthority,
   intent: Intent,
   transmit: Effect.Effect<A, E, R>,
@@ -165,6 +165,15 @@ export const authorizeFinalBrokerSubmit = <A, E, R>(
       ),
     )
 }
+
+export const authorizeFinalBrokerSubmit = Pipeable.generic<
+  <A, E, R>(
+    intent: Intent,
+    transmit: Effect.Effect<A, E, R>,
+    dependencies: ExecutionProgramDependencies,
+  ) => (authority: MutationExecutionAuthority) => Effect.Effect<A, E | FinalSubmitAuthorizationFailure, R>,
+  typeof authorizeFinalBrokerSubmitDataFirst
+>(4, authorizeFinalBrokerSubmitDataFirst)
 
 const provideCoordinatorDependencies = <A, E, R>(
   effect: Effect.Effect<A, E, R>,

--- a/services/bayn/src/forward-performance/postgres.ts
+++ b/services/bayn/src/forward-performance/postgres.ts
@@ -31,6 +31,7 @@ import type {
   ForwardPerformanceStrategyEvidence,
   ForwardPerformanceTransactionEvidence,
 } from './model'
+import { Pipeable } from '../pipeable'
 
 const TerminalCycleRow = Schema.Struct({
   cycle_id: Sha256,
@@ -978,7 +979,7 @@ const marketVolumeRequestsFromRows = (
   })
 }
 
-export const readForwardPerformancePostgres = (
+const readForwardPerformancePostgresDataFirst = (
   sql: PgClient.PgClient,
   accountId: string,
   authorityGenerationHash?: string,
@@ -1751,3 +1752,11 @@ export const readForwardPerformancePostgres = (
       }),
     )
     .pipe(Effect.mapError(postgresError))
+
+export const readForwardPerformancePostgres = Pipeable.by<
+  (
+    accountId: string,
+    authorityGenerationHash?: string,
+  ) => (sql: PgClient.PgClient) => ReturnType<typeof readForwardPerformancePostgresDataFirst>,
+  typeof readForwardPerformancePostgresDataFirst
+>((arguments_) => typeof arguments_[0] !== 'string', readForwardPerformancePostgresDataFirst)

--- a/services/bayn/src/forward-performance/program.ts
+++ b/services/bayn/src/forward-performance/program.ts
@@ -516,7 +516,7 @@ const requireBrokerIdentity = (
     : Effect.succeed(config as BoundForwardPerformanceConfig)
 }
 
-export const runForwardPerformance = (
+const runForwardPerformanceDataFirst = (
   loadedConfig: LoadedRuntimeConfig,
   readers: ForwardPerformanceReaders = liveForwardPerformanceReaders,
   options: { readonly authorityGenerationHash?: string } = {},
@@ -603,3 +603,14 @@ export const runForwardPerformance = (
     )
     return receipt
   })
+
+export const runForwardPerformance = Pipeable.by<
+  (
+    readers?: ForwardPerformanceReaders,
+    options?: { readonly authorityGenerationHash?: string },
+  ) => (loadedConfig: LoadedRuntimeConfig) => ReturnType<typeof runForwardPerformanceDataFirst>,
+  typeof runForwardPerformanceDataFirst
+>(
+  (arguments_) => typeof arguments_[0] === 'object' && arguments_[0] !== null && 'runtimeMode' in arguments_[0],
+  runForwardPerformanceDataFirst,
+)

--- a/services/bayn/src/forward-performance/tigerbeetle.ts
+++ b/services/bayn/src/forward-performance/tigerbeetle.ts
@@ -18,6 +18,7 @@ import type {
   ForwardPerformanceCashYieldEvidence,
   ForwardPerformanceLedgerTotals,
 } from './model'
+import { Pipeable } from '../pipeable'
 
 export class ForwardPerformanceLedgerError extends Data.TaggedError('ForwardPerformanceLedgerError')<{
   readonly operation: 'read'
@@ -167,7 +168,7 @@ const validateCashYieldEvidence = (
     return cashYieldAmount
   })
 
-export const readForwardPerformanceLedger = (
+const readForwardPerformanceLedgerDataFirst = (
   config: Pick<RuntimeConfig, 'operationTimeoutMs' | 'tigerBeetle'>,
   accountId: string,
   accountPlans: readonly LedgerPlan[],
@@ -231,3 +232,16 @@ export const readForwardPerformanceLedger = (
       cashYieldEvidenceRequired: cashYieldResidual > 0n,
     }
   })
+
+export const readForwardPerformanceLedger = Pipeable.by<
+  (
+    accountId: string,
+    accountPlans: readonly LedgerPlan[],
+    cashYieldEvidence?: ForwardPerformanceCashYieldEvidence,
+    dependencies?: JournalDependencies,
+    generationPlans?: readonly LedgerPlan[],
+  ) => (
+    config: Pick<RuntimeConfig, 'operationTimeoutMs' | 'tigerBeetle'>,
+  ) => ReturnType<typeof readForwardPerformanceLedgerDataFirst>,
+  typeof readForwardPerformanceLedgerDataFirst
+>((arguments_) => typeof arguments_[0] === 'object' && arguments_[0] !== null, readForwardPerformanceLedgerDataFirst)

--- a/services/bayn/src/health/program.ts
+++ b/services/bayn/src/health/program.ts
@@ -298,7 +298,7 @@ const collectHealthProbeResults = (
   )
 }
 
-export const checkHealth = (
+const checkHealthDataFirst = (
   config: RuntimeConfig,
   state: Ref.Ref<RuntimeState>,
   dependencies: HealthDependencies,
@@ -341,7 +341,22 @@ export const checkHealth = (
     yield* interpretHealthLogs(deriveHealthLogDecisions(transition))
   }).pipe(Effect.withLogSpan('health'))
 
-export const runHealthMonitor = (
+export const checkHealth = Pipeable.by<
+  (
+    state: Ref.Ref<RuntimeState>,
+    dependencies: HealthDependencies,
+    broker?: BrokerProbe,
+    autonomousCycleFiber?: Fiber.Fiber<void, never>,
+    cycleObservationId?: string,
+    qualificationEvidenceRequired?: boolean,
+  ) => (config: RuntimeConfig) => ReturnType<typeof checkHealthDataFirst>,
+  typeof checkHealthDataFirst
+>(
+  (arguments_) => typeof arguments_[0] === 'object' && arguments_[0] !== null && 'healthIntervalMs' in arguments_[0],
+  checkHealthDataFirst,
+)
+
+const runHealthMonitorDataFirst = (
   config: RuntimeConfig,
   state: Ref.Ref<RuntimeState>,
   dependencies: HealthDependencies,
@@ -359,3 +374,18 @@ export const runHealthMonitor = (
     cycleObservationId,
     qualificationEvidenceRequired,
   ).pipe(Effect.repeat(Schedule.spaced(Duration.millis(config.healthIntervalMs))), Effect.asVoid)
+
+export const runHealthMonitor = Pipeable.by<
+  (
+    state: Ref.Ref<RuntimeState>,
+    dependencies: HealthDependencies,
+    broker?: BrokerProbe,
+    autonomousCycleFiber?: Fiber.Fiber<void, never>,
+    cycleObservationId?: string,
+    qualificationEvidenceRequired?: boolean,
+  ) => (config: RuntimeConfig) => ReturnType<typeof runHealthMonitorDataFirst>,
+  typeof runHealthMonitorDataFirst
+>(
+  (arguments_) => typeof arguments_[0] === 'object' && arguments_[0] !== null && 'healthIntervalMs' in arguments_[0],
+  runHealthMonitorDataFirst,
+)

--- a/services/bayn/src/http.ts
+++ b/services/bayn/src/http.ts
@@ -464,11 +464,20 @@ const historicalReadFailureDecisionDataFirst = (runId: string, error: Operationa
 
 export const historicalReadFailureDecision = Pipeable.dual(2, historicalReadFailureDecisionDataFirst)
 
-export const readHistoricalEvidence = <A, R>(
+const readHistoricalEvidenceDataFirst = <A, R>(
   read: Effect.Effect<Option.Option<A>, DatabaseError, R>,
   timeoutMs: number,
 ): Effect.Effect<Option.Option<A>, OperationalError, R> =>
   withinDeadline(databaseOperation(read, 'read-evidence'), timeoutMs, 'database', 'read-evidence')
+
+export const readHistoricalEvidence = Pipeable.generic<
+  <A, R>(
+    timeoutMs: number,
+  ) => (
+    read: Effect.Effect<Option.Option<A>, DatabaseError, R>,
+  ) => Effect.Effect<Option.Option<A>, OperationalError, R>,
+  typeof readHistoricalEvidenceDataFirst
+>(2, readHistoricalEvidenceDataFirst)
 
 export const fallbackResponseDecision = (method: string): HttpResponseDecision =>
   method === 'GET'

--- a/services/bayn/src/ledger-plan/verification.ts
+++ b/services/bayn/src/ledger-plan/verification.ts
@@ -170,7 +170,7 @@ export interface LedgerBalances {
   readonly transfersById: ReadonlyMap<bigint, LedgerTransferRecord>
 }
 
-export const reconcileBalances = (
+const reconcileBalancesDataFirst = (
   operation: 'check-run' | 'reconcile' | 'verify-account',
   accounts: readonly LedgerAccountRecord[],
   transfers: readonly LedgerTransferRecord[],
@@ -262,7 +262,16 @@ export const reconcileBalances = (
   return Result.succeed({ accountsById, transfersById })
 }
 
-export const reconcileLedgerPlan = (
+export const reconcileBalances = Pipeable.by<
+  (
+    accounts: readonly LedgerAccountRecord[],
+    transfers: readonly LedgerTransferRecord[],
+    runId?: string,
+  ) => (operation: 'check-run' | 'reconcile' | 'verify-account') => ReturnType<typeof reconcileBalancesDataFirst>,
+  typeof reconcileBalancesDataFirst
+>((arguments_) => typeof arguments_[0] === 'string', reconcileBalancesDataFirst)
+
+const reconcileLedgerPlanDataFirst = (
   plan: LedgerPlan,
   actualAccounts: readonly LedgerAccountRecord[],
   actualTransfers: readonly LedgerTransferRecord[],
@@ -272,3 +281,12 @@ export const reconcileLedgerPlan = (
     yield* verifyLedgerPlanRecords(operation, 'account', 'transfer', plan, actualAccounts, actualTransfers)
     yield* reconcileBalances(operation, actualAccounts, actualTransfers)
   })
+
+export const reconcileLedgerPlan = Pipeable.by<
+  (
+    actualAccounts: readonly LedgerAccountRecord[],
+    actualTransfers: readonly LedgerTransferRecord[],
+    operation?: 'reconcile' | 'verify-account',
+  ) => (plan: LedgerPlan) => ReturnType<typeof reconcileLedgerPlanDataFirst>,
+  typeof reconcileLedgerPlanDataFirst
+>((arguments_) => !Array.isArray(arguments_[0]), reconcileLedgerPlanDataFirst)

--- a/services/bayn/src/ledger.ts
+++ b/services/bayn/src/ledger.ts
@@ -32,6 +32,7 @@ import {
   type TigerBeetleRequestClient,
 } from './tigerbeetle-client'
 import type { ReconciliationResult } from './types'
+import { Pipeable } from './pipeable'
 
 export class JournalValidationError extends OperationalError {
   readonly validation: LedgerValidationError
@@ -179,7 +180,7 @@ const verifyAccount = (
     return Result.isSuccess(reconcileLedgerPlan(expected, accounts, transfers, 'verify-account'))
   })
 
-export const JournalLive = (
+const JournalLiveDataFirst = (
   config: Pick<RuntimeConfig, 'operationTimeoutMs' | 'tigerBeetle'>,
   dependencies?: JournalDependencies,
 ): Layer.Layer<Journal, OperationalError> =>
@@ -199,6 +200,16 @@ export const JournalLive = (
       ),
     ),
   )
+
+export const JournalLive = Pipeable.by<
+  (
+    dependencies?: JournalDependencies,
+  ) => (config: Pick<RuntimeConfig, 'operationTimeoutMs' | 'tigerBeetle'>) => ReturnType<typeof JournalLiveDataFirst>,
+  typeof JournalLiveDataFirst
+>(
+  (arguments_) => typeof arguments_[0] === 'object' && arguments_[0] !== null && 'tigerBeetle' in arguments_[0],
+  JournalLiveDataFirst,
+)
 
 export {
   assembleAccountPlan,

--- a/services/bayn/src/market-data/verification/publications.ts
+++ b/services/bayn/src/market-data/verification/publications.ts
@@ -52,7 +52,7 @@ export const selectPublicationManifest = Pipeable.by<
   typeof selectPublicationManifestDataFirst
 >((arguments_) => Array.isArray(arguments_[0]), selectPublicationManifestDataFirst)
 
-export const verifyBoundFinalizedPublication = (
+const verifyBoundFinalizedPublicationDataFirst = (
   rows: Pick<SnapshotRows, 'sessions' | 'manifests'>,
   input: FinalizedPublicationRequest,
   contract: MarketDataContract,
@@ -79,6 +79,21 @@ export const verifyBoundFinalizedPublication = (
           : Result.succeed(inspection),
     ),
   )
+
+export const verifyBoundFinalizedPublication = Pipeable.by<
+  (
+    input: FinalizedPublicationRequest,
+    contract: MarketDataContract,
+    observedAt: string,
+    expectedSnapshotId?: string,
+  ) => (
+    rows: Pick<SnapshotRows, 'sessions' | 'manifests'>,
+  ) => ReturnType<typeof verifyBoundFinalizedPublicationDataFirst>,
+  typeof verifyBoundFinalizedPublicationDataFirst
+>(
+  (arguments_) => typeof arguments_[0] === 'object' && arguments_[0] !== null && 'sessions' in arguments_[0],
+  verifyBoundFinalizedPublicationDataFirst,
+)
 
 const selectCyclePublicationManifestsDataFirst = (
   manifests: readonly SignalManifestRow[],

--- a/services/bayn/src/market-data/verification/publications.ts
+++ b/services/bayn/src/market-data/verification/publications.ts
@@ -30,7 +30,7 @@ const verifyFinalizedPublicationDataFirst = (
 
 export const verifyFinalizedPublication = Pipeable.dual(4, verifyFinalizedPublicationDataFirst)
 
-export const selectPublicationManifest = (
+const selectPublicationManifestDataFirst = (
   manifests: readonly SignalManifestRow[],
   expectedSnapshotId?: string,
 ): Result.Result<SignalManifestRow | undefined, MarketDataVerificationError> => {
@@ -44,6 +44,13 @@ export const selectPublicationManifest = (
       })
     : Result.succeed(manifests[0])
 }
+
+export const selectPublicationManifest = Pipeable.by<
+  (
+    expectedSnapshotId?: string,
+  ) => (manifests: readonly SignalManifestRow[]) => ReturnType<typeof selectPublicationManifestDataFirst>,
+  typeof selectPublicationManifestDataFirst
+>((arguments_) => Array.isArray(arguments_[0]), selectPublicationManifestDataFirst)
 
 export const verifyBoundFinalizedPublication = (
   rows: Pick<SnapshotRows, 'sessions' | 'manifests'>,

--- a/services/bayn/src/market-data/verification/shared.ts
+++ b/services/bayn/src/market-data/verification/shared.ts
@@ -22,11 +22,18 @@ const requireConditionDataFirst = (
 
 export const requireCondition = Pipeable.dual(2, requireConditionDataFirst)
 
-export const requireValue = <A>(
+const requireValueDataFirst = <A>(
   value: A | null | undefined,
   error: MarketDataVerificationError,
 ): Result.Result<A, MarketDataVerificationError> =>
   value === null || value === undefined ? fail(error) : Result.succeed(value)
+
+export const requireValue = Pipeable.generic<
+  <A>(
+    error: MarketDataVerificationError,
+  ) => (value: A | null | undefined) => Result.Result<A, MarketDataVerificationError>,
+  typeof requireValueDataFirst
+>(2, requireValueDataFirst)
 
 export const validateAll = (
   validations: ReadonlyArray<Result.Result<void, MarketDataVerificationError>>,

--- a/services/bayn/src/observe-composition/mutation-decisions.ts
+++ b/services/bayn/src/observe-composition/mutation-decisions.ts
@@ -178,7 +178,7 @@ export type PreparedMutationIntentAdmissionFailure = {
   readonly message: string
 }
 
-export const decidePreparedMutationIntentAdmission = (
+const decidePreparedMutationIntentAdmissionDataFirst = (
   prepared: PreparedMutationIntentDecision,
   effectiveAuthority: Authority,
   observedAt: string,
@@ -233,6 +233,22 @@ export const decidePreparedMutationIntentAdmission = (
   }
   return Result.succeed(undefined)
 }
+
+export const decidePreparedMutationIntentAdmission = Pipeable.by<
+  (
+    effectiveAuthority: Authority,
+    observedAt: string,
+    expiresAt: string,
+    unknownMutationCount: number,
+    reconciliationStatus?: ReconciliationStatus,
+    accountingExact?: boolean,
+    unknownOrderCount?: number,
+  ) => (prepared: PreparedMutationIntentDecision) => ReturnType<typeof decidePreparedMutationIntentAdmissionDataFirst>,
+  typeof decidePreparedMutationIntentAdmissionDataFirst
+>(
+  (arguments_) => typeof arguments_[0] === 'object' && arguments_[0] !== null,
+  decidePreparedMutationIntentAdmissionDataFirst,
+)
 
 export const decidePreparedCloseIntentAdmission = (
   intent: Pick<Intent, 'side'>,

--- a/services/bayn/src/observe-composition/mutation-decisions.ts
+++ b/services/bayn/src/observe-composition/mutation-decisions.ts
@@ -250,7 +250,7 @@ export const decidePreparedMutationIntentAdmission = Pipeable.by<
   decidePreparedMutationIntentAdmissionDataFirst,
 )
 
-export const decidePreparedCloseIntentAdmission = (
+const decidePreparedCloseIntentAdmissionDataFirst = (
   intent: Pick<Intent, 'side'>,
   prepared: PreparedMutationIntentDecision,
   observedAt: string,
@@ -305,6 +305,22 @@ export const decidePreparedCloseIntentAdmission = (
   }
   return Result.succeed(undefined)
 }
+
+export const decidePreparedCloseIntentAdmission = Pipeable.by<
+  (
+    prepared: PreparedMutationIntentDecision,
+    observedAt: string,
+    expiresAt: string,
+    unknownMutationCount: number,
+    reconciliationStatus?: ReconciliationStatus,
+    accountingExact?: boolean,
+    unknownOrderCount?: number,
+  ) => (intent: Pick<Intent, 'side'>) => ReturnType<typeof decidePreparedCloseIntentAdmissionDataFirst>,
+  typeof decidePreparedCloseIntentAdmissionDataFirst
+>(
+  (arguments_) => typeof arguments_[0] === 'object' && arguments_[0] !== null && 'side' in arguments_[0],
+  decidePreparedCloseIntentAdmissionDataFirst,
+)
 
 const appendPendingMutationOrderDataFirst = (orders: readonly Order[], pending: Order): readonly Order[] =>
   orders.some((order) => order.brokerOrderId === pending.brokerOrderId || order.clientOrderId === pending.clientOrderId)

--- a/services/bayn/src/observe-composition/mutation-intent-interpreter.ts
+++ b/services/bayn/src/observe-composition/mutation-intent-interpreter.ts
@@ -36,6 +36,7 @@ import {
   type PreparedMutationCycleStep,
 } from './mutation-decisions'
 import { mutationRunnerError } from './mutation-interpreter'
+import { Pipeable } from '../pipeable'
 
 export type MutationPreparationFacts = {
   readonly snapshot: {
@@ -225,7 +226,7 @@ type PaperIntentRecoveryLookup = Omit<PreparedPaperIntent, 'intent'> & {
   readonly intentId: string
 }
 
-export const prepareMutationIntent = <R, E, I extends MutationIntentInput, P extends MutationPreparation>(
+const prepareMutationIntentDataFirst = <R, E, I extends MutationIntentInput, P extends MutationPreparation>(
   input: I,
   preparation: P,
   policy: Policy,
@@ -594,3 +595,16 @@ export const prepareMutationIntent = <R, E, I extends MutationIntentInput, P ext
       ? { _tag: 'Complete', observedAt: facts.evaluatedAt }
       : { _tag: 'Wait', observedAt: facts.evaluatedAt }
   })
+
+export const prepareMutationIntent = Pipeable.generic<
+  <R, E, I extends MutationIntentInput, P extends MutationPreparation>(
+    preparation: P,
+    policy: Policy,
+    cycle: AutonomousCycle,
+    document: PaperDecisionDocument,
+    reconcile: Effect.Effect<ReconciliationPassResult, E, R>,
+    allowSubmit: boolean,
+    dependencies: MutationPreparationDependencies<R, E, I, P>,
+  ) => (input: I) => Effect.Effect<PreparedMutationCycleStep, CycleRunnerError, R | IntentStore | MutationStore>,
+  typeof prepareMutationIntentDataFirst
+>(8, prepareMutationIntentDataFirst)

--- a/services/bayn/src/observe-composition/mutation-interpreter.ts
+++ b/services/bayn/src/observe-composition/mutation-interpreter.ts
@@ -133,7 +133,7 @@ export const executeMutationIntentWithExecutor = <E, R>(
     return { settlement, consistencyDelayMs: event.consistencyDelayMs, operation }
   })
 
-export const executeMutationIntent = (
+const executeMutationIntentDataFirst = (
   executionProgram: ExecutionProgram,
   intentId: string,
   action: 'RECOVER_SUBMIT' | 'RECOVER_CANCEL' | 'SUBMIT',
@@ -149,3 +149,12 @@ export const executeMutationIntent = (
     submitExpiresAt,
     currentUtcInstant,
   )
+
+export const executeMutationIntent = Pipeable.by<
+  (
+    intentId: string,
+    action: 'RECOVER_SUBMIT' | 'RECOVER_CANCEL' | 'SUBMIT',
+    submitExpiresAt?: string,
+  ) => (executionProgram: ExecutionProgram) => ReturnType<typeof executeMutationIntentDataFirst>,
+  typeof executeMutationIntentDataFirst
+>((arguments_) => typeof arguments_[0] === 'object' && arguments_[0] !== null, executeMutationIntentDataFirst)

--- a/services/bayn/src/operations.ts
+++ b/services/bayn/src/operations.ts
@@ -5,6 +5,7 @@ import { CycleObservabilityError } from './db/cycle-observability'
 import { DatabaseError } from './db/evidence-store'
 import { operationalError, retryableOperationalError, type Component, type OperationalError } from './errors'
 import { retryLayerAcquisition } from './resource-boundary'
+import { Pipeable } from './pipeable'
 
 type DatabaseOperationFailure = DatabaseError | CycleObservabilityError
 
@@ -34,7 +35,7 @@ export const sqlResource = <A, E, R>(layer: Layer.Layer<A, E, R>): Layer.Layer<A
     ),
   )
 
-export const withinDeadline = <A, R>(
+const withinDeadlineDataFirst = <A, R>(
   effect: Effect.Effect<A, OperationalError, R>,
   timeoutMs: number,
   component: Component,
@@ -48,7 +49,16 @@ export const withinDeadline = <A, R>(
     }),
   )
 
-export const databaseOperation = <A, R>(
+export const withinDeadline = Pipeable.generic<
+  <A, R>(
+    timeoutMs: number,
+    component: Component,
+    operation: string,
+  ) => (effect: Effect.Effect<A, OperationalError, R>) => Effect.Effect<A, OperationalError, R>,
+  typeof withinDeadlineDataFirst
+>(4, withinDeadlineDataFirst)
+
+const databaseOperationDataFirst = <A, R>(
   effect: Effect.Effect<A, DatabaseOperationFailure, R>,
   operation: string,
 ): Effect.Effect<A, OperationalError, R> =>
@@ -62,3 +72,10 @@ export const databaseOperation = <A, R>(
       return makeError('database', operation, `PostgreSQL ${operation} failed`, cause)
     }),
   )
+
+export const databaseOperation = Pipeable.generic<
+  <A, R>(
+    operation: string,
+  ) => (effect: Effect.Effect<A, DatabaseOperationFailure, R>) => Effect.Effect<A, OperationalError, R>,
+  typeof databaseOperationDataFirst
+>(2, databaseOperationDataFirst)

--- a/services/bayn/src/paper-proof/operations.ts
+++ b/services/bayn/src/paper-proof/operations.ts
@@ -73,14 +73,22 @@ const timeoutFailureDataFirst = (operation: PaperProofError['operation'], messag
 
 export const timeoutFailure = Pipeable.dual(2, timeoutFailureDataFirst)
 
-export const lift = <A>(
+const liftDataFirst = <A>(
   operation: PaperProofError['operation'],
   message: string,
   effect: Effect.Effect<A, Error>,
 ): Effect.Effect<A, PaperProofError> =>
   effect.pipe(Effect.mapError((cause) => paperProofFailure(operation, message, cause)))
 
-export const liftBounded = <A>(
+export const lift = Pipeable.generic<
+  <A>(
+    message: string,
+    effect: Effect.Effect<A, Error>,
+  ) => (operation: PaperProofError['operation']) => Effect.Effect<A, PaperProofError>,
+  typeof liftDataFirst
+>(3, liftDataFirst)
+
+const liftBoundedDataFirst = <A>(
   operation: PaperProofError['operation'],
   message: string,
   effect: Effect.Effect<A, Error>,
@@ -95,6 +103,15 @@ export const liftBounded = <A>(
         ),
     }),
   )
+
+export const liftBounded = Pipeable.generic<
+  <A>(
+    message: string,
+    effect: Effect.Effect<A, Error>,
+    timeoutMs: number,
+  ) => (operation: PaperProofError['operation']) => Effect.Effect<A, PaperProofError>,
+  typeof liftBoundedDataFirst
+>(4, liftBoundedDataFirst)
 
 const validateReconciliationAccountDataFirst = (
   expectedAccountId: string,

--- a/services/bayn/src/pipeable.test.ts
+++ b/services/bayn/src/pipeable.test.ts
@@ -27,4 +27,16 @@ describe('pipeable functions', () => {
     expect(pair(42, 'paper')).toEqual([42, 'paper'])
     expect(pair('paper')(42)).toEqual([42, 'paper'])
   })
+
+  test('supports an explicit optional-argument discriminator', () => {
+    const repeatDataFirst = (self: string, count = 1): string => self.repeat(count)
+    const repeat = Pipeable.by<(count?: number) => (self: string) => string, typeof repeatDataFirst>(
+      (arguments_) => typeof arguments_[0] === 'string',
+      repeatDataFirst,
+    )
+
+    expect(repeat('bayn')).toBe('bayn')
+    expect(repeat('bayn', 2)).toBe('baynbayn')
+    expect(repeat(2)('bayn')).toBe('baynbayn')
+  })
 })

--- a/services/bayn/src/pipeable.test.ts
+++ b/services/bayn/src/pipeable.test.ts
@@ -16,4 +16,15 @@ describe('pipeable functions', () => {
     expect(append('bayn', '-paper')).toBe('bayn-paper')
     expect(append('-paper')('bayn')).toBe('bayn-paper')
   })
+
+  test('preserves generic inference in both call styles', () => {
+    const pairDataFirst = <A>(self: A, suffix: string): readonly [A, string] => [self, suffix]
+    const pair = Pipeable.generic<<A>(suffix: string) => (self: A) => readonly [A, string], typeof pairDataFirst>(
+      2,
+      pairDataFirst,
+    )
+
+    expect(pair(42, 'paper')).toEqual([42, 'paper'])
+    expect(pair('paper')(42)).toEqual([42, 'paper'])
+  })
 })

--- a/services/bayn/src/pipeable.ts
+++ b/services/bayn/src/pipeable.ts
@@ -23,4 +23,9 @@ const dual = <DataFirst extends AnyFunction>(
   >
 }
 
-export const Pipeable = { dual } as const
+const generic = <DataLast extends AnyFunction, DataFirst extends AnyFunction>(
+  arity: Parameters<DataFirst>['length'],
+  body: DataFirst,
+): DataLast & DataFirst => Function.dual<DataLast, DataFirst>(arity, body)
+
+export const Pipeable = { dual, generic } as const

--- a/services/bayn/src/pipeable.ts
+++ b/services/bayn/src/pipeable.ts
@@ -28,4 +28,9 @@ const generic = <DataLast extends AnyFunction, DataFirst extends AnyFunction>(
   body: DataFirst,
 ): DataLast & DataFirst => Function.dual<DataLast, DataFirst>(arity, body)
 
-export const Pipeable = { dual, generic } as const
+const by = <DataLast extends AnyFunction, DataFirst extends AnyFunction>(
+  isDataFirst: (arguments_: IArguments) => boolean,
+  body: DataFirst,
+): DataLast & DataFirst => Function.dual<DataLast, DataFirst>(isDataFirst, body)
+
+export const Pipeable = { by, dual, generic } as const

--- a/services/bayn/src/resource-boundary.ts
+++ b/services/bayn/src/resource-boundary.ts
@@ -1,10 +1,11 @@
 import { Cause, Context, Effect, Exit, Layer, Scope } from 'effect'
+import { Pipeable } from './pipeable'
 
 /**
  * Runs one acquisition in a child scope. Failed or interrupted attempts close immediately and retain both the
  * acquisition and cleanup causes; successful attempts leave the child scope attached to `scope` for the caller to own.
  */
-export const scopedAcquisition = <A, E, R>(
+const scopedAcquisitionDataFirst = <A, E, R>(
   acquire: (scope: Scope.Scope) => Effect.Effect<A, E, R>,
   scope: Scope.Scope,
 ): Effect.Effect<A, E, R> =>
@@ -24,6 +25,11 @@ export const scopedAcquisition = <A, E, R>(
       return yield* Effect.failCause(result.cause)
     }),
   )
+
+export const scopedAcquisition = Pipeable.generic<
+  <A, E, R>(scope: Scope.Scope) => (acquire: (scope: Scope.Scope) => Effect.Effect<A, E, R>) => Effect.Effect<A, E, R>,
+  typeof scopedAcquisitionDataFirst
+>(2, scopedAcquisitionDataFirst)
 
 const acquireFreshLayer = <A, E, R>(
   layer: Layer.Layer<A, E, R>,
@@ -45,17 +51,29 @@ const scopedLayer = <A, E, R>(
  * Applies a retry policy to fresh, scoped layer acquisition. The retry callback receives an Effect rather than a
  * Layer, so retrying cannot accidentally rebuild a layer through a nested `Layer.build` conversion.
  */
-export const retryLayerAcquisition = <A, E, R>(
+const retryLayerAcquisitionDataFirst = <A, E, R>(
   layer: Layer.Layer<A, E, R>,
   retry: (acquisition: Effect.Effect<Context.Context<A>, E, R>) => Effect.Effect<Context.Context<A>, E, R>,
 ): Layer.Layer<A, E, R> => scopedLayer((scope) => retry(Effect.suspend(() => acquireFreshLayer(layer, scope))))
+
+export const retryLayerAcquisition = Pipeable.generic<
+  <A, E, R>(
+    retry: (acquisition: Effect.Effect<Context.Context<A>, E, R>) => Effect.Effect<Context.Context<A>, E, R>,
+  ) => (layer: Layer.Layer<A, E, R>) => Layer.Layer<A, E, R>,
+  typeof retryLayerAcquisitionDataFirst
+>(2, retryLayerAcquisitionDataFirst)
 
 /**
  * Maps errors from a scoped dependency layer at the resource boundary. The dependency is built once for the
  * boundary and its finalizers remain owned by the same scope as the layer that consumes it.
  */
-export const mapLayerAcquisitionError = <A, E, E2, R>(
+const mapLayerAcquisitionErrorDataFirst = <A, E, E2, R>(
   layer: Layer.Layer<A, E, R>,
   mapError: (cause: E) => E2,
 ): Layer.Layer<A, E2, R> =>
   scopedLayer((scope) => Effect.suspend(() => acquireFreshLayer(layer, scope)).pipe(Effect.mapError(mapError)))
+
+export const mapLayerAcquisitionError = Pipeable.generic<
+  <A, E, E2, R>(mapError: (cause: E) => E2) => (layer: Layer.Layer<A, E, R>) => Layer.Layer<A, E2, R>,
+  typeof mapLayerAcquisitionErrorDataFirst
+>(2, mapLayerAcquisitionErrorDataFirst)

--- a/services/bayn/src/risk-balanced-trend/evaluation.ts
+++ b/services/bayn/src/risk-balanced-trend/evaluation.ts
@@ -10,11 +10,12 @@ import {
 } from '../strategy/risk-balanced-trend/decision'
 import type { RiskBalancedTrendEvaluation } from './model'
 import { parseMatchingManifest } from './schema'
+import { Pipeable } from '../pipeable'
 
 export { compileCurrentRiskBalancedTrendDecision } from '../strategy/risk-balanced-trend/current-decision'
 export { prepareRiskBalancedTrendQualification } from '../strategy/risk-balanced-trend/qualification-precommit'
 
-export const evaluateRiskBalancedTrend = (
+const evaluateRiskBalancedTrendDataFirst = (
   bars: readonly DailyBar[],
   inputManifest: InputManifest,
   protocol: Protocol,
@@ -30,6 +31,16 @@ export const evaluateRiskBalancedTrend = (
     inputManifest: verifiedManifest.success,
   })
 }
+
+export const evaluateRiskBalancedTrend = Pipeable.by<
+  (
+    inputManifest: InputManifest,
+    protocol: Protocol,
+    provenance: RuntimeProvenance,
+    definition?: RiskBalancedTrendStrategyDefinition,
+  ) => (bars: readonly DailyBar[]) => ReturnType<typeof evaluateRiskBalancedTrendDataFirst>,
+  typeof evaluateRiskBalancedTrendDataFirst
+>((arguments_) => Array.isArray(arguments_[0]), evaluateRiskBalancedTrendDataFirst)
 
 /** @deprecated Historical callers should use the generic evaluator summary. */
 export { summarizeEvaluation } from '../strategy/evaluation-runner'

--- a/services/bayn/src/simulation-reconciliation/broker-containment.ts
+++ b/services/bayn/src/simulation-reconciliation/broker-containment.ts
@@ -3,6 +3,7 @@ import { Cause, Effect, Exit } from 'effect'
 import type { ExecutionStoreError, ReconciliationPersistence } from '../db/execution-store'
 import type { WriterFenceError, WriterFenceService } from '../execution/writer-fence'
 import { ReconciliationError, incompletePassReason, type ReconciliationPassError } from './broker-reconciler-model'
+import { Pipeable } from '../pipeable'
 
 export type ContainmentDecision =
   | { readonly _tag: 'PreserveInterruption' }
@@ -52,7 +53,7 @@ const preserveFailureAfterContainment = (
     : Effect.fail(containmentError)
 }
 
-export const containRuntimeFailure = <A, R>(
+const containRuntimeFailureDataFirst = <A, R>(
   effect: Effect.Effect<A, ReconciliationPassError, R>,
   store: ReconciliationPersistence,
   fence: WriterFenceService,
@@ -68,3 +69,12 @@ export const containRuntimeFailure = <A, R>(
     },
     onSuccess: Effect.succeed,
   })
+
+export const containRuntimeFailure = Pipeable.generic<
+  <A, R>(
+    store: ReconciliationPersistence,
+    fence: WriterFenceService,
+    now: Effect.Effect<string>,
+  ) => (effect: Effect.Effect<A, ReconciliationPassError, R>) => Effect.Effect<A, ReconciliationPassError, R>,
+  typeof containRuntimeFailureDataFirst
+>(4, containRuntimeFailureDataFirst)

--- a/services/bayn/src/simulation-reconciliation/broker-model.ts
+++ b/services/bayn/src/simulation-reconciliation/broker-model.ts
@@ -310,7 +310,7 @@ const instantDataFirst = (
 
 export const instant = Pipeable.dual(3, instantDataFirst)
 
-export const indexUnique = <A>(
+const indexUniqueDataFirst = <A>(
   values: readonly A[],
   identity: (value: A) => string,
   collection: ReconciliationIdentityCollection,
@@ -328,6 +328,14 @@ export const indexUnique = <A>(
       ),
     Result.succeed(HashMap.empty()),
   )
+
+export const indexUnique = Pipeable.generic<
+  <A>(
+    identity: (value: A) => string,
+    collection: ReconciliationIdentityCollection,
+  ) => (values: readonly A[]) => ReconciliationDecision<HashMap.HashMap<string, A>>,
+  typeof indexUniqueDataFirst
+>(3, indexUniqueDataFirst)
 
 const discrepancy = (
   accountId: string,

--- a/services/bayn/src/simulation-reconciliation/broker-reconciler-model.ts
+++ b/services/bayn/src/simulation-reconciliation/broker-reconciler-model.ts
@@ -176,7 +176,7 @@ const normalizationFailure = (
     },
   })
 
-export const mapObservationFailure = <A>(
+const mapObservationFailureDataFirst = <A>(
   stage: NormalizationStage,
   identity: string | undefined,
   result: Result.Result<A, BrokerObservationError>,
@@ -185,6 +185,14 @@ export const mapObservationFailure = <A>(
     result,
     Result.mapError((error) => normalizationFailure(stage, identity, error)),
   )
+
+export const mapObservationFailure = Pipeable.generic<
+  <A>(
+    identity: string | undefined,
+    result: Result.Result<A, BrokerObservationError>,
+  ) => (stage: NormalizationStage) => Result.Result<A, ReconciliationError>,
+  typeof mapObservationFailureDataFirst
+>(3, mapObservationFailureDataFirst)
 
 const normalizeTimestampDataFirst = (
   stage: Extract<NormalizationStage, 'order-timestamp' | 'fill-ordering'>,

--- a/services/bayn/src/simulation-reconciliation/validation.ts
+++ b/services/bayn/src/simulation-reconciliation/validation.ts
@@ -132,7 +132,7 @@ export const validateCanonicalIdentity = Pipeable.dual(2, validateCanonicalIdent
 
 type IndexedIdentity = CanonicalIdentityEvidence
 
-export const indexUnique = <A extends { readonly id: string }>(
+const indexUniqueDataFirst = <A extends { readonly id: string }>(
   values: readonly A[],
   entity: Extract<InvalidEvidenceStateProblem, { readonly _tag: 'DuplicateIdentity' }>['entity'],
   evidenceFor: (value: A) => IndexedIdentity,
@@ -150,7 +150,15 @@ export const indexUnique = <A extends { readonly id: string }>(
   return Result.succeed(byId)
 }
 
-export const indexUniqueBy = <A>(
+export const indexUnique = Pipeable.generic<
+  <A extends { readonly id: string }>(
+    entity: Extract<InvalidEvidenceStateProblem, { readonly _tag: 'DuplicateIdentity' }>['entity'],
+    evidenceFor: (value: A) => IndexedIdentity,
+  ) => (values: readonly A[]) => Validation<ReadonlyMap<string, A>>,
+  typeof indexUniqueDataFirst
+>(3, indexUniqueDataFirst)
+
+const indexUniqueByDataFirst = <A>(
   values: readonly A[],
   keyOf: (value: A) => string,
   duplicate: (value: A) => SimulationReconciliationIssue,
@@ -164,7 +172,15 @@ export const indexUniqueBy = <A>(
   return Result.succeed(indexed)
 }
 
-export const groupValuesBy = <A>(
+export const indexUniqueBy = Pipeable.generic<
+  <A>(
+    keyOf: (value: A) => string,
+    duplicate: (value: A) => SimulationReconciliationIssue,
+  ) => (values: readonly A[]) => Validation<ReadonlyMap<string, A>>,
+  typeof indexUniqueByDataFirst
+>(3, indexUniqueByDataFirst)
+
+const groupValuesByDataFirst = <A>(
   values: readonly A[],
   keyOf: (value: A) => string,
 ): ReadonlyMap<string, readonly A[]> => {
@@ -175,6 +191,11 @@ export const groupValuesBy = <A>(
   }
   return grouped
 }
+
+export const groupValuesBy = Pipeable.generic<
+  <A>(keyOf: (value: A) => string) => (values: readonly A[]) => ReadonlyMap<string, readonly A[]>,
+  typeof groupValuesByDataFirst
+>(2, groupValuesByDataFirst)
 
 const validateDecisionIdentityDataFirst = (runId: string, decision: DecisionEvent): Validation<void> => {
   const { id: _, kind: __, ...payload } = decision

--- a/services/bayn/src/simulation/evidence.ts
+++ b/services/bayn/src/simulation/evidence.ts
@@ -52,7 +52,7 @@ const makeDecisionDataFirst = (
 
 export const makeDecision = Pipeable.dual(4, makeDecisionDataFirst)
 
-export const makeOrder = (
+const makeOrderDataFirst = (
   runId: string,
   decision: DecisionEvent,
   sessionDate: IsoDate,
@@ -100,6 +100,20 @@ export const makeOrder = (
       )
     }),
   )
+
+export const makeOrder = Pipeable.by<
+  (
+    decision: DecisionEvent,
+    sessionDate: IsoDate,
+    symbol: string,
+    side: 'buy' | 'sell',
+    requestedQuantityMicros: bigint,
+    referencePrice: bigint,
+    protocol: SimulationProtocol,
+    forceFullFill?: boolean,
+  ) => (runId: string) => ReturnType<typeof makeOrderDataFirst>,
+  typeof makeOrderDataFirst
+>((arguments_) => typeof arguments_[0] === 'string', makeOrderDataFirst)
 
 const limitOrderFillToBuyingPowerDataFirst = (
   runId: string,

--- a/services/bayn/src/simulation/inputs.ts
+++ b/services/bayn/src/simulation/inputs.ts
@@ -304,7 +304,7 @@ const selectEvaluationWindowDataFirst = (
 
 export const selectEvaluationWindow = Pipeable.dual(4, selectEvaluationWindowDataFirst)
 
-export const makeEvaluationIdentity = (
+const makeEvaluationIdentityDataFirst = (
   inputManifest: InputManifest,
   protocol: Protocol,
   provenance: RuntimeProvenance,
@@ -388,3 +388,18 @@ export const makeEvaluationIdentity = (
     }),
   )
 }
+
+export const makeEvaluationIdentity = Pipeable.by<
+  (
+    protocol: Protocol,
+    provenance: RuntimeProvenance,
+    expectedStrategyName?: string,
+  ) => (inputManifest: InputManifest) => ReturnType<typeof makeEvaluationIdentityDataFirst>,
+  typeof makeEvaluationIdentityDataFirst
+>(
+  (arguments_) =>
+    typeof arguments_[0] === 'object' &&
+    arguments_[0] !== null &&
+    arguments_[0].schemaVersion === 'bayn.input-manifest.v3',
+  makeEvaluationIdentityDataFirst,
+)

--- a/services/bayn/src/simulation/inputs.ts
+++ b/services/bayn/src/simulation/inputs.ts
@@ -78,7 +78,7 @@ const requiredSessionDataFirst = (
 
 export const requiredSession = Pipeable.dual(3, requiredSessionDataFirst)
 
-export const requiredRecordValue = <A>(
+const requiredRecordValueDataFirst = <A>(
   values: Readonly<Record<string, A>>,
   key: string,
   operation: RecordOperation,
@@ -94,6 +94,15 @@ export const requiredRecordValue = <A>(
     ),
   )
 }
+
+export const requiredRecordValue = Pipeable.generic<
+  <A>(
+    key: string,
+    operation: RecordOperation,
+    context: string,
+  ) => (values: Readonly<Record<string, A>>) => Result.Result<A, SimulationFailure>,
+  typeof requiredRecordValueDataFirst
+>(4, requiredRecordValueDataFirst)
 
 const buildAlignedSession = (
   bars: readonly DailyBar[],

--- a/services/bayn/src/simulation/record.ts
+++ b/services/bayn/src/simulation/record.ts
@@ -1,6 +1,7 @@
 import { Option, pipe, Result } from 'effect'
 
 import type { SimulationFailure } from './model'
+import { Pipeable } from '../pipeable'
 
 type RecordAccessOperation = Extract<SimulationFailure, { readonly _tag: 'RecordAccessFailed' }>['operation']
 
@@ -19,7 +20,7 @@ const accessFailure = (
   cause,
 })
 
-export const optionalRecordValue = <A>(
+const optionalRecordValueDataFirst = <A>(
   values: Readonly<Record<string, A>>,
   key: string,
   operation: RecordAccessOperation,
@@ -38,3 +39,12 @@ export const optionalRecordValue = <A>(
       return Result.succeed(Option.some(descriptor.value as A))
     }),
   )
+
+export const optionalRecordValue = Pipeable.generic<
+  <A>(
+    key: string,
+    operation: RecordAccessOperation,
+    context: string,
+  ) => (values: Readonly<Record<string, A>>) => Result.Result<Option.Option<A>, SimulationFailure>,
+  typeof optionalRecordValueDataFirst
+>(4, optionalRecordValueDataFirst)

--- a/services/bayn/src/simulation/simulate.ts
+++ b/services/bayn/src/simulation/simulate.ts
@@ -10,6 +10,7 @@ import type { AlignedSession, SimulationDecision, SimulationFailure, SimulationI
 import { rebalanceSession } from './rebalance'
 import { initialState, type SessionOpeningSnapshot, type SimulationState } from './state'
 import { closeSession } from './valuation'
+import { Pipeable } from '../pipeable'
 
 const fail = <A = never>(failure: SimulationFailure): Result.Result<A, SimulationFailure> => Result.fail(failure)
 
@@ -247,7 +248,7 @@ const runSimulation = (
     Result.succeed(state),
   )
 
-export const simulate = (
+const simulateDataFirst = (
   sessions: readonly AlignedSession[],
   targets: readonly SimulationTarget[],
   startIndex: number,
@@ -288,3 +289,16 @@ export const simulate = (
     Result.flatMap((state) => completeSimulation(state, protocol, costMultiplierMicros, recordEvents)),
   )
 }
+
+export const simulate = Pipeable.by<
+  (
+    targets: readonly SimulationTarget[],
+    startIndex: number,
+    protocol: SimulationProtocol,
+    costMultiplierMicros: bigint,
+    runId: string,
+    recordEvents: boolean,
+    terminalCloseTarget?: (target: SimulationTarget, executionIndex: number) => SimulationTarget,
+  ) => (sessions: readonly AlignedSession[]) => ReturnType<typeof simulateDataFirst>,
+  typeof simulateDataFirst
+>((arguments_) => Array.isArray(arguments_[1]), simulateDataFirst)

--- a/services/bayn/src/strategy.ts
+++ b/services/bayn/src/strategy.ts
@@ -8,6 +8,7 @@ import type {
   StrategyDecisionFailure,
   TargetPortfolio,
 } from './strategy/core'
+import { Pipeable } from './pipeable'
 
 export type {
   CompiledStrategyDecision,
@@ -31,7 +32,7 @@ export const activeStrategyName = 'risk-balanced-trend' as const
 export const activeStrategyBehaviorHash = riskBalancedTrendBehaviorHash
 
 /** Attach the reviewed module identity to the executable application exported by that module. */
-export const bindReviewedStrategySource = <
+const bindReviewedStrategySourceDataFirst = <
   TMarket,
   TFailure extends StrategyDecisionFailure,
   TTarget extends TargetPortfolio,
@@ -42,6 +43,15 @@ export const bindReviewedStrategySource = <
   ...application,
   reviewedSource: Object.freeze({ ...reviewedSource }),
 })
+
+export const bindReviewedStrategySource = Pipeable.generic<
+  <TMarket, TFailure extends StrategyDecisionFailure, TTarget extends TargetPortfolio>(
+    reviewedSource: ReviewedStrategySource,
+  ) => (
+    application: StrategyApplication<TMarket, TFailure, TTarget>,
+  ) => StrategyApplication<TMarket, TFailure, TTarget>,
+  typeof bindReviewedStrategySourceDataFirst
+>(2, bindReviewedStrategySourceDataFirst)
 export type {
   RiskBalancedTrendMarketContext,
   RiskBalancedTrendStrategyApplication,

--- a/services/bayn/src/strategy/execution-model/fixed-point.ts
+++ b/services/bayn/src/strategy/execution-model/fixed-point.ts
@@ -9,7 +9,7 @@ export type ExecutionResult<A> = Result.Result<A, ExecutionModelFailure>
 
 export const fail = <A>(failure: ExecutionModelFailure): ExecutionResult<A> => Result.fail(failure)
 
-export const ensureUnsigned = (value: string, field: string, minimum = 0n): ExecutionResult<bigint> => {
+const ensureUnsignedDataFirst = (value: string, field: string, minimum = 0n): ExecutionResult<bigint> => {
   if (!/^[0-9]+$/.test(value)) {
     return fail({ _tag: 'InvalidUnsignedInteger', field, value, minimum })
   }
@@ -17,7 +17,12 @@ export const ensureUnsigned = (value: string, field: string, minimum = 0n): Exec
   return parsed < minimum ? fail({ _tag: 'InvalidUnsignedInteger', field, value, minimum }) : Result.succeed(parsed)
 }
 
-export const scaledNumber = (value: number, field: string, scale = Number(MICROS)): ExecutionResult<bigint> => {
+export const ensureUnsigned = Pipeable.by<
+  (field: string, minimum?: bigint) => (value: string) => ExecutionResult<bigint>,
+  typeof ensureUnsignedDataFirst
+>((arguments_) => typeof arguments_[1] === 'string', ensureUnsignedDataFirst)
+
+const scaledNumberDataFirst = (value: number, field: string, scale = Number(MICROS)): ExecutionResult<bigint> => {
   if (!Number.isFinite(value)) {
     return fail({ _tag: 'InvalidFixedPointNumber', field, value, scale, reason: 'not-finite' })
   }
@@ -31,6 +36,11 @@ export const scaledNumber = (value: number, field: string, scale = Number(MICROS
     ? fail({ _tag: 'InvalidFixedPointNumber', field, value, scale, reason: 'precision-exceeded' })
     : Result.succeed(BigInt(rounded))
 }
+
+export const scaledNumber = Pipeable.by<
+  (field: string, scale?: number) => (value: number) => ReturnType<typeof scaledNumberDataFirst>,
+  typeof scaledNumberDataFirst
+>((arguments_) => typeof arguments_[0] === 'number', scaledNumberDataFirst)
 
 const integerNumberDataFirst = (
   value: number,
@@ -94,7 +104,7 @@ const quantizeNearestDataFirst = (value: bigint, increment: bigint): ExecutionRe
 
 export const quantizeNearest = Pipeable.dual(2, quantizeNearestDataFirst)
 
-export const numberToMicros = (value: number, field = 'value'): ExecutionResult<bigint> => {
+const numberToMicrosDataFirst = (value: number, field = 'value'): ExecutionResult<bigint> => {
   const scale = Number(MICROS)
   if (!Number.isFinite(value)) {
     return fail({ _tag: 'InvalidFixedPointNumber', field, value, scale, reason: 'not-finite' })
@@ -107,6 +117,11 @@ export const numberToMicros = (value: number, field = 'value'): ExecutionResult<
     ? Result.succeed(BigInt(scaled))
     : fail({ _tag: 'InvalidFixedPointNumber', field, value, scale, reason: 'precision-exceeded' })
 }
+
+export const numberToMicros = Pipeable.by<
+  (field?: string) => (value: number) => ReturnType<typeof numberToMicrosDataFirst>,
+  typeof numberToMicrosDataFirst
+>((arguments_) => typeof arguments_[0] === 'number', numberToMicrosDataFirst)
 
 export const microsToNumber = (value: bigint): number => Number(value) / Number(MICROS)
 

--- a/services/bayn/src/strategy/risk-balanced-trend/application.ts
+++ b/services/bayn/src/strategy/risk-balanced-trend/application.ts
@@ -12,6 +12,7 @@ import {
   riskBalancedTrendContextAtSignal,
   type RiskBalancedTrendStrategyDefinition,
 } from './decision'
+import { Pipeable } from '../../pipeable'
 
 export type RiskBalancedTrendStrategyApplication = StrategyApplication<
   import('./decision').RiskBalancedTrendMarketContext,
@@ -24,7 +25,7 @@ const applicationFailure = (
   cause: unknown,
 ): StrategyApplicationFailure => ({ _tag: 'StrategyApplicationFailure', operation, cause })
 
-export const makeRiskBalancedTrendApplication = (
+const makeRiskBalancedTrendApplicationDataFirst = (
   protocol: import('../../types').Protocol,
   suppliedDefinition?: RiskBalancedTrendStrategyDefinition,
 ): RiskBalancedTrendStrategyApplication => {
@@ -79,3 +80,13 @@ export const makeRiskBalancedTrendApplication = (
       ),
   }
 }
+
+export const makeRiskBalancedTrendApplication = Pipeable.by<
+  (
+    suppliedDefinition?: RiskBalancedTrendStrategyDefinition,
+  ) => (protocol: import('../../types').Protocol) => ReturnType<typeof makeRiskBalancedTrendApplicationDataFirst>,
+  typeof makeRiskBalancedTrendApplicationDataFirst
+>(
+  (arguments_) => typeof arguments_[0] === 'object' && arguments_[0] !== null && 'schemaVersion' in arguments_[0],
+  makeRiskBalancedTrendApplicationDataFirst,
+)

--- a/services/bayn/src/strategy/risk-balanced-trend/current-decision.ts
+++ b/services/bayn/src/strategy/risk-balanced-trend/current-decision.ts
@@ -14,6 +14,7 @@ import type {
   RiskBalancedTrendFailure,
 } from '../../risk-balanced-trend/model'
 import { decodeCurrentDecisionCycleBinding } from '../../risk-balanced-trend/schema'
+import { Pipeable } from '../../pipeable'
 
 const fail = <A = never>(failure: RiskBalancedTrendFailure): Result.Result<A, RiskBalancedTrendFailure> =>
   Result.fail(failure)
@@ -35,7 +36,7 @@ const terminalPrices = (
     Result.map((prices) => Object.fromEntries(prices)),
   )
 
-export const compileCurrentRiskBalancedTrendDecision = (
+const compileCurrentRiskBalancedTrendDecisionDataFirst = (
   bars: readonly DailyBar[],
   inputManifest: InputManifest,
   protocol: Protocol,
@@ -92,3 +93,13 @@ export const compileCurrentRiskBalancedTrendDecision = (
       ),
     ),
   )
+
+export const compileCurrentRiskBalancedTrendDecision = Pipeable.by<
+  (
+    inputManifest: InputManifest,
+    protocol: Protocol,
+    cycleBinding: CurrentDecisionCycleBinding,
+    definition?: RiskBalancedTrendStrategyDefinition,
+  ) => (bars: readonly DailyBar[]) => ReturnType<typeof compileCurrentRiskBalancedTrendDecisionDataFirst>,
+  typeof compileCurrentRiskBalancedTrendDecisionDataFirst
+>((arguments_) => Array.isArray(arguments_[0]), compileCurrentRiskBalancedTrendDecisionDataFirst)

--- a/services/bayn/src/strategy/risk-balanced-trend/decision.ts
+++ b/services/bayn/src/strategy/risk-balanced-trend/decision.ts
@@ -215,7 +215,7 @@ const riskBalancedTrendContextAtSignalDataFirst = (
 
 export const riskBalancedTrendContextAtSignal = Pipeable.dual(3, riskBalancedTrendContextAtSignalDataFirst)
 
-export const decisionFromAlignedSessions = (
+const decisionFromAlignedSessionsDataFirst = (
   sessions: readonly AlignedSession[],
   signalIndex: number,
   protocol: Protocol,
@@ -225,3 +225,12 @@ export const decisionFromAlignedSessions = (
     riskBalancedTrendContextAtSignal(sessions, signalIndex, protocol),
     Result.flatMap((context) => definition.decide(context)),
   )
+
+export const decisionFromAlignedSessions = Pipeable.by<
+  (
+    signalIndex: number,
+    protocol: Protocol,
+    definition?: RiskBalancedTrendStrategyDefinition,
+  ) => (sessions: readonly AlignedSession[]) => ReturnType<typeof decisionFromAlignedSessionsDataFirst>,
+  typeof decisionFromAlignedSessionsDataFirst
+>((arguments_) => Array.isArray(arguments_[0]), decisionFromAlignedSessionsDataFirst)

--- a/services/bayn/src/strategy/risk-balanced-trend/shared.ts
+++ b/services/bayn/src/strategy/risk-balanced-trend/shared.ts
@@ -16,7 +16,7 @@ export const fail = <A = never>(failure: RiskBalancedTrendFailure): Result.Resul
 
 export const requiredHistory = (protocol: Protocol): number => Math.max(protocol.volatilityWindow, ...protocol.horizons)
 
-export const finite = (
+const finiteDataFirst = (
   value: number,
   operation: Extract<RiskBalancedTrendFailure, { readonly _tag: 'InvalidRiskBalancedTrendNumber' }>['operation'],
   symbol: string | null = null,
@@ -26,6 +26,14 @@ export const finite = (
     : value < 0 && operation === 'portfolio-variance'
       ? fail({ _tag: 'InvalidRiskBalancedTrendNumber', operation, value, symbol, reason: 'negative' })
       : Result.succeed(value)
+
+export const finite = Pipeable.by<
+  (
+    operation: Extract<RiskBalancedTrendFailure, { readonly _tag: 'InvalidRiskBalancedTrendNumber' }>['operation'],
+    symbol?: string | null,
+  ) => (value: number) => ReturnType<typeof finiteDataFirst>,
+  typeof finiteDataFirst
+>((arguments_) => typeof arguments_[0] === 'number', finiteDataFirst)
 
 const dailyReturnsDataFirst = (
   closes: readonly number[],

--- a/services/bayn/src/tigerbeetle-client.ts
+++ b/services/bayn/src/tigerbeetle-client.ts
@@ -243,7 +243,7 @@ const resolveReplicaEndpoint = (
         Effect.flatMap((addresses) => replicaAddressBoundary(validateResolvedReplicaEndpoint(endpoint, addresses))),
       )
 
-export const resolveReplicaAddresses = (
+const resolveReplicaAddressesDataFirst = (
   configuredAddresses: readonly string[],
   resolveHostname: ResolveHostname = lookupIpv4,
 ): Effect.Effect<string[], OperationalError> =>
@@ -255,6 +255,13 @@ export const resolveReplicaAddresses = (
     ),
     Effect.flatMap((addresses) => replicaAddressBoundary(validateResolvedReplicaAddresses(addresses))),
   )
+
+export const resolveReplicaAddresses = Pipeable.by<
+  (
+    resolveHostname?: ResolveHostname,
+  ) => (configuredAddresses: readonly string[]) => ReturnType<typeof resolveReplicaAddressesDataFirst>,
+  typeof resolveReplicaAddressesDataFirst
+>((arguments_) => Array.isArray(arguments_[0]), resolveReplicaAddressesDataFirst)
 
 export interface JournalDependencies {
   readonly createClient: (options: ClientInitArgs) => TigerBeetleClient

--- a/services/bayn/src/tigerbeetle-client.ts
+++ b/services/bayn/src/tigerbeetle-client.ts
@@ -459,7 +459,7 @@ const tigerBeetleRequest = <A>(
     ),
   )
 
-export const makeTigerBeetleRequestClient = (
+const makeTigerBeetleRequestClientDataFirst = (
   config: Pick<RuntimeConfig, 'operationTimeoutMs' | 'tigerBeetle'>,
   dependencies: JournalDependencies = defaultDependencies,
 ) =>
@@ -476,3 +476,15 @@ export const makeTigerBeetleRequestClient = (
     }
     return client
   })
+
+export const makeTigerBeetleRequestClient = Pipeable.by<
+  (
+    dependencies?: JournalDependencies,
+  ) => (
+    config: Pick<RuntimeConfig, 'operationTimeoutMs' | 'tigerBeetle'>,
+  ) => ReturnType<typeof makeTigerBeetleRequestClientDataFirst>,
+  typeof makeTigerBeetleRequestClientDataFirst
+>(
+  (arguments_) => typeof arguments_[0] === 'object' && arguments_[0] !== null && 'tigerBeetle' in arguments_[0],
+  makeTigerBeetleRequestClientDataFirst,
+)


### PR DESCRIPTION
## Summary

- Makes optional domain and boundary APIs pipeable while retaining their absence semantics.
- Keeps this native stack layer independently reviewable at 895 changed lines.
- Bases directly on codex/bayn-effect-tsgo-pipeable-schema so GitHub shows only this layer.

## Related Issues

None

## Testing

- bunx tsc --noEmit --project services/bayn/tsconfig.json
- bun run lint
- bun run lint:oxlint
- bun run lint:oxlint:type
- bun run build
- Focused tests for the touched subsystem were run while constructing the layer.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable and Breaking Changes is filled in.
- [x] Documentation and follow-ups are unchanged or represented by later stack layers.