### PR TITLE
fix(bayn): disable Kubernetes service links

### DIFF
--- a/argocd/applications/bayn/deployment.yaml
+++ b/argocd/applications/bayn/deployment.yaml
@@ -27,6 +27,7 @@ spec:
     spec:
       serviceAccountName: bayn
       automountServiceAccountToken: false
+      enableServiceLinks: false
       terminationGracePeriodSeconds: 30
       nodeSelector:
         kubernetes.io/arch: arm64

--- a/argocd/applications/bayn/lifecycle-current.yaml
+++ b/argocd/applications/bayn/lifecycle-current.yaml
@@ -27,6 +27,7 @@ spec:
     spec:
       serviceAccountName: bayn-lifecycle
       automountServiceAccountToken: false
+      enableServiceLinks: false
       terminationGracePeriodSeconds: 30
       nodeSelector:
         kubernetes.io/arch: arm64
@@ -358,6 +359,7 @@ spec:
     spec:
       serviceAccountName: bayn
       automountServiceAccountToken: false
+      enableServiceLinks: false
       restartPolicy: OnFailure
       nodeSelector:
         kubernetes.io/arch: arm64

--- a/packages/scripts/src/bayn/lifecycle-manifests.test.ts
+++ b/packages/scripts/src/bayn/lifecycle-manifests.test.ts
@@ -13,6 +13,7 @@ import {
   validateBaynLifecycleCommandAuthentication,
   validateBaynLifecycleCommandPort,
   validateBaynLifecycleOperationTimeout,
+  validateBaynServiceLinksDisabled,
   type BaynLifecycleImagePin,
 } from './lifecycle-manifests'
 
@@ -47,6 +48,7 @@ describe('Bayn lifecycle release manifests', () => {
     expect(current).toContain('- tokenreviews')
     expect(current).toContain('cidr: 10.96.0.1/32')
     expect(current).toContain('name: BAYN_OPERATION_TIMEOUT_MS')
+    expect(current.match(/enableServiceLinks: false/g)).toHaveLength(2)
     expect(current).not.toContain('secretKeyRef:')
     expect(current).not.toContain('BAYN_ALPACA_')
     expect(current).not.toContain('DATABASE_URL')
@@ -78,6 +80,7 @@ describe('Bayn lifecycle release manifests', () => {
     expect(parseBaynLifecyclePrevious(previous)).toBeNull()
     expect(baynLifecycleIsActive(kustomization)).toBeTrue()
     expect(() => validateBaynLifecycleCommandPort(deployment)).not.toThrow()
+    expect(() => validateBaynServiceLinksDisabled(deployment)).not.toThrow()
     expect(() => validateBaynLifecycleCommandAuthentication(deployment)).not.toThrow()
     expect(() => validateBaynLifecycleOperationTimeout(deployment)).not.toThrow()
     expect(() => validateBaynLifecycleActivation(deployment, kustomization)).not.toThrow()
@@ -92,6 +95,9 @@ describe('Bayn lifecycle release manifests', () => {
     expect(() =>
       validateBaynLifecycleCommandPort(deployment.replace('name: lifecycle-cmd', 'name: lifecycle-command')),
     ).toThrow('Bayn deployment must expose exactly one lifecycle-cmd container port on TCP 8081')
+    expect(() => validateBaynServiceLinksDisabled(deployment.replace('      enableServiceLinks: false\n', ''))).toThrow(
+      'Bayn deployment must disable Kubernetes service-link environment injection',
+    )
     expect(() =>
       validateBaynLifecycleCommandAuthentication(
         deployment.replace(

--- a/packages/scripts/src/bayn/lifecycle-manifests.ts
+++ b/packages/scripts/src/bayn/lifecycle-manifests.ts
@@ -68,6 +68,12 @@ export const validateBaynLifecycleCommandPort = (deployment: string): void => {
   }
 }
 
+export const validateBaynServiceLinksDisabled = (deployment: string): void => {
+  if (baynPodSpec(deployment).enableServiceLinks !== false) {
+    throw new Error('Bayn deployment must disable Kubernetes service-link environment injection')
+  }
+}
+
 export const validateBaynLifecycleCommandAuthentication = (deployment: string): void => {
   const container = baynContainer(deployment)
   const mounts = Array.isArray(container.volumeMounts) ? container.volumeMounts : []
@@ -173,6 +179,7 @@ spec:
     spec:
       serviceAccountName: bayn-lifecycle
       automountServiceAccountToken: false
+      enableServiceLinks: false
       terminationGracePeriodSeconds: 30
       nodeSelector:
         kubernetes.io/arch: arm64
@@ -510,6 +517,7 @@ spec:
     spec:
       serviceAccountName: bayn
       automountServiceAccountToken: false
+      enableServiceLinks: false
       restartPolicy: OnFailure
       nodeSelector:
         kubernetes.io/arch: arm64

--- a/packages/scripts/src/bayn/verify-promotion-eligibility.test.ts
+++ b/packages/scripts/src/bayn/verify-promotion-eligibility.test.ts
@@ -75,6 +75,7 @@ spec:
       annotations:
         kubectl.kubernetes.io/restartedAt: ${JSON.stringify(pins.rolloutTimestamp)}
     spec:
+      enableServiceLinks: false
       containers:
         - name: bayn
           image: bayn-main

--- a/packages/scripts/src/bayn/verify-promotion-eligibility.ts
+++ b/packages/scripts/src/bayn/verify-promotion-eligibility.ts
@@ -11,6 +11,7 @@ import {
   validateBaynLifecycleActivation,
   validateBaynLifecycleCommandPort,
   validateBaynLifecyclePromotion,
+  validateBaynServiceLinksDisabled,
   type BaynLifecycleImagePin,
 } from './lifecycle-manifests'
 
@@ -564,6 +565,7 @@ const applicationEnabled = (applicationSet: string): boolean => {
 
 export const parseBaynPromotionPins = (manifests: BaynPromotionManifestContents): BaynPromotionPins => {
   validateBaynLifecycleCommandPort(manifests.deployment)
+  validateBaynServiceLinksDisabled(manifests.deployment)
   validateBaynLifecycleActivation(manifests.deployment, manifests.kustomization)
   const image = kustomizationImage(manifests.kustomization)
   const lifecycleCurrent = parseBaynLifecycleCurrent(manifests.lifecycleCurrent)


### PR DESCRIPTION
## Summary

- disable Kubernetes service-link environment injection in the Bayn process, versioned Restate worker, and registration hook
- prevent the bayn-lifecycle-command Service from overwriting BAYN_LIFECYCLE_COMMAND_PORT with a tcp:// URL
- enforce the invariant in canonical lifecycle rendering and promotion eligibility with regression coverage

## Related Issues

None

## Testing

- bun test packages/scripts/src/bayn/lifecycle-manifests.test.ts packages/scripts/src/bayn/verify-promotion-eligibility.test.ts
- bun test packages/scripts/src
- bun run --filter @proompteng/scripts lint
- bun run --filter @proompteng/scripts lint:oxlint:type
- bun run lint:argocd
- bunx oxfmt --check on all changed TypeScript and YAML files
- kustomize build argocd/applications/bayn piped to kubectl server-side dry-run; all mutable resources accepted, while the existing same-name Argo hook Job correctly requires BeforeHookCreation because its pod template is immutable

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots and Breaking Changes sections are handled appropriately.
- [x] Documentation, release notes, and follow-ups are updated or tracked.