### PR TITLE
fix(bayn): skip expired paper bootstrap cycles

### DIFF
--- a/services/bayn/migrations/0033_lifecycle_command_not_due_reason.ts
+++ b/services/bayn/migrations/0033_lifecycle_command_not_due_reason.ts
@@ -1,0 +1,52 @@
+import { Effect } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient
+
+  yield* sql`
+    ALTER TABLE lifecycle_commands
+    ADD COLUMN not_due_reason text
+      CHECK (not_due_reason IN ('MONTH_END_CADENCE', 'STALE_PAPER_BOOTSTRAP')),
+    ADD CONSTRAINT lifecycle_commands_not_due_reason_shape CHECK (
+      not_due_reason IS NULL
+      OR (status = 'COMPLETED' AND result = 'SUCCESS' AND outcome = 'NOT_DUE')
+    )
+  `
+
+  yield* sql`
+    CREATE OR REPLACE FUNCTION enforce_lifecycle_command_transition()
+    RETURNS trigger
+    LANGUAGE plpgsql
+    AS $function$
+    BEGIN
+      IF TG_OP = 'DELETE' THEN
+        RAISE EXCEPTION 'lifecycle commands cannot be deleted' USING ERRCODE = '55000';
+      END IF;
+
+      IF TG_OP = 'INSERT' THEN
+        IF NEW.status <> 'STARTED' THEN
+          RAISE EXCEPTION 'lifecycle commands must begin in STARTED state' USING ERRCODE = '23514';
+        END IF;
+        RETURN NEW;
+      END IF;
+
+      IF OLD.status <> 'STARTED' OR NEW.status <> 'COMPLETED' THEN
+        RAISE EXCEPTION 'lifecycle command may only transition STARTED to COMPLETED' USING ERRCODE = '23514';
+      END IF;
+
+      IF (to_jsonb(OLD) - ARRAY[
+        'status', 'result', 'outcome', 'operation', 'failure', 'message', 'observed_at', 'cadence_decision',
+        'not_due_reason', 'completed_at'
+      ]) <> (to_jsonb(NEW) - ARRAY[
+        'status', 'result', 'outcome', 'operation', 'failure', 'message', 'observed_at', 'cadence_decision',
+        'not_due_reason', 'completed_at'
+      ]) THEN
+        RAISE EXCEPTION 'lifecycle command identity is immutable' USING ERRCODE = '55000';
+      END IF;
+
+      RETURN NEW;
+    END
+    $function$
+  `
+})

--- a/services/bayn/src/cycle-observability.test.ts
+++ b/services/bayn/src/cycle-observability.test.ts
@@ -309,6 +309,16 @@ describe('autonomous cycle operations classification', () => {
     expect(
       projectResearchPaperBootstrapWaiting(failed, true, {
         ...matchingPass,
+        cadenceDecision: { signalSessionDate: '2026-09-10', executionSessionDate: '2026-09-11' },
+      }),
+    ).toMatchObject({
+      condition: CycleOperationsCondition.Waiting,
+      reason: CycleOperationsReason.StalePaperBootstrapSkipped,
+      last: { signalSessionDate: '2026-08-10', executionSessionDate: '2026-08-11' },
+    })
+    expect(
+      projectResearchPaperBootstrapWaiting(failed, true, {
+        ...matchingPass,
         notDueReason: CycleNotDueReason.MonthEndCadence,
       }),
     ).toBe(failed)
@@ -316,6 +326,12 @@ describe('autonomous cycle operations classification', () => {
       projectResearchPaperBootstrapWaiting(failed, true, {
         ...matchingPass,
         cadenceDecision: { ...matchingPass.cadenceDecision, signalSessionDate: '2026-08-09' },
+      }),
+    ).toBe(failed)
+    expect(
+      projectResearchPaperBootstrapWaiting(failed, true, {
+        ...matchingPass,
+        cadenceDecision: { signalSessionDate: '2026-09-10', executionSessionDate: '2026-08-11' },
       }),
     ).toBe(failed)
 

--- a/services/bayn/src/cycle-observability.test.ts
+++ b/services/bayn/src/cycle-observability.test.ts
@@ -11,7 +11,6 @@ import {
   deriveCycleOperationsStatus,
   deriveCycleOperationsStatusResult,
   projectAutonomousCycleCadenceObservation,
-  projectResearchPaperBootstrapWaiting,
   retainedAutonomousCycleCadenceDecision,
   renderCycleOperationsStatusFailure,
   type CycleOperationsProjection,
@@ -19,6 +18,7 @@ import {
 } from './cycle-observability'
 import { CycleState, CycleTerminalReason } from './cycle'
 import { CycleNotDueReason } from './cycle-runner/model'
+import { projectResearchPaperBootstrapWaiting } from './health/decisions'
 import { Authority, KillState, ReconciliationStatus } from './paper'
 
 const now = '2026-07-20T12:00:00.000Z'

--- a/services/bayn/src/cycle-observability.test.ts
+++ b/services/bayn/src/cycle-observability.test.ts
@@ -11,12 +11,14 @@ import {
   deriveCycleOperationsStatus,
   deriveCycleOperationsStatusResult,
   projectAutonomousCycleCadenceObservation,
+  projectResearchPaperBootstrapWaiting,
   retainedAutonomousCycleCadenceDecision,
   renderCycleOperationsStatusFailure,
   type CycleOperationsProjection,
   type CycleOperationsSnapshot,
 } from './cycle-observability'
 import { CycleState, CycleTerminalReason } from './cycle'
+import { CycleNotDueReason } from './cycle-runner/model'
 import { Authority, KillState, ReconciliationStatus } from './paper'
 
 const now = '2026-07-20T12:00:00.000Z'
@@ -262,6 +264,88 @@ describe('month-end cadence observability decisions', () => {
 })
 
 describe('autonomous cycle operations classification', () => {
+  test('projects only an exact reconciled research bootstrap miss into a healthy wait', () => {
+    const last = snapshot(CycleState.Blocked, {
+      signalSessionDate: '2026-08-10',
+      executionSessionDate: '2026-08-11',
+      terminalReason: CycleTerminalReason.MissedPublication,
+    })
+    const authority = {
+      generationHash: '4'.repeat(64),
+      maximum: Authority.Paper,
+      effective: Authority.Paper,
+      kill: KillState.Clear,
+      reason: null,
+      updatedAt: now,
+    } as const
+    const reconciliation = {
+      accountId: 'paper-account-1',
+      reconciliationId: '5'.repeat(64),
+      status: ReconciliationStatus.Exact,
+      discrepancyCount: 0,
+      reconciledAt: now,
+      coversLatestMutation: true,
+    } as const
+    const failed = deriveCycleOperationsStatus(
+      projection({ last, authority, reconciliation }),
+      Date.parse(now),
+      Authority.Paper,
+      thresholds,
+    )
+    const matchingPass = {
+      result: 'SUCCESS' as const,
+      outcome: 'NOT_DUE' as const,
+      notDueReason: CycleNotDueReason.StalePaperBootstrap,
+      cadenceDecision: { signalSessionDate: '2026-08-10', executionSessionDate: '2026-08-11' },
+    }
+
+    expect(projectResearchPaperBootstrapWaiting(failed, true, matchingPass)).toMatchObject({
+      condition: CycleOperationsCondition.Waiting,
+      reason: CycleOperationsReason.StalePaperBootstrapSkipped,
+      last: { phase: CycleState.Blocked, terminalReason: CycleTerminalReason.MissedPublication },
+      alerts: { cycleFailed: false, reconciliationBlocked: false, killActive: false },
+    })
+    expect(projectResearchPaperBootstrapWaiting(failed, false, matchingPass)).toBe(failed)
+    expect(
+      projectResearchPaperBootstrapWaiting(failed, true, {
+        ...matchingPass,
+        notDueReason: CycleNotDueReason.MonthEndCadence,
+      }),
+    ).toBe(failed)
+    expect(
+      projectResearchPaperBootstrapWaiting(failed, true, {
+        ...matchingPass,
+        cadenceDecision: { ...matchingPass.cadenceDecision, signalSessionDate: '2026-08-09' },
+      }),
+    ).toBe(failed)
+
+    const unsafe = deriveCycleOperationsStatus(
+      projection({
+        last,
+        authority,
+        reconciliation,
+        mutations: {
+          eventCount: 1,
+          recoveryFoundCount: 0,
+          approvedIntentCount: 0,
+          acknowledgedIntentCount: 0,
+          unresolvedCount: 1,
+          oldestUnresolvedAt: now,
+          latestOccurredAt: now,
+        },
+      }),
+      Date.parse(now),
+      Authority.Paper,
+      thresholds,
+    )
+    expect(projectResearchPaperBootstrapWaiting(unsafe, true, matchingPass)).toBe(unsafe)
+    expect(unsafe).toMatchObject({
+      condition: CycleOperationsCondition.Failed,
+      reason: CycleOperationsReason.UnresolvedMutation,
+      alerts: { cycleFailed: true },
+    })
+  })
+
   test('returns exact clock failures without defecting', () => {
     const notInteger = deriveCycleOperationsStatusResult(projection(), 0.5, Authority.Observe, thresholds)
     expect(notInteger).toEqual(

--- a/services/bayn/src/cycle-observability.ts
+++ b/services/bayn/src/cycle-observability.ts
@@ -1,7 +1,8 @@
 import { DateTime, Option, Result } from 'effect'
 
 import { Authority, KillState, ReconciliationStatus } from './execution/contracts'
-import { CycleState, type CycleTerminalReason } from './cycle'
+import { CycleState, CycleTerminalReason } from './cycle'
+import { CycleNotDueReason, type CycleRunResult } from './cycle-runner/model'
 import { utcInstantFromEpochMillisResult, type UtcEpochMillisFailure } from './time'
 import { Pipeable } from './pipeable'
 
@@ -338,6 +339,7 @@ export enum CycleOperationsReason {
   ReconciliationDiscrepancy = 'RECONCILIATION_DISCREPANCY',
   ReconciliationPredatesMutation = 'RECONCILIATION_PREDATES_MUTATION',
   ReconciliationStale = 'RECONCILIATION_STALE',
+  StalePaperBootstrapSkipped = 'STALE_PAPER_BOOTSTRAP_SKIPPED',
 }
 
 export interface CycleOperationsAlerts {
@@ -361,6 +363,58 @@ export interface CycleOperationsStatus extends CycleOperationsProjection {
   readonly zeroMutation: boolean | null
   readonly alerts: CycleOperationsAlerts
   readonly error: string | null
+}
+
+export interface ResearchPaperBootstrapPassObservation {
+  readonly result: 'SUCCESS' | 'FAILURE'
+  readonly outcome?: CycleRunResult['outcome']
+  readonly notDueReason?: CycleNotDueReason
+  readonly cadenceDecision?: {
+    readonly signalSessionDate: string | null
+    readonly executionSessionDate: string | null
+  }
+}
+
+/**
+ * A research activation that starts after its first publication deadline must wait for a newer publication. The
+ * immutable missed cycle remains visible, but it is no longer an operational failure after a matching NOT_DUE pass
+ * and fresh exact reconciliation prove that no mutation is pending. Every other blocked-cycle state remains failed.
+ */
+export const projectResearchPaperBootstrapWaiting = (
+  status: CycleOperationsStatus,
+  enabled: boolean,
+  lastPass: ResearchPaperBootstrapPassObservation | null,
+): CycleOperationsStatus => {
+  const last = status.last
+  const cadence = lastPass?.cadenceDecision
+  if (
+    !enabled ||
+    status.condition !== CycleOperationsCondition.Failed ||
+    status.reason !== CycleOperationsReason.LastCycleBlocked ||
+    status.current !== null ||
+    last?.phase !== CycleState.Blocked ||
+    last.terminalReason !== CycleTerminalReason.MissedPublication ||
+    status.authority?.maximum !== Authority.Paper ||
+    status.authority.effective !== Authority.Paper ||
+    status.authority.kill !== KillState.Clear ||
+    status.reconciliation?.status !== ReconciliationStatus.Exact ||
+    status.reconciliation.discrepancyCount !== 0 ||
+    !status.reconciliation.coversLatestMutation ||
+    status.mutations.unresolvedCount !== 0 ||
+    lastPass?.result !== 'SUCCESS' ||
+    lastPass.outcome !== 'NOT_DUE' ||
+    lastPass.notDueReason !== CycleNotDueReason.StalePaperBootstrap ||
+    cadence?.signalSessionDate !== last.signalSessionDate ||
+    cadence.executionSessionDate !== last.executionSessionDate
+  ) {
+    return status
+  }
+  return {
+    ...status,
+    condition: CycleOperationsCondition.Waiting,
+    reason: CycleOperationsReason.StalePaperBootstrapSkipped,
+    alerts: { ...status.alerts, cycleFailed: false },
+  }
 }
 
 export type CycleOperationsStatusFailure = {

--- a/services/bayn/src/cycle-observability.ts
+++ b/services/bayn/src/cycle-observability.ts
@@ -2,7 +2,6 @@ import { DateTime, Option, Result } from 'effect'
 
 import { Authority, KillState, ReconciliationStatus } from './execution/contracts'
 import { CycleState, CycleTerminalReason } from './cycle'
-import { CycleNotDueReason, type CycleRunResult } from './cycle-runner/model'
 import { utcInstantFromEpochMillisResult, type UtcEpochMillisFailure } from './time'
 import { Pipeable } from './pipeable'
 
@@ -363,58 +362,6 @@ export interface CycleOperationsStatus extends CycleOperationsProjection {
   readonly zeroMutation: boolean | null
   readonly alerts: CycleOperationsAlerts
   readonly error: string | null
-}
-
-export interface ResearchPaperBootstrapPassObservation {
-  readonly result: 'SUCCESS' | 'FAILURE'
-  readonly outcome?: CycleRunResult['outcome']
-  readonly notDueReason?: CycleNotDueReason
-  readonly cadenceDecision?: {
-    readonly signalSessionDate: string | null
-    readonly executionSessionDate: string | null
-  }
-}
-
-/**
- * A research activation that starts after its first publication deadline must wait for a newer publication. The
- * immutable missed cycle remains visible, but it is no longer an operational failure after a matching NOT_DUE pass
- * and fresh exact reconciliation prove that no mutation is pending. Every other blocked-cycle state remains failed.
- */
-export const projectResearchPaperBootstrapWaiting = (
-  status: CycleOperationsStatus,
-  enabled: boolean,
-  lastPass: ResearchPaperBootstrapPassObservation | null,
-): CycleOperationsStatus => {
-  const last = status.last
-  const cadence = lastPass?.cadenceDecision
-  if (
-    !enabled ||
-    status.condition !== CycleOperationsCondition.Failed ||
-    status.reason !== CycleOperationsReason.LastCycleBlocked ||
-    status.current !== null ||
-    last?.phase !== CycleState.Blocked ||
-    last.terminalReason !== CycleTerminalReason.MissedPublication ||
-    status.authority?.maximum !== Authority.Paper ||
-    status.authority.effective !== Authority.Paper ||
-    status.authority.kill !== KillState.Clear ||
-    status.reconciliation?.status !== ReconciliationStatus.Exact ||
-    status.reconciliation.discrepancyCount !== 0 ||
-    !status.reconciliation.coversLatestMutation ||
-    status.mutations.unresolvedCount !== 0 ||
-    lastPass?.result !== 'SUCCESS' ||
-    lastPass.outcome !== 'NOT_DUE' ||
-    lastPass.notDueReason !== CycleNotDueReason.StalePaperBootstrap ||
-    cadence?.signalSessionDate !== last.signalSessionDate ||
-    cadence.executionSessionDate !== last.executionSessionDate
-  ) {
-    return status
-  }
-  return {
-    ...status,
-    condition: CycleOperationsCondition.Waiting,
-    reason: CycleOperationsReason.StalePaperBootstrapSkipped,
-    alerts: { ...status.alerts, cycleFailed: false },
-  }
 }
 
 export type CycleOperationsStatusFailure = {

--- a/services/bayn/src/cycle-runner.test.ts
+++ b/services/bayn/src/cycle-runner.test.ts
@@ -48,7 +48,7 @@ import {
   type CycleRunContext,
   type CycleRunResult,
 } from './cycle-runner'
-import { CycleNotDueReconciliationError } from './cycle-runner/model'
+import { CycleNotDueReason, CycleNotDueReconciliationError } from './cycle-runner/model'
 import { completeCycleAuthoritySelection } from './cycle-runner/decisions'
 import { runAutonomousCycleUntilSettled } from './cycle-runner/program'
 import { selectBoundDecision } from './cycle-runner/recovery-decision-binding'
@@ -1090,6 +1090,7 @@ describe('autonomous cycle runner', () => {
     expect(selectCycleAuthoritySlots([{ publication, existing: undefined }])).toEqual({
       _tag: 'READ_CALENDAR',
       publications: [publication],
+      reason: 'DISCOVERY',
     })
     expect(
       selectCycleAuthoritySlots([
@@ -1099,6 +1100,7 @@ describe('autonomous cycle runner', () => {
     ).toEqual({
       _tag: 'READ_CALENDAR',
       publications: [publication, olderPublication],
+      reason: 'DISCOVERY',
     })
     for (const state of [CycleState.Completed, CycleState.NoTrade, CycleState.Blocked] as const) {
       const cycle = { ...terminal, state }
@@ -1109,35 +1111,51 @@ describe('autonomous cycle runner', () => {
     }
     expect(
       completeCycleAuthoritySelection(
-        { _tag: 'UNCLAIMED', publications: [publication], latestTerminal: terminal },
+        { _tag: 'UNCLAIMED', publications: [publication], latestTerminal: { publication, cycle: terminal } },
         'PAPER_BOOTSTRAP',
       ),
-    ).toEqual({ _tag: 'ALREADY_TERMINAL', cycle: terminal })
+    ).toEqual({
+      _tag: 'READ_CALENDAR',
+      publications: [publication],
+      reason: 'MISSED_PAPER_BOOTSTRAP',
+    })
     const noTrade = { ...terminal, state: CycleState.NoTrade }
     expect(
       completeCycleAuthoritySelection(
-        { _tag: 'UNCLAIMED', publications: [publication], latestTerminal: noTrade },
+        { _tag: 'UNCLAIMED', publications: [publication], latestTerminal: { publication, cycle: noTrade } },
         'PAPER_BOOTSTRAP',
       ),
-    ).toEqual({ _tag: 'READ_CALENDAR', publications: [publication] })
+    ).toEqual({ _tag: 'READ_CALENDAR', publications: [publication], reason: 'DISCOVERY' })
     const blocked = { ...terminal, state: CycleState.Blocked }
     expect(
       completeCycleAuthoritySelection(
-        { _tag: 'UNCLAIMED', publications: [publication], latestTerminal: blocked },
+        { _tag: 'UNCLAIMED', publications: [publication], latestTerminal: { publication, cycle: blocked } },
         'PAPER_BOOTSTRAP',
       ),
-    ).toEqual({ _tag: 'ALREADY_TERMINAL', cycle: blocked })
+    ).toEqual({
+      _tag: 'READ_CALENDAR',
+      publications: [publication],
+      reason: 'MISSED_PAPER_BOOTSTRAP',
+    })
     const newerPublication = finalizedPublicationInspection('2026-02-02')
     expect(
       completeCycleAuthoritySelection(
-        { _tag: 'UNCLAIMED', publications: [newerPublication, publication], latestTerminal: terminal },
+        {
+          _tag: 'UNCLAIMED',
+          publications: [newerPublication, publication],
+          latestTerminal: { publication, cycle: terminal },
+        },
         'PAPER_BOOTSTRAP',
       ),
-    ).toEqual({ _tag: 'READ_CALENDAR', publications: [newerPublication] })
+    ).toEqual({ _tag: 'READ_CALENDAR', publications: [newerPublication], reason: 'DISCOVERY' })
     const riskBlocked = { ...terminal, terminalReason: CycleTerminalReason.Risk }
     expect(
       completeCycleAuthoritySelection(
-        { _tag: 'UNCLAIMED', publications: [newerPublication], latestTerminal: riskBlocked },
+        {
+          _tag: 'UNCLAIMED',
+          publications: [newerPublication],
+          latestTerminal: { publication, cycle: riskBlocked },
+        },
         'PAPER_BOOTSTRAP',
       ),
     ).toEqual({ _tag: 'ALREADY_TERMINAL', cycle: riskBlocked })
@@ -1155,13 +1173,14 @@ describe('autonomous cycle runner', () => {
     ).toEqual({
       _tag: 'READ_CALENDAR',
       publications: [olderPublication],
+      reason: 'DISCOVERY',
     })
     expect(
       selectCycleAuthoritySlots([
         { publication, existing: undefined },
         { publication: olderPublication, existing: terminal },
       ]),
-    ).toEqual({ _tag: 'READ_CALENDAR', publications: [publication] })
+    ).toEqual({ _tag: 'READ_CALENDAR', publications: [publication], reason: 'DISCOVERY' })
     expect(selectCycleAuthoritySlots([{ publication, existing: pending }])).toEqual({
       _tag: 'RESUME',
       publication,
@@ -2493,7 +2512,7 @@ describe('autonomous cycle runner', () => {
     expect(control.binds).toBe(0)
   })
 
-  test('admits only a newer PAPER bootstrap publication after a missed publication deadline', async () => {
+  test('skips an expired PAPER bootstrap without persistence and admits only a newer publication', async () => {
     const control: StoreControl = { acquisitions: [], binds: 0 }
     const store = cycleStore(control)
     let calendarReads = 0
@@ -2529,12 +2548,10 @@ describe('autonomous cycle runner', () => {
     )
 
     expect(result.missed).toMatchObject({
-      outcome: 'ACQUIRED',
+      outcome: 'NOT_DUE',
+      reason: CycleNotDueReason.StalePaperBootstrap,
       signalSessionDate: '2026-01-29',
-      readiness: {
-        outcome: 'BLOCKED',
-        cycle: { state: CycleState.Blocked, terminalReason: CycleTerminalReason.MissedPublication },
-      },
+      executionSessionDate: '2026-01-30',
     })
     expect(result.successor).toMatchObject({
       outcome: 'ACQUIRED',
@@ -2546,8 +2563,63 @@ describe('autonomous cycle runner', () => {
       },
     })
     expect(calendarReads).toBe(2)
-    expect(control.acquisitions).toHaveLength(2)
+    expect(control.acquisitions).toHaveLength(1)
     expect(control.binds).toBe(1)
+  })
+
+  test('restarts a persisted missed PAPER bootstrap as an exact not-due wait without reacquisition', async () => {
+    const control: StoreControl = { acquisitions: [], binds: 0 }
+    const persistence = makeCycleStorePersistence()
+    const store = cycleStore(control, persistence)
+    const publication = finalizedPublicationInspection('2026-01-29', '2026-01-29T21:15:00.000Z')
+    const executionSession = selectNextExecutionSession(publication.signalSession.session_date, monthEndCalendar)
+    if (executionSession === undefined) throw new Error('bootstrap fixture requires an execution session')
+    const paperContext = { ...context(), cadence: 'PAPER_BOOTSTRAP' as const }
+    const draft = dueCycleDraftFixture(
+      { ...paperContext, signalSession: publication.signalSession },
+      monthEndCalendar,
+      executionSession,
+    )
+    const terminal = cycleFrom(draft, draft.window.publicationDeadlineAt)
+    persistence.cycles.set(terminal.identity.cycleId, terminal)
+    persistence.slots.set(
+      slotKey({
+        qualificationRunId: terminal.identity.qualificationRunId,
+        accountId: terminal.identity.accountId,
+        signalSessionDate: terminal.identity.signalSessionDate,
+      }),
+      terminal.identity.cycleId,
+    )
+    let calendarReads = 0
+    const read = brokerRead(() => {
+      calendarReads += 1
+      return Effect.succeed({ value: monthEndCalendar, evidence })
+    })
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        // A persisted terminal outcome remains authoritative even if the observed clock is before its deadline.
+        yield* TestClock.setTime(Date.parse('2026-01-30T13:00:00.000Z'))
+        return yield* provide(
+          runAutonomousCyclePass(paperContext),
+          read,
+          store,
+          marketDataService(Effect.succeed(finalizedPublications([publication]))),
+        )
+      }).pipe(Effect.provide(TestClock.layer())),
+    )
+
+    expect(result).toMatchObject({
+      outcome: 'NOT_DUE',
+      reason: CycleNotDueReason.StalePaperBootstrap,
+      signalSessionDate: '2026-01-29',
+      executionSessionDate: '2026-01-30',
+      observedAt: '2026-01-30T13:00:00.000Z',
+    })
+    expect(calendarReads).toBe(1)
+    expect(control.acquisitions).toHaveLength(0)
+    expect(control.binds).toBe(0)
+    expect(persistence.cycles.get(terminal.identity.cycleId)).toEqual(terminal)
   })
 
   test('reinspects and activates a bound cycle on restart before any new discovery', async () => {

--- a/services/bayn/src/cycle-runner.test.ts
+++ b/services/bayn/src/cycle-runner.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 
-import { Cause, Deferred, Effect, Fiber, Layer, Logger, Option, References, Result } from 'effect'
+import { Cause, Clock, Deferred, Effect, Fiber, Layer, Logger, Option, References, Result } from 'effect'
 import { TestClock } from 'effect/testing'
 
 import {
@@ -2565,6 +2565,44 @@ describe('autonomous cycle runner', () => {
     expect(calendarReads).toBe(2)
     expect(control.acquisitions).toHaveLength(1)
     expect(control.binds).toBe(1)
+  })
+
+  test('rechecks a PAPER bootstrap deadline immediately before acquisition without persisting the race loser', async () => {
+    const control: StoreControl = { acquisitions: [], binds: 0 }
+    const times = [
+      Date.parse('2026-02-02T13:57:59.998Z'),
+      Date.parse('2026-02-02T13:57:59.999Z'),
+      Date.parse('2026-02-02T13:58:00.000Z'),
+    ] as const
+    let clockReads = 0
+    const readTime = () => times[Math.min(clockReads++, times.length - 1)]
+    const currentTime = () => times[Math.min(clockReads, times.length - 1)]
+    const clock: Clock.Clock = {
+      currentTimeMillisUnsafe: readTime,
+      currentTimeMillis: Effect.sync(readTime),
+      currentTimeNanosUnsafe: () => BigInt(currentTime()) * 1_000_000n,
+      currentTimeNanos: Effect.sync(() => BigInt(currentTime()) * 1_000_000n),
+      sleep: () => Effect.void,
+    }
+
+    const result = await Effect.runPromise(
+      provide(
+        runAutonomousCyclePass({ ...context(), cadence: 'PAPER_BOOTSTRAP' }),
+        brokerRead(() => Effect.succeed({ value: monthEndCalendar, evidence })),
+        cycleStore(control),
+        marketDataService(Effect.succeed(finalizedPublication()), finalizedPublicationInspection()),
+      ).pipe(Effect.provideService(Clock.Clock, clock)),
+    )
+
+    expect(result).toMatchObject({
+      outcome: 'NOT_DUE',
+      reason: CycleNotDueReason.StalePaperBootstrap,
+      signalSessionDate: '2026-01-30',
+      executionSessionDate: '2026-02-02',
+      observedAt: '2026-02-02T13:58:00.000Z',
+    })
+    expect(control.acquisitions).toHaveLength(0)
+    expect(control.binds).toBe(0)
   })
 
   test('restarts a persisted missed PAPER bootstrap as an exact not-due wait without reacquisition', async () => {

--- a/services/bayn/src/cycle-runner/admission-decisions.ts
+++ b/services/bayn/src/cycle-runner/admission-decisions.ts
@@ -30,7 +30,7 @@ export interface CycleAcquireMaterial {
   readonly calendarReadContentHash: string
 }
 
-type CycleCalendarCandidateDecision =
+export type CycleCalendarCandidateDecision =
   | { readonly _tag: 'NOT_DUE'; readonly result: CycleNotDueResult }
   | { readonly _tag: 'ACQUIRE'; readonly material: CycleAcquireMaterial }
 
@@ -41,6 +41,25 @@ type CycleCalendarCandidateFailure =
       readonly signalSessionDate: string
       readonly cause: CycleConstructionFailure
     }
+
+const stalePaperBootstrapResult = (material: CycleAcquireMaterial, observedAt: string): CycleNotDueResult => ({
+  outcome: 'NOT_DUE',
+  reason: CycleNotDueReason.StalePaperBootstrap,
+  signalSessionDate: material.signalSessionDate,
+  executionSessionDate: material.executionSessionDate,
+  observedAt,
+  calendarResponseHash: material.calendarResponseHash,
+  calendarReadContentHash: material.calendarReadContentHash,
+})
+
+export const selectCycleAcquisition = (
+  cadence: CycleRunContext['cadence'],
+  material: CycleAcquireMaterial,
+  acquiredAt: string,
+): CycleCalendarCandidateDecision =>
+  cadence === 'PAPER_BOOTSTRAP' && acquiredAt >= material.draft.window.publicationDeadlineAt
+    ? { _tag: 'NOT_DUE', result: stalePaperBootstrapResult(material, acquiredAt) }
+    : { _tag: 'ACQUIRE', material }
 
 const selectCycleCalendarPublication = <R>(
   context: CycleRunContext<R>,
@@ -81,16 +100,11 @@ const selectCycleCalendarPublication = <R>(
           result: { outcome: 'NOT_DUE', reason: CycleNotDueReason.MonthEndCadence, observedAt, ...common },
         }
       }
-      if (
-        context.cadence === 'PAPER_BOOTSTRAP' &&
-        (knownMissedPaperBootstrap || observedAt >= draft.window.publicationDeadlineAt)
-      ) {
-        return {
-          _tag: 'NOT_DUE',
-          result: { outcome: 'NOT_DUE', reason: CycleNotDueReason.StalePaperBootstrap, observedAt, ...common },
-        }
+      const material = { publication, draft, ...common }
+      if (context.cadence === 'PAPER_BOOTSTRAP' && knownMissedPaperBootstrap) {
+        return { _tag: 'NOT_DUE', result: stalePaperBootstrapResult(material, observedAt) }
       }
-      return { _tag: 'ACQUIRE', material: { publication, draft, ...common } }
+      return selectCycleAcquisition(context.cadence, material, observedAt)
     },
   )
 }

--- a/services/bayn/src/cycle-runner/admission-decisions.ts
+++ b/services/bayn/src/cycle-runner/admission-decisions.ts
@@ -13,13 +13,12 @@ import {
 } from './calendar-decisions'
 import {
   runnerError,
+  CycleNotDueReason,
   type CycleCandidate,
   type CycleRunContext,
   type CycleRunnerError,
   type CycleRunResult,
 } from './model'
-import { Pipeable } from '../pipeable'
-
 type CycleNotDueResult = Extract<CycleRunResult, { readonly outcome: 'NOT_DUE' }>
 
 export interface CycleAcquireMaterial {
@@ -49,6 +48,7 @@ const selectCycleCalendarPublication = <R>(
   observation: MarketCalendarObservation,
   calendarReadContentHash: string,
   observedAt: string,
+  knownMissedPaperBootstrap: boolean,
 ): Result.Result<CycleCalendarCandidateDecision, CycleCalendarCandidateFailure> => {
   const candidate: CycleCandidate = {
     qualificationRunId: context.qualificationRunId,
@@ -74,10 +74,24 @@ const selectCycleCalendarPublication = <R>(
       makeDueCycleDraft(candidate, observation, executionSession),
       (cause): CycleCalendarCandidateFailure => ({ _tag: 'CycleDraftConstructionFailed', signalSessionDate, cause }),
     ),
-    (draft): CycleCalendarCandidateDecision =>
-      draft === undefined
-        ? { _tag: 'NOT_DUE', result: { outcome: 'NOT_DUE', observedAt, ...common } }
-        : { _tag: 'ACQUIRE', material: { publication, draft, ...common } },
+    (draft): CycleCalendarCandidateDecision => {
+      if (draft === undefined) {
+        return {
+          _tag: 'NOT_DUE',
+          result: { outcome: 'NOT_DUE', reason: CycleNotDueReason.MonthEndCadence, observedAt, ...common },
+        }
+      }
+      if (
+        context.cadence === 'PAPER_BOOTSTRAP' &&
+        (knownMissedPaperBootstrap || observedAt >= draft.window.publicationDeadlineAt)
+      ) {
+        return {
+          _tag: 'NOT_DUE',
+          result: { outcome: 'NOT_DUE', reason: CycleNotDueReason.StalePaperBootstrap, observedAt, ...common },
+        }
+      }
+      return { _tag: 'ACQUIRE', material: { publication, draft, ...common } }
+    },
   )
 }
 
@@ -87,6 +101,7 @@ const selectCycleCalendarCandidateDataFirst = <R>(
   observation: MarketCalendarObservation,
   calendarReadContentHash: string,
   observedAt: string,
+  knownMissedPaperBootstrap = false,
 ): Result.Result<CycleCalendarCandidateDecision, CycleCalendarCandidateFailure> => {
   const [first, ...remaining] = publications
   return remaining.reduce<Result.Result<CycleCalendarCandidateDecision, CycleCalendarCandidateFailure>>(
@@ -97,24 +112,30 @@ const selectCycleCalendarCandidateDataFirst = <R>(
           current._tag === 'ACQUIRE'
             ? Result.succeed(current)
             : pipe(
-                selectCycleCalendarPublication(context, publication, observation, calendarReadContentHash, observedAt),
+                selectCycleCalendarPublication(
+                  context,
+                  publication,
+                  observation,
+                  calendarReadContentHash,
+                  observedAt,
+                  knownMissedPaperBootstrap,
+                ),
                 Result.map((next) => (next._tag === 'ACQUIRE' ? next : current)),
               ),
         ),
       ),
-    selectCycleCalendarPublication(context, first, observation, calendarReadContentHash, observedAt),
+    selectCycleCalendarPublication(
+      context,
+      first,
+      observation,
+      calendarReadContentHash,
+      observedAt,
+      knownMissedPaperBootstrap,
+    ),
   )
 }
 
-export const selectCycleCalendarCandidate = Pipeable.generic<
-  <R>(
-    publications: NonEmptyPublications,
-    observation: MarketCalendarObservation,
-    calendarReadContentHash: string,
-    observedAt: string,
-  ) => (context: CycleRunContext<R>) => Result.Result<CycleCalendarCandidateDecision, CycleCalendarCandidateFailure>,
-  typeof selectCycleCalendarCandidateDataFirst
->(5, selectCycleCalendarCandidateDataFirst)
+export const selectCycleCalendarCandidate = selectCycleCalendarCandidateDataFirst
 
 export const publicationFailureError = (cause: CyclePublicationFailure): CycleRunnerError =>
   runnerError({

--- a/services/bayn/src/cycle-runner/authority-decisions.ts
+++ b/services/bayn/src/cycle-runner/authority-decisions.ts
@@ -16,18 +16,27 @@ export interface CycleAuthoritySlot {
 
 type NonEmptyAuthoritySlots = readonly [CycleAuthoritySlot, ...CycleAuthoritySlot[]]
 
+interface TerminalCycleAuthoritySlot {
+  readonly publication: MarketDataInspection
+  readonly cycle: AutonomousCycle
+}
+
 export type CycleAuthoritySelection =
   | Extract<CycleAuthoritySlotDecision, { readonly _tag: 'RESUME' | 'ALREADY_ACQUIRED' }>
-  | { readonly _tag: 'READ_CALENDAR'; readonly publications: NonEmptyPublications }
+  | {
+      readonly _tag: 'READ_CALENDAR'
+      readonly publications: NonEmptyPublications
+      readonly reason: 'DISCOVERY' | 'MISSED_PAPER_BOOTSTRAP'
+    }
   | { readonly _tag: 'ALREADY_TERMINAL'; readonly cycle: AutonomousCycle }
 
 export type CycleAuthoritySelectionState =
   | {
       readonly _tag: 'UNCLAIMED'
       readonly publications: NonEmptyPublications
-      readonly latestTerminal: AutonomousCycle | undefined
+      readonly latestTerminal: TerminalCycleAuthoritySlot | undefined
     }
-  | { readonly _tag: 'TERMINAL'; readonly latestTerminal: AutonomousCycle }
+  | { readonly _tag: 'TERMINAL'; readonly latestTerminal: TerminalCycleAuthoritySlot }
 
 type CycleAuthoritySelectionReduction =
   | { readonly _tag: 'CONTINUE'; readonly state: CycleAuthoritySelectionState }
@@ -53,7 +62,10 @@ export const beginCycleAuthoritySelection = (slot: CycleAuthoritySlot): CycleAut
         state: { _tag: 'UNCLAIMED', publications: [decision.publication], latestTerminal: undefined },
       }
     case 'TERMINAL':
-      return { _tag: 'CONTINUE', state: { _tag: 'TERMINAL', latestTerminal: decision.cycle } }
+      return {
+        _tag: 'CONTINUE',
+        state: { _tag: 'TERMINAL', latestTerminal: { publication: slot.publication, cycle: decision.cycle } },
+      }
     case 'RESUME':
     case 'ALREADY_ACQUIRED':
       return decision
@@ -79,7 +91,7 @@ const reduceCycleAuthoritySelectionDataFirst = (
         _tag: 'CONTINUE',
         state:
           state._tag === 'UNCLAIMED' && state.latestTerminal === undefined
-            ? { ...state, latestTerminal: decision.cycle }
+            ? { ...state, latestTerminal: { publication: slot.publication, cycle: decision.cycle } }
             : state,
       }
     case 'RESUME':
@@ -94,8 +106,17 @@ const completeCycleAuthoritySelectionDataFirst = (
   state: CycleAuthoritySelectionState,
   cadence?: 'MONTHLY' | 'PAPER_BOOTSTRAP',
 ): CycleAuthoritySelection => {
-  if (state._tag === 'TERMINAL') return { _tag: 'ALREADY_TERMINAL', cycle: state.latestTerminal }
-  const latestTerminal = state.latestTerminal
+  if (state._tag === 'TERMINAL') {
+    const cycle = state.latestTerminal.cycle
+    return cadence === 'PAPER_BOOTSTRAP' && cycle.terminalReason === CycleTerminalReason.MissedPublication
+      ? {
+          _tag: 'READ_CALENDAR',
+          publications: [state.latestTerminal.publication],
+          reason: 'MISSED_PAPER_BOOTSTRAP',
+        }
+      : { _tag: 'ALREADY_TERMINAL', cycle }
+  }
+  const latestTerminal = state.latestTerminal?.cycle
   if (cadence === 'PAPER_BOOTSTRAP' && latestTerminal !== undefined && latestTerminal.state !== CycleState.NoTrade) {
     const newerPublications = state.publications.filter(
       (publication) => publication.signalSession.session_date > latestTerminal.identity.signalSessionDate,
@@ -106,11 +127,26 @@ const completeCycleAuthoritySelectionDataFirst = (
       latestTerminal.terminalReason === CycleTerminalReason.MissedPublication &&
       firstNewerPublication !== undefined
     ) {
-      return { _tag: 'READ_CALENDAR', publications: [firstNewerPublication, ...remainingNewerPublications] }
+      return {
+        _tag: 'READ_CALENDAR',
+        publications: [firstNewerPublication, ...remainingNewerPublications],
+        reason: 'DISCOVERY',
+      }
+    }
+    if (
+      latestTerminal.state === CycleState.Blocked &&
+      latestTerminal.terminalReason === CycleTerminalReason.MissedPublication &&
+      state.latestTerminal !== undefined
+    ) {
+      return {
+        _tag: 'READ_CALENDAR',
+        publications: [state.latestTerminal.publication],
+        reason: 'MISSED_PAPER_BOOTSTRAP',
+      }
     }
     return { _tag: 'ALREADY_TERMINAL', cycle: latestTerminal }
   }
-  return { _tag: 'READ_CALENDAR', publications: state.publications }
+  return { _tag: 'READ_CALENDAR', publications: state.publications, reason: 'DISCOVERY' }
 }
 
 export const completeCycleAuthoritySelection = Pipeable.by<

--- a/services/bayn/src/cycle-runner/decisions.ts
+++ b/services/bayn/src/cycle-runner/decisions.ts
@@ -21,6 +21,7 @@ export {
   calendarCandidateFailureError,
   calendarQueryFailureError,
   publicationFailureError,
+  selectCycleAcquisition,
   selectCycleCalendarCandidate,
   selectDiscoveredPublications,
   type CycleAcquireMaterial,

--- a/services/bayn/src/cycle-runner/model.ts
+++ b/services/bayn/src/cycle-runner/model.ts
@@ -41,6 +41,11 @@ export interface CycleCandidate {
   readonly executionPolicy: CycleExecutionPolicy
 }
 
+export enum CycleNotDueReason {
+  MonthEndCadence = 'MONTH_END_CADENCE',
+  StalePaperBootstrap = 'STALE_PAPER_BOOTSTRAP',
+}
+
 export type CycleBindingResult = Exclude<CyclePublicationReadiness, { readonly outcome: 'WAITING' }>
 
 export type CycleRunResult =
@@ -81,6 +86,8 @@ export type CycleRunResult =
     }
   | {
       readonly outcome: 'NOT_DUE'
+      /** Optional only for compatibility with lifecycle observations persisted before reasons were recorded. */
+      readonly reason?: CycleNotDueReason
       readonly signalSessionDate: string
       readonly executionSessionDate: string
       readonly observedAt: string

--- a/services/bayn/src/cycle-runner/pass-decisions.ts
+++ b/services/bayn/src/cycle-runner/pass-decisions.ts
@@ -4,7 +4,13 @@ import { decideMonthEndCadenceEligibility, type MonthEndCadenceDecision } from '
 import { CycleState, type AutonomousCycle } from '../cycle'
 import type { CycleReadinessError } from '../cycle-readiness'
 import type { CycleRecoverySelection } from '../cycle-recovery'
-import { runnerError, type CyclePassObservation, type CycleRunnerError, type CycleRunResult } from './model'
+import {
+  runnerError,
+  type CycleNotDueReason,
+  type CyclePassObservation,
+  type CycleRunnerError,
+  type CycleRunResult,
+} from './model'
 import { Pipeable } from '../pipeable'
 
 export const readinessFailure = (cause: CycleReadinessError): CycleRunnerError['failure'] => {
@@ -83,6 +89,7 @@ export type RetainedAutonomousCyclePassObservation =
       readonly result: 'SUCCESS'
       readonly observedAt: string
       readonly outcome: CycleRunResult['outcome']
+      readonly notDueReason?: CycleNotDueReason
       readonly cadenceDecision?: MonthEndCadenceDecision
     }
   | {
@@ -110,6 +117,9 @@ export const retainAutonomousCyclePassObservation = (
     result: 'SUCCESS',
     observedAt: observation.observedAt,
     outcome: observation.result.outcome,
+    ...(observation.result.outcome === 'NOT_DUE' && observation.result.reason !== undefined
+      ? { notDueReason: observation.result.reason }
+      : {}),
     ...(cadenceDecision === undefined ? {} : { cadenceDecision }),
   }
 }
@@ -201,6 +211,7 @@ export const cyclePassLogFacts = (observation: CyclePassObservation): CyclePassL
         message: 'Bayn autonomous cycle pass completed',
         annotations: {
           outcome: result.outcome,
+          ...(result.reason === undefined ? {} : { notDueReason: result.reason }),
           signalSessionDate: result.signalSessionDate,
           executionSessionDate: result.executionSessionDate,
           observedAt: result.observedAt,

--- a/services/bayn/src/cycle-runner/program.ts
+++ b/services/bayn/src/cycle-runner/program.ts
@@ -206,9 +206,17 @@ const interpretCycleCalendar = <R>(
   observation: MarketCalendarObservation,
   calendarReadContentHash: string,
   observedAt: string,
+  knownMissedPaperBootstrap: boolean,
 ): Effect.Effect<CycleRunResult, CycleRunnerError, CycleStore> =>
   Effect.fromResult(
-    selectCycleCalendarCandidate(context, publications, observation, calendarReadContentHash, observedAt),
+    selectCycleCalendarCandidate(
+      context,
+      publications,
+      observation,
+      calendarReadContentHash,
+      observedAt,
+      knownMissedPaperBootstrap,
+    ),
   ).pipe(
     Effect.mapError(calendarCandidateFailureError),
     Effect.flatMap((decision) =>
@@ -218,10 +226,10 @@ const interpretCycleCalendar = <R>(
 
 const readCycleCalendar = <R>(
   context: CycleRunContext<R>,
-  publications: NonEmptyPublications,
+  selection: Extract<CycleAuthoritySelection, { readonly _tag: 'READ_CALENDAR' }>,
 ): Effect.Effect<CycleRunResult, CycleRunnerError, BrokerRead | CycleStore> =>
   pipe(
-    marketCalendarQueryForPublications(publications),
+    marketCalendarQueryForPublications(selection.publications),
     Effect.fromResult,
     Effect.mapError(calendarQueryFailureError),
     Effect.flatMap((query) =>
@@ -242,7 +250,14 @@ const readCycleCalendar = <R>(
       pipe(
         currentIsoTime,
         Effect.flatMap((observedAt) =>
-          interpretCycleCalendar(context, publications, calendar.value, calendar.evidence.contentHash, observedAt),
+          interpretCycleCalendar(
+            context,
+            selection.publications,
+            calendar.value,
+            calendar.evidence.contentHash,
+            observedAt,
+            selection.reason === 'MISSED_PAPER_BOOTSTRAP',
+          ),
         ),
       ),
     ),
@@ -271,7 +286,7 @@ const interpretCycleAuthoritySelection = <R>(
         cycle: selection.cycle,
       })
     case 'READ_CALENDAR':
-      return readCycleCalendar(context, selection.publications)
+      return readCycleCalendar(context, selection)
   }
 }
 

--- a/services/bayn/src/cycle-runner/program.ts
+++ b/services/bayn/src/cycle-runner/program.ts
@@ -21,6 +21,7 @@ import {
   marketCalendarQueryForPublications,
   readinessFailure,
   reduceCycleAuthoritySelection,
+  selectCycleAcquisition,
   selectCycleCalendarCandidate,
   selectCyclePassContinuation,
   selectDiscoveredPublications,
@@ -154,6 +155,7 @@ const resumeDiscoveredPublication = (
   )
 
 const acquireCycleCandidate = (
+  cadence: CycleRunContext['cadence'],
   material: CycleAcquireMaterial,
 ): Effect.Effect<CycleRunResult, CycleRunnerError, CycleStore> =>
   pipe(
@@ -161,9 +163,11 @@ const acquireCycleCandidate = (
     Effect.flatMap((store) =>
       pipe(
         currentIsoTime,
-        Effect.flatMap((acquiredAt) =>
-          pipe(
-            store.acquire(material.draft, acquiredAt),
+        Effect.flatMap((acquiredAt) => {
+          const admission = selectCycleAcquisition(cadence, material, acquiredAt)
+          if (admission._tag === 'NOT_DUE') return Effect.succeed(admission.result)
+          return pipe(
+            store.acquire(admission.material.draft, acquiredAt),
             Effect.mapError((cause) =>
               runnerError({
                 operation: 'acquire-cycle',
@@ -172,30 +176,30 @@ const acquireCycleCandidate = (
                 cause,
               }),
             ),
-          ),
-        ),
-        Effect.flatMap((receipt) =>
-          pipe(
-            currentIsoTime,
-            Effect.flatMap((bindingObservedAt) =>
+            Effect.flatMap((receipt) =>
               pipe(
-                bindDiscoveredPublication(receipt.cycle, material.publication, bindingObservedAt),
-                Effect.map(
-                  (readiness): CycleRunResult => ({
-                    outcome: receipt.created ? 'ACQUIRED' : 'REACQUIRED',
-                    signalSessionDate: material.signalSessionDate,
-                    executionSessionDate: material.executionSessionDate,
-                    observedAt: bindingObservedAt,
-                    calendarResponseHash: material.calendarResponseHash,
-                    calendarReadContentHash: material.calendarReadContentHash,
-                    receipt,
-                    readiness,
-                  }),
+                currentIsoTime,
+                Effect.flatMap((bindingObservedAt) =>
+                  pipe(
+                    bindDiscoveredPublication(receipt.cycle, material.publication, bindingObservedAt),
+                    Effect.map(
+                      (readiness): CycleRunResult => ({
+                        outcome: receipt.created ? 'ACQUIRED' : 'REACQUIRED',
+                        signalSessionDate: material.signalSessionDate,
+                        executionSessionDate: material.executionSessionDate,
+                        observedAt: bindingObservedAt,
+                        calendarResponseHash: material.calendarResponseHash,
+                        calendarReadContentHash: material.calendarReadContentHash,
+                        receipt,
+                        readiness,
+                      }),
+                    ),
+                  ),
                 ),
               ),
             ),
-          ),
-        ),
+          )
+        }),
       ),
     ),
   )
@@ -220,7 +224,9 @@ const interpretCycleCalendar = <R>(
   ).pipe(
     Effect.mapError(calendarCandidateFailureError),
     Effect.flatMap((decision) =>
-      decision._tag === 'NOT_DUE' ? Effect.succeed(decision.result) : acquireCycleCandidate(decision.material),
+      decision._tag === 'NOT_DUE'
+        ? Effect.succeed(decision.result)
+        : acquireCycleCandidate(context.cadence, decision.material),
     ),
   )
 

--- a/services/bayn/src/db/cycle-store/integration.test.ts
+++ b/services/bayn/src/db/cycle-store/integration.test.ts
@@ -48,6 +48,8 @@ import {
   type CycleRunContext,
   type CycleRunResult,
 } from '../../cycle-runner'
+import { CycleNotDueReason } from '../../cycle-runner/model'
+import { decideMonthEndCadenceEligibility } from '../../cycle-observability'
 import { runAutonomousCycleUntilSettled } from '../../cycle-runner/program'
 import { AuthorityGenerationStore, ExecutionStoreLive } from '../execution-store'
 import { LifecycleCommandStore } from '../lifecycle-command'
@@ -4939,7 +4941,39 @@ describePostgres('PostgreSQL autonomous cycle store', () => {
           const conflicting = yield* Effect.exit(
             fence.transaction(store.begin({ ...command, commandId: lifecycleCommandId('primary', 3), sequence: 3 })),
           )
-          return { recoveredCursor, resumed, completed, replay, nextCursor, conflicting }
+          const secondCommand = {
+            controllerKey: 'primary',
+            commandId: lifecycleCommandId('primary', 2),
+            sequence: 2,
+            issuedAt: new Date(Date.parse(issuedAt) + 1).toISOString(),
+          }
+          const secondBegin = yield* fence.transaction(store.begin(secondCommand))
+          const secondCompletedAt = new Date().toISOString()
+          const secondObservation = {
+            result: 'SUCCESS' as const,
+            outcome: 'NOT_DUE' as const,
+            observedAt: secondCompletedAt,
+            notDueReason: CycleNotDueReason.StalePaperBootstrap,
+            cadenceDecision: decideMonthEndCadenceEligibility({
+              signalSessionDate: '2026-08-10',
+              executionSessionDate: '2026-08-11',
+            }),
+          }
+          const secondCompleted = yield* fence.transaction(
+            store.complete({ ...secondCommand, completedAt: secondCompletedAt, observation: secondObservation }),
+          )
+          const secondReplay = yield* fence.transaction(store.begin(secondCommand))
+          return {
+            recoveredCursor,
+            resumed,
+            completed,
+            replay,
+            nextCursor,
+            conflicting,
+            secondBegin,
+            secondCompleted,
+            secondReplay,
+          }
         }),
       )
 
@@ -4949,6 +4983,24 @@ describePostgres('PostgreSQL autonomous cycle store', () => {
         completed: { result: 'SUCCESS', outcome: 'NOT_DUE' },
         replay: { _tag: 'Completed', observation: { result: 'SUCCESS', outcome: 'NOT_DUE' } },
         nextCursor: { _tag: 'Next', sequence: 2 },
+        secondBegin: { _tag: 'Execute' },
+        secondCompleted: {
+          result: 'SUCCESS',
+          outcome: 'NOT_DUE',
+          notDueReason: CycleNotDueReason.StalePaperBootstrap,
+          cadenceDecision: {
+            signalSessionDate: '2026-08-10',
+            executionSessionDate: '2026-08-11',
+          },
+        },
+        secondReplay: {
+          _tag: 'Completed',
+          observation: {
+            result: 'SUCCESS',
+            outcome: 'NOT_DUE',
+            notDueReason: CycleNotDueReason.StalePaperBootstrap,
+          },
+        },
       })
       expect(Exit.isFailure(recovered.conflicting)).toBe(true)
     } finally {

--- a/services/bayn/src/db/evidence-store.integration.test.ts
+++ b/services/bayn/src/db/evidence-store.integration.test.ts
@@ -1219,6 +1219,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
       { migration_id: 30, name: 'clear_unused_research_paper_rearm' },
       { migration_id: 31, name: 'blocked_paper_generation_rollover' },
       { migration_id: 32, name: 'lifecycle_commands' },
+      { migration_id: 33, name: 'lifecycle_command_not_due_reason' },
     ])
   })
 

--- a/services/bayn/src/db/lifecycle-command-postgres.ts
+++ b/services/bayn/src/db/lifecycle-command-postgres.ts
@@ -8,6 +8,7 @@ import {
   MonthEndCadenceDecisionSchema,
   type AutonomousCyclePassObservation,
 } from '../runtime-state'
+import { CycleNotDueReason } from '../cycle-runner/model'
 import {
   LifecycleCommandStore,
   LifecycleCommandStoreError,
@@ -45,6 +46,7 @@ const CommandRow = Schema.Struct({
   message: Schema.NullOr(Schema.NonEmptyString),
   observed_at: Schema.NullOr(UtcInstantSchema),
   cadence_decision: Schema.NullOr(MonthEndCadenceDecisionSchema),
+  not_due_reason: Schema.NullOr(Schema.Enum(CycleNotDueReason)),
 })
 
 const CommandRows = Schema.Tuple([CommandRow])
@@ -81,6 +83,7 @@ const decodeObservation = (
       outcome: row.outcome,
       observedAt: row.observed_at,
       ...(row.cadence_decision === null ? {} : { cadenceDecision: row.cadence_decision }),
+      ...(row.not_due_reason === null ? {} : { notDueReason: row.not_due_reason }),
     }).pipe(Effect.mapError((cause) => storeError('decode', 'lifecycle command observation failed decoding', cause)))
   }
   if (
@@ -128,7 +131,8 @@ const readCursor = (
                  WHEN observed_at IS NULL THEN NULL
                  ELSE to_char(observed_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
                END AS observed_at,
-               cadence_decision
+               cadence_decision,
+               not_due_reason
         FROM lifecycle_commands
         WHERE controller_key = ${validatedControllerKey}
         ORDER BY sequence DESC
@@ -190,7 +194,8 @@ const begin = (sql: PgClient.PgClient, candidate: LifecycleCommandInput) =>
                    WHEN observed_at IS NULL THEN NULL
                    ELSE to_char(observed_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
                  END AS observed_at,
-                 cadence_decision
+                 cadence_decision,
+                 not_due_reason
           FROM lifecycle_commands
           WHERE controller_key = ${input.controllerKey}
             AND command_id = ${input.commandId}
@@ -241,6 +246,7 @@ const complete = (sql: PgClient.PgClient, candidate: LifecycleCommandCompletionI
           message = ${success ? null : input.observation.message},
           observed_at = ${input.observation.observedAt},
           cadence_decision = ${success ? (input.observation.cadenceDecision ?? null) : null},
+          not_due_reason = ${success && input.observation.outcome === 'NOT_DUE' ? (input.observation.notDueReason ?? null) : null},
           completed_at = greatest(${input.completedAt}, started_at)
         WHERE controller_key = ${input.controllerKey}
           AND command_id = ${input.commandId}
@@ -261,7 +267,8 @@ const complete = (sql: PgClient.PgClient, candidate: LifecycleCommandCompletionI
             WHEN observed_at IS NULL THEN NULL
             ELSE to_char(observed_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')
           END AS observed_at,
-          cadence_decision
+          cadence_decision,
+          not_due_reason
       `.pipe(
         Effect.flatMap(Schema.decodeUnknownEffect(CommandRows, strictParseOptions)),
         Effect.flatMap(([row]) => decodeObservation(row)),

--- a/services/bayn/src/db/migrations.ts
+++ b/services/bayn/src/db/migrations.ts
@@ -32,6 +32,7 @@ import unusedResearchPaperRearm from '../../migrations/0029_unused_research_pape
 import clearUnusedResearchPaperRearm from '../../migrations/0030_clear_unused_research_paper_rearm'
 import blockedPaperGenerationRollover from '../../migrations/0031_blocked_paper_generation_rollover'
 import lifecycleCommands from '../../migrations/0032_lifecycle_commands'
+import lifecycleCommandNotDueReason from '../../migrations/0033_lifecycle_command_not_due_reason'
 
 export const migrationLoader = PgMigrator.fromRecord({
   '1_initial_schema': initialSchema,
@@ -66,4 +67,5 @@ export const migrationLoader = PgMigrator.fromRecord({
   '30_clear_unused_research_paper_rearm': clearUnusedResearchPaperRearm,
   '31_blocked_paper_generation_rollover': blockedPaperGenerationRollover,
   '32_lifecycle_commands': lifecycleCommands,
+  '33_lifecycle_command_not_due_reason': lifecycleCommandNotDueReason,
 })

--- a/services/bayn/src/health.test.ts
+++ b/services/bayn/src/health.test.ts
@@ -20,8 +20,14 @@ import {
   type ReadResult,
 } from './broker/alpaca'
 import { BrokerEnvironment, makeBrokerIdentity } from './broker/identity'
-import { CycleOperationsCondition, CycleOperationsReason, type CycleOperationsProjection } from './cycle-observability'
+import {
+  CycleOperationsCondition,
+  CycleOperationsReason,
+  decideMonthEndCadenceEligibility,
+  type CycleOperationsProjection,
+} from './cycle-observability'
 import { CycleState, CycleTerminalReason } from './cycle'
+import { CycleNotDueReason } from './cycle-runner/model'
 import { currentUtcInstant } from './time'
 import { CycleObservability, type CycleObservabilityShape } from './db/cycle-observability'
 import { DatabaseError, EvidenceStore } from './db/evidence-store'
@@ -855,6 +861,96 @@ describe('Bayn continuous health', () => {
 
     expect(transition.next.cycle.reason).not.toBe(CycleOperationsReason.AuthorityMaximumMismatch)
     expect(transition.next.cycle.alerts.authorityIncoherent).toBe(false)
+  })
+
+  test('recovers readiness after an exact stale research bootstrap wait and preserves immutable failure evidence', () => {
+    const checkedAt = '2026-08-11T17:30:00.000Z'
+    const terminalAt = '2026-08-11T17:12:00.000Z'
+    const generationHash = 'b'.repeat(64)
+    const current: RuntimeState = {
+      ...readyState(),
+      autonomousCycleLoop: {
+        configured: true,
+        startedAt: terminalAt,
+        lastPass: {
+          result: 'SUCCESS',
+          observedAt: checkedAt,
+          outcome: 'NOT_DUE',
+          notDueReason: CycleNotDueReason.StalePaperBootstrap,
+          cadenceDecision: decideMonthEndCadenceEligibility({
+            signalSessionDate: '2026-08-10',
+            executionSessionDate: '2026-08-11',
+          }),
+        },
+      },
+      paperActivation: {
+        _tag: 'Realized',
+        requestHash: 'a'.repeat(64),
+        generationHash,
+        grant: 'Research',
+        cutoffAt: '2026-09-01T13:30:00.000Z',
+        expiresAt: '2026-09-03T20:00:00.000Z',
+        maximumCloseSessions: 3,
+      },
+    }
+    const transition = deriveHealthTransition(current, {
+      config,
+      evidenceAvailable: true,
+      results: {
+        postgresql: { _tag: 'Available', value: undefined },
+        signal: { _tag: 'Available', value: undefined },
+        tigerBeetle: { _tag: 'Available', value: undefined },
+        durableEvidence: { _tag: 'Available', value: undefined },
+        cycle: {
+          _tag: 'Available',
+          value: {
+            ...emptyCycleProjection(),
+            last: {
+              ...pendingCycle(terminalAt),
+              signalSessionDate: '2026-08-10',
+              executionSessionDate: '2026-08-11',
+              phase: CycleState.Blocked,
+              snapshotId: null,
+              terminalReason: CycleTerminalReason.MissedPublication,
+              terminalAt,
+            },
+            authority: {
+              generationHash,
+              maximum: Authority.Paper,
+              effective: Authority.Paper,
+              kill: KillState.Clear,
+              reason: null,
+              updatedAt: checkedAt,
+            },
+            reconciliation: {
+              accountId: brokerAccountId,
+              reconciliationId: 'c'.repeat(64),
+              status: ReconciliationStatus.Exact,
+              discrepancyCount: 0,
+              reconciledAt: checkedAt,
+              coversLatestMutation: true,
+            },
+          },
+        },
+        broker: null,
+      },
+      broker: undefined,
+      cycleFiber: { _tag: 'Running' },
+      clock: availableClock(checkedAt),
+    })
+
+    expect(transition).toMatchObject({
+      next: {
+        status: 'READY',
+        cycle: {
+          condition: CycleOperationsCondition.Waiting,
+          reason: CycleOperationsReason.StalePaperBootstrapSkipped,
+          last: { phase: CycleState.Blocked, terminalReason: CycleTerminalReason.MissedPublication },
+          alerts: { cycleFailed: false, reconciliationBlocked: false },
+        },
+      },
+      failedDependencies: [],
+    })
   })
 
   test('observes a research cycle binding when startup evidence is unavailable', async () => {

--- a/services/bayn/src/health/decisions.ts
+++ b/services/bayn/src/health/decisions.ts
@@ -5,14 +5,16 @@ import { historicalSandboxAuthority } from '../execution/legacy-authority'
 import type { FinalizedSnapshotProvenance } from '../contracts'
 import {
   CycleOperationsCondition,
+  CycleOperationsReason,
   deriveCycleOperationsStatusResult,
-  projectResearchPaperBootstrapWaiting,
   renderCycleOperationsStatusFailure,
   type CycleOperationsProjection,
   type CycleOperationsStatus,
   unknownCycleOperationsStatus,
 } from '../cycle-observability'
-import { Authority } from '../execution/contracts'
+import { CycleState, CycleTerminalReason } from '../cycle'
+import { CycleNotDueReason, type CycleRunResult } from '../cycle-runner/model'
+import { Authority, KillState, ReconciliationStatus } from '../execution/contracts'
 import type { QualificationRecord, RecoveredEvaluationEvidence } from '../db/evidence-store'
 import { canonicalHashV1Result, renderCanonicalJsonFailure } from '../hash'
 import type {
@@ -39,6 +41,58 @@ import type {
   SignalIdentityFailure,
 } from './model'
 import { Pipeable } from '../pipeable'
+
+export interface ResearchPaperBootstrapPassObservation {
+  readonly result: 'SUCCESS' | 'FAILURE'
+  readonly outcome?: CycleRunResult['outcome']
+  readonly notDueReason?: CycleNotDueReason
+  readonly cadenceDecision?: {
+    readonly signalSessionDate: string | null
+    readonly executionSessionDate: string | null
+  }
+}
+
+/**
+ * A research activation that starts after its first publication deadline must wait for a newer publication. The
+ * immutable missed cycle remains visible, but it is no longer an operational failure after a matching NOT_DUE pass
+ * and fresh exact reconciliation prove that no mutation is pending. Every other blocked-cycle state remains failed.
+ */
+export const projectResearchPaperBootstrapWaiting = (
+  status: CycleOperationsStatus,
+  enabled: boolean,
+  lastPass: ResearchPaperBootstrapPassObservation | null,
+): CycleOperationsStatus => {
+  const last = status.last
+  const cadence = lastPass?.cadenceDecision
+  if (
+    !enabled ||
+    status.condition !== CycleOperationsCondition.Failed ||
+    status.reason !== CycleOperationsReason.LastCycleBlocked ||
+    status.current !== null ||
+    last?.phase !== CycleState.Blocked ||
+    last.terminalReason !== CycleTerminalReason.MissedPublication ||
+    status.authority?.maximum !== Authority.Paper ||
+    status.authority.effective !== Authority.Paper ||
+    status.authority.kill !== KillState.Clear ||
+    status.reconciliation?.status !== ReconciliationStatus.Exact ||
+    status.reconciliation.discrepancyCount !== 0 ||
+    !status.reconciliation.coversLatestMutation ||
+    status.mutations.unresolvedCount !== 0 ||
+    lastPass?.result !== 'SUCCESS' ||
+    lastPass.outcome !== 'NOT_DUE' ||
+    lastPass.notDueReason !== CycleNotDueReason.StalePaperBootstrap ||
+    cadence?.signalSessionDate !== last.signalSessionDate ||
+    cadence.executionSessionDate !== last.executionSessionDate
+  ) {
+    return status
+  }
+  return {
+    ...status,
+    condition: CycleOperationsCondition.Waiting,
+    reason: CycleOperationsReason.StalePaperBootstrapSkipped,
+    alerts: { ...status.alerts, cycleFailed: false },
+  }
+}
 
 const validateSignalIdentityDataFirst = (
   snapshot: FinalizedSnapshotProvenance,

--- a/services/bayn/src/health/decisions.ts
+++ b/services/bayn/src/health/decisions.ts
@@ -52,6 +52,18 @@ export interface ResearchPaperBootstrapPassObservation {
   }
 }
 
+const observesMissedOrNewerBootstrap = (
+  last: NonNullable<CycleOperationsStatus['last']>,
+  cadence: NonNullable<ResearchPaperBootstrapPassObservation['cadenceDecision']> | undefined,
+): boolean => {
+  if (cadence === undefined || cadence.signalSessionDate === null || cadence.executionSessionDate === null) return false
+  const exact =
+    cadence.signalSessionDate === last.signalSessionDate && cadence.executionSessionDate === last.executionSessionDate
+  const newer =
+    cadence.signalSessionDate > last.signalSessionDate && cadence.executionSessionDate > last.executionSessionDate
+  return exact || newer
+}
+
 /**
  * A research activation that starts after its first publication deadline must wait for a newer publication. The
  * immutable missed cycle remains visible, but it is no longer an operational failure after a matching NOT_DUE pass
@@ -81,8 +93,7 @@ export const projectResearchPaperBootstrapWaiting = (
     lastPass?.result !== 'SUCCESS' ||
     lastPass.outcome !== 'NOT_DUE' ||
     lastPass.notDueReason !== CycleNotDueReason.StalePaperBootstrap ||
-    cadence?.signalSessionDate !== last.signalSessionDate ||
-    cadence.executionSessionDate !== last.executionSessionDate
+    !observesMissedOrNewerBootstrap(last, cadence)
   ) {
     return status
   }

--- a/services/bayn/src/health/decisions.ts
+++ b/services/bayn/src/health/decisions.ts
@@ -6,6 +6,7 @@ import type { FinalizedSnapshotProvenance } from '../contracts'
 import {
   CycleOperationsCondition,
   deriveCycleOperationsStatusResult,
+  projectResearchPaperBootstrapWaiting,
   renderCycleOperationsStatusFailure,
   type CycleOperationsProjection,
   type CycleOperationsStatus,
@@ -290,7 +291,12 @@ const deriveCycleStatus = (
           ...unknownCycleOperationsStatus(renderCycleOperationsStatusFailure(failure)),
           checkedAt: null,
         }),
-        onSuccess: (status) => status,
+        onSuccess: (status) =>
+          projectResearchPaperBootstrapWaiting(
+            status,
+            runtime.paperActivation?._tag === 'Realized' && runtime.paperActivation.grant === 'Research',
+            runtime.autonomousCycleLoop.lastPass,
+          ),
       },
     )
   }

--- a/services/bayn/src/http.test.ts
+++ b/services/bayn/src/http.test.ts
@@ -28,7 +28,7 @@ import {
   MonthEndCadenceReason,
 } from './cycle-observability'
 import { CycleState, CycleTerminalReason, type AutonomousCycle } from './cycle'
-import type { CyclePassObservation, CycleRunResult } from './cycle-runner/model'
+import { CycleNotDueReason, type CyclePassObservation, type CycleRunResult } from './cycle-runner/model'
 import { retainAutonomousCyclePassObservation } from './cycle-runner/pass-decisions'
 import { DatabaseError, type EvidenceStoreService } from './db/evidence-store'
 import type { BrokerProbe } from './health'
@@ -1478,6 +1478,93 @@ describe('Bayn HTTP probes', () => {
     expect(metrics).toContain('bayn_cycle_reason{reason="last_cycle_blocked"} 1')
     expect(metrics).toContain('bayn_cycle_terminal_reason{reason="blocked_provenance_mismatch"} 1')
     expect(metrics).toContain('bayn_cycle_terminal_reason{reason="blocked_data_stale"} 0')
+  })
+
+  test('exposes the reconciled stale research bootstrap wait in status and metrics', () => {
+    const base = readyState()
+    const checkedAt = '2026-08-11T17:30:00.000Z'
+    const generationHash = '4'.repeat(64)
+    const state: RuntimeState = {
+      ...base,
+      cycle: {
+        ...base.cycle,
+        last: {
+          cycleId: '1'.repeat(64),
+          accountId: 'paper-account-1',
+          signalSessionDate: '2026-08-10',
+          executionSessionDate: '2026-08-11',
+          phase: CycleState.Blocked,
+          snapshotId: null,
+          decisionHash: null,
+          terminalReason: CycleTerminalReason.MissedPublication,
+          submissionOpenAt: '2026-08-11T13:30:00.000Z',
+          submissionCutoffAt: '2026-08-11T13:58:00.000Z',
+          executionOpenAt: '2026-08-11T14:30:00.000Z',
+          executionCloseAt: '2026-08-11T21:00:00.000Z',
+          createdAt: '2026-08-11T17:12:00.000Z',
+          updatedAt: '2026-08-11T17:12:00.000Z',
+          terminalAt: '2026-08-11T17:12:00.000Z',
+        },
+        authority: {
+          generationHash,
+          maximum: Authority.Paper,
+          effective: Authority.Paper,
+          kill: KillState.Clear,
+          reason: null,
+          updatedAt: checkedAt,
+        },
+        reconciliation: {
+          accountId: 'paper-account-1',
+          reconciliationId: '5'.repeat(64),
+          status: ReconciliationStatus.Exact,
+          discrepancyCount: 0,
+          reconciledAt: checkedAt,
+          coversLatestMutation: true,
+        },
+        condition: CycleOperationsCondition.Waiting,
+        reason: CycleOperationsReason.StalePaperBootstrapSkipped,
+        alerts: { ...base.cycle.alerts, cycleFailed: false, reconciliationBlocked: false },
+      },
+      autonomousCycleLoop: {
+        configured: true,
+        owner: 'Restate',
+        startedAt: checkedAt,
+        lastPass: {
+          result: 'SUCCESS',
+          observedAt: checkedAt,
+          outcome: 'NOT_DUE',
+          notDueReason: CycleNotDueReason.StalePaperBootstrap,
+        },
+      },
+      paperActivation: {
+        _tag: 'Realized',
+        requestHash: '6'.repeat(64),
+        generationHash,
+        grant: 'Research',
+        cutoffAt: '2026-09-01T13:30:00.000Z',
+        expiresAt: '2026-09-03T20:00:00.000Z',
+        maximumCloseSessions: 3,
+      },
+    }
+
+    const facts = statusFacts(state, readOnlyExecution, provenance, 'embedded')
+    const metrics = renderPrometheusMetrics(state, config, provenance, 'embedded')
+
+    expect(facts.cycle).toMatchObject({
+      condition: CycleOperationsCondition.Waiting,
+      reason: CycleOperationsReason.StalePaperBootstrapSkipped,
+      last: { terminalReason: CycleTerminalReason.MissedPublication },
+    })
+    expect(facts.autonomousCycleLoop.lastPass).toMatchObject({
+      result: 'SUCCESS',
+      outcome: 'NOT_DUE',
+      notDueReason: CycleNotDueReason.StalePaperBootstrap,
+    })
+    expect(metrics).toContain('bayn_cycle_condition{condition="waiting"} 1')
+    expect(metrics).toContain('bayn_cycle_reason{reason="stale_paper_bootstrap_skipped"} 1')
+    expect(metrics).toContain('bayn_cycle_terminal_reason{reason="blocked_missed_publication_deadline"} 1')
+    expect(metrics).toContain('bayn_autonomous_cycle_loop_last_pass{result="success"} 1')
+    expect(metrics).toContain('bayn_autonomous_cycle_not_due_reason{reason="stale_paper_bootstrap"} 1')
   })
 
   test('propagates interruption and finalizes a historical read exactly once', async () => {

--- a/services/bayn/src/http.ts
+++ b/services/bayn/src/http.ts
@@ -16,6 +16,7 @@ import {
   type AutonomousCycleCadenceFreshness,
 } from './cycle-observability'
 import { CycleState, CycleTerminalReason } from './cycle'
+import { CycleNotDueReason } from './cycle-runner/model'
 import type { DatabaseError, EvidenceStoreService } from './db/evidence-store'
 import type { OperationalError } from './errors'
 import { BrokerAccess, CapitalAuthorityKind } from './execution/authority'
@@ -172,6 +173,7 @@ const publicAutonomousCycleLoop = (state: RuntimeState) => {
               result: lastPass.result,
               observedAt: lastPass.observedAt,
               outcome: lastPass.outcome,
+              ...(lastPass.notDueReason === undefined ? {} : { notDueReason: lastPass.notDueReason }),
             }
           : {
               result: lastPass.result,
@@ -523,6 +525,11 @@ const renderPrometheusMetricsDataFirst = (
     cycleObservationAvailable === false ? 'unknown' : (state.cycle.last?.terminalReason?.toLowerCase() ?? 'none')
   const loopResults = ['unknown', 'success', 'failure'] as const
   const loopResult = state.autonomousCycleLoop.lastPass?.result.toLowerCase() ?? 'unknown'
+  const notDueReasons = ['unknown', 'none', ...Object.values(CycleNotDueReason).map((reason) => reason.toLowerCase())]
+  const loopNotDueReason =
+    state.autonomousCycleLoop.lastPass?.result === 'SUCCESS' && state.autonomousCycleLoop.lastPass.outcome === 'NOT_DUE'
+      ? (state.autonomousCycleLoop.lastPass.notDueReason?.toLowerCase() ?? 'unknown')
+      : 'none'
   const paperActivationRealized = state.paperActivation?._tag === 'Realized'
   const effectiveBrokerMutation = paperActivationRealized || config.execution.brokerAccess === BrokerAccess.Mutation
   const effectiveCapitalPromotion =
@@ -619,6 +626,11 @@ const renderPrometheusMetricsDataFirst = (
     '# TYPE bayn_autonomous_cycle_loop_last_pass gauge',
     ...loopResults.map(
       (result) => `bayn_autonomous_cycle_loop_last_pass{result="${result}"} ${loopResult === result ? 1 : 0}`,
+    ),
+    '# HELP bayn_autonomous_cycle_not_due_reason Exact bounded reason for the latest NOT_DUE pass.',
+    '# TYPE bayn_autonomous_cycle_not_due_reason gauge',
+    ...notDueReasons.map(
+      (reason) => `bayn_autonomous_cycle_not_due_reason{reason="${reason}"} ${loopNotDueReason === reason ? 1 : 0}`,
     ),
     ...(state.autonomousCycleLoop.lastPass === null
       ? []

--- a/services/bayn/src/lifecycle-command-http.test.ts
+++ b/services/bayn/src/lifecycle-command-http.test.ts
@@ -4,6 +4,7 @@ import type { AddressInfo } from 'node:net'
 
 import { Data, Effect, Exit, Fiber } from 'effect'
 
+import { CycleNotDueReason } from './cycle-runner/model'
 import type { LifecycleCommandStoreShape } from './db/lifecycle-command'
 import type { WriterFenceService } from './execution/writer-fence'
 import { executeLifecycleCommand, type LifecycleCommandAdvance, serveLifecycleCommands } from './lifecycle-command-http'
@@ -19,6 +20,7 @@ const command = {
 const observation = {
   result: 'SUCCESS' as const,
   outcome: 'NOT_DUE' as const,
+  notDueReason: CycleNotDueReason.StalePaperBootstrap,
   observedAt: '2026-08-10T20:00:01.000Z',
 }
 

--- a/services/bayn/src/runtime-state.ts
+++ b/services/bayn/src/runtime-state.ts
@@ -10,6 +10,7 @@ import {
 } from './cycle-observability'
 import type { QualificationResult } from './qualification'
 import type { RetainedAutonomousCyclePassObservation } from './cycle-runner/pass-decisions'
+import { CycleNotDueReason } from './cycle-runner/model'
 import { IsoDateSchema, UtcInstantSchema } from './schemas'
 import type { EvaluationSummary, ReconciliationResult } from './types'
 
@@ -108,6 +109,7 @@ export const AutonomousCyclePassObservationSchema = Schema.Union([
       'ACQUIRED',
       'REACQUIRED',
     ]),
+    notDueReason: Schema.optionalKey(Schema.Enum(CycleNotDueReason)),
     cadenceDecision: Schema.optionalKey(MonthEndCadenceDecisionSchema),
   }),
   Schema.Struct({


### PR DESCRIPTION
## Summary

- reject expired research PAPER bootstrap publications before cycle acquisition while preserving immutable missed-cycle evidence across restart
- persist the exact NOT_DUE reason through Restate lifecycle commands and PostgreSQL migration 33
- restore readiness only after exact flat reconciliation, zero unresolved mutations, and an exact-or-newer stale-bootstrap pass
- expose bounded Effect logs, public status, and Prometheus metrics while retaining normal admission for the next eligible publication

## Related Issues

PROOMPT-405

## Testing

- `bun test services/bayn/src/http.test.ts services/bayn/src/cycle-observability.test.ts services/bayn/src/health.test.ts services/bayn/src/cycle-runner.test.ts services/bayn/src/cycle-runner/pass-decisions-observability.test.ts services/bayn/src/restate-lifecycle.test.ts services/bayn/src/lifecycle-command-http.test.ts` (145 pass)
- review regression boundary: health, observability, and architecture tests (53 pass, 221 assertions)
- `bun run --cwd services/bayn test` (1,114 pass, 165 PostgreSQL-gated skip, 0 fail, 8,028 assertions)
- `BAYN_TEST_POSTGRES_URL=... bun run --cwd services/bayn test:postgres` against isolated PostgreSQL 16 (150 pass)
- strict Effect diagnostics, TypeScript, Oxlint, type-aware Oxlint, Oxfmt, and production build
- broker sandbox (3 pass), Effect runtime compatibility (4 pass), and Bayn scripts (137 pass)
- Nix production dependency invariant
- hosted amd64 and arm64 image builds on the implementation head

## Breaking Changes

None. Migration 33 adds a nullable, backward-compatible lifecycle observation reason.

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable and Breaking Changes is filled in.
- [x] Migration and operational observability changes are included in the same scoped Bayn release.