### PR TITLE
fix(bayn): resume exact paper generation across builds

### DIFF
--- a/services/bayn/src/composition.test.ts
+++ b/services/bayn/src/composition.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, test } from 'bun:test'
 
-import { Context, Deferred, Effect, Fiber, FileSystem, Layer, Ref, Result } from 'effect'
+import { Context, Deferred, Effect, Fiber, FileSystem, Layer, Logger, Redacted, Ref, References, Result } from 'effect'
 import { TestClock } from 'effect/testing'
 
+import { config, fixtureRuntime } from './app-test-support'
 import { provideTestLayer } from './effect-test-support'
 
 import {
@@ -10,17 +11,38 @@ import {
   closedCycleReceiptEmissionAllowed,
   finalizePaperEpisode,
   paperReceiptFinalizationWindowOpen,
+  prepareOrRecoverResearchPaperActivation,
+  recoverPaperActivationGeneration,
   refreshResearchPaperActivationReconciliation,
   restrictExpiredPaperActivation,
   retryClosedCycleReceipts,
 } from './composition'
-import { BrokerEnvironment } from './broker/identity'
-import type { AuthorityRestrictionStoreShape } from './db/execution-store'
-import { makeResearchPaperActivationRequest, makeResearchPaperPlanHash } from './execution/configuration'
+import { makeApplicationPlan, type ApplicationPlanFor } from './app'
+import { alpacaSandboxBaseUrl, type BrokerSessionShape } from './broker/alpaca'
+import { BrokerEnvironment, BrokerProvider, makeBrokerIdentity } from './broker/identity'
+import { makeStrategyProtocolHash } from './contracts'
+import type {
+  AuthorityGenerationStoreShape,
+  AuthorityRestrictionStoreShape,
+  CapitalGrantLifecycleStoreShape,
+} from './db/execution-store'
+import { BrokerAccess, noCapitalAuthority } from './execution/authority'
+import {
+  makeResearchPaperActivationRequest,
+  makeResearchPaperBuildContinuation,
+  makeResearchPaperPlanHash,
+} from './execution/configuration'
+import {
+  Authority,
+  KillState,
+  makeResearchCapitalGrantGenerationResult,
+  type AuthorityState,
+} from './execution/contracts'
 import type { WriterFenceService } from './execution/writer-fence'
 import { utcInstantFromEpochMillis } from './time'
 import { paperEpisodeReceiptFinalizationExpiresAt } from './observe-composition'
 import { initialState } from './runtime-state'
+import { fixtureProtocol } from './test-fixtures'
 
 const hash = (value: string) => value.repeat(64).slice(0, 64)
 
@@ -58,6 +80,205 @@ const researchRequest = Result.getOrThrow(
     ...researchPlanFields,
   }),
 )
+
+const continuationAccountId = 'paper-continuation-account'
+const continuationSourceGenerationHash = hash('a')
+const continuationBrokerIdentity = Result.getOrThrow(
+  makeBrokerIdentity({
+    schemaVersion: 'bayn.broker-identity.v2',
+    provider: BrokerProvider.Alpaca,
+    environment: BrokerEnvironment.Sandbox,
+    accountId: continuationAccountId,
+  }),
+)
+const continuationStrategyProtocolHash = makeStrategyProtocolHash(fixtureRuntime.provenance.strategy)
+const continuationResearchPlan = {
+  schemaVersion: 'bayn.paper-research-plan.v1' as const,
+  activation: {
+    sourceRevision: config.build.sourceRevision,
+    imageRepository: config.build.imageRepository,
+    imageDigest: config.build.imageDigest,
+  },
+  strategy: {
+    name: fixtureRuntime.provenance.strategy.name,
+    behaviorHash: fixtureRuntime.provenance.strategy.behaviorHash,
+    parameterHash: fixtureRuntime.provenance.strategy.parameterHash,
+    parameterSchemaVersion: fixtureRuntime.provenance.strategy.parameterSchemaVersion,
+    protocolHash: continuationStrategyProtocolHash,
+  },
+  broker: {
+    environment: BrokerEnvironment.Sandbox,
+    accountId: continuationAccountId,
+    identityHash: continuationBrokerIdentity.identityHash,
+  },
+  riskPolicyHash: hash('b'),
+  limits: { maxOpenOrders: 0 as const, maxPositions: 0 as const },
+  cutoffAt: '2026-09-01T13:30:00.000Z',
+  expiresAt: '2026-09-03T20:00:00.000Z',
+  maximumCloseSessions: 3 as const,
+} as const
+const { schemaVersion: _continuationPlanSchemaVersion, ...continuationResearchPlanFields } = continuationResearchPlan
+const continuationRequest = Result.getOrThrow(
+  makeResearchPaperActivationRequest({
+    schemaVersion: 'bayn.paper-research-activation-request.v1',
+    grant: {
+      _tag: 'Research',
+      planHash: Result.getOrThrow(makeResearchPaperPlanHash(continuationResearchPlan)),
+    },
+    ...continuationResearchPlanFields,
+  }),
+)
+const continuationGeneration = Result.getOrThrow(
+  makeResearchCapitalGrantGenerationResult({
+    schemaVersion: 'bayn.paper-authority-generation.v3',
+    maximum: Authority.Paper,
+    previousGenerationHash: continuationSourceGenerationHash,
+    grant: continuationRequest.grant,
+    activationSourceRevision: continuationRequest.activation.sourceRevision,
+    activationImageRepository: continuationRequest.activation.imageRepository,
+    activationImageDigest: continuationRequest.activation.imageDigest,
+    strategyName: continuationRequest.strategy.name,
+    strategyBehaviorHash: continuationRequest.strategy.behaviorHash,
+    strategyParameterHash: continuationRequest.strategy.parameterHash,
+    strategyParameterSchemaVersion: continuationRequest.strategy.parameterSchemaVersion,
+    strategyProtocolHash: continuationRequest.strategy.protocolHash,
+    accountId: continuationRequest.broker.accountId,
+    brokerIdentityHash: continuationRequest.broker.identityHash,
+    riskPolicyHash: continuationRequest.riskPolicyHash,
+    proofPlanHash: continuationRequest.grant.planHash,
+    reconciliationId: hash('c'),
+    reconciliationContentHash: hash('d'),
+  }),
+)
+const continuationBuild = {
+  sourceRevision: 'e'.repeat(40),
+  imageRepository: continuationRequest.activation.imageRepository,
+  imageDigest: `sha256:${hash('f')}`,
+} as const
+const researchBuildContinuation = Result.getOrThrow(
+  makeResearchPaperBuildContinuation({
+    schemaVersion: 'bayn.paper-research-build-continuation.v1',
+    request: continuationRequest,
+    generationHash: continuationGeneration.generationHash,
+    activation: continuationBuild,
+  }),
+)
+const mismatchedResearchBuildContinuation = Result.getOrThrow(
+  makeResearchPaperBuildContinuation({
+    schemaVersion: 'bayn.paper-research-build-continuation.v1',
+    request: continuationRequest,
+    generationHash: hash('0'),
+    activation: continuationBuild,
+  }),
+)
+const staleResearchBuildContinuation = Result.getOrThrow(
+  makeResearchPaperBuildContinuation({
+    schemaVersion: 'bayn.paper-research-build-continuation.v1',
+    request: continuationRequest,
+    generationHash: continuationGeneration.generationHash,
+    activation: {
+      ...continuationBuild,
+      sourceRevision: '0'.repeat(40),
+      imageDigest: `sha256:${hash('1')}`,
+    },
+  }),
+)
+const continuationApplicationPlan: ApplicationPlanFor<'AutonomousService'> = (() => {
+  const plan = makeApplicationPlan({
+    config: {
+      ...config,
+      runtimeMode: 'AutonomousService',
+      cyclePollIntervalMs: 30_000,
+      execution: {
+        brokerIdentity: continuationBrokerIdentity,
+        brokerAccess: BrokerAccess.ReadOnly,
+        capitalAuthority: noCapitalAuthority,
+      },
+      build: { ...config.build, ...continuationBuild },
+      alpaca: {
+        provider: BrokerProvider.Alpaca,
+        environment: BrokerEnvironment.Sandbox,
+        identity: continuationBrokerIdentity,
+        baseUrl: alpacaSandboxBaseUrl,
+        expectedAccountId: continuationAccountId,
+        authorityGenerationHash: continuationSourceGenerationHash,
+        key: Redacted.make('test-key'),
+        secret: Redacted.make('test-secret'),
+        proxyUrl: 'http://proxy.test:3128',
+        operationTimeoutMs: config.operationTimeoutMs,
+        retryAttempts: 0,
+        reconciliationIntervalMs: 30_000,
+      },
+    },
+    protocol: fixtureProtocol,
+    parameterHash: fixtureRuntime.provenance.strategy.parameterHash,
+    strategy: fixtureRuntime,
+    strategyProtocolHash: continuationStrategyProtocolHash,
+  })
+  if (plan._tag !== 'AutonomousService') throw new Error('continuation fixture must produce AutonomousService')
+  return plan
+})()
+const continuationAuthority: AuthorityState = {
+  schemaVersion: 'bayn.paper-authority.v1',
+  generationHash: continuationGeneration.generationHash,
+  maximum: Authority.Paper,
+  effective: Authority.Paper,
+  kill: KillState.Clear,
+  version: 2,
+  updatedAt: '2026-08-10T18:00:00.000Z',
+}
+
+const continuationAuthorityStore = (
+  generation: typeof continuationGeneration | null = continuationGeneration,
+  authority: AuthorityState = continuationAuthority,
+): AuthorityGenerationStoreShape => ({
+  ensureAuthorityGeneration: () => Effect.die(new Error('build continuation must not rearm authority')),
+  readAuthorityState: Effect.succeed(authority),
+  readResearchAuthorityGeneration: (generationHash) =>
+    Effect.succeed(generation?.generationHash === generationHash ? generation : undefined),
+})
+
+const unusedCapitalGrantLifecycle: CapitalGrantLifecycleStoreShape = {
+  prepareCapitalGrant: () => Effect.die(new Error('build continuation must not prepare authority')),
+  activateCapitalGrant: () => Effect.die(new Error('build continuation must not activate qualified authority')),
+  activateResearchCapitalGrant: () => Effect.die(new Error('build continuation must not activate research authority')),
+}
+
+const unusedBrokerSession = {} as BrokerSessionShape
+const unusedAuthorityRestrictionStore: AuthorityRestrictionStoreShape = {
+  restrictAuthority: () => Effect.die(new Error('active close lease must not restrict authority')),
+}
+const unusedWriterFence: WriterFenceService = {
+  backendPid: 1,
+  check: Effect.void,
+  transaction: <A, E, R>(effect: Effect.Effect<A, E, R>) => effect,
+}
+
+const resumeBuildContinuation = (
+  continuation = researchBuildContinuation,
+  authorityStore = continuationAuthorityStore(),
+) =>
+  prepareOrRecoverResearchPaperActivation(
+    continuationApplicationPlan,
+    continuationRequest,
+    continuation,
+    unusedBrokerSession,
+    authorityStore,
+    unusedCapitalGrantLifecycle,
+    Effect.die(new Error('build continuation must not run pre-activation reconciliation')),
+    config.operationTimeoutMs,
+  )
+
+const recoverBuildContinuation = (continuation = researchBuildContinuation) =>
+  recoverPaperActivationGeneration(
+    continuationApplicationPlan,
+    continuationRequest,
+    continuation,
+    null,
+    continuationAuthorityStore(),
+    unusedAuthorityRestrictionStore,
+    unusedWriterFence,
+  )
 
 describe('Bayn application platform', () => {
   test('provides filesystem access for TLS-backed PostgreSQL acquisition', async () => {
@@ -173,6 +394,68 @@ describe('Bayn PAPER receipt retry boundary', () => {
 })
 
 describe('Bayn PAPER startup recovery boundary', () => {
+  test('resumes only the exact active research generation across a reviewed build change', async () => {
+    const logs: Array<{ readonly message: unknown; readonly annotations: Record<string, unknown> }> = []
+    const logger = Logger.make<unknown, void>((entry) => {
+      logs.push({
+        message: entry.message,
+        annotations: { ...entry.fiber.getRef(References.CurrentLogAnnotations) },
+      })
+    })
+    const generation = await Effect.runPromise(resumeBuildContinuation().pipe(Effect.provide(Logger.layer([logger]))))
+
+    expect(generation).toEqual(continuationGeneration)
+    expect(logs).toContainEqual({
+      message: ['Bayn PAPER build continuation resumed the active generation'],
+      annotations: {
+        service: 'bayn',
+        continuationHash: researchBuildContinuation.continuationHash,
+        generationHash: continuationGeneration.generationHash,
+        sourceRevision: continuationBuild.sourceRevision,
+        imageDigest: continuationBuild.imageDigest,
+      },
+    })
+  })
+
+  test('fails closed before rearm or activation when continuation generation history is absent or mismatched', async () => {
+    const cases = [
+      {
+        continuation: researchBuildContinuation,
+        store: continuationAuthorityStore(null),
+        message: 'durable research PAPER history is missing',
+      },
+      {
+        continuation: mismatchedResearchBuildContinuation,
+        store: continuationAuthorityStore(),
+        message: 'research PAPER build continuation requires the exact active generation',
+      },
+    ] as const
+
+    for (const fixture of cases) {
+      const failure = await Effect.runPromise(Effect.flip(resumeBuildContinuation(fixture.continuation, fixture.store)))
+
+      expect(failure.message).toBe(fixture.message)
+    }
+  })
+
+  test('recovers the exact continuation after cutoff and rejects stale build or generation bindings', async () => {
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        yield* TestClock.setTime(Date.parse('2026-09-02T13:30:00.000Z'))
+        const recovered = yield* recoverBuildContinuation()
+        const mismatched = yield* recoverBuildContinuation(mismatchedResearchBuildContinuation).pipe(Effect.flip)
+        const stale = yield* recoverBuildContinuation(staleResearchBuildContinuation).pipe(Effect.flip)
+        return { recovered, mismatched, stale }
+      }).pipe(provideTestLayer(TestClock.layer())),
+    )
+
+    expect(result.recovered).toEqual(continuationGeneration)
+    expect(result.mismatched.message).toBe(
+      'research PAPER build continuation is not bound to the active generation and current build',
+    )
+    expect(result.stale.message).toBe('paper activation request is not bound to the current activation build')
+  })
+
   test('persists one fresh reconciliation before activating a new research PAPER generation', async () => {
     const operations: string[] = []
 

--- a/services/bayn/src/composition.ts
+++ b/services/bayn/src/composition.ts
@@ -612,7 +612,7 @@ const readBoundPaperActivationGeneration = (
     return generation
   })
 
-const recoverPaperActivationGeneration = (
+export const recoverPaperActivationGeneration = (
   plan: ApplicationPlanFor<'AutonomousService'>,
   request: PaperActivationRequest,
   buildContinuation: ResearchPaperBuildContinuation | null,
@@ -881,7 +881,7 @@ export const refreshResearchPaperActivationReconciliation = Pipeable.generic<
   typeof refreshResearchPaperActivationReconciliationDataFirst
 >(2, refreshResearchPaperActivationReconciliationDataFirst)
 
-const prepareOrRecoverResearchPaperActivation = (
+export const prepareOrRecoverResearchPaperActivation = (
   plan: ApplicationPlanFor<'AutonomousService'>,
   request: ResearchPaperActivationRequest,
   buildContinuation: ResearchPaperBuildContinuation | null,

--- a/services/bayn/src/composition.ts
+++ b/services/bayn/src/composition.ts
@@ -76,15 +76,18 @@ import {
 } from './execution/contracts'
 import {
   CapitalAuthoritySelection,
-  decodePaperActivationRequestResult,
+  decodePaperActivationConfigurationResult,
   isResearchPaperActivationRequest,
+  isResearchPaperBuildContinuation,
   researchCapitalGrantProof,
+  researchPaperBuildContinuationIsBound,
   researchPaperGenerationIsBoundToRequest,
   resolveExecutionPolicy,
   type ExecutionPolicy,
   type PaperActivationRequest,
   type QualifiedPaperActivationRequest,
   type ResearchPaperActivationRequest,
+  type ResearchPaperBuildContinuation,
 } from './execution/configuration'
 import { IntentStore, IntentStoreLive } from './execution/intents'
 import { MutationStore, MutationStoreLive } from './execution/mutations'
@@ -338,17 +341,24 @@ const paperActivationOperationalError = (message: string, cause?: unknown): Oper
     cause: cause === undefined ? { _tag: 'PaperActivationPreparationRejected' } : cause,
   })
 
-const decodeConfiguredPaperActivationRequest = (serialized: string): Result.Result<PaperActivationRequest, string> => {
+interface ConfiguredPaperActivation {
+  readonly request: PaperActivationRequest
+  readonly buildContinuation: ResearchPaperBuildContinuation | null
+}
+
+const decodeConfiguredPaperActivation = (serialized: string): Result.Result<ConfiguredPaperActivation, string> => {
   let value: unknown
   try {
     value = JSON.parse(serialized) as unknown
   } catch {
-    return Result.fail('configured PAPER activation request is not valid JSON')
+    return Result.fail('configured PAPER activation is not valid JSON')
   }
-  const decoded = decodePaperActivationRequestResult(value)
+  const decoded = decodePaperActivationConfigurationResult(value)
   return Result.isFailure(decoded)
-    ? Result.fail('configured PAPER activation request failed its canonical schema and hash validation')
-    : Result.succeed(decoded.success)
+    ? Result.fail('configured PAPER activation failed its canonical schema and hash validation')
+    : isResearchPaperBuildContinuation(decoded.success)
+      ? Result.succeed({ request: decoded.success.request, buildContinuation: decoded.success })
+      : Result.succeed({ request: decoded.success, buildContinuation: null })
 }
 
 const readOnlyExecutionPolicy = (plan: ApplicationPlanFor<'AutonomousService'>): ReadOnlyExecutionPolicy => ({
@@ -362,9 +372,12 @@ const paperActivationRequestIsCurrent = (
   plan: ApplicationPlanFor<'AutonomousService'>,
   evidence: RuntimeEvidence | null,
   observedAt: string,
-  allowCloseRecovery = false,
+  options: {
+    readonly allowCloseRecovery?: boolean
+    readonly buildContinuation?: ResearchPaperBuildContinuation | null
+  } = {},
 ): Result.Result<void, string> => {
-  if (!allowCloseRecovery && (request.expiresAt <= observedAt || request.cutoffAt <= observedAt)) {
+  if (options.allowCloseRecovery !== true && (request.expiresAt <= observedAt || request.cutoffAt <= observedAt)) {
     return Result.fail('paper activation request is expired or past its immutable cutoff')
   }
   if (request.strategy.protocolHash !== plan.strategyProtocolHash) {
@@ -379,11 +392,19 @@ const paperActivationRequestIsCurrent = (
   ) {
     return Result.fail('paper activation request strategy identity does not match the current strategy')
   }
-  if (
-    request.activation.sourceRevision !== plan.config.build.sourceRevision ||
-    request.activation.imageRepository !== plan.config.build.imageRepository ||
-    request.activation.imageDigest !== plan.config.build.imageDigest
-  ) {
+  const requestBuildIsCurrent =
+    request.activation.sourceRevision === plan.config.build.sourceRevision &&
+    request.activation.imageRepository === plan.config.build.imageRepository &&
+    request.activation.imageDigest === plan.config.build.imageDigest
+  const continuationBuildIsCurrent =
+    isResearchPaperActivationRequest(request) &&
+    options.buildContinuation !== null &&
+    options.buildContinuation !== undefined &&
+    options.buildContinuation.request.requestHash === request.requestHash &&
+    options.buildContinuation.activation.sourceRevision === plan.config.build.sourceRevision &&
+    options.buildContinuation.activation.imageRepository === plan.config.build.imageRepository &&
+    options.buildContinuation.activation.imageDigest === plan.config.build.imageDigest
+  if (!requestBuildIsCurrent && !continuationBuildIsCurrent) {
     return Result.fail('paper activation request is not bound to the current activation build')
   }
   if (isResearchPaperActivationRequest(request)) {
@@ -525,6 +546,7 @@ const preparedPaperActivationIsBound = (
 const readBoundPaperActivationGeneration = (
   plan: ApplicationPlanFor<'AutonomousService'>,
   request: PaperActivationRequest,
+  buildContinuation: ResearchPaperBuildContinuation | null,
   authorityStore: AuthorityGenerationStoreShape,
 ): Effect.Effect<PaperAuthorityGeneration, OperationalError> =>
   Effect.gen(function* () {
@@ -561,9 +583,16 @@ const readBoundPaperActivationGeneration = (
       if (generation === undefined) {
         return yield* paperActivationOperationalError('durable research PAPER history is missing')
       }
-      yield* Effect.fromResult(
-        researchPaperGenerationIsBoundToRequest(request, plan.config.alpaca.authorityGenerationHash, generation),
-      ).pipe(Effect.mapError((message) => paperActivationOperationalError(message)))
+      const binding =
+        buildContinuation === null
+          ? researchPaperGenerationIsBoundToRequest(request, plan.config.alpaca.authorityGenerationHash, generation)
+          : researchPaperBuildContinuationIsBound(
+              buildContinuation,
+              plan.config.alpaca.authorityGenerationHash,
+              generation,
+              plan.config.build,
+            )
+      yield* Effect.fromResult(binding).pipe(Effect.mapError((message) => paperActivationOperationalError(message)))
       return generation
     }
     if (authorityStore.readAuthorityGeneration === undefined) {
@@ -586,6 +615,7 @@ const readBoundPaperActivationGeneration = (
 const recoverPaperActivationGeneration = (
   plan: ApplicationPlanFor<'AutonomousService'>,
   request: PaperActivationRequest,
+  buildContinuation: ResearchPaperBuildContinuation | null,
   evidence: RuntimeEvidence | null,
   authorityStore: AuthorityGenerationStoreShape,
   authorityRestrictionStore: AuthorityRestrictionStoreShape,
@@ -593,9 +623,12 @@ const recoverPaperActivationGeneration = (
 ): Effect.Effect<PaperAuthorityGeneration, OperationalError> =>
   Effect.gen(function* () {
     const observedAt = yield* currentUtcInstant
-    yield* Effect.fromResult(paperActivationRequestIsCurrent(request, plan, evidence, observedAt, true)).pipe(
-      Effect.mapError((message) => paperActivationOperationalError(message)),
-    )
+    yield* Effect.fromResult(
+      paperActivationRequestIsCurrent(request, plan, evidence, observedAt, {
+        allowCloseRecovery: true,
+        buildContinuation,
+      }),
+    ).pipe(Effect.mapError((message) => paperActivationOperationalError(message)))
     const closeExpiresAt = paperEpisodeCloseExpiresAt(request.expiresAt)
     if (observedAt >= closeExpiresAt) {
       yield* restrictExpiredPaperActivation(authorityRestrictionStore, writerFence)
@@ -604,12 +637,13 @@ const recoverPaperActivationGeneration = (
     if (observedAt < request.cutoffAt) {
       return yield* paperActivationOperationalError('durable PAPER close recovery is outside its immutable close lease')
     }
-    return yield* readBoundPaperActivationGeneration(plan, request, authorityStore)
+    return yield* readBoundPaperActivationGeneration(plan, request, buildContinuation, authorityStore)
   })
 
 const recoverPaperReceiptFinalizationGeneration = (
   plan: ApplicationPlanFor<'AutonomousService'>,
   request: PaperActivationRequest,
+  buildContinuation: ResearchPaperBuildContinuation | null,
   evidence: RuntimeEvidence | null,
   authorityStore: AuthorityGenerationStoreShape,
   authorityRestrictionStore: AuthorityRestrictionStoreShape,
@@ -617,14 +651,17 @@ const recoverPaperReceiptFinalizationGeneration = (
 ): Effect.Effect<PaperAuthorityGeneration, OperationalError> =>
   Effect.gen(function* () {
     const observedAt = yield* currentUtcInstant
-    yield* Effect.fromResult(paperActivationRequestIsCurrent(request, plan, evidence, observedAt, true)).pipe(
-      Effect.mapError((message) => paperActivationOperationalError(message)),
-    )
+    yield* Effect.fromResult(
+      paperActivationRequestIsCurrent(request, plan, evidence, observedAt, {
+        allowCloseRecovery: true,
+        buildContinuation,
+      }),
+    ).pipe(Effect.mapError((message) => paperActivationOperationalError(message)))
     if (observedAt < paperEpisodeCloseExpiresAt(request.expiresAt)) {
       return yield* paperActivationOperationalError('durable PAPER receipt finalization is outside its bounded lease')
     }
     yield* restrictExpiredPaperActivation(authorityRestrictionStore, writerFence)
-    return yield* readBoundPaperActivationGeneration(plan, request, authorityStore)
+    return yield* readBoundPaperActivationGeneration(plan, request, buildContinuation, authorityStore)
   })
 
 type PaperActivationStartupResolution =
@@ -812,7 +849,7 @@ const prepareResearchPaperActivation = (
     yield* Effect.fromResult(validateActivatedResearchAuthority(authority)).pipe(
       Effect.mapError((message) => paperActivationOperationalError(message)),
     )
-    return yield* readBoundPaperActivationGeneration(plan, request, authorityStore).pipe(
+    return yield* readBoundPaperActivationGeneration(plan, request, null, authorityStore).pipe(
       Effect.flatMap((generation) =>
         generation.schemaVersion === 'bayn.paper-authority-generation.v3'
           ? Effect.succeed(generation)
@@ -847,6 +884,7 @@ export const refreshResearchPaperActivationReconciliation = Pipeable.generic<
 const prepareOrRecoverResearchPaperActivation = (
   plan: ApplicationPlanFor<'AutonomousService'>,
   request: ResearchPaperActivationRequest,
+  buildContinuation: ResearchPaperBuildContinuation | null,
   session: BrokerSessionShape,
   authorityStore: AuthorityGenerationStoreShape,
   lifecycle: CapitalGrantLifecycleStoreShape,
@@ -864,7 +902,18 @@ const prepareOrRecoverResearchPaperActivation = (
     const currentGenerationMatchesRequest =
       currentGeneration !== undefined &&
       Result.isSuccess(
-        researchPaperGenerationIsBoundToRequest(request, plan.config.alpaca.authorityGenerationHash, currentGeneration),
+        buildContinuation === null
+          ? researchPaperGenerationIsBoundToRequest(
+              request,
+              plan.config.alpaca.authorityGenerationHash,
+              currentGeneration,
+            )
+          : researchPaperBuildContinuationIsBound(
+              buildContinuation,
+              plan.config.alpaca.authorityGenerationHash,
+              currentGeneration,
+              plan.config.build,
+            ),
       )
     const decision = yield* Effect.fromResult(
       decidePaperEpisodeAuthority({
@@ -881,6 +930,11 @@ const prepareOrRecoverResearchPaperActivation = (
         paperActivationOperationalError('research PAPER durable authority does not match this episode', cause),
       ),
     )
+    if (buildContinuation !== null && decision._tag !== 'Resume') {
+      return yield* paperActivationOperationalError(
+        'research PAPER build continuation requires the exact active generation',
+      )
+    }
     if (decision._tag === 'Rearm') {
       const rearmed = yield* authorityStore
         .ensureAuthorityGeneration({
@@ -907,7 +961,20 @@ const prepareOrRecoverResearchPaperActivation = (
       yield* refreshResearchPaperActivationReconciliation(reconcile, operationTimeoutMs)
       return yield* prepareResearchPaperActivation(plan, request, session, authorityStore, lifecycle)
     }
-    return currentGeneration ?? (yield* paperActivationOperationalError('research PAPER recovery lost durable history'))
+    const generation =
+      currentGeneration ?? (yield* paperActivationOperationalError('research PAPER recovery lost durable history'))
+    if (buildContinuation !== null) {
+      yield* Effect.logInfo('Bayn PAPER build continuation resumed the active generation').pipe(
+        Effect.annotateLogs({
+          service: 'bayn',
+          continuationHash: buildContinuation.continuationHash,
+          generationHash: generation.generationHash,
+          sourceRevision: plan.config.build.sourceRevision,
+          imageDigest: plan.config.build.imageDigest,
+        }),
+      )
+    }
+    return generation
   })
 
 const pendingPaperActivation = (
@@ -1203,12 +1270,12 @@ const runAutonomousService = (plan: ApplicationPlanFor<'AutonomousService'>) =>
       strategyProtocolHash: plan.strategyProtocolHash,
     }) as ApplicationPlanFor<'AutonomousService'>
     const serializedRequest = observePlan.config.paperActivationRequestJson
-    const decodedRequest: Result.Result<PaperActivationRequest | null, string> =
-      serializedRequest === undefined ? Result.succeed(null) : decodeConfiguredPaperActivationRequest(serializedRequest)
+    const decodedActivation: Result.Result<ConfiguredPaperActivation | null, string> =
+      serializedRequest === undefined ? Result.succeed(null) : decodeConfiguredPaperActivation(serializedRequest)
     const startupEvidenceMode =
-      Result.isSuccess(decodedRequest) &&
-      decodedRequest.success !== null &&
-      isResearchPaperActivationRequest(decodedRequest.success)
+      Result.isSuccess(decodedActivation) &&
+      decodedActivation.success !== null &&
+      isResearchPaperActivationRequest(decodedActivation.success.request)
         ? ('Research' as const)
         : ('Qualification' as const)
     const noCycle = (
@@ -1228,30 +1295,40 @@ const runAutonomousService = (plan: ApplicationPlanFor<'AutonomousService'>) =>
     const resolveAfterStartup: AutonomousRuntimeResolver<never, never> = (state) => {
       const validateStaticRequest: Effect.Effect<
         Result.Result<
-          { readonly request: PaperActivationRequest | null; readonly evidence: RuntimeEvidence | null },
+          {
+            readonly request: PaperActivationRequest | null
+            readonly buildContinuation: ResearchPaperBuildContinuation | null
+            readonly evidence: RuntimeEvidence | null
+          },
           string
         >,
         OperationalError
       > = Effect.gen(function* () {
-        if (Result.isFailure(decodedRequest)) {
+        if (Result.isFailure(decodedActivation)) {
           yield* pendingPaperActivation(state, null, 'REQUEST_INVALID')
           return Result.fail('request-invalid')
         }
-        const request = decodedRequest.success
+        const configured = decodedActivation.success
+        const request = configured?.request ?? null
+        const buildContinuation = configured?.buildContinuation ?? null
         const current = yield* Ref.get(state)
-        if (request === null) return Result.succeed({ request, evidence: current.evidence })
+        if (request === null) return Result.succeed({ request, buildContinuation, evidence: current.evidence })
         const observedAt = yield* currentUtcInstant
-        const validation = paperActivationRequestIsCurrent(request, observePlan, current.evidence, observedAt, true)
+        const validation = paperActivationRequestIsCurrent(request, observePlan, current.evidence, observedAt, {
+          allowCloseRecovery: true,
+          buildContinuation,
+        })
         if (Result.isFailure(validation)) {
           yield* pendingPaperActivation(state, request, 'PREPARATION_FAILED')
           return Result.fail(validation.failure)
         }
-        return Result.succeed({ request, evidence: current.evidence })
+        return Result.succeed({ request, buildContinuation, evidence: current.evidence })
       })
       return validateStaticRequest.pipe(
         Effect.flatMap((validated): Effect.Effect<AutonomousRuntime<never, never>, never, Scope.Scope> => {
           if (Result.isFailure(validated)) return Effect.succeed(pendingRuntime())
           const request = validated.success.request
+          const buildContinuation = validated.success.buildContinuation
           return Effect.flatMap(Scope.Scope, (scope) =>
             scopedAcquisition(
               (attemptScope) =>
@@ -1334,6 +1411,7 @@ const runAutonomousService = (plan: ApplicationPlanFor<'AutonomousService'>) =>
                                   ? recoverPaperReceiptFinalizationGeneration(
                                       observePlan,
                                       request,
+                                      buildContinuation,
                                       evidence,
                                       runtimeServices.authorityGenerationStore,
                                       runtimeServices.authorityRestrictionStore,
@@ -1348,6 +1426,7 @@ const runAutonomousService = (plan: ApplicationPlanFor<'AutonomousService'>) =>
                                     ? recoverPaperActivationGeneration(
                                         observePlan,
                                         request,
+                                        buildContinuation,
                                         evidence,
                                         runtimeServices.authorityGenerationStore,
                                         runtimeServices.authorityRestrictionStore,
@@ -1357,6 +1436,7 @@ const runAutonomousService = (plan: ApplicationPlanFor<'AutonomousService'>) =>
                                       ? prepareOrRecoverResearchPaperActivation(
                                           observePlan,
                                           request,
+                                          buildContinuation,
                                           runtimeServices.session,
                                           runtimeServices.authorityGenerationStore,
                                           runtimeServices.capitalGrantLifecycleStore,

--- a/services/bayn/src/execution/configuration.test.ts
+++ b/services/bayn/src/execution/configuration.test.ts
@@ -7,10 +7,13 @@ import { BrokerAccess, CapitalAuthorityKind } from './authority'
 import { Authority, makeResearchCapitalGrantGenerationResult } from './contracts'
 import {
   CapitalAuthoritySelection,
+  decodePaperActivationConfigurationResult,
   decodePaperActivationRequestResult,
   makePaperActivationRequest,
   makeResearchPaperActivationRequest,
+  makeResearchPaperBuildContinuation,
   makeResearchPaperPlanHash,
+  researchPaperBuildContinuationIsBound,
   researchCapitalGrantProof,
   researchPaperGenerationIsBoundToRequest,
   resolveExecutionPolicy,
@@ -260,5 +263,59 @@ describe('execution policy configuration', () => {
     expect(researchPaperGenerationIsBoundToRequest(request, 'f'.repeat(64), generation)).toMatchObject({
       _tag: 'Failure',
     })
+
+    const currentActivation = {
+      sourceRevision: 'b'.repeat(40),
+      imageRepository: request.activation.imageRepository,
+      imageDigest: `sha256:${'c'.repeat(64)}`,
+    }
+    const continuation = Result.getOrThrow(
+      makeResearchPaperBuildContinuation({
+        schemaVersion: 'bayn.paper-research-build-continuation.v1',
+        request,
+        generationHash: generation.generationHash,
+        activation: currentActivation,
+      }),
+    )
+    expect(decodePaperActivationConfigurationResult(continuation)).toEqual(Result.succeed(continuation))
+    expect(
+      researchPaperBuildContinuationIsBound(continuation, sourceGenerationHash, generation, currentActivation),
+    ).toEqual(Result.succeed(undefined))
+    expect(
+      researchPaperBuildContinuationIsBound(continuation, sourceGenerationHash, generation, {
+        ...currentActivation,
+        imageDigest: `sha256:${'d'.repeat(64)}`,
+      }),
+    ).toMatchObject({ _tag: 'Failure' })
+    const wrongGenerationContinuation = Result.getOrThrow(
+      makeResearchPaperBuildContinuation({
+        schemaVersion: 'bayn.paper-research-build-continuation.v1',
+        request,
+        generationHash: 'e'.repeat(64),
+        activation: currentActivation,
+      }),
+    )
+    expect(
+      researchPaperBuildContinuationIsBound(
+        wrongGenerationContinuation,
+        sourceGenerationHash,
+        generation,
+        currentActivation,
+      ),
+    ).toMatchObject({ _tag: 'Failure' })
+    expect(
+      decodePaperActivationConfigurationResult({
+        ...continuation,
+        generationHash: 'e'.repeat(64),
+      }),
+    ).toMatchObject({ _tag: 'Failure' })
+    expect(
+      makeResearchPaperBuildContinuation({
+        schemaVersion: 'bayn.paper-research-build-continuation.v1',
+        request,
+        generationHash: generation.generationHash,
+        activation: { ...currentActivation, imageRepository: 'ghcr.io/other/bayn' },
+      }),
+    ).toEqual(Result.fail('ResearchPaperBuildContinuationCanonicalizationFailed'))
   })
 })

--- a/services/bayn/src/execution/configuration.ts
+++ b/services/bayn/src/execution/configuration.ts
@@ -41,6 +41,7 @@ export interface LiveCapitalGrantRequest {
 export const paperActivationRequestSchemaVersion = 'bayn.paper-activation-request.v1' as const
 export const researchPaperActivationRequestSchemaVersion = 'bayn.paper-research-activation-request.v1' as const
 export const researchPaperPlanSchemaVersion = 'bayn.paper-research-plan.v1' as const
+export const researchPaperBuildContinuationSchemaVersion = 'bayn.paper-research-build-continuation.v1' as const
 
 const PaperActivationStrategySchema = Schema.Struct({
   name: StrictNonEmptyStringSchema,
@@ -55,6 +56,7 @@ const PaperActivationRevisionBindingSchema = Schema.Struct({
   imageRepository: ImageRepositorySchema,
   imageDigest: ImageDigestSchema,
 })
+export type PaperActivationRevisionBinding = typeof PaperActivationRevisionBindingSchema.Type
 
 const PaperActivationRequestMaterialSchema = Schema.Struct({
   schemaVersion: Schema.Literal(paperActivationRequestSchemaVersion),
@@ -157,6 +159,45 @@ export const ResearchPaperActivationRequestSchema = Schema.Struct({
 )
 export type ResearchPaperActivationRequest = typeof ResearchPaperActivationRequestSchema.Type
 
+const ResearchPaperBuildContinuationMaterialSchema = Schema.Struct({
+  schemaVersion: Schema.Literal(researchPaperBuildContinuationSchemaVersion),
+  request: ResearchPaperActivationRequestSchema,
+  generationHash: Sha256Schema,
+  activation: PaperActivationRevisionBindingSchema,
+})
+
+export const ResearchPaperBuildContinuationSchema = Schema.Struct({
+  ...ResearchPaperBuildContinuationMaterialSchema.fields,
+  continuationHash: Sha256Schema,
+}).check(
+  Schema.makeFilter(
+    (
+      continuation: typeof ResearchPaperBuildContinuationMaterialSchema.Type & {
+        readonly continuationHash: string
+      },
+    ) => {
+      if (continuation.activation.imageRepository !== continuation.request.activation.imageRepository) return false
+      const { continuationHash: _continuationHash, ...material } = continuation
+      const expected = canonicalHashV1Result(material)
+      return Result.isSuccess(expected) && continuation.continuationHash === expected.success
+    },
+  ),
+)
+export type ResearchPaperBuildContinuation = typeof ResearchPaperBuildContinuationSchema.Type
+
+export const makeResearchPaperBuildContinuation = (
+  material: typeof ResearchPaperBuildContinuationMaterialSchema.Type,
+): Result.Result<ResearchPaperBuildContinuation, 'ResearchPaperBuildContinuationCanonicalizationFailed'> => {
+  if (material.activation.imageRepository !== material.request.activation.imageRepository) {
+    return Result.fail('ResearchPaperBuildContinuationCanonicalizationFailed')
+  }
+  return pipe(
+    canonicalHashV1Result(material),
+    Result.mapError(() => 'ResearchPaperBuildContinuationCanonicalizationFailed' as const),
+    Result.map((continuationHash) => ({ ...material, continuationHash }) as ResearchPaperBuildContinuation),
+  )
+}
+
 export const isResearchPaperActivationRequest = (
   request: PaperActivationRequest,
 ): request is ResearchPaperActivationRequest => request.schemaVersion === researchPaperActivationRequestSchemaVersion
@@ -220,11 +261,39 @@ export const researchPaperGenerationIsBoundToRequest = Pipeable.dual(
   researchPaperGenerationIsBoundToRequestDataFirst,
 )
 
+export const researchPaperBuildContinuationIsBound = (
+  continuation: ResearchPaperBuildContinuation,
+  sourceGenerationHash: string,
+  generation: ResearchCapitalGrantGeneration,
+  currentActivation: PaperActivationRevisionBinding,
+): Result.Result<void, string> => {
+  if (
+    continuation.generationHash !== generation.generationHash ||
+    continuation.activation.sourceRevision !== currentActivation.sourceRevision ||
+    continuation.activation.imageRepository !== currentActivation.imageRepository ||
+    continuation.activation.imageDigest !== currentActivation.imageDigest
+  ) {
+    return Result.fail('research PAPER build continuation is not bound to the active generation and current build')
+  }
+  return researchPaperGenerationIsBoundToRequest(continuation.request, sourceGenerationHash, generation)
+}
+
 export const PaperActivationRequestSchema = Schema.Union([
   QualifiedPaperActivationRequestSchema,
   ResearchPaperActivationRequestSchema,
 ])
 export type PaperActivationRequest = typeof PaperActivationRequestSchema.Type
+
+export const PaperActivationConfigurationSchema = Schema.Union([
+  PaperActivationRequestSchema,
+  ResearchPaperBuildContinuationSchema,
+])
+export type PaperActivationConfiguration = typeof PaperActivationConfigurationSchema.Type
+
+export const isResearchPaperBuildContinuation = (
+  configuration: PaperActivationConfiguration,
+): configuration is ResearchPaperBuildContinuation =>
+  configuration.schemaVersion === researchPaperBuildContinuationSchemaVersion
 
 const requestWithoutHash = (
   request:
@@ -269,6 +338,15 @@ const decodePaperActivationRequestResultDataFirst = Schema.decodeUnknownResult(
 
 export const decodePaperActivationRequestResult = Pipeable.dual(1, (input: unknown) =>
   decodePaperActivationRequestResultDataFirst(input),
+)
+
+const decodePaperActivationConfigurationResultDataFirst = Schema.decodeUnknownResult(
+  PaperActivationConfigurationSchema,
+  strictParseOptions,
+)
+
+export const decodePaperActivationConfigurationResult = Pipeable.dual(1, (input: unknown) =>
+  decodePaperActivationConfigurationResultDataFirst(input),
 )
 
 export type CapitalAuthorityRequest = NoCapitalRequest | SandboxCapitalRequest | LiveCapitalGrantRequest


### PR DESCRIPTION
## Summary

- Accept a canonical sealed research PAPER build-continuation wrapper bound to the original activation request, exact durable generation, and exact replacement source/image.
- Resume only the already-active generation; reject activation, rearm, generation drift, repository drift, or build drift before broker-capable startup.
- Emit and test a structured Effect log with the continuation, generation, source, and image identities when the exact continuation is resumed.

## Related Issues

None

## Testing

- `bun test services/bayn/src/execution/configuration.test.ts services/bayn/src/composition.test.ts` (20 pass, 0 fail)
- `bun run --filter @proompteng/bayn test` (1,072 pass, 161 skip, 0 fail)
- `BAYN_TEST_POSTGRES_URL=postgresql://bayn:bayn@127.0.0.1:5432/bayn_test bun run --filter @proompteng/bayn test:postgres` (exit 0)
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn build`

## Breaking Changes

None. Existing activation-request payloads remain valid; the continuation wrapper is an additional fail-closed configuration form.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable and breaking changes are documented.
- [x] No documentation or release-note change is required; the exact sealed rollout is a separate reviewed GitOps change after this image is published.