### PR TITLE
fix(bayn): use valid lifecycle port name

### DIFF
--- a/argocd/applications/bayn/deployment.yaml
+++ b/argocd/applications/bayn/deployment.yaml
@@ -45,7 +45,7 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
-            - name: lifecycle-command
+            - name: lifecycle-cmd
               containerPort: 8081
               protocol: TCP
           env:

--- a/argocd/applications/bayn/lifecycle-current.yaml
+++ b/argocd/applications/bayn/lifecycle-current.yaml
@@ -187,9 +187,9 @@ spec:
   selector:
     app.kubernetes.io/name: bayn
   ports:
-    - name: lifecycle-command
+    - name: lifecycle-cmd
       port: 8081
-      targetPort: lifecycle-command
+      targetPort: lifecycle-cmd
       protocol: TCP
 ---
 apiVersion: networking.k8s.io/v1
@@ -211,7 +211,7 @@ spec:
             matchLabels:
               app.kubernetes.io/name: bayn-lifecycle
       ports:
-        - port: lifecycle-command
+        - port: lifecycle-cmd
           protocol: TCP
 ---
 apiVersion: networking.k8s.io/v1
@@ -290,7 +290,7 @@ spec:
             matchLabels:
               app.kubernetes.io/name: bayn
       ports:
-        - port: lifecycle-command
+        - port: lifecycle-cmd
           protocol: TCP
 ---
 apiVersion: networking.k8s.io/v1

--- a/packages/scripts/src/bayn/lifecycle-manifests.test.ts
+++ b/packages/scripts/src/bayn/lifecycle-manifests.test.ts
@@ -84,11 +84,14 @@ describe('Bayn lifecycle release manifests', () => {
     expect(() =>
       validateBaynLifecycleCommandPort(
         deployment.replace(
-          `            - name: lifecycle-command\n              containerPort: 8081\n              protocol: TCP\n`,
+          `            - name: lifecycle-cmd\n              containerPort: 8081\n              protocol: TCP\n`,
           '',
         ),
       ),
-    ).toThrow('Bayn deployment must expose exactly one lifecycle-command container port on TCP 8081')
+    ).toThrow('Bayn deployment must expose exactly one lifecycle-cmd container port on TCP 8081')
+    expect(() =>
+      validateBaynLifecycleCommandPort(deployment.replace('name: lifecycle-cmd', 'name: lifecycle-command')),
+    ).toThrow('Bayn deployment must expose exactly one lifecycle-cmd container port on TCP 8081')
     expect(() =>
       validateBaynLifecycleCommandAuthentication(
         deployment.replace(

--- a/packages/scripts/src/bayn/lifecycle-manifests.ts
+++ b/packages/scripts/src/bayn/lifecycle-manifests.ts
@@ -60,11 +60,11 @@ export const validateBaynLifecycleCommandPort = (deployment: string): void => {
   const lifecyclePorts = Array.isArray(ports)
     ? ports.filter(
         (port) =>
-          record(port) && port.name === 'lifecycle-command' && port.containerPort === 8081 && port.protocol === 'TCP',
+          record(port) && port.name === 'lifecycle-cmd' && port.containerPort === 8081 && port.protocol === 'TCP',
       )
     : []
   if (lifecyclePorts.length !== 1) {
-    throw new Error('Bayn deployment must expose exactly one lifecycle-command container port on TCP 8081')
+    throw new Error('Bayn deployment must expose exactly one lifecycle-cmd container port on TCP 8081')
   }
 }
 
@@ -339,9 +339,9 @@ spec:
   selector:
     app.kubernetes.io/name: bayn
   ports:
-    - name: lifecycle-command
+    - name: lifecycle-cmd
       port: 8081
-      targetPort: lifecycle-command
+      targetPort: lifecycle-cmd
       protocol: TCP
 ---
 apiVersion: networking.k8s.io/v1
@@ -363,7 +363,7 @@ spec:
             matchLabels:
               app.kubernetes.io/name: bayn-lifecycle
       ports:
-        - port: lifecycle-command
+        - port: lifecycle-cmd
           protocol: TCP
 ---
 apiVersion: networking.k8s.io/v1
@@ -442,7 +442,7 @@ spec:
             matchLabels:
               app.kubernetes.io/name: bayn
       ports:
-        - port: lifecycle-command
+        - port: lifecycle-cmd
           protocol: TCP
 ---
 apiVersion: networking.k8s.io/v1

--- a/packages/scripts/src/bayn/verify-promotion-eligibility.test.ts
+++ b/packages/scripts/src/bayn/verify-promotion-eligibility.test.ts
@@ -79,7 +79,7 @@ spec:
         - name: bayn
           image: bayn-main
           ports:
-            - name: lifecycle-command
+            - name: lifecycle-cmd
               containerPort: 8081
               protocol: TCP
           env:


### PR DESCRIPTION
## Summary

- Rename the Bayn lifecycle command port from the invalid 17-character name to the Kubernetes-valid lifecycle-cmd name.
- Keep Deployment, Service targetPort, NetworkPolicy named-port references, and the canonical renderer consistent.
- Add a regression that rejects the exact overlength port name that blocked Argo server-side comparison.

## Related Issues

None

## Testing

- bun test packages/scripts/src/bayn/lifecycle-manifests.test.ts (6 pass, 0 fail)
- bunx oxfmt --check packages/scripts/src/bayn/lifecycle-manifests.ts packages/scripts/src/bayn/lifecycle-manifests.test.ts
- bunx oxlint --deny-warnings packages/scripts/src/bayn/lifecycle-manifests.ts packages/scripts/src/bayn/lifecycle-manifests.test.ts
- bun run lint:argocd (0 invalid)
- kustomize build --enable-helm argocd/applications/bayn piped to kubectl server-side dry-run with conflict forcing (all resources accepted by the live API server)

## Breaking Changes

None. The port remains TCP 8081; only its internal Kubernetes name changes. Argo will retry the previously rejected activation after this merge.

## Rollout and impact

- Normal automated Argo reconciliation only; no direct apply.
- The prior activation was rejected during comparison, so no partial resource wave was applied.
- Expected impact is the same bounded Bayn restart and lifecycle registration already documented in PR #13651.
- Acceptance requires Argo sync to the merge revision, the exact reviewed image, successful registration, healthy readiness, and live lifecycle recovery evidence.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable and Breaking Changes are documented.
- [x] Documentation, release notes, and follow-ups are updated or tracked.