### PR TITLE
refactor(bayn): structure runtime failures

### DIFF
--- a/services/bayn/src/execution/mutations/decisions.ts
+++ b/services/bayn/src/execution/mutations/decisions.ts
@@ -136,12 +136,14 @@ const intentStateForIdentifiedSubmit = (
   }
 }
 
-export const storeError = (
-  operation: MutationStoreError['operation'],
-  failure: MutationStoreError['failure'],
-  message: string,
-  cause?: unknown,
-) => new MutationStoreErrorValue({ operation, failure, message, cause })
+export interface MutationStoreErrorInput {
+  readonly operation: MutationStoreError['operation']
+  readonly failure: MutationStoreError['failure']
+  readonly message: string
+  readonly cause?: unknown
+}
+
+export const storeError = (input: MutationStoreErrorInput): MutationStoreError => new MutationStoreErrorValue(input)
 
 export const startStoreOperationFor = (operation: MutationOperation): StartStoreOperation =>
   operation === MutationOperation.Submit ? 'begin-submit' : 'begin-cancel'
@@ -198,7 +200,11 @@ const decideMutationStartReplayDataFirst = (
     existing.mutationId !== expectedMutationId.success
   ) {
     return Result.fail(
-      storeError(storeOperation, 'conflict', 'mutation identity was reused with different request content'),
+      storeError({
+        operation: storeOperation,
+        failure: 'conflict',
+        message: 'mutation identity was reused with different request content',
+      }),
     )
   }
   return Result.succeed({
@@ -216,10 +222,14 @@ const decideMutationAuthorityDataFirst = (
 ): Result.Result<MutationAuthorityBinding, MutationStoreError> => {
   const storeOperation = startStoreOperationFor(operation)
   if (authority === undefined) {
-    return Result.fail(storeError(storeOperation, 'authority', 'paper authority is not initialized'))
+    return Result.fail(
+      storeError({ operation: storeOperation, failure: 'authority', message: 'paper authority is not initialized' }),
+    )
   }
   if (authority.maximum !== Authority.Paper) {
-    return Result.fail(storeError(storeOperation, 'authority', 'GitOps maximum authority is not PAPER'))
+    return Result.fail(
+      storeError({ operation: storeOperation, failure: 'authority', message: 'GitOps maximum authority is not PAPER' }),
+    )
   }
   const ordinarySubmit = authority.effective === Authority.Paper && authority.killState === KillState.Clear
   const boundedCloseSubmit =
@@ -227,7 +237,13 @@ const decideMutationAuthorityDataFirst = (
     (authority.effective === Authority.Paper || authority.effective === Authority.Observe) &&
     (authority.killState === KillState.Clear || authority.killState === KillState.Active)
   if (operation === MutationOperation.Submit && !ordinarySubmit && !boundedCloseSubmit) {
-    return Result.fail(storeError('begin-submit', 'authority', 'effective authority is not PAPER and clear'))
+    return Result.fail(
+      storeError({
+        operation: 'begin-submit',
+        failure: 'authority',
+        message: 'effective authority is not PAPER and clear',
+      }),
+    )
   }
   if (
     operation === MutationOperation.Cancel &&
@@ -235,12 +251,20 @@ const decideMutationAuthorityDataFirst = (
     authority.effective !== Authority.Paper
   ) {
     return Result.fail(
-      storeError('begin-cancel', 'authority', 'cancellation requires PAPER authority or an active kill'),
+      storeError({
+        operation: 'begin-cancel',
+        failure: 'authority',
+        message: 'cancellation requires PAPER authority or an active kill',
+      }),
     )
   }
   if (authority.generationMaximum !== Authority.Paper || authority.generationAccountId === null) {
     return Result.fail(
-      storeError(storeOperation, 'authority', 'active PAPER authority lacks its immutable account binding'),
+      storeError({
+        operation: storeOperation,
+        failure: 'authority',
+        message: 'active PAPER authority lacks its immutable account binding',
+      }),
     )
   }
   return Result.succeed({
@@ -263,10 +287,18 @@ export const decideFinalSubmitAuthorization = (
   closeOnly = false,
 ): Result.Result<void, MutationStoreError> => {
   if (intent === undefined) {
-    return Result.fail(storeError('begin-submit', 'invariant', 'final submit intent does not exist'))
+    return Result.fail(
+      storeError({ operation: 'begin-submit', failure: 'invariant', message: 'final submit intent does not exist' }),
+    )
   }
   if (closeOnly && intent.side !== OrderSide.Sell) {
-    return Result.fail(storeError('begin-submit', 'authority', 'close-only submit requires a sell intent'))
+    return Result.fail(
+      storeError({
+        operation: 'begin-submit',
+        failure: 'authority',
+        message: 'close-only submit requires a sell intent',
+      }),
+    )
   }
   if (
     intent.state !== IntentState.IoStarted ||
@@ -279,11 +311,11 @@ export const decideFinalSubmitAuthorization = (
     intent.authorityGenerationHash !== authority.generationHash
   ) {
     return Result.fail(
-      storeError(
-        'begin-submit',
-        'authority',
-        'final submit no longer matches active PAPER authority and immutable intent bindings',
-      ),
+      storeError({
+        operation: 'begin-submit',
+        failure: 'authority',
+        message: 'final submit no longer matches active PAPER authority and immutable intent bindings',
+      }),
     )
   }
   return Result.succeed(undefined)
@@ -292,7 +324,13 @@ export const decideFinalSubmitAuthorization = (
 export const decideMutationContainment = (unresolved: boolean | undefined): Result.Result<void, MutationStoreError> =>
   unresolved === false
     ? Result.succeed(undefined)
-    : Result.fail(storeError('begin-submit', 'invariant', 'another broker mutation has an unresolved outcome'))
+    : Result.fail(
+        storeError({
+          operation: 'begin-submit',
+          failure: 'invariant',
+          message: 'another broker mutation has an unresolved outcome',
+        }),
+      )
 
 const decideMutationStartDataFirst = (
   operation: MutationOperation,
@@ -303,7 +341,9 @@ const decideMutationStartDataFirst = (
 ): Result.Result<MutationStartDecision, MutationStoreError> => {
   const storeOperation = startStoreOperationFor(operation)
   if (intent === undefined) {
-    return Result.fail(storeError(storeOperation, 'invariant', 'intent does not exist'))
+    return Result.fail(
+      storeError({ operation: storeOperation, failure: 'invariant', message: 'intent does not exist' }),
+    )
   }
   if (
     intent.generationMaximum !== Authority.Paper ||
@@ -313,24 +353,38 @@ const decideMutationStartDataFirst = (
     intent.generationStrategyName !== intent.strategyName
   ) {
     return Result.fail(
-      storeError(
-        storeOperation,
-        'authority',
-        'intent does not match its immutable PAPER authority-generation bindings',
-      ),
+      storeError({
+        operation: storeOperation,
+        failure: 'authority',
+        message: 'intent does not match its immutable PAPER authority-generation bindings',
+      }),
     )
   }
   if (intent.accountId !== authority.accountId) {
     return Result.fail(
-      storeError(storeOperation, 'authority', 'intent account does not match the active PAPER authority generation'),
+      storeError({
+        operation: storeOperation,
+        failure: 'authority',
+        message: 'intent account does not match the active PAPER authority generation',
+      }),
     )
   }
   if (input.closeOnly === true && intent.side !== OrderSide.Sell) {
-    return Result.fail(storeError('begin-submit', 'authority', 'close-only submit requires a sell intent'))
+    return Result.fail(
+      storeError({
+        operation: 'begin-submit',
+        failure: 'authority',
+        message: 'close-only submit requires a sell intent',
+      }),
+    )
   }
   if (operation === MutationOperation.Submit && intent.authorityGenerationHash !== authority.generationHash) {
     return Result.fail(
-      storeError('begin-submit', 'authority', 'intent authority generation is not the active PAPER generation'),
+      storeError({
+        operation: 'begin-submit',
+        failure: 'authority',
+        message: 'intent authority generation is not the active PAPER generation',
+      }),
     )
   }
 
@@ -356,16 +410,30 @@ const decideMutationStartDataFirst = (
           )
   if (requiredState === undefined) {
     return Result.fail(
-      storeError('begin-cancel', 'invariant', 'cancel requires the exact durable submitted order identity'),
+      storeError({
+        operation: 'begin-cancel',
+        failure: 'invariant',
+        message: 'cancel requires the exact durable submitted order identity',
+      }),
     )
   }
   if (intent.state !== requiredState) {
     return Result.fail(
-      storeError(storeOperation, 'invariant', `${operation.toLowerCase()} requires an ${requiredState} intent`),
+      storeError({
+        operation: storeOperation,
+        failure: 'invariant',
+        message: `${operation.toLowerCase()} requires an ${requiredState} intent`,
+      }),
     )
   }
   if (input.occurredAt <= intent.updatedAt) {
-    return Result.fail(storeError(storeOperation, 'invariant', 'mutation time must follow the intent state'))
+    return Result.fail(
+      storeError({
+        operation: storeOperation,
+        failure: 'invariant',
+        message: 'mutation time must follow the intent state',
+      }),
+    )
   }
 
   return Result.map(
@@ -659,7 +727,11 @@ const decideMutationEventContract = (
   return valid
     ? Result.succeed(undefined)
     : Result.fail(
-        storeError(storeOperation, 'invariant', 'mutation event does not match its operation and evidence contract'),
+        storeError({
+          operation: storeOperation,
+          failure: 'invariant',
+          message: 'mutation event does not match its operation and evidence contract',
+        }),
       )
 }
 
@@ -672,7 +744,9 @@ const decideMutationOutcomeDataFirst = (
   const storeOperation = outcomeStoreOperation(definition)
   const facts = decideMutationOutcomeDefinition(definition)
   if (previous === undefined) {
-    return Result.fail(storeError(storeOperation, 'invariant', 'mutation STARTED event does not exist'))
+    return Result.fail(
+      storeError({ operation: storeOperation, failure: 'invariant', message: 'mutation STARTED event does not exist' }),
+    )
   }
   const expectedMutationId = canonicalMutationId(storeOperation, input.intentId, facts.operation)
   if (Result.isFailure(expectedMutationId)) return Result.fail(expectedMutationId.failure)
@@ -681,17 +755,31 @@ const decideMutationOutcomeDataFirst = (
     previous.operation !== facts.operation ||
     previous.mutationId !== expectedMutationId.success
   ) {
-    return Result.fail(storeError(storeOperation, 'conflict', 'mutation identity and sequence must remain exact'))
+    return Result.fail(
+      storeError({
+        operation: storeOperation,
+        failure: 'conflict',
+        message: 'mutation identity and sequence must remain exact',
+      }),
+    )
   }
   if (previous.requestHash !== input.requestHash) {
-    return Result.fail(storeError(storeOperation, 'conflict', 'mutation request hash changed'))
+    return Result.fail(
+      storeError({ operation: storeOperation, failure: 'conflict', message: 'mutation request hash changed' }),
+    )
   }
   if (
     previous.brokerOrderId !== undefined &&
     input.brokerOrderId !== undefined &&
     previous.brokerOrderId !== input.brokerOrderId
   ) {
-    return Result.fail(storeError(storeOperation, 'conflict', 'mutation broker order identity cannot change'))
+    return Result.fail(
+      storeError({
+        operation: storeOperation,
+        failure: 'conflict',
+        message: 'mutation broker order identity cannot change',
+      }),
+    )
   }
 
   const brokerOrderId = previous.brokerOrderId ?? input.brokerOrderId
@@ -714,21 +802,31 @@ const decideMutationOutcomeDataFirst = (
   if (sameOutcome(previous, event)) {
     if (facts.replayIntent !== undefined && !matchesReplayIntent(facts.replayIntent, currentIntent)) {
       return Result.fail(
-        storeError(storeOperation, 'conflict', 'mutation outcome replay conflicts with durable intent state'),
+        storeError({
+          operation: storeOperation,
+          failure: 'conflict',
+          message: 'mutation outcome replay conflicts with durable intent state',
+        }),
       )
     }
     return Result.succeed({ _tag: 'ReplayMutation', event: previous })
   }
   if (input.occurredAt < previous.occurredAt) {
-    return Result.fail(storeError(storeOperation, 'conflict', 'mutation identity and sequence must remain exact'))
+    return Result.fail(
+      storeError({
+        operation: storeOperation,
+        failure: 'conflict',
+        message: 'mutation identity and sequence must remain exact',
+      }),
+    )
   }
   if (!allowsOutcomeEvent(previous.eventType, facts.eventType)) {
     return Result.fail(
-      storeError(
-        storeOperation,
-        'conflict',
-        `invalid mutation transition from ${previous.eventType} to ${facts.eventType}`,
-      ),
+      storeError({
+        operation: storeOperation,
+        failure: 'conflict',
+        message: `invalid mutation transition from ${previous.eventType} to ${facts.eventType}`,
+      }),
     )
   }
   const eventContract = decideMutationEventContract(storeOperation, event)
@@ -749,7 +847,11 @@ const decideCancelFirstDataFirst = (
 ): Result.Result<void, MutationStoreError> =>
   decision._tag === 'RequireNoDurableCancellation' && cancellation !== undefined
     ? Result.fail(
-        storeError('record-recovery', 'conflict', 'terminal submit recovery cannot overtake a durable cancellation'),
+        storeError({
+          operation: 'record-recovery',
+          failure: 'conflict',
+          message: 'terminal submit recovery cannot overtake a durable cancellation',
+        }),
       )
     : Result.succeed(undefined)
 
@@ -764,13 +866,13 @@ const decideMutationAppendDataFirst = (
   appendedEventIds.length === 1
     ? Result.succeed(event)
     : Result.fail(
-        storeError(
-          storeOperation,
-          requireCurrentRisk ? 'invariant' : 'conflict',
-          requireCurrentRisk
+        storeError({
+          operation: storeOperation,
+          failure: requireCurrentRisk ? 'invariant' : 'conflict',
+          message: requireCurrentRisk
             ? 'mutation start requires a current approved risk decision'
             : 'mutation event append lost its race',
-        ),
+        }),
       )
 
 export const decideMutationAppend = Pipeable.dual(4, decideMutationAppendDataFirst)
@@ -780,7 +882,13 @@ export const decideSubmitStartWrite = (
 ): Result.Result<void, MutationStoreError> =>
   transitionedIntentIds.length === 1
     ? Result.succeed(undefined)
-    : Result.fail(storeError('begin-submit', 'conflict', 'approved intent transition lost its race'))
+    : Result.fail(
+        storeError({
+          operation: 'begin-submit',
+          failure: 'conflict',
+          message: 'approved intent transition lost its race',
+        }),
+      )
 
 const decideMutationOutcomeWriteDataFirst = (
   storeOperation: OutcomeStoreOperation,
@@ -788,7 +896,13 @@ const decideMutationOutcomeWriteDataFirst = (
 ): Result.Result<void, MutationStoreError> =>
   transitionedIntentIds.length === 1
     ? Result.succeed(undefined)
-    : Result.fail(storeError(storeOperation, 'conflict', 'intent mutation outcome lost its race'))
+    : Result.fail(
+        storeError({
+          operation: storeOperation,
+          failure: 'conflict',
+          message: 'intent mutation outcome lost its race',
+        }),
+      )
 
 export const decideMutationOutcomeWrite = Pipeable.dual(2, decideMutationOutcomeWriteDataFirst)
 
@@ -804,7 +918,9 @@ const decideSubmitRecoveryWriteDataFirst = (
   if (recoveredIntentIds.length === 0 && transition.nextState === IntentState.Acknowledged) {
     return Result.succeed({ _tag: 'VerifyAcknowledgedIntent' })
   }
-  return Result.fail(storeError(storeOperation, 'conflict', 'unknown intent recovery lost its race'))
+  return Result.fail(
+    storeError({ operation: storeOperation, failure: 'conflict', message: 'unknown intent recovery lost its race' }),
+  )
 }
 
 export const decideSubmitRecoveryWrite = Pipeable.dual(3, decideSubmitRecoveryWriteDataFirst)
@@ -815,7 +931,13 @@ const decideAcknowledgedRecoveryDataFirst = (
 ): Result.Result<void, MutationStoreError> =>
   acknowledged === true
     ? Result.succeed(undefined)
-    : Result.fail(storeError(storeOperation, 'conflict', 'submit recovery requires an unresolved durable intent'))
+    : Result.fail(
+        storeError({
+          operation: storeOperation,
+          failure: 'conflict',
+          message: 'submit recovery requires an unresolved durable intent',
+        }),
+      )
 
 export const decideAcknowledgedRecovery = Pipeable.dual(2, decideAcknowledgedRecoveryDataFirst)
 
@@ -827,13 +949,13 @@ const decideRecoveredOutcomeWriteDataFirst = (
   transitionedIntentIds.length === 1
     ? Result.succeed(undefined)
     : Result.fail(
-        storeError(
-          storeOperation,
-          'conflict',
-          acknowledgedTerminal
+        storeError({
+          operation: storeOperation,
+          failure: 'conflict',
+          message: acknowledgedTerminal
             ? 'acknowledged intent terminal recovery lost its race'
             : 'recovered intent outcome lost its race',
-        ),
+        }),
       )
 
 export const decideRecoveredOutcomeWrite = Pipeable.dual(3, decideRecoveredOutcomeWriteDataFirst)
@@ -844,7 +966,9 @@ const decideCancelRecoveryStateDataFirst = (
 ): Result.Result<IntentState.Acknowledged | IntentState.Recovered, MutationStoreError> => {
   if (recoveredIntentIds.length === 0) return Result.succeed(IntentState.Acknowledged)
   if (recoveredIntentIds.length === 1) return Result.succeed(IntentState.Recovered)
-  return Result.fail(storeError(storeOperation, 'conflict', 'intent mutation outcome lost its race'))
+  return Result.fail(
+    storeError({ operation: storeOperation, failure: 'conflict', message: 'intent mutation outcome lost its race' }),
+  )
 }
 
 export const decideCancelRecoveryState = Pipeable.dual(2, decideCancelRecoveryStateDataFirst)
@@ -854,7 +978,12 @@ const decodeStartInputDataFirst = (
   input: unknown,
 ): Result.Result<MutationStartInput, MutationStoreError> =>
   Result.mapError(decodeStartInputResult(input), (cause) =>
-    storeError(startStoreOperationFor(operation), 'decode', 'invalid mutation start', cause),
+    storeError({
+      operation: startStoreOperationFor(operation),
+      failure: 'decode',
+      message: 'invalid mutation start',
+      cause,
+    }),
   )
 
 export const decodeStartInput = Pipeable.dual(2, decodeStartInputDataFirst)
@@ -878,7 +1007,7 @@ const decodeOutcomeInputDataFirst = (
       ...(input.brokerOrderId === undefined ? {} : { brokerOrderId: input.brokerOrderId }),
       ...(evidence._tag === 'RetainCompleteEvidence' ? { evidence: evidence.evidence } : {}),
     }),
-    (cause) => storeError(storeOperation, 'decode', 'invalid mutation outcome', cause),
+    (cause) => storeError({ operation: storeOperation, failure: 'decode', message: 'invalid mutation outcome', cause }),
   )
 }
 

--- a/services/bayn/src/execution/mutations/postgres/events.ts
+++ b/services/bayn/src/execution/mutations/postgres/events.ts
@@ -53,7 +53,9 @@ export const makeMutationEventPostgres = (sql: PgClient.PgClient): MutationEvent
     fromDecision(() => decodeIntentId(intentId)).pipe(
       Effect.flatMap((decodedIntentId) => readLatest(decodedIntentId, operation)),
       Effect.mapError((cause) =>
-        cause instanceof MutationStoreError ? cause : storeError('read', 'query', 'mutation read failed', cause),
+        cause instanceof MutationStoreError
+          ? cause
+          : storeError({ operation: 'read', failure: 'query', message: 'mutation read failed', cause }),
       ),
     )
 

--- a/services/bayn/src/execution/mutations/program.ts
+++ b/services/bayn/src/execution/mutations/program.ts
@@ -24,7 +24,7 @@ export const makePostgresMutationStore = Effect.gen(function* () {
       Effect.mapError((cause) =>
         cause instanceof MutationStoreError || cause instanceof WriterFenceError
           ? cause
-          : storeError(operation, 'query', `mutation ${operation} failed`, cause),
+          : storeError({ operation, failure: 'query', message: `mutation ${operation} failed`, cause }),
       ),
     )
 

--- a/services/bayn/src/execution/mutations/rows.ts
+++ b/services/bayn/src/execution/mutations/rows.ts
@@ -110,13 +110,15 @@ const toEvent = (row: (typeof StoredEventRows.Type)[number]): MutationEvent => (
 export const decodeStoredEvents = (rows: unknown): Result.Result<readonly MutationEvent[], MutationStoreError> =>
   Result.map(
     Result.mapError(decodeStoredEventRows(rows), (cause) =>
-      storeError('read', 'decode', 'stored mutation event failed decoding', cause),
+      storeError({ operation: 'read', failure: 'decode', message: 'stored mutation event failed decoding', cause }),
     ),
     (decoded) => decoded.map(toEvent),
   )
 
 export const decodeIntentId = (intentId: string): Result.Result<string, MutationStoreError> =>
-  Result.mapError(decodeIntentIdResult(intentId), (cause) => storeError('read', 'decode', 'invalid intent ID', cause))
+  Result.mapError(decodeIntentIdResult(intentId), (cause) =>
+    storeError({ operation: 'read', failure: 'decode', message: 'invalid intent ID', cause }),
+  )
 
 const decodeAuthoritySnapshotDataFirst = (
   operation: MutationOperation,
@@ -124,7 +126,12 @@ const decodeAuthoritySnapshotDataFirst = (
 ): Result.Result<MutationAuthoritySnapshot | undefined, MutationStoreError> =>
   Result.map(
     Result.mapError(decodeAuthorityRows(rows), (cause) =>
-      storeError(startStoreOperationFor(operation), 'decode', 'stored mutation authority failed decoding', cause),
+      storeError({
+        operation: startStoreOperationFor(operation),
+        failure: 'decode',
+        message: 'stored mutation authority failed decoding',
+        cause,
+      }),
     ),
     (decoded) => {
       const authority = decoded[0]
@@ -149,7 +156,12 @@ const decodeIntentSnapshotDataFirst = (
 ): Result.Result<MutationIntentSnapshot | undefined, MutationStoreError> =>
   Result.map(
     Result.mapError(decodeIntentRows(rows), (cause) =>
-      storeError(startStoreOperationFor(operation), 'decode', 'stored mutation intent failed decoding', cause),
+      storeError({
+        operation: startStoreOperationFor(operation),
+        failure: 'decode',
+        message: 'stored mutation intent failed decoding',
+        cause,
+      }),
     ),
     (decoded) => {
       const intent = decoded[0]
@@ -176,7 +188,12 @@ export const decodeIntentSnapshot = Pipeable.dual(2, decodeIntentSnapshotDataFir
 export const decodeUnresolved = (rows: unknown): Result.Result<boolean | undefined, MutationStoreError> =>
   Result.map(
     Result.mapError(decodeUnresolvedRows(rows), (cause) =>
-      storeError('begin-submit', 'decode', 'unresolved mutation result failed decoding', cause),
+      storeError({
+        operation: 'begin-submit',
+        failure: 'decode',
+        message: 'unresolved mutation result failed decoding',
+        cause,
+      }),
     ),
     (decoded) => decoded[0]?.unresolved,
   )
@@ -187,7 +204,7 @@ const decodeEventIdsDataFirst = (
 ): Result.Result<readonly string[], MutationStoreError> =>
   Result.map(
     Result.mapError(decodeEventIdRows(rows), (cause) =>
-      storeError(operation, 'decode', 'mutation event append result failed decoding', cause),
+      storeError({ operation, failure: 'decode', message: 'mutation event append result failed decoding', cause }),
     ),
     (decoded) => decoded.map((row) => row.event_id),
   )
@@ -200,7 +217,7 @@ const decodeIntentIdsDataFirst = (
   rows: unknown,
 ): Result.Result<readonly string[], MutationStoreError> =>
   Result.map(
-    Result.mapError(decodeIntentIdRows(rows), (cause) => storeError(operation, 'decode', message, cause)),
+    Result.mapError(decodeIntentIdRows(rows), (cause) => storeError({ operation, failure: 'decode', message, cause })),
     (decoded) => decoded.map((row) => row.intent_id),
   )
 
@@ -212,7 +229,7 @@ const decodeOutcomeIntentSnapshotDataFirst = (
 ): Result.Result<MutationReplayIntentSnapshot | undefined, MutationStoreError> =>
   Result.map(
     Result.mapError(decodeOutcomeIntentRows(rows), (cause) =>
-      storeError(operation, 'decode', 'stored mutation intent state failed decoding', cause),
+      storeError({ operation, failure: 'decode', message: 'stored mutation intent state failed decoding', cause }),
     ),
     (decoded) => {
       const intent = decoded[0]
@@ -233,7 +250,12 @@ const decodeAcknowledgedDataFirst = (
 ): Result.Result<boolean | undefined, MutationStoreError> =>
   Result.map(
     Result.mapError(decodeAcknowledgedRows(rows), (cause) =>
-      storeError(operation, 'decode', 'acknowledged submit recovery result failed decoding', cause),
+      storeError({
+        operation,
+        failure: 'decode',
+        message: 'acknowledged submit recovery result failed decoding',
+        cause,
+      }),
     ),
     (decoded) => decoded[0]?.acknowledged,
   )

--- a/services/bayn/src/observe-composition.ts
+++ b/services/bayn/src/observe-composition.ts
@@ -991,25 +991,25 @@ export const buildClosingPaperCycleDecision = (
 ): Effect.Effect<PaperDecisionDocument, CycleRunnerError, ObserveDecisionRuntime> =>
   Effect.gen(function* () {
     const reconciliation = yield* reconcile.pipe(
-      Effect.mapError((cause) => mutationRunnerError('PAPER close reconciliation failed', cause)),
+      Effect.mapError((cause) => mutationRunnerError({ message: 'PAPER close reconciliation failed', cause })),
     )
     const evaluatedAt = yield* currentUtcInstant
     const executionAuthority = yield* Effect.fromResult(
       requireMutationAuthorityGeneration(reconciliation, policy, input.authorityGenerationHash),
-    ).pipe(Effect.mapError((cause) => mutationRunnerError(cause.message, cause, 'contract')))
+    ).pipe(Effect.mapError((cause) => mutationRunnerError({ message: cause.message, cause, failure: 'contract' })))
     const executionSession = yield* Effect.fromResult(
       recoverPaperExecutionSession(preparation, cycle, entryDocument),
-    ).pipe(Effect.mapError((cause) => mutationRunnerError(cause.message, cause, 'contract')))
+    ).pipe(Effect.mapError((cause) => mutationRunnerError({ message: cause.message, cause, failure: 'contract' })))
     const symbols = [
       ...entryDocument.targetPlan.targets.map((target) => target.symbol),
       ...reconciliation.brokerState.positions.map((position) => position.symbol),
     ]
     const closeDecision = yield* Effect.fromResult(
       makeClosingDecisionPlan(cycle.identity.signalSessionDate, symbols),
-    ).pipe(Effect.mapError((cause) => mutationRunnerError(cause.message, cause, 'contract')))
+    ).pipe(Effect.mapError((cause) => mutationRunnerError({ message: cause.message, cause, failure: 'contract' })))
     const closeDecisionHash = yield* Effect.fromResult(
       hashObserveMaterial('compiled-decision-hash', 'close decision is not canonicalizable', closeDecision),
-    ).pipe(Effect.mapError((cause) => mutationRunnerError(cause.message, cause, 'contract')))
+    ).pipe(Effect.mapError((cause) => mutationRunnerError({ message: cause.message, cause, failure: 'contract' })))
     const prices = yield* Effect.fromResult(
       makeClosingReferencePrices(
         entryDocument,
@@ -1017,10 +1017,10 @@ export const buildClosingPaperCycleDecision = (
         cycle.identity.signalSessionDate,
         evaluatedAt,
       ),
-    ).pipe(Effect.mapError((cause) => mutationRunnerError(cause.message, cause, 'contract')))
+    ).pipe(Effect.mapError((cause) => mutationRunnerError({ message: cause.message, cause, failure: 'contract' })))
     const policyHash = yield* Effect.fromResult(
       hashObserveMaterial('risk-policy-hash', 'PAPER close risk policy is not canonicalizable', policy),
-    ).pipe(Effect.mapError((cause) => mutationRunnerError(cause.message, cause, 'contract')))
+    ).pipe(Effect.mapError((cause) => mutationRunnerError({ message: cause.message, cause, failure: 'contract' })))
     const plannerInput: TargetPlannerInput = {
       schemaVersion: 'bayn.paper-target-planner-input.v1',
       strategyName: cycle.identity.strategyName,
@@ -1038,7 +1038,7 @@ export const buildClosingPaperCycleDecision = (
       observedAt: evaluatedAt,
     }
     const targetPlan = yield* Effect.fromResult(planTargets(plannerInput)).pipe(
-      Effect.mapError((cause) => mutationRunnerError(cause.message, cause, 'contract')),
+      Effect.mapError((cause) => mutationRunnerError({ message: cause.message, cause, failure: 'contract' })),
     )
     const riskInputs = yield* Effect.fromResult(
       reduceRiskInputs({
@@ -1052,7 +1052,7 @@ export const buildClosingPaperCycleDecision = (
         evaluatedAt,
         closeOnlyExpiresAt: closeExpiresAt,
       }),
-    ).pipe(Effect.mapError((cause) => mutationRunnerError(cause.message, cause, 'contract')))
+    ).pipe(Effect.mapError((cause) => mutationRunnerError({ message: cause.message, cause, failure: 'contract' })))
     return yield* buildPaperDecision({
       cycle,
       snapshot: {
@@ -1072,7 +1072,11 @@ export const buildClosingPaperCycleDecision = (
     }).pipe(
       Effect.mapError((cause) => {
         const converted = decisionBuildError(cause)
-        return mutationRunnerError('deterministic PAPER close plan construction failed', converted, converted.failure)
+        return mutationRunnerError({
+          message: 'deterministic PAPER close plan construction failed',
+          cause: converted,
+          failure: converted.failure,
+        })
       }),
     )
   })
@@ -1261,12 +1265,18 @@ const readBoundMutationDocument = (
 ): Effect.Effect<CycleDecisionDocument, CycleRunnerError, CycleStore> =>
   CycleStore.pipe(
     Effect.flatMap((store) => store.readDecisionDocument(cycle.identity.cycleId)),
-    Effect.mapError((cause) => mutationRunnerError('durable mutation-cycle shadow plan read failed', cause, 'store')),
+    Effect.mapError((cause) =>
+      mutationRunnerError({ message: 'durable mutation-cycle shadow plan read failed', cause, failure: 'store' }),
+    ),
     Effect.flatMap((document) =>
       Option.match(document, {
         onNone: () =>
           Effect.fail(
-            mutationRunnerError('decision-bound mutation cycle is missing its durable shadow plan', undefined, 'store'),
+            mutationRunnerError({
+              message: 'decision-bound mutation cycle is missing its durable shadow plan',
+              cause: undefined,
+              failure: 'store',
+            }),
           ),
         onSome: Effect.succeed,
       }),
@@ -1278,7 +1288,9 @@ const readPaperCycleClosure = (
   store: PaperCycleClosureStoreShape,
 ): Effect.Effect<PaperCycleClosure | undefined, CycleRunnerError> =>
   store.read(cycleId).pipe(
-    Effect.mapError((cause) => mutationRunnerError('durable PAPER close plan read failed', cause, 'store')),
+    Effect.mapError((cause) =>
+      mutationRunnerError({ message: 'durable PAPER close plan read failed', cause, failure: 'store' }),
+    ),
     Effect.map(Option.getOrUndefined),
   )
 
@@ -1287,7 +1299,9 @@ const readLatestPaperCycleCloseReplan = (
   store: PaperCycleClosureStoreShape,
 ): Effect.Effect<PaperCycleClosure | undefined, CycleRunnerError> =>
   store.readLatestReplan(cycleId).pipe(
-    Effect.mapError((cause) => mutationRunnerError('durable PAPER close replan read failed', cause, 'store')),
+    Effect.mapError((cause) =>
+      mutationRunnerError({ message: 'durable PAPER close replan read failed', cause, failure: 'store' }),
+    ),
     Effect.map(Option.getOrUndefined),
   )
 
@@ -1303,7 +1317,9 @@ const closePlanNeedsResidualReplan = (
         intentStore
           .read(intentId)
           .pipe(
-            Effect.mapError((cause) => mutationRunnerError('PAPER close intent recovery read failed', cause, 'store')),
+            Effect.mapError((cause) =>
+              mutationRunnerError({ message: 'PAPER close intent recovery read failed', cause, failure: 'store' }),
+            ),
           ),
       { concurrency: 1 },
     )
@@ -1315,7 +1331,7 @@ const closePlanNeedsResidualReplan = (
       return false
     }
     const facts = yield* reconcile.pipe(
-      Effect.mapError((cause) => mutationRunnerError('PAPER residual close reconciliation failed', cause)),
+      Effect.mapError((cause) => mutationRunnerError({ message: 'PAPER residual close reconciliation failed', cause })),
     )
     return paperClosePlanNeedsResidualReplan(
       records
@@ -1343,11 +1359,11 @@ const ensurePaperCycleClosure = (
     const existing = yield* readPaperCycleClosure(cycle.identity.cycleId, store)
     const entryDecisionHash = cycle.bindings.decisionHash
     if (entryDecisionHash === undefined) {
-      return yield* mutationRunnerError(
-        'active PAPER cycle has no immutable entry decision hash for its close plan',
-        undefined,
-        'contract',
-      )
+      return yield* mutationRunnerError({
+        message: 'active PAPER cycle has no immutable entry decision hash for its close plan',
+        cause: undefined,
+        failure: 'contract',
+      })
     }
     if (existing === undefined) {
       const document = yield* buildClosingPaperCycleDecision(
@@ -1370,11 +1386,17 @@ const ensurePaperCycleClosure = (
           expiresAt: closeExpiresAt,
         }),
       ).pipe(
-        Effect.mapError((cause) => mutationRunnerError('PAPER close plan canonical binding failed', cause, 'contract')),
+        Effect.mapError((cause) =>
+          mutationRunnerError({ message: 'PAPER close plan canonical binding failed', cause, failure: 'contract' }),
+        ),
       )
       const stored = yield* store
         .bind(closure)
-        .pipe(Effect.mapError((cause) => mutationRunnerError('PAPER close plan durable bind failed', cause, 'store')))
+        .pipe(
+          Effect.mapError((cause) =>
+            mutationRunnerError({ message: 'PAPER close plan durable bind failed', cause, failure: 'store' }),
+          ),
+        )
       return stored.document
     }
 
@@ -1404,14 +1426,18 @@ const ensurePaperCycleClosure = (
       }),
     ).pipe(
       Effect.mapError((cause) =>
-        mutationRunnerError('PAPER residual close plan canonical binding failed', cause, 'contract'),
+        mutationRunnerError({
+          message: 'PAPER residual close plan canonical binding failed',
+          cause,
+          failure: 'contract',
+        }),
       ),
     )
     const stored = yield* store
       .bindReplan(closure)
       .pipe(
         Effect.mapError((cause) =>
-          mutationRunnerError('PAPER residual close plan durable bind failed', cause, 'store'),
+          mutationRunnerError({ message: 'PAPER residual close plan durable bind failed', cause, failure: 'store' }),
         ),
       )
     return stored.document
@@ -1427,7 +1453,11 @@ const entryPaperCycleHasUnsuccessfulIntent = (
       (intentId) =>
         store
           .read(intentId)
-          .pipe(Effect.mapError((cause) => mutationRunnerError('entry PAPER intent read failed', cause, 'store'))),
+          .pipe(
+            Effect.mapError((cause) =>
+              mutationRunnerError({ message: 'entry PAPER intent read failed', cause, failure: 'store' }),
+            ),
+          ),
       { concurrency: 1 },
     )
     return records.some(
@@ -1470,17 +1500,19 @@ const readMutationPreparationFacts = (
       request.reconcile,
     )
     const reads = yield* Effect.fromResult(prepareObserveDecisionReads(decisionInput)).pipe(
-      Effect.mapError((cause) => mutationRunnerError('mutation cycle decision reads are invalid', cause, 'contract')),
+      Effect.mapError((cause) =>
+        mutationRunnerError({ message: 'mutation cycle decision reads are invalid', cause, failure: 'contract' }),
+      ),
     )
     const facts = yield* readObserveDecisionFacts(decisionInput, reads).pipe(
       Effect.mapError((cause) => {
         const converted = decisionBuildError(cause)
-        return mutationRunnerError(converted.message, cause, converted.failure)
+        return mutationRunnerError({ message: converted.message, cause, failure: converted.failure })
       }),
     )
     const authority = yield* Effect.fromResult(
       requireMutationAuthorityGeneration(facts.reconciliation, request.policy, request.input.authorityGenerationHash),
-    ).pipe(Effect.mapError((cause) => mutationRunnerError(cause.message, cause, 'contract')))
+    ).pipe(Effect.mapError((cause) => mutationRunnerError({ message: cause.message, cause, failure: 'contract' })))
     return {
       snapshot: facts.snapshot.manifest.finalizedSnapshot,
       reconciliation: facts.reconciliation,
@@ -1499,12 +1531,12 @@ const readCloseMutationPreparationFacts = (
 ): Effect.Effect<MutationPreparationFacts, CycleRunnerError, ObserveDecisionRuntime> =>
   Effect.gen(function* () {
     const reconciliation = yield* request.reconcile.pipe(
-      Effect.mapError((cause) => mutationRunnerError('PAPER close reconciliation failed', cause)),
+      Effect.mapError((cause) => mutationRunnerError({ message: 'PAPER close reconciliation failed', cause })),
     )
     const evaluatedAt = yield* currentUtcInstant
     const authority = yield* Effect.fromResult(
       requireMutationAuthorityGeneration(reconciliation, request.policy, request.input.authorityGenerationHash),
-    ).pipe(Effect.mapError((cause) => mutationRunnerError(cause.message, cause, 'contract')))
+    ).pipe(Effect.mapError((cause) => mutationRunnerError({ message: cause.message, cause, failure: 'contract' })))
     return {
       snapshot: {
         contentHash: request.document.bindings.snapshotContentHash,
@@ -1621,7 +1653,9 @@ const readUnfinishedMutationCycle = (
         accountId: context.accountId,
       }),
     ),
-    Effect.mapError((cause) => mutationRunnerError('oldest unfinished mutation cycle read failed', cause, 'store')),
+    Effect.mapError((cause) =>
+      mutationRunnerError({ message: 'oldest unfinished mutation cycle read failed', cause, failure: 'store' }),
+    ),
     Effect.map(Option.getOrUndefined),
   )
 
@@ -1634,7 +1668,9 @@ const terminalizeUnboundMutationCycleAtCutoff = (
 ): Effect.Effect<CycleRunResult, CycleRunnerError, CycleStore> =>
   CycleStore.pipe(
     Effect.flatMap((store) => store.block(cycle.identity.cycleId, CycleTerminalReason.Authority, observedAt)),
-    Effect.mapError((cause) => mutationRunnerError('expired PAPER unbound cycle finalization failed', cause, 'store')),
+    Effect.mapError((cause) =>
+      mutationRunnerError({ message: 'expired PAPER unbound cycle finalization failed', cause, failure: 'store' }),
+    ),
     Effect.map((receipt) => ({
       outcome: 'RECOVERED' as const,
       action: 'BLOCKED' as const,
@@ -1654,7 +1690,9 @@ const terminalizeBlockedPaperCycleDataFirst = (
     Effect.andThen(
       CycleStore.pipe(
         Effect.flatMap((store) => store.block(cycle.identity.cycleId, outcome.reason, outcome.observedAt)),
-        Effect.mapError((cause) => mutationRunnerError('blocked PAPER cycle finalization failed', cause, 'store')),
+        Effect.mapError((cause) =>
+          mutationRunnerError({ message: 'blocked PAPER cycle finalization failed', cause, failure: 'store' }),
+        ),
       ),
     ),
     Effect.map((receipt) => ({
@@ -1688,7 +1726,9 @@ const interpretBoundMutationCycleOutcome = (
     case 'Complete':
       return CycleStore.pipe(
         Effect.flatMap((store) => store.finish(cycle.identity.cycleId, CycleState.Completed, outcome.observedAt)),
-        Effect.mapError((cause) => mutationRunnerError('completed PAPER cycle finalization failed', cause, 'store')),
+        Effect.mapError((cause) =>
+          mutationRunnerError({ message: 'completed PAPER cycle finalization failed', cause, failure: 'store' }),
+        ),
         Effect.tap((receipt) =>
           receipt.changed && input.onClosedCycle !== undefined
             ? input.onClosedCycle(cycle.identity.cycleId, outcome.observedAt)

--- a/services/bayn/src/observe-composition/mutation-intent-interpreter.ts
+++ b/services/bayn/src/observe-composition/mutation-intent-interpreter.ts
@@ -104,11 +104,11 @@ const validateBoundMutationDocument = (
   (input.mutationPhase === 'CLOSE' && input.authorityGenerationHash !== document.bindings.authorityGenerationHash) ||
   input.accountId !== document.bindings.accountId
     ? Result.fail(
-        mutationRunnerError(
-          'durable shadow plan does not match the mutation cycle account, protocol, and decision binding',
-          undefined,
-          'contract',
-        ),
+        mutationRunnerError({
+          message: 'durable shadow plan does not match the mutation cycle account, protocol, and decision binding',
+          cause: undefined,
+          failure: 'contract',
+        }),
       )
     : Result.succeed(undefined)
 
@@ -118,15 +118,17 @@ const validateCurrentMutationPolicy = (
 ): Result.Result<void, CycleRunnerError> => {
   const policyHash = canonicalHashV1Result(policy)
   if (Result.isFailure(policyHash)) {
-    return Result.fail(mutationRunnerError('mutation cycle risk policy is not canonicalizable', policyHash.failure))
+    return Result.fail(
+      mutationRunnerError({ message: 'mutation cycle risk policy is not canonicalizable', cause: policyHash.failure }),
+    )
   }
   return policyHash.success !== document.bindings.policyHash
     ? Result.fail(
-        mutationRunnerError(
-          'current source-controlled PAPER risk policy changed from the durable decision binding',
-          undefined,
-          'contract',
-        ),
+        mutationRunnerError({
+          message: 'current source-controlled PAPER risk policy changed from the durable decision binding',
+          cause: undefined,
+          failure: 'contract',
+        }),
       )
     : Result.succeed(undefined)
 }
@@ -143,11 +145,11 @@ const boundPaperSubmissionCutoff = (
       document.expiresAt !== input.paperEpisodeExpiresAt
     ) {
       return Result.fail(
-        mutationRunnerError(
-          'durable PAPER close plan changed from its immutable activation close lease',
-          undefined,
-          'contract',
-        ),
+        mutationRunnerError({
+          message: 'durable PAPER close plan changed from its immutable activation close lease',
+          cause: undefined,
+          failure: 'contract',
+        }),
       )
     }
     return Result.succeed(input.paperEpisodeExpiresAt)
@@ -157,11 +159,11 @@ const boundPaperSubmissionCutoff = (
     document.expiresAt !== cycle.window.submissionCutoffAt
   ) {
     return Result.fail(
-      mutationRunnerError(
-        'durable PAPER decision changed from its immutable cycle submission window',
-        undefined,
-        'contract',
-      ),
+      mutationRunnerError({
+        message: 'durable PAPER decision changed from its immutable cycle submission window',
+        cause: undefined,
+        failure: 'contract',
+      }),
     )
   }
   return Result.succeed(cycle.window.submissionCutoffAt)
@@ -199,16 +201,22 @@ const validateCurrentMutationExecutionTerms = (
     MICROS,
   )
   if (Result.isFailure(fillTerms)) {
-    return Result.fail(mutationRunnerError('mutation execution terms are invalid', fillTerms.failure, 'contract'))
+    return Result.fail(
+      mutationRunnerError({
+        message: 'mutation execution terms are invalid',
+        cause: fillTerms.failure,
+        failure: 'contract',
+      }),
+    )
   }
   return fillTerms.success.notionalMicros.toString() === riskBinding.notionalLimitMicros
     ? Result.succeed(undefined)
     : Result.fail(
-        mutationRunnerError(
-          'durable mutation notional changed from the current execution model',
-          undefined,
-          'contract',
-        ),
+        mutationRunnerError({
+          message: 'durable mutation notional changed from the current execution model',
+          cause: undefined,
+          failure: 'contract',
+        }),
       )
 }
 
@@ -268,37 +276,47 @@ const prepareMutationIntentDataFirst = <R, E, I extends MutationIntentInput, P e
       const target = targets.get(targetIntent.symbol)
       const intentId = document.orderedIntentIds[index]
       if (riskBinding === undefined || target === undefined || intentId === undefined) {
-        return yield* mutationRunnerError(
-          'durable mutation target is missing its intent, risk, or final-position binding',
-          undefined,
-          'contract',
-        )
+        return yield* mutationRunnerError({
+          message: 'durable mutation target is missing its intent, risk, or final-position binding',
+          cause: undefined,
+          failure: 'contract',
+        })
       }
       const stored = yield* intentStore
         .read(intentId)
         .pipe(
-          Effect.mapError((cause) => mutationRunnerError('durable PAPER intent recovery read failed', cause, 'store')),
+          Effect.mapError((cause) =>
+            mutationRunnerError({ message: 'durable PAPER intent recovery read failed', cause, failure: 'store' }),
+          ),
         )
       const existing = Option.getOrUndefined(stored)
       const latestSubmit = yield* mutationStore
         .latest(intentId, MutationOperation.Submit)
-        .pipe(Effect.mapError((cause) => mutationRunnerError('durable submit state read failed', cause, 'store')))
+        .pipe(
+          Effect.mapError((cause) =>
+            mutationRunnerError({ message: 'durable submit state read failed', cause, failure: 'store' }),
+          ),
+        )
       const latestCancel = yield* mutationStore
         .latest(intentId, MutationOperation.Cancel)
-        .pipe(Effect.mapError((cause) => mutationRunnerError('durable cancel state read failed', cause, 'store')))
-      if (existing === undefined && (latestSubmit !== undefined || latestCancel !== undefined)) {
-        return yield* mutationRunnerError(
-          'durable mutation exists without its authority-bound intent',
-          { latestSubmit, latestCancel },
-          'contract',
+        .pipe(
+          Effect.mapError((cause) =>
+            mutationRunnerError({ message: 'durable cancel state read failed', cause, failure: 'store' }),
+          ),
         )
+      if (existing === undefined && (latestSubmit !== undefined || latestCancel !== undefined)) {
+        return yield* mutationRunnerError({
+          message: 'durable mutation exists without its authority-bound intent',
+          cause: { latestSubmit, latestCancel },
+          failure: 'contract',
+        })
       }
       if (existing !== undefined && existing.intent.intentId !== intentId) {
-        return yield* mutationRunnerError(
-          'durable PAPER intent recovery returned a different intent identity',
-          undefined,
-          'contract',
-        )
+        return yield* mutationRunnerError({
+          message: 'durable PAPER intent recovery returned a different intent identity',
+          cause: undefined,
+          failure: 'contract',
+        })
       }
       recoveryLookups.push({
         intentId,
@@ -326,22 +344,22 @@ const prepareMutationIntentDataFirst = <R, E, I extends MutationIntentInput, P e
         { authority: documentAuthority },
       ).pipe(
         Effect.mapError((cause) =>
-          mutationRunnerError('durable PAPER intent reconstruction failed', cause, 'contract'),
+          mutationRunnerError({ message: 'durable PAPER intent reconstruction failed', cause, failure: 'contract' }),
         ),
       )
       if (lookup.intentId !== intent.intentId) {
-        return yield* mutationRunnerError(
-          'durable PAPER intent identity or order changed after decision binding',
-          undefined,
-          'contract',
-        )
+        return yield* mutationRunnerError({
+          message: 'durable PAPER intent identity or order changed after decision binding',
+          cause: undefined,
+          failure: 'contract',
+        })
       }
       if (lookup.stored !== undefined && !immutableIntentBindingMatches(lookup.stored.intent, intent)) {
-        return yield* mutationRunnerError(
-          'stored PAPER intent changed from its durable decision binding',
-          undefined,
-          'contract',
-        )
+        return yield* mutationRunnerError({
+          message: 'stored PAPER intent changed from its durable decision binding',
+          cause: undefined,
+          failure: 'contract',
+        })
       }
       preparedIntents.push({ ...lookup, intent })
     }
@@ -352,7 +370,7 @@ const prepareMutationIntentDataFirst = <R, E, I extends MutationIntentInput, P e
       if (existing === undefined) continue
       const recovery = yield* Effect.fromResult(
         decidePreparedMutationRecovery(existing.intent, prepared.latestSubmit, prepared.latestCancel),
-      ).pipe(Effect.mapError((cause) => mutationRunnerError(cause.message, cause, 'contract')))
+      ).pipe(Effect.mapError((cause) => mutationRunnerError({ message: cause.message, cause, failure: 'contract' })))
       if (recovery._tag === 'Recover') {
         return mutationRecoveryIsDue(recovery.event, recoveryObservedAt)
           ? {
@@ -415,20 +433,20 @@ const prepareMutationIntentDataFirst = <R, E, I extends MutationIntentInput, P e
       if (
         preparedIntents.some((prepared) => prepared.latestSubmit !== undefined || prepared.latestCancel !== undefined)
       ) {
-        return yield* mutationRunnerError(
-          'broker mutation evidence exists before the complete immutable intent set was committed',
-          undefined,
-          'contract',
-        )
+        return yield* mutationRunnerError({
+          message: 'broker mutation evidence exists before the complete immutable intent set was committed',
+          cause: undefined,
+          failure: 'contract',
+        })
       }
     }
 
     if (input.mutationPhase === 'CLOSE' && intentStore.commitClosing === undefined) {
-      return yield* mutationRunnerError(
-        'PAPER close intent store does not expose the close-only authority port',
-        undefined,
-        'store',
-      )
+      return yield* mutationRunnerError({
+        message: 'PAPER close intent store does not expose the close-only authority port',
+        cause: undefined,
+        failure: 'store',
+      })
     }
     yield* Effect.forEach(
       preparedIntents,
@@ -437,7 +455,9 @@ const prepareMutationIntentDataFirst = <R, E, I extends MutationIntentInput, P e
           ? intentStore.commitClosing(prepared.intent, prepared.riskBinding.evaluation.decision)
           : intentStore.commit(prepared.intent, prepared.riskBinding.evaluation.decision)
         ).pipe(
-          Effect.mapError((cause) => mutationRunnerError('durable PAPER intent-set commit failed', cause, 'store')),
+          Effect.mapError((cause) =>
+            mutationRunnerError({ message: 'durable PAPER intent-set commit failed', cause, failure: 'store' }),
+          ),
         ),
       { concurrency: 1, discard: true },
     )
@@ -447,11 +467,11 @@ const prepareMutationIntentDataFirst = <R, E, I extends MutationIntentInput, P e
       document.bindings.snapshotContentHash !== facts.snapshot.contentHash ||
       document.bindings.snapshotFinalizedAt !== facts.snapshot.finalizedAt
     ) {
-      return yield* mutationRunnerError(
-        'bound mutation cycle snapshot publication changed after planning',
-        undefined,
-        'contract',
-      )
+      return yield* mutationRunnerError({
+        message: 'bound mutation cycle snapshot publication changed after planning',
+        cause: undefined,
+        failure: 'contract',
+      })
     }
 
     const terminalEvidence: PaperCycleIntentTerminalEvidence[] = []
@@ -464,20 +484,28 @@ const prepareMutationIntentDataFirst = <R, E, I extends MutationIntentInput, P e
     for (const prepared of preparedIntents) {
       const stored = yield* intentStore
         .read(prepared.intent.intentId)
-        .pipe(Effect.mapError((cause) => mutationRunnerError('committed PAPER intent readback failed', cause, 'store')))
+        .pipe(
+          Effect.mapError((cause) =>
+            mutationRunnerError({ message: 'committed PAPER intent readback failed', cause, failure: 'store' }),
+          ),
+        )
       const record = Option.getOrUndefined(stored)
       if (record === undefined) {
-        return yield* mutationRunnerError(
-          'committed PAPER intent disappeared before execution selection',
-          undefined,
-          'contract',
-        )
+        return yield* mutationRunnerError({
+          message: 'committed PAPER intent disappeared before execution selection',
+          cause: undefined,
+          failure: 'contract',
+        })
       }
       const latest = yield* mutationStore
         .latest(prepared.intent.intentId, MutationOperation.Submit)
-        .pipe(Effect.mapError((cause) => mutationRunnerError('durable submit state refresh failed', cause, 'store')))
+        .pipe(
+          Effect.mapError((cause) =>
+            mutationRunnerError({ message: 'durable submit state refresh failed', cause, failure: 'store' }),
+          ),
+        )
       const decision = yield* Effect.fromResult(decidePreparedMutationIntent(record.intent, latest)).pipe(
-        Effect.mapError((cause) => mutationRunnerError(cause.message, cause, 'contract')),
+        Effect.mapError((cause) => mutationRunnerError({ message: cause.message, cause, failure: 'contract' })),
       )
       switch (decision._tag) {
         case 'SkipTerminal':
@@ -554,7 +582,9 @@ const prepareMutationIntentDataFirst = <R, E, I extends MutationIntentInput, P e
                   facts.reconciliation.report.metrics.accountingExact,
                   facts.reconciliation.brokerState.unknownOrderCount,
                 ),
-          ).pipe(Effect.mapError((cause) => mutationRunnerError(cause.message, cause, 'contract')))
+          ).pipe(
+            Effect.mapError((cause) => mutationRunnerError({ message: cause.message, cause, failure: 'contract' })),
+          )
           return {
             _tag: 'Execute',
             action: 'SUBMIT',

--- a/services/bayn/src/observe-composition/mutation-interpreter.ts
+++ b/services/bayn/src/observe-composition/mutation-interpreter.ts
@@ -17,16 +17,18 @@ export type PaperMutationExecutor<E, R> = {
 
 export const mutationConsistencyDelayMs = 1_000
 
-export const mutationRunnerError = (
-  message: string,
-  cause?: unknown,
-  failure: CycleRunnerError['failure'] = 'operational',
-): CycleRunnerError =>
+export interface MutationRunnerErrorInput {
+  readonly message: string
+  readonly cause?: unknown
+  readonly failure?: CycleRunnerError['failure']
+}
+
+export const mutationRunnerError = (input: MutationRunnerErrorInput): CycleRunnerError =>
   new CycleRunnerError({
     operation: 'recover-cycle',
-    failure,
-    message,
-    cause,
+    failure: input.failure ?? 'operational',
+    message: input.message,
+    cause: input.cause,
   })
 
 const restrictMutationAuthorityDataFirst = (
@@ -41,11 +43,11 @@ const restrictMutationAuthorityDataFirst = (
       .transaction(store.restrictAuthority(`${subject} restricted effective authority: ${reason}`, updatedAt))
       .pipe(
         Effect.mapError((cause) =>
-          mutationRunnerError(
-            'authority restriction failed after a bound PAPER cycle failure',
-            { subject, reason, cause },
-            'store',
-          ),
+          mutationRunnerError({
+            message: 'authority restriction failed after a bound PAPER cycle failure',
+            cause: { subject, reason, cause },
+            failure: 'store',
+          }),
         ),
       )
   })
@@ -70,47 +72,49 @@ export const executeMutationIntentWithExecutor = <E, R>(
   Effect.gen(function* () {
     const store = yield* MutationStore
     const operation = action === 'RECOVER_CANCEL' ? MutationOperation.Cancel : MutationOperation.Submit
-    const existing = yield* store
-      .latest(intentId, operation)
-      .pipe(
-        Effect.mapError((cause) =>
-          mutationRunnerError(`durable ${operation.toLowerCase()} recovery read failed`, cause, 'store'),
-        ),
-      )
+    const existing = yield* store.latest(intentId, operation).pipe(
+      Effect.mapError((cause) =>
+        mutationRunnerError({
+          message: `durable ${operation.toLowerCase()} recovery read failed`,
+          cause,
+          failure: 'store',
+        }),
+      ),
+    )
     let event: MutationEvent
     if (existing === undefined) {
       if (action !== 'SUBMIT') {
-        return yield* mutationRunnerError(
-          `lookup-only PAPER recovery lost its durable ${operation.toLowerCase()} evidence`,
-          { intentId, action, operation },
-          'contract',
-        )
+        return yield* mutationRunnerError({
+          message: `lookup-only PAPER recovery lost its durable ${operation.toLowerCase()} evidence`,
+          cause: { intentId, action, operation },
+          failure: 'contract',
+        })
       }
       if (submitExpiresAt === undefined) {
-        return yield* mutationRunnerError(
-          'fresh PAPER submit is missing its immutable submission cutoff',
-          undefined,
-          'contract',
-        )
+        return yield* mutationRunnerError({
+          message: 'fresh PAPER submit is missing its immutable submission cutoff',
+          cause: undefined,
+          failure: 'contract',
+        })
       }
       const submitObservedAt = yield* now
       if (submitObservedAt >= submitExpiresAt) {
-        return yield* mutationRunnerError(
-          'fresh PAPER submit crossed its immutable submission cutoff before broker I/O',
-          { intentId, submitObservedAt, submitExpiresAt },
-          'contract',
-        )
+        return yield* mutationRunnerError({
+          message: 'fresh PAPER submit crossed its immutable submission cutoff before broker I/O',
+          cause: { intentId, submitObservedAt, submitExpiresAt },
+          failure: 'contract',
+        })
       }
       if (executor.submit === undefined) {
-        return yield* mutationRunnerError(
-          'fresh PAPER submit is unavailable under OBSERVE recovery-only authority',
-          undefined,
-          'contract',
-        )
+        return yield* mutationRunnerError({
+          message: 'fresh PAPER submit is unavailable under OBSERVE recovery-only authority',
+          cause: undefined,
+          failure: 'contract',
+        })
       }
       event = yield* executor
         .submit(intentId, mutationConsistencyDelayMs)
-        .pipe(Effect.mapError((cause) => mutationRunnerError('guarded PAPER submit failed', cause)))
+        .pipe(Effect.mapError((cause) => mutationRunnerError({ message: 'guarded PAPER submit failed', cause })))
     } else if (operation === MutationOperation.Submit && submitDoesNotRequireRecovery(existing.eventType)) {
       event = existing
     } else {
@@ -118,17 +122,17 @@ export const executeMutationIntentWithExecutor = <E, R>(
         .recover(intentId, operation)
         .pipe(
           Effect.mapError((cause) =>
-            mutationRunnerError(`lookup-only PAPER ${operation.toLowerCase()} recovery failed`, cause),
+            mutationRunnerError({ message: `lookup-only PAPER ${operation.toLowerCase()} recovery failed`, cause }),
           ),
         )
     }
     const settlement = decideMutationIntentSettlement(event.eventType)
     if (settlement._tag === 'Unresolved') {
-      return yield* mutationRunnerError(
-        `guarded PAPER submit remains unresolved at ${settlement.eventType}`,
-        event,
-        'operational',
-      )
+      return yield* mutationRunnerError({
+        message: `guarded PAPER submit remains unresolved at ${settlement.eventType}`,
+        cause: event,
+        failure: 'operational',
+      })
     }
     return { settlement, consistencyDelayMs: event.consistencyDelayMs, operation }
   })

--- a/services/bayn/src/simulation-reconciliation/broker-compare.ts
+++ b/services/bayn/src/simulation-reconciliation/broker-compare.ts
@@ -50,10 +50,13 @@ export const compareReconciliation = (
         Result.flatMap(() =>
           ordered.length === 0
             ? Result.succeed(snapshot.stateHash)
-            : canonicalHash('observed-hash', {
-                schemaVersion: 'bayn.paper-reconciliation-observed.v1',
-                stateHash: snapshot.stateHash,
-                discrepancies: ordered.map((value) => value.evidenceHash),
+            : canonicalHash({
+                operation: 'observed-hash',
+                value: {
+                  schemaVersion: 'bayn.paper-reconciliation-observed.v1',
+                  stateHash: snapshot.stateHash,
+                  discrepancies: ordered.map((value) => value.evidenceHash),
+                },
               }),
         ),
         Result.map((observedHash) => ({

--- a/services/bayn/src/simulation-reconciliation/broker-model.ts
+++ b/services/bayn/src/simulation-reconciliation/broker-model.ts
@@ -221,17 +221,19 @@ export type ReconciliationDecisionError =
 export type ReconciliationDecision<A> = Result.Result<A, ReconciliationDecisionError>
 export const fail = <A>(error: ReconciliationDecisionError): ReconciliationDecision<A> => Result.fail(error)
 
-export const canonicalHash = (
-  operation: ReconciliationHashOperation,
-  value: unknown,
-  identity?: string,
-): ReconciliationDecision<string> =>
+export interface ReconciliationCanonicalHashInput {
+  readonly operation: ReconciliationHashOperation
+  readonly value: unknown
+  readonly identity?: string
+}
+
+export const canonicalHash = (input: ReconciliationCanonicalHashInput): ReconciliationDecision<string> =>
   Result.mapError(
-    canonicalHashV1Result(value),
+    canonicalHashV1Result(input.value),
     (cause): ReconciliationDecisionError => ({
       _tag: 'CanonicalizationFailed',
-      operation,
-      ...(identity === undefined ? {} : { identity }),
+      operation: input.operation,
+      ...(input.identity === undefined ? {} : { identity: input.identity }),
       cause,
     }),
   )
@@ -280,19 +282,25 @@ export const roundMicrosProduct = Pipeable.dual(3, roundMicrosProductDataFirst)
 
 export const reconciledStateHash = (state: ReconciledStateMaterial): ReconciliationDecision<string> =>
   pipe(
-    canonicalHash('broker-state-hash', {
-      schemaVersion: 'bayn.paper-risk-broker-state.v1',
-      account: state.account,
-      positions: state.positions,
-      positionsObservedAt: state.positionsObservedAt,
-      orders: state.orders,
-      ordersObservedAt: state.ordersObservedAt,
+    canonicalHash({
+      operation: 'broker-state-hash',
+      value: {
+        schemaVersion: 'bayn.paper-risk-broker-state.v1',
+        account: state.account,
+        positions: state.positions,
+        positionsObservedAt: state.positionsObservedAt,
+        orders: state.orders,
+        ordersObservedAt: state.ordersObservedAt,
+      },
     }),
     Result.flatMap((brokerStateHash) =>
-      canonicalHash('reconciled-state-hash', {
-        schemaVersion: 'bayn.paper-risk-reconciled-state.v1',
-        brokerStateHash,
-        accountingHash: state.accountingHash,
+      canonicalHash({
+        operation: 'reconciled-state-hash',
+        value: {
+          schemaVersion: 'bayn.paper-risk-reconciled-state.v1',
+          brokerStateHash,
+          accountingHash: state.accountingHash,
+        },
       }),
     ),
   )
@@ -347,18 +355,18 @@ const discrepancy = (
   expected === observed
     ? fail({ _tag: 'DiscrepancyWithoutDifference', kind, identity, value: expected })
     : pipe(
-        canonicalHash(
-          'discrepancy-id',
-          { schemaVersion: 'bayn.paper-discrepancy-id.v1', accountId, kind, identity },
+        canonicalHash({
+          operation: 'discrepancy-id',
+          value: { schemaVersion: 'bayn.paper-discrepancy-id.v1', accountId, kind, identity },
           identity,
-        ),
+        }),
         Result.flatMap((discrepancyId) =>
           pipe(
-            canonicalHash(
-              'discrepancy-evidence',
-              { schemaVersion: 'bayn.paper-discrepancy-evidence.v1', discrepancyId, expected, observed },
+            canonicalHash({
+              operation: 'discrepancy-evidence',
+              value: { schemaVersion: 'bayn.paper-discrepancy-evidence.v1', discrepancyId, expected, observed },
               identity,
-            ),
+            }),
             Result.map((evidenceHash) => ({ discrepancyId, kind, identity, expected, observed, evidenceHash })),
           ),
         ),


### PR DESCRIPTION
## Summary

- Makes runtime failure construction explicit and structurally typed.
- Keeps this native stack layer independently reviewable at 774 changed lines.
- Bases directly on codex/bayn-effect-tsgo-persistence-hashes so GitHub shows only this layer.

## Related Issues

None

## Testing

- bunx tsc --noEmit --project services/bayn/tsconfig.json
- bun run lint
- bun run lint:oxlint
- bun run lint:oxlint:type
- bun run build
- Focused tests for the touched subsystem were run while constructing the layer.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable and Breaking Changes is filled in.
- [x] Documentation and follow-ups are unchanged or represented by later stack layers.