### PR TITLE
fix(bayn): bound Restate lifecycle activation

### DIFF
--- a/services/bayn/src/restate-lifecycle-controller.test.ts
+++ b/services/bayn/src/restate-lifecycle-controller.test.ts
@@ -5,8 +5,13 @@ import { Result } from 'effect'
 import { lifecycleCommandId } from './lifecycle-command-contract'
 import { decodeRestateLifecycleConfig } from './restate-lifecycle'
 import {
+  lifecycleActivationAwaitTimeoutMs,
+  lifecycleActivationIdempotencyRetentionMs,
+  lifecycleActivationRetryPolicy,
+  lifecycleBootstrapRetryPolicy,
   lifecycleCommandFinalizationHeadroomMs,
   lifecycleCommandRequestTimeoutMs,
+  lifecycleCursorRequestTimeoutMs,
   lifecycleHandlerTimeouts,
   makeLifecycleCommandClient,
 } from './restate-lifecycle-controller'
@@ -45,6 +50,23 @@ describe('Restate lifecycle command client', () => {
       })
       expect(expected.inactivityTimeout).toBeGreaterThan(lifecycleCommandRequestTimeoutMs(operationTimeoutMs))
     }
+  })
+
+  test('bounds activation lock ownership and keeps the registration waiter outside that boundary', () => {
+    expect(lifecycleActivationRetryPolicy).toEqual({
+      maxAttempts: 8,
+      onMaxAttempts: 'kill',
+      initialInterval: 1_000,
+      maxInterval: 30_000,
+      exponentiationFactor: 2,
+    })
+    expect(lifecycleBootstrapRetryPolicy).toEqual({ maxAttempts: 1, onMaxAttempts: 'kill' })
+    expect(lifecycleActivationIdempotencyRetentionMs).toBe(600_000)
+    expect(lifecycleCursorRequestTimeoutMs).toBe(10_000)
+    expect(lifecycleActivationAwaitTimeoutMs).toBe(201_000)
+    expect(lifecycleActivationAwaitTimeoutMs).toBeGreaterThan(
+      lifecycleHandlerTimeouts(config.operationTimeoutMs).inactivityTimeout,
+    )
   })
 
   test('uses only the bound command origin and exact typed contracts', async () => {

--- a/services/bayn/src/restate-lifecycle-controller.test.ts
+++ b/services/bayn/src/restate-lifecycle-controller.test.ts
@@ -71,6 +71,7 @@ describe('Restate lifecycle command client', () => {
 
   test('uses only the bound command origin and exact typed contracts', async () => {
     const requests: Array<{ readonly url: string; readonly init: RequestInit }> = []
+    const credentialSignals: AbortSignal[] = []
     const request = async (input: string | URL | Request, init: RequestInit = {}): Promise<Response> => {
       const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url
       requests.push({ url, init })
@@ -97,7 +98,14 @@ describe('Restate lifecycle command client', () => {
         },
       })
     }
-    const client = makeLifecycleCommandClient(config, async () => 'projected-worker-token', request)
+    const client = makeLifecycleCommandClient(
+      config,
+      async (signal) => {
+        credentialSignals.push(signal)
+        return 'projected-worker-token'
+      },
+      request,
+    )
 
     expect(await client.readCursor()).toMatchObject({ cursor: { _tag: 'Next', sequence: 4 } })
     expect(
@@ -118,6 +126,7 @@ describe('Restate lifecycle command client', () => {
       'Bearer projected-worker-token',
     ])
     expect(requests.every(({ init }) => init.signal instanceof AbortSignal && !init.signal.aborted)).toBe(true)
+    expect(requests.map(({ init }) => init.signal)).toEqual(credentialSignals)
     const advanceBody = requests[1]?.init.body
     if (typeof advanceBody !== 'string') throw new Error('advance request body is not a string')
     expect(JSON.parse(advanceBody)).toEqual({

--- a/services/bayn/src/restate-lifecycle-controller.ts
+++ b/services/bayn/src/restate-lifecycle-controller.ts
@@ -20,6 +20,23 @@ import {
 const stateKey = 'controller'
 const maximumResponseBytes = 64 * 1024
 export const lifecycleCommandFinalizationHeadroomMs = 30_000
+export const lifecycleCursorRequestTimeoutMs = 10_000
+export const lifecycleActivationMaximumAttempts = 8
+export const lifecycleActivationInitialRetryIntervalMs = 1_000
+export const lifecycleActivationMaximumRetryIntervalMs = 30_000
+export const lifecycleActivationRetryIntervalFactor = 2
+export const lifecycleActivationIdempotencyRetentionMs = 10 * 60_000
+export const lifecycleActivationRetryPolicy = {
+  maxAttempts: lifecycleActivationMaximumAttempts,
+  onMaxAttempts: 'kill',
+  initialInterval: lifecycleActivationInitialRetryIntervalMs,
+  maxInterval: lifecycleActivationMaximumRetryIntervalMs,
+  exponentiationFactor: lifecycleActivationRetryIntervalFactor,
+} as const satisfies restate.RetryPolicy
+export const lifecycleBootstrapRetryPolicy = {
+  maxAttempts: 1,
+  onMaxAttempts: 'kill',
+} as const satisfies restate.RetryPolicy
 const lifecycleTickSerde = restate.serde.json.schema<RestateLifecycleTick>({
   type: 'object',
   required: ['schemaVersion', 'epoch', 'sequence'],
@@ -86,6 +103,21 @@ const readBoundedJson = async (response: Response): Promise<unknown> => {
 export const lifecycleCommandRequestTimeoutMs = (operationTimeoutMs: number): number =>
   operationTimeoutMs + lifecycleCommandFinalizationHeadroomMs
 
+const lifecycleActivationRetryDelayMs = (): number => {
+  let interval = lifecycleActivationInitialRetryIntervalMs
+  let total = 0
+  for (let attempt = 1; attempt < lifecycleActivationMaximumAttempts; attempt += 1) {
+    total += interval
+    interval = Math.min(interval * lifecycleActivationRetryIntervalFactor, lifecycleActivationMaximumRetryIntervalMs)
+  }
+  return total
+}
+
+export const lifecycleActivationAwaitTimeoutMs =
+  lifecycleCursorRequestTimeoutMs * lifecycleActivationMaximumAttempts +
+  lifecycleActivationRetryDelayMs() +
+  lifecycleCommandFinalizationHeadroomMs
+
 // Let the bounded HTTP request finish and give Restate one additional journal-finalization window before requesting
 // suspension. The abort window then bounds non-cooperative code without cutting off any accepted Bayn operation.
 export const lifecycleHandlerTimeouts = (
@@ -115,7 +147,7 @@ export const makeLifecycleCommandClient = (
   credential: LifecycleCommandCredential,
   request: HttpRequest = fetch,
 ): LifecycleCommandClient => {
-  const requestTimeoutMs = lifecycleCommandRequestTimeoutMs(config.operationTimeoutMs)
+  const commandRequestTimeoutMs = lifecycleCommandRequestTimeoutMs(config.operationTimeoutMs)
   return {
     readCursor: async () => {
       const token = await credential()
@@ -128,7 +160,7 @@ export const makeLifecycleCommandClient = (
               method: 'GET',
               headers: { authorization: `Bearer ${token}` },
             },
-            requestTimeoutMs,
+            lifecycleCursorRequestTimeoutMs,
           ),
         ),
         'Bayn lifecycle command cursor response failed validation',
@@ -150,7 +182,7 @@ export const makeLifecycleCommandClient = (
                 sourceRevision: config.sourceRevision,
               }),
             },
-            requestTimeoutMs,
+            commandRequestTimeoutMs,
           ),
         ),
         'Bayn lifecycle command response failed validation',
@@ -187,36 +219,39 @@ export const makeBaynLifecycle = (config: RestateLifecycleConfig, client: Lifecy
   restate.object({
     name: 'BaynLifecycle',
     handlers: {
-      activate: async (ctx: restate.ObjectContext<LifecycleObjectState>, candidate: unknown) => {
-        const request = decodeOrTerminal(
-          decodeRestateLifecycleActivation(candidate),
-          'Restate lifecycle activation request failed validation',
-        )
-        if (ctx.key !== config.controllerKey || request.controllerKey !== config.controllerKey) {
-          throw terminal('Restate lifecycle activation controller key does not match this deployment')
-        }
+      activate: restate.handlers.object.exclusive(
+        { retryPolicy: lifecycleActivationRetryPolicy },
+        async (ctx: restate.ObjectContext<LifecycleObjectState>, candidate: unknown) => {
+          const request = decodeOrTerminal(
+            decodeRestateLifecycleActivation(candidate),
+            'Restate lifecycle activation request failed validation',
+          )
+          if (ctx.key !== config.controllerKey || request.controllerKey !== config.controllerKey) {
+            throw terminal('Restate lifecycle activation controller key does not match this deployment')
+          }
 
-        const current = await readState(ctx)
-        // The public bootstrap is intentionally idempotent for one immutable plan. In particular, it cannot undo an
-        // operator-initiated deactivation; only a newly reviewed source/configuration plan may start a new epoch.
-        if (current?.planHash === config.planHash) return current
+          const current = await readState(ctx)
+          // The public bootstrap is intentionally idempotent for one immutable plan. In particular, it cannot undo an
+          // operator-initiated deactivation; only a newly reviewed source/configuration plan may start a new epoch.
+          if (current?.planHash === config.planHash) return current
 
-        const cursor = await ctx.run('recover Bayn lifecycle command cursor', () => client.readCursor())
-        if (cursor.controllerKey !== config.controllerKey || cursor.sourceRevision !== config.sourceRevision) {
-          throw new Error('Bayn lifecycle command cursor does not match this source deployment')
-        }
-        const state = initialRestateLifecycleState(config, cursor.cursor, current?.epoch ?? 0)
-        ctx.set(stateKey, state)
-        scheduleTick(ctx, state, 0)
-        await lifecycleLog('Bayn Restate lifecycle activated', {
-          controllerKey: ctx.key,
-          epoch: state.epoch,
-          nextSequence: state.cursor._tag === 'Pending' ? state.cursor.command.sequence : state.cursor.sequence,
-          planHash: state.planHash,
-          sourceRevision: state.sourceRevision,
-        })
-        return state
-      },
+          const cursor = await ctx.run('recover Bayn lifecycle command cursor', () => client.readCursor())
+          if (cursor.controllerKey !== config.controllerKey || cursor.sourceRevision !== config.sourceRevision) {
+            throw terminal('Bayn lifecycle command cursor does not match this source deployment')
+          }
+          const state = initialRestateLifecycleState(config, cursor.cursor, current?.epoch ?? 0)
+          ctx.set(stateKey, state)
+          scheduleTick(ctx, state, 0)
+          await lifecycleLog('Bayn Restate lifecycle activated', {
+            controllerKey: ctx.key,
+            epoch: state.epoch,
+            nextSequence: state.cursor._tag === 'Pending' ? state.cursor.command.sequence : state.cursor.sequence,
+            planHash: state.planHash,
+            sourceRevision: state.sourceRevision,
+          })
+          return state
+        },
+      ),
 
       advance: async (ctx: restate.ObjectContext<LifecycleObjectState>, candidate: unknown): Promise<void> => {
         const tick = decodeOrTerminal(decodeRestateLifecycleTick(candidate), 'Restate lifecycle tick failed validation')
@@ -296,16 +331,22 @@ export const makeBaynLifecycleBootstrap = (
   restate.service({
     name: 'BaynLifecycleBootstrap',
     handlers: {
-      start: async (ctx: restate.Context, candidate: unknown) => {
-        const request = decodeOrTerminal(
-          decodeRestateLifecycleActivation(candidate),
-          'Restate lifecycle bootstrap request failed validation',
-        )
-        if (request.controllerKey !== config.controllerKey) {
-          throw terminal('Restate lifecycle bootstrap controller key does not match this deployment')
-        }
-        return ctx.objectClient(lifecycle, config.controllerKey).activate(request)
-      },
+      start: restate.handlers.handler(
+        {
+          idempotencyRetention: lifecycleActivationIdempotencyRetentionMs,
+          retryPolicy: lifecycleBootstrapRetryPolicy,
+        },
+        async (ctx: restate.Context, candidate: unknown) => {
+          const request = decodeOrTerminal(
+            decodeRestateLifecycleActivation(candidate),
+            'Restate lifecycle bootstrap request failed validation',
+          )
+          if (request.controllerKey !== config.controllerKey) {
+            throw terminal('Restate lifecycle bootstrap controller key does not match this deployment')
+          }
+          return ctx.objectClient(lifecycle, config.controllerKey).activate(request)
+        },
+      ),
     },
     options: {
       ...lifecycleHandlerTimeouts(config.operationTimeoutMs),

--- a/services/bayn/src/restate-lifecycle-controller.ts
+++ b/services/bayn/src/restate-lifecycle-controller.ts
@@ -56,7 +56,7 @@ export interface LifecycleCommandClient {
 }
 
 type HttpRequest = (input: string | URL | Request, init?: RequestInit) => Promise<Response>
-export type LifecycleCommandCredential = () => Promise<string>
+export type LifecycleCommandCredential = (signal: AbortSignal) => Promise<string>
 
 export const lifecycleLog = (
   message: string,
@@ -131,9 +131,9 @@ const fetchJson = async (
   request: HttpRequest,
   url: string,
   init: RequestInit,
-  requestTimeoutMs: number,
+  signal: AbortSignal,
 ): Promise<unknown> => {
-  const response = await request(url, { ...init, signal: AbortSignal.timeout(requestTimeoutMs) })
+  const response = await request(url, { ...init, signal })
   if (!response.ok) {
     const message = `Bayn lifecycle command boundary returned HTTP ${response.status}`
     if (response.status >= 400 && response.status < 500) throw terminal(message)
@@ -150,7 +150,8 @@ export const makeLifecycleCommandClient = (
   const commandRequestTimeoutMs = lifecycleCommandRequestTimeoutMs(config.operationTimeoutMs)
   return {
     readCursor: async () => {
-      const token = await credential()
+      const signal = AbortSignal.timeout(lifecycleCursorRequestTimeoutMs)
+      const token = await credential(signal)
       return decodeOrTerminal(
         decodeLifecycleCommandCursorResponse(
           await fetchJson(
@@ -160,14 +161,15 @@ export const makeLifecycleCommandClient = (
               method: 'GET',
               headers: { authorization: `Bearer ${token}` },
             },
-            lifecycleCursorRequestTimeoutMs,
+            signal,
           ),
         ),
         'Bayn lifecycle command cursor response failed validation',
       )
     },
     advance: async (command) => {
-      const token = await credential()
+      const signal = AbortSignal.timeout(commandRequestTimeoutMs)
+      const token = await credential(signal)
       return decodeOrTerminal(
         decodeLifecycleCommandResponse(
           await fetchJson(
@@ -182,7 +184,7 @@ export const makeLifecycleCommandClient = (
                 sourceRevision: config.sourceRevision,
               }),
             },
-            commandRequestTimeoutMs,
+            signal,
           ),
         ),
         'Bayn lifecycle command response failed validation',

--- a/services/bayn/src/restate-lifecycle-register.test.ts
+++ b/services/bayn/src/restate-lifecycle-register.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from 'bun:test'
 
-import { restateDeploymentRegistration } from './restate-lifecycle-register'
+import {
+  restateDeploymentRegistration,
+  restateLifecycleActivationIdempotencyKey,
+  restateLifecycleActivationRequest,
+} from './restate-lifecycle-register'
+import { lifecycleActivationAwaitTimeoutMs } from './restate-lifecycle-controller'
 
 describe('Restate lifecycle deployment registration', () => {
   test('registers one immutable HTTP/2 endpoint without forcing replacement', () => {
@@ -17,5 +22,25 @@ describe('Restate lifecycle deployment registration', () => {
         source_revision: sourceRevision,
       },
     })
+  })
+
+  test('deduplicates pod retries while waiting for the bounded activation result', () => {
+    const sourceRevision = 'b'.repeat(40)
+    const controllerKey = 'primary'
+
+    expect(restateLifecycleActivationIdempotencyKey(sourceRevision, controllerKey)).toBe(
+      `bayn-lifecycle-${sourceRevision}-${controllerKey}`,
+    )
+    expect(restateLifecycleActivationRequest(sourceRevision, controllerKey)).toEqual({
+      body: {
+        schemaVersion: 'bayn.restate-lifecycle-activation.v1',
+        controllerKey,
+      },
+      headers: {
+        'idempotency-key': `bayn-lifecycle-${sourceRevision}-${controllerKey}`,
+      },
+      timeoutMs: lifecycleActivationAwaitTimeoutMs,
+    })
+    expect(lifecycleActivationAwaitTimeoutMs).toBe(201_000)
   })
 })

--- a/services/bayn/src/restate-lifecycle-register.ts
+++ b/services/bayn/src/restate-lifecycle-register.ts
@@ -3,6 +3,7 @@ import { Config, Data, Effect, Logger, Option, Schema, pipe } from 'effect'
 
 import { embeddedBuildMetadata } from './build'
 import { LifecycleControllerKeySchema } from './lifecycle-command-contract'
+import { lifecycleActivationAwaitTimeoutMs } from './restate-lifecycle-controller'
 import { GitSourceRevisionSchema } from './schemas'
 
 const InternalHttpOriginSchema = Schema.Trim.check(
@@ -25,7 +26,6 @@ const InternalHttpOriginSchema = Schema.Trim.check(
     { expected: 'an uncredentialed internal HTTP origin' },
   ),
 )
-
 class RestateRegistrationError extends Data.TaggedError('RestateRegistrationError')<{
   readonly operation: 'configuration' | 'register' | 'activate'
   readonly message: string
@@ -48,18 +48,24 @@ const config = Config.all({
   configuredSourceRevision: Config.option(Config.schema(GitSourceRevisionSchema, 'BAYN_CODE_REVISION')),
 })
 
+interface JsonPostOptions {
+  readonly headers?: Readonly<Record<string, string>>
+  readonly timeoutMs: number
+}
+
 const postJson = (
   operation: 'register' | 'activate',
   url: string,
   body: unknown,
+  options: JsonPostOptions,
 ): Effect.Effect<number, RestateRegistrationError> =>
   Effect.tryPromise({
     try: async () => {
       const response = await fetch(url, {
         method: 'POST',
-        headers: { 'content-type': 'application/json' },
+        headers: { 'content-type': 'application/json', ...options.headers },
         body: JSON.stringify(body),
-        signal: AbortSignal.timeout(30_000),
+        signal: AbortSignal.timeout(options.timeoutMs),
       })
       if (!response.ok) throw new Error(`${url} returned HTTP ${response.status}`)
       await response.body?.cancel()
@@ -81,6 +87,20 @@ export const restateDeploymentRegistration = (endpointUri: string, sourceRevisio
     service: 'bayn-lifecycle',
     source_revision: sourceRevision,
   },
+})
+
+export const restateLifecycleActivationIdempotencyKey = (sourceRevision: string, controllerKey: string): string =>
+  `bayn-lifecycle-${sourceRevision}-${controllerKey}`
+
+export const restateLifecycleActivationRequest = (sourceRevision: string, controllerKey: string) => ({
+  body: {
+    schemaVersion: 'bayn.restate-lifecycle-activation.v1',
+    controllerKey,
+  },
+  headers: {
+    'idempotency-key': restateLifecycleActivationIdempotencyKey(sourceRevision, controllerKey),
+  },
+  timeoutMs: lifecycleActivationAwaitTimeoutMs,
 })
 
 const program = Effect.gen(function* () {
@@ -107,6 +127,7 @@ const program = Effect.gen(function* () {
     'register',
     `${loaded.adminOrigin}/deployments`,
     restateDeploymentRegistration(loaded.endpointUri, sourceRevision),
+    { timeoutMs: 30_000 },
   )
   yield* Effect.logInfo('Bayn Restate deployment registered').pipe(
     Effect.annotateLogs({
@@ -116,10 +137,13 @@ const program = Effect.gen(function* () {
       sourceRevision,
     }),
   )
-  const activationStatus = yield* postJson('activate', `${loaded.ingressOrigin}/BaynLifecycleBootstrap/start`, {
-    schemaVersion: 'bayn.restate-lifecycle-activation.v1',
-    controllerKey: loaded.controllerKey,
-  })
+  const activation = restateLifecycleActivationRequest(sourceRevision, loaded.controllerKey)
+  const activationStatus = yield* postJson(
+    'activate',
+    `${loaded.ingressOrigin}/BaynLifecycleBootstrap/start`,
+    activation.body,
+    { headers: activation.headers, timeoutMs: activation.timeoutMs },
+  )
   yield* Effect.logInfo('Bayn Restate lifecycle activated through ingress').pipe(
     Effect.annotateLogs({
       activationStatus,

--- a/services/bayn/src/restate-lifecycle-server.test.ts
+++ b/services/bayn/src/restate-lifecycle-server.test.ts
@@ -3,8 +3,15 @@ import { connect, createServer as createHttp2Server, type ClientHttp2Session } f
 import { createServer as createHttpServer } from 'node:http'
 import type { AddressInfo } from 'node:net'
 
-import { Effect } from 'effect'
+import * as restate from '@restatedev/restate-sdk'
+import { Effect, Result } from 'effect'
 
+import { decodeRestateLifecycleConfig } from './restate-lifecycle'
+import {
+  makeBaynLifecycle,
+  makeBaynLifecycleBootstrap,
+  type LifecycleCommandClient,
+} from './restate-lifecycle-controller'
 import { acquireRestateLifecycleHttp2Server } from './restate-lifecycle-server'
 
 const reservePort = (): Promise<number> =>
@@ -22,6 +29,29 @@ const connectSession = (origin: string): Promise<ClientHttp2Session> =>
     const session = connect(origin)
     session.once('connect', () => resolve(session))
     session.once('error', reject)
+  })
+
+const readDiscovery = (session: ClientHttp2Session): Promise<unknown> =>
+  new Promise((resolve, reject) => {
+    const request = session.request({
+      ':method': 'GET',
+      ':path': '/discover',
+      accept: 'application/vnd.restate.endpointmanifest.v4+json',
+    })
+    let body = ''
+    request.setEncoding('utf8')
+    request.on('data', (chunk: string) => {
+      body += chunk
+    })
+    request.once('error', reject)
+    request.once('end', () => {
+      try {
+        resolve(JSON.parse(body) as unknown)
+      } catch (cause) {
+        reject(cause)
+      }
+    })
+    request.end()
   })
 
 describe('Bayn Restate lifecycle HTTP/2 server', () => {
@@ -45,5 +75,63 @@ describe('Bayn Restate lifecycle HTTP/2 server', () => {
     if (closed === undefined) throw new Error('HTTP/2 session did not connect')
     expect(await Promise.race([closed, Bun.sleep(1_000).then(() => 'timeout' as const)])).toBe('closed')
     expect(client?.destroyed).toBe(true)
+  })
+
+  test('publishes bounded activation retries without changing recurring lifecycle retries', async () => {
+    const decoded = decodeRestateLifecycleConfig({
+      schemaVersion: 'bayn.restate-lifecycle-config.v1',
+      controllerKey: 'primary',
+      commandBaseUrl: 'http://bayn-lifecycle-command.bayn.svc.cluster.local:8081',
+      operationTimeoutMs: 30_000,
+      pollIntervalMs: 30_000,
+      sourceRevision: 'a'.repeat(40),
+      port: 9080,
+    })
+    if (Result.isFailure(decoded)) throw decoded.failure
+    const commandClient: LifecycleCommandClient = {
+      readCursor: () => Promise.reject(new Error('not invoked by discovery')),
+      advance: () => Promise.reject(new Error('not invoked by discovery')),
+    }
+    const lifecycle = makeBaynLifecycle(decoded.success, commandClient)
+    const bootstrap = makeBaynLifecycleBootstrap(decoded.success, lifecycle)
+    const port = await reservePort()
+
+    await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const server = createHttp2Server(restate.createEndpointHandler({ services: [lifecycle, bootstrap] }))
+          yield* acquireRestateLifecycleHttp2Server(server, port)
+          const client = yield* Effect.promise(() => connectSession(`http://127.0.0.1:${port}`))
+          const discovery = yield* Effect.promise(() => readDiscovery(client))
+          client.close()
+
+          const services = (discovery as { readonly services?: readonly unknown[] }).services
+          const lifecycleService = services?.find(
+            (service) => (service as { readonly name?: string }).name === 'BaynLifecycle',
+          ) as { readonly handlers?: readonly Record<string, unknown>[] }
+          const bootstrapService = services?.find(
+            (service) => (service as { readonly name?: string }).name === 'BaynLifecycleBootstrap',
+          ) as { readonly handlers?: readonly Record<string, unknown>[] }
+          const activate = lifecycleService.handlers?.find((handler) => handler['name'] === 'activate')
+          const advance = lifecycleService.handlers?.find((handler) => handler['name'] === 'advance')
+          const start = bootstrapService.handlers?.find((handler) => handler['name'] === 'start')
+
+          expect(activate).toMatchObject({
+            retryPolicyExponentiationFactor: 2,
+            retryPolicyInitialInterval: 1_000,
+            retryPolicyMaxInterval: 30_000,
+            retryPolicyMaxAttempts: 8,
+            retryPolicyOnMaxAttempts: 'KILL',
+          })
+          expect(advance).not.toHaveProperty('retryPolicyMaxAttempts')
+          expect(advance).not.toHaveProperty('retryPolicyOnMaxAttempts')
+          expect(start).toMatchObject({
+            idempotencyRetention: 600_000,
+            retryPolicyMaxAttempts: 1,
+            retryPolicyOnMaxAttempts: 'KILL',
+          })
+        }),
+      ),
+    )
   })
 })

--- a/services/bayn/src/restate-lifecycle-server.ts
+++ b/services/bayn/src/restate-lifecycle-server.ts
@@ -60,14 +60,16 @@ const serverConfig = Config.all({
 
 const maximumServiceAccountTokenBytes = 16_384
 
-const commandCredential = (path: string) => async (): Promise<string> => {
-  const source = await readFile(path, 'utf8')
-  const token = source.trim()
-  if (token.length === 0 || Buffer.byteLength(token, 'utf8') > maximumServiceAccountTokenBytes) {
-    throw new Error('Bayn lifecycle command workload credential is empty or exceeds its size limit')
+const commandCredential =
+  (path: string) =>
+  async (signal: AbortSignal): Promise<string> => {
+    const source = await readFile(path, { encoding: 'utf8', signal })
+    const token = source.trim()
+    if (token.length === 0 || Buffer.byteLength(token, 'utf8') > maximumServiceAccountTokenBytes) {
+      throw new Error('Bayn lifecycle command workload credential is empty or exceeds its size limit')
+    }
+    return token
   }
-  return token
-}
 
 interface RestateHttp2ServerResource {
   readonly server: Http2Server


### PR DESCRIPTION
## Summary

- bound the one-time Restate lifecycle activation to eight retried cursor reads and kill the failed invocation instead of permanently pausing the virtual-object lock
- keep recurring lifecycle advancement durable while making cursor identity drift terminal and using a shorter cluster-local cursor timeout
- deduplicate Argo hook retries with a source/controller-bound idempotency key and wait through the complete bounded activation window
- prove the exact advertised handler policies through the real HTTP/2 discovery endpoint

## Related Issues

None

## Testing

- `bun test services/bayn/src/restate-lifecycle-controller.test.ts services/bayn/src/restate-lifecycle-register.test.ts services/bayn/src/restate-lifecycle-server.test.ts` (9 pass)
- `bun test --silent` in `services/bayn` (1,110 pass, 165 skip, 0 fail)
- `BAYN_TEST_POSTGRES_URL=postgresql://bayn:bayn@127.0.0.1:55439/bayn_test bun run test:postgres` in `services/bayn` (150 pass, 0 fail)
- `bun run tsc` in `services/bayn`
- `bun run lint` in `services/bayn`
- `bun run lint:oxlint` in `services/bayn`
- `bun run lint:oxlint:type` in `services/bayn`
- `bun run build` in `services/bayn`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
