### PR TITLE
feat(bayn): adopt durable Restate lifecycle

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -721,6 +721,7 @@
         "@effect/platform-node": "4.0.0-beta.102",
         "@effect/sql-clickhouse": "4.0.0-beta.102",
         "@effect/sql-pg": "4.0.0-beta.102",
+        "@restatedev/restate-sdk": "1.16.4",
         "effect": "4.0.0-beta.102",
         "tigerbeetle-node": "0.17.9",
       },
@@ -2447,6 +2448,10 @@
     "@redocly/openapi-core": ["@redocly/openapi-core@1.34.6", "", { "dependencies": { "@redocly/ajv": "^8.11.2", "@redocly/config": "^0.22.0", "colorette": "^1.2.0", "https-proxy-agent": "^7.0.5", "js-levenshtein": "^1.1.6", "js-yaml": "^4.1.0", "minimatch": "^5.0.1", "pluralize": "^8.0.0", "yaml-ast-parser": "0.0.43" } }, "sha512-2+O+riuIUgVSuLl3Lyh5AplWZyVMNuG2F98/o6NrutKJfW4/GTZdPpZlIphS0HGgcOHgmWcCSHj+dWFlZaGSHw=="],
 
     "@reduxjs/toolkit": ["@reduxjs/toolkit@2.11.2", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@standard-schema/utils": "^0.3.0", "immer": "^11.0.0", "redux": "^5.0.1", "redux-thunk": "^3.1.0", "reselect": "^5.1.0" }, "peerDependencies": { "react": "^16.9.0 || ^17.0.0 || ^18 || ^19", "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0" }, "optionalPeers": ["react", "react-redux"] }, "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ=="],
+
+    "@restatedev/restate-sdk": ["@restatedev/restate-sdk@1.16.4", "", { "dependencies": { "@restatedev/restate-sdk-core": "1.16.4" } }, "sha512-6i6CLCga0DyurJUkt7WcONVO1z32k5MC3mOF0QnmRIm0qN6eiY2ZRoUO9FPy1bSj5alnaCokKhsDyCF0q0M5WA=="],
+
+    "@restatedev/restate-sdk-core": ["@restatedev/restate-sdk-core@1.16.4", "", {}, "sha512-jxxi+y35aRcn71seCLVFFeOWO3rcBSOmM2Xjs80P1bdSpLLfZau38EPUSZV7yw8ZXq7TM++Z0CrHC1M5qE8Geg=="],
 
     "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.0.0-rc.18", "", { "os": "android", "cpu": "arm64" }, "sha512-lIDyUAfD7U3+BWKzdxMbJcsYHuqXqmGz40aeRqvuAm3y5TkJSYTBW2RDrn65DJFPQqVjUAUqq5uz8urzQ8aBdQ=="],
 

--- a/nix/images/bayn.nix
+++ b/nix/images/bayn.nix
@@ -21,13 +21,14 @@ let
   buildDefine = name: value: "--define ${name}=${lib.escapeShellArg (builtins.toJSON value)}";
   dependencySource = import ./bun-workspace-deps-source.nix { inherit lib repoRoot; };
   depsHash = {
-    x86_64-linux = "sha256-u91uWXdvRLtCVhhtiCV0JC0b7cybEC6IzTZ6HWa+a7M=";
-    aarch64-linux = "sha256-eiKVvu8pc++x+yvYGHWVoxEnNGFq1MeVV4tJxth2nPM=";
+    # Refreshed from the two authoritative Linux image builders after adding the Restate SDK.
+    x86_64-linux = "sha256-MBfmsLhO8voqDByn07GjN2ggruwGnM2iL3gvESXIYuI=";
+    aarch64-linux = "sha256-jIYq6UCJfpBolkHaG+jOGD887NW/DUn1lCHKKtEJWnU=";
   };
   buildCommands = [
     "bun --cwd=services/bayn run tsc"
     (
-      "bun --cwd=services/bayn build src/index.ts src/verify-build-contract.ts src/forward-performance-command.ts --target=node "
+      "bun --cwd=services/bayn build src/index.ts src/verify-build-contract.ts src/forward-performance-command.ts src/restate-lifecycle-server.ts src/restate-lifecycle-register.ts --target=node "
       + "--external tigerbeetle-node --outdir=dist "
       + buildDefine "__BAYN_BUILD_SOURCE_REVISION__" repoRevision
       + " "
@@ -40,6 +41,8 @@ let
     "node services/bayn/dist/verify-build-contract.js"
     "grep -F -- ${lib.escapeShellArg repoRevision} services/bayn/dist/index.js"
     "grep -F -- ${lib.escapeShellArg repoRevision} services/bayn/dist/forward-performance-command.js"
+    "grep -F -- ${lib.escapeShellArg repoRevision} services/bayn/dist/restate-lifecycle-server.js"
+    "grep -F -- ${lib.escapeShellArg repoRevision} services/bayn/dist/restate-lifecycle-register.js"
     "grep -F -- ${lib.escapeShellArg strategyBehaviorHash} services/bayn/dist/index.js"
     "grep -F -- ${lib.escapeShellArg strategyParameterHash} services/bayn/dist/index.js"
   ];
@@ -47,6 +50,8 @@ let
     mkdir -p "$out/app/services/bayn/dist" "$out/app/services/bayn/node_modules/tigerbeetle-node"
     cp "$TMPDIR/work/services/bayn/dist/index.js" "$out/app/services/bayn/dist/"
     cp "$TMPDIR/work/services/bayn/dist/forward-performance-command.js" "$out/app/services/bayn/dist/"
+    cp "$TMPDIR/work/services/bayn/dist/restate-lifecycle-server.js" "$out/app/services/bayn/dist/"
+    cp "$TMPDIR/work/services/bayn/dist/restate-lifecycle-register.js" "$out/app/services/bayn/dist/"
     cp "$TMPDIR/work/services/bayn/package.json" "$out/app/services/bayn/package.json"
     cp -R -L "$TMPDIR/work/services/bayn/node_modules/tigerbeetle-node/." \
       "$out/app/services/bayn/node_modules/tigerbeetle-node/"
@@ -90,6 +95,8 @@ import ./bun-workspace-service.nix {
   ];
   exposedPorts = {
     "8080/tcp" = { };
+    "8081/tcp" = { };
+    "9080/tcp" = { };
   };
   labels = {
     "org.opencontainers.image.revision" = repoRevision;

--- a/nix/images/signal-publisher.nix
+++ b/nix/images/signal-publisher.nix
@@ -16,8 +16,8 @@ import ./bun-workspace-service.nix {
   serviceName = "signal-publisher";
   packageName = "@proompteng/signal-publisher";
   depsHash = {
-    x86_64-linux = "sha256-xtEiOy2QuIPN51pX3/KGFQc+EeGy5gnpfK07F95KV+4=";
-    aarch64-linux = "sha256-k4hcwX92uYgqEHaTMV82FFGpekyjf0dGj/Bal8Nof2w=";
+    x86_64-linux = "sha256-K//wu3eFwvjPH7cAkyI0m050H1cQrC9eXsATAeDclOA=";
+    aarch64-linux = "sha256-F/c/vERygFGLeUtGHmUW7atCqMKDMBBGlX1Sqsfi3OU=";
   };
   installFilters = [
     "@proompteng/signal-publisher"

--- a/services/bayn/migrations/0031_blocked_paper_generation_rollover.ts
+++ b/services/bayn/migrations/0031_blocked_paper_generation_rollover.ts
@@ -1,0 +1,261 @@
+import { Effect } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient
+
+  yield* sql`
+    CREATE OR REPLACE FUNCTION enforce_intent_transition()
+    RETURNS trigger
+    LANGUAGE plpgsql
+    AS $function$
+    DECLARE
+      decision_outcome text;
+      decision_decided_at timestamptz;
+      decision_expires_at timestamptz;
+      decision_checked_at timestamptz;
+    BEGIN
+      IF TG_OP = 'DELETE' THEN
+        RAISE EXCEPTION 'intents cannot be deleted' USING ERRCODE = '55000';
+      END IF;
+
+      IF TG_OP = 'INSERT' THEN
+        IF NEW.state <> 'PLANNED'
+          OR NEW.risk_decision_id IS NOT NULL
+          OR NEW.terminal_outcome IS NOT NULL
+          OR NEW.state_version <> 1
+          OR NEW.updated_at <> NEW.created_at
+        THEN
+          RAISE EXCEPTION 'new intents must begin in PLANNED state' USING ERRCODE = '23514';
+        END IF;
+        RETURN NEW;
+      END IF;
+
+      IF (to_jsonb(OLD) - ARRAY['state', 'risk_decision_id', 'terminal_outcome', 'state_version', 'updated_at'])
+        <> (to_jsonb(NEW) - ARRAY['state', 'risk_decision_id', 'terminal_outcome', 'state_version', 'updated_at'])
+      THEN
+        RAISE EXCEPTION 'intent immutable fields cannot change' USING ERRCODE = '55000';
+      END IF;
+
+      IF NEW.state_version <> OLD.state_version + 1 OR NEW.updated_at <= OLD.updated_at THEN
+        RAISE EXCEPTION 'intent state version and time must advance' USING ERRCODE = '23514';
+      END IF;
+
+      IF OLD.state <> 'PLANNED' AND NEW.risk_decision_id IS DISTINCT FROM OLD.risk_decision_id THEN
+        RAISE EXCEPTION 'intent risk decision cannot change after planning' USING ERRCODE = '55000';
+      END IF;
+
+      IF NOT (CASE OLD.state
+        WHEN 'PLANNED' THEN NEW.state IN ('APPROVED', 'TERMINAL')
+        WHEN 'APPROVED' THEN NEW.state IN ('IO_STARTED', 'TERMINAL')
+        WHEN 'IO_STARTED' THEN NEW.state IN ('ACKNOWLEDGED', 'UNKNOWN', 'TERMINAL')
+        WHEN 'ACKNOWLEDGED' THEN NEW.state = 'TERMINAL'
+        WHEN 'UNKNOWN' THEN NEW.state = 'RECOVERED'
+        WHEN 'RECOVERED' THEN NEW.state IN ('ACKNOWLEDGED', 'TERMINAL')
+        WHEN 'TERMINAL' THEN false
+        ELSE false
+      END) THEN
+        RAISE EXCEPTION 'invalid intent transition from % to %', OLD.state, NEW.state USING ERRCODE = '23514';
+      END IF;
+
+      IF NEW.state = 'TERMINAL' AND NOT (CASE OLD.state
+        WHEN 'PLANNED' THEN NEW.terminal_outcome = 'BLOCKED'
+        WHEN 'APPROVED' THEN NEW.terminal_outcome IN ('BLOCKED', 'CANCELED', 'EXPIRED')
+        WHEN 'IO_STARTED' THEN NEW.terminal_outcome IN ('FILLED', 'CANCELED', 'EXPIRED', 'REJECTED')
+        WHEN 'ACKNOWLEDGED' THEN NEW.terminal_outcome IN ('FILLED', 'CANCELED', 'EXPIRED', 'REJECTED')
+        WHEN 'RECOVERED' THEN NEW.terminal_outcome IN ('FILLED', 'CANCELED', 'EXPIRED', 'REJECTED')
+        ELSE false
+      END) THEN
+        RAISE EXCEPTION 'invalid terminal outcome % from %', NEW.terminal_outcome, OLD.state USING ERRCODE = '23514';
+      END IF;
+
+      IF OLD.state = 'PLANNED' OR NEW.state = 'IO_STARTED' THEN
+        SELECT outcome, decided_at, expires_at
+        INTO decision_outcome, decision_decided_at, decision_expires_at
+        FROM risk_decisions
+        WHERE decision_id = NEW.risk_decision_id AND intent_id = NEW.intent_id;
+
+        IF NOT FOUND THEN
+          RAISE EXCEPTION 'intent transition requires its bound risk decision' USING ERRCODE = '23503';
+        END IF;
+
+        decision_checked_at := clock_timestamp();
+        IF decision_decided_at > NEW.updated_at
+          OR decision_expires_at <= NEW.updated_at
+          OR decision_decided_at > decision_checked_at
+          OR decision_expires_at <= decision_checked_at
+        THEN
+          RAISE EXCEPTION 'intent transition requires a current risk decision' USING ERRCODE = '23514';
+        END IF;
+
+        IF NEW.state = 'TERMINAL' AND decision_outcome <> 'BLOCKED' THEN
+          RAISE EXCEPTION 'blocked terminal intent requires a blocked risk decision' USING ERRCODE = '23514';
+        END IF;
+
+        IF NEW.state <> 'TERMINAL' AND decision_outcome <> 'APPROVED' THEN
+          RAISE EXCEPTION 'broker I/O requires an approved risk decision' USING ERRCODE = '23514';
+        END IF;
+      END IF;
+
+      RETURN NEW;
+    END
+    $function$
+  `
+
+  yield* sql`
+    CREATE OR REPLACE FUNCTION research_paper_rearm_eligible(
+      candidate_generation_hash text,
+      candidate_authority_version bigint,
+      candidate_activated_at timestamptz
+    )
+    RETURNS boolean
+    LANGUAGE sql
+    STABLE
+    AS $function$
+      SELECT EXISTS (
+        SELECT 1
+        FROM authority_state AS state
+        JOIN authority_generations AS previous_generation
+          ON previous_generation.generation_hash = state.generation_hash
+        JOIN authority_generations AS candidate_generation
+          ON candidate_generation.generation_hash = candidate_generation_hash
+        JOIN LATERAL (
+          SELECT reconciliation.*
+          FROM reconciliations AS reconciliation
+          WHERE reconciliation.account_id = previous_generation.account_id
+          ORDER BY reconciliation.reconciled_at DESC, reconciliation.reconciliation_id COLLATE "C" DESC
+          LIMIT 1
+        ) AS reconciliation ON true
+        WHERE state.singleton
+          AND (
+            (
+              state.maximum = 'PAPER'
+              AND state.effective = 'OBSERVE'
+              AND state.kill_state = 'ACTIVE'
+              AND state.reason LIKE 'PAPER autonomous cycle loop restricted effective authority:%'
+            )
+            OR (
+              state.maximum = 'PAPER'
+              AND state.effective = 'PAPER'
+              AND state.kill_state = 'CLEAR'
+              AND state.reason IS NULL
+            )
+          )
+          AND state.version + 1 = candidate_authority_version
+          AND previous_generation.maximum = 'PAPER'
+          AND previous_generation.activation_schema_version IN (
+            'bayn.paper-authority-generation.v2',
+            'bayn.paper-authority-generation.v3'
+          )
+          AND CASE previous_generation.activation_schema_version
+            WHEN 'bayn.paper-authority-generation.v2' THEN previous_generation.qualification_run_id IS NOT NULL
+            WHEN 'bayn.paper-authority-generation.v3' THEN previous_generation.proof_plan_hash IS NOT NULL
+            ELSE false
+          END
+          AND candidate_generation.previous_generation_hash = previous_generation.generation_hash
+          AND candidate_generation.maximum = 'OBSERVE'
+          AND candidate_generation.activation_schema_version IS NULL
+          AND candidate_generation.authority_version = candidate_authority_version
+          AND candidate_generation.activated_at = candidate_activated_at
+          AND candidate_generation.broker_identity_schema_version = previous_generation.broker_identity_schema_version
+          AND candidate_generation.broker_identity_hash = previous_generation.broker_identity_hash
+          AND candidate_generation.broker_provider = previous_generation.broker_provider
+          AND candidate_generation.broker_environment = 'sandbox'
+          AND candidate_generation.broker_environment = previous_generation.broker_environment
+          AND candidate_generation.account_id = previous_generation.account_id
+          AND reconciliation.status = 'EXACT'
+          AND reconciliation.expected_hash = reconciliation.observed_hash
+          AND jsonb_array_length(reconciliation.discrepancies) = 0
+          AND reconciliation.reconciled_at > state.updated_at
+          AND reconciliation.reconciled_at < candidate_activated_at
+          AND NOT EXISTS (
+            SELECT 1
+            FROM autonomous_cycles AS cycle
+            WHERE cycle.qualification_run_id = CASE previous_generation.activation_schema_version
+                WHEN 'bayn.paper-authority-generation.v2' THEN previous_generation.qualification_run_id
+                WHEN 'bayn.paper-authority-generation.v3' THEN previous_generation.proof_plan_hash
+                ELSE NULL
+              END
+              AND cycle.account_id = previous_generation.account_id
+              AND cycle.state IN ('PENDING', 'ACTIVE')
+          )
+          AND (
+            NOT EXISTS (
+              SELECT 1
+              FROM intents AS intent
+              WHERE intent.authority_generation_hash = previous_generation.generation_hash
+            )
+            OR (
+              EXISTS (
+                SELECT 1
+                FROM intents AS intent
+                WHERE intent.authority_generation_hash = previous_generation.generation_hash
+              )
+              AND NOT EXISTS (
+                SELECT 1
+                FROM intents AS intent
+                WHERE intent.authority_generation_hash = previous_generation.generation_hash
+                  AND intent.state <> 'TERMINAL'
+              )
+              AND NOT paper_account_has_unresolved_mutation(
+                previous_generation.account_id,
+                reconciliation.reconciled_at
+              )
+              AND reconciliation.reconciled_at > COALESCE(
+                (
+                  SELECT max(intent.updated_at)
+                  FROM intents AS intent
+                  WHERE intent.authority_generation_hash = previous_generation.generation_hash
+                ),
+                state.updated_at
+              )
+              AND reconciliation.reconciled_at > COALESCE(
+                (
+                  SELECT max(event.occurred_at)
+                  FROM mutation_events AS event
+                  JOIN intents AS intent ON intent.intent_id = event.intent_id
+                  WHERE intent.authority_generation_hash = previous_generation.generation_hash
+                ),
+                state.updated_at
+              )
+              AND EXISTS (
+                SELECT 1
+                FROM position_snapshots AS snapshot
+                WHERE snapshot.account_id = previous_generation.account_id
+                  AND snapshot.position_count = 0
+                  AND snapshot.observed_at <= reconciliation.reconciled_at
+                  AND NOT EXISTS (
+                    SELECT 1
+                    FROM position_snapshots AS later
+                    WHERE later.account_id = snapshot.account_id
+                      AND (
+                        later.observed_at > snapshot.observed_at
+                        OR (
+                          later.observed_at = snapshot.observed_at
+                          AND later.snapshot_id COLLATE "C" > snapshot.snapshot_id COLLATE "C"
+                        )
+                      )
+                  )
+              )
+              AND NOT EXISTS (
+                SELECT 1
+                FROM (
+                  SELECT DISTINCT ON (broker_order.broker_order_id)
+                    broker_order.intent_id,
+                    broker_order.status,
+                    event.observed_at
+                  FROM orders AS broker_order
+                  JOIN broker_events AS event ON event.event_id = broker_order.event_id
+                  WHERE broker_order.account_id = previous_generation.account_id
+                  ORDER BY broker_order.broker_order_id, event.source_sequence DESC
+                ) AS latest_order
+                WHERE latest_order.intent_id IS NULL
+                  OR latest_order.status IN ('NEW', 'PARTIALLY_FILLED', 'PENDING')
+                  OR latest_order.observed_at > reconciliation.reconciled_at
+              )
+            )
+          )
+      )
+    $function$
+  `
+})

--- a/services/bayn/migrations/0032_lifecycle_commands.ts
+++ b/services/bayn/migrations/0032_lifecycle_commands.ts
@@ -1,0 +1,89 @@
+import { Effect } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient
+
+  yield* sql`
+    CREATE TABLE lifecycle_commands (
+      controller_key text NOT NULL CHECK (controller_key ~ '^[a-z0-9][a-z0-9._-]{0,63}$'),
+      command_id text NOT NULL CHECK (command_id ~ '^[0-9a-f]{64}$'),
+      sequence bigint NOT NULL CHECK (sequence > 0),
+      issued_at timestamptz NOT NULL,
+      status text NOT NULL CHECK (status IN ('STARTED', 'COMPLETED')),
+      result text CHECK (result IN ('SUCCESS', 'FAILURE')),
+      outcome text,
+      operation text,
+      failure text,
+      message text,
+      observed_at timestamptz,
+      cadence_decision jsonb,
+      started_at timestamptz NOT NULL,
+      completed_at timestamptz,
+      PRIMARY KEY (controller_key, command_id),
+      UNIQUE (controller_key, sequence),
+      CHECK (
+        (status = 'STARTED'
+          AND result IS NULL
+          AND outcome IS NULL
+          AND operation IS NULL
+          AND failure IS NULL
+          AND message IS NULL
+          AND observed_at IS NULL
+          AND cadence_decision IS NULL
+          AND completed_at IS NULL)
+        OR
+        (status = 'COMPLETED'
+          AND result IS NOT NULL
+          AND observed_at IS NOT NULL
+          AND completed_at IS NOT NULL
+          AND completed_at >= started_at
+          AND (
+            (result = 'SUCCESS' AND outcome IS NOT NULL AND operation IS NULL AND failure IS NULL AND message IS NULL)
+            OR
+            (result = 'FAILURE' AND outcome IS NULL AND operation IS NOT NULL AND failure IS NOT NULL AND message IS NOT NULL)
+          ))
+      )
+    )
+  `
+
+  yield* sql`
+    CREATE FUNCTION enforce_lifecycle_command_transition()
+    RETURNS trigger
+    LANGUAGE plpgsql
+    AS $function$
+    BEGIN
+      IF TG_OP = 'DELETE' THEN
+        RAISE EXCEPTION 'lifecycle commands cannot be deleted' USING ERRCODE = '55000';
+      END IF;
+
+      IF TG_OP = 'INSERT' THEN
+        IF NEW.status <> 'STARTED' THEN
+          RAISE EXCEPTION 'lifecycle commands must begin in STARTED state' USING ERRCODE = '23514';
+        END IF;
+        RETURN NEW;
+      END IF;
+
+      IF OLD.status <> 'STARTED' OR NEW.status <> 'COMPLETED' THEN
+        RAISE EXCEPTION 'lifecycle command may only transition STARTED to COMPLETED' USING ERRCODE = '23514';
+      END IF;
+
+      IF (to_jsonb(OLD) - ARRAY[
+        'status', 'result', 'outcome', 'operation', 'failure', 'message', 'observed_at', 'cadence_decision', 'completed_at'
+      ]) <> (to_jsonb(NEW) - ARRAY[
+        'status', 'result', 'outcome', 'operation', 'failure', 'message', 'observed_at', 'cadence_decision', 'completed_at'
+      ]) THEN
+        RAISE EXCEPTION 'lifecycle command identity is immutable' USING ERRCODE = '55000';
+      END IF;
+
+      RETURN NEW;
+    END
+    $function$
+  `
+
+  yield* sql`
+    CREATE TRIGGER lifecycle_command_transition
+    BEFORE INSERT OR UPDATE OR DELETE ON lifecycle_commands
+    FOR EACH ROW EXECUTE FUNCTION enforce_lifecycle_command_transition()
+  `
+})

--- a/services/bayn/package.json
+++ b/services/bayn/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "bun build src/index.ts src/forward-performance-command.ts --target=node --external tigerbeetle-node --outdir=dist",
+    "build": "bun build src/index.ts src/forward-performance-command.ts src/restate-lifecycle-server.ts src/restate-lifecycle-register.ts --target=node --external tigerbeetle-node --outdir=dist",
     "dev": "BAYN_PROVENANCE_MODE=development bun --watch src/index.ts",
     "forward:performance": "BAYN_PROVENANCE_MODE=development node dist/forward-performance-command.js",
     "start": "BAYN_PROVENANCE_MODE=development node dist/index.js",
@@ -24,6 +24,7 @@
     "@effect/platform-node": "4.0.0-beta.102",
     "@effect/sql-clickhouse": "4.0.0-beta.102",
     "@effect/sql-pg": "4.0.0-beta.102",
+    "@restatedev/restate-sdk": "1.16.4",
     "effect": "4.0.0-beta.102",
     "tigerbeetle-node": "0.17.9"
   },

--- a/services/bayn/src/app-test-support.ts
+++ b/services/bayn/src/app-test-support.ts
@@ -58,6 +58,9 @@ export const historicalEvidence: StoredEvaluationEvidence = {
 export const config: RuntimeConfig = {
   host: '127.0.0.1',
   port: 0,
+  lifecycleOwner: 'Process',
+  lifecycleCommandPort: 8081,
+  lifecycleControllerKey: 'primary',
   execution: {
     brokerIdentity: undefined,
     brokerAccess: BrokerAccess.ReadOnly,

--- a/services/bayn/src/app.test.ts
+++ b/services/bayn/src/app.test.ts
@@ -116,6 +116,9 @@ const broker: BrokerProbe = {
 const autonomousConfig = (runtime: typeof config): AutonomousApplicationConfig => ({
   ...runtime,
   runtimeMode: 'AutonomousService',
+  lifecycleOwner: runtime.lifecycleOwner ?? 'Process',
+  lifecycleCommandPort: runtime.lifecycleCommandPort ?? 8081,
+  lifecycleControllerKey: runtime.lifecycleControllerKey ?? 'primary',
   cyclePollIntervalMs: 30_000,
   execution: {
     brokerIdentity: Result.getOrThrow(
@@ -155,6 +158,9 @@ const autonomousConfig = (runtime: typeof config): AutonomousApplicationConfig =
 const brokerlessConfig = (runtime: typeof config): BrokerlessApplicationConfig => ({
   ...runtime,
   runtimeMode: 'BrokerlessService',
+  lifecycleOwner: runtime.lifecycleOwner ?? 'Process',
+  lifecycleCommandPort: runtime.lifecycleCommandPort ?? 8081,
+  lifecycleControllerKey: runtime.lifecycleControllerKey ?? 'primary',
   cyclePollIntervalMs: 30_000,
   execution: {
     brokerIdentity: undefined,

--- a/services/bayn/src/app.ts
+++ b/services/bayn/src/app.ts
@@ -129,7 +129,7 @@ const cyclePassDependencyError = (
   observation: Extract<AutonomousCyclePassObservation, { readonly result: 'FAILURE' }>,
 ): string => `${observation.operation}/${observation.failure}: ${observation.message}`
 
-const recordAutonomousCyclePass = (
+export const recordAutonomousCyclePass = (
   state: Ref.Ref<RuntimeState>,
   observation: AutonomousCyclePassObservation,
 ): Effect.Effect<void> => Ref.update(state, (current) => applyAutonomousCyclePass(current, observation))
@@ -165,12 +165,16 @@ const brokerProbe = <StartupR, LoopR>(runtime: ApplicationRuntime<StartupR, Loop
 const qualificationEvidenceRequired = <StartupR, LoopR>(runtime: ApplicationRuntime<StartupR, LoopR>): boolean =>
   runtime._tag === 'Brokerless' || runtime.startupEvidenceMode !== 'Research'
 
-const initialRuntimeState = <StartupR, LoopR>(runtime: ApplicationRuntime<StartupR, LoopR>): RuntimeState =>
+const initialRuntimeState = <StartupR, LoopR>(
+  config: RuntimeConfig,
+  runtime: ApplicationRuntime<StartupR, LoopR>,
+): RuntimeState =>
   runtime._tag === 'Brokerless'
     ? initialState({})
     : initialState({
         broker: runtime._tag === 'AutonomousRead' ? (runtime.broker ?? runtime.brokerConfiguration) : runtime.broker,
         autonomousCycleLoopConfigured: true,
+        autonomousCycleLoopOwner: config.lifecycleOwner ?? 'Process',
       })
 
 const resolveRuntimeAfterStartup = <StartupR, LoopR>(
@@ -248,7 +252,7 @@ const runApplicationDataFirst = <StartupR, LoopR>(
   runtime: ApplicationRuntime<StartupR, LoopR>,
 ): Effect.Effect<never, OperationalError, HttpServer.HttpServer | StartupR | LoopR> =>
   Effect.gen(function* () {
-    const state = yield* Ref.make(initialRuntimeState(runtime))
+    const state = yield* Ref.make(initialRuntimeState(config, runtime))
     yield* serveHttp(config, state, strategy.provenance, config.build.verification, dependencies.evidenceStore.read)
     if (qualificationEvidenceRequired(runtime)) {
       yield* runStartup(config, state, strategy, dependencies)

--- a/services/bayn/src/blocked-generation-recovery.ts
+++ b/services/bayn/src/blocked-generation-recovery.ts
@@ -1,0 +1,129 @@
+import { Effect } from 'effect'
+
+import type { AuthorityGenerationStoreShape } from './db/execution-store'
+import { BlockedCycleIntentStoreError, type BlockedCycleIntentStoreShape } from './execution/intents'
+import { Authority, KillState } from './execution/contracts'
+import type { WriterFenceService } from './execution/writer-fence'
+import { OperationalError } from './errors'
+import { currentUtcInstant } from './time'
+
+export type BlockedGenerationRolloverReceipt =
+  | { readonly _tag: 'NotRequired' }
+  | {
+      readonly _tag: 'RolledOver'
+      readonly previousGenerationHash: string
+      readonly generationHash: string
+      readonly blockedCycleCount: number
+      readonly blockedIntentCount: number
+      readonly expiredIntentCount: number
+      readonly terminalIntentCount: number
+    }
+
+export interface BlockedGenerationRecoveryInput<R> {
+  readonly accountId: string
+  readonly observeGenerationHash: string
+  readonly blockedIntents: BlockedCycleIntentStoreShape
+  readonly authorityStore: AuthorityGenerationStoreShape
+  readonly writerFence: WriterFenceService
+  /** Must persist and validate a fresh exact, flat reconciliation after intent settlement. */
+  readonly reconcileAfterSettlement: Effect.Effect<void, OperationalError, R>
+}
+
+const recoveryError = (message: string, cause?: unknown): OperationalError =>
+  new OperationalError({
+    component: 'strategy',
+    operation: 'blocked-generation-recovery',
+    message,
+    retryable: false,
+    cause: cause === undefined ? { _tag: 'BlockedGenerationRecoveryRejected' } : cause,
+  })
+
+const settlementNeedsMutationRecovery = (error: OperationalError): boolean =>
+  error.operation === 'blocked-generation-recovery' &&
+  error.cause instanceof BlockedCycleIntentStoreError &&
+  error.cause.failure === 'invariant'
+
+/**
+ * A restricted PAPER generation may still own a nonterminal mutation when the process restarts. Advance the existing
+ * recovery-first driver before every settlement attempt; only the precise nonterminal-intent invariant waits and
+ * retries. Query, decode, reconciliation, and authority failures remain fatal.
+ */
+export const recoverRestrictedGenerationBeforeRollover = <A, E, R>(input: {
+  readonly advance: Effect.Effect<A, E, R>
+  readonly wait: (advance: A) => Effect.Effect<void, never, R>
+  readonly settle: Effect.Effect<BlockedGenerationRolloverReceipt, OperationalError, R>
+}): Effect.Effect<BlockedGenerationRolloverReceipt, E | OperationalError, R> => {
+  const recover = (): Effect.Effect<BlockedGenerationRolloverReceipt, E | OperationalError, R> =>
+    input.advance.pipe(
+      Effect.flatMap((advanced) =>
+        input.settle.pipe(
+          Effect.catchIf(settlementNeedsMutationRecovery, () => input.wait(advanced).pipe(Effect.andThen(recover()))),
+          Effect.flatMap((receipt) =>
+            receipt._tag === 'RolledOver'
+              ? Effect.succeed(receipt)
+              : Effect.fail(recoveryError('restricted generation recovery found no blocked generation to roll over')),
+          ),
+        ),
+      ),
+    )
+  return Effect.suspend(recover)
+}
+
+/**
+ * Settles the terminal generation first, then requires later exact reconciliation before clearing the kill in a new
+ * OBSERVE generation. The transaction boundary intentionally excludes reconciliation and authority rollover.
+ */
+export const recoverBlockedGenerationToObserve = <R>(
+  input: BlockedGenerationRecoveryInput<R>,
+): Effect.Effect<BlockedGenerationRolloverReceipt, OperationalError, R> =>
+  Effect.gen(function* () {
+    const observedAt = yield* currentUtcInstant
+    const settlement = yield* input.writerFence
+      .transaction(input.blockedIntents.settleCurrentBlockedGeneration({ accountId: input.accountId, observedAt }))
+      .pipe(Effect.mapError((cause) => recoveryError('blocked generation intent settlement failed', cause)))
+    if (settlement._tag === 'NoBlockedGeneration') return { _tag: 'NotRequired' }
+
+    yield* Effect.logWarning('Bayn settled a terminal blocked generation before authority rollover').pipe(
+      Effect.annotateLogs({
+        service: 'bayn',
+        previousGenerationHash: settlement.authorityGenerationHash,
+        blockedCycleCount: settlement.blockedCycleCount,
+        blockedIntentCount: settlement.blockedIntentCount,
+        expiredIntentCount: settlement.expiredIntentCount,
+        terminalIntentCount: settlement.terminalIntentCount,
+      }),
+    )
+
+    yield* input.reconcileAfterSettlement
+    const authority = yield* input.authorityStore
+      .ensureAuthorityGeneration({ generationHash: input.observeGenerationHash, maximum: Authority.Observe })
+      .pipe(Effect.mapError((cause) => recoveryError('blocked generation OBSERVE rollover failed', cause)))
+    if (
+      authority.generationHash !== input.observeGenerationHash ||
+      authority.maximum !== Authority.Observe ||
+      authority.effective !== Authority.Observe ||
+      authority.kill !== KillState.Clear
+    ) {
+      return yield* recoveryError('blocked generation rollover did not return clear OBSERVE authority')
+    }
+
+    yield* Effect.logInfo('Bayn completed blocked generation rollover to clear OBSERVE').pipe(
+      Effect.annotateLogs({
+        service: 'bayn',
+        previousGenerationHash: settlement.authorityGenerationHash,
+        generationHash: authority.generationHash,
+        authorityVersion: authority.version,
+        authorityEffective: authority.effective,
+        authorityKill: authority.kill,
+      }),
+    )
+    return {
+      _tag: 'RolledOver',
+      previousGenerationHash: settlement.authorityGenerationHash,
+      generationHash: authority.generationHash,
+      blockedCycleCount: settlement.blockedCycleCount,
+      blockedIntentCount: settlement.blockedIntentCount,
+      expiredIntentCount: settlement.expiredIntentCount,
+      terminalIntentCount: settlement.terminalIntentCount,
+    }
+  })

--- a/services/bayn/src/composition.test.ts
+++ b/services/bayn/src/composition.test.ts
@@ -4,6 +4,10 @@ import { Context, Deferred, Effect, Fiber, FileSystem, Layer, Logger, Redacted, 
 import { TestClock } from 'effect/testing'
 
 import { config, fixtureRuntime } from './app-test-support'
+import {
+  recoverBlockedGenerationToObserve,
+  recoverRestrictedGenerationBeforeRollover,
+} from './blocked-generation-recovery'
 import { provideTestLayer } from './effect-test-support'
 
 import {
@@ -38,7 +42,9 @@ import {
   makeResearchCapitalGrantGenerationResult,
   type AuthorityState,
 } from './execution/contracts'
+import { BlockedCycleIntentStoreError, type BlockedCycleIntentStoreShape } from './execution/intents'
 import type { WriterFenceService } from './execution/writer-fence'
+import { OperationalError } from './errors'
 import { utcInstantFromEpochMillis } from './time'
 import { paperEpisodeReceiptFinalizationExpiresAt } from './observe-composition'
 import { initialState } from './runtime-state'
@@ -188,6 +194,9 @@ const continuationApplicationPlan: ApplicationPlanFor<'AutonomousService'> = (()
     config: {
       ...config,
       runtimeMode: 'AutonomousService',
+      lifecycleOwner: config.lifecycleOwner ?? 'Process',
+      lifecycleCommandPort: config.lifecycleCommandPort ?? 8081,
+      lifecycleControllerKey: config.lifecycleControllerKey ?? 'primary',
       cyclePollIntervalMs: 30_000,
       execution: {
         brokerIdentity: continuationBrokerIdentity,
@@ -515,6 +524,165 @@ describe('Bayn PAPER startup recovery boundary', () => {
     )
 
     expect(operations).toEqual(['reconcile', 'activate'])
+  })
+
+  test('settles, freshly reconciles, and only then rolls a blocked generation to clear OBSERVE', async () => {
+    const operations: string[] = []
+    const sourceGenerationHash = hash('1')
+    const previousGenerationHash = hash('2')
+    const blockedIntents: BlockedCycleIntentStoreShape = {
+      terminalizeUntouchedApproved: () => Effect.die(new Error('cycle terminalization is outside startup recovery')),
+      settleCurrentBlockedGeneration: () =>
+        Effect.sync(() => {
+          operations.push('settle')
+          return {
+            _tag: 'BlockedGenerationSettled' as const,
+            authorityGenerationHash: previousGenerationHash,
+            blockedCycleCount: 1,
+            blockedIntentCount: 0,
+            expiredIntentCount: 1,
+            intentCount: 1,
+            terminalIntentCount: 1,
+          }
+        }),
+    }
+    const authorityStore: AuthorityGenerationStoreShape = {
+      ensureAuthorityGeneration: (input) =>
+        Effect.sync(() => {
+          operations.push('rollover')
+          return {
+            schemaVersion: 'bayn.paper-authority.v1' as const,
+            generationHash: input.generationHash,
+            maximum: Authority.Observe,
+            effective: Authority.Observe,
+            kill: KillState.Clear,
+            version: 3,
+            updatedAt: '2026-08-10T19:00:02.000Z',
+          }
+        }),
+    }
+    const writerFence: WriterFenceService = {
+      backendPid: 1,
+      check: Effect.void,
+      transaction: (effect) => Effect.sync(() => operations.push('fence')).pipe(Effect.andThen(effect)),
+    }
+
+    const receipt = await Effect.runPromise(
+      Effect.gen(function* () {
+        yield* TestClock.setTime(Date.parse('2026-08-10T19:00:00.000Z'))
+        return yield* recoverBlockedGenerationToObserve({
+          accountId: 'paper-account',
+          observeGenerationHash: sourceGenerationHash,
+          blockedIntents,
+          authorityStore,
+          writerFence,
+          reconcileAfterSettlement: Effect.sync(() => operations.push('reconcile')),
+        })
+      }).pipe(provideTestLayer(TestClock.layer())),
+    )
+
+    expect(operations).toEqual(['fence', 'settle', 'reconcile', 'rollover'])
+    expect(receipt).toEqual({
+      _tag: 'RolledOver',
+      previousGenerationHash,
+      generationHash: sourceGenerationHash,
+      blockedCycleCount: 1,
+      blockedIntentCount: 0,
+      expiredIntentCount: 1,
+      terminalIntentCount: 1,
+    })
+  })
+
+  test('does not reconcile or rotate when no blocked generation exists', async () => {
+    const blockedIntents: BlockedCycleIntentStoreShape = {
+      terminalizeUntouchedApproved: () => Effect.die(new Error('cycle terminalization is outside startup recovery')),
+      settleCurrentBlockedGeneration: () => Effect.succeed({ _tag: 'NoBlockedGeneration' }),
+    }
+    const authorityStore: AuthorityGenerationStoreShape = {
+      ensureAuthorityGeneration: () => Effect.die(new Error('no blocked generation must not rotate authority')),
+    }
+
+    const receipt = await Effect.runPromise(
+      recoverBlockedGenerationToObserve({
+        accountId: 'paper-account',
+        observeGenerationHash: hash('1'),
+        blockedIntents,
+        authorityStore,
+        writerFence: unusedWriterFence,
+        reconcileAfterSettlement: Effect.die(new Error('no blocked generation must not reconcile')),
+      }),
+    )
+
+    expect(receipt).toEqual({ _tag: 'NotRequired' })
+  })
+
+  test('recovers a nonterminal mutation before retrying blocked-generation settlement', async () => {
+    const operations: string[] = []
+    let attempt = 0
+    const receipt = await Effect.runPromise(
+      recoverRestrictedGenerationBeforeRollover({
+        advance: Effect.sync(() => {
+          attempt += 1
+          operations.push(`recover:${attempt.toString()}`)
+          return attempt
+        }),
+        wait: (advanced) => Effect.sync(() => operations.push(`wait:${advanced.toString()}`)),
+        settle: Effect.suspend(() => {
+          operations.push(`settle:${attempt.toString()}`)
+          return attempt === 1
+            ? Effect.fail(
+                new OperationalError({
+                  component: 'strategy',
+                  operation: 'blocked-generation-recovery',
+                  message: 'blocked generation intent settlement failed',
+                  retryable: false,
+                  cause: new BlockedCycleIntentStoreError({
+                    failure: 'invariant',
+                    message: 'intent still requires broker recovery',
+                  }),
+                }),
+              )
+            : Effect.succeed({
+                _tag: 'RolledOver' as const,
+                previousGenerationHash: hash('1'),
+                generationHash: hash('2'),
+                blockedCycleCount: 1,
+                blockedIntentCount: 1,
+                expiredIntentCount: 0,
+                terminalIntentCount: 1,
+              })
+        }),
+      }),
+    )
+
+    expect(operations).toEqual(['recover:1', 'settle:1', 'wait:1', 'recover:2', 'settle:2'])
+    expect(receipt).toEqual({
+      _tag: 'RolledOver',
+      previousGenerationHash: hash('1'),
+      generationHash: hash('2'),
+      blockedCycleCount: 1,
+      blockedIntentCount: 1,
+      expiredIntentCount: 0,
+      terminalIntentCount: 1,
+    })
+  })
+
+  test('fails closed when restricted recovery cannot identify a generation to roll over', async () => {
+    let advances = 0
+    const failure = await Effect.runPromise(
+      Effect.flip(
+        recoverRestrictedGenerationBeforeRollover({
+          advance: Effect.sync(() => {
+            advances += 1
+          }),
+          wait: () => Effect.die(new Error('a missing blocked generation is not retryable')),
+          settle: Effect.succeed({ _tag: 'NotRequired' }),
+        }),
+      ),
+    )
+
+    expect(advances).toBe(1)
+    expect(failure.message).toBe('restricted generation recovery found no blocked generation to roll over')
   })
 
   test('keeps activation disabled when the fresh reconciliation fails', async () => {

--- a/services/bayn/src/composition.ts
+++ b/services/bayn/src/composition.ts
@@ -20,6 +20,7 @@ import {
 
 import {
   makeApplicationPlan,
+  recordAutonomousCyclePass,
   runApplication,
   type ApplicationDependencies,
   type ApplicationIdentity,
@@ -29,6 +30,10 @@ import {
   type AutonomousRuntime,
   type AutonomousRuntimeResolver,
 } from './app'
+import {
+  recoverBlockedGenerationToObserve,
+  recoverRestrictedGenerationBeforeRollover,
+} from './blocked-generation-recovery'
 import { AlpacaBrokerResourcesLive } from './broker/alpaca/composition'
 import {
   BrokerRead,
@@ -43,6 +48,8 @@ import { BrokerEnvironment } from './broker/identity'
 import type { LoadedRuntimeConfig } from './config'
 import { CycleObservability, CycleObservabilityLive } from './db/cycle-observability'
 import { CycleStore, CycleStoreLive } from './db/cycle-store'
+import { LifecycleCommandStore } from './db/lifecycle-command'
+import { LifecycleCommandStoreLive } from './db/lifecycle-command-postgres'
 import {
   ForwardPerformanceReceiptStore,
   type ForwardPerformanceReceiptStoreShape,
@@ -89,7 +96,13 @@ import {
   type ResearchPaperActivationRequest,
   type ResearchPaperBuildContinuation,
 } from './execution/configuration'
-import { IntentStore, IntentStoreLive } from './execution/intents'
+import {
+  BlockedCycleIntentStore,
+  BlockedCycleIntentStoreLive,
+  IntentStore,
+  IntentStoreLive,
+  type BlockedCycleIntentStoreShape,
+} from './execution/intents'
 import { MutationStore, MutationStoreLive } from './execution/mutations'
 import { makeExecutionProgram, type ExecutionProgram } from './execution/runtime-program'
 import { resolvePreparedSandboxAuthority } from './execution/runtime-authority'
@@ -102,6 +115,7 @@ import { Journal, JournalLive } from './ledger'
 import { MarketData, MarketDataLive } from './market-data'
 import {
   decidePaperEpisodeAuthority,
+  paperEpisodeFailureRestrictionPrefix,
   paperGrantFromGeneration,
   paperGrantKey,
   validatePaperEpisodeCloseWindow,
@@ -112,8 +126,11 @@ import {
   makeObserveAutonomousCycleStartup,
   paperEpisodeCloseExpiresAt,
   paperEpisodeReceiptFinalizationExpiresAt,
+  type RecoveryFirstCycleDriverInterpreter,
 } from './observe-composition'
 import { restrictMutationAuthority } from './observe-composition/mutation-interpreter'
+import { acquireKubernetesLifecycleCommandAuthenticator } from './lifecycle-command-auth'
+import { serveLifecycleCommands } from './lifecycle-command-http'
 import { sqlResource } from './operations'
 import { runOnce, type ReconciliationPassError } from './reconciler'
 import {
@@ -209,11 +226,13 @@ export const AutonomousRuntimeResourcesLive = (plan: ApplicationPlanFor<'Autonom
   const writerFence = WriterFenceResourceLive.pipe(Layer.provide(postgres))
   const executionPersistence = Layer.mergeAll(
     ExecutionStoreResourceLive(plan.config),
+    BlockedCycleIntentStoreLive,
     IntentStoreLive,
     MutationStoreLive,
     LiveCapitalGrantStoreLive,
     PaperCycleClosureStorePostgresLive,
     ForwardPerformanceReceiptStoreLive,
+    LifecycleCommandStoreLive,
   ).pipe(Layer.provideMerge(writerFence), Layer.provideMerge(postgres), Layer.provideMerge(journal))
   return Layer.mergeAll(
     BrokerSessionResourceLive(plan.config),
@@ -282,24 +301,63 @@ const runtimeBroker = (
   executionDisabledReason: mutationEnabled ? null : ('BROKER_ACCESS_READ_ONLY' as const),
 })
 
-const observeCycle = (plan: ApplicationPlanFor<'AutonomousService'>) =>
-  makeObserveAutonomousCycleStartup({
+const lifecycleDriverInterpreter = (
+  plan: ApplicationPlanFor<'AutonomousService'>,
+  store: import('./db/lifecycle-command').LifecycleCommandStoreShape,
+  writerFence: WriterFenceService,
+) =>
+  plan.config.lifecycleOwner === 'Restate'
+    ? (((driver) =>
+        Effect.gen(function* () {
+          const authenticate = yield* acquireKubernetesLifecycleCommandAuthenticator()
+          return yield* serveLifecycleCommands(
+            {
+              host: plan.config.host,
+              port: plan.config.lifecycleCommandPort,
+              controllerKey: plan.config.lifecycleControllerKey,
+              sourceRevision: plan.config.build.sourceRevision,
+              previousSourceRevision: plan.config.lifecyclePreviousSourceRevision,
+              nextDelayMs: driver.nextDelayMs,
+            },
+            store,
+            writerFence,
+            authenticate,
+            driver.advance,
+          )
+        }).pipe(Effect.scoped, Effect.orDie)) satisfies RecoveryFirstCycleDriverInterpreter)
+    : undefined
+
+const observeCycle = (
+  plan: ApplicationPlanFor<'AutonomousService'>,
+  lifecycleCommandStore: import('./db/lifecycle-command').LifecycleCommandStoreShape,
+  writerFence: WriterFenceService,
+) => {
+  const interpretCycleDriver = lifecycleDriverInterpreter(plan, lifecycleCommandStore, writerFence)
+  return makeObserveAutonomousCycleStartup({
     accountId: plan.config.alpaca.expectedAccountId,
     authorityGenerationHash: plan.config.alpaca.authorityGenerationHash,
     pollIntervalMs: plan.config.cyclePollIntervalMs,
     reconciliationIntervalMs: plan.config.alpaca.reconciliationIntervalMs,
     reconciliationPassTimeoutMs: plan.config.operationTimeoutMs,
     strategy: plan.strategy,
+    ...(interpretCycleDriver === undefined ? {} : { interpretCycleDriver }),
   })
+}
 
 const mutationCycle = (
   plan: ApplicationPlanFor<'AutonomousService'>,
   executionProgram: ExecutionProgram,
   paperEpisode: PaperActivationRequest,
   paperCycleClosureStore: PaperCycleClosureStoreShape,
+  blockedCycleIntentStore: BlockedCycleIntentStoreShape,
+  lifecycleCommandStore: import('./db/lifecycle-command').LifecycleCommandStoreShape,
+  writerFence: WriterFenceService,
   onClosedCycle: (cycleId: string, observedAt: string) => Effect.Effect<void>,
-) =>
-  makeMutationAutonomousCycleStartup({
+  interpretCycleDriverOverride?: RecoveryFirstCycleDriverInterpreter,
+) => {
+  const interpretCycleDriver =
+    interpretCycleDriverOverride ?? lifecycleDriverInterpreter(plan, lifecycleCommandStore, writerFence)
+  return makeMutationAutonomousCycleStartup({
     accountId: plan.config.alpaca.expectedAccountId,
     authorityGenerationHash:
       plan.config.execution.capitalAuthority._tag === CapitalAuthorityKind.Sandbox
@@ -312,11 +370,14 @@ const mutationCycle = (
     ...(isResearchPaperActivationRequest(paperEpisode) ? { cycleCadence: 'PAPER_BOOTSTRAP' as const } : {}),
     executionProgram,
     paperCycleClosureStore,
+    blockedCycleIntentStore,
     onClosedCycle,
     paperEpisodeCutoffAt: paperEpisode.cutoffAt,
     paperEpisodeCloseSubmitCutoffAt: paperEpisode.expiresAt,
     paperEpisodeExpiresAt: paperEpisodeCloseExpiresAt(paperEpisode.expiresAt),
+    ...(interpretCycleDriver === undefined ? {} : { interpretCycleDriver }),
   })
+}
 
 const executionProgramError = (
   cause: BrokerMutationError | Schema.SchemaError | Result.Result.Failure<ReturnType<typeof makeExecutionProgram>>,
@@ -1351,6 +1412,8 @@ const runAutonomousService = (plan: ApplicationPlanFor<'AutonomousService'>) =>
                       alpacaHttpClient: AlpacaHttpClient,
                       liveCapitalGrants: LiveCapitalGrantStore,
                       intentStore: IntentStore,
+                      blockedCycleIntentStore: BlockedCycleIntentStore,
+                      lifecycleCommandStore: LifecycleCommandStore,
                       mutationStore: MutationStore,
                       writerFence: WriterFence,
                       cycleStore: CycleStore,
@@ -1381,7 +1444,11 @@ const runAutonomousService = (plan: ApplicationPlanFor<'AutonomousService'>) =>
                           Layer.succeed(PaperCycleClosureStore, runtimeServices.paperCycleClosureStore),
                         )
                         const readStartCycle = (startup: AutonomousCycleStartupInput) =>
-                          observeCycle(observePlan)(startup).pipe(
+                          observeCycle(
+                            observePlan,
+                            runtimeServices.lifecycleCommandStore,
+                            runtimeServices.writerFence,
+                          )(startup).pipe(
                             // @effect-diagnostics-next-line strictEffectProvide:off -- value-only cycle services have no resource lifetime
                             Effect.provide(cycleResources),
                             Effect.map((loop) =>
@@ -1403,10 +1470,25 @@ const runAutonomousService = (plan: ApplicationPlanFor<'AutonomousService'>) =>
                             : {}),
                           startCycle: readStartCycle,
                         })
-                        if (request === null) return Effect.succeed(readRuntime())
+                        const recoverBlockedGeneration = recoverBlockedGenerationToObserve({
+                          accountId: observePlan.config.alpaca.expectedAccountId,
+                          observeGenerationHash: observePlan.config.alpaca.authorityGenerationHash,
+                          blockedIntents: runtimeServices.blockedCycleIntentStore,
+                          authorityStore: runtimeServices.authorityGenerationStore,
+                          writerFence: runtimeServices.writerFence,
+                          reconcileAfterSettlement: refreshResearchPaperActivationReconciliation(
+                            runOnce.pipe(
+                              // @effect-diagnostics-next-line strictEffectProvide:off -- value-only cycle services have no resource lifetime
+                              Effect.provide(cycleResources),
+                            ),
+                            observePlan.config.operationTimeoutMs,
+                          ),
+                        })
+                        if (request === null) return recoverBlockedGeneration.pipe(Effect.as(readRuntime()))
                         const evidence = validated.success.evidence
                         if (evidence === null && !isResearchPaperActivationRequest(request)) {
-                          return pendingPaperActivation(state, request, 'STARTUP_EVIDENCE_UNAVAILABLE').pipe(
+                          return recoverBlockedGeneration.pipe(
+                            Effect.andThen(pendingPaperActivation(state, request, 'STARTUP_EVIDENCE_UNAVAILABLE')),
                             Effect.as(readRuntime()),
                           )
                         }
@@ -1464,67 +1546,88 @@ const runAutonomousService = (plan: ApplicationPlanFor<'AutonomousService'>) =>
                                           ),
                             ),
                           )
-                        return prepareOrRecover.pipe(
-                          Effect.flatMap(
-                            (
-                              prepared,
-                            ): Effect.Effect<AutonomousRuntime<never, never>, OperationalError, Scope.Scope> => {
-                              if (prepared._tag === 'ReceiptFinalization') {
-                                const emitClosedCycleReceipt = makeClosedCycleReceiptEmitter(
-                                  observePlan.config,
-                                  runtimeServices.pgClient,
-                                  prepared.generation.generationHash,
-                                  runtimeServices.forwardPerformanceReceiptStore,
-                                )
-                                const finalizeClosedCycleReceipt = (cycleId: string | undefined, observedAt: string) =>
-                                  finalizePaperEpisode(
-                                    state,
-                                    request,
-                                    prepared.generation.generationHash,
-                                    runtimeServices.authorityRestrictionStore,
-                                    runtimeServices.writerFence,
-                                    emitClosedCycleReceipt,
-                                    cycleId,
-                                    observedAt,
-                                  )
-                                return Effect.gen(function* () {
-                                  yield* pendingPaperActivation(state, request, 'REQUEST_EXPIRED')
-                                  const observedAt = yield* currentUtcInstant
-                                  if (!paperReceiptFinalizationWindowOpen(request.expiresAt, observedAt)) {
-                                    const existing = yield* runtimeServices.forwardPerformanceReceiptStore
-                                      .read(prepared.generation.generationHash)
-                                      .pipe(
-                                        Effect.mapError((cause) =>
-                                          paperActivationOperationalError(
-                                            'durable PAPER receipt recovery read failed',
-                                            cause,
-                                          ),
-                                        ),
-                                      )
-                                    if (Option.isSome(existing)) {
-                                      yield* finalizePaperEpisode(
-                                        state,
-                                        request,
-                                        prepared.generation.generationHash,
-                                        runtimeServices.authorityRestrictionStore,
-                                        runtimeServices.writerFence,
-                                        () => Effect.succeed(existing.value.receiptHash),
-                                        existing.value.cycleId,
-                                        observedAt,
-                                      )
-                                    }
-                                    return readRuntime()
-                                  }
-                                  yield* Effect.forkScoped(
-                                    retryClosedCycleReceipts(
-                                      finalizeClosedCycleReceipt,
-                                      request.cutoffAt,
-                                      paperEpisodeReceiptFinalizationExpiresAt(request.expiresAt),
-                                      observePlan.config.alpaca.reconciliationIntervalMs,
+                        const resolveReceiptFinalization = (
+                          prepared: Extract<PaperActivationStartupResolution, { readonly _tag: 'ReceiptFinalization' }>,
+                        ): Effect.Effect<AutonomousRuntime<never, never>, OperationalError, Scope.Scope> => {
+                          const emitClosedCycleReceipt = makeClosedCycleReceiptEmitter(
+                            observePlan.config,
+                            runtimeServices.pgClient,
+                            prepared.generation.generationHash,
+                            runtimeServices.forwardPerformanceReceiptStore,
+                          )
+                          const finalizeClosedCycleReceipt = (cycleId: string | undefined, observedAt: string) =>
+                            finalizePaperEpisode(
+                              state,
+                              request,
+                              prepared.generation.generationHash,
+                              runtimeServices.authorityRestrictionStore,
+                              runtimeServices.writerFence,
+                              emitClosedCycleReceipt,
+                              cycleId,
+                              observedAt,
+                            )
+                          return Effect.gen(function* () {
+                            yield* pendingPaperActivation(state, request, 'REQUEST_EXPIRED')
+                            const observedAt = yield* currentUtcInstant
+                            if (!paperReceiptFinalizationWindowOpen(request.expiresAt, observedAt)) {
+                              const existing = yield* runtimeServices.forwardPerformanceReceiptStore
+                                .read(prepared.generation.generationHash)
+                                .pipe(
+                                  Effect.mapError((cause) =>
+                                    paperActivationOperationalError(
+                                      'durable PAPER receipt recovery read failed',
+                                      cause,
                                     ),
-                                  )
-                                  return readRuntime()
-                                })
+                                  ),
+                                )
+                              if (Option.isSome(existing)) {
+                                yield* finalizePaperEpisode(
+                                  state,
+                                  request,
+                                  prepared.generation.generationHash,
+                                  runtimeServices.authorityRestrictionStore,
+                                  runtimeServices.writerFence,
+                                  () => Effect.succeed(existing.value.receiptHash),
+                                  existing.value.cycleId,
+                                  observedAt,
+                                )
+                              }
+                              return readRuntime()
+                            }
+                            yield* Effect.forkScoped(
+                              retryClosedCycleReceipts(
+                                finalizeClosedCycleReceipt,
+                                request.cutoffAt,
+                                paperEpisodeReceiptFinalizationExpiresAt(request.expiresAt),
+                                observePlan.config.alpaca.reconciliationIntervalMs,
+                              ),
+                            )
+                            return readRuntime()
+                          })
+                        }
+                        const resolvePrepared = (
+                          prepared: PaperActivationStartupResolution,
+                        ): Effect.Effect<AutonomousRuntime<never, never>, OperationalError, Scope.Scope> => {
+                          if (runtimeServices.authorityGenerationStore.readAuthorityState === undefined) {
+                            return Effect.fail(
+                              paperActivationOperationalError(
+                                'PAPER startup recovery requires durable authority state reads',
+                              ),
+                            )
+                          }
+                          return runtimeServices.authorityGenerationStore.readAuthorityState.pipe(
+                            Effect.mapError((cause) =>
+                              paperActivationOperationalError('PAPER startup recovery authority read failed', cause),
+                            ),
+                            Effect.flatMap((authorityState) => {
+                              const restricted =
+                                authorityState.generationHash === prepared.generation.generationHash &&
+                                authorityState.maximum === Authority.Paper &&
+                                authorityState.effective === Authority.Observe &&
+                                authorityState.kill === KillState.Active &&
+                                authorityState.reason?.startsWith(paperEpisodeFailureRestrictionPrefix) === true
+                              if (prepared._tag === 'ReceiptFinalization' && !restricted) {
+                                return resolveReceiptFinalization(prepared)
                               }
                               if (observePlan.config.alpaca.identity.environment !== BrokerEnvironment.Sandbox) {
                                 return Effect.fail(
@@ -1642,49 +1745,21 @@ const runAutonomousService = (plan: ApplicationPlanFor<'AutonomousService'>) =>
                                       ),
                                     ),
                                     Effect.mapError(executionProgramError),
-                                    Effect.tap(() =>
-                                      realizedPaperActivation(
-                                        state,
-                                        request,
-                                        prepared.generation.generationHash,
-                                        paperGrant._tag,
-                                      ),
-                                    ),
-                                    Effect.tap(() =>
-                                      Effect.forkScoped(
-                                        retryClosedCycleReceipts(
-                                          finalizeClosedCycleReceipt,
-                                          request.cutoffAt,
-                                          paperEpisodeReceiptFinalizationExpiresAt(request.expiresAt),
-                                          realizedPlan.config.alpaca.reconciliationIntervalMs,
-                                        ),
-                                      ).pipe(Effect.asVoid),
-                                    ),
-                                    Effect.tap(() =>
-                                      Effect.forkScoped(
-                                        restrictPaperAtExpiry(
-                                          paperEpisodeCloseExpiresAt(request.expiresAt),
-                                          runtimeServices.authorityRestrictionStore,
-                                          runtimeServices.writerFence,
-                                        ),
-                                      ).pipe(Effect.asVoid),
-                                    ),
-                                    Effect.map((executionProgram) => ({
-                                      _tag: 'AutonomousMutation' as const,
-                                      startupEvidenceMode: isResearchPaperActivationRequest(request)
-                                        ? ('Research' as const)
-                                        : ('Qualification' as const),
-                                      broker: runtimeBroker(realizedPlan, runtimeServices.session.read, true),
-                                      cycleBindingId,
-                                      cycleObservationId: cycleBindingId,
-                                      executionProgram,
-                                      startCycle: (startup: AutonomousCycleStartupInput) =>
+                                    Effect.flatMap((executionProgram) => {
+                                      const startCycle = (
+                                        startup: AutonomousCycleStartupInput,
+                                        interpretCycleDriver?: RecoveryFirstCycleDriverInterpreter,
+                                      ) =>
                                         mutationCycle(
                                           realizedPlan,
                                           executionProgram,
                                           request,
                                           runtimeServices.paperCycleClosureStore,
+                                          runtimeServices.blockedCycleIntentStore,
+                                          runtimeServices.lifecycleCommandStore,
+                                          runtimeServices.writerFence,
                                           onClosedCycle,
+                                          interpretCycleDriver,
                                         )(startup).pipe(
                                           // @effect-diagnostics-next-line strictEffectProvide:off -- value-only cycle services have no resource lifetime
                                           Effect.provide(cycleResources),
@@ -1694,13 +1769,76 @@ const runAutonomousService = (plan: ApplicationPlanFor<'AutonomousService'>) =>
                                               Effect.provide(cycleResources),
                                             ),
                                           ),
+                                        )
+                                      const runtime = {
+                                        _tag: 'AutonomousMutation' as const,
+                                        startupEvidenceMode: isResearchPaperActivationRequest(request)
+                                          ? ('Research' as const)
+                                          : ('Qualification' as const),
+                                        broker: runtimeBroker(realizedPlan, runtimeServices.session.read, true),
+                                        cycleBindingId,
+                                        cycleObservationId: cycleBindingId,
+                                        executionProgram,
+                                        startCycle,
+                                      }
+                                      const activate = realizedPaperActivation(
+                                        state,
+                                        request,
+                                        prepared.generation.generationHash,
+                                        paperGrant._tag,
+                                      ).pipe(
+                                        Effect.andThen(
+                                          Effect.forkScoped(
+                                            retryClosedCycleReceipts(
+                                              finalizeClosedCycleReceipt,
+                                              request.cutoffAt,
+                                              paperEpisodeReceiptFinalizationExpiresAt(request.expiresAt),
+                                              realizedPlan.config.alpaca.reconciliationIntervalMs,
+                                            ),
+                                          ),
                                         ),
-                                    })),
+                                        Effect.andThen(
+                                          Effect.forkScoped(
+                                            restrictPaperAtExpiry(
+                                              paperEpisodeCloseExpiresAt(request.expiresAt),
+                                              runtimeServices.authorityRestrictionStore,
+                                              runtimeServices.writerFence,
+                                            ),
+                                          ),
+                                        ),
+                                        Effect.as(runtime),
+                                      )
+                                      if (!restricted) return activate
+
+                                      const recover: RecoveryFirstCycleDriverInterpreter = (driver) =>
+                                        recoverRestrictedGenerationBeforeRollover({
+                                          advance: driver.advance,
+                                          wait: driver.wait,
+                                          settle: recoverBlockedGeneration,
+                                        }).pipe(
+                                          Effect.asVoid,
+                                          Effect.catch((cause) => Effect.die(cause)),
+                                        )
+                                      return startCycle(
+                                        {
+                                          qualificationRunId: cycleBindingId,
+                                          recordPass: (observation) => recordAutonomousCyclePass(state, observation),
+                                        },
+                                        recover,
+                                      ).pipe(
+                                        Effect.flatMap((loop) => loop),
+                                        Effect.andThen(prepareOrRecover),
+                                        Effect.flatMap(resolvePrepared),
+                                      )
+                                    }),
                                   )
                                 }),
                               )
-                            },
-                          ),
+                            }),
+                          )
+                        }
+                        return prepareOrRecover.pipe(
+                          Effect.flatMap(resolvePrepared),
                           Effect.catch((cause) =>
                             Effect.logWarning('Bayn PAPER activation remains in OBSERVE').pipe(
                               Effect.annotateLogs({

--- a/services/bayn/src/config.test.ts
+++ b/services/bayn/src/config.test.ts
@@ -85,6 +85,10 @@ const baseParsedConfig: ParsedRuntimeConfig = {
   provenanceMode: 'production',
   healthIntervalMs: 30_000,
   operationTimeoutMs: 30_000,
+  lifecycleOwner: 'Process',
+  lifecycleCommandPort: 8081,
+  lifecycleControllerKey: 'primary',
+  lifecyclePreviousSourceRevision: undefined,
   cycleStallThresholdMs: 300_000,
   reconciliationStaleThresholdMs: 120_000,
   unknownMutationThresholdMs: 300_000,
@@ -574,6 +578,18 @@ describe('pure runtime configuration resolution', () => {
       },
     )
     expectFailure(
+      {
+        lifecycleOwner: 'Restate',
+        lifecycleCommandPort: 8080,
+        configuredAlpaca: alpaca(BrokerEnvironment.Sandbox),
+      },
+      { _tag: 'LifecycleCommandPortConflict', httpPort: 8080, lifecycleCommandPort: 8080 },
+    )
+    expectFailure(
+      { lifecycleOwner: 'Restate', authorityGenerationHash: undefined },
+      { _tag: 'RestateLifecycleRequiresAutonomousService' },
+    )
+    expectFailure(
       { postgres: { ...baseParsedConfig.postgres, tls: false } },
       { _tag: 'ProductionPostgresRequiresTls', postgresTls: false },
     )
@@ -664,6 +680,25 @@ describe('runtime configuration loading', () => {
         _tag: 'InvalidExecutionPolicy',
         cause: { _tag: 'SandboxBrokerRequiresSandboxCapital' },
       },
+    })
+  })
+
+  test('loads one Restate owner and one bounded prior rollout source for the autonomous service', async () => {
+    const environment = new Map(runtimeEnvironment)
+    environment.delete('BAYN_OPERATION')
+    environment.set('BAYN_LIFECYCLE_OWNER', 'RESTATE')
+    environment.set('BAYN_LIFECYCLE_COMMAND_PORT', '8081')
+    environment.set('BAYN_LIFECYCLE_CONTROLLER_KEY', 'primary')
+    environment.set('BAYN_LIFECYCLE_PREVIOUS_SOURCE_REVISION', 'e'.repeat(40))
+
+    const config = await Effect.runPromise(provideEnvironment(loadConfig(buildMetadata), environment))
+
+    expect(config).toMatchObject({
+      runtimeMode: 'AutonomousService',
+      lifecycleOwner: 'Restate',
+      lifecycleCommandPort: 8081,
+      lifecycleControllerKey: 'primary',
+      lifecyclePreviousSourceRevision: 'e'.repeat(40),
     })
   })
 

--- a/services/bayn/src/config/load.ts
+++ b/services/bayn/src/config/load.ts
@@ -22,6 +22,16 @@ const presentRuntimeConfigFailure = (failure: RuntimeConfigResolutionFailure): R
         operation: 'cycle-loop',
         message: 'cycle poll interval must be shorter than the cycle stall threshold',
       }
+    case 'LifecycleCommandPortConflict':
+      return {
+        operation: 'lifecycle-command',
+        message: 'Restate lifecycle command port must differ from the public Bayn HTTP port',
+      }
+    case 'RestateLifecycleRequiresAutonomousService':
+      return {
+        operation: 'lifecycle-command',
+        message: 'Restate lifecycle ownership requires an autonomous broker-bound Bayn service',
+      }
     case 'PaperReconciliationCadenceNotWithinStaleThreshold':
       return {
         operation: 'cycle-loop',

--- a/services/bayn/src/config/model.ts
+++ b/services/bayn/src/config/model.ts
@@ -12,6 +12,9 @@ import type {
 } from '../execution/configuration'
 import type { ExecutionPrepareRequest } from '../execution-prepare/model'
 
+export const minimumOperationalThresholdMs = 1_000
+export const maximumOperationalThresholdMs = 86_400_000
+
 export interface RuntimeBuildMetadata extends EmbeddedBuildMetadata {
   readonly imageDigest: string
   readonly verification: 'embedded' | 'development-configured'
@@ -26,6 +29,10 @@ export interface RuntimeConfig {
   readonly build: RuntimeBuildMetadata
   readonly healthIntervalMs: number
   readonly operationTimeoutMs: number
+  readonly lifecycleOwner?: 'Process' | 'Restate'
+  readonly lifecycleCommandPort?: number
+  readonly lifecycleControllerKey?: string
+  readonly lifecyclePreviousSourceRevision?: string | undefined
   readonly cycleStallThresholdMs: number
   readonly reconciliationStaleThresholdMs: number
   readonly unknownMutationThresholdMs: number
@@ -64,7 +71,21 @@ export type RuntimeOperation = 'ExecutionCandidateDiscovery' | 'ExecutionPrepare
 
 export type AlpacaRuntimeConfig = NonNullable<RuntimeConfig['alpaca']>
 
-type LoadedRuntimeConfigBase = Omit<RuntimeConfig, 'alpaca' | 'qualificationRunId'> & AutonomousCycleRuntimeConfig
+type LoadedRuntimeConfigBase = Omit<
+  RuntimeConfig,
+  | 'alpaca'
+  | 'qualificationRunId'
+  | 'lifecycleOwner'
+  | 'lifecycleCommandPort'
+  | 'lifecycleControllerKey'
+  | 'lifecyclePreviousSourceRevision'
+> &
+  AutonomousCycleRuntimeConfig & {
+    readonly lifecycleOwner: 'Process' | 'Restate'
+    readonly lifecycleCommandPort: number
+    readonly lifecycleControllerKey: string
+    readonly lifecyclePreviousSourceRevision?: string | undefined
+  }
 
 export type LoadedRuntimeConfig = LoadedRuntimeConfigBase &
   (
@@ -120,6 +141,10 @@ export interface ParsedRuntimeConfig {
   readonly provenanceMode: 'production' | 'development'
   readonly healthIntervalMs: number
   readonly operationTimeoutMs: number
+  readonly lifecycleOwner: 'Process' | 'Restate'
+  readonly lifecycleCommandPort: number
+  readonly lifecycleControllerKey: string
+  readonly lifecyclePreviousSourceRevision: string | undefined
   readonly cycleStallThresholdMs: number
   readonly reconciliationStaleThresholdMs: number
   readonly unknownMutationThresholdMs: number
@@ -161,6 +186,14 @@ export type RuntimeConfigResolutionFailure =
       readonly _tag: 'CyclePollIntervalNotShorterThanStallThreshold'
       readonly cyclePollIntervalMs: number
       readonly cycleStallThresholdMs: number
+    }
+  | {
+      readonly _tag: 'LifecycleCommandPortConflict'
+      readonly httpPort: number
+      readonly lifecycleCommandPort: number
+    }
+  | {
+      readonly _tag: 'RestateLifecycleRequiresAutonomousService'
     }
   | {
       readonly _tag: 'PaperReconciliationCadenceNotWithinStaleThreshold'

--- a/services/bayn/src/config/resolution.ts
+++ b/services/bayn/src/config/resolution.ts
@@ -46,6 +46,25 @@ const validateCycleTiming = (
         cycleStallThresholdMs: parsed.cycleStallThresholdMs,
       })
 
+const validateLifecyclePorts = (
+  parsed: ParsedRuntimeConfig,
+): Result.Result<ParsedRuntimeConfig, RuntimeConfigResolutionFailure> =>
+  parsed.lifecycleOwner === 'Process' || parsed.port !== parsed.lifecycleCommandPort
+    ? Result.succeed(parsed)
+    : fail({
+        _tag: 'LifecycleCommandPortConflict',
+        httpPort: parsed.port,
+        lifecycleCommandPort: parsed.lifecycleCommandPort,
+      })
+
+const validateLifecycleMode = (
+  parsed: ParsedRuntimeConfig,
+  alpaca: AlpacaRuntimeConfig | undefined,
+): Result.Result<void, RuntimeConfigResolutionFailure> =>
+  parsed.lifecycleOwner === 'Process' || (alpaca !== undefined && parsed.configuredOperation === undefined)
+    ? Result.succeed(undefined)
+    : fail({ _tag: 'RestateLifecycleRequiresAutonomousService' })
+
 const validatePaperReconciliationTiming = (
   parsed: ParsedRuntimeConfig,
   execution: ExecutionPolicy,
@@ -265,6 +284,10 @@ const baseConfig = (
   build,
   healthIntervalMs: parsed.healthIntervalMs,
   operationTimeoutMs: parsed.operationTimeoutMs,
+  lifecycleOwner: parsed.lifecycleOwner,
+  lifecycleCommandPort: parsed.lifecycleCommandPort,
+  lifecycleControllerKey: parsed.lifecycleControllerKey,
+  lifecyclePreviousSourceRevision: parsed.lifecyclePreviousSourceRevision,
   cycleStallThresholdMs: parsed.cycleStallThresholdMs,
   reconciliationStaleThresholdMs: parsed.reconciliationStaleThresholdMs,
   unknownMutationThresholdMs: parsed.unknownMutationThresholdMs,
@@ -352,8 +375,12 @@ export const resolveRuntimeConfig = (
   const parsed = bounds.success
   const timing = validateCycleTiming(parsed)
   if (Result.isFailure(timing)) return Result.fail(timing.failure)
+  const lifecyclePorts = validateLifecyclePorts(parsed)
+  if (Result.isFailure(lifecyclePorts)) return Result.fail(lifecyclePorts.failure)
   const alpaca = decodeAlpaca(parsed)
   if (Result.isFailure(alpaca)) return Result.fail(alpaca.failure)
+  const lifecycleMode = validateLifecycleMode(parsed, alpaca.success)
+  if (Result.isFailure(lifecycleMode)) return Result.fail(lifecycleMode.failure)
   const execution = resolvePolicy(parsed, alpaca.success)
   if (Result.isFailure(execution)) return Result.fail(execution.failure)
   const reconciliationTiming = validatePaperReconciliationTiming(parsed, execution.success, alpaca.success)

--- a/services/bayn/src/config/source.ts
+++ b/services/bayn/src/config/source.ts
@@ -6,6 +6,7 @@ import { EvaluationBoundsSchema, IsoDateSchema, Sha256Schema } from '../contract
 import { BrokerAccess, BrokerAccessSchema } from '../execution/authority'
 import { CapitalAuthoritySelection } from '../execution/configuration'
 import { ExecutionPrepareRequestSchema } from '../execution-prepare/model'
+import { LifecycleControllerKeySchema } from '../lifecycle-command-contract'
 import {
   GitSourceRevisionSchema as SourceRevision,
   ImageDigestSchema as ImageDigest,
@@ -13,12 +14,19 @@ import {
   PositiveIntegerSchema as PositiveInteger,
   TrimmedNonEmptyStringSchema as NonEmptyString,
 } from '../schemas'
-import type { ParsedRuntimeConfig, RuntimeOperation } from './model'
+import {
+  maximumOperationalThresholdMs,
+  minimumOperationalThresholdMs,
+  type ParsedRuntimeConfig,
+  type RuntimeOperation,
+} from './model'
 import { Pipeable } from '../pipeable'
 
 const ProvenanceMode = Schema.Literals(['production', 'development'])
 const RetryAttempts = Schema.Int.check(Schema.isBetween({ minimum: 0, maximum: 3 }))
-const OperationalThresholdMs = Schema.Int.check(Schema.isBetween({ minimum: 1_000, maximum: 86_400_000 }))
+const OperationalThresholdMs = Schema.Int.check(
+  Schema.isBetween({ minimum: minimumOperationalThresholdMs, maximum: maximumOperationalThresholdMs }),
+)
 const LegacyAuthorityTokenSchema = Schema.Literals(['OBSERVE', 'PAPER'])
 const RuntimeOperationTokenSchema = Schema.Literals([
   'EXECUTION_CANDIDATE_DISCOVERY',
@@ -26,6 +34,7 @@ const RuntimeOperationTokenSchema = Schema.Literals([
   'EXECUTION_PREPARE',
 ])
 const CapitalAuthoritySelectionSchema = Schema.Enum(CapitalAuthoritySelection)
+const LifecycleOwnerSchema = Schema.Literals(['PROCESS', 'RESTATE'])
 
 const ReplicaAddresses = Schema.Trim.pipe(
   Schema.decodeTo(
@@ -78,6 +87,14 @@ export const runtimeConfigSource = Config.all({
   liveCapitalGrantHash: Config.option(Config.schema(Sha256Schema, 'BAYN_LIVE_CAPITAL_GRANT_HASH')),
   healthIntervalMs: positiveInteger('BAYN_HEALTH_INTERVAL_MS', 30_000),
   operationTimeoutMs: positiveInteger('BAYN_OPERATION_TIMEOUT_MS', 30_000),
+  lifecycleOwner: Config.schema(LifecycleOwnerSchema, 'BAYN_LIFECYCLE_OWNER').pipe(Config.withDefault('PROCESS')),
+  lifecycleCommandPort: Config.port('BAYN_LIFECYCLE_COMMAND_PORT').pipe(Config.withDefault(8081)),
+  lifecycleControllerKey: Config.schema(LifecycleControllerKeySchema, 'BAYN_LIFECYCLE_CONTROLLER_KEY').pipe(
+    Config.withDefault('primary'),
+  ),
+  lifecyclePreviousSourceRevision: Config.option(
+    Config.schema(SourceRevision, 'BAYN_LIFECYCLE_PREVIOUS_SOURCE_REVISION'),
+  ),
   cycleStallThresholdMs: operationalThreshold('BAYN_CYCLE_STALL_THRESHOLD_MS', 300_000),
   reconciliationStaleThresholdMs: operationalThreshold('BAYN_RECONCILIATION_STALE_THRESHOLD_MS', 120_000),
   unknownMutationThresholdMs: operationalThreshold('BAYN_UNKNOWN_MUTATION_THRESHOLD_MS', 300_000),
@@ -140,6 +157,10 @@ export const runtimeConfigSource = Config.all({
       provenanceMode: config.provenanceMode,
       healthIntervalMs: config.healthIntervalMs,
       operationTimeoutMs: config.operationTimeoutMs,
+      lifecycleOwner: config.lifecycleOwner === 'RESTATE' ? 'Restate' : 'Process',
+      lifecycleCommandPort: config.lifecycleCommandPort,
+      lifecycleControllerKey: config.lifecycleControllerKey,
+      lifecyclePreviousSourceRevision: Option.getOrUndefined(config.lifecyclePreviousSourceRevision),
       cycleStallThresholdMs: config.cycleStallThresholdMs,
       reconciliationStaleThresholdMs: config.reconciliationStaleThresholdMs,
       unknownMutationThresholdMs: config.unknownMutationThresholdMs,

--- a/services/bayn/src/db/cycle-store/integration.test.ts
+++ b/services/bayn/src/db/cycle-store/integration.test.ts
@@ -50,8 +50,12 @@ import {
 } from '../../cycle-runner'
 import { runAutonomousCycleUntilSettled } from '../../cycle-runner/program'
 import { AuthorityGenerationStore, ExecutionStoreLive } from '../execution-store'
-import { WriterFenceLive } from '../../execution/writer-fence'
+import { LifecycleCommandStore } from '../lifecycle-command'
+import { LifecycleCommandStoreLive } from '../lifecycle-command-postgres'
+import { WriterFence, WriterFenceLive } from '../../execution/writer-fence'
+import { BlockedCycleIntentStore, BlockedCycleIntentStoreLive } from '../../execution/intents'
 import { canonicalHashV1, sha256 } from '../../hash'
+import { lifecycleCommandId } from '../../lifecycle-command-contract'
 import { Journal, type JournalService } from '../../ledger'
 import {
   MarketData,
@@ -299,7 +303,12 @@ const autonomousJournal: JournalService = {
 
 const makeAutonomousRuntime = () =>
   ManagedRuntime.make(
-    Layer.mergeAll(CycleStoreLive, ExecutionStoreLive(autonomousRuntimeConfig)).pipe(
+    Layer.mergeAll(
+      CycleStoreLive,
+      ExecutionStoreLive(autonomousRuntimeConfig),
+      BlockedCycleIntentStoreLive,
+      LifecycleCommandStoreLive,
+    ).pipe(
       Layer.provideMerge(WriterFenceLive),
       Layer.provideMerge(Layer.succeed(Journal, autonomousJournal)),
       Layer.provideMerge(PostgresClientLive(autonomousRuntimeConfig)),
@@ -3468,9 +3477,10 @@ describePostgres('PostgreSQL autonomous cycle store', () => {
       const result = await atomicRuntime.runPromise(
         Effect.gen(function* () {
           const sql = yield* PgClient.PgClient
+          const writerFence = yield* WriterFence
           const [clock] = yield* sql<{ evaluated_at: string }>`
           SELECT to_char(
-            (clock_timestamp() - interval '1 second') AT TIME ZONE 'UTC',
+            (clock_timestamp() - interval '1 minute') AT TIME ZONE 'UTC',
             'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'
           ) AS evaluated_at
         `
@@ -3497,6 +3507,7 @@ describePostgres('PostgreSQL autonomous cycle store', () => {
             lastSession: signalSessionDate,
           })
           const store = yield* CycleStore
+          const blockedCycleIntentStore = yield* BlockedCycleIntentStore
           yield* store.acquire(draft, acquisitionAt)
           yield* store.bindSnapshot(draft.identity.cycleId, manifest, snapshotBoundAt)
           const activated = yield* store.activate(draft.identity.cycleId, activatedAt)
@@ -3533,11 +3544,16 @@ describePostgres('PostgreSQL autonomous cycle store', () => {
         `
 
           const terminalization = yield* Effect.exit(
-            terminalizeBlockedPaperCycle(bound.cycle, {
-              _tag: 'Block',
-              reason: CycleTerminalReason.MissedSubmission,
-              observedAt: draft.window.submissionCutoffAt,
-            }),
+            terminalizeBlockedPaperCycle(
+              bound.cycle,
+              {
+                _tag: 'Block',
+                reason: CycleTerminalReason.MissedSubmission,
+                observedAt: draft.window.submissionCutoffAt,
+              },
+              planned.document.bindings.authorityGenerationHash,
+              blockedCycleIntentStore,
+            ),
           )
           const [authorityAfterRejectedBlock] = yield* sql<{
             effective: string
@@ -3555,11 +3571,91 @@ describePostgres('PostgreSQL autonomous cycle store', () => {
             unfinished.intent.intentId,
             'cancel-unknown',
           )
-          const committed = yield* terminalizeBlockedPaperCycle(bound.cycle, {
-            _tag: 'Block',
-            reason: CycleTerminalReason.Risk,
-            observedAt: settled.recoveredAt,
-          })
+          const committed = yield* terminalizeBlockedPaperCycle(
+            bound.cycle,
+            {
+              _tag: 'Block',
+              reason: CycleTerminalReason.Risk,
+              observedAt: settled.recoveredAt,
+            },
+            planned.document.bindings.authorityGenerationHash,
+            blockedCycleIntentStore,
+          )
+          const staleIntentId = canonicalHashV1({ cycleId: draft.identity.cycleId, fixture: 'stale-approved' })
+          const staleDecisionId = canonicalHashV1({ intentId: staleIntentId, fixture: 'risk-decision' })
+          const staleInputHash = canonicalHashV1({ intentId: staleIntentId, fixture: 'risk-input' })
+          const [staleTiming] = yield* sql<{ decided_at: string; observed_at: string }>`
+            SELECT
+              to_char(
+                clock_timestamp() AT TIME ZONE 'UTC',
+                'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'
+              ) AS decided_at,
+              to_char(
+                greatest(clock_timestamp(), cycle.terminal_at + interval '1 hour') AT TIME ZONE 'UTC',
+                'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"'
+              ) AS observed_at
+            FROM autonomous_cycles AS cycle
+            WHERE cycle.cycle_id = ${draft.identity.cycleId}
+          `
+          if (staleTiming === undefined) return yield* Effect.die(new Error('stale intent timing is unavailable'))
+          yield* sql`
+            INSERT INTO intents (
+              intent_id, schema_version, authority_generation_hash, strategy_name,
+              cycle_id, decision_hash, policy_hash, account_id, client_order_id,
+              symbol, side, order_type, time_in_force, quantity_micros,
+              notional_limit_micros, state, created_at, updated_at
+            )
+            SELECT
+              ${staleIntentId}, source.schema_version, source.authority_generation_hash, source.strategy_name,
+              source.cycle_id, source.decision_hash, source.policy_hash, source.account_id,
+              ${`stale-${staleIntentId.slice(0, 24)}`}, 'ZZZ', source.side, source.order_type,
+              source.time_in_force, source.quantity_micros, source.notional_limit_micros,
+              'PLANNED', ${staleTiming.decided_at}::timestamptz - interval '1 millisecond',
+              ${staleTiming.decided_at}::timestamptz - interval '1 millisecond'
+            FROM intents AS source
+            WHERE source.intent_id = ${unfinished.intent.intentId}
+          `
+          yield* writerFence.transaction(
+            sql`
+              INSERT INTO risk_decisions (
+                decision_id, schema_version, input_hash, intent_id, policy_hash,
+                outcome, reason_codes, decided_at, expires_at
+              )
+              SELECT
+                ${staleDecisionId}, source.schema_version, ${staleInputHash}, ${staleIntentId}, source.policy_hash,
+                'APPROVED', ARRAY[]::text[], ${staleTiming.decided_at}::timestamptz,
+                ${staleTiming.decided_at}::timestamptz + interval '1 hour'
+              FROM risk_decisions AS source
+              WHERE source.intent_id = ${unfinished.intent.intentId}
+            `.pipe(
+              Effect.andThen(sql`
+                UPDATE intents
+                SET
+                  risk_decision_id = ${staleDecisionId},
+                  state = 'APPROVED',
+                  state_version = state_version + 1,
+                  updated_at = ${staleTiming.decided_at}::timestamptz
+                WHERE intent_id = ${staleIntentId}
+              `),
+            ),
+          )
+          const settlement = yield* writerFence.transaction(
+            blockedCycleIntentStore.settleCurrentBlockedGeneration({
+              accountId: draft.identity.accountId,
+              observedAt: staleTiming.observed_at,
+            }),
+          )
+          const replay = yield* writerFence.transaction(
+            blockedCycleIntentStore.settleCurrentBlockedGeneration({
+              accountId: draft.identity.accountId,
+              observedAt: utcInstantFromEpochMillis(Date.parse(staleTiming.observed_at) + 1),
+            }),
+          )
+          const [staleIntent] = yield* sql<{ state: string; terminal_outcome: string | null }>`
+            SELECT state, terminal_outcome
+            FROM intents
+            WHERE intent_id = ${staleIntentId}
+          `
           const [authorityAfterCommittedBlock] = yield* sql<{
             effective: string
             kill_state: string
@@ -3575,6 +3671,9 @@ describePostgres('PostgreSQL autonomous cycle store', () => {
             authorityAfterRejectedBlock,
             committed,
             cycleAfterRejectedBlock,
+            replay,
+            settlement,
+            staleIntent,
             terminalization,
           }
         }).pipe(Effect.provide(TestClock.layer())),
@@ -3606,6 +3705,23 @@ describePostgres('PostgreSQL autonomous cycle store', () => {
       expect(result.authorityAfterCommittedBlock?.reason).toContain(
         `bound cycle ${result.committed.cycle.identity.cycleId} blocked: BLOCKED_RISK`,
       )
+      expect(result.settlement).toMatchObject({
+        _tag: 'BlockedGenerationSettled',
+        authorityGenerationHash: plannedPaperGenerationHash,
+        blockedCycleCount: 1,
+        blockedIntentCount: 0,
+        expiredIntentCount: 1,
+        intentCount: 2,
+        terminalIntentCount: 2,
+      })
+      expect(result.replay).toMatchObject({
+        _tag: 'BlockedGenerationSettled',
+        blockedIntentCount: 0,
+        expiredIntentCount: 0,
+        intentCount: 2,
+        terminalIntentCount: 2,
+      })
+      expect(result.staleIntent).toEqual({ state: 'TERMINAL', terminal_outcome: 'EXPIRED' })
     } finally {
       await atomicRuntime.dispose()
     }
@@ -4774,4 +4890,70 @@ describePostgres('PostgreSQL autonomous cycle store', () => {
       if (restartedRuntime !== undefined) await restartedRuntime.dispose()
     }
   }, 60_000)
+
+  test('recovers one contiguous lifecycle command across process ownership loss and replays its completion', async () => {
+    let first = makeAutonomousRuntime()
+    let second: ReturnType<typeof makeAutonomousRuntime> | undefined
+    const issuedAt = new Date().toISOString()
+    const command = {
+      controllerKey: 'primary',
+      commandId: lifecycleCommandId('primary', 1),
+      sequence: 1,
+      issuedAt,
+    }
+
+    try {
+      const started = await first.runPromise(
+        Effect.gen(function* () {
+          const store = yield* LifecycleCommandStore
+          const fence = yield* WriterFence
+          const initialCursor = yield* store.readCursor('primary')
+          const begin = yield* fence.transaction(store.begin(command))
+          const pendingCursor = yield* store.readCursor('primary')
+          return { initialCursor, begin, pendingCursor }
+        }),
+      )
+      expect(started).toEqual({
+        initialCursor: { _tag: 'Next', sequence: 1 },
+        begin: { _tag: 'Execute' },
+        pendingCursor: { _tag: 'Pending', command },
+      })
+
+      await first.dispose()
+      second = makeAutonomousRuntime()
+      const recovered = await second.runPromise(
+        Effect.gen(function* () {
+          const store = yield* LifecycleCommandStore
+          const fence = yield* WriterFence
+          const recoveredCursor = yield* store.readCursor('primary')
+          const resumed = yield* fence.transaction(store.begin(command))
+          const completedAt = new Date().toISOString()
+          const observation = {
+            result: 'SUCCESS' as const,
+            outcome: 'NOT_DUE' as const,
+            observedAt: completedAt,
+          }
+          const completed = yield* fence.transaction(store.complete({ ...command, completedAt, observation }))
+          const replay = yield* fence.transaction(store.begin(command))
+          const nextCursor = yield* store.readCursor('primary')
+          const conflicting = yield* Effect.exit(
+            fence.transaction(store.begin({ ...command, commandId: lifecycleCommandId('primary', 3), sequence: 3 })),
+          )
+          return { recoveredCursor, resumed, completed, replay, nextCursor, conflicting }
+        }),
+      )
+
+      expect(recovered).toMatchObject({
+        recoveredCursor: { _tag: 'Pending', command },
+        resumed: { _tag: 'Execute' },
+        completed: { result: 'SUCCESS', outcome: 'NOT_DUE' },
+        replay: { _tag: 'Completed', observation: { result: 'SUCCESS', outcome: 'NOT_DUE' } },
+        nextCursor: { _tag: 'Next', sequence: 2 },
+      })
+      expect(Exit.isFailure(recovered.conflicting)).toBe(true)
+    } finally {
+      await first.dispose()
+      if (second !== undefined) await second.dispose()
+    }
+  })
 })

--- a/services/bayn/src/db/evidence-store.integration.test.ts
+++ b/services/bayn/src/db/evidence-store.integration.test.ts
@@ -1167,6 +1167,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
       'fills',
       'gate_outcomes',
       'intents',
+      'lifecycle_commands',
       'live_capital_grant_revocations',
       'live_capital_grants',
       'mutation_events',
@@ -1216,6 +1217,8 @@ describePostgres('PostgreSQL evaluation evidence', () => {
       { migration_id: 28, name: 'research_paper_grants' },
       { migration_id: 29, name: 'unused_research_paper_rearm' },
       { migration_id: 30, name: 'clear_unused_research_paper_rearm' },
+      { migration_id: 31, name: 'blocked_paper_generation_rollover' },
+      { migration_id: 32, name: 'lifecycle_commands' },
     ])
   })
 

--- a/services/bayn/src/db/execution-store/observe-authority.ts
+++ b/services/bayn/src/db/execution-store/observe-authority.ts
@@ -337,17 +337,21 @@ const makeObserveAuthorityInterpreterDataFirst = (
         ), research_rearm AS (
           SELECT
             state.maximum = 'PAPER'
-            AND previous_generation.activation_schema_version = 'bayn.paper-authority-generation.v3'
             AND (
               (
                 state.effective = 'OBSERVE'
                 AND state.kill_state = 'ACTIVE'
                 AND state.reason LIKE 'PAPER autonomous cycle loop restricted effective authority:%'
+                AND previous_generation.activation_schema_version IN (
+                  'bayn.paper-authority-generation.v2',
+                  'bayn.paper-authority-generation.v3'
+                )
               )
               OR (
                 state.effective = 'PAPER'
                 AND state.kill_state = 'CLEAR'
                 AND state.reason IS NULL
+                AND previous_generation.activation_schema_version = 'bayn.paper-authority-generation.v3'
               )
             ) AS candidate,
             research_paper_rearm_eligible(

--- a/services/bayn/src/db/lifecycle-command-postgres.ts
+++ b/services/bayn/src/db/lifecycle-command-postgres.ts
@@ -1,0 +1,282 @@
+import { PgClient } from '@effect/sql-pg'
+import { Effect, Layer, Schema } from 'effect'
+import { isSqlError } from 'effect/unstable/sql/SqlError'
+
+import { Sha256Schema, UtcInstantSchema, strictParseOptions } from '../schemas'
+import {
+  AutonomousCyclePassObservationSchema,
+  MonthEndCadenceDecisionSchema,
+  type AutonomousCyclePassObservation,
+} from '../runtime-state'
+import {
+  LifecycleCommandStore,
+  LifecycleCommandStoreError,
+  type LifecycleCommandCompletionInput,
+  type LifecycleCommandCursor,
+  type LifecycleCommandInput,
+  type LifecycleCommandStoreShape,
+} from './lifecycle-command'
+
+const ControllerKeySchema = Schema.Trim.check(Schema.isPattern(/^[a-z0-9][a-z0-9._-]{0,63}$/))
+const SequenceSchema = Schema.Int.check(Schema.isGreaterThan(0))
+
+const CommandInputSchema = Schema.Struct({
+  controllerKey: ControllerKeySchema,
+  commandId: Sha256Schema,
+  sequence: SequenceSchema,
+  issuedAt: UtcInstantSchema,
+})
+
+const CompletionInputSchema = Schema.Struct({
+  ...CommandInputSchema.fields,
+  completedAt: UtcInstantSchema,
+  observation: AutonomousCyclePassObservationSchema,
+})
+
+const CommandRow = Schema.Struct({
+  command_id: Sha256Schema,
+  sequence: Schema.BigIntFromString,
+  issued_at: UtcInstantSchema,
+  status: Schema.Literals(['STARTED', 'COMPLETED']),
+  result: Schema.NullOr(Schema.Literals(['SUCCESS', 'FAILURE'])),
+  outcome: Schema.NullOr(Schema.NonEmptyString),
+  operation: Schema.NullOr(Schema.NonEmptyString),
+  failure: Schema.NullOr(Schema.NonEmptyString),
+  message: Schema.NullOr(Schema.NonEmptyString),
+  observed_at: Schema.NullOr(UtcInstantSchema),
+  cadence_decision: Schema.NullOr(MonthEndCadenceDecisionSchema),
+})
+
+const CommandRows = Schema.Tuple([CommandRow])
+
+const PreviousSequenceRows = Schema.Tuple([Schema.Struct({ previous_sequence: Schema.BigIntFromString })])
+const CursorRows = Schema.Array(CommandRow)
+
+const storeError = (
+  failure: LifecycleCommandStoreError['failure'],
+  message: string,
+  cause?: unknown,
+): LifecycleCommandStoreError => new LifecycleCommandStoreError({ failure, message, cause })
+
+const classifyCause = (cause: unknown): LifecycleCommandStoreError => {
+  if (cause instanceof LifecycleCommandStoreError) return cause
+  if (Schema.isSchemaError(cause)) return storeError('decode', 'lifecycle command evidence failed decoding', cause)
+  if (isSqlError(cause)) {
+    const failure =
+      cause.reason._tag === 'ConstraintError' || cause.reason._tag === 'UniqueViolation' ? 'conflict' : 'query'
+    return storeError(failure, 'lifecycle command persistence failed', cause)
+  }
+  return storeError('query', 'lifecycle command persistence failed', cause)
+}
+
+const decodeObservation = (
+  row: (typeof CommandRows.Type)[0],
+): Effect.Effect<AutonomousCyclePassObservation, LifecycleCommandStoreError> => {
+  if (row.result === 'SUCCESS' && row.outcome !== null && row.observed_at !== null) {
+    return Schema.decodeUnknownEffect(
+      AutonomousCyclePassObservationSchema,
+      strictParseOptions,
+    )({
+      result: 'SUCCESS',
+      outcome: row.outcome,
+      observedAt: row.observed_at,
+      ...(row.cadence_decision === null ? {} : { cadenceDecision: row.cadence_decision }),
+    }).pipe(Effect.mapError((cause) => storeError('decode', 'lifecycle command observation failed decoding', cause)))
+  }
+  if (
+    row.result === 'FAILURE' &&
+    row.operation !== null &&
+    row.failure !== null &&
+    row.message !== null &&
+    row.observed_at !== null
+  ) {
+    return Schema.decodeUnknownEffect(
+      AutonomousCyclePassObservationSchema,
+      strictParseOptions,
+    )({
+      result: 'FAILURE',
+      operation: row.operation as never,
+      failure: row.failure as never,
+      message: row.message,
+      observedAt: row.observed_at,
+    }).pipe(Effect.mapError((cause) => storeError('decode', 'lifecycle command observation failed decoding', cause)))
+  }
+  return Effect.fail(storeError('invariant', 'completed lifecycle command has an invalid observation projection'))
+}
+
+const readCursor = (
+  sql: PgClient.PgClient,
+  controllerKey: string,
+): Effect.Effect<LifecycleCommandCursor, LifecycleCommandStoreError> =>
+  Schema.decodeUnknownEffect(
+    ControllerKeySchema,
+    strictParseOptions,
+  )(controllerKey).pipe(
+    Effect.flatMap((validatedControllerKey) =>
+      sql<Record<string, unknown>>`
+        SELECT
+               command_id,
+               sequence,
+               to_char(issued_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') AS issued_at,
+               status,
+               result,
+               outcome,
+               operation,
+               failure,
+               message,
+               CASE
+                 WHEN observed_at IS NULL THEN NULL
+                 ELSE to_char(observed_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
+               END AS observed_at,
+               cadence_decision
+        FROM lifecycle_commands
+        WHERE controller_key = ${validatedControllerKey}
+        ORDER BY sequence DESC
+        LIMIT 1
+      `.pipe(Effect.flatMap(Schema.decodeUnknownEffect(CursorRows, strictParseOptions))),
+    ),
+    Effect.flatMap((rows) => {
+      const row = rows[0]
+      if (row === undefined) {
+        return Effect.succeed<LifecycleCommandCursor>({ _tag: 'Next', sequence: 1 })
+      }
+      const next = Number(row.sequence) + 1
+      if (!Number.isSafeInteger(next)) {
+        return Effect.fail(storeError('invariant', 'lifecycle command sequence exhausted the safe integer range'))
+      }
+      return row.status === 'STARTED'
+        ? Effect.succeed<LifecycleCommandCursor>({
+            _tag: 'Pending',
+            command: {
+              controllerKey,
+              commandId: row.command_id,
+              sequence: Number(row.sequence),
+              issuedAt: row.issued_at,
+            },
+          })
+        : Effect.succeed<LifecycleCommandCursor>({ _tag: 'Next', sequence: next })
+    }),
+    Effect.mapError(classifyCause),
+  )
+
+const begin = (sql: PgClient.PgClient, candidate: LifecycleCommandInput) =>
+  Schema.decodeUnknownEffect(
+    CommandInputSchema,
+    strictParseOptions,
+  )(candidate).pipe(
+    Effect.flatMap((input) =>
+      Effect.gen(function* () {
+        const inserted = yield* sql<Record<string, unknown>>`
+          INSERT INTO lifecycle_commands (
+            controller_key, command_id, sequence, issued_at, status, started_at
+          ) VALUES (
+            ${input.controllerKey}, ${input.commandId}, ${input.sequence}, ${input.issuedAt}, 'STARTED', clock_timestamp()
+          )
+          ON CONFLICT DO NOTHING
+          RETURNING command_id
+        `
+        const rows = yield* sql<Record<string, unknown>>`
+          SELECT
+                 command_id,
+                 sequence,
+                 to_char(issued_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') AS issued_at,
+                 status,
+                 result,
+                 outcome,
+                 operation,
+                 failure,
+                 message,
+                 CASE
+                   WHEN observed_at IS NULL THEN NULL
+                   ELSE to_char(observed_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
+                 END AS observed_at,
+                 cadence_decision
+          FROM lifecycle_commands
+          WHERE controller_key = ${input.controllerKey}
+            AND command_id = ${input.commandId}
+          FOR UPDATE
+        `.pipe(Effect.flatMap(Schema.decodeUnknownEffect(CommandRows, strictParseOptions)))
+        const [row] = rows
+        if (row.sequence !== BigInt(input.sequence) || row.issued_at !== input.issuedAt) {
+          return yield* storeError('conflict', 'lifecycle command identity does not match its durable command id')
+        }
+        if (inserted.length > 0) {
+          const [previous] = yield* sql<Record<string, unknown>>`
+            SELECT COALESCE(max(sequence), 0)::bigint AS previous_sequence
+            FROM lifecycle_commands
+            WHERE controller_key = ${input.controllerKey}
+              AND command_id <> ${input.commandId}
+          `.pipe(Effect.flatMap(Schema.decodeUnknownEffect(PreviousSequenceRows, strictParseOptions)))
+          if (BigInt(input.sequence) !== previous.previous_sequence + 1n) {
+            return yield* storeError('invariant', 'lifecycle command sequence is not contiguous', {
+              expectedSequence: (previous.previous_sequence + 1n).toString(),
+              actualSequence: input.sequence,
+            })
+          }
+        }
+        if (row.status === 'COMPLETED') {
+          return { _tag: 'Completed' as const, observation: yield* decodeObservation(row) }
+        }
+        return { _tag: 'Execute' as const }
+      }),
+    ),
+    Effect.mapError(classifyCause),
+  )
+
+const complete = (sql: PgClient.PgClient, candidate: LifecycleCommandCompletionInput) =>
+  Schema.decodeUnknownEffect(
+    CompletionInputSchema,
+    strictParseOptions,
+  )(candidate).pipe(
+    Effect.flatMap((input) => {
+      const success = input.observation.result === 'SUCCESS'
+      return sql<Record<string, unknown>>`
+        UPDATE lifecycle_commands
+        SET
+          status = 'COMPLETED',
+          result = ${input.observation.result},
+          outcome = ${success ? input.observation.outcome : null},
+          operation = ${success ? null : input.observation.operation},
+          failure = ${success ? null : input.observation.failure},
+          message = ${success ? null : input.observation.message},
+          observed_at = ${input.observation.observedAt},
+          cadence_decision = ${success ? (input.observation.cadenceDecision ?? null) : null},
+          completed_at = greatest(${input.completedAt}, started_at)
+        WHERE controller_key = ${input.controllerKey}
+          AND command_id = ${input.commandId}
+          AND sequence = ${input.sequence}
+          AND issued_at = ${input.issuedAt}
+          AND status = 'STARTED'
+        RETURNING
+          command_id,
+          sequence,
+          to_char(issued_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"') AS issued_at,
+          status,
+          result,
+          outcome,
+          operation,
+          failure,
+          message,
+          CASE
+            WHEN observed_at IS NULL THEN NULL
+            ELSE to_char(observed_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
+          END AS observed_at,
+          cadence_decision
+      `.pipe(
+        Effect.flatMap(Schema.decodeUnknownEffect(CommandRows, strictParseOptions)),
+        Effect.flatMap(([row]) => decodeObservation(row)),
+      )
+    }),
+    Effect.mapError(classifyCause),
+  )
+
+const makeStore = Effect.gen(function* () {
+  const sql = yield* PgClient.PgClient
+  return {
+    readCursor: (controllerKey) => readCursor(sql, controllerKey),
+    begin: (input) => begin(sql, input),
+    complete: (input) => complete(sql, input),
+  } satisfies LifecycleCommandStoreShape
+})
+
+export const LifecycleCommandStoreLive = Layer.effect(LifecycleCommandStore, makeStore)

--- a/services/bayn/src/db/lifecycle-command.ts
+++ b/services/bayn/src/db/lifecycle-command.ts
@@ -1,0 +1,46 @@
+import { Context, Data, Effect } from 'effect'
+
+import type { AutonomousCyclePassObservation } from '../runtime-state'
+
+export interface LifecycleCommandInput {
+  readonly controllerKey: string
+  readonly commandId: string
+  readonly sequence: number
+  readonly issuedAt: string
+}
+
+export type LifecycleCommandBeginReceipt =
+  | { readonly _tag: 'Execute' }
+  | { readonly _tag: 'Completed'; readonly observation: AutonomousCyclePassObservation }
+
+export interface LifecycleCommandCompletionInput extends LifecycleCommandInput {
+  readonly completedAt: string
+  readonly observation: AutonomousCyclePassObservation
+}
+
+export type LifecycleCommandCursor =
+  | { readonly _tag: 'Next'; readonly sequence: number }
+  | { readonly _tag: 'Pending'; readonly command: LifecycleCommandInput }
+
+export class LifecycleCommandStoreError extends Data.TaggedError('LifecycleCommandStoreError')<{
+  readonly failure: 'conflict' | 'decode' | 'invariant' | 'query'
+  readonly message: string
+  readonly cause?: unknown
+}> {}
+
+export interface LifecycleCommandStoreShape {
+  /** Recovers the exact pending command after controller state loss, or the next contiguous sequence. */
+  readonly readCursor: (controllerKey: string) => Effect.Effect<LifecycleCommandCursor, LifecycleCommandStoreError>
+  /** Must be called inside WriterFence. STARTED commands are intentionally retryable after process failure. */
+  readonly begin: (
+    input: LifecycleCommandInput,
+  ) => Effect.Effect<LifecycleCommandBeginReceipt, LifecycleCommandStoreError>
+  /** Must be called inside WriterFence after the one-pass interpreter has durably recorded its observation. */
+  readonly complete: (
+    input: LifecycleCommandCompletionInput,
+  ) => Effect.Effect<AutonomousCyclePassObservation, LifecycleCommandStoreError>
+}
+
+export class LifecycleCommandStore extends Context.Service<LifecycleCommandStore, LifecycleCommandStoreShape>()(
+  '@proompteng/bayn/db/lifecycle-command/LifecycleCommandStore',
+) {}

--- a/services/bayn/src/db/migrations.ts
+++ b/services/bayn/src/db/migrations.ts
@@ -30,6 +30,8 @@ import distinctCloseReplanIntents from '../../migrations/0027_distinct_close_rep
 import researchPaperGrants from '../../migrations/0028_research_paper_grants'
 import unusedResearchPaperRearm from '../../migrations/0029_unused_research_paper_rearm'
 import clearUnusedResearchPaperRearm from '../../migrations/0030_clear_unused_research_paper_rearm'
+import blockedPaperGenerationRollover from '../../migrations/0031_blocked_paper_generation_rollover'
+import lifecycleCommands from '../../migrations/0032_lifecycle_commands'
 
 export const migrationLoader = PgMigrator.fromRecord({
   '1_initial_schema': initialSchema,
@@ -62,4 +64,6 @@ export const migrationLoader = PgMigrator.fromRecord({
   '28_research_paper_grants': researchPaperGrants,
   '29_unused_research_paper_rearm': unusedResearchPaperRearm,
   '30_clear_unused_research_paper_rearm': clearUnusedResearchPaperRearm,
+  '31_blocked_paper_generation_rollover': blockedPaperGenerationRollover,
+  '32_lifecycle_commands': lifecycleCommands,
 })

--- a/services/bayn/src/db/paper-store.integration.test.ts
+++ b/services/bayn/src/db/paper-store.integration.test.ts
@@ -2292,6 +2292,73 @@ describePostgres('paper accounting persistence', () => {
     }
   }, 15_000)
 
+  test('clears a failure-restricted qualified v2 PAPER generation only after fresh exact reconciliation', async () => {
+    const sourceGenerationHash = hash('qualified-v2-recovery-source')
+    const nextSourceGenerationHash = hash('qualified-v2-recovery-next-source')
+    const activationReconciliation = exactReconciliation('qualified-v2-recovery-activation')
+    const activation = makeActivation(sourceGenerationHash, qualifiedEvidence, activationReconciliation)
+    const runtime = makeActivationRuntime({ fail: false, planHashes: [] }, activation)
+    try {
+      const result = await runtime.runPromise(
+        Effect.gen(function* () {
+          const store = yield* ExecutionStore
+          const sql = yield* PgClient.PgClient
+
+          yield* seedQualificationEvidence(qualifiedEvidence)
+          yield* seedExactReconciliation(activationReconciliation)
+          yield* store.ensureAuthorityGeneration({
+            generationHash: sourceGenerationHash,
+            maximum: Authority.Observe,
+          })
+          const activated = yield* store.activateCapitalGrant(proofBinding(activation))
+          const [restrictionTime] = yield* sql<{ updated_at: Date }>`
+            SELECT greatest(clock_timestamp(), updated_at + interval '1 millisecond') AS updated_at
+            FROM authority_state
+            WHERE singleton
+          `
+          if (restrictionTime === undefined) return yield* Effect.die(new Error('restriction time is unavailable'))
+          yield* store.restrictAuthority(
+            `${paperEpisodeFailureRestrictionPrefix} qualified v2 recovery`,
+            restrictionTime.updated_at.toISOString(),
+          )
+
+          const beforeFreshReconciliation = yield* Effect.flip(
+            store.ensureAuthorityGeneration({
+              generationHash: nextSourceGenerationHash,
+              maximum: Authority.Observe,
+            }),
+          )
+          yield* seedExactReconciliation(exactReconciliation('qualified-v2-recovery-rollover'))
+          const rearmed = yield* store.ensureAuthorityGeneration({
+            generationHash: nextSourceGenerationHash,
+            maximum: Authority.Observe,
+          })
+          return { activated, beforeFreshReconciliation, rearmed }
+        }),
+      )
+
+      expect(result.activated).toMatchObject({
+        generationHash: activation.generationHash,
+        maximum: Authority.Paper,
+        effective: Authority.Paper,
+        kill: KillState.Clear,
+      })
+      expect(result.beforeFreshReconciliation).toMatchObject({
+        operation: 'authority',
+        failure: 'invariant',
+      })
+      expect(result.rearmed).toMatchObject({
+        generationHash: nextSourceGenerationHash,
+        maximum: Authority.Observe,
+        effective: Authority.Observe,
+        kill: KillState.Clear,
+      })
+      expect(result.rearmed.reason).toBeUndefined()
+    } finally {
+      await runtime.dispose()
+    }
+  }, 15_000)
+
   test('rotates a non-rearm research PAPER kill to OBSERVE without clearing it', async () => {
     const sourceGenerationHash = hash('operator-killed-research-paper-source')
     const nextSourceGenerationHash = hash('operator-killed-research-paper-next-source')

--- a/services/bayn/src/execution/intents.ts
+++ b/services/bayn/src/execution/intents.ts
@@ -1,2 +1,4 @@
 export * from './intents/domain'
+export * from './intents/blocked-cycle'
+export { BlockedCycleIntentStoreLive } from './intents/blocked-cycle-postgres'
 export { IntentStoreLive } from './intents/postgres'

--- a/services/bayn/src/execution/intents/blocked-cycle-postgres.ts
+++ b/services/bayn/src/execution/intents/blocked-cycle-postgres.ts
@@ -1,0 +1,296 @@
+import { PgClient } from '@effect/sql-pg'
+import { Effect, Layer, Schema } from 'effect'
+import { isSqlError } from 'effect/unstable/sql/SqlError'
+
+import { Sha256Schema, UtcInstantSchema, strictParseOptions } from '../../schemas'
+import {
+  BlockedCycleIntentStore,
+  BlockedCycleIntentStoreError,
+  type BlockedCycleIntentStoreShape,
+  type BlockedCycleIntentTerminalizationInput,
+  type CurrentBlockedGenerationSettlementInput,
+  type CurrentBlockedGenerationSettlementReceipt,
+} from './blocked-cycle'
+
+const InputSchema = Schema.Struct({
+  authorityGenerationHash: Sha256Schema,
+  cycleId: Sha256Schema,
+  observedAt: UtcInstantSchema,
+})
+
+const ReceiptRows = Schema.Tuple([
+  Schema.Struct({
+    blocked_intent_count: Schema.Int.check(Schema.isGreaterThanOrEqualTo(0)),
+    expired_intent_count: Schema.Int.check(Schema.isGreaterThanOrEqualTo(0)),
+    terminal_intent_count: Schema.Int.check(Schema.isGreaterThanOrEqualTo(0)),
+    nonterminal_intent_count: Schema.Int.check(Schema.isGreaterThanOrEqualTo(0)),
+  }),
+])
+
+const CurrentSettlementInputSchema = Schema.Struct({
+  accountId: Schema.NonEmptyString,
+  observedAt: UtcInstantSchema,
+})
+
+const CurrentSettlementRows = Schema.Tuple([
+  Schema.Struct({
+    authority_generation_hash: Schema.NullOr(Sha256Schema),
+    blocked_cycle_count: Schema.Int.check(Schema.isGreaterThanOrEqualTo(0)),
+    blocked_intent_count: Schema.Int.check(Schema.isGreaterThanOrEqualTo(0)),
+    expired_intent_count: Schema.Int.check(Schema.isGreaterThanOrEqualTo(0)),
+    intent_count: Schema.Int.check(Schema.isGreaterThanOrEqualTo(0)),
+    terminal_intent_count: Schema.Int.check(Schema.isGreaterThanOrEqualTo(0)),
+    nonterminal_intent_count: Schema.Int.check(Schema.isGreaterThanOrEqualTo(0)),
+  }),
+])
+
+const storeError = (
+  failure: BlockedCycleIntentStoreError['failure'],
+  message: string,
+  cause?: unknown,
+): BlockedCycleIntentStoreError => new BlockedCycleIntentStoreError({ failure, message, cause })
+
+const classifyCause = (cause: unknown): BlockedCycleIntentStoreError => {
+  if (cause instanceof BlockedCycleIntentStoreError) return cause
+  if (Schema.isSchemaError(cause)) return storeError('decode', 'blocked-cycle intent evidence failed decoding', cause)
+  if (isSqlError(cause)) {
+    const failure =
+      cause.reason._tag === 'ConstraintError' || cause.reason._tag === 'UniqueViolation' ? 'conflict' : 'query'
+    return storeError(failure, 'blocked-cycle intent terminalization failed', cause)
+  }
+  return storeError('query', 'blocked-cycle intent terminalization failed', cause)
+}
+
+const terminalizeUntouchedApproved = (sql: PgClient.PgClient, candidate: BlockedCycleIntentTerminalizationInput) =>
+  Schema.decodeUnknownEffect(
+    InputSchema,
+    strictParseOptions,
+  )(candidate).pipe(
+    Effect.flatMap((input) =>
+      Effect.gen(function* () {
+        const rows = yield* sql<Record<string, unknown>>`
+            WITH bound_cycle AS MATERIALIZED (
+              SELECT cycle.cycle_id, cycle.submission_cutoff_at
+              FROM autonomous_cycles AS cycle
+              JOIN autonomous_cycle_shadow_decisions AS decision
+                ON decision.cycle_id = cycle.cycle_id
+               AND decision.decision_hash = cycle.decision_hash
+              WHERE cycle.cycle_id = ${input.cycleId}
+                AND cycle.state = 'BLOCKED'
+                AND cycle.terminal_at <= ${input.observedAt}
+                AND decision.document ->> 'schemaVersion' = 'bayn.paper-cycle-decision.v1'
+                AND decision.document ->> 'mode' = 'PAPER'
+                AND decision.document #>> '{bindings,authorityGenerationHash}' = ${input.authorityGenerationHash}
+              FOR UPDATE OF cycle
+            ), terminalized AS (
+              UPDATE intents AS intent
+              SET
+                state = 'TERMINAL',
+                terminal_outcome = CASE
+                  WHEN decision.expires_at <= ${input.observedAt}::timestamptz
+                    OR cycle.submission_cutoff_at <= ${input.observedAt}::timestamptz
+                  THEN 'EXPIRED'
+                  ELSE 'BLOCKED'
+                END,
+                state_version = intent.state_version + 1,
+                updated_at = GREATEST(
+                  ${input.observedAt}::timestamptz,
+                  intent.updated_at + interval '1 millisecond'
+                )
+              FROM bound_cycle AS cycle
+              JOIN risk_decisions AS decision ON true
+              WHERE intent.cycle_id = cycle.cycle_id
+                AND intent.authority_generation_hash = ${input.authorityGenerationHash}
+                AND intent.state = 'APPROVED'
+                AND decision.decision_id = intent.risk_decision_id
+                AND decision.intent_id = intent.intent_id
+                AND NOT EXISTS (
+                  SELECT 1 FROM mutation_events AS event WHERE event.intent_id = intent.intent_id
+                )
+                AND NOT EXISTS (
+                  SELECT 1 FROM orders AS broker_order WHERE broker_order.intent_id = intent.intent_id
+                )
+                AND NOT EXISTS (
+                  SELECT 1 FROM fills AS fill WHERE fill.intent_id = intent.intent_id
+                )
+              RETURNING intent.intent_id, intent.terminal_outcome
+            ), counts AS (
+              SELECT
+                count(*) FILTER (WHERE terminal_outcome = 'BLOCKED')::integer AS blocked_intent_count,
+                count(*) FILTER (WHERE terminal_outcome = 'EXPIRED')::integer AS expired_intent_count
+              FROM terminalized
+            )
+            SELECT
+              counts.blocked_intent_count,
+              counts.expired_intent_count,
+              count(*) FILTER (
+                WHERE intent.state = 'TERMINAL' OR terminalized.intent_id IS NOT NULL
+              )::integer AS terminal_intent_count,
+              count(*) FILTER (
+                WHERE intent.state <> 'TERMINAL' AND terminalized.intent_id IS NULL
+              )::integer AS nonterminal_intent_count
+            FROM counts
+            JOIN bound_cycle AS cycle ON true
+            LEFT JOIN intents AS intent
+              ON intent.cycle_id = cycle.cycle_id
+             AND intent.authority_generation_hash = ${input.authorityGenerationHash}
+            LEFT JOIN terminalized ON terminalized.intent_id = intent.intent_id
+            GROUP BY counts.blocked_intent_count, counts.expired_intent_count
+          `.pipe(Effect.flatMap(Schema.decodeUnknownEffect(ReceiptRows, strictParseOptions)))
+        const [receipt] = rows
+        if (receipt.nonterminal_intent_count !== 0) {
+          return yield* storeError(
+            'invariant',
+            'blocked cycle retains an intent that cannot be terminalized without broker recovery',
+            { nonterminalIntentCount: receipt.nonterminal_intent_count },
+          )
+        }
+        return {
+          blockedIntentCount: receipt.blocked_intent_count,
+          expiredIntentCount: receipt.expired_intent_count,
+          terminalIntentCount: receipt.terminal_intent_count,
+        }
+      }),
+    ),
+    Effect.mapError(classifyCause),
+  )
+
+const settleCurrentBlockedGeneration = (sql: PgClient.PgClient, candidate: CurrentBlockedGenerationSettlementInput) =>
+  Schema.decodeUnknownEffect(
+    CurrentSettlementInputSchema,
+    strictParseOptions,
+  )(candidate).pipe(
+    Effect.flatMap((input) =>
+      sql<Record<string, unknown>>`
+        WITH current_generation AS MATERIALIZED (
+          SELECT
+            state.generation_hash,
+            generation.account_id
+          FROM authority_state AS state
+          JOIN authority_generations AS generation
+            ON generation.generation_hash = state.generation_hash
+          WHERE state.singleton
+            AND state.maximum = 'PAPER'
+            AND state.effective = 'OBSERVE'
+            AND state.kill_state = 'ACTIVE'
+            AND state.reason LIKE 'PAPER autonomous cycle loop restricted effective authority:%'
+            AND generation.maximum = 'PAPER'
+            AND generation.activation_schema_version IN (
+              'bayn.paper-authority-generation.v2',
+              'bayn.paper-authority-generation.v3'
+            )
+            AND generation.account_id = ${input.accountId}
+          FOR UPDATE OF state
+        ), blocked_cycles AS MATERIALIZED (
+          SELECT cycle.cycle_id, cycle.submission_cutoff_at
+          FROM current_generation AS generation
+          JOIN autonomous_cycles AS cycle
+            ON cycle.account_id = generation.account_id
+          JOIN autonomous_cycle_shadow_decisions AS decision
+            ON decision.cycle_id = cycle.cycle_id
+           AND decision.decision_hash = cycle.decision_hash
+          WHERE cycle.state = 'BLOCKED'
+            AND cycle.terminal_at <= ${input.observedAt}::timestamptz
+            AND decision.document ->> 'schemaVersion' = 'bayn.paper-cycle-decision.v1'
+            AND decision.document ->> 'mode' = 'PAPER'
+            AND decision.document #>> '{bindings,authorityGenerationHash}' = generation.generation_hash
+          FOR UPDATE OF cycle
+        ), terminalized AS (
+          UPDATE intents AS intent
+          SET
+            state = 'TERMINAL',
+            terminal_outcome = CASE
+              WHEN decision.expires_at <= ${input.observedAt}::timestamptz
+                OR cycle.submission_cutoff_at <= ${input.observedAt}::timestamptz
+              THEN 'EXPIRED'
+              ELSE 'BLOCKED'
+            END,
+            state_version = intent.state_version + 1,
+            updated_at = GREATEST(
+              ${input.observedAt}::timestamptz,
+              intent.updated_at + interval '1 millisecond'
+            )
+          FROM current_generation AS generation
+          JOIN blocked_cycles AS cycle ON true
+          JOIN risk_decisions AS decision ON true
+          WHERE intent.authority_generation_hash = generation.generation_hash
+            AND intent.cycle_id = cycle.cycle_id
+            AND intent.state = 'APPROVED'
+            AND decision.decision_id = intent.risk_decision_id
+            AND decision.intent_id = intent.intent_id
+            AND NOT EXISTS (
+              SELECT 1 FROM mutation_events AS event WHERE event.intent_id = intent.intent_id
+            )
+            AND NOT EXISTS (
+              SELECT 1 FROM orders AS broker_order WHERE broker_order.intent_id = intent.intent_id
+            )
+            AND NOT EXISTS (
+              SELECT 1 FROM fills AS fill WHERE fill.intent_id = intent.intent_id
+            )
+          RETURNING intent.intent_id, intent.terminal_outcome
+        ), terminalized_counts AS (
+          SELECT
+            count(*) FILTER (WHERE terminal_outcome = 'BLOCKED')::integer AS blocked_intent_count,
+            count(*) FILTER (WHERE terminal_outcome = 'EXPIRED')::integer AS expired_intent_count
+          FROM terminalized
+        ), intent_counts AS (
+          SELECT
+            count(intent.intent_id)::integer AS intent_count,
+            count(intent.intent_id) FILTER (
+              WHERE intent.state = 'TERMINAL' OR terminalized.intent_id IS NOT NULL
+            )::integer AS terminal_intent_count,
+            count(intent.intent_id) FILTER (
+              WHERE intent.state <> 'TERMINAL' AND terminalized.intent_id IS NULL
+            )::integer AS nonterminal_intent_count
+          FROM current_generation AS generation
+          LEFT JOIN intents AS intent
+            ON intent.authority_generation_hash = generation.generation_hash
+          LEFT JOIN terminalized ON terminalized.intent_id = intent.intent_id
+        )
+        SELECT
+          (SELECT generation_hash FROM current_generation) AS authority_generation_hash,
+          (SELECT count(*)::integer FROM blocked_cycles) AS blocked_cycle_count,
+          terminalized_counts.blocked_intent_count,
+          terminalized_counts.expired_intent_count,
+          intent_counts.intent_count,
+          intent_counts.terminal_intent_count,
+          intent_counts.nonterminal_intent_count
+        FROM terminalized_counts, intent_counts
+      `.pipe(Effect.flatMap(Schema.decodeUnknownEffect(CurrentSettlementRows, strictParseOptions))),
+    ),
+    Effect.flatMap(
+      ([receipt]): Effect.Effect<CurrentBlockedGenerationSettlementReceipt, BlockedCycleIntentStoreError> => {
+        if (receipt.authority_generation_hash === null) {
+          return Effect.succeed({ _tag: 'NoBlockedGeneration' as const })
+        }
+        if (receipt.nonterminal_intent_count !== 0) {
+          return Effect.fail(
+            storeError(
+              'invariant',
+              `current blocked generation retains ${receipt.nonterminal_intent_count} intent(s) that require broker recovery after inspecting ${receipt.blocked_cycle_count} blocked cycle(s) and terminalizing ${receipt.blocked_intent_count} blocked/${receipt.expired_intent_count} expired intent(s)`,
+            ),
+          )
+        }
+        return Effect.succeed({
+          _tag: 'BlockedGenerationSettled' as const,
+          authorityGenerationHash: receipt.authority_generation_hash,
+          blockedCycleCount: receipt.blocked_cycle_count,
+          blockedIntentCount: receipt.blocked_intent_count,
+          expiredIntentCount: receipt.expired_intent_count,
+          intentCount: receipt.intent_count,
+          terminalIntentCount: receipt.terminal_intent_count,
+        })
+      },
+    ),
+    Effect.mapError(classifyCause),
+  )
+
+const makeStore = Effect.gen(function* () {
+  const sql = yield* PgClient.PgClient
+  return {
+    terminalizeUntouchedApproved: (input) => terminalizeUntouchedApproved(sql, input),
+    settleCurrentBlockedGeneration: (input) => settleCurrentBlockedGeneration(sql, input),
+  } satisfies BlockedCycleIntentStoreShape
+})
+
+export const BlockedCycleIntentStoreLive = Layer.effect(BlockedCycleIntentStore, makeStore)

--- a/services/bayn/src/execution/intents/blocked-cycle.ts
+++ b/services/bayn/src/execution/intents/blocked-cycle.ts
@@ -1,0 +1,60 @@
+import { Context, Data, Effect } from 'effect'
+
+export interface BlockedCycleIntentTerminalizationInput {
+  readonly authorityGenerationHash: string
+  readonly cycleId: string
+  readonly observedAt: string
+}
+
+export interface BlockedCycleIntentTerminalizationReceipt {
+  readonly blockedIntentCount: number
+  readonly expiredIntentCount: number
+  readonly terminalIntentCount: number
+}
+
+export interface CurrentBlockedGenerationSettlementInput {
+  readonly accountId: string
+  readonly observedAt: string
+}
+
+export type CurrentBlockedGenerationSettlementReceipt =
+  | { readonly _tag: 'NoBlockedGeneration' }
+  | {
+      readonly _tag: 'BlockedGenerationSettled'
+      readonly authorityGenerationHash: string
+      readonly blockedCycleCount: number
+      readonly blockedIntentCount: number
+      readonly expiredIntentCount: number
+      readonly intentCount: number
+      readonly terminalIntentCount: number
+    }
+
+export class BlockedCycleIntentStoreError extends Data.TaggedError('BlockedCycleIntentStoreError')<{
+  readonly failure: 'conflict' | 'decode' | 'invariant' | 'query'
+  readonly message: string
+  readonly cause?: unknown
+}> {}
+
+/**
+ * Terminalizes untouched approved intents after their bound cycle has durably blocked.
+ *
+ * The live interpreter deliberately does not open its own transaction. Its only caller composes this operation with
+ * cycle terminalization and authority restriction inside the process-owned WriterFence transaction.
+ */
+export interface BlockedCycleIntentStoreShape {
+  readonly terminalizeUntouchedApproved: (
+    input: BlockedCycleIntentTerminalizationInput,
+  ) => Effect.Effect<BlockedCycleIntentTerminalizationReceipt, BlockedCycleIntentStoreError>
+  /**
+   * Repairs a generation that was already kill-restricted and terminal when this process started. The caller must
+   * run this operation inside the process-owned WriterFence transaction. A later, separate exact reconciliation is
+   * deliberately required before OBSERVE generation rollover can clear the kill.
+   */
+  readonly settleCurrentBlockedGeneration: (
+    input: CurrentBlockedGenerationSettlementInput,
+  ) => Effect.Effect<CurrentBlockedGenerationSettlementReceipt, BlockedCycleIntentStoreError>
+}
+
+export class BlockedCycleIntentStore extends Context.Service<BlockedCycleIntentStore, BlockedCycleIntentStoreShape>()(
+  '@proompteng/bayn/execution/intents/blocked-cycle/BlockedCycleIntentStore',
+) {}

--- a/services/bayn/src/forward-performance/program.test.ts
+++ b/services/bayn/src/forward-performance/program.test.ts
@@ -33,6 +33,9 @@ const config: LoadedRuntimeConfig = {
   runtimeMode: 'AutonomousService',
   host: '127.0.0.1',
   port: 8080,
+  lifecycleOwner: 'Process',
+  lifecycleCommandPort: 8081,
+  lifecycleControllerKey: 'primary',
   execution: {
     brokerIdentity: identityResult.success,
     brokerAccess: BrokerAccess.ReadOnly,

--- a/services/bayn/src/health.test.ts
+++ b/services/bayn/src/health.test.ts
@@ -997,6 +997,47 @@ describe('Bayn continuous health', () => {
     })
   })
 
+  test('keeps Restate-owned lifecycle unavailable until its first durable pass reaches Bayn', () => {
+    const startedAt = '2026-07-20T00:00:00.000Z'
+    const current: RuntimeState = {
+      ...readyState(),
+      autonomousCycleLoop: {
+        configured: true,
+        owner: 'Restate',
+        startedAt,
+        lastPass: null,
+      },
+    }
+    const transition = deriveHealthTransition(current, {
+      config,
+      evidenceAvailable: true,
+      results: {
+        postgresql: { _tag: 'Available', value: undefined },
+        signal: { _tag: 'Available', value: undefined },
+        tigerBeetle: { _tag: 'Available', value: undefined },
+        durableEvidence: { _tag: 'Available', value: undefined },
+        cycle: { _tag: 'Available', value: emptyCycleProjection() },
+        broker: null,
+      },
+      broker: undefined,
+      cycleFiber: { _tag: 'Running' },
+      clock: availableClock('2026-07-20T00:00:01.000Z'),
+    })
+
+    expect(transition.next).toMatchObject({
+      status: 'DEGRADED',
+      health: {
+        dependencies: {
+          cycleRunner: {
+            status: 'UNAVAILABLE',
+            error: 'Restate lifecycle has not completed its first durable pass',
+          },
+        },
+      },
+      error: 'cycleRunner: Restate lifecycle has not completed its first durable pass',
+    })
+  })
+
   test('preserves the prior validated cycle-runner failure when the clock is unavailable', () => {
     const progressAt = '2026-07-20T00:00:00.000Z'
     const previousRunner = {

--- a/services/bayn/src/health/decisions.ts
+++ b/services/bayn/src/health/decisions.ts
@@ -212,6 +212,9 @@ const cycleLoopHealth = (
   if (fiber._tag === 'NotProvided') return unavailable('configured autonomous cycle loop has no scoped fiber')
   if (fiber._tag === 'ExitedSuccessfully') return unavailable('autonomous cycle loop exited unexpectedly')
   if (fiber._tag === 'ExitedWithFailure') return unavailable(`autonomous cycle loop failed: ${fiber.error}`)
+  if (loop.owner === 'Restate' && loop.lastPass === null) {
+    return unavailable('Restate lifecycle has not completed its first durable pass')
+  }
   if (loop.lastPass?.result === 'FAILURE') {
     return unavailable(`${loop.lastPass.operation}/${loop.lastPass.failure}: ${loop.lastPass.message}`)
   }

--- a/services/bayn/src/http.ts
+++ b/services/bayn/src/http.ts
@@ -161,6 +161,7 @@ const publicAutonomousCycleLoop = (state: RuntimeState) => {
   const lastPass = state.autonomousCycleLoop.lastPass
   return {
     configured: state.autonomousCycleLoop.configured,
+    owner: state.autonomousCycleLoop.owner ?? 'Process',
     startedAt: state.autonomousCycleLoop.startedAt,
     cadence: autonomousCycleCadenceObservation(state),
     lastPass:
@@ -602,9 +603,15 @@ const renderPrometheusMetricsDataFirst = (
     '# HELP bayn_cycle_stall_threshold_seconds Configured attempt-stall threshold.',
     '# TYPE bayn_cycle_stall_threshold_seconds gauge',
     `bayn_cycle_stall_threshold_seconds ${prometheusNumber(config.cycleStallThresholdMs / 1_000)}`,
-    '# HELP bayn_autonomous_cycle_loop_configured Whether the in-process autonomous cycle loop is configured.',
+    '# HELP bayn_autonomous_cycle_loop_configured Whether autonomous cycle ownership is configured.',
     '# TYPE bayn_autonomous_cycle_loop_configured gauge',
     `bayn_autonomous_cycle_loop_configured ${state.autonomousCycleLoop.configured ? 1 : 0}`,
+    '# HELP bayn_autonomous_cycle_owner Active durable scheduler owner for the Bayn lifecycle.',
+    '# TYPE bayn_autonomous_cycle_owner gauge',
+    ...(['process', 'restate'] as const).map(
+      (owner) =>
+        `bayn_autonomous_cycle_owner{owner="${owner}"} ${(state.autonomousCycleLoop.owner ?? 'Process').toLowerCase() === owner ? 1 : 0}`,
+    ),
     '# HELP bayn_autonomous_cycle_loop_health_available Whether the configured scoped loop is live and has not failed or stalled.',
     '# TYPE bayn_autonomous_cycle_loop_health_available gauge',
     `bayn_autonomous_cycle_loop_health_available ${loopHealthy ? 1 : 0}`,

--- a/services/bayn/src/lifecycle-command-auth.test.ts
+++ b/services/bayn/src/lifecycle-command-auth.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, test } from 'bun:test'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { Effect, Exit } from 'effect'
+import { HttpClient, HttpClientResponse } from 'effect/unstable/http'
+
+import {
+  bearerToken,
+  lifecycleCommandServiceAccount,
+  lifecycleCommandTokenAudience,
+  makeLifecycleCommandAuthenticator,
+  type LifecycleCommandAuthenticationConfig,
+} from './lifecycle-command-auth'
+
+const tokenReviewResponse = (
+  request: Parameters<Parameters<typeof HttpClient.make>[0]>[0],
+  status: object,
+  httpStatus = 201,
+) =>
+  HttpClientResponse.fromWeb(
+    request,
+    new Response(JSON.stringify({ apiVersion: 'authentication.k8s.io/v1', kind: 'TokenReview', status }), {
+      status: httpStatus,
+      headers: { 'content-type': 'application/json' },
+    }),
+  )
+
+const requestBody = (request: Parameters<Parameters<typeof HttpClient.make>[0]>[0]): unknown => {
+  if (request.body._tag !== 'Uint8Array') throw new Error('expected a JSON request body')
+  return JSON.parse(new TextDecoder().decode(request.body.body))
+}
+
+describe('Bayn lifecycle command authentication', () => {
+  test('accepts only the exact projected service-account identity and audience', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'bayn-lifecycle-auth-'))
+    const reviewerTokenPath = join(directory, 'token')
+    await writeFile(reviewerTokenPath, 'reviewer-token\n', { mode: 0o600 })
+    const config: LifecycleCommandAuthenticationConfig = {
+      apiOrigin: 'https://kubernetes.default.svc.cluster.local',
+      caPath: join(directory, 'ca.crt'),
+      reviewerTokenPath,
+      audience: lifecycleCommandTokenAudience,
+      expectedUsername: lifecycleCommandServiceAccount,
+    }
+    const requests: Array<{ readonly authorization: string | undefined; readonly body: unknown }> = []
+    const identities = [
+      {
+        authenticated: true,
+        audiences: [lifecycleCommandTokenAudience],
+        user: { username: lifecycleCommandServiceAccount },
+      },
+      {
+        authenticated: true,
+        audiences: [lifecycleCommandTokenAudience],
+        user: { username: 'system:serviceaccount:bayn:other' },
+      },
+      { authenticated: true, audiences: ['other-audience'], user: { username: lifecycleCommandServiceAccount } },
+    ]
+    const client = HttpClient.make((request) => {
+      requests.push({ authorization: request.headers['authorization'], body: requestBody(request) })
+      const identity = identities.shift()
+      if (identity === undefined) return Effect.die(new Error('unexpected TokenReview request'))
+      return Effect.succeed(tokenReviewResponse(request, identity))
+    })
+
+    try {
+      const authorized = await Effect.runPromise(
+        Effect.all([
+          makeLifecycleCommandAuthenticator(config, client)('worker-token'),
+          makeLifecycleCommandAuthenticator(config, client)('wrong-worker'),
+          makeLifecycleCommandAuthenticator(config, client)('wrong-audience'),
+        ]),
+      )
+
+      expect(authorized).toEqual([true, false, false])
+      expect(requests).toEqual(
+        Array.from({ length: 3 }, (_unused, index) => ({
+          authorization: 'Bearer reviewer-token',
+          body: {
+            apiVersion: 'authentication.k8s.io/v1',
+            kind: 'TokenReview',
+            spec: {
+              token: ['worker-token', 'wrong-worker', 'wrong-audience'][index],
+              audiences: [lifecycleCommandTokenAudience],
+            },
+          },
+        })),
+      )
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+
+  test('fails closed on malformed bearer headers and TokenReview outages', async () => {
+    expect(bearerToken(undefined)).toBeNull()
+    expect(bearerToken('Basic token')).toBeNull()
+    expect(bearerToken('Bearer token extra')).toBeNull()
+    expect(bearerToken('Bearer projected-token')).toBe('projected-token')
+
+    const directory = await mkdtemp(join(tmpdir(), 'bayn-lifecycle-auth-'))
+    const reviewerTokenPath = join(directory, 'token')
+    await writeFile(reviewerTokenPath, 'reviewer-token', { mode: 0o600 })
+    const client = HttpClient.make((request) => Effect.succeed(tokenReviewResponse(request, {}, 503)))
+    try {
+      const exit = await Effect.runPromise(
+        makeLifecycleCommandAuthenticator(
+          {
+            apiOrigin: 'https://kubernetes.default.svc.cluster.local',
+            caPath: join(directory, 'ca.crt'),
+            reviewerTokenPath,
+            audience: lifecycleCommandTokenAudience,
+            expectedUsername: lifecycleCommandServiceAccount,
+          },
+          client,
+        )('worker-token').pipe(Effect.exit),
+      )
+      expect(Exit.isFailure(exit)).toBe(true)
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+})

--- a/services/bayn/src/lifecycle-command-auth.ts
+++ b/services/bayn/src/lifecycle-command-auth.ts
@@ -1,0 +1,169 @@
+import { readFile } from 'node:fs/promises'
+
+import { NodeHttpClient } from '@effect/platform-node'
+import { Data, Effect, Schema, type Scope } from 'effect'
+import { HttpClient, HttpClientRequest, HttpClientResponse } from 'effect/unstable/http'
+
+const maximumServiceAccountTokenBytes = 16_384
+
+export const lifecycleCommandTokenAudience = 'bayn.proompteng.ai/lifecycle-command'
+export const lifecycleCommandServiceAccount = 'system:serviceaccount:bayn:bayn-lifecycle'
+
+export const kubernetesLifecycleCommandAuthentication = {
+  apiOrigin: 'https://kubernetes.default.svc.cluster.local',
+  caPath: '/var/run/secrets/bayn-lifecycle-reviewer/ca.crt',
+  reviewerTokenPath: '/var/run/secrets/bayn-lifecycle-reviewer/token',
+  audience: lifecycleCommandTokenAudience,
+  expectedUsername: lifecycleCommandServiceAccount,
+} as const
+
+export interface LifecycleCommandAuthenticationConfig {
+  readonly apiOrigin: string
+  readonly caPath: string
+  readonly reviewerTokenPath: string
+  readonly audience: string
+  readonly expectedUsername: string
+}
+
+export class LifecycleCommandAuthenticationError extends Data.TaggedError('LifecycleCommandAuthenticationError')<{
+  readonly operation: 'configuration' | 'token-review'
+  readonly message: string
+  readonly cause?: unknown
+}> {}
+
+export type LifecycleCommandAuthenticator = (
+  presentedToken: string,
+) => Effect.Effect<boolean, LifecycleCommandAuthenticationError>
+
+const TokenReviewResponseSchema = Schema.Struct({
+  status: Schema.optional(
+    Schema.Struct({
+      authenticated: Schema.optional(Schema.Boolean),
+      audiences: Schema.optional(Schema.Array(Schema.String)),
+      user: Schema.optional(
+        Schema.Struct({
+          username: Schema.optional(Schema.String),
+        }),
+      ),
+    }),
+  ),
+})
+
+const decodeTokenReviewResponse = HttpClientResponse.schemaBodyJson(TokenReviewResponseSchema)
+
+const requiredToken = (
+  source: string,
+  operation: LifecycleCommandAuthenticationError['operation'],
+  description: string,
+): Effect.Effect<string, LifecycleCommandAuthenticationError> => {
+  const token = source.trim()
+  return token.length > 0 && Buffer.byteLength(token, 'utf8') <= maximumServiceAccountTokenBytes
+    ? Effect.succeed(token)
+    : Effect.fail(
+        new LifecycleCommandAuthenticationError({
+          operation,
+          message: `${description} is empty or exceeds the bounded token size`,
+        }),
+      )
+}
+
+export const bearerToken = (authorization: string | undefined): string | null => {
+  if (authorization === undefined || authorization.length > maximumServiceAccountTokenBytes + 7) return null
+  const matched = /^Bearer ([^\s,]+)$/i.exec(authorization)
+  return matched?.[1] ?? null
+}
+
+const readRequiredFile = (
+  path: string,
+  operation: LifecycleCommandAuthenticationError['operation'],
+  message: string,
+): Effect.Effect<string, LifecycleCommandAuthenticationError> =>
+  Effect.tryPromise({
+    try: (signal) => readFile(path, { encoding: 'utf8', signal }),
+    catch: (cause) => new LifecycleCommandAuthenticationError({ operation, message, cause }),
+  })
+
+export const makeLifecycleCommandAuthenticator =
+  (config: LifecycleCommandAuthenticationConfig, client: HttpClient.HttpClient): LifecycleCommandAuthenticator =>
+  (presentedToken) =>
+    Effect.gen(function* () {
+      const reviewerTokenSource = yield* readRequiredFile(
+        config.reviewerTokenPath,
+        'token-review',
+        'Kubernetes reviewer credential is unavailable',
+      )
+      const reviewerToken = yield* requiredToken(reviewerTokenSource, 'token-review', 'Kubernetes reviewer credential')
+      const boundedPresentedToken = yield* requiredToken(
+        presentedToken,
+        'token-review',
+        'presented lifecycle credential',
+      )
+      const request = yield* HttpClientRequest.bodyJson(
+        HttpClientRequest.post(`${config.apiOrigin}/apis/authentication.k8s.io/v1/tokenreviews`, {
+          acceptJson: true,
+          headers: { authorization: `Bearer ${reviewerToken}` },
+        }),
+        {
+          apiVersion: 'authentication.k8s.io/v1',
+          kind: 'TokenReview',
+          spec: { token: boundedPresentedToken, audiences: [config.audience] },
+        },
+      ).pipe(
+        Effect.mapError(
+          (cause) =>
+            new LifecycleCommandAuthenticationError({
+              operation: 'token-review',
+              message: 'Kubernetes TokenReview request encoding failed',
+              cause,
+            }),
+        ),
+      )
+      const response = yield* client.execute(request).pipe(
+        Effect.timeout('5 seconds'),
+        Effect.mapError(
+          (cause) =>
+            new LifecycleCommandAuthenticationError({
+              operation: 'token-review',
+              message: 'Kubernetes TokenReview request failed',
+              cause,
+            }),
+        ),
+      )
+      if (response.status !== 200 && response.status !== 201) {
+        return yield* new LifecycleCommandAuthenticationError({
+          operation: 'token-review',
+          message: `Kubernetes TokenReview returned HTTP ${response.status.toString()}`,
+        })
+      }
+      const reviewed = yield* decodeTokenReviewResponse(response).pipe(
+        Effect.mapError(
+          (cause) =>
+            new LifecycleCommandAuthenticationError({
+              operation: 'token-review',
+              message: 'Kubernetes TokenReview response failed validation',
+              cause,
+            }),
+        ),
+      )
+      return (
+        reviewed.status?.authenticated === true &&
+        reviewed.status.user?.username === config.expectedUsername &&
+        reviewed.status.audiences?.includes(config.audience) === true
+      )
+    })
+
+export const acquireKubernetesLifecycleCommandAuthenticator = (
+  config: LifecycleCommandAuthenticationConfig = kubernetesLifecycleCommandAuthentication,
+): Effect.Effect<LifecycleCommandAuthenticator, LifecycleCommandAuthenticationError, Scope.Scope> =>
+  Effect.gen(function* () {
+    const ca = yield* readRequiredFile(config.caPath, 'configuration', 'Kubernetes TokenReview CA is unavailable')
+    if (ca.trim().length === 0) {
+      return yield* new LifecycleCommandAuthenticationError({
+        operation: 'configuration',
+        message: 'Kubernetes TokenReview CA is empty',
+      })
+    }
+    const agents = yield* NodeHttpClient.makeAgent({ ca })
+    const client = yield* NodeHttpClient.makeNodeHttp.pipe(Effect.provideService(NodeHttpClient.HttpAgent, agents))
+    return makeLifecycleCommandAuthenticator(config, client)
+  })

--- a/services/bayn/src/lifecycle-command-contract.test.ts
+++ b/services/bayn/src/lifecycle-command-contract.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from 'bun:test'
+
+import { decideLifecycleCommand, lifecycleCommandId } from './lifecycle-command-contract'
+
+describe('Bayn lifecycle command contract', () => {
+  const sourceRevision = 'a'.repeat(40)
+  const command = {
+    schemaVersion: 'bayn.lifecycle-command.v1' as const,
+    controllerKey: 'primary',
+    commandId: lifecycleCommandId('primary', 7),
+    sequence: 7,
+    issuedAt: '2026-08-10T12:00:00.000Z',
+    sourceRevision,
+  }
+
+  test('accepts only the exact deterministic controller command identity', () => {
+    expect(decideLifecycleCommand('primary', [sourceRevision], command)).toEqual({
+      _tag: 'Accept',
+      sourceRevision,
+      command: {
+        controllerKey: command.controllerKey,
+        commandId: command.commandId,
+        sequence: command.sequence,
+        issuedAt: command.issuedAt,
+      },
+    })
+    expect(decideLifecycleCommand('other', [sourceRevision], command)).toEqual({
+      _tag: 'Reject',
+      status: 403,
+      reason: 'CONTROLLER_MISMATCH',
+    })
+    expect(decideLifecycleCommand('primary', [sourceRevision], { ...command, commandId: '0'.repeat(64) })).toEqual({
+      _tag: 'Reject',
+      status: 403,
+      reason: 'CONTROLLER_MISMATCH',
+    })
+    expect(decideLifecycleCommand('primary', ['b'.repeat(40)], command)).toEqual({
+      _tag: 'Reject',
+      status: 503,
+      reason: 'SOURCE_REVISION_MISMATCH',
+    })
+  })
+
+  test('rejects malformed and unbounded command input without coercion', () => {
+    expect(decideLifecycleCommand('primary', [sourceRevision], { ...command, sequence: 0 })).toEqual({
+      _tag: 'Reject',
+      status: 400,
+      reason: 'INVALID_COMMAND',
+    })
+    expect(decideLifecycleCommand('primary', [sourceRevision], { ...command, extra: true })).toEqual({
+      _tag: 'Reject',
+      status: 400,
+      reason: 'INVALID_COMMAND',
+    })
+  })
+})

--- a/services/bayn/src/lifecycle-command-contract.ts
+++ b/services/bayn/src/lifecycle-command-contract.ts
@@ -1,0 +1,64 @@
+import { createHash } from 'node:crypto'
+
+import { Result, Schema } from 'effect'
+
+import { GitSourceRevisionSchema, Sha256Schema, UtcInstantSchema, strictParseOptions } from './schemas'
+
+export const LifecycleControllerKeySchema = Schema.Trim.check(Schema.isPattern(/^[a-z0-9][a-z0-9._-]{0,63}$/))
+export const LifecycleSequenceSchema = Schema.Int.check(
+  Schema.isBetween({ minimum: 1, maximum: Number.MAX_SAFE_INTEGER }),
+)
+
+export const LifecycleCommandSchema = Schema.Struct({
+  schemaVersion: Schema.Literal('bayn.lifecycle-command.v1'),
+  controllerKey: LifecycleControllerKeySchema,
+  commandId: Sha256Schema,
+  sequence: LifecycleSequenceSchema,
+  issuedAt: UtcInstantSchema,
+})
+
+export type LifecycleCommand = Omit<typeof LifecycleCommandSchema.Type, 'schemaVersion'>
+
+export const LifecycleCommandRequestSchema = Schema.Struct({
+  ...LifecycleCommandSchema.fields,
+  sourceRevision: GitSourceRevisionSchema,
+})
+
+const decodeLifecycleCommandRequest = Schema.decodeUnknownResult(LifecycleCommandRequestSchema, strictParseOptions)
+
+export const lifecycleCommandId = (controllerKey: string, sequence: number): string =>
+  createHash('sha256').update(`bayn/lifecycle-command/v1/${controllerKey}/${sequence}`).digest('hex')
+
+export type LifecycleCommandDecision =
+  | { readonly _tag: 'Accept'; readonly command: LifecycleCommand; readonly sourceRevision: string }
+  | {
+      readonly _tag: 'Reject'
+      readonly status: 400 | 403 | 503
+      readonly reason: 'INVALID_COMMAND' | 'CONTROLLER_MISMATCH' | 'SOURCE_REVISION_MISMATCH'
+    }
+
+export const decideLifecycleCommand = (
+  expectedControllerKey: string,
+  acceptedSourceRevisions: readonly string[],
+  candidate: unknown,
+): LifecycleCommandDecision => {
+  const decoded = decodeLifecycleCommandRequest(candidate)
+  if (Result.isFailure(decoded)) return { _tag: 'Reject', status: 400, reason: 'INVALID_COMMAND' }
+  const request = decoded.success
+  const command: LifecycleCommand = {
+    controllerKey: request.controllerKey,
+    commandId: request.commandId,
+    sequence: request.sequence,
+    issuedAt: request.issuedAt,
+  }
+  if (
+    command.controllerKey !== expectedControllerKey ||
+    command.commandId !== lifecycleCommandId(command.controllerKey, command.sequence)
+  ) {
+    return { _tag: 'Reject', status: 403, reason: 'CONTROLLER_MISMATCH' }
+  }
+  if (!acceptedSourceRevisions.includes(request.sourceRevision)) {
+    return { _tag: 'Reject', status: 503, reason: 'SOURCE_REVISION_MISMATCH' }
+  }
+  return { _tag: 'Accept', command, sourceRevision: request.sourceRevision }
+}

--- a/services/bayn/src/lifecycle-command-http.test.ts
+++ b/services/bayn/src/lifecycle-command-http.test.ts
@@ -1,0 +1,399 @@
+import { describe, expect, test } from 'bun:test'
+import { createServer as createNodeServer } from 'node:http'
+import type { AddressInfo } from 'node:net'
+
+import { Data, Effect, Exit, Fiber } from 'effect'
+
+import type { LifecycleCommandStoreShape } from './db/lifecycle-command'
+import type { WriterFenceService } from './execution/writer-fence'
+import { executeLifecycleCommand, type LifecycleCommandAdvance, serveLifecycleCommands } from './lifecycle-command-http'
+import { lifecycleCommandId } from './lifecycle-command-contract'
+
+const command = {
+  controllerKey: 'primary',
+  commandId: 'a'.repeat(64),
+  sequence: 1,
+  issuedAt: '2026-08-10T20:00:00.000Z',
+}
+
+const observation = {
+  result: 'SUCCESS' as const,
+  outcome: 'NOT_DUE' as const,
+  observedAt: '2026-08-10T20:00:01.000Z',
+}
+
+const lifecycleToken = 'projected-lifecycle-token'
+const lifecycleAuthorization = { authorization: `Bearer ${lifecycleToken}` }
+const authenticateLifecycle = (token: string) => Effect.succeed(token === lifecycleToken)
+
+const makeFence = (transactions: string[]): WriterFenceService => {
+  const transaction: WriterFenceService['transaction'] = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+    Effect.sync(() => transactions.push('transaction')).pipe(Effect.andThen(effect))
+  return { backendPid: 7, check: Effect.void, transaction }
+}
+
+class AdvanceFailure extends Data.TaggedError('AdvanceFailure')<{}> {}
+
+const reservePort = (): Promise<number> =>
+  new Promise((resolve, reject) => {
+    const server = createNodeServer()
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address() as AddressInfo
+      server.close((cause) => (cause === undefined ? resolve(address.port) : reject(cause)))
+    })
+  })
+
+const waitForServer = async (origin: string): Promise<void> => {
+  for (let attempt = 0; attempt < 50; attempt += 1) {
+    try {
+      const response = await fetch(`${origin}/livez`, { signal: AbortSignal.timeout(100) })
+      if (response.ok) return
+    } catch {
+      // The scoped server fiber may not have bound its socket yet.
+    }
+    await Bun.sleep(10)
+  }
+  throw new Error('lifecycle command server did not listen')
+}
+
+describe('Bayn lifecycle command execution', () => {
+  test('durably begins, advances once, and completes a fresh command under the writer fence', async () => {
+    const calls: string[] = []
+    const store: LifecycleCommandStoreShape = {
+      readCursor: () => Effect.die(new Error('cursor is outside this boundary')),
+      begin: (input) =>
+        Effect.sync(() => {
+          calls.push(`begin:${input.sequence}`)
+          return { _tag: 'Execute' as const }
+        }),
+      complete: (input) =>
+        Effect.sync(() => {
+          calls.push(`complete:${input.sequence}`)
+          expect(input.observation).toEqual(observation)
+          return input.observation
+        }),
+    }
+
+    const receipt = await Effect.runPromise(
+      executeLifecycleCommand(
+        store,
+        makeFence(calls),
+        command,
+        Effect.sync(() => {
+          calls.push('advance')
+          return { observation }
+        }),
+      ),
+    )
+
+    expect(receipt).toEqual({ observation, replayed: false })
+    expect(calls).toEqual(['transaction', 'begin:1', 'advance', 'transaction', 'complete:1'])
+  })
+
+  test('replays a completed receipt without advancing the lifecycle again', async () => {
+    const calls: string[] = []
+    const store: LifecycleCommandStoreShape = {
+      readCursor: () => Effect.die(new Error('cursor is outside this boundary')),
+      begin: () => Effect.succeed({ _tag: 'Completed', observation }),
+      complete: () => Effect.die(new Error('completed commands must not be completed twice')),
+    }
+
+    const receipt = await Effect.runPromise(
+      executeLifecycleCommand(
+        store,
+        makeFence(calls),
+        command,
+        Effect.die(new Error('completed commands must not advance twice')),
+      ),
+    )
+
+    expect(receipt).toEqual({ observation, replayed: true })
+    expect(calls).toEqual(['transaction'])
+  })
+
+  test('leaves a started command incomplete when the one-pass interpreter fails', async () => {
+    const calls: string[] = []
+    const store: LifecycleCommandStoreShape = {
+      readCursor: () => Effect.die(new Error('cursor is outside this boundary')),
+      begin: () => Effect.succeed({ _tag: 'Execute' }),
+      complete: () =>
+        Effect.sync(() => {
+          calls.push('complete')
+          return observation
+        }),
+    }
+
+    const exit = await Effect.runPromiseExit(
+      executeLifecycleCommand(store, makeFence(calls), command, Effect.fail(new AdvanceFailure())),
+    )
+
+    expect(Exit.isFailure(exit)).toBe(true)
+    expect(calls).toEqual(['transaction'])
+  })
+
+  test('accepts only current and one prior rollout revision before advancing an exact bound command', async () => {
+    const port = await reservePort()
+    const sourceRevision = 'a'.repeat(40)
+    const calls: Array<{ readonly operation: string; readonly input: unknown }> = []
+    const store: LifecycleCommandStoreShape = {
+      readCursor: () => Effect.succeed({ _tag: 'Next', sequence: 1 }),
+      begin: (input) =>
+        Effect.sync(() => {
+          calls.push({ operation: 'begin', input })
+          return { _tag: 'Execute' as const }
+        }),
+      complete: (input) =>
+        Effect.sync(() => {
+          calls.push({ operation: 'complete', input })
+          return input.observation
+        }),
+    }
+    const advance = Effect.sync(() => {
+      calls.push({ operation: 'advance', input: null })
+      return { observation }
+    })
+
+    await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          yield* serveLifecycleCommands(
+            {
+              host: '127.0.0.1',
+              port,
+              controllerKey: 'primary',
+              sourceRevision,
+              previousSourceRevision: 'b'.repeat(40),
+              nextDelayMs: 30_000,
+            },
+            store,
+            makeFence([]),
+            authenticateLifecycle,
+            advance,
+          ).pipe(Effect.forkScoped({ startImmediately: true }))
+          const origin = `http://127.0.0.1:${port}`
+          yield* Effect.promise(() => waitForServer(origin))
+
+          const unauthenticated = yield* Effect.promise(() => fetch(`${origin}/v1/lifecycle/cursor`))
+          expect(unauthenticated.status).toBe(401)
+          const unauthenticatedBody = yield* Effect.promise(() => unauthenticated.json())
+          expect(unauthenticatedBody).toEqual({ accepted: false, reason: 'AUTHENTICATION_REQUIRED' })
+
+          const forged = yield* Effect.promise(() =>
+            fetch(`${origin}/v1/lifecycle/cursor`, { headers: { authorization: 'Bearer forged-token' } }),
+          )
+          expect(forged.status).toBe(403)
+          const forgedBody = yield* Effect.promise(() => forged.json())
+          expect(forgedBody).toEqual({ accepted: false, reason: 'AUTHENTICATION_REJECTED' })
+          expect(calls).toEqual([])
+
+          const cursor = yield* Effect.promise(() =>
+            fetch(`${origin}/v1/lifecycle/cursor`, { headers: lifecycleAuthorization }).then((response) =>
+              response.json(),
+            ),
+          )
+          expect(cursor).toEqual({
+            schemaVersion: 'bayn.lifecycle-command-cursor.v1',
+            controllerKey: 'primary',
+            sourceRevision,
+            cursor: { _tag: 'Next', sequence: 1 },
+          })
+
+          const request = {
+            schemaVersion: 'bayn.lifecycle-command.v1',
+            controllerKey: 'primary',
+            commandId: lifecycleCommandId('primary', 1),
+            sequence: 1,
+            issuedAt: command.issuedAt,
+          } as const
+          const mismatched = yield* Effect.promise(() =>
+            fetch(`${origin}/v1/lifecycle/advance`, {
+              method: 'POST',
+              headers: { ...lifecycleAuthorization, 'content-type': 'application/json' },
+              body: JSON.stringify({ ...request, sourceRevision: 'c'.repeat(40) }),
+            }),
+          )
+          expect(mismatched.status).toBe(503)
+          const mismatchedBody = yield* Effect.promise(() => mismatched.json())
+          expect(mismatchedBody).toEqual({ accepted: false, reason: 'SOURCE_REVISION_MISMATCH' })
+          expect(calls).toEqual([])
+
+          const accepted = yield* Effect.promise(() =>
+            fetch(`${origin}/v1/lifecycle/advance`, {
+              method: 'POST',
+              headers: { ...lifecycleAuthorization, 'content-type': 'application/json' },
+              body: JSON.stringify({ ...request, sourceRevision: 'b'.repeat(40) }),
+            }),
+          )
+          expect(accepted.status).toBe(200)
+          const acceptedBody = yield* Effect.promise(() => accepted.json())
+          expect(acceptedBody).toEqual({
+            schemaVersion: 'bayn.lifecycle-command-response.v1',
+            accepted: true,
+            commandId: request.commandId,
+            sequence: 1,
+            sourceRevision: 'b'.repeat(40),
+            replayed: false,
+            nextDelayMs: 30_000,
+            observation,
+          })
+          expect(calls.map(({ operation }) => operation)).toEqual(['begin', 'advance', 'complete'])
+          expect(calls[0]?.input).toEqual({
+            controllerKey: 'primary',
+            commandId: request.commandId,
+            sequence: 1,
+            issuedAt: command.issuedAt,
+          })
+        }),
+      ),
+    )
+  }, 10_000)
+
+  test('serializes a timed-out command and its retry so the one-pass interpreter advances once', async () => {
+    const port = await reservePort()
+    const sourceRevision = 'a'.repeat(40)
+    let completed = false
+    let advanceCount = 0
+    let releaseAdvance: (() => void) | undefined
+    const store: LifecycleCommandStoreShape = {
+      readCursor: () => Effect.succeed({ _tag: 'Next', sequence: 1 }),
+      begin: () => Effect.sync(() => (completed ? { _tag: 'Completed', observation } : { _tag: 'Execute' })),
+      complete: (input) =>
+        Effect.sync(() => {
+          completed = true
+          return input.observation
+        }),
+    }
+    const request = {
+      schemaVersion: 'bayn.lifecycle-command.v1',
+      controllerKey: 'primary',
+      commandId: lifecycleCommandId('primary', 1),
+      sequence: 1,
+      issuedAt: command.issuedAt,
+      sourceRevision,
+    } as const
+
+    await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          yield* serveLifecycleCommands(
+            {
+              host: '127.0.0.1',
+              port,
+              controllerKey: 'primary',
+              sourceRevision,
+              previousSourceRevision: undefined,
+              nextDelayMs: 30_000,
+            },
+            store,
+            makeFence([]),
+            authenticateLifecycle,
+            Effect.callback<LifecycleCommandAdvance>((resume) => {
+              advanceCount += 1
+              releaseAdvance = () => resume(Effect.succeed({ observation }))
+            }),
+          ).pipe(Effect.forkScoped({ startImmediately: true }))
+          const origin = `http://127.0.0.1:${port}`
+          yield* Effect.promise(() => waitForServer(origin))
+
+          const send = () =>
+            fetch(`${origin}/v1/lifecycle/advance`, {
+              method: 'POST',
+              headers: { ...lifecycleAuthorization, 'content-type': 'application/json' },
+              body: JSON.stringify(request),
+            })
+          const first = send()
+          while (advanceCount === 0) yield* Effect.sleep('1 millis')
+          const retry = send()
+          yield* Effect.sleep('10 millis')
+          expect(advanceCount).toBe(1)
+          releaseAdvance?.()
+
+          const responses = yield* Effect.promise(() => Promise.all([first, retry]))
+          const bodies = yield* Effect.promise(() => Promise.all(responses.map((response) => response.json())))
+          expect(responses.map((response) => response.status)).toEqual([200, 200])
+          expect(advanceCount).toBe(1)
+          expect(bodies.map((body) => body.replayed)).toEqual([false, true])
+        }),
+      ),
+    )
+  }, 10_000)
+
+  test('interrupts and joins an in-flight command before closing the server', async () => {
+    const port = await reservePort()
+    const sourceRevision = 'a'.repeat(40)
+    let releaseStarted: (() => void) | undefined
+    const started = new Promise<void>((resolve) => {
+      releaseStarted = resolve
+    })
+    let interrupted = false
+    let completed = false
+    const store: LifecycleCommandStoreShape = {
+      readCursor: () => Effect.succeed({ _tag: 'Next', sequence: 1 }),
+      begin: () => Effect.succeed({ _tag: 'Execute' }),
+      complete: () =>
+        Effect.sync(() => {
+          completed = true
+          return observation
+        }),
+    }
+    const advance = Effect.callback<LifecycleCommandAdvance>((_resume) => {
+      releaseStarted?.()
+      return Effect.sync(() => {
+        interrupted = true
+      })
+    })
+    const request = {
+      schemaVersion: 'bayn.lifecycle-command.v1',
+      controllerKey: 'primary',
+      commandId: lifecycleCommandId('primary', 1),
+      sequence: 1,
+      issuedAt: command.issuedAt,
+      sourceRevision,
+    } as const
+
+    await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const serverFiber = yield* serveLifecycleCommands(
+            {
+              host: '127.0.0.1',
+              port,
+              controllerKey: 'primary',
+              sourceRevision,
+              previousSourceRevision: undefined,
+              nextDelayMs: 30_000,
+            },
+            store,
+            makeFence([]),
+            authenticateLifecycle,
+            advance,
+          ).pipe(Effect.forkScoped({ startImmediately: true }))
+          const origin = `http://127.0.0.1:${port}`
+          yield* Effect.promise(() => waitForServer(origin))
+          const pendingRequest = fetch(`${origin}/v1/lifecycle/advance`, {
+            method: 'POST',
+            headers: { ...lifecycleAuthorization, 'content-type': 'application/json' },
+            body: JSON.stringify(request),
+          }).then(
+            () => 'response' as const,
+            () => 'closed' as const,
+          )
+          const startOutcome = yield* Effect.promise(() =>
+            Promise.race([started.then(() => 'started' as const), Bun.sleep(1_000).then(() => 'timeout' as const)]),
+          )
+          expect(startOutcome).toBe('started')
+
+          yield* Fiber.interrupt(serverFiber)
+
+          const requestOutcome = yield* Effect.promise(() =>
+            Promise.race([pendingRequest, Bun.sleep(1_000).then(() => 'timeout' as const)]),
+          )
+          expect(requestOutcome).toBe('closed')
+          expect(interrupted).toBe(true)
+          expect(completed).toBe(false)
+        }),
+      ),
+    )
+  }, 10_000)
+})

--- a/services/bayn/src/lifecycle-command-http.ts
+++ b/services/bayn/src/lifecycle-command-http.ts
@@ -1,0 +1,296 @@
+import { createServer } from 'node:http'
+import type { Socket } from 'node:net'
+
+import { NodeHttpServer } from '@effect/platform-node'
+import { Cause, Data, Effect, Exit, FileSystem, Scope, Semaphore } from 'effect'
+import { HttpServerRequest, HttpServerResponse } from 'effect/unstable/http'
+import type { ServeError } from 'effect/unstable/http/HttpServerError'
+
+import type { LifecycleCommandStoreShape } from './db/lifecycle-command'
+import type { WriterFenceService } from './execution/writer-fence'
+import { bearerToken, type LifecycleCommandAuthenticator } from './lifecycle-command-auth'
+import { decideLifecycleCommand } from './lifecycle-command-contract'
+import type { AutonomousCyclePassObservation } from './runtime-state'
+import { currentUtcInstant } from './time'
+import type { CycleRunnerError } from './cycle-runner'
+
+export interface LifecycleCommandServerConfig {
+  readonly host: string
+  readonly port: number
+  readonly controllerKey: string
+  readonly sourceRevision: string
+  readonly previousSourceRevision: string | undefined
+  readonly nextDelayMs: number
+}
+
+export interface LifecycleCommandExecutionReceipt {
+  readonly observation: AutonomousCyclePassObservation
+  readonly replayed: boolean
+}
+
+export interface LifecycleCommandAdvance {
+  readonly observation: AutonomousCyclePassObservation
+}
+
+export const executeLifecycleCommand = <E, R>(
+  store: LifecycleCommandStoreShape,
+  fence: WriterFenceService,
+  command: {
+    readonly controllerKey: string
+    readonly commandId: string
+    readonly sequence: number
+    readonly issuedAt: string
+  },
+  advance: Effect.Effect<LifecycleCommandAdvance, E, R>,
+): Effect.Effect<
+  LifecycleCommandExecutionReceipt,
+  E | import('./db/lifecycle-command').LifecycleCommandStoreError | import('./execution/writer-fence').WriterFenceError,
+  R
+> =>
+  fence.transaction(store.begin(command)).pipe(
+    Effect.flatMap((receipt) => {
+      if (receipt._tag === 'Completed') {
+        const replayed: LifecycleCommandExecutionReceipt = {
+          observation: receipt.observation,
+          replayed: true,
+        }
+        return Effect.logInfo('Bayn lifecycle command replayed from durable completion').pipe(
+          Effect.annotateLogs({
+            controllerKey: command.controllerKey,
+            commandId: command.commandId,
+            commandSequence: command.sequence,
+            commandResult: receipt.observation.result,
+          }),
+          Effect.as(replayed),
+        )
+      }
+      return advance.pipe(
+        Effect.flatMap((advanced) =>
+          currentUtcInstant.pipe(
+            Effect.flatMap((completedAt) =>
+              fence.transaction(store.complete({ ...command, completedAt, observation: advanced.observation })),
+            ),
+          ),
+        ),
+        Effect.tap((observation) =>
+          Effect.logInfo('Bayn lifecycle command completed').pipe(
+            Effect.annotateLogs({
+              controllerKey: command.controllerKey,
+              commandId: command.commandId,
+              commandSequence: command.sequence,
+              commandResult: observation.result,
+            }),
+          ),
+        ),
+        Effect.map(
+          (observation): LifecycleCommandExecutionReceipt => ({
+            observation,
+            replayed: false,
+          }),
+        ),
+      )
+    }),
+  )
+
+class LifecycleCommandHttpError extends Data.TaggedError('LifecycleCommandHttpError')<{
+  readonly reason: 'INVALID_JSON'
+  readonly message: string
+  readonly cause?: unknown
+}> {}
+
+const maximumCommandBytes = 4_096
+
+const jsonResponse = (status: number, body: unknown): Effect.Effect<HttpServerResponse.HttpServerResponse> =>
+  HttpServerResponse.json(body, {
+    status,
+    headers: { 'cache-control': 'no-store', connection: 'close' },
+  }).pipe(Effect.orDie)
+
+const readJsonBody = (
+  request: HttpServerRequest.HttpServerRequest,
+): Effect.Effect<unknown, LifecycleCommandHttpError> => {
+  const declaredLength = Number.parseInt(request.headers['content-length'] ?? '0', 10)
+  if (Number.isFinite(declaredLength) && declaredLength > maximumCommandBytes) {
+    return Effect.fail(new LifecycleCommandHttpError({ reason: 'INVALID_JSON', message: 'command body exceeds limit' }))
+  }
+  return request.json.pipe(
+    Effect.provideService(HttpServerRequest.MaxBodySize, FileSystem.Size(maximumCommandBytes)),
+    Effect.mapError(
+      (cause) =>
+        new LifecycleCommandHttpError({
+          reason: 'INVALID_JSON',
+          message: 'command body is not valid bounded JSON',
+          cause,
+        }),
+    ),
+  )
+}
+
+const authenticateRequest = (
+  authorization: string | undefined,
+  authenticate: LifecycleCommandAuthenticator,
+): Effect.Effect<
+  | { readonly _tag: 'Authorized' }
+  | { readonly _tag: 'Rejected'; readonly status: 401 | 403 | 503; readonly reason: string },
+  never
+> => {
+  const token = bearerToken(authorization)
+  if (token === null) {
+    return Effect.succeed({ _tag: 'Rejected', status: 401, reason: 'AUTHENTICATION_REQUIRED' })
+  }
+  return authenticate(token).pipe(
+    Effect.map((authorized) =>
+      authorized
+        ? ({ _tag: 'Authorized' } as const)
+        : ({ _tag: 'Rejected', status: 403, reason: 'AUTHENTICATION_REJECTED' } as const),
+    ),
+    Effect.catch((cause) =>
+      Effect.logError('Bayn lifecycle command authentication failed', cause).pipe(
+        Effect.andThen(
+          Effect.succeed({ _tag: 'Rejected', status: 503, reason: 'AUTHENTICATION_UNAVAILABLE' } as const),
+        ),
+      ),
+    ),
+  )
+}
+
+const handleRequest = <R>(
+  config: LifecycleCommandServerConfig,
+  store: LifecycleCommandStoreShape,
+  fence: WriterFenceService,
+  commandPermit: Semaphore.Semaphore,
+  authenticate: LifecycleCommandAuthenticator,
+  advance: Effect.Effect<LifecycleCommandAdvance, CycleRunnerError, R>,
+): Effect.Effect<HttpServerResponse.HttpServerResponse, never, HttpServerRequest.HttpServerRequest | R> =>
+  HttpServerRequest.HttpServerRequest.pipe(
+    Effect.flatMap((request) => {
+      if (request.method === 'GET' && request.url === '/livez') {
+        return jsonResponse(200, { service: 'bayn-lifecycle-command', live: true })
+      }
+      return authenticateRequest(request.headers['authorization'], authenticate).pipe(
+        Effect.flatMap((authentication) => {
+          if (authentication._tag === 'Rejected') {
+            return jsonResponse(authentication.status, { accepted: false, reason: authentication.reason })
+          }
+          if (request.method === 'GET' && request.url === '/v1/lifecycle/cursor') {
+            return store.readCursor(config.controllerKey).pipe(
+              Effect.flatMap((cursor) =>
+                jsonResponse(200, {
+                  schemaVersion: 'bayn.lifecycle-command-cursor.v1',
+                  controllerKey: config.controllerKey,
+                  sourceRevision: config.sourceRevision,
+                  cursor,
+                }),
+              ),
+              Effect.catch((cause) =>
+                Effect.logError('Bayn lifecycle command cursor failed', cause).pipe(
+                  Effect.annotateLogs({ controllerKey: config.controllerKey }),
+                  Effect.andThen(jsonResponse(503, { available: false, reason: 'CURSOR_FAILED' })),
+                ),
+              ),
+            )
+          }
+          if (request.method !== 'POST' || request.url !== '/v1/lifecycle/advance') {
+            return jsonResponse(404, { error: 'not found' })
+          }
+          return readJsonBody(request).pipe(
+            Effect.map((candidate) =>
+              decideLifecycleCommand(
+                config.controllerKey,
+                [
+                  config.sourceRevision,
+                  ...(config.previousSourceRevision === undefined ? [] : [config.previousSourceRevision]),
+                ],
+                candidate,
+              ),
+            ),
+            Effect.orElseSucceed(() => ({
+              _tag: 'Reject' as const,
+              status: 400 as const,
+              reason: 'INVALID_COMMAND' as const,
+            })),
+            Effect.flatMap((decision) => {
+              if (decision._tag === 'Reject') {
+                return jsonResponse(decision.status, { accepted: false, reason: decision.reason })
+              }
+              return commandPermit.withPermit(executeLifecycleCommand(store, fence, decision.command, advance)).pipe(
+                Effect.interruptible,
+                Effect.flatMap((receipt) =>
+                  jsonResponse(200, {
+                    schemaVersion: 'bayn.lifecycle-command-response.v1',
+                    accepted: true,
+                    commandId: decision.command.commandId,
+                    sequence: decision.command.sequence,
+                    sourceRevision: decision.sourceRevision,
+                    replayed: receipt.replayed,
+                    nextDelayMs: config.nextDelayMs,
+                    observation: receipt.observation,
+                  }),
+                ),
+                Effect.catch((cause) =>
+                  Effect.logError('Bayn lifecycle command failed', cause).pipe(
+                    Effect.annotateLogs({
+                      controllerKey: decision.command.controllerKey,
+                      commandId: decision.command.commandId,
+                      commandSequence: decision.command.sequence,
+                    }),
+                    Effect.andThen(jsonResponse(503, { accepted: false, reason: 'COMMAND_FAILED' })),
+                  ),
+                ),
+              )
+            }),
+          )
+        }),
+      )
+    }),
+    Effect.catchCause((cause) =>
+      Cause.hasInterruptsOnly(cause)
+        ? Effect.failCause(cause)
+        : Effect.logError('Bayn lifecycle command handler defect', cause).pipe(
+            Effect.andThen(jsonResponse(500, { accepted: false, reason: 'INTERNAL_ERROR' })),
+          ),
+    ),
+  )
+
+export const serveLifecycleCommands = <R>(
+  config: LifecycleCommandServerConfig,
+  store: LifecycleCommandStoreShape,
+  fence: WriterFenceService,
+  authenticate: LifecycleCommandAuthenticator,
+  advance: Effect.Effect<LifecycleCommandAdvance, CycleRunnerError, R>,
+): Effect.Effect<never, ServeError, R> =>
+  Effect.gen(function* () {
+    const commandPermit = yield* Semaphore.make(1)
+    const nodeServer = createServer()
+    const sockets = new Set<Socket>()
+    nodeServer.on('connection', (socket) => {
+      sockets.add(socket)
+      socket.once('close', () => sockets.delete(socket))
+    })
+    yield* NodeHttpServer.make(() => nodeServer, {
+      host: config.host,
+      port: config.port,
+      disablePreemptiveShutdown: true,
+      gracefulShutdownTimeout: '5 seconds',
+    })
+    const requestScope = yield* Scope.make('parallel')
+    const handler = yield* NodeHttpServer.makeHandler(
+      handleRequest(config, store, fence, commandPermit, authenticate, advance),
+      { scope: requestScope },
+    )
+    nodeServer.on('request', handler)
+    yield* Effect.logInfo('Bayn lifecycle command server is listening').pipe(
+      Effect.annotateLogs({ controllerKey: config.controllerKey, host: config.host, port: config.port }),
+    )
+    // The official Effect handler owns every request in requestScope. Unwinding first detaches new work, then closes
+    // that scope to interrupt and join active handlers before the official NodeHttpServer finalizer closes sockets.
+    return yield* Effect.never.pipe(
+      Effect.ensuring(
+        Effect.sync(() => {
+          nodeServer.off('request', handler)
+          for (const socket of sockets) socket.destroy()
+          nodeServer.closeAllConnections()
+        }).pipe(Effect.andThen(Scope.close(requestScope, Exit.void))),
+      ),
+    )
+  }).pipe(Effect.scoped)

--- a/services/bayn/src/observe-composition.test.ts
+++ b/services/bayn/src/observe-composition.test.ts
@@ -51,7 +51,13 @@ import {
 } from './db/execution-store'
 import { operationalError, type OperationalError } from './errors'
 import { BrokerAccess, makeExecutionAuthority, sandboxCapitalAuthority } from './execution/authority'
-import { IntentStore, planPaperIntent, type IntentStoreService, type StoredIntent } from './execution/intents'
+import {
+  IntentStore,
+  planPaperIntent,
+  type BlockedCycleIntentStoreShape,
+  type IntentStoreService,
+  type StoredIntent,
+} from './execution/intents'
 import { MutationEventType, MutationStore, type MutationEvent, type MutationStoreShape } from './execution/mutations'
 import type { ExecutionProgram } from './execution/runtime-program'
 import { WriterFence, WriterFenceError, type WriterFenceService } from './execution/writer-fence'
@@ -83,6 +89,7 @@ import {
   makeMutationAutonomousCycleStartup,
   makeObserveAutonomousCycleStartup,
   prepareObserveStartup,
+  recoveryFirstCycleNextDelayMs,
   terminalizeBlockedPaperCycle,
 } from './observe-composition'
 import {
@@ -120,6 +127,11 @@ const generationHash = 'a'.repeat(64)
 const accountingHash = 'b'.repeat(64)
 const reconciledAt = '2020-05-01T12:45:01.000Z'
 const evaluatedAt = '2020-05-01T12:45:02.000Z'
+
+test('external lifecycle ownership never schedules past the reconciliation cadence', () => {
+  expect(recoveryFirstCycleNextDelayMs({ pollIntervalMs: 300_000, reconciliationIntervalMs: 30_000 })).toBe(30_000)
+  expect(recoveryFirstCycleNextDelayMs({ pollIntervalMs: 15_000, reconciliationIntervalMs: 30_000 })).toBe(15_000)
+})
 
 test('PAPER submissions obey separate entry and final close-session cutoffs', () => {
   expect(
@@ -1776,15 +1788,28 @@ describe('OBSERVE runtime composition', () => {
           events.push('fence')
         }).pipe(Effect.andThen(effect)),
     }
+    const blockedCycleIntentStore: BlockedCycleIntentStoreShape = {
+      settleCurrentBlockedGeneration: () => Effect.die(new Error('startup recovery is outside this unit boundary')),
+      terminalizeUntouchedApproved: () =>
+        Effect.sync(() => {
+          events.push('terminalize-intents')
+          return { blockedIntentCount: 0, expiredIntentCount: 1, terminalIntentCount: 1 }
+        }),
+    }
 
     const result = await Effect.runPromise(
       Effect.gen(function* () {
         yield* TestClock.setTime(Date.parse(observedAt))
-        return yield* terminalizeBlockedPaperCycle(fixture.boundCycle, {
-          _tag: 'Block',
-          reason: CycleTerminalReason.Risk,
-          observedAt,
-        })
+        return yield* terminalizeBlockedPaperCycle(
+          fixture.boundCycle,
+          {
+            _tag: 'Block',
+            reason: CycleTerminalReason.Risk,
+            observedAt,
+          },
+          generationHash,
+          blockedCycleIntentStore,
+        )
       }).pipe(
         Effect.provideService(CycleStore, cycleStore),
         Effect.provideService(AuthorityRestrictionStore, authorityRestrictionStore),
@@ -1793,7 +1818,7 @@ describe('OBSERVE runtime composition', () => {
       ),
     )
 
-    expect(events).toEqual(['fence', 'block', 'restrict'])
+    expect(events).toEqual(['fence', 'block', 'restrict', 'terminalize-intents'])
     expect(result).toMatchObject({ action: 'BLOCKED', cycle: { state: CycleState.Blocked } })
   })
 
@@ -1833,14 +1858,23 @@ describe('OBSERVE runtime composition', () => {
       check: unused,
       transaction: (effect) => effect,
     }
+    const blockedCycleIntentStore: BlockedCycleIntentStoreShape = {
+      settleCurrentBlockedGeneration: () => Effect.die(new Error('startup recovery is outside this unit boundary')),
+      terminalizeUntouchedApproved: () => Effect.die(new Error('rejected cycle block must not terminalize intents')),
+    }
 
     const failure = await Effect.runPromise(
       Effect.flip(
-        terminalizeBlockedPaperCycle(fixture.boundCycle, {
-          _tag: 'Block',
-          reason: CycleTerminalReason.MissedSubmission,
-          observedAt,
-        }).pipe(
+        terminalizeBlockedPaperCycle(
+          fixture.boundCycle,
+          {
+            _tag: 'Block',
+            reason: CycleTerminalReason.MissedSubmission,
+            observedAt,
+          },
+          generationHash,
+          blockedCycleIntentStore,
+        ).pipe(
           Effect.provideService(CycleStore, cycleStore),
           Effect.provideService(AuthorityRestrictionStore, authorityRestrictionStore),
           Effect.provideService(WriterFence, writerFence),

--- a/services/bayn/src/observe-composition.ts
+++ b/services/bayn/src/observe-composition.ts
@@ -44,7 +44,7 @@ import { WriterFence } from './execution/writer-fence'
 import { MutationOperation } from './broker/alpaca-mutations'
 import { recover as recoverMutation } from './execution/coordinator'
 import { BrokerAccess, CapitalAuthorityKind } from './execution/authority'
-import { IntentStore } from './execution/intents'
+import { IntentStore, type BlockedCycleIntentStoreShape } from './execution/intents'
 import { MutationStore } from './execution/mutations'
 import type { ExecutionProgram } from './execution/runtime-program'
 import {
@@ -83,6 +83,7 @@ import type {
   PaperDecisionDocument,
 } from './shadow-decision-contract'
 import { currentUtcInstant, utcInstantFromEpochMillis } from './time'
+import type { AutonomousCyclePassObservation } from './runtime-state'
 import {
   planTargets,
   type SignalSessionReferencePrices,
@@ -1094,7 +1095,10 @@ export const buildClosingPaperCycleDecision = (
 const observePass = (
   recordPass: Parameters<AutonomousCycleStartup>[0]['recordPass'],
   observation: CyclePassObservation,
-) => recordPass(retainAutonomousCyclePassObservation(observation))
+): Effect.Effect<AutonomousCyclePassObservation> => {
+  const retained = retainAutonomousCyclePassObservation(observation)
+  return recordPass(retained).pipe(Effect.as(retained))
+}
 
 export type ObserveAutonomousCycleInput = {
   readonly accountId: string
@@ -1106,10 +1110,12 @@ export type ObserveAutonomousCycleInput = {
   readonly cycleCadence?: 'MONTHLY' | 'PAPER_BOOTSTRAP'
   readonly mutationPhase?: 'ENTRY' | 'CLOSE'
   readonly paperCycleClosureStore?: PaperCycleClosureStoreShape
+  readonly blockedCycleIntentStore?: BlockedCycleIntentStoreShape
   readonly paperEpisodeCutoffAt?: string
   readonly paperEpisodeCloseSubmitCutoffAt?: string
   readonly paperEpisodeExpiresAt?: string
   readonly onClosedCycle?: (cycleId: string, observedAt: string) => Effect.Effect<void>
+  readonly interpretCycleDriver?: RecoveryFirstCycleDriverInterpreter
 }
 
 export const paperEpisodeCloseGraceMs = 15 * 60_000
@@ -1136,7 +1142,7 @@ type ObserveDecisionRuntime =
   | AuthorityRestrictionStore
   | WriterFence
 type ObserveRuntime = CycleStore | ObserveDecisionRuntime
-type RecoveryFirstRuntime = ObserveRuntime | IntentStore | MutationStore
+export type RecoveryFirstRuntime = ObserveRuntime | IntentStore | MutationStore
 
 export type ObserveStartupPreparation = {
   readonly executionModel: CausalProtocol['executionModel']
@@ -1781,13 +1787,15 @@ const terminalizeUnboundMutationCycleAtCutoff = (
 const terminalizeBlockedPaperCycleDataFirst = (
   cycle: AutonomousCycle,
   outcome: Extract<BoundMutationCycleOutcome, { readonly _tag: 'Block' }>,
+  authorityGenerationHash: string,
+  blockedIntents: BlockedCycleIntentStoreShape,
 ): Effect.Effect<CycleRunResult, CycleRunnerError, CycleStore | AuthorityRestrictionStore | WriterFence> =>
   Effect.gen(function* () {
     const store = yield* CycleStore
     const restrictionStore = yield* AuthorityRestrictionStore
     const fence = yield* WriterFence
     const restrictionReason = `bound cycle ${cycle.identity.cycleId} blocked: ${outcome.reason}`
-    const receipt = yield* fence.transaction(
+    const { cycleReceipt, intentReceipt } = yield* fence.transaction(
       store.block(cycle.identity.cycleId, outcome.reason, outcome.observedAt).pipe(
         Effect.mapError((cause) =>
           mutationRunnerError({ message: 'blocked PAPER cycle finalization failed', cause, failure: 'store' }),
@@ -1808,6 +1816,24 @@ const terminalizeBlockedPaperCycleDataFirst = (
               ),
             ),
         ),
+        Effect.bindTo('cycleReceipt'),
+        Effect.bind('intentReceipt', () =>
+          blockedIntents
+            .terminalizeUntouchedApproved({
+              authorityGenerationHash,
+              cycleId: cycle.identity.cycleId,
+              observedAt: outcome.observedAt,
+            })
+            .pipe(
+              Effect.mapError((cause) =>
+                mutationRunnerError({
+                  message: 'untouched approved intents could not be terminalized with their blocked PAPER cycle',
+                  cause,
+                  failure: 'store',
+                }),
+              ),
+            ),
+        ),
       ),
     )
     yield* Effect.logWarning('Bayn PAPER cycle terminalized with restricted mutation authority').pipe(
@@ -1815,6 +1841,9 @@ const terminalizeBlockedPaperCycleDataFirst = (
         service: 'bayn',
         cycleId: cycle.identity.cycleId,
         terminalReason: outcome.reason,
+        blockedIntentCount: intentReceipt.blockedIntentCount,
+        expiredIntentCount: intentReceipt.expiredIntentCount,
+        terminalIntentCount: intentReceipt.terminalIntentCount,
         observedAt: outcome.observedAt,
       }),
     )
@@ -1822,7 +1851,7 @@ const terminalizeBlockedPaperCycleDataFirst = (
       outcome: 'RECOVERED' as const,
       action: 'BLOCKED' as const,
       observedAt: outcome.observedAt,
-      cycle: receipt.cycle,
+      cycle: cycleReceipt.cycle,
     }
   }).pipe(
     Effect.mapError((cause) =>
@@ -1832,7 +1861,7 @@ const terminalizeBlockedPaperCycleDataFirst = (
     ),
   )
 
-export const terminalizeBlockedPaperCycle = Pipeable.dual(2, terminalizeBlockedPaperCycleDataFirst)
+export const terminalizeBlockedPaperCycle = terminalizeBlockedPaperCycleDataFirst
 
 const interpretBoundMutationCycleOutcome = (
   input: ObserveAutonomousCycleInput,
@@ -1851,7 +1880,14 @@ const interpretBoundMutationCycleOutcome = (
         cycle,
       })
     case 'Block':
-      return terminalizeBlockedPaperCycle(cycle, outcome)
+      return input.blockedCycleIntentStore === undefined
+        ? Effect.fail(
+            mutationRunnerError({
+              message: 'blocked PAPER cycle terminalization store is unavailable',
+              failure: 'contract',
+            }),
+          )
+        : terminalizeBlockedPaperCycle(cycle, outcome, input.authorityGenerationHash, input.blockedCycleIntentStore)
     case 'Complete':
       return CycleStore.pipe(
         Effect.flatMap((store) => store.finish(cycle.identity.cycleId, CycleState.Completed, outcome.observedAt)),
@@ -1944,11 +1980,11 @@ const runRecoveryFirstCyclePass = (
 const observeMutationPass = (
   startup: Parameters<AutonomousCycleStartup>[0],
   observation: CyclePassObservation,
-): Effect.Effect<void> => {
+): Effect.Effect<AutonomousCyclePassObservation> => {
   const facts = cyclePassLogFacts(observation)
   const log = facts.level === 'INFO' ? Effect.logInfo(facts.message) : Effect.logError(facts.message)
   return observePass(startup.recordPass, observation).pipe(
-    Effect.andThen(log.pipe(Effect.annotateLogs(facts.annotations))),
+    Effect.tap(() => log.pipe(Effect.annotateLogs(facts.annotations))),
   )
 }
 
@@ -2024,7 +2060,7 @@ const observeMutationIdleReconciliation = (
   cadence: Ref.Ref<ReconciliationCadenceState>,
   reconcile: Effect.Effect<ReconciliationPassResult, ReconciliationPassError, ObserveDecisionRuntime>,
   result: Extract<CycleRunResult, { readonly outcome: 'NOT_DUE' }>,
-): Effect.Effect<void, never, ObserveDecisionRuntime> =>
+): Effect.Effect<AutonomousCyclePassObservation, never, ObserveDecisionRuntime> =>
   reconcileMutationNotDuePass(input, cadence, reconcile, result).pipe(
     Effect.flatMap((reconciled) =>
       currentUtcInstant.pipe(
@@ -2145,7 +2181,7 @@ const observeMutationCycleResult = (
   cadence: Ref.Ref<ReconciliationCadenceState>,
   reconcile: Effect.Effect<ReconciliationPassResult, ReconciliationPassError, ObserveDecisionRuntime>,
   result: CycleRunResult,
-): Effect.Effect<void, never, ObserveDecisionRuntime> =>
+): Effect.Effect<AutonomousCyclePassObservation, never, ObserveDecisionRuntime> =>
   result.outcome === 'NOT_DUE'
     ? observeMutationIdleReconciliation(input, startup, cadence, reconcile, result)
     : Ref.get(cadence).pipe(
@@ -2160,66 +2196,101 @@ const observeMutationCycleResult = (
         ),
       )
 
-const recoveryFirstCycleLoop = (
+export type RecoveryFirstCycleAdvance = {
+  readonly observation: AutonomousCyclePassObservation
+  readonly result?: CycleRunResult
+}
+
+export type RecoveryFirstCycleDriver = {
+  readonly advance: Effect.Effect<RecoveryFirstCycleAdvance, CycleRunnerError, RecoveryFirstRuntime>
+  /** The external owner must not delay the next command beyond either the cycle or reconciliation cadence. */
+  readonly nextDelayMs: number
+  readonly wait: (advance: RecoveryFirstCycleAdvance) => Effect.Effect<void, never, RecoveryFirstRuntime>
+}
+
+export type RecoveryFirstCycleDriverInterpreter = (
+  driver: RecoveryFirstCycleDriver,
+) => Effect.Effect<void, never, RecoveryFirstRuntime>
+
+export const recoveryFirstCycleNextDelayMs = (input: {
+  readonly pollIntervalMs: number
+  readonly reconciliationIntervalMs: number
+}): number => Math.min(input.pollIntervalMs, input.reconciliationIntervalMs)
+
+const makeRecoveryFirstCycleDriver = (
   input: ObserveAutonomousCycleInput,
   startup: Parameters<AutonomousCycleStartup>[0],
   preparation: ObserveStartupPreparation,
   policy: Policy,
   capability: PaperExecutionCapability,
   buildDecision: RecoveryFirstDecisionBuilder,
-): Effect.Effect<void, never, RecoveryFirstRuntime> =>
+): Effect.Effect<RecoveryFirstCycleDriver, never, RecoveryFirstRuntime> =>
   Effect.gen(function* () {
     const cadence = yield* Ref.make<ReconciliationCadenceState>({})
     const cyclePassTimeoutMs = Math.min(input.reconciliationPassTimeoutMs, input.reconciliationIntervalMs)
     const reconcile = boundedReconciliationPass(input.reconciliationPassTimeoutMs).pipe(
       Effect.tap(() => markMutationReconciliationCompleted(cadence)),
     )
-    const run = (): Effect.Effect<void, never, RecoveryFirstRuntime> =>
-      Effect.suspend(() =>
-        Effect.gen(function* () {
-          const context: CycleRunContext<ObserveDecisionRuntime> = {
-            qualificationRunId: startup.qualificationRunId,
-            ...(input.cycleCadence === undefined ? {} : { cadence: input.cycleCadence }),
-            strategyProtocolHash: preparation.strategyProtocolHash,
-            accountId: input.accountId,
-            executionPolicy: preparation.executionPolicy,
-            buildDecision: (cycle) => buildDecision(cycle, reconcile),
-          }
-          const result = yield* runMutationPassWithinTimeout(
-            runRecoveryFirstCyclePass(input, preparation, policy, context, reconcile, capability),
-            cyclePassTimeoutMs,
-          )
-          if (isPostMutationReconciliation(result)) {
-            return yield* completePostMutationReconciliation(result, reconcile)
-          }
-          return result
-        }).pipe(
-          Effect.matchEffect({
-            onFailure: (error) =>
-              (capability._tag === 'Mutation' ? restrictMutationLoopFailure(error) : Effect.void).pipe(
-                Effect.catch((restrictionError: CycleRunnerError) =>
-                  currentUtcInstant.pipe(
-                    Effect.flatMap((observedAt) =>
-                      observeMutationPass(startup, { outcome: 'FAILED', observedAt, error: restrictionError }),
-                    ),
-                    Effect.andThen(Effect.die(restrictionError)),
-                  ),
-                ),
-                Effect.andThen(currentUtcInstant),
-                Effect.flatMap((observedAt) => observeMutationPass(startup, { outcome: 'FAILED', observedAt, error })),
-                Effect.andThen(waitAfterMutationFailure(input, startup, cadence, reconcile)),
-                Effect.andThen(run()),
-              ),
-            onSuccess: (result) =>
-              observeMutationCycleResult(input, startup, cadence, reconcile, result).pipe(
-                Effect.andThen(waitAfterMutationPass(input, startup, cadence, reconcile, result)),
-                Effect.andThen(run()),
-              ),
-          }),
-        ),
+    const advance = Effect.gen(function* () {
+      const context: CycleRunContext<ObserveDecisionRuntime> = {
+        qualificationRunId: startup.qualificationRunId,
+        ...(input.cycleCadence === undefined ? {} : { cadence: input.cycleCadence }),
+        strategyProtocolHash: preparation.strategyProtocolHash,
+        accountId: input.accountId,
+        executionPolicy: preparation.executionPolicy,
+        buildDecision: (cycle) => buildDecision(cycle, reconcile),
+      }
+      const result = yield* runMutationPassWithinTimeout(
+        runRecoveryFirstCyclePass(input, preparation, policy, context, reconcile, capability),
+        cyclePassTimeoutMs,
       )
-    yield* run()
+      if (isPostMutationReconciliation(result)) {
+        return yield* completePostMutationReconciliation(result, reconcile)
+      }
+      return result
+    }).pipe(
+      Effect.matchEffect({
+        onFailure: (error) =>
+          (capability._tag === 'Mutation' ? restrictMutationLoopFailure(error) : Effect.void).pipe(
+            Effect.catch((restrictionError: CycleRunnerError) =>
+              currentUtcInstant.pipe(
+                Effect.flatMap((observedAt) =>
+                  observeMutationPass(startup, { outcome: 'FAILED', observedAt, error: restrictionError }),
+                ),
+                Effect.andThen(Effect.fail(restrictionError)),
+              ),
+            ),
+            Effect.andThen(currentUtcInstant),
+            Effect.flatMap((observedAt) => observeMutationPass(startup, { outcome: 'FAILED', observedAt, error })),
+            Effect.map((observation) => ({ observation })),
+          ),
+        onSuccess: (result) =>
+          observeMutationCycleResult(input, startup, cadence, reconcile, result).pipe(
+            Effect.map((observation) => ({ observation, result })),
+          ),
+      }),
+    )
+    return {
+      advance,
+      nextDelayMs: recoveryFirstCycleNextDelayMs(input),
+      wait: (completed) =>
+        completed.result === undefined
+          ? waitAfterMutationFailure(input, startup, cadence, reconcile)
+          : waitAfterMutationPass(input, startup, cadence, reconcile, completed.result),
+    }
   })
+
+const interpretRecoveryFirstCycleInProcess: RecoveryFirstCycleDriverInterpreter = (driver) => {
+  const run = (): Effect.Effect<void, never, RecoveryFirstRuntime> =>
+    Effect.suspend(() =>
+      driver.advance.pipe(
+        Effect.flatMap(driver.wait),
+        Effect.catch((restrictionError) => Effect.die(restrictionError)),
+        Effect.andThen(run()),
+      ),
+    )
+  return run()
+}
 
 const makeRecoveryFirstAutonomousLoop = (
   input: ObserveAutonomousCycleInput,
@@ -2235,7 +2306,11 @@ const makeRecoveryFirstAutonomousLoop = (
     Result.map(validateCycleLoopInterval(input.pollIntervalMs), () => input.reconciliationIntervalMs).pipe(
       Result.flatMap(validateReconciliationInterval),
       Result.flatMap(() => validateCyclePassTimeout(cyclePassTimeoutMs, input.reconciliationIntervalMs)),
-      Result.map(() => recoveryFirstCycleLoop(input, startup, preparation, policy, capability, buildDecision)),
+      Result.map(() =>
+        makeRecoveryFirstCycleDriver(input, startup, preparation, policy, capability, buildDecision).pipe(
+          Effect.flatMap(input.interpretCycleDriver ?? interpretRecoveryFirstCycleInProcess),
+        ),
+      ),
     ),
     (cause) =>
       operationalError({

--- a/services/bayn/src/restate-lifecycle-controller.test.ts
+++ b/services/bayn/src/restate-lifecycle-controller.test.ts
@@ -7,20 +7,20 @@ import { decodeRestateLifecycleConfig } from './restate-lifecycle'
 import {
   lifecycleCommandFinalizationHeadroomMs,
   lifecycleCommandRequestTimeoutMs,
+  lifecycleHandlerTimeouts,
   makeLifecycleCommandClient,
 } from './restate-lifecycle-controller'
 
-const config = Result.getOrThrow(
-  decodeRestateLifecycleConfig({
-    schemaVersion: 'bayn.restate-lifecycle-config.v1',
-    controllerKey: 'primary',
-    commandBaseUrl: 'http://bayn-lifecycle-command.bayn.svc.cluster.local:8081',
-    operationTimeoutMs: 30_000,
-    pollIntervalMs: 30_000,
-    sourceRevision: 'a'.repeat(40),
-    port: 9080,
-  }),
-)
+const configInput = {
+  schemaVersion: 'bayn.restate-lifecycle-config.v1',
+  controllerKey: 'primary',
+  commandBaseUrl: 'http://bayn-lifecycle-command.bayn.svc.cluster.local:8081',
+  operationTimeoutMs: 30_000,
+  pollIntervalMs: 30_000,
+  sourceRevision: 'a'.repeat(40),
+  port: 9080,
+} as const
+const config = Result.getOrThrow(decodeRestateLifecycleConfig(configInput))
 
 const jsonResponse = (body: unknown, init: ResponseInit = {}): Response => {
   const headers = new Headers(init.headers)
@@ -33,6 +33,18 @@ describe('Restate lifecycle command client', () => {
     expect(lifecycleCommandRequestTimeoutMs(1_000)).toBe(1_000 + lifecycleCommandFinalizationHeadroomMs)
     expect(lifecycleCommandRequestTimeoutMs(30_000)).toBe(60_000)
     expect(lifecycleCommandRequestTimeoutMs(86_400_000)).toBe(86_400_000 + lifecycleCommandFinalizationHeadroomMs)
+  })
+
+  test('keeps Restate inactivity and abort limits beyond every accepted command request', () => {
+    for (const operationTimeoutMs of [1_000, 30_000, 86_400_000]) {
+      const expected = lifecycleHandlerTimeouts(operationTimeoutMs)
+
+      expect(expected).toEqual({
+        inactivityTimeout: operationTimeoutMs + lifecycleCommandFinalizationHeadroomMs * 2,
+        abortTimeout: lifecycleCommandFinalizationHeadroomMs,
+      })
+      expect(expected.inactivityTimeout).toBeGreaterThan(lifecycleCommandRequestTimeoutMs(operationTimeoutMs))
+    }
   })
 
   test('uses only the bound command origin and exact typed contracts', async () => {

--- a/services/bayn/src/restate-lifecycle-controller.test.ts
+++ b/services/bayn/src/restate-lifecycle-controller.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, test } from 'bun:test'
+
+import { Result } from 'effect'
+
+import { lifecycleCommandId } from './lifecycle-command-contract'
+import { decodeRestateLifecycleConfig } from './restate-lifecycle'
+import {
+  lifecycleCommandFinalizationHeadroomMs,
+  lifecycleCommandRequestTimeoutMs,
+  makeLifecycleCommandClient,
+} from './restate-lifecycle-controller'
+
+const config = Result.getOrThrow(
+  decodeRestateLifecycleConfig({
+    schemaVersion: 'bayn.restate-lifecycle-config.v1',
+    controllerKey: 'primary',
+    commandBaseUrl: 'http://bayn-lifecycle-command.bayn.svc.cluster.local:8081',
+    operationTimeoutMs: 30_000,
+    pollIntervalMs: 30_000,
+    sourceRevision: 'a'.repeat(40),
+    port: 9080,
+  }),
+)
+
+const jsonResponse = (body: unknown, init: ResponseInit = {}): Response => {
+  const headers = new Headers(init.headers)
+  headers.set('content-type', 'application/json')
+  return new Response(JSON.stringify(body), { ...init, headers })
+}
+
+describe('Restate lifecycle command client', () => {
+  test('keeps bounded finalization headroom beyond every accepted Bayn pass timeout', () => {
+    expect(lifecycleCommandRequestTimeoutMs(1_000)).toBe(1_000 + lifecycleCommandFinalizationHeadroomMs)
+    expect(lifecycleCommandRequestTimeoutMs(30_000)).toBe(60_000)
+    expect(lifecycleCommandRequestTimeoutMs(86_400_000)).toBe(86_400_000 + lifecycleCommandFinalizationHeadroomMs)
+  })
+
+  test('uses only the bound command origin and exact typed contracts', async () => {
+    const requests: Array<{ readonly url: string; readonly init: RequestInit }> = []
+    const request = async (input: string | URL | Request, init: RequestInit = {}): Promise<Response> => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
+      requests.push({ url, init })
+      if (url.endsWith('/cursor')) {
+        return jsonResponse({
+          schemaVersion: 'bayn.lifecycle-command-cursor.v1',
+          controllerKey: 'primary',
+          sourceRevision: config.sourceRevision,
+          cursor: { _tag: 'Next', sequence: 4 },
+        })
+      }
+      return jsonResponse({
+        schemaVersion: 'bayn.lifecycle-command-response.v1',
+        accepted: true,
+        commandId: lifecycleCommandId('primary', 4),
+        sequence: 4,
+        sourceRevision: config.sourceRevision,
+        replayed: false,
+        nextDelayMs: 30_000,
+        observation: {
+          result: 'SUCCESS',
+          outcome: 'NOT_DUE',
+          observedAt: '2026-08-10T20:00:01.000Z',
+        },
+      })
+    }
+    const client = makeLifecycleCommandClient(config, async () => 'projected-worker-token', request)
+
+    expect(await client.readCursor()).toMatchObject({ cursor: { _tag: 'Next', sequence: 4 } })
+    expect(
+      await client.advance({
+        controllerKey: 'primary',
+        commandId: lifecycleCommandId('primary', 4),
+        sequence: 4,
+        issuedAt: '2026-08-10T20:00:00.000Z',
+      }),
+    ).toMatchObject({ sequence: 4, replayed: false })
+
+    expect(requests.map(({ url }) => url)).toEqual([
+      `${config.commandBaseUrl}/v1/lifecycle/cursor`,
+      `${config.commandBaseUrl}/v1/lifecycle/advance`,
+    ])
+    expect(requests.map(({ init }) => new Headers(init.headers).get('authorization'))).toEqual([
+      'Bearer projected-worker-token',
+      'Bearer projected-worker-token',
+    ])
+    expect(requests.every(({ init }) => init.signal instanceof AbortSignal && !init.signal.aborted)).toBe(true)
+    const advanceBody = requests[1]?.init.body
+    if (typeof advanceBody !== 'string') throw new Error('advance request body is not a string')
+    expect(JSON.parse(advanceBody)).toEqual({
+      schemaVersion: 'bayn.lifecycle-command.v1',
+      controllerKey: 'primary',
+      commandId: lifecycleCommandId('primary', 4),
+      sequence: 4,
+      issuedAt: '2026-08-10T20:00:00.000Z',
+      sourceRevision: config.sourceRevision,
+    })
+  })
+
+  test('fails closed on invalid, non-JSON, or oversized Bayn responses', async () => {
+    const invalidBodies: readonly Response[] = [
+      jsonResponse({ controllerKey: 'primary', cursor: { _tag: 'Next', sequence: 1 } }),
+      new Response('not json', { headers: { 'content-type': 'text/plain' } }),
+      new Response('x'.repeat(65 * 1024), { headers: { 'content-type': 'application/json' } }),
+    ]
+
+    for (const response of invalidBodies) {
+      const client = makeLifecycleCommandClient(
+        config,
+        async () => 'projected-worker-token',
+        async () => response,
+      )
+      let rejected = false
+      try {
+        await client.readCursor()
+      } catch {
+        rejected = true
+      }
+      expect(rejected).toBe(true)
+    }
+  })
+})

--- a/services/bayn/src/restate-lifecycle-controller.ts
+++ b/services/bayn/src/restate-lifecycle-controller.ts
@@ -86,6 +86,15 @@ const readBoundedJson = async (response: Response): Promise<unknown> => {
 export const lifecycleCommandRequestTimeoutMs = (operationTimeoutMs: number): number =>
   operationTimeoutMs + lifecycleCommandFinalizationHeadroomMs
 
+// Let the bounded HTTP request finish and give Restate one additional journal-finalization window before requesting
+// suspension. The abort window then bounds non-cooperative code without cutting off any accepted Bayn operation.
+export const lifecycleHandlerTimeouts = (
+  operationTimeoutMs: number,
+): { readonly inactivityTimeout: number; readonly abortTimeout: number } => ({
+  inactivityTimeout: lifecycleCommandRequestTimeoutMs(operationTimeoutMs) + lifecycleCommandFinalizationHeadroomMs,
+  abortTimeout: lifecycleCommandFinalizationHeadroomMs,
+})
+
 const fetchJson = async (
   request: HttpRequest,
   url: string,
@@ -276,8 +285,7 @@ export const makeBaynLifecycle = (config: RestateLifecycleConfig, client: Lifecy
     options: {
       ingressPrivate: true,
       enableLazyState: true,
-      inactivityTimeout: { minutes: 2 },
-      abortTimeout: { seconds: 60 },
+      ...lifecycleHandlerTimeouts(config.operationTimeoutMs),
     },
   })
 
@@ -300,7 +308,6 @@ export const makeBaynLifecycleBootstrap = (
       },
     },
     options: {
-      inactivityTimeout: { minutes: 2 },
-      abortTimeout: { seconds: 60 },
+      ...lifecycleHandlerTimeouts(config.operationTimeoutMs),
     },
   })

--- a/services/bayn/src/restate-lifecycle-controller.ts
+++ b/services/bayn/src/restate-lifecycle-controller.ts
@@ -1,0 +1,306 @@
+import * as restate from '@restatedev/restate-sdk'
+import { Effect, Logger, Result } from 'effect'
+
+import {
+  completeRestateLifecycleTick,
+  decodeLifecycleCommandCursorResponse,
+  decodeLifecycleCommandResponse,
+  decodeRestateLifecycleActivation,
+  decodeRestateLifecycleState,
+  decodeRestateLifecycleTick,
+  initialRestateLifecycleState,
+  lifecycleCommandFromCursor,
+  type LifecycleCommandCursorResponse,
+  type LifecycleCommandResponse,
+  type RestateLifecycleConfig,
+  type RestateLifecycleState,
+  type RestateLifecycleTick,
+} from './restate-lifecycle'
+
+const stateKey = 'controller'
+const maximumResponseBytes = 64 * 1024
+export const lifecycleCommandFinalizationHeadroomMs = 30_000
+const lifecycleTickSerde = restate.serde.json.schema<RestateLifecycleTick>({
+  type: 'object',
+  required: ['schemaVersion', 'epoch', 'sequence'],
+  additionalProperties: false,
+})
+
+type LifecycleObjectState = { readonly controller: RestateLifecycleState }
+
+export interface LifecycleCommandClient {
+  readonly readCursor: () => Promise<LifecycleCommandCursorResponse>
+  readonly advance: (command: {
+    readonly controllerKey: string
+    readonly commandId: string
+    readonly sequence: number
+    readonly issuedAt: string
+  }) => Promise<LifecycleCommandResponse>
+}
+
+type HttpRequest = (input: string | URL | Request, init?: RequestInit) => Promise<Response>
+export type LifecycleCommandCredential = () => Promise<string>
+
+export const lifecycleLog = (
+  message: string,
+  annotations: Readonly<Record<string, string | number | boolean>>,
+): Promise<void> =>
+  Effect.logInfo(message).pipe(
+    Effect.annotateLogs(annotations),
+    Effect.annotateLogs({ service: 'bayn-lifecycle' }),
+    // @effect-diagnostics-next-line strictEffectProvide:off -- Restate owns this isolated worker process
+    Effect.provide(Logger.layer([Logger.consoleJson])),
+    Effect.runPromise,
+  )
+
+const terminal = (message: string): restate.TerminalError =>
+  new restate.TerminalError(message, {
+    errorCode: 400,
+  })
+
+const decodeOrTerminal = <A>(decoded: Result.Result<A, unknown>, message: string): A => {
+  if (Result.isFailure(decoded)) throw terminal(message)
+  return decoded.success
+}
+
+const readBoundedJson = async (response: Response): Promise<unknown> => {
+  const contentType = response.headers.get('content-type') ?? ''
+  if (!contentType.toLowerCase().startsWith('application/json')) {
+    throw terminal('Bayn lifecycle command boundary returned a non-JSON response')
+  }
+  const declaredLength = Number.parseInt(response.headers.get('content-length') ?? '0', 10)
+  if (Number.isFinite(declaredLength) && declaredLength > maximumResponseBytes) {
+    throw terminal('Bayn lifecycle command boundary response exceeded its size limit')
+  }
+  const bytes = new Uint8Array(await response.arrayBuffer())
+  if (bytes.byteLength > maximumResponseBytes) {
+    throw terminal('Bayn lifecycle command boundary response exceeded its size limit')
+  }
+  try {
+    return JSON.parse(new TextDecoder().decode(bytes)) as unknown
+  } catch {
+    throw terminal('Bayn lifecycle command boundary returned invalid JSON')
+  }
+}
+
+export const lifecycleCommandRequestTimeoutMs = (operationTimeoutMs: number): number =>
+  operationTimeoutMs + lifecycleCommandFinalizationHeadroomMs
+
+const fetchJson = async (
+  request: HttpRequest,
+  url: string,
+  init: RequestInit,
+  requestTimeoutMs: number,
+): Promise<unknown> => {
+  const response = await request(url, { ...init, signal: AbortSignal.timeout(requestTimeoutMs) })
+  if (!response.ok) {
+    const message = `Bayn lifecycle command boundary returned HTTP ${response.status}`
+    if (response.status >= 400 && response.status < 500) throw terminal(message)
+    throw new Error(message)
+  }
+  return readBoundedJson(response)
+}
+
+export const makeLifecycleCommandClient = (
+  config: RestateLifecycleConfig,
+  credential: LifecycleCommandCredential,
+  request: HttpRequest = fetch,
+): LifecycleCommandClient => {
+  const requestTimeoutMs = lifecycleCommandRequestTimeoutMs(config.operationTimeoutMs)
+  return {
+    readCursor: async () => {
+      const token = await credential()
+      return decodeOrTerminal(
+        decodeLifecycleCommandCursorResponse(
+          await fetchJson(
+            request,
+            `${config.commandBaseUrl}/v1/lifecycle/cursor`,
+            {
+              method: 'GET',
+              headers: { authorization: `Bearer ${token}` },
+            },
+            requestTimeoutMs,
+          ),
+        ),
+        'Bayn lifecycle command cursor response failed validation',
+      )
+    },
+    advance: async (command) => {
+      const token = await credential()
+      return decodeOrTerminal(
+        decodeLifecycleCommandResponse(
+          await fetchJson(
+            request,
+            `${config.commandBaseUrl}/v1/lifecycle/advance`,
+            {
+              method: 'POST',
+              headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+              body: JSON.stringify({
+                schemaVersion: 'bayn.lifecycle-command.v1',
+                ...command,
+                sourceRevision: config.sourceRevision,
+              }),
+            },
+            requestTimeoutMs,
+          ),
+        ),
+        'Bayn lifecycle command response failed validation',
+      )
+    },
+  }
+}
+
+const readState = async (ctx: restate.ObjectContext<LifecycleObjectState>): Promise<RestateLifecycleState | null> => {
+  const candidate = await ctx.get(stateKey)
+  return candidate === null
+    ? null
+    : decodeOrTerminal(decodeRestateLifecycleState(candidate), 'Restate lifecycle state failed validation')
+}
+
+const scheduleTick = (
+  ctx: restate.ObjectContext<LifecycleObjectState>,
+  state: RestateLifecycleState,
+  delay: number,
+): void => {
+  const sequence = state.cursor._tag === 'Pending' ? state.cursor.command.sequence : state.cursor.sequence
+  ctx.genericSend({
+    service: 'BaynLifecycle',
+    method: 'advance',
+    key: ctx.key,
+    parameter: { schemaVersion: 'bayn.restate-lifecycle-tick.v1', epoch: state.epoch, sequence },
+    inputSerde: lifecycleTickSerde,
+    delay,
+    idempotencyKey: `bayn-lifecycle-${state.epoch}-${sequence}`,
+  })
+}
+
+export const makeBaynLifecycle = (config: RestateLifecycleConfig, client: LifecycleCommandClient) =>
+  restate.object({
+    name: 'BaynLifecycle',
+    handlers: {
+      activate: async (ctx: restate.ObjectContext<LifecycleObjectState>, candidate: unknown) => {
+        const request = decodeOrTerminal(
+          decodeRestateLifecycleActivation(candidate),
+          'Restate lifecycle activation request failed validation',
+        )
+        if (ctx.key !== config.controllerKey || request.controllerKey !== config.controllerKey) {
+          throw terminal('Restate lifecycle activation controller key does not match this deployment')
+        }
+
+        const current = await readState(ctx)
+        // The public bootstrap is intentionally idempotent for one immutable plan. In particular, it cannot undo an
+        // operator-initiated deactivation; only a newly reviewed source/configuration plan may start a new epoch.
+        if (current?.planHash === config.planHash) return current
+
+        const cursor = await ctx.run('recover Bayn lifecycle command cursor', () => client.readCursor())
+        if (cursor.controllerKey !== config.controllerKey || cursor.sourceRevision !== config.sourceRevision) {
+          throw new Error('Bayn lifecycle command cursor does not match this source deployment')
+        }
+        const state = initialRestateLifecycleState(config, cursor.cursor, current?.epoch ?? 0)
+        ctx.set(stateKey, state)
+        scheduleTick(ctx, state, 0)
+        await lifecycleLog('Bayn Restate lifecycle activated', {
+          controllerKey: ctx.key,
+          epoch: state.epoch,
+          nextSequence: state.cursor._tag === 'Pending' ? state.cursor.command.sequence : state.cursor.sequence,
+          planHash: state.planHash,
+          sourceRevision: state.sourceRevision,
+        })
+        return state
+      },
+
+      advance: async (ctx: restate.ObjectContext<LifecycleObjectState>, candidate: unknown): Promise<void> => {
+        const tick = decodeOrTerminal(decodeRestateLifecycleTick(candidate), 'Restate lifecycle tick failed validation')
+        const state = await readState(ctx)
+        if (state === null || !state.active || tick.epoch !== state.epoch) return
+        const expectedSequence = state.cursor._tag === 'Pending' ? state.cursor.command.sequence : state.cursor.sequence
+        if (tick.sequence !== expectedSequence) return
+
+        const issuedAt = await ctx.date.toJSON()
+        const command = lifecycleCommandFromCursor(config.controllerKey, state.cursor, issuedAt)
+        const response = await ctx.run('advance Bayn lifecycle', () => client.advance(command))
+        if (
+          response.commandId !== command.commandId ||
+          response.sequence !== command.sequence ||
+          response.sourceRevision !== config.sourceRevision
+        ) {
+          throw terminal('Bayn lifecycle command response identity does not match its request')
+        }
+        const completedAt = await ctx.date.toJSON()
+        const completed = completeRestateLifecycleTick(state, response, completedAt)
+        ctx.set(stateKey, completed)
+        scheduleTick(ctx, completed, response.nextDelayMs)
+        await lifecycleLog('Bayn Restate lifecycle command completed', {
+          commandId: response.commandId,
+          commandSequence: response.sequence,
+          controllerKey: ctx.key,
+          epoch: state.epoch,
+          outcome:
+            response.observation.result === 'SUCCESS'
+              ? response.observation.outcome
+              : `${response.observation.operation}/${response.observation.failure}`,
+          replayed: response.replayed,
+          result: response.observation.result,
+        })
+      },
+
+      deactivate: async (ctx: restate.ObjectContext<LifecycleObjectState>, candidate: unknown) => {
+        const request = decodeOrTerminal(
+          decodeRestateLifecycleActivation(candidate),
+          'Restate lifecycle deactivation request failed validation',
+        )
+        if (ctx.key !== config.controllerKey || request.controllerKey !== config.controllerKey) {
+          throw terminal('Restate lifecycle deactivation controller key does not match this deployment')
+        }
+        const current = await readState(ctx)
+        if (current === null || !current.active) return current
+        const state = { ...current, active: false, epoch: current.epoch + 1 }
+        ctx.set(stateKey, state)
+        await lifecycleLog('Bayn Restate lifecycle deactivated', {
+          controllerKey: ctx.key,
+          epoch: state.epoch,
+          planHash: state.planHash,
+        })
+        return state
+      },
+
+      status: restate.handlers.object.shared(
+        async (ctx: restate.ObjectSharedContext<LifecycleObjectState>, _candidate: unknown) => {
+          const candidate = await ctx.get(stateKey)
+          return candidate === null
+            ? null
+            : decodeOrTerminal(decodeRestateLifecycleState(candidate), 'Restate lifecycle state failed validation')
+        },
+      ),
+    },
+    options: {
+      ingressPrivate: true,
+      enableLazyState: true,
+      inactivityTimeout: { minutes: 2 },
+      abortTimeout: { seconds: 60 },
+    },
+  })
+
+export const makeBaynLifecycleBootstrap = (
+  config: RestateLifecycleConfig,
+  lifecycle: ReturnType<typeof makeBaynLifecycle>,
+) =>
+  restate.service({
+    name: 'BaynLifecycleBootstrap',
+    handlers: {
+      start: async (ctx: restate.Context, candidate: unknown) => {
+        const request = decodeOrTerminal(
+          decodeRestateLifecycleActivation(candidate),
+          'Restate lifecycle bootstrap request failed validation',
+        )
+        if (request.controllerKey !== config.controllerKey) {
+          throw terminal('Restate lifecycle bootstrap controller key does not match this deployment')
+        }
+        return ctx.objectClient(lifecycle, config.controllerKey).activate(request)
+      },
+    },
+    options: {
+      inactivityTimeout: { minutes: 2 },
+      abortTimeout: { seconds: 60 },
+    },
+  })

--- a/services/bayn/src/restate-lifecycle-register.test.ts
+++ b/services/bayn/src/restate-lifecycle-register.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from 'bun:test'
+
+import { restateDeploymentRegistration } from './restate-lifecycle-register'
+
+describe('Restate lifecycle deployment registration', () => {
+  test('registers one immutable HTTP/2 endpoint without forcing replacement', () => {
+    const sourceRevision = 'a'.repeat(40)
+
+    expect(
+      restateDeploymentRegistration('http://bayn-lifecycle-a.bayn.svc.cluster.local:9080', sourceRevision),
+    ).toEqual({
+      uri: 'http://bayn-lifecycle-a.bayn.svc.cluster.local:9080',
+      force: false,
+      metadata: {
+        managed_by: 'argocd',
+        service: 'bayn-lifecycle',
+        source_revision: sourceRevision,
+      },
+    })
+  })
+})

--- a/services/bayn/src/restate-lifecycle-register.ts
+++ b/services/bayn/src/restate-lifecycle-register.ts
@@ -1,0 +1,141 @@
+import { NodeRuntime } from '@effect/platform-node'
+import { Config, Data, Effect, Logger, Option, Schema, pipe } from 'effect'
+
+import { embeddedBuildMetadata } from './build'
+import { LifecycleControllerKeySchema } from './lifecycle-command-contract'
+import { GitSourceRevisionSchema } from './schemas'
+
+const InternalHttpOriginSchema = Schema.Trim.check(
+  Schema.makeFilter(
+    (candidate: string) => {
+      try {
+        const url = new URL(candidate)
+        return (
+          url.protocol === 'http:' &&
+          url.username === '' &&
+          url.password === '' &&
+          url.pathname === '/' &&
+          url.search === '' &&
+          url.hash === ''
+        )
+      } catch {
+        return false
+      }
+    },
+    { expected: 'an uncredentialed internal HTTP origin' },
+  ),
+)
+
+class RestateRegistrationError extends Data.TaggedError('RestateRegistrationError')<{
+  readonly operation: 'configuration' | 'register' | 'activate'
+  readonly message: string
+  readonly cause?: unknown
+}> {}
+
+const config = Config.all({
+  adminOrigin: Config.schema(InternalHttpOriginSchema, 'RESTATE_ADMIN_ORIGIN').pipe(
+    Config.withDefault('http://restate.restate.svc.cluster.local:9070'),
+  ),
+  ingressOrigin: Config.schema(InternalHttpOriginSchema, 'RESTATE_INGRESS_ORIGIN').pipe(
+    Config.withDefault('http://restate.restate.svc.cluster.local:8080'),
+  ),
+  endpointUri: Config.schema(InternalHttpOriginSchema, 'BAYN_RESTATE_ENDPOINT_URI').pipe(
+    Config.withDefault('http://bayn-lifecycle.bayn.svc.cluster.local:9080'),
+  ),
+  controllerKey: Config.schema(LifecycleControllerKeySchema, 'BAYN_LIFECYCLE_CONTROLLER_KEY').pipe(
+    Config.withDefault('primary'),
+  ),
+  configuredSourceRevision: Config.option(Config.schema(GitSourceRevisionSchema, 'BAYN_CODE_REVISION')),
+})
+
+const postJson = (
+  operation: 'register' | 'activate',
+  url: string,
+  body: unknown,
+): Effect.Effect<number, RestateRegistrationError> =>
+  Effect.tryPromise({
+    try: async () => {
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(body),
+        signal: AbortSignal.timeout(30_000),
+      })
+      if (!response.ok) throw new Error(`${url} returned HTTP ${response.status}`)
+      await response.body?.cancel()
+      return response.status
+    },
+    catch: (cause) =>
+      new RestateRegistrationError({
+        operation,
+        message: `Bayn Restate lifecycle ${operation} request failed`,
+        cause,
+      }),
+  })
+
+export const restateDeploymentRegistration = (endpointUri: string, sourceRevision: string) => ({
+  uri: endpointUri,
+  force: false,
+  metadata: {
+    managed_by: 'argocd',
+    service: 'bayn-lifecycle',
+    source_revision: sourceRevision,
+  },
+})
+
+const program = Effect.gen(function* () {
+  const loaded = yield* config
+  const configuredSourceRevision = Option.getOrUndefined(loaded.configuredSourceRevision)
+  const sourceRevision = embeddedBuildMetadata?.sourceRevision ?? configuredSourceRevision
+  if (sourceRevision === undefined) {
+    return yield* new RestateRegistrationError({
+      operation: 'configuration',
+      message: 'Bayn source revision is not configured',
+    })
+  }
+  if (
+    embeddedBuildMetadata !== undefined &&
+    configuredSourceRevision !== undefined &&
+    configuredSourceRevision !== embeddedBuildMetadata.sourceRevision
+  ) {
+    return yield* new RestateRegistrationError({
+      operation: 'configuration',
+      message: 'configured source revision does not match the immutable image source',
+    })
+  }
+  const registrationStatus = yield* postJson(
+    'register',
+    `${loaded.adminOrigin}/deployments`,
+    restateDeploymentRegistration(loaded.endpointUri, sourceRevision),
+  )
+  yield* Effect.logInfo('Bayn Restate deployment registered').pipe(
+    Effect.annotateLogs({
+      controllerKey: loaded.controllerKey,
+      endpointUri: loaded.endpointUri,
+      registrationStatus,
+      sourceRevision,
+    }),
+  )
+  const activationStatus = yield* postJson('activate', `${loaded.ingressOrigin}/BaynLifecycleBootstrap/start`, {
+    schemaVersion: 'bayn.restate-lifecycle-activation.v1',
+    controllerKey: loaded.controllerKey,
+  })
+  yield* Effect.logInfo('Bayn Restate lifecycle activated through ingress').pipe(
+    Effect.annotateLogs({
+      activationStatus,
+      controllerKey: loaded.controllerKey,
+      sourceRevision,
+    }),
+  )
+})
+
+if (import.meta.main) {
+  NodeRuntime.runMain(
+    pipe(
+      program,
+      Effect.annotateLogs({ service: 'bayn-lifecycle-register' }),
+      // @effect-diagnostics-next-line strictEffectProvide:off -- process entry point owns the logger layer
+      Effect.provide(Logger.layer([Logger.consoleJson])),
+    ),
+  )
+}

--- a/services/bayn/src/restate-lifecycle-server.test.ts
+++ b/services/bayn/src/restate-lifecycle-server.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from 'bun:test'
+import { connect, createServer as createHttp2Server, type ClientHttp2Session } from 'node:http2'
+import { createServer as createHttpServer } from 'node:http'
+import type { AddressInfo } from 'node:net'
+
+import { Effect } from 'effect'
+
+import { acquireRestateLifecycleHttp2Server } from './restate-lifecycle-server'
+
+const reservePort = (): Promise<number> =>
+  new Promise((resolve, reject) => {
+    const server = createHttpServer()
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address() as AddressInfo
+      server.close((cause) => (cause === undefined ? resolve(address.port) : reject(cause)))
+    })
+  })
+
+const connectSession = (origin: string): Promise<ClientHttp2Session> =>
+  new Promise((resolve, reject) => {
+    const session = connect(origin)
+    session.once('connect', () => resolve(session))
+    session.once('error', reject)
+  })
+
+describe('Bayn Restate lifecycle HTTP/2 server', () => {
+  test('destroys active client sessions before waiting for server shutdown', async () => {
+    const port = await reservePort()
+    let client: ClientHttp2Session | undefined
+    let closed: Promise<'closed'> | undefined
+
+    await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const server = createHttp2Server()
+          yield* acquireRestateLifecycleHttp2Server(server, port)
+          client = yield* Effect.promise(() => connectSession(`http://127.0.0.1:${port}`))
+          closed = new Promise((resolve) => client?.once('close', () => resolve('closed')))
+          expect(client.closed).toBe(false)
+        }),
+      ),
+    )
+
+    if (closed === undefined) throw new Error('HTTP/2 session did not connect')
+    expect(await Promise.race([closed, Bun.sleep(1_000).then(() => 'timeout' as const)])).toBe('closed')
+    expect(client?.destroyed).toBe(true)
+  })
+})

--- a/services/bayn/src/restate-lifecycle-server.ts
+++ b/services/bayn/src/restate-lifecycle-server.ts
@@ -1,0 +1,197 @@
+import { createServer, type Http2Server, type ServerHttp2Session } from 'node:http2'
+import { readFile } from 'node:fs/promises'
+
+import { NodeRuntime } from '@effect/platform-node'
+import * as restate from '@restatedev/restate-sdk'
+import { Config, Data, Effect, Logger, Option, Result, Schema, Scope, pipe } from 'effect'
+
+import { embeddedBuildMetadata } from './build'
+import { LifecycleControllerKeySchema } from './lifecycle-command-contract'
+import { decodeRestateLifecycleConfig } from './restate-lifecycle'
+import {
+  makeBaynLifecycle,
+  makeBaynLifecycleBootstrap,
+  makeLifecycleCommandClient,
+} from './restate-lifecycle-controller'
+import { GitSourceRevisionSchema } from './schemas'
+
+const InternalHttpOriginSchema = Schema.Trim.check(
+  Schema.makeFilter(
+    (candidate: string) => {
+      try {
+        const url = new URL(candidate)
+        return (
+          url.protocol === 'http:' &&
+          url.username === '' &&
+          url.password === '' &&
+          url.pathname === '/' &&
+          url.search === '' &&
+          url.hash === ''
+        )
+      } catch {
+        return false
+      }
+    },
+    { expected: 'an uncredentialed internal HTTP origin' },
+  ),
+)
+
+class RestateLifecycleServerError extends Data.TaggedError('RestateLifecycleServerError')<{
+  readonly operation: 'configuration' | 'listen'
+  readonly message: string
+  readonly cause?: unknown
+}> {}
+
+const serverConfig = Config.all({
+  controllerKey: Config.schema(LifecycleControllerKeySchema, 'BAYN_LIFECYCLE_CONTROLLER_KEY').pipe(
+    Config.withDefault('primary'),
+  ),
+  commandBaseUrl: Config.schema(InternalHttpOriginSchema, 'BAYN_LIFECYCLE_COMMAND_URL').pipe(
+    Config.withDefault('http://bayn-lifecycle-command.bayn.svc.cluster.local:8081'),
+  ),
+  commandTokenPath: Config.nonEmptyString('BAYN_LIFECYCLE_COMMAND_TOKEN_PATH').pipe(
+    Config.withDefault('/var/run/secrets/bayn-lifecycle-command/token'),
+  ),
+  operationTimeoutMs: Config.number('BAYN_OPERATION_TIMEOUT_MS').pipe(Config.withDefault(30_000)),
+  pollIntervalMs: Config.number('BAYN_CYCLE_POLL_INTERVAL_MS').pipe(Config.withDefault(30_000)),
+  port: Config.port('PORT').pipe(Config.withDefault(9080)),
+  configuredSourceRevision: Config.option(Config.schema(GitSourceRevisionSchema, 'BAYN_CODE_REVISION')),
+})
+
+const maximumServiceAccountTokenBytes = 16_384
+
+const commandCredential = (path: string) => async (): Promise<string> => {
+  const source = await readFile(path, 'utf8')
+  const token = source.trim()
+  if (token.length === 0 || Buffer.byteLength(token, 'utf8') > maximumServiceAccountTokenBytes) {
+    throw new Error('Bayn lifecycle command workload credential is empty or exceeds its size limit')
+  }
+  return token
+}
+
+interface RestateHttp2ServerResource {
+  readonly server: Http2Server
+  readonly sessions: Set<ServerHttp2Session>
+  readonly onSession: (session: ServerHttp2Session) => void
+}
+
+const listen = (
+  server: Http2Server,
+  port: number,
+): Effect.Effect<RestateHttp2ServerResource, RestateLifecycleServerError> =>
+  Effect.callback((resume) => {
+    const sessions = new Set<ServerHttp2Session>()
+    const onSession = (session: ServerHttp2Session): void => {
+      sessions.add(session)
+      session.once('close', () => sessions.delete(session))
+    }
+    const onError = (cause: Error) => {
+      server.off('listening', onListening)
+      server.off('session', onSession)
+      resume(
+        Effect.fail(
+          new RestateLifecycleServerError({
+            operation: 'listen',
+            message: 'Bayn Restate lifecycle endpoint failed to listen',
+            cause,
+          }),
+        ),
+      )
+    }
+    const onListening = () => {
+      server.off('error', onError)
+      resume(Effect.succeed({ server, sessions, onSession }))
+    }
+    server.on('session', onSession)
+    server.once('error', onError)
+    server.once('listening', onListening)
+    server.listen(port)
+    return Effect.sync(() => {
+      server.off('session', onSession)
+      for (const session of sessions) session.destroy()
+      server.close()
+    })
+  })
+
+const close = (resource: RestateHttp2ServerResource): Effect.Effect<void> =>
+  Effect.callback((resume) => {
+    resource.server.off('session', resource.onSession)
+    for (const session of resource.sessions) session.destroy()
+    if (!resource.server.listening) {
+      resume(Effect.void)
+      return
+    }
+    resource.server.close(() => resume(Effect.void))
+  })
+
+export const acquireRestateLifecycleHttp2Server = (
+  server: Http2Server,
+  port: number,
+): Effect.Effect<void, RestateLifecycleServerError, Scope.Scope> =>
+  Effect.acquireRelease(listen(server, port), close).pipe(Effect.asVoid)
+
+const program = Effect.gen(function* () {
+  const loaded = yield* serverConfig
+  const configuredSourceRevision = Option.getOrUndefined(loaded.configuredSourceRevision)
+  const sourceRevision = embeddedBuildMetadata?.sourceRevision ?? configuredSourceRevision
+  if (sourceRevision === undefined) {
+    return yield* new RestateLifecycleServerError({
+      operation: 'configuration',
+      message: 'Bayn source revision is not configured',
+    })
+  }
+  if (
+    embeddedBuildMetadata !== undefined &&
+    configuredSourceRevision !== undefined &&
+    configuredSourceRevision !== embeddedBuildMetadata.sourceRevision
+  ) {
+    return yield* new RestateLifecycleServerError({
+      operation: 'configuration',
+      message: 'configured source revision does not match the immutable image source',
+    })
+  }
+  const decoded = decodeRestateLifecycleConfig({
+    schemaVersion: 'bayn.restate-lifecycle-config.v1',
+    controllerKey: loaded.controllerKey,
+    commandBaseUrl: loaded.commandBaseUrl,
+    operationTimeoutMs: loaded.operationTimeoutMs,
+    pollIntervalMs: loaded.pollIntervalMs,
+    sourceRevision,
+    port: loaded.port,
+  })
+  if (Result.isFailure(decoded)) {
+    return yield* new RestateLifecycleServerError({
+      operation: 'configuration',
+      message: decoded.failure.message,
+      cause: decoded.failure.cause,
+    })
+  }
+  const config = decoded.success
+  const lifecycle = makeBaynLifecycle(
+    config,
+    makeLifecycleCommandClient(config, commandCredential(loaded.commandTokenPath)),
+  )
+  const bootstrap = makeBaynLifecycleBootstrap(config, lifecycle)
+  const server = createServer(restate.createEndpointHandler({ services: [lifecycle, bootstrap] }))
+  yield* acquireRestateLifecycleHttp2Server(server, config.port)
+  yield* Effect.logInfo('Bayn Restate lifecycle endpoint is listening').pipe(
+    Effect.annotateLogs({
+      controllerKey: config.controllerKey,
+      planHash: config.planHash,
+      port: config.port,
+      sourceRevision: config.sourceRevision,
+    }),
+  )
+  return yield* Effect.never
+}).pipe(Effect.scoped)
+
+if (import.meta.main) {
+  NodeRuntime.runMain(
+    pipe(
+      program,
+      Effect.annotateLogs({ service: 'bayn-lifecycle' }),
+      // @effect-diagnostics-next-line strictEffectProvide:off -- process entry point owns the logger layer
+      Effect.provide(Logger.layer([Logger.consoleJson])),
+    ),
+  )
+}

--- a/services/bayn/src/restate-lifecycle.test.ts
+++ b/services/bayn/src/restate-lifecycle.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, test } from 'bun:test'
+
+import { Result } from 'effect'
+
+import {
+  completeRestateLifecycleTick,
+  decodeLifecycleCommandResponse,
+  decodeRestateLifecycleConfig,
+  initialRestateLifecycleState,
+  lifecycleCommandFromCursor,
+} from './restate-lifecycle'
+
+const configInput = {
+  schemaVersion: 'bayn.restate-lifecycle-config.v1',
+  controllerKey: 'primary',
+  commandBaseUrl: 'http://bayn.bayn.svc.cluster.local:8081',
+  operationTimeoutMs: 30_000,
+  pollIntervalMs: 30_000,
+  sourceRevision: 'a'.repeat(40),
+  port: 9080,
+} as const
+
+describe('Restate lifecycle domain', () => {
+  test('normalizes and binds the exact controller plan', () => {
+    const config = Result.getOrThrow(
+      decodeRestateLifecycleConfig({ ...configInput, commandBaseUrl: `${configInput.commandBaseUrl}/` }),
+    )
+    expect(config.commandBaseUrl).toBe(configInput.commandBaseUrl)
+    expect(config.planHash).toMatch(/^[0-9a-f]{64}$/)
+    expect(config.planHash).toBe(Result.getOrThrow(decodeRestateLifecycleConfig(configInput)).planHash)
+    expect(config.planHash).not.toBe(
+      Result.getOrThrow(decodeRestateLifecycleConfig({ ...configInput, operationTimeoutMs: 60_000 })).planHash,
+    )
+  })
+
+  test('accepts every runtime cadence the Restate boundary can receive', () => {
+    expect(Result.isSuccess(decodeRestateLifecycleConfig({ ...configInput, operationTimeoutMs: 1_000 }))).toBe(true)
+    expect(Result.isSuccess(decodeRestateLifecycleConfig({ ...configInput, operationTimeoutMs: 86_400_000 }))).toBe(
+      true,
+    )
+    expect(Result.isFailure(decodeRestateLifecycleConfig({ ...configInput, operationTimeoutMs: 999 }))).toBe(true)
+    expect(Result.isFailure(decodeRestateLifecycleConfig({ ...configInput, operationTimeoutMs: 86_400_001 }))).toBe(
+      true,
+    )
+    expect(Result.isSuccess(decodeRestateLifecycleConfig({ ...configInput, pollIntervalMs: 600_000 }))).toBe(true)
+    expect(Result.isSuccess(decodeRestateLifecycleConfig({ ...configInput, pollIntervalMs: 86_400_000 }))).toBe(true)
+    expect(Result.isFailure(decodeRestateLifecycleConfig({ ...configInput, pollIntervalMs: 86_400_001 }))).toBe(true)
+
+    const response = {
+      schemaVersion: 'bayn.lifecycle-command-response.v1',
+      accepted: true,
+      commandId: 'c'.repeat(64),
+      sequence: 3,
+      sourceRevision: configInput.sourceRevision,
+      replayed: false,
+      observation: {
+        result: 'SUCCESS',
+        observedAt: '2026-08-10T20:00:00.000Z',
+        outcome: 'RECOVERED',
+      },
+    } as const
+    expect(Result.isSuccess(decodeLifecycleCommandResponse({ ...response, nextDelayMs: 1 }))).toBe(true)
+    expect(Result.isSuccess(decodeLifecycleCommandResponse({ ...response, nextDelayMs: 86_400_000 }))).toBe(true)
+    expect(Result.isFailure(decodeLifecycleCommandResponse({ ...response, nextDelayMs: 0 }))).toBe(true)
+    expect(Result.isFailure(decodeLifecycleCommandResponse({ ...response, nextDelayMs: 86_400_001 }))).toBe(true)
+  })
+
+  test('rejects credentialed, routed, or non-HTTP command URLs', () => {
+    for (const commandBaseUrl of [
+      'https://bayn.example.test',
+      'http://user:password@bayn:8081',
+      'http://bayn:8081/path',
+      'http://bayn:8081?target=other',
+    ]) {
+      expect(Result.isFailure(decodeRestateLifecycleConfig({ ...configInput, commandBaseUrl }))).toBe(true)
+    }
+  })
+
+  test('recovers the exact started command rather than allocating a duplicate sequence', () => {
+    const pending = {
+      _tag: 'Pending' as const,
+      command: {
+        controllerKey: 'primary',
+        commandId: 'b'.repeat(64),
+        sequence: 7,
+        issuedAt: '2026-08-10T20:00:00.000Z',
+      },
+    }
+    expect(lifecycleCommandFromCursor('primary', pending, '2026-08-10T21:00:00.000Z')).toEqual(pending.command)
+  })
+
+  test('advances a completed command exactly once', () => {
+    const config = Result.getOrThrow(decodeRestateLifecycleConfig(configInput))
+    const state = initialRestateLifecycleState(config, { _tag: 'Next', sequence: 3 }, 4)
+    const completed = completeRestateLifecycleTick(
+      state,
+      {
+        schemaVersion: 'bayn.lifecycle-command-response.v1',
+        accepted: true,
+        commandId: 'c'.repeat(64),
+        sequence: 3,
+        sourceRevision: config.sourceRevision,
+        replayed: false,
+        nextDelayMs: 30_000,
+        observation: {
+          result: 'SUCCESS',
+          observedAt: '2026-08-10T20:00:00.000Z',
+          outcome: 'RECOVERED',
+        },
+      },
+      '2026-08-10T20:00:01.000Z',
+    )
+    expect(completed).toMatchObject({
+      active: true,
+      epoch: 5,
+      cursor: { _tag: 'Next', sequence: 4 },
+      lastCompletion: { commandId: 'c'.repeat(64), sequence: 3, result: 'SUCCESS', outcome: 'RECOVERED' },
+    })
+  })
+})

--- a/services/bayn/src/restate-lifecycle.ts
+++ b/services/bayn/src/restate-lifecycle.ts
@@ -1,0 +1,236 @@
+import { Data, Result, Schema } from 'effect'
+
+import { lifecycleCommandId, LifecycleControllerKeySchema, LifecycleSequenceSchema } from './lifecycle-command-contract'
+import { maximumOperationalThresholdMs, minimumOperationalThresholdMs } from './config/model'
+import { sha256 } from './hash'
+import { AutonomousCyclePassObservationSchema } from './runtime-state'
+import { GitSourceRevisionSchema, Sha256Schema, UtcInstantSchema, strictParseOptions } from './schemas'
+
+const OperationalThresholdSchema = Schema.Int.check(
+  Schema.isBetween({ minimum: minimumOperationalThresholdMs, maximum: maximumOperationalThresholdMs }),
+)
+const NextDelayMsSchema = Schema.Int.check(Schema.isBetween({ minimum: 1, maximum: maximumOperationalThresholdMs }))
+const PortSchema = Schema.Int.check(Schema.isBetween({ minimum: 1, maximum: 65_535 }))
+const EpochSchema = Schema.Int.check(Schema.isBetween({ minimum: 1, maximum: Number.MAX_SAFE_INTEGER }))
+
+export const RestateLifecycleConfigSchema = Schema.Struct({
+  schemaVersion: Schema.Literal('bayn.restate-lifecycle-config.v1'),
+  controllerKey: LifecycleControllerKeySchema,
+  commandBaseUrl: Schema.Trim.check(Schema.isMinLength(1)),
+  operationTimeoutMs: OperationalThresholdSchema,
+  pollIntervalMs: OperationalThresholdSchema,
+  sourceRevision: GitSourceRevisionSchema,
+  port: PortSchema,
+})
+
+export type RestateLifecycleConfigInput = typeof RestateLifecycleConfigSchema.Type
+
+export interface RestateLifecycleConfig extends RestateLifecycleConfigInput {
+  readonly planHash: string
+}
+
+export class RestateLifecycleConfigError extends Data.TaggedError('RestateLifecycleConfigError')<{
+  readonly reason: 'INVALID_CONFIG' | 'INVALID_COMMAND_URL'
+  readonly message: string
+  readonly cause?: unknown
+}> {}
+
+const validateCommandBaseUrl = (candidate: string): Result.Result<string, RestateLifecycleConfigError> =>
+  Result.try({
+    try: () => {
+      const url = new URL(candidate)
+      if (
+        url.protocol !== 'http:' ||
+        url.username !== '' ||
+        url.password !== '' ||
+        url.search !== '' ||
+        url.hash !== '' ||
+        (url.pathname !== '' && url.pathname !== '/')
+      ) {
+        throw new Error('command URL must be an uncredentialed HTTP origin without path, query, or fragment')
+      }
+      return url.origin
+    },
+    catch: (cause) =>
+      new RestateLifecycleConfigError({
+        reason: 'INVALID_COMMAND_URL',
+        message: 'Bayn lifecycle command URL is invalid',
+        cause,
+      }),
+  })
+
+export const decodeRestateLifecycleConfig = (
+  candidate: unknown,
+): Result.Result<RestateLifecycleConfig, RestateLifecycleConfigError> => {
+  const decoded = Schema.decodeUnknownResult(RestateLifecycleConfigSchema, strictParseOptions)(candidate)
+  if (Result.isFailure(decoded)) {
+    return Result.fail(
+      new RestateLifecycleConfigError({
+        reason: 'INVALID_CONFIG',
+        message: 'Restate lifecycle configuration is invalid',
+        cause: decoded.failure,
+      }),
+    )
+  }
+  const commandBaseUrl = validateCommandBaseUrl(decoded.success.commandBaseUrl)
+  if (Result.isFailure(commandBaseUrl)) return Result.fail(commandBaseUrl.failure)
+  const config = { ...decoded.success, commandBaseUrl: commandBaseUrl.success }
+  return Result.succeed({
+    ...config,
+    planHash: sha256(
+      [
+        config.schemaVersion,
+        config.controllerKey,
+        config.commandBaseUrl,
+        String(config.operationTimeoutMs),
+        String(config.pollIntervalMs),
+        config.sourceRevision,
+      ].join('\n'),
+    ),
+  })
+}
+
+export const RestateLifecycleActivationSchema = Schema.Struct({
+  schemaVersion: Schema.Literal('bayn.restate-lifecycle-activation.v1'),
+  controllerKey: LifecycleControllerKeySchema,
+})
+
+export const RestateLifecycleTickSchema = Schema.Struct({
+  schemaVersion: Schema.Literal('bayn.restate-lifecycle-tick.v1'),
+  epoch: EpochSchema,
+  sequence: LifecycleSequenceSchema,
+})
+
+export type RestateLifecycleTick = typeof RestateLifecycleTickSchema.Type
+
+const LifecycleCommandInputSchema = Schema.Struct({
+  controllerKey: LifecycleControllerKeySchema,
+  commandId: Sha256Schema,
+  sequence: LifecycleSequenceSchema,
+  issuedAt: UtcInstantSchema,
+})
+
+const LifecycleCommandCursorSchema = Schema.Union([
+  Schema.TaggedStruct('Next', { sequence: LifecycleSequenceSchema }),
+  Schema.TaggedStruct('Pending', { command: LifecycleCommandInputSchema }),
+])
+
+export const LifecycleCommandCursorResponseSchema = Schema.Struct({
+  schemaVersion: Schema.Literal('bayn.lifecycle-command-cursor.v1'),
+  controllerKey: LifecycleControllerKeySchema,
+  sourceRevision: GitSourceRevisionSchema,
+  cursor: LifecycleCommandCursorSchema,
+})
+
+export const LifecycleCommandResponseSchema = Schema.Struct({
+  schemaVersion: Schema.Literal('bayn.lifecycle-command-response.v1'),
+  accepted: Schema.Literal(true),
+  commandId: Sha256Schema,
+  sequence: LifecycleSequenceSchema,
+  sourceRevision: GitSourceRevisionSchema,
+  replayed: Schema.Boolean,
+  nextDelayMs: NextDelayMsSchema,
+  observation: AutonomousCyclePassObservationSchema,
+})
+
+export type LifecycleCommandCursorResponse = typeof LifecycleCommandCursorResponseSchema.Type
+export type LifecycleCommandResponse = typeof LifecycleCommandResponseSchema.Type
+
+export interface RestateLifecycleState {
+  readonly schemaVersion: 'bayn.restate-lifecycle-state.v1'
+  readonly active: boolean
+  readonly epoch: number
+  readonly planHash: string
+  readonly sourceRevision: string
+  readonly cursor: LifecycleCommandCursorResponse['cursor']
+  readonly lastCompletion: {
+    readonly commandId: string
+    readonly sequence: number
+    readonly completedAt: string
+    readonly replayed: boolean
+    readonly result: 'SUCCESS' | 'FAILURE'
+    readonly outcome: string
+  } | null
+}
+
+const RestateLifecycleStateSchema = Schema.Struct({
+  schemaVersion: Schema.Literal('bayn.restate-lifecycle-state.v1'),
+  active: Schema.Boolean,
+  epoch: EpochSchema,
+  planHash: Sha256Schema,
+  sourceRevision: GitSourceRevisionSchema,
+  cursor: LifecycleCommandCursorSchema,
+  lastCompletion: Schema.NullOr(
+    Schema.Struct({
+      commandId: Sha256Schema,
+      sequence: LifecycleSequenceSchema,
+      completedAt: UtcInstantSchema,
+      replayed: Schema.Boolean,
+      result: Schema.Literals(['SUCCESS', 'FAILURE']),
+      outcome: Schema.NonEmptyString,
+    }),
+  ),
+})
+
+export const decodeRestateLifecycleActivation = Schema.decodeUnknownResult(
+  RestateLifecycleActivationSchema,
+  strictParseOptions,
+)
+export const decodeRestateLifecycleTick = Schema.decodeUnknownResult(RestateLifecycleTickSchema, strictParseOptions)
+export const decodeRestateLifecycleState = Schema.decodeUnknownResult(RestateLifecycleStateSchema, strictParseOptions)
+export const decodeLifecycleCommandCursorResponse = Schema.decodeUnknownResult(
+  LifecycleCommandCursorResponseSchema,
+  strictParseOptions,
+)
+export const decodeLifecycleCommandResponse = Schema.decodeUnknownResult(
+  LifecycleCommandResponseSchema,
+  strictParseOptions,
+)
+
+export const initialRestateLifecycleState = (
+  config: RestateLifecycleConfig,
+  cursor: LifecycleCommandCursorResponse['cursor'],
+  priorEpoch: number,
+): RestateLifecycleState => ({
+  schemaVersion: 'bayn.restate-lifecycle-state.v1',
+  active: true,
+  epoch: priorEpoch + 1,
+  planHash: config.planHash,
+  sourceRevision: config.sourceRevision,
+  cursor,
+  lastCompletion: null,
+})
+
+export const lifecycleCommandFromCursor = (
+  controllerKey: string,
+  cursor: LifecycleCommandCursorResponse['cursor'],
+  issuedAt: string,
+) =>
+  cursor._tag === 'Pending'
+    ? cursor.command
+    : {
+        controllerKey,
+        commandId: lifecycleCommandId(controllerKey, cursor.sequence),
+        sequence: cursor.sequence,
+        issuedAt,
+      }
+
+export const completeRestateLifecycleTick = (
+  state: RestateLifecycleState,
+  response: LifecycleCommandResponse,
+  completedAt: string,
+): RestateLifecycleState => ({
+  ...state,
+  cursor: { _tag: 'Next', sequence: response.sequence + 1 },
+  lastCompletion: {
+    commandId: response.commandId,
+    sequence: response.sequence,
+    completedAt,
+    replayed: response.replayed,
+    result: response.observation.result,
+    outcome:
+      response.observation.result === 'SUCCESS'
+        ? response.observation.outcome
+        : `${response.observation.operation}/${response.observation.failure}`,
+  },
+})

--- a/services/bayn/src/runtime-state.ts
+++ b/services/bayn/src/runtime-state.ts
@@ -1,11 +1,16 @@
+import { Schema } from 'effect'
+
 import type { RuntimeProvenance } from './contracts'
 import {
   CycleOperationsCondition,
+  MonthEndCadenceCondition,
+  MonthEndCadenceReason,
   type CycleOperationsStatus,
   unknownCycleOperationsStatus,
 } from './cycle-observability'
-import type { CycleRunnerError, CycleRunResult } from './cycle-runner'
 import type { QualificationResult } from './qualification'
+import type { RetainedAutonomousCyclePassObservation } from './cycle-runner/pass-decisions'
+import { IsoDateSchema, UtcInstantSchema } from './schemas'
 import type { EvaluationSummary, ReconciliationResult } from './types'
 
 export interface RuntimePersistenceReceipt {
@@ -59,22 +64,91 @@ export interface BrokerStatus extends BrokerConfiguration {
   readonly error: string | null
 }
 
-export type AutonomousCyclePassObservation =
-  | {
-      readonly result: 'SUCCESS'
-      readonly observedAt: string
-      readonly outcome: CycleRunResult['outcome']
-    }
-  | {
-      readonly result: 'FAILURE'
-      readonly observedAt: string
-      readonly operation: CycleRunnerError['operation']
-      readonly failure: CycleRunnerError['failure']
-      readonly message: string
-    }
+export const MonthEndCadenceDecisionSchema = Schema.Struct({
+  schemaVersion: Schema.Literal('bayn.month-end-cadence-decision.v1'),
+  condition: Schema.Literals([
+    MonthEndCadenceCondition.Due,
+    MonthEndCadenceCondition.ExpectedWait,
+    MonthEndCadenceCondition.Unknown,
+  ]),
+  reason: Schema.Literals([
+    MonthEndCadenceReason.SignalAndExecutionSessionSameMonth,
+    MonthEndCadenceReason.SignalToExecutionMonthTransition,
+    MonthEndCadenceReason.InvalidOrInsufficientCalendarEvidence,
+  ]),
+  signalSessionDate: Schema.NullOr(IsoDateSchema),
+  executionSessionDate: Schema.NullOr(IsoDateSchema),
+  nextEligibility: Schema.Union([
+    Schema.Struct({
+      status: Schema.Literal('PROVEN'),
+      sessionDate: IsoDateSchema,
+      basis: Schema.Literal('EXECUTION_SESSION_MONTH_TRANSITION'),
+    }),
+    Schema.Struct({
+      status: Schema.Literal('UNKNOWN'),
+      reason: Schema.Literals([
+        MonthEndCadenceReason.FutureCalendarEvidenceUnavailable,
+        MonthEndCadenceReason.InvalidOrInsufficientCalendarEvidence,
+      ]),
+    }),
+  ]),
+})
+
+export const AutonomousCyclePassObservationSchema = Schema.Union([
+  Schema.Struct({
+    result: Schema.Literal('SUCCESS'),
+    observedAt: UtcInstantSchema,
+    outcome: Schema.Literals([
+      'NO_PUBLICATION',
+      'ALREADY_ACQUIRED',
+      'ALREADY_TERMINAL',
+      'RESUMED',
+      'RECOVERED',
+      'NOT_DUE',
+      'ACQUIRED',
+      'REACQUIRED',
+    ]),
+    cadenceDecision: Schema.optionalKey(MonthEndCadenceDecisionSchema),
+  }),
+  Schema.Struct({
+    result: Schema.Literal('FAILURE'),
+    observedAt: UtcInstantSchema,
+    operation: Schema.Literals([
+      'acquire-cycle',
+      'bind-publication',
+      'build-decision',
+      'build-cycle',
+      'configure',
+      'inspect-publication',
+      'load-context',
+      'market-calendar',
+      'read-oldest-unfinished',
+      'read-authority-slot',
+      'reconcile-not-due',
+      'recover-cycle',
+      'run-cycle-pass',
+      'select-session',
+    ]),
+    failure: Schema.Literals([
+      'calendar-read',
+      'calendar-unavailable',
+      'context',
+      'contract',
+      'database',
+      'invalid-config',
+      'market-data',
+      'operational',
+      'store',
+    ]),
+    message: Schema.NonEmptyString,
+  }),
+])
+
+export type AutonomousCyclePassObservation = RetainedAutonomousCyclePassObservation
 
 export interface AutonomousCycleLoopStatus {
   readonly configured: boolean
+  readonly owner?: 'Process' | 'Restate'
   readonly startedAt: string | null
   readonly lastPass: AutonomousCyclePassObservation | null
 }
@@ -119,6 +193,7 @@ const unknownDependency = (): DependencyHealth => ({ status: 'UNKNOWN', checkedA
 export interface InitialRuntimeStateInput {
   readonly broker?: BrokerConfiguration | undefined
   readonly autonomousCycleLoopConfigured?: boolean
+  readonly autonomousCycleLoopOwner?: 'Process' | 'Restate'
 }
 
 export const initialState = (input: InitialRuntimeStateInput): RuntimeState => ({
@@ -139,6 +214,7 @@ export const initialState = (input: InitialRuntimeStateInput): RuntimeState => (
   cycle: unknownCycleOperationsStatus(),
   autonomousCycleLoop: {
     configured: input.autonomousCycleLoopConfigured ?? false,
+    owner: input.autonomousCycleLoopOwner ?? 'Process',
     startedAt: null,
     lastPass: null,
   },

--- a/services/bayn/src/startup.test.ts
+++ b/services/bayn/src/startup.test.ts
@@ -113,6 +113,9 @@ const cycleObservability = {
 const brokerlessConfig = (runtime: typeof config): BrokerlessApplicationConfig => ({
   ...runtime,
   runtimeMode: 'BrokerlessService',
+  lifecycleOwner: runtime.lifecycleOwner ?? 'Process',
+  lifecycleCommandPort: runtime.lifecycleCommandPort ?? 8081,
+  lifecycleControllerKey: runtime.lifecycleControllerKey ?? 'primary',
   cyclePollIntervalMs: 30_000,
   execution: {
     brokerIdentity: undefined,


### PR DESCRIPTION
## Summary

- Atomically settles blocked PAPER generations and expires untouched approved intents under the existing WriterFence before OBSERVE recovery.
- Adds a durable PostgreSQL lifecycle-command ledger, source-bound idempotent HTTP command, and keyed Restate virtual object with durable delayed self-scheduling.
- Keeps Bayn as the sole broker, database, and WriterFence owner while exposing truthful lifecycle readiness, status, metrics, and Effect JSON logs.
- Packages the lifecycle worker and registration entry points without activating Restate ownership in this source PR.

## Related Issues

None

## Testing

- bun run --cwd services/bayn test
- BAYN_TEST_POSTGRES_URL=postgresql://bayn:REDACTED@127.0.0.1:55439/bayn_test bun run --cwd services/bayn test:postgres
- bun run --cwd services/bayn build
- bun run --cwd services/bayn test:effect-runtime
- env -u BAYN_ALPACA_ACCOUNT_ID -u BAYN_ALPACA_KEY_ID -u BAYN_ALPACA_SECRET_KEY bun run --cwd services/bayn test:broker-sandbox
- bun run --cwd services/bayn tsc:all
- bun run --cwd services/bayn tsc:production
- bun run --cwd services/bayn lint:oxlint:type
- bun run --cwd services/bayn lint
- bun test services/bayn/src/db/cycle-store/architecture.test.ts

## Breaking Changes

Adds PostgreSQL migrations 0031 and 0032. Runtime ownership still defaults to PROCESS and this PR does not activate or deploy the Restate lifecycle.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; breaking changes are documented.
- [x] Documentation, release notes, and follow-ups are updated or tracked.