### PR TITLE
fix(bayn): reconcile before paper rearm

### DIFF
--- a/services/bayn/src/composition.test.ts
+++ b/services/bayn/src/composition.test.ts
@@ -515,8 +515,8 @@ describe('Bayn PAPER startup recovery boundary', () => {
     }
   })
 
-  test('activates research PAPER from the persisted OBSERVE successor instead of the bootstrap hash', async () => {
-    const previousPaperGenerationHash = hash('12')
+  test('reconciles a completed PAPER generation before rearming and activates from its OBSERVE successor', async () => {
+    const previousPaperGenerationHash = continuationGeneration.generationHash
     const successorGenerationHash = Result.getOrThrow(
       paperObserveSuccessorGenerationHash({ previousPaperGenerationHash }),
     )
@@ -557,27 +557,42 @@ describe('Bayn PAPER startup recovery boundary', () => {
     )
     let authority: AuthorityState = {
       schemaVersion: 'bayn.paper-authority.v1',
-      generationHash: successorGenerationHash,
-      maximum: Authority.Observe,
-      effective: Authority.Observe,
+      generationHash: previousPaperGenerationHash,
+      maximum: Authority.Paper,
+      effective: Authority.Paper,
       kill: KillState.Clear,
-      version: 3,
-      updatedAt: '2026-08-31T20:00:00.000Z',
+      version: 2,
+      updatedAt: '2026-08-31T19:59:59.000Z',
     }
     const operations: string[] = []
     const authorityStore: AuthorityGenerationStoreShape = {
       ensureAuthorityGeneration: ({ generationHash, maximum }) =>
         Effect.sync(() => {
-          operations.push(`validate:${generationHash}`)
+          operations.push(`rearm:${generationHash}`)
           expect({ generationHash, maximum }).toEqual({
             generationHash: successorGenerationHash,
             maximum: Authority.Observe,
           })
+          authority = {
+            schemaVersion: 'bayn.paper-authority.v1',
+            generationHash: successorGenerationHash,
+            maximum: Authority.Observe,
+            effective: Authority.Observe,
+            kill: KillState.Clear,
+            version: 3,
+            updatedAt: '2026-08-31T20:00:00.500Z',
+          }
           return authority
         }),
       readAuthorityState: Effect.sync(() => authority),
       readResearchAuthorityGeneration: (generationHash) =>
-        Effect.succeed(generationHash === generation.generationHash ? generation : undefined),
+        Effect.succeed(
+          generationHash === continuationGeneration.generationHash
+            ? continuationGeneration
+            : generationHash === generation.generationHash
+              ? generation
+              : undefined,
+        ),
     }
     const lifecycle: CapitalGrantLifecycleStoreShape = {
       prepareCapitalGrant: () => Effect.die(new Error('research activation must not prepare qualified authority')),
@@ -685,11 +700,7 @@ describe('Bayn PAPER startup recovery boundary', () => {
     )
 
     expect(activated).toEqual(generation)
-    expect(operations).toEqual([
-      `validate:${successorGenerationHash}`,
-      'reconcile',
-      `activate:${successorGenerationHash}`,
-    ])
+    expect(operations).toEqual(['reconcile', `rearm:${successorGenerationHash}`, `activate:${successorGenerationHash}`])
   })
 
   test('recovers the exact continuation after cutoff and rejects stale build or generation bindings', async () => {

--- a/services/bayn/src/composition.ts
+++ b/services/bayn/src/composition.ts
@@ -1021,6 +1021,7 @@ export const prepareOrRecoverResearchPaperActivation = (
         'research PAPER build continuation requires the exact active generation',
       )
     }
+    const activationRequired = decision._tag === 'Activate' || decision._tag === 'Rearm'
     const activationSourceGenerationHash =
       decision._tag === 'Rearm'
         ? yield* Effect.fromResult(
@@ -1033,6 +1034,11 @@ export const prepareOrRecoverResearchPaperActivation = (
             ),
           )
         : currentSourceGenerationHash
+    if (activationRequired) {
+      // PostgreSQL requires broker evidence observed after the previous authority update. It must exist before a
+      // completed PAPER generation is rearmed, and the same observation then binds the new activation.
+      yield* refreshResearchPaperActivationReconciliation(reconcile, operationTimeoutMs)
+    }
     if (decision._tag === 'Rearm') {
       const rearmed = yield* authorityStore
         .ensureAuthorityGeneration({
@@ -1055,8 +1061,7 @@ export const prepareOrRecoverResearchPaperActivation = (
         )
       }
     }
-    if (decision._tag !== 'Resume' && decision._tag !== 'ResumeRestricted') {
-      yield* refreshResearchPaperActivationReconciliation(reconcile, operationTimeoutMs)
+    if (activationRequired) {
       return yield* prepareResearchPaperActivation(
         plan,
         request,


### PR DESCRIPTION
## Summary

- reconcile the flat sandbox account after the completed PAPER authority transition and before creating its OBSERVE successor
- preserve the existing fail-closed PostgreSQL rearm invariants instead of bypassing their freshness requirement
- add a causal regression for the live restart state and prove reconciliation -> rearm -> activation ordering

## Related Issues

None

## Testing

- `bun test services/bayn/src/composition.test.ts --timeout 30000` (23 passed)
- `bun run --cwd services/bayn test` (1,110 passed, 165 PostgreSQL-only skipped, 0 failed)
- `BAYN_TEST_POSTGRES_URL=postgresql://bayn:bayn@127.0.0.1:55441/bayn_test bun run --cwd services/bayn test:postgres` (150 passed, 0 failed against fresh PostgreSQL 18)
- `bun run --cwd services/bayn tsc`
- `bun run --cwd services/bayn lint`
- `bun run --cwd services/bayn lint:oxlint`
- `bun run --cwd services/bayn lint:oxlint:type`
- `bun run --cwd services/bayn build`
- `bun test packages/scripts/src/bayn` (137 passed, 0 failed)

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable and Breaking Changes is filled in.
- [x] No documentation, release-note, or follow-up change is required for this causal runtime fix.
