### PR TITLE
fix(bayn): use API audience for lifecycle review

### DIFF
--- a/argocd/applications/bayn/deployment.yaml
+++ b/argocd/applications/bayn/deployment.yaml
@@ -198,7 +198,8 @@ spec:
             defaultMode: 0444
             sources:
               - serviceAccountToken:
-                  audience: https://kubernetes.default.svc.cluster.local
+                  # Omit audience so kubelet binds this reviewer credential to
+                  # the API server's configured authentication audience.
                   expirationSeconds: 3600
                   path: token
               - configMap:

--- a/packages/scripts/src/bayn/lifecycle-manifests.test.ts
+++ b/packages/scripts/src/bayn/lifecycle-manifests.test.ts
@@ -111,6 +111,14 @@ describe('Bayn lifecycle release manifests', () => {
       ),
     ).toThrow('Bayn deployment must mount exactly one read-only lifecycle TokenReview identity')
     expect(() =>
+      validateBaynLifecycleCommandAuthentication(
+        deployment.replace(
+          '                  expirationSeconds: 3600\n',
+          '                  audience: bayn.proompteng.ai/lifecycle-command\n                  expirationSeconds: 3600\n',
+        ),
+      ),
+    ).toThrow('Bayn lifecycle TokenReview identity must use the API server audience and be bounded and CA-verified')
+    expect(() =>
       validateBaynLifecycleOperationTimeout(
         deployment.replace(
           `            - name: BAYN_OPERATION_TIMEOUT_MS\n              value: "30000"\n`,

--- a/packages/scripts/src/bayn/lifecycle-manifests.ts
+++ b/packages/scripts/src/bayn/lifecycle-manifests.ts
@@ -100,7 +100,7 @@ export const validateBaynLifecycleCommandAuthentication = (deployment: string): 
     (source) =>
       record(source) &&
       record(source.serviceAccountToken) &&
-      source.serviceAccountToken.audience === 'https://kubernetes.default.svc.cluster.local' &&
+      source.serviceAccountToken.audience === undefined &&
       source.serviceAccountToken.expirationSeconds === 3600 &&
       source.serviceAccountToken.path === 'token',
   )
@@ -116,7 +116,9 @@ export const validateBaynLifecycleCommandAuthentication = (deployment: string): 
       source.configMap.items[0].path === 'ca.crt',
   )
   if (projected.defaultMode !== 444 || serviceAccountTokens.length !== 1 || rootCas.length !== 1) {
-    throw new Error('Bayn lifecycle TokenReview identity must be bounded, audience-bound, and CA-verified')
+    throw new Error(
+      'Bayn lifecycle TokenReview identity must use the API server audience and be bounded and CA-verified',
+    )
   }
 }
 


### PR DESCRIPTION
## Summary

- issue the Bayn TokenReview caller credential for the Kubernetes API server's configured default audience instead of a DNS audience the Talos API rejects with HTTP 401
- keep the Restate worker's presented identity separately bound to `bayn.proompteng.ai/lifecycle-command`
- enforce the reviewer-token contract in the checked deployment validator and reject custom-audience regressions

## Related Issues

None

## Testing

- live read-only diagnosis: custom `https://kubernetes.default.svc.cluster.local` and `https://kubernetes.default.svc` service-account tokens returned HTTP 401; the cluster-default token authenticated and reached authorization
- live read-only handshake: a cluster-default `bayn` reviewer token authenticated `system:serviceaccount:bayn:bayn-lifecycle` for `bayn.proompteng.ai/lifecycle-command`
- `kubectl auth can-i create tokenreviews.authentication.k8s.io --as=system:serviceaccount:bayn:bayn`
- `bun test packages/scripts/src/bayn` — 137 pass, 0 fail
- `bun run --filter @proompteng/bayn test` — 1,110 pass, 165 PostgreSQL skips, 0 fail
- `bun run --filter @proompteng/scripts lint`
- `bun run --filter @proompteng/scripts lint:oxlint:type`
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn build`
- `bun run lint:argocd`
- `nix develop -c scripts/kubeconform.sh argocd/applications/bayn`
- `nix develop -c kustomize build --enable-helm argocd/applications/bayn`

## Rollout and impact

- Merging changes the Bayn pod template and causes one normal Argo-managed Bayn restart. The Restate worker token, worker image, database, broker credentials, RBAC, network policy, and trading limits are unchanged.
- The current deployment is already fail-closed: TokenReview HTTP 401 keeps `cycleRunner` degraded and has produced zero broker mutations. The expected impact is restoration of authenticated Restate lifecycle calls, not direct order submission.
- Roll out only through the normal main build/release, exact source-and-digest activation refresh, reviewed promotion PR, and Argo reconciliation. Do not patch the Deployment or Secret directly.
- Verify after rollout: reviewer-token claims use the cluster API audience; TokenReview authenticates only the exact lifecycle service account and command audience; registration/bootstrap completes; `/readyz` is READY; reconciliation is EXACT; no stale cycle replays; no broker mutation occurs before bounded PAPER authority.
- Roll back only through a reviewed Git revert and Argo. Reverting restores the known fail-closed HTTP 401 behavior; it does not grant broker authority or mutate the account.

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable; Breaking Changes is filled in.
- [x] Rollout, impact, verification, rollback, and the remaining live proof are documented and tracked in PROOMPT-405.
