### PR TITLE
fix(bayn): resume restricted PAPER recovery

### DIFF
--- a/services/bayn/src/composition.test.ts
+++ b/services/bayn/src/composition.test.ts
@@ -409,6 +409,46 @@ describe('Bayn PAPER startup recovery boundary', () => {
       message: ['Bayn PAPER build continuation resumed the active generation'],
       annotations: {
         service: 'bayn',
+        activationMode: 'ACTIVE',
+        continuationHash: researchBuildContinuation.continuationHash,
+        generationHash: continuationGeneration.generationHash,
+        sourceRevision: continuationBuild.sourceRevision,
+        imageDigest: continuationBuild.imageDigest,
+      },
+    })
+  })
+
+  test('resumes an exact failure-restricted generation for recovery without rearming or activating', async () => {
+    const authorityReason =
+      'PAPER autonomous cycle loop restricted effective authority: bound cycle blocked: BLOCKED_MISSED_SUBMISSION_DEADLINE'
+    const authority: AuthorityState = {
+      ...continuationAuthority,
+      effective: Authority.Observe,
+      kill: KillState.Active,
+      reason: authorityReason,
+    }
+    const logs: Array<{ readonly message: unknown; readonly annotations: Record<string, unknown> }> = []
+    const logger = Logger.make<unknown, void>((entry) => {
+      logs.push({
+        message: entry.message,
+        annotations: { ...entry.fiber.getRef(References.CurrentLogAnnotations) },
+      })
+    })
+
+    const generation = await Effect.runPromise(
+      resumeBuildContinuation(
+        researchBuildContinuation,
+        continuationAuthorityStore(continuationGeneration, authority),
+      ).pipe(Effect.provide(Logger.layer([logger]))),
+    )
+
+    expect(generation).toEqual(continuationGeneration)
+    expect(logs).toContainEqual({
+      message: ['Bayn PAPER build continuation resumed a restricted active generation for recovery'],
+      annotations: {
+        service: 'bayn',
+        activationMode: 'RECOVERY_ONLY',
+        authorityReason,
         continuationHash: researchBuildContinuation.continuationHash,
         generationHash: continuationGeneration.generationHash,
         sourceRevision: continuationBuild.sourceRevision,

--- a/services/bayn/src/composition.ts
+++ b/services/bayn/src/composition.ts
@@ -930,7 +930,7 @@ export const prepareOrRecoverResearchPaperActivation = (
         paperActivationOperationalError('research PAPER durable authority does not match this episode', cause),
       ),
     )
-    if (buildContinuation !== null && decision._tag !== 'Resume') {
+    if (buildContinuation !== null && decision._tag !== 'Resume' && decision._tag !== 'ResumeRestricted') {
       return yield* paperActivationOperationalError(
         'research PAPER build continuation requires the exact active generation',
       )
@@ -957,20 +957,27 @@ export const prepareOrRecoverResearchPaperActivation = (
         )
       }
     }
-    if (decision._tag !== 'Resume') {
+    if (decision._tag !== 'Resume' && decision._tag !== 'ResumeRestricted') {
       yield* refreshResearchPaperActivationReconciliation(reconcile, operationTimeoutMs)
       return yield* prepareResearchPaperActivation(plan, request, session, authorityStore, lifecycle)
     }
     const generation =
       currentGeneration ?? (yield* paperActivationOperationalError('research PAPER recovery lost durable history'))
     if (buildContinuation !== null) {
-      yield* Effect.logInfo('Bayn PAPER build continuation resumed the active generation').pipe(
+      const restricted = decision._tag === 'ResumeRestricted'
+      yield* Effect.logInfo(
+        restricted
+          ? 'Bayn PAPER build continuation resumed a restricted active generation for recovery'
+          : 'Bayn PAPER build continuation resumed the active generation',
+      ).pipe(
         Effect.annotateLogs({
           service: 'bayn',
+          activationMode: restricted ? 'RECOVERY_ONLY' : 'ACTIVE',
           continuationHash: buildContinuation.continuationHash,
           generationHash: generation.generationHash,
           sourceRevision: plan.config.build.sourceRevision,
           imageDigest: plan.config.build.imageDigest,
+          ...(restricted ? { authorityReason: authority.reason ?? 'unknown' } : {}),
         }),
       )
     }

--- a/services/bayn/src/paper-episode.test.ts
+++ b/services/bayn/src/paper-episode.test.ts
@@ -168,6 +168,17 @@ describe('paper episode decisions', () => {
     expect(
       decidePaperEpisodeAuthority({
         ...common,
+        generationHash: 'b'.repeat(64),
+        maximum: 'PAPER',
+        effective: 'OBSERVE',
+        kill: 'ACTIVE',
+        currentGenerationMatchesRequest: true,
+        reason: 'PAPER autonomous cycle loop restricted effective authority: build-decision failed',
+      }),
+    ).toEqual(Result.succeed({ _tag: 'ResumeRestricted' }))
+    expect(
+      decidePaperEpisodeAuthority({
+        ...common,
         generationHash: 'c'.repeat(64),
         maximum: 'PAPER',
         effective: 'PAPER',

--- a/services/bayn/src/paper-episode.ts
+++ b/services/bayn/src/paper-episode.ts
@@ -158,6 +158,7 @@ export type PaperEpisodeAuthorityDecision =
   | { readonly _tag: 'Activate' }
   | { readonly _tag: 'Rearm' }
   | { readonly _tag: 'Resume' }
+  | { readonly _tag: 'ResumeRestricted' }
 
 export const decidePaperEpisodeAuthority = (
   facts: PaperEpisodeAuthorityFacts,
@@ -194,7 +195,7 @@ export const decidePaperEpisodeAuthority = (
     facts.generationHash !== facts.sourceGenerationHash &&
     facts.reason?.startsWith(paperEpisodeFailureRestrictionPrefix) === true
   ) {
-    return Result.succeed({ _tag: 'Rearm' })
+    return Result.succeed({ _tag: facts.currentGenerationMatchesRequest ? 'ResumeRestricted' : 'Rearm' })
   }
   return Result.fail({ _tag: 'IdentityDrift' })
 }


### PR DESCRIPTION
## Summary

- distinguish an exact failure-restricted PAPER generation from a mismatched generation at the pure authority boundary
- resume the exact restricted generation in recovery-only mode without rearming authority, activating a generation, or running pre-activation reconciliation
- emit a structured Effect lifecycle log with activation mode, continuation, generation, build provenance, and the bounded authority reason
- preserve the active kill so fresh submissions remain fail-closed while existing broker outcomes can recover

## Related Issues

None

## Testing

- bun test services/bayn/src/paper-episode.test.ts services/bayn/src/composition.test.ts
- bun run --filter @proompteng/bayn test
- bun run --filter @proompteng/bayn tsc
- bun run --filter @proompteng/bayn lint
- bun run --filter @proompteng/bayn lint:oxlint
- bun run --filter @proompteng/bayn lint:oxlint:type
- bun run --filter @proompteng/bayn build
- bun run --filter @proompteng/bayn test:postgres (local PostgreSQL fixture unavailable; 154 integration cases skipped, hosted PostgreSQL gate required)

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] Documentation and release notes are not required for this bounded recovery correction.
