### PR TITLE
chore(product): promote nix product images

### DIFF
--- a/argocd/applications/app/kustomization.yaml
+++ b/argocd/applications/app/kustomization.yaml
@@ -8,5 +8,5 @@ resources:
   - secret.yaml
 images:
   - name: registry.ide-newton.ts.net/lab/app
-    digest: sha256:7e8dcfd4b334c6fe0838a1d971cb2f83f97b9dcd7995acddb53d11dd50d9290a
+    digest: sha256:de56c7cb73f3e6adfd5b2265db139951dd6b277f49984c5c72e3a7eb05b310fa
     newName: registry.ide-newton.ts.net/lab/app

--- a/argocd/applications/docs/kustomization.yaml
+++ b/argocd/applications/docs/kustomization.yaml
@@ -4,5 +4,5 @@ resources:
   - generated
 images:
   - name: registry.ide-newton.ts.net/lab/docs
-    digest: sha256:436862334370c11b9539fe0f2d1dd190b2bcf0bb3e0d3a0812b97ce12402aaf8
+    digest: sha256:239d9a3afdbb53b3929754d759d4b3f1ef7f43e20bde93e45cdb06b08858bd0a
     newName: registry.ide-newton.ts.net/lab/docs

--- a/argocd/applications/proompteng/kustomization.yaml
+++ b/argocd/applications/proompteng/kustomization.yaml
@@ -6,5 +6,5 @@ resources:
 - ingressroute.yaml
 images:
 - name: registry.ide-newton.ts.net/lab/proompteng
-  digest: sha256:9c4bfd91efa4224f8b503c26d10985982ebfbf76c49e152276d6d92d10b04540
+  digest: sha256:c5bdb2413866a81edca11449b6eb80edb946ecc697018296056fe8761407eaeb
   newName: registry.ide-newton.ts.net/lab/proompteng

--- a/argocd/applications/synthesis/kustomization.yaml
+++ b/argocd/applications/synthesis/kustomization.yaml
@@ -11,5 +11,5 @@ resources:
   - agents-domain
 images:
   - name: registry.ide-newton.ts.net/lab/synthesis
-    digest: sha256:9a04243c4a6ab27de3a8bebb7febd0cd8497be75d22f52c52a05a12af27f40d4
+    digest: sha256:84be557dee9a030423a2527a593d6016f7156ffe88f7bf7ffbb7ce817f30d895
     newName: registry.ide-newton.ts.net/lab/synthesis


### PR DESCRIPTION
## Summary

- Promote enabled product app image digests built by the shared Nix OCI workflow.
- `app`: `registry.ide-newton.ts.net/lab/app@sha256:de56c7cb73f3e6adfd5b2265db139951dd6b277f49984c5c72e3a7eb05b310fa` from `204d8a95a5107fdb5061c25b09a801b3589eb936`
- `docs`: `registry.ide-newton.ts.net/lab/docs@sha256:239d9a3afdbb53b3929754d759d4b3f1ef7f43e20bde93e45cdb06b08858bd0a` from `204d8a95a5107fdb5061c25b09a801b3589eb936`
- `proompteng`: `registry.ide-newton.ts.net/lab/proompteng@sha256:c5bdb2413866a81edca11449b6eb80edb946ecc697018296056fe8761407eaeb` from `204d8a95a5107fdb5061c25b09a801b3589eb936`
- `synthesis`: `registry.ide-newton.ts.net/lab/synthesis@sha256:84be557dee9a030423a2527a593d6016f7156ffe88f7bf7ffbb7ce817f30d895` from `204d8a95a5107fdb5061c25b09a801b3589eb936`

## Related Issues

N/A

## Testing

- `nix run .#assert-oci-platforms -- <image>@<digest> linux/amd64 linux/arm64` for each promoted image.

## Screenshots (if applicable)

N/A

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.