### PR TITLE
refactor(bayn): structure broker and database failures

### DIFF
--- a/services/bayn/src/broker/alpaca-mutations/decisions.ts
+++ b/services/bayn/src/broker/alpaca-mutations/decisions.ts
@@ -190,7 +190,9 @@ export const authorizeMutationAccess = (
   authority: ExecutionAuthority,
 ): Result.Result<BrokerAccess.Mutation, BrokerMutationError> => {
   if (authority.brokerAccess !== BrokerAccess.Mutation) {
-    return Result.fail(configurationError('Alpaca mutation capability requires explicit mutation broker access'))
+    return Result.fail(
+      configurationError({ message: 'Alpaca mutation capability requires explicit mutation broker access' }),
+    )
   }
   return Result.succeed(BrokerAccess.Mutation)
 }
@@ -208,16 +210,19 @@ const resolveMutationCapabilityDataFirst = (
     preflight.accountId !== connection.expectedAccountId
   ) {
     return Result.fail(
-      configurationError('Alpaca mutation capability requires an exact verified broker session binding', {
-        _tag: 'BrokerSessionBindingMismatch',
-        connectionProvider: connection.provider,
-        preflightProvider: preflight.provider,
-        connectionEnvironment: connection.environment,
-        preflightEnvironment: preflight.environment,
-        connectionBaseUrl: connection.baseUrl,
-        preflightBaseUrl: preflight.baseUrl,
-        connectionAccountId: connection.expectedAccountId,
-        preflightAccountId: preflight.accountId,
+      configurationError({
+        message: 'Alpaca mutation capability requires an exact verified broker session binding',
+        cause: {
+          _tag: 'BrokerSessionBindingMismatch',
+          connectionProvider: connection.provider,
+          preflightProvider: preflight.provider,
+          connectionEnvironment: connection.environment,
+          preflightEnvironment: preflight.environment,
+          connectionBaseUrl: connection.baseUrl,
+          preflightBaseUrl: preflight.baseUrl,
+          connectionAccountId: connection.expectedAccountId,
+          preflightAccountId: preflight.accountId,
+        },
       }),
     )
   }
@@ -225,10 +230,13 @@ const resolveMutationCapabilityDataFirst = (
     yield* authorizeMutationAccess(authority)
     if (authority.brokerIdentity.identityHash !== connection.identity.identityHash) {
       return yield* Result.fail(
-        configurationError('Alpaca mutation authority identity does not match the verified broker session', {
-          _tag: 'BrokerIdentityMismatch',
-          authorityIdentityHash: authority.brokerIdentity.identityHash,
-          connectionIdentityHash: connection.identity.identityHash,
+        configurationError({
+          message: 'Alpaca mutation authority identity does not match the verified broker session',
+          cause: {
+            _tag: 'BrokerIdentityMismatch',
+            authorityIdentityHash: authority.brokerIdentity.identityHash,
+            connectionIdentityHash: connection.identity.identityHash,
+          },
         }),
       )
     }
@@ -328,7 +336,11 @@ export const submitBody = (intent: Intent): Result.Result<OrderRequestBody, Orde
 
 const submitRequestHash = (body: OrderRequestBody): Result.Result<string, BrokerMutationError> =>
   Result.mapError(canonicalHashV1Result(body), (cause) =>
-    invalidRequest(MutationOperation.Submit, 'order request cannot be canonically hashed', cause),
+    invalidRequest({
+      operation: MutationOperation.Submit,
+      message: 'order request cannot be canonically hashed',
+      cause,
+    }),
   )
 
 const prepareSubmitDataFirst = (
@@ -337,17 +349,28 @@ const prepareSubmitDataFirst = (
 ): Result.Result<PreparedSubmit, BrokerMutationError> => {
   const decoded = decodeIntent(input)
   if (Result.isFailure(decoded)) {
-    return Result.fail(invalidRequest(MutationOperation.Submit, 'invalid order intent', decoded.failure))
+    return Result.fail(
+      invalidRequest({ operation: MutationOperation.Submit, message: 'invalid order intent', cause: decoded.failure }),
+    )
   }
   const intent = decoded.success
   if (intent.accountId !== expectedAccountId) {
     return Result.fail(
-      invalidRequest(MutationOperation.Submit, 'order intent account does not match the configured Alpaca account'),
+      invalidRequest({
+        operation: MutationOperation.Submit,
+        message: 'order intent account does not match the configured Alpaca account',
+      }),
     )
   }
   const body = submitBody(intent)
   if (Result.isFailure(body)) {
-    return Result.fail(invalidRequest(MutationOperation.Submit, 'order intent cannot be submitted', body.failure))
+    return Result.fail(
+      invalidRequest({
+        operation: MutationOperation.Submit,
+        message: 'order intent cannot be submitted',
+        cause: body.failure,
+      }),
+    )
   }
   return Result.map(submitRequestHash(body.success), (requestHash) => ({
     intent,
@@ -364,7 +387,13 @@ export const cancelRequestHash = (brokerOrderId: string): string =>
 export const prepareCancel = (input: unknown): Result.Result<PreparedCancel, BrokerMutationError> => {
   const decoded = decodeOrderId(input)
   if (Result.isFailure(decoded)) {
-    return Result.fail(invalidRequest(MutationOperation.Cancel, 'invalid Alpaca order ID', decoded.failure))
+    return Result.fail(
+      invalidRequest({
+        operation: MutationOperation.Cancel,
+        message: 'invalid Alpaca order ID',
+        cause: decoded.failure,
+      }),
+    )
   }
   const brokerOrderId = decoded.success
   return Result.mapError(
@@ -372,7 +401,12 @@ export const prepareCancel = (input: unknown): Result.Result<PreparedCancel, Bro
       brokerOrderId,
       requestHash,
     })),
-    (cause) => invalidRequest(MutationOperation.Cancel, 'cancel request cannot be canonically hashed', cause),
+    (cause) =>
+      invalidRequest({
+        operation: MutationOperation.Cancel,
+        message: 'cancel request cannot be canonically hashed',
+        cause,
+      }),
   )
 }
 
@@ -385,45 +419,50 @@ const responseEvidence = (
 
 const canonicalSubmitResponseHash = (facts: SubmitResponseFacts): Result.Result<string, BrokerMutationError> =>
   Result.mapError(canonicalHashV1Result(facts.body), (cause) =>
-    unknownOutcome(
-      MutationOperation.Submit,
-      'Alpaca submit response cannot be canonically hashed',
-      facts.requestHash,
-      { status: facts.status, requestId: facts.requestId },
+    unknownOutcome({
+      operation: MutationOperation.Submit,
+      message: 'Alpaca submit response cannot be canonically hashed',
+      requestHash: facts.requestHash,
+      evidence: { status: facts.status, requestId: facts.requestId },
       cause,
-    ),
+    }),
   )
 
 const canonicalCancelResponseHash = (facts: CancelResponseFacts): Result.Result<string, BrokerMutationError> => {
   if (facts.status === 204) {
     return Result.mapError(canonicalHashV1Result(null), (cause) =>
-      unknownOutcome(
-        MutationOperation.Cancel,
-        'Alpaca cancel response cannot be canonically hashed',
-        facts.requestHash,
-        { status: facts.status, requestId: facts.requestId },
+      unknownOutcome({
+        operation: MutationOperation.Cancel,
+        message: 'Alpaca cancel response cannot be canonically hashed',
+        requestHash: facts.requestHash,
+        evidence: { status: facts.status, requestId: facts.requestId },
         cause,
-      ),
+      }),
     )
   }
   if (facts.body === undefined) {
     return Result.fail(
-      unknownOutcome(MutationOperation.Cancel, 'Alpaca cancel response body is missing', facts.requestHash, {
-        status: facts.status,
-        requestId: facts.requestId,
+      unknownOutcome({
+        operation: MutationOperation.Cancel,
+        message: 'Alpaca cancel response body is missing',
+        requestHash: facts.requestHash,
+        evidence: {
+          status: facts.status,
+          requestId: facts.requestId,
+        },
       }),
     )
   }
   const decoded = decodeJsonResponseBody(facts.body)
   const material = Result.isSuccess(decoded) ? decoded.success : facts.body
   return Result.mapError(canonicalHashV1Result(material), (cause) =>
-    unknownOutcome(
-      MutationOperation.Cancel,
-      'Alpaca cancel response cannot be canonically hashed',
-      facts.requestHash,
-      { status: facts.status, requestId: facts.requestId },
+    unknownOutcome({
+      operation: MutationOperation.Cancel,
+      message: 'Alpaca cancel response cannot be canonically hashed',
+      requestHash: facts.requestHash,
+      evidence: { status: facts.status, requestId: facts.requestId },
       cause,
-    ),
+    }),
   )
 }
 
@@ -433,13 +472,13 @@ const normalizeAcceptedOrder = (
   evidence: MutationEvidence,
 ): Result.Result<Order, BrokerMutationError> =>
   Result.mapError(normalizeOrderResult(raw, facts.intent.accountId, facts.observedAt), (cause) =>
-    unknownOutcome(
-      MutationOperation.Submit,
-      'Alpaca submit response violates the order contract',
-      facts.requestHash,
+    unknownOutcome({
+      operation: MutationOperation.Submit,
+      message: 'Alpaca submit response violates the order contract',
+      requestHash: facts.requestHash,
       evidence,
       cause,
-    ),
+    }),
   )
 
 const acceptedOrderMatches = (order: Order, facts: SubmitResponseFacts): boolean =>
@@ -469,38 +508,38 @@ export const classifySubmitResponse = (
     const failure = decodeErrorResponse(facts.body)
     if (Result.isFailure(failure)) {
       return Result.fail(
-        unknownOutcome(
-          MutationOperation.Submit,
-          'Alpaca submit error response is invalid',
-          facts.requestHash,
+        unknownOutcome({
+          operation: MutationOperation.Submit,
+          message: 'Alpaca submit error response is invalid',
+          requestHash: facts.requestHash,
           evidence,
-          failure.failure,
-        ),
+          cause: failure.failure,
+        }),
       )
     }
     if ([400, 401, 403, 404, 422].includes(facts.status)) {
       return Result.fail(knownRejection(facts.requestHash, evidence, failure.success.code, failure.success.message))
     }
     return Result.fail(
-      unknownOutcome(
-        MutationOperation.Submit,
-        `Alpaca submit returned ambiguous HTTP ${facts.status}`,
-        facts.requestHash,
+      unknownOutcome({
+        operation: MutationOperation.Submit,
+        message: `Alpaca submit returned ambiguous HTTP ${facts.status}`,
+        requestHash: facts.requestHash,
         evidence,
-      ),
+      }),
     )
   }
 
   const decoded = decodeOrder(facts.body)
   if (Result.isFailure(decoded)) {
     return Result.fail(
-      unknownOutcome(
-        MutationOperation.Submit,
-        'Alpaca submit response does not match the order schema',
-        facts.requestHash,
+      unknownOutcome({
+        operation: MutationOperation.Submit,
+        message: 'Alpaca submit response does not match the order schema',
+        requestHash: facts.requestHash,
         evidence,
-        decoded.failure,
-      ),
+        cause: decoded.failure,
+      }),
     )
   }
   const order = normalizeAcceptedOrder(decoded.success, facts, evidence)
@@ -520,11 +559,11 @@ export const classifyCancelResponse = (
   return facts.status === 204
     ? Result.succeed({ requestHash: facts.requestHash, brokerOrderId: facts.brokerOrderId, evidence })
     : Result.fail(
-        unknownOutcome(
-          MutationOperation.Cancel,
-          `Alpaca cancel returned HTTP ${facts.status}; order lookup is required`,
-          facts.requestHash,
+        unknownOutcome({
+          operation: MutationOperation.Cancel,
+          message: `Alpaca cancel returned HTTP ${facts.status}; order lookup is required`,
+          requestHash: facts.requestHash,
           evidence,
-        ),
+        }),
       )
 }

--- a/services/bayn/src/broker/alpaca-mutations/interpreter.ts
+++ b/services/bayn/src/broker/alpaca-mutations/interpreter.ts
@@ -41,15 +41,14 @@ const withDeadline = <A, E>(
     Effect.mapError((cause) =>
       cause instanceof BrokerMutationError
         ? cause
-        : unknownOutcome(
+        : unknownOutcome({
             operation,
-            Cause.isTimeoutError(cause)
+            message: Cause.isTimeoutError(cause)
               ? `Alpaca ${operation.toLowerCase()} exceeded its ${timeoutMs}ms deadline`
               : `Alpaca ${operation.toLowerCase()} outcome is unknown because no valid response was available`,
             requestHash,
-            undefined,
             cause,
-          ),
+          }),
     ),
   )
 
@@ -60,13 +59,13 @@ const responseHeaders = (
 ): Effect.Effect<{ readonly 'x-request-id': string }, BrokerMutationError> =>
   decodeHeaders(response).pipe(
     Effect.mapError((cause) =>
-      unknownOutcome(
+      unknownOutcome({
         operation,
-        `Alpaca ${operation.toLowerCase()} response headers are invalid`,
+        message: `Alpaca ${operation.toLowerCase()} response headers are invalid`,
         requestHash,
-        { status: response.status },
+        evidence: { status: response.status },
         cause,
-      ),
+      }),
     ),
   )
 
@@ -77,13 +76,13 @@ const readSubmitBody = (
 ): Effect.Effect<unknown, BrokerMutationError> =>
   response.json.pipe(
     Effect.mapError((cause) =>
-      unknownOutcome(
-        MutationOperation.Submit,
-        'Alpaca submit response body is not valid JSON',
+      unknownOutcome({
+        operation: MutationOperation.Submit,
+        message: 'Alpaca submit response body is not valid JSON',
         requestHash,
-        { status: response.status, requestId: headers['x-request-id'] },
+        evidence: { status: response.status, requestId: headers['x-request-id'] },
         cause,
-      ),
+      }),
     ),
   )
 
@@ -96,13 +95,13 @@ const readCancelBody = (
     ? Effect.as(Effect.void, undefined)
     : response.text.pipe(
         Effect.mapError((cause) =>
-          unknownOutcome(
-            MutationOperation.Cancel,
-            'Alpaca cancel response body could not be read',
+          unknownOutcome({
+            operation: MutationOperation.Cancel,
+            message: 'Alpaca cancel response body could not be read',
             requestHash,
-            { status: response.status, requestId: headers['x-request-id'] },
+            evidence: { status: response.status, requestId: headers['x-request-id'] },
             cause,
-          ),
+          }),
         ),
       )
 
@@ -127,7 +126,7 @@ const makeMutationDataFirst = (
           prepared.request,
         ).pipe(
           Effect.mapError((cause) =>
-            invalidRequest(MutationOperation.Submit, 'order request cannot be encoded', cause),
+            invalidRequest({ operation: MutationOperation.Submit, message: 'order request cannot be encoded', cause }),
           ),
         )
         return yield* withDeadline(

--- a/services/bayn/src/broker/alpaca-mutations/model.ts
+++ b/services/bayn/src/broker/alpaca-mutations/model.ts
@@ -91,39 +91,52 @@ export const causeSummary = (cause: unknown): Readonly<Record<string, string>> =
   return { tag: typeof cause }
 }
 
-export const configurationError = (message: string, cause?: unknown) =>
+export interface BrokerMutationConfigurationErrorInput {
+  readonly message: string
+  readonly cause?: unknown
+}
+
+export const configurationError = (input: BrokerMutationConfigurationErrorInput) =>
   new BrokerMutationError({
     operation: MutationOperation.Submit,
     failure: MutationFailure.Configuration,
     outcome: MutationOutcome.Known,
-    message,
-    ...(cause === undefined ? {} : { cause: causeSummary(cause) }),
+    message: input.message,
+    ...(input.cause === undefined ? {} : { cause: causeSummary(input.cause) }),
   })
 
-export const invalidRequest = (operation: MutationOperation, message: string, cause?: unknown) =>
+export interface BrokerMutationInvalidRequestInput {
+  readonly operation: MutationOperation
+  readonly message: string
+  readonly cause?: unknown
+}
+
+export const invalidRequest = (input: BrokerMutationInvalidRequestInput) =>
   new BrokerMutationError({
-    operation,
+    operation: input.operation,
     failure: MutationFailure.InvalidRequest,
     outcome: MutationOutcome.Known,
-    message,
-    ...(cause === undefined ? {} : { cause: causeSummary(cause) }),
+    message: input.message,
+    ...(input.cause === undefined ? {} : { cause: causeSummary(input.cause) }),
   })
 
-export const unknownOutcome = (
-  operation: MutationOperation,
-  message: string,
-  requestHash?: string,
-  evidence?: PartialMutationEvidence,
-  cause?: unknown,
-) =>
+export interface BrokerMutationUnknownOutcomeInput {
+  readonly operation: MutationOperation
+  readonly message: string
+  readonly requestHash?: string
+  readonly evidence?: PartialMutationEvidence
+  readonly cause?: unknown
+}
+
+export const unknownOutcome = (input: BrokerMutationUnknownOutcomeInput) =>
   new BrokerMutationError({
-    operation,
+    operation: input.operation,
     failure: MutationFailure.Unknown,
     outcome: MutationOutcome.Unknown,
-    message,
-    ...(requestHash === undefined ? {} : { requestHash }),
-    ...(evidence === undefined ? {} : { evidence }),
-    ...(cause === undefined ? {} : { cause: causeSummary(cause) }),
+    message: input.message,
+    ...(input.requestHash === undefined ? {} : { requestHash: input.requestHash }),
+    ...(input.evidence === undefined ? {} : { evidence: input.evidence }),
+    ...(input.cause === undefined ? {} : { cause: causeSummary(input.cause) }),
   })
 
 const knownRejectionDataFirst = (

--- a/services/bayn/src/broker/alpaca/failures.ts
+++ b/services/bayn/src/broker/alpaca/failures.ts
@@ -70,15 +70,20 @@ export class BrokerReadContractFailure extends Data.TaggedError('BrokerReadContr
   readonly actual?: string
 }> {}
 
-export const contractFailure = (
-  reason: BrokerReadContractFailureReason,
-  message: string,
-  facts: {
+export interface BrokerReadContractFailureInput {
+  readonly reason: BrokerReadContractFailureReason
+  readonly message: string
+  readonly facts?: {
     readonly field?: string
     readonly expected?: string
     readonly actual?: string
-  } = {},
-): BrokerReadContractFailure => new BrokerReadContractFailure({ reason, message, ...facts })
+  }
+}
+
+export const contractFailure = (input: BrokerReadContractFailureInput): BrokerReadContractFailure => {
+  const { facts = {}, ...failure } = input
+  return new BrokerReadContractFailure({ ...failure, ...facts })
+}
 
 interface ReadEvidenceLike {
   readonly status?: number
@@ -93,10 +98,13 @@ const redactDiagnostic = (value: string, sensitiveValues: readonly string[]): st
     value,
   )
 
-export const safeCause = (
-  cause: unknown,
-  sensitiveValues: readonly string[] = [],
-): Readonly<Record<string, string>> => {
+export interface SafeCauseInput {
+  readonly cause: unknown
+  readonly sensitiveValues?: readonly string[]
+}
+
+export const safeCause = (input: SafeCauseInput): Readonly<Record<string, string>> => {
+  const { cause, sensitiveValues = [] } = input
   if (cause instanceof BrokerReadContractFailure) {
     return {
       tag: cause._tag,
@@ -142,35 +150,39 @@ export const safeCause = (
   return { tag: typeof cause }
 }
 
-export const configurationError = (
-  operation: 'configuration' | 'proxy',
-  message: string,
-  cause?: unknown,
-): BrokerReadError =>
+export interface BrokerReadConfigurationErrorInput {
+  readonly operation: 'configuration' | 'proxy'
+  readonly message: string
+  readonly cause?: unknown
+}
+
+export const configurationError = (input: BrokerReadConfigurationErrorInput): BrokerReadError =>
   new BrokerReadError({
-    operation,
+    operation: input.operation,
     kind: BrokerReadErrorKind.Configuration,
-    message,
+    message: input.message,
     retryable: false,
-    cause: cause === undefined ? undefined : safeCause(cause),
+    cause: input.cause === undefined ? undefined : safeCause({ cause: input.cause }),
   })
 
-export const invalidResponse = (
-  operation: BrokerReadOperation,
-  message: string,
-  evidence?: ReadEvidenceLike,
-  cause?: unknown,
-): BrokerReadError =>
+export interface InvalidResponseInput {
+  readonly operation: BrokerReadOperation
+  readonly message: string
+  readonly evidence?: ReadEvidenceLike
+  readonly cause?: unknown
+}
+
+export const invalidResponse = (input: InvalidResponseInput): BrokerReadError =>
   new BrokerReadError({
-    operation,
+    operation: input.operation,
     kind: BrokerReadErrorKind.InvalidResponse,
-    message,
+    message: input.message,
     retryable: false,
-    ...(evidence?.status === undefined ? {} : { status: evidence.status }),
-    ...(evidence?.requestId === undefined ? {} : { requestId: evidence.requestId }),
-    ...(evidence?.contentHash === undefined ? {} : { contentHash: evidence.contentHash }),
-    ...(evidence?.observedAt === undefined ? {} : { observedAt: evidence.observedAt }),
-    ...(cause === undefined ? {} : { cause: safeCause(cause) }),
+    ...(input.evidence?.status === undefined ? {} : { status: input.evidence.status }),
+    ...(input.evidence?.requestId === undefined ? {} : { requestId: input.evidence.requestId }),
+    ...(input.evidence?.contentHash === undefined ? {} : { contentHash: input.evidence.contentHash }),
+    ...(input.evidence?.observedAt === undefined ? {} : { observedAt: input.evidence.observedAt }),
+    ...(input.cause === undefined ? {} : { cause: safeCause({ cause: input.cause }) }),
   })
 
 const invalidRequestDataFirst = (operation: BrokerReadOperation, message: string, cause: unknown): BrokerReadError =>
@@ -179,7 +191,7 @@ const invalidRequestDataFirst = (operation: BrokerReadOperation, message: string
     kind: BrokerReadErrorKind.InvalidRequest,
     message,
     retryable: false,
-    cause: safeCause(cause),
+    cause: safeCause({ cause }),
   })
 
 export const invalidRequest = Pipeable.dual(3, invalidRequestDataFirst)
@@ -194,7 +206,7 @@ const transportErrorDataFirst = (
     kind: BrokerReadErrorKind.Transport,
     message: `Alpaca ${operation} request failed before a response was available`,
     retryable: true,
-    cause: safeCause(cause, sensitiveValues),
+    cause: safeCause({ cause, sensitiveValues }),
   })
 
 export const transportError = Pipeable.dual(3, transportErrorDataFirst)
@@ -245,7 +257,7 @@ const timeoutErrorDataFirst = (
     kind: BrokerReadErrorKind.Timeout,
     message: `Alpaca ${operation} exceeded its ${timeoutMs}ms deadline`,
     retryable: true,
-    cause: safeCause(cause, sensitiveValues),
+    cause: safeCause({ cause, sensitiveValues }),
   })
 
 export const timeoutError = Pipeable.dual(4, timeoutErrorDataFirst)

--- a/services/bayn/src/broker/alpaca/http.ts
+++ b/services/bayn/src/broker/alpaca/http.ts
@@ -93,7 +93,12 @@ const normalizeRead = <A>(
   Effect.fromResult(result).pipe(
     Effect.map((value) => ({ value, evidence })),
     Effect.mapError((cause) =>
-      invalidResponse(operation, `Alpaca ${operation} response violates the Bayn read contract`, evidence, cause),
+      invalidResponse({
+        operation,
+        message: `Alpaca ${operation} response violates the Bayn read contract`,
+        evidence,
+        cause,
+      }),
     ),
   )
 
@@ -110,7 +115,8 @@ const makeProxyDispatcherDataFirst = (
       Effect.flatMap((url) =>
         Effect.try({
           try: () => dependencies.create(url),
-          catch: (cause) => configurationError('proxy', 'Alpaca proxy dispatcher acquisition failed', cause),
+          catch: (cause) =>
+            configurationError({ operation: 'proxy', message: 'Alpaca proxy dispatcher acquisition failed', cause }),
         }),
       ),
     ),
@@ -135,7 +141,7 @@ export const parseProxyUrl = (proxyUrl: string): Result.Result<URL, BrokerReadEr
             : cause.reason === 'CREDENTIALS_FORBIDDEN'
               ? 'Alpaca proxy credentials must not be embedded in the URL'
               : 'Alpaca proxy URL must contain only an origin'
-      return configurationError('proxy', message, cause)
+      return configurationError({ operation: 'proxy', message, cause })
     }),
   )
 
@@ -151,7 +157,8 @@ const makeVerifiedProxyDispatcher = (
   Effect.acquireRelease(
     Effect.try({
       try: () => dependencies.create(new URL(proxyUrl)),
-      catch: (cause) => configurationError('proxy', 'Alpaca proxy dispatcher acquisition failed', cause),
+      catch: (cause) =>
+        configurationError({ operation: 'proxy', message: 'Alpaca proxy dispatcher acquisition failed', cause }),
     }),
     (dispatcher) => Effect.promise(() => dependencies.destroy(dispatcher)),
   )
@@ -360,40 +367,40 @@ export const make = (connection: BrokerConnection): Effect.Effect<BrokerReadShap
           .pipe(Effect.mapError((cause) => transportError(operation, cause, sensitiveValues)))
         const headers = yield* decodeResponseHeaders(response).pipe(
           Effect.mapError((cause) =>
-            invalidResponse(
+            invalidResponse({
               operation,
-              `Alpaca ${operation} response headers are invalid`,
-              { status: response.status },
+              message: `Alpaca ${operation} response headers are invalid`,
+              evidence: { status: response.status },
               cause,
-            ),
+            }),
           ),
         )
         const raw = yield* response.json.pipe(
           Effect.mapError((cause) =>
-            invalidResponse(
+            invalidResponse({
               operation,
-              `Alpaca ${operation} response body is not valid JSON`,
-              { status: response.status, requestId: headers['x-request-id'] },
+              message: `Alpaca ${operation} response body is not valid JSON`,
+              evidence: { status: response.status, requestId: headers['x-request-id'] },
               cause,
-            ),
+            }),
           ),
         )
         const contentHash = yield* Effect.fromResult(
           Result.mapError(canonicalHashV1Result(raw), (failure) =>
-            contractFailure(
-              'CANONICAL_HASH',
-              `Alpaca ${operation} response cannot be canonically hashed: ${renderCanonicalJsonFailure(failure)}`,
-              { field: 'response.body', actual: failure.path },
-            ),
+            contractFailure({
+              reason: 'CANONICAL_HASH',
+              message: `Alpaca ${operation} response cannot be canonically hashed: ${renderCanonicalJsonFailure(failure)}`,
+              facts: { field: 'response.body', actual: failure.path },
+            }),
           ),
         ).pipe(
           Effect.mapError((cause) =>
-            invalidResponse(
+            invalidResponse({
               operation,
-              `Alpaca ${operation} response cannot be canonically hashed`,
-              { status: response.status, requestId: headers['x-request-id'] },
+              message: `Alpaca ${operation} response cannot be canonically hashed`,
+              evidence: { status: response.status, requestId: headers['x-request-id'] },
               cause,
-            ),
+            }),
           ),
         )
         const observedAt = yield* currentUtcInstant
@@ -401,19 +408,19 @@ export const make = (connection: BrokerConnection): Effect.Effect<BrokerReadShap
           responseEvidenceResult(headers, response.status, contentHash, observedAt),
         ).pipe(
           Effect.mapError((cause) =>
-            invalidResponse(
+            invalidResponse({
               operation,
-              `Alpaca ${operation} rate-limit metadata is invalid`,
-              { status: response.status, requestId: headers['x-request-id'], contentHash, observedAt },
+              message: `Alpaca ${operation} rate-limit metadata is invalid`,
+              evidence: { status: response.status, requestId: headers['x-request-id'], contentHash, observedAt },
               cause,
-            ),
+            }),
           ),
         )
 
         if (response.status < 200 || response.status >= 300) {
           const failure = yield* Effect.fromResult(decodeErrorResponse(raw)).pipe(
             Effect.mapError((cause) =>
-              invalidResponse(operation, `Alpaca ${operation} error response is invalid`, evidence, cause),
+              invalidResponse({ operation, message: `Alpaca ${operation} error response is invalid`, evidence, cause }),
             ),
           )
           return yield* statusError(
@@ -429,7 +436,12 @@ export const make = (connection: BrokerConnection): Effect.Effect<BrokerReadShap
 
         const value = yield* Effect.fromResult(decoder(raw)).pipe(
           Effect.mapError((cause) =>
-            invalidResponse(operation, `Alpaca ${operation} response body does not match its schema`, evidence, cause),
+            invalidResponse({
+              operation,
+              message: `Alpaca ${operation} response body does not match its schema`,
+              evidence,
+              cause,
+            }),
           ),
         )
         yield* Effect.annotateCurrentSpan({
@@ -596,12 +608,12 @@ export const make = (connection: BrokerConnection): Effect.Effect<BrokerReadShap
               }
             }),
             Effect.mapError((cause) =>
-              invalidResponse(
-                'fill-activities',
-                'Alpaca fill-activities response violates the Bayn read contract',
-                result.evidence,
+              invalidResponse({
+                operation: 'fill-activities',
+                message: 'Alpaca fill-activities response violates the Bayn read contract',
+                evidence: result.evidence,
                 cause,
-              ),
+              }),
             ),
           ),
         ),

--- a/services/bayn/src/broker/alpaca/normalizers.ts
+++ b/services/bayn/src/broker/alpaca/normalizers.ts
@@ -42,9 +42,13 @@ const decimalPattern = /^(?:0|[1-9][0-9]*)(?:\.[0-9]+)?$|^-[1-9][0-9]*(?:\.[0-9]
 
 const hashResult = (value: unknown, field: string): Result.Result<string, BrokerReadContractFailure> =>
   Result.mapError(canonicalHashV1Result(value), (failure) =>
-    contractFailure('CANONICAL_HASH', `${field} cannot be canonically hashed: ${renderCanonicalJsonFailure(failure)}`, {
-      field,
-      actual: failure.path,
+    contractFailure({
+      reason: 'CANONICAL_HASH',
+      message: `${field} cannot be canonically hashed: ${renderCanonicalJsonFailure(failure)}`,
+      facts: {
+        field,
+        actual: failure.path,
+      },
     }),
   )
 
@@ -55,7 +59,11 @@ const decimalToMicrosResultDataFirst = (
 ): Result.Result<string, BrokerReadContractFailure> => {
   if (!decimalPattern.test(value)) {
     return Result.fail(
-      contractFailure('DECIMAL_FORMAT', `${name} is not a canonical decimal`, { field: name, actual: value }),
+      contractFailure({
+        reason: 'DECIMAL_FORMAT',
+        message: `${name} is not a canonical decimal`,
+        facts: { field: name, actual: value },
+      }),
     )
   }
   const negative = value.startsWith('-')
@@ -65,22 +73,36 @@ const decimalToMicrosResultDataFirst = (
   const fraction = separator === -1 ? '' : absolute.slice(separator + 1)
   if (fraction.length > 6 && /[1-9]/.test(fraction.slice(6))) {
     return Result.fail(
-      contractFailure('DECIMAL_PRECISION', `${name} cannot be represented exactly as decimal micros`, {
-        field: name,
-        actual: value,
+      contractFailure({
+        reason: 'DECIMAL_PRECISION',
+        message: `${name} cannot be represented exactly as decimal micros`,
+        facts: {
+          field: name,
+          actual: value,
+        },
       }),
     )
   }
   const micros = BigInt(whole) * 1_000_000n + BigInt((fraction.slice(0, 6) + '000000').slice(0, 6))
   const result = negative ? -micros : micros
   if (!signed && result < 0n) {
-    return Result.fail(contractFailure('DECIMAL_SIGN', `${name} must be non-negative`, { field: name, actual: value }))
+    return Result.fail(
+      contractFailure({
+        reason: 'DECIMAL_SIGN',
+        message: `${name} must be non-negative`,
+        facts: { field: name, actual: value },
+      }),
+    )
   }
   if (signed ? result < I128_MIN || result > I128_MAX : result > U128_MAX) {
     return Result.fail(
-      contractFailure('DECIMAL_RANGE', `${name} exceeds the decimal micros range`, {
-        field: name,
-        actual: value,
+      contractFailure({
+        reason: 'DECIMAL_RANGE',
+        message: `${name} exceeds the decimal micros range`,
+        facts: {
+          field: name,
+          actual: value,
+        },
       }),
     )
   }
@@ -92,7 +114,13 @@ export const decimalToMicrosResult = Pipeable.dual(3, decimalToMicrosResultDataF
 const positiveMicrosResult = (value: string, name: string): Result.Result<string, BrokerReadContractFailure> =>
   Result.flatMap(decimalToMicrosResult(value, false, name), (micros) =>
     micros === '0'
-      ? Result.fail(contractFailure('DECIMAL_ZERO', `${name} must be positive`, { field: name, actual: value }))
+      ? Result.fail(
+          contractFailure({
+            reason: 'DECIMAL_ZERO',
+            message: `${name} must be positive`,
+            facts: { field: name, actual: value },
+          }),
+        )
       : Result.succeed(micros),
   )
 
@@ -111,15 +139,25 @@ const positionMicrosResult = (
   Result.flatMap(decimalToMicrosResult(value, true, name), (decoded) => {
     const parsed = BigInt(decoded)
     if (parsed === 0n) {
-      return Result.fail(contractFailure('DECIMAL_ZERO', `${name} must be non-zero`, { field: name, actual: value }))
+      return Result.fail(
+        contractFailure({
+          reason: 'DECIMAL_ZERO',
+          message: `${name} must be non-zero`,
+          facts: { field: name, actual: value },
+        }),
+      )
     }
     const magnitude = parsed < 0n ? -parsed : parsed
     const normalized = side === PositionSide.Short ? -magnitude : magnitude
     return normalized < I128_MIN || normalized > I128_MAX
       ? Result.fail(
-          contractFailure('DECIMAL_RANGE', `${name} exceeds the decimal micros range`, {
-            field: name,
-            actual: value,
+          contractFailure({
+            reason: 'DECIMAL_RANGE',
+            message: `${name} exceeds the decimal micros range`,
+            facts: {
+              field: name,
+              actual: value,
+            },
           }),
         )
       : Result.succeed(normalized.toString())
@@ -132,10 +170,14 @@ const normalizeAccountResultDataFirst = (
 ): Result.Result<Account, BrokerReadContractFailure> => {
   if (raw.id !== expectedAccountId) {
     return Result.fail(
-      contractFailure('ACCOUNT_BINDING', `credential resolved account ${raw.id}, expected ${expectedAccountId}`, {
-        field: 'account.id',
-        expected: expectedAccountId,
-        actual: raw.id,
+      contractFailure({
+        reason: 'ACCOUNT_BINDING',
+        message: `credential resolved account ${raw.id}, expected ${expectedAccountId}`,
+        facts: {
+          field: 'account.id',
+          expected: expectedAccountId,
+          actual: raw.id,
+        },
       }),
     )
   }
@@ -187,10 +229,14 @@ const normalizePositionResultDataFirst = (
 ): Result.Result<Position, BrokerReadContractFailure> => {
   if (raw.asset_class !== AssetClass.UsEquity) {
     return Result.fail(
-      contractFailure('ASSET_CLASS', `unsupported position asset class ${raw.asset_class}`, {
-        field: 'position.asset_class',
-        expected: AssetClass.UsEquity,
-        actual: raw.asset_class,
+      contractFailure({
+        reason: 'ASSET_CLASS',
+        message: `unsupported position asset class ${raw.asset_class}`,
+        facts: {
+          field: 'position.asset_class',
+          expected: AssetClass.UsEquity,
+          actual: raw.asset_class,
+        },
       }),
     )
   }
@@ -236,10 +282,14 @@ const normalizeAssetResultDataFirst = (
 ): Result.Result<AssetObservation, BrokerReadContractFailure> => {
   if (raw.symbol !== requestedSymbol) {
     return Result.fail(
-      contractFailure('ASSET_BINDING', `asset lookup returned symbol ${raw.symbol}, expected ${requestedSymbol}`, {
-        field: 'asset.symbol',
-        expected: requestedSymbol,
-        actual: raw.symbol,
+      contractFailure({
+        reason: 'ASSET_BINDING',
+        message: `asset lookup returned symbol ${raw.symbol}, expected ${requestedSymbol}`,
+        facts: {
+          field: 'asset.symbol',
+          expected: requestedSymbol,
+          actual: raw.symbol,
+        },
       }),
     )
   }
@@ -273,34 +323,49 @@ const normalizeOrderResultDataFirst = (
 ): Result.Result<Order, BrokerReadContractFailure> => {
   if (raw.asset_class !== AssetClass.UsEquity) {
     return Result.fail(
-      contractFailure('ASSET_CLASS', `unsupported order asset class ${raw.asset_class}`, {
-        field: 'order.asset_class',
-        expected: AssetClass.UsEquity,
-        actual: raw.asset_class,
+      contractFailure({
+        reason: 'ASSET_CLASS',
+        message: `unsupported order asset class ${raw.asset_class}`,
+        facts: {
+          field: 'order.asset_class',
+          expected: AssetClass.UsEquity,
+          actual: raw.asset_class,
+        },
       }),
     )
   }
   const assetClass = raw.asset_class
   if ((raw.qty === null) === (raw.notional === null)) {
-    return Result.fail(contractFailure('ORDER_SHAPE', 'order must contain exactly one of qty or notional'))
+    return Result.fail(
+      contractFailure({ reason: 'ORDER_SHAPE', message: 'order must contain exactly one of qty or notional' }),
+    )
   }
   if (raw.order_type !== undefined && raw.order_type !== raw.type) {
-    return Result.fail(contractFailure('ORDER_SHAPE', 'deprecated order_type does not match type'))
+    return Result.fail(contractFailure({ reason: 'ORDER_SHAPE', message: 'deprecated order_type does not match type' }))
   }
   if (raw.order_class === OrderClass.MultiLeg) {
-    return Result.fail(contractFailure('ORDER_SHAPE', 'multi-leg orders are outside the Bayn equity contract'))
+    return Result.fail(
+      contractFailure({ reason: 'ORDER_SHAPE', message: 'multi-leg orders are outside the Bayn equity contract' }),
+    )
   }
   if (raw.type === OrderType.Limit && raw.limit_price === null) {
-    return Result.fail(contractFailure('ORDER_SHAPE', 'limit order is missing limit_price'))
+    return Result.fail(contractFailure({ reason: 'ORDER_SHAPE', message: 'limit order is missing limit_price' }))
   }
   if (raw.type === OrderType.Stop && raw.stop_price === null) {
-    return Result.fail(contractFailure('ORDER_SHAPE', 'stop order is missing stop_price'))
+    return Result.fail(contractFailure({ reason: 'ORDER_SHAPE', message: 'stop order is missing stop_price' }))
   }
   if (raw.type === OrderType.StopLimit && (raw.limit_price === null || raw.stop_price === null)) {
-    return Result.fail(contractFailure('ORDER_SHAPE', 'stop-limit order is missing limit_price or stop_price'))
+    return Result.fail(
+      contractFailure({ reason: 'ORDER_SHAPE', message: 'stop-limit order is missing limit_price or stop_price' }),
+    )
   }
   if (raw.type === OrderType.TrailingStop && (raw.trail_price === null) === (raw.trail_percent === null)) {
-    return Result.fail(contractFailure('ORDER_SHAPE', 'trailing-stop order must contain exactly one trailing offset'))
+    return Result.fail(
+      contractFailure({
+        reason: 'ORDER_SHAPE',
+        message: 'trailing-stop order must contain exactly one trailing offset',
+      }),
+    )
   }
 
   return Result.gen(function* () {
@@ -309,7 +374,9 @@ const normalizeOrderResultDataFirst = (
       raw.notional === null ? undefined : yield* positiveMicrosResult(raw.notional, 'order notional')
     const filledQuantityMicros = yield* decimalToMicrosResult(raw.filled_qty, false, 'filled quantity')
     if (quantityMicros !== undefined && BigInt(filledQuantityMicros) > BigInt(quantityMicros)) {
-      return yield* Result.fail(contractFailure('ORDER_SHAPE', 'filled quantity exceeds order quantity'))
+      return yield* Result.fail(
+        contractFailure({ reason: 'ORDER_SHAPE', message: 'filled quantity exceeds order quantity' }),
+      )
     }
     const filledAveragePriceMicros = yield* optionalMicrosResult(raw.filled_avg_price, false, 'filled average price')
     const limitPriceMicros = yield* optionalMicrosResult(raw.limit_price, false, 'limit price')
@@ -372,11 +439,11 @@ const normalizeFillActivityResultDataFirst = (
 ): Result.Result<FillActivity, BrokerReadContractFailure> => {
   if (raw.account_id !== undefined && raw.account_id !== accountId) {
     return Result.fail(
-      contractFailure(
-        'FILL_ACCOUNT_BINDING',
-        `fill activity resolved account ${raw.account_id}, expected ${accountId}`,
-        { field: 'fill.account_id', expected: accountId, actual: raw.account_id },
-      ),
+      contractFailure({
+        reason: 'FILL_ACCOUNT_BINDING',
+        message: `fill activity resolved account ${raw.account_id}, expected ${accountId}`,
+        facts: { field: 'fill.account_id', expected: accountId, actual: raw.account_id },
+      }),
     )
   }
   return Result.gen(function* () {
@@ -386,7 +453,10 @@ const normalizeFillActivityResultDataFirst = (
     const quantityMicros = yield* positiveMicrosResult(raw.qty, 'fill quantity')
     if (BigInt(cumulativeQuantityMicros) < BigInt(quantityMicros)) {
       return yield* Result.fail(
-        contractFailure('FILL_SHAPE', 'cumulative fill quantity is smaller than this fill quantity'),
+        contractFailure({
+          reason: 'FILL_SHAPE',
+          message: 'cumulative fill quantity is smaller than this fill quantity',
+        }),
       )
     }
     if (
@@ -394,7 +464,10 @@ const normalizeFillActivityResultDataFirst = (
       (raw.type === TradeActivityType.PartialFill && leavesQuantityMicros === '0')
     ) {
       return yield* Result.fail(
-        contractFailure('FILL_SHAPE', `fill activity type ${raw.type} is inconsistent with leaves quantity`),
+        contractFailure({
+          reason: 'FILL_SHAPE',
+          message: `fill activity type ${raw.type} is inconsistent with leaves quantity`,
+        }),
       )
     }
     return {
@@ -447,11 +520,11 @@ const marketCalendarInstantResult = (
   )
   return zoned._tag === 'None'
     ? Result.fail(
-        contractFailure(
-          'CALENDAR_INSTANT',
-          `market calendar ${field} is not a valid ${marketCalendarTimeZone} wall-clock instant`,
-          { field: `calendar.${field}`, actual: `${date} ${time}` },
-        ),
+        contractFailure({
+          reason: 'CALENDAR_INSTANT',
+          message: `market calendar ${field} is not a valid ${marketCalendarTimeZone} wall-clock instant`,
+          facts: { field: `calendar.${field}`, actual: `${date} ${time}` },
+        }),
       )
     : Result.succeed(DateTime.formatIso(zoned.value))
 }
@@ -465,11 +538,11 @@ const normalizeMarketCalendarResultDataFirst = (
       raw.map((session): Result.Result<MarketCalendarSession, BrokerReadContractFailure> => {
         if (session.date < query.start || session.date > query.end) {
           return Result.fail(
-            contractFailure(
-              'CALENDAR_RANGE',
-              `market calendar session ${session.date} is outside the requested range`,
-              { field: 'calendar.date', expected: `${query.start}..${query.end}`, actual: session.date },
-            ),
+            contractFailure({
+              reason: 'CALENDAR_RANGE',
+              message: `market calendar session ${session.date} is outside the requested range`,
+              facts: { field: 'calendar.date', expected: `${query.start}..${query.end}`, actual: session.date },
+            }),
           )
         }
         return Result.gen(function* () {
@@ -477,9 +550,13 @@ const normalizeMarketCalendarResultDataFirst = (
           const closeAt = yield* marketCalendarInstantResult(session.date, session.close, 'close')
           if (openAt >= closeAt) {
             return yield* Result.fail(
-              contractFailure('CALENDAR_HOURS', `market calendar session ${session.date} has invalid hours`, {
-                field: 'calendar.hours',
-                actual: `${openAt}..${closeAt}`,
+              contractFailure({
+                reason: 'CALENDAR_HOURS',
+                message: `market calendar session ${session.date} has invalid hours`,
+                facts: {
+                  field: 'calendar.hours',
+                  actual: `${openAt}..${closeAt}`,
+                },
               }),
             )
           }
@@ -491,7 +568,10 @@ const normalizeMarketCalendarResultDataFirst = (
     for (let index = 1; index < sessions.length; index += 1) {
       if (sessions[index - 1]?.date === sessions[index]?.date) {
         return yield* Result.fail(
-          contractFailure('CALENDAR_DUPLICATE', `market calendar contains duplicate session ${sessions[index]?.date}`),
+          contractFailure({
+            reason: 'CALENDAR_DUPLICATE',
+            message: `market calendar contains duplicate session ${sessions[index]?.date}`,
+          }),
         )
       }
     }

--- a/services/bayn/src/broker/alpaca/preflight.ts
+++ b/services/bayn/src/broker/alpaca/preflight.ts
@@ -99,9 +99,13 @@ const permissionFailure = (
 
 const proofHashResult = (value: unknown, field: string): Result.Result<string, BrokerReadContractFailure> =>
   Result.mapError(canonicalHashV1Result(value), (failure) =>
-    contractFailure('CANONICAL_HASH', `${field} is not canonical JSON: ${renderCanonicalJsonFailure(failure)}`, {
-      field,
-      actual: failure.path,
+    contractFailure({
+      reason: 'CANONICAL_HASH',
+      message: `${field} is not canonical JSON: ${renderCanonicalJsonFailure(failure)}`,
+      facts: {
+        field,
+        actual: failure.path,
+      },
     }),
   )
 
@@ -115,12 +119,12 @@ const expectNotFound = (
         error.kind === BrokerReadErrorKind.NotFound ? Effect.succeed('NOT_FOUND' as const) : Effect.fail(error),
       onSuccess: (result) =>
         Effect.fail(
-          invalidResponse(
+          invalidResponse({
             operation,
-            `Alpaca ${operation} unexpectedly resolved the observe-only proof identity`,
-            result.evidence,
-            result.value,
-          ),
+            message: `Alpaca ${operation} unexpectedly resolved the observe-only proof identity`,
+            evidence: result.evidence,
+            cause: result.value,
+          }),
         ),
     }),
   )
@@ -135,12 +139,12 @@ const verifyOrderLookup = (
       result.value.brokerOrderId === expected.brokerOrderId && result.value.clientOrderId === expected.clientOrderId
         ? Effect.succeed('MATCHED' as const)
         : Effect.fail(
-            invalidResponse(
+            invalidResponse({
               operation,
-              `Alpaca ${operation} returned a different order during observe-only preflight`,
-              result.evidence,
-              result.value,
-            ),
+              message: `Alpaca ${operation} returned a different order during observe-only preflight`,
+              evidence: result.evidence,
+              cause: result.value,
+            }),
           ),
     ),
   )
@@ -223,7 +227,7 @@ const verifyReadAccessDataFirst = (
             kind: BrokerReadErrorKind.InvalidResponse,
             message: 'Alpaca observe-only preflight data is not canonical JSON',
             retryable: false,
-            cause: safeCause(cause),
+            cause: safeCause({ cause }),
           }),
       ),
     )

--- a/services/bayn/src/broker/alpaca/requests.ts
+++ b/services/bayn/src/broker/alpaca/requests.ts
@@ -119,10 +119,14 @@ const responseEvidenceResultDataFirst = (
   const remaining = headers['x-ratelimit-remaining']
   if (limit !== undefined && remaining !== undefined && BigInt(remaining) > BigInt(limit)) {
     return Result.fail(
-      contractFailure('RATE_LIMIT', 'rate-limit remaining exceeds limit', {
-        field: 'x-ratelimit-remaining',
-        expected: `<=${limit}`,
-        actual: remaining,
+      contractFailure({
+        reason: 'RATE_LIMIT',
+        message: 'rate-limit remaining exceeds limit',
+        facts: {
+          field: 'x-ratelimit-remaining',
+          expected: `<=${limit}`,
+          actual: remaining,
+        },
       }),
     )
   }

--- a/services/bayn/src/db/cycle-store/binding-program.ts
+++ b/services/bayn/src/db/cycle-store/binding-program.ts
@@ -114,12 +114,12 @@ const makeCycleBindingProgramsDataFirst = (
     ensureSnapshotReference(sql, inputManifest).pipe(
       Effect.catchTag(snapshotReferenceIssueTags, (cause) =>
         Effect.fail(
-          cycleStoreError(
-            'bind-snapshot',
-            'conflict',
-            `stored snapshot reference diverged from the finalized Signal publication: ${renderSnapshotReferenceIssue(cause)}`,
+          cycleStoreError({
+            operation: 'bind-snapshot',
+            failure: 'conflict',
+            message: `stored snapshot reference diverged from the finalized Signal publication: ${renderSnapshotReferenceIssue(cause)}`,
             cause,
-          ),
+          }),
         ),
       ),
     )

--- a/services/bayn/src/db/cycle-store/model.ts
+++ b/services/bayn/src/db/cycle-store/model.ts
@@ -109,20 +109,24 @@ const defaultPersistenceFailure = (
   }
 }
 
-export const cycleStoreError = (
-  operation: CycleStoreError['operation'],
-  failure: CycleStoreError['failure'],
-  message: string,
-  cause?: unknown,
-  persistenceFailure = defaultPersistenceFailure(failure),
-): CycleStoreError =>
-  new CycleStoreError({
+export interface CycleStoreErrorInput {
+  readonly operation: CycleStoreError['operation']
+  readonly failure: CycleStoreError['failure']
+  readonly message: string
+  readonly cause?: unknown
+  readonly persistenceFailure?: NonNullable<CycleStoreError['persistenceFailure']>
+}
+
+export const cycleStoreError = (input: CycleStoreErrorInput): CycleStoreError => {
+  const { operation, failure, message, cause, persistenceFailure = defaultPersistenceFailure(failure) } = input
+  return new CycleStoreError({
     operation,
     failure,
     persistenceFailure,
     message: cause === undefined ? message : `${message}: ${messageOf(cause)}`,
     cause,
   })
+}
 
 const runCycleStoreDataFirst = <A, E, R>(
   operation: CycleStoreError['operation'],
@@ -132,7 +136,12 @@ const runCycleStoreDataFirst = <A, E, R>(
     Effect.mapError((cause) => {
       if (cause instanceof CycleStoreError) return cause
       if (Schema.isSchemaError(cause)) {
-        return cycleStoreError(operation, 'decode', 'autonomous cycle contract decoding failed', cause)
+        return cycleStoreError({
+          operation,
+          failure: 'decode',
+          message: 'autonomous cycle contract decoding failed',
+          cause,
+        })
       }
       if (isSqlError(cause)) {
         const failure =
@@ -156,15 +165,20 @@ const runCycleStoreDataFirst = <A, E, R>(
               return 'query'
           }
         })()
-        return cycleStoreError(
+        return cycleStoreError({
           operation,
           failure,
-          'autonomous cycle PostgreSQL operation failed',
+          message: 'autonomous cycle PostgreSQL operation failed',
           cause,
           persistenceFailure,
-        )
+        })
       }
-      return cycleStoreError(operation, 'invariant', 'autonomous cycle operation failed unexpectedly', cause)
+      return cycleStoreError({
+        operation,
+        failure: 'invariant',
+        message: 'autonomous cycle operation failed unexpectedly',
+        cause,
+      })
     }),
   )
 
@@ -179,7 +193,7 @@ const failCycleStoreDataFirst = (
   operation: CycleStoreError['operation'],
   failure: CycleStoreError['failure'],
   message: string,
-): Effect.Effect<never, CycleStoreError> => Effect.fail(cycleStoreError(operation, failure, message))
+): Effect.Effect<never, CycleStoreError> => Effect.fail(cycleStoreError({ operation, failure, message }))
 
 export const failCycleStore = Pipeable.dual(3, failCycleStoreDataFirst)
 
@@ -188,7 +202,7 @@ const liftCycleDecisionDataFirst = <A>(
   decision: Result.Result<A, CycleStoreDecisionFailure>,
 ): Effect.Effect<A, CycleStoreError> =>
   Effect.fromResult(decision).pipe(
-    Effect.mapError(({ failure, message }) => cycleStoreError(operation, failure, message)),
+    Effect.mapError(({ failure, message }) => cycleStoreError({ operation, failure, message })),
   )
 
 export const liftCycleDecision = Pipeable.generic<

--- a/services/bayn/src/db/evidence-store/bootstrap.ts
+++ b/services/bayn/src/db/evidence-store/bootstrap.ts
@@ -27,7 +27,12 @@ export const PostgresClientLive = (config: Pick<RuntimeConfig, 'operationTimeout
   return Layer.unwrap(
     readCertificate.pipe(
       Effect.mapError((cause) =>
-        databaseError('unavailable', 'tls', 'failed to read PostgreSQL CA certificate', cause),
+        databaseError({
+          failure: 'unavailable',
+          operation: 'tls',
+          message: 'failed to read PostgreSQL CA certificate',
+          cause,
+        }),
       ),
       Effect.map((ca) =>
         PgClient.layerFrom(
@@ -57,7 +62,11 @@ const migrate = Effect.gen(function* () {
     `,
   )
   if (boundary.legacy_exists) {
-    return yield* databaseError('migration', 'migrate', 'legacy migration tracker is unsupported after the hard cut')
+    return yield* databaseError({
+      failure: 'migration',
+      operation: 'migrate',
+      message: 'legacy migration tracker is unsupported after the hard cut',
+    })
   }
   if (boundary.current_exists) {
     const identities = yield* decodeMigrationIdentities(
@@ -65,7 +74,11 @@ const migrate = Effect.gen(function* () {
     )
     const [initial] = identities
     if (identities.length !== 1 || initial?.name !== 'initial_schema') {
-      return yield* databaseError('migration', 'migrate', 'legacy migration history is unsupported after the hard cut')
+      return yield* databaseError({
+        failure: 'migration',
+        operation: 'migrate',
+        message: 'legacy migration history is unsupported after the hard cut',
+      })
     }
   }
   yield* PgMigrator.run({ loader: migrationLoader, table: 'schema_migrations' })
@@ -77,7 +90,7 @@ const migrations = migrate.pipe(
       ? cause
       : isSqlError(cause)
         ? classifyDatabaseError('migrate', cause)
-        : databaseError('migration', 'migrate', 'PostgreSQL migration failed', cause),
+        : databaseError({ failure: 'migration', operation: 'migrate', message: 'PostgreSQL migration failed', cause }),
   ),
   Effect.asVoid,
 )
@@ -91,7 +104,11 @@ const withMigrationDeadline = <R>(
       duration: operationTimeoutMs,
       orElse: () =>
         Effect.fail(
-          databaseError('migration', 'migrate', `PostgreSQL migration timed out after ${operationTimeoutMs}ms`),
+          databaseError({
+            failure: 'migration',
+            operation: 'migrate',
+            message: `PostgreSQL migration timed out after ${operationTimeoutMs}ms`,
+          }),
         ),
     }),
   )

--- a/services/bayn/src/db/evidence-store/errors.ts
+++ b/services/bayn/src/db/evidence-store/errors.ts
@@ -59,35 +59,40 @@ const defaultPersistenceFailure = (failure: DatabaseFailure): PersistenceFailure
   }
 }
 
-export const databaseError = (
-  failure: DatabaseFailure,
-  operation: string,
-  message: string,
-  cause?: unknown,
-  persistenceFailure = defaultPersistenceFailure(failure),
-): DatabaseError =>
-  new DatabaseError({
+export interface DatabaseErrorInput {
+  readonly failure: DatabaseFailure
+  readonly operation: string
+  readonly message: string
+  readonly cause?: unknown
+  readonly persistenceFailure?: PersistenceFailure
+}
+
+export const databaseError = (input: DatabaseErrorInput): DatabaseError => {
+  const { failure, operation, message, cause, persistenceFailure = defaultPersistenceFailure(failure) } = input
+  return new DatabaseError({
     failure,
     persistenceFailure,
     operation,
     message: cause === undefined ? message : `${message}: ${messageOf(cause)}`,
     cause,
   })
+}
 
 const classifyDatabaseErrorDataFirst = (operation: string, cause: unknown): DatabaseError => {
   if (cause instanceof DatabaseError) return cause
-  if (Schema.isSchemaError(cause)) return databaseError('decode', operation, 'database row decoding failed', cause)
+  if (Schema.isSchemaError(cause))
+    return databaseError({ failure: 'decode', operation, message: 'database row decoding failed', cause })
   if (isSqlError(cause)) {
     const classified = classifySqlReason(cause.reason)
-    return databaseError(
-      classified.failure,
+    return databaseError({
+      failure: classified.failure,
       operation,
-      'PostgreSQL operation failed',
+      message: 'PostgreSQL operation failed',
       cause,
-      classified.persistenceFailure,
-    )
+      persistenceFailure: classified.persistenceFailure,
+    })
   }
-  return databaseError('invariant', operation, 'unexpected database result', cause)
+  return databaseError({ failure: 'invariant', operation, message: 'unexpected database result', cause })
 }
 
 export const classifyDatabaseError = Pipeable.dual(2, classifyDatabaseErrorDataFirst)
@@ -104,40 +109,47 @@ export const runDatabase = Pipeable.generic<
 >(2, runDatabaseDataFirst)
 
 const ensureDataFirst = (condition: boolean, operation: string, message: string): Effect.Effect<void, DatabaseError> =>
-  condition ? Effect.void : Effect.fail(databaseError('invariant', operation, message))
+  condition ? Effect.void : Effect.fail(databaseError({ failure: 'invariant', operation, message }))
 
 export const ensure = Pipeable.dual(3, ensureDataFirst)
 
 const persistencePlanDatabaseErrorDataFirst = (operation: string, failure: PersistencePlanFailure): DatabaseError =>
-  databaseError(
-    'invariant',
+  databaseError({
+    failure: 'invariant',
     operation,
-    renderPersistencePlanFailure(failure),
-    failure._tag === 'SimulationReconciliationFailed' ? failure.issues : failure,
-  )
+    message: renderPersistencePlanFailure(failure),
+    cause: failure._tag === 'SimulationReconciliationFailed' ? failure.issues : failure,
+  })
 
 export const persistencePlanDatabaseError = Pipeable.dual(2, persistencePlanDatabaseErrorDataFirst)
 
 const qualificationDecisionDatabaseErrorDataFirst = (
   operation: string,
   failure: QualificationDecisionFailure,
-): DatabaseError => databaseError('invariant', operation, renderQualificationDecisionFailure(failure), failure)
+): DatabaseError =>
+  databaseError({
+    failure: 'invariant',
+    operation,
+    message: renderQualificationDecisionFailure(failure),
+    cause: failure,
+  })
 
 export const qualificationDecisionDatabaseError = Pipeable.dual(2, qualificationDecisionDatabaseErrorDataFirst)
 
 const storedQualificationDatabaseErrorDataFirst = (
   operation: string,
   failure: StoredQualificationFailure,
-): DatabaseError => databaseError('invariant', operation, renderStoredQualificationFailure(failure), failure)
+): DatabaseError =>
+  databaseError({ failure: 'invariant', operation, message: renderStoredQualificationFailure(failure), cause: failure })
 
 export const storedQualificationDatabaseError = Pipeable.dual(2, storedQualificationDatabaseErrorDataFirst)
 
 const evidenceRecoveryDatabaseErrorDataFirst = (operation: string, issue: EvidenceRecoveryIssue): DatabaseError =>
-  databaseError(
-    issue._tag === 'DecodeFailure' ? 'decode' : 'invariant',
+  databaseError({
+    failure: issue._tag === 'DecodeFailure' ? 'decode' : 'invariant',
     operation,
-    renderEvidenceRecoveryIssue(issue),
-    issue._tag === 'SimulationFailure' ? issue.issues : issue,
-  )
+    message: renderEvidenceRecoveryIssue(issue),
+    cause: issue._tag === 'SimulationFailure' ? issue.issues : issue,
+  })
 
 export const evidenceRecoveryDatabaseError = Pipeable.dual(2, evidenceRecoveryDatabaseErrorDataFirst)

--- a/services/bayn/src/db/evidence-store/persist-program.ts
+++ b/services/bayn/src/db/evidence-store/persist-program.ts
@@ -45,7 +45,11 @@ const makeEvidencePersistenceProgramDataFirst = (
             )
             if (plan.qualification !== undefined) {
               if (Option.isNone(storedQualification)) {
-                return yield* databaseError('invariant', 'persist-qualification', 'qualification lock was not opened')
+                return yield* databaseError({
+                  failure: 'invariant',
+                  operation: 'persist-qualification',
+                  message: 'qualification lock was not opened',
+                })
               }
               yield* ensure(
                 storedQualification.value.state === 'OPENED_INCOMPLETE',
@@ -86,11 +90,11 @@ const makeEvidencePersistenceProgramDataFirst = (
             })
             if (inserted.length === 0) {
               if (plan.qualification !== undefined) {
-                return yield* databaseError(
-                  'invariant',
-                  'persist-qualification',
-                  'locked qualification candidate was already evaluated without a terminal result',
-                )
+                return yield* databaseError({
+                  failure: 'invariant',
+                  operation: 'persist-qualification',
+                  message: 'locked qualification candidate was already evaluated without a terminal result',
+                })
               }
               return yield* references.readReceipt(plan, true)
             }

--- a/services/bayn/src/db/evidence-store/qualification-program.ts
+++ b/services/bayn/src/db/evidence-store/qualification-program.ts
@@ -53,7 +53,12 @@ const makeQualificationProgramsDataFirst = (
       Effect.gen(function* () {
         const plan = yield* Effect.fromResult(validateQualificationOpenInput(input)).pipe(
           Effect.mapError((cause) =>
-            databaseError('invariant', 'open-qualification', renderQualificationDecisionFailure(cause), cause),
+            databaseError({
+              failure: 'invariant',
+              operation: 'open-qualification',
+              message: renderQualificationDecisionFailure(cause),
+              cause,
+            }),
           ),
         )
         const lock = plan.lock
@@ -122,11 +127,11 @@ const makeQualificationProgramsDataFirst = (
               Effect.mapError((failure) => storedQualificationDatabaseError('open-qualification', failure)),
             )
             if (Option.isNone(stored)) {
-              return yield* databaseError(
-                'invariant',
-                'open-qualification',
-                'conflicting qualification lock is missing',
-              )
+              return yield* databaseError({
+                failure: 'invariant',
+                operation: 'open-qualification',
+                message: 'conflicting qualification lock is missing',
+              })
             }
             yield* Effect.fromResult(validateQualificationLockMatch(stored.value.lock, lock)).pipe(
               Effect.mapError((failure) => qualificationDecisionDatabaseError('open-qualification', failure)),

--- a/services/bayn/src/db/evidence-store/read-program.ts
+++ b/services/bayn/src/db/evidence-store/read-program.ts
@@ -21,12 +21,12 @@ import type { EvidenceReferencePrograms } from './reference-programs'
 import { Pipeable } from '../../pipeable'
 
 const readInputDatabaseError = (operation: string, cause: EvidenceReadInputFailure) =>
-  databaseError(
-    cause._tag === 'InvalidRunId' ? 'decode' : 'invariant',
+  databaseError({
+    failure: cause._tag === 'InvalidRunId' ? 'decode' : 'invariant',
     operation,
-    renderEvidenceReadInputFailure(cause),
+    message: renderEvidenceReadInputFailure(cause),
     cause,
-  )
+  })
 
 export interface EvidenceReadPrograms {
   readonly read: EvidenceStoreService['read']
@@ -69,7 +69,11 @@ const makeEvidenceReadProgramsDataFirst = (
             yield* ensure(metadata.length === 1, 'read-artifact-items', 'artifact series metadata is duplicated')
             const [series] = metadata
             if (series === undefined) {
-              return yield* databaseError('invariant', 'read-artifact-items', 'artifact series metadata disappeared')
+              return yield* databaseError({
+                failure: 'invariant',
+                operation: 'read-artifact-items',
+                message: 'artifact series metadata disappeared',
+              })
             }
             const rows = yield* statements.getArtifactItems({ runId, artifactName, afterOrdinal, limit })
             yield* ensure(

--- a/services/bayn/src/db/evidence-store/reference-programs.ts
+++ b/services/bayn/src/db/evidence-store/reference-programs.ts
@@ -67,7 +67,14 @@ const makeEvidenceReferenceProgramsDataFirst = (
   const ensureSnapshotReference: EvidenceReferencePrograms['ensureSnapshotReference'] = (inputManifest) =>
     ensureSnapshotReferenceRow(sql, inputManifest).pipe(
       Effect.catchTag(snapshotReferenceIssueTags, (cause) =>
-        Effect.fail(databaseError('invariant', 'snapshot-reference', renderSnapshotReferenceIssue(cause), cause)),
+        Effect.fail(
+          databaseError({
+            failure: 'invariant',
+            operation: 'snapshot-reference',
+            message: renderSnapshotReferenceIssue(cause),
+            cause,
+          }),
+        ),
       ),
     )
 

--- a/services/bayn/src/db/execution-store/accounting.ts
+++ b/services/bayn/src/db/execution-store/accounting.ts
@@ -186,12 +186,12 @@ const makeAccountingInterpreterDataFirst = (
           ).pipe(
             Effect.fromResult,
             Effect.mapError((cause) =>
-              executionStoreError(
-                'account',
-                'invariant',
-                `fill accounting plan is invalid: ${renderAccountingFailure(cause)}`,
+              executionStoreError({
+                operation: 'account',
+                failure: 'invariant',
+                message: `fill accounting plan is invalid: ${renderAccountingFailure(cause)}`,
                 cause,
-              ),
+              }),
             ),
           )
           const replay = yield* liftStoreDecision('account', decidePreparedAccountingReplay(stored, expected))
@@ -264,13 +264,16 @@ const makeAccountingInterpreterDataFirst = (
       decodeFillInput(input).pipe(
         Effect.flatMap(prepare),
         Effect.tap((prepared) =>
-          journal
-            .post(prepared.ledger)
-            .pipe(
-              Effect.mapError((cause) =>
-                executionStoreError('account', 'ledger', 'TigerBeetle accounting post failed', cause),
-              ),
+          journal.post(prepared.ledger).pipe(
+            Effect.mapError((cause) =>
+              executionStoreError({
+                operation: 'account',
+                failure: 'ledger',
+                message: 'TigerBeetle accounting post failed',
+                cause,
+              }),
             ),
+          ),
         ),
         Effect.flatMap(recordReceipt),
       ),

--- a/services/bayn/src/db/execution-store/errors.ts
+++ b/services/bayn/src/db/execution-store/errors.ts
@@ -9,24 +9,26 @@ import { Pipeable } from '../../pipeable'
 
 const messageOf = (cause: unknown): string => (cause instanceof Error ? cause.message : String(cause))
 
-export const executionStoreError = (
-  operation: ExecutionStoreError['operation'],
-  failure: ExecutionStoreError['failure'],
-  message: string,
-  cause?: unknown,
-): ExecutionStoreError =>
+export interface ExecutionStoreErrorInput {
+  readonly operation: ExecutionStoreError['operation']
+  readonly failure: ExecutionStoreError['failure']
+  readonly message: string
+  readonly cause?: unknown
+}
+
+export const executionStoreError = (input: ExecutionStoreErrorInput): ExecutionStoreError =>
   new ExecutionStoreError({
-    operation,
-    failure,
-    message: cause === undefined ? message : `${message}: ${messageOf(cause)}`,
-    cause,
+    operation: input.operation,
+    failure: input.failure,
+    message: input.cause === undefined ? input.message : `${input.message}: ${messageOf(input.cause)}`,
+    cause: input.cause,
   })
 
 const failExecutionStoreDataFirst = (
   operation: ExecutionStoreError['operation'],
   failure: ExecutionStoreError['failure'],
   message: string,
-): Effect.Effect<never, ExecutionStoreError> => Effect.fail(executionStoreError(operation, failure, message))
+): Effect.Effect<never, ExecutionStoreError> => Effect.fail(executionStoreError({ operation, failure, message }))
 
 export const failExecutionStore = Pipeable.dual(3, failExecutionStoreDataFirst)
 
@@ -38,28 +40,39 @@ const runExecutionOperationDataFirst = <A, E, R>(
     Effect.mapError((cause) => {
       if (cause instanceof ExecutionStoreError) return cause
       if (cause instanceof ReconciliationStoreError) {
-        return executionStoreError(
+        return executionStoreError({
           operation,
-          cause.failure === 'ledger'
-            ? 'ledger'
-            : cause.failure === 'decode'
-              ? 'decode'
-              : cause.failure === 'invariant'
-                ? 'invariant'
-                : 'query',
-          'paper reconciliation operation failed',
+          failure:
+            cause.failure === 'ledger'
+              ? 'ledger'
+              : cause.failure === 'decode'
+                ? 'decode'
+                : cause.failure === 'invariant'
+                  ? 'invariant'
+                  : 'query',
+          message: 'paper reconciliation operation failed',
           cause,
-        )
+        })
       }
       if (Schema.isSchemaError(cause)) {
-        return executionStoreError(operation, 'decode', 'paper store contract decoding failed', cause)
+        return executionStoreError({
+          operation,
+          failure: 'decode',
+          message: 'paper store contract decoding failed',
+          cause,
+        })
       }
       if (isSqlError(cause)) {
         const failure =
           cause.reason._tag === 'ConstraintError' || cause.reason._tag === 'UniqueViolation' ? 'conflict' : 'query'
-        return executionStoreError(operation, failure, 'paper store PostgreSQL operation failed', cause)
+        return executionStoreError({ operation, failure, message: 'paper store PostgreSQL operation failed', cause })
       }
-      return executionStoreError(operation, 'invariant', 'paper store operation failed unexpectedly', cause)
+      return executionStoreError({
+        operation,
+        failure: 'invariant',
+        message: 'paper store operation failed unexpectedly',
+        cause,
+      })
     }),
   )
 
@@ -75,7 +88,9 @@ const liftStoreDecisionDataFirst = <A>(
   decision: Result.Result<A, ExecutionStoreDecisionFailure>,
 ): Effect.Effect<A, ExecutionStoreError> =>
   Effect.fromResult(decision).pipe(
-    Effect.mapError((failure) => executionStoreError(operation, failure.failure, failure.message, failure.cause)),
+    Effect.mapError((failure) =>
+      executionStoreError({ operation, failure: failure.failure, message: failure.message, cause: failure.cause }),
+    ),
   )
 
 export const liftStoreDecision = Pipeable.generic<
@@ -91,6 +106,11 @@ export const liftAuthorityDecision = <A>(
   Effect.fromResult(decision).pipe(
     Effect.mapError((failure) => {
       const details = capitalGrantFailureDetails(failure)
-      return executionStoreError('authority', details.failure, details.message, details.cause)
+      return executionStoreError({
+        operation: 'authority',
+        failure: details.failure,
+        message: details.message,
+        cause: details.cause,
+      })
     }),
   )

--- a/services/bayn/src/execution/mutation-authority.ts
+++ b/services/bayn/src/execution/mutation-authority.ts
@@ -784,7 +784,7 @@ const validateLiveCapitalLimitsDataFirst = (
 export const validateLiveCapitalLimits = Pipeable.dual(6, validateLiveCapitalLimitsDataFirst)
 
 const mutationAuthorizationError = (message: string, cause: unknown) =>
-  invalidRequest(MutationOperation.Submit, message, cause)
+  invalidRequest({ operation: MutationOperation.Submit, message, cause })
 
 const refreshLiveBrokerSubmitSnapshotDataFirst = (
   authority: LiveMutationExecutionAuthority,

--- a/services/bayn/src/execution/runtime-program.ts
+++ b/services/bayn/src/execution/runtime-program.ts
@@ -154,13 +154,11 @@ const authorizeFinalBrokerSubmitDataFirst = <A, E, R>(
     .pipe(
       Effect.mapError((cause) =>
         transmissionStarted && cause instanceof WriterFenceError
-          ? unknownOutcome(
-              MutationOperation.Submit,
-              'final submit transaction failed after broker transmission began',
-              undefined,
-              undefined,
+          ? unknownOutcome({
+              operation: MutationOperation.Submit,
+              message: 'final submit transaction failed after broker transmission began',
               cause,
-            )
+            })
           : cause,
       ),
     )


### PR DESCRIPTION
## Summary

- Replaces positional broker and database failure construction with structured typed inputs.
- Keeps this native stack layer independently reviewable at 981 changed lines.
- Bases directly on codex/bayn-effect-tsgo-ledger-errors so GitHub shows only this layer.

## Related Issues

None

## Testing

- bunx tsc --noEmit --project services/bayn/tsconfig.json
- bun run lint
- bun run lint:oxlint
- bun run lint:oxlint:type
- bun run build
- Focused tests for the touched subsystem were run while constructing the layer.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable and Breaking Changes is filled in.
- [x] Documentation and follow-ups are unchanged or represented by later stack layers.