### PR TITLE
fix(bayn): reconcile externally driven lifecycle ticks

### DIFF
--- a/argocd/applications/bayn/lifecycle-current.yaml
+++ b/argocd/applications/bayn/lifecycle-current.yaml
@@ -348,7 +348,7 @@ metadata:
     argocd.argoproj.io/hook-delete-policy: BeforeHookCreation,HookSucceeded
 spec:
   backoffLimit: 6
-  activeDeadlineSeconds: 600
+  activeDeadlineSeconds: 720
   ttlSecondsAfterFinished: 300
   template:
     metadata:
@@ -381,6 +381,8 @@ spec:
               value: 23448de7ce3f2f3cf5ca8be9728802e2dbb0f60d
             - name: BAYN_LIFECYCLE_CONTROLLER_KEY
               value: primary
+            - name: BAYN_OPERATION_TIMEOUT_MS
+              value: "30000"
             - name: BAYN_RESTATE_ENDPOINT_URI
               value: http://bayn-lifecycle-23448de7ce3f.bayn.svc.cluster.local:9080
             - name: RESTATE_ADMIN_ORIGIN

--- a/packages/scripts/src/bayn/lifecycle-manifests.test.ts
+++ b/packages/scripts/src/bayn/lifecycle-manifests.test.ts
@@ -3,6 +3,7 @@ import { readFileSync } from 'node:fs'
 
 import {
   advanceBaynLifecycleManifests,
+  baynLifecycleRegistrationActiveDeadlineSeconds,
   baynLifecycleIsActive,
   parseBaynLifecycleCurrent,
   parseBaynLifecyclePrevious,
@@ -47,7 +48,8 @@ describe('Bayn lifecycle release manifests', () => {
     expect(current).toContain('name: bayn-lifecycle-token-reviewer')
     expect(current).toContain('- tokenreviews')
     expect(current).toContain('cidr: 10.96.0.1/32')
-    expect(current).toContain('name: BAYN_OPERATION_TIMEOUT_MS')
+    expect(current.match(/name: BAYN_OPERATION_TIMEOUT_MS/g)).toHaveLength(2)
+    expect(current).toContain(`activeDeadlineSeconds: ${baynLifecycleRegistrationActiveDeadlineSeconds.toString()}`)
     expect(current.match(/enableServiceLinks: false/g)).toHaveLength(2)
     expect(current).not.toContain('secretKeyRef:')
     expect(current).not.toContain('BAYN_ALPACA_')

--- a/packages/scripts/src/bayn/lifecycle-manifests.ts
+++ b/packages/scripts/src/bayn/lifecycle-manifests.ts
@@ -5,6 +5,7 @@ const tagPattern = /^[A-Za-z0-9._-]{1,128}$/
 const digestPattern = /^sha256:[0-9a-f]{64}$/
 const imageRepository = 'registry.ide-newton.ts.net/lab/bayn'
 export const baynLifecycleOperationTimeoutMs = 30_000
+export const baynLifecycleRegistrationActiveDeadlineSeconds = 720
 
 export const baynLifecycleCurrentPath = 'argocd/applications/bayn/lifecycle-current.yaml'
 export const baynLifecyclePreviousPath = 'argocd/applications/bayn/lifecycle-previous.yaml'
@@ -508,7 +509,7 @@ metadata:
     argocd.argoproj.io/hook-delete-policy: BeforeHookCreation,HookSucceeded
 spec:
   backoffLimit: 6
-  activeDeadlineSeconds: 600
+  activeDeadlineSeconds: ${baynLifecycleRegistrationActiveDeadlineSeconds.toString()}
   ttlSecondsAfterFinished: 300
   template:
     metadata:
@@ -541,6 +542,8 @@ spec:
               value: ${pin.sourceSha}
             - name: BAYN_LIFECYCLE_CONTROLLER_KEY
               value: primary
+            - name: BAYN_OPERATION_TIMEOUT_MS
+              value: "${baynLifecycleOperationTimeoutMs.toString()}"
             - name: BAYN_RESTATE_ENDPOINT_URI
               value: http://${name}.bayn.svc.cluster.local:9080
             - name: RESTATE_ADMIN_ORIGIN

--- a/services/bayn/src/execution/mutations/index.ts
+++ b/services/bayn/src/execution/mutations/index.ts
@@ -1,4 +1,4 @@
-export { MutationEventType, MutationStore, MutationStoreError } from './model'
+export { maximumConsistencyDelayMs, MutationEventType, MutationStore, MutationStoreError } from './model'
 export type {
   MutationAuthorityBinding,
   MutationAuthoritySnapshot,

--- a/services/bayn/src/execution/mutations/model.ts
+++ b/services/bayn/src/execution/mutations/model.ts
@@ -31,7 +31,8 @@ export enum MutationEventType {
 
 export const Sequence = Schema.Int.check(Schema.isGreaterThan(0))
 export const HttpStatus = Schema.Int.check(Schema.isBetween({ minimum: 100, maximum: 599 }))
-export const ConsistencyDelay = Schema.Int.check(Schema.isBetween({ minimum: 1, maximum: 300_000 }))
+export const maximumConsistencyDelayMs = 300_000
+export const ConsistencyDelay = Schema.Int.check(Schema.isBetween({ minimum: 1, maximum: maximumConsistencyDelayMs }))
 export const BrokerOrderId = NonEmptyString.check(Schema.isMaxLength(256))
 export const MutationEventSchema = Schema.Struct({
   schemaVersion: Schema.Literal('bayn.paper-mutation-event.v1'),

--- a/services/bayn/src/observe-composition.test.ts
+++ b/services/bayn/src/observe-composition.test.ts
@@ -4056,6 +4056,135 @@ describe('OBSERVE runtime composition', () => {
     mutationEvents.length = 0
     mutationReconciliations = 0
     publicationReads = 0
+    const externalObservations: Parameters<Parameters<typeof mutationStartup>[0]['recordPass']>[0][] = []
+    let externalNextDelayMs: number | undefined
+    const externalStartup = makeMutationAutonomousCycleStartup({
+      accountId,
+      authorityGenerationHash: generationHash,
+      pollIntervalMs: 100,
+      reconciliationIntervalMs: 100,
+      reconciliationPassTimeoutMs: 30_000,
+      strategy: fixtureRuntime,
+      executionProgram: sandboxExecutionProgram(),
+      interpretCycleDriver: (driver) =>
+        Effect.gen(function* () {
+          externalNextDelayMs = driver.nextDelayMs
+          yield* driver.advance.pipe(Effect.orDie)
+          yield* TestClock.adjust(100)
+          yield* driver.advance.pipe(Effect.orDie)
+        }),
+    })
+    mutationPhase = true
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        yield* TestClock.setTime(Date.parse(reconciledAt))
+        const loop = yield* externalStartup({
+          qualificationRunId: 'c'.repeat(64),
+          recordPass: (observation) =>
+            Effect.sync(() => {
+              externalObservations.push(observation)
+              mutationEvents.push(`external-observe:${externalObservations.length.toString()}`)
+            }),
+        })
+        yield* loop.pipe(
+          Effect.provideService(BrokerRead, brokerRead),
+          Effect.provideService(CycleStore, cycleStore),
+          Effect.provideService(MarketData, missingPublicationMarketData),
+          Effect.provideService(BrokerEventStore, executionStore),
+          Effect.provideService(FillAccountingStore, executionStore),
+          Effect.provideService(ValuationStore, executionStore),
+          Effect.provideService(ReconciliationStore, executionStore),
+          Effect.provideService(AuthorityGenerationStore, executionStore),
+          Effect.provideService(AuthorityRestrictionStore, executionStore),
+          Effect.provideService(WriterFence, writerFence),
+          Effect.provideService(IntentStore, intentStore),
+          Effect.provideService(MutationStore, mutationStore),
+        )
+      }).pipe(Effect.provide(TestClock.layer())),
+    )
+    mutationPhase = false
+
+    expect(externalNextDelayMs).toBe(100)
+    expect(externalObservations).toHaveLength(2)
+    expect(externalObservations[0]).toMatchObject({ result: 'SUCCESS', outcome: 'NO_PUBLICATION' })
+    expect(externalObservations[1]).toMatchObject({ result: 'SUCCESS', outcome: 'NO_PUBLICATION' })
+    expect(mutationReconciliations).toBe(2)
+    expect(mutationEvents.indexOf('reconcile:1')).toBeLessThan(mutationEvents.indexOf('publication:1'))
+    expect(mutationEvents.indexOf('reconcile:2')).toBeLessThan(mutationEvents.indexOf('publication:2'))
+
+    mutationEvents.length = 0
+    mutationReconciliations = 0
+    publicationReads = 0
+    nextReconciliationFailure = new ExecutionStoreError({
+      operation: 'reconciliation',
+      failure: 'query',
+      message: 'external lifecycle reconciliation persistence failed',
+    })
+    const externalFailureObservations: Parameters<Parameters<typeof mutationStartup>[0]['recordPass']>[0][] = []
+    const externalFailureStartup = makeMutationAutonomousCycleStartup({
+      accountId,
+      authorityGenerationHash: generationHash,
+      pollIntervalMs: 100,
+      reconciliationIntervalMs: 100,
+      reconciliationPassTimeoutMs: 30_000,
+      strategy: fixtureRuntime,
+      executionProgram: sandboxExecutionProgram(),
+      interpretCycleDriver: (driver) =>
+        Effect.gen(function* () {
+          yield* driver.advance.pipe(Effect.orDie)
+          yield* TestClock.adjust(100)
+          yield* driver.advance.pipe(Effect.orDie)
+        }),
+    })
+    mutationPhase = true
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        yield* TestClock.setTime(Date.parse(reconciledAt))
+        const loop = yield* externalFailureStartup({
+          qualificationRunId: 'c'.repeat(64),
+          recordPass: (observation) =>
+            Effect.sync(() => {
+              externalFailureObservations.push(observation)
+              mutationEvents.push(`external-failure-observe:${externalFailureObservations.length.toString()}`)
+            }),
+        })
+        yield* loop.pipe(
+          Effect.provideService(BrokerRead, brokerRead),
+          Effect.provideService(CycleStore, cycleStore),
+          Effect.provideService(MarketData, missingPublicationMarketData),
+          Effect.provideService(BrokerEventStore, executionStore),
+          Effect.provideService(FillAccountingStore, executionStore),
+          Effect.provideService(ValuationStore, executionStore),
+          Effect.provideService(ReconciliationStore, executionStore),
+          Effect.provideService(AuthorityGenerationStore, executionStore),
+          Effect.provideService(AuthorityRestrictionStore, executionStore),
+          Effect.provideService(WriterFence, writerFence),
+          Effect.provideService(IntentStore, intentStore),
+          Effect.provideService(MutationStore, mutationStore),
+        )
+      }).pipe(Effect.provide(TestClock.layer())),
+    )
+    mutationPhase = false
+
+    expect(externalFailureObservations).toHaveLength(2)
+    expect(externalFailureObservations[0]).toMatchObject({
+      result: 'FAILURE',
+      operation: 'reconcile-not-due',
+      message: 'same-pass reconciliation store operation failed: external lifecycle reconciliation persistence failed',
+    })
+    expect(externalFailureObservations[1]).toMatchObject({ result: 'SUCCESS', outcome: 'NO_PUBLICATION' })
+    expect(publicationReads).toBe(1)
+    expect(mutationReconciliations).toBe(1)
+    expect(mutationEvents.indexOf('reconcile-failed')).toBeLessThan(
+      mutationEvents.indexOf('external-failure-observe:1'),
+    )
+    expect(mutationEvents.indexOf('reconcile:1')).toBeLessThan(mutationEvents.indexOf('publication:1'))
+    expect(authorityRestrictions).toBe(1)
+    authorityRestrictions = 0
+
+    mutationEvents.length = 0
+    mutationReconciliations = 0
+    publicationReads = 0
     nextReconciliationFailure = new ExecutionStoreError({
       operation: 'reconciliation',
       failure: 'query',

--- a/services/bayn/src/observe-composition.ts
+++ b/services/bayn/src/observe-composition.ts
@@ -2034,6 +2034,19 @@ const attemptMutationIdleReconciliation = (
     ),
   )
 
+const reconcileMutationBeforeExternallyDrivenAdvance = (
+  input: ObserveAutonomousCycleInput,
+  cadence: Ref.Ref<ReconciliationCadenceState>,
+  reconcile: Effect.Effect<ReconciliationPassResult, ReconciliationPassError, ObserveDecisionRuntime>,
+): Effect.Effect<void, CycleRunnerError, ObserveDecisionRuntime> =>
+  Effect.gen(function* () {
+    const nowNanos = yield* Clock.currentTimeNanos
+    const state = yield* Ref.get(cadence)
+    const decision = decideIdleReconciliationCadence(state, nowNanos, input.reconciliationIntervalMs)
+    if (decision._tag === 'RECONCILE') yield* attemptMutationIdleReconciliation(cadence, reconcile)
+    else if (state.lastFailure !== undefined) return yield* state.lastFailure
+  })
+
 const reconcileMutationNotDuePass = (
   input: ObserveAutonomousCycleInput,
   cadence: Ref.Ref<ReconciliationCadenceState>,
@@ -2231,7 +2244,7 @@ const makeRecoveryFirstCycleDriver = (
     const reconcile = boundedReconciliationPass(input.reconciliationPassTimeoutMs).pipe(
       Effect.tap(() => markMutationReconciliationCompleted(cadence)),
     )
-    const advance = Effect.gen(function* () {
+    const advanceCycle = Effect.gen(function* () {
       const context: CycleRunContext<ObserveDecisionRuntime> = {
         qualificationRunId: startup.qualificationRunId,
         ...(input.cycleCadence === undefined ? {} : { cadence: input.cycleCadence }),
@@ -2270,6 +2283,21 @@ const makeRecoveryFirstCycleDriver = (
           ),
       }),
     )
+    const advance =
+      input.interpretCycleDriver === undefined
+        ? advanceCycle
+        : reconcileMutationBeforeExternallyDrivenAdvance(input, cadence, reconcile).pipe(
+            Effect.matchEffect({
+              onFailure: (error) =>
+                currentUtcInstant.pipe(
+                  Effect.flatMap((observedAt) =>
+                    observeMutationPass(startup, { outcome: 'FAILED', observedAt, error }),
+                  ),
+                  Effect.map((observation) => ({ observation })),
+                ),
+              onSuccess: () => advanceCycle,
+            }),
+          )
     return {
       advance,
       nextDelayMs: recoveryFirstCycleNextDelayMs(input),

--- a/services/bayn/src/restate-lifecycle-controller.test.ts
+++ b/services/bayn/src/restate-lifecycle-controller.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test'
 
 import { Result } from 'effect'
 
+import { maximumConsistencyDelayMs } from './execution/mutations'
 import { lifecycleCommandId } from './lifecycle-command-contract'
 import { decodeRestateLifecycleConfig } from './restate-lifecycle'
 import {
@@ -34,10 +35,14 @@ const jsonResponse = (body: unknown, init: ResponseInit = {}): Response => {
 }
 
 describe('Restate lifecycle command client', () => {
-  test('bounds both external advance phases and retains durable finalization headroom', () => {
-    expect(lifecycleCommandRequestTimeoutMs(1_000)).toBe(2_000 + lifecycleCommandFinalizationHeadroomMs)
-    expect(lifecycleCommandRequestTimeoutMs(30_000)).toBe(90_000)
-    expect(lifecycleCommandRequestTimeoutMs(86_400_000)).toBe(172_800_000 + lifecycleCommandFinalizationHeadroomMs)
+  test('bounds every external advance phase and retains durable finalization headroom', () => {
+    expect(lifecycleCommandRequestTimeoutMs(1_000)).toBe(
+      3_000 + maximumConsistencyDelayMs + lifecycleCommandFinalizationHeadroomMs,
+    )
+    expect(lifecycleCommandRequestTimeoutMs(30_000)).toBe(420_000)
+    expect(lifecycleCommandRequestTimeoutMs(86_400_000)).toBe(
+      259_200_000 + maximumConsistencyDelayMs + lifecycleCommandFinalizationHeadroomMs,
+    )
   })
 
   test('keeps Restate inactivity and abort limits beyond every accepted command request', () => {
@@ -45,7 +50,8 @@ describe('Restate lifecycle command client', () => {
       const expected = lifecycleHandlerTimeouts(operationTimeoutMs)
 
       expect(expected).toEqual({
-        inactivityTimeout: operationTimeoutMs * 2 + lifecycleCommandFinalizationHeadroomMs * 2,
+        inactivityTimeout:
+          operationTimeoutMs * 3 + maximumConsistencyDelayMs + lifecycleCommandFinalizationHeadroomMs * 2,
         abortTimeout: lifecycleCommandFinalizationHeadroomMs,
       })
       expect(expected.inactivityTimeout).toBeGreaterThan(lifecycleCommandRequestTimeoutMs(operationTimeoutMs))
@@ -63,7 +69,7 @@ describe('Restate lifecycle command client', () => {
     expect(lifecycleBootstrapRetryPolicy).toEqual({ maxAttempts: 1, onMaxAttempts: 'kill' })
     expect(lifecycleActivationIdempotencyRetentionMs).toBe(600_000)
     expect(lifecycleCursorRequestTimeoutMs).toBe(10_000)
-    expect(lifecycleActivationAwaitTimeoutMs).toBe(201_000)
+    expect(lifecycleActivationAwaitTimeoutMs).toBe(501_000)
     expect(lifecycleActivationAwaitTimeoutMs).toBeGreaterThan(
       lifecycleHandlerTimeouts(config.operationTimeoutMs).inactivityTimeout,
     )

--- a/services/bayn/src/restate-lifecycle-controller.test.ts
+++ b/services/bayn/src/restate-lifecycle-controller.test.ts
@@ -7,7 +7,9 @@ import { lifecycleCommandId } from './lifecycle-command-contract'
 import { decodeRestateLifecycleConfig } from './restate-lifecycle'
 import {
   lifecycleActivationAwaitTimeoutMs,
+  lifecycleActivationHandlerTimeouts,
   lifecycleActivationIdempotencyRetentionMs,
+  lifecycleActivationMaximumAttempts,
   lifecycleActivationRetryPolicy,
   lifecycleBootstrapRetryPolicy,
   lifecycleCommandFinalizationHeadroomMs,
@@ -69,9 +71,19 @@ describe('Restate lifecycle command client', () => {
     expect(lifecycleBootstrapRetryPolicy).toEqual({ maxAttempts: 1, onMaxAttempts: 'kill' })
     expect(lifecycleActivationIdempotencyRetentionMs).toBe(600_000)
     expect(lifecycleCursorRequestTimeoutMs).toBe(10_000)
-    expect(lifecycleActivationAwaitTimeoutMs).toBe(501_000)
-    expect(lifecycleActivationAwaitTimeoutMs).toBeGreaterThan(
-      lifecycleHandlerTimeouts(config.operationTimeoutMs).inactivityTimeout,
+    expect(lifecycleActivationAwaitTimeoutMs(config.operationTimeoutMs)).toBe(621_000)
+    expect(lifecycleActivationAwaitTimeoutMs(config.operationTimeoutMs)).toBe(
+      lifecycleCommandRequestTimeoutMs(config.operationTimeoutMs) +
+        lifecycleCursorRequestTimeoutMs * lifecycleActivationMaximumAttempts +
+        91_000 +
+        lifecycleCommandFinalizationHeadroomMs,
+    )
+    expect(lifecycleActivationHandlerTimeouts(config.operationTimeoutMs)).toEqual({
+      inactivityTimeout: 651_000,
+      abortTimeout: lifecycleCommandFinalizationHeadroomMs,
+    })
+    expect(lifecycleActivationHandlerTimeouts(config.operationTimeoutMs).inactivityTimeout).toBeGreaterThan(
+      lifecycleActivationAwaitTimeoutMs(config.operationTimeoutMs),
     )
   })
 

--- a/services/bayn/src/restate-lifecycle-controller.test.ts
+++ b/services/bayn/src/restate-lifecycle-controller.test.ts
@@ -34,10 +34,10 @@ const jsonResponse = (body: unknown, init: ResponseInit = {}): Response => {
 }
 
 describe('Restate lifecycle command client', () => {
-  test('keeps bounded finalization headroom beyond every accepted Bayn pass timeout', () => {
-    expect(lifecycleCommandRequestTimeoutMs(1_000)).toBe(1_000 + lifecycleCommandFinalizationHeadroomMs)
-    expect(lifecycleCommandRequestTimeoutMs(30_000)).toBe(60_000)
-    expect(lifecycleCommandRequestTimeoutMs(86_400_000)).toBe(86_400_000 + lifecycleCommandFinalizationHeadroomMs)
+  test('bounds both external advance phases and retains durable finalization headroom', () => {
+    expect(lifecycleCommandRequestTimeoutMs(1_000)).toBe(2_000 + lifecycleCommandFinalizationHeadroomMs)
+    expect(lifecycleCommandRequestTimeoutMs(30_000)).toBe(90_000)
+    expect(lifecycleCommandRequestTimeoutMs(86_400_000)).toBe(172_800_000 + lifecycleCommandFinalizationHeadroomMs)
   })
 
   test('keeps Restate inactivity and abort limits beyond every accepted command request', () => {
@@ -45,7 +45,7 @@ describe('Restate lifecycle command client', () => {
       const expected = lifecycleHandlerTimeouts(operationTimeoutMs)
 
       expect(expected).toEqual({
-        inactivityTimeout: operationTimeoutMs + lifecycleCommandFinalizationHeadroomMs * 2,
+        inactivityTimeout: operationTimeoutMs * 2 + lifecycleCommandFinalizationHeadroomMs * 2,
         abortTimeout: lifecycleCommandFinalizationHeadroomMs,
       })
       expect(expected.inactivityTimeout).toBeGreaterThan(lifecycleCommandRequestTimeoutMs(operationTimeoutMs))

--- a/services/bayn/src/restate-lifecycle-controller.ts
+++ b/services/bayn/src/restate-lifecycle-controller.ts
@@ -117,10 +117,13 @@ const lifecycleActivationRetryDelayMs = (): number => {
   return total
 }
 
-export const lifecycleActivationAwaitTimeoutMs =
+// Activation is an exclusive virtual-object command. A rollout request can therefore wait behind one already-running
+// advance before its own bounded cursor recovery begins. Keep the ingress waiter alive for both phases and a separate
+// response-finalization window; otherwise a healthy activation can be abandoned while Restate is still progressing.
+export const lifecycleActivationAwaitTimeoutMs = (operationTimeoutMs: number): number =>
+  lifecycleCommandRequestTimeoutMs(operationTimeoutMs) +
   lifecycleCursorRequestTimeoutMs * lifecycleActivationMaximumAttempts +
   lifecycleActivationRetryDelayMs() +
-  maximumConsistencyDelayMs +
   lifecycleCommandFinalizationHeadroomMs
 
 // Let the bounded HTTP request finish and give Restate one additional journal-finalization window before requesting
@@ -129,6 +132,13 @@ export const lifecycleHandlerTimeouts = (
   operationTimeoutMs: number,
 ): { readonly inactivityTimeout: number; readonly abortTimeout: number } => ({
   inactivityTimeout: lifecycleCommandRequestTimeoutMs(operationTimeoutMs) + lifecycleCommandFinalizationHeadroomMs,
+  abortTimeout: lifecycleCommandFinalizationHeadroomMs,
+})
+
+export const lifecycleActivationHandlerTimeouts = (
+  operationTimeoutMs: number,
+): { readonly inactivityTimeout: number; readonly abortTimeout: number } => ({
+  inactivityTimeout: lifecycleActivationAwaitTimeoutMs(operationTimeoutMs) + lifecycleCommandFinalizationHeadroomMs,
   abortTimeout: lifecycleCommandFinalizationHeadroomMs,
 })
 
@@ -356,6 +366,6 @@ export const makeBaynLifecycleBootstrap = (
       ),
     },
     options: {
-      ...lifecycleHandlerTimeouts(config.operationTimeoutMs),
+      ...lifecycleActivationHandlerTimeouts(config.operationTimeoutMs),
     },
   })

--- a/services/bayn/src/restate-lifecycle-controller.ts
+++ b/services/bayn/src/restate-lifecycle-controller.ts
@@ -100,8 +100,10 @@ const readBoundedJson = async (response: Response): Promise<unknown> => {
   }
 }
 
+// One externally driven advance can run a reconciliation preflight and then a cycle pass. Each phase is independently
+// bounded by operationTimeoutMs; retain a separate finalization window for the durable command receipt and response.
 export const lifecycleCommandRequestTimeoutMs = (operationTimeoutMs: number): number =>
-  operationTimeoutMs + lifecycleCommandFinalizationHeadroomMs
+  operationTimeoutMs * 2 + lifecycleCommandFinalizationHeadroomMs
 
 const lifecycleActivationRetryDelayMs = (): number => {
   let interval = lifecycleActivationInitialRetryIntervalMs

--- a/services/bayn/src/restate-lifecycle-controller.ts
+++ b/services/bayn/src/restate-lifecycle-controller.ts
@@ -1,6 +1,7 @@
 import * as restate from '@restatedev/restate-sdk'
 import { Effect, Logger, Result } from 'effect'
 
+import { maximumConsistencyDelayMs } from './execution/mutations'
 import {
   completeRestateLifecycleTick,
   decodeLifecycleCommandCursorResponse,
@@ -100,10 +101,11 @@ const readBoundedJson = async (response: Response): Promise<unknown> => {
   }
 }
 
-// One externally driven advance can run a reconciliation preflight and then a cycle pass. Each phase is independently
-// bounded by operationTimeoutMs; retain a separate finalization window for the durable command receipt and response.
+// One externally driven advance can run a bounded reconciliation preflight and cycle pass. A successful mutation can
+// then require the maximum schema-valid consistency delay and one separately bounded reconciliation. Retain a final
+// window for the durable command receipt and response rather than interrupting an accepted broker mutation mid-settle.
 export const lifecycleCommandRequestTimeoutMs = (operationTimeoutMs: number): number =>
-  operationTimeoutMs * 2 + lifecycleCommandFinalizationHeadroomMs
+  operationTimeoutMs * 3 + maximumConsistencyDelayMs + lifecycleCommandFinalizationHeadroomMs
 
 const lifecycleActivationRetryDelayMs = (): number => {
   let interval = lifecycleActivationInitialRetryIntervalMs
@@ -118,6 +120,7 @@ const lifecycleActivationRetryDelayMs = (): number => {
 export const lifecycleActivationAwaitTimeoutMs =
   lifecycleCursorRequestTimeoutMs * lifecycleActivationMaximumAttempts +
   lifecycleActivationRetryDelayMs() +
+  maximumConsistencyDelayMs +
   lifecycleCommandFinalizationHeadroomMs
 
 // Let the bounded HTTP request finish and give Restate one additional journal-finalization window before requesting

--- a/services/bayn/src/restate-lifecycle-register.test.ts
+++ b/services/bayn/src/restate-lifecycle-register.test.ts
@@ -31,7 +31,7 @@ describe('Restate lifecycle deployment registration', () => {
     expect(restateLifecycleActivationIdempotencyKey(sourceRevision, controllerKey)).toBe(
       `bayn-lifecycle-${sourceRevision}-${controllerKey}`,
     )
-    expect(restateLifecycleActivationRequest(sourceRevision, controllerKey)).toEqual({
+    expect(restateLifecycleActivationRequest(sourceRevision, controllerKey, 30_000)).toEqual({
       body: {
         schemaVersion: 'bayn.restate-lifecycle-activation.v1',
         controllerKey,
@@ -39,8 +39,8 @@ describe('Restate lifecycle deployment registration', () => {
       headers: {
         'idempotency-key': `bayn-lifecycle-${sourceRevision}-${controllerKey}`,
       },
-      timeoutMs: lifecycleActivationAwaitTimeoutMs,
+      timeoutMs: lifecycleActivationAwaitTimeoutMs(30_000),
     })
-    expect(lifecycleActivationAwaitTimeoutMs).toBe(501_000)
+    expect(lifecycleActivationAwaitTimeoutMs(30_000)).toBe(621_000)
   })
 })

--- a/services/bayn/src/restate-lifecycle-register.test.ts
+++ b/services/bayn/src/restate-lifecycle-register.test.ts
@@ -41,6 +41,6 @@ describe('Restate lifecycle deployment registration', () => {
       },
       timeoutMs: lifecycleActivationAwaitTimeoutMs,
     })
-    expect(lifecycleActivationAwaitTimeoutMs).toBe(201_000)
+    expect(lifecycleActivationAwaitTimeoutMs).toBe(501_000)
   })
 })

--- a/services/bayn/src/restate-lifecycle-register.ts
+++ b/services/bayn/src/restate-lifecycle-register.ts
@@ -3,6 +3,7 @@ import { Config, Data, Effect, Logger, Option, Schema, pipe } from 'effect'
 
 import { embeddedBuildMetadata } from './build'
 import { LifecycleControllerKeySchema } from './lifecycle-command-contract'
+import { OperationalThresholdSchema } from './restate-lifecycle'
 import { lifecycleActivationAwaitTimeoutMs } from './restate-lifecycle-controller'
 import { GitSourceRevisionSchema } from './schemas'
 
@@ -44,6 +45,9 @@ const config = Config.all({
   ),
   controllerKey: Config.schema(LifecycleControllerKeySchema, 'BAYN_LIFECYCLE_CONTROLLER_KEY').pipe(
     Config.withDefault('primary'),
+  ),
+  operationTimeoutMs: Config.schema(OperationalThresholdSchema, 'BAYN_OPERATION_TIMEOUT_MS').pipe(
+    Config.withDefault(30_000),
   ),
   configuredSourceRevision: Config.option(Config.schema(GitSourceRevisionSchema, 'BAYN_CODE_REVISION')),
 })
@@ -92,7 +96,11 @@ export const restateDeploymentRegistration = (endpointUri: string, sourceRevisio
 export const restateLifecycleActivationIdempotencyKey = (sourceRevision: string, controllerKey: string): string =>
   `bayn-lifecycle-${sourceRevision}-${controllerKey}`
 
-export const restateLifecycleActivationRequest = (sourceRevision: string, controllerKey: string) => ({
+export const restateLifecycleActivationRequest = (
+  sourceRevision: string,
+  controllerKey: string,
+  operationTimeoutMs: number,
+) => ({
   body: {
     schemaVersion: 'bayn.restate-lifecycle-activation.v1',
     controllerKey,
@@ -100,7 +108,7 @@ export const restateLifecycleActivationRequest = (sourceRevision: string, contro
   headers: {
     'idempotency-key': restateLifecycleActivationIdempotencyKey(sourceRevision, controllerKey),
   },
-  timeoutMs: lifecycleActivationAwaitTimeoutMs,
+  timeoutMs: lifecycleActivationAwaitTimeoutMs(operationTimeoutMs),
 })
 
 const program = Effect.gen(function* () {
@@ -137,7 +145,7 @@ const program = Effect.gen(function* () {
       sourceRevision,
     }),
   )
-  const activation = restateLifecycleActivationRequest(sourceRevision, loaded.controllerKey)
+  const activation = restateLifecycleActivationRequest(sourceRevision, loaded.controllerKey, loaded.operationTimeoutMs)
   const activationStatus = yield* postJson(
     'activate',
     `${loaded.ingressOrigin}/BaynLifecycleBootstrap/start`,

--- a/services/bayn/src/restate-lifecycle.ts
+++ b/services/bayn/src/restate-lifecycle.ts
@@ -6,7 +6,7 @@ import { sha256 } from './hash'
 import { AutonomousCyclePassObservationSchema } from './runtime-state'
 import { GitSourceRevisionSchema, Sha256Schema, UtcInstantSchema, strictParseOptions } from './schemas'
 
-const OperationalThresholdSchema = Schema.Int.check(
+export const OperationalThresholdSchema = Schema.Int.check(
   Schema.isBetween({ minimum: minimumOperationalThresholdMs, maximum: maximumOperationalThresholdMs }),
 )
 const NextDelayMsSchema = Schema.Int.check(Schema.isBetween({ minimum: 1, maximum: maximumOperationalThresholdMs }))


### PR DESCRIPTION
## Summary

- Refresh due broker/account reconciliation before each externally driven Restate lifecycle advance, closing the gap left when the in-process wait interpreter is not used.
- Preserve the existing in-process cadence and fail closed on a preflight reconciliation error while allowing a later durable Restate command to recover.
- Cover external-driver success, typed failure, recovery, publication ordering, and mutation-boundary behavior without broker mutation shortcuts.

## Related Issues

None.

## Testing

- `bun run --filter @proompteng/bayn test` — 1,115 passed, 165 PostgreSQL-gated tests skipped, 0 failed.
- `bun run --filter @proompteng/bayn test:postgres` against PostgreSQL 18 — 150 passed, 0 failed.
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn build`

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked; no public contract or operator procedure changed.
