### PR TITLE
fix(bayn): defer paper cutoff until mutation settles

### DIFF
--- a/services/bayn/src/db/cycle-store/integration.test.ts
+++ b/services/bayn/src/db/cycle-store/integration.test.ts
@@ -65,6 +65,7 @@ import {
   buildObserveCycleDecision,
   loadObserveRiskPolicy,
   prepareObserveStartup,
+  terminalizeBlockedPaperCycle,
   type ObserveDecisionFailure,
 } from '../../observe-composition'
 import {
@@ -3459,6 +3460,156 @@ describePostgres('PostgreSQL autonomous cycle store', () => {
       orders: 0,
     })
   })
+
+  test('atomically rolls back a rejected PAPER block and commits a settled PAPER block with restriction', async () => {
+    const executionPolicy = Result.getOrThrow(makeCycleExecutionPolicyFromModel(fixtureProtocol.executionModel))
+    const atomicRuntime = makeAutonomousRuntime()
+    try {
+      const result = await atomicRuntime.runPromise(
+        Effect.gen(function* () {
+          const sql = yield* PgClient.PgClient
+          const [clock] = yield* sql<{ evaluated_at: string }>`
+          SELECT to_char(
+            (clock_timestamp() - interval '1 second') AT TIME ZONE 'UTC',
+            'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'
+          ) AS evaluated_at
+        `
+          if (clock === undefined) return yield* Effect.die(new Error('database Clock returned no row'))
+          const {
+            evaluationAt: evaluatedAt,
+            executionOpenAt,
+            executionSessionDate,
+            signalSessionDate,
+            snapshotBoundAt,
+          } = monthEndExecutionWindow(clock.evaluated_at)
+          const draft = makeDraft('paper-account-atomic-terminalization', {
+            executionPolicy,
+            executionCloseAt: `${executionSessionDate}T23:59:59.999Z`,
+            executionOpenAt,
+            executionSessionDate,
+            signalSessionDate,
+          })
+          const acquisitionAt = utcInstantFromEpochMillis(Date.parse(draft.window.signalCloseAt) + 60_000)
+          const activatedAt = utcInstantFromEpochMillis(Date.parse(snapshotBoundAt) + 1_000)
+          const manifest = makeInputManifest(snapshotA, {
+            asOfSession: signalSessionDate,
+            finalizedAt: snapshotBoundAt,
+            lastSession: signalSessionDate,
+          })
+          const store = yield* CycleStore
+          yield* store.acquire(draft, acquisitionAt)
+          yield* store.bindSnapshot(draft.identity.cycleId, manifest, snapshotBoundAt)
+          const activated = yield* store.activate(draft.identity.cycleId, activatedAt)
+          const planned = yield* buildPlannedPaperDecision(activated.cycle, snapshotA, {
+            evaluatedAt,
+            snapshotFinalizedAt: snapshotBoundAt,
+          })
+          if (planned.document.targetPlan.status !== TargetPlanStatus.Planned) {
+            return yield* Effect.die(new Error('atomic terminalization fixture requires a planned PAPER decision'))
+          }
+          yield* insertReconciliation(planned.reconciliation)
+          yield* insertQualifiedPaperLineage(planned.document)
+          const unfinished = yield* insertUnfinishedPlannedPaperMutation(planned.document, 'cancel-unknown')
+          const bound = yield* store.bindDecision(draft.identity.cycleId, planned.document, evaluatedAt)
+          yield* sql`
+          INSERT INTO authority_state (
+            schema_version, generation_hash, maximum, effective, kill_state,
+            reason, version, updated_at
+          ) VALUES (
+            'bayn.paper-authority.v1', ${'9'.repeat(64)},
+            'OBSERVE', 'OBSERVE', 'CLEAR', NULL, 1,
+            ${utcInstantFromEpochMillis(Date.parse(planned.document.createdAt) - 1_000)}
+          )
+        `
+          yield* sql`
+          UPDATE authority_state
+          SET
+            generation_hash = ${planned.document.bindings.authorityGenerationHash},
+            maximum = 'PAPER',
+            effective = 'PAPER',
+            version = 2,
+            updated_at = ${planned.document.createdAt}
+          WHERE singleton
+        `
+
+          const terminalization = yield* Effect.exit(
+            terminalizeBlockedPaperCycle(bound.cycle, {
+              _tag: 'Block',
+              reason: CycleTerminalReason.MissedSubmission,
+              observedAt: draft.window.submissionCutoffAt,
+            }),
+          )
+          const [authorityAfterRejectedBlock] = yield* sql<{
+            effective: string
+            kill_state: string
+            reason: string | null
+            version: string
+          }>`
+          SELECT effective, kill_state, reason, version
+          FROM authority_state
+          WHERE singleton
+        `
+          const cycleAfterRejectedBlock = yield* store.read(draft.identity.cycleId)
+          const settled = yield* settleSupersededMutation(
+            planned.document,
+            unfinished.intent.intentId,
+            'cancel-unknown',
+          )
+          const committed = yield* terminalizeBlockedPaperCycle(bound.cycle, {
+            _tag: 'Block',
+            reason: CycleTerminalReason.Risk,
+            observedAt: settled.recoveredAt,
+          })
+          const [authorityAfterCommittedBlock] = yield* sql<{
+            effective: string
+            kill_state: string
+            reason: string | null
+            version: string
+          }>`
+          SELECT effective, kill_state, reason, version
+          FROM authority_state
+          WHERE singleton
+        `
+          return {
+            authorityAfterCommittedBlock,
+            authorityAfterRejectedBlock,
+            committed,
+            cycleAfterRejectedBlock,
+            terminalization,
+          }
+        }).pipe(Effect.provide(TestClock.layer())),
+      )
+
+      expect(Exit.isFailure(result.terminalization)).toBe(true)
+      if (Exit.isFailure(result.terminalization)) {
+        expect(Cause.squash(result.terminalization.cause)).toMatchObject({
+          failure: 'store',
+          message: 'blocked PAPER cycle finalization failed',
+        })
+      }
+      expect(result.authorityAfterRejectedBlock).toEqual({
+        effective: 'PAPER',
+        kill_state: 'CLEAR',
+        reason: null,
+        version: '2',
+      })
+      expect(Option.getOrUndefined(result.cycleAfterRejectedBlock)).toMatchObject({ state: CycleState.Active })
+      expect(result.committed).toMatchObject({ action: 'BLOCKED', cycle: { state: CycleState.Blocked } })
+      if (result.committed.outcome !== 'RECOVERED' || result.committed.action !== 'BLOCKED') {
+        return expect.unreachable('settled PAPER terminalization must return a blocked recovery receipt')
+      }
+      expect(result.authorityAfterCommittedBlock).toMatchObject({
+        effective: 'OBSERVE',
+        kill_state: 'ACTIVE',
+        version: '3',
+      })
+      expect(result.authorityAfterCommittedBlock?.reason).toContain(
+        `bound cycle ${result.committed.cycle.identity.cycleId} blocked: BLOCKED_RISK`,
+      )
+    } finally {
+      await atomicRuntime.dispose()
+    }
+  }, 15_000)
 
   test.each(['submit-accepted', 'submit-unknown', 'cancel-accepted', 'cancel-unknown'] as const)(
     'keeps superseded %s mutation history recoverable before an exact idempotent provenance block',

--- a/services/bayn/src/observe-composition.test.ts
+++ b/services/bayn/src/observe-composition.test.ts
@@ -30,7 +30,7 @@ import {
   makeExecutionCalendarObservation,
 } from './cycle'
 import { makeStrategyProtocolHash } from './contracts'
-import { CycleStore, type CycleStoreShape } from './db/cycle-store'
+import { CycleStore, CycleStoreError, type CycleStoreShape } from './db/cycle-store'
 import { decideCompletion, validateCompletionDocument } from './db/cycle-store/decisions'
 import { attachCycleDecisionStoreEvidence, cycleDecisionStoreEvidence } from './db/cycle-store/model'
 import type { BrokerSnapshot, ReconciliationWriteResult } from './db/reconciliation'
@@ -880,6 +880,102 @@ describe('OBSERVE runtime composition', () => {
     })
   })
 
+  test('defers an expired untouched remainder while an earlier acknowledged order is stably open', async () => {
+    const fixture = await paperLifecycleFixture((policy) => policy, partialFillDecision)
+    const first = fixture.intents[0]
+    const second = fixture.intents[1]
+    if (first === undefined || second === undefined) {
+      return expect.unreachable('fixture requires two intents')
+    }
+    const accepted: MutationEvent = {
+      schemaVersion: 'bayn.paper-mutation-event.v1',
+      eventId: '4'.repeat(64),
+      mutationId: '5'.repeat(64),
+      intentId: first.intentId,
+      sequence: 2,
+      operation: MutationOperation.Submit,
+      eventType: MutationEventType.SubmitAccepted,
+      requestHash: '6'.repeat(64),
+      consistencyDelayMs: 1_000,
+      brokerOrderId: 'stable-open-after-cutoff',
+      occurredAt: fixture.document.createdAt,
+    }
+    const pending = Result.getOrThrow(decidePreparedMutationIntent(first, accepted))
+    if (pending._tag !== 'Pending') return expect.unreachable('accepted intent must be pending')
+    const observedAt = utcInstantFromEpochMillis(Date.parse(fixture.document.submissionCutoffAt) + 1_000)
+    const firstRecord = storedIntent(first, IntentState.Acknowledged, accepted.occurredAt)
+    const secondRecord = storedIntent(second, IntentState.Approved, accepted.occurredAt)
+
+    const step = await prepareStoredPaperStep(
+      fixture,
+      firstRecord,
+      accepted,
+      observedAt,
+      0,
+      () => undefined,
+      fixture.input,
+      undefined,
+      true,
+      fixture.policy,
+      fixture.preparation,
+      new Map([
+        [first.intentId, firstRecord],
+        [second.intentId, secondRecord],
+      ]),
+      new Map<string, MutationEvent | undefined>([
+        [first.intentId, accepted],
+        [second.intentId, undefined],
+      ]),
+      [{ ...pending.order, observedAt }],
+    )
+
+    expect(step).toEqual({ _tag: 'Wait', observedAt })
+  })
+
+  test('uses a settled unsuccessful predecessor instead of an expired untouched remainder as the terminal cause', async () => {
+    const fixture = await paperLifecycleFixture((policy) => policy, partialFillDecision)
+    const first = fixture.intents[0]
+    const second = fixture.intents[1]
+    if (first === undefined || second === undefined) {
+      return expect.unreachable('fixture requires two intents')
+    }
+    const observedAt = utcInstantFromEpochMillis(Date.parse(fixture.document.submissionCutoffAt) + 1_000)
+    const firstRecord = storedIntent(
+      { ...first, state: IntentState.Terminal, terminalOutcome: TerminalOutcome.Rejected },
+      IntentState.Terminal,
+      observedAt,
+    )
+    const secondRecord = storedIntent(second, IntentState.Approved, fixture.document.createdAt)
+
+    const step = await prepareStoredPaperStep(
+      fixture,
+      firstRecord,
+      undefined,
+      observedAt,
+      0,
+      () => undefined,
+      fixture.input,
+      undefined,
+      true,
+      fixture.policy,
+      fixture.preparation,
+      new Map([
+        [first.intentId, firstRecord],
+        [second.intentId, secondRecord],
+      ]),
+      new Map<string, MutationEvent | undefined>([
+        [first.intentId, undefined],
+        [second.intentId, undefined],
+      ]),
+    )
+
+    expect(step).toEqual({
+      _tag: 'Block',
+      reason: CycleTerminalReason.Risk,
+      observedAt,
+    })
+  })
+
   test('executes unsubmitted intents and skips terminal intents in fresh mutation passes', () => {
     const base: Intent = {
       schemaVersion: 'bayn.paper-intent.v3',
@@ -1625,7 +1721,7 @@ describe('OBSERVE runtime composition', () => {
     expect(Result.isFailure(validateCompletionDocument(completion, [fixture.document]))).toBe(true)
   })
 
-  test('revokes PAPER authority before persisting a risk-blocked cycle terminal', async () => {
+  test('atomically persists a risk-blocked cycle before restricting PAPER authority', async () => {
     const fixture = await paperLifecycleFixture((policy) => ({
       ...policy,
       maxOrderNotionalMicros: '1',
@@ -1697,8 +1793,66 @@ describe('OBSERVE runtime composition', () => {
       ),
     )
 
-    expect(events).toEqual(['fence', 'restrict', 'block'])
+    expect(events).toEqual(['fence', 'block', 'restrict'])
     expect(result).toMatchObject({ action: 'BLOCKED', cycle: { state: CycleState.Blocked } })
+  })
+
+  test('does not restrict PAPER authority when the causal cycle block is rejected', async () => {
+    const fixture = await paperLifecycleFixture()
+    const observedAt = fixture.document.submissionCutoffAt
+    const unused = Effect.die(new Error('failed PAPER terminalization used an unrelated store operation'))
+    let restrictions = 0
+    const cycleStore: CycleStoreShape = {
+      acquire: () => unused,
+      read: () => unused,
+      readAuthoritySlot: () => unused,
+      readDecisionDocument: () => unused,
+      readOldestUnfinished: () => unused,
+      bindSnapshot: () => unused,
+      activate: () => unused,
+      bindDecision: () => unused,
+      finish: () => unused,
+      block: () =>
+        Effect.fail(
+          new CycleStoreError({
+            operation: 'block',
+            failure: 'query',
+            persistenceFailure: 'constraint',
+            message: 'open mutation prevents cycle block',
+          }),
+        ),
+    }
+    const authorityRestrictionStore: AuthorityRestrictionStoreShape = {
+      restrictAuthority: () =>
+        Effect.sync(() => {
+          restrictions += 1
+        }),
+    }
+    const writerFence: WriterFenceService = {
+      backendPid: 1,
+      check: unused,
+      transaction: (effect) => effect,
+    }
+
+    const failure = await Effect.runPromise(
+      Effect.flip(
+        terminalizeBlockedPaperCycle(fixture.boundCycle, {
+          _tag: 'Block',
+          reason: CycleTerminalReason.MissedSubmission,
+          observedAt,
+        }).pipe(
+          Effect.provideService(CycleStore, cycleStore),
+          Effect.provideService(AuthorityRestrictionStore, authorityRestrictionStore),
+          Effect.provideService(WriterFence, writerFence),
+        ),
+      ),
+    )
+
+    expect(failure).toMatchObject({
+      failure: 'store',
+      message: 'blocked PAPER cycle finalization failed',
+    })
+    expect(restrictions).toBe(0)
   })
 
   test('terminalizes an untouched PAPER remainder when its durable approval expires', async () => {

--- a/services/bayn/src/observe-composition.ts
+++ b/services/bayn/src/observe-composition.ts
@@ -1782,24 +1782,54 @@ const terminalizeBlockedPaperCycleDataFirst = (
   cycle: AutonomousCycle,
   outcome: Extract<BoundMutationCycleOutcome, { readonly _tag: 'Block' }>,
 ): Effect.Effect<CycleRunResult, CycleRunnerError, CycleStore | AuthorityRestrictionStore | WriterFence> =>
-  restrictMutationAuthority(
-    'PAPER autonomous cycle loop',
-    `bound cycle ${cycle.identity.cycleId} blocked: ${outcome.reason}`,
-  ).pipe(
-    Effect.andThen(
-      CycleStore.pipe(
-        Effect.flatMap((store) => store.block(cycle.identity.cycleId, outcome.reason, outcome.observedAt)),
+  Effect.gen(function* () {
+    const store = yield* CycleStore
+    const restrictionStore = yield* AuthorityRestrictionStore
+    const fence = yield* WriterFence
+    const restrictionReason = `bound cycle ${cycle.identity.cycleId} blocked: ${outcome.reason}`
+    const receipt = yield* fence.transaction(
+      store.block(cycle.identity.cycleId, outcome.reason, outcome.observedAt).pipe(
         Effect.mapError((cause) =>
           mutationRunnerError({ message: 'blocked PAPER cycle finalization failed', cause, failure: 'store' }),
         ),
+        Effect.tap(() =>
+          restrictionStore
+            .restrictAuthority(
+              `PAPER autonomous cycle loop restricted effective authority: ${restrictionReason}`,
+              outcome.observedAt,
+            )
+            .pipe(
+              Effect.mapError((cause) =>
+                mutationRunnerError({
+                  message: 'authority restriction failed after a bound PAPER cycle failure',
+                  cause: { subject: 'PAPER autonomous cycle loop', reason: restrictionReason, cause },
+                  failure: 'store',
+                }),
+              ),
+            ),
+        ),
       ),
-    ),
-    Effect.map((receipt) => ({
+    )
+    yield* Effect.logWarning('Bayn PAPER cycle terminalized with restricted mutation authority').pipe(
+      Effect.annotateLogs({
+        service: 'bayn',
+        cycleId: cycle.identity.cycleId,
+        terminalReason: outcome.reason,
+        observedAt: outcome.observedAt,
+      }),
+    )
+    return {
       outcome: 'RECOVERED' as const,
       action: 'BLOCKED' as const,
       observedAt: outcome.observedAt,
       cycle: receipt.cycle,
-    })),
+    }
+  }).pipe(
+    Effect.mapError((cause) =>
+      cause instanceof CycleRunnerError
+        ? cause
+        : mutationRunnerError({ message: 'blocked PAPER cycle transaction failed', cause, failure: 'store' }),
+    ),
   )
 
 export const terminalizeBlockedPaperCycle = Pipeable.dual(2, terminalizeBlockedPaperCycleDataFirst)

--- a/services/bayn/src/observe-composition/mutation-intent-interpreter.ts
+++ b/services/bayn/src/observe-composition/mutation-intent-interpreter.ts
@@ -505,6 +505,12 @@ const prepareMutationIntentDataFirst = <R, E, I extends MutationIntentInput, P e
     const terminalEvidence: PaperCycleIntentTerminalEvidence[] = []
     let pendingIntentFound = false
     let unsuccessfulIntentFound = false
+    let deferredExpiration:
+      | {
+          readonly reason: CycleTerminalReason.MissedSubmission | CycleTerminalReason.Risk
+          readonly observedAt: string
+        }
+      | undefined
     const hasFilledIntent = paperCycleHasFilledIntent({
       intents: preparedIntents.flatMap((prepared) => (prepared.stored === undefined ? [] : [prepared.stored.intent])),
       orders: facts.reconciliation.brokerState.orders,
@@ -593,12 +599,10 @@ const prepareMutationIntentDataFirst = <R, E, I extends MutationIntentInput, P e
             submissionCutoffAt,
           )
           if (expirationReason !== undefined) {
-            return {
-              _tag: 'Block',
-              reason: expirationReason,
-              observedAt: facts.evaluatedAt,
-            }
+            deferredExpiration ??= { reason: expirationReason, observedAt: facts.evaluatedAt }
+            continue
           }
+          if (deferredExpiration !== undefined) continue
           yield* Effect.fromResult(
             input.mutationPhase === 'CLOSE'
               ? decidePreparedCloseIntentAdmission(
@@ -635,7 +639,21 @@ const prepareMutationIntentDataFirst = <R, E, I extends MutationIntentInput, P e
       }
     }
 
-    if (pendingIntentFound) return { _tag: 'Wait', observedAt: facts.evaluatedAt }
+    if (pendingIntentFound) {
+      if (deferredExpiration !== undefined) {
+        yield* Effect.logInfo('Bayn PAPER cutoff terminalization deferred by a nonterminal broker intent').pipe(
+          Effect.annotateLogs({
+            service: 'bayn',
+            cycleId: cycle.identity.cycleId,
+            authorityGenerationHash: document.bindings.authorityGenerationHash,
+            mutationPhase: input.mutationPhase ?? 'ENTRY',
+            terminalReason: deferredExpiration.reason,
+            observedAt: facts.evaluatedAt,
+          }),
+        )
+      }
+      return { _tag: 'Wait', observedAt: facts.evaluatedAt }
+    }
 
     if (unsuccessfulIntentFound) {
       const recoveryDeadline =
@@ -651,6 +669,14 @@ const prepareMutationIntentDataFirst = <R, E, I extends MutationIntentInput, P e
         _tag: 'Block',
         reason: CycleTerminalReason.Risk,
         observedAt: facts.evaluatedAt,
+      }
+    }
+
+    if (deferredExpiration !== undefined) {
+      return {
+        _tag: 'Block',
+        reason: deferredExpiration.reason,
+        observedAt: deferredExpiration.observedAt,
       }
     }
 


### PR DESCRIPTION
## Summary

- defer cutoff terminalization while an acknowledged broker order remains nonterminal, while still forbidding fresh post-cutoff submits
- atomically persist the causal cycle block and authority restriction under one writer fence so a rejected block cannot strand authority in restricted state
- emit structured Effect lifecycle logs and add causal unit and PostgreSQL regressions for the live failure shape

## Related Issues

None

## Testing

- `bun run --filter @proompteng/bayn test` (1,075 passed, 162 PostgreSQL-only skipped, 0 failed)
- `BAYN_TEST_POSTGRES_URL=postgresql://bayn:bayn@127.0.0.1:5432/bayn_test bun run --cwd services/bayn test:postgres` (147 passed, 0 failed)
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn build`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable and Breaking Changes is filled in.
- [x] No documentation, release-note, or follow-up change is required for this causal runtime fix.