### PR TITLE
feat(bayn): expose paper recovery metrics

### DIFF
--- a/services/bayn/src/http.test.ts
+++ b/services/bayn/src/http.test.ts
@@ -358,6 +358,30 @@ describe('Bayn HTTP pure decisions', () => {
     expect(metrics).toContain('bayn_mutation_recovery_found_events_total 185')
     expect(metrics).toContain('bayn_intents{state="approved"} 3')
     expect(metrics).toContain('bayn_intents{state="acknowledged"} 1')
+    expect(metrics).toContain('bayn_paper_activation_recovery_only 0')
+
+    const restrictedMetrics = renderPrometheusMetrics(
+      {
+        ...realized,
+        cycle: {
+          ...realized.cycle,
+          authority: {
+            generationHash: realized.paperActivation.generationHash,
+            maximum: Authority.Paper,
+            effective: Authority.Observe,
+            kill: KillState.Active,
+            reason: 'PAPER autonomous cycle loop restricted effective authority: bounded recovery',
+            updatedAt: '2026-09-01T13:31:00.000Z',
+          },
+          alerts: { ...realized.cycle.alerts, killActive: true },
+        },
+      },
+      config,
+      provenance,
+      'embedded',
+    )
+    expect(restrictedMetrics).toContain('bayn_paper_activation_recovery_only 1')
+    expect(restrictedMetrics).toContain('bayn_authority_effective{authority="observe"} 1')
   })
 
   test('covers every readiness decision branch without mutating runtime facts', () => {
@@ -1242,6 +1266,8 @@ describe('Bayn HTTP probes', () => {
               },
             })
             expect(metrics.body).toContain('bayn_runtime_ready 1')
+            expect(metrics.body).toContain('bayn_paper_activation_state{state="realized"} 1')
+            expect(metrics.body).toContain('bayn_paper_activation_state{state="pending"} 0')
           }),
         ),
         Effect.asVoid,
@@ -1819,6 +1845,7 @@ describe('Bayn HTTP probes', () => {
     expect(metrics).toContain('bayn_cycle_reason{reason="observation_unavailable"} 1')
     expect(metrics).toContain('bayn_cycle_phase{phase="unknown"} 1')
     expect(metrics).toContain('bayn_cycle_terminal_reason{reason="unknown"} 1')
+    expect(metrics).toContain('bayn_paper_activation_state{state="not_configured"} 1')
     expect(metrics).toContain('bayn_zero_mutation_confirmed 0')
     expect(metrics).not.toContain('bayn_cycle_unfinished_count ')
     expect(metrics).not.toContain('bayn_mutation_events_total ')

--- a/services/bayn/src/http.ts
+++ b/services/bayn/src/http.ts
@@ -526,6 +526,11 @@ const renderPrometheusMetricsDataFirst = (
   const effectiveBrokerMutation = paperActivationRealized || config.execution.brokerAccess === BrokerAccess.Mutation
   const effectiveCapitalPromotion =
     paperActivationRealized || config.execution.capitalAuthority._tag !== CapitalAuthorityKind.None
+  const paperActivationState =
+    state.paperActivation?._tag === 'NotConfigured' || state.paperActivation === undefined
+      ? 'not_configured'
+      : state.paperActivation._tag.toLowerCase()
+  const paperActivationStates = ['not_configured', 'pending', 'realized', 'completed'] as const
   const cadence = autonomousCycleCadenceObservation(state)
   const cadenceConditions = Object.values(MonthEndCadenceCondition)
   const cadenceReasons = Object.values(MonthEndCadenceReason)
@@ -538,13 +543,17 @@ const renderPrometheusMetricsDataFirst = (
     state.autonomousCycleLoop.lastPass === null || state.health.checkedAt === null
       ? undefined
       : Math.max(0, Date.parse(state.health.checkedAt) - Date.parse(state.autonomousCycleLoop.lastPass.observedAt))
-  const effectiveAuthority = paperActivationRealized
-    ? 'paper'
-    : state.cycle.authority === null
+  const effectiveAuthority =
+    state.cycle.authority === null
       ? 'unknown'
       : state.cycle.authority.effective === Authority.Paper
         ? 'paper'
         : 'observe'
+  const paperActivationRecoveryOnly =
+    paperActivationRealized &&
+    state.cycle.authority?.maximum === Authority.Paper &&
+    state.cycle.authority.effective === Authority.Observe &&
+    state.cycle.alerts.killActive
   const lines = [
     '# HELP bayn_runtime_ready Whether the bounded runtime state and required dependencies are operationally ready.',
     '# TYPE bayn_runtime_ready gauge',
@@ -726,6 +735,15 @@ const renderPrometheusMetricsDataFirst = (
     '# HELP bayn_capital_promotion_enabled Whether capital promotion is enabled in this runtime.',
     '# TYPE bayn_capital_promotion_enabled gauge',
     `bayn_capital_promotion_enabled ${effectiveCapitalPromotion ? 1 : 0}`,
+    '# HELP bayn_paper_activation_state Current PAPER activation lifecycle state.',
+    '# TYPE bayn_paper_activation_state gauge',
+    ...paperActivationStates.map(
+      (activationState) =>
+        `bayn_paper_activation_state{state="${activationState}"} ${paperActivationState === activationState ? 1 : 0}`,
+    ),
+    '# HELP bayn_paper_activation_recovery_only Whether the realized PAPER runtime is restricted to recovery and close operations.',
+    '# TYPE bayn_paper_activation_recovery_only gauge',
+    `bayn_paper_activation_recovery_only ${paperActivationRecoveryOnly ? 1 : 0}`,
     '# HELP bayn_build_info Verified runtime build provenance.',
     '# TYPE bayn_build_info gauge',
     `bayn_build_info{source_revision="${prometheusLabel(provenance.sourceRevision)}",image_digest="${prometheusLabel(provenance.image.digest)}",verification="${prometheusLabel(provenanceVerification)}"} 1`,


### PR DESCRIPTION
## Summary

- expose the PAPER activation lifecycle as a bounded one-hot Prometheus gauge
- expose whether a realized PAPER runtime is recovery-only because durable authority remains OBSERVE with an active kill
- project durable effective authority directly instead of masking a recovery restriction as PAPER
- retain existing recovery-event, intent-state, unresolved-mutation, and reconciliation metrics for rate and convergence queries

## Related Issues

None

## Testing

- bun test services/bayn/src/http.test.ts
- bun run --filter @proompteng/bayn test
- bun run --filter @proompteng/bayn tsc
- bun run --filter @proompteng/bayn lint
- bun run --filter @proompteng/bayn lint:oxlint
- bun run --filter @proompteng/bayn lint:oxlint:type
- bun run --filter @proompteng/bayn build

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] Documentation and release notes are not required for these runtime metrics.
