### PR TITLE
refactor(bayn): align test Effect idioms

### DIFF
--- a/services/bayn/src/app-test-support.ts
+++ b/services/bayn/src/app-test-support.ts
@@ -22,6 +22,7 @@ import type { RuntimeState } from './runtime-state'
 import { makeRiskBalancedTrendApplication } from './strategy'
 import { prepareRiskBalancedTrendQualificationLock } from './strategy/risk-balanced-trend/qualification'
 import { fixtureProtocol, makeSnapshot, makeTestProvenance } from './test-fixtures'
+import { Pipeable } from './pipeable'
 
 export const provenance = makeTestProvenance()
 export const historicalRunId = '9'.repeat(64)
@@ -113,7 +114,7 @@ export const successfulJournal: JournalService = {
     }),
 }
 
-export const marketDataService = (
+const marketDataServiceDataFirst = (
   load: MarketDataService['load'],
   inspectedSnapshot = makeSnapshot(),
 ): MarketDataService => ({
@@ -319,14 +320,19 @@ export const pinnedStore = (): EvidenceStoreService => ({
     }),
 })
 
-export const fetchJson = async (port: number, path: string, method = 'GET') => {
-  const response = await fetch(`http://127.0.0.1:${port}${path}`, { method })
-  return {
-    status: response.status,
-    allow: response.headers.get('allow'),
-    body: (await response.json()) as Record<string, unknown>,
-  }
-}
+export const marketDataService = Pipeable.by<
+  (inspectedSnapshot: ReturnType<typeof makeSnapshot>) => (load: MarketDataService['load']) => MarketDataService,
+  typeof marketDataServiceDataFirst
+>(
+  (arguments_) =>
+    !(
+      typeof arguments_[0] === 'object' &&
+      arguments_[0] !== null &&
+      'bars' in arguments_[0] &&
+      'manifest' in arguments_[0]
+    ),
+  marketDataServiceDataFirst,
+)
 
 export const readyState = (): RuntimeState => {
   const evaluation = fixtureEvaluation

--- a/services/bayn/src/app.test.ts
+++ b/services/bayn/src/app.test.ts
@@ -558,17 +558,19 @@ describe('Bayn application composition', () => {
         Effect.gen(function* () {
           const cycleUsed = yield* Deferred.make<void>()
           const healthUsed = yield* Deferred.make<void>()
-          type RuntimeResource = {
+          interface RuntimeResourceShape {
             readonly close: () => void
             readonly use: (consumer: 'cycle' | 'health') => Effect.Effect<void>
           }
-          const RuntimeResource = Context.Service<RuntimeResource>('BaynApplicationTest/RuntimeResource')
+          class RuntimeResource extends Context.Service<RuntimeResource, RuntimeResourceShape>()(
+            '@proompteng/bayn/app.test/RuntimeResource',
+          ) {}
           const runtimeResourceLayer = Layer.effect(
             RuntimeResource,
             Effect.acquireRelease(
               Effect.sync(() => {
                 let open = true
-                const resource: RuntimeResource = {
+                const resource: RuntimeResourceShape = {
                   close: () => void (open = false),
                   use: (consumer) =>
                     Effect.sync(() => {

--- a/services/bayn/src/broker/alpaca.test.ts
+++ b/services/bayn/src/broker/alpaca.test.ts
@@ -1502,8 +1502,7 @@ describe('Alpaca paper reads', () => {
 
     const services = await Effect.runPromise(
       Effect.all({ session: BrokerSession, read: BrokerRead }).pipe(
-        Effect.provide(testLayer),
-        Effect.provide(TestClock.layer()),
+        Effect.provide(Layer.merge(testLayer, TestClock.layer())),
       ),
     )
 

--- a/services/bayn/src/broker/alpaca.test.ts
+++ b/services/bayn/src/broker/alpaca.test.ts
@@ -200,12 +200,23 @@ describe('Alpaca paper reads', () => {
     let inspected = ''
     let surface: readonly string[] = []
     const client = HttpClient.make((request, target) =>
-      Effect.sync(() => {
+      Effect.gen(function* () {
         method = request.method
         url = target.toString()
         key = request.headers['apca-api-key-id'] ?? ''
         secret = request.headers['apca-api-secret-key'] ?? ''
-        inspected = Schema.encodeSync(Schema.UnknownFromJsonString)(request.toJSON())
+        inspected = yield* Schema.encodeEffect(Schema.UnknownFromJsonString)(request.toJSON()).pipe(
+          Effect.mapError(
+            (cause) =>
+              new HttpClientError.HttpClientError({
+                reason: new HttpClientError.EncodeError({
+                  request,
+                  cause,
+                  description: 'failed to encode redacted request inspection',
+                }),
+              }),
+          ),
+        )
         return jsonResponse(request, accountResponse)
       }),
     )

--- a/services/bayn/src/broker/alpaca.test.ts
+++ b/services/bayn/src/broker/alpaca.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'bun:test'
 
 import { Undici } from '@effect/platform-node'
-import { Effect, Fiber, Layer, Redacted, Result } from 'effect'
+import { Effect, Fiber, Layer, Redacted, Result, Schema } from 'effect'
 import { TestClock } from 'effect/testing'
 import { HttpClient, HttpClientError, HttpClientResponse } from 'effect/unstable/http'
 
@@ -205,7 +205,7 @@ describe('Alpaca paper reads', () => {
         url = target.toString()
         key = request.headers['apca-api-key-id'] ?? ''
         secret = request.headers['apca-api-secret-key'] ?? ''
-        inspected = JSON.stringify(request)
+        inspected = Schema.encodeSync(Schema.UnknownFromJsonString)(request.toJSON())
         return jsonResponse(request, accountResponse)
       }),
     )

--- a/services/bayn/src/broker/alpaca/session.test.ts
+++ b/services/bayn/src/broker/alpaca/session.test.ts
@@ -136,7 +136,7 @@ describe('Alpaca broker session acquisition retry', () => {
         expect(accountRequests).toBe(2)
         yield* TestClock.adjust(1_000)
         return yield* Fiber.join(fiber)
-      }).pipe(Effect.provide(Logger.layer([logger])), Effect.provide(TestClock.layer())),
+      }).pipe(Effect.provide(Layer.merge(Logger.layer([logger]), TestClock.layer()))),
     )
 
     expect(services.session.read).toBe(services.read)

--- a/services/bayn/src/clickhouse-patch.test.ts
+++ b/services/bayn/src/clickhouse-patch.test.ts
@@ -5,17 +5,20 @@ import { NodeHttpClient } from '@effect/platform-node'
 import { ClickhouseClient } from '@effect/sql-clickhouse'
 import { Effect, Layer } from 'effect'
 
-const listen = (server: ReturnType<typeof createServer>): Promise<number> =>
-  new Promise((resolve, reject) => {
-    server.once('error', reject)
+const listen = (server: ReturnType<typeof createServer>): Effect.Effect<number> =>
+  Effect.callback<number>((resume) => {
+    const onError = (cause: Error) => resume(Effect.die(cause))
+    server.once('error', onError)
     server.listen(0, '127.0.0.1', () => {
+      server.off('error', onError)
       const address = server.address()
       if (address === null || typeof address === 'string') {
-        reject(new Error('ClickHouse test server did not bind a TCP port'))
+        resume(Effect.die(new Error('ClickHouse test server did not bind a TCP port')))
         return
       }
-      resolve(address.port)
+      resume(Effect.succeed(address.port))
     })
+    return Effect.sync(() => server.off('error', onError))
   })
 
 test('Effect ClickHouse drains its connection check before exposing the client', async () => {
@@ -26,12 +29,17 @@ test('Effect ClickHouse drains its connection check before exposing the client',
     response.writeHead(200, { 'content-type': 'text/plain; charset=UTF-8', 'x-clickhouse-summary': '{}' })
     response.flushHeaders()
     response.write('1\n')
-    setTimeout(() => {
-      responseFinished = true
-      response.end()
-    }, 250)
+    Effect.sleep(250).pipe(
+      Effect.andThen(
+        Effect.sync(() => {
+          responseFinished = true
+          response.end()
+        }),
+      ),
+      Effect.runFork,
+    )
   })
-  const port = await listen(server)
+  const port = await Effect.runPromise(listen(server))
 
   try {
     await Effect.runPromise(

--- a/services/bayn/src/clickhouse-patch.test.ts
+++ b/services/bayn/src/clickhouse-patch.test.ts
@@ -3,7 +3,7 @@ import { createServer } from 'node:http'
 
 import { NodeHttpClient } from '@effect/platform-node'
 import { ClickhouseClient } from '@effect/sql-clickhouse'
-import { Effect, Layer } from 'effect'
+import { Effect, Fiber, Layer } from 'effect'
 
 const listen = (server: ReturnType<typeof createServer>): Effect.Effect<number> =>
   Effect.callback<number>((resume) => {
@@ -24,19 +24,22 @@ const listen = (server: ReturnType<typeof createServer>): Effect.Effect<number> 
 test('Effect ClickHouse drains its connection check before exposing the client', async () => {
   let responseFinished = false
   let requests = 0
+  const responseFibers: Array<Fiber.Fiber<void>> = []
   const server = createServer((_, response) => {
     requests += 1
     response.writeHead(200, { 'content-type': 'text/plain; charset=UTF-8', 'x-clickhouse-summary': '{}' })
     response.flushHeaders()
     response.write('1\n')
-    Effect.sleep(250).pipe(
-      Effect.andThen(
-        Effect.sync(() => {
-          responseFinished = true
-          response.end()
-        }),
+    responseFibers.push(
+      Effect.sleep(250).pipe(
+        Effect.andThen(
+          Effect.sync(() => {
+            responseFinished = true
+            response.end()
+          }),
+        ),
+        Effect.runFork,
       ),
-      Effect.runFork,
     )
   })
   const port = await Effect.runPromise(listen(server))
@@ -63,6 +66,7 @@ test('Effect ClickHouse drains its connection check before exposing the client',
     )
     expect(requests).toBe(1)
   } finally {
+    await Effect.runPromise(Effect.forEach(responseFibers, Fiber.interrupt, { discard: true }))
     server.close()
     server.closeAllConnections()
   }

--- a/services/bayn/src/contracts.test.ts
+++ b/services/bayn/src/contracts.test.ts
@@ -14,7 +14,7 @@ import {
 } from './contracts'
 import { fixtureProtocol, makeSnapshot, makeTestProvenance } from './test-fixtures'
 
-const expectFailure = async (effect: Effect.Effect<unknown, unknown>): Promise<void> => {
+const expectFailure = async <A, E>(effect: Effect.Effect<A, E>): Promise<void> => {
   expect(Exit.isFailure(await Effect.runPromiseExit(effect))).toBe(true)
 }
 

--- a/services/bayn/src/cycle-runner.test.ts
+++ b/services/bayn/src/cycle-runner.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 
-import { Cause, Deferred, Effect, Fiber, Logger, Option, References, Result } from 'effect'
+import { Cause, Deferred, Effect, Fiber, Layer, Logger, Option, References, Result } from 'effect'
 import { TestClock } from 'effect/testing'
 
 import {
@@ -3519,7 +3519,7 @@ describe('autonomous cycle runner', () => {
         expect(control.acquisitions).toHaveLength(1)
         yield* Fiber.interrupt(fiber)
       }),
-    ).pipe(Effect.provide(Logger.layer([logger])), Effect.provide(TestClock.layer()))
+    ).pipe(Effect.provide(Layer.merge(Logger.layer([logger]), TestClock.layer())))
 
     await Effect.runPromise(program)
     expect(

--- a/services/bayn/src/cycle.test.ts
+++ b/services/bayn/src/cycle.test.ts
@@ -186,7 +186,7 @@ describe('autonomous cycle identity and calendar', () => {
     }
 
     const identity = makeCycleIdentitySuccess(material)
-    const decoded = Schema.decodeUnknownResult(
+    const decoded = Schema.decodeResult(
       CycleIdentitySchema,
       strictParseOptions,
     )({

--- a/services/bayn/src/db/cycle-observability.integration.test.ts
+++ b/services/bayn/src/db/cycle-observability.integration.test.ts
@@ -139,7 +139,7 @@ const seedSafetyState = (reconciledAt = '2026-03-06T21:00:00.000Z') =>
       ${reconciliationHash},
       ${'1'.repeat(64)},
       'EXACT',
-      ${sql.json(JSON.stringify([]))},
+      ${sql.json([])},
       ${reconciledAt}
     )
   `
@@ -616,7 +616,7 @@ describePostgres('PostgreSQL cycle observability projection', () => {
             ${reconciliationHash},
             ${'2'.repeat(64)},
             'EXACT',
-            ${sql.json(JSON.stringify([]))},
+            ${sql.json([])},
             ${'2026-03-06T21:00:00.000Z'}
           )
         `

--- a/services/bayn/src/db/cycle-observability.integration.test.ts
+++ b/services/bayn/src/db/cycle-observability.integration.test.ts
@@ -22,8 +22,9 @@ import { CycleStore, CycleStoreLive } from './cycle-store'
 import { PostgresClientLive } from './evidence-store'
 import { migrationLoader } from './migrations'
 import { readForwardPerformancePostgres } from '../forward-performance/postgres'
+import { baynTestPostgresUrl } from '../test-environment.test-support'
 
-const postgresUrl = process.env['BAYN_TEST_POSTGRES_URL']
+const postgresUrl = baynTestPostgresUrl
 const testUrl = postgresUrl ?? 'postgresql://bayn:bayn@127.0.0.1:5432/bayn_test'
 const describePostgres = postgresUrl === undefined ? describe.skip : describe
 const qualificationRunId = 'a'.repeat(64)

--- a/services/bayn/src/db/cycle-observability.integration.test.ts
+++ b/services/bayn/src/db/cycle-observability.integration.test.ts
@@ -2,7 +2,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:tes
 
 import { NodeServices } from '@effect/platform-node'
 import { PgClient, PgMigrator } from '@effect/sql-pg'
-import { Effect, Layer, ManagedRuntime, Redacted, Result } from 'effect'
+import { Effect, Layer, ManagedRuntime, Redacted, Result, Schema } from 'effect'
 
 import {
   CycleState,
@@ -24,6 +24,7 @@ import { migrationLoader } from './migrations'
 import { readForwardPerformancePostgres } from '../forward-performance/postgres'
 import { baynTestPostgresUrl } from '../test-environment.test-support'
 
+const encodeSqlJson = Schema.encodeSync(Schema.UnknownFromJsonString)
 const postgresUrl = baynTestPostgresUrl
 const testUrl = postgresUrl ?? 'postgresql://bayn:bayn@127.0.0.1:5432/bayn_test'
 const describePostgres = postgresUrl === undefined ? describe.skip : describe
@@ -139,7 +140,7 @@ const seedSafetyState = (reconciledAt = '2026-03-06T21:00:00.000Z') =>
       ${reconciliationHash},
       ${'1'.repeat(64)},
       'EXACT',
-      ${sql.json([])},
+      ${sql.json(encodeSqlJson([]))},
       ${reconciledAt}
     )
   `
@@ -616,7 +617,7 @@ describePostgres('PostgreSQL cycle observability projection', () => {
             ${reconciliationHash},
             ${'2'.repeat(64)},
             'EXACT',
-            ${sql.json([])},
+            ${sql.json(encodeSqlJson([]))},
             ${'2026-03-06T21:00:00.000Z'}
           )
         `

--- a/services/bayn/src/db/cycle-store/integration.test.ts
+++ b/services/bayn/src/db/cycle-store/integration.test.ts
@@ -78,6 +78,7 @@ import {
 import { makeRiskBalancedTrendDefinition } from '../../strategy'
 import { TargetPlanReason, TargetPlanStatus } from '../../target-planner'
 import { fixtureProtocol, makeSnapshot, makeTestProvenance } from '../../test-fixtures'
+import { baynTestPostgresUrl, isGithubActions } from '../../test-environment.test-support'
 import {
   DataFeed,
   DataSource,
@@ -93,7 +94,7 @@ import { PostgresClientLive } from '../evidence-store'
 import { migrationLoader } from '../migrations'
 import { CycleStore, CycleStoreLive, type CycleStoreShape } from '.'
 
-const postgresUrl = process.env['BAYN_TEST_POSTGRES_URL']
+const postgresUrl = baynTestPostgresUrl
 const testUrl = postgresUrl ?? 'postgresql://bayn:bayn@127.0.0.1:5432/bayn_test'
 const describePostgres = postgresUrl === undefined ? describe.skip : describe
 const signalCalendarVersion = 'signal-XNYS-2026-v1'
@@ -144,7 +145,7 @@ interface PostgresProcessRestartEvidence {
 }
 
 const restartGithubPostgres18Process = async (): Promise<PostgresProcessRestartEvidence | undefined> => {
-  if (process.env['GITHUB_ACTIONS'] !== 'true') return undefined
+  if (!isGithubActions) return undefined
 
   const url = new URL(testUrl)
   const port = url.port.length === 0 ? '5432' : url.port
@@ -4570,7 +4571,7 @@ describePostgres('PostgreSQL autonomous cycle store', () => {
       await firstRuntime.dispose()
 
       const processRestart = await restartGithubPostgres18Process()
-      if (process.env['GITHUB_ACTIONS'] === 'true') {
+      if (isGithubActions) {
         expect(processRestart).toMatchObject({
           containerId: expect.any(String),
           image: expect.stringMatching(/^postgres:18(?:-|$)/),

--- a/services/bayn/src/db/cycle-store/integration.test.ts
+++ b/services/bayn/src/db/cycle-store/integration.test.ts
@@ -1428,7 +1428,7 @@ const insertReconciliation = (result: ReconciliationPassResult) =>
         ${reconciliation.observedHash},
         ${reconciliation.contentHash},
         ${reconciliation.status},
-        ${sql.json(JSON.stringify(reconciliation.discrepancies))},
+        ${sql.json(reconciliation.discrepancies)},
         ${reconciliation.reconciledAt}
       )
     `

--- a/services/bayn/src/db/cycle-store/integration.test.ts
+++ b/services/bayn/src/db/cycle-store/integration.test.ts
@@ -2,7 +2,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:tes
 
 import { NodeServices } from '@effect/platform-node'
 import { PgClient, PgMigrator } from '@effect/sql-pg'
-import { Cause, Deferred, Effect, Exit, Layer, ManagedRuntime, Option, Redacted, Result } from 'effect'
+import { Cause, Deferred, Effect, Exit, Layer, ManagedRuntime, Option, Redacted, Result, Schema } from 'effect'
 import { TestClock } from 'effect/testing'
 
 import {
@@ -94,6 +94,7 @@ import { PostgresClientLive } from '../evidence-store'
 import { migrationLoader } from '../migrations'
 import { CycleStore, CycleStoreLive, type CycleStoreShape } from '.'
 
+const encodeSqlJson = Schema.encodeSync(Schema.UnknownFromJsonString)
 const postgresUrl = baynTestPostgresUrl
 const testUrl = postgresUrl ?? 'postgresql://bayn:bayn@127.0.0.1:5432/bayn_test'
 const describePostgres = postgresUrl === undefined ? describe.skip : describe
@@ -1428,7 +1429,7 @@ const insertReconciliation = (result: ReconciliationPassResult) =>
         ${reconciliation.observedHash},
         ${reconciliation.contentHash},
         ${reconciliation.status},
-        ${sql.json(reconciliation.discrepancies)},
+        ${sql.json(encodeSqlJson(reconciliation.discrepancies))},
         ${reconciliation.reconciledAt}
       )
     `

--- a/services/bayn/src/db/evidence-store.integration.test.ts
+++ b/services/bayn/src/db/evidence-store.integration.test.ts
@@ -103,6 +103,7 @@ import {
   ValuationStore,
 } from './execution-store'
 import { LiveCapitalGrantStore, LiveCapitalGrantStoreLive } from './live-capital-grant'
+import { baynTestPostgresUrl } from '../test-environment.test-support'
 
 const ExecutionStore = Effect.gen(function* () {
   const events = yield* BrokerEventStore
@@ -123,7 +124,7 @@ const ExecutionStore = Effect.gen(function* () {
   }
 })
 
-const postgresUrl = process.env['BAYN_TEST_POSTGRES_URL']
+const postgresUrl = baynTestPostgresUrl
 const testUrl = postgresUrl ?? 'postgresql://bayn:bayn@127.0.0.1:5432/bayn_test'
 const describePostgres = postgresUrl === undefined ? describe.skip : describe
 const orderId = '61e69015-8549-4bfd-b9c3-01e75843f47d'

--- a/services/bayn/src/db/evidence-store.integration.test.ts
+++ b/services/bayn/src/db/evidence-store.integration.test.ts
@@ -140,6 +140,7 @@ const ExecutionStore = Effect.gen(function* () {
   }
 })
 
+const encodeSqlJson = Schema.encodeSync(Schema.UnknownFromJsonString)
 const postgresUrl = baynTestPostgresUrl
 const testUrl = postgresUrl ?? 'postgresql://bayn:bayn@127.0.0.1:5432/bayn_test'
 const describePostgres = postgresUrl === undefined ? describe.skip : describe
@@ -961,7 +962,7 @@ const activateAuditedCapitalGrant = async () => {
           ) VALUES (
             ${mutationReconciliationId}, 'bayn.paper-reconciliation.v1', 'paper-account-1',
             ${accountStateHash}, ${accountStateHash}, ${mutationReconciliationContentHash},
-            'EXACT', ${sql.json([])}, clock_timestamp()
+            'EXACT', ${sql.json(encodeSqlJson([]))}, clock_timestamp()
           )
         `
         yield* store.ensureAuthorityGeneration({
@@ -1075,7 +1076,7 @@ const rotateAuditedCapitalGrant = (
           ) VALUES (
             ${reconciliationId}, 'bayn.paper-reconciliation.v1', ${accountId},
             ${reconciliationStateHash}, ${reconciliationStateHash}, ${reconciliationContentHash},
-            'EXACT', ${sql.json([])}, clock_timestamp()
+            'EXACT', ${sql.json(encodeSqlJson([]))}, clock_timestamp()
           )
         `
         const activated = yield* store.activateCapitalGrant(proofBinding(paperGeneration))
@@ -3218,7 +3219,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
             ) VALUES (
               ${reconciliationId}, 'bayn.paper-reconciliation.v1', 'paper-account-1',
               ${accountStateHash}, ${accountStateHash}, ${reconciliationContentHash},
-              'EXACT', ${sql.json([])}, clock_timestamp()
+              'EXACT', ${sql.json(encodeSqlJson([]))}, clock_timestamp()
             )
             RETURNING reconciled_at
           `

--- a/services/bayn/src/db/evidence-store.integration.test.ts
+++ b/services/bayn/src/db/evidence-store.integration.test.ts
@@ -2350,9 +2350,8 @@ describePostgres('PostgreSQL evaluation evidence', () => {
             yield* Effect.sleep(Duration.millis(10))
           }
           if (mutationPid === undefined) {
-            return yield* Effect.fail(
-              `mutation did not wait on the table lock: ${Schema.encodeSync(Schema.UnknownFromJsonString)(activities)}`,
-            )
+            const encodedActivities = yield* Schema.encodeEffect(Schema.UnknownFromJsonString)(activities)
+            return yield* Effect.fail(`mutation did not wait on the table lock: ${encodedActivities}`)
           }
           const terminated = yield* Effect.promise(() =>
             runtime.runPromise(
@@ -4415,9 +4414,8 @@ describePostgres('PostgreSQL evaluation evidence', () => {
             yield* Effect.sleep(Duration.millis(10))
           }
           if (lockWait === undefined) {
-            return yield* Effect.fail(
-              `update is not waiting on the lock: ${Schema.encodeSync(Schema.UnknownFromJsonString)(activities)}`,
-            )
+            const encodedActivities = yield* Schema.encodeEffect(Schema.UnknownFromJsonString)(activities)
+            return yield* Effect.fail(`update is not waiting on the lock: ${encodedActivities}`)
           }
           yield* Effect.promise(() =>
             observerRuntime.runPromise(

--- a/services/bayn/src/db/evidence-store.integration.test.ts
+++ b/services/bayn/src/db/evidence-store.integration.test.ts
@@ -4,7 +4,20 @@ import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:tes
 
 import { NodeServices } from '@effect/platform-node'
 import { PgClient } from '@effect/sql-pg'
-import { Cause, Deferred, Duration, Effect, Exit, Fiber, Layer, ManagedRuntime, Option, Redacted, Result } from 'effect'
+import {
+  Cause,
+  Deferred,
+  Duration,
+  Effect,
+  Exit,
+  Fiber,
+  Layer,
+  ManagedRuntime,
+  Option,
+  Redacted,
+  Result,
+  Schema,
+} from 'effect'
 
 import authorityBoundIntents from '../../migrations/0016_authority_bound_intents'
 import stableCapitalGrantGeneration from '../../migrations/0017_stable_paper_authority_generation'
@@ -945,7 +958,7 @@ const activateAuditedCapitalGrant = async () => {
           ) VALUES (
             ${mutationReconciliationId}, 'bayn.paper-reconciliation.v1', 'paper-account-1',
             ${accountStateHash}, ${accountStateHash}, ${mutationReconciliationContentHash},
-            'EXACT', ${sql.json(JSON.stringify([]))}, clock_timestamp()
+            'EXACT', ${sql.json([])}, clock_timestamp()
           )
         `
         yield* store.ensureAuthorityGeneration({
@@ -1059,7 +1072,7 @@ const rotateAuditedCapitalGrant = (
           ) VALUES (
             ${reconciliationId}, 'bayn.paper-reconciliation.v1', ${accountId},
             ${reconciliationStateHash}, ${reconciliationStateHash}, ${reconciliationContentHash},
-            'EXACT', ${sql.json(JSON.stringify([]))}, clock_timestamp()
+            'EXACT', ${sql.json([])}, clock_timestamp()
           )
         `
         const activated = yield* store.activateCapitalGrant(proofBinding(paperGeneration))
@@ -2334,7 +2347,9 @@ describePostgres('PostgreSQL evaluation evidence', () => {
             yield* Effect.sleep(Duration.millis(10))
           }
           if (mutationPid === undefined) {
-            return yield* Effect.fail(`mutation did not wait on the table lock: ${JSON.stringify(activities)}`)
+            return yield* Effect.fail(
+              `mutation did not wait on the table lock: ${Schema.encodeSync(Schema.UnknownFromJsonString)(activities)}`,
+            )
           }
           const terminated = yield* Effect.promise(() =>
             runtime.runPromise(
@@ -3201,7 +3216,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
             ) VALUES (
               ${reconciliationId}, 'bayn.paper-reconciliation.v1', 'paper-account-1',
               ${accountStateHash}, ${accountStateHash}, ${reconciliationContentHash},
-              'EXACT', ${sql.json(JSON.stringify([]))}, clock_timestamp()
+              'EXACT', ${sql.json([])}, clock_timestamp()
             )
             RETURNING reconciled_at
           `
@@ -4397,7 +4412,9 @@ describePostgres('PostgreSQL evaluation evidence', () => {
             yield* Effect.sleep(Duration.millis(10))
           }
           if (lockWait === undefined) {
-            return yield* Effect.fail(`update is not waiting on the lock: ${JSON.stringify(activities)}`)
+            return yield* Effect.fail(
+              `update is not waiting on the lock: ${Schema.encodeSync(Schema.UnknownFromJsonString)(activities)}`,
+            )
           }
           yield* Effect.promise(() =>
             observerRuntime.runPromise(

--- a/services/bayn/src/db/evidence-store.integration.test.ts
+++ b/services/bayn/src/db/evidence-store.integration.test.ts
@@ -6,6 +6,7 @@ import { NodeServices } from '@effect/platform-node'
 import { PgClient } from '@effect/sql-pg'
 import {
   Cause,
+  Data,
   Deferred,
   Duration,
   Effect,
@@ -117,6 +118,8 @@ import {
 } from './execution-store'
 import { LiveCapitalGrantStore, LiveCapitalGrantStoreLive } from './live-capital-grant'
 import { baynTestPostgresUrl } from '../test-environment.test-support'
+
+class TestFailure extends Data.TaggedError('TestFailure')<{ readonly message: string }> {}
 
 const ExecutionStore = Effect.gen(function* () {
   const events = yield* BrokerEventStore
@@ -6279,7 +6282,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
         `.pipe(
           Effect.timeoutOrElse({
             duration: '2 seconds',
-            orElse: () => Effect.fail(new Error('PostgreSQL pool did not recover')),
+            orElse: () => Effect.fail(new TestFailure({ message: 'PostgreSQL pool did not recover' })),
           }),
         )
       }),

--- a/services/bayn/src/db/evidence-store.integration.test.ts
+++ b/services/bayn/src/db/evidence-store.integration.test.ts
@@ -771,8 +771,8 @@ const mutationPaperActivation = () =>
     mutationReconciliationId,
     mutationReconciliationContentHash,
   )
-const planForGeneration = (input: IntentPlan, generationHash: string) => {
-  return planPaperIntent(input, {
+const planForGeneration = (input: IntentPlan, generationHash: string) =>
+  planPaperIntent(input, {
     authority: {
       schemaVersion: 'bayn.paper-authority.v1',
       generationHash,
@@ -783,7 +783,6 @@ const planForGeneration = (input: IntentPlan, generationHash: string) => {
       updatedAt: '2026-07-22T10:00:00.000Z',
     },
   })
-}
 const plan = (input: IntentPlan) => planForGeneration(input, mutationPaperActivation().generationHash)
 
 const proofBinding = (activation: CapitalGrantGeneration) => ({
@@ -2309,29 +2308,33 @@ describePostgres('PostgreSQL evaluation evidence', () => {
             ),
             { startImmediately: true },
           )
-          const mutationPid = yield* Effect.gen(function* () {
-            type WaitingMutation = { pid: number; query: string }
-            let activities: readonly WaitingMutation[] = []
-            for (let attempt = 0; attempt < 200; attempt += 1) {
-              activities = yield* Effect.promise(() =>
-                runtime.runPromise(
-                  Effect.gen(function* () {
-                    const sql = yield* PgClient.PgClient
-                    return yield* sql<WaitingMutation>`
+          type WaitingMutation = { pid: number; query: string }
+          let activities: readonly WaitingMutation[] = []
+          let mutationPid: number | undefined
+          for (let attempt = 0; attempt < 200; attempt += 1) {
+            activities = yield* Effect.promise(() =>
+              runtime.runPromise(
+                Effect.gen(function* () {
+                  const sql = yield* PgClient.PgClient
+                  return yield* sql<WaitingMutation>`
                       SELECT pid::integer, query
                       FROM pg_stat_activity
                       WHERE pid = ${backendPid}
                         AND datname = current_database()
                         AND wait_event_type = 'Lock'
                     `
-                  }),
-                ),
-              )
-              if (activities[0] !== undefined) return activities[0].pid
-              yield* Effect.sleep(Duration.millis(10))
+                }),
+              ),
+            )
+            if (activities[0] !== undefined) {
+              mutationPid = activities[0].pid
+              break
             }
+            yield* Effect.sleep(Duration.millis(10))
+          }
+          if (mutationPid === undefined) {
             return yield* Effect.fail(`mutation did not wait on the table lock: ${JSON.stringify(activities)}`)
-          })
+          }
           const terminated = yield* Effect.promise(() =>
             runtime.runPromise(
               Effect.gen(function* () {
@@ -4356,20 +4359,20 @@ describePostgres('PostgreSQL evaluation evidence', () => {
             `),
             { startImmediately: true },
           )
-          const lockWait = yield* Effect.gen(function* () {
-            type LockActivity = {
-              query: string
-              started_before_expiry: boolean
-              state: string
-              wait_event_type: string | null
-            }
-            let activities: readonly LockActivity[] = []
-            for (let attempt = 0; attempt < 200; attempt += 1) {
-              activities = yield* Effect.promise(() =>
-                observerRuntime.runPromise(
-                  Effect.gen(function* () {
-                    const observerSql = yield* PgClient.PgClient
-                    return yield* observerSql<LockActivity>`
+          type LockActivity = {
+            query: string
+            started_before_expiry: boolean
+            state: string
+            wait_event_type: string | null
+          }
+          let activities: readonly LockActivity[] = []
+          let lockWait: { readonly waiting: true; readonly started_before_expiry: boolean } | undefined
+          for (let attempt = 0; attempt < 200; attempt += 1) {
+            activities = yield* Effect.promise(() =>
+              observerRuntime.runPromise(
+                Effect.gen(function* () {
+                  const observerSql = yield* PgClient.PgClient
+                  return yield* observerSql<LockActivity>`
                       SELECT
                         activity.query,
                         activity.state,
@@ -4380,19 +4383,21 @@ describePostgres('PostgreSQL evaluation evidence', () => {
                         AND activity.usename = current_user
                         AND activity.datname = current_database()
                     `
-                  }),
-                ),
-              )
-              const observed = activities.find(
-                (row) => row.wait_event_type === 'Lock' && row.query.toUpperCase().includes('UPDATE INTENTS'),
-              )
-              if (observed !== undefined) {
-                return { waiting: true, started_before_expiry: observed.started_before_expiry }
-              }
-              yield* Effect.sleep(Duration.millis(10))
+                }),
+              ),
+            )
+            const observed = activities.find(
+              (row) => row.wait_event_type === 'Lock' && row.query.toUpperCase().includes('UPDATE INTENTS'),
+            )
+            if (observed !== undefined) {
+              lockWait = { waiting: true, started_before_expiry: observed.started_before_expiry }
+              break
             }
+            yield* Effect.sleep(Duration.millis(10))
+          }
+          if (lockWait === undefined) {
             return yield* Effect.fail(`update is not waiting on the lock: ${JSON.stringify(activities)}`)
-          })
+          }
           yield* Effect.promise(() =>
             observerRuntime.runPromise(
               Effect.gen(function* () {

--- a/services/bayn/src/db/evidence-store/errors.test.ts
+++ b/services/bayn/src/db/evidence-store/errors.test.ts
@@ -7,18 +7,18 @@ import { classifyDatabaseError } from './errors'
 describe('evidence persistence error classification', () => {
   test('retains connectivity, transaction, constraint, and query distinctions', () => {
     const cases = [
-      [new ConnectionError({ cause: new Error('reset'), operation: 'connect' }), 'unavailable', 'connectivity'],
-      [new DeadlockError({ cause: new Error('deadlock'), operation: 'query' }), 'unavailable', 'transaction'],
+      [ConnectionError.make({ cause: new Error('reset'), operation: 'connect' }), 'unavailable', 'connectivity'],
+      [DeadlockError.make({ cause: new Error('deadlock'), operation: 'query' }), 'unavailable', 'transaction'],
       [
-        new UniqueViolation({ cause: new Error('duplicate'), operation: 'query', constraint: 'evaluation_runs_pkey' }),
+        UniqueViolation.make({ cause: new Error('duplicate'), operation: 'query', constraint: 'evaluation_runs_pkey' }),
         'constraint',
         'constraint',
       ],
-      [new SqlSyntaxError({ cause: new Error('syntax'), operation: 'query' }), 'query', 'query'],
+      [SqlSyntaxError.make({ cause: new Error('syntax'), operation: 'query' }), 'query', 'query'],
     ] as const
 
     for (const [reason, failure, persistenceFailure] of cases) {
-      expect(classifyDatabaseError('persist', new SqlError({ reason }))).toMatchObject({
+      expect(classifyDatabaseError('persist', SqlError.make({ reason }))).toMatchObject({
         failure,
         persistenceFailure,
         operation: 'persist',

--- a/services/bayn/src/db/paper-store.integration.test.ts
+++ b/services/bayn/src/db/paper-store.integration.test.ts
@@ -4,7 +4,7 @@ import { beforeAll, beforeEach, describe, expect, test } from 'bun:test'
 
 import { NodeServices } from '@effect/platform-node'
 import { PgClient } from '@effect/sql-pg'
-import { Cause, Deferred, Duration, Effect, Exit, Fiber, Layer, ManagedRuntime, Redacted, Result } from 'effect'
+import { Cause, Deferred, Duration, Effect, Exit, Fiber, Layer, ManagedRuntime, Redacted, Result, Schema } from 'effect'
 
 import type { RuntimeConfig } from '../config'
 import { orderRequestBody } from '../broker/alpaca-mutations'
@@ -91,6 +91,7 @@ const ExecutionStore = Effect.gen(function* () {
   }
 })
 
+const encodeSqlJson = Schema.encodeSync(Schema.UnknownFromJsonString)
 const postgresUrl = baynTestPostgresUrl
 const testUrl = postgresUrl ?? 'postgresql://bayn:bayn@127.0.0.1:5432/bayn_test'
 const describePostgres = postgresUrl === undefined ? describe.skip : describe
@@ -491,8 +492,8 @@ const seedQualificationEvidence = (fixture: QualificationFixture) =>
       ) VALUES (
         ${result.runId}, 0, 'paper_activation_fixture',
         ${result.evaluationVerdict.gates[0].passed},
-        ${sql.json(result.evaluationVerdict.gates[0].actual)},
-        ${sql.json(result.evaluationVerdict.gates[0].required)},
+        ${sql.json(encodeSqlJson(result.evaluationVerdict.gates[0].actual))},
+        ${sql.json(encodeSqlJson(result.evaluationVerdict.gates[0].required))},
         ${hash(`${result.runId}-gate`)}
       )
     `
@@ -538,7 +539,7 @@ const seedExactReconciliation = (fixture: ReconciliationFixture, reconciliationA
         content_hash, status, discrepancies, reconciled_at
       ) VALUES (
         ${fixture.reconciliationId}, 'bayn.paper-reconciliation.v1', ${reconciliationAccountId},
-        ${stateHash}, ${stateHash}, ${fixture.contentHash}, 'EXACT', ${sql.json([])},
+        ${stateHash}, ${stateHash}, ${fixture.contentHash}, 'EXACT', ${sql.json(encodeSqlJson([]))},
         clock_timestamp() - (${fixture.databaseAgeMs} * interval '1 millisecond')
       )
     `
@@ -1155,7 +1156,7 @@ describePostgres('paper accounting persistence', () => {
             ) VALUES (
               ${reconciliationId}, 'bayn.paper-reconciliation.v1', ${accountId},
               ${reconciliationStateHash}, ${reconciliationStateHash}, ${reconciliationContentHash},
-              'EXACT', ${sql.json([])}, ${reconciliationTime.reconciled_at.toISOString()}
+              'EXACT', ${sql.json(encodeSqlJson([]))}, ${reconciliationTime.reconciled_at.toISOString()}
             )
           `
           const recovered = yield* store.ensureAuthorityGeneration({
@@ -1276,7 +1277,7 @@ describePostgres('paper accounting persistence', () => {
             ) VALUES (
               ${hash('legacy-observe-recovery-reconciliation')}, 'bayn.paper-reconciliation.v1', ${accountId},
               ${reconciliationStateHash}, ${reconciliationStateHash},
-              ${hash('legacy-observe-recovery-content')}, 'EXACT', ${sql.json([])},
+              ${hash('legacy-observe-recovery-content')}, 'EXACT', ${sql.json(encodeSqlJson([]))},
               ${reconciliationTime.reconciled_at.toISOString()}
             )
           `
@@ -1388,7 +1389,7 @@ describePostgres('paper accounting persistence', () => {
             ) VALUES (
               ${hash('untrusted-observe-recovery-reconciliation')}, 'bayn.paper-reconciliation.v1', ${accountId},
               ${reconciliationStateHash}, ${reconciliationStateHash},
-              ${hash('untrusted-observe-recovery-content')}, 'EXACT', ${sql.json([])},
+              ${hash('untrusted-observe-recovery-content')}, 'EXACT', ${sql.json(encodeSqlJson([]))},
               ${reconciliationTime.reconciled_at.toISOString()}
             )
           `
@@ -1467,7 +1468,7 @@ describePostgres('paper accounting persistence', () => {
             ) VALUES (
               ${hash('observe-recovery-identity-reconciliation')}, 'bayn.paper-reconciliation.v1',
               ${changedIdentity.accountId}, ${reconciliationStateHash}, ${reconciliationStateHash},
-              ${hash('observe-recovery-identity-content')}, 'EXACT', ${sql.json([])},
+              ${hash('observe-recovery-identity-content')}, 'EXACT', ${sql.json(encodeSqlJson([]))},
               ${reconciliationTime.reconciled_at.toISOString()}
             )
           `
@@ -3549,7 +3550,7 @@ describePostgres('paper accounting persistence', () => {
             ) VALUES (
               ${hash('later-discrepancy')}, 'bayn.paper-reconciliation.v1', ${accountId},
               ${hash('expected-state')}, ${hash('observed-state')}, ${hash('later-discrepancy-content')},
-              'DISCREPANCY', ${sql.json([{ discrepancyId: hash('discrepancy') }])},
+              'DISCREPANCY', ${sql.json(encodeSqlJson([{ discrepancyId: hash('discrepancy') }]))},
               clock_timestamp()
             )
           `

--- a/services/bayn/src/db/paper-store.integration.test.ts
+++ b/services/bayn/src/db/paper-store.integration.test.ts
@@ -31,6 +31,7 @@ import {
   type CapitalGrantGeneration,
   type ResearchCapitalGrantGeneration,
 } from '../execution/contracts'
+import { baynTestPostgresUrl } from '../test-environment.test-support'
 import {
   defaultQualificationStatisticsPolicyDocument,
   makeQualificationLock,
@@ -90,7 +91,7 @@ const ExecutionStore = Effect.gen(function* () {
   }
 })
 
-const postgresUrl = process.env['BAYN_TEST_POSTGRES_URL']
+const postgresUrl = baynTestPostgresUrl
 const testUrl = postgresUrl ?? 'postgresql://bayn:bayn@127.0.0.1:5432/bayn_test'
 const describePostgres = postgresUrl === undefined ? describe.skip : describe
 const accountId = 'paper-account-1'

--- a/services/bayn/src/db/paper-store.integration.test.ts
+++ b/services/bayn/src/db/paper-store.integration.test.ts
@@ -491,8 +491,8 @@ const seedQualificationEvidence = (fixture: QualificationFixture) =>
       ) VALUES (
         ${result.runId}, 0, 'paper_activation_fixture',
         ${result.evaluationVerdict.gates[0].passed},
-        ${sql.json(JSON.stringify(result.evaluationVerdict.gates[0].actual))},
-        ${sql.json(JSON.stringify(result.evaluationVerdict.gates[0].required))},
+        ${sql.json(result.evaluationVerdict.gates[0].actual)},
+        ${sql.json(result.evaluationVerdict.gates[0].required)},
         ${hash(`${result.runId}-gate`)}
       )
     `
@@ -538,7 +538,7 @@ const seedExactReconciliation = (fixture: ReconciliationFixture, reconciliationA
         content_hash, status, discrepancies, reconciled_at
       ) VALUES (
         ${fixture.reconciliationId}, 'bayn.paper-reconciliation.v1', ${reconciliationAccountId},
-        ${stateHash}, ${stateHash}, ${fixture.contentHash}, 'EXACT', ${sql.json(JSON.stringify([]))},
+        ${stateHash}, ${stateHash}, ${fixture.contentHash}, 'EXACT', ${sql.json([])},
         clock_timestamp() - (${fixture.databaseAgeMs} * interval '1 millisecond')
       )
     `
@@ -1155,7 +1155,7 @@ describePostgres('paper accounting persistence', () => {
             ) VALUES (
               ${reconciliationId}, 'bayn.paper-reconciliation.v1', ${accountId},
               ${reconciliationStateHash}, ${reconciliationStateHash}, ${reconciliationContentHash},
-              'EXACT', ${sql.json(JSON.stringify([]))}, ${reconciliationTime.reconciled_at.toISOString()}
+              'EXACT', ${sql.json([])}, ${reconciliationTime.reconciled_at.toISOString()}
             )
           `
           const recovered = yield* store.ensureAuthorityGeneration({
@@ -1276,7 +1276,7 @@ describePostgres('paper accounting persistence', () => {
             ) VALUES (
               ${hash('legacy-observe-recovery-reconciliation')}, 'bayn.paper-reconciliation.v1', ${accountId},
               ${reconciliationStateHash}, ${reconciliationStateHash},
-              ${hash('legacy-observe-recovery-content')}, 'EXACT', ${sql.json(JSON.stringify([]))},
+              ${hash('legacy-observe-recovery-content')}, 'EXACT', ${sql.json([])},
               ${reconciliationTime.reconciled_at.toISOString()}
             )
           `
@@ -1388,7 +1388,7 @@ describePostgres('paper accounting persistence', () => {
             ) VALUES (
               ${hash('untrusted-observe-recovery-reconciliation')}, 'bayn.paper-reconciliation.v1', ${accountId},
               ${reconciliationStateHash}, ${reconciliationStateHash},
-              ${hash('untrusted-observe-recovery-content')}, 'EXACT', ${sql.json(JSON.stringify([]))},
+              ${hash('untrusted-observe-recovery-content')}, 'EXACT', ${sql.json([])},
               ${reconciliationTime.reconciled_at.toISOString()}
             )
           `
@@ -1467,7 +1467,7 @@ describePostgres('paper accounting persistence', () => {
             ) VALUES (
               ${hash('observe-recovery-identity-reconciliation')}, 'bayn.paper-reconciliation.v1',
               ${changedIdentity.accountId}, ${reconciliationStateHash}, ${reconciliationStateHash},
-              ${hash('observe-recovery-identity-content')}, 'EXACT', ${sql.json(JSON.stringify([]))},
+              ${hash('observe-recovery-identity-content')}, 'EXACT', ${sql.json([])},
               ${reconciliationTime.reconciled_at.toISOString()}
             )
           `
@@ -3552,7 +3552,7 @@ describePostgres('paper accounting persistence', () => {
             ) VALUES (
               ${hash('later-discrepancy')}, 'bayn.paper-reconciliation.v1', ${accountId},
               ${hash('expected-state')}, ${hash('observed-state')}, ${hash('later-discrepancy-content')},
-              'DISCREPANCY', ${sql.json(JSON.stringify([{ discrepancyId: hash('discrepancy') }]))},
+              'DISCREPANCY', ${sql.json([{ discrepancyId: hash('discrepancy') }])},
               clock_timestamp()
             )
           `

--- a/services/bayn/src/db/paper-store.integration.test.ts
+++ b/services/bayn/src/db/paper-store.integration.test.ts
@@ -3344,14 +3344,11 @@ describePostgres('paper accounting persistence', () => {
     const rotationRuntime = makeIndependentStoreRuntime({ fail: false, planHashes: [] }, config)
     const client = makeClientRuntime()
     let arrivals = 0
-    let releaseRace: () => void = () => undefined
-    const raceGate = new Promise<void>((resolve) => {
-      releaseRace = resolve
-    })
-    const awaitRace = Effect.promise(() => {
+    const raceGate = Deferred.makeUnsafe<void>()
+    const awaitRace = Effect.gen(function* () {
       arrivals += 1
-      if (arrivals === 2) releaseRace()
-      return raceGate
+      if (arrivals === 2) yield* Deferred.succeed(raceGate, undefined)
+      yield* Deferred.await(raceGate)
     })
     try {
       const [activationExit, rotationExit] = await Promise.all([

--- a/services/bayn/src/effect-runtime-compatibility.test.ts
+++ b/services/bayn/src/effect-runtime-compatibility.test.ts
@@ -4,21 +4,21 @@ import { Effect, Fiber, Option, Result, Schema, Semaphore } from 'effect'
 
 describe('Effect beta.102 runtime compatibility', () => {
   test('keeps deeply nested JSON validation stack safe', () => {
-    let nested: unknown = null
+    let nested: Schema.Json = null
     for (let index = 0; index < 25_000; index += 1) nested = [nested]
 
-    expect(Result.isSuccess(Schema.decodeUnknownResult(Schema.Json)(nested))).toBe(true)
+    expect(Result.isSuccess(Schema.decodeResult(Schema.Json)(nested))).toBe(true)
   })
 
   test('decodes and encodes valid dates while rejecting invalid dates', () => {
     const date = new Date('2026-07-27T12:34:56.789Z')
 
-    expect(Schema.decodeUnknownResult(Schema.Date)(date)).toEqual(Result.succeed(date))
+    expect(Schema.decodeResult(Schema.Date)(date)).toEqual(Result.succeed(date))
     expect(Schema.encodeUnknownResult(Schema.Date)(date)).toEqual(Result.succeed(date))
-    expect(Result.isFailure(Schema.decodeUnknownResult(Schema.Date)(new Date(Number.NaN)))).toBe(true)
-    expect(Result.isFailure(Schema.encodeUnknownResult(Schema.Date)(new Date(Number.NaN)))).toBe(true)
-    expect(Result.isFailure(Schema.decodeUnknownResult(Schema.DateFromString)('not-a-date'))).toBe(true)
-    expect(Result.isFailure(Schema.decodeUnknownResult(Schema.DateFromMillis)(8_640_000_000_000_001))).toBe(true)
+    expect(Result.isFailure(Schema.decodeResult(Schema.Date)(new Date(Number.NaN)))).toBe(true)
+    expect(Result.isFailure(Schema.encodeResult(Schema.Date)(new Date(Number.NaN)))).toBe(true)
+    expect(Result.isFailure(Schema.decodeResult(Schema.DateFromString)('not-a-date'))).toBe(true)
+    expect(Result.isFailure(Schema.decodeResult(Schema.DateFromMillis)(8_640_000_000_000_001))).toBe(true)
   })
 
   test('recovers permits after interrupted semaphore waiters', async () => {

--- a/services/bayn/src/execution-candidate-discovery.test.ts
+++ b/services/bayn/src/execution-candidate-discovery.test.ts
@@ -21,6 +21,8 @@ import {
 import { TestClock } from 'effect/testing'
 import { HttpClient, HttpClientResponse } from 'effect/unstable/http'
 
+import { baynTestPostgresUrl } from './test-environment.test-support'
+
 import {
   AccountStatus,
   AssetClass,
@@ -1145,7 +1147,7 @@ describe('paper candidate discovery', () => {
   })
 })
 
-const postgresUrl = process.env['BAYN_TEST_POSTGRES_URL']
+const postgresUrl = baynTestPostgresUrl
 const describePostgres = postgresUrl === undefined ? describe.skip : describe
 
 describePostgres('paper candidate discovery PostgreSQL transaction', () => {

--- a/services/bayn/src/execution-prepare/execution-prepare.integration.test.ts
+++ b/services/bayn/src/execution-prepare/execution-prepare.integration.test.ts
@@ -4,7 +4,7 @@ import { beforeAll, beforeEach, describe, expect, test } from 'bun:test'
 
 import { NodeServices } from '@effect/platform-node'
 import { PgClient } from '@effect/sql-pg'
-import { Effect, Layer, ManagedRuntime, Redacted, Result } from 'effect'
+import { Effect, Layer, ManagedRuntime, Redacted, Result, Schema } from 'effect'
 
 import { BrokerProvider, alpacaSandboxBaseUrl } from '../broker/alpaca'
 import { makeBrokerIdentity } from '../broker/identity'
@@ -39,6 +39,7 @@ import { makeExecutionPrepareDiscoveryReceiptFixture } from './test-fixture'
 
 type ExecutionPrepareRequest = ExecutionPrepareProofPlanRequest
 
+const encodeSqlJson = Schema.encodeSync(Schema.UnknownFromJsonString)
 const postgresUrl = baynTestPostgresUrl
 const testUrl = postgresUrl ?? 'postgresql://bayn:bayn@127.0.0.1:5432/bayn_test'
 const describePostgres = postgresUrl === undefined ? describe.skip : describe
@@ -294,8 +295,8 @@ const seedQualification = (fixture: QualificationFixture) =>
       INSERT INTO gate_outcomes (run_id, ordinal, gate_name, passed, actual, required, content_hash)
       VALUES (
         ${result.runId}, 0, 'execution_prepare_fixture', ${result.evaluationVerdict.gates[0].passed},
-        ${sql.json(result.evaluationVerdict.gates[0].actual)},
-        ${sql.json(result.evaluationVerdict.gates[0].required)},
+        ${sql.json(encodeSqlJson(result.evaluationVerdict.gates[0].actual))},
+        ${sql.json(encodeSqlJson(result.evaluationVerdict.gates[0].required))},
         ${hash(`${result.runId}-gate`)}
       )
     `
@@ -372,7 +373,7 @@ const seedReconciliation = (fixture: ReconciliationFixture) =>
       ) VALUES (
         ${fixture.reconciliationId}, 'bayn.paper-reconciliation.v1', ${accountId},
         ${expectedHash}, ${observedHash}, ${fixture.contentHash}, ${fixture.exact ? 'EXACT' : 'DISCREPANCY'},
-        ${sql.json(discrepancies)},
+        ${sql.json(encodeSqlJson(discrepancies))},
         clock_timestamp() - (${fixture.ageMs} * interval '1 millisecond')
       )
     `

--- a/services/bayn/src/execution-prepare/execution-prepare.integration.test.ts
+++ b/services/bayn/src/execution-prepare/execution-prepare.integration.test.ts
@@ -294,8 +294,8 @@ const seedQualification = (fixture: QualificationFixture) =>
       INSERT INTO gate_outcomes (run_id, ordinal, gate_name, passed, actual, required, content_hash)
       VALUES (
         ${result.runId}, 0, 'execution_prepare_fixture', ${result.evaluationVerdict.gates[0].passed},
-        ${sql.json(JSON.stringify(result.evaluationVerdict.gates[0].actual))},
-        ${sql.json(JSON.stringify(result.evaluationVerdict.gates[0].required))},
+        ${sql.json(result.evaluationVerdict.gates[0].actual)},
+        ${sql.json(result.evaluationVerdict.gates[0].required)},
         ${hash(`${result.runId}-gate`)}
       )
     `
@@ -372,7 +372,7 @@ const seedReconciliation = (fixture: ReconciliationFixture) =>
       ) VALUES (
         ${fixture.reconciliationId}, 'bayn.paper-reconciliation.v1', ${accountId},
         ${expectedHash}, ${observedHash}, ${fixture.contentHash}, ${fixture.exact ? 'EXACT' : 'DISCREPANCY'},
-        ${sql.json(JSON.stringify(discrepancies))},
+        ${sql.json(discrepancies)},
         clock_timestamp() - (${fixture.ageMs} * interval '1 millisecond')
       )
     `

--- a/services/bayn/src/execution-prepare/execution-prepare.integration.test.ts
+++ b/services/bayn/src/execution-prepare/execution-prepare.integration.test.ts
@@ -31,6 +31,7 @@ import {
   type QualificationSeries,
 } from '../qualification-statistics'
 import { fixtureProtocol } from '../test-fixtures'
+import { baynTestPostgresUrl } from '../test-environment.test-support'
 import type { ExecutionPrepareProofPlanRequest, ExecutionPrepareRuntimeBinding } from './model'
 import { ExecutionPrepareStoreLive } from './live'
 import { prepareExecution } from './program'
@@ -38,7 +39,7 @@ import { makeExecutionPrepareDiscoveryReceiptFixture } from './test-fixture'
 
 type ExecutionPrepareRequest = ExecutionPrepareProofPlanRequest
 
-const postgresUrl = process.env['BAYN_TEST_POSTGRES_URL']
+const postgresUrl = baynTestPostgresUrl
 const testUrl = postgresUrl ?? 'postgresql://bayn:bayn@127.0.0.1:5432/bayn_test'
 const describePostgres = postgresUrl === undefined ? describe.skip : describe
 const accountId = 'execution-prepare-account'

--- a/services/bayn/src/execution/coordinator.test.ts
+++ b/services/bayn/src/execution/coordinator.test.ts
@@ -1514,7 +1514,7 @@ const makeHarness = (options: HarnessOptions = {}) => {
         })
       }
       const observedAt = new Date(yield* Clock.currentTimeMillis).toISOString()
-      if (options.notFoundOnce && lookupCalls === 1) {
+      if (options.notFoundOnce === true && lookupCalls === 1) {
         return yield* new BrokerReadError({
           operation: 'order-by-client-id',
           kind: BrokerReadErrorKind.NotFound,
@@ -1555,10 +1555,10 @@ const makeHarness = (options: HarnessOptions = {}) => {
       if (latest.get(MutationOperation.Submit)?.eventType !== MutationEventType.SubmitStarted) {
         return Effect.die(new Error('submit happened before SUBMIT_STARTED was durable'))
       }
-      if (options.crashAfterSubmit) return Effect.die(new Error('injected crash after send'))
+      if (options.crashAfterSubmit === true) return Effect.die(new Error('injected crash after send'))
       if (options.submitError !== undefined) return Effect.fail(options.submitError)
       const hash = canonicalHashV1(encodedRequest(submitted))
-      if (options.unknownSubmit) {
+      if (options.unknownSubmit === true) {
         return Effect.fail(
           new BrokerMutationError({
             operation: MutationOperation.Submit,
@@ -1580,7 +1580,10 @@ const makeHarness = (options: HarnessOptions = {}) => {
   }
 
   const fenceCheck = Effect.suspend(() => {
-    if (!options.lostFence && !(options.lostFenceAfterSubmit && latest.has(MutationOperation.Submit))) {
+    if (
+      options.lostFence !== true &&
+      !(options.lostFenceAfterSubmit === true && latest.has(MutationOperation.Submit))
+    ) {
       return Effect.void
     }
     return Effect.fail(

--- a/services/bayn/src/forward-performance/program.test.ts
+++ b/services/bayn/src/forward-performance/program.test.ts
@@ -116,7 +116,7 @@ const makeReadOnlySql = (observation: SqlObservation, fixture: SqlFixture = {}):
               firstObservedAt: '2026-07-20T21:01:00.000Z',
               lastObservedAt: '2026-07-20T21:01:00.000Z',
             },
-            ...(fixture.extraReconciliationDiscrepancy
+            ...(fixture.extraReconciliationDiscrepancy === true
               ? [
                   {
                     discrepancyId: hash('2'),

--- a/services/bayn/src/health.test.ts
+++ b/services/bayn/src/health.test.ts
@@ -23,7 +23,7 @@ import { BrokerEnvironment, makeBrokerIdentity } from './broker/identity'
 import { CycleOperationsCondition, CycleOperationsReason, type CycleOperationsProjection } from './cycle-observability'
 import { CycleState, CycleTerminalReason } from './cycle'
 import { CycleObservability, type CycleObservabilityShape } from './db/cycle-observability'
-import { EvidenceStore } from './db/evidence-store'
+import { DatabaseError, EvidenceStore } from './db/evidence-store'
 import { BrokerAccess, CapitalAuthorityKind } from './execution/authority'
 import { Authority, KillState, ReconciliationStatus } from './execution/contracts'
 import {
@@ -1819,7 +1819,17 @@ describe('Bayn continuous health', () => {
     }
     const evidenceStore = {
       ...recoveringStore(initial),
-      check: Effect.suspend(() => (databaseAvailable ? Effect.void : Effect.fail(new Error('database unavailable')))),
+      check: Effect.suspend(() =>
+        databaseAvailable
+          ? Effect.void
+          : Effect.fail(
+              new DatabaseError({
+                failure: 'unavailable',
+                operation: 'check',
+                message: 'database unavailable',
+              }),
+            ),
+      ),
     }
     const dependencies = (
       effect: Effect.Effect<void, never, MarketData | Journal | EvidenceStore | CycleObservability>,

--- a/services/bayn/src/http.test.ts
+++ b/services/bayn/src/http.test.ts
@@ -164,7 +164,7 @@ const request = (port: number, path: string, method = 'GET') =>
     try: async (signal) => {
       const response = await fetch(`http://127.0.0.1:${port}${path}`, { method, signal })
       const contentType = response.headers.get('content-type')
-      const body = contentType?.includes('application/json') ? await response.json() : await response.text()
+      const body = contentType?.includes('application/json') === true ? await response.json() : await response.text()
       return {
         status: response.status,
         allow: response.headers.get('allow'),

--- a/services/bayn/src/http.test.ts
+++ b/services/bayn/src/http.test.ts
@@ -1588,7 +1588,7 @@ describe('Bayn HTTP probes', () => {
     await withHttpServer({ state: runtimeState }, ({ port }) =>
       request(port, '/v1/status').pipe(
         Effect.tap((response) =>
-          Effect.sync(() => {
+          Effect.gen(function* () {
             expect(response.body).toMatchObject({
               broker: {
                 configured: true,
@@ -1603,7 +1603,8 @@ describe('Bayn HTTP probes', () => {
             expect(body.broker).not.toHaveProperty('read')
             expect(body.broker).not.toHaveProperty('expectedAccountId')
             expect(body.broker).not.toHaveProperty('accountId')
-            expect(Schema.encodeSync(Schema.UnknownFromJsonString)(response.body)).not.toContain('paper-account-1')
+            const encodedBody = yield* Schema.encodeEffect(Schema.UnknownFromJsonString)(response.body)
+            expect(encodedBody).not.toContain('paper-account-1')
             expect(Object.values(body.broker).some((value) => typeof value === 'function')).toBe(false)
           }),
         ),

--- a/services/bayn/src/http.test.ts
+++ b/services/bayn/src/http.test.ts
@@ -2,7 +2,7 @@ import { connect, type Socket } from 'node:net'
 
 import { describe, expect, test } from 'bun:test'
 
-import { Cause, Deferred, Effect, Exit, Fiber, Option, Ref, Result } from 'effect'
+import { Cause, Deferred, Effect, Exit, Fiber, Option, Ref, Result, Schema } from 'effect'
 import { TestClock } from 'effect/testing'
 import { HttpServer } from 'effect/unstable/http'
 
@@ -1599,7 +1599,7 @@ describe('Bayn HTTP probes', () => {
             expect(body.broker).not.toHaveProperty('read')
             expect(body.broker).not.toHaveProperty('expectedAccountId')
             expect(body.broker).not.toHaveProperty('accountId')
-            expect(JSON.stringify(response.body)).not.toContain('paper-account-1')
+            expect(Schema.encodeSync(Schema.UnknownFromJsonString)(response.body)).not.toContain('paper-account-1')
             expect(Object.values(body.broker).some((value) => typeof value === 'function')).toBe(false)
           }),
         ),

--- a/services/bayn/src/http.test.ts
+++ b/services/bayn/src/http.test.ts
@@ -2,7 +2,7 @@ import { connect, type Socket } from 'node:net'
 
 import { describe, expect, test } from 'bun:test'
 
-import { Cause, Deferred, Effect, Exit, Fiber, Option, Ref, Result, Schema } from 'effect'
+import { Cause, Data, Deferred, Effect, Exit, Fiber, Option, Ref, Result, Schema } from 'effect'
 import { TestClock } from 'effect/testing'
 import { HttpServer } from 'effect/unstable/http'
 
@@ -124,9 +124,13 @@ interface TestServer {
   readonly state: Ref.Ref<RuntimeState>
 }
 
-const withHttpServer = (
+class TestHttpRequestError extends Data.TaggedError('TestHttpRequestError')<{
+  readonly cause: unknown
+}> {}
+
+const withHttpServer = <E>(
   options: TestServerOptions,
-  use: (server: TestServer) => Effect.Effect<void, unknown>,
+  use: (server: TestServer) => Effect.Effect<void, E>,
 ): Promise<void> => {
   const serverConfig = {
     cycleStallThresholdMs: config.cycleStallThresholdMs,
@@ -173,7 +177,7 @@ const request = (port: number, path: string, method = 'GET') =>
         body,
       }
     },
-    catch: (cause) => cause,
+    catch: (cause) => new TestHttpRequestError({ cause }),
   })
 
 const connectSocket = (port: number): Effect.Effect<Socket> =>

--- a/services/bayn/src/market-data.test.ts
+++ b/services/bayn/src/market-data.test.ts
@@ -378,15 +378,15 @@ describe('finalized Signal snapshot reader', () => {
       const authorization = marketDataOperationError(
         operation,
         'Signal query failed',
-        new SqlError({
-          reason: new AuthorizationError({ cause: new Error('SELECT denied'), operation: 'query' }),
+        SqlError.make({
+          reason: AuthorizationError.make({ cause: new Error('SELECT denied'), operation: 'query' }),
         }),
       )
       const connection = marketDataOperationError(
         operation,
         'Signal query failed',
-        new SqlError({
-          reason: new ConnectionError({ cause: new Error('connection reset'), operation: 'query' }),
+        SqlError.make({
+          reason: ConnectionError.make({ cause: new Error('connection reset'), operation: 'query' }),
         }),
       )
 

--- a/services/bayn/src/market-data.test.ts
+++ b/services/bayn/src/market-data.test.ts
@@ -156,30 +156,28 @@ const producerRows = {
 const makeFixture = (): {
   readonly rows: SnapshotRows
   readonly request: SnapshotRequest
-} => {
-  return {
-    rows: producerRows,
-    request: {
-      snapshotId,
-      publicationAsOf: '2025-01-03',
-      calendarVersion: 'alpaca-us-equity-calendar-v1',
-      universeId: 'cross-asset-taa-v1',
-      universeSymbolHash,
-      universe: symbols,
-      historyStart: '2025-01-02',
+} => ({
+  rows: producerRows,
+  request: {
+    snapshotId,
+    publicationAsOf: '2025-01-03',
+    calendarVersion: 'alpaca-us-equity-calendar-v1',
+    universeId: 'cross-asset-taa-v1',
+    universeSymbolHash,
+    universe: symbols,
+    historyStart: '2025-01-02',
+    evaluationStart: '2025-01-03',
+    bounds: {
+      schemaVersion: 'bayn.evaluation-bounds.v1',
+      dataStart: '2025-01-02',
+      dataEnd: '2025-01-03',
+      lookbackStart: '2025-01-02',
       evaluationStart: '2025-01-03',
-      bounds: {
-        schemaVersion: 'bayn.evaluation-bounds.v1',
-        dataStart: '2025-01-02',
-        dataEnd: '2025-01-03',
-        lookbackStart: '2025-01-02',
-        evaluationStart: '2025-01-03',
-        evaluationEnd: '2025-01-03',
-      },
-      observedAt: '2025-01-04T02:00:00.000Z',
+      evaluationEnd: '2025-01-03',
     },
-  }
-}
+    observedAt: '2025-01-04T02:00:00.000Z',
+  },
+})
 
 const makePublicationRevision = (
   fixture: ReturnType<typeof makeFixture>,
@@ -1047,7 +1045,7 @@ describe('finalized Signal snapshot reader', () => {
           signalSessionDate: '2025-01-03',
           signalCalendarVersion: fixture.request.calendarVersion,
         })
-      }).pipe(Effect.provide(layer), Effect.provide(TestClock.layer())),
+      }).pipe(Effect.provide(Layer.merge(layer, TestClock.layer()))),
     )
 
     expect(result.bars).toHaveLength(fixture.rows.bars.length)

--- a/services/bayn/src/operations.test.ts
+++ b/services/bayn/src/operations.test.ts
@@ -19,8 +19,8 @@ const buildSqlResource = <A, E, R>(layer: Layer.Layer<A, E, R>) => Layer.build(s
 describe('Bayn SQL dependency acquisition', () => {
   test('retries only retryable SQL failures', async () => {
     let attempts = 0
-    const retryable = new SqlError({
-      reason: new ConnectionError({ cause: new Error('transient timeout'), operation: 'connect' }),
+    const retryable = SqlError.make({
+      reason: ConnectionError.make({ cause: new Error('transient timeout'), operation: 'connect' }),
     })
     const dependencies = Layer.effectDiscard(
       Effect.suspend(() => {
@@ -42,8 +42,8 @@ describe('Bayn SQL dependency acquisition', () => {
     await Effect.runPromise(program)
 
     attempts = 0
-    const nonRetryable = new SqlError({
-      reason: new AuthenticationError({ cause: new Error('invalid credentials'), operation: 'connect' }),
+    const nonRetryable = SqlError.make({
+      reason: AuthenticationError.make({ cause: new Error('invalid credentials'), operation: 'connect' }),
     })
     const exit = await Effect.runPromiseExit(
       Effect.scoped(
@@ -63,8 +63,8 @@ describe('Bayn SQL dependency acquisition', () => {
 
   test('retries retryable SQL failures wrapped by the database layer', async () => {
     let attempts = 0
-    const connection = new SqlError({
-      reason: new ConnectionError({ cause: new Error('connection refused'), operation: 'connect' }),
+    const connection = SqlError.make({
+      reason: ConnectionError.make({ cause: new Error('connection refused'), operation: 'connect' }),
     })
     const unavailable = new DatabaseError({
       failure: 'unavailable',
@@ -98,8 +98,8 @@ describe('Bayn SQL dependency acquisition', () => {
       failure: 'unavailable',
       operation: 'connect',
       message: 'PostgreSQL operation failed',
-      cause: new SqlError({
-        reason: new UnknownError({
+      cause: SqlError.make({
+        reason: UnknownError.make({
           cause: Object.assign(new Error('connect ECONNREFUSED'), { code: 'ECONNREFUSED' }),
           operation: 'connect',
         }),
@@ -144,8 +144,8 @@ describe('Bayn SQL dependency acquisition', () => {
         }),
       ).pipe(Effect.provide(TestClock.layer()))
     }
-    const rawRefusal = new SqlError({
-      reason: new UnknownError({
+    const rawRefusal = SqlError.make({
+      reason: UnknownError.make({
         cause: Object.assign(new Error('connect ECONNREFUSED'), { code: 'ECONNREFUSED' }),
         operation: 'connect',
       }),
@@ -154,8 +154,8 @@ describe('Bayn SQL dependency acquisition', () => {
       failure: 'unavailable',
       operation: 'connect',
       message: 'PostgreSQL operation failed',
-      cause: new SqlError({
-        reason: new UnknownError({
+      cause: SqlError.make({
+        reason: UnknownError.make({
           cause: Object.assign(new Error('invalid certificate'), { code: 'ERR_TLS_CERT_ALTNAME_INVALID' }),
           operation: 'connect',
         }),
@@ -175,8 +175,8 @@ describe('Bayn SQL dependency acquisition', () => {
 
   test('interrupts a pending retry', async () => {
     let attempts = 0
-    const retryable = new SqlError({
-      reason: new ConnectionError({ cause: new Error('transient timeout'), operation: 'connect' }),
+    const retryable = SqlError.make({
+      reason: ConnectionError.make({ cause: new Error('transient timeout'), operation: 'connect' }),
     })
     const program = Effect.scoped(
       Effect.gen(function* () {
@@ -240,18 +240,18 @@ describe('Bayn database operation failures', () => {
 
     const [authentication, authorization, connection] = await Promise.all([
       classify(
-        new SqlError({
-          reason: new AuthenticationError({ cause: new Error('invalid credentials'), operation: 'connect' }),
+        SqlError.make({
+          reason: AuthenticationError.make({ cause: new Error('invalid credentials'), operation: 'connect' }),
         }),
       ),
       classify(
-        new SqlError({
-          reason: new AuthorizationError({ cause: new Error('permission denied'), operation: 'query' }),
+        SqlError.make({
+          reason: AuthorizationError.make({ cause: new Error('permission denied'), operation: 'query' }),
         }),
       ),
       classify(
-        new SqlError({
-          reason: new ConnectionError({ cause: new Error('connection reset'), operation: 'query' }),
+        SqlError.make({
+          reason: ConnectionError.make({ cause: new Error('connection reset'), operation: 'query' }),
         }),
       ),
     ])
@@ -281,13 +281,13 @@ describe('Bayn database operation failures', () => {
 
     const [connection, authorization] = await Promise.all([
       classify(
-        new SqlError({
-          reason: new ConnectionError({ cause: new Error('connection reset'), operation: 'query' }),
+        SqlError.make({
+          reason: ConnectionError.make({ cause: new Error('connection reset'), operation: 'query' }),
         }),
       ),
       classify(
-        new SqlError({
-          reason: new AuthorizationError({ cause: new Error('permission denied'), operation: 'query' }),
+        SqlError.make({
+          reason: AuthorizationError.make({ cause: new Error('permission denied'), operation: 'query' }),
         }),
       ),
     ])

--- a/services/bayn/src/operations.test.ts
+++ b/services/bayn/src/operations.test.ts
@@ -126,7 +126,7 @@ describe('Bayn SQL dependency acquisition', () => {
   })
 
   test('keeps unverified and non-PostgreSQL unknown connect errors terminal', async () => {
-    const countAttempts = (failure: unknown) => {
+    const countAttempts = <E>(failure: E) => {
       let attempts = 0
       return Effect.scoped(
         Effect.gen(function* () {

--- a/services/bayn/src/paper-proof/program.test.ts
+++ b/services/bayn/src/paper-proof/program.test.ts
@@ -391,7 +391,7 @@ const fixture = (options: FixtureOptions) => {
         Effect.gen(function* () {
           sequence.push('submit:preflight')
           if (options.failSubmitPrerequisite === true) {
-            return yield* Effect.fail(new TestFailure({ message: 'submit prerequisite failed before mutation start' }))
+            return yield* new TestFailure({ message: 'submit prerequisite failed before mutation start' })
           }
           sequence.push('submit:mutation-started')
           yield* beforeBrokerMutation()
@@ -399,7 +399,7 @@ const fixture = (options: FixtureOptions) => {
           sequence.push('submit')
           if (options.neverSubmitAfterMarker === true) return yield* Effect.never
           if (options.failSubmit === true) {
-            return yield* Effect.fail(new TestFailure({ message: 'submit failed after durable marker' }))
+            return yield* new TestFailure({ message: 'submit failed after durable marker' })
           }
           const submitted = options.submitEvent ?? event(MutationEventType.SubmitAccepted)
           mutationState.submit = submitted
@@ -410,7 +410,7 @@ const fixture = (options: FixtureOptions) => {
         Effect.gen(function* () {
           sequence.push('cancel:preflight')
           if (options.failCancelPrerequisite === true) {
-            return yield* Effect.fail(new TestFailure({ message: 'cancel prerequisite failed before mutation start' }))
+            return yield* new TestFailure({ message: 'cancel prerequisite failed before mutation start' })
           }
           sequence.push('cancel:mutation-started')
           if (options.cancelStartedEvent !== undefined) mutationState.cancel = options.cancelStartedEvent
@@ -419,7 +419,7 @@ const fixture = (options: FixtureOptions) => {
           sequence.push('cancel')
           if (options.neverCancelAfterMarker === true) return yield* Effect.never
           if (options.failCancel === true) {
-            return yield* Effect.fail(new TestFailure({ message: 'cancel failed after durable marker' }))
+            return yield* new TestFailure({ message: 'cancel failed after durable marker' })
           }
           const canceled = options.cancelEvent ?? event(MutationEventType.CancelAccepted, MutationOperation.Cancel)
           mutationState.cancel = canceled

--- a/services/bayn/src/paper-proof/program.test.ts
+++ b/services/bayn/src/paper-proof/program.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 
-import { Effect, Exit, Fiber } from 'effect'
+import { Data, Effect, Exit, Fiber } from 'effect'
 import { TestClock } from 'effect/testing'
 
 import { MutationOperation } from '../broker/alpaca-mutations'
@@ -28,6 +28,8 @@ import {
 import { runPaperProofPrepare } from './prepare'
 
 type PaperProofPublicExports = typeof import('./index')
+
+class TestFailure extends Data.TaggedError('TestFailure')<{ readonly message: string }> {}
 
 const hash = (character: string): string => character.repeat(64)
 const accountId = 'paper-account'
@@ -298,7 +300,9 @@ const fixture = (options: FixtureOptions) => {
       calls.activate += 1
       sequence.push('activate')
       if (options.neverActivation === true) return Effect.never
-      return options.failActivation === true ? Effect.fail(new Error('activation failed')) : Effect.void
+      return options.failActivation === true
+        ? Effect.fail(new TestFailure({ message: 'activation failed' }))
+        : Effect.void
     },
     restrictAuthority: () => {
       calls.restrict += 1
@@ -310,20 +314,26 @@ const fixture = (options: FixtureOptions) => {
         calls.recoveryLoad += 1
         sequence.push('recovery:load')
         if (options.neverRecoveryLoad === true) return Effect.never
-        if (options.failRecoveryLoad === true) return Effect.fail(new Error('recovery load failed'))
+        if (options.failRecoveryLoad === true) {
+          return Effect.fail(new TestFailure({ message: 'recovery load failed' }))
+        }
         return Effect.succeed(recoveryState.required)
       },
       loadCompletion: () => {
         calls.completionLoad += 1
         sequence.push('recovery:load-completion')
         if (options.neverCompletionLoad === true) return Effect.never
-        if (options.failCompletionLoad === true) return Effect.fail(new Error('completion load failed'))
+        if (options.failCompletionLoad === true) {
+          return Effect.fail(new TestFailure({ message: 'completion load failed' }))
+        }
         return Effect.succeed(recoveryState.completion)
       },
       markRequired: (required) => {
         calls.recoveryMark += 1
         sequence.push(`recovery:mark:${required.operation}`)
-        if (options.failRecoveryMark === true) return Effect.fail(new Error('recovery mark failed before commit'))
+        if (options.failRecoveryMark === true) {
+          return Effect.fail(new TestFailure({ message: 'recovery mark failed before commit' }))
+        }
         recoveryState.required = required
         delete recoveryState.completion
         return Effect.void
@@ -341,7 +351,9 @@ const fixture = (options: FixtureOptions) => {
           !sameMutationEvent(completion.mutation, guard.expectedLatestMutation) ||
           (guard.rejectAnyCancellation && mutationState.cancel !== undefined)
         ) {
-          return Effect.fail(new Error('recovery completion guard rejected stale authority evidence'))
+          return Effect.fail(
+            new TestFailure({ message: 'recovery completion guard rejected stale authority evidence' }),
+          )
         }
         const commit = Effect.sync(() => {
           recoveryState.completion = completion
@@ -349,7 +361,9 @@ const fixture = (options: FixtureOptions) => {
         })
         if (options.neverCompleteAfterCommit === true) return commit.pipe(Effect.andThen(Effect.never))
         if (options.failCompleteAfterCommit === true) {
-          return commit.pipe(Effect.andThen(Effect.fail(new Error('completion response failed after commit'))))
+          return commit.pipe(
+            Effect.andThen(Effect.fail(new TestFailure({ message: 'completion response failed after commit' }))),
+          )
         }
         return commit
       },
@@ -377,7 +391,7 @@ const fixture = (options: FixtureOptions) => {
         Effect.gen(function* () {
           sequence.push('submit:preflight')
           if (options.failSubmitPrerequisite === true) {
-            return yield* Effect.fail(new Error('submit prerequisite failed before mutation start'))
+            return yield* Effect.fail(new TestFailure({ message: 'submit prerequisite failed before mutation start' }))
           }
           sequence.push('submit:mutation-started')
           yield* beforeBrokerMutation()
@@ -385,7 +399,7 @@ const fixture = (options: FixtureOptions) => {
           sequence.push('submit')
           if (options.neverSubmitAfterMarker === true) return yield* Effect.never
           if (options.failSubmit === true) {
-            return yield* Effect.fail(new Error('submit failed after durable marker'))
+            return yield* Effect.fail(new TestFailure({ message: 'submit failed after durable marker' }))
           }
           const submitted = options.submitEvent ?? event(MutationEventType.SubmitAccepted)
           mutationState.submit = submitted
@@ -396,7 +410,7 @@ const fixture = (options: FixtureOptions) => {
         Effect.gen(function* () {
           sequence.push('cancel:preflight')
           if (options.failCancelPrerequisite === true) {
-            return yield* Effect.fail(new Error('cancel prerequisite failed before mutation start'))
+            return yield* Effect.fail(new TestFailure({ message: 'cancel prerequisite failed before mutation start' }))
           }
           sequence.push('cancel:mutation-started')
           if (options.cancelStartedEvent !== undefined) mutationState.cancel = options.cancelStartedEvent
@@ -405,7 +419,7 @@ const fixture = (options: FixtureOptions) => {
           sequence.push('cancel')
           if (options.neverCancelAfterMarker === true) return yield* Effect.never
           if (options.failCancel === true) {
-            return yield* Effect.fail(new Error('cancel failed after durable marker'))
+            return yield* Effect.fail(new TestFailure({ message: 'cancel failed after durable marker' }))
           }
           const canceled = options.cancelEvent ?? event(MutationEventType.CancelAccepted, MutationOperation.Cancel)
           mutationState.cancel = canceled
@@ -424,7 +438,9 @@ const fixture = (options: FixtureOptions) => {
       calls.prepareIntent += 1
       sequence.push('intent:prepare')
       if (options.neverPrepareIntent === true) return Effect.never
-      if (options.failPrepareIntent === true) return Effect.fail(new Error('intent preparation failed'))
+      if (options.failPrepareIntent === true) {
+        return Effect.fail(new TestFailure({ message: 'intent preparation failed' }))
+      }
       return Effect.succeed({
         intentId,
         clientOrderId: `b1_${'A'.repeat(43)}`,
@@ -442,7 +458,7 @@ const fixture = (options: FixtureOptions) => {
       sequence.push(`reconcile:${calls.reconcile.toString()}`)
       if (options.neverReconcileCalls?.includes(calls.reconcile) === true) return Effect.never
       if (options.failReconcileCalls?.includes(calls.reconcile) === true) {
-        return Effect.fail(new Error('reconciliation failed'))
+        return Effect.fail(new TestFailure({ message: 'reconciliation failed' }))
       }
       return Effect.succeed({
         reconciliationId: hash(String(Math.min(calls.reconcile, 9))),
@@ -457,7 +473,7 @@ const fixture = (options: FixtureOptions) => {
       calls.clock += 1
       if (options.neverClockCalls?.includes(calls.clock) === true) return Effect.never
       return options.failClockCalls?.includes(calls.clock) === true
-        ? Effect.fail(new Error('clock failed'))
+        ? Effect.fail(new TestFailure({ message: 'clock failed' }))
         : Effect.succeed('2026-07-31T08:00:01.000Z')
     }),
   }

--- a/services/bayn/src/paper.test.ts
+++ b/services/bayn/src/paper.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 
-import { Effect, Exit, Result } from 'effect'
+import { Effect, Exit, Result, Schema } from 'effect'
 
 import {
   AccountStatus,
@@ -46,7 +46,7 @@ const i128Max = '170141183460469231731687303715884105727'
 const makeCapitalGrantGeneration = (input: Parameters<typeof makeCapitalGrantGenerationResult>[0]) =>
   Result.getOrThrow(makeCapitalGrantGenerationResult(input))
 
-const expectFailure = async (effect: Effect.Effect<unknown, unknown>): Promise<void> => {
+const expectFailure = async <A, E>(effect: Effect.Effect<A, E>): Promise<void> => {
   expect(Exit.isFailure(await Effect.runPromiseExit(effect))).toBe(true)
 }
 
@@ -157,7 +157,7 @@ const intent = {
 describe('paper contracts', () => {
   test('strictly decodes every broker payload and tagged event', async () => {
     const contracts: ReadonlyArray<{
-      decode: (value: unknown) => Effect.Effect<unknown, unknown>
+      decode: (value: unknown) => Effect.Effect<unknown, Schema.SchemaError>
       value: Record<string, unknown>
     }> = [
       { decode: decodeAccountSnapshot, value: account },

--- a/services/bayn/src/qualification-statistics.test.ts
+++ b/services/bayn/src/qualification-statistics.test.ts
@@ -611,7 +611,7 @@ describe('walk-forward and terminal qualification semantics', () => {
     const changedMaterial = { ...originalMaterial, bootstrap: changedBootstrap }
 
     expect(() =>
-      Schema.decodeUnknownSync(QualificationAnalysisSchema, { onExcessProperty: 'error' })({
+      Schema.decodeSync(QualificationAnalysisSchema, { onExcessProperty: 'error' })({
         ...changedMaterial,
         analysisHash: canonicalHashV1(changedMaterial),
       }),

--- a/services/bayn/src/qualification.test.ts
+++ b/services/bayn/src/qualification.test.ts
@@ -138,10 +138,9 @@ describe('qualification lock', () => {
     ).toBe(true)
 
     const lock = successOf(makeQualificationLock(material))
-    expect(() =>
-      Schema.decodeUnknownSync(QualificationLockSchema)({ ...lock, universeId: 'equity-infrastructure-v1' }),
-    ).toThrow()
-    expect(() => Schema.decodeUnknownSync(QualificationLockSchema)({ ...lock, lockId: '0'.repeat(64) })).toThrow()
+    const invalidUniverseLock: unknown = { ...lock, universeId: 'equity-infrastructure-v1' }
+    expect(() => Schema.decodeUnknownSync(QualificationLockSchema)(invalidUniverseLock)).toThrow()
+    expect(() => Schema.decodeSync(QualificationLockSchema)({ ...lock, lockId: '0'.repeat(64) })).toThrow()
   })
 })
 

--- a/services/bayn/src/resources.test.ts
+++ b/services/bayn/src/resources.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 
-import { Cause, Deferred, Effect, Exit, Fiber, Layer, Option, Redacted, Ref, Result } from 'effect'
+import { Cause, Data, Deferred, Effect, Exit, Fiber, Layer, Option, Redacted, Ref, Result } from 'effect'
 import { AuthorizationError, SqlError } from 'effect/unstable/sql/SqlError'
 import { HttpClient, HttpClientResponse } from 'effect/unstable/http'
 
@@ -27,6 +27,8 @@ import {
   validateResolvedReplicaEndpoint,
   type ReplicaAddressValidationError,
 } from './tigerbeetle-client'
+
+class TestFailure extends Data.TaggedError('TestFailure')<{ readonly message: string }> {}
 
 const initialize = (runtimeConfig: RuntimeConfig, state: Ref.Ref<RuntimeState>, strategy: StrategyRuntime) =>
   Effect.all({ marketData: MarketData, journal: Journal, evidenceStore: EvidenceStore }).pipe(
@@ -496,7 +498,7 @@ describe('Bayn resource lifecycle', () => {
           yield* journal.checkRun({ runId: 'a'.repeat(64), accountCount: 0, transferCount: 0, exact: true }).pipe(
             Effect.timeoutOrElse({
               duration: 250,
-              orElse: () => Effect.fail(new Error('paired TigerBeetle queries were serialized')),
+              orElse: () => Effect.fail(new TestFailure({ message: 'paired TigerBeetle queries were serialized' })),
             }),
           )
         }).pipe(

--- a/services/bayn/src/resources.test.ts
+++ b/services/bayn/src/resources.test.ts
@@ -517,15 +517,12 @@ describe('Bayn resource lifecycle', () => {
 
   test('invalidates an interrupted TigerBeetle client and defers replacement to the next request', async () => {
     const closeCounts = [0, 0]
-    let rejectLookup: ((cause: Error) => void) | undefined
+    const pendingLookup = Deferred.makeUnsafe<never, TestFailure>()
     const interruptedClient = makeTigerBeetleClient({
-      lookupAccounts: () =>
-        new Promise<never>((_, reject) => {
-          rejectLookup = reject
-        }),
+      lookupAccounts: () => Effect.runPromise(Deferred.await(pendingLookup)),
       destroy: () => {
         closeCounts[0] += 1
-        rejectLookup?.(new Error('client closed'))
+        Effect.runSync(Deferred.fail(pendingLookup, new TestFailure({ message: 'client closed' })))
       },
     })
     const recoveredClient = makeTigerBeetleClient({
@@ -650,16 +647,13 @@ describe('Bayn resource lifecycle', () => {
 
   test('destroys TigerBeetle to cancel its indefinite retry when the startup deadline expires', async () => {
     let destroyed = false
-    let rejectLookup: ((cause: Error) => void) | undefined
+    const pendingLookup = Deferred.makeUnsafe<never, TestFailure>()
     const tigerBeetleClient = makeTigerBeetleClient({
-      lookupAccounts: () =>
-        new Promise<never>((_, reject) => {
-          rejectLookup = reject
-        }),
+      lookupAccounts: () => Effect.runPromise(Deferred.await(pendingLookup)),
       destroy: () => {
         if (destroyed) return
         destroyed = true
-        rejectLookup?.(new Error('client closed'))
+        Effect.runSync(Deferred.fail(pendingLookup, new TestFailure({ message: 'client closed' })))
       },
     })
     const marketData = marketDataService(Effect.succeed(makeSnapshot()))

--- a/services/bayn/src/resources.test.ts
+++ b/services/bayn/src/resources.test.ts
@@ -622,8 +622,8 @@ describe('Bayn resource lifecycle', () => {
   })
 
   test('keeps ClickHouse authorization failures observable as terminal startup failures', async () => {
-    const authorization = new SqlError({
-      reason: new AuthorizationError({ cause: new Error('SELECT denied'), operation: 'query' }),
+    const authorization = SqlError.make({
+      reason: AuthorizationError.make({ cause: new Error('SELECT denied'), operation: 'query' }),
     })
     const marketData = marketDataService(
       Effect.fail(marketDataOperationError('load', 'failed to load finalized Signal snapshot', authorization)),

--- a/services/bayn/src/startup.test.ts
+++ b/services/bayn/src/startup.test.ts
@@ -1437,8 +1437,8 @@ describe('Bayn startup lifecycle', () => {
 
   test('keeps PostgreSQL authentication failures observable as terminal startup failures', async () => {
     const state = await Effect.runPromise(Ref.make(initialState({})))
-    const authentication = new SqlError({
-      reason: new AuthenticationError({ cause: new Error('invalid credentials'), operation: 'persist' }),
+    const authentication = SqlError.make({
+      reason: AuthenticationError.make({ cause: new Error('invalid credentials'), operation: 'persist' }),
     })
     const unauthorized: EvidenceStoreService = {
       ...successfulEvidenceStore,

--- a/services/bayn/src/test-environment.test-support.ts
+++ b/services/bayn/src/test-environment.test-support.ts
@@ -1,0 +1,7 @@
+import { Config, Effect, Option } from 'effect'
+
+const optionalString = (name: string): string | undefined =>
+  Effect.runSync(Config.option(Config.string(name))).pipe(Option.getOrUndefined)
+
+export const baynTestPostgresUrl = optionalString('BAYN_TEST_POSTGRES_URL')
+export const isGithubActions = Effect.runSync(Config.boolean('GITHUB_ACTIONS').pipe(Config.withDefault(false)))

--- a/services/bayn/src/test-fixtures.ts
+++ b/services/bayn/src/test-fixtures.ts
@@ -3,6 +3,7 @@ import { Effect } from 'effect'
 import { makeRuntimeProvenance, type RuntimeProvenance } from './contracts'
 import { canonicalHashV1 } from './hash'
 import { hashParameters, loadDefaultProtocol } from './protocol'
+import { Pipeable } from './pipeable'
 import {
   DataFeed,
   DataSource,
@@ -20,13 +21,15 @@ import {
 
 export const fixtureProtocol = Effect.runSync(loadDefaultProtocol)
 
-export const makeTestProvenance = (
+type TestProvenanceOverrides = {
+  readonly sourceRevision?: string
+  readonly imageDigest?: string
+  readonly behaviorHash?: string
+}
+
+const makeTestProvenanceDataFirst = (
   protocol: Protocol = fixtureProtocol,
-  overrides: {
-    readonly sourceRevision?: string
-    readonly imageDigest?: string
-    readonly behaviorHash?: string
-  } = {},
+  overrides: TestProvenanceOverrides = {},
 ): RuntimeProvenance =>
   makeRuntimeProvenance({
     sourceRevision: overrides.sourceRevision ?? 'a'.repeat(40),
@@ -42,13 +45,30 @@ export const makeTestProvenance = (
     },
   })
 
-export const makeTestDefinition = (
+export const makeTestProvenance = Pipeable.by<
+  (overrides: TestProvenanceOverrides) => (protocol: Protocol) => RuntimeProvenance,
+  typeof makeTestProvenanceDataFirst
+>(
+  (arguments_) =>
+    arguments_.length === 0 ||
+    (typeof arguments_[0] === 'object' && arguments_[0] !== null && 'schemaVersion' in arguments_[0]),
+  makeTestProvenanceDataFirst,
+)
+
+const makeTestDefinitionDataFirst = (
   protocol: Protocol = fixtureProtocol,
   decide: RiskBalancedTrendStrategyDefinition['decide'] = makeRiskBalancedTrendDefinition(protocol).decide,
 ): RiskBalancedTrendStrategyDefinition => ({
   ...makeRiskBalancedTrendDefinition(protocol),
   decide,
 })
+
+export const makeTestDefinition = Pipeable.by<
+  (
+    decide: RiskBalancedTrendStrategyDefinition['decide'],
+  ) => (protocol: Protocol) => RiskBalancedTrendStrategyDefinition,
+  typeof makeTestDefinitionDataFirst
+>((arguments_) => arguments_.length === 0 || typeof arguments_[0] !== 'function', makeTestDefinitionDataFirst)
 
 export const makeBars = (sessionCount = 1_122): readonly DailyBar[] => {
   const bars: DailyBar[] = []


### PR DESCRIPTION
## Summary

- Aligns test configuration, schemas, JSON, errors, and async primitives with Effect APIs.
- Keeps this native stack layer independently reviewable at 579 changed lines.
- Bases directly on codex/bayn-effect-tsgo-runtime-composition so GitHub shows only this layer.

## Related Issues

None

## Testing

- bunx tsc --noEmit --project services/bayn/tsconfig.json
- bun run lint
- bun run lint:oxlint
- bun run lint:oxlint:type
- bun run build
- Focused tests for the touched subsystem were run while constructing the layer.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable and Breaking Changes is filled in.
- [x] Documentation and follow-ups are unchanged or represented by later stack layers.