### PR TITLE
fix(bayn): rotate blocked paper authority safely

### DIFF
--- a/services/bayn/src/blocked-generation-recovery.ts
+++ b/services/bayn/src/blocked-generation-recovery.ts
@@ -1,11 +1,27 @@
-import { Effect } from 'effect'
+import { Effect, Result } from 'effect'
 
 import type { AuthorityGenerationStoreShape } from './db/execution-store'
 import { BlockedCycleIntentStoreError, type BlockedCycleIntentStoreShape } from './execution/intents'
 import { Authority, KillState } from './execution/contracts'
 import type { WriterFenceService } from './execution/writer-fence'
 import { OperationalError } from './errors'
+import { canonicalHashV1Result, type CanonicalHashFailure } from './hash'
 import { currentUtcInstant } from './time'
+
+const observeSuccessorSchemaVersion = 'bayn.paper-observe-successor-generation.v1' as const
+
+/**
+ * Derives the immutable OBSERVE successor for one terminal PAPER generation. The configured generation is only a
+ * bootstrap key, not a reusable history key; the terminal PAPER hash makes retries deterministic and independent of
+ * which reviewed build performs recovery.
+ */
+export const paperObserveSuccessorGenerationHash = (input: {
+  readonly previousPaperGenerationHash: string
+}): Result.Result<string, CanonicalHashFailure> =>
+  canonicalHashV1Result({
+    schemaVersion: observeSuccessorSchemaVersion,
+    previousPaperGenerationHash: input.previousPaperGenerationHash,
+  })
 
 export type BlockedGenerationRolloverReceipt =
   | { readonly _tag: 'NotRequired' }
@@ -21,7 +37,6 @@ export type BlockedGenerationRolloverReceipt =
 
 export interface BlockedGenerationRecoveryInput<R> {
   readonly accountId: string
-  readonly observeGenerationHash: string
   readonly blockedIntents: BlockedCycleIntentStoreShape
   readonly authorityStore: AuthorityGenerationStoreShape
   readonly writerFence: WriterFenceService
@@ -95,11 +110,16 @@ export const recoverBlockedGenerationToObserve = <R>(
     )
 
     yield* input.reconcileAfterSettlement
+    const successorGenerationHash = yield* Effect.fromResult(
+      paperObserveSuccessorGenerationHash({
+        previousPaperGenerationHash: settlement.authorityGenerationHash,
+      }),
+    ).pipe(Effect.mapError((cause) => recoveryError('blocked generation OBSERVE successor hashing failed', cause)))
     const authority = yield* input.authorityStore
-      .ensureAuthorityGeneration({ generationHash: input.observeGenerationHash, maximum: Authority.Observe })
+      .ensureAuthorityGeneration({ generationHash: successorGenerationHash, maximum: Authority.Observe })
       .pipe(Effect.mapError((cause) => recoveryError('blocked generation OBSERVE rollover failed', cause)))
     if (
-      authority.generationHash !== input.observeGenerationHash ||
+      authority.generationHash !== successorGenerationHash ||
       authority.maximum !== Authority.Observe ||
       authority.effective !== Authority.Observe ||
       authority.kill !== KillState.Clear

--- a/services/bayn/src/composition.test.ts
+++ b/services/bayn/src/composition.test.ts
@@ -15,6 +15,7 @@ import {
   ApplicationPlatformLive,
   closedCycleReceiptEmissionAllowed,
   finalizePaperEpisode,
+  observeCycleGenerationHash,
   paperReceiptFinalizationWindowOpen,
   prepareOrRecoverResearchPaperActivation,
   recoverPaperActivationGeneration,
@@ -23,7 +24,7 @@ import {
   retryClosedCycleReceipts,
 } from './composition'
 import { makeApplicationPlan, type ApplicationPlanFor } from './app'
-import { alpacaSandboxBaseUrl, type BrokerSessionShape } from './broker/alpaca'
+import { AccountStatus, alpacaSandboxBaseUrl, type BrokerSessionShape } from './broker/alpaca'
 import { BrokerEnvironment, BrokerProvider, makeBrokerIdentity } from './broker/identity'
 import { makeStrategyProtocolHash } from './contracts'
 import type {
@@ -46,8 +47,9 @@ import {
 import { BlockedCycleIntentStoreError, type BlockedCycleIntentStoreShape } from './execution/intents'
 import type { WriterFenceService } from './execution/writer-fence'
 import { OperationalError } from './errors'
+import { canonicalHashV1Result } from './hash'
 import { utcInstantFromEpochMillis } from './time'
-import { paperEpisodeReceiptFinalizationExpiresAt } from './observe-composition'
+import { loadObserveRiskPolicy, paperEpisodeReceiptFinalizationExpiresAt } from './observe-composition'
 import { initialState } from './runtime-state'
 import { fixtureProtocol } from './test-fixtures'
 
@@ -404,6 +406,31 @@ describe('Bayn PAPER receipt retry boundary', () => {
 })
 
 describe('Bayn PAPER startup recovery boundary', () => {
+  test('starts OBSERVE cycles from the persisted successor and never from stale PAPER authority', () => {
+    const successorGenerationHash = Result.getOrThrow(
+      paperObserveSuccessorGenerationHash({ previousPaperGenerationHash: hash('12') }),
+    )
+    const observeAuthority: AuthorityState = {
+      schemaVersion: 'bayn.paper-authority.v1',
+      generationHash: successorGenerationHash,
+      maximum: Authority.Observe,
+      effective: Authority.Observe,
+      kill: KillState.Clear,
+      version: 3,
+      updatedAt: '2026-08-11T13:00:00.000Z',
+    }
+
+    expect(observeCycleGenerationHash(observeAuthority)).toEqual(Result.succeed(successorGenerationHash))
+    expect(
+      observeCycleGenerationHash({
+        ...observeAuthority,
+        generationHash: hash('34'),
+        maximum: Authority.Paper,
+        effective: Authority.Paper,
+      }),
+    ).toEqual(Result.fail('OBSERVE cycle startup requires current effective OBSERVE authority'))
+  })
+
   test('resumes only the exact active research generation across a reviewed build change', async () => {
     const logs: Array<{ readonly message: unknown; readonly annotations: Record<string, unknown> }> = []
     const logger = Logger.make<unknown, void>((entry) => {
@@ -486,6 +513,183 @@ describe('Bayn PAPER startup recovery boundary', () => {
 
       expect(failure.message).toBe(fixture.message)
     }
+  })
+
+  test('activates research PAPER from the persisted OBSERVE successor instead of the bootstrap hash', async () => {
+    const previousPaperGenerationHash = hash('12')
+    const successorGenerationHash = Result.getOrThrow(
+      paperObserveSuccessorGenerationHash({ previousPaperGenerationHash }),
+    )
+    const riskPolicy = await Effect.runPromise(
+      loadObserveRiskPolicy(continuationAccountId, continuationApplicationPlan.strategy.definition.parameters.universe),
+    )
+    const riskPolicyHash = Result.getOrThrow(canonicalHashV1Result(riskPolicy))
+    const plan = { ...continuationResearchPlan, activation: continuationBuild, riskPolicyHash }
+    const { schemaVersion: _schemaVersion, ...planFields } = plan
+    const request = Result.getOrThrow(
+      makeResearchPaperActivationRequest({
+        schemaVersion: 'bayn.paper-research-activation-request.v1',
+        grant: { _tag: 'Research', planHash: Result.getOrThrow(makeResearchPaperPlanHash(plan)) },
+        ...planFields,
+      }),
+    )
+    const generation = Result.getOrThrow(
+      makeResearchCapitalGrantGenerationResult({
+        schemaVersion: 'bayn.paper-authority-generation.v3',
+        maximum: Authority.Paper,
+        previousGenerationHash: successorGenerationHash,
+        grant: request.grant,
+        activationSourceRevision: request.activation.sourceRevision,
+        activationImageRepository: request.activation.imageRepository,
+        activationImageDigest: request.activation.imageDigest,
+        strategyName: request.strategy.name,
+        strategyBehaviorHash: request.strategy.behaviorHash,
+        strategyParameterHash: request.strategy.parameterHash,
+        strategyParameterSchemaVersion: request.strategy.parameterSchemaVersion,
+        strategyProtocolHash: request.strategy.protocolHash,
+        accountId: request.broker.accountId,
+        brokerIdentityHash: request.broker.identityHash,
+        riskPolicyHash: request.riskPolicyHash,
+        proofPlanHash: request.grant.planHash,
+        reconciliationId: hash('34'),
+        reconciliationContentHash: hash('56'),
+      }),
+    )
+    let authority: AuthorityState = {
+      schemaVersion: 'bayn.paper-authority.v1',
+      generationHash: successorGenerationHash,
+      maximum: Authority.Observe,
+      effective: Authority.Observe,
+      kill: KillState.Clear,
+      version: 3,
+      updatedAt: '2026-08-31T20:00:00.000Z',
+    }
+    const operations: string[] = []
+    const authorityStore: AuthorityGenerationStoreShape = {
+      ensureAuthorityGeneration: ({ generationHash, maximum }) =>
+        Effect.sync(() => {
+          operations.push(`validate:${generationHash}`)
+          expect({ generationHash, maximum }).toEqual({
+            generationHash: successorGenerationHash,
+            maximum: Authority.Observe,
+          })
+          return authority
+        }),
+      readAuthorityState: Effect.sync(() => authority),
+      readResearchAuthorityGeneration: (generationHash) =>
+        Effect.succeed(generationHash === generation.generationHash ? generation : undefined),
+    }
+    const lifecycle: CapitalGrantLifecycleStoreShape = {
+      prepareCapitalGrant: () => Effect.die(new Error('research activation must not prepare qualified authority')),
+      activateCapitalGrant: () => Effect.die(new Error('research activation must not activate qualified authority')),
+      activateResearchCapitalGrant: (_proof, sourceGenerationHash) =>
+        Effect.sync(() => {
+          operations.push(`activate:${sourceGenerationHash}`)
+          authority = {
+            schemaVersion: 'bayn.paper-authority.v1',
+            generationHash: generation.generationHash,
+            maximum: Authority.Paper,
+            effective: Authority.Paper,
+            kill: KillState.Clear,
+            version: 4,
+            updatedAt: '2026-08-31T20:00:01.000Z',
+          }
+          return authority
+        }),
+    }
+    const unusedBrokerRead = Effect.die(new Error('research activation performed an unrelated broker read'))
+    const session: BrokerSessionShape = {
+      connection: {
+        provider: continuationApplicationPlan.config.alpaca.provider,
+        environment: continuationApplicationPlan.config.alpaca.environment,
+        identity: continuationApplicationPlan.config.alpaca.identity,
+        baseUrl: continuationApplicationPlan.config.alpaca.baseUrl,
+        expectedAccountId: continuationApplicationPlan.config.alpaca.expectedAccountId,
+        key: continuationApplicationPlan.config.alpaca.key,
+        secret: continuationApplicationPlan.config.alpaca.secret,
+        proxyUrl: continuationApplicationPlan.config.alpaca.proxyUrl,
+        operationTimeoutMs: continuationApplicationPlan.config.alpaca.operationTimeoutMs,
+        retryAttempts: continuationApplicationPlan.config.alpaca.retryAttempts,
+      },
+      preflight: {
+        provider: BrokerProvider.Alpaca,
+        environment: BrokerEnvironment.Sandbox,
+        baseUrl: alpacaSandboxBaseUrl,
+        accountId: continuationAccountId,
+        accountStatus: AccountStatus.Active,
+        accountBlocked: false,
+        tradingBlocked: false,
+        tradeSuspendedByUser: false,
+        accountHash: hash('78'),
+        fractionalTrading: true,
+        accountConfigurationHash: hash('9a'),
+        openOrderCount: 0,
+        recentOrderCount: 0,
+        ordersHash: hash('bc'),
+        positionCount: 0,
+        positionsHash: hash('de'),
+        fillCount: 0,
+        fillsHash: hash('f0'),
+        marketCalendarSessionCount: 3,
+        marketCalendarHash: hash('12'),
+        orderById: 'NOT_FOUND',
+        orderByClientId: 'NOT_FOUND',
+      },
+      read: {
+        account: unusedBrokerRead,
+        accountConfiguration: unusedBrokerRead,
+        assetBySymbol: () => unusedBrokerRead,
+        positions: unusedBrokerRead,
+        orders: () => unusedBrokerRead,
+        orderById: () => unusedBrokerRead,
+        orderByClientId: () => unusedBrokerRead,
+        fillActivities: () => unusedBrokerRead,
+        marketCalendar: (query: { readonly start: string; readonly end: string }) =>
+          Effect.succeed({
+            value: {
+              schemaVersion: 'bayn.alpaca-market-calendar-observation.v1',
+              source: 'alpaca-v2-calendar',
+              requestedRange: query,
+              timeZone: 'UTC',
+              sessions: [
+                { date: '2026-09-01', openAt: '2026-09-01T13:30:00.000Z', closeAt: '2026-09-01T20:00:00.000Z' },
+                { date: '2026-09-02', openAt: '2026-09-02T13:30:00.000Z', closeAt: '2026-09-02T20:00:00.000Z' },
+                { date: '2026-09-03', openAt: '2026-09-03T13:30:00.000Z', closeAt: '2026-09-03T20:00:00.000Z' },
+              ],
+              normalizedResponseHash: hash('34'),
+            },
+            evidence: {
+              requestId: 'calendar-request',
+              status: 200,
+              contentHash: hash('56'),
+              observedAt: '2026-08-31T20:00:00.000Z',
+            },
+          }),
+      },
+    }
+
+    const activated = await Effect.runPromise(
+      Effect.gen(function* () {
+        yield* TestClock.setTime(Date.parse('2026-08-31T20:00:00.000Z'))
+        return yield* prepareOrRecoverResearchPaperActivation(
+          continuationApplicationPlan,
+          request,
+          null,
+          session,
+          authorityStore,
+          lifecycle,
+          Effect.sync(() => operations.push('reconcile')),
+          config.operationTimeoutMs,
+        )
+      }).pipe(provideTestLayer(TestClock.layer())),
+    )
+
+    expect(activated).toEqual(generation)
+    expect(operations).toEqual([
+      `validate:${successorGenerationHash}`,
+      'reconcile',
+      `activate:${successorGenerationHash}`,
+    ])
   })
 
   test('recovers the exact continuation after cutoff and rejects stale build or generation bindings', async () => {

--- a/services/bayn/src/composition.test.ts
+++ b/services/bayn/src/composition.test.ts
@@ -5,6 +5,7 @@ import { TestClock } from 'effect/testing'
 
 import { config, fixtureRuntime } from './app-test-support'
 import {
+  paperObserveSuccessorGenerationHash,
   recoverBlockedGenerationToObserve,
   recoverRestrictedGenerationBeforeRollover,
 } from './blocked-generation-recovery'
@@ -528,8 +529,12 @@ describe('Bayn PAPER startup recovery boundary', () => {
 
   test('settles, freshly reconciles, and only then rolls a blocked generation to clear OBSERVE', async () => {
     const operations: string[] = []
-    const sourceGenerationHash = hash('1')
     const previousGenerationHash = hash('2')
+    const successorGenerationHash = Result.getOrThrow(
+      paperObserveSuccessorGenerationHash({
+        previousPaperGenerationHash: previousGenerationHash,
+      }),
+    )
     const blockedIntents: BlockedCycleIntentStoreShape = {
       terminalizeUntouchedApproved: () => Effect.die(new Error('cycle terminalization is outside startup recovery')),
       settleCurrentBlockedGeneration: () =>
@@ -572,7 +577,6 @@ describe('Bayn PAPER startup recovery boundary', () => {
         yield* TestClock.setTime(Date.parse('2026-08-10T19:00:00.000Z'))
         return yield* recoverBlockedGenerationToObserve({
           accountId: 'paper-account',
-          observeGenerationHash: sourceGenerationHash,
           blockedIntents,
           authorityStore,
           writerFence,
@@ -585,12 +589,27 @@ describe('Bayn PAPER startup recovery boundary', () => {
     expect(receipt).toEqual({
       _tag: 'RolledOver',
       previousGenerationHash,
-      generationHash: sourceGenerationHash,
+      generationHash: successorGenerationHash,
       blockedCycleCount: 1,
       blockedIntentCount: 0,
       expiredIntentCount: 1,
       terminalIntentCount: 1,
     })
+  })
+
+  test('derives one stable OBSERVE successor per immutable PAPER generation', () => {
+    const previousPaperGenerationHash = hash('2')
+    const first = Result.getOrThrow(paperObserveSuccessorGenerationHash({ previousPaperGenerationHash }))
+    const replay = Result.getOrThrow(paperObserveSuccessorGenerationHash({ previousPaperGenerationHash }))
+    const nextEpisode = Result.getOrThrow(
+      paperObserveSuccessorGenerationHash({
+        previousPaperGenerationHash: hash('3'),
+      }),
+    )
+
+    expect(first).toBe(replay)
+    expect(first).not.toBe(previousPaperGenerationHash)
+    expect(nextEpisode).not.toBe(first)
   })
 
   test('does not reconcile or rotate when no blocked generation exists', async () => {
@@ -605,7 +624,6 @@ describe('Bayn PAPER startup recovery boundary', () => {
     const receipt = await Effect.runPromise(
       recoverBlockedGenerationToObserve({
         accountId: 'paper-account',
-        observeGenerationHash: hash('1'),
         blockedIntents,
         authorityStore,
         writerFence: unusedWriterFence,

--- a/services/bayn/src/composition.ts
+++ b/services/bayn/src/composition.ts
@@ -31,6 +31,7 @@ import {
   type AutonomousRuntimeResolver,
 } from './app'
 import {
+  paperObserveSuccessorGenerationHash,
   recoverBlockedGenerationToObserve,
   recoverRestrictedGenerationBeforeRollover,
 } from './blocked-generation-recovery'
@@ -646,10 +647,10 @@ const readBoundPaperActivationGeneration = (
       }
       const binding =
         buildContinuation === null
-          ? researchPaperGenerationIsBoundToRequest(request, plan.config.alpaca.authorityGenerationHash, generation)
+          ? researchPaperGenerationIsBoundToRequest(request, generation.previousGenerationHash, generation)
           : researchPaperBuildContinuationIsBound(
               buildContinuation,
-              plan.config.alpaca.authorityGenerationHash,
+              generation.previousGenerationHash,
               generation,
               plan.config.build,
             )
@@ -960,18 +961,35 @@ export const prepareOrRecoverResearchPaperActivation = (
       Effect.mapError((cause) => paperActivationOperationalError('research PAPER authority read failed', cause)),
     )
     const currentGeneration = yield* readCurrentResearchPaperGeneration(authority, authorityStore)
+    const currentSourceGenerationHash = currentGeneration?.previousGenerationHash ?? authority.generationHash
+    if (authority.maximum === Authority.Observe) {
+      const replayed = yield* authorityStore
+        .ensureAuthorityGeneration({ generationHash: authority.generationHash, maximum: Authority.Observe })
+        .pipe(
+          Effect.mapError((cause) =>
+            paperActivationOperationalError('research PAPER current OBSERVE generation validation failed', cause),
+          ),
+        )
+      if (
+        replayed.generationHash !== authority.generationHash ||
+        replayed.maximum !== authority.maximum ||
+        replayed.effective !== authority.effective ||
+        replayed.kill !== authority.kill ||
+        replayed.version !== authority.version
+      ) {
+        return yield* paperActivationOperationalError(
+          'research PAPER current OBSERVE generation changed during validation',
+        )
+      }
+    }
     const currentGenerationMatchesRequest =
       currentGeneration !== undefined &&
       Result.isSuccess(
         buildContinuation === null
-          ? researchPaperGenerationIsBoundToRequest(
-              request,
-              plan.config.alpaca.authorityGenerationHash,
-              currentGeneration,
-            )
+          ? researchPaperGenerationIsBoundToRequest(request, currentSourceGenerationHash, currentGeneration)
           : researchPaperBuildContinuationIsBound(
               buildContinuation,
-              plan.config.alpaca.authorityGenerationHash,
+              currentSourceGenerationHash,
               currentGeneration,
               plan.config.build,
             ),
@@ -979,7 +997,7 @@ export const prepareOrRecoverResearchPaperActivation = (
     const decision = yield* Effect.fromResult(
       decidePaperEpisodeAuthority({
         generationHash: authority.generationHash,
-        sourceGenerationHash: plan.config.alpaca.authorityGenerationHash,
+        sourceGenerationHash: currentSourceGenerationHash,
         currentGenerationMatchesRequest,
         maximum: authority.maximum,
         effective: authority.effective,
@@ -997,9 +1015,18 @@ export const prepareOrRecoverResearchPaperActivation = (
       )
     }
     if (decision._tag === 'Rearm') {
+      const successorGenerationHash = yield* Effect.fromResult(
+        paperObserveSuccessorGenerationHash({
+          previousPaperGenerationHash: authority.generationHash,
+        }),
+      ).pipe(
+        Effect.mapError((cause) =>
+          paperActivationOperationalError('research PAPER OBSERVE successor hashing failed', cause),
+        ),
+      )
       const rearmed = yield* authorityStore
         .ensureAuthorityGeneration({
-          generationHash: plan.config.alpaca.authorityGenerationHash,
+          generationHash: successorGenerationHash,
           maximum: Authority.Observe,
         })
         .pipe(
@@ -1008,7 +1035,7 @@ export const prepareOrRecoverResearchPaperActivation = (
           ),
         )
       if (
-        rearmed.generationHash !== plan.config.alpaca.authorityGenerationHash ||
+        rearmed.generationHash !== successorGenerationHash ||
         rearmed.maximum !== Authority.Observe ||
         rearmed.effective !== Authority.Observe ||
         rearmed.kill !== KillState.Clear
@@ -1472,7 +1499,6 @@ const runAutonomousService = (plan: ApplicationPlanFor<'AutonomousService'>) =>
                         })
                         const recoverBlockedGeneration = recoverBlockedGenerationToObserve({
                           accountId: observePlan.config.alpaca.expectedAccountId,
-                          observeGenerationHash: observePlan.config.alpaca.authorityGenerationHash,
                           blockedIntents: runtimeServices.blockedCycleIntentStore,
                           authorityStore: runtimeServices.authorityGenerationStore,
                           writerFence: runtimeServices.writerFence,

--- a/services/bayn/src/composition.ts
+++ b/services/bayn/src/composition.ts
@@ -328,15 +328,21 @@ const lifecycleDriverInterpreter = (
         }).pipe(Effect.scoped, Effect.orDie)) satisfies RecoveryFirstCycleDriverInterpreter)
     : undefined
 
+export const observeCycleGenerationHash = (authority: AuthorityState): Result.Result<string, string> =>
+  authority.maximum === Authority.Observe && authority.effective === Authority.Observe
+    ? Result.succeed(authority.generationHash)
+    : Result.fail('OBSERVE cycle startup requires current effective OBSERVE authority')
+
 const observeCycle = (
   plan: ApplicationPlanFor<'AutonomousService'>,
   lifecycleCommandStore: import('./db/lifecycle-command').LifecycleCommandStoreShape,
   writerFence: WriterFenceService,
+  authorityGenerationHash: string,
 ) => {
   const interpretCycleDriver = lifecycleDriverInterpreter(plan, lifecycleCommandStore, writerFence)
   return makeObserveAutonomousCycleStartup({
     accountId: plan.config.alpaca.expectedAccountId,
-    authorityGenerationHash: plan.config.alpaca.authorityGenerationHash,
+    authorityGenerationHash,
     pollIntervalMs: plan.config.cyclePollIntervalMs,
     reconciliationIntervalMs: plan.config.alpaca.reconciliationIntervalMs,
     reconciliationPassTimeoutMs: plan.config.operationTimeoutMs,
@@ -885,6 +891,7 @@ const readCurrentResearchPaperGeneration = (
 const prepareResearchPaperActivation = (
   plan: ApplicationPlanFor<'AutonomousService'>,
   request: ResearchPaperActivationRequest,
+  sourceGenerationHash: string,
   session: BrokerSessionShape,
   authorityStore: AuthorityGenerationStoreShape,
   lifecycle: CapitalGrantLifecycleStoreShape,
@@ -902,7 +909,7 @@ const prepareResearchPaperActivation = (
 
     const proof = researchCapitalGrantProof(request)
     const authority = yield* lifecycle
-      .activateResearchCapitalGrant(proof)
+      .activateResearchCapitalGrant(proof, sourceGenerationHash)
       .pipe(
         Effect.mapError((cause) =>
           paperActivationOperationalError('research PAPER generation activation failed', cause),
@@ -1014,19 +1021,22 @@ export const prepareOrRecoverResearchPaperActivation = (
         'research PAPER build continuation requires the exact active generation',
       )
     }
+    const activationSourceGenerationHash =
+      decision._tag === 'Rearm'
+        ? yield* Effect.fromResult(
+            paperObserveSuccessorGenerationHash({
+              previousPaperGenerationHash: authority.generationHash,
+            }),
+          ).pipe(
+            Effect.mapError((cause) =>
+              paperActivationOperationalError('research PAPER OBSERVE successor hashing failed', cause),
+            ),
+          )
+        : currentSourceGenerationHash
     if (decision._tag === 'Rearm') {
-      const successorGenerationHash = yield* Effect.fromResult(
-        paperObserveSuccessorGenerationHash({
-          previousPaperGenerationHash: authority.generationHash,
-        }),
-      ).pipe(
-        Effect.mapError((cause) =>
-          paperActivationOperationalError('research PAPER OBSERVE successor hashing failed', cause),
-        ),
-      )
       const rearmed = yield* authorityStore
         .ensureAuthorityGeneration({
-          generationHash: successorGenerationHash,
+          generationHash: activationSourceGenerationHash,
           maximum: Authority.Observe,
         })
         .pipe(
@@ -1035,7 +1045,7 @@ export const prepareOrRecoverResearchPaperActivation = (
           ),
         )
       if (
-        rearmed.generationHash !== successorGenerationHash ||
+        rearmed.generationHash !== activationSourceGenerationHash ||
         rearmed.maximum !== Authority.Observe ||
         rearmed.effective !== Authority.Observe ||
         rearmed.kill !== KillState.Clear
@@ -1047,7 +1057,14 @@ export const prepareOrRecoverResearchPaperActivation = (
     }
     if (decision._tag !== 'Resume' && decision._tag !== 'ResumeRestricted') {
       yield* refreshResearchPaperActivationReconciliation(reconcile, operationTimeoutMs)
-      return yield* prepareResearchPaperActivation(plan, request, session, authorityStore, lifecycle)
+      return yield* prepareResearchPaperActivation(
+        plan,
+        request,
+        activationSourceGenerationHash,
+        session,
+        authorityStore,
+        lifecycle,
+      )
     }
     const generation =
       currentGeneration ?? (yield* paperActivationOperationalError('research PAPER recovery lost durable history'))
@@ -1471,11 +1488,27 @@ const runAutonomousService = (plan: ApplicationPlanFor<'AutonomousService'>) =>
                           Layer.succeed(PaperCycleClosureStore, runtimeServices.paperCycleClosureStore),
                         )
                         const readStartCycle = (startup: AutonomousCycleStartupInput) =>
-                          observeCycle(
-                            observePlan,
-                            runtimeServices.lifecycleCommandStore,
-                            runtimeServices.writerFence,
-                          )(startup).pipe(
+                          Effect.gen(function* () {
+                            if (runtimeServices.authorityGenerationStore.readAuthorityState === undefined) {
+                              return yield* paperActivationOperationalError(
+                                'OBSERVE cycle startup requires durable authority state reads',
+                              )
+                            }
+                            const authority = yield* runtimeServices.authorityGenerationStore.readAuthorityState.pipe(
+                              Effect.mapError((cause) =>
+                                paperActivationOperationalError('OBSERVE cycle startup authority read failed', cause),
+                              ),
+                            )
+                            const authorityGenerationHash = yield* Effect.fromResult(
+                              observeCycleGenerationHash(authority),
+                            ).pipe(Effect.mapError((message) => paperActivationOperationalError(message)))
+                            return yield* observeCycle(
+                              observePlan,
+                              runtimeServices.lifecycleCommandStore,
+                              runtimeServices.writerFence,
+                              authorityGenerationHash,
+                            )(startup)
+                          }).pipe(
                             // @effect-diagnostics-next-line strictEffectProvide:off -- value-only cycle services have no resource lifetime
                             Effect.provide(cycleResources),
                             Effect.map((loop) =>

--- a/services/bayn/src/db/capital-grant-algebra.test.ts
+++ b/services/bayn/src/db/capital-grant-algebra.test.ts
@@ -654,7 +654,7 @@ describe('PAPER authority algebra', () => {
       successOf(
         validateResearchCapitalGrantProof({
           proof: research,
-          configuredSourceGenerationHash: observeGenerationHash,
+          sourceGenerationHash: observeGenerationHash,
           accountId,
           brokerIdentityHash: research.brokerIdentityHash,
           build: config.build,

--- a/services/bayn/src/db/capital-grant-algebra.ts
+++ b/services/bayn/src/db/capital-grant-algebra.ts
@@ -739,7 +739,7 @@ const researchRuntimeMismatch = (
 
 export const validateResearchCapitalGrantProof = (input: {
   readonly proof: ResearchCapitalGrantProofBinding
-  readonly configuredSourceGenerationHash: string
+  readonly sourceGenerationHash: string
   readonly accountId: string
   readonly brokerIdentityHash: string
   readonly build: AuthorityBuildFacts
@@ -761,7 +761,7 @@ export const validateResearchCapitalGrantProof = (input: {
   ) {
     return researchRuntimeMismatch('strategy')
   }
-  return /^[0-9a-f]{64}$/.test(input.configuredSourceGenerationHash)
+  return /^[0-9a-f]{64}$/.test(input.sourceGenerationHash)
     ? Result.succeed(undefined)
     : researchRuntimeMismatch('generationHash')
 }

--- a/services/bayn/src/db/execution-store/capital-grant.ts
+++ b/services/bayn/src/db/execution-store/capital-grant.ts
@@ -61,13 +61,14 @@ export interface CapitalGrantInterpreter {
   readonly activateCapitalGrant: (proof: CapitalGrantProofBinding) => Effect.Effect<AuthorityState, ExecutionStoreError>
   readonly activateResearchCapitalGrant: (
     proof: ResearchCapitalGrantProofBinding,
+    sourceGenerationHash: string,
   ) => Effect.Effect<AuthorityState, ExecutionStoreError>
 }
 
 interface ResearchPaperRuntimeBinding {
   readonly accountId: string
   readonly brokerIdentityHash: string
-  readonly configuredSourceGenerationHash: string
+  readonly sourceGenerationHash: string
 }
 
 const makeCapitalGrantInterpreterDataFirst = (
@@ -98,7 +99,9 @@ const makeCapitalGrantInterpreterDataFirst = (
       ),
     )
 
-  const requireResearchPaperRuntime = (): Effect.Effect<ResearchPaperRuntimeBinding, ExecutionStoreError> => {
+  const requireResearchPaperRuntime = (
+    sourceGenerationHash: string,
+  ): Effect.Effect<ResearchPaperRuntimeBinding, ExecutionStoreError> => {
     const identity = config.execution.brokerIdentity
     const alpaca = config.alpaca
     if (
@@ -116,7 +119,7 @@ const makeCapitalGrantInterpreterDataFirst = (
     return Effect.succeed({
       accountId: identity.accountId,
       brokerIdentityHash: identity.identityHash,
-      configuredSourceGenerationHash: alpaca.authorityGenerationHash,
+      sourceGenerationHash,
     })
   }
 
@@ -497,14 +500,14 @@ const makeCapitalGrantInterpreterDataFirst = (
       yield* liftAuthorityDecision(
         validatePaperPrepareGeneration(current, {
           accountId: binding.accountId,
-          configuredGenerationHash: binding.configuredSourceGenerationHash,
+          configuredGenerationHash: binding.sourceGenerationHash,
           qualificationRunId: proof.grant.planHash,
         }),
       )
       yield* liftAuthorityDecision(
         validateResearchCapitalGrantProof({
           proof,
-          configuredSourceGenerationHash: binding.configuredSourceGenerationHash,
+          sourceGenerationHash: binding.sourceGenerationHash,
           accountId: binding.accountId,
           brokerIdentityHash: binding.brokerIdentityHash,
           build: config.build,
@@ -523,9 +526,7 @@ const makeCapitalGrantInterpreterDataFirst = (
   ) =>
     researchPaperGenerationFromRow(history).pipe(
       Effect.flatMap((stored) =>
-        liftAuthorityDecision(
-          validateResearchPaperGenerationReplay(stored, proof, binding.configuredSourceGenerationHash),
-        ),
+        liftAuthorityDecision(validateResearchPaperGenerationReplay(stored, proof, binding.sourceGenerationHash)),
       ),
       Effect.as(current),
     )
@@ -598,16 +599,16 @@ const makeCapitalGrantInterpreterDataFirst = (
       return yield* writeResearchPaperGenerationActivation(decision, derived, activatedAt)
     })
 
-  const activateResearchCapitalGrant = (candidate: ResearchCapitalGrantProofBinding) =>
+  const activateResearchCapitalGrant = (candidate: ResearchCapitalGrantProofBinding, sourceGenerationHash: string) =>
     runExecutionOperation(
       'authority',
       Effect.gen(function* () {
         const proof = yield* decodeResearchCapitalGrantProofBinding(candidate)
-        const binding = yield* requireResearchPaperRuntime()
+        const binding = yield* requireResearchPaperRuntime(sourceGenerationHash)
         yield* liftAuthorityDecision(
           validateResearchCapitalGrantProof({
             proof,
-            configuredSourceGenerationHash: binding.configuredSourceGenerationHash,
+            sourceGenerationHash: binding.sourceGenerationHash,
             accountId: binding.accountId,
             brokerIdentityHash: binding.brokerIdentityHash,
             build: config.build,

--- a/services/bayn/src/db/execution-store/contract.ts
+++ b/services/bayn/src/db/execution-store/contract.ts
@@ -105,10 +105,12 @@ export interface CapitalGrantLifecycleStoreShape {
   /**
    * Atomically derives a reconciliation-bound research generation, records it, and activates PAPER authority. The
    * static request intentionally cannot predict this generation hash because reconciliation continues until the
-   * activation transaction acquires its fence.
+   * activation transaction acquires its fence. The source hash is the durable OBSERVE generation validated by the
+   * caller and is checked again under the activation transaction lock.
    */
   readonly activateResearchCapitalGrant: (
     proof: ResearchCapitalGrantProofBinding,
+    sourceGenerationHash: string,
   ) => Effect.Effect<AuthorityState, ExecutionStoreError>
 }
 

--- a/services/bayn/src/db/paper-store.integration.test.ts
+++ b/services/bayn/src/db/paper-store.integration.test.ts
@@ -20,6 +20,7 @@ import {
 } from 'effect'
 
 import type { RuntimeConfig } from '../config'
+import { paperObserveSuccessorGenerationHash, recoverBlockedGenerationToObserve } from '../blocked-generation-recovery'
 import { orderRequestBody } from '../broker/alpaca-mutations'
 import { makeStrategyProtocolHash } from '../contracts'
 import { operationalError } from '../errors'
@@ -71,6 +72,7 @@ import { BrokerProvider, alpacaSandboxBaseUrl } from '../broker/alpaca'
 import { makeBrokerIdentity, type BrokerIdentity } from '../broker/identity'
 import { incompletePassReason } from '../simulation-reconciliation/broker-reconciler-model'
 import { paperEpisodeFailureRestrictionPrefix } from '../paper-episode'
+import type { BlockedCycleIntentStoreShape } from '../execution/intents'
 import { EvidenceStore, EvidenceStoreFromPostgres, PostgresClientLive } from './evidence-store'
 import {
   BrokerEventStore,
@@ -2354,6 +2356,152 @@ describePostgres('paper accounting persistence', () => {
         kill: KillState.Clear,
       })
       expect(result.rearmed.reason).toBeUndefined()
+    } finally {
+      await runtime.dispose()
+    }
+  }, 15_000)
+
+  test('rolls a settled PAPER generation into one fresh restart-safe OBSERVE successor', async () => {
+    const configuredObserveGenerationHash = hash('blocked-rollover-configured-observe')
+    const activationReconciliation = exactReconciliation('blocked-rollover-activation')
+    const activation = makeResearchActivation(configuredObserveGenerationHash, activationReconciliation)
+    const runtime = makeStoreRuntime(
+      { fail: false, planHashes: [] },
+      researchRuntimeConfig(configuredObserveGenerationHash),
+    )
+    try {
+      const result = await runtime.runPromise(
+        Effect.gen(function* () {
+          const store = yield* ExecutionStore
+          const sql = yield* PgClient.PgClient
+          const writerFence = yield* WriterFence
+          const activateResearch = store.activateResearchCapitalGrant
+          assert(activateResearch !== undefined, 'research PAPER activation must be implemented')
+
+          yield* seedExactReconciliation(activationReconciliation)
+          yield* store.ensureAuthorityGeneration({
+            generationHash: configuredObserveGenerationHash,
+            maximum: Authority.Observe,
+          })
+          const paper = yield* activateResearch(researchProofBinding(activation))
+          const [restrictionTime] = yield* sql<{ updated_at: Date }>`
+            SELECT greatest(clock_timestamp(), updated_at + interval '1 millisecond') AS updated_at
+            FROM authority_state
+            WHERE singleton
+          `
+          if (restrictionTime === undefined) return yield* Effect.die(new Error('restriction time is unavailable'))
+          yield* store.restrictAuthority(
+            `${paperEpisodeFailureRestrictionPrefix} blocked rollover regression`,
+            restrictionTime.updated_at.toISOString(),
+          )
+
+          const blockedIntents: BlockedCycleIntentStoreShape = {
+            terminalizeUntouchedApproved: () => Effect.die(new Error('startup settlement only')),
+            settleCurrentBlockedGeneration: () =>
+              Effect.succeed({
+                _tag: 'BlockedGenerationSettled' as const,
+                authorityGenerationHash: paper.generationHash,
+                blockedCycleCount: 1,
+                blockedIntentCount: 0,
+                expiredIntentCount: 0,
+                intentCount: 0,
+                terminalIntentCount: 0,
+              }),
+          }
+          const reconciliation = exactReconciliation('blocked-rollover-after-settlement')
+          const reconcileAfterSettlement = Effect.gen(function* () {
+            const stateHash = hash('blocked-rollover-after-settlement-state')
+            yield* sql`
+                INSERT INTO reconciliations (
+                  reconciliation_id, schema_version, account_id, expected_hash, observed_hash,
+                  content_hash, status, discrepancies, reconciled_at
+                )
+                SELECT
+                  ${reconciliation.reconciliationId}, 'bayn.paper-reconciliation.v1', ${accountId},
+                  ${stateHash}, ${stateHash}, ${reconciliation.contentHash}, 'EXACT',
+                  ${sql.json(encodeSqlJson([]))}, greatest(clock_timestamp(), state.updated_at + interval '1 millisecond')
+                FROM authority_state AS state
+                WHERE state.singleton
+              `
+          }).pipe(
+            Effect.mapError((cause) =>
+              operationalError({
+                component: 'database',
+                operation: 'test-blocked-rollover',
+                message: 'test reconciliation write failed',
+                cause,
+              }),
+            ),
+          )
+          const first = yield* recoverBlockedGenerationToObserve({
+            accountId,
+            blockedIntents,
+            authorityStore: store,
+            writerFence,
+            reconcileAfterSettlement,
+          })
+          if (first._tag !== 'RolledOver') return yield* Effect.die(new Error('rollover receipt is missing'))
+          const replay = yield* store.ensureAuthorityGeneration({
+            generationHash: first.generationHash,
+            maximum: Authority.Observe,
+          })
+          const reusedBootstrap = yield* Effect.flip(
+            store.ensureAuthorityGeneration({
+              generationHash: configuredObserveGenerationHash,
+              maximum: Authority.Observe,
+            }),
+          )
+          const history = yield* sql<{
+            generation_hash: string
+            maximum: Authority
+            previous_generation_hash: string | null
+          }>`
+            SELECT generation_hash, maximum, previous_generation_hash
+            FROM authority_generations
+            ORDER BY authority_version
+          `
+          return { first, history, paper, replay, reusedBootstrap }
+        }),
+      )
+
+      const expectedSuccessor = Result.getOrThrow(
+        paperObserveSuccessorGenerationHash({
+          previousPaperGenerationHash: result.paper.generationHash,
+        }),
+      )
+      expect(result.first).toMatchObject({
+        _tag: 'RolledOver',
+        previousGenerationHash: result.paper.generationHash,
+        generationHash: expectedSuccessor,
+      })
+      expect(result.replay).toMatchObject({
+        generationHash: expectedSuccessor,
+        maximum: Authority.Observe,
+        effective: Authority.Observe,
+        kill: KillState.Clear,
+      })
+      expect(result.reusedBootstrap).toMatchObject({
+        operation: 'authority',
+        failure: 'conflict',
+        message: 'authority generation hash was already used',
+      })
+      expect(result.history).toEqual([
+        {
+          generation_hash: configuredObserveGenerationHash,
+          maximum: Authority.Observe,
+          previous_generation_hash: null,
+        },
+        {
+          generation_hash: result.paper.generationHash,
+          maximum: Authority.Paper,
+          previous_generation_hash: configuredObserveGenerationHash,
+        },
+        {
+          generation_hash: expectedSuccessor,
+          maximum: Authority.Observe,
+          previous_generation_hash: result.paper.generationHash,
+        },
+      ])
     } finally {
       await runtime.dispose()
     }

--- a/services/bayn/src/db/paper-store.integration.test.ts
+++ b/services/bayn/src/db/paper-store.integration.test.ts
@@ -1959,9 +1959,9 @@ describePostgres('paper accounting persistence', () => {
             generationHash: initialGenerationHash,
             maximum: Authority.Observe,
           })
-          const activated = yield* activateResearch(researchProofBinding(staticRequest))
+          const activated = yield* activateResearch(researchProofBinding(staticRequest), initialGenerationHash)
           const beforeReplay = yield* readAuthorityTupleEvidence
-          const replay = yield* activateResearch(researchProofBinding(staticRequest))
+          const replay = yield* activateResearch(researchProofBinding(staticRequest), initialGenerationHash)
           const afterReplay = yield* readAuthorityTupleEvidence
           const research = yield* readResearch(expected.generationHash)
           const qualified = yield* readQualified(expected.generationHash)
@@ -2032,7 +2032,7 @@ describePostgres('paper accounting persistence', () => {
             generationHash: sourceGenerationHash,
             maximum: Authority.Observe,
           })
-          const activated = yield* activateResearch(researchProofBinding(activation))
+          const activated = yield* activateResearch(researchProofBinding(activation), sourceGenerationHash)
           const [restrictionTime] = yield* sql<{ updated_at: Date }>`
             SELECT greatest(clock_timestamp(), updated_at + interval '1 millisecond') AS updated_at
             FROM authority_state
@@ -2148,7 +2148,7 @@ describePostgres('paper accounting persistence', () => {
             generationHash: sourceGenerationHash,
             maximum: Authority.Observe,
           })
-          const activated = yield* activateResearch(researchProofBinding(activation))
+          const activated = yield* activateResearch(researchProofBinding(activation), sourceGenerationHash)
           yield* sql`
             WITH timing AS (
               SELECT (clock_timestamp() AT TIME ZONE 'UTC')::date + 2 AS execution_date
@@ -2330,7 +2330,22 @@ describePostgres('paper accounting persistence', () => {
               maximum: Authority.Observe,
             }),
           )
-          yield* seedExactReconciliation(exactReconciliation('qualified-v2-recovery-rollover'))
+          const rolloverReconciliation = exactReconciliation('qualified-v2-recovery-rollover')
+          const rolloverStateHash = hash('qualified-v2-recovery-rollover-state')
+          yield* sql`
+            INSERT INTO reconciliations (
+              reconciliation_id, schema_version, account_id, expected_hash, observed_hash,
+              content_hash, status, discrepancies, reconciled_at
+            )
+            SELECT
+              ${rolloverReconciliation.reconciliationId}, 'bayn.paper-reconciliation.v1', ${accountId},
+              ${rolloverStateHash}, ${rolloverStateHash}, ${rolloverReconciliation.contentHash}, 'EXACT',
+              ${sql.json(encodeSqlJson([]))}, greatest(clock_timestamp(), state.updated_at + interval '1 millisecond')
+            FROM authority_state AS state
+            WHERE state.singleton
+          `
+          // Recovery requires a strictly later, independently sampled activation time.
+          yield* sql`SELECT pg_sleep(0.01)`
           const rearmed = yield* store.ensureAuthorityGeneration({
             generationHash: nextSourceGenerationHash,
             maximum: Authority.Observe,
@@ -2383,7 +2398,7 @@ describePostgres('paper accounting persistence', () => {
             generationHash: configuredObserveGenerationHash,
             maximum: Authority.Observe,
           })
-          const paper = yield* activateResearch(researchProofBinding(activation))
+          const paper = yield* activateResearch(researchProofBinding(activation), configuredObserveGenerationHash)
           const [restrictionTime] = yield* sql<{ updated_at: Date }>`
             SELECT greatest(clock_timestamp(), updated_at + interval '1 millisecond') AS updated_at
             FROM authority_state
@@ -2451,6 +2466,21 @@ describePostgres('paper accounting persistence', () => {
               maximum: Authority.Observe,
             }),
           )
+          const nextReconciliation = exactReconciliation('blocked-rollover-next-activation')
+          const nextStateHash = hash('blocked-rollover-next-activation-state')
+          yield* sql`
+            INSERT INTO reconciliations (
+              reconciliation_id, schema_version, account_id, expected_hash, observed_hash,
+              content_hash, status, discrepancies, reconciled_at
+            )
+            SELECT
+              ${nextReconciliation.reconciliationId}, 'bayn.paper-reconciliation.v1', ${accountId},
+              ${nextStateHash}, ${nextStateHash}, ${nextReconciliation.contentHash}, 'EXACT',
+              ${sql.json(encodeSqlJson([]))}, greatest(clock_timestamp(), state.updated_at + interval '1 millisecond')
+            FROM authority_state AS state
+            WHERE state.singleton
+          `
+          const nextPaper = yield* activateResearch(researchProofBinding(activation), first.generationHash)
           const history = yield* sql<{
             generation_hash: string
             maximum: Authority
@@ -2460,7 +2490,7 @@ describePostgres('paper accounting persistence', () => {
             FROM authority_generations
             ORDER BY authority_version
           `
-          return { first, history, paper, replay, reusedBootstrap }
+          return { first, history, nextPaper, paper, replay, reusedBootstrap }
         }),
       )
 
@@ -2485,6 +2515,13 @@ describePostgres('paper accounting persistence', () => {
         failure: 'conflict',
         message: 'authority generation hash was already used',
       })
+      expect(result.nextPaper).toMatchObject({
+        maximum: Authority.Paper,
+        effective: Authority.Paper,
+        kill: KillState.Clear,
+      })
+      expect(result.nextPaper.version).toBe(result.replay.version + 1)
+      expect(result.nextPaper.generationHash).not.toBe(result.paper.generationHash)
       expect(result.history).toEqual([
         {
           generation_hash: configuredObserveGenerationHash,
@@ -2500,6 +2537,11 @@ describePostgres('paper accounting persistence', () => {
           generation_hash: expectedSuccessor,
           maximum: Authority.Observe,
           previous_generation_hash: result.paper.generationHash,
+        },
+        {
+          generation_hash: result.nextPaper.generationHash,
+          maximum: Authority.Paper,
+          previous_generation_hash: expectedSuccessor,
         },
       ])
     } finally {
@@ -2526,7 +2568,7 @@ describePostgres('paper accounting persistence', () => {
             generationHash: sourceGenerationHash,
             maximum: Authority.Observe,
           })
-          yield* activateResearch(researchProofBinding(activation))
+          yield* activateResearch(researchProofBinding(activation), sourceGenerationHash)
           const [restrictionTime] = yield* sql<{ updated_at: Date }>`
             SELECT greatest(clock_timestamp(), updated_at + interval '1 millisecond') AS updated_at
             FROM authority_state


### PR DESCRIPTION
## Summary

- derive one deterministic immutable OBSERVE successor from each terminal PAPER generation instead of reusing the configured bootstrap identity
- validate durable current authority and use the persisted predecessor when recovering or activating research PAPER across successor generations
- prove exact settlement/reconciliation ordering, retry idempotency, immutable authority history, and bootstrap-hash reuse rejection with unit and PostgreSQL regressions

## Related Issues

None

## Testing

- `bun test --timeout 30000` from `services/bayn`: 1105 pass, 165 skip, 0 fail
- `BAYN_TEST_POSTGRES_URL=postgresql://bayn:bayn@127.0.0.1:5432/bayn_test bun run test:postgres`: all four PostgreSQL test files passed
- `bun run tsc`
- `bun run lint`
- `bun run lint:oxlint:type`: 0 warnings, 0 errors across 110 rules
- `bun run build`: all four production entrypoints bundled

## Breaking Changes

None. Existing authority history is preserved; only future terminal PAPER rollover identities change.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] No documentation or release-note change is required; live rollout proof remains part of this delivery.
