### PR TITLE
refactor(bayn): structure ledger failures

### DIFF
--- a/services/bayn/src/forward-performance/tigerbeetle.ts
+++ b/services/bayn/src/forward-performance/tigerbeetle.ts
@@ -69,7 +69,7 @@ const SHA256_PATTERN = /^[0-9a-f]{64}$/
 const INTEGER_PATTERN = /^(?:0|-[1-9][0-9]*|[1-9][0-9]*)$/
 
 const cashYieldFailure = (detail: string, material: Readonly<Record<string, unknown>>): LedgerValidationError =>
-  ledgerValidationError('verify-account', 'invalid-transaction', detail, material)
+  ledgerValidationError({ operation: 'verify-account', reason: 'invalid-transaction', message: detail, material })
 
 const parseSignedI128 = (value: string, field: string): Result.Result<bigint, LedgerValidationError> => {
   if (!INTEGER_PATTERN.test(value)) {
@@ -204,16 +204,16 @@ const readForwardPerformanceLedgerDataFirst = (
 
     if (accounts.length >= LEDGER_BATCH_MAX || transfers.length >= LEDGER_BATCH_MAX) {
       return yield* ledgerError(
-        ledgerValidationError(
-          'verify-account',
-          'batch-limit',
-          'paper account reached the exact TigerBeetle reconciliation limit',
-          {
+        ledgerValidationError({
+          operation: 'verify-account',
+          reason: 'batch-limit',
+          message: 'paper account reached the exact TigerBeetle reconciliation limit',
+          material: {
             accountCount: accounts.length,
             transferCount: transfers.length,
             limit: LEDGER_BATCH_MAX,
           },
-        ),
+        }),
       )
     }
 

--- a/services/bayn/src/ledger-plan.test.ts
+++ b/services/bayn/src/ledger-plan.test.ts
@@ -636,6 +636,7 @@ describe('ledger plan Result algebra', () => {
       reason: 'record-mismatch',
       material: { id: plan.transfers[0].id },
     })
+    expect('detail' in mismatch).toBeFalse()
   })
 
   test('reconciles exact sets and posted balances without throwing assertions', () => {

--- a/services/bayn/src/ledger-plan/model.ts
+++ b/services/bayn/src/ledger-plan/model.ts
@@ -154,22 +154,28 @@ export class LedgerValidationError extends Data.TaggedError('LedgerValidationErr
   readonly cause?: unknown
 }> {}
 
-export const ledgerValidationError = (
-  operation: LedgerValidationOperation,
-  reason: LedgerValidationReason,
-  message: string,
-  material: Readonly<Record<string, unknown>>,
-  cause?: unknown,
-): LedgerValidationError => new LedgerValidationError({ operation, reason, message, material, cause })
+export interface LedgerValidationErrorInput {
+  readonly operation: LedgerValidationOperation
+  readonly reason: LedgerValidationReason
+  readonly message: string
+  readonly material: Readonly<Record<string, unknown>>
+  readonly cause?: unknown
+}
 
-export const failLedgerValidation = (
-  operation: LedgerValidationOperation,
-  reason: LedgerValidationReason,
-  detail: string,
-  material: Readonly<Record<string, unknown>>,
-  cause?: unknown,
-): Result.Result<never, LedgerValidationError> =>
-  Result.fail(ledgerValidationError(operation, reason, `TigerBeetle ${operation} failed: ${detail}`, material, cause))
+export const ledgerValidationError = (input: LedgerValidationErrorInput): LedgerValidationError =>
+  new LedgerValidationError(input)
+
+export interface FailLedgerValidationInput extends Omit<LedgerValidationErrorInput, 'message'> {
+  readonly detail: string
+}
+
+export const failLedgerValidation = (input: FailLedgerValidationInput): Result.Result<never, LedgerValidationError> =>
+  Result.fail(
+    ledgerValidationError({
+      ...input,
+      message: `TigerBeetle ${input.operation} failed: ${input.detail}`,
+    }),
+  )
 
 export interface LedgerPlan {
   readonly runKey: bigint
@@ -302,13 +308,13 @@ const ledgerPlanCause = (failure: LedgerPlanFailureDetail): unknown => {
 
 const makeLedgerPlanFailureDataFirst = (ledger: number, detail: LedgerPlanFailureDetail): LedgerPlanFailure =>
   Object.assign(
-    ledgerValidationError(
-      'build-plan',
-      'ledger-plan-failure',
-      `TigerBeetle build-plan failed: ${renderLedgerPlanFailure(detail)}`,
-      { ledger, failure: detail },
-      ledgerPlanCause(detail),
-    ),
+    ledgerValidationError({
+      operation: 'build-plan',
+      reason: 'ledger-plan-failure',
+      message: `TigerBeetle build-plan failed: ${renderLedgerPlanFailure(detail)}`,
+      material: { ledger, failure: detail },
+      cause: ledgerPlanCause(detail),
+    }),
     { kind: detail.kind, detail },
   ) as LedgerPlanFailure
 

--- a/services/bayn/src/ledger-plan/model.ts
+++ b/services/bayn/src/ledger-plan/model.ts
@@ -169,11 +169,14 @@ export interface FailLedgerValidationInput extends Omit<LedgerValidationErrorInp
   readonly detail: string
 }
 
-export const failLedgerValidation = (input: FailLedgerValidationInput): Result.Result<never, LedgerValidationError> =>
+export const failLedgerValidation = ({
+  detail,
+  ...input
+}: FailLedgerValidationInput): Result.Result<never, LedgerValidationError> =>
   Result.fail(
     ledgerValidationError({
       ...input,
-      message: `TigerBeetle ${input.operation} failed: ${input.detail}`,
+      message: `TigerBeetle ${input.operation} failed: ${detail}`,
     }),
   )
 

--- a/services/bayn/src/ledger-plan/persisted-evidence.ts
+++ b/services/bayn/src/ledger-plan/persisted-evidence.ts
@@ -55,11 +55,11 @@ const verifyPersistedAccount = (
     account.timestamp <= 0n ||
     (expectedId !== undefined && account.id !== expectedId)
   ) {
-    return failLedgerValidation(
-      'check-run',
-      'invalid-account-metadata',
-      `run ${result.runId} account ${account.id} has invalid locally verifiable metadata`,
-      {
+    return failLedgerValidation({
+      operation: 'check-run',
+      reason: 'invalid-account-metadata',
+      detail: `run ${result.runId} account ${account.id} has invalid locally verifiable metadata`,
+      material: {
         runId: result.runId,
         account,
         expected: {
@@ -74,7 +74,7 @@ const verifyPersistedAccount = (
           ...(expectedId === undefined ? {} : { deterministicId: expectedId }),
         },
       },
-    )
+    })
   }
   return Result.succeed(undefined)
 }
@@ -114,11 +114,11 @@ const verifyPersistedTransfer = (
     credit.code !== accountCodePair[1] ||
     (transfer.code === TransferCode.funding && (transfer.id !== fundingId || transfer.user_data_128 !== fundingEventId))
   ) {
-    return failLedgerValidation(
-      'check-run',
-      'invalid-transfer-metadata',
-      `run ${result.runId} transfer ${transfer.id} has invalid locally verifiable metadata`,
-      {
+    return failLedgerValidation({
+      operation: 'check-run',
+      reason: 'invalid-transfer-metadata',
+      detail: `run ${result.runId} transfer ${transfer.id} has invalid locally verifiable metadata`,
+      material: {
         runId: result.runId,
         transfer,
         expected: {
@@ -136,7 +136,7 @@ const verifyPersistedTransfer = (
             : {}),
         },
       },
-    )
+    })
   }
   return Result.succeed(undefined)
 }
@@ -153,30 +153,30 @@ export const validatePersistedRunEvidence = (
 ): Result.Result<void, LedgerValidationError> =>
   Result.gen(function* () {
     if (accounts.length !== result.accountCount) {
-      return yield* failLedgerValidation(
-        'check-run',
-        'run-count-mismatch',
-        `run ${result.runId} has ${accounts.length} accounts; expected ${result.accountCount}`,
-        {
+      return yield* failLedgerValidation({
+        operation: 'check-run',
+        reason: 'run-count-mismatch',
+        detail: `run ${result.runId} has ${accounts.length} accounts; expected ${result.accountCount}`,
+        material: {
           runId: result.runId,
           kind: 'account',
           actualCount: accounts.length,
           expectedCount: result.accountCount,
         },
-      )
+      })
     }
     if (transfers.length !== result.transferCount) {
-      return yield* failLedgerValidation(
-        'check-run',
-        'run-count-mismatch',
-        `run ${result.runId} has ${transfers.length} transfers; expected ${result.transferCount}`,
-        {
+      return yield* failLedgerValidation({
+        operation: 'check-run',
+        reason: 'run-count-mismatch',
+        detail: `run ${result.runId} has ${transfers.length} transfers; expected ${result.transferCount}`,
+        material: {
           runId: result.runId,
           kind: 'transfer',
           actualCount: transfers.length,
           expectedCount: result.transferCount,
         },
-      )
+      })
     }
 
     const runKey = stableU128('bayn-run-v1', result.runId)
@@ -188,24 +188,24 @@ export const validatePersistedRunEvidence = (
         const expectedId = stableU128('bayn-account-v1', result.runId, name)
         const persistedAccount = reconciled.accountsById.get(expectedId)
         if (persistedAccount === undefined) {
-          return yield* failLedgerValidation(
-            'check-run',
-            'record-set-mismatch',
-            `run ${result.runId} is missing required ${name} account`,
-            { runId: result.runId, kind: 'account', code, expectedId },
-          )
+          return yield* failLedgerValidation({
+            operation: 'check-run',
+            reason: 'record-set-mismatch',
+            detail: `run ${result.runId} is missing required ${name} account`,
+            material: { runId: result.runId, kind: 'account', code, expectedId },
+          })
         }
         if (persistedAccount.code !== code) {
-          return yield* failLedgerValidation(
-            'check-run',
-            'invalid-account-metadata',
-            `run ${result.runId} required ${name} account has code ${persistedAccount.code}; expected ${code}`,
-            {
+          return yield* failLedgerValidation({
+            operation: 'check-run',
+            reason: 'invalid-account-metadata',
+            detail: `run ${result.runId} required ${name} account has code ${persistedAccount.code}; expected ${code}`,
+            material: {
               runId: result.runId,
               account: persistedAccount,
               expected: { deterministicId: expectedId, code },
             },
-          )
+          })
         }
       }
     }
@@ -214,11 +214,11 @@ export const validatePersistedRunEvidence = (
     }
     const fundingId = stableU128('bayn-transfer-v1', result.runId, 'funding', 'principal')
     if (transfers.length > 0 && !reconciled.transfersById.has(fundingId)) {
-      return yield* failLedgerValidation(
-        'check-run',
-        'record-set-mismatch',
-        `run ${result.runId} is missing its deterministic funding transfer`,
-        { runId: result.runId, kind: 'transfer', code: TransferCode.funding, expectedId: fundingId },
-      )
+      return yield* failLedgerValidation({
+        operation: 'check-run',
+        reason: 'record-set-mismatch',
+        detail: `run ${result.runId} is missing its deterministic funding transfer`,
+        material: { runId: result.runId, kind: 'transfer', code: TransferCode.funding, expectedId: fundingId },
+      })
     }
   })

--- a/services/bayn/src/ledger-plan/verification.ts
+++ b/services/bayn/src/ledger-plan/verification.ts
@@ -57,29 +57,34 @@ const verifyUniqueExact = <Record extends { readonly id: bigint }>(
   const actualDuplicateId = duplicateRecordId(actual)
   const expectedDuplicateId = duplicateRecordId(expected)
   if (actual.length !== expected.length || actualDuplicateId !== undefined || expectedDuplicateId !== undefined) {
-    return failLedgerValidation(
+    return failLedgerValidation({
       operation,
-      'record-set-mismatch',
-      `${kind} set mismatch: expected ${expected.length}, received ${actual.length}`,
-      {
+      reason: 'record-set-mismatch',
+      detail: `${kind} set mismatch: expected ${expected.length}, received ${actual.length}`,
+      material: {
         kind,
         expectedCount: expected.length,
         actualCount: actual.length,
         ...(actualDuplicateId === undefined ? {} : { duplicateId: actualDuplicateId }),
         ...(expectedDuplicateId === undefined ? {} : { duplicateExpectedId: expectedDuplicateId }),
       },
-    )
+    })
   }
 
   const expectedById = new Map(expected.map((value) => [value.id, value]))
   for (const value of actual) {
     const expectedValue = expectedById.get(value.id)
     if (expectedValue === undefined || !matches(value, expectedValue)) {
-      return failLedgerValidation(operation, 'record-mismatch', `${kind} ${value.id} does not match its plan`, {
-        kind,
-        id: value.id,
-        actual: value,
-        expected: expectedValue,
+      return failLedgerValidation({
+        operation,
+        reason: 'record-mismatch',
+        detail: `${kind} ${value.id} does not match its plan`,
+        material: {
+          kind,
+          id: value.id,
+          actual: value,
+          expected: expectedValue,
+        },
       })
     }
   }
@@ -128,17 +133,17 @@ const preflightTransfersDataFirst = (
   const expectedDuplicateId = duplicateRecordId(expected)
   const existingDuplicateId = duplicateRecordId(existing)
   if (expectedDuplicateId !== undefined || existingDuplicateId !== undefined) {
-    return failLedgerValidation(
-      'preflight-transfers',
-      'record-set-mismatch',
-      'transfer preflight contains duplicate deterministic IDs',
-      {
+    return failLedgerValidation({
+      operation: 'preflight-transfers',
+      reason: 'record-set-mismatch',
+      detail: 'transfer preflight contains duplicate deterministic IDs',
+      material: {
         expectedCount: expected.length,
         actualCount: existing.length,
         ...(expectedDuplicateId === undefined ? {} : { duplicateExpectedId: expectedDuplicateId }),
         ...(existingDuplicateId === undefined ? {} : { duplicateId: existingDuplicateId }),
       },
-    )
+    })
   }
 
   const expectedById = new Map(expected.map((transfer) => [transfer.id, transfer]))
@@ -146,17 +151,17 @@ const preflightTransfersDataFirst = (
   for (const transfer of existing) {
     const expectedTransfer = expectedById.get(transfer.id)
     if (expectedTransfer === undefined || !transferMetadataMatches(transfer, expectedTransfer)) {
-      return failLedgerValidation(
-        'preflight-transfers',
-        'record-mismatch',
-        `existing transfer ${transfer.id} does not match its plan`,
-        {
+      return failLedgerValidation({
+        operation: 'preflight-transfers',
+        reason: 'record-mismatch',
+        detail: `existing transfer ${transfer.id} does not match its plan`,
+        material: {
           kind: 'existing transfer',
           id: transfer.id,
           actual: transfer,
           expected: expectedTransfer,
         },
-      )
+      })
     }
     existingIds.add(transfer.id)
   }
@@ -178,25 +183,27 @@ const reconcileBalancesDataFirst = (
 ): Result.Result<LedgerBalances, LedgerValidationError> => {
   const accountDuplicateId = duplicateRecordId(accounts)
   if (accountDuplicateId !== undefined) {
-    return failLedgerValidation(
+    return failLedgerValidation({
       operation,
-      'duplicate-account',
-      runId === undefined
-        ? `ledger contains duplicate account ${accountDuplicateId}`
-        : `run ${runId} contains duplicate account ${accountDuplicateId}`,
-      { ...(runId === undefined ? {} : { runId }), accountId: accountDuplicateId },
-    )
+      reason: 'duplicate-account',
+      detail:
+        runId === undefined
+          ? `ledger contains duplicate account ${accountDuplicateId}`
+          : `run ${runId} contains duplicate account ${accountDuplicateId}`,
+      material: { ...(runId === undefined ? {} : { runId }), accountId: accountDuplicateId },
+    })
   }
   const transferDuplicateId = duplicateRecordId(transfers)
   if (transferDuplicateId !== undefined) {
-    return failLedgerValidation(
+    return failLedgerValidation({
       operation,
-      'duplicate-transfer',
-      runId === undefined
-        ? `ledger contains duplicate transfer ${transferDuplicateId}`
-        : `run ${runId} contains duplicate transfer ${transferDuplicateId}`,
-      { ...(runId === undefined ? {} : { runId }), transferId: transferDuplicateId },
-    )
+      reason: 'duplicate-transfer',
+      detail:
+        runId === undefined
+          ? `ledger contains duplicate transfer ${transferDuplicateId}`
+          : `run ${runId} contains duplicate transfer ${transferDuplicateId}`,
+      material: { ...(runId === undefined ? {} : { runId }), transferId: transferDuplicateId },
+    })
   }
 
   const accountsById = new Map(accounts.map((account) => [account.id, account]))
@@ -206,19 +213,20 @@ const reconcileBalancesDataFirst = (
     const debit = balances.get(transfer.debit_account_id)
     const credit = balances.get(transfer.credit_account_id)
     if (debit === undefined || credit === undefined) {
-      return failLedgerValidation(
+      return failLedgerValidation({
         operation,
-        'unknown-account-reference',
-        runId === undefined
-          ? `transfer ${transfer.id} references an unknown account`
-          : `run ${runId} transfer ${transfer.id} references an account outside the run`,
-        {
+        reason: 'unknown-account-reference',
+        detail:
+          runId === undefined
+            ? `transfer ${transfer.id} references an unknown account`
+            : `run ${runId} transfer ${transfer.id} references an account outside the run`,
+        material: {
           ...(runId === undefined ? {} : { runId }),
           transferId: transfer.id,
           debitAccountId: transfer.debit_account_id,
           creditAccountId: transfer.credit_account_id,
         },
-      )
+      })
     }
     if (transfer.debit_account_id === transfer.credit_account_id) {
       balances.set(transfer.debit_account_id, {
@@ -234,14 +242,15 @@ const reconcileBalancesDataFirst = (
   for (const account of accounts) {
     const balance = balances.get(account.id)
     if (balance === undefined) {
-      return failLedgerValidation(
+      return failLedgerValidation({
         operation,
-        'missing-balance',
-        runId === undefined
-          ? `unexpected account ${account.id}`
-          : `run ${runId} has no balance for account ${account.id}`,
-        { ...(runId === undefined ? {} : { runId }), accountId: account.id },
-      )
+        reason: 'missing-balance',
+        detail:
+          runId === undefined
+            ? `unexpected account ${account.id}`
+            : `run ${runId} has no balance for account ${account.id}`,
+        material: { ...(runId === undefined ? {} : { runId }), accountId: account.id },
+      })
     }
     if (
       account.debits_pending !== 0n ||
@@ -249,14 +258,15 @@ const reconcileBalancesDataFirst = (
       account.debits_posted !== balance.debits ||
       account.credits_posted !== balance.credits
     ) {
-      return failLedgerValidation(
+      return failLedgerValidation({
         operation,
-        'invalid-balance',
-        runId === undefined
-          ? `account ${account.id} balance does not reconcile exactly`
-          : `run ${runId} account ${account.id} balance does not reconcile locally`,
-        { ...(runId === undefined ? {} : { runId }), account, expected: balance },
-      )
+        reason: 'invalid-balance',
+        detail:
+          runId === undefined
+            ? `account ${account.id} balance does not reconcile exactly`
+            : `run ${runId} account ${account.id} balance does not reconcile locally`,
+        material: { ...(runId === undefined ? {} : { runId }), account, expected: balance },
+      })
     }
   }
   return Result.succeed({ accountsById, transfersById })

--- a/services/bayn/src/ledger/decisions.ts
+++ b/services/bayn/src/ledger/decisions.ts
@@ -23,36 +23,36 @@ const classifyCreateBatch = <Record extends { readonly id: bigint }>(
   results: readonly LedgerCreateResult[],
 ): Result.Result<readonly Record[], LedgerValidationError> => {
   if (results.length !== records.length) {
-    return failLedgerValidation(
+    return failLedgerValidation({
       operation,
-      'batch-result-count',
-      `TigerBeetle returned an incomplete ${kind} result batch`,
-      { kind, expectedCount: records.length, actualCount: results.length },
-    )
+      reason: 'batch-result-count',
+      detail: `TigerBeetle returned an incomplete ${kind} result batch`,
+      material: { kind, expectedCount: records.length, actualCount: results.length },
+    })
   }
 
   const existing: Record[] = []
   for (const [index, result] of results.entries()) {
     const record = records[index]
     if (record === undefined) {
-      return failLedgerValidation(
+      return failLedgerValidation({
         operation,
-        'batch-result-count',
-        `TigerBeetle returned a ${kind} result without a corresponding record`,
-        { kind, index, expectedCount: records.length, actualCount: results.length },
-      )
+        reason: 'batch-result-count',
+        detail: `TigerBeetle returned a ${kind} result without a corresponding record`,
+        material: { kind, index, expectedCount: records.length, actualCount: results.length },
+      })
     }
     if (result.outcome === 'created') continue
     if (result.outcome === 'exists') {
       existing.push(record)
       continue
     }
-    return failLedgerValidation(
+    return failLedgerValidation({
       operation,
-      'create-rejected',
-      `TigerBeetle rejected ${kind} ${record.id} with status ${result.status}`,
-      { kind, id: record.id, status: result.status },
-    )
+      reason: 'create-rejected',
+      detail: `TigerBeetle rejected ${kind} ${record.id} with status ${result.status}`,
+      material: { kind, id: record.id, status: result.status },
+    })
   }
   return Result.succeed(existing)
 }
@@ -88,18 +88,28 @@ const queryFilter = (ledger: number): LedgerQueryFilter => ({
 export const transactionTransferQuery = (plan: LedgerPlan): Result.Result<LedgerQueryFilter, LedgerValidationError> => {
   if (plan.accounts.length === 0 || plan.transfers.length === 0) {
     return Result.fail(
-      ledgerValidationError('post', 'empty-plan', 'TigerBeetle posting plan must contain accounts and transfers', {
-        accountCount: plan.accounts.length,
-        transferCount: plan.transfers.length,
+      ledgerValidationError({
+        operation: 'post',
+        reason: 'empty-plan',
+        message: 'TigerBeetle posting plan must contain accounts and transfers',
+        material: {
+          accountCount: plan.accounts.length,
+          transferCount: plan.transfers.length,
+        },
       }),
     )
   }
   if (plan.accounts.length >= LEDGER_BATCH_MAX || plan.transfers.length >= LEDGER_BATCH_MAX) {
     return Result.fail(
-      ledgerValidationError('post', 'batch-limit', 'TigerBeetle posting plan exceeds batch limits', {
-        accountCount: plan.accounts.length,
-        transferCount: plan.transfers.length,
-        limit: LEDGER_BATCH_MAX,
+      ledgerValidationError({
+        operation: 'post',
+        reason: 'batch-limit',
+        message: 'TigerBeetle posting plan exceeds batch limits',
+        material: {
+          accountCount: plan.accounts.length,
+          transferCount: plan.transfers.length,
+          limit: LEDGER_BATCH_MAX,
+        },
       }),
     )
   }
@@ -112,18 +122,19 @@ export const transactionTransferQuery = (plan: LedgerPlan): Result.Result<Ledger
       (transfer) => transfer.ledger !== first.ledger || transfer.user_data_128 !== first.user_data_128,
     )
   ) {
-    return failLedgerValidation(
-      'build-transaction-transfer-query',
-      'invalid-transaction',
-      first === undefined
-        ? 'accounting plan contains no transfers'
-        : 'accounting transfers do not share one nonzero transaction tag and ledger',
-      {
+    return failLedgerValidation({
+      operation: 'build-transaction-transfer-query',
+      reason: 'invalid-transaction',
+      detail:
+        first === undefined
+          ? 'accounting plan contains no transfers'
+          : 'accounting transfers do not share one nonzero transaction tag and ledger',
+      material: {
         transferCount: plan.transfers.length,
         transactionTag: first?.user_data_128,
         ledger: first?.ledger,
       },
-    )
+    })
   }
   return Result.succeed({
     ...queryFilter(first.ledger),
@@ -143,10 +154,15 @@ const persistedRunQueriesDataFirst = (
 ): Result.Result<LedgerQueries, LedgerValidationError> => {
   if (result.accountCount >= LEDGER_BATCH_MAX || result.transferCount >= LEDGER_BATCH_MAX) {
     return Result.fail(
-      ledgerValidationError('check-run', 'batch-limit', 'persisted TigerBeetle counts exceed the exact query limit', {
-        accountCount: result.accountCount,
-        transferCount: result.transferCount,
-        limit: LEDGER_BATCH_MAX,
+      ledgerValidationError({
+        operation: 'check-run',
+        reason: 'batch-limit',
+        message: 'persisted TigerBeetle counts exceed the exact query limit',
+        material: {
+          accountCount: result.accountCount,
+          transferCount: result.transferCount,
+          limit: LEDGER_BATCH_MAX,
+        },
       }),
     )
   }
@@ -172,10 +188,15 @@ const accountReconciliationQueriesDataFirst = (
 ): Result.Result<LedgerQueries, LedgerValidationError> => {
   if (plan.accounts.length >= LEDGER_BATCH_MAX || plan.transfers.length >= LEDGER_BATCH_MAX) {
     return Result.fail(
-      ledgerValidationError('verify-account', 'batch-limit', 'paper account exceeds the exact reconciliation limit', {
-        accountCount: plan.accounts.length,
-        transferCount: plan.transfers.length,
-        limit: LEDGER_BATCH_MAX,
+      ledgerValidationError({
+        operation: 'verify-account',
+        reason: 'batch-limit',
+        message: 'paper account exceeds the exact reconciliation limit',
+        material: {
+          accountCount: plan.accounts.length,
+          transferCount: plan.transfers.length,
+          limit: LEDGER_BATCH_MAX,
+        },
       }),
     )
   }
@@ -212,33 +233,39 @@ const assembleAccountPlanDataFirst = (
   const transfers = new Map<bigint, LedgerTransferRecord>()
   for (const plan of plans) {
     if (plan.runKey !== runKey || plan.runTag !== runTag) {
-      return failLedgerValidation(
-        'build-account-reconciliation',
-        'wrong-account',
-        `accounting plan does not belong to paper account ${accountId}`,
-        { accountId, planRunKey: plan.runKey, planRunTag: plan.runTag, expectedRunKey: runKey, expectedRunTag: runTag },
-      )
+      return failLedgerValidation({
+        operation: 'build-account-reconciliation',
+        reason: 'wrong-account',
+        detail: `accounting plan does not belong to paper account ${accountId}`,
+        material: {
+          accountId,
+          planRunKey: plan.runKey,
+          planRunTag: plan.runTag,
+          expectedRunKey: runKey,
+          expectedRunTag: runTag,
+        },
+      })
     }
     for (const account of plan.accounts) {
       const existing = accounts.get(account.id)
       if (existing !== undefined && !accountMetadataMatches(account, existing)) {
-        return failLedgerValidation(
-          'build-account-reconciliation',
-          'record-mismatch',
-          `accounting account ${account.id} does not match its plan`,
-          { kind: 'accounting account', id: account.id, actual: account, expected: existing },
-        )
+        return failLedgerValidation({
+          operation: 'build-account-reconciliation',
+          reason: 'record-mismatch',
+          detail: `accounting account ${account.id} does not match its plan`,
+          material: { kind: 'accounting account', id: account.id, actual: account, expected: existing },
+        })
       }
       if (existing === undefined) accounts.set(account.id, account)
     }
     for (const transfer of plan.transfers) {
       if (transfers.has(transfer.id)) {
-        return failLedgerValidation(
-          'build-account-reconciliation',
-          'duplicate-transfer',
-          `duplicate accounting transfer ${transfer.id}`,
-          { accountId, transferId: transfer.id },
-        )
+        return failLedgerValidation({
+          operation: 'build-account-reconciliation',
+          reason: 'duplicate-transfer',
+          detail: `duplicate accounting transfer ${transfer.id}`,
+          material: { accountId, transferId: transfer.id },
+        })
       }
       transfers.set(transfer.id, transfer)
     }

--- a/services/bayn/src/paper-proof/mutations.ts
+++ b/services/bayn/src/paper-proof/mutations.ts
@@ -85,12 +85,12 @@ const prepareSubmitIntent = (
       prepared.intentId === context.sourcePlan.intentId
         ? Effect.succeed(prepared)
         : Effect.fail(
-            paperProofFailure(
-              'SUBMIT',
-              'prepared PAPER intent identity does not match the source-controlled proof plan',
-              prepared,
-              'invariant',
-            ),
+            paperProofFailure({
+              operation: 'SUBMIT',
+              message: 'prepared PAPER intent identity does not match the source-controlled proof plan',
+              cause: prepared,
+              failure: 'invariant',
+            }),
           ),
     ),
   )
@@ -264,12 +264,12 @@ const runPaperProofSubmitDataFirst = (
       MutationOperation.Cancel,
     )
     if (cancellation !== undefined) {
-      return yield* paperProofFailure(
-        'SUBMIT',
-        'paper proof submit is superseded by a durable cancellation mutation',
-        cancellation,
-        'mutation-unresolved',
-      )
+      return yield* paperProofFailure({
+        operation: 'SUBMIT',
+        message: 'paper proof submit is superseded by a durable cancellation mutation',
+        cause: cancellation,
+        failure: 'mutation-unresolved',
+      })
     }
     const existing = yield* readPaperProofMutation(context, 'SUBMIT', dependencies.mutations, MutationOperation.Submit)
     const admission = yield* Effect.fromResult(decideSubmitAdmission(cancellation, existing))

--- a/services/bayn/src/paper-proof/operations.ts
+++ b/services/bayn/src/paper-proof/operations.ts
@@ -51,17 +51,17 @@ export type PaperProofReceiptFields = Omit<
 
 export type PaperProofExecutionHook = () => Effect.Effect<void, PaperProofError>
 
-export const paperProofFailure = (
-  operation: PaperProofError['operation'],
-  message: string,
-  cause: unknown,
-  failure: PaperProofError['failure'] = 'operational',
-): PaperProofError =>
+export interface PaperProofFailureInput {
+  readonly operation: PaperProofError['operation']
+  readonly message: string
+  readonly cause: unknown
+  readonly failure?: PaperProofError['failure']
+}
+
+export const paperProofFailure = (input: PaperProofFailureInput): PaperProofError =>
   new PaperProofError({
-    operation,
-    failure,
-    message,
-    cause,
+    ...input,
+    failure: input.failure ?? 'operational',
   })
 
 const timeoutFailureDataFirst = (operation: PaperProofError['operation'], message: string): PaperProofError =>
@@ -78,7 +78,7 @@ const liftDataFirst = <A>(
   message: string,
   effect: Effect.Effect<A, Error>,
 ): Effect.Effect<A, PaperProofError> =>
-  effect.pipe(Effect.mapError((cause) => paperProofFailure(operation, message, cause)))
+  effect.pipe(Effect.mapError((cause) => paperProofFailure({ operation, message, cause })))
 
 export const lift = Pipeable.generic<
   <A>(
@@ -120,12 +120,12 @@ const validateReconciliationAccountDataFirst = (
   reconciliation.accountId === expectedAccountId
     ? Result.succeed(reconciliation)
     : Result.fail(
-        paperProofFailure(
-          'RECONCILE',
-          'paper proof reconciliation account does not match the source-controlled account',
-          reconciliation,
-          'invariant',
-        ),
+        paperProofFailure({
+          operation: 'RECONCILE',
+          message: 'paper proof reconciliation account does not match the source-controlled account',
+          cause: reconciliation,
+          failure: 'invariant',
+        }),
       )
 
 export const validateReconciliationAccount = Pipeable.dual(2, validateReconciliationAccountDataFirst)
@@ -136,12 +136,12 @@ export const validateExactReconciliation = (
   reconciliation.status === 'EXACT' && reconciliation.unknownMutationCount === 0
     ? Result.succeed(reconciliation)
     : Result.fail(
-        paperProofFailure(
-          'RECONCILE',
-          'paper proof requires exact reconciliation with zero unknown mutations',
-          reconciliation,
-          'invariant',
-        ),
+        paperProofFailure({
+          operation: 'RECONCILE',
+          message: 'paper proof requires exact reconciliation with zero unknown mutations',
+          cause: reconciliation,
+          failure: 'invariant',
+        }),
       )
 
 const observeReconciliationDataFirst = (
@@ -240,12 +240,12 @@ const decideSubmitAdmissionDataFirst = (
 ): Result.Result<SubmitAdmission, PaperProofError> => {
   if (cancellation !== undefined) {
     return Result.fail(
-      paperProofFailure(
-        'SUBMIT',
-        'paper proof submit is superseded by a durable cancellation mutation',
-        cancellation,
-        'mutation-unresolved',
-      ),
+      paperProofFailure({
+        operation: 'SUBMIT',
+        message: 'paper proof submit is superseded by a durable cancellation mutation',
+        cause: cancellation,
+        failure: 'mutation-unresolved',
+      }),
     )
   }
   return existing === undefined
@@ -272,25 +272,32 @@ const decideCancellationAdmissionDataFirst = (
   if (existing !== undefined) return Result.succeed({ _tag: 'Existing', event: existing })
   if (submitted === undefined || !isSuccessfulSubmit(submitted) || submitted.brokerOrderId === undefined) {
     return Result.fail(
-      paperProofFailure(
-        'CANCEL',
-        'paper proof cancellation requires an exact durable submitted broker order',
-        submitted,
-        'mutation-unresolved',
-      ),
+      paperProofFailure({
+        operation: 'CANCEL',
+        message: 'paper proof cancellation requires an exact durable submitted broker order',
+        cause: submitted,
+        failure: 'mutation-unresolved',
+      }),
     )
   }
   if (intent === undefined) {
-    return Result.fail(paperProofFailure('CANCEL', 'paper proof durable intent does not exist', intent, 'invariant'))
+    return Result.fail(
+      paperProofFailure({
+        operation: 'CANCEL',
+        message: 'paper proof durable intent does not exist',
+        cause: intent,
+        failure: 'invariant',
+      }),
+    )
   }
   if (intent.state !== IntentState.Acknowledged) {
     return Result.fail(
-      paperProofFailure(
-        'CANCEL',
-        'paper proof cancellation requires an acknowledged durable intent',
-        intent,
-        'mutation-unresolved',
-      ),
+      paperProofFailure({
+        operation: 'CANCEL',
+        message: 'paper proof cancellation requires an acknowledged durable intent',
+        cause: intent,
+        failure: 'mutation-unresolved',
+      }),
     )
   }
   return Result.succeed({ _tag: 'New' })
@@ -352,23 +359,23 @@ const decideRecoverySelectionDataFirst = (
   const operation = selectRecoveryOperation(state, required)
   if (operation === undefined) {
     return Result.fail(
-      paperProofFailure(
-        'RECOVERY_STATE',
-        'paper proof RECOVER requires a durable marker, completion, or mutation evidence',
-        { required, mutations: state },
-        'mutation-unresolved',
-      ),
+      paperProofFailure({
+        operation: 'RECOVERY_STATE',
+        message: 'paper proof RECOVER requires a durable marker, completion, or mutation evidence',
+        cause: { required, mutations: state },
+        failure: 'mutation-unresolved',
+      }),
     )
   }
   const recorded = mutationForOperation(state, operation)
   return recorded === undefined
     ? Result.fail(
-        paperProofFailure(
-          'RECOVERY_STATE',
-          'paper proof recovery marker does not have a durable mutation to recover',
-          { operation, required, mutations: state },
-          'mutation-unresolved',
-        ),
+        paperProofFailure({
+          operation: 'RECOVERY_STATE',
+          message: 'paper proof recovery marker does not have a durable mutation to recover',
+          cause: { operation, required, mutations: state },
+          failure: 'mutation-unresolved',
+        }),
       )
     : Result.succeed({ operation, recorded })
 }
@@ -395,12 +402,12 @@ const validateCompletionMutationIdentityDataFirst = (
     completion.mutation.operation === expectedOperation
     ? Result.succeed(undefined)
     : Result.fail(
-        paperProofFailure(
-          'RECOVERY_STATE',
-          'paper proof durable recovery completion mutation identity is invalid',
-          completion,
-          'invariant',
-        ),
+        paperProofFailure({
+          operation: 'RECOVERY_STATE',
+          message: 'paper proof durable recovery completion mutation identity is invalid',
+          cause: completion,
+          failure: 'invariant',
+        }),
       )
 }
 
@@ -436,22 +443,22 @@ const ensureRecoveryMarkerCompatibleDataFirst = (
       if (existing === undefined) return Effect.as(Effect.void, undefined)
       if (!recoveryIdentityMatches(context, existing)) {
         return Effect.fail(
-          paperProofFailure(
-            'RECOVERY_STATE',
-            'paper proof durable recovery marker does not match the pinned proof identity',
-            existing,
-            'invariant',
-          ),
+          paperProofFailure({
+            operation: 'RECOVERY_STATE',
+            message: 'paper proof durable recovery marker does not match the pinned proof identity',
+            cause: existing,
+            failure: 'invariant',
+          }),
         )
       }
       if (existing.operation === 'CANCEL' && operation === 'SUBMIT') {
         return Effect.fail(
-          paperProofFailure(
-            'RECOVERY_STATE',
-            'paper proof cannot replace an unresolved cancellation marker with submit recovery',
-            existing,
-            'mutation-unresolved',
-          ),
+          paperProofFailure({
+            operation: 'RECOVERY_STATE',
+            message: 'paper proof cannot replace an unresolved cancellation marker with submit recovery',
+            cause: existing,
+            failure: 'mutation-unresolved',
+          }),
         )
       }
       return Effect.succeed(existing)
@@ -520,12 +527,12 @@ const loadRecoveryRequiredDataFirst = (
       required === undefined || recoveryIdentityMatches(context, required)
         ? Effect.succeed(required)
         : Effect.fail(
-            paperProofFailure(
-              'RECOVERY_STATE',
-              'paper proof durable recovery marker does not match the pinned proof identity',
-              required,
-              'invariant',
-            ),
+            paperProofFailure({
+              operation: 'RECOVERY_STATE',
+              message: 'paper proof durable recovery marker does not match the pinned proof identity',
+              cause: required,
+              failure: 'invariant',
+            }),
           ),
     ),
   )
@@ -545,12 +552,12 @@ const loadRecoveryCompletionDataFirst = (
     Effect.flatMap((completion) => {
       if (completion !== undefined && !recoveryIdentityMatches(context, completion)) {
         return Effect.fail(
-          paperProofFailure(
-            'RECOVERY_STATE',
-            'paper proof durable recovery completion does not match the pinned proof identity',
-            completion,
-            'invariant',
-          ),
+          paperProofFailure({
+            operation: 'RECOVERY_STATE',
+            message: 'paper proof durable recovery completion does not match the pinned proof identity',
+            cause: completion,
+            failure: 'invariant',
+          }),
         )
       }
       return Effect.succeed(completion)
@@ -567,7 +574,14 @@ const readPaperProofIntentDataFirst = (
   lift(operation, 'paper proof durable intent read failed', readIntent(context.sourcePlan.intentId)).pipe(
     Effect.flatMap((snapshot) =>
       snapshot === undefined
-        ? Effect.fail(paperProofFailure(operation, 'paper proof durable intent does not exist', snapshot, 'invariant'))
+        ? Effect.fail(
+            paperProofFailure({
+              operation,
+              message: 'paper proof durable intent does not exist',
+              cause: snapshot,
+              failure: 'invariant',
+            }),
+          )
         : Effect.succeed(snapshot),
     ),
   )
@@ -622,12 +636,12 @@ const makeRecoveryCompletionDataFirst = (
 ): Result.Result<PaperProofRecoveryCompletion, PaperProofError> =>
   receipt.mutation === undefined
     ? Result.fail(
-        paperProofFailure(
-          'RECOVERY_STATE',
-          'paper proof recovery completion requires durable mutation evidence',
-          receipt,
-          'invariant',
-        ),
+        paperProofFailure({
+          operation: 'RECOVERY_STATE',
+          message: 'paper proof recovery completion requires durable mutation evidence',
+          cause: receipt,
+          failure: 'invariant',
+        }),
       )
     : Result.succeed({
         schemaVersion: paperProofRecoveryCompletionSchemaVersion,
@@ -653,12 +667,12 @@ const completeRecoveryDataFirst = (
   Effect.gen(function* () {
     if (completion.operation === 'SUBMIT') {
       if (latestCancellation === undefined) {
-        return yield* paperProofFailure(
-          'RECOVERY_STATE',
-          'paper proof submit completion is missing its cancellation-state reader',
-          completion,
-          'invariant',
-        )
+        return yield* paperProofFailure({
+          operation: 'RECOVERY_STATE',
+          message: 'paper proof submit completion is missing its cancellation-state reader',
+          cause: completion,
+          failure: 'invariant',
+        })
       }
       const cancellation = yield* lift(
         'RECOVERY_STATE',
@@ -666,12 +680,12 @@ const completeRecoveryDataFirst = (
         latestCancellation(),
       )
       if (cancellation !== undefined) {
-        return yield* paperProofFailure(
-          'RECOVERY_STATE',
-          'paper proof submit completion is superseded by a durable cancellation mutation',
-          cancellation,
-          'mutation-unresolved',
-        )
+        return yield* paperProofFailure({
+          operation: 'RECOVERY_STATE',
+          message: 'paper proof submit completion is superseded by a durable cancellation mutation',
+          cause: cancellation,
+          failure: 'mutation-unresolved',
+        })
       }
     }
     yield* liftBounded(


### PR DESCRIPTION
## Summary

- Replaces positional ledger failure construction with structured typed inputs.
- Keeps this native stack layer independently reviewable at 655 changed lines.
- Bases directly on codex/bayn-effect-tsgo-operational-cycle-errors so GitHub shows only this layer.

## Related Issues

None

## Testing

- bunx tsc --noEmit --project services/bayn/tsconfig.json
- bun run lint
- bun run lint:oxlint
- bun run lint:oxlint:type
- bun run build
- Focused tests for the touched subsystem were run while constructing the layer.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable and Breaking Changes is filled in.
- [x] Documentation and follow-ups are unchanged or represented by later stack layers.