### PR TITLE
refactor(bayn): structure operational and cycle failures

### DIFF
--- a/services/bayn/src/app.ts
+++ b/services/bayn/src/app.ts
@@ -190,12 +190,12 @@ const currentUtcInstant = Clock.currentTimeMillis.pipe(
     Effect.try({
       try: () => utcInstantFromEpochMillis(millis),
       catch: (cause) =>
-        operationalError(
-          'strategy',
-          'cycle-loop-clock',
-          'runtime clock did not produce a canonical UTC instant',
+        operationalError({
+          component: 'strategy',
+          operation: 'cycle-loop-clock',
+          message: 'runtime clock did not produce a canonical UTC instant',
           cause,
-        ),
+        }),
     }),
   ),
 )

--- a/services/bayn/src/application-plan.ts
+++ b/services/bayn/src/application-plan.ts
@@ -113,28 +113,28 @@ const runtimeIdentityError = (failure: RuntimeIdentityFailure) =>
   pipe(
     Match.value(failure),
     Match.tag('RuntimeParameterHashFailed', ({ cause }) =>
-      operationalError(
-        'strategy',
-        'runtime-identity/parameter-hash',
-        'runtime strategy parameter-hash construction failed',
+      operationalError({
+        component: 'strategy',
+        operation: 'runtime-identity/parameter-hash',
+        message: 'runtime strategy parameter-hash construction failed',
         cause,
-      ),
+      }),
     ),
     Match.tag('RuntimeProvenanceFailed', ({ cause }) =>
-      operationalError(
-        'strategy',
-        'runtime-identity/provenance',
-        'runtime strategy provenance construction failed',
+      operationalError({
+        component: 'strategy',
+        operation: 'runtime-identity/provenance',
+        message: 'runtime strategy provenance construction failed',
         cause,
-      ),
+      }),
     ),
     Match.tag('RuntimeStrategyProtocolHashFailed', ({ cause }) =>
-      operationalError(
-        'strategy',
-        'runtime-identity/strategy-protocol-hash',
-        'runtime strategy protocol-hash construction failed',
+      operationalError({
+        component: 'strategy',
+        operation: 'runtime-identity/strategy-protocol-hash',
+        message: 'runtime strategy protocol-hash construction failed',
         cause,
-      ),
+      }),
     ),
     Match.exhaustive,
   )

--- a/services/bayn/src/broker/alpaca/http.ts
+++ b/services/bayn/src/broker/alpaca/http.ts
@@ -275,29 +275,42 @@ const makeFreshBrokerPriceReaderDataFirst = (
           'APCA-API-SECRET-KEY': secret,
         },
       })
-      const response = yield* authenticated
-        .execute(request)
-        .pipe(
-          Effect.mapError((cause) =>
-            operationalError('http', 'alpaca-latest-quote', 'Alpaca latest quote request failed', cause),
-          ),
-        )
+      const response = yield* authenticated.execute(request).pipe(
+        Effect.mapError((cause) =>
+          operationalError({
+            component: 'http',
+            operation: 'alpaca-latest-quote',
+            message: 'Alpaca latest quote request failed',
+            cause,
+          }),
+        ),
+      )
       if (response.status < 200 || response.status >= 300) {
-        return yield* operationalError(
-          'http',
-          'alpaca-latest-quote',
-          `Alpaca latest quote returned HTTP ${response.status.toString()}`,
-        )
+        return yield* operationalError({
+          component: 'http',
+          operation: 'alpaca-latest-quote',
+          message: `Alpaca latest quote returned HTTP ${response.status.toString()}`,
+        })
       }
       const raw = yield* response.json.pipe(
         Effect.mapError((cause) =>
-          operationalError('http', 'alpaca-latest-quote', 'Alpaca latest quote body is not valid JSON', cause),
+          operationalError({
+            component: 'http',
+            operation: 'alpaca-latest-quote',
+            message: 'Alpaca latest quote body is not valid JSON',
+            cause,
+          }),
         ),
       )
       const observedAt = yield* currentUtcInstant
       return yield* Effect.fromResult(decodeFreshBrokerPrice(symbol, raw, observedAt)).pipe(
         Effect.mapError((cause) =>
-          operationalError('http', 'alpaca-latest-quote', 'Alpaca latest quote violates the price contract', cause),
+          operationalError({
+            component: 'http',
+            operation: 'alpaca-latest-quote',
+            message: 'Alpaca latest quote violates the price contract',
+            cause,
+          }),
         ),
       )
     }).pipe(
@@ -305,11 +318,11 @@ const makeFreshBrokerPriceReaderDataFirst = (
         duration: connection.operationTimeoutMs,
         orElse: () =>
           Effect.fail(
-            operationalError(
-              'http',
-              'alpaca-latest-quote',
-              `Alpaca latest quote timed out after ${connection.operationTimeoutMs.toString()}ms`,
-            ),
+            operationalError({
+              component: 'http',
+              operation: 'alpaca-latest-quote',
+              message: `Alpaca latest quote timed out after ${connection.operationTimeoutMs.toString()}ms`,
+            }),
           ),
       }),
       Effect.provideService(Headers.CurrentRedactedNames, redactedHeaders),

--- a/services/bayn/src/build.ts
+++ b/services/bayn/src/build.ts
@@ -51,7 +51,13 @@ const verifyParameterHashDataFirst = (
 ): Effect.Effect<void, OperationalError> =>
   metadata.strategyParameterHash === actualParameterHash
     ? Effect.void
-    : Effect.fail(operationalError('config', 'provenance', 'compiled strategy parameters do not match build metadata'))
+    : Effect.fail(
+        operationalError({
+          component: 'config',
+          operation: 'provenance',
+          message: 'compiled strategy parameters do not match build metadata',
+        }),
+      )
 
 export const verifyParameterHash = Pipeable.dual(2, verifyParameterHashDataFirst)
 
@@ -61,6 +67,12 @@ const verifyBehaviorHashDataFirst = (
 ): Effect.Effect<void, OperationalError> =>
   metadata.strategyBehaviorHash === actualBehaviorHash
     ? Effect.void
-    : Effect.fail(operationalError('config', 'provenance', 'compiled strategy behavior does not match build metadata'))
+    : Effect.fail(
+        operationalError({
+          component: 'config',
+          operation: 'provenance',
+          message: 'compiled strategy behavior does not match build metadata',
+        }),
+      )
 
 export const verifyBehaviorHash = Pipeable.dual(2, verifyBehaviorHashDataFirst)

--- a/services/bayn/src/composition.ts
+++ b/services/bayn/src/composition.ts
@@ -319,8 +319,13 @@ const executionProgramError = (
   cause: BrokerMutationError | Result.Result.Failure<ReturnType<typeof makeExecutionProgram>>,
 ) =>
   cause instanceof BrokerMutationError
-    ? operationalError('config', 'broker-mutation', cause.message, cause)
-    : operationalError('config', 'execution-program', 'execution program requires validated mutation authority', cause)
+    ? operationalError({ component: 'config', operation: 'broker-mutation', message: cause.message, cause })
+    : operationalError({
+        component: 'config',
+        operation: 'execution-program',
+        message: 'execution program requires validated mutation authority',
+        cause,
+      })
 
 type ReadOnlyExecutionPolicy = Extract<ExecutionPolicy, { readonly brokerAccess: BrokerAccess.ReadOnly }>
 
@@ -1664,7 +1669,12 @@ const writeDiscoveryReceipt = (receipt: ExecutionCandidateDiscoveryReceipt) =>
   pipe(
     encodeJson(receipt),
     Effect.mapError((cause) =>
-      operationalError('strategy', 'paper-candidate-output', 'paper candidate receipt encoding failed', cause),
+      operationalError({
+        component: 'strategy',
+        operation: 'paper-candidate-output',
+        message: 'paper candidate receipt encoding failed',
+        cause,
+      }),
     ),
     Effect.flatMap((output) =>
       pipe(
@@ -1678,7 +1688,12 @@ const writeExecutionPrepareOutput = (output: ExecutionPrepareOutput) =>
   pipe(
     encodeJson(output),
     Effect.mapError((cause) =>
-      operationalError('strategy', 'execution-prepare-output', 'EXECUTION_PREPARE output encoding failed', cause),
+      operationalError({
+        component: 'strategy',
+        operation: 'execution-prepare-output',
+        message: 'EXECUTION_PREPARE output encoding failed',
+        cause,
+      }),
     ),
     Effect.flatMap((output) =>
       pipe(
@@ -1695,7 +1710,12 @@ const policyHash = (
   pipe(
     canonicalHashV1Result(policy),
     Result.mapError((cause) =>
-      operationalError('strategy', operation, 'source-controlled OBSERVE risk policy content hashing failed', cause),
+      operationalError({
+        component: 'strategy',
+        operation,
+        message: 'source-controlled OBSERVE risk policy content hashing failed',
+        cause,
+      }),
     ),
     Effect.fromResult,
   )
@@ -1720,12 +1740,12 @@ const executionCandidateIdentity = (
 const discoverExecutionCandidate = (plan: ApplicationPlanFor<'ExecutionCandidateDiscovery'>, riskPolicyHash: string) =>
   discoverExecutionCandidatesHistoricalCodec(executionCandidateIdentity(plan, riskPolicyHash)).pipe(
     Effect.mapError((cause) =>
-      operationalError(
-        'strategy',
-        'execution-candidate-discovery',
-        renderExecutionCandidateDiscoveryError(cause),
+      operationalError({
+        component: 'strategy',
+        operation: 'execution-candidate-discovery',
+        message: renderExecutionCandidateDiscoveryError(cause),
         cause,
-      ),
+      }),
     ),
   )
 
@@ -1733,12 +1753,12 @@ const runExecutionCandidateDiscovery = (plan: ApplicationPlanFor<'ExecutionCandi
   pipe(
     loadObserveRiskPolicy(plan.config.alpaca.expectedAccountId, plan.strategy.definition.parameters.universe),
     Effect.mapError((cause) =>
-      operationalError(
-        'config',
-        'execution-candidate-discovery',
-        'source-controlled OBSERVE risk policy is invalid',
+      operationalError({
+        component: 'config',
+        operation: 'execution-candidate-discovery',
+        message: 'source-controlled OBSERVE risk policy is invalid',
         cause,
-      ),
+      }),
     ),
     Effect.flatMap((policy) => policyHash(policy, 'paper-candidate-policy')),
     Effect.flatMap((riskPolicyHash) => discoverExecutionCandidate(plan, riskPolicyHash)),
@@ -1796,7 +1816,12 @@ export const validateExecutionPreparePlan = (plan: ApplicationPlanFor<'Execution
       plan.strategy.definition.parameters.universe,
     ).pipe(
       Effect.mapError((cause) =>
-        operationalError('config', 'execution-prepare', 'source-controlled OBSERVE risk policy is invalid', cause),
+        operationalError({
+          component: 'config',
+          operation: 'execution-prepare',
+          message: 'source-controlled OBSERVE risk policy is invalid',
+          cause,
+        }),
       ),
     )
     const riskPolicyHash = yield* policyHash(riskPolicy, 'execution-prepare-policy')

--- a/services/bayn/src/config/load.ts
+++ b/services/bayn/src/config/load.ts
@@ -126,7 +126,14 @@ export const loadConfig = (
   embedded: EmbeddedBuildMetadata | undefined = embeddedBuildMetadata,
 ): Effect.Effect<LoadedRuntimeConfig, OperationalError> =>
   runtimeConfigSource.pipe(
-    Effect.mapError((cause) => operationalError('config', 'load', 'invalid runtime configuration', cause)),
+    Effect.mapError((cause) =>
+      operationalError({
+        component: 'config',
+        operation: 'load',
+        message: 'invalid runtime configuration',
+        cause,
+      }),
+    ),
     Effect.flatMap((parsed) =>
       Effect.fromResult(resolveRuntimeConfig({ parsed, embeddedBuildMetadata: embedded })).pipe(
         Effect.mapError(resolutionFailureToOperationalError),

--- a/services/bayn/src/cycle-readiness.test.ts
+++ b/services/bayn/src/cycle-readiness.test.ts
@@ -397,7 +397,13 @@ describe('autonomous cycle finalized-publication readiness', () => {
           () =>
             TestClock.setTime(Date.parse(cycle.window.publicationDeadlineAt)).pipe(
               Effect.andThen(
-                Effect.fail(operationalError('market-data', 'inspect-publication', 'mutated finalized manifest')),
+                Effect.fail(
+                  operationalError({
+                    component: 'market-data',
+                    operation: 'inspect-publication',
+                    message: 'mutated finalized manifest',
+                  }),
+                ),
               ),
             ),
           control,

--- a/services/bayn/src/cycle-runner/admission-decisions.ts
+++ b/services/bayn/src/cycle-runner/admission-decisions.ts
@@ -117,22 +117,37 @@ export const selectCycleCalendarCandidate = Pipeable.generic<
 >(5, selectCycleCalendarCandidateDataFirst)
 
 export const publicationFailureError = (cause: CyclePublicationFailure): CycleRunnerError =>
-  runnerError('inspect-publication', 'contract', 'bounded cycle publication discovery is invalid', cause)
+  runnerError({
+    operation: 'inspect-publication',
+    failure: 'contract',
+    message: 'bounded cycle publication discovery is invalid',
+    cause,
+  })
 
 export const calendarQueryFailureError = (cause: CycleCalendarQueryFailure): CycleRunnerError =>
-  runnerError('market-calendar', 'contract', 'cycle calendar query construction failed', cause)
+  runnerError({
+    operation: 'market-calendar',
+    failure: 'contract',
+    message: 'cycle calendar query construction failed',
+    cause,
+  })
 
 export const calendarCandidateFailureError = (cause: CycleCalendarCandidateFailure): CycleRunnerError => {
   switch (cause._tag) {
     case 'CycleExecutionSessionUnavailable':
-      return runnerError(
-        'select-session',
-        'calendar-unavailable',
-        `broker calendar has no trading session after ${cause.signalSessionDate}`,
+      return runnerError({
+        operation: 'select-session',
+        failure: 'calendar-unavailable',
+        message: `broker calendar has no trading session after ${cause.signalSessionDate}`,
         cause,
-      )
+      })
     case 'CycleDraftConstructionFailed':
-      return runnerError('build-cycle', 'contract', 'autonomous cycle draft construction failed', cause)
+      return runnerError({
+        operation: 'build-cycle',
+        failure: 'contract',
+        message: 'autonomous cycle draft construction failed',
+        cause,
+      })
   }
 }
 
@@ -155,11 +170,11 @@ export const selectDiscoveredPublications = (
   const [firstPublication, ...remainingPublications] = discovery.publications
   if (firstPublication === undefined) {
     return Result.fail(
-      runnerError(
-        'inspect-publication',
-        'contract',
-        'FINALIZED cycle publication discovery must contain a publication',
-      ),
+      runnerError({
+        operation: 'inspect-publication',
+        failure: 'contract',
+        message: 'FINALIZED cycle publication discovery must contain a publication',
+      }),
     )
   }
   return pipe(

--- a/services/bayn/src/cycle-runner/loop.ts
+++ b/services/bayn/src/cycle-runner/loop.ts
@@ -45,7 +45,7 @@ const sleepUntil = (deadlineNanos: bigint): Effect.Effect<void> =>
   )
 
 const idleReconciliationError = (cause: CycleNotDueReconciliationError): CycleRunnerError =>
-  runnerError('reconcile-not-due', cause.failure, cause.message, cause)
+  runnerError({ operation: 'reconcile-not-due', failure: cause.failure, message: cause.message, cause })
 
 const markReconciliationCompleted = (cadence: Ref.Ref<ReconciliationCadenceState>): Effect.Effect<void> =>
   Clock.currentTimeNanos.pipe(Effect.flatMap((lastAttemptAtNanos) => Ref.set(cadence, { lastAttemptAtNanos })))
@@ -103,7 +103,12 @@ const runLoopPass = <E, ContextR, DecisionR>(
 ): Effect.Effect<CycleRunResult, CycleRunnerError, BrokerRead | CycleStore | MarketData | ContextR | DecisionR> =>
   options.context.pipe(
     Effect.mapError((cause) =>
-      runnerError('load-context', 'context', 'autonomous cycle context loading failed', cause),
+      runnerError({
+        operation: 'load-context',
+        failure: 'context',
+        message: 'autonomous cycle context loading failed',
+        cause,
+      }),
     ),
     Effect.map((context) => trackDecisionReconciliation(cadence, context)),
     Effect.flatMap(runAutonomousCycleUntilSettled),
@@ -111,11 +116,11 @@ const runLoopPass = <E, ContextR, DecisionR>(
   )
 
 const cyclePassTimeoutError = (timeoutMs: number): CycleRunnerError =>
-  runnerError(
-    'run-cycle-pass',
-    'operational',
-    `autonomous cycle pass did not complete or reconcile within ${timeoutMs.toString()}ms`,
-  )
+  runnerError({
+    operation: 'run-cycle-pass',
+    failure: 'operational',
+    message: `autonomous cycle pass did not complete or reconcile within ${timeoutMs.toString()}ms`,
+  })
 
 const runBoundedLoopPass = <E, ContextR, DecisionR>(
   options: AutonomousCycleLoopOptions<E, ContextR, DecisionR>,

--- a/services/bayn/src/cycle-runner/model.ts
+++ b/services/bayn/src/cycle-runner/model.ts
@@ -158,9 +158,11 @@ export interface AutonomousCycleLoopOptions<E = never, ContextR = never, Decisio
   readonly reconcileNotDue: Effect.Effect<void, CycleNotDueReconciliationError, DecisionR>
 }
 
-export const runnerError = (
-  operation: CycleRunnerError['operation'],
-  failure: CycleRunnerError['failure'],
-  message: string,
-  cause?: unknown,
-): CycleRunnerError => new CycleRunnerError({ operation, failure, message, cause })
+export interface CycleRunnerErrorInput {
+  readonly operation: CycleRunnerError['operation']
+  readonly failure: CycleRunnerError['failure']
+  readonly message: string
+  readonly cause?: unknown
+}
+
+export const runnerError = (input: CycleRunnerErrorInput): CycleRunnerError => new CycleRunnerError(input)

--- a/services/bayn/src/cycle-runner/pass-decisions.ts
+++ b/services/bayn/src/cycle-runner/pass-decisions.ts
@@ -34,7 +34,13 @@ const finishRecoveryResultDataFirst = (
     case CycleState.Blocked:
       return result('BLOCKED')
     default:
-      return Result.fail(runnerError('recover-cycle', 'contract', 'cycle finish did not produce a terminal state'))
+      return Result.fail(
+        runnerError({
+          operation: 'recover-cycle',
+          failure: 'contract',
+          message: 'cycle finish did not produce a terminal state',
+        }),
+      )
   }
 }
 
@@ -228,4 +234,10 @@ export const cyclePassLogFacts = (observation: CyclePassObservation): CyclePassL
 export const validateCycleLoopInterval = (pollIntervalMs: number): Result.Result<number, CycleRunnerError> =>
   Number.isSafeInteger(pollIntervalMs) && pollIntervalMs > 0
     ? Result.succeed(pollIntervalMs)
-    : Result.fail(runnerError('configure', 'invalid-config', 'cycle loop interval must be a positive safe integer'))
+    : Result.fail(
+        runnerError({
+          operation: 'configure',
+          failure: 'invalid-config',
+          message: 'cycle loop interval must be a positive safe integer',
+        }),
+      )

--- a/services/bayn/src/cycle-runner/program.ts
+++ b/services/bayn/src/cycle-runner/program.ts
@@ -48,21 +48,21 @@ const bindDiscoveredPublication = (
 ): Effect.Effect<CycleBindingResult, CycleRunnerError, CycleStore> =>
   bindFinalizedCyclePublication(cycle, inspection, observedAt).pipe(
     Effect.mapError((cause: CycleReadinessError) =>
-      runnerError(
-        'bind-publication',
-        cause.failure === 'store' ? 'store' : 'contract',
-        'exact finalized Signal publication binding failed',
+      runnerError({
+        operation: 'bind-publication',
+        failure: cause.failure === 'store' ? 'store' : 'contract',
+        message: 'exact finalized Signal publication binding failed',
         cause,
-      ),
+      }),
     ),
     Effect.flatMap((readiness) =>
       readiness.outcome === 'WAITING'
         ? Effect.fail(
-            runnerError(
-              'bind-publication',
-              'contract',
-              'discovered finalized Signal publication unexpectedly remained waiting',
-            ),
+            runnerError({
+              operation: 'bind-publication',
+              failure: 'contract',
+              message: 'discovered finalized Signal publication unexpectedly remained waiting',
+            }),
           )
         : Effect.succeed(readiness),
     ),
@@ -81,7 +81,12 @@ const readCycleAuthoritySlot = <R>(
       signalSessionDate,
     }),
     Effect.mapError((cause) =>
-      runnerError('read-authority-slot', 'store', 'durable autonomous cycle authority-slot read failed', cause),
+      runnerError({
+        operation: 'read-authority-slot',
+        failure: 'store',
+        message: 'durable autonomous cycle authority-slot read failed',
+        cause,
+      }),
     ),
     Effect.map((existing) => ({ publication, existing: Option.getOrUndefined(existing) })),
   )
@@ -160,7 +165,12 @@ const acquireCycleCandidate = (
           pipe(
             store.acquire(material.draft, acquiredAt),
             Effect.mapError((cause) =>
-              runnerError('acquire-cycle', 'store', 'durable autonomous cycle acquisition failed', cause),
+              runnerError({
+                operation: 'acquire-cycle',
+                failure: 'store',
+                message: 'durable autonomous cycle acquisition failed',
+                cause,
+              }),
             ),
           ),
         ),
@@ -219,7 +229,12 @@ const readCycleCalendar = <R>(
         BrokerRead,
         Effect.flatMap((broker) => broker.marketCalendar(query)),
         Effect.mapError((cause) =>
-          runnerError('market-calendar', 'calendar-read', 'authoritative broker calendar read failed', cause),
+          runnerError({
+            operation: 'market-calendar',
+            failure: 'calendar-read',
+            message: 'authoritative broker calendar read failed',
+            cause,
+          }),
         ),
       ),
     ),
@@ -267,7 +282,12 @@ export const discoverAutonomousCyclePass = <R>(
     MarketData,
     Effect.flatMap((marketData) => marketData.inspectCyclePublications),
     Effect.mapError((cause: OperationalError) =>
-      runnerError('inspect-publication', 'market-data', 'bounded finalized Signal publication discovery failed', cause),
+      runnerError({
+        operation: 'inspect-publication',
+        failure: 'market-data',
+        message: 'bounded finalized Signal publication discovery failed',
+        cause,
+      }),
     ),
     Effect.flatMap((discovery) =>
       pipe(
@@ -290,7 +310,12 @@ export const discoverAutonomousCyclePass = <R>(
 const chooseRecovery = (state: CycleRecoveryState): Effect.Effect<CycleRecoverySelection, CycleRunnerError> =>
   Effect.fromResult(selectCycleRecovery(state)).pipe(
     Effect.mapError((cause) =>
-      runnerError('recover-cycle', 'contract', 'autonomous cycle recovery state is invalid', cause),
+      runnerError({
+        operation: 'recover-cycle',
+        failure: 'contract',
+        message: 'autonomous cycle recovery state is invalid',
+        cause,
+      }),
     ),
   )
 
@@ -307,7 +332,12 @@ const recoverCycle = <R>(
         CycleStore,
         Effect.flatMap((store) => store.block(selection.cycleId, selection.reason, selection.observedAt)),
         Effect.mapError((cause) =>
-          runnerError('recover-cycle', 'store', 'unfinished autonomous cycle blocking failed', cause),
+          runnerError({
+            operation: 'recover-cycle',
+            failure: 'store',
+            message: 'unfinished autonomous cycle blocking failed',
+            cause,
+          }),
         ),
         Effect.map(
           (blocked): CycleRunResult => ({
@@ -321,7 +351,12 @@ const recoverCycle = <R>(
     case 'READ_PUBLICATION':
       return runCyclePublicationReadiness(selection.cycle).pipe(
         Effect.mapError((cause: CycleReadinessError) =>
-          runnerError('recover-cycle', readinessFailure(cause), 'unfinished cycle publication recovery failed', cause),
+          runnerError({
+            operation: 'recover-cycle',
+            failure: readinessFailure(cause),
+            message: 'unfinished cycle publication recovery failed',
+            cause,
+          }),
         ),
         Effect.flatMap((readiness) =>
           chooseRecovery({
@@ -347,7 +382,12 @@ const recoverCycle = <R>(
         CycleStore,
         Effect.flatMap((store) => store.activate(selection.cycleId, selection.observedAt)),
         Effect.mapError((cause) =>
-          runnerError('recover-cycle', 'store', 'snapshot-bound cycle activation failed', cause),
+          runnerError({
+            operation: 'recover-cycle',
+            failure: 'store',
+            message: 'snapshot-bound cycle activation failed',
+            cause,
+          }),
         ),
         Effect.map(
           (activation): CycleRunResult => ({
@@ -367,7 +407,9 @@ const recoverCycle = <R>(
       })
     case 'BUILD_DECISION':
       return context.buildDecision(selection.cycle).pipe(
-        Effect.mapError((cause) => runnerError('build-decision', cause.failure, cause.message, cause)),
+        Effect.mapError((cause) =>
+          runnerError({ operation: 'build-decision', failure: cause.failure, message: cause.message, cause }),
+        ),
         Effect.flatMap((document) =>
           pipe(
             currentIsoTime,
@@ -378,7 +420,12 @@ const recoverCycle = <R>(
                   store.bindDecision(selection.cycle.identity.cycleId, document, bindObservedAt),
                 ),
                 Effect.mapError((cause) =>
-                  runnerError('recover-cycle', 'store', 'durable shadow decision binding failed', cause),
+                  runnerError({
+                    operation: 'recover-cycle',
+                    failure: 'store',
+                    message: 'durable shadow decision binding failed',
+                    cause,
+                  }),
                 ),
                 Effect.map(
                   (binding): CycleRunResult => ({
@@ -397,7 +444,14 @@ const recoverCycle = <R>(
       return pipe(
         CycleStore,
         Effect.flatMap((store) => store.readDecisionDocument(selection.cycle.identity.cycleId)),
-        Effect.mapError((cause) => runnerError('recover-cycle', 'store', 'durable shadow decision read failed', cause)),
+        Effect.mapError((cause) =>
+          runnerError({
+            operation: 'recover-cycle',
+            failure: 'store',
+            message: 'durable shadow decision read failed',
+            cause,
+          }),
+        ),
         Effect.flatMap((document) =>
           pipe(
             currentIsoTime,
@@ -422,7 +476,12 @@ const recoverCycle = <R>(
         CycleStore,
         Effect.flatMap((store) => store.finish(selection.cycleId, selection.state, selection.observedAt)),
         Effect.mapError((cause) =>
-          runnerError('recover-cycle', 'store', 'shadow cycle terminal transition failed', cause),
+          runnerError({
+            operation: 'recover-cycle',
+            failure: 'store',
+            message: 'shadow cycle terminal transition failed',
+            cause,
+          }),
         ),
         Effect.flatMap((finished) => Effect.fromResult(finishRecoveryResult(selection, finished.cycle))),
       )
@@ -441,7 +500,12 @@ export const runAutonomousCyclePass = <R>(
       }),
     ),
     Effect.mapError((cause) =>
-      runnerError('read-oldest-unfinished', 'store', 'oldest unfinished autonomous cycle read failed', cause),
+      runnerError({
+        operation: 'read-oldest-unfinished',
+        failure: 'store',
+        message: 'oldest unfinished autonomous cycle read failed',
+        cause,
+      }),
     ),
     Effect.flatMap((unfinished) =>
       pipe(
@@ -477,20 +541,20 @@ const continueAutonomousCyclePass = <R>(
       const progressKey = cycleProgressKey(continuation.cycle)
       if (progressKey === previousProgressKey) {
         return Effect.fail(
-          runnerError(
-            'recover-cycle',
-            'contract',
-            `autonomous cycle pass repeated ${continuation.progress} without durable progress`,
-          ),
+          runnerError({
+            operation: 'recover-cycle',
+            failure: 'contract',
+            message: `autonomous cycle pass repeated ${continuation.progress} without durable progress`,
+          }),
         )
       }
       if (completedProgress.has(continuation.progress)) {
         return Effect.fail(
-          runnerError(
-            'recover-cycle',
-            'contract',
-            `autonomous cycle pass repeated ${continuation.progress} after durable progress`,
-          ),
+          runnerError({
+            operation: 'recover-cycle',
+            failure: 'contract',
+            message: `autonomous cycle pass repeated ${continuation.progress} after durable progress`,
+          }),
         )
       }
       return continueAutonomousCyclePass(context, new Set([...completedProgress, continuation.progress]), progressKey)

--- a/services/bayn/src/cycle-runner/reconciliation-cadence.ts
+++ b/services/bayn/src/cycle-runner/reconciliation-cadence.ts
@@ -15,7 +15,13 @@ export const validateReconciliationInterval = (
 ): Result.Result<number, CycleRunnerError> =>
   Number.isSafeInteger(reconciliationIntervalMs) && reconciliationIntervalMs > 0
     ? Result.succeed(reconciliationIntervalMs)
-    : Result.fail(runnerError('configure', 'invalid-config', 'reconciliation interval must be a positive safe integer'))
+    : Result.fail(
+        runnerError({
+          operation: 'configure',
+          failure: 'invalid-config',
+          message: 'reconciliation interval must be a positive safe integer',
+        }),
+      )
 
 const validateCyclePassTimeoutDataFirst = (
   cyclePassTimeoutMs: number,
@@ -24,11 +30,11 @@ const validateCyclePassTimeoutDataFirst = (
   Number.isSafeInteger(cyclePassTimeoutMs) && cyclePassTimeoutMs > 0 && cyclePassTimeoutMs <= reconciliationIntervalMs
     ? Result.succeed(cyclePassTimeoutMs)
     : Result.fail(
-        runnerError(
-          'configure',
-          'invalid-config',
-          'cycle pass timeout must be a positive safe integer no longer than the reconciliation interval',
-        ),
+        runnerError({
+          operation: 'configure',
+          failure: 'invalid-config',
+          message: 'cycle pass timeout must be a positive safe integer no longer than the reconciliation interval',
+        }),
       )
 
 export const validateCyclePassTimeout = Pipeable.dual(2, validateCyclePassTimeoutDataFirst)

--- a/services/bayn/src/cycle-runner/recovery-decision-binding.ts
+++ b/services/bayn/src/cycle-runner/recovery-decision-binding.ts
@@ -53,11 +53,11 @@ const validateDecisionBinding = (
     document.createdAt < cycle.window.submissionOpenAt ||
     document.createdAt > cycle.updatedAt
     ? Result.fail(
-        validateDecisionFailure(
-          'decision-binding',
-          'durable shadow decision does not match the active cycle binding',
+        validateDecisionFailure({
+          reason: 'decision-binding',
+          message: 'durable shadow decision does not match the active cycle binding',
           facts,
-        ),
+        }),
       )
     : Result.succeed(undefined)
 }
@@ -70,8 +70,12 @@ const selectBoundDecisionDataFirst = (
   if (document === undefined) return Result.succeed({ action: 'READ_DECISION', cycle })
   if (document === null) {
     return Result.fail(
-      selectRecoveryFailure('decision-missing', 'decision-bound cycle is missing its durable document', {
-        cycleId: cycle.identity.cycleId,
+      selectRecoveryFailure({
+        reason: 'decision-missing',
+        message: 'decision-bound cycle is missing its durable document',
+        facts: {
+          cycleId: cycle.identity.cycleId,
+        },
       }),
     )
   }

--- a/services/bayn/src/cycle-runner/recovery-model.ts
+++ b/services/bayn/src/cycle-runner/recovery-model.ts
@@ -133,26 +133,21 @@ type CycleRecoveryReason<Operation extends CycleRecoveryIssue['operation']> = Ex
   { readonly operation: Operation }
 >['reason']
 
-export const decodeRecoveryStateFailure = (
-  reason: CycleRecoveryReason<'decode-state'>,
-  message: string,
-  facts: Readonly<Record<string, unknown>> = {},
-  cause?: unknown,
-): CycleRecoveryFailure => new CycleRecoveryFailure({ operation: 'decode-state', reason, message, facts, cause })
+interface CycleRecoveryFailureInput<Operation extends CycleRecoveryIssue['operation']> {
+  readonly reason: CycleRecoveryReason<Operation>
+  readonly message: string
+  readonly facts?: Readonly<Record<string, unknown>>
+  readonly cause?: unknown
+}
 
-export const selectRecoveryFailure = (
-  reason: CycleRecoveryReason<'select'>,
-  message: string,
-  facts: Readonly<Record<string, unknown>> = {},
-  cause?: unknown,
-): CycleRecoveryFailure => new CycleRecoveryFailure({ operation: 'select', reason, message, facts, cause })
+export const decodeRecoveryStateFailure = (input: CycleRecoveryFailureInput<'decode-state'>): CycleRecoveryFailure =>
+  new CycleRecoveryFailure({ operation: 'decode-state', ...input, facts: input.facts ?? {} })
 
-export const validateDecisionFailure = (
-  reason: CycleRecoveryReason<'validate-decision'>,
-  message: string,
-  facts: Readonly<Record<string, unknown>> = {},
-  cause?: unknown,
-): CycleRecoveryFailure => new CycleRecoveryFailure({ operation: 'validate-decision', reason, message, facts, cause })
+export const selectRecoveryFailure = (input: CycleRecoveryFailureInput<'select'>): CycleRecoveryFailure =>
+  new CycleRecoveryFailure({ operation: 'select', ...input, facts: input.facts ?? {} })
+
+export const validateDecisionFailure = (input: CycleRecoveryFailureInput<'validate-decision'>): CycleRecoveryFailure =>
+  new CycleRecoveryFailure({ operation: 'validate-decision', ...input, facts: input.facts ?? {} })
 
 const PublicationFreshnessSchema = Schema.Struct({
   dataAgeMs: NonNegativeFiniteSchema,

--- a/services/bayn/src/cycle-runner/recovery-readiness.ts
+++ b/services/bayn/src/cycle-runner/recovery-readiness.ts
@@ -154,11 +154,12 @@ const validateReadinessDataFirst = (
   readinessIsCorrelated(cycle, recoveryObservedAt, readiness)
     ? Result.succeed(undefined)
     : Result.fail(
-        selectRecoveryFailure(
-          'readiness-binding',
-          'publication readiness must be the permitted transition of the exact selected cycle draft and snapshot',
-          readinessBindingFacts(cycle, recoveryObservedAt, readiness),
-        ),
+        selectRecoveryFailure({
+          reason: 'readiness-binding',
+          message:
+            'publication readiness must be the permitted transition of the exact selected cycle draft and snapshot',
+          facts: readinessBindingFacts(cycle, recoveryObservedAt, readiness),
+        }),
       )
 
 export const validateReadiness = Pipeable.dual(3, validateReadinessDataFirst)

--- a/services/bayn/src/cycle-runner/recovery-selection.ts
+++ b/services/bayn/src/cycle-runner/recovery-selection.ts
@@ -19,34 +19,46 @@ const validateRecoveryCycleContext = (
 ): Result.Result<void, CycleRecoveryFailure> => {
   if (cycle.identity.qualificationRunId !== state.qualificationRunId || cycle.identity.accountId !== state.accountId) {
     return Result.fail(
-      selectRecoveryFailure('scope', 'unfinished cycle does not match the configured recovery scope', {
-        cycleId: cycle.identity.cycleId,
-        expectedQualificationRunId: state.qualificationRunId,
-        actualQualificationRunId: cycle.identity.qualificationRunId,
-        expectedAccountId: state.accountId,
-        actualAccountId: cycle.identity.accountId,
-        cycleState: cycle.state,
-        cycleStateVersion: cycle.stateVersion,
-        submissionCutoffAt: cycle.window.submissionCutoffAt,
+      selectRecoveryFailure({
+        reason: 'scope',
+        message: 'unfinished cycle does not match the configured recovery scope',
+        facts: {
+          cycleId: cycle.identity.cycleId,
+          expectedQualificationRunId: state.qualificationRunId,
+          actualQualificationRunId: cycle.identity.qualificationRunId,
+          expectedAccountId: state.accountId,
+          actualAccountId: cycle.identity.accountId,
+          cycleState: cycle.state,
+          cycleStateVersion: cycle.stateVersion,
+          submissionCutoffAt: cycle.window.submissionCutoffAt,
+        },
       }),
     )
   }
   if (isTerminalCycleState(cycle.state)) {
     return Result.fail(
-      selectRecoveryFailure('terminal-cycle', 'terminal cycles must not enter autonomous recovery', {
-        cycleId: cycle.identity.cycleId,
-        state: cycle.state,
+      selectRecoveryFailure({
+        reason: 'terminal-cycle',
+        message: 'terminal cycles must not enter autonomous recovery',
+        facts: {
+          cycleId: cycle.identity.cycleId,
+          state: cycle.state,
+        },
       }),
     )
   }
   if (state.observedAt < cycle.updatedAt) {
     return Result.fail(
-      selectRecoveryFailure('chronology', 'recovery observation cannot precede the selected cycle update', {
-        actualObservedAt: state.observedAt,
-        expectedMinimumObservedAt: cycle.updatedAt,
-        cycleId: cycle.identity.cycleId,
-        cycleState: cycle.state,
-        cycleStateVersion: cycle.stateVersion,
+      selectRecoveryFailure({
+        reason: 'chronology',
+        message: 'recovery observation cannot precede the selected cycle update',
+        facts: {
+          actualObservedAt: state.observedAt,
+          expectedMinimumObservedAt: cycle.updatedAt,
+          cycleId: cycle.identity.cycleId,
+          cycleState: cycle.state,
+          cycleStateVersion: cycle.stateVersion,
+        },
       }),
     )
   }
@@ -59,8 +71,12 @@ const selectDecisionBoundRecovery = (
 ): Result.Result<CycleRecoverySelection, CycleRecoveryFailure> => {
   if (state.readiness !== undefined) {
     return Result.fail(
-      selectRecoveryFailure('state-evidence', 'active cycle recovery does not accept publication readiness', {
-        cycleId: cycle.identity.cycleId,
+      selectRecoveryFailure({
+        reason: 'state-evidence',
+        message: 'active cycle recovery does not accept publication readiness',
+        facts: {
+          cycleId: cycle.identity.cycleId,
+        },
       }),
     )
   }
@@ -130,15 +146,23 @@ const selectActiveRecovery = (
 ): Result.Result<CycleRecoverySelection, CycleRecoveryFailure> => {
   if (state.readiness !== undefined) {
     return Result.fail(
-      selectRecoveryFailure('state-evidence', 'active cycle recovery does not accept publication readiness', {
-        cycleId: cycle.identity.cycleId,
+      selectRecoveryFailure({
+        reason: 'state-evidence',
+        message: 'active cycle recovery does not accept publication readiness',
+        facts: {
+          cycleId: cycle.identity.cycleId,
+        },
       }),
     )
   }
   if (state.decisionDocument !== undefined) {
     return Result.fail(
-      selectRecoveryFailure('state-evidence', 'unbound active cycle cannot have durable decision evidence', {
-        cycleId: cycle.identity.cycleId,
+      selectRecoveryFailure({
+        reason: 'state-evidence',
+        message: 'unbound active cycle cannot have durable decision evidence',
+        facts: {
+          cycleId: cycle.identity.cycleId,
+        },
       }),
     )
   }
@@ -175,8 +199,12 @@ const selectPendingRecovery = (
 ): Result.Result<CycleRecoverySelection, CycleRecoveryFailure> => {
   if (state.decisionDocument !== undefined) {
     return Result.fail(
-      selectRecoveryFailure('state-evidence', 'pending cycle recovery does not accept decision evidence', {
-        cycleId: cycle.identity.cycleId,
+      selectRecoveryFailure({
+        reason: 'state-evidence',
+        message: 'pending cycle recovery does not accept decision evidence',
+        facts: {
+          cycleId: cycle.identity.cycleId,
+        },
       }),
     )
   }
@@ -192,7 +220,10 @@ const selectDecodedCycleRecovery = (
   if (cycle === undefined) {
     if (state.readiness !== undefined || state.decisionDocument !== undefined) {
       return Result.fail(
-        selectRecoveryFailure('evidence-without-cycle', 'recovery evidence requires an unfinished cycle'),
+        selectRecoveryFailure({
+          reason: 'evidence-without-cycle',
+          message: 'recovery evidence requires an unfinished cycle',
+        }),
       )
     }
     return Result.succeed({ action: 'DISCOVER' })
@@ -211,9 +242,13 @@ const selectDecodedCycleRecovery = (
       return selectPendingRecovery(state, cycle)
     default:
       return Result.fail(
-        selectRecoveryFailure('state-evidence', `unsupported unfinished cycle state ${cycle.state}`, {
-          cycleId: cycle.identity.cycleId,
-          state: cycle.state,
+        selectRecoveryFailure({
+          reason: 'state-evidence',
+          message: `unsupported unfinished cycle state ${cycle.state}`,
+          facts: {
+            cycleId: cycle.identity.cycleId,
+            state: cycle.state,
+          },
         }),
       )
   }
@@ -222,7 +257,12 @@ const selectDecodedCycleRecovery = (
 export const selectCycleRecovery = (state: unknown): Result.Result<CycleRecoverySelection, CycleRecoveryFailure> =>
   Result.flatMap(
     Result.mapError(decodeCycleRecoveryStateResult(state), (cause) =>
-      decodeRecoveryStateFailure('decode', 'autonomous cycle recovery state is invalid', {}, cause),
+      decodeRecoveryStateFailure({
+        reason: 'decode',
+        message: 'autonomous cycle recovery state is invalid',
+        facts: {},
+        cause,
+      }),
     ),
     selectDecodedCycleRecovery,
   )

--- a/services/bayn/src/db/paper-store.integration.test.ts
+++ b/services/bayn/src/db/paper-store.integration.test.ts
@@ -318,7 +318,9 @@ const journal = (control: JournalControl): JournalService => ({
     Effect.suspend(() => {
       control.planHashes.push(successOfResult(hashLedgerPlanResult(plan)))
       return control.fail
-        ? Effect.fail(operationalError('journal', 'post', 'injected TigerBeetle failure'))
+        ? Effect.fail(
+            operationalError({ component: 'journal', operation: 'post', message: 'injected TigerBeetle failure' }),
+          )
         : Effect.void
     }),
   verifyAccount: () => Effect.succeed(true),

--- a/services/bayn/src/errors.ts
+++ b/services/bayn/src/errors.ts
@@ -12,33 +12,26 @@ export class OperationalError extends Data.TaggedError('OperationalError')<{
 
 const causeMessage = (cause: unknown): string => (cause instanceof Error ? cause.message : String(cause))
 
-export const operationalError = (
-  component: Component,
-  operation: string,
-  message: string,
-  cause?: unknown,
-): OperationalError =>
+export interface OperationalErrorInput {
+  readonly component: Component
+  readonly operation: string
+  readonly message: string
+  readonly cause?: unknown
+}
+
+const makeOperationalError = (input: OperationalErrorInput, retryable: boolean): OperationalError =>
   new OperationalError({
-    component,
-    operation,
-    message: cause === undefined ? message : `${message}: ${causeMessage(cause)}`,
-    retryable: false,
-    cause,
+    component: input.component,
+    operation: input.operation,
+    message: input.cause === undefined ? input.message : `${input.message}: ${causeMessage(input.cause)}`,
+    retryable,
+    cause: input.cause,
   })
 
-export const retryableOperationalError = (
-  component: Component,
-  operation: string,
-  message: string,
-  cause?: unknown,
-): OperationalError =>
-  new OperationalError({
-    component,
-    operation,
-    message: cause === undefined ? message : `${message}: ${causeMessage(cause)}`,
-    retryable: true,
-    cause,
-  })
+export const operationalError = (input: OperationalErrorInput): OperationalError => makeOperationalError(input, false)
+
+export const retryableOperationalError = (input: OperationalErrorInput): OperationalError =>
+  makeOperationalError(input, true)
 
 export const formatError = (error: OperationalError): string =>
   `${error.component}.${error.operation}: ${error.message}`

--- a/services/bayn/src/health/program.ts
+++ b/services/bayn/src/health/program.ts
@@ -249,7 +249,13 @@ const collectHealthProbeResults = (
           !qualificationEvidenceRequired
             ? Effect.void
             : evidence === null
-              ? Effect.fail(operationalError('database', 'verify-evidence', 'startup evidence is unavailable'))
+              ? Effect.fail(
+                  operationalError({
+                    component: 'database',
+                    operation: 'verify-evidence',
+                    message: 'startup evidence is unavailable',
+                  }),
+                )
               : withinDeadline(
                   Effect.all([
                     databaseOperation(
@@ -272,7 +278,13 @@ const collectHealthProbeResults = (
         ),
         observe(
           cycleBindingId === undefined
-            ? Effect.fail(operationalError('database', 'cycle-observability', 'startup evidence is unavailable'))
+            ? Effect.fail(
+                operationalError({
+                  component: 'database',
+                  operation: 'cycle-observability',
+                  message: 'startup evidence is unavailable',
+                }),
+              )
             : withinDeadline(
                 databaseOperation(
                   cycleObservability.read(cycleBindingId, broker?.expectedAccountId),

--- a/services/bayn/src/market-data/errors.ts
+++ b/services/bayn/src/market-data/errors.ts
@@ -12,7 +12,7 @@ const marketDataOperationErrorDataFirst = (
   if (cause instanceof OperationalError) return cause
   if (isSqlError(cause)) {
     const makeError = cause.isRetryable ? retryableOperationalError : operationalError
-    return makeError('market-data', operation, message, cause)
+    return makeError({ component: 'market-data', operation, message, cause })
   }
   if (isMarketDataVerificationError(cause)) {
     return new OperationalError({
@@ -23,7 +23,7 @@ const marketDataOperationErrorDataFirst = (
       cause,
     })
   }
-  return retryableOperationalError('market-data', operation, message, cause)
+  return retryableOperationalError({ component: 'market-data', operation, message, cause })
 }
 
 export const marketDataOperationError = Pipeable.dual(3, marketDataOperationErrorDataFirst)

--- a/services/bayn/src/observe-composition.test.ts
+++ b/services/bayn/src/observe-composition.test.ts
@@ -3042,7 +3042,11 @@ describe('OBSERVE runtime composition', () => {
 
   test('closes read and reconciliation failures with their operational classifications and exact causes', async () => {
     const policy = await Effect.runPromise(loadObserveRiskPolicy(accountId, fixtureProtocol.universe))
-    const snapshotCause = operationalError('market-data', 'load', 'snapshot fixture failed')
+    const snapshotCause = operationalError({
+      component: 'market-data',
+      operation: 'load',
+      message: 'snapshot fixture failed',
+    })
     const calendarRootCause = { _tag: 'CalendarTransportFixtureFailure' }
     const calendarCause = new BrokerReadError({
       operation: 'market-calendar',

--- a/services/bayn/src/observe-composition.ts
+++ b/services/bayn/src/observe-composition.ts
@@ -315,13 +315,33 @@ const compositionFailure = (
 const reconciliationOperationalError = (cause: ReconciliationPassError): OperationalError => {
   switch (cause._tag) {
     case 'BrokerReadError':
-      return operationalError('market-data', 'reconciliation', 'same-pass broker reconciliation read failed', cause)
+      return operationalError({
+        component: 'market-data',
+        operation: 'reconciliation',
+        message: 'same-pass broker reconciliation read failed',
+        cause,
+      })
     case 'ExecutionStoreError':
-      return operationalError('database', 'reconciliation', 'same-pass reconciliation store operation failed', cause)
+      return operationalError({
+        component: 'database',
+        operation: 'reconciliation',
+        message: 'same-pass reconciliation store operation failed',
+        cause,
+      })
     case 'ReconciliationError':
-      return operationalError('strategy', 'reconciliation', 'same-pass reconciliation failed', cause)
+      return operationalError({
+        component: 'strategy',
+        operation: 'reconciliation',
+        message: 'same-pass reconciliation failed',
+        cause,
+      })
     case 'WriterFenceError':
-      return operationalError('database', 'reconciliation', 'same-pass reconciliation fence operation failed', cause)
+      return operationalError({
+        component: 'database',
+        operation: 'reconciliation',
+        message: 'same-pass reconciliation fence operation failed',
+        cause,
+      })
     case 'ReconciliationPassTimeoutError':
       return new OperationalError({
         component: 'market-data',
@@ -435,21 +455,24 @@ const readObserveDecisionFacts = <R>(
           })
           .pipe(
             Effect.mapError((cause) =>
-              operationalError(
-                'market-data',
-                'load-snapshot-publication',
-                'bound cycle snapshot publication read failed',
+              operationalError({
+                component: 'market-data',
+                operation: 'load-snapshot-publication',
+                message: 'bound cycle snapshot publication read failed',
                 cause,
-              ),
+              }),
             ),
           ),
-        brokerRead
-          .marketCalendar(preparation.marketCalendarQuery)
-          .pipe(
-            Effect.mapError((cause) =>
-              operationalError('market-data', 'market-calendar', 'execution-session calendar read failed', cause),
-            ),
+        brokerRead.marketCalendar(preparation.marketCalendarQuery).pipe(
+          Effect.mapError((cause) =>
+            operationalError({
+              component: 'market-data',
+              operation: 'market-calendar',
+              message: 'execution-session calendar read failed',
+              cause,
+            }),
           ),
+        ),
         input.reconcile.pipe(Effect.mapError(reconciliationOperationalError)),
       ],
       { concurrency: 3 },
@@ -568,12 +591,12 @@ const compileObserveStrategyDecision = <R>(
     })(),
   ).pipe(
     Effect.mapError((cause) =>
-      operationalError(
-        'strategy',
-        'current-decision',
-        'current strategy decision compilation failed',
-        unwrapStrategyApplicationFailure(cause),
-      ),
+      operationalError({
+        component: 'strategy',
+        operation: 'current-decision',
+        message: 'current strategy decision compilation failed',
+        cause: unwrapStrategyApplicationFailure(cause),
+      }),
     ),
   )
 
@@ -1113,12 +1136,21 @@ export const prepareObserveStartup = (
   const executionModel = strategyApplication(input.strategy).definition.parameters.executionModel
   if (executionModel.schemaVersion !== 'bayn.execution-model.v2') {
     return Result.fail(
-      operationalError('strategy', 'cycle-loop', 'autonomous cycles require the causal v2 execution model'),
+      operationalError({
+        component: 'strategy',
+        operation: 'cycle-loop',
+        message: 'autonomous cycles require the causal v2 execution model',
+      }),
     )
   }
   return Result.map(
     Result.mapError(makeCycleExecutionPolicyFromModel(executionModel), (cause) =>
-      operationalError('strategy', 'cycle-policy', 'autonomous cycle execution policy construction failed', cause),
+      operationalError({
+        component: 'strategy',
+        operation: 'cycle-policy',
+        message: 'autonomous cycle execution policy construction failed',
+        cause,
+      }),
     ),
     (executionPolicy) => ({
       executionModel,
@@ -1136,7 +1168,11 @@ const validateObserveAuthorityInitialization = (
   authority.maximum !== Authority.Observe ||
   authority.effective !== Authority.Observe
     ? Result.fail(
-        operationalError('database', 'authority', 'OBSERVE authority initialization returned incompatible state'),
+        operationalError({
+          component: 'database',
+          operation: 'authority',
+          message: 'OBSERVE authority initialization returned incompatible state',
+        }),
       )
     : Result.succeed(authority)
 
@@ -1151,7 +1187,12 @@ const initializeObserveAuthority = (
       }),
     ),
     Effect.mapError((cause) =>
-      operationalError('database', 'authority', 'OBSERVE authority initialization failed', cause),
+      operationalError({
+        component: 'database',
+        operation: 'authority',
+        message: 'OBSERVE authority initialization failed',
+        cause,
+      }),
     ),
     Effect.flatMap((authority) => Effect.fromResult(validateObserveAuthorityInitialization(authority, input))),
   )
@@ -1206,11 +1247,11 @@ const validateMutationExecutionProgram = (
     authority.strategy.parameterHash !== strategy.parameterHash ||
     authority.strategy.parameterSchemaVersion !== strategy.parameterSchemaVersion
     ? Result.fail(
-        operationalError(
-          'config',
-          'cycle-loop',
-          'mutation cycle execution program does not match its account, authority generation, and strategy',
-        ),
+        operationalError({
+          component: 'config',
+          operation: 'cycle-loop',
+          message: 'mutation cycle execution program does not match its account, authority generation, and strategy',
+        }),
       )
     : Result.succeed(undefined)
 }
@@ -2011,7 +2052,13 @@ const makeRecoveryFirstAutonomousLoop = (
       Result.flatMap(() => validateCyclePassTimeout(cyclePassTimeoutMs, input.reconciliationIntervalMs)),
       Result.map(() => recoveryFirstCycleLoop(input, startup, preparation, policy, capability, buildDecision)),
     ),
-    (cause) => operationalError('strategy', 'cycle-loop', `${operation} failed to start`, cause),
+    (cause) =>
+      operationalError({
+        component: 'strategy',
+        operation: 'cycle-loop',
+        message: `${operation} failed to start`,
+        cause,
+      }),
   )
 }
 
@@ -2052,7 +2099,12 @@ export const makeObserveAutonomousCycleStartup =
         strategyApplication(input.strategy).definition.parameters.universe,
       ).pipe(
         Effect.mapError((cause) =>
-          operationalError('strategy', 'risk-policy', 'source-controlled paper risk policy is invalid', cause),
+          operationalError({
+            component: 'strategy',
+            operation: 'risk-policy',
+            message: 'source-controlled paper risk policy is invalid',
+            cause,
+          }),
         ),
       )
       yield* initializeObserveAuthority(input)
@@ -2080,7 +2132,12 @@ export const makeMutationAutonomousCycleStartup =
         strategyApplication(input.strategy).definition.parameters.universe,
       ).pipe(
         Effect.mapError((cause) =>
-          operationalError('strategy', 'risk-policy', 'source-controlled paper risk policy is invalid', cause),
+          operationalError({
+            component: 'strategy',
+            operation: 'risk-policy',
+            message: 'source-controlled paper risk policy is invalid',
+            cause,
+          }),
         ),
       )
       return yield* Effect.fromResult(

--- a/services/bayn/src/operations.ts
+++ b/services/bayn/src/operations.ts
@@ -45,7 +45,13 @@ const withinDeadlineDataFirst = <A, R>(
     Effect.timeoutOrElse({
       duration: timeoutMs,
       orElse: () =>
-        Effect.fail(retryableOperationalError(component, operation, `${operation} timed out after ${timeoutMs}ms`)),
+        Effect.fail(
+          retryableOperationalError({
+            component,
+            operation,
+            message: `${operation} timed out after ${timeoutMs}ms`,
+          }),
+        ),
     }),
   )
 
@@ -69,7 +75,7 @@ const databaseOperationDataFirst = <A, R>(
           ? cause.failure === 'unavailable' && (!isSqlError(cause.cause) || cause.cause.isRetryable)
           : cause.failure === 'query' && isSqlError(cause.cause) && cause.cause.isRetryable
       const makeError = retryable ? retryableOperationalError : operationalError
-      return makeError('database', operation, `PostgreSQL ${operation} failed`, cause)
+      return makeError({ component: 'database', operation, message: `PostgreSQL ${operation} failed`, cause })
     }),
   )
 

--- a/services/bayn/src/protocol.ts
+++ b/services/bayn/src/protocol.ts
@@ -214,7 +214,9 @@ const protocolOperationalBoundary = <A>(
   decoded: Result.Result<A, ProtocolDecodeError>,
 ): Effect.Effect<A, OperationalError> =>
   Effect.fromResult(decoded).pipe(
-    Effect.mapError((error) => operationalError('strategy', 'parameters', error.message, error)),
+    Effect.mapError((error) =>
+      operationalError({ component: 'strategy', operation: 'parameters', message: error.message, cause: error }),
+    ),
   )
 
 export const loadProtocol = (input: unknown): Effect.Effect<Protocol, OperationalError> =>

--- a/services/bayn/src/resources.test.ts
+++ b/services/bayn/src/resources.test.ts
@@ -595,7 +595,12 @@ describe('Bayn resource lifecycle', () => {
   test('fails closed when ClickHouse returns a malformed row', async () => {
     const marketData = marketDataService(
       Effect.fail(
-        operationalError('market-data', 'verify', 'Signal snapshot verification failed', new Error('malformed row')),
+        operationalError({
+          component: 'market-data',
+          operation: 'verify',
+          message: 'Signal snapshot verification failed',
+          cause: new Error('malformed row'),
+        }),
       ),
     )
     const state = await Effect.runPromise(Ref.make(initialState()))

--- a/services/bayn/src/startup.test.ts
+++ b/services/bayn/src/startup.test.ts
@@ -1349,7 +1349,13 @@ describe('Bayn startup lifecycle', () => {
         Effect.timeoutOrElse({
           duration: 250,
           orElse: () =>
-            Effect.fail(operationalError('http', 'test', 'run remained alive after its startup worker died')),
+            Effect.fail(
+              operationalError({
+                component: 'http',
+                operation: 'test',
+                message: 'run remained alive after its startup worker died',
+              }),
+            ),
         }),
       ),
     )
@@ -1377,7 +1383,13 @@ describe('Bayn startup lifecycle', () => {
         Effect.timeoutOrElse({
           duration: 250,
           orElse: () =>
-            Effect.fail(operationalError('http', 'test', 'run remained live after a retryable startup failure')),
+            Effect.fail(
+              operationalError({
+                component: 'http',
+                operation: 'test',
+                message: 'run remained live after a retryable startup failure',
+              }),
+            ),
         }),
       ),
     )

--- a/services/bayn/src/target-planner/facts.ts
+++ b/services/bayn/src/target-planner/facts.ts
@@ -84,12 +84,12 @@ const plannerInputHash = (
   pipe(
     canonicalHashV1Result(value),
     Result.mapError((cause) =>
-      canonicalizePlannerInputFailure(
-        'hash',
-        `validated target-planner ${operation} evidence is not canonicalizable`,
-        { cycleId: input.cycleId },
+      canonicalizePlannerInputFailure({
+        reason: 'hash',
+        message: `validated target-planner ${operation} evidence is not canonicalizable`,
+        facts: { cycleId: input.cycleId },
         cause,
-      ),
+      }),
     ),
   )
 
@@ -102,12 +102,12 @@ export const deriveTargetPlannerHashes = (
     reconciledBrokerStateHash: pipe(
       reconciledStateHash(input.brokerState),
       Result.mapError((cause) =>
-        canonicalizePlannerInputFailure(
-          'hash',
-          'validated target-planner reconciled broker state is not canonicalizable',
-          { cycleId: input.cycleId },
+        canonicalizePlannerInputFailure({
+          reason: 'hash',
+          message: 'validated target-planner reconciled broker state is not canonicalizable',
+          facts: { cycleId: input.cycleId },
           cause,
-        ),
+        }),
       ),
     ),
   })
@@ -247,9 +247,13 @@ export const derivePlannedTargetFacts = (
           const targetWeight = facts.input.targetWeights[symbol]
           if (targetWeight === undefined) {
             return Result.fail(
-              deriveTargetsFailure('precision', 'reference-price symbol has no corresponding target weight', {
-                cycleId: facts.input.cycleId,
-                symbol,
+              deriveTargetsFailure({
+                reason: 'precision',
+                message: 'reference-price symbol has no corresponding target weight',
+                facts: {
+                  cycleId: facts.input.cycleId,
+                  symbol,
+                },
               }),
             )
           }
@@ -259,16 +263,16 @@ export const derivePlannedTargetFacts = (
                 precision: facts.input.precision,
               }),
               (cause) =>
-                deriveTargetsFailure(
-                  'precision',
-                  'target quantity could not be represented at the declared precision',
-                  {
+                deriveTargetsFailure({
+                  reason: 'precision',
+                  message: 'target quantity could not be represented at the declared precision',
+                  facts: {
                     cycleId: facts.input.cycleId,
                     symbol,
                     targetWeight,
                   },
                   cause,
-                ),
+                }),
             ),
             (targetQuantity) => [
               ...targetFacts,

--- a/services/bayn/src/target-planner/index.ts
+++ b/services/bayn/src/target-planner/index.ts
@@ -19,7 +19,12 @@ const decodeTargetPlannerInputResult = Schema.decodeUnknownResult(TargetPlannerI
 
 export const planTargets = (input: unknown): Result.Result<TargetPlanResult, TargetPlannerFailure> => {
   const decoded = Result.mapError(decodeTargetPlannerInputResult(input), (cause) =>
-    decodePlannerInputFailure('contract', 'target-planner input failed its durable contract', {}, cause),
+    decodePlannerInputFailure({
+      reason: 'contract',
+      message: 'target-planner input failed its durable contract',
+      facts: {},
+      cause,
+    }),
   )
   return Result.flatMap(decoded, (value) =>
     Result.flatMap(deriveTargetPlannerHashes(value), (hashes) =>

--- a/services/bayn/src/target-planner/model.ts
+++ b/services/bayn/src/target-planner/model.ts
@@ -186,48 +186,34 @@ type TargetPlannerReasonFor<Operation extends TargetPlannerIssue['operation']> =
   { readonly operation: Operation }
 >['reason']
 
+interface TargetPlannerFailureInput<Operation extends TargetPlannerIssue['operation']> {
+  readonly reason: TargetPlannerReasonFor<Operation>
+  readonly message: string
+  readonly facts?: Readonly<Record<string, unknown>>
+  readonly cause?: unknown
+}
+
 const failure = <Operation extends TargetPlannerIssue['operation']>(
   operation: Operation,
-  reason: TargetPlannerReasonFor<Operation>,
-  message: string,
-  facts: Readonly<Record<string, unknown>> = {},
-  cause?: unknown,
-): TargetPlannerFailure => new TargetPlannerFailureClass({ operation, reason, message, facts, cause } as never)
+  input: TargetPlannerFailureInput<Operation>,
+): TargetPlannerFailure => new TargetPlannerFailureClass({ operation, ...input, facts: input.facts ?? {} } as never)
 
 export const canonicalizePlannerInputFailure = (
-  reason: TargetPlannerReasonFor<'canonicalize-input'>,
-  message: string,
-  facts: Readonly<Record<string, unknown>> = {},
-  cause?: unknown,
-): TargetPlannerFailure => failure('canonicalize-input', reason, message, facts, cause)
+  input: TargetPlannerFailureInput<'canonicalize-input'>,
+): TargetPlannerFailure => failure('canonicalize-input', input)
 
 export const canonicalizePlannerOutputFailure = (
-  reason: TargetPlannerReasonFor<'canonicalize-output'>,
-  message: string,
-  facts: Readonly<Record<string, unknown>> = {},
-  cause?: unknown,
-): TargetPlannerFailure => failure('canonicalize-output', reason, message, facts, cause)
+  input: TargetPlannerFailureInput<'canonicalize-output'>,
+): TargetPlannerFailure => failure('canonicalize-output', input)
 
-export const decodePlannerInputFailure = (
-  reason: TargetPlannerReasonFor<'decode-input'>,
-  message: string,
-  facts: Readonly<Record<string, unknown>> = {},
-  cause?: unknown,
-): TargetPlannerFailure => failure('decode-input', reason, message, facts, cause)
+export const decodePlannerInputFailure = (input: TargetPlannerFailureInput<'decode-input'>): TargetPlannerFailure =>
+  failure('decode-input', input)
 
-export const decodePlannerOutputFailure = (
-  reason: TargetPlannerReasonFor<'decode-output'>,
-  message: string,
-  facts: Readonly<Record<string, unknown>> = {},
-  cause?: unknown,
-): TargetPlannerFailure => failure('decode-output', reason, message, facts, cause)
+export const decodePlannerOutputFailure = (input: TargetPlannerFailureInput<'decode-output'>): TargetPlannerFailure =>
+  failure('decode-output', input)
 
-export const deriveTargetsFailure = (
-  reason: TargetPlannerReasonFor<'derive-targets'>,
-  message: string,
-  facts: Readonly<Record<string, unknown>> = {},
-  cause?: unknown,
-): TargetPlannerFailure => failure('derive-targets', reason, message, facts, cause)
+export const deriveTargetsFailure = (input: TargetPlannerFailureInput<'derive-targets'>): TargetPlannerFailure =>
+  failure('derive-targets', input)
 
 export const PlannedTargetQuantitySchema = Schema.Struct({
   symbol: SymbolSchema,

--- a/services/bayn/src/target-planner/planning.ts
+++ b/services/bayn/src/target-planner/planning.ts
@@ -148,12 +148,12 @@ export const finalizeTargetPlan = (material: OutputMaterial): Result.Result<Targ
     pipe(
       canonicalHashV1Result(material),
       Result.mapError((cause) =>
-        canonicalizePlannerOutputFailure(
-          'hash',
-          'target-plan output material is not canonicalizable',
-          { inputHash: material.inputHash, status: material.status },
+        canonicalizePlannerOutputFailure({
+          reason: 'hash',
+          message: 'target-plan output material is not canonicalizable',
+          facts: { inputHash: material.inputHash, status: material.status },
           cause,
-        ),
+        }),
       ),
     ),
     (outputHash) => decodeTargetPlanResult({ ...material, outputHash }),

--- a/services/bayn/src/target-planner/result.ts
+++ b/services/bayn/src/target-planner/result.ts
@@ -297,7 +297,12 @@ const decodeTargetPlanSemanticResult = Schema.decodeUnknownResult(TargetPlanResu
 export const decodeTargetPlanResult = (input: unknown): Result.Result<TargetPlanResult, TargetPlannerFailure> =>
   Result.flatMap(
     Result.mapError(decodeTargetPlanSemanticResult(input), (cause) =>
-      decodePlannerOutputFailure('contract', 'target-plan output failed its durable contract', {}, cause),
+      decodePlannerOutputFailure({
+        reason: 'contract',
+        message: 'target-plan output failed its durable contract',
+        facts: {},
+        cause,
+      }),
     ),
     (decoded) => {
       const { outputHash, ...material } = decoded
@@ -305,24 +310,28 @@ export const decodeTargetPlanResult = (input: unknown): Result.Result<TargetPlan
         pipe(
           canonicalHashV1Result(material),
           Result.mapError((cause) =>
-            canonicalizePlannerOutputFailure(
-              'hash',
-              'target-plan output material is not canonicalizable',
-              { inputHash: decoded.inputHash, path: ['outputHash'], status: decoded.status },
+            canonicalizePlannerOutputFailure({
+              reason: 'hash',
+              message: 'target-plan output material is not canonicalizable',
+              facts: { inputHash: decoded.inputHash, path: ['outputHash'], status: decoded.status },
               cause,
-            ),
+            }),
           ),
         ),
         (expectedHash) =>
           expectedHash === outputHash
             ? Result.succeed(decoded)
             : Result.fail(
-                decodePlannerOutputFailure('hash', 'target-plan output hash does not match its canonical material', {
-                  expectedHash,
-                  inputHash: decoded.inputHash,
-                  observedHash: outputHash,
-                  path: ['outputHash'],
-                  status: decoded.status,
+                decodePlannerOutputFailure({
+                  reason: 'hash',
+                  message: 'target-plan output hash does not match its canonical material',
+                  facts: {
+                    expectedHash,
+                    inputHash: decoded.inputHash,
+                    observedHash: outputHash,
+                    path: ['outputHash'],
+                    status: decoded.status,
+                  },
                 }),
               ),
       )

--- a/services/bayn/src/tigerbeetle-client.ts
+++ b/services/bayn/src/tigerbeetle-client.ts
@@ -335,7 +335,13 @@ type TigerBeetleClientRef = ScopedRef.ScopedRef<Option.Option<TigerBeetleClient>
 const closeTigerBeetleClient = (client: TigerBeetleClient): Effect.Effect<void> =>
   Effect.try({
     try: () => client.destroy(),
-    catch: (cause) => operationalError('journal', 'close', 'failed to close TigerBeetle client', cause),
+    catch: (cause) =>
+      operationalError({
+        component: 'journal',
+        operation: 'close',
+        message: 'failed to close TigerBeetle client',
+        cause,
+      }),
   }).pipe(
     Effect.catch((error) =>
       Effect.logWarning('TigerBeetle client close failed').pipe(

--- a/services/bayn/src/verify-build-contract.ts
+++ b/services/bayn/src/verify-build-contract.ts
@@ -13,7 +13,12 @@ const program = Effect.gen(function* () {
     strictParseOptions,
   )(embeddedBuildMetadata).pipe(
     Effect.mapError((cause) =>
-      operationalError('config', 'provenance', 'production image is missing complete build metadata', cause),
+      operationalError({
+        component: 'config',
+        operation: 'provenance',
+        message: 'production image is missing complete build metadata',
+        cause,
+      }),
     ),
   )
   const protocol = yield* loadDefaultProtocol


### PR DESCRIPTION
## Summary

- Replaces positional operational and cycle failure construction with structured typed inputs.
- Keeps this native stack layer independently reviewable at 977 changed lines.
- Bases directly on codex/bayn-effect-tsgo-optional-apis so GitHub shows only this layer.

## Related Issues

None

## Testing

- bunx tsc --noEmit --project services/bayn/tsconfig.json
- bun run lint
- bun run lint:oxlint
- bun run lint:oxlint:type
- bun run build
- Focused tests for the touched subsystem were run while constructing the layer.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable and Breaking Changes is filled in.
- [x] Documentation and follow-ups are unchanged or represented by later stack layers.