### PR TITLE
fix(bayn): complete durable Restate lifecycle

### DIFF
--- a/services/bayn/migrations/0034_terminal_paper_generation_rollover.ts
+++ b/services/bayn/migrations/0034_terminal_paper_generation_rollover.ts
@@ -1,0 +1,176 @@
+import { Effect } from 'effect'
+import { SqlClient } from 'effect/unstable/sql'
+
+export default Effect.gen(function* () {
+  const sql = yield* SqlClient.SqlClient
+
+  yield* sql`
+    CREATE OR REPLACE FUNCTION research_paper_rearm_eligible(
+      candidate_generation_hash text,
+      candidate_authority_version bigint,
+      candidate_activated_at timestamptz
+    )
+    RETURNS boolean
+    LANGUAGE sql
+    STABLE
+    AS $function$
+      SELECT EXISTS (
+        SELECT 1
+        FROM authority_state AS state
+        JOIN authority_generations AS previous_generation
+          ON previous_generation.generation_hash = state.generation_hash
+        JOIN authority_generations AS candidate_generation
+          ON candidate_generation.generation_hash = candidate_generation_hash
+        JOIN LATERAL (
+          SELECT reconciliation.*
+          FROM reconciliations AS reconciliation
+          WHERE reconciliation.account_id = previous_generation.account_id
+          ORDER BY reconciliation.reconciled_at DESC, reconciliation.reconciliation_id COLLATE "C" DESC
+          LIMIT 1
+        ) AS reconciliation ON true
+        WHERE state.singleton
+          AND (
+            (
+              state.maximum = 'PAPER'
+              AND state.effective = 'OBSERVE'
+              AND state.kill_state = 'ACTIVE'
+              AND (
+                state.reason LIKE 'PAPER autonomous cycle loop restricted effective authority:%'
+                OR (
+                  state.reason IN (
+                    'PAPER episode restricted effective authority: flat exact receipt finalized',
+                    'PAPER activation lease restricted effective authority: immutable activation request expired'
+                  )
+                  AND EXISTS (
+                    SELECT 1
+                    FROM autonomous_forward_performance_receipts AS receipt
+                    WHERE receipt.authority_generation_hash = previous_generation.generation_hash
+                  )
+                )
+              )
+            )
+            OR (
+              state.maximum = 'PAPER'
+              AND state.effective = 'PAPER'
+              AND state.kill_state = 'CLEAR'
+              AND state.reason IS NULL
+            )
+          )
+          AND state.version + 1 = candidate_authority_version
+          AND previous_generation.maximum = 'PAPER'
+          AND previous_generation.activation_schema_version IN (
+            'bayn.paper-authority-generation.v2',
+            'bayn.paper-authority-generation.v3'
+          )
+          AND CASE previous_generation.activation_schema_version
+            WHEN 'bayn.paper-authority-generation.v2' THEN previous_generation.qualification_run_id IS NOT NULL
+            WHEN 'bayn.paper-authority-generation.v3' THEN previous_generation.proof_plan_hash IS NOT NULL
+            ELSE false
+          END
+          AND candidate_generation.previous_generation_hash = previous_generation.generation_hash
+          AND candidate_generation.maximum = 'OBSERVE'
+          AND candidate_generation.activation_schema_version IS NULL
+          AND candidate_generation.authority_version = candidate_authority_version
+          AND candidate_generation.activated_at = candidate_activated_at
+          AND candidate_generation.broker_identity_schema_version = previous_generation.broker_identity_schema_version
+          AND candidate_generation.broker_identity_hash = previous_generation.broker_identity_hash
+          AND candidate_generation.broker_provider = previous_generation.broker_provider
+          AND candidate_generation.broker_environment = 'sandbox'
+          AND candidate_generation.broker_environment = previous_generation.broker_environment
+          AND candidate_generation.account_id = previous_generation.account_id
+          AND reconciliation.status = 'EXACT'
+          AND reconciliation.expected_hash = reconciliation.observed_hash
+          AND jsonb_array_length(reconciliation.discrepancies) = 0
+          AND reconciliation.reconciled_at > state.updated_at
+          AND reconciliation.reconciled_at < candidate_activated_at
+          AND NOT EXISTS (
+            SELECT 1
+            FROM autonomous_cycles AS cycle
+            WHERE cycle.qualification_run_id = CASE previous_generation.activation_schema_version
+                WHEN 'bayn.paper-authority-generation.v2' THEN previous_generation.qualification_run_id
+                WHEN 'bayn.paper-authority-generation.v3' THEN previous_generation.proof_plan_hash
+                ELSE NULL
+              END
+              AND cycle.account_id = previous_generation.account_id
+              AND cycle.state IN ('PENDING', 'ACTIVE')
+          )
+          AND (
+            NOT EXISTS (
+              SELECT 1
+              FROM intents AS intent
+              WHERE intent.authority_generation_hash = previous_generation.generation_hash
+            )
+            OR (
+              EXISTS (
+                SELECT 1
+                FROM intents AS intent
+                WHERE intent.authority_generation_hash = previous_generation.generation_hash
+              )
+              AND NOT EXISTS (
+                SELECT 1
+                FROM intents AS intent
+                WHERE intent.authority_generation_hash = previous_generation.generation_hash
+                  AND intent.state <> 'TERMINAL'
+              )
+              AND NOT paper_account_has_unresolved_mutation(
+                previous_generation.account_id,
+                reconciliation.reconciled_at
+              )
+              AND reconciliation.reconciled_at > COALESCE(
+                (
+                  SELECT max(intent.updated_at)
+                  FROM intents AS intent
+                  WHERE intent.authority_generation_hash = previous_generation.generation_hash
+                ),
+                state.updated_at
+              )
+              AND reconciliation.reconciled_at > COALESCE(
+                (
+                  SELECT max(event.occurred_at)
+                  FROM mutation_events AS event
+                  JOIN intents AS intent ON intent.intent_id = event.intent_id
+                  WHERE intent.authority_generation_hash = previous_generation.generation_hash
+                ),
+                state.updated_at
+              )
+              AND EXISTS (
+                SELECT 1
+                FROM position_snapshots AS snapshot
+                WHERE snapshot.account_id = previous_generation.account_id
+                  AND snapshot.position_count = 0
+                  AND snapshot.observed_at <= reconciliation.reconciled_at
+                  AND NOT EXISTS (
+                    SELECT 1
+                    FROM position_snapshots AS later
+                    WHERE later.account_id = snapshot.account_id
+                      AND (
+                        later.observed_at > snapshot.observed_at
+                        OR (
+                          later.observed_at = snapshot.observed_at
+                          AND later.snapshot_id COLLATE "C" > snapshot.snapshot_id COLLATE "C"
+                        )
+                      )
+                  )
+              )
+              AND NOT EXISTS (
+                SELECT 1
+                FROM (
+                  SELECT DISTINCT ON (broker_order.broker_order_id)
+                    broker_order.intent_id,
+                    broker_order.status,
+                    event.observed_at
+                  FROM orders AS broker_order
+                  JOIN broker_events AS event ON event.event_id = broker_order.event_id
+                  WHERE broker_order.account_id = previous_generation.account_id
+                  ORDER BY broker_order.broker_order_id, event.source_sequence DESC
+                ) AS latest_order
+                WHERE latest_order.intent_id IS NULL
+                  OR latest_order.status IN ('NEW', 'PARTIALLY_FILLED', 'PENDING')
+                  OR latest_order.observed_at > reconciliation.reconciled_at
+              )
+            )
+          )
+      )
+    $function$
+  `
+})

--- a/services/bayn/src/blocked-generation-recovery.ts
+++ b/services/bayn/src/blocked-generation-recovery.ts
@@ -23,7 +23,7 @@ export const paperObserveSuccessorGenerationHash = (input: {
     previousPaperGenerationHash: input.previousPaperGenerationHash,
   })
 
-export type BlockedGenerationRolloverReceipt =
+export type TerminalGenerationRolloverReceipt =
   | { readonly _tag: 'NotRequired' }
   | {
       readonly _tag: 'RolledOver'
@@ -35,7 +35,7 @@ export type BlockedGenerationRolloverReceipt =
       readonly terminalIntentCount: number
     }
 
-export interface BlockedGenerationRecoveryInput<R> {
+export interface TerminalGenerationRecoveryInput<R> {
   readonly accountId: string
   readonly blockedIntents: BlockedCycleIntentStoreShape
   readonly authorityStore: AuthorityGenerationStoreShape
@@ -47,14 +47,14 @@ export interface BlockedGenerationRecoveryInput<R> {
 const recoveryError = (message: string, cause?: unknown): OperationalError =>
   new OperationalError({
     component: 'strategy',
-    operation: 'blocked-generation-recovery',
+    operation: 'terminal-generation-recovery',
     message,
     retryable: false,
-    cause: cause === undefined ? { _tag: 'BlockedGenerationRecoveryRejected' } : cause,
+    cause: cause === undefined ? { _tag: 'TerminalGenerationRecoveryRejected' } : cause,
   })
 
 const settlementNeedsMutationRecovery = (error: OperationalError): boolean =>
-  error.operation === 'blocked-generation-recovery' &&
+  error.operation === 'terminal-generation-recovery' &&
   error.cause instanceof BlockedCycleIntentStoreError &&
   error.cause.failure === 'invariant'
 
@@ -66,9 +66,9 @@ const settlementNeedsMutationRecovery = (error: OperationalError): boolean =>
 export const recoverRestrictedGenerationBeforeRollover = <A, E, R>(input: {
   readonly advance: Effect.Effect<A, E, R>
   readonly wait: (advance: A) => Effect.Effect<void, never, R>
-  readonly settle: Effect.Effect<BlockedGenerationRolloverReceipt, OperationalError, R>
-}): Effect.Effect<BlockedGenerationRolloverReceipt, E | OperationalError, R> => {
-  const recover = (): Effect.Effect<BlockedGenerationRolloverReceipt, E | OperationalError, R> =>
+  readonly settle: Effect.Effect<TerminalGenerationRolloverReceipt, OperationalError, R>
+}): Effect.Effect<TerminalGenerationRolloverReceipt, E | OperationalError, R> => {
+  const recover = (): Effect.Effect<TerminalGenerationRolloverReceipt, E | OperationalError, R> =>
     input.advance.pipe(
       Effect.flatMap((advanced) =>
         input.settle.pipe(
@@ -76,7 +76,7 @@ export const recoverRestrictedGenerationBeforeRollover = <A, E, R>(input: {
           Effect.flatMap((receipt) =>
             receipt._tag === 'RolledOver'
               ? Effect.succeed(receipt)
-              : Effect.fail(recoveryError('restricted generation recovery found no blocked generation to roll over')),
+              : Effect.fail(recoveryError('restricted generation recovery found no terminal generation to roll over')),
           ),
         ),
       ),
@@ -88,17 +88,17 @@ export const recoverRestrictedGenerationBeforeRollover = <A, E, R>(input: {
  * Settles the terminal generation first, then requires later exact reconciliation before clearing the kill in a new
  * OBSERVE generation. The transaction boundary intentionally excludes reconciliation and authority rollover.
  */
-export const recoverBlockedGenerationToObserve = <R>(
-  input: BlockedGenerationRecoveryInput<R>,
-): Effect.Effect<BlockedGenerationRolloverReceipt, OperationalError, R> =>
+export const recoverTerminalGenerationToObserve = <R>(
+  input: TerminalGenerationRecoveryInput<R>,
+): Effect.Effect<TerminalGenerationRolloverReceipt, OperationalError, R> =>
   Effect.gen(function* () {
     const observedAt = yield* currentUtcInstant
     const settlement = yield* input.writerFence
-      .transaction(input.blockedIntents.settleCurrentBlockedGeneration({ accountId: input.accountId, observedAt }))
-      .pipe(Effect.mapError((cause) => recoveryError('blocked generation intent settlement failed', cause)))
-    if (settlement._tag === 'NoBlockedGeneration') return { _tag: 'NotRequired' }
+      .transaction(input.blockedIntents.settleCurrentTerminalGeneration({ accountId: input.accountId, observedAt }))
+      .pipe(Effect.mapError((cause) => recoveryError('terminal generation intent settlement failed', cause)))
+    if (settlement._tag === 'NoTerminalGeneration') return { _tag: 'NotRequired' }
 
-    yield* Effect.logWarning('Bayn settled a terminal blocked generation before authority rollover').pipe(
+    yield* Effect.logWarning('Bayn settled a terminal PAPER generation before authority rollover').pipe(
       Effect.annotateLogs({
         service: 'bayn',
         previousGenerationHash: settlement.authorityGenerationHash,
@@ -114,20 +114,20 @@ export const recoverBlockedGenerationToObserve = <R>(
       paperObserveSuccessorGenerationHash({
         previousPaperGenerationHash: settlement.authorityGenerationHash,
       }),
-    ).pipe(Effect.mapError((cause) => recoveryError('blocked generation OBSERVE successor hashing failed', cause)))
+    ).pipe(Effect.mapError((cause) => recoveryError('terminal generation OBSERVE successor hashing failed', cause)))
     const authority = yield* input.authorityStore
       .ensureAuthorityGeneration({ generationHash: successorGenerationHash, maximum: Authority.Observe })
-      .pipe(Effect.mapError((cause) => recoveryError('blocked generation OBSERVE rollover failed', cause)))
+      .pipe(Effect.mapError((cause) => recoveryError('terminal generation OBSERVE rollover failed', cause)))
     if (
       authority.generationHash !== successorGenerationHash ||
       authority.maximum !== Authority.Observe ||
       authority.effective !== Authority.Observe ||
       authority.kill !== KillState.Clear
     ) {
-      return yield* recoveryError('blocked generation rollover did not return clear OBSERVE authority')
+      return yield* recoveryError('terminal generation rollover did not return clear OBSERVE authority')
     }
 
-    yield* Effect.logInfo('Bayn completed blocked generation rollover to clear OBSERVE').pipe(
+    yield* Effect.logInfo('Bayn completed terminal generation rollover to clear OBSERVE').pipe(
       Effect.annotateLogs({
         service: 'bayn',
         previousGenerationHash: settlement.authorityGenerationHash,

--- a/services/bayn/src/composition.test.ts
+++ b/services/bayn/src/composition.test.ts
@@ -28,6 +28,7 @@ import { provideTestLayer } from './effect-test-support'
 import {
   ApplicationPlatformLive,
   closedCycleReceiptEmissionAllowed,
+  decideExecutionLifecycleMaintenance,
   finalizePaperEpisode,
   observeCycleGenerationHash,
   paperReceiptFinalizationWindowOpen,
@@ -35,7 +36,7 @@ import {
   recoverPaperActivationGeneration,
   refreshResearchPaperActivationReconciliation,
   restrictExpiredPaperActivation,
-  retryClosedCycleReceipts,
+  runExecutionLifecycleMaintenance,
   runRestateLifecycleWithReconciliationGuardian,
 } from './composition'
 import { makeApplicationPlan, type ApplicationPlanFor } from './app'
@@ -63,7 +64,6 @@ import { BlockedCycleIntentStoreError, type BlockedCycleIntentStoreShape } from 
 import type { WriterFenceService } from './execution/writer-fence'
 import { OperationalError } from './errors'
 import { canonicalHashV1Result } from './hash'
-import { utcInstantFromEpochMillis } from './time'
 import { loadObserveRiskPolicy, paperEpisodeReceiptFinalizationExpiresAt } from './observe-composition'
 import { initialState } from './runtime-state'
 import { fixtureProtocol } from './test-fixtures'
@@ -373,90 +373,82 @@ describe('Bayn PAPER receipt retry boundary', () => {
     expect(closedCycleReceiptEmissionAllowed(cutoffAt, cutoffAt)).toBe(true)
   })
 
-  test('keeps retrying through the close lease instead of a fixed attempt count', async () => {
-    const startAt = Date.parse('2026-08-03T12:00:00.000Z')
-    const cutoffAt = utcInstantFromEpochMillis(startAt + 1_000)
-    const observedAt: string[] = []
+  test('derives due expiry and receipt work from immutable episode deadlines', () => {
+    const cutoffAt = '2026-08-03T12:00:00.000Z'
+    const closeExpiresAt = '2026-08-03T12:15:00.000Z'
+    const finalizationExpiresAt = '2026-08-03T12:30:00.000Z'
 
-    await Effect.runPromise(
+    expect(
+      decideExecutionLifecycleMaintenance({
+        cutoffAt,
+        closeExpiresAt,
+        finalizationExpiresAt,
+        observedAt: '2026-08-03T11:59:59.999Z',
+      }),
+    ).toEqual({ restrictExpiredAuthority: false, attemptReceiptFinalization: false })
+    expect(
+      decideExecutionLifecycleMaintenance({
+        cutoffAt,
+        closeExpiresAt,
+        finalizationExpiresAt,
+        observedAt: cutoffAt,
+      }),
+    ).toEqual({ restrictExpiredAuthority: false, attemptReceiptFinalization: true })
+    expect(
+      decideExecutionLifecycleMaintenance({
+        cutoffAt,
+        closeExpiresAt,
+        finalizationExpiresAt,
+        observedAt: closeExpiresAt,
+      }),
+    ).toEqual({ restrictExpiredAuthority: true, attemptReceiptFinalization: true })
+    expect(
+      decideExecutionLifecycleMaintenance({
+        cutoffAt,
+        closeExpiresAt,
+        finalizationExpiresAt,
+        observedAt: '2026-08-03T12:30:00.001Z',
+      }),
+    ).toEqual({ restrictExpiredAuthority: true, attemptReceiptFinalization: false })
+  })
+
+  test('executes due expiry and receipt work in one writer-fenced lifecycle command', async () => {
+    const operations: string[] = []
+    const authorityRestrictionStore: AuthorityRestrictionStoreShape = {
+      restrictAuthority: () =>
+        Effect.sync(() => {
+          operations.push('restrict')
+        }),
+    }
+    const writerFence: WriterFenceService = {
+      backendPid: 1,
+      check: Effect.void,
+      transaction: <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+        Effect.sync(() => {
+          operations.push('fence')
+        }).pipe(Effect.andThen(effect)),
+    }
+
+    const disposition = await Effect.runPromise(
       Effect.gen(function* () {
-        yield* TestClock.setTime(startAt)
-        const retry = yield* retryClosedCycleReceipts(
-          (cycleId, current) =>
+        yield* TestClock.setTime(Date.parse('2026-09-03T20:15:00.000Z'))
+        return yield* runExecutionLifecycleMaintenance(
+          researchRequest,
+          authorityRestrictionStore,
+          writerFence,
+          (cycleId, observedAt) =>
             Effect.sync(() => {
               expect(cycleId).toBeUndefined()
-              observedAt.push(current)
-              return observedAt.length >= 17
+              expect(observedAt).toBe('2026-09-03T20:15:00.000Z')
+              operations.push('finalize')
+              return true
             }),
-          cutoffAt,
-          utcInstantFromEpochMillis(startAt + 17_000),
-          1_000,
-        ).pipe(Effect.forkChild({ startImmediately: true }))
-        yield* Effect.yieldNow
-        yield* TestClock.adjust(17_000)
-        yield* Fiber.join(retry)
+        )
       }).pipe(provideTestLayer(TestClock.layer())),
     )
 
-    expect(observedAt).toHaveLength(17)
-    expect(observedAt.at(-1)).toBe(utcInstantFromEpochMillis(startAt + 17_000))
-  })
-
-  test('keeps retrying until close settlement and reconciliation produce a receipt', async () => {
-    const startAt = Date.parse('2026-08-03T12:00:00.000Z')
-    const cutoffAt = utcInstantFromEpochMillis(startAt + 1_000)
-    const observedAt: string[] = []
-
-    await Effect.runPromise(
-      Effect.gen(function* () {
-        yield* TestClock.setTime(startAt)
-        const retry = yield* retryClosedCycleReceipts(
-          (_cycleId, current) =>
-            Effect.sync(() => {
-              observedAt.push(current)
-              return observedAt.length >= 8
-            }),
-          cutoffAt,
-          utcInstantFromEpochMillis(startAt + 8_000),
-          1_000,
-        ).pipe(Effect.forkChild({ startImmediately: true }))
-        yield* Effect.yieldNow
-        yield* TestClock.adjust(8_000)
-        yield* Fiber.join(retry)
-      }).pipe(provideTestLayer(TestClock.layer())),
-    )
-
-    expect(observedAt).toHaveLength(8)
-    expect(observedAt.at(-1)).toBe(utcInstantFromEpochMillis(startAt + 8_000))
-  })
-
-  test('stops receipt retries at the bounded finalization lease when evidence never becomes eligible', async () => {
-    const startAt = Date.parse('2026-08-03T12:00:00.000Z')
-    const cutoffAt = utcInstantFromEpochMillis(startAt + 1_000)
-    const retryUntilAt = utcInstantFromEpochMillis(startAt + 4_000)
-    const observedAt: string[] = []
-
-    await Effect.runPromise(
-      Effect.gen(function* () {
-        yield* TestClock.setTime(startAt)
-        const retry = yield* retryClosedCycleReceipts(
-          (_cycleId, current) =>
-            Effect.sync(() => {
-              observedAt.push(current)
-              return false
-            }),
-          cutoffAt,
-          retryUntilAt,
-          1_000,
-        ).pipe(Effect.forkChild({ startImmediately: true }))
-        yield* Effect.yieldNow
-        yield* TestClock.adjust(10_000)
-        yield* Fiber.join(retry)
-      }).pipe(provideTestLayer(TestClock.layer())),
-    )
-
-    expect(observedAt).toHaveLength(4)
-    expect(observedAt.at(-1)).toBe(retryUntilAt)
+    expect(operations).toEqual(['fence', 'restrict', 'finalize'])
+    expect(disposition).toBe('COMPLETED')
   })
 
   test('leaves a bounded post-close finalization window for late settlement', () => {

--- a/services/bayn/src/composition.test.ts
+++ b/services/bayn/src/composition.test.ts
@@ -10,6 +10,7 @@ import {
   FileSystem,
   Layer,
   Logger,
+  Option,
   Redacted,
   Ref,
   References,
@@ -33,6 +34,7 @@ import {
   observeCycleGenerationHash,
   paperReceiptFinalizationWindowOpen,
   prepareOrRecoverResearchPaperActivation,
+  readCompletedExecutionLifecycle,
   recoverPaperActivationGeneration,
   refreshResearchPaperActivationReconciliation,
   restrictExpiredPaperActivation,
@@ -486,6 +488,68 @@ describe('Bayn PAPER startup recovery boundary', () => {
         effective: Authority.Paper,
       }),
     ).toEqual(Result.fail('OBSERVE cycle startup requires current effective OBSERVE authority'))
+  })
+
+  test('recognizes the receipt-completed OBSERVE successor before retrying PAPER recovery on restart', async () => {
+    const successorGenerationHash = Result.getOrThrow(
+      paperObserveSuccessorGenerationHash({
+        previousPaperGenerationHash: continuationGeneration.generationHash,
+      }),
+    )
+    const receiptHash = hash('receipt')
+    const authorityStore: AuthorityGenerationStoreShape = {
+      ensureAuthorityGeneration: () => Effect.die(new Error('completed execution must not mutate authority')),
+      readAuthorityState: Effect.succeed({
+        schemaVersion: 'bayn.paper-authority.v1',
+        generationHash: successorGenerationHash,
+        maximum: Authority.Observe,
+        effective: Authority.Observe,
+        kill: KillState.Clear,
+        version: 3,
+        updatedAt: '2026-09-03T20:01:00.000Z',
+      }),
+      readAuthorityGenerationLineage: (generationHash) =>
+        Effect.succeed(
+          generationHash === successorGenerationHash
+            ? {
+                generationHash,
+                previousGenerationHash: continuationGeneration.generationHash,
+                maximum: Authority.Observe,
+              }
+            : undefined,
+        ),
+      readResearchAuthorityGeneration: (generationHash) =>
+        Effect.succeed(generationHash === continuationGeneration.generationHash ? continuationGeneration : undefined),
+    }
+    const readReceiptHash = (generationHash: string) =>
+      Effect.succeed(
+        generationHash === continuationGeneration.generationHash ? Option.some(receiptHash) : Option.none<string>(),
+      )
+
+    const completed = await Effect.runPromise(
+      readCompletedExecutionLifecycle(
+        continuationApplicationPlan,
+        continuationRequest,
+        researchBuildContinuation,
+        authorityStore,
+        readReceiptHash,
+      ),
+    )
+    const withoutReceipt = await Effect.runPromise(
+      readCompletedExecutionLifecycle(
+        continuationApplicationPlan,
+        continuationRequest,
+        researchBuildContinuation,
+        authorityStore,
+        () => Effect.succeed(Option.none()),
+      ),
+    )
+
+    expect(completed).toEqual({
+      authorityGenerationHash: continuationGeneration.generationHash,
+      receiptHash,
+    })
+    expect(withoutReceipt).toBeUndefined()
   })
 
   test('resumes only the exact active research generation across a reviewed build change', async () => {

--- a/services/bayn/src/composition.test.ts
+++ b/services/bayn/src/composition.test.ts
@@ -20,7 +20,7 @@ import { TestClock } from 'effect/testing'
 import { config, fixtureRuntime } from './app-test-support'
 import {
   paperObserveSuccessorGenerationHash,
-  recoverBlockedGenerationToObserve,
+  recoverTerminalGenerationToObserve,
   recoverRestrictedGenerationBeforeRollover,
 } from './blocked-generation-recovery'
 import { provideTestLayer } from './effect-test-support'
@@ -809,11 +809,11 @@ describe('Bayn PAPER startup recovery boundary', () => {
     )
     const blockedIntents: BlockedCycleIntentStoreShape = {
       terminalizeUntouchedApproved: () => Effect.die(new Error('cycle terminalization is outside startup recovery')),
-      settleCurrentBlockedGeneration: () =>
+      settleCurrentTerminalGeneration: () =>
         Effect.sync(() => {
           operations.push('settle')
           return {
-            _tag: 'BlockedGenerationSettled' as const,
+            _tag: 'TerminalGenerationSettled' as const,
             authorityGenerationHash: previousGenerationHash,
             blockedCycleCount: 1,
             blockedIntentCount: 0,
@@ -847,7 +847,7 @@ describe('Bayn PAPER startup recovery boundary', () => {
     const receipt = await Effect.runPromise(
       Effect.gen(function* () {
         yield* TestClock.setTime(Date.parse('2026-08-10T19:00:00.000Z'))
-        return yield* recoverBlockedGenerationToObserve({
+        return yield* recoverTerminalGenerationToObserve({
           accountId: 'paper-account',
           blockedIntents,
           authorityStore,
@@ -884,22 +884,22 @@ describe('Bayn PAPER startup recovery boundary', () => {
     expect(nextEpisode).not.toBe(first)
   })
 
-  test('does not reconcile or rotate when no blocked generation exists', async () => {
+  test('does not reconcile or rotate when no terminal generation exists', async () => {
     const blockedIntents: BlockedCycleIntentStoreShape = {
       terminalizeUntouchedApproved: () => Effect.die(new Error('cycle terminalization is outside startup recovery')),
-      settleCurrentBlockedGeneration: () => Effect.succeed({ _tag: 'NoBlockedGeneration' }),
+      settleCurrentTerminalGeneration: () => Effect.succeed({ _tag: 'NoTerminalGeneration' }),
     }
     const authorityStore: AuthorityGenerationStoreShape = {
-      ensureAuthorityGeneration: () => Effect.die(new Error('no blocked generation must not rotate authority')),
+      ensureAuthorityGeneration: () => Effect.die(new Error('no terminal generation must not rotate authority')),
     }
 
     const receipt = await Effect.runPromise(
-      recoverBlockedGenerationToObserve({
+      recoverTerminalGenerationToObserve({
         accountId: 'paper-account',
         blockedIntents,
         authorityStore,
         writerFence: unusedWriterFence,
-        reconcileAfterSettlement: Effect.die(new Error('no blocked generation must not reconcile')),
+        reconcileAfterSettlement: Effect.die(new Error('no terminal generation must not reconcile')),
       }),
     )
 
@@ -923,7 +923,7 @@ describe('Bayn PAPER startup recovery boundary', () => {
             ? Effect.fail(
                 new OperationalError({
                   component: 'strategy',
-                  operation: 'blocked-generation-recovery',
+                  operation: 'terminal-generation-recovery',
                   message: 'blocked generation intent settlement failed',
                   retryable: false,
                   cause: new BlockedCycleIntentStoreError({
@@ -972,7 +972,7 @@ describe('Bayn PAPER startup recovery boundary', () => {
     )
 
     expect(advances).toBe(1)
-    expect(failure.message).toBe('restricted generation recovery found no blocked generation to roll over')
+    expect(failure.message).toBe('restricted generation recovery found no terminal generation to roll over')
   })
 
   test('keeps activation disabled when the fresh reconciliation fails', async () => {

--- a/services/bayn/src/composition.ts
+++ b/services/bayn/src/composition.ts
@@ -11,8 +11,8 @@ import {
   Redacted,
   Ref,
   Result,
-  Schedule,
   Schema,
+  Semaphore,
   Scope,
   Stdio,
   Stream,
@@ -26,6 +26,7 @@ import {
   type ApplicationIdentity,
   type ApplicationPlan,
   type ApplicationPlanFor,
+  type AutonomousCycleStartup,
   type AutonomousCycleStartupInput,
   type AutonomousRuntime,
   type AutonomousRuntimeResolver,
@@ -34,6 +35,7 @@ import {
   paperObserveSuccessorGenerationHash,
   recoverBlockedGenerationToObserve,
   recoverRestrictedGenerationBeforeRollover,
+  type BlockedGenerationRolloverReceipt,
 } from './blocked-generation-recovery'
 import { AlpacaBrokerResourcesLive } from './broker/alpaca/composition'
 import {
@@ -49,6 +51,7 @@ import { BrokerEnvironment } from './broker/identity'
 import type { LoadedRuntimeConfig } from './config'
 import { CycleObservability, CycleObservabilityLive } from './db/cycle-observability'
 import { CycleStore, CycleStoreLive } from './db/cycle-store'
+import { CycleRunnerError } from './cycle-runner'
 import { LifecycleCommandStore } from './db/lifecycle-command'
 import { LifecycleCommandStoreLive } from './db/lifecycle-command-postgres'
 import {
@@ -127,7 +130,11 @@ import {
   makeObserveAutonomousCycleStartup,
   paperEpisodeCloseExpiresAt,
   paperEpisodeReceiptFinalizationExpiresAt,
+  interpretRecoveryFirstCycleInProcess,
+  type LifecycleAdvanceDisposition,
+  type RecoveryFirstCycleDriver,
   type RecoveryFirstCycleDriverInterpreter,
+  type RecoveryFirstRuntime,
 } from './observe-composition'
 import { restrictMutationAuthority } from './observe-composition/mutation-interpreter'
 import { acquireKubernetesLifecycleCommandAuthenticator } from './lifecycle-command-auth'
@@ -153,7 +160,7 @@ import {
   type PrevalidatedExecutionPrepareInput,
 } from './execution-prepare'
 import { currentUtcInstant } from './time'
-import type { RuntimeEvidence, RuntimeState } from './runtime-state'
+import type { AutonomousCyclePassObservation, RuntimeEvidence, RuntimeState } from './runtime-state'
 import { scopedAcquisition } from './resource-boundary'
 import { strategyApplication } from './strategy'
 import { Pipeable } from './pipeable'
@@ -350,6 +357,57 @@ const lifecycleDriverInterpreter = (
         }).pipe(Effect.scoped, Effect.orDie)) satisfies RecoveryFirstCycleDriverInterpreter)
     : undefined
 
+const lifecycleMaintenanceCycle =
+  (
+    plan: ApplicationPlanFor<'AutonomousService'>,
+    store: import('./db/lifecycle-command').LifecycleCommandStoreShape,
+    writerFence: WriterFenceService,
+    maintainReconciliation: Effect.Effect<void>,
+    maintainLifecycle: Effect.Effect<LifecycleAdvanceDisposition, CycleRunnerError>,
+  ): AutonomousCycleStartup<RecoveryFirstRuntime> =>
+  (startup) =>
+    Semaphore.make(1).pipe(
+      Effect.map((operationPermit) => {
+        const nextDelayMs = Math.min(plan.config.cyclePollIntervalMs, plan.config.alpaca.reconciliationIntervalMs)
+        const observeSuccess = currentUtcInstant.pipe(
+          Effect.flatMap((observedAt) => {
+            const observation: AutonomousCyclePassObservation = {
+              result: 'SUCCESS',
+              observedAt,
+              outcome: 'RECOVERED',
+            }
+            return startup.recordPass(observation).pipe(Effect.as({ observation }))
+          }),
+        )
+        const advance = operationPermit.withPermit(
+          maintainLifecycle.pipe(
+            Effect.andThen(observeSuccess),
+            Effect.catch((error) =>
+              currentUtcInstant.pipe(
+                Effect.flatMap((observedAt) => {
+                  const observation: AutonomousCyclePassObservation = {
+                    result: 'FAILURE',
+                    observedAt,
+                    operation: error.operation,
+                    failure: error.failure,
+                    message: error.message,
+                  }
+                  return startup.recordPass(observation).pipe(Effect.andThen(Effect.fail(error)))
+                }),
+              ),
+            ),
+          ),
+        )
+        const driver: RecoveryFirstCycleDriver = {
+          advance,
+          maintainReconciliation: operationPermit.withPermit(maintainReconciliation),
+          nextDelayMs,
+          wait: () => Effect.sleep(Duration.millis(nextDelayMs)),
+        }
+        return (lifecycleDriverInterpreter(plan, store, writerFence) ?? interpretRecoveryFirstCycleInProcess)(driver)
+      }),
+    )
+
 export const observeCycleGenerationHash = (authority: AuthorityState): Result.Result<string, string> =>
   authority.maximum === Authority.Observe && authority.effective === Authority.Observe
     ? Result.succeed(authority.generationHash)
@@ -382,6 +440,7 @@ const mutationCycle = (
   lifecycleCommandStore: import('./db/lifecycle-command').LifecycleCommandStoreShape,
   writerFence: WriterFenceService,
   onClosedCycle: (cycleId: string, observedAt: string) => Effect.Effect<void>,
+  beforeLifecycleAdvance?: Effect.Effect<LifecycleAdvanceDisposition, CycleRunnerError>,
   interpretCycleDriverOverride?: RecoveryFirstCycleDriverInterpreter,
 ) => {
   const interpretCycleDriver =
@@ -404,6 +463,7 @@ const mutationCycle = (
     paperEpisodeCutoffAt: paperEpisode.cutoffAt,
     paperEpisodeCloseSubmitCutoffAt: paperEpisode.expiresAt,
     paperEpisodeExpiresAt: paperEpisodeCloseExpiresAt(paperEpisode.expiresAt),
+    ...(beforeLifecycleAdvance === undefined ? {} : { beforeLifecycleAdvance }),
     ...(interpretCycleDriver === undefined ? {} : { interpretCycleDriver }),
   })
 }
@@ -1195,28 +1255,89 @@ const restrictExpiredPaperActivationDataFirst = (
 
 export const restrictExpiredPaperActivation = Pipeable.dual(2, restrictExpiredPaperActivationDataFirst)
 
-const restrictPaperAtExpiry = (
-  expiresAt: string,
+export type ExecutionLifecycleMaintenanceDecision = {
+  readonly restrictExpiredAuthority: boolean
+  readonly attemptReceiptFinalization: boolean
+}
+
+export const decideExecutionLifecycleMaintenance = (input: {
+  readonly cutoffAt: string
+  readonly closeExpiresAt: string
+  readonly finalizationExpiresAt: string
+  readonly observedAt: string
+}): ExecutionLifecycleMaintenanceDecision => {
+  const observedMs = Date.parse(input.observedAt)
+  const cutoffMs = Date.parse(input.cutoffAt)
+  const closeExpiresMs = Date.parse(input.closeExpiresAt)
+  const finalizationExpiresMs = Date.parse(input.finalizationExpiresAt)
+  if (
+    !Number.isFinite(observedMs) ||
+    !Number.isFinite(cutoffMs) ||
+    !Number.isFinite(closeExpiresMs) ||
+    !Number.isFinite(finalizationExpiresMs)
+  ) {
+    return { restrictExpiredAuthority: true, attemptReceiptFinalization: false }
+  }
+  return {
+    restrictExpiredAuthority: observedMs >= closeExpiresMs,
+    attemptReceiptFinalization: observedMs >= cutoffMs && observedMs <= finalizationExpiresMs,
+  }
+}
+
+export const runExecutionLifecycleMaintenance = (
+  request: PaperActivationRequest,
   authorityRestrictionStore: AuthorityRestrictionStoreShape,
   writerFence: WriterFenceService,
-): Effect.Effect<void, never> =>
-  Effect.gen(function* () {
-    const observedAt = yield* currentUtcInstant
-    const remainingMs = Date.parse(expiresAt) - Date.parse(observedAt)
-    if (remainingMs > 0) yield* Effect.sleep(Duration.millis(remainingMs))
-    yield* restrictExpiredPaperActivation(authorityRestrictionStore, writerFence).pipe(
-      Effect.retry({
-        times: 4,
-        schedule: Schedule.spaced(Duration.seconds(1)),
-      }),
-      Effect.tapError((cause) =>
-        Effect.logError('Bayn PAPER activation expiry restriction exhausted retries').pipe(
-          Effect.annotateLogs({ reason: cause instanceof Error ? cause.message : String(cause) }),
+  finalizeReceipt: (cycleId: string | undefined, observedAt: string) => Effect.Effect<boolean, CycleRunnerError>,
+): Effect.Effect<LifecycleAdvanceDisposition, CycleRunnerError> =>
+  currentUtcInstant.pipe(
+    Effect.flatMap((observedAt) => {
+      const decision = decideExecutionLifecycleMaintenance({
+        cutoffAt: request.cutoffAt,
+        closeExpiresAt: paperEpisodeCloseExpiresAt(request.expiresAt),
+        finalizationExpiresAt: paperEpisodeReceiptFinalizationExpiresAt(request.expiresAt),
+        observedAt,
+      })
+      const restrict = decision.restrictExpiredAuthority
+        ? restrictMutationAuthority('PAPER activation lease', 'immutable activation request expired').pipe(
+            Effect.provideService(AuthorityRestrictionStore, authorityRestrictionStore),
+            Effect.provideService(WriterFence, writerFence),
+          )
+        : Effect.void
+      return restrict.pipe(
+        Effect.andThen(
+          decision.attemptReceiptFinalization
+            ? finalizeReceipt(undefined, observedAt).pipe(
+                Effect.map((completed) => (completed ? ('COMPLETED' as const) : ('CONTINUE' as const))),
+              )
+            : Effect.succeed('CONTINUE' as const),
         ),
-      ),
-      Effect.orDie,
-    )
-  })
+      )
+    }),
+  )
+
+const completeExecutionLifecycle = <A, E, R, RolloverR>(
+  finalization: Effect.Effect<boolean, E, R>,
+  rollover: Effect.Effect<A, OperationalError, RolloverR>,
+): Effect.Effect<boolean, E | CycleRunnerError, R | RolloverR> =>
+  finalization.pipe(
+    Effect.flatMap((finalized) =>
+      finalized
+        ? rollover.pipe(
+            Effect.mapError(
+              (cause) =>
+                new CycleRunnerError({
+                  operation: 'recover-cycle',
+                  failure: 'operational',
+                  message: 'terminal execution generation rollover failed',
+                  cause,
+                }),
+            ),
+            Effect.as(true),
+          )
+        : Effect.succeed(false),
+    ),
+  )
 
 const signedMicros = (value: string | null): bigint | undefined =>
   value !== null && /^-?(?:0|[1-9][0-9]*)$/.test(value) ? BigInt(value) : undefined
@@ -1352,33 +1473,6 @@ const finalizePaperEpisodeDataFirst = (
   )
 
 export const finalizePaperEpisode = Pipeable.dual(8, finalizePaperEpisodeDataFirst)
-
-const retryClosedCycleReceiptsDataFirst = (
-  emit: (cycleId: string | undefined, observedAt: string) => Effect.Effect<boolean>,
-  cutoffAt: string,
-  retryUntilAt: string,
-  intervalMs: number,
-): Effect.Effect<void> =>
-  Effect.gen(function* () {
-    const interval = Math.max(1_000, intervalMs)
-    const cutoffMs = Date.parse(cutoffAt)
-    const retryUntilMs = Date.parse(retryUntilAt)
-    if (!Number.isFinite(cutoffMs) || !Number.isFinite(retryUntilMs) || retryUntilMs < cutoffMs) return
-    while (true) {
-      const observedAt = yield* currentUtcInstant
-      const observedMs = Date.parse(observedAt)
-      const untilCutoff = cutoffMs - observedMs
-      if (untilCutoff > 0) {
-        yield* Effect.sleep(Duration.millis(Math.min(interval, untilCutoff)))
-        continue
-      }
-      if (yield* emit(undefined, observedAt)) return
-      if (observedMs >= retryUntilMs) return
-      yield* Effect.sleep(Duration.millis(Math.min(interval, retryUntilMs - observedMs)))
-    }
-  })
-
-export const retryClosedCycleReceipts = Pipeable.dual(4, retryClosedCycleReceiptsDataFirst)
 
 const closedCycleReceiptEmissionAllowedDataFirst = (cutoffAt: string, observedAt: string): boolean =>
   Date.parse(observedAt) >= Date.parse(cutoffAt)
@@ -1570,6 +1664,42 @@ const runAutonomousService = (plan: ApplicationPlanFor<'AutonomousService'>) =>
                             observePlan.config.operationTimeoutMs,
                           ),
                         })
+                        const recoverTerminalExecutionGeneration: Effect.Effect<
+                          BlockedGenerationRolloverReceipt,
+                          OperationalError
+                        > = recoverBlockedGeneration.pipe(
+                          Effect.flatMap(
+                            (receipt): Effect.Effect<BlockedGenerationRolloverReceipt, OperationalError> => {
+                              if (receipt._tag === 'RolledOver') return Effect.succeed(receipt)
+                              if (runtimeServices.authorityGenerationStore.readAuthorityState === undefined) {
+                                return Effect.fail(
+                                  paperActivationOperationalError(
+                                    'terminal execution rollover requires durable authority state reads',
+                                  ),
+                                )
+                              }
+                              return runtimeServices.authorityGenerationStore.readAuthorityState.pipe(
+                                Effect.mapError((cause) =>
+                                  paperActivationOperationalError(
+                                    'terminal execution rollover authority read failed',
+                                    cause,
+                                  ),
+                                ),
+                                Effect.flatMap((authority) =>
+                                  authority.maximum === Authority.Observe &&
+                                  authority.effective === Authority.Observe &&
+                                  authority.kill === KillState.Clear
+                                    ? Effect.succeed(receipt)
+                                    : Effect.fail(
+                                        paperActivationOperationalError(
+                                          'terminal execution rollover did not reach clear OBSERVE authority',
+                                        ),
+                                      ),
+                                ),
+                              )
+                            },
+                          ),
+                        )
                         if (request === null) return recoverBlockedGeneration.pipe(Effect.as(readRuntime()))
                         const evidence = validated.success.evidence
                         if (evidence === null && !isResearchPaperActivationRequest(request)) {
@@ -1652,6 +1782,11 @@ const runAutonomousService = (plan: ApplicationPlanFor<'AutonomousService'>) =>
                               cycleId,
                               observedAt,
                             )
+                          const finalizeExecutionLifecycleReceipt = (cycleId: string | undefined, observedAt: string) =>
+                            completeExecutionLifecycle(
+                              finalizeClosedCycleReceipt(cycleId, observedAt),
+                              recoverTerminalExecutionGeneration,
+                            )
                           return Effect.gen(function* () {
                             yield* pendingPaperActivation(state, request, 'REQUEST_EXPIRED')
                             const observedAt = yield* currentUtcInstant
@@ -1667,28 +1802,66 @@ const runAutonomousService = (plan: ApplicationPlanFor<'AutonomousService'>) =>
                                   ),
                                 )
                               if (Option.isSome(existing)) {
-                                yield* finalizePaperEpisode(
-                                  state,
-                                  request,
-                                  prepared.generation.generationHash,
-                                  runtimeServices.authorityRestrictionStore,
-                                  runtimeServices.writerFence,
-                                  () => Effect.succeed(existing.value.receiptHash),
-                                  existing.value.cycleId,
-                                  observedAt,
+                                yield* completeExecutionLifecycle(
+                                  finalizePaperEpisode(
+                                    state,
+                                    request,
+                                    prepared.generation.generationHash,
+                                    runtimeServices.authorityRestrictionStore,
+                                    runtimeServices.writerFence,
+                                    () => Effect.succeed(existing.value.receiptHash),
+                                    existing.value.cycleId,
+                                    observedAt,
+                                  ),
+                                  recoverTerminalExecutionGeneration,
+                                ).pipe(
+                                  Effect.mapError((cause) =>
+                                    paperActivationOperationalError(
+                                      'durable PAPER receipt terminal rollover failed',
+                                      cause,
+                                    ),
+                                  ),
                                 )
                               }
                               return readRuntime()
                             }
-                            yield* Effect.forkScoped(
-                              retryClosedCycleReceipts(
-                                finalizeClosedCycleReceipt,
-                                request.cutoffAt,
-                                paperEpisodeReceiptFinalizationExpiresAt(request.expiresAt),
-                                observePlan.config.alpaca.reconciliationIntervalMs,
+                            const maintainReconciliation = runOnce.pipe(
+                              // @effect-diagnostics-next-line strictEffectProvide:off -- value-only reconciliation services have no resource lifetime
+                              Effect.provide(cycleResources),
+                              Effect.asVoid,
+                              Effect.catch((cause) =>
+                                Effect.logError('Bayn receipt-finalization reconciliation guardian failed', cause),
                               ),
                             )
-                            return readRuntime()
+                            const maintainLifecycle = runExecutionLifecycleMaintenance(
+                              request,
+                              runtimeServices.authorityRestrictionStore,
+                              runtimeServices.writerFence,
+                              finalizeExecutionLifecycleReceipt,
+                            )
+                            const startCycle: AutonomousCycleStartup = (startup) =>
+                              lifecycleMaintenanceCycle(
+                                observePlan,
+                                runtimeServices.lifecycleCommandStore,
+                                runtimeServices.writerFence,
+                                maintainReconciliation,
+                                maintainLifecycle,
+                              )(startup).pipe(
+                                // @effect-diagnostics-next-line strictEffectProvide:off -- value-only lifecycle services have no resource lifetime
+                                Effect.provide(cycleResources),
+                                Effect.map((loop) =>
+                                  loop.pipe(
+                                    // @effect-diagnostics-next-line strictEffectProvide:off -- value-only lifecycle services have no resource lifetime
+                                    Effect.provide(cycleResources),
+                                  ),
+                                ),
+                              )
+                            return {
+                              ...readRuntime(),
+                              cycleBindingId: prepared.generation.generationHash,
+                              cycleObservationId: prepared.generation.generationHash,
+                              startCycle,
+                            }
                           })
                         }
                         const resolvePrepared = (
@@ -1790,10 +1963,24 @@ const runAutonomousService = (plan: ApplicationPlanFor<'AutonomousService'>) =>
                                       cycleId,
                                       observedAt,
                                     )
+                                  const finalizeExecutionLifecycleReceipt = (
+                                    cycleId: string | undefined,
+                                    observedAt: string,
+                                  ) =>
+                                    completeExecutionLifecycle(
+                                      finalizeClosedCycleReceipt(cycleId, observedAt),
+                                      recoverTerminalExecutionGeneration,
+                                    )
                                   const onClosedCycle = (cycleId: string, observedAt: string) =>
                                     closedCycleReceiptEmissionAllowed(request.cutoffAt, observedAt)
                                       ? finalizeClosedCycleReceipt(cycleId, observedAt).pipe(Effect.asVoid)
                                       : Effect.void
+                                  const maintainExecutionLifecycle = runExecutionLifecycleMaintenance(
+                                    request,
+                                    runtimeServices.authorityRestrictionStore,
+                                    runtimeServices.writerFence,
+                                    finalizeExecutionLifecycleReceipt,
+                                  )
                                   return makeMutation(
                                     runtimeServices.session,
                                     authority,
@@ -1845,6 +2032,7 @@ const runAutonomousService = (plan: ApplicationPlanFor<'AutonomousService'>) =>
                                           runtimeServices.lifecycleCommandStore,
                                           runtimeServices.writerFence,
                                           onClosedCycle,
+                                          maintainExecutionLifecycle,
                                           interpretCycleDriver,
                                         )(startup).pipe(
                                           // @effect-diagnostics-next-line strictEffectProvide:off -- value-only cycle services have no resource lifetime
@@ -1872,28 +2060,7 @@ const runAutonomousService = (plan: ApplicationPlanFor<'AutonomousService'>) =>
                                         request,
                                         prepared.generation.generationHash,
                                         paperGrant._tag,
-                                      ).pipe(
-                                        Effect.andThen(
-                                          Effect.forkScoped(
-                                            retryClosedCycleReceipts(
-                                              finalizeClosedCycleReceipt,
-                                              request.cutoffAt,
-                                              paperEpisodeReceiptFinalizationExpiresAt(request.expiresAt),
-                                              realizedPlan.config.alpaca.reconciliationIntervalMs,
-                                            ),
-                                          ),
-                                        ),
-                                        Effect.andThen(
-                                          Effect.forkScoped(
-                                            restrictPaperAtExpiry(
-                                              paperEpisodeCloseExpiresAt(request.expiresAt),
-                                              runtimeServices.authorityRestrictionStore,
-                                              runtimeServices.writerFence,
-                                            ),
-                                          ),
-                                        ),
-                                        Effect.as(runtime),
-                                      )
+                                      ).pipe(Effect.as(runtime))
                                       if (!restricted) return activate
 
                                       const recover: RecoveryFirstCycleDriverInterpreter = (driver) =>

--- a/services/bayn/src/composition.ts
+++ b/services/bayn/src/composition.ts
@@ -33,9 +33,9 @@ import {
 } from './app'
 import {
   paperObserveSuccessorGenerationHash,
-  recoverBlockedGenerationToObserve,
+  recoverTerminalGenerationToObserve,
   recoverRestrictedGenerationBeforeRollover,
-  type BlockedGenerationRolloverReceipt,
+  type TerminalGenerationRolloverReceipt,
 } from './blocked-generation-recovery'
 import { AlpacaBrokerResourcesLive } from './broker/alpaca/composition'
 import {
@@ -1651,7 +1651,7 @@ const runAutonomousService = (plan: ApplicationPlanFor<'AutonomousService'>) =>
                             : {}),
                           startCycle: readStartCycle,
                         })
-                        const recoverBlockedGeneration = recoverBlockedGenerationToObserve({
+                        const recoverBlockedGeneration = recoverTerminalGenerationToObserve({
                           accountId: observePlan.config.alpaca.expectedAccountId,
                           blockedIntents: runtimeServices.blockedCycleIntentStore,
                           authorityStore: runtimeServices.authorityGenerationStore,
@@ -1665,11 +1665,11 @@ const runAutonomousService = (plan: ApplicationPlanFor<'AutonomousService'>) =>
                           ),
                         })
                         const recoverTerminalExecutionGeneration: Effect.Effect<
-                          BlockedGenerationRolloverReceipt,
+                          TerminalGenerationRolloverReceipt,
                           OperationalError
                         > = recoverBlockedGeneration.pipe(
                           Effect.flatMap(
-                            (receipt): Effect.Effect<BlockedGenerationRolloverReceipt, OperationalError> => {
+                            (receipt): Effect.Effect<TerminalGenerationRolloverReceipt, OperationalError> => {
                               if (receipt._tag === 'RolledOver') return Effect.succeed(receipt)
                               if (runtimeServices.authorityGenerationStore.readAuthorityState === undefined) {
                                 return Effect.fail(

--- a/services/bayn/src/composition.ts
+++ b/services/bayn/src/composition.ts
@@ -762,6 +762,108 @@ const readBoundPaperActivationGeneration = (
     return generation
   })
 
+export interface CompletedExecutionLifecycle {
+  readonly authorityGenerationHash: string
+  readonly receiptHash: string
+}
+
+export const readCompletedExecutionLifecycle = (
+  plan: ApplicationPlanFor<'AutonomousService'>,
+  request: PaperActivationRequest,
+  buildContinuation: ResearchPaperBuildContinuation | null,
+  authorityStore: AuthorityGenerationStoreShape,
+  readReceiptHash: (authorityGenerationHash: string) => Effect.Effect<Option.Option<string>, OperationalError>,
+): Effect.Effect<CompletedExecutionLifecycle | undefined, OperationalError> =>
+  Effect.gen(function* () {
+    if (
+      authorityStore.readAuthorityState === undefined ||
+      authorityStore.readAuthorityGenerationLineage === undefined
+    ) {
+      return undefined
+    }
+    const authority = yield* authorityStore.readAuthorityState.pipe(
+      Effect.mapError((cause) =>
+        paperActivationOperationalError('completed execution lifecycle authority read failed', cause),
+      ),
+    )
+    if (
+      authority.maximum !== Authority.Observe ||
+      authority.effective !== Authority.Observe ||
+      authority.kill !== KillState.Clear
+    ) {
+      return undefined
+    }
+    const lineage = yield* authorityStore
+      .readAuthorityGenerationLineage(authority.generationHash)
+      .pipe(
+        Effect.mapError((cause) =>
+          paperActivationOperationalError('completed execution lifecycle lineage read failed', cause),
+        ),
+      )
+    if (
+      lineage === undefined ||
+      lineage.generationHash !== authority.generationHash ||
+      lineage.maximum !== Authority.Observe ||
+      lineage.previousGenerationHash === null
+    ) {
+      return undefined
+    }
+
+    const previousGenerationHash = lineage.previousGenerationHash
+    let generation: PaperAuthorityGeneration | undefined
+    let binding: Result.Result<void, string>
+    if (isResearchPaperActivationRequest(request)) {
+      if (authorityStore.readResearchAuthorityGeneration === undefined) return undefined
+      generation = yield* authorityStore
+        .readResearchAuthorityGeneration(previousGenerationHash)
+        .pipe(
+          Effect.mapError((cause) =>
+            paperActivationOperationalError('completed research PAPER generation read failed', cause),
+          ),
+        )
+      if (generation === undefined) return undefined
+      binding =
+        buildContinuation === null
+          ? researchPaperGenerationIsBoundToRequest(request, generation.previousGenerationHash, generation)
+          : researchPaperBuildContinuationIsBound(
+              buildContinuation,
+              generation.previousGenerationHash,
+              generation,
+              plan.config.build,
+            )
+    } else {
+      if (authorityStore.readAuthorityGeneration === undefined) return undefined
+      generation = yield* authorityStore
+        .readAuthorityGeneration(previousGenerationHash)
+        .pipe(
+          Effect.mapError((cause) =>
+            paperActivationOperationalError('completed qualified PAPER generation read failed', cause),
+          ),
+        )
+      if (generation === undefined) return undefined
+      binding = paperGenerationIsBoundToRequest(request, plan, generation)
+    }
+    if (Result.isFailure(binding)) return undefined
+
+    const expectedSuccessorHash = yield* Effect.fromResult(
+      paperObserveSuccessorGenerationHash({ previousPaperGenerationHash: generation.generationHash }),
+    ).pipe(
+      Effect.mapError((cause) =>
+        paperActivationOperationalError('completed execution lifecycle successor hashing failed', cause),
+      ),
+    )
+    if (expectedSuccessorHash !== authority.generationHash) {
+      return yield* paperActivationOperationalError(
+        'completed execution lifecycle OBSERVE successor does not match the terminal PAPER generation',
+      )
+    }
+    const receiptHash = yield* readReceiptHash(generation.generationHash)
+    return Option.match(receiptHash, {
+      onNone: () => undefined,
+      onSome: (hash) => ({ authorityGenerationHash: generation.generationHash, receiptHash: hash }),
+    })
+  })
+
 export const recoverPaperActivationGeneration = (
   plan: ApplicationPlanFor<'AutonomousService'>,
   request: PaperActivationRequest,
@@ -1701,6 +1803,22 @@ const runAutonomousService = (plan: ApplicationPlanFor<'AutonomousService'>) =>
                           ),
                         )
                         if (request === null) return recoverBlockedGeneration.pipe(Effect.as(readRuntime()))
+                        const completedLifecycle = readCompletedExecutionLifecycle(
+                          observePlan,
+                          request,
+                          buildContinuation,
+                          runtimeServices.authorityGenerationStore,
+                          (authorityGenerationHash) =>
+                            runtimeServices.forwardPerformanceReceiptStore.read(authorityGenerationHash).pipe(
+                              Effect.mapError((cause) =>
+                                paperActivationOperationalError(
+                                  'completed execution lifecycle receipt read failed',
+                                  cause,
+                                ),
+                              ),
+                              Effect.map(Option.map((receipt) => receipt.receiptHash)),
+                            ),
+                        )
                         const evidence = validated.success.evidence
                         if (evidence === null && !isResearchPaperActivationRequest(request)) {
                           return recoverBlockedGeneration.pipe(
@@ -2090,8 +2208,22 @@ const runAutonomousService = (plan: ApplicationPlanFor<'AutonomousService'>) =>
                             }),
                           )
                         }
-                        return prepareOrRecover.pipe(
-                          Effect.flatMap(resolvePrepared),
+                        return completedLifecycle.pipe(
+                          Effect.flatMap(
+                            (
+                              completed,
+                            ): Effect.Effect<AutonomousRuntime<never, never>, OperationalError, Scope.Scope> => {
+                              if (completed === undefined) {
+                                return prepareOrRecover.pipe(Effect.flatMap(resolvePrepared))
+                              }
+                              return completedPaperActivation(
+                                state,
+                                request,
+                                completed.authorityGenerationHash,
+                                completed.receiptHash,
+                              ).pipe(Effect.as(readRuntime()))
+                            },
+                          ),
                           Effect.catch((cause) =>
                             Effect.logWarning('Bayn PAPER activation remains in OBSERVE').pipe(
                               Effect.annotateLogs({

--- a/services/bayn/src/db/cycle-store/integration.test.ts
+++ b/services/bayn/src/db/cycle-store/integration.test.ts
@@ -3642,13 +3642,13 @@ describePostgres('PostgreSQL autonomous cycle store', () => {
             ),
           )
           const settlement = yield* writerFence.transaction(
-            blockedCycleIntentStore.settleCurrentBlockedGeneration({
+            blockedCycleIntentStore.settleCurrentTerminalGeneration({
               accountId: draft.identity.accountId,
               observedAt: staleTiming.observed_at,
             }),
           )
           const replay = yield* writerFence.transaction(
-            blockedCycleIntentStore.settleCurrentBlockedGeneration({
+            blockedCycleIntentStore.settleCurrentTerminalGeneration({
               accountId: draft.identity.accountId,
               observedAt: utcInstantFromEpochMillis(Date.parse(staleTiming.observed_at) + 1),
             }),
@@ -3708,7 +3708,7 @@ describePostgres('PostgreSQL autonomous cycle store', () => {
         `bound cycle ${result.committed.cycle.identity.cycleId} blocked: BLOCKED_RISK`,
       )
       expect(result.settlement).toMatchObject({
-        _tag: 'BlockedGenerationSettled',
+        _tag: 'TerminalGenerationSettled',
         authorityGenerationHash: plannedPaperGenerationHash,
         blockedCycleCount: 1,
         blockedIntentCount: 0,
@@ -3717,7 +3717,7 @@ describePostgres('PostgreSQL autonomous cycle store', () => {
         terminalIntentCount: 2,
       })
       expect(result.replay).toMatchObject({
-        _tag: 'BlockedGenerationSettled',
+        _tag: 'TerminalGenerationSettled',
         blockedIntentCount: 0,
         expiredIntentCount: 0,
         intentCount: 2,

--- a/services/bayn/src/db/evidence-store.integration.test.ts
+++ b/services/bayn/src/db/evidence-store.integration.test.ts
@@ -1220,6 +1220,7 @@ describePostgres('PostgreSQL evaluation evidence', () => {
       { migration_id: 31, name: 'blocked_paper_generation_rollover' },
       { migration_id: 32, name: 'lifecycle_commands' },
       { migration_id: 33, name: 'lifecycle_command_not_due_reason' },
+      { migration_id: 34, name: 'terminal_paper_generation_rollover' },
     ])
   })
 

--- a/services/bayn/src/db/execution-store.ts
+++ b/services/bayn/src/db/execution-store.ts
@@ -23,6 +23,7 @@ export {
   VALUATION_SNAPSHOT_MAX_SKEW_MS,
   ValuationStore,
   type BrokerEventStoreShape,
+  type AuthorityGenerationLineage,
   type AuthorityGenerationStoreShape,
   type AuthorityRestrictionStoreShape,
   type CapitalGrantLifecycleStoreShape,

--- a/services/bayn/src/db/execution-store/contract.ts
+++ b/services/bayn/src/db/execution-store/contract.ts
@@ -33,6 +33,12 @@ export interface EnsureAuthorityGenerationInput {
   readonly maximum: Authority
 }
 
+export interface AuthorityGenerationLineage {
+  readonly generationHash: string
+  readonly previousGenerationHash: string | null
+  readonly maximum: Authority
+}
+
 export class ExecutionStoreError extends Data.TaggedError('ExecutionStoreError')<{
   readonly operation:
     | 'ingest'
@@ -82,6 +88,9 @@ export interface AuthorityGenerationStoreShape {
   readonly readResearchAuthorityGeneration?: (
     generationHash: string,
   ) => Effect.Effect<ResearchCapitalGrantGeneration | undefined, ExecutionStoreError>
+  readonly readAuthorityGenerationLineage?: (
+    generationHash: string,
+  ) => Effect.Effect<AuthorityGenerationLineage | undefined, ExecutionStoreError>
 }
 
 /** Domain operations; the live Layer captures the process-wide writer fence. */

--- a/services/bayn/src/db/execution-store/observe-authority.ts
+++ b/services/bayn/src/db/execution-store/observe-authority.ts
@@ -28,7 +28,7 @@ import {
   researchPaperGenerationFromRow,
   type AuthorityPostgres,
 } from './authority-shared'
-import type { EnsureAuthorityGenerationInput, ExecutionStoreError } from './contract'
+import type { AuthorityGenerationLineage, EnsureAuthorityGenerationInput, ExecutionStoreError } from './contract'
 import { failExecutionStore, liftAuthorityDecision, runExecutionOperation } from './errors'
 import {
   decodeAuthorityStateObservationRows,
@@ -131,6 +131,9 @@ export interface ObserveAuthorityInterpreter {
   readonly readResearchAuthorityGeneration: (
     generationHash: string,
   ) => Effect.Effect<ResearchCapitalGrantGeneration | undefined, ExecutionStoreError>
+  readonly readAuthorityGenerationLineage: (
+    generationHash: string,
+  ) => Effect.Effect<AuthorityGenerationLineage | undefined, ExecutionStoreError>
 }
 
 const makeObserveAuthorityInterpreterDataFirst = (
@@ -512,7 +515,30 @@ const makeObserveAuthorityInterpreterDataFirst = (
       ),
     )
 
-  return { ensureAuthorityGeneration, readAuthorityState, readAuthorityGeneration, readResearchAuthorityGeneration }
+  const readAuthorityGenerationLineage = (generationHash: string) =>
+    runExecutionOperation(
+      'authority',
+      authority.readGeneration(generationHash).pipe(
+        Effect.map((rows) => {
+          const row = rows[0]
+          return row === undefined
+            ? undefined
+            : {
+                generationHash: row.generation_hash,
+                previousGenerationHash: row.previous_generation_hash,
+                maximum: row.maximum,
+              }
+        }),
+      ),
+    )
+
+  return {
+    ensureAuthorityGeneration,
+    readAuthorityState,
+    readAuthorityGeneration,
+    readResearchAuthorityGeneration,
+    readAuthorityGenerationLineage,
+  }
 }
 
 export const makeObserveAuthorityInterpreter = Pipeable.dual(3, makeObserveAuthorityInterpreterDataFirst)

--- a/services/bayn/src/db/execution-store/observe-authority.ts
+++ b/services/bayn/src/db/execution-store/observe-authority.ts
@@ -13,6 +13,7 @@ import {
   type CapitalGrantGeneration,
   type ResearchCapitalGrantGeneration,
 } from '../../execution/contracts'
+import { paperActivationExpiredRestrictionReason, paperEpisodeCompletedRestrictionReason } from '../../paper-episode'
 import { incompletePassReason } from '../../simulation-reconciliation/broker-reconciler-model'
 import {
   decideObserveGeneration,
@@ -233,7 +234,20 @@ const makeObserveAuthorityInterpreterDataFirst = (
           (
             state.effective = 'OBSERVE'
             AND state.kill_state = 'ACTIVE'
-            AND state.reason LIKE 'PAPER autonomous cycle loop restricted effective authority:%'
+            AND (
+              state.reason LIKE 'PAPER autonomous cycle loop restricted effective authority:%'
+              OR (
+                state.reason IN (
+                  ${paperEpisodeCompletedRestrictionReason},
+                  ${paperActivationExpiredRestrictionReason}
+                )
+                AND EXISTS (
+                  SELECT 1
+                  FROM autonomous_forward_performance_receipts AS receipt
+                  WHERE receipt.authority_generation_hash = state.generation_hash
+                )
+              )
+            )
           )
           OR (
             state.effective = 'PAPER'
@@ -341,7 +355,20 @@ const makeObserveAuthorityInterpreterDataFirst = (
               (
                 state.effective = 'OBSERVE'
                 AND state.kill_state = 'ACTIVE'
-                AND state.reason LIKE 'PAPER autonomous cycle loop restricted effective authority:%'
+                AND (
+                  state.reason LIKE 'PAPER autonomous cycle loop restricted effective authority:%'
+                  OR (
+                    state.reason IN (
+                      ${paperEpisodeCompletedRestrictionReason},
+                      ${paperActivationExpiredRestrictionReason}
+                    )
+                    AND EXISTS (
+                      SELECT 1
+                      FROM autonomous_forward_performance_receipts AS receipt
+                      WHERE receipt.authority_generation_hash = state.generation_hash
+                    )
+                  )
+                )
                 AND previous_generation.activation_schema_version IN (
                   'bayn.paper-authority-generation.v2',
                   'bayn.paper-authority-generation.v3'

--- a/services/bayn/src/db/execution-store/postgres.ts
+++ b/services/bayn/src/db/execution-store/postgres.ts
@@ -40,6 +40,7 @@ export const makeExecutionPersistence = (config: ExecutionStoreRuntimeConfig) =>
         readAuthorityState: observeAuthority.readAuthorityState,
         readAuthorityGeneration: observeAuthority.readAuthorityGeneration,
         readResearchAuthorityGeneration: observeAuthority.readResearchAuthorityGeneration,
+        readAuthorityGenerationLineage: observeAuthority.readAuthorityGenerationLineage,
       },
       capitalGrantLifecycle: {
         prepareCapitalGrant: capitalGrant.prepareCapitalGrant,

--- a/services/bayn/src/db/migrations.ts
+++ b/services/bayn/src/db/migrations.ts
@@ -33,6 +33,7 @@ import clearUnusedResearchPaperRearm from '../../migrations/0030_clear_unused_re
 import blockedPaperGenerationRollover from '../../migrations/0031_blocked_paper_generation_rollover'
 import lifecycleCommands from '../../migrations/0032_lifecycle_commands'
 import lifecycleCommandNotDueReason from '../../migrations/0033_lifecycle_command_not_due_reason'
+import terminalPaperGenerationRollover from '../../migrations/0034_terminal_paper_generation_rollover'
 
 export const migrationLoader = PgMigrator.fromRecord({
   '1_initial_schema': initialSchema,
@@ -68,4 +69,5 @@ export const migrationLoader = PgMigrator.fromRecord({
   '31_blocked_paper_generation_rollover': blockedPaperGenerationRollover,
   '32_lifecycle_commands': lifecycleCommands,
   '33_lifecycle_command_not_due_reason': lifecycleCommandNotDueReason,
+  '34_terminal_paper_generation_rollover': terminalPaperGenerationRollover,
 })

--- a/services/bayn/src/db/paper-store.integration.test.ts
+++ b/services/bayn/src/db/paper-store.integration.test.ts
@@ -2584,6 +2584,11 @@ describePostgres('paper accounting persistence', () => {
             assert(activateResearch !== undefined, 'research PAPER activation must be implemented')
             const readAuthorityState = store.readAuthorityState
             assert(readAuthorityState !== undefined, 'durable authority state reads must be implemented')
+            const readAuthorityGenerationLineage = store.readAuthorityGenerationLineage
+            assert(
+              readAuthorityGenerationLineage !== undefined,
+              'durable authority generation lineage reads must be implemented',
+            )
 
             yield* seedExactReconciliation(activationReconciliation)
             yield* store.ensureAuthorityGeneration({
@@ -2696,7 +2701,8 @@ describePostgres('paper accounting persistence', () => {
               reconcileAfterSettlement,
             })
             const authority = yield* readAuthorityState
-            return { authority, beforeReceipt, paper, rollover }
+            const lineage = yield* readAuthorityGenerationLineage(authority.generationHash)
+            return { authority, beforeReceipt, lineage, paper, rollover }
           }),
         )
 
@@ -2710,6 +2716,11 @@ describePostgres('paper accounting persistence', () => {
           maximum: Authority.Observe,
           effective: Authority.Observe,
           kill: KillState.Clear,
+        })
+        expect(result.lineage).toEqual({
+          generationHash: result.authority.generationHash,
+          previousGenerationHash: result.paper.generationHash,
+          maximum: Authority.Observe,
         })
       } finally {
         await runtime.dispose()

--- a/services/bayn/src/db/paper-store.integration.test.ts
+++ b/services/bayn/src/db/paper-store.integration.test.ts
@@ -20,7 +20,7 @@ import {
 } from 'effect'
 
 import type { RuntimeConfig } from '../config'
-import { paperObserveSuccessorGenerationHash, recoverBlockedGenerationToObserve } from '../blocked-generation-recovery'
+import { paperObserveSuccessorGenerationHash, recoverTerminalGenerationToObserve } from '../blocked-generation-recovery'
 import { orderRequestBody } from '../broker/alpaca-mutations'
 import { makeStrategyProtocolHash } from '../contracts'
 import { operationalError } from '../errors'
@@ -71,8 +71,16 @@ import {
 import { BrokerProvider, alpacaSandboxBaseUrl } from '../broker/alpaca'
 import { makeBrokerIdentity, type BrokerIdentity } from '../broker/identity'
 import { incompletePassReason } from '../simulation-reconciliation/broker-reconciler-model'
-import { paperEpisodeFailureRestrictionPrefix } from '../paper-episode'
-import type { BlockedCycleIntentStoreShape } from '../execution/intents'
+import {
+  paperActivationExpiredRestrictionReason,
+  paperEpisodeCompletedRestrictionReason,
+  paperEpisodeFailureRestrictionPrefix,
+} from '../paper-episode'
+import {
+  BlockedCycleIntentStore,
+  BlockedCycleIntentStoreLive,
+  type BlockedCycleIntentStoreShape,
+} from '../execution/intents'
 import { EvidenceStore, EvidenceStoreFromPostgres, PostgresClientLive } from './evidence-store'
 import {
   BrokerEventStore,
@@ -348,7 +356,7 @@ const journal = (control: JournalControl): JournalService => ({
 
 const makeStoreRuntime = (control: JournalControl, runtimeConfig: RuntimeConfig = config) =>
   ManagedRuntime.make(
-    ExecutionStoreLive(runtimeConfig).pipe(
+    Layer.mergeAll(ExecutionStoreLive(runtimeConfig), BlockedCycleIntentStoreLive).pipe(
       Layer.provideMerge(WriterFenceLive),
       Layer.provideMerge(Layer.succeed(Journal, journal(control))),
       Layer.provideMerge(PostgresClientLive(runtimeConfig)),
@@ -2412,9 +2420,9 @@ describePostgres('paper accounting persistence', () => {
 
           const blockedIntents: BlockedCycleIntentStoreShape = {
             terminalizeUntouchedApproved: () => Effect.die(new Error('startup settlement only')),
-            settleCurrentBlockedGeneration: () =>
+            settleCurrentTerminalGeneration: () =>
               Effect.succeed({
-                _tag: 'BlockedGenerationSettled' as const,
+                _tag: 'TerminalGenerationSettled' as const,
                 authorityGenerationHash: paper.generationHash,
                 blockedCycleCount: 1,
                 blockedIntentCount: 0,
@@ -2448,7 +2456,7 @@ describePostgres('paper accounting persistence', () => {
               }),
             ),
           )
-          const first = yield* recoverBlockedGenerationToObserve({
+          const first = yield* recoverTerminalGenerationToObserve({
             accountId,
             blockedIntents,
             authorityStore: store,
@@ -2548,6 +2556,167 @@ describePostgres('paper accounting persistence', () => {
       await runtime.dispose()
     }
   }, 15_000)
+
+  test.each([
+    ['completed', paperEpisodeCompletedRestrictionReason],
+    ['expired', paperActivationExpiredRestrictionReason],
+  ] as const)(
+    'rolls a receipt-finalized %s PAPER generation to clear OBSERVE only after durable receipt evidence',
+    async (fixture, restrictionReason) => {
+      const configuredObserveGenerationHash = hash(`receipt-rollover-${fixture}-configured-observe`)
+      const activationReconciliation = exactReconciliation(`receipt-rollover-${fixture}-activation`)
+      const activation = makeResearchActivation(configuredObserveGenerationHash, activationReconciliation)
+      const cycleId = hash(`receipt-rollover-${fixture}-cycle`)
+      const receiptHash = hash(`receipt-rollover-${fixture}-receipt`)
+      const contentHash = hash(`receipt-rollover-${fixture}-envelope`)
+      const runtime = makeStoreRuntime(
+        { fail: false, planHashes: [] },
+        researchRuntimeConfig(configuredObserveGenerationHash),
+      )
+      try {
+        const result = await runtime.runPromise(
+          Effect.gen(function* () {
+            const store = yield* ExecutionStore
+            const blockedIntents = yield* BlockedCycleIntentStore
+            const sql = yield* PgClient.PgClient
+            const writerFence = yield* WriterFence
+            const activateResearch = store.activateResearchCapitalGrant
+            assert(activateResearch !== undefined, 'research PAPER activation must be implemented')
+            const readAuthorityState = store.readAuthorityState
+            assert(readAuthorityState !== undefined, 'durable authority state reads must be implemented')
+
+            yield* seedExactReconciliation(activationReconciliation)
+            yield* store.ensureAuthorityGeneration({
+              generationHash: configuredObserveGenerationHash,
+              maximum: Authority.Observe,
+            })
+            const paper = yield* activateResearch(researchProofBinding(activation), configuredObserveGenerationHash)
+            yield* sql`
+            WITH timing AS (
+              SELECT
+                clock_timestamp() AS terminal_at,
+                (clock_timestamp() AT TIME ZONE 'UTC')::date AS execution_date
+            )
+            INSERT INTO autonomous_cycles (
+              cycle_id, schema_version, identity_schema_version, strategy_name,
+              qualification_run_id, strategy_protocol_hash, account_id,
+              signal_session_date, signal_calendar_version,
+              execution_policy_schema_version, execution_policy_hash,
+              strategy_execution_model_hash, submission_window_ms,
+              submission_cutoff_before_open_ms, window_schema_version,
+              execution_calendar_schema_version, execution_calendar_source,
+              execution_calendar_hash, execution_session_date, signal_close_at,
+              publication_deadline_at, submission_open_at, execution_open_at,
+              execution_close_at, submission_cutoff_at, state, snapshot_id,
+              decision_hash, terminal_reason, state_version, created_at, updated_at, terminal_at
+            )
+            SELECT
+              ${cycleId}, 'bayn.autonomous-cycle.v1', 'bayn.autonomous-cycle-identity.v1',
+              'risk-balanced-trend', ${activation.grant.planHash}, ${activation.strategyProtocolHash}, ${accountId},
+              execution_date - 1, 'test-calendar-v1',
+              'bayn.autonomous-cycle-execution-policy.v1', ${hash(`receipt-rollover-${fixture}-policy`)},
+              ${hash(`receipt-rollover-${fixture}-execution-model`)}, 1800000, 1800000,
+              'bayn.autonomous-cycle-window.v1', 'bayn.alpaca-market-calendar-observation.v1',
+              'alpaca-v2-calendar', ${hash(`receipt-rollover-${fixture}-calendar`)}, execution_date,
+              terminal_at - interval '4 hours', terminal_at - interval '3 hours',
+              terminal_at - interval '3 hours', terminal_at - interval '2 hours',
+              terminal_at + interval '4 hours', terminal_at - interval '2 hours 30 minutes',
+              'BLOCKED', NULL, NULL, 'BLOCKED_MISSED_PUBLICATION_DEADLINE', 1,
+              terminal_at, terminal_at, terminal_at
+            FROM timing
+          `
+            const [restrictionTime] = yield* sql<{ updated_at: Date }>`
+            SELECT greatest(clock_timestamp(), updated_at + interval '1 millisecond') AS updated_at
+            FROM authority_state
+            WHERE singleton
+          `
+            if (restrictionTime === undefined) return yield* Effect.die(new Error('restriction time is unavailable'))
+            yield* store.restrictAuthority(restrictionReason, restrictionTime.updated_at.toISOString())
+
+            const beforeReceipt = yield* writerFence.transaction(
+              blockedIntents.settleCurrentTerminalGeneration({
+                accountId,
+                observedAt: restrictionTime.updated_at.toISOString(),
+              }),
+            )
+            const [receiptTime] = yield* sql<{ created_at: Date }>`SELECT clock_timestamp() AS created_at`
+            if (receiptTime === undefined) return yield* Effect.die(new Error('receipt time is unavailable'))
+            const createdAt = receiptTime.created_at.toISOString()
+            yield* sql`
+            INSERT INTO autonomous_forward_performance_receipts (
+              authority_generation_hash, cycle_id, document, created_at
+            ) VALUES (
+              ${paper.generationHash},
+              ${cycleId},
+              ${sql.json(
+                encodeSqlJson({
+                  schemaVersion: 'bayn.forward-performance-receipt-envelope.v1',
+                  authorityGenerationHash: paper.generationHash,
+                  cycleId,
+                  createdAt,
+                  contentHash,
+                  receiptHash,
+                  receipt: { receiptHash },
+                }),
+              )},
+              ${createdAt}
+            )
+          `
+            const rolloverReconciliation = exactReconciliation(`receipt-rollover-${fixture}-after-terminal-settlement`)
+            const reconcileAfterSettlement = Effect.gen(function* () {
+              const stateHash = hash(`receipt-rollover-${fixture}-after-terminal-settlement-state`)
+              yield* sql`
+              INSERT INTO reconciliations (
+                reconciliation_id, schema_version, account_id, expected_hash, observed_hash,
+                content_hash, status, discrepancies, reconciled_at
+              )
+              SELECT
+                ${rolloverReconciliation.reconciliationId}, 'bayn.paper-reconciliation.v1', ${accountId},
+                ${stateHash}, ${stateHash}, ${rolloverReconciliation.contentHash}, 'EXACT',
+                ${sql.json(encodeSqlJson([]))}, greatest(clock_timestamp(), state.updated_at + interval '1 millisecond')
+              FROM authority_state AS state
+              WHERE state.singleton
+            `
+              yield* sql`SELECT pg_sleep(0.01)`
+            }).pipe(
+              Effect.mapError((cause) =>
+                operationalError({
+                  component: 'database',
+                  operation: 'test-receipt-rollover',
+                  message: 'test reconciliation write failed',
+                  cause,
+                }),
+              ),
+            )
+            const rollover = yield* recoverTerminalGenerationToObserve({
+              accountId,
+              blockedIntents,
+              authorityStore: store,
+              writerFence,
+              reconcileAfterSettlement,
+            })
+            const authority = yield* readAuthorityState
+            return { authority, beforeReceipt, paper, rollover }
+          }),
+        )
+
+        expect(result.beforeReceipt).toEqual({ _tag: 'NoTerminalGeneration' })
+        expect(result.rollover).toMatchObject({
+          _tag: 'RolledOver',
+          previousGenerationHash: result.paper.generationHash,
+        })
+        expect(result.authority).toMatchObject({
+          generationHash: result.rollover._tag === 'RolledOver' ? result.rollover.generationHash : '',
+          maximum: Authority.Observe,
+          effective: Authority.Observe,
+          kill: KillState.Clear,
+        })
+      } finally {
+        await runtime.dispose()
+      }
+    },
+    15_000,
+  )
 
   test('rotates a non-rearm research PAPER kill to OBSERVE without clearing it', async () => {
     const sourceGenerationHash = hash('operator-killed-research-paper-source')

--- a/services/bayn/src/execution/intents/blocked-cycle-postgres.ts
+++ b/services/bayn/src/execution/intents/blocked-cycle-postgres.ts
@@ -3,13 +3,14 @@ import { Effect, Layer, Schema } from 'effect'
 import { isSqlError } from 'effect/unstable/sql/SqlError'
 
 import { Sha256Schema, UtcInstantSchema, strictParseOptions } from '../../schemas'
+import { paperActivationExpiredRestrictionReason, paperEpisodeCompletedRestrictionReason } from '../../paper-episode'
 import {
   BlockedCycleIntentStore,
   BlockedCycleIntentStoreError,
   type BlockedCycleIntentStoreShape,
   type BlockedCycleIntentTerminalizationInput,
-  type CurrentBlockedGenerationSettlementInput,
-  type CurrentBlockedGenerationSettlementReceipt,
+  type CurrentTerminalGenerationSettlementInput,
+  type CurrentTerminalGenerationSettlementReceipt,
 } from './blocked-cycle'
 
 const InputSchema = Schema.Struct({
@@ -155,7 +156,7 @@ const terminalizeUntouchedApproved = (sql: PgClient.PgClient, candidate: Blocked
     Effect.mapError(classifyCause),
   )
 
-const settleCurrentBlockedGeneration = (sql: PgClient.PgClient, candidate: CurrentBlockedGenerationSettlementInput) =>
+const settleCurrentTerminalGeneration = (sql: PgClient.PgClient, candidate: CurrentTerminalGenerationSettlementInput) =>
   Schema.decodeUnknownEffect(
     CurrentSettlementInputSchema,
     strictParseOptions,
@@ -173,7 +174,20 @@ const settleCurrentBlockedGeneration = (sql: PgClient.PgClient, candidate: Curre
             AND state.maximum = 'PAPER'
             AND state.effective = 'OBSERVE'
             AND state.kill_state = 'ACTIVE'
-            AND state.reason LIKE 'PAPER autonomous cycle loop restricted effective authority:%'
+            AND (
+              state.reason LIKE 'PAPER autonomous cycle loop restricted effective authority:%'
+              OR (
+                state.reason IN (
+                  ${paperEpisodeCompletedRestrictionReason},
+                  ${paperActivationExpiredRestrictionReason}
+                )
+                AND EXISTS (
+                  SELECT 1
+                  FROM autonomous_forward_performance_receipts AS receipt
+                  WHERE receipt.authority_generation_hash = state.generation_hash
+                )
+              )
+            )
             AND generation.maximum = 'PAPER'
             AND generation.activation_schema_version IN (
               'bayn.paper-authority-generation.v2',
@@ -259,9 +273,9 @@ const settleCurrentBlockedGeneration = (sql: PgClient.PgClient, candidate: Curre
       `.pipe(Effect.flatMap(Schema.decodeUnknownEffect(CurrentSettlementRows, strictParseOptions))),
     ),
     Effect.flatMap(
-      ([receipt]): Effect.Effect<CurrentBlockedGenerationSettlementReceipt, BlockedCycleIntentStoreError> => {
+      ([receipt]): Effect.Effect<CurrentTerminalGenerationSettlementReceipt, BlockedCycleIntentStoreError> => {
         if (receipt.authority_generation_hash === null) {
-          return Effect.succeed({ _tag: 'NoBlockedGeneration' as const })
+          return Effect.succeed({ _tag: 'NoTerminalGeneration' as const })
         }
         if (receipt.nonterminal_intent_count !== 0) {
           return Effect.fail(
@@ -272,7 +286,7 @@ const settleCurrentBlockedGeneration = (sql: PgClient.PgClient, candidate: Curre
           )
         }
         return Effect.succeed({
-          _tag: 'BlockedGenerationSettled' as const,
+          _tag: 'TerminalGenerationSettled' as const,
           authorityGenerationHash: receipt.authority_generation_hash,
           blockedCycleCount: receipt.blocked_cycle_count,
           blockedIntentCount: receipt.blocked_intent_count,
@@ -289,7 +303,7 @@ const makeStore = Effect.gen(function* () {
   const sql = yield* PgClient.PgClient
   return {
     terminalizeUntouchedApproved: (input) => terminalizeUntouchedApproved(sql, input),
-    settleCurrentBlockedGeneration: (input) => settleCurrentBlockedGeneration(sql, input),
+    settleCurrentTerminalGeneration: (input) => settleCurrentTerminalGeneration(sql, input),
   } satisfies BlockedCycleIntentStoreShape
 })
 

--- a/services/bayn/src/execution/intents/blocked-cycle.ts
+++ b/services/bayn/src/execution/intents/blocked-cycle.ts
@@ -12,15 +12,15 @@ export interface BlockedCycleIntentTerminalizationReceipt {
   readonly terminalIntentCount: number
 }
 
-export interface CurrentBlockedGenerationSettlementInput {
+export interface CurrentTerminalGenerationSettlementInput {
   readonly accountId: string
   readonly observedAt: string
 }
 
-export type CurrentBlockedGenerationSettlementReceipt =
-  | { readonly _tag: 'NoBlockedGeneration' }
+export type CurrentTerminalGenerationSettlementReceipt =
+  | { readonly _tag: 'NoTerminalGeneration' }
   | {
-      readonly _tag: 'BlockedGenerationSettled'
+      readonly _tag: 'TerminalGenerationSettled'
       readonly authorityGenerationHash: string
       readonly blockedCycleCount: number
       readonly blockedIntentCount: number
@@ -50,9 +50,9 @@ export interface BlockedCycleIntentStoreShape {
    * run this operation inside the process-owned WriterFence transaction. A later, separate exact reconciliation is
    * deliberately required before OBSERVE generation rollover can clear the kill.
    */
-  readonly settleCurrentBlockedGeneration: (
-    input: CurrentBlockedGenerationSettlementInput,
-  ) => Effect.Effect<CurrentBlockedGenerationSettlementReceipt, BlockedCycleIntentStoreError>
+  readonly settleCurrentTerminalGeneration: (
+    input: CurrentTerminalGenerationSettlementInput,
+  ) => Effect.Effect<CurrentTerminalGenerationSettlementReceipt, BlockedCycleIntentStoreError>
 }
 
 export class BlockedCycleIntentStore extends Context.Service<BlockedCycleIntentStore, BlockedCycleIntentStoreShape>()(

--- a/services/bayn/src/observe-composition.test.ts
+++ b/services/bayn/src/observe-composition.test.ts
@@ -1789,7 +1789,7 @@ describe('OBSERVE runtime composition', () => {
         }).pipe(Effect.andThen(effect)),
     }
     const blockedCycleIntentStore: BlockedCycleIntentStoreShape = {
-      settleCurrentBlockedGeneration: () => Effect.die(new Error('startup recovery is outside this unit boundary')),
+      settleCurrentTerminalGeneration: () => Effect.die(new Error('startup recovery is outside this unit boundary')),
       terminalizeUntouchedApproved: () =>
         Effect.sync(() => {
           events.push('terminalize-intents')
@@ -1859,7 +1859,7 @@ describe('OBSERVE runtime composition', () => {
       transaction: (effect) => effect,
     }
     const blockedCycleIntentStore: BlockedCycleIntentStoreShape = {
-      settleCurrentBlockedGeneration: () => Effect.die(new Error('startup recovery is outside this unit boundary')),
+      settleCurrentTerminalGeneration: () => Effect.die(new Error('startup recovery is outside this unit boundary')),
       terminalizeUntouchedApproved: () => Effect.die(new Error('rejected cycle block must not terminalize intents')),
     }
 

--- a/services/bayn/src/observe-composition.test.ts
+++ b/services/bayn/src/observe-composition.test.ts
@@ -4069,6 +4069,7 @@ describe('OBSERVE runtime composition', () => {
     mutationReconciliations = 0
     publicationReads = 0
     const externalObservations: Parameters<Parameters<typeof mutationStartup>[0]['recordPass']>[0][] = []
+    let lifecycleMaintenanceRuns = 0
     let externalNextDelayMs: number | undefined
     const externalStartup = makeMutationAutonomousCycleStartup({
       accountId,
@@ -4078,6 +4079,11 @@ describe('OBSERVE runtime composition', () => {
       reconciliationPassTimeoutMs: 30_000,
       strategy: fixtureRuntime,
       executionProgram: sandboxExecutionProgram(),
+      beforeLifecycleAdvance: Effect.sync(() => {
+        lifecycleMaintenanceRuns += 1
+        mutationEvents.push(`maintenance:${lifecycleMaintenanceRuns.toString()}`)
+        return lifecycleMaintenanceRuns === 3 ? ('COMPLETED' as const) : ('CONTINUE' as const)
+      }),
       interpretCycleDriver: (driver) =>
         Effect.gen(function* () {
           externalNextDelayMs = driver.nextDelayMs
@@ -4138,12 +4144,16 @@ describe('OBSERVE runtime composition', () => {
     expect(externalObservations).toHaveLength(3)
     expect(externalObservations[0]).toMatchObject({ result: 'SUCCESS', outcome: 'NO_PUBLICATION' })
     expect(externalObservations[1]).toMatchObject({ result: 'SUCCESS', outcome: 'NO_PUBLICATION' })
-    expect(externalObservations[2]).toMatchObject({ result: 'SUCCESS', outcome: 'NO_PUBLICATION' })
+    expect(externalObservations[2]).toMatchObject({ result: 'SUCCESS', outcome: 'RECOVERED' })
+    expect(lifecycleMaintenanceRuns).toBe(3)
     expect(mutationReconciliations).toBe(3)
+    expect(mutationEvents.indexOf('maintenance:1')).toBeLessThan(mutationEvents.indexOf('reconcile:1'))
+    expect(mutationEvents.indexOf('maintenance:2')).toBeLessThan(mutationEvents.indexOf('reconcile:2'))
+    expect(mutationEvents.indexOf('maintenance:3')).toBeGreaterThan(mutationEvents.indexOf('reconcile:3'))
     expect(mutationEvents.indexOf('reconcile:1')).toBeLessThan(mutationEvents.indexOf('publication:1'))
     expect(mutationEvents.indexOf('reconcile:2')).toBeLessThan(mutationEvents.indexOf('publication:2'))
-    expect(mutationEvents.indexOf('reconcile:3')).toBeLessThan(mutationEvents.indexOf('publication:3'))
-    expect(mutationEvents.filter((event) => event.startsWith('publication:'))).toHaveLength(3)
+    expect(mutationEvents).not.toContain('publication:3')
+    expect(mutationEvents.filter((event) => event.startsWith('publication:'))).toHaveLength(2)
 
     mutationEvents.length = 0
     mutationReconciliations = 0

--- a/services/bayn/src/observe-composition.ts
+++ b/services/bayn/src/observe-composition.ts
@@ -1115,8 +1115,12 @@ export type ObserveAutonomousCycleInput = {
   readonly paperEpisodeCloseSubmitCutoffAt?: string
   readonly paperEpisodeExpiresAt?: string
   readonly onClosedCycle?: (cycleId: string, observedAt: string) => Effect.Effect<void>
+  /** Runs due lifecycle maintenance inside the same serialized command as the cycle pass. */
+  readonly beforeLifecycleAdvance?: Effect.Effect<LifecycleAdvanceDisposition, CycleRunnerError>
   readonly interpretCycleDriver?: RecoveryFirstCycleDriverInterpreter
 }
+
+export type LifecycleAdvanceDisposition = 'CONTINUE' | 'COMPLETED'
 
 export const paperEpisodeCloseGraceMs = 15 * 60_000
 
@@ -2288,7 +2292,7 @@ const makeRecoveryFirstCycleDriver = (
           ),
       }),
     )
-    const advance = operationPermit.withPermit(
+    const runCycleAdvance =
       input.interpretCycleDriver === undefined
         ? advanceCycle
         : reconcileMutationBeforeExternallyDrivenAdvance(input, cadence, reconcile).pipe(
@@ -2302,6 +2306,25 @@ const makeRecoveryFirstCycleDriver = (
                 ),
               onSuccess: () => advanceCycle,
             }),
+          )
+    const advance = operationPermit.withPermit(
+      input.beforeLifecycleAdvance === undefined
+        ? runCycleAdvance
+        : input.beforeLifecycleAdvance.pipe(
+            Effect.flatMap((disposition) =>
+              disposition === 'CONTINUE'
+                ? runCycleAdvance
+                : currentUtcInstant.pipe(
+                    Effect.flatMap((observedAt) => {
+                      const observation: AutonomousCyclePassObservation = {
+                        result: 'SUCCESS',
+                        observedAt,
+                        outcome: 'RECOVERED',
+                      }
+                      return startup.recordPass(observation).pipe(Effect.as({ observation }))
+                    }),
+                  ),
+            ),
           ),
     )
     const maintainReconciliation = operationPermit.withPermit(
@@ -2329,7 +2352,7 @@ const makeRecoveryFirstCycleDriver = (
     }
   })
 
-const interpretRecoveryFirstCycleInProcess: RecoveryFirstCycleDriverInterpreter = (driver) => {
+export const interpretRecoveryFirstCycleInProcess: RecoveryFirstCycleDriverInterpreter = (driver) => {
   const run = (): Effect.Effect<void, never, RecoveryFirstRuntime> =>
     Effect.suspend(() =>
       driver.advance.pipe(

--- a/services/bayn/src/paper-episode.ts
+++ b/services/bayn/src/paper-episode.ts
@@ -153,6 +153,10 @@ export interface PaperEpisodeAuthorityFacts {
 }
 
 export const paperEpisodeFailureRestrictionPrefix = 'PAPER autonomous cycle loop restricted effective authority:'
+export const paperEpisodeCompletedRestrictionReason =
+  'PAPER episode restricted effective authority: flat exact receipt finalized'
+export const paperActivationExpiredRestrictionReason =
+  'PAPER activation lease restricted effective authority: immutable activation request expired'
 
 export type PaperEpisodeAuthorityDecision =
   | { readonly _tag: 'Activate' }


### PR DESCRIPTION
## Summary

- Move PAPER expiry and receipt-finalization maintenance from process-local sleeping fibers into the existing serialized Restate lifecycle command.
- Complete terminal generation rollover to clear OBSERVE only after a durable exact forward-performance receipt.
- Skip stale cycle work after lifecycle completion while preserving PostgreSQL, TigerBeetle, broker mutation, WriterFence, and reconciliation-guardian ownership.

## Related Issues

None

## Testing

- `bun test services/bayn/src/composition.test.ts services/bayn/src/observe-composition.test.ts` — 79 pass, 0 fail.
- `bun run --filter @proompteng/bayn test` — 1,116 pass, 165 skip, 0 fail.
- `BAYN_TEST_POSTGRES_URL=postgresql://bayn:bayn@127.0.0.1:55432/bayn_test bun run --filter @proompteng/bayn test:postgres` — every PostgreSQL integration suite passed.
- `bun run --filter @proompteng/bayn tsc` — strict all and production profiles passed.
- `bun run --filter @proompteng/bayn lint`
- `bun run --filter @proompteng/bayn lint:oxlint`
- `bun run --filter @proompteng/bayn lint:oxlint:type`
- `bun run --filter @proompteng/bayn build`
- `git diff --check`

## Breaking Changes

None

## Checklist

- [x] Testing section documents the exact validation performed.
- [x] Screenshots are not applicable and Breaking Changes is filled in.
- [x] No documentation or release-note changes are required for this internal lifecycle ownership correction.