### PR TITLE
refactor(bayn): align runtime Effect composition

### DIFF
--- a/services/bayn/src/app.ts
+++ b/services/bayn/src/app.ts
@@ -247,36 +247,27 @@ const runApplicationDataFirst = <StartupR, LoopR>(
   dependencies: ApplicationDependencies,
   runtime: ApplicationRuntime<StartupR, LoopR>,
 ): Effect.Effect<never, OperationalError, HttpServer.HttpServer | StartupR | LoopR> =>
-  pipe(
-    Effect.Do,
-    Effect.bind('state', () => Ref.make(initialRuntimeState(runtime))),
-    Effect.tap(({ state }) =>
-      serveHttp(config, state, strategy.provenance, config.build.verification, dependencies.evidenceStore.read),
-    ),
-    Effect.tap(({ state }) =>
-      qualificationEvidenceRequired(runtime) ? runStartup(config, state, strategy, dependencies) : Effect.void,
-    ),
-    Effect.bind('resolvedRuntime', ({ state }) => resolveRuntimeAfterStartup(runtime, state)),
-    Effect.bind('autonomousCycleFiber', ({ state, resolvedRuntime }) => startAutonomousCycle(resolvedRuntime, state)),
-    Effect.tap(({ autonomousCycleFiber, resolvedRuntime, state }) =>
-      pipe(
-        runHealthMonitor(
-          config,
-          state,
-          dependencies,
-          brokerProbe(resolvedRuntime),
-          autonomousCycleFiber,
-          resolvedRuntime._tag === 'Brokerless'
-            ? undefined
-            : (resolvedRuntime.cycleObservationId ?? resolvedRuntime.cycleBindingId ?? undefined),
-          qualificationEvidenceRequired(resolvedRuntime),
-        ),
-        Effect.forkScoped({ startImmediately: true }),
-      ),
-    ),
-    Effect.andThen(Effect.never),
-    Effect.scoped,
-  )
+  Effect.gen(function* () {
+    const state = yield* Ref.make(initialRuntimeState(runtime))
+    yield* serveHttp(config, state, strategy.provenance, config.build.verification, dependencies.evidenceStore.read)
+    if (qualificationEvidenceRequired(runtime)) {
+      yield* runStartup(config, state, strategy, dependencies)
+    }
+    const resolvedRuntime = yield* resolveRuntimeAfterStartup(runtime, state)
+    const autonomousCycleFiber = yield* startAutonomousCycle(resolvedRuntime, state)
+    yield* runHealthMonitor(
+      config,
+      state,
+      dependencies,
+      brokerProbe(resolvedRuntime),
+      autonomousCycleFiber,
+      resolvedRuntime._tag === 'Brokerless'
+        ? undefined
+        : (resolvedRuntime.cycleObservationId ?? resolvedRuntime.cycleBindingId ?? undefined),
+      qualificationEvidenceRequired(resolvedRuntime),
+    ).pipe(Effect.forkScoped({ startImmediately: true }))
+    return yield* Effect.never
+  }).pipe(Effect.scoped)
 
 export const runApplication = Pipeable.generic<
   <StartupR, LoopR>(

--- a/services/bayn/src/app.ts
+++ b/services/bayn/src/app.ts
@@ -167,11 +167,11 @@ const qualificationEvidenceRequired = <StartupR, LoopR>(runtime: ApplicationRunt
 
 const initialRuntimeState = <StartupR, LoopR>(runtime: ApplicationRuntime<StartupR, LoopR>): RuntimeState =>
   runtime._tag === 'Brokerless'
-    ? initialState()
-    : initialState(
-        runtime._tag === 'AutonomousRead' ? (runtime.broker ?? runtime.brokerConfiguration) : runtime.broker,
-        true,
-      )
+    ? initialState({})
+    : initialState({
+        broker: runtime._tag === 'AutonomousRead' ? (runtime.broker ?? runtime.brokerConfiguration) : runtime.broker,
+        autonomousCycleLoopConfigured: true,
+      })
 
 const resolveRuntimeAfterStartup = <StartupR, LoopR>(
   runtime: ApplicationRuntime<StartupR, LoopR>,

--- a/services/bayn/src/broker/alpaca-mutations/model.ts
+++ b/services/bayn/src/broker/alpaca-mutations/model.ts
@@ -62,7 +62,9 @@ export interface BrokerMutationShape {
   readonly orderByClientId?: (clientOrderId: string) => Effect.Effect<ReadResult<Order>, BrokerReadError>
 }
 
-export class BrokerMutation extends Context.Service<BrokerMutation, BrokerMutationShape>()('bayn/BrokerMutation') {}
+export class BrokerMutation extends Context.Service<BrokerMutation, BrokerMutationShape>()(
+  '@proompteng/bayn/broker/alpaca-mutations/model/BrokerMutation',
+) {}
 
 const stringFact = (cause: object, name: string): string | undefined => {
   const value = name in cause ? cause[name as keyof typeof cause] : undefined

--- a/services/bayn/src/broker/alpaca/http.ts
+++ b/services/bayn/src/broker/alpaca/http.ts
@@ -74,7 +74,7 @@ import { Pipeable } from '../../pipeable'
 const decodeResponseHeaders = HttpClientResponse.schemaHeaders(ResponseHeadersSchema, responseParseOptions)
 
 export class AlpacaHttpClient extends Context.Service<AlpacaHttpClient, HttpClient.HttpClient>()(
-  'bayn/AlpacaHttpClient',
+  '@proompteng/bayn/broker/alpaca/http/AlpacaHttpClient',
 ) {}
 
 const decodeInput = <A>(

--- a/services/bayn/src/broker/alpaca/model.ts
+++ b/services/bayn/src/broker/alpaca/model.ts
@@ -401,7 +401,9 @@ export interface BrokerReadShape {
   ) => Effect.Effect<ReadResult<MarketCalendarObservation>, BrokerReadError>
 }
 
-export class BrokerRead extends Context.Service<BrokerRead, BrokerReadShape>()('bayn/BrokerRead') {}
+export class BrokerRead extends Context.Service<BrokerRead, BrokerReadShape>()(
+  '@proompteng/bayn/broker/alpaca/model/BrokerRead',
+) {}
 
 export interface ReadPreflight {
   readonly provider: BrokerProvider

--- a/services/bayn/src/broker/alpaca/model.ts
+++ b/services/bayn/src/broker/alpaca/model.ts
@@ -1,5 +1,5 @@
 import type { Undici } from '@effect/platform-node'
-import { Context, Effect, Schema, type Result } from 'effect'
+import { Context, DateTime, Effect, Option, Schema, type Result } from 'effect'
 
 import type { BrokerEnvironment } from '../../execution/authority'
 import {
@@ -45,28 +45,11 @@ const Decimal = Schema.String.check(Schema.isPattern(/^(?:0|[1-9][0-9]*)(?:\.[0-
 const isUtcTimestamp = (value: string): boolean => {
   const match = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d{1,9}))?Z$/.exec(value)
   if (match === null) return false
-  const components = match.slice(1, 7).map(Number)
-  if (components.length !== 6) return false
-  const [year, month, day, hour, minute, second] = components
-  if (
-    year === undefined ||
-    month === undefined ||
-    day === undefined ||
-    hour === undefined ||
-    minute === undefined ||
-    second === undefined
-  ) {
-    return false
-  }
-  const date = new Date(Date.UTC(year, month - 1, day, hour, minute, second))
-  return (
-    date.getUTCFullYear() === year &&
-    date.getUTCMonth() === month - 1 &&
-    date.getUTCDate() === day &&
-    date.getUTCHours() === hour &&
-    date.getUTCMinutes() === minute &&
-    date.getUTCSeconds() === second
-  )
+  const year = match[1]
+  if (year === undefined || Number(year) < 100) return false
+  const seconds = value.slice(0, 19)
+  const date = DateTime.make(`${seconds}.000Z`)
+  return Option.isSome(date) && DateTime.formatIso(date.value).slice(0, 19) === seconds
 }
 const Timestamp = Schema.String.check(Schema.makeFilter(isUtcTimestamp, { expected: 'an RFC 3339 UTC timestamp' }))
 const ExternalClientOrderId = Schema.String.check(

--- a/services/bayn/src/broker/alpaca/session.ts
+++ b/services/bayn/src/broker/alpaca/session.ts
@@ -31,7 +31,9 @@ export interface BrokerSessionShape {
   readonly preflight: ReadPreflight
 }
 
-export class BrokerSession extends Context.Service<BrokerSession, BrokerSessionShape>()('bayn/BrokerSession') {}
+export class BrokerSession extends Context.Service<BrokerSession, BrokerSessionShape>()(
+  '@proompteng/bayn/broker/alpaca/session/BrokerSession',
+) {}
 
 const brokerSessionRetrySpacing = Duration.seconds(1)
 const brokerSessionRetrySpacingMs = 1_000

--- a/services/bayn/src/broker/observations.ts
+++ b/services/bayn/src/broker/observations.ts
@@ -148,10 +148,7 @@ export const sourceTimestamp = (value: string): Result.Result<string, BrokerObse
   const match = /^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})(?:\.(\d{1,9}))?Z$/.exec(value)
   if (match === null) return fail({ _tag: 'TimestampInvalid', value })
   return pipe(
-    Schema.decodeUnknownResult(
-      UtcOrderTimestamp,
-      strictParseOptions,
-    )(`${match[1]}.${(match[2] ?? '').padEnd(9, '0')}Z`),
+    Schema.decodeResult(UtcOrderTimestamp, strictParseOptions)(`${match[1]}.${(match[2] ?? '').padEnd(9, '0')}Z`),
     Result.mapError((): BrokerObservationError => ({ _tag: 'TimestampInvalid', value })),
   )
 }
@@ -161,7 +158,7 @@ const canonicalInstant = (value: string): Result.Result<string, BrokerObservatio
     sourceTimestamp(value),
     Result.flatMap((timestamp) =>
       pipe(
-        Schema.decodeUnknownResult(UtcInstant, strictParseOptions)(`${timestamp.slice(0, 23)}Z`),
+        Schema.decodeResult(UtcInstant, strictParseOptions)(`${timestamp.slice(0, 23)}Z`),
         Result.mapError((): BrokerObservationError => ({ _tag: 'TimestampInvalid', value })),
       ),
     ),

--- a/services/bayn/src/composition.test.ts
+++ b/services/bayn/src/composition.test.ts
@@ -298,10 +298,10 @@ describe('Bayn PAPER startup recovery boundary', () => {
     const result = await Effect.runPromise(
       Effect.gen(function* () {
         const state = yield* Ref.make(
-          initialState(
-            { expectedAccountId: 'paper-account', executionEligible: true, executionDisabledReason: null },
-            true,
-          ),
+          initialState({
+            broker: { expectedAccountId: 'paper-account', executionEligible: true, executionDisabledReason: null },
+            autonomousCycleLoopConfigured: true,
+          }),
         )
         const finalized = yield* finalizePaperEpisode(
           state,

--- a/services/bayn/src/cycle-observability.ts
+++ b/services/bayn/src/cycle-observability.ts
@@ -1,4 +1,4 @@
-import { Result } from 'effect'
+import { DateTime, Option, Result } from 'effect'
 
 import { Authority, KillState, ReconciliationStatus } from './execution/contracts'
 import { CycleState, type CycleTerminalReason } from './cycle'
@@ -73,8 +73,8 @@ export type AutonomousCycleCadenceFreshness = 'AVAILABLE' | 'STALE' | 'UNAVAILAB
 
 const isIsoDate = (value: string | undefined): value is string => {
   if (value === undefined || !/^\d{4}-\d{2}-\d{2}$/.test(value)) return false
-  const date = new Date(`${value}T00:00:00.000Z`)
-  return !Number.isNaN(date.getTime()) && date.toISOString().slice(0, 10) === value
+  const date = DateTime.make(`${value}T00:00:00.000Z`)
+  return Option.isSome(date) && DateTime.formatIsoDate(date.value) === value
 }
 
 const unknownNextEligibility = (

--- a/services/bayn/src/cycle-runner/calendar-decisions.ts
+++ b/services/bayn/src/cycle-runner/calendar-decisions.ts
@@ -1,4 +1,4 @@
-import { HashSet, pipe, Result } from 'effect'
+import { DateTime, HashSet, Option, pipe, Result } from 'effect'
 
 import type { MarketCalendarObservation, MarketCalendarQuery, MarketCalendarSession } from '../broker/alpaca'
 import {
@@ -73,21 +73,21 @@ const shiftIsoDate = (date: string, days: number): Result.Result<string, IsoDate
   const failure = (cause: IsoDateShiftCause): Result.Result<never, IsoDateShiftFailure> =>
     Result.fail({ _tag: 'IsoDateShiftOutOfRange', date, days, cause })
   if (!Number.isSafeInteger(days)) return failure({ _tag: 'IsoDateOffsetInvalid', date, days })
-  const inputDate = new Date(`${date}T00:00:00.000Z`)
-  const inputEpochMillis = inputDate.getTime()
-  if (!Number.isFinite(inputEpochMillis)) {
+  const inputEpochMillis = Date.parse(`${date}T00:00:00.000Z`)
+  const inputDate = DateTime.make(inputEpochMillis)
+  if (Option.isNone(inputDate)) {
     return failure({ _tag: 'IsoDateInputInvalid', date, epochMillis: inputEpochMillis })
   }
-  const input = inputDate.toISOString()
+  const input = DateTime.formatIso(inputDate.value)
   if (input !== `${date}T00:00:00.000Z`) {
     return failure({ _tag: 'IsoDateInputNotCanonical', date, normalized: input })
   }
   const shiftedEpochMillis = inputEpochMillis + days * millisecondsPerDay
-  const shiftedDateValue = new Date(shiftedEpochMillis)
-  if (!Number.isFinite(shiftedDateValue.getTime())) {
+  const shiftedDateValue = DateTime.make(shiftedEpochMillis)
+  if (Option.isNone(shiftedDateValue)) {
     return failure({ _tag: 'IsoDateShiftEpochOutOfRange', date, days, epochMillis: shiftedEpochMillis })
   }
-  const shifted = shiftedDateValue.toISOString()
+  const shifted = DateTime.formatIso(shiftedDateValue.value)
   const shiftedDate = shifted.slice(0, 10)
   return /^\d{4}-\d{2}-\d{2}$/.test(shiftedDate) && shifted === `${shiftedDate}T00:00:00.000Z`
     ? Result.succeed(shiftedDate)

--- a/services/bayn/src/cycle-runner/cycle-construction.ts
+++ b/services/bayn/src/cycle-runner/cycle-construction.ts
@@ -3,6 +3,7 @@ import { Data, DateTime, Result, Schema } from 'effect'
 import { canonicalHashV1Result } from '../hash'
 import { ExecutionModelV2Schema } from '../protocol'
 import { strictParseOptions } from '../schemas'
+import { utcInstantFromEpochMillis } from '../time'
 import {
   cycleTimeZone,
   decodeCycleDraftResult,
@@ -343,10 +344,10 @@ const deriveCycleWindowTimes = (
       ),
     )
   }
-  const submissionCutoffAt = new Date(
+  const submissionCutoffAt = utcInstantFromEpochMillis(
     Date.parse(calendar.executionOpenAt) - policy.submissionCutoffBeforeOpenMs,
-  ).toISOString()
-  const submissionOpenAt = new Date(Date.parse(submissionCutoffAt) - policy.submissionWindowMs).toISOString()
+  )
+  const submissionOpenAt = utcInstantFromEpochMillis(Date.parse(submissionCutoffAt) - policy.submissionWindowMs)
   if (submissionOpenAt <= signalCloseAt) {
     return Result.fail(
       failure('cycle-window', 'submission-window', 'submission window must begin after the Signal session close', {

--- a/services/bayn/src/db/capital-grant-algebra.ts
+++ b/services/bayn/src/db/capital-grant-algebra.ts
@@ -1,4 +1,4 @@
-import { pipe, Result } from 'effect'
+import { DateTime, pipe, Result } from 'effect'
 
 import type { RuntimeBuildMetadata } from '../config'
 import { makeStrategyProtocolHashResult, type ContractConstructionFailure } from '../contracts'
@@ -375,13 +375,13 @@ const validateAuthorityObservationDataFirst = (
   current: AuthorityState,
   observedAt: Date,
 ): Result.Result<void, CapitalGrantAlgebraFailure> => {
-  const updatedAt = new Date(current.updatedAt)
-  return updatedAt.getTime() <= observedAt.getTime()
+  const updatedAt = DateTime.makeUnsafe(current.updatedAt)
+  return DateTime.toEpochMillis(updatedAt) <= observedAt.getTime()
     ? Result.succeed(undefined)
     : fail({
         _tag: 'AuthorityUpdateAfterObservation',
         generationHash: current.generationHash,
-        updatedAt,
+        updatedAt: DateTime.toDateUtc(updatedAt),
         observedAt,
       })
 }
@@ -412,7 +412,7 @@ const validateCurrentGenerationHistoryDataFirst = <History extends AuthorityGene
       epochMillis: historyActivatedAtEpochMillis,
     })
   }
-  const historyActivatedAt = new Date(historyActivatedAtEpochMillis).toISOString()
+  const historyActivatedAt = DateTime.formatIso(DateTime.makeUnsafe(historyActivatedAtEpochMillis))
   if (
     history.generationHash !== current.generationHash ||
     history.maximum !== current.maximum ||

--- a/services/bayn/src/db/cycle-observability.ts
+++ b/services/bayn/src/db/cycle-observability.ts
@@ -33,7 +33,7 @@ export interface CycleObservabilityShape {
 }
 
 export class CycleObservability extends Context.Service<CycleObservability, CycleObservabilityShape>()(
-  'bayn/CycleObservability',
+  '@proompteng/bayn/db/cycle-observability/CycleObservability',
 ) {}
 
 const NullableDate = Schema.NullOr(Schema.Date)

--- a/services/bayn/src/db/cycle-store/model.ts
+++ b/services/bayn/src/db/cycle-store/model.ts
@@ -87,7 +87,9 @@ export interface CycleStoreShape {
   ) => Effect.Effect<CycleMutationReceipt, CycleStoreError>
 }
 
-export class CycleStore extends Context.Service<CycleStore, CycleStoreShape>()('bayn/CycleStore') {}
+export class CycleStore extends Context.Service<CycleStore, CycleStoreShape>()(
+  '@proompteng/bayn/db/cycle-store/model/CycleStore',
+) {}
 
 export type CycleStoreInternalError = CycleStoreError | Schema.SchemaError | SqlError
 

--- a/services/bayn/src/db/evidence-store/model.ts
+++ b/services/bayn/src/db/evidence-store/model.ts
@@ -61,4 +61,6 @@ export interface EvidenceStoreService {
   ) => Effect.Effect<Option.Option<QualificationRecord>, DatabaseError>
 }
 
-export class EvidenceStore extends Context.Service<EvidenceStore, EvidenceStoreService>()('bayn/EvidenceStore') {}
+export class EvidenceStore extends Context.Service<EvidenceStore, EvidenceStoreService>()(
+  '@proompteng/bayn/db/evidence-store/model/EvidenceStore',
+) {}

--- a/services/bayn/src/db/execution-store/contract.ts
+++ b/services/bayn/src/db/execution-store/contract.ts
@@ -117,27 +117,29 @@ export interface AuthorityRestrictionStoreShape {
 }
 
 export class BrokerEventStore extends Context.Service<BrokerEventStore, BrokerEventStoreShape>()(
-  'bayn/BrokerEventStore',
+  '@proompteng/bayn/db/execution-store/contract/BrokerEventStore',
 ) {}
 export class FillAccountingStore extends Context.Service<FillAccountingStore, FillAccountingStoreShape>()(
-  'bayn/FillAccountingStore',
+  '@proompteng/bayn/db/execution-store/contract/FillAccountingStore',
 ) {}
-export class ValuationStore extends Context.Service<ValuationStore, ValuationStoreShape>()('bayn/ValuationStore') {}
+export class ValuationStore extends Context.Service<ValuationStore, ValuationStoreShape>()(
+  '@proompteng/bayn/db/execution-store/contract/ValuationStore',
+) {}
 export class ReconciliationStore extends Context.Service<ReconciliationStore, ReconciliationStoreShape>()(
-  'bayn/ReconciliationStore',
+  '@proompteng/bayn/db/execution-store/contract/ReconciliationStore',
 ) {}
 export class AuthorityGenerationStore extends Context.Service<
   AuthorityGenerationStore,
   AuthorityGenerationStoreShape
->()('bayn/AuthorityGenerationStore') {}
+>()('@proompteng/bayn/db/execution-store/contract/AuthorityGenerationStore') {}
 export class CapitalGrantLifecycleStore extends Context.Service<
   CapitalGrantLifecycleStore,
   CapitalGrantLifecycleStoreShape
->()('bayn/CapitalGrantLifecycleStore') {}
+>()('@proompteng/bayn/db/execution-store/contract/CapitalGrantLifecycleStore') {}
 export class AuthorityRestrictionStore extends Context.Service<
   AuthorityRestrictionStore,
   AuthorityRestrictionStoreShape
->()('bayn/AuthorityRestrictionStore') {}
+>()('@proompteng/bayn/db/execution-store/contract/AuthorityRestrictionStore') {}
 
 export interface ReconciliationPersistence {
   readonly events: BrokerEventStoreShape

--- a/services/bayn/src/db/execution-store/decisions.ts
+++ b/services/bayn/src/db/execution-store/decisions.ts
@@ -9,6 +9,7 @@ import type { EventReceipt, PositionSnapshotReceipt } from './contract'
 import type { AccountRow, EventIdRow, EventRow, PositionRow, PositionSnapshotRow } from './rows'
 import { EventKind } from './rows'
 import { Pipeable } from '../../pipeable'
+import { utcInstantFromEpochMillisResult } from '../../time'
 
 export interface ExecutionStoreDecisionFailure {
   readonly failure: 'conflict' | 'invariant'
@@ -100,9 +101,9 @@ const timestampDecision = (
   source: ExecutionStoreTimestampFailure['source'],
   epochMillis: number,
 ): Result.Result<string, ExecutionStoreDecisionFailure> => {
-  const instant = new Date(epochMillis)
-  return Number.isFinite(instant.getTime())
-    ? Result.succeed(instant.toISOString())
+  const instant = utcInstantFromEpochMillisResult(epochMillis)
+  return Result.isSuccess(instant)
+    ? Result.succeed(instant.success)
     : fail('invariant', 'valuation timestamp evidence is invalid', {
         _tag: 'ExecutionStoreTimestampFailure',
         source,

--- a/services/bayn/src/db/forward-performance-receipt.ts
+++ b/services/bayn/src/db/forward-performance-receipt.ts
@@ -235,7 +235,7 @@ export interface ForwardPerformanceReceiptStoreShape {
 export class ForwardPerformanceReceiptStore extends Context.Service<
   ForwardPerformanceReceiptStore,
   ForwardPerformanceReceiptStoreShape
->()('bayn/ForwardPerformanceReceiptStore') {}
+>()('@proompteng/bayn/db/forward-performance-receipt/ForwardPerformanceReceiptStore') {}
 
 const decodeEnvelopeResult = Schema.decodeUnknownResult(ForwardPerformanceReceiptEnvelopeSchema, strictParseOptions)
 

--- a/services/bayn/src/db/live-capital-grant.ts
+++ b/services/bayn/src/db/live-capital-grant.ts
@@ -40,7 +40,7 @@ export interface LiveCapitalGrantStoreShape {
 }
 
 export class LiveCapitalGrantStore extends Context.Service<LiveCapitalGrantStore, LiveCapitalGrantStoreShape>()(
-  'bayn/LiveCapitalGrantStore',
+  '@proompteng/bayn/db/live-capital-grant/LiveCapitalGrantStore',
 ) {}
 
 const RowSchema = Schema.Struct({

--- a/services/bayn/src/db/live-capital-grant.ts
+++ b/services/bayn/src/db/live-capital-grant.ts
@@ -1,5 +1,5 @@
 import { PgClient } from '@effect/sql-pg'
-import { Context, Data, Effect, Layer, Result, Schema } from 'effect'
+import { Context, Data, DateTime, Effect, Layer, Result, Schema } from 'effect'
 import { isSqlError } from 'effect/unstable/sql/SqlError'
 
 import {
@@ -42,6 +42,8 @@ export interface LiveCapitalGrantStoreShape {
 export class LiveCapitalGrantStore extends Context.Service<LiveCapitalGrantStore, LiveCapitalGrantStoreShape>()(
   '@proompteng/bayn/db/live-capital-grant/LiveCapitalGrantStore',
 ) {}
+
+const sqlTimestamp = (value: string): Date => DateTime.toDateUtc(DateTime.makeUnsafe(value))
 
 const RowSchema = Schema.Struct({
   grant_hash: Sha256Schema,
@@ -398,7 +400,7 @@ const makeStore = Effect.gen(function* () {
         ${grant.strategy.parameterSchemaVersion},
         ${grant.limits.maxGrossNotionalMicros}, ${grant.limits.maxOrderNotionalMicros},
         ${grant.limits.maxPositionNotionalMicros}, ${grant.limits.maxDailyLossMicros}, ${grant.limits.maxOpenOrders},
-        ${new Date(grant.validFrom)}, ${new Date(grant.validUntil)}, ${new Date(grant.issuedAt)}, ${grant.issuedBy}
+        ${sqlTimestamp(grant.validFrom)}, ${sqlTimestamp(grant.validUntil)}, ${sqlTimestamp(grant.issuedAt)}, ${grant.issuedBy}
       FROM authority_generations AS generation
       WHERE generation.generation_hash = ${grant.authorityGenerationHash}
         AND generation.maximum = 'PAPER'
@@ -438,7 +440,7 @@ const makeStore = Effect.gen(function* () {
                     INSERT INTO live_capital_grant_revocations (
                       grant_hash, schema_version, revoked_at, revoked_by, reason
                     ) VALUES (
-                      ${grantHash}, ${revocation.schemaVersion}, ${new Date(revocation.revokedAt)},
+                      ${grantHash}, ${revocation.schemaVersion}, ${sqlTimestamp(revocation.revokedAt)},
                       ${revocation.revokedBy}, ${revocation.reason}
                     )
                     ON CONFLICT (grant_hash) DO NOTHING

--- a/services/bayn/src/db/paper-cycle-closure.ts
+++ b/services/bayn/src/db/paper-cycle-closure.ts
@@ -64,7 +64,7 @@ export interface PaperCycleClosureStoreShape {
 }
 
 export class PaperCycleClosureStore extends Context.Service<PaperCycleClosureStore, PaperCycleClosureStoreShape>()(
-  'bayn/PaperCycleClosureStore',
+  '@proompteng/bayn/db/paper-cycle-closure/PaperCycleClosureStore',
 ) {}
 
 const decodePaperCycleClosureResultDataFirst = Schema.decodeUnknownResult(PaperCycleClosureSchema, strictParseOptions)

--- a/services/bayn/src/execution-candidate-discovery/broker-observation-validation.ts
+++ b/services/bayn/src/execution-candidate-discovery/broker-observation-validation.ts
@@ -27,6 +27,7 @@ import {
 } from './model'
 import { requireCondition, requireValue, type ExecutionCandidateDiscoveryError } from './failure'
 import { Pipeable } from '../pipeable'
+import { utcInstantFromEpochMillisResult } from '../time'
 
 const assetEligibilityRules = [
   [PaperCandidateIneligibility.AssetClass, (asset: AssetObservation) => asset.assetClass !== AssetClass.UsEquity],
@@ -206,8 +207,8 @@ const assembleValidatedObservationsDataFirst = (
       cause: { _tag: 'ObservationCaptureEpochNotSafeInteger', observedAtMs: capturedAtMs },
     })
   }
-  const capturedAtDate = new Date(capturedAtMs)
-  if (!Number.isFinite(capturedAtDate.getTime())) {
+  const capturedAtResult = utcInstantFromEpochMillisResult(capturedAtMs)
+  if (Result.isFailure(capturedAtResult)) {
     return Result.fail({
       _tag: 'ObservationCaptureTimeInvalid',
       failure: 'broker',
@@ -215,7 +216,7 @@ const assembleValidatedObservationsDataFirst = (
       cause: { _tag: 'ObservationCaptureEpochOutOfRange', observedAtMs: capturedAtMs },
     })
   }
-  const capturedAt = capturedAtDate.toISOString()
+  const capturedAt = capturedAtResult.success
   return pipe(
     Result.all([
       requireCondition(capturedAtMs < Date.parse(validatedSnapshot.snapshot.document.expiresAt), {

--- a/services/bayn/src/execution-candidate-discovery/program.ts
+++ b/services/bayn/src/execution-candidate-discovery/program.ts
@@ -81,14 +81,13 @@ const readSnapshotTransaction = (
   ExecutionCandidateDiscoverySnapshot,
   CycleObservabilityError | CycleStoreError | ExecutionCandidateDiscoveryError
 > =>
-  pipe(
-    Effect.Do,
-    Effect.bind('projection', () => observability.read(identity.qualificationRunId, identity.accountId)),
-    Effect.bind('last', ({ projection }) => Effect.fromResult(selectCompletedCycle(projection))),
-    Effect.bind('cycle', ({ last }) => readCycle(store, last.cycleId)),
-    Effect.bind('document', ({ last }) => readDecisionDocument(store, last.cycleId)),
-    Effect.map(({ cycle, document, projection }) => ({ cycle, document, projection })),
-  )
+  Effect.gen(function* () {
+    const projection = yield* observability.read(identity.qualificationRunId, identity.accountId)
+    const last = yield* Effect.fromResult(selectCompletedCycle(projection))
+    const cycle = yield* readCycle(store, last.cycleId)
+    const document = yield* readDecisionDocument(store, last.cycleId)
+    return { cycle, document, projection }
+  })
 
 const readDiscoverySnapshot = (
   identity: ExecutionCandidateDiscoveryIdentity,
@@ -185,25 +184,16 @@ const readAssets = (
 const observeBroker = (
   validatedSnapshot: ValidatedPaperCandidateSnapshot,
 ): Effect.Effect<ValidatedPaperCandidateObservations, ExecutionCandidateDiscoveryError, BrokerRead> =>
-  pipe(
-    BrokerRead,
-    Effect.flatMap((broker) =>
-      pipe(
-        Effect.Do,
-        Effect.bind('account', () => readAccount(broker, validatedSnapshot.identity)),
-        Effect.bind('accountConfiguration', ({ account }) => readAccountConfiguration(broker, account)),
-        Effect.bind('assets', ({ accountConfiguration }) =>
-          readAssets(broker, validatedSnapshot.snapshot, accountConfiguration),
-        ),
-        Effect.bind('capturedAtMs', () => Clock.currentTimeMillis),
-        Effect.flatMap(({ account, accountConfiguration, assets, capturedAtMs }) =>
-          Effect.fromResult(
-            assembleValidatedObservations(validatedSnapshot, account, accountConfiguration, assets, capturedAtMs),
-          ),
-        ),
-      ),
-    ),
-  )
+  Effect.gen(function* () {
+    const broker = yield* BrokerRead
+    const account = yield* readAccount(broker, validatedSnapshot.identity)
+    const accountConfiguration = yield* readAccountConfiguration(broker, account)
+    const assets = yield* readAssets(broker, validatedSnapshot.snapshot, accountConfiguration)
+    const capturedAtMs = yield* Clock.currentTimeMillis
+    return yield* Effect.fromResult(
+      assembleValidatedObservations(validatedSnapshot, account, accountConfiguration, assets, capturedAtMs),
+    )
+  })
 
 export const discoverPaperCandidates = (
   candidateIdentity: ExecutionCandidateDiscoveryIdentity,
@@ -212,21 +202,11 @@ export const discoverPaperCandidates = (
   ExecutionCandidateDiscoveryError,
   PgClient.PgClient | CycleObservability | CycleStore | BrokerRead
 > =>
-  pipe(
-    validateIdentity(candidateIdentity),
-    Effect.fromResult,
-    Effect.flatMap((identity) =>
-      pipe(
-        Effect.Do,
-        Effect.bind('snapshot', () => readDiscoverySnapshot(identity)),
-        Effect.bind('startedAt', () => Clock.currentTimeMillis),
-        Effect.bind('validatedSnapshot', ({ snapshot, startedAt }) =>
-          Effect.fromResult(validateSnapshotForIdentity(identity, snapshot, startedAt)),
-        ),
-        Effect.bind('observations', ({ validatedSnapshot }) => observeBroker(validatedSnapshot)),
-        Effect.flatMap(({ observations, validatedSnapshot }) =>
-          Effect.fromResult(makeExecutionCandidateDiscoveryReceipt(validatedSnapshot, observations)),
-        ),
-      ),
-    ),
-  )
+  Effect.gen(function* () {
+    const identity = yield* Effect.fromResult(validateIdentity(candidateIdentity))
+    const snapshot = yield* readDiscoverySnapshot(identity)
+    const startedAt = yield* Clock.currentTimeMillis
+    const validatedSnapshot = yield* Effect.fromResult(validateSnapshotForIdentity(identity, snapshot, startedAt))
+    const observations = yield* observeBroker(validatedSnapshot)
+    return yield* Effect.fromResult(makeExecutionCandidateDiscoveryReceipt(validatedSnapshot, observations))
+  })

--- a/services/bayn/src/execution-candidate-discovery/receipt-construction.ts
+++ b/services/bayn/src/execution-candidate-discovery/receipt-construction.ts
@@ -164,7 +164,7 @@ const decodeReceipt = (
     ),
     Result.flatMap((observationReceiptHash) =>
       pipe(
-        Schema.decodeUnknownResult(
+        Schema.decodeResult(
           DiscoveryReceiptSchema,
           strictParseOptions,
         )({
@@ -214,7 +214,7 @@ const makeExecutionCandidateDiscoveryReceiptDataFirst = (
           candidates,
           consistencyDelayMs: { status: 'REQUIRED_UNBOUND' as const },
         },
-        Schema.decodeUnknownResult(CandidateFactsMaterialSchema, strictParseOptions),
+        Schema.decodeResult(CandidateFactsMaterialSchema, strictParseOptions),
         Result.mapError(
           (cause): ExecutionCandidateDiscoveryError => ({
             _tag: 'CandidateFactsDecodeFailed',

--- a/services/bayn/src/execution-candidate-discovery/snapshot-validation.ts
+++ b/services/bayn/src/execution-candidate-discovery/snapshot-validation.ts
@@ -24,7 +24,7 @@ export const validateIdentity = (
   input: ExecutionCandidateDiscoveryIdentity,
 ): Result.Result<ExecutionCandidateDiscoveryIdentity, ExecutionCandidateDiscoveryError> =>
   pipe(
-    Schema.decodeUnknownResult(RuntimeIdentitySchema, strictParseOptions)(input),
+    Schema.decodeResult(RuntimeIdentitySchema, strictParseOptions)(input),
     Result.mapError(
       (cause): ExecutionCandidateDiscoveryError => ({ _tag: 'IdentityDecodeFailed', failure: 'invalid-input', cause }),
     ),

--- a/services/bayn/src/execution-session.ts
+++ b/services/bayn/src/execution-session.ts
@@ -10,6 +10,7 @@ import {
 import { canonicalHashV1Result } from './hash'
 import { ExecutionModelV2Schema, type ExecutionModel } from './protocol'
 import { IsoDateSchema, Sha256Schema, UtcInstantSchema, strictParseOptions } from './schemas'
+import { utcInstantFromEpochMillis } from './time'
 
 const CalendarIdentitySchema = Schema.Struct({
   schemaVersion: Schema.Literal('bayn.alpaca-market-calendar-observation.v1'),
@@ -265,9 +266,9 @@ const deriveSubmissionWindow = (
 ): Result.Result<Omit<ExecutionSessionWindow, 'executionSession'>, ExecutionSessionBindingFailure> => {
   const submissionOpenAt =
     signal.finalizedAt >= planningBrokerState.observedAt ? signal.finalizedAt : planningBrokerState.observedAt
-  const submissionCutoffAt = new Date(
+  const submissionCutoffAt = utcInstantFromEpochMillis(
     Date.parse(executionSession.openAt) - submissionCutoffLeadMinutes * 60_000,
-  ).toISOString()
+  )
   if (submissionOpenAt >= submissionCutoffAt || submissionCutoffAt >= executionSession.openAt) {
     return Result.fail(
       deriveWindowFailure(

--- a/services/bayn/src/execution/contracts.ts
+++ b/services/bayn/src/execution/contracts.ts
@@ -448,14 +448,19 @@ const allowedTerminalOutcomes: Readonly<Partial<Record<IntentState, readonly Ter
   ],
 }
 
-export const isIntentTransitionAllowed = (
-  from: IntentState,
-  to: IntentState,
-  terminalOutcome?: TerminalOutcome,
-): boolean => {
-  if (!allowedTransitions[from].includes(to)) return false
-  if (to !== IntentState.Terminal) return terminalOutcome === undefined
-  return terminalOutcome !== undefined && (allowedTerminalOutcomes[from]?.includes(terminalOutcome) ?? false)
+export interface IntentTransitionInput {
+  readonly from: IntentState
+  readonly to: IntentState
+  readonly terminalOutcome?: TerminalOutcome
+}
+
+export const isIntentTransitionAllowed = (input: IntentTransitionInput): boolean => {
+  if (!allowedTransitions[input.from].includes(input.to)) return false
+  if (input.to !== IntentState.Terminal) return input.terminalOutcome === undefined
+  return (
+    input.terminalOutcome !== undefined &&
+    (allowedTerminalOutcomes[input.from]?.includes(input.terminalOutcome) ?? false)
+  )
 }
 
 const RiskInputBase = Schema.Struct({

--- a/services/bayn/src/execution/coordinator-decisions.ts
+++ b/services/bayn/src/execution/coordinator-decisions.ts
@@ -491,8 +491,8 @@ const ensureRecoveryDelayDataFirst = (
   operation: MutationOperation,
   event: MutationEvent,
   currentMillis: number,
-): Result.Result<MutationEvent, ExecutionDecisionFailure> => {
-  return Result.flatMap(parseInstant(operation, 'occurred-at', event.occurredAt), (occurredAt) =>
+): Result.Result<MutationEvent, ExecutionDecisionFailure> =>
+  Result.flatMap(parseInstant(operation, 'occurred-at', event.occurredAt), (occurredAt) =>
     Result.flatMap(validateCurrentTime(operation, currentMillis), (now) => {
       const eligibleMillis = occurredAt + event.consistencyDelayMs
       return now >= eligibleMillis
@@ -506,7 +506,6 @@ const ensureRecoveryDelayDataFirst = (
           )
     }),
   )
-}
 
 export const ensureRecoveryDelay = Pipeable.dual(3, ensureRecoveryDelayDataFirst)
 

--- a/services/bayn/src/execution/coordinator.test.ts
+++ b/services/bayn/src/execution/coordinator.test.ts
@@ -314,7 +314,9 @@ describe('MutationStore decision algebra', () => {
     const binding = resultSuccess(decideMutationAuthority(MutationOperation.Submit, decisionAuthority))
 
     expect(
-      resultSuccess(decideFinalSubmitAuthorization(binding, decisionIntent(IntentState.IoStarted))),
+      resultSuccess(
+        decideFinalSubmitAuthorization({ authority: binding, intent: decisionIntent(IntentState.IoStarted) }),
+      ),
     ).toBeUndefined()
     for (const snapshot of [
       undefined,
@@ -322,7 +324,7 @@ describe('MutationStore decision algebra', () => {
       { ...decisionIntent(IntentState.IoStarted), authorityGenerationHash: '9'.repeat(64) },
       { ...decisionIntent(IntentState.IoStarted), generationAccountId: 'another-account' },
     ]) {
-      expect(resultFailure(decideFinalSubmitAuthorization(binding, snapshot))).toMatchObject({
+      expect(resultFailure(decideFinalSubmitAuthorization({ authority: binding, intent: snapshot }))).toMatchObject({
         operation: 'begin-submit',
       })
     }
@@ -351,7 +353,13 @@ describe('MutationStore decision algebra', () => {
       ),
     ).toMatchObject({ failure: 'authority', message: 'close-only submit requires a sell intent' })
     expect(
-      resultFailure(decideFinalSubmitAuthorization(closeBinding, decisionIntent(IntentState.IoStarted), true)),
+      resultFailure(
+        decideFinalSubmitAuthorization({
+          authority: closeBinding,
+          intent: decisionIntent(IntentState.IoStarted),
+          closeOnly: true,
+        }),
+      ),
     ).toMatchObject({ failure: 'authority', message: 'close-only submit requires a sell intent' })
   })
 

--- a/services/bayn/src/execution/coordinator.ts
+++ b/services/bayn/src/execution/coordinator.ts
@@ -410,8 +410,8 @@ const recoverAtBroker = (
   stored: StoredIntent,
   operation: MutationOperation,
   interrupted: MutationEvent,
-) => {
-  return services.broker.orderByClientId(stored.intent.clientOrderId).pipe(
+) =>
+  services.broker.orderByClientId(stored.intent.clientOrderId).pipe(
     Effect.matchEffect({
       onFailure: (error) =>
         persistRecoveryDecision(
@@ -431,7 +431,6 @@ const recoverAtBroker = (
         ),
     }),
   )
-}
 
 const continueRecovery = (
   services: RecoveryServices,

--- a/services/bayn/src/execution/intents/domain.ts
+++ b/services/bayn/src/execution/intents/domain.ts
@@ -191,7 +191,7 @@ const makeReferenceIntentResult = (decoded: IntentPlan): Result.Result<Reference
   const intentId = referenceIntentIdResult(decoded)
   if (Result.isFailure(intentId)) return Result.fail(intentId.failure)
   return Result.mapError(
-    Schema.decodeUnknownResult(
+    Schema.decodeResult(
       ReferenceIntentSchema,
       strictParseOptions,
     )({

--- a/services/bayn/src/execution/intents/domain.ts
+++ b/services/bayn/src/execution/intents/domain.ts
@@ -337,7 +337,9 @@ export interface IntentStoreService {
   readonly read: (intentId: string) => Effect.Effect<Option.Option<StoredIntent>, IntentStoreError>
 }
 
-export class IntentStore extends Context.Service<IntentStore, IntentStoreService>()('bayn/IntentStore') {}
+export class IntentStore extends Context.Service<IntentStore, IntentStoreService>()(
+  '@proompteng/bayn/execution/intents/domain/IntentStore',
+) {}
 
 const intentRowFields = {
   schema_version: Schema.Literal('bayn.paper-intent.v3'),

--- a/services/bayn/src/execution/intents/domain.ts
+++ b/services/bayn/src/execution/intents/domain.ts
@@ -154,7 +154,7 @@ const paperIntentIdResult = (
     paperIdentityMaterial(input, authorityGenerationHash),
   )
 
-export const paperIntentIdForDecodedPlan = paperIntentIdResult
+export const paperIntentIdForDecodedPlan = Pipeable.dual(2, paperIntentIdResult)
 
 export const intentIdForPlan = referenceIntentIdResult
 

--- a/services/bayn/src/execution/mutations/decisions.ts
+++ b/services/bayn/src/execution/mutations/decisions.ts
@@ -281,11 +281,16 @@ export const decideMutationAuthority = Pipeable.by<
   typeof decideMutationAuthorityDataFirst
 >((arguments_) => typeof arguments_[0] === 'string', decideMutationAuthorityDataFirst)
 
+export interface FinalSubmitAuthorizationInput {
+  readonly authority: MutationAuthorityBinding
+  readonly intent: MutationIntentSnapshot | undefined
+  readonly closeOnly?: boolean
+}
+
 export const decideFinalSubmitAuthorization = (
-  authority: MutationAuthorityBinding,
-  intent: MutationIntentSnapshot | undefined,
-  closeOnly = false,
+  input: FinalSubmitAuthorizationInput,
 ): Result.Result<void, MutationStoreError> => {
+  const { authority, intent, closeOnly = false } = input
   if (intent === undefined) {
     return Result.fail(
       storeError({ operation: 'begin-submit', failure: 'invariant', message: 'final submit intent does not exist' }),

--- a/services/bayn/src/execution/mutations/model.ts
+++ b/services/bayn/src/execution/mutations/model.ts
@@ -189,7 +189,9 @@ export interface MutationStoreShape {
   ) => Effect.Effect<MutationEvent | undefined, MutationStoreError>
 }
 
-export class MutationStore extends Context.Service<MutationStore, MutationStoreShape>()('bayn/MutationStore') {}
+export class MutationStore extends Context.Service<MutationStore, MutationStoreShape>()(
+  '@proompteng/bayn/execution/mutations/model/MutationStore',
+) {}
 
 export type MutationStartInput = typeof StartInputSchema.Type
 export type MutationOutcomeInput = typeof OutcomeInputSchema.Type

--- a/services/bayn/src/execution/mutations/postgres/start.ts
+++ b/services/bayn/src/execution/mutations/postgres/start.ts
@@ -206,7 +206,7 @@ const makeMutationStartPostgresDataFirst = (
     Effect.gen(function* () {
       const authority = yield* readAuthorityBinding(MutationOperation.Submit, closeOnly)
       const intent = yield* readIntent(MutationOperation.Submit, intentId)
-      yield* fromDecision(() => decideFinalSubmitAuthorization(authority, intent, closeOnly))
+      yield* fromDecision(() => decideFinalSubmitAuthorization({ authority, intent, closeOnly }))
     })
 
   return { authorizeSubmit, begin }

--- a/services/bayn/src/execution/writer-fence.ts
+++ b/services/bayn/src/execution/writer-fence.ts
@@ -24,7 +24,9 @@ export type WriterFenceTransaction = <A, E, R>(
   effect: Effect.Effect<A, E, R>,
 ) => Effect.Effect<A, E | WriterFenceError, R>
 
-export class WriterFence extends Context.Service<WriterFence, WriterFenceService>()('bayn/WriterFence') {}
+export class WriterFence extends Context.Service<WriterFence, WriterFenceService>()(
+  '@proompteng/bayn/execution/writer-fence/WriterFence',
+) {}
 
 /**
  * Explicitly crosses the WriterFence interpreter boundary for callers that do not already hold the service value.

--- a/services/bayn/src/forward-performance/execution-quality.ts
+++ b/services/bayn/src/forward-performance/execution-quality.ts
@@ -1,4 +1,4 @@
-import { Result } from 'effect'
+import { DateTime, Option, Result } from 'effect'
 
 import { canonicalHashV1Result, type CanonicalHashFailure } from '../hash'
 import type {
@@ -57,13 +57,16 @@ const roundHalfUp = (quantity: bigint, price: bigint): bigint | undefined => {
   return inSignedRange(value) ? value : undefined
 }
 
-const validInstant = (value: string): boolean =>
-  UTC_INSTANT_PATTERN.test(value) && Number.isFinite(Date.parse(value)) && new Date(value).toISOString() === value
+const validInstant = (value: string): boolean => {
+  if (!UTC_INSTANT_PATTERN.test(value)) return false
+  const instant = DateTime.make(value)
+  return Option.isSome(instant) && DateTime.formatIso(instant.value) === value
+}
 
 const validIsoDate = (value: string): boolean => {
   if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return false
-  const instant = new Date(`${value}T00:00:00.000Z`)
-  return Number.isFinite(instant.getTime()) && instant.toISOString().startsWith(`${value}T`)
+  const instant = DateTime.make(`${value}T00:00:00.000Z`)
+  return Option.isSome(instant) && DateTime.formatIsoDate(instant.value) === value
 }
 
 const compareStrings = (left: string, right: string): number => (left < right ? -1 : left > right ? 1 : 0)

--- a/services/bayn/src/forward-performance/program.ts
+++ b/services/bayn/src/forward-performance/program.ts
@@ -81,7 +81,7 @@ export const liveForwardPerformanceReaders: ForwardPerformanceReaders = {
   postgres: readForwardPerformancePostgres,
   ledger: (config, accountId, accountPlans, cashYieldEvidence, generationPlans) =>
     readForwardPerformanceLedger(config, accountId, accountPlans, cashYieldEvidence, undefined, generationPlans),
-  marketVolume: readForwardPerformanceMarketVolume,
+  marketVolume: (config, requests) => readForwardPerformanceMarketVolume(config, requests),
 }
 
 const SIGNED_I128_MAX = (1n << 127n) - 1n
@@ -408,10 +408,10 @@ export const readForwardPerformanceMarketVolumeWithClient = Pipeable.dual(
   readForwardPerformanceMarketVolumeWithClientDataFirst,
 )
 
-export function readForwardPerformanceMarketVolume(
+const readForwardPerformanceMarketVolumeDataFirst = (
   config: Pick<LoadedRuntimeConfig, 'clickhouse' | 'operationTimeoutMs'>,
   requests: readonly ForwardPerformanceMarketVolumeRequest[],
-): Effect.Effect<readonly ForwardPerformanceMarketVolumeEvidence[], ForwardPerformanceMarketVolumeError> {
+): Effect.Effect<readonly ForwardPerformanceMarketVolumeEvidence[], ForwardPerformanceMarketVolumeError> => {
   if (requests.length === 0) return Effect.succeed([])
   const client = ClickhouseClient.layer({
     url: config.clickhouse.url,
@@ -430,6 +430,8 @@ export function readForwardPerformanceMarketVolume(
     ),
   )
 }
+
+export const readForwardPerformanceMarketVolume = Pipeable.dual(2, readForwardPerformanceMarketVolumeDataFirst)
 
 const canonicalUnsigned = (value: string): bigint | undefined =>
   /^(?:0|[1-9][0-9]*)$/.test(value) ? BigInt(value) : undefined

--- a/services/bayn/src/forward-performance/program.ts
+++ b/services/bayn/src/forward-performance/program.ts
@@ -1,6 +1,6 @@
 import { ClickhouseClient } from '@effect/sql-clickhouse'
 import { PgClient } from '@effect/sql-pg'
-import { Data, Effect, Redacted, Result, Scope } from 'effect'
+import { Data, DateTime, Effect, Option, Redacted, Result, Scope } from 'effect'
 
 import type { LoadedRuntimeConfig } from '../config'
 import { verifyAccountingReceipts } from '../db/reconciliation-algebra'
@@ -104,7 +104,8 @@ const finalizedInstant = (value: string): string | undefined => {
   const match = /^(\d{4}-\d{2}-\d{2}) (\d{2}:\d{2}:\d{2})(?:[.]([0-9]{3}))?$/.exec(value)
   if (match === null || match[1] === undefined || match[2] === undefined) return undefined
   const instant = `${match[1]}T${match[2]}.${match[3] ?? '000'}Z`
-  return Number.isFinite(Date.parse(instant)) && new Date(instant).toISOString() === instant ? instant : undefined
+  const dateTime = DateTime.make(instant)
+  return Option.isSome(dateTime) && DateTime.formatIso(dateTime.value) === instant ? instant : undefined
 }
 
 interface ForwardPerformanceMarketSnapshotRows {

--- a/services/bayn/src/health.test.ts
+++ b/services/bayn/src/health.test.ts
@@ -343,7 +343,7 @@ const brokerRuntimeState = (broker: BrokerProbe, startedAt = new Date().toISOStr
     startedAt,
     lastPass: { result: 'SUCCESS', observedAt: startedAt, outcome: 'NO_PUBLICATION' },
   },
-  broker: initialState(broker, true).broker,
+  broker: initialState({ broker, autonomousCycleLoopConfigured: true }).broker,
 })
 
 const emptyCycleProjection = (): CycleOperationsProjection => ({
@@ -853,7 +853,7 @@ describe('Bayn continuous health', () => {
     const checkedAt = '2026-07-20T00:00:00.000Z'
     const generationHash = 'd'.repeat(64)
     const initial: RuntimeState = {
-      ...initialState(),
+      ...initialState({}),
       paperActivation: {
         _tag: 'Realized',
         requestHash: 'c'.repeat(64),
@@ -1768,7 +1768,7 @@ describe('Bayn continuous health', () => {
         startedAt: null,
         lastPass: null,
       },
-      broker: initialState(broker).broker,
+      broker: initialState({ broker }).broker,
     }
     const state = await Effect.runPromise(Ref.make(initial))
 

--- a/services/bayn/src/http.test.ts
+++ b/services/bayn/src/http.test.ts
@@ -140,7 +140,7 @@ const withHttpServer = (
   return Effect.runPromise(
     Effect.scoped(
       Effect.gen(function* () {
-        const state = yield* Ref.make(options.state ?? initialState())
+        const state = yield* Ref.make(options.state ?? initialState({}))
         yield* serveHttp(
           serverConfig,
           state,
@@ -250,7 +250,7 @@ describe('Bayn HTTP pure decisions', () => {
   })
 
   test('decides historical evidence, fallback, and status responses from immutable values', () => {
-    const initial = initialState()
+    const initial = initialState({})
     expect(historicalEvidenceResponseDecision(Option.some(historicalEvidence))).toEqual({
       _tag: 'Json',
       status: 200,
@@ -454,7 +454,7 @@ describe('Bayn HTTP pure decisions', () => {
       },
       {
         name: 'initial unknown dependencies',
-        state: initialState(),
+        state: initialState({}),
         ready: false,
         status: 503,
         failedDependencies: ['postgresql', 'signal', 'tigerBeetle', 'evidence', 'cycle', 'cycleRunner'],
@@ -477,7 +477,7 @@ describe('Bayn HTTP pure decisions', () => {
   })
 
   test('covers every public status projection branch from immutable facts', () => {
-    const initial = initialState()
+    const initial = initialState({})
     const healthy = readyState()
     const checkedAt = healthy.health.checkedAt
     const observedAt = checkedAt ?? '2026-07-20T00:00:00.000Z'
@@ -1007,7 +1007,7 @@ describe('Bayn HTTP pure decisions', () => {
 
 describe('Bayn HTTP probes', () => {
   test('serves every route from the current runtime state and closes its socket', async () => {
-    const initial = initialState()
+    const initial = initialState({})
     let port = 0
     await withHttpServer({ state: initial }, (server) => {
       port = server.port
@@ -1577,7 +1577,7 @@ describe('Bayn HTTP probes', () => {
       executionEligible: false,
       executionDisabledReason: 'MAXIMUM_AUTHORITY_OBSERVE',
     }
-    const runtimeState = initialState(broker)
+    const runtimeState = initialState({ broker })
     expect(runtimeState.broker).not.toHaveProperty('read')
     expect(Object.values(runtimeState.broker ?? {}).some((value) => typeof value === 'function')).toBe(false)
 
@@ -1771,7 +1771,7 @@ describe('Bayn HTTP probes', () => {
   })
 
   test('does not synthesize durable cycle, mutation, reconciliation, or authority observations', () => {
-    const metrics = renderPrometheusMetrics(initialState(), config, provenance, 'embedded')
+    const metrics = renderPrometheusMetrics(initialState({}), config, provenance, 'embedded')
 
     expect(metrics).toContain('bayn_cycle_observation_available 0')
     expect(metrics).toContain('bayn_cycle_condition{condition="unknown"} 1')

--- a/services/bayn/src/ledger-plan/persisted-evidence.ts
+++ b/services/bayn/src/ledger-plan/persisted-evidence.ts
@@ -1,6 +1,7 @@
 import { Result } from 'effect'
 
 import { canonicalHashV1, stableU128, stableU64 } from '../hash'
+import { Pipeable } from '../pipeable'
 import type { ReconciliationResult } from '../types'
 import {
   AccountCode,
@@ -145,7 +146,7 @@ const verifyPersistedTransfer = (
  * Validates only invariants reconstructible from a persisted reconciliation receipt and TigerBeetle records.
  * Event-derived identities other than funding require the original expected plan and are verified separately.
  */
-export const validatePersistedRunEvidence = (
+const validatePersistedRunEvidenceDataFirst = (
   result: ReconciliationResult,
   ledger: number,
   accounts: readonly LedgerAccountRecord[],
@@ -222,3 +223,5 @@ export const validatePersistedRunEvidence = (
       })
     }
   })
+
+export const validatePersistedRunEvidence = Pipeable.dual(4, validatePersistedRunEvidenceDataFirst)

--- a/services/bayn/src/ledger.ts
+++ b/services/bayn/src/ledger.ts
@@ -59,7 +59,7 @@ export interface JournalService {
   readonly checkRun: (result: ReconciliationResult) => Effect.Effect<void, JournalError>
 }
 
-export class Journal extends Context.Service<Journal, JournalService>()('bayn/Journal') {}
+export class Journal extends Context.Service<Journal, JournalService>()('@proompteng/bayn/ledger/Journal') {}
 
 const validationBoundary = <A>(decision: Result.Result<A, LedgerValidationError>) =>
   Effect.fromResult(decision).pipe(Effect.mapError((validation) => new JournalValidationError(validation)))

--- a/services/bayn/src/market-data/model.ts
+++ b/services/bayn/src/market-data/model.ts
@@ -86,9 +86,6 @@ export interface MarketDataService {
   readonly load: Effect.Effect<MarketDataSnapshot, OperationalError>
 }
 
-export type MarketData = {
-  readonly MarketData: unique symbol
-  readonly Service: MarketDataService
-}
-
-export const MarketData = Context.Service<MarketData, MarketDataService>('bayn/MarketData')
+export class MarketData extends Context.Service<MarketData, MarketDataService>()(
+  '@proompteng/bayn/market-data/model/MarketData',
+) {}

--- a/services/bayn/src/market-data/verification/manifest.ts
+++ b/services/bayn/src/market-data/verification/manifest.ts
@@ -222,7 +222,7 @@ const verifyManifestDataFirst = (
             sessionsContentHash: manifest.sessions_content_hash,
           } as const
           return pipe(
-            Schema.decodeUnknownResult(
+            Schema.decodeResult(
               FinalizedSnapshotProvenanceSchema,
               strictParseOptions,
             )({

--- a/services/bayn/src/observe-composition.test.ts
+++ b/services/bayn/src/observe-composition.test.ts
@@ -2595,7 +2595,7 @@ describe('OBSERVE runtime composition', () => {
     expect(step).toEqual({ _tag: 'Wait', observedAt })
     expect(restrictions).toHaveLength(1)
     expect(restrictions[0]).toContain(`intent ${fixture.intent.intentId} ended CANCELED`)
-    expect(paperCycleHasFilledIntent([record.intent], [partialOrder])).toBe(true)
+    expect(paperCycleHasFilledIntent({ intents: [record.intent], orders: [partialOrder] })).toBe(true)
 
     const closeExpiresAt = new Date(Date.parse(cutoffAt) + 60_000).toISOString()
     const closeRestrictions: string[] = []

--- a/services/bayn/src/observe-composition.test.ts
+++ b/services/bayn/src/observe-composition.test.ts
@@ -693,17 +693,17 @@ const prepareStoredPaperStep = async (
   return Effect.runPromise(
     Effect.gen(function* () {
       yield* TestClock.setTime(Date.parse(observedAt))
-      return yield* prepareNextMutationIntent(
+      return yield* prepareNextMutationIntent({
         input,
         preparation,
         policy,
-        fixture.boundCycle,
+        cycle: fixture.boundCycle,
         document,
-        Effect.succeed(
+        reconcile: Effect.succeed(
           reconciliationResultAt(observedAt, unknownMutationCount, 0, reconciledPositions, reconciledOrders),
         ),
         allowSubmit,
-      )
+      })
     }).pipe(
       Effect.provideService(BrokerRead, decisionBrokerRead(calendarRead([]))),
       Effect.provideService(MarketData, marketData([])),
@@ -991,15 +991,17 @@ describe('OBSERVE runtime composition', () => {
     const waiting = await Effect.runPromise(
       Effect.gen(function* () {
         yield* TestClock.setTime(Date.parse(observedAt))
-        return yield* prepareNextMutationIntent(
-          fixture.input,
-          fixture.preparation,
-          fixture.policy,
-          fixture.boundCycle,
-          fixture.document,
-          Effect.die(new Error('OBSERVE recovery-only execution must not reconcile before refusing fresh submit')),
-          false,
-        )
+        return yield* prepareNextMutationIntent({
+          input: fixture.input,
+          preparation: fixture.preparation,
+          policy: fixture.policy,
+          cycle: fixture.boundCycle,
+          document: fixture.document,
+          reconcile: Effect.die(
+            new Error('OBSERVE recovery-only execution must not reconcile before refusing fresh submit'),
+          ),
+          allowSubmit: false,
+        })
       }).pipe(
         Effect.provideService(BrokerRead, decisionBrokerRead(calendarRead([]))),
         Effect.provideService(MarketData, marketData([])),
@@ -1599,14 +1601,14 @@ describe('OBSERVE runtime composition', () => {
     const step = await Effect.runPromise(
       Effect.gen(function* () {
         yield* TestClock.setTime(Date.parse(riskExpiresAt))
-        return yield* prepareNextMutationIntent(
-          fixture.input,
-          fixture.preparation,
-          fixture.policy,
-          fixture.boundCycle,
-          fixture.document,
-          Effect.die(new Error('pre-commit expiry must not reconcile or read the broker')),
-        )
+        return yield* prepareNextMutationIntent({
+          input: fixture.input,
+          preparation: fixture.preparation,
+          policy: fixture.policy,
+          cycle: fixture.boundCycle,
+          document: fixture.document,
+          reconcile: Effect.die(new Error('pre-commit expiry must not reconcile or read the broker')),
+        })
       }).pipe(
         Effect.provideService(BrokerRead, decisionBrokerRead(calendarRead([]))),
         Effect.provideService(MarketData, marketData([])),
@@ -1661,14 +1663,14 @@ describe('OBSERVE runtime composition', () => {
     const step = await Effect.runPromise(
       Effect.gen(function* () {
         yield* TestClock.setTime(Date.parse(observedAt))
-        return yield* prepareNextMutationIntent(
-          { ...fixture.input, authorityGenerationHash: 'f'.repeat(64) },
-          fixture.preparation,
-          fixture.policy,
-          fixture.boundCycle,
-          fixture.document,
-          Effect.die(new Error('superseded PAPER generation must not reconcile or read the broker')),
-        )
+        return yield* prepareNextMutationIntent({
+          input: { ...fixture.input, authorityGenerationHash: 'f'.repeat(64) },
+          preparation: fixture.preparation,
+          policy: fixture.policy,
+          cycle: fixture.boundCycle,
+          document: fixture.document,
+          reconcile: Effect.die(new Error('superseded PAPER generation must not reconcile or read the broker')),
+        })
       }).pipe(
         Effect.provideService(BrokerRead, decisionBrokerRead(calendarRead([]))),
         Effect.provideService(MarketData, marketData([])),
@@ -1916,14 +1918,16 @@ describe('OBSERVE runtime composition', () => {
       Effect.gen(function* () {
         yield* TestClock.setTime(Date.parse(observedAt))
         return yield* Effect.flip(
-          prepareNextMutationIntent(
-            fixture.input,
-            fixture.preparation,
-            driftedPolicy,
-            fixture.boundCycle,
-            fixture.document,
-            Effect.die(new Error('policy drift must fail before reconciliation, broker reads, or fresh submission')),
-          ),
+          prepareNextMutationIntent({
+            input: fixture.input,
+            preparation: fixture.preparation,
+            policy: driftedPolicy,
+            cycle: fixture.boundCycle,
+            document: fixture.document,
+            reconcile: Effect.die(
+              new Error('policy drift must fail before reconciliation, broker reads, or fresh submission'),
+            ),
+          }),
         )
       }).pipe(
         Effect.provideService(BrokerRead, decisionBrokerRead(calendarRead([]))),
@@ -2029,17 +2033,17 @@ describe('OBSERVE runtime composition', () => {
       Effect.gen(function* () {
         yield* TestClock.setTime(Date.parse(observedAt))
         return yield* Effect.flip(
-          prepareNextMutationIntent(
-            fixture.input,
-            driftedPreparation,
-            fixture.policy,
-            fixture.boundCycle,
-            fixture.document,
-            Effect.sync(() => {
+          prepareNextMutationIntent({
+            input: fixture.input,
+            preparation: driftedPreparation,
+            policy: fixture.policy,
+            cycle: fixture.boundCycle,
+            document: fixture.document,
+            reconcile: Effect.sync(() => {
               reconciliations += 1
               return reconciliationResultAt(observedAt)
             }),
-          ),
+          }),
         )
       }).pipe(
         Effect.provideService(BrokerRead, decisionBrokerRead(calendarRead([]))),
@@ -2174,15 +2178,15 @@ describe('OBSERVE runtime composition', () => {
       Effect.runPromise(
         Effect.gen(function* () {
           yield* TestClock.setTime(Date.parse(observedAt))
-          return yield* buildClosingPaperCycleDecision(
-            fixture.input,
-            fixture.preparation,
-            fixture.policy,
-            fixture.boundCycle,
+          return yield* buildClosingPaperCycleDecision({
+            input: fixture.input,
+            preparation: fixture.preparation,
+            policy: fixture.policy,
+            cycle: fixture.boundCycle,
             entryDocument,
-            Effect.succeed(currentReconciliation),
+            reconcile: Effect.succeed(currentReconciliation),
             closeExpiresAt,
-          )
+          })
         }).pipe(
           Effect.provideService(BrokerRead, decisionBrokerRead(calendarRead([]))),
           Effect.provideService(MarketData, marketData([])),
@@ -2233,19 +2237,19 @@ describe('OBSERVE runtime composition', () => {
     const admission = await Effect.runPromise(
       Effect.gen(function* () {
         yield* TestClock.setTime(Date.parse(observedAt))
-        return yield* prepareNextMutationIntent(
-          {
+        return yield* prepareNextMutationIntent({
+          input: {
             ...fixture.input,
             mutationPhase: 'CLOSE',
             paperEpisodeCutoffAt: fixture.document.submissionCutoffAt,
             paperEpisodeExpiresAt: closeExpiresAt,
           },
-          fixture.preparation,
-          fixture.policy,
-          fixture.boundCycle,
-          close,
-          Effect.succeed(currentReconciliation),
-        )
+          preparation: fixture.preparation,
+          policy: fixture.policy,
+          cycle: fixture.boundCycle,
+          document: close,
+          reconcile: Effect.succeed(currentReconciliation),
+        })
       }).pipe(
         Effect.provideService(BrokerRead, decisionBrokerRead(calendarRead([]))),
         Effect.provideService(MarketData, marketData([])),
@@ -2355,15 +2359,15 @@ describe('OBSERVE runtime composition', () => {
     const close = await Effect.runPromise(
       Effect.gen(function* () {
         yield* TestClock.setTime(Date.parse(observedAt))
-        return yield* buildClosingPaperCycleDecision(
-          fixture.input,
-          fixture.preparation,
-          fixture.policy,
-          fixture.boundCycle,
-          fixture.document,
-          Effect.succeed(currentReconciliation),
+        return yield* buildClosingPaperCycleDecision({
+          input: fixture.input,
+          preparation: fixture.preparation,
+          policy: fixture.policy,
+          cycle: fixture.boundCycle,
+          entryDocument: fixture.document,
+          reconcile: Effect.succeed(currentReconciliation),
           closeExpiresAt,
-        )
+        })
       }).pipe(
         Effect.provideService(BrokerRead, decisionBrokerRead(calendarRead([]))),
         Effect.provideService(MarketData, marketData([])),

--- a/services/bayn/src/observe-composition.ts
+++ b/services/bayn/src/observe-composition.ts
@@ -1646,12 +1646,12 @@ const executeBoundPaperCycle = (
           step.action,
           step.action === 'SUBMIT' ? step.submitExpiresAt : undefined,
         )
-      : executeMutationIntentWithExecutor(
-          { recover: recoverMutation },
-          step.intentId,
-          step.action,
-          step.action === 'SUBMIT' ? step.submitExpiresAt : undefined,
-        )
+      : executeMutationIntentWithExecutor({
+          executor: { recover: recoverMutation },
+          intentId: step.intentId,
+          action: step.action,
+          submitExpiresAt: step.action === 'SUBMIT' ? step.submitExpiresAt : undefined,
+        })
     if (executed.operation === MutationOperation.Submit && executed.settlement.outcome !== 'accepted') {
       yield* restrictMutationAuthority(
         `bound PAPER cycle ${cycle.identity.cycleId}`,

--- a/services/bayn/src/observe-composition.ts
+++ b/services/bayn/src/observe-composition.ts
@@ -82,7 +82,7 @@ import type {
   ObserveShadowDecisionDocument,
   PaperDecisionDocument,
 } from './shadow-decision-contract'
-import { currentUtcInstant } from './time'
+import { currentUtcInstant, utcInstantFromEpochMillis } from './time'
 import {
   planTargets,
   type SignalSessionReferencePrices,
@@ -1111,15 +1111,15 @@ export type ObserveAutonomousCycleInput = {
 export const paperEpisodeCloseGraceMs = 15 * 60_000
 
 export const paperEpisodeCloseExpiresAt = (authorityExpiresAt: string): string =>
-  new Date(Date.parse(authorityExpiresAt) + paperEpisodeCloseGraceMs).toISOString()
+  utcInstantFromEpochMillis(Date.parse(authorityExpiresAt) + paperEpisodeCloseGraceMs)
 
 /** Receipt finalization remains bounded, but survives late close settlement and transient read failures. */
 export const paperEpisodeReceiptFinalizationGraceMs = 15 * 60_000
 
 export const paperEpisodeReceiptFinalizationExpiresAt = (authorityExpiresAt: string): string =>
-  new Date(
+  utcInstantFromEpochMillis(
     Date.parse(paperEpisodeCloseExpiresAt(authorityExpiresAt)) + paperEpisodeReceiptFinalizationGraceMs,
-  ).toISOString()
+  )
 
 type ObserveDecisionRuntime =
   | BrokerRead

--- a/services/bayn/src/observe-composition.ts
+++ b/services/bayn/src/observe-composition.ts
@@ -979,17 +979,22 @@ const recoverPaperExecutionSession = (
   )
 }
 
+export interface BuildClosingPaperCycleDecisionInput {
+  readonly input: ObserveAutonomousCycleInput
+  readonly preparation: ObserveStartupPreparation
+  readonly policy: Policy
+  readonly cycle: AutonomousCycle
+  readonly entryDocument: PaperDecisionDocument
+  readonly reconcile: Effect.Effect<ReconciliationPassResult, ReconciliationPassError, ObserveDecisionRuntime>
+  readonly closeExpiresAt: string
+  readonly replanGenerationHash?: string
+}
+
 export const buildClosingPaperCycleDecision = (
-  input: ObserveAutonomousCycleInput,
-  preparation: ObserveStartupPreparation,
-  policy: Policy,
-  cycle: AutonomousCycle,
-  entryDocument: PaperDecisionDocument,
-  reconcile: Effect.Effect<ReconciliationPassResult, ReconciliationPassError, ObserveDecisionRuntime>,
-  closeExpiresAt: string,
-  replanGenerationHash?: string,
-): Effect.Effect<PaperDecisionDocument, CycleRunnerError, ObserveDecisionRuntime> =>
-  Effect.gen(function* () {
+  request: BuildClosingPaperCycleDecisionInput,
+): Effect.Effect<PaperDecisionDocument, CycleRunnerError, ObserveDecisionRuntime> => {
+  const { input, preparation, policy, cycle, entryDocument, reconcile, closeExpiresAt, replanGenerationHash } = request
+  return Effect.gen(function* () {
     const reconciliation = yield* reconcile.pipe(
       Effect.mapError((cause) => mutationRunnerError({ message: 'PAPER close reconciliation failed', cause })),
     )
@@ -1080,6 +1085,7 @@ export const buildClosingPaperCycleDecision = (
       }),
     )
   })
+}
 
 const observePass = (
   recordPass: Parameters<AutonomousCycleStartup>[0]['recordPass'],
@@ -1366,7 +1372,7 @@ const ensurePaperCycleClosure = (
       })
     }
     if (existing === undefined) {
-      const document = yield* buildClosingPaperCycleDecision(
+      const document = yield* buildClosingPaperCycleDecision({
         input,
         preparation,
         policy,
@@ -1374,7 +1380,7 @@ const ensurePaperCycleClosure = (
         entryDocument,
         reconcile,
         closeExpiresAt,
-      )
+      })
       if (!document.dispatchable || document.targetPlan.status !== TargetPlanStatus.Planned) return undefined
       const closure = yield* Effect.fromResult(
         makePaperCycleClosure({
@@ -1404,7 +1410,7 @@ const ensurePaperCycleClosure = (
     const active = latestReplan ?? existing
     if (!(yield* closePlanNeedsResidualReplan(active.document, reconcile))) return active.document
 
-    const document = yield* buildClosingPaperCycleDecision(
+    const document = yield* buildClosingPaperCycleDecision({
       input,
       preparation,
       policy,
@@ -1412,8 +1418,8 @@ const ensurePaperCycleClosure = (
       entryDocument,
       reconcile,
       closeExpiresAt,
-      active.contentHash,
-    )
+      replanGenerationHash: active.contentHash,
+    })
     if (!document.dispatchable || document.targetPlan.status !== TargetPlanStatus.Planned) return active.document
     const closure = yield* Effect.fromResult(
       makePaperCycleClosure({
@@ -1548,20 +1554,34 @@ const readCloseMutationPreparationFacts = (
     }
   })
 
+export interface PrepareNextMutationIntentInput {
+  readonly input: ObserveAutonomousCycleInput
+  readonly preparation: ObserveStartupPreparation
+  readonly policy: Policy
+  readonly cycle: AutonomousCycle
+  readonly document: PaperDecisionDocument
+  readonly reconcile: Effect.Effect<ReconciliationPassResult, ReconciliationPassError, ObserveDecisionRuntime>
+  readonly allowSubmit?: boolean
+}
+
 export const prepareNextMutationIntent = (
-  input: ObserveAutonomousCycleInput,
-  preparation: ObserveStartupPreparation,
-  policy: Policy,
-  cycle: AutonomousCycle,
-  document: PaperDecisionDocument,
-  reconcile: Effect.Effect<ReconciliationPassResult, ReconciliationPassError, ObserveDecisionRuntime>,
-  allowSubmit = true,
+  request: PrepareNextMutationIntentInput,
 ): Effect.Effect<PreparedMutationCycleStep, CycleRunnerError, ObserveDecisionRuntime | IntentStore | MutationStore> =>
-  prepareMutationIntent(input, preparation, policy, cycle, document, reconcile, allowSubmit, {
-    now: currentUtcInstant,
-    readFacts: input.mutationPhase === 'CLOSE' ? readCloseMutationPreparationFacts : readMutationPreparationFacts,
-    restrictAuthority: restrictMutationAuthority,
-  })
+  prepareMutationIntent(
+    request.input,
+    request.preparation,
+    request.policy,
+    request.cycle,
+    request.document,
+    request.reconcile,
+    request.allowSubmit ?? true,
+    {
+      now: currentUtcInstant,
+      readFacts:
+        request.input.mutationPhase === 'CLOSE' ? readCloseMutationPreparationFacts : readMutationPreparationFacts,
+      restrictAuthority: restrictMutationAuthority,
+    },
+  )
 
 const executeBoundPaperCycle = (
   input: ObserveAutonomousCycleInput,
@@ -1581,14 +1601,14 @@ const executeBoundPaperCycle = (
       ...(closeOnly ? { mutationPhase: 'CLOSE' as const } : { mutationPhase: 'ENTRY' as const }),
     }
     const activeDocument = closeDocument ?? document
-    const step = yield* prepareNextMutationIntent(
-      phaseInput,
+    const step = yield* prepareNextMutationIntent({
+      input: phaseInput,
       preparation,
       policy,
       cycle,
-      activeDocument,
+      document: activeDocument,
       reconcile,
-      paperMutationSubmissionAllowed({
+      allowSubmit: paperMutationSubmissionAllowed({
         capability: capability._tag,
         closeOnly,
         ...(input.paperEpisodeCutoffAt === undefined ? {} : { paperEpisodeCutoffAt: input.paperEpisodeCutoffAt }),
@@ -1597,7 +1617,7 @@ const executeBoundPaperCycle = (
           : { paperEpisodeCloseSubmitCutoffAt: input.paperEpisodeCloseSubmitCutoffAt }),
         observedAt,
       }),
-    )
+    })
     if (step._tag !== 'Execute') {
       if (step._tag !== 'Complete') return step
       const entryHasUnsuccessfulIntent =

--- a/services/bayn/src/observe-composition/mutation-decisions.ts
+++ b/services/bayn/src/observe-composition/mutation-decisions.ts
@@ -21,10 +21,13 @@ const quantityScale = 1_000_000n
 export const countOpenPositions = (positions: readonly Pick<Position, 'quantityMicros'>[]): number =>
   positions.filter((position) => BigInt(position.quantityMicros) !== 0n).length
 
-export const paperCycleHasFilledIntent = (
-  intents: readonly Pick<Intent, 'intentId' | 'state' | 'terminalOutcome'>[],
-  orders: readonly Pick<Order, 'intentId' | 'filledQuantityMicros'>[] = [],
-): boolean => {
+export interface PaperCycleFillInput {
+  readonly intents: readonly Pick<Intent, 'intentId' | 'state' | 'terminalOutcome'>[]
+  readonly orders?: readonly Pick<Order, 'intentId' | 'filledQuantityMicros'>[]
+}
+
+export const paperCycleHasFilledIntent = (input: PaperCycleFillInput): boolean => {
+  const { intents, orders = [] } = input
   const intentIds = new Set(intents.map((intent) => intent.intentId))
   return (
     intents.some(
@@ -37,12 +40,14 @@ export const paperCycleHasFilledIntent = (
   )
 }
 
-/** A settled close plan must be replaced when authoritative positions remain open. */
-export const paperClosePlanNeedsResidualReplan = (
+const paperClosePlanNeedsResidualReplanDataFirst = (
   intents: readonly Pick<Intent, 'state'>[],
   openPositionCount: number,
 ): boolean =>
   intents.length > 0 && intents.every((intent) => intent.state === IntentState.Terminal) && openPositionCount > 0
+
+/** A settled close plan must be replaced when authoritative positions remain open. */
+export const paperClosePlanNeedsResidualReplan = Pipeable.dual(2, paperClosePlanNeedsResidualReplanDataFirst)
 
 const comparePositionSymbol = (left: Position, right: Position): number =>
   left.symbol < right.symbol ? -1 : left.symbol > right.symbol ? 1 : 0

--- a/services/bayn/src/observe-composition/mutation-intent-interpreter.ts
+++ b/services/bayn/src/observe-composition/mutation-intent-interpreter.ts
@@ -476,10 +476,10 @@ const prepareMutationIntentDataFirst = <R, E, I extends MutationIntentInput, P e
 
     const terminalEvidence: PaperCycleIntentTerminalEvidence[] = []
     let unsuccessfulIntentFound = false
-    const hasFilledIntent = paperCycleHasFilledIntent(
-      preparedIntents.flatMap((prepared) => (prepared.stored === undefined ? [] : [prepared.stored.intent])),
-      facts.reconciliation.brokerState.orders,
-    )
+    const hasFilledIntent = paperCycleHasFilledIntent({
+      intents: preparedIntents.flatMap((prepared) => (prepared.stored === undefined ? [] : [prepared.stored.intent])),
+      orders: facts.reconciliation.brokerState.orders,
+    })
     const hasOpenPosition = countOpenPositions(facts.reconciliation.brokerState.positions) > 0
     for (const prepared of preparedIntents) {
       const stored = yield* intentStore

--- a/services/bayn/src/observe-composition/mutation-interpreter.ts
+++ b/services/bayn/src/observe-composition/mutation-interpreter.ts
@@ -62,14 +62,19 @@ export const restrictMutationLoopFailure = (
 const submitDoesNotRequireRecovery = (eventType: MutationEvent['eventType']): boolean =>
   eventType === MutationEventType.SubmitRejected || eventType === MutationEventType.SubmitDenied
 
+export interface ExecuteMutationIntentInput<E, R> {
+  readonly executor: PaperMutationExecutor<E, R>
+  readonly intentId: string
+  readonly action: 'RECOVER_SUBMIT' | 'RECOVER_CANCEL' | 'SUBMIT'
+  readonly submitExpiresAt?: string | undefined
+  readonly now?: Effect.Effect<string, never, R>
+}
+
 export const executeMutationIntentWithExecutor = <E, R>(
-  executor: PaperMutationExecutor<E, R>,
-  intentId: string,
-  action: 'RECOVER_SUBMIT' | 'RECOVER_CANCEL' | 'SUBMIT',
-  submitExpiresAt?: string,
-  now: Effect.Effect<string, never, R> = currentUtcInstant,
-): Effect.Effect<MutationIntentExecutionResult, CycleRunnerError, MutationStore | R> =>
-  Effect.gen(function* () {
+  input: ExecuteMutationIntentInput<E, R>,
+): Effect.Effect<MutationIntentExecutionResult, CycleRunnerError, MutationStore | R> => {
+  const { executor, intentId, action, submitExpiresAt, now = currentUtcInstant } = input
+  return Effect.gen(function* () {
     const store = yield* MutationStore
     const operation = action === 'RECOVER_CANCEL' ? MutationOperation.Cancel : MutationOperation.Submit
     const existing = yield* store.latest(intentId, operation).pipe(
@@ -136,6 +141,7 @@ export const executeMutationIntentWithExecutor = <E, R>(
     }
     return { settlement, consistencyDelayMs: event.consistencyDelayMs, operation }
   })
+}
 
 const executeMutationIntentDataFirst = (
   executionProgram: ExecutionProgram,
@@ -143,16 +149,16 @@ const executeMutationIntentDataFirst = (
   action: 'RECOVER_SUBMIT' | 'RECOVER_CANCEL' | 'SUBMIT',
   submitExpiresAt?: string,
 ): Effect.Effect<MutationIntentExecutionResult, CycleRunnerError, MutationStore> =>
-  executeMutationIntentWithExecutor(
-    {
+  executeMutationIntentWithExecutor({
+    executor: {
       submit: executionProgram.submit,
       recover: executionProgram.recover,
     },
     intentId,
     action,
     submitExpiresAt,
-    currentUtcInstant,
-  )
+    now: currentUtcInstant,
+  })
 
 export const executeMutationIntent = Pipeable.by<
   (

--- a/services/bayn/src/paper.test.ts
+++ b/services/bayn/src/paper.test.ts
@@ -286,16 +286,17 @@ describe('paper contracts', () => {
       for (const to of Object.values(IntentState)) {
         if (to === IntentState.Terminal) {
           for (const outcome of Object.values(TerminalOutcome)) {
-            expect(isIntentTransitionAllowed(from, to, outcome), `${from}:${outcome}`).toBe(
+            expect(isIntentTransitionAllowed({ from, to, terminalOutcome: outcome }), `${from}:${outcome}`).toBe(
               allowedTerminal.has(`${from}:${outcome}`),
             )
           }
           continue
         }
-        expect(isIntentTransitionAllowed(from, to), `${from}:${to}`).toBe(allowed.has(`${from}:${to}`))
-        expect(isIntentTransitionAllowed(from, to, TerminalOutcome.Blocked), `${from}:${to}:unexpected outcome`).toBe(
-          false,
-        )
+        expect(isIntentTransitionAllowed({ from, to }), `${from}:${to}`).toBe(allowed.has(`${from}:${to}`))
+        expect(
+          isIntentTransitionAllowed({ from, to, terminalOutcome: TerminalOutcome.Blocked }),
+          `${from}:${to}:unexpected outcome`,
+        ).toBe(false)
       }
     }
   })

--- a/services/bayn/src/resources.test.ts
+++ b/services/bayn/src/resources.test.ts
@@ -574,7 +574,7 @@ describe('Bayn resource lifecycle', () => {
     const marketData = marketDataService(
       Effect.never.pipe(Effect.onInterrupt(() => Effect.sync(() => void (interrupted = true)))),
     )
-    const state = await Effect.runPromise(Ref.make(initialState()))
+    const state = await Effect.runPromise(Ref.make(initialState({})))
 
     const exit = await Effect.runPromiseExit(
       Effect.scoped(
@@ -603,7 +603,7 @@ describe('Bayn resource lifecycle', () => {
         }),
       ),
     )
-    const state = await Effect.runPromise(Ref.make(initialState()))
+    const state = await Effect.runPromise(Ref.make(initialState({})))
 
     await Effect.runPromise(
       Effect.scoped(
@@ -628,7 +628,7 @@ describe('Bayn resource lifecycle', () => {
     const marketData = marketDataService(
       Effect.fail(marketDataOperationError('load', 'failed to load finalized Signal snapshot', authorization)),
     )
-    const state = await Effect.runPromise(Ref.make(initialState()))
+    const state = await Effect.runPromise(Ref.make(initialState({})))
 
     await Effect.runPromise(
       Effect.scoped(
@@ -661,7 +661,7 @@ describe('Bayn resource lifecycle', () => {
       },
     })
     const marketData = marketDataService(Effect.succeed(makeSnapshot()))
-    const state = await Effect.runPromise(Ref.make(initialState()))
+    const state = await Effect.runPromise(Ref.make(initialState({})))
 
     const exit = await Effect.runPromiseExit(
       Effect.scoped(

--- a/services/bayn/src/risk.test.ts
+++ b/services/bayn/src/risk.test.ts
@@ -342,7 +342,7 @@ const evaluateSuccess = (
   policy: Policy,
   proposedPositions?: State['positions'],
 ): Evaluation => {
-  const result = evaluate(intent, state, policy, proposedPositions)
+  const result = evaluate({ intent, state, policy, proposedPositions })
   if (Result.isFailure(result)) throw result.failure
   return result.success
 }
@@ -921,11 +921,11 @@ describe('bounded paper risk', () => {
     expect(rotated.input.inputHash).not.toBe(baseline.input.inputHash)
     expect(rotated.gates.find((gate) => gate.name === 'reconciliation')?.passed).toBe(true)
     const failures = [
-      evaluate(makeIntent(), rotatedState, makePolicy()),
-      evaluate(makeReferenceIntent(), baselineState, makePolicy()),
-      evaluate(
-        makeReferenceIntent(),
-        makeState({
+      evaluate({ intent: makeIntent(), state: rotatedState, policy: makePolicy() }),
+      evaluate({ intent: makeReferenceIntent(), state: baselineState, policy: makePolicy() }),
+      evaluate({
+        intent: makeReferenceIntent(),
+        state: makeState({
           authority: {
             ...baselineState.authority,
             effective: Authority.Observe,
@@ -933,19 +933,19 @@ describe('bounded paper risk', () => {
             reason: 'operator kill',
           },
         }),
-        makePolicy(),
-      ),
-      evaluate(
-        makeIntent(),
-        makeState({
+        policy: makePolicy(),
+      }),
+      evaluate({
+        intent: makeIntent(),
+        state: makeState({
           authority: {
             ...baselineState.authority,
             maximum: Authority.Observe,
             effective: Authority.Observe,
           },
         }),
-        makePolicy(),
-      ),
+        policy: makePolicy(),
+      }),
     ] as const
     expect(failures.map((result) => (Result.isFailure(result) ? result.failure.reason : null))).toEqual([
       'authority-generation',
@@ -966,10 +966,13 @@ describe('bounded paper risk', () => {
 
   test('returns closed tagged failures for malformed exported inputs', () => {
     const cases = [
-      ['intent', evaluate({}, makeState(), makePolicy())],
-      ['state', evaluate(makeIntent(), {}, makePolicy())],
-      ['policy', evaluate(makeIntent(), makeState(), {})],
-      ['positions', evaluate(makeIntent(), makeState(), makePolicy(), [{}])],
+      ['intent', evaluate({ intent: {}, state: makeState(), policy: makePolicy() })],
+      ['state', evaluate({ intent: makeIntent(), state: {}, policy: makePolicy() })],
+      ['policy', evaluate({ intent: makeIntent(), state: makeState(), policy: {} })],
+      [
+        'positions',
+        evaluate({ intent: makeIntent(), state: makeState(), policy: makePolicy(), proposedPositions: [{}] }),
+      ],
     ] as const
 
     for (const [reason, result] of cases) {
@@ -1008,7 +1011,7 @@ describe('bounded paper risk', () => {
     ]
 
     for (const proposedPositions of cases) {
-      const result = evaluate(makeIntent(), state, makePolicy(), proposedPositions)
+      const result = evaluate({ intent: makeIntent(), state, policy: makePolicy(), proposedPositions })
       expect(Result.isFailure(result)).toBe(true)
       if (Result.isFailure(result)) {
         expect(result.failure).toMatchObject({
@@ -1028,7 +1031,12 @@ describe('bounded paper risk', () => {
     const proposedPositions = state.positions.map((position) =>
       position.symbol === 'AMD' ? { ...position, marketValueMicros: '0' } : position,
     )
-    const result = evaluate(makeIntent(), state, makePolicy({ maxGrossExposureMicros: '250000000' }), proposedPositions)
+    const result = evaluate({
+      intent: makeIntent(),
+      state,
+      policy: makePolicy({ maxGrossExposureMicros: '250000000' }),
+      proposedPositions,
+    })
 
     expect(Result.isFailure(result)).toBe(true)
     if (Result.isFailure(result)) {

--- a/services/bayn/src/risk.ts
+++ b/services/bayn/src/risk.ts
@@ -1252,26 +1252,28 @@ const evaluateDecoded = (
     })
   })
 
-export const evaluate = (
-  intentInput: unknown,
-  stateInput: unknown,
-  policyInput: unknown,
-  proposedPositionsInput?: unknown,
-): Result.Result<Evaluation, RiskEvaluationFailure> => {
-  const intent = Result.mapError(decodeRiskIntentResult(intentInput), (cause) =>
+export interface RiskEvaluationInput {
+  readonly intent: unknown
+  readonly state: unknown
+  readonly policy: unknown
+  readonly proposedPositions?: unknown
+}
+
+export const evaluate = (input: RiskEvaluationInput): Result.Result<Evaluation, RiskEvaluationFailure> => {
+  const intent = Result.mapError(decodeRiskIntentResult(input.intent), (cause) =>
     decodeRiskInputFailure('intent', 'risk intent is invalid', {}, cause),
   )
   if (Result.isFailure(intent)) return Result.fail(intent.failure)
-  const state = Result.mapError(decodeRiskStateResult(stateInput), (cause) =>
+  const state = Result.mapError(decodeRiskStateResult(input.state), (cause) =>
     decodeRiskInputFailure('state', 'risk state is invalid', {}, cause),
   )
   if (Result.isFailure(state)) return Result.fail(state.failure)
-  const policy = Result.mapError(decodeRiskPolicyResult(policyInput), (cause) =>
+  const policy = Result.mapError(decodeRiskPolicyResult(input.policy), (cause) =>
     decodeRiskInputFailure('policy', 'risk policy is invalid', {}, cause),
   )
   if (Result.isFailure(policy)) return Result.fail(policy.failure)
   const proposedPositions = Result.mapError(
-    decodeProposedPositionsResult(proposedPositionsInput ?? state.success.positions),
+    decodeProposedPositionsResult(input.proposedPositions ?? state.success.positions),
     (cause) => decodeRiskInputFailure('positions', 'proposed risk positions are invalid', {}, cause),
   )
   if (Result.isFailure(proposedPositions)) return Result.fail(proposedPositions.failure)

--- a/services/bayn/src/risk.ts
+++ b/services/bayn/src/risk.ts
@@ -39,6 +39,7 @@ import {
   strictParseOptions as StrictParseOptions,
 } from './schemas'
 import { Pipeable } from './pipeable'
+import { utcInstantFromEpochMillis } from './time'
 
 const MAX_POLICY_MICROS = 9_223_372_036_854_775_807n
 const MAX_AGE_MS = 86_400_000
@@ -551,7 +552,7 @@ const divideUp = (numerator: bigint, denominator: bigint): bigint =>
 const divideAwayFromZero = (numerator: bigint, denominator: bigint): bigint =>
   numerator < 0n ? -divideUp(-numerator, denominator) : divideUp(numerator, denominator)
 const instant = (value: string): number => Date.parse(value)
-const utc = (value: number): string => new Date(value).toISOString()
+const utc = utcInstantFromEpochMillis
 
 const makeGate = (
   name: Gate,

--- a/services/bayn/src/risk.ts
+++ b/services/bayn/src/risk.ts
@@ -1235,8 +1235,8 @@ const evaluateDecoded = (
 ): Result.Result<Evaluation, RiskEvaluationFailure> =>
   Result.flatMap(validateAuthorityBinding(intent, state), () => {
     const facts = parseRiskFacts(intent, state, policy, proposedPositions)
-    return Result.flatMap(deriveReconciledHash(facts), (reconciledHash) => {
-      return Result.flatMap(deriveRiskMetrics(facts), (metrics) => {
+    return Result.flatMap(deriveReconciledHash(facts), (reconciledHash) =>
+      Result.flatMap(deriveRiskMetrics(facts), (metrics) => {
         const gates = buildRiskGates(facts, metrics, reconciledHash)
         const reasonCodes = gates.filter((gate) => !gate.passed).map((gate) => gate.reason)
         const outcome = reasonCodes.length === 0 ? RiskOutcome.Approved : RiskOutcome.Blocked
@@ -1248,8 +1248,8 @@ const evaluateDecoded = (
             ),
           ),
         )
-      })
-    })
+      }),
+    )
   })
 
 export interface RiskEvaluationInput {

--- a/services/bayn/src/runtime-state.ts
+++ b/services/bayn/src/runtime-state.ts
@@ -116,7 +116,12 @@ export interface RuntimeState {
 
 const unknownDependency = (): DependencyHealth => ({ status: 'UNKNOWN', checkedAt: null, error: null })
 
-export const initialState = (broker?: BrokerConfiguration, autonomousCycleLoopConfigured = false): RuntimeState => ({
+export interface InitialRuntimeStateInput {
+  readonly broker?: BrokerConfiguration | undefined
+  readonly autonomousCycleLoopConfigured?: boolean
+}
+
+export const initialState = (input: InitialRuntimeStateInput): RuntimeState => ({
   status: 'STARTING',
   evidence: null,
   health: {
@@ -133,19 +138,19 @@ export const initialState = (broker?: BrokerConfiguration, autonomousCycleLoopCo
   },
   cycle: unknownCycleOperationsStatus(),
   autonomousCycleLoop: {
-    configured: autonomousCycleLoopConfigured,
+    configured: input.autonomousCycleLoopConfigured ?? false,
     startedAt: null,
     lastPass: null,
   },
   paperActivation: { _tag: 'NotConfigured' },
   broker:
-    broker === undefined
+    input.broker === undefined
       ? null
       : {
           configured: true,
-          expectedAccountId: broker.expectedAccountId,
-          executionEligible: broker.executionEligible,
-          executionDisabledReason: broker.executionDisabledReason,
+          expectedAccountId: input.broker.expectedAccountId,
+          executionEligible: input.broker.executionEligible,
+          executionDisabledReason: input.broker.executionDisabledReason,
           accountId: null,
           accountBound: null,
           readAvailable: null,

--- a/services/bayn/src/schemas.ts
+++ b/services/bayn/src/schemas.ts
@@ -1,17 +1,17 @@
-import { Schema } from 'effect'
+import { DateTime, Option, Schema } from 'effect'
 
 export const strictParseOptions = { onExcessProperty: 'error' } as const
 
 const isIsoDate = (value: string): value is `${number}-${number}-${number}` => {
   if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return false
-  const date = new Date(`${value}T00:00:00.000Z`)
-  return !Number.isNaN(date.getTime()) && date.toISOString().slice(0, 10) === value
+  const date = DateTime.make(`${value}T00:00:00.000Z`)
+  return Option.isSome(date) && DateTime.formatIsoDate(date.value) === value
 }
 
 const isUtcInstant = (value: string): boolean => {
   if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/.test(value)) return false
-  const date = new Date(value)
-  return !Number.isNaN(date.getTime()) && date.toISOString() === value
+  const date = DateTime.make(value)
+  return Option.isSome(date) && DateTime.formatIso(date.value) === value
 }
 
 const isUtcOrderTimestamp = (value: string): boolean => {
@@ -19,8 +19,8 @@ const isUtcOrderTimestamp = (value: string): boolean => {
   if (match === null) return false
   const [, seconds, fractional] = match
   if (seconds === undefined || fractional === undefined) return false
-  const date = new Date(`${seconds}.${fractional.slice(0, 3)}Z`)
-  return !Number.isNaN(date.getTime()) && date.toISOString().slice(0, 19) === seconds
+  const date = DateTime.make(`${seconds}.${fractional.slice(0, 3)}Z`)
+  return Option.isSome(date) && DateTime.formatIso(date.value).slice(0, 19) === seconds
 }
 
 export const StrictNonEmptyStringSchema = Schema.String.check(

--- a/services/bayn/src/shadow-decision.ts
+++ b/services/bayn/src/shadow-decision.ts
@@ -421,7 +421,12 @@ const reduceShadowDelta = (
     (cause) => error('contract', 'cumulative shadow risk state is invalid', cause),
   )
   if (Result.isFailure(state)) return Result.fail(state.failure)
-  const evaluation = evaluate(intent.success, state.success, context.input.policy, accumulator.projectedPositions)
+  const evaluation = evaluate({
+    intent: intent.success,
+    state: state.success,
+    policy: context.input.policy,
+    proposedPositions: accumulator.projectedPositions,
+  })
   if (Result.isFailure(evaluation)) {
     return Result.fail(error('risk', 'shadow target risk evaluation failed', evaluation.failure))
   }

--- a/services/bayn/src/simulation/inputs.ts
+++ b/services/bayn/src/simulation/inputs.ts
@@ -83,8 +83,8 @@ const requiredRecordValueDataFirst = <A>(
   key: string,
   operation: RecordOperation,
   context: string,
-): Result.Result<A, SimulationFailure> => {
-  return pipe(
+): Result.Result<A, SimulationFailure> =>
+  pipe(
     optionalRecordValue(values, key, operation, context),
     Result.flatMap(
       Option.match({
@@ -93,7 +93,6 @@ const requiredRecordValueDataFirst = <A>(
       }),
     ),
   )
-}
 
 export const requiredRecordValue = Pipeable.generic<
   <A>(

--- a/services/bayn/src/simulation/rebalance.ts
+++ b/services/bayn/src/simulation/rebalance.ts
@@ -358,8 +358,8 @@ const applyBuyOrder = (
         Result.flatMap((terms) =>
           pipe(
             makeFill(input.runId, decision, order, terms, terms.notionalMicros),
-            Result.flatMap((fill) => {
-              return pipe(
+            Result.flatMap((fill) =>
+              pipe(
                 positionFor(state.positions, order.event.symbol),
                 Result.flatMap((position) => {
                   const updated = {
@@ -389,8 +389,8 @@ const applyBuyOrder = (
                     })),
                   )
                 }),
-              )
-            }),
+              ),
+            ),
           ),
         ),
       ),

--- a/services/bayn/src/simulation/simulate.ts
+++ b/services/bayn/src/simulation/simulate.ts
@@ -169,9 +169,9 @@ const runSession = (
         ? recordSkippedTargetDecision(accrued, session, scheduledTarget, input)
         : Result.succeed(accrued),
     ),
-    Result.flatMap((accrued) => {
-      return target === undefined ? Result.succeed(accrued) : rebalanceSession(accrued, session, target, opening, input)
-    }),
+    Result.flatMap((accrued) =>
+      target === undefined ? Result.succeed(accrued) : rebalanceSession(accrued, session, target, opening, input),
+    ),
     Result.flatMap((updated) => {
       if (replaceScheduledTarget || !finalSession || !hasOpenPosition(updated)) {
         return Result.succeed(updated)

--- a/services/bayn/src/simulation/valuation.ts
+++ b/services/bayn/src/simulation/valuation.ts
@@ -61,8 +61,8 @@ const markedPositions = (
   Result.all(
     Object.keys(session.bars)
       .sort()
-      .map((symbol) => {
-        return pipe(
+      .map((symbol) =>
+        pipe(
           Result.all({
             position: positionFor(positions, symbol),
             priceMicros: requiredRecordValue(closingPrices, symbol, 'price', 'closing prices'),
@@ -79,8 +79,8 @@ const markedPositions = (
               })),
             ),
           ),
-        )
-      }),
+        ),
+      ),
   )
 
 const closeSessionDataFirst = (

--- a/services/bayn/src/startup.test.ts
+++ b/services/bayn/src/startup.test.ts
@@ -749,7 +749,7 @@ describe('Bayn startup lifecycle', () => {
         forbiddenCalls += 1
         throw new Error(message)
       })
-    const state = await Effect.runPromise(Ref.make(initialState()))
+    const state = await Effect.runPromise(Ref.make(initialState({})))
 
     await Effect.runPromise(
       initialize(pinnedRuntimeConfig, state, fixtureRuntime).pipe(
@@ -882,7 +882,7 @@ describe('Bayn startup lifecycle', () => {
           })
         }),
     }
-    const state = await Effect.runPromise(Ref.make(initialState()))
+    const state = await Effect.runPromise(Ref.make(initialState({})))
 
     await Effect.runPromise(
       initialize(pinnedRuntimeConfig, state, fixtureRuntime).pipe(
@@ -944,7 +944,7 @@ describe('Bayn startup lifecycle', () => {
     ]
 
     for (const testCase of cases) {
-      const state = await Effect.runPromise(Ref.make(initialState()))
+      const state = await Effect.runPromise(Ref.make(initialState({})))
       await Effect.runPromise(
         initialize(testCase.config, state, testCase.strategy).pipe(
           Effect.provideService(MarketData, marketDataService(Effect.die(new Error('must not load bars')))),
@@ -961,7 +961,7 @@ describe('Bayn startup lifecycle', () => {
   })
 
   test('converts malformed persisted canonical material to a terminal failure without a defect', async () => {
-    const state = await Effect.runPromise(Ref.make(initialState()))
+    const state = await Effect.runPromise(Ref.make(initialState({})))
     const exit = await Effect.runPromiseExit(
       initialize(pinnedRuntimeConfig, state, fixtureRuntime).pipe(
         Effect.provideService(MarketData, marketDataService(Effect.die(new Error('must not load bars')))),
@@ -1020,7 +1020,7 @@ describe('Bayn startup lifecycle', () => {
         return Effect.die(new Error('recovered startup must not persist'))
       },
     }
-    const state = await Effect.runPromise(Ref.make(initialState()))
+    const state = await Effect.runPromise(Ref.make(initialState({})))
 
     await Effect.runPromise(
       initialize(config, state, fixtureRuntime).pipe(
@@ -1064,7 +1064,7 @@ describe('Bayn startup lifecycle', () => {
         return Effect.die(new Error('unrelated terminal qualification must not be persisted'))
       },
     }
-    const state = await Effect.runPromise(Ref.make(initialState()))
+    const state = await Effect.runPromise(Ref.make(initialState({})))
 
     await Effect.runPromise(
       initialize(config, state, fixtureRuntime).pipe(
@@ -1107,7 +1107,7 @@ describe('Bayn startup lifecycle', () => {
         return Effect.die(new Error('incomplete qualification must not persist'))
       },
     }
-    const state = await Effect.runPromise(Ref.make(initialState()))
+    const state = await Effect.runPromise(Ref.make(initialState({})))
 
     await Effect.runPromise(
       initialize(config, state, fixtureRuntime).pipe(
@@ -1153,7 +1153,7 @@ describe('Bayn startup lifecycle', () => {
         return Effect.die(new Error('corrupt recovery must not journal'))
       },
     }
-    const state = await Effect.runPromise(Ref.make(initialState()))
+    const state = await Effect.runPromise(Ref.make(initialState({})))
 
     await Effect.runPromise(
       initialize(config, state, fixtureRuntime).pipe(
@@ -1177,7 +1177,7 @@ describe('Bayn startup lifecycle', () => {
   test('evaluates through the provided StrategyDefinition and shared runner', async () => {
     let calls = 0
     const snapshot = makeSnapshot()
-    const state = await Effect.runPromise(Ref.make(initialState()))
+    const state = await Effect.runPromise(Ref.make(initialState({})))
     const strategy: StrategyRuntime = {
       definition: {
         ...fixtureRuntime.definition,
@@ -1203,7 +1203,7 @@ describe('Bayn startup lifecycle', () => {
 
   test('records durable evaluation and reconciliation before health opens readiness', async () => {
     const snapshot = makeSnapshot()
-    const state = await Effect.runPromise(Ref.make(initialState()))
+    const state = await Effect.runPromise(Ref.make(initialState({})))
     const marketData = marketDataService(Effect.succeed(snapshot))
 
     await Effect.runPromise(
@@ -1275,7 +1275,7 @@ describe('Bayn startup lifecycle', () => {
           }
         }),
     }
-    const state = await Effect.runPromise(Ref.make(initialState()))
+    const state = await Effect.runPromise(Ref.make(initialState({})))
 
     await Effect.runPromise(
       initialize(config, state, fixtureRuntime).pipe(
@@ -1298,7 +1298,7 @@ describe('Bayn startup lifecycle', () => {
   })
 
   test('rejects an underpowered calendar before opening a qualification lock', async () => {
-    const state = await Effect.runPromise(Ref.make(initialState()))
+    const state = await Effect.runPromise(Ref.make(initialState({})))
     const shortSnapshot = makeSnapshot(700)
     const marketData = marketDataService(Effect.succeed(shortSnapshot), shortSnapshot)
 
@@ -1318,7 +1318,7 @@ describe('Bayn startup lifecycle', () => {
 
   test('interrupts a stalled dependency and returns a retryable startup failure', async () => {
     let interrupted = false
-    const state = await Effect.runPromise(Ref.make(initialState()))
+    const state = await Effect.runPromise(Ref.make(initialState({})))
     const marketData = marketDataService(
       Effect.never.pipe(Effect.onInterrupt(() => Effect.sync(() => void (interrupted = true)))),
     )
@@ -1403,7 +1403,7 @@ describe('Bayn startup lifecycle', () => {
   })
 
   test('returns a retryable startup failure when durable evidence cannot be committed', async () => {
-    const state = await Effect.runPromise(Ref.make(initialState()))
+    const state = await Effect.runPromise(Ref.make(initialState({})))
     const unavailable: EvidenceStoreService = {
       check: Effect.void,
       read: () => Effect.succeed(Option.none()),
@@ -1436,7 +1436,7 @@ describe('Bayn startup lifecycle', () => {
   })
 
   test('keeps PostgreSQL authentication failures observable as terminal startup failures', async () => {
-    const state = await Effect.runPromise(Ref.make(initialState()))
+    const state = await Effect.runPromise(Ref.make(initialState({})))
     const authentication = new SqlError({
       reason: new AuthenticationError({ cause: new Error('invalid credentials'), operation: 'persist' }),
     })

--- a/services/bayn/src/tigerbeetle-client.ts
+++ b/services/bayn/src/tigerbeetle-client.ts
@@ -302,18 +302,24 @@ const normalizeCreateResult = (
 })
 
 const adaptTigerBeetleClient = (client: TigerBeetleNodeClient): TigerBeetleClient => ({
-  createAccounts: async (accounts) =>
-    (await client.createAccounts([...accounts])).map((result) =>
-      normalizeCreateResult(result, CreateAccountStatus.created, CreateAccountStatus.exists),
-    ),
-  createTransfers: async (transfers) =>
-    (await client.createTransfers([...transfers])).map((result) =>
-      normalizeCreateResult(result, CreateTransferStatus.created, CreateTransferStatus.exists),
-    ),
-  lookupAccounts: async (ids) => client.lookupAccounts([...ids]),
-  lookupTransfers: async (ids) => client.lookupTransfers([...ids]),
-  queryAccounts: async (filter) => client.queryAccounts(filter),
-  queryTransfers: async (filter) => client.queryTransfers(filter),
+  createAccounts: (accounts) =>
+    client
+      .createAccounts([...accounts])
+      .then((results) =>
+        results.map((result) => normalizeCreateResult(result, CreateAccountStatus.created, CreateAccountStatus.exists)),
+      ),
+  createTransfers: (transfers) =>
+    client
+      .createTransfers([...transfers])
+      .then((results) =>
+        results.map((result) =>
+          normalizeCreateResult(result, CreateTransferStatus.created, CreateTransferStatus.exists),
+        ),
+      ),
+  lookupAccounts: (ids) => client.lookupAccounts([...ids]),
+  lookupTransfers: (ids) => client.lookupTransfers([...ids]),
+  queryAccounts: (filter) => client.queryAccounts(filter),
+  queryTransfers: (filter) => client.queryTransfers(filter),
   destroy: () => client.destroy(),
 })
 


### PR DESCRIPTION
## Summary

- Aligns runtime inputs, service keys, dates, and control flow with idiomatic Effect composition.
- Keeps this native stack layer independently reviewable at 953 changed lines.
- Bases directly on codex/bayn-effect-tsgo-runtime-failures so GitHub shows only this layer.

## Related Issues

None

## Testing

- bunx tsc --noEmit --project services/bayn/tsconfig.json
- bun run lint
- bun run lint:oxlint
- bun run lint:oxlint:type
- bun run build
- Focused tests for the touched subsystem were run while constructing the layer.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable and Breaking Changes is filled in.
- [x] Documentation and follow-ups are unchanged or represented by later stack layers.