### PR TITLE
refactor(bayn): remove account-specific execution plumbing

### DIFF
--- a/services/bayn/README.md
+++ b/services/bayn/README.md
@@ -1,12 +1,13 @@
 # Bayn
 
-Bayn is a single-writer, paper-only quantitative research and execution runtime. Its active strategy is
+Bayn is a single-writer quantitative research and execution runtime. Its active strategy is
 `bayn.risk-balanced-trend.protocol.v4`: normalized horizon trends are clipped before a median aggregate, at least three
 of four horizons must be positive, and eligible sleeves are risk-budgeted by conviction per unit annualized volatility.
 The universe, monthly rebalance, 35% sleeve cap, 10% portfolio-volatility ceiling, execution costs, benchmarks,
 uncertainty policy, and economic gates are source-controlled. A terminal qualification result never grants broker or
-capital authority by itself. GitOps may separately grant one bounded sandbox PAPER generation from either a qualified
-binding or an explicit research binding; Bayn never composes live-capital authority.
+capital authority by itself. GitOps currently grants only bounded sandbox PAPER generations from qualified or explicit
+research bindings. The final authorization and broker-mutation core is account-environment agnostic; live-capital grants
+remain a dormant adapter boundary until separately reviewed and configured.
 
 ## Runtime contract
 

--- a/services/bayn/src/composition.ts
+++ b/services/bayn/src/composition.ts
@@ -1539,9 +1539,9 @@ const runAutonomousService = (plan: ApplicationPlanFor<'AutonomousService'>) =>
                                                 runtimeServices.alpacaHttpClient,
                                               ),
                                               currentUtcInstant,
-                                              paperEpisodeEntryExpiresAt: request.cutoffAt,
-                                              paperEpisodeCloseExpiresAt: paperEpisodeCloseExpiresAt(request.expiresAt),
-                                              isPaperEpisodeCloseIntent: (intentId) =>
+                                              entrySubmitExpiresAt: request.cutoffAt,
+                                              closeSubmitExpiresAt: paperEpisodeCloseExpiresAt(request.expiresAt),
+                                              isCloseOnlyIntent: (intentId) =>
                                                 runtimeServices.paperCycleClosureStore
                                                   .containsIntent(intentId)
                                                   .pipe(Effect.orElseSucceed(() => false)),

--- a/services/bayn/src/execution/mutation-authority.test.ts
+++ b/services/bayn/src/execution/mutation-authority.test.ts
@@ -37,8 +37,9 @@ import {
 import {
   isLiveMutationExecutionAuthority,
   makeAuthorityGuardedBrokerMutation,
-  refreshLiveBrokerSubmitSnapshot,
-  validateLiveBrokerSubmitSnapshot,
+  refreshExecutionBrokerSubmitSnapshot,
+  validateExecutionBrokerSubmitSnapshot,
+  validateLiveGrantForSubmit,
   type FinalSubmitAuthorization,
 } from './mutation-authority'
 
@@ -307,24 +308,29 @@ const runLiveSubmit = async (input: ScenarioInput = {}) => {
     input.finalSubmitAuthorization ??
     ((proposedIntent, transmit) =>
       Effect.gen(function* () {
-        const snapshot = yield* refreshLiveBrokerSubmitSnapshot(authority, proposedIntent, {
+        const snapshot = yield* refreshExecutionBrokerSubmitSnapshot(grant.limits, proposedIntent, {
           brokerRead,
           freshBrokerPrice,
         })
         const persisted = yield* liveCapitalGrants.read()
         if (persisted === undefined) return yield* Effect.fail({ _tag: 'LiveCapitalGrantMissing' as const })
         const observedAt = yield* currentUtcInstant
-        const validation = validateLiveBrokerSubmitSnapshot(authority, persisted, proposedIntent, snapshot, observedAt)
+        const freshAuthority = validateLiveGrantForSubmit(authority, persisted, observedAt)
+        if (Result.isFailure(freshAuthority)) return yield* Effect.fail(freshAuthority.failure)
+        const validation = validateExecutionBrokerSubmitSnapshot(
+          freshAuthority.success,
+          freshAuthority.success.capitalAuthority.grant.limits,
+          proposedIntent,
+          snapshot,
+          observedAt,
+          { closeOnly: false },
+        )
         if (Result.isFailure(validation)) return yield* Effect.fail(validation.failure)
         trace.push('authorize')
         return yield* transmit
       }))
   const guarded = makeAuthorityGuardedBrokerMutation(authority, {
-    brokerRead,
     brokerMutation,
-    liveCapitalGrants,
-    freshBrokerPrice,
-    currentUtcInstant,
     finalSubmitAuthorization,
   })
   const exit = await Effect.runPromiseExit(guarded.submit(input.proposedIntent ?? intent()))
@@ -361,7 +367,7 @@ describe('final broker mutation authority', () => {
       openOrders: [],
     })
 
-    expect(failureTag(observed.exit)).toBe('LiveBrokerPositionSnapshotChanged')
+    expect(failureTag(observed.exit)).toBe('BrokerPositionSnapshotChanged')
     expect(observed.positionReads).toBe(2)
     expect(observed.priceReads).toBe(0)
     expect(observed.grantReads).toBe(0)
@@ -434,26 +440,26 @@ describe('final broker mutation authority', () => {
   })
 
   test.each([
-    ['order notional', { maxOrderNotionalMicros: '99999999' }, {}, 'LiveOrderNotionalLimitExceeded'],
+    ['order notional', { maxOrderNotionalMicros: '99999999' }, {}, 'OrderNotionalLimitExceeded'],
     [
       'position notional',
       { maxPositionNotionalMicros: '150000000' },
       { positions: [position()] },
-      'LivePositionNotionalLimitExceeded',
+      'PositionNotionalLimitExceeded',
     ],
     [
       'gross notional',
       { maxGrossNotionalMicros: '150000000' },
       { positions: [position()] },
-      'LiveGrossNotionalLimitExceeded',
+      'GrossNotionalLimitExceeded',
     ],
     [
       'daily loss',
       { maxDailyLossMicros: '99999999' },
       { brokerAccount: account({ lastEquityMicros: '1100000000', equityMicros: '1000000000' }) },
-      'LiveDailyLossLimitExceeded',
+      'DailyLossLimitExceeded',
     ],
-    ['open orders', { maxOpenOrders: 1 }, { openOrders: [order()] }, 'LiveOpenOrderLimitExceeded'],
+    ['open orders', { maxOpenOrders: 1 }, { openOrders: [order()] }, 'OpenOrderLimitExceeded'],
   ] as const)(
     'enforces the live %s limit at the final boundary',
     async (_name, limitOverride, snapshotOverride, tag) => {
@@ -553,7 +559,7 @@ describe('final broker mutation authority', () => {
       }),
     })
 
-    expect(failureTag(observed.exit)).toBe('LiveIncreasingSellUnsupported')
+    expect(failureTag(observed.exit)).toBe('IncreasingSellUnsupported')
     expect(observed.submits).toBe(0)
   })
 
@@ -576,7 +582,7 @@ describe('final broker mutation authority', () => {
       }),
     })
 
-    expect(failureTag(observed.exit)).toBe('LiveIncreasingSellUnsupported')
+    expect(failureTag(observed.exit)).toBe('IncreasingSellUnsupported')
     expect(observed.submits).toBe(0)
   })
 
@@ -595,7 +601,7 @@ describe('final broker mutation authority', () => {
       openOrders: [queuedSell],
     })
 
-    expect(failureTag(observed.exit)).toBe('LiveGrossNotionalLimitExceeded')
+    expect(failureTag(observed.exit)).toBe('GrossNotionalLimitExceeded')
     expect(observed.submits).toBe(0)
   })
 
@@ -618,7 +624,7 @@ describe('final broker mutation authority', () => {
       },
     })
 
-    expect(failureTag(observed.exit)).toBe('LivePendingSellUncovered')
+    expect(failureTag(observed.exit)).toBe('PendingSellUncovered')
     expect(observed.submits).toBe(0)
   })
 
@@ -708,7 +714,7 @@ describe('final broker mutation authority', () => {
       proposedIntent: intent({ side: OrderSide.Sell, notionalLimitMicros: '99000000' }),
     })
 
-    expect(failureTag(observed.exit)).toBe('LiveOrderNotionalLimitExceeded')
+    expect(failureTag(observed.exit)).toBe('OrderNotionalLimitExceeded')
     expect(observed.submits).toBe(0)
   })
 
@@ -722,7 +728,7 @@ describe('final broker mutation authority', () => {
       freshAskPriceMicros: '121000000',
     })
 
-    expect(failureTag(observed.exit)).toBe('LiveOrderNotionalLimitExceeded')
+    expect(failureTag(observed.exit)).toBe('OrderNotionalLimitExceeded')
     expect(observed.submits).toBe(0)
   })
 
@@ -783,21 +789,7 @@ describe('final broker mutation authority', () => {
     const guarded = makeAuthorityGuardedBrokerMutation(
       mutationAuthority(BrokerEnvironment.Sandbox, sandboxCapitalAuthority(authorityGenerationHash)),
       {
-        brokerRead: new Proxy({} as BrokerReadShape, {
-          get: () => {
-            reads += 1
-            return Effect.die(new Error('sandbox must not read live exposure'))
-          },
-        }),
         brokerMutation: mutation,
-        liveCapitalGrants: {
-          read: () => {
-            grantReads += 1
-            return Effect.as(Effect.void, undefined)
-          },
-        },
-        freshBrokerPrice: () => Effect.die(new Error('sandbox must not read a live broker price')),
-        currentUtcInstant: Effect.die(new Error('sandbox must not read the live grant clock')),
         finalSubmitAuthorization: (_intent, transmit) => transmit,
       },
     )
@@ -826,23 +818,7 @@ describe('final broker mutation authority', () => {
     const guarded = makeAuthorityGuardedBrokerMutation(
       mutationAuthority(BrokerEnvironment.Live, liveCapitalAuthority(grant)),
       {
-        brokerRead: {} as BrokerReadShape,
         brokerMutation: mutation,
-        liveCapitalGrants: {
-          read: () => {
-            grantReads += 1
-            return Effect.succeed(
-              liveCapitalAuthority(grant, {
-                schemaVersion: 'bayn.live-capital-grant-revocation.v1',
-                revokedAt: activeAt,
-                revokedBy: 'operator:test',
-                reason: 'containment',
-              }),
-            )
-          },
-        },
-        freshBrokerPrice: () => Effect.die(new Error('cancellation must not read a broker price')),
-        currentUtcInstant: Effect.succeed(activeAt),
         finalSubmitAuthorization: () => Effect.die(new Error('cancellation must not authorize submit')),
       },
     )

--- a/services/bayn/src/execution/mutation-authority.ts
+++ b/services/bayn/src/execution/mutation-authority.ts
@@ -17,7 +17,6 @@ import {
   orderPriceBoundaryMicros,
   type BrokerMutationShape,
 } from '../broker/alpaca-mutations'
-import type { LiveCapitalGrantStoreShape } from '../db/live-capital-grant'
 import type { OperationalError } from '../errors'
 import { canonicalHashV1Result } from '../hash'
 import { OrderSide as IntentOrderSide, type Intent } from '../paper'
@@ -64,7 +63,7 @@ export type IntentAuthorityBindingFailure =
       readonly observed: string
     }
 
-export type LiveCapitalLimitFailure =
+export type ExecutionCapitalLimitFailure =
   | IntentAuthorityBindingFailure
   | {
       readonly _tag: 'BrokerAccountMismatch'
@@ -113,38 +112,38 @@ export type LiveCapitalLimitFailure =
       readonly filledQuantityMicros: string
     }
   | {
-      readonly _tag: 'LiveOrderNotionalLimitExceeded'
+      readonly _tag: 'OrderNotionalLimitExceeded'
       readonly limitMicros: string
       readonly proposedMicros: string
     }
   | {
-      readonly _tag: 'LivePositionNotionalLimitExceeded'
+      readonly _tag: 'PositionNotionalLimitExceeded'
       readonly symbol: string
       readonly limitMicros: string
       readonly projectedMicros: string
     }
   | {
-      readonly _tag: 'LiveGrossNotionalLimitExceeded'
+      readonly _tag: 'GrossNotionalLimitExceeded'
       readonly limitMicros: string
       readonly projectedMicros: string
     }
   | {
-      readonly _tag: 'LiveDailyLossLimitExceeded'
+      readonly _tag: 'DailyLossLimitExceeded'
       readonly limitMicros: string
       readonly observedMicros: string
     }
   | {
-      readonly _tag: 'LiveOpenOrderLimitExceeded'
+      readonly _tag: 'OpenOrderLimitExceeded'
       readonly limit: number
       readonly observed: number
     }
   | {
-      readonly _tag: 'LiveBrokerPositionSnapshotChanged'
+      readonly _tag: 'BrokerPositionSnapshotChanged'
       readonly beforeHash: string
       readonly afterHash: string
     }
   | {
-      readonly _tag: 'LiveBrokerPositionSnapshotInvalid'
+      readonly _tag: 'BrokerPositionSnapshotInvalid'
       readonly cause: unknown
     }
   | {
@@ -169,13 +168,13 @@ export type LiveCapitalLimitFailure =
       readonly observedMicros: string
     }
   | {
-      readonly _tag: 'LiveIncreasingSellUnsupported'
+      readonly _tag: 'IncreasingSellUnsupported'
       readonly symbol: string
       readonly currentQuantityMicros: string
       readonly projectedQuantityMicros: string
     }
   | {
-      readonly _tag: 'LivePendingSellUncovered'
+      readonly _tag: 'PendingSellUncovered'
       readonly symbol: string
       readonly currentQuantityMicros: string
       readonly pendingSellQuantityMicros: string
@@ -190,8 +189,6 @@ export interface ExecutionCapitalSnapshot {
   readonly positions: readonly Position[]
   readonly openOrders: readonly Order[]
 }
-
-export type LiveCapitalSnapshot = ExecutionCapitalSnapshot
 
 export interface FreshBrokerQuote {
   readonly symbol: string
@@ -210,11 +207,7 @@ export interface FinalSubmitAuthorization {
 }
 
 export interface MutationAuthorityDependencies {
-  readonly brokerRead: BrokerReadShape
   readonly brokerMutation: BrokerMutationShape
-  readonly liveCapitalGrants: Pick<LiveCapitalGrantStoreShape, 'read'>
-  readonly freshBrokerPrice: (symbol: string) => Effect.Effect<FreshBrokerQuote, OperationalError>
-  readonly currentUtcInstant: Effect.Effect<string>
   readonly finalSubmitAuthorization: FinalSubmitAuthorization
 }
 
@@ -222,9 +215,10 @@ export interface ExecutionBrokerSubmitSnapshot extends ExecutionCapitalSnapshot 
   readonly quotes: ReadonlyMap<string, FreshBrokerQuote>
 }
 
-export type LiveBrokerSubmitSnapshot = ExecutionBrokerSubmitSnapshot
-
-export type LiveBrokerSubmitRefreshDependencies = Pick<MutationAuthorityDependencies, 'brokerRead' | 'freshBrokerPrice'>
+export interface BrokerSubmitRefreshDependencies {
+  readonly brokerRead: BrokerReadShape
+  readonly freshBrokerPrice: (symbol: string) => Effect.Effect<FreshBrokerQuote, OperationalError>
+}
 
 export interface ExecutionCapitalLimitContext {
   readonly closeOnly: boolean
@@ -277,28 +271,28 @@ const positionExposureIdentity = (positions: readonly Position[]) =>
       left.assetId < right.assetId ? -1 : left.assetId > right.assetId ? 1 : left.symbol.localeCompare(right.symbol),
     )
 
-const validateStableLivePositionSnapshotDataFirst = (
+const validateStablePositionSnapshotDataFirst = (
   before: readonly Position[],
   after: readonly Position[],
-): Result.Result<readonly Position[], LiveCapitalLimitFailure> => {
+): Result.Result<readonly Position[], ExecutionCapitalLimitFailure> => {
   const beforeHash = canonicalHashV1Result(positionExposureIdentity(before))
   if (Result.isFailure(beforeHash)) {
-    return Result.fail({ _tag: 'LiveBrokerPositionSnapshotInvalid', cause: beforeHash.failure })
+    return Result.fail({ _tag: 'BrokerPositionSnapshotInvalid', cause: beforeHash.failure })
   }
   const afterHash = canonicalHashV1Result(positionExposureIdentity(after))
   if (Result.isFailure(afterHash)) {
-    return Result.fail({ _tag: 'LiveBrokerPositionSnapshotInvalid', cause: afterHash.failure })
+    return Result.fail({ _tag: 'BrokerPositionSnapshotInvalid', cause: afterHash.failure })
   }
   return beforeHash.success === afterHash.success
     ? Result.succeed(after)
     : Result.fail({
-        _tag: 'LiveBrokerPositionSnapshotChanged',
+        _tag: 'BrokerPositionSnapshotChanged',
         beforeHash: beforeHash.success,
         afterHash: afterHash.success,
       })
 }
 
-export const validateStableLivePositionSnapshot = Pipeable.dual(2, validateStableLivePositionSnapshotDataFirst)
+export const validateStablePositionSnapshot = Pipeable.dual(2, validateStablePositionSnapshotDataFirst)
 
 const expectedAuthorityGeneration = (authority: MutationExecutionAuthority): string =>
   authority.capitalAuthority._tag === CapitalAuthorityKind.Sandbox
@@ -347,7 +341,7 @@ const freshSidePrice = (
   side: IntentOrderSide | BrokerOrderSide,
   quote: FreshBrokerQuote,
   observedAt: string,
-): Result.Result<bigint, LiveCapitalLimitFailure> => {
+): Result.Result<bigint, ExecutionCapitalLimitFailure> => {
   const priceText =
     side === IntentOrderSide.Buy || side === BrokerOrderSide.Buy ? quote.askPriceMicros : quote.bidPriceMicros
   const priceMicros = parseCanonicalPositiveMicros(priceText)
@@ -383,7 +377,7 @@ const freshSidePrice = (
   return Result.succeed(priceMicros)
 }
 
-export const boundedBrokerOrderNotional = (intent: Intent): Result.Result<bigint, LiveCapitalLimitFailure> => {
+export const boundedBrokerOrderNotional = (intent: Intent): Result.Result<bigint, ExecutionCapitalLimitFailure> => {
   const quantityMicros = parseCanonicalPositiveMicros(intent.quantityMicros)
   const priceBoundary = orderPriceBoundaryMicros(intent)
   if (quantityMicros === undefined || Result.isFailure(priceBoundary)) {
@@ -395,11 +389,11 @@ export const boundedBrokerOrderNotional = (intent: Intent): Result.Result<bigint
   return Result.succeed((quantityMicros * priceBoundary.success + microsPerUnit - 1n) / microsPerUnit)
 }
 
-const liveOrderCapNotionalDataFirst = (
+const orderCapNotionalDataFirst = (
   intent: Intent,
   quote: FreshBrokerQuote,
   observedAt: string,
-): Result.Result<bigint, LiveCapitalLimitFailure> => {
+): Result.Result<bigint, ExecutionCapitalLimitFailure> => {
   if (intent.side === IntentOrderSide.Buy) return boundedBrokerOrderNotional(intent)
   const quantityMicros = parseCanonicalPositiveMicros(intent.quantityMicros)
   const freshBid = freshSidePrice(intent.symbol, intent.side, quote, observedAt)
@@ -414,13 +408,13 @@ const liveOrderCapNotionalDataFirst = (
   return Result.succeed((quantityMicros * freshBid.success + microsPerUnit - 1n) / microsPerUnit)
 }
 
-export const liveOrderCapNotional = Pipeable.dual(3, liveOrderCapNotionalDataFirst)
+export const orderCapNotional = Pipeable.dual(3, orderCapNotionalDataFirst)
 
 const validateBrokerPriceBoundaryDataFirst = (
   intent: Intent,
   quote: FreshBrokerQuote,
   observedAt: string,
-): Result.Result<void, LiveCapitalLimitFailure> => {
+): Result.Result<void, ExecutionCapitalLimitFailure> => {
   const observedPrice = freshSidePrice(intent.symbol, intent.side, quote, observedAt)
   if (Result.isFailure(observedPrice)) return Result.fail(observedPrice.failure)
   const boundary = orderPriceBoundaryMicros(intent)
@@ -453,13 +447,13 @@ const orderHasUnboundedExecutionPrice = (order: Order): boolean =>
   order.limitPriceMicros === undefined &&
   (order.orderType === BrokerOrderType.Stop || order.orderType === BrokerOrderType.TrailingStop)
 
-const quoteSymbolsForLiveExposureDataFirst = (intent: Intent, _openOrders: readonly Order[]): readonly string[] => [
+const quoteSymbolsForExposureDataFirst = (intent: Intent, _openOrders: readonly Order[]): readonly string[] => [
   intent.symbol,
 ]
 
-export const quoteSymbolsForLiveExposure = Pipeable.dual(2, quoteSymbolsForLiveExposureDataFirst)
+export const quoteSymbolsForExposure = Pipeable.dual(2, quoteSymbolsForExposureDataFirst)
 
-const signedOrderNotional = (order: Order): Result.Result<bigint, LiveCapitalLimitFailure> => {
+const signedOrderNotional = (order: Order): Result.Result<bigint, ExecutionCapitalLimitFailure> => {
   const remainingQuantity = unfilledOrderQuantity(order)
   if (Result.isFailure(remainingQuantity)) return Result.fail(remainingQuantity.failure)
   if (orderHasUnboundedExecutionPrice(order)) {
@@ -521,7 +515,7 @@ const unfilledOrderQuantity = (
   order: Order,
 ): Result.Result<
   bigint | undefined,
-  Extract<LiveCapitalLimitFailure, { readonly _tag: 'OpenOrderQuantityUnavailable' | 'OpenOrderQuantityInvalid' }>
+  Extract<ExecutionCapitalLimitFailure, { readonly _tag: 'OpenOrderQuantityUnavailable' | 'OpenOrderQuantityInvalid' }>
 > => {
   if (order.quantityMicros === undefined) return Result.succeed(undefined)
   const quantity = BigInt(order.quantityMicros)
@@ -540,7 +534,7 @@ const unfilledOrderQuantity = (
 
 export const priceOpenOrders = (
   openOrders: readonly Order[],
-): Result.Result<ReadonlyMap<string, bigint>, LiveCapitalLimitFailure> => {
+): Result.Result<ReadonlyMap<string, bigint>, ExecutionCapitalLimitFailure> => {
   const notionals = new Map<string, bigint>()
   for (const order of openOrders) {
     const notional = signedOrderNotional(order)
@@ -552,10 +546,10 @@ export const priceOpenOrders = (
 
 const minimumSymbolQuantityAfterPendingSells = (
   intent: Intent,
-  snapshot: LiveCapitalSnapshot,
+  snapshot: ExecutionCapitalSnapshot,
 ): Result.Result<
   { readonly beforeIntentMicros: bigint; readonly afterIntentMicros: bigint },
-  Extract<LiveCapitalLimitFailure, { readonly _tag: 'OpenOrderQuantityUnavailable' | 'OpenOrderQuantityInvalid' }>
+  Extract<ExecutionCapitalLimitFailure, { readonly _tag: 'OpenOrderQuantityUnavailable' | 'OpenOrderQuantityInvalid' }>
 > => {
   let beforeIntentMicros = snapshot.positions
     .filter((position) => position.symbol === intent.symbol)
@@ -583,14 +577,14 @@ const minimumSymbolQuantityAfterPendingSells = (
 }
 
 export const validatePendingSellCoverage = (
-  snapshot: LiveCapitalSnapshot,
+  snapshot: ExecutionCapitalSnapshot,
 ): Result.Result<
   void,
   Extract<
-    LiveCapitalLimitFailure,
+    ExecutionCapitalLimitFailure,
     | { readonly _tag: 'OpenOrderQuantityUnavailable' }
     | { readonly _tag: 'OpenOrderQuantityInvalid' }
-    | { readonly _tag: 'LivePendingSellUncovered' }
+    | { readonly _tag: 'PendingSellUncovered' }
   >
 > => {
   const currentBySymbol = new Map<string, bigint>()
@@ -614,7 +608,7 @@ export const validatePendingSellCoverage = (
     const currentQuantity = currentBySymbol.get(symbol) ?? 0n
     if (pendingSellQuantity > currentQuantity) {
       return Result.fail({
-        _tag: 'LivePendingSellUncovered',
+        _tag: 'PendingSellUncovered',
         symbol,
         currentQuantityMicros: currentQuantity.toString(),
         pendingSellQuantityMicros: pendingSellQuantity.toString(),
@@ -649,7 +643,7 @@ export const maximumAbsoluteExposureAcrossPendingFills = Pipeable.dual(
 const validateSnapshotBindings = (
   authority: MutationExecutionAuthority,
   snapshot: ExecutionCapitalSnapshot,
-): Result.Result<void, LiveCapitalLimitFailure> => {
+): Result.Result<void, ExecutionCapitalLimitFailure> => {
   const expectedAccountId = authority.brokerIdentity.accountId
   if (snapshot.account.id !== expectedAccountId) {
     return Result.fail({
@@ -704,7 +698,7 @@ const validateExecutionCapitalLimitsDataFirst = (
   proposedOrderNotional: bigint,
   openOrderNotionals: ReadonlyMap<string, bigint>,
   context: ExecutionCapitalLimitContext,
-): Result.Result<void, LiveCapitalLimitFailure> => {
+): Result.Result<void, ExecutionCapitalLimitFailure> => {
   const binding = validateIntentAuthorityBinding(authority, intent)
   if (Result.isFailure(binding)) return Result.fail(binding.failure)
   const snapshotBinding = validateSnapshotBindings(authority, snapshot)
@@ -714,7 +708,7 @@ const validateExecutionCapitalLimitsDataFirst = (
 
   if (snapshot.openOrders.length >= limits.maxOpenOrders) {
     return Result.fail({
-      _tag: 'LiveOpenOrderLimitExceeded',
+      _tag: 'OpenOrderLimitExceeded',
       limit: limits.maxOpenOrders,
       observed: snapshot.openOrders.length,
     })
@@ -792,14 +786,14 @@ const validateExecutionCapitalLimitsDataFirst = (
     : limits.maxOrderNotionalMicros
   if (enforcedOrderLimit !== undefined && proposedOrderNotional > BigInt(enforcedOrderLimit)) {
     return Result.fail({
-      _tag: 'LiveOrderNotionalLimitExceeded',
+      _tag: 'OrderNotionalLimitExceeded',
       limitMicros: enforcedOrderLimit,
       proposedMicros: proposedOrderNotional.toString(),
     })
   }
   if (intent.side === IntentOrderSide.Sell && projectedQuantity.success.afterIntentMicros < 0n) {
     return Result.fail({
-      _tag: 'LiveIncreasingSellUnsupported',
+      _tag: 'IncreasingSellUnsupported',
       symbol: intent.symbol,
       currentQuantityMicros: projectedQuantity.success.beforeIntentMicros.toString(),
       projectedQuantityMicros: projectedQuantity.success.afterIntentMicros.toString(),
@@ -808,7 +802,7 @@ const validateExecutionCapitalLimitsDataFirst = (
 
   if (projectedSymbol > BigInt(limits.maxPositionNotionalMicros) && projectedSymbol >= currentSymbol) {
     return Result.fail({
-      _tag: 'LivePositionNotionalLimitExceeded',
+      _tag: 'PositionNotionalLimitExceeded',
       symbol: intent.symbol,
       limitMicros: limits.maxPositionNotionalMicros,
       projectedMicros: projectedSymbol.toString(),
@@ -817,7 +811,7 @@ const validateExecutionCapitalLimitsDataFirst = (
 
   if (projectedGross > BigInt(limits.maxGrossNotionalMicros) && projectedGross >= currentGross) {
     return Result.fail({
-      _tag: 'LiveGrossNotionalLimitExceeded',
+      _tag: 'GrossNotionalLimitExceeded',
       limitMicros: limits.maxGrossNotionalMicros,
       projectedMicros: projectedGross.toString(),
     })
@@ -830,7 +824,7 @@ const validateExecutionCapitalLimitsDataFirst = (
     : limits.maxDailyLossMicros
   if (enforcedDailyLossLimit !== undefined && observedLoss > BigInt(enforcedDailyLossLimit)) {
     return Result.fail({
-      _tag: 'LiveDailyLossLimitExceeded',
+      _tag: 'DailyLossLimitExceeded',
       limitMicros: enforcedDailyLossLimit,
       observedMicros: observedLoss.toString(),
     })
@@ -840,34 +834,13 @@ const validateExecutionCapitalLimitsDataFirst = (
 
 export const validateExecutionCapitalLimits = Pipeable.dual(8, validateExecutionCapitalLimitsDataFirst)
 
-const validateLiveCapitalLimitsDataFirst = (
-  authority: LiveMutationExecutionAuthority,
-  intent: Intent,
-  snapshot: LiveCapitalSnapshot,
-  proposedExposureNotional: bigint,
-  proposedOrderNotional: bigint,
-  openOrderNotionals: ReadonlyMap<string, bigint>,
-): Result.Result<void, LiveCapitalLimitFailure> =>
-  validateExecutionCapitalLimits(
-    authority,
-    authority.capitalAuthority.grant.limits,
-    intent,
-    snapshot,
-    proposedExposureNotional,
-    proposedOrderNotional,
-    openOrderNotionals,
-    { closeOnly: false },
-  )
-
-export const validateLiveCapitalLimits = Pipeable.dual(6, validateLiveCapitalLimitsDataFirst)
-
 const mutationAuthorizationError = (message: string, cause: unknown) =>
   invalidRequest({ operation: MutationOperation.Submit, message, cause })
 
 const refreshExecutionBrokerSubmitSnapshotDataFirst = (
   limits: ExecutionCapitalLimits,
   intent: Intent,
-  dependencies: LiveBrokerSubmitRefreshDependencies,
+  dependencies: BrokerSubmitRefreshDependencies,
 ): Effect.Effect<ExecutionBrokerSubmitSnapshot, BrokerMutationError> =>
   Effect.gen(function* () {
     const account = yield* dependencies.brokerRead.account.pipe(
@@ -895,14 +868,14 @@ const refreshExecutionBrokerSubmitSnapshotDataFirst = (
         mutationAuthorizationError('broker positions could not be confirmed after open-order refresh', cause),
       ),
     )
-    const stablePositions = validateStableLivePositionSnapshot(positionsBefore.value, positionsAfter.value)
+    const stablePositions = validateStablePositionSnapshot(positionsBefore.value, positionsAfter.value)
     if (Result.isFailure(stablePositions)) {
       return yield* mutationAuthorizationError(
         'broker position snapshot changed during exposure refresh',
         stablePositions.failure,
       )
     }
-    const quoteSymbols = quoteSymbolsForLiveExposure(intent, openOrders.value)
+    const quoteSymbols = quoteSymbolsForExposure(intent, openOrders.value)
     const quoteEntries = yield* Effect.forEach(quoteSymbols, (symbol) =>
       dependencies.freshBrokerPrice(symbol).pipe(
         Effect.map((quote) => [symbol, quote] as const),
@@ -920,15 +893,6 @@ const refreshExecutionBrokerSubmitSnapshotDataFirst = (
   })
 
 export const refreshExecutionBrokerSubmitSnapshot = Pipeable.dual(3, refreshExecutionBrokerSubmitSnapshotDataFirst)
-
-const refreshLiveBrokerSubmitSnapshotDataFirst = (
-  authority: LiveMutationExecutionAuthority,
-  intent: Intent,
-  dependencies: LiveBrokerSubmitRefreshDependencies,
-): Effect.Effect<LiveBrokerSubmitSnapshot, BrokerMutationError> =>
-  refreshExecutionBrokerSubmitSnapshot(authority.capitalAuthority.grant.limits, intent, dependencies)
-
-export const refreshLiveBrokerSubmitSnapshot = Pipeable.dual(3, refreshLiveBrokerSubmitSnapshotDataFirst)
 
 export type LiveGrantRefreshFailure =
   | ExecutionAuthorityConstructionFailure
@@ -971,9 +935,8 @@ const validateLiveGrantForSubmitDataFirst = (
 
 export const validateLiveGrantForSubmit = Pipeable.dual(3, validateLiveGrantForSubmitDataFirst)
 
-export type LiveBrokerSubmitValidationFailure =
-  | LiveGrantRefreshFailure
-  | LiveCapitalLimitFailure
+export type BrokerSubmitValidationFailure =
+  | ExecutionCapitalLimitFailure
   | {
       readonly _tag: 'FreshBrokerPriceMissing'
       readonly symbol: string
@@ -986,7 +949,7 @@ const validateExecutionBrokerSubmitSnapshotDataFirst = (
   snapshot: ExecutionBrokerSubmitSnapshot,
   observedAt: string,
   context: ExecutionCapitalLimitContext,
-): Result.Result<void, LiveBrokerSubmitValidationFailure> => {
+): Result.Result<void, BrokerSubmitValidationFailure> => {
   const intentQuote = snapshot.quotes.get(intent.symbol)
   if (intentQuote === undefined) {
     return Result.fail({
@@ -998,8 +961,8 @@ const validateExecutionBrokerSubmitSnapshotDataFirst = (
   if (Result.isFailure(priceBoundary)) return Result.fail(priceBoundary.failure)
   const requestedNotional = boundedBrokerOrderNotional(intent)
   if (Result.isFailure(requestedNotional)) return Result.fail(requestedNotional.failure)
-  const orderCapNotional = liveOrderCapNotional(intent, intentQuote, observedAt)
-  if (Result.isFailure(orderCapNotional)) return Result.fail(orderCapNotional.failure)
+  const proposedOrderCapNotional = orderCapNotional(intent, intentQuote, observedAt)
+  if (Result.isFailure(proposedOrderCapNotional)) return Result.fail(proposedOrderCapNotional.failure)
   const openOrderNotionals = priceOpenOrders(snapshot.openOrders)
   if (Result.isFailure(openOrderNotionals)) return Result.fail(openOrderNotionals.failure)
   return validateExecutionCapitalLimits(
@@ -1008,35 +971,13 @@ const validateExecutionBrokerSubmitSnapshotDataFirst = (
     intent,
     snapshot,
     requestedNotional.success,
-    orderCapNotional.success,
+    proposedOrderCapNotional.success,
     openOrderNotionals.success,
     context,
   )
 }
 
 export const validateExecutionBrokerSubmitSnapshot = Pipeable.dual(6, validateExecutionBrokerSubmitSnapshotDataFirst)
-
-const validateLiveBrokerSubmitSnapshotDataFirst = (
-  captured: LiveMutationExecutionAuthority,
-  persisted: LiveCapitalAuthority,
-  intent: Intent,
-  snapshot: LiveBrokerSubmitSnapshot,
-  observedAt: string,
-): Result.Result<void, LiveBrokerSubmitValidationFailure> => {
-  const fresh = validateLiveGrantForSubmit(captured, persisted, observedAt)
-  return Result.isFailure(fresh)
-    ? Result.fail(fresh.failure)
-    : validateExecutionBrokerSubmitSnapshot(
-        fresh.success,
-        fresh.success.capitalAuthority.grant.limits,
-        intent,
-        snapshot,
-        observedAt,
-        { closeOnly: false },
-      )
-}
-
-export const validateLiveBrokerSubmitSnapshot = Pipeable.dual(5, validateLiveBrokerSubmitSnapshotDataFirst)
 
 const makeAuthorityGuardedBrokerMutationDataFirst = (
   authority: MutationExecutionAuthority,
@@ -1049,7 +990,7 @@ const makeAuthorityGuardedBrokerMutationDataFirst = (
         Effect.mapError((cause) =>
           cause instanceof BrokerMutationError
             ? cause
-            : mutationAuthorizationError('final submit authorization failed after broker preflight', cause),
+            : mutationAuthorizationError('final broker submit authorization failed', cause),
         ),
       )
   const submit = (intent: Intent) => {

--- a/services/bayn/src/execution/runtime-program.test.ts
+++ b/services/bayn/src/execution/runtime-program.test.ts
@@ -420,7 +420,7 @@ describe('same-code execution program composition', () => {
     expect(posts).toBe(0)
   })
 
-  test('revalidates the PAPER lease after broker refresh and before transmission', async () => {
+  test('revalidates the execution window after broker refresh and before transmission', async () => {
     const fixture = finalLiveFixture()
     const sandboxAuthority = Result.getOrThrow(
       makeExecutionAuthority({
@@ -440,7 +440,7 @@ describe('same-code execution program composition', () => {
     let instantReads = 0
     let posts = 0
     const testDependencies: ExecutionProgramDependencies = {
-      ...dependencies('paper-lease-expiry-during-refresh'),
+      ...dependencies('execution-window-expiry-during-refresh'),
       intentStore: {
         read: () => Effect.succeed(Option.some(fixture.stored)),
       } as unknown as ExecutionProgramDependencies['intentStore'],
@@ -457,8 +457,8 @@ describe('same-code execution program composition', () => {
           observedAt: brokerObservedAt,
         }),
       currentUtcInstant: Effect.sync(() => instants[instantReads++] ?? expiresAt),
-      paperEpisodeEntryExpiresAt: expiresAt,
-      isPaperEpisodeCloseIntent: () => Effect.succeed(false),
+      entrySubmitExpiresAt: expiresAt,
+      isCloseOnlyIntent: () => Effect.succeed(false),
     }
 
     const exit = await Effect.runPromise(
@@ -472,7 +472,7 @@ describe('same-code execution program composition', () => {
       ).pipe(Effect.exit, Effect.provide(TestClock.layer())),
     )
 
-    expect(finalAuthorizationFailureTag(exit)).toBe('PaperEpisodeExpired')
+    expect(finalAuthorizationFailureTag(exit)).toBe('ExecutionWindowExpired')
     expect(instantReads).toBe(3)
     expect(posts).toBe(0)
   })

--- a/services/bayn/src/execution/runtime-program.test.ts
+++ b/services/bayn/src/execution/runtime-program.test.ts
@@ -571,8 +571,8 @@ describe('same-code execution program composition', () => {
           quotedAt: afterEntryBeforeClose,
           observedAt: afterEntryBeforeClose,
         }),
-      paperEpisodeEntryExpiresAt: episodeExpiresAt,
-      paperEpisodeCloseExpiresAt: closeExpiresAt,
+      entrySubmitExpiresAt: episodeExpiresAt,
+      closeSubmitExpiresAt: closeExpiresAt,
     }
 
     const denied = await Effect.runPromise(
@@ -582,10 +582,10 @@ describe('same-code execution program composition', () => {
         Effect.sync(() => {
           posts += 1
         }),
-        { ...shared, isPaperEpisodeCloseIntent: () => Effect.succeed(false) },
+        { ...shared, isCloseOnlyIntent: () => Effect.succeed(false) },
       ).pipe(Effect.exit, Effect.provide(TestClock.layer())),
     )
-    expect(finalAuthorizationFailureTag(denied)).toBe('PaperEpisodeExpired')
+    expect(finalAuthorizationFailureTag(denied)).toBe('ExecutionWindowExpired')
     expect(authorizedCloseOnly).toBe(false)
     expect(posts).toBe(0)
 
@@ -598,7 +598,7 @@ describe('same-code execution program composition', () => {
           Effect.sync(() => {
             posts += 1
           }),
-          { ...shared, isPaperEpisodeCloseIntent: () => Effect.succeed(true) },
+          { ...shared, isCloseOnlyIntent: () => Effect.succeed(true) },
         )
       }).pipe(Effect.provide(TestClock.layer())),
     )
@@ -616,11 +616,11 @@ describe('same-code execution program composition', () => {
         {
           ...shared,
           currentUtcInstant: Effect.succeed(afterClose),
-          isPaperEpisodeCloseIntent: () => Effect.succeed(true),
+          isCloseOnlyIntent: () => Effect.succeed(true),
         },
       ).pipe(Effect.exit, Effect.provide(TestClock.layer())),
     )
-    expect(finalAuthorizationFailureTag(closeExpired)).toBe('PaperEpisodeExpired')
+    expect(finalAuthorizationFailureTag(closeExpired)).toBe('ExecutionWindowExpired')
     expect(posts).toBe(1)
   })
 
@@ -664,7 +664,7 @@ describe('same-code execution program composition', () => {
         authorizeSubmit: () => Effect.void,
       } as unknown as ExecutionProgramDependencies['mutationStore'],
       writerFence: { backendPid: 1, check: Effect.void, transaction: (effect) => effect },
-      isPaperEpisodeCloseIntent: () => Effect.succeed(true),
+      isCloseOnlyIntent: () => Effect.succeed(true),
     }
 
     const exit = await Effect.runPromise(
@@ -704,7 +704,7 @@ describe('same-code execution program composition', () => {
       ).pipe(Effect.exit, Effect.provide(TestClock.layer())),
     )
 
-    expect(finalAuthorizationFailureTag(shortElsewhere)).toBe('LiveOrderNotionalLimitExceeded')
+    expect(finalAuthorizationFailureTag(shortElsewhere)).toBe('OrderNotionalLimitExceeded')
     expect(posts).toBe(1)
   })
 
@@ -757,7 +757,7 @@ describe('same-code execution program composition', () => {
         read: () => Effect.die(new Error('final authorization must use the locked grant read')),
         lockForSubmit: () => Effect.succeed(liveCapitalAuthority(grant)),
       },
-      isPaperEpisodeCloseIntent: () => Effect.succeed(true),
+      isCloseOnlyIntent: () => Effect.succeed(true),
     }
 
     const exit = await Effect.runPromise(
@@ -771,7 +771,7 @@ describe('same-code execution program composition', () => {
       ).pipe(Effect.exit, Effect.provide(TestClock.layer())),
     )
 
-    expect(finalAuthorizationFailureTag(exit)).toBe('LiveOrderNotionalLimitExceeded')
+    expect(finalAuthorizationFailureTag(exit)).toBe('OrderNotionalLimitExceeded')
     expect(posts).toBe(0)
   })
 
@@ -957,7 +957,7 @@ describe('same-code execution program composition', () => {
       ).pipe(Effect.exit, Effect.provide(TestClock.layer())),
     )
 
-    expect(finalAuthorizationFailureTag(exit)).toBe('LiveBrokerPositionSnapshotChanged')
+    expect(finalAuthorizationFailureTag(exit)).toBe('BrokerPositionSnapshotChanged')
     expect(trace).toEqual(['lock', 'account', 'positions', 'orders', 'positions'])
     expect(posts).toBe(0)
   })

--- a/services/bayn/src/execution/runtime-program.ts
+++ b/services/bayn/src/execution/runtime-program.ts
@@ -44,11 +44,11 @@ export interface ExecutionProgramDependencies {
   readonly riskPolicy: Policy
   readonly freshBrokerPrice: (symbol: string) => Effect.Effect<FreshBrokerQuote, OperationalError>
   readonly currentUtcInstant: Effect.Effect<string>
-  /** The reviewed PAPER entry lease, checked at the final writer fence. */
-  readonly paperEpisodeEntryExpiresAt?: string
+  /** The reviewed entry lease, checked at the final writer fence. */
+  readonly entrySubmitExpiresAt?: string
   /** Close-only intents may finish recovery until this separate close lease expires. */
-  readonly paperEpisodeCloseExpiresAt?: string
-  readonly isPaperEpisodeCloseIntent?: (intentId: string) => Effect.Effect<boolean>
+  readonly closeSubmitExpiresAt?: string
+  readonly isCloseOnlyIntent?: (intentId: string) => Effect.Effect<boolean>
 }
 
 export interface ExecutionProgramConstructionFailure {
@@ -158,28 +158,23 @@ const validateFinalSubmitRisk = (intentId: string, dependencies: ExecutionProgra
     Effect.asVoid,
   )
 
-const validatePaperEpisodeLease = (
+const validateExecutionWindow = (
   intentId: string,
   dependencies: ExecutionProgramDependencies,
   closeIntent?: boolean,
 ): Effect.Effect<void, FinalSubmitAuthorizationFailure> =>
   Effect.gen(function* () {
-    if (
-      dependencies.paperEpisodeEntryExpiresAt === undefined &&
-      dependencies.paperEpisodeCloseExpiresAt === undefined
-    ) {
+    if (dependencies.entrySubmitExpiresAt === undefined && dependencies.closeSubmitExpiresAt === undefined) {
       return
     }
     const isCloseIntent =
       closeIntent ??
-      (dependencies.isPaperEpisodeCloseIntent !== undefined
-        ? yield* dependencies.isPaperEpisodeCloseIntent(intentId)
-        : false)
-    const expiresAt = isCloseIntent ? dependencies.paperEpisodeCloseExpiresAt : dependencies.paperEpisodeEntryExpiresAt
+      (dependencies.isCloseOnlyIntent !== undefined ? yield* dependencies.isCloseOnlyIntent(intentId) : false)
+    const expiresAt = isCloseIntent ? dependencies.closeSubmitExpiresAt : dependencies.entrySubmitExpiresAt
     if (expiresAt === undefined) return
     const observedAt = yield* dependencies.currentUtcInstant
     if (observedAt < expiresAt) return
-    return yield* Effect.fail({ _tag: 'PaperEpisodeExpired' as const, expiresAt, observedAt })
+    return yield* Effect.fail({ _tag: 'ExecutionWindowExpired' as const, expiresAt, observedAt })
   })
 
 const authorizeFinalBrokerSubmitDataFirst = <A, E, R>(
@@ -193,14 +188,12 @@ const authorizeFinalBrokerSubmitDataFirst = <A, E, R>(
     .transaction(
       Effect.gen(function* () {
         const closeOnly =
-          dependencies.isPaperEpisodeCloseIntent !== undefined
-            ? yield* dependencies.isPaperEpisodeCloseIntent(intent.intentId)
-            : false
+          dependencies.isCloseOnlyIntent !== undefined ? yield* dependencies.isCloseOnlyIntent(intent.intentId) : false
         yield* dependencies.mutationStore.authorizeSubmit(intent.intentId, closeOnly)
         yield* validateFinalSubmitRisk(intent.intentId, dependencies)
         const capital = yield* finalExecutionGrantAuthorization(authority, intent, dependencies)
         yield* validateFinalSubmitRisk(intent.intentId, dependencies)
-        yield* validatePaperEpisodeLease(intent.intentId, dependencies, closeOnly)
+        yield* validateExecutionWindow(intent.intentId, dependencies, closeOnly)
         yield* finalBrokerAuthorization(authority, capital, intent, closeOnly, dependencies)
         yield* validateFinalSubmitRisk(intent.intentId, dependencies)
         yield* validatePaperEpisodeLease(intent.intentId, dependencies, closeOnly)
@@ -253,22 +246,20 @@ const makeExecutionProgramDataFirst = (authority: ExecutionAuthority, dependenci
   const coordinatorDependencies: ExecutionProgramDependencies = {
     ...dependencies,
     brokerMutation: makeAuthorityGuardedBrokerMutation(authority, {
-      ...dependencies,
+      brokerMutation: dependencies.brokerMutation,
       finalSubmitAuthorization: (intent, transmit) =>
         authorizeFinalBrokerSubmit(mutationAuthority, intent, transmit, dependencies),
     }),
   }
-  const isPaperEpisodeCloseIntent = (intentId: string) =>
-    dependencies.isPaperEpisodeCloseIntent === undefined
-      ? Effect.succeed(false)
-      : dependencies.isPaperEpisodeCloseIntent(intentId)
+  const isCloseOnlyIntent = (intentId: string) =>
+    dependencies.isCloseOnlyIntent === undefined ? Effect.succeed(false) : dependencies.isCloseOnlyIntent(intentId)
   return Result.succeed({
     _tag: 'ExecutionProgram' as const,
     schemaVersion: 'bayn.execution-program.v1' as const,
     authority,
     dryRunSubmit: (intentId: string) => provideCoordinatorDependencies(dryRunSubmit(intentId), coordinatorDependencies),
     submit: (intentId: string, consistencyDelayMs: number) =>
-      isPaperEpisodeCloseIntent(intentId).pipe(
+      isCloseOnlyIntent(intentId).pipe(
         Effect.flatMap((closeOnly) =>
           provideCoordinatorDependencies(submit(intentId, consistencyDelayMs, closeOnly), coordinatorDependencies),
         ),

--- a/services/bayn/src/execution/runtime-program.ts
+++ b/services/bayn/src/execution/runtime-program.ts
@@ -196,7 +196,7 @@ const authorizeFinalBrokerSubmitDataFirst = <A, E, R>(
         yield* validateExecutionWindow(intent.intentId, dependencies, closeOnly)
         yield* finalBrokerAuthorization(authority, capital, intent, closeOnly, dependencies)
         yield* validateFinalSubmitRisk(intent.intentId, dependencies)
-        yield* validatePaperEpisodeLease(intent.intentId, dependencies, closeOnly)
+        yield* validateExecutionWindow(intent.intentId, dependencies, closeOnly)
         transmissionStarted = true
         return yield* transmit
       }),


### PR DESCRIPTION
## Summary

- removes compatibility-only live wrappers from the shared final-submit authorization boundary
- uses account-environment-neutral capital, exposure, execution-window, and failure vocabulary
- documents the current sandbox-only deployment while retaining the dormant reviewed live-grant adapter

## Related Issues

None

## Testing

- `bun test services/bayn/src/execution/mutation-authority.test.ts services/bayn/src/execution/runtime-program.test.ts` (47 pass, 0 fail)
- `bun run --filter @proompteng/bayn test` (1,066 pass, 160 environment-gated skips, 0 fail)
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint` (95 rules, 0 findings)
- `bun run --filter @proompteng/bayn lint:oxlint:type` (110 rules, 0 findings)
- `bun run --filter @proompteng/bayn build`
- `bun run --filter @proompteng/bayn test:postgres` (0 pass, 152 database-gated skips because no test database URL is configured)

## Breaking Changes

None. Durable authority, grant, and persistence schema identifiers are unchanged.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable and Breaking Changes is filled in.
- [x] Documentation is updated; no release notes or follow-up issue is required.
