### PR TITLE
ci(bayn): version Restate lifecycle deployment

### DIFF
--- a/.github/workflows/bayn-promotion-eligibility.yml
+++ b/.github/workflows/bayn-promotion-eligibility.yml
@@ -61,6 +61,9 @@ jobs:
         with:
           bun-version: 1.3.14
 
+      - name: Install verifier dependencies
+        run: bun install --frozen-lockfile --ignore-scripts --filter @proompteng/scripts
+
       - name: Require exact-head review and immutable promotion provenance
         env:
           GH_TOKEN: ${{ github.token }}
@@ -102,6 +105,9 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.14
+
+      - name: Install verifier dependencies
+        run: bun install --frozen-lockfile --ignore-scripts --filter @proompteng/scripts
 
       - name: Refresh the exact-head gate when eligibility changes
         env:

--- a/.github/workflows/bayn-promotion-eligibility.yml
+++ b/.github/workflows/bayn-promotion-eligibility.yml
@@ -16,6 +16,8 @@ on:
       - 'argocd/applications/bayn/deployment.yaml'
       - 'argocd/applications/bayn/kustomization.yaml'
       - 'argocd/applicationsets/product.yaml'
+      - 'argocd/applications/bayn/lifecycle-current.yaml'
+      - 'argocd/applications/bayn/lifecycle-previous.yaml'
   issue_comment:
     types:
       - created

--- a/.github/workflows/bayn-release.yml
+++ b/.github/workflows/bayn-release.yml
@@ -70,6 +70,7 @@ jobs:
           git merge-base --is-ancestor "$source_sha" HEAD
           git diff --quiet "$source_sha..HEAD" -- \
             services/bayn \
+            packages/scripts/src/bayn/lifecycle-manifests.ts \
             packages/scripts/src/bayn/update-manifests.ts \
             nix/images/bayn.nix \
             nix/images/bayn-runtime-root.nix \
@@ -173,6 +174,8 @@ jobs:
           git diff --exit-code -- \
             argocd/applications/bayn/kustomization.yaml \
             argocd/applications/bayn/deployment.yaml \
+            argocd/applications/bayn/lifecycle-current.yaml \
+            argocd/applications/bayn/lifecycle-previous.yaml \
             argocd/applicationsets/product.yaml
           {
             echo '## Bayn candidate image held'
@@ -196,6 +199,8 @@ jobs:
           add-paths: |
             argocd/applications/bayn/kustomization.yaml
             argocd/applications/bayn/deployment.yaml
+            argocd/applications/bayn/lifecycle-current.yaml
+            argocd/applications/bayn/lifecycle-previous.yaml
             argocd/applicationsets/product.yaml
           body: |
             ## Summary

--- a/.github/workflows/bayn-release.yml
+++ b/.github/workflows/bayn-release.yml
@@ -110,6 +110,9 @@ jobs:
             substituters = http://attic.attic.svc.cluster.local/lab https://cache.nixos.org/
             extra-trusted-public-keys = ${{ vars.ATTIC_PUBLIC_KEY }}
 
+      - name: Install manifest renderer dependencies
+        run: bun install --frozen-lockfile --ignore-scripts --filter @proompteng/scripts
+
       - name: Verify image and decide promotion
         id: promotion
         shell: bash

--- a/argocd/applications/bayn/deployment.yaml
+++ b/argocd/applications/bayn/deployment.yaml
@@ -39,14 +39,19 @@ spec:
           type: RuntimeDefault
       containers:
         - name: bayn
-          image: registry.ide-newton.ts.net/lab/bayn
+          image: bayn-main
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
               containerPort: 8080
               protocol: TCP
+            - name: lifecycle-command
+              containerPort: 8081
+              protocol: TCP
           env:
             - name: BAYN_CODE_REVISION
+              value: 3a36fc2b3d80a323560f2ee03a1faed81dffcc29
+            - name: BAYN_LIFECYCLE_PREVIOUS_SOURCE_REVISION
               value: 3a36fc2b3d80a323560f2ee03a1faed81dffcc29
             - name: BAYN_IMAGE_REPOSITORY
               value: registry.ide-newton.ts.net/lab/bayn
@@ -176,12 +181,28 @@ spec:
               drop:
                 - ALL
           volumeMounts:
+            - name: bayn-lifecycle-reviewer
+              mountPath: /var/run/secrets/bayn-lifecycle-reviewer
+              readOnly: true
             - name: tmp
               mountPath: /tmp
             - name: postgres-ca
               mountPath: /var/run/secrets/bayn/postgres
               readOnly: true
       volumes:
+        - name: bayn-lifecycle-reviewer
+          projected:
+            defaultMode: 0444
+            sources:
+              - serviceAccountToken:
+                  audience: https://kubernetes.default.svc.cluster.local
+                  expirationSeconds: 3600
+                  path: token
+              - configMap:
+                  name: kube-root-ca.crt
+                  items:
+                    - key: ca.crt
+                      path: ca.crt
         - name: tmp
           emptyDir:
             sizeLimit: 256Mi

--- a/argocd/applications/bayn/kustomization.yaml
+++ b/argocd/applications/bayn/kustomization.yaml
@@ -20,7 +20,7 @@ configMapGenerator:
     files:
       - squid.conf
 images:
-  - name: registry.ide-newton.ts.net/lab/bayn
+  - name: bayn-main
     newName: registry.ide-newton.ts.net/lab/bayn
     newTag: "sha-3a36fc2b3d80a323560f2ee03a1faed81dffcc29"
     digest: sha256:f936106f72ac3de75b7e338cb2b780e59fa1498cd756e68dcc8c38f6e29d6192

--- a/argocd/applications/bayn/lifecycle-current.yaml
+++ b/argocd/applications/bayn/lifecycle-current.yaml
@@ -1,0 +1,402 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bayn-lifecycle-3a36fc2b3d80
+  labels:
+    app.kubernetes.io/name: bayn-lifecycle
+    app.kubernetes.io/part-of: bayn
+    app.kubernetes.io/version: 3a36fc2b3d80
+  annotations:
+    bayn.proompteng.ai/source-revision: 3a36fc2b3d80a323560f2ee03a1faed81dffcc29
+spec:
+  replicas: 1
+  revisionHistoryLimit: 1
+  progressDeadlineSeconds: 600
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: bayn-lifecycle
+      app.kubernetes.io/version: 3a36fc2b3d80
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: bayn-lifecycle
+        app.kubernetes.io/part-of: bayn
+        app.kubernetes.io/version: 3a36fc2b3d80
+    spec:
+      serviceAccountName: bayn-lifecycle
+      automountServiceAccountToken: false
+      terminationGracePeriodSeconds: 30
+      nodeSelector:
+        kubernetes.io/arch: arm64
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: lifecycle
+          image: registry.ide-newton.ts.net/lab/bayn:sha-3a36fc2b3d80a323560f2ee03a1faed81dffcc29@sha256:f936106f72ac3de75b7e338cb2b780e59fa1498cd756e68dcc8c38f6e29d6192
+          imagePullPolicy: IfNotPresent
+          command:
+            - node
+            - dist/restate-lifecycle-server.js
+          ports:
+            - name: restate
+              containerPort: 9080
+              protocol: TCP
+          env:
+            - name: BAYN_CODE_REVISION
+              value: 3a36fc2b3d80a323560f2ee03a1faed81dffcc29
+            - name: BAYN_LIFECYCLE_CONTROLLER_KEY
+              value: primary
+            - name: BAYN_LIFECYCLE_COMMAND_URL
+              value: http://bayn-lifecycle-command.bayn.svc.cluster.local:8081
+            - name: BAYN_LIFECYCLE_COMMAND_TOKEN_PATH
+              value: /var/run/secrets/bayn-lifecycle-command/token
+            - name: BAYN_OPERATION_TIMEOUT_MS
+              value: "30000"
+            - name: BAYN_CYCLE_POLL_INTERVAL_MS
+              value: "30000"
+            - name: PORT
+              value: "9080"
+            - name: NODE_ENV
+              value: production
+          startupProbe:
+            tcpSocket:
+              port: restate
+            periodSeconds: 2
+            failureThreshold: 30
+          readinessProbe:
+            tcpSocket:
+              port: restate
+            periodSeconds: 5
+            timeoutSeconds: 2
+            failureThreshold: 2
+          livenessProbe:
+            tcpSocket:
+              port: restate
+            periodSeconds: 10
+            timeoutSeconds: 2
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 50m
+              memory: 96Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: command-identity
+              mountPath: /var/run/secrets/bayn-lifecycle-command
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: command-identity
+          projected:
+            defaultMode: 0444
+            sources:
+              - serviceAccountToken:
+                  audience: bayn.proompteng.ai/lifecycle-command
+                  expirationSeconds: 3600
+                  path: token
+        - name: tmp
+          emptyDir:
+            sizeLimit: 64Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: bayn-lifecycle-3a36fc2b3d80
+  labels:
+    app.kubernetes.io/name: bayn-lifecycle
+    app.kubernetes.io/part-of: bayn
+    app.kubernetes.io/version: 3a36fc2b3d80
+  annotations:
+    bayn.proompteng.ai/source-revision: 3a36fc2b3d80a323560f2ee03a1faed81dffcc29
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: bayn-lifecycle
+    app.kubernetes.io/version: 3a36fc2b3d80
+  ports:
+    - name: restate
+      port: 9080
+      targetPort: restate
+      protocol: TCP
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: bayn-lifecycle
+  labels:
+    app.kubernetes.io/name: bayn-lifecycle
+    app.kubernetes.io/part-of: bayn
+automountServiceAccountToken: false
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: bayn-lifecycle-token-reviewer
+  labels:
+    app.kubernetes.io/name: bayn-lifecycle-command
+    app.kubernetes.io/part-of: bayn
+rules:
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: bayn-lifecycle-token-reviewer
+  labels:
+    app.kubernetes.io/name: bayn-lifecycle-command
+    app.kubernetes.io/part-of: bayn
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: bayn-lifecycle-token-reviewer
+subjects:
+  - kind: ServiceAccount
+    name: bayn
+    namespace: bayn
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: bayn-lifecycle-command
+  labels:
+    app.kubernetes.io/name: bayn-lifecycle-command
+    app.kubernetes.io/part-of: bayn
+spec:
+  type: ClusterIP
+  publishNotReadyAddresses: true
+  selector:
+    app.kubernetes.io/name: bayn
+  ports:
+    - name: lifecycle-command
+      port: 8081
+      targetPort: lifecycle-command
+      protocol: TCP
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: bayn-lifecycle-command
+  labels:
+    app.kubernetes.io/name: bayn-lifecycle-command
+    app.kubernetes.io/part-of: bayn
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: bayn
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: bayn-lifecycle
+      ports:
+        - port: lifecycle-command
+          protocol: TCP
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: bayn-lifecycle-token-review
+  labels:
+    app.kubernetes.io/name: bayn-lifecycle-command
+    app.kubernetes.io/part-of: bayn
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: bayn
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 10.96.0.1/32
+      ports:
+        - port: 443
+          protocol: TCP
+    # This cluster evaluates Service traffic after translation to the control-plane endpoint. Keep the API VIP above
+    # and permit only the current control-plane endpoints on the secure API port.
+    - to:
+        - ipBlock:
+            cidr: 100.100.244.141/32
+        - ipBlock:
+            cidr: 100.100.244.142/32
+        - ipBlock:
+            cidr: 100.100.244.190/32
+      ports:
+        - port: 6443
+          protocol: TCP
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: bayn-lifecycle-worker
+  labels:
+    app.kubernetes.io/name: bayn-lifecycle
+    app.kubernetes.io/part-of: bayn
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: bayn-lifecycle
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: restate
+          podSelector:
+            matchLabels:
+              app: restate
+      ports:
+        - port: restate
+          protocol: TCP
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: bayn
+      ports:
+        - port: lifecycle-command
+          protocol: TCP
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: bayn-lifecycle-register
+  labels:
+    app.kubernetes.io/name: bayn-lifecycle-register
+    app.kubernetes.io/part-of: bayn
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: bayn-lifecycle-register
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: restate
+          podSelector:
+            matchLabels:
+              app: restate
+      ports:
+        - port: 9070
+          protocol: TCP
+        - port: 8080
+          protocol: TCP
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: bayn-lifecycle-register-3a36fc2b3d80
+  labels:
+    app.kubernetes.io/name: bayn-lifecycle-register
+    app.kubernetes.io/part-of: bayn
+    app.kubernetes.io/version: 3a36fc2b3d80
+  annotations:
+    # The command Service publishes not-ready Bayn endpoints, so this same-wave hook can activate the first durable
+    # tick that makes strict Restate-owned readiness healthy. PostSync would deadlock behind that readiness gate.
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation,HookSucceeded
+spec:
+  backoffLimit: 6
+  activeDeadlineSeconds: 600
+  ttlSecondsAfterFinished: 300
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: bayn-lifecycle-register
+        app.kubernetes.io/part-of: bayn
+        app.kubernetes.io/version: 3a36fc2b3d80
+    spec:
+      serviceAccountName: bayn
+      automountServiceAccountToken: false
+      restartPolicy: OnFailure
+      nodeSelector:
+        kubernetes.io/arch: arm64
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: register
+          image: registry.ide-newton.ts.net/lab/bayn:sha-3a36fc2b3d80a323560f2ee03a1faed81dffcc29@sha256:f936106f72ac3de75b7e338cb2b780e59fa1498cd756e68dcc8c38f6e29d6192
+          imagePullPolicy: IfNotPresent
+          command:
+            - node
+            - dist/restate-lifecycle-register.js
+          env:
+            - name: BAYN_CODE_REVISION
+              value: 3a36fc2b3d80a323560f2ee03a1faed81dffcc29
+            - name: BAYN_LIFECYCLE_CONTROLLER_KEY
+              value: primary
+            - name: BAYN_RESTATE_ENDPOINT_URI
+              value: http://bayn-lifecycle-3a36fc2b3d80.bayn.svc.cluster.local:9080
+            - name: RESTATE_ADMIN_ORIGIN
+              value: http://restate.restate.svc.cluster.local:9070
+            - name: RESTATE_INGRESS_ORIGIN
+              value: http://restate.restate.svc.cluster.local:8080
+            - name: NODE_ENV
+              value: production
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+            limits:
+              cpu: 250m
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL

--- a/argocd/applications/bayn/lifecycle-previous.yaml
+++ b/argocd/applications/bayn/lifecycle-previous.yaml
@@ -1,0 +1,3 @@
+apiVersion: v1
+kind: List
+items: []

--- a/argocd/applications/restate/networkpolicy.yaml
+++ b/argocd/applications/restate/networkpolicy.yaml
@@ -30,6 +30,16 @@ spec:
     - from:
         - namespaceSelector:
             matchLabels:
+              kubernetes.io/metadata.name: bayn
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/name: bayn-lifecycle-register
+      ports:
+        - port: admin
+          protocol: TCP
+    - from:
+        - namespaceSelector:
+            matchLabels:
               kubernetes.io/metadata.name: tailscale
           podSelector:
             matchLabels:

--- a/packages/scripts/src/bayn/bayn-promotion-eligibility-workflow.test.ts
+++ b/packages/scripts/src/bayn/bayn-promotion-eligibility-workflow.test.ts
@@ -90,6 +90,21 @@ describe('Bayn promotion eligibility workflow', () => {
     expect(workflow).toContain('timeout-minutes: 8')
   })
 
+  test('installs locked verifier dependencies in every job before executing the verifier', () => {
+    const install = 'bun install --frozen-lockfile --ignore-scripts --filter @proompteng/scripts'
+    const verifier = 'bun packages/scripts/src/bayn/verify-promotion-eligibility.ts'
+    const requiredStart = workflow.indexOf('  required:')
+    const refreshStart = workflow.indexOf('  refresh:')
+    const required = workflow.slice(requiredStart, refreshStart)
+    const refresh = workflow.slice(refreshStart)
+
+    expect(workflow.split(install).length - 1).toBe(2)
+    expect(required.indexOf(install)).toBeGreaterThan(-1)
+    expect(required.indexOf(install)).toBeLessThan(required.indexOf(verifier))
+    expect(refresh.indexOf(install)).toBeGreaterThan(-1)
+    expect(refresh.indexOf(install)).toBeLessThan(refresh.indexOf(verifier))
+  })
+
   test('refreshes the exact-head gate in both directions without touching unrelated pull requests', () => {
     expect(workflow).toContain('name: Refresh the exact-head gate when eligibility changes')
     expect(workflow).toContain("github.event_name == 'schedule'")

--- a/packages/scripts/src/bayn/bayn-release-workflow.test.ts
+++ b/packages/scripts/src/bayn/bayn-release-workflow.test.ts
@@ -7,6 +7,7 @@ const buildPushWorkflow = readFileSync(
   'utf8',
 )
 const baynCiWorkflow = readFileSync(new URL('../../../../.github/workflows/bayn-ci.yml', import.meta.url), 'utf8')
+const releaseWorkflow = readFileSync(new URL('../../../../.github/workflows/bayn-release.yml', import.meta.url), 'utf8')
 
 test('publishes the exact main push SHA without a post-merge review verifier', () => {
   expect(buildPushWorkflow).toContain('branches:\n      - main')
@@ -38,4 +39,10 @@ test('keeps the existing Bayn PR gate aggregation', () => {
     'test-command: bun run --cwd services/bayn tsc && bun run --cwd services/bayn test && bun test packages/scripts/src/bayn',
   )
   expect(baynCiWorkflow).not.toContain('verify-release-review')
+})
+
+test('holds release when the lifecycle manifest renderer changed after the built source', () => {
+  expect(releaseWorkflow).toContain('git diff --quiet "$source_sha..HEAD" --')
+  expect(releaseWorkflow).toContain('packages/scripts/src/bayn/lifecycle-manifests.ts \\')
+  expect(releaseWorkflow.split('packages/scripts/src/bayn/lifecycle-manifests.ts').length - 1).toBe(1)
 })

--- a/packages/scripts/src/bayn/bayn-release-workflow.test.ts
+++ b/packages/scripts/src/bayn/bayn-release-workflow.test.ts
@@ -46,3 +46,10 @@ test('holds release when the lifecycle manifest renderer changed after the built
   expect(releaseWorkflow).toContain('packages/scripts/src/bayn/lifecycle-manifests.ts \\')
   expect(releaseWorkflow.split('packages/scripts/src/bayn/lifecycle-manifests.ts').length - 1).toBe(1)
 })
+
+test('installs locked manifest renderer dependencies before executing the release renderer', () => {
+  const install = 'bun install --frozen-lockfile --ignore-scripts --filter @proompteng/scripts'
+  const render = 'bun packages/scripts/src/bayn/update-manifests.ts'
+  expect(releaseWorkflow.split(install).length - 1).toBe(1)
+  expect(releaseWorkflow.indexOf(install)).toBeLessThan(releaseWorkflow.indexOf(render))
+})

--- a/packages/scripts/src/bayn/lifecycle-manifests.test.ts
+++ b/packages/scripts/src/bayn/lifecycle-manifests.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
+
+import {
+  advanceBaynLifecycleManifests,
+  baynLifecycleIsActive,
+  parseBaynLifecycleCurrent,
+  parseBaynLifecyclePrevious,
+  renderBaynLifecycleCurrent,
+  renderBaynLifecyclePrevious,
+  validateBaynLifecycleActivation,
+  validateBaynLifecyclePromotion,
+  validateBaynLifecycleCommandAuthentication,
+  validateBaynLifecycleCommandPort,
+  validateBaynLifecycleOperationTimeout,
+  type BaynLifecycleImagePin,
+} from './lifecycle-manifests'
+
+const pin = (character: string): BaynLifecycleImagePin => {
+  const sourceSha = character.repeat(40)
+  return {
+    sourceSha,
+    tag: `sha-${sourceSha}`,
+    digest: `sha256:${character.repeat(64)}`,
+  }
+}
+
+const inactiveKustomization = 'resources:\n  - deployment.yaml\n'
+const activeKustomization = `${inactiveKustomization}  - lifecycle-current.yaml\n  - lifecycle-previous.yaml\n`
+
+describe('Bayn lifecycle release manifests', () => {
+  test('renders canonical source-versioned current and empty previous endpoints', () => {
+    const current = renderBaynLifecycleCurrent(pin('a'))
+
+    expect(parseBaynLifecycleCurrent(current)).toEqual(pin('a'))
+    expect(parseBaynLifecyclePrevious(renderBaynLifecyclePrevious(null))).toBeNull()
+    expect(current).toContain('name: bayn-lifecycle-aaaaaaaaaaaa')
+    expect(current).toContain(`image: registry.ide-newton.ts.net/lab/bayn:${pin('a').tag}@${pin('a').digest}`)
+    expect(current).toContain('argocd.argoproj.io/hook: Sync')
+    expect(current).not.toContain('argocd.argoproj.io/hook: PostSync')
+    expect(current).toContain('name: bayn-lifecycle-command')
+    expect(current).toContain('name: bayn-lifecycle-worker')
+    expect(current).toContain('name: bayn-lifecycle-register')
+    expect(current).toContain('serviceAccountName: bayn-lifecycle')
+    expect(current).toContain('audience: bayn.proompteng.ai/lifecycle-command')
+    expect(current).toContain('name: bayn-lifecycle-token-reviewer')
+    expect(current).toContain('- tokenreviews')
+    expect(current).toContain('cidr: 10.96.0.1/32')
+    expect(current).toContain('name: BAYN_OPERATION_TIMEOUT_MS')
+    expect(current).not.toContain('secretKeyRef:')
+    expect(current).not.toContain('BAYN_ALPACA_')
+    expect(current).not.toContain('DATABASE_URL')
+  })
+
+  test('keeps the checked-in dormant endpoints canonical and inactive', () => {
+    const current = readFileSync(
+      new URL('../../../../argocd/applications/bayn/lifecycle-current.yaml', import.meta.url),
+      'utf8',
+    )
+    const previous = readFileSync(
+      new URL('../../../../argocd/applications/bayn/lifecycle-previous.yaml', import.meta.url),
+      'utf8',
+    )
+    const kustomization = readFileSync(
+      new URL('../../../../argocd/applications/bayn/kustomization.yaml', import.meta.url),
+      'utf8',
+    )
+    const deployment = readFileSync(
+      new URL('../../../../argocd/applications/bayn/deployment.yaml', import.meta.url),
+      'utf8',
+    )
+
+    expect(parseBaynLifecycleCurrent(current)).toEqual({
+      sourceSha: '3a36fc2b3d80a323560f2ee03a1faed81dffcc29',
+      tag: 'sha-3a36fc2b3d80a323560f2ee03a1faed81dffcc29',
+      digest: 'sha256:f936106f72ac3de75b7e338cb2b780e59fa1498cd756e68dcc8c38f6e29d6192',
+    })
+    expect(parseBaynLifecyclePrevious(previous)).toBeNull()
+    expect(baynLifecycleIsActive(kustomization)).toBeFalse()
+    expect(() => validateBaynLifecycleCommandPort(deployment)).not.toThrow()
+    expect(() => validateBaynLifecycleCommandAuthentication(deployment)).not.toThrow()
+    expect(() => validateBaynLifecycleOperationTimeout(deployment)).not.toThrow()
+    expect(() => validateBaynLifecycleActivation(deployment, kustomization)).not.toThrow()
+    expect(() =>
+      validateBaynLifecycleCommandPort(
+        deployment.replace(
+          `            - name: lifecycle-command\n              containerPort: 8081\n              protocol: TCP\n`,
+          '',
+        ),
+      ),
+    ).toThrow('Bayn deployment must expose exactly one lifecycle-command container port on TCP 8081')
+    expect(() =>
+      validateBaynLifecycleCommandAuthentication(
+        deployment.replace(
+          `            - name: bayn-lifecycle-reviewer\n              mountPath: /var/run/secrets/bayn-lifecycle-reviewer\n              readOnly: true\n`,
+          '',
+        ),
+      ),
+    ).toThrow('Bayn deployment must mount exactly one read-only lifecycle TokenReview identity')
+    expect(() =>
+      validateBaynLifecycleOperationTimeout(
+        deployment.replace(
+          `            - name: BAYN_OPERATION_TIMEOUT_MS\n              value: "30000"\n`,
+          `            - name: BAYN_OPERATION_TIMEOUT_MS\n              value: "60000"\n`,
+        ),
+      ),
+    ).toThrow('Bayn and Restate lifecycle must share BAYN_OPERATION_TIMEOUT_MS=30000')
+  })
+
+  test('switches lifecycle resources and ownership as one activation boundary', () => {
+    const deployment = readFileSync(
+      new URL('../../../../argocd/applications/bayn/deployment.yaml', import.meta.url),
+      'utf8',
+    )
+    const restateOwnedDeployment = deployment.replace(
+      '            - name: BAYN_LIFECYCLE_PREVIOUS_SOURCE_REVISION\n',
+      '            - name: BAYN_LIFECYCLE_OWNER\n              value: RESTATE\n            - name: BAYN_LIFECYCLE_PREVIOUS_SOURCE_REVISION\n',
+    )
+
+    expect(() => validateBaynLifecycleActivation(deployment, activeKustomization)).toThrow(
+      'active Bayn lifecycle resources require BAYN_LIFECYCLE_OWNER=RESTATE',
+    )
+    expect(() => validateBaynLifecycleActivation(restateOwnedDeployment, inactiveKustomization)).toThrow(
+      'BAYN_LIFECYCLE_OWNER=RESTATE requires active Bayn lifecycle resources',
+    )
+    expect(() => validateBaynLifecycleActivation(restateOwnedDeployment, activeKustomization)).not.toThrow()
+  })
+
+  test('updates only the dormant current endpoint before activation', () => {
+    const base = {
+      current: renderBaynLifecycleCurrent(pin('a')),
+      previous: renderBaynLifecyclePrevious(null),
+    }
+
+    expect(advanceBaynLifecycleManifests({ base, kustomization: inactiveKustomization, next: pin('b') })).toEqual({
+      current: renderBaynLifecycleCurrent(pin('b')),
+      previous: renderBaynLifecyclePrevious(null),
+    })
+  })
+
+  test('retains exactly one prior immutable endpoint after activation', () => {
+    const base = {
+      current: renderBaynLifecycleCurrent(pin('b')),
+      previous: renderBaynLifecyclePrevious(pin('a')),
+    }
+    const head = advanceBaynLifecycleManifests({ base, kustomization: activeKustomization, next: pin('c') })
+
+    expect(parseBaynLifecycleCurrent(head.current)).toEqual(pin('c'))
+    expect(parseBaynLifecyclePrevious(head.previous)).toEqual(pin('b'))
+    expect(validateBaynLifecyclePromotion({ base, head, baseKustomization: activeKustomization, next: pin('c') })).toBe(
+      null,
+    )
+  })
+
+  test('rejects partial activation and noncanonical endpoint changes', () => {
+    expect(() => baynLifecycleIsActive('resources:\n  - lifecycle-current.yaml\n')).toThrow(
+      'current and previous resources must be activated together',
+    )
+    expect(() => parseBaynLifecycleCurrent(`${renderBaynLifecycleCurrent(pin('a'))}# unexpected\n`)).toThrow(
+      'not canonical',
+    )
+  })
+})

--- a/packages/scripts/src/bayn/lifecycle-manifests.ts
+++ b/packages/scripts/src/bayn/lifecycle-manifests.ts
@@ -1,0 +1,664 @@
+import { parse } from 'yaml'
+
+const sourceShaPattern = /^[0-9a-f]{40}$/
+const tagPattern = /^[A-Za-z0-9._-]{1,128}$/
+const digestPattern = /^sha256:[0-9a-f]{64}$/
+const imageRepository = 'registry.ide-newton.ts.net/lab/bayn'
+export const baynLifecycleOperationTimeoutMs = 30_000
+
+export const baynLifecycleCurrentPath = 'argocd/applications/bayn/lifecycle-current.yaml'
+export const baynLifecyclePreviousPath = 'argocd/applications/bayn/lifecycle-previous.yaml'
+
+export interface BaynLifecycleImagePin {
+  readonly sourceSha: string
+  readonly tag: string
+  readonly digest: string
+}
+
+export interface BaynLifecycleManifestPair {
+  readonly current: string
+  readonly previous: string
+}
+
+const validatePin = (pin: BaynLifecycleImagePin): void => {
+  if (!sourceShaPattern.test(pin.sourceSha)) throw new Error(`invalid lifecycle source SHA: ${pin.sourceSha}`)
+  if (!tagPattern.test(pin.tag)) throw new Error(`invalid lifecycle image tag: ${pin.tag}`)
+  if (!digestPattern.test(pin.digest)) throw new Error(`invalid lifecycle image digest: ${pin.digest}`)
+  if (pin.tag !== `sha-${pin.sourceSha}`) {
+    throw new Error(`lifecycle image tag ${pin.tag} does not bind source ${pin.sourceSha}`)
+  }
+}
+
+const version = (sourceSha: string): string => sourceSha.slice(0, 12)
+const workloadName = (sourceSha: string): string => `bayn-lifecycle-${version(sourceSha)}`
+const image = (pin: BaynLifecycleImagePin): string => `${imageRepository}:${pin.tag}@${pin.digest}`
+
+const record = (value: unknown): value is Record<string, unknown> => typeof value === 'object' && value !== null
+
+const baynPodSpec = (deployment: string): Record<string, unknown> => {
+  const manifest: unknown = parse(deployment)
+  const spec = record(manifest) && record(manifest.spec) ? manifest.spec : undefined
+  const template = spec !== undefined && record(spec.template) ? spec.template : undefined
+  const podSpec = template !== undefined && record(template.spec) ? template.spec : undefined
+  if (podSpec === undefined) throw new Error('Bayn deployment must contain a pod spec')
+  return podSpec
+}
+
+const baynContainer = (deployment: string): Record<string, unknown> => {
+  const podSpec = baynPodSpec(deployment)
+  const containers = podSpec !== undefined && Array.isArray(podSpec.containers) ? podSpec.containers : []
+  const baynContainers = containers.filter((container) => record(container) && container.name === 'bayn')
+  if (baynContainers.length !== 1 || !record(baynContainers[0])) {
+    throw new Error('Bayn deployment must contain exactly one bayn container')
+  }
+  return baynContainers[0]
+}
+
+export const validateBaynLifecycleCommandPort = (deployment: string): void => {
+  const container = baynContainer(deployment)
+  const ports = container.ports
+  const lifecyclePorts = Array.isArray(ports)
+    ? ports.filter(
+        (port) =>
+          record(port) && port.name === 'lifecycle-command' && port.containerPort === 8081 && port.protocol === 'TCP',
+      )
+    : []
+  if (lifecyclePorts.length !== 1) {
+    throw new Error('Bayn deployment must expose exactly one lifecycle-command container port on TCP 8081')
+  }
+}
+
+export const validateBaynLifecycleCommandAuthentication = (deployment: string): void => {
+  const container = baynContainer(deployment)
+  const mounts = Array.isArray(container.volumeMounts) ? container.volumeMounts : []
+  const reviewerMounts = mounts.filter(
+    (mount) =>
+      record(mount) &&
+      mount.name === 'bayn-lifecycle-reviewer' &&
+      mount.mountPath === '/var/run/secrets/bayn-lifecycle-reviewer' &&
+      mount.readOnly === true,
+  )
+  if (reviewerMounts.length !== 1) {
+    throw new Error('Bayn deployment must mount exactly one read-only lifecycle TokenReview identity')
+  }
+  const volumes = baynPodSpec(deployment).volumes
+  const reviewerVolumes = Array.isArray(volumes)
+    ? volumes.filter((volume) => record(volume) && volume.name === 'bayn-lifecycle-reviewer')
+    : []
+  if (reviewerVolumes.length !== 1 || !record(reviewerVolumes[0]?.projected)) {
+    throw new Error('Bayn deployment must project exactly one lifecycle TokenReview identity')
+  }
+  const projected = reviewerVolumes[0].projected
+  const sources = Array.isArray(projected.sources) ? projected.sources : []
+  const serviceAccountTokens = sources.filter(
+    (source) =>
+      record(source) &&
+      record(source.serviceAccountToken) &&
+      source.serviceAccountToken.audience === 'https://kubernetes.default.svc.cluster.local' &&
+      source.serviceAccountToken.expirationSeconds === 3600 &&
+      source.serviceAccountToken.path === 'token',
+  )
+  const rootCas = sources.filter(
+    (source) =>
+      record(source) &&
+      record(source.configMap) &&
+      source.configMap.name === 'kube-root-ca.crt' &&
+      Array.isArray(source.configMap.items) &&
+      source.configMap.items.length === 1 &&
+      record(source.configMap.items[0]) &&
+      source.configMap.items[0].key === 'ca.crt' &&
+      source.configMap.items[0].path === 'ca.crt',
+  )
+  if (projected.defaultMode !== 444 || serviceAccountTokens.length !== 1 || rootCas.length !== 1) {
+    throw new Error('Bayn lifecycle TokenReview identity must be bounded, audience-bound, and CA-verified')
+  }
+}
+
+export const validateBaynLifecycleOperationTimeout = (deployment: string): void => {
+  const environment = baynContainer(deployment).env
+  const timeouts = Array.isArray(environment)
+    ? environment.filter((entry) => record(entry) && entry.name === 'BAYN_OPERATION_TIMEOUT_MS')
+    : []
+  if (
+    timeouts.length !== 1 ||
+    !record(timeouts[0]) ||
+    timeouts[0].value !== baynLifecycleOperationTimeoutMs.toString()
+  ) {
+    throw new Error(
+      `Bayn and Restate lifecycle must share BAYN_OPERATION_TIMEOUT_MS=${baynLifecycleOperationTimeoutMs.toString()}`,
+    )
+  }
+}
+
+const lifecycleOwner = (deployment: string): string | undefined => {
+  const environment = baynContainer(deployment).env
+  const owners = Array.isArray(environment)
+    ? environment.filter((entry) => record(entry) && entry.name === 'BAYN_LIFECYCLE_OWNER')
+    : []
+  if (owners.length === 0) return undefined
+  if (owners.length !== 1 || !record(owners[0]) || typeof owners[0].value !== 'string') {
+    throw new Error('Bayn deployment must contain at most one literal BAYN_LIFECYCLE_OWNER value')
+  }
+  return owners[0].value
+}
+
+const workerManifest = (pin: BaynLifecycleImagePin): string => {
+  const name = workloadName(pin.sourceSha)
+  return `apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ${name}
+  labels:
+    app.kubernetes.io/name: bayn-lifecycle
+    app.kubernetes.io/part-of: bayn
+    app.kubernetes.io/version: ${version(pin.sourceSha)}
+  annotations:
+    bayn.proompteng.ai/source-revision: ${pin.sourceSha}
+spec:
+  replicas: 1
+  revisionHistoryLimit: 1
+  progressDeadlineSeconds: 600
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: bayn-lifecycle
+      app.kubernetes.io/version: ${version(pin.sourceSha)}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: bayn-lifecycle
+        app.kubernetes.io/part-of: bayn
+        app.kubernetes.io/version: ${version(pin.sourceSha)}
+    spec:
+      serviceAccountName: bayn-lifecycle
+      automountServiceAccountToken: false
+      terminationGracePeriodSeconds: 30
+      nodeSelector:
+        kubernetes.io/arch: arm64
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: lifecycle
+          image: ${image(pin)}
+          imagePullPolicy: IfNotPresent
+          command:
+            - node
+            - dist/restate-lifecycle-server.js
+          ports:
+            - name: restate
+              containerPort: 9080
+              protocol: TCP
+          env:
+            - name: BAYN_CODE_REVISION
+              value: ${pin.sourceSha}
+            - name: BAYN_LIFECYCLE_CONTROLLER_KEY
+              value: primary
+            - name: BAYN_LIFECYCLE_COMMAND_URL
+              value: http://bayn-lifecycle-command.bayn.svc.cluster.local:8081
+            - name: BAYN_LIFECYCLE_COMMAND_TOKEN_PATH
+              value: /var/run/secrets/bayn-lifecycle-command/token
+            - name: BAYN_OPERATION_TIMEOUT_MS
+              value: "${baynLifecycleOperationTimeoutMs.toString()}"
+            - name: BAYN_CYCLE_POLL_INTERVAL_MS
+              value: "30000"
+            - name: PORT
+              value: "9080"
+            - name: NODE_ENV
+              value: production
+          startupProbe:
+            tcpSocket:
+              port: restate
+            periodSeconds: 2
+            failureThreshold: 30
+          readinessProbe:
+            tcpSocket:
+              port: restate
+            periodSeconds: 5
+            timeoutSeconds: 2
+            failureThreshold: 2
+          livenessProbe:
+            tcpSocket:
+              port: restate
+            periodSeconds: 10
+            timeoutSeconds: 2
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 50m
+              memory: 96Mi
+            limits:
+              cpu: 500m
+              memory: 256Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: command-identity
+              mountPath: /var/run/secrets/bayn-lifecycle-command
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: command-identity
+          projected:
+            defaultMode: 0444
+            sources:
+              - serviceAccountToken:
+                  audience: bayn.proompteng.ai/lifecycle-command
+                  expirationSeconds: 3600
+                  path: token
+        - name: tmp
+          emptyDir:
+            sizeLimit: 64Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ${name}
+  labels:
+    app.kubernetes.io/name: bayn-lifecycle
+    app.kubernetes.io/part-of: bayn
+    app.kubernetes.io/version: ${version(pin.sourceSha)}
+  annotations:
+    bayn.proompteng.ai/source-revision: ${pin.sourceSha}
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: bayn-lifecycle
+    app.kubernetes.io/version: ${version(pin.sourceSha)}
+  ports:
+    - name: restate
+      port: 9080
+      targetPort: restate
+      protocol: TCP
+`
+}
+
+export const renderBaynLifecycleCurrent = (pin: BaynLifecycleImagePin): string => {
+  validatePin(pin)
+  const name = workloadName(pin.sourceSha)
+  return `${workerManifest(pin)}---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: bayn-lifecycle
+  labels:
+    app.kubernetes.io/name: bayn-lifecycle
+    app.kubernetes.io/part-of: bayn
+automountServiceAccountToken: false
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: bayn-lifecycle-token-reviewer
+  labels:
+    app.kubernetes.io/name: bayn-lifecycle-command
+    app.kubernetes.io/part-of: bayn
+rules:
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: bayn-lifecycle-token-reviewer
+  labels:
+    app.kubernetes.io/name: bayn-lifecycle-command
+    app.kubernetes.io/part-of: bayn
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: bayn-lifecycle-token-reviewer
+subjects:
+  - kind: ServiceAccount
+    name: bayn
+    namespace: bayn
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: bayn-lifecycle-command
+  labels:
+    app.kubernetes.io/name: bayn-lifecycle-command
+    app.kubernetes.io/part-of: bayn
+spec:
+  type: ClusterIP
+  publishNotReadyAddresses: true
+  selector:
+    app.kubernetes.io/name: bayn
+  ports:
+    - name: lifecycle-command
+      port: 8081
+      targetPort: lifecycle-command
+      protocol: TCP
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: bayn-lifecycle-command
+  labels:
+    app.kubernetes.io/name: bayn-lifecycle-command
+    app.kubernetes.io/part-of: bayn
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: bayn
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: bayn-lifecycle
+      ports:
+        - port: lifecycle-command
+          protocol: TCP
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: bayn-lifecycle-token-review
+  labels:
+    app.kubernetes.io/name: bayn-lifecycle-command
+    app.kubernetes.io/part-of: bayn
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: bayn
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 10.96.0.1/32
+      ports:
+        - port: 443
+          protocol: TCP
+    # This cluster evaluates Service traffic after translation to the control-plane endpoint. Keep the API VIP above
+    # and permit only the current control-plane endpoints on the secure API port.
+    - to:
+        - ipBlock:
+            cidr: 100.100.244.141/32
+        - ipBlock:
+            cidr: 100.100.244.142/32
+        - ipBlock:
+            cidr: 100.100.244.190/32
+      ports:
+        - port: 6443
+          protocol: TCP
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: bayn-lifecycle-worker
+  labels:
+    app.kubernetes.io/name: bayn-lifecycle
+    app.kubernetes.io/part-of: bayn
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: bayn-lifecycle
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: restate
+          podSelector:
+            matchLabels:
+              app: restate
+      ports:
+        - port: restate
+          protocol: TCP
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    - to:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: bayn
+      ports:
+        - port: lifecycle-command
+          protocol: TCP
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: bayn-lifecycle-register
+  labels:
+    app.kubernetes.io/name: bayn-lifecycle-register
+    app.kubernetes.io/part-of: bayn
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: bayn-lifecycle-register
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: restate
+          podSelector:
+            matchLabels:
+              app: restate
+      ports:
+        - port: 9070
+          protocol: TCP
+        - port: 8080
+          protocol: TCP
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: bayn-lifecycle-register-${version(pin.sourceSha)}
+  labels:
+    app.kubernetes.io/name: bayn-lifecycle-register
+    app.kubernetes.io/part-of: bayn
+    app.kubernetes.io/version: ${version(pin.sourceSha)}
+  annotations:
+    # The command Service publishes not-ready Bayn endpoints, so this same-wave hook can activate the first durable
+    # tick that makes strict Restate-owned readiness healthy. PostSync would deadlock behind that readiness gate.
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation,HookSucceeded
+spec:
+  backoffLimit: 6
+  activeDeadlineSeconds: 600
+  ttlSecondsAfterFinished: 300
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: bayn-lifecycle-register
+        app.kubernetes.io/part-of: bayn
+        app.kubernetes.io/version: ${version(pin.sourceSha)}
+    spec:
+      serviceAccountName: bayn
+      automountServiceAccountToken: false
+      restartPolicy: OnFailure
+      nodeSelector:
+        kubernetes.io/arch: arm64
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: register
+          image: ${image(pin)}
+          imagePullPolicy: IfNotPresent
+          command:
+            - node
+            - dist/restate-lifecycle-register.js
+          env:
+            - name: BAYN_CODE_REVISION
+              value: ${pin.sourceSha}
+            - name: BAYN_LIFECYCLE_CONTROLLER_KEY
+              value: primary
+            - name: BAYN_RESTATE_ENDPOINT_URI
+              value: http://${name}.bayn.svc.cluster.local:9080
+            - name: RESTATE_ADMIN_ORIGIN
+              value: http://restate.restate.svc.cluster.local:9070
+            - name: RESTATE_INGRESS_ORIGIN
+              value: http://restate.restate.svc.cluster.local:8080
+            - name: NODE_ENV
+              value: production
+          resources:
+            requests:
+              cpu: 25m
+              memory: 64Mi
+            limits:
+              cpu: 250m
+              memory: 128Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+`
+}
+
+export const renderBaynLifecyclePrevious = (pin: BaynLifecycleImagePin | null): string => {
+  if (pin === null) return 'apiVersion: v1\nkind: List\nitems: []\n'
+  validatePin(pin)
+  return workerManifest(pin)
+}
+
+const firstMatch = (source: string, pattern: RegExp, name: string): string => {
+  const match = pattern.exec(source)?.[1]
+  if (match === undefined) throw new Error(`expected ${name}`)
+  return match
+}
+
+export const parseBaynLifecycleCurrent = (source: string): BaynLifecycleImagePin => {
+  const sourceSha = firstMatch(
+    source,
+    /^    bayn\.proompteng\.ai\/source-revision: ([0-9a-f]{40})$/m,
+    'current lifecycle source revision',
+  )
+  const reference = firstMatch(
+    source,
+    /^          image: (registry\.ide-newton\.ts\.net\/lab\/bayn:[^@\n]+@sha256:[0-9a-f]{64})$/m,
+    'current lifecycle image',
+  )
+  const imageMatch = /^registry\.ide-newton\.ts\.net\/lab\/bayn:([^@]+)@(sha256:[0-9a-f]{64})$/.exec(reference)
+  if (imageMatch?.[1] === undefined || imageMatch[2] === undefined) throw new Error('invalid current lifecycle image')
+  const pin = { sourceSha, tag: imageMatch[1], digest: imageMatch[2] }
+  validatePin(pin)
+  if (source !== renderBaynLifecycleCurrent(pin)) throw new Error('current lifecycle manifest is not canonical')
+  return pin
+}
+
+export const parseBaynLifecyclePrevious = (source: string): BaynLifecycleImagePin | null => {
+  if (source === renderBaynLifecyclePrevious(null)) return null
+  const sourceSha = firstMatch(
+    source,
+    /^    bayn\.proompteng\.ai\/source-revision: ([0-9a-f]{40})$/m,
+    'previous lifecycle source revision',
+  )
+  const reference = firstMatch(
+    source,
+    /^          image: (registry\.ide-newton\.ts\.net\/lab\/bayn:[^@\n]+@sha256:[0-9a-f]{64})$/m,
+    'previous lifecycle image',
+  )
+  const imageMatch = /^registry\.ide-newton\.ts\.net\/lab\/bayn:([^@]+)@(sha256:[0-9a-f]{64})$/.exec(reference)
+  if (imageMatch?.[1] === undefined || imageMatch[2] === undefined) throw new Error('invalid previous lifecycle image')
+  const pin = { sourceSha, tag: imageMatch[1], digest: imageMatch[2] }
+  validatePin(pin)
+  if (source !== renderBaynLifecyclePrevious(pin)) throw new Error('previous lifecycle manifest is not canonical')
+  return pin
+}
+
+export const baynLifecycleIsActive = (kustomization: string): boolean => {
+  const current = /^  - lifecycle-current\.yaml$/m.test(kustomization)
+  const previous = /^  - lifecycle-previous\.yaml$/m.test(kustomization)
+  if (current !== previous) throw new Error('Bayn lifecycle current and previous resources must be activated together')
+  return current
+}
+
+export const validateBaynLifecycleActivation = (deployment: string, kustomization: string): void => {
+  const active = baynLifecycleIsActive(kustomization)
+  const owner = lifecycleOwner(deployment)
+  if (active && owner !== 'RESTATE') {
+    throw new Error('active Bayn lifecycle resources require BAYN_LIFECYCLE_OWNER=RESTATE')
+  }
+  if (!active && owner === 'RESTATE') {
+    throw new Error('BAYN_LIFECYCLE_OWNER=RESTATE requires active Bayn lifecycle resources')
+  }
+  if (owner !== undefined && owner !== 'PROCESS' && owner !== 'RESTATE') {
+    throw new Error(`invalid BAYN_LIFECYCLE_OWNER value: ${owner}`)
+  }
+}
+
+export const advanceBaynLifecycleManifests = (input: {
+  readonly base: BaynLifecycleManifestPair
+  readonly kustomization: string
+  readonly next: BaynLifecycleImagePin
+}): BaynLifecycleManifestPair => {
+  const current = parseBaynLifecycleCurrent(input.base.current)
+  parseBaynLifecyclePrevious(input.base.previous)
+  return {
+    current: renderBaynLifecycleCurrent(input.next),
+    previous: baynLifecycleIsActive(input.kustomization) ? renderBaynLifecyclePrevious(current) : input.base.previous,
+  }
+}
+
+export const validateBaynLifecyclePromotion = (input: {
+  readonly base: BaynLifecycleManifestPair
+  readonly head: BaynLifecycleManifestPair
+  readonly baseKustomization: string
+  readonly next: BaynLifecycleImagePin
+}): string | null => {
+  try {
+    const expected = advanceBaynLifecycleManifests({
+      base: input.base,
+      kustomization: input.baseKustomization,
+      next: input.next,
+    })
+    if (input.head.current !== expected.current)
+      return `${baynLifecycleCurrentPath} is not the exact next source endpoint`
+    if (input.head.previous !== expected.previous) {
+      return `${baynLifecyclePreviousPath} does not retain exactly the prior source endpoint`
+    }
+    return null
+  } catch (error) {
+    return error instanceof Error ? error.message : 'Bayn lifecycle manifest validation failed'
+  }
+}

--- a/packages/scripts/src/bayn/update-manifests.test.ts
+++ b/packages/scripts/src/bayn/update-manifests.test.ts
@@ -9,6 +9,7 @@ import {
   type BaynCandidateRuntime,
   type UpdateBaynManifestOptions,
 } from './update-manifests'
+import { renderBaynLifecycleCurrent, renderBaynLifecyclePrevious } from './lifecycle-manifests'
 
 const currentSnapshotId = '840c75885270b349d4a992e003918ce7e6fe39730f981a20b2e88ae2db45a2e2'
 const strategyBehaviorHash = '1'.repeat(64)
@@ -44,6 +45,8 @@ interface FixturePaths {
   readonly kustomizationPath: string
   readonly deploymentPath: string
   readonly applicationSetPath: string
+  readonly lifecycleCurrentPath: string
+  readonly lifecyclePreviousPath: string
 }
 
 let directory: string | undefined
@@ -62,6 +65,8 @@ const makeFixture = (options: FixtureOptions = {}): FixturePaths => {
     kustomizationPath: join(directory, 'kustomization.yaml'),
     deploymentPath: join(directory, 'deployment.yaml'),
     applicationSetPath: join(directory, 'product.yaml'),
+    lifecycleCurrentPath: join(directory, 'lifecycle-current.yaml'),
+    lifecyclePreviousPath: join(directory, 'lifecycle-previous.yaml'),
   }
   const bindings = {
     ...currentBindings,
@@ -73,6 +78,7 @@ const makeFixture = (options: FixtureOptions = {}): FixturePaths => {
   const pin = options.qualificationRunId === undefined ? qualificationRunId : options.qualificationRunId
   const environment = [
     environmentBlock('BAYN_CODE_REVISION', '0'.repeat(40)),
+    environmentBlock('BAYN_LIFECYCLE_PREVIOUS_SOURCE_REVISION', 'f'.repeat(40)),
     environmentBlock('BAYN_IMAGE_REPOSITORY', 'registry.ide-newton.ts.net/lab/bayn'),
     environmentBlock('BAYN_IMAGE_DIGEST', `sha256:${'0'.repeat(64)}`),
     environmentBlock('BAYN_STRATEGY_BEHAVIOR_HASH', options.behaviorHash ?? strategyBehaviorHash),
@@ -86,7 +92,7 @@ const makeFixture = (options: FixtureOptions = {}): FixturePaths => {
 
   writeFileSync(
     paths.kustomizationPath,
-    'images:\n  - name: registry.ide-newton.ts.net/lab/bayn\n    newName: registry.ide-newton.ts.net/lab/bayn\n    newTag: bootstrap\n',
+    'images:\n  - name: bayn-main\n    newName: registry.ide-newton.ts.net/lab/bayn\n    newTag: bootstrap\n',
   )
   writeFileSync(
     paths.deploymentPath,
@@ -96,6 +102,15 @@ const makeFixture = (options: FixtureOptions = {}): FixturePaths => {
     paths.applicationSetPath,
     'elements:\n              - name: bayn\n                path: argocd/applications/bayn\n                enabled: "false"\n              - name: next\n                enabled: "true"\n',
   )
+  writeFileSync(
+    paths.lifecycleCurrentPath,
+    renderBaynLifecycleCurrent({
+      sourceSha: '0'.repeat(40),
+      tag: `sha-${'0'.repeat(40)}`,
+      digest: `sha256:${'0'.repeat(64)}`,
+    }),
+  )
+  writeFileSync(paths.lifecyclePreviousPath, renderBaynLifecyclePrevious(null))
   return paths
 }
 
@@ -144,9 +159,30 @@ describe('Bayn manifest promotion', () => {
     expect(readFileSync(paths.deploymentPath, 'utf8')).toContain(
       environmentBlock('BAYN_QUALIFICATION_RUN_ID', qualificationRunId).trim(),
     )
+    expect(readFileSync(paths.deploymentPath, 'utf8')).toContain(
+      `- name: BAYN_LIFECYCLE_PREVIOUS_SOURCE_REVISION\n              value: ${'0'.repeat(40)}`,
+    )
     expect(readFileSync(paths.kustomizationPath, 'utf8')).not.toContain('qualification-dossier')
     expect(readFileSync(paths.deploymentPath, 'utf8')).not.toContain('qualification-dossier')
     expect(readFileSync(paths.applicationSetPath, 'utf8')).toContain('enabled: "true"')
+    expect(readFileSync(paths.lifecycleCurrentPath, 'utf8')).toContain(`source-revision: ${'a'.repeat(40)}`)
+    expect(readFileSync(paths.lifecyclePreviousPath, 'utf8')).toBe(renderBaynLifecyclePrevious(null))
+  })
+
+  test('rotates one prior lifecycle endpoint only after lifecycle activation', () => {
+    const paths = makeFixture()
+    writeFileSync(
+      paths.kustomizationPath,
+      `${readFileSync(paths.kustomizationPath, 'utf8')}resources:\n  - lifecycle-current.yaml\n  - lifecycle-previous.yaml\n`,
+    )
+
+    promote(paths)
+
+    expect(readFileSync(paths.lifecycleCurrentPath, 'utf8')).toContain(`source-revision: ${'a'.repeat(40)}`)
+    expect(readFileSync(paths.lifecyclePreviousPath, 'utf8')).toContain(`source-revision: ${'0'.repeat(40)}`)
+    expect(readFileSync(paths.deploymentPath, 'utf8')).toContain(
+      `- name: BAYN_LIFECYCLE_PREVIOUS_SOURCE_REVISION\n              value: ${'0'.repeat(40)}`,
+    )
   })
 
   test('preserves and replaces qualification using only the run-ID pin', () => {

--- a/packages/scripts/src/bayn/update-manifests.ts
+++ b/packages/scripts/src/bayn/update-manifests.ts
@@ -3,6 +3,12 @@
 import { readFileSync, writeFileSync } from 'node:fs'
 import process from 'node:process'
 
+import {
+  advanceBaynLifecycleManifests,
+  baynLifecycleCurrentPath,
+  baynLifecyclePreviousPath,
+} from './lifecycle-manifests'
+
 const digestPattern = /^sha256:[0-9a-f]{64}$/
 const hashPattern = /^[0-9a-f]{64}$/
 const sourceShaPattern = /^[0-9a-f]{40}$/
@@ -39,6 +45,8 @@ export interface UpdateBaynManifestOptions {
   readonly kustomizationPath?: string
   readonly deploymentPath?: string
   readonly applicationSetPath?: string
+  readonly lifecycleCurrentPath?: string
+  readonly lifecyclePreviousPath?: string
 }
 
 export interface BaynManifestUpdate {
@@ -209,6 +217,8 @@ export const updateBaynManifests = (options: UpdateBaynManifestOptions): BaynMan
   const kustomizationPath = options.kustomizationPath ?? 'argocd/applications/bayn/kustomization.yaml'
   const deploymentPath = options.deploymentPath ?? 'argocd/applications/bayn/deployment.yaml'
   const applicationSetPath = options.applicationSetPath ?? 'argocd/applicationsets/product.yaml'
+  const lifecycleCurrentManifestPath = options.lifecycleCurrentPath ?? baynLifecycleCurrentPath
+  const lifecyclePreviousManifestPath = options.lifecyclePreviousPath ?? baynLifecyclePreviousPath
   const kustomization = readFileSync(kustomizationPath, 'utf8')
   const deployment = readFileSync(deploymentPath, 'utf8')
   const qualificationPins = [...deployment.matchAll(new RegExp(qualificationPin.source, 'g'))]
@@ -337,7 +347,7 @@ export const updateBaynManifests = (options: UpdateBaynManifestOptions): BaynMan
     }
   }
   const imageBlock =
-    /(  - name: registry\.ide-newton\.ts\.net\/lab\/bayn\n    newName: registry\.ide-newton\.ts\.net\/lab\/bayn\n    newTag: )[^\n]+(?:\n    digest: [^\n]+)?/
+    /(  - name: bayn-main\n    newName: registry\.ide-newton\.ts\.net\/lab\/bayn\n    newTag: )[^\n]+(?:\n    digest: [^\n]+)?/
   const updatedKustomization = replaceExactlyOnce(
     kustomization,
     imageBlock,
@@ -350,6 +360,12 @@ export const updateBaynManifests = (options: UpdateBaynManifestOptions): BaynMan
     /(            - name: BAYN_CODE_REVISION\n              value: )[^\n]+/,
     `$1${options.sourceSha}`,
     'BAYN_CODE_REVISION value',
+  )
+  updatedDeployment = replaceExactlyOnce(
+    updatedDeployment,
+    /(            - name: BAYN_LIFECYCLE_PREVIOUS_SOURCE_REVISION\n              value: )[^\n]+/,
+    `$1${deployedSourceSha}`,
+    'BAYN_LIFECYCLE_PREVIOUS_SOURCE_REVISION value',
   )
   updatedDeployment = replaceExactlyOnce(
     updatedDeployment,
@@ -398,9 +414,20 @@ export const updateBaynManifests = (options: UpdateBaynManifestOptions): BaynMan
     'Bayn ApplicationSet enabled state',
   )
 
+  const lifecycle = advanceBaynLifecycleManifests({
+    base: {
+      current: readFileSync(lifecycleCurrentManifestPath, 'utf8'),
+      previous: readFileSync(lifecyclePreviousManifestPath, 'utf8'),
+    },
+    kustomization,
+    next: { sourceSha: options.sourceSha, tag: options.tag, digest: options.digest },
+  })
+
   writeFileSync(kustomizationPath, updatedKustomization)
   writeFileSync(deploymentPath, updatedDeployment)
   writeFileSync(applicationSetPath, updatedApplicationSet)
+  writeFileSync(lifecycleCurrentManifestPath, lifecycle.current)
+  writeFileSync(lifecyclePreviousManifestPath, lifecycle.previous)
   return {
     promotionAction: 'promote',
     promotionReason: 'eligible',

--- a/packages/scripts/src/bayn/verify-promotion-automerge.test.ts
+++ b/packages/scripts/src/bayn/verify-promotion-automerge.test.ts
@@ -39,6 +39,7 @@ const snapshot = (): BaynPromotionAutomergeSnapshot => ({
     files: [
       { path: 'argocd/applications/bayn/deployment.yaml', status: 'MODIFIED' },
       { path: 'argocd/applications/bayn/kustomization.yaml', status: 'MODIFIED' },
+      { path: 'argocd/applications/bayn/lifecycle-current.yaml', status: 'MODIFIED' },
     ],
   },
   checks: [
@@ -124,7 +125,7 @@ describe('Bayn promotion auto-merge decision', () => {
     ).toBe('automerge-opted-out')
   })
 
-  test('requires exactly the two modified Bayn manifests', () => {
+  test('requires all release-owned manifests and permits only bounded lifecycle rotation', () => {
     const missing = snapshot()
     const extra = snapshot()
     const renamed = snapshot()
@@ -135,6 +136,19 @@ describe('Bayn promotion auto-merge decision', () => {
         pullRequest: { ...missing.pullRequest, files: missing.pullRequest.files.slice(0, 1) },
       }),
     ).toBe('promotion-paths-mismatch')
+    const rotated = snapshot()
+    expect(
+      decisionCode({
+        ...rotated,
+        pullRequest: {
+          ...rotated.pullRequest,
+          files: [
+            ...rotated.pullRequest.files,
+            { path: 'argocd/applications/bayn/lifecycle-previous.yaml', status: 'MODIFIED' },
+          ],
+        },
+      }),
+    ).toBe('eligible')
     expect(
       decisionCode({
         ...extra,

--- a/packages/scripts/src/bayn/verify-promotion-automerge.ts
+++ b/packages/scripts/src/bayn/verify-promotion-automerge.ts
@@ -8,7 +8,13 @@ export const baynPromotionBranch = 'codex/bayn-release-current'
 export const baynPromotionAutomergeManifestPaths = [
   'argocd/applications/bayn/deployment.yaml',
   'argocd/applications/bayn/kustomization.yaml',
+  'argocd/applications/bayn/lifecycle-current.yaml',
 ] as const
+
+const optionalPromotionManifestPaths = new Set([
+  'argocd/applications/bayn/lifecycle-previous.yaml',
+  'argocd/applicationsets/product.yaml',
+])
 
 export const baynPromotionAutomergeRequiredChecks = [
   { workflow: 'Semantic Commits', name: 'Lint commit messages' },
@@ -188,16 +194,16 @@ export const decideBaynPromotionAutomerge = (
     return hold('automerge-opted-out', `PR #${pullRequest.number} has the do-not-automerge label`)
   }
 
-  const expectedPaths = [...baynPromotionAutomergeManifestPaths].sort()
-  const actualPaths = pullRequest.files.map(({ path }) => path).sort()
+  const expectedPaths = new Set<string>(baynPromotionAutomergeManifestPaths)
+  const actualPaths = new Set(pullRequest.files.map(({ path }) => path))
   if (
-    actualPaths.length !== expectedPaths.length ||
-    actualPaths.some((path, index) => path !== expectedPaths[index]) ||
+    [...expectedPaths].some((path) => !actualPaths.has(path)) ||
+    [...actualPaths].some((path) => !expectedPaths.has(path) && !optionalPromotionManifestPaths.has(path)) ||
     pullRequest.files.some(({ status }) => status !== 'MODIFIED')
   ) {
     return hold(
       'promotion-paths-mismatch',
-      `PR #${pullRequest.number} must modify exactly the two existing Bayn promotion manifests`,
+      `PR #${pullRequest.number} must modify the exact Bayn release manifests and no unrelated path`,
     )
   }
 

--- a/packages/scripts/src/bayn/verify-promotion-eligibility.test.ts
+++ b/packages/scripts/src/bayn/verify-promotion-eligibility.test.ts
@@ -3,6 +3,8 @@ import { readFileSync } from 'node:fs'
 import { describe, expect, test } from 'bun:test'
 import { parse } from 'yaml'
 
+import { renderBaynLifecycleCurrent, renderBaynLifecyclePrevious } from './lifecycle-manifests'
+
 import {
   baynPromotionCodexBotLogin,
   baynPromotionCodexReviewer,
@@ -75,10 +77,16 @@ spec:
     spec:
       containers:
         - name: bayn
-          image: registry.ide-newton.ts.net/lab/bayn
+          image: bayn-main
+          ports:
+            - name: lifecycle-command
+              containerPort: 8081
+              protocol: TCP
           env:
             - name: BAYN_CODE_REVISION
               value: ${pins.sourceSha}
+            - name: BAYN_LIFECYCLE_PREVIOUS_SOURCE_REVISION
+              value: ${oldSourceSha}
             - name: BAYN_IMAGE_REPOSITORY
               value: registry.ide-newton.ts.net/lab/bayn
             - name: BAYN_IMAGE_DIGEST
@@ -119,7 +127,7 @@ namespace: bayn
 resources:
   - deployment.yaml
 images:
-  - name: registry.ide-newton.ts.net/lab/bayn
+  - name: bayn-main
     newName: registry.ide-newton.ts.net/lab/bayn
     newTag: ${JSON.stringify(pins.tag)}
     digest: ${pins.digest}
@@ -143,6 +151,8 @@ const manifests = (pins: ManifestPins, enabled = true): BaynPromotionManifestCon
   deployment: deployment(pins),
   kustomization: kustomization(pins),
   applicationSet: applicationSet(enabled),
+  lifecycleCurrent: renderBaynLifecycleCurrent(pins),
+  lifecyclePrevious: renderBaynLifecyclePrevious(null),
 })
 
 const basePins: ManifestPins = {
@@ -180,6 +190,11 @@ const pullRequest = (overrides: Partial<BaynPromotionPullRequest> = {}): BaynPro
     },
     {
       path: 'argocd/applications/bayn/kustomization.yaml',
+      status: 'modified',
+      previousPath: null,
+    },
+    {
+      path: 'argocd/applications/bayn/lifecycle-current.yaml',
       status: 'modified',
       previousPath: null,
     },
@@ -664,10 +679,34 @@ describe('Bayn promotion eligibility', () => {
     ['image tag', { ...headPins, tag: `sha-${staleHeadSha}` }, 'promotion-pin-inconsistent'],
     ['image digest', { ...headPins, digest: `sha256:${'9'.repeat(64)}` }, 'release-contract-mismatch'],
   ] as const)('rejects an altered %s', (_name, alteredPins, expectedCode) => {
-    const altered = manifests(alteredPins)
+    const valid = manifests(headPins)
+    const altered =
+      _name === 'source revision'
+        ? { ...valid, deployment: valid.deployment.replace(sourceSha, staleHeadSha) }
+        : _name === 'image tag'
+          ? { ...valid, kustomization: valid.kustomization.replace(headPins.tag, alteredPins.tag) }
+          : manifests(alteredPins)
     expect(evaluate(snapshot({ headManifests: altered }))).toMatchObject({
       status: 'hold',
       code: expectedCode,
+    })
+  })
+
+  test('rejects a command boundary that does not retain exactly the promotion base source', () => {
+    const valid = manifests(headPins)
+    expect(
+      evaluate(
+        snapshot({
+          headManifests: {
+            ...valid,
+            deployment: valid.deployment.replace(`value: ${oldSourceSha}`, `value: ${staleHeadSha}`),
+          },
+        }),
+      ),
+    ).toMatchObject({
+      status: 'hold',
+      code: 'promotion-pin-inconsistent',
+      message: 'Bayn command boundary does not retain exactly the prior lifecycle source revision',
     })
   })
 
@@ -752,6 +791,13 @@ describe('Bayn promotion eligibility', () => {
     expect(buildWorkflow.on.push.paths).toBeUndefined()
     for (const pattern of buildWorkflow.on.push.paths ?? []) {
       const path = representativeBuildTriggerPath(pattern)
+      expect(isBaynPromotionSourceAffectingPath(path)).toBeTrue()
+    }
+    for (const path of [
+      'packages/scripts/src/bayn/lifecycle-manifests.ts',
+      'packages/scripts/src/bayn/update-manifests.ts',
+      'nix/images/bayn.nix',
+    ]) {
       expect(isBaynPromotionSourceAffectingPath(path)).toBeTrue()
     }
     for (const path of [
@@ -1123,11 +1169,15 @@ describe('bounded GitHub failure handling', () => {
       ['argocd/applications/bayn/deployment.yaml', manifests(headPins).deployment],
       ['argocd/applications/bayn/kustomization.yaml', manifests(headPins).kustomization],
       ['argocd/applicationsets/product.yaml', manifests(headPins).applicationSet],
+      ['argocd/applications/bayn/lifecycle-current.yaml', manifests(headPins).lifecycleCurrent],
+      ['argocd/applications/bayn/lifecycle-previous.yaml', manifests(headPins).lifecyclePrevious],
     ])
     const baseManifestByPath = new Map([
       ['argocd/applications/bayn/deployment.yaml', manifests(basePins).deployment],
       ['argocd/applications/bayn/kustomization.yaml', manifests(basePins).kustomization],
       ['argocd/applicationsets/product.yaml', manifests(basePins).applicationSet],
+      ['argocd/applications/bayn/lifecycle-current.yaml', manifests(basePins).lifecycleCurrent],
+      ['argocd/applications/bayn/lifecycle-previous.yaml', manifests(basePins).lifecyclePrevious],
     ])
     const emptyConnection = { nodes: [], pageInfo: { hasNextPage: false, endCursor: null } }
     const forcePushConnection = {
@@ -1789,14 +1839,15 @@ describe('real release provenance discovery regression', () => {
         const path = decodeURIComponent(parsed.pathname.split('/contents/')[1] ?? '')
         const ref = parsed.searchParams.get('ref')
         const pins = ref === realPromotionHeadSha ? realHeadPins : basePins
-        const content =
-          manifests(pins)[
-            path.endsWith('deployment.yaml')
-              ? 'deployment'
-              : path.endsWith('kustomization.yaml')
-                ? 'kustomization'
-                : 'applicationSet'
-          ]
+        const pinManifests = manifests(pins)
+        const content = new Map([
+          ['argocd/applications/bayn/deployment.yaml', pinManifests.deployment],
+          ['argocd/applications/bayn/kustomization.yaml', pinManifests.kustomization],
+          ['argocd/applicationsets/product.yaml', pinManifests.applicationSet],
+          ['argocd/applications/bayn/lifecycle-current.yaml', pinManifests.lifecycleCurrent],
+          ['argocd/applications/bayn/lifecycle-previous.yaml', pinManifests.lifecyclePrevious],
+        ]).get(path)
+        if (content === undefined) throw new Error(`unexpected manifest ${path}`)
         return Response.json({
           type: 'file',
           encoding: 'base64',

--- a/packages/scripts/src/bayn/verify-promotion-eligibility.ts
+++ b/packages/scripts/src/bayn/verify-promotion-eligibility.ts
@@ -3,6 +3,17 @@
 import { inflateRawSync } from 'node:zlib'
 import process from 'node:process'
 
+import {
+  baynLifecycleCurrentPath,
+  baynLifecyclePreviousPath,
+  parseBaynLifecycleCurrent,
+  parseBaynLifecyclePrevious,
+  validateBaynLifecycleActivation,
+  validateBaynLifecycleCommandPort,
+  validateBaynLifecyclePromotion,
+  type BaynLifecycleImagePin,
+} from './lifecycle-manifests'
+
 const githubApiVersion = '2022-11-28'
 const githubGraphqlUrl = 'https://api.github.com/graphql'
 const maximumGraphqlPages = 20
@@ -28,14 +39,18 @@ export const baynPromotionManifestPaths = [
   'argocd/applications/bayn/deployment.yaml',
   'argocd/applications/bayn/kustomization.yaml',
   'argocd/applicationsets/product.yaml',
+  baynLifecycleCurrentPath,
+  baynLifecyclePreviousPath,
 ] as const
 
 const deploymentPath = baynPromotionManifestPaths[0]
 const kustomizationPath = baynPromotionManifestPaths[1]
 const applicationSetPath = baynPromotionManifestPaths[2]
+const lifecycleCurrentPath = baynPromotionManifestPaths[3]
 const promotionPathSet = new Set<string>(baynPromotionManifestPaths)
 
 const exactBaynBuildInputPaths = new Set([
+  'packages/scripts/src/bayn/lifecycle-manifests.ts',
   'packages/scripts/src/bayn/update-manifests.ts',
   'nix/images/bayn.nix',
   'nix/images/bayn-runtime-root.nix',
@@ -69,6 +84,7 @@ export const isBaynPromotionSourceAffectingPath = (path: string): boolean =>
 
 const mutableDeploymentEnvironmentNames = [
   'BAYN_CODE_REVISION',
+  'BAYN_LIFECYCLE_PREVIOUS_SOURCE_REVISION',
   'BAYN_IMAGE_DIGEST',
   'BAYN_STRATEGY_BEHAVIOR_HASH',
   'BAYN_STRATEGY_PARAMETER_HASH',
@@ -145,6 +161,8 @@ export interface BaynPromotionManifestContents {
   readonly deployment: string
   readonly kustomization: string
   readonly applicationSet: string
+  readonly lifecycleCurrent: string
+  readonly lifecyclePrevious: string
 }
 
 export interface BaynReleaseContract {
@@ -317,6 +335,7 @@ export class GitHubPromotionEligibilityError extends Error {
 
 interface BaynPromotionPins {
   readonly sourceSha: string
+  readonly lifecyclePreviousSourceRevision: string
   readonly tag: string
   readonly digest: string
   readonly deploymentRepository: string
@@ -324,6 +343,7 @@ interface BaynPromotionPins {
   readonly kustomizationNewName: string
   readonly rolloutTimestamp: string
   readonly applicationEnabled: boolean
+  readonly lifecycleCurrent: BaynLifecycleImagePin
 }
 
 const shortSha = (sha: string): string => sha.slice(0, 12)
@@ -515,7 +535,7 @@ const rolloutTimestamp = (deployment: string): string => {
 
 const kustomizationImage = (kustomization: string) => {
   const pattern = /  - name: ([^\n]+)\n    newName: ([^\n]+)\n    newTag: ([^\n]+)\n    digest: ([^\n]+)\n/g
-  const matches = [...kustomization.matchAll(pattern)].filter((match) => match[1]?.trim() === expectedImage)
+  const matches = [...kustomization.matchAll(pattern)].filter((match) => match[1]?.trim() === 'bayn-main')
   if (matches.length !== 1) throw new Error('expected exactly one Bayn kustomization image block')
   const [match] = matches
   if (
@@ -543,9 +563,14 @@ const applicationEnabled = (applicationSet: string): boolean => {
 }
 
 export const parseBaynPromotionPins = (manifests: BaynPromotionManifestContents): BaynPromotionPins => {
+  validateBaynLifecycleCommandPort(manifests.deployment)
+  validateBaynLifecycleActivation(manifests.deployment, manifests.kustomization)
   const image = kustomizationImage(manifests.kustomization)
+  const lifecycleCurrent = parseBaynLifecycleCurrent(manifests.lifecycleCurrent)
+  parseBaynLifecyclePrevious(manifests.lifecyclePrevious)
   return {
     sourceSha: environmentValue(manifests.deployment, 'BAYN_CODE_REVISION'),
+    lifecyclePreviousSourceRevision: environmentValue(manifests.deployment, 'BAYN_LIFECYCLE_PREVIOUS_SOURCE_REVISION'),
     tag: image.tag,
     digest: environmentValue(manifests.deployment, 'BAYN_IMAGE_DIGEST'),
     deploymentRepository: environmentValue(manifests.deployment, 'BAYN_IMAGE_REPOSITORY'),
@@ -553,6 +578,7 @@ export const parseBaynPromotionPins = (manifests: BaynPromotionManifestContents)
     kustomizationNewName: image.newName,
     rolloutTimestamp: rolloutTimestamp(manifests.deployment),
     applicationEnabled: applicationEnabled(manifests.applicationSet),
+    lifecycleCurrent,
   }
 }
 
@@ -580,7 +606,7 @@ const normalizeDeployment = (deployment: string): string => {
 const normalizeKustomization = (kustomization: string): string =>
   replaceExactlyOnce(
     kustomization,
-    /(  - name: registry\.ide-newton\.ts\.net\/lab\/bayn\n    newName: registry\.ide-newton\.ts\.net\/lab\/bayn\n    newTag: )[^\n]+\n    digest: [^\n]+/,
+    /(  - name: bayn-main\n    newName: registry\.ide-newton\.ts\.net\/lab\/bayn\n    newTag: )[^\n]+\n    digest: [^\n]+/,
     '$1"__BAYN_IMAGE_TAG__"\n    digest: __BAYN_IMAGE_DIGEST__',
     'Bayn image block',
   )
@@ -615,18 +641,28 @@ const validateManifestShape = (
 
 const validatePins = (pins: BaynPromotionPins, requireApplicationEnabled: boolean): string | null => {
   if (!/^[0-9a-f]{40}$/.test(pins.sourceSha)) return `invalid source revision ${pins.sourceSha}`
+  if (!/^[0-9a-f]{40}$/.test(pins.lifecyclePreviousSourceRevision)) {
+    return `invalid previous lifecycle source revision ${pins.lifecyclePreviousSourceRevision}`
+  }
   if (pins.tag !== `sha-${pins.sourceSha}`) {
     return `image tag ${pins.tag} does not bind source revision ${shortSha(pins.sourceSha)}`
   }
   if (!/^sha256:[0-9a-f]{64}$/.test(pins.digest)) return `invalid image digest ${pins.digest}`
   if (
     pins.deploymentRepository !== expectedImage ||
-    pins.kustomizationName !== expectedImage ||
+    pins.kustomizationName !== 'bayn-main' ||
     pins.kustomizationNewName !== expectedImage
   ) {
     return 'Bayn image repository is not internally consistent'
   }
   if (!Number.isFinite(Date.parse(pins.rolloutTimestamp))) return 'Bayn rollout timestamp is invalid'
+  if (
+    pins.lifecycleCurrent.sourceSha !== pins.sourceSha ||
+    pins.lifecycleCurrent.tag !== pins.tag ||
+    pins.lifecycleCurrent.digest !== pins.digest
+  ) {
+    return 'Bayn lifecycle current endpoint does not bind the promoted source and image'
+  }
   if (requireApplicationEnabled && !pins.applicationEnabled) {
     return 'Bayn ApplicationSet entry must be enabled after promotion'
   }
@@ -690,10 +726,14 @@ export const evaluateBaynPromotionEligibility = (input: {
     )
   }
   const changedPaths = new Set(pullRequest.files.map((file) => file.path))
-  if (!changedPaths.has(deploymentPath) || !changedPaths.has(kustomizationPath)) {
+  if (
+    !changedPaths.has(deploymentPath) ||
+    !changedPaths.has(kustomizationPath) ||
+    !changedPaths.has(lifecycleCurrentPath)
+  ) {
     return hold(
       'promotion-paths-not-permitted',
-      `promotion PR #${pullRequest.number} must change both ${deploymentPath} and ${kustomizationPath}`,
+      `promotion PR #${pullRequest.number} must change ${deploymentPath}, ${kustomizationPath}, and ${lifecycleCurrentPath}`,
       false,
     )
   }
@@ -722,6 +762,28 @@ export const evaluateBaynPromotionEligibility = (input: {
   const headPinFailure = validatePins(headPins, true)
   if (headPinFailure !== null) {
     return hold('promotion-pin-inconsistent', `head manifests are inconsistent: ${headPinFailure}`, false)
+  }
+  const lifecycleFailure = validateBaynLifecyclePromotion({
+    base: {
+      current: input.snapshot.baseManifests.lifecycleCurrent,
+      previous: input.snapshot.baseManifests.lifecyclePrevious,
+    },
+    head: {
+      current: input.snapshot.headManifests.lifecycleCurrent,
+      previous: input.snapshot.headManifests.lifecyclePrevious,
+    },
+    baseKustomization: input.snapshot.baseManifests.kustomization,
+    next: { sourceSha: headPins.sourceSha, tag: headPins.tag, digest: headPins.digest },
+  })
+  if (lifecycleFailure !== null) {
+    return hold('promotion-manifest-shape-mismatch', lifecycleFailure, false)
+  }
+  if (headPins.lifecyclePreviousSourceRevision !== basePins.sourceSha) {
+    return hold(
+      'promotion-pin-inconsistent',
+      'Bayn command boundary does not retain exactly the prior lifecycle source revision',
+      false,
+    )
   }
   if (
     basePins.sourceSha === headPins.sourceSha ||
@@ -854,7 +916,9 @@ export const evaluateBaynPromotionEligibility = (input: {
 const manifestsEqual = (left: BaynPromotionManifestContents, right: BaynPromotionManifestContents): boolean =>
   left.deployment === right.deployment &&
   left.kustomization === right.kustomization &&
-  left.applicationSet === right.applicationSet
+  left.applicationSet === right.applicationSet &&
+  left.lifecycleCurrent === right.lifecycleCurrent &&
+  left.lifecyclePrevious === right.lifecyclePrevious
 
 export const evaluateBaynPromotionCurrentBaseRefresh = (input: {
   readonly expectedRepository: string
@@ -1280,10 +1344,10 @@ const fetchFileContent = async (
 const fetchManifests = async (
   options: GitHubRequestOptions & { readonly repository: string; readonly ref: string },
 ): Promise<BaynPromotionManifestContents> => {
-  const [deployment, kustomization, applicationSet] = await Promise.all(
+  const [deployment, kustomization, applicationSet, lifecycleCurrent, lifecyclePrevious] = await Promise.all(
     baynPromotionManifestPaths.map((path) => fetchFileContent({ ...options, path })),
   )
-  return { deployment, kustomization, applicationSet }
+  return { deployment, kustomization, applicationSet, lifecycleCurrent, lifecyclePrevious }
 }
 
 const fetchSourceFreshness = async (
@@ -2508,8 +2572,20 @@ export const createGitHubPromotionEligibilityLoader = (options: {
       return {
         repository: options.repository,
         pullRequest,
-        baseManifests: { deployment: '', kustomization: '', applicationSet: '' },
-        headManifests: { deployment: '', kustomization: '', applicationSet: '' },
+        baseManifests: {
+          deployment: '',
+          kustomization: '',
+          applicationSet: '',
+          lifecycleCurrent: '',
+          lifecyclePrevious: '',
+        },
+        headManifests: {
+          deployment: '',
+          kustomization: '',
+          applicationSet: '',
+          lifecycleCurrent: '',
+          lifecyclePrevious: '',
+        },
         sourceFreshness: { status: 'stale', reason: 'exact promotion head changed before verification' },
         sourceSha: null,
       }
@@ -2518,8 +2594,20 @@ export const createGitHubPromotionEligibilityLoader = (options: {
       return {
         repository: options.repository,
         pullRequest,
-        baseManifests: { deployment: '', kustomization: '', applicationSet: '' },
-        headManifests: { deployment: '', kustomization: '', applicationSet: '' },
+        baseManifests: {
+          deployment: '',
+          kustomization: '',
+          applicationSet: '',
+          lifecycleCurrent: '',
+          lifecyclePrevious: '',
+        },
+        headManifests: {
+          deployment: '',
+          kustomization: '',
+          applicationSet: '',
+          lifecycleCurrent: '',
+          lifecyclePrevious: '',
+        },
         sourceFreshness: { status: 'fresh' },
         sourceSha: null,
       }


### PR DESCRIPTION
## Summary

- Adds canonical immutable current and previous lifecycle worker manifests bound to exact source and image identity.
- Extends Bayn release and promotion tooling to rotate and verify lifecycle source versions without widening the promotion diff.
- Adds least-privilege Bayn worker, registration, command, and Restate admin NetworkPolicy paths.
- Keeps the lifecycle manifests dormant in this PR; activation remains a separate exact-source GitOps change after the stack is reviewed and published.

## Related Issues

None

## Testing

- bun test packages/scripts/src/bayn/lifecycle-manifests.test.ts packages/scripts/src/bayn/update-manifests.test.ts packages/scripts/src/bayn/verify-promotion-automerge.test.ts packages/scripts/src/bayn/verify-promotion-eligibility.test.ts
- bun run --cwd packages/scripts lint:oxlint:type
- bunx oxfmt --check packages/scripts/src/bayn/lifecycle-manifests.ts packages/scripts/src/bayn/lifecycle-manifests.test.ts packages/scripts/src/bayn/update-manifests.ts packages/scripts/src/bayn/update-manifests.test.ts packages/scripts/src/bayn/verify-promotion-automerge.ts packages/scripts/src/bayn/verify-promotion-automerge.test.ts packages/scripts/src/bayn/verify-promotion-eligibility.ts packages/scripts/src/bayn/verify-promotion-eligibility.test.ts
- kustomize build --enable-helm argocd/applications/bayn
- kustomize build --enable-helm argocd/applications/restate
- nix develop -c bash scripts/kubeconform.sh argocd/applications/bayn argocd/applications/restate
- nix develop -c actionlint .github/workflows/bayn-promotion-eligibility.yml .github/workflows/bayn-release.yml

## Breaking Changes

None. The new lifecycle manifests are intentionally not included by the Bayn root Kustomization, so this layer cannot activate Restate ownership.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; breaking changes are documented.
- [x] Documentation, release notes, and follow-ups are updated or tracked.