### PR TITLE
refactor(bayn): scope test layers explicitly

### DIFF
--- a/services/bayn/src/broker/alpaca-mutations.test.ts
+++ b/services/bayn/src/broker/alpaca-mutations.test.ts
@@ -4,6 +4,7 @@ import { Deferred, Effect, Fiber, Redacted, Ref, Result } from 'effect'
 import { TestClock } from 'effect/testing'
 import { HttpClient, HttpClientError, HttpClientResponse } from 'effect/unstable/http'
 
+import { provideTestLayer } from '../effect-test-support'
 import { canonicalHashV1 } from '../hash'
 import {
   BrokerAccess,
@@ -509,7 +510,7 @@ describe('Alpaca broker mutations', () => {
           return yield* Fiber.join(fiber)
         }),
       { operationTimeoutMs: 5_000 },
-    ).pipe(Effect.provide(TestClock.layer()))
+    ).pipe(provideTestLayer(TestClock.layer()))
 
     const receipt = await Effect.runPromise(program)
     expect(receipt.evidence.observedAt).toBe('1970-01-01T00:00:02.000Z')
@@ -638,7 +639,7 @@ describe('Alpaca broker mutations', () => {
           return yield* Fiber.join(fiber)
         }),
       ),
-      Effect.provide(TestClock.layer()),
+      provideTestLayer(TestClock.layer()),
     )
 
     const failure = await Effect.runPromise(program)
@@ -697,7 +698,7 @@ describe('Alpaca broker mutations', () => {
           return yield* Fiber.join(fiber)
         }),
       ),
-      Effect.provide(TestClock.layer()),
+      provideTestLayer(TestClock.layer()),
     )
 
     const failure = await Effect.runPromise(program)
@@ -816,7 +817,7 @@ describe('Alpaca broker mutations', () => {
           return yield* Fiber.join(fiber)
         }),
       { operationTimeoutMs: 5_000 },
-    ).pipe(Effect.provide(TestClock.layer()))
+    ).pipe(provideTestLayer(TestClock.layer()))
 
     const failure = await Effect.runPromise(program)
     expect(failure).toMatchObject({

--- a/services/bayn/src/composition.test.ts
+++ b/services/bayn/src/composition.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, test } from 'bun:test'
 import { Context, Deferred, Effect, Fiber, FileSystem, Layer, Ref, Result } from 'effect'
 import { TestClock } from 'effect/testing'
 
+import { provideTestLayer } from './effect-test-support'
+
 import {
   ApplicationPlatformLive,
   closedCycleReceiptEmissionAllowed,
@@ -95,7 +97,7 @@ describe('Bayn PAPER receipt retry boundary', () => {
         yield* Effect.yieldNow
         yield* TestClock.adjust(17_000)
         yield* Fiber.join(retry)
-      }).pipe(Effect.provide(TestClock.layer())),
+      }).pipe(provideTestLayer(TestClock.layer())),
     )
 
     expect(observedAt).toHaveLength(17)
@@ -123,7 +125,7 @@ describe('Bayn PAPER receipt retry boundary', () => {
         yield* Effect.yieldNow
         yield* TestClock.adjust(8_000)
         yield* Fiber.join(retry)
-      }).pipe(Effect.provide(TestClock.layer())),
+      }).pipe(provideTestLayer(TestClock.layer())),
     )
 
     expect(observedAt).toHaveLength(8)
@@ -152,7 +154,7 @@ describe('Bayn PAPER receipt retry boundary', () => {
         yield* Effect.yieldNow
         yield* TestClock.adjust(10_000)
         yield* Fiber.join(retry)
-      }).pipe(Effect.provide(TestClock.layer())),
+      }).pipe(provideTestLayer(TestClock.layer())),
     )
 
     expect(observedAt).toHaveLength(4)
@@ -243,7 +245,7 @@ describe('Bayn PAPER startup recovery boundary', () => {
         const failure = yield* Fiber.join(activation)
         expect(yield* Ref.get(finalizations)).toBe(1)
         return failure
-      }).pipe(Effect.provide(TestClock.layer())),
+      }).pipe(provideTestLayer(TestClock.layer())),
     )
 
     expect(operations).toEqual([])
@@ -271,7 +273,7 @@ describe('Bayn PAPER startup recovery boundary', () => {
       Effect.gen(function* () {
         yield* TestClock.setTime(Date.parse('2026-08-03T12:00:00.000Z'))
         yield* restrictExpiredPaperActivation(authorityRestrictionStore, writerFence)
-      }).pipe(Effect.provide(TestClock.layer())),
+      }).pipe(provideTestLayer(TestClock.layer())),
     )
 
     expect(restrictions).toEqual([

--- a/services/bayn/src/effect-test-support.test.ts
+++ b/services/bayn/src/effect-test-support.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from 'bun:test'
+
+import { Deferred, Effect, Exit, Fiber, Layer, Ref } from 'effect'
+
+import { provideTestLayer } from './effect-test-support'
+
+describe('provideTestLayer', () => {
+  test('preserves an acquisition failure without running the provided effect', async () => {
+    let effectRuns = 0
+    const acquisitionFailure = new Error('test layer acquisition failed')
+    const layer = Layer.effectDiscard(Effect.fail(acquisitionFailure))
+
+    const failure = await Effect.runPromise(
+      Effect.sync(() => {
+        effectRuns += 1
+      }).pipe(provideTestLayer(layer), Effect.flip),
+    )
+
+    expect(failure).toBe(acquisitionFailure)
+    expect(effectRuns).toBe(0)
+  })
+
+  test('finalizes an acquired layer once when the provided effect fails', async () => {
+    let finalizations = 0
+    const effectFailure = new Error('provided effect failed')
+    const layer = Layer.effectDiscard(
+      Effect.acquireRelease(Effect.void, () =>
+        Effect.sync(() => {
+          finalizations += 1
+        }),
+      ),
+    )
+
+    const failure = await Effect.runPromise(Effect.fail(effectFailure).pipe(provideTestLayer(layer), Effect.flip))
+
+    expect(failure).toBe(effectFailure)
+    expect(finalizations).toBe(1)
+  })
+
+  test('finalizes an acquired layer once when the provided effect is interrupted', () =>
+    Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const acquired = yield* Deferred.make<void>()
+          const finalizations = yield* Ref.make(0)
+          const layer = Layer.effectDiscard(
+            Effect.acquireRelease(Deferred.succeed(acquired, undefined), () =>
+              Ref.update(finalizations, (count) => count + 1),
+            ),
+          )
+          const fiber = yield* Effect.never.pipe(provideTestLayer(layer), Effect.forkChild({ startImmediately: true }))
+
+          yield* Deferred.await(acquired)
+          yield* Fiber.interrupt(fiber)
+
+          expect(Exit.isFailure(yield* Fiber.await(fiber))).toBe(true)
+          expect(yield* Ref.get(finalizations)).toBe(1)
+        }),
+      ),
+    ))
+})

--- a/services/bayn/src/effect-test-support.ts
+++ b/services/bayn/src/effect-test-support.ts
@@ -1,0 +1,15 @@
+import { Effect, Layer } from 'effect'
+import { Pipeable } from './pipeable'
+
+const provideTestLayerDataFirst = <A, E, R, ROut, E2, RIn>(
+  effect: Effect.Effect<A, E, R>,
+  layer: Layer.Layer<ROut, E2, RIn>,
+): Effect.Effect<A, E | E2, RIn | Exclude<R, ROut>> =>
+  Effect.scoped(Layer.build(layer).pipe(Effect.flatMap((services) => effect.pipe(Effect.provide(services)))))
+
+export const provideTestLayer = Pipeable.generic<
+  <ROut, E2, RIn>(
+    layer: Layer.Layer<ROut, E2, RIn>,
+  ) => <A, E, R>(effect: Effect.Effect<A, E, R>) => Effect.Effect<A, E | E2, RIn | Exclude<R, ROut>>,
+  typeof provideTestLayerDataFirst
+>(2, provideTestLayerDataFirst)

--- a/services/bayn/src/execution-candidate-discovery.test.ts
+++ b/services/bayn/src/execution-candidate-discovery.test.ts
@@ -21,6 +21,7 @@ import {
 import { TestClock } from 'effect/testing'
 import { HttpClient, HttpClientResponse } from 'effect/unstable/http'
 
+import { provideTestLayer } from './effect-test-support'
 import { baynTestPostgresUrl } from './test-environment.test-support'
 
 import {
@@ -447,7 +448,7 @@ const program = (
     Effect.provideService(CycleObservability, observability),
     Effect.provideService(CycleStore, cycleStore),
     Effect.provideService(BrokerRead, read),
-    Effect.provide(TestClock.layer()),
+    provideTestLayer(TestClock.layer()),
   )
 }
 
@@ -1206,7 +1207,7 @@ describePostgres('paper candidate discovery PostgreSQL transaction', () => {
             Effect.provideService(CycleStore, cycleStore),
             Effect.provideService(BrokerRead, broker(state)),
           )
-        }).pipe(Effect.provide(TestClock.layer())),
+        }).pipe(provideTestLayer(TestClock.layer())),
       )
     } finally {
       await runtime.dispose()

--- a/services/bayn/src/execution/coordinator.test.ts
+++ b/services/bayn/src/execution/coordinator.test.ts
@@ -4,6 +4,7 @@ import { Cause, Clock, Duration, Effect, Exit, Fiber, Option, Result } from 'eff
 import { TestClock } from 'effect/testing'
 import { utcInstantFromEpochMillis } from '../time'
 
+import { provideTestLayer } from '../effect-test-support'
 import {
   BrokerMutation,
   BrokerMutationError,
@@ -1607,16 +1608,16 @@ const makeHarness = (options: HarnessOptions = {}) => {
         check: fenceCheck,
         transaction: (effect) => effect,
       }),
-      Effect.provide(TestClock.layer()),
+      provideTestLayer(TestClock.layer()),
     )
   const provideIntentRead = <A, E>(effect: Effect.Effect<A, E, IntentStore>) =>
-    effect.pipe(Effect.provideService(IntentStore, intentStore), Effect.provide(TestClock.layer()))
+    effect.pipe(Effect.provideService(IntentStore, intentStore), provideTestLayer(TestClock.layer()))
   const provideRecovery = <A, E>(effect: Effect.Effect<A, E, IntentStore | MutationStore | BrokerRead>) =>
     effect.pipe(
       Effect.provideService(IntentStore, intentStore),
       Effect.provideService(MutationStore, mutationStore),
       Effect.provideService(BrokerRead, read),
-      Effect.provide(TestClock.layer()),
+      provideTestLayer(TestClock.layer()),
     )
 
   return {

--- a/services/bayn/src/forward-performance/program.test.ts
+++ b/services/bayn/src/forward-performance/program.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'bun:test'
 
 import { ClickhouseClient } from '@effect/sql-clickhouse'
 import { PgClient } from '@effect/sql-pg'
-import { DateTime, Effect, Layer, Redacted, Result } from 'effect'
+import { DateTime, Effect, Redacted, Result } from 'effect'
 
 import { prepareAccounting } from '../accounting/domain'
 import { makeBrokerIdentity, BrokerEnvironment, BrokerProvider } from '../broker/identity'
@@ -460,7 +460,7 @@ describe('forward performance read program', () => {
 
     const evidence = await Effect.runPromise(
       readForwardPerformanceMarketVolumeWithClient(marketReaderConfig, [marketVolumeRequest]).pipe(
-        Effect.provide(Layer.succeed(ClickhouseClient.ClickhouseClient, client)),
+        Effect.provideService(ClickhouseClient.ClickhouseClient, client),
       ),
     )
 
@@ -625,7 +625,7 @@ describe('forward performance read program', () => {
     }
 
     const receipt = await Effect.runPromise(
-      Effect.scoped(runForwardPerformance(config, readers).pipe(Effect.provide(Layer.succeed(PgClient.PgClient, sql)))),
+      Effect.scoped(runForwardPerformance(config, readers).pipe(Effect.provideService(PgClient.PgClient, sql))),
     )
 
     expect(observation.statements.length).toBeGreaterThan(8)
@@ -816,7 +816,7 @@ describe('forward performance read program', () => {
     }
 
     const receipt = await Effect.runPromise(
-      Effect.scoped(runForwardPerformance(config, readers).pipe(Effect.provide(Layer.succeed(PgClient.PgClient, sql)))),
+      Effect.scoped(runForwardPerformance(config, readers).pipe(Effect.provideService(PgClient.PgClient, sql))),
     )
 
     expect(receipt.evidence.reasonCodes).toContain('NON_EXACT_RECONCILIATION')
@@ -998,7 +998,7 @@ describe('forward performance read program', () => {
     }
 
     const receipt = await Effect.runPromise(
-      Effect.scoped(runForwardPerformance(config, readers).pipe(Effect.provide(Layer.succeed(PgClient.PgClient, sql)))),
+      Effect.scoped(runForwardPerformance(config, readers).pipe(Effect.provideService(PgClient.PgClient, sql))),
     )
 
     expect(receipt.schemaVersion).toBe('bayn.forward-performance-receipt.v3')

--- a/services/bayn/src/http.test.ts
+++ b/services/bayn/src/http.test.ts
@@ -7,6 +7,7 @@ import { Cause, Data, Deferred, Effect, Exit, Fiber, Layer, Option, Ref, Result,
 import { TestClock } from 'effect/testing'
 import { HttpClient, HttpClientRequest, HttpMethod, HttpServer } from 'effect/unstable/http'
 
+import { provideTestLayer } from './effect-test-support'
 import {
   config,
   historicalEvidence,
@@ -995,7 +996,7 @@ describe('Bayn HTTP pure decisions', () => {
         yield* TestClock.adjust(1_000)
         const error = yield* Fiber.join(failureFiber)
         return { error, finalizations: yield* Ref.get(finalizations) }
-      }).pipe(Effect.provide(TestClock.layer())),
+      }).pipe(provideTestLayer(TestClock.layer())),
     )
     expect(timeout).toMatchObject({
       error: {

--- a/services/bayn/src/ledger.test.ts
+++ b/services/bayn/src/ledger.test.ts
@@ -6,6 +6,7 @@ import { CreateAccountStatus, CreateTransferStatus, type Account, type Transfer 
 
 import { prepareAccounting, rebuildAccountingLedger } from './accounting/domain'
 import type { RuntimeConfig } from './config'
+import { provideTestLayer } from './effect-test-support'
 import { BrokerAccess, noCapitalAuthority } from './execution/authority'
 import { OrderSide, type Fill } from './paper'
 import {
@@ -176,16 +177,14 @@ const makeLedgerClient = () => {
 }
 
 const withJournal = <A, E>(client: TigerBeetleClient, use: (journal: JournalService) => Effect.Effect<A, E>) =>
-  Effect.scoped(
-    Effect.gen(function* () {
-      return yield* use(yield* Journal)
-    }).pipe(
-      Effect.provide(
-        JournalLive(journalConfig, {
-          createClient: () => client,
-          resolveReplicaAddresses: () => Effect.succeed(['3000']),
-        }),
-      ),
+  Effect.gen(function* () {
+    return yield* use(yield* Journal)
+  }).pipe(
+    provideTestLayer(
+      JournalLive(journalConfig, {
+        createClient: () => client,
+        resolveReplicaAddresses: () => Effect.succeed(['3000']),
+      }),
     ),
   )
 
@@ -1053,16 +1052,14 @@ describe('TigerBeetle simulation journal', () => {
         exact: true,
       })
     const useJournal = <A, E>(body: (journal: JournalService) => Effect.Effect<A, E>) =>
-      Effect.scoped(
-        Effect.gen(function* () {
-          return yield* body(yield* Journal)
-        }).pipe(
-          Effect.provide(
-            JournalLive(config, {
-              createClient: () => client,
-              resolveReplicaAddresses: () => Effect.succeed(['3000']),
-            }),
-          ),
+      Effect.gen(function* () {
+        return yield* body(yield* Journal)
+      }).pipe(
+        provideTestLayer(
+          JournalLive(config, {
+            createClient: () => client,
+            resolveReplicaAddresses: () => Effect.succeed(['3000']),
+          }),
         ),
       )
 

--- a/services/bayn/src/operations.test.ts
+++ b/services/bayn/src/operations.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, test } from 'bun:test'
 
 import { Effect, Exit, Fiber, Layer } from 'effect'
 import { TestClock } from 'effect/testing'
+
+import { provideTestLayer } from './effect-test-support'
 import {
   AuthenticationError,
   AuthorizationError,
@@ -37,7 +39,7 @@ describe('Bayn SQL dependency acquisition', () => {
         yield* Fiber.join(fiber)
         expect(attempts).toBe(2)
       }),
-    ).pipe(Effect.provide(TestClock.layer()))
+    ).pipe(provideTestLayer(TestClock.layer()))
 
     await Effect.runPromise(program)
 
@@ -87,7 +89,7 @@ describe('Bayn SQL dependency acquisition', () => {
         yield* Fiber.join(fiber)
         expect(attempts).toBe(2)
       }),
-    ).pipe(Effect.provide(TestClock.layer()))
+    ).pipe(provideTestLayer(TestClock.layer()))
 
     await Effect.runPromise(program)
   })
@@ -120,7 +122,7 @@ describe('Bayn SQL dependency acquisition', () => {
         yield* Fiber.join(fiber)
         expect(attempts).toBe(2)
       }),
-    ).pipe(Effect.provide(TestClock.layer()))
+    ).pipe(provideTestLayer(TestClock.layer()))
 
     await Effect.runPromise(program)
   })
@@ -142,7 +144,7 @@ describe('Bayn SQL dependency acquisition', () => {
           const exit = yield* Fiber.await(fiber)
           return { attempts, exit }
         }),
-      ).pipe(Effect.provide(TestClock.layer()))
+      ).pipe(provideTestLayer(TestClock.layer()))
     }
     const rawRefusal = SqlError.make({
       reason: UnknownError.make({
@@ -193,7 +195,7 @@ describe('Bayn SQL dependency acquisition', () => {
         yield* TestClock.adjust('2 seconds')
         expect(attempts).toBe(1)
       }),
-    ).pipe(Effect.provide(TestClock.layer()))
+    ).pipe(provideTestLayer(TestClock.layer()))
 
     await Effect.runPromise(program)
   })

--- a/services/bayn/src/paper-proof/program.test.ts
+++ b/services/bayn/src/paper-proof/program.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, test } from 'bun:test'
 import { Data, Effect, Exit, Fiber } from 'effect'
 import { TestClock } from 'effect/testing'
 
+import { provideTestLayer } from '../effect-test-support'
+
 import { MutationOperation } from '../broker/alpaca-mutations'
 import { BrokerProvider } from '../broker/connection'
 import { BrokerEnvironment } from '../broker/identity'
@@ -523,7 +525,7 @@ const runWithTestClock = <A, E>(effect: Effect.Effect<A, E>, advanceMs: number):
       yield* Effect.yieldNow
       yield* TestClock.adjust(advanceMs)
       return yield* Fiber.join(fiber)
-    }).pipe(Effect.provide(TestClock.layer())),
+    }).pipe(provideTestLayer(TestClock.layer())),
   )
 
 describe('bounded PAPER proof command', () => {

--- a/services/bayn/src/reconciler.test.ts
+++ b/services/bayn/src/reconciler.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, test } from 'bun:test'
 
 import { Cause, Deferred, Effect, Exit, Fiber, HashSet, Result } from 'effect'
 import { TestClock } from 'effect/testing'
+
+import { provideTestLayer } from './effect-test-support'
 import { utcInstantFromEpochMillis } from './time'
 
 import {
@@ -457,7 +459,7 @@ describe('paper reconciliation loop', () => {
     }
     const control: StoreControl = { writes: 0, reconciliations: [], restrictions: [] }
 
-    const result = await Effect.runPromise(provide(read, makeStore(control)).pipe(Effect.provide(TestClock.layer())))
+    const result = await Effect.runPromise(provide(read, makeStore(control)).pipe(provideTestLayer(TestClock.layer())))
 
     expect(orderCutoffs).toEqual(['1970-01-01T00:00:00.000Z', '1970-01-01T00:00:00.100Z'])
     expect(fillCutoffs).toEqual(orderCutoffs)

--- a/services/bayn/src/simulation-reconciliation/broker-persistence.test.ts
+++ b/services/bayn/src/simulation-reconciliation/broker-persistence.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, test } from 'bun:test'
 
 import { Cause, Effect, Logger, References } from 'effect'
 
+import { provideTestLayer } from '../effect-test-support'
+
 import { AccountStatus, type Account, type ReadEvidence } from '../broker/alpaca'
 import type { ReconciliationPersistence } from '../db/execution-store'
 import type { BrokerSnapshot, ReconciliationWriteResult } from '../db/reconciliation'
@@ -151,7 +153,7 @@ describe('simulation reconciliation persistence logging', () => {
 
     const result = await Effect.runPromise(
       persistStableSnapshot(store, fence, snapshot, Effect.succeed(observedAt)).pipe(
-        Effect.provide(Logger.layer([logger])),
+        provideTestLayer(Logger.layer([logger])),
       ),
     )
 

--- a/services/bayn/src/startup.test.ts
+++ b/services/bayn/src/startup.test.ts
@@ -6,6 +6,7 @@ import { NodeServices } from '@effect/platform-node'
 import { Cause, Effect, Exit, Layer, Option, Ref, Result } from 'effect'
 import { AuthenticationError, SqlError } from 'effect/unstable/sql/SqlError'
 
+import { provideTestLayer } from './effect-test-support'
 import {
   provenance,
   config,
@@ -1345,7 +1346,7 @@ describe('Bayn startup lifecycle', () => {
         Effect.provideService(Journal, successfulJournal),
         Effect.provideService(EvidenceStore, successfulEvidenceStore),
         Effect.provideService(CycleObservability, cycleObservability),
-        Effect.provide(HttpServerLive(config)),
+        provideTestLayer(HttpServerLive(config)),
         Effect.timeoutOrElse({
           duration: 250,
           orElse: () =>
@@ -1379,7 +1380,7 @@ describe('Bayn startup lifecycle', () => {
         Effect.provideService(Journal, journal),
         Effect.provideService(EvidenceStore, successfulEvidenceStore),
         Effect.provideService(CycleObservability, cycleObservability),
-        Effect.provide(HttpServerLive(config)),
+        provideTestLayer(HttpServerLive(config)),
         Effect.timeoutOrElse({
           duration: 250,
           orElse: () =>

--- a/services/bayn/src/time.test.ts
+++ b/services/bayn/src/time.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from 'bun:test'
 import { Effect, Result } from 'effect'
 import { TestClock } from 'effect/testing'
 
+import { provideTestLayer } from './effect-test-support'
 import {
   addUtcDays,
   currentUtcDate,
@@ -38,7 +39,7 @@ describe('Bayn UTC clock boundary', () => {
       Effect.gen(function* () {
         yield* TestClock.setTime(Date.parse('2026-07-26T06:23:57.295Z'))
         return yield* Effect.all([currentUtcInstant, currentUtcDate])
-      }).pipe(Effect.provide(TestClock.layer())),
+      }).pipe(provideTestLayer(TestClock.layer())),
     )
 
     expect(instant).toBe('2026-07-26T06:23:57.295Z')


### PR DESCRIPTION
## Summary

- Add a scoped test-layer helper that builds each Layer inside one resource-safe Effect scope before providing its Context.
- Replace 32 direct Layer-provision call sites across 13 Bayn tests; use direct service provision for simple service fixtures.
- Reduce strictEffectProvide diagnostics from 172 to 140 without suppressions; this stack layer changes 130 lines.

## Related Issues

None

## Testing

- `bun test src/composition.test.ts src/execution-candidate-discovery.test.ts src/http.test.ts src/ledger.test.ts src/operations.test.ts src/reconciler.test.ts src/startup.test.ts src/time.test.ts src/broker/alpaca-mutations.test.ts src/execution/coordinator.test.ts src/forward-performance/program.test.ts src/paper-proof/program.test.ts src/simulation-reconciliation/broker-persistence.test.ts` (255 pass, 1 PostgreSQL-gated skip, 0 fail)
- `bun run lint`
- `bun run lint:oxlint`
- `bun run lint:oxlint:type`
- `bun run build`
- Latest `@effect/tsgo` all-rules diagnostic audit: strictEffectProvide 172 -> 140; no new diagnostic families.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] Documentation and release notes are not required for this internal refactor.