### PR TITLE
refactor(bayn): structure persistence hashes

### DIFF
--- a/services/bayn/src/db/evidence-recovery/complete.ts
+++ b/services/bayn/src/db/evidence-recovery/complete.ts
@@ -59,8 +59,16 @@ const validateEvaluationIdentity = (prepared: PreparedEvidenceRecovery): Result.
 const validateEvaluationInput = (prepared: PreparedEvidenceRecovery): Result.Result<void, EvidenceRecoveryIssue> =>
   Result.gen(function* () {
     const { evaluation, inputManifest } = prepared.decoded
-    const evaluationBoundsHash = yield* canonicalHash('evaluation-bounds', evaluation.input.bounds, 'evaluation')
-    const manifestBoundsHash = yield* canonicalHash('evaluation-bounds', inputManifest.bounds, 'input-manifest')
+    const evaluationBoundsHash = yield* canonicalHash({
+      operation: 'evaluation-bounds',
+      value: evaluation.input.bounds,
+      subject: 'evaluation',
+    })
+    const manifestBoundsHash = yield* canonicalHash({
+      operation: 'evaluation-bounds',
+      value: inputManifest.bounds,
+      subject: 'input-manifest',
+    })
     if (evaluationBoundsHash !== manifestBoundsHash) {
       return yield* componentMismatch(['evaluation', 'input', 'boundsHash'], evaluationBoundsHash, manifestBoundsHash)
     }
@@ -71,16 +79,16 @@ const validateEvaluationInput = (prepared: PreparedEvidenceRecovery): Result.Res
     for (const [path, observed, expected] of facts) {
       if (observed !== expected) return yield* componentMismatch(path, observed, expected)
     }
-    const evaluationSymbolsHash = yield* canonicalHash(
-      'evaluation-input-symbols',
-      evaluation.input.symbols,
-      'evaluation',
-    )
-    const manifestSymbolsHash = yield* canonicalHash(
-      'evaluation-input-symbols',
-      inputManifest.symbols.map((coverage) => coverage.symbol),
-      'input-manifest',
-    )
+    const evaluationSymbolsHash = yield* canonicalHash({
+      operation: 'evaluation-input-symbols',
+      value: evaluation.input.symbols,
+      subject: 'evaluation',
+    })
+    const manifestSymbolsHash = yield* canonicalHash({
+      operation: 'evaluation-input-symbols',
+      value: inputManifest.symbols.map((coverage) => coverage.symbol),
+      subject: 'input-manifest',
+    })
     if (evaluationSymbolsHash !== manifestSymbolsHash) {
       return yield* componentMismatch(
         ['evaluation', 'input', 'symbolsHash'],
@@ -140,12 +148,16 @@ const validateSignalDecisions = (prepared: PreparedEvidenceRecovery): Result.Res
           return yield* componentMismatch(['signalDecisions', index, path], observed, expected)
         }
       }
-      const decisionWeightsHash = yield* canonicalHash(
-        'signal-target-weights',
-        decision.targetWeights,
-        `decision:${decision.decisionId}`,
-      )
-      const eventWeightsHash = yield* canonicalHash('signal-target-weights', event.targetWeights, `event:${event.id}`)
+      const decisionWeightsHash = yield* canonicalHash({
+        operation: 'signal-target-weights',
+        value: decision.targetWeights,
+        subject: `decision:${decision.decisionId}`,
+      })
+      const eventWeightsHash = yield* canonicalHash({
+        operation: 'signal-target-weights',
+        value: event.targetWeights,
+        subject: `event:${event.id}`,
+      })
       if (decisionWeightsHash !== eventWeightsHash) {
         return yield* componentMismatch(
           ['signalDecisions', index, 'targetWeightsHash'],
@@ -239,7 +251,7 @@ const validateMetricArtifact = (
 ): Result.Result<void, EvidenceRecoveryIssue> =>
   Result.gen(function* () {
     const artifact = yield* requiredArtifact(prepared.artifacts, artifactName)
-    const expectedHash = yield* canonicalHash('evaluation-metric', value, artifactName)
+    const expectedHash = yield* canonicalHash({ operation: 'evaluation-metric', value, subject: artifactName })
     if (artifact.contentHash !== expectedHash) {
       return yield* componentMismatch(['artifacts', artifactName, 'contentHash'], artifact.contentHash, expectedHash)
     }
@@ -257,12 +269,16 @@ const validateMarkedEquityBinding = (
         prepared.runId,
       )
     }
-    const evaluationHash = yield* canonicalHash(
-      'evaluation-marked-equity',
-      evaluation.markedEquityReconciliation,
-      'evaluation',
-    )
-    const artifactHash = yield* canonicalHash('evaluation-marked-equity', markedEquity, 'artifact')
+    const evaluationHash = yield* canonicalHash({
+      operation: 'evaluation-marked-equity',
+      value: evaluation.markedEquityReconciliation,
+      subject: 'evaluation',
+    })
+    const artifactHash = yield* canonicalHash({
+      operation: 'evaluation-marked-equity',
+      value: markedEquity,
+      subject: 'artifact',
+    })
     if (evaluationHash !== artifactHash) {
       return yield* componentMismatch(['evaluation', 'markedEquityReconciliation'], evaluationHash, artifactHash)
     }
@@ -288,12 +304,16 @@ const validateRecoveredGates = (prepared: PreparedEvidenceRecovery): Result.Resu
     for (const [index, gate] of gates.entries()) {
       const expectedGate = expectedGates[index]
       if (expectedGate === undefined) return yield* componentMismatch(['gates', index], gate, 'evaluation gate')
-      const observedHash = yield* canonicalHash(
-        'gate-outcome',
-        { name: gate.name, passed: gate.passed, actual: gate.actual, required: gate.required },
-        `stored:${index}`,
-      )
-      const expectedHash = yield* canonicalHash('gate-outcome', expectedGate, `evaluation:${index}`)
+      const observedHash = yield* canonicalHash({
+        operation: 'gate-outcome',
+        value: { name: gate.name, passed: gate.passed, actual: gate.actual, required: gate.required },
+        subject: `stored:${index}`,
+      })
+      const expectedHash = yield* canonicalHash({
+        operation: 'gate-outcome',
+        value: expectedGate,
+        subject: `evaluation:${index}`,
+      })
       if (observedHash !== expectedHash) {
         return yield* componentMismatch(['gates', index], observedHash, expectedHash)
       }
@@ -329,16 +349,24 @@ const validateReconstructedProof = (
   storedMarkedHash: string,
 ): Result.Result<void, EvidenceRecoveryIssue> =>
   Result.gen(function* () {
-    const proofMarkedHash = yield* canonicalHash('marked-equity-proof', proof.reconciliation, 'reconstructed')
+    const proofMarkedHash = yield* canonicalHash({
+      operation: 'marked-equity-proof',
+      value: proof.reconciliation,
+      subject: 'reconstructed',
+    })
     if (proofMarkedHash !== storedMarkedHash) {
       return yield* componentMismatch(['markedEquity', 'proofHash'], proofMarkedHash, storedMarkedHash)
     }
-    const proofEquityHash = yield* canonicalHash('recovered-equity-series', proof.equitySeries, 'reconstructed')
-    const storedEquityHash = yield* canonicalHash(
-      'recovered-equity-series',
-      prepared.decoded.equitySeries.items,
-      'artifact',
-    )
+    const proofEquityHash = yield* canonicalHash({
+      operation: 'recovered-equity-series',
+      value: proof.equitySeries,
+      subject: 'reconstructed',
+    })
+    const storedEquityHash = yield* canonicalHash({
+      operation: 'recovered-equity-series',
+      value: prepared.decoded.equitySeries.items,
+      subject: 'artifact',
+    })
     if (proofEquityHash !== storedEquityHash) {
       return yield* componentMismatch(['equitySeries', 'proofHash'], proofEquityHash, storedEquityHash)
     }

--- a/services/bayn/src/db/evidence-recovery/prepare.ts
+++ b/services/bayn/src/db/evidence-recovery/prepare.ts
@@ -241,20 +241,24 @@ const validateProtocolExecutionLock = (
     for (const [path, observed, expected] of facts) {
       if (observed !== expected) return yield* mismatch('protocol', [path], observed, expected)
     }
-    const parameterHash = yield* canonicalHash('protocol-parameters', stored.protocol.parameters, stored.run.runId)
+    const parameterHash = yield* canonicalHash({
+      operation: 'protocol-parameters',
+      value: stored.protocol.parameters,
+      subject: stored.run.runId,
+    })
     if (parameterHash !== provenance.strategy.parameterHash) {
       return yield* mismatch('protocol', ['parameterHash'], parameterHash, provenance.strategy.parameterHash)
     }
-    const protocolExecutionHash = yield* canonicalHash(
-      'protocol-execution-model',
-      stored.protocol.parameters.executionModel,
-      stored.run.runId,
-    )
-    const ordersExecutionHash = yield* canonicalHash(
-      'protocol-execution-model',
-      orders.executionModel,
-      'simulated-orders',
-    )
+    const protocolExecutionHash = yield* canonicalHash({
+      operation: 'protocol-execution-model',
+      value: stored.protocol.parameters.executionModel,
+      subject: stored.run.runId,
+    })
+    const ordersExecutionHash = yield* canonicalHash({
+      operation: 'protocol-execution-model',
+      value: orders.executionModel,
+      subject: 'simulated-orders',
+    })
     if (protocolExecutionHash !== ordersExecutionHash) {
       return yield* mismatch('protocol', ['executionModelHash'], ordersExecutionHash, protocolExecutionHash)
     }
@@ -331,16 +335,16 @@ const validateArtifactManifest = (
 ): Result.Result<void, EvidenceRecoveryIssue> =>
   Result.gen(function* () {
     const manifestArtifacts = yield* collectManifestArtifacts(artifacts, decoded)
-    const eventReferencesHash = yield* canonicalHash(
-      'artifact-manifest-expected',
-      stored.events.map(({ ordinal, id, kind, contentHash }) => ({ ordinal, id, kind, contentHash })),
-      'events',
-    )
-    const gateReferencesHash = yield* canonicalHash(
-      'artifact-manifest-expected',
-      stored.gates.map(({ ordinal, name, passed, contentHash }) => ({ ordinal, name, passed, contentHash })),
-      'gates',
-    )
+    const eventReferencesHash = yield* canonicalHash({
+      operation: 'artifact-manifest-expected',
+      value: stored.events.map(({ ordinal, id, kind, contentHash }) => ({ ordinal, id, kind, contentHash })),
+      subject: 'events',
+    })
+    const gateReferencesHash = yield* canonicalHash({
+      operation: 'artifact-manifest-expected',
+      value: stored.gates.map(({ ordinal, name, passed, contentHash }) => ({ ordinal, name, passed, contentHash })),
+      subject: 'gates',
+    })
     const expected = {
       schemaVersion: 'bayn.qualification-artifact-manifest.v1',
       identity: {
@@ -366,12 +370,16 @@ const validateArtifactManifest = (
       events: { count: stored.events.length, contentHash: eventReferencesHash },
       gates: { count: stored.gates.length, contentHash: gateReferencesHash },
     }
-    const observedHash = yield* canonicalHash(
-      'artifact-manifest-observed',
-      decoded.artifactManifest,
-      'qualification-artifact-manifest',
-    )
-    const expectedHash = yield* canonicalHash('artifact-manifest-expected', expected, 'qualification-artifact-manifest')
+    const observedHash = yield* canonicalHash({
+      operation: 'artifact-manifest-observed',
+      value: decoded.artifactManifest,
+      subject: 'qualification-artifact-manifest',
+    })
+    const expectedHash = yield* canonicalHash({
+      operation: 'artifact-manifest-expected',
+      value: expected,
+      subject: 'qualification-artifact-manifest',
+    })
     if (observedHash !== expectedHash) {
       return yield* mismatch('manifest', ['qualificationArtifactManifest'], observedHash, expectedHash)
     }

--- a/services/bayn/src/db/evidence-recovery/reconciliation-proof.ts
+++ b/services/bayn/src/db/evidence-recovery/reconciliation-proof.ts
@@ -35,8 +35,16 @@ const validateRecoveredSnapshotReferenceDataFirst = (
     for (const [path, observed, expected] of facts) {
       if (observed !== expected) return yield* mismatch('snapshot', [path], observed, expected)
     }
-    const observedManifestHash = yield* canonicalHash('snapshot-manifest', row.manifest, 'stored')
-    const expectedManifestHash = yield* canonicalHash('snapshot-manifest', snapshot, 'input-manifest')
+    const observedManifestHash = yield* canonicalHash({
+      operation: 'snapshot-manifest',
+      value: row.manifest,
+      subject: 'stored',
+    })
+    const expectedManifestHash = yield* canonicalHash({
+      operation: 'snapshot-manifest',
+      value: snapshot,
+      subject: 'input-manifest',
+    })
     if (observedManifestHash !== expectedManifestHash) {
       return yield* mismatch('snapshot', ['manifestHash'], observedManifestHash, expectedManifestHash)
     }

--- a/services/bayn/src/db/evidence-recovery/shared.ts
+++ b/services/bayn/src/db/evidence-recovery/shared.ts
@@ -22,17 +22,19 @@ const mismatchDataFirst = (
 
 export const mismatch = Pipeable.dual(4, mismatchDataFirst)
 
-export const canonicalHash = (
-  operation: RecoveryCanonicalizationOperation,
-  value: unknown,
-  subject?: string,
-): Result.Result<string, EvidenceRecoveryIssue> =>
+export interface RecoveryCanonicalHashInput {
+  readonly operation: RecoveryCanonicalizationOperation
+  readonly value: unknown
+  readonly subject?: string
+}
+
+export const canonicalHash = (input: RecoveryCanonicalHashInput): Result.Result<string, EvidenceRecoveryIssue> =>
   Result.mapError(
-    canonicalHashV1Result(value),
+    canonicalHashV1Result(input.value),
     (cause): EvidenceRecoveryIssue => ({
       _tag: 'CanonicalizationFailure',
-      operation,
-      ...(subject === undefined ? {} : { subject }),
+      operation: input.operation,
+      ...(input.subject === undefined ? {} : { subject: input.subject }),
       cause,
     }),
   )

--- a/services/bayn/src/db/evidence-recovery/stored.ts
+++ b/services/bayn/src/db/evidence-recovery/stored.ts
@@ -43,11 +43,11 @@ const validateStoredProtocol = (
         receipt.strategy_name,
       )
     }
-    const parameterHash = yield* canonicalHash(
-      'stored-protocol-parameters',
-      rows.protocol.parameters,
-      rows.protocol.protocol_hash,
-    )
+    const parameterHash = yield* canonicalHash({
+      operation: 'stored-protocol-parameters',
+      value: rows.protocol.parameters,
+      subject: rows.protocol.protocol_hash,
+    })
     if (rows.protocol.parameter_hash !== parameterHash) {
       return yield* mismatch('stored-graph', ['protocol', 'parameterHash'], rows.protocol.parameter_hash, parameterHash)
     }
@@ -78,7 +78,11 @@ const validateStoredCounts = (
 const validateStoredArtifacts = (rows: StoredEvidenceRows): Result.Result<void, EvidenceRecoveryIssue> =>
   Result.gen(function* () {
     for (const artifact of rows.artifacts) {
-      const expectedHash = yield* canonicalHash('stored-artifact-payload', artifact.payload, artifact.artifact_name)
+      const expectedHash = yield* canonicalHash({
+        operation: 'stored-artifact-payload',
+        value: artifact.payload,
+        subject: artifact.artifact_name,
+      })
       if (artifact.content_hash !== expectedHash) {
         return yield* mismatch(
           'stored-graph',
@@ -96,7 +100,11 @@ const validateStoredEvents = (rows: StoredEvidenceRows): Result.Result<void, Evi
       if (event.ordinal !== index) {
         return yield* mismatch('stored-graph', ['events', event.event_id, 'ordinal'], event.ordinal, index)
       }
-      const expectedHash = yield* canonicalHash('stored-event-payload', event.payload, event.event_id)
+      const expectedHash = yield* canonicalHash({
+        operation: 'stored-event-payload',
+        value: event.payload,
+        subject: event.event_id,
+      })
       if (event.content_hash !== expectedHash) {
         return yield* mismatch(
           'stored-graph',
@@ -114,11 +122,11 @@ const validateStoredGates = (rows: StoredEvidenceRows): Result.Result<void, Evid
       if (gate.ordinal !== index) {
         return yield* mismatch('stored-graph', ['gates', gate.gate_name, 'ordinal'], gate.ordinal, index)
       }
-      const expectedHash = yield* canonicalHash(
-        'stored-gate-payload',
-        { name: gate.gate_name, passed: gate.passed, actual: gate.actual, required: gate.required },
-        gate.gate_name,
-      )
+      const expectedHash = yield* canonicalHash({
+        operation: 'stored-gate-payload',
+        value: { name: gate.gate_name, passed: gate.passed, actual: gate.actual, required: gate.required },
+        subject: gate.gate_name,
+      })
       if (gate.content_hash !== expectedHash) {
         return yield* mismatch(
           'stored-graph',
@@ -149,8 +157,16 @@ const validateStoredStatuses = (
       eventCount: receipt.event_count,
       gateCount: receipt.gate_count,
     }
-    const writingHash = yield* canonicalHash('stored-writing-status', writing.detail, runId)
-    const expectedHash = yield* canonicalHash('stored-writing-status', expectedDetail, runId)
+    const writingHash = yield* canonicalHash({
+      operation: 'stored-writing-status',
+      value: writing.detail,
+      subject: runId,
+    })
+    const expectedHash = yield* canonicalHash({
+      operation: 'stored-writing-status',
+      value: expectedDetail,
+      subject: runId,
+    })
     if (writingHash !== expectedHash) {
       return yield* mismatch('stored-graph', ['statuses', 0, 'detail'], writing.detail, expectedDetail)
     }

--- a/services/bayn/src/db/evidence-store/persistence-evaluation.ts
+++ b/services/bayn/src/db/evidence-store/persistence-evaluation.ts
@@ -72,7 +72,7 @@ const validatePersistenceEvaluationDataFirst = (
       )
     }
 
-    const parameterHash = yield* persistenceCanonicalHash('parameters', parameters)
+    const parameterHash = yield* persistenceCanonicalHash({ operation: 'parameters', value: parameters })
     if (parameterHash !== provenance.strategy.parameterHash) {
       return yield* persistenceMismatch(
         'parameter-hash',
@@ -81,16 +81,16 @@ const validatePersistenceEvaluationDataFirst = (
         parameterHash,
       )
     }
-    const executionHash = yield* persistenceCanonicalHash(
-      'execution-model',
-      evaluation.simulation.executionModel,
-      'simulation',
-    )
-    const expectedExecutionHash = yield* persistenceCanonicalHash(
-      'execution-model',
-      parameters.executionModel,
-      'parameters',
-    )
+    const executionHash = yield* persistenceCanonicalHash({
+      operation: 'execution-model',
+      value: evaluation.simulation.executionModel,
+      subject: 'simulation',
+    })
+    const expectedExecutionHash = yield* persistenceCanonicalHash({
+      operation: 'execution-model',
+      value: parameters.executionModel,
+      subject: 'parameters',
+    })
     if (executionHash !== expectedExecutionHash) {
       return yield* persistenceMismatch(
         'execution-model',
@@ -135,7 +135,10 @@ const validatePersistenceEvaluationDataFirst = (
     }
 
     const { hash: inputManifestHash, ...manifestMaterial } = evaluation.inputManifest
-    const expectedManifestHash = yield* persistenceCanonicalHash('input-manifest', manifestMaterial)
+    const expectedManifestHash = yield* persistenceCanonicalHash({
+      operation: 'input-manifest',
+      value: manifestMaterial,
+    })
     if (inputManifestHash !== expectedManifestHash) {
       return yield* persistenceMismatch(
         'input-manifest-hash',
@@ -165,16 +168,16 @@ const validatePersistenceEvaluationDataFirst = (
       } satisfies PersistencePlanFailure)
     }
     const equityProof = equityProofResult.success
-    const proofReconciliationHash = yield* persistenceCanonicalHash(
-      'marked-equity-reconciliation',
-      equityProof.reconciliation,
-      'reconstructed',
-    )
-    const evaluationReconciliationHash = yield* persistenceCanonicalHash(
-      'marked-equity-reconciliation',
-      evaluation.markedEquityReconciliation,
-      'evaluation',
-    )
+    const proofReconciliationHash = yield* persistenceCanonicalHash({
+      operation: 'marked-equity-reconciliation',
+      value: equityProof.reconciliation,
+      subject: 'reconstructed',
+    })
+    const evaluationReconciliationHash = yield* persistenceCanonicalHash({
+      operation: 'marked-equity-reconciliation',
+      value: evaluation.markedEquityReconciliation,
+      subject: 'evaluation',
+    })
     if (proofReconciliationHash !== evaluationReconciliationHash) {
       return yield* persistenceMismatch(
         'marked-equity-proof',
@@ -183,8 +186,16 @@ const validatePersistenceEvaluationDataFirst = (
         proofReconciliationHash,
       )
     }
-    const proofEquityHash = yield* persistenceCanonicalHash('equity-series', equityProof.equitySeries, 'reconstructed')
-    const evaluationEquityHash = yield* persistenceCanonicalHash('equity-series', evaluation.equitySeries, 'evaluation')
+    const proofEquityHash = yield* persistenceCanonicalHash({
+      operation: 'equity-series',
+      value: equityProof.equitySeries,
+      subject: 'reconstructed',
+    })
+    const evaluationEquityHash = yield* persistenceCanonicalHash({
+      operation: 'equity-series',
+      value: evaluation.equitySeries,
+      subject: 'evaluation',
+    })
     if (proofEquityHash !== evaluationEquityHash) {
       return yield* persistenceMismatch(
         'marked-equity-proof',
@@ -230,16 +241,16 @@ const validatePersistenceEvaluationDataFirst = (
           )
         }
       }
-      const decisionWeightsHash = yield* persistenceCanonicalHash(
-        'signal-target-weights',
-        decision.targetWeights,
-        `decision:${decision.decisionId}`,
-      )
-      const eventWeightsHash = yield* persistenceCanonicalHash(
-        'signal-target-weights',
-        event.targetWeights,
-        `event:${event.id}`,
-      )
+      const decisionWeightsHash = yield* persistenceCanonicalHash({
+        operation: 'signal-target-weights',
+        value: decision.targetWeights,
+        subject: `decision:${decision.decisionId}`,
+      })
+      const eventWeightsHash = yield* persistenceCanonicalHash({
+        operation: 'signal-target-weights',
+        value: event.targetWeights,
+        subject: `event:${event.id}`,
+      })
       if (decisionWeightsHash !== eventWeightsHash) {
         return yield* persistenceMismatch(
           'signal-decisions',

--- a/services/bayn/src/db/evidence-store/persistence-failures.ts
+++ b/services/bayn/src/db/evidence-store/persistence-failures.ts
@@ -23,17 +23,21 @@ const persistenceMismatchDataFirst = (
 
 export const persistenceMismatch = Pipeable.dual(4, persistenceMismatchDataFirst)
 
+export interface PersistenceCanonicalHashInput {
+  readonly operation: PersistenceCanonicalizationOperation
+  readonly value: unknown
+  readonly subject?: string
+}
+
 export const persistenceCanonicalHash = (
-  operation: PersistenceCanonicalizationOperation,
-  value: unknown,
-  subject?: string,
+  input: PersistenceCanonicalHashInput,
 ): Result.Result<string, PersistencePlanFailure> =>
   Result.mapError(
-    canonicalHashV1Result(value),
+    canonicalHashV1Result(input.value),
     (cause): PersistencePlanFailure => ({
       _tag: 'PersistenceCanonicalizationFailed',
-      operation,
-      ...(subject === undefined ? {} : { subject }),
+      operation: input.operation,
+      ...(input.subject === undefined ? {} : { subject: input.subject }),
       cause,
     }),
   )

--- a/services/bayn/src/db/evidence-store/persistence-plan.ts
+++ b/services/bayn/src/db/evidence-store/persistence-plan.ts
@@ -25,13 +25,16 @@ const makeArtifact = (
   payload: unknown,
   itemCount = 0,
 ): Result.Result<PersistenceArtifact, PersistencePlanFailure> =>
-  Result.map(persistenceCanonicalHash('artifact-payload', payload, name), (contentHash) => ({
-    name,
-    schemaVersion,
-    contentHash,
-    payload,
-    itemCount,
-  }))
+  Result.map(
+    persistenceCanonicalHash({ operation: 'artifact-payload', value: payload, subject: name }),
+    (contentHash) => ({
+      name,
+      schemaVersion,
+      contentHash,
+      payload,
+      itemCount,
+    }),
+  )
 
 const makePersistenceEvidence = (
   input: PersistEvaluationInput,
@@ -124,7 +127,7 @@ const makePersistenceEvidence = (
         ordinal,
         id: event.id,
         kind: event.kind,
-        contentHash: yield* persistenceCanonicalHash('event-payload', event, event.id),
+        contentHash: yield* persistenceCanonicalHash({ operation: 'event-payload', value: event, subject: event.id }),
         payload: event,
       })
     }
@@ -136,7 +139,7 @@ const makePersistenceEvidence = (
         passed: gate.passed,
         actual: gate.actual,
         required: gate.required,
-        contentHash: yield* persistenceCanonicalHash('gate-payload', gate, gate.name),
+        contentHash: yield* persistenceCanonicalHash({ operation: 'gate-payload', value: gate, subject: gate.name }),
       })
     }
     if (events.length === 0) return yield* persistenceMismatch('events-empty', ['events', 'length'], 0, 'at least 1')
@@ -180,16 +183,16 @@ const validatePersistenceQualification = (
     for (const [path, observed, expected] of scalarFacts) {
       if (observed !== expected) return yield* persistenceMismatch('qualification-result', path, observed, expected)
     }
-    const resultVerdictHash = yield* persistenceCanonicalHash(
-      'qualification-verdict',
-      result.evaluationVerdict,
-      'result',
-    )
-    const evaluationVerdictHash = yield* persistenceCanonicalHash(
-      'qualification-verdict',
-      evaluation.verdict,
-      'evaluation',
-    )
+    const resultVerdictHash = yield* persistenceCanonicalHash({
+      operation: 'qualification-verdict',
+      value: result.evaluationVerdict,
+      subject: 'result',
+    })
+    const evaluationVerdictHash = yield* persistenceCanonicalHash({
+      operation: 'qualification-verdict',
+      value: evaluation.verdict,
+      subject: 'evaluation',
+    })
     if (resultVerdictHash !== evaluationVerdictHash) {
       return yield* persistenceMismatch(
         'qualification-result',
@@ -198,12 +201,16 @@ const validatePersistenceQualification = (
         evaluationVerdictHash,
       )
     }
-    const resultTrialsHash = yield* persistenceCanonicalHash(
-      'qualification-prior-trials',
-      result.analysis.priorTrialRunIds,
-      'result',
-    )
-    const lockTrialsHash = yield* persistenceCanonicalHash('qualification-prior-trials', lock.priorTrialRunIds, 'lock')
+    const resultTrialsHash = yield* persistenceCanonicalHash({
+      operation: 'qualification-prior-trials',
+      value: result.analysis.priorTrialRunIds,
+      subject: 'result',
+    })
+    const lockTrialsHash = yield* persistenceCanonicalHash({
+      operation: 'qualification-prior-trials',
+      value: lock.priorTrialRunIds,
+      subject: 'lock',
+    })
     if (resultTrialsHash !== lockTrialsHash) {
       return yield* persistenceMismatch(
         'qualification-result',
@@ -232,14 +239,14 @@ const makePersistenceArtifactManifest = (
 > =>
   Result.gen(function* () {
     const { evaluation, provenance } = input
-    const eventsHash = yield* persistenceCanonicalHash(
-      'artifact-manifest-events',
-      evidence.events.map(({ ordinal, id, kind, contentHash }) => ({ ordinal, id, kind, contentHash })),
-    )
-    const gatesHash = yield* persistenceCanonicalHash(
-      'artifact-manifest-gates',
-      evidence.gates.map(({ ordinal, name, passed, contentHash }) => ({ ordinal, name, passed, contentHash })),
-    )
+    const eventsHash = yield* persistenceCanonicalHash({
+      operation: 'artifact-manifest-events',
+      value: evidence.events.map(({ ordinal, id, kind, contentHash }) => ({ ordinal, id, kind, contentHash })),
+    })
+    const gatesHash = yield* persistenceCanonicalHash({
+      operation: 'artifact-manifest-gates',
+      value: evidence.gates.map(({ ordinal, name, passed, contentHash }) => ({ ordinal, name, passed, contentHash })),
+    })
     return {
       schemaVersion: 'bayn.qualification-artifact-manifest.v1',
       identity: {

--- a/services/bayn/src/db/evidence-store/persistence-receipt.ts
+++ b/services/bayn/src/db/evidence-store/persistence-receipt.ts
@@ -21,8 +21,16 @@ const validateProtocolReferenceDataFirst = (
   reference: StoredProtocolReference,
 ): Result.Result<void, PersistencePlanFailure> =>
   Result.gen(function* () {
-    const storedParameterHash = yield* persistenceCanonicalHash('protocol-parameters', reference.parameters, 'stored')
-    const expectedParameterHash = yield* persistenceCanonicalHash('protocol-parameters', input.parameters, 'input')
+    const storedParameterHash = yield* persistenceCanonicalHash({
+      operation: 'protocol-parameters',
+      value: reference.parameters,
+      subject: 'stored',
+    })
+    const expectedParameterHash = yield* persistenceCanonicalHash({
+      operation: 'protocol-parameters',
+      value: input.parameters,
+      subject: 'input',
+    })
     const facts = [
       [['schemaVersion'], reference.schema_version, input.provenance.strategy.parameterSchemaVersion],
       [['strategyName'], reference.strategy_name, input.provenance.strategy.name],
@@ -124,7 +132,11 @@ const validatePersistenceReceiptDataFirst = (
           'absent',
         )
       }
-      const payloadHash = yield* persistenceCanonicalHash('stored-artifact', artifact.payload, artifact.artifact_name)
+      const payloadHash = yield* persistenceCanonicalHash({
+        operation: 'stored-artifact',
+        value: artifact.payload,
+        subject: artifact.artifact_name,
+      })
       const observed = {
         name: artifact.artifact_name,
         schemaVersion: artifact.schema_version,
@@ -152,7 +164,11 @@ const validatePersistenceReceiptDataFirst = (
       if (expected === undefined) {
         return yield* persistenceMismatch('receipt-event-content', ['events', index], event.event_id, 'absent')
       }
-      const payloadHash = yield* persistenceCanonicalHash('stored-event', event.payload, event.event_id)
+      const payloadHash = yield* persistenceCanonicalHash({
+        operation: 'stored-event',
+        value: event.payload,
+        subject: event.event_id,
+      })
       const observed = {
         ordinal: event.ordinal,
         id: event.event_id,
@@ -183,11 +199,11 @@ const validatePersistenceReceiptDataFirst = (
       if (expected === undefined) {
         return yield* persistenceMismatch('receipt-gate-content', ['gates', index], gate.gate_name, 'absent')
       }
-      const payloadHash = yield* persistenceCanonicalHash(
-        'stored-gate',
-        { name: gate.gate_name, passed: gate.passed, actual: gate.actual, required: gate.required },
-        gate.gate_name,
-      )
+      const payloadHash = yield* persistenceCanonicalHash({
+        operation: 'stored-gate',
+        value: { name: gate.gate_name, passed: gate.passed, actual: gate.actual, required: gate.required },
+        subject: gate.gate_name,
+      })
       const observed = {
         ordinal: gate.ordinal,
         name: gate.gate_name,
@@ -226,18 +242,26 @@ const validatePersistenceReceiptDataFirst = (
         ['WRITING', 'COMPLETE'],
       )
     }
-    const writingHash = yield* persistenceCanonicalHash('stored-status', writing.detail, 'WRITING')
-    const expectedWritingHash = yield* persistenceCanonicalHash(
-      'stored-status',
-      { artifactCount: plan.artifacts.length, eventCount: plan.events.length, gateCount: plan.gates.length },
-      'expected-WRITING',
-    )
-    const completeHash = yield* persistenceCanonicalHash('stored-status', complete.detail, 'COMPLETE')
-    const expectedCompleteHash = yield* persistenceCanonicalHash(
-      'stored-status',
-      { reconciliationExact: true, verdict: plan.evaluation.verdict.status },
-      'expected-COMPLETE',
-    )
+    const writingHash = yield* persistenceCanonicalHash({
+      operation: 'stored-status',
+      value: writing.detail,
+      subject: 'WRITING',
+    })
+    const expectedWritingHash = yield* persistenceCanonicalHash({
+      operation: 'stored-status',
+      value: { artifactCount: plan.artifacts.length, eventCount: plan.events.length, gateCount: plan.gates.length },
+      subject: 'expected-WRITING',
+    })
+    const completeHash = yield* persistenceCanonicalHash({
+      operation: 'stored-status',
+      value: complete.detail,
+      subject: 'COMPLETE',
+    })
+    const expectedCompleteHash = yield* persistenceCanonicalHash({
+      operation: 'stored-status',
+      value: { reconciliationExact: true, verdict: plan.evaluation.verdict.status },
+      subject: 'expected-COMPLETE',
+    })
     if (writingHash !== expectedWritingHash || completeHash !== expectedCompleteHash) {
       return yield* persistenceMismatch(
         'receipt-status-history',


### PR DESCRIPTION
## Summary

- Makes persistence hash construction accept explicit structured material.
- Keeps this native stack layer independently reviewable at 474 changed lines.
- Bases directly on codex/bayn-effect-tsgo-broker-db-errors so GitHub shows only this layer.

## Related Issues

None

## Testing

- bunx tsc --noEmit --project services/bayn/tsconfig.json
- bun run lint
- bun run lint:oxlint
- bun run lint:oxlint:type
- bun run build
- Focused tests for the touched subsystem were run while constructing the layer.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable and Breaking Changes is filled in.
- [x] Documentation and follow-ups are unchanged or represented by later stack layers.