### PR TITLE
fix(bayn): recover denied paper generation

### DIFF
--- a/services/bayn/src/composition.test.ts
+++ b/services/bayn/src/composition.test.ts
@@ -577,8 +577,7 @@ describe('Bayn PAPER startup recovery boundary', () => {
   })
 
   test('resumes an exact failure-restricted generation for recovery without rearming or activating', async () => {
-    const authorityReason =
-      'PAPER autonomous cycle loop restricted effective authority: bound cycle blocked: BLOCKED_MISSED_SUBMISSION_DEADLINE'
+    const authorityReason = `bound PAPER cycle ${hash('c')} restricted effective authority: intent ${hash('d')} submit settled denied`
     const authority: AuthorityState = {
       ...continuationAuthority,
       effective: Authority.Observe,

--- a/services/bayn/src/composition.ts
+++ b/services/bayn/src/composition.ts
@@ -119,7 +119,7 @@ import { Journal, JournalLive } from './ledger'
 import { MarketData, MarketDataLive } from './market-data'
 import {
   decidePaperEpisodeAuthority,
-  paperEpisodeFailureRestrictionPrefix,
+  isPaperEpisodeFailureRestriction,
   paperGrantFromGeneration,
   paperGrantKey,
   validatePaperEpisodeCloseWindow,
@@ -2002,7 +2002,7 @@ const runAutonomousService = (plan: ApplicationPlanFor<'AutonomousService'>) =>
                                 authorityState.maximum === Authority.Paper &&
                                 authorityState.effective === Authority.Observe &&
                                 authorityState.kill === KillState.Active &&
-                                authorityState.reason?.startsWith(paperEpisodeFailureRestrictionPrefix) === true
+                                isPaperEpisodeFailureRestriction(authorityState.reason)
                               if (prepared._tag === 'ReceiptFinalization' && !restricted) {
                                 return resolveReceiptFinalization(prepared)
                               }

--- a/services/bayn/src/db/paper-store.integration.test.ts
+++ b/services/bayn/src/db/paper-store.integration.test.ts
@@ -2747,6 +2747,125 @@ describePostgres('paper accounting persistence', () => {
     15_000,
   )
 
+  test.each([
+    [
+      'a legacy broker-denial restriction',
+      `bound PAPER cycle ${hash('legacy-denial-cycle')} restricted effective authority: intent ${hash('legacy-denial-intent')} submit settled denied`,
+      'RolledOver',
+    ],
+    ['an operator kill', 'operator requested PAPER stop', 'NotRequired'],
+    [
+      'a malformed legacy restriction',
+      `bound PAPER cycle short restricted effective authority: intent ${hash('malformed-legacy-intent')} submit settled denied`,
+      'NotRequired',
+    ],
+  ] as const)(
+    'handles %s through the durable terminal-generation recovery boundary',
+    async (_fixture, reason, expectedTag) => {
+      const configuredObserveGenerationHash = hash(`restriction-classification-${_fixture}-observe`)
+      const activationReconciliation = exactReconciliation(`restriction-classification-${_fixture}-activation`)
+      const activation = makeResearchActivation(configuredObserveGenerationHash, activationReconciliation)
+      const runtime = makeStoreRuntime(
+        { fail: false, planHashes: [] },
+        researchRuntimeConfig(configuredObserveGenerationHash),
+      )
+      try {
+        const result = await runtime.runPromise(
+          Effect.gen(function* () {
+            const store = yield* ExecutionStore
+            const blockedIntents = yield* BlockedCycleIntentStore
+            const sql = yield* PgClient.PgClient
+            const writerFence = yield* WriterFence
+            const activateResearch = store.activateResearchCapitalGrant
+            assert(activateResearch !== undefined, 'research PAPER activation must be implemented')
+
+            yield* seedExactReconciliation(activationReconciliation)
+            yield* store.ensureAuthorityGeneration({
+              generationHash: configuredObserveGenerationHash,
+              maximum: Authority.Observe,
+            })
+            const paper = yield* activateResearch(researchProofBinding(activation), configuredObserveGenerationHash)
+            const [restrictionTime] = yield* sql<{ updated_at: Date }>`
+            SELECT greatest(clock_timestamp(), updated_at + interval '1 millisecond') AS updated_at
+            FROM authority_state
+            WHERE singleton
+          `
+            if (restrictionTime === undefined) return yield* Effect.die(new Error('restriction time is unavailable'))
+            yield* store.restrictAuthority(reason, restrictionTime.updated_at.toISOString())
+            const reconciliation = exactReconciliation(`restriction-classification-${_fixture}-settlement`)
+            const reconcileAfterSettlement = Effect.gen(function* () {
+              const stateHash = hash(`restriction-classification-${_fixture}-state`)
+              yield* sql`
+                INSERT INTO reconciliations (
+                  reconciliation_id, schema_version, account_id, expected_hash, observed_hash,
+                  content_hash, status, discrepancies, reconciled_at
+                )
+                SELECT
+                  ${reconciliation.reconciliationId}, 'bayn.paper-reconciliation.v1', ${accountId},
+                  ${stateHash}, ${stateHash}, ${reconciliation.contentHash}, 'EXACT',
+                  ${sql.json(encodeSqlJson([]))}, greatest(clock_timestamp(), state.updated_at + interval '1 millisecond')
+                FROM authority_state AS state
+                WHERE state.singleton
+              `
+            }).pipe(
+              Effect.mapError((cause) =>
+                operationalError({
+                  component: 'database',
+                  operation: 'test-legacy-restriction-recovery',
+                  message: 'test reconciliation write failed',
+                  cause,
+                }),
+              ),
+            )
+            const recovery = yield* recoverTerminalGenerationToObserve({
+              accountId,
+              blockedIntents,
+              authorityStore: store,
+              writerFence,
+              reconcileAfterSettlement,
+            })
+            const [authority] = yield* sql<{
+              effective: Authority
+              generation_hash: string
+              kill_state: KillState
+              maximum: Authority
+              reason: string | null
+            }>`
+              SELECT generation_hash, maximum, effective, kill_state, reason
+              FROM authority_state
+              WHERE singleton
+            `
+            if (authority === undefined) return yield* Effect.die(new Error('authority state is unavailable'))
+            return { authority, paper, recovery }
+          }),
+        )
+
+        expect(result.recovery._tag).toBe(expectedTag)
+        if (result.recovery._tag === 'RolledOver') {
+          expect(result.recovery.previousGenerationHash).toBe(result.paper.generationHash)
+          expect(result.authority).toEqual({
+            effective: Authority.Observe,
+            generation_hash: result.recovery.generationHash,
+            kill_state: KillState.Clear,
+            maximum: Authority.Observe,
+            reason: null,
+          })
+        } else {
+          expect(result.authority).toMatchObject({
+            effective: Authority.Observe,
+            generation_hash: result.paper.generationHash,
+            kill_state: KillState.Active,
+            maximum: Authority.Paper,
+            reason,
+          })
+        }
+      } finally {
+        await runtime.dispose()
+      }
+    },
+    15_000,
+  )
+
   test('rotates a non-rearm research PAPER kill to OBSERVE without clearing it', async () => {
     const sourceGenerationHash = hash('operator-killed-research-paper-source')
     const nextSourceGenerationHash = hash('operator-killed-research-paper-next-source')

--- a/services/bayn/src/execution/intents/blocked-cycle-postgres.ts
+++ b/services/bayn/src/execution/intents/blocked-cycle-postgres.ts
@@ -3,7 +3,12 @@ import { Effect, Layer, Schema } from 'effect'
 import { isSqlError } from 'effect/unstable/sql/SqlError'
 
 import { Sha256Schema, UtcInstantSchema, strictParseOptions } from '../../schemas'
-import { paperActivationExpiredRestrictionReason, paperEpisodeCompletedRestrictionReason } from '../../paper-episode'
+import {
+  legacyPaperEpisodeFailureRestrictionPattern,
+  paperActivationExpiredRestrictionReason,
+  paperEpisodeCompletedRestrictionReason,
+  paperEpisodeFailureRestrictionPrefix,
+} from '../../paper-episode'
 import {
   BlockedCycleIntentStore,
   BlockedCycleIntentStoreError,
@@ -166,7 +171,8 @@ const settleCurrentTerminalGeneration = (sql: PgClient.PgClient, candidate: Curr
         WITH current_generation AS MATERIALIZED (
           SELECT
             state.generation_hash,
-            generation.account_id
+            generation.account_id,
+            state.reason ~ ${legacyPaperEpisodeFailureRestrictionPattern} AS legacy_failure_restriction
           FROM authority_state AS state
           JOIN authority_generations AS generation
             ON generation.generation_hash = state.generation_hash
@@ -176,6 +182,7 @@ const settleCurrentTerminalGeneration = (sql: PgClient.PgClient, candidate: Curr
             AND state.kill_state = 'ACTIVE'
             AND (
               state.reason LIKE 'PAPER autonomous cycle loop restricted effective authority:%'
+              OR state.reason ~ ${legacyPaperEpisodeFailureRestrictionPattern}
               OR (
                 state.reason IN (
                   ${paperEpisodeCompletedRestrictionReason},
@@ -260,6 +267,20 @@ const settleCurrentTerminalGeneration = (sql: PgClient.PgClient, candidate: Curr
           LEFT JOIN intents AS intent
             ON intent.authority_generation_hash = generation.generation_hash
           LEFT JOIN terminalized ON terminalized.intent_id = intent.intent_id
+        ), canonicalized_authority AS (
+          UPDATE authority_state AS state
+          SET
+            reason = ${paperEpisodeFailureRestrictionPrefix} || ' ' || state.reason,
+            version = state.version + 1,
+            updated_at = GREATEST(
+              ${input.observedAt}::timestamptz,
+              state.updated_at + interval '1 millisecond'
+            )
+          FROM current_generation AS generation
+          WHERE state.singleton
+            AND state.generation_hash = generation.generation_hash
+            AND generation.legacy_failure_restriction
+          RETURNING state.generation_hash
         )
         SELECT
           (SELECT generation_hash FROM current_generation) AS authority_generation_hash,

--- a/services/bayn/src/observe-composition.ts
+++ b/services/bayn/src/observe-composition.ts
@@ -1710,8 +1710,8 @@ const executeBoundPaperCycle = (
     )
     if (executed.operation === MutationOperation.Submit && executed.settlement.outcome !== 'accepted') {
       yield* restrictMutationAuthority(
-        `bound PAPER cycle ${cycle.identity.cycleId}`,
-        `intent ${step.intentId} submit settled ${executed.settlement.outcome}`,
+        'PAPER autonomous cycle loop',
+        `bound cycle ${cycle.identity.cycleId}: intent ${step.intentId} submit settled ${executed.settlement.outcome}`,
       )
     }
     if (executed.mutationAdvanced)

--- a/services/bayn/src/observe-composition/mutation-intent-interpreter.ts
+++ b/services/bayn/src/observe-composition/mutation-intent-interpreter.ts
@@ -553,8 +553,8 @@ const prepareMutationIntentDataFirst = <R, E, I extends MutationIntentInput, P e
           if (record.intent.terminalOutcome !== TerminalOutcome.Filled) {
             unsuccessfulIntentFound = true
             yield* dependencies.restrictAuthority(
-              `bound PAPER cycle ${cycle.identity.cycleId}`,
-              `intent ${prepared.intent.intentId} ended ${record.intent.terminalOutcome ?? 'without outcome'}`,
+              'PAPER autonomous cycle loop',
+              `bound cycle ${cycle.identity.cycleId}: intent ${prepared.intent.intentId} ended ${record.intent.terminalOutcome ?? 'without outcome'}`,
             )
             continue
           }

--- a/services/bayn/src/paper-episode.test.ts
+++ b/services/bayn/src/paper-episode.test.ts
@@ -4,6 +4,7 @@ import { Result } from 'effect'
 import {
   decidePaperEpisodeAuthority,
   decidePaperEpisodeCycleTerminalization,
+  isPaperEpisodeFailureRestriction,
   paperEpisodeAllocationCapitalMicros,
   paperGrantFromGeneration,
   paperGrantKey,
@@ -71,6 +72,38 @@ describe('paperEpisodeAllocationCapitalMicros', () => {
 })
 
 describe('paper episode decisions', () => {
+  test('recognizes only canonical and exact legacy system failure restrictions', () => {
+    const cycleId = 'a'.repeat(64)
+    const intentId = 'b'.repeat(64)
+
+    expect(
+      isPaperEpisodeFailureRestriction(
+        'PAPER autonomous cycle loop restricted effective authority: bound cycle blocked: BLOCKED_RISK',
+      ),
+    ).toBe(true)
+    expect(
+      isPaperEpisodeFailureRestriction(
+        `bound PAPER cycle ${cycleId} restricted effective authority: intent ${intentId} submit settled denied`,
+      ),
+    ).toBe(true)
+    expect(
+      isPaperEpisodeFailureRestriction(
+        `bound PAPER cycle ${cycleId} restricted effective authority: intent ${intentId} ended REJECTED`,
+      ),
+    ).toBe(true)
+    expect(isPaperEpisodeFailureRestriction('operator requested PAPER stop')).toBe(false)
+    expect(
+      isPaperEpisodeFailureRestriction(
+        `bound PAPER cycle ${cycleId} restricted effective authority: intent ${intentId} ended FILLED`,
+      ),
+    ).toBe(false)
+    expect(
+      isPaperEpisodeFailureRestriction(
+        `bound PAPER cycle ${cycleId.slice(1)} restricted effective authority: intent ${intentId} submit settled denied`,
+      ),
+    ).toBe(false)
+  })
+
   test('adapts legacy qualification history and research history to one grant boundary', () => {
     const qualified = paperGrantFromGeneration({
       schemaVersion: 'bayn.paper-authority-generation.v2',
@@ -174,6 +207,17 @@ describe('paper episode decisions', () => {
         kill: 'ACTIVE',
         currentGenerationMatchesRequest: true,
         reason: 'PAPER autonomous cycle loop restricted effective authority: build-decision failed',
+      }),
+    ).toEqual(Result.succeed({ _tag: 'ResumeRestricted' }))
+    expect(
+      decidePaperEpisodeAuthority({
+        ...common,
+        generationHash: 'b'.repeat(64),
+        maximum: 'PAPER',
+        effective: 'OBSERVE',
+        kill: 'ACTIVE',
+        currentGenerationMatchesRequest: true,
+        reason: `bound PAPER cycle ${'c'.repeat(64)} restricted effective authority: intent ${'d'.repeat(64)} submit settled denied`,
       }),
     ).toEqual(Result.succeed({ _tag: 'ResumeRestricted' }))
     expect(

--- a/services/bayn/src/paper-episode.ts
+++ b/services/bayn/src/paper-episode.ts
@@ -153,6 +153,15 @@ export interface PaperEpisodeAuthorityFacts {
 }
 
 export const paperEpisodeFailureRestrictionPrefix = 'PAPER autonomous cycle loop restricted effective authority:'
+export const legacyPaperEpisodeFailureRestrictionPattern =
+  '^bound PAPER cycle [0-9a-f]{64} restricted effective authority: intent [0-9a-f]{64} (submit settled (denied|rejected)|ended (BLOCKED|CANCELED|EXPIRED|REJECTED|without outcome))$'
+const legacyPaperEpisodeFailureRestriction = new RegExp(legacyPaperEpisodeFailureRestrictionPattern)
+
+/** Accepts only system-authored failure restrictions; operator kills and malformed legacy reasons stay fail-closed. */
+export const isPaperEpisodeFailureRestriction = (reason: string | undefined): boolean =>
+  reason?.startsWith(paperEpisodeFailureRestrictionPrefix) === true ||
+  (reason !== undefined && legacyPaperEpisodeFailureRestriction.test(reason))
+
 export const paperEpisodeCompletedRestrictionReason =
   'PAPER episode restricted effective authority: flat exact receipt finalized'
 export const paperActivationExpiredRestrictionReason =
@@ -197,7 +206,7 @@ export const decidePaperEpisodeAuthority = (
     facts.effective === 'OBSERVE' &&
     facts.kill === 'ACTIVE' &&
     facts.generationHash !== facts.sourceGenerationHash &&
-    facts.reason?.startsWith(paperEpisodeFailureRestrictionPrefix) === true
+    isPaperEpisodeFailureRestriction(facts.reason)
   ) {
     return Result.succeed({ _tag: facts.currentGenerationMatchesRequest ? 'ResumeRestricted' : 'Rearm' })
   }


### PR DESCRIPTION
## Summary\n\n- Recognize the exact historical broker-denial restriction that currently prevents the active PAPER generation from entering recovery.\n- Settle that terminal generation in PostgreSQL while continuing to reject operator kills, malformed identities, and successful fills.\n- Emit the canonical PAPER restriction subject for all future submit and terminal-intent failures.\n- Allow startup recovery to roll the restricted generation to a clear OBSERVE successor so Restate lifecycle startup can proceed.\n\n## Related Issues\n\nPROOMPT-405\n\n## Testing\n\n- bun run --filter @proompteng/bayn test — 1,119 passed, 170 PostgreSQL-gated skipped, 0 failed\n- BAYN_TEST_POSTGRES_URL=<redacted-local-postgres> bun run --filter @proompteng/bayn test:postgres — 155 passed, 0 failed\n- bun run --filter @proompteng/bayn tsc\n- bun run --filter @proompteng/bayn lint\n- bun run --filter @proompteng/bayn lint:oxlint\n- bun run --filter @proompteng/bayn lint:oxlint:type\n- bun run --filter @proompteng/bayn build\n- git diff --check\n\n## Breaking Changes\n\nNone. This recovery remains fail-closed: it clears only exact system-authored PAPER failure restrictions after durable terminal settlement. A separate reviewed activation remains required before broker execution can resume.\n\n## Checklist\n\n- [x] Testing section documents the exact validation performed.\n- [x] Screenshots are not applicable and Breaking Changes is filled in.\n- [x] Follow-up activation and live Restate proof are explicitly tracked.