### PR TITLE
refactor(bayn): unify final broker authorization

### DIFF
--- a/services/bayn/src/composition.ts
+++ b/services/bayn/src/composition.ts
@@ -316,14 +316,14 @@ const mutationCycle = (
   })
 
 const executionProgramError = (
-  cause: BrokerMutationError | Result.Result.Failure<ReturnType<typeof makeExecutionProgram>>,
+  cause: BrokerMutationError | Schema.SchemaError | Result.Result.Failure<ReturnType<typeof makeExecutionProgram>>,
 ) =>
   cause instanceof BrokerMutationError
     ? operationalError({ component: 'config', operation: 'broker-mutation', message: cause.message, cause })
     : operationalError({
         component: 'config',
         operation: 'execution-program',
-        message: 'execution program requires validated mutation authority',
+        message: 'execution program requires validated mutation authority and risk policy',
         cause,
       })
 
@@ -1524,26 +1524,34 @@ const runAutonomousService = (plan: ApplicationPlanFor<'AutonomousService'>) =>
                                     runtimeServices.alpacaHttpClient,
                                   ).pipe(
                                     Effect.flatMap((brokerMutation) =>
-                                      Effect.fromResult(
-                                        makeExecutionProgram(authority, {
-                                          brokerRead: runtimeServices.session.read,
-                                          liveCapitalGrants: runtimeServices.liveCapitalGrants,
-                                          freshBrokerPrice: makeFreshBrokerPriceReader(
-                                            runtimeServices.session.connection,
-                                            runtimeServices.alpacaHttpClient,
+                                      loadObserveRiskPolicy(
+                                        realizedPlan.config.alpaca.expectedAccountId,
+                                        realizedPlan.strategy.definition.parameters.universe,
+                                      ).pipe(
+                                        Effect.flatMap((riskPolicy) =>
+                                          Effect.fromResult(
+                                            makeExecutionProgram(authority, {
+                                              brokerRead: runtimeServices.session.read,
+                                              liveCapitalGrants: runtimeServices.liveCapitalGrants,
+                                              riskPolicy,
+                                              freshBrokerPrice: makeFreshBrokerPriceReader(
+                                                runtimeServices.session.connection,
+                                                runtimeServices.alpacaHttpClient,
+                                              ),
+                                              currentUtcInstant,
+                                              paperEpisodeEntryExpiresAt: request.cutoffAt,
+                                              paperEpisodeCloseExpiresAt: paperEpisodeCloseExpiresAt(request.expiresAt),
+                                              isPaperEpisodeCloseIntent: (intentId) =>
+                                                runtimeServices.paperCycleClosureStore
+                                                  .containsIntent(intentId)
+                                                  .pipe(Effect.orElseSucceed(() => false)),
+                                              intentStore: runtimeServices.intentStore,
+                                              mutationStore: runtimeServices.mutationStore,
+                                              writerFence: runtimeServices.writerFence,
+                                              brokerMutation,
+                                            }),
                                           ),
-                                          currentUtcInstant,
-                                          paperEpisodeEntryExpiresAt: request.cutoffAt,
-                                          paperEpisodeCloseExpiresAt: paperEpisodeCloseExpiresAt(request.expiresAt),
-                                          isPaperEpisodeCloseIntent: (intentId) =>
-                                            runtimeServices.paperCycleClosureStore
-                                              .containsIntent(intentId)
-                                              .pipe(Effect.orElseSucceed(() => false)),
-                                          intentStore: runtimeServices.intentStore,
-                                          mutationStore: runtimeServices.mutationStore,
-                                          writerFence: runtimeServices.writerFence,
-                                          brokerMutation,
-                                        }),
+                                        ),
                                       ),
                                     ),
                                     Effect.mapError(executionProgramError),

--- a/services/bayn/src/execution/authority.ts
+++ b/services/bayn/src/execution/authority.ts
@@ -40,13 +40,15 @@ export interface SandboxCapitalAuthority {
   readonly authorityGenerationHash: string
 }
 
-export interface LiveCapitalLimits {
+export interface ExecutionCapitalLimits {
   readonly maxGrossNotionalMicros: string
   readonly maxOrderNotionalMicros: string
   readonly maxPositionNotionalMicros: string
   readonly maxDailyLossMicros: string
   readonly maxOpenOrders: number
 }
+
+export type LiveCapitalLimits = ExecutionCapitalLimits
 
 export interface ExecutionStrategyIdentity {
   readonly name: string

--- a/services/bayn/src/execution/mutation-authority.test.ts
+++ b/services/bayn/src/execution/mutation-authority.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 
-import { Cause, Deferred, Effect, Fiber, Result } from 'effect'
+import { Cause, Effect, Result } from 'effect'
 
 import {
   AccountStatus,
@@ -34,7 +34,13 @@ import {
   type LiveCapitalLimits,
   type MutationExecutionAuthority,
 } from './authority'
-import { makeAuthorityGuardedBrokerMutation, type FinalSubmitAuthorization } from './mutation-authority'
+import {
+  isLiveMutationExecutionAuthority,
+  makeAuthorityGuardedBrokerMutation,
+  refreshLiveBrokerSubmitSnapshot,
+  validateLiveBrokerSubmitSnapshot,
+  type FinalSubmitAuthorization,
+} from './mutation-authority'
 
 const accountId = 'e6fe16f3-64a4-4921-8928-cadf02f92f98'
 const authorityGenerationHash = '1'.repeat(64)
@@ -269,47 +275,58 @@ const runLiveSubmit = async (input: ScenarioInput = {}) => {
       }),
     cancel: () => Effect.succeed(cancelReceipt),
   }
-  const guarded = makeAuthorityGuardedBrokerMutation(
-    mutationAuthority(BrokerEnvironment.Live, liveCapitalAuthority(grant)),
-    {
-      brokerRead,
-      brokerMutation,
-      liveCapitalGrants: {
-        read: () =>
-          Effect.sync(() => {
-            trace.push('grant')
-            grantReads += 1
-            if (input.persistedAtRead !== undefined) return input.persistedAtRead(priceReads)
-            return input.persisted === undefined && !('persisted' in input)
-              ? liveCapitalAuthority(grant)
-              : input.persisted
-          }),
-      },
-      freshBrokerPrice: (symbol) =>
-        Effect.sync(() => {
-          trace.push('price')
-          priceReads += 1
-          const quote = input.freshPricesBySymbol?.[symbol]
-          return {
-            symbol,
-            bidPriceMicros: quote?.bid ?? input.freshBidPriceMicros ?? '100000000',
-            askPriceMicros: quote?.ask ?? input.freshAskPriceMicros ?? '100000000',
-            quotedAt: input.quotedAt ?? activeAt,
-            observedAt: input.observedAt ?? activeAt,
-          }
-        }),
-      currentUtcInstant: Effect.sync(() => {
-        trace.push('clock')
-        return input.observedAt ?? activeAt
+  const authority = mutationAuthority(BrokerEnvironment.Live, liveCapitalAuthority(grant))
+  if (!isLiveMutationExecutionAuthority(authority)) throw new Error('live submit fixture requires live authority')
+  const liveCapitalGrants = {
+    read: () =>
+      Effect.sync(() => {
+        trace.push('grant')
+        grantReads += 1
+        if (input.persistedAtRead !== undefined) return input.persistedAtRead(priceReads)
+        return input.persisted === undefined && !('persisted' in input) ? liveCapitalAuthority(grant) : input.persisted
       }),
-      finalSubmitAuthorization:
-        input.finalSubmitAuthorization ??
-        ((_intent, transmit) =>
-          Effect.sync(() => {
-            trace.push('authorize')
-          }).pipe(Effect.andThen(transmit))),
-    },
-  )
+  }
+  const freshBrokerPrice = (symbol: string) =>
+    Effect.sync(() => {
+      trace.push('price')
+      priceReads += 1
+      const quote = input.freshPricesBySymbol?.[symbol]
+      return {
+        symbol,
+        bidPriceMicros: quote?.bid ?? input.freshBidPriceMicros ?? '100000000',
+        askPriceMicros: quote?.ask ?? input.freshAskPriceMicros ?? '100000000',
+        quotedAt: input.quotedAt ?? activeAt,
+        observedAt: input.observedAt ?? activeAt,
+      }
+    })
+  const currentUtcInstant = Effect.sync(() => {
+    trace.push('clock')
+    return input.observedAt ?? activeAt
+  })
+  const finalSubmitAuthorization: FinalSubmitAuthorization =
+    input.finalSubmitAuthorization ??
+    ((proposedIntent, transmit) =>
+      Effect.gen(function* () {
+        const snapshot = yield* refreshLiveBrokerSubmitSnapshot(authority, proposedIntent, {
+          brokerRead,
+          freshBrokerPrice,
+        })
+        const persisted = yield* liveCapitalGrants.read()
+        if (persisted === undefined) return yield* Effect.fail({ _tag: 'LiveCapitalGrantMissing' as const })
+        const observedAt = yield* currentUtcInstant
+        const validation = validateLiveBrokerSubmitSnapshot(authority, persisted, proposedIntent, snapshot, observedAt)
+        if (Result.isFailure(validation)) return yield* Effect.fail(validation.failure)
+        trace.push('authorize')
+        return yield* transmit
+      }))
+  const guarded = makeAuthorityGuardedBrokerMutation(authority, {
+    brokerRead,
+    brokerMutation,
+    liveCapitalGrants,
+    freshBrokerPrice,
+    currentUtcInstant,
+    finalSubmitAuthorization,
+  })
   const exit = await Effect.runPromiseExit(guarded.submit(input.proposedIntent ?? intent()))
   return { exit, grant, grantReads, orderLimit, positionReads, priceReads, submits, trace }
 }
@@ -350,95 +367,6 @@ describe('final broker mutation authority', () => {
     expect(observed.grantReads).toBe(0)
     expect(observed.submits).toBe(0)
     expect(observed.trace.slice(0, 4)).toEqual(['account', 'positions', 'orders', 'positions'])
-  })
-
-  test('serializes concurrent live snapshots through broker submission', async () => {
-    const grant = liveGrant({ ...defaultLimits, maxOpenOrders: 1 })
-    const observed = await Effect.runPromise(
-      Effect.gen(function* () {
-        const firstSubmitStarted = yield* Deferred.make<void>()
-        const releaseFirstSubmit = yield* Deferred.make<void>()
-        let openOrders: readonly Order[] = []
-        let snapshotReads = 0
-        let submits = 0
-        const unusedRead = Effect.die(new Error('unused broker read in concurrent mutation authority test'))
-        const brokerRead: BrokerReadShape = {
-          account: Effect.succeed(readResult(account())),
-          accountConfiguration: unusedRead,
-          assetBySymbol: () => unusedRead,
-          positions: Effect.succeed(readResult([])),
-          orders: () =>
-            Effect.sync(() => {
-              snapshotReads += 1
-              return readResult(openOrders)
-            }),
-          orderById: () => unusedRead,
-          orderByClientId: () => unusedRead,
-          fillActivities: () => unusedRead,
-          marketCalendar: () => unusedRead,
-        }
-        const brokerMutation: BrokerMutationShape = {
-          submit: (submittedIntent) =>
-            Effect.gen(function* () {
-              submits += 1
-              if (submits === 1) {
-                yield* Deferred.succeed(firstSubmitStarted, undefined)
-                yield* Deferred.await(releaseFirstSubmit)
-              }
-              const accepted = order({ clientOrderId: submittedIntent.clientOrderId })
-              openOrders = [...openOrders, accepted]
-              return { ...submitReceipt, order: accepted }
-            }),
-          cancel: () => Effect.succeed(cancelReceipt),
-        }
-        const guarded = makeAuthorityGuardedBrokerMutation(
-          mutationAuthority(BrokerEnvironment.Live, liveCapitalAuthority(grant)),
-          {
-            brokerRead,
-            brokerMutation,
-            liveCapitalGrants: { read: () => Effect.succeed(liveCapitalAuthority(grant)) },
-            freshBrokerPrice: (symbol) =>
-              Effect.succeed({
-                symbol,
-                bidPriceMicros: '100000000',
-                askPriceMicros: '100000000',
-                quotedAt: activeAt,
-                observedAt: activeAt,
-              }),
-            currentUtcInstant: Effect.succeed(activeAt),
-            finalSubmitAuthorization: (_intent, transmit) => transmit,
-          },
-        )
-        const first = yield* guarded
-          .submit(intent({ intentId: 'a'.repeat(64), clientOrderId: 'concurrent-live-1' }))
-          .pipe(Effect.exit, Effect.forkChild)
-        yield* Deferred.await(firstSubmitStarted)
-        const second = yield* guarded
-          .submit(intent({ intentId: 'b'.repeat(64), clientOrderId: 'concurrent-live-2' }))
-          .pipe(Effect.exit, Effect.forkChild)
-        yield* Effect.sleep('10 millis')
-        const snapshotReadsWhileFirstBlocked = snapshotReads
-        yield* Deferred.succeed(releaseFirstSubmit, undefined)
-        return {
-          first: yield* Fiber.join(first),
-          second: yield* Fiber.join(second),
-          snapshotReads,
-          snapshotReadsWhileFirstBlocked,
-          submits,
-        }
-      }),
-    )
-
-    expect(observed.snapshotReadsWhileFirstBlocked).toBe(1)
-    expect(observed.snapshotReads).toBe(2)
-    expect(observed.submits).toBe(1)
-    expect([observed.first._tag, observed.second._tag].sort()).toEqual(['Failure', 'Success'])
-    const rejected = observed.first._tag === 'Failure' ? observed.first : observed.second
-    expect(rejected._tag).toBe('Failure')
-    if (rejected._tag === 'Failure') {
-      const failure = rejected.cause.reasons.find(Cause.isFailReason)?.error
-      expect(failure?.cause?.['tag']).toBe('LiveOpenOrderLimitExceeded')
-    }
   })
 
   test.each([
@@ -493,13 +421,15 @@ describe('final broker mutation authority', () => {
     expect(observed.submits).toBe(0)
   })
 
-  test('rechecks the final submit window after live preflight with zero broker submits', async () => {
+  test('delegates final-submit rejection before any broker preflight', async () => {
     const observed = await runLiveSubmit({
       finalSubmitAuthorization: () => Effect.fail({ _tag: 'ExpiredRiskDecision' as const }),
     })
 
     expect(failureTag(observed.exit)).toBe('ExpiredRiskDecision')
-    expect(observed.priceReads).toBe(1)
+    expect(observed.priceReads).toBe(0)
+    expect(observed.grantReads).toBe(0)
+    expect(observed.positionReads).toBe(0)
     expect(observed.submits).toBe(0)
   })
 

--- a/services/bayn/src/execution/mutation-authority.ts
+++ b/services/bayn/src/execution/mutation-authority.ts
@@ -772,16 +772,20 @@ const validateExecutionCapitalLimitsDataFirst = (
   )
   const currentGross = worstCaseGross(false)
   const projectedGross = worstCaseGross(true)
+  const currentNet = [...currentBySymbol.values()].reduce((total, notional) => total + notional, 0n)
+  const projectedNet = currentNet + proposedSignedNotional
   const projectedQuantity = minimumSymbolQuantityAfterPendingSells(intent, snapshot)
   if (Result.isFailure(projectedQuantity)) return Result.fail(projectedQuantity.failure)
   const exposureReducingClose =
     context.closeOnly &&
     intent.side === IntentOrderSide.Sell &&
+    snapshot.positions.every((position) => BigInt(position.quantityMicros) >= 0n) &&
     projectedQuantity.success.beforeIntentMicros > 0n &&
     projectedQuantity.success.afterIntentMicros >= 0n &&
     projectedQuantity.success.afterIntentMicros < projectedQuantity.success.beforeIntentMicros &&
     projectedSymbol < currentSymbol &&
-    projectedGross <= currentGross
+    projectedGross <= currentGross &&
+    absolute(projectedNet) <= absolute(currentNet)
 
   const enforcedOrderLimit = exposureReducingClose
     ? context.hardCloseLimits?.maxOrderNotionalMicros

--- a/services/bayn/src/execution/mutation-authority.ts
+++ b/services/bayn/src/execution/mutation-authority.ts
@@ -1,4 +1,4 @@
-import { Effect, Result, Semaphore } from 'effect'
+import { Effect, Result } from 'effect'
 
 import {
   AccountStatus,
@@ -21,11 +21,13 @@ import type { LiveCapitalGrantStoreShape } from '../db/live-capital-grant'
 import type { OperationalError } from '../errors'
 import { canonicalHashV1Result } from '../hash'
 import { OrderSide as IntentOrderSide, type Intent } from '../paper'
+import type { Policy } from '../risk'
 import {
   BrokerAccess,
   BrokerEnvironment,
   CapitalAuthorityKind,
   makeExecutionAuthority,
+  type ExecutionCapitalLimits,
   type ExecutionAuthority,
   type ExecutionAuthorityConstructionFailure,
   type LiveCapitalAuthority,
@@ -183,11 +185,13 @@ export type LiveCapitalLimitFailure =
       readonly symbol: string
     }
 
-export interface LiveCapitalSnapshot {
+export interface ExecutionCapitalSnapshot {
   readonly account: Account
   readonly positions: readonly Position[]
   readonly openOrders: readonly Order[]
 }
+
+export type LiveCapitalSnapshot = ExecutionCapitalSnapshot
 
 export interface FreshBrokerQuote {
   readonly symbol: string
@@ -214,15 +218,45 @@ export interface MutationAuthorityDependencies {
   readonly finalSubmitAuthorization: FinalSubmitAuthorization
 }
 
-export interface LiveBrokerSubmitSnapshot extends LiveCapitalSnapshot {
+export interface ExecutionBrokerSubmitSnapshot extends ExecutionCapitalSnapshot {
   readonly quotes: ReadonlyMap<string, FreshBrokerQuote>
 }
+
+export type LiveBrokerSubmitSnapshot = ExecutionBrokerSubmitSnapshot
 
 export type LiveBrokerSubmitRefreshDependencies = Pick<MutationAuthorityDependencies, 'brokerRead' | 'freshBrokerPrice'>
 
 const absolute = (value: bigint): bigint => (value < 0n ? -value : value)
 const freshBrokerPriceMaximumAgeMs = 5_000
 const microsPerUnit = 1_000_000n
+
+export const executionCapitalLimitsFromPolicy = (policy: Policy): ExecutionCapitalLimits => ({
+  maxGrossNotionalMicros: policy.maxGrossExposureMicros,
+  maxOrderNotionalMicros: policy.maxOrderNotionalMicros,
+  maxPositionNotionalMicros: policy.maxSymbolExposureMicros,
+  maxDailyLossMicros: policy.maxDailyLossMicros,
+  maxOpenOrders: policy.maxUnresolvedOrders + 1,
+})
+
+const minimumMicros = (left: string, right: string): string => {
+  const leftMicros = BigInt(left)
+  const rightMicros = BigInt(right)
+  return (leftMicros < rightMicros ? leftMicros : rightMicros).toString()
+}
+
+export const constrainExecutionCapitalLimits = (
+  policyLimits: ExecutionCapitalLimits,
+  grantLimits: ExecutionCapitalLimits,
+): ExecutionCapitalLimits => ({
+  maxGrossNotionalMicros: minimumMicros(policyLimits.maxGrossNotionalMicros, grantLimits.maxGrossNotionalMicros),
+  maxOrderNotionalMicros: minimumMicros(policyLimits.maxOrderNotionalMicros, grantLimits.maxOrderNotionalMicros),
+  maxPositionNotionalMicros: minimumMicros(
+    policyLimits.maxPositionNotionalMicros,
+    grantLimits.maxPositionNotionalMicros,
+  ),
+  maxDailyLossMicros: minimumMicros(policyLimits.maxDailyLossMicros, grantLimits.maxDailyLossMicros),
+  maxOpenOrders: Math.min(policyLimits.maxOpenOrders, grantLimits.maxOpenOrders),
+})
 
 const positionExposureIdentity = (positions: readonly Position[]) =>
   positions
@@ -608,8 +642,8 @@ export const maximumAbsoluteExposureAcrossPendingFills = Pipeable.dual(
 )
 
 const validateSnapshotBindings = (
-  authority: LiveMutationExecutionAuthority,
-  snapshot: LiveCapitalSnapshot,
+  authority: MutationExecutionAuthority,
+  snapshot: ExecutionCapitalSnapshot,
 ): Result.Result<void, LiveCapitalLimitFailure> => {
   const expectedAccountId = authority.brokerIdentity.accountId
   if (snapshot.account.id !== expectedAccountId) {
@@ -656,10 +690,11 @@ const validateSnapshotBindings = (
   return Result.succeed(undefined)
 }
 
-const validateLiveCapitalLimitsDataFirst = (
-  authority: LiveMutationExecutionAuthority,
+const validateExecutionCapitalLimitsDataFirst = (
+  authority: MutationExecutionAuthority,
+  limits: ExecutionCapitalLimits,
   intent: Intent,
-  snapshot: LiveCapitalSnapshot,
+  snapshot: ExecutionCapitalSnapshot,
   proposedExposureNotional: bigint,
   proposedOrderNotional: bigint,
   openOrderNotionals: ReadonlyMap<string, bigint>,
@@ -671,7 +706,6 @@ const validateLiveCapitalLimitsDataFirst = (
   const pendingSellCoverage = validatePendingSellCoverage(snapshot)
   if (Result.isFailure(pendingSellCoverage)) return Result.fail(pendingSellCoverage.failure)
 
-  const limits = authority.capitalAuthority.grant.limits
   const orderLimit = BigInt(limits.maxOrderNotionalMicros)
   if (snapshot.openOrders.length >= limits.maxOpenOrders) {
     return Result.fail({
@@ -781,46 +815,66 @@ const validateLiveCapitalLimitsDataFirst = (
   return Result.succeed(undefined)
 }
 
+export const validateExecutionCapitalLimits = Pipeable.dual(7, validateExecutionCapitalLimitsDataFirst)
+
+const validateLiveCapitalLimitsDataFirst = (
+  authority: LiveMutationExecutionAuthority,
+  intent: Intent,
+  snapshot: LiveCapitalSnapshot,
+  proposedExposureNotional: bigint,
+  proposedOrderNotional: bigint,
+  openOrderNotionals: ReadonlyMap<string, bigint>,
+): Result.Result<void, LiveCapitalLimitFailure> =>
+  validateExecutionCapitalLimits(
+    authority,
+    authority.capitalAuthority.grant.limits,
+    intent,
+    snapshot,
+    proposedExposureNotional,
+    proposedOrderNotional,
+    openOrderNotionals,
+  )
+
 export const validateLiveCapitalLimits = Pipeable.dual(6, validateLiveCapitalLimitsDataFirst)
 
 const mutationAuthorizationError = (message: string, cause: unknown) =>
   invalidRequest({ operation: MutationOperation.Submit, message, cause })
 
-const refreshLiveBrokerSubmitSnapshotDataFirst = (
-  authority: LiveMutationExecutionAuthority,
+const refreshExecutionBrokerSubmitSnapshotDataFirst = (
+  limits: ExecutionCapitalLimits,
   intent: Intent,
   dependencies: LiveBrokerSubmitRefreshDependencies,
-): Effect.Effect<LiveBrokerSubmitSnapshot, BrokerMutationError> =>
+): Effect.Effect<ExecutionBrokerSubmitSnapshot, BrokerMutationError> =>
   Effect.gen(function* () {
     const account = yield* dependencies.brokerRead.account.pipe(
       Effect.mapError((cause) =>
-        mutationAuthorizationError('live broker account could not be refreshed before submit', cause),
+        mutationAuthorizationError('broker account could not be refreshed before submit', cause),
       ),
     )
     const positionsBefore = yield* dependencies.brokerRead.positions.pipe(
       Effect.mapError((cause) =>
-        mutationAuthorizationError('live broker positions could not be refreshed before submit', cause),
+        mutationAuthorizationError('broker positions could not be refreshed before submit', cause),
       ),
     )
     const openOrders = yield* dependencies.brokerRead
       .orders({
         status: OrderCollection.Open,
-        limit: authority.capitalAuthority.grant.limits.maxOpenOrders,
+        limit: limits.maxOpenOrders,
       })
       .pipe(
         Effect.mapError((cause) =>
-          mutationAuthorizationError('live broker open orders could not be refreshed before submit', cause),
+          mutationAuthorizationError('broker open orders could not be refreshed before submit', cause),
         ),
       )
     const positionsAfter = yield* dependencies.brokerRead.positions.pipe(
       Effect.mapError((cause) =>
-        mutationAuthorizationError('live broker positions could not be confirmed after open-order refresh', cause),
+        mutationAuthorizationError('broker positions could not be confirmed after open-order refresh', cause),
       ),
     )
     const stablePositions = validateStableLivePositionSnapshot(positionsBefore.value, positionsAfter.value)
     if (Result.isFailure(stablePositions)) {
       return yield* mutationAuthorizationError(
-        'live broker position snapshot changed during exposure refresh',
+        'broker position snapshot changed during exposure refresh',
         stablePositions.failure,
       )
     }
@@ -840,6 +894,15 @@ const refreshLiveBrokerSubmitSnapshotDataFirst = (
       quotes: new Map(quoteEntries),
     }
   })
+
+export const refreshExecutionBrokerSubmitSnapshot = Pipeable.dual(3, refreshExecutionBrokerSubmitSnapshotDataFirst)
+
+const refreshLiveBrokerSubmitSnapshotDataFirst = (
+  authority: LiveMutationExecutionAuthority,
+  intent: Intent,
+  dependencies: LiveBrokerSubmitRefreshDependencies,
+): Effect.Effect<LiveBrokerSubmitSnapshot, BrokerMutationError> =>
+  refreshExecutionBrokerSubmitSnapshot(authority.capitalAuthority.grant.limits, intent, dependencies)
 
 export const refreshLiveBrokerSubmitSnapshot = Pipeable.dual(3, refreshLiveBrokerSubmitSnapshotDataFirst)
 
@@ -892,15 +955,13 @@ export type LiveBrokerSubmitValidationFailure =
       readonly symbol: string
     }
 
-const validateLiveBrokerSubmitSnapshotDataFirst = (
-  captured: LiveMutationExecutionAuthority,
-  persisted: LiveCapitalAuthority,
+const validateExecutionBrokerSubmitSnapshotDataFirst = (
+  authority: MutationExecutionAuthority,
+  limits: ExecutionCapitalLimits,
   intent: Intent,
-  snapshot: LiveBrokerSubmitSnapshot,
+  snapshot: ExecutionBrokerSubmitSnapshot,
   observedAt: string,
 ): Result.Result<void, LiveBrokerSubmitValidationFailure> => {
-  const fresh = validateLiveGrantForSubmit(captured, persisted, observedAt)
-  if (Result.isFailure(fresh)) return Result.fail(fresh.failure)
   const intentQuote = snapshot.quotes.get(intent.symbol)
   if (intentQuote === undefined) {
     return Result.fail({
@@ -916,8 +977,9 @@ const validateLiveBrokerSubmitSnapshotDataFirst = (
   if (Result.isFailure(orderCapNotional)) return Result.fail(orderCapNotional.failure)
   const openOrderNotionals = priceOpenOrders(snapshot.openOrders)
   if (Result.isFailure(openOrderNotionals)) return Result.fail(openOrderNotionals.failure)
-  return validateLiveCapitalLimits(
-    fresh.success,
+  return validateExecutionCapitalLimits(
+    authority,
+    limits,
     intent,
     snapshot,
     requestedNotional.success,
@@ -926,13 +988,33 @@ const validateLiveBrokerSubmitSnapshotDataFirst = (
   )
 }
 
+export const validateExecutionBrokerSubmitSnapshot = Pipeable.dual(5, validateExecutionBrokerSubmitSnapshotDataFirst)
+
+const validateLiveBrokerSubmitSnapshotDataFirst = (
+  captured: LiveMutationExecutionAuthority,
+  persisted: LiveCapitalAuthority,
+  intent: Intent,
+  snapshot: LiveBrokerSubmitSnapshot,
+  observedAt: string,
+): Result.Result<void, LiveBrokerSubmitValidationFailure> => {
+  const fresh = validateLiveGrantForSubmit(captured, persisted, observedAt)
+  return Result.isFailure(fresh)
+    ? Result.fail(fresh.failure)
+    : validateExecutionBrokerSubmitSnapshot(
+        fresh.success,
+        fresh.success.capitalAuthority.grant.limits,
+        intent,
+        snapshot,
+        observedAt,
+      )
+}
+
 export const validateLiveBrokerSubmitSnapshot = Pipeable.dual(5, validateLiveBrokerSubmitSnapshotDataFirst)
 
 const makeAuthorityGuardedBrokerMutationDataFirst = (
   authority: MutationExecutionAuthority,
   dependencies: MutationAuthorityDependencies,
 ): BrokerMutationShape => {
-  const liveSubmitPermit = Semaphore.makeUnsafe(1)
   const transmit = (intent: Intent) =>
     dependencies
       .finalSubmitAuthorization(intent, dependencies.brokerMutation.submit(intent))
@@ -950,41 +1032,7 @@ const makeAuthorityGuardedBrokerMutationDataFirst = (
         mutationAuthorizationError('intent is not bound to the active execution authority', binding.failure),
       )
     }
-    if (!isLiveMutationExecutionAuthority(authority)) {
-      return transmit(intent)
-    }
-    const liveAuthority = authority
-
-    return liveSubmitPermit.withPermit(
-      Effect.gen(function* () {
-        const snapshot = yield* refreshLiveBrokerSubmitSnapshot(liveAuthority, intent, dependencies)
-        const grantHash = liveAuthority.capitalAuthority.grant.grantHash
-        const persisted = yield* dependencies.liveCapitalGrants.read(grantHash).pipe(
-          Effect.mapError((cause) =>
-            mutationAuthorizationError('live capital grant could not be refreshed before submit', cause),
-          ),
-          Effect.flatMap((grant) =>
-            grant === undefined
-              ? Effect.fail(
-                  mutationAuthorizationError('live capital grant is missing before submit', {
-                    _tag: 'LiveCapitalGrantMissing',
-                    grantHash,
-                  }),
-                )
-              : Effect.succeed(grant),
-          ),
-        )
-        const observedAt = yield* dependencies.currentUtcInstant
-        const validation = validateLiveBrokerSubmitSnapshot(liveAuthority, persisted, intent, snapshot, observedAt)
-        if (Result.isFailure(validation)) {
-          return yield* mutationAuthorizationError(
-            'live broker submit preflight rejected the broker submit',
-            validation.failure,
-          )
-        }
-        return yield* transmit(intent)
-      }),
-    )
+    return transmit(intent)
   }
 
   return {

--- a/services/bayn/src/execution/mutation-authority.ts
+++ b/services/bayn/src/execution/mutation-authority.ts
@@ -226,6 +226,11 @@ export type LiveBrokerSubmitSnapshot = ExecutionBrokerSubmitSnapshot
 
 export type LiveBrokerSubmitRefreshDependencies = Pick<MutationAuthorityDependencies, 'brokerRead' | 'freshBrokerPrice'>
 
+export interface ExecutionCapitalLimitContext {
+  readonly closeOnly: boolean
+  readonly hardCloseLimits?: Pick<ExecutionCapitalLimits, 'maxOrderNotionalMicros' | 'maxDailyLossMicros'>
+}
+
 const absolute = (value: bigint): bigint => (value < 0n ? -value : value)
 const freshBrokerPriceMaximumAgeMs = 5_000
 const microsPerUnit = 1_000_000n
@@ -698,6 +703,7 @@ const validateExecutionCapitalLimitsDataFirst = (
   proposedExposureNotional: bigint,
   proposedOrderNotional: bigint,
   openOrderNotionals: ReadonlyMap<string, bigint>,
+  context: ExecutionCapitalLimitContext,
 ): Result.Result<void, LiveCapitalLimitFailure> => {
   const binding = validateIntentAuthorityBinding(authority, intent)
   if (Result.isFailure(binding)) return Result.fail(binding.failure)
@@ -706,7 +712,6 @@ const validateExecutionCapitalLimitsDataFirst = (
   const pendingSellCoverage = validatePendingSellCoverage(snapshot)
   if (Result.isFailure(pendingSellCoverage)) return Result.fail(pendingSellCoverage.failure)
 
-  const orderLimit = BigInt(limits.maxOrderNotionalMicros)
   if (snapshot.openOrders.length >= limits.maxOpenOrders) {
     return Result.fail({
       _tag: 'LiveOpenOrderLimitExceeded',
@@ -769,11 +774,22 @@ const validateExecutionCapitalLimitsDataFirst = (
   const projectedGross = worstCaseGross(true)
   const projectedQuantity = minimumSymbolQuantityAfterPendingSells(intent, snapshot)
   if (Result.isFailure(projectedQuantity)) return Result.fail(projectedQuantity.failure)
+  const exposureReducingClose =
+    context.closeOnly &&
+    intent.side === IntentOrderSide.Sell &&
+    projectedQuantity.success.beforeIntentMicros > 0n &&
+    projectedQuantity.success.afterIntentMicros >= 0n &&
+    projectedQuantity.success.afterIntentMicros < projectedQuantity.success.beforeIntentMicros &&
+    projectedSymbol < currentSymbol &&
+    projectedGross <= currentGross
 
-  if (proposedOrderNotional > orderLimit) {
+  const enforcedOrderLimit = exposureReducingClose
+    ? context.hardCloseLimits?.maxOrderNotionalMicros
+    : limits.maxOrderNotionalMicros
+  if (enforcedOrderLimit !== undefined && proposedOrderNotional > BigInt(enforcedOrderLimit)) {
     return Result.fail({
       _tag: 'LiveOrderNotionalLimitExceeded',
-      limitMicros: limits.maxOrderNotionalMicros,
+      limitMicros: enforcedOrderLimit,
       proposedMicros: proposedOrderNotional.toString(),
     })
   }
@@ -805,17 +821,20 @@ const validateExecutionCapitalLimitsDataFirst = (
 
   const dailyLoss = BigInt(snapshot.account.lastEquityMicros) - BigInt(snapshot.account.equityMicros)
   const observedLoss = dailyLoss > 0n ? dailyLoss : 0n
-  if (observedLoss > BigInt(limits.maxDailyLossMicros)) {
+  const enforcedDailyLossLimit = exposureReducingClose
+    ? context.hardCloseLimits?.maxDailyLossMicros
+    : limits.maxDailyLossMicros
+  if (enforcedDailyLossLimit !== undefined && observedLoss > BigInt(enforcedDailyLossLimit)) {
     return Result.fail({
       _tag: 'LiveDailyLossLimitExceeded',
-      limitMicros: limits.maxDailyLossMicros,
+      limitMicros: enforcedDailyLossLimit,
       observedMicros: observedLoss.toString(),
     })
   }
   return Result.succeed(undefined)
 }
 
-export const validateExecutionCapitalLimits = Pipeable.dual(7, validateExecutionCapitalLimitsDataFirst)
+export const validateExecutionCapitalLimits = Pipeable.dual(8, validateExecutionCapitalLimitsDataFirst)
 
 const validateLiveCapitalLimitsDataFirst = (
   authority: LiveMutationExecutionAuthority,
@@ -833,6 +852,7 @@ const validateLiveCapitalLimitsDataFirst = (
     proposedExposureNotional,
     proposedOrderNotional,
     openOrderNotionals,
+    { closeOnly: false },
   )
 
 export const validateLiveCapitalLimits = Pipeable.dual(6, validateLiveCapitalLimitsDataFirst)
@@ -961,6 +981,7 @@ const validateExecutionBrokerSubmitSnapshotDataFirst = (
   intent: Intent,
   snapshot: ExecutionBrokerSubmitSnapshot,
   observedAt: string,
+  context: ExecutionCapitalLimitContext,
 ): Result.Result<void, LiveBrokerSubmitValidationFailure> => {
   const intentQuote = snapshot.quotes.get(intent.symbol)
   if (intentQuote === undefined) {
@@ -985,10 +1006,11 @@ const validateExecutionBrokerSubmitSnapshotDataFirst = (
     requestedNotional.success,
     orderCapNotional.success,
     openOrderNotionals.success,
+    context,
   )
 }
 
-export const validateExecutionBrokerSubmitSnapshot = Pipeable.dual(5, validateExecutionBrokerSubmitSnapshotDataFirst)
+export const validateExecutionBrokerSubmitSnapshot = Pipeable.dual(6, validateExecutionBrokerSubmitSnapshotDataFirst)
 
 const validateLiveBrokerSubmitSnapshotDataFirst = (
   captured: LiveMutationExecutionAuthority,
@@ -1006,6 +1028,7 @@ const validateLiveBrokerSubmitSnapshotDataFirst = (
         intent,
         snapshot,
         observedAt,
+        { closeOnly: false },
       )
 }
 

--- a/services/bayn/src/execution/runtime-program.test.ts
+++ b/services/bayn/src/execution/runtime-program.test.ts
@@ -373,6 +373,53 @@ describe('same-code execution program composition', () => {
     }
   })
 
+  test('revalidates a live grant after broker refresh and before transmission', async () => {
+    const fixture = finalLiveFixture()
+    let instantReads = 0
+    let posts = 0
+    const testDependencies: ExecutionProgramDependencies = {
+      ...dependencies('live-grant-expiry-during-refresh'),
+      intentStore: {
+        read: () => Effect.succeed(Option.some(fixture.stored)),
+      } as unknown as ExecutionProgramDependencies['intentStore'],
+      mutationStore: {
+        authorizeSubmit: () => Effect.void,
+      } as unknown as ExecutionProgramDependencies['mutationStore'],
+      writerFence: { backendPid: 1, check: Effect.void, transaction: (effect) => effect },
+      liveCapitalGrants: {
+        read: () => Effect.die(new Error('final authorization must use the locked grant read')),
+        lockForSubmit: () => Effect.succeed(liveCapitalAuthority(fixture.grant)),
+      },
+      freshBrokerPrice: (symbol) =>
+        Effect.succeed({
+          symbol,
+          bidPriceMicros: '100000000',
+          askPriceMicros: '100000000',
+          quotedAt: fixture.grant.validUntil,
+          observedAt: fixture.grant.validUntil,
+        }),
+      currentUtcInstant: Effect.sync(() => {
+        instantReads += 1
+        return instantReads === 1 ? observedAt : fixture.grant.validUntil
+      }),
+    }
+
+    const exit = await Effect.runPromise(
+      authorizeFinalBrokerSubmit(
+        fixture.authority,
+        fixture.intent,
+        Effect.sync(() => {
+          posts += 1
+        }),
+        testDependencies,
+      ).pipe(Effect.exit, Effect.provide(TestClock.layer())),
+    )
+
+    expect(finalAuthorizationFailureTag(exit)).toBe('LiveGrantExpired')
+    expect(instantReads).toBe(2)
+    expect(posts).toBe(0)
+  })
+
   test('rejects a risk-policy binding mismatch before broker or grant I/O', async () => {
     const fixture = finalLiveFixture()
     const authority = Result.getOrThrow(

--- a/services/bayn/src/execution/runtime-program.test.ts
+++ b/services/bayn/src/execution/runtime-program.test.ts
@@ -576,6 +576,32 @@ describe('same-code execution program composition', () => {
 
     expect(exit._tag).toBe('Success')
     expect(posts).toBe(1)
+
+    const shortElsewhere = await Effect.runPromise(
+      authorizeFinalBrokerSubmit(
+        authority,
+        intent,
+        Effect.sync(() => {
+          posts += 1
+        }),
+        {
+          ...testDependencies,
+          brokerRead: stableBrokerRead([
+            brokerPosition(),
+            brokerPosition({
+              assetId: '7781125b-04ba-4fcb-903f-ad4c34eb6832',
+              symbol: 'NVDA',
+              side: PositionSide.Short,
+              quantityMicros: '-2000000',
+              marketValueMicros: '-200000000',
+            }),
+          ]),
+        },
+      ).pipe(Effect.exit, Effect.provide(TestClock.layer())),
+    )
+
+    expect(finalAuthorizationFailureTag(shortElsewhere)).toBe('LiveOrderNotionalLimitExceeded')
+    expect(posts).toBe(1)
   })
 
   test('keeps a distinct live-grant order cap on an exposure-reducing close', async () => {

--- a/services/bayn/src/execution/runtime-program.test.ts
+++ b/services/bayn/src/execution/runtime-program.test.ts
@@ -16,6 +16,8 @@ import {
 } from '../broker/alpaca'
 import { BrokerEnvironment, BrokerProvider, makeBrokerIdentity } from '../broker/identity'
 import { BrokerMutationError, MutationFailure } from '../broker/alpaca-mutations'
+import { canonicalHashV1Result } from '../hash'
+import { BrokerMode, type Policy } from '../risk'
 import {
   BrokerAccess,
   CapitalAuthorityKind,
@@ -49,6 +51,28 @@ const strategy: ExecutionStrategyIdentity = {
   parameterHash: '3'.repeat(64),
   parameterSchemaVersion: 'bayn.risk-balanced-trend.protocol.v4',
 }
+const riskPolicy: Policy = {
+  schemaVersion: 'bayn.paper-risk-policy.v1',
+  accountId,
+  brokerMode: BrokerMode.Paper,
+  allowedSymbols: ['AMD'],
+  allowedOrderTypes: [OrderType.Market],
+  allowedTimeInForce: [TimeInForce.Day],
+  maxOrderNotionalMicros: '10000000000',
+  maxSymbolExposureMicros: '25000000000',
+  maxGrossExposureMicros: '100000000000',
+  maxNetExposureMicros: '100000000000',
+  maxDailyTradedNotionalMicros: '200000000000',
+  maxDailyLossMicros: '1000000000',
+  maxDrawdownMicros: '1000000000',
+  maxIntentAgeMs: 300_000,
+  maxBrokerStateAgeMs: 300_000,
+  maxMarketDataAgeMs: 300_000,
+  maxAdverseSlippageBps: 10,
+  maxUnresolvedOrders: 0,
+  decisionTtlMs: 300_000,
+}
+const riskPolicyHash = Result.getOrThrow(canonicalHashV1Result(riskPolicy))
 const identity = (environment: BrokerEnvironment) =>
   Result.getOrThrow(
     makeBrokerIdentity({
@@ -60,7 +84,7 @@ const identity = (environment: BrokerEnvironment) =>
   )
 
 const dependencies = (label: string): ExecutionProgramDependencies => ({
-  brokerRead: {} as ExecutionProgramDependencies['brokerRead'],
+  brokerRead: stableBrokerRead(),
   brokerMutation: {
     submit: () => Effect.die(new Error(`${label} submit must not run during composition proof`)),
     cancel: () => Effect.die(new Error(`${label} cancel must not run during composition proof`)),
@@ -68,11 +92,19 @@ const dependencies = (label: string): ExecutionProgramDependencies => ({
   intentStore: {} as ExecutionProgramDependencies['intentStore'],
   mutationStore: {} as ExecutionProgramDependencies['mutationStore'],
   writerFence: {} as ExecutionProgramDependencies['writerFence'],
+  riskPolicy,
   liveCapitalGrants: {
     lockForSubmit: () => Effect.die(new Error(`${label} live grant lock must not run during composition proof`)),
     read: () => Effect.die(new Error(`${label} live grant read must not run during composition proof`)),
   },
-  freshBrokerPrice: () => Effect.die(new Error(`${label} fresh price read must not run during composition proof`)),
+  freshBrokerPrice: (symbol) =>
+    Effect.succeed({
+      symbol,
+      bidPriceMicros: '100000000',
+      askPriceMicros: '100000000',
+      quotedAt: observedAt,
+      observedAt,
+    }),
   currentUtcInstant: Effect.succeed(observedAt),
 })
 
@@ -83,7 +115,7 @@ const readEvidence: ReadEvidence = {
   observedAt,
 }
 const readResult = <A>(value: A): ReadResult<A> => ({ value, evidence: readEvidence })
-const brokerAccount = (): Account => ({
+const brokerAccount = (overrides: Partial<Account> = {}): Account => ({
   id: accountId,
   status: AccountStatus.Active,
   currency: 'USD',
@@ -95,6 +127,7 @@ const brokerAccount = (): Account => ({
   tradingBlocked: false,
   tradeSuspendedByUser: false,
   observedAt,
+  ...overrides,
 })
 const brokerPosition = (): Position => ({
   accountId,
@@ -110,6 +143,21 @@ const brokerPosition = (): Position => ({
   unrealizedPnlMicros: '0',
   observedAt,
 })
+
+const stableBrokerRead = (positions: readonly Position[] = []): BrokerReadShape => {
+  const unusedRead = Effect.die(new Error('stable broker fixture used an unrelated broker read'))
+  return {
+    account: Effect.succeed(readResult(brokerAccount())),
+    accountConfiguration: unusedRead,
+    assetBySymbol: () => unusedRead,
+    positions: Effect.succeed(readResult(positions)),
+    orders: () => Effect.succeed(readResult([])),
+    orderById: () => unusedRead,
+    orderByClientId: () => unusedRead,
+    fillActivities: () => unusedRead,
+    marketCalendar: () => unusedRead,
+  }
+}
 
 const finalLiveFixture = () => {
   const liveIdentity = identity(BrokerEnvironment.Live)
@@ -151,7 +199,7 @@ const finalLiveFixture = () => {
     strategyName: strategy.name,
     cycleId: '7'.repeat(64),
     decisionHash: '8'.repeat(64),
-    policyHash: '9'.repeat(64),
+    policyHash: riskPolicyHash,
     accountId,
     clientOrderId: `b1_${'C'.repeat(43)}`,
     symbol: 'AMD',
@@ -263,6 +311,113 @@ describe('same-code execution program composition', () => {
     )
   })
 
+  test('applies the same fresh broker-account safeguard to sandbox and live submissions', async () => {
+    const live = finalLiveFixture()
+    const sandboxAuthority = Result.getOrThrow(
+      makeExecutionAuthority({
+        brokerIdentity: identity(BrokerEnvironment.Sandbox),
+        brokerAccess: BrokerAccess.Mutation,
+        capitalAuthority: sandboxCapitalAuthority(authorityGenerationHash),
+        strategy,
+        observedAt,
+      }),
+    )
+    if (sandboxAuthority.brokerAccess !== BrokerAccess.Mutation) {
+      throw new Error('fixture requires sandbox mutation authority')
+    }
+
+    for (const authority of [sandboxAuthority, live.authority]) {
+      let posts = 0
+      let accountReads = 0
+      const brokerRead = stableBrokerRead()
+      const testDependencies: ExecutionProgramDependencies = {
+        ...dependencies(authority.brokerIdentity.environment),
+        brokerRead: {
+          ...brokerRead,
+          account: Effect.sync(() => {
+            accountReads += 1
+            return readResult(brokerAccount({ tradingBlocked: true }))
+          }),
+        },
+        intentStore: {
+          read: () => Effect.succeed(Option.some(live.stored)),
+        } as unknown as ExecutionProgramDependencies['intentStore'],
+        mutationStore: {
+          authorizeSubmit: () => Effect.void,
+        } as unknown as ExecutionProgramDependencies['mutationStore'],
+        writerFence: { backendPid: 1, check: Effect.void, transaction: (effect) => effect },
+        liveCapitalGrants: {
+          read: () => Effect.die(new Error('final authorization must use the locked grant read')),
+          lockForSubmit:
+            authority.brokerIdentity.environment === BrokerEnvironment.Live
+              ? () => Effect.succeed(liveCapitalAuthority(live.grant))
+              : () => Effect.die(new Error('sandbox final authorization must not read a live grant')),
+        },
+      }
+
+      const exit = await Effect.runPromise(
+        authorizeFinalBrokerSubmit(
+          authority,
+          live.intent,
+          Effect.sync(() => {
+            posts += 1
+          }),
+          testDependencies,
+        ).pipe(Effect.exit, Effect.provide(TestClock.layer())),
+      )
+
+      expect(finalAuthorizationFailureTag(exit)).toBe('BrokerAccountUnavailable')
+      expect(accountReads).toBe(1)
+      expect(posts).toBe(0)
+    }
+  })
+
+  test('rejects a risk-policy binding mismatch before broker or grant I/O', async () => {
+    const fixture = finalLiveFixture()
+    const authority = Result.getOrThrow(
+      makeExecutionAuthority({
+        brokerIdentity: identity(BrokerEnvironment.Sandbox),
+        brokerAccess: BrokerAccess.Mutation,
+        capitalAuthority: sandboxCapitalAuthority(authorityGenerationHash),
+        strategy,
+        observedAt,
+      }),
+    )
+    if (authority.brokerAccess !== BrokerAccess.Mutation) throw new Error('fixture requires mutation authority')
+    const intent = { ...fixture.intent, policyHash: '0'.repeat(64) }
+    const stored = {
+      ...fixture.stored,
+      intent,
+      decision: { ...fixture.stored.decision, policyHash: intent.policyHash },
+    }
+    let posts = 0
+    const testDependencies: ExecutionProgramDependencies = {
+      ...dependencies('policy-mismatch'),
+      brokerRead: {} as ExecutionProgramDependencies['brokerRead'],
+      intentStore: {
+        read: () => Effect.succeed(Option.some(stored)),
+      } as unknown as ExecutionProgramDependencies['intentStore'],
+      mutationStore: {
+        authorizeSubmit: () => Effect.void,
+      } as unknown as ExecutionProgramDependencies['mutationStore'],
+      writerFence: { backendPid: 1, check: Effect.void, transaction: (effect) => effect },
+    }
+
+    const exit = await Effect.runPromise(
+      authorizeFinalBrokerSubmit(
+        authority,
+        intent,
+        Effect.sync(() => {
+          posts += 1
+        }),
+        testDependencies,
+      ).pipe(Effect.exit, Effect.provide(TestClock.layer())),
+    )
+
+    expect(finalAuthorizationFailureTag(exit)).toBe('ExecutionRiskPolicyHashMismatch')
+    expect(posts).toBe(0)
+  })
+
   test('expires PAPER submission authority at runtime while allowing only a precommitted close intent', async () => {
     const sandboxIdentity = identity(BrokerEnvironment.Sandbox)
     const authority = Result.getOrThrow(
@@ -287,6 +442,7 @@ describe('same-code execution program composition', () => {
     let authorizedCloseOnly: boolean | undefined
     const shared: ExecutionProgramDependencies = {
       ...dependencies('paper-lease'),
+      brokerRead: stableBrokerRead([brokerPosition()]),
       intentStore: {
         read: () => Effect.succeed(Option.some(stored)),
       } as unknown as ExecutionProgramDependencies['intentStore'],
@@ -302,6 +458,14 @@ describe('same-code execution program composition', () => {
         transaction: (effect) => effect,
       },
       currentUtcInstant: Effect.succeed(afterEntryBeforeClose),
+      freshBrokerPrice: (symbol) =>
+        Effect.succeed({
+          symbol,
+          bidPriceMicros: '100000000',
+          askPriceMicros: '100000000',
+          quotedAt: afterEntryBeforeClose,
+          observedAt: afterEntryBeforeClose,
+        }),
       paperEpisodeEntryExpiresAt: episodeExpiresAt,
       paperEpisodeCloseExpiresAt: closeExpiresAt,
     }
@@ -397,7 +561,7 @@ describe('same-code execution program composition', () => {
       strategyName: strategy.name,
       cycleId: 'c'.repeat(64),
       decisionHash: 'd'.repeat(64),
-      policyHash: 'e'.repeat(64),
+      policyHash: riskPolicyHash,
       accountId,
       clientOrderId: `b1_${'A'.repeat(43)}`,
       symbol: 'AMD',
@@ -638,7 +802,7 @@ describe('same-code execution program composition', () => {
       strategyName: strategy.name,
       cycleId: '9'.repeat(64),
       decisionHash: 'a'.repeat(64),
-      policyHash: 'b'.repeat(64),
+      policyHash: riskPolicyHash,
       accountId,
       clientOrderId: `b1_${'B'.repeat(43)}`,
       symbol: 'AMD',

--- a/services/bayn/src/execution/runtime-program.test.ts
+++ b/services/bayn/src/execution/runtime-program.test.ts
@@ -420,6 +420,63 @@ describe('same-code execution program composition', () => {
     expect(posts).toBe(0)
   })
 
+  test('revalidates the PAPER lease after broker refresh and before transmission', async () => {
+    const fixture = finalLiveFixture()
+    const sandboxAuthority = Result.getOrThrow(
+      makeExecutionAuthority({
+        brokerIdentity: identity(BrokerEnvironment.Sandbox),
+        brokerAccess: BrokerAccess.Mutation,
+        capitalAuthority: sandboxCapitalAuthority(authorityGenerationHash),
+        strategy,
+        observedAt,
+      }),
+    )
+    if (sandboxAuthority.brokerAccess !== BrokerAccess.Mutation) {
+      throw new Error('fixture requires sandbox mutation authority')
+    }
+    const brokerObservedAt = '2026-07-28T08:00:00.010Z'
+    const expiresAt = '2026-07-28T08:00:00.020Z'
+    const instants = [observedAt, brokerObservedAt, expiresAt]
+    let instantReads = 0
+    let posts = 0
+    const testDependencies: ExecutionProgramDependencies = {
+      ...dependencies('paper-lease-expiry-during-refresh'),
+      intentStore: {
+        read: () => Effect.succeed(Option.some(fixture.stored)),
+      } as unknown as ExecutionProgramDependencies['intentStore'],
+      mutationStore: {
+        authorizeSubmit: () => Effect.void,
+      } as unknown as ExecutionProgramDependencies['mutationStore'],
+      writerFence: { backendPid: 1, check: Effect.void, transaction: (effect) => effect },
+      freshBrokerPrice: (symbol) =>
+        Effect.succeed({
+          symbol,
+          bidPriceMicros: '100000000',
+          askPriceMicros: '100000000',
+          quotedAt: brokerObservedAt,
+          observedAt: brokerObservedAt,
+        }),
+      currentUtcInstant: Effect.sync(() => instants[instantReads++] ?? expiresAt),
+      paperEpisodeEntryExpiresAt: expiresAt,
+      isPaperEpisodeCloseIntent: () => Effect.succeed(false),
+    }
+
+    const exit = await Effect.runPromise(
+      authorizeFinalBrokerSubmit(
+        sandboxAuthority,
+        fixture.intent,
+        Effect.sync(() => {
+          posts += 1
+        }),
+        testDependencies,
+      ).pipe(Effect.exit, Effect.provide(TestClock.layer())),
+    )
+
+    expect(finalAuthorizationFailureTag(exit)).toBe('PaperEpisodeExpired')
+    expect(instantReads).toBe(3)
+    expect(posts).toBe(0)
+  })
+
   test('rejects a risk-policy binding mismatch before broker or grant I/O', async () => {
     const fixture = finalLiveFixture()
     const authority = Result.getOrThrow(

--- a/services/bayn/src/execution/runtime-program.test.ts
+++ b/services/bayn/src/execution/runtime-program.test.ts
@@ -129,7 +129,7 @@ const brokerAccount = (overrides: Partial<Account> = {}): Account => ({
   observedAt,
   ...overrides,
 })
-const brokerPosition = (): Position => ({
+const brokerPosition = (overrides: Partial<Position> = {}): Position => ({
   accountId,
   assetId: 'b0b6dd9d-8b9b-48a9-ba46-b9d54906e415',
   symbol: 'AMD',
@@ -142,12 +142,13 @@ const brokerPosition = (): Position => ({
   marketValueMicros: '100000000',
   unrealizedPnlMicros: '0',
   observedAt,
+  ...overrides,
 })
 
-const stableBrokerRead = (positions: readonly Position[] = []): BrokerReadShape => {
+const stableBrokerRead = (positions: readonly Position[] = [], account: Account = brokerAccount()): BrokerReadShape => {
   const unusedRead = Effect.die(new Error('stable broker fixture used an unrelated broker read'))
   return {
-    account: Effect.succeed(readResult(brokerAccount())),
+    account: Effect.succeed(readResult(account)),
     accountConfiguration: unusedRead,
     assetBySymbol: () => unusedRead,
     positions: Effect.succeed(readResult(positions)),
@@ -517,6 +518,131 @@ describe('same-code execution program composition', () => {
     )
     expect(finalAuthorizationFailureTag(closeExpired)).toBe('PaperEpisodeExpired')
     expect(posts).toBe(1)
+  })
+
+  test('preserves policy limit exemptions for a freshly verified exposure-reducing close', async () => {
+    const authority = Result.getOrThrow(
+      makeExecutionAuthority({
+        brokerIdentity: identity(BrokerEnvironment.Sandbox),
+        brokerAccess: BrokerAccess.Mutation,
+        capitalAuthority: sandboxCapitalAuthority(authorityGenerationHash),
+        strategy,
+        observedAt,
+      }),
+    )
+    if (authority.brokerAccess !== BrokerAccess.Mutation) throw new Error('fixture requires mutation authority')
+    const source = finalLiveFixture()
+    const closePolicy: Policy = {
+      ...riskPolicy,
+      maxOrderNotionalMicros: '99999999',
+      maxDailyLossMicros: '99999999',
+    }
+    const policyHash = Result.getOrThrow(canonicalHashV1Result(closePolicy))
+    const intent: Intent = { ...source.intent, side: OrderSide.Sell, policyHash }
+    if (source.stored.decision === undefined) throw new Error('fixture requires an approved risk decision')
+    const stored: StoredIntent = {
+      ...source.stored,
+      intent,
+      decision: { ...source.stored.decision, policyHash },
+    }
+    let posts = 0
+    const testDependencies: ExecutionProgramDependencies = {
+      ...dependencies('close-policy-exemption'),
+      riskPolicy: closePolicy,
+      brokerRead: stableBrokerRead(
+        [brokerPosition()],
+        brokerAccount({ lastEquityMicros: '1100000000', equityMicros: '1000000000' }),
+      ),
+      intentStore: {
+        read: () => Effect.succeed(Option.some(stored)),
+      } as unknown as ExecutionProgramDependencies['intentStore'],
+      mutationStore: {
+        authorizeSubmit: () => Effect.void,
+      } as unknown as ExecutionProgramDependencies['mutationStore'],
+      writerFence: { backendPid: 1, check: Effect.void, transaction: (effect) => effect },
+      isPaperEpisodeCloseIntent: () => Effect.succeed(true),
+    }
+
+    const exit = await Effect.runPromise(
+      authorizeFinalBrokerSubmit(
+        authority,
+        intent,
+        Effect.sync(() => {
+          posts += 1
+        }),
+        testDependencies,
+      ).pipe(Effect.exit, Effect.provide(TestClock.layer())),
+    )
+
+    expect(exit._tag).toBe('Success')
+    expect(posts).toBe(1)
+  })
+
+  test('keeps a distinct live-grant order cap on an exposure-reducing close', async () => {
+    const liveIdentity = identity(BrokerEnvironment.Live)
+    const grant = Result.getOrThrow(
+      makeLiveCapitalGrant({
+        schemaVersion: 'bayn.live-capital-grant.v1',
+        brokerIdentity: liveIdentity,
+        authorityGenerationHash,
+        strategy,
+        limits: {
+          maxGrossNotionalMicros: '100000000000',
+          maxOrderNotionalMicros: '99999999',
+          maxPositionNotionalMicros: '25000000000',
+          maxDailyLossMicros: '1000000000',
+          maxOpenOrders: 5,
+        },
+        validFrom: '2026-07-28T07:00:00.000Z',
+        validUntil: '2026-07-28T09:00:00.000Z',
+        issuedAt: '2026-07-28T06:00:00.000Z',
+        issuedBy: 'operator:test',
+      }),
+    )
+    const authority = Result.getOrThrow(
+      makeExecutionAuthority({
+        brokerIdentity: liveIdentity,
+        brokerAccess: BrokerAccess.Mutation,
+        capitalAuthority: liveCapitalAuthority(grant),
+        strategy,
+        observedAt,
+      }),
+    )
+    if (authority.brokerAccess !== BrokerAccess.Mutation) throw new Error('fixture requires mutation authority')
+    const source = finalLiveFixture()
+    const intent: Intent = { ...source.intent, side: OrderSide.Sell }
+    const stored: StoredIntent = { ...source.stored, intent }
+    let posts = 0
+    const testDependencies: ExecutionProgramDependencies = {
+      ...dependencies('close-grant-cap'),
+      brokerRead: stableBrokerRead([brokerPosition()]),
+      intentStore: {
+        read: () => Effect.succeed(Option.some(stored)),
+      } as unknown as ExecutionProgramDependencies['intentStore'],
+      mutationStore: {
+        authorizeSubmit: () => Effect.void,
+      } as unknown as ExecutionProgramDependencies['mutationStore'],
+      writerFence: { backendPid: 1, check: Effect.void, transaction: (effect) => effect },
+      liveCapitalGrants: {
+        read: () => Effect.die(new Error('final authorization must use the locked grant read')),
+        lockForSubmit: () => Effect.succeed(liveCapitalAuthority(grant)),
+      },
+      isPaperEpisodeCloseIntent: () => Effect.succeed(true),
+    }
+
+    const exit = await Effect.runPromise(
+      authorizeFinalBrokerSubmit(
+        authority,
+        intent,
+        Effect.sync(() => {
+          posts += 1
+        }),
+        testDependencies,
+      ).pipe(Effect.exit, Effect.provide(TestClock.layer())),
+    )
+
+    expect(finalAuthorizationFailureTag(exit)).toBe('LiveOrderNotionalLimitExceeded')
+    expect(posts).toBe(0)
   })
 
   test('rechecks risk expiry after a blocking live-grant lock and performs zero broker posts', async () => {

--- a/services/bayn/src/execution/runtime-program.ts
+++ b/services/bayn/src/execution/runtime-program.ts
@@ -16,6 +16,7 @@ import {
   CapitalAuthorityKind,
   type ExecutionCapitalLimits,
   type ExecutionAuthority,
+  type LiveCapitalAuthority,
   type MutationExecutionAuthority,
 } from './authority'
 import { IntentStore, type IntentStoreService } from './intents'
@@ -58,6 +59,7 @@ export interface ExecutionProgramConstructionFailure {
 interface FinalExecutionCapitalAuthorization {
   readonly limits: ExecutionCapitalLimits
   readonly hardCloseLimits?: Pick<ExecutionCapitalLimits, 'maxOrderNotionalMicros' | 'maxDailyLossMicros'>
+  readonly liveGrant?: LiveCapitalAuthority
 }
 
 const executionPolicyLimits = (
@@ -108,6 +110,7 @@ const finalExecutionGrantAuthorization = (
     return {
       limits: constrainExecutionCapitalLimits(policyLimits.success, grantLimits),
       hardCloseLimits: grantLimits,
+      liveGrant: persisted,
     }
   })
 }
@@ -122,10 +125,22 @@ const finalBrokerAuthorization = (
   return Effect.gen(function* () {
     const snapshot = yield* refreshExecutionBrokerSubmitSnapshot(capital.limits, intent, dependencies)
     const observedAt = yield* dependencies.currentUtcInstant
-    const validation = validateExecutionBrokerSubmitSnapshot(authority, capital.limits, intent, snapshot, observedAt, {
-      closeOnly,
-      ...(capital.hardCloseLimits === undefined ? {} : { hardCloseLimits: capital.hardCloseLimits }),
-    })
+    const refreshedAuthority =
+      capital.liveGrant === undefined
+        ? Result.succeed(authority)
+        : validateLiveGrantForSubmit(authority, capital.liveGrant, observedAt)
+    if (Result.isFailure(refreshedAuthority)) return yield* Effect.fail(refreshedAuthority.failure)
+    const validation = validateExecutionBrokerSubmitSnapshot(
+      refreshedAuthority.success,
+      capital.limits,
+      intent,
+      snapshot,
+      observedAt,
+      {
+        closeOnly,
+        ...(capital.hardCloseLimits === undefined ? {} : { hardCloseLimits: capital.hardCloseLimits }),
+      },
+    )
     if (Result.isFailure(validation)) return yield* Effect.fail(validation.failure)
   })
 }

--- a/services/bayn/src/execution/runtime-program.ts
+++ b/services/bayn/src/execution/runtime-program.ts
@@ -203,6 +203,7 @@ const authorizeFinalBrokerSubmitDataFirst = <A, E, R>(
         yield* validatePaperEpisodeLease(intent.intentId, dependencies, closeOnly)
         yield* finalBrokerAuthorization(authority, capital, intent, closeOnly, dependencies)
         yield* validateFinalSubmitRisk(intent.intentId, dependencies)
+        yield* validatePaperEpisodeLease(intent.intentId, dependencies, closeOnly)
         transmissionStarted = true
         return yield* transmit
       }),

--- a/services/bayn/src/execution/runtime-program.ts
+++ b/services/bayn/src/execution/runtime-program.ts
@@ -5,6 +5,8 @@ import { BrokerMutation, type BrokerMutationShape } from '../broker/alpaca-mutat
 import { unknownOutcome } from '../broker/alpaca-mutations/model'
 import type { LiveCapitalGrantStoreShape } from '../db/live-capital-grant'
 import type { OperationalError } from '../errors'
+import { canonicalHashV1Result } from '../hash'
+import type { Policy } from '../risk'
 import { MutationOperation } from '../broker/alpaca-mutations'
 import { cancel, dryRunSubmit, recover, submit } from './coordinator'
 import { selectStoredIntent, validateStartedSubmitRiskDecision } from './coordinator-decisions'
@@ -12,17 +14,18 @@ import type { Intent } from './contracts'
 import {
   BrokerAccess,
   CapitalAuthorityKind,
+  type ExecutionCapitalLimits,
   type ExecutionAuthority,
-  type LiveCapitalAuthority,
   type MutationExecutionAuthority,
 } from './authority'
 import { IntentStore, type IntentStoreService } from './intents'
 import { MutationStore, type MutationStoreShape } from './mutations'
 import {
   makeAuthorityGuardedBrokerMutation,
-  isLiveMutationExecutionAuthority,
-  refreshLiveBrokerSubmitSnapshot,
-  validateLiveBrokerSubmitSnapshot,
+  constrainExecutionCapitalLimits,
+  executionCapitalLimitsFromPolicy,
+  refreshExecutionBrokerSubmitSnapshot,
+  validateExecutionBrokerSubmitSnapshot,
   validateLiveGrantForSubmit,
   type FinalSubmitAuthorizationFailure,
   type FreshBrokerQuote,
@@ -37,6 +40,7 @@ export interface ExecutionProgramDependencies {
   readonly mutationStore: MutationStoreShape
   readonly writerFence: WriterFenceService
   readonly liveCapitalGrants: Pick<LiveCapitalGrantStoreShape, 'lockForSubmit' | 'read'>
+  readonly riskPolicy: Policy
   readonly freshBrokerPrice: (symbol: string) => Effect.Effect<FreshBrokerQuote, OperationalError>
   readonly currentUtcInstant: Effect.Effect<string>
   /** The reviewed PAPER entry lease, checked at the final writer fence. */
@@ -51,12 +55,41 @@ export interface ExecutionProgramConstructionFailure {
   readonly brokerAccess: BrokerAccess
 }
 
-const finalLiveGrantAuthorization = (
+const executionPolicyLimits = (
   authority: MutationExecutionAuthority,
+  intent: Intent,
   dependencies: ExecutionProgramDependencies,
-): Effect.Effect<LiveCapitalAuthority | undefined, FinalSubmitAuthorizationFailure> => {
+): Result.Result<ExecutionCapitalLimits, FinalSubmitAuthorizationFailure> => {
+  const policyHash = canonicalHashV1Result(dependencies.riskPolicy)
+  if (Result.isFailure(policyHash)) {
+    return Result.fail({ _tag: 'ExecutionRiskPolicyInvalid' as const })
+  }
+  if (policyHash.success !== intent.policyHash) {
+    return Result.fail({
+      _tag: 'ExecutionRiskPolicyHashMismatch' as const,
+      expected: intent.policyHash,
+      observed: policyHash.success,
+    })
+  }
+  if (dependencies.riskPolicy.accountId !== authority.brokerIdentity.accountId) {
+    return Result.fail({
+      _tag: 'ExecutionRiskPolicyAccountMismatch' as const,
+      expected: authority.brokerIdentity.accountId,
+      observed: dependencies.riskPolicy.accountId,
+    })
+  }
+  return Result.succeed(executionCapitalLimitsFromPolicy(dependencies.riskPolicy))
+}
+
+const finalExecutionGrantAuthorization = (
+  authority: MutationExecutionAuthority,
+  intent: Intent,
+  dependencies: ExecutionProgramDependencies,
+): Effect.Effect<ExecutionCapitalLimits, FinalSubmitAuthorizationFailure> => {
+  const policyLimits = executionPolicyLimits(authority, intent, dependencies)
+  if (Result.isFailure(policyLimits)) return Effect.fail(policyLimits.failure)
   const capital = authority.capitalAuthority
-  if (capital._tag !== CapitalAuthorityKind.LiveGrant) return Effect.as(Effect.void, undefined)
+  if (capital._tag !== CapitalAuthorityKind.LiveGrant) return Effect.succeed(policyLimits.success)
   const grantHash = capital.grant.grantHash
   return Effect.gen(function* () {
     const persisted = yield* dependencies.liveCapitalGrants.lockForSubmit(grantHash)
@@ -66,23 +99,20 @@ const finalLiveGrantAuthorization = (
     const observedAt = yield* dependencies.currentUtcInstant
     const validated = validateLiveGrantForSubmit(authority, persisted, observedAt)
     if (Result.isFailure(validated)) return yield* Effect.fail(validated.failure)
-    return persisted
+    return constrainExecutionCapitalLimits(policyLimits.success, validated.success.capitalAuthority.grant.limits)
   })
 }
 
-const finalLiveBrokerAuthorization = (
+const finalBrokerAuthorization = (
   authority: MutationExecutionAuthority,
-  persisted: LiveCapitalAuthority,
+  limits: ExecutionCapitalLimits,
   intent: Intent,
   dependencies: ExecutionProgramDependencies,
 ): Effect.Effect<void, FinalSubmitAuthorizationFailure> => {
-  if (!isLiveMutationExecutionAuthority(authority)) {
-    return Effect.fail({ _tag: 'FreshAuthorityCapabilityMismatch' as const })
-  }
   return Effect.gen(function* () {
-    const snapshot = yield* refreshLiveBrokerSubmitSnapshot(authority, intent, dependencies)
+    const snapshot = yield* refreshExecutionBrokerSubmitSnapshot(limits, intent, dependencies)
     const observedAt = yield* dependencies.currentUtcInstant
-    const validation = validateLiveBrokerSubmitSnapshot(authority, persisted, intent, snapshot, observedAt)
+    const validation = validateExecutionBrokerSubmitSnapshot(authority, limits, intent, snapshot, observedAt)
     if (Result.isFailure(validation)) return yield* Effect.fail(validation.failure)
   })
 }
@@ -140,13 +170,11 @@ const authorizeFinalBrokerSubmitDataFirst = <A, E, R>(
             : false
         yield* dependencies.mutationStore.authorizeSubmit(intent.intentId, closeOnly)
         yield* validateFinalSubmitRisk(intent.intentId, dependencies)
-        const persisted = yield* finalLiveGrantAuthorization(authority, dependencies)
+        const limits = yield* finalExecutionGrantAuthorization(authority, intent, dependencies)
         yield* validateFinalSubmitRisk(intent.intentId, dependencies)
-        if (persisted !== undefined) {
-          yield* finalLiveBrokerAuthorization(authority, persisted, intent, dependencies)
-          yield* validateFinalSubmitRisk(intent.intentId, dependencies)
-        }
         yield* validatePaperEpisodeLease(intent.intentId, dependencies, closeOnly)
+        yield* finalBrokerAuthorization(authority, limits, intent, dependencies)
+        yield* validateFinalSubmitRisk(intent.intentId, dependencies)
         transmissionStarted = true
         return yield* transmit
       }),

--- a/services/bayn/src/execution/runtime-program.ts
+++ b/services/bayn/src/execution/runtime-program.ts
@@ -55,6 +55,11 @@ export interface ExecutionProgramConstructionFailure {
   readonly brokerAccess: BrokerAccess
 }
 
+interface FinalExecutionCapitalAuthorization {
+  readonly limits: ExecutionCapitalLimits
+  readonly hardCloseLimits?: Pick<ExecutionCapitalLimits, 'maxOrderNotionalMicros' | 'maxDailyLossMicros'>
+}
+
 const executionPolicyLimits = (
   authority: MutationExecutionAuthority,
   intent: Intent,
@@ -85,11 +90,11 @@ const finalExecutionGrantAuthorization = (
   authority: MutationExecutionAuthority,
   intent: Intent,
   dependencies: ExecutionProgramDependencies,
-): Effect.Effect<ExecutionCapitalLimits, FinalSubmitAuthorizationFailure> => {
+): Effect.Effect<FinalExecutionCapitalAuthorization, FinalSubmitAuthorizationFailure> => {
   const policyLimits = executionPolicyLimits(authority, intent, dependencies)
   if (Result.isFailure(policyLimits)) return Effect.fail(policyLimits.failure)
   const capital = authority.capitalAuthority
-  if (capital._tag !== CapitalAuthorityKind.LiveGrant) return Effect.succeed(policyLimits.success)
+  if (capital._tag !== CapitalAuthorityKind.LiveGrant) return Effect.succeed({ limits: policyLimits.success })
   const grantHash = capital.grant.grantHash
   return Effect.gen(function* () {
     const persisted = yield* dependencies.liveCapitalGrants.lockForSubmit(grantHash)
@@ -99,20 +104,28 @@ const finalExecutionGrantAuthorization = (
     const observedAt = yield* dependencies.currentUtcInstant
     const validated = validateLiveGrantForSubmit(authority, persisted, observedAt)
     if (Result.isFailure(validated)) return yield* Effect.fail(validated.failure)
-    return constrainExecutionCapitalLimits(policyLimits.success, validated.success.capitalAuthority.grant.limits)
+    const grantLimits = validated.success.capitalAuthority.grant.limits
+    return {
+      limits: constrainExecutionCapitalLimits(policyLimits.success, grantLimits),
+      hardCloseLimits: grantLimits,
+    }
   })
 }
 
 const finalBrokerAuthorization = (
   authority: MutationExecutionAuthority,
-  limits: ExecutionCapitalLimits,
+  capital: FinalExecutionCapitalAuthorization,
   intent: Intent,
+  closeOnly: boolean,
   dependencies: ExecutionProgramDependencies,
 ): Effect.Effect<void, FinalSubmitAuthorizationFailure> => {
   return Effect.gen(function* () {
-    const snapshot = yield* refreshExecutionBrokerSubmitSnapshot(limits, intent, dependencies)
+    const snapshot = yield* refreshExecutionBrokerSubmitSnapshot(capital.limits, intent, dependencies)
     const observedAt = yield* dependencies.currentUtcInstant
-    const validation = validateExecutionBrokerSubmitSnapshot(authority, limits, intent, snapshot, observedAt)
+    const validation = validateExecutionBrokerSubmitSnapshot(authority, capital.limits, intent, snapshot, observedAt, {
+      closeOnly,
+      ...(capital.hardCloseLimits === undefined ? {} : { hardCloseLimits: capital.hardCloseLimits }),
+    })
     if (Result.isFailure(validation)) return yield* Effect.fail(validation.failure)
   })
 }
@@ -170,10 +183,10 @@ const authorizeFinalBrokerSubmitDataFirst = <A, E, R>(
             : false
         yield* dependencies.mutationStore.authorizeSubmit(intent.intentId, closeOnly)
         yield* validateFinalSubmitRisk(intent.intentId, dependencies)
-        const limits = yield* finalExecutionGrantAuthorization(authority, intent, dependencies)
+        const capital = yield* finalExecutionGrantAuthorization(authority, intent, dependencies)
         yield* validateFinalSubmitRisk(intent.intentId, dependencies)
         yield* validatePaperEpisodeLease(intent.intentId, dependencies, closeOnly)
-        yield* finalBrokerAuthorization(authority, limits, intent, dependencies)
+        yield* finalBrokerAuthorization(authority, capital, intent, closeOnly, dependencies)
         yield* validateFinalSubmitRisk(intent.intentId, dependencies)
         transmissionStarted = true
         return yield* transmit


### PR DESCRIPTION
## Summary

- run sandbox and live submissions through one writer-fenced final authorization sequence
- bind final submission to the exact source-controlled risk policy and let live grants only tighten its limits
- refresh account, positions, open orders, and quotes for both broker environments immediately before transmission
- revalidate the locked live grant and PAPER lease against the post-refresh time before broker transmission
- remove the duplicate live-only preflight from the broker mutation adapter

## Related Issues

None

## Testing

- `bun test services/bayn/src/execution/runtime-program.test.ts services/bayn/src/execution/mutation-authority.test.ts services/bayn/src/composition.test.ts` (59 pass, 0 fail)
- `bun run --filter @proompteng/bayn test` (1,066 pass, 160 environment-gated skips, 0 fail)
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn build`
- `bun run --filter @proompteng/bayn test:postgres` (database-gated integration cases skipped because no test database URL was configured)

## Breaking Changes

None. Persisted authority, grant, intent, decision, and generation schemas remain unchanged.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable and Breaking Changes is filled in.
- [x] Documentation and follow-up cleanup are carried in dependent stack layers.
