### PR TITLE
fix(bayn): keep Restate reconciliation fresh

### DIFF
--- a/services/bayn/src/composition.test.ts
+++ b/services/bayn/src/composition.test.ts
@@ -1,6 +1,20 @@
 import { describe, expect, test } from 'bun:test'
 
-import { Context, Deferred, Effect, Fiber, FileSystem, Layer, Logger, Redacted, Ref, References, Result } from 'effect'
+import {
+  Cause,
+  Context,
+  Deferred,
+  Effect,
+  Exit,
+  Fiber,
+  FileSystem,
+  Layer,
+  Logger,
+  Redacted,
+  Ref,
+  References,
+  Result,
+} from 'effect'
 import { TestClock } from 'effect/testing'
 
 import { config, fixtureRuntime } from './app-test-support'
@@ -22,6 +36,7 @@ import {
   refreshResearchPaperActivationReconciliation,
   restrictExpiredPaperActivation,
   retryClosedCycleReceipts,
+  runRestateLifecycleWithReconciliationGuardian,
 } from './composition'
 import { makeApplicationPlan, type ApplicationPlanFor } from './app'
 import { AccountStatus, alpacaSandboxBaseUrl, type BrokerSessionShape } from './broker/alpaca'
@@ -297,6 +312,56 @@ describe('Bayn application platform', () => {
     const context = await Effect.runPromise(Effect.scoped(Layer.build(ApplicationPlatformLive)))
 
     expect(Context.get(context, FileSystem.FileSystem)).toBeDefined()
+  })
+
+  test('owns the Restate reconciliation guardian for exactly the service scope', async () => {
+    let interrupted = false
+
+    await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const started = yield* Deferred.make<void>()
+          yield* runRestateLifecycleWithReconciliationGuardian(
+            Deferred.succeed(started, undefined).pipe(
+              Effect.andThen(Effect.never),
+              Effect.onInterrupt(() => Effect.sync(() => void (interrupted = true))),
+            ),
+            30_000,
+            Effect.never,
+          ).pipe(Effect.forkScoped)
+          yield* Deferred.await(started)
+        }),
+      ),
+    )
+
+    expect(interrupted).toBe(true)
+  })
+
+  test('propagates a reconciliation guardian defect to the owning Restate lifecycle', async () => {
+    const defect = new Error('guardian invariant defect')
+
+    const exit = await Effect.runPromise(
+      Effect.gen(function* () {
+        const lifecycleStarted = yield* Deferred.make<void>()
+        const lifecycleInterrupted = yield* Deferred.make<void>()
+        const result = yield* runRestateLifecycleWithReconciliationGuardian(
+          Deferred.await(lifecycleStarted).pipe(Effect.andThen(Effect.die(defect))),
+          30_000,
+          Deferred.succeed(lifecycleStarted, undefined).pipe(
+            Effect.andThen(Effect.never),
+            Effect.onInterrupt(() => Deferred.succeed(lifecycleInterrupted, undefined)),
+          ),
+        ).pipe(Effect.exit)
+        yield* Deferred.await(lifecycleInterrupted)
+        return result
+      }),
+    )
+
+    expect(Exit.isFailure(exit)).toBe(true)
+    if (Exit.isFailure(exit)) {
+      expect(Cause.hasDies(exit.cause)).toBe(true)
+      expect(Cause.pretty(exit.cause)).toContain(defect.message)
+    }
   })
 })
 

--- a/services/bayn/src/composition.ts
+++ b/services/bayn/src/composition.ts
@@ -302,6 +302,18 @@ const runtimeBroker = (
   executionDisabledReason: mutationEnabled ? null : ('BROKER_ACCESS_READ_ONLY' as const),
 })
 
+export const runRestateLifecycleWithReconciliationGuardian = <A, E, R, GuardianR>(
+  maintainReconciliation: Effect.Effect<void, never, R>,
+  intervalMs: number,
+  lifecycle: Effect.Effect<A, E, GuardianR>,
+): Effect.Effect<A, E, R | GuardianR> =>
+  Effect.zipWith(
+    Effect.forever(maintainReconciliation.pipe(Effect.andThen(Effect.sleep(Duration.millis(intervalMs))))),
+    lifecycle,
+    (_guardian, result) => result,
+    { concurrent: true },
+  )
+
 const lifecycleDriverInterpreter = (
   plan: ApplicationPlanFor<'AutonomousService'>,
   store: import('./db/lifecycle-command').LifecycleCommandStoreShape,
@@ -311,19 +323,29 @@ const lifecycleDriverInterpreter = (
     ? (((driver) =>
         Effect.gen(function* () {
           const authenticate = yield* acquireKubernetesLifecycleCommandAuthenticator()
-          return yield* serveLifecycleCommands(
-            {
-              host: plan.config.host,
-              port: plan.config.lifecycleCommandPort,
+          yield* Effect.logInfo('Bayn Restate reconciliation guardian started').pipe(
+            Effect.annotateLogs({
               controllerKey: plan.config.lifecycleControllerKey,
-              sourceRevision: plan.config.build.sourceRevision,
-              previousSourceRevision: plan.config.lifecyclePreviousSourceRevision,
-              nextDelayMs: driver.nextDelayMs,
-            },
-            store,
-            writerFence,
-            authenticate,
-            driver.advance,
+              reconciliationIntervalMs: plan.config.alpaca.reconciliationIntervalMs,
+            }),
+          )
+          return yield* runRestateLifecycleWithReconciliationGuardian(
+            driver.maintainReconciliation,
+            driver.nextDelayMs,
+            serveLifecycleCommands(
+              {
+                host: plan.config.host,
+                port: plan.config.lifecycleCommandPort,
+                controllerKey: plan.config.lifecycleControllerKey,
+                sourceRevision: plan.config.build.sourceRevision,
+                previousSourceRevision: plan.config.lifecyclePreviousSourceRevision,
+                nextDelayMs: driver.nextDelayMs,
+              },
+              store,
+              writerFence,
+              authenticate,
+              driver.advance,
+            ),
           )
         }).pipe(Effect.scoped, Effect.orDie)) satisfies RecoveryFirstCycleDriverInterpreter)
     : undefined

--- a/services/bayn/src/observe-composition.test.ts
+++ b/services/bayn/src/observe-composition.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 
-import { Cause, Deferred, Effect, Exit, Fiber, Option, Result } from 'effect'
+import { Cause, Deferred, Effect, Exit, Fiber, Layer, Logger, Option, Result } from 'effect'
 import { TestClock } from 'effect/testing'
 
 import type { AutonomousCycleLoop } from './app'
@@ -3670,6 +3670,8 @@ describe('OBSERVE runtime composition', () => {
     let mutationCalendarReads = 0
     let mutationReconciliations = 0
     let nextReconciliationFailure: ExecutionStoreError | undefined
+    let reconciliationEntered: Deferred.Deferred<void> | undefined
+    let reconciliationGate: Deferred.Deferred<void> | undefined
     let secondMutationCalendarRead: Deferred.Deferred<void> | undefined
     const mutationEvents: string[] = []
     const unusedRead = Effect.die(new Error('NOT_DUE reconciliation used an unrelated broker read'))
@@ -3795,14 +3797,24 @@ describe('OBSERVE runtime composition', () => {
             mutationEvents.push('reconcile-failed')
             return Effect.fail(failure)
           }
-          return Effect.sync(() => {
-            reconciledSnapshots.push(brokerSnapshot)
-            if (mutationPhase) {
-              mutationReconciliations += 1
-              mutationEvents.push(`reconcile:${mutationReconciliations.toString()}`)
-            }
-            return persisted
-          })
+          const entered = reconciliationEntered
+          const gate = reconciliationGate
+          return (
+            entered === undefined || gate === undefined
+              ? Effect.void
+              : Deferred.succeed(entered, undefined).pipe(Effect.andThen(Deferred.await(gate)))
+          ).pipe(
+            Effect.andThen(
+              Effect.sync(() => {
+                reconciledSnapshots.push(brokerSnapshot)
+                if (mutationPhase) {
+                  mutationReconciliations += 1
+                  mutationEvents.push(`reconcile:${mutationReconciliations.toString()}`)
+                }
+                return persisted
+              }),
+            ),
+          )
         }),
       ensureAuthorityGeneration: () => {
         const authority = exact.riskContext.authority
@@ -4072,6 +4084,24 @@ describe('OBSERVE runtime composition', () => {
           yield* driver.advance.pipe(Effect.orDie)
           yield* TestClock.adjust(100)
           yield* driver.advance.pipe(Effect.orDie)
+          const entered = yield* Deferred.make<void>()
+          const gate = yield* Deferred.make<void>()
+          reconciliationEntered = entered
+          reconciliationGate = gate
+          yield* TestClock.adjust(100)
+          const guardian = yield* driver.maintainReconciliation.pipe(Effect.forkChild({ startImmediately: true }))
+          yield* Deferred.await(entered)
+          const overlappingAdvance = yield* driver.advance.pipe(
+            Effect.orDie,
+            Effect.forkChild({ startImmediately: true }),
+          )
+          yield* Effect.yieldNow
+          expect(publicationReads).toBe(2)
+          yield* Deferred.succeed(gate, undefined)
+          yield* Fiber.join(guardian)
+          yield* Fiber.join(overlappingAdvance)
+          reconciliationEntered = undefined
+          reconciliationGate = undefined
         }),
     })
     mutationPhase = true
@@ -4105,12 +4135,15 @@ describe('OBSERVE runtime composition', () => {
     mutationPhase = false
 
     expect(externalNextDelayMs).toBe(100)
-    expect(externalObservations).toHaveLength(2)
+    expect(externalObservations).toHaveLength(3)
     expect(externalObservations[0]).toMatchObject({ result: 'SUCCESS', outcome: 'NO_PUBLICATION' })
     expect(externalObservations[1]).toMatchObject({ result: 'SUCCESS', outcome: 'NO_PUBLICATION' })
-    expect(mutationReconciliations).toBe(2)
+    expect(externalObservations[2]).toMatchObject({ result: 'SUCCESS', outcome: 'NO_PUBLICATION' })
+    expect(mutationReconciliations).toBe(3)
     expect(mutationEvents.indexOf('reconcile:1')).toBeLessThan(mutationEvents.indexOf('publication:1'))
     expect(mutationEvents.indexOf('reconcile:2')).toBeLessThan(mutationEvents.indexOf('publication:2'))
+    expect(mutationEvents.indexOf('reconcile:3')).toBeLessThan(mutationEvents.indexOf('publication:3'))
+    expect(mutationEvents.filter((event) => event.startsWith('publication:'))).toHaveLength(3)
 
     mutationEvents.length = 0
     mutationReconciliations = 0
@@ -4180,6 +4213,97 @@ describe('OBSERVE runtime composition', () => {
     )
     expect(mutationEvents.indexOf('reconcile:1')).toBeLessThan(mutationEvents.indexOf('publication:1'))
     expect(authorityRestrictions).toBe(1)
+    authorityRestrictions = 0
+
+    mutationEvents.length = 0
+    mutationReconciliations = 0
+    publicationReads = 0
+    const guardianRecoveryObservations: Parameters<Parameters<typeof mutationStartup>[0]['recordPass']>[0][] = []
+    const guardianRecoveryLogs: unknown[] = []
+    const guardianRecoveryLogger = Logger.make<unknown, void>((entry) => {
+      guardianRecoveryLogs.push(entry.message)
+    })
+    const guardianRecoveryStartup = makeMutationAutonomousCycleStartup({
+      accountId,
+      authorityGenerationHash: generationHash,
+      pollIntervalMs: 100,
+      reconciliationIntervalMs: 100,
+      reconciliationPassTimeoutMs: 30_000,
+      strategy: fixtureRuntime,
+      executionProgram: sandboxExecutionProgram(),
+      interpretCycleDriver: (driver) =>
+        Effect.gen(function* () {
+          yield* driver.advance.pipe(Effect.orDie)
+          nextReconciliationFailure = new ExecutionStoreError({
+            operation: 'reconciliation',
+            failure: 'query',
+            message: 'guardian reconciliation persistence failed',
+          })
+          yield* TestClock.adjust(100)
+          yield* driver.maintainReconciliation
+          yield* TestClock.adjust(100)
+          yield* driver.maintainReconciliation
+        }),
+    })
+    mutationPhase = true
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        yield* TestClock.setTime(Date.parse(reconciledAt))
+        const loop = yield* guardianRecoveryStartup({
+          qualificationRunId: 'd'.repeat(64),
+          recordPass: (observation) =>
+            Effect.sync(() => {
+              guardianRecoveryObservations.push(observation)
+              mutationEvents.push(`guardian-recovery-observe:${guardianRecoveryObservations.length.toString()}`)
+            }),
+        })
+        yield* loop.pipe(
+          Effect.provideService(BrokerRead, brokerRead),
+          Effect.provideService(CycleStore, cycleStore),
+          Effect.provideService(MarketData, missingPublicationMarketData),
+          Effect.provideService(BrokerEventStore, executionStore),
+          Effect.provideService(FillAccountingStore, executionStore),
+          Effect.provideService(ValuationStore, executionStore),
+          Effect.provideService(ReconciliationStore, executionStore),
+          Effect.provideService(AuthorityGenerationStore, executionStore),
+          Effect.provideService(AuthorityRestrictionStore, executionStore),
+          Effect.provideService(WriterFence, writerFence),
+          Effect.provideService(IntentStore, intentStore),
+          Effect.provideService(MutationStore, mutationStore),
+        )
+      }).pipe(Effect.provide(Layer.merge(Logger.layer([guardianRecoveryLogger]), TestClock.layer()))),
+    )
+    mutationPhase = false
+
+    expect(guardianRecoveryObservations).toEqual([
+      expect.objectContaining({ result: 'SUCCESS', outcome: 'NO_PUBLICATION' }),
+    ])
+    expect(mutationEvents).toContain('reconcile-failed')
+    expect(mutationEvents.indexOf('reconcile-failed')).toBeGreaterThan(
+      mutationEvents.indexOf('guardian-recovery-observe:1'),
+    )
+    expect(mutationEvents.indexOf('reconcile:2')).toBeGreaterThan(mutationEvents.indexOf('reconcile-failed'))
+    expect(publicationReads).toBe(1)
+    expect(mutationReconciliations).toBe(2)
+    expect(authorityRestrictions).toBe(1)
+    expect(guardianRecoveryLogs).toContainEqual([
+      'Bayn Restate reconciliation guardian failed',
+      expect.objectContaining({
+        _tag: 'CycleRunnerError',
+        operation: 'reconcile-not-due',
+        cause: expect.objectContaining({
+          _tag: 'CycleNotDueReconciliationError',
+          cause: expect.objectContaining({
+            _tag: 'OperationalError',
+            cause: expect.objectContaining({
+              _tag: 'ExecutionStoreError',
+              operation: 'reconciliation',
+              failure: 'query',
+            }),
+          }),
+        }),
+      }),
+    ])
     authorityRestrictions = 0
 
     mutationEvents.length = 0

--- a/services/bayn/src/observe-composition.ts
+++ b/services/bayn/src/observe-composition.ts
@@ -1,4 +1,4 @@
-import { Clock, Data, Duration, Effect, Option, pipe, Ref, Result } from 'effect'
+import { Clock, Data, Duration, Effect, Option, pipe, Ref, Result, Semaphore } from 'effect'
 
 import type { AutonomousCycleLoop, AutonomousCycleStartup } from './app'
 import { BrokerRead, type BrokerReadShape, type MarketCalendarQuery } from './broker/alpaca'
@@ -2169,7 +2169,7 @@ const waitAfterMutationPass = (
     }),
   )
 
-const waitAfterMutationFailure = (
+const maintainMutationReconciliation = (
   input: ObserveAutonomousCycleInput,
   startup: Parameters<AutonomousCycleStartup>[0],
   cadence: Ref.Ref<ReconciliationCadenceState>,
@@ -2187,6 +2187,8 @@ const waitAfterMutationFailure = (
       ),
     ),
   )
+
+const waitAfterMutationFailure = maintainMutationReconciliation
 
 const observeMutationCycleResult = (
   input: ObserveAutonomousCycleInput,
@@ -2216,6 +2218,8 @@ export type RecoveryFirstCycleAdvance = {
 
 export type RecoveryFirstCycleDriver = {
   readonly advance: Effect.Effect<RecoveryFirstCycleAdvance, CycleRunnerError, RecoveryFirstRuntime>
+  /** Keeps broker/accounting truth fresh while an external lifecycle owner is delayed between commands. */
+  readonly maintainReconciliation: Effect.Effect<void, never, RecoveryFirstRuntime>
   /** The external owner must not delay the next command beyond either the cycle or reconciliation cadence. */
   readonly nextDelayMs: number
   readonly wait: (advance: RecoveryFirstCycleAdvance) => Effect.Effect<void, never, RecoveryFirstRuntime>
@@ -2240,6 +2244,7 @@ const makeRecoveryFirstCycleDriver = (
 ): Effect.Effect<RecoveryFirstCycleDriver, never, RecoveryFirstRuntime> =>
   Effect.gen(function* () {
     const cadence = yield* Ref.make<ReconciliationCadenceState>({})
+    const operationPermit = yield* Semaphore.make(1)
     const cyclePassTimeoutMs = Math.min(input.reconciliationPassTimeoutMs, input.reconciliationIntervalMs)
     const reconcile = boundedReconciliationPass(input.reconciliationPassTimeoutMs).pipe(
       Effect.tap(() => markMutationReconciliationCompleted(cadence)),
@@ -2283,7 +2288,7 @@ const makeRecoveryFirstCycleDriver = (
           ),
       }),
     )
-    const advance =
+    const advance = operationPermit.withPermit(
       input.interpretCycleDriver === undefined
         ? advanceCycle
         : reconcileMutationBeforeExternallyDrivenAdvance(input, cadence, reconcile).pipe(
@@ -2297,9 +2302,25 @@ const makeRecoveryFirstCycleDriver = (
                 ),
               onSuccess: () => advanceCycle,
             }),
-          )
+          ),
+    )
+    const maintainReconciliation = operationPermit.withPermit(
+      reconcileMutationBeforeExternallyDrivenAdvance(input, cadence, reconcile).pipe(
+        Effect.catch((error) =>
+          // Reconciliation persistence owns guardian readiness; do not replace Restate lifecycle progress.
+          Effect.logError('Bayn Restate reconciliation guardian failed', error).pipe(
+            Effect.annotateLogs({
+              operation: error.operation,
+              failure: error.failure,
+              reason: error.message,
+            }),
+          ),
+        ),
+      ),
+    )
     return {
       advance,
+      maintainReconciliation,
       nextDelayMs: recoveryFirstCycleNextDelayMs(input),
       wait: (completed) =>
         completed.result === undefined


### PR DESCRIPTION
## Summary

- keep broker and accounting reconciliation fresh when the external Restate lifecycle owner is delayed between commands
- serialize the reconciliation guardian with lifecycle advances so no cycle can publish or mutate across an in-flight reconciliation
- own the guardian fiber with the Bayn service scope and record typed reconciliation failures through existing cycle observability

## Related Issues

PROOMPT-405

## Testing

- `bun test services/bayn/src/observe-composition.test.ts -t "persists writer-fenced NOT_DUE reconciliation"`
- `bun test services/bayn/src/composition.test.ts -t "owns the Restate reconciliation guardian"`
- `bun run --filter @proompteng/bayn test` (1,117 pass, 165 PostgreSQL-gated skips, 0 fail)
- `bun run --filter @proompteng/bayn tsc`
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn build`
- `bun run --filter @proompteng/bayn test:postgres` (local suites skipped because `BAYN_TEST_POSTGRES_URL` is CI-only; hosted PostgreSQL integration remains required)

## Breaking Changes

None.

## Checklist

- [x] Testing section documents the exact validation performed (or `N/A` with justification).
- [x] Screenshots and Breaking Changes sections are handled appropriately (removed or filled in).
- [x] Documentation, release notes, and follow-ups are updated or tracked.
