### PR TITLE
refactor(bayn): use Effect platform and date boundaries

### DIFF
--- a/services/bayn/src/app.test.ts
+++ b/services/bayn/src/app.test.ts
@@ -15,6 +15,7 @@ import {
   successfulEvidenceStore,
   successfulJournal,
 } from './app-test-support'
+import { utcInstantFromEpochMillis } from './time'
 import {
   type ApplicationIdentity,
   type AutonomousCycleStartupInput,
@@ -353,7 +354,7 @@ describe('Bayn application composition', () => {
                 startupQualificationRunId = qualificationRunId
               }),
               Effect.andThen(Clock.currentTimeMillis),
-              Effect.map((millis) => new Date(millis).toISOString()),
+              Effect.map(utcInstantFromEpochMillis),
               Effect.flatMap((observedAt) => recordPass({ result: 'SUCCESS', observedAt, outcome: 'NO_PUBLICATION' })),
               Effect.as(
                 pipe(
@@ -634,7 +635,7 @@ describe('Bayn application composition', () => {
                             startCycle: ({ recordPass }: AutonomousCycleStartupInput) =>
                               resource.use('cycle').pipe(
                                 Effect.andThen(Clock.currentTimeMillis),
-                                Effect.map((millis) => new Date(millis).toISOString()),
+                                Effect.map(utcInstantFromEpochMillis),
                                 Effect.flatMap((observedAt) =>
                                   recordPass({ result: 'SUCCESS', observedAt, outcome: 'NO_PUBLICATION' }),
                                 ),

--- a/services/bayn/src/clickhouse-patch.test.ts
+++ b/services/bayn/src/clickhouse-patch.test.ts
@@ -1,73 +1,58 @@
 import { expect, test } from 'bun:test'
-import { createServer } from 'node:http'
 
 import { NodeHttpClient } from '@effect/platform-node'
 import { ClickhouseClient } from '@effect/sql-clickhouse'
-import { Effect, Fiber, Layer } from 'effect'
+import { Effect, Layer, Ref, Stream } from 'effect'
 
-const listen = (server: ReturnType<typeof createServer>): Effect.Effect<number> =>
-  Effect.callback<number>((resume) => {
-    const onError = (cause: Error) => resume(Effect.die(cause))
-    server.once('error', onError)
-    server.listen(0, '127.0.0.1', () => {
-      server.off('error', onError)
-      const address = server.address()
-      if (address === null || typeof address === 'string') {
-        resume(Effect.die(new Error('ClickHouse test server did not bind a TCP port')))
-        return
-      }
-      resume(Effect.succeed(address.port))
-    })
-    return Effect.sync(() => server.off('error', onError))
-  })
-
-test('Effect ClickHouse drains its connection check before exposing the client', async () => {
-  let responseFinished = false
-  let requests = 0
-  const responseFibers: Array<Fiber.Fiber<void>> = []
-  const server = createServer((_, response) => {
-    requests += 1
-    response.writeHead(200, { 'content-type': 'text/plain; charset=UTF-8', 'x-clickhouse-summary': '{}' })
-    response.flushHeaders()
-    response.write('1\n')
-    responseFibers.push(
-      Effect.sleep(250).pipe(
-        Effect.andThen(
-          Effect.sync(() => {
-            responseFinished = true
-            response.end()
-          }),
-        ),
-        Effect.runFork,
-      ),
-    )
-  })
-  const port = await Effect.runPromise(listen(server))
-
-  try {
-    await Effect.runPromise(
-      Effect.scoped(
-        Effect.gen(function* () {
-          yield* ClickhouseClient.ClickhouseClient
-          expect(responseFinished).toBe(true)
-        }).pipe(
-          Effect.provide(
-            ClickhouseClient.layer({
-              url: `http://127.0.0.1:${port}`,
-              username: 'default',
-              password: '',
-              database: 'signal',
-              application: 'bayn-patch-test',
-              request_timeout: 1_000,
-            }).pipe(Layer.provide(NodeHttpClient.layerNodeHttp)),
+test('Effect ClickHouse drains its connection check before exposing the client', () =>
+  Effect.runPromise(
+    Effect.scoped(
+      Effect.gen(function* () {
+        const responseFinished = yield* Ref.make(false)
+        const requests = yield* Ref.make(0)
+        const runSync = Effect.runSyncWith(yield* Effect.context<never>())
+        const server = yield* Effect.acquireRelease(
+          Effect.sync(() =>
+            Bun.serve({
+              hostname: '127.0.0.1',
+              port: 0,
+              fetch: () => {
+                runSync(Ref.update(requests, (count) => count + 1))
+                const body = Stream.make('1\n').pipe(
+                  Stream.concat(
+                    Stream.fromEffect(
+                      Effect.sleep(250).pipe(Effect.andThen(Ref.set(responseFinished, true)), Effect.as('')),
+                    ),
+                  ),
+                  Stream.encodeText,
+                  Stream.toReadableStream,
+                )
+                return new Response(body, {
+                  headers: {
+                    'content-type': 'text/plain; charset=UTF-8',
+                    'x-clickhouse-summary': '{}',
+                  },
+                })
+              },
+            }),
           ),
-        ),
-      ),
-    )
-    expect(requests).toBe(1)
-  } finally {
-    await Effect.runPromise(Effect.forEach(responseFibers, Fiber.interrupt, { discard: true }))
-    server.close()
-    server.closeAllConnections()
-  }
-})
+          (server) => Effect.promise(() => server.stop(true)),
+        )
+        const clickhouseServices = yield* Layer.build(
+          ClickhouseClient.layer({
+            url: server.url.href,
+            username: 'default',
+            password: '',
+            database: 'signal',
+            application: 'bayn-patch-test',
+            request_timeout: 1_000,
+          }).pipe(Layer.provide(NodeHttpClient.layerNodeHttp)),
+        )
+        yield* Effect.gen(function* () {
+          yield* ClickhouseClient.ClickhouseClient
+          expect(yield* Ref.get(responseFinished)).toBe(true)
+          expect(yield* Ref.get(requests)).toBe(1)
+        }).pipe(Effect.provide(clickhouseServices))
+      }),
+    ),
+  ))

--- a/services/bayn/src/composition.test.ts
+++ b/services/bayn/src/composition.test.ts
@@ -16,6 +16,7 @@ import { BrokerEnvironment } from './broker/identity'
 import type { AuthorityRestrictionStoreShape } from './db/execution-store'
 import { makeResearchPaperActivationRequest, makeResearchPaperPlanHash } from './execution/configuration'
 import type { WriterFenceService } from './execution/writer-fence'
+import { utcInstantFromEpochMillis } from './time'
 import { paperEpisodeReceiptFinalizationExpiresAt } from './observe-composition'
 import { initialState } from './runtime-state'
 
@@ -74,7 +75,7 @@ describe('Bayn PAPER receipt retry boundary', () => {
 
   test('keeps retrying through the close lease instead of a fixed attempt count', async () => {
     const startAt = Date.parse('2026-08-03T12:00:00.000Z')
-    const cutoffAt = new Date(startAt + 1_000).toISOString()
+    const cutoffAt = utcInstantFromEpochMillis(startAt + 1_000)
     const observedAt: string[] = []
 
     await Effect.runPromise(
@@ -88,7 +89,7 @@ describe('Bayn PAPER receipt retry boundary', () => {
               return observedAt.length >= 17
             }),
           cutoffAt,
-          new Date(startAt + 17_000).toISOString(),
+          utcInstantFromEpochMillis(startAt + 17_000),
           1_000,
         ).pipe(Effect.forkChild({ startImmediately: true }))
         yield* Effect.yieldNow
@@ -98,12 +99,12 @@ describe('Bayn PAPER receipt retry boundary', () => {
     )
 
     expect(observedAt).toHaveLength(17)
-    expect(observedAt.at(-1)).toBe(new Date(startAt + 17_000).toISOString())
+    expect(observedAt.at(-1)).toBe(utcInstantFromEpochMillis(startAt + 17_000))
   })
 
   test('keeps retrying until close settlement and reconciliation produce a receipt', async () => {
     const startAt = Date.parse('2026-08-03T12:00:00.000Z')
-    const cutoffAt = new Date(startAt + 1_000).toISOString()
+    const cutoffAt = utcInstantFromEpochMillis(startAt + 1_000)
     const observedAt: string[] = []
 
     await Effect.runPromise(
@@ -116,7 +117,7 @@ describe('Bayn PAPER receipt retry boundary', () => {
               return observedAt.length >= 8
             }),
           cutoffAt,
-          new Date(startAt + 8_000).toISOString(),
+          utcInstantFromEpochMillis(startAt + 8_000),
           1_000,
         ).pipe(Effect.forkChild({ startImmediately: true }))
         yield* Effect.yieldNow
@@ -126,13 +127,13 @@ describe('Bayn PAPER receipt retry boundary', () => {
     )
 
     expect(observedAt).toHaveLength(8)
-    expect(observedAt.at(-1)).toBe(new Date(startAt + 8_000).toISOString())
+    expect(observedAt.at(-1)).toBe(utcInstantFromEpochMillis(startAt + 8_000))
   })
 
   test('stops receipt retries at the bounded finalization lease when evidence never becomes eligible', async () => {
     const startAt = Date.parse('2026-08-03T12:00:00.000Z')
-    const cutoffAt = new Date(startAt + 1_000).toISOString()
-    const retryUntilAt = new Date(startAt + 4_000).toISOString()
+    const cutoffAt = utcInstantFromEpochMillis(startAt + 1_000)
+    const retryUntilAt = utcInstantFromEpochMillis(startAt + 4_000)
     const observedAt: string[] = []
 
     await Effect.runPromise(

--- a/services/bayn/src/cycle-runner.test.ts
+++ b/services/bayn/src/cycle-runner.test.ts
@@ -67,7 +67,7 @@ import {
   type ObserveShadowDecisionDocument,
 } from './shadow-decision-contract'
 import { TargetPlanReason, TargetPlanStatus } from './target-planner'
-import { currentUtcInstant } from './time'
+import { currentUtcInstant, utcInstantFromEpochMillis } from './time'
 import { DataFeed, DataSource, PriceAdjustment, PublicationSchema, type InputManifest, type IsoDate } from './types'
 
 type CycleLoopTestOptions<E, ContextR, DecisionR> = Omit<
@@ -828,14 +828,14 @@ describe('autonomous cycle runner', () => {
     }
 
     const decision = makeDecision(active, active.window.submissionOpenAt)
-    const decisionBoundAt = new Date(Date.parse(decision.createdAt) + 1).toISOString()
+    const decisionBoundAt = utcInstantFromEpochMillis(Date.parse(decision.createdAt) + 1)
     const decisionBound: AutonomousCycle = {
       ...active,
       bindings: { ...active.bindings, decisionHash: decision.contentHash },
       stateVersion: active.stateVersion + 1,
       updatedAt: decisionBoundAt,
     }
-    const afterCutoff = new Date(Date.parse(active.window.submissionCutoffAt) + 1).toISOString()
+    const afterCutoff = utcInstantFromEpochMillis(Date.parse(active.window.submissionCutoffAt) + 1)
     expect(
       selectCycleRecovery(
         recoveryState(decisionBound, {

--- a/services/bayn/src/db/capital-grant-algebra.test.ts
+++ b/services/bayn/src/db/capital-grant-algebra.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 
-import { Result } from 'effect'
+import { DateTime, Result } from 'effect'
 
 import { config, fixtureLock, fixtureQualification } from '../app-test-support'
 import { canonicalHashV1 } from '../hash'
@@ -64,8 +64,14 @@ const failureOf = <A>(result: Result.Result<A, CapitalGrantAlgebraFailure>): Cap
 const hash = (value: string): string => canonicalHashV1({ value })
 const accountId = 'paper-authority-account'
 const observeGenerationHash = hash('observe-generation')
-const updatedAt = new Date('2026-07-25T20:00:00.000Z')
-const observedAt = new Date('2026-07-25T20:00:01.000Z')
+const sqlTimestamp = (value: string | number): Date => DateTime.toDateUtc(DateTime.makeUnsafe(value))
+const invalidSqlTimestamp = (): Date => {
+  const value = Object.create(Date.prototype) as Date
+  Object.defineProperty(value, 'getTime', { value: () => Number.NaN })
+  return value
+}
+const updatedAt = sqlTimestamp('2026-07-25T20:00:00.000Z')
+const observedAt = sqlTimestamp('2026-07-25T20:00:01.000Z')
 
 const observeAuthority: AuthorityState = {
   schemaVersion: 'bayn.paper-authority.v1',
@@ -101,7 +107,7 @@ const reconciliation: ExactReconciliationFacts = {
   accountId,
   contentHash: hash('reconciliation-content'),
   status: ReconciliationStatus.Exact,
-  reconciledAt: new Date('2026-07-25T20:00:00.500Z'),
+  reconciledAt: sqlTimestamp('2026-07-25T20:00:00.500Z'),
 }
 
 const researchProof = (): ResearchCapitalGrantProofBinding => {
@@ -144,11 +150,11 @@ const researchProof = (): ResearchCapitalGrantProofBinding => {
 }
 
 const qualificationSeries = (runId: string): QualificationSeries => {
-  const sessionDate = (index: number): `${number}-${number}-${number}` => {
-    const date = new Date('2000-01-01T00:00:00.000Z')
-    date.setUTCDate(date.getUTCDate() + index)
-    return date.toISOString().slice(0, 10) as `${number}-${number}-${number}`
-  }
+  const sessionDate = (index: number): `${number}-${number}-${number}` =>
+    DateTime.makeUnsafe('2000-01-01T00:00:00.000Z').pipe(
+      DateTime.add({ days: index }),
+      DateTime.formatIsoDate,
+    ) as `${number}-${number}-${number}`
   const blockCount = 90
   return {
     schemaVersion: 'bayn.qualification-series.v1',
@@ -283,7 +289,7 @@ describe('PAPER authority algebra', () => {
     expect(successOf(validateCurrentGenerationHistory(observeAuthority, observeHistory))).toEqual(observeHistory)
 
     expect(
-      failureOf(validateAuthorityObservation(observeAuthority, new Date('2026-07-25T19:59:59.999Z'))),
+      failureOf(validateAuthorityObservation(observeAuthority, sqlTimestamp('2026-07-25T19:59:59.999Z'))),
     ).toMatchObject({
       _tag: 'AuthorityUpdateAfterObservation',
       generationHash: observeGenerationHash,
@@ -299,7 +305,7 @@ describe('PAPER authority algebra', () => {
       generationHash: observeGenerationHash,
       authorityVersion: 'NaN',
     })
-    const invalidActivatedAt = new Date(Number.NaN)
+    const invalidActivatedAt = invalidSqlTimestamp()
     const invalidTimestamp = failureOf(
       validateCurrentGenerationHistory(observeAuthority, {
         ...observeHistory,
@@ -550,7 +556,7 @@ describe('PAPER authority algebra', () => {
       failureOf(
         validatePaperGenerationFreshness(
           reconciliation,
-          new Date(reconciliation.reconciledAt.getTime() + config.reconciliationStaleThresholdMs),
+          sqlTimestamp(reconciliation.reconciledAt.getTime() + config.reconciliationStaleThresholdMs),
           config.reconciliationStaleThresholdMs,
         ),
       ),

--- a/services/bayn/src/db/cycle-observability.test.ts
+++ b/services/bayn/src/db/cycle-observability.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 
-import { Result } from 'effect'
+import { DateTime, Result } from 'effect'
 
 import { CycleState, CycleTerminalReason } from '../cycle'
 import { Authority, KillState, ReconciliationStatus } from '../execution/contracts'
@@ -9,6 +9,8 @@ import {
   projectCycleObservabilityRow,
   type CycleObservabilityProjectionRow,
 } from './cycle-observability'
+
+const sqlTimestamp = (value: string): Date => DateTime.toDateUtc(DateTime.makeUnsafe(value))
 
 const emptyRow = (): CycleObservabilityProjectionRow => ({
   current_cycle_id: null,
@@ -72,12 +74,12 @@ const currentCycleRow = (): CycleObservabilityProjectionRow => ({
   current_snapshot_id: '2'.repeat(64),
   current_decision_hash: null,
   current_terminal_reason: null,
-  current_submission_open_at: new Date('2026-07-27T13:00:00.000Z'),
-  current_submission_cutoff_at: new Date('2026-07-27T13:28:00.000Z'),
-  current_execution_open_at: new Date('2026-07-27T13:30:00.000Z'),
-  current_execution_close_at: new Date('2026-07-27T20:00:00.000Z'),
-  current_created_at: new Date('2026-07-24T21:00:00.000Z'),
-  current_updated_at: new Date('2026-07-24T21:01:00.000Z'),
+  current_submission_open_at: sqlTimestamp('2026-07-27T13:00:00.000Z'),
+  current_submission_cutoff_at: sqlTimestamp('2026-07-27T13:28:00.000Z'),
+  current_execution_open_at: sqlTimestamp('2026-07-27T13:30:00.000Z'),
+  current_execution_close_at: sqlTimestamp('2026-07-27T20:00:00.000Z'),
+  current_created_at: sqlTimestamp('2026-07-24T21:00:00.000Z'),
+  current_updated_at: sqlTimestamp('2026-07-24T21:01:00.000Z'),
 })
 
 describe('cycle observability projection', () => {
@@ -115,17 +117,17 @@ describe('cycle observability projection', () => {
       authority_effective: Authority.Observe,
       authority_kill: KillState.Clear,
       authority_reason: null,
-      authority_updated_at: new Date('2026-07-24T21:02:00.000Z'),
+      authority_updated_at: sqlTimestamp('2026-07-24T21:02:00.000Z'),
       reconciliation_id: '4'.repeat(64),
       reconciliation_account_id: 'paper-account-1',
       reconciliation_status: ReconciliationStatus.Exact,
       reconciliation_discrepancy_count: 0,
-      reconciled_at: new Date('2026-07-24T21:03:00.000Z'),
+      reconciled_at: sqlTimestamp('2026-07-24T21:03:00.000Z'),
       reconciliation_covers_latest_mutation: true,
       mutation_event_count: 2,
       unresolved_mutation_count: 1,
-      oldest_unresolved_mutation_at: new Date('2026-07-24T21:04:00.000Z'),
-      latest_mutation_at: new Date('2026-07-24T21:05:00.000Z'),
+      oldest_unresolved_mutation_at: sqlTimestamp('2026-07-24T21:04:00.000Z'),
+      latest_mutation_at: sqlTimestamp('2026-07-24T21:05:00.000Z'),
     }
 
     const projected = projectCycleObservabilityRow(row)
@@ -234,13 +236,13 @@ describe('cycle observability projection', () => {
       last_snapshot_id: '6'.repeat(64),
       last_decision_hash: null,
       last_terminal_reason: CycleTerminalReason.MissedPublication,
-      last_submission_open_at: new Date('2026-07-27T13:00:00.000Z'),
-      last_submission_cutoff_at: new Date('2026-07-27T13:28:00.000Z'),
-      last_execution_open_at: new Date('2026-07-27T13:30:00.000Z'),
-      last_execution_close_at: new Date('2026-07-27T20:00:00.000Z'),
-      last_created_at: new Date('2026-07-24T21:00:00.000Z'),
-      last_updated_at: new Date('2026-07-24T21:10:00.000Z'),
-      last_terminal_at: new Date('2026-07-24T21:10:00.000Z'),
+      last_submission_open_at: sqlTimestamp('2026-07-27T13:00:00.000Z'),
+      last_submission_cutoff_at: sqlTimestamp('2026-07-27T13:28:00.000Z'),
+      last_execution_open_at: sqlTimestamp('2026-07-27T13:30:00.000Z'),
+      last_execution_close_at: sqlTimestamp('2026-07-27T20:00:00.000Z'),
+      last_created_at: sqlTimestamp('2026-07-24T21:00:00.000Z'),
+      last_updated_at: sqlTimestamp('2026-07-24T21:10:00.000Z'),
+      last_terminal_at: sqlTimestamp('2026-07-24T21:10:00.000Z'),
     }
 
     const projected = projectCycleObservabilityRow(row)

--- a/services/bayn/src/db/cycle-store/architecture.test.ts
+++ b/services/bayn/src/db/cycle-store/architecture.test.ts
@@ -1,8 +1,7 @@
 import { describe, expect, test } from 'bun:test'
-import { resolve } from 'node:path'
 
-const serviceRoot = resolve(import.meta.dir, '../../..')
-const architectureLint = resolve(import.meta.dir, 'architecture-lint.mjs')
+const serviceRoot = `${import.meta.dir}/../../..`
+const architectureLint = `${import.meta.dir}/architecture-lint.mjs`
 
 describe('Bayn production architecture', () => {
   test('keeps production modules outside import cycles', async () => {

--- a/services/bayn/src/db/cycle-store/decisions.test.ts
+++ b/services/bayn/src/db/cycle-store/decisions.test.ts
@@ -16,6 +16,7 @@ import {
 import { canonicalHashV1 } from '../../hash'
 import { makeObserveShadowDecisionDocument, type ObserveShadowDecisionDocument } from '../../shadow-decision-contract'
 import { TargetPlanReason, TargetPlanStatus, type BlockedTargetPlanReason } from '../../target-planner'
+import { utcInstantFromEpochMillis } from '../../time'
 import { DataFeed, DataSource, PriceAdjustment, PublicationSchema, type InputManifest } from '../../types'
 import {
   decideAcquire,
@@ -345,7 +346,7 @@ describe('cycle store decisions', () => {
 
   test('uses an authority block for an unbound cycle before its submission deadline', () => {
     const unbound = activeCycle()
-    const beforeSubmissionCutoff = new Date(Date.parse(unbound.window.submissionCutoffAt) - 1).toISOString()
+    const beforeSubmissionCutoff = utcInstantFromEpochMillis(Date.parse(unbound.window.submissionCutoffAt) - 1)
 
     expect(value(decideBlock(unbound, CycleTerminalReason.Authority, beforeSubmissionCutoff))).toMatchObject({
       _tag: 'Persist',

--- a/services/bayn/src/db/cycle-store/integration.test.ts
+++ b/services/bayn/src/db/cycle-store/integration.test.ts
@@ -2,7 +2,19 @@ import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:tes
 
 import { NodeServices } from '@effect/platform-node'
 import { PgClient, PgMigrator } from '@effect/sql-pg'
-import { Cause, DateTime, Deferred, Effect, Exit, Layer, ManagedRuntime, Option, Redacted, Result, Schema } from 'effect'
+import {
+  Cause,
+  DateTime,
+  Deferred,
+  Effect,
+  Exit,
+  Layer,
+  ManagedRuntime,
+  Option,
+  Redacted,
+  Result,
+  Schema,
+} from 'effect'
 import { TestClock } from 'effect/testing'
 
 import {

--- a/services/bayn/src/db/cycle-store/integration.test.ts
+++ b/services/bayn/src/db/cycle-store/integration.test.ts
@@ -2,7 +2,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:tes
 
 import { NodeServices } from '@effect/platform-node'
 import { PgClient, PgMigrator } from '@effect/sql-pg'
-import { Cause, Deferred, Effect, Exit, Layer, ManagedRuntime, Option, Redacted, Result, Schema } from 'effect'
+import { Cause, DateTime, Deferred, Effect, Exit, Layer, ManagedRuntime, Option, Redacted, Result, Schema } from 'effect'
 import { TestClock } from 'effect/testing'
 
 import {
@@ -79,6 +79,7 @@ import { makeRiskBalancedTrendDefinition } from '../../strategy'
 import { TargetPlanReason, TargetPlanStatus } from '../../target-planner'
 import { fixtureProtocol, makeSnapshot, makeTestProvenance } from '../../test-fixtures'
 import { baynTestPostgresUrl, isGithubActions } from '../../test-environment.test-support'
+import { utcDateFromEpochMillis, utcInstantFromEpochMillis } from '../../time'
 import {
   DataFeed,
   DataSource,
@@ -295,11 +296,11 @@ const makeAutonomousRuntime = () =>
 
 const weekdaySessions = (start: IsoDate, count: number): readonly IsoDate[] => {
   const sessions: IsoDate[] = []
-  const cursor = new Date(`${start}T00:00:00.000Z`)
+  let cursor = DateTime.makeUnsafe(`${start}T00:00:00.000Z`)
   while (sessions.length < count) {
-    const day = cursor.getUTCDay()
-    if (day !== 0 && day !== 6) sessions.push(cursor.toISOString().slice(0, 10) as IsoDate)
-    cursor.setUTCDate(cursor.getUTCDate() + 1)
+    const day = DateTime.getPartUtc(cursor, 'weekDay')
+    if (day !== 0 && day !== 6) sessions.push(DateTime.formatIsoDate(cursor) as IsoDate)
+    cursor = DateTime.add(cursor, { days: 1 })
   }
   return sessions
 }
@@ -894,17 +895,17 @@ const monthEndExecutionWindow = (
   readonly snapshotBoundAt: string
   readonly signalSessionDate: IsoDate
 } => {
-  const evaluated = new Date(evaluatedAt)
-  const execution = new Date(evaluated.getTime() + 44 * 60_000)
-  const signal = new Date(Date.UTC(execution.getUTCFullYear(), execution.getUTCMonth(), 0))
-  while (signal.getUTCDay() === 0 || signal.getUTCDay() === 6) signal.setUTCDate(signal.getUTCDate() - 1)
-  const executionSessionDate = execution.toISOString().slice(0, 10) as IsoDate
+  const evaluated = DateTime.makeUnsafe(evaluatedAt)
+  const execution = DateTime.add(evaluated, { minutes: 44 })
+  let signal = DateTime.subtract(DateTime.startOf(execution, 'month'), { days: 1 })
+  while ([0, 6].includes(DateTime.getPartUtc(signal, 'weekDay'))) signal = DateTime.subtract(signal, { days: 1 })
+  const executionSessionDate = DateTime.formatIsoDate(execution) as IsoDate
   return {
     evaluationAt: evaluatedAt,
-    executionOpenAt: execution.toISOString(),
+    executionOpenAt: DateTime.formatIso(execution),
     executionSessionDate,
-    snapshotBoundAt: new Date(evaluated.getTime() - 2 * 60_000).toISOString(),
-    signalSessionDate: signal.toISOString().slice(0, 10) as IsoDate,
+    snapshotBoundAt: DateTime.formatIso(DateTime.subtract(evaluated, { minutes: 2 })),
+    signalSessionDate: DateTime.formatIsoDate(signal) as IsoDate,
   }
 }
 
@@ -1254,7 +1255,7 @@ const plannedPaperSnapshot = (
   const sessionOffsetMs =
     Date.parse(`${draft.identity.signalSessionDate}T00:00:00.000Z`) - Date.parse(`${sourceLastSession}T00:00:00.000Z`)
   const shiftSession = (session: IsoDate): IsoDate =>
-    new Date(Date.parse(`${session}T00:00:00.000Z`) + sessionOffsetMs).toISOString().slice(0, 10) as IsoDate
+    utcDateFromEpochMillis(Date.parse(`${session}T00:00:00.000Z`) + sessionOffsetMs) as IsoDate
   const sessions = sourceSessions.map(shiftSession)
   const firstSession = sessions.at(0)
   const lastSession = sessions.at(-1)
@@ -1341,7 +1342,7 @@ const plannedPaperBrokerRead = (draft: CycleDraft, observedAt = decisionAt): Bro
     orderByClientId: () => unused,
     fillActivities: () => unused,
     marketCalendar: (query) => {
-      const signalOpenAt = new Date(Date.parse(draft.window.signalCloseAt) - 6.5 * 60 * 60 * 1_000).toISOString()
+      const signalOpenAt = utcInstantFromEpochMillis(Date.parse(draft.window.signalCloseAt) - 6.5 * 60 * 60 * 1_000)
       const material = {
         schemaVersion: 'bayn.alpaca-market-calendar-observation.v1' as const,
         source: 'alpaca-v2-calendar' as const,
@@ -1498,9 +1499,9 @@ const insertQualifiedPaperLineage = (
       cycleId: document.bindings.cycleId,
       decisionHash: document.contentHash,
     })
-    const intentCreatedAt = new Date(Date.parse(document.createdAt) - 1_000).toISOString()
-    const submitStartedAt = new Date(Date.parse(document.createdAt) + 1).toISOString()
-    const deniedAt = new Date(Date.parse(document.createdAt) + 2).toISOString()
+    const intentCreatedAt = utcInstantFromEpochMillis(Date.parse(document.createdAt) - 1_000)
+    const submitStartedAt = utcInstantFromEpochMillis(Date.parse(document.createdAt) + 1)
+    const deniedAt = utcInstantFromEpochMillis(Date.parse(document.createdAt) + 2)
     const mutationId = canonicalHashV1({ intentId: intent.intentId, operation: 'SUBMIT' })
     const requestHash = canonicalHashV1({ intentId: intent.intentId, request: 'pretransmit-denied' })
 
@@ -1879,7 +1880,7 @@ const insertSupersedingObserveGeneration = (document: PaperDecisionDocument) =>
         accountId: document.bindings.accountId,
       }),
     )
-    const activatedAt = new Date(Date.parse(document.createdAt) + 10_000).toISOString()
+    const activatedAt = utcInstantFromEpochMillis(Date.parse(document.createdAt) + 10_000)
     yield* sql`
       INSERT INTO authority_generations (
         generation_hash,
@@ -1940,10 +1941,10 @@ const insertFilledPlannedPaperIntent = (
       },
     )
     const sql = yield* PgClient.PgClient
-    const intentCreatedAt = new Date(Date.parse(document.createdAt) - 1).toISOString()
-    const submitStartedAt = new Date(Date.parse(document.createdAt) + 1).toISOString()
-    const acceptedAt = new Date(Date.parse(document.createdAt) + 2).toISOString()
-    const filledAt = new Date(Date.parse(document.createdAt) + 3).toISOString()
+    const intentCreatedAt = utcInstantFromEpochMillis(Date.parse(document.createdAt) - 1)
+    const submitStartedAt = utcInstantFromEpochMillis(Date.parse(document.createdAt) + 1)
+    const acceptedAt = utcInstantFromEpochMillis(Date.parse(document.createdAt) + 2)
+    const filledAt = utcInstantFromEpochMillis(Date.parse(document.createdAt) + 3)
     const mutationId = canonicalHashV1({ intentId: intent.intentId, operation: 'SUBMIT' })
     const requestHash = canonicalHashV1({ intentId: intent.intentId, request: 'filled-completion' })
     const brokerOrderId = `filled-${intent.intentId.slice(0, 24)}`
@@ -2083,11 +2084,11 @@ const insertUnfinishedPlannedPaperMutation = (document: PaperDecisionDocument, f
       },
     )
     const sql = yield* PgClient.PgClient
-    const intentCreatedAt = new Date(Date.parse(document.createdAt) - 1).toISOString()
-    const submitStartedAt = new Date(Date.parse(document.createdAt) + 1).toISOString()
-    const submitOutcomeAt = new Date(Date.parse(document.createdAt) + 2).toISOString()
-    const cancelStartedAt = new Date(Date.parse(document.createdAt) + 3).toISOString()
-    const cancelOutcomeAt = new Date(Date.parse(document.createdAt) + 4).toISOString()
+    const intentCreatedAt = utcInstantFromEpochMillis(Date.parse(document.createdAt) - 1)
+    const submitStartedAt = utcInstantFromEpochMillis(Date.parse(document.createdAt) + 1)
+    const submitOutcomeAt = utcInstantFromEpochMillis(Date.parse(document.createdAt) + 2)
+    const cancelStartedAt = utcInstantFromEpochMillis(Date.parse(document.createdAt) + 3)
+    const cancelOutcomeAt = utcInstantFromEpochMillis(Date.parse(document.createdAt) + 4)
     const submitMutationId = canonicalHashV1({ intentId: intent.intentId, operation: 'SUBMIT' })
     const cancelMutationId = canonicalHashV1({ intentId: intent.intentId, operation: 'CANCEL' })
     const submitRequestHash = canonicalHashV1({ intentId: intent.intentId, fixture, operation: 'SUBMIT' })
@@ -2237,8 +2238,9 @@ const settleSupersededMutation = (
     const mutationId = canonicalHashV1({ intentId, operation })
     const requestHash = canonicalHashV1({ intentId, fixture, operation })
     const brokerOrderId = `superseded-${intentId.slice(0, 24)}`
-    const recoveredAt = new Date(Date.parse(document.createdAt) + 11_000).toISOString()
-    const terminalAt = fixture === 'submit-unknown' ? new Date(Date.parse(recoveredAt) + 1).toISOString() : recoveredAt
+    const recoveredAt = utcInstantFromEpochMillis(Date.parse(document.createdAt) + 11_000)
+    const terminalAt =
+      fixture === 'submit-unknown' ? utcInstantFromEpochMillis(Date.parse(recoveredAt) + 1) : recoveredAt
     const terminalOutcome = operation === 'CANCEL' ? 'CANCELED' : 'FILLED'
     yield* sql.withTransaction(
       Effect.gen(function* () {
@@ -3257,8 +3259,8 @@ describePostgres('PostgreSQL autonomous cycle store', () => {
 
         const riskExpiresAt = planned.document.deltaRisk[0]?.evaluation.decision.expiresAt
         if (riskExpiresAt === undefined) return yield* Effect.die(new Error('PAPER risk expiry is missing'))
-        const beforeRiskExpiry = new Date(Date.parse(riskExpiresAt) - 1).toISOString()
-        const beforeSubmissionCutoff = new Date(Date.parse(draft.window.submissionCutoffAt) - 1).toISOString()
+        const beforeRiskExpiry = utcInstantFromEpochMillis(Date.parse(riskExpiresAt) - 1)
+        const beforeSubmissionCutoff = utcInstantFromEpochMillis(Date.parse(draft.window.submissionCutoffAt) - 1)
         const sql = yield* PgClient.PgClient
         const directEarlyRisk = yield* Effect.exit(sql`
           UPDATE autonomous_cycles
@@ -3474,8 +3476,8 @@ describePostgres('PostgreSQL autonomous cycle store', () => {
             executionSessionDate,
             signalSessionDate,
           })
-          const acquisitionAt = new Date(Date.parse(draft.window.signalCloseAt) + 60_000).toISOString()
-          const activatedAt = new Date(Date.parse(snapshotBoundAt) + 1_000).toISOString()
+          const acquisitionAt = utcInstantFromEpochMillis(Date.parse(draft.window.signalCloseAt) + 60_000)
+          const activatedAt = utcInstantFromEpochMillis(Date.parse(snapshotBoundAt) + 1_000)
           const manifest = makeInputManifest(snapshotA, {
             asOfSession: signalSessionDate,
             finalizedAt: snapshotBoundAt,
@@ -3498,9 +3500,10 @@ describePostgres('PostgreSQL autonomous cycle store', () => {
           yield* store.bindDecision(draft.identity.cycleId, planned.document, evaluatedAt)
           const successor = yield* insertSupersedingObserveGeneration(planned.document)
           const rotatedQualificationRunId = 'e'.repeat(64)
-          const earlierSignalDateValue = new Date(`${signalSessionDate}T00:00:00.000Z`)
-          earlierSignalDateValue.setUTCDate(earlierSignalDateValue.getUTCDate() - 1)
-          const earlierSignalSessionDate = earlierSignalDateValue.toISOString().slice(0, 10) as IsoDate
+          const earlierSignalSessionDate = DateTime.makeUnsafe(`${signalSessionDate}T00:00:00.000Z`).pipe(
+            DateTime.subtract({ days: 1 }),
+            DateTime.formatIsoDate,
+          ) as IsoDate
           const currentDraft = makeDraft(draft.identity.accountId, {
             executionCloseAt: `${signalSessionDate}T23:59:59.999Z`,
             executionOpenAt: `${signalSessionDate}T20:00:00.000Z`,
@@ -3511,7 +3514,7 @@ describePostgres('PostgreSQL autonomous cycle store', () => {
           })
           yield* store.acquire(
             currentDraft,
-            new Date(Date.parse(currentDraft.window.signalCloseAt) + 60_000).toISOString(),
+            utcInstantFromEpochMillis(Date.parse(currentDraft.window.signalCloseAt) + 60_000),
           )
           const recoveryScope = {
             qualificationRunId: rotatedQualificationRunId,
@@ -3632,8 +3635,8 @@ describePostgres('PostgreSQL autonomous cycle store', () => {
           executionSessionDate,
           signalSessionDate,
         })
-        const acquisitionAt = new Date(Date.parse(draft.window.signalCloseAt) + 60_000).toISOString()
-        const activatedAt = new Date(Date.parse(snapshotBoundAt) + 1_000).toISOString()
+        const acquisitionAt = utcInstantFromEpochMillis(Date.parse(draft.window.signalCloseAt) + 60_000)
+        const activatedAt = utcInstantFromEpochMillis(Date.parse(snapshotBoundAt) + 1_000)
         const manifest = makeInputManifest(snapshotA, {
           asOfSession: signalSessionDate,
           finalizedAt: snapshotBoundAt,
@@ -3665,8 +3668,8 @@ describePostgres('PostgreSQL autonomous cycle store', () => {
           operation: 'CANCEL',
         })
         const brokerOrderId = `superseded-${unfinished.intent.intentId.slice(0, 24)}`
-        const cancelStartedAt = new Date(Date.parse(planned.document.createdAt) + 3).toISOString()
-        const cancelUnknownAt = new Date(Date.parse(planned.document.createdAt) + 4).toISOString()
+        const cancelStartedAt = utcInstantFromEpochMillis(Date.parse(planned.document.createdAt) + 3)
+        const cancelUnknownAt = utcInstantFromEpochMillis(Date.parse(planned.document.createdAt) + 4)
         yield* sql`
           INSERT INTO mutation_events (
             event_id, schema_version, mutation_id, intent_id, sequence,
@@ -3683,7 +3686,7 @@ describePostgres('PostgreSQL autonomous cycle store', () => {
             'CANCEL', 'CANCEL_UNKNOWN', ${cancelRequestHash}, 1000, ${brokerOrderId}, ${cancelUnknownAt}
           )
         `
-        const terminalAt = new Date(Date.parse(planned.document.createdAt) + 5).toISOString()
+        const terminalAt = utcInstantFromEpochMillis(Date.parse(planned.document.createdAt) + 5)
         yield* sql`
           UPDATE intents
           SET
@@ -3697,7 +3700,7 @@ describePostgres('PostgreSQL autonomous cycle store', () => {
           store.block(draft.identity.cycleId, CycleTerminalReason.Risk, terminalAt),
         )
 
-        const recoveryAt = new Date(Date.parse(planned.document.createdAt) + 11_000).toISOString()
+        const recoveryAt = utcInstantFromEpochMillis(Date.parse(planned.document.createdAt) + 11_000)
         yield* sql`
           INSERT INTO mutation_events (
             event_id, schema_version, mutation_id, intent_id, sequence,
@@ -3877,8 +3880,8 @@ describePostgres('PostgreSQL autonomous cycle store', () => {
           executionSessionDate,
           signalSessionDate,
         })
-        const acquisitionAt = new Date(Date.parse(draft.window.signalCloseAt) + 60_000).toISOString()
-        const activatedAt = new Date(Date.parse(snapshotBoundAt) + 1_000).toISOString()
+        const acquisitionAt = utcInstantFromEpochMillis(Date.parse(draft.window.signalCloseAt) + 60_000)
+        const activatedAt = utcInstantFromEpochMillis(Date.parse(snapshotBoundAt) + 1_000)
         const manifest = makeInputManifest(snapshotB, {
           asOfSession: signalSessionDate,
           finalizedAt: snapshotBoundAt,
@@ -3902,7 +3905,7 @@ describePostgres('PostgreSQL autonomous cycle store', () => {
         yield* insertReconciliation(planned.reconciliation)
         yield* store.bindDecision(draft.identity.cycleId, planned.document, evaluatedAt)
         const denied = yield* insertQualifiedPaperLineage(planned.document, { deniedIntent: true })
-        const prematureAt = new Date(Date.parse(denied.deniedAt) - 1).toISOString()
+        const prematureAt = utcInstantFromEpochMillis(Date.parse(denied.deniedAt) - 1)
 
         const directPremature = yield* Effect.exit(sql`
           UPDATE autonomous_cycles
@@ -4013,8 +4016,8 @@ describePostgres('PostgreSQL autonomous cycle store', () => {
           executionSessionDate,
           signalSessionDate,
         })
-        const acquisitionAt = new Date(Date.parse(draft.window.signalCloseAt) + 60_000).toISOString()
-        const activatedAt = new Date(Date.parse(snapshotBoundAt) + 1_000).toISOString()
+        const acquisitionAt = utcInstantFromEpochMillis(Date.parse(draft.window.signalCloseAt) + 60_000)
+        const activatedAt = utcInstantFromEpochMillis(Date.parse(snapshotBoundAt) + 1_000)
         const manifest = makeInputManifest(snapshotB, {
           asOfSession: signalSessionDate,
           finalizedAt: snapshotBoundAt,
@@ -4053,14 +4056,14 @@ describePostgres('PostgreSQL autonomous cycle store', () => {
         )
 
         const filled = yield* insertFilledPlannedPaperIntent(planned.document, 'started')
-        const unresolvedReconciledAt = new Date(Date.parse(filled.filledAt) + 1).toISOString()
+        const unresolvedReconciledAt = utcInstantFromEpochMillis(Date.parse(filled.filledAt) + 1)
         yield* insertReconciliation(plannedPaperReconciliation(activated.cycle, unresolvedReconciledAt))
         const unresolvedStarted = yield* Effect.exit(
           store.finish(draft.identity.cycleId, CycleState.Completed, unresolvedReconciledAt),
         )
-        const settledAt = new Date(Date.parse(unresolvedReconciledAt) + 1).toISOString()
+        const settledAt = utcInstantFromEpochMillis(Date.parse(unresolvedReconciledAt) + 1)
         yield* settleStartedPaperSubmit(filled, settledAt)
-        const reconciledAt = new Date(Date.parse(settledAt) + 1).toISOString()
+        const reconciledAt = utcInstantFromEpochMillis(Date.parse(settledAt) + 1)
         yield* insertReconciliation(plannedPaperReconciliation(activated.cycle, reconciledAt))
         const completed = yield* store.finish(draft.identity.cycleId, CycleState.Completed, reconciledAt)
         const replayed = yield* store.finish(draft.identity.cycleId, CycleState.Completed, reconciledAt)
@@ -4129,7 +4132,7 @@ describePostgres('PostgreSQL autonomous cycle store', () => {
   test('finishes the exact no-trade decision once after cutoff and preserves terminal history across runtimes', async () => {
     const draft = makeDraft()
     const shadowDecision = makeShadowDecision(draft, snapshotA)
-    const afterCutoff = new Date(Date.parse(draft.window.submissionCutoffAt) + 1).toISOString()
+    const afterCutoff = utcInstantFromEpochMillis(Date.parse(draft.window.submissionCutoffAt) + 1)
     const result = await runtime.runPromise(
       Effect.gen(function* () {
         const store = yield* CycleStore
@@ -4169,7 +4172,7 @@ describePostgres('PostgreSQL autonomous cycle store', () => {
         )
         const directUpdate = yield* Effect.exit(sql`
           UPDATE autonomous_cycles
-          SET updated_at = ${new Date(Date.parse(afterCutoff) + 1).toISOString()}, state_version = state_version + 1
+          SET updated_at = ${utcInstantFromEpochMillis(Date.parse(afterCutoff) + 1)}, state_version = state_version + 1
           WHERE cycle_id = ${draft.identity.cycleId}
         `)
         const directDelete = yield* Effect.exit(sql`
@@ -4369,7 +4372,7 @@ describePostgres('PostgreSQL autonomous cycle store', () => {
         yield* store.bindSnapshot(afterCutoffDraft.identity.cycleId, makeInputManifest(snapshotA), snapshotAt)
         const activationAfterCutoff = yield* store.activate(
           afterCutoffDraft.identity.cycleId,
-          new Date(Date.parse(afterCutoffDraft.window.submissionCutoffAt) + 1).toISOString(),
+          utcInstantFromEpochMillis(Date.parse(afterCutoffDraft.window.submissionCutoffAt) + 1),
         )
 
         yield* store.acquire(decisionDraft, acquireAt)

--- a/services/bayn/src/db/execution-store/decisions.test.ts
+++ b/services/bayn/src/db/execution-store/decisions.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 
-import { Result } from 'effect'
+import { DateTime, Result } from 'effect'
 
 import { prepareAccounting } from '../../accounting/domain'
 import type { BrokerEventInput, PositionEventInput, PositionSnapshotInput } from '../../broker/observations'
@@ -29,6 +29,12 @@ const accountId = 'paper-account-1'
 const occurredAt = '2026-07-22T15:30:00.000Z'
 const observedAt = '2026-07-22T15:30:01.000Z'
 const hash = (value: string): string => canonicalHashV1({ value })
+const sqlTimestamp = (value: string): Date => DateTime.toDateUtc(DateTime.makeUnsafe(value))
+const invalidSqlTimestamp = (): Date => {
+  const value = Object.create(Date.prototype) as Date
+  Object.defineProperty(value, 'getTime', { value: () => Number.NaN })
+  return value
+}
 
 const value = <A, E>(result: Result.Result<A, E>): A => {
   expect(Result.isSuccess(result)).toBe(true)
@@ -279,7 +285,7 @@ describe('ExecutionStore decisions', () => {
       schema_version: 'bayn.paper-position-snapshot.v1',
       account_id: input.accountId,
       source_hash: input.sourceHash,
-      observed_at: new Date(input.observedAt),
+      observed_at: sqlTimestamp(input.observedAt),
       position_count: plan.eventIds.length,
       content_hash: plan.contentHash,
     }
@@ -301,7 +307,7 @@ describe('ExecutionStore decisions', () => {
     })
     expect(failure(finishPositionSnapshot(plan, [], true))).toMatchObject({ failure: 'conflict' })
     expect(
-      failure(validateStoredPositionSnapshot(input, plan, [{ ...stored, observed_at: new Date(Number.NaN) }])),
+      failure(validateStoredPositionSnapshot(input, plan, [{ ...stored, observed_at: invalidSqlTimestamp() }])),
     ).toEqual({
       failure: 'invariant',
       message: 'valuation timestamp evidence is invalid',
@@ -323,7 +329,7 @@ describe('ExecutionStore decisions', () => {
           schema_version: 'bayn.paper-position-snapshot.v1',
           account_id: accountId,
           source_hash: input.sourceHash,
-          observed_at: new Date(observedAt),
+          observed_at: sqlTimestamp(observedAt),
           position_count: 2,
           content_hash: plan.contentHash,
         },
@@ -335,7 +341,7 @@ describe('ExecutionStore decisions', () => {
       source_event_id: position.sourceEventId,
       symbol: position.position.symbol,
       market_value_micros: position.position.marketValueMicros,
-      observed_at: new Date(observedAt),
+      observed_at: sqlTimestamp(observedAt),
     }))
     const valuation = value(
       planValuation(
@@ -344,7 +350,7 @@ describe('ExecutionStore decisions', () => {
           event_id: hash('account-event'),
           account_id: accountId,
           cash_micros: '1000000000',
-          observed_at: new Date(observedAt),
+          observed_at: sqlTimestamp(observedAt),
         },
         snapshot,
         rows,
@@ -370,7 +376,7 @@ describe('ExecutionStore decisions', () => {
             event_id: hash('account-event'),
             account_id: accountId,
             cash_micros: 'not-an-integer',
-            observed_at: new Date(observedAt),
+            observed_at: sqlTimestamp(observedAt),
           },
           snapshot,
           rows,
@@ -394,7 +400,7 @@ describe('ExecutionStore decisions', () => {
             event_id: hash('account-event'),
             account_id: accountId,
             cash_micros: '1000000000',
-            observed_at: new Date(observedAt),
+            observed_at: sqlTimestamp(observedAt),
           },
           snapshot,
           [{ ...rows[0]!, market_value_micros: 'invalid-market-value' }, rows[1]!],
@@ -420,7 +426,7 @@ describe('ExecutionStore decisions', () => {
             event_id: hash('account-event'),
             account_id: accountId,
             cash_micros: '1000000000',
-            observed_at: new Date(Number.NaN),
+            observed_at: invalidSqlTimestamp(),
           },
           snapshot,
           rows,

--- a/services/bayn/src/db/paper-store.integration.test.ts
+++ b/services/bayn/src/db/paper-store.integration.test.ts
@@ -4,7 +4,20 @@ import { beforeAll, beforeEach, describe, expect, test } from 'bun:test'
 
 import { NodeServices } from '@effect/platform-node'
 import { PgClient } from '@effect/sql-pg'
-import { Cause, Deferred, Duration, Effect, Exit, Fiber, Layer, ManagedRuntime, Redacted, Result, Schema } from 'effect'
+import {
+  Cause,
+  DateTime,
+  Deferred,
+  Duration,
+  Effect,
+  Exit,
+  Fiber,
+  Layer,
+  ManagedRuntime,
+  Redacted,
+  Result,
+  Schema,
+} from 'effect'
 
 import type { RuntimeConfig } from '../config'
 import { orderRequestBody } from '../broker/alpaca-mutations'
@@ -157,11 +170,11 @@ const qualificationPolicy = (name: string) =>
   )
 
 const qualificationSeries = (runId: string): QualificationSeries => {
-  const sessionDate = (index: number): `${number}-${number}-${number}` => {
-    const date = new Date('2000-01-01T00:00:00.000Z')
-    date.setUTCDate(date.getUTCDate() + index)
-    return date.toISOString().slice(0, 10) as `${number}-${number}-${number}`
-  }
+  const sessionDate = (index: number): `${number}-${number}-${number}` =>
+    DateTime.makeUnsafe('2000-01-01T00:00:00.000Z').pipe(
+      DateTime.add({ days: index }),
+      DateTime.formatIsoDate,
+    ) as `${number}-${number}-${number}`
   const blockCount = 90
   return {
     schemaVersion: 'bayn.qualification-series.v1',
@@ -4413,9 +4426,9 @@ describePostgres('paper accounting persistence', () => {
             )
           `
           const activationTime = Date.parse(activated.updatedAt)
-          const mismatchObservedAt = new Date(activationTime + 1).toISOString()
-          const ongoingObservedAt = new Date(activationTime + 2).toISOString()
-          const resolvedObservedAt = new Date(activationTime + 3).toISOString()
+          const mismatchObservedAt = DateTime.formatIso(DateTime.makeUnsafe(activationTime + 1))
+          const ongoingObservedAt = DateTime.formatIso(DateTime.makeUnsafe(activationTime + 2))
+          const resolvedObservedAt = DateTime.formatIso(DateTime.makeUnsafe(activationTime + 3))
 
           const mismatchInput = {
             ...setup.baseline,

--- a/services/bayn/src/db/reconciliation-algebra.test.ts
+++ b/services/bayn/src/db/reconciliation-algebra.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 
-import { Result } from 'effect'
+import { DateTime, Result } from 'effect'
 
 import { prepareAccounting } from '../accounting/domain'
 import { MutationOperation, historicalMarketOrderRequestBody, orderRequestBody } from '../broker/alpaca-mutations'
@@ -35,6 +35,13 @@ import {
   type ReconciliationAlgebraFailure,
   type RiskContextRow,
 } from './reconciliation-algebra'
+
+const sqlTimestamp = (value: string): Date => DateTime.toDateUtc(DateTime.makeUnsafe(value))
+const invalidSqlTimestamp = (): Date => {
+  const value = Object.create(Date.prototype) as Date
+  Object.defineProperty(value, 'getTime', { value: () => Number.NaN })
+  return value
+}
 
 const successOf = <A>(result: Result.Result<A, ReconciliationAlgebraFailure>): A => {
   expect(Result.isSuccess(result)).toBe(true)
@@ -600,8 +607,8 @@ describe('PostgreSQL reconciliation algebra', () => {
       peakEquityMicros: '1000000000',
     })
 
-    const updatedAt = new Date('2026-07-22T15:30:01.000Z')
-    const observedAuthorityAt = new Date('2026-07-22T15:30:02.000Z')
+    const updatedAt = sqlTimestamp('2026-07-22T15:30:01.000Z')
+    const observedAuthorityAt = sqlTimestamp('2026-07-22T15:30:02.000Z')
     const authority = successOf(
       riskContextFromRow(
         {
@@ -674,8 +681,8 @@ describe('PostgreSQL reconciliation algebra', () => {
           authority_effective: Authority.Paper,
           authority_kill: KillState.Clear,
           authority_version: '1',
-          authority_updated_at: new Date('2026-07-22T15:30:01.000Z'),
-          authority_observed_at: new Date('2026-07-22T15:30:02.000Z'),
+          authority_updated_at: sqlTimestamp('2026-07-22T15:30:01.000Z'),
+          authority_observed_at: sqlTimestamp('2026-07-22T15:30:02.000Z'),
         },
         0,
       ),
@@ -701,8 +708,8 @@ describe('PostgreSQL reconciliation algebra', () => {
           authority_effective: Authority.Observe,
           authority_kill: KillState.Clear,
           authority_version: '1',
-          authority_updated_at: new Date(Number.NaN),
-          authority_observed_at: new Date('2026-07-22T15:30:02.000Z'),
+          authority_updated_at: invalidSqlTimestamp(),
+          authority_observed_at: sqlTimestamp('2026-07-22T15:30:02.000Z'),
         },
         0,
       ),

--- a/services/bayn/src/effect-runtime-compatibility.test.ts
+++ b/services/bayn/src/effect-runtime-compatibility.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 
-import { Effect, Fiber, Option, Result, Schema, Semaphore } from 'effect'
+import { DateTime, Effect, Fiber, Option, Result, Schema, Semaphore } from 'effect'
 
 describe('Effect beta.102 runtime compatibility', () => {
   test('keeps deeply nested JSON validation stack safe', () => {
@@ -11,12 +11,14 @@ describe('Effect beta.102 runtime compatibility', () => {
   })
 
   test('decodes and encodes valid dates while rejecting invalid dates', () => {
-    const date = new Date('2026-07-27T12:34:56.789Z')
+    const date = DateTime.toDateUtc(DateTime.makeUnsafe('2026-07-27T12:34:56.789Z'))
+    const invalidDate = Object.create(Date.prototype) as Date
+    Object.defineProperty(invalidDate, 'getTime', { value: () => Number.NaN })
 
     expect(Schema.decodeResult(Schema.Date)(date)).toEqual(Result.succeed(date))
     expect(Schema.encodeUnknownResult(Schema.Date)(date)).toEqual(Result.succeed(date))
-    expect(Result.isFailure(Schema.decodeResult(Schema.Date)(new Date(Number.NaN)))).toBe(true)
-    expect(Result.isFailure(Schema.encodeResult(Schema.Date)(new Date(Number.NaN)))).toBe(true)
+    expect(Result.isFailure(Schema.decodeResult(Schema.Date)(invalidDate))).toBe(true)
+    expect(Result.isFailure(Schema.encodeResult(Schema.Date)(invalidDate))).toBe(true)
     expect(Result.isFailure(Schema.decodeResult(Schema.DateFromString)('not-a-date'))).toBe(true)
     expect(Result.isFailure(Schema.decodeResult(Schema.DateFromMillis)(8_640_000_000_000_001))).toBe(true)
   })

--- a/services/bayn/src/execution-prepare/execution-prepare.integration.test.ts
+++ b/services/bayn/src/execution-prepare/execution-prepare.integration.test.ts
@@ -4,7 +4,7 @@ import { beforeAll, beforeEach, describe, expect, test } from 'bun:test'
 
 import { NodeServices } from '@effect/platform-node'
 import { PgClient } from '@effect/sql-pg'
-import { Effect, Layer, ManagedRuntime, Redacted, Result, Schema } from 'effect'
+import { DateTime, Effect, Layer, ManagedRuntime, Redacted, Result, Schema } from 'effect'
 
 import { BrokerProvider, alpacaSandboxBaseUrl } from '../broker/alpaca'
 import { makeBrokerIdentity } from '../broker/identity'
@@ -165,7 +165,7 @@ const qualificationPolicy = (name: string) =>
 
 const qualificationSeries = (runId: string): QualificationSeries => {
   const sessionDate = (index: number): `${number}-${number}-${number}` => {
-    const date = new Date('2000-01-01T00:00:00.000Z')
+    const date = DateTime.toDateUtc(DateTime.makeUnsafe('2000-01-01T00:00:00.000Z'))
     date.setUTCDate(date.getUTCDate() + index)
     return date.toISOString().slice(0, 10) as `${number}-${number}-${number}`
   }

--- a/services/bayn/src/execution/coordinator.test.ts
+++ b/services/bayn/src/execution/coordinator.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test'
 
 import { Cause, Clock, Duration, Effect, Exit, Fiber, Option, Result } from 'effect'
 import { TestClock } from 'effect/testing'
+import { utcInstantFromEpochMillis } from '../time'
 
 import {
   BrokerMutation,
@@ -1513,7 +1514,7 @@ const makeHarness = (options: HarnessOptions = {}) => {
           retryable: false,
         })
       }
-      const observedAt = new Date(yield* Clock.currentTimeMillis).toISOString()
+      const observedAt = utcInstantFromEpochMillis(yield* Clock.currentTimeMillis)
       if (options.notFoundOnce === true && lookupCalls === 1) {
         return yield* new BrokerReadError({
           operation: 'order-by-client-id',

--- a/services/bayn/src/forward-performance/program.test.ts
+++ b/services/bayn/src/forward-performance/program.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'bun:test'
 
 import { ClickhouseClient } from '@effect/sql-clickhouse'
 import { PgClient } from '@effect/sql-pg'
-import { Effect, Layer, Redacted, Result } from 'effect'
+import { DateTime, Effect, Layer, Redacted, Result } from 'effect'
 
 import { prepareAccounting } from '../accounting/domain'
 import { makeBrokerIdentity, BrokerEnvironment, BrokerProvider } from '../broker/identity'
@@ -131,7 +131,7 @@ const makeReadOnlySql = (observation: SqlObservation, fixture: SqlFixture = {}):
                 ]
               : []),
           ],
-          reconciled_at: new Date('2026-07-20T21:01:00.000Z'),
+          reconciled_at: DateTime.toDateUtc(DateTime.makeUnsafe('2026-07-20T21:01:00.000Z')),
         },
       ])
     }
@@ -140,17 +140,17 @@ const makeReadOnlySql = (observation: SqlObservation, fixture: SqlFixture = {}):
         {
           reconciliation_id: hash('a'),
           reconciliation_content_hash: hash('b'),
-          reconciled_at: new Date('2026-07-20T21:01:00.000Z'),
+          reconciled_at: DateTime.toDateUtc(DateTime.makeUnsafe('2026-07-20T21:01:00.000Z')),
           baseline_account_event_id: hash('1'),
-          baseline_observed_at: new Date('2026-07-19T13:00:00.000Z'),
+          baseline_observed_at: DateTime.toDateUtc(DateTime.makeUnsafe('2026-07-19T13:00:00.000Z')),
           baseline_cash_micros: '1000',
           opening_account_event_id: hash('c'),
-          opening_observed_at: new Date('2026-07-20T13:00:00.000Z'),
+          opening_observed_at: DateTime.toDateUtc(DateTime.makeUnsafe('2026-07-20T13:00:00.000Z')),
           opening_cash_micros: '1000',
           pre_window_accounted_cash_delta_micros: '0',
           pre_window_cash_residual_micros: fixture.preWindowCashResidualMicros ?? '0',
           closing_account_event_id: hash('d'),
-          closing_observed_at: new Date('2026-07-20T21:00:00.000Z'),
+          closing_observed_at: DateTime.toDateUtc(DateTime.makeUnsafe('2026-07-20T21:00:00.000Z')),
           closing_cash_micros: '1200',
           accounted_cash_delta_micros: '0',
           cash_yield_micros: '200',

--- a/services/bayn/src/hash.test.ts
+++ b/services/bayn/src/hash.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test'
-import { Result } from 'effect'
+import { DateTime, Result } from 'effect'
 
 import {
   canonicalHashV1,
@@ -196,7 +196,9 @@ describe('canonical hashing', () => {
       actualType: 'object',
     })
 
-    expect(failureOf(canonicalJsonV1Result(new Date('2026-01-01T00:00:00.000Z')))).toEqual({
+    expect(
+      failureOf(canonicalJsonV1Result(DateTime.toDateUtc(DateTime.makeUnsafe('2026-01-01T00:00:00.000Z')))),
+    ).toEqual({
       _tag: 'CanonicalJsonFailure',
       path: '$',
       reason: 'non-plain-object',

--- a/services/bayn/src/health.test.ts
+++ b/services/bayn/src/health.test.ts
@@ -22,6 +22,7 @@ import {
 import { BrokerEnvironment, makeBrokerIdentity } from './broker/identity'
 import { CycleOperationsCondition, CycleOperationsReason, type CycleOperationsProjection } from './cycle-observability'
 import { CycleState, CycleTerminalReason } from './cycle'
+import { currentUtcInstant } from './time'
 import { CycleObservability, type CycleObservabilityShape } from './db/cycle-observability'
 import { DatabaseError, EvidenceStore } from './db/evidence-store'
 import { BrokerAccess, CapitalAuthorityKind } from './execution/authority'
@@ -336,7 +337,7 @@ const brokerProbe = (read: BrokerReadShape): BrokerProbe => ({
   executionDisabledReason: 'MAXIMUM_AUTHORITY_OBSERVE',
 })
 
-const brokerRuntimeState = (broker: BrokerProbe, startedAt = new Date().toISOString()): RuntimeState => ({
+const brokerRuntimeState = (broker: BrokerProbe, startedAt: string): RuntimeState => ({
   ...readyState(),
   autonomousCycleLoop: {
     configured: true,
@@ -1435,7 +1436,7 @@ describe('Bayn continuous health', () => {
       },
     }
     const broker: BrokerProbe = brokerWithMutations
-    const initial = brokerRuntimeState(broker)
+    const initial = brokerRuntimeState(broker, await Effect.runPromise(currentUtcInstant))
     const state = await Effect.runPromise(Ref.make(initial))
     const cycleFiber = Effect.runFork(Effect.never)
 
@@ -1471,7 +1472,7 @@ describe('Bayn continuous health', () => {
   test('degrades for every unavailable broker read and recovers on the next complete pass', async () => {
     const control = brokerReadControl()
     const broker = brokerProbe(brokerRead(control))
-    const initial = brokerRuntimeState(broker)
+    const initial = brokerRuntimeState(broker, await Effect.runPromise(currentUtcInstant))
     const state = await Effect.runPromise(Ref.make(initial))
     const cycleFiber = Effect.runFork(Effect.never)
     try {
@@ -1511,7 +1512,7 @@ describe('Bayn continuous health', () => {
   test('degrades on malformed broker data and recovers on the next complete pass', async () => {
     const control = brokerReadControl()
     const broker = brokerProbe(brokerRead(control))
-    const initial = brokerRuntimeState(broker)
+    const initial = brokerRuntimeState(broker, await Effect.runPromise(currentUtcInstant))
     const state = await Effect.runPromise(Ref.make(initial))
     const cycleFiber = Effect.runFork(Effect.never)
 
@@ -1540,7 +1541,7 @@ describe('Bayn continuous health', () => {
   test('preserves identity mismatch precedence and recovers from every permission drift', async () => {
     const control = brokerReadControl()
     const broker = brokerProbe(brokerRead(control))
-    const initial = brokerRuntimeState(broker)
+    const initial = brokerRuntimeState(broker, await Effect.runPromise(currentUtcInstant))
     const state = await Effect.runPromise(Ref.make(initial))
     const cycleFiber = Effect.runFork(Effect.never)
 
@@ -1737,7 +1738,7 @@ describe('Bayn continuous health', () => {
   test('interrupts every in-flight broker read without publishing a partial health pass', async () => {
     const pending = await Effect.runPromise(makePendingBrokerRead())
     const broker = brokerProbe(pending.read)
-    const initial = brokerRuntimeState(broker)
+    const initial = brokerRuntimeState(broker, await Effect.runPromise(currentUtcInstant))
     const state = await Effect.runPromise(Ref.make(initial))
     const cycleFiber = Effect.runFork(Effect.never)
     const healthFiber = Effect.runFork(provideHealthyDependencies(initial, probe(config, state, broker, cycleFiber)))

--- a/services/bayn/src/http.test.ts
+++ b/services/bayn/src/http.test.ts
@@ -2,9 +2,10 @@ import { connect, type Socket } from 'node:net'
 
 import { describe, expect, test } from 'bun:test'
 
-import { Cause, Data, Deferred, Effect, Exit, Fiber, Option, Ref, Result, Schema } from 'effect'
+import { NodeHttpClient } from '@effect/platform-node'
+import { Cause, Data, Deferred, Effect, Exit, Fiber, Layer, Option, Ref, Result, Schema } from 'effect'
 import { TestClock } from 'effect/testing'
-import { HttpServer } from 'effect/unstable/http'
+import { HttpClient, HttpClientRequest, HttpMethod, HttpServer } from 'effect/unstable/http'
 
 import {
   config,
@@ -124,13 +125,21 @@ interface TestServer {
   readonly state: Ref.Ref<RuntimeState>
 }
 
+interface TestHttpResponse {
+  readonly status: number
+  readonly allow: string | null
+  readonly cacheControl: string | null
+  readonly contentType: string | null
+  readonly body: unknown
+}
+
 class TestHttpRequestError extends Data.TaggedError('TestHttpRequestError')<{
   readonly cause: unknown
 }> {}
 
 const withHttpServer = <E>(
   options: TestServerOptions,
-  use: (server: TestServer) => Effect.Effect<void, E>,
+  use: (server: TestServer) => Effect.Effect<void, E, HttpClient.HttpClient>,
 ): Promise<void> => {
   const serverConfig = {
     cycleStallThresholdMs: config.cycleStallThresholdMs,
@@ -144,41 +153,48 @@ const withHttpServer = <E>(
   return Effect.runPromise(
     Effect.scoped(
       Effect.gen(function* () {
-        const state = yield* Ref.make(options.state ?? initialState({}))
-        yield* serveHttp(
-          serverConfig,
-          state,
-          provenance,
-          'embedded',
-          options.readEvidence ?? successfulEvidenceStore.read,
-        )
-        const server = yield* HttpServer.HttpServer
-        const address = server.address
-        expect(address._tag).toBe('TcpAddress')
-        return address._tag === 'TcpAddress'
-          ? yield* use({ port: address.port, state })
-          : yield* Effect.die('expected TCP')
-      }).pipe(Effect.provide(HttpServerLive(serverConfig))),
+        const services = yield* Layer.build(Layer.merge(HttpServerLive(serverConfig), NodeHttpClient.layerNodeHttp))
+        return yield* Effect.gen(function* () {
+          const state = yield* Ref.make(options.state ?? initialState({}))
+          yield* serveHttp(
+            serverConfig,
+            state,
+            provenance,
+            'embedded',
+            options.readEvidence ?? successfulEvidenceStore.read,
+          )
+          const server = yield* HttpServer.HttpServer
+          const address = server.address
+          expect(address._tag).toBe('TcpAddress')
+          return address._tag === 'TcpAddress'
+            ? yield* use({ port: address.port, state })
+            : yield* Effect.die('expected TCP')
+        }).pipe(Effect.provide(services))
+      }),
     ),
   )
 }
 
-const request = (port: number, path: string, method = 'GET') =>
-  Effect.tryPromise({
-    try: async (signal) => {
-      const response = await fetch(`http://127.0.0.1:${port}${path}`, { method, signal })
-      const contentType = response.headers.get('content-type')
-      const body = contentType?.includes('application/json') === true ? await response.json() : await response.text()
-      return {
-        status: response.status,
-        allow: response.headers.get('allow'),
-        cacheControl: response.headers.get('cache-control'),
-        contentType,
-        body,
-      }
-    },
-    catch: (cause) => new TestHttpRequestError({ cause }),
-  })
+const request = (port: number, path: string, method: HttpMethod.HttpMethod = 'GET') =>
+  HttpClient.execute(HttpClientRequest.make(method)(`http://127.0.0.1:${port}${path}`)).pipe(
+    Effect.flatMap((response) => {
+      const header = (name: string): string | null => (name in response.headers ? response.headers[name] : null)
+      const contentType = header('content-type')
+      const body = contentType?.includes('application/json') === true ? response.json : response.text
+      return body.pipe(
+        Effect.map(
+          (body): TestHttpResponse => ({
+            status: response.status,
+            allow: header('allow'),
+            cacheControl: header('cache-control'),
+            contentType,
+            body,
+          }),
+        ),
+      )
+    }),
+    Effect.mapError((cause) => new TestHttpRequestError({ cause })),
+  )
 
 const connectSocket = (port: number): Effect.Effect<Socket> =>
   Effect.callback<Socket>((resume) => {
@@ -1158,7 +1174,14 @@ describe('Bayn HTTP probes', () => {
       return assertRoutes.pipe(Effect.andThen(assertCurrentState))
     })
 
-    await Effect.runPromise(Effect.flip(request(port, '/livez')))
+    await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const services = yield* Layer.build(NodeHttpClient.layerNodeHttp)
+          return yield* Effect.flip(request(port, '/livez')).pipe(Effect.provide(services))
+        }),
+      ),
+    )
   })
 
   test('does not convert a historical read defect into an operational 503 response', async () => {

--- a/services/bayn/src/observe-composition.test.ts
+++ b/services/bayn/src/observe-composition.test.ts
@@ -108,6 +108,7 @@ import { Reason, type Policy } from './risk'
 import { decodePaperDecisionDocument, makePaperDecisionDocument } from './shadow-decision-contract'
 import { TargetPlanStatus } from './target-planner'
 import { fixtureProtocol, makeSnapshot, makeTestDefinition } from './test-fixtures'
+import { utcInstantFromEpochMillis } from './time'
 import type { DecisionPlan, IsoDate } from './types'
 
 const signalDate = '2020-04-30'
@@ -935,7 +936,7 @@ describe('OBSERVE runtime composition', () => {
   test('keeps OBSERVE recovery-only execution lookup-capable while fresh submit remains structurally unavailable', async () => {
     const fixture = await paperLifecycleFixture()
     const occurredAt = fixture.document.createdAt
-    const observedAt = new Date(Date.parse(occurredAt) + 1_000).toISOString()
+    const observedAt = utcInstantFromEpochMillis(Date.parse(occurredAt) + 1_000)
     const submitUnknown: MutationEvent = {
       schemaVersion: 'bayn.paper-mutation-event.v1',
       eventId: '1'.repeat(64),
@@ -1236,8 +1237,8 @@ describe('OBSERVE runtime composition', () => {
       eventId: '6'.repeat(64),
       eventType: MutationEventType.CancelUnknown,
     }
-    const dueAt = new Date(Date.parse(evaluatedAt) + accepted.consistencyDelayMs).toISOString()
-    expect(mutationRecoveryIsDue(accepted, new Date(Date.parse(dueAt) - 1).toISOString())).toBe(false)
+    const dueAt = utcInstantFromEpochMillis(Date.parse(evaluatedAt) + accepted.consistencyDelayMs)
+    expect(mutationRecoveryIsDue(accepted, utcInstantFromEpochMillis(Date.parse(dueAt) - 1))).toBe(false)
     expect(mutationRecoveryIsDue(accepted, dueAt)).toBe(true)
     expect(paperSubmitExpiresAt(cycle.window.submissionCutoffAt, evaluatedAt)).toBe(evaluatedAt)
     expect(paperSubmitExpiresAt(evaluatedAt, cycle.window.submissionCutoffAt)).toBe(evaluatedAt)
@@ -1330,7 +1331,7 @@ describe('OBSERVE runtime composition', () => {
 
   test('keeps an accepted pending intent lookup-recoverable after its immutable submission cutoff', async () => {
     const fixture = await paperLifecycleFixture()
-    const afterCutoff = new Date(Date.parse(fixture.document.submissionCutoffAt) + 1_000).toISOString()
+    const afterCutoff = utcInstantFromEpochMillis(Date.parse(fixture.document.submissionCutoffAt) + 1_000)
     const record = storedIntent(fixture.intent, IntentState.Acknowledged, fixture.document.createdAt)
     const accepted: MutationEvent = {
       schemaVersion: 'bayn.paper-mutation-event.v1',
@@ -1358,7 +1359,7 @@ describe('OBSERVE runtime composition', () => {
 
   test('keeps an unknown submit lookup-recoverable after its immutable submission cutoff', async () => {
     const fixture = await paperLifecycleFixture()
-    const afterCutoff = new Date(Date.parse(fixture.document.submissionCutoffAt) + 1_000).toISOString()
+    const afterCutoff = utcInstantFromEpochMillis(Date.parse(fixture.document.submissionCutoffAt) + 1_000)
     const record = storedIntent(fixture.intent, IntentState.Unknown, fixture.document.createdAt)
     const unknown: MutationEvent = {
       schemaVersion: 'bayn.paper-mutation-event.v1',
@@ -1423,7 +1424,7 @@ describe('OBSERVE runtime composition', () => {
       ...policy,
       maxOrderNotionalMicros: '1',
     }))
-    const observedAt = new Date(Date.parse(fixture.document.createdAt) + 1).toISOString()
+    const observedAt = utcInstantFromEpochMillis(Date.parse(fixture.document.createdAt) + 1)
 
     expect(fixture.document).toMatchObject({
       mode: 'PAPER',
@@ -1472,7 +1473,7 @@ describe('OBSERVE runtime composition', () => {
       ...policy,
       maxOrderNotionalMicros: '1',
     }))
-    const observedAt = new Date(Date.parse(fixture.document.createdAt) + 1).toISOString()
+    const observedAt = utcInstantFromEpochMillis(Date.parse(fixture.document.createdAt) + 1)
     const blockedCycle = Effect.runSync(
       decodeAutonomousCycle({
         ...fixture.boundCycle,
@@ -1636,7 +1637,7 @@ describe('OBSERVE runtime composition', () => {
 
   test('terminalizes a superseded PAPER generation after proving no mutation exists', async () => {
     const fixture = await paperLifecycleFixture()
-    const observedAt = new Date(Date.parse(fixture.document.createdAt) + 1).toISOString()
+    const observedAt = utcInstantFromEpochMillis(Date.parse(fixture.document.createdAt) + 1)
     let intentReads = 0
     let mutationReads = 0
     let commits = 0
@@ -1700,7 +1701,7 @@ describe('OBSERVE runtime composition', () => {
   test('recovers superseded accepted and unknown submits and cancellations before provenance blocking', async () => {
     const fixture = await paperLifecycleFixture()
     const occurredAt = fixture.document.createdAt
-    const observedAt = new Date(Date.parse(occurredAt) + 1_000).toISOString()
+    const observedAt = utcInstantFromEpochMillis(Date.parse(occurredAt) + 1_000)
     const supersededInput = { ...fixture.input, authorityGenerationHash: 'f'.repeat(64) }
     const driftedPolicy: Policy = {
       ...fixture.policy,
@@ -1869,7 +1870,7 @@ describe('OBSERVE runtime composition', () => {
   test('recovers old-policy mutation work before rejecting fresh work under the current policy', async () => {
     const fixture = await paperLifecycleFixture()
     const occurredAt = fixture.document.createdAt
-    const observedAt = new Date(Date.parse(occurredAt) + 1_000).toISOString()
+    const observedAt = utcInstantFromEpochMillis(Date.parse(occurredAt) + 1_000)
     const driftedPolicy: Policy = {
       ...fixture.policy,
       maxOrderNotionalMicros: (BigInt(fixture.policy.maxOrderNotionalMicros) - 1n).toString(),
@@ -1962,7 +1963,7 @@ describe('OBSERVE runtime composition', () => {
   test('recovers old execution-model mutations before gating fresh submission on the current model', async () => {
     const fixture = await paperLifecycleFixture()
     const occurredAt = fixture.document.createdAt
-    const observedAt = new Date(Date.parse(occurredAt) + 1_000).toISOString()
+    const observedAt = utcInstantFromEpochMillis(Date.parse(occurredAt) + 1_000)
     const supersededInput = { ...fixture.input, authorityGenerationHash: 'f'.repeat(64) }
     const driftedPreparation = {
       ...fixture.preparation,
@@ -2083,7 +2084,7 @@ describe('OBSERVE runtime composition', () => {
 
   test('terminalizes a known rejected PAPER intent without waiting for cutoff', async () => {
     const fixture = await paperLifecycleFixture()
-    const rejectedAt = new Date(Date.parse(fixture.document.createdAt) + 1_000).toISOString()
+    const rejectedAt = utcInstantFromEpochMillis(Date.parse(fixture.document.createdAt) + 1_000)
     expect(rejectedAt < fixture.risk.evaluation.decision.expiresAt).toBe(true)
     const record = storedIntent(fixture.intent, IntentState.Terminal, rejectedAt, TerminalOutcome.Rejected)
     const rejected: MutationEvent = {
@@ -2125,8 +2126,8 @@ describe('OBSERVE runtime composition', () => {
       maxBrokerStateAgeMs: 3_600_000,
       maxMarketDataAgeMs: 3_600_000,
     }))
-    const observedAt = new Date(Date.parse(fixture.document.submissionCutoffAt) + 1_000).toISOString()
-    const closeExpiresAt = new Date(Date.parse(observedAt) + 60_000).toISOString()
+    const observedAt = utcInstantFromEpochMillis(Date.parse(fixture.document.submissionCutoffAt) + 1_000)
+    const closeExpiresAt = utcInstantFromEpochMillis(Date.parse(observedAt) + 60_000)
     const position: Position = {
       schemaVersion: 'bayn.paper-position.v1',
       accountId,
@@ -2275,8 +2276,8 @@ describe('OBSERVE runtime composition', () => {
 
   test('keeps a rejected PAPER close intent recoverable while reconciliation still shows an open position', async () => {
     const fixture = await paperLifecycleFixture()
-    const observedAt = new Date(Date.parse(fixture.document.createdAt) + 1_000).toISOString()
-    const closeExpiresAt = new Date(Date.parse(observedAt) + 60_000).toISOString()
+    const observedAt = utcInstantFromEpochMillis(Date.parse(fixture.document.createdAt) + 1_000)
+    const closeExpiresAt = utcInstantFromEpochMillis(Date.parse(observedAt) + 60_000)
     const rejected: MutationEvent = {
       schemaVersion: 'bayn.paper-mutation-event.v1',
       eventId: '5'.repeat(64),
@@ -2342,8 +2343,8 @@ describe('OBSERVE runtime composition', () => {
       }),
       partialFillDecision,
     )
-    const observedAt = new Date(Date.parse(fixture.document.submissionCutoffAt) + 1_000).toISOString()
-    const closeExpiresAt = new Date(Date.parse(observedAt) + 60_000).toISOString()
+    const observedAt = utcInstantFromEpochMillis(Date.parse(fixture.document.submissionCutoffAt) + 1_000)
+    const closeExpiresAt = utcInstantFromEpochMillis(Date.parse(observedAt) + 60_000)
     const positions = fixture.intents.map((intent) => ({
       schemaVersion: 'bayn.paper-position.v1' as const,
       accountId,
@@ -2480,8 +2481,8 @@ describe('OBSERVE runtime composition', () => {
     if (filledIntent === undefined || rejectedIntent === undefined) {
       return expect.unreachable('partial-fill fixture requires two planned intents')
     }
-    const observedAt = new Date(Date.parse(fixture.document.createdAt) + 1_000).toISOString()
-    const cutoffAt = new Date(Date.parse(observedAt) + 60_000).toISOString()
+    const observedAt = utcInstantFromEpochMillis(Date.parse(fixture.document.createdAt) + 1_000)
+    const cutoffAt = utcInstantFromEpochMillis(Date.parse(observedAt) + 60_000)
     const filledRecord = storedIntent(filledIntent, IntentState.Terminal, observedAt, TerminalOutcome.Filled)
     const rejectedRecord = storedIntent(rejectedIntent, IntentState.Terminal, observedAt, TerminalOutcome.Rejected)
     const accepted: MutationEvent = {
@@ -2542,8 +2543,8 @@ describe('OBSERVE runtime composition', () => {
 
   test('keeps a single canceled partial-fill PAPER intent recoverable before cutoff', async () => {
     const fixture = await paperLifecycleFixture()
-    const observedAt = new Date(Date.parse(fixture.document.createdAt) + 1_000).toISOString()
-    const cutoffAt = new Date(Date.parse(observedAt) + 60_000).toISOString()
+    const observedAt = utcInstantFromEpochMillis(Date.parse(fixture.document.createdAt) + 1_000)
+    const cutoffAt = utcInstantFromEpochMillis(Date.parse(observedAt) + 60_000)
     const record = storedIntent(fixture.intent, IntentState.Terminal, observedAt, TerminalOutcome.Canceled)
     const accepted: MutationEvent = {
       schemaVersion: 'bayn.paper-mutation-event.v1',
@@ -2597,7 +2598,7 @@ describe('OBSERVE runtime composition', () => {
     expect(restrictions[0]).toContain(`intent ${fixture.intent.intentId} ended CANCELED`)
     expect(paperCycleHasFilledIntent({ intents: [record.intent], orders: [partialOrder] })).toBe(true)
 
-    const closeExpiresAt = new Date(Date.parse(cutoffAt) + 60_000).toISOString()
+    const closeExpiresAt = utcInstantFromEpochMillis(Date.parse(cutoffAt) + 60_000)
     const closeRestrictions: string[] = []
     const closeStep = await prepareStoredPaperStep(
       fixture,
@@ -2628,8 +2629,8 @@ describe('OBSERVE runtime composition', () => {
 
   test('completes a filled PAPER cycle after a later exact post-cutoff reconciliation', async () => {
     const fixture = await paperLifecycleFixture()
-    const terminalAt = new Date(Date.parse(fixture.document.submissionCutoffAt) + 1_000).toISOString()
-    const reconciledLaterAt = new Date(Date.parse(terminalAt) + 1_000).toISOString()
+    const terminalAt = utcInstantFromEpochMillis(Date.parse(fixture.document.submissionCutoffAt) + 1_000)
+    const reconciledLaterAt = utcInstantFromEpochMillis(Date.parse(terminalAt) + 1_000)
     const record = storedIntent(fixture.intent, IntentState.Terminal, terminalAt, TerminalOutcome.Filled)
     const accepted: MutationEvent = {
       schemaVersion: 'bayn.paper-mutation-event.v1',
@@ -2835,7 +2836,7 @@ describe('OBSERVE runtime composition', () => {
     })
     const alteredExpiry = makePaperDecisionDocument({
       ...material,
-      expiresAt: new Date(Date.parse(material.expiresAt) - 1).toISOString(),
+      expiresAt: utcInstantFromEpochMillis(Date.parse(material.expiresAt) - 1),
     })
 
     for (const altered of [alteredGeneration, alteredTarget, alteredOrder, alteredCumulativeRisk, alteredExpiry]) {
@@ -4438,7 +4439,7 @@ describe('OBSERVE runtime composition', () => {
         updatedAt: document.createdAt,
       }),
     )
-    const recoveredAt = new Date(Date.parse(document.createdAt) + 1).toISOString()
+    const recoveredAt = utcInstantFromEpochMillis(Date.parse(document.createdAt) + 1)
     const completedCycle = Effect.runSync(
       decodeAutonomousCycle({
         ...boundCycle,

--- a/services/bayn/src/qualification-reference.test.ts
+++ b/services/bayn/src/qualification-reference.test.ts
@@ -1,10 +1,8 @@
 import assert from 'node:assert/strict'
-import { mkdtemp, rm } from 'node:fs/promises'
-import { tmpdir } from 'node:os'
-import { join } from 'node:path'
 
 import { describe, expect, test } from 'bun:test'
-import { Result } from 'effect'
+import { NodeFileSystem } from '@effect/platform-node'
+import { Data, Effect, FileSystem, Layer, Result } from 'effect'
 
 import { canonicalHashV1 } from './hash'
 import { makeRuntimeProvenance } from './contracts'
@@ -28,6 +26,10 @@ const assertFailure = <A, E>(result: Result.Result<A, E>): E => {
   assert(Result.isFailure(result), 'reference evaluation fixture must fail')
   return result.failure
 }
+
+class ReferenceBuildError extends Data.TaggedError('ReferenceBuildError')<{
+  readonly cause: unknown
+}> {}
 
 describe('independent qualification reference', () => {
   test('reproduces every persisted strategy and benchmark artifact', () => {
@@ -216,31 +218,47 @@ describe('independent qualification reference', () => {
     expect(canonicalHashV1(changed.strategy.decisions)).not.toBe(canonicalHashV1(original.strategy.decisions))
   })
 
-  test('keeps the reference dependency graph outside the production strategy evaluator', async () => {
-    const outputDirectory = await mkdtemp(join(tmpdir(), 'bayn-reference-dependency-'))
-    try {
-      const buildInputs = async (entrypoint: URL): Promise<readonly string[]> => {
-        const build = await Bun.build({
-          entrypoints: [entrypoint.pathname],
-          outdir: outputDirectory,
-          target: 'bun',
-          metafile: true,
-          packages: 'external',
-        })
-        assert(build.success, build.logs.map(String).join('\n'))
-        assert(build.metafile !== undefined, 'dependency-boundary build omitted its metafile')
-        return Object.keys(build.metafile.inputs).map((path) => path.replaceAll('\\', '/'))
-      }
-      const productionEvaluator = /(?:^|\/)risk-balanced-trend(?:\.ts|\/)/
-      const productionInputs = await buildInputs(new URL('./risk-balanced-trend/index.ts', import.meta.url))
-      const referenceInputs = await buildInputs(new URL('./audit/reference.ts', import.meta.url))
+  test('keeps the reference dependency graph outside the production strategy evaluator', () =>
+    Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const services = yield* Layer.build(NodeFileSystem.layer)
+          return yield* Effect.gen(function* () {
+            const fileSystem = yield* FileSystem.FileSystem
+            const outputDirectory = yield* fileSystem.makeTempDirectoryScoped({
+              prefix: 'bayn-reference-dependency-',
+            })
+            const buildInputs = (entrypoint: URL): Effect.Effect<readonly string[], ReferenceBuildError> =>
+              Effect.gen(function* () {
+                const build = yield* Effect.tryPromise({
+                  try: () =>
+                    Bun.build({
+                      entrypoints: [entrypoint.pathname],
+                      outdir: outputDirectory,
+                      target: 'bun',
+                      metafile: true,
+                      packages: 'external',
+                    }),
+                  catch: (cause) => new ReferenceBuildError({ cause }),
+                })
+                if (!build.success) return yield* new ReferenceBuildError({ cause: build.logs })
+                if (build.metafile === undefined) {
+                  return yield* new ReferenceBuildError({
+                    cause: 'dependency-boundary build omitted its metafile',
+                  })
+                }
+                return Object.keys(build.metafile.inputs).map((path) => path.replaceAll('\\', '/'))
+              })
+            const productionEvaluator = /(?:^|\/)risk-balanced-trend(?:\.ts|\/)/
+            const productionInputs = yield* buildInputs(new URL('./risk-balanced-trend/index.ts', import.meta.url))
+            const referenceInputs = yield* buildInputs(new URL('./audit/reference.ts', import.meta.url))
 
-      expect(productionInputs.some((path) => productionEvaluator.test(path))).toBe(true)
-      expect(referenceInputs.filter((path) => productionEvaluator.test(path))).toEqual([])
-    } finally {
-      await rm(outputDirectory, { recursive: true, force: true })
-    }
-  })
+            expect(productionInputs.some((path) => productionEvaluator.test(path))).toBe(true)
+            expect(referenceInputs.filter((path) => productionEvaluator.test(path))).toEqual([])
+          }).pipe(Effect.provide(services))
+        }),
+      ),
+    ))
 
   test('independently keeps planned quantities invariant to future execution OHLC', () => {
     const snapshot = makeSnapshot(900)

--- a/services/bayn/src/qualification-statistics.test.ts
+++ b/services/bayn/src/qualification-statistics.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict'
 
 import { describe, expect, test } from 'bun:test'
 
-import { Result, Schema } from 'effect'
+import { DateTime, Result, Schema } from 'effect'
 
 import {
   QualificationAnalysisSchema,
@@ -42,7 +42,7 @@ const successOf = <A, E>(result: Result.Result<A, E>): A => {
 }
 
 const isoDate = (index: number): `${number}-${number}-${number}` => {
-  const date = new Date('2000-01-01T00:00:00.000Z')
+  const date = DateTime.toDateUtc(DateTime.makeUnsafe('2000-01-01T00:00:00.000Z'))
   date.setUTCDate(date.getUTCDate() + index)
   return date.toISOString().slice(0, 10) as `${number}-${number}-${number}`
 }

--- a/services/bayn/src/qualification.test.ts
+++ b/services/bayn/src/qualification.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 
-import { Result, Schema } from 'effect'
+import { DateTime, Result, Schema } from 'effect'
 
 import {
   defaultQualificationStatisticsPolicyDocument,
@@ -146,7 +146,7 @@ describe('qualification lock', () => {
 
 const qualificationSeries = (): QualificationSeries => {
   const sessionDate = (index: number): `${number}-${number}-${number}` => {
-    const date = new Date('2000-01-01T00:00:00.000Z')
+    const date = DateTime.toDateUtc(DateTime.makeUnsafe('2000-01-01T00:00:00.000Z'))
     date.setUTCDate(date.getUTCDate() + index)
     return date.toISOString().slice(0, 10) as `${number}-${number}-${number}`
   }

--- a/services/bayn/src/reconciler.test.ts
+++ b/services/bayn/src/reconciler.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test'
 
 import { Cause, Deferred, Effect, Exit, Fiber, HashSet, Result } from 'effect'
 import { TestClock } from 'effect/testing'
+import { utcInstantFromEpochMillis } from './time'
 
 import {
   AccountStatus as BrokerAccountStatus,
@@ -76,7 +77,7 @@ const order = (index: number): BrokerOrder => ({
   clientOrderId: `client-order-${index}`,
   createdAt: observedAt,
   updatedAt: observedAt,
-  submittedAt: new Date(index).toISOString(),
+  submittedAt: utcInstantFromEpochMillis(index),
   assetId: `asset-${index}`,
   symbol: 'NVDA',
   assetClass: AssetClass.UsEquity,

--- a/services/bayn/src/risk.test.ts
+++ b/services/bayn/src/risk.test.ts
@@ -22,6 +22,7 @@ import {
   type ReferenceIntent,
 } from './paper'
 import { reconciledStateHash } from './reconciliation'
+import { utcDateFromEpochMillis, utcInstantFromEpochMillis } from './time'
 import {
   BrokerMode,
   EvaluationSchema,
@@ -96,17 +97,17 @@ const changeExecutionWindow = (
         : { signal: { ...material.signal, finalizedAt: overrides.submissionOpenAt } }),
     })
   }
-  const executionOpenAt = new Date(
+  const executionOpenAt = utcInstantFromEpochMillis(
     Date.parse(overrides.submissionCutoffAt) + material.submissionCutoffLeadMinutes * 60_000,
-  ).toISOString()
+  )
   const executionDate = executionOpenAt.slice(0, 10) as State['executionSession']['executionSession']['date']
-  const signalDate = new Date(Date.parse(`${executionDate}T00:00:00.000Z`) - 24 * 60 * 60_000)
-    .toISOString()
-    .slice(0, 10) as State['executionSession']['signal']['sessionDate']
+  const signalDate = utcDateFromEpochMillis(
+    Date.parse(`${executionDate}T00:00:00.000Z`) - 24 * 60 * 60_000,
+  ) as State['executionSession']['signal']['sessionDate']
   const executionSession = {
     date: executionDate,
     openAt: executionOpenAt,
-    closeAt: new Date(Date.parse(executionOpenAt) + 2 * 60 * 60_000).toISOString(),
+    closeAt: utcInstantFromEpochMillis(Date.parse(executionOpenAt) + 2 * 60 * 60_000),
   }
   const calendar = {
     schemaVersion: material.calendar.schemaVersion,

--- a/services/bayn/src/shadow-decision.test.ts
+++ b/services/bayn/src/shadow-decision.test.ts
@@ -15,6 +15,7 @@ import {
 import { defaultExecutionModel } from './execution-model'
 import { bindExecutionSession, type BindExecutionSessionInput } from './execution-session'
 import { canonicalHashV1 } from './hash'
+import { utcInstantFromEpochMillis } from './time'
 import {
   AccountStatus,
   Authority,
@@ -544,7 +545,7 @@ describe('OBSERVE shadow decision', () => {
 
   test('clamps blocked risk evidence at the last instant before the exclusive cycle cutoff', async () => {
     const input = makeInput()
-    const createdAt = new Date(Date.parse(input.cycle.window.submissionCutoffAt) - 1).toISOString()
+    const createdAt = utcInstantFromEpochMillis(Date.parse(input.cycle.window.submissionCutoffAt) - 1)
     const plannerInput = { ...input.plannerInput, observedAt: createdAt }
     const document = await build({
       ...input,

--- a/services/bayn/src/simulation-reconciliation.test.ts
+++ b/services/bayn/src/simulation-reconciliation.test.ts
@@ -15,6 +15,7 @@ import {
   type SimulationReconciliationResult,
 } from './simulation-reconciliation'
 import { fixtureProtocol, makeSnapshot, makeTestProvenance } from './test-fixtures'
+import { utcDateFromEpochMillis } from './time'
 import type { EvaluationEvent, Protocol, SimulationTrace } from './types'
 
 const snapshot = makeSnapshot(800)
@@ -114,7 +115,7 @@ const makeEmptyInput = (): MarkedEquityReconciliationInput => {
 const makeRoundTripInput = (dayCount: number): MarkedEquityReconciliationInput => {
   const sessionDates = Array.from(
     { length: dayCount },
-    (_, index) => new Date(Date.UTC(2026, 1, index + 1)).toISOString().slice(0, 10) as `${number}-${number}-${number}`,
+    (_, index) => utcDateFromEpochMillis(Date.UTC(2026, 1, index + 1)) as `${number}-${number}-${number}`,
   )
   const input = makeEmptyInput()
   const markTemplate = input.simulation.dailyMarks[0]

--- a/services/bayn/src/test-fixtures.ts
+++ b/services/bayn/src/test-fixtures.ts
@@ -1,4 +1,4 @@
-import { Effect } from 'effect'
+import { DateTime, Effect } from 'effect'
 
 import { makeRuntimeProvenance, type RuntimeProvenance } from './contracts'
 import { canonicalHashV1 } from './hash'
@@ -72,10 +72,10 @@ export const makeTestDefinition = Pipeable.by<
 
 export const makeBars = (sessionCount = 1_122): readonly DailyBar[] => {
   const bars: DailyBar[] = []
-  const cursor = new Date(`${fixtureProtocol.historyStart}T00:00:00Z`)
+  let cursor = DateTime.makeUnsafe(`${fixtureProtocol.historyStart}T00:00:00Z`)
   let session = 0
   while (session < sessionCount) {
-    const day = cursor.getUTCDay()
+    const day = DateTime.getPartUtc(cursor, 'weekDay')
     if (day !== 0 && day !== 6) {
       for (let symbolIndex = 0; symbolIndex < fixtureProtocol.universe.length; symbolIndex += 1) {
         const symbol = fixtureProtocol.universe[symbolIndex]
@@ -85,7 +85,7 @@ export const makeBars = (sessionCount = 1_122): readonly DailyBar[] => {
         const open = close * (1 + 0.002 * Math.sin(session / 7 + symbolIndex))
         bars.push({
           symbol,
-          sessionDate: cursor.toISOString().slice(0, 10) as IsoDate,
+          sessionDate: DateTime.formatIsoDate(cursor) as IsoDate,
           open,
           high: Math.max(open, close) * 1.003,
           low: Math.min(open, close) * 0.997,
@@ -99,7 +99,7 @@ export const makeBars = (sessionCount = 1_122): readonly DailyBar[] => {
       }
       session += 1
     }
-    cursor.setUTCDate(cursor.getUTCDate() + 1)
+    cursor = DateTime.add(cursor, { days: 1 })
   }
   return bars
 }


### PR DESCRIPTION
## Summary

- Uses Effect platform services and DateTime boundaries in HTTP, schema, OBSERVE, and database tests.
- Keeps this native stack layer independently reviewable at 719 changed lines.
- Bases directly on codex/bayn-effect-tsgo-test-idioms-final so GitHub shows only this layer.

## Related Issues

None

## Testing

- bunx tsc --noEmit --project services/bayn/tsconfig.json
- bun run lint
- bun run lint:oxlint
- bun run lint:oxlint:type
- bun run build
- Focused tests for the touched subsystem were run while constructing the layer.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable and Breaking Changes is filled in.
- [x] Documentation and follow-ups are unchanged or represented by later stack layers.